### PR TITLE
Add onboard subcommand with web-based setup UI

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ func newApp() *ucli.App {
 			gatewayCommand(),
 			modelsCommand(),
 			skillsCommand(),
+			onboardCommand(),
 		},
 	}
 }

--- a/onboard.go
+++ b/onboard.go
@@ -226,9 +226,15 @@ func applyJSONToConfig(cfg *Config, body *configJSON) {
 	cfg.ModelFast = body.ModelFast
 	cfg.Workspace = body.Workspace
 
+	// Merge providers: update api_key/base_url but preserve existing Models.
+	existing := cfg.Providers
 	cfg.Providers = make(map[string]ProviderConfig, len(body.Providers))
 	for name, p := range body.Providers {
-		cfg.Providers[name] = ProviderConfig{APIKey: p.APIKey, BaseURL: p.BaseURL}
+		pc := ProviderConfig{APIKey: p.APIKey, BaseURL: p.BaseURL}
+		if prev, ok := existing[name]; ok {
+			pc.Models = prev.Models
+		}
+		cfg.Providers[name] = pc
 	}
 
 	cfg.Channels.Telegram = TelegramConfig{
@@ -240,9 +246,95 @@ func applyJSONToConfig(cfg *Config, body *configJSON) {
 	}
 }
 
-// saveConfig writes the config to ~/.anna/config.yaml.
+// saveConfig reads the existing config.yaml, merges onboarding fields on top
+// (preserving runner, cron, and other sections), and writes it back.
 func saveConfig(cfg *Config) error {
-	return saveConfigTo(configPath(), cfg)
+	path := configPath()
+
+	// Read existing file as a raw map to preserve unknown sections.
+	existing := make(map[string]any)
+	data, err := os.ReadFile(path)
+	if err == nil {
+		_ = yaml.Unmarshal(data, &existing)
+	}
+
+	// Overlay onboarding-managed fields.
+	setIfNonEmpty(existing, "provider", cfg.Provider)
+	setIfNonEmpty(existing, "model", cfg.Model)
+	setOrDelete(existing, "model_strong", cfg.ModelStrong)
+	setOrDelete(existing, "model_fast", cfg.ModelFast)
+	setOrDelete(existing, "workspace", cfg.Workspace)
+
+	// Merge providers: update api_key/base_url, preserve everything else
+	// (models, headers, etc.) in each provider entry.
+	if len(cfg.Providers) > 0 {
+		existingProvs, _ := existing["providers"].(map[string]any)
+		if existingProvs == nil {
+			existingProvs = make(map[string]any)
+		}
+
+		// Remove providers no longer in the onboarding set.
+		for name := range existingProvs {
+			if _, ok := cfg.Providers[name]; !ok {
+				delete(existingProvs, name)
+			}
+		}
+
+		for name, p := range cfg.Providers {
+			pm, _ := existingProvs[name].(map[string]any)
+			if pm == nil {
+				pm = make(map[string]any)
+			}
+			setOrDelete(pm, "api_key", p.APIKey)
+			setOrDelete(pm, "base_url", p.BaseURL)
+			existingProvs[name] = pm
+		}
+		existing["providers"] = existingProvs
+	} else {
+		delete(existing, "providers")
+	}
+
+	// Merge telegram channel config.
+	tg := cfg.Channels.Telegram
+	if tg.Token != "" || tg.NotifyChat != "" || tg.ChannelID != "" || tg.GroupMode != "" || len(tg.AllowedIDs) > 0 {
+		existingChannels, _ := existing["channels"].(map[string]any)
+		if existingChannels == nil {
+			existingChannels = make(map[string]any)
+		}
+		tgMap, _ := existingChannels["telegram"].(map[string]any)
+		if tgMap == nil {
+			tgMap = make(map[string]any)
+		}
+		setOrDelete(tgMap, "token", tg.Token)
+		setOrDelete(tgMap, "notify_chat", tg.NotifyChat)
+		setOrDelete(tgMap, "channel_id", tg.ChannelID)
+		setOrDelete(tgMap, "group_mode", tg.GroupMode)
+		if len(tg.AllowedIDs) > 0 {
+			tgMap["allowed_ids"] = tg.AllowedIDs
+		} else {
+			delete(tgMap, "allowed_ids")
+		}
+		existingChannels["telegram"] = tgMap
+		existing["channels"] = existingChannels
+	}
+
+	return writeYAMLFile(path, existing)
+}
+
+// setIfNonEmpty sets key in m if value is non-empty, otherwise leaves it as-is.
+func setIfNonEmpty(m map[string]any, key, value string) {
+	if value != "" {
+		m[key] = value
+	}
+}
+
+// setOrDelete sets key in m if value is non-empty, otherwise deletes it.
+func setOrDelete(m map[string]any, key, value string) {
+	if value != "" {
+		m[key] = value
+	} else {
+		delete(m, key)
+	}
 }
 
 // mergeProviderModelsCache updates the models cache for a single provider,
@@ -297,75 +389,6 @@ func openBrowser(url string) {
 		}
 		go func() { _ = cmd.Wait() }()
 	}
-}
-
-// saveConfigTo marshals cfg to YAML and writes it to path,
-// stripping zero-value fields for a clean config file.
-func saveConfigTo(path string, cfg *Config) error {
-	// Build a clean map to avoid writing empty/default values.
-	out := make(map[string]any)
-
-	if cfg.Provider != "" && cfg.Provider != "anthropic" {
-		out["provider"] = cfg.Provider
-	}
-	if cfg.Model != "" && cfg.Model != "claude-sonnet-4-6" {
-		out["model"] = cfg.Model
-	}
-	if cfg.ModelStrong != "" {
-		out["model_strong"] = cfg.ModelStrong
-	}
-	if cfg.ModelFast != "" {
-		out["model_fast"] = cfg.ModelFast
-	}
-	if cfg.Workspace != "" {
-		out["workspace"] = cfg.Workspace
-	}
-
-	if len(cfg.Providers) > 0 {
-		provs := make(map[string]any, len(cfg.Providers))
-		for name, p := range cfg.Providers {
-			pm := make(map[string]any)
-			if p.APIKey != "" {
-				pm["api_key"] = p.APIKey
-			}
-			if p.BaseURL != "" {
-				pm["base_url"] = p.BaseURL
-			}
-			if len(p.Models) > 0 {
-				pm["models"] = p.Models
-			}
-			provs[name] = pm
-		}
-		out["providers"] = provs
-	}
-
-	tg := cfg.Channels.Telegram
-	if hasTelegramConfig(tg) {
-		tgMap := make(map[string]any)
-		if tg.Token != "" {
-			tgMap["token"] = tg.Token
-		}
-		if tg.NotifyChat != "" {
-			tgMap["notify_chat"] = tg.NotifyChat
-		}
-		if tg.ChannelID != "" {
-			tgMap["channel_id"] = tg.ChannelID
-		}
-		if tg.GroupMode != "" {
-			tgMap["group_mode"] = tg.GroupMode
-		}
-		if len(tg.AllowedIDs) > 0 {
-			tgMap["allowed_ids"] = tg.AllowedIDs
-		}
-		out["channels"] = map[string]any{"telegram": tgMap}
-	}
-
-	return writeYAMLFile(path, out)
-}
-
-func hasTelegramConfig(tg TelegramConfig) bool {
-	return tg.Token != "" || tg.NotifyChat != "" || tg.ChannelID != "" ||
-		tg.GroupMode != "" || len(tg.AllowedIDs) > 0
 }
 
 // writeYAMLFile writes a map as YAML to the given path.

--- a/onboard.go
+++ b/onboard.go
@@ -1,0 +1,381 @@
+package main
+
+import (
+	"context"
+	"embed"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	ucli "github.com/urfave/cli/v2"
+	"github.com/vaayne/anna/ai/stream"
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed onboard.html
+var onboardFS embed.FS
+
+func onboardCommand() *ucli.Command {
+	return &ucli.Command{
+		Name:  "onboard",
+		Usage: "Open a web page to set up anna for the first time",
+		Flags: []ucli.Flag{
+			&ucli.IntFlag{
+				Name:  "port",
+				Usage: "Port to listen on (0 = random)",
+				Value: 0,
+			},
+		},
+		Action: func(c *ucli.Context) error {
+			return runOnboard(c.Context, c.Int("port"))
+		},
+	}
+}
+
+func runOnboard(ctx context.Context, port int) error {
+	cfg, err := LoadConfig()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	mux := http.NewServeMux()
+
+	// Serve the single-page HTML.
+	mux.HandleFunc("GET /", func(w http.ResponseWriter, r *http.Request) {
+		data, _ := onboardFS.ReadFile("onboard.html")
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write(data)
+	})
+
+	// GET /api/config — return current config + cached models.
+	mux.HandleFunc("GET /api/config", func(w http.ResponseWriter, r *http.Request) {
+		// Build per-provider model lists from cache.
+		models := make(map[string][]string)
+		if cache, err := LoadModelsCache(); err == nil {
+			for _, m := range cache.Models {
+				models[m.Provider] = append(models[m.Provider], m.Model)
+			}
+		}
+
+		writeJSON(w, http.StatusOK, map[string]any{
+			"config": cfgToJSON(cfg),
+			"models": models,
+		})
+	})
+
+	// POST /api/config — save config from JSON body.
+	mux.HandleFunc("POST /api/config", func(w http.ResponseWriter, r *http.Request) {
+		var body configJSON
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+			return
+		}
+		applyJSONToConfig(cfg, &body)
+
+		if err := saveConfig(cfg); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "save failed: " + err.Error()})
+			return
+		}
+
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	})
+
+	// POST /api/providers/{name}/models — fetch models from provider API.
+	mux.HandleFunc("POST /api/providers/{name}/models", func(w http.ResponseWriter, r *http.Request) {
+		name := r.PathValue("name")
+
+		var body struct {
+			APIKey  string `json:"api_key"`
+			BaseURL string `json:"base_url"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+			return
+		}
+
+		if body.APIKey == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "api_key is required"})
+			return
+		}
+
+		provCfg := ProviderConfig{APIKey: body.APIKey, BaseURL: body.BaseURL}
+		provider := newStreamProvider(name, provCfg)
+		if provider == nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "unknown provider: " + name})
+			return
+		}
+
+		lister, ok := provider.(stream.ModelLister)
+		if !ok {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": name + " does not support model listing"})
+			return
+		}
+
+		fetchCtx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+		defer cancel()
+
+		listed, err := lister.ListModels(fetchCtx)
+		if err != nil {
+			writeJSON(w, http.StatusBadGateway, map[string]string{"error": "fetch failed: " + err.Error()})
+			return
+		}
+
+		modelIDs := make([]string, 0, len(listed))
+		for _, m := range listed {
+			modelIDs = append(modelIDs, m.ID)
+		}
+
+		// Update the global models cache with these results.
+		mergeProviderModelsCache(name, modelIDs)
+
+		writeJSON(w, http.StatusOK, map[string]any{"models": modelIDs})
+	})
+
+	// Listen on requested port (0 = random).
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		return fmt.Errorf("listen: %w", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	addr := ln.Addr().String()
+	url := "http://" + addr
+	fmt.Printf("Anna setup running at %s\n", url)
+
+	openBrowser(url)
+
+	srv := &http.Server{Handler: mux}
+
+	// Shutdown on context cancellation.
+	go func() {
+		<-ctx.Done()
+		shutCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutCtx)
+	}()
+
+	if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+		return fmt.Errorf("serve: %w", err)
+	}
+	return nil
+}
+
+// configJSON is the JSON shape exchanged with the frontend.
+type configJSON struct {
+	Provider    string                  `json:"provider"`
+	Model       string                  `json:"model"`
+	ModelStrong string                  `json:"model_strong"`
+	ModelFast   string                  `json:"model_fast"`
+	Workspace   string                  `json:"workspace"`
+	Providers   map[string]providerJSON `json:"providers"`
+	Channels    channelsJSON            `json:"channels"`
+}
+
+type providerJSON struct {
+	APIKey  string `json:"api_key"`
+	BaseURL string `json:"base_url"`
+}
+
+type channelsJSON struct {
+	Telegram telegramJSON `json:"telegram"`
+}
+
+type telegramJSON struct {
+	Token      string  `json:"token"`
+	NotifyChat string  `json:"notify_chat"`
+	ChannelID  string  `json:"channel_id"`
+	GroupMode  string  `json:"group_mode"`
+	AllowedIDs []int64 `json:"allowed_ids"`
+}
+
+func cfgToJSON(cfg *Config) configJSON {
+	providers := make(map[string]providerJSON, len(cfg.Providers))
+	for name, p := range cfg.Providers {
+		providers[name] = providerJSON{APIKey: p.APIKey, BaseURL: p.BaseURL}
+	}
+	return configJSON{
+		Provider:    cfg.Provider,
+		Model:       cfg.Model,
+		ModelStrong: cfg.ModelStrong,
+		ModelFast:   cfg.ModelFast,
+		Workspace:   cfg.Workspace,
+		Providers:   providers,
+		Channels: channelsJSON{
+			Telegram: telegramJSON{
+				Token:      cfg.Channels.Telegram.Token,
+				NotifyChat: cfg.Channels.Telegram.NotifyChat,
+				ChannelID:  cfg.Channels.Telegram.ChannelID,
+				GroupMode:  cfg.Channels.Telegram.GroupMode,
+				AllowedIDs: cfg.Channels.Telegram.AllowedIDs,
+			},
+		},
+	}
+}
+
+func applyJSONToConfig(cfg *Config, body *configJSON) {
+	cfg.Provider = body.Provider
+	cfg.Model = body.Model
+	cfg.ModelStrong = body.ModelStrong
+	cfg.ModelFast = body.ModelFast
+	cfg.Workspace = body.Workspace
+
+	cfg.Providers = make(map[string]ProviderConfig, len(body.Providers))
+	for name, p := range body.Providers {
+		cfg.Providers[name] = ProviderConfig{APIKey: p.APIKey, BaseURL: p.BaseURL}
+	}
+
+	cfg.Channels.Telegram = TelegramConfig{
+		Token:      body.Channels.Telegram.Token,
+		NotifyChat: body.Channels.Telegram.NotifyChat,
+		ChannelID:  body.Channels.Telegram.ChannelID,
+		GroupMode:  body.Channels.Telegram.GroupMode,
+		AllowedIDs: body.Channels.Telegram.AllowedIDs,
+	}
+}
+
+// saveConfig writes the config to ~/.anna/config.yaml.
+func saveConfig(cfg *Config) error {
+	return saveConfigTo(configPath(), cfg)
+}
+
+// mergeProviderModelsCache updates the models cache for a single provider,
+// preserving models from other providers.
+func mergeProviderModelsCache(providerName string, modelIDs []string) {
+	cache, err := LoadModelsCache()
+	if err != nil {
+		cache = &ModelsCache{}
+	}
+
+	// Keep models from other providers.
+	var kept []CachedModel
+	for _, m := range cache.Models {
+		if m.Provider != providerName {
+			kept = append(kept, m)
+		}
+	}
+
+	// Add new models for this provider.
+	for _, id := range modelIDs {
+		kept = append(kept, CachedModel{Provider: providerName, Model: id})
+	}
+
+	cache.Models = kept
+	cache.UpdatedAt = time.Now().UTC()
+
+	if err := SaveModelsCache(cache); err != nil {
+		slog.Warn("failed to save models cache", "error", err)
+	}
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func openBrowser(url string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "linux":
+		cmd = exec.Command("xdg-open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	}
+	if cmd != nil {
+		if err := cmd.Start(); err != nil {
+			slog.Warn("failed to open browser", "error", err)
+			return
+		}
+		go func() { _ = cmd.Wait() }()
+	}
+}
+
+// saveConfigTo marshals cfg to YAML and writes it to path,
+// stripping zero-value fields for a clean config file.
+func saveConfigTo(path string, cfg *Config) error {
+	// Build a clean map to avoid writing empty/default values.
+	out := make(map[string]any)
+
+	if cfg.Provider != "" && cfg.Provider != "anthropic" {
+		out["provider"] = cfg.Provider
+	}
+	if cfg.Model != "" && cfg.Model != "claude-sonnet-4-6" {
+		out["model"] = cfg.Model
+	}
+	if cfg.ModelStrong != "" {
+		out["model_strong"] = cfg.ModelStrong
+	}
+	if cfg.ModelFast != "" {
+		out["model_fast"] = cfg.ModelFast
+	}
+	if cfg.Workspace != "" {
+		out["workspace"] = cfg.Workspace
+	}
+
+	if len(cfg.Providers) > 0 {
+		provs := make(map[string]any, len(cfg.Providers))
+		for name, p := range cfg.Providers {
+			pm := make(map[string]any)
+			if p.APIKey != "" {
+				pm["api_key"] = p.APIKey
+			}
+			if p.BaseURL != "" {
+				pm["base_url"] = p.BaseURL
+			}
+			if len(p.Models) > 0 {
+				pm["models"] = p.Models
+			}
+			provs[name] = pm
+		}
+		out["providers"] = provs
+	}
+
+	tg := cfg.Channels.Telegram
+	if hasTelegramConfig(tg) {
+		tgMap := make(map[string]any)
+		if tg.Token != "" {
+			tgMap["token"] = tg.Token
+		}
+		if tg.NotifyChat != "" {
+			tgMap["notify_chat"] = tg.NotifyChat
+		}
+		if tg.ChannelID != "" {
+			tgMap["channel_id"] = tg.ChannelID
+		}
+		if tg.GroupMode != "" {
+			tgMap["group_mode"] = tg.GroupMode
+		}
+		if len(tg.AllowedIDs) > 0 {
+			tgMap["allowed_ids"] = tg.AllowedIDs
+		}
+		out["channels"] = map[string]any{"telegram": tgMap}
+	}
+
+	return writeYAMLFile(path, out)
+}
+
+func hasTelegramConfig(tg TelegramConfig) bool {
+	return tg.Token != "" || tg.NotifyChat != "" || tg.ChannelID != "" ||
+		tg.GroupMode != "" || len(tg.AllowedIDs) > 0
+}
+
+// writeYAMLFile writes a map as YAML to the given path.
+func writeYAMLFile(path string, data map[string]any) error {
+	out, err := yaml.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+	return os.WriteFile(path, out, 0o644)
+}

--- a/onboard.go
+++ b/onboard.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
 	"embed"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -16,6 +18,7 @@ import (
 
 	ucli "github.com/urfave/cli/v2"
 	"github.com/vaayne/anna/ai/stream"
+	"github.com/vaayne/anna/cron"
 	"gopkg.in/yaml.v3"
 )
 
@@ -136,6 +139,138 @@ func runOnboard(ctx context.Context, port int) error {
 		mergeProviderModelsCache(name, modelIDs)
 
 		writeJSON(w, http.StatusOK, map[string]any{"models": modelIDs})
+	})
+
+	// Cron jobs CRUD — direct file I/O, no scheduler needed.
+	cronDir := cfg.Cron.DataDir
+	if cronDir == "" {
+		cronDir = filepath.Join(cfg.Workspace, "cron")
+	}
+
+	mux.HandleFunc("GET /api/cron/jobs", func(w http.ResponseWriter, r *http.Request) {
+		jobs, err := loadCronJobs(cronDir)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"jobs": jobs})
+	})
+
+	mux.HandleFunc("POST /api/cron/jobs", func(w http.ResponseWriter, r *http.Request) {
+		var body cronJobJSON
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+			return
+		}
+		if body.Name == "" || body.Message == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name and message are required"})
+			return
+		}
+		sched, err := parseCronSchedule(body)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+
+		jobs, err := loadCronJobs(cronDir)
+		if err != nil {
+			jobs = nil
+		}
+
+		job := cron.Job{
+			ID:          generateShortID(),
+			Name:        body.Name,
+			Schedule:    sched,
+			Message:     body.Message,
+			SessionMode: body.SessionMode,
+			Enabled:     body.Enabled,
+			CreatedAt:   time.Now(),
+		}
+		if job.SessionMode == "" {
+			job.SessionMode = cron.SessionReuse
+		}
+		jobs = append(jobs, job)
+
+		if err := saveCronJobs(cronDir, jobs); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "save failed: " + err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, job)
+	})
+
+	mux.HandleFunc("PUT /api/cron/jobs/{id}", func(w http.ResponseWriter, r *http.Request) {
+		id := r.PathValue("id")
+		var body cronJobJSON
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+			return
+		}
+
+		jobs, err := loadCronJobs(cronDir)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+
+		found := false
+		for i, j := range jobs {
+			if j.ID == id {
+				if body.Name != "" {
+					jobs[i].Name = body.Name
+				}
+				if body.Message != "" {
+					jobs[i].Message = body.Message
+				}
+				if body.SessionMode != "" {
+					jobs[i].SessionMode = body.SessionMode
+				}
+				jobs[i].Enabled = body.Enabled
+				if sched, err := parseCronSchedule(body); err == nil {
+					jobs[i].Schedule = sched
+				}
+				found = true
+				break
+			}
+		}
+		if !found {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "job not found"})
+			return
+		}
+
+		if err := saveCronJobs(cronDir, jobs); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "save failed: " + err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	})
+
+	mux.HandleFunc("DELETE /api/cron/jobs/{id}", func(w http.ResponseWriter, r *http.Request) {
+		id := r.PathValue("id")
+		jobs, err := loadCronJobs(cronDir)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+
+		filtered := make([]cron.Job, 0, len(jobs))
+		found := false
+		for _, j := range jobs {
+			if j.ID == id {
+				found = true
+				continue
+			}
+			filtered = append(filtered, j)
+		}
+		if !found {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "job not found"})
+			return
+		}
+
+		if err := saveCronJobs(cronDir, filtered); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "save failed: " + err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 	})
 
 	// Listen on requested port (0 = random).
@@ -364,6 +499,75 @@ func mergeProviderModelsCache(providerName string, modelIDs []string) {
 	if err := SaveModelsCache(cache); err != nil {
 		slog.Warn("failed to save models cache", "error", err)
 	}
+}
+
+// cronJobJSON is the JSON shape for cron job create/update.
+type cronJobJSON struct {
+	Name        string `json:"name"`
+	Message     string `json:"message"`
+	Cron        string `json:"cron"`
+	Every       string `json:"every"`
+	SessionMode string `json:"session_mode"`
+	Enabled     bool   `json:"enabled"`
+}
+
+func parseCronSchedule(body cronJobJSON) (cron.Schedule, error) {
+	sched := cron.Schedule{Cron: body.Cron, Every: body.Every}
+	count := 0
+	if sched.Cron != "" {
+		count++
+	}
+	if sched.Every != "" {
+		count++
+	}
+	if count == 0 {
+		return sched, fmt.Errorf("schedule requires cron or every")
+	}
+	if count > 1 {
+		return sched, fmt.Errorf("schedule must have exactly one of cron or every")
+	}
+	if sched.Every != "" {
+		if _, err := time.ParseDuration(sched.Every); err != nil {
+			return sched, fmt.Errorf("invalid duration %q: %w", sched.Every, err)
+		}
+	}
+	return sched, nil
+}
+
+func loadCronJobs(dataDir string) ([]cron.Job, error) {
+	data, err := os.ReadFile(filepath.Join(dataDir, "jobs.json"))
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var jobs []cron.Job
+	if err := json.Unmarshal(data, &jobs); err != nil {
+		return nil, fmt.Errorf("parse jobs.json: %w", err)
+	}
+	return jobs, nil
+}
+
+func saveCronJobs(dataDir string, jobs []cron.Job) error {
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(jobs, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := filepath.Join(dataDir, "jobs.json.tmp")
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, filepath.Join(dataDir, "jobs.json"))
+}
+
+func generateShortID() string {
+	b := make([]byte, 4)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {

--- a/onboard.html
+++ b/onboard.html
@@ -341,6 +341,123 @@
         </div>
       </div>
     </section>
+
+    <!-- Tab 3: Cron -->
+    <section x-show="activeTab === 3" x-transition.opacity.duration.150ms>
+
+      <!-- Add / Edit form -->
+      <div class="rounded-xl border border-surface-3 bg-surface-0 shadow-card overflow-hidden mb-5">
+        <div class="flex items-center gap-2 px-4 py-2.5 border-b border-surface-2">
+          <svg class="w-4 h-4 text-primary-500" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/></svg>
+          <span class="text-sm font-medium text-ink-0" x-text="cronEditing ? 'Edit Job' : 'New Job'"></span>
+          <button x-show="cronEditing" @click="cronCancelEdit()"
+                  class="ml-auto text-[11px] text-ink-2 hover:text-ink-0 cursor-pointer">Cancel</button>
+        </div>
+        <div class="px-4 py-4 space-y-3">
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div>
+              <label class="text-[11px] font-medium text-ink-2 uppercase tracking-wider mb-1.5 block">Name</label>
+              <input type="text" x-model="cronForm.name" placeholder="Daily summary"
+                     class="w-full h-10 rounded-lg border border-surface-4 bg-surface-0 px-3 text-sm text-ink-0 shadow-card placeholder:text-ink-3 focus:outline-none focus:border-primary-400 focus:shadow-input-focus transition-all duration-150">
+            </div>
+            <div>
+              <label class="text-[11px] font-medium text-ink-2 uppercase tracking-wider mb-1.5 block">Session Mode</label>
+              <select x-model="cronForm.session_mode"
+                      class="w-full h-10 rounded-lg border border-surface-4 bg-surface-0 px-3 text-sm text-ink-0 shadow-card focus:outline-none focus:border-primary-400 focus:shadow-input-focus transition-all duration-150 cursor-pointer appearance-none bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20fill%3D%22%23868e96%22%20viewBox%3D%220%200%2016%2016%22%3E%3Cpath%20d%3D%22M4.646%206.646a.5.5%200%20011%200L8%209.293l2.354-2.647a.5.5%200%2001.707.708l-3%203a.5.5%200%2001-.707%200l-3-3a.5.5%200%20010-.708z%22%2F%3E%3C%2Fsvg%3E')] bg-[length:16px] bg-[right_10px_center] bg-no-repeat">
+                <option value="reuse">Reuse session</option>
+                <option value="new">New session each run</option>
+              </select>
+            </div>
+          </div>
+          <div>
+            <label class="text-[11px] font-medium text-ink-2 uppercase tracking-wider mb-1.5 block">Schedule</label>
+            <div class="flex items-center gap-2 mb-2">
+              <label class="inline-flex items-center gap-1.5 cursor-pointer">
+                <input type="radio" x-model="cronForm.schedule_type" value="cron" class="accent-primary-600">
+                <span class="text-xs text-ink-1">Cron expression</span>
+              </label>
+              <label class="inline-flex items-center gap-1.5 cursor-pointer">
+                <input type="radio" x-model="cronForm.schedule_type" value="every" class="accent-primary-600">
+                <span class="text-xs text-ink-1">Interval</span>
+              </label>
+            </div>
+            <input x-show="cronForm.schedule_type === 'cron'" type="text" x-model="cronForm.cron" placeholder="0 9 * * 1-5 (weekdays at 9am)"
+                   class="w-full h-10 rounded-lg border border-surface-4 bg-surface-0 px-3 text-sm text-ink-0 font-mono shadow-card placeholder:text-ink-3 focus:outline-none focus:border-primary-400 focus:shadow-input-focus transition-all duration-150">
+            <input x-show="cronForm.schedule_type === 'every'" type="text" x-model="cronForm.every" placeholder="30m, 2h, 1h30m"
+                   class="w-full h-10 rounded-lg border border-surface-4 bg-surface-0 px-3 text-sm text-ink-0 font-mono shadow-card placeholder:text-ink-3 focus:outline-none focus:border-primary-400 focus:shadow-input-focus transition-all duration-150">
+          </div>
+          <div>
+            <label class="text-[11px] font-medium text-ink-2 uppercase tracking-wider mb-1.5 block">Message / Instruction</label>
+            <textarea x-model="cronForm.message" rows="3" placeholder="What should Anna do when this job runs?"
+                      class="w-full rounded-lg border border-surface-4 bg-surface-0 px-3 py-2 text-sm text-ink-0 shadow-card placeholder:text-ink-3 focus:outline-none focus:border-primary-400 focus:shadow-input-focus transition-all duration-150 resize-y"></textarea>
+          </div>
+          <div class="flex items-center justify-between pt-1">
+            <label class="inline-flex items-center gap-2 cursor-pointer">
+              <input type="checkbox" x-model="cronForm.enabled" class="accent-primary-600 w-4 h-4 rounded">
+              <span class="text-xs text-ink-1">Enabled</span>
+            </label>
+            <button @click="cronSave()" :disabled="!cronForm.name || !cronForm.message || (cronForm.schedule_type === 'cron' ? !cronForm.cron : !cronForm.every)"
+                    class="inline-flex items-center gap-1.5 h-8 px-3.5 text-xs font-medium text-white bg-primary-600 rounded-md shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 disabled:opacity-40 disabled:cursor-not-allowed transition-all duration-150 cursor-pointer active:scale-[0.98]">
+              <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5"/></svg>
+              <span x-text="cronEditing ? 'Update' : 'Create'"></span>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Job list -->
+      <template x-if="cronJobs.length === 0 && !cronLoading">
+        <div class="rounded-xl border-2 border-dashed border-surface-3 py-16 text-center">
+          <div class="w-10 h-10 rounded-full bg-surface-2 flex items-center justify-center mx-auto mb-3">
+            <svg class="w-5 h-5 text-ink-3" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/></svg>
+          </div>
+          <p class="text-sm text-ink-2">No scheduled jobs</p>
+          <p class="text-xs text-ink-3 mt-0.5">Create one above to run tasks on a schedule</p>
+        </div>
+      </template>
+
+      <div class="space-y-2">
+        <template x-for="job in cronJobs" :key="job.id">
+          <div class="rounded-xl border border-surface-3 bg-surface-0 shadow-card hover:shadow-card-hover transition-shadow duration-200 px-4 py-3">
+            <div class="flex items-center justify-between">
+              <div class="flex items-center gap-3 min-w-0">
+                <button @click="cronToggle(job)" class="shrink-0 cursor-pointer"
+                        :title="job.enabled ? 'Disable' : 'Enable'">
+                  <div class="w-8 h-5 rounded-full transition-colors duration-200 flex items-center"
+                       :class="job.enabled ? 'bg-primary-500' : 'bg-surface-4'">
+                    <div class="w-3.5 h-3.5 rounded-full bg-white shadow-sm transition-transform duration-200"
+                         :class="job.enabled ? 'translate-x-[14px]' : 'translate-x-[3px]'"></div>
+                  </div>
+                </button>
+                <div class="min-w-0">
+                  <div class="text-sm font-medium text-ink-0 truncate" x-text="job.name"></div>
+                  <div class="text-[11px] text-ink-2 font-mono mt-0.5"
+                       x-text="job.schedule.cron ? ('cron: ' + job.schedule.cron) : ('every ' + job.schedule.every)"></div>
+                </div>
+              </div>
+              <div class="flex items-center gap-1 shrink-0 ml-3">
+                <button @click="cronEdit(job)"
+                        class="p-1.5 rounded-md text-ink-3 hover:text-primary-600 hover:bg-primary-50 transition-colors duration-150 cursor-pointer"
+                        title="Edit">
+                  <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125"/></svg>
+                </button>
+                <button @click="cronDelete(job.id)"
+                        class="p-1.5 rounded-md text-ink-3 hover:text-danger-500 hover:bg-danger-50 transition-colors duration-150 cursor-pointer"
+                        title="Delete">
+                  <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"/></svg>
+                </button>
+              </div>
+            </div>
+            <div class="mt-2 text-xs text-ink-2 line-clamp-2" x-text="job.message"></div>
+            <div class="mt-1.5 flex items-center gap-2">
+              <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium"
+                    :class="job.session_mode === 'new' ? 'bg-primary-50 text-primary-700' : 'bg-surface-2 text-ink-2'"
+                    x-text="job.session_mode === 'new' ? 'new session' : 'reuse session'"></span>
+            </div>
+          </div>
+        </template>
+      </div>
+    </section>
   </main>
 
   <!-- Footer -->
@@ -366,6 +483,7 @@ function onboard() {
       { id: 'global', label: 'Global', icon: 'M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z' },
       { id: 'providers', label: 'Providers', icon: 'M5.25 14.25h13.5m-13.5 0a3 3 0 0 1-3-3m3 3a3 3 0 1 0 0 6h13.5a3 3 0 1 0 0-6m-16.5-3a3 3 0 0 1 3-3h13.5a3 3 0 0 1 3 3m-19.5 0a4.5 4.5 0 0 1 .9-2.7L5.737 5.1a3.375 3.375 0 0 1 2.7-1.35h7.126c1.062 0 2.062.5 2.7 1.35l2.587 3.45a4.5 4.5 0 0 1 .9 2.7m0 0a3 3 0 0 1-3 3m0 3h.008v.008h-.008v-.008Zm0-6h.008v.008h-.008v-.008Z' },
       { id: 'channels', label: 'Channels', icon: 'M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z' },
+      { id: 'cron', label: 'Cron', icon: 'M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z' },
     ],
     config: {
       provider: 'anthropic',
@@ -382,6 +500,10 @@ function onboard() {
     saving: false,
     message: '',
     messageType: 'success',
+    cronJobs: [],
+    cronLoading: false,
+    cronEditing: null,
+    cronForm: { name: '', message: '', schedule_type: 'cron', cron: '', every: '', session_mode: 'reuse', enabled: true },
 
     get availableProviderTypes() {
       return Object.keys(providerDefaults);
@@ -470,6 +592,7 @@ function onboard() {
         this.showMessage('Failed to load config: ' + e.message, 'error');
       }
       this.newProviderType = this.addableProviders[0] || '';
+      this.cronLoad();
     },
 
     async save() {
@@ -491,6 +614,102 @@ function onboard() {
         this.showMessage('Network error: ' + e.message, 'error');
       } finally {
         this.saving = false;
+      }
+    },
+
+    async cronLoad() {
+      this.cronLoading = true;
+      try {
+        const resp = await fetch('/api/cron/jobs');
+        const data = await resp.json();
+        this.cronJobs = data.jobs || [];
+      } catch (e) {
+        this.showMessage('Failed to load cron jobs: ' + e.message, 'error');
+      } finally {
+        this.cronLoading = false;
+      }
+    },
+
+    cronResetForm() {
+      this.cronForm = { name: '', message: '', schedule_type: 'cron', cron: '', every: '', session_mode: 'reuse', enabled: true };
+      this.cronEditing = null;
+    },
+
+    cronEdit(job) {
+      this.cronEditing = job.id;
+      const isCron = !!job.schedule.cron;
+      this.cronForm = {
+        name: job.name,
+        message: job.message,
+        schedule_type: isCron ? 'cron' : 'every',
+        cron: job.schedule.cron || '',
+        every: job.schedule.every || '',
+        session_mode: job.session_mode || 'reuse',
+        enabled: job.enabled,
+      };
+    },
+
+    cronCancelEdit() {
+      this.cronResetForm();
+    },
+
+    async cronSave() {
+      const payload = {
+        name: this.cronForm.name,
+        message: this.cronForm.message,
+        cron: this.cronForm.schedule_type === 'cron' ? this.cronForm.cron : '',
+        every: this.cronForm.schedule_type === 'every' ? this.cronForm.every : '',
+        session_mode: this.cronForm.session_mode,
+        enabled: this.cronForm.enabled,
+      };
+      try {
+        const url = this.cronEditing ? `/api/cron/jobs/${this.cronEditing}` : '/api/cron/jobs';
+        const method = this.cronEditing ? 'PUT' : 'POST';
+        const resp = await fetch(url, { method, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
+        const data = await resp.json();
+        if (!resp.ok) {
+          this.showMessage(data.error || 'Failed to save job', 'error');
+          return;
+        }
+        this.showMessage(this.cronEditing ? 'Job updated' : 'Job created', 'success');
+        this.cronResetForm();
+        await this.cronLoad();
+      } catch (e) {
+        this.showMessage('Network error: ' + e.message, 'error');
+      }
+    },
+
+    async cronToggle(job) {
+      try {
+        const resp = await fetch(`/api/cron/jobs/${job.id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: job.name, message: job.message, cron: job.schedule.cron || '', every: job.schedule.every || '', session_mode: job.session_mode, enabled: !job.enabled }),
+        });
+        if (!resp.ok) {
+          const data = await resp.json();
+          this.showMessage(data.error || 'Failed to toggle job', 'error');
+          return;
+        }
+        await this.cronLoad();
+      } catch (e) {
+        this.showMessage('Network error: ' + e.message, 'error');
+      }
+    },
+
+    async cronDelete(id) {
+      try {
+        const resp = await fetch(`/api/cron/jobs/${id}`, { method: 'DELETE' });
+        if (!resp.ok) {
+          const data = await resp.json();
+          this.showMessage(data.error || 'Failed to delete job', 'error');
+          return;
+        }
+        this.showMessage('Job deleted', 'success');
+        if (this.cronEditing === id) this.cronResetForm();
+        await this.cronLoad();
+      } catch (e) {
+        this.showMessage('Network error: ' + e.message, 'error');
       }
     },
 

--- a/onboard.html
+++ b/onboard.html
@@ -6,193 +6,331 @@
   <title>Anna - Setup</title>
   <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
   <script>
     tailwind.config = {
       theme: {
         extend: {
+          fontFamily: {
+            sans: ['Inter', 'system-ui', 'sans-serif'],
+            mono: ['JetBrains Mono', 'ui-monospace', 'monospace'],
+          },
           colors: {
-            brand: { 50: '#f0f9ff', 100: '#e0f2fe', 200: '#bae6fd', 300: '#7dd3fc', 400: '#38bdf8', 500: '#0ea5e9', 600: '#0284c7', 700: '#0369a1', 800: '#075985', 900: '#0c4a6e' }
-          }
-        }
-      }
+            surface: { 0: '#ffffff', 1: '#f8f9fa', 2: '#f1f3f5', 3: '#e9ecef', 4: '#dee2e6' },
+            ink: { 0: '#212529', 1: '#495057', 2: '#868e96', 3: '#adb5bd', 4: '#ced4da' },
+            primary: { 50: '#eef2ff', 100: '#e0e7ff', 200: '#c7d2fe', 300: '#a5b4fc', 400: '#818cf8', 500: '#6366f1', 600: '#4f46e5', 700: '#4338ca', 800: '#3730a3', 900: '#312e81' },
+            success: { 50: '#ecfdf5', 500: '#22c55e', 600: '#16a34a' },
+            danger: { 50: '#fef2f2', 500: '#ef4444', 600: '#dc2626' },
+          },
+          boxShadow: {
+            'card': '0 1px 3px 0 rgb(0 0 0 / 0.04), 0 1px 2px -1px rgb(0 0 0 / 0.04)',
+            'card-hover': '0 4px 6px -1px rgb(0 0 0 / 0.05), 0 2px 4px -2px rgb(0 0 0 / 0.04)',
+            'input-focus': '0 0 0 3px rgb(99 102 241 / 0.12)',
+          },
+        },
+      },
     }
   </script>
   <style>
     [x-cloak] { display: none !important; }
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; }
+    }
+    /* Custom scrollbar */
+    ::-webkit-scrollbar { width: 6px; }
+    ::-webkit-scrollbar-track { background: transparent; }
+    ::-webkit-scrollbar-thumb { background: #ced4da; border-radius: 3px; }
+    ::-webkit-scrollbar-thumb:hover { background: #adb5bd; }
+    /* Password reveal override */
+    input::-ms-reveal { display: none; }
   </style>
 </head>
-<body class="bg-gray-50 min-h-screen">
+<body class="bg-surface-1 min-h-screen font-sans text-ink-0 antialiased">
 
-<div x-data="onboard()" x-cloak class="max-w-3xl mx-auto py-10 px-4">
-  <!-- Header -->
-  <div class="text-center mb-10">
-    <h1 class="text-3xl font-bold text-gray-900">Anna Setup</h1>
-    <p class="mt-2 text-gray-500">Configure your local AI assistant</p>
+<div x-data="onboard()" x-cloak class="min-h-screen flex flex-col">
+
+  <!-- Top bar -->
+  <header class="sticky top-0 z-30 bg-surface-0/80 backdrop-blur-lg border-b border-surface-3">
+    <div class="max-w-2xl mx-auto px-5 h-14 flex items-center justify-between">
+      <div class="flex items-center gap-2.5">
+        <div class="w-7 h-7 rounded-lg bg-gradient-to-br from-primary-500 to-primary-700 flex items-center justify-center shadow-sm">
+          <svg class="w-4 h-4 text-white" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456Z"/></svg>
+        </div>
+        <span class="text-sm font-semibold text-ink-0 tracking-tight">Anna</span>
+        <span class="text-xs text-ink-3 hidden sm:inline">/</span>
+        <span class="text-xs text-ink-2 hidden sm:inline">Setup</span>
+      </div>
+      <button @click="save()" :disabled="saving"
+              class="inline-flex items-center gap-1.5 h-8 px-3.5 text-xs font-medium text-white bg-primary-600 rounded-md shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 disabled:opacity-40 disabled:cursor-not-allowed transition-all duration-150 cursor-pointer active:scale-[0.98]">
+        <svg x-show="!saving" class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5"/></svg>
+        <svg x-show="saving" class="w-3.5 h-3.5 animate-spin" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path></svg>
+        <span x-text="saving ? 'Saving...' : 'Save'"></span>
+      </button>
+    </div>
+  </header>
+
+  <!-- Toast -->
+  <div class="fixed top-16 left-1/2 -translate-x-1/2 z-50 w-full max-w-sm px-4"
+       x-show="message" x-transition:enter="transition ease-out duration-200" x-transition:enter-start="opacity-0 -translate-y-1 scale-95" x-transition:enter-end="opacity-100 translate-y-0 scale-100"
+       x-transition:leave="transition ease-in duration-150" x-transition:leave-start="opacity-100 translate-y-0 scale-100" x-transition:leave-end="opacity-0 -translate-y-1 scale-95">
+    <div :class="messageType === 'error' ? 'bg-danger-600' : 'bg-ink-0'" class="flex items-center gap-2 px-3.5 py-2.5 rounded-lg shadow-lg ring-1 ring-black/5 text-xs text-white">
+      <template x-if="messageType === 'error'">
+        <svg class="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z"/></svg>
+      </template>
+      <template x-if="messageType !== 'error'">
+        <svg class="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5"/></svg>
+      </template>
+      <span x-text="message" class="leading-snug"></span>
+    </div>
   </div>
 
-  <!-- Status messages -->
-  <div x-show="message" x-transition
-       :class="messageType === 'error' ? 'bg-red-50 border-red-200 text-red-700' : 'bg-green-50 border-green-200 text-green-700'"
-       class="mb-6 px-4 py-3 rounded-lg border text-sm" x-text="message"></div>
+  <!-- Main -->
+  <main class="flex-1 max-w-2xl w-full mx-auto px-5 py-8">
 
-  <!-- Section 1: Global Settings -->
-  <section class="bg-white rounded-xl shadow-sm border border-gray-200 p-6 mb-6">
-    <h2 class="text-lg font-semibold text-gray-900 mb-4">Global Settings</h2>
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-      <div>
-        <label class="block text-sm font-medium text-gray-700 mb-1">Provider</label>
-        <select x-model="config.provider" class="w-full rounded-lg border-gray-300 border px-3 py-2 text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none">
-          <template x-for="p in availableProviderTypes" :key="p">
-            <option :value="p" x-text="p" :selected="p === config.provider"></option>
-          </template>
-        </select>
-      </div>
-      <div>
-        <label class="block text-sm font-medium text-gray-700 mb-1">Model</label>
-        <div class="relative">
-          <input type="text" x-model="config.model" list="model-list" placeholder="e.g. claude-sonnet-4-6"
-                 class="w-full rounded-lg border-gray-300 border px-3 py-2 text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none">
-          <datalist id="model-list">
-            <template x-for="m in modelsForProvider(config.provider)" :key="m">
-              <option :value="m"></option>
-            </template>
-          </datalist>
-        </div>
-      </div>
-      <div>
-        <label class="block text-sm font-medium text-gray-700 mb-1">Model Strong <span class="text-gray-400 font-normal">(optional)</span></label>
-        <input type="text" x-model="config.model_strong" list="model-list" placeholder="Falls back to Model"
-               class="w-full rounded-lg border-gray-300 border px-3 py-2 text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none">
-      </div>
-      <div>
-        <label class="block text-sm font-medium text-gray-700 mb-1">Model Fast <span class="text-gray-400 font-normal">(optional)</span></label>
-        <input type="text" x-model="config.model_fast" list="model-list" placeholder="Falls back to Model"
-               class="w-full rounded-lg border-gray-300 border px-3 py-2 text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none">
-      </div>
-      <div class="md:col-span-2">
-        <label class="block text-sm font-medium text-gray-700 mb-1">Workspace <span class="text-gray-400 font-normal">(optional)</span></label>
-        <input type="text" x-model="config.workspace" placeholder="Default: ~/.anna/workspace"
-               class="w-full rounded-lg border-gray-300 border px-3 py-2 text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none">
-      </div>
-    </div>
-  </section>
+    <!-- Tab navigation -->
+    <nav class="flex gap-0.5 p-1 bg-surface-2 rounded-lg mb-8 w-fit" role="tablist">
+      <template x-for="(tab, i) in tabs" :key="tab.id">
+        <button @click="activeTab = i" role="tab" :aria-selected="activeTab === i"
+                :class="activeTab === i ? 'bg-surface-0 text-ink-0 shadow-card' : 'text-ink-2 hover:text-ink-1'"
+                class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-150 cursor-pointer">
+          <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" :d="tab.icon"/></svg>
+          <span x-text="tab.label"></span>
+        </button>
+      </template>
+    </nav>
 
-  <!-- Section 2: Providers -->
-  <section class="bg-white rounded-xl shadow-sm border border-gray-200 p-6 mb-6">
-    <div class="flex items-center justify-between mb-4">
-      <h2 class="text-lg font-semibold text-gray-900">Providers</h2>
-      <div class="flex items-center gap-2">
-        <select x-model="newProviderType" class="rounded-lg border-gray-300 border px-3 py-1.5 text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none">
+    <!-- Tab 0: Global -->
+    <section x-show="activeTab === 0" x-transition.opacity.duration.150ms>
+      <div class="space-y-6">
+        <!-- Primary row -->
+        <fieldset class="space-y-1.5">
+          <legend class="text-xs font-semibold text-ink-2 uppercase tracking-wider mb-3">Default provider</legend>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div>
+              <label for="provider" class="sr-only">Provider</label>
+              <select id="provider" x-model="config.provider"
+                      class="w-full h-10 rounded-lg border border-surface-4 bg-surface-0 px-3 text-sm text-ink-0 shadow-card focus:outline-none focus:border-primary-400 focus:shadow-input-focus transition-all duration-150 cursor-pointer appearance-none bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20fill%3D%22%23868e96%22%20viewBox%3D%220%200%2016%2016%22%3E%3Cpath%20d%3D%22M4.646%206.646a.5.5%200%20011%200L8%209.293l2.354-2.647a.5.5%200%2001.707.708l-3%203a.5.5%200%2001-.707%200l-3-3a.5.5%200%20010-.708z%22%2F%3E%3C%2Fsvg%3E')] bg-[length:16px] bg-[right_10px_center] bg-no-repeat">
+                <template x-for="p in availableProviderTypes" :key="p">
+                  <option :value="p" x-text="p"></option>
+                </template>
+              </select>
+            </div>
+            <div>
+              <label for="model" class="sr-only">Model</label>
+              <input id="model" type="text" x-model="config.model" list="model-list" placeholder="Model ID"
+                     class="w-full h-10 rounded-lg border border-surface-4 bg-surface-0 px-3 text-sm text-ink-0 font-mono shadow-card placeholder:text-ink-3 focus:outline-none focus:border-primary-400 focus:shadow-input-focus transition-all duration-150">
+              <datalist id="model-list">
+                <template x-for="m in modelsForProvider(config.provider)" :key="m">
+                  <option :value="m"></option>
+                </template>
+              </datalist>
+            </div>
+          </div>
+        </fieldset>
+
+        <!-- Model tiers -->
+        <fieldset class="space-y-1.5">
+          <legend class="text-xs font-semibold text-ink-2 uppercase tracking-wider mb-3">Model tiers <span class="normal-case font-normal tracking-normal text-ink-3">optional overrides</span></legend>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div class="relative">
+              <label for="model-strong" class="absolute left-3 top-1/2 -translate-y-1/2 text-[10px] font-medium text-ink-3 uppercase tracking-wider pointer-events-none transition-all duration-150"
+                     :class="config.model_strong ? 'top-2 -translate-y-0 text-[9px] text-primary-500' : ''">Strong</label>
+              <input id="model-strong" type="text" x-model="config.model_strong" list="model-list"
+                     class="w-full h-10 rounded-lg border border-surface-4 bg-surface-0 px-3 text-sm text-ink-0 font-mono shadow-card placeholder:text-ink-3 focus:outline-none focus:border-primary-400 focus:shadow-input-focus transition-all duration-150"
+                     :class="config.model_strong ? 'pt-3.5 pb-0.5' : ''">
+            </div>
+            <div class="relative">
+              <label for="model-fast" class="absolute left-3 top-1/2 -translate-y-1/2 text-[10px] font-medium text-ink-3 uppercase tracking-wider pointer-events-none transition-all duration-150"
+                     :class="config.model_fast ? 'top-2 -translate-y-0 text-[9px] text-primary-500' : ''">Fast</label>
+              <input id="model-fast" type="text" x-model="config.model_fast" list="model-list"
+                     class="w-full h-10 rounded-lg border border-surface-4 bg-surface-0 px-3 text-sm text-ink-0 font-mono shadow-card placeholder:text-ink-3 focus:outline-none focus:border-primary-400 focus:shadow-input-focus transition-all duration-150"
+                     :class="config.model_fast ? 'pt-3.5 pb-0.5' : ''">
+            </div>
+          </div>
+        </fieldset>
+
+        <!-- Workspace -->
+        <fieldset class="space-y-1.5">
+          <legend class="text-xs font-semibold text-ink-2 uppercase tracking-wider mb-3">Workspace <span class="normal-case font-normal tracking-normal text-ink-3">data directory</span></legend>
+          <input id="workspace" type="text" x-model="config.workspace" placeholder="~/.anna/workspace"
+                 class="w-full h-10 rounded-lg border border-surface-4 bg-surface-0 px-3 text-sm text-ink-1 font-mono shadow-card placeholder:text-ink-3 focus:outline-none focus:border-primary-400 focus:shadow-input-focus transition-all duration-150">
+        </fieldset>
+      </div>
+    </section>
+
+    <!-- Tab 1: Providers -->
+    <section x-show="activeTab === 1" x-transition.opacity.duration.150ms>
+
+      <!-- Add bar -->
+      <div class="flex items-center gap-2 mb-5">
+        <select x-model="newProviderType"
+                class="flex-1 h-10 rounded-lg border border-surface-4 bg-surface-0 px-3 text-sm text-ink-0 shadow-card focus:outline-none focus:border-primary-400 focus:shadow-input-focus transition-all duration-150 cursor-pointer appearance-none bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20fill%3D%22%23868e96%22%20viewBox%3D%220%200%2016%2016%22%3E%3Cpath%20d%3D%22M4.646%206.646a.5.5%200%20011%200L8%209.293l2.354-2.647a.5.5%200%2001.707.708l-3%203a.5.5%200%2001-.707%200l-3-3a.5.5%200%20010-.708z%22%2F%3E%3C%2Fsvg%3E')] bg-[length:16px] bg-[right_10px_center] bg-no-repeat">
+          <option value="" disabled>Select provider...</option>
           <template x-for="p in addableProviders" :key="p">
             <option :value="p" x-text="p"></option>
           </template>
         </select>
         <button @click="addProvider()" :disabled="!newProviderType"
-                class="px-3 py-1.5 text-sm font-medium text-white bg-brand-600 rounded-lg hover:bg-brand-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
+                class="inline-flex items-center gap-1.5 h-10 px-4 text-xs font-medium text-white bg-primary-600 rounded-lg shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 disabled:opacity-40 disabled:cursor-not-allowed transition-all duration-150 cursor-pointer active:scale-[0.98]">
+          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15"/></svg>
           Add
         </button>
       </div>
-    </div>
 
-    <template x-if="Object.keys(config.providers).length === 0">
-      <p class="text-sm text-gray-400 text-center py-4">No providers configured. Add one to get started.</p>
-    </template>
-
-    <div class="space-y-4">
-      <template x-for="(prov, name) in config.providers" :key="name">
-        <div class="border border-gray-200 rounded-lg p-4">
-          <div class="flex items-center justify-between mb-3">
-            <h3 class="font-medium text-gray-900" x-text="name"></h3>
-            <button @click="removeProvider(name)" class="text-sm text-red-500 hover:text-red-700 transition-colors">Remove</button>
+      <!-- Empty -->
+      <template x-if="Object.keys(config.providers).length === 0">
+        <div class="rounded-xl border-2 border-dashed border-surface-3 py-16 text-center">
+          <div class="w-10 h-10 rounded-full bg-surface-2 flex items-center justify-center mx-auto mb-3">
+            <svg class="w-5 h-5 text-ink-3" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15"/></svg>
           </div>
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
-            <div class="md:col-span-2">
-              <label class="block text-sm font-medium text-gray-700 mb-1">API Key <span class="text-red-500">*</span></label>
-              <input type="password" :value="prov.api_key" @input="prov.api_key = $event.target.value" placeholder="Required"
-                     class="w-full rounded-lg border-gray-300 border px-3 py-2 text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none">
-            </div>
-            <div class="md:col-span-2">
-              <label class="block text-sm font-medium text-gray-700 mb-1">Base URL</label>
-              <input type="text" :value="prov.base_url" @input="prov.base_url = $event.target.value" :placeholder="defaultBaseURL(name)"
-                     class="w-full rounded-lg border-gray-300 border px-3 py-2 text-sm text-gray-600 focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none">
-            </div>
-          </div>
-          <div class="mt-3 flex items-center gap-3">
-            <button @click="fetchModels(name)" :disabled="!prov.api_key || fetchingModels[name]"
-                    class="px-3 py-1.5 text-sm font-medium text-brand-700 bg-brand-50 border border-brand-200 rounded-lg hover:bg-brand-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
-              <span x-show="!fetchingModels[name]">Get All Models</span>
-              <span x-show="fetchingModels[name]">Fetching...</span>
-            </button>
-            <span x-show="providerModels[name]?.length" class="text-xs text-gray-400" x-text="(providerModels[name]?.length || 0) + ' models cached'"></span>
-          </div>
+          <p class="text-sm text-ink-2">No providers yet</p>
+          <p class="text-xs text-ink-3 mt-0.5">Add one above to connect to an LLM API</p>
         </div>
       </template>
-    </div>
-  </section>
 
-  <!-- Section 3: Channels -->
-  <section class="bg-white rounded-xl shadow-sm border border-gray-200 p-6 mb-6">
-    <h2 class="text-lg font-semibold text-gray-900 mb-4">Channels</h2>
+      <!-- Cards -->
+      <div class="space-y-3">
+        <template x-for="(prov, name) in config.providers" :key="name">
+          <div class="rounded-xl border border-surface-3 bg-surface-0 shadow-card hover:shadow-card-hover transition-shadow duration-200 overflow-hidden">
+            <!-- Header -->
+            <div class="flex items-center justify-between px-4 py-2.5 border-b border-surface-2">
+              <div class="flex items-center gap-2">
+                <div class="w-6 h-6 rounded-md flex items-center justify-center"
+                     :class="{'bg-[#d97706]/10 text-[#d97706]': name === 'anthropic', 'bg-[#10a37f]/10 text-[#10a37f]': name.startsWith('openai')}">
+                  <template x-if="name === 'anthropic'">
+                    <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor"><path d="M17.304 3.541h-3.483l6.26 16.918h3.483L17.304 3.541zm-10.61 0L.436 20.459h3.583l1.274-3.574h6.54l1.273 3.574h3.584L10.43 3.541H6.695zm-.424 10.76L8.56 8.282l2.29 6.019H6.27z"/></svg>
+                  </template>
+                  <template x-if="name.startsWith('openai')">
+                    <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor"><path d="M22.282 9.821a5.985 5.985 0 0 0-.516-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a5.998 5.998 0 0 0-3.998 2.9 6.042 6.042 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.051 6.051 0 0 0 6.515 2.9A5.985 5.985 0 0 0 13.26 24a6.056 6.056 0 0 0 5.772-4.206 5.99 5.99 0 0 0 3.997-2.9 6.056 6.056 0 0 0-.747-7.073zM13.26 22.43a4.476 4.476 0 0 1-2.876-1.04l.141-.081 4.779-2.758a.795.795 0 0 0 .392-.681v-6.737l2.02 1.168a.071.071 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.494 4.494zM3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.783 2.759a.771.771 0 0 0 .78 0l5.843-3.369v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646zM2.34 7.896a4.485 4.485 0 0 1 2.366-1.973V11.6a.766.766 0 0 0 .388.676l5.815 3.355-2.02 1.168a.076.076 0 0 1-.071 0l-4.83-2.786A4.504 4.504 0 0 1 2.34 7.872zm16.597 3.855-5.833-3.387L15.119 7.2a.076.076 0 0 1 .071 0l4.83 2.791a4.494 4.494 0 0 1-.676 8.105v-5.678a.79.79 0 0 0-.407-.667zm2.01-3.023-.141-.085-4.774-2.782a.776.776 0 0 0-.785 0L9.409 9.23V6.897a.066.066 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.68 4.66zm-12.64 4.135-2.02-1.164a.08.08 0 0 1-.038-.057V6.075a4.5 4.5 0 0 1 7.375-3.453l-.142.08L8.704 5.46a.795.795 0 0 0-.393.681zm1.097-2.365 2.602-1.5 2.607 1.5v2.999l-2.597 1.5-2.607-1.5z"/></svg>
+                  </template>
+                </div>
+                <span class="text-sm font-medium text-ink-0" x-text="name"></span>
+              </div>
+              <button @click="removeProvider(name)"
+                      class="p-1 rounded-md text-ink-3 hover:text-danger-500 hover:bg-danger-50 transition-colors duration-150 cursor-pointer focus:outline-none"
+                      :aria-label="'Remove ' + name">
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/></svg>
+              </button>
+            </div>
 
-    <!-- Telegram -->
-    <div class="border border-gray-200 rounded-lg p-4">
-      <h3 class="font-medium text-gray-900 mb-3">Telegram</h3>
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
-        <div class="md:col-span-2">
-          <label class="block text-sm font-medium text-gray-700 mb-1">Bot Token</label>
-          <input type="password" x-model="config.channels.telegram.token" placeholder="From @BotFather"
-                 class="w-full rounded-lg border-gray-300 border px-3 py-2 text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none">
+            <!-- Body -->
+            <div class="px-4 py-4 space-y-3">
+              <div>
+                <label :for="'key-' + name" class="flex items-center gap-1 text-[11px] font-medium text-ink-2 uppercase tracking-wider mb-1.5">
+                  <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 5.25a3 3 0 0 1 3 3m3 0a6 6 0 0 1-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1 1 21.75 8.25Z"/></svg>
+                  API Key
+                </label>
+                <input :id="'key-' + name" type="password" :value="prov.api_key" @input="prov.api_key = $event.target.value" placeholder="sk-..."
+                       class="w-full h-10 rounded-lg border border-surface-4 bg-surface-0 px-3 text-sm text-ink-0 font-mono shadow-card placeholder:text-ink-3 focus:outline-none focus:border-primary-400 focus:shadow-input-focus transition-all duration-150">
+              </div>
+              <div>
+                <label :for="'url-' + name" class="flex items-center gap-1 text-[11px] font-medium text-ink-2 uppercase tracking-wider mb-1.5">
+                  <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244"/></svg>
+                  Base URL
+                </label>
+                <input :id="'url-' + name" type="text" :value="prov.base_url" @input="prov.base_url = $event.target.value" :placeholder="defaultBaseURL(name)"
+                       class="w-full h-10 rounded-lg border border-surface-4 bg-surface-0 px-3 text-sm text-ink-1 font-mono shadow-card placeholder:text-ink-3 focus:outline-none focus:border-primary-400 focus:shadow-input-focus transition-all duration-150">
+              </div>
+
+              <!-- Models fetch -->
+              <div class="flex items-center gap-2 pt-1">
+                <button @click="fetchModels(name)" :disabled="!prov.api_key || fetchingModels[name]"
+                        class="inline-flex items-center gap-1.5 h-8 px-3 text-[11px] font-medium rounded-md border transition-all duration-150 cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed active:scale-[0.98]"
+                        :class="fetchingModels[name] ? 'bg-surface-2 border-surface-3 text-ink-3' : 'bg-surface-0 border-surface-4 text-ink-1 hover:bg-surface-1 hover:border-ink-4'">
+                  <svg x-show="!fetchingModels[name]" class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3"/></svg>
+                  <svg x-show="fetchingModels[name]" class="w-3.5 h-3.5 animate-spin" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path></svg>
+                  <span x-text="fetchingModels[name] ? 'Fetching...' : 'Get All Models'"></span>
+                </button>
+                <span x-show="providerModels[name]?.length" class="inline-flex items-center gap-1 text-[11px] text-success-600 font-medium">
+                  <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5"/></svg>
+                  <span x-text="providerModels[name]?.length + ' models'"></span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </template>
+      </div>
+    </section>
+
+    <!-- Tab 2: Channels -->
+    <section x-show="activeTab === 2" x-transition.opacity.duration.150ms>
+      <div class="rounded-xl border border-surface-3 bg-surface-0 shadow-card overflow-hidden">
+        <!-- Telegram header -->
+        <div class="flex items-center gap-2 px-4 py-2.5 border-b border-surface-2">
+          <svg class="w-5 h-5 text-[#26A5E4]" viewBox="0 0 24 24" fill="currentColor"><path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.96 6.504-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z"/></svg>
+          <span class="text-sm font-medium text-ink-0">Telegram</span>
         </div>
-        <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">Notify Chat ID</label>
-          <input type="text" x-model="config.channels.telegram.notify_chat" placeholder="Chat ID for notifications"
-                 class="w-full rounded-lg border-gray-300 border px-3 py-2 text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none">
-        </div>
-        <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">Channel ID</label>
-          <input type="text" x-model="config.channels.telegram.channel_id" placeholder="Default channel ID"
-                 class="w-full rounded-lg border-gray-300 border px-3 py-2 text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none">
-        </div>
-        <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">Group Mode</label>
-          <select x-model="config.channels.telegram.group_mode"
-                  class="w-full rounded-lg border-gray-300 border px-3 py-2 text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none">
-            <option value="">Default</option>
-            <option value="mention">Mention</option>
-            <option value="always">Always</option>
-            <option value="disabled">Disabled</option>
-          </select>
-        </div>
-        <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">Allowed User IDs</label>
-          <input type="text" :value="(config.channels.telegram.allowed_ids || []).join(', ')"
-                 @change="config.channels.telegram.allowed_ids = $event.target.value.split(',').map(s => s.trim()).filter(Boolean).map(Number)"
-                 placeholder="Comma-separated IDs"
-                 class="w-full rounded-lg border-gray-300 border px-3 py-2 text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none">
+
+        <div class="px-4 py-4 space-y-3">
+          <div>
+            <label for="tg-token" class="flex items-center gap-1 text-[11px] font-medium text-ink-2 uppercase tracking-wider mb-1.5">
+              <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 5.25a3 3 0 0 1 3 3m3 0a6 6 0 0 1-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1 1 21.75 8.25Z"/></svg>
+              Bot Token
+            </label>
+            <input id="tg-token" type="password" x-model="config.channels.telegram.token" placeholder="From @BotFather"
+                   class="w-full h-10 rounded-lg border border-surface-4 bg-surface-0 px-3 text-sm text-ink-0 font-mono shadow-card placeholder:text-ink-3 focus:outline-none focus:border-primary-400 focus:shadow-input-focus transition-all duration-150">
+          </div>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div>
+              <label for="tg-notify" class="text-[11px] font-medium text-ink-2 uppercase tracking-wider mb-1.5 block">Notify Chat</label>
+              <input id="tg-notify" type="text" x-model="config.channels.telegram.notify_chat" placeholder="Chat ID"
+                     class="w-full h-10 rounded-lg border border-surface-4 bg-surface-0 px-3 text-sm text-ink-0 shadow-card placeholder:text-ink-3 focus:outline-none focus:border-primary-400 focus:shadow-input-focus transition-all duration-150">
+            </div>
+            <div>
+              <label for="tg-channel" class="text-[11px] font-medium text-ink-2 uppercase tracking-wider mb-1.5 block">Channel ID</label>
+              <input id="tg-channel" type="text" x-model="config.channels.telegram.channel_id" placeholder="Default channel"
+                     class="w-full h-10 rounded-lg border border-surface-4 bg-surface-0 px-3 text-sm text-ink-0 shadow-card placeholder:text-ink-3 focus:outline-none focus:border-primary-400 focus:shadow-input-focus transition-all duration-150">
+            </div>
+          </div>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div>
+              <label for="tg-group" class="text-[11px] font-medium text-ink-2 uppercase tracking-wider mb-1.5 block">Group Mode</label>
+              <select id="tg-group" x-model="config.channels.telegram.group_mode"
+                      class="w-full h-10 rounded-lg border border-surface-4 bg-surface-0 px-3 text-sm text-ink-0 shadow-card focus:outline-none focus:border-primary-400 focus:shadow-input-focus transition-all duration-150 cursor-pointer appearance-none bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20fill%3D%22%23868e96%22%20viewBox%3D%220%200%2016%2016%22%3E%3Cpath%20d%3D%22M4.646%206.646a.5.5%200%20011%200L8%209.293l2.354-2.647a.5.5%200%2001.707.708l-3%203a.5.5%200%2001-.707%200l-3-3a.5.5%200%20010-.708z%22%2F%3E%3C%2Fsvg%3E')] bg-[length:16px] bg-[right_10px_center] bg-no-repeat">
+                <option value="">Default</option>
+                <option value="mention">Mention</option>
+                <option value="always">Always</option>
+                <option value="disabled">Disabled</option>
+              </select>
+            </div>
+            <div>
+              <label for="tg-allowed" class="text-[11px] font-medium text-ink-2 uppercase tracking-wider mb-1.5 block">Allowed IDs</label>
+              <input id="tg-allowed" type="text" :value="(config.channels.telegram.allowed_ids || []).join(', ')"
+                     @change="config.channels.telegram.allowed_ids = $event.target.value.split(',').map(s => s.trim()).filter(Boolean).map(Number)"
+                     placeholder="Comma-separated user IDs"
+                     class="w-full h-10 rounded-lg border border-surface-4 bg-surface-0 px-3 text-sm text-ink-0 shadow-card placeholder:text-ink-3 focus:outline-none focus:border-primary-400 focus:shadow-input-focus transition-all duration-150">
+            </div>
+          </div>
         </div>
       </div>
-    </div>
-  </section>
+    </section>
+  </main>
 
-  <!-- Save -->
-  <div class="flex justify-end gap-3">
-    <button @click="save()" :disabled="saving"
-            class="px-6 py-2.5 text-sm font-medium text-white bg-brand-600 rounded-lg hover:bg-brand-700 disabled:opacity-50 transition-colors shadow-sm">
-      <span x-show="!saving">Save Configuration</span>
-      <span x-show="saving">Saving...</span>
-    </button>
-  </div>
+  <!-- Footer -->
+  <footer class="border-t border-surface-3 bg-surface-0/60 backdrop-blur-sm">
+    <div class="max-w-2xl mx-auto px-5 py-3 flex items-center justify-between">
+      <span class="text-[11px] text-ink-3 font-mono">~/.anna/config.yaml</span>
+      <span class="text-[11px] text-ink-3">Press <kbd class="px-1 py-0.5 bg-surface-2 rounded text-ink-2 font-mono text-[10px]">Ctrl+C</kbd> in terminal to close</span>
+    </div>
+  </footer>
 </div>
 
 <script>
 function onboard() {
   const providerDefaults = {
-    'anthropic':        { base_url: 'https://api.anthropic.com' },
-    'openai':           { base_url: 'https://api.openai.com/v1' },
-    'openai-response':  { base_url: 'https://api.openai.com/v1' },
+    'anthropic':       { base_url: 'https://api.anthropic.com' },
+    'openai':          { base_url: 'https://api.openai.com/v1' },
+    'openai-response': { base_url: 'https://api.openai.com/v1' },
   };
 
   return {
+    activeTab: 0,
+    tabs: [
+      { id: 'global', label: 'Global', icon: 'M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z' },
+      { id: 'providers', label: 'Providers', icon: 'M5.25 14.25h13.5m-13.5 0a3 3 0 0 1-3-3m3 3a3 3 0 1 0 0 6h13.5a3 3 0 1 0 0-6m-16.5-3a3 3 0 0 1 3-3h13.5a3 3 0 0 1 3 3m-19.5 0a4.5 4.5 0 0 1 .9-2.7L5.737 5.1a3.375 3.375 0 0 1 2.7-1.35h7.126c1.062 0 2.062.5 2.7 1.35l2.587 3.45a4.5 4.5 0 0 1 .9 2.7m0 0a3 3 0 0 1-3 3m0 3h.008v.008h-.008v-.008Zm0-6h.008v.008h-.008v-.008Z' },
+      { id: 'channels', label: 'Channels', icon: 'M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z' },
+    ],
     config: {
       provider: 'anthropic',
       model: 'claude-sonnet-4-6',
@@ -263,7 +401,6 @@ function onboard() {
         const resp = await fetch('/api/config');
         const data = await resp.json();
         if (data.config) {
-          // Merge loaded config with defaults to ensure all fields exist.
           this.config = {
             ...this.config,
             ...data.config,
@@ -279,7 +416,6 @@ function onboard() {
       } catch (e) {
         this.showMessage('Failed to load config: ' + e.message, 'error');
       }
-      // Initialize addable provider dropdown.
       this.newProviderType = this.addableProviders[0] || '';
     },
 
@@ -297,7 +433,7 @@ function onboard() {
           this.showMessage(data.error || 'Failed to save', 'error');
           return;
         }
-        this.showMessage('Configuration saved successfully!', 'success');
+        this.showMessage('Configuration saved!', 'success');
       } catch (e) {
         this.showMessage('Network error: ' + e.message, 'error');
       } finally {
@@ -308,7 +444,7 @@ function onboard() {
     showMessage(msg, type) {
       this.message = msg;
       this.messageType = type;
-      if (type === 'success') setTimeout(() => this.clearMessage(), 4000);
+      if (type === 'success') setTimeout(() => this.clearMessage(), 3000);
     },
 
     clearMessage() {

--- a/onboard.html
+++ b/onboard.html
@@ -1,0 +1,321 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Anna - Setup</title>
+  <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            brand: { 50: '#f0f9ff', 100: '#e0f2fe', 200: '#bae6fd', 300: '#7dd3fc', 400: '#38bdf8', 500: '#0ea5e9', 600: '#0284c7', 700: '#0369a1', 800: '#075985', 900: '#0c4a6e' }
+          }
+        }
+      }
+    }
+  </script>
+  <style>
+    [x-cloak] { display: none !important; }
+  </style>
+</head>
+<body class="bg-gray-50 min-h-screen">
+
+<div x-data="onboard()" x-cloak class="max-w-3xl mx-auto py-10 px-4">
+  <!-- Header -->
+  <div class="text-center mb-10">
+    <h1 class="text-3xl font-bold text-gray-900">Anna Setup</h1>
+    <p class="mt-2 text-gray-500">Configure your local AI assistant</p>
+  </div>
+
+  <!-- Status messages -->
+  <div x-show="message" x-transition
+       :class="messageType === 'error' ? 'bg-red-50 border-red-200 text-red-700' : 'bg-green-50 border-green-200 text-green-700'"
+       class="mb-6 px-4 py-3 rounded-lg border text-sm" x-text="message"></div>
+
+  <!-- Section 1: Global Settings -->
+  <section class="bg-white rounded-xl shadow-sm border border-gray-200 p-6 mb-6">
+    <h2 class="text-lg font-semibold text-gray-900 mb-4">Global Settings</h2>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div>
+        <label class="block text-sm font-medium text-gray-700 mb-1">Provider</label>
+        <select x-model="config.provider" class="w-full rounded-lg border-gray-300 border px-3 py-2 text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none">
+          <template x-for="p in availableProviderTypes" :key="p">
+            <option :value="p" x-text="p" :selected="p === config.provider"></option>
+          </template>
+        </select>
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-gray-700 mb-1">Model</label>
+        <div class="relative">
+          <input type="text" x-model="config.model" list="model-list" placeholder="e.g. claude-sonnet-4-6"
+                 class="w-full rounded-lg border-gray-300 border px-3 py-2 text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none">
+          <datalist id="model-list">
+            <template x-for="m in modelsForProvider(config.provider)" :key="m">
+              <option :value="m"></option>
+            </template>
+          </datalist>
+        </div>
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-gray-700 mb-1">Model Strong <span class="text-gray-400 font-normal">(optional)</span></label>
+        <input type="text" x-model="config.model_strong" list="model-list" placeholder="Falls back to Model"
+               class="w-full rounded-lg border-gray-300 border px-3 py-2 text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none">
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-gray-700 mb-1">Model Fast <span class="text-gray-400 font-normal">(optional)</span></label>
+        <input type="text" x-model="config.model_fast" list="model-list" placeholder="Falls back to Model"
+               class="w-full rounded-lg border-gray-300 border px-3 py-2 text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none">
+      </div>
+      <div class="md:col-span-2">
+        <label class="block text-sm font-medium text-gray-700 mb-1">Workspace <span class="text-gray-400 font-normal">(optional)</span></label>
+        <input type="text" x-model="config.workspace" placeholder="Default: ~/.anna/workspace"
+               class="w-full rounded-lg border-gray-300 border px-3 py-2 text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none">
+      </div>
+    </div>
+  </section>
+
+  <!-- Section 2: Providers -->
+  <section class="bg-white rounded-xl shadow-sm border border-gray-200 p-6 mb-6">
+    <div class="flex items-center justify-between mb-4">
+      <h2 class="text-lg font-semibold text-gray-900">Providers</h2>
+      <div class="flex items-center gap-2">
+        <select x-model="newProviderType" class="rounded-lg border-gray-300 border px-3 py-1.5 text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none">
+          <template x-for="p in addableProviders" :key="p">
+            <option :value="p" x-text="p"></option>
+          </template>
+        </select>
+        <button @click="addProvider()" :disabled="!newProviderType"
+                class="px-3 py-1.5 text-sm font-medium text-white bg-brand-600 rounded-lg hover:bg-brand-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
+          Add
+        </button>
+      </div>
+    </div>
+
+    <template x-if="Object.keys(config.providers).length === 0">
+      <p class="text-sm text-gray-400 text-center py-4">No providers configured. Add one to get started.</p>
+    </template>
+
+    <div class="space-y-4">
+      <template x-for="(prov, name) in config.providers" :key="name">
+        <div class="border border-gray-200 rounded-lg p-4">
+          <div class="flex items-center justify-between mb-3">
+            <h3 class="font-medium text-gray-900" x-text="name"></h3>
+            <button @click="removeProvider(name)" class="text-sm text-red-500 hover:text-red-700 transition-colors">Remove</button>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+            <div class="md:col-span-2">
+              <label class="block text-sm font-medium text-gray-700 mb-1">API Key <span class="text-red-500">*</span></label>
+              <input type="password" :value="prov.api_key" @input="prov.api_key = $event.target.value" placeholder="Required"
+                     class="w-full rounded-lg border-gray-300 border px-3 py-2 text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none">
+            </div>
+            <div class="md:col-span-2">
+              <label class="block text-sm font-medium text-gray-700 mb-1">Base URL</label>
+              <input type="text" :value="prov.base_url" @input="prov.base_url = $event.target.value" :placeholder="defaultBaseURL(name)"
+                     class="w-full rounded-lg border-gray-300 border px-3 py-2 text-sm text-gray-600 focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none">
+            </div>
+          </div>
+          <div class="mt-3 flex items-center gap-3">
+            <button @click="fetchModels(name)" :disabled="!prov.api_key || fetchingModels[name]"
+                    class="px-3 py-1.5 text-sm font-medium text-brand-700 bg-brand-50 border border-brand-200 rounded-lg hover:bg-brand-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
+              <span x-show="!fetchingModels[name]">Get All Models</span>
+              <span x-show="fetchingModels[name]">Fetching...</span>
+            </button>
+            <span x-show="providerModels[name]?.length" class="text-xs text-gray-400" x-text="(providerModels[name]?.length || 0) + ' models cached'"></span>
+          </div>
+        </div>
+      </template>
+    </div>
+  </section>
+
+  <!-- Section 3: Channels -->
+  <section class="bg-white rounded-xl shadow-sm border border-gray-200 p-6 mb-6">
+    <h2 class="text-lg font-semibold text-gray-900 mb-4">Channels</h2>
+
+    <!-- Telegram -->
+    <div class="border border-gray-200 rounded-lg p-4">
+      <h3 class="font-medium text-gray-900 mb-3">Telegram</h3>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <div class="md:col-span-2">
+          <label class="block text-sm font-medium text-gray-700 mb-1">Bot Token</label>
+          <input type="password" x-model="config.channels.telegram.token" placeholder="From @BotFather"
+                 class="w-full rounded-lg border-gray-300 border px-3 py-2 text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none">
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 mb-1">Notify Chat ID</label>
+          <input type="text" x-model="config.channels.telegram.notify_chat" placeholder="Chat ID for notifications"
+                 class="w-full rounded-lg border-gray-300 border px-3 py-2 text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none">
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 mb-1">Channel ID</label>
+          <input type="text" x-model="config.channels.telegram.channel_id" placeholder="Default channel ID"
+                 class="w-full rounded-lg border-gray-300 border px-3 py-2 text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none">
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 mb-1">Group Mode</label>
+          <select x-model="config.channels.telegram.group_mode"
+                  class="w-full rounded-lg border-gray-300 border px-3 py-2 text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none">
+            <option value="">Default</option>
+            <option value="mention">Mention</option>
+            <option value="always">Always</option>
+            <option value="disabled">Disabled</option>
+          </select>
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 mb-1">Allowed User IDs</label>
+          <input type="text" :value="(config.channels.telegram.allowed_ids || []).join(', ')"
+                 @change="config.channels.telegram.allowed_ids = $event.target.value.split(',').map(s => s.trim()).filter(Boolean).map(Number)"
+                 placeholder="Comma-separated IDs"
+                 class="w-full rounded-lg border-gray-300 border px-3 py-2 text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none">
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Save -->
+  <div class="flex justify-end gap-3">
+    <button @click="save()" :disabled="saving"
+            class="px-6 py-2.5 text-sm font-medium text-white bg-brand-600 rounded-lg hover:bg-brand-700 disabled:opacity-50 transition-colors shadow-sm">
+      <span x-show="!saving">Save Configuration</span>
+      <span x-show="saving">Saving...</span>
+    </button>
+  </div>
+</div>
+
+<script>
+function onboard() {
+  const providerDefaults = {
+    'anthropic':        { base_url: 'https://api.anthropic.com' },
+    'openai':           { base_url: 'https://api.openai.com/v1' },
+    'openai-response':  { base_url: 'https://api.openai.com/v1' },
+  };
+
+  return {
+    config: {
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+      model_strong: '',
+      model_fast: '',
+      workspace: '',
+      providers: {},
+      channels: { telegram: { token: '', notify_chat: '', channel_id: '', group_mode: '', allowed_ids: [] } },
+    },
+    providerModels: {},
+    fetchingModels: {},
+    newProviderType: '',
+    saving: false,
+    message: '',
+    messageType: 'success',
+
+    get availableProviderTypes() {
+      return Object.keys(providerDefaults);
+    },
+
+    get addableProviders() {
+      return this.availableProviderTypes.filter(p => !(p in this.config.providers));
+    },
+
+    defaultBaseURL(name) {
+      return providerDefaults[name]?.base_url || '';
+    },
+
+    modelsForProvider(provider) {
+      return this.providerModels[provider] || [];
+    },
+
+    addProvider() {
+      if (!this.newProviderType || this.newProviderType in this.config.providers) return;
+      this.config.providers[this.newProviderType] = { api_key: '', base_url: '' };
+      this.newProviderType = this.addableProviders[0] || '';
+    },
+
+    removeProvider(name) {
+      delete this.config.providers[name];
+    },
+
+    async fetchModels(name) {
+      this.fetchingModels[name] = true;
+      this.clearMessage();
+      try {
+        const resp = await fetch(`/api/providers/${name}/models`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(this.config.providers[name]),
+        });
+        const data = await resp.json();
+        if (!resp.ok) {
+          this.showMessage(data.error || 'Failed to fetch models', 'error');
+          return;
+        }
+        this.providerModels[name] = data.models || [];
+        this.showMessage(`Fetched ${this.providerModels[name].length} models from ${name}`, 'success');
+      } catch (e) {
+        this.showMessage('Network error: ' + e.message, 'error');
+      } finally {
+        this.fetchingModels[name] = false;
+      }
+    },
+
+    async init() {
+      try {
+        const resp = await fetch('/api/config');
+        const data = await resp.json();
+        if (data.config) {
+          // Merge loaded config with defaults to ensure all fields exist.
+          this.config = {
+            ...this.config,
+            ...data.config,
+            channels: {
+              telegram: { token: '', notify_chat: '', channel_id: '', group_mode: '', allowed_ids: [], ...data.config.channels?.telegram },
+            },
+            providers: data.config.providers || {},
+          };
+        }
+        if (data.models) {
+          this.providerModels = data.models;
+        }
+      } catch (e) {
+        this.showMessage('Failed to load config: ' + e.message, 'error');
+      }
+      // Initialize addable provider dropdown.
+      this.newProviderType = this.addableProviders[0] || '';
+    },
+
+    async save() {
+      this.saving = true;
+      this.clearMessage();
+      try {
+        const resp = await fetch('/api/config', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(this.config),
+        });
+        const data = await resp.json();
+        if (!resp.ok) {
+          this.showMessage(data.error || 'Failed to save', 'error');
+          return;
+        }
+        this.showMessage('Configuration saved successfully!', 'success');
+      } catch (e) {
+        this.showMessage('Network error: ' + e.message, 'error');
+      } finally {
+        this.saving = false;
+      }
+    },
+
+    showMessage(msg, type) {
+      this.message = msg;
+      this.messageType = type;
+      if (type === 'success') setTimeout(() => this.clearMessage(), 4000);
+    },
+
+    clearMessage() {
+      this.message = '';
+    },
+  };
+}
+</script>
+</body>
+</html>

--- a/onboard.html
+++ b/onboard.html
@@ -116,15 +116,25 @@
                 </template>
               </select>
             </div>
-            <div>
+            <div x-data="{ open: false, search: '' }" class="relative">
               <label for="model" class="sr-only">Model</label>
-              <input id="model" type="text" x-model="config.model" list="model-list" placeholder="Model ID"
-                     class="w-full h-10 rounded-lg border border-surface-4 bg-surface-0 px-3 text-sm text-ink-0 font-mono shadow-card placeholder:text-ink-3 focus:outline-none focus:border-primary-400 focus:shadow-input-focus transition-all duration-150">
-              <datalist id="model-list">
-                <template x-for="m in modelsForProvider(config.provider)" :key="m">
-                  <option :value="m"></option>
+              <div class="relative">
+                <input id="model" type="text" x-model="config.model" @focus="open = true; search = ''" @input="open = true; search = $event.target.value" placeholder="Model ID"
+                       class="w-full h-10 rounded-lg border border-surface-4 bg-surface-0 pl-3 pr-8 text-sm text-ink-0 font-mono shadow-card placeholder:text-ink-3 focus:outline-none focus:border-primary-400 focus:shadow-input-focus transition-all duration-150">
+                <button @click="open = !open" type="button" tabindex="-1"
+                        class="absolute right-0 top-0 h-10 w-8 flex items-center justify-center text-ink-3 hover:text-ink-1 cursor-pointer">
+                  <svg class="w-4 h-4 transition-transform duration-150" :class="open ? 'rotate-180' : ''" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg>
+                </button>
+              </div>
+              <div x-show="open && allModels.length > 0" @click.away="open = false" x-transition.opacity.duration.100ms
+                   class="absolute z-20 mt-1 w-full max-h-48 overflow-y-auto rounded-lg border border-surface-3 bg-surface-0 shadow-lg py-1">
+                <template x-for="m in filteredModels(search)" :key="m">
+                  <button @click="config.model = m; open = false" type="button"
+                          :class="config.model === m ? 'bg-primary-50 text-primary-700' : 'text-ink-1 hover:bg-surface-1'"
+                          class="w-full text-left px-3 py-1.5 text-xs font-mono cursor-pointer transition-colors duration-100" x-text="m"></button>
                 </template>
-              </datalist>
+                <div x-show="filteredModels(search).length === 0" class="px-3 py-2 text-xs text-ink-3">No matching models</div>
+              </div>
             </div>
           </div>
         </fieldset>
@@ -133,19 +143,45 @@
         <fieldset class="space-y-1.5">
           <legend class="text-xs font-semibold text-ink-2 uppercase tracking-wider mb-3">Model tiers <span class="normal-case font-normal tracking-normal text-ink-3">optional overrides</span></legend>
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div class="relative">
-              <label for="model-strong" class="absolute left-3 top-1/2 -translate-y-1/2 text-[10px] font-medium text-ink-3 uppercase tracking-wider pointer-events-none transition-all duration-150"
-                     :class="config.model_strong ? 'top-2 -translate-y-0 text-[9px] text-primary-500' : ''">Strong</label>
-              <input id="model-strong" type="text" x-model="config.model_strong" list="model-list"
-                     class="w-full h-10 rounded-lg border border-surface-4 bg-surface-0 px-3 text-sm text-ink-0 font-mono shadow-card placeholder:text-ink-3 focus:outline-none focus:border-primary-400 focus:shadow-input-focus transition-all duration-150"
-                     :class="config.model_strong ? 'pt-3.5 pb-0.5' : ''">
+            <div x-data="{ open: false, search: '' }" class="relative">
+              <label for="model-strong" class="text-[11px] font-medium text-ink-2 uppercase tracking-wider mb-1.5 block">Strong</label>
+              <div class="relative">
+                <input id="model-strong" type="text" x-model="config.model_strong" @focus="open = true; search = ''" @input="open = true; search = $event.target.value" placeholder="Falls back to default"
+                       class="w-full h-10 rounded-lg border border-surface-4 bg-surface-0 pl-3 pr-8 text-sm text-ink-0 font-mono shadow-card placeholder:text-ink-3 focus:outline-none focus:border-primary-400 focus:shadow-input-focus transition-all duration-150">
+                <button @click="open = !open" type="button" tabindex="-1"
+                        class="absolute right-0 top-0 h-10 w-8 flex items-center justify-center text-ink-3 hover:text-ink-1 cursor-pointer">
+                  <svg class="w-4 h-4 transition-transform duration-150" :class="open ? 'rotate-180' : ''" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg>
+                </button>
+              </div>
+              <div x-show="open && allModels.length > 0" @click.away="open = false" x-transition.opacity.duration.100ms
+                   class="absolute z-20 mt-1 w-full max-h-48 overflow-y-auto rounded-lg border border-surface-3 bg-surface-0 shadow-lg py-1">
+                <template x-for="m in filteredModels(search)" :key="m">
+                  <button @click="config.model_strong = m; open = false" type="button"
+                          :class="config.model_strong === m ? 'bg-primary-50 text-primary-700' : 'text-ink-1 hover:bg-surface-1'"
+                          class="w-full text-left px-3 py-1.5 text-xs font-mono cursor-pointer transition-colors duration-100" x-text="m"></button>
+                </template>
+                <div x-show="filteredModels(search).length === 0" class="px-3 py-2 text-xs text-ink-3">No matching models</div>
+              </div>
             </div>
-            <div class="relative">
-              <label for="model-fast" class="absolute left-3 top-1/2 -translate-y-1/2 text-[10px] font-medium text-ink-3 uppercase tracking-wider pointer-events-none transition-all duration-150"
-                     :class="config.model_fast ? 'top-2 -translate-y-0 text-[9px] text-primary-500' : ''">Fast</label>
-              <input id="model-fast" type="text" x-model="config.model_fast" list="model-list"
-                     class="w-full h-10 rounded-lg border border-surface-4 bg-surface-0 px-3 text-sm text-ink-0 font-mono shadow-card placeholder:text-ink-3 focus:outline-none focus:border-primary-400 focus:shadow-input-focus transition-all duration-150"
-                     :class="config.model_fast ? 'pt-3.5 pb-0.5' : ''">
+            <div x-data="{ open: false, search: '' }" class="relative">
+              <label for="model-fast" class="text-[11px] font-medium text-ink-2 uppercase tracking-wider mb-1.5 block">Fast</label>
+              <div class="relative">
+                <input id="model-fast" type="text" x-model="config.model_fast" @focus="open = true; search = ''" @input="open = true; search = $event.target.value" placeholder="Falls back to default"
+                       class="w-full h-10 rounded-lg border border-surface-4 bg-surface-0 pl-3 pr-8 text-sm text-ink-0 font-mono shadow-card placeholder:text-ink-3 focus:outline-none focus:border-primary-400 focus:shadow-input-focus transition-all duration-150">
+                <button @click="open = !open" type="button" tabindex="-1"
+                        class="absolute right-0 top-0 h-10 w-8 flex items-center justify-center text-ink-3 hover:text-ink-1 cursor-pointer">
+                  <svg class="w-4 h-4 transition-transform duration-150" :class="open ? 'rotate-180' : ''" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg>
+                </button>
+              </div>
+              <div x-show="open && allModels.length > 0" @click.away="open = false" x-transition.opacity.duration.100ms
+                   class="absolute z-20 mt-1 w-full max-h-48 overflow-y-auto rounded-lg border border-surface-3 bg-surface-0 shadow-lg py-1">
+                <template x-for="m in filteredModels(search)" :key="m">
+                  <button @click="config.model_fast = m; open = false" type="button"
+                          :class="config.model_fast === m ? 'bg-primary-50 text-primary-700' : 'text-ink-1 hover:bg-surface-1'"
+                          class="w-full text-left px-3 py-1.5 text-xs font-mono cursor-pointer transition-colors duration-100" x-text="m"></button>
+                </template>
+                <div x-show="filteredModels(search).length === 0" class="px-3 py-2 text-xs text-ink-3">No matching models</div>
+              </div>
             </div>
           </div>
         </fieldset>
@@ -357,6 +393,23 @@ function onboard() {
 
     defaultBaseURL(name) {
       return providerDefaults[name]?.base_url || '';
+    },
+
+    get allModels() {
+      const all = [];
+      const seen = new Set();
+      for (const models of Object.values(this.providerModels)) {
+        for (const m of models) {
+          if (!seen.has(m)) { seen.add(m); all.push(m); }
+        }
+      }
+      return all;
+    },
+
+    filteredModels(search) {
+      if (!search) return this.allModels;
+      const q = search.toLowerCase();
+      return this.allModels.filter(m => m.toLowerCase().includes(q));
     },
 
     modelsForProvider(provider) {


### PR DESCRIPTION
## Summary

- Add `anna onboard` subcommand that launches a local HTTP server with a web-based config editor
- Three-section UI (Global Settings, Providers, Channels) built with Alpine.js + Tailwind CSS
- Polished developer-tool aesthetic: sticky header, pill tabs with icons, brand logos, JetBrains Mono for code inputs
- Provider cards with "Get All Models" button that fetches from provider APIs and caches results
- Combo model selectors (type-to-filter + dropdown) for model, model_strong, and model_fast fields
- Auto-opens browser, graceful shutdown on Ctrl+C

## New files

- `onboard.go` — command, HTTP server, API handlers (config CRUD, model fetching)
- `onboard.html` — embedded single-page app (Alpine.js/Tailwind CSS CDN)

## Test plan

- [ ] Run `anna onboard` — browser opens, config loads
- [ ] Edit provider API key, click "Get All Models" — models appear in cache
- [ ] Change model via dropdown selector — value updates
- [ ] Save — verify `~/.anna/config.yaml` is written correctly
- [ ] Run `anna onboard --port 8080` — binds to specified port