### PR TITLE
♻️ Merge heartbeat package into cron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ♻️ Refactoring
+
+- **Cron**: Merge `heartbeat/` package into `cron/` — heartbeat is now a built-in cron task ([#49](https://github.com/vaayne/anna/pull/49))
+
 ## [0.4.2] - 2026-03-12
 
 ### ✨ Features

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ channel/cli/                        Interactive terminal chat (Bubble Tea TUI)
 channel/telegram/                   Telegram bot + streaming + notification backend
 channel/qq/                         QQ bot + webhook + streaming + notification backend
 channel/feishu/                     Feishu bot + WebSocket + streaming + notification backend
-cron/                               Scheduled jobs (gocron/v2)
+cron/                               Scheduled jobs (gocron/v2) + heartbeat polling
 memory/                             Lossless context management (DAG, compaction, retrieval)
 ```
 

--- a/cmd/anna/commands.go
+++ b/cmd/anna/commands.go
@@ -15,7 +15,6 @@ import (
 	"github.com/vaayne/anna/channel"
 	"github.com/vaayne/anna/config"
 	"github.com/vaayne/anna/cron"
-	"github.com/vaayne/anna/heartbeat"
 	"github.com/vaayne/anna/memory"
 	memorytool "github.com/vaayne/anna/memory/tool"
 	"github.com/vaayne/anna/skills"
@@ -43,7 +42,6 @@ type setupResult struct {
 	cfg        *config.Config
 	pool       *agent.Pool
 	cronSvc    *cron.Service
-	heartbeat  *heartbeat.Service
 	extraTools []tool.Tool
 	notifier   *channel.Dispatcher
 }
@@ -114,9 +112,9 @@ func setup(parent context.Context, gateway bool) (*setupResult, error) {
 	pool := agent.NewPool(factory, memoryEngine, opts...)
 	go pool.StartReaper(ctx)
 
-	var heartbeatSvc *heartbeat.Service
-	if cfg.Heartbeat.IsEnabled() {
-		heartbeatSvc = heartbeat.New(heartbeat.Config{
+	// Wire heartbeat on the cron service if enabled.
+	if cronSvc != nil && cfg.Heartbeat.IsEnabled() {
+		cronSvc.SetHeartbeat(cron.HeartbeatConfig{
 			File:      cfg.Heartbeat.FilePath(cfg.Workspace),
 			FastModel: cfg.ResolveModelID(config.ModelTierFast),
 		}, func(ctx context.Context, sessionID, message, model string) <-chan runner.Event {
@@ -146,7 +144,6 @@ func setup(parent context.Context, gateway bool) (*setupResult, error) {
 		cfg:        cfg,
 		pool:       pool,
 		cronSvc:    cronSvc,
-		heartbeat:  heartbeatSvc,
 		extraTools: extraTools,
 		notifier:   dispatcher,
 	}, nil

--- a/cmd/anna/gateway.go
+++ b/cmd/anna/gateway.go
@@ -16,7 +16,6 @@ import (
 	"github.com/vaayne/anna/channel/telegram"
 	"github.com/vaayne/anna/config"
 	"github.com/vaayne/anna/cron"
-	"github.com/vaayne/anna/heartbeat"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -153,11 +152,8 @@ func runGateway(ctx context.Context, s *setupResult, listFn channel.ModelListFun
 		defer func() { _ = s.cronSvc.Stop() }()
 	}
 
-	if s.heartbeat != nil {
-		if s.cronSvc == nil {
-			return fmt.Errorf("heartbeat requires the shared scheduler")
-		}
-		if err := scheduleHeartbeat(ctx, s.cronSvc, s.heartbeat, s.cfg.Heartbeat.Interval()); err != nil {
+	if s.cfg.Heartbeat.IsEnabled() && s.cronSvc != nil {
+		if err := s.cronSvc.StartHeartbeat(ctx, s.cfg.Heartbeat.Interval()); err != nil {
 			return fmt.Errorf("schedule heartbeat: %w", err)
 		}
 	}
@@ -187,15 +183,6 @@ func wireCronNotifier(cronSvc *cron.Service, pool *agent.Pool, dispatcher *chann
 			if err := dispatcher.Notify(ctx, channel.Notification{Text: text}); err != nil {
 				slog.Error("cron notification failed", "job_id", job.ID, "error", err)
 			}
-		}
-	})
-}
-
-func scheduleHeartbeat(ctx context.Context, cronSvc *cron.Service, heartbeatSvc *heartbeat.Service, every string) error {
-	slog.Info("starting heartbeat", "every", every)
-	return cronSvc.ScheduleEvery(ctx, every, func(ctx context.Context) {
-		if err := heartbeatSvc.Poll(ctx); err != nil {
-			slog.Error("heartbeat poll failed", "error", err)
 		}
 	})
 }

--- a/cron/heartbeat.go
+++ b/cron/heartbeat.go
@@ -1,10 +1,9 @@
-package heartbeat
+package cron
 
 import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"os"
 	"strings"
 	"time"
@@ -14,49 +13,69 @@ import (
 )
 
 const (
-	decisionSessionID = "heartbeat:decision"
-	mainSessionID     = "heartbeat:main"
+	heartbeatDecisionSessionID = "heartbeat:decision"
+	heartbeatMainSessionID     = "heartbeat:main"
 )
 
+// ChatFunc streams runner events for heartbeat decision/execution prompts.
 type ChatFunc func(ctx context.Context, sessionID, message, model string) <-chan runner.Event
 
-type Config struct {
+// HeartbeatConfig holds heartbeat-specific settings.
+type HeartbeatConfig struct {
 	File      string
 	FastModel string
 }
 
-type Service struct {
-	cfg      Config
-	chat     ChatFunc
-	notifier channel.Notifier
-	now      func() time.Time
-	log      *slog.Logger
-}
-
+// Decision is the gate-keeper response from the LLM.
 type Decision struct {
 	Action string `json:"action"`
 	Reason string `json:"reason,omitempty"`
 }
 
-func New(cfg Config, chat ChatFunc, notifier channel.Notifier) *Service {
-	return &Service{
-		cfg:      cfg,
-		chat:     chat,
-		notifier: notifier,
-		now:      time.Now,
-		log:      slog.With("component", "heartbeat"),
-	}
+// SetHeartbeat configures the heartbeat on the cron service.
+func (s *Service) SetHeartbeat(cfg HeartbeatConfig, chat ChatFunc, notifier channel.Notifier) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.heartbeatCfg = &cfg
+	s.heartbeatChat = chat
+	s.heartbeatNotifier = notifier
 }
 
-func (s *Service) Poll(ctx context.Context) error {
-	if s == nil {
-		return fmt.Errorf("heartbeat service is nil")
+// StartHeartbeat schedules the heartbeat poll on the shared scheduler.
+func (s *Service) StartHeartbeat(ctx context.Context, every string) error {
+	s.mu.Lock()
+	cfg := s.heartbeatCfg
+	s.mu.Unlock()
+
+	if cfg == nil {
+		return fmt.Errorf("heartbeat not configured; call SetHeartbeat first")
 	}
-	if s.chat == nil {
+
+	s.log.Info("starting heartbeat", "every", every)
+	return s.ScheduleEvery(ctx, every, func(ctx context.Context) {
+		if err := s.heartbeatPoll(ctx); err != nil {
+			s.log.Error("heartbeat poll failed", "error", err)
+		}
+	})
+}
+
+// heartbeatPoll reads the heartbeat file, decides whether to act, executes,
+// and sends the result via the notifier.
+func (s *Service) heartbeatPoll(ctx context.Context) error {
+	s.mu.Lock()
+	cfg := s.heartbeatCfg
+	chat := s.heartbeatChat
+	notifier := s.heartbeatNotifier
+	s.mu.Unlock()
+
+	if cfg == nil {
+		return fmt.Errorf("heartbeat not configured")
+	}
+	if chat == nil {
 		return fmt.Errorf("heartbeat chat function is nil")
 	}
 
-	content, err := s.readHeartbeatFile()
+	content, err := readHeartbeatFile(cfg.File)
 	if err != nil {
 		return err
 	}
@@ -64,7 +83,7 @@ func (s *Service) Poll(ctx context.Context) error {
 		return nil
 	}
 
-	decision, err := s.decide(ctx, content)
+	decision, err := heartbeatDecide(ctx, chat, cfg.FastModel, content)
 	if err != nil {
 		return err
 	}
@@ -73,7 +92,7 @@ func (s *Service) Poll(ctx context.Context) error {
 		return nil
 	}
 
-	result, err := s.execute(ctx, content)
+	result, err := heartbeatExecute(ctx, chat, content)
 	if err != nil {
 		return err
 	}
@@ -83,7 +102,7 @@ func (s *Service) Poll(ctx context.Context) error {
 	}
 
 	text := "*Heartbeat*\n\n" + result
-	if err := s.notifier.Notify(ctx, channel.Notification{Text: text}); err != nil {
+	if err := notifier.Notify(ctx, channel.Notification{Text: text}); err != nil {
 		return fmt.Errorf("notify heartbeat result: %w", err)
 	}
 
@@ -91,12 +110,12 @@ func (s *Service) Poll(ctx context.Context) error {
 	return nil
 }
 
-func (s *Service) readHeartbeatFile() (string, error) {
-	if strings.TrimSpace(s.cfg.File) == "" {
+func readHeartbeatFile(path string) (string, error) {
+	if strings.TrimSpace(path) == "" {
 		return "", fmt.Errorf("heartbeat file is not configured")
 	}
 
-	data, err := os.ReadFile(s.cfg.File)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return "", nil
@@ -107,9 +126,9 @@ func (s *Service) readHeartbeatFile() (string, error) {
 	return strings.TrimSpace(string(data)), nil
 }
 
-func (s *Service) decide(ctx context.Context, content string) (Decision, error) {
-	prompt := buildDecisionPrompt(s.now().UTC(), content)
-	text, usedTools, err := s.collect(ctx, decisionSessionID, prompt, s.cfg.FastModel)
+func heartbeatDecide(ctx context.Context, chat ChatFunc, fastModel, content string) (Decision, error) {
+	prompt := buildDecisionPrompt(time.Now().UTC(), content)
+	text, usedTools, err := collectChat(ctx, chat, heartbeatDecisionSessionID, prompt, fastModel)
 	if err != nil {
 		return Decision{}, err
 	}
@@ -124,17 +143,17 @@ func (s *Service) decide(ctx context.Context, content string) (Decision, error) 
 	return decision, nil
 }
 
-func (s *Service) execute(ctx context.Context, content string) (string, error) {
-	prompt := buildExecutionPrompt(s.now().UTC(), content)
-	text, _, err := s.collect(ctx, mainSessionID, prompt, "")
+func heartbeatExecute(ctx context.Context, chat ChatFunc, content string) (string, error) {
+	prompt := buildExecutionPrompt(time.Now().UTC(), content)
+	text, _, err := collectChat(ctx, chat, heartbeatMainSessionID, prompt, "")
 	if err != nil {
 		return "", err
 	}
 	return text, nil
 }
 
-func (s *Service) collect(ctx context.Context, sessionID, message, model string) (string, bool, error) {
-	stream := s.chat(ctx, sessionID, message, model)
+func collectChat(ctx context.Context, chat ChatFunc, sessionID, message, model string) (string, bool, error) {
+	stream := chat(ctx, sessionID, message, model)
 	var buf strings.Builder
 	usedTools := false
 

--- a/cron/heartbeat_test.go
+++ b/cron/heartbeat_test.go
@@ -1,4 +1,4 @@
-package heartbeat
+package cron
 
 import (
 	"context"
@@ -44,16 +44,31 @@ func makeChatFunc(calls *[]chatCall, responses map[string][]runner.Event) ChatFu
 	}
 }
 
-func TestPollSkipsMissingHeartbeatFile(t *testing.T) {
+func newHeartbeatTestService(t *testing.T, cfg HeartbeatConfig, calls *[]chatCall, responses map[string][]runner.Event, notifier channel.Notifier) *Service {
+	t.Helper()
+	dir := t.TempDir()
+	svc, err := New(dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := svc.StartEphemeral(context.Background()); err != nil {
+		t.Fatalf("StartEphemeral: %v", err)
+	}
+	t.Cleanup(func() { _ = svc.Stop() })
+	svc.SetHeartbeat(cfg, makeChatFunc(calls, responses), notifier)
+	return svc
+}
+
+func TestHeartbeatPollSkipsMissingFile(t *testing.T) {
 	var calls []chatCall
 	notifier := &fakeNotifier{}
-	svc := New(Config{
+	svc := newHeartbeatTestService(t, HeartbeatConfig{
 		File:      filepath.Join(t.TempDir(), "HEARTBEAT.md"),
 		FastModel: "fast-model",
-	}, makeChatFunc(&calls, nil), notifier)
+	}, &calls, nil, notifier)
 
-	if err := svc.Poll(context.Background()); err != nil {
-		t.Fatalf("Poll: %v", err)
+	if err := svc.heartbeatPoll(context.Background()); err != nil {
+		t.Fatalf("heartbeatPoll: %v", err)
 	}
 
 	if len(calls) != 0 {
@@ -64,7 +79,7 @@ func TestPollSkipsMissingHeartbeatFile(t *testing.T) {
 	}
 }
 
-func TestPollSkipDecisionUsesFastModel(t *testing.T) {
+func TestHeartbeatPollSkipDecisionUsesFastModel(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "HEARTBEAT.md")
 	if err := os.WriteFile(path, []byte("Check if anything needs doing."), 0o644); err != nil {
@@ -73,22 +88,22 @@ func TestPollSkipDecisionUsesFastModel(t *testing.T) {
 
 	var calls []chatCall
 	notifier := &fakeNotifier{}
-	svc := New(Config{
+	svc := newHeartbeatTestService(t, HeartbeatConfig{
 		File:      path,
 		FastModel: "fast-model",
-	}, makeChatFunc(&calls, map[string][]runner.Event{
-		decisionSessionID: {{Text: `{"action":"skip","reason":"nothing pending"}`}},
-	}), notifier)
+	}, &calls, map[string][]runner.Event{
+		heartbeatDecisionSessionID: {{Text: `{"action":"skip","reason":"nothing pending"}`}},
+	}, notifier)
 
-	if err := svc.Poll(context.Background()); err != nil {
-		t.Fatalf("Poll: %v", err)
+	if err := svc.heartbeatPoll(context.Background()); err != nil {
+		t.Fatalf("heartbeatPoll: %v", err)
 	}
 
 	if len(calls) != 1 {
 		t.Fatalf("expected 1 chat call, got %d", len(calls))
 	}
-	if calls[0].sessionID != decisionSessionID {
-		t.Fatalf("sessionID = %q, want %q", calls[0].sessionID, decisionSessionID)
+	if calls[0].sessionID != heartbeatDecisionSessionID {
+		t.Fatalf("sessionID = %q, want %q", calls[0].sessionID, heartbeatDecisionSessionID)
 	}
 	if calls[0].model != "fast-model" {
 		t.Fatalf("model = %q, want %q", calls[0].model, "fast-model")
@@ -98,7 +113,7 @@ func TestPollSkipDecisionUsesFastModel(t *testing.T) {
 	}
 }
 
-func TestPollRunDecisionExecutesAndNotifies(t *testing.T) {
+func TestHeartbeatPollRunDecisionExecutesAndNotifies(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "HEARTBEAT.md")
 	if err := os.WriteFile(path, []byte("Review the workspace and report actionable changes."), 0o644); err != nil {
@@ -107,25 +122,25 @@ func TestPollRunDecisionExecutesAndNotifies(t *testing.T) {
 
 	var calls []chatCall
 	notifier := &fakeNotifier{}
-	svc := New(Config{
+	svc := newHeartbeatTestService(t, HeartbeatConfig{
 		File:      path,
 		FastModel: "fast-model",
-	}, makeChatFunc(&calls, map[string][]runner.Event{
-		decisionSessionID: {{Text: `{"action":"run","reason":"new work detected"}`}},
-		mainSessionID:     {{Text: "Action complete."}},
-	}), notifier)
+	}, &calls, map[string][]runner.Event{
+		heartbeatDecisionSessionID: {{Text: `{"action":"run","reason":"new work detected"}`}},
+		heartbeatMainSessionID:     {{Text: "Action complete."}},
+	}, notifier)
 
-	if err := svc.Poll(context.Background()); err != nil {
-		t.Fatalf("Poll: %v", err)
+	if err := svc.heartbeatPoll(context.Background()); err != nil {
+		t.Fatalf("heartbeatPoll: %v", err)
 	}
 
 	if len(calls) != 2 {
 		t.Fatalf("expected 2 chat calls, got %d", len(calls))
 	}
-	if calls[0].sessionID != decisionSessionID || calls[0].model != "fast-model" {
+	if calls[0].sessionID != heartbeatDecisionSessionID || calls[0].model != "fast-model" {
 		t.Fatalf("unexpected decision call: %+v", calls[0])
 	}
-	if calls[1].sessionID != mainSessionID || calls[1].model != "" {
+	if calls[1].sessionID != heartbeatMainSessionID || calls[1].model != "" {
 		t.Fatalf("unexpected main call: %+v", calls[1])
 	}
 	if len(notifier.calls) != 1 {
@@ -136,7 +151,7 @@ func TestPollRunDecisionExecutesAndNotifies(t *testing.T) {
 	}
 }
 
-func TestPollFailsWhenDecisionUsesTools(t *testing.T) {
+func TestHeartbeatPollFailsWhenDecisionUsesTools(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "HEARTBEAT.md")
 	if err := os.WriteFile(path, []byte("Ping if needed."), 0o644); err != nil {
@@ -144,16 +159,16 @@ func TestPollFailsWhenDecisionUsesTools(t *testing.T) {
 	}
 
 	var calls []chatCall
-	svc := New(Config{
+	svc := newHeartbeatTestService(t, HeartbeatConfig{
 		File:      path,
 		FastModel: "fast-model",
-	}, makeChatFunc(&calls, map[string][]runner.Event{
-		decisionSessionID: {{
+	}, &calls, map[string][]runner.Event{
+		heartbeatDecisionSessionID: {{
 			ToolUse: &runner.ToolUseEvent{Tool: "bash", Status: "running"},
 		}},
-	}), &fakeNotifier{})
+	}, &fakeNotifier{})
 
-	err := svc.Poll(context.Background())
+	err := svc.heartbeatPoll(context.Background())
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -162,7 +177,7 @@ func TestPollFailsWhenDecisionUsesTools(t *testing.T) {
 	}
 }
 
-func TestPollReturnsNotifierError(t *testing.T) {
+func TestHeartbeatPollReturnsNotifierError(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "HEARTBEAT.md")
 	if err := os.WriteFile(path, []byte("Act now."), 0o644); err != nil {
@@ -171,15 +186,15 @@ func TestPollReturnsNotifierError(t *testing.T) {
 
 	var calls []chatCall
 	notifier := &fakeNotifier{err: errors.New("notify failed")}
-	svc := New(Config{
+	svc := newHeartbeatTestService(t, HeartbeatConfig{
 		File:      path,
 		FastModel: "fast-model",
-	}, makeChatFunc(&calls, map[string][]runner.Event{
-		decisionSessionID: {{Text: `{"action":"run","reason":"do it"}`}},
-		mainSessionID:     {{Text: "Done."}},
-	}), notifier)
+	}, &calls, map[string][]runner.Event{
+		heartbeatDecisionSessionID: {{Text: `{"action":"run","reason":"do it"}`}},
+		heartbeatMainSessionID:     {{Text: "Done."}},
+	}, notifier)
 
-	err := svc.Poll(context.Background())
+	err := svc.heartbeatPoll(context.Background())
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/cron/service.go
+++ b/cron/service.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-co-op/gocron/v2"
 	"github.com/google/uuid"
+	"github.com/vaayne/anna/channel"
 )
 
 // errOneTimeJobPast is returned by scheduleJob when a one-time job's timestamp
@@ -33,6 +34,11 @@ type Service struct {
 	jobs      map[string]Job
 	gids      map[string]uuid.UUID // job ID -> gocron job UUID
 	log       *slog.Logger
+
+	// Heartbeat (optional, configured via SetHeartbeat).
+	heartbeatCfg      *HeartbeatConfig
+	heartbeatChat     ChatFunc
+	heartbeatNotifier channel.Notifier
 }
 
 // New creates a cron service. Call Start to load persisted jobs and begin scheduling.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -110,6 +110,7 @@ db/
 
 cron/
   service.go                        Scheduler service (gocron/v2)
+  heartbeat.go                      Heartbeat polling (decide/execute/notify)
   persistence.go                    Job JSON persistence (load/save)
   job.go                            Job and Schedule types
   tool.go                           Agent cron tool (add/list/remove)

--- a/docs/cron-system.md
+++ b/docs/cron-system.md
@@ -32,12 +32,13 @@ Agent (via tool call)
 
 ### Package: `cron/`
 
-Top-level package (sibling to `agent/`, `channel/`). Four files:
+Top-level package (sibling to `agent/`, `channel/`). Five files:
 
 | File | Purpose |
 |------|---------|
 | `cron/job.go` | `Job` and `Schedule` types |
 | `cron/service.go` | `Service` — gocron wrapper, scheduling, job CRUD |
+| `cron/heartbeat.go` | Heartbeat polling — decide/execute/notify via LLM |
 | `cron/persistence.go` | JSON file I/O (load/save jobs) |
 | `cron/tool.go` | `CronTool` — agent tool implementing `tool.Tool` |
 
@@ -138,6 +139,31 @@ No parameters. Returns all scheduled jobs as JSON.
 Parameters:
 - `id` (required) — job ID from `add` or `list`
 
+## Heartbeat
+
+Heartbeat is a built-in periodic task managed by the cron service. It polls a `HEARTBEAT.md` file and uses the LLM to decide whether action is needed, executing instructions and sending results via the notification dispatcher.
+
+### How It Works
+
+1. `SetHeartbeat(cfg, chatFn, notifier)` configures heartbeat on the cron service
+2. `StartHeartbeat(ctx, every)` schedules the poll loop via `ScheduleEvery`
+3. Each tick:
+   - Reads the heartbeat file (skips if missing or empty)
+   - Sends the content to the fast model for a `skip`/`run` decision (no tools allowed)
+   - On `run`, sends the content to the main session for execution
+   - Delivers the result via the notification dispatcher
+
+### Configuration
+
+```yaml
+heartbeat:
+  enabled: false     # default: false
+  every: 10m         # poll interval (Go duration)
+  file: HEARTBEAT.md # relative to workspace unless absolute
+```
+
+Heartbeat only runs in `anna gateway` mode. The fast model is used for the gate decision to minimize cost.
+
 ## Wiring
 
 The cron system resolves a circular dependency (service needs pool for the callback, runner needs the tool) via deferred wiring in `main.go`:
@@ -146,11 +172,13 @@ The cron system resolves a circular dependency (service needs pool for the callb
 2. Create `cron.NewTool(service)` and pass to runner via `ExtraTools`
 3. Create pool with the runner factory
 4. Call `service.SetOnJob(...)` with a callback that calls `pool.Chat()`
-5. Call `service.Start(ctx)` in command handlers
+5. If heartbeat is enabled, call `service.SetHeartbeat(...)` with the chat function and notifier
+6. Call `service.Start(ctx)` (or `StartEphemeral` for heartbeat-only mode) in the gateway
+7. Call `service.StartHeartbeat(ctx, every)` after channels are wired
 
 ## Testing
 
-Tests are in `cron/cron_test.go` covering:
+Tests are in `cron/cron_test.go` and `cron/heartbeat_test.go` covering:
 
 - Add, list, remove lifecycle
 - Input validation (empty name, missing schedule, invalid duration, conflicting schedule fields, invalid/past timestamps)
@@ -165,6 +193,11 @@ Tests are in `cron/cron_test.go` covering:
 - Session mode via tool interface
 - Full tool interface (add/list/remove via `Execute`)
 - Error cases (invalid action, missing ID)
+- Heartbeat: skip when file is missing
+- Heartbeat: fast model used for decision
+- Heartbeat: run decision executes and notifies
+- Heartbeat: error when decision uses tools
+- Heartbeat: notifier errors propagated
 
 Run with:
 


### PR DESCRIPTION
## Summary

- Moved all heartbeat logic (poll, decide/execute prompts, decision parsing) from standalone `heartbeat/` package into `cron/heartbeat.go`
- Added `SetHeartbeat()` and `StartHeartbeat()` methods on `cron.Service` so heartbeat is configured and scheduled as part of the cron lifecycle
- Removed the `heartbeat/` package entirely — no more separate service or wiring in `commands.go`/`gateway.go`

## Test plan

- [x] All 22 cron tests pass (17 existing + 5 migrated heartbeat tests) with `-race`
- [x] Zero lint issues (`golangci-lint run`)
- [x] No remaining imports of `heartbeat` package