### PR TITLE
♻️ refactor: simplify runner path model to agent/user roots

### DIFF
--- a/cmd/anna/commands_test.go
+++ b/cmd/anna/commands_test.go
@@ -145,6 +145,7 @@ done
 func TestNewRunnerFactoryGo(t *testing.T) {
 	setupCommandTestAnnaHome(t)
 	snap := &config.Snapshot{
+		AgentID:  "test-agent",
 		Provider: "anthropic",
 		Model:    "test-model",
 		APIKey:   "test-key",
@@ -157,7 +158,7 @@ func TestNewRunnerFactoryGo(t *testing.T) {
 		t.Fatalf("NewRunnerFactory: %v", err)
 	}
 
-	r, err := factory(context.Background(), runner.RunnerParams{})
+	r, err := factory(context.Background(), runner.RunnerParams{UserID: 1})
 	if err != nil {
 		t.Fatalf("factory: %v", err)
 	}
@@ -215,6 +216,7 @@ func TestModelSwitcherPreservesPromptBuilders(t *testing.T) {
 	setupCommandTestAnnaHome(t)
 
 	snap := &config.Snapshot{
+		AgentID:  "test-agent",
 		Provider: "anthropic",
 		Model:    "anthropic/old-model",
 		APIKey:   "test-key",
@@ -253,9 +255,14 @@ func TestModelSwitcherPreservesPromptBuilders(t *testing.T) {
 		t.Fatalf("switchFn: %v", err)
 	}
 
+	session, err := pool.CreateSession("cli", 1)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	for range pool.Chat(ctx, "session-switch", "hello") {
+	for range pool.Chat(ctx, session.ID, "hello") {
 	}
 
 	if promptToolsCalls == 0 {

--- a/cmd/anna/skills.go
+++ b/cmd/anna/skills.go
@@ -203,11 +203,9 @@ func loadInstalledSkills(ctx context.Context) ([]skillstool.Skill, error) {
 		return nil, err
 	}
 	cwd, _ := os.Getwd()
-	home, _ := os.UserHomeDir()
 	return skillstool.LoadSkills(ctx, skillstool.LoadSkillsConfig{
-		HomeDir:   home,
 		AnnaHome:  config.AnnaHome(),
-		Workspace: snap.Workspace,
+		AgentRoot: snap.Workspace,
 		Cwd:       cwd,
 	}), nil
 }

--- a/cmd/anna/skills.go
+++ b/cmd/anna/skills.go
@@ -204,9 +204,9 @@ func loadInstalledSkills(ctx context.Context) ([]skillstool.Skill, error) {
 	}
 	cwd, _ := os.Getwd()
 	return skillstool.LoadSkills(ctx, skillstool.LoadSkillsConfig{
-		AnnaHome:  config.AnnaHome(),
-		AgentRoot: snap.Workspace,
-		Cwd:       cwd,
+		AnnaHome:    config.AnnaHome(),
+		AgentRoot:   snap.Workspace,
+		ProjectRoot: cwd,
 	}), nil
 }
 

--- a/internal/admin/sessions.go
+++ b/internal/admin/sessions.go
@@ -197,21 +197,21 @@ func (s *Server) getSessionSystemPrompt(w http.ResponseWriter, r *http.Request) 
 		agentCfg, _ = s.store.GetAgent(r.Context(), info.AgentID)
 	}
 	cwd, _ := os.Getwd()
-	var userDataDir string
+	var userRoot string
 	if info.UserID > 0 && info.AgentID != "" {
 		if userDir, err := agent.SetupUserWorkspace(info.AgentID, config.AnnaHome(), info.UserID); err == nil {
-			userDataDir = agent.UserDataDir(userDir)
+			userRoot = agent.UserRoot(userDir)
 		}
 	}
 	homeDir, _ := os.UserHomeDir()
 	promptSections, err := s.pluginHost.SystemPromptSections(r.Context(), pkgplugins.SystemPromptContext{
-		AnnaHome:    config.AnnaHome(),
-		HomeDir:     homeDir,
-		Workspace:   agentCfg.Workspace,
-		Cwd:         cwd,
-		UserID:      info.UserID,
-		AgentID:     info.AgentID,
-		UserDataDir: userDataDir,
+		AnnaHome:  config.AnnaHome(),
+		HomeDir:   homeDir,
+		AgentRoot: agentCfg.Workspace,
+		Cwd:       cwd,
+		UserID:    info.UserID,
+		AgentID:   info.AgentID,
+		UserRoot:  userRoot,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
@@ -229,9 +229,9 @@ func (s *Server) getSessionSystemPrompt(w http.ResponseWriter, r *http.Request) 
 		UserID:         info.UserID,
 		AgentID:        info.AgentID,
 		AnnaHome:       config.AnnaHome(),
-		Workspace:      agentCfg.Workspace,
+		AgentRoot:      agentCfg.Workspace,
 		Cwd:            cwd,
-		UserDataDir:    userDataDir,
+		UserRoot:       userRoot,
 		PromptTools:    promptTools,
 		PromptSections: promptSections,
 	})

--- a/internal/admin/sessions.go
+++ b/internal/admin/sessions.go
@@ -196,7 +196,6 @@ func (s *Server) getSessionSystemPrompt(w http.ResponseWriter, r *http.Request) 
 	if info.AgentID != "" {
 		agentCfg, _ = s.store.GetAgent(r.Context(), info.AgentID)
 	}
-	cwd, _ := os.Getwd()
 	var userRoot string
 	if info.UserID > 0 && info.AgentID != "" {
 		if userDir, err := agent.SetupUserWorkspace(info.AgentID, config.AnnaHome(), info.UserID); err == nil {
@@ -205,13 +204,13 @@ func (s *Server) getSessionSystemPrompt(w http.ResponseWriter, r *http.Request) 
 	}
 	homeDir, _ := os.UserHomeDir()
 	promptSections, err := s.pluginHost.SystemPromptSections(r.Context(), pkgplugins.SystemPromptContext{
-		AnnaHome:  config.AnnaHome(),
-		HomeDir:   homeDir,
-		AgentRoot: agentCfg.Workspace,
-		Cwd:       cwd,
-		UserID:    info.UserID,
-		AgentID:   info.AgentID,
-		UserRoot:  userRoot,
+		AnnaHome:    config.AnnaHome(),
+		HomeDir:     homeDir,
+		AgentRoot:   agentCfg.Workspace,
+		ProjectRoot: "",
+		UserID:      info.UserID,
+		AgentID:     info.AgentID,
+		UserRoot:    userRoot,
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
@@ -230,7 +229,6 @@ func (s *Server) getSessionSystemPrompt(w http.ResponseWriter, r *http.Request) 
 		AgentID:        info.AgentID,
 		AnnaHome:       config.AnnaHome(),
 		AgentRoot:      agentCfg.Workspace,
-		Cwd:            cwd,
 		UserRoot:       userRoot,
 		PromptTools:    promptTools,
 		PromptSections: promptSections,

--- a/internal/agent/factory.go
+++ b/internal/agent/factory.go
@@ -18,8 +18,8 @@ import (
 // NewRunnerFactory creates a runner.NewRunnerFunc for a given config snapshot.
 // The returned factory creates runners scoped to one agent's provider, model,
 // workspace, and system prompt. Memory provider, user ID, and agent ID are
-// injected per-session from RunnerParams. When UserID > 0, per-user workspace
-// directories are set up and per-user skills tools are created.
+// injected per-session from RunnerParams. Runner execution is always user-scoped,
+// so per-user workspace directories are created for every runner instance.
 //
 // Hooks are not part of the factory — they are injected via RunnerParams.HooksFn
 // by the Pool, keeping hook lifecycle fully decoupled from model/provider config.
@@ -44,14 +44,14 @@ func NewRunnerFactory(snap *config.Snapshot, extraTools []tools.Tool, pluginTool
 			}
 			cwd, _ := os.Getwd()
 
-			// Determine per-user paths when user ID is set.
-			var userDataDir string
-			if params.UserID > 0 {
-				userDir, err := SetupUserWorkspace(snap.AgentID, config.AnnaHome(), params.UserID)
-				if err == nil {
-					userDataDir = UserDataDir(userDir)
-				}
+			if params.UserID <= 0 {
+				return nil, fmt.Errorf("runner requires user scope")
 			}
+			userDir, err := SetupUserWorkspace(snap.AgentID, config.AnnaHome(), params.UserID)
+			if err != nil {
+				return nil, fmt.Errorf("setup user workspace: %w", err)
+			}
+			userDataDir := UserDataDir(userDir)
 
 			// Extract memory provider from params (typed as any to avoid circular imports).
 			var memProvider memory.Provider
@@ -91,7 +91,7 @@ func NewRunnerFactory(snap *config.Snapshot, extraTools []tools.Tool, pluginTool
 				PromptSections: promptSections,
 			})
 
-			// Use user data dir as working dir when available, otherwise use system cwd.
+			// Runner execution is always user-scoped, so tools start in the user root.
 			workDir := userDataDir
 
 			// Resolve hooks from RunnerParams — injected by Pool, not the factory.

--- a/internal/agent/factory.go
+++ b/internal/agent/factory.go
@@ -42,7 +42,6 @@ func NewRunnerFactory(snap *config.Snapshot, extraTools []tools.Tool, pluginTool
 			if apiName == "" {
 				apiName = provID
 			}
-			cwd, _ := os.Getwd()
 
 			if params.UserID <= 0 {
 				return nil, fmt.Errorf("runner requires user scope")
@@ -67,13 +66,13 @@ func NewRunnerFactory(snap *config.Snapshot, extraTools []tools.Tool, pluginTool
 			if promptSectionsFn != nil {
 				homeDir, _ := os.UserHomeDir()
 				promptSections, _ = promptSectionsFn(ctx, pkgplugins.SystemPromptContext{
-					AnnaHome:  config.AnnaHome(),
-					HomeDir:   homeDir,
-					AgentRoot: snap.Workspace,
-					Cwd:       cwd,
-					UserID:    params.UserID,
-					AgentID:   params.AgentID,
-					UserRoot:  userRoot,
+					AnnaHome:    config.AnnaHome(),
+					HomeDir:     homeDir,
+					AgentRoot:   snap.Workspace,
+					ProjectRoot: "",
+					UserID:      params.UserID,
+					AgentID:     params.AgentID,
+					UserRoot:    userRoot,
 				})
 			}
 
@@ -85,7 +84,6 @@ func NewRunnerFactory(snap *config.Snapshot, extraTools []tools.Tool, pluginTool
 				AgentID:        params.AgentID,
 				AnnaHome:       config.AnnaHome(),
 				AgentRoot:      snap.Workspace,
-				Cwd:            cwd,
 				UserRoot:       userRoot,
 				PromptTools:    promptTools,
 				PromptSections: promptSections,

--- a/internal/agent/factory.go
+++ b/internal/agent/factory.go
@@ -51,7 +51,7 @@ func NewRunnerFactory(snap *config.Snapshot, extraTools []tools.Tool, pluginTool
 			if err != nil {
 				return nil, fmt.Errorf("setup user workspace: %w", err)
 			}
-			userDataDir := UserDataDir(userDir)
+			userRoot := UserRoot(userDir)
 
 			// Extract memory provider from params (typed as any to avoid circular imports).
 			var memProvider memory.Provider
@@ -67,13 +67,13 @@ func NewRunnerFactory(snap *config.Snapshot, extraTools []tools.Tool, pluginTool
 			if promptSectionsFn != nil {
 				homeDir, _ := os.UserHomeDir()
 				promptSections, _ = promptSectionsFn(ctx, pkgplugins.SystemPromptContext{
-					AnnaHome:    config.AnnaHome(),
-					HomeDir:     homeDir,
-					Workspace:   snap.Workspace,
-					Cwd:         cwd,
-					UserID:      params.UserID,
-					AgentID:     params.AgentID,
-					UserDataDir: userDataDir,
+					AnnaHome:  config.AnnaHome(),
+					HomeDir:   homeDir,
+					AgentRoot: snap.Workspace,
+					Cwd:       cwd,
+					UserID:    params.UserID,
+					AgentID:   params.AgentID,
+					UserRoot:  userRoot,
 				})
 			}
 
@@ -84,15 +84,15 @@ func NewRunnerFactory(snap *config.Snapshot, extraTools []tools.Tool, pluginTool
 				UserID:         params.UserID,
 				AgentID:        params.AgentID,
 				AnnaHome:       config.AnnaHome(),
-				Workspace:      snap.Workspace,
+				AgentRoot:      snap.Workspace,
 				Cwd:            cwd,
-				UserDataDir:    userDataDir,
+				UserRoot:       userRoot,
 				PromptTools:    promptTools,
 				PromptSections: promptSections,
 			})
 
 			// Runner execution is always user-scoped, so tools start in the user root.
-			workDir := userDataDir
+			workDir := userRoot
 
 			// Resolve hooks from RunnerParams — injected by Pool, not the factory.
 			var hookPlugins []hooks.HookPlugin
@@ -104,7 +104,7 @@ func NewRunnerFactory(snap *config.Snapshot, extraTools []tools.Tool, pluginTool
 				API:            apiName,
 				Model:          modelID,
 				APIKey:         creds.APIKey,
-				Workspace:      snap.Workspace,
+				AgentRoot:      snap.Workspace,
 				AnnaHome:       config.AnnaHome(),
 				BaseURL:        creds.BaseURL,
 				System:         system,
@@ -112,7 +112,7 @@ func NewRunnerFactory(snap *config.Snapshot, extraTools []tools.Tool, pluginTool
 				ExtraTools:     extraTools,
 				PluginTools:    pluginToolsBuilder,
 				WorkDir:        workDir,
-				UserDataDir:    userDataDir,
+				UserRoot:       userRoot,
 				Sandbox:        snap.Sandbox,
 				HookPlugins:    hookPlugins,
 				ToolLifecycle:  toolLifecycle,

--- a/internal/agent/integration_test.go
+++ b/internal/agent/integration_test.go
@@ -42,6 +42,11 @@ func TestIntegrationPoolWithGoRunner(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
+	userRoot := filepath.Join(workspace, "users", "1", "data")
+	if err := os.MkdirAll(userRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
 	factory := func(ctx context.Context, _ runner.RunnerParams) (runner.Runner, error) {
 		return runner.NewGoRunner(ctx, runner.GoRunnerConfig{
 			API:       "anthropic",
@@ -49,7 +54,8 @@ func TestIntegrationPoolWithGoRunner(t *testing.T) {
 			APIKey:    os.Getenv("ANTHROPIC_API_KEY"),
 			BaseURL:   os.Getenv("ANTHROPIC_BASE_URL"),
 			AnnaHome:  annaHome,
-			Workspace: workspace,
+			AgentRoot: workspace,
+			UserRoot:  userRoot,
 			Providers: integrationProviderRegistryBuilder,
 		})
 	}

--- a/internal/agent/runner/gorunner.go
+++ b/internal/agent/runner/gorunner.go
@@ -257,8 +257,8 @@ func buildAgentPresets(cfg GoRunnerConfig) *agenttool.PresetRegistry {
 		slog.Warn("failed to extract builtin skills", "error", err)
 	}
 	return agenttool.NewPresetRegistry(agenttool.LoadAgentPresets(agenttool.LoadAgentPresetsConfig{
-		HomeDir:          paths.UserHome,
 		AgentRoot:        paths.AgentRoot,
+		UserRoot:         paths.UserRoot,
 		Cwd:              paths.WorkDir,
 		BuiltinSkillsDir: paths.builtinSkillsDir(),
 		Runtime:          cfg.ToolRuntime,

--- a/internal/agent/runner/gorunner.go
+++ b/internal/agent/runner/gorunner.go
@@ -35,15 +35,15 @@ type GoRunnerConfig struct {
 	Model          string // e.g. "claude-sonnet-4-20250514"
 	APIKey         string
 	BaseURL        string // optional provider base URL override
-	WorkDir        string // working directory for tool execution; defaults to UserDataDir when empty
-	Workspace      string // agent root directory
+	WorkDir        string // working directory for tool execution; defaults to UserRoot when empty
+	AgentRoot      string // agent root directory
 	AnnaHome       string // anna home directory (e.g. ~/.anna)
 	System         string // optional system prompt override (bypasses default prompt building)
 	PromptSections []pkgplugins.SystemPromptSection
 	ExtraTools     []tools.Tool // additional tools to register
 	PluginTools    func(context.Context, plugintools.BuildContext) []tools.Tool
 	ToolRuntime    pkgplugins.ToolRuntime
-	UserDataDir    string             // required per-user root used by prompts, skills, and sandbox execution
+	UserRoot       string             // required per-user root used by prompts, skills, and sandbox execution
 	HookPlugins    []hooks.HookPlugin // hook plugins for the engine loop
 	ToolLifecycle  *coreagent.ToolLifecycle
 	Providers      ProviderRegistryBuilder
@@ -78,11 +78,11 @@ func NewGoRunner(ctx context.Context, cfg GoRunnerConfig) (*GoRunner, error) {
 	if cfg.APIKey == "" {
 		return nil, fmt.Errorf("go runner: api_key is required")
 	}
-	if cfg.Workspace == "" {
-		return nil, fmt.Errorf("go runner: workspace is required")
+	if cfg.AgentRoot == "" {
+		return nil, fmt.Errorf("go runner: agent_root is required")
 	}
-	if cfg.UserDataDir == "" {
-		return nil, fmt.Errorf("go runner: user_data_dir is required")
+	if cfg.UserRoot == "" {
+		return nil, fmt.Errorf("go runner: user_root is required")
 	}
 
 	paths := resolveRunnerPaths(cfg)
@@ -111,9 +111,9 @@ func NewGoRunner(ctx context.Context, cfg GoRunnerConfig) (*GoRunner, error) {
 	if system == "" {
 		system = BuildSystemPromptFromDB(context.Background(), DBPromptParams{
 			AnnaHome:       paths.AnnaHome,
-			Workspace:      paths.Workspace,
+			AgentRoot:      paths.AgentRoot,
 			Cwd:            paths.WorkDir,
-			UserDataDir:    paths.UserDataDir,
+			UserRoot:       paths.UserRoot,
 			PromptSections: cfg.PromptSections,
 			Host:           session.Host(),
 		})
@@ -208,10 +208,10 @@ func buildToolRegistry(ctx context.Context, cfg GoRunnerConfig, session *runnerS
 	// Runtime capabilities are injected from the active runner session.
 	bc := plugintools.BuildContext{
 		WorkDir:     paths.WorkDir,
-		UserDataDir: paths.UserDataDir,
+		UserRoot:    paths.UserRoot,
 		AnnaHome:    paths.AnnaHome,
 		HomeDir:     paths.UserHome,
-		Workspace:   paths.Workspace,
+		AgentRoot:   paths.AgentRoot,
 		ToolsBinDir: paths.ToolsBinDir,
 		Runtime:     cfg.ToolRuntime,
 	}
@@ -258,7 +258,7 @@ func buildAgentPresets(cfg GoRunnerConfig) *agenttool.PresetRegistry {
 	}
 	return agenttool.NewPresetRegistry(agenttool.LoadAgentPresets(agenttool.LoadAgentPresetsConfig{
 		HomeDir:          paths.UserHome,
-		Workspace:        paths.Workspace,
+		AgentRoot:        paths.AgentRoot,
 		Cwd:              paths.WorkDir,
 		BuiltinSkillsDir: paths.BuiltinSkillsDir,
 		Runtime:          cfg.ToolRuntime,
@@ -275,8 +275,8 @@ func prepareSandbox(ctx context.Context, cfg GoRunnerConfig) error {
 	}
 	if err := boxshsandbox.Preflight(ctx, boxshsandbox.PreflightConfig{
 		AnnaHome:    paths.AnnaHome,
-		Workspace:   paths.Workspace,
-		UserDataDir: paths.UserDataDir,
+		Workspace:   paths.AgentRoot,
+		UserDataDir: paths.UserRoot,
 		Network: boxshsandbox.NetworkConfig{
 			Mode:      cfg.Sandbox.Network.Mode,
 			Allowlist: cfg.Sandbox.Network.Allowlist,

--- a/internal/agent/runner/gorunner.go
+++ b/internal/agent/runner/gorunner.go
@@ -112,7 +112,6 @@ func NewGoRunner(ctx context.Context, cfg GoRunnerConfig) (*GoRunner, error) {
 		system = BuildSystemPromptFromDB(context.Background(), DBPromptParams{
 			AnnaHome:       paths.AnnaHome,
 			AgentRoot:      paths.AgentRoot,
-			Cwd:            paths.WorkDir,
 			UserRoot:       paths.UserRoot,
 			PromptSections: cfg.PromptSections,
 			Host:           session.Host(),
@@ -130,13 +129,23 @@ func NewGoRunner(ctx context.Context, cfg GoRunnerConfig) (*GoRunner, error) {
 	hookSet := buildHookSet(cfg)
 
 	toolReg.Register(agenttool.NewAgentTool(agenttool.AgentConfig{
-		Providers:     reg,
-		Registry:      toolReg,
-		Model:         model,
-		APIKey:        cfg.APIKey,
-		BaseURL:       cfg.BaseURL,
-		System:        system,
-		Presets:       presets,
+		Providers: reg,
+		Registry:  toolReg,
+		Model:     model,
+		APIKey:    cfg.APIKey,
+		BaseURL:   cfg.BaseURL,
+		System:    system,
+		Presets:   presets,
+		PresetLoader: func(projectRoot string) *agenttool.PresetRegistry {
+			return agenttool.NewPresetRegistry(agenttool.LoadAgentPresets(agenttool.LoadAgentPresetsConfig{
+				AnnaHome:         paths.AnnaHome,
+				AgentRoot:        paths.AgentRoot,
+				UserRoot:         paths.UserRoot,
+				ProjectRoot:      projectRoot,
+				BuiltinSkillsDir: paths.builtinSkillsDir(),
+				Runtime:          cfg.ToolRuntime,
+			}))
+		},
 		Hooks:         hookSet,
 		ToolLifecycle: cfg.ToolLifecycle,
 	}))
@@ -208,6 +217,7 @@ func buildToolRegistry(ctx context.Context, cfg GoRunnerConfig, session *runnerS
 	// Runtime capabilities are injected from the active runner session.
 	bc := plugintools.BuildContext{
 		WorkDir:     paths.WorkDir,
+		ProjectRoot: "",
 		UserRoot:    paths.UserRoot,
 		AnnaHome:    paths.AnnaHome,
 		HomeDir:     paths.UserHome,
@@ -260,7 +270,7 @@ func buildAgentPresets(cfg GoRunnerConfig) *agenttool.PresetRegistry {
 		AnnaHome:         paths.AnnaHome,
 		AgentRoot:        paths.AgentRoot,
 		UserRoot:         paths.UserRoot,
-		Cwd:              paths.WorkDir,
+		ProjectRoot:      "",
 		BuiltinSkillsDir: paths.builtinSkillsDir(),
 		Runtime:          cfg.ToolRuntime,
 	}))

--- a/internal/agent/runner/gorunner.go
+++ b/internal/agent/runner/gorunner.go
@@ -257,6 +257,7 @@ func buildAgentPresets(cfg GoRunnerConfig) *agenttool.PresetRegistry {
 		slog.Warn("failed to extract builtin skills", "error", err)
 	}
 	return agenttool.NewPresetRegistry(agenttool.LoadAgentPresets(agenttool.LoadAgentPresetsConfig{
+		AnnaHome:         paths.AnnaHome,
 		AgentRoot:        paths.AgentRoot,
 		UserRoot:         paths.UserRoot,
 		Cwd:              paths.WorkDir,

--- a/internal/agent/runner/gorunner.go
+++ b/internal/agent/runner/gorunner.go
@@ -35,15 +35,15 @@ type GoRunnerConfig struct {
 	Model          string // e.g. "claude-sonnet-4-20250514"
 	APIKey         string
 	BaseURL        string // optional provider base URL override
-	WorkDir        string // working directory for tool execution
-	Workspace      string // workspace dir for skills/memory (e.g. ~/.anna/workspace)
+	WorkDir        string // working directory for tool execution; defaults to UserDataDir when empty
+	Workspace      string // agent root directory
 	AnnaHome       string // anna home directory (e.g. ~/.anna)
 	System         string // optional system prompt override (bypasses default prompt building)
 	PromptSections []pkgplugins.SystemPromptSection
 	ExtraTools     []tools.Tool // additional tools to register
 	PluginTools    func(context.Context, plugintools.BuildContext) []tools.Tool
 	ToolRuntime    pkgplugins.ToolRuntime
-	UserDataDir    string             // optional per-user data directory used by prompts, skills, and sandbox session setup
+	UserDataDir    string             // required per-user root used by prompts, skills, and sandbox execution
 	HookPlugins    []hooks.HookPlugin // hook plugins for the engine loop
 	ToolLifecycle  *coreagent.ToolLifecycle
 	Providers      ProviderRegistryBuilder
@@ -78,6 +78,14 @@ func NewGoRunner(ctx context.Context, cfg GoRunnerConfig) (*GoRunner, error) {
 	if cfg.APIKey == "" {
 		return nil, fmt.Errorf("go runner: api_key is required")
 	}
+	if cfg.Workspace == "" {
+		return nil, fmt.Errorf("go runner: workspace is required")
+	}
+	if cfg.UserDataDir == "" {
+		return nil, fmt.Errorf("go runner: user_data_dir is required")
+	}
+
+	paths := resolveRunnerPaths(cfg)
 
 	reg, err := buildProviderRegistry(cfg)
 	if err != nil {
@@ -102,10 +110,10 @@ func NewGoRunner(ctx context.Context, cfg GoRunnerConfig) (*GoRunner, error) {
 
 	if system == "" {
 		system = BuildSystemPromptFromDB(context.Background(), DBPromptParams{
-			AnnaHome:       cfg.AnnaHome,
-			Workspace:      cfg.Workspace,
-			Cwd:            cfg.WorkDir,
-			UserDataDir:    cfg.UserDataDir,
+			AnnaHome:       paths.AnnaHome,
+			Workspace:      paths.Workspace,
+			Cwd:            paths.WorkDir,
+			UserDataDir:    paths.UserDataDir,
 			PromptSections: cfg.PromptSections,
 			Host:           session.Host(),
 		})
@@ -187,15 +195,10 @@ func buildProviderRegistry(cfg GoRunnerConfig) (*providers.Registry, error) {
 // buildToolRegistry creates the tool registry with core and extra tools.
 func buildToolRegistry(ctx context.Context, cfg GoRunnerConfig, session *runnerSession) (*tools.Registry, error) {
 	// Extract embedded tool binaries (idempotent, safe for concurrent calls).
-	annaHome := cfg.AnnaHome
-	if annaHome == "" {
-		annaHome = config.AnnaHome()
-	}
-	homeDir, _ := os.UserHomeDir()
-	if err := embedded.EnsureTools(annaHome); err != nil {
+	paths := resolveRunnerPaths(cfg)
+	if err := embedded.EnsureTools(paths.AnnaHome); err != nil {
 		slog.Warn("failed to extract embedded tools", "error", err)
 	}
-	toolsBinDir := embedded.BinDir(annaHome)
 
 	toolReg := tools.NewRegistry()
 
@@ -204,12 +207,12 @@ func buildToolRegistry(ctx context.Context, cfg GoRunnerConfig, session *runnerS
 
 	// Runtime capabilities are injected from the active runner session.
 	bc := plugintools.BuildContext{
-		WorkDir:     cfg.WorkDir,
-		UserDataDir: cfg.UserDataDir,
-		AnnaHome:    cfg.AnnaHome,
-		HomeDir:     homeDir,
-		Workspace:   cfg.Workspace,
-		ToolsBinDir: toolsBinDir,
+		WorkDir:     paths.WorkDir,
+		UserDataDir: paths.UserDataDir,
+		AnnaHome:    paths.AnnaHome,
+		HomeDir:     paths.UserHome,
+		Workspace:   paths.Workspace,
+		ToolsBinDir: paths.ToolsBinDir,
 		Runtime:     cfg.ToolRuntime,
 	}
 
@@ -249,39 +252,31 @@ func collectSandboxReadOnlyDirs(toolsBinDir, pathEnv string) []string {
 }
 
 func buildAgentPresets(cfg GoRunnerConfig) *agenttool.PresetRegistry {
-	annaHome := cfg.AnnaHome
-	if annaHome == "" {
-		annaHome = config.AnnaHome()
-	}
-	homeDir, _ := os.UserHomeDir()
-	builtinSkillsDir := filepath.Join(annaHome, "cache", "builtin-skills")
-	if err := builtin.Extract(builtinSkillsDir); err != nil {
+	paths := resolveRunnerPaths(cfg)
+	if err := builtin.Extract(paths.BuiltinSkillsDir); err != nil {
 		slog.Warn("failed to extract builtin skills", "error", err)
 	}
 	return agenttool.NewPresetRegistry(agenttool.LoadAgentPresets(agenttool.LoadAgentPresetsConfig{
-		HomeDir:          homeDir,
-		Workspace:        cfg.Workspace,
-		Cwd:              cfg.WorkDir,
-		BuiltinSkillsDir: builtinSkillsDir,
+		HomeDir:          paths.UserHome,
+		Workspace:        paths.Workspace,
+		Cwd:              paths.WorkDir,
+		BuiltinSkillsDir: paths.BuiltinSkillsDir,
 		Runtime:          cfg.ToolRuntime,
 	}))
 }
 
 func prepareSandbox(ctx context.Context, cfg GoRunnerConfig) error {
-	annaHome := cfg.AnnaHome
-	if annaHome == "" {
-		annaHome = config.AnnaHome()
-	}
-	if err := embedded.EnsureTools(annaHome); err != nil {
+	paths := resolveRunnerPaths(cfg)
+	if err := embedded.EnsureTools(paths.AnnaHome); err != nil {
 		slog.Warn("failed to extract embedded tools", "error", err)
 	}
 	if cfg.Sandbox.BackendName() == config.SandboxBackendLocal {
 		return nil
 	}
 	if err := boxshsandbox.Preflight(ctx, boxshsandbox.PreflightConfig{
-		AnnaHome:    annaHome,
-		Workspace:   cfg.Workspace,
-		UserDataDir: cfg.UserDataDir,
+		AnnaHome:    paths.AnnaHome,
+		Workspace:   paths.Workspace,
+		UserDataDir: paths.UserDataDir,
 		Network: boxshsandbox.NetworkConfig{
 			Mode:      cfg.Sandbox.Network.Mode,
 			Allowlist: cfg.Sandbox.Network.Allowlist,

--- a/internal/agent/runner/gorunner.go
+++ b/internal/agent/runner/gorunner.go
@@ -212,7 +212,7 @@ func buildToolRegistry(ctx context.Context, cfg GoRunnerConfig, session *runnerS
 		AnnaHome:    paths.AnnaHome,
 		HomeDir:     paths.UserHome,
 		AgentRoot:   paths.AgentRoot,
-		ToolsBinDir: paths.ToolsBinDir,
+		ToolsBinDir: paths.toolsBinDir(),
 		Runtime:     cfg.ToolRuntime,
 	}
 
@@ -253,14 +253,14 @@ func collectSandboxReadOnlyDirs(toolsBinDir, pathEnv string) []string {
 
 func buildAgentPresets(cfg GoRunnerConfig) *agenttool.PresetRegistry {
 	paths := resolveRunnerPaths(cfg)
-	if err := builtin.Extract(paths.BuiltinSkillsDir); err != nil {
+	if err := builtin.Extract(paths.builtinSkillsDir()); err != nil {
 		slog.Warn("failed to extract builtin skills", "error", err)
 	}
 	return agenttool.NewPresetRegistry(agenttool.LoadAgentPresets(agenttool.LoadAgentPresetsConfig{
 		HomeDir:          paths.UserHome,
 		AgentRoot:        paths.AgentRoot,
 		Cwd:              paths.WorkDir,
-		BuiltinSkillsDir: paths.BuiltinSkillsDir,
+		BuiltinSkillsDir: paths.builtinSkillsDir(),
 		Runtime:          cfg.ToolRuntime,
 	}))
 }

--- a/internal/agent/runner/gorunner_integration_test.go
+++ b/internal/agent/runner/gorunner_integration_test.go
@@ -33,20 +33,20 @@ func integrationConfig(t *testing.T) GoRunnerConfig {
 	}
 	annaHome := t.TempDir()
 	workspace := t.TempDir()
-	userDataDir := workspace + "/users/1/data"
-	if err := os.MkdirAll(userDataDir, 0o755); err != nil {
+	userRoot := workspace + "/users/1/data"
+	if err := os.MkdirAll(userRoot, 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
 	_ = writeMockRPCBoxsh(t, annaHome, false)
 	return GoRunnerConfig{
-		API:         "anthropic",
-		Model:       model,
-		APIKey:      os.Getenv("ANTHROPIC_API_KEY"),
-		BaseURL:     os.Getenv("ANTHROPIC_BASE_URL"),
-		AnnaHome:    annaHome,
-		Workspace:   workspace,
-		UserDataDir: userDataDir,
-		Providers:   integrationProviderRegistryBuilder,
+		API:       "anthropic",
+		Model:     model,
+		APIKey:    os.Getenv("ANTHROPIC_API_KEY"),
+		BaseURL:   os.Getenv("ANTHROPIC_BASE_URL"),
+		AnnaHome:  annaHome,
+		AgentRoot: workspace,
+		UserRoot:  userRoot,
+		Providers: integrationProviderRegistryBuilder,
 	}
 }
 

--- a/internal/agent/runner/gorunner_integration_test.go
+++ b/internal/agent/runner/gorunner_integration_test.go
@@ -33,15 +33,20 @@ func integrationConfig(t *testing.T) GoRunnerConfig {
 	}
 	annaHome := t.TempDir()
 	workspace := t.TempDir()
+	userDataDir := workspace + "/users/1/data"
+	if err := os.MkdirAll(userDataDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
 	_ = writeMockRPCBoxsh(t, annaHome, false)
 	return GoRunnerConfig{
-		API:       "anthropic",
-		Model:     model,
-		APIKey:    os.Getenv("ANTHROPIC_API_KEY"),
-		BaseURL:   os.Getenv("ANTHROPIC_BASE_URL"),
-		AnnaHome:  annaHome,
-		Workspace: workspace,
-		Providers: integrationProviderRegistryBuilder,
+		API:         "anthropic",
+		Model:       model,
+		APIKey:      os.Getenv("ANTHROPIC_API_KEY"),
+		BaseURL:     os.Getenv("ANTHROPIC_BASE_URL"),
+		AnnaHome:    annaHome,
+		Workspace:   workspace,
+		UserDataDir: userDataDir,
+		Providers:   integrationProviderRegistryBuilder,
 	}
 }
 

--- a/internal/agent/runner/gorunner_test.go
+++ b/internal/agent/runner/gorunner_test.go
@@ -37,19 +37,19 @@ func testProviderRegistryBuilder(api, apiKey, baseURL string) (*providers.Regist
 	return reg, nil
 }
 
-func testRunnerPaths(t *testing.T) (annaHome, workspace, userDataDir string) {
+func testRunnerPaths(t *testing.T) (annaHome, workspace, userRoot string) {
 	t.Helper()
 	if !boxshclient.PlatformSupportsBoxsh() {
 		t.Skip("sandbox backend requires boxsh support on this platform")
 	}
 	annaHome = t.TempDir()
 	workspace = t.TempDir()
-	userDataDir = filepath.Join(workspace, "users", "1", "data")
-	if err := os.MkdirAll(userDataDir, 0o755); err != nil {
+	userRoot = filepath.Join(workspace, "users", "1", "data")
+	if err := os.MkdirAll(userRoot, 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
 	_ = writeMockRPCBoxsh(t, annaHome, false)
-	return annaHome, workspace, userDataDir
+	return annaHome, workspace, userRoot
 }
 
 func writeMockRPCBoxsh(t *testing.T, annaHome string, exitAfterHandshake bool) string {
@@ -88,12 +88,12 @@ func writeMockRPCBoxsh(t *testing.T, annaHome string, exitAfterHandshake bool) s
 
 func withTestRunnerPaths(t *testing.T, cfg GoRunnerConfig) GoRunnerConfig {
 	t.Helper()
-	annaHome, workspace, userDataDir := testRunnerPaths(t)
+	annaHome, workspace, userRoot := testRunnerPaths(t)
 	cfg.AnnaHome = annaHome
-	cfg.Workspace = workspace
-	cfg.UserDataDir = userDataDir
+	cfg.AgentRoot = workspace
+	cfg.UserRoot = userRoot
 	if cfg.WorkDir == "" {
-		cfg.WorkDir = userDataDir
+		cfg.WorkDir = userRoot
 	}
 	return cfg
 }
@@ -106,8 +106,8 @@ func TestNewGoRunnerRequiresConfig(t *testing.T) {
 		{"missing api", GoRunnerConfig{Model: "m", APIKey: "k"}},
 		{"missing model", GoRunnerConfig{API: "anthropic", APIKey: "k"}},
 		{"missing api_key", GoRunnerConfig{API: "anthropic", Model: "m"}},
-		{"missing workspace", GoRunnerConfig{API: "anthropic", Model: "m", APIKey: "k", UserDataDir: "/tmp/user"}},
-		{"missing user_data_dir", GoRunnerConfig{API: "anthropic", Model: "m", APIKey: "k", Workspace: "/tmp/workspace"}},
+		{"missing workspace", GoRunnerConfig{API: "anthropic", Model: "m", APIKey: "k", UserRoot: "/tmp/user"}},
+		{"missing user_data_dir", GoRunnerConfig{API: "anthropic", Model: "m", APIKey: "k", AgentRoot: "/tmp/workspace"}},
 	}
 
 	for _, tt := range tests {
@@ -147,19 +147,19 @@ func TestNewGoRunnerPreflightExtractsManagedTools(t *testing.T) {
 	}
 	annaHome := t.TempDir()
 	workspace := t.TempDir()
-	userDataDir := filepath.Join(workspace, "users", "1", "data")
-	if err := os.MkdirAll(userDataDir, 0o755); err != nil {
+	userRoot := filepath.Join(workspace, "users", "1", "data")
+	if err := os.MkdirAll(userRoot, 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
 
 	r, err := NewGoRunner(context.Background(), GoRunnerConfig{
-		API:         "anthropic",
-		Model:       "claude-sonnet-4-20250514",
-		APIKey:      "test-key",
-		AnnaHome:    annaHome,
-		Workspace:   workspace,
-		UserDataDir: userDataDir,
-		Providers:   testProviderRegistryBuilder,
+		API:       "anthropic",
+		Model:     "claude-sonnet-4-20250514",
+		APIKey:    "test-key",
+		AnnaHome:  annaHome,
+		AgentRoot: workspace,
+		UserRoot:  userRoot,
+		Providers: testProviderRegistryBuilder,
 	})
 	if err != nil {
 		t.Fatalf("NewGoRunner: %v", err)
@@ -178,20 +178,20 @@ func TestNewGoRunnerUsesBoxshCoreToolsAndCleansUp(t *testing.T) {
 
 	annaHome := t.TempDir()
 	workspace := t.TempDir()
-	userDataDir := filepath.Join(workspace, "users", "1", "data")
-	if err := os.MkdirAll(userDataDir, 0o755); err != nil {
+	userRoot := filepath.Join(workspace, "users", "1", "data")
+	if err := os.MkdirAll(userRoot, 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
 	commandsLog := writeMockRPCBoxsh(t, annaHome, false)
 
 	r, err := NewGoRunner(context.Background(), GoRunnerConfig{
-		API:         "anthropic",
-		Model:       "claude-sonnet-4-20250514",
-		APIKey:      "test-key",
-		AnnaHome:    annaHome,
-		Workspace:   workspace,
-		UserDataDir: userDataDir,
-		Providers:   testProviderRegistryBuilder,
+		API:       "anthropic",
+		Model:     "claude-sonnet-4-20250514",
+		APIKey:    "test-key",
+		AnnaHome:  annaHome,
+		AgentRoot: workspace,
+		UserRoot:  userRoot,
+		Providers: testProviderRegistryBuilder,
 	})
 	if err != nil {
 		t.Fatalf("NewGoRunner: %v", err)
@@ -236,20 +236,20 @@ func TestGoRunnerAliveTracksDeadBoxshBackend(t *testing.T) {
 
 	annaHome := t.TempDir()
 	workspace := t.TempDir()
-	userDataDir := filepath.Join(workspace, "users", "1", "data")
-	if err := os.MkdirAll(userDataDir, 0o755); err != nil {
+	userRoot := filepath.Join(workspace, "users", "1", "data")
+	if err := os.MkdirAll(userRoot, 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
 	_ = writeMockRPCBoxsh(t, annaHome, true)
 
 	r, err := NewGoRunner(context.Background(), GoRunnerConfig{
-		API:         "anthropic",
-		Model:       "claude-sonnet-4-20250514",
-		APIKey:      "test-key",
-		AnnaHome:    annaHome,
-		Workspace:   workspace,
-		UserDataDir: userDataDir,
-		Providers:   testProviderRegistryBuilder,
+		API:       "anthropic",
+		Model:     "claude-sonnet-4-20250514",
+		APIKey:    "test-key",
+		AnnaHome:  annaHome,
+		AgentRoot: workspace,
+		UserRoot:  userRoot,
+		Providers: testProviderRegistryBuilder,
 	})
 	if err != nil {
 		t.Fatalf("NewGoRunner: %v", err)

--- a/internal/agent/runner/gorunner_test.go
+++ b/internal/agent/runner/gorunner_test.go
@@ -37,15 +37,19 @@ func testProviderRegistryBuilder(api, apiKey, baseURL string) (*providers.Regist
 	return reg, nil
 }
 
-func testRunnerPaths(t *testing.T) (annaHome, workspace string) {
+func testRunnerPaths(t *testing.T) (annaHome, workspace, userDataDir string) {
 	t.Helper()
 	if !boxshclient.PlatformSupportsBoxsh() {
 		t.Skip("sandbox backend requires boxsh support on this platform")
 	}
 	annaHome = t.TempDir()
 	workspace = t.TempDir()
+	userDataDir = filepath.Join(workspace, "users", "1", "data")
+	if err := os.MkdirAll(userDataDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
 	_ = writeMockRPCBoxsh(t, annaHome, false)
-	return annaHome, workspace
+	return annaHome, workspace, userDataDir
 }
 
 func writeMockRPCBoxsh(t *testing.T, annaHome string, exitAfterHandshake bool) string {
@@ -84,9 +88,13 @@ func writeMockRPCBoxsh(t *testing.T, annaHome string, exitAfterHandshake bool) s
 
 func withTestRunnerPaths(t *testing.T, cfg GoRunnerConfig) GoRunnerConfig {
 	t.Helper()
-	annaHome, workspace := testRunnerPaths(t)
+	annaHome, workspace, userDataDir := testRunnerPaths(t)
 	cfg.AnnaHome = annaHome
 	cfg.Workspace = workspace
+	cfg.UserDataDir = userDataDir
+	if cfg.WorkDir == "" {
+		cfg.WorkDir = userDataDir
+	}
 	return cfg
 }
 
@@ -98,6 +106,8 @@ func TestNewGoRunnerRequiresConfig(t *testing.T) {
 		{"missing api", GoRunnerConfig{Model: "m", APIKey: "k"}},
 		{"missing model", GoRunnerConfig{API: "anthropic", APIKey: "k"}},
 		{"missing api_key", GoRunnerConfig{API: "anthropic", Model: "m"}},
+		{"missing workspace", GoRunnerConfig{API: "anthropic", Model: "m", APIKey: "k", UserDataDir: "/tmp/user"}},
+		{"missing user_data_dir", GoRunnerConfig{API: "anthropic", Model: "m", APIKey: "k", Workspace: "/tmp/workspace"}},
 	}
 
 	for _, tt := range tests {
@@ -137,14 +147,19 @@ func TestNewGoRunnerPreflightExtractsManagedTools(t *testing.T) {
 	}
 	annaHome := t.TempDir()
 	workspace := t.TempDir()
+	userDataDir := filepath.Join(workspace, "users", "1", "data")
+	if err := os.MkdirAll(userDataDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
 
 	r, err := NewGoRunner(context.Background(), GoRunnerConfig{
-		API:       "anthropic",
-		Model:     "claude-sonnet-4-20250514",
-		APIKey:    "test-key",
-		AnnaHome:  annaHome,
-		Workspace: workspace,
-		Providers: testProviderRegistryBuilder,
+		API:         "anthropic",
+		Model:       "claude-sonnet-4-20250514",
+		APIKey:      "test-key",
+		AnnaHome:    annaHome,
+		Workspace:   workspace,
+		UserDataDir: userDataDir,
+		Providers:   testProviderRegistryBuilder,
 	})
 	if err != nil {
 		t.Fatalf("NewGoRunner: %v", err)
@@ -163,15 +178,20 @@ func TestNewGoRunnerUsesBoxshCoreToolsAndCleansUp(t *testing.T) {
 
 	annaHome := t.TempDir()
 	workspace := t.TempDir()
+	userDataDir := filepath.Join(workspace, "users", "1", "data")
+	if err := os.MkdirAll(userDataDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
 	commandsLog := writeMockRPCBoxsh(t, annaHome, false)
 
 	r, err := NewGoRunner(context.Background(), GoRunnerConfig{
-		API:       "anthropic",
-		Model:     "claude-sonnet-4-20250514",
-		APIKey:    "test-key",
-		AnnaHome:  annaHome,
-		Workspace: workspace,
-		Providers: testProviderRegistryBuilder,
+		API:         "anthropic",
+		Model:       "claude-sonnet-4-20250514",
+		APIKey:      "test-key",
+		AnnaHome:    annaHome,
+		Workspace:   workspace,
+		UserDataDir: userDataDir,
+		Providers:   testProviderRegistryBuilder,
 	})
 	if err != nil {
 		t.Fatalf("NewGoRunner: %v", err)
@@ -216,15 +236,20 @@ func TestGoRunnerAliveTracksDeadBoxshBackend(t *testing.T) {
 
 	annaHome := t.TempDir()
 	workspace := t.TempDir()
+	userDataDir := filepath.Join(workspace, "users", "1", "data")
+	if err := os.MkdirAll(userDataDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
 	_ = writeMockRPCBoxsh(t, annaHome, true)
 
 	r, err := NewGoRunner(context.Background(), GoRunnerConfig{
-		API:       "anthropic",
-		Model:     "claude-sonnet-4-20250514",
-		APIKey:    "test-key",
-		AnnaHome:  annaHome,
-		Workspace: workspace,
-		Providers: testProviderRegistryBuilder,
+		API:         "anthropic",
+		Model:       "claude-sonnet-4-20250514",
+		APIKey:      "test-key",
+		AnnaHome:    annaHome,
+		Workspace:   workspace,
+		UserDataDir: userDataDir,
+		Providers:   testProviderRegistryBuilder,
 	})
 	if err != nil {
 		t.Fatalf("NewGoRunner: %v", err)

--- a/internal/agent/runner/paths.go
+++ b/internal/agent/runner/paths.go
@@ -19,13 +19,13 @@ import (
 //
 // In practice:
 //   - UserHome is used for host-side discovery of shared skills/agents.
-//   - Workspace is the agent-level persistent directory.
-//   - UserDataDir is the user-scoped persistent directory and required for execution.
+//   - AgentRoot is the agent-level persistent directory.
+//   - UserRoot is the user-scoped persistent directory and required for execution.
 //   - SandboxRoot is always the user-scoped writable root.
 //   - ProcessHome is exported as HOME for CLI tools running in the sandbox.
 //
-// This keeps call sites from having to re-decide which of cfg.Workspace,
-// cfg.UserDataDir, cfg.WorkDir, cfg.AnnaHome, or os.UserHomeDir() should be
+// This keeps call sites from having to re-decide which of cfg.AgentRoot,
+// cfg.UserRoot, cfg.WorkDir, cfg.AnnaHome, or os.UserHomeDir() should be
 // used for each operation.
 type runnerPaths struct {
 	// AnnaHome is Anna's resolved home directory.
@@ -36,24 +36,24 @@ type runnerPaths struct {
 	// Used for host-side shared discovery like ~/.agents/{skills,agents}.
 	UserHome string
 
-	// Workspace is the agent's persistent workspace directory.
-	// Used for agent-scoped files such as workspace-local skills/agents.
-	Workspace string
+	// AgentRoot is the agent's persistent root directory.
+	// Used for agent-scoped files such as agent-local skills/agents.
+	AgentRoot string
 
 	// WorkDir is the requested working directory for tool execution.
-	// When empty, it defaults to UserDataDir.
+	// When empty, it defaults to UserRoot.
 	WorkDir string
 
-	// UserDataDir is the user-scoped persistent storage within an agent.
+	// UserRoot is the user-scoped persistent storage within an agent.
 	// Runner execution is always user-scoped, so this must be set.
-	UserDataDir string
+	UserRoot string
 
 	// SandboxRoot is the directory exposed as the sandbox's writable root.
-	// It always resolves to UserDataDir.
+	// It always resolves to UserRoot.
 	SandboxRoot string
 
 	// ProcessHome is the HOME env visible to executed CLIs.
-	// It always resolves to UserDataDir.
+	// It always resolves to UserRoot.
 	ProcessHome string
 
 	// ToolsBinDir is Anna's managed bin directory.
@@ -70,9 +70,9 @@ type runnerPaths struct {
 // Resolution rules:
 //   - AnnaHome: cfg.AnnaHome or config.AnnaHome()
 //   - UserHome: os.UserHomeDir()
-//   - SandboxRoot: cfg.UserDataDir
-//   - ProcessHome: cfg.UserDataDir
-//   - WorkDir: cfg.WorkDir if set, else cfg.UserDataDir
+//   - SandboxRoot: cfg.UserRoot
+//   - ProcessHome: cfg.UserRoot
+//   - WorkDir: cfg.WorkDir if set, else cfg.UserRoot
 func resolveRunnerPaths(cfg GoRunnerConfig) runnerPaths {
 	annaHome := cfg.AnnaHome
 	if annaHome == "" {
@@ -82,25 +82,25 @@ func resolveRunnerPaths(cfg GoRunnerConfig) runnerPaths {
 	userHome, _ := os.UserHomeDir()
 	workDir := cfg.WorkDir
 	if workDir == "" {
-		workDir = cfg.UserDataDir
+		workDir = cfg.UserRoot
 	}
 
 	return runnerPaths{
 		AnnaHome:         annaHome,
 		UserHome:         userHome,
-		Workspace:        cfg.Workspace,
+		AgentRoot:        cfg.AgentRoot,
 		WorkDir:          workDir,
-		UserDataDir:      cfg.UserDataDir,
-		SandboxRoot:      cfg.UserDataDir,
-		ProcessHome:      cfg.UserDataDir,
+		UserRoot:         cfg.UserRoot,
+		SandboxRoot:      cfg.UserRoot,
+		ProcessHome:      cfg.UserRoot,
 		ToolsBinDir:      embedded.BinDir(annaHome),
 		BuiltinSkillsDir: filepath.Join(annaHome, "cache", "builtin-skills"),
 	}
 }
 
-// sandboxWorkspaceRoot returns the directory mounted as the sandbox root.
-// Runner execution is always user-scoped, so this is always UserDataDir.
-func sandboxWorkspaceRoot(cfg GoRunnerConfig) string {
+// sandboxRoot returns the directory mounted as the sandbox root.
+// Runner execution is always user-scoped, so this is always UserRoot.
+func sandboxRoot(cfg GoRunnerConfig) string {
 	return resolveRunnerPaths(cfg).SandboxRoot
 }
 

--- a/internal/agent/runner/paths.go
+++ b/internal/agent/runner/paths.go
@@ -42,8 +42,6 @@ func resolveRunnerPaths(cfg GoRunnerConfig) runnerPaths {
 	}
 }
 
-func (p runnerPaths) sandboxRoot() string { return p.UserRoot }
-func (p runnerPaths) processHome() string { return p.UserRoot }
 func (p runnerPaths) toolsBinDir() string { return embedded.BinDir(p.AnnaHome) }
 func (p runnerPaths) builtinSkillsDir() string {
 	return filepath.Join(p.AnnaHome, "cache", "builtin-skills")
@@ -52,7 +50,7 @@ func (p runnerPaths) builtinSkillsDir() string {
 // sandboxRoot returns the directory mounted as the sandbox root.
 // Runner execution is always user-scoped, so this is always UserRoot.
 func sandboxRoot(cfg GoRunnerConfig) string {
-	return resolveRunnerPaths(cfg).sandboxRoot()
+	return resolveRunnerPaths(cfg).UserRoot
 }
 
 // sandboxProcessEnv builds the baseline process environment injected into
@@ -60,8 +58,8 @@ func sandboxRoot(cfg GoRunnerConfig) string {
 // and propagates ANNA_HOME so CLIs don't accidentally target the host home.
 func sandboxProcessEnv(paths runnerPaths) map[string]string {
 	env := map[string]string{}
-	if home := paths.processHome(); home != "" {
-		env["HOME"] = home
+	if paths.UserRoot != "" {
+		env["HOME"] = paths.UserRoot
 	}
 	if paths.AnnaHome != "" {
 		env["ANNA_HOME"] = paths.AnnaHome

--- a/internal/agent/runner/paths.go
+++ b/internal/agent/runner/paths.go
@@ -8,71 +8,19 @@ import (
 	"github.com/vaayne/anna/internal/embedded"
 )
 
-// runnerPaths is the runner's normalized view of all path-like config.
-//
-// The intent is to separate a few similar-but-different concepts:
-//   - user home on the host machine (for shared discovery like ~/.agents)
-//   - agent workspace (the agent's persistent working area)
-//   - per-user data dir (user-scoped state inside an agent workspace)
-//   - sandbox root (the filesystem root exposed to sandboxed tools)
-//   - process home (the HOME env seen by commands executed in the sandbox)
-//
-// In practice:
-//   - UserHome is used for host-side discovery of shared skills/agents.
-//   - AgentRoot is the agent-level persistent directory.
-//   - UserRoot is the user-scoped persistent directory and required for execution.
-//   - SandboxRoot is always the user-scoped writable root.
-//   - ProcessHome is exported as HOME for CLI tools running in the sandbox.
-//
-// This keeps call sites from having to re-decide which of cfg.AgentRoot,
-// cfg.UserRoot, cfg.WorkDir, cfg.AnnaHome, or os.UserHomeDir() should be
-// used for each operation.
+// runnerPaths keeps only the runner's primary inputs.
+// Everything else used by the runner is derived from these values.
 type runnerPaths struct {
-	// AnnaHome is Anna's resolved home directory.
-	// Used for managed binaries, cache, builtin skills, and ANNA_HOME.
-	AnnaHome string
-
-	// UserHome is the real host user home directory from os.UserHomeDir().
-	// Used for host-side shared discovery like ~/.agents/{skills,agents}.
-	UserHome string
-
-	// AgentRoot is the agent's persistent root directory.
-	// Used for agent-scoped files such as agent-local skills/agents.
+	AnnaHome  string
+	UserHome  string
 	AgentRoot string
-
-	// WorkDir is the requested working directory for tool execution.
-	// When empty, it defaults to UserRoot.
-	WorkDir string
-
-	// UserRoot is the user-scoped persistent storage within an agent.
-	// Runner execution is always user-scoped, so this must be set.
-	UserRoot string
-
-	// SandboxRoot is the directory exposed as the sandbox's writable root.
-	// It always resolves to UserRoot.
-	SandboxRoot string
-
-	// ProcessHome is the HOME env visible to executed CLIs.
-	// It always resolves to UserRoot.
-	ProcessHome string
-
-	// ToolsBinDir is Anna's managed bin directory.
-	// Used to expose embedded helper binaries to tools and sandboxes.
-	ToolsBinDir string
-
-	// BuiltinSkillsDir is the extracted builtin skills cache directory.
-	// Used for builtin preset/skill discovery.
-	BuiltinSkillsDir string
+	UserRoot  string
+	WorkDir   string
 }
 
-// resolveRunnerPaths converts GoRunnerConfig into one normalized path bundle.
-//
-// Resolution rules:
-//   - AnnaHome: cfg.AnnaHome or config.AnnaHome()
-//   - UserHome: os.UserHomeDir()
-//   - SandboxRoot: cfg.UserRoot
-//   - ProcessHome: cfg.UserRoot
-//   - WorkDir: cfg.WorkDir if set, else cfg.UserRoot
+// resolveRunnerPaths converts GoRunnerConfig into the minimal path set the
+// runner actually owns. Derived paths stay as methods/helpers instead of being
+// stored as extra fields.
 func resolveRunnerPaths(cfg GoRunnerConfig) runnerPaths {
 	annaHome := cfg.AnnaHome
 	if annaHome == "" {
@@ -86,22 +34,25 @@ func resolveRunnerPaths(cfg GoRunnerConfig) runnerPaths {
 	}
 
 	return runnerPaths{
-		AnnaHome:         annaHome,
-		UserHome:         userHome,
-		AgentRoot:        cfg.AgentRoot,
-		WorkDir:          workDir,
-		UserRoot:         cfg.UserRoot,
-		SandboxRoot:      cfg.UserRoot,
-		ProcessHome:      cfg.UserRoot,
-		ToolsBinDir:      embedded.BinDir(annaHome),
-		BuiltinSkillsDir: filepath.Join(annaHome, "cache", "builtin-skills"),
+		AnnaHome:  annaHome,
+		UserHome:  userHome,
+		AgentRoot: cfg.AgentRoot,
+		WorkDir:   workDir,
+		UserRoot:  cfg.UserRoot,
 	}
+}
+
+func (p runnerPaths) sandboxRoot() string { return p.UserRoot }
+func (p runnerPaths) processHome() string { return p.UserRoot }
+func (p runnerPaths) toolsBinDir() string { return embedded.BinDir(p.AnnaHome) }
+func (p runnerPaths) builtinSkillsDir() string {
+	return filepath.Join(p.AnnaHome, "cache", "builtin-skills")
 }
 
 // sandboxRoot returns the directory mounted as the sandbox root.
 // Runner execution is always user-scoped, so this is always UserRoot.
 func sandboxRoot(cfg GoRunnerConfig) string {
-	return resolveRunnerPaths(cfg).SandboxRoot
+	return resolveRunnerPaths(cfg).sandboxRoot()
 }
 
 // sandboxProcessEnv builds the baseline process environment injected into
@@ -109,8 +60,8 @@ func sandboxRoot(cfg GoRunnerConfig) string {
 // and propagates ANNA_HOME so CLIs don't accidentally target the host home.
 func sandboxProcessEnv(paths runnerPaths) map[string]string {
 	env := map[string]string{}
-	if paths.ProcessHome != "" {
-		env["HOME"] = paths.ProcessHome
+	if home := paths.processHome(); home != "" {
+		env["HOME"] = home
 	}
 	if paths.AnnaHome != "" {
 		env["ANNA_HOME"] = paths.AnnaHome

--- a/internal/agent/runner/paths.go
+++ b/internal/agent/runner/paths.go
@@ -1,0 +1,119 @@
+package runner
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/vaayne/anna/internal/config"
+	"github.com/vaayne/anna/internal/embedded"
+)
+
+// runnerPaths is the runner's normalized view of all path-like config.
+//
+// The intent is to separate a few similar-but-different concepts:
+//   - user home on the host machine (for shared discovery like ~/.agents)
+//   - agent workspace (the agent's persistent working area)
+//   - per-user data dir (user-scoped state inside an agent workspace)
+//   - sandbox root (the filesystem root exposed to sandboxed tools)
+//   - process home (the HOME env seen by commands executed in the sandbox)
+//
+// In practice:
+//   - UserHome is used for host-side discovery of shared skills/agents.
+//   - Workspace is the agent-level persistent directory.
+//   - UserDataDir is the user-scoped persistent directory and required for execution.
+//   - SandboxRoot is always the user-scoped writable root.
+//   - ProcessHome is exported as HOME for CLI tools running in the sandbox.
+//
+// This keeps call sites from having to re-decide which of cfg.Workspace,
+// cfg.UserDataDir, cfg.WorkDir, cfg.AnnaHome, or os.UserHomeDir() should be
+// used for each operation.
+type runnerPaths struct {
+	// AnnaHome is Anna's resolved home directory.
+	// Used for managed binaries, cache, builtin skills, and ANNA_HOME.
+	AnnaHome string
+
+	// UserHome is the real host user home directory from os.UserHomeDir().
+	// Used for host-side shared discovery like ~/.agents/{skills,agents}.
+	UserHome string
+
+	// Workspace is the agent's persistent workspace directory.
+	// Used for agent-scoped files such as workspace-local skills/agents.
+	Workspace string
+
+	// WorkDir is the requested working directory for tool execution.
+	// When empty, it defaults to UserDataDir.
+	WorkDir string
+
+	// UserDataDir is the user-scoped persistent storage within an agent.
+	// Runner execution is always user-scoped, so this must be set.
+	UserDataDir string
+
+	// SandboxRoot is the directory exposed as the sandbox's writable root.
+	// It always resolves to UserDataDir.
+	SandboxRoot string
+
+	// ProcessHome is the HOME env visible to executed CLIs.
+	// It always resolves to UserDataDir.
+	ProcessHome string
+
+	// ToolsBinDir is Anna's managed bin directory.
+	// Used to expose embedded helper binaries to tools and sandboxes.
+	ToolsBinDir string
+
+	// BuiltinSkillsDir is the extracted builtin skills cache directory.
+	// Used for builtin preset/skill discovery.
+	BuiltinSkillsDir string
+}
+
+// resolveRunnerPaths converts GoRunnerConfig into one normalized path bundle.
+//
+// Resolution rules:
+//   - AnnaHome: cfg.AnnaHome or config.AnnaHome()
+//   - UserHome: os.UserHomeDir()
+//   - SandboxRoot: cfg.UserDataDir
+//   - ProcessHome: cfg.UserDataDir
+//   - WorkDir: cfg.WorkDir if set, else cfg.UserDataDir
+func resolveRunnerPaths(cfg GoRunnerConfig) runnerPaths {
+	annaHome := cfg.AnnaHome
+	if annaHome == "" {
+		annaHome = config.AnnaHome()
+	}
+
+	userHome, _ := os.UserHomeDir()
+	workDir := cfg.WorkDir
+	if workDir == "" {
+		workDir = cfg.UserDataDir
+	}
+
+	return runnerPaths{
+		AnnaHome:         annaHome,
+		UserHome:         userHome,
+		Workspace:        cfg.Workspace,
+		WorkDir:          workDir,
+		UserDataDir:      cfg.UserDataDir,
+		SandboxRoot:      cfg.UserDataDir,
+		ProcessHome:      cfg.UserDataDir,
+		ToolsBinDir:      embedded.BinDir(annaHome),
+		BuiltinSkillsDir: filepath.Join(annaHome, "cache", "builtin-skills"),
+	}
+}
+
+// sandboxWorkspaceRoot returns the directory mounted as the sandbox root.
+// Runner execution is always user-scoped, so this is always UserDataDir.
+func sandboxWorkspaceRoot(cfg GoRunnerConfig) string {
+	return resolveRunnerPaths(cfg).SandboxRoot
+}
+
+// sandboxProcessEnv builds the baseline process environment injected into
+// sandboxed commands. Today it pins HOME to the sandbox-visible writable area
+// and propagates ANNA_HOME so CLIs don't accidentally target the host home.
+func sandboxProcessEnv(paths runnerPaths) map[string]string {
+	env := map[string]string{}
+	if paths.ProcessHome != "" {
+		env["HOME"] = paths.ProcessHome
+	}
+	if paths.AnnaHome != "" {
+		env["ANNA_HOME"] = paths.AnnaHome
+	}
+	return env
+}

--- a/internal/agent/runner/prompt.go
+++ b/internal/agent/runner/prompt.go
@@ -62,7 +62,7 @@ type DBPromptParams struct {
 	AgentID        string          // agent ID for profile lookup
 	AnnaHome       string
 	AgentRoot      string
-	Cwd            string // optional working directory
+	ProjectRoot    string // optional project root for local/project-attached runs
 	UserRoot       string // per-user writable root
 	PromptTools    []pkgplugins.PromptToolInfo
 	PromptSections []pkgplugins.SystemPromptSection
@@ -114,9 +114,9 @@ func BuildSystemPromptFromDB(ctx context.Context, p DBPromptParams) string {
 	data.PromptSections = append(data.PromptSections, p.PromptSections...)
 
 	// Project context.
-	contextHost, closeContextHost := resolvePromptContextHost(ctx, p.Host, p.Cwd)
+	contextHost, closeContextHost := resolvePromptContextHost(ctx, p.Host, p.ProjectRoot)
 	defer closeContextHost()
-	data.ContextFiles = loadProjectContextFiles(contextHost, p.Cwd)
+	data.ContextFiles = loadProjectContextFiles(contextHost, p.ProjectRoot)
 
 	var buf bytes.Buffer
 	_ = systemTmpl.Execute(&buf, data)

--- a/internal/agent/runner/prompt.go
+++ b/internal/agent/runner/prompt.go
@@ -61,9 +61,9 @@ type DBPromptParams struct {
 	UserID         int64           // auth user ID for profile lookup
 	AgentID        string          // agent ID for profile lookup
 	AnnaHome       string
-	Workspace      string
+	AgentRoot      string
 	Cwd            string // optional working directory
-	UserDataDir    string // optional per-user data directory
+	UserRoot       string // per-user writable root
 	PromptTools    []pkgplugins.PromptToolInfo
 	PromptSections []pkgplugins.SystemPromptSection
 	Host           sandbox.Host

--- a/internal/agent/runner/prompt_context_test.go
+++ b/internal/agent/runner/prompt_context_test.go
@@ -25,7 +25,7 @@ func TestBuildSystemPromptLoadsProjectContextWithoutInjectedHost(t *testing.T) {
 
 	prompt := BuildSystemPromptFromDB(context.Background(), DBPromptParams{
 		SystemPrompt: "You are Anna.",
-		Cwd:          project,
+		ProjectRoot:  project,
 	})
 	if !strings.Contains(prompt, "root instructions") {
 		t.Fatalf("expected root AGENTS.md content in prompt: %s", prompt)

--- a/internal/agent/runner/runner.go
+++ b/internal/agent/runner/runner.go
@@ -48,7 +48,7 @@ type Runner interface {
 type RunnerParams struct {
 	Model   string                    // model ID (empty = use default)
 	Memory  any                       // memory.Provider — typed as any to avoid circular imports
-	UserID  int64                     // auth user ID (0 = no user isolation)
+	UserID  int64                     // auth user ID for user-scoped runner creation
 	AgentID string                    // agent ID for profile loading
 	HooksFn func() []hooks.HookPlugin // resolved at runner-creation time; nil = no hooks
 }

--- a/internal/agent/runner/sandbox_backend.go
+++ b/internal/agent/runner/sandbox_backend.go
@@ -100,7 +100,7 @@ func createLocalSession(_ context.Context, cfg GoRunnerConfig) (*runnerSession, 
 		Backend: config.SandboxBackendLocal,
 		Relaxed: true,
 		Filesystem: sandbox.FilesystemPolicy{
-			WorkspaceRoot: paths.sandboxRoot(),
+			WorkspaceRoot: paths.UserRoot,
 			WorkingDir:    paths.WorkDir,
 			AllowEscapes:  false,
 		},
@@ -151,7 +151,7 @@ func createBoxshSession(ctx context.Context, cfg GoRunnerConfig) (*runnerSession
 		Backend: config.SandboxBackendBoxsh,
 		Relaxed: false,
 		Filesystem: sandbox.FilesystemPolicy{
-			WorkspaceRoot: paths.sandboxRoot(),
+			WorkspaceRoot: paths.UserRoot,
 			WorkingDir:    paths.WorkDir,
 			ReadOnlyPaths: readOnlyDirs,
 			AllowEscapes:  false,

--- a/internal/agent/runner/sandbox_backend.go
+++ b/internal/agent/runner/sandbox_backend.go
@@ -100,7 +100,7 @@ func createLocalSession(_ context.Context, cfg GoRunnerConfig) (*runnerSession, 
 		Backend: config.SandboxBackendLocal,
 		Relaxed: true,
 		Filesystem: sandbox.FilesystemPolicy{
-			WorkspaceRoot: paths.SandboxRoot,
+			WorkspaceRoot: paths.sandboxRoot(),
 			WorkingDir:    paths.WorkDir,
 			AllowEscapes:  false,
 		},
@@ -136,7 +136,7 @@ func createBoxshSession(ctx context.Context, cfg GoRunnerConfig) (*runnerSession
 
 	paths := resolveRunnerPaths(cfg)
 	readOnlyDirs := collectSandboxReadOnlyDirs(
-		paths.ToolsBinDir,
+		paths.toolsBinDir(),
 		os.Getenv("PATH"),
 	)
 	if home, err := os.UserHomeDir(); err == nil && home != "" {
@@ -145,13 +145,13 @@ func createBoxshSession(ctx context.Context, cfg GoRunnerConfig) (*runnerSession
 			filepath.Join(home, ".agents", "agents"),
 		)
 	}
-	readOnlyDirs = append(readOnlyDirs, paths.BuiltinSkillsDir)
+	readOnlyDirs = append(readOnlyDirs, paths.builtinSkillsDir())
 
 	policy := sandbox.Policy{
 		Backend: config.SandboxBackendBoxsh,
 		Relaxed: false,
 		Filesystem: sandbox.FilesystemPolicy{
-			WorkspaceRoot: paths.SandboxRoot,
+			WorkspaceRoot: paths.sandboxRoot(),
 			WorkingDir:    paths.WorkDir,
 			ReadOnlyPaths: readOnlyDirs,
 			AllowEscapes:  false,

--- a/internal/agent/runner/sandbox_backend.go
+++ b/internal/agent/runner/sandbox_backend.go
@@ -8,7 +8,6 @@ import (
 	"runtime"
 
 	"github.com/vaayne/anna/internal/config"
-	"github.com/vaayne/anna/internal/embedded"
 	"github.com/vaayne/anna/internal/sandbox"
 	"github.com/vaayne/anna/plugins/sandbox/boxsh/boxshclient"
 )
@@ -96,19 +95,21 @@ var sessionRegistry = map[string]sessionFactory{
 var platformSupportsBoxsh = boxshclient.PlatformSupportsBoxsh
 
 func createLocalSession(_ context.Context, cfg GoRunnerConfig) (*runnerSession, error) {
+	paths := resolveRunnerPaths(cfg)
 	policy := sandbox.Policy{
 		Backend: config.SandboxBackendLocal,
 		Relaxed: true,
 		Filesystem: sandbox.FilesystemPolicy{
-			WorkspaceRoot: cfg.Workspace,
-			WorkingDir:    cfg.WorkDir,
+			WorkspaceRoot: paths.SandboxRoot,
+			WorkingDir:    paths.WorkDir,
 			AllowEscapes:  false,
 		},
 		Network: sandbox.NetworkPolicy{
 			Mode: sandbox.NetworkAllowAll,
 		},
 		Process: sandbox.ProcessPolicy{
-			InheritEnv: true,
+			Environment: sandboxProcessEnv(paths),
+			InheritEnv:  true,
 		},
 	}
 
@@ -133,13 +134,9 @@ func createBoxshSession(ctx context.Context, cfg GoRunnerConfig) (*runnerSession
 		return nil, fmt.Errorf("sandbox backend %q is not supported on %s", config.SandboxBackendBoxsh, runtime.GOOS)
 	}
 
-	annaHome := cfg.AnnaHome
-	if annaHome == "" {
-		annaHome = config.AnnaHome()
-	}
-
+	paths := resolveRunnerPaths(cfg)
 	readOnlyDirs := collectSandboxReadOnlyDirs(
-		embedded.BinDir(annaHome),
+		paths.ToolsBinDir,
 		os.Getenv("PATH"),
 	)
 	if home, err := os.UserHomeDir(); err == nil && home != "" {
@@ -148,14 +145,14 @@ func createBoxshSession(ctx context.Context, cfg GoRunnerConfig) (*runnerSession
 			filepath.Join(home, ".agents", "agents"),
 		)
 	}
-	readOnlyDirs = append(readOnlyDirs, filepath.Join(annaHome, "cache", "builtin-skills"))
+	readOnlyDirs = append(readOnlyDirs, paths.BuiltinSkillsDir)
 
 	policy := sandbox.Policy{
 		Backend: config.SandboxBackendBoxsh,
 		Relaxed: false,
 		Filesystem: sandbox.FilesystemPolicy{
-			WorkspaceRoot: sandboxWorkspaceRoot(cfg),
-			WorkingDir:    cfg.WorkDir,
+			WorkspaceRoot: paths.SandboxRoot,
+			WorkingDir:    paths.WorkDir,
 			ReadOnlyPaths: readOnlyDirs,
 			AllowEscapes:  false,
 		},
@@ -164,8 +161,8 @@ func createBoxshSession(ctx context.Context, cfg GoRunnerConfig) (*runnerSession
 			Allowlist: cfg.Sandbox.Network.Allowlist,
 		},
 		Process: sandbox.ProcessPolicy{
-			// Process policy uses defaults; config doesn't specify these yet.
-			InheritEnv: true,
+			Environment: sandboxProcessEnv(paths),
+			InheritEnv:  true,
 		},
 	}
 
@@ -174,7 +171,7 @@ func createBoxshSession(ctx context.Context, cfg GoRunnerConfig) (*runnerSession
 		return nil, fmt.Errorf("boxsh factory not available")
 	}
 
-	session, err := createSessionWithAnnaHome(ctx, factory, policy, cfg.AnnaHome)
+	session, err := createSessionWithAnnaHome(ctx, factory, policy, paths.AnnaHome)
 	if err != nil {
 		return nil, fmt.Errorf("create boxsh session: %w", err)
 	}
@@ -183,13 +180,6 @@ func createBoxshSession(ctx context.Context, cfg GoRunnerConfig) (*runnerSession
 		session: session,
 		policy:  policy,
 	}, nil
-}
-
-func sandboxWorkspaceRoot(cfg GoRunnerConfig) string {
-	if cfg.UserDataDir != "" {
-		return cfg.UserDataDir
-	}
-	return cfg.Workspace
 }
 
 var annaHomeEnvMu = struct{ ch chan struct{} }{ch: make(chan struct{}, 1)}

--- a/internal/agent/runner/sandbox_backend_test.go
+++ b/internal/agent/runner/sandbox_backend_test.go
@@ -25,9 +25,12 @@ func TestResolveSessionAutoFallsBackToLocalWhenBoxshUnsupported(t *testing.T) {
 	platformSupportsBoxsh = func() bool { return false }
 	t.Cleanup(func() { platformSupportsBoxsh = previous })
 
+	workspace := t.TempDir()
+	userDataDir := workspace + "/users/1/data"
 	rs, err := resolveSession(context.Background(), GoRunnerConfig{
-		Workspace: t.TempDir(),
-		WorkDir:   ".",
+		Workspace:   workspace,
+		UserDataDir: userDataDir,
+		WorkDir:     ".",
 		Sandbox: config.SandboxConfig{
 			Backend: config.SandboxBackendAuto,
 		},
@@ -68,13 +71,44 @@ func TestSandboxWorkspaceRootUsesUserDataDir(t *testing.T) {
 	}
 }
 
-func TestSandboxWorkspaceRootFallsBackToWorkspace(t *testing.T) {
+func TestResolveRunnerPathsDefaultsWorkDirToUserDataDir(t *testing.T) {
 	cfg := GoRunnerConfig{
-		Workspace: "/workspace/agent",
+		Workspace:   "/workspace/agent",
+		UserDataDir: "/workspace/agent/users/1/data",
 	}
 
-	if got := sandboxWorkspaceRoot(cfg); got != cfg.Workspace {
-		t.Fatalf("sandboxWorkspaceRoot() = %q, want %q", got, cfg.Workspace)
+	paths := resolveRunnerPaths(cfg)
+	if paths.WorkDir != cfg.UserDataDir {
+		t.Fatalf("WorkDir = %q, want %q", paths.WorkDir, cfg.UserDataDir)
+	}
+}
+
+func TestSandboxProcessEnvUsesSandboxRootAsHome(t *testing.T) {
+	cfg := GoRunnerConfig{
+		AnnaHome:    "/anna",
+		Workspace:   "/workspace/agent",
+		UserDataDir: "/workspace/agent/users/1/data",
+	}
+
+	env := sandboxProcessEnv(resolveRunnerPaths(cfg))
+	if got := env["HOME"]; got != cfg.UserDataDir {
+		t.Fatalf("HOME = %q, want %q", got, cfg.UserDataDir)
+	}
+	if got := env["ANNA_HOME"]; got != cfg.AnnaHome {
+		t.Fatalf("ANNA_HOME = %q, want %q", got, cfg.AnnaHome)
+	}
+}
+
+func TestSandboxProcessEnvUsesUserDataDirAsHome(t *testing.T) {
+	cfg := GoRunnerConfig{
+		AnnaHome:    "/anna",
+		Workspace:   "/workspace/agent",
+		UserDataDir: "/workspace/agent/users/1/data",
+	}
+
+	env := sandboxProcessEnv(resolveRunnerPaths(cfg))
+	if got := env["HOME"]; got != cfg.UserDataDir {
+		t.Fatalf("HOME = %q, want %q", got, cfg.UserDataDir)
 	}
 }
 

--- a/internal/agent/runner/sandbox_backend_test.go
+++ b/internal/agent/runner/sandbox_backend_test.go
@@ -26,11 +26,11 @@ func TestResolveSessionAutoFallsBackToLocalWhenBoxshUnsupported(t *testing.T) {
 	t.Cleanup(func() { platformSupportsBoxsh = previous })
 
 	workspace := t.TempDir()
-	userDataDir := workspace + "/users/1/data"
+	userRoot := workspace + "/users/1/data"
 	rs, err := resolveSession(context.Background(), GoRunnerConfig{
-		Workspace:   workspace,
-		UserDataDir: userDataDir,
-		WorkDir:     ".",
+		AgentRoot: workspace,
+		UserRoot:  userRoot,
+		WorkDir:   ".",
 		Sandbox: config.SandboxConfig{
 			Backend: config.SandboxBackendAuto,
 		},
@@ -60,55 +60,55 @@ func TestResolveSessionExplicitBoxshRejectsUnsupportedPlatform(t *testing.T) {
 	}
 }
 
-func TestSandboxWorkspaceRootUsesUserDataDir(t *testing.T) {
+func TestSandboxRootUsesUserRoot(t *testing.T) {
 	cfg := GoRunnerConfig{
-		Workspace:   "/workspace/agent",
-		UserDataDir: "/workspace/agent/users/1/data",
+		AgentRoot: "/workspace/agent",
+		UserRoot:  "/workspace/agent/users/1/data",
 	}
 
-	if got := sandboxWorkspaceRoot(cfg); got != cfg.UserDataDir {
-		t.Fatalf("sandboxWorkspaceRoot() = %q, want %q", got, cfg.UserDataDir)
+	if got := sandboxRoot(cfg); got != cfg.UserRoot {
+		t.Fatalf("sandboxRoot() = %q, want %q", got, cfg.UserRoot)
 	}
 }
 
-func TestResolveRunnerPathsDefaultsWorkDirToUserDataDir(t *testing.T) {
+func TestResolveRunnerPathsDefaultsWorkDirToUserRoot(t *testing.T) {
 	cfg := GoRunnerConfig{
-		Workspace:   "/workspace/agent",
-		UserDataDir: "/workspace/agent/users/1/data",
+		AgentRoot: "/workspace/agent",
+		UserRoot:  "/workspace/agent/users/1/data",
 	}
 
 	paths := resolveRunnerPaths(cfg)
-	if paths.WorkDir != cfg.UserDataDir {
-		t.Fatalf("WorkDir = %q, want %q", paths.WorkDir, cfg.UserDataDir)
+	if paths.WorkDir != cfg.UserRoot {
+		t.Fatalf("WorkDir = %q, want %q", paths.WorkDir, cfg.UserRoot)
 	}
 }
 
 func TestSandboxProcessEnvUsesSandboxRootAsHome(t *testing.T) {
 	cfg := GoRunnerConfig{
-		AnnaHome:    "/anna",
-		Workspace:   "/workspace/agent",
-		UserDataDir: "/workspace/agent/users/1/data",
+		AnnaHome:  "/anna",
+		AgentRoot: "/workspace/agent",
+		UserRoot:  "/workspace/agent/users/1/data",
 	}
 
 	env := sandboxProcessEnv(resolveRunnerPaths(cfg))
-	if got := env["HOME"]; got != cfg.UserDataDir {
-		t.Fatalf("HOME = %q, want %q", got, cfg.UserDataDir)
+	if got := env["HOME"]; got != cfg.UserRoot {
+		t.Fatalf("HOME = %q, want %q", got, cfg.UserRoot)
 	}
 	if got := env["ANNA_HOME"]; got != cfg.AnnaHome {
 		t.Fatalf("ANNA_HOME = %q, want %q", got, cfg.AnnaHome)
 	}
 }
 
-func TestSandboxProcessEnvUsesUserDataDirAsHome(t *testing.T) {
+func TestSandboxProcessEnvUsesUserRootAsHome(t *testing.T) {
 	cfg := GoRunnerConfig{
-		AnnaHome:    "/anna",
-		Workspace:   "/workspace/agent",
-		UserDataDir: "/workspace/agent/users/1/data",
+		AnnaHome:  "/anna",
+		AgentRoot: "/workspace/agent",
+		UserRoot:  "/workspace/agent/users/1/data",
 	}
 
 	env := sandboxProcessEnv(resolveRunnerPaths(cfg))
-	if got := env["HOME"]; got != cfg.UserDataDir {
-		t.Fatalf("HOME = %q, want %q", got, cfg.UserDataDir)
+	if got := env["HOME"]; got != cfg.UserRoot {
+		t.Fatalf("HOME = %q, want %q", got, cfg.UserRoot)
 	}
 }
 

--- a/internal/agent/workspace.go
+++ b/internal/agent/workspace.go
@@ -49,7 +49,7 @@ func UserSkillsDir(userWorkspace string) string {
 	return filepath.Join(userWorkspace, ".agents", "skills")
 }
 
-// UserDataDir returns the per-user data directory path within a user workspace.
-func UserDataDir(userWorkspace string) string {
+// UserRoot returns the per-user writable root path within a user workspace.
+func UserRoot(userWorkspace string) string {
 	return filepath.Join(userWorkspace, "data")
 }

--- a/internal/agent/workspace_test.go
+++ b/internal/agent/workspace_test.go
@@ -154,8 +154,8 @@ func TestUserSkillsDir(t *testing.T) {
 	}
 }
 
-func TestUserDataDir(t *testing.T) {
-	got := UserDataDir("/base/users/42")
+func TestUserRoot(t *testing.T) {
+	got := UserRoot("/base/users/42")
 	want := filepath.Join("/base/users/42", "data")
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)

--- a/internal/pluginhost/builders.go
+++ b/internal/pluginhost/builders.go
@@ -36,10 +36,10 @@ func (h *Host) BuildEnabledTools(ctx context.Context, bc plugintools.BuildContex
 			Platform:    h.platform(reg.PluginID),
 			State:       state,
 			WorkDir:     bc.WorkDir,
-			UserDataDir: bc.UserDataDir,
+			UserRoot:    bc.UserRoot,
 			AnnaHome:    bc.AnnaHome,
 			HomeDir:     bc.HomeDir,
-			Workspace:   bc.Workspace,
+			AgentRoot:   bc.AgentRoot,
 			ToolsBinDir: bc.ToolsBinDir,
 			Runtime:     bc.Runtime,
 		})

--- a/internal/pluginhost/builders.go
+++ b/internal/pluginhost/builders.go
@@ -36,6 +36,7 @@ func (h *Host) BuildEnabledTools(ctx context.Context, bc plugintools.BuildContex
 			Platform:    h.platform(reg.PluginID),
 			State:       state,
 			WorkDir:     bc.WorkDir,
+			ProjectRoot: bc.ProjectRoot,
 			UserRoot:    bc.UserRoot,
 			AnnaHome:    bc.AnnaHome,
 			HomeDir:     bc.HomeDir,

--- a/internal/pluginhost/host.go
+++ b/internal/pluginhost/host.go
@@ -334,15 +334,15 @@ func (h *Host) SystemPromptSections(ctx context.Context, build pkgplugins.System
 			}
 		}
 		section, err := reg.Build(ctx, pkgplugins.SystemPromptContext{
-			Platform:    h.platform(reg.PluginID),
-			State:       state,
-			AnnaHome:    build.AnnaHome,
-			HomeDir:     build.HomeDir,
-			Workspace:   build.Workspace,
-			Cwd:         build.Cwd,
-			UserID:      build.UserID,
-			AgentID:     build.AgentID,
-			UserDataDir: build.UserDataDir,
+			Platform:  h.platform(reg.PluginID),
+			State:     state,
+			AnnaHome:  build.AnnaHome,
+			HomeDir:   build.HomeDir,
+			AgentRoot: build.AgentRoot,
+			Cwd:       build.Cwd,
+			UserID:    build.UserID,
+			AgentID:   build.AgentID,
+			UserRoot:  build.UserRoot,
 		})
 		if err != nil {
 			return nil, err

--- a/internal/pluginhost/host.go
+++ b/internal/pluginhost/host.go
@@ -334,15 +334,15 @@ func (h *Host) SystemPromptSections(ctx context.Context, build pkgplugins.System
 			}
 		}
 		section, err := reg.Build(ctx, pkgplugins.SystemPromptContext{
-			Platform:  h.platform(reg.PluginID),
-			State:     state,
-			AnnaHome:  build.AnnaHome,
-			HomeDir:   build.HomeDir,
-			AgentRoot: build.AgentRoot,
-			Cwd:       build.Cwd,
-			UserID:    build.UserID,
-			AgentID:   build.AgentID,
-			UserRoot:  build.UserRoot,
+			Platform:    h.platform(reg.PluginID),
+			State:       state,
+			AnnaHome:    build.AnnaHome,
+			HomeDir:     build.HomeDir,
+			AgentRoot:   build.AgentRoot,
+			ProjectRoot: build.ProjectRoot,
+			UserID:      build.UserID,
+			AgentID:     build.AgentID,
+			UserRoot:    build.UserRoot,
 		})
 		if err != nil {
 			return nil, err

--- a/pkg/plugins/context.go
+++ b/pkg/plugins/context.go
@@ -14,6 +14,7 @@ type ToolContext struct {
 	Platform    Platform
 	State       PluginState
 	WorkDir     string
+	ProjectRoot string
 	UserRoot    string
 	AnnaHome    string
 	HomeDir     string
@@ -73,15 +74,15 @@ type PromptInventoryContext struct {
 
 // SystemPromptContext is the shared build context for prompt contributions.
 type SystemPromptContext struct {
-	Platform  Platform
-	State     PluginState
-	AnnaHome  string
-	HomeDir   string
-	AgentRoot string
-	Cwd       string
-	UserID    int64
-	AgentID   string
-	UserRoot  string
+	Platform    Platform
+	State       PluginState
+	AnnaHome    string
+	HomeDir     string
+	AgentRoot   string
+	ProjectRoot string
+	UserID      int64
+	AgentID     string
+	UserRoot    string
 }
 
 // BeforeRunContext is the narrow per-run lifecycle context exposed to plugins.

--- a/pkg/plugins/context.go
+++ b/pkg/plugins/context.go
@@ -14,10 +14,10 @@ type ToolContext struct {
 	Platform    Platform
 	State       PluginState
 	WorkDir     string
-	UserDataDir string
+	UserRoot    string
 	AnnaHome    string
 	HomeDir     string
-	Workspace   string
+	AgentRoot   string
 	ToolsBinDir string
 	Runtime     ToolRuntime
 }
@@ -73,15 +73,15 @@ type PromptInventoryContext struct {
 
 // SystemPromptContext is the shared build context for prompt contributions.
 type SystemPromptContext struct {
-	Platform    Platform
-	State       PluginState
-	AnnaHome    string
-	HomeDir     string
-	Workspace   string
-	Cwd         string
-	UserID      int64
-	AgentID     string
-	UserDataDir string
+	Platform  Platform
+	State     PluginState
+	AnnaHome  string
+	HomeDir   string
+	AgentRoot string
+	Cwd       string
+	UserID    int64
+	AgentID   string
+	UserRoot  string
 }
 
 // BeforeRunContext is the narrow per-run lifecycle context exposed to plugins.

--- a/plugins/reflect/conversation_review.go
+++ b/plugins/reflect/conversation_review.go
@@ -97,7 +97,7 @@ func (s *Service) newConversationReviewer(snap *pkgplugins.ReflectSnapshot, user
 
 func loadExistingSkillNames(workspace string, userID int64) []string {
 	allSkills := skillstool.LoadSkills(context.Background(), skillstool.LoadSkillsConfig{
-		Workspace:     workspace,
+		AgentRoot:     workspace,
 		UserSkillsDir: userSkillsDir(workspace, userID),
 	})
 	names := make([]string, 0, len(allSkills))

--- a/plugins/reflect/conversation_review.go
+++ b/plugins/reflect/conversation_review.go
@@ -89,7 +89,7 @@ func (s *Service) newConversationReviewer(snap *pkgplugins.ReflectSnapshot, user
 	return newReviewer(reviewerConfig{
 		Providers:      reg,
 		Model:          model,
-		SkillsTool:     skillstool.NewTool("", "", snap.Workspace, "", userSkillsDir(snap.Workspace, userID), nil),
+		SkillsTool:     skillstool.NewTool("", "", snap.Workspace, "", "", userSkillsDir(snap.Workspace, userID), nil),
 		MemoryTool:     memory.BuildTool(s.memory, memory.WithActionsOnly("profile_get", "profile_update")),
 		ExistingSkills: loadExistingSkillNames(snap.Workspace, userID),
 	})

--- a/plugins/tools/agent/agent.go
+++ b/plugins/tools/agent/agent.go
@@ -17,6 +17,7 @@ import (
 	"github.com/vaayne/anna/pkg/memory"
 	"github.com/vaayne/anna/pkg/providers"
 	"github.com/vaayne/anna/pkg/tools"
+	"github.com/vaayne/anna/plugins/tools/skills"
 )
 
 const (
@@ -40,7 +41,8 @@ type AgentConfig struct {
 	System        string
 	Emit          func(agent.LoopEvent) // optional event emitter for observability
 	Presets       *PresetRegistry       // loaded agent presets (nil = no presets)
-	Hooks         *hooks.HookSet        // inherited by subagents (nil = no hooks)
+	PresetLoader  func(string) *PresetRegistry
+	Hooks         *hooks.HookSet // inherited by subagents (nil = no hooks)
 	ToolLifecycle *agent.ToolLifecycle
 
 	// Configurable limits (zero = use defaults).
@@ -117,6 +119,10 @@ func AgentDefinition(presets *PresetRegistry) tools.Definition {
 							"model": map[string]any{
 								"type":        "string",
 								"description": "Optional model override (e.g. 'claude-haiku-4-5-20251001'). Defaults to parent model.",
+							},
+							"project_root": map[string]any{
+								"type":        "string",
+								"description": "Optional project root for project-local .agents discovery. Empty by default.",
 							},
 							"system": map[string]any{
 								"type":        "string",
@@ -208,6 +214,7 @@ type agentTaskConfig struct {
 	HasTools       bool     // true when "tools" key was present in args
 	MaxTurns       int
 	TimeoutSeconds int
+	ProjectRoot    string
 }
 
 // applyPreset merges preset defaults into the task config.
@@ -259,11 +266,18 @@ func (t *AgentTool) runSubAgent(parentCtx context.Context, tc agentTaskConfig) (
 		if t.cfg.Presets == nil {
 			return taskResult{Error: "no presets available"}
 		}
-		if p, ok := t.cfg.Presets.Lookup(tc.Preset); ok {
+		presets := t.cfg.Presets
+		if tc.ProjectRoot != "" && t.cfg.PresetLoader != nil {
+			presets = t.cfg.PresetLoader(tc.ProjectRoot)
+		}
+		if presets == nil {
+			return taskResult{Error: "no presets available"}
+		}
+		if p, ok := presets.Lookup(tc.Preset); ok {
 			tc.applyPreset(p)
 		} else {
 			return taskResult{Error: fmt.Sprintf("unknown preset: %q (available: %s)",
-				tc.Preset, strings.Join(t.cfg.Presets.Names(), ", "))}
+				tc.Preset, strings.Join(presets.Names(), ", "))}
 		}
 	}
 
@@ -273,6 +287,7 @@ func (t *AgentTool) runSubAgent(parentCtx context.Context, tc agentTaskConfig) (
 	}
 	ctx, cancel := context.WithTimeout(parentCtx, timeout)
 	defer cancel()
+	ctx = skills.WithProjectRoot(ctx, tc.ProjectRoot)
 
 	// Build scoped tool set.
 	toolSet, toolDefs, err := t.buildScopedTools(tc.Tools, tc.HasTools)
@@ -455,6 +470,9 @@ func parseAgentTasks(args map[string]any) ([]agentTaskConfig, error) {
 		}
 		if model, ok := obj["model"].(string); ok {
 			tc.Model = model
+		}
+		if projectRoot, ok := obj["project_root"].(string); ok {
+			tc.ProjectRoot = strings.TrimSpace(projectRoot)
 		}
 		if system, ok := obj["system"].(string); ok {
 			tc.System = system

--- a/plugins/tools/agent/preset_loader.go
+++ b/plugins/tools/agent/preset_loader.go
@@ -14,6 +14,7 @@ import (
 
 // LoadAgentPresetsConfig configures the agent preset discovery paths.
 type LoadAgentPresetsConfig struct {
+	AnnaHome         string // anna home dir (e.g. ~/.anna)
 	AgentRoot        string // agent root dir (e.g. ~/.anna/workspaces/{agentID})
 	UserRoot         string // user root dir (e.g. ~/.anna/workspaces/{agentID}/users/{userID}/data)
 	Cwd              string // working directory
@@ -22,12 +23,12 @@ type LoadAgentPresetsConfig struct {
 }
 
 // LoadAgentPresets discovers agent presets in increasing priority order:
-// ANNA_HOME -> agent root -> user root -> cwd.
+// builtin -> ANNA_HOME -> agent root -> user root -> cwd.
 func LoadAgentPresets(cfg LoadAgentPresetsConfig) []AgentPreset {
-	return loadAgentPresets(context.Background(), cfg.Runtime, cfg.AgentRoot, cfg.UserRoot, cfg.Cwd, cfg.BuiltinSkillsDir)
+	return loadAgentPresets(context.Background(), cfg.Runtime, cfg.AnnaHome, cfg.AgentRoot, cfg.UserRoot, cfg.Cwd, cfg.BuiltinSkillsDir)
 }
 
-func loadAgentPresets(ctx context.Context, runtime pkgplugins.ToolRuntime, agentRoot, userRoot, cwd, builtinSkillsDir string) []AgentPreset {
+func loadAgentPresets(ctx context.Context, runtime pkgplugins.ToolRuntime, annaHome, agentRoot, userRoot, cwd, builtinSkillsDir string) []AgentPreset {
 	indexByName := map[string]int{}
 	var presets []AgentPreset
 
@@ -53,7 +54,10 @@ func loadAgentPresets(ctx context.Context, runtime pkgplugins.ToolRuntime, agent
 	}
 
 	if builtinSkillsDir != "" {
-		addDir(filepath.Join(builtinSkillsDir, "agents"), "anna")
+		addDir(filepath.Join(builtinSkillsDir, "agents"), "builtin")
+	}
+	if annaHome != "" {
+		addDir(filepath.Join(annaHome, "agents"), "anna")
 	}
 	if agentRoot != "" {
 		addDir(filepath.Join(agentRoot, "agents"), "agent")

--- a/plugins/tools/agent/preset_loader.go
+++ b/plugins/tools/agent/preset_loader.go
@@ -17,7 +17,7 @@ type LoadAgentPresetsConfig struct {
 	AnnaHome         string // anna home dir (e.g. ~/.anna)
 	AgentRoot        string // agent root dir (e.g. ~/.anna/workspaces/{agentID})
 	UserRoot         string // user root dir (e.g. ~/.anna/workspaces/{agentID}/users/{userID}/data)
-	Cwd              string // working directory
+	ProjectRoot      string // optional project root for local/project-attached runs
 	BuiltinSkillsDir string // pre-extracted builtin skills directory (caller ensures extraction)
 	Runtime          pkgplugins.ToolRuntime
 }
@@ -25,10 +25,10 @@ type LoadAgentPresetsConfig struct {
 // LoadAgentPresets discovers agent presets in increasing priority order:
 // builtin -> ANNA_HOME -> agent root -> user root -> cwd.
 func LoadAgentPresets(cfg LoadAgentPresetsConfig) []AgentPreset {
-	return loadAgentPresets(context.Background(), cfg.Runtime, cfg.AnnaHome, cfg.AgentRoot, cfg.UserRoot, cfg.Cwd, cfg.BuiltinSkillsDir)
+	return loadAgentPresets(context.Background(), cfg.Runtime, cfg.AnnaHome, cfg.AgentRoot, cfg.UserRoot, cfg.ProjectRoot, cfg.BuiltinSkillsDir)
 }
 
-func loadAgentPresets(ctx context.Context, runtime pkgplugins.ToolRuntime, annaHome, agentRoot, userRoot, cwd, builtinSkillsDir string) []AgentPreset {
+func loadAgentPresets(ctx context.Context, runtime pkgplugins.ToolRuntime, annaHome, agentRoot, userRoot, projectRoot, builtinSkillsDir string) []AgentPreset {
 	indexByName := map[string]int{}
 	var presets []AgentPreset
 
@@ -65,8 +65,8 @@ func loadAgentPresets(ctx context.Context, runtime pkgplugins.ToolRuntime, annaH
 	if userRoot != "" {
 		addDir(filepath.Join(filepath.Dir(userRoot), ".agents", "agents"), "user")
 	}
-	if cwd != "" {
-		addDir(filepath.Join(cwd, ".agents", "agents"), "project")
+	if projectRoot != "" {
+		addDir(filepath.Join(projectRoot, ".agents", "agents"), "project")
 	}
 
 	return presets

--- a/plugins/tools/agent/preset_loader.go
+++ b/plugins/tools/agent/preset_loader.go
@@ -15,7 +15,7 @@ import (
 // LoadAgentPresetsConfig configures the agent preset discovery paths.
 type LoadAgentPresetsConfig struct {
 	HomeDir          string // user home directory for common presets
-	Workspace        string // agent workspace dir (e.g. ~/.anna/workspaces/{agentID})
+	AgentRoot        string // agent root dir (e.g. ~/.anna/workspaces/{agentID})
 	Cwd              string // working directory
 	BuiltinSkillsDir string // pre-extracted builtin skills directory (caller ensures extraction)
 	Runtime          pkgplugins.ToolRuntime
@@ -24,10 +24,10 @@ type LoadAgentPresetsConfig struct {
 // LoadAgentPresets discovers agent presets from multiple directories.
 // Priority order: cwd/.agents/agents/ > workspace/agents/ > ~/.agents/agents/ > builtin
 func LoadAgentPresets(cfg LoadAgentPresetsConfig) []AgentPreset {
-	return loadAgentPresets(context.Background(), cfg.Runtime, cfg.HomeDir, cfg.Workspace, cfg.Cwd, cfg.BuiltinSkillsDir)
+	return loadAgentPresets(context.Background(), cfg.Runtime, cfg.HomeDir, cfg.AgentRoot, cfg.Cwd, cfg.BuiltinSkillsDir)
 }
 
-func loadAgentPresets(ctx context.Context, runtime pkgplugins.ToolRuntime, homeDir, workspace, cwd, builtinSkillsDir string) []AgentPreset {
+func loadAgentPresets(ctx context.Context, runtime pkgplugins.ToolRuntime, homeDir, agentRoot, cwd, builtinSkillsDir string) []AgentPreset {
 	seen := map[string]bool{}
 	var presets []AgentPreset
 
@@ -56,9 +56,9 @@ func loadAgentPresets(ctx context.Context, runtime pkgplugins.ToolRuntime, homeD
 		addDir(filepath.Join(cwd, ".agents", "agents"), "project")
 	}
 
-	// 2. Agent-level workspace agents: workspace/agents/
-	if workspace != "" {
-		addDir(filepath.Join(workspace, "agents"), "agent")
+	// 2. Agent-level agents: agent_root/agents/
+	if agentRoot != "" {
+		addDir(filepath.Join(agentRoot, "agents"), "agent")
 	}
 
 	// 3. Common agents: ~/.agents/agents/

--- a/plugins/tools/agent/preset_loader.go
+++ b/plugins/tools/agent/preset_loader.go
@@ -14,28 +14,29 @@ import (
 
 // LoadAgentPresetsConfig configures the agent preset discovery paths.
 type LoadAgentPresetsConfig struct {
-	HomeDir          string // user home directory for common presets
 	AgentRoot        string // agent root dir (e.g. ~/.anna/workspaces/{agentID})
+	UserRoot         string // user root dir (e.g. ~/.anna/workspaces/{agentID}/users/{userID}/data)
 	Cwd              string // working directory
 	BuiltinSkillsDir string // pre-extracted builtin skills directory (caller ensures extraction)
 	Runtime          pkgplugins.ToolRuntime
 }
 
-// LoadAgentPresets discovers agent presets from multiple directories.
-// Priority order: cwd/.agents/agents/ > workspace/agents/ > ~/.agents/agents/ > builtin
+// LoadAgentPresets discovers agent presets in increasing priority order:
+// ANNA_HOME -> agent root -> user root -> cwd.
 func LoadAgentPresets(cfg LoadAgentPresetsConfig) []AgentPreset {
-	return loadAgentPresets(context.Background(), cfg.Runtime, cfg.HomeDir, cfg.AgentRoot, cfg.Cwd, cfg.BuiltinSkillsDir)
+	return loadAgentPresets(context.Background(), cfg.Runtime, cfg.AgentRoot, cfg.UserRoot, cfg.Cwd, cfg.BuiltinSkillsDir)
 }
 
-func loadAgentPresets(ctx context.Context, runtime pkgplugins.ToolRuntime, homeDir, agentRoot, cwd, builtinSkillsDir string) []AgentPreset {
-	seen := map[string]bool{}
+func loadAgentPresets(ctx context.Context, runtime pkgplugins.ToolRuntime, agentRoot, userRoot, cwd, builtinSkillsDir string) []AgentPreset {
+	indexByName := map[string]int{}
 	var presets []AgentPreset
 
 	add := func(p AgentPreset) {
-		if seen[p.Name] {
+		if idx, ok := indexByName[p.Name]; ok {
+			presets[idx] = p
 			return
 		}
-		seen[p.Name] = true
+		indexByName[p.Name] = len(presets)
 		presets = append(presets, p)
 	}
 
@@ -51,24 +52,17 @@ func loadAgentPresets(ctx context.Context, runtime pkgplugins.ToolRuntime, homeD
 		}
 	}
 
-	// 1. Project-local agents: cwd/.agents/agents/ (highest priority)
-	if cwd != "" {
-		addDir(filepath.Join(cwd, ".agents", "agents"), "project")
+	if builtinSkillsDir != "" {
+		addDir(filepath.Join(builtinSkillsDir, "agents"), "anna")
 	}
-
-	// 2. Agent-level agents: agent_root/agents/
 	if agentRoot != "" {
 		addDir(filepath.Join(agentRoot, "agents"), "agent")
 	}
-
-	// 3. Common agents: ~/.agents/agents/
-	if homeDir != "" {
-		addDir(filepath.Join(homeDir, ".agents", "agents"), "common")
+	if userRoot != "" {
+		addDir(filepath.Join(filepath.Dir(userRoot), ".agents", "agents"), "user")
 	}
-
-	// 4. Builtin agents: pre-extracted by the runner (lowest priority).
-	if builtinSkillsDir != "" {
-		addDir(filepath.Join(builtinSkillsDir, "agents"), "builtin")
+	if cwd != "" {
+		addDir(filepath.Join(cwd, ".agents", "agents"), "project")
 	}
 
 	return presets

--- a/plugins/tools/agent/preset_loader_test.go
+++ b/plugins/tools/agent/preset_loader_test.go
@@ -281,7 +281,7 @@ func TestLoadAgentPresetsDeduplication(t *testing.T) {
 	writeTestFile(t, filepath.Join(dir2, "agents", "unique.md"),
 		[]byte("---\nname: unique\ndescription: Only in workspace\n---\nUnique body."), 0o644)
 
-	presets := loadAgentPresets(context.Background(), nil, "", dir2, dir1, "")
+	presets := loadAgentPresets(context.Background(), nil, dir2, "", dir1, "")
 	if len(presets) != 2 {
 		t.Fatalf("expected 2 presets, got %d", len(presets))
 	}
@@ -324,35 +324,32 @@ func TestLoadAgentPresetsAllFourTiers(t *testing.T) {
 	t.Parallel()
 
 	cwd := t.TempDir()
-	workspace := t.TempDir()
-	home := t.TempDir()
-	builtin := t.TempDir()
+	agentRoot := t.TempDir()
+	userRoot := filepath.Join(t.TempDir(), "users", "7", "data")
+	anna := t.TempDir()
 
 	mkdirAll(t, filepath.Join(cwd, ".agents", "agents"), 0o755)
-	mkdirAll(t, filepath.Join(workspace, "agents"), 0o755)
-	mkdirAll(t, filepath.Join(home, ".agents", "agents"), 0o755)
-	mkdirAll(t, filepath.Join(builtin, "agents"), 0o755)
+	mkdirAll(t, filepath.Join(agentRoot, "agents"), 0o755)
+	mkdirAll(t, filepath.Join(filepath.Dir(userRoot), ".agents", "agents"), 0o755)
+	mkdirAll(t, filepath.Join(anna, "agents"), 0o755)
 
-	// Each tier has a unique preset + "overlap" that exists in all tiers.
 	preset := func(name, desc string) []byte {
 		return []byte("---\nname: " + name + "\ndescription: " + desc + "\n---\nBody.")
 	}
 
+	writeTestFile(t, filepath.Join(anna, "agents", "anna-only.md"), preset("anna-only", "From anna"), 0o644)
+	writeTestFile(t, filepath.Join(anna, "agents", "overlap.md"), preset("overlap", "Anna loses"), 0o644)
+
+	writeTestFile(t, filepath.Join(agentRoot, "agents", "agent-only.md"), preset("agent-only", "From agent root"), 0o644)
+	writeTestFile(t, filepath.Join(agentRoot, "agents", "overlap.md"), preset("overlap", "Agent loses"), 0o644)
+
+	writeTestFile(t, filepath.Join(filepath.Dir(userRoot), ".agents", "agents", "user-only.md"), preset("user-only", "From user root"), 0o644)
+	writeTestFile(t, filepath.Join(filepath.Dir(userRoot), ".agents", "agents", "overlap.md"), preset("overlap", "User loses"), 0o644)
+
 	writeTestFile(t, filepath.Join(cwd, ".agents", "agents", "project-only.md"), preset("project-only", "From project"), 0o644)
 	writeTestFile(t, filepath.Join(cwd, ".agents", "agents", "overlap.md"), preset("overlap", "Project wins"), 0o644)
 
-	writeTestFile(t, filepath.Join(workspace, "agents", "agent-only.md"), preset("agent-only", "From agent workspace"), 0o644)
-	writeTestFile(t, filepath.Join(workspace, "agents", "overlap.md"), preset("overlap", "Agent loses"), 0o644)
-
-	writeTestFile(t, filepath.Join(home, ".agents", "agents", "common-only.md"), preset("common-only", "From common"), 0o644)
-	writeTestFile(t, filepath.Join(home, ".agents", "agents", "overlap.md"), preset("overlap", "Common loses"), 0o644)
-
-	writeTestFile(t, filepath.Join(builtin, "agents", "builtin-only.md"), preset("builtin-only", "From builtin"), 0o644)
-	writeTestFile(t, filepath.Join(builtin, "agents", "overlap.md"), preset("overlap", "Builtin loses"), 0o644)
-
-	presets := loadAgentPresets(context.Background(), nil, home, workspace, cwd, builtin)
-
-	// Should have 5: project-only, agent-only, common-only, builtin-only, overlap (from project).
+	presets := loadAgentPresets(context.Background(), nil, agentRoot, userRoot, cwd, anna)
 	if len(presets) != 5 {
 		t.Fatalf("expected 5 presets, got %d", len(presets))
 	}
@@ -361,48 +358,23 @@ func TestLoadAgentPresetsAllFourTiers(t *testing.T) {
 	for _, p := range presets {
 		byName[p.Name] = p
 	}
-
-	// Verify each tier contributed its unique preset.
-	if byName["project-only"].Source != "project" {
-		t.Errorf("project-only Source = %q", byName["project-only"].Source)
+	if byName["anna-only"].Source != "anna" {
+		t.Errorf("anna-only Source = %q", byName["anna-only"].Source)
 	}
 	if byName["agent-only"].Source != "agent" {
 		t.Errorf("agent-only Source = %q", byName["agent-only"].Source)
 	}
-	if byName["common-only"].Source != "common" {
-		t.Errorf("common-only Source = %q", byName["common-only"].Source)
+	if byName["user-only"].Source != "user" {
+		t.Errorf("user-only Source = %q", byName["user-only"].Source)
 	}
-	if byName["builtin-only"].Source != "builtin" {
-		t.Errorf("builtin-only Source = %q", byName["builtin-only"].Source)
+	if byName["project-only"].Source != "project" {
+		t.Errorf("project-only Source = %q", byName["project-only"].Source)
 	}
-
-	// Overlap should come from project (highest priority).
 	if byName["overlap"].Source != "project" {
 		t.Errorf("overlap Source = %q, want %q", byName["overlap"].Source, "project")
 	}
 	if byName["overlap"].Description != "Project wins" {
 		t.Errorf("overlap Description = %q, want %q", byName["overlap"].Description, "Project wins")
-	}
-}
-
-func TestLoadAgentPresetsUsesConfiguredHomeDir(t *testing.T) {
-	t.Parallel()
-
-	home := t.TempDir()
-	builtin := t.TempDir()
-	mkdirAll(t, filepath.Join(home, ".agents", "agents"), 0o755)
-	writeTestFile(t, filepath.Join(home, ".agents", "agents", "common.md"),
-		[]byte("---\nname: common\ndescription: From configured home\n---\nBody."), 0o644)
-
-	presets := LoadAgentPresets(LoadAgentPresetsConfig{
-		HomeDir:          home,
-		BuiltinSkillsDir: builtin,
-	})
-	if len(presets) != 1 {
-		t.Fatalf("expected 1 preset, got %d", len(presets))
-	}
-	if presets[0].Source != "common" {
-		t.Fatalf("preset source = %q, want common", presets[0].Source)
 	}
 }
 
@@ -417,20 +389,14 @@ func TestLoadAgentPresetsPathDedup(t *testing.T) {
 	preset := []byte("---\nname: dup-test\ndescription: Should appear once\n---\nBody.")
 	writeTestFile(t, filepath.Join(shared, ".agents", "agents", "dup-test.md"), preset, 0o644)
 
-	// Pass the same directory as both cwd (scanned as .agents/agents/) and workspace (scanned as agents/).
-	// These are different subdirs so no dedup needed here. Instead test: pass same absolute path for
-	// two tiers that scan the same subdir.
+	// Pass the same directory as both agentRoot and builtin root. Both scan
+	// the same agents/ subdir, so filepath.Abs dedup should load it once.
 	dir := t.TempDir()
 	mkdirAll(t, filepath.Join(dir, "agents"), 0o755)
 	writeTestFile(t, filepath.Join(dir, "agents", "test.md"),
 		[]byte("---\nname: test\ndescription: Test agent\n---\nBody."), 0o644)
 
-	// Create a symlink that resolves to the same absolute path.
-	// Both workspace and home point to the same agents/ dir.
-	// Pass same dir as both workspace and builtin — they both scan "agents/".
-	presets := loadAgentPresets(context.Background(), nil, "", dir, "", dir)
-	// workspace=dir → dir/agents/, builtin=dir → dir/agents/
-	// filepath.Abs dedup should make them load only once.
+	presets := loadAgentPresets(context.Background(), nil, dir, "", "", dir)
 	if len(presets) != 1 {
 		t.Errorf("expected 1 preset (dedup), got %d", len(presets))
 	}

--- a/plugins/tools/agent/preset_loader_test.go
+++ b/plugins/tools/agent/preset_loader_test.go
@@ -281,7 +281,7 @@ func TestLoadAgentPresetsDeduplication(t *testing.T) {
 	writeTestFile(t, filepath.Join(dir2, "agents", "unique.md"),
 		[]byte("---\nname: unique\ndescription: Only in workspace\n---\nUnique body."), 0o644)
 
-	presets := loadAgentPresets(context.Background(), nil, dir2, "", dir1, "")
+	presets := loadAgentPresets(context.Background(), nil, "", dir2, "", dir1, "")
 	if len(presets) != 2 {
 		t.Fatalf("expected 2 presets, got %d", len(presets))
 	}
@@ -326,19 +326,24 @@ func TestLoadAgentPresetsAllFourTiers(t *testing.T) {
 	cwd := t.TempDir()
 	agentRoot := t.TempDir()
 	userRoot := filepath.Join(t.TempDir(), "users", "7", "data")
-	anna := t.TempDir()
+	annaHome := t.TempDir()
+	builtin := t.TempDir()
 
 	mkdirAll(t, filepath.Join(cwd, ".agents", "agents"), 0o755)
 	mkdirAll(t, filepath.Join(agentRoot, "agents"), 0o755)
 	mkdirAll(t, filepath.Join(filepath.Dir(userRoot), ".agents", "agents"), 0o755)
-	mkdirAll(t, filepath.Join(anna, "agents"), 0o755)
+	mkdirAll(t, filepath.Join(annaHome, "agents"), 0o755)
+	mkdirAll(t, filepath.Join(builtin, "agents"), 0o755)
 
 	preset := func(name, desc string) []byte {
 		return []byte("---\nname: " + name + "\ndescription: " + desc + "\n---\nBody.")
 	}
 
-	writeTestFile(t, filepath.Join(anna, "agents", "anna-only.md"), preset("anna-only", "From anna"), 0o644)
-	writeTestFile(t, filepath.Join(anna, "agents", "overlap.md"), preset("overlap", "Anna loses"), 0o644)
+	writeTestFile(t, filepath.Join(builtin, "agents", "builtin-only.md"), preset("builtin-only", "From builtin"), 0o644)
+	writeTestFile(t, filepath.Join(builtin, "agents", "overlap.md"), preset("overlap", "Builtin loses"), 0o644)
+
+	writeTestFile(t, filepath.Join(annaHome, "agents", "anna-only.md"), preset("anna-only", "From anna"), 0o644)
+	writeTestFile(t, filepath.Join(annaHome, "agents", "overlap.md"), preset("overlap", "Anna loses"), 0o644)
 
 	writeTestFile(t, filepath.Join(agentRoot, "agents", "agent-only.md"), preset("agent-only", "From agent root"), 0o644)
 	writeTestFile(t, filepath.Join(agentRoot, "agents", "overlap.md"), preset("overlap", "Agent loses"), 0o644)
@@ -349,14 +354,17 @@ func TestLoadAgentPresetsAllFourTiers(t *testing.T) {
 	writeTestFile(t, filepath.Join(cwd, ".agents", "agents", "project-only.md"), preset("project-only", "From project"), 0o644)
 	writeTestFile(t, filepath.Join(cwd, ".agents", "agents", "overlap.md"), preset("overlap", "Project wins"), 0o644)
 
-	presets := loadAgentPresets(context.Background(), nil, agentRoot, userRoot, cwd, anna)
-	if len(presets) != 5 {
-		t.Fatalf("expected 5 presets, got %d", len(presets))
+	presets := loadAgentPresets(context.Background(), nil, annaHome, agentRoot, userRoot, cwd, builtin)
+	if len(presets) != 6 {
+		t.Fatalf("expected 6 presets, got %d", len(presets))
 	}
 
 	byName := map[string]AgentPreset{}
 	for _, p := range presets {
 		byName[p.Name] = p
+	}
+	if byName["builtin-only"].Source != "builtin" {
+		t.Errorf("builtin-only Source = %q", byName["builtin-only"].Source)
 	}
 	if byName["anna-only"].Source != "anna" {
 		t.Errorf("anna-only Source = %q", byName["anna-only"].Source)
@@ -396,7 +404,7 @@ func TestLoadAgentPresetsPathDedup(t *testing.T) {
 	writeTestFile(t, filepath.Join(dir, "agents", "test.md"),
 		[]byte("---\nname: test\ndescription: Test agent\n---\nBody."), 0o644)
 
-	presets := loadAgentPresets(context.Background(), nil, dir, "", "", dir)
+	presets := loadAgentPresets(context.Background(), nil, "", dir, "", "", dir)
 	if len(presets) != 1 {
 		t.Errorf("expected 1 preset (dedup), got %d", len(presets))
 	}

--- a/plugins/tools/registry.go
+++ b/plugins/tools/registry.go
@@ -5,6 +5,7 @@ import pkgplugins "github.com/vaayne/anna/pkg/plugins"
 // BuildContext carries per-session configuration for tool construction.
 type BuildContext struct {
 	WorkDir     string // working directory for tool execution
+	ProjectRoot string // optional project root for local/project-attached runs
 	UserRoot    string // per-user writable root used by prompts, skills, and sandbox setup
 	AnnaHome    string // anna home directory (e.g. ~/.anna)
 	HomeDir     string // user home directory for common config/skills lookup

--- a/plugins/tools/registry.go
+++ b/plugins/tools/registry.go
@@ -5,10 +5,10 @@ import pkgplugins "github.com/vaayne/anna/pkg/plugins"
 // BuildContext carries per-session configuration for tool construction.
 type BuildContext struct {
 	WorkDir     string // working directory for tool execution
-	UserDataDir string // optional per-user data directory used by prompts, skills, and sandbox setup
+	UserRoot    string // per-user writable root used by prompts, skills, and sandbox setup
 	AnnaHome    string // anna home directory (e.g. ~/.anna)
 	HomeDir     string // user home directory for common config/skills lookup
-	Workspace   string // agent workspace dir
+	AgentRoot   string // agent root dir
 	ToolsBinDir string // path to anna tools bin directory (prepended to PATH)
 	Runtime     pkgplugins.ToolRuntime
 }

--- a/plugins/tools/skills/catalog.go
+++ b/plugins/tools/skills/catalog.go
@@ -56,7 +56,7 @@ const (
 var validNameRe = regexp.MustCompile(`^[a-z0-9-]+$`)
 
 // LoadSkills discovers skills in increasing priority order:
-// ANNA_HOME -> agent root -> user root -> cwd.
+// builtin -> ANNA_HOME -> agent root -> user root -> cwd.
 func LoadSkills(ctx context.Context, cfg LoadSkillsConfig) []Skill {
 	return loadSkills(ctx, cfg.Runtime, cfg.AnnaHome, cfg.AgentRoot, cfg.UserRoot, cfg.Cwd, cfg.UserSkillsDir)
 }
@@ -91,8 +91,9 @@ func loadSkills(ctx context.Context, runtime pkgplugins.ToolRuntime, annaHome, a
 		if err := builtin.Extract(builtinDir); err != nil {
 			slog.Warn("failed to extract builtin skills", "error", err)
 		} else {
-			addDir(builtinDir, "anna")
+			addDir(builtinDir, "builtin")
 		}
+		addDir(filepath.Join(annaHome, "skills"), "anna")
 	}
 	if agentRoot != "" {
 		addDir(filepath.Join(agentRoot, "skills"), "agent")

--- a/plugins/tools/skills/catalog.go
+++ b/plugins/tools/skills/catalog.go
@@ -33,9 +33,9 @@ type Skill struct {
 // LoadSkillsConfig controls skill discovery roots.
 type LoadSkillsConfig struct {
 	Runtime       pkgplugins.ToolRuntime
-	HomeDir       string
 	AnnaHome      string
-	Workspace     string
+	AgentRoot     string
+	UserRoot      string
 	Cwd           string
 	UserSkillsDir string
 }
@@ -55,20 +55,22 @@ const (
 
 var validNameRe = regexp.MustCompile(`^[a-z0-9-]+$`)
 
-// LoadSkills discovers skills from project, user, workspace, and common directories.
+// LoadSkills discovers skills in increasing priority order:
+// ANNA_HOME -> agent root -> user root -> cwd.
 func LoadSkills(ctx context.Context, cfg LoadSkillsConfig) []Skill {
-	return loadSkills(ctx, cfg.Runtime, cfg.HomeDir, cfg.AnnaHome, cfg.Workspace, cfg.Cwd, cfg.UserSkillsDir)
+	return loadSkills(ctx, cfg.Runtime, cfg.AnnaHome, cfg.AgentRoot, cfg.UserRoot, cfg.Cwd, cfg.UserSkillsDir)
 }
 
-func loadSkills(ctx context.Context, runtime pkgplugins.ToolRuntime, homeDir, annaHome, workspace, cwd, userSkillsDir string) []Skill {
-	seen := map[string]bool{}
+func loadSkills(ctx context.Context, runtime pkgplugins.ToolRuntime, annaHome, agentRoot, userRoot, cwd, userSkillsDir string) []Skill {
+	indexByName := map[string]int{}
 	var skills []Skill
 
 	add := func(s Skill) {
-		if seen[s.Name] {
+		if idx, ok := indexByName[s.Name]; ok {
+			skills[idx] = s
 			return
 		}
-		seen[s.Name] = true
+		indexByName[s.Name] = len(skills)
 		skills = append(skills, s)
 	}
 
@@ -84,25 +86,25 @@ func loadSkills(ctx context.Context, runtime pkgplugins.ToolRuntime, homeDir, an
 		}
 	}
 
-	if cwd != "" {
-		addDir(filepath.Join(cwd, ".agents", "skills"), "project")
-	}
-	if userSkillsDir != "" {
-		addDir(userSkillsDir, "user")
-	}
-	if workspace != "" {
-		addDir(filepath.Join(workspace, "skills"), "agent")
-	}
-	if homeDir != "" {
-		addDir(filepath.Join(homeDir, ".agents", "skills"), "common")
-	}
 	if annaHome != "" {
 		builtinDir := filepath.Join(annaHome, "cache", "builtin-skills")
 		if err := builtin.Extract(builtinDir); err != nil {
 			slog.Warn("failed to extract builtin skills", "error", err)
 		} else {
-			addDir(builtinDir, "builtin")
+			addDir(builtinDir, "anna")
 		}
+	}
+	if agentRoot != "" {
+		addDir(filepath.Join(agentRoot, "skills"), "agent")
+	}
+	if userSkillsDir == "" && userRoot != "" {
+		userSkillsDir = filepath.Join(filepath.Dir(userRoot), ".agents", "skills")
+	}
+	if userSkillsDir != "" {
+		addDir(userSkillsDir, "user")
+	}
+	if cwd != "" {
+		addDir(filepath.Join(cwd, ".agents", "skills"), "project")
 	}
 
 	return skills

--- a/plugins/tools/skills/catalog.go
+++ b/plugins/tools/skills/catalog.go
@@ -36,7 +36,7 @@ type LoadSkillsConfig struct {
 	AnnaHome      string
 	AgentRoot     string
 	UserRoot      string
-	Cwd           string
+	ProjectRoot   string
 	UserSkillsDir string
 }
 
@@ -58,10 +58,10 @@ var validNameRe = regexp.MustCompile(`^[a-z0-9-]+$`)
 // LoadSkills discovers skills in increasing priority order:
 // builtin -> ANNA_HOME -> agent root -> user root -> cwd.
 func LoadSkills(ctx context.Context, cfg LoadSkillsConfig) []Skill {
-	return loadSkills(ctx, cfg.Runtime, cfg.AnnaHome, cfg.AgentRoot, cfg.UserRoot, cfg.Cwd, cfg.UserSkillsDir)
+	return loadSkills(ctx, cfg.Runtime, cfg.AnnaHome, cfg.AgentRoot, cfg.UserRoot, cfg.ProjectRoot, cfg.UserSkillsDir)
 }
 
-func loadSkills(ctx context.Context, runtime pkgplugins.ToolRuntime, annaHome, agentRoot, userRoot, cwd, userSkillsDir string) []Skill {
+func loadSkills(ctx context.Context, runtime pkgplugins.ToolRuntime, annaHome, agentRoot, userRoot, projectRoot, userSkillsDir string) []Skill {
 	indexByName := map[string]int{}
 	var skills []Skill
 
@@ -104,8 +104,8 @@ func loadSkills(ctx context.Context, runtime pkgplugins.ToolRuntime, annaHome, a
 	if userSkillsDir != "" {
 		addDir(userSkillsDir, "user")
 	}
-	if cwd != "" {
-		addDir(filepath.Join(cwd, ".agents", "skills"), "project")
+	if projectRoot != "" {
+		addDir(filepath.Join(projectRoot, ".agents", "skills"), "project")
 	}
 
 	return skills

--- a/plugins/tools/skills/catalog_test.go
+++ b/plugins/tools/skills/catalog_test.go
@@ -15,11 +15,12 @@ func TestLoadSkillsPriorityLowToHigh(t *testing.T) {
 	userRoot := filepath.Join(t.TempDir(), "users", "7", "data")
 	cwd := t.TempDir()
 
-	annaDir := filepath.Join(annaHome, "cache", "builtin-skills", "shared")
+	builtinDir := filepath.Join(annaHome, "cache", "builtin-skills", "shared")
+	annaDir := filepath.Join(annaHome, "skills", "shared")
 	agentDir := filepath.Join(agentRoot, "skills", "shared")
 	userDir := filepath.Join(filepath.Dir(userRoot), ".agents", "skills", "shared")
 	projectDir := filepath.Join(cwd, ".agents", "skills", "shared")
-	for _, dir := range []string{annaDir, agentDir, userDir, projectDir} {
+	for _, dir := range []string{builtinDir, annaDir, agentDir, userDir, projectDir} {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatal(err)
 		}
@@ -30,6 +31,7 @@ func TestLoadSkillsPriorityLowToHigh(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+	writeSkill(builtinDir, "builtin")
 	writeSkill(annaDir, "anna")
 	writeSkill(agentDir, "agent")
 	writeSkill(userDir, "user")

--- a/plugins/tools/skills/catalog_test.go
+++ b/plugins/tools/skills/catalog_test.go
@@ -7,33 +7,58 @@ import (
 	"testing"
 )
 
-func TestLoadSkillsWithConfigUsesConfiguredHomeDir(t *testing.T) {
+func TestLoadSkillsPriorityLowToHigh(t *testing.T) {
 	t.Parallel()
 
-	home := t.TempDir()
-	commonDir := filepath.Join(home, ".agents", "skills", "common-skill")
-	if err := os.MkdirAll(commonDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(commonDir, "SKILL.md"), []byte(`---
-description: Common skill
-status: active
----
-body
-`), 0o644); err != nil {
-		t.Fatal(err)
+	annaHome := t.TempDir()
+	agentRoot := t.TempDir()
+	userRoot := filepath.Join(t.TempDir(), "users", "7", "data")
+	cwd := t.TempDir()
+
+	annaDir := filepath.Join(annaHome, "cache", "builtin-skills", "shared")
+	agentDir := filepath.Join(agentRoot, "skills", "shared")
+	userDir := filepath.Join(filepath.Dir(userRoot), ".agents", "skills", "shared")
+	projectDir := filepath.Join(cwd, ".agents", "skills", "shared")
+	for _, dir := range []string{annaDir, agentDir, userDir, projectDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
 	}
 
+	writeSkill := func(dir, desc string) {
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\ndescription: "+desc+"\nstatus: active\n---\nbody\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeSkill(annaDir, "anna")
+	writeSkill(agentDir, "agent")
+	writeSkill(userDir, "user")
+	writeSkill(projectDir, "project")
+
 	skills := LoadSkills(context.Background(), LoadSkillsConfig{
-		HomeDir: home,
+		AnnaHome:  annaHome,
+		AgentRoot: agentRoot,
+		UserRoot:  userRoot,
+		Cwd:       cwd,
 	})
-	if len(skills) != 1 {
-		t.Fatalf("expected 1 skill, got %d", len(skills))
+
+	var shared Skill
+	var found bool
+	for _, skill := range skills {
+		if skill.Name != "shared" {
+			continue
+		}
+		shared = skill
+		found = true
+		break
 	}
-	if skills[0].Name != "common-skill" {
-		t.Fatalf("skill name = %q, want common-skill", skills[0].Name)
+	if !found {
+		t.Fatal("expected shared skill to be discovered")
 	}
-	if skills[0].Source != "common" {
-		t.Fatalf("skill source = %q, want common", skills[0].Source)
+	if shared.Source != "project" {
+		t.Fatalf("skill source = %q, want project", shared.Source)
+	}
+	if shared.Description != "project" {
+		t.Fatalf("skill description = %q, want project", shared.Description)
 	}
 }

--- a/plugins/tools/skills/catalog_test.go
+++ b/plugins/tools/skills/catalog_test.go
@@ -38,10 +38,10 @@ func TestLoadSkillsPriorityLowToHigh(t *testing.T) {
 	writeSkill(projectDir, "project")
 
 	skills := LoadSkills(context.Background(), LoadSkillsConfig{
-		AnnaHome:  annaHome,
-		AgentRoot: agentRoot,
-		UserRoot:  userRoot,
-		Cwd:       cwd,
+		AnnaHome:    annaHome,
+		AgentRoot:   agentRoot,
+		UserRoot:    userRoot,
+		ProjectRoot: cwd,
 	})
 
 	var shared Skill

--- a/plugins/tools/skills/plugin.go
+++ b/plugins/tools/skills/plugin.go
@@ -28,7 +28,7 @@ func init() {
 			Description: "Manage local agent skills.",
 			Required:    true,
 			Build: func(ctx pkgplugins.ToolContext) (tools.Tool, error) {
-				return NewTool(ctx.AnnaHome, ctx.HomeDir, ctx.AgentRoot, ctx.WorkDir, userSkillsDir(ctx.UserRoot), ctx.Runtime), nil
+				return NewTool(ctx.AnnaHome, ctx.HomeDir, ctx.AgentRoot, ctx.ProjectRoot, ctx.WorkDir, userSkillsDir(ctx.UserRoot), ctx.Runtime), nil
 			},
 		})
 		host.AddSystemPrompt(pkgplugins.SystemPromptSpec{

--- a/plugins/tools/skills/plugin.go
+++ b/plugins/tools/skills/plugin.go
@@ -28,7 +28,7 @@ func init() {
 			Description: "Manage local agent skills.",
 			Required:    true,
 			Build: func(ctx pkgplugins.ToolContext) (tools.Tool, error) {
-				return NewTool(ctx.AnnaHome, ctx.HomeDir, ctx.Workspace, ctx.WorkDir, userSkillsDir(ctx.UserDataDir), ctx.Runtime), nil
+				return NewTool(ctx.AnnaHome, ctx.HomeDir, ctx.AgentRoot, ctx.WorkDir, userSkillsDir(ctx.UserRoot), ctx.Runtime), nil
 			},
 		})
 		host.AddSystemPrompt(pkgplugins.SystemPromptSpec{
@@ -40,11 +40,11 @@ func init() {
 	}))
 }
 
-func userSkillsDir(userDataDir string) string {
-	if userDataDir == "" {
+func userSkillsDir(userRoot string) string {
+	if userRoot == "" {
 		return ""
 	}
-	return filepath.Join(filepath.Dir(userDataDir), ".agents", "skills")
+	return filepath.Join(filepath.Dir(userRoot), ".agents", "skills")
 }
 
 func SkillsDefinition() tools.Definition {

--- a/plugins/tools/skills/project_context.go
+++ b/plugins/tools/skills/project_context.go
@@ -1,0 +1,21 @@
+package skills
+
+import "context"
+
+type projectRootContextKey struct{}
+
+func WithProjectRoot(ctx context.Context, projectRoot string) context.Context {
+	if projectRoot == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, projectRootContextKey{}, projectRoot)
+}
+
+func projectRootFromContext(ctx context.Context, fallback string) string {
+	if ctx != nil {
+		if projectRoot, ok := ctx.Value(projectRootContextKey{}).(string); ok && projectRoot != "" {
+			return projectRoot
+		}
+	}
+	return fallback
+}

--- a/plugins/tools/skills/prompt.go
+++ b/plugins/tools/skills/prompt.go
@@ -11,9 +11,9 @@ func buildPromptSection(_ context.Context, build pkgplugins.SystemPromptContext)
 	skills := VisibleSkills(LoadSkills(context.Background(), LoadSkillsConfig{
 		HomeDir:       build.HomeDir,
 		AnnaHome:      build.AnnaHome,
-		Workspace:     build.Workspace,
+		Workspace:     build.AgentRoot,
 		Cwd:           build.Cwd,
-		UserSkillsDir: userSkillsDir(build.UserDataDir),
+		UserSkillsDir: userSkillsDir(build.UserRoot),
 	}))
 	if len(skills) == 0 {
 		return pkgplugins.SystemPromptSection{}, nil

--- a/plugins/tools/skills/prompt.go
+++ b/plugins/tools/skills/prompt.go
@@ -12,7 +12,7 @@ func buildPromptSection(_ context.Context, build pkgplugins.SystemPromptContext)
 		AnnaHome:      build.AnnaHome,
 		AgentRoot:     build.AgentRoot,
 		UserRoot:      build.UserRoot,
-		Cwd:           build.Cwd,
+		ProjectRoot:   build.ProjectRoot,
 		UserSkillsDir: userSkillsDir(build.UserRoot),
 	}))
 	if len(skills) == 0 {

--- a/plugins/tools/skills/prompt.go
+++ b/plugins/tools/skills/prompt.go
@@ -9,9 +9,9 @@ import (
 
 func buildPromptSection(_ context.Context, build pkgplugins.SystemPromptContext) (pkgplugins.SystemPromptSection, error) {
 	skills := VisibleSkills(LoadSkills(context.Background(), LoadSkillsConfig{
-		HomeDir:       build.HomeDir,
 		AnnaHome:      build.AnnaHome,
-		Workspace:     build.AgentRoot,
+		AgentRoot:     build.AgentRoot,
+		UserRoot:      build.UserRoot,
 		Cwd:           build.Cwd,
 		UserSkillsDir: userSkillsDir(build.UserRoot),
 	}))

--- a/plugins/tools/skills/prompt_test.go
+++ b/plugins/tools/skills/prompt_test.go
@@ -60,11 +60,11 @@ old body
 
 	homeDir := t.TempDir()
 	section, err := buildPromptSection(context.Background(), pkgplugins.SystemPromptContext{
-		AnnaHome:    annaHome,
-		HomeDir:     homeDir,
-		Workspace:   workspace,
-		Cwd:         cwd,
-		UserDataDir: userDataDir,
+		AnnaHome:  annaHome,
+		HomeDir:   homeDir,
+		AgentRoot: workspace,
+		Cwd:       cwd,
+		UserRoot:  userDataDir,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -88,7 +88,7 @@ func TestBuildPromptSectionOmitsEmptySkillList(t *testing.T) {
 	section, err := buildPromptSection(context.Background(), pkgplugins.SystemPromptContext{
 		AnnaHome:  "",
 		HomeDir:   t.TempDir(),
-		Workspace: t.TempDir(),
+		AgentRoot: t.TempDir(),
 		Cwd:       t.TempDir(),
 	})
 	if err != nil {

--- a/plugins/tools/skills/prompt_test.go
+++ b/plugins/tools/skills/prompt_test.go
@@ -60,11 +60,11 @@ old body
 
 	homeDir := t.TempDir()
 	section, err := buildPromptSection(context.Background(), pkgplugins.SystemPromptContext{
-		AnnaHome:  annaHome,
-		HomeDir:   homeDir,
-		AgentRoot: workspace,
-		Cwd:       cwd,
-		UserRoot:  userDataDir,
+		AnnaHome:    annaHome,
+		HomeDir:     homeDir,
+		AgentRoot:   workspace,
+		ProjectRoot: cwd,
+		UserRoot:    userDataDir,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -86,10 +86,10 @@ old body
 
 func TestBuildPromptSectionOmitsEmptySkillList(t *testing.T) {
 	section, err := buildPromptSection(context.Background(), pkgplugins.SystemPromptContext{
-		AnnaHome:  "",
-		HomeDir:   t.TempDir(),
-		AgentRoot: t.TempDir(),
-		Cwd:       t.TempDir(),
+		AnnaHome:    "",
+		HomeDir:     t.TempDir(),
+		AgentRoot:   t.TempDir(),
+		ProjectRoot: t.TempDir(),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/plugins/tools/skills/tool.go
+++ b/plugins/tools/skills/tool.go
@@ -58,17 +58,17 @@ var skillsInputSchema = func() map[string]any {
 type Tool struct {
 	homeDir       string
 	annaHome      string
-	workspace     string
+	agentRoot     string
 	cwd           string
 	userSkillsDir string
 	runtime       pkgplugins.ToolRuntime
 }
 
-func NewTool(annaHome, homeDir, workspace, cwd, userSkillsDir string, runtime pkgplugins.ToolRuntime) *Tool {
+func NewTool(annaHome, homeDir, agentRoot, cwd, userSkillsDir string, runtime pkgplugins.ToolRuntime) *Tool {
 	return &Tool{
 		homeDir:       homeDir,
 		annaHome:      annaHome,
-		workspace:     workspace,
+		agentRoot:     agentRoot,
 		cwd:           cwd,
 		userSkillsDir: userSkillsDir,
 		runtime:       runtime,
@@ -79,7 +79,7 @@ func (t *Tool) skillsDir() string {
 	if t.userSkillsDir != "" {
 		return t.userSkillsDir
 	}
-	return filepath.Join(t.workspace, "skills")
+	return filepath.Join(t.agentRoot, "skills")
 }
 
 func pkgskillsToolDefinition() tools.Definition {
@@ -182,9 +182,8 @@ type installedSkill struct {
 func (t *Tool) list(ctx context.Context) (string, error) {
 	all := LoadSkills(ctx, LoadSkillsConfig{
 		Runtime:       t.runtime,
-		HomeDir:       t.homeDir,
 		AnnaHome:      t.annaHome,
-		Workspace:     t.workspace,
+		AgentRoot:     t.agentRoot,
 		Cwd:           t.cwd,
 		UserSkillsDir: t.userSkillsDir,
 	})
@@ -216,9 +215,8 @@ func (t *Tool) load(ctx context.Context, args map[string]any) (string, error) {
 
 	all := LoadSkills(ctx, LoadSkillsConfig{
 		Runtime:       t.runtime,
-		HomeDir:       t.homeDir,
 		AnnaHome:      t.annaHome,
-		Workspace:     t.workspace,
+		AgentRoot:     t.agentRoot,
 		Cwd:           t.cwd,
 		UserSkillsDir: t.userSkillsDir,
 	})

--- a/plugins/tools/skills/tool.go
+++ b/plugins/tools/skills/tool.go
@@ -59,16 +59,18 @@ type Tool struct {
 	homeDir       string
 	annaHome      string
 	agentRoot     string
+	projectRoot   string
 	cwd           string
 	userSkillsDir string
 	runtime       pkgplugins.ToolRuntime
 }
 
-func NewTool(annaHome, homeDir, agentRoot, cwd, userSkillsDir string, runtime pkgplugins.ToolRuntime) *Tool {
+func NewTool(annaHome, homeDir, agentRoot, projectRoot, cwd, userSkillsDir string, runtime pkgplugins.ToolRuntime) *Tool {
 	return &Tool{
 		homeDir:       homeDir,
 		annaHome:      annaHome,
 		agentRoot:     agentRoot,
+		projectRoot:   projectRoot,
 		cwd:           cwd,
 		userSkillsDir: userSkillsDir,
 		runtime:       runtime,
@@ -184,7 +186,7 @@ func (t *Tool) list(ctx context.Context) (string, error) {
 		Runtime:       t.runtime,
 		AnnaHome:      t.annaHome,
 		AgentRoot:     t.agentRoot,
-		Cwd:           t.cwd,
+		ProjectRoot:   projectRootFromContext(ctx, t.projectRoot),
 		UserSkillsDir: t.userSkillsDir,
 	})
 	if len(all) == 0 {
@@ -217,7 +219,7 @@ func (t *Tool) load(ctx context.Context, args map[string]any) (string, error) {
 		Runtime:       t.runtime,
 		AnnaHome:      t.annaHome,
 		AgentRoot:     t.agentRoot,
-		Cwd:           t.cwd,
+		ProjectRoot:   projectRootFromContext(ctx, t.projectRoot),
 		UserSkillsDir: t.userSkillsDir,
 	})
 	for _, s := range all {

--- a/plugins/tools/skills/tool_test.go
+++ b/plugins/tools/skills/tool_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestDefinition(t *testing.T) {
-	tool := NewTool("/tmp/anna", "", "/tmp/agents", "/tmp/cwd", "", nil)
+	tool := NewTool("/tmp/anna", "", "/tmp/agents", "", "/tmp/cwd", "", nil)
 	def := tool.Definition()
 
 	if def.Name != "skills" {
@@ -25,7 +25,7 @@ func TestDefinition(t *testing.T) {
 }
 
 func TestExecuteUnknownAction(t *testing.T) {
-	tool := NewTool("/tmp/anna", "", "/tmp/agents", "/tmp/cwd", "", nil)
+	tool := NewTool("/tmp/anna", "", "/tmp/agents", "", "/tmp/cwd", "", nil)
 	_, err := tool.Execute(context.Background(), map[string]any{"action": "bogus"})
 	if err == nil {
 		t.Error("expected error for unknown action")
@@ -33,7 +33,7 @@ func TestExecuteUnknownAction(t *testing.T) {
 }
 
 func TestExecuteDispatch(t *testing.T) {
-	tool := NewTool("/tmp/anna", "", "/tmp/agents", "/tmp/cwd", "", nil)
+	tool := NewTool("/tmp/anna", "", "/tmp/agents", "", "/tmp/cwd", "", nil)
 	_, err := tool.Execute(context.Background(), map[string]any{"action": "search"})
 	if err == nil {
 		t.Error("expected error for search without query")
@@ -63,7 +63,7 @@ description: A test skill
 		t.Fatal(err)
 	}
 
-	tool := NewTool("/tmp/anna", "", filepath.Join(dir, ".agents"), dir, "", nil)
+	tool := NewTool("/tmp/anna", "", filepath.Join(dir, ".agents"), dir, dir, "", nil)
 	result, err := tool.list(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -95,7 +95,7 @@ func TestRemoveNotFound(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tool := NewTool("/tmp/anna", "", filepath.Join(dir, ".agents"), dir, "", nil)
+	tool := NewTool("/tmp/anna", "", filepath.Join(dir, ".agents"), dir, dir, "", nil)
 	_, err := tool.remove(context.Background(), map[string]any{"name": "nonexistent"})
 	if err == nil {
 		t.Error("expected error for nonexistent skill")
@@ -103,7 +103,7 @@ func TestRemoveNotFound(t *testing.T) {
 }
 
 func TestRemoveMissingName(t *testing.T) {
-	tool := NewTool("/tmp/anna", "", "/tmp/agents", "/tmp/cwd", "", nil)
+	tool := NewTool("/tmp/anna", "", "/tmp/agents", "", "/tmp/cwd", "", nil)
 	_, err := tool.remove(context.Background(), map[string]any{})
 	if err == nil {
 		t.Error("expected error for missing name")
@@ -111,7 +111,7 @@ func TestRemoveMissingName(t *testing.T) {
 }
 
 func TestRemoveInvalidName(t *testing.T) {
-	tool := NewTool("/tmp/anna", "", "/tmp/agents", "/tmp/cwd", "", nil)
+	tool := NewTool("/tmp/anna", "", "/tmp/agents", "", "/tmp/cwd", "", nil)
 	_, err := tool.remove(context.Background(), map[string]any{"name": "../../../etc"})
 	if err == nil {
 		t.Error("expected error for path traversal name")
@@ -128,7 +128,7 @@ func TestRemoveSuccess(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tool := NewTool("/tmp/anna", "", filepath.Join(dir, ".agents"), dir, "", nil)
+	tool := NewTool("/tmp/anna", "", filepath.Join(dir, ".agents"), dir, dir, "", nil)
 	result, err := tool.remove(context.Background(), map[string]any{"name": "my-skill"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -142,7 +142,7 @@ func TestRemoveSuccess(t *testing.T) {
 }
 
 func TestSearchMissingQuery(t *testing.T) {
-	tool := NewTool("/tmp/anna", "", "/tmp/agents", "/tmp/cwd", "", nil)
+	tool := NewTool("/tmp/anna", "", "/tmp/agents", "", "/tmp/cwd", "", nil)
 	_, err := tool.search(context.Background(), map[string]any{})
 	if err == nil {
 		t.Error("expected error for missing query")
@@ -150,7 +150,7 @@ func TestSearchMissingQuery(t *testing.T) {
 }
 
 func TestInstallMissingSource(t *testing.T) {
-	tool := NewTool("/tmp/anna", "", "/tmp/agents", "/tmp/cwd", "", nil)
+	tool := NewTool("/tmp/anna", "", "/tmp/agents", "", "/tmp/cwd", "", nil)
 	_, err := tool.install(context.Background(), map[string]any{})
 	if err == nil {
 		t.Error("expected error for missing source")
@@ -178,7 +178,7 @@ description: Test
 		t.Fatal(err)
 	}
 
-	tool := NewTool("/tmp/anna", "", workspace, projectDir, "", nil)
+	tool := NewTool("/tmp/anna", "", workspace, projectDir, projectDir, "", nil)
 	result, err := tool.install(context.Background(), map[string]any{"source": srcDir})
 	if err != nil {
 		t.Fatalf("install error: %v", err)
@@ -204,7 +204,7 @@ func TestLoadSkill(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tool := NewTool("/tmp/anna", "", filepath.Join(dir, ".agents"), dir, "", nil)
+	tool := NewTool("/tmp/anna", "", filepath.Join(dir, ".agents"), dir, dir, "", nil)
 
 	t.Run("loads existing skill", func(t *testing.T) {
 		result, err := tool.load(context.Background(), map[string]any{"name": "test-skill"})
@@ -247,7 +247,7 @@ func TestRemoveSingleCharName(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tool := NewTool("/tmp/anna", "", filepath.Join(dir, ".agents"), dir, "", nil)
+	tool := NewTool("/tmp/anna", "", filepath.Join(dir, ".agents"), dir, dir, "", nil)
 	_, err := tool.remove(context.Background(), map[string]any{"name": "x"})
 	if err != nil {
 		t.Fatalf("unexpected error removing single-char skill: %v", err)
@@ -280,7 +280,7 @@ description: User skill
 		t.Fatal(err)
 	}
 
-	tool := NewTool("/tmp/anna", "", agentWS, "", userSkillsDir, nil)
+	tool := NewTool("/tmp/anna", "", agentWS, "", "", userSkillsDir, nil)
 	result, err := tool.install(context.Background(), map[string]any{"source": srcDir})
 	if err != nil {
 		t.Fatalf("install error: %v", err)
@@ -334,7 +334,7 @@ description: User-specific skill
 		t.Fatal(err)
 	}
 
-	tool := NewTool("/tmp/anna", "", agentWS, "", filepath.Join(agentWS, "users", "42", ".agents", "skills"), nil)
+	tool := NewTool("/tmp/anna", "", agentWS, "", "", filepath.Join(agentWS, "users", "42", ".agents", "skills"), nil)
 	result, err := tool.list(context.Background())
 	if err != nil {
 		t.Fatalf("list error: %v", err)
@@ -354,7 +354,7 @@ func TestAgentLevelToolBackwardCompat(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tool := NewTool("/tmp/anna", "", agentWS, "", "", nil)
+	tool := NewTool("/tmp/anna", "", agentWS, "", "", "", nil)
 	got := tool.skillsDir()
 	want := filepath.Join(agentWS, "skills")
 	if got != want {
@@ -366,7 +366,7 @@ func TestPerUserToolSkillsDir(t *testing.T) {
 	base := t.TempDir()
 	agentWS := filepath.Join(base, "workspaces", "agent-1")
 
-	tool := NewTool("/tmp/anna", "", agentWS, "", filepath.Join(agentWS, "users", "7", ".agents", "skills"), nil)
+	tool := NewTool("/tmp/anna", "", agentWS, "", "", filepath.Join(agentWS, "users", "7", ".agents", "skills"), nil)
 	got := tool.skillsDir()
 	want := filepath.Join(agentWS, "users", "7", ".agents", "skills")
 	if got != want {


### PR DESCRIPTION
## Summary
- require user-scoped runner execution and derive sandbox root/HOME from the user root
- rename runner-facing path concepts from workspace/user data dir to agent root/user root
- update prompt, plugin, and test wiring to use the simplified two-root model

## Testing
- mise run format
- mise run test

## Notes
- This keeps persisted config fields like `Workspace` unchanged for now, but converts them at the runner boundary into the final execution names: `AgentRoot` and `UserRoot`.
