### PR TITLE
Add CI/CD workflows, Docker, and release infrastructure

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+bin/
+.agents/
+.git/
+.github/
+*.md
+cover.out
+docs/issues/
+handoff.md

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,63 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    name: Build Docker Image
+    runs-on: ubicloud-standard-2
+
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=main
+            type=sha,format=long
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/{1}:buildcache,mode=max', env.REGISTRY, env.IMAGE_NAME) || '' }}
+          build-args: |
+            VERSION=${{ github.sha }}

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -1,0 +1,58 @@
+name: Lint and Test
+
+on:
+  push:
+    branches: ["**"]
+    tags-ignore: ["v*.*.*"]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubicloud-standard-2
+    # TODO: remove continue-on-error once pre-existing lint issues are fixed
+    continue-on-error: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup mise
+        uses: jdx/mise-action@v3
+        with:
+          experimental: true
+          install: true
+          cache: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run lint
+        run: mise run lint
+
+  test:
+    name: Test
+    runs-on: ubicloud-standard-2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup mise
+        uses: jdx/mise-action@v3
+        with:
+          experimental: true
+          install: true
+          cache: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run tests with coverage
+        run: mise run test:coverage
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: coverage.out
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,156 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*.*.*"]
+
+permissions:
+  contents: write
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  goreleaser:
+    name: GoReleaser
+    runs-on: ubicloud-standard-2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup mise
+        uses: jdx/mise-action@v3
+        with:
+          experimental: true
+          install: true
+          cache: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  docker:
+    name: Docker Release
+    runs-on: ubicloud-standard-2
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+        include:
+          - platform: linux/amd64
+            suffix: amd64
+          - platform: linux/arm64
+            suffix: arm64
+
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: ${{ matrix.platform }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ github.ref_name }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-${{ matrix.suffix }}
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-${{ matrix.suffix }},mode=max
+          build-args: |
+            VERSION=${{ github.ref_name }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.suffix }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge Docker Manifests
+    runs-on: ubicloud-standard-2
+    needs: [goreleaser, docker]
+
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+            type=sha,format=long
+            type=semver,pattern={{raw}}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 bin/
 anna
 .agents/
+cover.out
+coverage.out
+coverage.html
+dist/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,23 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - gocritic
+    - misspell
+
+formatters:
+  enable:
+    - gofmt
+
+issues:
+  exclude-dirs:
+    - bin
+    - vendor

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,38 @@
+version: 2
+
+before:
+  hooks:
+    - go mod download
+
+builds:
+  - id: anna
+    main: .
+    binary: anna
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - id: anna
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^chore:"
+      - "^ci:"
+      - "^test:"
+
+release:
+  github:
+    owner: vaayne
+    name: anna
+  draft: false
+  prerelease: auto

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.24 AS builder
+
+WORKDIR /go/src/app
+COPY go.mod go.sum ./
+RUN go mod download
+
+ARG VERSION=dev
+ENV CGO_ENABLED=0 GOOS=linux
+
+COPY . .
+RUN go build -ldflags="-s -w" -o bin/anna .
+
+FROM gcr.io/distroless/static-debian13:nonroot AS app
+WORKDIR /service
+
+COPY --from=builder /go/src/app/bin/anna .
+
+USER nonroot:nonroot
+
+CMD ["./anna", "gateway"]

--- a/mise.toml
+++ b/mise.toml
@@ -1,12 +1,26 @@
 [tools]
-go = "1.23"
+go = "1.24"
+"github:golangci/golangci-lint" = "2.11.1"
+"github:goreleaser/goreleaser" = "2.14.1"
 
 [env]
 BINARY_NAME = "anna"
 
+# ============================================================================
+# Build Tasks
+# ============================================================================
+
 [tasks.build]
 description = "Build anna binary"
 run = "go build -o bin/$BINARY_NAME ."
+
+[tasks.clean]
+description = "Remove build artifacts"
+run = "rm -rf bin/"
+
+# ============================================================================
+# Run Tasks
+# ============================================================================
 
 [tasks.run]
 description = "Run anna (pass args after --)"
@@ -28,18 +42,38 @@ description = "Run gateway daemon (Telegram, etc.)"
 depends = ["build"]
 run = "./bin/$BINARY_NAME gateway"
 
+# ============================================================================
+# Code Quality Tasks
+# ============================================================================
+
+[tasks.lint]
+description = "Lint Go code"
+run = "golangci-lint run"
+
 [tasks.test]
 description = "Run all tests with race detection"
 run = "go test -v -race ./..."
 
-[tasks.lint]
-description = "Run go vet"
-run = "go vet ./..."
+[tasks."test:coverage"]
+description = "Run tests with coverage report"
+run = "go test -v -race -coverprofile=coverage.out ./..."
 
 [tasks.format]
 description = "Format Go code and tidy modules"
 run = "gofmt -w . && go mod tidy"
 
-[tasks.clean]
-description = "Remove build artifacts"
-run = "rm -rf bin/"
+# ============================================================================
+# Release Tasks
+# ============================================================================
+
+[tasks.release]
+description = "Create production release with GoReleaser"
+run = "goreleaser release --clean"
+
+[tasks."release:check"]
+description = "Validate GoReleaser configuration"
+run = "goreleaser check"
+
+[tasks."release:snapshot"]
+description = "Create snapshot release for testing"
+run = "goreleaser release --snapshot --clean"


### PR DESCRIPTION
## Summary

Add complete CI/CD pipeline for the anna project.

### Workflows

| Workflow | Trigger | What it does |
|---|---|---|
| **Lint and Test** | Push (branches), PRs to main | golangci-lint + `go test -race` with coverage upload |
| **Docker** | Push/PR to main | Build & validate Docker image; push to GHCR on main |
| **Release** | `v*.*.*` tags | GoReleaser binaries + multi-platform Docker with manifest merge |

### Infrastructure

- **Dockerfile** — Multi-stage (golang builder → distroless), runs `anna gateway`
- **.goreleaser.yaml** — Binary releases for linux/darwin/windows × amd64/arm64
- **.golangci.yml** — golangci-lint v2 config (errcheck, govet, staticcheck, gocritic, misspell)
- **mise.toml** — Added golangci-lint 2.11.1, goreleaser 2.14.1; Go 1.23→1.24; reorganized tasks with release section

### Design decisions

- Lint job uses `continue-on-error: true` — there are ~50 pre-existing `errcheck` issues to fix in a follow-up
- Release Docker tags skip `latest` for prerelease versions (e.g. `v1.2.3-rc.1`)
- Docker manifest merge waits for both GoReleaser and Docker jobs to prevent partial releases
- All workflows use ubicloud runners and mise for tool management, consistent with tokenflux

## Follow-up work

- [ ] Fix ~50 pre-existing `errcheck` lint issues, then remove `continue-on-error` from lint job
- [ ] Add coverage threshold or PR comment reporting

## Test plan

- [x] `mise run lint` runs (reports pre-existing issues, does not block)
- [x] `mise run test` passes
- [x] `mise run release:check` validates goreleaser config
- [x] CI lint-and-test workflow passes (lint soft-fail, test green)
- [x] CI docker workflow passes (build-only on PR)