### PR TITLE
Add Feishu (Lark) bot channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A minimal Go CLI that acts as a local AI assistant. Uses a native Go runner that calls LLM providers (Anthropic, OpenAI, OpenAI-compatible) directly.
 
-Two interfaces: **interactive CLI chat** and **gateway daemon** (Telegram bot, QQ bot).
+Two interfaces: **interactive CLI chat** and **gateway daemon** (Telegram bot, QQ bot, Feishu bot).
 
 ## Features
 
@@ -17,6 +17,10 @@ Two interfaces: **interactive CLI chat** and **gateway daemon** (Telegram bot, Q
   - Native Stream API for progressive response delivery
   - C2C (private) and group @mention support
   - Sandbox mode for testing
+- Feishu bot via WebSocket (no webhook, no public IP needed)
+  - Edit-in-place streaming for progressive response delivery
+  - Private (p2p) and group @mention support
+  - Access control via `allowed_ids`
 - Notification system with multi-backend dispatcher
 - Model management CLI (`anna models list/update/set/search`)
 - Tiered model config (strong/worker/fast) with runtime model switching
@@ -63,7 +67,7 @@ anna chat --stream   # Pipe prompt via stdin, stream to stdout
 anna gateway
 ```
 
-Starts all configured services (Telegram bot, QQ bot, cron scheduler). Services are activated based on config.
+Starts all configured services (Telegram bot, QQ bot, Feishu bot, cron scheduler). Services are activated based on config.
 
 ### Model Management
 
@@ -127,7 +131,10 @@ anna chat
   | QQ Bot    |----->|  Dispatcher   |
   | Webhook   |      | (notify tool) |--> Telegram
   +-----------+      |               |--> QQ
-                     +-------^--------+
+  +-----------+      |               |--> Feishu
+  | Feishu    |----->|               |
+  | WebSocket |      +-------^--------+
+  +-----------+              |
   +-----------+              |
   |   Cron    |--------------+
   +-----------+
@@ -148,6 +155,7 @@ channel/notifier.go                 Notification dispatcher (multi-backend)
 channel/notify_tool.go              Agent notify tool
 channel/telegram/                   Telegram bot + streaming + notification backend
 channel/qq/                         QQ bot + webhook + streaming + notification backend
+channel/feishu/                     Feishu bot + WebSocket + streaming + notification backend
 channel/cli/                        Interactive terminal chat (Bubble Tea TUI)
 cron/                               Scheduled jobs (gocron/v2)
 memory/                             Persistent memory (facts + journal)
@@ -165,6 +173,7 @@ ai/stream/                          Streaming abstractions
 | [Architecture](docs/architecture.md) | System design, packages, providers, tools |
 | [Telegram](docs/telegram.md) | Bot setup, streaming, groups, access control |
 | [QQ Bot](docs/qq.md) | Bot setup, webhook, streaming, access control |
+| [Feishu Bot](docs/feishu.md) | Bot setup, WebSocket, streaming, access control |
 | [Models](docs/models.md) | Tiers, CLI commands, provider setup, caching |
 | [Memory System](docs/memory-system.md) | Facts + journal, tool interface |
 | [Cron System](docs/cron-system.md) | Scheduled tasks, job persistence |

--- a/channel/feishu/feishu.go
+++ b/channel/feishu/feishu.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	lark "github.com/larksuite/oapi-sdk-go/v3"
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
@@ -21,6 +22,10 @@ import (
 )
 
 const feishuMaxMessageLen = 4000
+
+// seenMsgTTL is how long message IDs are retained for dedup.
+// Feishu retries within ~30s, so 5 minutes is generous.
+const seenMsgTTL = 5 * time.Minute
 
 // mentionPlaceholderRegex matches @_user_N placeholders inserted by Feishu for mentions.
 var mentionPlaceholderRegex = regexp.MustCompile(`@_user_\d+`)
@@ -50,7 +55,7 @@ type Bot struct {
 
 	mu         sync.RWMutex
 	chatModels map[string]ModelOption
-	seenMsgs   map[string]struct{} // message ID dedup
+	seenMsgs   map[string]time.Time // message ID -> first seen time
 
 	allowed map[string]struct{}
 	cfg     Config
@@ -78,7 +83,7 @@ func New(cfg Config, pool *agent.Pool, listFn ModelListFunc, switchFn ModelSwitc
 		listFn:     listFn,
 		switchFn:   switchFn,
 		chatModels: make(map[string]ModelOption),
-		seenMsgs:   make(map[string]struct{}),
+		seenMsgs:   make(map[string]time.Time),
 		allowed:    allowed,
 		cfg:        cfg,
 	}
@@ -290,13 +295,24 @@ func (b *Bot) isBotMentioned(mentions []*larkim.MentionEvent) bool {
 }
 
 // markSeen records a message ID and returns true if it was already seen.
+// Evicts entries older than seenMsgTTL to bound memory usage.
 func (b *Bot) markSeen(messageID string) bool {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+
+	now := time.Now()
+
+	// Evict expired entries.
+	for id, t := range b.seenMsgs {
+		if now.Sub(t) > seenMsgTTL {
+			delete(b.seenMsgs, id)
+		}
+	}
+
 	if _, ok := b.seenMsgs[messageID]; ok {
 		return true
 	}
-	b.seenMsgs[messageID] = struct{}{}
+	b.seenMsgs[messageID] = now
 	return false
 }
 

--- a/channel/feishu/feishu.go
+++ b/channel/feishu/feishu.go
@@ -1,0 +1,217 @@
+package feishu
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+
+	lark "github.com/larksuite/oapi-sdk-go/v3"
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
+	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher"
+	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
+	larkws "github.com/larksuite/oapi-sdk-go/v3/ws"
+	"github.com/vaayne/anna/agent"
+	"github.com/vaayne/anna/channel"
+)
+
+const feishuMaxMessageLen = 4000
+
+func logger() *slog.Logger { return slog.With("component", "feishu") }
+
+// Config holds Feishu bot settings.
+type Config struct {
+	AppID      string   // app ID
+	AppSecret  string   // app secret
+	NotifyChat string   // default chat ID for proactive notifications
+	GroupMode  string   // "mention" | "always" | "disabled"
+	AllowedIDs []string // user open_ids allowed (empty = allow all)
+}
+
+// Bot wraps a Feishu bot with agent pool integration.
+type Bot struct {
+	client   *lark.Client
+	wsClient *larkws.Client
+	pool     *agent.Pool
+	listFn   ModelListFunc
+	switchFn ModelSwitchFunc
+
+	mu         sync.RWMutex
+	chatModels map[string]ModelOption
+
+	allowed map[string]struct{}
+	cfg     Config
+	ctx     context.Context
+	cancel  context.CancelFunc
+}
+
+// New creates a Feishu bot. Call Start to begin receiving events.
+func New(cfg Config, pool *agent.Pool, listFn ModelListFunc, switchFn ModelSwitchFunc) (*Bot, error) {
+	if cfg.AppID == "" || cfg.AppSecret == "" {
+		return nil, fmt.Errorf("feishu: app_id and app_secret are required")
+	}
+
+	if cfg.GroupMode == "" {
+		cfg.GroupMode = "mention"
+	}
+
+	allowed := make(map[string]struct{}, len(cfg.AllowedIDs))
+	for _, id := range cfg.AllowedIDs {
+		allowed[id] = struct{}{}
+	}
+
+	b := &Bot{
+		pool:       pool,
+		listFn:     listFn,
+		switchFn:   switchFn,
+		chatModels: make(map[string]ModelOption),
+		allowed:    allowed,
+		cfg:        cfg,
+	}
+
+	return b, nil
+}
+
+// Start initializes the API client, registers event handlers, and starts
+// a WebSocket connection. It blocks until ctx is cancelled.
+func (b *Bot) Start(ctx context.Context) error {
+	b.ctx, b.cancel = context.WithCancel(ctx)
+
+	b.client = lark.NewClient(b.cfg.AppID, b.cfg.AppSecret,
+		lark.WithLogLevel(larkcore.LogLevelInfo),
+		lark.WithEnableTokenCache(true),
+	)
+
+	eventHandler := dispatcher.NewEventDispatcher("", "").
+		OnP2MessageReceiveV1(b.onMessage)
+
+	b.wsClient = larkws.NewClient(b.cfg.AppID, b.cfg.AppSecret,
+		larkws.WithEventHandler(eventHandler),
+		larkws.WithLogLevel(larkcore.LogLevelInfo),
+	)
+
+	logger().Info("feishu bot starting (WebSocket mode)")
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- b.wsClient.Start(b.ctx)
+	}()
+
+	select {
+	case <-b.ctx.Done():
+		return b.ctx.Err()
+	case err := <-errCh:
+		return fmt.Errorf("feishu: websocket error: %w", err)
+	}
+}
+
+// Stop cancels the bot context.
+func (b *Bot) Stop() {
+	logger().Info("stopping feishu bot")
+	if b.cancel != nil {
+		b.cancel()
+	}
+}
+
+// Name returns the backend name. Implements channel.Backend.
+func (b *Bot) Name() string { return "feishu" }
+
+// Notify sends a notification message. Implements channel.Backend.
+func (b *Bot) Notify(ctx context.Context, n channel.Notification) error {
+	chatID := n.ChatID
+	if chatID == "" {
+		chatID = b.cfg.NotifyChat
+	}
+	if chatID == "" {
+		return fmt.Errorf("feishu: no target chat ID")
+	}
+
+	// Strip channel prefix if present.
+	chatID = strings.TrimPrefix(chatID, "feishu:")
+
+	content := textContent(n.Text)
+	resp, err := b.client.Im.Message.Create(ctx,
+		larkim.NewCreateMessageReqBuilder().
+			ReceiveIdType(larkim.ReceiveIdTypeChatId).
+			Body(larkim.NewCreateMessageReqBodyBuilder().
+				MsgType(larkim.MsgTypeText).
+				ReceiveId(chatID).
+				Content(content).
+				Build()).
+			Build())
+	if err != nil {
+		return fmt.Errorf("feishu: notify: %w", err)
+	}
+	if !resp.Success() {
+		return fmt.Errorf("feishu: notify: code=%d msg=%s", resp.Code, resp.Msg)
+	}
+	return nil
+}
+
+// isAllowed returns true if the sender is in the allowed list.
+// An empty allowed list means everyone is allowed.
+func (b *Bot) isAllowed(openID string) bool {
+	if len(b.allowed) == 0 {
+		return true
+	}
+	_, ok := b.allowed[openID]
+	return ok
+}
+
+// channelForChat returns the channel identifier for a Feishu chat.
+func channelForChat(chatID string) string {
+	return "feishu:" + chatID
+}
+
+// resolveSession returns the active session ID for the given channel,
+// creating a new session if none exists.
+func (b *Bot) resolveSession(ch string) (string, error) {
+	info, err := b.pool.ResolveSession(ch)
+	if err != nil {
+		return "", err
+	}
+	return info.ID, nil
+}
+
+// textContent builds the JSON content string for a Feishu text message.
+func textContent(text string) string {
+	data, _ := json.Marshal(map[string]string{"text": text})
+	return string(data)
+}
+
+// shouldRespondInGroup checks whether the bot should respond based on group_mode
+// and whether it was mentioned.
+func (b *Bot) shouldRespondInGroup(mentions []*larkim.MentionEvent) bool {
+	switch b.cfg.GroupMode {
+	case "disabled":
+		return false
+	case "always":
+		return true
+	default: // "mention"
+		return isBotMentioned(mentions)
+	}
+}
+
+// isBotMentioned checks if any mention targets the bot itself (key "mention_all" is @all).
+func isBotMentioned(mentions []*larkim.MentionEvent) bool {
+	for _, m := range mentions {
+		if m.Key != nil && *m.Key != "@_all" {
+			// Any non-@all mention key means the bot was mentioned
+			// (Feishu only delivers events for messages that mention the bot in groups).
+			return true
+		}
+	}
+	return len(mentions) > 0
+}
+
+// stripMentions removes @mention placeholders from message text.
+func stripMentions(text string, mentions []*larkim.MentionEvent) string {
+	for _, m := range mentions {
+		if m.Key != nil {
+			text = strings.ReplaceAll(text, *m.Key, "")
+		}
+	}
+	return strings.TrimSpace(text)
+}

--- a/channel/feishu/feishu.go
+++ b/channel/feishu/feishu.go
@@ -23,11 +23,13 @@ func logger() *slog.Logger { return slog.With("component", "feishu") }
 
 // Config holds Feishu bot settings.
 type Config struct {
-	AppID      string   // app ID
-	AppSecret  string   // app secret
-	NotifyChat string   // default chat ID for proactive notifications
-	GroupMode  string   // "mention" | "always" | "disabled"
-	AllowedIDs []string // user open_ids allowed (empty = allow all)
+	AppID             string   // app ID
+	AppSecret         string   // app secret
+	EncryptKey        string   // event encrypt key (from Feishu developer console)
+	VerificationToken string   // event verification token (from Feishu developer console)
+	NotifyChat        string   // default chat ID for proactive notifications
+	GroupMode         string   // "mention" | "always" | "disabled"
+	AllowedIDs        []string // user open_ids allowed (empty = allow all)
 }
 
 // Bot wraps a Feishu bot with agent pool integration.
@@ -84,7 +86,7 @@ func (b *Bot) Start(ctx context.Context) error {
 		lark.WithEnableTokenCache(true),
 	)
 
-	eventHandler := dispatcher.NewEventDispatcher("", "").
+	eventHandler := dispatcher.NewEventDispatcher(b.cfg.VerificationToken, b.cfg.EncryptKey).
 		OnP2MessageReceiveV1(b.onMessage)
 
 	b.wsClient = larkws.NewClient(b.cfg.AppID, b.cfg.AppSecret,

--- a/channel/feishu/feishu.go
+++ b/channel/feishu/feishu.go
@@ -5,8 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net/http"
+	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	lark "github.com/larksuite/oapi-sdk-go/v3"
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
@@ -18,6 +21,9 @@ import (
 )
 
 const feishuMaxMessageLen = 4000
+
+// mentionPlaceholderRegex matches @_user_N placeholders inserted by Feishu for mentions.
+var mentionPlaceholderRegex = regexp.MustCompile(`@_user_\d+`)
 
 func logger() *slog.Logger { return slog.With("component", "feishu") }
 
@@ -39,6 +45,8 @@ type Bot struct {
 	pool     *agent.Pool
 	listFn   ModelListFunc
 	switchFn ModelSwitchFunc
+
+	botOpenID atomic.Value // bot's own open_id (string), fetched on startup
 
 	mu         sync.RWMutex
 	chatModels map[string]ModelOption
@@ -88,6 +96,10 @@ func (b *Bot) Start(ctx context.Context) error {
 		lark.WithEnableTokenCache(true),
 	)
 
+	if err := b.fetchBotOpenID(b.ctx); err != nil {
+		logger().Warn("failed to fetch bot open_id, self-message filtering disabled", "error", err)
+	}
+
 	eventHandler := dispatcher.NewEventDispatcher(b.cfg.VerificationToken, b.cfg.EncryptKey).
 		OnP2MessageReceiveV1(b.onMessage)
 
@@ -117,6 +129,38 @@ func (b *Bot) Stop() {
 	if b.cancel != nil {
 		b.cancel()
 	}
+}
+
+// fetchBotOpenID calls the Feishu bot info API to retrieve and store the bot's open_id.
+func (b *Bot) fetchBotOpenID(ctx context.Context) error {
+	resp, err := b.client.Do(ctx, &larkcore.ApiReq{
+		HttpMethod:                http.MethodGet,
+		ApiPath:                   "/open-apis/bot/v3/info",
+		SupportedAccessTokenTypes: []larkcore.AccessTokenType{larkcore.AccessTokenTypeTenant},
+	})
+	if err != nil {
+		return fmt.Errorf("bot info request: %w", err)
+	}
+
+	var result struct {
+		Code int `json:"code"`
+		Bot  struct {
+			OpenID string `json:"open_id"`
+		} `json:"bot"`
+	}
+	if err := json.Unmarshal(resp.RawBody, &result); err != nil {
+		return fmt.Errorf("bot info parse: %w", err)
+	}
+	if result.Code != 0 {
+		return fmt.Errorf("bot info api error (code=%d)", result.Code)
+	}
+	if result.Bot.OpenID == "" {
+		return fmt.Errorf("bot info: empty open_id")
+	}
+
+	b.botOpenID.Store(result.Bot.OpenID)
+	logger().Info("fetched bot open_id", "open_id", result.Bot.OpenID)
+	return nil
 }
 
 // Name returns the backend name. Implements channel.Backend.
@@ -212,20 +256,37 @@ func (b *Bot) shouldRespondInGroup(mentions []*larkim.MentionEvent) bool {
 	case "always":
 		return true
 	default: // "mention"
-		return isBotMentioned(mentions)
+		return b.isBotMentioned(mentions)
 	}
 }
 
-// isBotMentioned checks if any mention targets the bot itself (key "mention_all" is @all).
-func isBotMentioned(mentions []*larkim.MentionEvent) bool {
+// isBotMentioned checks if the bot was @mentioned by comparing each mention's
+// open_id against the bot's own open_id (fetched on startup).
+func (b *Bot) isBotMentioned(mentions []*larkim.MentionEvent) bool {
+	if len(mentions) == 0 {
+		return false
+	}
+
+	knownID, _ := b.botOpenID.Load().(string)
+	if knownID == "" {
+		// Fallback: if bot open_id is unknown, assume any non-@all mention is the bot.
+		for _, m := range mentions {
+			if m.Key != nil && *m.Key != "@_all" {
+				return true
+			}
+		}
+		return false
+	}
+
 	for _, m := range mentions {
-		if m.Key != nil && *m.Key != "@_all" {
-			// Any non-@all mention key means the bot was mentioned
-			// (Feishu only delivers events for messages that mention the bot in groups).
+		if m.Id == nil {
+			continue
+		}
+		if m.Id.OpenId != nil && *m.Id.OpenId == knownID {
 			return true
 		}
 	}
-	return len(mentions) > 0
+	return false
 }
 
 // markSeen records a message ID and returns true if it was already seen.
@@ -240,11 +301,13 @@ func (b *Bot) markSeen(messageID string) bool {
 }
 
 // stripMentions removes @mention placeholders from message text.
+// First removes known mention keys, then cleans up any remaining @_user_N patterns.
 func stripMentions(text string, mentions []*larkim.MentionEvent) string {
 	for _, m := range mentions {
 		if m.Key != nil {
 			text = strings.ReplaceAll(text, *m.Key, "")
 		}
 	}
+	text = mentionPlaceholderRegex.ReplaceAllString(text, "")
 	return strings.TrimSpace(text)
 }

--- a/channel/feishu/feishu.go
+++ b/channel/feishu/feishu.go
@@ -183,6 +183,24 @@ func textContent(text string) string {
 	return string(data)
 }
 
+// cardContent builds a Feishu Interactive Card JSON 2.0 string with markdown content.
+// Cards support the Patch API for in-place editing (plain text messages do not).
+func cardContent(text string) string {
+	card := map[string]any{
+		"schema": "2.0",
+		"body": map[string]any{
+			"elements": []map[string]any{
+				{
+					"tag":     "markdown",
+					"content": text,
+				},
+			},
+		},
+	}
+	data, _ := json.Marshal(card)
+	return string(data)
+}
+
 // shouldRespondInGroup checks whether the bot should respond based on group_mode
 // and whether it was mentioned.
 func (b *Bot) shouldRespondInGroup(mentions []*larkim.MentionEvent) bool {

--- a/channel/feishu/feishu.go
+++ b/channel/feishu/feishu.go
@@ -42,6 +42,7 @@ type Bot struct {
 
 	mu         sync.RWMutex
 	chatModels map[string]ModelOption
+	seenMsgs   map[string]struct{} // message ID dedup
 
 	allowed map[string]struct{}
 	cfg     Config
@@ -69,6 +70,7 @@ func New(cfg Config, pool *agent.Pool, listFn ModelListFunc, switchFn ModelSwitc
 		listFn:     listFn,
 		switchFn:   switchFn,
 		chatModels: make(map[string]ModelOption),
+		seenMsgs:   make(map[string]struct{}),
 		allowed:    allowed,
 		cfg:        cfg,
 	}
@@ -224,6 +226,17 @@ func isBotMentioned(mentions []*larkim.MentionEvent) bool {
 		}
 	}
 	return len(mentions) > 0
+}
+
+// markSeen records a message ID and returns true if it was already seen.
+func (b *Bot) markSeen(messageID string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if _, ok := b.seenMsgs[messageID]; ok {
+		return true
+	}
+	b.seenMsgs[messageID] = struct{}{}
+	return false
 }
 
 // stripMentions removes @mention placeholders from message text.

--- a/channel/feishu/feishu_test.go
+++ b/channel/feishu/feishu_test.go
@@ -560,12 +560,14 @@ func TestNotifyEmptyChatID(t *testing.T) {
 	}
 }
 
-// --- sendImage (no-op) ---
+// --- sendImage ---
 
-func TestSendImageNoOp(t *testing.T) {
-	bot := &Bot{}
-	// Should not panic.
-	bot.sendImage("target", "msg", runner.ImageEvent{})
+func TestSendImageInvalidBase64(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	bot := &Bot{ctx: ctx}
+	// Invalid base64 should log error but not panic.
+	bot.sendImage("target", "msg", runner.ImageEvent{Data: "not-valid-base64!!!"})
 }
 
 // --- Stop ---

--- a/channel/feishu/feishu_test.go
+++ b/channel/feishu/feishu_test.go
@@ -1,0 +1,582 @@
+package feishu
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
+	"github.com/vaayne/anna/agent/runner"
+	"github.com/vaayne/anna/channel"
+)
+
+// --- splitMessage ---
+
+func TestSplitMessageShort(t *testing.T) {
+	chunks := splitMessage("hello")
+	if len(chunks) != 1 || chunks[0] != "hello" {
+		t.Errorf("chunks = %v, want [hello]", chunks)
+	}
+}
+
+func TestSplitMessageExactLimit(t *testing.T) {
+	msg := strings.Repeat("a", feishuMaxMessageLen)
+	chunks := splitMessage(msg)
+	if len(chunks) != 1 {
+		t.Errorf("len(chunks) = %d, want 1", len(chunks))
+	}
+}
+
+func TestSplitMessageLong(t *testing.T) {
+	msg := strings.Repeat("a", feishuMaxMessageLen+100)
+	chunks := splitMessage(msg)
+	if len(chunks) != 2 {
+		t.Fatalf("len(chunks) = %d, want 2", len(chunks))
+	}
+	if len(chunks[0]) != feishuMaxMessageLen {
+		t.Errorf("chunk[0] len = %d, want %d", len(chunks[0]), feishuMaxMessageLen)
+	}
+	if len(chunks[1]) != 100 {
+		t.Errorf("chunk[1] len = %d, want 100", len(chunks[1]))
+	}
+}
+
+func TestSplitMessageAtNewline(t *testing.T) {
+	part1 := strings.Repeat("a", 3000)
+	part2 := strings.Repeat("b", 2000)
+	msg := part1 + "\n" + part2
+
+	chunks := splitMessage(msg)
+	if len(chunks) != 2 {
+		t.Fatalf("len(chunks) = %d, want 2", len(chunks))
+	}
+	if chunks[0] != part1+"\n" {
+		t.Errorf("chunk[0] should end at newline")
+	}
+}
+
+func TestSplitMessageMultibyteUTF8(t *testing.T) {
+	char := "中"
+	msg := strings.Repeat(char, feishuMaxMessageLen) // 3*feishuMaxMessageLen bytes
+	chunks := splitMessage(msg)
+	if len(chunks) < 2 {
+		t.Fatalf("expected multiple chunks, got %d", len(chunks))
+	}
+	for i, c := range chunks {
+		if len(c) > 0 && c[0]&0xC0 == 0x80 {
+			t.Errorf("chunk[%d] starts with UTF-8 continuation byte", i)
+		}
+	}
+}
+
+func TestSplitMessageEmpty(t *testing.T) {
+	chunks := splitMessage("")
+	if len(chunks) != 1 || chunks[0] != "" {
+		t.Errorf("empty message should return single empty chunk, got %v", chunks)
+	}
+}
+
+// --- buildStreamDisplay ---
+
+func TestBuildStreamDisplayShort(t *testing.T) {
+	d := buildStreamDisplay("hello", "")
+	if !strings.HasSuffix(d, typingCursor) {
+		t.Errorf("display should end with cursor, got %q", d)
+	}
+	if !strings.HasPrefix(d, "hello") {
+		t.Errorf("display should start with text, got %q", d)
+	}
+}
+
+func TestBuildStreamDisplayWithTool(t *testing.T) {
+	d := buildStreamDisplay("hello", "⚡ bash: ls")
+	if !strings.Contains(d, "⚡ bash: ls") {
+		t.Errorf("display should contain tool line, got %q", d)
+	}
+}
+
+func TestBuildStreamDisplayTruncates(t *testing.T) {
+	long := strings.Repeat("x", feishuMaxMessageLen+500)
+	d := buildStreamDisplay(long, "")
+	if len(d) > feishuMaxMessageLen {
+		t.Errorf("display len = %d, should be <= %d", len(d), feishuMaxMessageLen)
+	}
+	if !strings.Contains(d, "...") {
+		t.Errorf("truncated display should contain ellipsis")
+	}
+}
+
+func TestBuildStreamDisplayEmptyTextWithTool(t *testing.T) {
+	d := buildStreamDisplay("", "⚡ bash: ls")
+	if !strings.Contains(d, "⚡ bash: ls") {
+		t.Errorf("should show tool line: %q", d)
+	}
+}
+
+func TestBuildStreamDisplayEmptyAll(t *testing.T) {
+	d := buildStreamDisplay("", "")
+	if !strings.HasSuffix(d, typingCursor) {
+		t.Errorf("should end with cursor: %q", d)
+	}
+}
+
+// --- toolLine ---
+
+func TestToolLineRunning(t *testing.T) {
+	line := toolLine(&runner.ToolUseEvent{Tool: "bash", Status: "running", Input: "ls -la"})
+	if !strings.Contains(line, "bash") || !strings.Contains(line, "ls -la") {
+		t.Errorf("unexpected line: %q", line)
+	}
+}
+
+func TestToolLineRunningTruncatesMultibyte(t *testing.T) {
+	input := strings.Repeat("中", 61)
+	line := toolLine(&runner.ToolUseEvent{Tool: "bash", Status: "running", Input: input})
+	if !strings.HasSuffix(line, "...") {
+		t.Errorf("expected truncation ellipsis, got %q", line)
+	}
+}
+
+func TestToolLineError(t *testing.T) {
+	line := toolLine(&runner.ToolUseEvent{Tool: "read", Status: "error"})
+	if !strings.Contains(line, "failed") {
+		t.Errorf("unexpected line: %q", line)
+	}
+}
+
+func TestToolLineDefault(t *testing.T) {
+	line := toolLine(&runner.ToolUseEvent{Tool: "bash", Status: "done"})
+	if line != "" {
+		t.Errorf("expected empty, got %q", line)
+	}
+}
+
+func TestToolLineRunningNoInput(t *testing.T) {
+	line := toolLine(&runner.ToolUseEvent{Tool: "search", Status: "running"})
+	if !strings.Contains(line, "search") {
+		t.Errorf("unexpected line: %q", line)
+	}
+	if strings.Contains(line, ":") {
+		t.Errorf("no input should not have colon separator: %q", line)
+	}
+}
+
+func TestToolLineUnknownTool(t *testing.T) {
+	line := toolLine(&runner.ToolUseEvent{Tool: "custom_tool", Status: "running", Input: "x"})
+	if !strings.Contains(line, "🔧") {
+		t.Errorf("unknown tool should use default emoji: %q", line)
+	}
+}
+
+// --- filterModelsIndexed ---
+
+func TestFilterModelsIndexed(t *testing.T) {
+	models := []channel.ModelOption{
+		{Provider: "openai", Model: "gpt-4"},
+		{Provider: "anthropic", Model: "claude-3"},
+		{Provider: "openai", Model: "gpt-3.5"},
+	}
+
+	result := filterModelsIndexed(models, "openai")
+	if len(result) != 2 {
+		t.Fatalf("expected 2 matches, got %d", len(result))
+	}
+	if result[0].globalIdx != 1 || result[1].globalIdx != 3 {
+		t.Errorf("global indices should be 1 and 3, got %d and %d", result[0].globalIdx, result[1].globalIdx)
+	}
+}
+
+func TestFilterModelsIndexedNoMatch(t *testing.T) {
+	models := []channel.ModelOption{
+		{Provider: "openai", Model: "gpt-4"},
+	}
+	result := filterModelsIndexed(models, "gemini")
+	if len(result) != 0 {
+		t.Errorf("expected 0 matches, got %d", len(result))
+	}
+}
+
+func TestFilterModelsIndexedCaseInsensitive(t *testing.T) {
+	models := []channel.ModelOption{
+		{Provider: "Anthropic", Model: "Claude-3"},
+	}
+	result := filterModelsIndexed(models, "CLAUDE")
+	if len(result) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(result))
+	}
+}
+
+// --- New ---
+
+func TestNewValidConfig(t *testing.T) {
+	cfg := Config{AppID: "123", AppSecret: "secret"}
+	bot, err := New(cfg, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bot == nil {
+		t.Fatal("expected bot, got nil")
+	}
+	if bot.cfg.GroupMode != "mention" {
+		t.Errorf("default group_mode = %q, want %q", bot.cfg.GroupMode, "mention")
+	}
+}
+
+func TestNewMissingAppID(t *testing.T) {
+	_, err := New(Config{AppSecret: "secret"}, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected error for missing app_id")
+	}
+}
+
+func TestNewMissingAppSecret(t *testing.T) {
+	_, err := New(Config{AppID: "123"}, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected error for missing app_secret")
+	}
+}
+
+func TestNewCustomGroupMode(t *testing.T) {
+	cfg := Config{AppID: "1", AppSecret: "s", GroupMode: "always"}
+	bot, _ := New(cfg, nil, nil, nil)
+	if bot.cfg.GroupMode != "always" {
+		t.Errorf("group_mode = %q, want %q", bot.cfg.GroupMode, "always")
+	}
+}
+
+func TestNewAllowedIDs(t *testing.T) {
+	cfg := Config{AppID: "1", AppSecret: "s", AllowedIDs: []string{"u1", "u2"}}
+	bot, _ := New(cfg, nil, nil, nil)
+	if len(bot.allowed) != 2 {
+		t.Errorf("allowed len = %d, want 2", len(bot.allowed))
+	}
+}
+
+// --- isAllowed ---
+
+func TestIsAllowedEmptyList(t *testing.T) {
+	bot := &Bot{allowed: map[string]struct{}{}}
+	if !bot.isAllowed("anyone") {
+		t.Error("empty allowed list should allow everyone")
+	}
+}
+
+func TestIsAllowedMatch(t *testing.T) {
+	bot := &Bot{allowed: map[string]struct{}{"u1": {}}}
+	if !bot.isAllowed("u1") {
+		t.Error("u1 should be allowed")
+	}
+}
+
+func TestIsAllowedNoMatch(t *testing.T) {
+	bot := &Bot{allowed: map[string]struct{}{"u1": {}}}
+	if bot.isAllowed("u2") {
+		t.Error("u2 should not be allowed")
+	}
+}
+
+// --- channelForChat ---
+
+func TestChannelForChat(t *testing.T) {
+	if got := channelForChat("oc_123"); got != "feishu:oc_123" {
+		t.Errorf("channelForChat = %q", got)
+	}
+}
+
+// --- shouldRespondInGroup ---
+
+func TestShouldRespondInGroupMention(t *testing.T) {
+	bot := &Bot{cfg: Config{GroupMode: "mention"}}
+	key := "@_user_1"
+	mentions := []*larkim.MentionEvent{{Key: &key}}
+	if !bot.shouldRespondInGroup(mentions) {
+		t.Error("mention mode with mention should respond")
+	}
+}
+
+func TestShouldRespondInGroupMentionNoMentions(t *testing.T) {
+	bot := &Bot{cfg: Config{GroupMode: "mention"}}
+	if bot.shouldRespondInGroup(nil) {
+		t.Error("mention mode without mentions should not respond")
+	}
+}
+
+func TestShouldRespondInGroupAlways(t *testing.T) {
+	bot := &Bot{cfg: Config{GroupMode: "always"}}
+	if !bot.shouldRespondInGroup(nil) {
+		t.Error("always mode should respond")
+	}
+}
+
+func TestShouldRespondInGroupDisabled(t *testing.T) {
+	bot := &Bot{cfg: Config{GroupMode: "disabled"}}
+	if bot.shouldRespondInGroup(nil) {
+		t.Error("disabled mode should not respond")
+	}
+}
+
+// --- Name ---
+
+func TestBotName(t *testing.T) {
+	bot := &Bot{}
+	if bot.Name() != "feishu" {
+		t.Errorf("Name() = %q, want %q", bot.Name(), "feishu")
+	}
+}
+
+// --- textContent ---
+
+func TestTextContent(t *testing.T) {
+	got := textContent("hello")
+	if got != `{"text":"hello"}` {
+		t.Errorf("textContent = %q", got)
+	}
+}
+
+func TestTextContentEscapes(t *testing.T) {
+	got := textContent(`say "hi"`)
+	if !strings.Contains(got, `\"hi\"`) {
+		t.Errorf("textContent should escape quotes: %q", got)
+	}
+}
+
+// --- parseTextContent ---
+
+func TestParseTextContentValid(t *testing.T) {
+	text := parseTextContent(`{"text":"hello world"}`)
+	if text != "hello world" {
+		t.Errorf("parseTextContent = %q, want %q", text, "hello world")
+	}
+}
+
+func TestParseTextContentEmpty(t *testing.T) {
+	text := parseTextContent("")
+	if text != "" {
+		t.Errorf("parseTextContent empty = %q", text)
+	}
+}
+
+func TestParseTextContentInvalidJSON(t *testing.T) {
+	text := parseTextContent("not json")
+	if text != "not json" {
+		t.Errorf("parseTextContent invalid = %q", text)
+	}
+}
+
+// --- stripMentions ---
+
+func TestStripMentions(t *testing.T) {
+	key := "@_user_1"
+	mentions := []*larkim.MentionEvent{{Key: &key}}
+	result := stripMentions("hello @_user_1 world", mentions)
+	if result != "hello  world" {
+		t.Errorf("stripMentions = %q", result)
+	}
+}
+
+func TestStripMentionsNoMentions(t *testing.T) {
+	result := stripMentions("hello world", nil)
+	if result != "hello world" {
+		t.Errorf("stripMentions = %q", result)
+	}
+}
+
+// --- derefStr ---
+
+func TestDerefStrNil(t *testing.T) {
+	if derefStr(nil) != "" {
+		t.Error("derefStr nil should return empty")
+	}
+}
+
+func TestDerefStrValue(t *testing.T) {
+	s := "hello"
+	if derefStr(&s) != "hello" {
+		t.Error("derefStr should return value")
+	}
+}
+
+// --- formatModelList ---
+
+func TestFormatModelListNoQuery(t *testing.T) {
+	models := []channel.ModelOption{
+		{Provider: "openai", Model: "gpt-4"},
+		{Provider: "anthropic", Model: "claude-3"},
+	}
+	out := formatModelList(models, "")
+	if !strings.Contains(out, "1. openai/gpt-4") {
+		t.Errorf("missing model entry in output: %s", out)
+	}
+	if !strings.Contains(out, "2. anthropic/claude-3") {
+		t.Errorf("missing model entry in output: %s", out)
+	}
+}
+
+func TestFormatModelListWithQuery(t *testing.T) {
+	models := []channel.ModelOption{{Provider: "openai", Model: "gpt-4"}}
+	out := formatModelList(models, "openai")
+	if !strings.Contains(out, `filter: "openai"`) {
+		t.Errorf("should show filter query: %s", out)
+	}
+}
+
+// --- handleCommand ---
+
+func TestHandleCommandHelp(t *testing.T) {
+	bot := &Bot{}
+	var reply string
+	handled := bot.handleCommand("/help", "ch", func(s string) { reply = s })
+	if !handled {
+		t.Fatal("expected /help to be handled")
+	}
+	if !strings.Contains(reply, "Anna") {
+		t.Errorf("unexpected reply: %s", reply)
+	}
+}
+
+func TestHandleCommandStart(t *testing.T) {
+	bot := &Bot{}
+	var reply string
+	handled := bot.handleCommand("/start", "ch", func(s string) { reply = s })
+	if !handled {
+		t.Fatal("expected /start to be handled")
+	}
+	if reply != welcomeMessage {
+		t.Errorf("unexpected reply: %s", reply)
+	}
+}
+
+func TestHandleCommandUnknown(t *testing.T) {
+	bot := &Bot{}
+	handled := bot.handleCommand("hello world", "ch", func(s string) {})
+	if handled {
+		t.Error("regular text should not be handled as command")
+	}
+}
+
+func TestHandleCommandEmpty(t *testing.T) {
+	bot := &Bot{}
+	handled := bot.handleCommand("", "ch", func(s string) {})
+	if handled {
+		t.Error("empty text should not be handled")
+	}
+}
+
+// --- handleModelCommand ---
+
+func TestHandleModelCommandListModels(t *testing.T) {
+	models := []channel.ModelOption{
+		{Provider: "openai", Model: "gpt-4"},
+	}
+	bot := &Bot{
+		listFn:     func() []channel.ModelOption { return models },
+		chatModels: make(map[string]ModelOption),
+	}
+
+	var reply string
+	bot.handleModelCommand("", "ch", func(s string) { reply = s })
+	if !strings.Contains(reply, "openai/gpt-4") {
+		t.Errorf("expected model list, got: %s", reply)
+	}
+}
+
+func TestHandleModelCommandFilter(t *testing.T) {
+	models := []channel.ModelOption{
+		{Provider: "openai", Model: "gpt-4"},
+		{Provider: "anthropic", Model: "claude-3"},
+	}
+	bot := &Bot{
+		listFn:     func() []channel.ModelOption { return models },
+		chatModels: make(map[string]ModelOption),
+	}
+
+	var reply string
+	bot.handleModelCommand("claude", "ch", func(s string) { reply = s })
+	if !strings.Contains(reply, "claude-3") {
+		t.Errorf("expected filtered results with claude, got: %s", reply)
+	}
+	if strings.Contains(reply, "gpt-4") {
+		t.Errorf("should not contain non-matching model: %s", reply)
+	}
+}
+
+func TestHandleModelCommandFilterNoMatch(t *testing.T) {
+	models := []channel.ModelOption{
+		{Provider: "openai", Model: "gpt-4"},
+	}
+	bot := &Bot{
+		listFn:     func() []channel.ModelOption { return models },
+		chatModels: make(map[string]ModelOption),
+	}
+
+	var reply string
+	bot.handleModelCommand("gemini", "ch", func(s string) { reply = s })
+	if !strings.Contains(reply, "No models matching") {
+		t.Errorf("expected no match message, got: %s", reply)
+	}
+}
+
+func TestHandleModelCommandInvalidIndex(t *testing.T) {
+	models := []channel.ModelOption{
+		{Provider: "openai", Model: "gpt-4"},
+	}
+	bot := &Bot{
+		listFn:     func() []channel.ModelOption { return models },
+		chatModels: make(map[string]ModelOption),
+	}
+
+	var reply string
+	bot.handleModelCommand("5", "ch", func(s string) { reply = s })
+	if !strings.Contains(reply, "Invalid selection") {
+		t.Errorf("expected invalid selection, got: %s", reply)
+	}
+}
+
+func TestHandleModelCommandSwitchError(t *testing.T) {
+	models := []channel.ModelOption{
+		{Provider: "openai", Model: "gpt-4"},
+	}
+	bot := &Bot{
+		listFn:     func() []channel.ModelOption { return models },
+		switchFn:   func(string, string) error { return fmt.Errorf("switch failed") },
+		chatModels: make(map[string]ModelOption),
+	}
+
+	var reply string
+	bot.handleModelCommand("1", "ch", func(s string) { reply = s })
+	if !strings.Contains(reply, "Error switching model") {
+		t.Errorf("expected switch error, got: %s", reply)
+	}
+}
+
+// --- Notify ---
+
+func TestNotifyEmptyChatID(t *testing.T) {
+	bot := &Bot{cfg: Config{}}
+	err := bot.Notify(context.Background(), channel.Notification{})
+	if err == nil {
+		t.Fatal("expected error for empty chat ID")
+	}
+}
+
+// --- sendImage (no-op) ---
+
+func TestSendImageNoOp(t *testing.T) {
+	bot := &Bot{}
+	// Should not panic.
+	bot.sendImage("target", "msg", runner.ImageEvent{})
+}
+
+// --- Stop ---
+
+func TestStopWithCancel(t *testing.T) {
+	_, cancel := context.WithCancel(context.Background())
+	bot := &Bot{cancel: cancel}
+	bot.Stop() // should not panic
+}
+
+func TestStopWithoutCancel(t *testing.T) {
+	bot := &Bot{}
+	bot.Stop() // should not panic when cancel is nil
+}

--- a/channel/feishu/handler.go
+++ b/channel/feishu/handler.go
@@ -125,7 +125,7 @@ func (b *Bot) handleMessage(ch, chatID, messageID string, content runner.Message
 
 	logger().Debug("message received", "channel", ch)
 
-	response, images, streamErr := b.streamResponse(chatID, messageID, sessionID, content)
+	sentMsgID, response, images, streamErr := b.streamResponse(chatID, messageID, sessionID, content)
 
 	if streamErr != nil {
 		logger().Error("agent stream error", "session_id", sessionID, "error", streamErr)
@@ -140,7 +140,7 @@ func (b *Bot) handleMessage(ch, chatID, messageID string, content runner.Message
 		response = "(empty response)"
 	}
 
-	b.sendFinalResponse(chatID, messageID, response)
+	b.sendFinalResponse(chatID, messageID, sentMsgID, response)
 
 	for _, img := range images {
 		b.sendImage(chatID, messageID, img)

--- a/channel/feishu/handler.go
+++ b/channel/feishu/handler.go
@@ -35,6 +35,12 @@ func (b *Bot) onMessage(ctx context.Context, event *larkim.P2MessageReceiveV1) e
 	}
 
 	openID := *sender.SenderId.OpenId
+
+	// Skip messages from the bot itself to prevent infinite loops in groups.
+	if botID, _ := b.botOpenID.Load().(string); botID != "" && openID == botID {
+		return nil
+	}
+
 	if !b.isAllowed(openID) {
 		logger().Warn("unauthorized access", "open_id", openID)
 		return nil
@@ -100,6 +106,13 @@ func (b *Bot) buildMessageContent(msg *larkim.EventMessage) runner.MessageConten
 			return nil
 		}
 		return text
+
+	case "post":
+		// Rich text messages — pass raw JSON to the LLM for full context.
+		if strings.TrimSpace(rawContent) == "" {
+			return nil
+		}
+		return rawContent
 
 	case "image":
 		imageKey := extractJSONField(rawContent, "image_key")

--- a/channel/feishu/handler.go
+++ b/channel/feishu/handler.go
@@ -1,0 +1,229 @@
+package feishu
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
+	"github.com/vaayne/anna/agent/runner"
+)
+
+const welcomeMessage = "Hi! I'm Anna -- your local AI assistant.\n\n" +
+	"Commands:\n" +
+	"/new -- Start a fresh session\n" +
+	"/compact -- Compress conversation history\n" +
+	"/model -- Switch between models\n\n" +
+	"Just send me a message to get started."
+
+// onMessage handles incoming Feishu messages.
+func (b *Bot) onMessage(ctx context.Context, event *larkim.P2MessageReceiveV1) error {
+	if event == nil || event.Event == nil || event.Event.Message == nil {
+		return nil
+	}
+
+	msg := event.Event.Message
+	sender := event.Event.Sender
+
+	if sender == nil || sender.SenderId == nil || sender.SenderId.OpenId == nil {
+		return nil
+	}
+
+	openID := *sender.SenderId.OpenId
+	if !b.isAllowed(openID) {
+		logger().Warn("unauthorized access", "open_id", openID)
+		return nil
+	}
+
+	chatID := derefStr(msg.ChatId)
+	chatType := derefStr(msg.ChatType)
+	messageID := derefStr(msg.MessageId)
+	mentions := msg.Mentions
+
+	// Group mode check.
+	if chatType == "group" && !b.shouldRespondInGroup(mentions) {
+		return nil
+	}
+
+	// Parse message content.
+	content := b.buildMessageContent(msg)
+	if content == nil {
+		return nil
+	}
+
+	// Extract text for command handling.
+	text := parseTextContent(derefStr(msg.Content))
+	if chatType == "group" {
+		text = stripMentions(text, mentions)
+	}
+
+	ch := channelForChat(chatID)
+
+	// Handle commands.
+	if text != "" {
+		if handled := b.handleCommand(text, ch, func(reply string) {
+			b.replyText(b.ctx, messageID, reply)
+		}); handled {
+			return nil
+		}
+	}
+
+	b.handleMessage(ch, chatID, messageID, content)
+	return nil
+}
+
+// buildMessageContent constructs the message content from a Feishu message.
+// Returns nil if the message has no usable content.
+func (b *Bot) buildMessageContent(msg *larkim.EventMessage) runner.MessageContent {
+	msgType := derefStr(msg.MessageType)
+	rawContent := derefStr(msg.Content)
+
+	switch msgType {
+	case "text":
+		text := parseTextContent(rawContent)
+		text = stripMentions(text, msg.Mentions)
+		if strings.TrimSpace(text) == "" {
+			return nil
+		}
+		return text
+
+	case "image":
+		// TODO: support image input when image download API is available
+		logger().Debug("image message received, text-only supported for now")
+		return nil
+
+	default:
+		logger().Debug("unsupported message type", "type", msgType)
+		return nil
+	}
+}
+
+// parseTextContent extracts text from Feishu's JSON content format.
+// Content format: {"text":"hello @_user_1 world"}
+func parseTextContent(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	var content struct {
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal([]byte(raw), &content); err != nil {
+		return raw
+	}
+	return content.Text
+}
+
+// handleMessage processes an incoming message by streaming the agent response.
+func (b *Bot) handleMessage(ch, chatID, messageID string, content runner.MessageContent) {
+	sessionID, err := b.resolveSession(ch)
+	if err != nil {
+		logger().Error("resolve session failed", "channel", ch, "error", err)
+		b.replyText(b.ctx, messageID, fmt.Sprintf("Session error: %v", err))
+		return
+	}
+
+	logger().Debug("message received", "channel", ch)
+
+	response, images, streamErr := b.streamResponse(chatID, messageID, sessionID, content)
+
+	if streamErr != nil {
+		logger().Error("agent stream error", "session_id", sessionID, "error", streamErr)
+		if response == "" {
+			response = fmt.Sprintf("Agent error: %v", streamErr)
+		} else {
+			response += fmt.Sprintf("\n\n[Agent error: %v]", streamErr)
+		}
+	}
+
+	if strings.TrimSpace(response) == "" {
+		response = "(empty response)"
+	}
+
+	b.sendFinalResponse(chatID, messageID, response)
+
+	for _, img := range images {
+		b.sendImage(chatID, messageID, img)
+	}
+
+	logger().Debug("response sent", "channel", ch, "response_len", len(response), "images", len(images))
+}
+
+// handleCommand checks if text is a bot command and handles it.
+// Returns true if the text was a command.
+func (b *Bot) handleCommand(text, ch string, reply func(string)) bool {
+	fields := strings.Fields(text)
+	if len(fields) == 0 {
+		return false
+	}
+	cmd := strings.ToLower(fields[0])
+
+	switch cmd {
+	case "/start", "/help":
+		reply(welcomeMessage)
+		return true
+
+	case "/new":
+		info, err := b.pool.RotateSession(ch)
+		if err != nil {
+			logger().Error("rotate session failed", "channel", ch, "error", err)
+			reply(fmt.Sprintf("Error creating new session: %v", err))
+			return true
+		}
+		logger().Info("new session created", "session_id", info.ID, "channel", ch)
+		reply("New session started.")
+		return true
+
+	case "/compact":
+		sessionID, err := b.resolveSession(ch)
+		if err != nil {
+			reply(fmt.Sprintf("No active session: %v", err))
+			return true
+		}
+		summary, err := b.pool.CompactSession(b.ctx, sessionID)
+		if err != nil {
+			logger().Error("compact session failed", "session_id", sessionID, "error", err)
+			reply(fmt.Sprintf("Compaction failed: %v", err))
+			return true
+		}
+		logger().Info("session compacted", "session_id", sessionID, "summary_len", len(summary))
+		reply("Session compacted.")
+		return true
+
+	case "/model":
+		origCmd := strings.Fields(text)[0]
+		args := strings.TrimSpace(strings.TrimPrefix(text, origCmd))
+		b.handleModelCommand(args, ch, reply)
+		return true
+	}
+
+	return false
+}
+
+// replyText sends a text reply to a message.
+func (b *Bot) replyText(ctx context.Context, messageID, text string) {
+	content := textContent(text)
+	resp, err := b.client.Im.Message.Reply(ctx,
+		larkim.NewReplyMessageReqBuilder().
+			MessageId(messageID).
+			Body(larkim.NewReplyMessageReqBodyBuilder().
+				MsgType(larkim.MsgTypeText).
+				Content(content).
+				Build()).
+			Build())
+	if err != nil {
+		logger().Error("reply failed", "message_id", messageID, "error", err)
+		return
+	}
+	if !resp.Success() {
+		logger().Error("reply failed", "message_id", messageID, "code", resp.Code, "msg", resp.Msg)
+	}
+}
+
+// derefStr safely dereferences a string pointer, returning empty string if nil.
+func derefStr(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}

--- a/channel/feishu/handler.go
+++ b/channel/feishu/handler.go
@@ -45,6 +45,12 @@ func (b *Bot) onMessage(ctx context.Context, event *larkim.P2MessageReceiveV1) e
 	messageID := derefStr(msg.MessageId)
 	mentions := msg.Mentions
 
+	// Dedup: Feishu retries events if the handler doesn't return quickly.
+	if messageID != "" && b.markSeen(messageID) {
+		logger().Debug("duplicate message ignored", "message_id", messageID)
+		return nil
+	}
+
 	// Group mode check.
 	if chatType == "group" && !b.shouldRespondInGroup(mentions) {
 		return nil
@@ -64,7 +70,7 @@ func (b *Bot) onMessage(ctx context.Context, event *larkim.P2MessageReceiveV1) e
 
 	ch := channelForChat(chatID)
 
-	// Handle commands.
+	// Handle commands synchronously (they're fast).
 	if text != "" {
 		if handled := b.handleCommand(text, ch, func(reply string) {
 			b.replyText(b.ctx, messageID, reply)
@@ -73,7 +79,9 @@ func (b *Bot) onMessage(ctx context.Context, event *larkim.P2MessageReceiveV1) e
 		}
 	}
 
-	b.handleMessage(ch, chatID, messageID, content)
+	// Process agent response asynchronously so the handler returns
+	// immediately, preventing Feishu from retrying the event.
+	go b.handleMessage(ch, chatID, messageID, content)
 	return nil
 }
 

--- a/channel/feishu/handler.go
+++ b/channel/feishu/handler.go
@@ -2,12 +2,16 @@ package feishu
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"strings"
 
 	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
 	"github.com/vaayne/anna/agent/runner"
+	aitypes "github.com/vaayne/anna/ai/types"
 )
 
 const welcomeMessage = "Hi! I'm Anna -- your local AI assistant.\n\n" +
@@ -78,6 +82,7 @@ func (b *Bot) onMessage(ctx context.Context, event *larkim.P2MessageReceiveV1) e
 func (b *Bot) buildMessageContent(msg *larkim.EventMessage) runner.MessageContent {
 	msgType := derefStr(msg.MessageType)
 	rawContent := derefStr(msg.Content)
+	messageID := derefStr(msg.MessageId)
 
 	switch msgType {
 	case "text":
@@ -89,14 +94,76 @@ func (b *Bot) buildMessageContent(msg *larkim.EventMessage) runner.MessageConten
 		return text
 
 	case "image":
-		// TODO: support image input when image download API is available
-		logger().Debug("image message received, text-only supported for now")
-		return nil
+		imageKey := extractJSONField(rawContent, "image_key")
+		if imageKey == "" {
+			logger().Warn("image message missing image_key")
+			return nil
+		}
+		data, mime, err := b.downloadImage(messageID, imageKey)
+		if err != nil {
+			logger().Error("download image failed", "image_key", imageKey, "error", err)
+			return nil
+		}
+		encoded := base64.StdEncoding.EncodeToString(data)
+		logger().Debug("image received", "size", len(data), "mime", mime)
+		return []aitypes.ContentBlock{
+			aitypes.ImageContent{Data: encoded, MimeType: mime},
+		}
 
 	default:
 		logger().Debug("unsupported message type", "type", msgType)
 		return nil
 	}
+}
+
+// extractJSONField extracts a string field from a JSON object.
+func extractJSONField(raw, field string) string {
+	if raw == "" {
+		return ""
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		return ""
+	}
+	v, ok := m[field]
+	if !ok {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return ""
+	}
+	return s
+}
+
+// downloadImage downloads an image from Feishu using the MessageResource API.
+func (b *Bot) downloadImage(messageID, imageKey string) ([]byte, string, error) {
+	resp, err := b.client.Im.MessageResource.Get(b.ctx,
+		larkim.NewGetMessageResourceReqBuilder().
+			MessageId(messageID).
+			FileKey(imageKey).
+			Type("image").
+			Build())
+	if err != nil {
+		return nil, "", fmt.Errorf("get resource: %w", err)
+	}
+	if !resp.Success() {
+		return nil, "", fmt.Errorf("api error: code=%d msg=%s", resp.Code, resp.Msg)
+	}
+	if resp.File == nil {
+		return nil, "", fmt.Errorf("empty file in response")
+	}
+	if closer, ok := resp.File.(io.Closer); ok {
+		defer func() { _ = closer.Close() }()
+	}
+
+	data, err := io.ReadAll(resp.File)
+	if err != nil {
+		return nil, "", fmt.Errorf("read file: %w", err)
+	}
+
+	mime := http.DetectContentType(data)
+	return data, mime, nil
 }
 
 // parseTextContent extracts text from Feishu's JSON content format.

--- a/channel/feishu/model.go
+++ b/channel/feishu/model.go
@@ -1,0 +1,116 @@
+package feishu
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/vaayne/anna/channel"
+)
+
+// ModelOption re-exports channel.ModelOption for use by callers.
+type ModelOption = channel.ModelOption
+
+// ModelListFunc re-exports channel.ModelListFunc for use by callers.
+type ModelListFunc = channel.ModelListFunc
+
+// ModelSwitchFunc re-exports channel.ModelSwitchFunc for use by callers.
+type ModelSwitchFunc = channel.ModelSwitchFunc
+
+// handleModelCommand processes /model with optional arguments.
+// No args → list models; number → switch by index; text → filter.
+func (b *Bot) handleModelCommand(args, ch string, reply func(string)) {
+	models := b.listFn()
+
+	if args == "" {
+		reply(formatModelList(models, ""))
+		return
+	}
+
+	// Numeric arg → direct switch by 1-based global index.
+	if idx, err := strconv.Atoi(args); err == nil {
+		b.switchModel(models, idx, ch, reply)
+		return
+	}
+
+	// Text arg → filter models by substring match.
+	filtered := filterModelsIndexed(models, args)
+	if len(filtered) == 0 {
+		reply(fmt.Sprintf("No models matching %q.", args))
+		return
+	}
+	reply(formatIndexedModelList(filtered, args))
+}
+
+// switchModel handles model switching by 1-based index.
+func (b *Bot) switchModel(models []ModelOption, idx int, ch string, reply func(string)) {
+	if idx < 1 || idx > len(models) {
+		reply(fmt.Sprintf("Invalid selection. Use a number between 1 and %d.", len(models)))
+		return
+	}
+	selected := models[idx-1]
+	if b.switchFn != nil {
+		if err := b.switchFn(selected.Provider, selected.Model); err != nil {
+			reply(fmt.Sprintf("Error switching model: %v", err))
+			return
+		}
+	}
+	if _, err := b.pool.RotateSession(ch); err != nil {
+		logger().Error("rotate session after model switch failed", "channel", ch, "error", err)
+	}
+	b.mu.Lock()
+	b.chatModels[ch] = selected
+	b.mu.Unlock()
+	logger().Info("model switched", "channel", ch, "provider", selected.Provider, "model", selected.Model)
+	reply(fmt.Sprintf("Switched to %s/%s. Session reset.", selected.Provider, selected.Model))
+}
+
+// indexedModel pairs a ModelOption with its 1-based global index.
+type indexedModel struct {
+	ModelOption
+	globalIdx int
+}
+
+// formatModelList builds a text-based model list with 1-based numbered entries.
+func formatModelList(models []ModelOption, query string) string {
+	var sb strings.Builder
+	sb.WriteString("Available models")
+	if query != "" {
+		fmt.Fprintf(&sb, " (filter: %q)", query)
+	}
+	sb.WriteString(":\n\n")
+	for i, m := range models {
+		fmt.Fprintf(&sb, "%d. %s/%s\n", i+1, m.Provider, m.Model)
+	}
+	sb.WriteString("\nUse /model <number> to switch.")
+	return sb.String()
+}
+
+// formatIndexedModelList builds a text list preserving global indices.
+func formatIndexedModelList(models []indexedModel, query string) string {
+	var sb strings.Builder
+	sb.WriteString("Available models")
+	if query != "" {
+		fmt.Fprintf(&sb, " (filter: %q)", query)
+	}
+	sb.WriteString(":\n\n")
+	for _, m := range models {
+		fmt.Fprintf(&sb, "%d. %s/%s\n", m.globalIdx, m.Provider, m.Model)
+	}
+	sb.WriteString("\nUse /model <number> to switch.")
+	return sb.String()
+}
+
+// filterModelsIndexed returns indexed models matching the query,
+// preserving their 1-based global indices from the full list.
+func filterModelsIndexed(models []ModelOption, query string) []indexedModel {
+	query = strings.ToLower(query)
+	var out []indexedModel
+	for i, m := range models {
+		label := strings.ToLower(m.Provider + "/" + m.Model)
+		if strings.Contains(label, query) {
+			out = append(out, indexedModel{ModelOption: m, globalIdx: i + 1})
+		}
+	}
+	return out
+}

--- a/channel/feishu/render.go
+++ b/channel/feishu/render.go
@@ -7,11 +7,26 @@ import (
 	"github.com/vaayne/anna/agent/runner"
 )
 
-// sendFinalResponse sends the completed response, splitting into chunks
-// if necessary. If we already sent a streaming message, the final update
-// was applied in streamResponse, so this only handles the case where
-// streaming didn't produce any output.
-func (b *Bot) sendFinalResponse(chatID, replyMsgID, response string) {
+// sendFinalResponse delivers the completed response. If streaming already
+// sent a message (sentMsgID != ""), it updates that message in place.
+// Otherwise it sends a new reply, splitting into chunks if necessary.
+func (b *Bot) sendFinalResponse(chatID, replyMsgID, sentMsgID, response string) {
+	if sentMsgID != "" {
+		// Streaming already sent a message — update it with the final text.
+		chunks := splitMessage(response)
+		if err := b.updateMessage(sentMsgID, chunks[0]); err != nil {
+			logger().Error("final update failed", "error", err, "chat_id", chatID)
+		}
+		// Send overflow chunks as new replies.
+		for _, chunk := range chunks[1:] {
+			if _, err := b.sendReplyMessage(replyMsgID, chunk); err != nil {
+				logger().Error("send overflow chunk failed", "error", err, "chat_id", chatID)
+			}
+		}
+		return
+	}
+
+	// No streaming message was sent — send fresh reply.
 	chunks := splitMessage(response)
 	for _, chunk := range chunks {
 		if _, err := b.sendReplyMessage(replyMsgID, chunk); err != nil {

--- a/channel/feishu/render.go
+++ b/channel/feishu/render.go
@@ -14,12 +14,12 @@ func (b *Bot) sendFinalResponse(chatID, replyMsgID, sentMsgID, response string) 
 	if sentMsgID != "" {
 		// Streaming already sent a message — update it with the final text.
 		chunks := splitMessage(response)
-		if err := b.updateMessage(sentMsgID, chunks[0]); err != nil {
+		if err := b.patchMessage(sentMsgID, chunks[0]); err != nil {
 			logger().Error("final update failed", "error", err, "chat_id", chatID)
 		}
 		// Send overflow chunks as new replies.
 		for _, chunk := range chunks[1:] {
-			if _, err := b.sendReplyMessage(replyMsgID, chunk); err != nil {
+			if _, err := b.sendCardReply(replyMsgID, chunk); err != nil {
 				logger().Error("send overflow chunk failed", "error", err, "chat_id", chatID)
 			}
 		}
@@ -29,7 +29,7 @@ func (b *Bot) sendFinalResponse(chatID, replyMsgID, sentMsgID, response string) 
 	// No streaming message was sent — send fresh reply.
 	chunks := splitMessage(response)
 	for _, chunk := range chunks {
-		if _, err := b.sendReplyMessage(replyMsgID, chunk); err != nil {
+		if _, err := b.sendCardReply(replyMsgID, chunk); err != nil {
 			logger().Error("send final response failed", "error", err, "chat_id", chatID)
 		}
 	}

--- a/channel/feishu/render.go
+++ b/channel/feishu/render.go
@@ -1,9 +1,13 @@
 package feishu
 
 import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
 	"strings"
 	"unicode/utf8"
 
+	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
 	"github.com/vaayne/anna/agent/runner"
 )
 
@@ -35,11 +39,55 @@ func (b *Bot) sendFinalResponse(chatID, replyMsgID, sentMsgID, response string) 
 	}
 }
 
-// sendImage is a no-op: Feishu's image API requires uploading images first
-// to get an image_key. Agent-generated images are base64 in-memory.
-// TODO: support image sending once image upload is implemented.
-func (b *Bot) sendImage(_ string, _ string, _ runner.ImageEvent) {
-	logger().Debug("skipping image send: Feishu requires image upload for image_key")
+// sendImage decodes a base64 image, uploads it to Feishu to obtain an image_key,
+// then sends it as an image message in the chat.
+func (b *Bot) sendImage(chatID, replyMsgID string, img runner.ImageEvent) {
+	data, err := base64.StdEncoding.DecodeString(img.Data)
+	if err != nil {
+		logger().Error("decode image failed", "error", err)
+		return
+	}
+
+	// Upload image to get image_key.
+	uploadResp, err := b.client.Im.Image.Create(b.ctx,
+		larkim.NewCreateImageReqBuilder().
+			Body(larkim.NewCreateImageReqBodyBuilder().
+				ImageType("message").
+				Image(bytes.NewReader(data)).
+				Build()).
+			Build())
+	if err != nil {
+		logger().Error("upload image failed", "error", err)
+		return
+	}
+	if !uploadResp.Success() {
+		logger().Error("upload image api error", "code", uploadResp.Code, "msg", uploadResp.Msg)
+		return
+	}
+	if uploadResp.Data == nil || uploadResp.Data.ImageKey == nil {
+		logger().Error("upload image: no image_key returned")
+		return
+	}
+
+	imageKey := *uploadResp.Data.ImageKey
+
+	// Send image message as a reply.
+	content, _ := json.Marshal(map[string]string{"image_key": imageKey})
+	resp, err := b.client.Im.Message.Reply(b.ctx,
+		larkim.NewReplyMessageReqBuilder().
+			MessageId(replyMsgID).
+			Body(larkim.NewReplyMessageReqBodyBuilder().
+				MsgType(larkim.MsgTypeImage).
+				Content(string(content)).
+				Build()).
+			Build())
+	if err != nil {
+		logger().Error("send image failed", "error", err)
+		return
+	}
+	if !resp.Success() {
+		logger().Error("send image api error", "code", resp.Code, "msg", resp.Msg)
+	}
 }
 
 // splitMessage splits a message into chunks that fit within Feishu's message

--- a/channel/feishu/render.go
+++ b/channel/feishu/render.go
@@ -1,0 +1,58 @@
+package feishu
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	"github.com/vaayne/anna/agent/runner"
+)
+
+// sendFinalResponse sends the completed response, splitting into chunks
+// if necessary. If we already sent a streaming message, the final update
+// was applied in streamResponse, so this only handles the case where
+// streaming didn't produce any output.
+func (b *Bot) sendFinalResponse(chatID, replyMsgID, response string) {
+	chunks := splitMessage(response)
+	for _, chunk := range chunks {
+		if _, err := b.sendReplyMessage(replyMsgID, chunk); err != nil {
+			logger().Error("send final response failed", "error", err, "chat_id", chatID)
+		}
+	}
+}
+
+// sendImage is a no-op: Feishu's image API requires uploading images first
+// to get an image_key. Agent-generated images are base64 in-memory.
+// TODO: support image sending once image upload is implemented.
+func (b *Bot) sendImage(_ string, _ string, _ runner.ImageEvent) {
+	logger().Debug("skipping image send: Feishu requires image upload for image_key")
+}
+
+// splitMessage splits a message into chunks that fit within Feishu's message
+// length limit. It tries to split at newline boundaries when possible.
+func splitMessage(text string) []string {
+	if len(text) <= feishuMaxMessageLen {
+		return []string{text}
+	}
+
+	var chunks []string
+	for len(text) > 0 {
+		if len(text) <= feishuMaxMessageLen {
+			chunks = append(chunks, text)
+			break
+		}
+
+		cutAt := feishuMaxMessageLen
+		// Avoid splitting in the middle of a multi-byte UTF-8 character.
+		for cutAt > 0 && !utf8.RuneStart(text[cutAt]) {
+			cutAt--
+		}
+		if idx := strings.LastIndex(text[:cutAt], "\n"); idx > 0 {
+			cutAt = idx + 1
+		}
+
+		chunks = append(chunks, text[:cutAt])
+		text = text[cutAt:]
+	}
+
+	return chunks
+}

--- a/channel/feishu/stream.go
+++ b/channel/feishu/stream.go
@@ -97,7 +97,7 @@ func (b *Bot) streamResponse(chatID, replyMsgID, sessionID string, content runne
 
 		if sentMsgID == "" {
 			// Send initial reply.
-			msgID, err := b.sendReplyMessage(replyMsgID, display)
+			msgID, err := b.sendCardReply(replyMsgID, display)
 			if err != nil {
 				logger().Warn("stream reply failed", "error", err)
 			} else {
@@ -105,7 +105,7 @@ func (b *Bot) streamResponse(chatID, replyMsgID, sessionID string, content runne
 			}
 		} else {
 			// Update existing message.
-			if err := b.updateMessage(sentMsgID, display); err != nil {
+			if err := b.patchMessage(sentMsgID, display); err != nil {
 				logger().Warn("stream update failed", "error", err)
 			}
 		}
@@ -116,7 +116,7 @@ func (b *Bot) streamResponse(chatID, replyMsgID, sessionID string, content runne
 	if sentMsgID != "" {
 		final := sb.String()
 		if strings.TrimSpace(final) != "" {
-			if err := b.updateMessage(sentMsgID, final); err != nil {
+			if err := b.patchMessage(sentMsgID, final); err != nil {
 				logger().Warn("final update failed", "error", err)
 			}
 		}
@@ -125,14 +125,15 @@ func (b *Bot) streamResponse(chatID, replyMsgID, sessionID string, content runne
 	return sentMsgID, sb.String(), images, streamErr
 }
 
-// sendReplyMessage sends a text reply and returns the new message ID.
-func (b *Bot) sendReplyMessage(replyMsgID, text string) (string, error) {
-	content := textContent(text)
+// sendCardReply sends an interactive card reply and returns the new message ID.
+// Cards support the Patch API for in-place streaming edits.
+func (b *Bot) sendCardReply(replyMsgID, text string) (string, error) {
+	content := cardContent(text)
 	resp, err := b.client.Im.Message.Reply(b.ctx,
 		larkim.NewReplyMessageReqBuilder().
 			MessageId(replyMsgID).
 			Body(larkim.NewReplyMessageReqBodyBuilder().
-				MsgType(larkim.MsgTypeText).
+				MsgType(larkim.MsgTypeInteractive).
 				Content(content).
 				Build()).
 			Build())
@@ -148,9 +149,9 @@ func (b *Bot) sendReplyMessage(replyMsgID, text string) (string, error) {
 	return "", nil
 }
 
-// updateMessage edits an existing message in place using the Patch API.
-func (b *Bot) updateMessage(messageID, text string) error {
-	content := textContent(text)
+// patchMessage edits an existing card message in place using the Patch API.
+func (b *Bot) patchMessage(messageID, text string) error {
+	content := cardContent(text)
 	resp, err := b.client.Im.Message.Patch(b.ctx,
 		larkim.NewPatchMessageReqBuilder().
 			MessageId(messageID).

--- a/channel/feishu/stream.go
+++ b/channel/feishu/stream.go
@@ -48,9 +48,9 @@ func toolLine(t *runner.ToolUseEvent) string {
 }
 
 // streamResponse consumes the agent event stream and progressively updates
-// a reply message using Feishu's Message Update API. Returns the final text,
-// collected images, and any stream error.
-func (b *Bot) streamResponse(chatID, replyMsgID, sessionID string, content runner.MessageContent) (string, []runner.ImageEvent, error) {
+// a reply message using Feishu's Message Update API. Returns the sent message ID,
+// final text, collected images, and any stream error.
+func (b *Bot) streamResponse(chatID, replyMsgID, sessionID string, content runner.MessageContent) (string, string, []runner.ImageEvent, error) {
 	events := b.pool.Chat(b.ctx, sessionID, content)
 
 	var sb strings.Builder
@@ -122,7 +122,7 @@ func (b *Bot) streamResponse(chatID, replyMsgID, sessionID string, content runne
 		}
 	}
 
-	return sb.String(), images, streamErr
+	return sentMsgID, sb.String(), images, streamErr
 }
 
 // sendReplyMessage sends a text reply and returns the new message ID.

--- a/channel/feishu/stream.go
+++ b/channel/feishu/stream.go
@@ -1,0 +1,196 @@
+package feishu
+
+import (
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
+	"github.com/vaayne/anna/agent/runner"
+)
+
+const streamEditInterval = time.Second
+
+const typingCursor = " \u258D"
+
+var toolEmoji = map[string]string{
+	"bash":    "⚡",
+	"read":    "📖",
+	"write":   "✏️",
+	"edit":    "🔧",
+	"search":  "🔍",
+	"default": "🔧",
+}
+
+// toolLine returns a short status line for a tool-use event.
+func toolLine(t *runner.ToolUseEvent) string {
+	emoji, ok := toolEmoji[t.Tool]
+	if !ok {
+		emoji = toolEmoji["default"]
+	}
+	switch t.Status {
+	case "running":
+		input := t.Input
+		if utf8.RuneCountInString(input) > 60 {
+			r := []rune(input)
+			input = string(r[:57]) + "..."
+		}
+		if input != "" {
+			return fmt.Sprintf("%s %s: %s", emoji, t.Tool, input)
+		}
+		return fmt.Sprintf("%s %s", emoji, t.Tool)
+	case "error":
+		return fmt.Sprintf("❌ %s failed", t.Tool)
+	default:
+		return ""
+	}
+}
+
+// streamResponse consumes the agent event stream and progressively updates
+// a reply message using Feishu's Message Update API. Returns the final text,
+// collected images, and any stream error.
+func (b *Bot) streamResponse(chatID, replyMsgID, sessionID string, content runner.MessageContent) (string, []runner.ImageEvent, error) {
+	events := b.pool.Chat(b.ctx, sessionID, content)
+
+	var sb strings.Builder
+	var streamErr error
+	var currentTool string
+	var sentMsgID string
+	var images []runner.ImageEvent
+	lastSend := time.Time{}
+
+	for evt := range events {
+		if evt.Err != nil {
+			streamErr = evt.Err
+			break
+		}
+
+		if evt.Image != nil {
+			images = append(images, *evt.Image)
+			continue
+		}
+
+		if evt.ToolUse != nil {
+			line := toolLine(evt.ToolUse)
+			if line != "" {
+				currentTool = line
+			} else {
+				currentTool = ""
+			}
+			lastSend = time.Time{}
+		}
+
+		sb.WriteString(evt.Text)
+
+		now := time.Now()
+		if now.Sub(lastSend) < streamEditInterval {
+			continue
+		}
+
+		current := sb.String()
+		if strings.TrimSpace(current) == "" && currentTool == "" {
+			continue
+		}
+
+		display := buildStreamDisplay(current, currentTool)
+
+		if sentMsgID == "" {
+			// Send initial reply.
+			msgID, err := b.sendReplyMessage(replyMsgID, display)
+			if err != nil {
+				logger().Warn("stream reply failed", "error", err)
+			} else {
+				sentMsgID = msgID
+			}
+		} else {
+			// Update existing message.
+			if err := b.updateMessage(sentMsgID, display); err != nil {
+				logger().Warn("stream update failed", "error", err)
+			}
+		}
+		lastSend = now
+	}
+
+	// Final update to remove cursor.
+	if sentMsgID != "" {
+		final := sb.String()
+		if strings.TrimSpace(final) != "" {
+			if err := b.updateMessage(sentMsgID, final); err != nil {
+				logger().Warn("final update failed", "error", err)
+			}
+		}
+	}
+
+	return sb.String(), images, streamErr
+}
+
+// sendReplyMessage sends a text reply and returns the new message ID.
+func (b *Bot) sendReplyMessage(replyMsgID, text string) (string, error) {
+	content := textContent(text)
+	resp, err := b.client.Im.Message.Reply(b.ctx,
+		larkim.NewReplyMessageReqBuilder().
+			MessageId(replyMsgID).
+			Body(larkim.NewReplyMessageReqBodyBuilder().
+				MsgType(larkim.MsgTypeText).
+				Content(content).
+				Build()).
+			Build())
+	if err != nil {
+		return "", err
+	}
+	if !resp.Success() {
+		return "", fmt.Errorf("code=%d msg=%s", resp.Code, resp.Msg)
+	}
+	if resp.Data != nil && resp.Data.MessageId != nil {
+		return *resp.Data.MessageId, nil
+	}
+	return "", nil
+}
+
+// updateMessage edits an existing message in place.
+func (b *Bot) updateMessage(messageID, text string) error {
+	content := textContent(text)
+	resp, err := b.client.Im.Message.Update(b.ctx,
+		larkim.NewUpdateMessageReqBuilder().
+			MessageId(messageID).
+			Body(larkim.NewUpdateMessageReqBodyBuilder().
+				MsgType(larkim.MsgTypeText).
+				Content(content).
+				Build()).
+			Build())
+	if err != nil {
+		return err
+	}
+	if !resp.Success() {
+		return fmt.Errorf("code=%d msg=%s", resp.Code, resp.Msg)
+	}
+	return nil
+}
+
+// buildStreamDisplay constructs the streaming display text with tool indicator
+// and cursor, truncated to Feishu's message length limit (UTF-8 safe).
+func buildStreamDisplay(text, currentTool string) string {
+	display := text
+	suffix := typingCursor
+	if currentTool != "" {
+		suffix = "\n\n" + currentTool + typingCursor
+	}
+
+	if len(suffix) >= feishuMaxMessageLen {
+		suffix = typingCursor
+	}
+
+	if len(display)+len(suffix) > feishuMaxMessageLen {
+		cutAt := feishuMaxMessageLen - len(suffix) - 3
+		if cutAt < 0 {
+			cutAt = 0
+		}
+		for cutAt > 0 && !utf8.RuneStart(display[cutAt]) {
+			cutAt--
+		}
+		display = display[:cutAt] + "..."
+	}
+
+	return display + suffix
+}

--- a/channel/feishu/stream.go
+++ b/channel/feishu/stream.go
@@ -148,14 +148,13 @@ func (b *Bot) sendReplyMessage(replyMsgID, text string) (string, error) {
 	return "", nil
 }
 
-// updateMessage edits an existing message in place.
+// updateMessage edits an existing message in place using the Patch API.
 func (b *Bot) updateMessage(messageID, text string) error {
 	content := textContent(text)
-	resp, err := b.client.Im.Message.Update(b.ctx,
-		larkim.NewUpdateMessageReqBuilder().
+	resp, err := b.client.Im.Message.Patch(b.ctx,
+		larkim.NewPatchMessageReqBuilder().
 			MessageId(messageID).
-			Body(larkim.NewUpdateMessageReqBodyBuilder().
-				MsgType(larkim.MsgTypeText).
+			Body(larkim.NewPatchMessageReqBodyBuilder().
 				Content(content).
 				Build()).
 			Build())

--- a/config.go
+++ b/config.go
@@ -36,6 +36,7 @@ const (
 type ChannelsConfig struct {
 	Telegram TelegramConfig `yaml:"telegram" envPrefix:"TELEGRAM_"`
 	QQ       QQConfig       `yaml:"qq"       envPrefix:"QQ_"`
+	Feishu   FeishuConfig   `yaml:"feishu"   envPrefix:"FEISHU_"`
 }
 
 type CronConfig struct {
@@ -86,6 +87,14 @@ type CompactionConfig = agent.CompactionConfig
 type QQConfig struct {
 	AppID      string   `yaml:"app_id"      env:"APP_ID"`
 	AppSecret  string   `yaml:"app_secret"  env:"APP_SECRET"`
+	GroupMode  string   `yaml:"group_mode"  env:"GROUP_MODE"`
+	AllowedIDs []string `yaml:"allowed_ids" env:"ALLOWED_IDS"`
+}
+
+type FeishuConfig struct {
+	AppID      string   `yaml:"app_id"      env:"APP_ID"`
+	AppSecret  string   `yaml:"app_secret"  env:"APP_SECRET"`
+	NotifyChat string   `yaml:"notify_chat" env:"NOTIFY_CHAT"`
 	GroupMode  string   `yaml:"group_mode"  env:"GROUP_MODE"`
 	AllowedIDs []string `yaml:"allowed_ids" env:"ALLOWED_IDS"`
 }

--- a/config.go
+++ b/config.go
@@ -92,11 +92,13 @@ type QQConfig struct {
 }
 
 type FeishuConfig struct {
-	AppID      string   `yaml:"app_id"      env:"APP_ID"`
-	AppSecret  string   `yaml:"app_secret"  env:"APP_SECRET"`
-	NotifyChat string   `yaml:"notify_chat" env:"NOTIFY_CHAT"`
-	GroupMode  string   `yaml:"group_mode"  env:"GROUP_MODE"`
-	AllowedIDs []string `yaml:"allowed_ids" env:"ALLOWED_IDS"`
+	AppID             string   `yaml:"app_id"             env:"APP_ID"`
+	AppSecret         string   `yaml:"app_secret"         env:"APP_SECRET"`
+	EncryptKey        string   `yaml:"encrypt_key"        env:"ENCRYPT_KEY"`
+	VerificationToken string   `yaml:"verification_token" env:"VERIFICATION_TOKEN"`
+	NotifyChat        string   `yaml:"notify_chat"        env:"NOTIFY_CHAT"`
+	GroupMode         string   `yaml:"group_mode"         env:"GROUP_MODE"`
+	AllowedIDs        []string `yaml:"allowed_ids"        env:"ALLOWED_IDS"`
 }
 
 type TelegramConfig struct {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,13 +4,13 @@
 
 anna is structured as a set of loosely coupled packages wired together in `main.go`. The core flow:
 
-1. A **channel** (CLI or Telegram) receives user input
+1. A **channel** (CLI, Telegram, QQ, or Feishu) receives user input
 2. The **Pool** manages sessions and dispatches to a **Runner**
 3. The **Go runner** calls LLM providers via `ai/providers/`, executing tools in a loop
 4. Responses stream back through the channel to the user
 
 ```
-Channel (CLI/Telegram)
+Channel (CLI/Telegram/QQ/Feishu)
     |
     v
 Pool (sessions + runner lifecycle)
@@ -88,6 +88,12 @@ channel/
     stream.go                       Streaming via QQ Stream API
     render.go                       Message chunking
     model.go                        Text-based model selection UI
+  feishu/
+    feishu.go                       Bot setup, WebSocket, notification backend
+    handler.go                      Message event handlers
+    stream.go                       Streaming via message update (edit-in-place)
+    render.go                       Response splitting
+    model.go                        Text-based model list
 
 cron/
   cron.go                           Scheduler service (gocron/v2)
@@ -146,7 +152,7 @@ type Tool interface {
 | `memory` | Always | Persistent memory (update facts, append journal, search) |
 | `skills` | Always | Skill management (search/install/list/remove from skills.sh) |
 | `cron` | `cron.enabled: true` | Schedule tasks (add/list/remove jobs) |
-| `notify` | Gateway mode + Telegram configured | Send notifications via dispatcher |
+| `notify` | Gateway mode + channel configured | Send notifications via dispatcher |
 
 ## Session Lifecycle
 
@@ -176,8 +182,8 @@ Shared command logic (`/new`, `/compact`, `/model`) lives in `channel.Commander`
 ## Notification Flow
 
 ```
-Agent notify tool --> Dispatcher --> Channel (Telegram/QQ)
-Cron job result   --> Dispatcher --> Channel (Telegram/QQ)
+Agent notify tool --> Dispatcher --> Channel (Telegram/QQ/Feishu)
+Cron job result   --> Dispatcher --> Channel (Telegram/QQ/Feishu)
 ```
 
 The dispatcher is created early in setup, but backends are registered later when gateway services start. See [notification-system.md](notification-system.md) for details.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,6 +46,12 @@ channels:
     app_secret: "QQ_BOT_APP_SECRET"
     group_mode: "mention"          # mention | always | disabled
     allowed_ids: []                # User OpenIDs allowed (empty = allow all)
+  feishu:
+    app_id: "FEISHU_APP_ID"
+    app_secret: "FEISHU_APP_SECRET"
+    notify_chat: "oc_xxx"          # Chat ID for proactive notifications
+    group_mode: "mention"          # mention | always | disabled
+    allowed_ids: []                # User open_ids allowed (empty = allow all)
 
 # Default LLM provider
 provider: anthropic
@@ -117,6 +123,11 @@ All config fields support env var overrides using the `ANNA_` prefix. Nested str
 | `ANNA_QQ_APP_SECRET` | `channels.qq.app_secret` | |
 | `ANNA_QQ_GROUP_MODE` | `channels.qq.group_mode` | |
 | `ANNA_QQ_ALLOWED_IDS` | `channels.qq.allowed_ids` | Comma-separated |
+| `ANNA_FEISHU_APP_ID` | `channels.feishu.app_id` | |
+| `ANNA_FEISHU_APP_SECRET` | `channels.feishu.app_secret` | |
+| `ANNA_FEISHU_NOTIFY_CHAT` | `channels.feishu.notify_chat` | |
+| `ANNA_FEISHU_GROUP_MODE` | `channels.feishu.group_mode` | |
+| `ANNA_FEISHU_ALLOWED_IDS` | `channels.feishu.allowed_ids` | Comma-separated |
 | `ANTHROPIC_API_KEY` | `providers.anthropic.api_key` | Standard provider env |
 | `ANTHROPIC_BASE_URL` | `providers.anthropic.base_url` | Standard provider env |
 | `OPENAI_API_KEY` | `providers.openai.api_key` | Also used by `openai-response` |
@@ -137,3 +148,4 @@ All config fields support env var overrides using the `ANNA_` prefix. Nested str
 | `cron.data_dir` | `~/.anna/workspace/cron` |
 | `channels.telegram.group_mode` | `mention` |
 | `channels.qq.group_mode` | `mention` |
+| `channels.feishu.group_mode` | `mention` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,6 +49,8 @@ channels:
   feishu:
     app_id: "FEISHU_APP_ID"
     app_secret: "FEISHU_APP_SECRET"
+    encrypt_key: ""                # Event encrypt key (from developer console)
+    verification_token: ""         # Event verification token (from developer console)
     notify_chat: "oc_xxx"          # Chat ID for proactive notifications
     group_mode: "mention"          # mention | always | disabled
     allowed_ids: []                # User open_ids allowed (empty = allow all)
@@ -125,6 +127,8 @@ All config fields support env var overrides using the `ANNA_` prefix. Nested str
 | `ANNA_QQ_ALLOWED_IDS` | `channels.qq.allowed_ids` | Comma-separated |
 | `ANNA_FEISHU_APP_ID` | `channels.feishu.app_id` | |
 | `ANNA_FEISHU_APP_SECRET` | `channels.feishu.app_secret` | |
+| `ANNA_FEISHU_ENCRYPT_KEY` | `channels.feishu.encrypt_key` | |
+| `ANNA_FEISHU_VERIFICATION_TOKEN` | `channels.feishu.verification_token` | |
 | `ANNA_FEISHU_NOTIFY_CHAT` | `channels.feishu.notify_chat` | |
 | `ANNA_FEISHU_GROUP_MODE` | `channels.feishu.group_mode` | |
 | `ANNA_FEISHU_ALLOWED_IDS` | `channels.feishu.allowed_ids` | Comma-separated |

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -1,0 +1,107 @@
+# Feishu Bot
+
+anna includes a Feishu (Lark) bot that connects via WebSocket (persistent connection, no public URL required).
+
+## Setup
+
+1. Create a Feishu app at [Feishu Open Platform](https://open.feishu.cn/)
+2. Enable the **Bot** capability in your app settings
+3. Under **Event Subscriptions**, add `im.message.receive_v1` event
+4. Get your App ID and App Secret from the app credentials page
+5. Add credentials to `~/.anna/config.yaml`:
+
+```yaml
+channels:
+  feishu:
+    app_id: "YOUR_APP_ID"
+    app_secret: "YOUR_APP_SECRET"
+```
+
+Or via environment:
+
+```bash
+export ANNA_FEISHU_APP_ID="YOUR_APP_ID"
+export ANNA_FEISHU_APP_SECRET="YOUR_APP_SECRET"
+```
+
+6. Start the gateway:
+
+```bash
+anna gateway
+```
+
+The bot connects to Feishu via WebSocket -- no public URL or webhook setup needed.
+
+## Streaming Responses
+
+The bot uses Feishu's Message Update API for edit-in-place streaming. When the LLM generates tokens, the bot sends an initial reply and progressively updates it with new content, providing a smooth streaming experience.
+
+### Tool Indicators
+
+During tool execution, the stream shows status with emoji indicators:
+
+| Tool | Emoji |
+|------|-------|
+| `bash` | lightning |
+| `read` | book |
+| `write` | pencil |
+| `edit` | wrench |
+| `search` | magnifying glass |
+
+## Group Support
+
+In group chats, the bot responds to @mentions. Configure behavior:
+
+```yaml
+channels:
+  feishu:
+    group_mode: "mention"    # Respond to @mentions (default)
+    # group_mode: "always"   # Respond to all group messages
+    # group_mode: "disabled" # Ignore group messages entirely
+```
+
+## Access Control
+
+Restrict which users can interact with the bot using open_ids:
+
+```yaml
+channels:
+  feishu:
+    allowed_ids:
+      - "ou_xxxx"
+```
+
+Leave empty to allow all users.
+
+## Notifications
+
+Configure a default chat for proactive notifications (cron results, agent-triggered alerts):
+
+```yaml
+channels:
+  feishu:
+    notify_chat: "oc_xxxx"   # Chat ID for notifications
+```
+
+## Commands
+
+Send these commands as text messages to the bot:
+
+| Command | Description |
+|---------|-------------|
+| `/start` or `/help` | Welcome and help |
+| `/new` | Start a fresh session |
+| `/compact` | Compress conversation history |
+| `/model` | List available models |
+| `/model <number>` | Switch to model by number |
+| `/model <query>` | Filter models by name |
+
+## Configuration Reference
+
+| Field | Description | Default |
+|-------|-------------|---------|
+| `app_id` | Feishu App ID | (required) |
+| `app_secret` | Feishu App Secret | (required) |
+| `notify_chat` | Chat ID for proactive notifications | (optional) |
+| `group_mode` | Group behavior: `mention`, `always`, `disabled` | `mention` |
+| `allowed_ids` | User open_ids allowed (empty = all) | `[]` |

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -15,6 +15,8 @@ channels:
   feishu:
     app_id: "YOUR_APP_ID"
     app_secret: "YOUR_APP_SECRET"
+    encrypt_key: "YOUR_ENCRYPT_KEY"             # from Events & Callbacks page
+    verification_token: "YOUR_VERIFICATION_TOKEN" # from Events & Callbacks page
 ```
 
 Or via environment:
@@ -22,6 +24,8 @@ Or via environment:
 ```bash
 export ANNA_FEISHU_APP_ID="YOUR_APP_ID"
 export ANNA_FEISHU_APP_SECRET="YOUR_APP_SECRET"
+export ANNA_FEISHU_ENCRYPT_KEY="YOUR_ENCRYPT_KEY"
+export ANNA_FEISHU_VERIFICATION_TOKEN="YOUR_VERIFICATION_TOKEN"
 ```
 
 6. Start the gateway:
@@ -102,6 +106,8 @@ Send these commands as text messages to the bot:
 |-------|-------------|---------|
 | `app_id` | Feishu App ID | (required) |
 | `app_secret` | Feishu App Secret | (required) |
+| `encrypt_key` | Event encrypt key (from Events & Callbacks) | (optional) |
+| `verification_token` | Event verification token (from Events & Callbacks) | (optional) |
 | `notify_chat` | Chat ID for proactive notifications | (optional) |
 | `group_mode` | Group behavior: `mention`, `always`, `disabled` | `mention` |
 | `allowed_ids` | User open_ids allowed (empty = all) | `[]` |

--- a/docs/feishu.md
+++ b/docs/feishu.md
@@ -52,7 +52,17 @@ During tool execution, the stream shows status with emoji indicators:
 | `edit` | wrench |
 | `search` | magnifying glass |
 
+## Supported Message Types
+
+| Type | Behavior |
+|------|----------|
+| Text | Extracted and sent to the LLM |
+| Image | Downloaded, base64-encoded, sent as multimodal input |
+| Post (rich text) | Raw JSON passed to the LLM for full context |
+
 ## Group Support
+
+On startup, the bot fetches its own `open_id` via the Feishu Bot Info API. This enables reliable @mention detection in groups and prevents the bot from responding to its own messages (infinite loop protection).
 
 In group chats, the bot responds to @mentions. Configure behavior:
 

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/go-co-op/gocron/v2 v2.19.1
 	github.com/go-git/go-git/v5 v5.17.0
 	github.com/google/uuid v1.6.0
+	github.com/larksuite/oapi-sdk-go/v3 v3.5.3
 	github.com/muesli/termenv v0.16.0
 	github.com/openai/openai-go v1.12.0
 	github.com/tencent-connect/botgo v0.2.1
@@ -55,10 +56,11 @@ require (
 	github.com/go-git/go-billy/v5 v5.8.0 // indirect
 	github.com/go-resty/resty/v2 v2.6.0 // indirect
 	github.com/go-shiori/dom v0.0.0-20230515143342-73569d674e1c // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/gogs/chardet v0.0.0-20211120154057-b7413eaefb8f // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/gorilla/css v1.0.1 // indirect
-	github.com/gorilla/websocket v1.4.2 // indirect
+	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -242,6 +242,7 @@ github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg78
 github.com/goccy/go-yaml v1.9.5/go.mod h1:U/jl18uSupI5rdI2jmuCswEA2htH9eXfferR3KfscvA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/gogs/chardet v0.0.0-20211120154057-b7413eaefb8f h1:3BSP1Tbs2djlpprl7wCLuiqMaUh5SJkkzI2gDs+FgLs=
 github.com/gogs/chardet v0.0.0-20211120154057-b7413eaefb8f/go.mod h1:Pcatq5tYkCW2Q6yrR2VRHlbHpZ/R4/7qyL1TCF7vl14=
@@ -334,8 +335,9 @@ github.com/googleapis/gax-go/v2 v2.4.0/go.mod h1:XOTVJ59hdnfJLIP/dh8n5CGryZR2LxK
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
 github.com/gorilla/css v1.0.1 h1:ntNaBIghp6JmvWnxbZKANoLyuXTPZ4cAMlo6RyhlbO8=
 github.com/gorilla/css v1.0.1/go.mod h1:BvnYkspnSzMmwRK+b8/xgNPLiIuNZr6vbZBTPQ2A3b0=
-github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
+github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul/api v1.12.0/go.mod h1:6pVBMo0ebnYdt2S3H87XhekM/HHrUoTD2XXb/VrZVy0=
@@ -403,6 +405,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/larksuite/oapi-sdk-go/v3 v3.5.3 h1:xvf8Dv29kBXC5/DNDCLhHkAFW8l/0LlQJimO5Zn+JUk=
+github.com/larksuite/oapi-sdk-go/v3 v3.5.3/go.mod h1:ZEplY+kwuIrj/nqw5uSCINNATcH3KdxSN7y+UxYY5fI=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/vaayne/anna/agent/tool"
 	"github.com/vaayne/anna/channel"
 	clicmd "github.com/vaayne/anna/channel/cli"
+	"github.com/vaayne/anna/channel/feishu"
 	"github.com/vaayne/anna/channel/qq"
 	"github.com/vaayne/anna/channel/telegram"
 	"github.com/vaayne/anna/cron"
@@ -156,7 +157,7 @@ func setup(parent context.Context, gateway bool) (*setupResult, error) {
 	// Notification dispatcher + tool — backends are registered later in
 	// runGateway(). Only expose the tool in gateway mode where backends exist.
 	dispatcher := channel.NewDispatcher()
-	if gateway && (cfg.Channels.Telegram.Token != "" || (cfg.Channels.QQ.AppID != "" && cfg.Channels.QQ.AppSecret != "")) {
+	if gateway && (cfg.Channels.Telegram.Token != "" || (cfg.Channels.QQ.AppID != "" && cfg.Channels.QQ.AppSecret != "") || (cfg.Channels.Feishu.AppID != "" && cfg.Channels.Feishu.AppSecret != "")) {
 		extraTools = append(extraTools, channel.NewNotifyTool(dispatcher))
 	}
 
@@ -313,6 +314,28 @@ func runGateway(ctx context.Context, s *setupResult, listFn channel.ModelListFun
 
 		channels = append(channels, qqBot)
 		s.notifier.Register(qqBot, "")
+	}
+
+	// --- Feishu ---
+	fsCfg := s.cfg.Channels.Feishu
+	if fsCfg.AppID != "" && fsCfg.AppSecret != "" {
+		slog.Info("starting feishu bot")
+
+		fsBot, err := feishu.New(feishu.Config{
+			AppID:             fsCfg.AppID,
+			AppSecret:         fsCfg.AppSecret,
+			EncryptKey:        fsCfg.EncryptKey,
+			VerificationToken: fsCfg.VerificationToken,
+			NotifyChat:        fsCfg.NotifyChat,
+			GroupMode:         fsCfg.GroupMode,
+			AllowedIDs:        fsCfg.AllowedIDs,
+		}, s.pool, listFn, switchFn)
+		if err != nil {
+			return fmt.Errorf("create feishu bot: %w", err)
+		}
+
+		channels = append(channels, fsBot)
+		s.notifier.Register(fsBot, fsCfg.NotifyChat)
 	}
 
 	if len(channels) == 0 {

--- a/onboard.go
+++ b/onboard.go
@@ -540,6 +540,8 @@ func saveConfig(cfg *Config) error {
 		}
 		setOrDelete(fsMap, "app_id", fs.AppID)
 		setOrDelete(fsMap, "app_secret", fs.AppSecret)
+		setOrDelete(fsMap, "encrypt_key", fs.EncryptKey)
+		setOrDelete(fsMap, "verification_token", fs.VerificationToken)
 		setOrDelete(fsMap, "notify_chat", fs.NotifyChat)
 		setOrDelete(fsMap, "group_mode", fs.GroupMode)
 		if len(fs.AllowedIDs) > 0 {

--- a/onboard.go
+++ b/onboard.go
@@ -321,6 +321,7 @@ type providerJSON struct {
 type channelsJSON struct {
 	Telegram telegramJSON `json:"telegram"`
 	QQ       qqJSON       `json:"qq"`
+	Feishu   feishuJSON   `json:"feishu"`
 }
 
 type telegramJSON struct {
@@ -334,6 +335,14 @@ type telegramJSON struct {
 type qqJSON struct {
 	AppID      string   `json:"app_id"`
 	AppSecret  string   `json:"app_secret"`
+	GroupMode  string   `json:"group_mode"`
+	AllowedIDs []string `json:"allowed_ids"`
+}
+
+type feishuJSON struct {
+	AppID      string   `json:"app_id"`
+	AppSecret  string   `json:"app_secret"`
+	NotifyChat string   `json:"notify_chat"`
 	GroupMode  string   `json:"group_mode"`
 	AllowedIDs []string `json:"allowed_ids"`
 }
@@ -363,6 +372,13 @@ func cfgToJSON(cfg *Config) configJSON {
 				AppSecret:  cfg.Channels.QQ.AppSecret,
 				GroupMode:  cfg.Channels.QQ.GroupMode,
 				AllowedIDs: cfg.Channels.QQ.AllowedIDs,
+			},
+			Feishu: feishuJSON{
+				AppID:      cfg.Channels.Feishu.AppID,
+				AppSecret:  cfg.Channels.Feishu.AppSecret,
+				NotifyChat: cfg.Channels.Feishu.NotifyChat,
+				GroupMode:  cfg.Channels.Feishu.GroupMode,
+				AllowedIDs: cfg.Channels.Feishu.AllowedIDs,
 			},
 		},
 	}
@@ -399,6 +415,14 @@ func applyJSONToConfig(cfg *Config, body *configJSON) {
 		AppSecret:  body.Channels.QQ.AppSecret,
 		GroupMode:  body.Channels.QQ.GroupMode,
 		AllowedIDs: body.Channels.QQ.AllowedIDs,
+	}
+
+	cfg.Channels.Feishu = FeishuConfig{
+		AppID:      body.Channels.Feishu.AppID,
+		AppSecret:  body.Channels.Feishu.AppSecret,
+		NotifyChat: body.Channels.Feishu.NotifyChat,
+		GroupMode:  body.Channels.Feishu.GroupMode,
+		AllowedIDs: body.Channels.Feishu.AllowedIDs,
 	}
 }
 
@@ -494,6 +518,30 @@ func saveConfig(cfg *Config) error {
 			delete(qqMap, "allowed_ids")
 		}
 		existingChannels["qq"] = qqMap
+		existing["channels"] = existingChannels
+	}
+
+	// Merge Feishu channel config.
+	fs := cfg.Channels.Feishu
+	if fs.AppID != "" || fs.AppSecret != "" || fs.NotifyChat != "" || fs.GroupMode != "" || len(fs.AllowedIDs) > 0 {
+		existingChannels, _ := existing["channels"].(map[string]any)
+		if existingChannels == nil {
+			existingChannels = make(map[string]any)
+		}
+		fsMap, _ := existingChannels["feishu"].(map[string]any)
+		if fsMap == nil {
+			fsMap = make(map[string]any)
+		}
+		setOrDelete(fsMap, "app_id", fs.AppID)
+		setOrDelete(fsMap, "app_secret", fs.AppSecret)
+		setOrDelete(fsMap, "notify_chat", fs.NotifyChat)
+		setOrDelete(fsMap, "group_mode", fs.GroupMode)
+		if len(fs.AllowedIDs) > 0 {
+			fsMap["allowed_ids"] = fs.AllowedIDs
+		} else {
+			delete(fsMap, "allowed_ids")
+		}
+		existingChannels["feishu"] = fsMap
 		existing["channels"] = existingChannels
 	}
 

--- a/onboard.go
+++ b/onboard.go
@@ -340,11 +340,13 @@ type qqJSON struct {
 }
 
 type feishuJSON struct {
-	AppID      string   `json:"app_id"`
-	AppSecret  string   `json:"app_secret"`
-	NotifyChat string   `json:"notify_chat"`
-	GroupMode  string   `json:"group_mode"`
-	AllowedIDs []string `json:"allowed_ids"`
+	AppID             string   `json:"app_id"`
+	AppSecret         string   `json:"app_secret"`
+	EncryptKey        string   `json:"encrypt_key"`
+	VerificationToken string   `json:"verification_token"`
+	NotifyChat        string   `json:"notify_chat"`
+	GroupMode         string   `json:"group_mode"`
+	AllowedIDs        []string `json:"allowed_ids"`
 }
 
 func cfgToJSON(cfg *Config) configJSON {
@@ -374,11 +376,13 @@ func cfgToJSON(cfg *Config) configJSON {
 				AllowedIDs: cfg.Channels.QQ.AllowedIDs,
 			},
 			Feishu: feishuJSON{
-				AppID:      cfg.Channels.Feishu.AppID,
-				AppSecret:  cfg.Channels.Feishu.AppSecret,
-				NotifyChat: cfg.Channels.Feishu.NotifyChat,
-				GroupMode:  cfg.Channels.Feishu.GroupMode,
-				AllowedIDs: cfg.Channels.Feishu.AllowedIDs,
+				AppID:             cfg.Channels.Feishu.AppID,
+				AppSecret:         cfg.Channels.Feishu.AppSecret,
+				EncryptKey:        cfg.Channels.Feishu.EncryptKey,
+				VerificationToken: cfg.Channels.Feishu.VerificationToken,
+				NotifyChat:        cfg.Channels.Feishu.NotifyChat,
+				GroupMode:         cfg.Channels.Feishu.GroupMode,
+				AllowedIDs:        cfg.Channels.Feishu.AllowedIDs,
 			},
 		},
 	}
@@ -418,11 +422,13 @@ func applyJSONToConfig(cfg *Config, body *configJSON) {
 	}
 
 	cfg.Channels.Feishu = FeishuConfig{
-		AppID:      body.Channels.Feishu.AppID,
-		AppSecret:  body.Channels.Feishu.AppSecret,
-		NotifyChat: body.Channels.Feishu.NotifyChat,
-		GroupMode:  body.Channels.Feishu.GroupMode,
-		AllowedIDs: body.Channels.Feishu.AllowedIDs,
+		AppID:             body.Channels.Feishu.AppID,
+		AppSecret:         body.Channels.Feishu.AppSecret,
+		EncryptKey:        body.Channels.Feishu.EncryptKey,
+		VerificationToken: body.Channels.Feishu.VerificationToken,
+		NotifyChat:        body.Channels.Feishu.NotifyChat,
+		GroupMode:         body.Channels.Feishu.GroupMode,
+		AllowedIDs:        body.Channels.Feishu.AllowedIDs,
 	}
 }
 

--- a/onboard.html
+++ b/onboard.html
@@ -416,6 +416,24 @@
           </div>
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <div>
+              <label for="feishu-encrypt" class="flex items-center gap-1 text-[11px] font-medium text-ink-2 uppercase tracking-wider mb-1.5">
+                <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z"/></svg>
+                Encrypt Key
+              </label>
+              <input id="feishu-encrypt" type="password" x-model="config.channels.feishu.encrypt_key" placeholder="Event encrypt key (optional)"
+                     class="w-full h-10 rounded-lg border border-surface-4 bg-surface-0 px-3 text-sm text-ink-0 font-mono shadow-card placeholder:text-ink-3 focus:outline-none focus:border-primary-400 focus:shadow-input-focus transition-all duration-150">
+            </div>
+            <div>
+              <label for="feishu-verify" class="flex items-center gap-1 text-[11px] font-medium text-ink-2 uppercase tracking-wider mb-1.5">
+                <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z"/></svg>
+                Verification Token
+              </label>
+              <input id="feishu-verify" type="password" x-model="config.channels.feishu.verification_token" placeholder="Event verification token (optional)"
+                     class="w-full h-10 rounded-lg border border-surface-4 bg-surface-0 px-3 text-sm text-ink-0 font-mono shadow-card placeholder:text-ink-3 focus:outline-none focus:border-primary-400 focus:shadow-input-focus transition-all duration-150">
+            </div>
+          </div>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div>
               <label for="feishu-notify" class="flex items-center gap-1 text-[11px] font-medium text-ink-2 uppercase tracking-wider mb-1.5">
                 <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0"/></svg>
                 Notify Chat
@@ -598,7 +616,7 @@ function onboard() {
       channels: {
         telegram: { token: '', notify_chat: '', channel_id: '', group_mode: '', allowed_ids: [] },
         qq: { app_id: '', app_secret: '', group_mode: '', allowed_ids: [] },
-        feishu: { app_id: '', app_secret: '', notify_chat: '', group_mode: '', allowed_ids: [] },
+        feishu: { app_id: '', app_secret: '', encrypt_key: '', verification_token: '', notify_chat: '', group_mode: '', allowed_ids: [] },
       },
     },
     providerModels: {},

--- a/onboard.html
+++ b/onboard.html
@@ -388,6 +388,61 @@
           </div>
         </div>
       </div>
+      <!-- Feishu -->
+      <div class="rounded-xl border border-surface-3 bg-surface-0 shadow-card overflow-hidden mt-5">
+        <div class="flex items-center gap-2 px-4 py-2.5 border-b border-surface-2">
+          <svg class="w-5 h-5 text-[#3370FF]" viewBox="0 0 24 24" fill="currentColor"><path d="M3.806 7.293l5.685-4.27a.75.75 0 01.9 0l5.685 4.27a.75.75 0 01.274.69l-1.63 7.164a.75.75 0 01-.724.573H5.886a.75.75 0 01-.724-.573L3.532 7.983a.75.75 0 01.274-.69zM12 2l8.485 6.364a1.5 1.5 0 01.549 1.38l-2.442 10.742a1.5 1.5 0 01-1.449 1.146H6.857a1.5 1.5 0 01-1.449-1.146L2.966 9.744a1.5 1.5 0 01.549-1.38L12 2z"/></svg>
+          <span class="text-sm font-medium text-ink-0">Feishu</span>
+        </div>
+
+        <div class="px-4 py-4 space-y-3">
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div>
+              <label for="feishu-appid" class="flex items-center gap-1 text-[11px] font-medium text-ink-2 uppercase tracking-wider mb-1.5">
+                <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15 9h3.75M15 12h3.75M15 15h3.75M4.5 19.5h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25v10.5A2.25 2.25 0 0 0 4.5 19.5Zm6-10.125a1.875 1.875 0 1 1-3.75 0 1.875 1.875 0 0 1 3.75 0Zm1.294 6.336a6.721 6.721 0 0 1-3.17.789 6.721 6.721 0 0 1-3.168-.789 3.376 3.376 0 0 1 6.338 0Z"/></svg>
+                App ID
+              </label>
+              <input id="feishu-appid" type="text" x-model="config.channels.feishu.app_id" placeholder="Feishu App ID"
+                     class="w-full h-10 rounded-lg border border-surface-4 bg-surface-0 px-3 text-sm text-ink-0 font-mono shadow-card placeholder:text-ink-3 focus:outline-none focus:border-primary-400 focus:shadow-input-focus transition-all duration-150">
+            </div>
+            <div>
+              <label for="feishu-secret" class="flex items-center gap-1 text-[11px] font-medium text-ink-2 uppercase tracking-wider mb-1.5">
+                <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 5.25a3 3 0 0 1 3 3m3 0a6 6 0 0 1-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1 1 21.75 8.25Z"/></svg>
+                App Secret
+              </label>
+              <input id="feishu-secret" type="password" x-model="config.channels.feishu.app_secret" placeholder="Feishu App Secret"
+                     class="w-full h-10 rounded-lg border border-surface-4 bg-surface-0 px-3 text-sm text-ink-0 font-mono shadow-card placeholder:text-ink-3 focus:outline-none focus:border-primary-400 focus:shadow-input-focus transition-all duration-150">
+            </div>
+          </div>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div>
+              <label for="feishu-notify" class="flex items-center gap-1 text-[11px] font-medium text-ink-2 uppercase tracking-wider mb-1.5">
+                <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0"/></svg>
+                Notify Chat
+              </label>
+              <input id="feishu-notify" type="text" x-model="config.channels.feishu.notify_chat" placeholder="Chat ID for notifications"
+                     class="w-full h-10 rounded-lg border border-surface-4 bg-surface-0 px-3 text-sm text-ink-0 font-mono shadow-card placeholder:text-ink-3 focus:outline-none focus:border-primary-400 focus:shadow-input-focus transition-all duration-150">
+            </div>
+            <div>
+              <label for="feishu-group" class="text-[11px] font-medium text-ink-2 uppercase tracking-wider mb-1.5 block">Group Mode</label>
+              <select id="feishu-group" x-model="config.channels.feishu.group_mode"
+                      class="w-full h-10 rounded-lg border border-surface-4 bg-surface-0 px-3 text-sm text-ink-0 shadow-card focus:outline-none focus:border-primary-400 focus:shadow-input-focus transition-all duration-150 cursor-pointer appearance-none bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20fill%3D%22%23868e96%22%20viewBox%3D%220%200%2016%2016%22%3E%3Cpath%20d%3D%22M4.646%206.646a.5.5%200%20011%200L8%209.293l2.354-2.647a.5.5%200%2001.707.708l-3%203a.5.5%200%2001-.707%200l-3-3a.5.5%200%20010-.708z%22%2F%3E%3C%2Fsvg%3E')] bg-[length:16px] bg-[right_10px_center] bg-no-repeat">
+                <option value="">Default (mention)</option>
+                <option value="mention">Mention</option>
+                <option value="always">Always</option>
+                <option value="disabled">Disabled</option>
+              </select>
+            </div>
+          </div>
+          <div>
+            <label for="feishu-allowed" class="text-[11px] font-medium text-ink-2 uppercase tracking-wider mb-1.5 block">Allowed IDs</label>
+            <input id="feishu-allowed" type="text" :value="(config.channels.feishu.allowed_ids || []).join(', ')"
+                   @change="config.channels.feishu.allowed_ids = $event.target.value.split(',').map(s => s.trim()).filter(Boolean)"
+                   placeholder="Comma-separated open_ids"
+                   class="w-full h-10 rounded-lg border border-surface-4 bg-surface-0 px-3 text-sm text-ink-0 shadow-card placeholder:text-ink-3 focus:outline-none focus:border-primary-400 focus:shadow-input-focus transition-all duration-150">
+          </div>
+        </div>
+      </div>
     </section>
 
     <!-- Tab 3: Cron -->
@@ -543,6 +598,7 @@ function onboard() {
       channels: {
         telegram: { token: '', notify_chat: '', channel_id: '', group_mode: '', allowed_ids: [] },
         qq: { app_id: '', app_secret: '', group_mode: '', allowed_ids: [] },
+        feishu: { app_id: '', app_secret: '', notify_chat: '', group_mode: '', allowed_ids: [] },
       },
     },
     providerModels: {},
@@ -633,6 +689,7 @@ function onboard() {
             channels: {
               telegram: { token: '', notify_chat: '', channel_id: '', group_mode: '', allowed_ids: [], ...data.config.channels?.telegram },
               qq: { app_id: '', app_secret: '', group_mode: '', allowed_ids: [], ...data.config.channels?.qq },
+              feishu: { app_id: '', app_secret: '', notify_chat: '', group_mode: '', allowed_ids: [], ...data.config.channels?.feishu },
             },
             providers: data.config.providers || {},
           };


### PR DESCRIPTION
## Summary

- Add full Feishu bot channel with WebSocket connection (no public URL needed)
- Streaming responses via interactive cards with edit-in-place (Patch API)
- Image input (download + base64 encode) and output (upload + send)
- Rich text (post) message support — raw JSON forwarded to LLM
- Bot self-message filtering via open_id to prevent infinite loops in groups
- Reliable @mention detection using bot open_id instead of fragile key matching
- Regex-based mention placeholder stripping for stray `@_user_N` patterns
- Async message handling with message ID dedup to prevent duplicate replies
- Commands: `/new`, `/compact`, `/model`, `/help`
- Group mode config: `mention` (default), `always`, `disabled`
- Access control via `allowed_ids`
- Onboard UI fields for encrypt_key and verification_token

## Test plan

- [x] All existing tests pass (`mise run test` with `-race`)
- [x] 54 Feishu-specific unit tests pass
- [x] Lint clean (`mise run lint` — 0 issues)
- [ ] Manual test: DM the bot, verify streaming card response
- [ ] Manual test: Send image, verify multimodal input works
- [ ] Manual test: Send rich text (post) message
- [ ] Manual test: @mention in group chat, verify bot responds
- [ ] Manual test: Verify bot ignores its own messages in group