### PR TITLE
feat: add dual plugin system (Go + JS)

### DIFF
--- a/cmd/anna/chat.go
+++ b/cmd/anna/chat.go
@@ -46,7 +46,7 @@ func chatCommand() *ucli.Command {
 				return clicmd.RunStream(s.ctx, s.pool)
 			}
 			listFn := func() []channel.ModelOption { return collectModels(s.cfg) }
-			switchFn := modelSwitcher(s.cfg, s.pool, s.extraTools)
+			switchFn := modelSwitcher(s.cfg, s.pool, s.extraTools, s.pluginMgr.Registry())
 			return clicmd.RunChat(s.ctx, s.pool, s.cfg.Provider, s.cfg.Model, listFn, switchFn)
 		},
 	}

--- a/cmd/anna/commands.go
+++ b/cmd/anna/commands.go
@@ -100,7 +100,8 @@ func setup(parent context.Context, gateway bool) (*setupResult, error) {
 		memorytool.NewExpandTool(memoryEngine),
 	)
 
-	// Collect built-in tool names for plugin collision detection.
+	// Built-in tool names registered in GoRunner (internal/agent/tool/).
+	// Keep in sync with tool registrations in internal/agent/runner/gorunner.go.
 	builtinNames := append([]string{}, "read", "bash", "edit", "write", "web_fetch", "delegate")
 	for _, t := range extraTools {
 		builtinNames = append(builtinNames, t.Definition().Name)

--- a/cmd/anna/commands.go
+++ b/cmd/anna/commands.go
@@ -31,6 +31,7 @@ func newApp() *ucli.App {
 			gatewayCommand(),
 			modelsCommand(),
 			skillsCommand(),
+			pluginCommand(),
 			onboardCommand(),
 			versionCommand(),
 			upgradeCommand(),

--- a/cmd/anna/commands.go
+++ b/cmd/anna/commands.go
@@ -16,6 +16,7 @@ import (
 	"github.com/vaayne/anna/internal/config"
 	"github.com/vaayne/anna/internal/memory"
 	memorytool "github.com/vaayne/anna/internal/memory/tool"
+	pluginmgr "github.com/vaayne/anna/internal/plugin"
 	"github.com/vaayne/anna/internal/scheduler"
 	"github.com/vaayne/anna/internal/skills"
 )
@@ -44,6 +45,7 @@ type setupResult struct {
 	schedulerSvc *scheduler.Service
 	extraTools   []tool.Tool
 	notifier     *channel.Dispatcher
+	pluginMgr    *pluginmgr.Manager
 }
 
 func setup(parent context.Context, gateway bool) (*setupResult, error) {
@@ -97,8 +99,25 @@ func setup(parent context.Context, gateway bool) (*setupResult, error) {
 		memorytool.NewExpandTool(memoryEngine),
 	)
 
+	// Collect built-in tool names for plugin collision detection.
+	builtinNames := append([]string{}, "read", "bash", "edit", "write", "web_fetch", "delegate")
+	for _, t := range extraTools {
+		builtinNames = append(builtinNames, t.Definition().Name)
+	}
+
+	// Load plugins.
+	pm := pluginmgr.NewManager(slog.Default(), builtinNames)
+	if err := pm.LoadAll(cfg.Plugins); err != nil {
+		slog.Warn("plugin loading had errors", "error", err)
+	}
+
+	// Adapt plugin tools into the extra tools list.
+	for _, pt := range pm.Registry().Tools() {
+		extraTools = append(extraTools, pluginmgr.AdaptTool(pt))
+	}
+
 	idleTimeout := time.Duration(cfg.Runner.IdleTimeout) * time.Minute
-	factory, err := newRunnerFactory(cfg, extraTools)
+	factory, err := newRunnerFactory(cfg, extraTools, pm.Registry())
 	if err != nil {
 		return nil, fmt.Errorf("create runner factory: %w", err)
 	}
@@ -111,6 +130,7 @@ func setup(parent context.Context, gateway bool) (*setupResult, error) {
 		}.WithDefaults()),
 		agent.WithDefaultModel(cfg.ResolveModelID(config.ModelTierStrong)),
 		agent.WithFastModel(cfg.ResolveModelID(config.ModelTierFast)),
+		agent.WithPluginHooks(pm.Registry()),
 	}
 
 	pool := agent.NewPool(factory, memoryEngine, opts...)
@@ -150,6 +170,7 @@ func setup(parent context.Context, gateway bool) (*setupResult, error) {
 		schedulerSvc: schedulerSvc,
 		extraTools:   extraTools,
 		notifier:     dispatcher,
+		pluginMgr:    pm,
 	}, nil
 }
 
@@ -159,7 +180,7 @@ func hasEnabledNotifyChannel(cfg *config.Config) bool {
 		(cfg.Channels.Feishu.IsEnabled() && cfg.Channels.Feishu.IsNotifyEnabled())
 }
 
-func newRunnerFactory(cfg *config.Config, extraTools []tool.Tool) (runner.NewRunnerFunc, error) {
+func newRunnerFactory(cfg *config.Config, extraTools []tool.Tool, pluginHooks *pluginmgr.Registry) (runner.NewRunnerFunc, error) {
 	switch cfg.Runner.Type {
 	case "go":
 		providerCfg := cfg.Providers[cfg.Provider]
@@ -168,13 +189,14 @@ func newRunnerFactory(cfg *config.Config, extraTools []tool.Tool) (runner.NewRun
 				model = cfg.Model
 			}
 			return runner.NewGoRunner(ctx, runner.GoRunnerConfig{
-				API:        cfg.Provider,
-				Model:      model,
-				APIKey:     providerCfg.APIKey,
-				Workspace:  cfg.Workspace,
-				AnnaHome:   config.AnnaHome(),
-				BaseURL:    providerCfg.BaseURL,
-				ExtraTools: extraTools,
+				API:         cfg.Provider,
+				Model:       model,
+				APIKey:      providerCfg.APIKey,
+				Workspace:   cfg.Workspace,
+				AnnaHome:    config.AnnaHome(),
+				BaseURL:     providerCfg.BaseURL,
+				ExtraTools:  extraTools,
+				PluginHooks: pluginHooks,
 			})
 		}, nil
 	default:
@@ -184,11 +206,11 @@ func newRunnerFactory(cfg *config.Config, extraTools []tool.Tool) (runner.NewRun
 
 // modelSwitcher returns a function that switches the pool's runner factory
 // to use a different provider/model combination.
-func modelSwitcher(cfg *config.Config, pool *agent.Pool, extraTools []tool.Tool) channel.ModelSwitchFunc {
+func modelSwitcher(cfg *config.Config, pool *agent.Pool, extraTools []tool.Tool, pluginHooks *pluginmgr.Registry) channel.ModelSwitchFunc {
 	return func(provider, model string) error {
 		cfg.Provider = provider
 		cfg.Model = model
-		factory, err := newRunnerFactory(cfg, extraTools)
+		factory, err := newRunnerFactory(cfg, extraTools, pluginHooks)
 		if err != nil {
 			return err
 		}

--- a/cmd/anna/commands_test.go
+++ b/cmd/anna/commands_test.go
@@ -59,7 +59,7 @@ func TestNewRunnerFactoryGo(t *testing.T) {
 		},
 	}
 
-	factory, err := newRunnerFactory(cfg, nil)
+	factory, err := newRunnerFactory(cfg, nil, nil)
 	if err != nil {
 		t.Fatalf("newRunnerFactory: %v", err)
 	}
@@ -79,7 +79,7 @@ func TestNewRunnerFactoryUnknown(t *testing.T) {
 		Runner: config.RunnerConfig{Type: "invalid"},
 	}
 
-	_, err := newRunnerFactory(cfg, nil)
+	_, err := newRunnerFactory(cfg, nil, nil)
 	if err == nil {
 		t.Fatal("expected error for unknown runner type")
 	}

--- a/cmd/anna/gateway.go
+++ b/cmd/anna/gateway.go
@@ -37,7 +37,7 @@ func gatewayCommand() *ucli.Command {
 			// so early-firing jobs already have the dispatcher callback.
 
 			listFn := func() []channel.ModelOption { return collectModels(s.cfg) }
-			switchFn := modelSwitcher(s.cfg, s.pool, s.extraTools)
+			switchFn := modelSwitcher(s.cfg, s.pool, s.extraTools, s.pluginMgr.Registry())
 			return runGateway(s.ctx, s, listFn, switchFn)
 		},
 	}

--- a/cmd/anna/main.go
+++ b/cmd/anna/main.go
@@ -6,9 +6,7 @@ import (
 	"os"
 )
 
-// Main is the exported entry point for custom binaries built with Go plugins.
-// Plugin authors import this package and call Main() from their generated main.go.
-func Main() {
+func main() {
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
 	})))
@@ -19,8 +17,4 @@ func Main() {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
-}
-
-func main() {
-	Main()
 }

--- a/cmd/anna/main.go
+++ b/cmd/anna/main.go
@@ -6,7 +6,9 @@ import (
 	"os"
 )
 
-func main() {
+// Main is the exported entry point for custom binaries built with Go plugins.
+// Plugin authors import this package and call Main() from their generated main.go.
+func Main() {
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
 	})))
@@ -17,4 +19,8 @@ func main() {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+}
+
+func main() {
+	Main()
 }

--- a/cmd/anna/plugin.go
+++ b/cmd/anna/plugin.go
@@ -1,0 +1,328 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	ucli "github.com/urfave/cli/v2"
+	"github.com/vaayne/anna/internal/config"
+	"github.com/vaayne/anna/internal/plugin/goplugin"
+	"gopkg.in/yaml.v3"
+)
+
+func pluginCommand() *ucli.Command {
+	return &ucli.Command{
+		Name:  "plugin",
+		Usage: "Manage plugins",
+		Subcommands: []*ucli.Command{
+			pluginListCommand(),
+			pluginAddCommand(),
+			pluginRemoveCommand(),
+			pluginBuildCommand(),
+		},
+		Action: func(c *ucli.Context) error {
+			return pluginListAction()
+		},
+	}
+}
+
+func pluginListCommand() *ucli.Command {
+	return &ucli.Command{
+		Name:  "list",
+		Usage: "List all configured plugins",
+		Action: func(c *ucli.Context) error {
+			return pluginListAction()
+		},
+	}
+}
+
+func pluginListAction() error {
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	if len(cfg.Plugins) == 0 {
+		fmt.Println("No plugins configured.")
+		return nil
+	}
+
+	fmt.Printf("%-20s %-6s %s\n", "NAME", "TYPE", "PATH")
+	for _, p := range cfg.Plugins {
+		name := pluginName(p.Path)
+		kind := pluginKind(p.Path)
+		fmt.Printf("%-20s %-6s %s\n", name, kind, p.Path)
+	}
+	return nil
+}
+
+func pluginAddCommand() *ucli.Command {
+	return &ucli.Command{
+		Name:      "add",
+		Usage:     "Add a plugin to config.yaml (local .js file or Go directory)",
+		ArgsUsage: "<path>",
+		Flags: []ucli.Flag{
+			&ucli.StringSliceFlag{
+				Name:  "config",
+				Usage: "Plugin config key=value (repeatable)",
+			},
+		},
+		Action: func(c *ucli.Context) error {
+			path := c.Args().First()
+			if path == "" {
+				return fmt.Errorf("usage: anna plugin add <path>")
+			}
+
+			resolved := expandPluginPath(path)
+			if _, err := os.Stat(resolved); err != nil {
+				return fmt.Errorf("path %q does not exist", path)
+			}
+
+			kind := pluginKind(resolved)
+			if kind == "unknown" {
+				return fmt.Errorf("cannot detect plugin type for %q (expected .js file or directory with go.mod)", path)
+			}
+
+			pluginCfg := parsePluginConfig(c.StringSlice("config"))
+
+			if err := addPluginToConfig(path, pluginCfg); err != nil {
+				return err
+			}
+
+			name := pluginName(path)
+			fmt.Printf("Plugin %q (%s) added.\n", name, kind)
+			return nil
+		},
+	}
+}
+
+func pluginRemoveCommand() *ucli.Command {
+	return &ucli.Command{
+		Name:      "remove",
+		Aliases:   []string{"rm"},
+		Usage:     "Remove a plugin from config.yaml by name or path",
+		ArgsUsage: "<name|path>",
+		Action: func(c *ucli.Context) error {
+			target := c.Args().First()
+			if target == "" {
+				return fmt.Errorf("usage: anna plugin remove <name|path>")
+			}
+
+			if err := removePluginFromConfig(target); err != nil {
+				return err
+			}
+
+			fmt.Printf("Plugin %q removed.\n", target)
+			return nil
+		},
+	}
+}
+
+func pluginBuildCommand() *ucli.Command {
+	return &ucli.Command{
+		Name:  "build",
+		Usage: "Compile a custom binary with all Go plugins",
+		Flags: []ucli.Flag{
+			&ucli.StringFlag{
+				Name:  "output",
+				Usage: "Output binary path",
+				Value: "./anna-custom",
+			},
+		},
+		Action: func(c *ucli.Context) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+
+			var goPaths []string
+			for _, p := range cfg.Plugins {
+				resolved := expandPluginPath(p.Path)
+				if pluginKind(resolved) == "go" {
+					goPaths = append(goPaths, resolved)
+				}
+			}
+
+			if len(goPaths) == 0 {
+				fmt.Println("No Go plugins configured. Nothing to build.")
+				return nil
+			}
+
+			output := c.String("output")
+			fmt.Fprintf(os.Stderr, "Building custom binary with %d Go plugin(s)...\n", len(goPaths))
+
+			builder := goplugin.NewBuilder(goPaths, output, slog.Default())
+			if err := builder.Build(c.Context); err != nil {
+				return fmt.Errorf("build failed: %w", err)
+			}
+
+			fmt.Printf("Custom binary built: %s\n", output)
+			return nil
+		},
+	}
+}
+
+// addPluginToConfig reads config.yaml, appends the plugin (deduplicating by
+// path), and writes it back preserving other fields.
+func addPluginToConfig(path string, pluginCfg map[string]any) error {
+	raw, err := readConfigRaw()
+	if err != nil {
+		return err
+	}
+
+	plugins := rawPlugins(raw)
+
+	// Deduplicate by path.
+	for _, p := range plugins {
+		if pm, ok := p.(map[string]any); ok {
+			if pm["path"] == path {
+				return fmt.Errorf("plugin %q is already configured", path)
+			}
+		}
+	}
+
+	entry := map[string]any{"path": path}
+	if len(pluginCfg) > 0 {
+		entry["config"] = pluginCfg
+	}
+	plugins = append(plugins, entry)
+	raw["plugins"] = plugins
+
+	return writeConfigRaw(raw)
+}
+
+// removePluginFromConfig removes a plugin by matching name or path.
+func removePluginFromConfig(target string) error {
+	raw, err := readConfigRaw()
+	if err != nil {
+		return err
+	}
+
+	plugins := rawPlugins(raw)
+	var remaining []any
+	found := false
+
+	for _, p := range plugins {
+		pm, ok := p.(map[string]any)
+		if !ok {
+			remaining = append(remaining, p)
+			continue
+		}
+		pPath, _ := pm["path"].(string)
+		if pPath == target || pluginName(pPath) == target {
+			found = true
+			continue
+		}
+		remaining = append(remaining, p)
+	}
+
+	if !found {
+		return fmt.Errorf("plugin %q not found in config", target)
+	}
+
+	if len(remaining) == 0 {
+		delete(raw, "plugins")
+	} else {
+		raw["plugins"] = remaining
+	}
+
+	return writeConfigRaw(raw)
+}
+
+// readConfigRaw reads config.yaml as a generic map to preserve all fields.
+func readConfigRaw() (map[string]any, error) {
+	data, err := os.ReadFile(config.Path())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return make(map[string]any), nil
+		}
+		return nil, fmt.Errorf("read config: %w", err)
+	}
+	var raw map[string]any
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parse config: %w", err)
+	}
+	if raw == nil {
+		raw = make(map[string]any)
+	}
+	return raw, nil
+}
+
+// writeConfigRaw marshals the raw map back to config.yaml.
+func writeConfigRaw(raw map[string]any) error {
+	data, err := yaml.Marshal(raw)
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+	return os.WriteFile(config.Path(), data, 0o644)
+}
+
+// rawPlugins extracts the plugins slice from a raw config map.
+func rawPlugins(raw map[string]any) []any {
+	v, ok := raw["plugins"]
+	if !ok {
+		return nil
+	}
+	plugins, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	return plugins
+}
+
+// parsePluginConfig parses key=value strings into a map.
+func parsePluginConfig(pairs []string) map[string]any {
+	if len(pairs) == 0 {
+		return nil
+	}
+	m := make(map[string]any, len(pairs))
+	for _, pair := range pairs {
+		k, v, ok := strings.Cut(pair, "=")
+		if ok {
+			m[k] = v
+		}
+	}
+	return m
+}
+
+// pluginName returns a human-friendly name from a plugin path.
+func pluginName(path string) string {
+	base := filepath.Base(path)
+	return strings.TrimSuffix(base, filepath.Ext(base))
+}
+
+// pluginKind detects plugin type from path (replicates manager.detectKind logic).
+func pluginKind(path string) string {
+	resolved := expandPluginPath(path)
+	info, err := os.Stat(resolved)
+	if err != nil {
+		// Cannot stat; fall back to extension heuristic.
+		if strings.HasSuffix(path, ".js") {
+			return "js"
+		}
+		return "unknown"
+	}
+	if !info.IsDir() && strings.HasSuffix(path, ".js") {
+		return "js"
+	}
+	if info.IsDir() {
+		if _, err := os.Stat(filepath.Join(resolved, "go.mod")); err == nil {
+			return "go"
+		}
+	}
+	return "unknown"
+}
+
+// expandPluginPath expands ~ to the user's home directory.
+func expandPluginPath(path string) string {
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			return filepath.Join(home, path[2:])
+		}
+	}
+	return path
+}

--- a/cmd/anna/plugin.go
+++ b/cmd/anna/plugin.go
@@ -9,6 +9,7 @@ import (
 
 	ucli "github.com/urfave/cli/v2"
 	"github.com/vaayne/anna/internal/config"
+	pluginmgr "github.com/vaayne/anna/internal/plugin"
 	"github.com/vaayne/anna/internal/plugin/goplugin"
 	"gopkg.in/yaml.v3"
 )
@@ -53,7 +54,7 @@ func pluginListAction() error {
 	fmt.Printf("%-20s %-6s %s\n", "NAME", "TYPE", "PATH")
 	for _, p := range cfg.Plugins {
 		name := pluginName(p.Path)
-		kind := pluginKind(p.Path)
+		kind := pluginmgr.DetectKind(pluginmgr.ExpandPath(p.Path))
 		fmt.Printf("%-20s %-6s %s\n", name, kind, p.Path)
 	}
 	return nil
@@ -76,13 +77,13 @@ func pluginAddCommand() *ucli.Command {
 				return fmt.Errorf("usage: anna plugin add <path>")
 			}
 
-			resolved := expandPluginPath(path)
+			resolved := pluginmgr.ExpandPath(path)
 			if _, err := os.Stat(resolved); err != nil {
 				return fmt.Errorf("path %q does not exist", path)
 			}
 
-			kind := pluginKind(resolved)
-			if kind == "unknown" {
+			kind := pluginmgr.DetectKind(resolved)
+			if kind == "" {
 				return fmt.Errorf("cannot detect plugin type for %q (expected .js file or directory with go.mod)", path)
 			}
 
@@ -140,8 +141,8 @@ func pluginBuildCommand() *ucli.Command {
 
 			var goPaths []string
 			for _, p := range cfg.Plugins {
-				resolved := expandPluginPath(p.Path)
-				if pluginKind(resolved) == "go" {
+				resolved := pluginmgr.ExpandPath(p.Path)
+				if pluginmgr.DetectKind(resolved) == "go" {
 					goPaths = append(goPaths, resolved)
 				}
 			}
@@ -292,37 +293,4 @@ func parsePluginConfig(pairs []string) map[string]any {
 func pluginName(path string) string {
 	base := filepath.Base(path)
 	return strings.TrimSuffix(base, filepath.Ext(base))
-}
-
-// pluginKind detects plugin type from path (replicates manager.detectKind logic).
-func pluginKind(path string) string {
-	resolved := expandPluginPath(path)
-	info, err := os.Stat(resolved)
-	if err != nil {
-		// Cannot stat; fall back to extension heuristic.
-		if strings.HasSuffix(path, ".js") {
-			return "js"
-		}
-		return "unknown"
-	}
-	if !info.IsDir() && strings.HasSuffix(path, ".js") {
-		return "js"
-	}
-	if info.IsDir() {
-		if _, err := os.Stat(filepath.Join(resolved, "go.mod")); err == nil {
-			return "go"
-		}
-	}
-	return "unknown"
-}
-
-// expandPluginPath expands ~ to the user's home directory.
-func expandPluginPath(path string) string {
-	if strings.HasPrefix(path, "~/") {
-		home, err := os.UserHomeDir()
-		if err == nil {
-			return filepath.Join(home, path[2:])
-		}
-	}
-	return path
 }

--- a/docs/content/docs/features/meta.json
+++ b/docs/content/docs/features/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Features",
-  "pages": ["scheduler-system", "notification-system"]
+  "pages": ["scheduler-system", "notification-system", "plugin-system"]
 }

--- a/docs/content/docs/features/plugin-system.md
+++ b/docs/content/docs/features/plugin-system.md
@@ -1,0 +1,142 @@
+---
+title: Plugin System
+---
+
+## Overview
+
+Anna supports a dual plugin system that lets you extend the assistant with custom tools and lifecycle hooks. There are two plugin types:
+
+- **JS extensions** -- sandboxed JavaScript files loaded at runtime, no compilation required
+- **Go plugins** -- Go packages compiled into a custom anna binary for full-power extensions
+
+Both types are configured in `~/.anna/config.yaml` under the `plugins:` key.
+
+## Configuration
+
+Each plugin entry specifies a `path` and an optional `config` map that is passed to the plugin at load time:
+
+```yaml
+plugins:
+  - path: ~/.anna/plugins/weather.js
+    config:
+      api_key: "xxx"
+  - path: ~/.anna/plugins/github-tools
+    config:
+      token: "yyy"
+```
+
+- **JS extensions**: `path` points to a `.js` file
+- **Go plugins**: `path` points to a directory containing Go source
+
+## JS Extensions
+
+JS extensions are single `.js` files that run in a sandboxed QuickJS runtime. They interact with anna through the `anna` host object, which provides the following APIs:
+
+### Registering tools
+
+```js
+anna.registerTool({
+  name: "weather_lookup",
+  description: "Look up current weather for a city",
+  parameters: {
+    type: "object",
+    properties: {
+      city: { type: "string", description: "City name" }
+    },
+    required: ["city"]
+  }
+}, function(params) {
+  var resp = anna.fetch("https://api.weather.example.com/v1/current?q=" + params.city, {
+    headers: { "Authorization": "Bearer " + anna.config.api_key }
+  });
+  return JSON.parse(resp.body);
+});
+```
+
+### Lifecycle hooks
+
+```js
+anna.on("session:start", function(event) {
+  anna.log("Session started: " + event.session_id);
+});
+
+anna.on("session:end", function(event) {
+  anna.log("Session ended: " + event.session_id);
+});
+
+anna.on("tool:before", function(event) {
+  anna.log("About to call tool: " + event.tool_name);
+});
+
+anna.on("tool:after", function(event) {
+  anna.log("Tool completed: " + event.tool_name);
+});
+```
+
+### Host APIs
+
+| Function | Description |
+|----------|-------------|
+| `anna.registerTool(schema, handler)` | Register a new tool with JSON Schema parameters |
+| `anna.on(event, handler)` | Subscribe to a lifecycle event |
+| `anna.log(message)` | Write to anna's log output |
+| `anna.readFile(path)` | Read a file (scoped to workspace) |
+| `anna.writeFile(path, content)` | Write a file (scoped to workspace) |
+| `anna.fetch(url, options)` | HTTP request (with size and timeout limits) |
+| `anna.config` | The `config` map from the plugin's YAML entry |
+
+## Go Plugins
+
+Go plugins are full Go packages that are compiled into the anna binary. They use an `init()` function to register a factory with the plugin manager:
+
+```go
+package myplugin
+
+import "github.com/anthropic/anna/internal/plugin"
+
+func init() {
+    plugin.Register("myplugin", Factory)
+}
+
+func Factory(cfg map[string]any) (plugin.Plugin, error) {
+    return &myPlugin{apiKey: cfg["api_key"].(string)}, nil
+}
+
+type myPlugin struct {
+    apiKey string
+}
+
+// Implement plugin.Plugin interface...
+```
+
+After adding or updating a Go plugin, rebuild the binary:
+
+```bash
+anna plugin build
+```
+
+This produces a custom anna binary with the Go plugin compiled in.
+
+## CLI Commands
+
+```
+anna plugin list        # List all configured plugins and their status
+anna plugin add <path>  # Add a JS or Go plugin to config
+anna plugin remove <n>  # Remove a plugin from config by index
+anna plugin build       # Build custom binary with Go plugins compiled in
+```
+
+## Security
+
+### JS sandboxing
+
+JS extensions run inside a QuickJS sandbox with the following restrictions:
+
+- **File access**: `readFile` and `writeFile` are scoped to the anna workspace directory. Path traversal outside the workspace is blocked.
+- **Network access**: `fetch` enforces response size limits and connection timeouts to prevent resource exhaustion.
+- **No system access**: JS plugins cannot execute shell commands, access environment variables, or interact with the operating system directly.
+- **Isolated runtime**: Each plugin runs in its own JS context with no shared mutable state between plugins.
+
+### Go plugins
+
+Go plugins are compiled into the binary and run with the same permissions as anna itself. Only install Go plugins from trusted sources.

--- a/docs/content/docs/features/plugin-system.md
+++ b/docs/content/docs/features/plugin-system.md
@@ -57,19 +57,19 @@ anna.registerTool({
 
 ```js
 anna.on("session:start", function(event) {
-  anna.log("Session started: " + event.session_id);
+  anna.log("info", "Session started: " + event.session_id);
 });
 
 anna.on("session:end", function(event) {
-  anna.log("Session ended: " + event.session_id);
+  anna.log("info", "Session ended: " + event.session_id);
 });
 
 anna.on("tool:before", function(event) {
-  anna.log("About to call tool: " + event.tool_name);
+  anna.log("debug", "About to call tool: " + event.tool_name);
 });
 
 anna.on("tool:after", function(event) {
-  anna.log("Tool completed: " + event.tool_name);
+  anna.log("debug", "Tool completed: " + event.tool_name);
 });
 ```
 
@@ -79,7 +79,7 @@ anna.on("tool:after", function(event) {
 |----------|-------------|
 | `anna.registerTool(schema, handler)` | Register a new tool with JSON Schema parameters |
 | `anna.on(event, handler)` | Subscribe to a lifecycle event |
-| `anna.log(message)` | Write to anna's log output |
+| `anna.log(level, message)` | Write to anna's log output at the given level (`debug`, `info`, `warn`, `error`) |
 | `anna.readFile(path)` | Read a file (scoped to workspace) |
 | `anna.writeFile(path, content)` | Write a file (scoped to workspace) |
 | `anna.fetch(url, options)` | HTTP request (with size and timeout limits) |
@@ -92,14 +92,15 @@ Go plugins are full Go packages that are compiled into the anna binary. They use
 ```go
 package myplugin
 
-import "github.com/anthropic/anna/internal/plugin"
+import "github.com/vaayne/anna/pkg/plugin"
 
 func init() {
-    plugin.Register("myplugin", Factory)
-}
-
-func Factory(cfg map[string]any) (plugin.Plugin, error) {
-    return &myPlugin{apiKey: cfg["api_key"].(string)}, nil
+    plugin.Register(plugin.Factory{
+        Name: "myplugin",
+        New: func(cfg map[string]any) (plugin.Plugin, error) {
+            return &myPlugin{apiKey: cfg["api_key"].(string)}, nil
+        },
+    })
 }
 
 type myPlugin struct {

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v0.10.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
+	github.com/fastschema/qjs v0.0.6
 	github.com/go-co-op/gocron/v2 v2.19.1
 	github.com/google/uuid v1.6.0
 	github.com/larksuite/oapi-sdk-go/v3 v3.5.3
@@ -83,6 +84,7 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect
+	github.com/tetratelabs/wazero v1.9.0 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -200,6 +200,8 @@ github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
+github.com/fastschema/qjs v0.0.6 h1:C45KMmQMd21UwsUAmQHxUxiWOfzwTg1GJW0DA0AbFEE=
+github.com/fastschema/qjs v0.0.6/go.mod h1:bbg36wxXnx8g0FdKIe5+nCubrQvHa7XEVWqUptjHt/A=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
@@ -570,6 +572,8 @@ github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD
 github.com/subosito/gotenv v1.4.1/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/tencent-connect/botgo v0.2.1 h1:+BrTt9Zh+awL28GWC4g5Na3nQaGRWb0N5IctS8WqBCk=
 github.com/tencent-connect/botgo v0.2.1/go.mod h1:oO1sG9ybhXNickvt+CVym5khwQ+uKhTR+IhTqEfOVsI=
+github.com/tetratelabs/wazero v1.9.0 h1:IcZ56OuxrtaEz8UYNRHBrUa9bYeX9oVY93KspZZBf/I=
+github.com/tetratelabs/wazero v1.9.0/go.mod h1:TSbcXCfFP0L2FGkRPxHphadXPjo1T6W+CseNNY7EkjM=
 github.com/tidwall/gjson v1.9.3/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=

--- a/internal/agent/engine/engine.go
+++ b/internal/agent/engine/engine.go
@@ -99,6 +99,7 @@ func (e *Engine) runLoop(ctx context.Context, cfg LoopConfig, history []ai.Messa
 					emit(ToolFinished{Result: result})
 				}
 			},
+			PluginHooks: cfg.PluginHooks,
 		})
 		if err != nil {
 			return history, err

--- a/internal/agent/engine/tool_execution.go
+++ b/internal/agent/engine/tool_execution.go
@@ -9,8 +9,9 @@ import (
 
 // ToolCallbacks emits progress events around tool execution.
 type ToolCallbacks struct {
-	OnStart  func(call ai.ToolCall)
-	OnFinish func(result ai.ToolResultMessage)
+	OnStart     func(call ai.ToolCall)
+	OnFinish    func(result ai.ToolResultMessage)
+	PluginHooks PluginHookRunner // optional plugin lifecycle hooks
 }
 
 // ExecuteToolCalls runs each tool call in order and returns result messages.
@@ -20,6 +21,27 @@ func ExecuteToolCalls(ctx context.Context, calls []ai.ToolCall, tools ToolSet, c
 	for _, call := range calls {
 		if cb.OnStart != nil {
 			cb.OnStart(call)
+		}
+
+		// Run before_tool_call plugin hooks. If a hook returns an error,
+		// the tool call is blocked and the error is returned to the LLM.
+		if cb.PluginHooks != nil {
+			if err := cb.PluginHooks.RunHooks(ctx, "before_tool_call", beforeToolCallData{
+				ToolName:  call.Name,
+				Arguments: call.Arguments,
+			}); err != nil {
+				result := ai.ToolResultMessage{
+					ToolCallID: call.ID,
+					ToolName:   call.Name,
+					IsError:    true,
+					Content:    []ai.ContentBlock{ai.TextContent{Text: "blocked by plugin: " + err.Error()}},
+				}
+				results = append(results, result)
+				if cb.OnFinish != nil {
+					cb.OnFinish(result)
+				}
+				continue
+			}
 		}
 
 		toolFn, ok := tools[call.Name]
@@ -50,6 +72,16 @@ func ExecuteToolCalls(ctx context.Context, calls []ai.ToolCall, tools ToolSet, c
 			}
 			result.Content = []ai.ContentBlock{ai.TextContent{Text: errText}}
 		}
+
+		// Run after_tool_call plugin hooks (fire-and-forget).
+		if cb.PluginHooks != nil {
+			_ = cb.PluginHooks.RunHooks(ctx, "after_tool_call", afterToolCallData{
+				ToolName: call.Name,
+				Result:   content.Text,
+				IsError:  err != nil,
+			})
+		}
+
 		results = append(results, result)
 		if cb.OnFinish != nil {
 			cb.OnFinish(result)
@@ -61,4 +93,19 @@ func ExecuteToolCalls(ctx context.Context, calls []ai.ToolCall, tools ToolSet, c
 	}
 
 	return results, nil
+}
+
+// beforeToolCallData is passed to before_tool_call hooks.
+// Mirrors pkg/plugin.BeforeToolCallEvent without importing it.
+type beforeToolCallData struct {
+	ToolName  string
+	Arguments map[string]any
+}
+
+// afterToolCallData is passed to after_tool_call hooks.
+// Mirrors pkg/plugin.AfterToolCallEvent without importing it.
+type afterToolCallData struct {
+	ToolName string
+	Result   string
+	IsError  bool
 }

--- a/internal/agent/engine/tool_execution.go
+++ b/internal/agent/engine/tool_execution.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/vaayne/anna/internal/ai"
+	pluginapi "github.com/vaayne/anna/pkg/plugin"
 )
 
 // ToolCallbacks emits progress events around tool execution.
@@ -26,7 +27,7 @@ func ExecuteToolCalls(ctx context.Context, calls []ai.ToolCall, tools ToolSet, c
 		// Run before_tool_call plugin hooks. If a hook returns an error,
 		// the tool call is blocked and the error is returned to the LLM.
 		if cb.PluginHooks != nil {
-			if err := cb.PluginHooks.RunHooks(ctx, "before_tool_call", beforeToolCallData{
+			if err := cb.PluginHooks.RunHooks(ctx, "before_tool_call", pluginapi.BeforeToolCallEvent{
 				ToolName:  call.Name,
 				Arguments: call.Arguments,
 			}); err != nil {
@@ -75,7 +76,7 @@ func ExecuteToolCalls(ctx context.Context, calls []ai.ToolCall, tools ToolSet, c
 
 		// Run after_tool_call plugin hooks (fire-and-forget).
 		if cb.PluginHooks != nil {
-			_ = cb.PluginHooks.RunHooks(ctx, "after_tool_call", afterToolCallData{
+			_ = cb.PluginHooks.RunHooks(ctx, "after_tool_call", pluginapi.AfterToolCallEvent{
 				ToolName: call.Name,
 				Result:   content.Text,
 				IsError:  err != nil,
@@ -93,19 +94,4 @@ func ExecuteToolCalls(ctx context.Context, calls []ai.ToolCall, tools ToolSet, c
 	}
 
 	return results, nil
-}
-
-// beforeToolCallData is passed to before_tool_call hooks.
-// Mirrors pkg/plugin.BeforeToolCallEvent without importing it.
-type beforeToolCallData struct {
-	ToolName  string
-	Arguments map[string]any
-}
-
-// afterToolCallData is passed to after_tool_call hooks.
-// Mirrors pkg/plugin.AfterToolCallEvent without importing it.
-type afterToolCallData struct {
-	ToolName string
-	Result   string
-	IsError  bool
 }

--- a/internal/agent/engine/types.go
+++ b/internal/agent/engine/types.go
@@ -13,6 +13,12 @@ type ToolFunc func(ctx context.Context, call ai.ToolCall) (ai.TextContent, error
 // ToolSet maps tool names to handlers.
 type ToolSet map[string]ToolFunc
 
+// PluginHookRunner executes plugin lifecycle hooks.
+// Defined as an interface here so the engine package does not import internal/plugin.
+type PluginHookRunner interface {
+	RunHooks(ctx context.Context, event string, data any) error
+}
+
 // LoopConfig configures the agent loop behavior.
 type LoopConfig struct {
 	Model           ai.Model
@@ -22,4 +28,5 @@ type LoopConfig struct {
 	ToolDefinitions []toolspec.Definition
 	System          string
 	Interrupt       <-chan struct{}
+	PluginHooks     PluginHookRunner // optional plugin lifecycle hooks
 }

--- a/internal/agent/pool.go
+++ b/internal/agent/pool.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vaayne/anna/internal/agent/runner"
 	"github.com/vaayne/anna/internal/ai"
 	"github.com/vaayne/anna/internal/memory"
+	pluginapi "github.com/vaayne/anna/pkg/plugin"
 )
 
 // Pool manages a set of sessions, each with its own history and runner.
@@ -198,7 +199,7 @@ func (p *Pool) ArchiveSession(sessionID string) error {
 
 	// Fire session_end plugin hook.
 	if p.pluginHooks != nil {
-		_ = p.pluginHooks.RunHooks(context.Background(), "session_end", sessionEventData{
+		_ = p.pluginHooks.RunHooks(context.Background(), "session_end", pluginapi.SessionEvent{
 			SessionID: sessionID,
 			Channel:   info.Channel,
 		})
@@ -396,7 +397,7 @@ func (p *Pool) Close() error {
 	for id, sess := range sessions {
 		p.log.Info("closing session", "session_id", id)
 		if p.pluginHooks != nil {
-			_ = p.pluginHooks.RunHooks(context.Background(), "session_end", sessionEventData{
+			_ = p.pluginHooks.RunHooks(context.Background(), "session_end", pluginapi.SessionEvent{
 				SessionID: id,
 				Channel:   sess.Info.Channel,
 			})
@@ -485,7 +486,7 @@ func (p *Pool) getOrCreateRunner(ctx context.Context, sessionID string, model st
 
 	// Fire session_start plugin hook.
 	if p.pluginHooks != nil {
-		_ = p.pluginHooks.RunHooks(ctx, "session_start", sessionEventData{
+		_ = p.pluginHooks.RunHooks(ctx, "session_start", pluginapi.SessionEvent{
 			SessionID: sessionID,
 			Channel:   sess.Info.Channel,
 		})
@@ -493,10 +494,4 @@ func (p *Pool) getOrCreateRunner(ctx context.Context, sessionID string, model st
 
 	p.log.Info("created runner", "session_id", sessionID)
 	return sess, r, nil
-}
-
-// sessionEventData is passed to session lifecycle hooks.
-type sessionEventData struct {
-	SessionID string
-	Channel   string
 }

--- a/internal/agent/pool.go
+++ b/internal/agent/pool.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/vaayne/anna/internal/agent/engine"
 	"github.com/vaayne/anna/internal/agent/runner"
 	"github.com/vaayne/anna/internal/ai"
 	"github.com/vaayne/anna/internal/memory"
@@ -24,8 +25,9 @@ type Pool struct {
 	mu           sync.Mutex
 	idleTimeout  time.Duration
 	compaction   CompactionConfig
-	defaultModel string // default model ID for new runners
-	fastModel    string // model ID used for compaction / fast tasks
+	defaultModel string                  // default model ID for new runners
+	fastModel    string                  // model ID used for compaction / fast tasks
+	pluginHooks  engine.PluginHookRunner // optional plugin lifecycle hooks
 	log          *slog.Logger
 }
 
@@ -192,6 +194,14 @@ func (p *Pool) ArchiveSession(sessionID string) error {
 		if err := p.mem.SaveInfo(context.Background(), info); err != nil {
 			p.log.Warn("failed to persist archive", "session_id", sessionID, "error", err)
 		}
+	}
+
+	// Fire session_end plugin hook.
+	if p.pluginHooks != nil {
+		_ = p.pluginHooks.RunHooks(context.Background(), "session_end", sessionEventData{
+			SessionID: sessionID,
+			Channel:   info.Channel,
+		})
 	}
 
 	if r != nil {
@@ -385,6 +395,12 @@ func (p *Pool) Close() error {
 	var lastErr error
 	for id, sess := range sessions {
 		p.log.Info("closing session", "session_id", id)
+		if p.pluginHooks != nil {
+			_ = p.pluginHooks.RunHooks(context.Background(), "session_end", sessionEventData{
+				SessionID: id,
+				Channel:   sess.Info.Channel,
+			})
+		}
 		if closer, ok := sess.Runner.(io.Closer); ok {
 			if err := closer.Close(); err != nil {
 				lastErr = err
@@ -467,6 +483,20 @@ func (p *Pool) getOrCreateRunner(ctx context.Context, sessionID string, model st
 		p.log.Warn("memory bootstrap failed", "session_id", sessionID, "error", err)
 	}
 
+	// Fire session_start plugin hook.
+	if p.pluginHooks != nil {
+		_ = p.pluginHooks.RunHooks(ctx, "session_start", sessionEventData{
+			SessionID: sessionID,
+			Channel:   sess.Info.Channel,
+		})
+	}
+
 	p.log.Info("created runner", "session_id", sessionID)
 	return sess, r, nil
+}
+
+// sessionEventData is passed to session lifecycle hooks.
+type sessionEventData struct {
+	SessionID string
+	Channel   string
 }

--- a/internal/agent/pool_options.go
+++ b/internal/agent/pool_options.go
@@ -2,6 +2,8 @@ package agent
 
 import (
 	"time"
+
+	"github.com/vaayne/anna/internal/agent/engine"
 )
 
 // PoolOption configures a Pool.
@@ -32,6 +34,13 @@ func WithDefaultModel(model string) PoolOption {
 func WithFastModel(model string) PoolOption {
 	return func(p *Pool) {
 		p.fastModel = model
+	}
+}
+
+// WithPluginHooks sets the plugin lifecycle hook runner.
+func WithPluginHooks(hooks engine.PluginHookRunner) PoolOption {
+	return func(p *Pool) {
+		p.pluginHooks = hooks
 	}
 }
 

--- a/internal/agent/runner/builtin/anna/SKILL.md
+++ b/internal/agent/runner/builtin/anna/SKILL.md
@@ -3,10 +3,11 @@ name: anna
 description: >
   Self-knowledge about anna, the self-hosted AI assistant. Use when the user asks about
   anna itself: configuration, setup, onboarding, providers, models, channels (Telegram/QQ/Feishu),
-  memory system (LCM), scheduled jobs, heartbeat, skills, session compaction, notifications, self-update,
-  or general "how does anna work" / "help me get started" questions. Also triggers
+  memory system (LCM), scheduled jobs, heartbeat, skills, plugins, session compaction, notifications,
+  self-update, or general "how does anna work" / "help me get started" questions. Also triggers
   on "change my model", "set up telegram", "configure provider", "update anna",
-  "what can you do", "how do I install skills", "anna onboard".
+  "what can you do", "how do I install skills", "anna onboard", "plugin",
+  "add plugin", "install plugin", "manage plugins".
 ---
 
 # Anna Self-Knowledge
@@ -58,6 +59,10 @@ anna models update     # Refresh model cache
 anna skills list       # List installed skills
 anna skills search <q> # Search skill ecosystem
 anna skills install <s># Install a skill
+anna plugin list        # List configured plugins
+anna plugin add <path>  # Add a JS or Go plugin
+anna plugin remove <n>  # Remove plugin from config
+anna plugin build       # Build custom binary with Go plugins
 anna version           # Print version
 anna upgrade           # Self-update to latest release
 ```
@@ -71,6 +76,15 @@ You have a `delegate` tool that spawns subagent loops for bounded subtasks. Use 
 - **Options per task**: `model` (override model), `system` (additional instructions), `tools` (whitelist), `max_turns` (default 10), `timeout_seconds` (default 120)
 - Subagents get fresh context (no parent history) and cannot delegate further
 - Results are returned as JSON: `{"results": {"id": {"output": "...", "error": ""}}}`
+
+## Plugins
+
+anna supports two types of plugins:
+
+- **JS extensions** (`.js` files): Sandboxed scripts loaded at runtime. They can register tools and lifecycle hooks via the `anna` host object (e.g., `anna.registerTool()`, `anna.on()`). No compilation needed.
+- **Go plugins** (directories with Go code): Compiled into the binary via `anna plugin build`. They use an `init()` + factory pattern to register themselves.
+
+Plugins are configured in `~/.anna/config.yaml` under the `plugins:` key. Each entry specifies a `path` and optional `config` map passed to the plugin at load time.
 
 ## Memory, scheduler, notifications
 

--- a/internal/agent/runner/builtin/anna/references/configuration.md
+++ b/internal/agent/runner/builtin/anna/references/configuration.md
@@ -83,6 +83,14 @@ runner:
     max_tokens: 80000              # auto-compact threshold (-1 = disabled)
     keep_tail: 20                  # recent messages kept after compaction
 
+plugins:
+  - path: ~/.anna/plugins/weather.js
+    config:
+      api_key: "xxx"
+  - path: ~/.anna/plugins/github-tools
+    config:
+      token: "yyy"
+
 scheduler:
   enabled: true
 
@@ -107,6 +115,7 @@ All paths are relative to `$ANNA_HOME` (`~/.anna` by default).
 | `workspace/USER.md` | User preferences, name, timezone |
 | `workspace/memory.db` | SQLite database (message history, summaries, scheduler jobs) |
 | `workspace/skills/` | Installed skills |
+| `plugins/` | User plugin files (JS scripts, Go plugin dirs) |
 | `workspace/HEARTBEAT.md` | Heartbeat instructions |
 
 ## Environment variables

--- a/internal/agent/runner/gorunner.go
+++ b/internal/agent/runner/gorunner.go
@@ -20,25 +20,27 @@ const maxToolIterations = 40
 
 // GoRunnerConfig configures the Go runner.
 type GoRunnerConfig struct {
-	API        string // provider key: "anthropic", "openai"
-	Model      string // e.g. "claude-sonnet-4-20250514"
-	APIKey     string
-	BaseURL    string      // optional provider base URL override
-	WorkDir    string      // working directory for tool execution
-	Workspace  string      // workspace dir for skills/memory (e.g. ~/.anna/workspace)
-	AnnaHome   string      // anna home directory (e.g. ~/.anna)
-	System     string      // optional system prompt override (bypasses BuildSystemPrompt)
-	ExtraTools []tool.Tool // additional tools to register
+	API         string // provider key: "anthropic", "openai"
+	Model       string // e.g. "claude-sonnet-4-20250514"
+	APIKey      string
+	BaseURL     string                  // optional provider base URL override
+	WorkDir     string                  // working directory for tool execution
+	Workspace   string                  // workspace dir for skills/memory (e.g. ~/.anna/workspace)
+	AnnaHome    string                  // anna home directory (e.g. ~/.anna)
+	System      string                  // optional system prompt override (bypasses BuildSystemPrompt)
+	ExtraTools  []tool.Tool             // additional tools to register
+	PluginHooks engine.PluginHookRunner // optional plugin lifecycle hooks
 }
 
 // GoRunner implements Runner by calling LLM providers directly via Engine.
 type GoRunner struct {
-	eng    *engine.Engine
-	reg    *ai.Registry
-	tools  *tool.Registry
-	model  ai.Model
-	apiKey string
-	system string
+	eng         *engine.Engine
+	reg         *ai.Registry
+	tools       *tool.Registry
+	model       ai.Model
+	apiKey      string
+	system      string
+	pluginHooks engine.PluginHookRunner
 
 	mu           sync.Mutex
 	lastActivity time.Time
@@ -79,11 +81,12 @@ func NewGoRunner(_ context.Context, cfg GoRunnerConfig) (*GoRunner, error) {
 		tools.Register(t)
 	}
 	tools.Register(tool.NewDelegateTool(tool.DelegateConfig{
-		Engine:   eng,
-		Registry: tools,
-		Model:    model,
-		APIKey:   cfg.APIKey,
-		System:   system,
+		Engine:      eng,
+		Registry:    tools,
+		Model:       model,
+		APIKey:      cfg.APIKey,
+		System:      system,
+		PluginHooks: cfg.PluginHooks,
 	}))
 
 	return &GoRunner{
@@ -93,6 +96,7 @@ func NewGoRunner(_ context.Context, cfg GoRunnerConfig) (*GoRunner, error) {
 		model:        model,
 		apiKey:       cfg.APIKey,
 		system:       system,
+		pluginHooks:  cfg.PluginHooks,
 		lastActivity: time.Now(),
 		log:          slog.With("component", "go_runner"),
 	}, nil
@@ -120,6 +124,7 @@ func (r *GoRunner) Chat(ctx context.Context, history []ai.Message, message Messa
 			Tools:           r.buildToolSet(),
 			ToolDefinitions: r.tools.Definitions(),
 			System:          r.system,
+			PluginHooks:     r.pluginHooks,
 		}
 
 		if _, err := r.eng.Run(ctx, cfg, messages, func(e engine.LoopEvent) {

--- a/internal/agent/tool/delegate.go
+++ b/internal/agent/tool/delegate.go
@@ -23,11 +23,12 @@ const (
 
 // DelegateConfig holds the dependencies needed to spawn subagent loops.
 type DelegateConfig struct {
-	Engine   *engine.Engine
-	Registry *Registry
-	Model    ai.Model
-	APIKey   string
-	System   string
+	Engine      *engine.Engine
+	Registry    *Registry
+	Model       ai.Model
+	APIKey      string
+	System      string
+	PluginHooks engine.PluginHookRunner // optional plugin lifecycle hooks
 }
 
 // DelegateTool spawns child agent loops for bounded subtasks.
@@ -183,6 +184,7 @@ func (t *DelegateTool) runSubAgent(parentCtx context.Context, tc delegateTaskCon
 		Tools:           toolSet,
 		ToolDefinitions: toolDefs,
 		System:          system,
+		PluginHooks:     t.cfg.PluginHooks,
 	}
 
 	messages := []ai.Message{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,13 @@ type Config struct {
 	Heartbeat   HeartbeatConfig           `yaml:"heartbeat"    envPrefix:"HEARTBEAT_"`
 	Providers   map[string]ProviderConfig `yaml:"providers"`
 	Channels    ChannelsConfig            `yaml:"channels"`
+	Plugins     []PluginConfig            `yaml:"plugins"`
+}
+
+// PluginConfig describes a single plugin entry in config.yaml.
+type PluginConfig struct {
+	Path   string         `yaml:"path"`
+	Config map[string]any `yaml:"config"`
 }
 
 type RunnerConfig struct {

--- a/internal/plugin/adapt.go
+++ b/internal/plugin/adapt.go
@@ -1,0 +1,31 @@
+package plugin
+
+import (
+	"context"
+
+	"github.com/vaayne/anna/internal/agent/tool"
+	"github.com/vaayne/anna/internal/toolspec"
+	pluginapi "github.com/vaayne/anna/pkg/plugin"
+)
+
+// adaptedTool wraps a pluginapi.Tool to satisfy the tool.Tool interface.
+type adaptedTool struct {
+	inner pluginapi.Tool
+}
+
+func (a *adaptedTool) Definition() toolspec.Definition {
+	return toolspec.Definition{
+		Name:        a.inner.Name,
+		Description: a.inner.Description,
+		InputSchema: a.inner.InputSchema,
+	}
+}
+
+func (a *adaptedTool) Execute(ctx context.Context, args map[string]any) (string, error) {
+	return a.inner.Execute(ctx, args)
+}
+
+// AdaptTool converts a plugin API tool into an internal tool.Tool.
+func AdaptTool(t pluginapi.Tool) tool.Tool {
+	return &adaptedTool{inner: t}
+}

--- a/internal/plugin/adapt_test.go
+++ b/internal/plugin/adapt_test.go
@@ -1,0 +1,61 @@
+package plugin
+
+import (
+	"context"
+	"testing"
+
+	pluginapi "github.com/vaayne/anna/pkg/plugin"
+)
+
+func TestAdaptToolDefinition(t *testing.T) {
+	pt := pluginapi.Tool{
+		Name:        "search",
+		Description: "Search for things",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"query": map[string]any{"type": "string"},
+			},
+		},
+	}
+
+	adapted := AdaptTool(pt)
+	def := adapted.Definition()
+
+	if def.Name != "search" {
+		t.Errorf("Name = %q, want %q", def.Name, "search")
+	}
+	if def.Description != "Search for things" {
+		t.Errorf("Description = %q, want %q", def.Description, "Search for things")
+	}
+	if def.InputSchema == nil {
+		t.Fatal("InputSchema should not be nil")
+	}
+	if def.InputSchema["type"] != "object" {
+		t.Errorf("InputSchema[type] = %v, want %q", def.InputSchema["type"], "object")
+	}
+}
+
+func TestAdaptToolExecute(t *testing.T) {
+	var receivedArgs map[string]any
+	pt := pluginapi.Tool{
+		Name: "echo",
+		Execute: func(_ context.Context, args map[string]any) (string, error) {
+			receivedArgs = args
+			return "echoed: " + args["msg"].(string), nil
+		},
+	}
+
+	adapted := AdaptTool(pt)
+	args := map[string]any{"msg": "hello"}
+	result, err := adapted.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "echoed: hello" {
+		t.Errorf("result = %q, want %q", result, "echoed: hello")
+	}
+	if receivedArgs["msg"] != "hello" {
+		t.Errorf("args not passed correctly: %v", receivedArgs)
+	}
+}

--- a/internal/plugin/goplugin/builder.go
+++ b/internal/plugin/goplugin/builder.go
@@ -1,0 +1,224 @@
+// Package goplugin implements Caddy-style compilation for Go plugins.
+//
+// It generates a temporary Go module that blank-imports each plugin package
+// (triggering their init() registrations), then compiles a custom anna binary
+// with all plugins statically linked.
+package goplugin
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"text/template"
+)
+
+const (
+	annaModule    = "github.com/vaayne/anna"
+	defaultOutput = "./anna-custom"
+)
+
+// Builder orchestrates Caddy-style compilation of a custom anna binary with
+// Go plugins compiled in.
+type Builder struct {
+	plugins []string // absolute paths to plugin directories
+	output  string   // output binary path
+	logger  *slog.Logger
+}
+
+// NewBuilder creates a Builder. Each plugin path must be a local directory
+// containing a go.mod. Output defaults to "./anna-custom" if empty.
+func NewBuilder(plugins []string, output string, logger *slog.Logger) *Builder {
+	if output == "" {
+		output = defaultOutput
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Builder{
+		plugins: plugins,
+		output:  output,
+		logger:  logger,
+	}
+}
+
+// Build generates a temporary Go module and compiles a custom anna binary.
+// The caller's context controls cancellation of the underlying go commands.
+func (b *Builder) Build(ctx context.Context) error {
+	if err := b.checkGoToolchain(ctx); err != nil {
+		return err
+	}
+
+	modules, err := b.resolvePlugins()
+	if err != nil {
+		return err
+	}
+
+	annaRoot, err := b.findAnnaRoot()
+	if err != nil {
+		return err
+	}
+
+	tmpDir, err := os.MkdirTemp("", "anna-build-*")
+	if err != nil {
+		return fmt.Errorf("create temp dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	data := templateData{
+		AnnaModule:    annaModule,
+		AnnaLocalPath: annaRoot,
+		Plugins:       modules,
+	}
+
+	if err := b.writeFile(tmpDir, "main.go", mainGoTmpl, data); err != nil {
+		return err
+	}
+	if err := b.writeFile(tmpDir, "go.mod", goModTmpl, data); err != nil {
+		return err
+	}
+
+	b.logger.Info("running go mod tidy", "dir", tmpDir)
+	if err := b.runGo(ctx, tmpDir, "mod", "tidy"); err != nil {
+		return fmt.Errorf("go mod tidy: %w", err)
+	}
+
+	outputAbs, err := filepath.Abs(b.output)
+	if err != nil {
+		return fmt.Errorf("resolve output path: %w", err)
+	}
+
+	b.logger.Info("building custom binary", "output", outputAbs, "plugins", len(modules))
+	if err := b.runGo(ctx, tmpDir, "build", "-o", outputAbs, "."); err != nil {
+		return fmt.Errorf("go build: %w", err)
+	}
+
+	b.logger.Info("build complete", "binary", outputAbs)
+	return nil
+}
+
+// checkGoToolchain verifies that the go toolchain is available.
+func (b *Builder) checkGoToolchain(ctx context.Context) error {
+	cmd := exec.CommandContext(ctx, "go", "version")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("go toolchain not found (is Go installed?): %w\n%s", err, out)
+	}
+	b.logger.Debug("go toolchain found", "version", strings.TrimSpace(string(out)))
+	return nil
+}
+
+// resolvePlugins validates each plugin directory and reads its module path.
+func (b *Builder) resolvePlugins() ([]pluginModule, error) {
+	modules := make([]pluginModule, 0, len(b.plugins))
+	for _, dir := range b.plugins {
+		absDir, err := filepath.Abs(dir)
+		if err != nil {
+			return nil, fmt.Errorf("resolve plugin path %q: %w", dir, err)
+		}
+
+		modPath, err := readModulePath(filepath.Join(absDir, "go.mod"))
+		if err != nil {
+			return nil, fmt.Errorf("plugin %q: %w", absDir, err)
+		}
+
+		modules = append(modules, pluginModule{
+			Module:    modPath,
+			LocalPath: absDir,
+		})
+		b.logger.Debug("resolved plugin", "module", modPath, "path", absDir)
+	}
+	return modules, nil
+}
+
+// findAnnaRoot locates the anna project root by looking for go.mod in the
+// current executable's directory hierarchy, falling back to the working
+// directory hierarchy.
+func (b *Builder) findAnnaRoot() (string, error) {
+	// Try from executable location first.
+	if exe, err := os.Executable(); err == nil {
+		if root, ok := findGoModRoot(filepath.Dir(exe)); ok {
+			return root, nil
+		}
+	}
+
+	// Fall back to working directory.
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("get working directory: %w", err)
+	}
+	if root, ok := findGoModRoot(cwd); ok {
+		return root, nil
+	}
+
+	return "", fmt.Errorf("cannot find anna project root (no go.mod with module %s found)", annaModule)
+}
+
+// findGoModRoot walks up from dir looking for a go.mod containing the anna
+// module path.
+func findGoModRoot(dir string) (string, bool) {
+	for {
+		gomod := filepath.Join(dir, "go.mod")
+		if modPath, err := readModulePath(gomod); err == nil && modPath == annaModule {
+			return dir, true
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", false
+		}
+		dir = parent
+	}
+}
+
+// readModulePath reads the module path from a go.mod file.
+func readModulePath(gomodPath string) (string, error) {
+	f, err := os.Open(gomodPath)
+	if err != nil {
+		return "", fmt.Errorf("open go.mod: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "module ") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "module ")), nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("read go.mod: %w", err)
+	}
+	return "", fmt.Errorf("no module directive found in %s", gomodPath)
+}
+
+// writeFile renders a template to a file in the given directory.
+func (b *Builder) writeFile(dir, name string, tmpl *template.Template, data templateData) error {
+	path := filepath.Join(dir, name)
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", name, err)
+	}
+
+	if err := tmpl.Execute(f, data); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("render %s: %w", name, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", name, err)
+	}
+	b.logger.Debug("wrote file", "path", path)
+	return nil
+}
+
+// runGo executes a go command in the given directory.
+func (b *Builder) runGo(ctx context.Context, dir string, args ...string) error {
+	cmd := exec.CommandContext(ctx, "go", args...)
+	cmd.Dir = dir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/internal/plugin/goplugin/builder.go
+++ b/internal/plugin/goplugin/builder.go
@@ -75,7 +75,14 @@ func (b *Builder) Build(ctx context.Context) error {
 		Plugins:       modules,
 	}
 
-	if err := b.writeFile(tmpDir, "main.go", mainGoTmpl, data); err != nil {
+	// Copy cmd/anna source files into the temp dir so the build shares
+	// the same package main as the real anna binary.
+	cmdDir := filepath.Join(annaRoot, "cmd", "anna")
+	if err := b.copySources(cmdDir, tmpDir); err != nil {
+		return fmt.Errorf("copy cmd/anna sources: %w", err)
+	}
+
+	if err := b.writeFile(tmpDir, "plugins.go", pluginsGoTmpl, data); err != nil {
 		return err
 	}
 	if err := b.writeFile(tmpDir, "go.mod", goModTmpl, data); err != nil {
@@ -211,6 +218,29 @@ func (b *Builder) writeFile(dir, name string, tmpl *template.Template, data temp
 		return fmt.Errorf("close %s: %w", name, err)
 	}
 	b.logger.Debug("wrote file", "path", path)
+	return nil
+}
+
+// copySources copies all .go files (excluding test files) from srcDir to dstDir.
+func (b *Builder) copySources(srcDir, dstDir string) error {
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		return fmt.Errorf("read source dir %s: %w", srcDir, err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(srcDir, name))
+		if err != nil {
+			return fmt.Errorf("read %s: %w", name, err)
+		}
+		if err := os.WriteFile(filepath.Join(dstDir, name), data, 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", name, err)
+		}
+		b.logger.Debug("copied source file", "file", name)
+	}
 	return nil
 }
 

--- a/internal/plugin/goplugin/builder_test.go
+++ b/internal/plugin/goplugin/builder_test.go
@@ -1,0 +1,173 @@
+package goplugin
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewBuilderDefaults(t *testing.T) {
+	b := NewBuilder([]string{"/some/plugin"}, "", nil)
+
+	if b.output != defaultOutput {
+		t.Errorf("expected default output %q, got %q", defaultOutput, b.output)
+	}
+	if b.logger == nil {
+		t.Error("expected non-nil logger when nil is passed")
+	}
+	if len(b.plugins) != 1 || b.plugins[0] != "/some/plugin" {
+		t.Errorf("expected plugins [/some/plugin], got %v", b.plugins)
+	}
+}
+
+func TestNewBuilderCustomOutput(t *testing.T) {
+	b := NewBuilder([]string{}, "/tmp/my-binary", slog.Default())
+
+	if b.output != "/tmp/my-binary" {
+		t.Errorf("expected output %q, got %q", "/tmp/my-binary", b.output)
+	}
+}
+
+func TestReadModulePath(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		wantMod string
+		wantErr bool
+	}{
+		{
+			name:    "standard module line",
+			content: "module example.com/my-plugin\n\ngo 1.25\n",
+			wantMod: "example.com/my-plugin",
+		},
+		{
+			name:    "module line with extra whitespace",
+			content: "  module   github.com/foo/bar  \n\ngo 1.25\n",
+			wantMod: "github.com/foo/bar",
+		},
+		{
+			name:    "module line after comments",
+			content: "// this is a comment\nmodule example.com/test\n",
+			wantMod: "example.com/test",
+		},
+		{
+			name:    "no module directive",
+			content: "go 1.25\n\nrequire example.com/dep v1.0.0\n",
+			wantErr: true,
+		},
+		{
+			name:    "empty file",
+			content: "",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			gomodPath := filepath.Join(dir, "go.mod")
+			if err := os.WriteFile(gomodPath, []byte(tc.content), 0o644); err != nil {
+				t.Fatalf("write temp go.mod: %v", err)
+			}
+
+			got, err := readModulePath(gomodPath)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got module %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.wantMod {
+				t.Errorf("expected module %q, got %q", tc.wantMod, got)
+			}
+		})
+	}
+}
+
+func TestReadModulePathNotFound(t *testing.T) {
+	_, err := readModulePath("/nonexistent/path/go.mod")
+	if err == nil {
+		t.Error("expected error for missing go.mod, got nil")
+	}
+}
+
+func TestMainGoTemplate(t *testing.T) {
+	data := templateData{
+		AnnaModule:    "github.com/vaayne/anna",
+		AnnaLocalPath: "/home/user/anna",
+		Plugins: []pluginModule{
+			{Module: "example.com/plugin-a", LocalPath: "/home/user/plugin-a"},
+			{Module: "example.com/plugin-b", LocalPath: "/home/user/plugin-b"},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := mainGoTmpl.Execute(&buf, data); err != nil {
+		t.Fatalf("template execution failed: %v", err)
+	}
+
+	out := buf.String()
+
+	checks := []string{
+		"package main",
+		`_ "example.com/plugin-a"`,
+		`_ "example.com/plugin-b"`,
+		`anna "github.com/vaayne/anna/cmd/anna"`,
+		"anna.Main()",
+	}
+	for _, want := range checks {
+		if !bytes.Contains(buf.Bytes(), []byte(want)) {
+			t.Errorf("main.go output missing %q\n\nfull output:\n%s", want, out)
+		}
+	}
+}
+
+func TestGoModTemplate(t *testing.T) {
+	data := templateData{
+		AnnaModule:    "github.com/vaayne/anna",
+		AnnaLocalPath: "/home/user/anna",
+		Plugins: []pluginModule{
+			{Module: "example.com/plugin-a", LocalPath: "/home/user/plugin-a"},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := goModTmpl.Execute(&buf, data); err != nil {
+		t.Fatalf("template execution failed: %v", err)
+	}
+
+	out := buf.String()
+
+	checks := []string{
+		"module anna-custom",
+		"go 1.25",
+		"github.com/vaayne/anna v0.0.0",
+		"example.com/plugin-a v0.0.0",
+		"replace github.com/vaayne/anna => /home/user/anna",
+		"replace example.com/plugin-a => /home/user/plugin-a",
+	}
+	for _, want := range checks {
+		if !bytes.Contains(buf.Bytes(), []byte(want)) {
+			t.Errorf("go.mod output missing %q\n\nfull output:\n%s", want, out)
+		}
+	}
+}
+
+func TestBuildMissingPlugin(t *testing.T) {
+	b := NewBuilder(
+		[]string{"/nonexistent/plugin/path"},
+		filepath.Join(t.TempDir(), "anna-test"),
+		slog.Default(),
+	)
+
+	err := b.Build(context.Background())
+	if err == nil {
+		t.Fatal("expected error for non-existent plugin path, got nil")
+	}
+}

--- a/internal/plugin/goplugin/builder_test.go
+++ b/internal/plugin/goplugin/builder_test.go
@@ -97,7 +97,7 @@ func TestReadModulePathNotFound(t *testing.T) {
 	}
 }
 
-func TestMainGoTemplate(t *testing.T) {
+func TestPluginsGoTemplate(t *testing.T) {
 	data := templateData{
 		AnnaModule:    "github.com/vaayne/anna",
 		AnnaLocalPath: "/home/user/anna",
@@ -108,7 +108,7 @@ func TestMainGoTemplate(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if err := mainGoTmpl.Execute(&buf, data); err != nil {
+	if err := pluginsGoTmpl.Execute(&buf, data); err != nil {
 		t.Fatalf("template execution failed: %v", err)
 	}
 
@@ -118,13 +118,16 @@ func TestMainGoTemplate(t *testing.T) {
 		"package main",
 		`_ "example.com/plugin-a"`,
 		`_ "example.com/plugin-b"`,
-		`anna "github.com/vaayne/anna/cmd/anna"`,
-		"anna.Main()",
 	}
 	for _, want := range checks {
 		if !bytes.Contains(buf.Bytes(), []byte(want)) {
-			t.Errorf("main.go output missing %q\n\nfull output:\n%s", want, out)
+			t.Errorf("plugins.go output missing %q\n\nfull output:\n%s", want, out)
 		}
+	}
+
+	// Verify it does NOT import cmd/anna (the whole point of this fix).
+	if bytes.Contains(buf.Bytes(), []byte("cmd/anna")) {
+		t.Errorf("plugins.go should not import cmd/anna\n\nfull output:\n%s", out)
 	}
 }
 

--- a/internal/plugin/goplugin/templates.go
+++ b/internal/plugin/goplugin/templates.go
@@ -1,0 +1,56 @@
+package goplugin
+
+import "text/template"
+
+// pluginModule holds metadata for a single Go plugin module.
+type pluginModule struct {
+	// Module is the Go module path (e.g., "example.com/my-plugin").
+	Module string
+	// LocalPath is the absolute local directory path for the replace directive.
+	LocalPath string
+}
+
+// templateData is the data passed to both templates.
+type templateData struct {
+	AnnaModule    string
+	AnnaLocalPath string
+	Plugins       []pluginModule
+}
+
+// mainGoTmpl generates a main.go that blank-imports every plugin (triggering
+// their init() -> plugin.Register() calls) and delegates to anna's exported
+// Main() function.
+var mainGoTmpl = template.Must(template.New("main.go").Parse(`package main
+
+import (
+{{- range .Plugins}}
+	_ "{{.Module}}"
+{{- end}}
+
+	anna "github.com/vaayne/anna/cmd/anna"
+)
+
+func main() {
+	anna.Main()
+}
+`))
+
+// goModTmpl generates a go.mod that requires anna and all plugin modules,
+// with replace directives pointing each module to its local directory.
+var goModTmpl = template.Must(template.New("go.mod").Parse(`module anna-custom
+
+go 1.25
+
+require (
+	{{.AnnaModule}} v0.0.0
+{{- range .Plugins}}
+	{{.Module}} v0.0.0
+{{- end}}
+)
+
+replace {{.AnnaModule}} => {{.AnnaLocalPath}}
+
+{{- range .Plugins}}
+replace {{.Module}} => {{.LocalPath}}
+{{- end}}
+`))

--- a/internal/plugin/goplugin/templates.go
+++ b/internal/plugin/goplugin/templates.go
@@ -17,22 +17,16 @@ type templateData struct {
 	Plugins       []pluginModule
 }
 
-// mainGoTmpl generates a main.go that blank-imports every plugin (triggering
-// their init() -> plugin.Register() calls) and delegates to anna's exported
-// Main() function.
-var mainGoTmpl = template.Must(template.New("main.go").Parse(`package main
+// pluginsGoTmpl generates a plugins.go that blank-imports every plugin
+// (triggering their init() -> plugin.Register() calls). This file is placed
+// alongside the copied cmd/anna source so it is part of the same package main.
+var pluginsGoTmpl = template.Must(template.New("plugins.go").Parse(`package main
 
 import (
 {{- range .Plugins}}
 	_ "{{.Module}}"
 {{- end}}
-
-	anna "github.com/vaayne/anna/cmd/anna"
 )
-
-func main() {
-	anna.Main()
-}
 `))
 
 // goModTmpl generates a go.mod that requires anna and all plugin modules,

--- a/internal/plugin/jsrt/convert.go
+++ b/internal/plugin/jsrt/convert.go
@@ -35,7 +35,7 @@ func goToJSValue(ctx *qjs.Context, v any) (*qjs.Value, error) {
 	if err != nil {
 		return nil, fmt.Errorf("marshal %T: %w", v, err)
 	}
-	result, err := ctx.Eval("__conv.js", qjs.Code(fmt.Sprintf("(%s)", string(data))))
+	result, err := ctx.Eval("__conv.js", qjs.Code(fmt.Sprintf("JSON.parse(%q)", string(data))))
 	if err != nil {
 		return nil, fmt.Errorf("parse value in JS: %w", err)
 	}

--- a/internal/plugin/jsrt/convert.go
+++ b/internal/plugin/jsrt/convert.go
@@ -1,0 +1,67 @@
+package jsrt
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/fastschema/qjs"
+)
+
+// goToJSValue converts a Go value to a QJS value using JSON round-trip.
+// This is reliable for all serializable types including maps, slices, and structs.
+func goToJSValue(ctx *qjs.Context, v any) (*qjs.Value, error) {
+	if v == nil {
+		return ctx.NewNull(), nil
+	}
+
+	// Fast path for primitive types.
+	switch val := v.(type) {
+	case string:
+		return ctx.NewString(val), nil
+	case bool:
+		return ctx.NewBool(val), nil
+	case int:
+		return ctx.NewInt32(int32(val)), nil
+	case int32:
+		return ctx.NewInt32(val), nil
+	case int64:
+		return ctx.NewFloat64(float64(val)), nil
+	case float64:
+		return ctx.NewFloat64(val), nil
+	}
+
+	// Complex types: JSON round-trip.
+	data, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("marshal %T: %w", v, err)
+	}
+	result, err := ctx.Eval("__conv.js", qjs.Code(fmt.Sprintf("(%s)", string(data))))
+	if err != nil {
+		return nil, fmt.Errorf("parse value in JS: %w", err)
+	}
+	return result, nil
+}
+
+// jsValueToJSON calls JSON.stringify on a QJS value and returns the JSON string.
+func jsValueToJSON(ctx *qjs.Context, val *qjs.Value) (string, error) {
+	ctx.Global().SetPropertyStr("__tmp_val", val.Clone())
+	result, err := ctx.Eval("__stringify.js", qjs.Code("JSON.stringify(__tmp_val)"))
+	if err != nil {
+		return "", fmt.Errorf("JSON.stringify: %w", err)
+	}
+	defer result.Free()
+	return result.String(), nil
+}
+
+// jsValueToGoMap converts a QJS object value to a Go map via JSON round-trip.
+func jsValueToGoMap(ctx *qjs.Context, val *qjs.Value) (map[string]any, error) {
+	jsonStr, err := jsValueToJSON(ctx, val)
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(jsonStr), &m); err != nil {
+		return nil, fmt.Errorf("unmarshal: %w", err)
+	}
+	return m, nil
+}

--- a/internal/plugin/jsrt/hostapi.go
+++ b/internal/plugin/jsrt/hostapi.go
@@ -1,0 +1,232 @@
+package jsrt
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/fastschema/qjs"
+)
+
+const (
+	fetchDefaultTimeout = 30 * time.Second
+	fetchMaxTimeout     = 60 * time.Second
+	fetchMaxBodySize    = 1 << 20 // 1 MB
+)
+
+// hostAPI holds state for JS host API implementations.
+type hostAPI struct {
+	logger    *slog.Logger
+	pluginDir string
+}
+
+// registerHostAPIs sets log, readFile, writeFile, and fetch on the anna object.
+func registerHostAPIs(ctx *qjs.Context, anna *qjs.Value, ha *hostAPI) {
+	// anna.log(level, msg)
+	anna.SetPropertyStr("log", ctx.Function(func(this *qjs.This) (*qjs.Value, error) {
+		args := this.Args()
+		if len(args) < 2 {
+			return nil, errors.New("anna.log requires (level, msg)")
+		}
+		level := args[0].String()
+		msg := args[1].String()
+		switch strings.ToLower(level) {
+		case "debug":
+			ha.logger.Debug(msg)
+		case "warn", "warning":
+			ha.logger.Warn(msg)
+		case "error":
+			ha.logger.Error(msg)
+		default:
+			ha.logger.Info(msg)
+		}
+		return this.Context().NewUndefined(), nil
+	}))
+
+	// anna.readFile(path) → string
+	anna.SetPropertyStr("readFile", ctx.Function(func(this *qjs.This) (*qjs.Value, error) {
+		args := this.Args()
+		if len(args) < 1 {
+			return nil, errors.New("readFile requires a path argument")
+		}
+		resolved, err := ha.resolvePath(args[0].String())
+		if err != nil {
+			return nil, err
+		}
+		data, err := os.ReadFile(resolved)
+		if err != nil {
+			return nil, fmt.Errorf("readFile: %w", err)
+		}
+		return this.Context().NewString(string(data)), nil
+	}))
+
+	// anna.writeFile(path, content)
+	anna.SetPropertyStr("writeFile", ctx.Function(func(this *qjs.This) (*qjs.Value, error) {
+		args := this.Args()
+		if len(args) < 2 {
+			return nil, errors.New("writeFile requires (path, content)")
+		}
+		resolved, err := ha.resolvePath(args[0].String())
+		if err != nil {
+			return nil, err
+		}
+		if err := os.MkdirAll(filepath.Dir(resolved), 0o755); err != nil {
+			return nil, fmt.Errorf("writeFile mkdir: %w", err)
+		}
+		if err := os.WriteFile(resolved, []byte(args[1].String()), 0o644); err != nil {
+			return nil, fmt.Errorf("writeFile: %w", err)
+		}
+		return this.Context().NewBool(true), nil
+	}))
+
+	// anna.fetch(url, options?) → { status, body }
+	anna.SetPropertyStr("fetch", ctx.Function(func(this *qjs.This) (*qjs.Value, error) {
+		args := this.Args()
+		if len(args) < 1 {
+			return nil, errors.New("fetch requires a URL argument")
+		}
+		return ha.doFetch(this.Context(), args)
+	}))
+}
+
+// resolvePath validates and resolves a file path, ensuring it's within allowed dirs.
+// Allowed: plugin parent directory or ~/.anna/workspace/.
+func (ha *hostAPI) resolvePath(rawPath string) (string, error) {
+	// Resolve relative paths against plugin directory.
+	resolved := rawPath
+	if !filepath.IsAbs(resolved) {
+		resolved = filepath.Join(ha.pluginDir, resolved)
+	}
+	resolved = filepath.Clean(resolved)
+
+	// Resolve symlinks to prevent escapes.
+	evaled, err := filepath.EvalSymlinks(resolved)
+	if err != nil {
+		// File may not exist yet (for writes). Resolve the parent directory.
+		parent, err2 := filepath.EvalSymlinks(filepath.Dir(resolved))
+		if err2 != nil {
+			return "", fmt.Errorf("resolve path: %w", err)
+		}
+		evaled = filepath.Join(parent, filepath.Base(resolved))
+	}
+
+	if ha.isAllowedPath(evaled) {
+		return evaled, nil
+	}
+	return "", fmt.Errorf("access denied: path %q is outside allowed directories", rawPath)
+}
+
+// isAllowedPath checks if a resolved path is within allowed directories.
+func (ha *hostAPI) isAllowedPath(resolved string) bool {
+	// Allow plugin parent directory.
+	pluginDir, err := filepath.EvalSymlinks(ha.pluginDir)
+	if err == nil && isUnder(resolved, pluginDir) {
+		return true
+	}
+
+	// Allow ~/.anna/workspace/.
+	home, err := os.UserHomeDir()
+	if err == nil {
+		workspace := filepath.Join(home, ".anna", "workspace")
+		workspace, err = filepath.EvalSymlinks(workspace)
+		if err == nil && isUnder(resolved, workspace) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isUnder checks if path is under or equal to dir.
+func isUnder(path, dir string) bool {
+	return path == dir || strings.HasPrefix(path, dir+string(filepath.Separator))
+}
+
+// doFetch performs an HTTP request with safety constraints.
+func (ha *hostAPI) doFetch(ctx *qjs.Context, args []*qjs.Value) (*qjs.Value, error) {
+	rawURL := args[0].String()
+
+	// Validate URL scheme.
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return nil, fmt.Errorf("fetch: only http/https allowed, got %q", parsed.Scheme)
+	}
+
+	method := "GET"
+	var body io.Reader
+	headers := map[string]string{}
+	timeout := fetchDefaultTimeout
+
+	// Parse options if provided.
+	if len(args) > 1 && !args[1].IsUndefined() && !args[1].IsNull() {
+		opts := args[1]
+		if m := opts.GetPropertyStr("method"); !m.IsUndefined() {
+			method = strings.ToUpper(m.String())
+		}
+		if b := opts.GetPropertyStr("body"); !b.IsUndefined() {
+			body = strings.NewReader(b.String())
+		}
+		if t := opts.GetPropertyStr("timeout"); !t.IsUndefined() {
+			ms := t.Float64()
+			if ms > 0 {
+				d := time.Duration(ms) * time.Millisecond
+				if d > fetchMaxTimeout {
+					d = fetchMaxTimeout
+				}
+				timeout = d
+			}
+		}
+		if h := opts.GetPropertyStr("headers"); !h.IsUndefined() && !h.IsNull() {
+			headersMap, err := jsValueToGoMap(ctx, h)
+			if err == nil {
+				for k, v := range headersMap {
+					if s, ok := v.(string); ok {
+						headers[k] = s
+					}
+				}
+			}
+		}
+	}
+
+	client := &http.Client{Timeout: timeout}
+	req, err := http.NewRequest(method, rawURL, body)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Read body with size limit.
+	limitedReader := io.LimitReader(resp.Body, int64(fetchMaxBodySize)+1)
+	respBody, err := io.ReadAll(limitedReader)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if len(respBody) > fetchMaxBodySize {
+		ha.logger.Warn("fetch response truncated", "url", rawURL, "size", len(respBody))
+		respBody = respBody[:fetchMaxBodySize]
+	}
+
+	// Return { status, body }.
+	result := ctx.NewObject()
+	result.SetPropertyStr("status", ctx.NewInt32(int32(resp.StatusCode)))
+	result.SetPropertyStr("body", ctx.NewString(string(respBody)))
+	return result, nil
+}

--- a/internal/plugin/jsrt/hostapi.go
+++ b/internal/plugin/jsrt/hostapi.go
@@ -1,10 +1,12 @@
 package jsrt
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -161,6 +163,9 @@ func (ha *hostAPI) doFetch(ctx *qjs.Context, args []*qjs.Value) (*qjs.Value, err
 	if parsed.Scheme != "http" && parsed.Scheme != "https" {
 		return nil, fmt.Errorf("fetch: only http/https allowed, got %q", parsed.Scheme)
 	}
+	if isPrivateHost(parsed.Host) {
+		return nil, fmt.Errorf("fetch: requests to private/internal hosts are not allowed")
+	}
 
 	method := "GET"
 	var body io.Reader
@@ -198,8 +203,10 @@ func (ha *hostAPI) doFetch(ctx *qjs.Context, args []*qjs.Value) (*qjs.Value, err
 		}
 	}
 
+	reqCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
 	client := &http.Client{Timeout: timeout}
-	req, err := http.NewRequest(method, rawURL, body)
+	req, err := http.NewRequestWithContext(reqCtx, method, rawURL, body)
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}
@@ -229,4 +236,25 @@ func (ha *hostAPI) doFetch(ctx *qjs.Context, args []*qjs.Value) (*qjs.Value, err
 	result.SetPropertyStr("status", ctx.NewInt32(int32(resp.StatusCode)))
 	result.SetPropertyStr("body", ctx.NewString(string(respBody)))
 	return result, nil
+}
+
+// isPrivateHost checks if the host resolves to a private/internal IP.
+func isPrivateHost(host string) bool {
+	// Strip port if present.
+	hostname := host
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		hostname = h
+	}
+
+	ips, err := net.LookupIP(hostname)
+	if err != nil {
+		return false // can't resolve, let the request fail naturally
+	}
+
+	for _, ip := range ips {
+		if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/plugin/jsrt/runtime.go
+++ b/internal/plugin/jsrt/runtime.go
@@ -1,0 +1,245 @@
+package jsrt
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/fastschema/qjs"
+	pluginapi "github.com/vaayne/anna/pkg/plugin"
+)
+
+// JSPlugin wraps a single JS extension loaded via QJS.
+// All JS calls are serialized via mu since QJS runtimes are not goroutine-safe.
+type JSPlugin struct {
+	name    string
+	mu      sync.Mutex
+	runtime *qjs.Runtime
+}
+
+func (p *JSPlugin) Name() string                   { return p.name }
+func (p *JSPlugin) Init(_ pluginapi.Context) error { return nil }
+
+func (p *JSPlugin) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.runtime != nil {
+		p.runtime.Close()
+		p.runtime = nil
+	}
+	return nil
+}
+
+// ToolHookRegistrar is the subset of Registry that LoadJS needs.
+type ToolHookRegistrar interface {
+	RegisterTool(pluginapi.Tool) error
+	RegisterHook(pluginapi.EventKind, pluginapi.HookFunc)
+}
+
+// LoadJS loads a JS extension from the given path, registers its tools and hooks
+// into the registry, and returns a JSPlugin that satisfies pluginapi.Plugin.
+func LoadJS(path string, cfg map[string]any, registry ToolHookRegistrar, logger *slog.Logger) (*JSPlugin, error) {
+	code, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read plugin file: %w", err)
+	}
+
+	pluginName := pluginNameFromPath(path)
+	pluginDir := filepath.Dir(path)
+	plog := logger.With("plugin", pluginName)
+
+	rt, err := qjs.New()
+	if err != nil {
+		return nil, fmt.Errorf("create qjs runtime: %w", err)
+	}
+
+	p := &JSPlugin{
+		name:    pluginName,
+		runtime: rt,
+	}
+
+	ctx := rt.Context()
+
+	// Collectors for tools and hooks registered during plugin init.
+	type toolEntry struct {
+		tool      pluginapi.Tool
+		executeFn *qjs.Value
+	}
+	var toolEntries []toolEntry
+
+	type hookEntry struct {
+		event   pluginapi.EventKind
+		handler *qjs.Value
+	}
+	var hookEntries []hookEntry
+
+	// Build the anna host object.
+	anna := ctx.NewObject()
+
+	// anna.config
+	configVal, err := goToJSValue(ctx, cfg)
+	if err != nil {
+		rt.Close()
+		return nil, fmt.Errorf("convert config to JS: %w", err)
+	}
+	anna.SetPropertyStr("config", configVal)
+
+	// Host APIs: log, readFile, writeFile, fetch.
+	ha := &hostAPI{
+		logger:    plog,
+		pluginDir: pluginDir,
+	}
+	registerHostAPIs(ctx, anna, ha)
+
+	// anna.registerTool(def)
+	anna.SetPropertyStr("registerTool", ctx.Function(func(this *qjs.This) (*qjs.Value, error) {
+		t, execFn, err := parseToolDef(this)
+		if err != nil {
+			return nil, err
+		}
+		toolEntries = append(toolEntries, toolEntry{tool: t, executeFn: execFn})
+		return this.Context().NewBool(true), nil
+	}))
+
+	// anna.on(event, handler)
+	anna.SetPropertyStr("on", ctx.Function(func(this *qjs.This) (*qjs.Value, error) {
+		args := this.Args()
+		if len(args) < 2 {
+			return nil, errors.New("anna.on requires (event, handler)")
+		}
+		if !args[1].IsFunction() {
+			return nil, errors.New("anna.on second argument must be a function")
+		}
+		hookEntries = append(hookEntries, hookEntry{
+			event:   pluginapi.EventKind(args[0].String()),
+			handler: args[1].Clone(),
+		})
+		return this.Context().NewBool(true), nil
+	}))
+
+	// Execute the plugin code. The plugin file should be a function body that
+	// receives `anna` as its argument. We wrap it in an IIFE.
+	wrappedCode := fmt.Sprintf(
+		"(function(anna) {\n%s\n})(__anna_host);\n",
+		string(code),
+	)
+	ctx.Global().SetPropertyStr("__anna_host", anna)
+
+	_, err = ctx.Eval(filepath.Base(path), qjs.Code(wrappedCode))
+	if err != nil {
+		rt.Close()
+		return nil, fmt.Errorf("eval plugin %s: %w", pluginName, err)
+	}
+
+	// Register collected tools.
+	for _, te := range toolEntries {
+		t := te.tool
+		execFn := te.executeFn
+		t.Execute = func(_ context.Context, args map[string]any) (string, error) {
+			p.mu.Lock()
+			defer p.mu.Unlock()
+			if p.runtime == nil {
+				return "", errors.New("plugin is closed")
+			}
+			c := rt.Context()
+			argsVal, err := goToJSValue(c, args)
+			if err != nil {
+				return "", fmt.Errorf("convert args: %w", err)
+			}
+			result, err := c.Invoke(execFn, c.NewNull(), argsVal)
+			if err != nil {
+				return "", fmt.Errorf("tool execute: %w", err)
+			}
+			defer result.Free()
+			return result.String(), nil
+		}
+		if err := registry.RegisterTool(t); err != nil {
+			plog.Warn("failed to register tool", "tool", t.Name, "error", err)
+		}
+	}
+
+	// Register collected hooks.
+	for _, he := range hookEntries {
+		handler := he.handler
+		fn := func(_ context.Context, event any) error {
+			p.mu.Lock()
+			defer p.mu.Unlock()
+			if p.runtime == nil {
+				return nil
+			}
+			c := rt.Context()
+			eventVal, err := goToJSValue(c, event)
+			if err != nil {
+				plog.Warn("convert hook event failed", "error", err)
+				return nil
+			}
+			result, err := c.Invoke(handler, c.NewNull(), eventVal)
+			if err != nil {
+				plog.Warn("hook handler error", "error", err)
+				return nil
+			}
+			defer result.Free()
+			// Hook cancellation: returning a non-empty string blocks the action.
+			if result.IsString() {
+				reason := result.String()
+				if reason != "" && reason != "undefined" {
+					return errors.New(reason)
+				}
+			}
+			return nil
+		}
+		registry.RegisterHook(he.event, fn)
+	}
+
+	plog.Info("JS plugin loaded", "tools", len(toolEntries), "hooks", len(hookEntries))
+	return p, nil
+}
+
+// parseToolDef extracts tool metadata from the JS object argument.
+func parseToolDef(this *qjs.This) (pluginapi.Tool, *qjs.Value, error) {
+	args := this.Args()
+	if len(args) < 1 {
+		return pluginapi.Tool{}, nil, errors.New("registerTool requires a tool definition object")
+	}
+	def := args[0]
+
+	name := def.GetPropertyStr("name")
+	if name.IsUndefined() || name.String() == "" {
+		return pluginapi.Tool{}, nil, errors.New("tool name is required")
+	}
+
+	desc := def.GetPropertyStr("description")
+	executeFn := def.GetPropertyStr("execute")
+	if executeFn.IsUndefined() || !executeFn.IsFunction() {
+		return pluginapi.Tool{}, nil, fmt.Errorf("tool %q requires an execute function", name.String())
+	}
+
+	// Parse parameters/inputSchema.
+	var inputSchema map[string]any
+	params := def.GetPropertyStr("parameters")
+	if !params.IsUndefined() && !params.IsNull() {
+		ctx := this.Context()
+		schema, err := jsValueToGoMap(ctx, params)
+		if err == nil {
+			inputSchema = schema
+		}
+	}
+
+	t := pluginapi.Tool{
+		Name:        name.String(),
+		Description: desc.String(),
+		InputSchema: inputSchema,
+	}
+
+	return t, executeFn.Clone(), nil
+}
+
+func pluginNameFromPath(path string) string {
+	base := filepath.Base(path)
+	ext := filepath.Ext(base)
+	return base[:len(base)-len(ext)]
+}

--- a/internal/plugin/jsrt/runtime_test.go
+++ b/internal/plugin/jsrt/runtime_test.go
@@ -1,0 +1,395 @@
+package jsrt
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	pluginapi "github.com/vaayne/anna/pkg/plugin"
+)
+
+// testRegistry implements ToolHookRegistrar for testing.
+type testRegistry struct {
+	mu    sync.Mutex
+	tools map[string]pluginapi.Tool
+	hooks map[pluginapi.EventKind][]pluginapi.HookFunc
+}
+
+func newTestRegistry() *testRegistry {
+	return &testRegistry{
+		tools: make(map[string]pluginapi.Tool),
+		hooks: make(map[pluginapi.EventKind][]pluginapi.HookFunc),
+	}
+}
+
+func (r *testRegistry) RegisterTool(t pluginapi.Tool) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.tools[t.Name] = t
+	return nil
+}
+
+func (r *testRegistry) RegisterHook(event pluginapi.EventKind, fn pluginapi.HookFunc) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.hooks[event] = append(r.hooks[event], fn)
+}
+
+func TestLoadJS_ToolRegistration(t *testing.T) {
+	dir := t.TempDir()
+	pluginFile := filepath.Join(dir, "hello.js")
+	code := `
+		anna.registerTool({
+			name: "hello_world",
+			description: "Says hello",
+			parameters: { type: "object", properties: { name: { type: "string" } } },
+			execute: function(args) {
+				return "Hello, " + args.name + "!";
+			}
+		});
+	`
+	if err := os.WriteFile(pluginFile, []byte(code), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := newTestRegistry()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	p, err := LoadJS(pluginFile, nil, reg, logger)
+	if err != nil {
+		t.Fatalf("LoadJS: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	if p.Name() != "hello" {
+		t.Errorf("Name() = %q, want %q", p.Name(), "hello")
+	}
+
+	tool, ok := reg.tools["hello_world"]
+	if !ok {
+		t.Fatal("tool hello_world not registered")
+	}
+
+	result, err := tool.Execute(context.Background(), map[string]any{"name": "World"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if result != "Hello, World!" {
+		t.Errorf("Execute result = %q, want %q", result, "Hello, World!")
+	}
+}
+
+func TestLoadJS_HookRegistration(t *testing.T) {
+	dir := t.TempDir()
+	pluginFile := filepath.Join(dir, "hooks.js")
+	code := `
+		anna.on("before_tool_call", function(event) {
+			if (event.toolName === "blocked_tool") {
+				return "tool is blocked by plugin";
+			}
+		});
+	`
+	if err := os.WriteFile(pluginFile, []byte(code), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := newTestRegistry()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	p, err := LoadJS(pluginFile, nil, reg, logger)
+	if err != nil {
+		t.Fatalf("LoadJS: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	hooks := reg.hooks[pluginapi.EventBeforeToolCall]
+	if len(hooks) != 1 {
+		t.Fatalf("expected 1 hook, got %d", len(hooks))
+	}
+
+	// Should block the "blocked_tool".
+	err = hooks[0](context.Background(), pluginapi.BeforeToolCallEvent{
+		ToolName: "blocked_tool",
+	})
+	if err == nil {
+		t.Fatal("expected hook to return error for blocked_tool")
+	}
+	if err.Error() != "tool is blocked by plugin" {
+		t.Errorf("error = %q, want %q", err.Error(), "tool is blocked by plugin")
+	}
+
+	// Should allow other tools.
+	err = hooks[0](context.Background(), pluginapi.BeforeToolCallEvent{
+		ToolName: "allowed_tool",
+	})
+	if err != nil {
+		t.Errorf("expected nil error for allowed_tool, got: %v", err)
+	}
+}
+
+func TestLoadJS_Config(t *testing.T) {
+	dir := t.TempDir()
+	pluginFile := filepath.Join(dir, "config_test.js")
+	code := `
+		anna.registerTool({
+			name: "config_echo",
+			description: "Echoes config",
+			parameters: {},
+			execute: function(args) {
+				return "key=" + anna.config.api_key;
+			}
+		});
+	`
+	if err := os.WriteFile(pluginFile, []byte(code), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := newTestRegistry()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	cfg := map[string]any{"api_key": "secret123"}
+	p, err := LoadJS(pluginFile, cfg, reg, logger)
+	if err != nil {
+		t.Fatalf("LoadJS: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	tool := reg.tools["config_echo"]
+	result, err := tool.Execute(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if result != "key=secret123" {
+		t.Errorf("result = %q, want %q", result, "key=secret123")
+	}
+}
+
+func TestLoadJS_SyntaxError(t *testing.T) {
+	dir := t.TempDir()
+	pluginFile := filepath.Join(dir, "bad.js")
+	if err := os.WriteFile(pluginFile, []byte("this is not valid javascript {{{"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := newTestRegistry()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	_, err := LoadJS(pluginFile, nil, reg, logger)
+	if err == nil {
+		t.Fatal("expected error for syntax error in JS")
+	}
+}
+
+func TestLoadJS_HostAPI_ReadFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a data file in the plugin directory.
+	dataFile := filepath.Join(dir, "data.txt")
+	if err := os.WriteFile(dataFile, []byte("hello from file"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pluginFile := filepath.Join(dir, "reader.js")
+	code := `
+		anna.registerTool({
+			name: "read_data",
+			description: "Reads data.txt",
+			parameters: {},
+			execute: function(args) {
+				return anna.readFile("data.txt");
+			}
+		});
+	`
+	if err := os.WriteFile(pluginFile, []byte(code), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := newTestRegistry()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	p, err := LoadJS(pluginFile, nil, reg, logger)
+	if err != nil {
+		t.Fatalf("LoadJS: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	tool := reg.tools["read_data"]
+	result, err := tool.Execute(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if result != "hello from file" {
+		t.Errorf("result = %q, want %q", result, "hello from file")
+	}
+}
+
+func TestLoadJS_HostAPI_WriteFile(t *testing.T) {
+	dir := t.TempDir()
+
+	pluginFile := filepath.Join(dir, "writer.js")
+	code := `
+		anna.registerTool({
+			name: "write_data",
+			description: "Writes output.txt",
+			parameters: {},
+			execute: function(args) {
+				anna.writeFile("output.txt", "written by plugin");
+				return "done";
+			}
+		});
+	`
+	if err := os.WriteFile(pluginFile, []byte(code), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := newTestRegistry()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	p, err := LoadJS(pluginFile, nil, reg, logger)
+	if err != nil {
+		t.Fatalf("LoadJS: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	tool := reg.tools["write_data"]
+	_, err = tool.Execute(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "output.txt"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != "written by plugin" {
+		t.Errorf("file content = %q, want %q", string(data), "written by plugin")
+	}
+}
+
+func TestLoadJS_PathEscape(t *testing.T) {
+	dir := t.TempDir()
+
+	pluginFile := filepath.Join(dir, "escape.js")
+	code := `
+		anna.registerTool({
+			name: "escape_test",
+			description: "Tries to read outside allowed dirs",
+			parameters: {},
+			execute: function(args) {
+				return anna.readFile("../../etc/passwd");
+			}
+		});
+	`
+	if err := os.WriteFile(pluginFile, []byte(code), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := newTestRegistry()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	p, err := LoadJS(pluginFile, nil, reg, logger)
+	if err != nil {
+		t.Fatalf("LoadJS: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	tool := reg.tools["escape_test"]
+	_, err = tool.Execute(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for path escape attempt")
+	}
+}
+
+func TestLoadJS_ConcurrentToolCalls(t *testing.T) {
+	dir := t.TempDir()
+	pluginFile := filepath.Join(dir, "counter.js")
+	code := `
+		var count = 0;
+		anna.registerTool({
+			name: "increment",
+			description: "Increments counter",
+			parameters: {},
+			execute: function(args) {
+				count++;
+				return "" + count;
+			}
+		});
+	`
+	if err := os.WriteFile(pluginFile, []byte(code), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := newTestRegistry()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	p, err := LoadJS(pluginFile, nil, reg, logger)
+	if err != nil {
+		t.Fatalf("LoadJS: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	tool := reg.tools["increment"]
+
+	// Run 10 concurrent calls — mutex should serialize them.
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := tool.Execute(context.Background(), nil)
+			if err != nil {
+				t.Errorf("concurrent Execute: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Final call should return "11" (10 previous + 1).
+	result, err := tool.Execute(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if result != "11" {
+		t.Errorf("result = %q, want %q", result, "11")
+	}
+}
+
+func TestLoadJS_ClosedPlugin(t *testing.T) {
+	dir := t.TempDir()
+	pluginFile := filepath.Join(dir, "closeable.js")
+	code := `
+		anna.registerTool({
+			name: "closeable_tool",
+			description: "Tool on a closeable plugin",
+			parameters: {},
+			execute: function(args) {
+				return "ok";
+			}
+		});
+	`
+	if err := os.WriteFile(pluginFile, []byte(code), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := newTestRegistry()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	p, err := LoadJS(pluginFile, nil, reg, logger)
+	if err != nil {
+		t.Fatalf("LoadJS: %v", err)
+	}
+
+	// Close the plugin, then try to execute.
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	tool := reg.tools["closeable_tool"]
+	_, err = tool.Execute(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error after plugin close")
+	}
+}

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -34,9 +34,14 @@ func (m *Manager) Registry() *Registry {
 // LoadAll loads plugins from config. Best-effort: logs warnings for failures,
 // continues loading remaining plugins.
 func (m *Manager) LoadAll(configs []config.PluginConfig) error {
-	// Load compiled-in Go plugin factories first.
+	// Load compiled-in Go plugin factories — only those with a matching config entry.
 	for _, f := range pluginapi.Factories() {
-		m.loadGoFactory(f, findPluginConfig(configs, f.Name))
+		cfg, ok := findPluginConfig(configs, f.Name)
+		if !ok {
+			m.logger.Debug("skipping unconfigured Go plugin", "plugin", f.Name)
+			continue
+		}
+		m.loadGoFactory(f, cfg)
 	}
 
 	// Load file-based plugins (JS extensions).
@@ -107,15 +112,16 @@ func (m *Manager) loadGoFactory(f pluginapi.Factory, cfg map[string]any) {
 }
 
 // findPluginConfig finds config for a named plugin in the config list.
-func findPluginConfig(configs []config.PluginConfig, name string) map[string]any {
+// Returns the config map and true if found, or nil and false if not.
+func findPluginConfig(configs []config.PluginConfig, name string) (map[string]any, bool) {
 	for _, cfg := range configs {
 		base := filepath.Base(cfg.Path)
 		base = strings.TrimSuffix(base, filepath.Ext(base))
 		if base == name {
-			return cfg.Config
+			return cfg.Config, true
 		}
 	}
-	return nil
+	return nil, false
 }
 
 // detectKind determines plugin type from path.

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/vaayne/anna/internal/config"
+	"github.com/vaayne/anna/internal/plugin/jsrt"
 	pluginapi "github.com/vaayne/anna/pkg/plugin"
 )
 
@@ -44,7 +45,7 @@ func (m *Manager) LoadAll(configs []config.PluginConfig) error {
 		kind := detectKind(path)
 		switch kind {
 		case "js":
-			m.logger.Info("JS plugin loading not yet implemented", "path", path)
+			m.loadJS(path, cfg.Config)
 		case "go":
 			// Go plugins are loaded via factory registry (compiled-in), not
 			// from files at runtime. Skip here -- they were already loaded above.
@@ -67,6 +68,15 @@ func (m *Manager) Close() error {
 		}
 	}
 	return lastErr
+}
+
+func (m *Manager) loadJS(path string, cfg map[string]any) {
+	p, err := jsrt.LoadJS(path, cfg, m.registry, m.logger)
+	if err != nil {
+		m.logger.Warn("failed to load JS plugin", "path", path, "error", err)
+		return
+	}
+	m.plugins = append(m.plugins, p)
 }
 
 func (m *Manager) loadGoFactory(f pluginapi.Factory, cfg map[string]any) {

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -46,8 +46,8 @@ func (m *Manager) LoadAll(configs []config.PluginConfig) error {
 
 	// Load file-based plugins (JS extensions).
 	for _, cfg := range configs {
-		path := expandPath(cfg.Path)
-		kind := detectKind(path)
+		path := ExpandPath(cfg.Path)
+		kind := DetectKind(path)
 		switch kind {
 		case "js":
 			m.loadJS(path, cfg.Config)
@@ -124,8 +124,8 @@ func findPluginConfig(configs []config.PluginConfig, name string) (map[string]an
 	return nil, false
 }
 
-// detectKind determines plugin type from path.
-func detectKind(path string) string {
+// DetectKind determines plugin type from path ("js", "go", or "").
+func DetectKind(path string) string {
 	info, err := os.Stat(path)
 	if err != nil {
 		return ""
@@ -141,8 +141,8 @@ func detectKind(path string) string {
 	return ""
 }
 
-// expandPath expands ~ to home directory.
-func expandPath(path string) string {
+// ExpandPath expands ~ to the user's home directory.
+func ExpandPath(path string) string {
 	if strings.HasPrefix(path, "~/") {
 		home, err := os.UserHomeDir()
 		if err == nil {

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -1,0 +1,137 @@
+package plugin
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/vaayne/anna/internal/config"
+	pluginapi "github.com/vaayne/anna/pkg/plugin"
+)
+
+// Manager discovers, loads, and manages plugins.
+type Manager struct {
+	registry *Registry
+	plugins  []pluginapi.Plugin
+	logger   *slog.Logger
+}
+
+// NewManager creates a plugin manager.
+func NewManager(logger *slog.Logger, builtinToolNames []string) *Manager {
+	return &Manager{
+		registry: NewRegistry(builtinToolNames),
+		logger:   logger,
+	}
+}
+
+// Registry returns the plugin registry.
+func (m *Manager) Registry() *Registry {
+	return m.registry
+}
+
+// LoadAll loads plugins from config. Best-effort: logs warnings for failures,
+// continues loading remaining plugins.
+func (m *Manager) LoadAll(configs []config.PluginConfig) error {
+	// Load compiled-in Go plugin factories first.
+	for _, f := range pluginapi.Factories() {
+		m.loadGoFactory(f, findPluginConfig(configs, f.Name))
+	}
+
+	// Load file-based plugins (JS extensions).
+	for _, cfg := range configs {
+		path := expandPath(cfg.Path)
+		kind := detectKind(path)
+		switch kind {
+		case "js":
+			m.logger.Info("JS plugin loading not yet implemented", "path", path)
+		case "go":
+			// Go plugins are loaded via factory registry (compiled-in), not
+			// from files at runtime. Skip here -- they were already loaded above.
+			continue
+		default:
+			m.logger.Warn("unknown plugin type", "path", path)
+		}
+	}
+
+	return nil
+}
+
+// Close shuts down all plugins in reverse order.
+func (m *Manager) Close() error {
+	var lastErr error
+	for i := len(m.plugins) - 1; i >= 0; i-- {
+		if err := m.plugins[i].Close(); err != nil {
+			m.logger.Warn("plugin close error", "plugin", m.plugins[i].Name(), "error", err)
+			lastErr = err
+		}
+	}
+	return lastErr
+}
+
+func (m *Manager) loadGoFactory(f pluginapi.Factory, cfg map[string]any) {
+	p, err := f.New(cfg)
+	if err != nil {
+		m.logger.Warn("failed to create plugin", "plugin", f.Name, "error", err)
+		return
+	}
+
+	pctx := pluginapi.Context{
+		Config: cfg,
+		Logger: m.logger.With("plugin", f.Name),
+		RegisterTool: func(t pluginapi.Tool) error {
+			return m.registry.RegisterTool(t)
+		},
+		OnEvent: func(kind pluginapi.EventKind, fn pluginapi.HookFunc) {
+			m.registry.RegisterHook(kind, fn)
+		},
+	}
+
+	if err := p.Init(pctx); err != nil {
+		m.logger.Warn("plugin init failed", "plugin", f.Name, "error", err)
+		return
+	}
+
+	m.plugins = append(m.plugins, p)
+	m.logger.Info("plugin loaded", "plugin", f.Name)
+}
+
+// findPluginConfig finds config for a named plugin in the config list.
+func findPluginConfig(configs []config.PluginConfig, name string) map[string]any {
+	for _, cfg := range configs {
+		base := filepath.Base(cfg.Path)
+		base = strings.TrimSuffix(base, filepath.Ext(base))
+		if base == name {
+			return cfg.Config
+		}
+	}
+	return nil
+}
+
+// detectKind determines plugin type from path.
+func detectKind(path string) string {
+	info, err := os.Stat(path)
+	if err != nil {
+		return ""
+	}
+	if !info.IsDir() && strings.HasSuffix(path, ".js") {
+		return "js"
+	}
+	if info.IsDir() {
+		if _, err := os.Stat(filepath.Join(path, "go.mod")); err == nil {
+			return "go"
+		}
+	}
+	return ""
+}
+
+// expandPath expands ~ to home directory.
+func expandPath(path string) string {
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			return filepath.Join(home, path[2:])
+		}
+	}
+	return path
+}

--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -1,0 +1,193 @@
+package plugin
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vaayne/anna/internal/config"
+	pluginapi "github.com/vaayne/anna/pkg/plugin"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError + 1}))
+}
+
+func TestNewManager(t *testing.T) {
+	m := NewManager(discardLogger(), []string{"read"})
+	if m == nil {
+		t.Fatal("expected non-nil manager")
+	}
+	if m.registry == nil {
+		t.Fatal("expected non-nil registry")
+	}
+	if m.logger == nil {
+		t.Fatal("expected non-nil logger")
+	}
+}
+
+func TestLoadAllEmpty(t *testing.T) {
+	pluginapi.ResetFactories()
+	m := NewManager(discardLogger(), nil)
+
+	err := m.LoadAll(nil)
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+
+	err = m.LoadAll([]config.PluginConfig{})
+	if err != nil {
+		t.Fatalf("expected nil error for empty slice, got: %v", err)
+	}
+}
+
+func TestLoadAllInvalidPath(t *testing.T) {
+	pluginapi.ResetFactories()
+	m := NewManager(discardLogger(), nil)
+
+	err := m.LoadAll([]config.PluginConfig{
+		{Path: "/nonexistent/path/to/plugin.js", Config: nil},
+	})
+	if err != nil {
+		t.Fatalf("invalid path should not fail LoadAll, got: %v", err)
+	}
+}
+
+func TestCloseReverseOrder(t *testing.T) {
+	m := NewManager(discardLogger(), nil)
+
+	var closeOrder []string
+
+	for _, name := range []string{"first", "second", "third"} {
+		n := name
+		m.plugins = append(m.plugins, &mockPlugin{
+			name: n,
+			closeFn: func() error {
+				closeOrder = append(closeOrder, n)
+				return nil
+			},
+		})
+	}
+
+	if err := m.Close(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := []string{"third", "second", "first"}
+	if len(closeOrder) != len(expected) {
+		t.Fatalf("expected %d closes, got %d", len(expected), len(closeOrder))
+	}
+	for i, name := range expected {
+		if closeOrder[i] != name {
+			t.Errorf("close[%d] = %q, want %q", i, closeOrder[i], name)
+		}
+	}
+}
+
+func TestDetectKindJS(t *testing.T) {
+	tmp := t.TempDir()
+	jsFile := filepath.Join(tmp, "plugin.js")
+	if err := os.WriteFile(jsFile, []byte("// js plugin"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := detectKind(jsFile)
+	if got != "js" {
+		t.Errorf("detectKind(%q) = %q, want %q", jsFile, got, "js")
+	}
+}
+
+func TestDetectKindGo(t *testing.T) {
+	tmp := t.TempDir()
+	goDir := filepath.Join(tmp, "myplugin")
+	if err := os.MkdirAll(goDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(goDir, "go.mod"), []byte("module myplugin"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := detectKind(goDir)
+	if got != "go" {
+		t.Errorf("detectKind(%q) = %q, want %q", goDir, got, "go")
+	}
+}
+
+func TestDetectKindUnknown(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"nonexistent", "/nonexistent/path/file.txt"},
+		{"directory without go.mod", t.TempDir()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detectKind(tt.path)
+			if got != "" {
+				t.Errorf("detectKind(%q) = %q, want empty string", tt.path, got)
+			}
+		})
+	}
+}
+
+func TestExpandPath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot determine home directory")
+	}
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"~/foo", filepath.Join(home, "foo")},
+		{"~/a/b/c.js", filepath.Join(home, "a/b/c.js")},
+		{"/absolute/path", "/absolute/path"},
+		{"relative/path", "relative/path"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := expandPath(tt.input)
+			if got != tt.want {
+				t.Errorf("expandPath(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// mockPlugin implements pluginapi.Plugin for testing.
+type mockPlugin struct {
+	name    string
+	closeFn func() error
+}
+
+func (p *mockPlugin) Name() string                   { return p.name }
+func (p *mockPlugin) Init(_ pluginapi.Context) error { return nil }
+func (p *mockPlugin) Close() error {
+	if p.closeFn != nil {
+		return p.closeFn()
+	}
+	return nil
+}
+
+// Ensure mockPlugin implements the Plugin interface.
+var _ pluginapi.Plugin = (*mockPlugin)(nil)
+
+func TestCloseReturnsLastError(t *testing.T) {
+	m := NewManager(discardLogger(), nil)
+	m.plugins = append(m.plugins,
+		&mockPlugin{name: "ok", closeFn: func() error { return nil }},
+		&mockPlugin{name: "fail", closeFn: func() error { return fmt.Errorf("close error") }},
+	)
+
+	err := m.Close()
+	if err == nil {
+		t.Fatal("expected error from Close")
+	}
+	if err.Error() != "close error" {
+		t.Errorf("error = %q, want %q", err.Error(), "close error")
+	}
+}

--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -93,9 +93,9 @@ func TestDetectKindJS(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := detectKind(jsFile)
+	got := DetectKind(jsFile)
 	if got != "js" {
-		t.Errorf("detectKind(%q) = %q, want %q", jsFile, got, "js")
+		t.Errorf("DetectKind(%q) = %q, want %q", jsFile, got, "js")
 	}
 }
 
@@ -109,9 +109,9 @@ func TestDetectKindGo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := detectKind(goDir)
+	got := DetectKind(goDir)
 	if got != "go" {
-		t.Errorf("detectKind(%q) = %q, want %q", goDir, got, "go")
+		t.Errorf("DetectKind(%q) = %q, want %q", goDir, got, "go")
 	}
 }
 
@@ -125,9 +125,9 @@ func TestDetectKindUnknown(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := detectKind(tt.path)
+			got := DetectKind(tt.path)
 			if got != "" {
-				t.Errorf("detectKind(%q) = %q, want empty string", tt.path, got)
+				t.Errorf("DetectKind(%q) = %q, want empty string", tt.path, got)
 			}
 		})
 	}
@@ -150,9 +150,9 @@ func TestExpandPath(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			got := expandPath(tt.input)
+			got := ExpandPath(tt.input)
 			if got != tt.want {
-				t.Errorf("expandPath(%q) = %q, want %q", tt.input, got, tt.want)
+				t.Errorf("ExpandPath(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
 	}

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -1,0 +1,86 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	pluginapi "github.com/vaayne/anna/pkg/plugin"
+)
+
+// Registry collects tools and hooks from all plugins.
+type Registry struct {
+	mu       sync.RWMutex
+	tools    map[string]pluginapi.Tool
+	hooks    map[pluginapi.EventKind][]pluginapi.HookFunc
+	reserved map[string]struct{}
+}
+
+// NewRegistry creates a registry with the given built-in tool names reserved.
+func NewRegistry(builtinNames []string) *Registry {
+	reserved := make(map[string]struct{}, len(builtinNames))
+	for _, name := range builtinNames {
+		reserved[name] = struct{}{}
+	}
+	return &Registry{
+		tools:    make(map[string]pluginapi.Tool),
+		hooks:    make(map[pluginapi.EventKind][]pluginapi.HookFunc),
+		reserved: reserved,
+	}
+}
+
+// RegisterTool adds a tool. Returns error on duplicate or reserved name.
+func (r *Registry) RegisterTool(t pluginapi.Tool) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.reserved[t.Name]; ok {
+		return fmt.Errorf("tool name %q is reserved (built-in)", t.Name)
+	}
+	if _, ok := r.tools[t.Name]; ok {
+		return fmt.Errorf("duplicate tool name: %q", t.Name)
+	}
+	r.tools[t.Name] = t
+	return nil
+}
+
+// RegisterHook adds a lifecycle hook for the given event kind.
+func (r *Registry) RegisterHook(event pluginapi.EventKind, fn pluginapi.HookFunc) {
+	r.mu.Lock()
+	r.hooks[event] = append(r.hooks[event], fn)
+	r.mu.Unlock()
+}
+
+// Tools returns a copy of all registered tools.
+func (r *Registry) Tools() map[string]pluginapi.Tool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	result := make(map[string]pluginapi.Tool, len(r.tools))
+	for k, v := range r.tools {
+		result[k] = v
+	}
+	return result
+}
+
+// RunHooks executes all hooks for the given event kind sequentially.
+// For "before" events, the first hook that returns an error stops execution
+// and the error is returned (cancelling the action).
+// For "after" events, errors are ignored.
+//
+// The event parameter is a string (not EventKind) so that callers in the
+// engine package can use this method without importing pkg/plugin directly,
+// avoiding circular imports.
+func (r *Registry) RunHooks(ctx context.Context, event string, data any) error {
+	kind := pluginapi.EventKind(event)
+	r.mu.RLock()
+	hooks := make([]pluginapi.HookFunc, len(r.hooks[kind]))
+	copy(hooks, r.hooks[kind])
+	r.mu.RUnlock()
+
+	isBefore := kind == pluginapi.EventBeforeToolCall || kind == pluginapi.EventSessionStart
+	for _, fn := range hooks {
+		if err := fn(ctx, data); err != nil && isBefore {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -76,7 +76,7 @@ func (r *Registry) RunHooks(ctx context.Context, event string, data any) error {
 	copy(hooks, r.hooks[kind])
 	r.mu.RUnlock()
 
-	isBefore := kind == pluginapi.EventBeforeToolCall || kind == pluginapi.EventSessionStart
+	isBefore := kind == pluginapi.EventBeforeToolCall
 	for _, fn := range hooks {
 		if err := fn(ctx, data); err != nil && isBefore {
 			return err

--- a/internal/plugin/registry_test.go
+++ b/internal/plugin/registry_test.go
@@ -1,0 +1,170 @@
+package plugin
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	pluginapi "github.com/vaayne/anna/pkg/plugin"
+)
+
+func newTestTool(name string) pluginapi.Tool {
+	return pluginapi.Tool{
+		Name:        name,
+		Description: "test tool " + name,
+		InputSchema: map[string]any{"type": "object"},
+		Execute: func(_ context.Context, _ map[string]any) (string, error) {
+			return "ok", nil
+		},
+	}
+}
+
+func TestRegisterTool(t *testing.T) {
+	r := NewRegistry(nil)
+	tool := newTestTool("my_tool")
+
+	if err := r.RegisterTool(tool); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tools := r.Tools()
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(tools))
+	}
+	got, ok := tools["my_tool"]
+	if !ok {
+		t.Fatal("tool 'my_tool' not found")
+	}
+	if got.Description != "test tool my_tool" {
+		t.Errorf("unexpected description: %q", got.Description)
+	}
+}
+
+func TestRegisterToolDuplicate(t *testing.T) {
+	r := NewRegistry(nil)
+
+	if err := r.RegisterTool(newTestTool("dup")); err != nil {
+		t.Fatalf("first register: %v", err)
+	}
+
+	err := r.RegisterTool(newTestTool("dup"))
+	if err == nil {
+		t.Fatal("expected error for duplicate tool name")
+	}
+	if want := `duplicate tool name: "dup"`; err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestRegisterToolReservedName(t *testing.T) {
+	r := NewRegistry([]string{"read", "write", "execute"})
+
+	err := r.RegisterTool(newTestTool("read"))
+	if err == nil {
+		t.Fatal("expected error for reserved tool name")
+	}
+	if want := `tool name "read" is reserved (built-in)`; err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestRegisterHookAndRun(t *testing.T) {
+	r := NewRegistry(nil)
+
+	var received any
+	r.RegisterHook(pluginapi.EventBeforeToolCall, func(_ context.Context, event any) error {
+		received = event
+		return nil
+	})
+
+	data := pluginapi.BeforeToolCallEvent{ToolName: "grep", Arguments: map[string]any{"q": "hello"}}
+	err := r.RunHooks(context.Background(), string(pluginapi.EventBeforeToolCall), data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, ok := received.(pluginapi.BeforeToolCallEvent)
+	if !ok {
+		t.Fatalf("expected BeforeToolCallEvent, got %T", received)
+	}
+	if got.ToolName != "grep" {
+		t.Errorf("ToolName = %q, want %q", got.ToolName, "grep")
+	}
+}
+
+func TestRunHooksBeforeStopsOnError(t *testing.T) {
+	r := NewRegistry(nil)
+
+	callOrder := []string{}
+	r.RegisterHook(pluginapi.EventBeforeToolCall, func(_ context.Context, _ any) error {
+		callOrder = append(callOrder, "first")
+		return errors.New("blocked")
+	})
+	r.RegisterHook(pluginapi.EventBeforeToolCall, func(_ context.Context, _ any) error {
+		callOrder = append(callOrder, "second")
+		return nil
+	})
+
+	err := r.RunHooks(context.Background(), string(pluginapi.EventBeforeToolCall), nil)
+	if err == nil {
+		t.Fatal("expected error from before hook")
+	}
+	if err.Error() != "blocked" {
+		t.Errorf("error = %q, want %q", err.Error(), "blocked")
+	}
+	if len(callOrder) != 1 || callOrder[0] != "first" {
+		t.Errorf("expected only first hook to run, got %v", callOrder)
+	}
+}
+
+func TestRunHooksAfterIgnoresError(t *testing.T) {
+	r := NewRegistry(nil)
+
+	r.RegisterHook(pluginapi.EventAfterToolCall, func(_ context.Context, _ any) error {
+		return errors.New("ignored error")
+	})
+
+	err := r.RunHooks(context.Background(), string(pluginapi.EventAfterToolCall), nil)
+	if err != nil {
+		t.Fatalf("after hook error should be ignored, got: %v", err)
+	}
+}
+
+func TestRunHooksNoHooks(t *testing.T) {
+	r := NewRegistry(nil)
+
+	err := r.RunHooks(context.Background(), string(pluginapi.EventBeforeToolCall), nil)
+	if err != nil {
+		t.Fatalf("expected nil error with no hooks, got: %v", err)
+	}
+}
+
+func TestConcurrentRegisterAndRun(t *testing.T) {
+	r := NewRegistry(nil)
+
+	const n = 50
+	var wg sync.WaitGroup
+	wg.Add(n * 2)
+
+	// Concurrently register tools.
+	for i := range n {
+		go func(idx int) {
+			defer wg.Done()
+			_ = r.RegisterTool(newTestTool("tool_" + string(rune('a'+idx%26)) + "_" + string(rune('0'+idx/26))))
+		}(i)
+	}
+
+	// Concurrently run hooks.
+	r.RegisterHook(pluginapi.EventAfterToolCall, func(_ context.Context, _ any) error {
+		return nil
+	})
+	for range n {
+		go func() {
+			defer wg.Done()
+			_ = r.RunHooks(context.Background(), string(pluginapi.EventAfterToolCall), nil)
+		}()
+	}
+
+	wg.Wait()
+}

--- a/pkg/plugin/register.go
+++ b/pkg/plugin/register.go
@@ -1,0 +1,32 @@
+package plugin
+
+import "sync"
+
+var (
+	mu        sync.Mutex
+	factories []Factory
+)
+
+// Register is called from Go plugin init() functions to register a plugin factory.
+// It is safe for concurrent use.
+func Register(f Factory) {
+	mu.Lock()
+	factories = append(factories, f)
+	mu.Unlock()
+}
+
+// Factories returns a copy of all registered factories.
+func Factories() []Factory {
+	mu.Lock()
+	defer mu.Unlock()
+	result := make([]Factory, len(factories))
+	copy(result, factories)
+	return result
+}
+
+// ResetFactories clears the factory registry. Only for testing.
+func ResetFactories() {
+	mu.Lock()
+	factories = nil
+	mu.Unlock()
+}

--- a/pkg/plugin/register_test.go
+++ b/pkg/plugin/register_test.go
@@ -1,0 +1,89 @@
+package plugin
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestRegister(t *testing.T) {
+	ResetFactories()
+
+	f := Factory{Name: "test-plugin", New: func(cfg map[string]any) (Plugin, error) { return nil, nil }}
+	Register(f)
+
+	got := Factories()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 factory, got %d", len(got))
+	}
+	if got[0].Name != "test-plugin" {
+		t.Fatalf("expected name %q, got %q", "test-plugin", got[0].Name)
+	}
+}
+
+func TestRegisterMultiple(t *testing.T) {
+	ResetFactories()
+
+	names := []string{"alpha", "beta", "gamma"}
+	for _, name := range names {
+		Register(Factory{Name: name, New: func(cfg map[string]any) (Plugin, error) { return nil, nil }})
+	}
+
+	got := Factories()
+	if len(got) != len(names) {
+		t.Fatalf("expected %d factories, got %d", len(names), len(got))
+	}
+	for i, name := range names {
+		if got[i].Name != name {
+			t.Errorf("factory[%d]: expected %q, got %q", i, name, got[i].Name)
+		}
+	}
+}
+
+func TestFactoriesReturnsCopy(t *testing.T) {
+	ResetFactories()
+
+	Register(Factory{Name: "original", New: func(cfg map[string]any) (Plugin, error) { return nil, nil }})
+
+	got := Factories()
+	got[0] = Factory{Name: "mutated"}
+
+	original := Factories()
+	if original[0].Name != "original" {
+		t.Fatalf("modifying returned slice affected registry: got %q", original[0].Name)
+	}
+}
+
+func TestResetFactories(t *testing.T) {
+	ResetFactories()
+
+	Register(Factory{Name: "will-be-cleared", New: func(cfg map[string]any) (Plugin, error) { return nil, nil }})
+	ResetFactories()
+
+	got := Factories()
+	if len(got) != 0 {
+		t.Fatalf("expected 0 factories after reset, got %d", len(got))
+	}
+}
+
+func TestRegisterConcurrent(t *testing.T) {
+	ResetFactories()
+
+	const n = 100
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := range n {
+		go func(idx int) {
+			defer wg.Done()
+			Register(Factory{
+				Name: "concurrent-" + string(rune('A'+idx%26)),
+				New:  func(cfg map[string]any) (Plugin, error) { return nil, nil },
+			})
+		}(i)
+	}
+	wg.Wait()
+
+	got := Factories()
+	if len(got) != n {
+		t.Fatalf("expected %d factories, got %d", n, len(got))
+	}
+}

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -52,19 +52,19 @@ type HookFunc func(ctx context.Context, event any) error
 
 // BeforeToolCallEvent is passed to EventBeforeToolCall hooks.
 type BeforeToolCallEvent struct {
-	ToolName  string
-	Arguments map[string]any
+	ToolName  string         `json:"toolName"`
+	Arguments map[string]any `json:"arguments"`
 }
 
 // AfterToolCallEvent is passed to EventAfterToolCall hooks.
 type AfterToolCallEvent struct {
-	ToolName string
-	Result   string
-	IsError  bool
+	ToolName string `json:"toolName"`
+	Result   string `json:"result"`
+	IsError  bool   `json:"isError"`
 }
 
 // SessionEvent is passed to EventSessionStart and EventSessionEnd hooks.
 type SessionEvent struct {
-	SessionID string
-	Channel   string
+	SessionID string `json:"sessionId"`
+	Channel   string `json:"channel"`
 }

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -1,0 +1,70 @@
+package plugin
+
+import (
+	"context"
+	"log/slog"
+)
+
+// Factory is registered by Go plugins in init(). The Manager instantiates
+// plugins from factories after config is loaded at runtime.
+type Factory struct {
+	Name string
+	New  func(cfg map[string]any) (Plugin, error)
+}
+
+// Plugin is the interface both Go and JS plugins implement.
+type Plugin interface {
+	Name() string
+	Init(ctx Context) error
+	Close() error
+}
+
+// Context is passed to Plugin.Init(), providing registration APIs.
+type Context struct {
+	Config       map[string]any
+	Logger       *slog.Logger
+	RegisterTool func(Tool) error
+	OnEvent      func(EventKind, HookFunc)
+}
+
+// Tool is a plugin-provided tool definition.
+type Tool struct {
+	Name        string
+	Description string
+	InputSchema map[string]any
+	Execute     func(ctx context.Context, args map[string]any) (string, error)
+}
+
+// EventKind identifies lifecycle events.
+type EventKind string
+
+const (
+	EventBeforeToolCall EventKind = "before_tool_call"
+	EventAfterToolCall  EventKind = "after_tool_call"
+	EventSessionStart   EventKind = "session_start"
+	EventSessionEnd     EventKind = "session_end"
+)
+
+// HookFunc is a lifecycle hook handler.
+// For "before" events, returning a non-nil error cancels the action.
+// For "after" events, return values are ignored.
+type HookFunc func(ctx context.Context, event any) error
+
+// BeforeToolCallEvent is passed to EventBeforeToolCall hooks.
+type BeforeToolCallEvent struct {
+	ToolName  string
+	Arguments map[string]any
+}
+
+// AfterToolCallEvent is passed to EventAfterToolCall hooks.
+type AfterToolCallEvent struct {
+	ToolName string
+	Result   string
+	IsError  bool
+}
+
+// SessionEvent is passed to EventSessionStart and EventSessionEnd hooks.
+type SessionEvent struct {
+	SessionID string
+	Channel   string
+}


### PR DESCRIPTION
## Summary

Adds an extensible plugin system supporting two plugin types:

- **JS extensions** — `.js` files executed at runtime via QuickJS (CGO-free, Wasm-based), sandboxed with scoped file access and fetch limits
- **Go plugins** — local Go packages compiled into a custom binary via Caddy-style builder (`anna plugin build`)

Both types register through a unified `plugin.Registry` with tool registration and lifecycle event hooks (`before_tool_call`, `after_tool_call`, `session_start`, `session_end`).

### Key changes

- **`pkg/plugin/`** — Public contract (Factory, Plugin, Tool, HookFunc, EventKind) importable by external Go plugins
- **`internal/plugin/`** — Registry (reserved name protection, O(1) tool lookup), Manager (best-effort loading), AdaptTool
- **`internal/plugin/jsrt/`** — JS runtime with per-plugin mutex, host APIs (log, readFile, writeFile, fetch), path sandboxing
- **`internal/plugin/goplugin/`** — Builder generates temp module with blank imports + replace directives, runs `go build`
- **`cmd/anna/plugin.go`** — `anna plugin list/add/remove/build` CLI commands
- **`cmd/anna/main.go`** — Exported `Main()` for custom binary support
- **Engine integration** — Hooks threaded via `LoopConfig.PluginHooks` through GoRunner and DelegateTool; session hooks fired from Pool

### JS plugin example

```js
anna.registerTool({
    name: "get_weather",
    description: "Get weather for a city",
    parameters: { type: "object", properties: { city: { type: "string" } } },
    execute: function(args) {
        var resp = anna.fetch("https://api.weather.com/v1?city=" + args.city);
        return resp.body;
    }
});

anna.on("before_tool_call", function(event) {
    anna.log("info", "calling: " + event.toolName);
});
```

### Config

```yaml
plugins:
  - path: ~/.anna/plugins/weather.js
    config:
      api_key: "xxx"
  - path: ~/.anna/plugins/github-tools
    config:
      token: "yyy"
```

## Test plan

- [x] Unit tests for `pkg/plugin` (factory registry, concurrent safety)
- [x] Unit tests for `internal/plugin` (registry collision/reserved names, hooks, manager, adapter)
- [x] Unit tests for `internal/plugin/jsrt` (tool/hook registration, host APIs, sandboxing, concurrency)
- [x] Unit tests for `internal/plugin/goplugin` (template rendering, module path reading, builder validation)
- [x] All tests pass with `-race -short` (`go test -race -short ./...`)
- [x] Lint clean (`golangci-lint run`)
- [ ] Manual: `anna plugin add <path>` / `anna plugin list` / `anna plugin remove`
- [ ] Manual: JS plugin loads and tool executes via LLM
- [ ] Manual: `anna plugin build` produces custom binary with Go plugin