### PR TITLE
feat: add Go plugin builder with Caddy-style compilation

### DIFF
--- a/cmd/anna/plugin.go
+++ b/cmd/anna/plugin.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	ucli "github.com/urfave/cli/v2"
 	"github.com/vaayne/anna/internal/config"
 	pluginmgr "github.com/vaayne/anna/internal/plugin"
+	"github.com/vaayne/anna/internal/plugin/goplugin"
 	"gopkg.in/yaml.v3"
 )
 
@@ -20,6 +22,7 @@ func pluginCommand() *ucli.Command {
 			pluginListCommand(),
 			pluginAddCommand(),
 			pluginRemoveCommand(),
+			pluginBuildCommand(),
 		},
 		Action: func(c *ucli.Context) error {
 			return pluginListAction()
@@ -114,6 +117,50 @@ func pluginRemoveCommand() *ucli.Command {
 			}
 
 			fmt.Printf("Plugin %q removed.\n", target)
+			return nil
+		},
+	}
+}
+
+func pluginBuildCommand() *ucli.Command {
+	return &ucli.Command{
+		Name:  "build",
+		Usage: "Compile a custom binary with all Go plugins",
+		Flags: []ucli.Flag{
+			&ucli.StringFlag{
+				Name:  "output",
+				Usage: "Output binary path",
+				Value: "./anna-custom",
+			},
+		},
+		Action: func(c *ucli.Context) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+
+			var goPaths []string
+			for _, p := range cfg.Plugins {
+				resolved := pluginmgr.ExpandPath(p.Path)
+				if pluginmgr.DetectKind(resolved) == "go" {
+					goPaths = append(goPaths, resolved)
+				}
+			}
+
+			if len(goPaths) == 0 {
+				fmt.Println("No Go plugins configured. Nothing to build.")
+				return nil
+			}
+
+			output := c.String("output")
+			fmt.Fprintf(os.Stderr, "Building custom binary with %d Go plugin(s)...\n", len(goPaths))
+
+			builder := goplugin.NewBuilder(goPaths, output, slog.Default())
+			if err := builder.Build(c.Context); err != nil {
+				return fmt.Errorf("build failed: %w", err)
+			}
+
+			fmt.Printf("Custom binary built: %s\n", output)
 			return nil
 		},
 	}

--- a/internal/plugin/goplugin/builder.go
+++ b/internal/plugin/goplugin/builder.go
@@ -1,0 +1,254 @@
+// Package goplugin implements Caddy-style compilation for Go plugins.
+//
+// It generates a temporary Go module that blank-imports each plugin package
+// (triggering their init() registrations), then compiles a custom anna binary
+// with all plugins statically linked.
+package goplugin
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"text/template"
+)
+
+const (
+	annaModule    = "github.com/vaayne/anna"
+	defaultOutput = "./anna-custom"
+)
+
+// Builder orchestrates Caddy-style compilation of a custom anna binary with
+// Go plugins compiled in.
+type Builder struct {
+	plugins []string // absolute paths to plugin directories
+	output  string   // output binary path
+	logger  *slog.Logger
+}
+
+// NewBuilder creates a Builder. Each plugin path must be a local directory
+// containing a go.mod. Output defaults to "./anna-custom" if empty.
+func NewBuilder(plugins []string, output string, logger *slog.Logger) *Builder {
+	if output == "" {
+		output = defaultOutput
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Builder{
+		plugins: plugins,
+		output:  output,
+		logger:  logger,
+	}
+}
+
+// Build generates a temporary Go module and compiles a custom anna binary.
+// The caller's context controls cancellation of the underlying go commands.
+func (b *Builder) Build(ctx context.Context) error {
+	if err := b.checkGoToolchain(ctx); err != nil {
+		return err
+	}
+
+	modules, err := b.resolvePlugins()
+	if err != nil {
+		return err
+	}
+
+	annaRoot, err := b.findAnnaRoot()
+	if err != nil {
+		return err
+	}
+
+	tmpDir, err := os.MkdirTemp("", "anna-build-*")
+	if err != nil {
+		return fmt.Errorf("create temp dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	data := templateData{
+		AnnaModule:    annaModule,
+		AnnaLocalPath: annaRoot,
+		Plugins:       modules,
+	}
+
+	// Copy cmd/anna source files into the temp dir so the build shares
+	// the same package main as the real anna binary.
+	cmdDir := filepath.Join(annaRoot, "cmd", "anna")
+	if err := b.copySources(cmdDir, tmpDir); err != nil {
+		return fmt.Errorf("copy cmd/anna sources: %w", err)
+	}
+
+	if err := b.writeFile(tmpDir, "plugins.go", pluginsGoTmpl, data); err != nil {
+		return err
+	}
+	if err := b.writeFile(tmpDir, "go.mod", goModTmpl, data); err != nil {
+		return err
+	}
+
+	b.logger.Info("running go mod tidy", "dir", tmpDir)
+	if err := b.runGo(ctx, tmpDir, "mod", "tidy"); err != nil {
+		return fmt.Errorf("go mod tidy: %w", err)
+	}
+
+	outputAbs, err := filepath.Abs(b.output)
+	if err != nil {
+		return fmt.Errorf("resolve output path: %w", err)
+	}
+
+	b.logger.Info("building custom binary", "output", outputAbs, "plugins", len(modules))
+	if err := b.runGo(ctx, tmpDir, "build", "-o", outputAbs, "."); err != nil {
+		return fmt.Errorf("go build: %w", err)
+	}
+
+	b.logger.Info("build complete", "binary", outputAbs)
+	return nil
+}
+
+// checkGoToolchain verifies that the go toolchain is available.
+func (b *Builder) checkGoToolchain(ctx context.Context) error {
+	cmd := exec.CommandContext(ctx, "go", "version")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("go toolchain not found (is Go installed?): %w\n%s", err, out)
+	}
+	b.logger.Debug("go toolchain found", "version", strings.TrimSpace(string(out)))
+	return nil
+}
+
+// resolvePlugins validates each plugin directory and reads its module path.
+func (b *Builder) resolvePlugins() ([]pluginModule, error) {
+	modules := make([]pluginModule, 0, len(b.plugins))
+	for _, dir := range b.plugins {
+		absDir, err := filepath.Abs(dir)
+		if err != nil {
+			return nil, fmt.Errorf("resolve plugin path %q: %w", dir, err)
+		}
+
+		modPath, err := readModulePath(filepath.Join(absDir, "go.mod"))
+		if err != nil {
+			return nil, fmt.Errorf("plugin %q: %w", absDir, err)
+		}
+
+		modules = append(modules, pluginModule{
+			Module:    modPath,
+			LocalPath: absDir,
+		})
+		b.logger.Debug("resolved plugin", "module", modPath, "path", absDir)
+	}
+	return modules, nil
+}
+
+// findAnnaRoot locates the anna project root by looking for go.mod in the
+// current executable's directory hierarchy, falling back to the working
+// directory hierarchy.
+func (b *Builder) findAnnaRoot() (string, error) {
+	// Try from executable location first.
+	if exe, err := os.Executable(); err == nil {
+		if root, ok := findGoModRoot(filepath.Dir(exe)); ok {
+			return root, nil
+		}
+	}
+
+	// Fall back to working directory.
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("get working directory: %w", err)
+	}
+	if root, ok := findGoModRoot(cwd); ok {
+		return root, nil
+	}
+
+	return "", fmt.Errorf("cannot find anna project root (no go.mod with module %s found)", annaModule)
+}
+
+// findGoModRoot walks up from dir looking for a go.mod containing the anna
+// module path.
+func findGoModRoot(dir string) (string, bool) {
+	for {
+		gomod := filepath.Join(dir, "go.mod")
+		if modPath, err := readModulePath(gomod); err == nil && modPath == annaModule {
+			return dir, true
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", false
+		}
+		dir = parent
+	}
+}
+
+// readModulePath reads the module path from a go.mod file.
+func readModulePath(gomodPath string) (string, error) {
+	f, err := os.Open(gomodPath)
+	if err != nil {
+		return "", fmt.Errorf("open go.mod: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "module ") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "module ")), nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("read go.mod: %w", err)
+	}
+	return "", fmt.Errorf("no module directive found in %s", gomodPath)
+}
+
+// writeFile renders a template to a file in the given directory.
+func (b *Builder) writeFile(dir, name string, tmpl *template.Template, data templateData) error {
+	path := filepath.Join(dir, name)
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", name, err)
+	}
+
+	if err := tmpl.Execute(f, data); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("render %s: %w", name, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", name, err)
+	}
+	b.logger.Debug("wrote file", "path", path)
+	return nil
+}
+
+// copySources copies all .go files (excluding test files) from srcDir to dstDir.
+func (b *Builder) copySources(srcDir, dstDir string) error {
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		return fmt.Errorf("read source dir %s: %w", srcDir, err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(srcDir, name))
+		if err != nil {
+			return fmt.Errorf("read %s: %w", name, err)
+		}
+		if err := os.WriteFile(filepath.Join(dstDir, name), data, 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", name, err)
+		}
+		b.logger.Debug("copied source file", "file", name)
+	}
+	return nil
+}
+
+// runGo executes a go command in the given directory.
+func (b *Builder) runGo(ctx context.Context, dir string, args ...string) error {
+	cmd := exec.CommandContext(ctx, "go", args...)
+	cmd.Dir = dir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/internal/plugin/goplugin/builder_test.go
+++ b/internal/plugin/goplugin/builder_test.go
@@ -1,0 +1,176 @@
+package goplugin
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewBuilderDefaults(t *testing.T) {
+	b := NewBuilder([]string{"/some/plugin"}, "", nil)
+
+	if b.output != defaultOutput {
+		t.Errorf("expected default output %q, got %q", defaultOutput, b.output)
+	}
+	if b.logger == nil {
+		t.Error("expected non-nil logger when nil is passed")
+	}
+	if len(b.plugins) != 1 || b.plugins[0] != "/some/plugin" {
+		t.Errorf("expected plugins [/some/plugin], got %v", b.plugins)
+	}
+}
+
+func TestNewBuilderCustomOutput(t *testing.T) {
+	b := NewBuilder([]string{}, "/tmp/my-binary", slog.Default())
+
+	if b.output != "/tmp/my-binary" {
+		t.Errorf("expected output %q, got %q", "/tmp/my-binary", b.output)
+	}
+}
+
+func TestReadModulePath(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		wantMod string
+		wantErr bool
+	}{
+		{
+			name:    "standard module line",
+			content: "module example.com/my-plugin\n\ngo 1.25\n",
+			wantMod: "example.com/my-plugin",
+		},
+		{
+			name:    "module line with extra whitespace",
+			content: "  module   github.com/foo/bar  \n\ngo 1.25\n",
+			wantMod: "github.com/foo/bar",
+		},
+		{
+			name:    "module line after comments",
+			content: "// this is a comment\nmodule example.com/test\n",
+			wantMod: "example.com/test",
+		},
+		{
+			name:    "no module directive",
+			content: "go 1.25\n\nrequire example.com/dep v1.0.0\n",
+			wantErr: true,
+		},
+		{
+			name:    "empty file",
+			content: "",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			gomodPath := filepath.Join(dir, "go.mod")
+			if err := os.WriteFile(gomodPath, []byte(tc.content), 0o644); err != nil {
+				t.Fatalf("write temp go.mod: %v", err)
+			}
+
+			got, err := readModulePath(gomodPath)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got module %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.wantMod {
+				t.Errorf("expected module %q, got %q", tc.wantMod, got)
+			}
+		})
+	}
+}
+
+func TestReadModulePathNotFound(t *testing.T) {
+	_, err := readModulePath("/nonexistent/path/go.mod")
+	if err == nil {
+		t.Error("expected error for missing go.mod, got nil")
+	}
+}
+
+func TestPluginsGoTemplate(t *testing.T) {
+	data := templateData{
+		AnnaModule:    "github.com/vaayne/anna",
+		AnnaLocalPath: "/home/user/anna",
+		Plugins: []pluginModule{
+			{Module: "example.com/plugin-a", LocalPath: "/home/user/plugin-a"},
+			{Module: "example.com/plugin-b", LocalPath: "/home/user/plugin-b"},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := pluginsGoTmpl.Execute(&buf, data); err != nil {
+		t.Fatalf("template execution failed: %v", err)
+	}
+
+	out := buf.String()
+
+	checks := []string{
+		"package main",
+		`_ "example.com/plugin-a"`,
+		`_ "example.com/plugin-b"`,
+	}
+	for _, want := range checks {
+		if !bytes.Contains(buf.Bytes(), []byte(want)) {
+			t.Errorf("plugins.go output missing %q\n\nfull output:\n%s", want, out)
+		}
+	}
+
+	// Verify it does NOT import cmd/anna (the whole point of this fix).
+	if bytes.Contains(buf.Bytes(), []byte("cmd/anna")) {
+		t.Errorf("plugins.go should not import cmd/anna\n\nfull output:\n%s", out)
+	}
+}
+
+func TestGoModTemplate(t *testing.T) {
+	data := templateData{
+		AnnaModule:    "github.com/vaayne/anna",
+		AnnaLocalPath: "/home/user/anna",
+		Plugins: []pluginModule{
+			{Module: "example.com/plugin-a", LocalPath: "/home/user/plugin-a"},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := goModTmpl.Execute(&buf, data); err != nil {
+		t.Fatalf("template execution failed: %v", err)
+	}
+
+	out := buf.String()
+
+	checks := []string{
+		"module anna-custom",
+		"go 1.25",
+		"github.com/vaayne/anna v0.0.0",
+		"example.com/plugin-a v0.0.0",
+		"replace github.com/vaayne/anna => /home/user/anna",
+		"replace example.com/plugin-a => /home/user/plugin-a",
+	}
+	for _, want := range checks {
+		if !bytes.Contains(buf.Bytes(), []byte(want)) {
+			t.Errorf("go.mod output missing %q\n\nfull output:\n%s", want, out)
+		}
+	}
+}
+
+func TestBuildMissingPlugin(t *testing.T) {
+	b := NewBuilder(
+		[]string{"/nonexistent/plugin/path"},
+		filepath.Join(t.TempDir(), "anna-test"),
+		slog.Default(),
+	)
+
+	err := b.Build(context.Background())
+	if err == nil {
+		t.Fatal("expected error for non-existent plugin path, got nil")
+	}
+}

--- a/internal/plugin/goplugin/templates.go
+++ b/internal/plugin/goplugin/templates.go
@@ -1,0 +1,50 @@
+package goplugin
+
+import "text/template"
+
+// pluginModule holds metadata for a single Go plugin module.
+type pluginModule struct {
+	// Module is the Go module path (e.g., "example.com/my-plugin").
+	Module string
+	// LocalPath is the absolute local directory path for the replace directive.
+	LocalPath string
+}
+
+// templateData is the data passed to both templates.
+type templateData struct {
+	AnnaModule    string
+	AnnaLocalPath string
+	Plugins       []pluginModule
+}
+
+// pluginsGoTmpl generates a plugins.go that blank-imports every plugin
+// (triggering their init() -> plugin.Register() calls). This file is placed
+// alongside the copied cmd/anna source so it is part of the same package main.
+var pluginsGoTmpl = template.Must(template.New("plugins.go").Parse(`package main
+
+import (
+{{- range .Plugins}}
+	_ "{{.Module}}"
+{{- end}}
+)
+`))
+
+// goModTmpl generates a go.mod that requires anna and all plugin modules,
+// with replace directives pointing each module to its local directory.
+var goModTmpl = template.Must(template.New("go.mod").Parse(`module anna-custom
+
+go 1.25
+
+require (
+	{{.AnnaModule}} v0.0.0
+{{- range .Plugins}}
+	{{.Module}} v0.0.0
+{{- end}}
+)
+
+replace {{.AnnaModule}} => {{.AnnaLocalPath}}
+
+{{- range .Plugins}}
+replace {{.Module}} => {{.LocalPath}}
+{{- end}}
+`))


### PR DESCRIPTION
## Summary

**PR 2/3** of the plugin system (split from #56). Stacked on #57.

Adds Go plugin builder for compiling plugins into a custom anna binary:

- **`internal/plugin/goplugin/`** — Builder generates temp module with blank imports + replace directives, runs `go build` (Caddy-style approach)
- **`anna plugin build`** — CLI command to compile all configured Go plugins into a custom binary (`--output` flag, defaults to `./anna-custom`)
- Template rendering for main.go with plugin imports

### Usage

```bash
anna plugin build                    # builds ./anna-custom
anna plugin build --output ~/bin/anna  # custom output path
```

## Test plan

- [x] Unit tests for Go plugin builder (template rendering, module path reading, builder validation)
- [x] All tests pass with `-race -short`
- [x] Lint clean

## Stack

- PR 1/3 → `main`: [Plugin core + JS runtime](#57)
- **PR 2/3** (this) → PR 1: Go plugin builder
- PR 3/3 → this: [Docs & integration](feat/plugin-docs)