### PR TITLE
Fix Telegram /new command not creating new session

### DIFF
--- a/agent/pool.go
+++ b/agent/pool.go
@@ -96,26 +96,109 @@ func NewPool(factory runner.NewRunnerFunc, opts ...PoolOption) *Pool {
 }
 
 // CreateSession creates a new session with a generated ID and persists its metadata.
-func (p *Pool) CreateSession() (SessionInfo, error) {
+func (p *Pool) CreateSession(channel string) (SessionInfo, error) {
+	p.mu.Lock()
+	info := p.createSessionLocked(channel)
+	p.mu.Unlock()
+	return p.persistNewSession(info)
+}
+
+// createSessionLocked creates a new session and adds it to the in-memory map.
+// Caller must hold p.mu.
+func (p *Pool) createSessionLocked(channel string) SessionInfo {
 	now := time.Now()
 	info := SessionInfo{
-		ID:         uuid.New().String()[:8],
+		ID:         channel + "-" + uuid.New().String()[:8],
+		Channel:    channel,
 		CreatedAt:  now,
 		LastActive: now,
 	}
-
-	p.mu.Lock()
 	p.sessions[info.ID] = &Session{Info: info}
-	p.mu.Unlock()
+	return info
+}
 
+// persistNewSession saves session metadata to the store and logs creation.
+func (p *Pool) persistNewSession(info SessionInfo) (SessionInfo, error) {
 	if p.store != nil {
 		if err := p.store.SaveInfo(info); err != nil {
 			return info, fmt.Errorf("persist session info: %w", err)
 		}
 	}
-
-	p.log.Info("session created", "session_id", info.ID)
+	p.log.Info("session created", "session_id", info.ID, "channel", info.Channel)
 	return info, nil
+}
+
+// activeSessionLocked returns the most recent non-archived session for a channel
+// from the in-memory map and persistent store. Caller must hold p.mu.
+func (p *Pool) activeSessionLocked(channel string) (SessionInfo, bool) {
+	var best *SessionInfo
+	seen := make(map[string]struct{})
+
+	// Check in-memory sessions (have the freshest LastActive).
+	for _, sess := range p.sessions {
+		if sess.Info.Archived || sess.Info.Channel != channel {
+			continue
+		}
+		seen[sess.Info.ID] = struct{}{}
+		if best == nil || sess.Info.LastActive.After(best.LastActive) {
+			info := sess.Info
+			best = &info
+		}
+	}
+
+	// Check persistent store for sessions not yet in memory.
+	if p.store != nil {
+		items, err := p.store.ListInfo(false)
+		if err == nil {
+			for _, info := range items {
+				if info.Channel != channel {
+					continue
+				}
+				if _, ok := seen[info.ID]; ok {
+					continue
+				}
+				if best == nil || info.LastActive.After(best.LastActive) {
+					info := info
+					best = &info
+				}
+			}
+		}
+	}
+
+	if best == nil {
+		return SessionInfo{}, false
+	}
+	return *best, true
+}
+
+// ActiveSession returns the most recent non-archived session for a channel.
+func (p *Pool) ActiveSession(channel string) (SessionInfo, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.activeSessionLocked(channel)
+}
+
+// ResolveSession returns the active session for a channel, creating one if needed.
+// The check-and-create is atomic to prevent duplicate sessions under concurrent access.
+func (p *Pool) ResolveSession(channel string) (SessionInfo, error) {
+	p.mu.Lock()
+	if info, ok := p.activeSessionLocked(channel); ok {
+		p.mu.Unlock()
+		return info, nil
+	}
+	info := p.createSessionLocked(channel)
+	p.mu.Unlock()
+	return p.persistNewSession(info)
+}
+
+// RotateSession archives the active session for a channel (if any) and creates a new one.
+func (p *Pool) RotateSession(channel string) (SessionInfo, error) {
+	if old, ok := p.ActiveSession(channel); ok {
+		if err := p.ArchiveSession(old.ID); err != nil {
+			p.log.Warn("archive failed during rotate", "session_id", old.ID, "error", err)
+		}
+	}
+	return p.CreateSession(channel)
 }
 
 // GetSession returns metadata for a session.
@@ -485,12 +568,6 @@ func (p *Pool) Chat(ctx context.Context, sessionID string, message string, opts 
 	}()
 
 	return out
-}
-
-// Reset archives the session and removes it from memory.
-// For backward compatibility — prefer ArchiveSession for new code.
-func (p *Pool) Reset(sessionID string) error {
-	return p.ArchiveSession(sessionID)
 }
 
 // SetFactory replaces the runner factory used for new runners.

--- a/agent/pool_test.go
+++ b/agent/pool_test.go
@@ -203,7 +203,7 @@ func TestPoolChatErrorFromFactory(t *testing.T) {
 	}
 }
 
-func TestPoolReset(t *testing.T) {
+func TestPoolArchiveAndRecreate(t *testing.T) {
 	factory, runners := mockRunnerFactory([]runner.Event{{Text: "ok"}})
 	pool := NewPool(factory)
 	defer func() { _ = pool.Close() }()
@@ -214,13 +214,13 @@ func TestPoolReset(t *testing.T) {
 	for range stream {
 	}
 
-	if err := pool.Reset("sess"); err != nil {
-		t.Fatalf("Reset: %v", err)
+	if err := pool.ArchiveSession("sess"); err != nil {
+		t.Fatalf("ArchiveSession: %v", err)
 	}
 
 	// The old runner should be closed.
 	if !(*runners)[0].closed {
-		t.Error("old runner should be closed after Reset")
+		t.Error("old runner should be closed after ArchiveSession")
 	}
 
 	// Session should be removed.
@@ -228,7 +228,7 @@ func TestPoolReset(t *testing.T) {
 	_, exists := pool.sessions["sess"]
 	pool.mu.Unlock()
 	if exists {
-		t.Error("session should be removed after Reset")
+		t.Error("session should be removed after ArchiveSession")
 	}
 
 	// Next chat should create a new runner.
@@ -241,13 +241,13 @@ func TestPoolReset(t *testing.T) {
 	}
 }
 
-func TestPoolResetNonexistent(t *testing.T) {
+func TestPoolArchiveNonexistent(t *testing.T) {
 	factory, _ := mockRunnerFactory(nil)
 	pool := NewPool(factory)
 
 	// Should not error on nonexistent session.
-	if err := pool.Reset("nonexistent"); err != nil {
-		t.Fatalf("Reset nonexistent: %v", err)
+	if err := pool.ArchiveSession("nonexistent"); err != nil {
+		t.Fatalf("ArchiveSession nonexistent: %v", err)
 	}
 }
 
@@ -420,7 +420,7 @@ func TestPoolCreateSession(t *testing.T) {
 	pool := NewPool(factory)
 	defer func() { _ = pool.Close() }()
 
-	info, err := pool.CreateSession()
+	info, err := pool.CreateSession("test")
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
@@ -440,8 +440,8 @@ func TestPoolCreateAndListSessions(t *testing.T) {
 	pool := NewPool(factory)
 	defer func() { _ = pool.Close() }()
 
-	_, _ = pool.CreateSession()
-	_, _ = pool.CreateSession()
+	_, _ = pool.CreateSession("test")
+	_, _ = pool.CreateSession("test")
 
 	sessions, err := pool.ListSessions(false)
 	if err != nil {
@@ -452,12 +452,204 @@ func TestPoolCreateAndListSessions(t *testing.T) {
 	}
 }
 
+func TestPoolActiveSession(t *testing.T) {
+	factory, _ := mockRunnerFactory(nil)
+	pool := NewPool(factory)
+	defer func() { _ = pool.Close() }()
+
+	// No sessions yet.
+	_, ok := pool.ActiveSession("cli")
+	if ok {
+		t.Error("expected no active session")
+	}
+
+	// Create a session in "cli" channel.
+	info, _ := pool.CreateSession("cli")
+
+	got, ok := pool.ActiveSession("cli")
+	if !ok {
+		t.Fatal("expected active session")
+	}
+	if got.ID != info.ID {
+		t.Errorf("got ID %q, want %q", got.ID, info.ID)
+	}
+	if got.Channel != "cli" {
+		t.Errorf("got Channel %q, want %q", got.Channel, "cli")
+	}
+
+	// Different channel should not find it.
+	_, ok = pool.ActiveSession("tg123")
+	if ok {
+		t.Error("expected no active session for tg123")
+	}
+}
+
+func TestPoolResolveSession(t *testing.T) {
+	factory, _ := mockRunnerFactory(nil)
+	pool := NewPool(factory)
+	defer func() { _ = pool.Close() }()
+
+	// First call creates a new session.
+	info1, err := pool.ResolveSession("cli")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info1.Channel != "cli" {
+		t.Errorf("Channel = %q, want cli", info1.Channel)
+	}
+
+	// Second call returns the same session.
+	info2, err := pool.ResolveSession("cli")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info2.ID != info1.ID {
+		t.Errorf("second resolve returned different ID: %q vs %q", info2.ID, info1.ID)
+	}
+
+	// Archive and resolve again — should create a new session.
+	_ = pool.ArchiveSession(info1.ID)
+	info3, err := pool.ResolveSession("cli")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info3.ID == info1.ID {
+		t.Error("expected new session after archive")
+	}
+}
+
+func TestPoolRotateSession(t *testing.T) {
+	factory, _ := mockRunnerFactory([]runner.Event{{Text: "ok"}})
+	pool := NewPool(factory)
+	defer func() { _ = pool.Close() }()
+
+	ch := "tg12345"
+
+	// Create initial session and chat.
+	info1, _ := pool.CreateSession(ch)
+	stream := pool.Chat(context.Background(), info1.ID, "hello")
+	for range stream {
+	}
+
+	// Rotate: archives old, creates new.
+	info2, err := pool.RotateSession(ch)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info2.ID == info1.ID {
+		t.Error("new session should have different ID")
+	}
+
+	// New session should have no history.
+	history := pool.History(info2.ID)
+	if len(history) != 0 {
+		t.Errorf("new session should have empty history, got %d events", len(history))
+	}
+
+	// ActiveSession should return the new one.
+	active, ok := pool.ActiveSession(ch)
+	if !ok {
+		t.Fatal("expected active session")
+	}
+	if active.ID != info2.ID {
+		t.Errorf("active session = %q, want %q", active.ID, info2.ID)
+	}
+}
+
+func TestPoolRotateSessionNoExisting(t *testing.T) {
+	factory, _ := mockRunnerFactory(nil)
+	pool := NewPool(factory)
+	defer func() { _ = pool.Close() }()
+
+	// Rotate with no existing session should just create one.
+	info, err := pool.RotateSession("fresh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Channel != "fresh" {
+		t.Errorf("Channel = %q, want fresh", info.Channel)
+	}
+}
+
+func TestPoolResolveSessionConcurrent(t *testing.T) {
+	factory, _ := mockRunnerFactory(nil)
+	pool := NewPool(factory)
+	defer func() { _ = pool.Close() }()
+
+	// Launch multiple goroutines that all resolve the same channel concurrently.
+	const n = 20
+	results := make(chan string, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+			info, err := pool.ResolveSession("concurrent")
+			if err != nil {
+				t.Errorf("ResolveSession: %v", err)
+				return
+			}
+			results <- info.ID
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	// All goroutines should have resolved to the same session ID.
+	ids := make(map[string]struct{})
+	for id := range results {
+		ids[id] = struct{}{}
+	}
+	if len(ids) != 1 {
+		t.Errorf("expected 1 unique session ID, got %d: %v", len(ids), ids)
+	}
+}
+
+func TestPoolActiveSessionIgnoresLegacySessions(t *testing.T) {
+	// Sessions created before the Channel field was added have Channel == "".
+	// They should not match any channel query.
+	factory, _ := mockRunnerFactory(nil)
+	pool := NewPool(factory)
+	defer func() { _ = pool.Close() }()
+
+	// Simulate a legacy session by directly injecting one without a Channel.
+	pool.mu.Lock()
+	pool.sessions["legacy-abc"] = &Session{
+		Info: SessionInfo{
+			ID:         "legacy-abc",
+			Channel:    "",
+			CreatedAt:  time.Now(),
+			LastActive: time.Now(),
+		},
+	}
+	pool.mu.Unlock()
+
+	// ActiveSession for "cli" should not match the legacy session.
+	_, ok := pool.ActiveSession("cli")
+	if ok {
+		t.Error("legacy session with empty Channel should not match 'cli'")
+	}
+
+	// ResolveSession should create a new one instead.
+	info, err := pool.ResolveSession("cli")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Channel != "cli" {
+		t.Errorf("Channel = %q, want cli", info.Channel)
+	}
+	if info.ID == "legacy-abc" {
+		t.Error("should not reuse legacy session")
+	}
+}
+
 func TestPoolArchiveSession(t *testing.T) {
 	factory, runners := mockRunnerFactory([]runner.Event{{Text: "ok"}})
 	pool := NewPool(factory)
 	defer func() { _ = pool.Close() }()
 
-	info, _ := pool.CreateSession()
+	info, _ := pool.CreateSession("test")
 
 	// Chat to create a runner
 	stream := pool.Chat(context.Background(), info.ID, "test")
@@ -487,7 +679,7 @@ func TestPoolGetSession(t *testing.T) {
 	pool := NewPool(factory)
 	defer func() { _ = pool.Close() }()
 
-	info, _ := pool.CreateSession()
+	info, _ := pool.CreateSession("test")
 
 	got, err := pool.GetSession(info.ID)
 	if err != nil {
@@ -513,7 +705,7 @@ func TestPoolChatAutoTitles(t *testing.T) {
 	pool := NewPool(factory)
 	defer func() { _ = pool.Close() }()
 
-	info, _ := pool.CreateSession()
+	info, _ := pool.CreateSession("test")
 
 	stream := pool.Chat(context.Background(), info.ID, "How do I fix the bug in pool.go?")
 	for range stream {
@@ -537,7 +729,7 @@ func TestPoolChatAutoTitleTruncates(t *testing.T) {
 	pool := NewPool(factory)
 	defer func() { _ = pool.Close() }()
 
-	info, _ := pool.CreateSession()
+	info, _ := pool.CreateSession("test")
 
 	longMsg := "This is a very long message that should be truncated at a word boundary to keep the title reasonable and readable"
 	stream := pool.Chat(context.Background(), info.ID, longMsg)
@@ -568,7 +760,7 @@ func TestPoolChatWithModel(t *testing.T) {
 	defer func() { _ = pool.Close() }()
 
 	ctx := context.Background()
-	info, _ := pool.CreateSession()
+	info, _ := pool.CreateSession("test")
 
 	// First chat uses default model.
 	stream := pool.Chat(ctx, info.ID, "hello")
@@ -624,7 +816,7 @@ func TestPoolFastModelForCompaction(t *testing.T) {
 	)
 	defer func() { _ = pool.Close() }()
 
-	info, _ := pool.CreateSession()
+	info, _ := pool.CreateSession("test")
 
 	// Chat to create a session with history.
 	stream := pool.Chat(context.Background(), info.ID, "hello")
@@ -685,7 +877,7 @@ func TestSetDefaultModelAffectsNewSessions(t *testing.T) {
 	ctx := context.Background()
 
 	// First session uses initial default.
-	info1, _ := pool.CreateSession()
+	info1, _ := pool.CreateSession("test")
 	stream := pool.Chat(ctx, info1.ID, "hello")
 	for range stream {
 	}
@@ -700,7 +892,7 @@ func TestSetDefaultModelAffectsNewSessions(t *testing.T) {
 	pool.SetDefaultModel("switched-model")
 
 	// New session should use the switched model.
-	info2, _ := pool.CreateSession()
+	info2, _ := pool.CreateSession("test")
 	stream = pool.Chat(ctx, info2.ID, "hello")
 	for range stream {
 	}

--- a/agent/store/store.go
+++ b/agent/store/store.go
@@ -16,6 +16,7 @@ import (
 // SessionInfo holds metadata about a session, persisted in the index file.
 type SessionInfo struct {
 	ID         string    `json:"id"`
+	Channel    string    `json:"channel,omitempty"`
 	Title      string    `json:"title"`
 	CreatedAt  time.Time `json:"created_at"`
 	LastActive time.Time `json:"last_active"`

--- a/channel/cli/chat.go
+++ b/channel/cli/chat.go
@@ -121,25 +121,14 @@ func newChatModel(ctx context.Context, pool *agent.Pool, provider, model string,
 	return m
 }
 
-// resolveSession returns the most recently active non-archived session ID,
+const cliChannel = "cli"
+
+// resolveSession returns the most recently active CLI session ID,
 // or creates a new session if none exist.
 func resolveSession(pool *agent.Pool) string {
-	sessions, err := pool.ListSessions(false)
-	if err == nil && len(sessions) > 0 {
-		// Find the most recently active session.
-		best := sessions[0]
-		for _, s := range sessions[1:] {
-			if s.LastActive.After(best.LastActive) {
-				best = s
-			}
-		}
-		return best.ID
-	}
-
-	info, err := pool.CreateSession()
+	info, err := pool.ResolveSession(cliChannel)
 	if err != nil {
-		// Fallback: generate a simple ID so the app can still start.
-		return "session"
+		return "cli-session"
 	}
 	return info.ID
 }
@@ -445,9 +434,7 @@ func (m *chatModel) handleInput(input string) tea.Cmd {
 	case "/quit", "/exit":
 		return tea.Quit
 	case "/new":
-		// Archive current session and create a fresh one.
-		_ = m.pool.ArchiveSession(m.sessionID)
-		info, err := m.pool.CreateSession()
+		info, err := m.pool.RotateSession(cliChannel)
 		if err != nil {
 			m.history.WriteString(errorStyle.Render("error: "+err.Error()) + "\n\n")
 		} else {
@@ -624,8 +611,11 @@ func (m chatModel) handlePickingKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 
-		if err := m.pool.Reset(m.sessionID); err != nil {
-			m.history.WriteString(errorStyle.Render("error resetting session: "+err.Error()) + "\n\n")
+		info, err := m.pool.RotateSession(cliChannel)
+		if err != nil {
+			m.history.WriteString(errorStyle.Render("error creating session: "+err.Error()) + "\n\n")
+		} else {
+			m.sessionID = info.ID
 		}
 
 		m.provider = selected.provider

--- a/channel/telegram/handler.go
+++ b/channel/telegram/handler.go
@@ -37,17 +37,21 @@ func (b *Bot) registerHandlers() {
 	}))
 
 	b.bot.Handle("/new", b.guard(func(c tele.Context) error {
-		sessionID := sessionIDFor(c)
-		if err := b.pool.Reset(sessionID); err != nil {
-			logger().Error("reset session failed", "session_id", sessionID, "error", err)
+		ch := channelForChat(c)
+		info, err := b.pool.RotateSession(ch)
+		if err != nil {
+			logger().Error("rotate session failed", "channel", ch, "error", err)
 			return c.Send(fmt.Sprintf("Error creating new session: %v", err))
 		}
-		logger().Info("session reset", "session_id", sessionID)
+		logger().Info("new session created", "session_id", info.ID, "channel", ch)
 		return c.Send("New session started.")
 	}))
 
 	b.bot.Handle("/compact", b.guard(func(c tele.Context) error {
-		sessionID := sessionIDFor(c)
+		sessionID, err := b.resolveSession(c)
+		if err != nil {
+			return c.Send(fmt.Sprintf("No active session: %v", err))
+		}
 		_ = c.Notify(tele.Typing)
 		summary, err := b.pool.CompactSession(b.ctx, sessionID)
 		if err != nil {
@@ -129,7 +133,11 @@ func (b *Bot) registerHandlers() {
 // handleText processes incoming text messages.
 func (b *Bot) handleText(c tele.Context) error {
 	chatID := c.Chat().ID
-	sessionID := sessionIDFor(c)
+	sessionID, err := b.resolveSession(c)
+	if err != nil {
+		logger().Error("resolve session failed", "chat_id", chatID, "error", err)
+		return c.Send(fmt.Sprintf("Session error: %v", err))
+	}
 	text := c.Message().Text
 
 	// Strip bot mention in group chats (access control already handled by guard).

--- a/channel/telegram/model.go
+++ b/channel/telegram/model.go
@@ -134,13 +134,13 @@ func (b *Bot) switchModel(c tele.Context, models []ModelOption, idxStr string) e
 			return c.Send(fmt.Sprintf("Error switching model: %v", err))
 		}
 	}
-	sessionID := sessionIDFor(c)
-	if err := b.pool.Reset(sessionID); err != nil {
-		logger().Error("reset session after model switch failed", "session_id", sessionID, "error", err)
+	ch := channelForChat(c)
+	if _, err := b.pool.RotateSession(ch); err != nil {
+		logger().Error("rotate session after model switch failed", "channel", ch, "error", err)
 	}
 	b.mu.Lock()
 	b.chatModels[c.Chat().ID] = selected
 	b.mu.Unlock()
-	logger().Info("model switched", "session_id", sessionID, "provider", selected.Provider, "model", selected.Model)
+	logger().Info("model switched", "channel", ch, "provider", selected.Provider, "model", selected.Model)
 	return c.Send(fmt.Sprintf("Switched to %s/%s. Session reset.", selected.Provider, selected.Model))
 }

--- a/channel/telegram/telegram.go
+++ b/channel/telegram/telegram.go
@@ -228,8 +228,18 @@ func (b *Bot) stripBotMention(text string) string {
 	return strings.TrimSpace(strings.ReplaceAll(text, "@"+b.bot.Me.Username, ""))
 }
 
-// sessionIDFor returns the session ID for a chat. Uses chat ID directly
-// so groups share a single session.
-func sessionIDFor(c tele.Context) string {
-	return strconv.FormatInt(c.Chat().ID, 10)
+// channelForChat returns the channel identifier for a Telegram chat.
+// Each chat (private or group) gets its own channel namespace.
+func channelForChat(c tele.Context) string {
+	return "tg" + strconv.FormatInt(c.Chat().ID, 10)
+}
+
+// resolveSession returns the active session ID for the current chat,
+// creating a new session if none exists.
+func (b *Bot) resolveSession(c tele.Context) (string, error) {
+	info, err := b.pool.ResolveSession(channelForChat(c))
+	if err != nil {
+		return "", err
+	}
+	return info.ID, nil
 }


### PR DESCRIPTION
## Summary

- **Bug**: Telegram `/new` command was not creating a new session. It used the chat ID directly as session ID, so after archiving, the old conversation history was restored from disk on the next message.
- **Fix**: Both CLI and Telegram now follow the same channel-scoped UUID session pattern. Each session gets a unique ID (`cli-a1b2c3d4`, `tg12345-a1b2c3d4`), and `/new` archives the old session then creates a fresh one.
- Added `Channel` field to `SessionInfo`, `ActiveSession()` and `ResolveSession()` to `Pool`, and aligned CLI and Telegram to the same session lifecycle.

## Changes

| File | Change |
|---|---|
| `agent/store/store.go` | Added `Channel` field to `SessionInfo` |
| `agent/pool.go` | `CreateSession(channel)`, `ActiveSession()`, `ResolveSession()` |
| `agent/pool_test.go` | Updated tests, added 3 new tests |
| `channel/telegram/telegram.go` | `channelForChat()` + `resolveSession()` replacing `sessionIDFor()` |
| `channel/telegram/handler.go` | `/new`, `/compact`, `handleText` use new session pattern |
| `channel/telegram/model.go` | Model switch uses archive + create |
| `channel/cli/chat.go` | Uses `ResolveSession("cli")`, same archive + create pattern |

## Test plan

- [x] All existing tests pass (`go test -race ./...`)
- [x] New tests: `TestPoolActiveSession`, `TestPoolResolveSession`, `TestPoolNewSessionFlow`
- [ ] Manual: Telegram `/new` creates fresh session (no old history)
- [ ] Manual: CLI `/new` still works as before
- [ ] Manual: Model switch resets session in both channels