### PR TITLE
Add Channel interface and extract shared command/util logic

### DIFF
--- a/.superset/config.json
+++ b/.superset/config.json
@@ -1,0 +1,4 @@
+{
+  "setup": [],
+  "teardown": []
+}

--- a/channel/cli/chat.go
+++ b/channel/cli/chat.go
@@ -272,7 +272,7 @@ func (m chatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.historyPrefix += agentBorderStyle.Render(m.renderMarkdown(m.currentRaw.String())) + "\n"
 				m.currentRaw.Reset()
 			}
-			elapsed := formatDuration(time.Since(m.toolStartTime))
+			elapsed := channel.FormatDuration(time.Since(m.toolStartTime))
 			m.status = ""
 			m.historyPrefix += toolDoneStyle.Render(fmt.Sprintf("    ✓ %s (%s)", label, elapsed)) + "\n"
 		case "error":
@@ -280,7 +280,7 @@ func (m chatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.historyPrefix += agentBorderStyle.Render(m.renderMarkdown(m.currentRaw.String())) + "\n"
 				m.currentRaw.Reset()
 			}
-			elapsed := formatDuration(time.Since(m.toolStartTime))
+			elapsed := channel.FormatDuration(time.Since(m.toolStartTime))
 			m.status = ""
 			line := fmt.Sprintf("    ✗ %s (%s)", label, elapsed)
 			if msg.detail != "" {
@@ -547,18 +547,6 @@ func padLines(text, pad string) string {
 		lines[i] = pad + line
 	}
 	return strings.Join(lines, "\n")
-}
-
-// formatDuration returns a human-friendly duration string.
-func formatDuration(d time.Duration) string {
-	switch {
-	case d < time.Second:
-		return fmt.Sprintf("%dms", d.Milliseconds())
-	case d < time.Minute:
-		return fmt.Sprintf("%.1fs", d.Seconds())
-	default:
-		return fmt.Sprintf("%.0fm%.0fs", d.Minutes(), d.Seconds()-d.Minutes()*60)
-	}
 }
 
 func (m chatModel) handlePickingKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {

--- a/channel/command.go
+++ b/channel/command.go
@@ -1,0 +1,158 @@
+package channel
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// SessionPool is the session management interface used by Commander.
+// Implementations must return a struct whose ID field identifies the session.
+type SessionPool interface {
+	ResolveSession(channel string) (SessionInfo, error)
+	RotateSession(channel string) (SessionInfo, error)
+	CompactSession(ctx context.Context, sessionID string) (string, error)
+}
+
+// SessionInfo holds the minimal session metadata needed by channels.
+type SessionInfo struct {
+	ID string
+}
+
+// PoolAdapter adapts a concrete pool (e.g. *agent.Pool) whose session methods
+// return a richer SessionInfo type into the channel.SessionPool interface.
+// The adaptFn extracts the ID from the concrete type.
+type PoolAdapter[T any] struct {
+	ResolveFunc func(channel string) (T, error)
+	RotateFunc  func(channel string) (T, error)
+	CompactFunc func(ctx context.Context, sessionID string) (string, error)
+	AdaptFn     func(T) SessionInfo
+}
+
+func (a *PoolAdapter[T]) ResolveSession(ch string) (SessionInfo, error) {
+	v, err := a.ResolveFunc(ch)
+	if err != nil {
+		return SessionInfo{}, err
+	}
+	return a.AdaptFn(v), nil
+}
+
+func (a *PoolAdapter[T]) RotateSession(ch string) (SessionInfo, error) {
+	v, err := a.RotateFunc(ch)
+	if err != nil {
+		return SessionInfo{}, err
+	}
+	return a.AdaptFn(v), nil
+}
+
+func (a *PoolAdapter[T]) CompactSession(ctx context.Context, sessionID string) (string, error) {
+	return a.CompactFunc(ctx, sessionID)
+}
+
+// IndexedModel pairs a ModelOption with its 1-based global index.
+type IndexedModel struct {
+	ModelOption
+	GlobalIdx int
+}
+
+// Commander handles shared slash commands across all channels.
+// Each channel calls Commander methods and only handles presentation.
+type Commander struct {
+	pool     SessionPool
+	listFn   ModelListFunc
+	switchFn ModelSwitchFunc
+}
+
+// NewCommander creates a Commander backed by the given pool and model functions.
+func NewCommander(pool SessionPool, listFn ModelListFunc, switchFn ModelSwitchFunc) *Commander {
+	return &Commander{pool: pool, listFn: listFn, switchFn: switchFn}
+}
+
+// New creates a new session for the channel, returning the session ID.
+func (c *Commander) New(channelID string) (string, error) {
+	info, err := c.pool.RotateSession(channelID)
+	if err != nil {
+		return "", fmt.Errorf("create new session: %w", err)
+	}
+	return info.ID, nil
+}
+
+// Compact compacts the active session's history, returning the summary.
+func (c *Commander) Compact(ctx context.Context, channelID string) (string, error) {
+	info, err := c.pool.ResolveSession(channelID)
+	if err != nil {
+		return "", fmt.Errorf("no active session: %w", err)
+	}
+	summary, err := c.pool.CompactSession(ctx, info.ID)
+	if err != nil {
+		return "", fmt.Errorf("compaction failed: %w", err)
+	}
+	return summary, nil
+}
+
+// ModelList returns all models, optionally filtered by query.
+func (c *Commander) ModelList(query string) []IndexedModel {
+	models := c.listFn()
+	if query == "" {
+		return IndexModels(models)
+	}
+	return FilterModels(models, query)
+}
+
+// ModelSwitch switches to the model at the given 1-based index and rotates
+// the session. Returns the selected model.
+func (c *Commander) ModelSwitch(channelID string, idx int) (ModelOption, error) {
+	models := c.listFn()
+	if idx < 1 || idx > len(models) {
+		return ModelOption{}, fmt.Errorf("invalid selection, use a number between 1 and %d", len(models))
+	}
+	selected := models[idx-1]
+	if c.switchFn != nil {
+		if err := c.switchFn(selected.Provider, selected.Model); err != nil {
+			return ModelOption{}, fmt.Errorf("switch model: %w", err)
+		}
+	}
+	if _, err := c.pool.RotateSession(channelID); err != nil {
+		return selected, fmt.Errorf("rotate session after model switch: %w", err)
+	}
+	return selected, nil
+}
+
+// ParseModelArgs parses /model arguments. Returns (index, query):
+//   - numeric arg: index > 0, query empty
+//   - text arg: index 0, query set
+//   - no arg: index 0, query empty
+func ParseModelArgs(args string) (int, string) {
+	args = strings.TrimSpace(args)
+	if args == "" {
+		return 0, ""
+	}
+	if idx, err := strconv.Atoi(args); err == nil {
+		return idx, ""
+	}
+	return 0, args
+}
+
+// IndexModels wraps a full model list with sequential 1-based indices.
+func IndexModels(models []ModelOption) []IndexedModel {
+	out := make([]IndexedModel, len(models))
+	for i, m := range models {
+		out[i] = IndexedModel{ModelOption: m, GlobalIdx: i + 1}
+	}
+	return out
+}
+
+// FilterModels returns indexed models matching the query, preserving
+// their 1-based global indices from the full list.
+func FilterModels(models []ModelOption, query string) []IndexedModel {
+	query = strings.ToLower(query)
+	var out []IndexedModel
+	for i, m := range models {
+		label := strings.ToLower(m.Provider + "/" + m.Model)
+		if strings.Contains(label, query) {
+			out = append(out, IndexedModel{ModelOption: m, GlobalIdx: i + 1})
+		}
+	}
+	return out
+}

--- a/channel/command.go
+++ b/channel/command.go
@@ -3,7 +3,6 @@ package channel
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 )
 
@@ -101,13 +100,32 @@ func (c *Commander) ModelList(query string) []IndexedModel {
 }
 
 // ModelSwitch switches to the model at the given 1-based index and rotates
-// the session. Returns the selected model.
+// the session. Returns the selected model. This is used internally by
+// channels that select models via index (e.g. Telegram inline keyboards).
 func (c *Commander) ModelSwitch(channelID string, idx int) (ModelOption, error) {
 	models := c.listFn()
 	if idx < 1 || idx > len(models) {
 		return ModelOption{}, fmt.Errorf("invalid selection, use a number between 1 and %d", len(models))
 	}
 	selected := models[idx-1]
+	return c.doSwitch(channelID, selected)
+}
+
+// ModelSwitchByName switches to the model matching "provider/model" and
+// rotates the session. Returns the selected model.
+func (c *Commander) ModelSwitchByName(channelID, name string) (ModelOption, error) {
+	name = strings.ToLower(strings.TrimSpace(name))
+	models := c.listFn()
+	for _, m := range models {
+		if strings.ToLower(m.Provider+"/"+m.Model) == name {
+			return c.doSwitch(channelID, m)
+		}
+	}
+	return ModelOption{}, fmt.Errorf("unknown model %q, use /model to list available models", name)
+}
+
+// doSwitch applies the model switch and rotates the session.
+func (c *Commander) doSwitch(channelID string, selected ModelOption) (ModelOption, error) {
 	if c.switchFn != nil {
 		if err := c.switchFn(selected.Provider, selected.Model); err != nil {
 			return ModelOption{}, fmt.Errorf("switch model: %w", err)
@@ -119,19 +137,10 @@ func (c *Commander) ModelSwitch(channelID string, idx int) (ModelOption, error) 
 	return selected, nil
 }
 
-// ParseModelArgs parses /model arguments. Returns (index, query):
-//   - numeric arg: index > 0, query empty
-//   - text arg: index 0, query set
-//   - no arg: index 0, query empty
-func ParseModelArgs(args string) (int, string) {
-	args = strings.TrimSpace(args)
-	if args == "" {
-		return 0, ""
-	}
-	if idx, err := strconv.Atoi(args); err == nil {
-		return idx, ""
-	}
-	return 0, args
+// ParseModelArgs parses /model arguments as a query string.
+// Returns empty string when no arguments are provided.
+func ParseModelArgs(args string) string {
+	return strings.TrimSpace(args)
 }
 
 // IndexModels wraps a full model list with sequential 1-based indices.

--- a/channel/command.go
+++ b/channel/command.go
@@ -124,15 +124,18 @@ func (c *Commander) ModelSwitchByName(channelID, name string) (ModelOption, erro
 	return ModelOption{}, fmt.Errorf("unknown model %q, use /model to list available models", name)
 }
 
-// doSwitch applies the model switch and rotates the session.
+// doSwitch rotates the session first, then applies the model switch.
+// This ordering ensures no partial state: if rotation fails, the model
+// is unchanged; if the switch fails, the session was already rotated
+// (acceptable since rotation is idempotent).
 func (c *Commander) doSwitch(channelID string, selected ModelOption) (ModelOption, error) {
+	if _, err := c.pool.RotateSession(channelID); err != nil {
+		return ModelOption{}, fmt.Errorf("rotate session: %w", err)
+	}
 	if c.switchFn != nil {
 		if err := c.switchFn(selected.Provider, selected.Model); err != nil {
 			return ModelOption{}, fmt.Errorf("switch model: %w", err)
 		}
-	}
-	if _, err := c.pool.RotateSession(channelID); err != nil {
-		return selected, fmt.Errorf("rotate session after model switch: %w", err)
 	}
 	return selected, nil
 }

--- a/channel/command_test.go
+++ b/channel/command_test.go
@@ -1,0 +1,163 @@
+package channel
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+type mockPool struct {
+	sessions   map[string]SessionInfo
+	nextID     int
+	compactErr error
+}
+
+func newMockPool() *mockPool {
+	return &mockPool{sessions: make(map[string]SessionInfo)}
+}
+
+func (p *mockPool) ResolveSession(ch string) (SessionInfo, error) {
+	if info, ok := p.sessions[ch]; ok {
+		return info, nil
+	}
+	return p.createSession(ch), nil
+}
+
+func (p *mockPool) RotateSession(ch string) (SessionInfo, error) {
+	return p.createSession(ch), nil
+}
+
+func (p *mockPool) createSession(ch string) SessionInfo {
+	p.nextID++
+	info := SessionInfo{ID: fmt.Sprintf("session-%d", p.nextID)}
+	p.sessions[ch] = info
+	return info
+}
+
+func (p *mockPool) CompactSession(_ context.Context, _ string) (string, error) {
+	if p.compactErr != nil {
+		return "", p.compactErr
+	}
+	return "compacted", nil
+}
+
+func TestCommanderNew(t *testing.T) {
+	pool := newMockPool()
+	cmd := NewCommander(pool, nil, nil)
+
+	id, err := cmd.New("test-channel")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id == "" {
+		t.Fatal("expected non-empty session ID")
+	}
+}
+
+func TestCommanderCompact(t *testing.T) {
+	pool := newMockPool()
+	cmd := NewCommander(pool, nil, nil)
+
+	summary, err := cmd.Compact(context.Background(), "test-channel")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if summary != "compacted" {
+		t.Errorf("summary = %q, want %q", summary, "compacted")
+	}
+}
+
+func TestCommanderCompactError(t *testing.T) {
+	pool := newMockPool()
+	pool.compactErr = fmt.Errorf("db error")
+	cmd := NewCommander(pool, nil, nil)
+
+	_, err := cmd.Compact(context.Background(), "test-channel")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestCommanderModelSwitch(t *testing.T) {
+	pool := newMockPool()
+	models := []ModelOption{
+		{Provider: "openai", Model: "gpt-4"},
+		{Provider: "anthropic", Model: "claude-3"},
+	}
+	var switched ModelOption
+	listFn := func() []ModelOption { return models }
+	switchFn := func(p, m string) error { switched = ModelOption{Provider: p, Model: m}; return nil }
+
+	cmd := NewCommander(pool, listFn, switchFn)
+
+	selected, err := cmd.ModelSwitch("ch", 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if selected.Model != "claude-3" {
+		t.Errorf("selected = %v, want claude-3", selected)
+	}
+	if switched.Model != "claude-3" {
+		t.Errorf("switchFn not called correctly: %v", switched)
+	}
+}
+
+func TestCommanderModelSwitchOutOfRange(t *testing.T) {
+	pool := newMockPool()
+	models := []ModelOption{{Provider: "openai", Model: "gpt-4"}}
+	cmd := NewCommander(pool, func() []ModelOption { return models }, nil)
+
+	_, err := cmd.ModelSwitch("ch", 5)
+	if err == nil {
+		t.Fatal("expected error for out of range index")
+	}
+}
+
+func TestParseModelArgs(t *testing.T) {
+	tests := []struct {
+		input     string
+		wantIdx   int
+		wantQuery string
+	}{
+		{"", 0, ""},
+		{"3", 3, ""},
+		{"claude", 0, "claude"},
+		{" 2 ", 2, ""},
+		{" gpt ", 0, "gpt"},
+	}
+	for _, tt := range tests {
+		idx, query := ParseModelArgs(tt.input)
+		if idx != tt.wantIdx || query != tt.wantQuery {
+			t.Errorf("ParseModelArgs(%q) = (%d, %q), want (%d, %q)", tt.input, idx, query, tt.wantIdx, tt.wantQuery)
+		}
+	}
+}
+
+func TestIndexModels(t *testing.T) {
+	models := []ModelOption{
+		{Provider: "a", Model: "1"},
+		{Provider: "b", Model: "2"},
+	}
+	indexed := IndexModels(models)
+	if len(indexed) != 2 {
+		t.Fatalf("len = %d, want 2", len(indexed))
+	}
+	if indexed[0].GlobalIdx != 1 || indexed[1].GlobalIdx != 2 {
+		t.Errorf("indices = %d, %d; want 1, 2", indexed[0].GlobalIdx, indexed[1].GlobalIdx)
+	}
+}
+
+func TestFilterModels(t *testing.T) {
+	models := []ModelOption{
+		{Provider: "openai", Model: "gpt-4"},
+		{Provider: "anthropic", Model: "claude-3"},
+		{Provider: "openai", Model: "gpt-3.5"},
+	}
+	filtered := FilterModels(models, "gpt")
+	if len(filtered) != 2 {
+		t.Fatalf("len = %d, want 2", len(filtered))
+	}
+	if filtered[0].GlobalIdx != 1 || filtered[1].GlobalIdx != 3 {
+		t.Errorf("indices = %d, %d; want 1, 3", filtered[0].GlobalIdx, filtered[1].GlobalIdx)
+	}
+}

--- a/channel/command_test.go
+++ b/channel/command_test.go
@@ -113,22 +113,70 @@ func TestCommanderModelSwitchOutOfRange(t *testing.T) {
 	}
 }
 
+func TestCommanderModelSwitchByName(t *testing.T) {
+	pool := newMockPool()
+	models := []ModelOption{
+		{Provider: "openai", Model: "gpt-4"},
+		{Provider: "anthropic", Model: "claude-3"},
+	}
+	var switched ModelOption
+	listFn := func() []ModelOption { return models }
+	switchFn := func(p, m string) error { switched = ModelOption{Provider: p, Model: m}; return nil }
+
+	cmd := NewCommander(pool, listFn, switchFn)
+
+	selected, err := cmd.ModelSwitchByName("ch", "anthropic/claude-3")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if selected.Model != "claude-3" {
+		t.Errorf("selected = %v, want claude-3", selected)
+	}
+	if switched.Model != "claude-3" {
+		t.Errorf("switchFn not called correctly: %v", switched)
+	}
+}
+
+func TestCommanderModelSwitchByNameCaseInsensitive(t *testing.T) {
+	pool := newMockPool()
+	models := []ModelOption{{Provider: "OpenAI", Model: "GPT-4"}}
+	cmd := NewCommander(pool, func() []ModelOption { return models }, func(p, m string) error { return nil })
+
+	selected, err := cmd.ModelSwitchByName("ch", "openai/gpt-4")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if selected.Provider != "OpenAI" {
+		t.Errorf("provider = %q, want OpenAI", selected.Provider)
+	}
+}
+
+func TestCommanderModelSwitchByNameUnknown(t *testing.T) {
+	pool := newMockPool()
+	models := []ModelOption{{Provider: "openai", Model: "gpt-4"}}
+	cmd := NewCommander(pool, func() []ModelOption { return models }, nil)
+
+	_, err := cmd.ModelSwitchByName("ch", "fake/model")
+	if err == nil {
+		t.Fatal("expected error for unknown model")
+	}
+}
+
 func TestParseModelArgs(t *testing.T) {
 	tests := []struct {
-		input     string
-		wantIdx   int
-		wantQuery string
+		input string
+		want  string
 	}{
-		{"", 0, ""},
-		{"3", 3, ""},
-		{"claude", 0, "claude"},
-		{" 2 ", 2, ""},
-		{" gpt ", 0, "gpt"},
+		{"", ""},
+		{"3", "3"},
+		{"claude", "claude"},
+		{" gpt ", "gpt"},
+		{" openai/gpt-4 ", "openai/gpt-4"},
 	}
 	for _, tt := range tests {
-		idx, query := ParseModelArgs(tt.input)
-		if idx != tt.wantIdx || query != tt.wantQuery {
-			t.Errorf("ParseModelArgs(%q) = (%d, %q), want (%d, %q)", tt.input, idx, query, tt.wantIdx, tt.wantQuery)
+		got := ParseModelArgs(tt.input)
+		if got != tt.want {
+			t.Errorf("ParseModelArgs(%q) = %q, want %q", tt.input, got, tt.want)
 		}
 	}
 }

--- a/channel/model.go
+++ b/channel/model.go
@@ -1,5 +1,22 @@
 package channel
 
+import "context"
+
+// Channel is a messaging platform that receives user messages and sends notifications.
+type Channel interface {
+	// Name returns a unique identifier (e.g. "telegram", "qq").
+	Name() string
+
+	// Start begins listening for messages. Blocks until ctx is cancelled.
+	Start(ctx context.Context) error
+
+	// Stop gracefully shuts down the channel.
+	Stop()
+
+	// Notify sends a push notification to a target within this channel.
+	Notify(ctx context.Context, n Notification) error
+}
+
 // ModelOption represents a selectable provider/model combination.
 type ModelOption struct {
 	Provider string

--- a/channel/notifier.go
+++ b/channel/notifier.go
@@ -15,88 +15,82 @@ type Notification struct {
 	Silent  bool   // send without notification sound
 }
 
-// Notifier can push notifications. Both Dispatcher and individual backends
+// Notifier can push notifications. Both Dispatcher and individual channels
 // satisfy this interface, so consumers don't need to know the routing layer.
 type Notifier interface {
 	Notify(ctx context.Context, n Notification) error
 }
 
-// Backend is a named notification backend (telegram, slack, discord, etc.).
-type Backend interface {
-	Notifier
-	Name() string
-}
-
-type backendEntry struct {
-	backend     Backend
+type channelEntry struct {
+	channel     Channel
 	defaultChat string
 }
 
-// Dispatcher routes notifications to one or more registered backends.
+// Dispatcher routes notifications to one or more registered channels.
 // It implements Notifier so it can be passed to tools and cron wiring.
 type Dispatcher struct {
 	mu       sync.RWMutex
-	backends []backendEntry
+	channels []channelEntry
 }
 
-// NewDispatcher creates an empty dispatcher. Register backends before use.
+// NewDispatcher creates an empty dispatcher. Register channels before use.
 func NewDispatcher() *Dispatcher {
 	return &Dispatcher{}
 }
 
-// Register adds a backend with its default chat/channel target.
-func (d *Dispatcher) Register(b Backend, defaultChat string) {
+// Register adds a channel with its default chat/channel target.
+func (d *Dispatcher) Register(ch Channel, defaultChat string) {
 	d.mu.Lock()
-	d.backends = append(d.backends, backendEntry{backend: b, defaultChat: defaultChat})
+	d.channels = append(d.channels, channelEntry{channel: ch, defaultChat: defaultChat})
 	d.mu.Unlock()
 }
 
-// Notify routes a notification to backends. If Notification.Channel is set,
-// only that backend receives it. Otherwise all registered backends receive it.
+// Notify routes a notification to channels. If Notification.Channel is set,
+// only that channel receives it. Otherwise all registered channels receive it.
 func (d *Dispatcher) Notify(ctx context.Context, n Notification) error {
 	d.mu.RLock()
-	entries := make([]backendEntry, len(d.backends))
-	copy(entries, d.backends)
+	entries := make([]channelEntry, len(d.channels))
+	copy(entries, d.channels)
 	d.mu.RUnlock()
 
 	if len(entries) == 0 {
-		return fmt.Errorf("no notification backends registered")
+		return fmt.Errorf("no notification channels registered")
 	}
 
-	// Route to a specific backend.
+	// Route to a specific channel.
 	if n.Channel != "" {
 		for _, e := range entries {
-			if e.backend.Name() == n.Channel {
+			if e.channel.Name() == n.Channel {
 				if n.ChatID == "" {
 					n.ChatID = e.defaultChat
 				}
-				return e.backend.Notify(ctx, n)
+				return e.channel.Notify(ctx, n)
 			}
 		}
 		return fmt.Errorf("unknown notification channel %q", n.Channel)
 	}
 
-	// Broadcast to all backends.
+	// Broadcast to all channels.
 	var errs []error
 	for _, e := range entries {
 		nn := n
 		if nn.ChatID == "" {
 			nn.ChatID = e.defaultChat
 		}
-		if err := e.backend.Notify(ctx, nn); err != nil {
-			errs = append(errs, fmt.Errorf("%s: %w", e.backend.Name(), err))
+		if err := e.channel.Notify(ctx, nn); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", e.channel.Name(), err))
 		}
 	}
 	return errors.Join(errs...)
 }
 
-// Backends returns the names of all registered backends.
-func (d *Dispatcher) Backends() []string {
+// Channels returns the names of all registered channels.
+func (d *Dispatcher) Channels() []string {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
-	names := make([]string, len(d.backends))
-	for i, e := range d.backends {
-		names[i] = e.backend.Name()
+	names := make([]string, len(d.channels))
+	for i, e := range d.channels {
+		names[i] = e.channel.Name()
 	}
 	return names
 }

--- a/channel/notifier_test.go
+++ b/channel/notifier_test.go
@@ -6,23 +6,25 @@ import (
 	"testing"
 )
 
-// mockBackend is a test Backend that records calls.
-type mockBackend struct {
+// mockChannel is a test Channel that records Notify calls.
+type mockChannel struct {
 	name  string
 	calls []Notification
 	err   error
 }
 
-func (m *mockBackend) Name() string { return m.name }
-func (m *mockBackend) Notify(_ context.Context, n Notification) error {
+func (m *mockChannel) Name() string                  { return m.name }
+func (m *mockChannel) Start(_ context.Context) error { return nil }
+func (m *mockChannel) Stop()                         {}
+func (m *mockChannel) Notify(_ context.Context, n Notification) error {
 	m.calls = append(m.calls, n)
 	return m.err
 }
 
 func TestDispatcherBroadcast(t *testing.T) {
 	d := NewDispatcher()
-	tg := &mockBackend{name: "telegram"}
-	slack := &mockBackend{name: "slack"}
+	tg := &mockChannel{name: "telegram"}
+	slack := &mockChannel{name: "slack"}
 	d.Register(tg, "tg-chat")
 	d.Register(slack, "slack-channel")
 
@@ -47,8 +49,8 @@ func TestDispatcherBroadcast(t *testing.T) {
 
 func TestDispatcherRouteToSpecific(t *testing.T) {
 	d := NewDispatcher()
-	tg := &mockBackend{name: "telegram"}
-	slack := &mockBackend{name: "slack"}
+	tg := &mockChannel{name: "telegram"}
+	slack := &mockChannel{name: "slack"}
 	d.Register(tg, "tg-chat")
 	d.Register(slack, "slack-channel")
 
@@ -73,7 +75,7 @@ func TestDispatcherRouteToSpecific(t *testing.T) {
 
 func TestDispatcherExplicitChatID(t *testing.T) {
 	d := NewDispatcher()
-	tg := &mockBackend{name: "telegram"}
+	tg := &mockChannel{name: "telegram"}
 	d.Register(tg, "default-chat")
 
 	err := d.Notify(context.Background(), Notification{
@@ -91,7 +93,7 @@ func TestDispatcherExplicitChatID(t *testing.T) {
 
 func TestDispatcherUnknownChannel(t *testing.T) {
 	d := NewDispatcher()
-	d.Register(&mockBackend{name: "telegram"}, "chat")
+	d.Register(&mockChannel{name: "telegram"}, "chat")
 
 	err := d.Notify(context.Background(), Notification{Channel: "discord", Text: "test"})
 	if err == nil {
@@ -99,18 +101,18 @@ func TestDispatcherUnknownChannel(t *testing.T) {
 	}
 }
 
-func TestDispatcherNoBackends(t *testing.T) {
+func TestDispatcherNoChannels(t *testing.T) {
 	d := NewDispatcher()
 	err := d.Notify(context.Background(), Notification{Text: "test"})
 	if err == nil {
-		t.Fatal("expected error with no backends")
+		t.Fatal("expected error with no channels")
 	}
 }
 
 func TestDispatcherPartialFailure(t *testing.T) {
 	d := NewDispatcher()
-	good := &mockBackend{name: "telegram"}
-	bad := &mockBackend{name: "slack", err: errors.New("slack down")}
+	good := &mockChannel{name: "telegram"}
+	bad := &mockChannel{name: "slack", err: errors.New("slack down")}
 	d.Register(good, "chat")
 	d.Register(bad, "channel")
 
@@ -118,22 +120,22 @@ func TestDispatcherPartialFailure(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error on partial failure")
 	}
-	// Good backend should still have been called.
+	// Good channel should still have been called.
 	if len(good.calls) != 1 {
-		t.Errorf("good backend got %d calls, want 1", len(good.calls))
+		t.Errorf("good channel got %d calls, want 1", len(good.calls))
 	}
 }
 
-func TestDispatcherBackends(t *testing.T) {
+func TestDispatcherChannels(t *testing.T) {
 	d := NewDispatcher()
-	d.Register(&mockBackend{name: "telegram"}, "")
-	d.Register(&mockBackend{name: "slack"}, "")
+	d.Register(&mockChannel{name: "telegram"}, "")
+	d.Register(&mockChannel{name: "slack"}, "")
 
-	names := d.Backends()
+	names := d.Channels()
 	if len(names) != 2 {
-		t.Fatalf("len(Backends()) = %d, want 2", len(names))
+		t.Fatalf("len(Channels()) = %d, want 2", len(names))
 	}
 	if names[0] != "telegram" || names[1] != "slack" {
-		t.Errorf("Backends() = %v, want [telegram slack]", names)
+		t.Errorf("Channels() = %v, want [telegram slack]", names)
 	}
 }

--- a/channel/notify_tool.go
+++ b/channel/notify_tool.go
@@ -68,9 +68,9 @@ func (t *NotifyTool) Execute(ctx context.Context, args map[string]any) (string, 
 		return "", fmt.Errorf("send notification: %w", err)
 	}
 
-	backends := t.dispatcher.Backends()
+	channels := t.dispatcher.Channels()
 	if ch != "" {
 		return fmt.Sprintf("Notification sent to %s.", ch), nil
 	}
-	return fmt.Sprintf("Notification broadcast to %v.", backends), nil
+	return fmt.Sprintf("Notification broadcast to %v.", channels), nil
 }

--- a/channel/qq/handler.go
+++ b/channel/qq/handler.go
@@ -227,29 +227,24 @@ func (b *Bot) handleCommand(text, ch string, reply func(string)) bool {
 		return true
 
 	case "/new":
-		info, err := b.pool.RotateSession(ch)
+		sessionID, err := b.cmd.New(ch)
 		if err != nil {
 			logger().Error("rotate session failed", "channel", ch, "error", err)
 			reply(fmt.Sprintf("Error creating new session: %v", err))
 			return true
 		}
-		logger().Info("new session created", "session_id", info.ID, "channel", ch)
+		logger().Info("new session created", "session_id", sessionID, "channel", ch)
 		reply("New session started.")
 		return true
 
 	case "/compact":
-		sessionID, err := b.resolveSession(ch)
+		summary, err := b.cmd.Compact(b.ctx, ch)
 		if err != nil {
-			reply(fmt.Sprintf("No active session: %v", err))
-			return true
-		}
-		summary, err := b.pool.CompactSession(b.ctx, sessionID)
-		if err != nil {
-			logger().Error("compact session failed", "session_id", sessionID, "error", err)
+			logger().Error("compact session failed", "channel", ch, "error", err)
 			reply(fmt.Sprintf("Compaction failed: %v", err))
 			return true
 		}
-		logger().Info("session compacted", "session_id", sessionID, "summary_len", len(summary))
+		logger().Info("session compacted", "channel", ch, "summary_len", len(summary))
 		reply("Session compacted.")
 		return true
 

--- a/channel/qq/model.go
+++ b/channel/qq/model.go
@@ -2,63 +2,39 @@ package qq
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/vaayne/anna/channel"
 )
 
-// ModelOption re-exports channel.ModelOption for use by callers.
-type ModelOption = channel.ModelOption
-
-// ModelListFunc re-exports channel.ModelListFunc for use by callers.
-type ModelListFunc = channel.ModelListFunc
-
-// ModelSwitchFunc re-exports channel.ModelSwitchFunc for use by callers.
-type ModelSwitchFunc = channel.ModelSwitchFunc
-
 // handleModelCommand processes /model with optional arguments.
 // No args → list models; number → switch by index; text → filter.
 func (b *Bot) handleModelCommand(args, ch string, reply func(string)) {
-	models := b.listFn()
+	idx, query := channel.ParseModelArgs(args)
 
-	if args == "" {
-		reply(formatModelList(models, ""))
+	if idx > 0 {
+		b.switchModelByIdx(idx, ch, reply)
 		return
 	}
 
-	// Numeric arg → direct switch by 1-based global index.
-	if idx, err := strconv.Atoi(args); err == nil {
-		b.switchModel(models, idx, ch, reply)
+	models := b.cmd.ModelList(query)
+	if len(models) == 0 {
+		if query != "" {
+			reply(fmt.Sprintf("No models matching %q.", query))
+		} else {
+			reply("No models configured.")
+		}
 		return
 	}
-
-	// Text arg → filter models by substring match.
-	// Displayed numbers are global indices so /model <N> always works
-	// consistently whether the list was filtered or not.
-	filtered := filterModelsIndexed(models, args)
-	if len(filtered) == 0 {
-		reply(fmt.Sprintf("No models matching %q.", args))
-		return
-	}
-	reply(formatIndexedModelList(filtered, args))
+	reply(formatModelList(models, query))
 }
 
-// switchModel handles model switching by 1-based index.
-func (b *Bot) switchModel(models []ModelOption, idx int, ch string, reply func(string)) {
-	if idx < 1 || idx > len(models) {
-		reply(fmt.Sprintf("Invalid selection. Use a number between 1 and %d.", len(models)))
+// switchModelByIdx handles model switching by 1-based index using Commander.
+func (b *Bot) switchModelByIdx(idx int, ch string, reply func(string)) {
+	selected, err := b.cmd.ModelSwitch(ch, idx)
+	if err != nil {
+		reply(fmt.Sprintf("Error: %v", err))
 		return
-	}
-	selected := models[idx-1]
-	if b.switchFn != nil {
-		if err := b.switchFn(selected.Provider, selected.Model); err != nil {
-			reply(fmt.Sprintf("Error switching model: %v", err))
-			return
-		}
-	}
-	if _, err := b.pool.RotateSession(ch); err != nil {
-		logger().Error("rotate session after model switch failed", "channel", ch, "error", err)
 	}
 	b.mu.Lock()
 	b.chatModels[ch] = selected
@@ -67,30 +43,8 @@ func (b *Bot) switchModel(models []ModelOption, idx int, ch string, reply func(s
 	reply(fmt.Sprintf("Switched to %s/%s. Session reset.", selected.Provider, selected.Model))
 }
 
-// indexedModel pairs a ModelOption with its 1-based global index.
-type indexedModel struct {
-	ModelOption
-	globalIdx int
-}
-
-// formatModelList builds a text-based model list with 1-based numbered entries.
-func formatModelList(models []ModelOption, query string) string {
-	var sb strings.Builder
-	sb.WriteString("Available models")
-	if query != "" {
-		fmt.Fprintf(&sb, " (filter: %q)", query)
-	}
-	sb.WriteString(":\n\n")
-	for i, m := range models {
-		fmt.Fprintf(&sb, "%d. %s/%s\n", i+1, m.Provider, m.Model)
-	}
-	sb.WriteString("\nUse /model <number> to switch.")
-	return sb.String()
-}
-
-// formatIndexedModelList builds a text list preserving global indices,
-// so numbers stay consistent between filtered and unfiltered views.
-func formatIndexedModelList(models []indexedModel, query string) string {
+// formatModelList builds a text-based model list with numbered entries.
+func formatModelList(models []channel.IndexedModel, query string) string {
 	var sb strings.Builder
 	sb.WriteString("Available models")
 	if query != "" {
@@ -98,22 +52,8 @@ func formatIndexedModelList(models []indexedModel, query string) string {
 	}
 	sb.WriteString(":\n\n")
 	for _, m := range models {
-		fmt.Fprintf(&sb, "%d. %s/%s\n", m.globalIdx, m.Provider, m.Model)
+		fmt.Fprintf(&sb, "%d. %s/%s\n", m.GlobalIdx, m.Provider, m.Model)
 	}
 	sb.WriteString("\nUse /model <number> to switch.")
 	return sb.String()
-}
-
-// filterModelsIndexed returns indexed models matching the query,
-// preserving their 1-based global indices from the full list.
-func filterModelsIndexed(models []ModelOption, query string) []indexedModel {
-	query = strings.ToLower(query)
-	var out []indexedModel
-	for i, m := range models {
-		label := strings.ToLower(m.Provider + "/" + m.Model)
-		if strings.Contains(label, query) {
-			out = append(out, indexedModel{ModelOption: m, globalIdx: i + 1})
-		}
-	}
-	return out
 }

--- a/channel/qq/model.go
+++ b/channel/qq/model.go
@@ -8,12 +8,13 @@ import (
 )
 
 // handleModelCommand processes /model with optional arguments.
-// No args → list models; number → switch by index; text → filter.
+// No args → list models; text with "/" → switch by name; text → filter.
 func (b *Bot) handleModelCommand(args, ch string, reply func(string)) {
-	idx, query := channel.ParseModelArgs(args)
+	query := channel.ParseModelArgs(args)
 
-	if idx > 0 {
-		b.switchModelByIdx(idx, ch, reply)
+	// If the query looks like "provider/model", try switching directly.
+	if query != "" && strings.Contains(query, "/") {
+		b.switchModelByName(query, ch, reply)
 		return
 	}
 
@@ -29,9 +30,9 @@ func (b *Bot) handleModelCommand(args, ch string, reply func(string)) {
 	reply(formatModelList(models, query))
 }
 
-// switchModelByIdx handles model switching by 1-based index using Commander.
-func (b *Bot) switchModelByIdx(idx int, ch string, reply func(string)) {
-	selected, err := b.cmd.ModelSwitch(ch, idx)
+// switchModelByName handles model switching by "provider/model" name using Commander.
+func (b *Bot) switchModelByName(name, ch string, reply func(string)) {
+	selected, err := b.cmd.ModelSwitchByName(ch, name)
 	if err != nil {
 		reply(fmt.Sprintf("Error: %v", err))
 		return
@@ -43,7 +44,7 @@ func (b *Bot) switchModelByIdx(idx int, ch string, reply func(string)) {
 	reply(fmt.Sprintf("Switched to %s/%s. Session reset.", selected.Provider, selected.Model))
 }
 
-// formatModelList builds a text-based model list with numbered entries.
+// formatModelList builds a text-based model list.
 func formatModelList(models []channel.IndexedModel, query string) string {
 	var sb strings.Builder
 	sb.WriteString("Available models")
@@ -52,8 +53,8 @@ func formatModelList(models []channel.IndexedModel, query string) string {
 	}
 	sb.WriteString(":\n\n")
 	for _, m := range models {
-		fmt.Fprintf(&sb, "%d. %s/%s\n", m.GlobalIdx, m.Provider, m.Model)
+		fmt.Fprintf(&sb, "• %s/%s\n", m.Provider, m.Model)
 	}
-	sb.WriteString("\nUse /model <number> to switch.")
+	sb.WriteString("\nUse /model <provider/model> to switch.")
 	return sb.String()
 }

--- a/channel/qq/qq.go
+++ b/channel/qq/qq.go
@@ -31,17 +31,19 @@ type Config struct {
 }
 
 // Bot wraps a QQ bot with agent pool integration.
+// It implements channel.Channel.
 type Bot struct {
 	api            openapi.OpenAPI
 	creds          *token.QQBotCredentials
 	tokenSource    oauth2.TokenSource
 	sessionManager botgo.SessionManager
 	pool           *agent.Pool
-	listFn         ModelListFunc
-	switchFn       ModelSwitchFunc
+	cmd            *channel.Commander
+	listFn         channel.ModelListFunc
+	switchFn       channel.ModelSwitchFunc
 
 	mu         sync.RWMutex
-	chatModels map[string]ModelOption
+	chatModels map[string]channel.ModelOption
 
 	allowed map[string]struct{}
 	cfg     Config
@@ -50,7 +52,7 @@ type Bot struct {
 }
 
 // New creates a QQ bot. Call Start to begin receiving events.
-func New(cfg Config, pool *agent.Pool, listFn ModelListFunc, switchFn ModelSwitchFunc) (*Bot, error) {
+func New(cfg Config, pool *agent.Pool, listFn channel.ModelListFunc, switchFn channel.ModelSwitchFunc) (*Bot, error) {
 	if cfg.AppID == "" || cfg.AppSecret == "" {
 		return nil, fmt.Errorf("qq: app_id and app_secret are required")
 	}
@@ -64,11 +66,19 @@ func New(cfg Config, pool *agent.Pool, listFn ModelListFunc, switchFn ModelSwitc
 		allowed[id] = struct{}{}
 	}
 
+	poolAdapter := &channel.PoolAdapter[agent.SessionInfo]{
+		ResolveFunc: pool.ResolveSession,
+		RotateFunc:  pool.RotateSession,
+		CompactFunc: pool.CompactSession,
+		AdaptFn:     func(info agent.SessionInfo) channel.SessionInfo { return channel.SessionInfo{ID: info.ID} },
+	}
+
 	b := &Bot{
 		pool:       pool,
+		cmd:        channel.NewCommander(poolAdapter, listFn, switchFn),
 		listFn:     listFn,
 		switchFn:   switchFn,
-		chatModels: make(map[string]ModelOption),
+		chatModels: make(map[string]channel.ModelOption),
 		allowed:    allowed,
 		cfg:        cfg,
 	}
@@ -130,10 +140,10 @@ func (b *Bot) Stop() {
 	}
 }
 
-// Name returns the backend name. Implements channel.Backend.
+// Name returns the channel name. Implements channel.Channel.
 func (b *Bot) Name() string { return "qq" }
 
-// Notify sends a notification message. Implements channel.Backend.
+// Notify sends a notification message. Implements channel.Channel.
 func (b *Bot) Notify(ctx context.Context, n channel.Notification) error {
 	if n.ChatID == "" {
 		return fmt.Errorf("qq: no target chat ID")

--- a/channel/qq/qq_test.go
+++ b/channel/qq/qq_test.go
@@ -13,10 +13,10 @@ import (
 	"github.com/vaayne/anna/channel"
 )
 
-// --- splitMessage ---
+// --- SplitMessage (shared) ---
 
 func TestSplitMessageShort(t *testing.T) {
-	chunks := splitMessage("hello")
+	chunks := channel.SplitMessage("hello", qqMaxMessageLen)
 	if len(chunks) != 1 || chunks[0] != "hello" {
 		t.Errorf("chunks = %v, want [hello]", chunks)
 	}
@@ -24,7 +24,7 @@ func TestSplitMessageShort(t *testing.T) {
 
 func TestSplitMessageExactLimit(t *testing.T) {
 	msg := strings.Repeat("a", qqMaxMessageLen)
-	chunks := splitMessage(msg)
+	chunks := channel.SplitMessage(msg, qqMaxMessageLen)
 	if len(chunks) != 1 {
 		t.Errorf("len(chunks) = %d, want 1", len(chunks))
 	}
@@ -32,7 +32,7 @@ func TestSplitMessageExactLimit(t *testing.T) {
 
 func TestSplitMessageLong(t *testing.T) {
 	msg := strings.Repeat("a", qqMaxMessageLen+100)
-	chunks := splitMessage(msg)
+	chunks := channel.SplitMessage(msg, qqMaxMessageLen)
 	if len(chunks) != 2 {
 		t.Fatalf("len(chunks) = %d, want 2", len(chunks))
 	}
@@ -49,7 +49,7 @@ func TestSplitMessageAtNewline(t *testing.T) {
 	part2 := strings.Repeat("b", 2000)
 	msg := part1 + "\n" + part2
 
-	chunks := splitMessage(msg)
+	chunks := channel.SplitMessage(msg, qqMaxMessageLen)
 	if len(chunks) != 2 {
 		t.Fatalf("len(chunks) = %d, want 2", len(chunks))
 	}
@@ -59,19 +59,23 @@ func TestSplitMessageAtNewline(t *testing.T) {
 }
 
 func TestSplitMessageMultibyteUTF8(t *testing.T) {
-	// Build a string of Chinese characters that exceeds the limit.
-	// Each character is 3 bytes in UTF-8.
 	char := "中"
 	msg := strings.Repeat(char, qqMaxMessageLen) // 3*qqMaxMessageLen bytes
-	chunks := splitMessage(msg)
+	chunks := channel.SplitMessage(msg, qqMaxMessageLen)
 	if len(chunks) < 2 {
 		t.Fatalf("expected multiple chunks, got %d", len(chunks))
 	}
-	// Verify no chunk starts with a continuation byte (broken rune).
 	for i, c := range chunks {
 		if len(c) > 0 && c[0]&0xC0 == 0x80 {
 			t.Errorf("chunk[%d] starts with UTF-8 continuation byte", i)
 		}
+	}
+}
+
+func TestSplitMessageEmpty(t *testing.T) {
+	chunks := channel.SplitMessage("", qqMaxMessageLen)
+	if len(chunks) != 1 || chunks[0] != "" {
+		t.Errorf("empty message should return single empty chunk, got %v", chunks)
 	}
 }
 
@@ -105,6 +109,20 @@ func TestBuildStreamDisplayTruncates(t *testing.T) {
 	}
 }
 
+func TestBuildStreamDisplayEmptyTextWithTool(t *testing.T) {
+	d := buildStreamDisplay("", "⚡ bash: ls")
+	if !strings.Contains(d, "⚡ bash: ls") {
+		t.Errorf("should show tool line: %q", d)
+	}
+}
+
+func TestBuildStreamDisplayEmptyAll(t *testing.T) {
+	d := buildStreamDisplay("", "")
+	if !strings.HasSuffix(d, typingCursor) {
+		t.Errorf("should end with cursor: %q", d)
+	}
+}
+
 // --- toolLine ---
 
 func TestToolLineRunning(t *testing.T) {
@@ -115,12 +133,20 @@ func TestToolLineRunning(t *testing.T) {
 }
 
 func TestToolLineRunningTruncatesMultibyte(t *testing.T) {
-	// 61 Chinese characters = well over 60 runes
 	input := strings.Repeat("中", 61)
 	line := toolLine(&runner.ToolUseEvent{Tool: "bash", Status: "running", Input: input})
-	// Should be truncated to 57 runes + "..."
 	if !strings.HasSuffix(line, "...") {
 		t.Errorf("expected truncation ellipsis, got %q", line)
+	}
+}
+
+func TestToolLineRunningNoInput(t *testing.T) {
+	line := toolLine(&runner.ToolUseEvent{Tool: "search", Status: "running"})
+	if !strings.Contains(line, "search") {
+		t.Errorf("unexpected line: %q", line)
+	}
+	if strings.Contains(line, ":") {
+		t.Errorf("no input should not have colon separator: %q", line)
 	}
 }
 
@@ -138,39 +164,42 @@ func TestToolLineDefault(t *testing.T) {
 	}
 }
 
-// --- filterModelsIndexed ---
+func TestToolLineUnknownTool(t *testing.T) {
+	line := toolLine(&runner.ToolUseEvent{Tool: "custom_tool", Status: "running", Input: "x"})
+	if !strings.Contains(line, "🔧") {
+		t.Errorf("unknown tool should use default emoji: %q", line)
+	}
+}
 
-func TestFilterModelsIndexed(t *testing.T) {
+// --- FilterModels (shared) ---
+
+func TestFilterModels(t *testing.T) {
 	models := []channel.ModelOption{
 		{Provider: "openai", Model: "gpt-4"},
 		{Provider: "anthropic", Model: "claude-3"},
 		{Provider: "openai", Model: "gpt-3.5"},
 	}
 
-	result := filterModelsIndexed(models, "openai")
+	result := channel.FilterModels(models, "openai")
 	if len(result) != 2 {
 		t.Fatalf("expected 2 matches, got %d", len(result))
 	}
-	if result[0].globalIdx != 1 || result[1].globalIdx != 3 {
-		t.Errorf("global indices should be 1 and 3, got %d and %d", result[0].globalIdx, result[1].globalIdx)
+	if result[0].GlobalIdx != 1 || result[1].GlobalIdx != 3 {
+		t.Errorf("global indices should be 1 and 3, got %d and %d", result[0].GlobalIdx, result[1].GlobalIdx)
 	}
 }
 
-func TestFilterModelsIndexedNoMatch(t *testing.T) {
-	models := []channel.ModelOption{
-		{Provider: "openai", Model: "gpt-4"},
-	}
-	result := filterModelsIndexed(models, "gemini")
+func TestFilterModelsNoMatch(t *testing.T) {
+	models := []channel.ModelOption{{Provider: "openai", Model: "gpt-4"}}
+	result := channel.FilterModels(models, "gemini")
 	if len(result) != 0 {
 		t.Errorf("expected 0 matches, got %d", len(result))
 	}
 }
 
-func TestFilterModelsIndexedCaseInsensitive(t *testing.T) {
-	models := []channel.ModelOption{
-		{Provider: "Anthropic", Model: "Claude-3"},
-	}
-	result := filterModelsIndexed(models, "CLAUDE")
+func TestFilterModelsCaseInsensitive(t *testing.T) {
+	models := []channel.ModelOption{{Provider: "Anthropic", Model: "Claude-3"}}
+	result := channel.FilterModels(models, "CLAUDE")
 	if len(result) != 1 {
 		t.Fatalf("expected 1 match, got %d", len(result))
 	}
@@ -294,10 +323,10 @@ func TestBotName(t *testing.T) {
 // --- formatModelList ---
 
 func TestFormatModelListNoQuery(t *testing.T) {
-	models := []channel.ModelOption{
+	models := channel.IndexModels([]channel.ModelOption{
 		{Provider: "openai", Model: "gpt-4"},
 		{Provider: "anthropic", Model: "claude-3"},
-	}
+	})
 	out := formatModelList(models, "")
 	if !strings.Contains(out, "1. openai/gpt-4") {
 		t.Errorf("missing model entry in output: %s", out)
@@ -311,23 +340,12 @@ func TestFormatModelListNoQuery(t *testing.T) {
 }
 
 func TestFormatModelListWithQuery(t *testing.T) {
-	models := []channel.ModelOption{{Provider: "openai", Model: "gpt-4"}}
+	models := channel.IndexModels([]channel.ModelOption{
+		{Provider: "openai", Model: "gpt-4"},
+	})
 	out := formatModelList(models, "openai")
 	if !strings.Contains(out, `filter: "openai"`) {
 		t.Errorf("should show filter query: %s", out)
-	}
-}
-
-// --- formatIndexedModelList ---
-
-func TestFormatIndexedModelList(t *testing.T) {
-	models := []indexedModel{
-		{ModelOption: channel.ModelOption{Provider: "openai", Model: "gpt-4"}, globalIdx: 1},
-		{ModelOption: channel.ModelOption{Provider: "openai", Model: "gpt-3.5"}, globalIdx: 3},
-	}
-	out := formatIndexedModelList(models, "openai")
-	if !strings.Contains(out, "1. openai/gpt-4") || !strings.Contains(out, "3. openai/gpt-3.5") {
-		t.Errorf("unexpected output: %s", out)
 	}
 }
 
@@ -384,9 +402,6 @@ func TestDownloadImageAddsScheme(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	// Strip the "http://" to test scheme addition.
-	// downloadImage adds "https://" but httptest uses http, so this will fail.
-	// Instead test that a valid URL works fine without prefix modification.
 	data, _, err := downloadImage(context.Background(), srv.URL)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -411,7 +426,6 @@ func TestDownloadImageBadStatus(t *testing.T) {
 func TestDownloadImageTooLarge(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "image/png")
-		// Write more than maxImageSize
 		_, _ = w.Write(make([]byte, maxImageSize+10))
 	}))
 	defer srv.Close()
@@ -424,7 +438,6 @@ func TestDownloadImageTooLarge(t *testing.T) {
 
 func TestDownloadImageDetectsMIME(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		// No Content-Type header — should be auto-detected.
 		_, _ = w.Write([]byte("hello"))
 	}))
 	defer srv.Close()
@@ -487,8 +500,9 @@ func TestHandleModelCommandListModels(t *testing.T) {
 		{Provider: "openai", Model: "gpt-4"},
 	}
 	bot := &Bot{
+		cmd:        channel.NewCommander(newTestPool(), func() []channel.ModelOption { return models }, nil),
 		listFn:     func() []channel.ModelOption { return models },
-		chatModels: make(map[string]ModelOption),
+		chatModels: make(map[string]channel.ModelOption),
 	}
 
 	var reply string
@@ -504,8 +518,9 @@ func TestHandleModelCommandFilter(t *testing.T) {
 		{Provider: "anthropic", Model: "claude-3"},
 	}
 	bot := &Bot{
+		cmd:        channel.NewCommander(newTestPool(), func() []channel.ModelOption { return models }, nil),
 		listFn:     func() []channel.ModelOption { return models },
-		chatModels: make(map[string]ModelOption),
+		chatModels: make(map[string]channel.ModelOption),
 	}
 
 	var reply string
@@ -523,8 +538,9 @@ func TestHandleModelCommandFilterNoMatch(t *testing.T) {
 		{Provider: "openai", Model: "gpt-4"},
 	}
 	bot := &Bot{
+		cmd:        channel.NewCommander(newTestPool(), func() []channel.ModelOption { return models }, nil),
 		listFn:     func() []channel.ModelOption { return models },
-		chatModels: make(map[string]ModelOption),
+		chatModels: make(map[string]channel.ModelOption),
 	}
 
 	var reply string
@@ -539,13 +555,14 @@ func TestHandleModelCommandInvalidIndex(t *testing.T) {
 		{Provider: "openai", Model: "gpt-4"},
 	}
 	bot := &Bot{
+		cmd:        channel.NewCommander(newTestPool(), func() []channel.ModelOption { return models }, nil),
 		listFn:     func() []channel.ModelOption { return models },
-		chatModels: make(map[string]ModelOption),
+		chatModels: make(map[string]channel.ModelOption),
 	}
 
 	var reply string
 	bot.handleModelCommand("5", "ch", func(s string) { reply = s })
-	if !strings.Contains(reply, "Invalid selection") {
+	if !strings.Contains(reply, "invalid selection") {
 		t.Errorf("expected invalid selection, got: %s", reply)
 	}
 }
@@ -554,15 +571,17 @@ func TestHandleModelCommandSwitchError(t *testing.T) {
 	models := []channel.ModelOption{
 		{Provider: "openai", Model: "gpt-4"},
 	}
+	switchFn := func(string, string) error { return fmt.Errorf("switch failed") }
 	bot := &Bot{
+		cmd:        channel.NewCommander(newTestPool(), func() []channel.ModelOption { return models }, switchFn),
 		listFn:     func() []channel.ModelOption { return models },
-		switchFn:   func(string, string) error { return fmt.Errorf("switch failed") },
-		chatModels: make(map[string]ModelOption),
+		switchFn:   switchFn,
+		chatModels: make(map[string]channel.ModelOption),
 	}
 
 	var reply string
 	bot.handleModelCommand("1", "ch", func(s string) { reply = s })
-	if !strings.Contains(reply, "Error switching model") {
+	if !strings.Contains(reply, "switch model") {
 		t.Errorf("expected switch error, got: %s", reply)
 	}
 }
@@ -574,50 +593,6 @@ func TestNotifyEmptyChatID(t *testing.T) {
 	err := bot.Notify(context.Background(), channel.Notification{})
 	if err == nil {
 		t.Fatal("expected error for empty chat ID")
-	}
-}
-
-// --- toolLine edge cases ---
-
-func TestToolLineRunningNoInput(t *testing.T) {
-	line := toolLine(&runner.ToolUseEvent{Tool: "search", Status: "running"})
-	if !strings.Contains(line, "search") {
-		t.Errorf("unexpected line: %q", line)
-	}
-	if strings.Contains(line, ":") {
-		t.Errorf("no input should not have colon separator: %q", line)
-	}
-}
-
-func TestToolLineUnknownTool(t *testing.T) {
-	line := toolLine(&runner.ToolUseEvent{Tool: "custom_tool", Status: "running", Input: "x"})
-	if !strings.Contains(line, "🔧") {
-		t.Errorf("unknown tool should use default emoji: %q", line)
-	}
-}
-
-// --- buildStreamDisplay edge cases ---
-
-func TestBuildStreamDisplayEmptyTextWithTool(t *testing.T) {
-	d := buildStreamDisplay("", "⚡ bash: ls")
-	if !strings.Contains(d, "⚡ bash: ls") {
-		t.Errorf("should show tool line: %q", d)
-	}
-}
-
-func TestBuildStreamDisplayEmptyAll(t *testing.T) {
-	d := buildStreamDisplay("", "")
-	if !strings.HasSuffix(d, typingCursor) {
-		t.Errorf("should end with cursor: %q", d)
-	}
-}
-
-// --- splitMessage edge cases ---
-
-func TestSplitMessageEmpty(t *testing.T) {
-	chunks := splitMessage("")
-	if len(chunks) != 1 || chunks[0] != "" {
-		t.Errorf("empty message should return single empty chunk, got %v", chunks)
 	}
 }
 
@@ -671,6 +646,32 @@ func TestBuildMessageContentEmptyNoAttachments(t *testing.T) {
 
 func TestSendImageNoOp(t *testing.T) {
 	bot := &Bot{}
-	// Should not panic.
 	bot.sendImage("target", "msg", runner.ImageEvent{}, scopeC2C)
+}
+
+// --- test helpers ---
+
+type testPool struct {
+	sessions map[string]channel.SessionInfo
+	nextID   int
+}
+
+func newTestPool() *testPool { return &testPool{sessions: make(map[string]channel.SessionInfo)} }
+
+func (p *testPool) ResolveSession(ch string) (channel.SessionInfo, error) {
+	if info, ok := p.sessions[ch]; ok {
+		return info, nil
+	}
+	return p.RotateSession(ch)
+}
+
+func (p *testPool) RotateSession(ch string) (channel.SessionInfo, error) {
+	p.nextID++
+	info := channel.SessionInfo{ID: fmt.Sprintf("s-%d", p.nextID)}
+	p.sessions[ch] = info
+	return info, nil
+}
+
+func (p *testPool) CompactSession(_ context.Context, _ string) (string, error) {
+	return "compacted", nil
 }

--- a/channel/qq/qq_test.go
+++ b/channel/qq/qq_test.go
@@ -328,10 +328,10 @@ func TestFormatModelListNoQuery(t *testing.T) {
 		{Provider: "anthropic", Model: "claude-3"},
 	})
 	out := formatModelList(models, "")
-	if !strings.Contains(out, "1. openai/gpt-4") {
+	if !strings.Contains(out, "• openai/gpt-4") {
 		t.Errorf("missing model entry in output: %s", out)
 	}
-	if !strings.Contains(out, "2. anthropic/claude-3") {
+	if !strings.Contains(out, "• anthropic/claude-3") {
 		t.Errorf("missing model entry in output: %s", out)
 	}
 	if strings.Contains(out, "filter") {
@@ -550,7 +550,30 @@ func TestHandleModelCommandFilterNoMatch(t *testing.T) {
 	}
 }
 
-func TestHandleModelCommandInvalidIndex(t *testing.T) {
+func TestHandleModelCommandSwitchByName(t *testing.T) {
+	models := []channel.ModelOption{
+		{Provider: "openai", Model: "gpt-4"},
+	}
+	var switched string
+	switchFn := func(p, m string) error { switched = p + "/" + m; return nil }
+	bot := &Bot{
+		cmd:        channel.NewCommander(newTestPool(), func() []channel.ModelOption { return models }, switchFn),
+		listFn:     func() []channel.ModelOption { return models },
+		switchFn:   switchFn,
+		chatModels: make(map[string]channel.ModelOption),
+	}
+
+	var reply string
+	bot.handleModelCommand("openai/gpt-4", "ch", func(s string) { reply = s })
+	if !strings.Contains(reply, "Switched to openai/gpt-4") {
+		t.Errorf("expected switch confirmation, got: %s", reply)
+	}
+	if switched != "openai/gpt-4" {
+		t.Errorf("expected switch to openai/gpt-4, got: %s", switched)
+	}
+}
+
+func TestHandleModelCommandSwitchByNameUnknown(t *testing.T) {
 	models := []channel.ModelOption{
 		{Provider: "openai", Model: "gpt-4"},
 	}
@@ -561,9 +584,9 @@ func TestHandleModelCommandInvalidIndex(t *testing.T) {
 	}
 
 	var reply string
-	bot.handleModelCommand("5", "ch", func(s string) { reply = s })
-	if !strings.Contains(reply, "invalid selection") {
-		t.Errorf("expected invalid selection, got: %s", reply)
+	bot.handleModelCommand("fake/model", "ch", func(s string) { reply = s })
+	if !strings.Contains(reply, "unknown model") {
+		t.Errorf("expected unknown model error, got: %s", reply)
 	}
 }
 
@@ -580,9 +603,27 @@ func TestHandleModelCommandSwitchError(t *testing.T) {
 	}
 
 	var reply string
-	bot.handleModelCommand("1", "ch", func(s string) { reply = s })
+	bot.handleModelCommand("openai/gpt-4", "ch", func(s string) { reply = s })
 	if !strings.Contains(reply, "switch model") {
 		t.Errorf("expected switch error, got: %s", reply)
+	}
+}
+
+func TestHandleModelCommandNumericTreatedAsFilter(t *testing.T) {
+	models := []channel.ModelOption{
+		{Provider: "openai", Model: "gpt-4"},
+	}
+	bot := &Bot{
+		cmd:        channel.NewCommander(newTestPool(), func() []channel.ModelOption { return models }, nil),
+		listFn:     func() []channel.ModelOption { return models },
+		chatModels: make(map[string]channel.ModelOption),
+	}
+
+	var reply string
+	bot.handleModelCommand("5", "ch", func(s string) { reply = s })
+	// "5" is now treated as a filter query, not an index
+	if !strings.Contains(reply, "No models matching") {
+		t.Errorf("expected no match for numeric filter, got: %s", reply)
 	}
 }
 

--- a/channel/qq/render.go
+++ b/channel/qq/render.go
@@ -1,17 +1,15 @@
 package qq
 
 import (
-	"strings"
-	"unicode/utf8"
-
 	"github.com/tencent-connect/botgo/dto"
 	"github.com/vaayne/anna/agent/runner"
+	"github.com/vaayne/anna/channel"
 )
 
 // sendFinalResponse sends the completed response, splitting into chunks
 // if necessary.
 func (b *Bot) sendFinalResponse(targetID, msgID, response string, scope messageScope) {
-	chunks := splitMessage(response)
+	chunks := channel.SplitMessage(response, qqMaxMessageLen)
 	for i, chunk := range chunks {
 		// MsgSeq starts at 100 to avoid collisions with stream chunk
 		// sequence numbers (which start at 1).
@@ -42,34 +40,4 @@ func (b *Bot) sendFinalResponse(targetID, msgID, response string, scope messageS
 // TODO: support image sending once a file-upload or proxy solution is available.
 func (b *Bot) sendImage(_ string, _ string, _ runner.ImageEvent, _ messageScope) {
 	logger().Debug("skipping image send: QQ requires HTTP URL for rich media")
-}
-
-// splitMessage splits a message into chunks that fit within QQ's message
-// length limit. It tries to split at newline boundaries when possible.
-func splitMessage(text string) []string {
-	if len(text) <= qqMaxMessageLen {
-		return []string{text}
-	}
-
-	var chunks []string
-	for len(text) > 0 {
-		if len(text) <= qqMaxMessageLen {
-			chunks = append(chunks, text)
-			break
-		}
-
-		cutAt := qqMaxMessageLen
-		// Avoid splitting in the middle of a multi-byte UTF-8 character.
-		for cutAt > 0 && !utf8.RuneStart(text[cutAt]) {
-			cutAt--
-		}
-		if idx := strings.LastIndex(text[:cutAt], "\n"); idx > 0 {
-			cutAt = idx + 1
-		}
-
-		chunks = append(chunks, text[:cutAt])
-		text = text[cutAt:]
-	}
-
-	return chunks
 }

--- a/channel/telegram/handler.go
+++ b/channel/telegram/handler.go
@@ -76,10 +76,11 @@ func (b *Bot) registerHandlers() {
 
 	b.bot.Handle("/model", b.guard(func(c tele.Context) error {
 		args := strings.TrimSpace(c.Message().Payload)
-		idx, query := channel.ParseModelArgs(args)
+		query := channel.ParseModelArgs(args)
 
-		if idx > 0 {
-			return b.switchModelByIdx(c, idx)
+		// If the query looks like "provider/model", try switching directly.
+		if query != "" && strings.Contains(query, "/") {
+			return b.switchModelByName(c, query)
 		}
 
 		models := b.cmd.ModelList(query)

--- a/channel/telegram/handler.go
+++ b/channel/telegram/handler.go
@@ -11,8 +11,18 @@ import (
 
 	"github.com/vaayne/anna/agent/runner"
 	aitypes "github.com/vaayne/anna/ai/types"
+	"github.com/vaayne/anna/channel"
 	tele "gopkg.in/telebot.v4"
 )
+
+// atoiOr converts a string to int, returning fallback on error.
+func atoiOr(s string, fallback int) int {
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return fallback
+	}
+	return v
+}
 
 const welcomeMessage = `👋 Hi! I'm Anna — your local AI assistant.
 
@@ -43,49 +53,43 @@ func (b *Bot) registerHandlers() {
 
 	b.bot.Handle("/new", b.guard(func(c tele.Context) error {
 		ch := channelForChat(c)
-		info, err := b.pool.RotateSession(ch)
+		sessionID, err := b.cmd.New(ch)
 		if err != nil {
 			logger().Error("rotate session failed", "channel", ch, "error", err)
 			return c.Send(fmt.Sprintf("Error creating new session: %v", err))
 		}
-		logger().Info("new session created", "session_id", info.ID, "channel", ch)
+		logger().Info("new session created", "session_id", sessionID, "channel", ch)
 		return c.Send("New session started.")
 	}))
 
 	b.bot.Handle("/compact", b.guard(func(c tele.Context) error {
-		sessionID, err := b.resolveSession(c)
-		if err != nil {
-			return c.Send(fmt.Sprintf("No active session: %v", err))
-		}
+		ch := channelForChat(c)
 		_ = c.Notify(tele.Typing)
-		summary, err := b.pool.CompactSession(b.ctx, sessionID)
+		summary, err := b.cmd.Compact(b.ctx, ch)
 		if err != nil {
-			logger().Error("compact session failed", "session_id", sessionID, "error", err)
+			logger().Error("compact session failed", "channel", ch, "error", err)
 			return c.Send(fmt.Sprintf("Compaction failed: %v", err))
 		}
-		logger().Info("session compacted", "session_id", sessionID, "summary_len", len(summary))
+		logger().Info("session compacted", "channel", ch, "summary_len", len(summary))
 		return c.Send("Session compacted.")
 	}))
 
 	b.bot.Handle("/model", b.guard(func(c tele.Context) error {
 		args := strings.TrimSpace(c.Message().Payload)
-		models := b.listFn()
+		idx, query := channel.ParseModelArgs(args)
 
-		if args == "" {
-			return b.sendModelKeyboard(c, indexModels(models))
+		if idx > 0 {
+			return b.switchModelByIdx(c, idx)
 		}
 
-		// Numeric arg → direct switch by index.
-		if _, err := strconv.Atoi(args); err == nil {
-			return b.switchModel(c, models, args)
+		models := b.cmd.ModelList(query)
+		if len(models) == 0 {
+			if query != "" {
+				return c.Send(fmt.Sprintf("No models matching %q.", query))
+			}
+			return c.Send("No models configured.")
 		}
-
-		// Text arg → filter models by substring match, preserving global indices.
-		filtered := filterModels(models, args)
-		if len(filtered) == 0 {
-			return c.Send(fmt.Sprintf("No models matching %q.", args))
-		}
-		return b.sendModelKeyboard(c, filtered)
+		return b.sendModelKeyboard(c, models)
 	}))
 
 	// Handle inline keyboard callbacks for model selection via unique handler.
@@ -93,8 +97,7 @@ func (b *Bot) registerHandlers() {
 	b.bot.Handle("\fmodel_select", b.guard(func(c tele.Context) error {
 		idxStr := c.Data()
 		logger().Debug("model_select callback fired", "data", idxStr, "sender", c.Sender().ID, "chat", c.Chat().ID)
-		models := b.listFn()
-		if err := b.switchModel(c, models, idxStr); err != nil {
+		if err := b.switchModelByIdx(c, atoiOr(idxStr, 0)); err != nil {
 			logger().Error("model switch failed", "data", idxStr, "error", err)
 			return err
 		}
@@ -109,8 +112,7 @@ func (b *Bot) registerHandlers() {
 		pageStr, query, _ := strings.Cut(data, "|")
 		page, _ := strconv.Atoi(pageStr)
 
-		allModels := b.listFn()
-		models := filterModels(allModels, query)
+		models := b.cmd.ModelList(query)
 		if err := b.sendModelPage(c, models, page, query, true); err != nil {
 			logger().Error("model page failed", "page", page, "error", err)
 			return err

--- a/channel/telegram/model.go
+++ b/channel/telegram/model.go
@@ -83,7 +83,22 @@ func (b *Bot) sendModelPage(c tele.Context, models []channel.IndexedModel, page 
 	return c.Send(text, markup)
 }
 
+// switchModelByName handles model switching by "provider/model" name using Commander.
+func (b *Bot) switchModelByName(c tele.Context, name string) error {
+	ch := channelForChat(c)
+	selected, err := b.cmd.ModelSwitchByName(ch, name)
+	if err != nil {
+		return c.Send(fmt.Sprintf("Error: %v", err))
+	}
+	b.mu.Lock()
+	b.chatModels[c.Chat().ID] = selected
+	b.mu.Unlock()
+	logger().Info("model switched", "channel", ch, "provider", selected.Provider, "model", selected.Model)
+	return c.Send(fmt.Sprintf("Switched to %s/%s. Session reset.", selected.Provider, selected.Model))
+}
+
 // switchModelByIdx handles model switching by 1-based index using Commander.
+// Used internally by inline keyboard callbacks.
 func (b *Bot) switchModelByIdx(c tele.Context, idx int) error {
 	ch := channelForChat(c)
 	selected, err := b.cmd.ModelSwitch(ch, idx)

--- a/channel/telegram/model.go
+++ b/channel/telegram/model.go
@@ -2,64 +2,22 @@ package telegram
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
 
 	"github.com/vaayne/anna/channel"
 	tele "gopkg.in/telebot.v4"
 )
 
-// ModelOption re-exports channel.ModelOption for use by callers.
-type ModelOption = channel.ModelOption
-
-// ModelListFunc re-exports channel.ModelListFunc for use by callers.
-type ModelListFunc = channel.ModelListFunc
-
-// ModelSwitchFunc re-exports channel.ModelSwitchFunc for use by callers.
-type ModelSwitchFunc = channel.ModelSwitchFunc
-
 const modelsPerPage = 8
 
-// indexedModel pairs a ModelOption with its 1-based index in the full model list.
-type indexedModel struct {
-	ModelOption
-	globalIdx int
-}
-
-// indexModels wraps a full model list with sequential 1-based indices.
-func indexModels(models []ModelOption) []indexedModel {
-	out := make([]indexedModel, len(models))
-	for i, m := range models {
-		out[i] = indexedModel{ModelOption: m, globalIdx: i + 1}
-	}
-	return out
-}
-
-// filterModels returns indexed models matching the query (or all if query is empty).
-func filterModels(models []ModelOption, query string) []indexedModel {
-	if query == "" {
-		return indexModels(models)
-	}
-	query = strings.ToLower(query)
-	var out []indexedModel
-	for i, m := range models {
-		label := strings.ToLower(m.Provider + "/" + m.Model)
-		if strings.Contains(label, query) {
-			out = append(out, indexedModel{ModelOption: m, globalIdx: i + 1})
-		}
-	}
-	return out
-}
-
 // sendModelKeyboard sends a paginated inline keyboard with model selection buttons.
-func (b *Bot) sendModelKeyboard(c tele.Context, models []indexedModel) error {
+func (b *Bot) sendModelKeyboard(c tele.Context, models []channel.IndexedModel) error {
 	return b.sendModelPage(c, models, 0, "", false)
 }
 
 // sendModelPage renders a single page of the model keyboard.
 // query is preserved in nav button data so filtered pagination works across pages.
 // If edit is true, it edits the existing message instead of sending a new one.
-func (b *Bot) sendModelPage(c tele.Context, models []indexedModel, page int, query string, edit bool) error {
+func (b *Bot) sendModelPage(c tele.Context, models []channel.IndexedModel, page int, query string, edit bool) error {
 	if len(models) == 0 {
 		return c.Send("No models configured.")
 	}
@@ -90,7 +48,7 @@ func (b *Bot) sendModelPage(c tele.Context, models []indexedModel, page int, que
 		if hasActive && m.Provider == active.Provider && m.Model == active.Model {
 			label = "✅ " + label
 		}
-		btn := markup.Data(label, "model_select", fmt.Sprintf("%d", m.globalIdx))
+		btn := markup.Data(label, "model_select", fmt.Sprintf("%d", m.GlobalIdx))
 		rows = append(rows, markup.Row(btn))
 	}
 
@@ -116,27 +74,21 @@ func (b *Bot) sendModelPage(c tele.Context, models []indexedModel, page int, que
 	markup.Inline(rows...)
 
 	text := fmt.Sprintf("Select a model (%d total):", len(models))
+	if query != "" {
+		text = fmt.Sprintf("Select a model (filter: %q, %d matches):", query, len(models))
+	}
 	if edit {
 		return c.Edit(text, markup)
 	}
 	return c.Send(text, markup)
 }
 
-// switchModel handles model switching by index string.
-func (b *Bot) switchModel(c tele.Context, models []ModelOption, idxStr string) error {
-	idx, err := strconv.Atoi(idxStr)
-	if err != nil || idx < 1 || idx > len(models) {
-		return c.Send(fmt.Sprintf("Invalid selection. Use a number between 1 and %d.", len(models)))
-	}
-	selected := models[idx-1]
-	if b.switchFn != nil {
-		if err := b.switchFn(selected.Provider, selected.Model); err != nil {
-			return c.Send(fmt.Sprintf("Error switching model: %v", err))
-		}
-	}
+// switchModelByIdx handles model switching by 1-based index using Commander.
+func (b *Bot) switchModelByIdx(c tele.Context, idx int) error {
 	ch := channelForChat(c)
-	if _, err := b.pool.RotateSession(ch); err != nil {
-		logger().Error("rotate session after model switch failed", "channel", ch, "error", err)
+	selected, err := b.cmd.ModelSwitch(ch, idx)
+	if err != nil {
+		return c.Send(fmt.Sprintf("Error: %v", err))
 	}
 	b.mu.Lock()
 	b.chatModels[c.Chat().ID] = selected

--- a/channel/telegram/render.go
+++ b/channel/telegram/render.go
@@ -5,9 +5,9 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"strings"
 
 	"github.com/vaayne/anna/agent/runner"
+	"github.com/vaayne/anna/channel"
 	"github.com/yuin/goldmark/parser"
 	tele "gopkg.in/telebot.v4"
 )
@@ -49,7 +49,7 @@ func (b *Bot) sendChunkedMarkdown(chat tele.Recipient, text string, silent bool,
 	if sendOpts == nil {
 		sendOpts = &tele.SendOptions{ParseMode: tele.ModeMarkdownV2}
 	}
-	chunks := splitMessage(text)
+	chunks := channel.SplitMessage(text, telegramMaxMessageLen)
 	for _, chunk := range chunks {
 		rendered := renderMarkdown(b.md, chunk)
 		if _, err := b.bot.Send(chat, rendered, sendOpts); err != nil {
@@ -74,31 +74,4 @@ func renderMarkdown(md goldmarkMD, text string) string {
 		return text
 	}
 	return result
-}
-
-// splitMessage splits a message into chunks that fit within Telegram's 4096
-// character limit. It tries to split at newline boundaries when possible.
-func splitMessage(text string) []string {
-	if len(text) <= telegramMaxMessageLen {
-		return []string{text}
-	}
-
-	var chunks []string
-	for len(text) > 0 {
-		if len(text) <= telegramMaxMessageLen {
-			chunks = append(chunks, text)
-			break
-		}
-
-		cutAt := telegramMaxMessageLen
-		// Try to find the last newline before the limit.
-		if idx := strings.LastIndex(text[:cutAt], "\n"); idx > 0 {
-			cutAt = idx + 1 // Include the newline in the current chunk.
-		}
-
-		chunks = append(chunks, text[:cutAt])
-		text = text[cutAt:]
-	}
-
-	return chunks
 }

--- a/channel/telegram/stream.go
+++ b/channel/telegram/stream.go
@@ -10,6 +10,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/vaayne/anna/agent/runner"
+	"github.com/vaayne/anna/channel"
 	tele "gopkg.in/telebot.v4"
 )
 
@@ -124,7 +125,7 @@ func (tt *toolTracker) render() string {
 			input := truncate(tt.activeInput, 60)
 			line += ": " + input
 		}
-		line += fmt.Sprintf(" (%s)", formatDuration(elapsed))
+		line += fmt.Sprintf(" (%s)", channel.FormatDuration(elapsed))
 		sb.WriteString(line)
 		sb.WriteByte('\n')
 	}
@@ -199,7 +200,7 @@ func (tt *toolTracker) renderFinal() string {
 		}
 	}
 	sb.WriteString(") · ")
-	sb.WriteString(formatDuration(totalDur))
+	sb.WriteString(channel.FormatDuration(totalDur))
 
 	// Append individual lines for error calls.
 	for _, rec := range errors {
@@ -226,7 +227,7 @@ func renderToolRecord(rec toolRecord) string {
 		detail := truncate(rec.Detail, 80)
 		line += " → " + detail
 	}
-	line += fmt.Sprintf(" (%s)", formatDuration(rec.Duration))
+	line += fmt.Sprintf(" (%s)", channel.FormatDuration(rec.Duration))
 	return line
 }
 
@@ -236,14 +237,6 @@ func emojiFor(tool string) string {
 		return e
 	}
 	return toolEmoji["default"]
-}
-
-// formatDuration formats a duration as a human-friendly string.
-func formatDuration(d time.Duration) string {
-	if d < time.Second {
-		return fmt.Sprintf("%dms", d.Milliseconds())
-	}
-	return fmt.Sprintf("%.1fs", d.Seconds())
 }
 
 // truncate shortens s to maxLen bytes, appending "..." if truncated.

--- a/channel/telegram/telegram.go
+++ b/channel/telegram/telegram.go
@@ -33,15 +33,17 @@ type Config struct {
 }
 
 // Bot wraps a Telegram bot with agent pool integration.
+// It implements channel.Channel.
 type Bot struct {
 	bot      *tele.Bot
 	pool     *agent.Pool
-	listFn   ModelListFunc
-	switchFn ModelSwitchFunc
+	cmd      *channel.Commander
+	listFn   channel.ModelListFunc
+	switchFn channel.ModelSwitchFunc
 	md       goldmarkMD
 
 	mu         sync.RWMutex
-	chatModels map[int64]ModelOption
+	chatModels map[int64]channel.ModelOption
 
 	allowed map[int64]struct{} // empty map = allow all
 	cfg     Config
@@ -49,7 +51,7 @@ type Bot struct {
 }
 
 // New creates a Telegram bot and registers handlers. Call Start to begin polling.
-func New(cfg Config, pool *agent.Pool, listFn ModelListFunc, switchFn ModelSwitchFunc) (*Bot, error) {
+func New(cfg Config, pool *agent.Pool, listFn channel.ModelListFunc, switchFn channel.ModelSwitchFunc) (*Bot, error) {
 	bot, err := tele.NewBot(tele.Settings{
 		Token: cfg.Token,
 		Poller: &tele.LongPoller{
@@ -70,13 +72,21 @@ func New(cfg Config, pool *agent.Pool, listFn ModelListFunc, switchFn ModelSwitc
 		allowed[id] = struct{}{}
 	}
 
+	poolAdapter := &channel.PoolAdapter[agent.SessionInfo]{
+		ResolveFunc: pool.ResolveSession,
+		RotateFunc:  pool.RotateSession,
+		CompactFunc: pool.CompactSession,
+		AdaptFn:     func(info agent.SessionInfo) channel.SessionInfo { return channel.SessionInfo{ID: info.ID} },
+	}
+
 	b := &Bot{
 		bot:        bot,
 		pool:       pool,
+		cmd:        channel.NewCommander(poolAdapter, listFn, switchFn),
 		listFn:     listFn,
 		switchFn:   switchFn,
 		md:         tgmd.TGMD(),
-		chatModels: make(map[int64]ModelOption),
+		chatModels: make(map[int64]channel.ModelOption),
 		allowed:    allowed,
 		cfg:        cfg,
 	}
@@ -105,10 +115,16 @@ func (b *Bot) Start(ctx context.Context) error {
 	return ctx.Err()
 }
 
-// Name returns the backend name. Implements channel.Backend.
+// Stop gracefully shuts down the Telegram bot. Implements channel.Channel.
+func (b *Bot) Stop() {
+	logger().Info("stopping telegram bot")
+	b.bot.Stop()
+}
+
+// Name returns the channel name. Implements channel.Channel.
 func (b *Bot) Name() string { return "telegram" }
 
-// Notify sends a message to the specified chat. Implements channel.Backend.
+// Notify sends a message to the specified chat. Implements channel.Channel.
 func (b *Bot) Notify(_ context.Context, n channel.Notification) error {
 	chatID := n.ChatID
 	if chatID == "" {

--- a/channel/telegram/telegram_test.go
+++ b/channel/telegram/telegram_test.go
@@ -6,12 +6,13 @@ import (
 	"time"
 
 	"github.com/vaayne/anna/agent/runner"
+	"github.com/vaayne/anna/channel"
 
 	tgmd "github.com/Mad-Pixels/goldmark-tgmd"
 )
 
 func TestSplitMessageShort(t *testing.T) {
-	chunks := splitMessage("hello")
+	chunks := channel.SplitMessage("hello", telegramMaxMessageLen)
 	if len(chunks) != 1 || chunks[0] != "hello" {
 		t.Errorf("chunks = %v, want [hello]", chunks)
 	}
@@ -19,7 +20,7 @@ func TestSplitMessageShort(t *testing.T) {
 
 func TestSplitMessageExactLimit(t *testing.T) {
 	msg := strings.Repeat("a", telegramMaxMessageLen)
-	chunks := splitMessage(msg)
+	chunks := channel.SplitMessage(msg, telegramMaxMessageLen)
 	if len(chunks) != 1 {
 		t.Errorf("len(chunks) = %d, want 1", len(chunks))
 	}
@@ -27,7 +28,7 @@ func TestSplitMessageExactLimit(t *testing.T) {
 
 func TestSplitMessageLong(t *testing.T) {
 	msg := strings.Repeat("a", telegramMaxMessageLen+100)
-	chunks := splitMessage(msg)
+	chunks := channel.SplitMessage(msg, telegramMaxMessageLen)
 	if len(chunks) != 2 {
 		t.Errorf("len(chunks) = %d, want 2", len(chunks))
 	}
@@ -44,7 +45,7 @@ func TestSplitMessageAtNewline(t *testing.T) {
 	part2 := strings.Repeat("b", 2000)
 	msg := part1 + "\n" + part2
 
-	chunks := splitMessage(msg)
+	chunks := channel.SplitMessage(msg, telegramMaxMessageLen)
 	if len(chunks) != 2 {
 		t.Fatalf("len(chunks) = %d, want 2", len(chunks))
 	}
@@ -57,7 +58,7 @@ func TestSplitMessageAtNewline(t *testing.T) {
 }
 
 func TestSplitMessageEmpty(t *testing.T) {
-	chunks := splitMessage("")
+	chunks := channel.SplitMessage("", telegramMaxMessageLen)
 	if len(chunks) != 1 || chunks[0] != "" {
 		t.Errorf("chunks = %v, want [\"\"]", chunks)
 	}
@@ -65,7 +66,7 @@ func TestSplitMessageEmpty(t *testing.T) {
 
 func TestSplitMessageMultipleChunks(t *testing.T) {
 	msg := strings.Repeat("x", telegramMaxMessageLen*3+500)
-	chunks := splitMessage(msg)
+	chunks := channel.SplitMessage(msg, telegramMaxMessageLen)
 	if len(chunks) != 4 {
 		t.Errorf("len(chunks) = %d, want 4", len(chunks))
 	}
@@ -409,9 +410,9 @@ func TestFormatDuration(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := formatDuration(tt.d)
+		got := channel.FormatDuration(tt.d)
 		if got != tt.want {
-			t.Errorf("formatDuration(%v) = %q, want %q", tt.d, got, tt.want)
+			t.Errorf("FormatDuration(%v) = %q, want %q", tt.d, got, tt.want)
 		}
 	}
 }
@@ -502,13 +503,11 @@ func TestBuildStreamDisplayTruncation(t *testing.T) {
 
 func TestBuildStreamDisplayUTF8Safe(t *testing.T) {
 	// Build a string that would need truncation, with multi-byte runes near the cut point.
-	// U+4E16 (世) is 3 bytes in UTF-8.
 	prefix := strings.Repeat("a", telegramMaxMessageLen-20)
 	multibyte := strings.Repeat("世", 20) // 60 bytes, will push past limit
 	text := prefix + multibyte
 
 	got := buildStreamDisplay(text, "", false)
-	// Verify the result is valid UTF-8 (strings.ToValidUTF8 would change invalid bytes).
 	if strings.ToValidUTF8(got, "?") != got {
 		t.Error("buildStreamDisplay() produced invalid UTF-8")
 	}

--- a/channel/util.go
+++ b/channel/util.go
@@ -1,0 +1,53 @@
+package channel
+
+import (
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+// SplitMessage splits text into chunks that fit within maxLen.
+// It tries to split at newline boundaries and avoids cutting multi-byte
+// UTF-8 characters.
+func SplitMessage(text string, maxLen int) []string {
+	if len(text) <= maxLen {
+		return []string{text}
+	}
+
+	var chunks []string
+	for len(text) > 0 {
+		if len(text) <= maxLen {
+			chunks = append(chunks, text)
+			break
+		}
+
+		cutAt := maxLen
+		// Avoid splitting in the middle of a multi-byte UTF-8 character.
+		for cutAt > 0 && !utf8.RuneStart(text[cutAt]) {
+			cutAt--
+		}
+		if idx := strings.LastIndex(text[:cutAt], "\n"); idx > 0 {
+			cutAt = idx + 1 // Include the newline in the current chunk.
+		}
+
+		chunks = append(chunks, text[:cutAt])
+		text = text[cutAt:]
+	}
+
+	return chunks
+}
+
+// FormatDuration formats a duration as a human-friendly string.
+func FormatDuration(d time.Duration) string {
+	switch {
+	case d < time.Second:
+		return fmt.Sprintf("%dms", d.Milliseconds())
+	case d < time.Minute:
+		return fmt.Sprintf("%.1fs", d.Seconds())
+	default:
+		m := int(d.Minutes())
+		s := int(d.Seconds()) - m*60
+		return fmt.Sprintf("%dm%ds", m, s)
+	}
+}

--- a/channel/util_test.go
+++ b/channel/util_test.go
@@ -1,0 +1,56 @@
+package channel
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSplitMessage(t *testing.T) {
+	t.Run("short message", func(t *testing.T) {
+		chunks := SplitMessage("hello", 100)
+		if len(chunks) != 1 || chunks[0] != "hello" {
+			t.Errorf("got %v", chunks)
+		}
+	})
+
+	t.Run("splits at newline", func(t *testing.T) {
+		text := strings.Repeat("a", 50) + "\n" + strings.Repeat("b", 50)
+		chunks := SplitMessage(text, 60)
+		if len(chunks) != 2 {
+			t.Fatalf("got %d chunks, want 2", len(chunks))
+		}
+	})
+
+	t.Run("handles UTF-8", func(t *testing.T) {
+		// Each emoji is 4 bytes. Create a string that would split mid-rune.
+		text := strings.Repeat("\U0001F600", 30) // 120 bytes
+		chunks := SplitMessage(text, 50)
+		for _, c := range chunks {
+			for i := 0; i < len(c); {
+				r, size := []rune(c[i:])[0], len(string([]rune(c[i:])[0]))
+				if r == 0xFFFD {
+					t.Error("invalid UTF-8 in chunk")
+				}
+				i += size
+			}
+		}
+	})
+}
+
+func TestFormatDuration(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{500 * time.Millisecond, "500ms"},
+		{1500 * time.Millisecond, "1.5s"},
+		{90 * time.Second, "1m30s"},
+	}
+	for _, tt := range tests {
+		got := FormatDuration(tt.d)
+		if got != tt.want {
+			t.Errorf("FormatDuration(%v) = %q, want %q", tt.d, got, tt.want)
+		}
+	}
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,9 +65,11 @@ agent/
     truncate.go                     Truncate large outputs to temp files
 
 channel/
-  notifier.go                       Notification dispatcher (multi-backend)
+  model.go                          Channel interface, model list/switch types
+  command.go                        Shared Commander (handles /new, /compact, /model)
+  util.go                           Shared utilities (SplitMessage, FormatDuration)
+  notifier.go                       Notification dispatcher (multi-channel)
   notify_tool.go                    Agent notify tool
-  model.go                          Model list/switch function types
   cli/
     cli.go                          Interactive TUI entry points
     chat.go                         Bubble Tea chat model
@@ -75,11 +77,17 @@ channel/
     model.go                        TUI model switching UI
     style.go                        Terminal styling
   telegram/
-    telegram.go                     Bot setup, long polling, notification backend
+    telegram.go                     Bot setup, long polling (implements channel.Channel)
     handler.go                      Message/callback handlers
     stream.go                       Streaming (draft API + edit fallback)
-    render.go                       Markdown rendering, message splitting
+    render.go                       Markdown rendering
     model.go                        Paginated model picker UI
+  qq/
+    qq.go                           Bot setup, WebSocket (implements channel.Channel)
+    handler.go                      Message handlers, command routing
+    stream.go                       Streaming via QQ Stream API
+    render.go                       Message chunking
+    model.go                        Text-based model selection UI
 
 cron/
   cron.go                           Scheduler service (gocron/v2)
@@ -150,11 +158,26 @@ type Tool interface {
 
 See [session-compaction.md](session-compaction.md) for history management.
 
+## Channel Interface
+
+All messaging platforms implement the `channel.Channel` interface:
+
+```go
+type Channel interface {
+    Name() string
+    Start(ctx context.Context) error
+    Stop()
+    Notify(ctx context.Context, n Notification) error
+}
+```
+
+Shared command logic (`/new`, `/compact`, `/model`) lives in `channel.Commander`, which each channel delegates to for the core logic. Channels only handle platform-specific presentation (Telegram uses inline keyboards, QQ uses text lists, CLI uses a TUI picker).
+
 ## Notification Flow
 
 ```
-Agent notify tool --> Dispatcher --> Backend (Telegram)
-Cron job result   --> Dispatcher --> Backend (Telegram)
+Agent notify tool --> Dispatcher --> Channel (Telegram/QQ)
+Cron job result   --> Dispatcher --> Channel (Telegram/QQ)
 ```
 
 The dispatcher is created early in setup, but backends are registered later when gateway services start. See [notification-system.md](notification-system.md) for details.

--- a/docs/notification-system.md
+++ b/docs/notification-system.md
@@ -6,7 +6,7 @@ Implemented — `channel/notifier.go`, `channel/notify_tool.go`, `channel/telegr
 
 ## Overview
 
-Anna supports proactive notifications so the agent, cron jobs, and other internal triggers can push messages to users without waiting for a request. The system uses a multi-backend dispatcher that routes notifications to one or more configured backends (Telegram, with Slack/Discord planned).
+Anna supports proactive notifications so the agent, cron jobs, and other internal triggers can push messages to users without waiting for a request. The system uses a multi-channel dispatcher that routes notifications to one or more configured channels (Telegram, QQ, with Slack/Discord planned).
 
 ## Architecture
 
@@ -29,7 +29,7 @@ Anna supports proactive notifications so the agent, cron jobs, and other interna
                     ▼            ▼          ▼   │
               ┌──────────┐ ┌────────┐ ┌───────┐│
               │ Telegram │ │ Slack  │ │Discord││
-              │ Backend  │ │(future)│ │(future)│
+              │ Channel  │ │(future)│ │(future)│
               └──────────┘ └────────┘ └───────┘
 ```
 
@@ -46,43 +46,45 @@ type Notification struct {
 }
 ```
 
-- `Channel` empty → broadcast to **all** registered backends
-- `Channel` set → route to that specific backend only
-- `ChatID` empty → each backend uses its configured default
+- `Channel` empty → broadcast to **all** registered channels
+- `Channel` set → route to that specific channel only
+- `ChatID` empty → each channel uses its configured default
 
-### `channel.Backend`
+### `channel.Channel`
 
-Interface that notification backends implement:
+Interface that all messaging platforms implement:
 
 ```go
-type Backend interface {
+type Channel interface {
     Name() string
+    Start(ctx context.Context) error
+    Stop()
     Notify(ctx context.Context, n Notification) error
 }
 ```
 
-Currently implemented: `telegram.Bot`.
+Currently implemented: `telegram.Bot`, `qq.Bot`.
 
 ### `channel.Dispatcher`
 
-Routes notifications to registered backends:
+Routes notifications to registered channels:
 
 ```go
 d := channel.NewDispatcher()
-d.Register(tgBot, "136345060")   // telegram backend with default chat
-d.Register(slackBot, "#alerts")  // future: slack backend
+d.Register(tgBot, "136345060")   // telegram channel with default chat
+d.Register(qqBot, "")            // qq channel
 
-// Broadcast to all backends (each uses its default chat):
+// Broadcast to all channels (each uses its default chat):
 d.Notify(ctx, channel.Notification{Text: "hello"})
 
-// Route to specific backend:
+// Route to specific channel:
 d.Notify(ctx, channel.Notification{Channel: "telegram", Text: "hello"})
 
 // Override the default chat:
 d.Notify(ctx, channel.Notification{Channel: "telegram", ChatID: "999", Text: "hello"})
 ```
 
-Partial failures: if one backend fails during broadcast, the others still receive the notification. Errors are joined via `errors.Join`.
+Partial failures: if one channel fails during broadcast, the others still receive the notification. Errors are joined via `errors.Join`.
 
 ### `channel.NotifyTool`
 
@@ -104,8 +106,8 @@ The LLM can call it with:
 ```
 
 - `message` (required) — the notification text
-- `channel` (optional) — target a specific backend; omit to broadcast
-- `chat_id` (optional) — override the backend's default target
+- `channel` (optional) — target a specific channel; omit to broadcast
+- `chat_id` (optional) — override the channel's default target
 - `silent` (optional) — suppress notification sound
 
 ## Wiring
@@ -121,23 +123,23 @@ setup()
 
 runGateway()
   ├── Create telegram.Bot
-  ├── dispatcher.Register(tgBot, notifyChat)  ← backend registered
+  ├── dispatcher.Register(tgBot, notifyChat)  ← channel registered
   ├── wireCronNotifier(cron, pool, dispatcher) ← cron output → dispatcher
   └── tgBot.Start(ctx)                        ← begin polling
 ```
 
-The dispatcher is created early (in `setup`) so the notify tool can reference it. Backends are registered later (in `runGateway`) when they're created. This avoids circular dependencies.
+The dispatcher is created early (in `setup`) so the notify tool can reference it. Channels are registered later (in `runGateway`) when they're created. This avoids circular dependencies.
 
 ### Cron → Notification
 
 When a cron job fires:
 1. The job runs through `pool.Chat()` to get the agent's response
 2. The full response text is collected
-3. The text is broadcast via `dispatcher.Notify()` to all backends
+3. The text is broadcast via `dispatcher.Notify()` to all channels
 
 ### CLI Mode
 
-In CLI mode (`anna chat`), no notification backends are registered, so the `notify` tool is not exposed to the agent. This avoids a broken tool path.
+In CLI mode (`anna chat`), no notification channels are registered, so the `notify` tool is not exposed to the agent. This avoids a broken tool path.
 
 ## Configuration
 
@@ -167,37 +169,42 @@ Environment variable overrides:
 When `Notify()` is called, the target chat is resolved in this order:
 
 1. `Notification.ChatID` (explicit in the call)
-2. Backend's registered default chat (from `dispatcher.Register`)
+2. Channel's registered default chat (from `dispatcher.Register`)
 3. For Telegram: `notify_chat` → `channel_id` → error
 
-## Adding a New Backend
+## Adding a New Channel
 
-To add Slack, Discord, or any other backend:
+To add Slack, Discord, or any other channel:
 
-1. **Implement `channel.Backend`:**
+1. **Implement `channel.Channel`:**
 
 ```go
 // channel/slack/slack.go
 type Bot struct { ... }
 
-func (b *Bot) Name() string { return "slack" }
+func (b *Bot) Name() string                                          { return "slack" }
+func (b *Bot) Start(ctx context.Context) error                       { /* start listening */ }
+func (b *Bot) Stop()                                                 { /* graceful shutdown */ }
 func (b *Bot) Notify(ctx context.Context, n channel.Notification) error {
     // Send n.Text to n.ChatID via Slack API
 }
 ```
+
+Use `channel.NewCommander(pool, listFn, switchFn)` for shared `/new`, `/compact`, `/model` command logic. Use `channel.SplitMessage()` and `channel.FormatDuration()` for shared utilities.
 
 2. **Register in `runGateway()`:**
 
 ```go
 if s.cfg.Slack.Token != "" {
     slackBot := slack.New(s.cfg.Slack)
+    channels = append(channels, slackBot)
     s.notifier.Register(slackBot, s.cfg.Slack.NotifyChannel)
 }
 ```
 
 3. **Add config fields** to `config.go` and env var overrides.
 
-No changes needed to the dispatcher, notify tool, or cron wiring — they work through the `Backend` interface.
+No changes needed to the dispatcher, notify tool, or cron wiring — they work through the `Channel` interface.
 
 ## Telegram-Specific Features
 

--- a/main.go
+++ b/main.go
@@ -269,12 +269,11 @@ func setupLogFile() error {
 
 func runGateway(ctx context.Context, s *setupResult, listFn channel.ModelListFunc, switchFn channel.ModelSwitchFunc) error {
 	g, gctx := errgroup.WithContext(ctx)
-	started := 0
+	var channels []channel.Channel
 
 	// --- Telegram ---
 	tg := s.cfg.Channels.Telegram
 	if tg.Token != "" {
-		started++
 		slog.Info("starting telegram bot")
 
 		tgBot, err := telegram.New(telegram.Config{
@@ -292,20 +291,13 @@ func runGateway(ctx context.Context, s *setupResult, listFn channel.ModelListFun
 		if defaultChat == "" {
 			defaultChat = tg.ChannelID
 		}
+		channels = append(channels, tgBot)
 		s.notifier.Register(tgBot, defaultChat)
-
-		g.Go(func() error {
-			if err := tgBot.Start(gctx); err != nil && gctx.Err() == nil {
-				return fmt.Errorf("telegram: %w", err)
-			}
-			return nil
-		})
 	}
 
 	// --- QQ ---
 	qqCfg := s.cfg.Channels.QQ
 	if qqCfg.AppID != "" && qqCfg.AppSecret != "" {
-		started++
 		slog.Info("starting qq bot")
 
 		qqBot, err := qq.New(qq.Config{
@@ -318,21 +310,25 @@ func runGateway(ctx context.Context, s *setupResult, listFn channel.ModelListFun
 			return fmt.Errorf("create qq bot: %w", err)
 		}
 
+		channels = append(channels, qqBot)
 		s.notifier.Register(qqBot, "")
+	}
 
+	if len(channels) == 0 {
+		return fmt.Errorf("no gateway services configured. Check %s", configPath())
+	}
+
+	// Start all channels.
+	for _, ch := range channels {
 		g.Go(func() error {
-			if err := qqBot.Start(gctx); err != nil && gctx.Err() == nil {
-				return fmt.Errorf("qq: %w", err)
+			if err := ch.Start(gctx); err != nil && gctx.Err() == nil {
+				return fmt.Errorf("%s: %w", ch.Name(), err)
 			}
 			return nil
 		})
 	}
 
-	if started == 0 {
-		return fmt.Errorf("no gateway services configured. Check %s", configPath())
-	}
-
-	// Wire cron notifications and start the scheduler AFTER backends
+	// Wire cron notifications and start the scheduler AFTER channels
 	// are registered, so early-firing jobs already use the dispatcher.
 	if s.cronSvc != nil {
 		wireCronNotifier(s.cronSvc, s.pool, s.notifier)


### PR DESCRIPTION
## Summary

- Introduce a `channel.Channel` interface (`Name`, `Start`, `Stop`, `Notify`) that all messaging platforms implement, replacing the ad-hoc `Backend` interface
- Extract duplicated `/new`, `/compact`, `/model` command logic into a shared `Commander`
- Move common utilities (`SplitMessage`, `FormatDuration`, `IndexModels`, `FilterModels`) to the `channel` package
- Simplify `runGateway` with a uniform channel registration loop
- Adding a new channel now only requires implementing 4 methods + using `Commander` for shared commands

## Changes

| Area | What changed |
|------|-------------|
| `channel/model.go` | New `Channel` interface |
| `channel/command.go` | Shared `Commander` for `/new`, `/compact`, `/model` |
| `channel/util.go` | Shared `SplitMessage`, `FormatDuration` |
| `channel/notifier.go` | `Backend` → `Channel` in Dispatcher |
| `telegram/` | Delegates to Commander, uses shared utils, adds `Stop()` |
| `qq/` | Delegates to Commander, uses shared utils |
| `cli/` | Uses shared `FormatDuration` |
| `main.go` | Uniform `[]channel.Channel` loop in `runGateway` |
| `docs/` | Updated architecture and notification-system docs |

Net: **+797 −491** lines (new shared code + tests, removed duplication)

## Test plan

- [x] All existing tests pass (`mise run test` with `-race`)
- [x] `mise run lint` — 0 issues
- [x] `mise run format` — clean
- [x] Telegram, QQ, CLI packages build and test independently