### PR TITLE
feat(cron): Add one-time scheduled jobs

### DIFF
--- a/cron/cron.go
+++ b/cron/cron.go
@@ -88,17 +88,36 @@ func (s *Service) AddJob(name, message string, sched Schedule) (Job, error) {
 	if message == "" {
 		return Job{}, fmt.Errorf("message is required")
 	}
-	if sched.Cron == "" && sched.Every == "" {
-		return Job{}, fmt.Errorf("schedule requires either cron or every")
+	setCount := 0
+	if sched.Cron != "" {
+		setCount++
 	}
-	if sched.Cron != "" && sched.Every != "" {
-		return Job{}, fmt.Errorf("schedule must have exactly one of cron or every")
+	if sched.Every != "" {
+		setCount++
+	}
+	if sched.At != "" {
+		setCount++
+	}
+	if setCount == 0 {
+		return Job{}, fmt.Errorf("schedule requires one of cron, every, or at")
+	}
+	if setCount > 1 {
+		return Job{}, fmt.Errorf("schedule must have exactly one of cron, every, or at")
 	}
 
 	// Validate schedule before persisting.
 	if sched.Every != "" {
 		if _, err := time.ParseDuration(sched.Every); err != nil {
 			return Job{}, fmt.Errorf("invalid duration %q: %w", sched.Every, err)
+		}
+	}
+	if sched.At != "" {
+		t, err := time.Parse(time.RFC3339, sched.At)
+		if err != nil {
+			return Job{}, fmt.Errorf("invalid at timestamp %q: must be RFC3339 format: %w", sched.At, err)
+		}
+		if !t.After(time.Now()) {
+			return Job{}, fmt.Errorf("at timestamp %q is in the past", sched.At)
 		}
 	}
 
@@ -186,23 +205,38 @@ func (s *Service) ListJobs() []Job {
 // scheduleJob registers a job with gocron. Caller must hold s.mu.
 func (s *Service) scheduleJob(ctx context.Context, job Job) error {
 	var jobDef gocron.JobDefinition
-	if job.Schedule.Cron != "" {
+	switch {
+	case job.Schedule.Cron != "":
 		jobDef = gocron.CronJob(job.Schedule.Cron, false)
-	} else {
+	case job.Schedule.Every != "":
 		d, err := time.ParseDuration(job.Schedule.Every)
 		if err != nil {
 			return fmt.Errorf("parse duration: %w", err)
 		}
 		jobDef = gocron.DurationJob(d)
+	case job.Schedule.At != "":
+		t, err := time.Parse(time.RFC3339, job.Schedule.At)
+		if err != nil {
+			return fmt.Errorf("parse at timestamp: %w", err)
+		}
+		if !t.After(time.Now()) {
+			s.log.Info("skipping one-time job with past timestamp", "id", job.ID, "at", job.Schedule.At)
+			return nil
+		}
+		jobDef = gocron.OneTimeJob(gocron.OneTimeJobStartDateTime(t))
 	}
 
 	captured := job
+	isOneTime := job.Schedule.At != ""
 	gj, err := s.scheduler.NewJob(jobDef, gocron.NewTask(func() {
 		s.mu.Lock()
 		fn := s.onJob
 		s.mu.Unlock()
 		if fn != nil {
 			fn(ctx, captured)
+		}
+		if isOneTime {
+			go s.removeOneTimeJob(captured.ID)
 		}
 	}))
 	if err != nil {
@@ -211,6 +245,23 @@ func (s *Service) scheduleJob(ctx context.Context, job Job) error {
 
 	s.gids[job.ID] = gj.ID()
 	return nil
+}
+
+// removeOneTimeJob cleans up a one-time job after it fires.
+func (s *Service) removeOneTimeJob(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if gid, ok := s.gids[id]; ok {
+		_ = s.scheduler.RemoveJob(gid)
+		delete(s.gids, id)
+	}
+	delete(s.jobs, id)
+	if err := s.saveJobsLocked(); err != nil {
+		s.log.Warn("failed to remove one-time job after execution", "id", id, "error", err)
+	} else {
+		s.log.Info("one-time job auto-removed after execution", "id", id)
+	}
 }
 
 // jobsFile returns the path to the jobs JSON file.

--- a/cron/cron.go
+++ b/cron/cron.go
@@ -92,7 +92,8 @@ func (s *Service) Stop() error {
 }
 
 // AddJob creates, persists, and schedules a new job.
-func (s *Service) AddJob(name, message string, sched Schedule) (Job, error) {
+// sessionMode controls session reuse: "reuse" (default) or "new".
+func (s *Service) AddJob(name, message string, sched Schedule, sessionMode string) (Job, error) {
 	if name == "" {
 		return Job{}, fmt.Errorf("name is required")
 	}
@@ -132,13 +133,21 @@ func (s *Service) AddJob(name, message string, sched Schedule) (Job, error) {
 		}
 	}
 
+	if sessionMode == "" {
+		sessionMode = SessionReuse
+	}
+	if sessionMode != SessionReuse && sessionMode != SessionNew {
+		return Job{}, fmt.Errorf("invalid session_mode %q: must be %q or %q", sessionMode, SessionReuse, SessionNew)
+	}
+
 	job := Job{
-		ID:        uuid.New().String()[:8],
-		Name:      name,
-		Schedule:  sched,
-		Message:   message,
-		Enabled:   true,
-		CreatedAt: time.Now(),
+		ID:          uuid.New().String()[:8],
+		Name:        name,
+		Schedule:    sched,
+		Message:     message,
+		SessionMode: sessionMode,
+		Enabled:     true,
+		CreatedAt:   time.Now(),
 	}
 
 	s.mu.Lock()

--- a/cron/cron.go
+++ b/cron/cron.go
@@ -10,9 +10,16 @@ import (
 	"sync"
 	"time"
 
+	"errors"
+
 	"github.com/go-co-op/gocron/v2"
 	"github.com/google/uuid"
 )
+
+// errOneTimeJobPast is returned by scheduleJob when a one-time job's timestamp
+// has already elapsed. Start suppresses this for persisted jobs; AddJob treats
+// it as a hard failure.
+var errOneTimeJobPast = errors.New("one-time job timestamp is in the past")
 
 // OnJobFunc is called when a scheduled job fires.
 type OnJobFunc func(ctx context.Context, job Job)
@@ -64,7 +71,11 @@ func (s *Service) Start(ctx context.Context) error {
 		s.jobs[j.ID] = j
 		if j.Enabled {
 			if err := s.scheduleJob(ctx, j); err != nil {
-				s.log.Warn("failed to schedule persisted job", "id", j.ID, "name", j.Name, "error", err)
+				if errors.Is(err, errOneTimeJobPast) {
+					s.log.Info("skipping one-time job with past timestamp", "id", j.ID, "at", j.Schedule.At)
+				} else {
+					s.log.Warn("failed to schedule persisted job", "id", j.ID, "name", j.Name, "error", err)
+				}
 			}
 		}
 	}
@@ -220,8 +231,7 @@ func (s *Service) scheduleJob(ctx context.Context, job Job) error {
 			return fmt.Errorf("parse at timestamp: %w", err)
 		}
 		if !t.After(time.Now()) {
-			s.log.Info("skipping one-time job with past timestamp", "id", job.ID, "at", job.Schedule.At)
-			return nil
+			return errOneTimeJobPast
 		}
 		jobDef = gocron.OneTimeJob(gocron.OneTimeJobStartDateTime(t))
 	}

--- a/cron/cron_test.go
+++ b/cron/cron_test.go
@@ -73,6 +73,7 @@ func TestAddJobValidation(t *testing.T) {
 	}
 	defer svc.Stop()
 
+	pastTime := time.Now().Add(-1 * time.Hour).Format(time.RFC3339)
 	tests := []struct {
 		name    string
 		jName   string
@@ -83,7 +84,12 @@ func TestAddJobValidation(t *testing.T) {
 		{"empty message", "test", "", Schedule{Every: "1h"}},
 		{"no schedule", "test", "msg", Schedule{}},
 		{"both cron and every", "test", "msg", Schedule{Cron: "* * * * *", Every: "1h"}},
+		{"both cron and at", "test", "msg", Schedule{Cron: "* * * * *", At: time.Now().Add(time.Hour).Format(time.RFC3339)}},
+		{"both every and at", "test", "msg", Schedule{Every: "1h", At: time.Now().Add(time.Hour).Format(time.RFC3339)}},
+		{"all three set", "test", "msg", Schedule{Cron: "* * * * *", Every: "1h", At: time.Now().Add(time.Hour).Format(time.RFC3339)}},
 		{"invalid duration", "test", "msg", Schedule{Every: "bogus"}},
+		{"invalid at format", "test", "msg", Schedule{At: "not-a-timestamp"}},
+		{"past at timestamp", "test", "msg", Schedule{At: pastTime}},
 	}
 
 	for _, tt := range tests {
@@ -261,6 +267,184 @@ func TestCronToolAddListRemove(t *testing.T) {
 	}
 	if result != "No scheduled jobs." {
 		t.Errorf("expected no jobs, got %q", result)
+	}
+}
+
+func TestOneTimeJobCreation(t *testing.T) {
+	dir := t.TempDir()
+	svc, err := New(dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := svc.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer svc.Stop()
+
+	futureTime := time.Now().Add(1 * time.Hour).Format(time.RFC3339)
+	job, err := svc.AddJob("one-time-test", "do something once", Schedule{At: futureTime})
+	if err != nil {
+		t.Fatalf("AddJob: %v", err)
+	}
+	if job.Schedule.At != futureTime {
+		t.Errorf("At = %q, want %q", job.Schedule.At, futureTime)
+	}
+
+	jobs := svc.ListJobs()
+	if len(jobs) != 1 {
+		t.Fatalf("ListJobs: got %d, want 1", len(jobs))
+	}
+}
+
+func TestOneTimeJobFiresAndAutoRemoves(t *testing.T) {
+	dir := t.TempDir()
+	svc, err := New(dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	var mu sync.Mutex
+	var fired []string
+	svc.SetOnJob(func(_ context.Context, job Job) {
+		mu.Lock()
+		fired = append(fired, job.ID)
+		mu.Unlock()
+	})
+
+	if err := svc.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer svc.Stop()
+
+	// Schedule 200ms from now.
+	at := time.Now().Add(200 * time.Millisecond).Format(time.RFC3339Nano)
+	job, err := svc.AddJob("fire-once", "ping once", Schedule{At: at})
+	if err != nil {
+		t.Fatalf("AddJob: %v", err)
+	}
+
+	// Wait for the callback to fire and cleanup to happen.
+	deadline := time.After(3 * time.Second)
+	for {
+		mu.Lock()
+		n := len(fired)
+		mu.Unlock()
+		if n > 0 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("callback did not fire within 3s")
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+
+	// Verify the callback fired with the right job.
+	mu.Lock()
+	if fired[0] != job.ID {
+		t.Errorf("fired job ID = %q, want %q", fired[0], job.ID)
+	}
+	mu.Unlock()
+
+	// Wait a bit for the async cleanup goroutine.
+	time.Sleep(200 * time.Millisecond)
+
+	// Job should be auto-removed.
+	jobs := svc.ListJobs()
+	if len(jobs) != 0 {
+		t.Errorf("ListJobs after one-time fire: got %d, want 0", len(jobs))
+	}
+}
+
+func TestOneTimeJobSkippedOnRestartIfPast(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a service and add a one-time job in the future.
+	svc1, err := New(dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := svc1.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	futureTime := time.Now().Add(1 * time.Hour).Format(time.RFC3339)
+	_, err = svc1.AddJob("restart-test", "do once", Schedule{At: futureTime})
+	if err != nil {
+		t.Fatalf("AddJob: %v", err)
+	}
+	svc1.Stop()
+
+	// Manually tamper the job to have a past timestamp to simulate missed window.
+	jobs, err := svc1.loadJobs()
+	if err != nil {
+		t.Fatalf("loadJobs: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs))
+	}
+	jobs[0].Schedule.At = time.Now().Add(-1 * time.Hour).Format(time.RFC3339)
+	svc1.mu.Lock()
+	svc1.jobs[jobs[0].ID] = jobs[0]
+	_ = svc1.saveJobsLocked()
+	svc1.mu.Unlock()
+
+	// Restart: the past one-time job should be loaded but not scheduled (silently skipped).
+	svc2, err := New(dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := svc2.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer svc2.Stop()
+
+	// Job is still in the list (persisted) but not scheduled with gocron.
+	listed := svc2.ListJobs()
+	if len(listed) != 1 {
+		t.Fatalf("expected 1 persisted job, got %d", len(listed))
+	}
+
+	svc2.mu.Lock()
+	_, hasGID := svc2.gids[listed[0].ID]
+	svc2.mu.Unlock()
+	if hasGID {
+		t.Error("expected past one-time job to not be scheduled with gocron")
+	}
+}
+
+func TestCronToolAddOneTimeJob(t *testing.T) {
+	dir := t.TempDir()
+	svc, err := New(dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := svc.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer svc.Stop()
+
+	ct := NewTool(svc)
+
+	futureTime := time.Now().Add(1 * time.Hour).Format(time.RFC3339)
+	result, err := ct.Execute(context.Background(), map[string]any{
+		"action":  "add",
+		"name":    "reminder",
+		"message": "check the weather",
+		"at":      futureTime,
+	})
+	if err != nil {
+		t.Fatalf("Execute add one-time: %v", err)
+	}
+	if result == "" {
+		t.Fatal("expected non-empty result")
+	}
+
+	jobs := svc.ListJobs()
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs))
+	}
+	if jobs[0].Schedule.At != futureTime {
+		t.Errorf("At = %q, want %q", jobs[0].Schedule.At, futureTime)
 	}
 }
 

--- a/cron/cron_test.go
+++ b/cron/cron_test.go
@@ -21,7 +21,7 @@ func TestAddListRemoveJob(t *testing.T) {
 	defer svc.Stop()
 
 	// Add a job.
-	job, err := svc.AddJob("test", "say hello", Schedule{Every: "1h"})
+	job, err := svc.AddJob("test", "say hello", Schedule{Every: "1h"}, "")
 	if err != nil {
 		t.Fatalf("AddJob: %v", err)
 	}
@@ -94,7 +94,7 @@ func TestAddJobValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := svc.AddJob(tt.jName, tt.message, tt.sched)
+			_, err := svc.AddJob(tt.jName, tt.message, tt.sched, "")
 			if err == nil {
 				t.Error("expected error")
 			}
@@ -129,7 +129,7 @@ func TestJobPersistenceAcrossRestart(t *testing.T) {
 	if err := svc1.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
-	job, err := svc1.AddJob("persist-test", "check weather", Schedule{Cron: "0 9 * * *"})
+	job, err := svc1.AddJob("persist-test", "check weather", Schedule{Cron: "0 9 * * *"}, "")
 	if err != nil {
 		t.Fatalf("AddJob: %v", err)
 	}
@@ -177,7 +177,7 @@ func TestOnJobCallbackFires(t *testing.T) {
 	}
 	defer svc.Stop()
 
-	_, err = svc.AddJob("quick", "ping", Schedule{Every: "100ms"})
+	_, err = svc.AddJob("quick", "ping", Schedule{Every: "100ms"}, "")
 	if err != nil {
 		t.Fatalf("AddJob: %v", err)
 	}
@@ -282,7 +282,7 @@ func TestOneTimeJobCreation(t *testing.T) {
 	defer svc.Stop()
 
 	futureTime := time.Now().Add(1 * time.Hour).Format(time.RFC3339)
-	job, err := svc.AddJob("one-time-test", "do something once", Schedule{At: futureTime})
+	job, err := svc.AddJob("one-time-test", "do something once", Schedule{At: futureTime}, "")
 	if err != nil {
 		t.Fatalf("AddJob: %v", err)
 	}
@@ -318,7 +318,7 @@ func TestOneTimeJobFiresAndAutoRemoves(t *testing.T) {
 
 	// Schedule 200ms from now.
 	at := time.Now().Add(200 * time.Millisecond).Format(time.RFC3339Nano)
-	job, err := svc.AddJob("fire-once", "ping once", Schedule{At: at})
+	job, err := svc.AddJob("fire-once", "ping once", Schedule{At: at}, "")
 	if err != nil {
 		t.Fatalf("AddJob: %v", err)
 	}
@@ -368,7 +368,7 @@ func TestOneTimeJobSkippedOnRestartIfPast(t *testing.T) {
 		t.Fatalf("Start: %v", err)
 	}
 	futureTime := time.Now().Add(1 * time.Hour).Format(time.RFC3339)
-	_, err = svc1.AddJob("restart-test", "do once", Schedule{At: futureTime})
+	_, err = svc1.AddJob("restart-test", "do once", Schedule{At: futureTime}, "")
 	if err != nil {
 		t.Fatalf("AddJob: %v", err)
 	}
@@ -445,6 +445,133 @@ func TestCronToolAddOneTimeJob(t *testing.T) {
 	}
 	if jobs[0].Schedule.At != futureTime {
 		t.Errorf("At = %q, want %q", jobs[0].Schedule.At, futureTime)
+	}
+}
+
+func TestSessionModeDefault(t *testing.T) {
+	dir := t.TempDir()
+	svc, err := New(dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := svc.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer svc.Stop()
+
+	// Empty session_mode defaults to "reuse".
+	job, err := svc.AddJob("default-mode", "msg", Schedule{Every: "1h"}, "")
+	if err != nil {
+		t.Fatalf("AddJob: %v", err)
+	}
+	if job.SessionMode != SessionReuse {
+		t.Errorf("SessionMode = %q, want %q", job.SessionMode, SessionReuse)
+	}
+}
+
+func TestSessionModeReuse(t *testing.T) {
+	dir := t.TempDir()
+	svc, err := New(dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := svc.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer svc.Stop()
+
+	job, err := svc.AddJob("reuse-mode", "msg", Schedule{Every: "1h"}, SessionReuse)
+	if err != nil {
+		t.Fatalf("AddJob: %v", err)
+	}
+
+	// Reuse mode: SessionID is stable across calls.
+	id1 := job.SessionID()
+	id2 := job.SessionID()
+	if id1 != id2 {
+		t.Errorf("reuse mode: SessionID changed: %q vs %q", id1, id2)
+	}
+	if id1 != "cron:"+job.ID {
+		t.Errorf("reuse mode: SessionID = %q, want %q", id1, "cron:"+job.ID)
+	}
+}
+
+func TestSessionModeNew(t *testing.T) {
+	dir := t.TempDir()
+	svc, err := New(dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := svc.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer svc.Stop()
+
+	job, err := svc.AddJob("new-mode", "msg", Schedule{Every: "1h"}, SessionNew)
+	if err != nil {
+		t.Fatalf("AddJob: %v", err)
+	}
+	if job.SessionMode != SessionNew {
+		t.Errorf("SessionMode = %q, want %q", job.SessionMode, SessionNew)
+	}
+
+	// New mode: SessionID differs across calls.
+	id1 := job.SessionID()
+	time.Sleep(1 * time.Millisecond) // ensure different nano timestamp
+	id2 := job.SessionID()
+	if id1 == id2 {
+		t.Error("new mode: SessionID should differ between calls")
+	}
+}
+
+func TestSessionModeInvalid(t *testing.T) {
+	dir := t.TempDir()
+	svc, err := New(dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := svc.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer svc.Stop()
+
+	_, err = svc.AddJob("bad-mode", "msg", Schedule{Every: "1h"}, "invalid")
+	if err == nil {
+		t.Error("expected error for invalid session_mode")
+	}
+}
+
+func TestCronToolSessionMode(t *testing.T) {
+	dir := t.TempDir()
+	svc, err := New(dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := svc.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer svc.Stop()
+
+	ct := NewTool(svc)
+
+	// Add with session_mode "new" via tool.
+	_, err = ct.Execute(context.Background(), map[string]any{
+		"action":       "add",
+		"name":         "fresh-session",
+		"message":      "do work",
+		"every":        "1h",
+		"session_mode": "new",
+	})
+	if err != nil {
+		t.Fatalf("Execute add: %v", err)
+	}
+
+	jobs := svc.ListJobs()
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs))
+	}
+	if jobs[0].SessionMode != SessionNew {
+		t.Errorf("SessionMode = %q, want %q", jobs[0].SessionMode, SessionNew)
 	}
 }
 

--- a/cron/job.go
+++ b/cron/job.go
@@ -1,6 +1,16 @@
 package cron
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
+
+const (
+	// SessionReuse reuses the same session across job executions (default).
+	SessionReuse = "reuse"
+	// SessionNew creates a fresh session for each execution.
+	SessionNew = "new"
+)
 
 // Schedule defines when a job runs. Exactly one field must be set.
 type Schedule struct {
@@ -11,10 +21,22 @@ type Schedule struct {
 
 // Job is the persisted job definition.
 type Job struct {
-	ID        string   `json:"id"`
-	Name      string   `json:"name"`
-	Schedule  Schedule `json:"schedule"`
-	Message   string   `json:"message"`
-	Enabled   bool     `json:"enabled"`
-	CreatedAt time.Time `json:"created_at"`
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	Schedule    Schedule  `json:"schedule"`
+	Message     string    `json:"message"`
+	SessionMode string    `json:"session_mode"` // "reuse" (default) or "new"
+	Enabled     bool      `json:"enabled"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+// SessionID returns the session identifier for this job execution.
+// In "reuse" mode, the ID is stable across executions. In "new" mode,
+// a timestamp suffix ensures each execution gets a fresh session.
+func (j Job) SessionID() string {
+	base := "cron:" + j.ID
+	if j.SessionMode == SessionNew {
+		return fmt.Sprintf("%s:%d", base, time.Now().UnixNano())
+	}
+	return base
 }

--- a/cron/job.go
+++ b/cron/job.go
@@ -6,6 +6,7 @@ import "time"
 type Schedule struct {
 	Cron  string `json:"cron,omitempty"`  // "0 9 * * 1-5"
 	Every string `json:"every,omitempty"` // "30m", "2h"
+	At    string `json:"at,omitempty"`    // RFC3339: "2024-01-15T14:30:00+08:00"
 }
 
 // Job is the persisted job definition.

--- a/cron/tool.go
+++ b/cron/tool.go
@@ -38,6 +38,11 @@ var cronInputSchema = func() map[string]any {
       "type": "string",
       "description": "RFC3339 timestamp for a one-time job, e.g. '2024-01-15T14:30:00+08:00' (use at OR cron OR every, not combined)"
     },
+    "session_mode": {
+      "type": "string",
+      "enum": ["reuse", "new"],
+      "description": "Session behavior: 'reuse' (default) keeps conversation history across executions, 'new' starts a fresh session each time"
+    },
     "id": {
       "type": "string",
       "description": "Job ID (required for remove)"
@@ -89,8 +94,9 @@ func (t *CronTool) add(args map[string]any) (string, error) {
 	every, _ := args["every"].(string)
 
 	at, _ := args["at"].(string)
+	sessionMode, _ := args["session_mode"].(string)
 	sched := Schedule{Cron: cronExpr, Every: every, At: at}
-	job, err := t.service.AddJob(name, message, sched)
+	job, err := t.service.AddJob(name, message, sched, sessionMode)
 	if err != nil {
 		return "", err
 	}

--- a/cron/tool.go
+++ b/cron/tool.go
@@ -34,6 +34,10 @@ var cronInputSchema = func() map[string]any {
       "type": "string",
       "description": "Go duration, e.g. '30m', '2h', '24h' (use every OR cron, not both)"
     },
+    "at": {
+      "type": "string",
+      "description": "RFC3339 timestamp for a one-time job, e.g. '2024-01-15T14:30:00+08:00' (use at OR cron OR every, not combined)"
+    },
     "id": {
       "type": "string",
       "description": "Job ID (required for remove)"
@@ -58,7 +62,7 @@ func NewTool(service *Service) *CronTool {
 func (t *CronTool) Definition() aitypes.ToolDefinition {
 	return aitypes.ToolDefinition{
 		Name:        "cron",
-		Description: "Manage scheduled tasks. Use action 'add' to create a recurring job, 'list' to see all jobs, or 'remove' to delete a job.",
+		Description: "Manage scheduled tasks. Use action 'add' to create a recurring or one-time job, 'list' to see all jobs, or 'remove' to delete a job. For one-time jobs, use the 'at' field with an RFC3339 timestamp.",
 		InputSchema: cronInputSchema,
 	}
 }
@@ -84,7 +88,8 @@ func (t *CronTool) add(args map[string]any) (string, error) {
 	cronExpr, _ := args["cron"].(string)
 	every, _ := args["every"].(string)
 
-	sched := Schedule{Cron: cronExpr, Every: every}
+	at, _ := args["at"].(string)
+	sched := Schedule{Cron: cronExpr, Every: every, At: at}
 	job, err := t.service.AddJob(name, message, sched)
 	if err != nil {
 		return "", err

--- a/docs/cron-system.md
+++ b/docs/cron-system.md
@@ -52,12 +52,13 @@ Top-level package (sibling to `agent/`, `channel/`). Three files:
 
 ```go
 type Job struct {
-    ID        string    // short UUID
-    Name      string    // human-readable name
-    Schedule  Schedule  // cron or interval
-    Message   string    // prompt sent to agent
-    Enabled   bool
-    CreatedAt time.Time
+    ID          string    // short UUID
+    Name        string    // human-readable name
+    Schedule    Schedule  // cron, interval, or one-time
+    Message     string    // prompt sent to agent
+    SessionMode string    // "reuse" (default) or "new"
+    Enabled     bool
+    CreatedAt   time.Time
 }
 ```
 
@@ -84,7 +85,10 @@ Behavior details:
 
 ### Session Model
 
-Each cron job gets a dedicated session with ID `cron:{job.ID}`. This means the agent retains conversational memory across scheduled runs of the same job.
+Each cron job's session behavior is controlled by its `session_mode`:
+
+- **`reuse`** (default) — the job gets a stable session ID `cron:{job.ID}`. The agent retains conversational memory across scheduled runs of the same job.
+- **`new`** — each execution gets a unique session ID `cron:{job.ID}:{timestamp}`. The agent starts fresh every time with no prior context.
 
 ## Configuration
 
@@ -112,6 +116,7 @@ Parameters:
 - `cron` — cron expression (use this OR `every` OR `at`)
 - `every` — Go duration (use this OR `cron` OR `at`)
 - `at` — RFC3339 timestamp for a one-time job (use this OR `cron` OR `every`)
+- `session_mode` — `"reuse"` (default) keeps conversation history; `"new"` starts fresh each execution
 
 Example (recurring): _"Set a reminder every 30 minutes to check my email"_ triggers:
 ```json
@@ -155,6 +160,8 @@ Tests are in `cron/cron_test.go` covering:
 - One-time job fires exactly once and auto-removes
 - One-time job with past timestamp skipped on restart
 - Tool interface for one-time jobs
+- Session mode default, reuse, new, and invalid validation
+- Session mode via tool interface
 - Full tool interface (add/list/remove via `Execute`)
 - Error cases (invalid action, missing ID)
 

--- a/docs/cron-system.md
+++ b/docs/cron-system.md
@@ -46,6 +46,7 @@ Top-level package (sibling to `agent/`, `channel/`). Three files:
 
 - `cron` — a cron expression (e.g. `"0 9 * * 1-5"` for weekdays at 9am)
 - `every` — a Go duration (e.g. `"30m"`, `"2h"`, `"24h"`)
+- `at` — an RFC3339 timestamp for a one-time job (e.g. `"2024-01-15T14:30:00+08:00"`)
 
 **Job** is the persisted definition:
 
@@ -70,6 +71,16 @@ type Job struct {
 ### Persistence
 
 Jobs are stored as a JSON array in `{dataDir}/jobs.json` (default: `.agents/cron/jobs.json`). Writes are atomic (temp file + rename).
+
+### One-Time Jobs
+
+Jobs scheduled with `at` run exactly once at the specified time and are automatically removed from both the scheduler and `jobs.json` after execution. This keeps the job list clean without stale entries.
+
+Behavior details:
+- The `at` field must be a valid RFC3339 timestamp with timezone offset
+- Timestamps in the past are rejected at creation time
+- If Anna restarts and a one-time job's timestamp has already passed, the job is silently skipped (not scheduled) but remains in persistence until manually removed
+- On successful execution, the cleanup runs asynchronously to avoid blocking the scheduler
 
 ### Session Model
 
@@ -98,12 +109,18 @@ The `cron` tool is automatically registered with the Go runner when cron is enab
 Parameters:
 - `name` (required) — human-readable name
 - `message` (required) — the instruction to execute on each run
-- `cron` — cron expression (use this OR `every`)
-- `every` — Go duration (use this OR `cron`)
+- `cron` — cron expression (use this OR `every` OR `at`)
+- `every` — Go duration (use this OR `cron` OR `at`)
+- `at` — RFC3339 timestamp for a one-time job (use this OR `cron` OR `every`)
 
-Example: _"Set a reminder every 30 minutes to check my email"_ triggers:
+Example (recurring): _"Set a reminder every 30 minutes to check my email"_ triggers:
 ```json
 {"action": "add", "name": "email check", "message": "Check my email and summarize new messages", "every": "30m"}
+```
+
+Example (one-time): _"Remind me at 2:40 PM to check Beijing weather"_ triggers:
+```json
+{"action": "add", "name": "weather reminder", "message": "Check Beijing weather and send me a summary", "at": "2024-01-15T14:40:00+08:00"}
 ```
 
 ### `list` — List all jobs
@@ -130,10 +147,14 @@ The cron system resolves a circular dependency (service needs pool for the callb
 Tests are in `cron/cron_test.go` covering:
 
 - Add, list, remove lifecycle
-- Input validation (empty name, missing schedule, invalid duration, etc.)
+- Input validation (empty name, missing schedule, invalid duration, conflicting schedule fields, invalid/past timestamps)
 - Remove non-existent job
 - Persistence across service restart
 - Callback firing on schedule
+- One-time job creation and validation
+- One-time job fires exactly once and auto-removes
+- One-time job with past timestamp skipped on restart
+- Tool interface for one-time jobs
 - Full tool interface (add/list/remove via `Execute`)
 - Error cases (invalid action, missing ID)
 

--- a/main.go
+++ b/main.go
@@ -180,7 +180,7 @@ func setup(parent context.Context, gateway bool) (*setupResult, error) {
 	// Wire the cron callback now that pool exists.
 	if cronSvc != nil {
 		cronSvc.SetOnJob(func(ctx context.Context, job cron.Job) {
-			sessionID := "cron:" + job.ID
+			sessionID := job.SessionID()
 			msg := fmt.Sprintf("[Scheduled Task] %s\n\nInstruction: %s", job.Name, job.Message)
 			ch := pool.Chat(ctx, sessionID, msg)
 			for evt := range ch {
@@ -311,7 +311,7 @@ func runGateway(ctx context.Context, s *setupResult, listFn channel.ModelListFun
 // and broadcast it via the notification dispatcher.
 func wireCronNotifier(cronSvc *cron.Service, pool *agent.Pool, dispatcher *channel.Dispatcher) {
 	cronSvc.SetOnJob(func(ctx context.Context, job cron.Job) {
-		sessionID := "cron:" + job.ID
+		sessionID := job.SessionID()
 		msg := fmt.Sprintf("[Scheduled Task] %s\n\nInstruction: %s", job.Name, job.Message)
 		var result strings.Builder
 		for evt := range pool.Chat(ctx, sessionID, msg) {


### PR DESCRIPTION
## Summary
- Adds `at` field (RFC3339 timestamp) to `Schedule` for one-time job support
- Jobs scheduled with `at` fire exactly once then auto-remove from scheduler and `jobs.json`
- Past one-time jobs are gracefully skipped on restart (not scheduled, kept in persistence)
- Agent tool exposes the new `at` parameter alongside existing `cron`/`every`

Closes #19

## Test plan
- [x] All existing tests pass (`go test -race ./cron/`)
- [x] New validation tests: conflicting schedule fields, invalid/past timestamps
- [x] One-time job creation and listing
- [x] One-time job fires callback and auto-removes from persistence
- [x] Past one-time job skipped on service restart
- [x] Tool interface for one-time jobs
- [x] `go vet` and `go build ./...` clean