### PR TITLE
Embed rtk, fd, rg binaries and wrap bash with rtk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ coverage.html
 dist/
 handoff.md
 anna
+
+# Embedded tool binaries (downloaded via scripts/download-tools.sh)
+internal/embedded/binaries/*.gz

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,6 +3,7 @@ version: 2
 before:
   hooks:
     - go mod download
+    - bash scripts/download-tools.sh
 
 builds:
   - id: anna

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,7 +3,6 @@ version: 2
 before:
   hooks:
     - go mod download
-    - bash scripts/download-tools.sh
 
 builds:
   - id: anna
@@ -20,6 +19,9 @@ builds:
     goarch:
       - amd64
       - arm64
+    hooks:
+      pre:
+        - bash scripts/download-tools.sh --goos {{ .Os }} --goarch {{ .Arch }}
 
 archives:
   - id: anna

--- a/internal/agent/runner/template/system.md
+++ b/internal/agent/runner/template/system.md
@@ -14,6 +14,7 @@ You are Anna, a personal AI assistant.
 - `write`: Create a new file or fully overwrite an existing one
 - `edit`: Surgical string replacement in a file (old text must match exactly)
 - `bash`: Run shell commands — git, system tools, package managers, etc. Do NOT use bash to read/write files; use the dedicated tools above
+  - Built-in CLI tools available in bash: `fd` (fast file finder), `rg` (ripgrep, fast regex search). Prefer these over `find` and `grep`
 - `memory`: Manage persistent knowledge across sessions. See the Memories section below for file scope rules
 
 ### Conditionally available

--- a/internal/agent/tool/bash.go
+++ b/internal/agent/tool/bash.go
@@ -98,19 +98,23 @@ var rtkPath = sync.OnceValue(func() string {
 	return ""
 })
 
-// wrapWithRTK prefixes the command with "rtk" if rtk is available.
-// Skips wrapping for commands starting with env var assignments
-// (e.g. "FOO=bar go test") to preserve shell semantics.
+// wrapWithRTK uses "rtk rewrite" to determine how to wrap the command.
+// rtk rewrite handles env prefixes, pipes, and unsupported commands correctly.
+// Returns the original command unchanged if rtk is unavailable or the command
+// has no rtk equivalent.
 func wrapWithRTK(command string, _ []string) string {
-	if rtkPath() == "" {
+	rtk := rtkPath()
+	if rtk == "" {
 		return command
 	}
-	// Check if first token is an env var assignment (WORD=...).
-	first, _, _ := strings.Cut(strings.TrimSpace(command), " ")
-	if strings.Contains(first, "=") {
-		return command
+	out, err := exec.Command(rtk, "rewrite", command).Output()
+	if err != nil {
+		return command // unsupported command, use as-is
 	}
-	return rtkPath() + " " + command
+	if rewritten := strings.TrimSpace(string(out)); rewritten != "" {
+		return rewritten
+	}
+	return command
 }
 
 // envWithToolsBin returns the current environment with ANNA_HOME/bin prepended to PATH.

--- a/internal/agent/tool/bash.go
+++ b/internal/agent/tool/bash.go
@@ -44,7 +44,7 @@ func (t *BashTool) Execute(ctx context.Context, args map[string]any) (string, er
 	}
 
 	env := envWithToolsBin()
-	command = wrapWithRTK(command, env)
+	command = wrapWithRTK(command)
 
 	cmd := exec.CommandContext(ctx, "bash", "-c", command)
 	if t.workDir != "" {
@@ -102,7 +102,7 @@ var rtkPath = sync.OnceValue(func() string {
 // rtk rewrite handles env prefixes, pipes, and unsupported commands correctly.
 // Returns the original command unchanged if rtk is unavailable or the command
 // has no rtk equivalent.
-func wrapWithRTK(command string, _ []string) string {
+func wrapWithRTK(command string) string {
 	rtk := rtkPath()
 	if rtk == "" {
 		return command

--- a/internal/agent/tool/bash.go
+++ b/internal/agent/tool/bash.go
@@ -99,8 +99,15 @@ var rtkPath = sync.OnceValue(func() string {
 })
 
 // wrapWithRTK prefixes the command with "rtk" if rtk is available.
+// Skips wrapping for commands starting with env var assignments
+// (e.g. "FOO=bar go test") to preserve shell semantics.
 func wrapWithRTK(command string, _ []string) string {
 	if rtkPath() == "" {
+		return command
+	}
+	// Check if first token is an env var assignment (WORD=...).
+	first, _, _ := strings.Cut(strings.TrimSpace(command), " ")
+	if strings.Contains(first, "=") {
 		return command
 	}
 	return rtkPath() + " " + command

--- a/internal/agent/tool/bash.go
+++ b/internal/agent/tool/bash.go
@@ -4,9 +4,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
+	"strings"
+	"sync"
 	"time"
 
+	"github.com/vaayne/anna/internal/config"
+	"github.com/vaayne/anna/internal/embedded"
 	"github.com/vaayne/anna/internal/toolspec"
 )
 
@@ -38,10 +43,14 @@ func (t *BashTool) Execute(ctx context.Context, args map[string]any) (string, er
 		return "", fmt.Errorf("bash: command is required")
 	}
 
+	env := envWithToolsBin()
+	command = wrapWithRTK(command, env)
+
 	cmd := exec.CommandContext(ctx, "bash", "-c", command)
 	if t.workDir != "" {
 		cmd.Dir = t.workDir
 	}
+	cmd.Env = env
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -75,6 +84,39 @@ func (t *BashTool) Execute(ctx context.Context, args map[string]any) (string, er
 
 func formatMetadataFooter(exitCode int, elapsed time.Duration) string {
 	return fmt.Sprintf("\n[exit:%d | %s]", exitCode, formatDuration(elapsed))
+}
+
+// rtkPath caches the resolved rtk binary path (empty if not found).
+var rtkPath = sync.OnceValue(func() string {
+	// Check ANNA_HOME/bin first, then system PATH.
+	if p := embedded.ToolPath(config.AnnaHome(), "rtk"); p != "" {
+		return p
+	}
+	if p, err := exec.LookPath("rtk"); err == nil {
+		return p
+	}
+	return ""
+})
+
+// wrapWithRTK prefixes the command with "rtk" if rtk is available.
+func wrapWithRTK(command string, _ []string) string {
+	if rtkPath() == "" {
+		return command
+	}
+	return rtkPath() + " " + command
+}
+
+// envWithToolsBin returns the current environment with ANNA_HOME/bin prepended to PATH.
+func envWithToolsBin() []string {
+	binDir := embedded.BinDir(config.AnnaHome())
+	env := os.Environ()
+	for i, e := range env {
+		if strings.HasPrefix(e, "PATH=") {
+			env[i] = "PATH=" + binDir + string(os.PathListSeparator) + e[5:]
+			return env
+		}
+	}
+	return append(env, "PATH="+binDir)
 }
 
 func formatDuration(d time.Duration) string {

--- a/internal/agent/tool/bash_helpers_test.go
+++ b/internal/agent/tool/bash_helpers_test.go
@@ -1,0 +1,40 @@
+package tool
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestWrapWithRTK_NoRTK(t *testing.T) {
+	// Save and restore the cached rtkPath.
+	orig := rtkPath
+	rtkPath = func() string { return "" }
+	defer func() { rtkPath = orig }()
+
+	cmd := "git status"
+	if got := wrapWithRTK(cmd); got != cmd {
+		t.Errorf("wrapWithRTK(%q) = %q, want original when rtk absent", cmd, got)
+	}
+}
+
+func TestEnvWithToolsBin_PrependsPATH(t *testing.T) {
+	env := envWithToolsBin()
+
+	var pathEntry string
+	for _, e := range env {
+		if strings.HasPrefix(e, "PATH=") {
+			pathEntry = e
+			break
+		}
+	}
+	if pathEntry == "" {
+		t.Fatal("PATH not found in env")
+	}
+
+	// ANNA_HOME/bin should be the first entry.
+	parts := strings.SplitN(pathEntry[5:], string(os.PathListSeparator), 2)
+	if !strings.HasSuffix(parts[0], "bin") {
+		t.Errorf("first PATH entry should end with bin, got %q", parts[0])
+	}
+}

--- a/internal/agent/tool/tool.go
+++ b/internal/agent/tool/tool.go
@@ -3,7 +3,10 @@ package tool
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
+	"github.com/vaayne/anna/internal/config"
+	"github.com/vaayne/anna/internal/embedded"
 	"github.com/vaayne/anna/internal/toolspec"
 )
 
@@ -20,6 +23,9 @@ type Registry struct {
 
 // NewRegistry creates a registry with the default built-in tools.
 func NewRegistry(workDir string) *Registry {
+	if err := embedded.EnsureTools(config.AnnaHome()); err != nil {
+		slog.Warn("failed to extract embedded tools", "error", err)
+	}
 	r := &Registry{tools: make(map[string]Tool)}
 	r.Register(&ReadTool{})
 	r.Register(&BashTool{workDir: workDir})

--- a/internal/embedded/binaries/PLACEHOLDER
+++ b/internal/embedded/binaries/PLACEHOLDER
@@ -1,0 +1,1 @@
+placeholder

--- a/internal/embedded/embed.go
+++ b/internal/embedded/embed.go
@@ -1,0 +1,8 @@
+package embedded
+
+import "embed"
+
+//go:embed binaries/*
+var toolsFS embed.FS
+
+const toolsDir = "binaries"

--- a/internal/embedded/embedded.go
+++ b/internal/embedded/embedded.go
@@ -1,0 +1,108 @@
+package embedded
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+var ensureOnce sync.Once
+
+// EnsureTools extracts all embedded tool binaries to annaHome/bin/.
+// Gzip-compressed binaries in the embed FS are decompressed on extraction.
+// Already-extracted binaries are skipped. Safe for concurrent calls.
+func EnsureTools(annaHome string) error {
+	var err error
+	ensureOnce.Do(func() {
+		err = extractTools(BinDir(annaHome))
+	})
+	return err
+}
+
+// BinDir returns the tool binaries directory path.
+func BinDir(annaHome string) string {
+	return filepath.Join(annaHome, "bin")
+}
+
+// ToolPath returns the full path to a named tool binary, or empty if not embedded.
+func ToolPath(annaHome, name string) string {
+	p := filepath.Join(BinDir(annaHome), name)
+	if _, err := os.Stat(p); err == nil {
+		return p
+	}
+	return ""
+}
+
+// ToolNames returns the names of all embedded tools for the current platform.
+func ToolNames() []string {
+	entries, err := fs.ReadDir(toolsFS, toolsDir)
+	if err != nil {
+		return nil
+	}
+	var names []string
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".gz") {
+			names = append(names, strings.TrimSuffix(e.Name(), ".gz"))
+		}
+	}
+	return names
+}
+
+func extractTools(destDir string) error {
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return fmt.Errorf("create bin dir: %w", err)
+	}
+
+	entries, err := fs.ReadDir(toolsFS, toolsDir)
+	if err != nil {
+		return fmt.Errorf("read embedded tools: %w", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".gz") {
+			continue
+		}
+
+		name := strings.TrimSuffix(entry.Name(), ".gz")
+		destPath := filepath.Join(destDir, name)
+
+		if _, err := os.Stat(destPath); err == nil {
+			continue // already extracted
+		}
+
+		if err := extractGzip(toolsDir+"/"+entry.Name(), destPath); err != nil {
+			return fmt.Errorf("extract %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func extractGzip(srcPath, destPath string) error {
+	data, err := toolsFS.ReadFile(srcPath)
+	if err != nil {
+		return err
+	}
+
+	gr, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = gr.Close() }()
+
+	f, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		return err
+	}
+
+	if _, err = io.Copy(f, gr); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
+}

--- a/internal/embedded/embedded.go
+++ b/internal/embedded/embedded.go
@@ -119,7 +119,8 @@ func extractGzip(srcPath, destPath string) error {
 		return err
 	}
 
-	if _, err = io.Copy(f, gr); err != nil {
+	const maxBinarySize = 200 << 20 // 200 MB safety cap
+	if _, err = io.Copy(f, io.LimitReader(gr, maxBinarySize)); err != nil {
 		_ = f.Close()
 		return err
 	}

--- a/internal/embedded/embedded.go
+++ b/internal/embedded/embedded.go
@@ -59,6 +59,12 @@ func extractTools(destDir string) error {
 		return fmt.Errorf("create bin dir: %w", err)
 	}
 
+	fp := fingerprint()
+	fpFile := filepath.Join(destDir, ".embedded-version")
+	if old, err := os.ReadFile(fpFile); err == nil && string(old) == fp {
+		return nil // already up to date
+	}
+
 	entries, err := fs.ReadDir(toolsFS, toolsDir)
 	if err != nil {
 		return fmt.Errorf("read embedded tools: %w", err)
@@ -72,15 +78,28 @@ func extractTools(destDir string) error {
 		name := strings.TrimSuffix(entry.Name(), ".gz")
 		destPath := filepath.Join(destDir, name)
 
-		if _, err := os.Stat(destPath); err == nil {
-			continue // already extracted
-		}
-
 		if err := extractGzip(toolsDir+"/"+entry.Name(), destPath); err != nil {
 			return fmt.Errorf("extract %s: %w", name, err)
 		}
 	}
-	return nil
+
+	return os.WriteFile(fpFile, []byte(fp), 0o644)
+}
+
+// fingerprint returns a quick identifier based on embedded file names and sizes.
+// Changes when tool versions are bumped (different binary sizes).
+func fingerprint() string {
+	entries, err := fs.ReadDir(toolsFS, toolsDir)
+	if err != nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, e := range entries {
+		if info, err := e.Info(); err == nil {
+			fmt.Fprintf(&b, "%s:%d,", e.Name(), info.Size())
+		}
+	}
+	return b.String()
 }
 
 func extractGzip(srcPath, destPath string) error {

--- a/internal/embedded/embedded_test.go
+++ b/internal/embedded/embedded_test.go
@@ -1,0 +1,51 @@
+package embedded
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func TestExtractTools(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "bin")
+
+	names := ToolNames()
+	t.Logf("embedded tools: %v", names)
+	if len(names) == 0 {
+		t.Skip("no embedded tools (run scripts/download-tools.sh first)")
+	}
+
+	if err := extractTools(dest); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range names {
+		path := filepath.Join(dest, name)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Errorf("expected %s to exist: %v", name, err)
+			continue
+		}
+		if info.Size() == 0 {
+			t.Errorf("expected %s to be non-empty", name)
+		}
+		if info.Mode()&0o111 == 0 {
+			t.Errorf("expected %s to be executable", name)
+		}
+		t.Logf("  %s: %d bytes", name, info.Size())
+	}
+}
+
+func TestEnsureToolsIdempotent(t *testing.T) {
+	ensureOnce = sync.Once{}
+	dest := t.TempDir()
+
+	if err := EnsureTools(dest); err != nil {
+		t.Fatal(err)
+	}
+	// Second call should be a no-op (sync.Once)
+	if err := EnsureTools(dest); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/mise.toml
+++ b/mise.toml
@@ -97,6 +97,14 @@ description = "Validate Atlas migrations"
 run = "atlas migrate validate --env local"
 
 # ============================================================================
+# Embedded Tools Tasks
+# ============================================================================
+
+[tasks."tools:download"]
+description = "Download fd, rg, rtk for current platform (via mise)"
+run = "bash scripts/download-tools.sh"
+
+# ============================================================================
 # Release Tasks
 # ============================================================================
 

--- a/scripts/download-tools.sh
+++ b/scripts/download-tools.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# Download fd, rg, rtk for the current platform using mise.
+# Binaries are gzip-compressed into internal/embedded/binaries/ for go:embed.
+
+BINARIES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/internal/embedded/binaries"
+mkdir -p "$BINARIES_DIR"
+
+FD_VERSION="${FD_VERSION:-10.4.2}"
+RG_VERSION="${RG_VERSION:-15.1.0}"
+RTK_VERSION="${RTK_VERSION:-0.30.0}"
+
+download() {
+  local name="$1" spec="$2"
+  local dest="$BINARIES_DIR/${name}.gz"
+  if [[ -f "$dest" ]]; then echo "EXISTS $name"; return; fi
+
+  local tmp; tmp="$(mktemp -d)"
+  echo "DOWNLOAD $name ($spec)"
+  mise install-into "$spec" "$tmp"
+
+  local bin; bin="$(find "$tmp" -name "$name" -o -name "${name}.exe" | head -1)"
+  if [[ -z "$bin" ]]; then echo "WARN: $name not found"; rm -rf "$tmp"; return; fi
+
+  gzip -9 -c "$bin" > "$dest"
+  rm -rf "$tmp"
+  echo "OK $name ($(du -h "$dest" | cut -f1 | xargs))"
+}
+
+download fd  "github:sharkdp/fd@${FD_VERSION}"
+download rg  "github:BurntSushi/ripgrep@${RG_VERSION}"
+download rtk "github:rtk-ai/rtk@${RTK_VERSION}"
+
+echo "Done."

--- a/scripts/download-tools.sh
+++ b/scripts/download-tools.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-# Download fd, rg, rtk for the current platform using mise.
-# Binaries are gzip-compressed into internal/embedded/binaries/ for go:embed.
+# Download fd, rg, rtk binaries, gzip-compressed into internal/embedded/binaries/.
+#
+# Usage:
+#   ./scripts/download-tools.sh                                # current platform (dev)
+#   ./scripts/download-tools.sh --goos linux --goarch amd64    # cross-platform (release)
 
 BINARIES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/internal/embedded/binaries"
 mkdir -p "$BINARIES_DIR"
@@ -11,17 +14,33 @@ FD_VERSION="${FD_VERSION:-10.4.2}"
 RG_VERSION="${RG_VERSION:-15.1.0}"
 RTK_VERSION="${RTK_VERSION:-0.30.0}"
 
+GOOS="" GOARCH=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in --goos) GOOS="$2"; shift 2 ;; --goarch) GOARCH="$2"; shift 2 ;; *) echo "Unknown: $1"; exit 1 ;; esac
+done
+
+# Map Go os/arch to mise env vars
+mise_env=""
+if [[ -n "$GOOS" ]]; then
+  os="$GOOS"; [[ "$os" == "darwin" ]] && os="macos"
+  arch="$GOARCH"; [[ "$arch" == "amd64" ]] && arch="x86_64"; [[ "$arch" == "arm64" ]] && arch="aarch64"
+  mise_env="MISE_OS=$os MISE_ARCH=$arch"
+
+  # Clean previous platform's binaries (goreleaser calls per-target)
+  find "$BINARIES_DIR" -name '*.gz' -delete 2>/dev/null || true
+fi
+
 download() {
   local name="$1" spec="$2"
   local dest="$BINARIES_DIR/${name}.gz"
-  if [[ -f "$dest" ]]; then echo "EXISTS $name"; return; fi
+  [[ -f "$dest" ]] && echo "EXISTS $name" && return
 
   local tmp; tmp="$(mktemp -d)"
-  echo "DOWNLOAD $name ($spec)"
-  mise install-into "$spec" "$tmp"
+  echo "DOWNLOAD $name ($spec) ${mise_env}"
+  eval $mise_env mise install-into "$spec" "$tmp"
 
   local bin; bin="$(find "$tmp" -name "$name" -o -name "${name}.exe" | head -1)"
-  if [[ -z "$bin" ]]; then echo "WARN: $name not found"; rm -rf "$tmp"; return; fi
+  [[ -z "$bin" ]] && { echo "WARN: $name not found"; rm -rf "$tmp"; return; }
 
   gzip -9 -c "$bin" > "$dest"
   rm -rf "$tmp"


### PR DESCRIPTION
## Summary

- Embed fd, rg, rtk binaries (gzip-compressed) via `internal/embedded` package, extracted to `ANNA_HOME/bin/` on first use
- All bash tool commands automatically wrapped with `rtk` for 60-90% token reduction on command output
- `ANNA_HOME/bin` prepended to PATH so embedded tools are available to the LLM
- Download script uses `mise install-into` — no manual platform mapping needed
- Binary size impact: +6MB (~83MB total from 77MB base)

## How it works

1. `mise run tools:download` → downloads fd, rg, rtk for current platform via mise
2. Binaries are gzip-compressed into `internal/embedded/binaries/` and embedded via `//go:embed`
3. On first tool registry creation, binaries are extracted to `ANNA_HOME/bin/`
4. Bash tool checks for rtk (embedded or system PATH) and wraps commands as `rtk <command>`

## Test plan

- [x] `go build ./...` compiles clean
- [x] `golangci-lint run` — 0 issues
- [x] `go test -v -race ./internal/embedded/` — extraction + idempotency tests pass
- [ ] Manual: verify `rtk` wrapping reduces token output for common commands (git status, ls, etc.)
- [ ] CI: each platform runner runs `mise run tools:download` before build