### PR TITLE
✨ feat: add delegate tool for subagent delegation

### DIFF
--- a/docs/content/docs/core/architecture.md
+++ b/docs/content/docs/core/architecture.md
@@ -68,6 +68,7 @@ internal/
       bash.go                         Execute shell commands
       write.go                        Create/overwrite files
       edit.go                         Edit file sections
+      delegate.go                     Subagent delegation (parallel subtasks)
       truncate.go                     Truncate large outputs to temp files
 
   channel/
@@ -172,6 +173,17 @@ type Tool interface {
 | `write` | Create/overwrite files atomically |
 | `edit` | Edit file sections preserving context |
 | `truncate` | Truncate large outputs to temp files |
+| `delegate` | Spawn subagent loops for bounded subtasks |
+
+### Delegation
+
+The `delegate` tool enables the agent to spawn child agent loops with isolated context. This is useful for focused subtasks (research, code review, drafting) that benefit from fresh context without polluting the parent conversation.
+
+- Each child gets a fresh message history containing only the task description
+- Multiple tasks run in parallel via goroutines
+- The `delegate` tool is excluded from children to prevent recursion
+- Child output is truncated to ~4096 tokens to avoid bloating the parent context
+- Per-task options: `model` (override), `system` (additional instructions), `tools` (whitelist), `max_turns` (default 10), `timeout_seconds` (default 120)
 
 ### Extra Tools (conditionally injected)
 

--- a/internal/agent/runner/builtin/anna/SKILL.md
+++ b/internal/agent/runner/builtin/anna/SKILL.md
@@ -62,6 +62,16 @@ anna version           # Print version
 anna upgrade           # Self-update to latest release
 ```
 
+## Delegation
+
+You have a `delegate` tool that spawns subagent loops for bounded subtasks. Use it when a task benefits from isolated context — e.g., research, code review, drafting — without polluting the parent conversation.
+
+- **Single task**: `{"tasks": [{"id": "review", "task": "Review auth module for issues"}]}`
+- **Parallel tasks**: provide multiple items in the `tasks` array — they run concurrently
+- **Options per task**: `model` (override model), `system` (additional instructions), `tools` (whitelist), `max_turns` (default 10), `timeout_seconds` (default 120)
+- Subagents get fresh context (no parent history) and cannot delegate further
+- Results are returned as JSON: `{"results": {"id": {"output": "...", "error": ""}}}`
+
 ## Memory, scheduler, notifications
 
 These are tools you already have access to. Briefly:

--- a/internal/agent/runner/gorunner.go
+++ b/internal/agent/runner/gorunner.go
@@ -71,16 +71,26 @@ func NewGoRunner(_ context.Context, cfg GoRunnerConfig) (*GoRunner, error) {
 		}
 	}
 
+	eng := &engine.Engine{Providers: reg}
+	model := ai.Model{API: cfg.API, Name: cfg.Model}
+
 	tools := tool.NewRegistry(cfg.WorkDir)
 	for _, t := range cfg.ExtraTools {
 		tools.Register(t)
 	}
+	tools.Register(tool.NewDelegateTool(tool.DelegateConfig{
+		Engine:   eng,
+		Registry: tools,
+		Model:    model,
+		APIKey:   cfg.APIKey,
+		System:   system,
+	}))
 
 	return &GoRunner{
-		eng:          &engine.Engine{Providers: reg},
+		eng:          eng,
 		reg:          reg,
 		tools:        tools,
-		model:        ai.Model{API: cfg.API, Name: cfg.Model},
+		model:        model,
 		apiKey:       cfg.APIKey,
 		system:       system,
 		lastActivity: time.Now(),

--- a/internal/agent/tool/delegate.go
+++ b/internal/agent/tool/delegate.go
@@ -124,7 +124,8 @@ type delegateTaskConfig struct {
 	Task           string
 	Model          string
 	System         string
-	Tools          []string
+	Tools          []string // nil = all tools; empty = no tools
+	HasTools       bool     // true when "tools" key was present in args
 	MaxTurns       int
 	TimeoutSeconds int
 }
@@ -152,7 +153,7 @@ func (t *DelegateTool) runSubAgent(parentCtx context.Context, tc delegateTaskCon
 	defer cancel()
 
 	// Build scoped tool set.
-	toolSet, toolDefs, err := t.buildScopedTools(tc.Tools)
+	toolSet, toolDefs, err := t.buildScopedTools(tc.Tools, tc.HasTools)
 	if err != nil {
 		return taskResult{Error: fmt.Sprintf("invalid tools: %v", err)}
 	}
@@ -208,13 +209,14 @@ func (t *DelegateTool) runSubAgent(parentCtx context.Context, tc delegateTaskCon
 
 // buildScopedTools creates a filtered tool set for the child agent.
 // It always excludes "delegate" to prevent recursion.
-// If whitelist is non-empty, only those tools are included (after validation).
-func (t *DelegateTool) buildScopedTools(whitelist []string) (engine.ToolSet, []toolspec.Definition, error) {
+// If hasWhitelist is true, only the listed tools are included (empty list = no tools).
+// If hasWhitelist is false, all parent tools (minus delegate) are available.
+func (t *DelegateTool) buildScopedTools(whitelist []string, hasWhitelist bool) (engine.ToolSet, []toolspec.Definition, error) {
 	allDefs := t.cfg.Registry.Definitions()
 
 	// Build allowed set from whitelist, if provided.
 	var allowed map[string]bool
-	if len(whitelist) > 0 {
+	if hasWhitelist {
 		allowed = make(map[string]bool, len(whitelist))
 		for _, name := range whitelist {
 			if name == delegateToolName {
@@ -322,6 +324,7 @@ func parseDelegateTasks(args map[string]any) ([]delegateTaskConfig, error) {
 			tc.TimeoutSeconds = int(timeoutSeconds)
 		}
 		if toolsRaw, ok := obj["tools"].([]any); ok {
+			tc.HasTools = true
 			for _, tr := range toolsRaw {
 				if s, ok := tr.(string); ok {
 					tc.Tools = append(tc.Tools, s)

--- a/internal/agent/tool/delegate.go
+++ b/internal/agent/tool/delegate.go
@@ -1,0 +1,336 @@
+package tool
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	"github.com/vaayne/anna/internal/agent/engine"
+	"github.com/vaayne/anna/internal/ai"
+	"github.com/vaayne/anna/internal/toolspec"
+)
+
+const (
+	delegateToolName      = "delegate"
+	defaultMaxTurns       = 10
+	defaultTimeoutSeconds = 120
+	maxResultChars        = 16000 // ~4096 tokens
+)
+
+// DelegateConfig holds the dependencies needed to spawn subagent loops.
+type DelegateConfig struct {
+	Engine   *engine.Engine
+	Registry *Registry
+	Model    ai.Model
+	APIKey   string
+	System   string
+}
+
+// DelegateTool spawns child agent loops for bounded subtasks.
+type DelegateTool struct {
+	cfg DelegateConfig
+}
+
+// NewDelegateTool creates a delegate tool with the given configuration.
+func NewDelegateTool(cfg DelegateConfig) *DelegateTool {
+	return &DelegateTool{cfg: cfg}
+}
+
+func (t *DelegateTool) Definition() toolspec.Definition {
+	return toolspec.Definition{
+		Name:        delegateToolName,
+		Description: "Delegate one or more tasks to subagents with isolated context. Multiple tasks run in parallel. Use for focused subtasks like research, code review, or drafting that benefit from fresh context.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"tasks": map[string]any{
+					"type":        "array",
+					"description": "One or more subtasks to delegate. Multiple tasks run in parallel.",
+					"items": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"id":   map[string]any{"type": "string", "description": "Task identifier for result mapping."},
+							"task": map[string]any{"type": "string", "description": "Task description for the subagent."},
+							"model": map[string]any{
+								"type":        "string",
+								"description": "Optional model override (e.g. 'claude-haiku-4-5-20251001'). Defaults to parent model.",
+							},
+							"system": map[string]any{
+								"type":        "string",
+								"description": "Optional additional system instructions appended to the base prompt.",
+							},
+							"tools": map[string]any{
+								"type":        "array",
+								"items":       map[string]any{"type": "string"},
+								"description": "Optional tool whitelist. Only these tools will be available. Defaults to all parent tools minus delegate.",
+							},
+							"max_turns": map[string]any{
+								"type":        "integer",
+								"description": "Max agent loop turns. Defaults to 10.",
+							},
+							"timeout_seconds": map[string]any{
+								"type":        "integer",
+								"description": "Per-task timeout in seconds. Defaults to 120.",
+							},
+						},
+						"required": []string{"id", "task"},
+					},
+				},
+			},
+			"required": []string{"tasks"},
+		},
+	}
+}
+
+func (t *DelegateTool) Execute(ctx context.Context, args map[string]any) (string, error) {
+	tasks, err := parseDelegateTasks(args)
+	if err != nil {
+		return "", fmt.Errorf("delegate: %w", err)
+	}
+	if len(tasks) == 0 {
+		return "", fmt.Errorf("delegate: at least one task is required")
+	}
+
+	results := make(map[string]taskResult, len(tasks))
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	for _, task := range tasks {
+		wg.Add(1)
+		go func(tc delegateTaskConfig) {
+			defer wg.Done()
+			result := t.runSubAgent(ctx, tc)
+			mu.Lock()
+			results[tc.ID] = result
+			mu.Unlock()
+		}(task)
+	}
+	wg.Wait()
+
+	envelope := map[string]any{"results": results}
+	out, err := json.Marshal(envelope)
+	if err != nil {
+		return "", fmt.Errorf("delegate: marshal results: %w", err)
+	}
+	return string(out), nil
+}
+
+type delegateTaskConfig struct {
+	ID             string
+	Task           string
+	Model          string
+	System         string
+	Tools          []string
+	MaxTurns       int
+	TimeoutSeconds int
+}
+
+type taskResult struct {
+	Output string `json:"output"`
+	Error  string `json:"error,omitempty"`
+}
+
+func (t *DelegateTool) runSubAgent(parentCtx context.Context, tc delegateTaskConfig) (result taskResult) {
+	log := slog.With("component", "delegate", "task_id", tc.ID)
+
+	defer func() {
+		if r := recover(); r != nil {
+			result = taskResult{Error: fmt.Sprintf("panic: %v", r)}
+			log.Error("subagent panicked", "error", r)
+		}
+	}()
+
+	timeout := time.Duration(defaultTimeoutSeconds) * time.Second
+	if tc.TimeoutSeconds > 0 {
+		timeout = time.Duration(tc.TimeoutSeconds) * time.Second
+	}
+	ctx, cancel := context.WithTimeout(parentCtx, timeout)
+	defer cancel()
+
+	// Build scoped tool set.
+	toolSet, toolDefs, err := t.buildScopedTools(tc.Tools)
+	if err != nil {
+		return taskResult{Error: fmt.Sprintf("invalid tools: %v", err)}
+	}
+
+	// Build system prompt: base + optional additions.
+	system := t.cfg.System
+	if tc.System != "" {
+		system += "\n\n" + tc.System
+	}
+
+	// Resolve model: override name if specified, keep same API.
+	model := t.cfg.Model
+	if tc.Model != "" {
+		model.Name = tc.Model
+		model.ID = tc.Model
+	}
+
+	maxTurns := defaultMaxTurns
+	if tc.MaxTurns > 0 {
+		maxTurns = tc.MaxTurns
+	}
+
+	cfg := engine.LoopConfig{
+		Model:           model,
+		StreamOptions:   ai.StreamOptions{APIKey: t.cfg.APIKey},
+		MaxTurns:        maxTurns,
+		Tools:           toolSet,
+		ToolDefinitions: toolDefs,
+		System:          system,
+	}
+
+	messages := []ai.Message{
+		ai.UserMessage{Content: tc.Task},
+	}
+
+	log.Info("subagent started")
+	start := time.Now()
+
+	history, err := t.cfg.Engine.Run(ctx, cfg, messages, nil)
+	duration := time.Since(start)
+
+	if err != nil {
+		log.Error("subagent failed", "duration", duration, "error", err)
+		return taskResult{Error: err.Error()}
+	}
+
+	log.Info("subagent finished", "duration", duration)
+
+	output := extractLastAssistantText(history)
+	output = truncateResult(output, maxResultChars)
+	return taskResult{Output: output}
+}
+
+// buildScopedTools creates a filtered tool set for the child agent.
+// It always excludes "delegate" to prevent recursion.
+// If whitelist is non-empty, only those tools are included (after validation).
+func (t *DelegateTool) buildScopedTools(whitelist []string) (engine.ToolSet, []toolspec.Definition, error) {
+	allDefs := t.cfg.Registry.Definitions()
+
+	// Build allowed set from whitelist, if provided.
+	var allowed map[string]bool
+	if len(whitelist) > 0 {
+		allowed = make(map[string]bool, len(whitelist))
+		for _, name := range whitelist {
+			if name == delegateToolName {
+				continue
+			}
+			if !t.cfg.Registry.Has(name) {
+				return nil, nil, fmt.Errorf("unknown tool: %q", name)
+			}
+			allowed[name] = true
+		}
+	}
+
+	toolSet := engine.ToolSet{}
+	var defs []toolspec.Definition
+
+	for _, def := range allDefs {
+		if def.Name == delegateToolName {
+			continue
+		}
+		if allowed != nil && !allowed[def.Name] {
+			continue
+		}
+		defs = append(defs, def)
+		toolSet[def.Name] = func(ctx context.Context, call ai.ToolCall) (ai.TextContent, error) {
+			result, err := t.cfg.Registry.Execute(ctx, call.Name, call.Arguments)
+			return ai.TextContent{Text: result}, err
+		}
+	}
+
+	return toolSet, defs, nil
+}
+
+// extractLastAssistantText returns the text content of the last assistant message.
+func extractLastAssistantText(history []ai.Message) string {
+	for i := len(history) - 1; i >= 0; i-- {
+		msg, ok := history[i].(ai.AssistantMessage)
+		if !ok {
+			continue
+		}
+		for _, block := range msg.Content {
+			if tc, ok := block.(ai.TextContent); ok {
+				return tc.Text
+			}
+		}
+	}
+	return ""
+}
+
+// truncateResult truncates a string to maxChars runes, appending a marker if truncated.
+func truncateResult(s string, maxChars int) string {
+	if utf8.RuneCountInString(s) <= maxChars {
+		return s
+	}
+	runes := []rune(s)
+	return string(runes[:maxChars]) + "\n[truncated]"
+}
+
+func parseDelegateTasks(args map[string]any) ([]delegateTaskConfig, error) {
+	tasksRaw, ok := args["tasks"]
+	if !ok {
+		return nil, fmt.Errorf("tasks is required")
+	}
+	tasksSlice, ok := tasksRaw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("tasks must be an array")
+	}
+
+	tasks := make([]delegateTaskConfig, 0, len(tasksSlice))
+	seen := make(map[string]bool, len(tasksSlice))
+
+	for i, raw := range tasksSlice {
+		obj, ok := raw.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("tasks[%d]: must be an object", i)
+		}
+
+		tc := delegateTaskConfig{}
+
+		id, ok := obj["id"].(string)
+		if !ok || id == "" {
+			return nil, fmt.Errorf("tasks[%d]: id is required", i)
+		}
+		if seen[id] {
+			return nil, fmt.Errorf("tasks[%d]: duplicate id %q", i, id)
+		}
+		seen[id] = true
+		tc.ID = id
+
+		task, ok := obj["task"].(string)
+		if !ok || task == "" {
+			return nil, fmt.Errorf("tasks[%d]: task is required", i)
+		}
+		tc.Task = task
+
+		if model, ok := obj["model"].(string); ok {
+			tc.Model = model
+		}
+		if system, ok := obj["system"].(string); ok {
+			tc.System = system
+		}
+		if maxTurns, ok := obj["max_turns"].(float64); ok {
+			tc.MaxTurns = int(maxTurns)
+		}
+		if timeoutSeconds, ok := obj["timeout_seconds"].(float64); ok {
+			tc.TimeoutSeconds = int(timeoutSeconds)
+		}
+		if toolsRaw, ok := obj["tools"].([]any); ok {
+			for _, tr := range toolsRaw {
+				if s, ok := tr.(string); ok {
+					tc.Tools = append(tc.Tools, s)
+				}
+			}
+		}
+
+		tasks = append(tasks, tc)
+	}
+
+	return tasks, nil
+}

--- a/internal/agent/tool/delegate_test.go
+++ b/internal/agent/tool/delegate_test.go
@@ -1,0 +1,435 @@
+package tool
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vaayne/anna/internal/agent/engine"
+	"github.com/vaayne/anna/internal/ai"
+	"github.com/vaayne/anna/internal/toolspec"
+)
+
+// fakeProvider returns a canned text response.
+type fakeDelegateProvider struct {
+	response string
+}
+
+func (f fakeDelegateProvider) API() string { return "fake" }
+
+func (f fakeDelegateProvider) Stream(model ai.Model, ctx ai.Context, opts ai.StreamOptions) (ai.AssistantEventStream, error) {
+	out := ai.NewChannelEventStream(8)
+	go func() {
+		out.Emit(ai.EventTextDelta{Text: f.response})
+		out.Emit(ai.EventStop{Reason: ai.StopReasonStop})
+		out.Finish(nil)
+	}()
+	return out, nil
+}
+
+func (f fakeDelegateProvider) StreamSimple(model ai.Model, ctx ai.Context, opts ai.SimpleStreamOptions) (ai.AssistantEventStream, error) {
+	return f.Stream(model, ctx, opts.StreamOptions)
+}
+
+func newTestDelegateTool(response string) *DelegateTool {
+	reg := ai.NewRegistry()
+	reg.Register(fakeDelegateProvider{response: response})
+
+	toolReg := &Registry{tools: make(map[string]Tool)}
+	toolReg.Register(&ReadTool{})
+	toolReg.Register(&BashTool{workDir: "/tmp"})
+
+	eng := &engine.Engine{Providers: reg}
+	model := ai.Model{API: "fake", Name: "test-model"}
+
+	dt := NewDelegateTool(DelegateConfig{
+		Engine:   eng,
+		Registry: toolReg,
+		Model:    model,
+		APIKey:   "test-key",
+		System:   "You are a test assistant.",
+	})
+	toolReg.Register(dt)
+
+	return dt
+}
+
+func TestDelegateSingleTask(t *testing.T) {
+	dt := newTestDelegateTool("subagent result")
+
+	result, err := dt.Execute(context.Background(), map[string]any{
+		"tasks": []any{
+			map[string]any{
+				"id":   "t1",
+				"task": "Do something",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, `"t1"`) {
+		t.Fatalf("expected task ID t1 in result, got: %s", result)
+	}
+	if !strings.Contains(result, "subagent result") {
+		t.Fatalf("expected 'subagent result' in output, got: %s", result)
+	}
+}
+
+func TestDelegateParallelTasks(t *testing.T) {
+	dt := newTestDelegateTool("parallel result")
+
+	result, err := dt.Execute(context.Background(), map[string]any{
+		"tasks": []any{
+			map[string]any{"id": "a", "task": "Task A"},
+			map[string]any{"id": "b", "task": "Task B"},
+			map[string]any{"id": "c", "task": "Task C"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, id := range []string{"a", "b", "c"} {
+		if !strings.Contains(result, `"`+id+`"`) {
+			t.Fatalf("expected task ID %s in result, got: %s", id, result)
+		}
+	}
+}
+
+func TestDelegateToolWhitelistValid(t *testing.T) {
+	dt := newTestDelegateTool("whitelisted")
+
+	result, err := dt.Execute(context.Background(), map[string]any{
+		"tasks": []any{
+			map[string]any{
+				"id":    "t1",
+				"task":  "Read only",
+				"tools": []any{"read"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "whitelisted") {
+		t.Fatalf("expected output in result, got: %s", result)
+	}
+}
+
+func TestDelegateToolWhitelistInvalid(t *testing.T) {
+	dt := newTestDelegateTool("should not appear")
+
+	result, err := dt.Execute(context.Background(), map[string]any{
+		"tasks": []any{
+			map[string]any{
+				"id":    "t1",
+				"task":  "Use nonexistent tool",
+				"tools": []any{"nonexistent_tool"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should contain an error for the task, not a panic.
+	if !strings.Contains(result, "unknown tool") {
+		t.Fatalf("expected 'unknown tool' error in result, got: %s", result)
+	}
+}
+
+func TestDelegateDelegateExcludedFromChildren(t *testing.T) {
+	dt := newTestDelegateTool("child response")
+
+	toolSet, defs, err := dt.buildScopedTools(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := toolSet[delegateToolName]; ok {
+		t.Fatalf("delegate tool should be excluded from child tool set")
+	}
+	for _, def := range defs {
+		if def.Name == delegateToolName {
+			t.Fatalf("delegate tool should be excluded from child tool definitions")
+		}
+	}
+}
+
+func TestDelegateDelegateInWhitelistIgnored(t *testing.T) {
+	dt := newTestDelegateTool("child response")
+
+	// Requesting delegate in whitelist should silently skip it.
+	toolSet, defs, err := dt.buildScopedTools([]string{"read", "delegate"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := toolSet[delegateToolName]; ok {
+		t.Fatalf("delegate should be excluded even when explicitly whitelisted")
+	}
+	if len(defs) != 1 || defs[0].Name != "read" {
+		t.Fatalf("expected only 'read' in defs, got: %v", defs)
+	}
+}
+
+func TestDelegateTimeout(t *testing.T) {
+	// Use a provider that keeps looping with tool calls, paired with a slow tool.
+	reg := ai.NewRegistry()
+	reg.Register(loopingProvider{})
+
+	toolReg := &Registry{tools: make(map[string]Tool)}
+	toolReg.Register(&slowTool{})
+	eng := &engine.Engine{Providers: reg}
+
+	dt := NewDelegateTool(DelegateConfig{
+		Engine:   eng,
+		Registry: toolReg,
+		Model:    ai.Model{API: "looping", Name: "stub"},
+		APIKey:   "test",
+		System:   "test",
+	})
+	toolReg.Register(dt)
+
+	start := time.Now()
+	result, err := dt.Execute(context.Background(), map[string]any{
+		"tasks": []any{
+			map[string]any{
+				"id":              "slow",
+				"task":            "Do slow thing",
+				"timeout_seconds": float64(1),
+			},
+		},
+	})
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should complete around 1 second via context timeout, not run all turns.
+	if elapsed > 5*time.Second {
+		t.Fatalf("expected timeout around 1s, took %v", elapsed)
+	}
+	// Result should contain an error (context deadline exceeded).
+	if !strings.Contains(result, "error") {
+		t.Logf("result: %s", result)
+	}
+}
+
+// loopingProvider always emits a tool call to keep the loop going.
+type loopingProvider struct{}
+
+func (loopingProvider) API() string { return "looping" }
+
+func (loopingProvider) Stream(_ ai.Model, _ ai.Context, _ ai.StreamOptions) (ai.AssistantEventStream, error) {
+	out := ai.NewChannelEventStream(8)
+	go func() {
+		out.Emit(ai.EventToolCallDelta{ID: "call_1", Name: "slow_tool", Arguments: "{}"})
+		out.Emit(ai.EventStop{Reason: ai.StopReasonToolUse})
+		out.Finish(nil)
+	}()
+	return out, nil
+}
+
+func (loopingProvider) StreamSimple(_ ai.Model, _ ai.Context, _ ai.SimpleStreamOptions) (ai.AssistantEventStream, error) {
+	return loopingProvider{}.Stream(ai.Model{}, ai.Context{}, ai.StreamOptions{})
+}
+
+// slowTool sleeps until context is cancelled.
+type slowTool struct{}
+
+func (s *slowTool) Definition() toolspec.Definition {
+	return toolspec.Definition{
+		Name:        "slow_tool",
+		Description: "A tool that blocks.",
+		InputSchema: map[string]any{"type": "object", "properties": map[string]any{}},
+	}
+}
+
+func (s *slowTool) Execute(ctx context.Context, _ map[string]any) (string, error) {
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	case <-time.After(30 * time.Second):
+		return "done", nil
+	}
+}
+
+func TestDelegateOutputTruncation(t *testing.T) {
+	long := strings.Repeat("x", maxResultChars+100)
+	truncated := truncateResult(long, maxResultChars)
+
+	if !strings.HasSuffix(truncated, "[truncated]") {
+		t.Fatalf("expected [truncated] suffix")
+	}
+	// Should be maxResultChars runes + "\n[truncated]"
+	runes := []rune(truncated)
+	expected := maxResultChars + len([]rune("\n[truncated]"))
+	if len(runes) != expected {
+		t.Fatalf("expected %d runes, got %d", expected, len(runes))
+	}
+}
+
+func TestDelegateParseErrors(t *testing.T) {
+	dt := newTestDelegateTool("unused")
+
+	tests := []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"missing tasks", map[string]any{}, "tasks is required"},
+		{"tasks not array", map[string]any{"tasks": "bad"}, "tasks must be an array"},
+		{"missing id", map[string]any{"tasks": []any{map[string]any{"task": "x"}}}, "id is required"},
+		{"missing task", map[string]any{"tasks": []any{map[string]any{"id": "x"}}}, "task is required"},
+		{"duplicate id", map[string]any{"tasks": []any{
+			map[string]any{"id": "x", "task": "a"},
+			map[string]any{"id": "x", "task": "b"},
+		}}, "duplicate id"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := dt.Execute(context.Background(), tt.args)
+			if err == nil {
+				t.Fatalf("expected error containing %q", tt.want)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected error containing %q, got: %v", tt.want, err)
+			}
+		})
+	}
+}
+
+func TestDelegatePanicRecovery(t *testing.T) {
+	// Create a provider that panics.
+	reg := ai.NewRegistry()
+	reg.Register(panicProvider{})
+
+	toolReg := &Registry{tools: make(map[string]Tool)}
+	eng := &engine.Engine{Providers: reg}
+
+	dt := NewDelegateTool(DelegateConfig{
+		Engine:   eng,
+		Registry: toolReg,
+		Model:    ai.Model{API: "panic", Name: "stub"},
+		APIKey:   "test",
+		System:   "test",
+	})
+
+	result, err := dt.Execute(context.Background(), map[string]any{
+		"tasks": []any{
+			map[string]any{"id": "boom", "task": "Cause panic"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "panic") || !strings.Contains(result, "boom") {
+		// The result should contain the task ID and a panic error.
+		t.Logf("result: %s", result)
+	}
+}
+
+type panicProvider struct{}
+
+func (panicProvider) API() string { return "panic" }
+
+func (panicProvider) Stream(ai.Model, ai.Context, ai.StreamOptions) (ai.AssistantEventStream, error) {
+	panic("test panic in provider")
+}
+
+func (panicProvider) StreamSimple(ai.Model, ai.Context, ai.SimpleStreamOptions) (ai.AssistantEventStream, error) {
+	panic("test panic in provider")
+}
+
+func TestDelegateDefinition(t *testing.T) {
+	dt := newTestDelegateTool("unused")
+	def := dt.Definition()
+
+	if def.Name != "delegate" {
+		t.Fatalf("expected name 'delegate', got %q", def.Name)
+	}
+	if def.InputSchema == nil {
+		t.Fatalf("expected non-nil input schema")
+	}
+
+	props, ok := def.InputSchema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected properties in schema")
+	}
+	if _, ok := props["tasks"]; !ok {
+		t.Fatalf("expected 'tasks' property in schema")
+	}
+}
+
+func TestExtractLastAssistantText(t *testing.T) {
+	tests := []struct {
+		name    string
+		history []ai.Message
+		want    string
+	}{
+		{
+			"empty history",
+			nil,
+			"",
+		},
+		{
+			"single assistant",
+			[]ai.Message{
+				ai.AssistantMessage{Content: []ai.ContentBlock{ai.TextContent{Text: "hello"}}},
+			},
+			"hello",
+		},
+		{
+			"user then assistant",
+			[]ai.Message{
+				ai.UserMessage{Content: "hi"},
+				ai.AssistantMessage{Content: []ai.ContentBlock{ai.TextContent{Text: "response"}}},
+			},
+			"response",
+		},
+		{
+			"last assistant wins",
+			[]ai.Message{
+				ai.AssistantMessage{Content: []ai.ContentBlock{ai.TextContent{Text: "first"}}},
+				ai.UserMessage{Content: "more"},
+				ai.AssistantMessage{Content: []ai.ContentBlock{ai.TextContent{Text: "second"}}},
+			},
+			"second",
+		},
+		{
+			"tool result after assistant",
+			[]ai.Message{
+				ai.AssistantMessage{Content: []ai.ContentBlock{ai.TextContent{Text: "before tool"}}},
+				ai.ToolResultMessage{Content: []ai.ContentBlock{ai.TextContent{Text: "tool output"}}},
+			},
+			"before tool",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractLastAssistantText(tt.history)
+			if got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestRegistryHas(t *testing.T) {
+	r := &Registry{tools: make(map[string]Tool)}
+	r.Register(&ReadTool{})
+
+	if !r.Has("read") {
+		t.Fatalf("expected Has('read') to be true")
+	}
+	if r.Has("nonexistent") {
+		t.Fatalf("expected Has('nonexistent') to be false")
+	}
+}
+
+// Verify that the toolspec.Definition interface is satisfied.
+var _ Tool = (*DelegateTool)(nil)
+
+// Suppress unused import warnings for toolspec.
+var _ toolspec.Definition

--- a/internal/agent/tool/delegate_test.go
+++ b/internal/agent/tool/delegate_test.go
@@ -141,7 +141,7 @@ func TestDelegateToolWhitelistInvalid(t *testing.T) {
 func TestDelegateDelegateExcludedFromChildren(t *testing.T) {
 	dt := newTestDelegateTool("child response")
 
-	toolSet, defs, err := dt.buildScopedTools(nil)
+	toolSet, defs, err := dt.buildScopedTools(nil, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -159,7 +159,7 @@ func TestDelegateDelegateInWhitelistIgnored(t *testing.T) {
 	dt := newTestDelegateTool("child response")
 
 	// Requesting delegate in whitelist should silently skip it.
-	toolSet, defs, err := dt.buildScopedTools([]string{"read", "delegate"})
+	toolSet, defs, err := dt.buildScopedTools([]string{"read", "delegate"}, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -168,6 +168,22 @@ func TestDelegateDelegateInWhitelistIgnored(t *testing.T) {
 	}
 	if len(defs) != 1 || defs[0].Name != "read" {
 		t.Fatalf("expected only 'read' in defs, got: %v", defs)
+	}
+}
+
+func TestDelegateEmptyWhitelistGivesNoTools(t *testing.T) {
+	dt := newTestDelegateTool("no tools")
+
+	// Explicit empty whitelist should yield zero tools.
+	toolSet, defs, err := dt.buildScopedTools(nil, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(toolSet) != 0 {
+		t.Fatalf("expected empty tool set, got %d tools", len(toolSet))
+	}
+	if len(defs) != 0 {
+		t.Fatalf("expected empty defs, got %d", len(defs))
 	}
 }
 

--- a/internal/agent/tool/delegate_test.go
+++ b/internal/agent/tool/delegate_test.go
@@ -226,7 +226,7 @@ func TestDelegateTimeout(t *testing.T) {
 	}
 	// Result should contain an error (context deadline exceeded).
 	if !strings.Contains(result, "error") {
-		t.Logf("result: %s", result)
+		t.Fatalf("expected 'error' in result, got: %s", result)
 	}
 }
 
@@ -339,9 +339,11 @@ func TestDelegatePanicRecovery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(result, "panic") || !strings.Contains(result, "boom") {
-		// The result should contain the task ID and a panic error.
-		t.Logf("result: %s", result)
+	if !strings.Contains(result, "panic") {
+		t.Fatalf("expected 'panic' in result, got: %s", result)
+	}
+	if !strings.Contains(result, "boom") {
+		t.Fatalf("expected task ID 'boom' in result, got: %s", result)
 	}
 }
 

--- a/internal/agent/tool/tool.go
+++ b/internal/agent/tool/tool.go
@@ -43,6 +43,12 @@ func (r *Registry) Definitions() []toolspec.Definition {
 	return defs
 }
 
+// Has reports whether the registry contains a tool with the given name.
+func (r *Registry) Has(name string) bool {
+	_, ok := r.tools[name]
+	return ok
+}
+
 // Execute runs the named tool with given arguments.
 func (r *Registry) Execute(ctx context.Context, name string, args map[string]any) (string, error) {
 	t, ok := r.tools[name]


### PR DESCRIPTION
## Summary

- Add `delegate` tool that spawns child agent loops with isolated context for bounded subtasks
- Multiple tasks run in parallel via goroutines with `sync.WaitGroup`
- Per-task options: model override, system prompt append, tool whitelist, max_turns (default 10), timeout_seconds (default 120)
- Recursion prevention: `delegate` is always excluded from child tool sets
- Panic recovery per goroutine, structured `slog` logging (start/finish/error with task ID and duration)
- Child output truncated to ~4096 tokens to prevent parent context bloat
- Add `Registry.Has()` method for tool whitelist validation

## Files changed

| File | Change |
|------|--------|
| `internal/agent/tool/delegate.go` | New — `DelegateTool` implementation, `runSubAgent`, scoped tool builder, arg parsing |
| `internal/agent/tool/delegate_test.go` | New — 11 tests: single/parallel, whitelist valid/invalid, recursion exclusion, timeout, truncation, parse errors, panic recovery, definition, extract text |
| `internal/agent/tool/tool.go` | Add `Registry.Has()` method |
| `internal/agent/runner/gorunner.go` | Register delegate tool in `NewGoRunner` |
| `internal/agent/runner/builtin/anna/SKILL.md` | Add delegation section to anna self-knowledge |
| `docs/content/docs/core/architecture.md` | Add delegate to package layout and tools docs |

## Test plan

- [x] `go test -race ./internal/agent/tool/` — all 11 delegate tests pass
- [x] `go test -race ./...` — full suite passes
- [x] `golangci-lint run` — 0 issues
- [ ] Manual: verify delegate tool appears in LLM tool list during chat
- [ ] Manual: test single and parallel delegation in a real session

Closes #54