### PR TITLE
🐛 fix: channel reliability — init errors, enabled flag, typed constants

### DIFF
--- a/cmd/anna/gateway.go
+++ b/cmd/anna/gateway.go
@@ -127,12 +127,12 @@ func runServer(ctx context.Context, s *setupResult, listFn channel.ModelListFunc
 			telegram.WithAuth(as, engine, linkCodes),
 		)
 		if err != nil {
-			return fmt.Errorf("create telegram bot: %w", err)
-		}
-
-		channels = append(channels, tgBot)
-		if tgCfg.EnableNotify {
-			s.notifier.Register(tgBot)
+			slog.Warn("telegram bot disabled", "error", err)
+		} else {
+			channels = append(channels, tgBot)
+			if tgCfg.EnableNotify {
+				s.notifier.Register(tgBot)
+			}
 		}
 	}
 
@@ -148,12 +148,12 @@ func runServer(ctx context.Context, s *setupResult, listFn channel.ModelListFunc
 			qq.WithAuth(as, engine, linkCodes),
 		)
 		if err != nil {
-			return fmt.Errorf("create qq bot: %w", err)
-		}
-
-		channels = append(channels, qqBot)
-		if qqCfg.EnableNotify {
-			s.notifier.Register(qqBot)
+			slog.Warn("qq bot disabled", "error", err)
+		} else {
+			channels = append(channels, qqBot)
+			if qqCfg.EnableNotify {
+				s.notifier.Register(qqBot)
+			}
 		}
 	}
 
@@ -172,12 +172,12 @@ func runServer(ctx context.Context, s *setupResult, listFn channel.ModelListFunc
 			feishu.WithAuth(as, engine, linkCodes),
 		)
 		if err != nil {
-			return fmt.Errorf("create feishu bot: %w", err)
-		}
-
-		channels = append(channels, fsBot)
-		if fsCfg.EnableNotify {
-			s.notifier.Register(fsBot)
+			slog.Warn("feishu bot disabled", "error", err)
+		} else {
+			channels = append(channels, fsBot)
+			if fsCfg.EnableNotify {
+				s.notifier.Register(fsBot)
+			}
 		}
 	}
 
@@ -194,12 +194,12 @@ func runServer(ctx context.Context, s *setupResult, listFn channel.ModelListFunc
 			weixin.WithAuth(as, engine, linkCodes),
 		)
 		if err != nil {
-			return fmt.Errorf("create weixin bot: %w", err)
-		}
-
-		channels = append(channels, wxBot)
-		if wxCfg.EnableNotify {
-			s.notifier.Register(wxBot)
+			slog.Warn("weixin bot disabled", "error", err)
+		} else {
+			channels = append(channels, wxBot)
+			if wxCfg.EnableNotify {
+				s.notifier.Register(wxBot)
+			}
 		}
 	}
 

--- a/cmd/anna/gateway.go
+++ b/cmd/anna/gateway.go
@@ -79,9 +79,12 @@ func runServer(ctx context.Context, s *setupResult, listFn channel.ModelListFunc
 	// Link codes are shared between admin panel and channel bots.
 	linkCodes := auth.NewLinkCodeStore()
 
+	// Admin server is always created so channel stop functions can be registered
+	// even when the panel is disabled.
+	adminSrv := admin.New(s.store, as, engine, s.mem, s.db, linkCodes)
+
 	// Start admin panel server.
 	if adminPort > 0 {
-		adminSrv := admin.New(s.store, as, engine, s.mem, s.db, linkCodes)
 		ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", adminPort))
 		if err != nil {
 			return fmt.Errorf("admin listen: %w", err)
@@ -130,6 +133,7 @@ func runServer(ctx context.Context, s *setupResult, listFn channel.ModelListFunc
 			slog.Warn("telegram bot disabled", "error", err)
 		} else {
 			channels = append(channels, tgBot)
+			adminSrv.RegisterChannelStop("telegram", tgBot.Stop)
 			if tgCfg.EnableNotify {
 				s.notifier.Register(tgBot)
 			}
@@ -151,6 +155,7 @@ func runServer(ctx context.Context, s *setupResult, listFn channel.ModelListFunc
 			slog.Warn("qq bot disabled", "error", err)
 		} else {
 			channels = append(channels, qqBot)
+			adminSrv.RegisterChannelStop("qq", qqBot.Stop)
 			if qqCfg.EnableNotify {
 				s.notifier.Register(qqBot)
 			}
@@ -175,6 +180,7 @@ func runServer(ctx context.Context, s *setupResult, listFn channel.ModelListFunc
 			slog.Warn("feishu bot disabled", "error", err)
 		} else {
 			channels = append(channels, fsBot)
+			adminSrv.RegisterChannelStop("feishu", fsBot.Stop)
 			if fsCfg.EnableNotify {
 				s.notifier.Register(fsBot)
 			}
@@ -197,6 +203,7 @@ func runServer(ctx context.Context, s *setupResult, listFn channel.ModelListFunc
 			slog.Warn("weixin bot disabled", "error", err)
 		} else {
 			channels = append(channels, wxBot)
+			adminSrv.RegisterChannelStop("weixin", wxBot.Stop)
 			if wxCfg.EnableNotify {
 				s.notifier.Register(wxBot)
 			}
@@ -363,10 +370,10 @@ type weixinChannelConfig struct {
 }
 
 // loadChannelConfig loads a channel's JSON config from the store and
-// deserializes it into the given type. Returns nil if not found.
+// deserializes it into the given type. Returns nil if not found or disabled.
 func loadChannelConfig[T any](store config.Store, channelID string) *T {
 	ch, err := store.GetChannel(context.Background(), channelID)
-	if err != nil {
+	if err != nil || !ch.Enabled {
 		return nil
 	}
 	var cfg T

--- a/cmd/anna/gateway.go
+++ b/cmd/anna/gateway.go
@@ -113,10 +113,10 @@ func runServer(ctx context.Context, s *setupResult, listFn channel.ModelListFunc
 	}
 
 	// Load channel configs from DB.
-	tgCfg := loadChannelConfig[telegramChannelConfig](s.store, "telegram")
-	qqCfg := loadChannelConfig[qqChannelConfig](s.store, "qq")
-	fsCfg := loadChannelConfig[feishuChannelConfig](s.store, "feishu")
-	wxCfg := loadChannelConfig[weixinChannelConfig](s.store, "weixin")
+	tgCfg := loadChannelConfig[telegramChannelConfig](s.store, channel.PlatformTelegram)
+	qqCfg := loadChannelConfig[qqChannelConfig](s.store, channel.PlatformQQ)
+	fsCfg := loadChannelConfig[feishuChannelConfig](s.store, channel.PlatformFeishu)
+	wxCfg := loadChannelConfig[weixinChannelConfig](s.store, channel.PlatformWeixin)
 
 	// --- Telegram ---
 	if tgCfg != nil && tgCfg.Token != "" {
@@ -133,7 +133,7 @@ func runServer(ctx context.Context, s *setupResult, listFn channel.ModelListFunc
 			slog.Warn("telegram bot disabled", "error", err)
 		} else {
 			channels = append(channels, tgBot)
-			adminSrv.RegisterChannelStop("telegram", tgBot.Stop)
+			adminSrv.RegisterChannelStop(channel.PlatformTelegram, tgBot.Stop)
 			if tgCfg.EnableNotify {
 				s.notifier.Register(tgBot)
 			}
@@ -155,7 +155,7 @@ func runServer(ctx context.Context, s *setupResult, listFn channel.ModelListFunc
 			slog.Warn("qq bot disabled", "error", err)
 		} else {
 			channels = append(channels, qqBot)
-			adminSrv.RegisterChannelStop("qq", qqBot.Stop)
+			adminSrv.RegisterChannelStop(channel.PlatformQQ, qqBot.Stop)
 			if qqCfg.EnableNotify {
 				s.notifier.Register(qqBot)
 			}
@@ -180,7 +180,7 @@ func runServer(ctx context.Context, s *setupResult, listFn channel.ModelListFunc
 			slog.Warn("feishu bot disabled", "error", err)
 		} else {
 			channels = append(channels, fsBot)
-			adminSrv.RegisterChannelStop("feishu", fsBot.Stop)
+			adminSrv.RegisterChannelStop(channel.PlatformFeishu, fsBot.Stop)
 			if fsCfg.EnableNotify {
 				s.notifier.Register(fsBot)
 			}
@@ -203,7 +203,7 @@ func runServer(ctx context.Context, s *setupResult, listFn channel.ModelListFunc
 			slog.Warn("weixin bot disabled", "error", err)
 		} else {
 			channels = append(channels, wxBot)
-			adminSrv.RegisterChannelStop("weixin", wxBot.Stop)
+			adminSrv.RegisterChannelStop(channel.PlatformWeixin, wxBot.Stop)
 			if wxCfg.EnableNotify {
 				s.notifier.Register(wxBot)
 			}

--- a/internal/admin/channels.go
+++ b/internal/admin/channels.go
@@ -37,5 +37,8 @@ func (s *Server) updateChannel(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	if !ch.Enabled {
+		s.stopChannel(platform)
+	}
 	writeData(w, http.StatusOK, ch)
 }

--- a/internal/admin/profile.go
+++ b/internal/admin/profile.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/vaayne/anna/internal/auth"
+	"github.com/vaayne/anna/internal/channel"
 )
 
 // listProfileIdentities handles GET /api/auth/profile/identities.
@@ -105,7 +106,7 @@ func (s *Server) generateLinkCode(w http.ResponseWriter, r *http.Request) {
 	}
 
 	switch body.Platform {
-	case "telegram", "qq", "feishu":
+	case channel.PlatformTelegram, channel.PlatformQQ, channel.PlatformFeishu:
 		// valid
 	default:
 		writeError(w, http.StatusBadRequest, "platform must be telegram, qq, or feishu")

--- a/internal/admin/server.go
+++ b/internal/admin/server.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"sync"
 
 	"github.com/vaayne/anna/internal/auth"
 	"github.com/vaayne/anna/internal/config"
@@ -26,6 +27,9 @@ type Server struct {
 	mux         *http.ServeMux
 	log         *slog.Logger
 	corsOriginV string // cached CORS origin
+
+	channelMu   sync.RWMutex
+	channelStop map[string]func() // platform → stop function for running channel
 }
 
 // New creates an admin server with all API routes mounted.
@@ -50,6 +54,7 @@ func New(store config.Store, authStore auth.AuthStore, engine *auth.PolicyEngine
 		mux:         http.NewServeMux(),
 		log:         slog.With("component", "admin"),
 		corsOriginV: corsOrigin,
+		channelStop: make(map[string]func()),
 	}
 
 	// Serve static assets (JS modules).
@@ -180,6 +185,28 @@ func (s *Server) redirectRoot(w http.ResponseWriter, r *http.Request) {
 // LinkCodes returns the link code store for use by channel handlers.
 func (s *Server) LinkCodes() *auth.LinkCodeStore {
 	return s.linkCodes
+}
+
+// RegisterChannelStop registers a stop function for a running channel so the
+// admin panel can stop it when it is disabled via the UI.
+func (s *Server) RegisterChannelStop(platform string, stop func()) {
+	s.channelMu.Lock()
+	s.channelStop[platform] = stop
+	s.channelMu.Unlock()
+}
+
+// stopChannel stops a running channel if one is registered for the platform.
+func (s *Server) stopChannel(platform string) {
+	s.channelMu.RLock()
+	stop, ok := s.channelStop[platform]
+	s.channelMu.RUnlock()
+	if ok {
+		s.log.Info("stopping channel", "platform", platform)
+		stop()
+		s.channelMu.Lock()
+		delete(s.channelStop, platform)
+		s.channelMu.Unlock()
+	}
 }
 
 // Handler returns the HTTP handler with CORS, JSON, and auth middleware applied.

--- a/internal/admin/ui/pages/channels.templ
+++ b/internal/admin/ui/pages/channels.templ
@@ -197,7 +197,7 @@ templ channelBlock(name string, platform string) {
 				<input
 					type="checkbox"
 					:checked={ "channelData." + platform + ".enabled" }
-					@change={ "channelData." + platform + ".enabled = $event.target.checked" }
+					@change={ "channelData." + platform + ".enabled = $event.target.checked; saveChannel('" + platform + "')" }
 					class="toggle toggle-primary toggle-sm"
 				/>
 				<span class="text-sm">Enable</span>

--- a/internal/admin/ui/pages/channels_templ.go
+++ b/internal/admin/ui/pages/channels_templ.go
@@ -516,9 +516,9 @@ func channelBlock(name string, platform string) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var22 string
-		templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs("channelData." + platform + ".enabled = $event.target.checked")
+		templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs("channelData." + platform + ".enabled = $event.target.checked; saveChannel('" + platform + "')")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/admin/ui/pages/channels.templ`, Line: 200, Col: 77}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/admin/ui/pages/channels.templ`, Line: 200, Col: 110}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 		if templ_7745c5c3_Err != nil {

--- a/internal/admin/weixin_qr.go
+++ b/internal/admin/weixin_qr.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/vaayne/anna/internal/auth"
+	"github.com/vaayne/anna/internal/channel"
 	"github.com/vaayne/anna/internal/channel/weixin"
 	"github.com/vaayne/anna/internal/config"
 )
@@ -66,11 +67,11 @@ func (s *Server) pollWeixinQRStatus(w http.ResponseWriter, r *http.Request) {
 			externalID = status.ILinkBotID
 		}
 		if externalID != "" && s.authStore != nil {
-			if _, err := s.authStore.GetIdentityByPlatform(r.Context(), "weixin", externalID); err != nil {
+			if _, err := s.authStore.GetIdentityByPlatform(r.Context(), channel.PlatformWeixin, externalID); err != nil {
 				// Identity doesn't exist yet — create it.
 				if _, err := s.authStore.CreateIdentity(r.Context(), auth.Identity{
 					UserID:     info.UserID,
-					Platform:   "weixin",
+					Platform:   channel.PlatformWeixin,
 					ExternalID: externalID,
 				}); err != nil {
 					s.log.Warn("create weixin identity", "user_id", info.UserID, "error", err)
@@ -86,10 +87,10 @@ func (s *Server) pollWeixinQRStatus(w http.ResponseWriter, r *http.Request) {
 // channel config in the DB.
 func (s *Server) saveWeixinCredentials(ctx context.Context, status *weixin.QRCodeStatusResponse) error {
 	var raw map[string]any
-	ch, err := s.store.GetChannel(ctx, "weixin")
+	ch, err := s.store.GetChannel(ctx, channel.PlatformWeixin)
 	if err != nil {
 		raw = make(map[string]any)
-		ch = config.Channel{ID: "weixin", Enabled: true}
+		ch = config.Channel{ID: channel.PlatformWeixin, Enabled: true}
 	} else {
 		if err := json.Unmarshal([]byte(ch.Config), &raw); err != nil {
 			raw = make(map[string]any)
@@ -107,7 +108,7 @@ func (s *Server) saveWeixinCredentials(ctx context.Context, status *weixin.QRCod
 	}
 
 	return s.store.UpsertChannel(ctx, config.Channel{
-		ID:      "weixin",
+		ID:      channel.PlatformWeixin,
 		Enabled: ch.Enabled,
 		Config:  string(data),
 	})

--- a/internal/channel/cli/chat.go
+++ b/internal/channel/cli/chat.go
@@ -119,7 +119,7 @@ func newChatModel(ctx context.Context, pool *agent.Pool, provider, model string,
 	return m
 }
 
-const cliChannel = "cli"
+const cliChannel = channel.PlatformCLI
 
 // resolveSession returns the most recently active CLI session ID,
 // or creates a new session if none exist.

--- a/internal/channel/feishu/feishu.go
+++ b/internal/channel/feishu/feishu.go
@@ -200,7 +200,7 @@ func (b *Bot) fetchBotOpenID(ctx context.Context) error {
 }
 
 // Name returns the backend name. Implements channel.Backend.
-func (b *Bot) Name() string { return "feishu" }
+func (b *Bot) Name() string { return channel.PlatformFeishu }
 
 // Notify sends a notification message. Implements channel.Backend.
 // Supports both chat IDs (oc_ prefix) and user open IDs (ou_ prefix).

--- a/internal/channel/feishu/handler.go
+++ b/internal/channel/feishu/handler.go
@@ -142,7 +142,7 @@ func (b *Bot) onMessage(ctx context.Context, event *larkim.P2MessageReceiveV1) e
 
 	// Try link code before anything else.
 	if b.authStore != nil && b.linkCodes != nil && text != "" {
-		if resp, ok := channel.TryLinkCode(b.ctx, b.authStore, b.linkCodes, text, "feishu", openID, ""); ok {
+		if resp, ok := channel.TryLinkCode(b.ctx, b.authStore, b.linkCodes, text, channel.PlatformFeishu, openID, ""); ok {
 			replyFn(resp)
 			return nil
 		}

--- a/internal/channel/feishu/thread.go
+++ b/internal/channel/feishu/thread.go
@@ -88,7 +88,7 @@ func (b *Bot) resolveWithThread(openID, chatID, chatType, rootID string) (*chann
 		b.store,
 		b.authStore,
 		b.engine,
-		"feishu",
+		channel.PlatformFeishu,
 		openID,
 		"",
 		chatID,

--- a/internal/channel/model.go
+++ b/internal/channel/model.go
@@ -2,6 +2,15 @@ package channel
 
 import "context"
 
+// Platform identifiers for each messaging channel.
+const (
+	PlatformTelegram = "telegram"
+	PlatformQQ       = "qq"
+	PlatformFeishu   = "feishu"
+	PlatformWeixin   = "weixin"
+	PlatformCLI      = "cli"
+)
+
 // Channel is a messaging platform that receives user messages and sends notifications.
 type Channel interface {
 	// Name returns a unique identifier (e.g. "telegram", "qq").

--- a/internal/channel/qq/handler.go
+++ b/internal/channel/qq/handler.go
@@ -24,7 +24,7 @@ func (b *Bot) c2cMessageHandler() event.C2CMessageEventHandler {
 		// Try link code before anything else.
 		text := strings.TrimSpace(msg.Content)
 		if b.authStore != nil && b.linkCodes != nil && text != "" {
-			if resp, ok := channel.TryLinkCode(b.ctx, b.authStore, b.linkCodes, text, "qq", authorID, ""); ok {
+			if resp, ok := channel.TryLinkCode(b.ctx, b.authStore, b.linkCodes, text, channel.PlatformQQ, authorID, ""); ok {
 				b.replyC2C(b.ctx, authorID, msg.ID, resp)
 				return nil
 			}

--- a/internal/channel/qq/qq.go
+++ b/internal/channel/qq/qq.go
@@ -151,7 +151,7 @@ func (b *Bot) Stop() {
 }
 
 // Name returns the channel name. Implements channel.Channel.
-func (b *Bot) Name() string { return "qq" }
+func (b *Bot) Name() string { return channel.PlatformQQ }
 
 // Notify sends a notification message. Implements channel.Channel.
 func (b *Bot) Notify(ctx context.Context, n channel.Notification) error {
@@ -201,7 +201,7 @@ func (b *Bot) resolve(authorID, groupID string) (*channel.ResolvedChat, error) {
 		b.store,
 		b.authStore,
 		b.engine,
-		"qq",
+		channel.PlatformQQ,
 		authorID,
 		"",
 		groupID,

--- a/internal/channel/telegram/handler.go
+++ b/internal/channel/telegram/handler.go
@@ -209,7 +209,7 @@ func (b *Bot) handleText(c tele.Context) error {
 			if name == "" {
 				name = sender.Username
 			}
-			if resp, ok := channel.TryLinkCode(b.ctx, b.authStore, b.linkCodes, text, "telegram", strconv.FormatInt(sender.ID, 10), name); ok {
+			if resp, ok := channel.TryLinkCode(b.ctx, b.authStore, b.linkCodes, text, channel.PlatformTelegram, strconv.FormatInt(sender.ID, 10), name); ok {
 				return c.Send(resp)
 			}
 		}

--- a/internal/channel/telegram/telegram.go
+++ b/internal/channel/telegram/telegram.go
@@ -131,7 +131,7 @@ func (b *Bot) Stop() {
 }
 
 // Name returns the channel name. Implements channel.Channel.
-func (b *Bot) Name() string { return "telegram" }
+func (b *Bot) Name() string { return channel.PlatformTelegram }
 
 // Notify sends a message to the specified chat. Implements channel.Channel.
 func (b *Bot) Notify(_ context.Context, n channel.Notification) error {
@@ -255,7 +255,7 @@ func (b *Bot) resolve(c tele.Context) (*channel.ResolvedChat, error) {
 		b.store,
 		b.authStore,
 		b.engine,
-		"telegram",
+		channel.PlatformTelegram,
 		senderID,
 		name,
 		chatID,

--- a/internal/channel/weixin/handler.go
+++ b/internal/channel/weixin/handler.go
@@ -84,7 +84,7 @@ func (b *Bot) handleText(msg WeixinMessage, text string) {
 
 	// Try link code before anything else.
 	if b.authStore != nil && b.linkCodes != nil {
-		if resp, ok := channel.TryLinkCode(b.ctx, b.authStore, b.linkCodes, text, "weixin", msg.FromUserID, ""); ok {
+		if resp, ok := channel.TryLinkCode(b.ctx, b.authStore, b.linkCodes, text, channel.PlatformWeixin, msg.FromUserID, ""); ok {
 			reply(resp)
 			return
 		}

--- a/internal/channel/weixin/weixin.go
+++ b/internal/channel/weixin/weixin.go
@@ -87,7 +87,7 @@ func New(cfg Config, pm *agent.PoolManager, store config.Store, listFn channel.M
 }
 
 // Name returns the channel name. Implements channel.Channel.
-func (b *Bot) Name() string { return "weixin" }
+func (b *Bot) Name() string { return channel.PlatformWeixin }
 
 // Stop gracefully shuts down the WeChat bot. Implements channel.Channel.
 func (b *Bot) Stop() {
@@ -218,7 +218,7 @@ func (b *Bot) resolve(userID string) (*channel.ResolvedChat, error) {
 		b.store,
 		b.authStore,
 		b.engine,
-		"weixin",
+		channel.PlatformWeixin,
 		userID,
 		"",     // no display name available from iLink
 		userID, // chatID = userID for DM
@@ -228,7 +228,7 @@ func (b *Bot) resolve(userID string) (*channel.ResolvedChat, error) {
 
 // loadCursor loads the get_updates_buf cursor from the DB channel config.
 func (b *Bot) loadCursor() string {
-	ch, err := b.store.GetChannel(context.Background(), "weixin")
+	ch, err := b.store.GetChannel(context.Background(), channel.PlatformWeixin)
 	if err != nil {
 		return ""
 	}
@@ -241,7 +241,7 @@ func (b *Bot) loadCursor() string {
 
 // persistCursor saves the get_updates_buf cursor to the DB channel config.
 func (b *Bot) persistCursor(buf string) {
-	ch, err := b.store.GetChannel(context.Background(), "weixin")
+	ch, err := b.store.GetChannel(context.Background(), channel.PlatformWeixin)
 	if err != nil {
 		logger().Warn("failed to load channel config for cursor persist", "error", err)
 		return
@@ -261,7 +261,7 @@ func (b *Bot) persistCursor(buf string) {
 	}
 
 	if err := b.store.UpsertChannel(context.Background(), config.Channel{
-		ID:      "weixin",
+		ID:      channel.PlatformWeixin,
 		Enabled: ch.Enabled,
 		Config:  string(data),
 	}); err != nil {
@@ -276,7 +276,7 @@ func (b *Bot) clearCredentials() {
 	b.typingTickets = sync.Map{}
 
 	// Clear credentials from DB.
-	ch, err := b.store.GetChannel(context.Background(), "weixin")
+	ch, err := b.store.GetChannel(context.Background(), channel.PlatformWeixin)
 	if err != nil {
 		logger().Warn("failed to load channel config for credential clear", "error", err)
 		return
@@ -299,7 +299,7 @@ func (b *Bot) clearCredentials() {
 	}
 
 	if err := b.store.UpsertChannel(context.Background(), config.Channel{
-		ID:      "weixin",
+		ID:      channel.PlatformWeixin,
 		Enabled: ch.Enabled,
 		Config:  string(data),
 	}); err != nil {


### PR DESCRIPTION
## Summary

- Degrade channel init errors to warnings so a bad token (e.g. Telegram 404) no longer kills the whole server — other channels and the admin panel start normally
- Auto-save channel enabled state when toggling the Enable switch (Save button was hidden inside `x-show="enabled"`, so disabling a channel couldn't be persisted)
- Make the channel `enabled` flag actually stop running channels — `loadChannelConfig` now returns nil for disabled channels; `admin.Server` holds a stop-function registry and calls `Stop()` when a channel is disabled via the UI
- Replace channel name string literals (`"telegram"`, `"qq"`, `"feishu"`, `"weixin"`, `"cli"`) with `Platform*` typed constants across channel packages, admin handlers, and gateway

## Test plan

- [x] Start server with an invalid Telegram token — other channels should still start
- [x] Disable a channel in the admin panel — verify it stops immediately and stays disabled on restart
- [x] Enable a channel — verify it starts correctly