### PR TITLE
♻️ refactor: use mcphub/pkg/skills for skill installation

### DIFF
--- a/cmd/anna/skills.go
+++ b/cmd/anna/skills.go
@@ -79,7 +79,7 @@ func skillsInstallCommand() *ucli.Command {
 	return &ucli.Command{
 		Name:      "install",
 		Aliases:   []string{"add"},
-		Usage:     "Install a skill (e.g. anna skills install owner/repo@skill-name)",
+		Usage:     "Install a skill (e.g. owner/repo@skill-name, GitHub/GitLab URL, or local path)",
 		ArgsUsage: "<source>",
 		Action: func(c *ucli.Context) error {
 			source := c.Args().First()

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/openai/openai-go v1.12.0
 	github.com/tencent-connect/botgo v0.2.1
 	github.com/urfave/cli/v2 v2.27.7
-	github.com/vaayne/mcphub v0.2.3-0.20260313111648-70338468817c
+	github.com/vaayne/mcphub v0.2.3
 	github.com/yuin/goldmark v1.7.8
 	golang.org/x/oauth2 v0.30.0
 	golang.org/x/sync v0.18.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vaayne/anna
 
-go 1.24.2
+go 1.25
 
 require (
 	codeberg.org/readeck/go-readability/v2 v2.1.1
@@ -13,13 +13,13 @@ require (
 	github.com/charmbracelet/glamour v0.10.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	github.com/go-co-op/gocron/v2 v2.19.1
-	github.com/go-git/go-git/v5 v5.17.0
 	github.com/google/uuid v1.6.0
 	github.com/larksuite/oapi-sdk-go/v3 v3.5.3
 	github.com/muesli/termenv v0.16.0
 	github.com/openai/openai-go v1.12.0
 	github.com/tencent-connect/botgo v0.2.1
 	github.com/urfave/cli/v2 v2.27.7
+	github.com/vaayne/mcphub v0.2.3-0.20260313111648-70338468817c
 	github.com/yuin/goldmark v1.7.8
 	golang.org/x/oauth2 v0.30.0
 	golang.org/x/sync v0.18.0
@@ -50,12 +50,13 @@ require (
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
-	github.com/dlclark/regexp2 v1.11.0 // indirect
+	github.com/dlclark/regexp2 v1.11.4 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.8.0 // indirect
+	github.com/go-git/go-git/v5 v5.17.0 // indirect
 	github.com/go-resty/resty/v2 v2.6.0 // indirect
 	github.com/go-shiori/dom v0.0.0-20230515143342-73569d674e1c // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
-github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
-github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/dlclark/regexp2 v1.11.4 h1:rPYF9/LECdNymJufQKmri9gV604RvvABwgOA8un7yAo=
+github.com/dlclark/regexp2 v1.11.4/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
@@ -584,6 +584,8 @@ github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/urfave/cli/v2 v2.27.7 h1:bH59vdhbjLv3LAvIu6gd0usJHgoTTPhCFib8qqOwXYU=
 github.com/urfave/cli/v2 v2.27.7/go.mod h1:CyNAG/xg+iAOg0N4MPGZqVmv2rCoP267496AOXUZjA4=
+github.com/vaayne/mcphub v0.2.3-0.20260313111648-70338468817c h1:0bBxYb+MfPGWL69s8S8/v4A6lKOs+y7iurS3lykFKxQ=
+github.com/vaayne/mcphub v0.2.3-0.20260313111648-70338468817c/go.mod h1:XeuDwvluj08ap3ZAUOFJMJNBPDQJ85V0alOqnVbST54=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=

--- a/go.sum
+++ b/go.sum
@@ -584,8 +584,8 @@ github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/urfave/cli/v2 v2.27.7 h1:bH59vdhbjLv3LAvIu6gd0usJHgoTTPhCFib8qqOwXYU=
 github.com/urfave/cli/v2 v2.27.7/go.mod h1:CyNAG/xg+iAOg0N4MPGZqVmv2rCoP267496AOXUZjA4=
-github.com/vaayne/mcphub v0.2.3-0.20260313111648-70338468817c h1:0bBxYb+MfPGWL69s8S8/v4A6lKOs+y7iurS3lykFKxQ=
-github.com/vaayne/mcphub v0.2.3-0.20260313111648-70338468817c/go.mod h1:XeuDwvluj08ap3ZAUOFJMJNBPDQJ85V0alOqnVbST54=
+github.com/vaayne/mcphub v0.2.3 h1:7kelx34lXiygYB0hURHAnSX4xIwRbPiPZMbiIRbrRL8=
+github.com/vaayne/mcphub v0.2.3/go.mod h1:JO/LaqGZ1nq0Jm1nEhy+1cTiEKU2FNkJCKvj8wJzC78=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=

--- a/internal/skills/install.go
+++ b/internal/skills/install.go
@@ -3,46 +3,24 @@ package skills
 import (
 	"context"
 	"fmt"
-	"io"
-	"io/fs"
-	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 
-	git "github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing"
+	mcpskills "github.com/vaayne/mcphub/pkg/skills"
+	_ "github.com/vaayne/mcphub/pkg/skills/providers"
 )
 
 // Install fetches a skill from source and installs it into targetDir.
-// Source format: "owner/repo@skill-name" or "owner/repo@skill-name#ref".
+// Source formats:
+//   - "owner/repo@skill-name" or "owner/repo@skill-name#ref" (GitHub shorthand)
+//   - "https://github.com/owner/repo/tree/branch/path" (GitHub URL)
+//   - "https://gitlab.com/owner/repo" (GitLab URL)
+//   - "./local/path" (local directory)
+//   - "https://example.com/SKILL.md" (direct URL)
+//
 // Returns the installed skill name.
 func Install(ctx context.Context, source, targetDir string) (string, error) {
-	owner, repo, skillName, ref, err := parseSource(source)
-	if err != nil {
-		return "", err
-	}
-
-	cacheDir, err := getCacheDir(owner, repo, ref)
-	if err != nil {
-		return "", fmt.Errorf("create cache dir: %w", err)
-	}
-
-	if err := cloneOrUpdate(ctx, owner, repo, ref, cacheDir); err != nil {
-		return "", fmt.Errorf("fetch repo: %w", err)
-	}
-
-	skillDir, err := findSkillDir(cacheDir, skillName)
-	if err != nil {
-		return "", err
-	}
-
-	dst := filepath.Join(targetDir, skillName)
-	if err := copyDir(skillDir, dst); err != nil {
-		return "", fmt.Errorf("install skill: %w", err)
-	}
-
-	return skillName, nil
+	return install(ctx, source, targetDir)
 }
 
 func (t *SkillsTool) install(ctx context.Context, args map[string]any) (string, error) {
@@ -51,223 +29,83 @@ func (t *SkillsTool) install(ctx context.Context, args map[string]any) (string, 
 		return "", fmt.Errorf("source is required for install action (e.g. owner/repo@skill-name)")
 	}
 
-	owner, repo, skillName, ref, err := parseSource(source)
+	targetDir := filepath.Join(t.workspace, "skills")
+	skillName, err := install(ctx, source, targetDir)
 	if err != nil {
 		return "", err
 	}
 
-	cacheDir, err := getCacheDir(owner, repo, ref)
+	installed := filepath.Join(targetDir, skillName)
+	return fmt.Sprintf("Skill %q installed to %s.", skillName, installed), nil
+}
+
+// install is the shared implementation for both the public Install function and the tool method.
+func install(ctx context.Context, source, targetDir string) (string, error) {
+	// Handle anna's #ref syntax in shorthand: owner/repo@skill#ref
+	// mcphub's ParseSource doesn't split #ref from shorthand, so we pre-process it.
+	ref := ""
+	if !strings.HasPrefix(source, "http://") && !strings.HasPrefix(source, "https://") &&
+		!strings.HasPrefix(source, "/") && !strings.HasPrefix(source, ".") {
+		if idx := strings.LastIndex(source, "#"); idx != -1 {
+			ref = source[idx+1:]
+			source = source[:idx]
+		}
+	}
+
+	parsed, err := mcpskills.ParseSource(source)
 	if err != nil {
-		return "", fmt.Errorf("create cache dir: %w", err)
+		return "", fmt.Errorf("invalid source %q: %w", source, err)
 	}
 
-	clone := t.cloner
-	if clone == nil {
-		clone = cloneOrUpdate
-	}
-	if err := clone(ctx, owner, repo, ref, cacheDir); err != nil {
-		return "", fmt.Errorf("fetch repo: %w", err)
+	// Apply pre-processed ref if ParseSource didn't capture one.
+	if ref != "" && parsed.Ref == "" {
+		parsed.Ref = ref
 	}
 
-	skillDir, err := findSkillDir(cacheDir, skillName)
+	switch parsed.Type {
+	case mcpskills.SourceTypeGitHub, mcpskills.SourceTypeGitLab, mcpskills.SourceTypeGit:
+		return installFromGit(ctx, parsed, targetDir)
+	case mcpskills.SourceTypeLocal:
+		return installFromLocal(parsed, targetDir)
+	case mcpskills.SourceTypeDirectURL, mcpskills.SourceTypeWellKnown:
+		return "", fmt.Errorf("source type %q is not yet supported", parsed.Type)
+	default:
+		return "", fmt.Errorf("unknown source type %q", parsed.Type)
+	}
+}
+
+func installFromGit(ctx context.Context, parsed *mcpskills.ParsedSource, targetDir string) (string, error) {
+	src := mcpskills.GitSource{
+		URL:         parsed.URL,
+		Ref:         parsed.Ref,
+		Subpath:     parsed.Subpath,
+		SkillFilter: parsed.SkillFilter,
+	}
+
+	local, err := mcpskills.FetchGitSkill(ctx, src)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("fetch skill: %w", err)
 	}
 
-	targetDir := filepath.Join(t.workspace, "skills", skillName)
-	if err := copyDir(skillDir, targetDir); err != nil {
+	dst := filepath.Join(targetDir, local.SkillName)
+	if err := mcpskills.InstallSkill(local.Path, dst); err != nil {
 		return "", fmt.Errorf("install skill: %w", err)
 	}
 
-	return fmt.Sprintf("Skill %q installed to %s.", skillName, targetDir), nil
+	return local.SkillName, nil
 }
 
-// parseSource parses "owner/repo@skill-name" or "owner/repo@skill-name#ref".
-func parseSource(source string) (owner, repo, skillName, ref string, err error) {
-	// Split off optional #ref
-	if idx := strings.LastIndex(source, "#"); idx != -1 {
-		ref = source[idx+1:]
-		source = source[:idx]
-	}
-
-	// Split owner/repo@skill-name
-	atIdx := strings.Index(source, "@")
-	if atIdx == -1 {
-		return "", "", "", "", fmt.Errorf("invalid source %q: expected format owner/repo@skill-name", source)
-	}
-
-	repoPath := source[:atIdx]
-	skillName = source[atIdx+1:]
-
-	parts := strings.SplitN(repoPath, "/", 2)
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return "", "", "", "", fmt.Errorf("invalid source %q: expected format owner/repo@skill-name", source)
-	}
-
-	if skillName == "" {
-		return "", "", "", "", fmt.Errorf("invalid source %q: skill name is empty", source)
-	}
-
-	// Validate all segments to prevent path traversal in cache/install paths.
-	for _, seg := range []struct{ name, val string }{
-		{"owner", parts[0]},
-		{"repo", parts[1]},
-		{"skill", skillName},
-		{"ref", ref},
-	} {
-		if seg.val == "" {
-			continue
-		}
-		if !safeSegmentRe.MatchString(seg.val) {
-			return "", "", "", "", fmt.Errorf("invalid %s %q: must be alphanumeric, hyphens, dots, or underscores", seg.name, seg.val)
-		}
-	}
-
-	return parts[0], parts[1], skillName, ref, nil
-}
-
-// safeSegmentRe matches path-safe segments: alphanumeric, hyphens, dots, underscores.
-// Rejects "..", leading dots, slashes, and other path traversal patterns.
-var safeSegmentRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
-
-func getCacheDir(owner, repo, ref string) (string, error) {
-	home, err := os.UserHomeDir()
+func installFromLocal(parsed *mcpskills.ParsedSource, targetDir string) (string, error) {
+	skillDir, err := mcpskills.FindSkillDir(parsed.LocalPath, "")
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("find skill: %w", err)
 	}
 
-	dirName := repo
-	if ref != "" {
-		dirName = repo + "@" + ref
+	skillName := filepath.Base(skillDir)
+	dst := filepath.Join(targetDir, skillName)
+	if err := mcpskills.InstallSkill(skillDir, dst); err != nil {
+		return "", fmt.Errorf("install skill: %w", err)
 	}
 
-	cacheDir := filepath.Join(home, ".cache", "anna", "skills", owner, dirName)
-	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
-		return "", err
-	}
-	return cacheDir, nil
-}
-
-func cloneOrUpdate(ctx context.Context, owner, repo, ref, cacheDir string) error {
-	repoURL := fmt.Sprintf("https://github.com/%s/%s.git", owner, repo)
-
-	// Try to open existing repo and pull
-	r, err := git.PlainOpen(cacheDir)
-	if err == nil {
-		w, err := r.Worktree()
-		if err != nil {
-			return fmt.Errorf("open worktree: %w", err)
-		}
-		err = w.PullContext(ctx, &git.PullOptions{RemoteName: "origin"})
-		if err != nil && err != git.NoErrAlreadyUpToDate {
-			return fmt.Errorf("pull: %w", err)
-		}
-		return nil
-	}
-
-	// Fresh clone
-	cloneOpts := &git.CloneOptions{
-		URL:   repoURL,
-		Depth: 1,
-	}
-	if ref != "" {
-		cloneOpts.ReferenceName = plumbing.NewBranchReferenceName(ref)
-		cloneOpts.SingleBranch = true
-	}
-
-	_, err = git.PlainCloneContext(ctx, cacheDir, false, cloneOpts)
-	if err != nil {
-		// Clean up failed clone
-		_ = os.RemoveAll(cacheDir)
-		return fmt.Errorf("clone %s: %w", repoURL, err)
-	}
-
-	return nil
-}
-
-// findSkillDir walks the cache looking for a directory with the given name containing SKILL.md.
-func findSkillDir(cacheDir, skillName string) (string, error) {
-	var found string
-	err := filepath.WalkDir(cacheDir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() && d.Name() == ".git" {
-			return filepath.SkipDir
-		}
-		if !d.IsDir() && d.Name() == "SKILL.md" {
-			dir := filepath.Dir(path)
-			if filepath.Base(dir) == skillName {
-				found = dir
-				return filepath.SkipAll
-			}
-		}
-		return nil
-	})
-	if err != nil {
-		return "", fmt.Errorf("walk cache: %w", err)
-	}
-	if found == "" {
-		return "", fmt.Errorf("skill %q not found in repository", skillName)
-	}
-	return found, nil
-}
-
-// copyDir recursively copies src to dst, skipping .git directories.
-func copyDir(src, dst string) error {
-	// Remove existing target
-	if err := os.RemoveAll(dst); err != nil {
-		return err
-	}
-
-	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-
-		if d.IsDir() && d.Name() == ".git" {
-			return filepath.SkipDir
-		}
-
-		rel, err := filepath.Rel(src, path)
-		if err != nil {
-			return err
-		}
-		target := filepath.Join(dst, rel)
-
-		if d.IsDir() {
-			return os.MkdirAll(target, 0o755)
-		}
-
-		if !d.Type().IsRegular() {
-			return nil // skip symlinks etc.
-		}
-
-		return copyFile(path, target)
-	})
-}
-
-func copyFile(src, dst string) (err error) {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = in.Close() }()
-
-	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-		return err
-	}
-
-	out, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if cerr := out.Close(); cerr != nil && err == nil {
-			err = cerr
-		}
-	}()
-
-	_, err = io.Copy(out, in)
-	return err
+	return skillName, nil
 }

--- a/internal/skills/tool.go
+++ b/internal/skills/tool.go
@@ -28,7 +28,7 @@ var skillsInputSchema = func() map[string]any {
     },
     "source": {
       "type": "string",
-      "description": "Package source to install, e.g. 'owner/repo@skill-name' (required for install)"
+      "description": "Skill source to install. Supports: 'owner/repo@skill-name' (GitHub shorthand), 'owner/repo@skill-name#ref' (with branch/tag), GitHub/GitLab URLs, or local paths (required for install)"
     },
     "name": {
       "type": "string",
@@ -40,16 +40,12 @@ var skillsInputSchema = func() map[string]any {
 	return m
 }()
 
-// cloneFn abstracts git clone/update for testing.
-type cloneFn func(ctx context.Context, owner, repo, ref, cacheDir string) error
-
 // SkillsTool exposes skill management as an agent tool.
 type SkillsTool struct {
 	annaHome  string
 	workspace string
 	cwd       string
-	searchURL string  // override for testing; empty uses default
-	cloner    cloneFn // override for testing; nil uses default
+	searchURL string // override for testing; empty uses default
 }
 
 // NewTool creates a SkillsTool for the given anna home, workspace and working directory.

--- a/internal/skills/tool_test.go
+++ b/internal/skills/tool_test.go
@@ -7,12 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
-	"time"
-
-	git "github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing/object"
 )
 
 func TestDefinition(t *testing.T) {
@@ -201,131 +196,6 @@ func TestSearchMissingQuery(t *testing.T) {
 	}
 }
 
-func TestParseSource(t *testing.T) {
-	tests := []struct {
-		input     string
-		owner     string
-		repo      string
-		skill     string
-		ref       string
-		expectErr bool
-	}{
-		{"owner/repo@skill", "owner", "repo", "skill", "", false},
-		{"owner/repo@skill#main", "owner", "repo", "skill", "main", false},
-		{"vercel-labs/agent-skills@react-best-practices", "vercel-labs", "agent-skills", "react-best-practices", "", false},
-		{"invalid", "", "", "", "", true},
-		{"owner/repo", "", "", "", "", true},
-		{"owner/@skill", "", "", "", "", true},
-		{"/repo@skill", "", "", "", "", true},
-		{"owner/repo@", "", "", "", "", true},
-		// Path traversal attempts
-		{"../evil/repo@skill", "", "", "", "", true},
-		{"owner/../../etc@skill", "", "", "", "", true},
-		{"owner/repo@../../../etc", "", "", "", "", true},
-		{"owner/repo@skill#../../main", "", "", "", "", true},
-		{"owner/repo@skill#..", "", "", "", "", true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			owner, repo, skill, ref, err := parseSource(tt.input)
-			if tt.expectErr {
-				if err == nil {
-					t.Error("expected error")
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if owner != tt.owner || repo != tt.repo || skill != tt.skill || ref != tt.ref {
-				t.Errorf("got (%q, %q, %q, %q), want (%q, %q, %q, %q)",
-					owner, repo, skill, ref, tt.owner, tt.repo, tt.skill, tt.ref)
-			}
-		})
-	}
-}
-
-func TestCopyDir(t *testing.T) {
-	src := t.TempDir()
-	if err := os.WriteFile(filepath.Join(src, "SKILL.md"), []byte("# Test"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(filepath.Join(src, "sub"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(src, "sub", "helper.md"), []byte("helper"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(filepath.Join(src, ".git"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(src, ".git", "config"), []byte("gitconfig"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	dst := filepath.Join(t.TempDir(), "target")
-	if err := copyDir(src, dst); err != nil {
-		t.Fatalf("copyDir error: %v", err)
-	}
-
-	// SKILL.md should be copied
-	if _, err := os.Stat(filepath.Join(dst, "SKILL.md")); err != nil {
-		t.Error("expected SKILL.md to be copied")
-	}
-	// sub/helper.md should be copied
-	if _, err := os.Stat(filepath.Join(dst, "sub", "helper.md")); err != nil {
-		t.Error("expected sub/helper.md to be copied")
-	}
-	// .git should NOT be copied
-	if _, err := os.Stat(filepath.Join(dst, ".git")); !os.IsNotExist(err) {
-		t.Error("expected .git to be skipped")
-	}
-}
-
-func TestFindSkillDir(t *testing.T) {
-	cache := t.TempDir()
-	skillDir := filepath.Join(cache, "skills", "my-skill")
-	if err := os.MkdirAll(skillDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# Skill"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	found, err := findSkillDir(cache, "my-skill")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if found != skillDir {
-		t.Errorf("expected %q, got %q", skillDir, found)
-	}
-}
-
-func TestFindSkillDirNotFound(t *testing.T) {
-	cache := t.TempDir()
-	_, err := findSkillDir(cache, "nonexistent")
-	if err == nil {
-		t.Error("expected error for missing skill")
-	}
-}
-
-func TestInstallMissingSource(t *testing.T) {
-	tool := NewTool("/tmp/anna", "/tmp/agents", "/tmp/cwd")
-	_, err := tool.install(context.Background(), map[string]any{})
-	if err == nil {
-		t.Error("expected error for missing source")
-	}
-}
-
-func TestInstallInvalidSource(t *testing.T) {
-	tool := NewTool("/tmp/anna", "/tmp/agents", "/tmp/cwd")
-	_, err := tool.install(context.Background(), map[string]any{"source": "invalid"})
-	if err == nil {
-		t.Error("expected error for invalid source")
-	}
-}
-
 func TestSearchAPIError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -368,162 +238,22 @@ func TestSearchInvalidJSON(t *testing.T) {
 	}
 }
 
-func TestGetCacheDir(t *testing.T) {
-	dir, err := getCacheDir("owner", "repo", "")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !filepath.IsAbs(dir) {
-		t.Error("expected absolute path")
-	}
-
-	dirWithRef, err := getCacheDir("owner", "repo", "main")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if dir == dirWithRef {
-		t.Error("expected different dirs for different refs")
+func TestInstallMissingSource(t *testing.T) {
+	tool := NewTool("/tmp/anna", "/tmp/agents", "/tmp/cwd")
+	_, err := tool.install(context.Background(), map[string]any{})
+	if err == nil {
+		t.Error("expected error for missing source")
 	}
 }
 
-func TestCopyFileContent(t *testing.T) {
-	src := filepath.Join(t.TempDir(), "source.txt")
-	if err := os.WriteFile(src, []byte("hello world"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	dst := filepath.Join(t.TempDir(), "sub", "dest.txt")
-	if err := copyFile(src, dst); err != nil {
-		t.Fatalf("copyFile error: %v", err)
-	}
-
-	data, err := os.ReadFile(dst)
-	if err != nil {
-		t.Fatalf("read dst: %v", err)
-	}
-	if string(data) != "hello world" {
-		t.Errorf("expected 'hello world', got %q", string(data))
-	}
-}
-
-// createTestRepo creates a bare git repo with a skill directory for testing.
-func createTestRepo(t *testing.T, skillName string) string {
-	t.Helper()
-
-	repoDir := t.TempDir()
-	r, err := git.PlainInit(repoDir, false)
-	if err != nil {
-		t.Fatalf("git init: %v", err)
-	}
-
-	// Create skill directory with SKILL.md
-	skillDir := filepath.Join(repoDir, skillName)
+func TestInstallFromLocalDir(t *testing.T) {
+	// Create a local skill directory
+	srcDir := t.TempDir()
+	skillDir := filepath.Join(srcDir, "my-skill")
 	if err := os.MkdirAll(skillDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(`---
-name: `+skillName+`
-description: Test skill for install
----
-# `+skillName+`
-`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	w, err := r.Worktree()
-	if err != nil {
-		t.Fatalf("worktree: %v", err)
-	}
-	if _, err := w.Add(skillName); err != nil {
-		t.Fatalf("git add: %v", err)
-	}
-	if _, err := w.Commit("initial", &git.CommitOptions{
-		Author: &object.Signature{Name: "test", Email: "test@test.com", When: time.Now()},
-	}); err != nil {
-		t.Fatalf("git commit: %v", err)
-	}
-
-	return repoDir
-}
-
-func TestCloneOrUpdate(t *testing.T) {
-	srcRepo := createTestRepo(t, "my-skill")
-
-	cacheDir := filepath.Join(t.TempDir(), "cache")
-	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	// Clone from local repo (use file:// protocol)
-	_, err := git.PlainClone(cacheDir, false, &git.CloneOptions{URL: srcRepo})
-	if err != nil {
-		t.Fatalf("initial clone: %v", err)
-	}
-
-	// Verify skill file exists in cache
-	skillFile := filepath.Join(cacheDir, "my-skill", "SKILL.md")
-	if _, err := os.Stat(skillFile); err != nil {
-		t.Fatalf("expected SKILL.md in cache: %v", err)
-	}
-
-	// findSkillDir should work on the cache
-	found, err := findSkillDir(cacheDir, "my-skill")
-	if err != nil {
-		t.Fatalf("findSkillDir: %v", err)
-	}
-
-	// Copy to target
-	targetDir := filepath.Join(t.TempDir(), "target")
-	if err := copyDir(found, targetDir); err != nil {
-		t.Fatalf("copyDir: %v", err)
-	}
-
-	data, err := os.ReadFile(filepath.Join(targetDir, "SKILL.md"))
-	if err != nil {
-		t.Fatalf("read installed SKILL.md: %v", err)
-	}
-	if len(data) == 0 {
-		t.Error("expected non-empty SKILL.md")
-	}
-}
-
-func TestCloneOrUpdateExistingCache(t *testing.T) {
-	srcRepo := createTestRepo(t, "test-skill")
-
-	cacheDir := filepath.Join(t.TempDir(), "cache")
-
-	// First clone
-	_, err := git.PlainClone(cacheDir, false, &git.CloneOptions{URL: srcRepo})
-	if err != nil {
-		t.Fatalf("clone: %v", err)
-	}
-
-	// cloneOrUpdate should succeed on existing cache (pull path)
-	// Note: this tests the "open existing repo" branch of cloneOrUpdate
-	// We can't easily test the remote pull without a real remote, but
-	// we verify it doesn't error when already up to date
-	r, err := git.PlainOpen(cacheDir)
-	if err != nil {
-		t.Fatalf("open: %v", err)
-	}
-	w, err := r.Worktree()
-	if err != nil {
-		t.Fatalf("worktree: %v", err)
-	}
-	err = w.Pull(&git.PullOptions{RemoteName: "origin"})
-	if err != nil && err != git.NoErrAlreadyUpToDate {
-		t.Fatalf("pull: %v", err)
-	}
-}
-
-func TestInstallFullFlow(t *testing.T) {
-	// Create a fake "cached repo" with a skill
-	cacheBase := t.TempDir()
-	skillSrc := filepath.Join(cacheBase, "my-skill")
-	if err := os.MkdirAll(skillSrc, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(skillSrc, "SKILL.md"), []byte(`---
 name: my-skill
 description: A great skill
 ---
@@ -532,23 +262,52 @@ description: A great skill
 		t.Fatal(err)
 	}
 
-	projectDir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(projectDir, ".agents", "skills"), 0o755); err != nil {
+	// Install from local path
+	targetDir := filepath.Join(t.TempDir(), "skills")
+	name, err := Install(context.Background(), srcDir, targetDir)
+	if err != nil {
+		t.Fatalf("install error: %v", err)
+	}
+	if name != "my-skill" {
+		t.Errorf("expected skill name 'my-skill', got %q", name)
+	}
+
+	// Verify installed
+	installed := filepath.Join(targetDir, "my-skill", "SKILL.md")
+	data, err := os.ReadFile(installed)
+	if err != nil {
+		t.Fatalf("installed SKILL.md not found: %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("expected non-empty SKILL.md")
+	}
+}
+
+func TestInstallFromLocalDirViaTool(t *testing.T) {
+	// Create a local skill directory
+	srcDir := t.TempDir()
+	skillDir := filepath.Join(srcDir, "test-skill")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(`---
+name: test-skill
+description: Test
+---
+# Test
+`), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	// Create tool with a fake cloner that just sets up the cache
-	tool := &SkillsTool{
-		workspace: filepath.Join(projectDir, ".agents"),
-		cwd:       projectDir,
-		cloner: func(_ context.Context, _, _, _, cacheDir string) error {
-			// Copy our fake repo into the cache dir
-			return copyDir(cacheBase, cacheDir)
-		},
+	projectDir := t.TempDir()
+	workspace := filepath.Join(projectDir, ".agents")
+	if err := os.MkdirAll(filepath.Join(workspace, "skills"), 0o755); err != nil {
+		t.Fatal(err)
 	}
 
+	tool := NewTool("/tmp/anna", workspace, projectDir)
 	result, err := tool.install(context.Background(), map[string]any{
-		"source": "test-owner/test-repo@my-skill",
+		"source": srcDir,
 	})
 	if err != nil {
 		t.Fatalf("install error: %v", err)
@@ -557,33 +316,10 @@ description: A great skill
 		t.Error("expected non-empty result")
 	}
 
-	// Verify skill was installed
-	installed := filepath.Join(projectDir, ".agents", "skills", "my-skill", "SKILL.md")
-	data, err := os.ReadFile(installed)
-	if err != nil {
+	// Verify installed
+	installed := filepath.Join(workspace, "skills", "test-skill", "SKILL.md")
+	if _, err := os.Stat(installed); err != nil {
 		t.Fatalf("installed SKILL.md not found: %v", err)
-	}
-	if !strings.Contains(string(data), "A great skill") {
-		t.Error("expected installed SKILL.md to contain description")
-	}
-}
-
-func TestInstallSkillNotInRepo(t *testing.T) {
-	cacheBase := t.TempDir()
-	// Empty cache — no skill dirs
-
-	tool := &SkillsTool{
-		cwd: t.TempDir(),
-		cloner: func(_ context.Context, _, _, _, cacheDir string) error {
-			return copyDir(cacheBase, cacheDir)
-		},
-	}
-
-	_, err := tool.install(context.Background(), map[string]any{
-		"source": "owner/repo@nonexistent",
-	})
-	if err == nil {
-		t.Error("expected error for skill not found in repo")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replace anna's internal GitHub-only skill installer with `mcphub/pkg/skills`
- Update Go version from 1.24.2 to 1.25
- Now supports multiple source formats: GitHub/GitLab URLs, local paths, shorthand
- Backward compatible with existing `owner/repo@skill-name#ref` syntax

## Changes

- **`internal/skills/install.go`**: Rewrote to use `mcphub.ParseSource`, `FetchGitSkill`, `InstallSkill`, `FindSkillDir`. Removed ~170 lines of internal git/copy logic.
- **`internal/skills/tool.go`**: Removed `cloneFn`/`cloner` test seam, updated schema description
- **`internal/skills/tool_test.go`**: Replaced internal function tests with local-path integration tests
- **`cmd/anna/skills.go`**: Updated usage string
- **`go.mod`**: `go 1.25`, added `github.com/vaayne/mcphub`

## Dependencies

- Requires https://github.com/vaayne/mcphub/pull/9 (move skills to `pkg/`)

## Test plan

- [x] `go build ./...` passes
- [x] `go test -race ./internal/skills/...` — 18/18 tests pass
- [x] `golangci-lint run` — 0 issues
- [ ] Manual test: `anna skills install owner/repo@skill-name`
- [ ] Manual test: `anna skills install ./local/path`