### PR TITLE
Add version and self-upgrade commands

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,6 +8,8 @@ builds:
   - id: anna
     main: .
     binary: anna
+    ldflags:
+      - -s -w -X main.version={{ .Version }}
     env:
       - CGO_ENABLED=0
     goos:

--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ anna gateway
 
 Starts all configured services (Telegram bot, QQ bot, Feishu bot, cron scheduler). Services are activated based on config.
 
+### Version And Upgrades
+
+```bash
+anna version
+anna upgrade
+anna upgrade --install-dir "$HOME/.local/bin"
+```
+
+`anna version` prints the running build version. `anna upgrade` downloads the latest stable GitHub release for the current platform and installs `anna` into `$HOME/.local/bin` by default.
+
 ### Model Management
 
 ```bash

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -53,6 +53,16 @@ Or use the interactive CLI:
 anna chat
 ```
 
+### Version And Self-Upgrade
+
+```bash
+anna version
+anna upgrade
+anna upgrade --install-dir "$HOME/.local/bin"
+```
+
+`anna upgrade` fetches the latest stable release from GitHub, downloads the matching archive for the current OS/architecture, and installs the binary into `$HOME/.local/bin` by default.
+
 ### Systemd Service (Linux)
 
 ```ini

--- a/main.go
+++ b/main.go
@@ -43,14 +43,17 @@ func main() {
 
 func newApp() *ucli.App {
 	return &ucli.App{
-		Name:  "anna",
-		Usage: "A local AI assistant",
+		Name:    "anna",
+		Usage:   "A local AI assistant",
+		Version: displayVersion(),
 		Commands: []*ucli.Command{
 			chatCommand(),
 			gatewayCommand(),
 			modelsCommand(),
 			skillsCommand(),
 			onboardCommand(),
+			versionCommand(),
+			upgradeCommand(),
 		},
 	}
 }

--- a/mise.toml
+++ b/mise.toml
@@ -12,7 +12,7 @@ BINARY_NAME = "anna"
 
 [tasks.build]
 description = "Build anna binary"
-run = "go build -o bin/$BINARY_NAME ."
+run = "VERSION=${VERSION:-$(git describe --tags --always --dirty 2>/dev/null || echo dev)} && go build -ldflags=\"-X main.version=$VERSION\" -o bin/$BINARY_NAME ."
 
 [tasks.clean]
 description = "Remove build artifacts"

--- a/version_cmd.go
+++ b/version_cmd.go
@@ -30,6 +30,7 @@ var (
 	upgradeAPIBaseURL   = "https://api.github.com"
 	upgradeUserAgent    = "anna-upgrade"
 	errUnsupportedAsset = errors.New("no release asset for current platform")
+	errInvalidTarget    = errors.New("existing target is not a replaceable file")
 	renameFile          = os.Rename
 )
 
@@ -113,7 +114,7 @@ func defaultInstallDir() (string, error) {
 	return filepath.Join(home, ".local", "bin"), nil
 }
 
-func fetchLatestRelease(ctx context.Context) (*githubRelease, error) {
+func fetchLatestRelease(ctx context.Context) (release *githubRelease, err error) {
 	url := strings.TrimRight(upgradeAPIBaseURL, "/") + "/repos/" + githubOwner + "/" + githubRepo + "/releases/latest"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -126,21 +127,25 @@ func fetchLatestRelease(ctx context.Context) (*githubRelease, error) {
 	if err != nil {
 		return nil, fmt.Errorf("fetch latest release: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("close release response body: %w", closeErr)
+		}
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
 		return nil, fmt.Errorf("fetch latest release: unexpected status %s: %s", resp.Status, strings.TrimSpace(string(body)))
 	}
 
-	var release githubRelease
-	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+	var parsed githubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
 		return nil, fmt.Errorf("decode release response: %w", err)
 	}
-	if normalizeVersion(release.TagName) == "" {
-		return nil, fmt.Errorf("latest release tag %q is invalid", release.TagName)
+	if normalizeVersion(parsed.TagName) == "" {
+		return nil, fmt.Errorf("latest release tag %q is invalid", parsed.TagName)
 	}
-	return &release, nil
+	return &parsed, nil
 }
 
 func runUpgrade(ctx context.Context, installDir, currentVersion, goos, goarch string) (*upgradeResult, error) {
@@ -194,7 +199,7 @@ func releaseAssetSuffixes(goos, goarch string) []string {
 	return []string{base + ".tar.gz", base + ".zip"}
 }
 
-func installReleaseAsset(ctx context.Context, asset githubReleaseAsset, installDir, goos string) (string, error) {
+func installReleaseAsset(ctx context.Context, asset githubReleaseAsset, installDir, goos string) (targetPath string, err error) {
 	if err := os.MkdirAll(installDir, 0o755); err != nil {
 		return "", fmt.Errorf("create install dir: %w", err)
 	}
@@ -203,7 +208,11 @@ func installReleaseAsset(ctx context.Context, asset githubReleaseAsset, installD
 	if err != nil {
 		return "", fmt.Errorf("create temp dir: %w", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() {
+		if removeErr := os.RemoveAll(tmpDir); removeErr != nil && err == nil {
+			err = fmt.Errorf("cleanup temp dir: %w", removeErr)
+		}
+	}()
 
 	archivePath := filepath.Join(tmpDir, asset.Name)
 	if err := downloadFile(ctx, asset.BrowserDownloadURL, archivePath); err != nil {
@@ -216,14 +225,14 @@ func installReleaseAsset(ctx context.Context, asset githubReleaseAsset, installD
 		return "", err
 	}
 
-	targetPath := filepath.Join(installDir, binaryName)
+	targetPath = filepath.Join(installDir, binaryName)
 	if err := installBinary(extractedPath, targetPath, goos != "windows"); err != nil {
 		return "", err
 	}
 	return targetPath, nil
 }
 
-func downloadFile(ctx context.Context, url, dest string) error {
+func downloadFile(ctx context.Context, url, dest string) (err error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return fmt.Errorf("build asset request: %w", err)
@@ -234,7 +243,11 @@ func downloadFile(ctx context.Context, url, dest string) error {
 	if err != nil {
 		return fmt.Errorf("download asset: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("close asset response body: %w", closeErr)
+		}
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
@@ -245,10 +258,12 @@ func downloadFile(ctx context.Context, url, dest string) error {
 	if err != nil {
 		return fmt.Errorf("create archive file: %w", err)
 	}
-	defer out.Close()
-
 	if _, err := io.Copy(out, resp.Body); err != nil {
+		_ = out.Close()
 		return fmt.Errorf("write archive file: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("close archive file: %w", err)
 	}
 	return nil
 }
@@ -264,18 +279,26 @@ func extractBinaryFromArchive(archivePath, destDir, binaryName string) (string, 
 	}
 }
 
-func extractBinaryFromTarGz(archivePath, destDir, binaryName string) (string, error) {
+func extractBinaryFromTarGz(archivePath, destDir, binaryName string) (outPath string, err error) {
 	file, err := os.Open(archivePath)
 	if err != nil {
 		return "", fmt.Errorf("open archive: %w", err)
 	}
-	defer file.Close()
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("close archive: %w", closeErr)
+		}
+	}()
 
 	gzReader, err := gzip.NewReader(file)
 	if err != nil {
 		return "", fmt.Errorf("open gzip archive: %w", err)
 	}
-	defer gzReader.Close()
+	defer func() {
+		if closeErr := gzReader.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("close gzip archive: %w", closeErr)
+		}
+	}()
 
 	tarReader := tar.NewReader(gzReader)
 	for {
@@ -292,7 +315,7 @@ func extractBinaryFromTarGz(archivePath, destDir, binaryName string) (string, er
 		if filepath.Base(header.Name) != binaryName {
 			continue
 		}
-		outPath := filepath.Join(destDir, binaryName)
+		outPath = filepath.Join(destDir, binaryName)
 		if err := writeReaderToFile(outPath, tarReader, 0o755); err != nil {
 			return "", err
 		}
@@ -301,12 +324,16 @@ func extractBinaryFromTarGz(archivePath, destDir, binaryName string) (string, er
 	return "", fmt.Errorf("binary %q not found in archive", binaryName)
 }
 
-func extractBinaryFromZip(archivePath, destDir, binaryName string) (string, error) {
+func extractBinaryFromZip(archivePath, destDir, binaryName string) (outPath string, err error) {
 	reader, err := zip.OpenReader(archivePath)
 	if err != nil {
 		return "", fmt.Errorf("open zip archive: %w", err)
 	}
-	defer reader.Close()
+	defer func() {
+		if closeErr := reader.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("close zip archive: %w", closeErr)
+		}
+	}()
 
 	for _, file := range reader.File {
 		if filepath.Base(file.Name) != binaryName {
@@ -316,7 +343,7 @@ func extractBinaryFromZip(archivePath, destDir, binaryName string) (string, erro
 		if err != nil {
 			return "", fmt.Errorf("open zip entry: %w", err)
 		}
-		outPath := filepath.Join(destDir, binaryName)
+		outPath = filepath.Join(destDir, binaryName)
 		writeErr := writeReaderToFile(outPath, rc, 0o755)
 		closeErr := rc.Close()
 		if writeErr != nil {
@@ -335,10 +362,13 @@ func writeReaderToFile(path string, reader io.Reader, mode os.FileMode) error {
 	if err != nil {
 		return fmt.Errorf("create extracted binary: %w", err)
 	}
-	defer out.Close()
 
 	if _, err := io.Copy(out, reader); err != nil {
+		_ = out.Close()
 		return fmt.Errorf("write extracted binary: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("close extracted binary: %w", err)
 	}
 	return nil
 }
@@ -350,7 +380,6 @@ func installBinary(srcPath, targetPath string, executable bool) error {
 	if err != nil {
 		return fmt.Errorf("open extracted binary: %w", err)
 	}
-	defer in.Close()
 
 	mode := os.FileMode(0o644)
 	if executable {
@@ -362,9 +391,13 @@ func installBinary(srcPath, targetPath string, executable bool) error {
 	}
 
 	_, copyErr := io.Copy(out, in)
+	inputCloseErr := in.Close()
 	closeErr := out.Close()
 	if copyErr != nil {
 		return fmt.Errorf("write temp install file: %w", copyErr)
+	}
+	if inputCloseErr != nil {
+		return fmt.Errorf("close extracted binary: %w", inputCloseErr)
 	}
 	if closeErr != nil {
 		return fmt.Errorf("close temp install file: %w", closeErr)
@@ -376,7 +409,12 @@ func installBinary(srcPath, targetPath string, executable bool) error {
 		}
 	}
 
-	if _, err := os.Stat(targetPath); err == nil {
+	if err := ensureReplaceableTarget(targetPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+
+	if _, err := os.Lstat(targetPath); err == nil {
 		if err := renameFile(targetPath, backupPath); err != nil {
 			_ = os.Remove(tmpPath)
 			return fmt.Errorf("move existing binary aside: %w", err)
@@ -403,6 +441,22 @@ func installBinary(srcPath, targetPath string, executable bool) error {
 		}
 	}
 	return nil
+}
+
+func ensureReplaceableTarget(targetPath string) error {
+	info, err := os.Lstat(targetPath)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("stat existing target: %w", err)
+	}
+
+	mode := info.Mode()
+	if mode.IsRegular() || mode&os.ModeSymlink != 0 {
+		return nil
+	}
+	return fmt.Errorf("%w: %s", errInvalidTarget, targetPath)
 }
 
 func binaryNameForGOOS(goos string) string {

--- a/version_cmd.go
+++ b/version_cmd.go
@@ -1,0 +1,433 @@
+package main
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	ucli "github.com/urfave/cli/v2"
+)
+
+const (
+	githubOwner = "vaayne"
+	githubRepo  = "anna"
+)
+
+var (
+	version             = "dev"
+	upgradeHTTPClient   = &http.Client{Timeout: 30 * time.Second}
+	upgradeAPIBaseURL   = "https://api.github.com"
+	upgradeUserAgent    = "anna-upgrade"
+	errUnsupportedAsset = errors.New("no release asset for current platform")
+	renameFile          = os.Rename
+)
+
+type githubRelease struct {
+	TagName string               `json:"tag_name"`
+	Assets  []githubReleaseAsset `json:"assets"`
+}
+
+type githubReleaseAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+type upgradeResult struct {
+	CurrentVersion string
+	LatestVersion  string
+	TargetPath     string
+	AlreadyCurrent bool
+}
+
+func versionCommand() *ucli.Command {
+	return &ucli.Command{
+		Name:  "version",
+		Usage: "Show the current anna version",
+		Action: func(c *ucli.Context) error {
+			fmt.Println(displayVersion())
+			return nil
+		},
+	}
+}
+
+func upgradeCommand() *ucli.Command {
+	return &ucli.Command{
+		Name:  "upgrade",
+		Usage: "Upgrade anna to the latest stable GitHub release",
+		Flags: []ucli.Flag{
+			&ucli.StringFlag{
+				Name:  "install-dir",
+				Usage: "Directory to install the upgraded binary into",
+			},
+		},
+		Action: func(c *ucli.Context) error {
+			installDir := c.String("install-dir")
+			if installDir == "" {
+				dir, err := defaultInstallDir()
+				if err != nil {
+					return err
+				}
+				installDir = dir
+			}
+
+			result, err := runUpgrade(c.Context, installDir, displayVersion(), runtime.GOOS, runtime.GOARCH)
+			if err != nil {
+				return err
+			}
+			if result.AlreadyCurrent {
+				fmt.Printf("anna %s is already up to date\n", result.CurrentVersion)
+				return nil
+			}
+
+			fmt.Printf("Upgraded anna from %s to %s\n", result.CurrentVersion, result.LatestVersion)
+			fmt.Printf("Installed to %s\n", result.TargetPath)
+			return nil
+		},
+	}
+}
+
+func displayVersion() string {
+	normalized := normalizeVersion(version)
+	if normalized == "" {
+		return "dev"
+	}
+	return normalized
+}
+
+func defaultInstallDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+	return filepath.Join(home, ".local", "bin"), nil
+}
+
+func fetchLatestRelease(ctx context.Context) (*githubRelease, error) {
+	url := strings.TrimRight(upgradeAPIBaseURL, "/") + "/repos/" + githubOwner + "/" + githubRepo + "/releases/latest"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build release request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", upgradeUserAgent)
+
+	resp, err := upgradeHTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch latest release: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
+		return nil, fmt.Errorf("fetch latest release: unexpected status %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+
+	var release githubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return nil, fmt.Errorf("decode release response: %w", err)
+	}
+	if normalizeVersion(release.TagName) == "" {
+		return nil, fmt.Errorf("latest release tag %q is invalid", release.TagName)
+	}
+	return &release, nil
+}
+
+func runUpgrade(ctx context.Context, installDir, currentVersion, goos, goarch string) (*upgradeResult, error) {
+	release, err := fetchLatestRelease(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &upgradeResult{
+		CurrentVersion: normalizeVersion(currentVersion),
+		LatestVersion:  normalizeVersion(release.TagName),
+	}
+	if result.CurrentVersion == "" {
+		result.CurrentVersion = "dev"
+	}
+	if result.LatestVersion == "" {
+		return nil, fmt.Errorf("latest release tag %q is invalid", release.TagName)
+	}
+	if result.LatestVersion == normalizeVersion(currentVersion) {
+		result.AlreadyCurrent = true
+		return result, nil
+	}
+
+	asset, err := selectReleaseAsset(release.Assets, goos, goarch)
+	if err != nil {
+		return nil, err
+	}
+
+	targetPath, err := installReleaseAsset(ctx, asset, installDir, goos)
+	if err != nil {
+		return nil, err
+	}
+	result.TargetPath = targetPath
+	return result, nil
+}
+
+func selectReleaseAsset(assets []githubReleaseAsset, goos, goarch string) (githubReleaseAsset, error) {
+	suffixes := releaseAssetSuffixes(goos, goarch)
+	for _, asset := range assets {
+		for _, suffix := range suffixes {
+			if strings.HasSuffix(asset.Name, suffix) {
+				return asset, nil
+			}
+		}
+	}
+	return githubReleaseAsset{}, fmt.Errorf("%w: %s/%s", errUnsupportedAsset, goos, goarch)
+}
+
+func releaseAssetSuffixes(goos, goarch string) []string {
+	base := "_" + goos + "_" + goarch
+	return []string{base + ".tar.gz", base + ".zip"}
+}
+
+func installReleaseAsset(ctx context.Context, asset githubReleaseAsset, installDir, goos string) (string, error) {
+	if err := os.MkdirAll(installDir, 0o755); err != nil {
+		return "", fmt.Errorf("create install dir: %w", err)
+	}
+
+	tmpDir, err := os.MkdirTemp("", "anna-upgrade-*")
+	if err != nil {
+		return "", fmt.Errorf("create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	archivePath := filepath.Join(tmpDir, asset.Name)
+	if err := downloadFile(ctx, asset.BrowserDownloadURL, archivePath); err != nil {
+		return "", err
+	}
+
+	binaryName := binaryNameForGOOS(goos)
+	extractedPath, err := extractBinaryFromArchive(archivePath, tmpDir, binaryName)
+	if err != nil {
+		return "", err
+	}
+
+	targetPath := filepath.Join(installDir, binaryName)
+	if err := installBinary(extractedPath, targetPath, goos != "windows"); err != nil {
+		return "", err
+	}
+	return targetPath, nil
+}
+
+func downloadFile(ctx context.Context, url, dest string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("build asset request: %w", err)
+	}
+	req.Header.Set("User-Agent", upgradeUserAgent)
+
+	resp, err := upgradeHTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("download asset: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
+		return fmt.Errorf("download asset: unexpected status %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+
+	out, err := os.Create(dest)
+	if err != nil {
+		return fmt.Errorf("create archive file: %w", err)
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, resp.Body); err != nil {
+		return fmt.Errorf("write archive file: %w", err)
+	}
+	return nil
+}
+
+func extractBinaryFromArchive(archivePath, destDir, binaryName string) (string, error) {
+	switch {
+	case strings.HasSuffix(archivePath, ".tar.gz"):
+		return extractBinaryFromTarGz(archivePath, destDir, binaryName)
+	case strings.HasSuffix(archivePath, ".zip"):
+		return extractBinaryFromZip(archivePath, destDir, binaryName)
+	default:
+		return "", fmt.Errorf("unsupported archive format: %s", filepath.Base(archivePath))
+	}
+}
+
+func extractBinaryFromTarGz(archivePath, destDir, binaryName string) (string, error) {
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return "", fmt.Errorf("open archive: %w", err)
+	}
+	defer file.Close()
+
+	gzReader, err := gzip.NewReader(file)
+	if err != nil {
+		return "", fmt.Errorf("open gzip archive: %w", err)
+	}
+	defer gzReader.Close()
+
+	tarReader := tar.NewReader(gzReader)
+	for {
+		header, err := tarReader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return "", fmt.Errorf("read tar archive: %w", err)
+		}
+		if header.Typeflag != tar.TypeReg {
+			continue
+		}
+		if filepath.Base(header.Name) != binaryName {
+			continue
+		}
+		outPath := filepath.Join(destDir, binaryName)
+		if err := writeReaderToFile(outPath, tarReader, 0o755); err != nil {
+			return "", err
+		}
+		return outPath, nil
+	}
+	return "", fmt.Errorf("binary %q not found in archive", binaryName)
+}
+
+func extractBinaryFromZip(archivePath, destDir, binaryName string) (string, error) {
+	reader, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return "", fmt.Errorf("open zip archive: %w", err)
+	}
+	defer reader.Close()
+
+	for _, file := range reader.File {
+		if filepath.Base(file.Name) != binaryName {
+			continue
+		}
+		rc, err := file.Open()
+		if err != nil {
+			return "", fmt.Errorf("open zip entry: %w", err)
+		}
+		outPath := filepath.Join(destDir, binaryName)
+		writeErr := writeReaderToFile(outPath, rc, 0o755)
+		closeErr := rc.Close()
+		if writeErr != nil {
+			return "", writeErr
+		}
+		if closeErr != nil {
+			return "", fmt.Errorf("close zip entry: %w", closeErr)
+		}
+		return outPath, nil
+	}
+	return "", fmt.Errorf("binary %q not found in archive", binaryName)
+}
+
+func writeReaderToFile(path string, reader io.Reader, mode os.FileMode) error {
+	out, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode)
+	if err != nil {
+		return fmt.Errorf("create extracted binary: %w", err)
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, reader); err != nil {
+		return fmt.Errorf("write extracted binary: %w", err)
+	}
+	return nil
+}
+
+func installBinary(srcPath, targetPath string, executable bool) error {
+	tmpPath := targetPath + ".tmp"
+	backupPath := targetPath + ".bak"
+	in, err := os.Open(srcPath)
+	if err != nil {
+		return fmt.Errorf("open extracted binary: %w", err)
+	}
+	defer in.Close()
+
+	mode := os.FileMode(0o644)
+	if executable {
+		mode = 0o755
+	}
+	out, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode)
+	if err != nil {
+		return fmt.Errorf("create temp install file: %w", err)
+	}
+
+	_, copyErr := io.Copy(out, in)
+	closeErr := out.Close()
+	if copyErr != nil {
+		return fmt.Errorf("write temp install file: %w", copyErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close temp install file: %w", closeErr)
+	}
+
+	if executable {
+		if err := os.Chmod(tmpPath, 0o755); err != nil {
+			return fmt.Errorf("chmod temp install file: %w", err)
+		}
+	}
+
+	if _, err := os.Stat(targetPath); err == nil {
+		if err := renameFile(targetPath, backupPath); err != nil {
+			_ = os.Remove(tmpPath)
+			return fmt.Errorf("move existing binary aside: %w", err)
+		}
+		defer func() {
+			if _, err := os.Stat(backupPath); err == nil {
+				_ = os.RemoveAll(backupPath)
+			}
+		}()
+	}
+
+	if err := renameFile(tmpPath, targetPath); err != nil {
+		if _, statErr := os.Stat(backupPath); statErr == nil {
+			if restoreErr := renameFile(backupPath, targetPath); restoreErr != nil {
+				return fmt.Errorf("install binary: %w (restore failed: %v)", err, restoreErr)
+			}
+		}
+		return fmt.Errorf("install binary: %w", err)
+	}
+
+	if _, err := os.Stat(backupPath); err == nil {
+		if removeErr := os.RemoveAll(backupPath); removeErr != nil {
+			return fmt.Errorf("cleanup previous binary backup: %w", removeErr)
+		}
+	}
+	return nil
+}
+
+func binaryNameForGOOS(goos string) string {
+	if goos == "windows" {
+		return "anna.exe"
+	}
+	return "anna"
+}
+
+func normalizeVersion(v string) string {
+	trimmed := strings.TrimSpace(v)
+	trimmed = strings.TrimPrefix(trimmed, "v")
+	if trimmed == "" {
+		return ""
+	}
+	parts := strings.Split(trimmed, ".")
+	for _, part := range parts {
+		if part == "" {
+			return ""
+		}
+		for _, r := range part {
+			if r < '0' || r > '9' {
+				return trimmed
+			}
+		}
+	}
+	return trimmed
+}

--- a/version_cmd_test.go
+++ b/version_cmd_test.go
@@ -1,0 +1,282 @@
+package main
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDisplayVersion(t *testing.T) {
+	prev := version
+	t.Cleanup(func() { version = prev })
+
+	version = "v1.2.3"
+	if got := displayVersion(); got != "1.2.3" {
+		t.Fatalf("displayVersion() = %q, want %q", got, "1.2.3")
+	}
+
+	version = ""
+	if got := displayVersion(); got != "dev" {
+		t.Fatalf("displayVersion() = %q, want %q", got, "dev")
+	}
+}
+
+func TestSelectReleaseAsset(t *testing.T) {
+	assets := []githubReleaseAsset{
+		{Name: "anna_0.3.0_darwin_arm64.tar.gz"},
+		{Name: "anna_0.3.0_linux_amd64.tar.gz"},
+	}
+
+	asset, err := selectReleaseAsset(assets, "darwin", "arm64")
+	if err != nil {
+		t.Fatalf("selectReleaseAsset() error = %v", err)
+	}
+	if asset.Name != "anna_0.3.0_darwin_arm64.tar.gz" {
+		t.Fatalf("selectReleaseAsset() = %q, want darwin arm64 asset", asset.Name)
+	}
+}
+
+func TestSelectReleaseAssetUnsupported(t *testing.T) {
+	_, err := selectReleaseAsset([]githubReleaseAsset{{Name: "anna_0.3.0_linux_amd64.tar.gz"}}, "darwin", "arm64")
+	if !errors.Is(err, errUnsupportedAsset) {
+		t.Fatalf("selectReleaseAsset() error = %v, want errUnsupportedAsset", err)
+	}
+}
+
+func TestFetchLatestRelease(t *testing.T) {
+	prevBaseURL := upgradeAPIBaseURL
+	prevClient := upgradeHTTPClient
+	t.Cleanup(func() {
+		upgradeAPIBaseURL = prevBaseURL
+		upgradeHTTPClient = prevClient
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/vaayne/anna/releases/latest" {
+			t.Fatalf("path = %s, want /repos/vaayne/anna/releases/latest", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tag_name":"v0.3.0","assets":[{"name":"anna_0.3.0_darwin_arm64.tar.gz","browser_download_url":"https://example.com/anna"}]}`))
+	}))
+	defer server.Close()
+
+	upgradeAPIBaseURL = server.URL
+	upgradeHTTPClient = server.Client()
+
+	release, err := fetchLatestRelease(context.Background())
+	if err != nil {
+		t.Fatalf("fetchLatestRelease() error = %v", err)
+	}
+	if release.TagName != "v0.3.0" {
+		t.Fatalf("fetchLatestRelease() tag = %q, want v0.3.0", release.TagName)
+	}
+	if len(release.Assets) != 1 {
+		t.Fatalf("fetchLatestRelease() assets = %d, want 1", len(release.Assets))
+	}
+}
+
+func TestRunUpgradeAlreadyCurrent(t *testing.T) {
+	prevBaseURL := upgradeAPIBaseURL
+	prevClient := upgradeHTTPClient
+	t.Cleanup(func() {
+		upgradeAPIBaseURL = prevBaseURL
+		upgradeHTTPClient = prevClient
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tag_name":"v0.3.0","assets":[]}`))
+	}))
+	defer server.Close()
+
+	upgradeAPIBaseURL = server.URL
+	upgradeHTTPClient = server.Client()
+
+	result, err := runUpgrade(context.Background(), t.TempDir(), "0.3.0", "darwin", "arm64")
+	if err != nil {
+		t.Fatalf("runUpgrade() error = %v", err)
+	}
+	if !result.AlreadyCurrent {
+		t.Fatalf("runUpgrade() AlreadyCurrent = false, want true")
+	}
+	if result.TargetPath != "" {
+		t.Fatalf("runUpgrade() TargetPath = %q, want empty", result.TargetPath)
+	}
+}
+
+func TestRunUpgradeInstallsBinary(t *testing.T) {
+	prevBaseURL := upgradeAPIBaseURL
+	prevClient := upgradeHTTPClient
+	t.Cleanup(func() {
+		upgradeAPIBaseURL = prevBaseURL
+		upgradeHTTPClient = prevClient
+	})
+
+	archivePath := filepath.Join(t.TempDir(), "anna_0.4.0_darwin_arm64.tar.gz")
+	if err := writeTarGzArchive(archivePath, "anna", []byte("new-binary")); err != nil {
+		t.Fatalf("writeTarGzArchive() error = %v", err)
+	}
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/vaayne/anna/releases/latest":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"tag_name":"v0.4.0","assets":[{"name":"anna_0.4.0_darwin_arm64.tar.gz","browser_download_url":"%s/download/anna_0.4.0_darwin_arm64.tar.gz"}]}`, server.URL)))
+		case "/download/anna_0.4.0_darwin_arm64.tar.gz":
+			http.ServeFile(w, r, archivePath)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	upgradeAPIBaseURL = server.URL
+	upgradeHTTPClient = server.Client()
+
+	installDir := t.TempDir()
+	result, err := runUpgrade(context.Background(), installDir, "0.3.0", "darwin", "arm64")
+	if err != nil {
+		t.Fatalf("runUpgrade() error = %v", err)
+	}
+	if result.AlreadyCurrent {
+		t.Fatalf("runUpgrade() AlreadyCurrent = true, want false")
+	}
+
+	data, err := os.ReadFile(filepath.Join(installDir, "anna"))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(data) != "new-binary" {
+		t.Fatalf("installed binary = %q, want new-binary", string(data))
+	}
+}
+
+func TestExtractBinaryFromTarGz(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "anna.tar.gz")
+	if err := writeTarGzArchive(archivePath, "anna", []byte("tar-binary")); err != nil {
+		t.Fatalf("writeTarGzArchive() error = %v", err)
+	}
+
+	extractedPath, err := extractBinaryFromTarGz(archivePath, dir, "anna")
+	if err != nil {
+		t.Fatalf("extractBinaryFromTarGz() error = %v", err)
+	}
+
+	data, err := os.ReadFile(extractedPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(data) != "tar-binary" {
+		t.Fatalf("extractBinaryFromTarGz() data = %q, want tar-binary", string(data))
+	}
+}
+
+func TestExtractBinaryFromZip(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "anna.zip")
+	if err := writeZipArchive(archivePath, "anna.exe", []byte("zip-binary")); err != nil {
+		t.Fatalf("writeZipArchive() error = %v", err)
+	}
+
+	extractedPath, err := extractBinaryFromZip(archivePath, dir, "anna.exe")
+	if err != nil {
+		t.Fatalf("extractBinaryFromZip() error = %v", err)
+	}
+
+	data, err := os.ReadFile(extractedPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(data) != "zip-binary" {
+		t.Fatalf("extractBinaryFromZip() data = %q, want zip-binary", string(data))
+	}
+}
+
+func TestInstallBinaryRestoresExistingOnRenameFailure(t *testing.T) {
+	prevRename := renameFile
+	t.Cleanup(func() { renameFile = prevRename })
+
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "anna-new")
+	targetPath := filepath.Join(dir, "anna")
+	if err := os.WriteFile(srcPath, []byte("new"), 0o755); err != nil {
+		t.Fatalf("WriteFile(src) error = %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte("old"), 0o755); err != nil {
+		t.Fatalf("WriteFile(target) error = %v", err)
+	}
+
+	failInstall := true
+	renameFile = func(oldPath, newPath string) error {
+		if filepath.Base(oldPath) == "anna.tmp" && filepath.Base(newPath) == "anna" && failInstall {
+			failInstall = false
+			return errors.New("simulated rename failure")
+		}
+		return os.Rename(oldPath, newPath)
+	}
+
+	err := installBinary(srcPath, targetPath, true)
+	if err == nil {
+		t.Fatal("installBinary() error = nil, want rename failure")
+	}
+
+	data, readErr := os.ReadFile(targetPath)
+	if readErr != nil {
+		t.Fatalf("ReadFile(target) error = %v", readErr)
+	}
+	if string(data) != "old" {
+		t.Fatalf("target content = %q, want old", string(data))
+	}
+}
+
+func writeTarGzArchive(path, name string, data []byte) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	gzipWriter := gzip.NewWriter(file)
+	defer gzipWriter.Close()
+
+	tarWriter := tar.NewWriter(gzipWriter)
+	defer tarWriter.Close()
+
+	if err := tarWriter.WriteHeader(&tar.Header{
+		Name: name,
+		Mode: 0o755,
+		Size: int64(len(data)),
+	}); err != nil {
+		return err
+	}
+	_, err = tarWriter.Write(data)
+	return err
+}
+
+func writeZipArchive(path, name string, data []byte) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	zipWriter := zip.NewWriter(file)
+	defer zipWriter.Close()
+
+	writer, err := zipWriter.Create(name)
+	if err != nil {
+		return err
+	}
+	_, err = writer.Write(data)
+	return err
+}

--- a/version_cmd_test.go
+++ b/version_cmd_test.go
@@ -130,7 +130,7 @@ func TestRunUpgradeInstallsBinary(t *testing.T) {
 		switch r.URL.Path {
 		case "/repos/vaayne/anna/releases/latest":
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(fmt.Sprintf(`{"tag_name":"v0.4.0","assets":[{"name":"anna_0.4.0_darwin_arm64.tar.gz","browser_download_url":"%s/download/anna_0.4.0_darwin_arm64.tar.gz"}]}`, server.URL)))
+			_, _ = fmt.Fprintf(w, `{"tag_name":"v0.4.0","assets":[{"name":"anna_0.4.0_darwin_arm64.tar.gz","browser_download_url":"%s/download/anna_0.4.0_darwin_arm64.tar.gz"}]}`, server.URL)
 		case "/download/anna_0.4.0_darwin_arm64.tar.gz":
 			http.ServeFile(w, r, archivePath)
 		default:
@@ -239,28 +239,58 @@ func TestInstallBinaryRestoresExistingOnRenameFailure(t *testing.T) {
 	}
 }
 
+func TestInstallBinaryRejectsDirectoryTarget(t *testing.T) {
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "anna-new")
+	targetPath := filepath.Join(dir, "anna")
+	if err := os.WriteFile(srcPath, []byte("new"), 0o755); err != nil {
+		t.Fatalf("WriteFile(src) error = %v", err)
+	}
+	if err := os.Mkdir(targetPath, 0o755); err != nil {
+		t.Fatalf("Mkdir(target) error = %v", err)
+	}
+
+	err := installBinary(srcPath, targetPath, true)
+	if !errors.Is(err, errInvalidTarget) {
+		t.Fatalf("installBinary() error = %v, want errInvalidTarget", err)
+	}
+}
+
 func writeTarGzArchive(path, name string, data []byte) error {
 	file, err := os.Create(path)
 	if err != nil {
 		return err
 	}
-	defer file.Close()
 
 	gzipWriter := gzip.NewWriter(file)
-	defer gzipWriter.Close()
-
 	tarWriter := tar.NewWriter(gzipWriter)
-	defer tarWriter.Close()
 
 	if err := tarWriter.WriteHeader(&tar.Header{
 		Name: name,
 		Mode: 0o755,
 		Size: int64(len(data)),
 	}); err != nil {
+		_ = tarWriter.Close()
+		_ = gzipWriter.Close()
+		_ = file.Close()
 		return err
 	}
-	_, err = tarWriter.Write(data)
-	return err
+	if _, err := tarWriter.Write(data); err != nil {
+		_ = tarWriter.Close()
+		_ = gzipWriter.Close()
+		_ = file.Close()
+		return err
+	}
+	if err := tarWriter.Close(); err != nil {
+		_ = gzipWriter.Close()
+		_ = file.Close()
+		return err
+	}
+	if err := gzipWriter.Close(); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
 }
 
 func writeZipArchive(path, name string, data []byte) error {
@@ -268,15 +298,22 @@ func writeZipArchive(path, name string, data []byte) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
 
 	zipWriter := zip.NewWriter(file)
-	defer zipWriter.Close()
-
 	writer, err := zipWriter.Create(name)
 	if err != nil {
+		_ = zipWriter.Close()
+		_ = file.Close()
 		return err
 	}
-	_, err = writer.Write(data)
-	return err
+	if _, err := writer.Write(data); err != nil {
+		_ = zipWriter.Close()
+		_ = file.Close()
+		return err
+	}
+	if err := zipWriter.Close(); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
 }


### PR DESCRIPTION
## Summary
- add top-level `version` and `upgrade` commands to the CLI
- inject build version metadata for local builds and GoReleaser releases
- download the latest stable GitHub release asset for the current platform into a local bin dir with safe replacement behavior
- document the new commands in the README and deployment guide

## Verification
- go test ./...
- go run . version
- go run . upgrade --install-dir <temp dir>
- go run -ldflags="-X main.version=v0.3.0" . upgrade --install-dir <temp dir>
