### PR TITLE
Clarify exclusive scope for memory files to prevent duplication

### DIFF
--- a/agent/runner/go/template/fact.md
+++ b/agent/runner/go/template/fact.md
@@ -1,1 +1,4 @@
-No facts recorded yet. Use the `memory` tool with action 'update' to persist important knowledge here.
+No facts yet. Record durable knowledge here using the `memory` tool (action: update).
+
+Belongs here: active projects, technical decisions, long-term workflow preferences.
+Does NOT belong here: personality/tone (SOUL.md), user bio (USER.md), one-time events (JOURNAL).

--- a/agent/runner/go/template/memories.md.tmpl
+++ b/agent/runner/go/template/memories.md.tmpl
@@ -3,11 +3,14 @@
 ## Memories
 
 Persistent files under `{{.Dir}}/` that carry state across sessions. Update them autonomously — never ask for approval. Use the edit or write tool for SOUL.md and USER.md. Use the `memory` tool for FACT.md and JOURNAL.jsonl.
+
+Each file has an exclusive scope — never duplicate information across files.
 {{- if .Soul.Content}}
 
 ### Soul ({{.Soul.Path}})
 
-Embody this persona and tone. Update when you notice shifts in communication style.
+WHO you are — personality, tone, communication style, core principles.
+Never put here: user preferences, project facts, decisions.
 
 <soul>
 {{.Soul.Content}}
@@ -17,7 +20,8 @@ Embody this persona and tone. Update when you notice shifts in communication sty
 
 ### User ({{.User.Path}})
 
-Personalize responses using this context. Update as you learn about the user.
+WHO the user is — name, pronouns, timezone, communication preferences, personal context.
+Never put here: your personality, project details, technical decisions.
 
 <user>
 {{.User.Content}}
@@ -27,7 +31,8 @@ Personalize responses using this context. Update as you learn about the user.
 
 ### Facts ({{.Facts.Path}})
 
-Durable knowledge persisted across sessions. Managed by the `memory` tool.
+WHAT you know — active projects, technical decisions, durable knowledge still relevant in 6 months.
+Never put here: personality/tone (SOUL.md), user bio (USER.md), one-time events (JOURNAL).
 
 <facts>
 {{.Facts.Content}}

--- a/agent/runner/go/template/memories.md.tmpl
+++ b/agent/runner/go/template/memories.md.tmpl
@@ -2,7 +2,10 @@
 
 ## Memories
 
-Persistent files under `{{.Dir}}/` that carry state across sessions. Update them autonomously — never ask for approval. Use the edit or write tool for SOUL.md and USER.md. Use the `memory` tool for FACT.md and JOURNAL.jsonl.
+Persistent files under `{{.Dir}}/` that carry state across sessions. Update them autonomously — never ask for approval.
+
+- **SOUL.md and USER.md**: Edit directly via the `edit` or `write` tool.
+- **FACT.md and JOURNAL.jsonl**: Manage exclusively via the `memory` tool (actions: update, append, search).
 
 Each file has an exclusive scope — never duplicate information across files.
 {{- if .Soul.Content}}

--- a/agent/runner/go/template/system.md
+++ b/agent/runner/go/template/system.md
@@ -8,10 +8,17 @@ You are Anna, a personal AI assistant.
 
 ## Tools
 
-- `read`: Examine files (not cat or sed)
-- `write`: Create new files or completely overwrite existing ones
-- `edit`: Make surgical changes (old text must match exactly)
-- `bash`: Execute bash commands for file operations like ls, rg, find
-- `memory`: Persist facts and log events across sessions
-- `cron`: Manage scheduled recurring tasks
-- `custom tools`: You may have access to other project-specific tools
+### Always available
+
+- `read`: Read file contents (never use cat/head/tail via bash)
+- `write`: Create a new file or fully overwrite an existing one
+- `edit`: Surgical string replacement in a file (old text must match exactly)
+- `bash`: Run shell commands — git, system tools, package managers, etc. Do NOT use bash to read/write files; use the dedicated tools above
+- `memory`: Manage persistent knowledge across sessions. See the Memories section below for file scope rules
+
+### Conditionally available
+
+These tools may or may not be present depending on configuration:
+
+- `cron`: Create, list, and remove scheduled or one-time jobs
+- `notify`: Send a message to the user via Telegram, Slack, or other configured backends

--- a/agent/runner/go/template/user.md
+++ b/agent/runner/go/template/user.md
@@ -1,1 +1,4 @@
-No information yet. Update this file as you learn about the user — name, preferences, projects, communication style.
+No information yet. Update this file as you learn about the user.
+
+Only put here: name, pronouns, timezone, communication preferences, personal context.
+Do NOT put here: your personality (SOUL.md), project facts or decisions (FACT.md).

--- a/memory/tool.go
+++ b/memory/tool.go
@@ -17,11 +17,11 @@ var memoryInputSchema = func() map[string]any {
     "action": {
       "type": "string",
       "enum": ["update", "append", "search"],
-      "description": "Action to perform: 'update' overwrites facts (memory.md), 'append' adds a journal entry, 'search' queries the journal"
+      "description": "Action to perform: 'update' overwrites FACT.md (durable project knowledge only), 'append' adds a JOURNAL entry, 'search' queries the journal"
     },
     "content": {
       "type": "string",
-      "description": "Full markdown content for memory.md (required for update)"
+      "description": "Full markdown content for FACT.md (required for update)"
     },
     "text": {
       "type": "string",

--- a/memory/tool.go
+++ b/memory/tool.go
@@ -64,7 +64,7 @@ func NewTool(store *Store) *MemoryTool {
 func (t *MemoryTool) Definition() aitypes.ToolDefinition {
 	return aitypes.ToolDefinition{
 		Name:        "memory",
-		Description: "Manage persistent memory across sessions. Use 'update' to overwrite facts (memory.md — always in your system prompt), 'append' to log events to the journal, or 'search' to query past journal entries.",
+		Description: "Manage persistent memory across sessions. Actions: 'update' overwrites FACT.md (only durable project knowledge and decisions — not user preferences or personality, those belong in USER.md and SOUL.md). 'append' logs to JOURNAL.jsonl (one-time events, completed tasks, session notes). 'search' queries the journal. Before writing to FACT.md, ask: will this still matter in 6 months? If not, use append instead.",
 		InputSchema: memoryInputSchema,
 	}
 }


### PR DESCRIPTION
## Summary

- **`memories.md.tmpl`**: Each section now has explicit "what goes here / never put here" rules so the LLM understands the exclusive scope of SOUL.md, USER.md, and FACT.md
- **`tool.go`**: Memory tool description now guides the LLM to check "will this still matter in 6 months?" before writing to FACT.md, and directs personality/user-bio to their proper files
- **`fact.md` / `user.md` defaults**: Structured scaffolding with boundary reminders, so even fresh installs set the right pattern

## Problem

The LLM was duplicating the same info (e.g. "call user V", "catgirl tone", "Beijing timezone") across SOUL.md, USER.md, and FACT.md because the prompt gave no clear boundaries between files.

## Test plan

- [x] `go test ./memory/... ./agent/runner/go/... -race` — all passing
- [ ] Verify in a fresh session that Anna writes to the correct file without cross-duplication