### PR TITLE
✨ Telegram tool summary with history, timing, and result status

### DIFF
--- a/agent/runner/gorunner.go
+++ b/agent/runner/gorunner.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -179,21 +180,15 @@ func convertLoopEvent(e engine.LoopEvent) []Event {
 
 	case engine.ToolFinished:
 		status := "done"
-		detail := ""
+		detail := summarizeToolResult(e.Result)
 		if e.Result.IsError {
 			status = "error"
-			for _, block := range e.Result.Content {
-				if tc, ok := block.(aitypes.TextContent); ok {
-					detail = tc.Text
-				}
-			}
 		}
 		rpc := ToolResultToRPCEvent(e.Result)
 		return []Event{
 			{ToolUse: &ToolUseEvent{
 				Tool:   e.Result.ToolName,
 				Status: status,
-				Input:  summarizeToolInput(e.Result.ToolName, nil),
 				Detail: detail,
 			}},
 			{Store: &rpc},
@@ -204,6 +199,48 @@ func convertLoopEvent(e engine.LoopEvent) []Event {
 	}
 
 	return nil
+}
+
+// summarizeToolResult returns a short human-readable summary of a tool result.
+func summarizeToolResult(result aitypes.ToolResultMessage) string {
+	var text string
+	for _, block := range result.Content {
+		if tc, ok := block.(aitypes.TextContent); ok {
+			text = tc.Text
+			break
+		}
+	}
+	if text == "" {
+		return ""
+	}
+
+	if result.IsError {
+		// For errors, show the first line.
+		if idx := strings.Index(text, "\n"); idx > 0 {
+			text = text[:idx]
+		}
+		if len(text) > 120 {
+			return text[:117] + "..."
+		}
+		return text
+	}
+
+	// For success, produce a brief summary based on tool type.
+	lines := strings.Count(text, "\n") + 1
+	runeCount := len([]rune(text))
+
+	switch {
+	case runeCount <= 80:
+		// Short result — show inline.
+		if idx := strings.Index(text, "\n"); idx > 0 {
+			text = text[:idx]
+		}
+		return text
+	case lines > 1:
+		return fmt.Sprintf("%d lines", lines)
+	default:
+		return fmt.Sprintf("%d chars", runeCount)
+	}
 }
 
 // summarizeToolInput returns a short human-readable summary of tool arguments.

--- a/agent/runner/gorunner_test.go
+++ b/agent/runner/gorunner_test.go
@@ -518,3 +518,67 @@ func TestAliveAlwaysTrue(t *testing.T) {
 		t.Error("Alive() should still be true after Close (no subprocess)")
 	}
 }
+
+func TestSummarizeToolResult(t *testing.T) {
+	tests := []struct {
+		name    string
+		result  aitypes.ToolResultMessage
+		want    string
+		contain string // if non-empty, check Contains instead of exact match
+	}{
+		{
+			name: "empty content",
+			result: aitypes.ToolResultMessage{
+				ToolName: "bash",
+				Content:  nil,
+			},
+			want: "",
+		},
+		{
+			name: "short result inline",
+			result: aitypes.ToolResultMessage{
+				ToolName: "bash",
+				Content:  []aitypes.ContentBlock{aitypes.TextContent{Text: "hello world"}},
+			},
+			want: "hello world",
+		},
+		{
+			name: "multiline short result first line",
+			result: aitypes.ToolResultMessage{
+				ToolName: "bash",
+				Content:  []aitypes.ContentBlock{aitypes.TextContent{Text: "ok\ndone"}},
+			},
+			want: "ok",
+		},
+		{
+			name: "long multiline shows line count",
+			result: aitypes.ToolResultMessage{
+				ToolName: "read",
+				Content:  []aitypes.ContentBlock{aitypes.TextContent{Text: "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\nline11\nline12\nline13\nline14\nline15"}},
+			},
+			contain: "15 lines",
+		},
+		{
+			name: "error shows first line",
+			result: aitypes.ToolResultMessage{
+				ToolName: "bash",
+				IsError:  true,
+				Content:  []aitypes.ContentBlock{aitypes.TextContent{Text: "permission denied\nsome stack trace"}},
+			},
+			want: "permission denied",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := summarizeToolResult(tt.result)
+			if tt.contain != "" {
+				if got != tt.contain {
+					t.Errorf("summarizeToolResult() = %q, want %q", got, tt.contain)
+				}
+			} else if got != tt.want {
+				t.Errorf("summarizeToolResult() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/agent/tool/tool_test.go
+++ b/agent/tool/tool_test.go
@@ -2,9 +2,15 @@ package tool
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	readability "codeberg.org/readeck/go-readability/v2"
 )
 
 func TestRegistryDefinitions(t *testing.T) {
@@ -226,5 +232,57 @@ func TestWriteToolMissingArg(t *testing.T) {
 	_, err := tool.Execute(context.Background(), map[string]any{})
 	if err == nil {
 		t.Fatal("expected error for missing file_path")
+	}
+}
+
+func TestWebFetchToolNoContent(t *testing.T) {
+	// Serve minimal HTML that readability cannot extract content from (nil Node).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		// Empty body with just a title — readability will parse but produce nil Node.
+		_, _ = fmt.Fprint(w, `<html><head><title>Test Page</title></head><body><script>app()</script></body></html>`)
+	}))
+	defer srv.Close()
+
+	tool := NewWebFetchTool()
+	result, err := tool.Execute(context.Background(), map[string]any{"url": srv.URL})
+	if err != nil {
+		t.Fatalf("expected no error for nil-Node page, got: %v", err)
+	}
+	if !strings.Contains(result, "No readable content") {
+		t.Errorf("expected fallback message, got: %q", result)
+	}
+	if !strings.Contains(result, "Test Page") {
+		t.Errorf("expected title in fallback, got: %q", result)
+	}
+}
+
+func TestWebFetchToolSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = fmt.Fprint(w, `<html><head><title>Article</title></head><body><article><p>Hello world. This is a test article with enough content for readability to extract.</p><p>Second paragraph with more details about the topic at hand.</p></article></body></html>`)
+	}))
+	defer srv.Close()
+
+	tool := NewWebFetchTool()
+	result, err := tool.Execute(context.Background(), map[string]any{"url": srv.URL})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == "" {
+		t.Error("expected non-empty result")
+	}
+}
+
+func TestBuildNoContentMessage(t *testing.T) {
+	msg := buildNoContentMessage("https://example.com/page", readability.Article{})
+	if !strings.Contains(msg, "No readable content") {
+		t.Error("missing header")
+	}
+	if !strings.Contains(msg, "https://example.com/page") {
+		t.Error("missing URL")
+	}
+	if !strings.Contains(msg, "JavaScript") {
+		t.Error("missing guidance hint")
 	}
 }

--- a/agent/tool/webfetch.go
+++ b/agent/tool/webfetch.go
@@ -150,6 +150,13 @@ func (t *WebFetchTool) fetch(ctx context.Context, rawURL string, parsed *url.URL
 	if err != nil {
 		return fetchResult{}, fmt.Errorf("webfetch: readability parse failed: %w", err)
 	}
+
+	if article.Node == nil {
+		// Readability parsed the HTML but found no extractable content.
+		// Return whatever metadata was found so the LLM has something useful.
+		return fetchResult{rawContent: buildNoContentMessage(rawURL, article)}, nil
+	}
+
 	return fetchResult{article: article}, nil
 }
 
@@ -247,6 +254,29 @@ func (t *WebFetchTool) renderJSON(article readability.Article, parsed *url.URL) 
 		return "", fmt.Errorf("webfetch: json marshal failed: %w", err)
 	}
 	return string(b), nil
+}
+
+// buildNoContentMessage produces a fallback message when readability could not
+// extract article content (Node is nil). This commonly happens with pages that
+// require JavaScript, use bot detection, or have no article-like structure
+// (e.g. search engine result pages, SPAs, login walls).
+func buildNoContentMessage(rawURL string, article readability.Article) string {
+	var sb strings.Builder
+	sb.WriteString("No readable content could be extracted from this page.\n")
+	sb.WriteString("URL: " + rawURL + "\n")
+
+	if title := article.Title(); title != "" {
+		sb.WriteString("Title: " + title + "\n")
+	}
+	if siteName := article.SiteName(); siteName != "" {
+		sb.WriteString("Site: " + siteName + "\n")
+	}
+	// Note: article.Excerpt() panics when Node is nil (readability bug),
+	// so we only call safe metadata accessors above.
+
+	sb.WriteString("\nThis usually means the page requires JavaScript rendering, ")
+	sb.WriteString("uses bot detection, or has no article-like content (e.g. search engines, SPAs).")
+	return sb.String()
 }
 
 func (t *WebFetchTool) writeMetadata(w *strings.Builder, article readability.Article) {

--- a/channel/telegram/handler.go
+++ b/channel/telegram/handler.go
@@ -150,7 +150,7 @@ func (b *Bot) handleText(c tele.Context) error {
 	typingCtx, stopTyping := context.WithCancel(b.ctx)
 	go keepTyping(typingCtx, c)
 
-	response, streamErr := b.streamResponse(c, sessionID, text)
+	response, tracker, streamErr := b.streamResponse(c, sessionID, text)
 
 	stopTyping()
 
@@ -165,6 +165,10 @@ func (b *Bot) handleText(c tele.Context) error {
 
 	if strings.TrimSpace(response) == "" {
 		response = "(empty response)"
+	}
+
+	if tracker != nil && tracker.hasHistory() {
+		response += tracker.renderFinal()
 	}
 
 	b.sendFinalResponse(c, response)

--- a/channel/telegram/stream.go
+++ b/channel/telegram/stream.go
@@ -221,13 +221,13 @@ func (b *Bot) streamResponse(c tele.Context, sessionID, prompt string) (string, 
 		if fallback {
 			// Draft failed on first attempt — the event channel is still
 			// open. Continue with edit-based streaming, preserving any
-			// text already buffered from consumed events.
+			// text and tool state already buffered from consumed events.
 			logger().Info("sendMessageDraft not supported, falling back to edit mode")
-			return b.streamEditEvents(c, events, text)
+			return b.streamEditEvents(c, events, text, tracker)
 		}
 		return text, tracker, err
 	}
-	return b.streamEditEvents(c, events, "")
+	return b.streamEditEvents(c, events, "", nil)
 }
 
 // streamDraft uses Telegram's sendMessageDraft API for smooth streaming
@@ -285,12 +285,15 @@ func (b *Bot) streamDraft(c tele.Context, events <-chan runner.Event) (text stri
 // consuming from an existing event channel. Required for group chats where
 // sendMessageDraft is not available. Any already-buffered text from a prior
 // draft attempt is preserved via the initial parameter.
-func (b *Bot) streamEditEvents(c tele.Context, events <-chan runner.Event, initial string) (string, *toolTracker, error) {
+func (b *Bot) streamEditEvents(c tele.Context, events <-chan runner.Event, initial string, existing *toolTracker) (string, *toolTracker, error) {
 	var sb strings.Builder
 	sb.WriteString(initial)
 	var sentMsg *tele.Message
 	var streamErr error
 	var tt toolTracker
+	if existing != nil {
+		tt = *existing
+	}
 	lastEdit := time.Time{}
 
 	for evt := range events {

--- a/channel/telegram/stream.go
+++ b/channel/telegram/stream.go
@@ -137,6 +137,27 @@ func (tt *toolTracker) isDisplaying() bool {
 	return time.Now().Before(tt.displayUntil)
 }
 
+// hasHistory returns true if any tools were tracked.
+func (tt *toolTracker) hasHistory() bool {
+	return len(tt.history) > 0
+}
+
+// renderFinal builds the tool summary for the final message, separated by a line.
+func (tt *toolTracker) renderFinal() string {
+	if len(tt.history) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString("\n\n——————————————————\n")
+	for i, rec := range tt.history {
+		sb.WriteString(renderToolRecord(rec))
+		if i < len(tt.history)-1 {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
 // renderToolRecord formats a single completed tool record.
 func renderToolRecord(rec toolRecord) string {
 	statusEmoji := "✅"
@@ -188,11 +209,11 @@ func truncate(s string, maxLen int) string {
 // For private chats it uses Telegram's sendMessageDraft API (Bot API 9.3+)
 // for smooth animated streaming. For groups (where drafts aren't supported)
 // it falls back to the edit-in-place approach.
-func (b *Bot) streamResponse(c tele.Context, sessionID, prompt string) (string, error) {
+func (b *Bot) streamResponse(c tele.Context, sessionID, prompt string) (string, *toolTracker, error) {
 	events := b.pool.Chat(b.ctx, sessionID, prompt)
 
 	if !isGroup(c) {
-		text, fallback, err := b.streamDraft(c, events)
+		text, tracker, fallback, err := b.streamDraft(c, events)
 		if fallback {
 			// Draft failed on first attempt — the event channel is still
 			// open. Continue with edit-based streaming, preserving any
@@ -200,7 +221,7 @@ func (b *Bot) streamResponse(c tele.Context, sessionID, prompt string) (string, 
 			logger().Info("sendMessageDraft not supported, falling back to edit mode")
 			return b.streamEditEvents(c, events, text)
 		}
-		return text, err
+		return text, tracker, err
 	}
 	return b.streamEditEvents(c, events, "")
 }
@@ -209,10 +230,10 @@ func (b *Bot) streamResponse(c tele.Context, sessionID, prompt string) (string, 
 // in private chats. If the first draft call fails, it returns fallback=true
 // so the caller can switch to edit mode. The buffered text is returned so
 // no consumed events are lost.
-func (b *Bot) streamDraft(c tele.Context, events <-chan runner.Event) (text string, fallback bool, err error) {
+func (b *Bot) streamDraft(c tele.Context, events <-chan runner.Event) (text string, tracker *toolTracker, fallback bool, err error) {
 	var sb strings.Builder
 	var streamErr error
-	var tracker toolTracker
+	var tt toolTracker
 	lastSend := time.Time{}
 	draftID := rand.Int64N(1<<53) + 1
 	chatID := c.Chat().ID
@@ -226,7 +247,7 @@ func (b *Bot) streamDraft(c tele.Context, events <-chan runner.Event) (text stri
 
 		forceRefresh := false
 		if evt.ToolUse != nil {
-			forceRefresh = tracker.handle(evt.ToolUse)
+			forceRefresh = tt.handle(evt.ToolUse)
 		}
 
 		sb.WriteString(evt.Text)
@@ -237,15 +258,15 @@ func (b *Bot) streamDraft(c tele.Context, events <-chan runner.Event) (text stri
 		}
 
 		current := sb.String()
-		if strings.TrimSpace(current) == "" && !tracker.isDisplaying() {
+		if strings.TrimSpace(current) == "" && !tt.isDisplaying() {
 			continue
 		}
 
-		display := buildStreamDisplay(current, tracker.render(), tracker.isDisplaying())
+		display := buildStreamDisplay(current, tt.render(), tt.isDisplaying())
 
 		if err := b.sendDraftRaw(chatID, draftID, display); err != nil {
 			if firstDraft {
-				return sb.String(), true, nil
+				return sb.String(), &tt, true, nil
 			}
 			logger().Warn("sendMessageDraft failed mid-stream", "error", err)
 		}
@@ -253,19 +274,19 @@ func (b *Bot) streamDraft(c tele.Context, events <-chan runner.Event) (text stri
 		lastSend = now
 	}
 
-	return sb.String(), false, streamErr
+	return sb.String(), &tt, false, streamErr
 }
 
 // streamEditEvents uses the traditional edit-in-place approach for streaming,
 // consuming from an existing event channel. Required for group chats where
 // sendMessageDraft is not available. Any already-buffered text from a prior
 // draft attempt is preserved via the initial parameter.
-func (b *Bot) streamEditEvents(c tele.Context, events <-chan runner.Event, initial string) (string, error) {
+func (b *Bot) streamEditEvents(c tele.Context, events <-chan runner.Event, initial string) (string, *toolTracker, error) {
 	var sb strings.Builder
 	sb.WriteString(initial)
 	var sentMsg *tele.Message
 	var streamErr error
-	var tracker toolTracker
+	var tt toolTracker
 	lastEdit := time.Time{}
 
 	for evt := range events {
@@ -276,7 +297,7 @@ func (b *Bot) streamEditEvents(c tele.Context, events <-chan runner.Event, initi
 
 		forceRefresh := false
 		if evt.ToolUse != nil {
-			forceRefresh = tracker.handle(evt.ToolUse)
+			forceRefresh = tt.handle(evt.ToolUse)
 		}
 
 		sb.WriteString(evt.Text)
@@ -287,11 +308,11 @@ func (b *Bot) streamEditEvents(c tele.Context, events <-chan runner.Event, initi
 		}
 
 		current := sb.String()
-		if strings.TrimSpace(current) == "" && !tracker.isDisplaying() {
+		if strings.TrimSpace(current) == "" && !tt.isDisplaying() {
 			continue
 		}
 
-		display := buildStreamDisplay(current, tracker.render(), tracker.isDisplaying())
+		display := buildStreamDisplay(current, tt.render(), tt.isDisplaying())
 
 		if sentMsg == nil {
 			msg, err := b.bot.Send(c.Chat(), display)
@@ -315,7 +336,7 @@ func (b *Bot) streamEditEvents(c tele.Context, events <-chan runner.Event, initi
 		}
 	}
 
-	return sb.String(), streamErr
+	return sb.String(), &tt, streamErr
 }
 
 // buildStreamDisplay constructs the streaming display text with tool summary,

--- a/channel/telegram/stream.go
+++ b/channel/telegram/stream.go
@@ -75,9 +75,13 @@ func (tt *toolTracker) start(t *runner.ToolUseEvent) {
 // finish records the active tool as completed and enforces minimum display time.
 func (tt *toolTracker) finish(t *runner.ToolUseEvent) {
 	dur := time.Since(tt.activeStart)
+	input := tt.activeInput
+	if t.Input != "" {
+		input = t.Input
+	}
 	tt.history = append(tt.history, toolRecord{
 		Tool:     t.Tool,
-		Input:    t.Input,
+		Input:    input,
 		Status:   t.Status,
 		Detail:   t.Detail,
 		Duration: dur,
@@ -170,11 +174,11 @@ func renderToolRecord(rec toolRecord) string {
 		input := truncate(rec.Input, 60)
 		line += ": " + input
 	}
-	line += fmt.Sprintf(" (%s)", formatDuration(rec.Duration))
-	if rec.Status == "error" && rec.Detail != "" {
+	if rec.Detail != "" {
 		detail := truncate(rec.Detail, 80)
-		line += " — " + detail
+		line += " → " + detail
 	}
+	line += fmt.Sprintf(" (%s)", formatDuration(rec.Duration))
 	return line
 }
 

--- a/channel/telegram/stream.go
+++ b/channel/telegram/stream.go
@@ -23,6 +23,10 @@ const typingInterval = 4 * time.Second
 // typingCursor is appended to the message while streaming to indicate activity.
 const typingCursor = " \u258D"
 
+// minToolDisplayDuration is the minimum time a tool indicator stays visible
+// after completion, so it doesn't flash and disappear instantly.
+const minToolDisplayDuration = 2 * time.Second
+
 // toolEmoji maps known tool names to display emoji.
 var toolEmoji = map[string]string{
 	"bash":    "⚡",
@@ -33,27 +37,151 @@ var toolEmoji = map[string]string{
 	"default": "🔧",
 }
 
-// toolLine returns a short status line for a tool-use event.
-func toolLine(t *runner.ToolUseEvent) string {
-	emoji, ok := toolEmoji[t.Tool]
-	if !ok {
-		emoji = toolEmoji["default"]
+// toolRecord holds a completed tool invocation for the summary section.
+type toolRecord struct {
+	Tool     string
+	Input    string
+	Status   string // "done" or "error"
+	Detail   string
+	Duration time.Duration
+}
+
+// toolTracker tracks active and completed tool invocations during streaming.
+type toolTracker struct {
+	history      []toolRecord
+	activeTool   string
+	activeInput  string
+	activeStart  time.Time
+	displayUntil time.Time // minimum time to keep showing the last-finished tool
+}
+
+// start registers a new tool as running.
+func (tt *toolTracker) start(t *runner.ToolUseEvent) {
+	// If a tool was already active, finish it as "done" (missed the finish event).
+	if tt.activeTool != "" {
+		tt.history = append(tt.history, toolRecord{
+			Tool:     tt.activeTool,
+			Input:    tt.activeInput,
+			Status:   "done",
+			Duration: time.Since(tt.activeStart),
+		})
 	}
+	tt.activeTool = t.Tool
+	tt.activeInput = t.Input
+	tt.activeStart = time.Now()
+	tt.displayUntil = time.Time{}
+}
+
+// finish records the active tool as completed and enforces minimum display time.
+func (tt *toolTracker) finish(t *runner.ToolUseEvent) {
+	dur := time.Since(tt.activeStart)
+	tt.history = append(tt.history, toolRecord{
+		Tool:     t.Tool,
+		Input:    t.Input,
+		Status:   t.Status,
+		Detail:   t.Detail,
+		Duration: dur,
+	})
+	tt.displayUntil = time.Now().Add(minToolDisplayDuration)
+	tt.activeTool = ""
+	tt.activeInput = ""
+	tt.activeStart = time.Time{}
+}
+
+// handle processes a tool event, returning true if a display refresh is needed.
+func (tt *toolTracker) handle(t *runner.ToolUseEvent) bool {
 	switch t.Status {
 	case "running":
-		input := t.Input
-		if len(input) > 60 {
-			input = input[:57] + "..."
-		}
-		if input != "" {
-			return fmt.Sprintf("%s %s: %s", emoji, t.Tool, input)
-		}
-		return fmt.Sprintf("%s %s", emoji, t.Tool)
-	case "error":
-		return fmt.Sprintf("❌ %s failed", t.Tool)
-	default:
-		return ""
+		tt.start(t)
+		return true
+	case "done", "error":
+		tt.finish(t)
+		return true
 	}
+	return false
+}
+
+// render builds the tool summary section for the streaming display.
+func (tt *toolTracker) render() string {
+	var sb strings.Builder
+
+	// Completed tools summary.
+	for _, rec := range tt.history {
+		sb.WriteString(renderToolRecord(rec))
+		sb.WriteByte('\n')
+	}
+
+	// Active tool with spinner.
+	if tt.activeTool != "" {
+		emoji := emojiFor(tt.activeTool)
+		elapsed := time.Since(tt.activeStart).Truncate(100 * time.Millisecond)
+		line := fmt.Sprintf("⏳ %s %s", emoji, tt.activeTool)
+		if tt.activeInput != "" {
+			input := truncate(tt.activeInput, 60)
+			line += ": " + input
+		}
+		line += fmt.Sprintf(" (%s)", formatDuration(elapsed))
+		sb.WriteString(line)
+		sb.WriteByte('\n')
+	}
+
+	return sb.String()
+}
+
+// isDisplaying returns true if there is an active tool or the minimum display
+// duration for the last finished tool has not yet elapsed.
+func (tt *toolTracker) isDisplaying() bool {
+	if tt.activeTool != "" {
+		return true
+	}
+	return time.Now().Before(tt.displayUntil)
+}
+
+// renderToolRecord formats a single completed tool record.
+func renderToolRecord(rec toolRecord) string {
+	statusEmoji := "✅"
+	if rec.Status == "error" {
+		statusEmoji = "❌"
+	}
+	emoji := emojiFor(rec.Tool)
+	line := fmt.Sprintf("%s %s %s", statusEmoji, emoji, rec.Tool)
+	if rec.Input != "" {
+		input := truncate(rec.Input, 60)
+		line += ": " + input
+	}
+	line += fmt.Sprintf(" (%s)", formatDuration(rec.Duration))
+	if rec.Status == "error" && rec.Detail != "" {
+		detail := truncate(rec.Detail, 80)
+		line += " — " + detail
+	}
+	return line
+}
+
+// emojiFor returns the emoji for a tool name.
+func emojiFor(tool string) string {
+	if e, ok := toolEmoji[tool]; ok {
+		return e
+	}
+	return toolEmoji["default"]
+}
+
+// formatDuration formats a duration as a human-friendly string.
+func formatDuration(d time.Duration) string {
+	if d < time.Second {
+		return fmt.Sprintf("%dms", d.Milliseconds())
+	}
+	return fmt.Sprintf("%.1fs", d.Seconds())
+}
+
+// truncate shortens s to maxLen characters, appending "..." if truncated.
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	if maxLen <= 3 {
+		return "..."
+	}
+	return s[:maxLen-3] + "..."
 }
 
 // streamResponse consumes the agent stream, displaying progress in real time.
@@ -84,7 +212,7 @@ func (b *Bot) streamResponse(c tele.Context, sessionID, prompt string) (string, 
 func (b *Bot) streamDraft(c tele.Context, events <-chan runner.Event) (text string, fallback bool, err error) {
 	var sb strings.Builder
 	var streamErr error
-	var currentTool string
+	var tracker toolTracker
 	lastSend := time.Time{}
 	draftID := rand.Int64N(1<<53) + 1
 	chatID := c.Chat().ID
@@ -96,36 +224,29 @@ func (b *Bot) streamDraft(c tele.Context, events <-chan runner.Event) (text stri
 			break
 		}
 
+		forceRefresh := false
 		if evt.ToolUse != nil {
-			line := toolLine(evt.ToolUse)
-			if line != "" {
-				currentTool = line
-			} else {
-				currentTool = ""
-			}
-			lastSend = time.Time{}
+			forceRefresh = tracker.handle(evt.ToolUse)
 		}
 
 		sb.WriteString(evt.Text)
 
 		now := time.Now()
-		if now.Sub(lastSend) < streamEditInterval {
+		if !forceRefresh && now.Sub(lastSend) < streamEditInterval {
 			continue
 		}
 
 		current := sb.String()
-		if strings.TrimSpace(current) == "" && currentTool == "" {
+		if strings.TrimSpace(current) == "" && !tracker.isDisplaying() {
 			continue
 		}
 
-		display := buildStreamDisplay(current, currentTool)
+		display := buildStreamDisplay(current, tracker.render(), tracker.isDisplaying())
 
 		if err := b.sendDraftRaw(chatID, draftID, display); err != nil {
 			if firstDraft {
 				return sb.String(), true, nil
 			}
-			// Mid-stream failure: log and continue without updates
-			// rather than breaking the stream.
 			logger().Warn("sendMessageDraft failed mid-stream", "error", err)
 		}
 		firstDraft = false
@@ -144,7 +265,7 @@ func (b *Bot) streamEditEvents(c tele.Context, events <-chan runner.Event, initi
 	sb.WriteString(initial)
 	var sentMsg *tele.Message
 	var streamErr error
-	var currentTool string
+	var tracker toolTracker
 	lastEdit := time.Time{}
 
 	for evt := range events {
@@ -153,29 +274,24 @@ func (b *Bot) streamEditEvents(c tele.Context, events <-chan runner.Event, initi
 			break
 		}
 
+		forceRefresh := false
 		if evt.ToolUse != nil {
-			line := toolLine(evt.ToolUse)
-			if line != "" {
-				currentTool = line
-			} else {
-				currentTool = ""
-			}
-			lastEdit = time.Time{}
+			forceRefresh = tracker.handle(evt.ToolUse)
 		}
 
 		sb.WriteString(evt.Text)
 
 		now := time.Now()
-		if now.Sub(lastEdit) < streamEditInterval {
+		if !forceRefresh && now.Sub(lastEdit) < streamEditInterval {
 			continue
 		}
 
 		current := sb.String()
-		if strings.TrimSpace(current) == "" && currentTool == "" {
+		if strings.TrimSpace(current) == "" && !tracker.isDisplaying() {
 			continue
 		}
 
-		display := buildStreamDisplay(current, currentTool)
+		display := buildStreamDisplay(current, tracker.render(), tracker.isDisplaying())
 
 		if sentMsg == nil {
 			msg, err := b.bot.Send(c.Chat(), display)
@@ -202,13 +318,14 @@ func (b *Bot) streamEditEvents(c tele.Context, events <-chan runner.Event, initi
 	return sb.String(), streamErr
 }
 
-// buildStreamDisplay constructs the streaming display text with tool indicator,
+// buildStreamDisplay constructs the streaming display text with tool summary,
 // cursor, and length truncation (UTF-8 safe).
-func buildStreamDisplay(text, currentTool string) string {
+func buildStreamDisplay(text, toolSection string, hasTools bool) string {
 	display := text
 	suffix := typingCursor
-	if currentTool != "" {
-		suffix = "\n\n_" + currentTool + "_" + typingCursor
+
+	if hasTools && toolSection != "" {
+		suffix = "\n\n" + strings.TrimRight(toolSection, "\n") + typingCursor
 	}
 
 	if len(suffix) >= telegramMaxMessageLen {

--- a/channel/telegram/stream.go
+++ b/channel/telegram/stream.go
@@ -146,19 +146,67 @@ func (tt *toolTracker) hasHistory() bool {
 	return len(tt.history) > 0
 }
 
-// renderFinal builds the tool summary for the final message, separated by a line.
+// renderFinal builds a compact tool summary for the final message.
+// Shows a one-liner with tool counts and total time, plus individual
+// lines for any failed tool calls.
 func (tt *toolTracker) renderFinal() string {
 	if len(tt.history) == 0 {
 		return ""
 	}
-	var sb strings.Builder
-	sb.WriteString("\n\n——————————————————\n")
-	for i, rec := range tt.history {
-		sb.WriteString(renderToolRecord(rec))
-		if i < len(tt.history)-1 {
-			sb.WriteByte('\n')
+
+	// Count tools by name (preserving order of first appearance).
+	type toolCount struct {
+		name  string
+		count int
+	}
+	seen := map[string]int{}
+	var counts []toolCount
+	var totalDur time.Duration
+	var errors []toolRecord
+
+	for _, rec := range tt.history {
+		totalDur += rec.Duration
+		if rec.Status == "error" {
+			errors = append(errors, rec)
+		}
+		if idx, ok := seen[rec.Tool]; ok {
+			counts[idx].count++
+		} else {
+			seen[rec.Tool] = len(counts)
+			counts = append(counts, toolCount{name: rec.Tool, count: 1})
 		}
 	}
+
+	// Build compact summary: "📎 5 tools (2× read, 2× bash, 1× edit) · 3.2s"
+	var sb strings.Builder
+	sb.WriteString("\n\n——————————————————\n")
+
+	total := len(tt.history)
+	fmt.Fprintf(&sb, "📎 %d tool", total)
+	if total != 1 {
+		sb.WriteByte('s')
+	}
+	sb.WriteString(" (")
+	for i, tc := range counts {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		emoji := emojiFor(tc.name)
+		if tc.count > 1 {
+			fmt.Fprintf(&sb, "%d× %s%s", tc.count, emoji, tc.name)
+		} else {
+			sb.WriteString(emoji + tc.name)
+		}
+	}
+	sb.WriteString(") · ")
+	sb.WriteString(formatDuration(totalDur))
+
+	// Append individual lines for error calls.
+	for _, rec := range errors {
+		sb.WriteByte('\n')
+		sb.WriteString(renderToolRecord(rec))
+	}
+
 	return sb.String()
 }
 

--- a/channel/telegram/telegram_test.go
+++ b/channel/telegram/telegram_test.go
@@ -232,27 +232,59 @@ func TestToolTrackerRenderFinal(t *testing.T) {
 	if !strings.Contains(got, "——————————————————") {
 		t.Error("renderFinal() missing separator line")
 	}
-	if !strings.Contains(got, "✅") {
-		t.Error("renderFinal() missing checkmark for done tool")
-	}
-	if !strings.Contains(got, "❌") {
-		t.Error("renderFinal() missing error emoji")
+	// Compact one-liner with tool counts.
+	if !strings.Contains(got, "📎 2 tools") {
+		t.Error("renderFinal() missing compact tool count")
 	}
 	if !strings.Contains(got, "read") || !strings.Contains(got, "bash") {
-		t.Error("renderFinal() missing tool names")
+		t.Error("renderFinal() missing tool names in summary")
 	}
-	if !strings.Contains(got, "main.go") {
-		t.Error("renderFinal() missing tool input (preserved from start)")
-	}
-	if !strings.Contains(got, "42 lines") {
-		t.Error("renderFinal() missing result detail")
+	// Error tool should be shown in detail.
+	if !strings.Contains(got, "❌") {
+		t.Error("renderFinal() missing error line")
 	}
 	if !strings.Contains(got, "exit 1") {
 		t.Error("renderFinal() missing error detail")
 	}
-	// Should not end with a trailing newline after last record.
-	if strings.HasSuffix(got, "\n") {
-		t.Error("renderFinal() should not end with trailing newline")
+	// Successful tools should NOT have individual lines.
+	if strings.Contains(got, "✅") {
+		t.Error("renderFinal() should not have individual success lines")
+	}
+}
+
+func TestToolTrackerRenderFinalAllSuccess(t *testing.T) {
+	var tracker toolTracker
+	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "running", Input: "a.go"})
+	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "done"})
+	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "running", Input: "b.go"})
+	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "done"})
+	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "running", Input: "go test"})
+	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "done"})
+
+	got := tracker.renderFinal()
+	if !strings.Contains(got, "📎 3 tools") {
+		t.Errorf("renderFinal() = %q, want '3 tools'", got)
+	}
+	if !strings.Contains(got, "2× 📖read") {
+		t.Errorf("renderFinal() = %q, want '2× 📖read'", got)
+	}
+	if !strings.Contains(got, "⚡bash") {
+		t.Errorf("renderFinal() = %q, want '⚡bash'", got)
+	}
+	// No error lines.
+	if strings.Contains(got, "❌") {
+		t.Error("renderFinal() should not have error lines for all-success")
+	}
+}
+
+func TestToolTrackerRenderFinalSingleTool(t *testing.T) {
+	var tracker toolTracker
+	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "running", Input: "x.go"})
+	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "done"})
+
+	got := tracker.renderFinal()
+	if !strings.Contains(got, "📎 1 tool (") {
+		t.Errorf("renderFinal() = %q, want singular 'tool'", got)
 	}
 }
 

--- a/channel/telegram/telegram_test.go
+++ b/channel/telegram/telegram_test.go
@@ -3,6 +3,7 @@ package telegram
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/vaayne/anna/agent/runner"
 
@@ -123,79 +124,232 @@ func TestBotCommands(t *testing.T) {
 	}
 }
 
-func TestToolLine(t *testing.T) {
+func TestToolTracker(t *testing.T) {
+	var tracker toolTracker
+
+	// Start a tool.
+	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "running", Input: "ls -la"})
+	if tracker.activeTool != "bash" {
+		t.Errorf("activeTool = %q, want %q", tracker.activeTool, "bash")
+	}
+	if !tracker.isDisplaying() {
+		t.Error("expected isDisplaying=true while tool is active")
+	}
+
+	rendered := tracker.render()
+	if !strings.Contains(rendered, "⏳") {
+		t.Errorf("render() = %q, want spinner emoji", rendered)
+	}
+	if !strings.Contains(rendered, "bash") {
+		t.Errorf("render() = %q, want tool name", rendered)
+	}
+	if !strings.Contains(rendered, "ls -la") {
+		t.Errorf("render() = %q, want tool input", rendered)
+	}
+
+	// Finish the tool.
+	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "done", Input: "ls -la"})
+	if tracker.activeTool != "" {
+		t.Errorf("activeTool = %q, want empty after done", tracker.activeTool)
+	}
+	if len(tracker.history) != 1 {
+		t.Fatalf("history len = %d, want 1", len(tracker.history))
+	}
+	if tracker.history[0].Tool != "bash" {
+		t.Errorf("history[0].Tool = %q, want %q", tracker.history[0].Tool, "bash")
+	}
+
+	rendered = tracker.render()
+	if !strings.Contains(rendered, "✅") {
+		t.Errorf("render() = %q, want checkmark for done tool", rendered)
+	}
+	if !strings.Contains(rendered, "bash") {
+		t.Errorf("render() = %q, want tool name in history", rendered)
+	}
+}
+
+func TestToolTrackerError(t *testing.T) {
+	var tracker toolTracker
+	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "running", Input: "exit 1"})
+	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "error", Input: "exit 1", Detail: "command failed"})
+
+	if len(tracker.history) != 1 {
+		t.Fatalf("history len = %d, want 1", len(tracker.history))
+	}
+	rec := tracker.history[0]
+	if rec.Status != "error" {
+		t.Errorf("status = %q, want %q", rec.Status, "error")
+	}
+
+	rendered := tracker.render()
+	if !strings.Contains(rendered, "❌") {
+		t.Errorf("render() = %q, want error emoji", rendered)
+	}
+	if !strings.Contains(rendered, "command failed") {
+		t.Errorf("render() = %q, want error detail", rendered)
+	}
+}
+
+func TestToolTrackerMultipleTools(t *testing.T) {
+	var tracker toolTracker
+	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "running", Input: "main.go"})
+	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "done", Input: "main.go"})
+	tracker.handle(&runner.ToolUseEvent{Tool: "edit", Status: "running", Input: "main.go"})
+	tracker.handle(&runner.ToolUseEvent{Tool: "edit", Status: "done", Input: "main.go"})
+	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "running", Input: "go test"})
+
+	if len(tracker.history) != 2 {
+		t.Fatalf("history len = %d, want 2", len(tracker.history))
+	}
+	if tracker.activeTool != "bash" {
+		t.Errorf("activeTool = %q, want %q", tracker.activeTool, "bash")
+	}
+
+	rendered := tracker.render()
+	// Should contain two completed tools and one active.
+	if strings.Count(rendered, "✅") != 2 {
+		t.Errorf("render() has %d checkmarks, want 2", strings.Count(rendered, "✅"))
+	}
+	if !strings.Contains(rendered, "⏳") {
+		t.Error("render() missing spinner for active tool")
+	}
+}
+
+func TestToolTrackerMinDisplayDuration(t *testing.T) {
+	var tracker toolTracker
+	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "running", Input: "file.go"})
+	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "done", Input: "file.go"})
+
+	// Right after finishing, should still be displaying (minimum duration).
+	if !tracker.isDisplaying() {
+		t.Error("expected isDisplaying=true right after tool finished")
+	}
+}
+
+func TestToolTrackerStartOverwritesActive(t *testing.T) {
+	var tracker toolTracker
+	// Start one tool, then start another without finishing the first.
+	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "running", Input: "a.go"})
+	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "running", Input: "ls"})
+
+	// The first tool should be auto-finished in history.
+	if len(tracker.history) != 1 {
+		t.Fatalf("history len = %d, want 1", len(tracker.history))
+	}
+	if tracker.history[0].Tool != "read" {
+		t.Errorf("history[0].Tool = %q, want %q", tracker.history[0].Tool, "read")
+	}
+	if tracker.activeTool != "bash" {
+		t.Errorf("activeTool = %q, want %q", tracker.activeTool, "bash")
+	}
+}
+
+func TestRenderToolRecord(t *testing.T) {
 	tests := []struct {
-		name string
-		evt  runner.ToolUseEvent
-		want string
+		name       string
+		rec        toolRecord
+		wantParts  []string
+		wantAbsent []string
 	}{
 		{
-			name: "bash running",
-			evt:  runner.ToolUseEvent{Tool: "bash", Status: "running", Input: "ls -la"},
-			want: "⚡ bash: ls -la",
+			name:      "done with input",
+			rec:       toolRecord{Tool: "bash", Input: "ls -la", Status: "done", Duration: 500 * time.Millisecond},
+			wantParts: []string{"✅", "⚡", "bash", "ls -la", "500ms"},
 		},
 		{
-			name: "read running",
-			evt:  runner.ToolUseEvent{Tool: "read", Status: "running", Input: "main.go"},
-			want: "📖 read: main.go",
+			name:      "done seconds",
+			rec:       toolRecord{Tool: "read", Input: "main.go", Status: "done", Duration: 2500 * time.Millisecond},
+			wantParts: []string{"✅", "📖", "read", "main.go", "2.5s"},
 		},
 		{
-			name: "unknown tool running",
-			evt:  runner.ToolUseEvent{Tool: "custom", Status: "running", Input: "something"},
-			want: "🔧 custom: something",
+			name:      "error with detail",
+			rec:       toolRecord{Tool: "bash", Input: "rm -rf /", Status: "error", Detail: "permission denied", Duration: time.Second},
+			wantParts: []string{"❌", "bash", "permission denied"},
 		},
 		{
-			name: "tool error",
-			evt:  runner.ToolUseEvent{Tool: "bash", Status: "error"},
-			want: "❌ bash failed",
-		},
-		{
-			name: "tool done returns empty",
-			evt:  runner.ToolUseEvent{Tool: "bash", Status: "done"},
-			want: "",
-		},
-		{
-			name: "running no input",
-			evt:  runner.ToolUseEvent{Tool: "edit", Status: "running"},
-			want: "🔧 edit",
-		},
-		{
-			name: "long input truncated",
-			evt:  runner.ToolUseEvent{Tool: "bash", Status: "running", Input: strings.Repeat("x", 80)},
-			want: "⚡ bash: " + strings.Repeat("x", 57) + "...",
+			name:       "done no input",
+			rec:        toolRecord{Tool: "search", Status: "done", Duration: 100 * time.Millisecond},
+			wantParts:  []string{"✅", "🔍", "search", "100ms"},
+			wantAbsent: []string{": "},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := toolLine(&tt.evt)
-			if got != tt.want {
-				t.Errorf("toolLine() = %q, want %q", got, tt.want)
+			got := renderToolRecord(tt.rec)
+			for _, part := range tt.wantParts {
+				if !strings.Contains(got, part) {
+					t.Errorf("renderToolRecord() = %q, want to contain %q", got, part)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(got, absent) {
+					t.Errorf("renderToolRecord() = %q, should not contain %q", got, absent)
+				}
 			}
 		})
 	}
 }
 
-func TestToolLineLongToolName(t *testing.T) {
-	// A very long tool name should not cause toolLine to produce something
-	// that would panic during stream truncation.
-	evt := runner.ToolUseEvent{
-		Tool:   strings.Repeat("x", 5000),
-		Status: "running",
-		Input:  "test",
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		input  string
+		maxLen int
+		want   string
+	}{
+		{"hello", 10, "hello"},
+		{"hello world", 8, "hello..."},
+		{"abc", 3, "abc"},
+		{"abcdef", 5, "ab..."},
 	}
-	line := toolLine(&evt)
-	if line == "" {
-		t.Error("expected non-empty line for running tool")
+
+	for _, tt := range tests {
+		got := truncate(tt.input, tt.maxLen)
+		if got != tt.want {
+			t.Errorf("truncate(%q, %d) = %q, want %q", tt.input, tt.maxLen, got, tt.want)
+		}
 	}
-	// The suffix built from this would exceed telegramMaxMessageLen.
-	// Verify the guard logic: suffix falls back to typingCursor.
-	suffix := "\n\n_" + line + "_" + typingCursor
-	if len(suffix) < telegramMaxMessageLen {
-		t.Skip("tool name not long enough to trigger guard")
+}
+
+func TestFormatDuration(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{500 * time.Millisecond, "500ms"},
+		{0, "0ms"},
+		{time.Second, "1.0s"},
+		{2500 * time.Millisecond, "2.5s"},
+		{10 * time.Second, "10.0s"},
 	}
-	// The production code would replace this with just typingCursor.
-	// This test just ensures toolLine itself doesn't panic.
+
+	for _, tt := range tests {
+		got := formatDuration(tt.d)
+		if got != tt.want {
+			t.Errorf("formatDuration(%v) = %q, want %q", tt.d, got, tt.want)
+		}
+	}
+}
+
+func TestEmojiFor(t *testing.T) {
+	tests := []struct {
+		tool string
+		want string
+	}{
+		{"bash", "⚡"},
+		{"read", "📖"},
+		{"write", "✏️"},
+		{"edit", "🔧"},
+		{"search", "🔍"},
+		{"unknown_tool", "🔧"},
+	}
+
+	for _, tt := range tests {
+		got := emojiFor(tt.tool)
+		if got != tt.want {
+			t.Errorf("emojiFor(%q) = %q, want %q", tt.tool, got, tt.want)
+		}
+	}
 }
 
 func TestToolEmojiDefaults(t *testing.T) {
@@ -214,7 +368,8 @@ func TestBuildStreamDisplay(t *testing.T) {
 	tests := []struct {
 		name        string
 		text        string
-		currentTool string
+		toolSection string
+		hasTools    bool
 		wantSuffix  string
 	}{
 		{
@@ -223,13 +378,14 @@ func TestBuildStreamDisplay(t *testing.T) {
 			wantSuffix: typingCursor,
 		},
 		{
-			name:        "with tool",
+			name:        "with tool section",
 			text:        "hello",
-			currentTool: "⚡ bash: ls",
-			wantSuffix:  "\n\n_⚡ bash: ls_" + typingCursor,
+			toolSection: "✅ ⚡ bash: ls (100ms)\n",
+			hasTools:    true,
+			wantSuffix:  "\n\n✅ ⚡ bash: ls (100ms)" + typingCursor,
 		},
 		{
-			name:       "empty text",
+			name:       "empty text no tools",
 			text:       "",
 			wantSuffix: typingCursor,
 		},
@@ -237,7 +393,7 @@ func TestBuildStreamDisplay(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildStreamDisplay(tt.text, tt.currentTool)
+			got := buildStreamDisplay(tt.text, tt.toolSection, tt.hasTools)
 			if !strings.HasSuffix(got, tt.wantSuffix) {
 				t.Errorf("buildStreamDisplay() = %q, want suffix %q", got, tt.wantSuffix)
 			}
@@ -250,7 +406,7 @@ func TestBuildStreamDisplay(t *testing.T) {
 
 func TestBuildStreamDisplayTruncation(t *testing.T) {
 	longText := strings.Repeat("a", telegramMaxMessageLen+500)
-	got := buildStreamDisplay(longText, "")
+	got := buildStreamDisplay(longText, "", false)
 	if len(got) > telegramMaxMessageLen {
 		t.Errorf("buildStreamDisplay() len = %d, want <= %d", len(got), telegramMaxMessageLen)
 	}
@@ -266,7 +422,7 @@ func TestBuildStreamDisplayUTF8Safe(t *testing.T) {
 	multibyte := strings.Repeat("世", 20) // 60 bytes, will push past limit
 	text := prefix + multibyte
 
-	got := buildStreamDisplay(text, "")
+	got := buildStreamDisplay(text, "", false)
 	// Verify the result is valid UTF-8 (strings.ToValidUTF8 would change invalid bytes).
 	if strings.ToValidUTF8(got, "?") != got {
 		t.Error("buildStreamDisplay() produced invalid UTF-8")

--- a/channel/telegram/telegram_test.go
+++ b/channel/telegram/telegram_test.go
@@ -215,6 +215,56 @@ func TestToolTrackerMultipleTools(t *testing.T) {
 	}
 }
 
+func TestToolTrackerRenderFinal(t *testing.T) {
+	var tracker toolTracker
+
+	// No history → empty string.
+	if got := tracker.renderFinal(); got != "" {
+		t.Errorf("renderFinal() with no history = %q, want empty", got)
+	}
+
+	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "running", Input: "main.go"})
+	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "done", Input: "main.go"})
+	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "running", Input: "go test"})
+	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "error", Input: "go test", Detail: "exit 1"})
+
+	got := tracker.renderFinal()
+	if !strings.Contains(got, "——————————————————") {
+		t.Error("renderFinal() missing separator line")
+	}
+	if !strings.Contains(got, "✅") {
+		t.Error("renderFinal() missing checkmark for done tool")
+	}
+	if !strings.Contains(got, "❌") {
+		t.Error("renderFinal() missing error emoji")
+	}
+	if !strings.Contains(got, "read") || !strings.Contains(got, "bash") {
+		t.Error("renderFinal() missing tool names")
+	}
+	if !strings.Contains(got, "main.go") {
+		t.Error("renderFinal() missing tool input")
+	}
+	if !strings.Contains(got, "exit 1") {
+		t.Error("renderFinal() missing error detail")
+	}
+	// Should not end with a trailing newline after last record.
+	if strings.HasSuffix(got, "\n") {
+		t.Error("renderFinal() should not end with trailing newline")
+	}
+}
+
+func TestToolTrackerHasHistory(t *testing.T) {
+	var tracker toolTracker
+	if tracker.hasHistory() {
+		t.Error("hasHistory() should be false with no tools")
+	}
+	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "running", Input: "x"})
+	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "done", Input: "x"})
+	if !tracker.hasHistory() {
+		t.Error("hasHistory() should be true after tool finished")
+	}
+}
+
 func TestToolTrackerMinDisplayDuration(t *testing.T) {
 	var tracker toolTracker
 	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "running", Input: "file.go"})

--- a/channel/telegram/telegram_test.go
+++ b/channel/telegram/telegram_test.go
@@ -171,7 +171,7 @@ func TestToolTracker(t *testing.T) {
 func TestToolTrackerError(t *testing.T) {
 	var tracker toolTracker
 	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "running", Input: "exit 1"})
-	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "error", Input: "exit 1", Detail: "command failed"})
+	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "error", Detail: "command failed"})
 
 	if len(tracker.history) != 1 {
 		t.Fatalf("history len = %d, want 1", len(tracker.history))
@@ -224,9 +224,9 @@ func TestToolTrackerRenderFinal(t *testing.T) {
 	}
 
 	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "running", Input: "main.go"})
-	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "done", Input: "main.go"})
+	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "done", Detail: "42 lines"})
 	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "running", Input: "go test"})
-	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "error", Input: "go test", Detail: "exit 1"})
+	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "error", Detail: "exit 1"})
 
 	got := tracker.renderFinal()
 	if !strings.Contains(got, "——————————————————") {
@@ -242,7 +242,10 @@ func TestToolTrackerRenderFinal(t *testing.T) {
 		t.Error("renderFinal() missing tool names")
 	}
 	if !strings.Contains(got, "main.go") {
-		t.Error("renderFinal() missing tool input")
+		t.Error("renderFinal() missing tool input (preserved from start)")
+	}
+	if !strings.Contains(got, "42 lines") {
+		t.Error("renderFinal() missing result detail")
 	}
 	if !strings.Contains(got, "exit 1") {
 		t.Error("renderFinal() missing error detail")
@@ -302,25 +305,25 @@ func TestRenderToolRecord(t *testing.T) {
 		wantAbsent []string
 	}{
 		{
-			name:      "done with input",
-			rec:       toolRecord{Tool: "bash", Input: "ls -la", Status: "done", Duration: 500 * time.Millisecond},
-			wantParts: []string{"✅", "⚡", "bash", "ls -la", "500ms"},
+			name:      "done with input and detail",
+			rec:       toolRecord{Tool: "bash", Input: "ls -la", Status: "done", Detail: "3 files", Duration: 500 * time.Millisecond},
+			wantParts: []string{"✅", "⚡", "bash", "ls -la", "→ 3 files", "500ms"},
 		},
 		{
 			name:      "done seconds",
-			rec:       toolRecord{Tool: "read", Input: "main.go", Status: "done", Duration: 2500 * time.Millisecond},
-			wantParts: []string{"✅", "📖", "read", "main.go", "2.5s"},
+			rec:       toolRecord{Tool: "read", Input: "main.go", Status: "done", Detail: "42 lines", Duration: 2500 * time.Millisecond},
+			wantParts: []string{"✅", "📖", "read", "main.go", "→ 42 lines", "2.5s"},
 		},
 		{
 			name:      "error with detail",
 			rec:       toolRecord{Tool: "bash", Input: "rm -rf /", Status: "error", Detail: "permission denied", Duration: time.Second},
-			wantParts: []string{"❌", "bash", "permission denied"},
+			wantParts: []string{"❌", "bash", "rm -rf /", "→ permission denied"},
 		},
 		{
-			name:       "done no input",
+			name:       "done no input no detail",
 			rec:        toolRecord{Tool: "search", Status: "done", Duration: 100 * time.Millisecond},
 			wantParts:  []string{"✅", "🔍", "search", "100ms"},
-			wantAbsent: []string{": "},
+			wantAbsent: []string{": ", "→"},
 		},
 	}
 


### PR DESCRIPTION
## Summary

- **Tool history during streaming**: Replace single-tool indicator with `toolTracker` that accumulates all tool invocations. Shows active tool with ⏳ spinner and completed tools with ✅/❌ status.
- **Minimum display duration**: Tools stay visible for at least 2 seconds after completion so fast tools don't flash and disappear.
- **Tool summary in final message**: Append a `——————` separated tool summary to the final response so users can see what was done in each turn.
- **Rich tool info**: Each record shows tool emoji, name, input (what it did), result summary (→ outcome), and elapsed time.
- **Webfetch nil Node fix**: Handle readability returning nil `Node` for JS-heavy/bot-blocked pages (e.g. Google Search) — return a helpful fallback message instead of crashing.

Example final message:
```
Here's the test results...

——————————————————
✅ 📖 read: main.go → 42 lines (312ms)
✅ ⚡ bash: go test ./... → ok (2.1s)
❌ ⚡ bash: rm -rf / → permission denied (1.0s)
```

## Test plan

- [x] All existing tests pass (`go test -race ./...`)
- [x] New tests for `toolTracker` (start, finish, error, multiple tools, min display, overwrite)
- [x] New tests for `renderToolRecord`, `renderFinal`, `formatDuration`, `truncate`, `emojiFor`
- [x] New tests for `summarizeToolResult` in runner package
- [x] New tests for webfetch nil-Node handling with httptest server
- [ ] Manual test: send message in Telegram that triggers tool use, verify streaming shows tools and final message includes summary