### PR TITLE
♻️ refactor: extract pkg/channel and make channel plugins thin adapters

### DIFF
--- a/cmd/anna/channels.go
+++ b/cmd/anna/channels.go
@@ -3,10 +3,9 @@ package main
 import (
 	"fmt"
 
-	"github.com/vaayne/anna/internal/agent"
-	"github.com/vaayne/anna/internal/auth"
 	"github.com/vaayne/anna/internal/channel"
 	"github.com/vaayne/anna/internal/config"
+	pkgchannel "github.com/vaayne/anna/pkg/channel"
 	"github.com/vaayne/anna/plugins/channels/feishu"
 	"github.com/vaayne/anna/plugins/channels/qq"
 	"github.com/vaayne/anna/plugins/channels/telegram"
@@ -15,14 +14,9 @@ import (
 
 func buildChannel(
 	name string,
+	handler pkgchannel.MessageHandler,
 	store config.Store,
-	poolManager *agent.PoolManager,
-	authStore auth.AuthStore,
-	engine *auth.PolicyEngine,
-	linkCodes *auth.LinkCodeStore,
-	listFn channel.ModelListFunc,
-	switchFn channel.ModelSwitchFunc,
-) (channel.Channel, error) {
+) (pkgchannel.Channel, error) {
 	switch name {
 	case "telegram":
 		cfg := channel.LoadConfig[channel.TelegramConfig](store, name)
@@ -33,9 +27,7 @@ func buildChannel(
 			Token:     cfg.Token,
 			ChannelID: cfg.ChannelID,
 			GroupMode: cfg.GroupMode,
-		}, poolManager, store, listFn, switchFn,
-			telegram.WithAuth(authStore, engine, linkCodes),
-		)
+		}, handler)
 
 	case "qq":
 		cfg := channel.LoadConfig[channel.QQConfig](store, name)
@@ -46,9 +38,7 @@ func buildChannel(
 			AppID:     cfg.AppID,
 			AppSecret: cfg.AppSecret,
 			GroupMode: cfg.GroupMode,
-		}, poolManager, store, listFn, switchFn,
-			qq.WithAuth(authStore, engine, linkCodes),
-		)
+		}, handler)
 
 	case "feishu":
 		cfg := channel.LoadConfig[channel.FeishuConfig](store, name)
@@ -71,9 +61,7 @@ func buildChannel(
 			VerificationToken: cfg.VerificationToken,
 			GroupMode:         cfg.GroupMode,
 			Groups:            groups,
-		}, poolManager, store, listFn, switchFn,
-			feishu.WithAuth(authStore, engine, linkCodes),
-		)
+		}, handler)
 
 	case "weixin":
 		cfg := channel.LoadConfig[channel.WeixinConfig](store, name)
@@ -85,9 +73,7 @@ func buildChannel(
 			BaseURL:  cfg.BaseURL,
 			BotID:    cfg.BotID,
 			UserID:   cfg.UserID,
-		}, poolManager, store, listFn, switchFn,
-			weixin.WithAuth(authStore, engine, linkCodes),
-		)
+		}, handler)
 
 	default:
 		return nil, fmt.Errorf("unknown channel: %s", name)

--- a/cmd/anna/channels.go
+++ b/cmd/anna/channels.go
@@ -14,7 +14,7 @@ import (
 
 func buildChannel(
 	name string,
-	handler pkgchannel.MessageHandler,
+	handler pkgchannel.Handler,
 	store config.Store,
 ) (pkgchannel.Channel, error) {
 	switch name {

--- a/cmd/anna/commands.go
+++ b/cmd/anna/commands.go
@@ -227,7 +227,7 @@ func setup(parent context.Context, gateway bool) (*setupResult, error) {
 
 // modelSwitcher returns a function that switches the pool's runner factory
 // to use a different provider/model combination.
-func modelSwitcher(snap *config.Snapshot, store config.Store, pool *agent.Pool, extraTools []tools.Tool) channel.ModelSwitchFunc {
+func modelSwitcher(snap *config.Snapshot, store config.Store, pool *agent.Pool, extraTools []tools.Tool) func(string, string) error {
 	return func(provider, model string) error {
 		snap.Provider = provider
 		snap.Model = model

--- a/cmd/anna/gateway.go
+++ b/cmd/anna/gateway.go
@@ -118,6 +118,21 @@ func runServer(ctx context.Context, s *setupResult, listFn func() []pkgchannel.M
 		})
 	}
 
+	// Configure channel hot-reload so the admin UI can start/stop channels.
+	adminSrv.SetChannelLifecycle(gctx,
+		func(name string) (pkgchannel.Channel, error) {
+			if !channel.HasValidConfig(s.store, name) {
+				return nil, fmt.Errorf("%s: missing or invalid config", name)
+			}
+			return buildChannel(name, coordinator, s.store)
+		},
+		func(name string, ch pkgchannel.Channel) {
+			if channel.IsNotifyEnabled(s.store, name) {
+				s.notifier.Register(ch)
+			}
+		},
+	)
+
 	// Load enabled channel plugins from settings_plugins.
 	channelNames := []string{"telegram", "qq", "feishu", "weixin"}
 	for _, name := range channelNames {

--- a/cmd/anna/gateway.go
+++ b/cmd/anna/gateway.go
@@ -131,6 +131,9 @@ func runServer(ctx context.Context, s *setupResult, listFn func() []pkgchannel.M
 				s.notifier.Register(ch)
 			}
 		},
+		func(name string) {
+			s.notifier.Unregister(name)
+		},
 	)
 
 	// Load enabled channel plugins from settings_plugins.

--- a/cmd/anna/gateway.go
+++ b/cmd/anna/gateway.go
@@ -22,6 +22,7 @@ import (
 	"github.com/vaayne/anna/internal/config"
 	appdb "github.com/vaayne/anna/internal/db"
 	"github.com/vaayne/anna/internal/scheduler"
+	pkgchannel "github.com/vaayne/anna/pkg/channel"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -51,16 +52,16 @@ func serverAction(c *ucli.Context) error {
 		return err
 	}
 	defer func() { _ = s.poolManager.Close() }()
-	listFn := func() []channel.ModelOption {
+	listFn := func() []pkgchannel.ModelOption {
 		return collectModelsFromStore(ctx, s.store, s.snap)
 	}
 	switchFn := modelSwitcher(s.snap, s.store, s.pool, s.extraTools)
 	return runServer(s.ctx, s, listFn, switchFn, c.Int("admin-port"), c.Bool("open"))
 }
 
-func runServer(ctx context.Context, s *setupResult, listFn channel.ModelListFunc, switchFn channel.ModelSwitchFunc, adminPort int, openBrowser bool) error {
+func runServer(ctx context.Context, s *setupResult, listFn func() []pkgchannel.ModelOption, switchFn func(string, string) error, adminPort int, openBrowser bool) error {
 	g, gctx := errgroup.WithContext(ctx)
-	var channels []channel.Channel
+	var channels []pkgchannel.Channel
 
 	// Create auth store and policy engine for channel bots and admin panel.
 	as := appdb.NewAuthStore(s.db)
@@ -78,6 +79,15 @@ func runServer(ctx context.Context, s *setupResult, listFn channel.ModelListFunc
 	// Admin server is always created so channel stop functions can be registered
 	// even when the panel is disabled.
 	adminSrv := admin.New(s.store, as, engine, s.mem, s.db, linkCodes, s.poolManager)
+
+	// Create the coordinator that implements MessageHandler for all channels.
+	coordinator := channel.NewCoordinator(
+		s.poolManager,
+		s.store,
+		listFn,
+		switchFn,
+		channel.WithCoordinatorAuth(as, engine, linkCodes),
+	)
 
 	// Start admin panel server.
 	if adminPort > 0 {
@@ -120,7 +130,7 @@ func runServer(ctx context.Context, s *setupResult, listFn channel.ModelListFunc
 			slog.Debug("skipping channel without valid config", "channel", name)
 			continue
 		}
-		ch, err := buildChannel(name, s.store, s.poolManager, as, engine, linkCodes, listFn, switchFn)
+		ch, err := buildChannel(name, coordinator, s.store)
 		if err != nil {
 			return err
 		}

--- a/internal/admin/channels.go
+++ b/internal/admin/channels.go
@@ -82,7 +82,9 @@ func (s *Server) updateChannel(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	if !req.Enabled {
+	if req.Enabled {
+		s.startChannel(platform)
+	} else {
 		s.stopChannel(platform)
 	}
 	writeData(w, http.StatusOK, pluginToChannelView(p))

--- a/internal/admin/plugins.go
+++ b/internal/admin/plugins.go
@@ -34,9 +34,13 @@ func (s *Server) togglePlugin(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	// If disabling a channel plugin, stop it.
-	if p.Kind == config.PluginKindChannel && !req.Enabled {
-		s.stopChannel(p.Name)
+	// Hot-reload channel plugins: start on enable, stop on disable.
+	if p.Kind == config.PluginKindChannel {
+		if req.Enabled {
+			s.startChannel(p.Name)
+		} else {
+			s.stopChannel(p.Name)
+		}
 	}
 	// Hot-reload tool plugins so the change takes effect without restart.
 	if p.Kind == config.PluginKindTool && s.poolManager != nil {

--- a/internal/admin/server.go
+++ b/internal/admin/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vaayne/anna/internal/config"
 	"github.com/vaayne/anna/internal/db/sqlc"
 	"github.com/vaayne/anna/internal/memory"
+	pkgchannel "github.com/vaayne/anna/pkg/channel"
 )
 
 // Server provides HTTP handlers for the admin API and templ-rendered pages.
@@ -30,8 +31,11 @@ type Server struct {
 	log         *slog.Logger
 	corsOriginV string // cached CORS origin
 
-	channelMu   sync.RWMutex
-	channelStop map[string]func() // platform → stop function for running channel
+	channelMu      sync.RWMutex
+	channelStop    map[string]func()                             // platform → stop function for running channel
+	channelBuilder func(name string) (pkgchannel.Channel, error) // builds a channel by platform name
+	channelNotify  func(name string, ch pkgchannel.Channel)      // registers channel for notifications
+	channelCtx     context.Context                               // parent context for started channels
 }
 
 // New creates an admin server with all API routes mounted.
@@ -202,6 +206,53 @@ func (s *Server) RegisterChannelStop(platform string, stop func()) {
 	s.channelMu.Lock()
 	s.channelStop[platform] = stop
 	s.channelMu.Unlock()
+}
+
+// SetChannelLifecycle configures the admin server to start/stop channels dynamically.
+// builder creates a channel by platform name; notify registers it for notifications.
+func (s *Server) SetChannelLifecycle(
+	ctx context.Context,
+	builder func(name string) (pkgchannel.Channel, error),
+	notify func(name string, ch pkgchannel.Channel),
+) {
+	s.channelMu.Lock()
+	s.channelBuilder = builder
+	s.channelNotify = notify
+	s.channelCtx = ctx
+	s.channelMu.Unlock()
+}
+
+// startChannel builds, starts, and registers a channel for the given platform.
+// No-op if the channel is already running or no builder is configured.
+func (s *Server) startChannel(platform string) {
+	s.channelMu.RLock()
+	_, running := s.channelStop[platform]
+	builder := s.channelBuilder
+	notify := s.channelNotify
+	ctx := s.channelCtx
+	s.channelMu.RUnlock()
+
+	if running || builder == nil {
+		return
+	}
+
+	ch, err := builder(platform)
+	if err != nil {
+		s.log.Error("failed to build channel", "platform", platform, "error", err)
+		return
+	}
+
+	s.RegisterChannelStop(platform, ch.Stop)
+	if notify != nil {
+		notify(platform, ch)
+	}
+
+	s.log.Info("starting channel", "platform", platform)
+	go func() {
+		if err := ch.Start(ctx); err != nil && ctx.Err() == nil {
+			s.log.Error("channel stopped with error", "platform", platform, "error", err)
+		}
+	}()
 }
 
 // stopChannel stops a running channel if one is registered for the platform.

--- a/internal/admin/server.go
+++ b/internal/admin/server.go
@@ -31,11 +31,12 @@ type Server struct {
 	log         *slog.Logger
 	corsOriginV string // cached CORS origin
 
-	channelMu      sync.RWMutex
-	channelStop    map[string]func()                             // platform → stop function for running channel
-	channelBuilder func(name string) (pkgchannel.Channel, error) // builds a channel by platform name
-	channelNotify  func(name string, ch pkgchannel.Channel)      // registers channel for notifications
-	channelCtx     context.Context                               // parent context for started channels
+	channelMu       sync.RWMutex
+	channelStop     map[string]func()                             // platform → stop function for running channel
+	channelBuilder  func(name string) (pkgchannel.Channel, error) // builds a channel by platform name
+	channelNotify   func(name string, ch pkgchannel.Channel)      // registers channel for notifications
+	channelUnnotify func(name string)                             // unregisters channel from notifications
+	channelCtx      context.Context                               // parent context for started channels
 }
 
 // New creates an admin server with all API routes mounted.
@@ -209,15 +210,18 @@ func (s *Server) RegisterChannelStop(platform string, stop func()) {
 }
 
 // SetChannelLifecycle configures the admin server to start/stop channels dynamically.
-// builder creates a channel by platform name; notify registers it for notifications.
+// builder creates a channel by platform name; notify registers it for notifications;
+// unnotify removes it from the notification dispatcher on stop.
 func (s *Server) SetChannelLifecycle(
 	ctx context.Context,
 	builder func(name string) (pkgchannel.Channel, error),
 	notify func(name string, ch pkgchannel.Channel),
+	unnotify func(name string),
 ) {
 	s.channelMu.Lock()
 	s.channelBuilder = builder
 	s.channelNotify = notify
+	s.channelUnnotify = unnotify
 	s.channelCtx = ctx
 	s.channelMu.Unlock()
 }
@@ -259,10 +263,14 @@ func (s *Server) startChannel(platform string) {
 func (s *Server) stopChannel(platform string) {
 	s.channelMu.RLock()
 	stop, ok := s.channelStop[platform]
+	unnotify := s.channelUnnotify
 	s.channelMu.RUnlock()
 	if ok {
 		s.log.Info("stopping channel", "platform", platform)
 		stop()
+		if unnotify != nil {
+			unnotify(platform)
+		}
 		s.channelMu.Lock()
 		delete(s.channelStop, platform)
 		s.channelMu.Unlock()

--- a/internal/channel/agent_command.go
+++ b/internal/channel/agent_command.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/vaayne/anna/internal/auth"
 	"github.com/vaayne/anna/internal/config"
+	pkgchannel "github.com/vaayne/anna/pkg/channel"
 )
 
 // AgentCommander handles the /agent slash command for listing and switching agents.
@@ -55,7 +56,12 @@ func (ac *AgentCommander) Switch(ctx context.Context, user auth.AuthUser, chat C
 	return ac.authStore.UpdateUserDefaultAgent(ctx, user.ID, ag.ID)
 }
 
+// Re-exported utility from pkg/channel.
+var ParseCommandArgs = pkgchannel.ParseCommandArgs
+
 // IndexedAgent pairs a config.Agent with its 1-based global index.
+// This wraps config.Agent (not pkgchannel.AgentInfo) for backward compat
+// with internal callers that need the full Agent struct.
 type IndexedAgent struct {
 	config.Agent
 	GlobalIdx int
@@ -90,12 +96,6 @@ func HandleAgentCommand(ctx context.Context, ac *AgentCommander, rc *ResolvedCha
 		return
 	}
 	reply(FormatAgentList(agents, rc.AgentID))
-}
-
-// ParseCommandArgs extracts arguments after the command token.
-// Example: ParseCommandArgs("/agent foo", "/agent") returns "foo".
-func ParseCommandArgs(text, cmd string) string {
-	return strings.TrimSpace(strings.TrimPrefix(text, cmd))
 }
 
 // FormatAgentList formats the agent list for display, marking the current agent.

--- a/internal/channel/command.go
+++ b/internal/channel/command.go
@@ -4,17 +4,21 @@ import (
 	"context"
 	"fmt"
 	"strings"
+
+	pkgchannel "github.com/vaayne/anna/pkg/channel"
 )
 
-// WelcomeMessage is the shared welcome/help text for all channels.
-const WelcomeMessage = "Hi! I'm Anna -- your local AI assistant.\n\n" +
-	"Commands:\n" +
-	"/new -- Start a fresh session\n" +
-	"/compact -- Compress conversation history\n" +
-	"/model -- Switch between models\n" +
-	"/agent -- List or switch agents\n" +
-	"/whoami -- Show your user ID\n\n" +
-	"Just send me a message to get started."
+// Re-export from pkg/channel for internal callers.
+const WelcomeMessage = pkgchannel.WelcomeMessage
+
+// Re-exported types and functions from pkg/channel.
+type IndexedModel = pkgchannel.IndexedModel
+
+var (
+	ParseModelArgs = pkgchannel.ParseModelArgs
+	IndexModels    = pkgchannel.IndexModels
+	FilterModels   = pkgchannel.FilterModels
+)
 
 // HandleCommand processes common bot commands shared across all channels.
 // Returns the response text and whether the command was handled.
@@ -50,39 +54,4 @@ func HandleCommand(ctx context.Context, rc *ResolvedChat, text, senderID string)
 	}
 
 	return "", false
-}
-
-// IndexedModel pairs a ModelOption with its 1-based global index.
-type IndexedModel struct {
-	ModelOption
-	GlobalIdx int
-}
-
-// ParseModelArgs parses /model arguments as a query string.
-// Returns empty string when no arguments are provided.
-func ParseModelArgs(args string) string {
-	return strings.TrimSpace(args)
-}
-
-// IndexModels wraps a full model list with sequential 1-based indices.
-func IndexModels(models []ModelOption) []IndexedModel {
-	out := make([]IndexedModel, len(models))
-	for i, m := range models {
-		out[i] = IndexedModel{ModelOption: m, GlobalIdx: i + 1}
-	}
-	return out
-}
-
-// FilterModels returns indexed models matching the query, preserving
-// their 1-based global indices from the full list.
-func FilterModels(models []ModelOption, query string) []IndexedModel {
-	query = strings.ToLower(query)
-	var out []IndexedModel
-	for i, m := range models {
-		label := strings.ToLower(m.Provider + "/" + m.Model)
-		if strings.Contains(label, query) {
-			out = append(out, IndexedModel{ModelOption: m, GlobalIdx: i + 1})
-		}
-	}
-	return out
 }

--- a/internal/channel/coordinator.go
+++ b/internal/channel/coordinator.go
@@ -3,7 +3,6 @@ package channel
 import (
 	"context"
 	"fmt"
-	"log/slog"
 
 	"github.com/vaayne/anna/internal/agent"
 	"github.com/vaayne/anna/internal/agent/runner"
@@ -62,31 +61,48 @@ func (c *Coordinator) resolve(ctx context.Context, msg pkgchannel.IncomingMessag
 	return Resolve(ctx, c.poolManager, c.store, c.authStore, c.engine, msg.Platform, msg.SenderID, msg.SenderName, msg.ChatID, msg.IsGroup)
 }
 
+// HandleIncoming resolves the user once, tries command handling, and if the
+// command is not handled, streams a chat response. This avoids double
+// resolution when a plugin needs to try commands before messaging.
+func (c *Coordinator) HandleIncoming(ctx context.Context, msg pkgchannel.IncomingMessage, command, args string) (string, bool, *pkgchannel.ChatStream, error) {
+	// Try link code first (before auth resolution, since it creates identity).
+	if c.authStore != nil && c.linkCodes != nil {
+		fullText := command
+		if args != "" {
+			fullText = command + " " + args
+		}
+		if resp, ok := TryLinkCode(ctx, c.authStore, c.linkCodes, fullText, msg.Platform, msg.SenderID, msg.SenderName); ok {
+			return resp, true, nil, nil
+		}
+	}
+
+	rc, err := c.resolve(ctx, msg)
+	if err != nil {
+		return "", false, nil, err
+	}
+
+	// Try shared commands.
+	if command != "" {
+		if resp, ok := HandleCommand(ctx, rc, command+" "+args, msg.SenderID); ok {
+			return resp, true, nil, nil
+		}
+	}
+
+	// Not a command — stream a chat response.
+	stream, err := c.chatWithRC(ctx, rc, msg.Content)
+	if err != nil {
+		return "", false, nil, err
+	}
+	return "", false, stream, nil
+}
+
 // HandleMessage resolves the user, routes to an agent, and streams a response.
 func (c *Coordinator) HandleMessage(ctx context.Context, msg pkgchannel.IncomingMessage) (*pkgchannel.ChatStream, error) {
 	rc, err := c.resolve(ctx, msg)
 	if err != nil {
 		return nil, err
 	}
-
-	events, sessionID, err := rc.Chat(ctx, msg.Content)
-	if err != nil {
-		return nil, err
-	}
-
-	// Convert internal runner.Event to pkg/channel.Event.
-	out := make(chan pkgchannel.Event, 100)
-	go func() {
-		defer close(out)
-		for evt := range events {
-			out <- convertEvent(evt)
-		}
-	}()
-
-	return &pkgchannel.ChatStream{
-		Events:    out,
-		SessionID: sessionID,
-	}, nil
+	return c.chatWithRC(ctx, rc, msg.Content)
 }
 
 // HandleCommand processes shared commands (/start, /new, /compact, /whoami, /link).
@@ -108,6 +124,27 @@ func (c *Coordinator) HandleCommand(ctx context.Context, msg pkgchannel.Incoming
 	}
 
 	return HandleCommand(ctx, rc, command+" "+args, msg.SenderID)
+}
+
+// chatWithRC streams a chat response using a pre-resolved chat.
+func (c *Coordinator) chatWithRC(ctx context.Context, rc *ResolvedChat, content any) (*pkgchannel.ChatStream, error) {
+	events, sessionID, err := rc.Chat(ctx, content)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(chan pkgchannel.Event, 100)
+	go func() {
+		defer close(out)
+		for evt := range events {
+			out <- convertEvent(evt)
+		}
+	}()
+
+	return &pkgchannel.ChatStream{
+		Events:    out,
+		SessionID: sessionID,
+	}, nil
 }
 
 // ListAgents returns enabled agents the user can access and the current agent ID.
@@ -151,7 +188,6 @@ func (c *Coordinator) SwitchModel(provider, model string) error {
 	return c.switchFn(provider, model)
 }
 
-// convertEvent converts an internal runner.Event to a pkg/channel.Event.
 func convertEvent(evt runner.Event) pkgchannel.Event {
 	out := pkgchannel.Event{
 		Text: evt.Text,
@@ -176,8 +212,3 @@ func convertEvent(evt runner.Event) pkgchannel.Event {
 
 // compile-time check.
 var _ pkgchannel.MessageHandler = (*Coordinator)(nil)
-
-func init() {
-	// Verify the logger is callable.
-	_ = slog.Default()
-}

--- a/internal/channel/coordinator.go
+++ b/internal/channel/coordinator.go
@@ -2,7 +2,6 @@ package channel
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/vaayne/anna/internal/agent"
 	"github.com/vaayne/anna/internal/agent/runner"
@@ -12,7 +11,7 @@ import (
 	pkgchannel "github.com/vaayne/anna/pkg/channel"
 )
 
-// Coordinator implements pkgchannel.MessageHandler. It owns all business logic
+// Coordinator implements pkgchannel.Handler. It owns all business logic
 // that channels previously called directly: user/agent resolution, session
 // management, command handling, account linking, and model/agent switching.
 type Coordinator struct {
@@ -37,7 +36,7 @@ func WithCoordinatorAuth(authStore auth.AuthStore, engine *auth.PolicyEngine, li
 	}
 }
 
-// NewCoordinator creates a Coordinator that satisfies pkgchannel.MessageHandler.
+// NewCoordinator creates a Coordinator that satisfies pkgchannel.Handler.
 func NewCoordinator(
 	pm *agent.PoolManager,
 	store config.Store,
@@ -95,36 +94,6 @@ func (c *Coordinator) HandleIncoming(ctx context.Context, msg pkgchannel.Incomin
 		return "", false, nil, err
 	}
 	return "", false, stream, nil
-}
-
-// HandleMessage resolves the user, routes to an agent, and streams a response.
-func (c *Coordinator) HandleMessage(ctx context.Context, msg pkgchannel.IncomingMessage) (*pkgchannel.ChatStream, error) {
-	rc, err := c.resolve(ctx, msg)
-	if err != nil {
-		return nil, err
-	}
-	return c.chatWithRC(ctx, rc, msg.Content)
-}
-
-// HandleCommand processes shared commands (/start, /new, /compact, /whoami, /link).
-func (c *Coordinator) HandleCommand(ctx context.Context, msg pkgchannel.IncomingMessage, command, args string) (string, bool) {
-	// Try link code first (before auth resolution, since it creates identity).
-	if c.authStore != nil && c.linkCodes != nil {
-		fullText := command
-		if args != "" {
-			fullText = command + " " + args
-		}
-		if resp, ok := TryLinkCode(ctx, c.authStore, c.linkCodes, fullText, msg.Platform, msg.SenderID, msg.SenderName); ok {
-			return resp, true
-		}
-	}
-
-	rc, err := c.resolve(ctx, msg)
-	if err != nil {
-		return fmt.Sprintf("Error: %v", err), true
-	}
-
-	return HandleCommand(ctx, rc, command+" "+args, msg.SenderID)
 }
 
 // chatWithRC streams a chat response using a pre-resolved chat.
@@ -212,4 +181,4 @@ func convertEvent(evt runner.Event) pkgchannel.Event {
 }
 
 // compile-time check.
-var _ pkgchannel.MessageHandler = (*Coordinator)(nil)
+var _ pkgchannel.Handler = (*Coordinator)(nil)

--- a/internal/channel/coordinator.go
+++ b/internal/channel/coordinator.go
@@ -8,6 +8,7 @@ import (
 	"github.com/vaayne/anna/internal/agent/runner"
 	"github.com/vaayne/anna/internal/auth"
 	"github.com/vaayne/anna/internal/config"
+	"github.com/vaayne/anna/pkg/ai"
 	pkgchannel "github.com/vaayne/anna/pkg/channel"
 )
 
@@ -127,7 +128,7 @@ func (c *Coordinator) HandleCommand(ctx context.Context, msg pkgchannel.Incoming
 }
 
 // chatWithRC streams a chat response using a pre-resolved chat.
-func (c *Coordinator) chatWithRC(ctx context.Context, rc *ResolvedChat, content any) (*pkgchannel.ChatStream, error) {
+func (c *Coordinator) chatWithRC(ctx context.Context, rc *ResolvedChat, content []ai.ContentBlock) (*pkgchannel.ChatStream, error) {
 	events, sessionID, err := rc.Chat(ctx, content)
 	if err != nil {
 		return nil, err

--- a/internal/channel/coordinator.go
+++ b/internal/channel/coordinator.go
@@ -1,0 +1,183 @@
+package channel
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/vaayne/anna/internal/agent"
+	"github.com/vaayne/anna/internal/agent/runner"
+	"github.com/vaayne/anna/internal/auth"
+	"github.com/vaayne/anna/internal/config"
+	pkgchannel "github.com/vaayne/anna/pkg/channel"
+)
+
+// Coordinator implements pkgchannel.MessageHandler. It owns all business logic
+// that channels previously called directly: user/agent resolution, session
+// management, command handling, account linking, and model/agent switching.
+type Coordinator struct {
+	poolManager *agent.PoolManager
+	store       config.Store
+	authStore   auth.AuthStore
+	engine      *auth.PolicyEngine
+	linkCodes   *auth.LinkCodeStore
+	listFn      func() []pkgchannel.ModelOption
+	switchFn    func(provider, model string) error
+}
+
+// CoordinatorOption configures the Coordinator.
+type CoordinatorOption func(*Coordinator)
+
+// WithCoordinatorAuth configures the coordinator with auth support.
+func WithCoordinatorAuth(authStore auth.AuthStore, engine *auth.PolicyEngine, linkCodes *auth.LinkCodeStore) CoordinatorOption {
+	return func(c *Coordinator) {
+		c.authStore = authStore
+		c.engine = engine
+		c.linkCodes = linkCodes
+	}
+}
+
+// NewCoordinator creates a Coordinator that satisfies pkgchannel.MessageHandler.
+func NewCoordinator(
+	pm *agent.PoolManager,
+	store config.Store,
+	listFn func() []pkgchannel.ModelOption,
+	switchFn func(provider, model string) error,
+	opts ...CoordinatorOption,
+) *Coordinator {
+	c := &Coordinator{
+		poolManager: pm,
+		store:       store,
+		listFn:      listFn,
+		switchFn:    switchFn,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// resolve performs the full user -> agent -> pool -> session key resolution.
+func (c *Coordinator) resolve(ctx context.Context, msg pkgchannel.IncomingMessage) (*ResolvedChat, error) {
+	return Resolve(ctx, c.poolManager, c.store, c.authStore, c.engine, msg.Platform, msg.SenderID, msg.SenderName, msg.ChatID, msg.IsGroup)
+}
+
+// HandleMessage resolves the user, routes to an agent, and streams a response.
+func (c *Coordinator) HandleMessage(ctx context.Context, msg pkgchannel.IncomingMessage) (*pkgchannel.ChatStream, error) {
+	rc, err := c.resolve(ctx, msg)
+	if err != nil {
+		return nil, err
+	}
+
+	events, sessionID, err := rc.Chat(ctx, msg.Content)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert internal runner.Event to pkg/channel.Event.
+	out := make(chan pkgchannel.Event, 100)
+	go func() {
+		defer close(out)
+		for evt := range events {
+			out <- convertEvent(evt)
+		}
+	}()
+
+	return &pkgchannel.ChatStream{
+		Events:    out,
+		SessionID: sessionID,
+	}, nil
+}
+
+// HandleCommand processes shared commands (/start, /new, /compact, /whoami, /link).
+func (c *Coordinator) HandleCommand(ctx context.Context, msg pkgchannel.IncomingMessage, command, args string) (string, bool) {
+	// Try link code first (before auth resolution, since it creates identity).
+	if c.authStore != nil && c.linkCodes != nil {
+		fullText := command
+		if args != "" {
+			fullText = command + " " + args
+		}
+		if resp, ok := TryLinkCode(ctx, c.authStore, c.linkCodes, fullText, msg.Platform, msg.SenderID, msg.SenderName); ok {
+			return resp, true
+		}
+	}
+
+	rc, err := c.resolve(ctx, msg)
+	if err != nil {
+		return fmt.Sprintf("Error: %v", err), true
+	}
+
+	return HandleCommand(ctx, rc, command+" "+args, msg.SenderID)
+}
+
+// ListAgents returns enabled agents the user can access and the current agent ID.
+func (c *Coordinator) ListAgents(ctx context.Context, msg pkgchannel.IncomingMessage) ([]pkgchannel.AgentInfo, string, error) {
+	rc, err := c.resolve(ctx, msg)
+	if err != nil {
+		return nil, "", err
+	}
+
+	ac := NewAgentCommander(c.store, c.authStore)
+	agents, err := ac.List(ctx)
+	if err != nil {
+		return nil, "", err
+	}
+
+	infos := make([]pkgchannel.AgentInfo, len(agents))
+	for i, a := range agents {
+		infos[i] = pkgchannel.AgentInfo{ID: a.ID, Name: a.Name}
+	}
+	return infos, rc.AgentID, nil
+}
+
+// SwitchAgent switches the active agent for the chat context.
+func (c *Coordinator) SwitchAgent(ctx context.Context, msg pkgchannel.IncomingMessage, agentSlug string) error {
+	rc, err := c.resolve(ctx, msg)
+	if err != nil {
+		return err
+	}
+
+	ac := NewAgentCommander(c.store, c.authStore)
+	return ac.Switch(ctx, rc.User, rc.ChatCtx, agentSlug)
+}
+
+// ListModels returns available models.
+func (c *Coordinator) ListModels() []pkgchannel.ModelOption {
+	return c.listFn()
+}
+
+// SwitchModel switches the active model.
+func (c *Coordinator) SwitchModel(provider, model string) error {
+	return c.switchFn(provider, model)
+}
+
+// convertEvent converts an internal runner.Event to a pkg/channel.Event.
+func convertEvent(evt runner.Event) pkgchannel.Event {
+	out := pkgchannel.Event{
+		Text: evt.Text,
+		Err:  evt.Err,
+	}
+	if evt.Image != nil {
+		out.Image = &pkgchannel.ImageEvent{
+			Data:     evt.Image.Data,
+			MimeType: evt.Image.MimeType,
+		}
+	}
+	if evt.ToolUse != nil {
+		out.ToolUse = &pkgchannel.ToolUseEvent{
+			Tool:   evt.ToolUse.Tool,
+			Status: evt.ToolUse.Status,
+			Input:  evt.ToolUse.Input,
+			Detail: evt.ToolUse.Detail,
+		}
+	}
+	return out
+}
+
+// compile-time check.
+var _ pkgchannel.MessageHandler = (*Coordinator)(nil)
+
+func init() {
+	// Verify the logger is callable.
+	_ = slog.Default()
+}

--- a/internal/channel/model.go
+++ b/internal/channel/model.go
@@ -1,41 +1,35 @@
 package channel
 
-import "context"
-
-// Platform identifiers for each messaging channel.
-const (
-	PlatformTelegram = "telegram"
-	PlatformQQ       = "qq"
-	PlatformFeishu   = "feishu"
-	PlatformWeixin   = "weixin"
-	PlatformCLI      = "cli"
+import (
+	pkgchannel "github.com/vaayne/anna/pkg/channel"
 )
 
-// Channel is a messaging platform that receives user messages and sends notifications.
-type Channel interface {
-	// Name returns a unique identifier (e.g. "telegram", "qq").
-	Name() string
+// Type aliases re-exported from pkg/channel so that internal callers
+// continue to compile without import changes.
 
-	// Start begins listening for messages. Blocks until ctx is cancelled.
-	Start(ctx context.Context) error
+// Platform identifiers.
+const (
+	PlatformTelegram = pkgchannel.PlatformTelegram
+	PlatformQQ       = pkgchannel.PlatformQQ
+	PlatformFeishu   = pkgchannel.PlatformFeishu
+	PlatformWeixin   = pkgchannel.PlatformWeixin
+	PlatformCLI      = pkgchannel.PlatformCLI
+)
 
-	// Stop gracefully shuts down the channel.
-	Stop()
+// Channel is the messaging platform adapter interface.
+type Channel = pkgchannel.Channel
 
-	// Notify sends a push notification to a target within this channel.
-	Notify(ctx context.Context, n Notification) error
-}
+// Notification is a push message to send to a chat.
+type Notification = pkgchannel.Notification
 
 // ModelOption represents a selectable provider/model combination.
-type ModelOption struct {
-	Provider string
-	Model    string
-}
+type ModelOption = pkgchannel.ModelOption
+
+// AgentInfo is agent metadata for display in channel UIs.
+type AgentInfo = pkgchannel.AgentInfo
 
 // ModelListFunc returns the current list of available models.
-// Called on demand so callers always see the latest cached models.
 type ModelListFunc func() []ModelOption
 
 // ModelSwitchFunc switches the active model in the pool.
-// It rebuilds the runner factory for the given provider/model pair.
 type ModelSwitchFunc func(provider, model string) error

--- a/internal/channel/notifier.go
+++ b/internal/channel/notifier.go
@@ -10,14 +10,6 @@ import (
 	"github.com/vaayne/anna/internal/auth"
 )
 
-// Notification represents a message to push to a user or channel.
-type Notification struct {
-	Channel string // optional: route to a specific backend ("telegram", "slack")
-	ChatID  string // target chat/channel within the backend
-	Text    string // markdown content
-	Silent  bool   // send without notification sound
-}
-
 // Notifier can push notifications. Both Dispatcher and individual channels
 // satisfy this interface, so consumers don't need to know the routing layer.
 type Notifier interface {

--- a/internal/channel/notifier.go
+++ b/internal/channel/notifier.go
@@ -40,6 +40,19 @@ func (d *Dispatcher) Register(ch Channel) {
 	d.mu.Unlock()
 }
 
+// Unregister removes all channels with the given name from the dispatcher.
+func (d *Dispatcher) Unregister(name string) {
+	d.mu.Lock()
+	filtered := d.channels[:0]
+	for _, e := range d.channels {
+		if e.channel.Name() != name {
+			filtered = append(filtered, e)
+		}
+	}
+	d.channels = filtered
+	d.mu.Unlock()
+}
+
 // Notify routes a notification to channels. If Notification.Channel is set,
 // only that channel receives it. Otherwise all registered channels receive it.
 func (d *Dispatcher) Notify(ctx context.Context, n Notification) error {

--- a/internal/channel/util.go
+++ b/internal/channel/util.go
@@ -1,53 +1,11 @@
 package channel
 
 import (
-	"fmt"
-	"strings"
-	"time"
-	"unicode/utf8"
+	pkgchannel "github.com/vaayne/anna/pkg/channel"
 )
 
-// SplitMessage splits text into chunks that fit within maxLen.
-// It tries to split at newline boundaries and avoids cutting multi-byte
-// UTF-8 characters.
-func SplitMessage(text string, maxLen int) []string {
-	if len(text) <= maxLen {
-		return []string{text}
-	}
-
-	var chunks []string
-	for len(text) > 0 {
-		if len(text) <= maxLen {
-			chunks = append(chunks, text)
-			break
-		}
-
-		cutAt := maxLen
-		// Avoid splitting in the middle of a multi-byte UTF-8 character.
-		for cutAt > 0 && !utf8.RuneStart(text[cutAt]) {
-			cutAt--
-		}
-		if idx := strings.LastIndex(text[:cutAt], "\n"); idx > 0 {
-			cutAt = idx + 1 // Include the newline in the current chunk.
-		}
-
-		chunks = append(chunks, text[:cutAt])
-		text = text[cutAt:]
-	}
-
-	return chunks
-}
-
-// FormatDuration formats a duration as a human-friendly string.
-func FormatDuration(d time.Duration) string {
-	switch {
-	case d < time.Second:
-		return fmt.Sprintf("%dms", d.Milliseconds())
-	case d < time.Minute:
-		return fmt.Sprintf("%.1fs", d.Seconds())
-	default:
-		m := int(d.Minutes())
-		s := int(d.Seconds()) - m*60
-		return fmt.Sprintf("%dm%ds", m, s)
-	}
-}
+// Re-exported from pkg/channel for internal callers.
+var (
+	SplitMessage   = pkgchannel.SplitMessage
+	FormatDuration = pkgchannel.FormatDuration
+)

--- a/pkg/channel/agent.go
+++ b/pkg/channel/agent.go
@@ -1,5 +1,10 @@
 package channel
 
+import (
+	"fmt"
+	"strings"
+)
+
 // IndexedAgent pairs an AgentInfo with its 1-based global index.
 type IndexedAgent struct {
 	AgentInfo
@@ -13,4 +18,22 @@ func IndexAgents(agents []AgentInfo) []IndexedAgent {
 		out[i] = IndexedAgent{AgentInfo: a, GlobalIdx: i + 1}
 	}
 	return out
+}
+
+// FormatAgentList builds a text-based agent list, marking the current agent.
+func FormatAgentList(agents []IndexedAgent, currentAgentID string) string {
+	if len(agents) == 0 {
+		return "No agents available."
+	}
+	var sb strings.Builder
+	sb.WriteString("Available agents:\n\n")
+	for _, ag := range agents {
+		prefix := "• "
+		if ag.ID == currentAgentID {
+			prefix = "✅ "
+		}
+		fmt.Fprintf(&sb, "%s%s (%s)\n", prefix, ag.ID, ag.Name)
+	}
+	sb.WriteString("\nUse /agent <slug> to switch.")
+	return sb.String()
 }

--- a/pkg/channel/agent.go
+++ b/pkg/channel/agent.go
@@ -1,0 +1,16 @@
+package channel
+
+// IndexedAgent pairs an AgentInfo with its 1-based global index.
+type IndexedAgent struct {
+	AgentInfo
+	GlobalIdx int
+}
+
+// IndexAgents wraps a full agent list with sequential 1-based indices.
+func IndexAgents(agents []AgentInfo) []IndexedAgent {
+	out := make([]IndexedAgent, len(agents))
+	for i, a := range agents {
+		out[i] = IndexedAgent{AgentInfo: a, GlobalIdx: i + 1}
+	}
+	return out
+}

--- a/pkg/channel/channel.go
+++ b/pkg/channel/channel.go
@@ -1,0 +1,107 @@
+// Package channel defines the public contract for channel plugins.
+// Channel plugins are thin platform adapters (Telegram, QQ, Feishu, Weixin)
+// that normalise incoming messages, delegate business logic to a MessageHandler,
+// and render streamed responses back to the platform.
+package channel
+
+import "context"
+
+// Platform identifiers for each messaging channel.
+const (
+	PlatformTelegram = "telegram"
+	PlatformQQ       = "qq"
+	PlatformFeishu   = "feishu"
+	PlatformWeixin   = "weixin"
+	PlatformCLI      = "cli"
+)
+
+// Channel is a messaging platform adapter.
+type Channel interface {
+	// Name returns a unique identifier (e.g. "telegram", "qq").
+	Name() string
+
+	// Start begins listening for messages. Blocks until ctx is cancelled.
+	Start(ctx context.Context) error
+
+	// Stop gracefully shuts down the channel.
+	Stop()
+
+	// Notify sends a push notification to a target within this channel.
+	Notify(ctx context.Context, n Notification) error
+}
+
+// MessageHandler is the coordinator interface injected into channel plugins.
+// It owns user resolution, agent routing, session management, and command handling.
+type MessageHandler interface {
+	// HandleMessage resolves the user, routes to an agent, and streams a response.
+	HandleMessage(ctx context.Context, msg IncomingMessage) (*ChatStream, error)
+
+	// HandleCommand processes shared commands (/start, /new, /compact, /whoami, /link).
+	// Returns (response, handled). Unhandled commands return ("", false).
+	HandleCommand(ctx context.Context, msg IncomingMessage, command, args string) (string, bool)
+
+	// ListAgents returns enabled agents the user can access and the current agent ID.
+	ListAgents(ctx context.Context, msg IncomingMessage) ([]AgentInfo, string, error)
+
+	// SwitchAgent switches the active agent for this chat context.
+	SwitchAgent(ctx context.Context, msg IncomingMessage, agentSlug string) error
+
+	// ListModels returns available models.
+	ListModels() []ModelOption
+
+	// SwitchModel switches the active model.
+	SwitchModel(provider, model string) error
+}
+
+// IncomingMessage is the normalised input from any platform.
+type IncomingMessage struct {
+	Platform   string // "telegram", "qq", etc.
+	SenderID   string // platform-specific user ID
+	SenderName string // display name
+	ChatID     string // group/channel ID (empty for DMs)
+	IsGroup    bool
+	Content    any // string or []ai.ContentBlock
+}
+
+// ChatStream holds the event channel and session metadata returned by HandleMessage.
+type ChatStream struct {
+	Events    <-chan Event
+	SessionID string
+}
+
+// Event is a stream event from the agent, consumed by channel plugins
+// to render responses on the platform.
+type Event struct {
+	Text    string
+	Image   *ImageEvent
+	ToolUse *ToolUseEvent
+	Err     error
+}
+
+// ImageEvent carries a base64-encoded image.
+type ImageEvent struct {
+	Data     string // base64 encoded
+	MimeType string // e.g. "image/jpeg"
+}
+
+// ToolUseEvent describes a tool invocation in progress or completed.
+type ToolUseEvent struct {
+	Tool   string // tool name, e.g. "bash", "read"
+	Status string // "running", "done", "error"
+	Input  string // short summary of the tool input
+	Detail string // error detail or result summary
+}
+
+// Notification is a push message to send to a chat.
+type Notification struct {
+	Channel string // optional: route to a specific backend
+	ChatID  string // target chat/channel within the backend
+	Text    string // markdown content
+	Silent  bool   // send without notification sound
+}
+
+// AgentInfo is agent metadata for display in channel UIs.
+type AgentInfo struct {
+	ID   string
+	Name string
+}

--- a/pkg/channel/channel.go
+++ b/pkg/channel/channel.go
@@ -34,35 +34,45 @@ type Channel interface {
 	Notify(ctx context.Context, n Notification) error
 }
 
-// MessageHandler is the coordinator interface injected into channel plugins.
+// MessageHandler is the core coordinator interface injected into channel plugins.
 // It owns user resolution, agent routing, session management, and command handling.
+// The single HandleIncoming entry point resolves the user once, tries command
+// handling, and falls through to chat streaming — eliminating double resolution.
 type MessageHandler interface {
 	// HandleIncoming resolves the user once, tries command handling, and if the
-	// command is not handled, streams a chat response. This avoids double
-	// resolution when a plugin needs to try commands before falling through
-	// to message handling. Returns (commandResponse, handled, stream, err).
+	// command is not handled, streams a chat response.
+	// Returns (commandResponse, handled, stream, err).
 	// If handled is true, commandResponse contains the reply and stream is nil.
 	// If handled is false, stream contains the chat response.
 	HandleIncoming(ctx context.Context, msg IncomingMessage, command, args string) (string, bool, *ChatStream, error)
+}
 
-	// HandleMessage resolves the user, routes to an agent, and streams a response.
-	HandleMessage(ctx context.Context, msg IncomingMessage) (*ChatStream, error)
-
-	// HandleCommand processes shared commands (/start, /new, /compact, /whoami, /link).
-	// Returns (response, handled). Unhandled commands return ("", false).
-	HandleCommand(ctx context.Context, msg IncomingMessage, command, args string) (string, bool)
-
-	// ListAgents returns enabled agents the user can access and the current agent ID.
-	ListAgents(ctx context.Context, msg IncomingMessage) ([]AgentInfo, string, error)
-
-	// SwitchAgent switches the active agent for this chat context.
-	SwitchAgent(ctx context.Context, msg IncomingMessage, agentSlug string) error
-
+// ModelManager provides model listing and switching for channel plugins
+// that support the /model command.
+type ModelManager interface {
 	// ListModels returns available models.
 	ListModels() []ModelOption
 
 	// SwitchModel switches the active model.
 	SwitchModel(provider, model string) error
+}
+
+// AgentManager provides agent listing and switching for channel plugins
+// that support the /agent command.
+type AgentManager interface {
+	// ListAgents returns enabled agents the user can access and the current agent ID.
+	ListAgents(ctx context.Context, msg IncomingMessage) ([]AgentInfo, string, error)
+
+	// SwitchAgent switches the active agent for this chat context.
+	SwitchAgent(ctx context.Context, msg IncomingMessage, agentSlug string) error
+}
+
+// Handler combines message routing with model and agent management.
+// Channel plugins typically need all three capabilities.
+type Handler interface {
+	MessageHandler
+	ModelManager
+	AgentManager
 }
 
 // IncomingMessage is the normalised input from any platform.

--- a/pkg/channel/channel.go
+++ b/pkg/channel/channel.go
@@ -4,7 +4,11 @@
 // and render streamed responses back to the platform.
 package channel
 
-import "context"
+import (
+	"context"
+
+	"github.com/vaayne/anna/pkg/ai"
+)
 
 // Platform identifiers for each messaging channel.
 const (
@@ -68,7 +72,7 @@ type IncomingMessage struct {
 	SenderName string // display name
 	ChatID     string // group/channel ID (empty for DMs)
 	IsGroup    bool
-	Content    any // string or []ai.ContentBlock
+	Content    []ai.ContentBlock
 }
 
 // ChatStream holds the event channel and session metadata returned by HandleMessage.

--- a/pkg/channel/channel.go
+++ b/pkg/channel/channel.go
@@ -33,6 +33,14 @@ type Channel interface {
 // MessageHandler is the coordinator interface injected into channel plugins.
 // It owns user resolution, agent routing, session management, and command handling.
 type MessageHandler interface {
+	// HandleIncoming resolves the user once, tries command handling, and if the
+	// command is not handled, streams a chat response. This avoids double
+	// resolution when a plugin needs to try commands before falling through
+	// to message handling. Returns (commandResponse, handled, stream, err).
+	// If handled is true, commandResponse contains the reply and stream is nil.
+	// If handled is false, stream contains the chat response.
+	HandleIncoming(ctx context.Context, msg IncomingMessage, command, args string) (string, bool, *ChatStream, error)
+
 	// HandleMessage resolves the user, routes to an agent, and streams a response.
 	HandleMessage(ctx context.Context, msg IncomingMessage) (*ChatStream, error)
 

--- a/pkg/channel/model.go
+++ b/pkg/channel/model.go
@@ -1,0 +1,44 @@
+package channel
+
+import "strings"
+
+// ModelOption represents a selectable provider/model combination.
+type ModelOption struct {
+	Provider string
+	Model    string
+}
+
+// IndexedModel pairs a ModelOption with its 1-based global index.
+type IndexedModel struct {
+	ModelOption
+	GlobalIdx int
+}
+
+// ParseModelArgs parses /model arguments as a query string.
+// Returns empty string when no arguments are provided.
+func ParseModelArgs(args string) string {
+	return strings.TrimSpace(args)
+}
+
+// IndexModels wraps a full model list with sequential 1-based indices.
+func IndexModels(models []ModelOption) []IndexedModel {
+	out := make([]IndexedModel, len(models))
+	for i, m := range models {
+		out[i] = IndexedModel{ModelOption: m, GlobalIdx: i + 1}
+	}
+	return out
+}
+
+// FilterModels returns indexed models matching the query, preserving
+// their 1-based global indices from the full list.
+func FilterModels(models []ModelOption, query string) []IndexedModel {
+	query = strings.ToLower(query)
+	var out []IndexedModel
+	for i, m := range models {
+		label := strings.ToLower(m.Provider + "/" + m.Model)
+		if strings.Contains(label, query) {
+			out = append(out, IndexedModel{ModelOption: m, GlobalIdx: i + 1})
+		}
+	}
+	return out
+}

--- a/pkg/channel/model.go
+++ b/pkg/channel/model.go
@@ -1,6 +1,9 @@
 package channel
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 // ModelOption represents a selectable provider/model combination.
 type ModelOption struct {
@@ -41,4 +44,31 @@ func FilterModels(models []ModelOption, query string) []IndexedModel {
 		}
 	}
 	return out
+}
+
+// FindModelByName looks up a model by "provider/model" name (case-insensitive).
+// Returns the model and true if found, zero value and false otherwise.
+func FindModelByName(models []ModelOption, name string) (ModelOption, bool) {
+	name = strings.ToLower(strings.TrimSpace(name))
+	for _, m := range models {
+		if strings.ToLower(m.Provider+"/"+m.Model) == name {
+			return m, true
+		}
+	}
+	return ModelOption{}, false
+}
+
+// FormatModelList builds a text-based model list with bullet points.
+func FormatModelList(models []IndexedModel, query string) string {
+	var sb strings.Builder
+	sb.WriteString("Available models")
+	if query != "" {
+		fmt.Fprintf(&sb, " (filter: %q)", query)
+	}
+	sb.WriteString(":\n\n")
+	for _, m := range models {
+		fmt.Fprintf(&sb, "• %s/%s\n", m.Provider, m.Model)
+	}
+	sb.WriteString("\nUse /model <provider/model> to switch.")
+	return sb.String()
 }

--- a/pkg/channel/stream.go
+++ b/pkg/channel/stream.go
@@ -1,0 +1,259 @@
+package channel
+
+import (
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+// ToolEmoji maps known tool names to display emoji.
+var ToolEmoji = map[string]string{
+	"bash":    "⚡",
+	"read":    "📖",
+	"write":   "✏️",
+	"edit":    "🔧",
+	"search":  "🔍",
+	"default": "🔧",
+}
+
+// EmojiFor returns the emoji for a tool name, falling back to the default.
+func EmojiFor(tool string) string {
+	if e, ok := ToolEmoji[tool]; ok {
+		return e
+	}
+	return ToolEmoji["default"]
+}
+
+// Truncate shortens s to maxLen bytes, appending "..." if truncated.
+// Cuts at a valid UTF-8 boundary to avoid producing invalid strings.
+func Truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	if maxLen <= 3 {
+		return "..."
+	}
+	cutAt := maxLen - 3
+	for cutAt > 0 && !utf8.RuneStart(s[cutAt]) {
+		cutAt--
+	}
+	return s[:cutAt] + "..."
+}
+
+// ToolLine returns a short status line for a tool-use event.
+// Used by channels with simple tool display (no full tracker).
+func ToolLine(t *ToolUseEvent) string {
+	emoji := EmojiFor(t.Tool)
+	switch t.Status {
+	case "running":
+		input := t.Input
+		if utf8.RuneCountInString(input) > 60 {
+			r := []rune(input)
+			input = string(r[:57]) + "..."
+		}
+		if input != "" {
+			return fmt.Sprintf("%s %s: %s", emoji, t.Tool, input)
+		}
+		return fmt.Sprintf("%s %s", emoji, t.Tool)
+	case "error":
+		return fmt.Sprintf("❌ %s failed", t.Tool)
+	default:
+		return ""
+	}
+}
+
+// ToolRecord holds a completed tool invocation for summary display.
+type ToolRecord struct {
+	Tool     string
+	Input    string
+	Status   string // "done" or "error"
+	Detail   string
+	Duration time.Duration
+}
+
+// ToolTracker tracks active and completed tool invocations during streaming.
+type ToolTracker struct {
+	History      []ToolRecord
+	ActiveTool   string
+	ActiveInput  string
+	ActiveStart  time.Time
+	DisplayUntil time.Time // minimum time to keep showing the last-finished tool
+
+	// MinDisplayDuration controls how long a finished tool stays visible.
+	// Zero means no minimum.
+	MinDisplayDuration time.Duration
+}
+
+// Start registers a new tool as running.
+func (tt *ToolTracker) Start(t *ToolUseEvent) {
+	// If a tool was already active, finish it as "done" (missed the finish event).
+	if tt.ActiveTool != "" {
+		tt.History = append(tt.History, ToolRecord{
+			Tool:     tt.ActiveTool,
+			Input:    tt.ActiveInput,
+			Status:   "done",
+			Duration: time.Since(tt.ActiveStart),
+		})
+	}
+	tt.ActiveTool = t.Tool
+	tt.ActiveInput = t.Input
+	tt.ActiveStart = time.Now()
+	tt.DisplayUntil = time.Time{}
+}
+
+// Finish records the active tool as completed.
+func (tt *ToolTracker) Finish(t *ToolUseEvent) {
+	dur := time.Since(tt.ActiveStart)
+	input := tt.ActiveInput
+	if t.Input != "" {
+		input = t.Input
+	}
+	tt.History = append(tt.History, ToolRecord{
+		Tool:     t.Tool,
+		Input:    input,
+		Status:   t.Status,
+		Detail:   t.Detail,
+		Duration: dur,
+	})
+	if tt.MinDisplayDuration > 0 {
+		tt.DisplayUntil = time.Now().Add(tt.MinDisplayDuration)
+	}
+	tt.ActiveTool = ""
+	tt.ActiveInput = ""
+	tt.ActiveStart = time.Time{}
+}
+
+// Handle processes a tool event, returning true if a display refresh is needed.
+func (tt *ToolTracker) Handle(t *ToolUseEvent) bool {
+	switch t.Status {
+	case "running":
+		tt.Start(t)
+		return true
+	case "done", "error":
+		tt.Finish(t)
+		return true
+	}
+	return false
+}
+
+// IsDisplaying returns true if there is an active tool or the minimum display
+// duration for the last finished tool has not yet elapsed.
+func (tt *ToolTracker) IsDisplaying() bool {
+	if tt.ActiveTool != "" {
+		return true
+	}
+	return time.Now().Before(tt.DisplayUntil)
+}
+
+// HasHistory returns true if any tools were tracked.
+func (tt *ToolTracker) HasHistory() bool {
+	return len(tt.History) > 0
+}
+
+// Render builds the tool section for real-time streaming display,
+// showing completed tools and the active tool with elapsed time.
+func (tt *ToolTracker) Render() string {
+	var sb strings.Builder
+
+	for _, rec := range tt.History {
+		sb.WriteString(RenderToolRecord(rec))
+		sb.WriteByte('\n')
+	}
+
+	if tt.ActiveTool != "" {
+		emoji := EmojiFor(tt.ActiveTool)
+		elapsed := time.Since(tt.ActiveStart).Truncate(100 * time.Millisecond)
+		line := fmt.Sprintf("⏳ %s %s", emoji, tt.ActiveTool)
+		if tt.ActiveInput != "" {
+			input := Truncate(tt.ActiveInput, 60)
+			line += ": " + input
+		}
+		line += fmt.Sprintf(" (%s)", FormatDuration(elapsed))
+		sb.WriteString(line)
+		sb.WriteByte('\n')
+	}
+
+	return sb.String()
+}
+
+// RenderFinal builds a compact tool summary for the final message.
+// Shows a one-liner with tool counts and total time, plus individual
+// lines for any failed tool calls.
+func (tt *ToolTracker) RenderFinal() string {
+	if len(tt.History) == 0 {
+		return ""
+	}
+
+	type toolCount struct {
+		name  string
+		count int
+	}
+	seen := map[string]int{}
+	var counts []toolCount
+	var totalDur time.Duration
+	var errors []ToolRecord
+
+	for _, rec := range tt.History {
+		totalDur += rec.Duration
+		if rec.Status == "error" {
+			errors = append(errors, rec)
+		}
+		if idx, ok := seen[rec.Tool]; ok {
+			counts[idx].count++
+		} else {
+			seen[rec.Tool] = len(counts)
+			counts = append(counts, toolCount{name: rec.Tool, count: 1})
+		}
+	}
+
+	var sb strings.Builder
+	sb.WriteString("\n\n——————————————————\n")
+
+	total := len(tt.History)
+	fmt.Fprintf(&sb, "📎 %d tool", total)
+	if total != 1 {
+		sb.WriteByte('s')
+	}
+	sb.WriteString(" (")
+	for i, tc := range counts {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		emoji := EmojiFor(tc.name)
+		if tc.count > 1 {
+			fmt.Fprintf(&sb, "%d× %s%s", tc.count, emoji, tc.name)
+		} else {
+			sb.WriteString(emoji + tc.name)
+		}
+	}
+	sb.WriteString(") · ")
+	sb.WriteString(FormatDuration(totalDur))
+
+	for _, rec := range errors {
+		sb.WriteByte('\n')
+		sb.WriteString(RenderToolRecord(rec))
+	}
+
+	return sb.String()
+}
+
+// RenderToolRecord formats a single completed tool record.
+func RenderToolRecord(rec ToolRecord) string {
+	statusEmoji := "✅"
+	if rec.Status == "error" {
+		statusEmoji = "❌"
+	}
+	emoji := EmojiFor(rec.Tool)
+	line := fmt.Sprintf("%s %s %s", statusEmoji, emoji, rec.Tool)
+	if rec.Input != "" {
+		input := Truncate(rec.Input, 60)
+		line += ": " + input
+	}
+	if rec.Detail != "" {
+		detail := Truncate(rec.Detail, 80)
+		line += " → " + detail
+	}
+	line += fmt.Sprintf(" (%s)", FormatDuration(rec.Duration))
+	return line
+}

--- a/pkg/channel/util.go
+++ b/pkg/channel/util.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"time"
 	"unicode/utf8"
+
+	"github.com/vaayne/anna/pkg/ai"
 )
 
 // WelcomeMessage is the shared welcome/help text for all channels.
@@ -66,4 +68,9 @@ func FormatDuration(d time.Duration) string {
 // Example: ParseCommandArgs("/agent foo", "/agent") returns "foo".
 func ParseCommandArgs(text, cmd string) string {
 	return strings.TrimSpace(strings.TrimPrefix(text, cmd))
+}
+
+// TextContent wraps a plain string as a single-element []ai.ContentBlock.
+func TextContent(text string) []ai.ContentBlock {
+	return []ai.ContentBlock{ai.TextContent{Text: text}}
 }

--- a/pkg/channel/util.go
+++ b/pkg/channel/util.go
@@ -1,0 +1,69 @@
+package channel
+
+import (
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+// WelcomeMessage is the shared welcome/help text for all channels.
+const WelcomeMessage = "Hi! I'm Anna -- your local AI assistant.\n\n" +
+	"Commands:\n" +
+	"/new -- Start a fresh session\n" +
+	"/compact -- Compress conversation history\n" +
+	"/model -- Switch between models\n" +
+	"/agent -- List or switch agents\n" +
+	"/whoami -- Show your user ID\n\n" +
+	"Just send me a message to get started."
+
+// SplitMessage splits text into chunks that fit within maxLen.
+// It tries to split at newline boundaries and avoids cutting multi-byte
+// UTF-8 characters.
+func SplitMessage(text string, maxLen int) []string {
+	if len(text) <= maxLen {
+		return []string{text}
+	}
+
+	var chunks []string
+	for len(text) > 0 {
+		if len(text) <= maxLen {
+			chunks = append(chunks, text)
+			break
+		}
+
+		cutAt := maxLen
+		// Avoid splitting in the middle of a multi-byte UTF-8 character.
+		for cutAt > 0 && !utf8.RuneStart(text[cutAt]) {
+			cutAt--
+		}
+		if idx := strings.LastIndex(text[:cutAt], "\n"); idx > 0 {
+			cutAt = idx + 1 // Include the newline in the current chunk.
+		}
+
+		chunks = append(chunks, text[:cutAt])
+		text = text[cutAt:]
+	}
+
+	return chunks
+}
+
+// FormatDuration formats a duration as a human-friendly string.
+func FormatDuration(d time.Duration) string {
+	switch {
+	case d < time.Second:
+		return fmt.Sprintf("%dms", d.Milliseconds())
+	case d < time.Minute:
+		return fmt.Sprintf("%.1fs", d.Seconds())
+	default:
+		m := int(d.Minutes())
+		s := int(d.Seconds()) - m*60
+		return fmt.Sprintf("%dm%ds", m, s)
+	}
+}
+
+// ParseCommandArgs extracts arguments after the command token.
+// Example: ParseCommandArgs("/agent foo", "/agent") returns "foo".
+func ParseCommandArgs(text, cmd string) string {
+	return strings.TrimSpace(strings.TrimPrefix(text, cmd))
+}

--- a/plugins/channels/feishu/feishu.go
+++ b/plugins/channels/feishu/feishu.go
@@ -17,6 +17,7 @@ import (
 	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher"
 	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
 	larkws "github.com/larksuite/oapi-sdk-go/v3/ws"
+	"github.com/vaayne/anna/pkg/ai"
 	"github.com/vaayne/anna/pkg/channel"
 )
 
@@ -378,7 +379,7 @@ func stripMentions(text string, mentions []*larkim.MentionEvent) string {
 }
 
 // incomingMsg builds an IncomingMessage from the Feishu context.
-func (b *Bot) incomingMsg(openID, chatID string, chatType string, content any) channel.IncomingMessage {
+func (b *Bot) incomingMsg(openID, chatID string, chatType string, content []ai.ContentBlock) channel.IncomingMessage {
 	return channel.IncomingMessage{
 		Platform: channel.PlatformFeishu,
 		SenderID: openID,

--- a/plugins/channels/feishu/feishu.go
+++ b/plugins/channels/feishu/feishu.go
@@ -54,7 +54,7 @@ type Config struct {
 type Bot struct {
 	client   *lark.Client
 	wsClient *larkws.Client
-	handler  channel.MessageHandler
+	handler  channel.Handler
 
 	botOpenID atomic.Value // bot's own open_id (string), fetched on startup
 
@@ -70,7 +70,7 @@ type Bot struct {
 }
 
 // New creates a Feishu bot. Call Start to begin receiving events.
-func New(cfg Config, handler channel.MessageHandler) (*Bot, error) {
+func New(cfg Config, handler channel.Handler) (*Bot, error) {
 	if cfg.AppID == "" || cfg.AppSecret == "" {
 		return nil, fmt.Errorf("feishu: app_id and app_secret are required")
 	}

--- a/plugins/channels/feishu/feishu.go
+++ b/plugins/channels/feishu/feishu.go
@@ -17,10 +17,7 @@ import (
 	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher"
 	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
 	larkws "github.com/larksuite/oapi-sdk-go/v3/ws"
-	"github.com/vaayne/anna/internal/agent"
-	"github.com/vaayne/anna/internal/auth"
-	"github.com/vaayne/anna/internal/channel"
-	"github.com/vaayne/anna/internal/config"
+	"github.com/vaayne/anna/pkg/channel"
 )
 
 const feishuMaxMessageLen = 4000
@@ -54,21 +51,14 @@ type Config struct {
 
 // Bot wraps a Feishu bot with agent pool integration.
 type Bot struct {
-	client      *lark.Client
-	wsClient    *larkws.Client
-	poolManager *agent.PoolManager
-	store       config.Store
-	authStore   auth.AuthStore
-	engine      *auth.PolicyEngine
-	linkCodes   *auth.LinkCodeStore
-	agentCmd    *channel.AgentCommander
-	listFn      ModelListFunc
-	switchFn    ModelSwitchFunc
+	client   *lark.Client
+	wsClient *larkws.Client
+	handler  channel.MessageHandler
 
 	botOpenID atomic.Value // bot's own open_id (string), fetched on startup
 
 	mu            sync.RWMutex
-	chatModels    map[string]ModelOption
+	chatModels    map[string]channel.ModelOption
 	seenMsgs      map[string]time.Time          // message ID -> first seen time
 	lastSeenSweep time.Time                     // last time seenMsgs was swept
 	activeStreams map[string]context.CancelFunc // streamKey -> cancel func
@@ -78,22 +68,8 @@ type Bot struct {
 	cancel context.CancelFunc
 }
 
-// BotOption configures the Feishu Bot.
-type BotOption func(*Bot)
-
-// WithAuth configures the bot with auth store and link code store for
-// account linking support.
-func WithAuth(authStore auth.AuthStore, engine *auth.PolicyEngine, linkCodes *auth.LinkCodeStore) BotOption {
-	return func(b *Bot) {
-		b.authStore = authStore
-		b.engine = engine
-		b.linkCodes = linkCodes
-		b.agentCmd = channel.NewAgentCommander(b.store, authStore)
-	}
-}
-
 // New creates a Feishu bot. Call Start to begin receiving events.
-func New(cfg Config, pm *agent.PoolManager, store config.Store, listFn ModelListFunc, switchFn ModelSwitchFunc, opts ...BotOption) (*Bot, error) {
+func New(cfg Config, handler channel.MessageHandler) (*Bot, error) {
 	if cfg.AppID == "" || cfg.AppSecret == "" {
 		return nil, fmt.Errorf("feishu: app_id and app_secret are required")
 	}
@@ -103,19 +79,11 @@ func New(cfg Config, pm *agent.PoolManager, store config.Store, listFn ModelList
 	}
 
 	b := &Bot{
-		poolManager:   pm,
-		store:         store,
-		agentCmd:      channel.NewAgentCommander(store, nil),
-		listFn:        listFn,
-		switchFn:      switchFn,
-		chatModels:    make(map[string]ModelOption),
+		handler:       handler,
+		chatModels:    make(map[string]channel.ModelOption),
 		seenMsgs:      make(map[string]time.Time),
 		activeStreams: make(map[string]context.CancelFunc),
 		cfg:           cfg,
-	}
-
-	for _, opt := range opts {
-		opt(b)
 	}
 
 	return b, nil
@@ -199,10 +167,10 @@ func (b *Bot) fetchBotOpenID(ctx context.Context) error {
 	return nil
 }
 
-// Name returns the backend name. Implements channel.Backend.
+// Name returns the backend name. Implements channel.Channel.
 func (b *Bot) Name() string { return channel.PlatformFeishu }
 
-// Notify sends a notification message. Implements channel.Backend.
+// Notify sends a notification message. Implements channel.Channel.
 // Supports both chat IDs (oc_ prefix) and user open IDs (ou_ prefix).
 func (b *Bot) Notify(ctx context.Context, n channel.Notification) error {
 	chatID := n.ChatID
@@ -407,4 +375,15 @@ func stripMentions(text string, mentions []*larkim.MentionEvent) string {
 	}
 	text = mentionPlaceholderRegex.ReplaceAllString(text, "")
 	return strings.TrimSpace(text)
+}
+
+// incomingMsg builds an IncomingMessage from the Feishu context.
+func (b *Bot) incomingMsg(openID, chatID string, chatType string, content any) channel.IncomingMessage {
+	return channel.IncomingMessage{
+		Platform: channel.PlatformFeishu,
+		SenderID: openID,
+		ChatID:   chatID,
+		IsGroup:  chatType == "group",
+		Content:  content,
+	}
 }

--- a/plugins/channels/feishu/feishu_test.go
+++ b/plugins/channels/feishu/feishu_test.go
@@ -1114,14 +1114,6 @@ func (m *mockHandler) HandleIncoming(_ context.Context, _ channel.IncomingMessag
 	return "", false, nil, nil
 }
 
-func (m *mockHandler) HandleMessage(_ context.Context, _ channel.IncomingMessage) (*channel.ChatStream, error) {
-	return nil, fmt.Errorf("not implemented")
-}
-
-func (m *mockHandler) HandleCommand(_ context.Context, _ channel.IncomingMessage, _, _ string) (string, bool) {
-	return "", false
-}
-
 func (m *mockHandler) ListAgents(_ context.Context, _ channel.IncomingMessage) ([]channel.AgentInfo, string, error) {
 	return nil, "", nil
 }

--- a/plugins/channels/feishu/feishu_test.go
+++ b/plugins/channels/feishu/feishu_test.go
@@ -1089,6 +1089,10 @@ type mockHandler struct {
 	switchErr error
 }
 
+func (m *mockHandler) HandleIncoming(_ context.Context, _ channel.IncomingMessage, _, _ string) (string, bool, *channel.ChatStream, error) {
+	return "", false, nil, nil
+}
+
 func (m *mockHandler) HandleMessage(_ context.Context, _ channel.IncomingMessage) (*channel.ChatStream, error) {
 	return nil, fmt.Errorf("not implemented")
 }

--- a/plugins/channels/feishu/feishu_test.go
+++ b/plugins/channels/feishu/feishu_test.go
@@ -125,7 +125,7 @@ func TestBuildStreamDisplayEmptyAll(t *testing.T) {
 // --- toolLine ---
 
 func TestToolLineRunning(t *testing.T) {
-	line := toolLine(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "ls -la"})
+	line := channel.ToolLine(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "ls -la"})
 	if !strings.Contains(line, "bash") || !strings.Contains(line, "ls -la") {
 		t.Errorf("unexpected line: %q", line)
 	}
@@ -133,28 +133,28 @@ func TestToolLineRunning(t *testing.T) {
 
 func TestToolLineRunningTruncatesMultibyte(t *testing.T) {
 	input := strings.Repeat("中", 61)
-	line := toolLine(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: input})
+	line := channel.ToolLine(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: input})
 	if !strings.HasSuffix(line, "...") {
 		t.Errorf("expected truncation ellipsis, got %q", line)
 	}
 }
 
 func TestToolLineError(t *testing.T) {
-	line := toolLine(&channel.ToolUseEvent{Tool: "read", Status: "error"})
+	line := channel.ToolLine(&channel.ToolUseEvent{Tool: "read", Status: "error"})
 	if !strings.Contains(line, "failed") {
 		t.Errorf("unexpected line: %q", line)
 	}
 }
 
 func TestToolLineDefault(t *testing.T) {
-	line := toolLine(&channel.ToolUseEvent{Tool: "bash", Status: "done"})
+	line := channel.ToolLine(&channel.ToolUseEvent{Tool: "bash", Status: "done"})
 	if line != "" {
 		t.Errorf("expected empty, got %q", line)
 	}
 }
 
 func TestToolLineRunningNoInput(t *testing.T) {
-	line := toolLine(&channel.ToolUseEvent{Tool: "search", Status: "running"})
+	line := channel.ToolLine(&channel.ToolUseEvent{Tool: "search", Status: "running"})
 	if !strings.Contains(line, "search") {
 		t.Errorf("unexpected line: %q", line)
 	}
@@ -164,7 +164,7 @@ func TestToolLineRunningNoInput(t *testing.T) {
 }
 
 func TestToolLineUnknownTool(t *testing.T) {
-	line := toolLine(&channel.ToolUseEvent{Tool: "custom_tool", Status: "running", Input: "x"})
+	line := channel.ToolLine(&channel.ToolUseEvent{Tool: "custom_tool", Status: "running", Input: "x"})
 	if !strings.Contains(line, "🔧") {
 		t.Errorf("unknown tool should use default emoji: %q", line)
 	}

--- a/plugins/channels/feishu/feishu_test.go
+++ b/plugins/channels/feishu/feishu_test.go
@@ -8,15 +8,13 @@ import (
 	"time"
 
 	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
-	"github.com/vaayne/anna/internal/agent"
-	"github.com/vaayne/anna/internal/agent/runner"
-	"github.com/vaayne/anna/internal/channel"
+	"github.com/vaayne/anna/pkg/channel"
 )
 
-// --- splitMessage ---
+// --- splitMessage (now uses channel.SplitMessage) ---
 
 func TestSplitMessageShort(t *testing.T) {
-	chunks := splitMessage("hello")
+	chunks := channel.SplitMessage("hello", feishuMaxMessageLen)
 	if len(chunks) != 1 || chunks[0] != "hello" {
 		t.Errorf("chunks = %v, want [hello]", chunks)
 	}
@@ -24,7 +22,7 @@ func TestSplitMessageShort(t *testing.T) {
 
 func TestSplitMessageExactLimit(t *testing.T) {
 	msg := strings.Repeat("a", feishuMaxMessageLen)
-	chunks := splitMessage(msg)
+	chunks := channel.SplitMessage(msg, feishuMaxMessageLen)
 	if len(chunks) != 1 {
 		t.Errorf("len(chunks) = %d, want 1", len(chunks))
 	}
@@ -32,7 +30,7 @@ func TestSplitMessageExactLimit(t *testing.T) {
 
 func TestSplitMessageLong(t *testing.T) {
 	msg := strings.Repeat("a", feishuMaxMessageLen+100)
-	chunks := splitMessage(msg)
+	chunks := channel.SplitMessage(msg, feishuMaxMessageLen)
 	if len(chunks) != 2 {
 		t.Fatalf("len(chunks) = %d, want 2", len(chunks))
 	}
@@ -49,7 +47,7 @@ func TestSplitMessageAtNewline(t *testing.T) {
 	part2 := strings.Repeat("b", 2000)
 	msg := part1 + "\n" + part2
 
-	chunks := splitMessage(msg)
+	chunks := channel.SplitMessage(msg, feishuMaxMessageLen)
 	if len(chunks) != 2 {
 		t.Fatalf("len(chunks) = %d, want 2", len(chunks))
 	}
@@ -61,7 +59,7 @@ func TestSplitMessageAtNewline(t *testing.T) {
 func TestSplitMessageMultibyteUTF8(t *testing.T) {
 	char := "中"
 	msg := strings.Repeat(char, feishuMaxMessageLen) // 3*feishuMaxMessageLen bytes
-	chunks := splitMessage(msg)
+	chunks := channel.SplitMessage(msg, feishuMaxMessageLen)
 	if len(chunks) < 2 {
 		t.Fatalf("expected multiple chunks, got %d", len(chunks))
 	}
@@ -73,7 +71,7 @@ func TestSplitMessageMultibyteUTF8(t *testing.T) {
 }
 
 func TestSplitMessageEmpty(t *testing.T) {
-	chunks := splitMessage("")
+	chunks := channel.SplitMessage("", feishuMaxMessageLen)
 	if len(chunks) != 1 || chunks[0] != "" {
 		t.Errorf("empty message should return single empty chunk, got %v", chunks)
 	}
@@ -126,7 +124,7 @@ func TestBuildStreamDisplayEmptyAll(t *testing.T) {
 // --- toolLine ---
 
 func TestToolLineRunning(t *testing.T) {
-	line := toolLine(&runner.ToolUseEvent{Tool: "bash", Status: "running", Input: "ls -la"})
+	line := toolLine(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "ls -la"})
 	if !strings.Contains(line, "bash") || !strings.Contains(line, "ls -la") {
 		t.Errorf("unexpected line: %q", line)
 	}
@@ -134,28 +132,28 @@ func TestToolLineRunning(t *testing.T) {
 
 func TestToolLineRunningTruncatesMultibyte(t *testing.T) {
 	input := strings.Repeat("中", 61)
-	line := toolLine(&runner.ToolUseEvent{Tool: "bash", Status: "running", Input: input})
+	line := toolLine(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: input})
 	if !strings.HasSuffix(line, "...") {
 		t.Errorf("expected truncation ellipsis, got %q", line)
 	}
 }
 
 func TestToolLineError(t *testing.T) {
-	line := toolLine(&runner.ToolUseEvent{Tool: "read", Status: "error"})
+	line := toolLine(&channel.ToolUseEvent{Tool: "read", Status: "error"})
 	if !strings.Contains(line, "failed") {
 		t.Errorf("unexpected line: %q", line)
 	}
 }
 
 func TestToolLineDefault(t *testing.T) {
-	line := toolLine(&runner.ToolUseEvent{Tool: "bash", Status: "done"})
+	line := toolLine(&channel.ToolUseEvent{Tool: "bash", Status: "done"})
 	if line != "" {
 		t.Errorf("expected empty, got %q", line)
 	}
 }
 
 func TestToolLineRunningNoInput(t *testing.T) {
-	line := toolLine(&runner.ToolUseEvent{Tool: "search", Status: "running"})
+	line := toolLine(&channel.ToolUseEvent{Tool: "search", Status: "running"})
 	if !strings.Contains(line, "search") {
 		t.Errorf("unexpected line: %q", line)
 	}
@@ -165,13 +163,13 @@ func TestToolLineRunningNoInput(t *testing.T) {
 }
 
 func TestToolLineUnknownTool(t *testing.T) {
-	line := toolLine(&runner.ToolUseEvent{Tool: "custom_tool", Status: "running", Input: "x"})
+	line := toolLine(&channel.ToolUseEvent{Tool: "custom_tool", Status: "running", Input: "x"})
 	if !strings.Contains(line, "🔧") {
 		t.Errorf("unknown tool should use default emoji: %q", line)
 	}
 }
 
-// --- filterModelsIndexed ---
+// --- filterModels (now uses channel.FilterModels) ---
 
 func TestFilterModelsIndexed(t *testing.T) {
 	models := []channel.ModelOption{
@@ -180,12 +178,12 @@ func TestFilterModelsIndexed(t *testing.T) {
 		{Provider: "openai", Model: "gpt-3.5"},
 	}
 
-	result := filterModelsIndexed(models, "openai")
+	result := channel.FilterModels(models, "openai")
 	if len(result) != 2 {
 		t.Fatalf("expected 2 matches, got %d", len(result))
 	}
-	if result[0].globalIdx != 1 || result[1].globalIdx != 3 {
-		t.Errorf("global indices should be 1 and 3, got %d and %d", result[0].globalIdx, result[1].globalIdx)
+	if result[0].GlobalIdx != 1 || result[1].GlobalIdx != 3 {
+		t.Errorf("global indices should be 1 and 3, got %d and %d", result[0].GlobalIdx, result[1].GlobalIdx)
 	}
 }
 
@@ -193,7 +191,7 @@ func TestFilterModelsIndexedNoMatch(t *testing.T) {
 	models := []channel.ModelOption{
 		{Provider: "openai", Model: "gpt-4"},
 	}
-	result := filterModelsIndexed(models, "gemini")
+	result := channel.FilterModels(models, "gemini")
 	if len(result) != 0 {
 		t.Errorf("expected 0 matches, got %d", len(result))
 	}
@@ -203,7 +201,7 @@ func TestFilterModelsIndexedCaseInsensitive(t *testing.T) {
 	models := []channel.ModelOption{
 		{Provider: "Anthropic", Model: "Claude-3"},
 	}
-	result := filterModelsIndexed(models, "CLAUDE")
+	result := channel.FilterModels(models, "CLAUDE")
 	if len(result) != 1 {
 		t.Fatalf("expected 1 match, got %d", len(result))
 	}
@@ -213,7 +211,7 @@ func TestFilterModelsIndexedCaseInsensitive(t *testing.T) {
 
 func TestNewValidConfig(t *testing.T) {
 	cfg := Config{AppID: "123", AppSecret: "secret"}
-	bot, err := New(cfg, nil, nil, nil, nil)
+	bot, err := New(cfg, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -226,14 +224,14 @@ func TestNewValidConfig(t *testing.T) {
 }
 
 func TestNewMissingAppID(t *testing.T) {
-	_, err := New(Config{AppSecret: "secret"}, nil, nil, nil, nil)
+	_, err := New(Config{AppSecret: "secret"}, nil)
 	if err == nil {
 		t.Fatal("expected error for missing app_id")
 	}
 }
 
 func TestNewMissingAppSecret(t *testing.T) {
-	_, err := New(Config{AppID: "123"}, nil, nil, nil, nil)
+	_, err := New(Config{AppID: "123"}, nil)
 	if err == nil {
 		t.Fatal("expected error for missing app_secret")
 	}
@@ -241,22 +239,9 @@ func TestNewMissingAppSecret(t *testing.T) {
 
 func TestNewCustomGroupMode(t *testing.T) {
 	cfg := Config{AppID: "1", AppSecret: "s", GroupMode: "always"}
-	bot, _ := New(cfg, nil, nil, nil, nil)
+	bot, _ := New(cfg, nil)
 	if bot.cfg.GroupMode != "always" {
 		t.Errorf("group_mode = %q, want %q", bot.cfg.GroupMode, "always")
-	}
-}
-
-// --- resolve session key format ---
-
-func TestResolveSessionKeyFormat(t *testing.T) {
-	got := agent.BuildSessionKey("anna", "feishu", "ou_123", "group:oc_456")
-	if got != "anna:feishu:ou_123:group:oc_456" {
-		t.Errorf("BuildSessionKey group = %q", got)
-	}
-	got = agent.BuildSessionKey("anna", "feishu", "ou_123", "private")
-	if got != "anna:feishu:ou_123:private" {
-		t.Errorf("BuildSessionKey private = %q", got)
 	}
 }
 
@@ -376,10 +361,10 @@ func TestDerefStrValue(t *testing.T) {
 // --- formatModelList ---
 
 func TestFormatModelListNoQuery(t *testing.T) {
-	models := []channel.ModelOption{
+	models := channel.IndexModels([]channel.ModelOption{
 		{Provider: "openai", Model: "gpt-4"},
 		{Provider: "anthropic", Model: "claude-3"},
-	}
+	})
 	out := formatModelList(models, "")
 	if !strings.Contains(out, "1. openai/gpt-4") {
 		t.Errorf("missing model entry in output: %s", out)
@@ -390,76 +375,12 @@ func TestFormatModelListNoQuery(t *testing.T) {
 }
 
 func TestFormatModelListWithQuery(t *testing.T) {
-	models := []channel.ModelOption{{Provider: "openai", Model: "gpt-4"}}
+	models := channel.IndexModels([]channel.ModelOption{
+		{Provider: "openai", Model: "gpt-4"},
+	})
 	out := formatModelList(models, "openai")
 	if !strings.Contains(out, `filter: "openai"`) {
 		t.Errorf("should show filter query: %s", out)
-	}
-}
-
-// --- handleCommand ---
-
-func TestHandleCommandHelp(t *testing.T) {
-	bot := &Bot{}
-	var reply string
-	handled := bot.handleCommand(&channel.ResolvedChat{SessionKey: "ch"}, "/help", "ou_test123", func(s string) { reply = s })
-	if !handled {
-		t.Fatal("expected /help to be handled")
-	}
-	if !strings.Contains(reply, "Anna") {
-		t.Errorf("unexpected reply: %s", reply)
-	}
-}
-
-func TestHandleCommandStart(t *testing.T) {
-	bot := &Bot{}
-	var reply string
-	handled := bot.handleCommand(&channel.ResolvedChat{SessionKey: "ch"}, "/start", "ou_test123", func(s string) { reply = s })
-	if !handled {
-		t.Fatal("expected /start to be handled")
-	}
-	if reply != channel.WelcomeMessage {
-		t.Errorf("unexpected reply: %s", reply)
-	}
-}
-
-func TestHandleCommandUnknown(t *testing.T) {
-	bot := &Bot{}
-	handled := bot.handleCommand(&channel.ResolvedChat{SessionKey: "ch"}, "hello world", "ou_test123", func(s string) {})
-	if handled {
-		t.Error("regular text should not be handled as command")
-	}
-}
-
-func TestHandleCommandEmpty(t *testing.T) {
-	bot := &Bot{}
-	handled := bot.handleCommand(&channel.ResolvedChat{SessionKey: "ch"}, "", "ou_test123", func(s string) {})
-	if handled {
-		t.Error("empty text should not be handled")
-	}
-}
-
-func TestHandleCommandWhoami(t *testing.T) {
-	bot := &Bot{}
-	var reply string
-	handled := bot.handleCommand(&channel.ResolvedChat{SessionKey: "ch"}, "/whoami", "ou_abc123", func(s string) { reply = s })
-	if !handled {
-		t.Fatal("expected /whoami to be handled")
-	}
-	if !strings.Contains(reply, "ou_abc123") {
-		t.Errorf("expected reply to contain sender open_id, got: %s", reply)
-	}
-}
-
-func TestHandleCommandAuthDeprecated(t *testing.T) {
-	bot := &Bot{}
-	var reply string
-	handled := bot.handleCommand(&channel.ResolvedChat{SessionKey: "ch"}, "/auth abc123", "ou_test123", func(s string) { reply = s })
-	if !handled {
-		t.Fatal("expected /auth to be handled")
-	}
-	if !strings.Contains(reply, "removed") || !strings.Contains(reply, "lark-cli") {
-		t.Errorf("unexpected reply: %s", reply)
 	}
 }
 
@@ -470,12 +391,12 @@ func TestHandleModelCommandListModels(t *testing.T) {
 		{Provider: "openai", Model: "gpt-4"},
 	}
 	bot := &Bot{
-		listFn:     func() []channel.ModelOption { return models },
-		chatModels: make(map[string]ModelOption),
+		handler:    &mockHandler{models: models},
+		chatModels: make(map[string]channel.ModelOption),
 	}
 
 	var reply string
-	bot.handleModelCommand(&channel.ResolvedChat{SessionKey: "ch"}, "", func(s string) { reply = s })
+	bot.handleModelCommand("", func(s string) { reply = s })
 	if !strings.Contains(reply, "openai/gpt-4") {
 		t.Errorf("expected model list, got: %s", reply)
 	}
@@ -487,12 +408,12 @@ func TestHandleModelCommandFilter(t *testing.T) {
 		{Provider: "anthropic", Model: "claude-3"},
 	}
 	bot := &Bot{
-		listFn:     func() []channel.ModelOption { return models },
-		chatModels: make(map[string]ModelOption),
+		handler:    &mockHandler{models: models},
+		chatModels: make(map[string]channel.ModelOption),
 	}
 
 	var reply string
-	bot.handleModelCommand(&channel.ResolvedChat{SessionKey: "ch"}, "claude", func(s string) { reply = s })
+	bot.handleModelCommand("claude", func(s string) { reply = s })
 	if !strings.Contains(reply, "claude-3") {
 		t.Errorf("expected filtered results with claude, got: %s", reply)
 	}
@@ -506,30 +427,30 @@ func TestHandleModelCommandFilterNoMatch(t *testing.T) {
 		{Provider: "openai", Model: "gpt-4"},
 	}
 	bot := &Bot{
-		listFn:     func() []channel.ModelOption { return models },
-		chatModels: make(map[string]ModelOption),
+		handler:    &mockHandler{models: models},
+		chatModels: make(map[string]channel.ModelOption),
 	}
 
 	var reply string
-	bot.handleModelCommand(&channel.ResolvedChat{SessionKey: "ch"}, "gemini", func(s string) { reply = s })
+	bot.handleModelCommand("gemini", func(s string) { reply = s })
 	if !strings.Contains(reply, "No models matching") {
 		t.Errorf("expected no match message, got: %s", reply)
 	}
 }
 
-func TestHandleModelCommandInvalidIndex(t *testing.T) {
+func TestHandleModelCommandSwitchByName(t *testing.T) {
 	models := []channel.ModelOption{
 		{Provider: "openai", Model: "gpt-4"},
 	}
 	bot := &Bot{
-		listFn:     func() []channel.ModelOption { return models },
-		chatModels: make(map[string]ModelOption),
+		handler:    &mockHandler{models: models},
+		chatModels: make(map[string]channel.ModelOption),
 	}
 
 	var reply string
-	bot.handleModelCommand(&channel.ResolvedChat{SessionKey: "ch"}, "5", func(s string) { reply = s })
-	if !strings.Contains(reply, "Invalid selection") {
-		t.Errorf("expected invalid selection, got: %s", reply)
+	bot.handleModelCommand("openai/gpt-4", func(s string) { reply = s })
+	if !strings.Contains(reply, "Switched to openai/gpt-4") {
+		t.Errorf("expected switch confirmation, got: %s", reply)
 	}
 }
 
@@ -538,13 +459,12 @@ func TestHandleModelCommandSwitchError(t *testing.T) {
 		{Provider: "openai", Model: "gpt-4"},
 	}
 	bot := &Bot{
-		listFn:     func() []channel.ModelOption { return models },
-		switchFn:   func(string, string) error { return fmt.Errorf("switch failed") },
-		chatModels: make(map[string]ModelOption),
+		handler:    &mockHandler{models: models, switchErr: fmt.Errorf("switch failed")},
+		chatModels: make(map[string]channel.ModelOption),
 	}
 
 	var reply string
-	bot.handleModelCommand(&channel.ResolvedChat{SessionKey: "ch"}, "1", func(s string) { reply = s })
+	bot.handleModelCommand("openai/gpt-4", func(s string) { reply = s })
 	if !strings.Contains(reply, "Error switching model") {
 		t.Errorf("expected switch error, got: %s", reply)
 	}
@@ -567,7 +487,7 @@ func TestSendImageInvalidBase64(t *testing.T) {
 	defer cancel()
 	bot := &Bot{ctx: ctx}
 	// Invalid base64 should log error but not panic.
-	bot.sendImage("target", "msg", runner.ImageEvent{Data: "not-valid-base64!!!"})
+	bot.sendImage("target", "msg", channel.ImageEvent{Data: "not-valid-base64!!!"})
 }
 
 // --- Stop ---
@@ -882,60 +802,14 @@ func TestExtractJSONIntStringValue(t *testing.T) {
 	}
 }
 
-// --- Thread session key ---
+// --- Thread helpers ---
 
-func TestThreadChannelCtxGroup(t *testing.T) {
-	ctx, isGroup := threadChannelCtx("oc_123", "group", "")
-	if ctx != "group:oc_123" {
-		t.Errorf("channelCtx = %q, want group:oc_123", ctx)
+func TestThreadReplyTarget(t *testing.T) {
+	if threadReplyTarget("msg1", "root1") != "root1" {
+		t.Error("should return rootID when non-empty")
 	}
-	if !isGroup {
-		t.Error("expected isGroup = true")
-	}
-}
-
-func TestThreadChannelCtxGroupWithThread(t *testing.T) {
-	ctx, isGroup := threadChannelCtx("oc_123", "group", "om_root1")
-	if ctx != "group:oc_123:thread:om_root1" {
-		t.Errorf("channelCtx = %q, want group:oc_123:thread:om_root1", ctx)
-	}
-	if !isGroup {
-		t.Error("expected isGroup = true")
-	}
-}
-
-func TestThreadChannelCtxPrivate(t *testing.T) {
-	ctx, isGroup := threadChannelCtx("", "p2p", "")
-	if ctx != "private" {
-		t.Errorf("channelCtx = %q, want private", ctx)
-	}
-	if isGroup {
-		t.Error("expected isGroup = false")
-	}
-}
-
-func TestThreadSessionKeyFormat(t *testing.T) {
-	got := agent.BuildSessionKey("anna", "feishu", "ou_123", "group:oc_456:thread:om_root1")
-	want := "anna:feishu:ou_123:group:oc_456:thread:om_root1"
-	if got != want {
-		t.Errorf("BuildSessionKey thread = %q, want %q", got, want)
-	}
-}
-
-func TestReplaceChannelCtxGroup(t *testing.T) {
-	key := "anna:feishu:ou_123:group:oc_456"
-	got := replaceChannelCtx(key, "group:oc_456:thread:om_root1")
-	want := "anna:feishu:ou_123:group:oc_456:thread:om_root1"
-	if got != want {
-		t.Errorf("replaceChannelCtx = %q, want %q", got, want)
-	}
-}
-
-func TestReplaceChannelCtxPrivate(t *testing.T) {
-	key := "anna:feishu:ou_123:private"
-	got := replaceChannelCtx(key, "private")
-	if got != key {
-		t.Errorf("replaceChannelCtx = %q, want %q", got, key)
+	if threadReplyTarget("msg1", "") != "msg1" {
+		t.Error("should return messageID when rootID is empty")
 	}
 }
 
@@ -1057,15 +931,16 @@ func TestStreamResponseElapsedTiming(t *testing.T) {
 	defer func() { nowFunc = origNow }()
 
 	// With no events, elapsed = end - start.
-	events := make(chan runner.Event)
+	events := make(chan channel.Event)
 	close(events)
 
-	// Bot with nil client — sendCardReplyInThread will fail gracefully.
+	// Bot with nil client -- sendCardReplyInThread will fail gracefully.
 	// We can't call it directly (nil panic), so just test the timing logic.
 	elapsed := end.Sub(start)
 	if elapsed != 3200*time.Millisecond {
 		t.Errorf("elapsed = %v, want 3.2s", elapsed)
 	}
+	_ = events // used to verify the type compiles
 }
 
 // --- Phase 5b: Per-group config ---
@@ -1205,4 +1080,35 @@ func TestOnReactionSelfReaction(t *testing.T) {
 	if err != nil {
 		t.Errorf("self-reaction should be ignored, got %v", err)
 	}
+}
+
+// --- mockHandler for tests ---
+
+type mockHandler struct {
+	models    []channel.ModelOption
+	switchErr error
+}
+
+func (m *mockHandler) HandleMessage(_ context.Context, _ channel.IncomingMessage) (*channel.ChatStream, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *mockHandler) HandleCommand(_ context.Context, _ channel.IncomingMessage, _, _ string) (string, bool) {
+	return "", false
+}
+
+func (m *mockHandler) ListAgents(_ context.Context, _ channel.IncomingMessage) ([]channel.AgentInfo, string, error) {
+	return nil, "", nil
+}
+
+func (m *mockHandler) SwitchAgent(_ context.Context, _ channel.IncomingMessage, _ string) error {
+	return nil
+}
+
+func (m *mockHandler) ListModels() []channel.ModelOption {
+	return m.models
+}
+
+func (m *mockHandler) SwitchModel(_, _ string) error {
+	return m.switchErr
 }

--- a/plugins/channels/feishu/feishu_test.go
+++ b/plugins/channels/feishu/feishu_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
+	"github.com/vaayne/anna/pkg/ai"
 	"github.com/vaayne/anna/pkg/channel"
 )
 
@@ -763,12 +764,15 @@ func TestBuildMessageContentUnsupportedType(t *testing.T) {
 		MessageId:   &msgID,
 	}
 	got := bot.buildMessageContent(msg)
-	str, ok := got.(string)
-	if !ok {
-		t.Fatalf("expected string, got %T", got)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(got))
 	}
-	if str != "[Unsupported message type: card_action]" {
-		t.Errorf("unsupported type = %q", str)
+	tc, ok := got[0].(ai.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", got[0])
+	}
+	if tc.Text != "[Unsupported message type: card_action]" {
+		t.Errorf("unsupported type = %q", tc.Text)
 	}
 }
 
@@ -1015,23 +1019,40 @@ func TestGroupSystemPromptEmpty(t *testing.T) {
 	}
 }
 
-func TestPrependSystemPromptString(t *testing.T) {
-	got := prependSystemPrompt("hello", "Be concise.")
-	str, ok := got.(string)
-	if !ok {
-		t.Fatalf("expected string, got %T", got)
+func TestPrependSystemPromptText(t *testing.T) {
+	content := channel.TextContent("hello")
+	got := prependSystemPrompt(content, "Be concise.")
+	if len(got) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(got))
 	}
-	if !strings.Contains(str, "[System: Be concise.]") || !strings.Contains(str, "hello") {
-		t.Errorf("prependSystemPrompt = %q", str)
+	prefix, ok := got[0].(ai.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent prefix, got %T", got[0])
+	}
+	if !strings.Contains(prefix.Text, "[System: Be concise.]") {
+		t.Errorf("prefix = %q", prefix.Text)
+	}
+	body, ok := got[1].(ai.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent body, got %T", got[1])
+	}
+	if body.Text != "hello" {
+		t.Errorf("body = %q", body.Text)
 	}
 }
 
-func TestPrependSystemPromptNonString(t *testing.T) {
-	// Non-string content should pass through unchanged.
-	original := []int{1, 2, 3}
-	got := prependSystemPrompt(original, "ignored")
-	if fmt.Sprintf("%v", got) != fmt.Sprintf("%v", original) {
-		t.Errorf("non-string content should be unchanged")
+func TestPrependSystemPromptImage(t *testing.T) {
+	content := []ai.ContentBlock{ai.ImageContent{Data: "abc", MimeType: "image/png"}}
+	got := prependSystemPrompt(content, "Be concise.")
+	if len(got) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(got))
+	}
+	prefix, ok := got[0].(ai.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent prefix, got %T", got[0])
+	}
+	if !strings.Contains(prefix.Text, "[System: Be concise.]") {
+		t.Errorf("prefix = %q", prefix.Text)
 	}
 }
 

--- a/plugins/channels/feishu/handler.go
+++ b/plugins/channels/feishu/handler.go
@@ -67,7 +67,8 @@ func (b *Bot) onReaction(ctx context.Context, event *larkim.P2MessageReactionCre
 	reactionText := fmt.Sprintf("[User reacted with %s on message %s]", emojiType, messageID)
 
 	msg := b.incomingMsg(openID, chatID, chatType, channel.TextContent(reactionText))
-	go b.handleMessage(msg, openID, chatID, messageID, rootID)
+	replyFn := func(reply string) { b.replyInThread(b.ctx, messageID, rootID, reply) }
+	go b.handleIncoming(msg, "", "", openID, chatID, messageID, rootID, replyFn)
 	return nil
 }
 
@@ -136,7 +137,7 @@ func (b *Bot) onMessage(ctx context.Context, event *larkim.P2MessageReceiveV1) e
 
 	incoming := b.incomingMsg(openID, chatID, chatType, content)
 
-	// Try shared commands via the handler.
+	// Handle plugin-local commands first.
 	if text != "" {
 		fields := strings.Fields(text)
 		if len(fields) > 0 {
@@ -151,15 +152,12 @@ func (b *Bot) onMessage(ctx context.Context, event *larkim.P2MessageReceiveV1) e
 				b.handleModelCommand(args, replyFn)
 				return nil
 			}
-
-			if resp, ok := b.handler.HandleCommand(b.ctx, incoming, cmd, args); ok {
-				replyFn(resp)
-				return nil
-			}
 		}
 	}
 
-	go b.handleMessage(incoming, openID, chatID, messageID, rootID)
+	// Parse command for coordinator (shared commands + chat streaming).
+	cmd, args := parseFeishuCommand(text)
+	go b.handleIncoming(incoming, cmd, args, openID, chatID, messageID, rootID, replyFn)
 	return nil
 }
 
@@ -393,7 +391,9 @@ func parseTextContent(raw string) string {
 }
 
 // handleMessage processes an incoming message by streaming the agent response.
-func (b *Bot) handleMessage(msg channel.IncomingMessage, openID, chatID, messageID, rootID string) {
+// handleIncoming delegates to the coordinator via HandleIncoming.
+// Shared commands are handled by the coordinator; otherwise a chat stream is returned.
+func (b *Bot) handleIncoming(msg channel.IncomingMessage, cmd, args, openID, chatID, messageID, rootID string, replyFn func(string)) {
 	// Create cancellable context for abort support.
 	ctx, cancel := context.WithCancel(b.ctx)
 	key := streamKey(chatID, rootID)
@@ -401,10 +401,14 @@ func (b *Bot) handleMessage(msg channel.IncomingMessage, openID, chatID, message
 	defer b.unregisterStream(key)
 	defer cancel()
 
-	stream, err := b.handler.HandleMessage(ctx, msg)
+	resp, handled, stream, err := b.handler.HandleIncoming(ctx, msg, cmd, args)
 	if err != nil {
 		logger().Error("chat failed", "open_id", openID, "error", err)
 		b.replyInThread(b.ctx, messageID, rootID, fmt.Sprintf("Session error: %v", err))
+		return
+	}
+	if handled {
+		replyFn(resp)
 		return
 	}
 
@@ -435,6 +439,17 @@ func (b *Bot) handleMessage(msg channel.IncomingMessage, openID, chatID, message
 	}
 
 	logger().Debug("response sent", "open_id", openID, "response_len", len(response), "images", len(images))
+}
+
+// parseFeishuCommand extracts command and args from text.
+func parseFeishuCommand(text string) (string, string) {
+	fields := strings.Fields(text)
+	if len(fields) == 0 || !strings.HasPrefix(fields[0], "/") {
+		return "", ""
+	}
+	cmd := fields[0]
+	args := channel.ParseCommandArgs(text, cmd)
+	return cmd, args
 }
 
 // replyText sends a text reply to a message.

--- a/plugins/channels/feishu/handler.go
+++ b/plugins/channels/feishu/handler.go
@@ -10,9 +10,8 @@ import (
 	"strings"
 
 	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
-	"github.com/vaayne/anna/internal/agent/runner"
-	"github.com/vaayne/anna/internal/channel"
 	"github.com/vaayne/anna/pkg/ai"
+	"github.com/vaayne/anna/pkg/channel"
 )
 
 // onReaction handles incoming Feishu reaction events.
@@ -67,13 +66,8 @@ func (b *Bot) onReaction(ctx context.Context, event *larkim.P2MessageReactionCre
 
 	reactionText := fmt.Sprintf("[User reacted with %s on message %s]", emojiType, messageID)
 
-	rc, err := b.resolveWithThread(openID, chatID, chatType, rootID)
-	if err != nil {
-		logger().Error("resolve for reaction failed", "open_id", openID, "error", err)
-		return nil
-	}
-
-	go b.handleMessage(rc, openID, chatID, messageID, rootID, reactionText)
+	msg := b.incomingMsg(openID, chatID, chatType, reactionText)
+	go b.handleMessage(msg, openID, chatID, messageID, rootID)
 	return nil
 }
 
@@ -111,7 +105,7 @@ func (b *Bot) onMessage(ctx context.Context, event *larkim.P2MessageReceiveV1) e
 		return nil
 	}
 
-	// Extract text once for cancel detection, commands, and link codes.
+	// Extract text once for cancel detection and commands.
 	text := parseTextContent(derefStr(msg.Content))
 	if chatType == "group" {
 		text = stripMentions(text, mentions)
@@ -133,24 +127,28 @@ func (b *Bot) onMessage(ctx context.Context, event *larkim.P2MessageReceiveV1) e
 
 	replyFn := func(reply string) { b.replyInThread(b.ctx, messageID, rootID, reply) }
 
-	rc, err := b.resolveWithThread(openID, chatID, chatType, rootID)
-	if err != nil {
-		logger().Error("resolve failed", "open_id", openID, "error", err)
-		replyFn(fmt.Sprintf("Error: %v", err))
-		return nil
-	}
+	incoming := b.incomingMsg(openID, chatID, chatType, content)
 
-	// Try link code before anything else.
-	if b.authStore != nil && b.linkCodes != nil && text != "" {
-		if resp, ok := channel.TryLinkCode(b.ctx, b.authStore, b.linkCodes, text, channel.PlatformFeishu, openID, ""); ok {
-			replyFn(resp)
-			return nil
-		}
-	}
-
+	// Try shared commands via the handler.
 	if text != "" {
-		if handled := b.handleCommand(rc, text, openID, replyFn); handled {
-			return nil
+		fields := strings.Fields(text)
+		if len(fields) > 0 {
+			cmd := fields[0]
+			args := channel.ParseCommandArgs(text, cmd)
+
+			switch strings.ToLower(cmd) {
+			case "/auth":
+				replyFn("The /auth command was removed. Feishu workspace OAuth is no longer supported. If you need Lark workspace access, install a lark-cli skill and run `lark-cli auth login --recommend`.")
+				return nil
+			case "/model":
+				b.handleModelCommand(args, replyFn)
+				return nil
+			}
+
+			if resp, ok := b.handler.HandleCommand(b.ctx, incoming, cmd, args); ok {
+				replyFn(resp)
+				return nil
+			}
 		}
 	}
 
@@ -158,15 +156,16 @@ func (b *Bot) onMessage(ctx context.Context, event *larkim.P2MessageReceiveV1) e
 	if chatType == "group" {
 		if sp := b.groupSystemPrompt(chatID); sp != "" {
 			content = prependSystemPrompt(content, sp)
+			incoming.Content = content
 		}
 	}
 
-	go b.handleMessage(rc, openID, chatID, messageID, rootID, content)
+	go b.handleMessage(incoming, openID, chatID, messageID, rootID)
 	return nil
 }
 
 // prependSystemPrompt adds a system prompt prefix to message content.
-func prependSystemPrompt(content runner.MessageContent, prompt string) runner.MessageContent {
+func prependSystemPrompt(content any, prompt string) any {
 	switch c := content.(type) {
 	case string:
 		return fmt.Sprintf("[System: %s]\n\n%s", prompt, c)
@@ -177,7 +176,7 @@ func prependSystemPrompt(content runner.MessageContent, prompt string) runner.Me
 }
 
 // buildMessageContent constructs the message content from a Feishu message.
-func (b *Bot) buildMessageContent(msg *larkim.EventMessage) runner.MessageContent {
+func (b *Bot) buildMessageContent(msg *larkim.EventMessage) any {
 	msgType := derefStr(msg.MessageType)
 	rawContent := derefStr(msg.Content)
 	messageID := derefStr(msg.MessageId)
@@ -400,7 +399,7 @@ func parseTextContent(raw string) string {
 }
 
 // handleMessage processes an incoming message by streaming the agent response.
-func (b *Bot) handleMessage(rc *channel.ResolvedChat, openID, chatID, messageID, rootID string, content runner.MessageContent) {
+func (b *Bot) handleMessage(msg channel.IncomingMessage, openID, chatID, messageID, rootID string) {
 	// Create cancellable context for abort support.
 	ctx, cancel := context.WithCancel(b.ctx)
 	key := streamKey(chatID, rootID)
@@ -408,19 +407,19 @@ func (b *Bot) handleMessage(rc *channel.ResolvedChat, openID, chatID, messageID,
 	defer b.unregisterStream(key)
 	defer cancel()
 
-	events, sessionID, err := rc.Chat(ctx, content)
+	stream, err := b.handler.HandleMessage(ctx, msg)
 	if err != nil {
 		logger().Error("chat failed", "open_id", openID, "error", err)
 		b.replyInThread(b.ctx, messageID, rootID, fmt.Sprintf("Session error: %v", err))
 		return
 	}
 
-	logger().Debug("message received", "open_id", openID, "session", sessionID, "root_id", rootID)
+	logger().Debug("message received", "open_id", openID, "session", stream.SessionID, "root_id", rootID)
 
-	sentMsgID, response, images, elapsed, streamErr := b.streamResponseInThread(events, chatID, messageID, rootID)
+	sentMsgID, response, images, elapsed, streamErr := b.streamResponseInThread(stream.Events, chatID, messageID, rootID)
 
 	if streamErr != nil {
-		logger().Error("agent stream error", "session_id", sessionID, "error", streamErr)
+		logger().Error("agent stream error", "session_id", stream.SessionID, "error", streamErr)
 		if response == "" {
 			response = fmt.Sprintf("Agent error: %v", streamErr)
 		} else {
@@ -442,36 +441,6 @@ func (b *Bot) handleMessage(rc *channel.ResolvedChat, openID, chatID, messageID,
 	}
 
 	logger().Debug("response sent", "open_id", openID, "response_len", len(response), "images", len(images))
-}
-
-// handleCommand checks if text is a bot command and handles it.
-func (b *Bot) handleCommand(rc *channel.ResolvedChat, text, senderID string, reply func(string)) bool {
-	if resp, ok := channel.HandleCommand(b.ctx, rc, text, senderID); ok {
-		reply(resp)
-		return true
-	}
-
-	fields := strings.Fields(text)
-	if len(fields) == 0 {
-		return false
-	}
-	cmd := strings.ToLower(fields[0])
-
-	args := channel.ParseCommandArgs(text, fields[0])
-
-	switch cmd {
-	case "/auth":
-		reply("The /auth command was removed. Feishu workspace OAuth is no longer supported. If you need Lark workspace access, install a lark-cli skill and run `lark-cli auth login --recommend`.")
-		return true
-	case "/model":
-		b.handleModelCommand(rc, args, reply)
-		return true
-	case "/agent":
-		channel.HandleAgentCommand(b.ctx, b.agentCmd, rc, args, reply)
-		return true
-	}
-
-	return false
 }
 
 // replyText sends a text reply to a message.

--- a/plugins/channels/feishu/handler.go
+++ b/plugins/channels/feishu/handler.go
@@ -151,6 +151,9 @@ func (b *Bot) onMessage(ctx context.Context, event *larkim.P2MessageReceiveV1) e
 			case "/model":
 				b.handleModelCommand(args, replyFn)
 				return nil
+			case "/agent":
+				b.handleAgentCommand(incoming, args, replyFn)
+				return nil
 			}
 		}
 	}

--- a/plugins/channels/feishu/handler.go
+++ b/plugins/channels/feishu/handler.go
@@ -66,7 +66,7 @@ func (b *Bot) onReaction(ctx context.Context, event *larkim.P2MessageReactionCre
 
 	reactionText := fmt.Sprintf("[User reacted with %s on message %s]", emojiType, messageID)
 
-	msg := b.incomingMsg(openID, chatID, chatType, reactionText)
+	msg := b.incomingMsg(openID, chatID, chatType, channel.TextContent(reactionText))
 	go b.handleMessage(msg, openID, chatID, messageID, rootID)
 	return nil
 }
@@ -127,6 +127,13 @@ func (b *Bot) onMessage(ctx context.Context, event *larkim.P2MessageReceiveV1) e
 
 	replyFn := func(reply string) { b.replyInThread(b.ctx, messageID, rootID, reply) }
 
+	// Prepend per-group system prompt to content if configured.
+	if chatType == "group" {
+		if sp := b.groupSystemPrompt(chatID); sp != "" {
+			content = prependSystemPrompt(content, sp)
+		}
+	}
+
 	incoming := b.incomingMsg(openID, chatID, chatType, content)
 
 	// Try shared commands via the handler.
@@ -152,31 +159,18 @@ func (b *Bot) onMessage(ctx context.Context, event *larkim.P2MessageReceiveV1) e
 		}
 	}
 
-	// Prepend per-group system prompt to content if configured.
-	if chatType == "group" {
-		if sp := b.groupSystemPrompt(chatID); sp != "" {
-			content = prependSystemPrompt(content, sp)
-			incoming.Content = content
-		}
-	}
-
 	go b.handleMessage(incoming, openID, chatID, messageID, rootID)
 	return nil
 }
 
 // prependSystemPrompt adds a system prompt prefix to message content.
-func prependSystemPrompt(content any, prompt string) any {
-	switch c := content.(type) {
-	case string:
-		return fmt.Sprintf("[System: %s]\n\n%s", prompt, c)
-	default:
-		// For non-text content (images, etc.), wrap as-is.
-		return content
-	}
+func prependSystemPrompt(content []ai.ContentBlock, prompt string) []ai.ContentBlock {
+	prefix := ai.TextContent{Text: fmt.Sprintf("[System: %s]", prompt)}
+	return append([]ai.ContentBlock{prefix}, content...)
 }
 
 // buildMessageContent constructs the message content from a Feishu message.
-func (b *Bot) buildMessageContent(msg *larkim.EventMessage) any {
+func (b *Bot) buildMessageContent(msg *larkim.EventMessage) []ai.ContentBlock {
 	msgType := derefStr(msg.MessageType)
 	rawContent := derefStr(msg.Content)
 	messageID := derefStr(msg.MessageId)
@@ -188,13 +182,13 @@ func (b *Bot) buildMessageContent(msg *larkim.EventMessage) any {
 		if strings.TrimSpace(text) == "" {
 			return nil
 		}
-		return text
+		return channel.TextContent(text)
 
 	case "post":
 		if strings.TrimSpace(rawContent) == "" {
 			return nil
 		}
-		return rawContent
+		return channel.TextContent(rawContent)
 
 	case "image":
 		imageKey := extractJSONField(rawContent, "image_key")
@@ -214,32 +208,32 @@ func (b *Bot) buildMessageContent(msg *larkim.EventMessage) any {
 		}
 
 	case "audio":
-		return parseAudioContent(rawContent)
+		return channel.TextContent(parseAudioContent(rawContent))
 
 	case "video", "media":
-		return parseVideoContent(rawContent)
+		return channel.TextContent(parseVideoContent(rawContent))
 
 	case "file":
-		return parseFileContent(rawContent)
+		return channel.TextContent(parseFileContent(rawContent))
 
 	case "sticker":
-		return parseStickerContent(rawContent)
+		return channel.TextContent(parseStickerContent(rawContent))
 
 	case "location":
-		return parseLocationContent(rawContent)
+		return channel.TextContent(parseLocationContent(rawContent))
 
 	case "share_chat":
-		return parseShareChatContent(rawContent)
+		return channel.TextContent(parseShareChatContent(rawContent))
 
 	case "share_user":
-		return parseShareUserContent(rawContent)
+		return channel.TextContent(parseShareUserContent(rawContent))
 
 	case "merge_forward":
-		return parseMergeForwardContent(rawContent)
+		return channel.TextContent(parseMergeForwardContent(rawContent))
 
 	default:
 		logger().Debug("unsupported message type", "type", msgType)
-		return fmt.Sprintf("[Unsupported message type: %s]", msgType)
+		return channel.TextContent(fmt.Sprintf("[Unsupported message type: %s]", msgType))
 	}
 }
 

--- a/plugins/channels/feishu/model.go
+++ b/plugins/channels/feishu/model.go
@@ -36,18 +36,8 @@ func (b *Bot) handleModelCommand(args string, reply func(string)) {
 
 // switchModelByName handles model switching by "provider/model" name.
 func (b *Bot) switchModelByName(name string, reply func(string)) {
-	name = strings.ToLower(strings.TrimSpace(name))
-	models := b.handler.ListModels()
-	var selected channel.ModelOption
-	found := false
-	for _, m := range models {
-		if strings.ToLower(m.Provider+"/"+m.Model) == name {
-			selected = m
-			found = true
-			break
-		}
-	}
-	if !found {
+	selected, ok := channel.FindModelByName(b.handler.ListModels(), name)
+	if !ok {
 		reply(fmt.Sprintf("Unknown model %q, use /model to list available models.", name))
 		return
 	}

--- a/plugins/channels/feishu/model.go
+++ b/plugins/channels/feishu/model.go
@@ -2,92 +2,66 @@ package feishu
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
-	"github.com/vaayne/anna/internal/channel"
+	"github.com/vaayne/anna/pkg/channel"
 )
 
-// ModelOption re-exports channel.ModelOption for use by callers.
-type ModelOption = channel.ModelOption
-
-// ModelListFunc re-exports channel.ModelListFunc for use by callers.
-type ModelListFunc = channel.ModelListFunc
-
-// ModelSwitchFunc re-exports channel.ModelSwitchFunc for use by callers.
-type ModelSwitchFunc = channel.ModelSwitchFunc
-
 // handleModelCommand processes /model with optional arguments.
-// No args → list models; number → switch by index; text → filter.
-func (b *Bot) handleModelCommand(rc *channel.ResolvedChat, args string, reply func(string)) {
-	models := b.listFn()
+// No args -> list models; number -> switch by index; text -> filter.
+func (b *Bot) handleModelCommand(args string, reply func(string)) {
+	query := channel.ParseModelArgs(args)
+	models := b.handler.ListModels()
 
-	if args == "" {
-		reply(formatModelList(models, ""))
+	if query == "" {
+		indexed := channel.IndexModels(models)
+		reply(formatModelList(indexed, ""))
 		return
 	}
 
-	// Numeric arg → direct switch by 1-based global index.
-	if idx, err := strconv.Atoi(args); err == nil {
-		b.switchModel(rc, models, idx, reply)
+	// Check if it's a direct "provider/model" name.
+	if strings.Contains(query, "/") {
+		b.switchModelByName(query, reply)
 		return
 	}
 
-	// Text arg → filter models by substring match.
-	filtered := filterModelsIndexed(models, args)
+	// Text arg -> filter models by substring match.
+	filtered := channel.FilterModels(models, query)
 	if len(filtered) == 0 {
-		reply(fmt.Sprintf("No models matching %q.", args))
+		reply(fmt.Sprintf("No models matching %q.", query))
 		return
 	}
-	reply(formatIndexedModelList(filtered, args))
+	reply(formatModelList(filtered, query))
 }
 
-// switchModel handles model switching by 1-based index.
-func (b *Bot) switchModel(rc *channel.ResolvedChat, models []ModelOption, idx int, reply func(string)) {
-	if idx < 1 || idx > len(models) {
-		reply(fmt.Sprintf("Invalid selection. Use a number between 1 and %d.", len(models)))
-		return
-	}
-	selected := models[idx-1]
-	if b.switchFn != nil {
-		if err := b.switchFn(selected.Provider, selected.Model); err != nil {
-			reply(fmt.Sprintf("Error switching model: %v", err))
-			return
+// switchModelByName handles model switching by "provider/model" name.
+func (b *Bot) switchModelByName(name string, reply func(string)) {
+	name = strings.ToLower(strings.TrimSpace(name))
+	models := b.handler.ListModels()
+	var selected channel.ModelOption
+	found := false
+	for _, m := range models {
+		if strings.ToLower(m.Provider+"/"+m.Model) == name {
+			selected = m
+			found = true
+			break
 		}
 	}
-	if _, err := rc.RotateSession(); err != nil {
-		logger().Error("rotate session after model switch failed", "key", rc.SessionKey, "error", err)
+	if !found {
+		reply(fmt.Sprintf("Unknown model %q, use /model to list available models.", name))
+		return
 	}
-	b.mu.Lock()
-	b.chatModels[rc.SessionKey] = selected
-	b.mu.Unlock()
-	logger().Info("model switched", "key", rc.SessionKey, "provider", selected.Provider, "model", selected.Model)
+
+	if err := b.handler.SwitchModel(selected.Provider, selected.Model); err != nil {
+		reply(fmt.Sprintf("Error switching model: %v", err))
+		return
+	}
+	logger().Info("model switched", "provider", selected.Provider, "model", selected.Model)
 	reply(fmt.Sprintf("Switched to %s/%s. Session reset.", selected.Provider, selected.Model))
 }
 
-// indexedModel pairs a ModelOption with its 1-based global index.
-type indexedModel struct {
-	ModelOption
-	globalIdx int
-}
-
 // formatModelList builds a text-based model list with 1-based numbered entries.
-func formatModelList(models []ModelOption, query string) string {
-	var sb strings.Builder
-	sb.WriteString("Available models")
-	if query != "" {
-		fmt.Fprintf(&sb, " (filter: %q)", query)
-	}
-	sb.WriteString(":\n\n")
-	for i, m := range models {
-		fmt.Fprintf(&sb, "%d. %s/%s\n", i+1, m.Provider, m.Model)
-	}
-	sb.WriteString("\nUse /model <number> to switch.")
-	return sb.String()
-}
-
-// formatIndexedModelList builds a text list preserving global indices.
-func formatIndexedModelList(models []indexedModel, query string) string {
+func formatModelList(models []channel.IndexedModel, query string) string {
 	var sb strings.Builder
 	sb.WriteString("Available models")
 	if query != "" {
@@ -95,22 +69,8 @@ func formatIndexedModelList(models []indexedModel, query string) string {
 	}
 	sb.WriteString(":\n\n")
 	for _, m := range models {
-		fmt.Fprintf(&sb, "%d. %s/%s\n", m.globalIdx, m.Provider, m.Model)
+		fmt.Fprintf(&sb, "%d. %s/%s\n", m.GlobalIdx, m.Provider, m.Model)
 	}
 	sb.WriteString("\nUse /model <number> to switch.")
 	return sb.String()
-}
-
-// filterModelsIndexed returns indexed models matching the query,
-// preserving their 1-based global indices from the full list.
-func filterModelsIndexed(models []ModelOption, query string) []indexedModel {
-	query = strings.ToLower(query)
-	var out []indexedModel
-	for i, m := range models {
-		label := strings.ToLower(m.Provider + "/" + m.Model)
-		if strings.Contains(label, query) {
-			out = append(out, indexedModel{ModelOption: m, globalIdx: i + 1})
-		}
-	}
-	return out
 }

--- a/plugins/channels/feishu/model.go
+++ b/plugins/channels/feishu/model.go
@@ -1,7 +1,9 @@
 package feishu
 
 import (
+	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/vaayne/anna/pkg/channel"
@@ -25,6 +27,12 @@ func (b *Bot) handleModelCommand(args string, reply func(string)) {
 		return
 	}
 
+	// Check if it's a 1-based index number.
+	if idx, err := strconv.Atoi(query); err == nil {
+		b.switchModelByIdx(idx, reply)
+		return
+	}
+
 	// Text arg -> filter models by substring match.
 	filtered := channel.FilterModels(models, query)
 	if len(filtered) == 0 {
@@ -32,6 +40,23 @@ func (b *Bot) handleModelCommand(args string, reply func(string)) {
 		return
 	}
 	reply(formatModelList(filtered, query))
+}
+
+// switchModelByIdx handles model switching by 1-based index.
+func (b *Bot) switchModelByIdx(idx int, reply func(string)) {
+	models := b.handler.ListModels()
+	if idx < 1 || idx > len(models) {
+		reply(fmt.Sprintf("Invalid selection, use a number between 1 and %d.", len(models)))
+		return
+	}
+	selected := models[idx-1]
+
+	if err := b.handler.SwitchModel(selected.Provider, selected.Model); err != nil {
+		reply(fmt.Sprintf("Error switching model: %v", err))
+		return
+	}
+	logger().Info("model switched", "provider", selected.Provider, "model", selected.Model)
+	reply(fmt.Sprintf("Switched to %s/%s. Session reset.", selected.Provider, selected.Model))
 }
 
 // switchModelByName handles model switching by "provider/model" name.
@@ -48,6 +73,31 @@ func (b *Bot) switchModelByName(name string, reply func(string)) {
 	}
 	logger().Info("model switched", "provider", selected.Provider, "model", selected.Model)
 	reply(fmt.Sprintf("Switched to %s/%s. Session reset.", selected.Provider, selected.Model))
+}
+
+// handleAgentCommand processes /agent with optional arguments.
+func (b *Bot) handleAgentCommand(incoming channel.IncomingMessage, args string, reply func(string)) {
+	// Direct switch by slug.
+	if args != "" {
+		if err := b.handler.SwitchAgent(context.Background(), incoming, args); err != nil {
+			reply(fmt.Sprintf("Error switching agent: %v", err))
+			return
+		}
+		logger().Info("agent switched", "agent_id", args)
+		reply(fmt.Sprintf("Switched to agent: %s", args))
+		return
+	}
+
+	agents, currentAgentID, err := b.handler.ListAgents(context.Background(), incoming)
+	if err != nil {
+		reply(fmt.Sprintf("Error listing agents: %v", err))
+		return
+	}
+	if len(agents) == 0 {
+		reply("No agents available.")
+		return
+	}
+	reply(channel.FormatAgentList(channel.IndexAgents(agents), currentAgentID))
 }
 
 // formatModelList builds a text-based model list with 1-based numbered entries.

--- a/plugins/channels/feishu/render.go
+++ b/plugins/channels/feishu/render.go
@@ -4,16 +4,14 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
-	"strings"
-	"unicode/utf8"
 
 	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
-	"github.com/vaayne/anna/internal/agent/runner"
+	"github.com/vaayne/anna/pkg/channel"
 )
 
 // sendImage decodes a base64 image, uploads it to Feishu to obtain an image_key,
 // then sends it as an image message in the chat.
-func (b *Bot) sendImage(chatID, replyMsgID string, img runner.ImageEvent) {
+func (b *Bot) sendImage(chatID, replyMsgID string, img channel.ImageEvent) {
 	data, err := base64.StdEncoding.DecodeString(img.Data)
 	if err != nil {
 		logger().Error("decode image failed", "error", err)
@@ -60,34 +58,4 @@ func (b *Bot) sendImage(chatID, replyMsgID string, img runner.ImageEvent) {
 	if !resp.Success() {
 		logger().Error("send image api error", "code", resp.Code, "msg", resp.Msg)
 	}
-}
-
-// splitMessage splits a message into chunks that fit within Feishu's message
-// length limit. It tries to split at newline boundaries when possible.
-func splitMessage(text string) []string {
-	if len(text) <= feishuMaxMessageLen {
-		return []string{text}
-	}
-
-	var chunks []string
-	for len(text) > 0 {
-		if len(text) <= feishuMaxMessageLen {
-			chunks = append(chunks, text)
-			break
-		}
-
-		cutAt := feishuMaxMessageLen
-		// Avoid splitting in the middle of a multi-byte UTF-8 character.
-		for cutAt > 0 && !utf8.RuneStart(text[cutAt]) {
-			cutAt--
-		}
-		if idx := strings.LastIndex(text[:cutAt], "\n"); idx > 0 {
-			cutAt = idx + 1
-		}
-
-		chunks = append(chunks, text[:cutAt])
-		text = text[cutAt:]
-	}
-
-	return chunks
 }

--- a/plugins/channels/feishu/stream.go
+++ b/plugins/channels/feishu/stream.go
@@ -7,7 +7,7 @@ import (
 	"unicode/utf8"
 
 	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
-	"github.com/vaayne/anna/internal/agent/runner"
+	"github.com/vaayne/anna/pkg/channel"
 )
 
 const streamEditInterval = time.Second
@@ -33,7 +33,7 @@ var toolEmoji = map[string]string{
 }
 
 // toolLine returns a short status line for a tool-use event.
-func toolLine(t *runner.ToolUseEvent) string {
+func toolLine(t *channel.ToolUseEvent) string {
 	emoji, ok := toolEmoji[t.Tool]
 	if !ok {
 		emoji = toolEmoji["default"]
@@ -77,14 +77,14 @@ var nowFunc = time.Now
 //  1. Thinking: sends initial card with "Thinking..." immediately
 //  2. Generating: updates card with streaming content + cursor
 //  3. Complete: final content with elapsed time footer
-func (b *Bot) streamResponseInThread(events <-chan runner.Event, chatID, replyMsgID, rootID string) (string, string, []runner.ImageEvent, time.Duration, error) {
+func (b *Bot) streamResponseInThread(events <-chan channel.Event, chatID, replyMsgID, rootID string) (string, string, []channel.ImageEvent, time.Duration, error) {
 	startTime := nowFunc()
 
 	var sb strings.Builder
 	var streamErr error
 	var currentTool string
 	var sentMsgID string
-	var images []runner.ImageEvent
+	var images []channel.ImageEvent
 	phase := phaseThinking
 	lastSend := time.Time{}
 
@@ -134,7 +134,7 @@ func (b *Bot) streamResponseInThread(events <-chan runner.Event, chatID, replyMs
 			continue
 		}
 
-		// Phase 2: Generating — content with cursor.
+		// Phase 2: Generating -- content with cursor.
 		display := buildStreamDisplay(current, currentTool)
 
 		if sentMsgID == "" {
@@ -153,7 +153,7 @@ func (b *Bot) streamResponseInThread(events <-chan runner.Event, chatID, replyMs
 		lastSend = now
 	}
 
-	// Phase 3: Complete — remove cursor (final patch is handled by handleMessage
+	// Phase 3: Complete -- remove cursor (final patch is handled by handleMessage
 	// via sendFinalResponseInThread with elapsed time appended).
 	elapsed := nowFunc().Sub(startTime)
 

--- a/plugins/channels/feishu/stream.go
+++ b/plugins/channels/feishu/stream.go
@@ -23,39 +23,6 @@ const (
 	phaseComplete                      // Stream finished
 )
 
-var toolEmoji = map[string]string{
-	"bash":    "⚡",
-	"read":    "📖",
-	"write":   "✏️",
-	"edit":    "🔧",
-	"search":  "🔍",
-	"default": "🔧",
-}
-
-// toolLine returns a short status line for a tool-use event.
-func toolLine(t *channel.ToolUseEvent) string {
-	emoji, ok := toolEmoji[t.Tool]
-	if !ok {
-		emoji = toolEmoji["default"]
-	}
-	switch t.Status {
-	case "running":
-		input := t.Input
-		if utf8.RuneCountInString(input) > 60 {
-			r := []rune(input)
-			input = string(r[:57]) + "..."
-		}
-		if input != "" {
-			return fmt.Sprintf("%s %s: %s", emoji, t.Tool, input)
-		}
-		return fmt.Sprintf("%s %s", emoji, t.Tool)
-	case "error":
-		return fmt.Sprintf("❌ %s failed", t.Tool)
-	default:
-		return ""
-	}
-}
-
 // thinkingContent returns the card content for the thinking phase.
 func thinkingContent() string {
 	return "⏳ Thinking..."
@@ -108,7 +75,7 @@ func (b *Bot) streamResponseInThread(events <-chan channel.Event, chatID, replyM
 		}
 
 		if evt.ToolUse != nil {
-			line := toolLine(evt.ToolUse)
+			line := channel.ToolLine(evt.ToolUse)
 			if line != "" {
 				currentTool = line
 			} else {

--- a/plugins/channels/feishu/thread.go
+++ b/plugins/channels/feishu/thread.go
@@ -3,26 +3,8 @@ package feishu
 import (
 	"context"
 
-	"github.com/vaayne/anna/internal/agent/runner"
-	"github.com/vaayne/anna/internal/channel"
+	"github.com/vaayne/anna/pkg/channel"
 )
-
-// threadChannelCtx builds a channelCtx string that includes thread context.
-// When rootID is non-empty, the session is scoped to the thread; otherwise
-// it falls back to the regular group or private context.
-func threadChannelCtx(chatID, chatType, rootID string) (channelCtx string, isGroup bool) {
-	isGroup = chatType == "group"
-	if isGroup && chatID != "" {
-		if rootID != "" {
-			channelCtx = "group:" + chatID + ":thread:" + rootID
-		} else {
-			channelCtx = "group:" + chatID
-		}
-	} else {
-		channelCtx = "private"
-	}
-	return channelCtx, isGroup
-}
 
 // threadReplyTarget returns rootID if non-empty (thread reply), otherwise messageID.
 func threadReplyTarget(messageID, rootID string) string {
@@ -49,7 +31,7 @@ func (b *Bot) sendFinalResponseInThread(chatID, replyMsgID, rootID, sentMsgID, r
 	replyTo := threadReplyTarget(replyMsgID, rootID)
 
 	if sentMsgID != "" {
-		chunks := splitMessage(response)
+		chunks := channel.SplitMessage(response, feishuMaxMessageLen)
 		if err := b.patchMessage(sentMsgID, chunks[0]); err != nil {
 			logger().Error("final update failed", "error", err, "chat_id", chatID)
 		}
@@ -61,7 +43,7 @@ func (b *Bot) sendFinalResponseInThread(chatID, replyMsgID, rootID, sentMsgID, r
 		return
 	}
 
-	chunks := splitMessage(response)
+	chunks := channel.SplitMessage(response, feishuMaxMessageLen)
 	for _, chunk := range chunks {
 		if _, err := b.sendCardReply(replyTo, chunk); err != nil {
 			logger().Error("send final response failed", "error", err, "chat_id", chatID)
@@ -70,57 +52,6 @@ func (b *Bot) sendFinalResponseInThread(chatID, replyMsgID, rootID, sentMsgID, r
 }
 
 // sendImageInThread sends an image in the correct thread context.
-func (b *Bot) sendImageInThread(chatID, replyMsgID, rootID string, img runner.ImageEvent) {
+func (b *Bot) sendImageInThread(chatID, replyMsgID, rootID string, img channel.ImageEvent) {
 	b.sendImage(chatID, threadReplyTarget(replyMsgID, rootID), img)
-}
-
-// resolveWithThread performs resolution with thread-aware channelCtx.
-func (b *Bot) resolveWithThread(openID, chatID, chatType, rootID string) (*channel.ResolvedChat, error) {
-	channelCtx, isGroup := threadChannelCtx(chatID, chatType, rootID)
-
-	// Use the channelCtx-aware resolve path. The standard resolve() builds
-	// its own channelCtx from isGroup+chatID, but for threads we need a
-	// custom channelCtx. We call channel.Resolve directly with the group
-	// flag and then override the session key.
-	rc, err := channel.Resolve(
-		context.Background(),
-		b.poolManager,
-		b.store,
-		b.authStore,
-		b.engine,
-		channel.PlatformFeishu,
-		openID,
-		"",
-		chatID,
-		isGroup,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	// Override session key when in a thread (channelCtx differs from
-	// the default "group:chatID").
-	if rootID != "" && isGroup {
-		rc.SessionKey = replaceChannelCtx(rc.SessionKey, channelCtx)
-	}
-
-	return rc, nil
-}
-
-// replaceChannelCtx replaces the channelCtx suffix in a session key.
-// Session key format: {prefix}:{channelCtx}
-// For group sessions the channelCtx is "group:chatID"; we replace it
-// with the thread-aware variant.
-func replaceChannelCtx(sessionKey, newCtx string) string {
-	// The channelCtx is the last colon-separated segment(s) that starts
-	// with "group:" or "private". We find "group:" and replace from there.
-	for i := 0; i < len(sessionKey); i++ {
-		if i+6 <= len(sessionKey) && sessionKey[i:i+6] == "group:" {
-			return sessionKey[:i] + newCtx
-		}
-		if i+7 <= len(sessionKey) && sessionKey[i:i+7] == "private" {
-			return sessionKey[:i] + newCtx
-		}
-	}
-	return sessionKey
 }

--- a/plugins/channels/qq/handler.go
+++ b/plugins/channels/qq/handler.go
@@ -19,7 +19,6 @@ func (b *Bot) c2cMessageHandler() event.C2CMessageEventHandler {
 	return func(_ *dto.WSPayload, data *dto.WSC2CMessageData) error {
 		msg := (*dto.Message)(data)
 		authorID := msg.Author.ID
-		text := strings.TrimSpace(msg.Content)
 
 		content := b.buildMessageContent(msg)
 		if content == nil {
@@ -29,13 +28,13 @@ func (b *Bot) c2cMessageHandler() event.C2CMessageEventHandler {
 		replyFn := func(reply string) { b.replyC2C(b.ctx, authorID, msg.ID, reply) }
 		incoming := incomingMsg(authorID, "", content)
 
-		if text != "" {
-			if handled := b.handleCommand(incoming, text, replyFn); handled {
-				return nil
-			}
+		text := strings.TrimSpace(msg.Content)
+		if handled := b.handleLocalCommand(incoming, text, replyFn); handled {
+			return nil
 		}
 
-		b.handleMessage(authorID, "", msg.ID, incoming, scopeC2C)
+		cmd, args := parseCommand(text)
+		b.handleIncoming(authorID, "", msg.ID, incoming, cmd, args, scopeC2C)
 		return nil
 	}
 }
@@ -60,13 +59,12 @@ func (b *Bot) groupATMessageHandler() event.GroupATMessageEventHandler {
 		incoming := incomingMsg(authorID, groupID, content)
 
 		text := strings.TrimSpace(msg.Content)
-		if text != "" {
-			if handled := b.handleCommand(incoming, text, replyFn); handled {
-				return nil
-			}
+		if handled := b.handleLocalCommand(incoming, text, replyFn); handled {
+			return nil
 		}
 
-		b.handleMessage(authorID, groupID, msg.ID, incoming, scopeGroup)
+		cmd, args := parseCommand(text)
+		b.handleIncoming(authorID, groupID, msg.ID, incoming, cmd, args, scopeGroup)
 		return nil
 	}
 }
@@ -164,17 +162,23 @@ func downloadImage(ctx context.Context, rawURL string) ([]byte, string, error) {
 	return data, mime, nil
 }
 
-// handleMessage processes an incoming message by streaming the agent response.
-func (b *Bot) handleMessage(authorID, groupID, msgID string, incoming channel.IncomingMessage, scope messageScope) {
+// handleIncoming delegates to the coordinator via HandleIncoming.
+// The coordinator handles shared commands (/start, /new, /compact, /whoami, /link);
+// if not a command, it streams a chat response.
+func (b *Bot) handleIncoming(authorID, groupID, msgID string, incoming channel.IncomingMessage, cmd, args string, scope messageScope) {
 	replyTarget := authorID
 	if groupID != "" {
 		replyTarget = groupID
 	}
 
-	stream, err := b.handler.HandleMessage(b.ctx, incoming)
+	resp, handled, stream, err := b.handler.HandleIncoming(b.ctx, incoming, cmd, args)
 	if err != nil {
 		logger().Error("chat failed", "author", authorID, "error", err)
 		b.sendReply(replyTarget, msgID, fmt.Sprintf("Session error: %v", err), scope)
+		return
+	}
+	if handled {
+		b.sendReply(replyTarget, msgID, resp, scope)
 		return
 	}
 
@@ -204,20 +208,12 @@ func (b *Bot) handleMessage(authorID, groupID, msgID string, incoming channel.In
 	logger().Debug("response sent", "author", authorID, "response_len", len(response), "images", len(images))
 }
 
-// handleCommand checks if text is a bot command and handles it.
-// Returns true if the text was a command.
-func (b *Bot) handleCommand(incoming channel.IncomingMessage, text string, reply func(string)) bool {
-	fields := strings.Fields(text)
-	if len(fields) == 0 {
+// handleLocalCommand handles plugin-local commands (/model, /agent, /help, /whoami).
+// Returns true if the text was handled.
+func (b *Bot) handleLocalCommand(incoming channel.IncomingMessage, text string, reply func(string)) bool {
+	cmd, args := parseCommand(text)
+	if cmd == "" {
 		return false
-	}
-	cmd := strings.ToLower(fields[0])
-	args := channel.ParseCommandArgs(text, fields[0])
-
-	// Try shared commands via handler (/start, /new, /compact, /whoami, /help, /link).
-	if resp, ok := b.handler.HandleCommand(b.ctx, incoming, cmd, args); ok {
-		reply(resp)
-		return true
 	}
 
 	switch cmd {
@@ -227,9 +223,26 @@ func (b *Bot) handleCommand(incoming channel.IncomingMessage, text string, reply
 	case "/agent":
 		b.handleAgentCommand(incoming, args, reply)
 		return true
+	case "/help":
+		reply(channel.WelcomeMessage)
+		return true
+	case "/whoami":
+		reply(fmt.Sprintf("Your sender ID: %s", incoming.SenderID))
+		return true
 	}
 
 	return false
+}
+
+// parseCommand extracts the command and arguments from text.
+func parseCommand(text string) (string, string) {
+	fields := strings.Fields(text)
+	if len(fields) == 0 || !strings.HasPrefix(fields[0], "/") {
+		return "", ""
+	}
+	cmd := strings.ToLower(fields[0])
+	args := channel.ParseCommandArgs(text, fields[0])
+	return cmd, args
 }
 
 // shouldRespondInGroup checks whether the bot should respond based on group_mode.

--- a/plugins/channels/qq/handler.go
+++ b/plugins/channels/qq/handler.go
@@ -81,7 +81,7 @@ const (
 
 // buildMessageContent constructs the message content from a QQ message.
 // Returns nil if the message has no usable content.
-func (b *Bot) buildMessageContent(msg *dto.Message) any {
+func (b *Bot) buildMessageContent(msg *dto.Message) []ai.ContentBlock {
 	text := strings.TrimSpace(msg.Content)
 	images := extractImageAttachments(msg)
 
@@ -90,7 +90,7 @@ func (b *Bot) buildMessageContent(msg *dto.Message) any {
 	}
 
 	if len(images) == 0 {
-		return text
+		return channel.TextContent(text)
 	}
 
 	var blocks []ai.ContentBlock

--- a/plugins/channels/qq/handler.go
+++ b/plugins/channels/qq/handler.go
@@ -10,9 +10,8 @@ import (
 
 	"github.com/tencent-connect/botgo/dto"
 	"github.com/tencent-connect/botgo/event"
-	"github.com/vaayne/anna/internal/agent/runner"
-	"github.com/vaayne/anna/internal/channel"
 	"github.com/vaayne/anna/pkg/ai"
+	"github.com/vaayne/anna/pkg/channel"
 )
 
 // c2cMessageHandler returns a handler for private (C2C) messages.
@@ -20,15 +19,7 @@ func (b *Bot) c2cMessageHandler() event.C2CMessageEventHandler {
 	return func(_ *dto.WSPayload, data *dto.WSC2CMessageData) error {
 		msg := (*dto.Message)(data)
 		authorID := msg.Author.ID
-
-		// Try link code before anything else.
 		text := strings.TrimSpace(msg.Content)
-		if b.authStore != nil && b.linkCodes != nil && text != "" {
-			if resp, ok := channel.TryLinkCode(b.ctx, b.authStore, b.linkCodes, text, channel.PlatformQQ, authorID, ""); ok {
-				b.replyC2C(b.ctx, authorID, msg.ID, resp)
-				return nil
-			}
-		}
 
 		content := b.buildMessageContent(msg)
 		if content == nil {
@@ -36,21 +27,15 @@ func (b *Bot) c2cMessageHandler() event.C2CMessageEventHandler {
 		}
 
 		replyFn := func(reply string) { b.replyC2C(b.ctx, authorID, msg.ID, reply) }
-
-		rc, err := b.resolve(authorID, "")
-		if err != nil {
-			logger().Error("resolve failed", "user_id", authorID, "error", err)
-			replyFn(fmt.Sprintf("Error: %v", err))
-			return nil
-		}
+		incoming := incomingMsg(authorID, "", content)
 
 		if text != "" {
-			if handled := b.handleCommand(rc, text, authorID, replyFn); handled {
+			if handled := b.handleCommand(incoming, text, replyFn); handled {
 				return nil
 			}
 		}
 
-		b.handleMessage(rc, authorID, "", msg.ID, content, scopeC2C)
+		b.handleMessage(authorID, "", msg.ID, incoming, scopeC2C)
 		return nil
 	}
 }
@@ -72,22 +57,16 @@ func (b *Bot) groupATMessageHandler() event.GroupATMessageEventHandler {
 		}
 
 		replyFn := func(reply string) { b.replyGroup(b.ctx, groupID, msg.ID, reply) }
-
-		rc, err := b.resolve(authorID, groupID)
-		if err != nil {
-			logger().Error("resolve failed", "user_id", authorID, "group_id", groupID, "error", err)
-			replyFn(fmt.Sprintf("Error: %v", err))
-			return nil
-		}
+		incoming := incomingMsg(authorID, groupID, content)
 
 		text := strings.TrimSpace(msg.Content)
 		if text != "" {
-			if handled := b.handleCommand(rc, text, authorID, replyFn); handled {
+			if handled := b.handleCommand(incoming, text, replyFn); handled {
 				return nil
 			}
 		}
 
-		b.handleMessage(rc, authorID, groupID, msg.ID, content, scopeGroup)
+		b.handleMessage(authorID, groupID, msg.ID, incoming, scopeGroup)
 		return nil
 	}
 }
@@ -102,7 +81,7 @@ const (
 
 // buildMessageContent constructs the message content from a QQ message.
 // Returns nil if the message has no usable content.
-func (b *Bot) buildMessageContent(msg *dto.Message) runner.MessageContent {
+func (b *Bot) buildMessageContent(msg *dto.Message) any {
 	text := strings.TrimSpace(msg.Content)
 	images := extractImageAttachments(msg)
 
@@ -186,25 +165,25 @@ func downloadImage(ctx context.Context, rawURL string) ([]byte, string, error) {
 }
 
 // handleMessage processes an incoming message by streaming the agent response.
-func (b *Bot) handleMessage(rc *channel.ResolvedChat, authorID, groupID, msgID string, content runner.MessageContent, scope messageScope) {
+func (b *Bot) handleMessage(authorID, groupID, msgID string, incoming channel.IncomingMessage, scope messageScope) {
 	replyTarget := authorID
 	if groupID != "" {
 		replyTarget = groupID
 	}
 
-	events, sessionID, err := rc.Chat(b.ctx, content)
+	stream, err := b.handler.HandleMessage(b.ctx, incoming)
 	if err != nil {
 		logger().Error("chat failed", "author", authorID, "error", err)
 		b.sendReply(replyTarget, msgID, fmt.Sprintf("Session error: %v", err), scope)
 		return
 	}
 
-	logger().Debug("message received", "author", authorID, "session", sessionID)
+	logger().Debug("message received", "author", authorID, "session", stream.SessionID)
 
-	response, images, streamErr := b.streamResponse(events, authorID, groupID, msgID, scope)
+	response, images, streamErr := b.streamResponse(stream.Events, authorID, groupID, msgID, scope)
 
 	if streamErr != nil {
-		logger().Error("agent stream error", "session_id", sessionID, "error", streamErr)
+		logger().Error("agent stream error", "session_id", stream.SessionID, "error", streamErr)
 		if response == "" {
 			response = fmt.Sprintf("Agent error: %v", streamErr)
 		} else {
@@ -227,27 +206,26 @@ func (b *Bot) handleMessage(rc *channel.ResolvedChat, authorID, groupID, msgID s
 
 // handleCommand checks if text is a bot command and handles it.
 // Returns true if the text was a command.
-func (b *Bot) handleCommand(rc *channel.ResolvedChat, text, senderID string, reply func(string)) bool {
-	// Try shared handler first.
-	if resp, ok := channel.HandleCommand(b.ctx, rc, text, senderID); ok {
-		reply(resp)
-		return true
-	}
-
+func (b *Bot) handleCommand(incoming channel.IncomingMessage, text string, reply func(string)) bool {
 	fields := strings.Fields(text)
 	if len(fields) == 0 {
 		return false
 	}
 	cmd := strings.ToLower(fields[0])
-
 	args := channel.ParseCommandArgs(text, fields[0])
+
+	// Try shared commands via handler (/start, /new, /compact, /whoami, /help, /link).
+	if resp, ok := b.handler.HandleCommand(b.ctx, incoming, cmd, args); ok {
+		reply(resp)
+		return true
+	}
 
 	switch cmd {
 	case "/model":
-		b.handleModelCommand(rc, args, reply)
+		b.handleModelCommand(args, reply)
 		return true
 	case "/agent":
-		channel.HandleAgentCommand(b.ctx, b.agentCmd, rc, args, reply)
+		b.handleAgentCommand(incoming, args, reply)
 		return true
 	}
 

--- a/plugins/channels/qq/model.go
+++ b/plugins/channels/qq/model.go
@@ -1,15 +1,16 @@
 package qq
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
-	"github.com/vaayne/anna/internal/channel"
+	"github.com/vaayne/anna/pkg/channel"
 )
 
 // modelList returns models optionally filtered by query.
 func (b *Bot) modelList(query string) []channel.IndexedModel {
-	models := b.listFn()
+	models := b.handler.ListModels()
 	if query == "" {
 		return channel.IndexModels(models)
 	}
@@ -17,13 +18,13 @@ func (b *Bot) modelList(query string) []channel.IndexedModel {
 }
 
 // handleModelCommand processes /model with optional arguments.
-// No args → list models; text with "/" → switch by name; text → filter.
-func (b *Bot) handleModelCommand(rc *channel.ResolvedChat, args string, reply func(string)) {
+// No args -> list models; text with "/" -> switch by name; text -> filter.
+func (b *Bot) handleModelCommand(args string, reply func(string)) {
 	query := channel.ParseModelArgs(args)
 
 	// If the query looks like "provider/model", try switching directly.
 	if query != "" && strings.Contains(query, "/") {
-		b.switchModelByName(rc, query, reply)
+		b.switchModelByName(query, reply)
 		return
 	}
 
@@ -40,9 +41,9 @@ func (b *Bot) handleModelCommand(rc *channel.ResolvedChat, args string, reply fu
 }
 
 // switchModelByName handles model switching by "provider/model" name.
-func (b *Bot) switchModelByName(rc *channel.ResolvedChat, name string, reply func(string)) {
+func (b *Bot) switchModelByName(name string, reply func(string)) {
 	name = strings.ToLower(strings.TrimSpace(name))
-	models := b.listFn()
+	models := b.handler.ListModels()
 	var selected channel.ModelOption
 	found := false
 	for _, m := range models {
@@ -57,21 +58,37 @@ func (b *Bot) switchModelByName(rc *channel.ResolvedChat, name string, reply fun
 		return
 	}
 
-	if _, err := rc.RotateSession(); err != nil {
-		reply(fmt.Sprintf("Error rotating session: %v", err))
+	if err := b.handler.SwitchModel(selected.Provider, selected.Model); err != nil {
+		reply(fmt.Sprintf("Error switching model: %v", err))
 		return
 	}
-	if b.switchFn != nil {
-		if err := b.switchFn(selected.Provider, selected.Model); err != nil {
-			reply(fmt.Sprintf("Error switching model: %v", err))
+	logger().Info("model switched", "provider", selected.Provider, "model", selected.Model)
+	reply(fmt.Sprintf("Switched to %s/%s. Session reset.", selected.Provider, selected.Model))
+}
+
+// handleAgentCommand processes /agent with optional arguments.
+func (b *Bot) handleAgentCommand(incoming channel.IncomingMessage, args string, reply func(string)) {
+	// Direct switch by slug.
+	if args != "" {
+		if err := b.handler.SwitchAgent(context.Background(), incoming, args); err != nil {
+			reply(fmt.Sprintf("Error switching agent: %v", err))
 			return
 		}
+		logger().Info("agent switched", "agent_id", args)
+		reply(fmt.Sprintf("Switched to agent: %s", args))
+		return
 	}
-	b.mu.Lock()
-	b.chatModels[rc.SessionKey] = selected
-	b.mu.Unlock()
-	logger().Info("model switched", "key", rc.SessionKey, "provider", selected.Provider, "model", selected.Model)
-	reply(fmt.Sprintf("Switched to %s/%s. Session reset.", selected.Provider, selected.Model))
+
+	agents, currentAgentID, err := b.handler.ListAgents(context.Background(), incoming)
+	if err != nil {
+		reply(fmt.Sprintf("Error listing agents: %v", err))
+		return
+	}
+	if len(agents) == 0 {
+		reply("No agents available.")
+		return
+	}
+	reply(formatAgentList(channel.IndexAgents(agents), currentAgentID))
 }
 
 // formatModelList builds a text-based model list.
@@ -86,5 +103,20 @@ func formatModelList(models []channel.IndexedModel, query string) string {
 		fmt.Fprintf(&sb, "• %s/%s\n", m.Provider, m.Model)
 	}
 	sb.WriteString("\nUse /model <provider/model> to switch.")
+	return sb.String()
+}
+
+// formatAgentList builds a text-based agent list.
+func formatAgentList(agents []channel.IndexedAgent, currentAgentID string) string {
+	var sb strings.Builder
+	sb.WriteString("Available agents:\n\n")
+	for _, ag := range agents {
+		prefix := "• "
+		if ag.ID == currentAgentID {
+			prefix = "✅ "
+		}
+		fmt.Fprintf(&sb, "%s%s (%s)\n", prefix, ag.ID, ag.Name)
+	}
+	sb.WriteString("\nUse /agent <slug> to switch.")
 	return sb.String()
 }

--- a/plugins/channels/qq/model.go
+++ b/plugins/channels/qq/model.go
@@ -37,23 +37,13 @@ func (b *Bot) handleModelCommand(args string, reply func(string)) {
 		}
 		return
 	}
-	reply(formatModelList(models, query))
+	reply(channel.FormatModelList(models, query))
 }
 
 // switchModelByName handles model switching by "provider/model" name.
 func (b *Bot) switchModelByName(name string, reply func(string)) {
-	name = strings.ToLower(strings.TrimSpace(name))
-	models := b.handler.ListModels()
-	var selected channel.ModelOption
-	found := false
-	for _, m := range models {
-		if strings.ToLower(m.Provider+"/"+m.Model) == name {
-			selected = m
-			found = true
-			break
-		}
-	}
-	if !found {
+	selected, ok := channel.FindModelByName(b.handler.ListModels(), name)
+	if !ok {
 		reply(fmt.Sprintf("Unknown model %q, use /model to list available models.", name))
 		return
 	}
@@ -88,35 +78,5 @@ func (b *Bot) handleAgentCommand(incoming channel.IncomingMessage, args string, 
 		reply("No agents available.")
 		return
 	}
-	reply(formatAgentList(channel.IndexAgents(agents), currentAgentID))
-}
-
-// formatModelList builds a text-based model list.
-func formatModelList(models []channel.IndexedModel, query string) string {
-	var sb strings.Builder
-	sb.WriteString("Available models")
-	if query != "" {
-		fmt.Fprintf(&sb, " (filter: %q)", query)
-	}
-	sb.WriteString(":\n\n")
-	for _, m := range models {
-		fmt.Fprintf(&sb, "• %s/%s\n", m.Provider, m.Model)
-	}
-	sb.WriteString("\nUse /model <provider/model> to switch.")
-	return sb.String()
-}
-
-// formatAgentList builds a text-based agent list.
-func formatAgentList(agents []channel.IndexedAgent, currentAgentID string) string {
-	var sb strings.Builder
-	sb.WriteString("Available agents:\n\n")
-	for _, ag := range agents {
-		prefix := "• "
-		if ag.ID == currentAgentID {
-			prefix = "✅ "
-		}
-		fmt.Fprintf(&sb, "%s%s (%s)\n", prefix, ag.ID, ag.Name)
-	}
-	sb.WriteString("\nUse /agent <slug> to switch.")
-	return sb.String()
+	reply(channel.FormatAgentList(channel.IndexAgents(agents), currentAgentID))
 }

--- a/plugins/channels/qq/qq.go
+++ b/plugins/channels/qq/qq.go
@@ -35,7 +35,7 @@ type Bot struct {
 	creds          *token.QQBotCredentials
 	tokenSource    oauth2.TokenSource
 	sessionManager botgo.SessionManager
-	handler        channel.MessageHandler
+	handler        channel.Handler
 
 	chatModels map[string]channel.ModelOption
 
@@ -45,7 +45,7 @@ type Bot struct {
 }
 
 // New creates a QQ bot. Call Start to begin receiving events.
-func New(cfg Config, handler channel.MessageHandler) (*Bot, error) {
+func New(cfg Config, handler channel.Handler) (*Bot, error) {
 	if cfg.AppID == "" || cfg.AppSecret == "" {
 		return nil, fmt.Errorf("qq: app_id and app_secret are required")
 	}

--- a/plugins/channels/qq/qq.go
+++ b/plugins/channels/qq/qq.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tencent-connect/botgo/event"
 	"github.com/tencent-connect/botgo/openapi"
 	"github.com/tencent-connect/botgo/token"
+	"github.com/vaayne/anna/pkg/ai"
 	"github.com/vaayne/anna/pkg/channel"
 	"golang.org/x/oauth2"
 )
@@ -159,7 +160,7 @@ func channelForGroup(groupID string) string {
 }
 
 // incomingMsg builds an IncomingMessage from QQ message context.
-func incomingMsg(authorID, groupID string, content any) channel.IncomingMessage {
+func incomingMsg(authorID, groupID string, content []ai.ContentBlock) channel.IncomingMessage {
 	chatID := channelForC2C(authorID)
 	isGroup := groupID != ""
 	if isGroup {

--- a/plugins/channels/qq/qq.go
+++ b/plugins/channels/qq/qq.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/tencent-connect/botgo"
@@ -13,10 +12,7 @@ import (
 	"github.com/tencent-connect/botgo/event"
 	"github.com/tencent-connect/botgo/openapi"
 	"github.com/tencent-connect/botgo/token"
-	"github.com/vaayne/anna/internal/agent"
-	"github.com/vaayne/anna/internal/auth"
-	"github.com/vaayne/anna/internal/channel"
-	"github.com/vaayne/anna/internal/config"
+	"github.com/vaayne/anna/pkg/channel"
 	"golang.org/x/oauth2"
 )
 
@@ -38,16 +34,8 @@ type Bot struct {
 	creds          *token.QQBotCredentials
 	tokenSource    oauth2.TokenSource
 	sessionManager botgo.SessionManager
-	poolManager    *agent.PoolManager
-	store          config.Store
-	authStore      auth.AuthStore
-	engine         *auth.PolicyEngine
-	linkCodes      *auth.LinkCodeStore
-	agentCmd       *channel.AgentCommander
-	listFn         channel.ModelListFunc
-	switchFn       channel.ModelSwitchFunc
+	handler        channel.MessageHandler
 
-	mu         sync.RWMutex
 	chatModels map[string]channel.ModelOption
 
 	cfg    Config
@@ -55,22 +43,8 @@ type Bot struct {
 	cancel context.CancelFunc
 }
 
-// BotOption configures the QQ Bot.
-type BotOption func(*Bot)
-
-// WithAuth configures the bot with auth store and link code store for
-// account linking support.
-func WithAuth(authStore auth.AuthStore, engine *auth.PolicyEngine, linkCodes *auth.LinkCodeStore) BotOption {
-	return func(b *Bot) {
-		b.authStore = authStore
-		b.engine = engine
-		b.linkCodes = linkCodes
-		b.agentCmd = channel.NewAgentCommander(b.store, authStore)
-	}
-}
-
 // New creates a QQ bot. Call Start to begin receiving events.
-func New(cfg Config, pm *agent.PoolManager, store config.Store, listFn channel.ModelListFunc, switchFn channel.ModelSwitchFunc, opts ...BotOption) (*Bot, error) {
+func New(cfg Config, handler channel.MessageHandler) (*Bot, error) {
 	if cfg.AppID == "" || cfg.AppSecret == "" {
 		return nil, fmt.Errorf("qq: app_id and app_secret are required")
 	}
@@ -80,17 +54,9 @@ func New(cfg Config, pm *agent.PoolManager, store config.Store, listFn channel.M
 	}
 
 	b := &Bot{
-		poolManager: pm,
-		store:       store,
-		agentCmd:    channel.NewAgentCommander(store, nil),
-		listFn:      listFn,
-		switchFn:    switchFn,
-		chatModels:  make(map[string]channel.ModelOption),
-		cfg:         cfg,
-	}
-
-	for _, opt := range opts {
-		opt(b)
+		handler:    handler,
+		chatModels: make(map[string]channel.ModelOption),
+		cfg:        cfg,
 	}
 
 	return b, nil
@@ -192,19 +158,19 @@ func channelForGroup(groupID string) string {
 	return "qq:group:" + groupID
 }
 
-// resolve performs full user/agent/pool/session-key resolution for the
-// given QQ message context. Call once per incoming message or command.
-func (b *Bot) resolve(authorID, groupID string) (*channel.ResolvedChat, error) {
-	return channel.Resolve(
-		context.Background(),
-		b.poolManager,
-		b.store,
-		b.authStore,
-		b.engine,
-		channel.PlatformQQ,
-		authorID,
-		"",
-		groupID,
-		groupID != "",
-	)
+// incomingMsg builds an IncomingMessage from QQ message context.
+func incomingMsg(authorID, groupID string, content any) channel.IncomingMessage {
+	chatID := channelForC2C(authorID)
+	isGroup := groupID != ""
+	if isGroup {
+		chatID = channelForGroup(groupID)
+	}
+	return channel.IncomingMessage{
+		Platform:   channel.PlatformQQ,
+		SenderID:   authorID,
+		SenderName: "",
+		ChatID:     chatID,
+		IsGroup:    isGroup,
+		Content:    content,
+	}
 }

--- a/plugins/channels/qq/qq_test.go
+++ b/plugins/channels/qq/qq_test.go
@@ -9,10 +9,7 @@ import (
 	"testing"
 
 	"github.com/tencent-connect/botgo/dto"
-	"github.com/vaayne/anna/internal/agent"
-	"github.com/vaayne/anna/internal/agent/runner"
-	"github.com/vaayne/anna/internal/channel"
-	"github.com/vaayne/anna/internal/memory"
+	"github.com/vaayne/anna/pkg/channel"
 )
 
 // --- SplitMessage (shared) ---
@@ -128,7 +125,7 @@ func TestBuildStreamDisplayEmptyAll(t *testing.T) {
 // --- toolLine ---
 
 func TestToolLineRunning(t *testing.T) {
-	line := toolLine(&runner.ToolUseEvent{Tool: "bash", Status: "running", Input: "ls -la"})
+	line := toolLine(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "ls -la"})
 	if !strings.Contains(line, "bash") || !strings.Contains(line, "ls -la") {
 		t.Errorf("unexpected line: %q", line)
 	}
@@ -136,14 +133,14 @@ func TestToolLineRunning(t *testing.T) {
 
 func TestToolLineRunningTruncatesMultibyte(t *testing.T) {
 	input := strings.Repeat("中", 61)
-	line := toolLine(&runner.ToolUseEvent{Tool: "bash", Status: "running", Input: input})
+	line := toolLine(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: input})
 	if !strings.HasSuffix(line, "...") {
 		t.Errorf("expected truncation ellipsis, got %q", line)
 	}
 }
 
 func TestToolLineRunningNoInput(t *testing.T) {
-	line := toolLine(&runner.ToolUseEvent{Tool: "search", Status: "running"})
+	line := toolLine(&channel.ToolUseEvent{Tool: "search", Status: "running"})
 	if !strings.Contains(line, "search") {
 		t.Errorf("unexpected line: %q", line)
 	}
@@ -153,21 +150,21 @@ func TestToolLineRunningNoInput(t *testing.T) {
 }
 
 func TestToolLineError(t *testing.T) {
-	line := toolLine(&runner.ToolUseEvent{Tool: "read", Status: "error"})
+	line := toolLine(&channel.ToolUseEvent{Tool: "read", Status: "error"})
 	if !strings.Contains(line, "failed") {
 		t.Errorf("unexpected line: %q", line)
 	}
 }
 
 func TestToolLineDefault(t *testing.T) {
-	line := toolLine(&runner.ToolUseEvent{Tool: "bash", Status: "done"})
+	line := toolLine(&channel.ToolUseEvent{Tool: "bash", Status: "done"})
 	if line != "" {
 		t.Errorf("expected empty, got %q", line)
 	}
 }
 
 func TestToolLineUnknownTool(t *testing.T) {
-	line := toolLine(&runner.ToolUseEvent{Tool: "custom_tool", Status: "running", Input: "x"})
+	line := toolLine(&channel.ToolUseEvent{Tool: "custom_tool", Status: "running", Input: "x"})
 	if !strings.Contains(line, "🔧") {
 		t.Errorf("unknown tool should use default emoji: %q", line)
 	}
@@ -211,7 +208,7 @@ func TestFilterModelsCaseInsensitive(t *testing.T) {
 
 func TestNewValidConfig(t *testing.T) {
 	cfg := Config{AppID: "123", AppSecret: "secret"}
-	bot, err := New(cfg, nil, nil, nil, nil)
+	bot, err := New(cfg, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -224,14 +221,14 @@ func TestNewValidConfig(t *testing.T) {
 }
 
 func TestNewMissingAppID(t *testing.T) {
-	_, err := New(Config{AppSecret: "secret"}, nil, nil, nil, nil)
+	_, err := New(Config{AppSecret: "secret"}, nil)
 	if err == nil {
 		t.Fatal("expected error for missing app_id")
 	}
 }
 
 func TestNewMissingAppSecret(t *testing.T) {
-	_, err := New(Config{AppID: "123"}, nil, nil, nil, nil)
+	_, err := New(Config{AppID: "123"}, nil)
 	if err == nil {
 		t.Fatal("expected error for missing app_secret")
 	}
@@ -239,7 +236,7 @@ func TestNewMissingAppSecret(t *testing.T) {
 
 func TestNewCustomGroupMode(t *testing.T) {
 	cfg := Config{AppID: "1", AppSecret: "s", GroupMode: "always"}
-	bot, _ := New(cfg, nil, nil, nil, nil)
+	bot, _ := New(cfg, nil)
 	if bot.cfg.GroupMode != "always" {
 		t.Errorf("group_mode = %q, want %q", bot.cfg.GroupMode, "always")
 	}
@@ -424,10 +421,63 @@ func TestDownloadImageDetectsMIME(t *testing.T) {
 
 // --- handleCommand ---
 
+// mockHandler implements channel.MessageHandler for tests.
+type mockHandler struct {
+	handleCommandFn func(ctx context.Context, msg channel.IncomingMessage, cmd, args string) (string, bool)
+	listModelsFn    func() []channel.ModelOption
+	switchModelFn   func(provider, model string) error
+	listAgentsFn    func(ctx context.Context, msg channel.IncomingMessage) ([]channel.AgentInfo, string, error)
+	switchAgentFn   func(ctx context.Context, msg channel.IncomingMessage, slug string) error
+}
+
+func (m *mockHandler) HandleMessage(context.Context, channel.IncomingMessage) (*channel.ChatStream, error) {
+	return nil, nil
+}
+func (m *mockHandler) HandleCommand(ctx context.Context, msg channel.IncomingMessage, cmd, args string) (string, bool) {
+	if m.handleCommandFn != nil {
+		return m.handleCommandFn(ctx, msg, cmd, args)
+	}
+	// Default: handle /help, /start, /whoami
+	switch cmd {
+	case "/help":
+		return "Anna help text", true
+	case "/start":
+		return channel.WelcomeMessage, true
+	case "/whoami":
+		return fmt.Sprintf("Your user ID: %s", msg.SenderID), true
+	}
+	return "", false
+}
+func (m *mockHandler) ListAgents(ctx context.Context, msg channel.IncomingMessage) ([]channel.AgentInfo, string, error) {
+	if m.listAgentsFn != nil {
+		return m.listAgentsFn(ctx, msg)
+	}
+	return nil, "", nil
+}
+func (m *mockHandler) SwitchAgent(ctx context.Context, msg channel.IncomingMessage, slug string) error {
+	if m.switchAgentFn != nil {
+		return m.switchAgentFn(ctx, msg, slug)
+	}
+	return nil
+}
+func (m *mockHandler) ListModels() []channel.ModelOption {
+	if m.listModelsFn != nil {
+		return m.listModelsFn()
+	}
+	return nil
+}
+func (m *mockHandler) SwitchModel(provider, model string) error {
+	if m.switchModelFn != nil {
+		return m.switchModelFn(provider, model)
+	}
+	return nil
+}
+
 func TestHandleCommandHelp(t *testing.T) {
-	bot := &Bot{}
+	bot := &Bot{handler: &mockHandler{}}
 	var reply string
-	handled := bot.handleCommand(&channel.ResolvedChat{SessionKey: "ch"}, "/help", "user123", func(s string) { reply = s })
+	incoming := incomingMsg("user123", "", "")
+	handled := bot.handleCommand(incoming, "/help", func(s string) { reply = s })
 	if !handled {
 		t.Fatal("expected /help to be handled")
 	}
@@ -437,9 +487,10 @@ func TestHandleCommandHelp(t *testing.T) {
 }
 
 func TestHandleCommandStart(t *testing.T) {
-	bot := &Bot{}
+	bot := &Bot{handler: &mockHandler{}}
 	var reply string
-	handled := bot.handleCommand(&channel.ResolvedChat{SessionKey: "ch"}, "/start", "user123", func(s string) { reply = s })
+	incoming := incomingMsg("user123", "", "")
+	handled := bot.handleCommand(incoming, "/start", func(s string) { reply = s })
 	if !handled {
 		t.Fatal("expected /start to be handled")
 	}
@@ -449,25 +500,28 @@ func TestHandleCommandStart(t *testing.T) {
 }
 
 func TestHandleCommandUnknown(t *testing.T) {
-	bot := &Bot{}
-	handled := bot.handleCommand(&channel.ResolvedChat{SessionKey: "ch"}, "hello world", "user123", func(s string) {})
+	bot := &Bot{handler: &mockHandler{}}
+	incoming := incomingMsg("user123", "", "")
+	handled := bot.handleCommand(incoming, "hello world", func(s string) {})
 	if handled {
 		t.Error("regular text should not be handled as command")
 	}
 }
 
 func TestHandleCommandEmpty(t *testing.T) {
-	bot := &Bot{}
-	handled := bot.handleCommand(&channel.ResolvedChat{SessionKey: "ch"}, "", "user123", func(s string) {})
+	bot := &Bot{handler: &mockHandler{}}
+	incoming := incomingMsg("user123", "", "")
+	handled := bot.handleCommand(incoming, "", func(s string) {})
 	if handled {
 		t.Error("empty text should not be handled")
 	}
 }
 
 func TestHandleCommandWhoami(t *testing.T) {
-	bot := &Bot{}
+	bot := &Bot{handler: &mockHandler{}}
 	var reply string
-	handled := bot.handleCommand(&channel.ResolvedChat{SessionKey: "ch"}, "/whoami", "OPEN_ID_ABC", func(s string) { reply = s })
+	incoming := incomingMsg("OPEN_ID_ABC", "", "")
+	handled := bot.handleCommand(incoming, "/whoami", func(s string) { reply = s })
 	if !handled {
 		t.Fatal("expected /whoami to be handled")
 	}
@@ -483,12 +537,12 @@ func TestHandleModelCommandListModels(t *testing.T) {
 		{Provider: "openai", Model: "gpt-4"},
 	}
 	bot := &Bot{
-		listFn:     func() []channel.ModelOption { return models },
+		handler:    &mockHandler{listModelsFn: func() []channel.ModelOption { return models }},
 		chatModels: make(map[string]channel.ModelOption),
 	}
 
 	var reply string
-	bot.handleModelCommand(&channel.ResolvedChat{SessionKey: "ch"}, "", func(s string) { reply = s })
+	bot.handleModelCommand("", func(s string) { reply = s })
 	if !strings.Contains(reply, "openai/gpt-4") {
 		t.Errorf("expected model list, got: %s", reply)
 	}
@@ -500,12 +554,12 @@ func TestHandleModelCommandFilter(t *testing.T) {
 		{Provider: "anthropic", Model: "claude-3"},
 	}
 	bot := &Bot{
-		listFn:     func() []channel.ModelOption { return models },
+		handler:    &mockHandler{listModelsFn: func() []channel.ModelOption { return models }},
 		chatModels: make(map[string]channel.ModelOption),
 	}
 
 	var reply string
-	bot.handleModelCommand(&channel.ResolvedChat{SessionKey: "ch"}, "claude", func(s string) { reply = s })
+	bot.handleModelCommand("claude", func(s string) { reply = s })
 	if !strings.Contains(reply, "claude-3") {
 		t.Errorf("expected filtered results with claude, got: %s", reply)
 	}
@@ -519,12 +573,12 @@ func TestHandleModelCommandFilterNoMatch(t *testing.T) {
 		{Provider: "openai", Model: "gpt-4"},
 	}
 	bot := &Bot{
-		listFn:     func() []channel.ModelOption { return models },
+		handler:    &mockHandler{listModelsFn: func() []channel.ModelOption { return models }},
 		chatModels: make(map[string]channel.ModelOption),
 	}
 
 	var reply string
-	bot.handleModelCommand(&channel.ResolvedChat{SessionKey: "ch"}, "gemini", func(s string) { reply = s })
+	bot.handleModelCommand("gemini", func(s string) { reply = s })
 	if !strings.Contains(reply, "No models matching") {
 		t.Errorf("expected no match message, got: %s", reply)
 	}
@@ -535,16 +589,16 @@ func TestHandleModelCommandSwitchByName(t *testing.T) {
 		{Provider: "openai", Model: "gpt-4"},
 	}
 	var switched string
-	switchFn := func(p, m string) error { switched = p + "/" + m; return nil }
-	pool := newTestAgentPool(t)
 	bot := &Bot{
-		listFn:     func() []channel.ModelOption { return models },
-		switchFn:   switchFn,
+		handler: &mockHandler{
+			listModelsFn:  func() []channel.ModelOption { return models },
+			switchModelFn: func(p, m string) error { switched = p + "/" + m; return nil },
+		},
 		chatModels: make(map[string]channel.ModelOption),
 	}
 
 	var reply string
-	bot.handleModelCommand(&channel.ResolvedChat{Pool: pool, SessionKey: "ch"}, "openai/gpt-4", func(s string) { reply = s })
+	bot.handleModelCommand("openai/gpt-4", func(s string) { reply = s })
 	if !strings.Contains(reply, "Switched to openai/gpt-4") {
 		t.Errorf("expected switch confirmation, got: %s", reply)
 	}
@@ -558,12 +612,12 @@ func TestHandleModelCommandSwitchByNameUnknown(t *testing.T) {
 		{Provider: "openai", Model: "gpt-4"},
 	}
 	bot := &Bot{
-		listFn:     func() []channel.ModelOption { return models },
+		handler:    &mockHandler{listModelsFn: func() []channel.ModelOption { return models }},
 		chatModels: make(map[string]channel.ModelOption),
 	}
 
 	var reply string
-	bot.handleModelCommand(&channel.ResolvedChat{SessionKey: "ch"}, "fake/model", func(s string) { reply = s })
+	bot.handleModelCommand("fake/model", func(s string) { reply = s })
 	if !strings.Contains(reply, "Unknown model") {
 		t.Errorf("expected unknown model error, got: %s", reply)
 	}
@@ -573,16 +627,16 @@ func TestHandleModelCommandSwitchError(t *testing.T) {
 	models := []channel.ModelOption{
 		{Provider: "openai", Model: "gpt-4"},
 	}
-	switchFn := func(string, string) error { return fmt.Errorf("switch failed") }
-	pool := newTestAgentPool(t)
 	bot := &Bot{
-		listFn:     func() []channel.ModelOption { return models },
-		switchFn:   switchFn,
+		handler: &mockHandler{
+			listModelsFn:  func() []channel.ModelOption { return models },
+			switchModelFn: func(string, string) error { return fmt.Errorf("switch failed") },
+		},
 		chatModels: make(map[string]channel.ModelOption),
 	}
 
 	var reply string
-	bot.handleModelCommand(&channel.ResolvedChat{Pool: pool, SessionKey: "ch"}, "openai/gpt-4", func(s string) { reply = s })
+	bot.handleModelCommand("openai/gpt-4", func(s string) { reply = s })
 	if !strings.Contains(reply, "Error switching model") {
 		t.Errorf("expected switch error, got: %s", reply)
 	}
@@ -593,12 +647,12 @@ func TestHandleModelCommandNumericTreatedAsFilter(t *testing.T) {
 		{Provider: "openai", Model: "gpt-4"},
 	}
 	bot := &Bot{
-		listFn:     func() []channel.ModelOption { return models },
+		handler:    &mockHandler{listModelsFn: func() []channel.ModelOption { return models }},
 		chatModels: make(map[string]channel.ModelOption),
 	}
 
 	var reply string
-	bot.handleModelCommand(&channel.ResolvedChat{SessionKey: "ch"}, "5", func(s string) { reply = s })
+	bot.handleModelCommand("5", func(s string) { reply = s })
 	// "5" is now treated as a filter query, not an index
 	if !strings.Contains(reply, "No models matching") {
 		t.Errorf("expected no match for numeric filter, got: %s", reply)
@@ -665,16 +719,33 @@ func TestBuildMessageContentEmptyNoAttachments(t *testing.T) {
 
 func TestSendImageNoOp(t *testing.T) {
 	bot := &Bot{}
-	bot.sendImage("target", "msg", runner.ImageEvent{}, scopeC2C)
+	bot.sendImage("target", "msg", channel.ImageEvent{}, scopeC2C)
 }
 
-// newTestAgentPool creates a minimal *agent.Pool for tests that need RotateSession.
-func newTestAgentPool(t *testing.T) *agent.Pool {
-	t.Helper()
-	eng, err := memory.NewEngine(t.TempDir()+"/test.db", &memory.StaticSummarizer{Response: "test"})
-	if err != nil {
-		t.Fatalf("NewEngine: %v", err)
+// --- incomingMsg ---
+
+func TestIncomingMsgC2C(t *testing.T) {
+	msg := incomingMsg("user1", "", "hello")
+	if msg.Platform != channel.PlatformQQ {
+		t.Errorf("Platform = %q, want %q", msg.Platform, channel.PlatformQQ)
 	}
-	t.Cleanup(func() { _ = eng.Close() })
-	return agent.NewPool(nil, eng)
+	if msg.SenderID != "user1" {
+		t.Errorf("SenderID = %q, want %q", msg.SenderID, "user1")
+	}
+	if msg.ChatID != "qq:c2c:user1" {
+		t.Errorf("ChatID = %q, want %q", msg.ChatID, "qq:c2c:user1")
+	}
+	if msg.IsGroup {
+		t.Error("IsGroup should be false for C2C")
+	}
+}
+
+func TestIncomingMsgGroup(t *testing.T) {
+	msg := incomingMsg("user1", "group1", "hello")
+	if msg.ChatID != "qq:group:group1" {
+		t.Errorf("ChatID = %q, want %q", msg.ChatID, "qq:group:group1")
+	}
+	if !msg.IsGroup {
+		t.Error("IsGroup should be true for group")
+	}
 }

--- a/plugins/channels/qq/qq_test.go
+++ b/plugins/channels/qq/qq_test.go
@@ -422,39 +422,29 @@ func TestDownloadImageDetectsMIME(t *testing.T) {
 
 // --- handleCommand ---
 
-// mockHandler implements channel.MessageHandler for tests.
+// mockHandler implements channel.Handler for tests.
 type mockHandler struct {
-	handleCommandFn func(ctx context.Context, msg channel.IncomingMessage, cmd, args string) (string, bool)
-	listModelsFn    func() []channel.ModelOption
-	switchModelFn   func(provider, model string) error
-	listAgentsFn    func(ctx context.Context, msg channel.IncomingMessage) ([]channel.AgentInfo, string, error)
-	switchAgentFn   func(ctx context.Context, msg channel.IncomingMessage, slug string) error
+	handleIncomingFn func(ctx context.Context, msg channel.IncomingMessage, cmd, args string) (string, bool, *channel.ChatStream, error)
+	listModelsFn     func() []channel.ModelOption
+	switchModelFn    func(provider, model string) error
+	listAgentsFn     func(ctx context.Context, msg channel.IncomingMessage) ([]channel.AgentInfo, string, error)
+	switchAgentFn    func(ctx context.Context, msg channel.IncomingMessage, slug string) error
 }
 
-func (m *mockHandler) HandleIncoming(_ context.Context, msg channel.IncomingMessage, cmd, args string) (string, bool, *channel.ChatStream, error) {
-	resp, handled := m.HandleCommand(context.Background(), msg, cmd, args)
-	if handled {
-		return resp, true, nil, nil
+func (m *mockHandler) HandleIncoming(ctx context.Context, msg channel.IncomingMessage, cmd, args string) (string, bool, *channel.ChatStream, error) {
+	if m.handleIncomingFn != nil {
+		return m.handleIncomingFn(ctx, msg, cmd, args)
+	}
+	// Default: handle shared commands.
+	switch cmd {
+	case "/start":
+		return channel.WelcomeMessage, true, nil, nil
+	case "/new":
+		return "Session reset.", true, nil, nil
+	case "/whoami":
+		return fmt.Sprintf("Your user ID: %s", msg.SenderID), true, nil, nil
 	}
 	return "", false, nil, nil
-}
-func (m *mockHandler) HandleMessage(context.Context, channel.IncomingMessage) (*channel.ChatStream, error) {
-	return nil, nil
-}
-func (m *mockHandler) HandleCommand(ctx context.Context, msg channel.IncomingMessage, cmd, args string) (string, bool) {
-	if m.handleCommandFn != nil {
-		return m.handleCommandFn(ctx, msg, cmd, args)
-	}
-	// Default: handle /help, /start, /whoami
-	switch cmd {
-	case "/help":
-		return "Anna help text", true
-	case "/start":
-		return channel.WelcomeMessage, true
-	case "/whoami":
-		return fmt.Sprintf("Your user ID: %s", msg.SenderID), true
-	}
-	return "", false
 }
 func (m *mockHandler) ListAgents(ctx context.Context, msg channel.IncomingMessage) ([]channel.AgentInfo, string, error) {
 	if m.listAgentsFn != nil {
@@ -481,11 +471,11 @@ func (m *mockHandler) SwitchModel(provider, model string) error {
 	return nil
 }
 
-func TestHandleCommandHelp(t *testing.T) {
+func TestHandleLocalCommandHelp(t *testing.T) {
 	bot := &Bot{handler: &mockHandler{}}
 	var reply string
 	incoming := incomingMsg("user123", "", nil)
-	handled := bot.handleCommand(incoming, "/help", func(s string) { reply = s })
+	handled := bot.handleLocalCommand(incoming, "/help", func(s string) { reply = s })
 	if !handled {
 		t.Fatal("expected /help to be handled")
 	}
@@ -494,47 +484,34 @@ func TestHandleCommandHelp(t *testing.T) {
 	}
 }
 
-func TestHandleCommandStart(t *testing.T) {
-	bot := &Bot{handler: &mockHandler{}}
-	var reply string
-	incoming := incomingMsg("user123", "", nil)
-	handled := bot.handleCommand(incoming, "/start", func(s string) { reply = s })
-	if !handled {
-		t.Fatal("expected /start to be handled")
-	}
-	if reply != channel.WelcomeMessage {
-		t.Errorf("unexpected reply: %s", reply)
-	}
-}
-
-func TestHandleCommandUnknown(t *testing.T) {
-	bot := &Bot{handler: &mockHandler{}}
-	incoming := incomingMsg("user123", "", nil)
-	handled := bot.handleCommand(incoming, "hello world", func(s string) {})
-	if handled {
-		t.Error("regular text should not be handled as command")
-	}
-}
-
-func TestHandleCommandEmpty(t *testing.T) {
-	bot := &Bot{handler: &mockHandler{}}
-	incoming := incomingMsg("user123", "", nil)
-	handled := bot.handleCommand(incoming, "", func(s string) {})
-	if handled {
-		t.Error("empty text should not be handled")
-	}
-}
-
-func TestHandleCommandWhoami(t *testing.T) {
+func TestHandleLocalCommandWhoami(t *testing.T) {
 	bot := &Bot{handler: &mockHandler{}}
 	var reply string
 	incoming := incomingMsg("OPEN_ID_ABC", "", nil)
-	handled := bot.handleCommand(incoming, "/whoami", func(s string) { reply = s })
+	handled := bot.handleLocalCommand(incoming, "/whoami", func(s string) { reply = s })
 	if !handled {
 		t.Fatal("expected /whoami to be handled")
 	}
 	if !strings.Contains(reply, "OPEN_ID_ABC") {
 		t.Errorf("expected reply to contain sender ID, got: %s", reply)
+	}
+}
+
+func TestHandleLocalCommandUnknown(t *testing.T) {
+	bot := &Bot{handler: &mockHandler{}}
+	incoming := incomingMsg("user123", "", nil)
+	handled := bot.handleLocalCommand(incoming, "hello world", func(s string) {})
+	if handled {
+		t.Error("regular text should not be handled as command")
+	}
+}
+
+func TestHandleLocalCommandEmpty(t *testing.T) {
+	bot := &Bot{handler: &mockHandler{}}
+	incoming := incomingMsg("user123", "", nil)
+	handled := bot.handleLocalCommand(incoming, "", func(s string) {})
+	if handled {
+		t.Error("empty text should not be handled")
 	}
 }
 

--- a/plugins/channels/qq/qq_test.go
+++ b/plugins/channels/qq/qq_test.go
@@ -126,7 +126,7 @@ func TestBuildStreamDisplayEmptyAll(t *testing.T) {
 // --- toolLine ---
 
 func TestToolLineRunning(t *testing.T) {
-	line := toolLine(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "ls -la"})
+	line := channel.ToolLine(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "ls -la"})
 	if !strings.Contains(line, "bash") || !strings.Contains(line, "ls -la") {
 		t.Errorf("unexpected line: %q", line)
 	}
@@ -134,14 +134,14 @@ func TestToolLineRunning(t *testing.T) {
 
 func TestToolLineRunningTruncatesMultibyte(t *testing.T) {
 	input := strings.Repeat("中", 61)
-	line := toolLine(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: input})
+	line := channel.ToolLine(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: input})
 	if !strings.HasSuffix(line, "...") {
 		t.Errorf("expected truncation ellipsis, got %q", line)
 	}
 }
 
 func TestToolLineRunningNoInput(t *testing.T) {
-	line := toolLine(&channel.ToolUseEvent{Tool: "search", Status: "running"})
+	line := channel.ToolLine(&channel.ToolUseEvent{Tool: "search", Status: "running"})
 	if !strings.Contains(line, "search") {
 		t.Errorf("unexpected line: %q", line)
 	}
@@ -151,21 +151,21 @@ func TestToolLineRunningNoInput(t *testing.T) {
 }
 
 func TestToolLineError(t *testing.T) {
-	line := toolLine(&channel.ToolUseEvent{Tool: "read", Status: "error"})
+	line := channel.ToolLine(&channel.ToolUseEvent{Tool: "read", Status: "error"})
 	if !strings.Contains(line, "failed") {
 		t.Errorf("unexpected line: %q", line)
 	}
 }
 
 func TestToolLineDefault(t *testing.T) {
-	line := toolLine(&channel.ToolUseEvent{Tool: "bash", Status: "done"})
+	line := channel.ToolLine(&channel.ToolUseEvent{Tool: "bash", Status: "done"})
 	if line != "" {
 		t.Errorf("expected empty, got %q", line)
 	}
 }
 
 func TestToolLineUnknownTool(t *testing.T) {
-	line := toolLine(&channel.ToolUseEvent{Tool: "custom_tool", Status: "running", Input: "x"})
+	line := channel.ToolLine(&channel.ToolUseEvent{Tool: "custom_tool", Status: "running", Input: "x"})
 	if !strings.Contains(line, "🔧") {
 		t.Errorf("unknown tool should use default emoji: %q", line)
 	}

--- a/plugins/channels/qq/qq_test.go
+++ b/plugins/channels/qq/qq_test.go
@@ -295,7 +295,7 @@ func TestFormatModelListNoQuery(t *testing.T) {
 		{Provider: "openai", Model: "gpt-4"},
 		{Provider: "anthropic", Model: "claude-3"},
 	})
-	out := formatModelList(models, "")
+	out := channel.FormatModelList(models, "")
 	if !strings.Contains(out, "• openai/gpt-4") {
 		t.Errorf("missing model entry in output: %s", out)
 	}
@@ -311,7 +311,7 @@ func TestFormatModelListWithQuery(t *testing.T) {
 	models := channel.IndexModels([]channel.ModelOption{
 		{Provider: "openai", Model: "gpt-4"},
 	})
-	out := formatModelList(models, "openai")
+	out := channel.FormatModelList(models, "openai")
 	if !strings.Contains(out, `filter: "openai"`) {
 		t.Errorf("should show filter query: %s", out)
 	}
@@ -430,6 +430,13 @@ type mockHandler struct {
 	switchAgentFn   func(ctx context.Context, msg channel.IncomingMessage, slug string) error
 }
 
+func (m *mockHandler) HandleIncoming(_ context.Context, msg channel.IncomingMessage, cmd, args string) (string, bool, *channel.ChatStream, error) {
+	resp, handled := m.HandleCommand(context.Background(), msg, cmd, args)
+	if handled {
+		return resp, true, nil, nil
+	}
+	return "", false, nil, nil
+}
 func (m *mockHandler) HandleMessage(context.Context, channel.IncomingMessage) (*channel.ChatStream, error) {
 	return nil, nil
 }

--- a/plugins/channels/qq/qq_test.go
+++ b/plugins/channels/qq/qq_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/tencent-connect/botgo/dto"
+	"github.com/vaayne/anna/pkg/ai"
 	"github.com/vaayne/anna/pkg/channel"
 )
 
@@ -483,7 +484,7 @@ func (m *mockHandler) SwitchModel(provider, model string) error {
 func TestHandleCommandHelp(t *testing.T) {
 	bot := &Bot{handler: &mockHandler{}}
 	var reply string
-	incoming := incomingMsg("user123", "", "")
+	incoming := incomingMsg("user123", "", nil)
 	handled := bot.handleCommand(incoming, "/help", func(s string) { reply = s })
 	if !handled {
 		t.Fatal("expected /help to be handled")
@@ -496,7 +497,7 @@ func TestHandleCommandHelp(t *testing.T) {
 func TestHandleCommandStart(t *testing.T) {
 	bot := &Bot{handler: &mockHandler{}}
 	var reply string
-	incoming := incomingMsg("user123", "", "")
+	incoming := incomingMsg("user123", "", nil)
 	handled := bot.handleCommand(incoming, "/start", func(s string) { reply = s })
 	if !handled {
 		t.Fatal("expected /start to be handled")
@@ -508,7 +509,7 @@ func TestHandleCommandStart(t *testing.T) {
 
 func TestHandleCommandUnknown(t *testing.T) {
 	bot := &Bot{handler: &mockHandler{}}
-	incoming := incomingMsg("user123", "", "")
+	incoming := incomingMsg("user123", "", nil)
 	handled := bot.handleCommand(incoming, "hello world", func(s string) {})
 	if handled {
 		t.Error("regular text should not be handled as command")
@@ -517,7 +518,7 @@ func TestHandleCommandUnknown(t *testing.T) {
 
 func TestHandleCommandEmpty(t *testing.T) {
 	bot := &Bot{handler: &mockHandler{}}
-	incoming := incomingMsg("user123", "", "")
+	incoming := incomingMsg("user123", "", nil)
 	handled := bot.handleCommand(incoming, "", func(s string) {})
 	if handled {
 		t.Error("empty text should not be handled")
@@ -527,7 +528,7 @@ func TestHandleCommandEmpty(t *testing.T) {
 func TestHandleCommandWhoami(t *testing.T) {
 	bot := &Bot{handler: &mockHandler{}}
 	var reply string
-	incoming := incomingMsg("OPEN_ID_ABC", "", "")
+	incoming := incomingMsg("OPEN_ID_ABC", "", nil)
 	handled := bot.handleCommand(incoming, "/whoami", func(s string) { reply = s })
 	if !handled {
 		t.Fatal("expected /whoami to be handled")
@@ -695,12 +696,15 @@ func TestBuildMessageContentTextOnly(t *testing.T) {
 	bot := &Bot{}
 	msg := &dto.Message{Content: "hello world"}
 	content := bot.buildMessageContent(msg)
-	text, ok := content.(string)
-	if !ok {
-		t.Fatalf("expected string, got %T", content)
+	if len(content) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(content))
 	}
-	if text != "hello world" {
-		t.Errorf("text = %q, want %q", text, "hello world")
+	tc, ok := content[0].(ai.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", content[0])
+	}
+	if tc.Text != "hello world" {
+		t.Errorf("text = %q, want %q", tc.Text, "hello world")
 	}
 }
 
@@ -732,7 +736,7 @@ func TestSendImageNoOp(t *testing.T) {
 // --- incomingMsg ---
 
 func TestIncomingMsgC2C(t *testing.T) {
-	msg := incomingMsg("user1", "", "hello")
+	msg := incomingMsg("user1", "", channel.TextContent("hello"))
 	if msg.Platform != channel.PlatformQQ {
 		t.Errorf("Platform = %q, want %q", msg.Platform, channel.PlatformQQ)
 	}
@@ -748,7 +752,7 @@ func TestIncomingMsgC2C(t *testing.T) {
 }
 
 func TestIncomingMsgGroup(t *testing.T) {
-	msg := incomingMsg("user1", "group1", "hello")
+	msg := incomingMsg("user1", "group1", channel.TextContent("hello"))
 	if msg.ChatID != "qq:group:group1" {
 		t.Errorf("ChatID = %q, want %q", msg.ChatID, "qq:group:group1")
 	}

--- a/plugins/channels/qq/render.go
+++ b/plugins/channels/qq/render.go
@@ -2,8 +2,7 @@ package qq
 
 import (
 	"github.com/tencent-connect/botgo/dto"
-	"github.com/vaayne/anna/internal/agent/runner"
-	"github.com/vaayne/anna/internal/channel"
+	"github.com/vaayne/anna/pkg/channel"
 )
 
 // sendFinalResponse sends the completed response, splitting into chunks
@@ -38,6 +37,6 @@ func (b *Bot) sendFinalResponse(targetID, msgID, response string, scope messageS
 // does not accept raw binary or base64 data. Agent-generated images are
 // base64 in-memory with no public URL, so we skip them.
 // TODO: support image sending once a file-upload or proxy solution is available.
-func (b *Bot) sendImage(_ string, _ string, _ runner.ImageEvent, _ messageScope) {
+func (b *Bot) sendImage(_ string, _ string, _ channel.ImageEvent, _ messageScope) {
 	logger().Debug("skipping image send: QQ requires HTTP URL for rich media")
 }

--- a/plugins/channels/qq/stream.go
+++ b/plugins/channels/qq/stream.go
@@ -7,7 +7,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/tencent-connect/botgo/dto"
-	"github.com/vaayne/anna/internal/agent/runner"
+	"github.com/vaayne/anna/pkg/channel"
 )
 
 const streamEditInterval = time.Second
@@ -24,7 +24,7 @@ var toolEmoji = map[string]string{
 }
 
 // toolLine returns a short status line for a tool-use event.
-func toolLine(t *runner.ToolUseEvent) string {
+func toolLine(t *channel.ToolUseEvent) string {
 	emoji, ok := toolEmoji[t.Tool]
 	if !ok {
 		emoji = toolEmoji["default"]
@@ -50,7 +50,7 @@ func toolLine(t *runner.ToolUseEvent) string {
 // streamResponse consumes the agent event stream and progressively sends
 // updates using QQ's native Stream API. Returns the final text, collected
 // images, and any stream error.
-func (b *Bot) streamResponse(events <-chan runner.Event, authorID, groupID, msgID string, scope messageScope) (string, []runner.ImageEvent, error) {
+func (b *Bot) streamResponse(events <-chan channel.Event, authorID, groupID, msgID string, scope messageScope) (string, []channel.ImageEvent, error) {
 	targetID := authorID
 	if groupID != "" {
 		targetID = groupID
@@ -60,7 +60,7 @@ func (b *Bot) streamResponse(events <-chan runner.Event, authorID, groupID, msgI
 	var streamErr error
 	var currentTool string
 	var streamMsgID string
-	var images []runner.ImageEvent
+	var images []channel.ImageEvent
 	var seq uint32 = 1
 	lastSend := time.Time{}
 

--- a/plugins/channels/qq/stream.go
+++ b/plugins/channels/qq/stream.go
@@ -1,7 +1,6 @@
 package qq
 
 import (
-	"fmt"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -13,39 +12,6 @@ import (
 const streamEditInterval = time.Second
 
 const typingCursor = " \u258D"
-
-var toolEmoji = map[string]string{
-	"bash":    "⚡",
-	"read":    "📖",
-	"write":   "✏️",
-	"edit":    "🔧",
-	"search":  "🔍",
-	"default": "🔧",
-}
-
-// toolLine returns a short status line for a tool-use event.
-func toolLine(t *channel.ToolUseEvent) string {
-	emoji, ok := toolEmoji[t.Tool]
-	if !ok {
-		emoji = toolEmoji["default"]
-	}
-	switch t.Status {
-	case "running":
-		input := t.Input
-		if utf8.RuneCountInString(input) > 60 {
-			r := []rune(input)
-			input = string(r[:57]) + "..."
-		}
-		if input != "" {
-			return fmt.Sprintf("%s %s: %s", emoji, t.Tool, input)
-		}
-		return fmt.Sprintf("%s %s", emoji, t.Tool)
-	case "error":
-		return fmt.Sprintf("❌ %s failed", t.Tool)
-	default:
-		return ""
-	}
-}
 
 // streamResponse consumes the agent event stream and progressively sends
 // updates using QQ's native Stream API. Returns the final text, collected
@@ -76,7 +42,7 @@ func (b *Bot) streamResponse(events <-chan channel.Event, authorID, groupID, msg
 		}
 
 		if evt.ToolUse != nil {
-			line := toolLine(evt.ToolUse)
+			line := channel.ToolLine(evt.ToolUse)
 			if line != "" {
 				currentTool = line
 			} else {

--- a/plugins/channels/telegram/agent.go
+++ b/plugins/channels/telegram/agent.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 
-	"github.com/vaayne/anna/internal/channel"
+	"github.com/vaayne/anna/pkg/channel"
 	tele "gopkg.in/telebot.v4"
 )
 
@@ -73,13 +72,9 @@ func (b *Bot) sendAgentPage(c tele.Context, agents []channel.IndexedAgent, page 
 
 // switchAgentByIdx handles agent switching by 1-based index.
 func (b *Bot) switchAgentByIdx(c tele.Context, idx int) error {
-	rc, err := b.resolve(c)
-	if err != nil {
-		return c.Send(fmt.Sprintf("Error: %v", err))
-	}
+	msg := b.incomingMsg(c, "")
 
-	ctx := context.Background()
-	agents, err := b.agentCmd.List(ctx)
+	agents, _, err := b.handler.ListAgents(context.Background(), msg)
 	if err != nil {
 		return c.Send(fmt.Sprintf("Error listing agents: %v", err))
 	}
@@ -88,23 +83,10 @@ func (b *Bot) switchAgentByIdx(c tele.Context, idx int) error {
 	}
 	selected := agents[idx-1]
 
-	if err := b.agentCmd.Switch(ctx, rc.User, rc.ChatCtx, selected.ID); err != nil {
+	if err := b.handler.SwitchAgent(context.Background(), msg, selected.ID); err != nil {
 		return c.Send(fmt.Sprintf("Error switching agent: %v", err))
 	}
 
-	logger().Info("agent switched", "key", rc.SessionKey, "agent_id", selected.ID)
+	logger().Info("agent switched", "agent_id", selected.ID)
 	return c.Send(fmt.Sprintf("Switched to agent: %s (%s)", selected.ID, selected.Name))
-}
-
-// switchAgentBySlug handles agent switching by slug name.
-// Accepts a pre-resolved rc to avoid a redundant resolve call.
-func (b *Bot) switchAgentBySlug(c tele.Context, rc *channel.ResolvedChat, slug string) error {
-	slug = strings.TrimSpace(slug)
-
-	if err := b.agentCmd.Switch(context.Background(), rc.User, rc.ChatCtx, slug); err != nil {
-		return c.Send(fmt.Sprintf("Error switching agent: %v", err))
-	}
-
-	logger().Info("agent switched", "key", rc.SessionKey, "agent_id", slug)
-	return c.Send(fmt.Sprintf("Switched to agent: %s", slug))
 }

--- a/plugins/channels/telegram/agent.go
+++ b/plugins/channels/telegram/agent.go
@@ -72,7 +72,7 @@ func (b *Bot) sendAgentPage(c tele.Context, agents []channel.IndexedAgent, page 
 
 // switchAgentByIdx handles agent switching by 1-based index.
 func (b *Bot) switchAgentByIdx(c tele.Context, idx int) error {
-	msg := b.incomingMsg(c, "")
+	msg := b.incomingMsg(c, nil)
 
 	agents, _, err := b.handler.ListAgents(context.Background(), msg)
 	if err != nil {

--- a/plugins/channels/telegram/handler.go
+++ b/plugins/channels/telegram/handler.go
@@ -9,9 +9,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/vaayne/anna/internal/agent/runner"
-	"github.com/vaayne/anna/internal/channel"
 	"github.com/vaayne/anna/pkg/ai"
+	"github.com/vaayne/anna/pkg/channel"
 	tele "gopkg.in/telebot.v4"
 )
 
@@ -106,16 +105,13 @@ func (b *Bot) registerHandlers() {
 	b.bot.Handle("\fagent_page", b.guard(func(c tele.Context) error {
 		page, _ := strconv.Atoi(c.Data())
 
-		rc, err := b.resolve(c)
+		msg := b.incomingMsg(c, "")
+		agents, currentAgentID, err := b.handler.ListAgents(context.Background(), msg)
 		if err != nil {
 			return c.Send(fmt.Sprintf("Error: %v", err))
 		}
-
-		agents, listErr := b.agentCmd.List(context.Background())
-		if listErr != nil {
-			return c.Send(fmt.Sprintf("Error: %v", listErr))
-		}
-		if err := b.sendAgentPage(c, channel.IndexAgents(agents), page, rc.AgentID, true); err != nil {
+		indexed := channel.IndexAgents(agents)
+		if err := b.sendAgentPage(c, indexed, page, currentAgentID, true); err != nil {
 			logger().Error("agent page failed", "page", page, "error", err)
 			return err
 		}
@@ -143,7 +139,7 @@ func (b *Bot) registerHandlers() {
 
 // modelList returns models optionally filtered by query.
 func (b *Bot) modelList(query string) []channel.IndexedModel {
-	models := b.listFn()
+	models := b.handler.ListModels()
 	if query == "" {
 		return channel.IndexModels(models)
 	}
@@ -171,27 +167,27 @@ func (b *Bot) handleModel(c tele.Context) error {
 
 // handleAgent handles the /agent command with inline keyboard.
 func (b *Bot) handleAgent(c tele.Context) error {
-	rc, err := b.resolve(c)
-	if err != nil {
-		return c.Send(fmt.Sprintf("Error: %v", err))
-	}
-
-	ctx := context.Background()
 	args := strings.TrimSpace(c.Message().Payload)
+
+	msg := b.incomingMsg(c, "")
 
 	// Direct switch by slug.
 	if args != "" {
-		return b.switchAgentBySlug(c, rc, args)
+		if err := b.handler.SwitchAgent(context.Background(), msg, args); err != nil {
+			return c.Send(fmt.Sprintf("Error switching agent: %v", err))
+		}
+		logger().Info("agent switched", "agent_id", args)
+		return c.Send(fmt.Sprintf("Switched to agent: %s", args))
 	}
 
-	agents, listErr := b.agentCmd.List(ctx)
-	if listErr != nil {
-		return c.Send(fmt.Sprintf("Error listing agents: %v", listErr))
+	agents, currentAgentID, err := b.handler.ListAgents(context.Background(), msg)
+	if err != nil {
+		return c.Send(fmt.Sprintf("Error listing agents: %v", err))
 	}
 	if len(agents) == 0 {
 		return c.Send("No agents available.")
 	}
-	return b.sendAgentKeyboard(c, channel.IndexAgents(agents), rc.AgentID)
+	return b.sendAgentKeyboard(c, channel.IndexAgents(agents), currentAgentID)
 }
 
 // handleText processes incoming text messages.
@@ -201,30 +197,19 @@ func (b *Bot) handleText(c tele.Context) error {
 		text = b.stripBotMention(text)
 	}
 
-	// Try link code before anything else.
-	if b.authStore != nil && b.linkCodes != nil {
-		sender := c.Sender()
-		if sender != nil {
-			name := sender.FirstName
-			if name == "" {
-				name = sender.Username
-			}
-			if resp, ok := channel.TryLinkCode(b.ctx, b.authStore, b.linkCodes, text, channel.PlatformTelegram, strconv.FormatInt(sender.ID, 10), name); ok {
-				return c.Send(resp)
-			}
+	msg := b.incomingMsg(c, text)
+
+	// Try link code / shared commands via coordinator.
+	fields := strings.Fields(text)
+	if len(fields) > 0 {
+		cmd := fields[0]
+		args := strings.TrimSpace(strings.TrimPrefix(text, cmd))
+		if resp, ok := b.handler.HandleCommand(b.ctx, msg, cmd, args); ok {
+			return c.Send(resp)
 		}
 	}
 
-	// Try shared command handler first.
-	rc, err := b.resolve(c)
-	if err != nil {
-		return c.Send(fmt.Sprintf("Error: %v", err))
-	}
-	if resp, ok := channel.HandleCommand(b.ctx, rc, text, strconv.FormatInt(c.Sender().ID, 10)); ok {
-		return c.Send(resp)
-	}
-
-	return b.handleMessage(c, rc, text)
+	return b.handleMessage(c, msg)
 }
 
 // handlePhoto processes incoming photo messages.
@@ -265,18 +250,15 @@ func (b *Bot) handlePhoto(c tele.Context) error {
 
 	logger().Debug("photo received", "chat_id", c.Chat().ID, "size", len(data), "mime", mimeType)
 
-	rc, err := b.resolve(c)
-	if err != nil {
-		return c.Send(fmt.Sprintf("Error: %v", err))
-	}
-	return b.handleMessage(c, rc, content)
+	msg := b.incomingMsg(c, content)
+	return b.handleMessage(c, msg)
 }
 
 // handleMessage is the common flow for text and multimodal messages.
-func (b *Bot) handleMessage(c tele.Context, rc *channel.ResolvedChat, message runner.MessageContent) error {
+func (b *Bot) handleMessage(c tele.Context, msg channel.IncomingMessage) error {
 	chatID := c.Chat().ID
 
-	events, sessionID, err := rc.Chat(b.ctx, message)
+	stream, err := b.handler.HandleMessage(b.ctx, msg)
 	if err != nil {
 		logger().Error("chat failed", "chat_id", chatID, "error", err)
 		return c.Send(fmt.Sprintf("Session error: %v", err))
@@ -287,12 +269,12 @@ func (b *Bot) handleMessage(c tele.Context, rc *channel.ResolvedChat, message ru
 	typingCtx, stopTyping := context.WithCancel(b.ctx)
 	go keepTyping(typingCtx, c)
 
-	response, tracker, images, streamErr := b.streamEvents(c, events)
+	response, tracker, images, streamErr := b.streamEvents(c, stream.Events)
 
 	stopTyping()
 
 	if streamErr != nil {
-		logger().Error("agent stream error", "session_id", sessionID, "error", streamErr)
+		logger().Error("agent stream error", "session_id", stream.SessionID, "error", streamErr)
 		if response == "" {
 			response = fmt.Sprintf("Agent error: %v", streamErr)
 		} else {

--- a/plugins/channels/telegram/handler.go
+++ b/plugins/channels/telegram/handler.go
@@ -105,7 +105,7 @@ func (b *Bot) registerHandlers() {
 	b.bot.Handle("\fagent_page", b.guard(func(c tele.Context) error {
 		page, _ := strconv.Atoi(c.Data())
 
-		msg := b.incomingMsg(c, "")
+		msg := b.incomingMsg(c, nil)
 		agents, currentAgentID, err := b.handler.ListAgents(context.Background(), msg)
 		if err != nil {
 			return c.Send(fmt.Sprintf("Error: %v", err))
@@ -169,7 +169,7 @@ func (b *Bot) handleModel(c tele.Context) error {
 func (b *Bot) handleAgent(c tele.Context) error {
 	args := strings.TrimSpace(c.Message().Payload)
 
-	msg := b.incomingMsg(c, "")
+	msg := b.incomingMsg(c, nil)
 
 	// Direct switch by slug.
 	if args != "" {
@@ -197,7 +197,7 @@ func (b *Bot) handleText(c tele.Context) error {
 		text = b.stripBotMention(text)
 	}
 
-	msg := b.incomingMsg(c, text)
+	msg := b.incomingMsg(c, channel.TextContent(text))
 
 	// Parse command if present.
 	var cmd, args string

--- a/plugins/channels/telegram/handler.go
+++ b/plugins/channels/telegram/handler.go
@@ -257,12 +257,9 @@ func (b *Bot) handlePhoto(c tele.Context) error {
 	logger().Debug("photo received", "chat_id", c.Chat().ID, "size", len(data), "mime", mimeType)
 
 	msg := b.incomingMsg(c, content)
-	return b.handleMessage(c, msg)
-}
 
-// handleMessage resolves and streams a response for non-text messages (photos).
-func (b *Bot) handleMessage(c tele.Context, msg channel.IncomingMessage) error {
-	stream, err := b.handler.HandleMessage(b.ctx, msg)
+	// Photos are never commands — pass empty command to HandleIncoming.
+	_, _, stream, err := b.handler.HandleIncoming(b.ctx, msg, "", "")
 	if err != nil {
 		logger().Error("chat failed", "chat_id", c.Chat().ID, "error", err)
 		return c.Send(fmt.Sprintf("Session error: %v", err))

--- a/plugins/channels/telegram/handler.go
+++ b/plugins/channels/telegram/handler.go
@@ -292,8 +292,8 @@ func (b *Bot) handleStream(c tele.Context, stream *channel.ChatStream) error {
 		response = "(empty response)"
 	}
 
-	if tracker != nil && tracker.hasHistory() {
-		response += tracker.renderFinal()
+	if tracker != nil && tracker.HasHistory() {
+		response += tracker.RenderFinal()
 	}
 
 	b.sendFinalResponse(c, response, images)

--- a/plugins/channels/telegram/handler.go
+++ b/plugins/channels/telegram/handler.go
@@ -199,17 +199,23 @@ func (b *Bot) handleText(c tele.Context) error {
 
 	msg := b.incomingMsg(c, text)
 
-	// Try link code / shared commands via coordinator.
-	fields := strings.Fields(text)
-	if len(fields) > 0 {
-		cmd := fields[0]
-		args := strings.TrimSpace(strings.TrimPrefix(text, cmd))
-		if resp, ok := b.handler.HandleCommand(b.ctx, msg, cmd, args); ok {
-			return c.Send(resp)
-		}
+	// Parse command if present.
+	var cmd, args string
+	if fields := strings.Fields(text); len(fields) > 0 {
+		cmd = fields[0]
+		args = strings.TrimSpace(strings.TrimPrefix(text, cmd))
 	}
 
-	return b.handleMessage(c, msg)
+	// Single resolution: try command, then fall through to chat.
+	resp, handled, stream, err := b.handler.HandleIncoming(b.ctx, msg, cmd, args)
+	if err != nil {
+		return c.Send(fmt.Sprintf("Error: %v", err))
+	}
+	if handled {
+		return c.Send(resp)
+	}
+
+	return b.handleStream(c, stream)
 }
 
 // handlePhoto processes incoming photo messages.
@@ -254,16 +260,19 @@ func (b *Bot) handlePhoto(c tele.Context) error {
 	return b.handleMessage(c, msg)
 }
 
-// handleMessage is the common flow for text and multimodal messages.
+// handleMessage resolves and streams a response for non-text messages (photos).
 func (b *Bot) handleMessage(c tele.Context, msg channel.IncomingMessage) error {
-	chatID := c.Chat().ID
-
 	stream, err := b.handler.HandleMessage(b.ctx, msg)
 	if err != nil {
-		logger().Error("chat failed", "chat_id", chatID, "error", err)
+		logger().Error("chat failed", "chat_id", c.Chat().ID, "error", err)
 		return c.Send(fmt.Sprintf("Session error: %v", err))
 	}
+	return b.handleStream(c, stream)
+}
 
+// handleStream renders a ChatStream to the Telegram chat.
+func (b *Bot) handleStream(c tele.Context, stream *channel.ChatStream) error {
+	chatID := c.Chat().ID
 	logger().Debug("message received", "chat_id", chatID)
 
 	typingCtx, stopTyping := context.WithCancel(b.ctx)

--- a/plugins/channels/telegram/model.go
+++ b/plugins/channels/telegram/model.go
@@ -2,7 +2,6 @@ package telegram
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/vaayne/anna/pkg/channel"
 	tele "gopkg.in/telebot.v4"
@@ -86,18 +85,8 @@ func (b *Bot) sendModelPage(c tele.Context, models []channel.IndexedModel, page 
 
 // switchModelByName handles model switching by "provider/model" name.
 func (b *Bot) switchModelByName(c tele.Context, name string) error {
-	name = strings.ToLower(strings.TrimSpace(name))
-	models := b.handler.ListModels()
-	var selected channel.ModelOption
-	found := false
-	for _, m := range models {
-		if strings.ToLower(m.Provider+"/"+m.Model) == name {
-			selected = m
-			found = true
-			break
-		}
-	}
-	if !found {
+	selected, ok := channel.FindModelByName(b.handler.ListModels(), name)
+	if !ok {
 		return c.Send(fmt.Sprintf("Unknown model %q, use /model to list available models.", name))
 	}
 

--- a/plugins/channels/telegram/model.go
+++ b/plugins/channels/telegram/model.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/vaayne/anna/internal/channel"
+	"github.com/vaayne/anna/pkg/channel"
 	tele "gopkg.in/telebot.v4"
 )
 
@@ -86,13 +86,8 @@ func (b *Bot) sendModelPage(c tele.Context, models []channel.IndexedModel, page 
 
 // switchModelByName handles model switching by "provider/model" name.
 func (b *Bot) switchModelByName(c tele.Context, name string) error {
-	rc, err := b.resolve(c)
-	if err != nil {
-		return c.Send(fmt.Sprintf("Error: %v", err))
-	}
-
 	name = strings.ToLower(strings.TrimSpace(name))
-	models := b.listFn()
+	models := b.handler.ListModels()
 	var selected channel.ModelOption
 	found := false
 	for _, m := range models {
@@ -106,46 +101,31 @@ func (b *Bot) switchModelByName(c tele.Context, name string) error {
 		return c.Send(fmt.Sprintf("Unknown model %q, use /model to list available models.", name))
 	}
 
-	if _, err := rc.RotateSession(); err != nil {
-		return c.Send(fmt.Sprintf("Error rotating session: %v", err))
-	}
-	if b.switchFn != nil {
-		if err := b.switchFn(selected.Provider, selected.Model); err != nil {
-			return c.Send(fmt.Sprintf("Error switching model: %v", err))
-		}
+	if err := b.handler.SwitchModel(selected.Provider, selected.Model); err != nil {
+		return c.Send(fmt.Sprintf("Error switching model: %v", err))
 	}
 	b.mu.Lock()
 	b.chatModels[c.Chat().ID] = selected
 	b.mu.Unlock()
-	logger().Info("model switched", "key", rc.SessionKey, "provider", selected.Provider, "model", selected.Model)
+	logger().Info("model switched", "provider", selected.Provider, "model", selected.Model)
 	return c.Send(fmt.Sprintf("Switched to %s/%s. Session reset.", selected.Provider, selected.Model))
 }
 
 // switchModelByIdx handles model switching by 1-based index.
 // Used internally by inline keyboard callbacks.
 func (b *Bot) switchModelByIdx(c tele.Context, idx int) error {
-	rc, err := b.resolve(c)
-	if err != nil {
-		return c.Send(fmt.Sprintf("Error: %v", err))
-	}
-
-	models := b.listFn()
+	models := b.handler.ListModels()
 	if idx < 1 || idx > len(models) {
 		return c.Send(fmt.Sprintf("Invalid selection, use a number between 1 and %d.", len(models)))
 	}
 	selected := models[idx-1]
 
-	if _, err := rc.RotateSession(); err != nil {
-		return c.Send(fmt.Sprintf("Error rotating session: %v", err))
-	}
-	if b.switchFn != nil {
-		if err := b.switchFn(selected.Provider, selected.Model); err != nil {
-			return c.Send(fmt.Sprintf("Error switching model: %v", err))
-		}
+	if err := b.handler.SwitchModel(selected.Provider, selected.Model); err != nil {
+		return c.Send(fmt.Sprintf("Error switching model: %v", err))
 	}
 	b.mu.Lock()
 	b.chatModels[c.Chat().ID] = selected
 	b.mu.Unlock()
-	logger().Info("model switched", "key", rc.SessionKey, "provider", selected.Provider, "model", selected.Model)
+	logger().Info("model switched", "provider", selected.Provider, "model", selected.Model)
 	return c.Send(fmt.Sprintf("Switched to %s/%s. Session reset.", selected.Provider, selected.Model))
 }

--- a/plugins/channels/telegram/render.go
+++ b/plugins/channels/telegram/render.go
@@ -6,8 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/vaayne/anna/internal/agent/runner"
-	"github.com/vaayne/anna/internal/channel"
+	"github.com/vaayne/anna/pkg/channel"
 	"github.com/yuin/goldmark/parser"
 	tele "gopkg.in/telebot.v4"
 )
@@ -19,7 +18,7 @@ type goldmarkMD interface {
 
 // sendFinalResponse sends the completed response with markdown rendering,
 // splitting into chunks if necessary. It also sends any collected images.
-func (b *Bot) sendFinalResponse(c tele.Context, response string, images []runner.ImageEvent) {
+func (b *Bot) sendFinalResponse(c tele.Context, response string, images []channel.ImageEvent) {
 	if err := b.sendChunkedMarkdown(c.Chat(), response, false, nil); err != nil {
 		logger().Error("sendFinalResponse failed", "chat_id", c.Chat().ID, "error", err)
 	}
@@ -29,7 +28,7 @@ func (b *Bot) sendFinalResponse(c tele.Context, response string, images []runner
 }
 
 // sendImage decodes a base64 image and sends it as a photo to the chat.
-func (b *Bot) sendImage(c tele.Context, img runner.ImageEvent) {
+func (b *Bot) sendImage(c tele.Context, img channel.ImageEvent) {
 	data, err := base64.StdEncoding.DecodeString(img.Data)
 	if err != nil {
 		logger().Error("decode image failed", "error", err)

--- a/plugins/channels/telegram/stream.go
+++ b/plugins/channels/telegram/stream.go
@@ -9,8 +9,7 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/vaayne/anna/internal/agent/runner"
-	"github.com/vaayne/anna/internal/channel"
+	"github.com/vaayne/anna/pkg/channel"
 	tele "gopkg.in/telebot.v4"
 )
 
@@ -57,7 +56,7 @@ type toolTracker struct {
 }
 
 // start registers a new tool as running.
-func (tt *toolTracker) start(t *runner.ToolUseEvent) {
+func (tt *toolTracker) start(t *channel.ToolUseEvent) {
 	// If a tool was already active, finish it as "done" (missed the finish event).
 	if tt.activeTool != "" {
 		tt.history = append(tt.history, toolRecord{
@@ -74,7 +73,7 @@ func (tt *toolTracker) start(t *runner.ToolUseEvent) {
 }
 
 // finish records the active tool as completed and enforces minimum display time.
-func (tt *toolTracker) finish(t *runner.ToolUseEvent) {
+func (tt *toolTracker) finish(t *channel.ToolUseEvent) {
 	dur := time.Since(tt.activeStart)
 	input := tt.activeInput
 	if t.Input != "" {
@@ -94,7 +93,7 @@ func (tt *toolTracker) finish(t *runner.ToolUseEvent) {
 }
 
 // handle processes a tool event, returning true if a display refresh is needed.
-func (tt *toolTracker) handle(t *runner.ToolUseEvent) bool {
+func (tt *toolTracker) handle(t *channel.ToolUseEvent) bool {
 	switch t.Status {
 	case "running":
 		tt.start(t)
@@ -259,7 +258,7 @@ func truncate(s string, maxLen int) string {
 // For private chats it uses Telegram's sendMessageDraft API (Bot API 9.3+)
 // for smooth animated streaming. For groups (where drafts aren't supported)
 // it falls back to the edit-in-place approach.
-func (b *Bot) streamEvents(c tele.Context, events <-chan runner.Event) (string, *toolTracker, []runner.ImageEvent, error) {
+func (b *Bot) streamEvents(c tele.Context, events <-chan channel.Event) (string, *toolTracker, []channel.ImageEvent, error) {
 	if !isGroup(c) {
 		text, tracker, images, fallback, err := b.streamDraft(c, events)
 		if fallback {
@@ -278,11 +277,11 @@ func (b *Bot) streamEvents(c tele.Context, events <-chan runner.Event) (string, 
 // in private chats. If the first draft call fails, it returns fallback=true
 // so the caller can switch to edit mode. The buffered text is returned so
 // no consumed events are lost.
-func (b *Bot) streamDraft(c tele.Context, events <-chan runner.Event) (text string, tracker *toolTracker, images []runner.ImageEvent, fallback bool, err error) {
+func (b *Bot) streamDraft(c tele.Context, events <-chan channel.Event) (text string, tracker *toolTracker, images []channel.ImageEvent, fallback bool, err error) {
 	var sb strings.Builder
 	var streamErr error
 	var tt toolTracker
-	var imgs []runner.ImageEvent
+	var imgs []channel.ImageEvent
 	lastSend := time.Time{}
 	draftID := rand.Int64N(1<<53) + 1
 	chatID := c.Chat().ID
@@ -335,7 +334,7 @@ func (b *Bot) streamDraft(c tele.Context, events <-chan runner.Event) (text stri
 // consuming from an existing event channel. Required for group chats where
 // sendMessageDraft is not available. Any already-buffered text from a prior
 // draft attempt is preserved via the initial parameter.
-func (b *Bot) streamEditEvents(c tele.Context, events <-chan runner.Event, initial string, existing *toolTracker, existingImages []runner.ImageEvent) (string, *toolTracker, []runner.ImageEvent, error) {
+func (b *Bot) streamEditEvents(c tele.Context, events <-chan channel.Event, initial string, existing *toolTracker, existingImages []channel.ImageEvent) (string, *toolTracker, []channel.ImageEvent, error) {
 	var sb strings.Builder
 	sb.WriteString(initial)
 	var sentMsg *tele.Message
@@ -344,7 +343,7 @@ func (b *Bot) streamEditEvents(c tele.Context, events <-chan runner.Event, initi
 	if existing != nil {
 		tt = *existing
 	}
-	var imgs []runner.ImageEvent
+	var imgs []channel.ImageEvent
 	imgs = append(imgs, existingImages...)
 	lastEdit := time.Time{}
 

--- a/plugins/channels/telegram/stream.go
+++ b/plugins/channels/telegram/stream.go
@@ -2,7 +2,6 @@ package telegram
 
 import (
 	"context"
-	"fmt"
 	"math/rand/v2"
 	"strconv"
 	"strings"
@@ -27,238 +26,16 @@ const typingCursor = " \u258D"
 // after completion, so it doesn't flash and disappear instantly.
 const minToolDisplayDuration = 2 * time.Second
 
-// toolEmoji maps known tool names to display emoji.
-var toolEmoji = map[string]string{
-	"bash":    "⚡",
-	"read":    "📖",
-	"write":   "✏️",
-	"edit":    "🔧",
-	"search":  "🔍",
-	"default": "🔧",
-}
-
-// toolRecord holds a completed tool invocation for the summary section.
-type toolRecord struct {
-	Tool     string
-	Input    string
-	Status   string // "done" or "error"
-	Detail   string
-	Duration time.Duration
-}
-
-// toolTracker tracks active and completed tool invocations during streaming.
-type toolTracker struct {
-	history      []toolRecord
-	activeTool   string
-	activeInput  string
-	activeStart  time.Time
-	displayUntil time.Time // minimum time to keep showing the last-finished tool
-}
-
-// start registers a new tool as running.
-func (tt *toolTracker) start(t *channel.ToolUseEvent) {
-	// If a tool was already active, finish it as "done" (missed the finish event).
-	if tt.activeTool != "" {
-		tt.history = append(tt.history, toolRecord{
-			Tool:     tt.activeTool,
-			Input:    tt.activeInput,
-			Status:   "done",
-			Duration: time.Since(tt.activeStart),
-		})
-	}
-	tt.activeTool = t.Tool
-	tt.activeInput = t.Input
-	tt.activeStart = time.Now()
-	tt.displayUntil = time.Time{}
-}
-
-// finish records the active tool as completed and enforces minimum display time.
-func (tt *toolTracker) finish(t *channel.ToolUseEvent) {
-	dur := time.Since(tt.activeStart)
-	input := tt.activeInput
-	if t.Input != "" {
-		input = t.Input
-	}
-	tt.history = append(tt.history, toolRecord{
-		Tool:     t.Tool,
-		Input:    input,
-		Status:   t.Status,
-		Detail:   t.Detail,
-		Duration: dur,
-	})
-	tt.displayUntil = time.Now().Add(minToolDisplayDuration)
-	tt.activeTool = ""
-	tt.activeInput = ""
-	tt.activeStart = time.Time{}
-}
-
-// handle processes a tool event, returning true if a display refresh is needed.
-func (tt *toolTracker) handle(t *channel.ToolUseEvent) bool {
-	switch t.Status {
-	case "running":
-		tt.start(t)
-		return true
-	case "done", "error":
-		tt.finish(t)
-		return true
-	}
-	return false
-}
-
-// render builds the tool summary section for the streaming display.
-func (tt *toolTracker) render() string {
-	var sb strings.Builder
-
-	// Completed tools summary.
-	for _, rec := range tt.history {
-		sb.WriteString(renderToolRecord(rec))
-		sb.WriteByte('\n')
-	}
-
-	// Active tool with spinner.
-	if tt.activeTool != "" {
-		emoji := emojiFor(tt.activeTool)
-		elapsed := time.Since(tt.activeStart).Truncate(100 * time.Millisecond)
-		line := fmt.Sprintf("⏳ %s %s", emoji, tt.activeTool)
-		if tt.activeInput != "" {
-			input := truncate(tt.activeInput, 60)
-			line += ": " + input
-		}
-		line += fmt.Sprintf(" (%s)", channel.FormatDuration(elapsed))
-		sb.WriteString(line)
-		sb.WriteByte('\n')
-	}
-
-	return sb.String()
-}
-
-// isDisplaying returns true if there is an active tool or the minimum display
-// duration for the last finished tool has not yet elapsed.
-func (tt *toolTracker) isDisplaying() bool {
-	if tt.activeTool != "" {
-		return true
-	}
-	return time.Now().Before(tt.displayUntil)
-}
-
-// hasHistory returns true if any tools were tracked.
-func (tt *toolTracker) hasHistory() bool {
-	return len(tt.history) > 0
-}
-
-// renderFinal builds a compact tool summary for the final message.
-// Shows a one-liner with tool counts and total time, plus individual
-// lines for any failed tool calls.
-func (tt *toolTracker) renderFinal() string {
-	if len(tt.history) == 0 {
-		return ""
-	}
-
-	// Count tools by name (preserving order of first appearance).
-	type toolCount struct {
-		name  string
-		count int
-	}
-	seen := map[string]int{}
-	var counts []toolCount
-	var totalDur time.Duration
-	var errors []toolRecord
-
-	for _, rec := range tt.history {
-		totalDur += rec.Duration
-		if rec.Status == "error" {
-			errors = append(errors, rec)
-		}
-		if idx, ok := seen[rec.Tool]; ok {
-			counts[idx].count++
-		} else {
-			seen[rec.Tool] = len(counts)
-			counts = append(counts, toolCount{name: rec.Tool, count: 1})
-		}
-	}
-
-	// Build compact summary: "📎 5 tools (2× read, 2× bash, 1× edit) · 3.2s"
-	var sb strings.Builder
-	sb.WriteString("\n\n——————————————————\n")
-
-	total := len(tt.history)
-	fmt.Fprintf(&sb, "📎 %d tool", total)
-	if total != 1 {
-		sb.WriteByte('s')
-	}
-	sb.WriteString(" (")
-	for i, tc := range counts {
-		if i > 0 {
-			sb.WriteString(", ")
-		}
-		emoji := emojiFor(tc.name)
-		if tc.count > 1 {
-			fmt.Fprintf(&sb, "%d× %s%s", tc.count, emoji, tc.name)
-		} else {
-			sb.WriteString(emoji + tc.name)
-		}
-	}
-	sb.WriteString(") · ")
-	sb.WriteString(channel.FormatDuration(totalDur))
-
-	// Append individual lines for error calls.
-	for _, rec := range errors {
-		sb.WriteByte('\n')
-		sb.WriteString(renderToolRecord(rec))
-	}
-
-	return sb.String()
-}
-
-// renderToolRecord formats a single completed tool record.
-func renderToolRecord(rec toolRecord) string {
-	statusEmoji := "✅"
-	if rec.Status == "error" {
-		statusEmoji = "❌"
-	}
-	emoji := emojiFor(rec.Tool)
-	line := fmt.Sprintf("%s %s %s", statusEmoji, emoji, rec.Tool)
-	if rec.Input != "" {
-		input := truncate(rec.Input, 60)
-		line += ": " + input
-	}
-	if rec.Detail != "" {
-		detail := truncate(rec.Detail, 80)
-		line += " → " + detail
-	}
-	line += fmt.Sprintf(" (%s)", channel.FormatDuration(rec.Duration))
-	return line
-}
-
-// emojiFor returns the emoji for a tool name.
-func emojiFor(tool string) string {
-	if e, ok := toolEmoji[tool]; ok {
-		return e
-	}
-	return toolEmoji["default"]
-}
-
-// truncate shortens s to maxLen bytes, appending "..." if truncated.
-// Cuts at a valid UTF-8 boundary to avoid producing invalid strings.
-func truncate(s string, maxLen int) string {
-	if len(s) <= maxLen {
-		return s
-	}
-	if maxLen <= 3 {
-		return "..."
-	}
-	cutAt := maxLen - 3
-	for cutAt > 0 && !utf8.RuneStart(s[cutAt]) {
-		cutAt--
-	}
-	return s[:cutAt] + "..."
+// newToolTracker creates a ToolTracker configured for Telegram display.
+func newToolTracker() channel.ToolTracker {
+	return channel.ToolTracker{MinDisplayDuration: minToolDisplayDuration}
 }
 
 // streamEvents consumes the agent event stream, displaying progress in real time.
 // For private chats it uses Telegram's sendMessageDraft API (Bot API 9.3+)
 // for smooth animated streaming. For groups (where drafts aren't supported)
 // it falls back to the edit-in-place approach.
-func (b *Bot) streamEvents(c tele.Context, events <-chan channel.Event) (string, *toolTracker, []channel.ImageEvent, error) {
+func (b *Bot) streamEvents(c tele.Context, events <-chan channel.Event) (string, *channel.ToolTracker, []channel.ImageEvent, error) {
 	if !isGroup(c) {
 		text, tracker, images, fallback, err := b.streamDraft(c, events)
 		if fallback {
@@ -277,10 +54,10 @@ func (b *Bot) streamEvents(c tele.Context, events <-chan channel.Event) (string,
 // in private chats. If the first draft call fails, it returns fallback=true
 // so the caller can switch to edit mode. The buffered text is returned so
 // no consumed events are lost.
-func (b *Bot) streamDraft(c tele.Context, events <-chan channel.Event) (text string, tracker *toolTracker, images []channel.ImageEvent, fallback bool, err error) {
+func (b *Bot) streamDraft(c tele.Context, events <-chan channel.Event) (text string, tracker *channel.ToolTracker, images []channel.ImageEvent, fallback bool, err error) {
 	var sb strings.Builder
 	var streamErr error
-	var tt toolTracker
+	tt := newToolTracker()
 	var imgs []channel.ImageEvent
 	lastSend := time.Time{}
 	draftID := rand.Int64N(1<<53) + 1
@@ -300,7 +77,7 @@ func (b *Bot) streamDraft(c tele.Context, events <-chan channel.Event) (text str
 
 		forceRefresh := false
 		if evt.ToolUse != nil {
-			forceRefresh = tt.handle(evt.ToolUse)
+			forceRefresh = tt.Handle(evt.ToolUse)
 		}
 
 		sb.WriteString(evt.Text)
@@ -311,11 +88,11 @@ func (b *Bot) streamDraft(c tele.Context, events <-chan channel.Event) (text str
 		}
 
 		current := sb.String()
-		if strings.TrimSpace(current) == "" && !tt.isDisplaying() {
+		if strings.TrimSpace(current) == "" && !tt.IsDisplaying() {
 			continue
 		}
 
-		display := buildStreamDisplay(current, tt.render(), tt.isDisplaying())
+		display := buildStreamDisplay(current, tt.Render(), tt.IsDisplaying())
 
 		if err := b.sendDraftRaw(chatID, draftID, display); err != nil {
 			if firstDraft {
@@ -334,12 +111,12 @@ func (b *Bot) streamDraft(c tele.Context, events <-chan channel.Event) (text str
 // consuming from an existing event channel. Required for group chats where
 // sendMessageDraft is not available. Any already-buffered text from a prior
 // draft attempt is preserved via the initial parameter.
-func (b *Bot) streamEditEvents(c tele.Context, events <-chan channel.Event, initial string, existing *toolTracker, existingImages []channel.ImageEvent) (string, *toolTracker, []channel.ImageEvent, error) {
+func (b *Bot) streamEditEvents(c tele.Context, events <-chan channel.Event, initial string, existing *channel.ToolTracker, existingImages []channel.ImageEvent) (string, *channel.ToolTracker, []channel.ImageEvent, error) {
 	var sb strings.Builder
 	sb.WriteString(initial)
 	var sentMsg *tele.Message
 	var streamErr error
-	var tt toolTracker
+	tt := newToolTracker()
 	if existing != nil {
 		tt = *existing
 	}
@@ -360,7 +137,7 @@ func (b *Bot) streamEditEvents(c tele.Context, events <-chan channel.Event, init
 
 		forceRefresh := false
 		if evt.ToolUse != nil {
-			forceRefresh = tt.handle(evt.ToolUse)
+			forceRefresh = tt.Handle(evt.ToolUse)
 		}
 
 		sb.WriteString(evt.Text)
@@ -371,11 +148,11 @@ func (b *Bot) streamEditEvents(c tele.Context, events <-chan channel.Event, init
 		}
 
 		current := sb.String()
-		if strings.TrimSpace(current) == "" && !tt.isDisplaying() {
+		if strings.TrimSpace(current) == "" && !tt.IsDisplaying() {
 			continue
 		}
 
-		display := buildStreamDisplay(current, tt.render(), tt.isDisplaying())
+		display := buildStreamDisplay(current, tt.Render(), tt.IsDisplaying())
 
 		if sentMsg == nil {
 			msg, err := b.bot.Send(c.Chat(), display)

--- a/plugins/channels/telegram/telegram.go
+++ b/plugins/channels/telegram/telegram.go
@@ -11,10 +11,7 @@ import (
 
 	tgmd "github.com/Mad-Pixels/goldmark-tgmd"
 
-	"github.com/vaayne/anna/internal/agent"
-	"github.com/vaayne/anna/internal/auth"
-	"github.com/vaayne/anna/internal/channel"
-	"github.com/vaayne/anna/internal/config"
+	"github.com/vaayne/anna/pkg/channel"
 	tele "gopkg.in/telebot.v4"
 )
 
@@ -35,16 +32,9 @@ type Config struct {
 // Bot wraps a Telegram bot with agent pool integration.
 // It implements channel.Channel.
 type Bot struct {
-	bot         *tele.Bot
-	poolManager *agent.PoolManager
-	store       config.Store
-	authStore   auth.AuthStore
-	engine      *auth.PolicyEngine
-	linkCodes   *auth.LinkCodeStore
-	agentCmd    *channel.AgentCommander
-	listFn      channel.ModelListFunc
-	switchFn    channel.ModelSwitchFunc
-	md          goldmarkMD
+	bot     *tele.Bot
+	handler channel.MessageHandler
+	md      goldmarkMD
 
 	mu         sync.RWMutex
 	chatModels map[int64]channel.ModelOption
@@ -54,7 +44,7 @@ type Bot struct {
 }
 
 // New creates a Telegram bot and registers handlers. Call Start to begin polling.
-func New(cfg Config, pm *agent.PoolManager, store config.Store, listFn channel.ModelListFunc, switchFn channel.ModelSwitchFunc, opts ...BotOption) (*Bot, error) {
+func New(cfg Config, handler channel.MessageHandler) (*Bot, error) {
 	bot, err := tele.NewBot(tele.Settings{
 		Token: cfg.Token,
 		Poller: &tele.LongPoller{
@@ -71,37 +61,15 @@ func New(cfg Config, pm *agent.PoolManager, store config.Store, listFn channel.M
 	}
 
 	b := &Bot{
-		bot:         bot,
-		poolManager: pm,
-		store:       store,
-		agentCmd:    channel.NewAgentCommander(store, nil),
-		listFn:      listFn,
-		switchFn:    switchFn,
-		md:          tgmd.TGMD(),
-		chatModels:  make(map[int64]channel.ModelOption),
-		cfg:         cfg,
-	}
-
-	for _, opt := range opts {
-		opt(b)
+		bot:        bot,
+		handler:    handler,
+		md:         tgmd.TGMD(),
+		chatModels: make(map[int64]channel.ModelOption),
+		cfg:        cfg,
 	}
 
 	b.registerHandlers()
 	return b, nil
-}
-
-// BotOption configures the Telegram Bot.
-type BotOption func(*Bot)
-
-// WithAuth configures the bot with auth store and link code store for
-// account linking support.
-func WithAuth(authStore auth.AuthStore, engine *auth.PolicyEngine, linkCodes *auth.LinkCodeStore) BotOption {
-	return func(b *Bot) {
-		b.authStore = authStore
-		b.engine = engine
-		b.linkCodes = linkCodes
-		b.agentCmd = channel.NewAgentCommander(b.store, authStore)
-	}
 }
 
 // Start begins long polling. It blocks until ctx is cancelled.
@@ -145,8 +113,8 @@ func (b *Bot) Notify(_ context.Context, n channel.Notification) error {
 
 	// Support both numeric IDs and @username for channels.
 	var chat tele.Recipient
-	if id, err := strconv.ParseInt(chatID, 10, 64); err == nil {
-		chat = &tele.Chat{ID: id}
+	if numID, err := strconv.ParseInt(chatID, 10, 64); err == nil {
+		chat = &tele.Chat{ID: numID}
 	} else {
 		chat = chatRef(chatID)
 	}
@@ -232,33 +200,24 @@ func (b *Bot) stripBotMention(text string) string {
 	return strings.TrimSpace(strings.ReplaceAll(text, "@"+b.bot.Me.Username, ""))
 }
 
-// resolve performs full user/agent/pool/session-key resolution for the
-// current Telegram context. Call once per incoming message or command.
-func (b *Bot) resolve(c tele.Context) (*channel.ResolvedChat, error) {
+// incomingMsg builds an IncomingMessage from the Telegram context.
+func (b *Bot) incomingMsg(c tele.Context, content any) channel.IncomingMessage {
 	sender := c.Sender()
-	if sender == nil {
-		return nil, fmt.Errorf("no sender in message")
+	senderID := ""
+	senderName := ""
+	if sender != nil {
+		senderID = fmt.Sprintf("%d", sender.ID)
+		senderName = sender.FirstName
+		if senderName == "" {
+			senderName = sender.Username
+		}
 	}
-
-	name := sender.FirstName
-	if name == "" {
-		name = sender.Username
+	return channel.IncomingMessage{
+		Platform:   channel.PlatformTelegram,
+		SenderID:   senderID,
+		SenderName: senderName,
+		ChatID:     fmt.Sprintf("%d", c.Chat().ID),
+		IsGroup:    isGroup(c),
+		Content:    content,
 	}
-
-	senderID := strconv.FormatInt(sender.ID, 10)
-	chatID := strconv.FormatInt(c.Chat().ID, 10)
-	group := isGroup(c)
-
-	return channel.Resolve(
-		context.Background(),
-		b.poolManager,
-		b.store,
-		b.authStore,
-		b.engine,
-		channel.PlatformTelegram,
-		senderID,
-		name,
-		chatID,
-		group,
-	)
 }

--- a/plugins/channels/telegram/telegram.go
+++ b/plugins/channels/telegram/telegram.go
@@ -11,6 +11,7 @@ import (
 
 	tgmd "github.com/Mad-Pixels/goldmark-tgmd"
 
+	"github.com/vaayne/anna/pkg/ai"
 	"github.com/vaayne/anna/pkg/channel"
 	tele "gopkg.in/telebot.v4"
 )
@@ -201,7 +202,7 @@ func (b *Bot) stripBotMention(text string) string {
 }
 
 // incomingMsg builds an IncomingMessage from the Telegram context.
-func (b *Bot) incomingMsg(c tele.Context, content any) channel.IncomingMessage {
+func (b *Bot) incomingMsg(c tele.Context, content []ai.ContentBlock) channel.IncomingMessage {
 	sender := c.Sender()
 	senderID := ""
 	senderName := ""

--- a/plugins/channels/telegram/telegram.go
+++ b/plugins/channels/telegram/telegram.go
@@ -34,7 +34,7 @@ type Config struct {
 // It implements channel.Channel.
 type Bot struct {
 	bot     *tele.Bot
-	handler channel.MessageHandler
+	handler channel.Handler
 	md      goldmarkMD
 
 	mu         sync.RWMutex
@@ -45,7 +45,7 @@ type Bot struct {
 }
 
 // New creates a Telegram bot and registers handlers. Call Start to begin polling.
-func New(cfg Config, handler channel.MessageHandler) (*Bot, error) {
+func New(cfg Config, handler channel.Handler) (*Bot, error) {
 	bot, err := tele.NewBot(tele.Settings{
 		Token: cfg.Token,
 		Poller: &tele.LongPoller{

--- a/plugins/channels/telegram/telegram_test.go
+++ b/plugins/channels/telegram/telegram_test.go
@@ -125,18 +125,18 @@ func TestBotCommands(t *testing.T) {
 }
 
 func TestToolTracker(t *testing.T) {
-	var tracker toolTracker
+	var tracker channel.ToolTracker
 
 	// Start a tool.
-	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "ls -la"})
-	if tracker.activeTool != "bash" {
-		t.Errorf("activeTool = %q, want %q", tracker.activeTool, "bash")
+	tracker.Handle(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "ls -la"})
+	if tracker.ActiveTool != "bash" {
+		t.Errorf("activeTool = %q, want %q", tracker.ActiveTool, "bash")
 	}
-	if !tracker.isDisplaying() {
+	if !tracker.IsDisplaying() {
 		t.Error("expected isDisplaying=true while tool is active")
 	}
 
-	rendered := tracker.render()
+	rendered := tracker.Render()
 	if !strings.Contains(rendered, "⏳") {
 		t.Errorf("render() = %q, want spinner emoji", rendered)
 	}
@@ -148,18 +148,18 @@ func TestToolTracker(t *testing.T) {
 	}
 
 	// Finish the tool.
-	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "done", Input: "ls -la"})
-	if tracker.activeTool != "" {
-		t.Errorf("activeTool = %q, want empty after done", tracker.activeTool)
+	tracker.Handle(&channel.ToolUseEvent{Tool: "bash", Status: "done", Input: "ls -la"})
+	if tracker.ActiveTool != "" {
+		t.Errorf("activeTool = %q, want empty after done", tracker.ActiveTool)
 	}
-	if len(tracker.history) != 1 {
-		t.Fatalf("history len = %d, want 1", len(tracker.history))
+	if len(tracker.History) != 1 {
+		t.Fatalf("history len = %d, want 1", len(tracker.History))
 	}
-	if tracker.history[0].Tool != "bash" {
-		t.Errorf("history[0].Tool = %q, want %q", tracker.history[0].Tool, "bash")
+	if tracker.History[0].Tool != "bash" {
+		t.Errorf("history[0].Tool = %q, want %q", tracker.History[0].Tool, "bash")
 	}
 
-	rendered = tracker.render()
+	rendered = tracker.Render()
 	if !strings.Contains(rendered, "✅") {
 		t.Errorf("render() = %q, want checkmark for done tool", rendered)
 	}
@@ -169,19 +169,19 @@ func TestToolTracker(t *testing.T) {
 }
 
 func TestToolTrackerError(t *testing.T) {
-	var tracker toolTracker
-	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "exit 1"})
-	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "error", Detail: "command failed"})
+	var tracker channel.ToolTracker
+	tracker.Handle(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "exit 1"})
+	tracker.Handle(&channel.ToolUseEvent{Tool: "bash", Status: "error", Detail: "command failed"})
 
-	if len(tracker.history) != 1 {
-		t.Fatalf("history len = %d, want 1", len(tracker.history))
+	if len(tracker.History) != 1 {
+		t.Fatalf("history len = %d, want 1", len(tracker.History))
 	}
-	rec := tracker.history[0]
+	rec := tracker.History[0]
 	if rec.Status != "error" {
 		t.Errorf("status = %q, want %q", rec.Status, "error")
 	}
 
-	rendered := tracker.render()
+	rendered := tracker.Render()
 	if !strings.Contains(rendered, "❌") {
 		t.Errorf("render() = %q, want error emoji", rendered)
 	}
@@ -191,21 +191,21 @@ func TestToolTrackerError(t *testing.T) {
 }
 
 func TestToolTrackerMultipleTools(t *testing.T) {
-	var tracker toolTracker
-	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "main.go"})
-	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "done", Input: "main.go"})
-	tracker.handle(&channel.ToolUseEvent{Tool: "edit", Status: "running", Input: "main.go"})
-	tracker.handle(&channel.ToolUseEvent{Tool: "edit", Status: "done", Input: "main.go"})
-	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "go test"})
+	var tracker channel.ToolTracker
+	tracker.Handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "main.go"})
+	tracker.Handle(&channel.ToolUseEvent{Tool: "read", Status: "done", Input: "main.go"})
+	tracker.Handle(&channel.ToolUseEvent{Tool: "edit", Status: "running", Input: "main.go"})
+	tracker.Handle(&channel.ToolUseEvent{Tool: "edit", Status: "done", Input: "main.go"})
+	tracker.Handle(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "go test"})
 
-	if len(tracker.history) != 2 {
-		t.Fatalf("history len = %d, want 2", len(tracker.history))
+	if len(tracker.History) != 2 {
+		t.Fatalf("history len = %d, want 2", len(tracker.History))
 	}
-	if tracker.activeTool != "bash" {
-		t.Errorf("activeTool = %q, want %q", tracker.activeTool, "bash")
+	if tracker.ActiveTool != "bash" {
+		t.Errorf("activeTool = %q, want %q", tracker.ActiveTool, "bash")
 	}
 
-	rendered := tracker.render()
+	rendered := tracker.Render()
 	// Should contain two completed tools and one active.
 	if strings.Count(rendered, "✅") != 2 {
 		t.Errorf("render() has %d checkmarks, want 2", strings.Count(rendered, "✅"))
@@ -216,19 +216,19 @@ func TestToolTrackerMultipleTools(t *testing.T) {
 }
 
 func TestToolTrackerRenderFinal(t *testing.T) {
-	var tracker toolTracker
+	var tracker channel.ToolTracker
 
 	// No history → empty string.
-	if got := tracker.renderFinal(); got != "" {
+	if got := tracker.RenderFinal(); got != "" {
 		t.Errorf("renderFinal() with no history = %q, want empty", got)
 	}
 
-	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "main.go"})
-	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "done", Detail: "42 lines"})
-	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "go test"})
-	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "error", Detail: "exit 1"})
+	tracker.Handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "main.go"})
+	tracker.Handle(&channel.ToolUseEvent{Tool: "read", Status: "done", Detail: "42 lines"})
+	tracker.Handle(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "go test"})
+	tracker.Handle(&channel.ToolUseEvent{Tool: "bash", Status: "error", Detail: "exit 1"})
 
-	got := tracker.renderFinal()
+	got := tracker.RenderFinal()
 	if !strings.Contains(got, "——————————————————") {
 		t.Error("renderFinal() missing separator line")
 	}
@@ -253,15 +253,15 @@ func TestToolTrackerRenderFinal(t *testing.T) {
 }
 
 func TestToolTrackerRenderFinalAllSuccess(t *testing.T) {
-	var tracker toolTracker
-	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "a.go"})
-	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "done"})
-	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "b.go"})
-	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "done"})
-	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "go test"})
-	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "done"})
+	var tracker channel.ToolTracker
+	tracker.Handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "a.go"})
+	tracker.Handle(&channel.ToolUseEvent{Tool: "read", Status: "done"})
+	tracker.Handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "b.go"})
+	tracker.Handle(&channel.ToolUseEvent{Tool: "read", Status: "done"})
+	tracker.Handle(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "go test"})
+	tracker.Handle(&channel.ToolUseEvent{Tool: "bash", Status: "done"})
 
-	got := tracker.renderFinal()
+	got := tracker.RenderFinal()
 	if !strings.Contains(got, "📎 3 tools") {
 		t.Errorf("renderFinal() = %q, want '3 tools'", got)
 	}
@@ -278,82 +278,82 @@ func TestToolTrackerRenderFinalAllSuccess(t *testing.T) {
 }
 
 func TestToolTrackerRenderFinalSingleTool(t *testing.T) {
-	var tracker toolTracker
-	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "x.go"})
-	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "done"})
+	var tracker channel.ToolTracker
+	tracker.Handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "x.go"})
+	tracker.Handle(&channel.ToolUseEvent{Tool: "read", Status: "done"})
 
-	got := tracker.renderFinal()
+	got := tracker.RenderFinal()
 	if !strings.Contains(got, "📎 1 tool (") {
 		t.Errorf("renderFinal() = %q, want singular 'tool'", got)
 	}
 }
 
 func TestToolTrackerHasHistory(t *testing.T) {
-	var tracker toolTracker
-	if tracker.hasHistory() {
+	var tracker channel.ToolTracker
+	if tracker.HasHistory() {
 		t.Error("hasHistory() should be false with no tools")
 	}
-	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "x"})
-	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "done", Input: "x"})
-	if !tracker.hasHistory() {
+	tracker.Handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "x"})
+	tracker.Handle(&channel.ToolUseEvent{Tool: "read", Status: "done", Input: "x"})
+	if !tracker.HasHistory() {
 		t.Error("hasHistory() should be true after tool finished")
 	}
 }
 
 func TestToolTrackerMinDisplayDuration(t *testing.T) {
-	var tracker toolTracker
-	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "file.go"})
-	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "done", Input: "file.go"})
+	tracker := channel.ToolTracker{MinDisplayDuration: 2 * time.Second}
+	tracker.Handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "file.go"})
+	tracker.Handle(&channel.ToolUseEvent{Tool: "read", Status: "done", Input: "file.go"})
 
 	// Right after finishing, should still be displaying (minimum duration).
-	if !tracker.isDisplaying() {
+	if !tracker.IsDisplaying() {
 		t.Error("expected isDisplaying=true right after tool finished")
 	}
 }
 
 func TestToolTrackerStartOverwritesActive(t *testing.T) {
-	var tracker toolTracker
+	var tracker channel.ToolTracker
 	// Start one tool, then start another without finishing the first.
-	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "a.go"})
-	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "ls"})
+	tracker.Handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "a.go"})
+	tracker.Handle(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "ls"})
 
 	// The first tool should be auto-finished in history.
-	if len(tracker.history) != 1 {
-		t.Fatalf("history len = %d, want 1", len(tracker.history))
+	if len(tracker.History) != 1 {
+		t.Fatalf("history len = %d, want 1", len(tracker.History))
 	}
-	if tracker.history[0].Tool != "read" {
-		t.Errorf("history[0].Tool = %q, want %q", tracker.history[0].Tool, "read")
+	if tracker.History[0].Tool != "read" {
+		t.Errorf("history[0].Tool = %q, want %q", tracker.History[0].Tool, "read")
 	}
-	if tracker.activeTool != "bash" {
-		t.Errorf("activeTool = %q, want %q", tracker.activeTool, "bash")
+	if tracker.ActiveTool != "bash" {
+		t.Errorf("activeTool = %q, want %q", tracker.ActiveTool, "bash")
 	}
 }
 
 func TestRenderToolRecord(t *testing.T) {
 	tests := []struct {
 		name       string
-		rec        toolRecord
+		rec        channel.ToolRecord
 		wantParts  []string
 		wantAbsent []string
 	}{
 		{
 			name:      "done with input and detail",
-			rec:       toolRecord{Tool: "bash", Input: "ls -la", Status: "done", Detail: "3 files", Duration: 500 * time.Millisecond},
+			rec:       channel.ToolRecord{Tool: "bash", Input: "ls -la", Status: "done", Detail: "3 files", Duration: 500 * time.Millisecond},
 			wantParts: []string{"✅", "⚡", "bash", "ls -la", "→ 3 files", "500ms"},
 		},
 		{
 			name:      "done seconds",
-			rec:       toolRecord{Tool: "read", Input: "main.go", Status: "done", Detail: "42 lines", Duration: 2500 * time.Millisecond},
+			rec:       channel.ToolRecord{Tool: "read", Input: "main.go", Status: "done", Detail: "42 lines", Duration: 2500 * time.Millisecond},
 			wantParts: []string{"✅", "📖", "read", "main.go", "→ 42 lines", "2.5s"},
 		},
 		{
 			name:      "error with detail",
-			rec:       toolRecord{Tool: "bash", Input: "rm -rf /", Status: "error", Detail: "permission denied", Duration: time.Second},
+			rec:       channel.ToolRecord{Tool: "bash", Input: "rm -rf /", Status: "error", Detail: "permission denied", Duration: time.Second},
 			wantParts: []string{"❌", "bash", "rm -rf /", "→ permission denied"},
 		},
 		{
 			name:       "done no input no detail",
-			rec:        toolRecord{Tool: "search", Status: "done", Duration: 100 * time.Millisecond},
+			rec:        channel.ToolRecord{Tool: "search", Status: "done", Duration: 100 * time.Millisecond},
 			wantParts:  []string{"✅", "🔍", "search", "100ms"},
 			wantAbsent: []string{": ", "→"},
 		},
@@ -361,15 +361,15 @@ func TestRenderToolRecord(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := renderToolRecord(tt.rec)
+			got := channel.RenderToolRecord(tt.rec)
 			for _, part := range tt.wantParts {
 				if !strings.Contains(got, part) {
-					t.Errorf("renderToolRecord() = %q, want to contain %q", got, part)
+					t.Errorf("channel.RenderToolRecord() = %q, want to contain %q", got, part)
 				}
 			}
 			for _, absent := range tt.wantAbsent {
 				if strings.Contains(got, absent) {
-					t.Errorf("renderToolRecord() = %q, should not contain %q", got, absent)
+					t.Errorf("channel.RenderToolRecord() = %q, should not contain %q", got, absent)
 				}
 			}
 		})
@@ -389,9 +389,9 @@ func TestTruncate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := truncate(tt.input, tt.maxLen)
+		got := channel.Truncate(tt.input, tt.maxLen)
 		if got != tt.want {
-			t.Errorf("truncate(%q, %d) = %q, want %q", tt.input, tt.maxLen, got, tt.want)
+			t.Errorf("channel.Truncate(%q, %d) = %q, want %q", tt.input, tt.maxLen, got, tt.want)
 		}
 	}
 }
@@ -430,9 +430,9 @@ func TestEmojiFor(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := emojiFor(tt.tool)
+		got := channel.EmojiFor(tt.tool)
 		if got != tt.want {
-			t.Errorf("emojiFor(%q) = %q, want %q", tt.tool, got, tt.want)
+			t.Errorf("channel.EmojiFor(%q) = %q, want %q", tt.tool, got, tt.want)
 		}
 	}
 }
@@ -440,11 +440,11 @@ func TestEmojiFor(t *testing.T) {
 func TestToolEmojiDefaults(t *testing.T) {
 	// Verify all documented tools have emoji entries.
 	for _, tool := range []string{"bash", "read", "write", "edit", "search"} {
-		if _, ok := toolEmoji[tool]; !ok {
+		if _, ok := channel.ToolEmoji[tool]; !ok {
 			t.Errorf("missing emoji for tool %q", tool)
 		}
 	}
-	if _, ok := toolEmoji["default"]; !ok {
+	if _, ok := channel.ToolEmoji["default"]; !ok {
 		t.Error("missing default emoji")
 	}
 }
@@ -547,14 +547,14 @@ func TestAtoiOrZero(t *testing.T) {
 // --- truncate edge cases ---
 
 func TestTruncateEmpty(t *testing.T) {
-	if got := truncate("", 10); got != "" {
-		t.Errorf("truncate('', 10) = %q, want empty", got)
+	if got := channel.Truncate("", 10); got != "" {
+		t.Errorf("channel.Truncate('', 10) = %q, want empty", got)
 	}
 }
 
 func TestTruncateExact(t *testing.T) {
-	if got := truncate("abc", 3); got != "abc" {
-		t.Errorf("truncate(abc, 3) = %q, want abc", got)
+	if got := channel.Truncate("abc", 3); got != "abc" {
+		t.Errorf("channel.Truncate(abc, 3) = %q, want abc", got)
 	}
 }
 

--- a/plugins/channels/telegram/telegram_test.go
+++ b/plugins/channels/telegram/telegram_test.go
@@ -5,8 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/vaayne/anna/internal/agent/runner"
-	"github.com/vaayne/anna/internal/channel"
+	"github.com/vaayne/anna/pkg/channel"
 
 	tgmd "github.com/Mad-Pixels/goldmark-tgmd"
 )
@@ -129,7 +128,7 @@ func TestToolTracker(t *testing.T) {
 	var tracker toolTracker
 
 	// Start a tool.
-	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "running", Input: "ls -la"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "ls -la"})
 	if tracker.activeTool != "bash" {
 		t.Errorf("activeTool = %q, want %q", tracker.activeTool, "bash")
 	}
@@ -149,7 +148,7 @@ func TestToolTracker(t *testing.T) {
 	}
 
 	// Finish the tool.
-	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "done", Input: "ls -la"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "done", Input: "ls -la"})
 	if tracker.activeTool != "" {
 		t.Errorf("activeTool = %q, want empty after done", tracker.activeTool)
 	}
@@ -171,8 +170,8 @@ func TestToolTracker(t *testing.T) {
 
 func TestToolTrackerError(t *testing.T) {
 	var tracker toolTracker
-	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "running", Input: "exit 1"})
-	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "error", Detail: "command failed"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "exit 1"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "error", Detail: "command failed"})
 
 	if len(tracker.history) != 1 {
 		t.Fatalf("history len = %d, want 1", len(tracker.history))
@@ -193,11 +192,11 @@ func TestToolTrackerError(t *testing.T) {
 
 func TestToolTrackerMultipleTools(t *testing.T) {
 	var tracker toolTracker
-	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "running", Input: "main.go"})
-	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "done", Input: "main.go"})
-	tracker.handle(&runner.ToolUseEvent{Tool: "edit", Status: "running", Input: "main.go"})
-	tracker.handle(&runner.ToolUseEvent{Tool: "edit", Status: "done", Input: "main.go"})
-	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "running", Input: "go test"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "main.go"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "done", Input: "main.go"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "edit", Status: "running", Input: "main.go"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "edit", Status: "done", Input: "main.go"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "go test"})
 
 	if len(tracker.history) != 2 {
 		t.Fatalf("history len = %d, want 2", len(tracker.history))
@@ -224,10 +223,10 @@ func TestToolTrackerRenderFinal(t *testing.T) {
 		t.Errorf("renderFinal() with no history = %q, want empty", got)
 	}
 
-	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "running", Input: "main.go"})
-	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "done", Detail: "42 lines"})
-	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "running", Input: "go test"})
-	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "error", Detail: "exit 1"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "main.go"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "done", Detail: "42 lines"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "go test"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "error", Detail: "exit 1"})
 
 	got := tracker.renderFinal()
 	if !strings.Contains(got, "——————————————————") {
@@ -255,12 +254,12 @@ func TestToolTrackerRenderFinal(t *testing.T) {
 
 func TestToolTrackerRenderFinalAllSuccess(t *testing.T) {
 	var tracker toolTracker
-	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "running", Input: "a.go"})
-	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "done"})
-	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "running", Input: "b.go"})
-	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "done"})
-	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "running", Input: "go test"})
-	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "done"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "a.go"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "done"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "b.go"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "done"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "go test"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "done"})
 
 	got := tracker.renderFinal()
 	if !strings.Contains(got, "📎 3 tools") {
@@ -280,8 +279,8 @@ func TestToolTrackerRenderFinalAllSuccess(t *testing.T) {
 
 func TestToolTrackerRenderFinalSingleTool(t *testing.T) {
 	var tracker toolTracker
-	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "running", Input: "x.go"})
-	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "done"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "x.go"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "done"})
 
 	got := tracker.renderFinal()
 	if !strings.Contains(got, "📎 1 tool (") {
@@ -294,8 +293,8 @@ func TestToolTrackerHasHistory(t *testing.T) {
 	if tracker.hasHistory() {
 		t.Error("hasHistory() should be false with no tools")
 	}
-	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "running", Input: "x"})
-	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "done", Input: "x"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "x"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "done", Input: "x"})
 	if !tracker.hasHistory() {
 		t.Error("hasHistory() should be true after tool finished")
 	}
@@ -303,8 +302,8 @@ func TestToolTrackerHasHistory(t *testing.T) {
 
 func TestToolTrackerMinDisplayDuration(t *testing.T) {
 	var tracker toolTracker
-	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "running", Input: "file.go"})
-	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "done", Input: "file.go"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "file.go"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "done", Input: "file.go"})
 
 	// Right after finishing, should still be displaying (minimum duration).
 	if !tracker.isDisplaying() {
@@ -315,8 +314,8 @@ func TestToolTrackerMinDisplayDuration(t *testing.T) {
 func TestToolTrackerStartOverwritesActive(t *testing.T) {
 	var tracker toolTracker
 	// Start one tool, then start another without finishing the first.
-	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "running", Input: "a.go"})
-	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "running", Input: "ls"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "a.go"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "ls"})
 
 	// The first tool should be auto-finished in history.
 	if len(tracker.history) != 1 {

--- a/plugins/channels/weixin/handler.go
+++ b/plugins/channels/weixin/handler.go
@@ -7,9 +7,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/vaayne/anna/internal/agent/runner"
-	"github.com/vaayne/anna/internal/channel"
 	"github.com/vaayne/anna/pkg/ai"
+	"github.com/vaayne/anna/pkg/channel"
 )
 
 // handleUpdates dispatches incoming messages from the getupdates response.
@@ -73,6 +72,18 @@ func (b *Bot) dispatchMessage(msg WeixinMessage) {
 	b.handleImages(msg, images, combinedText)
 }
 
+// incomingMsg builds a channel.IncomingMessage from a weixin message context.
+func (b *Bot) incomingMsg(msg WeixinMessage, content any) channel.IncomingMessage {
+	return channel.IncomingMessage{
+		Platform:   channel.PlatformWeixin,
+		SenderID:   msg.FromUserID,
+		SenderName: "", // no display name available from iLink
+		ChatID:     msg.FromUserID,
+		IsGroup:    false, // DM only for v1
+		Content:    content,
+	}
+}
+
 // handleText processes incoming text messages.
 func (b *Bot) handleText(msg WeixinMessage, text string) {
 	text = strings.TrimSpace(text)
@@ -81,47 +92,36 @@ func (b *Bot) handleText(msg WeixinMessage, text string) {
 	}
 
 	reply := func(resp string) { b.sendReply(msg, resp) }
+	incoming := b.incomingMsg(msg, text)
 
-	// Try link code before anything else.
-	if b.authStore != nil && b.linkCodes != nil {
-		if resp, ok := channel.TryLinkCode(b.ctx, b.authStore, b.linkCodes, text, channel.PlatformWeixin, msg.FromUserID, ""); ok {
+	// Try shared commands via coordinator (/start, /new, /compact, /whoami, /link).
+	fields := strings.Fields(text)
+	if len(fields) > 0 {
+		cmd := fields[0]
+		args := strings.TrimSpace(strings.TrimPrefix(text, cmd))
+		if resp, ok := b.handler.HandleCommand(b.ctx, incoming, cmd, args); ok {
 			reply(resp)
 			return
 		}
 	}
 
-	// Resolve user/agent/session.
-	rc, err := b.resolve(msg.FromUserID)
-	if err != nil {
-		logger().Error("resolve failed", "user_id", msg.FromUserID, "error", err)
-		reply(fmt.Sprintf("Error: %v", err))
-		return
-	}
-
-	// Try shared commands (/start, /new, /compact, /whoami).
-	if resp, ok := channel.HandleCommand(b.ctx, rc, text, msg.FromUserID); ok {
-		reply(resp)
-		return
-	}
-
 	// Parse command for channel-specific handling.
-	fields := strings.Fields(text)
 	if len(fields) > 0 {
 		cmd := strings.ToLower(fields[0])
 		args := channel.ParseCommandArgs(text, fields[0])
 
 		switch cmd {
 		case "/model":
-			b.handleModelCommand(rc, args, reply)
+			b.handleModelCommand(args, reply)
 			return
 		case "/agent":
-			channel.HandleAgentCommand(b.ctx, b.agentCmd, rc, args, reply)
+			b.handleAgentCommand(msg, args, reply)
 			return
 		}
 	}
 
 	// Normal message — send to agent.
-	b.handleMessage(msg, rc, text)
+	b.handleMessage(msg, incoming)
 }
 
 // extractMessageContent walks all items and returns text fragments and image items.
@@ -182,14 +182,8 @@ func (b *Bot) handleImages(msg WeixinMessage, images []*ImageItem, caption strin
 		return
 	}
 
-	rc, err := b.resolve(msg.FromUserID)
-	if err != nil {
-		logger().Error("resolve failed", "user_id", msg.FromUserID, "error", err)
-		b.sendReply(msg, fmt.Sprintf("Error: %v", err))
-		return
-	}
-
-	b.handleMessage(msg, rc, content)
+	incoming := b.incomingMsg(msg, content)
+	b.handleMessage(msg, incoming)
 }
 
 // downloadImage fetches and decrypts a single image from CDN.
@@ -217,26 +211,26 @@ func (b *Bot) downloadImage(userID string, imageItem *ImageItem) ([]byte, error)
 }
 
 // handleMessage is the common flow for text and multimodal messages.
-func (b *Bot) handleMessage(msg WeixinMessage, rc *channel.ResolvedChat, content runner.MessageContent) {
-	events, sessionID, err := rc.Chat(b.ctx, content)
+func (b *Bot) handleMessage(msg WeixinMessage, incoming channel.IncomingMessage) {
+	stream, err := b.handler.HandleMessage(b.ctx, incoming)
 	if err != nil {
 		logger().Error("chat failed", "user_id", msg.FromUserID, "error", err)
 		b.sendReply(msg, fmt.Sprintf("Session error: %v", err))
 		return
 	}
 
-	logger().Debug("message received", "user_id", msg.FromUserID, "session", sessionID)
+	logger().Debug("message received", "user_id", msg.FromUserID, "session", stream.SessionID)
 
 	// Start typing indicator.
 	typingCtx, stopTyping := context.WithCancel(b.ctx)
 	go b.keepTyping(typingCtx, msg)
 
-	response, tracker, images, streamErr := b.streamEvents(msg, events)
+	response, tracker, images, streamErr := b.streamEvents(msg, stream.Events)
 
 	stopTyping()
 
 	if streamErr != nil {
-		logger().Error("agent stream error", "session_id", sessionID, "error", streamErr)
+		logger().Error("agent stream error", "session_id", stream.SessionID, "error", streamErr)
 		if response == "" {
 			response = fmt.Sprintf("Agent error: %v", streamErr)
 		} else {
@@ -258,12 +252,12 @@ func (b *Bot) handleMessage(msg WeixinMessage, rc *channel.ResolvedChat, content
 
 // handleModelCommand processes /model with optional arguments.
 // No args → list models; text with "/" → switch by name; text → filter.
-func (b *Bot) handleModelCommand(rc *channel.ResolvedChat, args string, reply func(string)) {
+func (b *Bot) handleModelCommand(args string, reply func(string)) {
 	query := channel.ParseModelArgs(args)
 
 	// If the query looks like "provider/model", try switching directly.
 	if query != "" && strings.Contains(query, "/") {
-		b.switchModelByName(rc, query, reply)
+		b.switchModelByName(query, reply)
 		return
 	}
 
@@ -281,7 +275,7 @@ func (b *Bot) handleModelCommand(rc *channel.ResolvedChat, args string, reply fu
 
 // modelList returns models optionally filtered by query.
 func (b *Bot) modelList(query string) []channel.IndexedModel {
-	models := b.listFn()
+	models := b.handler.ListModels()
 	if query == "" {
 		return channel.IndexModels(models)
 	}
@@ -289,9 +283,9 @@ func (b *Bot) modelList(query string) []channel.IndexedModel {
 }
 
 // switchModelByName handles model switching by "provider/model" name.
-func (b *Bot) switchModelByName(rc *channel.ResolvedChat, name string, reply func(string)) {
+func (b *Bot) switchModelByName(name string, reply func(string)) {
 	name = strings.ToLower(strings.TrimSpace(name))
-	models := b.listFn()
+	models := b.handler.ListModels()
 	var selected channel.ModelOption
 	found := false
 	for _, m := range models {
@@ -306,18 +300,56 @@ func (b *Bot) switchModelByName(rc *channel.ResolvedChat, name string, reply fun
 		return
 	}
 
-	if _, err := rc.RotateSession(); err != nil {
-		reply(fmt.Sprintf("Error rotating session: %v", err))
+	if err := b.handler.SwitchModel(selected.Provider, selected.Model); err != nil {
+		reply(fmt.Sprintf("Error switching model: %v", err))
 		return
 	}
-	if b.switchFn != nil {
-		if err := b.switchFn(selected.Provider, selected.Model); err != nil {
-			reply(fmt.Sprintf("Error switching model: %v", err))
+	logger().Info("model switched", "provider", selected.Provider, "model", selected.Model)
+	reply(fmt.Sprintf("Switched to %s/%s. Session reset.", selected.Provider, selected.Model))
+}
+
+// handleAgentCommand processes /agent with optional arguments.
+func (b *Bot) handleAgentCommand(msg WeixinMessage, args string, reply func(string)) {
+	incoming := b.incomingMsg(msg, "")
+
+	// Direct switch by slug.
+	if args != "" {
+		if err := b.handler.SwitchAgent(context.Background(), incoming, args); err != nil {
+			reply(fmt.Sprintf("Error switching agent: %v", err))
 			return
 		}
+		logger().Info("agent switched", "agent_id", args)
+		reply(fmt.Sprintf("Switched to agent: %s", args))
+		return
 	}
-	logger().Info("model switched", "key", rc.SessionKey, "provider", selected.Provider, "model", selected.Model)
-	reply(fmt.Sprintf("Switched to %s/%s. Session reset.", selected.Provider, selected.Model))
+
+	agents, currentAgentID, err := b.handler.ListAgents(context.Background(), incoming)
+	if err != nil {
+		reply(fmt.Sprintf("Error listing agents: %v", err))
+		return
+	}
+	if len(agents) == 0 {
+		reply("No agents available.")
+		return
+	}
+
+	indexed := channel.IndexAgents(agents)
+	reply(formatAgentList(indexed, currentAgentID))
+}
+
+// formatAgentList builds a text-based agent list.
+func formatAgentList(agents []channel.IndexedAgent, currentID string) string {
+	var sb strings.Builder
+	sb.WriteString("Available agents:\n\n")
+	for _, ag := range agents {
+		prefix := "• "
+		if ag.ID == currentID {
+			prefix = "✅ "
+		}
+		fmt.Fprintf(&sb, "%s%s (%s)\n", prefix, ag.ID, ag.Name)
+	}
+	sb.WriteString("\nUse /agent <slug> to switch.")
+	return sb.String()
 }
 
 // formatModelList builds a text-based model list.

--- a/plugins/channels/weixin/handler.go
+++ b/plugins/channels/weixin/handler.go
@@ -94,18 +94,8 @@ func (b *Bot) handleText(msg WeixinMessage, text string) {
 	reply := func(resp string) { b.sendReply(msg, resp) }
 	incoming := b.incomingMsg(msg, channel.TextContent(text))
 
-	// Try shared commands via coordinator (/start, /new, /compact, /whoami, /link).
+	// Handle plugin-local commands first.
 	fields := strings.Fields(text)
-	if len(fields) > 0 {
-		cmd := fields[0]
-		args := strings.TrimSpace(strings.TrimPrefix(text, cmd))
-		if resp, ok := b.handler.HandleCommand(b.ctx, incoming, cmd, args); ok {
-			reply(resp)
-			return
-		}
-	}
-
-	// Parse command for channel-specific handling.
 	if len(fields) > 0 {
 		cmd := strings.ToLower(fields[0])
 		args := channel.ParseCommandArgs(text, fields[0])
@@ -120,8 +110,9 @@ func (b *Bot) handleText(msg WeixinMessage, text string) {
 		}
 	}
 
-	// Normal message — send to agent.
-	b.handleMessage(msg, incoming)
+	// Delegate to coordinator (shared commands + chat streaming).
+	cmd, args := parseWeixinCommand(text)
+	b.handleIncoming(msg, incoming, cmd, args)
 }
 
 // extractMessageContent walks all items and returns text fragments and image items.
@@ -183,7 +174,7 @@ func (b *Bot) handleImages(msg WeixinMessage, images []*ImageItem, caption strin
 	}
 
 	incoming := b.incomingMsg(msg, content)
-	b.handleMessage(msg, incoming)
+	b.handleIncoming(msg, incoming, "", "")
 }
 
 // downloadImage fetches and decrypts a single image from CDN.
@@ -210,12 +201,16 @@ func (b *Bot) downloadImage(userID string, imageItem *ImageItem) ([]byte, error)
 	return data, nil
 }
 
-// handleMessage is the common flow for text and multimodal messages.
-func (b *Bot) handleMessage(msg WeixinMessage, incoming channel.IncomingMessage) {
-	stream, err := b.handler.HandleMessage(b.ctx, incoming)
+// handleIncoming delegates to the coordinator via HandleIncoming.
+func (b *Bot) handleIncoming(msg WeixinMessage, incoming channel.IncomingMessage, cmd, args string) {
+	resp, handled, stream, err := b.handler.HandleIncoming(b.ctx, incoming, cmd, args)
 	if err != nil {
 		logger().Error("chat failed", "user_id", msg.FromUserID, "error", err)
 		b.sendReply(msg, fmt.Sprintf("Session error: %v", err))
+		return
+	}
+	if handled {
+		b.sendReply(msg, resp)
 		return
 	}
 
@@ -352,4 +347,15 @@ func (b *Bot) sendReply(msg WeixinMessage, text string) {
 	if err := b.client.SendMessage(reply, ""); err != nil {
 		logger().Error("send reply failed", "user_id", msg.FromUserID, "error", err)
 	}
+}
+
+// parseWeixinCommand extracts command and args from text.
+func parseWeixinCommand(text string) (string, string) {
+	fields := strings.Fields(text)
+	if len(fields) == 0 || !strings.HasPrefix(fields[0], "/") {
+		return "", ""
+	}
+	cmd := fields[0]
+	args := channel.ParseCommandArgs(text, cmd)
+	return cmd, args
 }

--- a/plugins/channels/weixin/handler.go
+++ b/plugins/channels/weixin/handler.go
@@ -73,7 +73,7 @@ func (b *Bot) dispatchMessage(msg WeixinMessage) {
 }
 
 // incomingMsg builds a channel.IncomingMessage from a weixin message context.
-func (b *Bot) incomingMsg(msg WeixinMessage, content any) channel.IncomingMessage {
+func (b *Bot) incomingMsg(msg WeixinMessage, content []ai.ContentBlock) channel.IncomingMessage {
 	return channel.IncomingMessage{
 		Platform:   channel.PlatformWeixin,
 		SenderID:   msg.FromUserID,
@@ -92,7 +92,7 @@ func (b *Bot) handleText(msg WeixinMessage, text string) {
 	}
 
 	reply := func(resp string) { b.sendReply(msg, resp) }
-	incoming := b.incomingMsg(msg, text)
+	incoming := b.incomingMsg(msg, channel.TextContent(text))
 
 	// Try shared commands via coordinator (/start, /new, /compact, /whoami, /link).
 	fields := strings.Fields(text)
@@ -300,7 +300,7 @@ func (b *Bot) switchModelByName(name string, reply func(string)) {
 
 // handleAgentCommand processes /agent with optional arguments.
 func (b *Bot) handleAgentCommand(msg WeixinMessage, args string, reply func(string)) {
-	incoming := b.incomingMsg(msg, "")
+	incoming := b.incomingMsg(msg, nil)
 
 	// Direct switch by slug.
 	if args != "" {

--- a/plugins/channels/weixin/handler.go
+++ b/plugins/channels/weixin/handler.go
@@ -237,8 +237,8 @@ func (b *Bot) handleIncoming(msg WeixinMessage, incoming channel.IncomingMessage
 		response = "(empty response)"
 	}
 
-	if tracker != nil && tracker.hasHistory() {
-		response += tracker.renderFinal()
+	if tracker != nil && tracker.HasHistory() {
+		response += tracker.RenderFinal()
 	}
 
 	b.sendFinalResponse(msg, response, images)

--- a/plugins/channels/weixin/handler.go
+++ b/plugins/channels/weixin/handler.go
@@ -270,7 +270,7 @@ func (b *Bot) handleModelCommand(args string, reply func(string)) {
 		}
 		return
 	}
-	reply(formatModelList(models, query))
+	reply(channel.FormatModelList(models, query))
 }
 
 // modelList returns models optionally filtered by query.
@@ -284,18 +284,8 @@ func (b *Bot) modelList(query string) []channel.IndexedModel {
 
 // switchModelByName handles model switching by "provider/model" name.
 func (b *Bot) switchModelByName(name string, reply func(string)) {
-	name = strings.ToLower(strings.TrimSpace(name))
-	models := b.handler.ListModels()
-	var selected channel.ModelOption
-	found := false
-	for _, m := range models {
-		if strings.ToLower(m.Provider+"/"+m.Model) == name {
-			selected = m
-			found = true
-			break
-		}
-	}
-	if !found {
+	selected, ok := channel.FindModelByName(b.handler.ListModels(), name)
+	if !ok {
 		reply(fmt.Sprintf("Unknown model %q, use /model to list available models.", name))
 		return
 	}
@@ -334,37 +324,7 @@ func (b *Bot) handleAgentCommand(msg WeixinMessage, args string, reply func(stri
 	}
 
 	indexed := channel.IndexAgents(agents)
-	reply(formatAgentList(indexed, currentAgentID))
-}
-
-// formatAgentList builds a text-based agent list.
-func formatAgentList(agents []channel.IndexedAgent, currentID string) string {
-	var sb strings.Builder
-	sb.WriteString("Available agents:\n\n")
-	for _, ag := range agents {
-		prefix := "• "
-		if ag.ID == currentID {
-			prefix = "✅ "
-		}
-		fmt.Fprintf(&sb, "%s%s (%s)\n", prefix, ag.ID, ag.Name)
-	}
-	sb.WriteString("\nUse /agent <slug> to switch.")
-	return sb.String()
-}
-
-// formatModelList builds a text-based model list.
-func formatModelList(models []channel.IndexedModel, query string) string {
-	var sb strings.Builder
-	sb.WriteString("Available models")
-	if query != "" {
-		fmt.Fprintf(&sb, " (filter: %q)", query)
-	}
-	sb.WriteString(":\n\n")
-	for _, m := range models {
-		fmt.Fprintf(&sb, "• %s/%s\n", m.Provider, m.Model)
-	}
-	sb.WriteString("\nUse /model <provider/model> to switch.")
-	return sb.String()
+	reply(channel.FormatAgentList(indexed, currentAgentID))
 }
 
 // sendReply sends a text reply to the message sender using the cached context_token.

--- a/plugins/channels/weixin/render.go
+++ b/plugins/channels/weixin/render.go
@@ -6,13 +6,12 @@ import (
 	"encoding/hex"
 	"strconv"
 
-	"github.com/vaayne/anna/internal/agent/runner"
-	"github.com/vaayne/anna/internal/channel"
+	"github.com/vaayne/anna/pkg/channel"
 )
 
 // sendFinalResponse splits text at 2000 chars and sends each chunk,
 // then sends any collected images.
-func (b *Bot) sendFinalResponse(msg WeixinMessage, response string, images []runner.ImageEvent) {
+func (b *Bot) sendFinalResponse(msg WeixinMessage, response string, images []channel.ImageEvent) {
 	chunks := channel.SplitMessage(response, weixinMaxMessageLen)
 
 	contextToken := ""
@@ -45,7 +44,7 @@ func (b *Bot) sendFinalResponse(msg WeixinMessage, response string, images []run
 }
 
 // sendImage encrypts and uploads an image to CDN, then sends it as a message.
-func (b *Bot) sendImage(msg WeixinMessage, img runner.ImageEvent) {
+func (b *Bot) sendImage(msg WeixinMessage, img channel.ImageEvent) {
 	data, err := decodeBase64(img.Data)
 	if err != nil {
 		logger().Error("decode image failed", "error", err)

--- a/plugins/channels/weixin/stream.go
+++ b/plugins/channels/weixin/stream.go
@@ -2,10 +2,8 @@ package weixin
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	"github.com/vaayne/anna/pkg/channel"
 )
@@ -19,196 +17,19 @@ const (
 	typingInterval = 5 * time.Second
 )
 
-// toolEmoji maps known tool names to display emoji.
-var toolEmoji = map[string]string{
-	"bash":    "⚡",
-	"read":    "📖",
-	"write":   "✏️",
-	"edit":    "🔧",
-	"search":  "🔍",
-	"default": "🔧",
-}
+const minToolDisplayDuration = 2 * time.Second
 
-// toolRecord holds a completed tool invocation for the summary section.
-type toolRecord struct {
-	Tool     string
-	Input    string
-	Status   string // "done" or "error"
-	Detail   string
-	Duration time.Duration
-}
-
-// toolTracker tracks active and completed tool invocations during streaming.
-type toolTracker struct {
-	history      []toolRecord
-	activeTool   string
-	activeInput  string
-	activeStart  time.Time
-	displayUntil time.Time
-}
-
-// start registers a new tool as running.
-func (tt *toolTracker) start(t *channel.ToolUseEvent) {
-	if tt.activeTool != "" {
-		tt.history = append(tt.history, toolRecord{
-			Tool:     tt.activeTool,
-			Input:    tt.activeInput,
-			Status:   "done",
-			Duration: time.Since(tt.activeStart),
-		})
-	}
-	tt.activeTool = t.Tool
-	tt.activeInput = t.Input
-	tt.activeStart = time.Now()
-	tt.displayUntil = time.Time{}
-}
-
-// finish records the active tool as completed.
-func (tt *toolTracker) finish(t *channel.ToolUseEvent) {
-	dur := time.Since(tt.activeStart)
-	input := tt.activeInput
-	if t.Input != "" {
-		input = t.Input
-	}
-	tt.history = append(tt.history, toolRecord{
-		Tool:     t.Tool,
-		Input:    input,
-		Status:   t.Status,
-		Detail:   t.Detail,
-		Duration: dur,
-	})
-	tt.displayUntil = time.Now().Add(2 * time.Second)
-	tt.activeTool = ""
-	tt.activeInput = ""
-	tt.activeStart = time.Time{}
-}
-
-// handle processes a tool event, returning true if a display refresh is needed.
-func (tt *toolTracker) handle(t *channel.ToolUseEvent) bool {
-	switch t.Status {
-	case "running":
-		tt.start(t)
-		return true
-	case "done", "error":
-		tt.finish(t)
-		return true
-	}
-	return false
-}
-
-// hasHistory returns true if any tools were tracked.
-func (tt *toolTracker) hasHistory() bool {
-	return len(tt.history) > 0
-}
-
-// renderFinal builds a compact tool summary for the final message.
-func (tt *toolTracker) renderFinal() string {
-	if len(tt.history) == 0 {
-		return ""
-	}
-
-	type toolCount struct {
-		name  string
-		count int
-	}
-	seen := map[string]int{}
-	var counts []toolCount
-	var totalDur time.Duration
-	var errors []toolRecord
-
-	for _, rec := range tt.history {
-		totalDur += rec.Duration
-		if rec.Status == "error" {
-			errors = append(errors, rec)
-		}
-		if idx, ok := seen[rec.Tool]; ok {
-			counts[idx].count++
-		} else {
-			seen[rec.Tool] = len(counts)
-			counts = append(counts, toolCount{name: rec.Tool, count: 1})
-		}
-	}
-
-	var sb strings.Builder
-	sb.WriteString("\n\n——————————————————\n")
-
-	total := len(tt.history)
-	fmt.Fprintf(&sb, "📎 %d tool", total)
-	if total != 1 {
-		sb.WriteByte('s')
-	}
-	sb.WriteString(" (")
-	for i, tc := range counts {
-		if i > 0 {
-			sb.WriteString(", ")
-		}
-		emoji := emojiFor(tc.name)
-		if tc.count > 1 {
-			fmt.Fprintf(&sb, "%d× %s%s", tc.count, emoji, tc.name)
-		} else {
-			sb.WriteString(emoji + tc.name)
-		}
-	}
-	sb.WriteString(") · ")
-	sb.WriteString(channel.FormatDuration(totalDur))
-
-	for _, rec := range errors {
-		sb.WriteByte('\n')
-		sb.WriteString(renderToolRecord(rec))
-	}
-
-	return sb.String()
-}
-
-// renderToolRecord formats a single completed tool record.
-func renderToolRecord(rec toolRecord) string {
-	statusEmoji := "✅"
-	if rec.Status == "error" {
-		statusEmoji = "❌"
-	}
-	emoji := emojiFor(rec.Tool)
-	line := fmt.Sprintf("%s %s %s", statusEmoji, emoji, rec.Tool)
-	if rec.Input != "" {
-		input := truncate(rec.Input, 60)
-		line += ": " + input
-	}
-	if rec.Detail != "" {
-		detail := truncate(rec.Detail, 80)
-		line += " → " + detail
-	}
-	line += fmt.Sprintf(" (%s)", channel.FormatDuration(rec.Duration))
-	return line
-}
-
-// emojiFor returns the emoji for a tool name.
-func emojiFor(tool string) string {
-	if e, ok := toolEmoji[tool]; ok {
-		return e
-	}
-	return toolEmoji["default"]
-}
-
-// truncate shortens s to maxLen bytes, appending "..." if truncated.
-func truncate(s string, maxLen int) string {
-	if len(s) <= maxLen {
-		return s
-	}
-	if maxLen <= 3 {
-		return "..."
-	}
-	cutAt := maxLen - 3
-	for cutAt > 0 && !utf8.RuneStart(s[cutAt]) {
-		cutAt--
-	}
-	return s[:cutAt] + "..."
+// newToolTracker creates a ToolTracker configured for WeChat display.
+func newToolTracker() channel.ToolTracker {
+	return channel.ToolTracker{MinDisplayDuration: minToolDisplayDuration}
 }
 
 // streamEvents consumes the agent event stream, accumulates text, and tracks tools.
 // Returns the final response text, tool tracker, collected images, and any stream error.
-func (b *Bot) streamEvents(msg WeixinMessage, events <-chan channel.Event) (string, *toolTracker, []channel.ImageEvent, error) {
+func (b *Bot) streamEvents(msg WeixinMessage, events <-chan channel.Event) (string, *channel.ToolTracker, []channel.ImageEvent, error) {
 	var sb strings.Builder
 	var streamErr error
-	var tt toolTracker
+	tt := newToolTracker()
 	var images []channel.ImageEvent
 
 	for evt := range events {
@@ -223,7 +44,7 @@ func (b *Bot) streamEvents(msg WeixinMessage, events <-chan channel.Event) (stri
 		}
 
 		if evt.ToolUse != nil {
-			tt.handle(evt.ToolUse)
+			tt.Handle(evt.ToolUse)
 		}
 
 		sb.WriteString(evt.Text)

--- a/plugins/channels/weixin/stream.go
+++ b/plugins/channels/weixin/stream.go
@@ -7,8 +7,7 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/vaayne/anna/internal/agent/runner"
-	"github.com/vaayne/anna/internal/channel"
+	"github.com/vaayne/anna/pkg/channel"
 )
 
 const (
@@ -49,7 +48,7 @@ type toolTracker struct {
 }
 
 // start registers a new tool as running.
-func (tt *toolTracker) start(t *runner.ToolUseEvent) {
+func (tt *toolTracker) start(t *channel.ToolUseEvent) {
 	if tt.activeTool != "" {
 		tt.history = append(tt.history, toolRecord{
 			Tool:     tt.activeTool,
@@ -65,7 +64,7 @@ func (tt *toolTracker) start(t *runner.ToolUseEvent) {
 }
 
 // finish records the active tool as completed.
-func (tt *toolTracker) finish(t *runner.ToolUseEvent) {
+func (tt *toolTracker) finish(t *channel.ToolUseEvent) {
 	dur := time.Since(tt.activeStart)
 	input := tt.activeInput
 	if t.Input != "" {
@@ -85,7 +84,7 @@ func (tt *toolTracker) finish(t *runner.ToolUseEvent) {
 }
 
 // handle processes a tool event, returning true if a display refresh is needed.
-func (tt *toolTracker) handle(t *runner.ToolUseEvent) bool {
+func (tt *toolTracker) handle(t *channel.ToolUseEvent) bool {
 	switch t.Status {
 	case "running":
 		tt.start(t)
@@ -206,11 +205,11 @@ func truncate(s string, maxLen int) string {
 
 // streamEvents consumes the agent event stream, accumulates text, and tracks tools.
 // Returns the final response text, tool tracker, collected images, and any stream error.
-func (b *Bot) streamEvents(msg WeixinMessage, events <-chan runner.Event) (string, *toolTracker, []runner.ImageEvent, error) {
+func (b *Bot) streamEvents(msg WeixinMessage, events <-chan channel.Event) (string, *toolTracker, []channel.ImageEvent, error) {
 	var sb strings.Builder
 	var streamErr error
 	var tt toolTracker
-	var images []runner.ImageEvent
+	var images []channel.ImageEvent
 
 	for evt := range events {
 		if evt.Err != nil {

--- a/plugins/channels/weixin/weixin.go
+++ b/plugins/channels/weixin/weixin.go
@@ -22,7 +22,7 @@ type Config struct {
 // It implements channel.Channel.
 type Bot struct {
 	client  *Client
-	handler channel.MessageHandler
+	handler channel.Handler
 
 	contextTokens sync.Map // key: userID string, value: contextToken string
 	typingTickets sync.Map // key: userID string, value: typingTicket string
@@ -37,7 +37,7 @@ type Bot struct {
 }
 
 // New creates a WeChat iLink bot. Call Start to begin polling.
-func New(cfg Config, handler channel.MessageHandler) (*Bot, error) {
+func New(cfg Config, handler channel.Handler) (*Bot, error) {
 	if cfg.BotToken == "" {
 		return nil, fmt.Errorf("weixin: bot_token is required")
 	}

--- a/plugins/channels/weixin/weixin.go
+++ b/plugins/channels/weixin/weixin.go
@@ -2,16 +2,12 @@ package weixin
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
 	"time"
 
-	"github.com/vaayne/anna/internal/agent"
-	"github.com/vaayne/anna/internal/auth"
-	"github.com/vaayne/anna/internal/channel"
-	"github.com/vaayne/anna/internal/config"
+	"github.com/vaayne/anna/pkg/channel"
 )
 
 // Config holds WeChat iLink bot settings.
@@ -22,65 +18,33 @@ type Config struct {
 	UserID   string `json:"user_id"`   // ilink_user_id
 }
 
-// dbConfig is the JSON shape persisted in settings_plugins.config.
-// It extends Config with runtime state fields.
-type dbConfig struct {
-	Config
-	GetUpdatesBuf string `json:"get_updates_buf,omitempty"`
-}
-
 // Bot wraps a WeChat iLink bot with agent pool integration.
 // It implements channel.Channel.
 type Bot struct {
-	client      *Client
-	poolManager *agent.PoolManager
-	store       config.Store
-	authStore   auth.AuthStore
-	engine      *auth.PolicyEngine
-	linkCodes   *auth.LinkCodeStore
-	agentCmd    *channel.AgentCommander
-	listFn      channel.ModelListFunc
-	switchFn    channel.ModelSwitchFunc
+	client  *Client
+	handler channel.MessageHandler
 
 	contextTokens sync.Map // key: userID string, value: contextToken string
 	typingTickets sync.Map // key: userID string, value: typingTicket string
+
+	// cursor holds the getupdates cursor in memory. It is lost on restart
+	// but repopulated immediately on the first getupdates response.
+	cursor string
 
 	cfg    Config
 	ctx    context.Context
 	cancel context.CancelFunc
 }
 
-// BotOption configures the WeChat Bot.
-type BotOption func(*Bot)
-
-// WithAuth configures the bot with auth store and link code store for
-// account linking support.
-func WithAuth(authStore auth.AuthStore, engine *auth.PolicyEngine, linkCodes *auth.LinkCodeStore) BotOption {
-	return func(b *Bot) {
-		b.authStore = authStore
-		b.engine = engine
-		b.linkCodes = linkCodes
-		b.agentCmd = channel.NewAgentCommander(b.store, authStore)
-	}
-}
-
 // New creates a WeChat iLink bot. Call Start to begin polling.
-func New(cfg Config, pm *agent.PoolManager, store config.Store, listFn channel.ModelListFunc, switchFn channel.ModelSwitchFunc, opts ...BotOption) (*Bot, error) {
+func New(cfg Config, handler channel.MessageHandler) (*Bot, error) {
 	if cfg.BotToken == "" {
 		return nil, fmt.Errorf("weixin: bot_token is required")
 	}
 
 	b := &Bot{
-		poolManager: pm,
-		store:       store,
-		agentCmd:    channel.NewAgentCommander(store, nil),
-		listFn:      listFn,
-		switchFn:    switchFn,
-		cfg:         cfg,
-	}
-
-	for _, opt := range opts {
-		opt(b)
+		handler: handler,
+		cfg:     cfg,
 	}
 
 	return b, nil
@@ -104,9 +68,6 @@ func (b *Bot) Start(ctx context.Context) error {
 	// Create the client with config values.
 	b.client = NewClient(b.cfg.BaseURL, "", b.cfg.BotToken)
 
-	// Load saved cursor from DB channel config.
-	buf := b.loadCursor()
-
 	// Poll loop with retry/backoff.
 	timeout := 35 * time.Second
 	consecutiveFailures := 0
@@ -121,12 +82,12 @@ func (b *Bot) Start(ctx context.Context) error {
 		default:
 		}
 
-		resp, err := b.client.GetUpdates(buf, "", timeout)
+		resp, err := b.client.GetUpdates(b.cursor, "", timeout)
 		if err != nil {
 			if errors.Is(err, ErrSessionExpired) {
 				logger().Error("session expired, clearing all state")
-				b.clearCredentials()
-				return fmt.Errorf("weixin: session expired (ret=-14), credentials cleared")
+				b.clearState()
+				return fmt.Errorf("weixin: session expired (ret=-14)")
 			}
 
 			// Local timeout — treat as empty response, continue.
@@ -154,10 +115,9 @@ func (b *Bot) Start(ctx context.Context) error {
 		// Success — reset failure counter.
 		consecutiveFailures = 0
 
-		// Update cursor and persist.
+		// Update cursor.
 		if resp.GetUpdatesBuf != "" {
-			buf = resp.GetUpdatesBuf
-			b.persistCursor(buf)
+			b.cursor = resp.GetUpdatesBuf
 		}
 
 		// Use adaptive timeout from response.
@@ -210,83 +170,11 @@ func (b *Bot) Notify(_ context.Context, n channel.Notification) error {
 	return nil
 }
 
-// resolve performs full user/agent/pool/session-key resolution.
-func (b *Bot) resolve(userID string) (*channel.ResolvedChat, error) {
-	return channel.Resolve(
-		context.Background(),
-		b.poolManager,
-		b.store,
-		b.authStore,
-		b.engine,
-		channel.PlatformWeixin,
-		userID,
-		"",     // no display name available from iLink
-		userID, // chatID = userID for DM
-		false,  // DM only for v1
-	)
-}
-
-// loadCursor loads the get_updates_buf cursor from the plugin config.
-func (b *Bot) loadCursor() string {
-	pluginID := config.PluginID(config.PluginKindChannel, channel.PlatformWeixin)
-	p, err := b.store.GetPlugin(context.Background(), pluginID)
-	if err != nil {
-		return ""
-	}
-	var dc dbConfig
-	data, err := json.Marshal(p.Config)
-	if err != nil {
-		return ""
-	}
-	if err := json.Unmarshal(data, &dc); err != nil {
-		return ""
-	}
-	return dc.GetUpdatesBuf
-}
-
-// persistCursor saves the get_updates_buf cursor to the plugin config.
-func (b *Bot) persistCursor(buf string) {
-	pluginID := config.PluginID(config.PluginKindChannel, channel.PlatformWeixin)
-	p, err := b.store.GetPlugin(context.Background(), pluginID)
-	if err != nil {
-		logger().Warn("failed to load plugin config for cursor persist", "error", err)
-		return
-	}
-	if p.Config == nil {
-		p.Config = make(map[string]any)
-	}
-	p.Config["get_updates_buf"] = buf
-
-	if err := b.store.UpsertPlugin(context.Background(), p); err != nil {
-		logger().Warn("failed to persist cursor", "error", err)
-	}
-}
-
-// clearCredentials removes credentials and state from DB and in-memory caches.
-func (b *Bot) clearCredentials() {
-	// Clear in-memory caches.
+// clearState clears in-memory caches on session expiry.
+func (b *Bot) clearState() {
 	b.contextTokens = sync.Map{}
 	b.typingTickets = sync.Map{}
-
-	// Clear credentials from plugin config.
-	pluginID := config.PluginID(config.PluginKindChannel, channel.PlatformWeixin)
-	p, err := b.store.GetPlugin(context.Background(), pluginID)
-	if err != nil {
-		logger().Warn("failed to load plugin config for credential clear", "error", err)
-		return
-	}
-	if p.Config == nil {
-		p.Config = make(map[string]any)
-	}
-
-	delete(p.Config, "bot_token")
-	delete(p.Config, "bot_id")
-	delete(p.Config, "user_id")
-	delete(p.Config, "get_updates_buf")
-
-	if err := b.store.UpsertPlugin(context.Background(), p); err != nil {
-		logger().Warn("failed to clear credentials in DB", "error", err)
-	}
+	b.cursor = ""
 }
 
 // isTimeoutError checks if an error is a network timeout.

--- a/plugins/channels/weixin/weixin_test.go
+++ b/plugins/channels/weixin/weixin_test.go
@@ -689,54 +689,54 @@ func TestStopWithoutCancel(t *testing.T) {
 func TestToolTracker(t *testing.T) {
 	t.Parallel()
 
-	var tracker toolTracker
+	var tracker channel.ToolTracker
 
-	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "ls -la"})
-	if tracker.activeTool != "bash" {
-		t.Errorf("activeTool = %q, want %q", tracker.activeTool, "bash")
+	tracker.Handle(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "ls -la"})
+	if tracker.ActiveTool != "bash" {
+		t.Errorf("activeTool = %q, want %q", tracker.ActiveTool, "bash")
 	}
 
-	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "done", Input: "ls -la"})
-	if tracker.activeTool != "" {
-		t.Errorf("activeTool = %q, want empty after done", tracker.activeTool)
+	tracker.Handle(&channel.ToolUseEvent{Tool: "bash", Status: "done", Input: "ls -la"})
+	if tracker.ActiveTool != "" {
+		t.Errorf("activeTool = %q, want empty after done", tracker.ActiveTool)
 	}
-	if len(tracker.history) != 1 {
-		t.Fatalf("history len = %d, want 1", len(tracker.history))
+	if len(tracker.History) != 1 {
+		t.Fatalf("history len = %d, want 1", len(tracker.History))
 	}
-	if tracker.history[0].Tool != "bash" {
-		t.Errorf("history[0].Tool = %q, want %q", tracker.history[0].Tool, "bash")
+	if tracker.History[0].Tool != "bash" {
+		t.Errorf("history[0].Tool = %q, want %q", tracker.History[0].Tool, "bash")
 	}
 }
 
 func TestToolTrackerError(t *testing.T) {
 	t.Parallel()
 
-	var tracker toolTracker
-	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "exit 1"})
-	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "error", Detail: "command failed"})
+	var tracker channel.ToolTracker
+	tracker.Handle(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "exit 1"})
+	tracker.Handle(&channel.ToolUseEvent{Tool: "bash", Status: "error", Detail: "command failed"})
 
-	if len(tracker.history) != 1 {
-		t.Fatalf("history len = %d, want 1", len(tracker.history))
+	if len(tracker.History) != 1 {
+		t.Fatalf("history len = %d, want 1", len(tracker.History))
 	}
-	if tracker.history[0].Status != "error" {
-		t.Errorf("status = %q, want %q", tracker.history[0].Status, "error")
+	if tracker.History[0].Status != "error" {
+		t.Errorf("status = %q, want %q", tracker.History[0].Status, "error")
 	}
 }
 
 func TestToolTrackerRenderFinal(t *testing.T) {
 	t.Parallel()
 
-	var tracker toolTracker
-	if got := tracker.renderFinal(); got != "" {
+	var tracker channel.ToolTracker
+	if got := tracker.RenderFinal(); got != "" {
 		t.Errorf("renderFinal() with no history = %q, want empty", got)
 	}
 
-	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "main.go"})
-	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "done", Detail: "42 lines"})
-	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "go test"})
-	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "error", Detail: "exit 1"})
+	tracker.Handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "main.go"})
+	tracker.Handle(&channel.ToolUseEvent{Tool: "read", Status: "done", Detail: "42 lines"})
+	tracker.Handle(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "go test"})
+	tracker.Handle(&channel.ToolUseEvent{Tool: "bash", Status: "error", Detail: "exit 1"})
 
-	got := tracker.renderFinal()
+	got := tracker.RenderFinal()
 	if !strings.Contains(got, "——————————————————") {
 		t.Error("renderFinal() missing separator line")
 	}
@@ -754,13 +754,13 @@ func TestToolTrackerRenderFinal(t *testing.T) {
 func TestToolTrackerHasHistory(t *testing.T) {
 	t.Parallel()
 
-	var tracker toolTracker
-	if tracker.hasHistory() {
+	var tracker channel.ToolTracker
+	if tracker.HasHistory() {
 		t.Error("hasHistory() should be false with no tools")
 	}
-	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "x"})
-	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "done", Input: "x"})
-	if !tracker.hasHistory() {
+	tracker.Handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "x"})
+	tracker.Handle(&channel.ToolUseEvent{Tool: "read", Status: "done", Input: "x"})
+	if !tracker.HasHistory() {
 		t.Error("hasHistory() should be true after tool finished")
 	}
 }
@@ -768,18 +768,18 @@ func TestToolTrackerHasHistory(t *testing.T) {
 func TestToolTrackerStartOverwritesActive(t *testing.T) {
 	t.Parallel()
 
-	var tracker toolTracker
-	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "a.go"})
-	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "ls"})
+	var tracker channel.ToolTracker
+	tracker.Handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "a.go"})
+	tracker.Handle(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "ls"})
 
-	if len(tracker.history) != 1 {
-		t.Fatalf("history len = %d, want 1", len(tracker.history))
+	if len(tracker.History) != 1 {
+		t.Fatalf("history len = %d, want 1", len(tracker.History))
 	}
-	if tracker.history[0].Tool != "read" {
-		t.Errorf("history[0].Tool = %q, want %q", tracker.history[0].Tool, "read")
+	if tracker.History[0].Tool != "read" {
+		t.Errorf("history[0].Tool = %q, want %q", tracker.History[0].Tool, "read")
 	}
-	if tracker.activeTool != "bash" {
-		t.Errorf("activeTool = %q, want %q", tracker.activeTool, "bash")
+	if tracker.ActiveTool != "bash" {
+		t.Errorf("activeTool = %q, want %q", tracker.ActiveTool, "bash")
 	}
 }
 
@@ -801,8 +801,8 @@ func TestEmojiFor(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		if got := emojiFor(tt.tool); got != tt.want {
-			t.Errorf("emojiFor(%q) = %q, want %q", tt.tool, got, tt.want)
+		if got := channel.EmojiFor(tt.tool); got != tt.want {
+			t.Errorf("channel.EmojiFor(%q) = %q, want %q", tt.tool, got, tt.want)
 		}
 	}
 }
@@ -825,9 +825,9 @@ func TestTruncate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := truncate(tt.input, tt.maxLen)
+		got := channel.Truncate(tt.input, tt.maxLen)
 		if got != tt.want {
-			t.Errorf("truncate(%q, %d) = %q, want %q", tt.input, tt.maxLen, got, tt.want)
+			t.Errorf("channel.Truncate(%q, %d) = %q, want %q", tt.input, tt.maxLen, got, tt.want)
 		}
 	}
 }
@@ -862,27 +862,27 @@ func TestRenderToolRecord(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		rec       toolRecord
+		rec       channel.ToolRecord
 		wantParts []string
 	}{
 		{
 			name:      "done with input and detail",
-			rec:       toolRecord{Tool: "bash", Input: "ls -la", Status: "done", Detail: "3 files", Duration: 500 * time.Millisecond},
+			rec:       channel.ToolRecord{Tool: "bash", Input: "ls -la", Status: "done", Detail: "3 files", Duration: 500 * time.Millisecond},
 			wantParts: []string{"✅", "⚡", "bash", "ls -la", "→ 3 files", "500ms"},
 		},
 		{
 			name:      "error with detail",
-			rec:       toolRecord{Tool: "bash", Input: "rm -rf /", Status: "error", Detail: "permission denied", Duration: time.Second},
+			rec:       channel.ToolRecord{Tool: "bash", Input: "rm -rf /", Status: "error", Detail: "permission denied", Duration: time.Second},
 			wantParts: []string{"❌", "bash", "rm -rf /", "→ permission denied"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := renderToolRecord(tt.rec)
+			got := channel.RenderToolRecord(tt.rec)
 			for _, part := range tt.wantParts {
 				if !strings.Contains(got, part) {
-					t.Errorf("renderToolRecord() = %q, want to contain %q", got, part)
+					t.Errorf("channel.RenderToolRecord() = %q, want to contain %q", got, part)
 				}
 			}
 		})

--- a/plugins/channels/weixin/weixin_test.go
+++ b/plugins/channels/weixin/weixin_test.go
@@ -898,7 +898,7 @@ func TestFormatModelListNoQuery(t *testing.T) {
 		{Provider: "openai", Model: "gpt-4"},
 		{Provider: "anthropic", Model: "claude-3"},
 	})
-	out := formatModelList(models, "")
+	out := channel.FormatModelList(models, "")
 	if !strings.Contains(out, "openai/gpt-4") {
 		t.Errorf("missing model entry: %s", out)
 	}
@@ -916,7 +916,7 @@ func TestFormatModelListWithQuery(t *testing.T) {
 	models := channel.IndexModels([]channel.ModelOption{
 		{Provider: "openai", Model: "gpt-4"},
 	})
-	out := formatModelList(models, "openai")
+	out := channel.FormatModelList(models, "openai")
 	if !strings.Contains(out, `filter: "openai"`) {
 		t.Errorf("should show filter query: %s", out)
 	}

--- a/plugins/channels/weixin/weixin_test.go
+++ b/plugins/channels/weixin/weixin_test.go
@@ -11,8 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/vaayne/anna/internal/agent/runner"
-	"github.com/vaayne/anna/internal/channel"
+	"github.com/vaayne/anna/pkg/channel"
 )
 
 func TestRandomWechatUIN(t *testing.T) {
@@ -310,7 +309,7 @@ func TestRandomClientID(t *testing.T) {
 func TestNewRequiresBotToken(t *testing.T) {
 	t.Parallel()
 
-	_, err := New(Config{}, nil, nil, nil, nil)
+	_, err := New(Config{}, nil)
 	if err == nil {
 		t.Fatal("expected error for empty bot_token")
 	}
@@ -323,7 +322,7 @@ func TestNewSuccess(t *testing.T) {
 	t.Parallel()
 
 	cfg := Config{BotToken: "test-token"}
-	bot, err := New(cfg, nil, nil, nil, nil)
+	bot, err := New(cfg, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -332,20 +331,6 @@ func TestNewSuccess(t *testing.T) {
 	}
 	if bot.cfg.BotToken != "test-token" {
 		t.Errorf("bot_token = %q, want %q", bot.cfg.BotToken, "test-token")
-	}
-}
-
-func TestNewWithAuth(t *testing.T) {
-	t.Parallel()
-
-	cfg := Config{BotToken: "tok"}
-	bot, err := New(cfg, nil, nil, nil, nil, WithAuth(nil, nil, nil))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	// WithAuth sets the agentCmd, verify it was applied by checking it's not nil.
-	if bot.agentCmd == nil {
-		t.Error("expected agentCmd to be set after WithAuth")
 	}
 }
 
@@ -706,12 +691,12 @@ func TestToolTracker(t *testing.T) {
 
 	var tracker toolTracker
 
-	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "running", Input: "ls -la"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "ls -la"})
 	if tracker.activeTool != "bash" {
 		t.Errorf("activeTool = %q, want %q", tracker.activeTool, "bash")
 	}
 
-	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "done", Input: "ls -la"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "done", Input: "ls -la"})
 	if tracker.activeTool != "" {
 		t.Errorf("activeTool = %q, want empty after done", tracker.activeTool)
 	}
@@ -727,8 +712,8 @@ func TestToolTrackerError(t *testing.T) {
 	t.Parallel()
 
 	var tracker toolTracker
-	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "running", Input: "exit 1"})
-	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "error", Detail: "command failed"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "exit 1"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "error", Detail: "command failed"})
 
 	if len(tracker.history) != 1 {
 		t.Fatalf("history len = %d, want 1", len(tracker.history))
@@ -746,10 +731,10 @@ func TestToolTrackerRenderFinal(t *testing.T) {
 		t.Errorf("renderFinal() with no history = %q, want empty", got)
 	}
 
-	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "running", Input: "main.go"})
-	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "done", Detail: "42 lines"})
-	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "running", Input: "go test"})
-	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "error", Detail: "exit 1"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "main.go"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "done", Detail: "42 lines"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "go test"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "error", Detail: "exit 1"})
 
 	got := tracker.renderFinal()
 	if !strings.Contains(got, "——————————————————") {
@@ -773,8 +758,8 @@ func TestToolTrackerHasHistory(t *testing.T) {
 	if tracker.hasHistory() {
 		t.Error("hasHistory() should be false with no tools")
 	}
-	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "running", Input: "x"})
-	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "done", Input: "x"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "x"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "done", Input: "x"})
 	if !tracker.hasHistory() {
 		t.Error("hasHistory() should be true after tool finished")
 	}
@@ -784,8 +769,8 @@ func TestToolTrackerStartOverwritesActive(t *testing.T) {
 	t.Parallel()
 
 	var tracker toolTracker
-	tracker.handle(&runner.ToolUseEvent{Tool: "read", Status: "running", Input: "a.go"})
-	tracker.handle(&runner.ToolUseEvent{Tool: "bash", Status: "running", Input: "ls"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "read", Status: "running", Input: "a.go"})
+	tracker.handle(&channel.ToolUseEvent{Tool: "bash", Status: "running", Input: "ls"})
 
 	if len(tracker.history) != 1 {
 		t.Fatalf("history len = %d, want 1", len(tracker.history))


### PR DESCRIPTION
## Summary

- Introduce `pkg/channel/` as the public contract for channel plugins — `Channel`, `MessageHandler`, `IncomingMessage`, `ChatStream`, `Event` types plus utilities
- Add `internal/channel.Coordinator` implementing `MessageHandler` — owns all business logic (user/agent resolution, session management, commands, account linking)
- Refactor all 4 channel plugins (telegram, qq, feishu, weixin) to thin platform adapters with **zero `internal/` imports**
- Simplify plugin constructors from 8+ dependency params to `New(Config, MessageHandler)`
- Net -110 lines despite adding a new package

## Motivation

Channel plugins were the last `plugins/` packages importing from `internal/`, violating the boundary that tools, hooks, and providers already respect. Business logic (auth, agent routing, session management) was scattered between `internal/channel` and each plugin.

## Test plan

- [x] `mise run format` — clean
- [x] `mise run lint` — 0 issues
- [x] `mise run test` — all tests pass with `-race`
- [x] `rg 'internal/' plugins/channels/` — zero matches
- [x] `rg 'internal/' pkg/channel/` — zero matches