### PR TITLE
✨ feat: Tiered model config (strong/worker/fast)

### DIFF
--- a/agent/integration_test.go
+++ b/agent/integration_test.go
@@ -26,7 +26,7 @@ func TestIntegrationPoolWithGoRunner(t *testing.T) {
 		model = "claude-sonnet-4-20250514"
 	}
 
-	factory := func(ctx context.Context) (runner.Runner, error) {
+	factory := func(ctx context.Context, _ string) (runner.Runner, error) {
 		return gorunner.New(ctx, gorunner.Config{
 			API:     "anthropic",
 			Model:   model,

--- a/agent/pool.go
+++ b/agent/pool.go
@@ -17,13 +17,15 @@ import (
 // Pool manages a set of sessions, each with its own history and runner.
 // It is the only type channels interact with.
 type Pool struct {
-	factory     runner.NewRunnerFunc
-	sessions    map[string]*Session
-	store       store.Store
-	mu          sync.Mutex
-	idleTimeout time.Duration
-	compaction  CompactionConfig
-	log         *slog.Logger
+	factory      runner.NewRunnerFunc
+	sessions     map[string]*Session
+	store        store.Store
+	mu           sync.Mutex
+	idleTimeout  time.Duration
+	compaction   CompactionConfig
+	defaultModel string // default model ID for new runners
+	fastModel    string // model ID used for compaction / fast tasks
+	log          *slog.Logger
 }
 
 // PoolOption configures a Pool.
@@ -43,6 +45,20 @@ func WithCompaction(cfg CompactionConfig) PoolOption {
 	}
 }
 
+// WithDefaultModel sets the default model ID for new runners.
+func WithDefaultModel(model string) PoolOption {
+	return func(p *Pool) {
+		p.defaultModel = model
+	}
+}
+
+// WithFastModel sets the model ID used for compaction and other fast tasks.
+func WithFastModel(model string) PoolOption {
+	return func(p *Pool) {
+		p.fastModel = model
+	}
+}
+
 // WithStore sets the persistent store for session history.
 func WithStore(s store.Store) PoolOption {
 	return func(p *Pool) {
@@ -50,13 +66,28 @@ func WithStore(s store.Store) PoolOption {
 	}
 }
 
+// ChatOption configures a single Chat call.
+type ChatOption func(*chatOptions)
+
+type chatOptions struct {
+	model string
+}
+
+// WithModel overrides the model for this Chat call. If the session already
+// has a runner with a different model, the runner is replaced.
+func WithModel(model string) ChatOption {
+	return func(o *chatOptions) {
+		o.model = model
+	}
+}
+
 // NewPool creates a new Pool with the given runner factory.
 func NewPool(factory runner.NewRunnerFunc, opts ...PoolOption) *Pool {
 	p := &Pool{
-		factory:     factory,
-		sessions:    make(map[string]*Session),
-		idleTimeout: 10 * time.Minute,
-		log:         slog.With("component", "pool"),
+		factory:      factory,
+		sessions:     make(map[string]*Session),
+		idleTimeout:  10 * time.Minute,
+		log:          slog.With("component", "pool"),
 	}
 	for _, opt := range opts {
 		opt(p)
@@ -209,7 +240,7 @@ func (p *Pool) CompactSession(ctx context.Context, sessionID string) (string, er
 		return "", fmt.Errorf("compaction requires a persistent store")
 	}
 
-	sess, r, err := p.getOrCreateRunner(ctx, sessionID)
+	sess, r, err := p.getOrCreateRunner(ctx, sessionID, p.fastModel)
 	if err != nil {
 		return "", fmt.Errorf("get runner: %w", err)
 	}
@@ -320,10 +351,15 @@ func (p *Pool) History(sessionID string) []runner.RPCEvent {
 // Chat sends a message in a session and streams back events.
 // Internally: gets/creates runner, passes history, collects events,
 // appends to session log, streams to caller.
-func (p *Pool) Chat(ctx context.Context, sessionID string, message string) <-chan runner.Event {
+func (p *Pool) Chat(ctx context.Context, sessionID string, message string, opts ...ChatOption) <-chan runner.Event {
 	out := make(chan runner.Event, 100)
 
-	sess, r, err := p.getOrCreateRunner(ctx, sessionID)
+	var co chatOptions
+	for _, o := range opts {
+		o(&co)
+	}
+
+	sess, r, err := p.getOrCreateRunner(ctx, sessionID, co.model)
 	if err != nil {
 		go func() {
 			out <- runner.Event{Err: fmt.Errorf("get runner: %w", err)}
@@ -344,7 +380,7 @@ func (p *Pool) Chat(ctx context.Context, sessionID string, message string) <-cha
 			p.log.Info("auto-compaction succeeded", "session_id", sessionID,
 				"summary_len", len(summary))
 			// Re-acquire session and runner after compaction (runner was restarted).
-			sess, r, err = p.getOrCreateRunner(ctx, sessionID)
+			sess, r, err = p.getOrCreateRunner(ctx, sessionID, co.model)
 			if err != nil {
 				go func() {
 					out <- runner.Event{Err: fmt.Errorf("get runner after compaction: %w", err)}
@@ -488,7 +524,9 @@ func (p *Pool) StartReaper(ctx context.Context) {
 
 // getOrCreateRunner returns the session and its runner, creating both if needed.
 // If the session is not in memory but exists on disk, its history is restored.
-func (p *Pool) getOrCreateRunner(ctx context.Context, sessionID string) (*Session, runner.Runner, error) {
+// If model is non-empty and differs from the session's current model, the
+// existing runner is replaced.
+func (p *Pool) getOrCreateRunner(ctx context.Context, sessionID string, model string) (*Session, runner.Runner, error) {
 	p.mu.Lock()
 	sess, ok := p.sessions[sessionID]
 	if ok && sess.Runner != nil {
@@ -502,8 +540,18 @@ func (p *Pool) getOrCreateRunner(ctx context.Context, sessionID string) (*Sessio
 		}
 	}
 	if ok && sess.Runner != nil {
-		p.mu.Unlock()
-		return sess, sess.Runner, nil
+		// If a specific model was requested and it differs from the session's
+		// current model, replace the runner.
+		if model != "" && sess.Model != model {
+			p.log.Info("switching model", "session_id", sessionID, "from", sess.Model, "to", model)
+			if closer, isCloser := sess.Runner.(io.Closer); isCloser {
+				_ = closer.Close()
+			}
+			sess.Runner = nil
+		} else {
+			p.mu.Unlock()
+			return sess, sess.Runner, nil
+		}
 	}
 	if !ok {
 		sess = &Session{}
@@ -535,13 +583,23 @@ func (p *Pool) getOrCreateRunner(ctx context.Context, sessionID string) (*Sessio
 	}
 	p.mu.Unlock()
 
-	r, err := p.factory(ctx)
+	// Resolve the model: explicit > session's current > pool default.
+	effectiveModel := model
+	if effectiveModel == "" {
+		effectiveModel = sess.Model
+	}
+	if effectiveModel == "" {
+		effectiveModel = p.defaultModel
+	}
+
+	r, err := p.factory(ctx, effectiveModel)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	p.mu.Lock()
 	sess.Runner = r
+	sess.Model = effectiveModel
 	p.mu.Unlock()
 
 	p.log.Info("created runner", "session_id", sessionID)

--- a/agent/pool.go
+++ b/agent/pool.go
@@ -240,9 +240,24 @@ func (p *Pool) CompactSession(ctx context.Context, sessionID string) (string, er
 		return "", fmt.Errorf("compaction requires a persistent store")
 	}
 
+	// Remember the session's original model so we can restore it after
+	// compaction — the fast model is only for generating the summary.
+	p.mu.Lock()
+	sess, ok := p.sessions[sessionID]
+	origModel := ""
+	if ok {
+		origModel = sess.Model
+	}
+	p.mu.Unlock()
+
 	sess, r, err := p.getOrCreateRunner(ctx, sessionID, p.fastModel)
 	if err != nil {
 		return "", fmt.Errorf("get runner: %w", err)
+	}
+
+	// If the session was new (no prior model), fall back to the pool default.
+	if origModel == "" {
+		origModel = p.defaultModel
 	}
 
 	p.mu.Lock()
@@ -283,6 +298,7 @@ func (p *Pool) CompactSession(ctx context.Context, sessionID string) (string, er
 		}
 		p.mu.Lock()
 		sess.Runner = nil
+		sess.Model = origModel // restore so next Chat uses the original model
 		p.mu.Unlock()
 	}
 
@@ -484,6 +500,14 @@ func (p *Pool) Reset(sessionID string) error {
 func (p *Pool) SetFactory(factory runner.NewRunnerFunc) {
 	p.mu.Lock()
 	p.factory = factory
+	p.mu.Unlock()
+}
+
+// SetDefaultModel updates the default model used for new runners.
+// Call this alongside SetFactory when the user switches models at runtime.
+func (p *Pool) SetDefaultModel(model string) {
+	p.mu.Lock()
+	p.defaultModel = model
 	p.mu.Unlock()
 }
 

--- a/agent/pool_test.go
+++ b/agent/pool_test.go
@@ -657,4 +657,57 @@ func TestPoolFastModelForCompaction(t *testing.T) {
 	if !found {
 		t.Errorf("compaction did not use fast model, models = %v", models)
 	}
+
+	// After compaction, session model should be restored to strong-model
+	// so subsequent chats don't stay on the fast tier.
+	pool.mu.Lock()
+	sessModel := pool.sessions[info.ID].Model
+	pool.mu.Unlock()
+
+	if sessModel != "strong-model" {
+		t.Errorf("session model after compaction = %q, want %q", sessModel, "strong-model")
+	}
+}
+
+func TestSetDefaultModelAffectsNewSessions(t *testing.T) {
+	var models []string
+	var mu sync.Mutex
+	factory := func(_ context.Context, model string) (runner.Runner, error) {
+		mu.Lock()
+		models = append(models, model)
+		mu.Unlock()
+		return newMockRunner([]runner.Event{{Text: "ok"}}), nil
+	}
+
+	pool := NewPool(factory, WithDefaultModel("initial-model"))
+	defer pool.Close()
+
+	ctx := context.Background()
+
+	// First session uses initial default.
+	info1, _ := pool.CreateSession()
+	stream := pool.Chat(ctx, info1.ID, "hello")
+	for range stream {
+	}
+
+	mu.Lock()
+	if models[0] != "initial-model" {
+		t.Fatalf("first session model = %q, want initial-model", models[0])
+	}
+	mu.Unlock()
+
+	// Switch default model at runtime.
+	pool.SetDefaultModel("switched-model")
+
+	// New session should use the switched model.
+	info2, _ := pool.CreateSession()
+	stream = pool.Chat(ctx, info2.ID, "hello")
+	for range stream {
+	}
+
+	mu.Lock()
+	if models[1] != "switched-model" {
+		t.Fatalf("second session model = %q, want switched-model", models[1])
+	}
+	mu.Unlock()
 }

--- a/agent/pool_test.go
+++ b/agent/pool_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/vaayne/anna/agent/runner"
+	"github.com/vaayne/anna/agent/store"
 )
 
 // mockRunner implements runner.Runner and io.Closer for pool tests.
@@ -68,7 +69,7 @@ func (m *mockRunner) LastActivity() time.Time {
 func mockRunnerFactory(events []runner.Event) (runner.NewRunnerFunc, *[]*mockRunner) {
 	var runners []*mockRunner
 	var mu sync.Mutex
-	factory := func(_ context.Context) (runner.Runner, error) {
+	factory := func(_ context.Context, _ string) (runner.Runner, error) {
 		r := newMockRunner(events)
 		mu.Lock()
 		runners = append(runners, r)
@@ -181,7 +182,7 @@ func TestPoolChatAccumulatesHistory(t *testing.T) {
 }
 
 func TestPoolChatErrorFromFactory(t *testing.T) {
-	factory := func(_ context.Context) (runner.Runner, error) {
+	factory := func(_ context.Context, _ string) (runner.Runner, error) {
 		return nil, fmt.Errorf("factory error")
 	}
 	pool := NewPool(factory)
@@ -289,7 +290,7 @@ func TestPoolReapIdle(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a session by triggering getOrCreateRunner.
-	_, r, err := pool.getOrCreateRunner(ctx, "idle-sess")
+	_, r, err := pool.getOrCreateRunner(ctx, "idle-sess", "")
 	if err != nil {
 		t.Fatalf("getOrCreateRunner: %v", err)
 	}
@@ -332,7 +333,7 @@ func TestPoolReapDead(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a session with a mockRunner.
-	_, _, err := pool.getOrCreateRunner(ctx, "dead-sess")
+	_, _, err := pool.getOrCreateRunner(ctx, "dead-sess", "")
 	if err != nil {
 		t.Fatalf("getOrCreateRunner: %v", err)
 	}
@@ -390,7 +391,7 @@ func TestPoolReplacesDeadRunnerOnChat(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a session with a runner.
-	_, _, err := pool.getOrCreateRunner(ctx, "sess")
+	_, _, err := pool.getOrCreateRunner(ctx, "sess", "")
 	if err != nil {
 		t.Fatalf("getOrCreateRunner: %v", err)
 	}
@@ -401,7 +402,7 @@ func TestPoolReplacesDeadRunnerOnChat(t *testing.T) {
 	(*runners)[0].mu.Unlock()
 
 	// Next call should create a new runner.
-	_, runner2, err := pool.getOrCreateRunner(ctx, "sess")
+	_, runner2, err := pool.getOrCreateRunner(ctx, "sess", "")
 	if err != nil {
 		t.Fatalf("getOrCreateRunner after death: %v", err)
 	}
@@ -549,5 +550,111 @@ func TestPoolChatAutoTitleTruncates(t *testing.T) {
 
 	if len(title) > 65 { // 60 + "…"
 		t.Errorf("title too long (%d chars): %q", len(title), title)
+	}
+}
+
+func TestPoolChatWithModel(t *testing.T) {
+	// Track which model was requested for each runner creation.
+	var models []string
+	var mu sync.Mutex
+	factory := func(_ context.Context, model string) (runner.Runner, error) {
+		mu.Lock()
+		models = append(models, model)
+		mu.Unlock()
+		return newMockRunner([]runner.Event{{Text: "ok"}}), nil
+	}
+
+	pool := NewPool(factory, WithDefaultModel("default-model"))
+	defer pool.Close()
+
+	ctx := context.Background()
+	info, _ := pool.CreateSession()
+
+	// First chat uses default model.
+	stream := pool.Chat(ctx, info.ID, "hello")
+	for range stream {
+	}
+
+	mu.Lock()
+	if len(models) != 1 || models[0] != "default-model" {
+		t.Fatalf("first call models = %v, want [default-model]", models)
+	}
+	mu.Unlock()
+
+	// Second chat with explicit model triggers runner replacement.
+	stream = pool.Chat(ctx, info.ID, "hello", WithModel("custom-model"))
+	for range stream {
+	}
+
+	mu.Lock()
+	if len(models) != 2 || models[1] != "custom-model" {
+		t.Fatalf("second call models = %v, want [..., custom-model]", models)
+	}
+	mu.Unlock()
+
+	// Third chat without model reuses the session's current model (custom-model).
+	stream = pool.Chat(ctx, info.ID, "hello")
+	for range stream {
+	}
+
+	mu.Lock()
+	// No new runner should be created — still 2 total.
+	if len(models) != 2 {
+		t.Fatalf("third call created new runner, models = %v, want len 2", models)
+	}
+	mu.Unlock()
+}
+
+func TestPoolFastModelForCompaction(t *testing.T) {
+	var models []string
+	var mu sync.Mutex
+	factory := func(_ context.Context, model string) (runner.Runner, error) {
+		mu.Lock()
+		models = append(models, model)
+		mu.Unlock()
+		return newMockRunner([]runner.Event{{Text: "summary text"}}), nil
+	}
+
+	dir := t.TempDir()
+	s, _ := store.NewFileStore(dir, t.TempDir())
+	pool := NewPool(factory,
+		WithDefaultModel("strong-model"),
+		WithFastModel("fast-model"),
+		WithStore(s),
+	)
+	defer pool.Close()
+
+	info, _ := pool.CreateSession()
+
+	// Chat to create a session with history.
+	stream := pool.Chat(context.Background(), info.ID, "hello")
+	for range stream {
+	}
+
+	mu.Lock()
+	if models[0] != "strong-model" {
+		t.Fatalf("chat model = %q, want strong-model", models[0])
+	}
+	mu.Unlock()
+
+	// Compact should use fast model.
+	_, err := pool.CompactSession(context.Background(), info.ID)
+	if err != nil {
+		t.Fatalf("CompactSession: %v", err)
+	}
+
+	mu.Lock()
+	// The compaction should have created a runner with fast-model.
+	found := false
+	for _, m := range models {
+		if m == "fast-model" {
+			found = true
+			break
+		}
+	}
+	mu.Unlock()
+
+	if !found {
+		t.Errorf("compaction did not use fast model, models = %v", models)
 	}
 }

--- a/agent/runner/runner.go
+++ b/agent/runner/runner.go
@@ -68,8 +68,9 @@ type Runner interface {
 	Chat(ctx context.Context, history []RPCEvent, message string) <-chan Event
 }
 
-// NewRunnerFunc creates a new Runner instance.
-type NewRunnerFunc func(ctx context.Context) (Runner, error)
+// NewRunnerFunc creates a new Runner instance for the given model ID.
+// An empty model means use the default.
+type NewRunnerFunc func(ctx context.Context, model string) (Runner, error)
 
 // HandlerFunc is an adapter to allow the use of ordinary functions as Runners.
 // If f is a function with the appropriate signature, HandlerFunc(f) is a Runner

--- a/agent/session.go
+++ b/agent/session.go
@@ -37,4 +37,5 @@ type Session struct {
 	Info   SessionInfo
 	Events []runner.RPCEvent
 	Runner runner.Runner
+	Model  string // model ID the current runner was created with
 }

--- a/channel/cli/cli_test.go
+++ b/channel/cli/cli_test.go
@@ -29,7 +29,7 @@ func (m *mockRunner) Chat(_ context.Context, _ []runner.RPCEvent, _ string) <-ch
 }
 
 func newTestPool(events []runner.Event) *agent.Pool {
-	factory := func(_ context.Context) (runner.Runner, error) {
+	factory := func(_ context.Context, _ string) (runner.Runner, error) {
 		return &mockRunner{events: events}, nil
 	}
 	return agent.NewPool(factory)

--- a/config.go
+++ b/config.go
@@ -13,11 +13,27 @@ import (
 type Config struct {
 	Provider  string                    `yaml:"provider"`
 	Model     string                    `yaml:"model"`
+	Models    ModelsConfig              `yaml:"models"`
 	Providers map[string]ProviderConfig `yaml:"providers"`
 	Runner    RunnerConfig              `yaml:"runner"`
 	Telegram  TelegramConfig            `yaml:"telegram"`
 	Sessions  string                    `yaml:"sessions"`
 	Cron      CronConfig                `yaml:"cron"`
+}
+
+// Model tier constants.
+const (
+	ModelTierStrong = "strong"
+	ModelTierWorker = "worker"
+	ModelTierFast   = "fast"
+)
+
+// ModelsConfig holds tiered model IDs.
+// Fallback chain: fast → worker → strong → Config.Model (backward compat).
+type ModelsConfig struct {
+	Strong string `yaml:"strong"`
+	Worker string `yaml:"worker"`
+	Fast   string `yaml:"fast"`
 }
 
 type CronConfig struct {
@@ -113,6 +129,15 @@ func loadConfigFrom(dir string) (*Config, error) {
 	if v := os.Getenv("ANNA_MODEL"); v != "" {
 		cfg.Model = v
 	}
+	if v := os.Getenv("ANNA_MODEL_STRONG"); v != "" {
+		cfg.Models.Strong = v
+	}
+	if v := os.Getenv("ANNA_MODEL_WORKER"); v != "" {
+		cfg.Models.Worker = v
+	}
+	if v := os.Getenv("ANNA_MODEL_FAST"); v != "" {
+		cfg.Models.Fast = v
+	}
 
 	// Initialize providers map if nil.
 	if cfg.Providers == nil {
@@ -167,19 +192,63 @@ func resolveProviderEnv(cfg *Config, name, keyEnv, urlEnv string) {
 // ResolveModel returns the types.Model for the default provider/model,
 // looking up from the provider's model list config.
 func (cfg *Config) ResolveModel() types.Model {
+	return cfg.ResolveModelTier(ModelTierStrong)
+}
+
+// ResolveModelTier returns the model ID for the given tier after applying
+// the fallback chain: fast → worker → strong → Config.Model.
+func (cfg *Config) ResolveModelTier(tier string) types.Model {
+	modelID := cfg.resolveModelID(tier)
 	providerCfg := cfg.Providers[cfg.Provider]
 	for _, m := range providerCfg.Models {
-		if m.ID == cfg.Model {
+		if m.ID == modelID {
 			return modelConfigToType(cfg.Provider, m)
 		}
 	}
 	// Fallback: construct a minimal Model from defaults.
 	return types.Model{
-		ID:       cfg.Model,
-		Name:     cfg.Model,
+		ID:       modelID,
+		Name:     modelID,
 		API:      cfg.Provider,
 		Provider: cfg.Provider,
 		BaseURL:  providerCfg.BaseURL,
+	}
+}
+
+// resolveModelID returns the model ID string for the given tier,
+// walking the fallback chain: fast → worker → strong → Config.Model.
+func (cfg *Config) resolveModelID(tier string) string {
+	switch tier {
+	case ModelTierFast:
+		if cfg.Models.Fast != "" {
+			return cfg.Models.Fast
+		}
+		if cfg.Models.Worker != "" {
+			return cfg.Models.Worker
+		}
+		if cfg.Models.Strong != "" {
+			return cfg.Models.Strong
+		}
+		return cfg.Model
+	case ModelTierWorker:
+		if cfg.Models.Worker != "" {
+			return cfg.Models.Worker
+		}
+		if cfg.Models.Strong != "" {
+			return cfg.Models.Strong
+		}
+		return cfg.Model
+	case ModelTierStrong:
+		if cfg.Models.Strong != "" {
+			return cfg.Models.Strong
+		}
+		return cfg.Model
+	default:
+		// Unknown tier, treat as strong.
+		if cfg.Models.Strong != "" {
+			return cfg.Models.Strong
+		}
+		return cfg.Model
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -294,7 +294,7 @@ func TestNewRunnerFactoryGo(t *testing.T) {
 		t.Fatalf("newRunnerFactory: %v", err)
 	}
 
-	r, err := factory(context.Background())
+	r, err := factory(context.Background(), "")
 	if err != nil {
 		t.Fatalf("factory: %v", err)
 	}
@@ -446,6 +446,166 @@ func TestResolveModelFallback(t *testing.T) {
 	}
 	if model.API != "anthropic" {
 		t.Errorf("model.API = %q, want %q (fallback to provider name)", model.API, "anthropic")
+	}
+}
+
+func TestResolveModelTierFallbackChain(t *testing.T) {
+	tests := []struct {
+		name   string
+		cfg    Config
+		tier   string
+		wantID string
+	}{
+		{
+			name:   "strong falls back to Model",
+			cfg:    Config{Provider: "anthropic", Model: "default-model", Providers: map[string]ProviderConfig{"anthropic": {}}},
+			tier:   "strong",
+			wantID: "default-model",
+		},
+		{
+			name:   "strong uses Models.Strong",
+			cfg:    Config{Provider: "anthropic", Model: "default-model", Models: ModelsConfig{Strong: "strong-model"}, Providers: map[string]ProviderConfig{"anthropic": {}}},
+			tier:   "strong",
+			wantID: "strong-model",
+		},
+		{
+			name:   "worker falls back to strong",
+			cfg:    Config{Provider: "anthropic", Model: "default-model", Models: ModelsConfig{Strong: "strong-model"}, Providers: map[string]ProviderConfig{"anthropic": {}}},
+			tier:   "worker",
+			wantID: "strong-model",
+		},
+		{
+			name:   "worker uses Models.Worker",
+			cfg:    Config{Provider: "anthropic", Model: "default-model", Models: ModelsConfig{Strong: "strong-model", Worker: "worker-model"}, Providers: map[string]ProviderConfig{"anthropic": {}}},
+			tier:   "worker",
+			wantID: "worker-model",
+		},
+		{
+			name:   "fast falls back to worker",
+			cfg:    Config{Provider: "anthropic", Model: "default-model", Models: ModelsConfig{Worker: "worker-model"}, Providers: map[string]ProviderConfig{"anthropic": {}}},
+			tier:   "fast",
+			wantID: "worker-model",
+		},
+		{
+			name:   "fast falls back to strong when no worker",
+			cfg:    Config{Provider: "anthropic", Model: "default-model", Models: ModelsConfig{Strong: "strong-model"}, Providers: map[string]ProviderConfig{"anthropic": {}}},
+			tier:   "fast",
+			wantID: "strong-model",
+		},
+		{
+			name:   "fast falls back to Model when nothing set",
+			cfg:    Config{Provider: "anthropic", Model: "default-model", Providers: map[string]ProviderConfig{"anthropic": {}}},
+			tier:   "fast",
+			wantID: "default-model",
+		},
+		{
+			name:   "fast uses Models.Fast",
+			cfg:    Config{Provider: "anthropic", Model: "default-model", Models: ModelsConfig{Strong: "s", Worker: "w", Fast: "fast-model"}, Providers: map[string]ProviderConfig{"anthropic": {}}},
+			tier:   "fast",
+			wantID: "fast-model",
+		},
+		{
+			name:   "unknown tier falls back like strong",
+			cfg:    Config{Provider: "anthropic", Model: "default-model", Models: ModelsConfig{Strong: "strong-model"}, Providers: map[string]ProviderConfig{"anthropic": {}}},
+			tier:   "unknown",
+			wantID: "strong-model",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := tt.cfg.ResolveModelTier(tt.tier)
+			if model.ID != tt.wantID {
+				t.Errorf("ResolveModelTier(%q) = %q, want %q", tt.tier, model.ID, tt.wantID)
+			}
+		})
+	}
+}
+
+func TestModelsConfigFromYAML(t *testing.T) {
+	dir := t.TempDir()
+	yamlContent := `
+provider: anthropic
+model: claude-sonnet-4-6
+models:
+  strong: claude-sonnet-4-6
+  worker: claude-haiku-3.5
+  fast: claude-haiku-3.5
+`
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(yamlContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := loadConfigFrom(dir)
+	if err != nil {
+		t.Fatalf("loadConfigFrom: %v", err)
+	}
+
+	if cfg.Models.Strong != "claude-sonnet-4-6" {
+		t.Errorf("Models.Strong = %q, want %q", cfg.Models.Strong, "claude-sonnet-4-6")
+	}
+	if cfg.Models.Worker != "claude-haiku-3.5" {
+		t.Errorf("Models.Worker = %q, want %q", cfg.Models.Worker, "claude-haiku-3.5")
+	}
+	if cfg.Models.Fast != "claude-haiku-3.5" {
+		t.Errorf("Models.Fast = %q, want %q", cfg.Models.Fast, "claude-haiku-3.5")
+	}
+}
+
+func TestModelTierEnvOverrides(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Setenv("ANNA_MODEL_STRONG", "env-strong")
+	t.Setenv("ANNA_MODEL_WORKER", "env-worker")
+	t.Setenv("ANNA_MODEL_FAST", "env-fast")
+
+	cfg, err := loadConfigFrom(dir)
+	if err != nil {
+		t.Fatalf("loadConfigFrom: %v", err)
+	}
+
+	if cfg.Models.Strong != "env-strong" {
+		t.Errorf("Models.Strong = %q, want %q", cfg.Models.Strong, "env-strong")
+	}
+	if cfg.Models.Worker != "env-worker" {
+		t.Errorf("Models.Worker = %q, want %q", cfg.Models.Worker, "env-worker")
+	}
+	if cfg.Models.Fast != "env-fast" {
+		t.Errorf("Models.Fast = %q, want %q", cfg.Models.Fast, "env-fast")
+	}
+
+	// Verify tier resolution uses env values.
+	model := cfg.ResolveModelTier("fast")
+	if model.ID != "env-fast" {
+		t.Errorf("ResolveModelTier(fast) = %q, want %q", model.ID, "env-fast")
+	}
+}
+
+func TestModelTierEnvOverridesYAML(t *testing.T) {
+	dir := t.TempDir()
+	yamlContent := `
+models:
+  strong: yaml-strong
+  fast: yaml-fast
+`
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(yamlContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("ANNA_MODEL_STRONG", "env-strong")
+
+	cfg, err := loadConfigFrom(dir)
+	if err != nil {
+		t.Fatalf("loadConfigFrom: %v", err)
+	}
+
+	// Env should override YAML.
+	if cfg.Models.Strong != "env-strong" {
+		t.Errorf("Models.Strong = %q, want %q", cfg.Models.Strong, "env-strong")
+	}
+	// YAML value should remain for non-overridden tiers.
+	if cfg.Models.Fast != "yaml-fast" {
+		t.Errorf("Models.Fast = %q, want %q", cfg.Models.Fast, "yaml-fast")
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -156,6 +156,8 @@ func setup(parent context.Context) (*setupResult, error) {
 	opts := []agent.PoolOption{
 		agent.WithIdleTimeout(idleTimeout),
 		agent.WithCompaction(cfg.Runner.Compaction.WithDefaults()),
+		agent.WithDefaultModel(cfg.resolveModelID(ModelTierStrong)),
+		agent.WithFastModel(cfg.resolveModelID(ModelTierFast)),
 	}
 	if cfg.Sessions != "" {
 		cwd, _ := os.Getwd()
@@ -198,10 +200,13 @@ func newRunnerFactory(cfg *Config, memStore *memory.Store, extraTools []tool.Too
 	switch cfg.Runner.Type {
 	case "go":
 		providerCfg := cfg.Providers[cfg.Provider]
-		return func(ctx context.Context) (runner.Runner, error) {
+		return func(ctx context.Context, model string) (runner.Runner, error) {
+			if model == "" {
+				model = cfg.Model
+			}
 			return gorunner.New(ctx, gorunner.Config{
 				API:         cfg.Provider,
-				Model:       cfg.Model,
+				Model:       model,
 				APIKey:      providerCfg.APIKey,
 				AgentsDir:   configDir(),
 				MemoryStore: memStore,

--- a/main.go
+++ b/main.go
@@ -230,6 +230,7 @@ func modelSwitcher(cfg *Config, pool *agent.Pool, memStore *memory.Store, extraT
 			return err
 		}
 		pool.SetFactory(factory)
+		pool.SetDefaultModel(model)
 		if err := SaveModelSelection(provider, model); err != nil {
 			slog.Warn("failed to persist model selection", "error", err)
 		}


### PR DESCRIPTION
## Summary

Replace the single global `model` config with a tiered model system. Different tasks have different intelligence requirements — compaction needs speed, while complex reasoning needs the best model.

## Changes

### Config (`config.go`)
- `ModelsConfig` struct with `Strong`, `Worker`, `Fast` tiers
- Fallback chain: `fast → worker → strong → Model` (backward compat)
- Env overrides: `ANNA_MODEL_STRONG`, `ANNA_MODEL_WORKER`, `ANNA_MODEL_FAST`
- `ResolveModelTier(tier)` / `resolveModelID(tier)` methods

### Runner (`agent/runner/runner.go`)
- `NewRunnerFunc` now accepts `model string` parameter

### Pool (`agent/pool.go`)
- `Chat()` accepts `...ChatOption` with `WithModel("model-id")` for per-call model selection
- `WithDefaultModel()` / `WithFastModel()` pool options
- Session tracks current model; runner replaced on model switch
- Compaction automatically uses the fast model tier

### Wiring (`main.go`)
- Pool created with `WithDefaultModel` (strong) and `WithFastModel` (fast)
- Factory passes model through to `gorunner.Config`

## Config Example

```yaml
provider: anthropic
model: claude-sonnet-4-6        # backward compat fallback

models:
  strong: claude-sonnet-4-6
  worker: claude-sonnet-4-6
  fast: claude-haiku-3.5
```

## Tests
- 9 new test cases covering fallback chain, YAML parsing, env overrides, `WithModel` chat option, and fast model compaction
- All existing tests pass

Closes #6