### PR TITLE
Telegram: image input support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Two interfaces: **interactive CLI chat** and **gateway daemon** (Telegram bot vi
 - Interactive CLI chat with Bubble Tea TUI and streaming responses
 - Telegram bot via long polling (no webhook, no public IP needed)
   - Streaming drafts (Bot API 9.3+) for smooth animated responses
+  - Image input support (send photos for vision-based analysis)
   - Group support with configurable `group_mode` (mention/always/disabled)
   - Access control via `allowed_ids`
 - Notification system with multi-backend dispatcher

--- a/agent/pool.go
+++ b/agent/pool.go
@@ -446,10 +446,9 @@ func (p *Pool) History(sessionID string) []runner.RPCEvent {
 }
 
 // Chat sends a message in a session and streams back events.
-// message is string (text-only) or []aitypes.ContentBlock (multimodal).
 // Internally: gets/creates runner, passes history, collects events,
 // appends to session log, streams to caller.
-func (p *Pool) Chat(ctx context.Context, sessionID string, message any, opts ...ChatOption) <-chan runner.Event {
+func (p *Pool) Chat(ctx context.Context, sessionID string, message runner.MessageContent, opts ...ChatOption) <-chan runner.Event {
 	out := make(chan runner.Event, 100)
 
 	var co chatOptions

--- a/agent/pool.go
+++ b/agent/pool.go
@@ -446,9 +446,10 @@ func (p *Pool) History(sessionID string) []runner.RPCEvent {
 }
 
 // Chat sends a message in a session and streams back events.
+// message is string (text-only) or []aitypes.ContentBlock (multimodal).
 // Internally: gets/creates runner, passes history, collects events,
 // appends to session log, streams to caller.
-func (p *Pool) Chat(ctx context.Context, sessionID string, message string, opts ...ChatOption) <-chan runner.Event {
+func (p *Pool) Chat(ctx context.Context, sessionID string, message any, opts ...ChatOption) <-chan runner.Event {
 	out := make(chan runner.Event, 100)
 
 	var co chatOptions
@@ -465,7 +466,8 @@ func (p *Pool) Chat(ctx context.Context, sessionID string, message string, opts 
 		return out
 	}
 
-	p.log.Debug("chat started", "session_id", sessionID, "history_len", len(sess.Events), "message_len", len(message))
+	msgText := runner.MessageText(message)
+	p.log.Debug("chat started", "session_id", sessionID, "history_len", len(sess.Events), "message_len", len(msgText))
 
 	// Auto-compact if the session has grown too large.
 	if p.NeedsCompaction(sessionID) {
@@ -496,12 +498,12 @@ func (p *Pool) Chat(ctx context.Context, sessionID string, message string, opts 
 	p.touchLastActive(sessionID, now)
 
 	// Store user message so stateless runners can reconstruct the conversation.
-	userEvt := runner.RPCEvent{Type: "user_message", Summary: message}
+	userEvt := runner.UserMessageToRPCEvent(message)
 	p.mu.Lock()
 	sess.Events = append(sess.Events, userEvt)
 	// Auto-title: use the first user message as the session title.
-	if sess.Info.Title == "" && len(message) > 0 {
-		title := message
+	if sess.Info.Title == "" && len(msgText) > 0 {
+		title := msgText
 		if len(title) > 60 {
 			// Truncate at word boundary.
 			if idx := strings.LastIndex(title[:60], " "); idx > 20 {

--- a/agent/pool_test.go
+++ b/agent/pool_test.go
@@ -28,7 +28,7 @@ func newMockRunner(events []runner.Event) *mockRunner {
 	}
 }
 
-func (m *mockRunner) Chat(_ context.Context, _ []runner.RPCEvent, _ any) <-chan runner.Event {
+func (m *mockRunner) Chat(_ context.Context, _ []runner.RPCEvent, _ runner.MessageContent) <-chan runner.Event {
 	m.mu.Lock()
 	m.lastActivity = time.Now()
 	events := m.events

--- a/agent/pool_test.go
+++ b/agent/pool_test.go
@@ -28,7 +28,7 @@ func newMockRunner(events []runner.Event) *mockRunner {
 	}
 }
 
-func (m *mockRunner) Chat(_ context.Context, _ []runner.RPCEvent, _ string) <-chan runner.Event {
+func (m *mockRunner) Chat(_ context.Context, _ []runner.RPCEvent, _ any) <-chan runner.Event {
 	m.mu.Lock()
 	m.lastActivity = time.Now()
 	events := m.events

--- a/agent/runner/gorunner.go
+++ b/agent/runner/gorunner.go
@@ -275,16 +275,16 @@ func decodeUserContent(evt RPCEvent) any {
 	if len(evt.Content) == 0 {
 		return evt.Summary
 	}
-	var blocks []contentBlockJSON
+	var blocks []ContentBlockJSON
 	if err := json.Unmarshal(evt.Content, &blocks); err != nil {
 		return evt.Summary
 	}
 	content := make([]aitypes.ContentBlock, 0, len(blocks))
 	for _, b := range blocks {
 		switch b.Kind {
-		case "text":
+		case BlockKindText:
 			content = append(content, aitypes.TextContent{Text: b.Text})
-		case "image":
+		case BlockKindImage:
 			content = append(content, aitypes.ImageContent{Data: b.Data, MimeType: b.MimeType})
 		}
 	}

--- a/agent/runner/gorunner.go
+++ b/agent/runner/gorunner.go
@@ -92,7 +92,8 @@ func NewGoRunner(_ context.Context, cfg GoRunnerConfig) (*GoRunner, error) {
 }
 
 // Chat converts history, runs the Engine agent loop, and forwards events to the returned channel.
-func (r *GoRunner) Chat(ctx context.Context, history []RPCEvent, message string) <-chan Event {
+// message is string (text-only) or []aitypes.ContentBlock (multimodal).
+func (r *GoRunner) Chat(ctx context.Context, history []RPCEvent, message any) <-chan Event {
 	out := make(chan Event, 100)
 
 	r.mu.Lock()
@@ -269,6 +270,31 @@ func summarizeToolInput(toolName string, args map[string]any) string {
 	return ""
 }
 
+// decodeUserContent reconstructs the user message content from an RPCEvent.
+// Returns []aitypes.ContentBlock if the event has multimodal content, or string otherwise.
+func decodeUserContent(evt RPCEvent) any {
+	if len(evt.Content) == 0 {
+		return evt.Summary
+	}
+	var blocks []contentBlockJSON
+	if err := json.Unmarshal(evt.Content, &blocks); err != nil {
+		return evt.Summary
+	}
+	content := make([]aitypes.ContentBlock, 0, len(blocks))
+	for _, b := range blocks {
+		switch b.Kind {
+		case "text":
+			content = append(content, aitypes.TextContent{Text: b.Text})
+		case "image":
+			content = append(content, aitypes.ImageContent{Data: b.Data, MimeType: b.MimeType})
+		}
+	}
+	if len(content) == 0 {
+		return evt.Summary
+	}
+	return content
+}
+
 // convertHistory rebuilds []aitypes.Message from RPCEvent history.
 func convertHistory(events []RPCEvent) []aitypes.Message {
 	var messages []aitypes.Message
@@ -305,7 +331,7 @@ func convertHistory(events []RPCEvent) []aitypes.Message {
 		case RPCEventUserMessage:
 			flushToolCalls()
 			flush()
-			messages = append(messages, aitypes.UserMessage{Content: evt.Summary})
+			messages = append(messages, aitypes.UserMessage{Content: decodeUserContent(evt)})
 
 		case RPCEventMessageUpdate:
 			if evt.Summary != "" {

--- a/agent/runner/gorunner.go
+++ b/agent/runner/gorunner.go
@@ -92,8 +92,7 @@ func NewGoRunner(_ context.Context, cfg GoRunnerConfig) (*GoRunner, error) {
 }
 
 // Chat converts history, runs the Engine agent loop, and forwards events to the returned channel.
-// message is string (text-only) or []aitypes.ContentBlock (multimodal).
-func (r *GoRunner) Chat(ctx context.Context, history []RPCEvent, message any) <-chan Event {
+func (r *GoRunner) Chat(ctx context.Context, history []RPCEvent, message MessageContent) <-chan Event {
 	out := make(chan Event, 100)
 
 	r.mu.Lock()

--- a/agent/runner/runner.go
+++ b/agent/runner/runner.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	aitypes "github.com/vaayne/anna/ai/types"
@@ -36,6 +37,7 @@ type RPCEvent struct {
 	Error                 string          `json:"error,omitempty"`
 	Tool                  string          `json:"tool,omitempty"`
 	Summary               string          `json:"summary,omitempty"`
+	Content               json.RawMessage `json:"content,omitempty"` // multimodal content blocks (images + text)
 }
 
 // AssistantMessageEvent represents the inner event for text deltas.
@@ -64,8 +66,10 @@ type Event struct {
 // Runner runs prompts against an AI backend.
 // It is stateless — it receives full history each call and must
 // reconstruct context from it.
+// The message parameter is string (text-only) or []aitypes.ContentBlock
+// (multimodal, e.g. text + images).
 type Runner interface {
-	Chat(ctx context.Context, history []RPCEvent, message string) <-chan Event
+	Chat(ctx context.Context, history []RPCEvent, message any) <-chan Event
 }
 
 // NewRunnerFunc creates a new Runner instance for the given model ID.
@@ -75,10 +79,10 @@ type NewRunnerFunc func(ctx context.Context, model string) (Runner, error)
 // HandlerFunc is an adapter to allow the use of ordinary functions as Runners.
 // If f is a function with the appropriate signature, HandlerFunc(f) is a Runner
 // that calls f.
-type HandlerFunc func(ctx context.Context, history []RPCEvent, message string) <-chan Event
+type HandlerFunc func(ctx context.Context, history []RPCEvent, message any) <-chan Event
 
 // Chat calls f(ctx, history, message).
-func (f HandlerFunc) Chat(ctx context.Context, history []RPCEvent, message string) <-chan Event {
+func (f HandlerFunc) Chat(ctx context.Context, history []RPCEvent, message any) <-chan Event {
 	return f(ctx, history, message)
 }
 
@@ -99,6 +103,58 @@ type Aliver interface {
 // ActivityTracker is an optional interface for runners that track last activity.
 type ActivityTracker interface {
 	LastActivity() time.Time
+}
+
+// contentBlockJSON is the JSON-serializable representation of a content block.
+type contentBlockJSON struct {
+	Kind     string `json:"kind"`                // "text" or "image"
+	Text     string `json:"text,omitempty"`      // for text blocks
+	Data     string `json:"data,omitempty"`      // base64 for image blocks
+	MimeType string `json:"mime_type,omitempty"` // for image blocks
+}
+
+// UserMessageToRPCEvent creates an RPCEvent for a user message.
+// message is string (text-only) or []aitypes.ContentBlock (multimodal).
+func UserMessageToRPCEvent(message any) RPCEvent {
+	evt := RPCEvent{Type: RPCEventUserMessage}
+	switch m := message.(type) {
+	case string:
+		evt.Summary = m
+	case []aitypes.ContentBlock:
+		var blocks []contentBlockJSON
+		for _, b := range m {
+			switch b := b.(type) {
+			case aitypes.TextContent:
+				blocks = append(blocks, contentBlockJSON{Kind: "text", Text: b.Text})
+				if evt.Summary == "" {
+					evt.Summary = b.Text
+				}
+			case aitypes.ImageContent:
+				blocks = append(blocks, contentBlockJSON{Kind: "image", Data: b.Data, MimeType: b.MimeType})
+			}
+		}
+		evt.Content, _ = json.Marshal(blocks)
+	default:
+		evt.Summary = fmt.Sprintf("%v", message)
+	}
+	return evt
+}
+
+// MessageText extracts the text portion of a message (string or []ContentBlock).
+func MessageText(message any) string {
+	switch m := message.(type) {
+	case string:
+		return m
+	case []aitypes.ContentBlock:
+		for _, b := range m {
+			if t, ok := b.(aitypes.TextContent); ok {
+				return t.Text
+			}
+		}
+		return ""
+	default:
+		return fmt.Sprintf("%v", message)
+	}
 }
 
 // TextDeltaToRPCEvent converts a text delta string to an RPCEvent for storage.

--- a/agent/runner/runner.go
+++ b/agent/runner/runner.go
@@ -28,6 +28,12 @@ const (
 	RPCEventAgentEnd      = "agent_end"
 )
 
+// Content block kind constants used in ContentBlockJSON serialization.
+const (
+	BlockKindText  = "text"
+	BlockKindImage = "image"
+)
+
 // RPCEvent represents an event in the runner protocol.
 // Pool stores these verbatim as the session history.
 type RPCEvent struct {
@@ -115,8 +121,8 @@ type ActivityTracker interface {
 	LastActivity() time.Time
 }
 
-// contentBlockJSON is the JSON-serializable representation of a content block.
-type contentBlockJSON struct {
+// ContentBlockJSON is the JSON-serializable representation of a content block.
+type ContentBlockJSON struct {
 	Kind     string `json:"kind"`                // "text" or "image"
 	Text     string `json:"text,omitempty"`      // for text blocks
 	Data     string `json:"data,omitempty"`      // base64 for image blocks
@@ -130,16 +136,16 @@ func UserMessageToRPCEvent(message MessageContent) RPCEvent {
 	case string:
 		evt.Summary = m
 	case []aitypes.ContentBlock:
-		var blocks []contentBlockJSON
+		var blocks []ContentBlockJSON
 		for _, b := range m {
 			switch b := b.(type) {
 			case aitypes.TextContent:
-				blocks = append(blocks, contentBlockJSON{Kind: "text", Text: b.Text})
+				blocks = append(blocks, ContentBlockJSON{Kind: BlockKindText, Text: b.Text})
 				if evt.Summary == "" {
 					evt.Summary = b.Text
 				}
 			case aitypes.ImageContent:
-				blocks = append(blocks, contentBlockJSON{Kind: "image", Data: b.Data, MimeType: b.MimeType})
+				blocks = append(blocks, ContentBlockJSON{Kind: BlockKindImage, Data: b.Data, MimeType: b.MimeType})
 			}
 		}
 		if data, err := json.Marshal(blocks); err != nil {
@@ -195,12 +201,7 @@ func ToolCallToRPCEvent(call aitypes.ToolCall) RPCEvent {
 
 // ToolResultToRPCEvent converts a tool result to an RPCEvent for history storage.
 func ToolResultToRPCEvent(result aitypes.ToolResultMessage) RPCEvent {
-	var text string
-	for _, block := range result.Content {
-		if tc, ok := block.(aitypes.TextContent); ok {
-			text += tc.Text
-		}
-	}
+	text := aitypes.FlattenText(result.Content)
 	contentJSON, _ := json.Marshal(text)
 	evt := RPCEvent{
 		Type:   RPCEventToolResult,

--- a/agent/runner/runner.go
+++ b/agent/runner/runner.go
@@ -54,10 +54,17 @@ type ToolUseEvent struct {
 	Detail string // error detail or result summary (for "error" status)
 }
 
+// ImageEvent carries a base64-encoded image to be sent to the channel.
+type ImageEvent struct {
+	Data     string // base64 encoded
+	MimeType string // e.g. "image/jpeg"
+}
+
 // Event is the consumer-facing stream event. Channels read these from the
 // stream returned by Pool.Chat().
 type Event struct {
 	Text    string
+	Image   *ImageEvent
 	ToolUse *ToolUseEvent
 	Store   *RPCEvent // if set, Pool appends to session history
 	Err     error

--- a/agent/runner/runner.go
+++ b/agent/runner/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"time"
 
 	aitypes "github.com/vaayne/anna/ai/types"
@@ -70,13 +71,15 @@ type Event struct {
 	Err     error
 }
 
+// MessageContent is the type for user messages passed through the runner pipeline.
+// It is either string (text-only) or []aitypes.ContentBlock (multimodal, e.g. text + images).
+type MessageContent = any
+
 // Runner runs prompts against an AI backend.
 // It is stateless — it receives full history each call and must
 // reconstruct context from it.
-// The message parameter is string (text-only) or []aitypes.ContentBlock
-// (multimodal, e.g. text + images).
 type Runner interface {
-	Chat(ctx context.Context, history []RPCEvent, message any) <-chan Event
+	Chat(ctx context.Context, history []RPCEvent, message MessageContent) <-chan Event
 }
 
 // NewRunnerFunc creates a new Runner instance for the given model ID.
@@ -86,10 +89,10 @@ type NewRunnerFunc func(ctx context.Context, model string) (Runner, error)
 // HandlerFunc is an adapter to allow the use of ordinary functions as Runners.
 // If f is a function with the appropriate signature, HandlerFunc(f) is a Runner
 // that calls f.
-type HandlerFunc func(ctx context.Context, history []RPCEvent, message any) <-chan Event
+type HandlerFunc func(ctx context.Context, history []RPCEvent, message MessageContent) <-chan Event
 
 // Chat calls f(ctx, history, message).
-func (f HandlerFunc) Chat(ctx context.Context, history []RPCEvent, message any) <-chan Event {
+func (f HandlerFunc) Chat(ctx context.Context, history []RPCEvent, message MessageContent) <-chan Event {
 	return f(ctx, history, message)
 }
 
@@ -121,8 +124,7 @@ type contentBlockJSON struct {
 }
 
 // UserMessageToRPCEvent creates an RPCEvent for a user message.
-// message is string (text-only) or []aitypes.ContentBlock (multimodal).
-func UserMessageToRPCEvent(message any) RPCEvent {
+func UserMessageToRPCEvent(message MessageContent) RPCEvent {
 	evt := RPCEvent{Type: RPCEventUserMessage}
 	switch m := message.(type) {
 	case string:
@@ -140,25 +142,24 @@ func UserMessageToRPCEvent(message any) RPCEvent {
 				blocks = append(blocks, contentBlockJSON{Kind: "image", Data: b.Data, MimeType: b.MimeType})
 			}
 		}
-		evt.Content, _ = json.Marshal(blocks)
+		if data, err := json.Marshal(blocks); err != nil {
+			slog.Warn("failed to marshal multimodal content", "error", err)
+		} else {
+			evt.Content = data
+		}
 	default:
 		evt.Summary = fmt.Sprintf("%v", message)
 	}
 	return evt
 }
 
-// MessageText extracts the text portion of a message (string or []ContentBlock).
-func MessageText(message any) string {
+// MessageText extracts and joins all text from a message.
+func MessageText(message MessageContent) string {
 	switch m := message.(type) {
 	case string:
 		return m
 	case []aitypes.ContentBlock:
-		for _, b := range m {
-			if t, ok := b.(aitypes.TextContent); ok {
-				return t.Text
-			}
-		}
-		return ""
+		return aitypes.FlattenText(m)
 	default:
 		return fmt.Sprintf("%v", message)
 	}

--- a/agent/runner/runner_test.go
+++ b/agent/runner/runner_test.go
@@ -6,9 +6,9 @@ import (
 )
 
 func TestHandlerFunc(t *testing.T) {
-	fn := HandlerFunc(func(ctx context.Context, history []RPCEvent, message string) <-chan Event {
+	fn := HandlerFunc(func(ctx context.Context, history []RPCEvent, message any) <-chan Event {
 		ch := make(chan Event, 1)
-		ch <- Event{Text: "hello from handler: " + message}
+		ch <- Event{Text: "hello from handler: " + MessageText(message)}
 		close(ch)
 		return ch
 	})

--- a/agent/runner/runner_test.go
+++ b/agent/runner/runner_test.go
@@ -2,11 +2,14 @@ package runner
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
+
+	aitypes "github.com/vaayne/anna/ai/types"
 )
 
 func TestHandlerFunc(t *testing.T) {
-	fn := HandlerFunc(func(ctx context.Context, history []RPCEvent, message any) <-chan Event {
+	fn := HandlerFunc(func(ctx context.Context, history []RPCEvent, message MessageContent) <-chan Event {
 		ch := make(chan Event, 1)
 		ch <- Event{Text: "hello from handler: " + MessageText(message)}
 		close(ch)
@@ -23,6 +26,122 @@ func TestHandlerFunc(t *testing.T) {
 	}
 	if evt.Text != "hello from handler: test" {
 		t.Errorf("text = %q, want %q", evt.Text, "hello from handler: test")
+	}
+}
+
+func TestMessageTextString(t *testing.T) {
+	got := MessageText("hello world")
+	if got != "hello world" {
+		t.Errorf("MessageText(string) = %q, want %q", got, "hello world")
+	}
+}
+
+func TestMessageTextMultimodal(t *testing.T) {
+	blocks := []aitypes.ContentBlock{
+		aitypes.TextContent{Text: "describe"},
+		aitypes.ImageContent{Data: "abc", MimeType: "image/png"},
+		aitypes.TextContent{Text: "this image"},
+	}
+	got := MessageText(blocks)
+	want := "describe this image"
+	if got != want {
+		t.Errorf("MessageText(multimodal) = %q, want %q", got, want)
+	}
+}
+
+func TestMessageTextEmpty(t *testing.T) {
+	blocks := []aitypes.ContentBlock{
+		aitypes.ImageContent{Data: "abc", MimeType: "image/png"},
+	}
+	got := MessageText(blocks)
+	if got != "" {
+		t.Errorf("MessageText(image-only) = %q, want empty", got)
+	}
+}
+
+func TestUserMessageToRPCEventString(t *testing.T) {
+	evt := UserMessageToRPCEvent("hello")
+	if evt.Type != RPCEventUserMessage {
+		t.Errorf("Type = %q, want %q", evt.Type, RPCEventUserMessage)
+	}
+	if evt.Summary != "hello" {
+		t.Errorf("Summary = %q, want %q", evt.Summary, "hello")
+	}
+	if evt.Content != nil {
+		t.Errorf("Content should be nil for text-only, got %s", string(evt.Content))
+	}
+}
+
+func TestUserMessageToRPCEventMultimodal(t *testing.T) {
+	blocks := []aitypes.ContentBlock{
+		aitypes.TextContent{Text: "caption"},
+		aitypes.ImageContent{Data: "base64data", MimeType: "image/jpeg"},
+	}
+	evt := UserMessageToRPCEvent(blocks)
+
+	if evt.Type != RPCEventUserMessage {
+		t.Errorf("Type = %q, want %q", evt.Type, RPCEventUserMessage)
+	}
+	if evt.Summary != "caption" {
+		t.Errorf("Summary = %q, want %q", evt.Summary, "caption")
+	}
+	if evt.Content == nil {
+		t.Fatal("Content should not be nil for multimodal")
+	}
+
+	var stored []contentBlockJSON
+	if err := json.Unmarshal(evt.Content, &stored); err != nil {
+		t.Fatalf("unmarshal Content: %v", err)
+	}
+	if len(stored) != 2 {
+		t.Fatalf("len(stored) = %d, want 2", len(stored))
+	}
+	if stored[0].Kind != "text" || stored[0].Text != "caption" {
+		t.Errorf("stored[0] = %+v, want text/caption", stored[0])
+	}
+	if stored[1].Kind != "image" || stored[1].Data != "base64data" {
+		t.Errorf("stored[1] = %+v, want image/base64data", stored[1])
+	}
+}
+
+func TestDecodeUserContentRoundTrip(t *testing.T) {
+	original := []aitypes.ContentBlock{
+		aitypes.TextContent{Text: "hello"},
+		aitypes.ImageContent{Data: "imgdata", MimeType: "image/png"},
+	}
+
+	// Encode
+	evt := UserMessageToRPCEvent(original)
+
+	// Decode
+	decoded := decodeUserContent(evt)
+	blocks, ok := decoded.([]aitypes.ContentBlock)
+	if !ok {
+		t.Fatalf("decodeUserContent returned %T, want []ContentBlock", decoded)
+	}
+	if len(blocks) != 2 {
+		t.Fatalf("len(blocks) = %d, want 2", len(blocks))
+	}
+
+	text, ok := blocks[0].(aitypes.TextContent)
+	if !ok || text.Text != "hello" {
+		t.Errorf("blocks[0] = %+v, want TextContent{Text: hello}", blocks[0])
+	}
+	img, ok := blocks[1].(aitypes.ImageContent)
+	if !ok || img.Data != "imgdata" || img.MimeType != "image/png" {
+		t.Errorf("blocks[1] = %+v, want ImageContent{imgdata, image/png}", blocks[1])
+	}
+}
+
+func TestDecodeUserContentTextOnly(t *testing.T) {
+	evt := UserMessageToRPCEvent("just text")
+	decoded := decodeUserContent(evt)
+	s, ok := decoded.(string)
+	if !ok {
+		t.Fatalf("decodeUserContent returned %T, want string", decoded)
+	}
+	if s != "just text" {
+		t.Errorf("decoded = %q, want %q", s, "just text")
 	}
 }
 

--- a/agent/runner/runner_test.go
+++ b/agent/runner/runner_test.go
@@ -89,7 +89,7 @@ func TestUserMessageToRPCEventMultimodal(t *testing.T) {
 		t.Fatal("Content should not be nil for multimodal")
 	}
 
-	var stored []contentBlockJSON
+	var stored []ContentBlockJSON
 	if err := json.Unmarshal(evt.Content, &stored); err != nil {
 		t.Fatalf("unmarshal Content: %v", err)
 	}

--- a/agent/store/store.go
+++ b/agent/store/store.go
@@ -96,6 +96,12 @@ type piTextContent struct {
 	Text string `json:"text"`
 }
 
+type piImageContent struct {
+	Type     string `json:"type"`
+	Data     string `json:"data"`
+	MimeType string `json:"mimeType"`
+}
+
 type piToolCall struct {
 	Type      string         `json:"type"`
 	ID        string         `json:"id"`
@@ -499,8 +505,12 @@ func rpcEventToEntry(evt runner.RPCEvent, parentID string) (sessionEntry, bool) 
 
 	switch evt.Type {
 	case runner.RPCEventUserMessage:
-		content := evt.Summary
-		contentJSON, _ := json.Marshal([]piTextContent{{Type: "text", Text: content}})
+		var contentJSON json.RawMessage
+		if len(evt.Content) > 0 {
+			contentJSON = userContentToPi(evt.Content, evt.Summary)
+		} else {
+			contentJSON, _ = json.Marshal([]piTextContent{{Type: "text", Text: evt.Summary}})
+		}
 		msg := piUserMessage{
 			Role:      "user",
 			Content:   contentJSON,
@@ -591,11 +601,9 @@ func entryToRPCEvents(entry sessionEntry) []runner.RPCEvent {
 		if err := json.Unmarshal(entry.Message, &msg); err != nil {
 			return nil
 		}
-		text := extractUserText(msg.Content)
-		return []runner.RPCEvent{{
-			Type:    runner.RPCEventUserMessage,
-			Summary: text,
-		}}
+		evt := runner.RPCEvent{Type: runner.RPCEventUserMessage}
+		evt.Summary, evt.Content = extractUserContent(msg.Content)
+		return []runner.RPCEvent{evt}
 
 	case "assistant":
 		var msg piAssistantMessage
@@ -645,15 +653,120 @@ func entryToRPCEvents(entry sessionEntry) []runner.RPCEvent {
 	}
 }
 
-// extractUserText extracts text from Pi user message content (string or content block array).
-func extractUserText(raw json.RawMessage) string {
-	// Try string first.
+// userContentToPi converts runner multimodal content (json.RawMessage of contentBlockJSON)
+// to Pi-format content blocks. Falls back to text-only if parsing fails.
+func userContentToPi(content json.RawMessage, fallbackText string) json.RawMessage {
+	// content is []contentBlockJSON from runner.UserMessageToRPCEvent.
+	var blocks []struct {
+		Kind     string `json:"kind"`
+		Text     string `json:"text,omitempty"`
+		Data     string `json:"data,omitempty"`
+		MimeType string `json:"mime_type,omitempty"`
+	}
+	if err := json.Unmarshal(content, &blocks); err != nil {
+		data, _ := json.Marshal([]piTextContent{{Type: "text", Text: fallbackText}})
+		return data
+	}
+
+	var piBlocks []any
+	for _, b := range blocks {
+		switch b.Kind {
+		case "text":
+			piBlocks = append(piBlocks, piTextContent{Type: "text", Text: b.Text})
+		case "image":
+			piBlocks = append(piBlocks, piImageContent{Type: "image", Data: b.Data, MimeType: b.MimeType})
+		}
+	}
+	if len(piBlocks) == 0 {
+		data, _ := json.Marshal([]piTextContent{{Type: "text", Text: fallbackText}})
+		return data
+	}
+	data, _ := json.Marshal(piBlocks)
+	return data
+}
+
+// extractUserContent extracts text and optional multimodal content from Pi user message content.
+// Returns (summary text, multimodal content as runner json.RawMessage or nil).
+func extractUserContent(raw json.RawMessage) (string, json.RawMessage) {
+	// Try string first (legacy format).
 	var s string
 	if err := json.Unmarshal(raw, &s); err == nil {
-		return s
+		return s, nil
 	}
-	// Try array of content blocks.
-	return extractTextFromContent(raw)
+
+	// Parse content block array.
+	var blocks []json.RawMessage
+	if err := json.Unmarshal(raw, &blocks); err != nil {
+		return "", nil
+	}
+
+	var hasImage bool
+	var textParts []string
+
+	for _, block := range blocks {
+		var peek struct {
+			Type string `json:"type"`
+		}
+		if json.Unmarshal(block, &peek) != nil {
+			continue
+		}
+		switch peek.Type {
+		case "text":
+			var tc piTextContent
+			if json.Unmarshal(block, &tc) == nil && tc.Text != "" {
+				textParts = append(textParts, tc.Text)
+			}
+		case "image":
+			hasImage = true
+		}
+	}
+
+	summary := strings.Join(textParts, "")
+
+	if !hasImage {
+		return summary, nil
+	}
+
+	// Convert Pi blocks to runner contentBlockJSON format for RPCEvent.Content.
+	var runnerBlocks []struct {
+		Kind     string `json:"kind"`
+		Text     string `json:"text,omitempty"`
+		Data     string `json:"data,omitempty"`
+		MimeType string `json:"mime_type,omitempty"`
+	}
+	for _, block := range blocks {
+		var peek struct {
+			Type string `json:"type"`
+		}
+		if json.Unmarshal(block, &peek) != nil {
+			continue
+		}
+		switch peek.Type {
+		case "text":
+			var tc piTextContent
+			if json.Unmarshal(block, &tc) == nil {
+				runnerBlocks = append(runnerBlocks, struct {
+					Kind     string `json:"kind"`
+					Text     string `json:"text,omitempty"`
+					Data     string `json:"data,omitempty"`
+					MimeType string `json:"mime_type,omitempty"`
+				}{Kind: "text", Text: tc.Text})
+			}
+		case "image":
+			var ic piImageContent
+			if json.Unmarshal(block, &ic) == nil {
+				runnerBlocks = append(runnerBlocks, struct {
+					Kind     string `json:"kind"`
+					Text     string `json:"text,omitempty"`
+					Data     string `json:"data,omitempty"`
+					MimeType string `json:"mime_type,omitempty"`
+				}{Kind: "image", Data: ic.Data, MimeType: ic.MimeType})
+			}
+		}
+	}
+
+	contentJSON, _ := json.Marshal(runnerBlocks)
+	return summary, contentJSON
 }
 
 // extractTextFromContent extracts concatenated text from a JSON array of content blocks.

--- a/agent/store/store.go
+++ b/agent/store/store.go
@@ -653,16 +653,10 @@ func entryToRPCEvents(entry sessionEntry) []runner.RPCEvent {
 	}
 }
 
-// userContentToPi converts runner multimodal content (json.RawMessage of contentBlockJSON)
+// userContentToPi converts runner multimodal content (json.RawMessage of ContentBlockJSON)
 // to Pi-format content blocks. Falls back to text-only if parsing fails.
 func userContentToPi(content json.RawMessage, fallbackText string) json.RawMessage {
-	// content is []contentBlockJSON from runner.UserMessageToRPCEvent.
-	var blocks []struct {
-		Kind     string `json:"kind"`
-		Text     string `json:"text,omitempty"`
-		Data     string `json:"data,omitempty"`
-		MimeType string `json:"mime_type,omitempty"`
-	}
+	var blocks []runner.ContentBlockJSON
 	if err := json.Unmarshal(content, &blocks); err != nil {
 		data, _ := json.Marshal([]piTextContent{{Type: "text", Text: fallbackText}})
 		return data
@@ -671,9 +665,9 @@ func userContentToPi(content json.RawMessage, fallbackText string) json.RawMessa
 	var piBlocks []any
 	for _, b := range blocks {
 		switch b.Kind {
-		case "text":
+		case runner.BlockKindText:
 			piBlocks = append(piBlocks, piTextContent{Type: "text", Text: b.Text})
-		case "image":
+		case runner.BlockKindImage:
 			piBlocks = append(piBlocks, piImageContent{Type: "image", Data: b.Data, MimeType: b.MimeType})
 		}
 	}
@@ -700,40 +694,11 @@ func extractUserContent(raw json.RawMessage) (string, json.RawMessage) {
 		return "", nil
 	}
 
+	// Single pass: collect text summary and runner blocks simultaneously.
 	var hasImage bool
 	var textParts []string
+	var runnerBlocks []runner.ContentBlockJSON
 
-	for _, block := range blocks {
-		var peek struct {
-			Type string `json:"type"`
-		}
-		if json.Unmarshal(block, &peek) != nil {
-			continue
-		}
-		switch peek.Type {
-		case "text":
-			var tc piTextContent
-			if json.Unmarshal(block, &tc) == nil && tc.Text != "" {
-				textParts = append(textParts, tc.Text)
-			}
-		case "image":
-			hasImage = true
-		}
-	}
-
-	summary := strings.Join(textParts, "")
-
-	if !hasImage {
-		return summary, nil
-	}
-
-	// Convert Pi blocks to runner contentBlockJSON format for RPCEvent.Content.
-	var runnerBlocks []struct {
-		Kind     string `json:"kind"`
-		Text     string `json:"text,omitempty"`
-		Data     string `json:"data,omitempty"`
-		MimeType string `json:"mime_type,omitempty"`
-	}
 	for _, block := range blocks {
 		var peek struct {
 			Type string `json:"type"`
@@ -745,24 +710,24 @@ func extractUserContent(raw json.RawMessage) (string, json.RawMessage) {
 		case "text":
 			var tc piTextContent
 			if json.Unmarshal(block, &tc) == nil {
-				runnerBlocks = append(runnerBlocks, struct {
-					Kind     string `json:"kind"`
-					Text     string `json:"text,omitempty"`
-					Data     string `json:"data,omitempty"`
-					MimeType string `json:"mime_type,omitempty"`
-				}{Kind: "text", Text: tc.Text})
+				if tc.Text != "" {
+					textParts = append(textParts, tc.Text)
+				}
+				runnerBlocks = append(runnerBlocks, runner.ContentBlockJSON{Kind: runner.BlockKindText, Text: tc.Text})
 			}
 		case "image":
+			hasImage = true
 			var ic piImageContent
 			if json.Unmarshal(block, &ic) == nil {
-				runnerBlocks = append(runnerBlocks, struct {
-					Kind     string `json:"kind"`
-					Text     string `json:"text,omitempty"`
-					Data     string `json:"data,omitempty"`
-					MimeType string `json:"mime_type,omitempty"`
-				}{Kind: "image", Data: ic.Data, MimeType: ic.MimeType})
+				runnerBlocks = append(runnerBlocks, runner.ContentBlockJSON{Kind: runner.BlockKindImage, Data: ic.Data, MimeType: ic.MimeType})
 			}
 		}
+	}
+
+	summary := strings.Join(textParts, "")
+
+	if !hasImage {
+		return summary, nil
 	}
 
 	contentJSON, _ := json.Marshal(runnerBlocks)

--- a/agent/store/store_test.go
+++ b/agent/store/store_test.go
@@ -599,6 +599,161 @@ func TestCompact(t *testing.T) {
 	}
 }
 
+func TestMultimodalUserMessageRoundTrip(t *testing.T) {
+	s := tempStore(t)
+
+	// Build a multimodal RPCEvent (text + image) as produced by runner.UserMessageToRPCEvent.
+	contentBlocks := []struct {
+		Kind     string `json:"kind"`
+		Text     string `json:"text,omitempty"`
+		Data     string `json:"data,omitempty"`
+		MimeType string `json:"mime_type,omitempty"`
+	}{
+		{Kind: "text", Text: "describe this image"},
+		{Kind: "image", Data: "iVBORw0KGgo=", MimeType: "image/png"},
+	}
+	contentJSON, _ := json.Marshal(contentBlocks)
+
+	evt := runner.RPCEvent{
+		Type:    runner.RPCEventUserMessage,
+		Summary: "describe this image",
+		Content: contentJSON,
+	}
+
+	if err := s.Append("s1", evt); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	loaded, err := s.Load("s1")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(loaded))
+	}
+
+	got := loaded[0]
+	if got.Type != runner.RPCEventUserMessage {
+		t.Errorf("Type = %q, want %q", got.Type, runner.RPCEventUserMessage)
+	}
+	if got.Summary != "describe this image" {
+		t.Errorf("Summary = %q, want %q", got.Summary, "describe this image")
+	}
+	if got.Content == nil {
+		t.Fatal("Content should not be nil for multimodal message")
+	}
+
+	// Verify the Content field round-trips correctly.
+	var restored []struct {
+		Kind     string `json:"kind"`
+		Text     string `json:"text,omitempty"`
+		Data     string `json:"data,omitempty"`
+		MimeType string `json:"mime_type,omitempty"`
+	}
+	if err := json.Unmarshal(got.Content, &restored); err != nil {
+		t.Fatalf("unmarshal Content: %v", err)
+	}
+	if len(restored) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(restored))
+	}
+	if restored[0].Kind != "text" || restored[0].Text != "describe this image" {
+		t.Errorf("block 0: %+v", restored[0])
+	}
+	if restored[1].Kind != "image" || restored[1].Data != "iVBORw0KGgo=" || restored[1].MimeType != "image/png" {
+		t.Errorf("block 1: %+v", restored[1])
+	}
+}
+
+func TestMultimodalUserMessagePiFormat(t *testing.T) {
+	s := tempStore(t)
+
+	contentBlocks := []struct {
+		Kind     string `json:"kind"`
+		Text     string `json:"text,omitempty"`
+		Data     string `json:"data,omitempty"`
+		MimeType string `json:"mime_type,omitempty"`
+	}{
+		{Kind: "text", Text: "caption"},
+		{Kind: "image", Data: "base64data", MimeType: "image/jpeg"},
+	}
+	contentJSON, _ := json.Marshal(contentBlocks)
+
+	evt := runner.RPCEvent{
+		Type:    runner.RPCEventUserMessage,
+		Summary: "caption",
+		Content: contentJSON,
+	}
+	if err := s.Append("s1", evt); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	// Read raw file and verify Pi format includes image block.
+	p := s.resolve("s1")
+	data, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected at least 2 lines, got %d", len(lines))
+	}
+
+	var entry sessionEntry
+	if err := json.Unmarshal([]byte(lines[1]), &entry); err != nil {
+		t.Fatalf("unmarshal entry: %v", err)
+	}
+
+	var msg piUserMessage
+	if err := json.Unmarshal(entry.Message, &msg); err != nil {
+		t.Fatalf("unmarshal message: %v", err)
+	}
+
+	// Content should be an array with both text and image blocks.
+	var blocks []json.RawMessage
+	if err := json.Unmarshal(msg.Content, &blocks); err != nil {
+		t.Fatalf("unmarshal content array: %v", err)
+	}
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 content blocks, got %d", len(blocks))
+	}
+
+	// Verify image block is present in Pi format.
+	var imgBlock piImageContent
+	if err := json.Unmarshal(blocks[1], &imgBlock); err != nil {
+		t.Fatalf("unmarshal image block: %v", err)
+	}
+	if imgBlock.Type != "image" || imgBlock.Data != "base64data" || imgBlock.MimeType != "image/jpeg" {
+		t.Errorf("image block: %+v", imgBlock)
+	}
+}
+
+func TestTextOnlyUserMessageNoContent(t *testing.T) {
+	s := tempStore(t)
+
+	// Text-only message should not get a Content field after round-trip.
+	evt := runner.RPCEvent{
+		Type:    runner.RPCEventUserMessage,
+		Summary: "just text",
+	}
+	if err := s.Append("s1", evt); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	loaded, err := s.Load("s1")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(loaded))
+	}
+	if loaded[0].Content != nil {
+		t.Errorf("Content should be nil for text-only, got %s", string(loaded[0].Content))
+	}
+	if loaded[0].Summary != "just text" {
+		t.Errorf("Summary = %q, want %q", loaded[0].Summary, "just text")
+	}
+}
+
 func TestCompactNonexistent(t *testing.T) {
 	s := tempStore(t)
 	_, err := s.Compact("nope", "summary", 5)

--- a/ai/providers/anthropic/convert_messages.go
+++ b/ai/providers/anthropic/convert_messages.go
@@ -29,8 +29,11 @@ func userContentBlocks(content any) []sdk.ContentBlockParamUnion {
 	case []types.ContentBlock:
 		blocks := make([]sdk.ContentBlockParamUnion, 0, len(c))
 		for _, block := range c {
-			if b, ok := block.(types.TextContent); ok {
+			switch b := block.(type) {
+			case types.TextContent:
 				blocks = append(blocks, sdk.NewTextBlock(b.Text))
+			case types.ImageContent:
+				blocks = append(blocks, sdk.NewImageBlockBase64(b.MimeType, b.Data))
 			}
 		}
 		return blocks

--- a/ai/providers/openai-response/convert_messages.go
+++ b/ai/providers/openai-response/convert_messages.go
@@ -23,7 +23,7 @@ func convertMessages(ctx types.Context) responses.ResponseInputParam {
 			items = append(items, responses.ResponseInputItemUnionParam{
 				OfFunctionCallOutput: &responses.ResponseInputItemFunctionCallOutputParam{
 					CallID: m.ToolCallID,
-					Output: flattenToolResult(m.Content),
+					Output: types.FlattenText(m.Content),
 				},
 			})
 		}
@@ -90,10 +90,9 @@ func userMessage(content any) responses.ResponseInputItemUnionParam {
 			case types.TextContent:
 				parts = append(parts, responses.ResponseInputContentParamOfInputText(b.Text))
 			case types.ImageContent:
-				dataURI := "data:" + b.MimeType + ";base64," + b.Data
 				img := responses.ResponseInputContentUnionParam{
 					OfInputImage: &responses.ResponseInputImageParam{
-						ImageURL: param.NewOpt(dataURI),
+						ImageURL: param.NewOpt(b.DataURI()),
 					},
 				}
 				parts = append(parts, img)
@@ -110,8 +109,4 @@ func userMessage(content any) responses.ResponseInputItemUnionParam {
 	default:
 		return textMsg(fmt.Sprintf("%v", content))
 	}
-}
-
-func flattenToolResult(content []types.ContentBlock) string {
-	return types.FlattenText(content)
 }

--- a/ai/providers/openai-response/convert_messages.go
+++ b/ai/providers/openai-response/convert_messages.go
@@ -81,8 +81,8 @@ func userMessage(content any) responses.ResponseInputItemUnionParam {
 	case string:
 		return textMsg(c)
 	case []types.ContentBlock:
-		if !hasImage(c) {
-			return textMsg(flattenText(c))
+		if !types.HasImage(c) {
+			return textMsg(types.FlattenText(c))
 		}
 		parts := make(responses.ResponseInputMessageContentListParam, 0, len(c))
 		for _, block := range c {
@@ -112,25 +112,6 @@ func userMessage(content any) responses.ResponseInputItemUnionParam {
 	}
 }
 
-func hasImage(blocks []types.ContentBlock) bool {
-	for _, b := range blocks {
-		if _, ok := b.(types.ImageContent); ok {
-			return true
-		}
-	}
-	return false
-}
-
-func flattenText(blocks []types.ContentBlock) string {
-	parts := make([]string, 0, len(blocks))
-	for _, block := range blocks {
-		if t, ok := block.(types.TextContent); ok && t.Text != "" {
-			parts = append(parts, t.Text)
-		}
-	}
-	return strings.Join(parts, " ")
-}
-
 func flattenToolResult(content []types.ContentBlock) string {
-	return flattenText(content)
+	return types.FlattenText(content)
 }

--- a/ai/providers/openai-response/convert_messages.go
+++ b/ai/providers/openai-response/convert_messages.go
@@ -16,14 +16,7 @@ func convertMessages(ctx types.Context) responses.ResponseInputParam {
 	for _, msg := range ctx.Messages {
 		switch m := msg.(type) {
 		case types.UserMessage:
-			items = append(items, responses.ResponseInputItemUnionParam{
-				OfMessage: &responses.EasyInputMessageParam{
-					Role: responses.EasyInputMessageRoleUser,
-					Content: responses.EasyInputMessageContentUnionParam{
-						OfString: param.NewOpt(userContent(m.Content)),
-					},
-				},
-			})
+			items = append(items, userMessage(m.Content))
 		case types.AssistantMessage:
 			items = append(items, convertAssistantMessage(m)...)
 		case types.ToolResultMessage:
@@ -72,29 +65,72 @@ func convertAssistantMessage(m types.AssistantMessage) responses.ResponseInputPa
 	return items
 }
 
-func userContent(content any) string {
+func userMessage(content any) responses.ResponseInputItemUnionParam {
+	textMsg := func(s string) responses.ResponseInputItemUnionParam {
+		return responses.ResponseInputItemUnionParam{
+			OfMessage: &responses.EasyInputMessageParam{
+				Role: responses.EasyInputMessageRoleUser,
+				Content: responses.EasyInputMessageContentUnionParam{
+					OfString: param.NewOpt(s),
+				},
+			},
+		}
+	}
+
 	switch c := content.(type) {
 	case string:
-		return c
+		return textMsg(c)
 	case []types.ContentBlock:
-		parts := make([]string, 0, len(c))
+		if !hasImage(c) {
+			return textMsg(flattenText(c))
+		}
+		parts := make(responses.ResponseInputMessageContentListParam, 0, len(c))
 		for _, block := range c {
-			if t, ok := block.(types.TextContent); ok && t.Text != "" {
-				parts = append(parts, t.Text)
+			switch b := block.(type) {
+			case types.TextContent:
+				parts = append(parts, responses.ResponseInputContentParamOfInputText(b.Text))
+			case types.ImageContent:
+				dataURI := "data:" + b.MimeType + ";base64," + b.Data
+				img := responses.ResponseInputContentUnionParam{
+					OfInputImage: &responses.ResponseInputImageParam{
+						ImageURL: param.NewOpt(dataURI),
+					},
+				}
+				parts = append(parts, img)
 			}
 		}
-		return strings.Join(parts, " ")
+		return responses.ResponseInputItemUnionParam{
+			OfMessage: &responses.EasyInputMessageParam{
+				Role: responses.EasyInputMessageRoleUser,
+				Content: responses.EasyInputMessageContentUnionParam{
+					OfInputItemContentList: parts,
+				},
+			},
+		}
 	default:
-		return fmt.Sprintf("%v", content)
+		return textMsg(fmt.Sprintf("%v", content))
 	}
 }
 
-func flattenToolResult(content []types.ContentBlock) string {
-	parts := make([]string, 0, len(content))
-	for _, block := range content {
+func hasImage(blocks []types.ContentBlock) bool {
+	for _, b := range blocks {
+		if _, ok := b.(types.ImageContent); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func flattenText(blocks []types.ContentBlock) string {
+	parts := make([]string, 0, len(blocks))
+	for _, block := range blocks {
 		if t, ok := block.(types.TextContent); ok && t.Text != "" {
 			parts = append(parts, t.Text)
 		}
 	}
 	return strings.Join(parts, " ")
+}
+
+func flattenToolResult(content []types.ContentBlock) string {
+	return flattenText(content)
 }

--- a/ai/providers/openai/convert_messages.go
+++ b/ai/providers/openai/convert_messages.go
@@ -24,7 +24,7 @@ func convertMessages(ctx types.Context) []sdk.ChatCompletionMessageParamUnion {
 		case types.AssistantMessage:
 			messages = append(messages, convertAssistantMessage(m))
 		case types.ToolResultMessage:
-			messages = append(messages, sdk.ToolMessage(flattenToolResult(m.Content), m.ToolCallID))
+			messages = append(messages, sdk.ToolMessage(types.FlattenText(m.Content), m.ToolCallID))
 		}
 	}
 	return messages
@@ -77,9 +77,8 @@ func userMessage(content any) sdk.ChatCompletionMessageParamUnion {
 			case types.TextContent:
 				parts = append(parts, sdk.TextContentPart(b.Text))
 			case types.ImageContent:
-				dataURI := "data:" + b.MimeType + ";base64," + b.Data
 				parts = append(parts, sdk.ImageContentPart(sdk.ChatCompletionContentPartImageImageURLParam{
-					URL: dataURI,
+					URL: b.DataURI(),
 				}))
 			}
 		}
@@ -87,8 +86,4 @@ func userMessage(content any) sdk.ChatCompletionMessageParamUnion {
 	default:
 		return sdk.UserMessage(fmt.Sprintf("%v", content))
 	}
-}
-
-func flattenToolResult(content []types.ContentBlock) string {
-	return types.FlattenText(content)
 }

--- a/ai/providers/openai/convert_messages.go
+++ b/ai/providers/openai/convert_messages.go
@@ -20,7 +20,7 @@ func convertMessages(ctx types.Context) []sdk.ChatCompletionMessageParamUnion {
 	for _, msg := range ctx.Messages {
 		switch m := msg.(type) {
 		case types.UserMessage:
-			messages = append(messages, sdk.UserMessage(userContent(m.Content)))
+			messages = append(messages, userMessage(m.Content))
 		case types.AssistantMessage:
 			messages = append(messages, convertAssistantMessage(m))
 		case types.ToolResultMessage:
@@ -63,29 +63,51 @@ func convertAssistantMessage(m types.AssistantMessage) sdk.ChatCompletionMessage
 	return sdk.AssistantMessage(strings.Join(textParts, " "))
 }
 
-func userContent(content any) string {
+func userMessage(content any) sdk.ChatCompletionMessageParamUnion {
 	switch c := content.(type) {
 	case string:
-		return c
+		return sdk.UserMessage(c)
 	case []types.ContentBlock:
-		parts := make([]string, 0, len(c))
+		if !hasImage(c) {
+			return sdk.UserMessage(flattenText(c))
+		}
+		parts := make([]sdk.ChatCompletionContentPartUnionParam, 0, len(c))
 		for _, block := range c {
-			if t, ok := block.(types.TextContent); ok && t.Text != "" {
-				parts = append(parts, t.Text)
+			switch b := block.(type) {
+			case types.TextContent:
+				parts = append(parts, sdk.TextContentPart(b.Text))
+			case types.ImageContent:
+				dataURI := "data:" + b.MimeType + ";base64," + b.Data
+				parts = append(parts, sdk.ImageContentPart(sdk.ChatCompletionContentPartImageImageURLParam{
+					URL: dataURI,
+				}))
 			}
 		}
-		return strings.Join(parts, " ")
+		return sdk.UserMessage(parts)
 	default:
-		return fmt.Sprintf("%v", content)
+		return sdk.UserMessage(fmt.Sprintf("%v", content))
 	}
 }
 
-func flattenToolResult(content []types.ContentBlock) string {
-	parts := make([]string, 0, len(content))
-	for _, block := range content {
+func hasImage(blocks []types.ContentBlock) bool {
+	for _, b := range blocks {
+		if _, ok := b.(types.ImageContent); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func flattenText(blocks []types.ContentBlock) string {
+	parts := make([]string, 0, len(blocks))
+	for _, block := range blocks {
 		if t, ok := block.(types.TextContent); ok && t.Text != "" {
 			parts = append(parts, t.Text)
 		}
 	}
 	return strings.Join(parts, " ")
+}
+
+func flattenToolResult(content []types.ContentBlock) string {
+	return flattenText(content)
 }

--- a/ai/providers/openai/convert_messages.go
+++ b/ai/providers/openai/convert_messages.go
@@ -68,8 +68,8 @@ func userMessage(content any) sdk.ChatCompletionMessageParamUnion {
 	case string:
 		return sdk.UserMessage(c)
 	case []types.ContentBlock:
-		if !hasImage(c) {
-			return sdk.UserMessage(flattenText(c))
+		if !types.HasImage(c) {
+			return sdk.UserMessage(types.FlattenText(c))
 		}
 		parts := make([]sdk.ChatCompletionContentPartUnionParam, 0, len(c))
 		for _, block := range c {
@@ -89,25 +89,6 @@ func userMessage(content any) sdk.ChatCompletionMessageParamUnion {
 	}
 }
 
-func hasImage(blocks []types.ContentBlock) bool {
-	for _, b := range blocks {
-		if _, ok := b.(types.ImageContent); ok {
-			return true
-		}
-	}
-	return false
-}
-
-func flattenText(blocks []types.ContentBlock) string {
-	parts := make([]string, 0, len(blocks))
-	for _, block := range blocks {
-		if t, ok := block.(types.TextContent); ok && t.Text != "" {
-			parts = append(parts, t.Text)
-		}
-	}
-	return strings.Join(parts, " ")
-}
-
 func flattenToolResult(content []types.ContentBlock) string {
-	return flattenText(content)
+	return types.FlattenText(content)
 }

--- a/ai/types/message.go
+++ b/ai/types/message.go
@@ -1,6 +1,9 @@
 package types
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 // TextSignatureV1 carries model-generated text signature metadata.
 type TextSignatureV1 struct {
@@ -88,3 +91,24 @@ type ToolResultMessage struct {
 }
 
 func (ToolResultMessage) messageRole() string { return "tool" }
+
+// HasImage reports whether the given content blocks contain at least one ImageContent.
+func HasImage(blocks []ContentBlock) bool {
+	for _, b := range blocks {
+		if _, ok := b.(ImageContent); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// FlattenText extracts and joins all TextContent values from content blocks.
+func FlattenText(blocks []ContentBlock) string {
+	parts := make([]string, 0, len(blocks))
+	for _, block := range blocks {
+		if t, ok := block.(TextContent); ok && t.Text != "" {
+			parts = append(parts, t.Text)
+		}
+	}
+	return strings.Join(parts, " ")
+}

--- a/ai/types/message.go
+++ b/ai/types/message.go
@@ -42,6 +42,11 @@ type ImageContent struct {
 
 func (ImageContent) contentBlockKind() string { return "image" }
 
+// DataURI returns the image as a data URI string (e.g. "data:image/jpeg;base64,...").
+func (ic ImageContent) DataURI() string {
+	return "data:" + ic.MimeType + ";base64," + ic.Data
+}
+
 // ToolCall represents a tool invocation emitted by an assistant.
 type ToolCall struct {
 	ID               string

--- a/ai/types/message_test.go
+++ b/ai/types/message_test.go
@@ -1,0 +1,50 @@
+package types
+
+import "testing"
+
+func TestHasImage(t *testing.T) {
+	tests := []struct {
+		name   string
+		blocks []ContentBlock
+		want   bool
+	}{
+		{"nil", nil, false},
+		{"empty", []ContentBlock{}, false},
+		{"text only", []ContentBlock{TextContent{Text: "hi"}}, false},
+		{"image only", []ContentBlock{ImageContent{Data: "x", MimeType: "image/png"}}, true},
+		{"mixed", []ContentBlock{TextContent{Text: "hi"}, ImageContent{Data: "x", MimeType: "image/png"}}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HasImage(tt.blocks); got != tt.want {
+				t.Errorf("HasImage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFlattenText(t *testing.T) {
+	tests := []struct {
+		name   string
+		blocks []ContentBlock
+		want   string
+	}{
+		{"nil", nil, ""},
+		{"empty", []ContentBlock{}, ""},
+		{"single text", []ContentBlock{TextContent{Text: "hello"}}, "hello"},
+		{"multiple text", []ContentBlock{TextContent{Text: "a"}, TextContent{Text: "b"}}, "a b"},
+		{"mixed with image", []ContentBlock{
+			TextContent{Text: "describe"},
+			ImageContent{Data: "x", MimeType: "image/png"},
+			TextContent{Text: "this"},
+		}, "describe this"},
+		{"empty text skipped", []ContentBlock{TextContent{Text: ""}, TextContent{Text: "only"}}, "only"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FlattenText(tt.blocks); got != tt.want {
+				t.Errorf("FlattenText() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/channel/cli/cli_test.go
+++ b/channel/cli/cli_test.go
@@ -19,7 +19,7 @@ type mockRunner struct {
 	events []runner.Event
 }
 
-func (m *mockRunner) Chat(_ context.Context, _ []runner.RPCEvent, _ string) <-chan runner.Event {
+func (m *mockRunner) Chat(_ context.Context, _ []runner.RPCEvent, _ any) <-chan runner.Event {
 	ch := make(chan runner.Event, len(m.events))
 	for _, e := range m.events {
 		ch <- e

--- a/channel/cli/cli_test.go
+++ b/channel/cli/cli_test.go
@@ -19,7 +19,7 @@ type mockRunner struct {
 	events []runner.Event
 }
 
-func (m *mockRunner) Chat(_ context.Context, _ []runner.RPCEvent, _ any) <-chan runner.Event {
+func (m *mockRunner) Chat(_ context.Context, _ []runner.RPCEvent, _ runner.MessageContent) <-chan runner.Event {
 	ch := make(chan runner.Event, len(m.events))
 	for _, e := range m.events {
 		ch <- e

--- a/channel/telegram/handler.go
+++ b/channel/telegram/handler.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/vaayne/anna/agent/runner"
 	aitypes "github.com/vaayne/anna/ai/types"
 	tele "gopkg.in/telebot.v4"
 )
@@ -161,7 +162,8 @@ func (b *Bot) handlePhoto(c tele.Context) error {
 	}
 	defer func() { _ = rc.Close() }()
 
-	data, err := io.ReadAll(rc)
+	const maxPhotoSize = 20 << 20 // 20MB — Telegram's file size limit
+	data, err := io.ReadAll(io.LimitReader(rc, maxPhotoSize))
 	if err != nil {
 		logger().Error("read photo failed", "error", err)
 		return c.Send(fmt.Sprintf("Failed to read photo: %v", err))
@@ -170,20 +172,18 @@ func (b *Bot) handlePhoto(c tele.Context) error {
 	mimeType := http.DetectContentType(data)
 	encoded := base64.StdEncoding.EncodeToString(data)
 
-	content := []aitypes.ContentBlock{
-		aitypes.ImageContent{Data: encoded, MimeType: mimeType},
-	}
+	var content []aitypes.ContentBlock
 	if caption := c.Message().Caption; caption != "" {
 		content = append(content, aitypes.TextContent{Text: caption})
 	}
+	content = append(content, aitypes.ImageContent{Data: encoded, MimeType: mimeType})
 
 	logger().Debug("photo received", "chat_id", c.Chat().ID, "size", len(data), "mime", mimeType)
 	return b.handleMessage(c, content)
 }
 
 // handleMessage is the common flow for text and multimodal messages.
-// message is string or []aitypes.ContentBlock.
-func (b *Bot) handleMessage(c tele.Context, message any) error {
+func (b *Bot) handleMessage(c tele.Context, message runner.MessageContent) error {
 	chatID := c.Chat().ID
 	sessionID, err := b.resolveSession(c)
 	if err != nil {

--- a/channel/telegram/handler.go
+++ b/channel/telegram/handler.go
@@ -163,10 +163,13 @@ func (b *Bot) handlePhoto(c tele.Context) error {
 	defer func() { _ = rc.Close() }()
 
 	const maxPhotoSize = 20 << 20 // 20MB — Telegram's file size limit
-	data, err := io.ReadAll(io.LimitReader(rc, maxPhotoSize))
+	data, err := io.ReadAll(io.LimitReader(rc, maxPhotoSize+1))
 	if err != nil {
 		logger().Error("read photo failed", "error", err)
 		return c.Send(fmt.Sprintf("Failed to read photo: %v", err))
+	}
+	if len(data) > maxPhotoSize {
+		return c.Send("Photo too large (max 20 MB).")
 	}
 
 	mimeType := http.DetectContentType(data)

--- a/channel/telegram/handler.go
+++ b/channel/telegram/handler.go
@@ -196,7 +196,7 @@ func (b *Bot) handleMessage(c tele.Context, message any) error {
 	typingCtx, stopTyping := context.WithCancel(b.ctx)
 	go keepTyping(typingCtx, c)
 
-	response, tracker, streamErr := b.streamResponse(c, sessionID, message)
+	response, tracker, images, streamErr := b.streamResponse(c, sessionID, message)
 
 	stopTyping()
 
@@ -217,7 +217,7 @@ func (b *Bot) handleMessage(c tele.Context, message any) error {
 		response += tracker.renderFinal()
 	}
 
-	b.sendFinalResponse(c, response)
+	b.sendFinalResponse(c, response, images)
 	logger().Debug("response sent", "chat_id", chatID, "response_len", len(response))
 	return nil
 }

--- a/channel/telegram/handler.go
+++ b/channel/telegram/handler.go
@@ -177,6 +177,9 @@ func (b *Bot) handlePhoto(c tele.Context) error {
 
 	var content []aitypes.ContentBlock
 	if caption := c.Message().Caption; caption != "" {
+		if isGroup(c) {
+			caption = b.stripBotMention(caption)
+		}
 		content = append(content, aitypes.TextContent{Text: caption})
 	}
 	content = append(content, aitypes.ImageContent{Data: encoded, MimeType: mimeType})

--- a/channel/telegram/handler.go
+++ b/channel/telegram/handler.go
@@ -2,10 +2,14 @@ package telegram
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
+	"io"
+	"net/http"
 	"strconv"
 	"strings"
 
+	aitypes "github.com/vaayne/anna/ai/types"
 	tele "gopkg.in/telebot.v4"
 )
 
@@ -122,6 +126,10 @@ func (b *Bot) registerHandlers() {
 		return b.handleText(c)
 	}))
 
+	b.bot.Handle(tele.OnPhoto, b.guard(func(c tele.Context) error {
+		return b.handlePhoto(c)
+	}))
+
 	// Debug: catch-all callback handler for unmatched callbacks.
 	b.bot.Handle(tele.OnCallback, func(c tele.Context) error {
 		cb := c.Callback()
@@ -132,25 +140,63 @@ func (b *Bot) registerHandlers() {
 
 // handleText processes incoming text messages.
 func (b *Bot) handleText(c tele.Context) error {
+	text := c.Message().Text
+	if isGroup(c) {
+		text = b.stripBotMention(text)
+	}
+	return b.handleMessage(c, text)
+}
+
+// handlePhoto processes incoming photo messages.
+func (b *Bot) handlePhoto(c tele.Context) error {
+	photo := c.Message().Photo
+	if photo == nil {
+		return c.Send("No photo found in message.")
+	}
+
+	rc, err := b.bot.File(&photo.File)
+	if err != nil {
+		logger().Error("download photo failed", "error", err)
+		return c.Send(fmt.Sprintf("Failed to download photo: %v", err))
+	}
+	defer func() { _ = rc.Close() }()
+
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		logger().Error("read photo failed", "error", err)
+		return c.Send(fmt.Sprintf("Failed to read photo: %v", err))
+	}
+
+	mimeType := http.DetectContentType(data)
+	encoded := base64.StdEncoding.EncodeToString(data)
+
+	content := []aitypes.ContentBlock{
+		aitypes.ImageContent{Data: encoded, MimeType: mimeType},
+	}
+	if caption := c.Message().Caption; caption != "" {
+		content = append(content, aitypes.TextContent{Text: caption})
+	}
+
+	logger().Debug("photo received", "chat_id", c.Chat().ID, "size", len(data), "mime", mimeType)
+	return b.handleMessage(c, content)
+}
+
+// handleMessage is the common flow for text and multimodal messages.
+// message is string or []aitypes.ContentBlock.
+func (b *Bot) handleMessage(c tele.Context, message any) error {
 	chatID := c.Chat().ID
 	sessionID, err := b.resolveSession(c)
 	if err != nil {
 		logger().Error("resolve session failed", "chat_id", chatID, "error", err)
 		return c.Send(fmt.Sprintf("Session error: %v", err))
 	}
-	text := c.Message().Text
 
-	// Strip bot mention in group chats (access control already handled by guard).
-	if isGroup(c) {
-		text = b.stripBotMention(text)
-	}
-
-	logger().Debug("message received", "chat_id", chatID, "text_len", len(text))
+	logger().Debug("message received", "chat_id", chatID)
 
 	typingCtx, stopTyping := context.WithCancel(b.ctx)
 	go keepTyping(typingCtx, c)
 
-	response, tracker, streamErr := b.streamResponse(c, sessionID, text)
+	response, tracker, streamErr := b.streamResponse(c, sessionID, message)
 
 	stopTyping()
 

--- a/channel/telegram/render.go
+++ b/channel/telegram/render.go
@@ -2,10 +2,12 @@ package telegram
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"strings"
 
+	"github.com/vaayne/anna/agent/runner"
 	"github.com/yuin/goldmark/parser"
 	tele "gopkg.in/telebot.v4"
 )
@@ -16,10 +18,26 @@ type goldmarkMD interface {
 }
 
 // sendFinalResponse sends the completed response with markdown rendering,
-// splitting into chunks if necessary.
-func (b *Bot) sendFinalResponse(c tele.Context, response string) {
+// splitting into chunks if necessary. It also sends any collected images.
+func (b *Bot) sendFinalResponse(c tele.Context, response string, images []runner.ImageEvent) {
 	if err := b.sendChunkedMarkdown(c.Chat(), response, false, nil); err != nil {
 		logger().Error("sendFinalResponse failed", "chat_id", c.Chat().ID, "error", err)
+	}
+	for _, img := range images {
+		b.sendImage(c, img)
+	}
+}
+
+// sendImage decodes a base64 image and sends it as a photo to the chat.
+func (b *Bot) sendImage(c tele.Context, img runner.ImageEvent) {
+	data, err := base64.StdEncoding.DecodeString(img.Data)
+	if err != nil {
+		logger().Error("decode image failed", "error", err)
+		return
+	}
+	photo := &tele.Photo{File: tele.FromReader(bytes.NewReader(data))}
+	if _, err := b.bot.Send(c.Chat(), photo); err != nil {
+		logger().Error("send image failed", "error", err)
 	}
 }
 

--- a/channel/telegram/stream.go
+++ b/channel/telegram/stream.go
@@ -261,31 +261,32 @@ func truncate(s string, maxLen int) string {
 // For private chats it uses Telegram's sendMessageDraft API (Bot API 9.3+)
 // for smooth animated streaming. For groups (where drafts aren't supported)
 // it falls back to the edit-in-place approach.
-func (b *Bot) streamResponse(c tele.Context, sessionID string, prompt any) (string, *toolTracker, error) {
+func (b *Bot) streamResponse(c tele.Context, sessionID string, prompt any) (string, *toolTracker, []runner.ImageEvent, error) {
 	events := b.pool.Chat(b.ctx, sessionID, prompt)
 
 	if !isGroup(c) {
-		text, tracker, fallback, err := b.streamDraft(c, events)
+		text, tracker, images, fallback, err := b.streamDraft(c, events)
 		if fallback {
 			// Draft failed on first attempt — the event channel is still
 			// open. Continue with edit-based streaming, preserving any
 			// text and tool state already buffered from consumed events.
 			logger().Info("sendMessageDraft not supported, falling back to edit mode")
-			return b.streamEditEvents(c, events, text, tracker)
+			return b.streamEditEvents(c, events, text, tracker, images)
 		}
-		return text, tracker, err
+		return text, tracker, images, err
 	}
-	return b.streamEditEvents(c, events, "", nil)
+	return b.streamEditEvents(c, events, "", nil, nil)
 }
 
 // streamDraft uses Telegram's sendMessageDraft API for smooth streaming
 // in private chats. If the first draft call fails, it returns fallback=true
 // so the caller can switch to edit mode. The buffered text is returned so
 // no consumed events are lost.
-func (b *Bot) streamDraft(c tele.Context, events <-chan runner.Event) (text string, tracker *toolTracker, fallback bool, err error) {
+func (b *Bot) streamDraft(c tele.Context, events <-chan runner.Event) (text string, tracker *toolTracker, images []runner.ImageEvent, fallback bool, err error) {
 	var sb strings.Builder
 	var streamErr error
 	var tt toolTracker
+	var imgs []runner.ImageEvent
 	lastSend := time.Time{}
 	draftID := rand.Int64N(1<<53) + 1
 	chatID := c.Chat().ID
@@ -295,6 +296,11 @@ func (b *Bot) streamDraft(c tele.Context, events <-chan runner.Event) (text stri
 		if evt.Err != nil {
 			streamErr = evt.Err
 			break
+		}
+
+		if evt.Image != nil {
+			imgs = append(imgs, *evt.Image)
+			continue
 		}
 
 		forceRefresh := false
@@ -318,7 +324,7 @@ func (b *Bot) streamDraft(c tele.Context, events <-chan runner.Event) (text stri
 
 		if err := b.sendDraftRaw(chatID, draftID, display); err != nil {
 			if firstDraft {
-				return sb.String(), &tt, true, nil
+				return sb.String(), &tt, imgs, true, nil
 			}
 			logger().Warn("sendMessageDraft failed mid-stream", "error", err)
 		}
@@ -326,14 +332,14 @@ func (b *Bot) streamDraft(c tele.Context, events <-chan runner.Event) (text stri
 		lastSend = now
 	}
 
-	return sb.String(), &tt, false, streamErr
+	return sb.String(), &tt, imgs, false, streamErr
 }
 
 // streamEditEvents uses the traditional edit-in-place approach for streaming,
 // consuming from an existing event channel. Required for group chats where
 // sendMessageDraft is not available. Any already-buffered text from a prior
 // draft attempt is preserved via the initial parameter.
-func (b *Bot) streamEditEvents(c tele.Context, events <-chan runner.Event, initial string, existing *toolTracker) (string, *toolTracker, error) {
+func (b *Bot) streamEditEvents(c tele.Context, events <-chan runner.Event, initial string, existing *toolTracker, existingImages []runner.ImageEvent) (string, *toolTracker, []runner.ImageEvent, error) {
 	var sb strings.Builder
 	sb.WriteString(initial)
 	var sentMsg *tele.Message
@@ -342,12 +348,19 @@ func (b *Bot) streamEditEvents(c tele.Context, events <-chan runner.Event, initi
 	if existing != nil {
 		tt = *existing
 	}
+	var imgs []runner.ImageEvent
+	imgs = append(imgs, existingImages...)
 	lastEdit := time.Time{}
 
 	for evt := range events {
 		if evt.Err != nil {
 			streamErr = evt.Err
 			break
+		}
+
+		if evt.Image != nil {
+			imgs = append(imgs, *evt.Image)
+			continue
 		}
 
 		forceRefresh := false
@@ -391,7 +404,7 @@ func (b *Bot) streamEditEvents(c tele.Context, events <-chan runner.Event, initi
 		}
 	}
 
-	return sb.String(), &tt, streamErr
+	return sb.String(), &tt, imgs, streamErr
 }
 
 // buildStreamDisplay constructs the streaming display text with tool summary,

--- a/channel/telegram/stream.go
+++ b/channel/telegram/stream.go
@@ -246,7 +246,8 @@ func formatDuration(d time.Duration) string {
 	return fmt.Sprintf("%.1fs", d.Seconds())
 }
 
-// truncate shortens s to maxLen characters, appending "..." if truncated.
+// truncate shortens s to maxLen bytes, appending "..." if truncated.
+// Cuts at a valid UTF-8 boundary to avoid producing invalid strings.
 func truncate(s string, maxLen int) string {
 	if len(s) <= maxLen {
 		return s
@@ -254,7 +255,11 @@ func truncate(s string, maxLen int) string {
 	if maxLen <= 3 {
 		return "..."
 	}
-	return s[:maxLen-3] + "..."
+	cutAt := maxLen - 3
+	for cutAt > 0 && !utf8.RuneStart(s[cutAt]) {
+		cutAt--
+	}
+	return s[:cutAt] + "..."
 }
 
 // streamResponse consumes the agent stream, displaying progress in real time.

--- a/channel/telegram/stream.go
+++ b/channel/telegram/stream.go
@@ -261,7 +261,7 @@ func truncate(s string, maxLen int) string {
 // For private chats it uses Telegram's sendMessageDraft API (Bot API 9.3+)
 // for smooth animated streaming. For groups (where drafts aren't supported)
 // it falls back to the edit-in-place approach.
-func (b *Bot) streamResponse(c tele.Context, sessionID, prompt string) (string, *toolTracker, error) {
+func (b *Bot) streamResponse(c tele.Context, sessionID string, prompt any) (string, *toolTracker, error) {
 	events := b.pool.Chat(b.ctx, sessionID, prompt)
 
 	if !isGroup(c) {

--- a/channel/telegram/stream.go
+++ b/channel/telegram/stream.go
@@ -261,7 +261,7 @@ func truncate(s string, maxLen int) string {
 // For private chats it uses Telegram's sendMessageDraft API (Bot API 9.3+)
 // for smooth animated streaming. For groups (where drafts aren't supported)
 // it falls back to the edit-in-place approach.
-func (b *Bot) streamResponse(c tele.Context, sessionID string, prompt any) (string, *toolTracker, []runner.ImageEvent, error) {
+func (b *Bot) streamResponse(c tele.Context, sessionID string, prompt runner.MessageContent) (string, *toolTracker, []runner.ImageEvent, error) {
 	events := b.pool.Chat(b.ctx, sessionID, prompt)
 
 	if !isGroup(c) {

--- a/channel/telegram/telegram.go
+++ b/channel/telegram/telegram.go
@@ -211,9 +211,10 @@ func (b *Bot) isMentionedOrReplied(c tele.Context) bool {
 			return true
 		}
 	}
-	// Check for @mention.
+	// Check for @mention in text or caption (photos carry text in Caption).
 	if b.bot.Me.Username != "" {
-		if strings.Contains(c.Message().Text, "@"+b.bot.Me.Username) {
+		mention := "@" + b.bot.Me.Username
+		if strings.Contains(c.Message().Text, mention) || strings.Contains(c.Message().Caption, mention) {
 			return true
 		}
 	}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,7 +108,7 @@ Three LLM providers are supported:
 | `openai` | Chat Completions API | GPT models |
 | `openai-response` | Responses API | OpenAI-compatible services (Perplexity, Together.ai, etc.) |
 
-Each provider implements the `stream.Provider` interface for streaming responses and optionally `stream.ModelLister` for model discovery.
+Each provider implements the `stream.Provider` interface for streaming responses and optionally `stream.ModelLister` for model discovery. All providers support multimodal input (text + images) via the `ImageContent` type, converting to their native image format (base64 blocks for Anthropic, data URI image_url for OpenAI).
 
 ## Tools
 
@@ -142,7 +142,7 @@ type Tool interface {
 
 ## Session Lifecycle
 
-1. Channel sends message to `Pool.Chat(ctx, sessionID, prompt)`
+1. Channel sends message to `Pool.Chat(ctx, sessionID, message)` — message is `string` (text) or `[]ContentBlock` (multimodal, e.g. text + images)
 2. Pool finds or creates a session, loading history from disk if persisted
 3. Pool acquires or creates a runner for the session
 4. Runner streams events back through a channel

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -45,6 +45,21 @@ During tool execution, the stream shows status with emoji indicators:
 | `edit` | wrench |
 | `search` | magnifying glass |
 
+## Image Support
+
+The bot accepts photo messages in private chats. When you send an image:
+
+1. The bot downloads the highest-resolution version from Telegram's file API
+2. Detects the MIME type and base64-encodes the image
+3. Sends it as a multimodal message (image + optional caption text) to the model
+4. The model analyzes the image and responds with text
+
+Use cases: describe screenshots, analyze diagrams, read documents from photos, etc.
+
+If the model returns images (e.g. from tool results), they are sent back as Telegram photos after the text response.
+
+> **Note:** Image support requires a vision-capable model (e.g. Claude 3+, GPT-4o).
+
 ## Group Support
 
 Configure how the bot responds in group chats:


### PR DESCRIPTION
## Summary

- Add `ImageContent` support to all 3 AI providers (Anthropic, OpenAI completions, OpenAI responses)
- Change `Runner.Chat` and `Pool.Chat` to accept multimodal messages (`string` or `[]ContentBlock`)
- Add `tele.OnPhoto` handler in Telegram — downloads photo, base64 encodes, sends as multimodal message
- Add `ImageEvent` plumbing through the stream for sending images back to Telegram
- Persist multimodal user messages in session history via `RPCEvent.Content` field

## Test plan

- [x] All existing tests pass (`go test -race ./...`)
- [x] Manually tested: send photo to Telegram bot, model describes the image
- [ ] Image output to Telegram (tracked in #34 — requires tool interface changes)

Closes #29