### PR TITLE
Add cron system for scheduled task execution

### DIFF
--- a/agent/pool.go
+++ b/agent/pool.go
@@ -155,6 +155,28 @@ func (p *Pool) ArchiveSession(sessionID string) error {
 	return nil
 }
 
+// History returns the event log for a session, loading from disk if needed.
+// Returns nil if the session has no history.
+func (p *Pool) History(sessionID string) []runner.RPCEvent {
+	p.mu.Lock()
+	sess, ok := p.sessions[sessionID]
+	if ok && len(sess.Events) > 0 {
+		events := make([]runner.RPCEvent, len(sess.Events))
+		copy(events, sess.Events)
+		p.mu.Unlock()
+		return events
+	}
+	p.mu.Unlock()
+
+	if p.store != nil {
+		events, err := p.store.Load(sessionID)
+		if err == nil && len(events) > 0 {
+			return events
+		}
+	}
+	return nil
+}
+
 // Chat sends a message in a session and streams back events.
 // Internally: gets/creates runner, passes history, collects events,
 // appends to session log, streams to caller.

--- a/agent/runner/go/runner.go
+++ b/agent/runner/go/runner.go
@@ -27,9 +27,10 @@ type Config struct {
 	Model     string // e.g. "claude-sonnet-4-20250514"
 	APIKey    string
 	BaseURL   string // optional provider base URL override
-	WorkDir   string // working directory for tool execution
-	AgentsDir string // .agents dir for persona files (soul.md, user.md, memory.md)
-	System    string // optional system prompt override (bypasses BuildSystemPrompt)
+	WorkDir    string      // working directory for tool execution
+	AgentsDir  string      // .agents dir for persona files (soul.md, user.md, memory.md)
+	System     string      // optional system prompt override (bypasses BuildSystemPrompt)
+	ExtraTools []tool.Tool // additional tools to register
 }
 
 // Runner implements runner.Runner by calling LLM providers directly via Engine.
@@ -68,10 +69,15 @@ func New(_ context.Context, cfg Config) (*Runner, error) {
 		system = BuildSystemPrompt(cfg.AgentsDir, cfg.WorkDir)
 	}
 
+	tools := tool.NewRegistry(cfg.WorkDir)
+	for _, t := range cfg.ExtraTools {
+		tools.Register(t)
+	}
+
 	return &Runner{
 		engine:       &core.Engine{Providers: reg},
 		reg:          reg,
-		tools:        tool.NewRegistry(cfg.WorkDir),
+		tools:        tools,
 		model:        aitypes.Model{API: cfg.API, Name: cfg.Model},
 		apiKey:       cfg.APIKey,
 		system:       system,

--- a/agent/runner/go/tool/tool.go
+++ b/agent/runner/go/tool/tool.go
@@ -21,14 +21,15 @@ type Registry struct {
 // NewRegistry creates a registry with the default built-in tools.
 func NewRegistry(workDir string) *Registry {
 	r := &Registry{tools: make(map[string]Tool)}
-	r.register(&ReadTool{})
-	r.register(&BashTool{workDir: workDir})
-	r.register(&EditTool{})
-	r.register(&WriteTool{})
+	r.Register(&ReadTool{})
+	r.Register(&BashTool{workDir: workDir})
+	r.Register(&EditTool{})
+	r.Register(&WriteTool{})
 	return r
 }
 
-func (r *Registry) register(t Tool) {
+// Register adds a tool to the registry.
+func (r *Registry) Register(t Tool) {
 	r.tools[t.Definition().Name] = t
 }
 

--- a/channel/cli/chat.go
+++ b/channel/cli/chat.go
@@ -17,6 +17,7 @@ import (
 	"github.com/vaayne/anna/agent"
 	"github.com/vaayne/anna/agent/runner"
 	"github.com/vaayne/anna/channel"
+
 )
 
 // streamStartMsg carries the stream channel from the agent.
@@ -93,7 +94,7 @@ func newChatModel(ctx context.Context, pool *agent.Pool, provider, model string,
 	// Resolve session: resume the most recent active session, or create a new one.
 	sessionID := resolveSession(pool)
 
-	return chatModel{
+	m := chatModel{
 		ctx:         ctx,
 		pool:        pool,
 		textarea:    ta,
@@ -105,6 +106,14 @@ func newChatModel(ctx context.Context, pool *agent.Pool, provider, model string,
 		switchModel: switchFn,
 		currentRaw:  &strings.Builder{},
 	}
+
+	// Restore conversation display from persisted history.
+	if rendered := renderResumedHistory(pool, sessionID); rendered != "" {
+		m.history.WriteString(rendered)
+		m.historyPrefix = m.history.String()
+	}
+
+	return m
 }
 
 // resolveSession returns the most recently active non-archived session ID,
@@ -128,6 +137,38 @@ func resolveSession(pool *agent.Pool) string {
 		return "session"
 	}
 	return info.ID
+}
+
+// renderResumedHistory builds the viewport content from a session's persisted events.
+// Only user messages and assistant text are rendered; tool calls are omitted for brevity.
+func renderResumedHistory(pool *agent.Pool, sessionID string) string {
+	events := pool.History(sessionID)
+	if len(events) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString(systemStyle.Render("[session resumed]") + "\n\n")
+
+	for _, evt := range events {
+		switch evt.Type {
+		case runner.RPCEventUserMessage:
+			if evt.Summary == "" || evt.Summary == "[Previous conversation summary]" {
+				continue
+			}
+			b.WriteString(userStyle.Render("You") + "\n")
+			b.WriteString(userBorderStyle.Render(chatTextStyle.Render(evt.Summary)) + "\n\n")
+
+		case runner.RPCEventMessageUpdate:
+			if evt.Summary == "" {
+				continue
+			}
+			b.WriteString(agentStyle.Render("Anna") + "\n")
+			b.WriteString(agentBorderStyle.Render(evt.Summary) + "\n\n")
+		}
+	}
+
+	return b.String()
 }
 
 func (m chatModel) Init() tea.Cmd {

--- a/config.go
+++ b/config.go
@@ -20,8 +20,13 @@ type Config struct {
 }
 
 type CronConfig struct {
-	Enabled bool   `yaml:"enabled"`
+	Enabled *bool  `yaml:"enabled"`
 	DataDir string `yaml:"data_dir"`
+}
+
+// CronEnabled returns whether cron is enabled (defaults to true).
+func (c CronConfig) CronEnabled() bool {
+	return c.Enabled == nil || *c.Enabled
 }
 
 type ProviderConfig struct {

--- a/config.go
+++ b/config.go
@@ -16,6 +16,12 @@ type Config struct {
 	Runner    RunnerConfig              `yaml:"runner"`
 	Telegram  TelegramConfig            `yaml:"telegram"`
 	Sessions  string                    `yaml:"sessions"`
+	Cron      CronConfig                `yaml:"cron"`
+}
+
+type CronConfig struct {
+	Enabled bool   `yaml:"enabled"`
+	DataDir string `yaml:"data_dir"`
 }
 
 type ProviderConfig struct {
@@ -138,6 +144,9 @@ func loadConfigFrom(dir string) (*Config, error) {
 	}
 	if cfg.Sessions == "" {
 		cfg.Sessions = filepath.Join(dir, "workspace", "sessions")
+	}
+	if cfg.Cron.DataDir == "" {
+		cfg.Cron.DataDir = filepath.Join(dir, "cron")
 	}
 
 	return cfg, nil

--- a/config_test.go
+++ b/config_test.go
@@ -309,7 +309,7 @@ func TestNewRunnerFactoryGo(t *testing.T) {
 		Runner: RunnerConfig{Type: "go"},
 	}
 
-	factory, err := newRunnerFactory(cfg)
+	factory, err := newRunnerFactory(cfg, nil)
 	if err != nil {
 		t.Fatalf("newRunnerFactory: %v", err)
 	}
@@ -329,7 +329,7 @@ func TestNewRunnerFactoryUnknown(t *testing.T) {
 		Runner: RunnerConfig{Type: "invalid"},
 	}
 
-	_, err := newRunnerFactory(cfg)
+	_, err := newRunnerFactory(cfg, nil)
 	if err == nil {
 		t.Fatal("expected error for unknown runner type")
 	}

--- a/cron/cron.go
+++ b/cron/cron.go
@@ -1,0 +1,237 @@
+package cron
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/go-co-op/gocron/v2"
+	"github.com/google/uuid"
+)
+
+// OnJobFunc is called when a scheduled job fires.
+type OnJobFunc func(ctx context.Context, job Job)
+
+// Service manages cron jobs backed by gocron/v2 with JSON persistence.
+type Service struct {
+	scheduler gocron.Scheduler
+	onJob     OnJobFunc
+	dataPath  string // directory containing jobs.json
+	mu        sync.Mutex
+	jobs      map[string]Job
+	gids      map[string]uuid.UUID // job ID -> gocron job UUID
+	log       *slog.Logger
+}
+
+// New creates a cron service. Call Start to load persisted jobs and begin scheduling.
+func New(dataPath string) (*Service, error) {
+	s, err := gocron.NewScheduler()
+	if err != nil {
+		return nil, fmt.Errorf("create scheduler: %w", err)
+	}
+	return &Service{
+		scheduler: s,
+		dataPath:  dataPath,
+		jobs:      make(map[string]Job),
+		gids:      make(map[string]uuid.UUID),
+		log:       slog.With("component", "cron"),
+	}, nil
+}
+
+// SetOnJob sets the callback invoked when a job fires.
+func (s *Service) SetOnJob(fn OnJobFunc) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.onJob = fn
+}
+
+// Start loads persisted jobs and starts the scheduler.
+func (s *Service) Start(ctx context.Context) error {
+	jobs, err := s.loadJobs()
+	if err != nil {
+		return fmt.Errorf("load jobs: %w", err)
+	}
+
+	s.mu.Lock()
+	for _, j := range jobs {
+		s.jobs[j.ID] = j
+		if j.Enabled {
+			if err := s.scheduleJob(ctx, j); err != nil {
+				s.log.Warn("failed to schedule persisted job", "id", j.ID, "name", j.Name, "error", err)
+			}
+		}
+	}
+	s.mu.Unlock()
+
+	s.scheduler.Start()
+	s.log.Info("cron service started", "jobs", len(jobs))
+	return nil
+}
+
+// Stop shuts down the scheduler.
+func (s *Service) Stop() error {
+	return s.scheduler.Shutdown()
+}
+
+// AddJob creates, persists, and schedules a new job.
+func (s *Service) AddJob(name, message string, sched Schedule) (Job, error) {
+	if name == "" {
+		return Job{}, fmt.Errorf("name is required")
+	}
+	if message == "" {
+		return Job{}, fmt.Errorf("message is required")
+	}
+	if sched.Cron == "" && sched.Every == "" {
+		return Job{}, fmt.Errorf("schedule requires either cron or every")
+	}
+	if sched.Cron != "" && sched.Every != "" {
+		return Job{}, fmt.Errorf("schedule must have exactly one of cron or every")
+	}
+
+	// Validate schedule before persisting.
+	if sched.Every != "" {
+		if _, err := time.ParseDuration(sched.Every); err != nil {
+			return Job{}, fmt.Errorf("invalid duration %q: %w", sched.Every, err)
+		}
+	}
+
+	job := Job{
+		ID:        uuid.New().String()[:8],
+		Name:      name,
+		Schedule:  sched,
+		Message:   message,
+		Enabled:   true,
+		CreatedAt: time.Now(),
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.scheduleJob(context.Background(), job); err != nil {
+		return Job{}, fmt.Errorf("schedule job: %w", err)
+	}
+
+	s.jobs[job.ID] = job
+	if err := s.saveJobsLocked(); err != nil {
+		return Job{}, fmt.Errorf("persist job: %w", err)
+	}
+
+	s.log.Info("job added", "id", job.ID, "name", name)
+	return job, nil
+}
+
+// RemoveJob unschedules and removes a job.
+func (s *Service) RemoveJob(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.jobs[id]; !ok {
+		return fmt.Errorf("job %q not found", id)
+	}
+
+	if gid, ok := s.gids[id]; ok {
+		if err := s.scheduler.RemoveJob(gid); err != nil {
+			s.log.Warn("failed to remove gocron job", "id", id, "error", err)
+		}
+		delete(s.gids, id)
+	}
+
+	delete(s.jobs, id)
+	if err := s.saveJobsLocked(); err != nil {
+		return fmt.Errorf("persist after remove: %w", err)
+	}
+
+	s.log.Info("job removed", "id", id)
+	return nil
+}
+
+// ListJobs returns all jobs.
+func (s *Service) ListJobs() []Job {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	result := make([]Job, 0, len(s.jobs))
+	for _, j := range s.jobs {
+		result = append(result, j)
+	}
+	return result
+}
+
+// scheduleJob registers a job with gocron. Caller must hold s.mu.
+func (s *Service) scheduleJob(ctx context.Context, job Job) error {
+	var jobDef gocron.JobDefinition
+	if job.Schedule.Cron != "" {
+		jobDef = gocron.CronJob(job.Schedule.Cron, false)
+	} else {
+		d, err := time.ParseDuration(job.Schedule.Every)
+		if err != nil {
+			return fmt.Errorf("parse duration: %w", err)
+		}
+		jobDef = gocron.DurationJob(d)
+	}
+
+	captured := job
+	gj, err := s.scheduler.NewJob(jobDef, gocron.NewTask(func() {
+		s.mu.Lock()
+		fn := s.onJob
+		s.mu.Unlock()
+		if fn != nil {
+			fn(ctx, captured)
+		}
+	}))
+	if err != nil {
+		return err
+	}
+
+	s.gids[job.ID] = gj.ID()
+	return nil
+}
+
+// jobsFile returns the path to the jobs JSON file.
+func (s *Service) jobsFile() string {
+	return filepath.Join(s.dataPath, "jobs.json")
+}
+
+// loadJobs reads the persisted jobs from disk.
+func (s *Service) loadJobs() ([]Job, error) {
+	data, err := os.ReadFile(s.jobsFile())
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var jobs []Job
+	if err := json.Unmarshal(data, &jobs); err != nil {
+		return nil, fmt.Errorf("parse jobs.json: %w", err)
+	}
+	return jobs, nil
+}
+
+// saveJobsLocked writes all jobs to disk atomically. Caller must hold s.mu.
+func (s *Service) saveJobsLocked() error {
+	if err := os.MkdirAll(s.dataPath, 0o755); err != nil {
+		return err
+	}
+
+	jobs := make([]Job, 0, len(s.jobs))
+	for _, j := range s.jobs {
+		jobs = append(jobs, j)
+	}
+
+	data, err := json.MarshalIndent(jobs, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	tmp := s.jobsFile() + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, s.jobsFile())
+}

--- a/cron/cron.go
+++ b/cron/cron.go
@@ -118,6 +118,12 @@ func (s *Service) AddJob(name, message string, sched Schedule) (Job, error) {
 
 	s.jobs[job.ID] = job
 	if err := s.saveJobsLocked(); err != nil {
+		// Roll back: remove from memory and unschedule.
+		delete(s.jobs, job.ID)
+		if gid, ok := s.gids[job.ID]; ok {
+			_ = s.scheduler.RemoveJob(gid)
+			delete(s.gids, job.ID)
+		}
 		return Job{}, fmt.Errorf("persist job: %w", err)
 	}
 
@@ -130,19 +136,30 @@ func (s *Service) RemoveJob(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, ok := s.jobs[id]; !ok {
+	job, ok := s.jobs[id]
+	if !ok {
 		return fmt.Errorf("job %q not found", id)
 	}
 
+	// Remove from scheduler first.
+	var removedGID uuid.UUID
+	var hadGID bool
 	if gid, ok := s.gids[id]; ok {
 		if err := s.scheduler.RemoveJob(gid); err != nil {
 			s.log.Warn("failed to remove gocron job", "id", id, "error", err)
 		}
+		removedGID = gid
+		hadGID = true
 		delete(s.gids, id)
 	}
 
 	delete(s.jobs, id)
 	if err := s.saveJobsLocked(); err != nil {
+		// Roll back: restore in-memory state so retry works.
+		s.jobs[id] = job
+		if hadGID {
+			s.gids[id] = removedGID
+		}
 		return fmt.Errorf("persist after remove: %w", err)
 	}
 

--- a/cron/cron.go
+++ b/cron/cron.go
@@ -22,6 +22,7 @@ type Service struct {
 	scheduler gocron.Scheduler
 	onJob     OnJobFunc
 	dataPath  string // directory containing jobs.json
+	ctx       context.Context // lifecycle context from Start
 	mu        sync.Mutex
 	jobs      map[string]Job
 	gids      map[string]uuid.UUID // job ID -> gocron job UUID
@@ -58,6 +59,7 @@ func (s *Service) Start(ctx context.Context) error {
 	}
 
 	s.mu.Lock()
+	s.ctx = ctx
 	for _, j := range jobs {
 		s.jobs[j.ID] = j
 		if j.Enabled {
@@ -112,7 +114,7 @@ func (s *Service) AddJob(name, message string, sched Schedule) (Job, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if err := s.scheduleJob(context.Background(), job); err != nil {
+	if err := s.scheduleJob(s.ctx, job); err != nil {
 		return Job{}, fmt.Errorf("schedule job: %w", err)
 	}
 
@@ -155,10 +157,13 @@ func (s *Service) RemoveJob(id string) error {
 
 	delete(s.jobs, id)
 	if err := s.saveJobsLocked(); err != nil {
-		// Roll back: restore in-memory state so retry works.
+		// Roll back: restore in-memory state and re-schedule so retry works.
 		s.jobs[id] = job
 		if hadGID {
-			s.gids[id] = removedGID
+			if schedErr := s.scheduleJob(s.ctx, job); schedErr != nil {
+				s.log.Warn("failed to re-schedule job during rollback", "id", id, "error", schedErr)
+				s.gids[id] = removedGID // keep stale GID as best-effort
+			}
 		}
 		return fmt.Errorf("persist after remove: %w", err)
 	}

--- a/cron/cron_test.go
+++ b/cron/cron_test.go
@@ -1,0 +1,297 @@
+package cron
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestAddListRemoveJob(t *testing.T) {
+	dir := t.TempDir()
+	svc, err := New(dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := svc.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer svc.Stop()
+
+	// Add a job.
+	job, err := svc.AddJob("test", "say hello", Schedule{Every: "1h"})
+	if err != nil {
+		t.Fatalf("AddJob: %v", err)
+	}
+	if job.ID == "" {
+		t.Fatal("expected non-empty job ID")
+	}
+	if job.Name != "test" {
+		t.Errorf("Name = %q, want %q", job.Name, "test")
+	}
+	if !job.Enabled {
+		t.Error("expected job to be enabled")
+	}
+
+	// List jobs.
+	jobs := svc.ListJobs()
+	if len(jobs) != 1 {
+		t.Fatalf("ListJobs: got %d, want 1", len(jobs))
+	}
+	if jobs[0].ID != job.ID {
+		t.Errorf("job ID = %q, want %q", jobs[0].ID, job.ID)
+	}
+
+	// Verify persistence file.
+	data, err := os.ReadFile(filepath.Join(dir, "jobs.json"))
+	if err != nil {
+		t.Fatalf("read jobs.json: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("jobs.json is empty")
+	}
+
+	// Remove job.
+	if err := svc.RemoveJob(job.ID); err != nil {
+		t.Fatalf("RemoveJob: %v", err)
+	}
+	if jobs := svc.ListJobs(); len(jobs) != 0 {
+		t.Errorf("ListJobs after remove: got %d, want 0", len(jobs))
+	}
+}
+
+func TestAddJobValidation(t *testing.T) {
+	dir := t.TempDir()
+	svc, err := New(dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := svc.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer svc.Stop()
+
+	tests := []struct {
+		name    string
+		jName   string
+		message string
+		sched   Schedule
+	}{
+		{"empty name", "", "msg", Schedule{Every: "1h"}},
+		{"empty message", "test", "", Schedule{Every: "1h"}},
+		{"no schedule", "test", "msg", Schedule{}},
+		{"both cron and every", "test", "msg", Schedule{Cron: "* * * * *", Every: "1h"}},
+		{"invalid duration", "test", "msg", Schedule{Every: "bogus"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := svc.AddJob(tt.jName, tt.message, tt.sched)
+			if err == nil {
+				t.Error("expected error")
+			}
+		})
+	}
+}
+
+func TestRemoveJobNotFound(t *testing.T) {
+	dir := t.TempDir()
+	svc, err := New(dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := svc.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer svc.Stop()
+
+	if err := svc.RemoveJob("nonexistent"); err == nil {
+		t.Error("expected error for nonexistent job")
+	}
+}
+
+func TestJobPersistenceAcrossRestart(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create and add a job.
+	svc1, err := New(dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := svc1.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	job, err := svc1.AddJob("persist-test", "check weather", Schedule{Cron: "0 9 * * *"})
+	if err != nil {
+		t.Fatalf("AddJob: %v", err)
+	}
+	svc1.Stop()
+
+	// Create a new service from the same directory.
+	svc2, err := New(dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := svc2.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer svc2.Stop()
+
+	jobs := svc2.ListJobs()
+	if len(jobs) != 1 {
+		t.Fatalf("ListJobs after restart: got %d, want 1", len(jobs))
+	}
+	if jobs[0].ID != job.ID {
+		t.Errorf("job ID = %q, want %q", jobs[0].ID, job.ID)
+	}
+	if jobs[0].Name != "persist-test" {
+		t.Errorf("job Name = %q, want %q", jobs[0].Name, "persist-test")
+	}
+}
+
+func TestOnJobCallbackFires(t *testing.T) {
+	dir := t.TempDir()
+	svc, err := New(dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	var mu sync.Mutex
+	var fired []string
+	svc.SetOnJob(func(_ context.Context, job Job) {
+		mu.Lock()
+		fired = append(fired, job.ID)
+		mu.Unlock()
+	})
+
+	if err := svc.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer svc.Stop()
+
+	_, err = svc.AddJob("quick", "ping", Schedule{Every: "100ms"})
+	if err != nil {
+		t.Fatalf("AddJob: %v", err)
+	}
+
+	// Wait for the callback to fire.
+	deadline := time.After(2 * time.Second)
+	for {
+		mu.Lock()
+		n := len(fired)
+		mu.Unlock()
+		if n > 0 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("callback did not fire within 2s")
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+}
+
+func TestCronToolAddListRemove(t *testing.T) {
+	dir := t.TempDir()
+	svc, err := New(dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := svc.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer svc.Stop()
+
+	ct := NewTool(svc)
+
+	// Definition should have name "cron".
+	def := ct.Definition()
+	if def.Name != "cron" {
+		t.Errorf("tool name = %q, want %q", def.Name, "cron")
+	}
+
+	// Add via tool.
+	result, err := ct.Execute(context.Background(), map[string]any{
+		"action":  "add",
+		"name":    "tool-test",
+		"message": "do something",
+		"every":   "1h",
+	})
+	if err != nil {
+		t.Fatalf("Execute add: %v", err)
+	}
+	if result == "" {
+		t.Fatal("expected non-empty result from add")
+	}
+
+	// List via tool.
+	result, err = ct.Execute(context.Background(), map[string]any{
+		"action": "list",
+	})
+	if err != nil {
+		t.Fatalf("Execute list: %v", err)
+	}
+	if result == "No scheduled jobs." {
+		t.Error("expected jobs in list")
+	}
+
+	// Get the job ID for removal.
+	jobs := svc.ListJobs()
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs))
+	}
+
+	// Remove via tool.
+	result, err = ct.Execute(context.Background(), map[string]any{
+		"action": "remove",
+		"id":     jobs[0].ID,
+	})
+	if err != nil {
+		t.Fatalf("Execute remove: %v", err)
+	}
+
+	// Verify removed.
+	result, err = ct.Execute(context.Background(), map[string]any{
+		"action": "list",
+	})
+	if err != nil {
+		t.Fatalf("Execute list after remove: %v", err)
+	}
+	if result != "No scheduled jobs." {
+		t.Errorf("expected no jobs, got %q", result)
+	}
+}
+
+func TestCronToolInvalidAction(t *testing.T) {
+	dir := t.TempDir()
+	svc, err := New(dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ct := NewTool(svc)
+
+	_, err = ct.Execute(context.Background(), map[string]any{
+		"action": "invalid",
+	})
+	if err == nil {
+		t.Error("expected error for invalid action")
+	}
+}
+
+func TestCronToolRemoveMissingID(t *testing.T) {
+	dir := t.TempDir()
+	svc, err := New(dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ct := NewTool(svc)
+
+	_, err = ct.Execute(context.Background(), map[string]any{
+		"action": "remove",
+	})
+	if err == nil {
+		t.Error("expected error for missing ID")
+	}
+}

--- a/cron/job.go
+++ b/cron/job.go
@@ -1,0 +1,19 @@
+package cron
+
+import "time"
+
+// Schedule defines when a job runs. Exactly one field must be set.
+type Schedule struct {
+	Cron  string `json:"cron,omitempty"`  // "0 9 * * 1-5"
+	Every string `json:"every,omitempty"` // "30m", "2h"
+}
+
+// Job is the persisted job definition.
+type Job struct {
+	ID        string   `json:"id"`
+	Name      string   `json:"name"`
+	Schedule  Schedule `json:"schedule"`
+	Message   string   `json:"message"`
+	Enabled   bool     `json:"enabled"`
+	CreatedAt time.Time `json:"created_at"`
+}

--- a/cron/tool.go
+++ b/cron/tool.go
@@ -1,0 +1,117 @@
+package cron
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	aitypes "github.com/vaayne/anna/pkg/ai/types"
+)
+
+var cronInputSchema = func() map[string]any {
+	var m map[string]any
+	_ = json.Unmarshal([]byte(`{
+  "type": "object",
+  "properties": {
+    "action": {
+      "type": "string",
+      "enum": ["add", "list", "remove"],
+      "description": "The action to perform"
+    },
+    "name": {
+      "type": "string",
+      "description": "Name of the job (required for add)"
+    },
+    "message": {
+      "type": "string",
+      "description": "The prompt/instruction to execute on schedule (required for add)"
+    },
+    "cron": {
+      "type": "string",
+      "description": "Cron expression, e.g. '0 9 * * 1-5' for weekdays at 9am (use cron OR every, not both)"
+    },
+    "every": {
+      "type": "string",
+      "description": "Go duration, e.g. '30m', '2h', '24h' (use every OR cron, not both)"
+    },
+    "id": {
+      "type": "string",
+      "description": "Job ID (required for remove)"
+    }
+  },
+  "required": ["action"]
+}`), &m)
+	return m
+}()
+
+// CronTool exposes cron management as an agent tool.
+type CronTool struct {
+	service *Service
+}
+
+// NewTool creates a CronTool backed by the given service.
+func NewTool(service *Service) *CronTool {
+	return &CronTool{service: service}
+}
+
+// Definition returns the tool definition for the LLM.
+func (t *CronTool) Definition() aitypes.ToolDefinition {
+	return aitypes.ToolDefinition{
+		Name:        "cron",
+		Description: "Manage scheduled tasks. Use action 'add' to create a recurring job, 'list' to see all jobs, or 'remove' to delete a job.",
+		InputSchema: cronInputSchema,
+	}
+}
+
+// Execute runs the cron tool action.
+func (t *CronTool) Execute(_ context.Context, args map[string]any) (string, error) {
+	action, _ := args["action"].(string)
+	switch action {
+	case "add":
+		return t.add(args)
+	case "list":
+		return t.list()
+	case "remove":
+		return t.remove(args)
+	default:
+		return "", fmt.Errorf("unknown action %q, expected add/list/remove", action)
+	}
+}
+
+func (t *CronTool) add(args map[string]any) (string, error) {
+	name, _ := args["name"].(string)
+	message, _ := args["message"].(string)
+	cronExpr, _ := args["cron"].(string)
+	every, _ := args["every"].(string)
+
+	sched := Schedule{Cron: cronExpr, Every: every}
+	job, err := t.service.AddJob(name, message, sched)
+	if err != nil {
+		return "", err
+	}
+
+	out, _ := json.MarshalIndent(job, "", "  ")
+	return fmt.Sprintf("Job created:\n%s", out), nil
+}
+
+func (t *CronTool) list() (string, error) {
+	jobs := t.service.ListJobs()
+	if len(jobs) == 0 {
+		return "No scheduled jobs.", nil
+	}
+
+	out, _ := json.MarshalIndent(jobs, "", "  ")
+	return string(out), nil
+}
+
+func (t *CronTool) remove(args map[string]any) (string, error) {
+	id, _ := args["id"].(string)
+	if id == "" {
+		return "", fmt.Errorf("id is required for remove action")
+	}
+
+	if err := t.service.RemoveJob(id); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("Job %q removed.", id), nil
+}

--- a/docs/cron-system.md
+++ b/docs/cron-system.md
@@ -1,0 +1,144 @@
+# Cron System
+
+## Status
+
+Implemented — `cron/` package with gocron/v2 scheduler, JSON persistence, and agent tool.
+
+## Overview
+
+Anna supports scheduled task execution so the agent can set reminders, run periodic tasks, and automate recurring work. The cron system delegates all scheduling to [gocron/v2](https://github.com/go-co-op/gocron) and adds persistence and an agent-facing tool on top.
+
+## Architecture
+
+```
+Agent (via tool call)
+    |
+    |  add / list / remove
+    v
++----------+       +-------------+
+| CronTool | ----> |   Service   |
++----------+       +------+------+
+                          |
+              +-----------+-----------+
+              |                       |
+     gocron/v2 Scheduler      jobs.json (disk)
+              |
+              v
+        OnJobFunc callback
+              |
+              v
+      pool.Chat(ctx, "cron:{id}", message)
+```
+
+### Package: `cron/`
+
+Top-level package (sibling to `agent/`, `channel/`). Three files:
+
+| File | Purpose |
+|------|---------|
+| `cron/job.go` | `Job` and `Schedule` types |
+| `cron/cron.go` | `Service` — gocron wrapper + JSON persistence |
+| `cron/tool.go` | `CronTool` — agent tool implementing `tool.Tool` |
+
+### Key Types
+
+**Schedule** defines when a job runs. Exactly one field must be set:
+
+- `cron` — a cron expression (e.g. `"0 9 * * 1-5"` for weekdays at 9am)
+- `every` — a Go duration (e.g. `"30m"`, `"2h"`, `"24h"`)
+
+**Job** is the persisted definition:
+
+```go
+type Job struct {
+    ID        string    // short UUID
+    Name      string    // human-readable name
+    Schedule  Schedule  // cron or interval
+    Message   string    // prompt sent to agent
+    Enabled   bool
+    CreatedAt time.Time
+}
+```
+
+### Service Lifecycle
+
+1. `cron.New(dataPath)` — creates scheduler
+2. `service.SetOnJob(fn)` — sets callback (deferred wiring to resolve circular dependency)
+3. `service.Start(ctx)` — loads `jobs.json`, registers all jobs with gocron, starts scheduler
+4. `service.Stop()` — shuts down scheduler
+
+### Persistence
+
+Jobs are stored as a JSON array in `{dataDir}/jobs.json` (default: `.agents/cron/jobs.json`). Writes are atomic (temp file + rename).
+
+### Session Model
+
+Each cron job gets a dedicated session with ID `cron:{job.ID}`. This means the agent retains conversational memory across scheduled runs of the same job.
+
+## Configuration
+
+Add to `.agents/config.yaml`:
+
+```yaml
+cron:
+  enabled: true
+  data_dir: .agents/cron  # optional, this is the default
+```
+
+Cron is only active when:
+- `cron.enabled` is `true`
+- `runner.type` is `go` (the Pi runner doesn't support custom tools)
+
+## Agent Tool
+
+The `cron` tool is automatically registered with the Go runner when cron is enabled. The agent uses it via tool calls with three actions:
+
+### `add` — Create a job
+
+Parameters:
+- `name` (required) — human-readable name
+- `message` (required) — the instruction to execute on each run
+- `cron` — cron expression (use this OR `every`)
+- `every` — Go duration (use this OR `cron`)
+
+Example: _"Set a reminder every 30 minutes to check my email"_ triggers:
+```json
+{"action": "add", "name": "email check", "message": "Check my email and summarize new messages", "every": "30m"}
+```
+
+### `list` — List all jobs
+
+No parameters. Returns all scheduled jobs as JSON.
+
+### `remove` — Delete a job
+
+Parameters:
+- `id` (required) — job ID from `add` or `list`
+
+## Wiring
+
+The cron system resolves a circular dependency (service needs pool for the callback, runner needs the tool) via deferred wiring in `main.go`:
+
+1. Create `cron.Service` with no callback
+2. Create `cron.NewTool(service)` and pass to runner via `ExtraTools`
+3. Create pool with the runner factory
+4. Call `service.SetOnJob(...)` with a callback that calls `pool.Chat()`
+5. Call `service.Start(ctx)` in command handlers
+
+## Testing
+
+Tests are in `cron/cron_test.go` covering:
+
+- Add, list, remove lifecycle
+- Input validation (empty name, missing schedule, invalid duration, etc.)
+- Remove non-existent job
+- Persistence across service restart
+- Callback firing on schedule
+- Full tool interface (add/list/remove via `Execute`)
+- Error cases (invalid action, missing ID)
+
+Run with:
+
+```bash
+go test -race ./cron/
+```

--- a/go.mod
+++ b/go.mod
@@ -32,8 +32,10 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/dlclark/regexp2 v1.11.0 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
+	github.com/go-co-op/gocron/v2 v2.19.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/css v1.0.1 // indirect
+	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
@@ -44,6 +46,7 @@ require (
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -165,6 +165,8 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-co-op/gocron/v2 v2.19.1 h1:B4iLeA0NB/2iO3EKQ7NfKn5KsQgZfjb2fkvoZJU3yBI=
+github.com/go-co-op/gocron/v2 v2.19.1/go.mod h1:5lEiCKk1oVJV39Zg7/YG10OnaVrDAV5GGR6O0663k6U=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -297,6 +299,8 @@ github.com/hashicorp/serf v0.9.6/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpT
 github.com/hashicorp/serf v0.9.7/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpTwn9UV4=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
+github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -407,6 +411,8 @@ github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=

--- a/main.go
+++ b/main.go
@@ -13,12 +13,14 @@ import (
 	ucli "github.com/urfave/cli/v2"
 	"github.com/vaayne/anna/agent"
 	"github.com/vaayne/anna/agent/runner"
-	"github.com/vaayne/anna/agent/store"
 	gorunner "github.com/vaayne/anna/agent/runner/go"
+	"github.com/vaayne/anna/agent/runner/go/tool"
 	"github.com/vaayne/anna/agent/runner/pi"
+	"github.com/vaayne/anna/agent/store"
 	"github.com/vaayne/anna/channel"
 	clicmd "github.com/vaayne/anna/channel/cli"
 	"github.com/vaayne/anna/channel/telegram"
+	"github.com/vaayne/anna/cron"
 )
 
 func main() {
@@ -63,18 +65,25 @@ func chatCommand() *ucli.Command {
 				}
 			}
 
-			ctx, cfg, pool, err := setup(c.Context)
+			s, err := setup(c.Context)
 			if err != nil {
 				return err
 			}
-			defer pool.Close()
+			defer s.pool.Close()
+
+			if s.cronSvc != nil {
+				if err := s.cronSvc.Start(s.ctx); err != nil {
+					return fmt.Errorf("start cron: %w", err)
+				}
+				defer s.cronSvc.Stop()
+			}
 
 			if c.Bool("stream") {
-				return clicmd.RunStream(ctx, pool)
+				return clicmd.RunStream(s.ctx, s.pool)
 			}
-			listFn := func() []channel.ModelOption { return collectModels(cfg) }
-			switchFn := modelSwitcher(cfg, pool)
-			return clicmd.RunChat(ctx, pool, cfg.Provider, cfg.Model, listFn, switchFn)
+			listFn := func() []channel.ModelOption { return collectModels(s.cfg) }
+			switchFn := modelSwitcher(s.cfg, s.pool, s.extraTools)
+			return clicmd.RunChat(s.ctx, s.pool, s.cfg.Provider, s.cfg.Model, listFn, switchFn)
 		},
 	}
 }
@@ -84,32 +93,59 @@ func gatewayCommand() *ucli.Command {
 		Name:  "gateway",
 		Usage: "Start daemon services (Telegram, etc.) based on config",
 		Action: func(c *ucli.Context) error {
-			ctx, cfg, pool, err := setup(c.Context)
+			s, err := setup(c.Context)
 			if err != nil {
 				return err
 			}
-			defer pool.Close()
+			defer s.pool.Close()
 
-			listFn := func() []channel.ModelOption { return collectModels(cfg) }
-			switchFn := modelSwitcher(cfg, pool)
-			return runGateway(ctx, cfg, pool, listFn, switchFn)
+			if s.cronSvc != nil {
+				if err := s.cronSvc.Start(s.ctx); err != nil {
+					return fmt.Errorf("start cron: %w", err)
+				}
+				defer s.cronSvc.Stop()
+			}
+
+			listFn := func() []channel.ModelOption { return collectModels(s.cfg) }
+			switchFn := modelSwitcher(s.cfg, s.pool, s.extraTools)
+			return runGateway(s.ctx, s.cfg, s.pool, listFn, switchFn)
 		},
 	}
 }
 
-func setup(parent context.Context) (context.Context, *Config, *agent.Pool, error) {
+type setupResult struct {
+	ctx        context.Context
+	cfg        *Config
+	pool       *agent.Pool
+	cronSvc    *cron.Service
+	extraTools []tool.Tool
+}
+
+func setup(parent context.Context) (*setupResult, error) {
 	cfg, err := LoadConfig()
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("loading config: %w", err)
+		return nil, fmt.Errorf("loading config: %w", err)
 	}
 
 	ctx, cancel := signal.NotifyContext(parent, syscall.SIGINT, syscall.SIGTERM)
 	_ = cancel // cancel is deferred via the caller's lifecycle
 
+	// Create cron service and tool before the runner factory so the tool
+	// can be injected into the Go runner.
+	var cronSvc *cron.Service
+	var extraTools []tool.Tool
+	if cfg.Cron.Enabled && cfg.Runner.Type == "go" {
+		cronSvc, err = cron.New(cfg.Cron.DataDir)
+		if err != nil {
+			return nil, fmt.Errorf("create cron service: %w", err)
+		}
+		extraTools = append(extraTools, cron.NewTool(cronSvc))
+	}
+
 	idleTimeout := time.Duration(cfg.Runner.IdleTimeout) * time.Minute
-	factory, err := newRunnerFactory(cfg)
+	factory, err := newRunnerFactory(cfg, extraTools)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("create runner factory: %w", err)
+		return nil, fmt.Errorf("create runner factory: %w", err)
 	}
 
 	opts := []agent.PoolOption{agent.WithIdleTimeout(idleTimeout)}
@@ -117,7 +153,7 @@ func setup(parent context.Context) (context.Context, *Config, *agent.Pool, error
 		cwd, _ := os.Getwd()
 		s, err := store.NewFileStore(cfg.Sessions, cwd)
 		if err != nil {
-			return nil, nil, nil, fmt.Errorf("create session store: %w", err)
+			return nil, fmt.Errorf("create session store: %w", err)
 		}
 		opts = append(opts, agent.WithStore(s))
 		slog.Info("session persistence enabled", "dir", cfg.Sessions)
@@ -126,10 +162,30 @@ func setup(parent context.Context) (context.Context, *Config, *agent.Pool, error
 	pool := agent.NewPool(factory, opts...)
 	go pool.StartReaper(ctx)
 
-	return ctx, cfg, pool, nil
+	// Wire the cron callback now that pool exists.
+	if cronSvc != nil {
+		cronSvc.SetOnJob(func(ctx context.Context, job cron.Job) {
+			sessionID := "cron:" + job.ID
+			msg := fmt.Sprintf("[Scheduled Task] %s\n\nInstruction: %s", job.Name, job.Message)
+			ch := pool.Chat(ctx, sessionID, msg)
+			for evt := range ch {
+				if evt.Err != nil {
+					slog.Error("cron job error", "job_id", job.ID, "error", evt.Err)
+				}
+			}
+		})
+	}
+
+	return &setupResult{
+		ctx:        ctx,
+		cfg:        cfg,
+		pool:       pool,
+		cronSvc:    cronSvc,
+		extraTools: extraTools,
+	}, nil
 }
 
-func newRunnerFactory(cfg *Config) (runner.NewRunnerFunc, error) {
+func newRunnerFactory(cfg *Config, extraTools []tool.Tool) (runner.NewRunnerFunc, error) {
 	switch cfg.Runner.Type {
 	case "process":
 		return func(ctx context.Context) (runner.Runner, error) {
@@ -139,11 +195,12 @@ func newRunnerFactory(cfg *Config) (runner.NewRunnerFunc, error) {
 		providerCfg := cfg.Providers[cfg.Provider]
 		return func(ctx context.Context) (runner.Runner, error) {
 			return gorunner.New(ctx, gorunner.Config{
-				API:       cfg.Provider,
-				Model:     cfg.Model,
-				APIKey:    providerCfg.APIKey,
-				AgentsDir: configDir(),
-				BaseURL:   providerCfg.BaseURL,
+				API:        cfg.Provider,
+				Model:      cfg.Model,
+				APIKey:     providerCfg.APIKey,
+				AgentsDir:  configDir(),
+				BaseURL:    providerCfg.BaseURL,
+				ExtraTools: extraTools,
 			})
 		}, nil
 	default:
@@ -153,11 +210,11 @@ func newRunnerFactory(cfg *Config) (runner.NewRunnerFunc, error) {
 
 // modelSwitcher returns a function that switches the pool's runner factory
 // to use a different provider/model combination.
-func modelSwitcher(cfg *Config, pool *agent.Pool) channel.ModelSwitchFunc {
+func modelSwitcher(cfg *Config, pool *agent.Pool, extraTools []tool.Tool) channel.ModelSwitchFunc {
 	return func(provider, model string) error {
 		cfg.Provider = provider
 		cfg.Model = model
-		factory, err := newRunnerFactory(cfg)
+		factory, err := newRunnerFactory(cfg, extraTools)
 		if err != nil {
 			return err
 		}

--- a/main.go
+++ b/main.go
@@ -134,7 +134,7 @@ func setup(parent context.Context) (*setupResult, error) {
 	// can be injected into the Go runner.
 	var cronSvc *cron.Service
 	var extraTools []tool.Tool
-	if cfg.Cron.Enabled && cfg.Runner.Type == "go" {
+	if cfg.Cron.CronEnabled() && cfg.Runner.Type == "go" {
 		cronSvc, err = cron.New(cfg.Cron.DataDir)
 		if err != nil {
 			return nil, fmt.Errorf("create cron service: %w", err)


### PR DESCRIPTION
## Summary

- Add `cron/` package with gocron/v2-backed scheduler, JSON persistence (atomic write), and agent tool (`add`/`list`/`remove` actions)
- Export `tool.Registry.Register` to support extra tools, add `ExtraTools` field to Go runner config
- Add `CronConfig` to config with `enabled` and `data_dir` fields (default: `.agents/cron`)
- Wire cron service in `main.go` using deferred `SetOnJob` callback to resolve circular dependency (service needs pool, runner needs tool)
- Each cron job gets a dedicated `cron:{job.ID}` session so the agent retains memory across runs
- Only active when `cron.enabled: true` and `runner.type: go`

## Test plan

- [x] `go test -race ./...` — all existing + new tests pass
- [x] `go build` — binary builds cleanly
- [ ] Manual: start chat with `runner.type: go`, ask agent to "set a reminder every 30s to say hello", verify `.agents/cron/jobs.json` created
- [ ] Manual: ask agent to "list my cron jobs", verify output
- [ ] Manual: wait 30s, observe agent turn fires in logs
- [ ] Manual: ask agent to "remove the hello reminder", verify removal
- [ ] Manual: restart process, verify jobs reload from disk