### PR TITLE
✨ feat: add heartbeat support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Two interfaces: **interactive CLI chat** and **gateway daemon** (Telegram bot, Q
   - Private (p2p) and group @mention support
   - Access control via `allowed_ids`
 - Notification system with multi-backend dispatcher
+- Heartbeat polling with fast-model gating and proactive notifications
 - Model management CLI (`anna models list/update/set/search`)
 - Tiered model config (strong/worker/fast) with runtime model switching
 - Per-chat session management with persistent history (JSONL)
@@ -106,7 +107,14 @@ providers:
 
 provider: anthropic
 model: claude-sonnet-4-6
+
+heartbeat:
+  enabled: true
+  every: 10m
+  file: "HEARTBEAT.md"
 ```
+
+Heartbeat runs in `anna gateway` and uses the fast model for the `skip`/`run` check before forwarding `run` cases into the reserved heartbeat session.
 
 Or use environment variables:
 

--- a/config.go
+++ b/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	Workspace   string                    `yaml:"workspace"    env:"WORKSPACE"`
 	Runner      RunnerConfig              `yaml:"runner"       envPrefix:"RUNNER_"`
 	Cron        CronConfig                `yaml:"cron"         envPrefix:"CRON_"`
+	Heartbeat   HeartbeatConfig           `yaml:"heartbeat"    envPrefix:"HEARTBEAT_"`
 	Providers   map[string]ProviderConfig `yaml:"providers"`
 	Channels    ChannelsConfig            `yaml:"channels"`
 }
@@ -47,6 +48,36 @@ type CronConfig struct {
 // CronEnabled returns whether cron is enabled (defaults to true).
 func (c CronConfig) CronEnabled() bool {
 	return c.Enabled == nil || *c.Enabled
+}
+
+type HeartbeatConfig struct {
+	Enabled *bool  `yaml:"enabled" env:"ENABLED"`
+	Every   string `yaml:"every"   env:"EVERY"`
+	File    string `yaml:"file"    env:"FILE"`
+}
+
+// IsEnabled returns whether heartbeat is enabled (defaults to false).
+func (c HeartbeatConfig) IsEnabled() bool {
+	return c.Enabled != nil && *c.Enabled
+}
+
+// Interval returns the configured heartbeat cadence.
+func (c HeartbeatConfig) Interval() string {
+	if c.Every == "" {
+		return "10m"
+	}
+	return c.Every
+}
+
+// FilePath resolves the configured heartbeat file relative to the workspace.
+func (c HeartbeatConfig) FilePath(workspace string) string {
+	if c.File == "" {
+		return filepath.Join(workspace, "HEARTBEAT.md")
+	}
+	if filepath.IsAbs(c.File) {
+		return c.File
+	}
+	return filepath.Join(workspace, c.File)
 }
 
 type ProviderConfig struct {

--- a/config_test.go
+++ b/config_test.go
@@ -37,6 +37,15 @@ func TestLoadConfigDefaults(t *testing.T) {
 	if cfg.Workspace != filepath.Join(dir, "workspace") {
 		t.Errorf("Workspace = %q, want %q", cfg.Workspace, filepath.Join(dir, "workspace"))
 	}
+	if cfg.Heartbeat.IsEnabled() {
+		t.Error("Heartbeat should be disabled by default")
+	}
+	if cfg.Heartbeat.Interval() != "10m" {
+		t.Errorf("Heartbeat.Interval() = %q, want %q", cfg.Heartbeat.Interval(), "10m")
+	}
+	if cfg.Heartbeat.FilePath(cfg.Workspace) != filepath.Join(dir, "workspace", "HEARTBEAT.md") {
+		t.Errorf("Heartbeat.FilePath() = %q, want %q", cfg.Heartbeat.FilePath(cfg.Workspace), filepath.Join(dir, "workspace", "HEARTBEAT.md"))
+	}
 }
 
 func TestLoadConfigFromFile(t *testing.T) {
@@ -45,6 +54,10 @@ func TestLoadConfigFromFile(t *testing.T) {
 runner:
   type: go
   idle_timeout: 5
+heartbeat:
+  enabled: true
+  every: 15m
+  file: notes/HEARTBEAT.md
 channels:
   telegram:
     token: "test-token-123"
@@ -64,12 +77,23 @@ channels:
 	if cfg.Channels.Telegram.Token != "test-token-123" {
 		t.Errorf("Channels.Telegram.Token = %q, want %q", cfg.Channels.Telegram.Token, "test-token-123")
 	}
+	if !cfg.Heartbeat.IsEnabled() {
+		t.Error("Heartbeat should be enabled from file config")
+	}
+	if cfg.Heartbeat.Interval() != "15m" {
+		t.Errorf("Heartbeat.Interval() = %q, want %q", cfg.Heartbeat.Interval(), "15m")
+	}
+	if cfg.Heartbeat.FilePath(cfg.Workspace) != filepath.Join(cfg.Workspace, "notes/HEARTBEAT.md") {
+		t.Errorf("Heartbeat.FilePath() = %q, want %q", cfg.Heartbeat.FilePath(cfg.Workspace), filepath.Join(cfg.Workspace, "notes/HEARTBEAT.md"))
+	}
 }
 
 func TestLoadConfigEnvOverrides(t *testing.T) {
 	dir := t.TempDir()
 
 	t.Setenv("ANNA_TELEGRAM_TOKEN", "env-token")
+	t.Setenv("ANNA_HEARTBEAT_ENABLED", "true")
+	t.Setenv("ANNA_HEARTBEAT_EVERY", "30m")
 
 	cfg, err := loadConfigFrom(dir)
 	if err != nil {
@@ -78,6 +102,12 @@ func TestLoadConfigEnvOverrides(t *testing.T) {
 
 	if cfg.Channels.Telegram.Token != "env-token" {
 		t.Errorf("Channels.Telegram.Token = %q, want %q", cfg.Channels.Telegram.Token, "env-token")
+	}
+	if !cfg.Heartbeat.IsEnabled() {
+		t.Error("Heartbeat should be enabled from env")
+	}
+	if cfg.Heartbeat.Interval() != "30m" {
+		t.Errorf("Heartbeat.Interval() = %q, want %q", cfg.Heartbeat.Interval(), "30m")
 	}
 }
 

--- a/cron/cron.go
+++ b/cron/cron.go
@@ -24,6 +24,9 @@ var errOneTimeJobPast = errors.New("one-time job timestamp is in the past")
 // OnJobFunc is called when a scheduled job fires.
 type OnJobFunc func(ctx context.Context, job Job)
 
+// TaskFunc is a lightweight scheduled callback that is not persisted as a cron job.
+type TaskFunc func(ctx context.Context)
+
 // Service manages cron jobs backed by gocron/v2 with JSON persistence.
 type Service struct {
 	scheduler gocron.Scheduler
@@ -89,6 +92,30 @@ func (s *Service) Start(ctx context.Context) error {
 // Stop shuts down the scheduler.
 func (s *Service) Stop() error {
 	return s.scheduler.Shutdown()
+}
+
+// ScheduleEvery registers a non-persisted recurring task on the existing scheduler.
+func (s *Service) ScheduleEvery(ctx context.Context, every string, fn TaskFunc) error {
+	if every == "" {
+		return fmt.Errorf("every is required")
+	}
+	if fn == nil {
+		return fmt.Errorf("task function is required")
+	}
+
+	d, err := time.ParseDuration(every)
+	if err != nil {
+		return fmt.Errorf("parse duration: %w", err)
+	}
+
+	_, err = s.scheduler.NewJob(gocron.DurationJob(d), gocron.NewTask(func() {
+		fn(ctx)
+	}))
+	if err != nil {
+		return fmt.Errorf("schedule task: %w", err)
+	}
+
+	return nil
 }
 
 // AddJob creates, persists, and schedules a new job.

--- a/cron/cron.go
+++ b/cron/cron.go
@@ -63,21 +63,37 @@ func (s *Service) SetOnJob(fn OnJobFunc) {
 
 // Start loads persisted jobs and starts the scheduler.
 func (s *Service) Start(ctx context.Context) error {
-	jobs, err := s.loadJobs()
-	if err != nil {
-		return fmt.Errorf("load jobs: %w", err)
+	return s.start(ctx, true)
+}
+
+// StartEphemeral starts the shared scheduler without loading persisted cron jobs.
+// Use this when the scheduler is only needed for internal tasks such as heartbeat.
+func (s *Service) StartEphemeral(ctx context.Context) error {
+	return s.start(ctx, false)
+}
+
+func (s *Service) start(ctx context.Context, loadPersisted bool) error {
+	var jobs []Job
+	var err error
+	if loadPersisted {
+		jobs, err = s.loadJobs()
+		if err != nil {
+			return fmt.Errorf("load jobs: %w", err)
+		}
 	}
 
 	s.mu.Lock()
 	s.ctx = ctx
-	for _, j := range jobs {
-		s.jobs[j.ID] = j
-		if j.Enabled {
-			if err := s.scheduleJob(ctx, j); err != nil {
-				if errors.Is(err, errOneTimeJobPast) {
-					s.log.Info("skipping one-time job with past timestamp", "id", j.ID, "at", j.Schedule.At)
-				} else {
-					s.log.Warn("failed to schedule persisted job", "id", j.ID, "name", j.Name, "error", err)
+	if loadPersisted {
+		for _, j := range jobs {
+			s.jobs[j.ID] = j
+			if j.Enabled {
+				if err := s.scheduleJob(ctx, j); err != nil {
+					if errors.Is(err, errOneTimeJobPast) {
+						s.log.Info("skipping one-time job with past timestamp", "id", j.ID, "at", j.Schedule.At)
+					} else {
+						s.log.Warn("failed to schedule persisted job", "id", j.ID, "name", j.Name, "error", err)
+					}
 				}
 			}
 		}
@@ -85,7 +101,11 @@ func (s *Service) Start(ctx context.Context) error {
 	s.mu.Unlock()
 
 	s.scheduler.Start()
-	s.log.Info("cron service started", "jobs", len(jobs))
+	if loadPersisted {
+		s.log.Info("cron service started", "jobs", len(jobs))
+	} else {
+		s.log.Info("cron service started without persisted jobs")
+	}
 	return nil
 }
 

--- a/cron/cron_test.go
+++ b/cron/cron_test.go
@@ -157,6 +157,36 @@ func TestJobPersistenceAcrossRestart(t *testing.T) {
 	}
 }
 
+func TestStartEphemeralSkipsPersistedJobs(t *testing.T) {
+	dir := t.TempDir()
+
+	svc1, err := New(dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := svc1.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	_, err = svc1.AddJob("persist-test", "check weather", Schedule{Every: "1h"}, "")
+	if err != nil {
+		t.Fatalf("AddJob: %v", err)
+	}
+	_ = svc1.Stop()
+
+	svc2, err := New(dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := svc2.StartEphemeral(context.Background()); err != nil {
+		t.Fatalf("StartEphemeral: %v", err)
+	}
+	defer func() { _ = svc2.Stop() }()
+
+	if jobs := svc2.ListJobs(); len(jobs) != 0 {
+		t.Fatalf("ListJobs after StartEphemeral: got %d, want 0", len(jobs))
+	}
+}
+
 func TestOnJobCallbackFires(t *testing.T) {
 	dir := t.TempDir()
 	svc, err := New(dir)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,7 +85,15 @@ runner:
 cron:
   enabled: true
   data_dir: "~/.anna/workspace/cron"  # Job persistence directory
+
+# Heartbeat polling
+heartbeat:
+  enabled: false
+  every: 10m
+  file: "HEARTBEAT.md"                # Relative to workspace unless absolute
 ```
+
+Heartbeat only runs in `anna gateway`. Each tick first uses the fast model to decide `skip` vs `run`, and only `run` decisions are sent into the main heartbeat session and then delivered through the notifier.
 
 ## Directory Layout
 
@@ -98,6 +106,7 @@ cron:
 | `~/.anna/workspace/memory/` | Persistent memory (facts + journal) | Data |
 | `~/.anna/workspace/skills/` | Installed skills | Data |
 | `~/.anna/workspace/cron/` | Cron job persistence | Data |
+| `~/.anna/workspace/HEARTBEAT.md` | Heartbeat instructions | Data |
 
 - **config.yaml** is static and user-edited — safe to version control.
 - **state.yaml** is written by `anna models set` and the `/model` command. It overrides `provider` and `model` from config.yaml.
@@ -122,6 +131,9 @@ All config fields support env var overrides using the `ANNA_` prefix. Nested str
 | `ANNA_RUNNER_IDLE_TIMEOUT` | `runner.idle_timeout` | |
 | `ANNA_CRON_ENABLED` | `cron.enabled` | |
 | `ANNA_CRON_DATA_DIR` | `cron.data_dir` | |
+| `ANNA_HEARTBEAT_ENABLED` | `heartbeat.enabled` | |
+| `ANNA_HEARTBEAT_EVERY` | `heartbeat.every` | Go duration such as `10m` |
+| `ANNA_HEARTBEAT_FILE` | `heartbeat.file` | Relative to workspace unless absolute |
 | `ANNA_TELEGRAM_ENABLED` | `channels.telegram.enabled` | |
 | `ANNA_TELEGRAM_ENABLE_NOTIFY` | `channels.telegram.enable_notify` | |
 | `ANNA_TELEGRAM_TOKEN` | `channels.telegram.token` | |
@@ -162,6 +174,9 @@ All config fields support env var overrides using the `ANNA_` prefix. Nested str
 | `runner.compaction.keep_tail` | `20` |
 | `cron.enabled` | `true` |
 | `cron.data_dir` | `~/.anna/workspace/cron` |
+| `heartbeat.enabled` | `false` |
+| `heartbeat.every` | `10m` |
+| `heartbeat.file` | `~/.anna/workspace/HEARTBEAT.md` |
 | `channels.telegram.enabled` | `true` |
 | `channels.telegram.enable_notify` | `false` |
 | `channels.telegram.group_mode` | `mention` |

--- a/heartbeat/service.go
+++ b/heartbeat/service.go
@@ -1,0 +1,200 @@
+package heartbeat
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/vaayne/anna/agent/runner"
+	"github.com/vaayne/anna/channel"
+)
+
+const (
+	decisionSessionID = "heartbeat:decision"
+	mainSessionID     = "heartbeat:main"
+)
+
+type ChatFunc func(ctx context.Context, sessionID, message, model string) <-chan runner.Event
+
+type Config struct {
+	File      string
+	FastModel string
+}
+
+type Service struct {
+	cfg      Config
+	chat     ChatFunc
+	notifier channel.Notifier
+	now      func() time.Time
+	log      *slog.Logger
+}
+
+type Decision struct {
+	Action string `json:"action"`
+	Reason string `json:"reason,omitempty"`
+}
+
+func New(cfg Config, chat ChatFunc, notifier channel.Notifier) *Service {
+	return &Service{
+		cfg:      cfg,
+		chat:     chat,
+		notifier: notifier,
+		now:      time.Now,
+		log:      slog.With("component", "heartbeat"),
+	}
+}
+
+func (s *Service) Poll(ctx context.Context) error {
+	if s == nil {
+		return fmt.Errorf("heartbeat service is nil")
+	}
+	if s.chat == nil {
+		return fmt.Errorf("heartbeat chat function is nil")
+	}
+
+	content, err := s.readHeartbeatFile()
+	if err != nil {
+		return err
+	}
+	if content == "" {
+		return nil
+	}
+
+	decision, err := s.decide(ctx, content)
+	if err != nil {
+		return err
+	}
+	if decision.Action == "skip" {
+		s.log.Debug("heartbeat skipped", "reason", decision.Reason)
+		return nil
+	}
+
+	result, err := s.execute(ctx, content)
+	if err != nil {
+		return err
+	}
+	result = strings.TrimSpace(result)
+	if result == "" {
+		return nil
+	}
+
+	text := "*Heartbeat*\n\n" + result
+	if err := s.notifier.Notify(ctx, channel.Notification{Text: text}); err != nil {
+		return fmt.Errorf("notify heartbeat result: %w", err)
+	}
+
+	s.log.Info("heartbeat executed", "reason", decision.Reason)
+	return nil
+}
+
+func (s *Service) readHeartbeatFile() (string, error) {
+	if strings.TrimSpace(s.cfg.File) == "" {
+		return "", fmt.Errorf("heartbeat file is not configured")
+	}
+
+	data, err := os.ReadFile(s.cfg.File)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("read heartbeat file: %w", err)
+	}
+
+	return strings.TrimSpace(string(data)), nil
+}
+
+func (s *Service) decide(ctx context.Context, content string) (Decision, error) {
+	prompt := buildDecisionPrompt(s.now().UTC(), content)
+	text, usedTools, err := s.collect(ctx, decisionSessionID, prompt, s.cfg.FastModel)
+	if err != nil {
+		return Decision{}, err
+	}
+	if usedTools {
+		return Decision{}, fmt.Errorf("heartbeat decision attempted to use tools")
+	}
+
+	decision, err := parseDecision(text)
+	if err != nil {
+		return Decision{}, fmt.Errorf("parse heartbeat decision: %w", err)
+	}
+	return decision, nil
+}
+
+func (s *Service) execute(ctx context.Context, content string) (string, error) {
+	prompt := buildExecutionPrompt(s.now().UTC(), content)
+	text, _, err := s.collect(ctx, mainSessionID, prompt, "")
+	if err != nil {
+		return "", err
+	}
+	return text, nil
+}
+
+func (s *Service) collect(ctx context.Context, sessionID, message, model string) (string, bool, error) {
+	stream := s.chat(ctx, sessionID, message, model)
+	var buf strings.Builder
+	usedTools := false
+
+	for evt := range stream {
+		if evt.Err != nil {
+			return buf.String(), usedTools, evt.Err
+		}
+		if evt.ToolUse != nil {
+			usedTools = true
+		}
+		if evt.Text != "" {
+			buf.WriteString(evt.Text)
+		}
+	}
+
+	return buf.String(), usedTools, nil
+}
+
+func parseDecision(raw string) (Decision, error) {
+	var decision Decision
+	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &decision); err != nil {
+		return Decision{}, err
+	}
+
+	decision.Action = strings.ToLower(strings.TrimSpace(decision.Action))
+	switch decision.Action {
+	case "skip", "run":
+		return decision, nil
+	default:
+		return Decision{}, fmt.Errorf("unsupported action %q", decision.Action)
+	}
+}
+
+func buildDecisionPrompt(now time.Time, content string) string {
+	return fmt.Sprintf(`You are the heartbeat gate for an autonomous assistant.
+Decide whether the heartbeat instructions need action right now.
+
+Rules:
+- Return JSON only.
+- Do not call any tools.
+- Use exactly one of the following actions: "skip" or "run".
+- Keep the reason short.
+
+Response schema:
+{"action":"skip","reason":"..."}
+
+Current time (UTC): %s
+
+HEARTBEAT.md:
+%s`, now.Format(time.RFC3339), content)
+}
+
+func buildExecutionPrompt(now time.Time, content string) string {
+	return fmt.Sprintf(`[Heartbeat Trigger]
+Current time (UTC): %s
+
+The heartbeat gate already decided this requires action now.
+Follow the instructions below.
+Do not use the notify tool. Your final response will be delivered automatically.
+
+HEARTBEAT.md:
+%s`, now.Format(time.RFC3339), content)
+}

--- a/heartbeat/service_test.go
+++ b/heartbeat/service_test.go
@@ -1,0 +1,189 @@
+package heartbeat
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vaayne/anna/agent/runner"
+	"github.com/vaayne/anna/channel"
+)
+
+type chatCall struct {
+	sessionID string
+	message   string
+	model     string
+}
+
+type fakeNotifier struct {
+	calls []channel.Notification
+	err   error
+}
+
+func (f *fakeNotifier) Notify(_ context.Context, n channel.Notification) error {
+	f.calls = append(f.calls, n)
+	return f.err
+}
+
+func makeChatFunc(calls *[]chatCall, responses map[string][]runner.Event) ChatFunc {
+	return func(_ context.Context, sessionID, message, model string) <-chan runner.Event {
+		*calls = append(*calls, chatCall{
+			sessionID: sessionID,
+			message:   message,
+			model:     model,
+		})
+
+		out := make(chan runner.Event, len(responses[sessionID]))
+		for _, evt := range responses[sessionID] {
+			out <- evt
+		}
+		close(out)
+		return out
+	}
+}
+
+func TestPollSkipsMissingHeartbeatFile(t *testing.T) {
+	var calls []chatCall
+	notifier := &fakeNotifier{}
+	svc := New(Config{
+		File:      filepath.Join(t.TempDir(), "HEARTBEAT.md"),
+		FastModel: "fast-model",
+	}, makeChatFunc(&calls, nil), notifier)
+
+	if err := svc.Poll(context.Background()); err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+
+	if len(calls) != 0 {
+		t.Fatalf("expected no chat calls, got %d", len(calls))
+	}
+	if len(notifier.calls) != 0 {
+		t.Fatalf("expected no notifications, got %d", len(notifier.calls))
+	}
+}
+
+func TestPollSkipDecisionUsesFastModel(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "HEARTBEAT.md")
+	if err := os.WriteFile(path, []byte("Check if anything needs doing."), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	var calls []chatCall
+	notifier := &fakeNotifier{}
+	svc := New(Config{
+		File:      path,
+		FastModel: "fast-model",
+	}, makeChatFunc(&calls, map[string][]runner.Event{
+		decisionSessionID: {{Text: `{"action":"skip","reason":"nothing pending"}`}},
+	}), notifier)
+
+	if err := svc.Poll(context.Background()); err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 chat call, got %d", len(calls))
+	}
+	if calls[0].sessionID != decisionSessionID {
+		t.Fatalf("sessionID = %q, want %q", calls[0].sessionID, decisionSessionID)
+	}
+	if calls[0].model != "fast-model" {
+		t.Fatalf("model = %q, want %q", calls[0].model, "fast-model")
+	}
+	if len(notifier.calls) != 0 {
+		t.Fatalf("expected no notifications, got %d", len(notifier.calls))
+	}
+}
+
+func TestPollRunDecisionExecutesAndNotifies(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "HEARTBEAT.md")
+	if err := os.WriteFile(path, []byte("Review the workspace and report actionable changes."), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	var calls []chatCall
+	notifier := &fakeNotifier{}
+	svc := New(Config{
+		File:      path,
+		FastModel: "fast-model",
+	}, makeChatFunc(&calls, map[string][]runner.Event{
+		decisionSessionID: {{Text: `{"action":"run","reason":"new work detected"}`}},
+		mainSessionID:     {{Text: "Action complete."}},
+	}), notifier)
+
+	if err := svc.Poll(context.Background()); err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 chat calls, got %d", len(calls))
+	}
+	if calls[0].sessionID != decisionSessionID || calls[0].model != "fast-model" {
+		t.Fatalf("unexpected decision call: %+v", calls[0])
+	}
+	if calls[1].sessionID != mainSessionID || calls[1].model != "" {
+		t.Fatalf("unexpected main call: %+v", calls[1])
+	}
+	if len(notifier.calls) != 1 {
+		t.Fatalf("expected 1 notification, got %d", len(notifier.calls))
+	}
+	if notifier.calls[0].Text != "*Heartbeat*\n\nAction complete." {
+		t.Fatalf("notification text = %q", notifier.calls[0].Text)
+	}
+}
+
+func TestPollFailsWhenDecisionUsesTools(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "HEARTBEAT.md")
+	if err := os.WriteFile(path, []byte("Ping if needed."), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	var calls []chatCall
+	svc := New(Config{
+		File:      path,
+		FastModel: "fast-model",
+	}, makeChatFunc(&calls, map[string][]runner.Event{
+		decisionSessionID: {{
+			ToolUse: &runner.ToolUseEvent{Tool: "bash", Status: "running"},
+		}},
+	}), &fakeNotifier{})
+
+	err := svc.Poll(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if err.Error() != "heartbeat decision attempted to use tools" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPollReturnsNotifierError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "HEARTBEAT.md")
+	if err := os.WriteFile(path, []byte("Act now."), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	var calls []chatCall
+	notifier := &fakeNotifier{err: errors.New("notify failed")}
+	svc := New(Config{
+		File:      path,
+		FastModel: "fast-model",
+	}, makeChatFunc(&calls, map[string][]runner.Event{
+		decisionSessionID: {{Text: `{"action":"run","reason":"do it"}`}},
+		mainSessionID:     {{Text: "Done."}},
+	}), notifier)
+
+	err := svc.Poll(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if err.Error() != "notify heartbeat result: notify failed" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/vaayne/anna/channel/qq"
 	"github.com/vaayne/anna/channel/telegram"
 	"github.com/vaayne/anna/cron"
+	"github.com/vaayne/anna/heartbeat"
 	"github.com/vaayne/anna/memory"
 	"github.com/vaayne/anna/skills"
 	"golang.org/x/sync/errgroup"
@@ -120,6 +121,7 @@ type setupResult struct {
 	cfg        *Config
 	pool       *agent.Pool
 	cronSvc    *cron.Service
+	heartbeat  *heartbeat.Service
 	memStore   *memory.Store
 	extraTools []tool.Tool
 	notifier   *channel.Dispatcher
@@ -138,12 +140,14 @@ func setup(parent context.Context, gateway bool) (*setupResult, error) {
 	// can be injected into the Go runner.
 	var cronSvc *cron.Service
 	var extraTools []tool.Tool
-	if cfg.Cron.CronEnabled() {
+	if cfg.Cron.CronEnabled() || (gateway && cfg.Heartbeat.IsEnabled()) {
 		cronSvc, err = cron.New(cfg.Cron.DataDir)
 		if err != nil {
 			return nil, fmt.Errorf("create cron service: %w", err)
 		}
-		extraTools = append(extraTools, cron.NewTool(cronSvc))
+		if cfg.Cron.CronEnabled() {
+			extraTools = append(extraTools, cron.NewTool(cronSvc))
+		}
 	}
 
 	// Memory store + tool — always available.
@@ -187,6 +191,19 @@ func setup(parent context.Context, gateway bool) (*setupResult, error) {
 	pool := agent.NewPool(factory, opts...)
 	go pool.StartReaper(ctx)
 
+	var heartbeatSvc *heartbeat.Service
+	if cfg.Heartbeat.IsEnabled() {
+		heartbeatSvc = heartbeat.New(heartbeat.Config{
+			File:      cfg.Heartbeat.FilePath(cfg.Workspace),
+			FastModel: cfg.resolveModelID(ModelTierFast),
+		}, func(ctx context.Context, sessionID, message, model string) <-chan runner.Event {
+			if model != "" {
+				return pool.Chat(ctx, sessionID, message, agent.WithModel(model))
+			}
+			return pool.Chat(ctx, sessionID, message)
+		}, dispatcher)
+	}
+
 	// Wire the cron callback now that pool exists.
 	if cronSvc != nil {
 		cronSvc.SetOnJob(func(ctx context.Context, job cron.Job) {
@@ -206,6 +223,7 @@ func setup(parent context.Context, gateway bool) (*setupResult, error) {
 		cfg:        cfg,
 		pool:       pool,
 		cronSvc:    cronSvc,
+		heartbeat:  heartbeatSvc,
 		memStore:   memStore,
 		extraTools: extraTools,
 		notifier:   dispatcher,
@@ -366,11 +384,22 @@ func runGateway(ctx context.Context, s *setupResult, listFn channel.ModelListFun
 	// Wire cron notifications and start the scheduler AFTER channels
 	// are registered, so early-firing jobs already use the dispatcher.
 	if s.cronSvc != nil {
-		wireCronNotifier(s.cronSvc, s.pool, s.notifier)
+		if s.cfg.Cron.CronEnabled() {
+			wireCronNotifier(s.cronSvc, s.pool, s.notifier)
+		}
 		if err := s.cronSvc.Start(ctx); err != nil {
 			return fmt.Errorf("start cron: %w", err)
 		}
 		defer func() { _ = s.cronSvc.Stop() }()
+	}
+
+	if s.heartbeat != nil {
+		if s.cronSvc == nil {
+			return fmt.Errorf("heartbeat requires the shared scheduler")
+		}
+		if err := scheduleHeartbeat(ctx, s.cronSvc, s.heartbeat, s.cfg.Heartbeat.Interval()); err != nil {
+			return fmt.Errorf("schedule heartbeat: %w", err)
+		}
 	}
 
 	err := g.Wait()
@@ -398,6 +427,15 @@ func wireCronNotifier(cronSvc *cron.Service, pool *agent.Pool, dispatcher *chann
 			if err := dispatcher.Notify(ctx, channel.Notification{Text: text}); err != nil {
 				slog.Error("cron notification failed", "job_id", job.ID, "error", err)
 			}
+		}
+	})
+}
+
+func scheduleHeartbeat(ctx context.Context, cronSvc *cron.Service, heartbeatSvc *heartbeat.Service, every string) error {
+	slog.Info("starting heartbeat", "every", every)
+	return cronSvc.ScheduleEvery(ctx, every, func(ctx context.Context) {
+		if err := heartbeatSvc.Poll(ctx); err != nil {
+			slog.Error("heartbeat poll failed", "error", err)
 		}
 	})
 }

--- a/main.go
+++ b/main.go
@@ -386,9 +386,13 @@ func runGateway(ctx context.Context, s *setupResult, listFn channel.ModelListFun
 	if s.cronSvc != nil {
 		if s.cfg.Cron.CronEnabled() {
 			wireCronNotifier(s.cronSvc, s.pool, s.notifier)
-		}
-		if err := s.cronSvc.Start(ctx); err != nil {
-			return fmt.Errorf("start cron: %w", err)
+			if err := s.cronSvc.Start(ctx); err != nil {
+				return fmt.Errorf("start cron: %w", err)
+			}
+		} else {
+			if err := s.cronSvc.StartEphemeral(ctx); err != nil {
+				return fmt.Errorf("start shared scheduler: %w", err)
+			}
 		}
 		defer func() { _ = s.cronSvc.Stop() }()
 	}


### PR DESCRIPTION
## Summary
- add configurable gateway heartbeat support backed by the workspace HEARTBEAT.md file
- use the fast model for heartbeat skip/run gating and only execute run cases in the reserved heartbeat session
- reuse the shared cron scheduler, add tests, and document the new configuration

## Testing
- go test ./...
