### PR TITLE
✨ feat(telegram): Notification channel, group support & model switch fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,13 +7,18 @@ anna is a minimal Go CLI that acts as a local AI assistant. It uses a native Go 
 ```
 main.go                         → Entry point, signal handling, wiring
 config.go                       → Config types, YAML loading, env var overrides
-agent/runner/runner.go          → Runner interface, Event, RPCEvent, RPCCommand, HandlerFunc, optional interfaces
+agent/runner/runner.go          → Runner interface, Event, RPCEvent, HandlerFunc, optional interfaces
 agent/runner/go/runner.go       → Go runner: native LLM provider calls
 agent/pool.go                   → Pool: session management, history, runner lifecycle
 agent/session.go                → Session: event history + runner
-channel/telegram/telegram.go    → Telegram long polling, message splitting
+channel/notifier.go             → Notifier/Backend interfaces, Dispatcher (multi-backend routing)
+channel/notify_tool.go          → Notify agent tool (send messages via dispatcher)
+channel/telegram/telegram.go    → Telegram bot: long polling, notifications, group support
 channel/cli/cli.go              → Interactive terminal chat
 channel/cli/chat.go             → Bubble Tea TUI chat model
+cron/cron.go                    → Scheduled jobs (gocron/v2)
+cron/tool.go                    → Cron agent tool
+memory/                         → Persistent memory (facts, journal)
 ```
 
 ## Development
@@ -37,15 +42,43 @@ Session data: `.agents/workspace/sessions`
 
 Env var overrides:
 - `ANNA_TELEGRAM_TOKEN` → telegram.token
+- `ANNA_TELEGRAM_NOTIFY_CHAT` → telegram.notify_chat
+- `ANNA_TELEGRAM_CHANNEL_ID` → telegram.channel_id
+- `ANNA_TELEGRAM_GROUP_MODE` → telegram.group_mode
 - `ANNA_RUNNER_TYPE` → runner.type
 - `ANNA_PROVIDER` → provider
 - `ANNA_MODEL` → model
+- `ANNA_MODEL_STRONG` → models.strong
+- `ANNA_MODEL_WORKER` → models.worker
+- `ANNA_MODEL_FAST` → models.fast
+
+### Telegram Config
+
+```yaml
+telegram:
+  token: "BOT_TOKEN"
+  notify_chat: "123456789"    # chat ID for proactive notifications
+  channel_id: "@my_channel"   # optional broadcast channel
+  group_mode: "mention"       # mention | always | disabled
+  allowed_ids:                # user IDs allowed to use the bot (empty = allow all)
+    - 136345060
+```
+
+### Notification System
+
+Multi-backend dispatcher routes notifications to all registered backends (or a specific one).
+
+- `channel.Backend` interface: `Name() string` + `Notify(ctx, Notification) error`
+- `channel.Dispatcher`: register backends, broadcast or route by channel name
+- `notify` agent tool: LLM can proactively push messages via any backend
+- Cron results are broadcast to all backends via the dispatcher
+
+Adding a new backend (Slack, Discord, etc.): implement `Backend`, register with dispatcher in `runGateway()`.
 
 ## Code Conventions
 
 - Channel-based package structure: `main`, `agent`, `agent/runner`, `agent/runner/go`, `channel/cli`, `channel/telegram`
-- Minimal dependencies (only `gopkg.in/yaml.v3`)
-- stdlib `net/http` for Telegram API (no third-party bot libraries)
+- Telegram bot via `gopkg.in/telebot.v4` (long polling)
 - Conventional commits with emoji prefixes
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -1,26 +1,32 @@
 # anna
 
-A minimal Go CLI that acts as a local AI assistant. It spawns [Pi](https://github.com/anthropics/claude-code) as a local process and communicates via JSON-RPC over stdin/stdout.
+A minimal Go CLI that acts as a local AI assistant. Uses a native Go runner that calls LLM providers (Anthropic, OpenAI) directly.
 
-Two interfaces: **interactive CLI chat** and **gateway daemon** (Telegram via long polling, etc.).
-
-~880 lines of Go. Single dependency (`gopkg.in/yaml.v3`).
+Two interfaces: **interactive CLI chat** and **gateway daemon** (Telegram bot via long polling).
 
 ## Features
 
-- Spawn and manage local Pi processes via JSON-RPC over stdin/stdout
-- Interactive CLI chat mode with streaming responses
+- Native Go runner calling LLM providers directly (Anthropic, OpenAI)
+- Interactive CLI chat with Bubble Tea TUI and streaming responses
 - Telegram bot via long polling (no webhook, no public IP needed)
-- Per-chat session management using Pi's native session files
-- Idle process auto-reaping (configurable timeout, default 10min)
+- **Notification system** — multi-backend dispatcher for proactive messaging
+  - Agent `notify` tool — LLM can push messages to users
+  - Cron job results broadcast to all notification backends
+  - Extensible: add Slack, Discord, etc. by implementing the `Backend` interface
+- **Telegram group support** — configurable `group_mode` (mention/always/disabled)
+- **Access control** — `allowed_ids` restricts bot to specific Telegram users
+- Tiered model config (strong/worker/fast) with runtime model switching
+- Per-chat session management with persistent history (JSONL)
+- Session compaction with LLM-generated summaries
+- Scheduled tasks via cron with persistent job storage
+- Persistent memory (facts + journal)
+- Idle runner auto-reaping (configurable timeout)
 - Graceful shutdown on SIGINT/SIGTERM
-- Telegram message auto-splitting at newline boundaries (4000 char limit)
-- Crash detection with auto-respawn on next message
 
 ## Prerequisites
 
-- Go 1.23+
-- [Pi](https://github.com/anthropics/claude-code) installed and on your PATH
+- Go 1.24+
+- An API key for at least one LLM provider (Anthropic, OpenAI)
 - (Optional) [mise](https://mise.jdx.dev/) for task automation
 
 ## Install
@@ -45,38 +51,60 @@ go build -o anna .
 anna chat
 ```
 
-Starts an interactive terminal session. Type your message, get streaming responses. `/quit` or `/exit` to stop.
+Starts an interactive terminal session with streaming responses.
 
 ### Gateway (Daemon)
 
 ```bash
-# Starts all configured services (e.g. Telegram bot)
 anna gateway
-
-# Or via environment variable
-ANNA_TELEGRAM_TOKEN=your-token anna gateway
 ```
 
-The gateway starts services based on your config. For Telegram, get a bot token from [@BotFather](https://t.me/BotFather).
+Starts all configured services (Telegram bot, cron scheduler). Services are activated based on config — e.g., Telegram starts only when a token is provided.
 
 ## Configuration
 
 Config file: `.agents/config.yaml`
 
 ```yaml
-# Pi CLI configuration
-pi:
-  # Path to the pi binary (default: "pi")
-  binary: "pi"
-  # Minutes of inactivity before closing a session (default: 10)
-  idle_timeout: 10
+provider: anthropic
+model: claude-sonnet-4-6
 
-# Telegram bot configuration
+# Tiered models (optional)
+models:
+  strong: claude-sonnet-4-6
+  worker: claude-haiku-4-5
+  fast: claude-haiku-4-5
+
+# Provider credentials
+providers:
+  anthropic:
+    api_key: "sk-..."
+  openai:
+    api_key: "sk-..."
+    base_url: "https://api.openai.com/v1"
+
+# Runner settings
+runner:
+  type: go
+  idle_timeout: 10          # minutes before reaping idle runners
+  compaction:
+    max_tokens: 80000       # auto-compact when history exceeds this
+    keep_tail: 20           # keep N recent messages after compaction
+
+# Telegram bot
 telegram:
-  # Bot token from @BotFather
-  token: "YOUR_TELEGRAM_BOT_TOKEN"
+  token: "BOT_TOKEN"
+  notify_chat: "123456789"  # chat ID for proactive notifications
+  channel_id: "@my_channel" # optional broadcast channel
+  group_mode: "mention"     # mention | always | disabled
+  allowed_ids:              # restrict to these user IDs (empty = allow all)
+    - 136345060
 
-# Directory for session state files (default: .agents/workspace/sessions)
+# Scheduled tasks
+cron:
+  enabled: true
+
+# Session persistence directory
 sessions: ".agents/workspace/sessions"
 ```
 
@@ -84,33 +112,52 @@ sessions: ".agents/workspace/sessions"
 
 | Variable | Overrides |
 |----------|-----------|
+| `ANNA_PROVIDER` | `provider` |
+| `ANNA_MODEL` | `model` |
+| `ANNA_MODEL_STRONG` | `models.strong` |
+| `ANNA_MODEL_WORKER` | `models.worker` |
+| `ANNA_MODEL_FAST` | `models.fast` |
+| `ANNA_RUNNER_TYPE` | `runner.type` |
 | `ANNA_TELEGRAM_TOKEN` | `telegram.token` |
-| `ANNA_PI_BINARY` | `pi.binary` |
+| `ANNA_TELEGRAM_NOTIFY_CHAT` | `telegram.notify_chat` |
+| `ANNA_TELEGRAM_CHANNEL_ID` | `telegram.channel_id` |
+| `ANNA_TELEGRAM_GROUP_MODE` | `telegram.group_mode` |
+| `ANTHROPIC_API_KEY` | `providers.anthropic.api_key` |
+| `OPENAI_API_KEY` | `providers.openai.api_key` |
 
 ## Architecture
 
 ```
-┌───────────────────────────────────────────────────────┐
-│                      anna                              │
-│                                                        │
-│  ┌──────────┐      ┌────────────────┐                │
-│  │ CLI Chat  │─────▶│                │                │
-│  └──────────┘      │ SessionManager │  stdin/stdout   │
-│                     │ (agent pool +  │◄──────────────▶ Pi Process(es)
-│  ┌──────────┐      │  idle timeout) │  JSON-RPC       │
-│  │ Telegram  │─────▶│                │                │
-│  │ LongPoll  │      └────────────────┘                │
-│  └──────────┘                                         │
-└────────────────────────────────────��──────────────────┘
+┌─────────────────────────────────────────────────────────┐
+│                        anna                             │
+│                                                         │
+│  ┌──────────┐      ┌────────────────┐                  │
+│  │ CLI Chat  │─────▶│                │                  │
+│  └──────────┘      │     Pool       │   LLM Providers  │
+│                     │ (sessions +   │◄────────────────▶ Anthropic / OpenAI
+│  ┌──────────┐      │  Go runner)   │   HTTP API        │
+│  │ Telegram  │─────▶│                │                  │
+│  │ LongPoll  │      └───────┬────────┘                  │
+│  └──────────┘              │                            │
+│                     ┌──────▼────────┐                   │
+│  ┌──────────┐      │  Dispatcher   │                   │
+│  │   Cron   │─────▶│ (notify tool) │──▶ Telegram       │
+│  └──────────┘      │               │──▶ Slack (future) │
+│                     └───────────────┘                   │
+└─────────────────────────────────────────────────────────┘
 ```
 
 ```
-main.go            Entry point, signal handling, wiring
-config.go          Config types, YAML loading, env var overrides
-agent/agent.go     Pi process lifecycle, JSON-RPC protocol
-agent/session.go   Agent pool by session ID, idle reaping
-bot/telegram.go    Telegram long polling, message splitting
-cli/chat.go        Interactive terminal chat
+main.go                         Entry point, signal handling, wiring
+config.go                       Config types, YAML loading, env var overrides
+agent/pool.go                   Session management, history, runner lifecycle
+agent/runner/go/runner.go       Go runner: native LLM provider calls
+channel/notifier.go             Notification dispatcher (multi-backend)
+channel/notify_tool.go          Agent notify tool
+channel/telegram/telegram.go    Telegram bot + notification backend
+channel/cli/cli.go              Interactive terminal chat
+cron/cron.go                    Scheduled jobs with gocron/v2
+memory/                         Persistent memory (facts + journal)
 ```
 
 ## Development
@@ -124,7 +171,6 @@ mise run lint           # go vet
 mise run format         # gofmt + go mod tidy
 mise run run:chat       # Build + run CLI chat
 mise run run:gateway    # Build + run gateway daemon
-mise run clean          # Remove build artifacts
 ```
 
 Or with plain Go:
@@ -133,8 +179,6 @@ Or with plain Go:
 go build -o anna .
 go test -race ./...
 ```
-
-Test coverage: **83.5%**
 
 ## License
 

--- a/channel/notifier.go
+++ b/channel/notifier.go
@@ -2,44 +2,101 @@ package channel
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 )
 
-// Notification represents a message to push to a chat or channel.
+// Notification represents a message to push to a user or channel.
 type Notification struct {
-	ChatID string // target chat/channel ID
-	Text   string // markdown content
-	Silent bool   // send without notification sound
+	Channel string // optional: route to a specific backend ("telegram", "slack")
+	ChatID  string // target chat/channel within the backend
+	Text    string // markdown content
+	Silent  bool   // send without notification sound
 }
 
-// Notifier can push messages to users proactively.
+// Notifier can push notifications. Both Dispatcher and individual backends
+// satisfy this interface, so consumers don't need to know the routing layer.
 type Notifier interface {
 	Notify(ctx context.Context, n Notification) error
 }
 
-// NotifierProxy is a Notifier whose backend can be set after construction.
-// This solves ordering issues where the notifier tool must be created before
-// the actual Notifier implementation (e.g., the Telegram bot) exists.
-type NotifierProxy struct {
-	mu       sync.Mutex
-	notifier Notifier
+// Backend is a named notification backend (telegram, slack, discord, etc.).
+type Backend interface {
+	Notifier
+	Name() string
 }
 
-// Set installs the real notifier backend.
-func (p *NotifierProxy) Set(n Notifier) {
-	p.mu.Lock()
-	p.notifier = n
-	p.mu.Unlock()
+type backendEntry struct {
+	backend     Backend
+	defaultChat string
 }
 
-// Notify delegates to the installed backend. Returns an error if no backend is set.
-func (p *NotifierProxy) Notify(ctx context.Context, n Notification) error {
-	p.mu.Lock()
-	notifier := p.notifier
-	p.mu.Unlock()
-	if notifier == nil {
-		return fmt.Errorf("no notifier configured")
+// Dispatcher routes notifications to one or more registered backends.
+// It implements Notifier so it can be passed to tools and cron wiring.
+type Dispatcher struct {
+	mu       sync.RWMutex
+	backends []backendEntry
+}
+
+// NewDispatcher creates an empty dispatcher. Register backends before use.
+func NewDispatcher() *Dispatcher {
+	return &Dispatcher{}
+}
+
+// Register adds a backend with its default chat/channel target.
+func (d *Dispatcher) Register(b Backend, defaultChat string) {
+	d.mu.Lock()
+	d.backends = append(d.backends, backendEntry{backend: b, defaultChat: defaultChat})
+	d.mu.Unlock()
+}
+
+// Notify routes a notification to backends. If Notification.Channel is set,
+// only that backend receives it. Otherwise all registered backends receive it.
+func (d *Dispatcher) Notify(ctx context.Context, n Notification) error {
+	d.mu.RLock()
+	entries := make([]backendEntry, len(d.backends))
+	copy(entries, d.backends)
+	d.mu.RUnlock()
+
+	if len(entries) == 0 {
+		return fmt.Errorf("no notification backends registered")
 	}
-	return notifier.Notify(ctx, n)
+
+	// Route to a specific backend.
+	if n.Channel != "" {
+		for _, e := range entries {
+			if e.backend.Name() == n.Channel {
+				if n.ChatID == "" {
+					n.ChatID = e.defaultChat
+				}
+				return e.backend.Notify(ctx, n)
+			}
+		}
+		return fmt.Errorf("unknown notification channel %q", n.Channel)
+	}
+
+	// Broadcast to all backends.
+	var errs []error
+	for _, e := range entries {
+		nn := n
+		if nn.ChatID == "" {
+			nn.ChatID = e.defaultChat
+		}
+		if err := e.backend.Notify(ctx, nn); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", e.backend.Name(), err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// Backends returns the names of all registered backends.
+func (d *Dispatcher) Backends() []string {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	names := make([]string, len(d.backends))
+	for i, e := range d.backends {
+		names[i] = e.backend.Name()
+	}
+	return names
 }

--- a/channel/notifier.go
+++ b/channel/notifier.go
@@ -1,0 +1,45 @@
+package channel
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// Notification represents a message to push to a chat or channel.
+type Notification struct {
+	ChatID string // target chat/channel ID
+	Text   string // markdown content
+	Silent bool   // send without notification sound
+}
+
+// Notifier can push messages to users proactively.
+type Notifier interface {
+	Notify(ctx context.Context, n Notification) error
+}
+
+// NotifierProxy is a Notifier whose backend can be set after construction.
+// This solves ordering issues where the notifier tool must be created before
+// the actual Notifier implementation (e.g., the Telegram bot) exists.
+type NotifierProxy struct {
+	mu       sync.Mutex
+	notifier Notifier
+}
+
+// Set installs the real notifier backend.
+func (p *NotifierProxy) Set(n Notifier) {
+	p.mu.Lock()
+	p.notifier = n
+	p.mu.Unlock()
+}
+
+// Notify delegates to the installed backend. Returns an error if no backend is set.
+func (p *NotifierProxy) Notify(ctx context.Context, n Notification) error {
+	p.mu.Lock()
+	notifier := p.notifier
+	p.mu.Unlock()
+	if notifier == nil {
+		return fmt.Errorf("no notifier configured")
+	}
+	return notifier.Notify(ctx, n)
+}

--- a/channel/notifier_test.go
+++ b/channel/notifier_test.go
@@ -1,0 +1,139 @@
+package channel
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// mockBackend is a test Backend that records calls.
+type mockBackend struct {
+	name  string
+	calls []Notification
+	err   error
+}
+
+func (m *mockBackend) Name() string { return m.name }
+func (m *mockBackend) Notify(_ context.Context, n Notification) error {
+	m.calls = append(m.calls, n)
+	return m.err
+}
+
+func TestDispatcherBroadcast(t *testing.T) {
+	d := NewDispatcher()
+	tg := &mockBackend{name: "telegram"}
+	slack := &mockBackend{name: "slack"}
+	d.Register(tg, "tg-chat")
+	d.Register(slack, "slack-channel")
+
+	err := d.Notify(context.Background(), Notification{Text: "hello"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(tg.calls) != 1 {
+		t.Fatalf("telegram got %d calls, want 1", len(tg.calls))
+	}
+	if tg.calls[0].ChatID != "tg-chat" {
+		t.Errorf("telegram ChatID = %q, want %q", tg.calls[0].ChatID, "tg-chat")
+	}
+	if len(slack.calls) != 1 {
+		t.Fatalf("slack got %d calls, want 1", len(slack.calls))
+	}
+	if slack.calls[0].ChatID != "slack-channel" {
+		t.Errorf("slack ChatID = %q, want %q", slack.calls[0].ChatID, "slack-channel")
+	}
+}
+
+func TestDispatcherRouteToSpecific(t *testing.T) {
+	d := NewDispatcher()
+	tg := &mockBackend{name: "telegram"}
+	slack := &mockBackend{name: "slack"}
+	d.Register(tg, "tg-chat")
+	d.Register(slack, "slack-channel")
+
+	err := d.Notify(context.Background(), Notification{
+		Channel: "slack",
+		Text:    "only slack",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(tg.calls) != 0 {
+		t.Errorf("telegram got %d calls, want 0", len(tg.calls))
+	}
+	if len(slack.calls) != 1 {
+		t.Fatalf("slack got %d calls, want 1", len(slack.calls))
+	}
+	if slack.calls[0].ChatID != "slack-channel" {
+		t.Errorf("slack ChatID = %q, want default %q", slack.calls[0].ChatID, "slack-channel")
+	}
+}
+
+func TestDispatcherExplicitChatID(t *testing.T) {
+	d := NewDispatcher()
+	tg := &mockBackend{name: "telegram"}
+	d.Register(tg, "default-chat")
+
+	err := d.Notify(context.Background(), Notification{
+		Channel: "telegram",
+		ChatID:  "override-chat",
+		Text:    "test",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tg.calls[0].ChatID != "override-chat" {
+		t.Errorf("ChatID = %q, want %q", tg.calls[0].ChatID, "override-chat")
+	}
+}
+
+func TestDispatcherUnknownChannel(t *testing.T) {
+	d := NewDispatcher()
+	d.Register(&mockBackend{name: "telegram"}, "chat")
+
+	err := d.Notify(context.Background(), Notification{Channel: "discord", Text: "test"})
+	if err == nil {
+		t.Fatal("expected error for unknown channel")
+	}
+}
+
+func TestDispatcherNoBackends(t *testing.T) {
+	d := NewDispatcher()
+	err := d.Notify(context.Background(), Notification{Text: "test"})
+	if err == nil {
+		t.Fatal("expected error with no backends")
+	}
+}
+
+func TestDispatcherPartialFailure(t *testing.T) {
+	d := NewDispatcher()
+	good := &mockBackend{name: "telegram"}
+	bad := &mockBackend{name: "slack", err: errors.New("slack down")}
+	d.Register(good, "chat")
+	d.Register(bad, "channel")
+
+	err := d.Notify(context.Background(), Notification{Text: "test"})
+	if err == nil {
+		t.Fatal("expected error on partial failure")
+	}
+	// Good backend should still have been called.
+	if len(good.calls) != 1 {
+		t.Errorf("good backend got %d calls, want 1", len(good.calls))
+	}
+}
+
+func TestDispatcherBackends(t *testing.T) {
+	d := NewDispatcher()
+	d.Register(&mockBackend{name: "telegram"}, "")
+	d.Register(&mockBackend{name: "slack"}, "")
+
+	names := d.Backends()
+	if len(names) != 2 {
+		t.Fatalf("len(Backends()) = %d, want 2", len(names))
+	}
+	if names[0] != "telegram" || names[1] != "slack" {
+		t.Errorf("Backends() = %v, want [telegram slack]", names)
+	}
+}

--- a/channel/notify_tool.go
+++ b/channel/notify_tool.go
@@ -7,16 +7,14 @@ import (
 	aitypes "github.com/vaayne/anna/pkg/ai/types"
 )
 
-// NotifyTool is an agent tool that sends notifications via a Notifier.
+// NotifyTool is an agent tool that sends notifications via a Dispatcher.
 type NotifyTool struct {
-	notifier    Notifier
-	defaultChat string
+	dispatcher *Dispatcher
 }
 
-// NewNotifyTool creates a notify tool. defaultChat is used when the agent
-// does not specify a target chat ID.
-func NewNotifyTool(notifier Notifier, defaultChat string) *NotifyTool {
-	return &NotifyTool{notifier: notifier, defaultChat: defaultChat}
+// NewNotifyTool creates a notify tool backed by the given dispatcher.
+func NewNotifyTool(dispatcher *Dispatcher) *NotifyTool {
+	return &NotifyTool{dispatcher: dispatcher}
 }
 
 var notifyInputSchema = map[string]any{
@@ -26,9 +24,13 @@ var notifyInputSchema = map[string]any{
 			"type":        "string",
 			"description": "The notification message to send (supports markdown)",
 		},
+		"channel": map[string]any{
+			"type":        "string",
+			"description": "Target backend (e.g. \"telegram\", \"slack\"). Omit to broadcast to all configured backends.",
+		},
 		"chat_id": map[string]any{
 			"type":        "string",
-			"description": "Target chat ID. Omit to use the default notification chat.",
+			"description": "Target chat/channel within the backend. Omit to use the default.",
 		},
 		"silent": map[string]any{
 			"type":        "boolean",
@@ -41,7 +43,7 @@ var notifyInputSchema = map[string]any{
 func (t *NotifyTool) Definition() aitypes.ToolDefinition {
 	return aitypes.ToolDefinition{
 		Name:        "notify",
-		Description: "Send a notification message to the user via Telegram. Use this to proactively push messages, alerts, cron job summaries, or long-running task results.",
+		Description: "Send a notification message to the user. Supports multiple backends (Telegram, Slack, etc.). Omit 'channel' to broadcast to all configured backends. Use this for proactive messages, alerts, cron summaries, or long-running task results.",
 		InputSchema: notifyInputSchema,
 	}
 }
@@ -52,23 +54,23 @@ func (t *NotifyTool) Execute(ctx context.Context, args map[string]any) (string, 
 		return "", fmt.Errorf("message is required")
 	}
 
+	ch, _ := args["channel"].(string)
 	chatID, _ := args["chat_id"].(string)
-	if chatID == "" {
-		chatID = t.defaultChat
-	}
-	if chatID == "" {
-		return "", fmt.Errorf("no chat_id provided and no default notification chat configured")
-	}
-
 	silent, _ := args["silent"].(bool)
 
-	err := t.notifier.Notify(ctx, Notification{
-		ChatID: chatID,
-		Text:   message,
-		Silent: silent,
+	err := t.dispatcher.Notify(ctx, Notification{
+		Channel: ch,
+		ChatID:  chatID,
+		Text:    message,
+		Silent:  silent,
 	})
 	if err != nil {
 		return "", fmt.Errorf("send notification: %w", err)
 	}
-	return "Notification sent successfully.", nil
+
+	backends := t.dispatcher.Backends()
+	if ch != "" {
+		return fmt.Sprintf("Notification sent to %s.", ch), nil
+	}
+	return fmt.Sprintf("Notification broadcast to %v.", backends), nil
 }

--- a/channel/notify_tool.go
+++ b/channel/notify_tool.go
@@ -1,0 +1,74 @@
+package channel
+
+import (
+	"context"
+	"fmt"
+
+	aitypes "github.com/vaayne/anna/pkg/ai/types"
+)
+
+// NotifyTool is an agent tool that sends notifications via a Notifier.
+type NotifyTool struct {
+	notifier    Notifier
+	defaultChat string
+}
+
+// NewNotifyTool creates a notify tool. defaultChat is used when the agent
+// does not specify a target chat ID.
+func NewNotifyTool(notifier Notifier, defaultChat string) *NotifyTool {
+	return &NotifyTool{notifier: notifier, defaultChat: defaultChat}
+}
+
+var notifyInputSchema = map[string]any{
+	"type": "object",
+	"properties": map[string]any{
+		"message": map[string]any{
+			"type":        "string",
+			"description": "The notification message to send (supports markdown)",
+		},
+		"chat_id": map[string]any{
+			"type":        "string",
+			"description": "Target chat ID. Omit to use the default notification chat.",
+		},
+		"silent": map[string]any{
+			"type":        "boolean",
+			"description": "Send without notification sound",
+		},
+	},
+	"required": []string{"message"},
+}
+
+func (t *NotifyTool) Definition() aitypes.ToolDefinition {
+	return aitypes.ToolDefinition{
+		Name:        "notify",
+		Description: "Send a notification message to the user via Telegram. Use this to proactively push messages, alerts, cron job summaries, or long-running task results.",
+		InputSchema: notifyInputSchema,
+	}
+}
+
+func (t *NotifyTool) Execute(ctx context.Context, args map[string]any) (string, error) {
+	message, _ := args["message"].(string)
+	if message == "" {
+		return "", fmt.Errorf("message is required")
+	}
+
+	chatID, _ := args["chat_id"].(string)
+	if chatID == "" {
+		chatID = t.defaultChat
+	}
+	if chatID == "" {
+		return "", fmt.Errorf("no chat_id provided and no default notification chat configured")
+	}
+
+	silent, _ := args["silent"].(bool)
+
+	err := t.notifier.Notify(ctx, Notification{
+		ChatID: chatID,
+		Text:   message,
+		Silent: silent,
+	})
+	if err != nil {
+		return "", fmt.Errorf("send notification: %w", err)
+	}
+	return "Notification sent successfully.", nil
+}

--- a/channel/telegram/telegram.go
+++ b/channel/telegram/telegram.go
@@ -254,7 +254,9 @@ func (b *Bot) registerHandlers() {
 func (b *Bot) guard(h tele.HandlerFunc) tele.HandlerFunc {
 	return func(c tele.Context) error {
 		if !b.isAllowed(c) {
-			log.Warn("unauthorized access", "user_id", c.Sender().ID)
+			if s := c.Sender(); s != nil {
+				log.Warn("unauthorized access", "user_id", s.ID)
+			}
 			return nil
 		}
 		if isGroup(c) && !b.shouldRespondInGroup(c) {

--- a/channel/telegram/telegram.go
+++ b/channel/telegram/telegram.go
@@ -126,6 +126,9 @@ func (b *Bot) Notify(_ context.Context, n channel.Notification) error {
 		chatID = b.cfg.NotifyChat
 	}
 	if chatID == "" {
+		chatID = b.cfg.ChannelID
+	}
+	if chatID == "" {
 		return fmt.Errorf("no target chat ID")
 	}
 
@@ -183,11 +186,11 @@ const welcomeMessage = `👋 Hi! I'm Anna — your local AI assistant.
 Just send me a message to get started.`
 
 func (b *Bot) registerHandlers() {
-	b.bot.Handle("/start", func(c tele.Context) error {
+	b.bot.Handle("/start", b.groupGuard(func(c tele.Context) error {
 		return c.Send(welcomeMessage, tele.ModeMarkdown)
-	})
+	}))
 
-	b.bot.Handle("/new", func(c tele.Context) error {
+	b.bot.Handle("/new", b.groupGuard(func(c tele.Context) error {
 		sessionID := sessionIDFor(c)
 		if err := b.pool.Reset(sessionID); err != nil {
 			log.Error("reset session failed", "session_id", sessionID, "error", err)
@@ -195,9 +198,9 @@ func (b *Bot) registerHandlers() {
 		}
 		log.Info("session reset", "session_id", sessionID)
 		return c.Send("New session started.")
-	})
+	}))
 
-	b.bot.Handle("/compact", func(c tele.Context) error {
+	b.bot.Handle("/compact", b.groupGuard(func(c tele.Context) error {
 		sessionID := sessionIDFor(c)
 		_ = c.Notify(tele.Typing)
 		summary, err := b.pool.CompactSession(b.ctx, sessionID)
@@ -207,9 +210,9 @@ func (b *Bot) registerHandlers() {
 		}
 		log.Info("session compacted", "session_id", sessionID, "summary_len", len(summary))
 		return c.Send("Session compacted.")
-	})
+	}))
 
-	b.bot.Handle("/model", func(c tele.Context) error {
+	b.bot.Handle("/model", b.groupGuard(func(c tele.Context) error {
 		args := strings.TrimSpace(c.Message().Payload)
 		models := b.listFn()
 
@@ -217,7 +220,7 @@ func (b *Bot) registerHandlers() {
 			return b.sendModelKeyboard(c, models)
 		}
 		return b.switchModel(c, models, args)
-	})
+	}))
 
 	// Handle inline keyboard callbacks for model selection via unique handler.
 	// telebot strips the "\fmodel_select|" prefix, so c.Data() = "1", "2", etc.
@@ -234,6 +237,17 @@ func (b *Bot) registerHandlers() {
 	b.bot.Handle(tele.OnText, func(c tele.Context) error {
 		return b.handleText(c)
 	})
+}
+
+// groupGuard wraps a handler so it respects group_mode settings.
+// In groups, the handler is skipped unless the bot should respond.
+func (b *Bot) groupGuard(h tele.HandlerFunc) tele.HandlerFunc {
+	return func(c tele.Context) error {
+		if isGroup(c) && !b.shouldRespondInGroup(c) {
+			return nil
+		}
+		return h(c)
+	}
 }
 
 // handleText processes incoming text messages.

--- a/channel/telegram/telegram.go
+++ b/channel/telegram/telegram.go
@@ -119,7 +119,10 @@ func (b *Bot) Start(ctx context.Context) error {
 	return ctx.Err()
 }
 
-// Notify sends a message to the specified chat. Implements channel.Notifier.
+// Name returns the backend name. Implements channel.Backend.
+func (b *Bot) Name() string { return "telegram" }
+
+// Notify sends a message to the specified chat. Implements channel.Backend.
 func (b *Bot) Notify(_ context.Context, n channel.Notification) error {
 	chatID := n.ChatID
 	if chatID == "" {

--- a/channel/telegram/telegram.go
+++ b/channel/telegram/telegram.go
@@ -240,9 +240,20 @@ func (b *Bot) registerHandlers() {
 		models := b.listFn()
 
 		if args == "" {
-			return b.sendModelKeyboard(c, models)
+			return b.sendModelKeyboard(c, indexModels(models))
 		}
-		return b.switchModel(c, models, args)
+
+		// Numeric arg → direct switch by index.
+		if _, err := strconv.Atoi(args); err == nil {
+			return b.switchModel(c, models, args)
+		}
+
+		// Text arg → filter models by substring match, preserving global indices.
+		filtered := filterModels(models, args)
+		if len(filtered) == 0 {
+			return c.Send(fmt.Sprintf("No models matching %q.", args))
+		}
+		return b.sendModelKeyboard(c, filtered)
 	}))
 
 	// Handle inline keyboard callbacks for model selection via unique handler.
@@ -258,6 +269,27 @@ func (b *Bot) registerHandlers() {
 		_ = c.Respond()
 		return c.Delete()
 	}))
+
+	// Handle pagination for model keyboard.
+	// Callback data format: "page" or "page|filter_query".
+	b.bot.Handle("\fmodel_page", b.guard(func(c tele.Context) error {
+		data := c.Data()
+		pageStr, query, _ := strings.Cut(data, "|")
+		page, _ := strconv.Atoi(pageStr)
+
+		allModels := b.listFn()
+		models := filterModels(allModels, query)
+		if err := b.sendModelPage(c, models, page, query, true); err != nil {
+			logger().Error("model page failed", "page", page, "error", err)
+			return err
+		}
+		return c.Respond()
+	}))
+
+	// No-op handler for the page counter button.
+	b.bot.Handle("\fmodel_noop", func(c tele.Context) error {
+		return c.Respond()
+	})
 
 	b.bot.Handle(tele.OnText, b.guard(func(c tele.Context) error {
 		return b.handleText(c)
@@ -399,27 +431,106 @@ func sessionIDFor(c tele.Context) string {
 	return strconv.FormatInt(c.Chat().ID, 10)
 }
 
-// sendModelKeyboard sends an inline keyboard with model selection buttons.
-func (b *Bot) sendModelKeyboard(c tele.Context, models []ModelOption) error {
+const modelsPerPage = 8
+
+// indexedModel pairs a ModelOption with its 1-based index in the full model list.
+type indexedModel struct {
+	ModelOption
+	globalIdx int
+}
+
+// indexModels wraps a full model list with sequential 1-based indices.
+func indexModels(models []ModelOption) []indexedModel {
+	out := make([]indexedModel, len(models))
+	for i, m := range models {
+		out[i] = indexedModel{ModelOption: m, globalIdx: i + 1}
+	}
+	return out
+}
+
+// filterModels returns indexed models matching the query (or all if query is empty).
+func filterModels(models []ModelOption, query string) []indexedModel {
+	if query == "" {
+		return indexModels(models)
+	}
+	query = strings.ToLower(query)
+	var out []indexedModel
+	for i, m := range models {
+		label := strings.ToLower(m.Provider + "/" + m.Model)
+		if strings.Contains(label, query) {
+			out = append(out, indexedModel{ModelOption: m, globalIdx: i + 1})
+		}
+	}
+	return out
+}
+
+// sendModelKeyboard sends a paginated inline keyboard with model selection buttons.
+func (b *Bot) sendModelKeyboard(c tele.Context, models []indexedModel) error {
+	return b.sendModelPage(c, models, 0, "", false)
+}
+
+// sendModelPage renders a single page of the model keyboard.
+// query is preserved in nav button data so filtered pagination works across pages.
+// If edit is true, it edits the existing message instead of sending a new one.
+func (b *Bot) sendModelPage(c tele.Context, models []indexedModel, page int, query string, edit bool) error {
 	if len(models) == 0 {
 		return c.Send("No models configured.")
+	}
+
+	totalPages := (len(models) + modelsPerPage - 1) / modelsPerPage
+	if page < 0 {
+		page = 0
+	}
+	if page >= totalPages {
+		page = totalPages - 1
+	}
+
+	start := page * modelsPerPage
+	end := start + modelsPerPage
+	if end > len(models) {
+		end = len(models)
 	}
 
 	active, hasActive := b.chatModels[c.Chat().ID]
 	markup := &tele.ReplyMarkup{}
 
 	var rows []tele.Row
-	for i, m := range models {
+	for i := start; i < end; i++ {
+		m := models[i]
 		label := fmt.Sprintf("%s/%s", m.Provider, m.Model)
 		if hasActive && m.Provider == active.Provider && m.Model == active.Model {
 			label = "✅ " + label
 		}
-		btn := markup.Data(label, "model_select", fmt.Sprintf("%d", i+1))
+		btn := markup.Data(label, "model_select", fmt.Sprintf("%d", m.globalIdx))
 		rows = append(rows, markup.Row(btn))
 	}
 
+	// Navigation row. Encode "page|query" so filtered pagination persists.
+	if totalPages > 1 {
+		pageData := func(p int) string {
+			if query == "" {
+				return fmt.Sprintf("%d", p)
+			}
+			return fmt.Sprintf("%d|%s", p, query)
+		}
+		var navBtns []tele.Btn
+		if page > 0 {
+			navBtns = append(navBtns, markup.Data("◀ Prev", "model_page", pageData(page-1)))
+		}
+		navBtns = append(navBtns, markup.Data(fmt.Sprintf("%d/%d", page+1, totalPages), "model_noop"))
+		if page < totalPages-1 {
+			navBtns = append(navBtns, markup.Data("Next ▶", "model_page", pageData(page+1)))
+		}
+		rows = append(rows, markup.Row(navBtns...))
+	}
+
 	markup.Inline(rows...)
-	return c.Send("Select a model:", markup)
+
+	text := fmt.Sprintf("Select a model (%d total):", len(models))
+	if edit {
+		return c.Edit(text, markup)
+	}
+	return c.Send(text, markup)
 }
 
 // switchModel handles model switching by index string.

--- a/channel/telegram/telegram.go
+++ b/channel/telegram/telegram.go
@@ -53,10 +53,11 @@ var log = slog.With("component", "telegram")
 
 // Config holds Telegram bot settings.
 type Config struct {
-	Token      string // bot token
-	NotifyChat string // default chat ID for proactive notifications
-	ChannelID  string // broadcast channel ID or @username
-	GroupMode  string // "mention" | "always" | "disabled"
+	Token      string  // bot token
+	NotifyChat string  // default chat ID for proactive notifications
+	ChannelID  string  // broadcast channel ID or @username
+	GroupMode  string  // "mention" | "always" | "disabled"
+	AllowedIDs []int64 // user IDs allowed to use the bot (empty = allow all)
 }
 
 // Bot wraps a Telegram bot with agent pool integration.
@@ -67,6 +68,7 @@ type Bot struct {
 	switchFn   channel.ModelSwitchFunc
 	md         goldmarkMD
 	chatModels map[int64]ModelOption
+	allowed    map[int64]struct{} // empty map = allow all
 	cfg        Config
 	ctx        context.Context
 }
@@ -85,6 +87,11 @@ func New(cfg Config, pool *agent.Pool, listFn ModelListFunc, switchFn channel.Mo
 		cfg.GroupMode = "mention"
 	}
 
+	allowed := make(map[int64]struct{}, len(cfg.AllowedIDs))
+	for _, id := range cfg.AllowedIDs {
+		allowed[id] = struct{}{}
+	}
+
 	b := &Bot{
 		bot:        bot,
 		pool:       pool,
@@ -92,6 +99,7 @@ func New(cfg Config, pool *agent.Pool, listFn ModelListFunc, switchFn channel.Mo
 		switchFn:   switchFn,
 		md:         tgmd.TGMD(),
 		chatModels: make(map[int64]ModelOption),
+		allowed:    allowed,
 		cfg:        cfg,
 	}
 
@@ -189,11 +197,11 @@ const welcomeMessage = `👋 Hi! I'm Anna — your local AI assistant.
 Just send me a message to get started.`
 
 func (b *Bot) registerHandlers() {
-	b.bot.Handle("/start", b.groupGuard(func(c tele.Context) error {
+	b.bot.Handle("/start", b.guard(func(c tele.Context) error {
 		return c.Send(welcomeMessage, tele.ModeMarkdown)
 	}))
 
-	b.bot.Handle("/new", b.groupGuard(func(c tele.Context) error {
+	b.bot.Handle("/new", b.guard(func(c tele.Context) error {
 		sessionID := sessionIDFor(c)
 		if err := b.pool.Reset(sessionID); err != nil {
 			log.Error("reset session failed", "session_id", sessionID, "error", err)
@@ -203,7 +211,7 @@ func (b *Bot) registerHandlers() {
 		return c.Send("New session started.")
 	}))
 
-	b.bot.Handle("/compact", b.groupGuard(func(c tele.Context) error {
+	b.bot.Handle("/compact", b.guard(func(c tele.Context) error {
 		sessionID := sessionIDFor(c)
 		_ = c.Notify(tele.Typing)
 		summary, err := b.pool.CompactSession(b.ctx, sessionID)
@@ -215,7 +223,7 @@ func (b *Bot) registerHandlers() {
 		return c.Send("Session compacted.")
 	}))
 
-	b.bot.Handle("/model", b.groupGuard(func(c tele.Context) error {
+	b.bot.Handle("/model", b.guard(func(c tele.Context) error {
 		args := strings.TrimSpace(c.Message().Payload)
 		models := b.listFn()
 
@@ -227,7 +235,7 @@ func (b *Bot) registerHandlers() {
 
 	// Handle inline keyboard callbacks for model selection via unique handler.
 	// telebot strips the "\fmodel_select|" prefix, so c.Data() = "1", "2", etc.
-	b.bot.Handle("\fmodel_select", func(c tele.Context) error {
+	b.bot.Handle("\fmodel_select", b.guard(func(c tele.Context) error {
 		idxStr := c.Data()
 		models := b.listFn()
 		if err := b.switchModel(c, models, idxStr); err != nil {
@@ -235,22 +243,38 @@ func (b *Bot) registerHandlers() {
 		}
 		_ = c.Respond()
 		return c.Delete()
-	})
+	}))
 
-	b.bot.Handle(tele.OnText, func(c tele.Context) error {
+	b.bot.Handle(tele.OnText, b.guard(func(c tele.Context) error {
 		return b.handleText(c)
-	})
+	}))
 }
 
-// groupGuard wraps a handler so it respects group_mode settings.
-// In groups, the handler is skipped unless the bot should respond.
-func (b *Bot) groupGuard(h tele.HandlerFunc) tele.HandlerFunc {
+// guard wraps a handler with access control and group mode checks.
+func (b *Bot) guard(h tele.HandlerFunc) tele.HandlerFunc {
 	return func(c tele.Context) error {
+		if !b.isAllowed(c) {
+			log.Warn("unauthorized access", "user_id", c.Sender().ID)
+			return nil
+		}
 		if isGroup(c) && !b.shouldRespondInGroup(c) {
 			return nil
 		}
 		return h(c)
 	}
+}
+
+// isAllowed returns true if the sender is in the allowed list.
+// An empty allowed list means everyone is allowed.
+func (b *Bot) isAllowed(c tele.Context) bool {
+	if len(b.allowed) == 0 {
+		return true
+	}
+	if c.Sender() == nil {
+		return false
+	}
+	_, ok := b.allowed[c.Sender().ID]
+	return ok
 }
 
 // handleText processes incoming text messages.

--- a/channel/telegram/telegram.go
+++ b/channel/telegram/telegram.go
@@ -259,7 +259,10 @@ func (b *Bot) guard(h tele.HandlerFunc) tele.HandlerFunc {
 			}
 			return nil
 		}
-		if isGroup(c) && !b.shouldRespondInGroup(c) {
+		// Skip group filtering for callback queries — they originate from
+		// the bot's own inline keyboards (e.g. model selection) and don't
+		// carry mention/reply context.
+		if isGroup(c) && c.Callback() == nil && !b.shouldRespondInGroup(c) {
 			return nil
 		}
 		return h(c)

--- a/channel/telegram/telegram.go
+++ b/channel/telegram/telegram.go
@@ -49,7 +49,10 @@ var toolEmoji = map[string]string{
 	"default": "🔧",
 }
 
-var log = slog.With("component", "telegram")
+// logger returns the package logger, always using the current default handler.
+// This must be a function (not a package-level var) because the default handler
+// is set in main() after package init.
+func logger() *slog.Logger { return slog.With("component", "telegram") }
 
 // Config holds Telegram bot settings.
 type Config struct {
@@ -76,8 +79,11 @@ type Bot struct {
 // New creates a Telegram bot and registers handlers. Call Start to begin polling.
 func New(cfg Config, pool *agent.Pool, listFn ModelListFunc, switchFn channel.ModelSwitchFunc) (*Bot, error) {
 	bot, err := tele.NewBot(tele.Settings{
-		Token:  cfg.Token,
-		Poller: &tele.LongPoller{Timeout: 30 * time.Second},
+		Token: cfg.Token,
+		Poller: &tele.LongPoller{
+			Timeout:        30 * time.Second,
+			AllowedUpdates: tele.AllowedUpdates,
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create bot: %w", err)
@@ -112,14 +118,14 @@ func (b *Bot) Start(ctx context.Context) error {
 	b.ctx = ctx
 
 	if err := registerCommands(b.bot); err != nil {
-		log.Warn("register telegram commands failed", "error", err)
+		logger().Warn("register telegram commands failed", "error", err)
 	}
 
-	log.Info("polling started")
+	logger().Info("polling started")
 
 	go func() {
 		<-ctx.Done()
-		log.Info("polling stopped")
+		logger().Info("polling stopped")
 		b.bot.Stop()
 	}()
 
@@ -151,7 +157,9 @@ func (b *Bot) Notify(_ context.Context, n channel.Notification) error {
 		chat = chatRef(chatID)
 	}
 
-	opts := &tele.SendOptions{}
+	logger().Debug("sending notification", "chat_id", chatID, "text_len", len(n.Text), "silent", n.Silent)
+
+	opts := &tele.SendOptions{ParseMode: tele.ModeMarkdownV2}
 	if n.Silent {
 		opts.DisableNotification = true
 	}
@@ -159,13 +167,17 @@ func (b *Bot) Notify(_ context.Context, n channel.Notification) error {
 	chunks := splitMessage(n.Text)
 	for _, chunk := range chunks {
 		rendered := renderMarkdown(b.md, chunk)
-		if _, err := b.bot.Send(chat, rendered, tele.ModeMarkdownV2, opts); err != nil {
+		if _, err := b.bot.Send(chat, rendered, opts); err != nil {
+			logger().Warn("markdown notification send failed, falling back to plain text", "error", err)
 			// Fallback to plain text.
-			if _, err := b.bot.Send(chat, chunk, opts); err != nil {
+			plainOpts := &tele.SendOptions{DisableNotification: n.Silent}
+			if _, err := b.bot.Send(chat, chunk, plainOpts); err != nil {
+				logger().Error("plain text notification send failed", "error", err)
 				return fmt.Errorf("send notification: %w", err)
 			}
 		}
 	}
+	logger().Debug("notification sent successfully", "chat_id", chatID, "chunks", len(chunks))
 	return nil
 }
 
@@ -204,10 +216,10 @@ func (b *Bot) registerHandlers() {
 	b.bot.Handle("/new", b.guard(func(c tele.Context) error {
 		sessionID := sessionIDFor(c)
 		if err := b.pool.Reset(sessionID); err != nil {
-			log.Error("reset session failed", "session_id", sessionID, "error", err)
+			logger().Error("reset session failed", "session_id", sessionID, "error", err)
 			return c.Send(fmt.Sprintf("Error creating new session: %v", err))
 		}
-		log.Info("session reset", "session_id", sessionID)
+		logger().Info("session reset", "session_id", sessionID)
 		return c.Send("New session started.")
 	}))
 
@@ -216,10 +228,10 @@ func (b *Bot) registerHandlers() {
 		_ = c.Notify(tele.Typing)
 		summary, err := b.pool.CompactSession(b.ctx, sessionID)
 		if err != nil {
-			log.Error("compact session failed", "session_id", sessionID, "error", err)
+			logger().Error("compact session failed", "session_id", sessionID, "error", err)
 			return c.Send(fmt.Sprintf("Compaction failed: %v", err))
 		}
-		log.Info("session compacted", "session_id", sessionID, "summary_len", len(summary))
+		logger().Info("session compacted", "session_id", sessionID, "summary_len", len(summary))
 		return c.Send("Session compacted.")
 	}))
 
@@ -237,8 +249,10 @@ func (b *Bot) registerHandlers() {
 	// telebot strips the "\fmodel_select|" prefix, so c.Data() = "1", "2", etc.
 	b.bot.Handle("\fmodel_select", b.guard(func(c tele.Context) error {
 		idxStr := c.Data()
+		logger().Debug("model_select callback fired", "data", idxStr, "sender", c.Sender().ID, "chat", c.Chat().ID)
 		models := b.listFn()
 		if err := b.switchModel(c, models, idxStr); err != nil {
+			logger().Error("model switch failed", "data", idxStr, "error", err)
 			return err
 		}
 		_ = c.Respond()
@@ -248,6 +262,13 @@ func (b *Bot) registerHandlers() {
 	b.bot.Handle(tele.OnText, b.guard(func(c tele.Context) error {
 		return b.handleText(c)
 	}))
+
+	// Debug: catch-all callback handler for unmatched callbacks.
+	b.bot.Handle(tele.OnCallback, func(c tele.Context) error {
+		cb := c.Callback()
+		logger().Warn("unmatched callback", "data", cb.Data, "unique", cb.Unique)
+		return c.Respond()
+	})
 }
 
 // guard wraps a handler with access control and group mode checks.
@@ -255,7 +276,7 @@ func (b *Bot) guard(h tele.HandlerFunc) tele.HandlerFunc {
 	return func(c tele.Context) error {
 		if !b.isAllowed(c) {
 			if s := c.Sender(); s != nil {
-				log.Warn("unauthorized access", "user_id", s.ID)
+				logger().Warn("unauthorized access", "user_id", s.ID)
 			}
 			return nil
 		}
@@ -263,7 +284,11 @@ func (b *Bot) guard(h tele.HandlerFunc) tele.HandlerFunc {
 		// the bot's own inline keyboards (e.g. model selection) and don't
 		// carry mention/reply context.
 		if isGroup(c) && c.Callback() == nil && !b.shouldRespondInGroup(c) {
+			logger().Debug("guard: skipped group message", "chat", c.Chat().ID)
 			return nil
+		}
+		if c.Callback() != nil {
+			logger().Debug("guard: passing callback through", "data", c.Callback().Data, "unique", c.Callback().Unique)
 		}
 		return h(c)
 	}
@@ -297,7 +322,7 @@ func (b *Bot) handleText(c tele.Context) error {
 		text = b.stripBotMention(text)
 	}
 
-	log.Debug("message received", "chat_id", chatID, "text_len", len(text))
+	logger().Debug("message received", "chat_id", chatID, "text_len", len(text))
 
 	typingCtx, stopTyping := context.WithCancel(b.ctx)
 	go keepTyping(typingCtx, c)
@@ -307,7 +332,7 @@ func (b *Bot) handleText(c tele.Context) error {
 	stopTyping()
 
 	if streamErr != nil {
-		log.Error("agent stream error", "session_id", sessionID, "error", streamErr)
+		logger().Error("agent stream error", "session_id", sessionID, "error", streamErr)
 		if response == "" {
 			response = fmt.Sprintf("Agent error: %v", streamErr)
 		} else {
@@ -320,7 +345,7 @@ func (b *Bot) handleText(c tele.Context) error {
 	}
 
 	b.sendFinalResponse(c, response)
-	log.Debug("response sent", "chat_id", chatID, "response_len", len(response))
+	logger().Debug("response sent", "chat_id", chatID, "response_len", len(response))
 	return nil
 }
 
@@ -411,10 +436,10 @@ func (b *Bot) switchModel(c tele.Context, models []ModelOption, idxStr string) e
 	}
 	sessionID := sessionIDFor(c)
 	if err := b.pool.Reset(sessionID); err != nil {
-		log.Error("reset session after model switch failed", "session_id", sessionID, "error", err)
+		logger().Error("reset session after model switch failed", "session_id", sessionID, "error", err)
 	}
 	b.chatModels[c.Chat().ID] = selected
-	log.Info("model switched", "session_id", sessionID, "provider", selected.Provider, "model", selected.Model)
+	logger().Info("model switched", "session_id", sessionID, "provider", selected.Provider, "model", selected.Model)
 	return c.Send(fmt.Sprintf("Switched to %s/%s. Session reset.", selected.Provider, selected.Model))
 }
 
@@ -506,13 +531,13 @@ func (b *Bot) streamResponse(c tele.Context, sessionID, prompt string) (string, 
 		if sentMsg == nil {
 			msg, err := b.bot.Send(c.Chat(), display+suffix)
 			if err != nil {
-				log.Warn("stream send failed", "error", err)
+				logger().Warn("stream send failed", "error", err)
 			} else {
 				sentMsg = msg
 			}
 		} else {
 			if _, err := b.bot.Edit(sentMsg, display+suffix); err != nil {
-				log.Warn("stream edit failed", "error", err)
+				logger().Warn("stream edit failed", "error", err)
 			}
 		}
 		lastEdit = now
@@ -521,7 +546,7 @@ func (b *Bot) streamResponse(c tele.Context, sessionID, prompt string) (string, 
 	// Clean up the streaming message so the caller can send the final version.
 	if sentMsg != nil {
 		if err := b.bot.Delete(sentMsg); err != nil {
-			log.Warn("delete streaming message failed", "error", err)
+			logger().Warn("delete streaming message failed", "error", err)
 		}
 	}
 
@@ -536,9 +561,9 @@ func (b *Bot) sendFinalResponse(c tele.Context, response string) {
 	for _, chunk := range chunks {
 		rendered := renderMarkdown(b.md, chunk)
 		if err := c.Send(rendered, tele.ModeMarkdownV2); err != nil {
-			log.Warn("markdown send failed, falling back to plain text", "error", err)
+			logger().Warn("markdown send failed, falling back to plain text", "error", err)
 			if err := c.Send(chunk); err != nil {
-				log.Error("sendMessage failed", "chat_id", chatID, "error", err)
+				logger().Error("sendMessage failed", "chat_id", chatID, "error", err)
 			}
 		}
 	}

--- a/channel/telegram/telegram.go
+++ b/channel/telegram/telegram.go
@@ -39,9 +39,6 @@ const typingInterval = 4 * time.Second
 // typingCursor is appended to the message while streaming to indicate activity.
 const typingCursor = " \u258D"
 
-// callbackModelPrefix is the prefix for model-selection callback data.
-const callbackModelPrefix = "model:"
-
 // toolEmoji maps known tool names to display emoji.
 var toolEmoji = map[string]string{
 	"bash":    "⚡",
@@ -53,6 +50,115 @@ var toolEmoji = map[string]string{
 }
 
 var log = slog.With("component", "telegram")
+
+// Config holds Telegram bot settings.
+type Config struct {
+	Token      string // bot token
+	NotifyChat string // default chat ID for proactive notifications
+	ChannelID  string // broadcast channel ID or @username
+	GroupMode  string // "mention" | "always" | "disabled"
+}
+
+// Bot wraps a Telegram bot with agent pool integration.
+type Bot struct {
+	bot        *tele.Bot
+	pool       *agent.Pool
+	listFn     ModelListFunc
+	switchFn   channel.ModelSwitchFunc
+	md         goldmarkMD
+	chatModels map[int64]ModelOption
+	cfg        Config
+	ctx        context.Context
+}
+
+// New creates a Telegram bot and registers handlers. Call Start to begin polling.
+func New(cfg Config, pool *agent.Pool, listFn ModelListFunc, switchFn channel.ModelSwitchFunc) (*Bot, error) {
+	bot, err := tele.NewBot(tele.Settings{
+		Token:  cfg.Token,
+		Poller: &tele.LongPoller{Timeout: 30 * time.Second},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create bot: %w", err)
+	}
+
+	if cfg.GroupMode == "" {
+		cfg.GroupMode = "mention"
+	}
+
+	b := &Bot{
+		bot:        bot,
+		pool:       pool,
+		listFn:     listFn,
+		switchFn:   switchFn,
+		md:         tgmd.TGMD(),
+		chatModels: make(map[int64]ModelOption),
+		cfg:        cfg,
+	}
+
+	b.registerHandlers()
+	return b, nil
+}
+
+// Start begins long polling. It blocks until ctx is cancelled.
+func (b *Bot) Start(ctx context.Context) error {
+	b.ctx = ctx
+
+	if err := registerCommands(b.bot); err != nil {
+		log.Warn("register telegram commands failed", "error", err)
+	}
+
+	log.Info("polling started")
+
+	go func() {
+		<-ctx.Done()
+		log.Info("polling stopped")
+		b.bot.Stop()
+	}()
+
+	b.bot.Start()
+	return ctx.Err()
+}
+
+// Notify sends a message to the specified chat. Implements channel.Notifier.
+func (b *Bot) Notify(_ context.Context, n channel.Notification) error {
+	chatID := n.ChatID
+	if chatID == "" {
+		chatID = b.cfg.NotifyChat
+	}
+	if chatID == "" {
+		return fmt.Errorf("no target chat ID")
+	}
+
+	// Support both numeric IDs and @username for channels.
+	var chat tele.Recipient
+	if id, err := strconv.ParseInt(chatID, 10, 64); err == nil {
+		chat = &tele.Chat{ID: id}
+	} else {
+		chat = chatRef(chatID)
+	}
+
+	opts := &tele.SendOptions{}
+	if n.Silent {
+		opts.DisableNotification = true
+	}
+
+	chunks := splitMessage(n.Text)
+	for _, chunk := range chunks {
+		rendered := renderMarkdown(b.md, chunk)
+		if _, err := b.bot.Send(chat, rendered, tele.ModeMarkdownV2, opts); err != nil {
+			// Fallback to plain text.
+			if _, err := b.bot.Send(chat, chunk, opts); err != nil {
+				return fmt.Errorf("send notification: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+// chatRef wraps a string (like "@channel_name") as a tele.Recipient.
+type chatRef string
+
+func (c chatRef) Recipient() string { return string(c) }
 
 func botCommands() []tele.Command {
 	return []tele.Command{
@@ -76,32 +182,14 @@ const welcomeMessage = `👋 Hi! I'm Anna — your local AI assistant.
 
 Just send me a message to get started.`
 
-// Run starts a Telegram bot using long polling. It blocks until ctx is
-// cancelled.
-func Run(ctx context.Context, token string, pool *agent.Pool, listFn ModelListFunc, switchFn channel.ModelSwitchFunc) error {
-	// Track per-chat active model for display purposes.
-	chatModels := make(map[int64]ModelOption)
-	bot, err := tele.NewBot(tele.Settings{
-		Token:  token,
-		Poller: &tele.LongPoller{Timeout: 30 * time.Second},
-	})
-	if err != nil {
-		return fmt.Errorf("create bot: %w", err)
-	}
-
-	md := tgmd.TGMD()
-
-	if err := registerCommands(bot); err != nil {
-		log.Warn("register telegram commands failed", "error", err)
-	}
-
-	bot.Handle("/start", func(c tele.Context) error {
+func (b *Bot) registerHandlers() {
+	b.bot.Handle("/start", func(c tele.Context) error {
 		return c.Send(welcomeMessage, tele.ModeMarkdown)
 	})
 
-	bot.Handle("/new", func(c tele.Context) error {
-		sessionID := strconv.FormatInt(c.Chat().ID, 10)
-		if err := pool.Reset(sessionID); err != nil {
+	b.bot.Handle("/new", func(c tele.Context) error {
+		sessionID := sessionIDFor(c)
+		if err := b.pool.Reset(sessionID); err != nil {
 			log.Error("reset session failed", "session_id", sessionID, "error", err)
 			return c.Send(fmt.Sprintf("Error creating new session: %v", err))
 		}
@@ -109,10 +197,10 @@ func Run(ctx context.Context, token string, pool *agent.Pool, listFn ModelListFu
 		return c.Send("New session started.")
 	})
 
-	bot.Handle("/compact", func(c tele.Context) error {
-		sessionID := strconv.FormatInt(c.Chat().ID, 10)
+	b.bot.Handle("/compact", func(c tele.Context) error {
+		sessionID := sessionIDFor(c)
 		_ = c.Notify(tele.Typing)
-		summary, err := pool.CompactSession(ctx, sessionID)
+		summary, err := b.pool.CompactSession(b.ctx, sessionID)
 		if err != nil {
 			log.Error("compact session failed", "session_id", sessionID, "error", err)
 			return c.Send(fmt.Sprintf("Compaction failed: %v", err))
@@ -121,105 +209,132 @@ func Run(ctx context.Context, token string, pool *agent.Pool, listFn ModelListFu
 		return c.Send("Session compacted.")
 	})
 
-	bot.Handle("/model", func(c tele.Context) error {
+	b.bot.Handle("/model", func(c tele.Context) error {
 		args := strings.TrimSpace(c.Message().Payload)
-		models := listFn()
+		models := b.listFn()
 
-		// No argument: show inline keyboard.
 		if args == "" {
-			return sendModelKeyboard(c, models, chatModels)
+			return b.sendModelKeyboard(c, models)
 		}
-
-		// Argument provided: switch to that model.
-		return switchModel(c, pool, chatModels, models, switchFn, args)
+		return b.switchModel(c, models, args)
 	})
 
-	// Handle inline keyboard callbacks for model selection.
-	bot.Handle(tele.OnCallback, func(c tele.Context) error {
-		data := c.Data()
-		if !strings.HasPrefix(data, callbackModelPrefix) {
-			return c.Respond()
-		}
-
-		idxStr := strings.TrimPrefix(data, callbackModelPrefix)
-		models := listFn()
-		if err := switchModel(c, pool, chatModels, models, switchFn, idxStr); err != nil {
+	// Handle inline keyboard callbacks for model selection via unique handler.
+	// telebot strips the "\fmodel_select|" prefix, so c.Data() = "1", "2", etc.
+	b.bot.Handle("\fmodel_select", func(c tele.Context) error {
+		idxStr := c.Data()
+		models := b.listFn()
+		if err := b.switchModel(c, models, idxStr); err != nil {
 			return err
 		}
-
-		// Acknowledge the callback and remove the keyboard.
 		_ = c.Respond()
 		return c.Delete()
 	})
 
-	bot.Handle(tele.OnText, func(c tele.Context) error {
-		chatID := c.Chat().ID
-		sessionID := strconv.FormatInt(chatID, 10)
-		text := c.Message().Text
-
-		log.Debug("message received", "chat_id", chatID, "text_len", len(text))
-
-		// Start persistent typing indicator.
-		typingCtx, stopTyping := context.WithCancel(ctx)
-		go keepTyping(typingCtx, c)
-
-		response, streamErr := streamResponse(bot, c, pool, ctx, sessionID, text)
-
-		stopTyping()
-
-		if streamErr != nil {
-			log.Error("agent stream error", "session_id", sessionID, "error", streamErr)
-			if response == "" {
-				response = fmt.Sprintf("Agent error: %v", streamErr)
-			} else {
-				response += fmt.Sprintf("\n\n[Agent error: %v]", streamErr)
-			}
-		}
-
-		if strings.TrimSpace(response) == "" {
-			response = "(empty response)"
-		}
-
-		sendFinalResponse(bot, c, md, response)
-		log.Debug("response sent", "chat_id", chatID, "response_len", len(response))
-		return nil
+	b.bot.Handle(tele.OnText, func(c tele.Context) error {
+		return b.handleText(c)
 	})
-
-	log.Info("polling started")
-
-	go func() {
-		<-ctx.Done()
-		log.Info("polling stopped")
-		bot.Stop()
-	}()
-
-	bot.Start()
-	return ctx.Err()
 }
 
-// keepTyping sends the typing indicator repeatedly until ctx is cancelled.
-func keepTyping(ctx context.Context, c tele.Context) {
-	_ = c.Notify(tele.Typing)
-	ticker := time.NewTicker(typingInterval)
-	defer ticker.Stop()
+// handleText processes incoming text messages.
+func (b *Bot) handleText(c tele.Context) error {
+	chatID := c.Chat().ID
+	sessionID := sessionIDFor(c)
+	text := c.Message().Text
 
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			_ = c.Notify(tele.Typing)
+	// Group chat filtering.
+	if isGroup(c) {
+		if !b.shouldRespondInGroup(c) {
+			return nil // silently ignore
 		}
+		// Strip bot mention from the message text.
+		text = b.stripBotMention(text)
+	}
+
+	log.Debug("message received", "chat_id", chatID, "text_len", len(text))
+
+	typingCtx, stopTyping := context.WithCancel(b.ctx)
+	go keepTyping(typingCtx, c)
+
+	response, streamErr := b.streamResponse(c, sessionID, text)
+
+	stopTyping()
+
+	if streamErr != nil {
+		log.Error("agent stream error", "session_id", sessionID, "error", streamErr)
+		if response == "" {
+			response = fmt.Sprintf("Agent error: %v", streamErr)
+		} else {
+			response += fmt.Sprintf("\n\n[Agent error: %v]", streamErr)
+		}
+	}
+
+	if strings.TrimSpace(response) == "" {
+		response = "(empty response)"
+	}
+
+	b.sendFinalResponse(c, response)
+	log.Debug("response sent", "chat_id", chatID, "response_len", len(response))
+	return nil
+}
+
+// isGroup returns true if the message is from a group or supergroup.
+func isGroup(c tele.Context) bool {
+	t := c.Chat().Type
+	return t == tele.ChatGroup || t == tele.ChatSuperGroup
+}
+
+// shouldRespondInGroup checks whether the bot should respond based on group_mode.
+func (b *Bot) shouldRespondInGroup(c tele.Context) bool {
+	switch b.cfg.GroupMode {
+	case "disabled":
+		return false
+	case "always":
+		return true
+	default: // "mention"
+		return b.isMentionedOrReplied(c)
 	}
 }
 
+// isMentionedOrReplied returns true if the bot is @mentioned in the text
+// or the message is a reply to one of the bot's messages.
+func (b *Bot) isMentionedOrReplied(c tele.Context) bool {
+	// Check for reply to bot.
+	if reply := c.Message().ReplyTo; reply != nil && reply.Sender != nil {
+		if reply.Sender.ID == b.bot.Me.ID {
+			return true
+		}
+	}
+	// Check for @mention.
+	if b.bot.Me.Username != "" {
+		if strings.Contains(c.Message().Text, "@"+b.bot.Me.Username) {
+			return true
+		}
+	}
+	return false
+}
+
+// stripBotMention removes @botname from the message text.
+func (b *Bot) stripBotMention(text string) string {
+	if b.bot.Me.Username == "" {
+		return text
+	}
+	return strings.TrimSpace(strings.ReplaceAll(text, "@"+b.bot.Me.Username, ""))
+}
+
+// sessionIDFor returns the session ID for a chat. Uses chat ID directly
+// so groups share a single session.
+func sessionIDFor(c tele.Context) string {
+	return strconv.FormatInt(c.Chat().ID, 10)
+}
+
 // sendModelKeyboard sends an inline keyboard with model selection buttons.
-func sendModelKeyboard(c tele.Context, models []ModelOption, chatModels map[int64]ModelOption) error {
+func (b *Bot) sendModelKeyboard(c tele.Context, models []ModelOption) error {
 	if len(models) == 0 {
 		return c.Send("No models configured.")
 	}
 
-	active, hasActive := chatModels[c.Chat().ID]
+	active, hasActive := b.chatModels[c.Chat().ID]
 	markup := &tele.ReplyMarkup{}
 
 	var rows []tele.Row
@@ -228,7 +343,7 @@ func sendModelKeyboard(c tele.Context, models []ModelOption, chatModels map[int6
 		if hasActive && m.Provider == active.Provider && m.Model == active.Model {
 			label = "✅ " + label
 		}
-		btn := markup.Data(label, "model_select", fmt.Sprintf("model:%d", i+1))
+		btn := markup.Data(label, "model_select", fmt.Sprintf("%d", i+1))
 		rows = append(rows, markup.Row(btn))
 	}
 
@@ -236,24 +351,23 @@ func sendModelKeyboard(c tele.Context, models []ModelOption, chatModels map[int6
 	return c.Send("Select a model:", markup)
 }
 
-// switchModel handles model switching by index string. Used by both /model
-// command and inline keyboard callback.
-func switchModel(c tele.Context, pool *agent.Pool, chatModels map[int64]ModelOption, models []ModelOption, switchFn channel.ModelSwitchFunc, idxStr string) error {
+// switchModel handles model switching by index string.
+func (b *Bot) switchModel(c tele.Context, models []ModelOption, idxStr string) error {
 	idx, err := strconv.Atoi(idxStr)
 	if err != nil || idx < 1 || idx > len(models) {
 		return c.Send(fmt.Sprintf("Invalid selection. Use a number between 1 and %d.", len(models)))
 	}
 	selected := models[idx-1]
-	if switchFn != nil {
-		if err := switchFn(selected.Provider, selected.Model); err != nil {
+	if b.switchFn != nil {
+		if err := b.switchFn(selected.Provider, selected.Model); err != nil {
 			return c.Send(fmt.Sprintf("Error switching model: %v", err))
 		}
 	}
-	sessionID := strconv.FormatInt(c.Chat().ID, 10)
-	if err := pool.Reset(sessionID); err != nil {
+	sessionID := sessionIDFor(c)
+	if err := b.pool.Reset(sessionID); err != nil {
 		log.Error("reset session after model switch failed", "session_id", sessionID, "error", err)
 	}
-	chatModels[c.Chat().ID] = selected
+	b.chatModels[c.Chat().ID] = selected
 	log.Info("model switched", "session_id", sessionID, "provider", selected.Provider, "model", selected.Model)
 	return c.Send(fmt.Sprintf("Switched to %s/%s. Session reset.", selected.Provider, selected.Model))
 }
@@ -285,14 +399,14 @@ func toolLine(t *runner.ToolUseEvent) string {
 // message in place as tokens arrive. It returns the final accumulated text
 // and any stream error. The sent message (if any) is deleted before returning
 // so the caller can send the final rendered version.
-func streamResponse(bot *tele.Bot, c tele.Context, pool *agent.Pool, ctx context.Context, sessionID, prompt string) (string, error) {
+func (b *Bot) streamResponse(c tele.Context, sessionID, prompt string) (string, error) {
 	var sb strings.Builder
 	var sentMsg *tele.Message
 	var streamErr error
 	var currentTool string
 	lastEdit := time.Time{}
 
-	for evt := range pool.Chat(ctx, sessionID, prompt) {
+	for evt := range b.pool.Chat(b.ctx, sessionID, prompt) {
 		if evt.Err != nil {
 			streamErr = evt.Err
 			break
@@ -344,14 +458,14 @@ func streamResponse(bot *tele.Bot, c tele.Context, pool *agent.Pool, ctx context
 		}
 
 		if sentMsg == nil {
-			msg, err := bot.Send(c.Chat(), display+suffix)
+			msg, err := b.bot.Send(c.Chat(), display+suffix)
 			if err != nil {
 				log.Warn("stream send failed", "error", err)
 			} else {
 				sentMsg = msg
 			}
 		} else {
-			if _, err := bot.Edit(sentMsg, display+suffix); err != nil {
+			if _, err := b.bot.Edit(sentMsg, display+suffix); err != nil {
 				log.Warn("stream edit failed", "error", err)
 			}
 		}
@@ -360,7 +474,7 @@ func streamResponse(bot *tele.Bot, c tele.Context, pool *agent.Pool, ctx context
 
 	// Clean up the streaming message so the caller can send the final version.
 	if sentMsg != nil {
-		if err := bot.Delete(sentMsg); err != nil {
+		if err := b.bot.Delete(sentMsg); err != nil {
 			log.Warn("delete streaming message failed", "error", err)
 		}
 	}
@@ -370,16 +484,32 @@ func streamResponse(bot *tele.Bot, c tele.Context, pool *agent.Pool, ctx context
 
 // sendFinalResponse sends the completed response with markdown rendering,
 // splitting into chunks if necessary.
-func sendFinalResponse(bot *tele.Bot, c tele.Context, md goldmarkMD, response string) {
+func (b *Bot) sendFinalResponse(c tele.Context, response string) {
 	chatID := c.Chat().ID
 	chunks := splitMessage(response)
 	for _, chunk := range chunks {
-		rendered := renderMarkdown(md, chunk)
+		rendered := renderMarkdown(b.md, chunk)
 		if err := c.Send(rendered, tele.ModeMarkdownV2); err != nil {
 			log.Warn("markdown send failed, falling back to plain text", "error", err)
 			if err := c.Send(chunk); err != nil {
 				log.Error("sendMessage failed", "chat_id", chatID, "error", err)
 			}
+		}
+	}
+}
+
+// keepTyping sends the typing indicator repeatedly until ctx is cancelled.
+func keepTyping(ctx context.Context, c tele.Context) {
+	_ = c.Notify(tele.Typing)
+	ticker := time.NewTicker(typingInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			_ = c.Notify(tele.Typing)
 		}
 	}
 }

--- a/config.go
+++ b/config.go
@@ -82,10 +82,11 @@ type RunnerConfig struct {
 type CompactionConfig = agent.CompactionConfig
 
 type TelegramConfig struct {
-	Token      string `yaml:"token"`
-	NotifyChat string `yaml:"notify_chat"`  // chat ID for proactive notifications
-	ChannelID  string `yaml:"channel_id"`   // broadcast channel (@name or numeric ID)
-	GroupMode  string `yaml:"group_mode"`   // "mention" | "always" | "disabled"
+	Token      string  `yaml:"token"`
+	NotifyChat string  `yaml:"notify_chat"`  // chat ID for proactive notifications
+	ChannelID  string  `yaml:"channel_id"`   // broadcast channel (@name or numeric ID)
+	GroupMode  string  `yaml:"group_mode"`   // "mention" | "always" | "disabled"
+	AllowedIDs []int64 `yaml:"allowed_ids"`  // user IDs allowed to use the bot (empty = allow all)
 }
 
 func configDir() string {

--- a/config.go
+++ b/config.go
@@ -82,7 +82,10 @@ type RunnerConfig struct {
 type CompactionConfig = agent.CompactionConfig
 
 type TelegramConfig struct {
-	Token string `yaml:"token"`
+	Token      string `yaml:"token"`
+	NotifyChat string `yaml:"notify_chat"`  // chat ID for proactive notifications
+	ChannelID  string `yaml:"channel_id"`   // broadcast channel (@name or numeric ID)
+	GroupMode  string `yaml:"group_mode"`   // "mention" | "always" | "disabled"
 }
 
 func configDir() string {
@@ -119,6 +122,15 @@ func loadConfigFrom(dir string) (*Config, error) {
 	// Apply environment variable overrides.
 	if v := os.Getenv("ANNA_TELEGRAM_TOKEN"); v != "" {
 		cfg.Telegram.Token = v
+	}
+	if v := os.Getenv("ANNA_TELEGRAM_NOTIFY_CHAT"); v != "" {
+		cfg.Telegram.NotifyChat = v
+	}
+	if v := os.Getenv("ANNA_TELEGRAM_CHANNEL_ID"); v != "" {
+		cfg.Telegram.ChannelID = v
+	}
+	if v := os.Getenv("ANNA_TELEGRAM_GROUP_MODE"); v != "" {
+		cfg.Telegram.GroupMode = v
 	}
 	if v := os.Getenv("ANNA_RUNNER_TYPE"); v != "" {
 		cfg.Runner.Type = v

--- a/docs/notification-system.md
+++ b/docs/notification-system.md
@@ -1,0 +1,224 @@
+# Notification System
+
+## Status
+
+Implemented — `channel/notifier.go`, `channel/notify_tool.go`, `channel/telegram/telegram.go`.
+
+## Overview
+
+Anna supports proactive notifications so the agent, cron jobs, and other internal triggers can push messages to users without waiting for a request. The system uses a multi-backend dispatcher that routes notifications to one or more configured backends (Telegram, with Slack/Discord planned).
+
+## Architecture
+
+```
+┌─────────────────┐
+│  Agent (notify   │──┐
+│  tool call)      │  │
+└─────────────────┘  │
+                      │   Notification{Channel, ChatID, Text, Silent}
+┌─────────────────┐  │           │
+│  Cron job result │──┼──────────▼──────────────┐
+└─────────────────┘  │      Dispatcher          │
+                      │  ┌──────────────────┐   │
+┌─────────────────┐  │  │ Route by Channel  │   │
+│  Future triggers │──┘  │ or broadcast all  │   │
+└─────────────────┘     └────────┬──────────┘   │
+                                 │              │
+                    ┌────────────┼──────────┐   │
+                    │            │          │   │
+                    ▼            ▼          ▼   │
+              ┌──────────┐ ┌────────┐ ┌───────┐│
+              │ Telegram │ │ Slack  │ │Discord││
+              │ Backend  │ │(future)│ │(future)│
+              └──────────┘ └────────┘ └───────┘
+```
+
+## Key Types
+
+### `channel.Notification`
+
+```go
+type Notification struct {
+    Channel string // optional: route to specific backend ("telegram", "slack")
+    ChatID  string // target chat/channel within the backend
+    Text    string // markdown content
+    Silent  bool   // send without notification sound
+}
+```
+
+- `Channel` empty → broadcast to **all** registered backends
+- `Channel` set → route to that specific backend only
+- `ChatID` empty → each backend uses its configured default
+
+### `channel.Backend`
+
+Interface that notification backends implement:
+
+```go
+type Backend interface {
+    Name() string
+    Notify(ctx context.Context, n Notification) error
+}
+```
+
+Currently implemented: `telegram.Bot`.
+
+### `channel.Dispatcher`
+
+Routes notifications to registered backends:
+
+```go
+d := channel.NewDispatcher()
+d.Register(tgBot, "136345060")   // telegram backend with default chat
+d.Register(slackBot, "#alerts")  // future: slack backend
+
+// Broadcast to all backends (each uses its default chat):
+d.Notify(ctx, channel.Notification{Text: "hello"})
+
+// Route to specific backend:
+d.Notify(ctx, channel.Notification{Channel: "telegram", Text: "hello"})
+
+// Override the default chat:
+d.Notify(ctx, channel.Notification{Channel: "telegram", ChatID: "999", Text: "hello"})
+```
+
+Partial failures: if one backend fails during broadcast, the others still receive the notification. Errors are joined via `errors.Join`.
+
+### `channel.NotifyTool`
+
+Agent-facing tool that wraps the dispatcher:
+
+```go
+tool := channel.NewNotifyTool(dispatcher)
+```
+
+The LLM can call it with:
+
+```json
+{
+  "message": "Build finished, 3 tests failed",
+  "channel": "telegram",
+  "chat_id": "136345060",
+  "silent": false
+}
+```
+
+- `message` (required) — the notification text
+- `channel` (optional) — target a specific backend; omit to broadcast
+- `chat_id` (optional) — override the backend's default target
+- `silent` (optional) — suppress notification sound
+
+## Wiring
+
+### Startup Flow (`main.go`)
+
+```
+setup()
+  ├── Create Dispatcher
+  ├── Create NotifyTool(dispatcher) → extraTools
+  ├── Create runner factory with extraTools
+  └── Create Pool
+
+runGateway()
+  ├── Create telegram.Bot
+  ├── dispatcher.Register(tgBot, notifyChat)  ← backend registered
+  ├── wireCronNotifier(cron, pool, dispatcher) ← cron output → dispatcher
+  └── tgBot.Start(ctx)                        ← begin polling
+```
+
+The dispatcher is created early (in `setup`) so the notify tool can reference it. Backends are registered later (in `runGateway`) when they're created. This avoids circular dependencies.
+
+### Cron → Notification
+
+When a cron job fires:
+1. The job runs through `pool.Chat()` to get the agent's response
+2. The full response text is collected
+3. The text is broadcast via `dispatcher.Notify()` to all backends
+
+### CLI Mode
+
+In CLI mode (`anna chat`), no notification backends are registered, so the `notify` tool is not exposed to the agent. This avoids a broken tool path.
+
+## Configuration
+
+### Telegram
+
+```yaml
+telegram:
+  token: "BOT_TOKEN"
+  notify_chat: "123456789"    # default chat for notifications
+  channel_id: "@my_channel"   # fallback if notify_chat is empty
+  group_mode: "mention"       # mention | always | disabled
+  allowed_ids:                # restrict bot to these user IDs
+    - 136345060
+```
+
+Environment variable overrides:
+
+| Variable | Field |
+|----------|-------|
+| `ANNA_TELEGRAM_NOTIFY_CHAT` | `telegram.notify_chat` |
+| `ANNA_TELEGRAM_CHANNEL_ID` | `telegram.channel_id` |
+| `ANNA_TELEGRAM_GROUP_MODE` | `telegram.group_mode` |
+
+### Notify Target Resolution
+
+When `Notify()` is called, the target chat is resolved in this order:
+
+1. `Notification.ChatID` (explicit in the call)
+2. Backend's registered default chat (from `dispatcher.Register`)
+3. For Telegram: `notify_chat` → `channel_id` → error
+
+## Adding a New Backend
+
+To add Slack, Discord, or any other backend:
+
+1. **Implement `channel.Backend`:**
+
+```go
+// channel/slack/slack.go
+type Bot struct { ... }
+
+func (b *Bot) Name() string { return "slack" }
+func (b *Bot) Notify(ctx context.Context, n channel.Notification) error {
+    // Send n.Text to n.ChatID via Slack API
+}
+```
+
+2. **Register in `runGateway()`:**
+
+```go
+if s.cfg.Slack.Token != "" {
+    slackBot := slack.New(s.cfg.Slack)
+    s.notifier.Register(slackBot, s.cfg.Slack.NotifyChannel)
+}
+```
+
+3. **Add config fields** to `config.go` and env var overrides.
+
+No changes needed to the dispatcher, notify tool, or cron wiring — they work through the `Backend` interface.
+
+## Telegram-Specific Features
+
+### Group Support
+
+The bot can operate in Telegram groups with configurable behavior:
+
+- `mention` (default) — respond only when @mentioned or replied to
+- `always` — respond to every message in the group
+- `disabled` — ignore all group messages (including commands)
+
+Session ID for groups = group chat ID (shared context per group).
+
+### Access Control
+
+`allowed_ids` restricts bot interaction to specific Telegram user IDs. When the list is empty, all users are allowed. Unauthorized users are silently ignored — all handlers (commands, callbacks, text) are wrapped in the access check.
+
+### Notification Delivery
+
+`telegram.Bot.Notify()` supports:
+- Numeric chat IDs (`"136345060"`)
+- Channel usernames (`"@my_channel"`)
+- Markdown rendering with MarkdownV2 fallback to plain text
+- Message splitting at 4000-char boundaries
+- Silent mode (`DisableNotification`)

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func chatCommand() *ucli.Command {
 				}
 			}
 
-			s, err := setup(c.Context)
+			s, err := setup(c.Context, false)
 			if err != nil {
 				return err
 			}
@@ -94,7 +94,7 @@ func gatewayCommand() *ucli.Command {
 		Name:  "gateway",
 		Usage: "Start daemon services (Telegram, etc.) based on config",
 		Action: func(c *ucli.Context) error {
-			s, err := setup(c.Context)
+			s, err := setup(c.Context, true)
 			if err != nil {
 				return err
 			}
@@ -124,7 +124,7 @@ type setupResult struct {
 	notifier   *channel.Dispatcher
 }
 
-func setup(parent context.Context) (*setupResult, error) {
+func setup(parent context.Context, gateway bool) (*setupResult, error) {
 	cfg, err := LoadConfig()
 	if err != nil {
 		return nil, fmt.Errorf("loading config: %w", err)
@@ -150,9 +150,9 @@ func setup(parent context.Context) (*setupResult, error) {
 	extraTools = append(extraTools, memory.NewTool(memStore))
 
 	// Notification dispatcher + tool — backends are registered later in
-	// runGateway(). Only expose the tool when a notification backend is configured.
+	// runGateway(). Only expose the tool in gateway mode where backends exist.
 	dispatcher := channel.NewDispatcher()
-	if cfg.Telegram.Token != "" {
+	if gateway && cfg.Telegram.Token != "" {
 		extraTools = append(extraTools, channel.NewNotifyTool(dispatcher))
 	}
 

--- a/main.go
+++ b/main.go
@@ -121,7 +121,7 @@ type setupResult struct {
 	cronSvc    *cron.Service
 	memStore   *memory.Store
 	extraTools []tool.Tool
-	notifier   *channel.NotifierProxy
+	notifier   *channel.Dispatcher
 }
 
 func setup(parent context.Context) (*setupResult, error) {
@@ -149,16 +149,11 @@ func setup(parent context.Context) (*setupResult, error) {
 	memStore := memory.NewStore(filepath.Join(configDir(), "memory"))
 	extraTools = append(extraTools, memory.NewTool(memStore))
 
-	// Notifier proxy + tool — only register when a notification backend
-	// (Telegram) is configured, so the agent doesn't see a broken tool in CLI mode.
-	var notifierProxy *channel.NotifierProxy
+	// Notification dispatcher + tool — backends are registered later in
+	// runGateway(). Only expose the tool when a notification backend is configured.
+	dispatcher := channel.NewDispatcher()
 	if cfg.Telegram.Token != "" {
-		notifierProxy = &channel.NotifierProxy{}
-		defaultChat := cfg.Telegram.NotifyChat
-		if defaultChat == "" {
-			defaultChat = cfg.Telegram.ChannelID
-		}
-		extraTools = append(extraTools, channel.NewNotifyTool(notifierProxy, defaultChat))
+		extraTools = append(extraTools, channel.NewNotifyTool(dispatcher))
 	}
 
 	idleTimeout := time.Duration(cfg.Runner.IdleTimeout) * time.Minute
@@ -207,7 +202,7 @@ func setup(parent context.Context) (*setupResult, error) {
 		cronSvc:    cronSvc,
 		memStore:   memStore,
 		extraTools: extraTools,
-		notifier:   notifierProxy,
+		notifier:   dispatcher,
 	}, nil
 }
 
@@ -285,14 +280,16 @@ func runGateway(ctx context.Context, s *setupResult, listFn channel.ModelListFun
 			return fmt.Errorf("create telegram bot: %w", err)
 		}
 
-		// Install the real notifier so the notify tool and cron can send messages.
-		if s.notifier != nil {
-			s.notifier.Set(tgBot)
+		// Register Telegram as a notification backend.
+		defaultChat := s.cfg.Telegram.NotifyChat
+		if defaultChat == "" {
+			defaultChat = s.cfg.Telegram.ChannelID
 		}
+		s.notifier.Register(tgBot, defaultChat)
 
-		// Override the cron callback to push results via Telegram.
+		// Override the cron callback to push results via the dispatcher.
 		if s.cronSvc != nil {
-			wireCronNotifier(s.cronSvc, s.pool, tgBot, s.cfg.Telegram.NotifyChat)
+			wireCronNotifier(s.cronSvc, s.pool, s.notifier)
 		}
 
 		if err := tgBot.Start(ctx); err != nil && ctx.Err() == nil {
@@ -309,11 +306,8 @@ func runGateway(ctx context.Context, s *setupResult, listFn channel.ModelListFun
 }
 
 // wireCronNotifier overrides the cron callback to collect the agent response
-// and push it to the configured notification chat.
-func wireCronNotifier(cronSvc *cron.Service, pool *agent.Pool, notifier channel.Notifier, notifyChat string) {
-	if notifyChat == "" {
-		return // no target chat, keep the default silent callback
-	}
+// and broadcast it via the notification dispatcher.
+func wireCronNotifier(cronSvc *cron.Service, pool *agent.Pool, dispatcher *channel.Dispatcher) {
 	cronSvc.SetOnJob(func(ctx context.Context, job cron.Job) {
 		sessionID := "cron:" + job.ID
 		msg := fmt.Sprintf("[Scheduled Task] %s\n\nInstruction: %s", job.Name, job.Message)
@@ -328,10 +322,7 @@ func wireCronNotifier(cronSvc *cron.Service, pool *agent.Pool, notifier channel.
 		}
 		if result.Len() > 0 {
 			text := fmt.Sprintf("*%s*\n\n%s", job.Name, result.String())
-			if err := notifier.Notify(ctx, channel.Notification{
-				ChatID: notifyChat,
-				Text:   text,
-			}); err != nil {
+			if err := dispatcher.Notify(ctx, channel.Notification{Text: text}); err != nil {
 				slog.Error("cron notification failed", "job_id", job.ID, "error", err)
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -149,10 +149,17 @@ func setup(parent context.Context) (*setupResult, error) {
 	memStore := memory.NewStore(filepath.Join(configDir(), "memory"))
 	extraTools = append(extraTools, memory.NewTool(memStore))
 
-	// Notifier proxy + tool — the real notifier is installed later when
-	// the Telegram bot (or other channel) is created.
-	notifierProxy := &channel.NotifierProxy{}
-	extraTools = append(extraTools, channel.NewNotifyTool(notifierProxy, cfg.Telegram.NotifyChat))
+	// Notifier proxy + tool — only register when a notification backend
+	// (Telegram) is configured, so the agent doesn't see a broken tool in CLI mode.
+	var notifierProxy *channel.NotifierProxy
+	if cfg.Telegram.Token != "" {
+		notifierProxy = &channel.NotifierProxy{}
+		defaultChat := cfg.Telegram.NotifyChat
+		if defaultChat == "" {
+			defaultChat = cfg.Telegram.ChannelID
+		}
+		extraTools = append(extraTools, channel.NewNotifyTool(notifierProxy, defaultChat))
+	}
 
 	idleTimeout := time.Duration(cfg.Runner.IdleTimeout) * time.Minute
 	factory, err := newRunnerFactory(cfg, memStore, extraTools)
@@ -279,7 +286,9 @@ func runGateway(ctx context.Context, s *setupResult, listFn channel.ModelListFun
 		}
 
 		// Install the real notifier so the notify tool and cron can send messages.
-		s.notifier.Set(tgBot)
+		if s.notifier != nil {
+			s.notifier.Set(tgBot)
+		}
 
 		// Override the cron callback to push results via Telegram.
 		if s.cronSvc != nil {

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -108,7 +109,7 @@ func gatewayCommand() *ucli.Command {
 
 			listFn := func() []channel.ModelOption { return collectModels(s.cfg) }
 			switchFn := modelSwitcher(s.cfg, s.pool, s.memStore, s.extraTools)
-			return runGateway(s.ctx, s.cfg, s.pool, listFn, switchFn)
+			return runGateway(s.ctx, s, listFn, switchFn)
 		},
 	}
 }
@@ -120,6 +121,7 @@ type setupResult struct {
 	cronSvc    *cron.Service
 	memStore   *memory.Store
 	extraTools []tool.Tool
+	notifier   *channel.NotifierProxy
 }
 
 func setup(parent context.Context) (*setupResult, error) {
@@ -146,6 +148,11 @@ func setup(parent context.Context) (*setupResult, error) {
 	// Memory store + tool — always available.
 	memStore := memory.NewStore(filepath.Join(configDir(), "memory"))
 	extraTools = append(extraTools, memory.NewTool(memStore))
+
+	// Notifier proxy + tool — the real notifier is installed later when
+	// the Telegram bot (or other channel) is created.
+	notifierProxy := &channel.NotifierProxy{}
+	extraTools = append(extraTools, channel.NewNotifyTool(notifierProxy, cfg.Telegram.NotifyChat))
 
 	idleTimeout := time.Duration(cfg.Runner.IdleTimeout) * time.Minute
 	factory, err := newRunnerFactory(cfg, memStore, extraTools)
@@ -193,6 +200,7 @@ func setup(parent context.Context) (*setupResult, error) {
 		cronSvc:    cronSvc,
 		memStore:   memStore,
 		extraTools: extraTools,
+		notifier:   notifierProxy,
 	}, nil
 }
 
@@ -253,13 +261,32 @@ func setupLogFile() error {
 	return nil
 }
 
-func runGateway(ctx context.Context, cfg *Config, pool *agent.Pool, listFn channel.ModelListFunc, switchFn channel.ModelSwitchFunc) error {
+func runGateway(ctx context.Context, s *setupResult, listFn channel.ModelListFunc, switchFn channel.ModelSwitchFunc) error {
 	started := 0
 
-	if cfg.Telegram.Token != "" {
+	if s.cfg.Telegram.Token != "" {
 		started++
 		slog.Info("starting telegram bot")
-		if err := telegram.Run(ctx, cfg.Telegram.Token, pool, listFn, switchFn); err != nil && ctx.Err() == nil {
+
+		tgBot, err := telegram.New(telegram.Config{
+			Token:      s.cfg.Telegram.Token,
+			NotifyChat: s.cfg.Telegram.NotifyChat,
+			ChannelID:  s.cfg.Telegram.ChannelID,
+			GroupMode:  s.cfg.Telegram.GroupMode,
+		}, s.pool, listFn, switchFn)
+		if err != nil {
+			return fmt.Errorf("create telegram bot: %w", err)
+		}
+
+		// Install the real notifier so the notify tool and cron can send messages.
+		s.notifier.Set(tgBot)
+
+		// Override the cron callback to push results via Telegram.
+		if s.cronSvc != nil {
+			wireCronNotifier(s.cronSvc, s.pool, tgBot, s.cfg.Telegram.NotifyChat)
+		}
+
+		if err := tgBot.Start(ctx); err != nil && ctx.Err() == nil {
 			return fmt.Errorf("telegram: %w", err)
 		}
 	}
@@ -270,4 +297,34 @@ func runGateway(ctx context.Context, cfg *Config, pool *agent.Pool, listFn chann
 
 	slog.Info("gateway stopped")
 	return nil
+}
+
+// wireCronNotifier overrides the cron callback to collect the agent response
+// and push it to the configured notification chat.
+func wireCronNotifier(cronSvc *cron.Service, pool *agent.Pool, notifier channel.Notifier, notifyChat string) {
+	if notifyChat == "" {
+		return // no target chat, keep the default silent callback
+	}
+	cronSvc.SetOnJob(func(ctx context.Context, job cron.Job) {
+		sessionID := "cron:" + job.ID
+		msg := fmt.Sprintf("[Scheduled Task] %s\n\nInstruction: %s", job.Name, job.Message)
+		var result strings.Builder
+		for evt := range pool.Chat(ctx, sessionID, msg) {
+			if evt.Err != nil {
+				slog.Error("cron job error", "job_id", job.ID, "error", evt.Err)
+			}
+			if evt.Text != "" {
+				result.WriteString(evt.Text)
+			}
+		}
+		if result.Len() > 0 {
+			text := fmt.Sprintf("*%s*\n\n%s", job.Name, result.String())
+			if err := notifier.Notify(ctx, channel.Notification{
+				ChatID: notifyChat,
+				Text:   text,
+			}); err != nil {
+				slog.Error("cron notification failed", "job_id", job.ID, "error", err)
+			}
+		}
+	})
 }

--- a/main.go
+++ b/main.go
@@ -275,6 +275,7 @@ func runGateway(ctx context.Context, s *setupResult, listFn channel.ModelListFun
 			NotifyChat: s.cfg.Telegram.NotifyChat,
 			ChannelID:  s.cfg.Telegram.ChannelID,
 			GroupMode:  s.cfg.Telegram.GroupMode,
+			AllowedIDs: s.cfg.Telegram.AllowedIDs,
 		}, s.pool, listFn, switchFn)
 		if err != nil {
 			return fmt.Errorf("create telegram bot: %w", err)

--- a/main.go
+++ b/main.go
@@ -100,12 +100,8 @@ func gatewayCommand() *ucli.Command {
 			}
 			defer s.pool.Close()
 
-			if s.cronSvc != nil {
-				if err := s.cronSvc.Start(s.ctx); err != nil {
-					return fmt.Errorf("start cron: %w", err)
-				}
-				defer s.cronSvc.Stop()
-			}
+			// Cron is started inside runGateway after notification wiring,
+			// so early-firing jobs already have the dispatcher callback.
 
 			listFn := func() []channel.ModelOption { return collectModels(s.cfg) }
 			switchFn := modelSwitcher(s.cfg, s.pool, s.memStore, s.extraTools)
@@ -288,9 +284,14 @@ func runGateway(ctx context.Context, s *setupResult, listFn channel.ModelListFun
 		}
 		s.notifier.Register(tgBot, defaultChat)
 
-		// Override the cron callback to push results via the dispatcher.
+		// Wire cron notifications and start the scheduler AFTER the backend
+		// is registered, so early-firing jobs already use the dispatcher.
 		if s.cronSvc != nil {
 			wireCronNotifier(s.cronSvc, s.pool, s.notifier)
+			if err := s.cronSvc.Start(ctx); err != nil {
+				return fmt.Errorf("start cron: %w", err)
+			}
+			defer s.cronSvc.Stop()
 		}
 
 		if err := tgBot.Start(ctx); err != nil && ctx.Err() == nil {


### PR DESCRIPTION
## Summary

Closes #13 — Telegram as a bidirectional notification channel with group support, access control, and a multi-backend notification dispatcher.

Also fixes: Telegram model switching via inline keyboard was broken (callback data prefix mismatch).

### Notification Dispatcher (multi-backend)
- `channel.Backend` interface (`Name` + `Notify`) — any channel can be a notification backend
- `channel.Dispatcher` — routes notifications to all registered backends (broadcast) or a specific one via `Notification.Channel`
- Per-backend default chat/channel, with explicit `ChatID` override
- Partial failure handling: one backend failing doesn't block others (`errors.Join`)

### Notify Agent Tool
- `notify` tool lets the LLM proactively push messages (alerts, cron summaries, task completion)
- Supports `channel` param for targeted delivery, omit to broadcast to all backends
- Only registered when a notification backend is configured (no broken tool in CLI mode)

### Cron → Notification
- Cron jobs collect the full agent response and broadcast via the dispatcher
- Results appear in Telegram (or any registered backend) automatically

### Telegram Bot Refactor
- Converted `Run()` → `Bot` struct with `New()` / `Start()` / `Notify()`
- `Bot` implements `channel.Backend` for the dispatcher
- Supports both numeric chat IDs and `@channel` usernames

### Telegram Group Support
- Configurable `group_mode`: `mention` (default) | `always` | `disabled`
- Bot responds in groups only when @mentioned or replied to (mention mode)
- Strips `@botname` from message text before processing
- All handlers (commands, callbacks, text) respect group mode

### Access Control
- `allowed_ids` restricts bot to specific Telegram user IDs
- Empty list = allow all (backward compatible)
- Unauthorized users silently ignored on all endpoints

### Model Switch Fix
- Inline keyboard used `tele.OnCallback` which receives raw data with `\f` prefix
- `strings.HasPrefix(data, "model:")` always returned false
- Fixed by using telebot's unique-based handler (`\fmodel_select`) which strips the prefix

### Config
```yaml
telegram:
  token: "..."
  notify_chat: "123456789"    # chat ID for proactive notifications
  channel_id: "@my_channel"   # fallback broadcast channel
  group_mode: "mention"       # mention | always | disabled
  allowed_ids:                # restrict to these user IDs (empty = allow all)
    - 136345060
```

Env var overrides: `ANNA_TELEGRAM_NOTIFY_CHAT`, `ANNA_TELEGRAM_CHANNEL_ID`, `ANNA_TELEGRAM_GROUP_MODE`

### New/Changed Files
- `channel/notifier.go` — Notification, Backend, Dispatcher
- `channel/notifier_test.go` — dispatcher unit tests
- `channel/notify_tool.go` — agent notify tool
- `channel/telegram/telegram.go` — refactored bot + Backend impl
- `config.go` — expanded TelegramConfig
- `main.go` — dispatcher wiring, cron notification
- `docs/notification-system.md` — design doc
- `README.md` / `CLAUDE.md` — updated

## Test plan

- [x] All existing tests pass with `-race` flag
- [x] Dispatcher unit tests (broadcast, routing, partial failure, unknown channel)
- [x] Manual: Telegram notification via API and via dispatcher code path
- [ ] Manual: `/model` inline keyboard → verify switch works
- [ ] Manual: add bot to group → verify mention-only response
- [ ] Manual: cron job fires → output appears in notify_chat
- [ ] Manual: unauthorized user sends message → silently ignored