### PR TITLE
✨ feat: session compaction with LLM-generated handoff summaries

### DIFF
--- a/agent/pool.go
+++ b/agent/pool.go
@@ -280,18 +280,19 @@ func (p *Pool) collectFullResponse(ctx context.Context, r runner.Runner, history
 	return buf.String(), nil
 }
 
-// NeedsCompaction reports whether a session has exceeded the compaction
-// threshold. Returns false if compaction is disabled or no store is set.
+// NeedsCompaction reports whether a session's estimated token count exceeds
+// the compaction threshold. Returns false if compaction is disabled or no
+// store is set.
 func (p *Pool) NeedsCompaction(sessionID string) bool {
-	if p.store == nil || p.compaction.MaxEvents <= 0 {
+	if p.store == nil || p.compaction.MaxTokens <= 0 {
 		return false
 	}
-	count, err := p.store.EventCount(sessionID)
+	tokens, err := p.store.EstimateTokens(sessionID)
 	if err != nil {
-		p.log.Warn("failed to check event count", "session_id", sessionID, "error", err)
+		p.log.Warn("failed to estimate tokens", "session_id", sessionID, "error", err)
 		return false
 	}
-	return count > p.compaction.MaxEvents
+	return tokens > p.compaction.MaxTokens
 }
 
 // History returns the event log for a session, loading from disk if needed.

--- a/agent/pool.go
+++ b/agent/pool.go
@@ -242,13 +242,18 @@ func (p *Pool) CompactSession(ctx context.Context, sessionID string) (string, er
 	sess.Events = newEvents
 	p.mu.Unlock()
 
-	// Kill the runner so it restarts with clean context on next Chat().
-	if closer, ok := r.(io.Closer); ok {
-		_ = closer.Close()
+	// Kill the runner so it restarts with clean context on next Chat() —
+	// unless the runner is stateful (maintains its own in-process context),
+	// in which case killing it would lose context for no benefit. The
+	// compacted history is persisted to disk for crash recovery either way.
+	if sf, ok := r.(runner.Stateful); !ok || !sf.Stateful() {
+		if closer, ok := r.(io.Closer); ok {
+			_ = closer.Close()
+		}
+		p.mu.Lock()
+		sess.Runner = nil
+		p.mu.Unlock()
 	}
-	p.mu.Lock()
-	sess.Runner = nil
-	p.mu.Unlock()
 
 	p.log.Info("compaction complete", "session_id", sessionID,
 		"summary_len", len(summary), "new_events", len(newEvents))

--- a/agent/pool.go
+++ b/agent/pool.go
@@ -209,20 +209,15 @@ func (p *Pool) CompactSession(ctx context.Context, sessionID string) (string, er
 		return "", fmt.Errorf("compaction requires a persistent store")
 	}
 
-	p.mu.Lock()
-	sess, ok := p.sessions[sessionID]
-	if !ok {
-		p.mu.Unlock()
-		return "", fmt.Errorf("session %q not found", sessionID)
+	sess, r, err := p.getOrCreateRunner(ctx, sessionID)
+	if err != nil {
+		return "", fmt.Errorf("get runner: %w", err)
 	}
-	r := sess.Runner
+
+	p.mu.Lock()
 	events := make([]runner.RPCEvent, len(sess.Events))
 	copy(events, sess.Events)
 	p.mu.Unlock()
-
-	if r == nil {
-		return "", fmt.Errorf("session %q has no active runner", sessionID)
-	}
 
 	p.log.Info("compaction started", "session_id", sessionID, "events", len(events))
 

--- a/agent/pool.go
+++ b/agent/pool.go
@@ -22,6 +22,7 @@ type Pool struct {
 	store       store.Store
 	mu          sync.Mutex
 	idleTimeout time.Duration
+	compaction  CompactionConfig
 	log         *slog.Logger
 }
 
@@ -32,6 +33,13 @@ type PoolOption func(*Pool)
 func WithIdleTimeout(d time.Duration) PoolOption {
 	return func(p *Pool) {
 		p.idleTimeout = d
+	}
+}
+
+// WithCompaction sets the compaction configuration.
+func WithCompaction(cfg CompactionConfig) PoolOption {
+	return func(p *Pool) {
+		p.compaction = cfg
 	}
 }
 
@@ -155,6 +163,137 @@ func (p *Pool) ArchiveSession(sessionID string) error {
 	return nil
 }
 
+// compactionPrompt is sent to the runner to generate a conversation summary
+// that replaces old history. Based on the handoff pattern — the summary must
+// be self-contained so the runner can continue without the original context.
+const compactionPrompt = `Summarize the conversation so far so a fresh context window can continue the work. Use this structure (skip empty sections):
+
+## Goal
+[Original objective of this session]
+
+## Progress
+- [What was completed]
+- [What was partially done]
+
+## Key Decisions
+- [Decision and why]
+
+## Files Changed
+- ` + "`path/to/file`" + ` — [what changed]
+
+## Current State
+[Where things stand — what works, what doesn't]
+
+## Blockers / Gotchas
+- [Issues, edge cases, or warnings]
+
+## Next Steps
+1. [Concrete next action]
+2. [Follow-up action]
+
+Guidelines:
+- Be self-contained — the reader has NO access to the previous conversation.
+- Be concise — only what's relevant. Skip empty sections.
+- Focus on decisions and rationale, not the discussion that led to them.
+- List concrete file paths with context, not just paths.
+- State next steps as actionable tasks — clear enough to execute immediately.
+- Do NOT use tools or ask questions. Just output the summary.`
+
+// CompactSession summarizes the conversation via the runner, rewrites the
+// session file with a compaction entry + recent messages, and restarts the
+// runner so it picks up the clean context.
+//
+// It returns the summary text on success.
+func (p *Pool) CompactSession(ctx context.Context, sessionID string) (string, error) {
+	if p.store == nil {
+		return "", fmt.Errorf("compaction requires a persistent store")
+	}
+
+	p.mu.Lock()
+	sess, ok := p.sessions[sessionID]
+	if !ok {
+		p.mu.Unlock()
+		return "", fmt.Errorf("session %q not found", sessionID)
+	}
+	r := sess.Runner
+	events := make([]runner.RPCEvent, len(sess.Events))
+	copy(events, sess.Events)
+	p.mu.Unlock()
+
+	if r == nil {
+		return "", fmt.Errorf("session %q has no active runner", sessionID)
+	}
+
+	p.log.Info("compaction started", "session_id", sessionID, "events", len(events))
+
+	// Ask the runner to summarize the conversation.
+	summary, err := p.collectFullResponse(ctx, r, events, compactionPrompt)
+	if err != nil {
+		return "", fmt.Errorf("generate summary: %w", err)
+	}
+
+	// Rewrite the session file with compaction.
+	keepTail := p.compaction.KeepTail
+	if keepTail == 0 {
+		keepTail = 20
+	}
+	newEvents, err := p.store.Compact(sessionID, summary, keepTail)
+	if err != nil {
+		return "", fmt.Errorf("compact store: %w", err)
+	}
+
+	// Replace in-memory events.
+	p.mu.Lock()
+	sess.Events = newEvents
+	p.mu.Unlock()
+
+	// Kill the runner so it restarts with clean context on next Chat().
+	if closer, ok := r.(io.Closer); ok {
+		_ = closer.Close()
+	}
+	p.mu.Lock()
+	sess.Runner = nil
+	p.mu.Unlock()
+
+	p.log.Info("compaction complete", "session_id", sessionID,
+		"summary_len", len(summary), "new_events", len(newEvents))
+
+	return summary, nil
+}
+
+// collectFullResponse sends a message to a runner and collects the complete
+// text response, blocking until the stream ends.
+func (p *Pool) collectFullResponse(ctx context.Context, r runner.Runner, history []runner.RPCEvent, message string) (string, error) {
+	stream := r.Chat(ctx, history, message)
+	var buf strings.Builder
+	for evt := range stream {
+		if evt.Err != nil {
+			return buf.String(), evt.Err
+		}
+		if evt.Text != "" {
+			buf.WriteString(evt.Text)
+		}
+	}
+	if buf.Len() == 0 {
+		return "", fmt.Errorf("empty summary response")
+	}
+	return buf.String(), nil
+}
+
+// NeedsCompaction reports whether a session has exceeded the compaction
+// threshold. Returns false if compaction is disabled or no store is set.
+func (p *Pool) NeedsCompaction(sessionID string) bool {
+	if p.store == nil || p.compaction.MaxEvents <= 0 {
+		return false
+	}
+	count, err := p.store.EventCount(sessionID)
+	if err != nil {
+		p.log.Warn("failed to check event count", "session_id", sessionID, "error", err)
+		return false
+	}
+	return count > p.compaction.MaxEvents
+}
+
 // History returns the event log for a session, loading from disk if needed.
 // Returns nil if the session has no history.
 func (p *Pool) History(sessionID string) []runner.RPCEvent {
@@ -193,6 +332,27 @@ func (p *Pool) Chat(ctx context.Context, sessionID string, message string) <-cha
 	}
 
 	p.log.Debug("chat started", "session_id", sessionID, "history_len", len(sess.Events), "message_len", len(message))
+
+	// Auto-compact if the session has grown too large.
+	if p.NeedsCompaction(sessionID) {
+		p.log.Info("auto-compaction triggered", "session_id", sessionID)
+		if summary, err := p.CompactSession(ctx, sessionID); err != nil {
+			p.log.Warn("auto-compaction failed, continuing with full history",
+				"session_id", sessionID, "error", err)
+		} else {
+			p.log.Info("auto-compaction succeeded", "session_id", sessionID,
+				"summary_len", len(summary))
+			// Re-acquire session and runner after compaction (runner was restarted).
+			sess, r, err = p.getOrCreateRunner(ctx, sessionID)
+			if err != nil {
+				go func() {
+					out <- runner.Event{Err: fmt.Errorf("get runner after compaction: %w", err)}
+					close(out)
+				}()
+				return out
+			}
+		}
+	}
 
 	// Update last active timestamp.
 	now := time.Now()

--- a/agent/runner/pi/runner.go
+++ b/agent/runner/pi/runner.go
@@ -296,3 +296,7 @@ func (r *Runner) LastActivity() time.Time {
 	defer r.mu.Unlock()
 	return r.lastActivity
 }
+
+// Stateful returns true — Pi maintains context in-process and does not
+// rebuild from the history parameter.
+func (r *Runner) Stateful() bool { return true }

--- a/agent/runner/runner.go
+++ b/agent/runner/runner.go
@@ -81,6 +81,15 @@ func (f HandlerFunc) Chat(ctx context.Context, history []RPCEvent, message strin
 	return f(ctx, history, message)
 }
 
+// Stateful is an optional interface for runners that maintain their own
+// context in-process (e.g., a long-running subprocess). When a runner is
+// Stateful, Pool will not kill it after compaction — the runner keeps its
+// live context and the compacted history is only persisted to disk for
+// crash recovery.
+type Stateful interface {
+	Stateful() bool
+}
+
 // Aliver is an optional interface for runners that can report liveness.
 type Aliver interface {
 	Alive() bool

--- a/agent/session.go
+++ b/agent/session.go
@@ -7,9 +7,9 @@ import (
 
 // CompactionConfig controls automatic session compaction.
 type CompactionConfig struct {
-	// MaxEvents triggers compaction when the session event count exceeds this.
-	// 0 disables automatic compaction. Default: 200.
-	MaxEvents int `yaml:"max_events"`
+	// MaxTokens triggers compaction when the estimated token count exceeds this.
+	// 0 disables automatic compaction. Default: 80000.
+	MaxTokens int `yaml:"max_tokens"`
 	// KeepTail is the number of recent message entries to preserve verbatim
 	// after compaction. Default: 20.
 	KeepTail int `yaml:"keep_tail"`
@@ -17,8 +17,8 @@ type CompactionConfig struct {
 
 // CompactionDefaults returns a CompactionConfig with sane defaults applied.
 func (c CompactionConfig) WithDefaults() CompactionConfig {
-	if c.MaxEvents == 0 {
-		c.MaxEvents = 200
+	if c.MaxTokens == 0 {
+		c.MaxTokens = 80_000
 	}
 	if c.KeepTail == 0 {
 		c.KeepTail = 20

--- a/agent/session.go
+++ b/agent/session.go
@@ -8,14 +8,16 @@ import (
 // CompactionConfig controls automatic session compaction.
 type CompactionConfig struct {
 	// MaxTokens triggers compaction when the estimated token count exceeds this.
-	// 0 disables automatic compaction. Default: 80000.
+	// 0 (or omitted) uses the default of 80000. Negative values disable
+	// automatic compaction. Manual /compact still works.
 	MaxTokens int `yaml:"max_tokens"`
 	// KeepTail is the number of recent message entries to preserve verbatim
 	// after compaction. Default: 20.
 	KeepTail int `yaml:"keep_tail"`
 }
 
-// CompactionDefaults returns a CompactionConfig with sane defaults applied.
+// WithDefaults returns a copy with zero-value fields replaced by defaults.
+// MaxTokens 0 → 80000; negative values are preserved (meaning disabled).
 func (c CompactionConfig) WithDefaults() CompactionConfig {
 	if c.MaxTokens == 0 {
 		c.MaxTokens = 80_000

--- a/agent/session.go
+++ b/agent/session.go
@@ -5,6 +5,27 @@ import (
 	"github.com/vaayne/anna/agent/store"
 )
 
+// CompactionConfig controls automatic session compaction.
+type CompactionConfig struct {
+	// MaxEvents triggers compaction when the session event count exceeds this.
+	// 0 disables automatic compaction. Default: 200.
+	MaxEvents int `yaml:"max_events"`
+	// KeepTail is the number of recent message entries to preserve verbatim
+	// after compaction. Default: 20.
+	KeepTail int `yaml:"keep_tail"`
+}
+
+// CompactionDefaults returns a CompactionConfig with sane defaults applied.
+func (c CompactionConfig) WithDefaults() CompactionConfig {
+	if c.MaxEvents == 0 {
+		c.MaxEvents = 200
+	}
+	if c.KeepTail == 0 {
+		c.KeepTail = 20
+	}
+	return c
+}
+
 // SessionInfo is an alias for store.SessionInfo.
 type SessionInfo = store.SessionInfo
 

--- a/agent/store/store.go
+++ b/agent/store/store.go
@@ -33,6 +33,15 @@ type Store interface {
 	// List returns all known session IDs.
 	List() ([]string, error)
 
+	// Compact replaces the session file with a compaction summary followed
+	// by the last keepTail raw JSONL message lines. Returns the events that
+	// would be loaded from the compacted file.
+	Compact(sessionID string, summary string, keepTail int) ([]runner.RPCEvent, error)
+
+	// EventCount returns the number of message entries in a session file
+	// without fully parsing them. Returns 0 if the session does not exist.
+	EventCount(sessionID string) (int, error)
+
 	// SaveInfo persists session metadata to the index.
 	SaveInfo(info SessionInfo) error
 	// LoadInfo reads metadata for a single session.
@@ -330,6 +339,136 @@ func (s *FileStore) List() ([]string, error) {
 		}
 	}
 	return ids, nil
+}
+
+// EventCount returns the number of message entries in a session file.
+func (s *FileStore) EventCount(sessionID string) (int, error) {
+	p := s.resolve(sessionID)
+	if p == "" {
+		return 0, nil
+	}
+
+	f, err := os.Open(p)
+	if err != nil {
+		return 0, fmt.Errorf("open session file: %w", err)
+	}
+	defer f.Close()
+
+	count := 0
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var peek struct {
+			Type string `json:"type"`
+		}
+		if json.Unmarshal(line, &peek) == nil && peek.Type == "message" {
+			count++
+		}
+	}
+	return count, scanner.Err()
+}
+
+// Compact rewrites the session file: a header, a compaction entry with the
+// given summary, and the last keepTail message lines from the original file.
+// Returns the events that Load() would produce from the compacted file.
+func (s *FileStore) Compact(sessionID string, summary string, keepTail int) ([]runner.RPCEvent, error) {
+	p := s.resolve(sessionID)
+	if p == "" {
+		return nil, fmt.Errorf("session %q not found", sessionID)
+	}
+
+	// Read all raw lines from the original file.
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return nil, fmt.Errorf("read session file: %w", err)
+	}
+
+	rawLines := strings.Split(strings.TrimSpace(string(data)), "\n")
+
+	// Separate header and message lines.
+	var headerLine string
+	var messageLines []string
+	for _, line := range rawLines {
+		var peek struct {
+			Type string `json:"type"`
+		}
+		if json.Unmarshal([]byte(line), &peek) != nil {
+			continue
+		}
+		if peek.Type == "session" && headerLine == "" {
+			headerLine = line
+		} else if peek.Type == "message" {
+			messageLines = append(messageLines, line)
+		}
+	}
+
+	if headerLine == "" {
+		return nil, fmt.Errorf("session %q: no header found", sessionID)
+	}
+
+	// Build compaction entry.
+	compID := shortID()
+	comp := compactionEntry{
+		Type:    "compaction",
+		ID:      compID,
+		Summary: summary,
+	}
+	compJSON, err := json.Marshal(comp)
+	if err != nil {
+		return nil, fmt.Errorf("marshal compaction: %w", err)
+	}
+
+	// Determine which message lines to keep.
+	var keptLines []string
+	if keepTail > 0 && keepTail < len(messageLines) {
+		keptLines = messageLines[len(messageLines)-keepTail:]
+	} else if keepTail >= len(messageLines) {
+		keptLines = messageLines
+	}
+
+	// Re-chain parentId: compaction → kept[0] → kept[1] → ...
+	parentID := compID
+	var rechained []string
+	for _, line := range keptLines {
+		var entry sessionEntry
+		if json.Unmarshal([]byte(line), &entry) != nil {
+			continue
+		}
+		entry.ParentID = &parentID
+		parentID = entry.ID
+		reJSON, _ := json.Marshal(entry)
+		rechained = append(rechained, string(reJSON))
+	}
+
+	// Write the compacted file (atomic: write temp, rename).
+	var buf strings.Builder
+	buf.WriteString(headerLine)
+	buf.WriteByte('\n')
+	buf.Write(compJSON)
+	buf.WriteByte('\n')
+	for _, line := range rechained {
+		buf.WriteString(line)
+		buf.WriteByte('\n')
+	}
+
+	tmpPath := p + ".compact.tmp"
+	if err := os.WriteFile(tmpPath, []byte(buf.String()), 0o644); err != nil {
+		return nil, fmt.Errorf("write compacted file: %w", err)
+	}
+	if err := os.Rename(tmpPath, p); err != nil {
+		_ = os.Remove(tmpPath)
+		return nil, fmt.Errorf("rename compacted file: %w", err)
+	}
+
+	// Update parentID chain for future appends.
+	s.lastParentID[sessionID] = parentID
+
+	// Reload events from the compacted file.
+	return s.Load(sessionID)
 }
 
 // rpcEventToEntry converts an RPCEvent to a Pi-compatible sessionEntry.

--- a/agent/store/store.go
+++ b/agent/store/store.go
@@ -38,9 +38,9 @@ type Store interface {
 	// would be loaded from the compacted file.
 	Compact(sessionID string, summary string, keepTail int) ([]runner.RPCEvent, error)
 
-	// EventCount returns the number of message entries in a session file
-	// without fully parsing them. Returns 0 if the session does not exist.
-	EventCount(sessionID string) (int, error)
+	// EstimateTokens returns a rough token count for the session's message
+	// content (~4 bytes per token). Returns 0 if the session does not exist.
+	EstimateTokens(sessionID string) (int, error)
 
 	// SaveInfo persists session metadata to the index.
 	SaveInfo(info SessionInfo) error
@@ -341,8 +341,10 @@ func (s *FileStore) List() ([]string, error) {
 	return ids, nil
 }
 
-// EventCount returns the number of message entries in a session file.
-func (s *FileStore) EventCount(sessionID string) (int, error) {
+// EstimateTokens returns a rough token count for a session by summing the
+// byte length of all message lines and dividing by 4 (≈1 token per 4 chars
+// for English text). Returns 0 if the session does not exist.
+func (s *FileStore) EstimateTokens(sessionID string) (int, error) {
 	p := s.resolve(sessionID)
 	if p == "" {
 		return 0, nil
@@ -354,7 +356,7 @@ func (s *FileStore) EventCount(sessionID string) (int, error) {
 	}
 	defer f.Close()
 
-	count := 0
+	totalBytes := 0
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	for scanner.Scan() {
@@ -365,11 +367,15 @@ func (s *FileStore) EventCount(sessionID string) (int, error) {
 		var peek struct {
 			Type string `json:"type"`
 		}
-		if json.Unmarshal(line, &peek) == nil && peek.Type == "message" {
-			count++
+		if json.Unmarshal(line, &peek) == nil && (peek.Type == "message" || peek.Type == "compaction") {
+			totalBytes += len(line)
 		}
 	}
-	return count, scanner.Err()
+	if err := scanner.Err(); err != nil {
+		return 0, err
+	}
+	// Rough estimate: ~4 bytes per token for English text + JSON overhead.
+	return totalBytes / 4, nil
 }
 
 // Compact rewrites the session file: a header, a compaction entry with the

--- a/agent/store/store_test.go
+++ b/agent/store/store_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -485,5 +486,144 @@ func TestListTimestampedFiles(t *testing.T) {
 	}
 	if !found["alpha"] || !found["beta"] {
 		t.Errorf("expected alpha and beta, got %v", ids)
+	}
+}
+
+func TestEventCount(t *testing.T) {
+	s := tempStore(t)
+
+	// No file → 0.
+	count, err := s.EventCount("nope")
+	if err != nil {
+		t.Fatalf("EventCount: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected 0, got %d", count)
+	}
+
+	// Append some events.
+	events := []runner.RPCEvent{
+		{Type: "user_message", Summary: "hello"},
+		{Type: "message_update", Summary: "hi there"},
+		{Type: "user_message", Summary: "how are you"},
+		{Type: "message_update", Summary: "good"},
+	}
+	if err := s.Append("s1", events...); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	count, err = s.EventCount("s1")
+	if err != nil {
+		t.Fatalf("EventCount: %v", err)
+	}
+	if count != 4 {
+		t.Fatalf("expected 4, got %d", count)
+	}
+}
+
+func TestCompact(t *testing.T) {
+	s := tempStore(t)
+
+	// Build a conversation with 10 messages.
+	for i := 0; i < 5; i++ {
+		events := []runner.RPCEvent{
+			{Type: "user_message", Summary: fmt.Sprintf("question %d", i)},
+			{Type: "message_update", Summary: fmt.Sprintf("answer %d", i)},
+		}
+		if err := s.Append("s1", events...); err != nil {
+			t.Fatalf("Append round %d: %v", i, err)
+		}
+	}
+
+	// Verify 10 events before compaction.
+	before, err := s.Load("s1")
+	if err != nil {
+		t.Fatalf("Load before: %v", err)
+	}
+	if len(before) != 10 {
+		t.Fatalf("expected 10 events before compaction, got %d", len(before))
+	}
+
+	// Compact keeping last 4 message lines (2 user + 2 assistant).
+	summary := "We discussed questions 0-4. All were answered."
+	after, err := s.Compact("s1", summary, 4)
+	if err != nil {
+		t.Fatalf("Compact: %v", err)
+	}
+
+	// Compaction produces: 2 synthetic (from compaction) + events from 4 kept lines.
+	// Each kept message line produces 1 RPCEvent, so 2 + 4 = 6.
+	if len(after) != 6 {
+		t.Fatalf("expected 6 events after compaction, got %d", len(after))
+	}
+
+	// First two events are from compaction.
+	if after[0].Type != runner.RPCEventUserMessage || after[0].Summary != "[Previous conversation summary]" {
+		t.Errorf("event 0: %+v", after[0])
+	}
+	if after[1].Type != runner.RPCEventMessageUpdate || !strings.Contains(after[1].Summary, "questions 0-4") {
+		t.Errorf("event 1: %+v", after[1])
+	}
+
+	// Kept events should be the last 4 messages (question 3, answer 3, question 4, answer 4).
+	if after[2].Summary != "question 3" {
+		t.Errorf("expected 'question 3', got %q", after[2].Summary)
+	}
+	if after[5].Summary != "answer 4" {
+		t.Errorf("expected 'answer 4', got %q", after[5].Summary)
+	}
+
+	// EventCount should reflect the compacted file.
+	count, err := s.EventCount("s1")
+	if err != nil {
+		t.Fatalf("EventCount after compact: %v", err)
+	}
+	if count != 4 {
+		t.Fatalf("expected 4 message entries after compaction, got %d", count)
+	}
+
+	// Appending after compaction should still work.
+	if err := s.Append("s1", runner.RPCEvent{Type: "user_message", Summary: "follow-up"}); err != nil {
+		t.Fatalf("Append after compact: %v", err)
+	}
+	final, err := s.Load("s1")
+	if err != nil {
+		t.Fatalf("Load final: %v", err)
+	}
+	if len(final) != 7 {
+		t.Fatalf("expected 7 events after append, got %d", len(final))
+	}
+	if final[6].Summary != "follow-up" {
+		t.Errorf("expected 'follow-up', got %q", final[6].Summary)
+	}
+}
+
+func TestCompactNonexistent(t *testing.T) {
+	s := tempStore(t)
+	_, err := s.Compact("nope", "summary", 5)
+	if err == nil {
+		t.Fatal("expected error for nonexistent session")
+	}
+}
+
+func TestCompactKeepAll(t *testing.T) {
+	s := tempStore(t)
+
+	events := []runner.RPCEvent{
+		{Type: "user_message", Summary: "q1"},
+		{Type: "message_update", Summary: "a1"},
+	}
+	if err := s.Append("s1", events...); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	// keepTail >= message count → keeps everything.
+	after, err := s.Compact("s1", "summary", 100)
+	if err != nil {
+		t.Fatalf("Compact: %v", err)
+	}
+	// 2 synthetic + 2 kept = 4
+	if len(after) != 4 {
+		t.Fatalf("expected 4 events, got %d", len(after))
 	}
 }

--- a/agent/store/store_test.go
+++ b/agent/store/store_test.go
@@ -489,16 +489,16 @@ func TestListTimestampedFiles(t *testing.T) {
 	}
 }
 
-func TestEventCount(t *testing.T) {
+func TestEstimateTokens(t *testing.T) {
 	s := tempStore(t)
 
 	// No file → 0.
-	count, err := s.EventCount("nope")
+	tokens, err := s.EstimateTokens("nope")
 	if err != nil {
-		t.Fatalf("EventCount: %v", err)
+		t.Fatalf("EstimateTokens: %v", err)
 	}
-	if count != 0 {
-		t.Fatalf("expected 0, got %d", count)
+	if tokens != 0 {
+		t.Fatalf("expected 0, got %d", tokens)
 	}
 
 	// Append some events.
@@ -512,12 +512,13 @@ func TestEventCount(t *testing.T) {
 		t.Fatalf("Append: %v", err)
 	}
 
-	count, err = s.EventCount("s1")
+	tokens, err = s.EstimateTokens("s1")
 	if err != nil {
-		t.Fatalf("EventCount: %v", err)
+		t.Fatalf("EstimateTokens: %v", err)
 	}
-	if count != 4 {
-		t.Fatalf("expected 4, got %d", count)
+	// Should be > 0 (exact value depends on JSON encoding overhead).
+	if tokens == 0 {
+		t.Fatal("expected non-zero token estimate")
 	}
 }
 
@@ -573,13 +574,13 @@ func TestCompact(t *testing.T) {
 		t.Errorf("expected 'answer 4', got %q", after[5].Summary)
 	}
 
-	// EventCount should reflect the compacted file.
-	count, err := s.EventCount("s1")
+	// Token estimate should be smaller after compaction.
+	tokens, err := s.EstimateTokens("s1")
 	if err != nil {
-		t.Fatalf("EventCount after compact: %v", err)
+		t.Fatalf("EstimateTokens after compact: %v", err)
 	}
-	if count != 4 {
-		t.Fatalf("expected 4 message entries after compaction, got %d", count)
+	if tokens == 0 {
+		t.Fatal("expected non-zero token estimate after compaction")
 	}
 
 	// Appending after compaction should still work.

--- a/channel/cli/chat.go
+++ b/channel/cli/chat.go
@@ -42,6 +42,12 @@ type streamDoneMsg struct{}
 // streamErrMsg carries a streaming error.
 type streamErrMsg struct{ err error }
 
+// compactDoneMsg signals that session compaction finished.
+type compactDoneMsg struct {
+	summary string
+	err     error
+}
+
 type chatModel struct {
 	ctx      context.Context
 	pool     *agent.Pool
@@ -329,6 +335,20 @@ func (m chatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.viewport.GotoBottom()
 		m.textarea.Focus()
 		return m, nil
+
+	case compactDoneMsg:
+		m.streaming = false
+		m.status = ""
+		if msg.err != nil {
+			m.history.WriteString(errorStyle.Render("compaction failed: "+msg.err.Error()) + "\n\n")
+		} else {
+			m.history.WriteString(systemStyle.Render("[session compacted]") + "\n\n")
+		}
+		m.historyPrefix = m.history.String()
+		m.viewport.SetContent(m.history.String())
+		m.viewport.GotoBottom()
+		m.textarea.Focus()
+		return m, nil
 	}
 
 	if !m.streaming {
@@ -440,6 +460,16 @@ func (m *chatModel) handleInput(input string) tea.Cmd {
 		m.viewport.SetContent(m.history.String())
 		m.viewport.GotoBottom()
 		return nil
+	case "/compact":
+		m.streaming = true
+		m.status = "Compacting session..."
+		m.textarea.Blur()
+		ctx := m.ctx
+		sessionID := m.sessionID
+		return func() tea.Msg {
+			summary, err := m.pool.CompactSession(ctx, sessionID)
+			return compactDoneMsg{summary: summary, err: err}
+		}
 	case "/model":
 		m.models = toModelOptions(m.listModels())
 		if len(m.models) == 0 {

--- a/channel/cli/command.go
+++ b/channel/cli/command.go
@@ -11,6 +11,7 @@ type slashCommand struct {
 }
 
 var slashCommands = []slashCommand{
+	{"/compact", "Compact session history"},
 	{"/model", "Switch model"},
 	{"/new", "Start new session"},
 	{"/quit", "Quit"},

--- a/channel/telegram/telegram.go
+++ b/channel/telegram/telegram.go
@@ -39,6 +39,7 @@ var log = slog.With("component", "telegram")
 func botCommands() []tele.Command {
 	return []tele.Command{
 		{Text: "new", Description: "Start a new session"},
+		{Text: "compact", Description: "Compact session history"},
 		{Text: "model", Description: "List or switch models"},
 	}
 }
@@ -74,6 +75,18 @@ func Run(ctx context.Context, token string, pool *agent.Pool, listFn ModelListFu
 		}
 		log.Info("session reset", "session_id", sessionID)
 		return c.Send("New session started.")
+	})
+
+	bot.Handle("/compact", func(c tele.Context) error {
+		sessionID := strconv.FormatInt(c.Chat().ID, 10)
+		_ = c.Notify(tele.Typing)
+		summary, err := pool.CompactSession(ctx, sessionID)
+		if err != nil {
+			log.Error("compact session failed", "session_id", sessionID, "error", err)
+			return c.Send(fmt.Sprintf("Compaction failed: %v", err))
+		}
+		log.Info("session compacted", "session_id", sessionID, "summary_len", len(summary))
+		return c.Send("Session compacted.")
 	})
 
 	bot.Handle("/model", func(c tele.Context) error {

--- a/channel/telegram/telegram_test.go
+++ b/channel/telegram/telegram_test.go
@@ -109,11 +109,11 @@ func TestRenderMarkdownFallback(t *testing.T) {
 
 func TestBotCommands(t *testing.T) {
 	commands := botCommands()
-	if len(commands) != 2 {
-		t.Fatalf("len(commands) = %d, want 2", len(commands))
+	if len(commands) != 3 {
+		t.Fatalf("len(commands) = %d, want 3", len(commands))
 	}
 
-	if commands[0].Text != "new" || commands[1].Text != "model" {
-		t.Fatalf("commands = %#v, want new/model", commands)
+	if commands[0].Text != "new" || commands[1].Text != "compact" || commands[2].Text != "model" {
+		t.Fatalf("commands = %#v, want new/compact/model", commands)
 	}
 }

--- a/config.go
+++ b/config.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/vaayne/anna/agent"
 	"github.com/vaayne/anna/pkg/ai/types"
 	"gopkg.in/yaml.v3"
 )
@@ -59,7 +60,11 @@ type RunnerConfig struct {
 	Process     ProcessConfig `yaml:"process"`
 	System      string        `yaml:"system"`
 	IdleTimeout int           `yaml:"idle_timeout"`
+	Compaction  CompactionConfig `yaml:"compaction"`
 }
+
+// CompactionConfig is an alias for agent.CompactionConfig for config YAML binding.
+type CompactionConfig = agent.CompactionConfig
 
 type ProcessConfig struct {
 	Binary string `yaml:"binary"`

--- a/docs/session-compaction.md
+++ b/docs/session-compaction.md
@@ -132,16 +132,38 @@ In `.agents/config.yaml` under `runner`:
 ```yaml
 runner:
   compaction:
-    max_tokens: 80000   # auto-compact threshold (0 = disabled)
+    max_tokens: 80000   # auto-compact threshold (0 = default 80k, -1 = disabled)
     keep_tail: 20       # recent messages to preserve verbatim
 ```
 
 Both fields have defaults applied via `CompactionConfig.WithDefaults()`:
-- `max_tokens`: 80,000
+- `max_tokens`: 80,000 (when 0 or omitted; set to `-1` to disable)
 - `keep_tail`: 20
 
-Setting `max_tokens: 0` in config disables automatic compaction; `/compact`
+Setting `max_tokens: -1` in config disables automatic compaction; `/compact`
 still works manually.
+
+## Stateful Runners
+
+Some runners (like the Pi subprocess) maintain their own context in-process and
+ignore the `history` parameter passed to `Chat()`. For these runners, killing
+the process after compaction would destroy live context for no benefit — the new
+process can't replay the compacted history anyway.
+
+Runners signal this by implementing the optional `runner.Stateful` interface:
+
+```go
+type Stateful interface {
+    Stateful() bool
+}
+```
+
+When a runner is stateful, `CompactSession()` skips the runner kill. The
+compacted history is still written to disk (for crash recovery and session
+restore), but the live runner keeps its in-process context intact.
+
+For stateless runners that rebuild context from history, the runner is killed as
+before so the next `Chat()` call starts fresh with the compacted history.
 
 ## Session Loading
 

--- a/docs/session-compaction.md
+++ b/docs/session-compaction.md
@@ -1,0 +1,165 @@
+# Session Compaction
+
+## Status
+
+Implemented — `agent/pool.go` (orchestration), `agent/store/store.go` (file rewriting), channels expose `/compact`.
+
+## Problem
+
+LLM runners have finite context windows. As a session accumulates messages, the
+JSONL history grows unbounded. Eventually the runner's context fills up, leading
+to degraded responses or hard failures. Long-lived sessions (Telegram chats,
+multi-day coding sessions) hit this wall quickly.
+
+We need a way to compress old history without losing critical context, and
+without requiring the user to manually start a new session.
+
+## Design: Handoff-Style Compaction
+
+The core idea is borrowed from the "handoff" pattern used by coding agents: when
+context gets too large, ask the LLM itself to produce a self-contained summary,
+then replace the old history with that summary plus a small tail of recent
+messages.
+
+```
+Before compaction:
+┌──────────────────────────────────┐
+│ session header                   │
+│ message 1                        │
+│ message 2                        │
+│ ...                              │
+│ message N-20                     │
+│ message N-19                     │  ← kept verbatim
+│ ...                              │
+│ message N                        │
+└──────────────────────────────────┘
+
+After compaction:
+┌──────────────────────────────────┐
+│ session header                   │
+│ compaction { summary }           │  ← LLM-generated summary
+│ message N-19                     │  ← last 20 messages kept
+│ ...                              │
+│ message N                        │
+└──────────────────────────────────┘
+```
+
+The summary is structured so the runner can continue the conversation without
+the original messages — it contains the goal, progress, decisions, files
+changed, current state, blockers, and next steps.
+
+## Architecture
+
+```
+Channel (/compact or auto)
+    |
+    v
+Pool.CompactSession(ctx, sessionID)
+    |
+    ├─ getOrCreateRunner()       load session from disk if needed, ensure runner
+    │
+    ├─ collectFullResponse()     send compaction prompt to runner, collect summary
+    │
+    ├─ store.Compact()           rewrite JSONL: header + compaction entry + tail
+    │
+    ├─ replace in-memory events  swap sess.Events with compacted version
+    │
+    └─ kill runner               next Chat() starts fresh with clean context
+```
+
+### Token Estimation
+
+`store.EstimateTokens()` scans the JSONL file, sums bytes of `message` and
+`compaction` lines, and divides by 4 (rough heuristic: ~4 bytes per token for
+English text with JSON overhead). This avoids loading entire sessions into
+memory just to check size.
+
+### Compaction Prompt
+
+The prompt asks the runner to produce a structured summary:
+
+- **Goal** — original session objective
+- **Progress** — what was completed or partially done
+- **Key Decisions** — decisions and rationale
+- **Files Changed** — paths with context
+- **Current State** — what works, what doesn't
+- **Blockers / Gotchas** — issues or edge cases
+- **Next Steps** — concrete, actionable tasks
+
+Guidelines enforce self-containment: the summary must make sense to a reader
+with zero access to the prior conversation.
+
+### JSONL File Format
+
+The compaction entry is a single JSON line:
+
+```json
+{"type":"compaction","id":"abc123","summary":"## Goal\n..."}
+```
+
+On `Load()`, the store converts this into a pair of `RPCEvent`s — a user
+message containing the summary and an assistant acknowledgment — so the runner
+sees it as normal conversation history.
+
+Message `parentId` fields are re-chained so the compaction entry becomes the
+parent of the first kept message, preserving the linked-list structure.
+
+## Triggers
+
+### Manual — `/compact` command
+
+Available in both CLI and Telegram:
+
+```
+/compact
+```
+
+Calls `Pool.CompactSession()` directly. Returns the summary text to the user.
+
+### Automatic — token threshold
+
+`Pool.Chat()` checks `Pool.NeedsCompaction()` before each message. If the
+estimated token count exceeds the threshold, compaction runs automatically
+before the user's message is sent.
+
+If auto-compaction fails, the system logs a warning and continues with the full
+history — it never blocks the user's message.
+
+## Configuration
+
+In `.agents/config.yaml` under `runner`:
+
+```yaml
+runner:
+  compaction:
+    max_tokens: 80000   # auto-compact threshold (0 = disabled)
+    keep_tail: 20       # recent messages to preserve verbatim
+```
+
+Both fields have defaults applied via `CompactionConfig.WithDefaults()`:
+- `max_tokens`: 80,000
+- `keep_tail`: 20
+
+Setting `max_tokens: 0` in config disables automatic compaction; `/compact`
+still works manually.
+
+## Session Loading
+
+`CompactSession()` uses `getOrCreateRunner()` — the same path as `Chat()` — so
+it works even when the session exists only on disk (e.g., after process restart
+or for Telegram sessions that haven't been accessed in this process lifetime).
+This ensures `/compact` is always available for any persisted session.
+
+## Failure Modes
+
+| Scenario | Behavior |
+|---|---|
+| No store configured | Returns error: "compaction requires a persistent store" |
+| Runner fails to summarize | Returns error, session untouched |
+| Store rewrite fails | Returns error, original file preserved |
+| Auto-compaction fails | Logs warning, continues with full history |
+| Empty summary from runner | Returns error: "empty summary response" |
+
+The original JSONL file is only replaced after the compaction entry and tail
+messages are successfully built. The write uses `os.Rename` for atomicity where
+the OS supports it.

--- a/main.go
+++ b/main.go
@@ -157,7 +157,10 @@ func setup(parent context.Context) (*setupResult, error) {
 		return nil, fmt.Errorf("create runner factory: %w", err)
 	}
 
-	opts := []agent.PoolOption{agent.WithIdleTimeout(idleTimeout)}
+	opts := []agent.PoolOption{
+		agent.WithIdleTimeout(idleTimeout),
+		agent.WithCompaction(cfg.Runner.Compaction.WithDefaults()),
+	}
 	if cfg.Sessions != "" {
 		cwd, _ := os.Getwd()
 		s, err := store.NewFileStore(cfg.Sessions, cwd)


### PR DESCRIPTION
## Summary

When session history grows too large, automatically (or manually) compact it by generating an LLM summary using a handoff-style prompt, then rewriting the session file with the summary + recent messages.

## Changes

### Core: Store + Pool
- **`Store.Compact()`** — atomically rewrites session JSONL: header → compaction entry → last N message lines (re-chained parentIds)
- **`Store.EstimateTokens()`** — rough token count (~4 bytes/token) from raw JSONL message lines, no full parse
- **`Pool.CompactSession()`** — orchestrates: summarize via runner → compact store → replace in-memory events → kill runner (restarts on next Chat)
- **`Pool.NeedsCompaction()`** — token-based threshold check
- **Auto-trigger** in `Pool.Chat()` before sending to runner

### Channels
- **CLI**: `/compact` slash command — async with "Compacting session..." status indicator
- **Telegram**: `/compact` bot command — typing indicator + confirmation message

### Config
```yaml
runner:
  compaction:
    max_tokens: 80000  # token threshold (0 = disabled), default 80k
    keep_tail: 20      # recent message lines to keep verbatim
```

### How it works
1. **Detect** — before each `Chat()`, estimate tokens via `EstimateTokens()`
2. **Summarize** — send handoff-style prompt (goal, progress, decisions, files changed, state, blockers, next steps) to the runner with full history
3. **Compact** — atomic rewrite of JSONL file with compaction entry + tail
4. **Reload** — runner killed, recreated on next call. Go runner picks up compacted events via `convertHistory()`. Pi runner starts fresh (compaction parsed by existing `parseCompaction()`)

### Tests
- `TestEstimateTokens` — empty + populated sessions
- `TestCompact` — full round-trip: build history → compact → verify events + append after
- `TestCompactNonexistent` — error case
- `TestCompactKeepAll` — keepTail >= message count
- Updated `TestBotCommands` for new `/compact` command
