### PR TITLE
✨ feat(telegram): Enhance bot UX

### DIFF
--- a/channel/telegram/telegram.go
+++ b/channel/telegram/telegram.go
@@ -14,6 +14,7 @@ import (
 	"github.com/yuin/goldmark/parser"
 
 	"github.com/vaayne/anna/agent"
+	"github.com/vaayne/anna/agent/runner"
 	"github.com/vaayne/anna/channel"
 	tele "gopkg.in/telebot.v4"
 )
@@ -31,13 +32,31 @@ const telegramMaxMessageLen = 4000
 // streamEditInterval controls how often we edit the message during streaming.
 const streamEditInterval = time.Second
 
+// typingInterval is how often we re-send the typing indicator. Telegram
+// expires typing status after ~5 seconds, so we resend every 4s.
+const typingInterval = 4 * time.Second
+
 // typingCursor is appended to the message while streaming to indicate activity.
 const typingCursor = " \u258D"
+
+// callbackModelPrefix is the prefix for model-selection callback data.
+const callbackModelPrefix = "model:"
+
+// toolEmoji maps known tool names to display emoji.
+var toolEmoji = map[string]string{
+	"bash":    "⚡",
+	"read":    "📖",
+	"write":   "✏️",
+	"edit":    "🔧",
+	"search":  "🔍",
+	"default": "🔧",
+}
 
 var log = slog.With("component", "telegram")
 
 func botCommands() []tele.Command {
 	return []tele.Command{
+		{Text: "start", Description: "Welcome & help"},
 		{Text: "new", Description: "Start a new session"},
 		{Text: "compact", Description: "Compact session history"},
 		{Text: "model", Description: "List or switch models"},
@@ -47,6 +66,15 @@ func botCommands() []tele.Command {
 func registerCommands(bot *tele.Bot) error {
 	return bot.SetCommands(botCommands())
 }
+
+const welcomeMessage = `👋 Hi! I'm Anna — your local AI assistant.
+
+*Commands*
+/new — Start a fresh session
+/compact — Compress conversation history
+/model — Switch between models
+
+Just send me a message to get started.`
 
 // Run starts a Telegram bot using long polling. It blocks until ctx is
 // cancelled.
@@ -66,6 +94,10 @@ func Run(ctx context.Context, token string, pool *agent.Pool, listFn ModelListFu
 	if err := registerCommands(bot); err != nil {
 		log.Warn("register telegram commands failed", "error", err)
 	}
+
+	bot.Handle("/start", func(c tele.Context) error {
+		return c.Send(welcomeMessage, tele.ModeMarkdown)
+	})
 
 	bot.Handle("/new", func(c tele.Context) error {
 		sessionID := strconv.FormatInt(c.Chat().ID, 10)
@@ -93,43 +125,31 @@ func Run(ctx context.Context, token string, pool *agent.Pool, listFn ModelListFu
 		args := strings.TrimSpace(c.Message().Payload)
 		models := listFn()
 
-		// No argument: list available models.
+		// No argument: show inline keyboard.
 		if args == "" {
-			if len(models) == 0 {
-				return c.Send("No models configured.")
-			}
-			active, ok := chatModels[c.Chat().ID]
-			var sb strings.Builder
-			sb.WriteString("Available models:\n\n")
-			for i, m := range models {
-				label := fmt.Sprintf("%s/%s", m.Provider, m.Model)
-				if ok && m.Provider == active.Provider && m.Model == active.Model {
-					label += " (current)"
-				}
-				sb.WriteString(fmt.Sprintf("%d. %s\n", i+1, label))
-			}
-			sb.WriteString("\nUse /model <number> to switch.")
-			return c.Send(sb.String())
+			return sendModelKeyboard(c, models, chatModels)
 		}
 
 		// Argument provided: switch to that model.
-		idx, err := strconv.Atoi(args)
-		if err != nil || idx < 1 || idx > len(models) {
-			return c.Send(fmt.Sprintf("Invalid selection. Use a number between 1 and %d.", len(models)))
+		return switchModel(c, pool, chatModels, models, switchFn, args)
+	})
+
+	// Handle inline keyboard callbacks for model selection.
+	bot.Handle(tele.OnCallback, func(c tele.Context) error {
+		data := c.Data()
+		if !strings.HasPrefix(data, callbackModelPrefix) {
+			return c.Respond()
 		}
-		selected := models[idx-1]
-		if switchFn != nil {
-			if err := switchFn(selected.Provider, selected.Model); err != nil {
-				return c.Send(fmt.Sprintf("Error switching model: %v", err))
-			}
+
+		idxStr := strings.TrimPrefix(data, callbackModelPrefix)
+		models := listFn()
+		if err := switchModel(c, pool, chatModels, models, switchFn, idxStr); err != nil {
+			return err
 		}
-		sessionID := strconv.FormatInt(c.Chat().ID, 10)
-		if err := pool.Reset(sessionID); err != nil {
-			log.Error("reset session after model switch failed", "session_id", sessionID, "error", err)
-		}
-		chatModels[c.Chat().ID] = selected
-		log.Info("model switched", "session_id", sessionID, "provider", selected.Provider, "model", selected.Model)
-		return c.Send(fmt.Sprintf("Switched to %s/%s. Session reset.", selected.Provider, selected.Model))
+
+		// Acknowledge the callback and remove the keyboard.
+		_ = c.Respond()
+		return c.Delete()
 	})
 
 	bot.Handle(tele.OnText, func(c tele.Context) error {
@@ -139,9 +159,13 @@ func Run(ctx context.Context, token string, pool *agent.Pool, listFn ModelListFu
 
 		log.Debug("message received", "chat_id", chatID, "text_len", len(text))
 
-		_ = c.Notify(tele.Typing)
+		// Start persistent typing indicator.
+		typingCtx, stopTyping := context.WithCancel(ctx)
+		go keepTyping(typingCtx, c)
 
 		response, streamErr := streamResponse(bot, c, pool, ctx, sessionID, text)
+
+		stopTyping()
 
 		if streamErr != nil {
 			log.Error("agent stream error", "session_id", sessionID, "error", streamErr)
@@ -173,6 +197,90 @@ func Run(ctx context.Context, token string, pool *agent.Pool, listFn ModelListFu
 	return ctx.Err()
 }
 
+// keepTyping sends the typing indicator repeatedly until ctx is cancelled.
+func keepTyping(ctx context.Context, c tele.Context) {
+	_ = c.Notify(tele.Typing)
+	ticker := time.NewTicker(typingInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			_ = c.Notify(tele.Typing)
+		}
+	}
+}
+
+// sendModelKeyboard sends an inline keyboard with model selection buttons.
+func sendModelKeyboard(c tele.Context, models []ModelOption, chatModels map[int64]ModelOption) error {
+	if len(models) == 0 {
+		return c.Send("No models configured.")
+	}
+
+	active, hasActive := chatModels[c.Chat().ID]
+	markup := &tele.ReplyMarkup{}
+
+	var rows []tele.Row
+	for i, m := range models {
+		label := fmt.Sprintf("%s/%s", m.Provider, m.Model)
+		if hasActive && m.Provider == active.Provider && m.Model == active.Model {
+			label = "✅ " + label
+		}
+		btn := markup.Data(label, "model_select", fmt.Sprintf("model:%d", i+1))
+		rows = append(rows, markup.Row(btn))
+	}
+
+	markup.Inline(rows...)
+	return c.Send("Select a model:", markup)
+}
+
+// switchModel handles model switching by index string. Used by both /model
+// command and inline keyboard callback.
+func switchModel(c tele.Context, pool *agent.Pool, chatModels map[int64]ModelOption, models []ModelOption, switchFn channel.ModelSwitchFunc, idxStr string) error {
+	idx, err := strconv.Atoi(idxStr)
+	if err != nil || idx < 1 || idx > len(models) {
+		return c.Send(fmt.Sprintf("Invalid selection. Use a number between 1 and %d.", len(models)))
+	}
+	selected := models[idx-1]
+	if switchFn != nil {
+		if err := switchFn(selected.Provider, selected.Model); err != nil {
+			return c.Send(fmt.Sprintf("Error switching model: %v", err))
+		}
+	}
+	sessionID := strconv.FormatInt(c.Chat().ID, 10)
+	if err := pool.Reset(sessionID); err != nil {
+		log.Error("reset session after model switch failed", "session_id", sessionID, "error", err)
+	}
+	chatModels[c.Chat().ID] = selected
+	log.Info("model switched", "session_id", sessionID, "provider", selected.Provider, "model", selected.Model)
+	return c.Send(fmt.Sprintf("Switched to %s/%s. Session reset.", selected.Provider, selected.Model))
+}
+
+// toolLine returns a short status line for a tool-use event.
+func toolLine(t *runner.ToolUseEvent) string {
+	emoji, ok := toolEmoji[t.Tool]
+	if !ok {
+		emoji = toolEmoji["default"]
+	}
+	switch t.Status {
+	case "running":
+		input := t.Input
+		if len(input) > 60 {
+			input = input[:57] + "..."
+		}
+		if input != "" {
+			return fmt.Sprintf("%s %s: %s", emoji, t.Tool, input)
+		}
+		return fmt.Sprintf("%s %s", emoji, t.Tool)
+	case "error":
+		return fmt.Sprintf("❌ %s failed", t.Tool)
+	default:
+		return ""
+	}
+}
+
 // streamResponse consumes the agent stream, sending and editing a Telegram
 // message in place as tokens arrive. It returns the final accumulated text
 // and any stream error. The sent message (if any) is deleted before returning
@@ -181,6 +289,7 @@ func streamResponse(bot *tele.Bot, c tele.Context, pool *agent.Pool, ctx context
 	var sb strings.Builder
 	var sentMsg *tele.Message
 	var streamErr error
+	var currentTool string
 	lastEdit := time.Time{}
 
 	for evt := range pool.Chat(ctx, sessionID, prompt) {
@@ -188,6 +297,19 @@ func streamResponse(bot *tele.Bot, c tele.Context, pool *agent.Pool, ctx context
 			streamErr = evt.Err
 			break
 		}
+
+		// Track tool-use events for display.
+		if evt.ToolUse != nil {
+			line := toolLine(evt.ToolUse)
+			if line != "" {
+				currentTool = line
+			} else {
+				currentTool = ""
+			}
+			// Force an immediate update to show tool status.
+			lastEdit = time.Time{}
+		}
+
 		sb.WriteString(evt.Text)
 
 		now := time.Now()
@@ -196,25 +318,31 @@ func streamResponse(bot *tele.Bot, c tele.Context, pool *agent.Pool, ctx context
 		}
 
 		current := sb.String()
-		if strings.TrimSpace(current) == "" {
+		// Show tool status even if no text yet.
+		if strings.TrimSpace(current) == "" && currentTool == "" {
 			continue
 		}
 
-		// Truncate display text if it exceeds the message limit.
+		// Build display: text + tool indicator + cursor.
 		display := current
-		if len(display)+len(typingCursor) > telegramMaxMessageLen {
-			display = display[:telegramMaxMessageLen-len(typingCursor)-3] + "..."
+		suffix := typingCursor
+		if currentTool != "" {
+			suffix = "\n\n_" + currentTool + "_" + typingCursor
+		}
+
+		if len(display)+len(suffix) > telegramMaxMessageLen {
+			display = display[:telegramMaxMessageLen-len(suffix)-3] + "..."
 		}
 
 		if sentMsg == nil {
-			msg, err := bot.Send(c.Chat(), display+typingCursor)
+			msg, err := bot.Send(c.Chat(), display+suffix)
 			if err != nil {
 				log.Warn("stream send failed", "error", err)
 			} else {
 				sentMsg = msg
 			}
 		} else {
-			if _, err := bot.Edit(sentMsg, display+typingCursor); err != nil {
+			if _, err := bot.Edit(sentMsg, display+suffix); err != nil {
 				log.Warn("stream edit failed", "error", err)
 			}
 		}

--- a/channel/telegram/telegram.go
+++ b/channel/telegram/telegram.go
@@ -330,8 +330,17 @@ func streamResponse(bot *tele.Bot, c tele.Context, pool *agent.Pool, ctx context
 			suffix = "\n\n_" + currentTool + "_" + typingCursor
 		}
 
+		// Guard against suffix being longer than the message limit.
+		if len(suffix) >= telegramMaxMessageLen {
+			suffix = typingCursor
+		}
+
 		if len(display)+len(suffix) > telegramMaxMessageLen {
-			display = display[:telegramMaxMessageLen-len(suffix)-3] + "..."
+			cutAt := telegramMaxMessageLen - len(suffix) - 3
+			if cutAt < 0 {
+				cutAt = 0
+			}
+			display = display[:cutAt] + "..."
 		}
 
 		if sentMsg == nil {

--- a/channel/telegram/telegram_test.go
+++ b/channel/telegram/telegram_test.go
@@ -176,6 +176,28 @@ func TestToolLine(t *testing.T) {
 	}
 }
 
+func TestToolLineLongToolName(t *testing.T) {
+	// A very long tool name should not cause toolLine to produce something
+	// that would panic during stream truncation.
+	evt := runner.ToolUseEvent{
+		Tool:   strings.Repeat("x", 5000),
+		Status: "running",
+		Input:  "test",
+	}
+	line := toolLine(&evt)
+	if line == "" {
+		t.Error("expected non-empty line for running tool")
+	}
+	// The suffix built from this would exceed telegramMaxMessageLen.
+	// Verify the guard logic: suffix falls back to typingCursor.
+	suffix := "\n\n_" + line + "_" + typingCursor
+	if len(suffix) < telegramMaxMessageLen {
+		t.Skip("tool name not long enough to trigger guard")
+	}
+	// The production code would replace this with just typingCursor.
+	// This test just ensures toolLine itself doesn't panic.
+}
+
 func TestToolEmojiDefaults(t *testing.T) {
 	// Verify all documented tools have emoji entries.
 	for _, tool := range []string{"bash", "read", "write", "edit", "search"} {

--- a/channel/telegram/telegram_test.go
+++ b/channel/telegram/telegram_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/vaayne/anna/agent/runner"
+
 	tgmd "github.com/Mad-Pixels/goldmark-tgmd"
 )
 
@@ -109,11 +111,79 @@ func TestRenderMarkdownFallback(t *testing.T) {
 
 func TestBotCommands(t *testing.T) {
 	commands := botCommands()
-	if len(commands) != 3 {
-		t.Fatalf("len(commands) = %d, want 3", len(commands))
+	if len(commands) != 4 {
+		t.Fatalf("len(commands) = %d, want 4", len(commands))
 	}
 
-	if commands[0].Text != "new" || commands[1].Text != "compact" || commands[2].Text != "model" {
-		t.Fatalf("commands = %#v, want new/compact/model", commands)
+	want := []string{"start", "new", "compact", "model"}
+	for i, cmd := range commands {
+		if cmd.Text != want[i] {
+			t.Errorf("commands[%d].Text = %q, want %q", i, cmd.Text, want[i])
+		}
+	}
+}
+
+func TestToolLine(t *testing.T) {
+	tests := []struct {
+		name string
+		evt  runner.ToolUseEvent
+		want string
+	}{
+		{
+			name: "bash running",
+			evt:  runner.ToolUseEvent{Tool: "bash", Status: "running", Input: "ls -la"},
+			want: "⚡ bash: ls -la",
+		},
+		{
+			name: "read running",
+			evt:  runner.ToolUseEvent{Tool: "read", Status: "running", Input: "main.go"},
+			want: "📖 read: main.go",
+		},
+		{
+			name: "unknown tool running",
+			evt:  runner.ToolUseEvent{Tool: "custom", Status: "running", Input: "something"},
+			want: "🔧 custom: something",
+		},
+		{
+			name: "tool error",
+			evt:  runner.ToolUseEvent{Tool: "bash", Status: "error"},
+			want: "❌ bash failed",
+		},
+		{
+			name: "tool done returns empty",
+			evt:  runner.ToolUseEvent{Tool: "bash", Status: "done"},
+			want: "",
+		},
+		{
+			name: "running no input",
+			evt:  runner.ToolUseEvent{Tool: "edit", Status: "running"},
+			want: "🔧 edit",
+		},
+		{
+			name: "long input truncated",
+			evt:  runner.ToolUseEvent{Tool: "bash", Status: "running", Input: strings.Repeat("x", 80)},
+			want: "⚡ bash: " + strings.Repeat("x", 57) + "...",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toolLine(&tt.evt)
+			if got != tt.want {
+				t.Errorf("toolLine() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestToolEmojiDefaults(t *testing.T) {
+	// Verify all documented tools have emoji entries.
+	for _, tool := range []string{"bash", "read", "write", "edit", "search"} {
+		if _, ok := toolEmoji[tool]; !ok {
+			t.Errorf("missing emoji for tool %q", tool)
+		}
+	}
+	if _, ok := toolEmoji["default"]; !ok {
+		t.Error("missing default emoji")
 	}
 }


### PR DESCRIPTION
## Changes

Implements P0 + P1 items from #11:

### /start welcome message
New users get a greeting with command overview.

### Persistent typing indicator
Typing status re-sent every 4s (Telegram expires it after ~5s). Previously only fired once at the start, leaving dead silence during long tool calls.

### Inline keyboard for /model
Tapping a button beats typing `/model 3`. Shows ✅ next to the current model. Callback handler cleans up the keyboard after selection.

### Tool-use indicators in streaming
While the agent runs tools, the streaming message shows what's happening:
- ⚡ `bash: ls -la`
- 📖 `read: main.go`
- ❌ `bash failed`

Tool lines appear as italicized suffixes on the streaming message and are removed when the final rendered response is sent.

### Refactoring
- Extracted `switchModel` helper shared by `/model` command and callback handler
- `keepTyping` goroutine with context cancellation

## Tests
- `TestToolLine` — all status types, truncation, unknown tools
- `TestToolEmojiDefaults` — all known tools have entries
- `TestBotCommands` — updated for 4 commands
- Full suite passes

Closes #11