### PR TITLE
♻️ refactor: simplify sandbox path model

### DIFF
--- a/internal/agent/runner/gorunner.go
+++ b/internal/agent/runner/gorunner.go
@@ -84,6 +84,9 @@ func NewGoRunner(ctx context.Context, cfg GoRunnerConfig) (*GoRunner, error) {
 	if cfg.UserRoot == "" {
 		return nil, fmt.Errorf("go runner: user_root is required")
 	}
+	if _, err := resolveSandboxPaths(cfg); err != nil {
+		return nil, fmt.Errorf("go runner: %w", err)
+	}
 
 	paths := resolveRunnerPaths(cfg)
 
@@ -215,12 +218,13 @@ func buildToolRegistry(ctx context.Context, cfg GoRunnerConfig, session *runnerS
 	// sandbox session.
 
 	// Runtime capabilities are injected from the active runner session.
+	homeDir, _ := os.UserHomeDir()
 	bc := plugintools.BuildContext{
 		WorkDir:     paths.WorkDir,
 		ProjectRoot: "",
 		UserRoot:    paths.UserRoot,
 		AnnaHome:    paths.AnnaHome,
-		HomeDir:     paths.UserHome,
+		HomeDir:     homeDir,
 		AgentRoot:   paths.AgentRoot,
 		ToolsBinDir: paths.toolsBinDir(),
 		Runtime:     cfg.ToolRuntime,
@@ -285,9 +289,8 @@ func prepareSandbox(ctx context.Context, cfg GoRunnerConfig) error {
 		return nil
 	}
 	if err := boxshsandbox.Preflight(ctx, boxshsandbox.PreflightConfig{
-		AnnaHome:    paths.AnnaHome,
-		Workspace:   paths.AgentRoot,
-		UserDataDir: paths.UserRoot,
+		AnnaHome: paths.AnnaHome,
+		UserRoot: paths.UserRoot,
 		Network: boxshsandbox.NetworkConfig{
 			Mode:      cfg.Sandbox.Network.Mode,
 			Allowlist: cfg.Sandbox.Network.Allowlist,

--- a/internal/agent/runner/gorunner.go
+++ b/internal/agent/runner/gorunner.go
@@ -218,13 +218,11 @@ func buildToolRegistry(ctx context.Context, cfg GoRunnerConfig, session *runnerS
 	// sandbox session.
 
 	// Runtime capabilities are injected from the active runner session.
-	homeDir, _ := os.UserHomeDir()
 	bc := plugintools.BuildContext{
 		WorkDir:     paths.WorkDir,
 		ProjectRoot: "",
 		UserRoot:    paths.UserRoot,
 		AnnaHome:    paths.AnnaHome,
-		HomeDir:     homeDir,
 		AgentRoot:   paths.AgentRoot,
 		ToolsBinDir: paths.toolsBinDir(),
 		Runtime:     cfg.ToolRuntime,

--- a/internal/agent/runner/gorunner_test.go
+++ b/internal/agent/runner/gorunner_test.go
@@ -468,13 +468,14 @@ func TestChatToolUseLoop(t *testing.T) {
 		},
 	}
 
-	r, err := NewGoRunner(context.Background(), withTestRunnerPaths(t, GoRunnerConfig{
+	cfg := withTestRunnerPaths(t, GoRunnerConfig{
 		API:       fp.api,
 		Model:     "test-model",
 		APIKey:    "test-key",
-		WorkDir:   dir,
 		Providers: testProviderRegistryBuilder,
-	}))
+	})
+	cfg.WorkDir = filepath.Join(cfg.UserRoot, filepath.Base(dir))
+	r, err := NewGoRunner(context.Background(), cfg)
 	if err != nil {
 		t.Fatalf("NewGoRunner: %v", err)
 	}

--- a/internal/agent/runner/paths.go
+++ b/internal/agent/runner/paths.go
@@ -78,16 +78,6 @@ func (p runnerPaths) builtinSkillsDir() string {
 	return filepath.Join(p.AnnaHome, "cache", "builtin-skills")
 }
 
-// sandboxRoot returns the directory mounted as the sandbox root.
-// Runner execution is always user-scoped, so this is always UserRoot.
-func sandboxRoot(cfg GoRunnerConfig) string {
-	paths, err := resolveSandboxPaths(cfg)
-	if err != nil {
-		return ""
-	}
-	return paths.UserRoot
-}
-
 // sandboxProcessEnv builds the baseline process environment injected into
 // sandboxed commands. Today it pins HOME to the sandbox-visible writable area
 // and propagates ANNA_HOME so CLIs don't accidentally target the host home.

--- a/internal/agent/runner/paths.go
+++ b/internal/agent/runner/paths.go
@@ -1,8 +1,9 @@
 package runner
 
 import (
-	"os"
+	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/vaayne/anna/internal/config"
 	"github.com/vaayne/anna/internal/embedded"
@@ -12,34 +13,64 @@ import (
 // Everything else used by the runner is derived from these values.
 type runnerPaths struct {
 	AnnaHome  string
-	UserHome  string
 	AgentRoot string
 	UserRoot  string
 	WorkDir   string
+}
+
+// sandboxPaths is the minimal path set sandbox policy creation depends on.
+// Sandbox execution is defined entirely by the user-scoped writable root and a
+// working directory constrained to that root.
+type sandboxPaths struct {
+	AnnaHome string
+	UserRoot string
+	WorkDir  string
 }
 
 // resolveRunnerPaths converts GoRunnerConfig into the minimal path set the
 // runner actually owns. Derived paths stay as methods/helpers instead of being
 // stored as extra fields.
 func resolveRunnerPaths(cfg GoRunnerConfig) runnerPaths {
+	paths, _ := resolveSandboxPaths(cfg)
+	return runnerPaths{
+		AnnaHome:  paths.AnnaHome,
+		AgentRoot: cfg.AgentRoot,
+		UserRoot:  paths.UserRoot,
+		WorkDir:   paths.WorkDir,
+	}
+}
+
+func resolveSandboxPaths(cfg GoRunnerConfig) (sandboxPaths, error) {
 	annaHome := cfg.AnnaHome
 	if annaHome == "" {
 		annaHome = config.AnnaHome()
 	}
+	if cfg.UserRoot == "" {
+		return sandboxPaths{}, fmt.Errorf("user_root is required")
+	}
 
-	userHome, _ := os.UserHomeDir()
+	userRoot, err := filepath.Abs(cfg.UserRoot)
+	if err != nil {
+		return sandboxPaths{}, fmt.Errorf("resolve user_root: %w", err)
+	}
 	workDir := cfg.WorkDir
 	if workDir == "" {
-		workDir = cfg.UserRoot
+		workDir = userRoot
+	}
+	if !filepath.IsAbs(workDir) {
+		workDir = filepath.Join(userRoot, workDir)
+	}
+	workDir = filepath.Clean(workDir)
+
+	if !isWithinPathRoot(userRoot, workDir) {
+		return sandboxPaths{}, fmt.Errorf("work_dir %q must stay within user_root %q", workDir, userRoot)
 	}
 
-	return runnerPaths{
-		AnnaHome:  annaHome,
-		UserHome:  userHome,
-		AgentRoot: cfg.AgentRoot,
-		WorkDir:   workDir,
-		UserRoot:  cfg.UserRoot,
-	}
+	return sandboxPaths{
+		AnnaHome: annaHome,
+		UserRoot: userRoot,
+		WorkDir:  workDir,
+	}, nil
 }
 
 func (p runnerPaths) toolsBinDir() string { return embedded.BinDir(p.AnnaHome) }
@@ -50,13 +81,17 @@ func (p runnerPaths) builtinSkillsDir() string {
 // sandboxRoot returns the directory mounted as the sandbox root.
 // Runner execution is always user-scoped, so this is always UserRoot.
 func sandboxRoot(cfg GoRunnerConfig) string {
-	return resolveRunnerPaths(cfg).UserRoot
+	paths, err := resolveSandboxPaths(cfg)
+	if err != nil {
+		return ""
+	}
+	return paths.UserRoot
 }
 
 // sandboxProcessEnv builds the baseline process environment injected into
 // sandboxed commands. Today it pins HOME to the sandbox-visible writable area
 // and propagates ANNA_HOME so CLIs don't accidentally target the host home.
-func sandboxProcessEnv(paths runnerPaths) map[string]string {
+func sandboxProcessEnv(paths sandboxPaths) map[string]string {
 	env := map[string]string{}
 	if paths.UserRoot != "" {
 		env["HOME"] = paths.UserRoot
@@ -65,4 +100,12 @@ func sandboxProcessEnv(paths runnerPaths) map[string]string {
 		env["ANNA_HOME"] = paths.AnnaHome
 	}
 	return env
+}
+
+func isWithinPathRoot(root, path string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }

--- a/internal/agent/runner/sandbox_backend.go
+++ b/internal/agent/runner/sandbox_backend.go
@@ -93,19 +93,24 @@ var sessionRegistry = map[string]sessionFactory{
 
 var platformSupportsBoxsh = boxshclient.PlatformSupportsBoxsh
 
+func runnerFilesystemPolicy(paths sandboxPaths, readOnlyPaths []string) sandbox.FilesystemPolicy {
+	return sandbox.FilesystemPolicy{
+		WorkspaceRoot: paths.UserRoot,
+		WorkingDir:    paths.WorkDir,
+		ReadOnlyPaths: readOnlyPaths,
+		AllowEscapes:  false,
+	}
+}
+
 func createLocalSession(_ context.Context, cfg GoRunnerConfig) (*runnerSession, error) {
 	paths, err := resolveSandboxPaths(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("resolve sandbox paths: %w", err)
 	}
 	policy := sandbox.Policy{
-		Backend: config.SandboxBackendLocal,
-		Relaxed: true,
-		Filesystem: sandbox.FilesystemPolicy{
-			WorkspaceRoot: paths.UserRoot,
-			WorkingDir:    paths.WorkDir,
-			AllowEscapes:  false,
-		},
+		Backend:    config.SandboxBackendLocal,
+		Relaxed:    true,
+		Filesystem: runnerFilesystemPolicy(paths, nil),
 		Network: sandbox.NetworkPolicy{
 			Mode: sandbox.NetworkAllowAll,
 		},
@@ -148,14 +153,9 @@ func createBoxshSession(ctx context.Context, cfg GoRunnerConfig) (*runnerSession
 	readOnlyDirs = append(readOnlyDirs, runnerPaths.builtinSkillsDir())
 
 	policy := sandbox.Policy{
-		Backend: config.SandboxBackendBoxsh,
-		Relaxed: false,
-		Filesystem: sandbox.FilesystemPolicy{
-			WorkspaceRoot: paths.UserRoot,
-			WorkingDir:    paths.WorkDir,
-			ReadOnlyPaths: readOnlyDirs,
-			AllowEscapes:  false,
-		},
+		Backend:    config.SandboxBackendBoxsh,
+		Relaxed:    false,
+		Filesystem: runnerFilesystemPolicy(paths, readOnlyDirs),
 		Network: sandbox.NetworkPolicy{
 			Mode:      sandbox.NetworkMode(cfg.Sandbox.Network.Mode),
 			Allowlist: cfg.Sandbox.Network.Allowlist,

--- a/internal/agent/runner/sandbox_backend.go
+++ b/internal/agent/runner/sandbox_backend.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"runtime"
 
 	"github.com/vaayne/anna/internal/config"
@@ -95,7 +94,10 @@ var sessionRegistry = map[string]sessionFactory{
 var platformSupportsBoxsh = boxshclient.PlatformSupportsBoxsh
 
 func createLocalSession(_ context.Context, cfg GoRunnerConfig) (*runnerSession, error) {
-	paths := resolveRunnerPaths(cfg)
+	paths, err := resolveSandboxPaths(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("resolve sandbox paths: %w", err)
+	}
 	policy := sandbox.Policy{
 		Backend: config.SandboxBackendLocal,
 		Relaxed: true,
@@ -134,18 +136,16 @@ func createBoxshSession(ctx context.Context, cfg GoRunnerConfig) (*runnerSession
 		return nil, fmt.Errorf("sandbox backend %q is not supported on %s", config.SandboxBackendBoxsh, runtime.GOOS)
 	}
 
-	paths := resolveRunnerPaths(cfg)
+	runnerPaths := resolveRunnerPaths(cfg)
+	paths, err := resolveSandboxPaths(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("resolve sandbox paths: %w", err)
+	}
 	readOnlyDirs := collectSandboxReadOnlyDirs(
-		paths.toolsBinDir(),
+		runnerPaths.toolsBinDir(),
 		os.Getenv("PATH"),
 	)
-	if home, err := os.UserHomeDir(); err == nil && home != "" {
-		readOnlyDirs = append(readOnlyDirs,
-			filepath.Join(home, ".agents", "skills"),
-			filepath.Join(home, ".agents", "agents"),
-		)
-	}
-	readOnlyDirs = append(readOnlyDirs, paths.builtinSkillsDir())
+	readOnlyDirs = append(readOnlyDirs, runnerPaths.builtinSkillsDir())
 
 	policy := sandbox.Policy{
 		Backend: config.SandboxBackendBoxsh,
@@ -171,7 +171,7 @@ func createBoxshSession(ctx context.Context, cfg GoRunnerConfig) (*runnerSession
 		return nil, fmt.Errorf("boxsh factory not available")
 	}
 
-	session, err := createSessionWithAnnaHome(ctx, factory, policy, paths.AnnaHome)
+	session, err := factory.CreateSession(ctx, policy)
 	if err != nil {
 		return nil, fmt.Errorf("create boxsh session: %w", err)
 	}
@@ -180,33 +180,6 @@ func createBoxshSession(ctx context.Context, cfg GoRunnerConfig) (*runnerSession
 		session: session,
 		policy:  policy,
 	}, nil
-}
-
-var annaHomeEnvMu = struct{ ch chan struct{} }{ch: make(chan struct{}, 1)}
-
-func createSessionWithAnnaHome(ctx context.Context, factory sandbox.Factory, policy sandbox.Policy, annaHome string) (sandbox.Session, error) {
-	if annaHome == "" {
-		return factory.CreateSession(ctx, policy)
-	}
-
-	annaHomeEnvMu.ch <- struct{}{}
-	defer func() { <-annaHomeEnvMu.ch }()
-
-	previous, hadPrevious := os.LookupEnv("ANNA_HOME")
-	if err := os.Setenv("ANNA_HOME", annaHome); err != nil {
-		return nil, err
-	}
-	config.ResetAnnaHome()
-	defer func() {
-		if hadPrevious {
-			_ = os.Setenv("ANNA_HOME", previous)
-		} else {
-			_ = os.Unsetenv("ANNA_HOME")
-		}
-		config.ResetAnnaHome()
-	}()
-
-	return factory.CreateSession(ctx, policy)
 }
 
 // resolveSession creates a runnerSession from configuration.

--- a/internal/agent/runner/sandbox_backend_test.go
+++ b/internal/agent/runner/sandbox_backend_test.go
@@ -60,17 +60,6 @@ func TestResolveSessionExplicitBoxshRejectsUnsupportedPlatform(t *testing.T) {
 	}
 }
 
-func TestSandboxRootUsesUserRoot(t *testing.T) {
-	cfg := GoRunnerConfig{
-		AgentRoot: "/workspace/agent",
-		UserRoot:  "/workspace/agent/users/1/data",
-	}
-
-	if got := sandboxRoot(cfg); got != cfg.UserRoot {
-		t.Fatalf("sandboxRoot() = %q, want %q", got, cfg.UserRoot)
-	}
-}
-
 func TestResolveRunnerPathsDefaultsWorkDirToUserRoot(t *testing.T) {
 	cfg := GoRunnerConfig{
 		AgentRoot: "/workspace/agent",
@@ -109,7 +98,7 @@ func TestResolveSandboxPathsRejectsWorkDirOutsideUserRoot(t *testing.T) {
 	}
 }
 
-func TestSandboxProcessEnvUsesSandboxRootAsHome(t *testing.T) {
+func TestSandboxProcessEnvUsesUserRootAsHome(t *testing.T) {
 	cfg := GoRunnerConfig{
 		AnnaHome:  "/anna",
 		AgentRoot: "/workspace/agent",
@@ -126,23 +115,6 @@ func TestSandboxProcessEnvUsesSandboxRootAsHome(t *testing.T) {
 	}
 	if got := env["ANNA_HOME"]; got != cfg.AnnaHome {
 		t.Fatalf("ANNA_HOME = %q, want %q", got, cfg.AnnaHome)
-	}
-}
-
-func TestSandboxProcessEnvUsesUserRootAsHome(t *testing.T) {
-	cfg := GoRunnerConfig{
-		AnnaHome:  "/anna",
-		AgentRoot: "/workspace/agent",
-		UserRoot:  "/workspace/agent/users/1/data",
-	}
-
-	paths, err := resolveSandboxPaths(cfg)
-	if err != nil {
-		t.Fatalf("resolveSandboxPaths: %v", err)
-	}
-	env := sandboxProcessEnv(paths)
-	if got := env["HOME"]; got != cfg.UserRoot {
-		t.Fatalf("HOME = %q, want %q", got, cfg.UserRoot)
 	}
 }
 

--- a/internal/agent/runner/sandbox_backend_test.go
+++ b/internal/agent/runner/sandbox_backend_test.go
@@ -83,6 +83,32 @@ func TestResolveRunnerPathsDefaultsWorkDirToUserRoot(t *testing.T) {
 	}
 }
 
+func TestResolveSandboxPathsJoinsRelativeWorkDirToUserRoot(t *testing.T) {
+	cfg := GoRunnerConfig{
+		AnnaHome: "/anna",
+		UserRoot: "/workspace/agent/users/1/data",
+		WorkDir:  "logs",
+	}
+
+	paths, err := resolveSandboxPaths(cfg)
+	if err != nil {
+		t.Fatalf("resolveSandboxPaths: %v", err)
+	}
+	if want := "/workspace/agent/users/1/data/logs"; paths.WorkDir != want {
+		t.Fatalf("WorkDir = %q, want %q", paths.WorkDir, want)
+	}
+}
+
+func TestResolveSandboxPathsRejectsWorkDirOutsideUserRoot(t *testing.T) {
+	_, err := resolveSandboxPaths(GoRunnerConfig{
+		UserRoot: "/workspace/agent/users/1/data",
+		WorkDir:  "/workspace/agent",
+	})
+	if err == nil {
+		t.Fatal("expected error for workdir outside user root")
+	}
+}
+
 func TestSandboxProcessEnvUsesSandboxRootAsHome(t *testing.T) {
 	cfg := GoRunnerConfig{
 		AnnaHome:  "/anna",
@@ -90,7 +116,11 @@ func TestSandboxProcessEnvUsesSandboxRootAsHome(t *testing.T) {
 		UserRoot:  "/workspace/agent/users/1/data",
 	}
 
-	env := sandboxProcessEnv(resolveRunnerPaths(cfg))
+	paths, err := resolveSandboxPaths(cfg)
+	if err != nil {
+		t.Fatalf("resolveSandboxPaths: %v", err)
+	}
+	env := sandboxProcessEnv(paths)
 	if got := env["HOME"]; got != cfg.UserRoot {
 		t.Fatalf("HOME = %q, want %q", got, cfg.UserRoot)
 	}
@@ -106,7 +136,11 @@ func TestSandboxProcessEnvUsesUserRootAsHome(t *testing.T) {
 		UserRoot:  "/workspace/agent/users/1/data",
 	}
 
-	env := sandboxProcessEnv(resolveRunnerPaths(cfg))
+	paths, err := resolveSandboxPaths(cfg)
+	if err != nil {
+		t.Fatalf("resolveSandboxPaths: %v", err)
+	}
+	env := sandboxProcessEnv(paths)
 	if got := env["HOME"]; got != cfg.UserRoot {
 		t.Fatalf("HOME = %q, want %q", got, cfg.UserRoot)
 	}

--- a/internal/pluginhost/builders.go
+++ b/internal/pluginhost/builders.go
@@ -34,12 +34,10 @@ func (h *Host) BuildEnabledTools(ctx context.Context, bc plugintools.BuildContex
 		}
 		t, err := reg.Build(pkgplugins.ToolContext{
 			Platform:    h.platform(reg.PluginID),
-			State:       state,
 			WorkDir:     bc.WorkDir,
 			ProjectRoot: bc.ProjectRoot,
 			UserRoot:    bc.UserRoot,
 			AnnaHome:    bc.AnnaHome,
-			HomeDir:     bc.HomeDir,
 			AgentRoot:   bc.AgentRoot,
 			ToolsBinDir: bc.ToolsBinDir,
 			Runtime:     bc.Runtime,

--- a/pkg/plugins/context.go
+++ b/pkg/plugins/context.go
@@ -10,14 +10,22 @@ import (
 )
 
 // ToolContext is the narrow build context for tool capabilities.
+// Execution paths are UserRoot + WorkDir. Discovery/config paths are AnnaHome,
+// AgentRoot, ProjectRoot, and the host HomeDir.
 type ToolContext struct {
-	Platform    Platform
-	State       PluginState
-	WorkDir     string
+	Platform Platform
+	State    PluginState
+	// WorkDir is the runtime working directory for tool execution. It is inside UserRoot.
+	WorkDir string
+	// ProjectRoot is optional project-scoped discovery context for local/project-attached runs.
 	ProjectRoot string
-	UserRoot    string
-	AnnaHome    string
-	HomeDir     string
+	// UserRoot is the runtime writable root and sandbox HOME for tool execution.
+	UserRoot string
+	// AnnaHome is the app/runtime home used for builtin assets and shared state.
+	AnnaHome string
+	// HomeDir is the host user's home directory for config/discovery, not sandbox HOME.
+	HomeDir string
+	// AgentRoot is the agent-scoped discovery root, not the sandbox writable root.
 	AgentRoot   string
 	ToolsBinDir string
 	Runtime     ToolRuntime
@@ -73,6 +81,7 @@ type PromptInventoryContext struct {
 }
 
 // SystemPromptContext is the shared build context for prompt contributions.
+// HomeDir is host-scoped discovery context; UserRoot is the runtime writable root.
 type SystemPromptContext struct {
 	Platform    Platform
 	State       PluginState

--- a/pkg/plugins/context.go
+++ b/pkg/plugins/context.go
@@ -11,10 +11,9 @@ import (
 
 // ToolContext is the narrow build context for tool capabilities.
 // Execution paths are UserRoot + WorkDir. Discovery/config paths are AnnaHome,
-// AgentRoot, ProjectRoot, and the host HomeDir.
+// AgentRoot, and ProjectRoot.
 type ToolContext struct {
 	Platform Platform
-	State    PluginState
 	// WorkDir is the runtime working directory for tool execution. It is inside UserRoot.
 	WorkDir string
 	// ProjectRoot is optional project-scoped discovery context for local/project-attached runs.
@@ -23,8 +22,6 @@ type ToolContext struct {
 	UserRoot string
 	// AnnaHome is the app/runtime home used for builtin assets and shared state.
 	AnnaHome string
-	// HomeDir is the host user's home directory for config/discovery, not sandbox HOME.
-	HomeDir string
 	// AgentRoot is the agent-scoped discovery root, not the sandbox writable root.
 	AgentRoot   string
 	ToolsBinDir string

--- a/plugins/reflect/conversation_review.go
+++ b/plugins/reflect/conversation_review.go
@@ -89,7 +89,7 @@ func (s *Service) newConversationReviewer(snap *pkgplugins.ReflectSnapshot, user
 	return newReviewer(reviewerConfig{
 		Providers:      reg,
 		Model:          model,
-		SkillsTool:     skillstool.NewTool("", "", snap.Workspace, "", "", userSkillsDir(snap.Workspace, userID), nil),
+		SkillsTool:     skillstool.NewTool("", snap.Workspace, "", userSkillsDir(snap.Workspace, userID), nil),
 		MemoryTool:     memory.BuildTool(s.memory, memory.WithActionsOnly("profile_get", "profile_update")),
 		ExistingSkills: loadExistingSkillNames(snap.Workspace, userID),
 	})

--- a/plugins/sandbox/boxsh/boxshclient/backend.go
+++ b/plugins/sandbox/boxsh/boxshclient/backend.go
@@ -30,14 +30,14 @@ type BackendConfig struct {
 	// AnnaHome is the Anna home directory (used for binary resolution).
 	AnnaHome string
 
-	// SandboxRoot is the writable root mounted into the sandbox.
-	SandboxRoot string
+	// UserRoot is the writable root mounted into the sandbox.
+	UserRoot string
 
 	// Sandbox contains the sandbox network configuration.
 	Sandbox NetworkConfig
 
 	// WorkDir is the working directory for tool execution.
-	// This is resolved relative to the sandbox root.
+	// This is resolved relative to the user root.
 	WorkDir string
 
 	// SessionBaseDir is the base directory for ephemeral session directories.
@@ -84,8 +84,8 @@ func (b *SharedBackend) Start(ctx context.Context, cfg BackendConfig) error {
 		return fmt.Errorf("boxshclient: backend already started")
 	}
 
-	// Determine sandbox root (SRC).
-	src := cfg.SandboxRoot
+	// Determine user root (SRC).
+	src := cfg.UserRoot
 
 	// Create an ephemeral overlay root on the same filesystem as SRC.
 	// boxsh's current overlay implementation requires that to avoid cross-device
@@ -210,8 +210,8 @@ func (b *SharedBackend) SessionDir() string {
 	return b.sessionDir
 }
 
-// SandboxRoot returns the source sandbox root (SRC).
-func (b *SharedBackend) SandboxRoot(ctx context.Context) (string, error) {
+// UserRoot returns the sandbox-visible user root for path resolution.
+func (b *SharedBackend) UserRoot(ctx context.Context) (string, error) {
 	b.mu.RLock()
 	client := b.client
 	b.mu.RUnlock()
@@ -220,10 +220,7 @@ func (b *SharedBackend) SandboxRoot(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("boxshclient: backend not started")
 	}
 
-	// The sandbox root is the SRC directory.
-	// We can determine this by stat-ing a known path or returning cached value.
-	// For now, we return the session configuration's Src field via reflection
-	// on the client configuration.
+	_ = ctx
 	return client.sessionConfig.Dst, nil
 }
 

--- a/plugins/sandbox/boxsh/boxshclient/backend.go
+++ b/plugins/sandbox/boxsh/boxshclient/backend.go
@@ -30,11 +30,8 @@ type BackendConfig struct {
 	// AnnaHome is the Anna home directory (used for binary resolution).
 	AnnaHome string
 
-	// Workspace is the agent workspace directory.
-	Workspace string
-
-	// UserDataDir is the per-user data directory (for user sessions).
-	UserDataDir string
+	// SandboxRoot is the writable root mounted into the sandbox.
+	SandboxRoot string
 
 	// Sandbox contains the sandbox network configuration.
 	Sandbox NetworkConfig
@@ -88,7 +85,7 @@ func (b *SharedBackend) Start(ctx context.Context, cfg BackendConfig) error {
 	}
 
 	// Determine sandbox root (SRC).
-	src := DeriveSandboxRoot(cfg.Workspace, cfg.UserDataDir)
+	src := cfg.SandboxRoot
 
 	// Create an ephemeral overlay root on the same filesystem as SRC.
 	// boxsh's current overlay implementation requires that to avoid cross-device
@@ -142,7 +139,6 @@ func (b *SharedBackend) Start(ctx context.Context, cfg BackendConfig) error {
 		"cwd", cwd,
 		"readonly_dir_count", len(uniqueCleanAbsPaths(cfg.ReadOnlyDirs)),
 		"network_mode", sessionCfg.NetworkMode,
-		"user_data_dir", cfg.UserDataDir,
 	)
 	return nil
 }

--- a/plugins/sandbox/boxsh/boxshclient/backend_test.go
+++ b/plugins/sandbox/boxsh/boxshclient/backend_test.go
@@ -23,8 +23,8 @@ func TestNewSharedBackend(t *testing.T) {
 	}
 
 	cfg := BackendConfig{
-		BinaryPath: boxshPath,
-		Workspace:  t.TempDir(),
+		BinaryPath:  boxshPath,
+		SandboxRoot: t.TempDir(),
 	}
 
 	backend, err := NewSharedBackend(cfg)
@@ -42,16 +42,13 @@ func TestNewSharedBackend(t *testing.T) {
 }
 
 func TestNewSharedBackendRequiresPlatformSupport(t *testing.T) {
-	// Save and restore GOOS for this test.
 	if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
-		// Can't test failure on supported platforms without mocking,
-		// so we just verify success path works.
 		return
 	}
 
 	cfg := BackendConfig{
-		BinaryPath: "/usr/local/bin/boxsh",
-		Workspace:  t.TempDir(),
+		BinaryPath:  "/usr/local/bin/boxsh",
+		SandboxRoot: t.TempDir(),
 	}
 
 	_, err := NewSharedBackend(cfg)
@@ -76,8 +73,8 @@ func TestSharedBackendNotAliveBeforeStart(t *testing.T) {
 	}
 
 	cfg := BackendConfig{
-		BinaryPath: boxshPath,
-		Workspace:  t.TempDir(),
+		BinaryPath:  boxshPath,
+		SandboxRoot: t.TempDir(),
 	}
 
 	backend, err := NewSharedBackend(cfg)
@@ -106,8 +103,8 @@ func TestSharedBackendClientReturnsNilBeforeStart(t *testing.T) {
 	}
 
 	cfg := BackendConfig{
-		BinaryPath: boxshPath,
-		Workspace:  t.TempDir(),
+		BinaryPath:  boxshPath,
+		SandboxRoot: t.TempDir(),
 	}
 
 	backend, err := NewSharedBackend(cfg)
@@ -136,8 +133,8 @@ func TestSharedBackendSessionDir(t *testing.T) {
 	}
 
 	cfg := BackendConfig{
-		BinaryPath: boxshPath,
-		Workspace:  t.TempDir(),
+		BinaryPath:  boxshPath,
+		SandboxRoot: t.TempDir(),
 	}
 
 	backend, err := NewSharedBackend(cfg)
@@ -145,7 +142,6 @@ func TestSharedBackendSessionDir(t *testing.T) {
 		t.Fatalf("NewSharedBackend: %v", err)
 	}
 
-	// Before start, session dir should be empty.
 	if dir := backend.SessionDir(); dir != "" {
 		t.Errorf("SessionDir before Start = %q, want empty", dir)
 	}
@@ -157,21 +153,9 @@ func TestIsSharedBackendError(t *testing.T) {
 		err  error
 		want bool
 	}{
-		{
-			name: "nil error",
-			err:  nil,
-			want: false,
-		},
-		{
-			name: "boxshclient error",
-			err:  &mockError{"boxshclient: something went wrong"},
-			want: true,
-		},
-		{
-			name: "other error",
-			err:  &mockError{"something else went wrong"},
-			want: false,
-		},
+		{name: "nil error", err: nil, want: false},
+		{name: "boxshclient error", err: &mockError{"boxshclient: something went wrong"}, want: true},
+		{name: "other error", err: &mockError{"something else went wrong"}, want: false},
 	}
 
 	for _, tt := range tests {
@@ -185,39 +169,9 @@ func TestIsSharedBackendError(t *testing.T) {
 }
 
 func TestBackendConfigSandboxRoot(t *testing.T) {
-	tests := []struct {
-		name        string
-		workspace   string
-		userDataDir string
-		want        string
-	}{
-		{
-			name:        "user session uses UserDataDir",
-			workspace:   "/workspace",
-			userDataDir: "/users/1/data",
-			want:        "/users/1/data",
-		},
-		{
-			name:        "system session uses Workspace",
-			workspace:   "/workspace",
-			userDataDir: "",
-			want:        "/workspace",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cfg := BackendConfig{
-				Workspace:   tt.workspace,
-				UserDataDir: tt.userDataDir,
-			}
-
-			// Verify expected behavior through SessionManager.
-			src := DeriveSandboxRoot(cfg.Workspace, cfg.UserDataDir)
-			if src != tt.want {
-				t.Errorf("SandboxRoot = %q, want %q", src, tt.want)
-			}
-		})
+	cfg := BackendConfig{SandboxRoot: "/users/1/data"}
+	if cfg.SandboxRoot != "/users/1/data" {
+		t.Fatalf("SandboxRoot = %q, want %q", cfg.SandboxRoot, "/users/1/data")
 	}
 }
 

--- a/plugins/sandbox/boxsh/boxshclient/backend_test.go
+++ b/plugins/sandbox/boxsh/boxshclient/backend_test.go
@@ -23,8 +23,8 @@ func TestNewSharedBackend(t *testing.T) {
 	}
 
 	cfg := BackendConfig{
-		BinaryPath:  boxshPath,
-		SandboxRoot: t.TempDir(),
+		BinaryPath: boxshPath,
+		UserRoot:   t.TempDir(),
 	}
 
 	backend, err := NewSharedBackend(cfg)
@@ -47,8 +47,8 @@ func TestNewSharedBackendRequiresPlatformSupport(t *testing.T) {
 	}
 
 	cfg := BackendConfig{
-		BinaryPath:  "/usr/local/bin/boxsh",
-		SandboxRoot: t.TempDir(),
+		BinaryPath: "/usr/local/bin/boxsh",
+		UserRoot:   t.TempDir(),
 	}
 
 	_, err := NewSharedBackend(cfg)
@@ -73,8 +73,8 @@ func TestSharedBackendNotAliveBeforeStart(t *testing.T) {
 	}
 
 	cfg := BackendConfig{
-		BinaryPath:  boxshPath,
-		SandboxRoot: t.TempDir(),
+		BinaryPath: boxshPath,
+		UserRoot:   t.TempDir(),
 	}
 
 	backend, err := NewSharedBackend(cfg)
@@ -103,8 +103,8 @@ func TestSharedBackendClientReturnsNilBeforeStart(t *testing.T) {
 	}
 
 	cfg := BackendConfig{
-		BinaryPath:  boxshPath,
-		SandboxRoot: t.TempDir(),
+		BinaryPath: boxshPath,
+		UserRoot:   t.TempDir(),
 	}
 
 	backend, err := NewSharedBackend(cfg)
@@ -133,8 +133,8 @@ func TestSharedBackendSessionDir(t *testing.T) {
 	}
 
 	cfg := BackendConfig{
-		BinaryPath:  boxshPath,
-		SandboxRoot: t.TempDir(),
+		BinaryPath: boxshPath,
+		UserRoot:   t.TempDir(),
 	}
 
 	backend, err := NewSharedBackend(cfg)
@@ -168,10 +168,10 @@ func TestIsSharedBackendError(t *testing.T) {
 	}
 }
 
-func TestBackendConfigSandboxRoot(t *testing.T) {
-	cfg := BackendConfig{SandboxRoot: "/users/1/data"}
-	if cfg.SandboxRoot != "/users/1/data" {
-		t.Fatalf("SandboxRoot = %q, want %q", cfg.SandboxRoot, "/users/1/data")
+func TestBackendConfigUserRoot(t *testing.T) {
+	cfg := BackendConfig{UserRoot: "/users/1/data"}
+	if cfg.UserRoot != "/users/1/data" {
+		t.Fatalf("UserRoot = %q, want %q", cfg.UserRoot, "/users/1/data")
 	}
 }
 

--- a/plugins/sandbox/boxsh/boxshclient/client.go
+++ b/plugins/sandbox/boxsh/boxshclient/client.go
@@ -521,20 +521,20 @@ func CleanupSessionDir(sessionDir string) error {
 }
 
 // ResolveSandboxCwd determines the working directory inside the sandbox.
-// If workDir is empty or not under the sandbox root, it defaults to the sandbox root.
-func ResolveSandboxCwd(sandboxRoot, workDir string) string {
+// If workDir is empty or not under the user root, it defaults to the user root.
+func ResolveSandboxCwd(userRoot, workDir string) string {
 	if workDir == "" {
-		return sandboxRoot
+		return userRoot
 	}
 
 	candidate := workDir
 	if !filepath.IsAbs(candidate) {
-		candidate = filepath.Join(sandboxRoot, candidate)
+		candidate = filepath.Join(userRoot, candidate)
 	}
 	candidate = filepath.Clean(candidate)
 
-	if !isWithinRoot(sandboxRoot, candidate) {
-		return sandboxRoot
+	if !isWithinRoot(userRoot, candidate) {
+		return userRoot
 	}
 
 	return candidate

--- a/plugins/sandbox/boxsh/boxshclient/client_test.go
+++ b/plugins/sandbox/boxsh/boxshclient/client_test.go
@@ -67,12 +67,12 @@ func TestCreateSessionDirCreatesBaseDir(t *testing.T) {
 
 func TestResolveSandboxCwd(t *testing.T) {
 	tests := []struct {
-		name        string
-		sandboxRoot string
-		workDir     string
-		want        string
+		name     string
+		userRoot string
+		workDir  string
+		want     string
 	}{
-		{"empty workdir uses sandbox root", "/workspace", "", "/workspace"},
+		{"empty workdir uses user root", "/workspace", "", "/workspace"},
 		{"relative workdir resolved against root", "/workspace", "src/project", "/workspace/src/project"},
 		{"absolute workdir under root used as-is", "/workspace", "/workspace/src/project", "/workspace/src/project"},
 		{"hidden child under root stays valid", "/workspace", "/workspace/.hidden", "/workspace/.hidden"},
@@ -81,9 +81,9 @@ func TestResolveSandboxCwd(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ResolveSandboxCwd(tt.sandboxRoot, tt.workDir)
+			got := ResolveSandboxCwd(tt.userRoot, tt.workDir)
 			if got != tt.want {
-				t.Errorf("ResolveSandboxCwd(%q, %q) = %q, want %q", tt.sandboxRoot, tt.workDir, got, tt.want)
+				t.Errorf("ResolveSandboxCwd(%q, %q) = %q, want %q", tt.userRoot, tt.workDir, got, tt.want)
 			}
 		})
 	}

--- a/plugins/sandbox/boxsh/boxshclient/coretools_helpers_test.go
+++ b/plugins/sandbox/boxsh/boxshclient/coretools_helpers_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func testResolveBackendPath(ctx context.Context, backend *SharedBackend, path string) (string, error) {
-	root, err := backend.SandboxRoot(ctx)
+	root, err := backend.UserRoot(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -32,7 +32,7 @@ func testResolveBackendPath(ctx context.Context, backend *SharedBackend, path st
 	if trimmed == "" || len(strings.Split(trimmed, string(filepath.Separator))) <= 2 {
 		return filepath.Join(root, strings.TrimPrefix(path, string(filepath.Separator))), nil
 	}
-	if err := ValidateSandboxPath(root, path); err != nil {
+	if err := ValidatePathWithinRoot(root, path); err != nil {
 		return "", err
 	}
 	return path, nil

--- a/plugins/sandbox/boxsh/boxshclient/integration_cow_test.go
+++ b/plugins/sandbox/boxsh/boxshclient/integration_cow_test.go
@@ -167,8 +167,7 @@ func TestSharedCOWView_AllToolsSeeSameSession(t *testing.T) {
 
 	cfg := BackendConfig{
 		AnnaHome:    annaHome,
-		Workspace:   workspace,
-		UserDataDir: src,
+		SandboxRoot: src,
 		WorkDir:     "/",
 		Sandbox:     NetworkConfig{Mode: NetworkDisabled},
 	}
@@ -250,9 +249,9 @@ func TestSharedCOWView_ClientAndSessionLifecycle(t *testing.T) {
 	writeStatefulMockBoxsh(t, annaHome)
 
 	cfg := BackendConfig{
-		AnnaHome:  annaHome,
-		Workspace: workspace,
-		Sandbox:   NetworkConfig{Mode: NetworkDisabled},
+		AnnaHome:    annaHome,
+		SandboxRoot: workspace,
+		Sandbox:     NetworkConfig{Mode: NetworkDisabled},
 	}
 
 	backend, err := NewSharedBackend(cfg)
@@ -296,9 +295,9 @@ func TestSharedCOWView_MultipleBackendsUseDistinctUpperdirs(t *testing.T) {
 	writeStatefulMockBoxsh(t, annaHome)
 
 	cfg := BackendConfig{
-		AnnaHome:  annaHome,
-		Workspace: workspace,
-		Sandbox:   NetworkConfig{Mode: NetworkDisabled},
+		AnnaHome:    annaHome,
+		SandboxRoot: workspace,
+		Sandbox:     NetworkConfig{Mode: NetworkDisabled},
 	}
 
 	backend1, err := NewSharedBackend(cfg)

--- a/plugins/sandbox/boxsh/boxshclient/integration_cow_test.go
+++ b/plugins/sandbox/boxsh/boxshclient/integration_cow_test.go
@@ -166,10 +166,10 @@ func TestSharedCOWView_AllToolsSeeSameSession(t *testing.T) {
 	writeStatefulMockBoxsh(t, annaHome)
 
 	cfg := BackendConfig{
-		AnnaHome:    annaHome,
-		SandboxRoot: src,
-		WorkDir:     "/",
-		Sandbox:     NetworkConfig{Mode: NetworkDisabled},
+		AnnaHome: annaHome,
+		UserRoot: src,
+		WorkDir:  "/",
+		Sandbox:  NetworkConfig{Mode: NetworkDisabled},
 	}
 
 	backend, err := NewSharedBackend(cfg)
@@ -249,9 +249,9 @@ func TestSharedCOWView_ClientAndSessionLifecycle(t *testing.T) {
 	writeStatefulMockBoxsh(t, annaHome)
 
 	cfg := BackendConfig{
-		AnnaHome:    annaHome,
-		SandboxRoot: workspace,
-		Sandbox:     NetworkConfig{Mode: NetworkDisabled},
+		AnnaHome: annaHome,
+		UserRoot: workspace,
+		Sandbox:  NetworkConfig{Mode: NetworkDisabled},
 	}
 
 	backend, err := NewSharedBackend(cfg)
@@ -295,9 +295,9 @@ func TestSharedCOWView_MultipleBackendsUseDistinctUpperdirs(t *testing.T) {
 	writeStatefulMockBoxsh(t, annaHome)
 
 	cfg := BackendConfig{
-		AnnaHome:    annaHome,
-		SandboxRoot: workspace,
-		Sandbox:     NetworkConfig{Mode: NetworkDisabled},
+		AnnaHome: annaHome,
+		UserRoot: workspace,
+		Sandbox:  NetworkConfig{Mode: NetworkDisabled},
 	}
 
 	backend1, err := NewSharedBackend(cfg)

--- a/plugins/sandbox/boxsh/boxshclient/isolation_test.go
+++ b/plugins/sandbox/boxsh/boxshclient/isolation_test.go
@@ -131,8 +131,7 @@ func TestIsolation_CrossWorkspaceAccessBlocked(t *testing.T) {
 
 	cfg := BackendConfig{
 		AnnaHome:    annaHome,
-		Workspace:   workspace,
-		UserDataDir: allowedRoot,
+		SandboxRoot: allowedRoot,
 		WorkDir:     "/",
 		Sandbox:     NetworkConfig{Mode: NetworkDisabled},
 	}
@@ -183,8 +182,7 @@ func TestIsolation_ParentDirectoryTraversalBlocked(t *testing.T) {
 
 	cfg := BackendConfig{
 		AnnaHome:    annaHome,
-		Workspace:   workspace,
-		UserDataDir: allowedRoot,
+		SandboxRoot: allowedRoot,
 		WorkDir:     "/",
 		Sandbox:     NetworkConfig{Mode: NetworkDisabled},
 	}
@@ -224,8 +222,8 @@ func TestIsolation_DifferentAgentsDifferentSessions(t *testing.T) {
 	}
 	writeIsolationMockBoxsh(t, annaHome)
 
-	cfg1 := BackendConfig{AnnaHome: annaHome, Workspace: workspace1, UserDataDir: userDataDir1, WorkDir: "/", Sandbox: NetworkConfig{Mode: NetworkDisabled}}
-	cfg2 := BackendConfig{AnnaHome: annaHome, Workspace: workspace2, UserDataDir: userDataDir2, WorkDir: "/", Sandbox: NetworkConfig{Mode: NetworkDisabled}}
+	cfg1 := BackendConfig{AnnaHome: annaHome, SandboxRoot: userDataDir1, WorkDir: "/", Sandbox: NetworkConfig{Mode: NetworkDisabled}}
+	cfg2 := BackendConfig{AnnaHome: annaHome, SandboxRoot: userDataDir2, WorkDir: "/", Sandbox: NetworkConfig{Mode: NetworkDisabled}}
 
 	backend1, err := NewSharedBackend(cfg1)
 	if err != nil {

--- a/plugins/sandbox/boxsh/boxshclient/isolation_test.go
+++ b/plugins/sandbox/boxsh/boxshclient/isolation_test.go
@@ -130,10 +130,10 @@ func TestIsolation_CrossWorkspaceAccessBlocked(t *testing.T) {
 	writeIsolationMockBoxsh(t, annaHome)
 
 	cfg := BackendConfig{
-		AnnaHome:    annaHome,
-		SandboxRoot: allowedRoot,
-		WorkDir:     "/",
-		Sandbox:     NetworkConfig{Mode: NetworkDisabled},
+		AnnaHome: annaHome,
+		UserRoot: allowedRoot,
+		WorkDir:  "/",
+		Sandbox:  NetworkConfig{Mode: NetworkDisabled},
 	}
 	backend, err := NewSharedBackend(cfg)
 	if err != nil {
@@ -144,13 +144,13 @@ func TestIsolation_CrossWorkspaceAccessBlocked(t *testing.T) {
 		t.Fatalf("backend.Start: %v", err)
 	}
 
-	if _, err := testRead(ctx, backend, filepath.Join(siblingRoot, "secret.txt"), 1, 0); err == nil || (!strings.Contains(err.Error(), "access denied") && !strings.Contains(err.Error(), "outside sandbox")) {
+	if _, err := testRead(ctx, backend, filepath.Join(siblingRoot, "secret.txt"), 1, 0); err == nil || (!strings.Contains(err.Error(), "access denied") && !strings.Contains(err.Error(), "outside user root")) {
 		t.Fatalf("expected sibling workspace denial, got %v", err)
 	}
-	if _, err := testWrite(ctx, backend, filepath.Join(siblingRoot, "hack.txt"), "nope"); err == nil || (!strings.Contains(err.Error(), "access denied") && !strings.Contains(err.Error(), "outside sandbox")) {
+	if _, err := testWrite(ctx, backend, filepath.Join(siblingRoot, "hack.txt"), "nope"); err == nil || (!strings.Contains(err.Error(), "access denied") && !strings.Contains(err.Error(), "outside user root")) {
 		t.Fatalf("expected sibling workspace write denial, got %v", err)
 	}
-	if _, err := testEdit(ctx, backend, filepath.Join(siblingRoot, "secret.txt"), "a", "b"); err == nil || (!strings.Contains(err.Error(), "access denied") && !strings.Contains(err.Error(), "outside sandbox")) {
+	if _, err := testEdit(ctx, backend, filepath.Join(siblingRoot, "secret.txt"), "a", "b"); err == nil || (!strings.Contains(err.Error(), "access denied") && !strings.Contains(err.Error(), "outside user root")) {
 		t.Fatalf("expected sibling workspace edit denial, got %v", err)
 	}
 	result, err := testExec(ctx, backend, "cat "+filepath.Join(siblingRoot, "secret.txt"), 0)
@@ -181,10 +181,10 @@ func TestIsolation_ParentDirectoryTraversalBlocked(t *testing.T) {
 	writeIsolationMockBoxsh(t, annaHome)
 
 	cfg := BackendConfig{
-		AnnaHome:    annaHome,
-		SandboxRoot: allowedRoot,
-		WorkDir:     "/",
-		Sandbox:     NetworkConfig{Mode: NetworkDisabled},
+		AnnaHome: annaHome,
+		UserRoot: allowedRoot,
+		WorkDir:  "/",
+		Sandbox:  NetworkConfig{Mode: NetworkDisabled},
 	}
 	backend, err := NewSharedBackend(cfg)
 	if err != nil {
@@ -195,10 +195,10 @@ func TestIsolation_ParentDirectoryTraversalBlocked(t *testing.T) {
 		t.Fatalf("backend.Start: %v", err)
 	}
 
-	if _, err := testRead(ctx, backend, "../other-agent/secrets.txt", 1, 0); err == nil || (!strings.Contains(err.Error(), "access denied") && !strings.Contains(err.Error(), "outside sandbox")) {
+	if _, err := testRead(ctx, backend, "../other-agent/secrets.txt", 1, 0); err == nil || (!strings.Contains(err.Error(), "access denied") && !strings.Contains(err.Error(), "outside user root")) {
 		t.Fatalf("expected parent traversal denial, got %v", err)
 	}
-	if _, err := testRead(ctx, backend, filepath.Join(allowedRoot, "..", "..", "secret.txt"), 1, 0); err == nil || (!strings.Contains(err.Error(), "access denied") && !strings.Contains(err.Error(), "outside sandbox")) {
+	if _, err := testRead(ctx, backend, filepath.Join(allowedRoot, "..", "..", "secret.txt"), 1, 0); err == nil || (!strings.Contains(err.Error(), "access denied") && !strings.Contains(err.Error(), "outside user root")) {
 		t.Fatalf("expected absolute traversal denial, got %v", err)
 	}
 }
@@ -222,8 +222,8 @@ func TestIsolation_DifferentAgentsDifferentSessions(t *testing.T) {
 	}
 	writeIsolationMockBoxsh(t, annaHome)
 
-	cfg1 := BackendConfig{AnnaHome: annaHome, SandboxRoot: userDataDir1, WorkDir: "/", Sandbox: NetworkConfig{Mode: NetworkDisabled}}
-	cfg2 := BackendConfig{AnnaHome: annaHome, SandboxRoot: userDataDir2, WorkDir: "/", Sandbox: NetworkConfig{Mode: NetworkDisabled}}
+	cfg1 := BackendConfig{AnnaHome: annaHome, UserRoot: userDataDir1, WorkDir: "/", Sandbox: NetworkConfig{Mode: NetworkDisabled}}
+	cfg2 := BackendConfig{AnnaHome: annaHome, UserRoot: userDataDir2, WorkDir: "/", Sandbox: NetworkConfig{Mode: NetworkDisabled}}
 
 	backend1, err := NewSharedBackend(cfg1)
 	if err != nil {
@@ -251,25 +251,25 @@ func TestIsolation_DifferentAgentsDifferentSessions(t *testing.T) {
 	}
 }
 
-func TestIsolation_ValidateSandboxPath(t *testing.T) {
+func TestIsolation_ValidatePathWithinRoot(t *testing.T) {
 	tests := []struct {
-		name        string
-		sandboxRoot string
-		path        string
-		wantErr     bool
-		errContain  string
+		name       string
+		userRoot   string
+		path       string
+		wantErr    bool
+		errContain string
 	}{
-		{name: "path inside sandbox", sandboxRoot: "/workspace", path: "/workspace/file.txt"},
-		{name: "relative path resolved inside sandbox", sandboxRoot: "/workspace", path: "file.txt"},
-		{name: "path outside sandbox", sandboxRoot: "/workspace", path: "/etc/passwd", wantErr: true, errContain: "outside sandbox"},
-		{name: "parent traversal blocked", sandboxRoot: "/workspace", path: "../etc/passwd", wantErr: true, errContain: "outside sandbox"},
-		{name: "empty sandbox root rejected", sandboxRoot: "", path: "/workspace/file.txt", wantErr: true, errContain: "required"},
-		{name: "relative sandbox root rejected", sandboxRoot: "workspace", path: "/workspace/file.txt", wantErr: true, errContain: "must be absolute"},
+		{name: "path inside sandbox", userRoot: "/workspace", path: "/workspace/file.txt"},
+		{name: "relative path resolved inside sandbox", userRoot: "/workspace", path: "file.txt"},
+		{name: "path outside user root", userRoot: "/workspace", path: "/etc/passwd", wantErr: true, errContain: "outside user root"},
+		{name: "parent traversal blocked", userRoot: "/workspace", path: "../etc/passwd", wantErr: true, errContain: "outside user root"},
+		{name: "empty user root rejected", userRoot: "", path: "/workspace/file.txt", wantErr: true, errContain: "required"},
+		{name: "relative user root rejected", userRoot: "workspace", path: "/workspace/file.txt", wantErr: true, errContain: "must be absolute"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateSandboxPath(tt.sandboxRoot, tt.path)
+			err := ValidatePathWithinRoot(tt.userRoot, tt.path)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error but got nil")

--- a/plugins/sandbox/boxsh/boxshclient/network_policy_test.go
+++ b/plugins/sandbox/boxsh/boxshclient/network_policy_test.go
@@ -147,7 +147,7 @@ func TestNetworkPolicy_DisabledModeBlocksConnections(t *testing.T) {
 	host, port, hits, cleanup := startTCPProbeServer(t)
 	defer cleanup()
 
-	cfg := BackendConfig{AnnaHome: annaHome, Workspace: workspace, WorkDir: "/", Sandbox: NetworkConfig{Mode: NetworkDisabled}}
+	cfg := BackendConfig{AnnaHome: annaHome, SandboxRoot: workspace, WorkDir: "/", Sandbox: NetworkConfig{Mode: NetworkDisabled}}
 	backend, err := NewSharedBackend(cfg)
 	if err != nil {
 		t.Fatalf("NewSharedBackend: %v", err)
@@ -180,7 +180,7 @@ func TestNetworkPolicy_AllowAllModePermitsConnections(t *testing.T) {
 	host, port, hits, cleanup := startTCPProbeServer(t)
 	defer cleanup()
 
-	cfg := BackendConfig{AnnaHome: annaHome, Workspace: workspace, WorkDir: "/", Sandbox: NetworkConfig{Mode: NetworkAllowAll}}
+	cfg := BackendConfig{AnnaHome: annaHome, SandboxRoot: workspace, WorkDir: "/", Sandbox: NetworkConfig{Mode: NetworkAllowAll}}
 	backend, err := NewSharedBackend(cfg)
 	if err != nil {
 		t.Fatalf("NewSharedBackend: %v", err)
@@ -217,7 +217,7 @@ func TestNetworkPolicy_WhitelistModeUnsupported(t *testing.T) {
 	host, _, _, cleanup := startTCPProbeServer(t)
 	defer cleanup()
 
-	cfg := BackendConfig{AnnaHome: annaHome, Workspace: workspace, WorkDir: "/", Sandbox: NetworkConfig{Mode: NetworkWhitelist, Allowlist: []string{host}}}
+	cfg := BackendConfig{AnnaHome: annaHome, SandboxRoot: workspace, WorkDir: "/", Sandbox: NetworkConfig{Mode: NetworkWhitelist, Allowlist: []string{host}}}
 	backend, err := NewSharedBackend(cfg)
 	if err != nil {
 		t.Fatalf("NewSharedBackend: %v", err)

--- a/plugins/sandbox/boxsh/boxshclient/network_policy_test.go
+++ b/plugins/sandbox/boxsh/boxshclient/network_policy_test.go
@@ -147,7 +147,7 @@ func TestNetworkPolicy_DisabledModeBlocksConnections(t *testing.T) {
 	host, port, hits, cleanup := startTCPProbeServer(t)
 	defer cleanup()
 
-	cfg := BackendConfig{AnnaHome: annaHome, SandboxRoot: workspace, WorkDir: "/", Sandbox: NetworkConfig{Mode: NetworkDisabled}}
+	cfg := BackendConfig{AnnaHome: annaHome, UserRoot: workspace, WorkDir: "/", Sandbox: NetworkConfig{Mode: NetworkDisabled}}
 	backend, err := NewSharedBackend(cfg)
 	if err != nil {
 		t.Fatalf("NewSharedBackend: %v", err)
@@ -180,7 +180,7 @@ func TestNetworkPolicy_AllowAllModePermitsConnections(t *testing.T) {
 	host, port, hits, cleanup := startTCPProbeServer(t)
 	defer cleanup()
 
-	cfg := BackendConfig{AnnaHome: annaHome, SandboxRoot: workspace, WorkDir: "/", Sandbox: NetworkConfig{Mode: NetworkAllowAll}}
+	cfg := BackendConfig{AnnaHome: annaHome, UserRoot: workspace, WorkDir: "/", Sandbox: NetworkConfig{Mode: NetworkAllowAll}}
 	backend, err := NewSharedBackend(cfg)
 	if err != nil {
 		t.Fatalf("NewSharedBackend: %v", err)
@@ -217,7 +217,7 @@ func TestNetworkPolicy_WhitelistModeUnsupported(t *testing.T) {
 	host, _, _, cleanup := startTCPProbeServer(t)
 	defer cleanup()
 
-	cfg := BackendConfig{AnnaHome: annaHome, SandboxRoot: workspace, WorkDir: "/", Sandbox: NetworkConfig{Mode: NetworkWhitelist, Allowlist: []string{host}}}
+	cfg := BackendConfig{AnnaHome: annaHome, UserRoot: workspace, WorkDir: "/", Sandbox: NetworkConfig{Mode: NetworkWhitelist, Allowlist: []string{host}}}
 	backend, err := NewSharedBackend(cfg)
 	if err != nil {
 		t.Fatalf("NewSharedBackend: %v", err)

--- a/plugins/sandbox/boxsh/boxshclient/session.go
+++ b/plugins/sandbox/boxsh/boxshclient/session.go
@@ -6,19 +6,16 @@ import (
 	"path/filepath"
 )
 
-// SessionManager handles the lifecycle of sandbox sessions including
-// workspace root selection, ephemeral directory creation, and cleanup.
+// SessionManager handles the lifecycle of sandbox sessions including sandbox
+// root selection, ephemeral directory creation, and cleanup.
 type SessionManager struct {
 	baseDir string // Base directory for ephemeral session directories
 }
 
 // SessionOptions configures a sandbox session.
 type SessionOptions struct {
-	// Workspace is the agent workspace directory.
-	Workspace string
-
-	// UserDataDir is the per-user data directory (used for user sessions).
-	UserDataDir string
+	// SandboxRoot is the writable root mounted into the sandbox.
+	SandboxRoot string
 
 	// WorkDir is the working directory for tool execution.
 	WorkDir string
@@ -43,9 +40,6 @@ type SessionInfo struct {
 
 	// NetworkAllowlist contains allowed hosts/CIDRs for whitelist mode.
 	NetworkAllowlist []string
-
-	// IsUserSession indicates if this is a user-scoped session (UserDataDir != "").
-	IsUserSession bool
 }
 
 // NewSessionManager creates a new session manager with the given base directory.
@@ -66,29 +60,22 @@ func NewSessionManager(baseDir string) (*SessionManager, error) {
 // CreateSession creates a new sandbox session with an ephemeral upperdir.
 // The caller is responsible for calling CleanupSession to remove the ephemeral directory.
 func (m *SessionManager) CreateSession(opts SessionOptions) (*SessionInfo, error) {
-	// Determine SRC based on session type.
-	// For user sessions (UserDataDir != ""): use UserDataDir.
-	// For non-user/system sessions: use Workspace.
-	src := opts.UserDataDir
+	src := opts.SandboxRoot
 	if src == "" {
-		src = opts.Workspace
-	}
-
-	if src == "" {
-		return nil, fmt.Errorf("session manager: workspace or user_data_dir is required")
+		return nil, fmt.Errorf("session manager: sandbox_root is required")
 	}
 
 	// Validate that src is an absolute path and exists.
 	if !filepath.IsAbs(src) {
-		return nil, fmt.Errorf("session manager: source path must be absolute: %q", src)
+		return nil, fmt.Errorf("session manager: sandbox root must be absolute: %q", src)
 	}
 
 	info, err := os.Stat(src)
 	if err != nil {
-		return nil, fmt.Errorf("session manager: stat source path %q: %w", src, err)
+		return nil, fmt.Errorf("session manager: stat sandbox root %q: %w", src, err)
 	}
 	if !info.IsDir() {
-		return nil, fmt.Errorf("session manager: source path %q is not a directory", src)
+		return nil, fmt.Errorf("session manager: sandbox root %q is not a directory", src)
 	}
 
 	// Create ephemeral session directory.
@@ -109,7 +96,6 @@ func (m *SessionManager) CreateSession(opts SessionOptions) (*SessionInfo, error
 		Cwd:              cwd,
 		NetworkMode:      networkMode,
 		NetworkAllowlist: opts.Sandbox.Allowlist,
-		IsUserSession:    opts.UserDataDir != "",
 	}
 
 	return session, nil
@@ -146,16 +132,6 @@ func BuildSessionConfig(info *SessionInfo) SessionConfig {
 		NetworkMode:      info.NetworkMode,
 		NetworkAllowlist: info.NetworkAllowlist,
 	}
-}
-
-// DeriveSandboxRoot computes the sandbox root (SRC) from workspace and user data dir.
-// - For user sessions (userDataDir != ""): use UserDataDir.
-// - For non-user/system sessions: use Workspace.
-func DeriveSandboxRoot(workspace, userDataDir string) string {
-	if userDataDir != "" {
-		return userDataDir
-	}
-	return workspace
 }
 
 // ValidateSandboxPath checks that a path is within the allowed sandbox boundaries.

--- a/plugins/sandbox/boxsh/boxshclient/session.go
+++ b/plugins/sandbox/boxsh/boxshclient/session.go
@@ -14,8 +14,8 @@ type SessionManager struct {
 
 // SessionOptions configures a sandbox session.
 type SessionOptions struct {
-	// SandboxRoot is the writable root mounted into the sandbox.
-	SandboxRoot string
+	// UserRoot is the writable root mounted into the sandbox.
+	UserRoot string
 
 	// WorkDir is the working directory for tool execution.
 	WorkDir string
@@ -60,22 +60,22 @@ func NewSessionManager(baseDir string) (*SessionManager, error) {
 // CreateSession creates a new sandbox session with an ephemeral upperdir.
 // The caller is responsible for calling CleanupSession to remove the ephemeral directory.
 func (m *SessionManager) CreateSession(opts SessionOptions) (*SessionInfo, error) {
-	src := opts.SandboxRoot
+	src := opts.UserRoot
 	if src == "" {
-		return nil, fmt.Errorf("session manager: sandbox_root is required")
+		return nil, fmt.Errorf("session manager: user_root is required")
 	}
 
 	// Validate that src is an absolute path and exists.
 	if !filepath.IsAbs(src) {
-		return nil, fmt.Errorf("session manager: sandbox root must be absolute: %q", src)
+		return nil, fmt.Errorf("session manager: user root must be absolute: %q", src)
 	}
 
 	info, err := os.Stat(src)
 	if err != nil {
-		return nil, fmt.Errorf("session manager: stat sandbox root %q: %w", src, err)
+		return nil, fmt.Errorf("session manager: stat user root %q: %w", src, err)
 	}
 	if !info.IsDir() {
-		return nil, fmt.Errorf("session manager: sandbox root %q is not a directory", src)
+		return nil, fmt.Errorf("session manager: user root %q is not a directory", src)
 	}
 
 	// Create ephemeral session directory.
@@ -119,8 +119,8 @@ func (m *SessionManager) createSessionDir() (string, error) {
 }
 
 // resolveCwd determines the effective working directory inside the sandbox.
-func (m *SessionManager) resolveCwd(sandboxRoot, workDir string) string {
-	return ResolveSandboxCwd(sandboxRoot, workDir)
+func (m *SessionManager) resolveCwd(userRoot, workDir string) string {
+	return ResolveSandboxCwd(userRoot, workDir)
 }
 
 // BuildSessionConfig builds a boxsh SessionConfig from SessionInfo.
@@ -134,33 +134,33 @@ func BuildSessionConfig(info *SessionInfo) SessionConfig {
 	}
 }
 
-// ValidateSandboxPath checks that a path is within the allowed sandbox boundaries.
+// ValidatePathWithinRoot checks that a path stays within the configured root.
 // This is a defensive check used before passing paths to the boxsh client.
-func ValidateSandboxPath(sandboxRoot, path string) error {
-	if sandboxRoot == "" {
-		return fmt.Errorf("sandbox root is required")
+func ValidatePathWithinRoot(userRoot, path string) error {
+	if userRoot == "" {
+		return fmt.Errorf("user root is required")
 	}
 
 	// Clean and resolve paths.
-	cleanRoot := filepath.Clean(sandboxRoot)
+	cleanRoot := filepath.Clean(userRoot)
 	cleanPath := filepath.Clean(path)
 
 	// Ensure both are absolute.
 	if !filepath.IsAbs(cleanRoot) {
-		return fmt.Errorf("sandbox root must be absolute: %q", sandboxRoot)
+		return fmt.Errorf("user root must be absolute: %q", userRoot)
 	}
 	if !filepath.IsAbs(cleanPath) {
 		cleanPath = filepath.Join(cleanRoot, cleanPath)
 	}
 
-	// Check that path is under the sandbox root.
+	// Check that path is under the user root.
 	rel, err := filepath.Rel(cleanRoot, cleanPath)
 	if err != nil {
 		return fmt.Errorf("path validation error: %w", err)
 	}
 
 	if rel == ".." || len(rel) > 2 && rel[:3] == "../" {
-		return fmt.Errorf("path %q is outside sandbox root %q", path, sandboxRoot)
+		return fmt.Errorf("path %q is outside user root %q", path, userRoot)
 	}
 
 	return nil

--- a/plugins/sandbox/boxsh/boxshclient/session_test.go
+++ b/plugins/sandbox/boxsh/boxshclient/session_test.go
@@ -51,10 +51,10 @@ func TestSessionManagerCreateSession(t *testing.T) {
 		t.Fatalf("NewSessionManager: %v", err)
 	}
 
-	sandboxRoot := t.TempDir()
+	userRoot := t.TempDir()
 	opts := SessionOptions{
-		SandboxRoot: sandboxRoot,
-		WorkDir:     "src",
+		UserRoot: userRoot,
+		WorkDir:  "src",
 		Sandbox: NetworkConfig{
 			Mode: NetworkDisabled,
 		},
@@ -64,13 +64,13 @@ func TestSessionManagerCreateSession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
-	if session.Src != sandboxRoot {
-		t.Errorf("Src = %q, want %q", session.Src, sandboxRoot)
+	if session.Src != userRoot {
+		t.Errorf("Src = %q, want %q", session.Src, userRoot)
 	}
 	if !hasPrefix(session.Dst, manager.baseDir) {
 		t.Errorf("Dst = %q, should be under %q", session.Dst, manager.baseDir)
 	}
-	if expectedCwd := filepath.Join(sandboxRoot, "src"); session.Cwd != expectedCwd {
+	if expectedCwd := filepath.Join(userRoot, "src"); session.Cwd != expectedCwd {
 		t.Errorf("Cwd = %q, want %q", session.Cwd, expectedCwd)
 	}
 	if session.NetworkMode != NetworkDisabled {
@@ -81,22 +81,22 @@ func TestSessionManagerCreateSession(t *testing.T) {
 	}
 }
 
-func TestSessionManagerCreateSessionDefaultsWorkDirToSandboxRoot(t *testing.T) {
+func TestSessionManagerCreateSessionDefaultsWorkDirToUserRoot(t *testing.T) {
 	manager, err := NewSessionManager(t.TempDir())
 	if err != nil {
 		t.Fatalf("NewSessionManager: %v", err)
 	}
 
-	sandboxRoot := t.TempDir()
-	session, err := manager.CreateSession(SessionOptions{SandboxRoot: sandboxRoot})
+	userRoot := t.TempDir()
+	session, err := manager.CreateSession(SessionOptions{UserRoot: userRoot})
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
-	if session.Src != sandboxRoot {
-		t.Errorf("Src = %q, want %q", session.Src, sandboxRoot)
+	if session.Src != userRoot {
+		t.Errorf("Src = %q, want %q", session.Src, userRoot)
 	}
-	if session.Cwd != sandboxRoot {
-		t.Errorf("Cwd = %q, want %q", session.Cwd, sandboxRoot)
+	if session.Cwd != userRoot {
+		t.Errorf("Cwd = %q, want %q", session.Cwd, userRoot)
 	}
 	if err := manager.CleanupSession(session); err != nil {
 		t.Errorf("CleanupSession: %v", err)
@@ -110,12 +110,12 @@ func TestSessionManagerCreateSessionRequiresWorkspace(t *testing.T) {
 	}
 
 	opts := SessionOptions{
-		SandboxRoot: "",
+		UserRoot: "",
 	}
 
 	_, err = manager.CreateSession(opts)
 	if err == nil {
-		t.Error("CreateSession should require sandbox root")
+		t.Error("CreateSession should require user root")
 	}
 }
 
@@ -126,12 +126,12 @@ func TestSessionManagerCreateSessionRequiresAbsoluteSrc(t *testing.T) {
 	}
 
 	opts := SessionOptions{
-		SandboxRoot: "relative/path",
+		UserRoot: "relative/path",
 	}
 
 	_, err = manager.CreateSession(opts)
 	if err == nil {
-		t.Error("CreateSession should require absolute sandbox root")
+		t.Error("CreateSession should require absolute user root")
 	}
 }
 
@@ -142,12 +142,12 @@ func TestSessionManagerCreateSessionRequiresExistingSrc(t *testing.T) {
 	}
 
 	opts := SessionOptions{
-		SandboxRoot: "/nonexistent/path/that/does/not/exist",
+		UserRoot: "/nonexistent/path/that/does/not/exist",
 	}
 
 	_, err = manager.CreateSession(opts)
 	if err == nil {
-		t.Error("CreateSession should require existing sandbox root")
+		t.Error("CreateSession should require existing user root")
 	}
 }
 
@@ -206,66 +206,66 @@ func TestBuildSessionConfig(t *testing.T) {
 	}
 }
 
-func TestValidateSandboxPath(t *testing.T) {
+func TestValidatePathWithinRoot(t *testing.T) {
 	tests := []struct {
-		name        string
-		sandboxRoot string
-		path        string
-		wantErr     bool
+		name     string
+		userRoot string
+		path     string
+		wantErr  bool
 	}{
 		{
-			name:        "path under root",
-			sandboxRoot: "/workspace",
-			path:        "/workspace/src/file.txt",
-			wantErr:     false,
+			name:     "path under root",
+			userRoot: "/workspace",
+			path:     "/workspace/src/file.txt",
+			wantErr:  false,
 		},
 		{
-			name:        "path at root",
-			sandboxRoot: "/workspace",
-			path:        "/workspace",
-			wantErr:     false,
+			name:     "path at root",
+			userRoot: "/workspace",
+			path:     "/workspace",
+			wantErr:  false,
 		},
 		{
-			name:        "path outside root",
-			sandboxRoot: "/workspace",
-			path:        "/outside/file.txt",
-			wantErr:     true,
+			name:     "path outside root",
+			userRoot: "/workspace",
+			path:     "/outside/file.txt",
+			wantErr:  true,
 		},
 		{
-			name:        "parent traversal",
-			sandboxRoot: "/workspace",
-			path:        "/workspace/../outside",
-			wantErr:     true,
+			name:     "parent traversal",
+			userRoot: "/workspace",
+			path:     "/workspace/../outside",
+			wantErr:  true,
 		},
 		{
-			name:        "relative path resolved under root",
-			sandboxRoot: "/workspace",
-			path:        "src/file.txt",
-			wantErr:     false,
+			name:     "relative path resolved under root",
+			userRoot: "/workspace",
+			path:     "src/file.txt",
+			wantErr:  false,
 		},
 		{
-			name:        "empty sandbox root",
-			sandboxRoot: "",
-			path:        "/workspace/file.txt",
-			wantErr:     true,
+			name:     "empty user root",
+			userRoot: "",
+			path:     "/workspace/file.txt",
+			wantErr:  true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateSandboxPath(tt.sandboxRoot, tt.path)
+			err := ValidatePathWithinRoot(tt.userRoot, tt.path)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("ValidateSandboxPath(%q, %q) error = %v, wantErr %v",
-					tt.sandboxRoot, tt.path, err, tt.wantErr)
+				t.Errorf("ValidatePathWithinRoot(%q, %q) error = %v, wantErr %v",
+					tt.userRoot, tt.path, err, tt.wantErr)
 			}
 		})
 	}
 }
 
-func TestValidateSandboxPathRequiresAbsoluteRoot(t *testing.T) {
-	err := ValidateSandboxPath("relative/path", "/workspace/file.txt")
+func TestValidatePathWithinRootRequiresAbsoluteRoot(t *testing.T) {
+	err := ValidatePathWithinRoot("relative/path", "/workspace/file.txt")
 	if err == nil {
-		t.Error("ValidateSandboxPath should require absolute sandbox root")
+		t.Error("ValidatePathWithinRoot should require absolute user root")
 	}
 }
 

--- a/plugins/sandbox/boxsh/boxshclient/session_test.go
+++ b/plugins/sandbox/boxsh/boxshclient/session_test.go
@@ -51,12 +51,9 @@ func TestSessionManagerCreateSession(t *testing.T) {
 		t.Fatalf("NewSessionManager: %v", err)
 	}
 
-	workspace := t.TempDir()
-	userDataDir := t.TempDir()
-
+	sandboxRoot := t.TempDir()
 	opts := SessionOptions{
-		Workspace:   workspace,
-		UserDataDir: userDataDir,
+		SandboxRoot: sandboxRoot,
 		WorkDir:     "src",
 		Sandbox: NetworkConfig{
 			Mode: NetworkDisabled,
@@ -67,72 +64,40 @@ func TestSessionManagerCreateSession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
-
-	// User session should use UserDataDir as Src.
-	if session.Src != userDataDir {
-		t.Errorf("Src = %q, want %q", session.Src, userDataDir)
+	if session.Src != sandboxRoot {
+		t.Errorf("Src = %q, want %q", session.Src, sandboxRoot)
 	}
-
-	// Dst should be created under manager baseDir.
 	if !hasPrefix(session.Dst, manager.baseDir) {
 		t.Errorf("Dst = %q, should be under %q", session.Dst, manager.baseDir)
 	}
-
-	// Cwd should be resolved.
-	expectedCwd := filepath.Join(userDataDir, "src")
-	if session.Cwd != expectedCwd {
+	if expectedCwd := filepath.Join(sandboxRoot, "src"); session.Cwd != expectedCwd {
 		t.Errorf("Cwd = %q, want %q", session.Cwd, expectedCwd)
 	}
-
 	if session.NetworkMode != NetworkDisabled {
 		t.Errorf("NetworkMode = %q, want %q", session.NetworkMode, NetworkDisabled)
 	}
-
-	if !session.IsUserSession {
-		t.Error("IsUserSession should be true")
-	}
-
-	// Cleanup.
 	if err := manager.CleanupSession(session); err != nil {
 		t.Errorf("CleanupSession: %v", err)
 	}
 }
 
-func TestSessionManagerCreateSystemSession(t *testing.T) {
+func TestSessionManagerCreateSessionDefaultsWorkDirToSandboxRoot(t *testing.T) {
 	manager, err := NewSessionManager(t.TempDir())
 	if err != nil {
 		t.Fatalf("NewSessionManager: %v", err)
 	}
 
-	workspace := t.TempDir()
-
-	opts := SessionOptions{
-		Workspace:   workspace,
-		UserDataDir: "", // No user data dir - system session
-		WorkDir:     "",
-		Sandbox:     NetworkConfig{},
-	}
-
-	session, err := manager.CreateSession(opts)
+	sandboxRoot := t.TempDir()
+	session, err := manager.CreateSession(SessionOptions{SandboxRoot: sandboxRoot})
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
-
-	// System session should use Workspace as Src.
-	if session.Src != workspace {
-		t.Errorf("Src = %q, want %q", session.Src, workspace)
+	if session.Src != sandboxRoot {
+		t.Errorf("Src = %q, want %q", session.Src, sandboxRoot)
 	}
-
-	// Cwd should default to Src.
-	if session.Cwd != workspace {
-		t.Errorf("Cwd = %q, want %q", session.Cwd, workspace)
+	if session.Cwd != sandboxRoot {
+		t.Errorf("Cwd = %q, want %q", session.Cwd, sandboxRoot)
 	}
-
-	if session.IsUserSession {
-		t.Error("IsUserSession should be false for system session")
-	}
-
-	// Cleanup.
 	if err := manager.CleanupSession(session); err != nil {
 		t.Errorf("CleanupSession: %v", err)
 	}
@@ -145,13 +110,12 @@ func TestSessionManagerCreateSessionRequiresWorkspace(t *testing.T) {
 	}
 
 	opts := SessionOptions{
-		Workspace:   "",
-		UserDataDir: "",
+		SandboxRoot: "",
 	}
 
 	_, err = manager.CreateSession(opts)
 	if err == nil {
-		t.Error("CreateSession should require workspace or user_data_dir")
+		t.Error("CreateSession should require sandbox root")
 	}
 }
 
@@ -162,13 +126,12 @@ func TestSessionManagerCreateSessionRequiresAbsoluteSrc(t *testing.T) {
 	}
 
 	opts := SessionOptions{
-		Workspace:   "relative/path",
-		UserDataDir: "",
+		SandboxRoot: "relative/path",
 	}
 
 	_, err = manager.CreateSession(opts)
 	if err == nil {
-		t.Error("CreateSession should require absolute workspace path")
+		t.Error("CreateSession should require absolute sandbox root")
 	}
 }
 
@@ -179,13 +142,12 @@ func TestSessionManagerCreateSessionRequiresExistingSrc(t *testing.T) {
 	}
 
 	opts := SessionOptions{
-		Workspace:   "/nonexistent/path/that/does/not/exist",
-		UserDataDir: "",
+		SandboxRoot: "/nonexistent/path/that/does/not/exist",
 	}
 
 	_, err = manager.CreateSession(opts)
 	if err == nil {
-		t.Error("CreateSession should require existing workspace")
+		t.Error("CreateSession should require existing sandbox root")
 	}
 }
 
@@ -241,38 +203,6 @@ func TestBuildSessionConfig(t *testing.T) {
 	}
 	if len(cfg.NetworkAllowlist) != 1 || cfg.NetworkAllowlist[0] != "example.com" {
 		t.Errorf("NetworkAllowlist = %v, want [example.com]", cfg.NetworkAllowlist)
-	}
-}
-
-func TestDeriveSandboxRoot(t *testing.T) {
-	tests := []struct {
-		name        string
-		workspace   string
-		userDataDir string
-		want        string
-	}{
-		{
-			name:        "user session prioritizes UserDataDir",
-			workspace:   "/workspace",
-			userDataDir: "/users/1/data",
-			want:        "/users/1/data",
-		},
-		{
-			name:        "system session uses Workspace",
-			workspace:   "/workspace",
-			userDataDir: "",
-			want:        "/workspace",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := DeriveSandboxRoot(tt.workspace, tt.userDataDir)
-			if got != tt.want {
-				t.Errorf("DeriveSandboxRoot(%q, %q) = %q, want %q",
-					tt.workspace, tt.userDataDir, got, tt.want)
-			}
-		})
 	}
 }
 

--- a/plugins/sandbox/boxsh/config.go
+++ b/plugins/sandbox/boxsh/config.go
@@ -15,10 +15,9 @@ const (
 type NetworkConfig = boxshclient.NetworkConfig
 
 type PreflightConfig struct {
-	AnnaHome    string
-	Workspace   string
-	UserDataDir string
-	Network     NetworkConfig
+	AnnaHome string
+	UserRoot string
+	Network  NetworkConfig
 }
 
 func (c PreflightConfig) Validate() error {

--- a/plugins/sandbox/boxsh/preflight.go
+++ b/plugins/sandbox/boxsh/preflight.go
@@ -24,10 +24,6 @@ func RequiresBoxsh(goos string) bool {
 	}
 }
 
-func SandboxRoot(cfg PreflightConfig) string {
-	return cfg.UserRoot
-}
-
 func ResolveManagedBoxshPath(annaHome string) (string, error) {
 	return boxshclient.ResolveManagedBoxshPath(annaHome)
 }
@@ -59,7 +55,7 @@ func Preflight(ctx context.Context, cfg PreflightConfig) error {
 		return err
 	}
 
-	root := SandboxRoot(cfg)
+	root := cfg.UserRoot
 	if root == "" {
 		return fmt.Errorf("sandbox: user root is required")
 	}

--- a/plugins/sandbox/boxsh/preflight.go
+++ b/plugins/sandbox/boxsh/preflight.go
@@ -25,10 +25,7 @@ func RequiresBoxsh(goos string) bool {
 }
 
 func SandboxRoot(cfg PreflightConfig) string {
-	if cfg.UserDataDir != "" {
-		return cfg.UserDataDir
-	}
-	return cfg.Workspace
+	return cfg.UserRoot
 }
 
 func ResolveManagedBoxshPath(annaHome string) (string, error) {
@@ -64,17 +61,17 @@ func Preflight(ctx context.Context, cfg PreflightConfig) error {
 
 	root := SandboxRoot(cfg)
 	if root == "" {
-		return fmt.Errorf("sandbox: workspace root is required")
+		return fmt.Errorf("sandbox: user root is required")
 	}
 	if !filepath.IsAbs(root) {
-		return fmt.Errorf("sandbox: workspace root must be absolute: %q", root)
+		return fmt.Errorf("sandbox: user root must be absolute: %q", root)
 	}
 	info, err := os.Stat(root)
 	if err != nil {
-		return fmt.Errorf("sandbox: stat workspace root %q: %w", root, err)
+		return fmt.Errorf("sandbox: stat user root %q: %w", root, err)
 	}
 	if !info.IsDir() {
-		return fmt.Errorf("sandbox: workspace root %q is not a directory", root)
+		return fmt.Errorf("sandbox: user root %q is not a directory", root)
 	}
 
 	annaHome := cfg.AnnaHome

--- a/plugins/sandbox/boxsh/preflight_test.go
+++ b/plugins/sandbox/boxsh/preflight_test.go
@@ -21,13 +21,9 @@ func TestRequiresBoxsh(t *testing.T) {
 }
 
 func TestSandboxRoot(t *testing.T) {
-	cfg := PreflightConfig{Workspace: "/workspace", UserDataDir: "/workspace/users/1/data"}
-	if got := SandboxRoot(cfg); got != cfg.UserDataDir {
-		t.Fatalf("SandboxRoot() = %q, want %q", got, cfg.UserDataDir)
-	}
-	cfg.UserDataDir = ""
-	if got := SandboxRoot(cfg); got != cfg.Workspace {
-		t.Fatalf("SandboxRoot() = %q, want %q", got, cfg.Workspace)
+	cfg := PreflightConfig{UserRoot: "/workspace/users/1/data"}
+	if got := SandboxRoot(cfg); got != cfg.UserRoot {
+		t.Fatalf("SandboxRoot() = %q, want %q", got, cfg.UserRoot)
 	}
 }
 
@@ -144,7 +140,7 @@ func TestPreflight(t *testing.T) {
 		t.Skip("boxsh preflight only applies on linux/darwin")
 	}
 	annaHome := t.TempDir()
-	workspace := t.TempDir()
+	userRoot := t.TempDir()
 	binDir := filepath.Join(annaHome, "bin")
 	if err := os.MkdirAll(binDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -155,9 +151,9 @@ func TestPreflight(t *testing.T) {
 	}
 
 	cfg := PreflightConfig{
-		AnnaHome:  annaHome,
-		Workspace: workspace,
-		Network:   NetworkConfig{Mode: NetworkDisabled},
+		AnnaHome: annaHome,
+		UserRoot: userRoot,
+		Network:  NetworkConfig{Mode: NetworkDisabled},
 	}
 	if err := Preflight(context.Background(), cfg); err != nil {
 		t.Fatalf("Preflight: %v", err)
@@ -169,9 +165,9 @@ func TestPreflightRejectsInvalidNetworkMode(t *testing.T) {
 		t.Skip("boxsh preflight only applies on linux/darwin")
 	}
 	cfg := PreflightConfig{
-		AnnaHome:  t.TempDir(),
-		Workspace: t.TempDir(),
-		Network:   NetworkConfig{Mode: "invalid"},
+		AnnaHome: t.TempDir(),
+		UserRoot: t.TempDir(),
+		Network:  NetworkConfig{Mode: "invalid"},
 	}
 	if err := Preflight(context.Background(), cfg); err == nil {
 		t.Fatal("expected invalid network mode error")

--- a/plugins/sandbox/boxsh/preflight_test.go
+++ b/plugins/sandbox/boxsh/preflight_test.go
@@ -20,13 +20,6 @@ func TestRequiresBoxsh(t *testing.T) {
 	}
 }
 
-func TestSandboxRoot(t *testing.T) {
-	cfg := PreflightConfig{UserRoot: "/workspace/users/1/data"}
-	if got := SandboxRoot(cfg); got != cfg.UserRoot {
-		t.Fatalf("SandboxRoot() = %q, want %q", got, cfg.UserRoot)
-	}
-}
-
 func TestResolveManagedBoxshPath(t *testing.T) {
 	annaHome := t.TempDir()
 	binDir := filepath.Join(annaHome, "bin")

--- a/plugins/sandbox/boxsh/session.go
+++ b/plugins/sandbox/boxsh/session.go
@@ -118,7 +118,7 @@ func (f *boxshFactory) CreateSession(ctx context.Context, policy Policy) (Sessio
 	backendCfg := boxshclient.BackendConfig{
 		AnnaHome:     annaHome,
 		BinaryPath:   binaryPath,
-		SandboxRoot:  policy.WorkspaceRootOrDefault(),
+		UserRoot:     policy.WorkspaceRootOrDefault(),
 		WorkDir:      policy.Filesystem.WorkingDir,
 		ReadOnlyDirs: policy.Filesystem.ReadOnlyPaths,
 		Sandbox: boxshclient.NetworkConfig{
@@ -543,7 +543,7 @@ func (h *boxshHost) OpenHTTPStream(_ context.Context, opts HTTPOptions) (HTTPStr
 }
 
 func (h *boxshHost) ResolvePath(path string) (string, error) {
-	root, err := h.session.backend.SandboxRoot(context.Background())
+	root, err := h.session.backend.UserRoot(context.Background())
 	if err != nil {
 		return "", err
 	}
@@ -570,7 +570,7 @@ func (h *boxshHost) ResolvePath(path string) (string, error) {
 	if filepath.IsAbs(path) {
 		return filepath.Join(root, strings.TrimPrefix(path, string(filepath.Separator))), nil
 	}
-	if err := boxshclient.ValidateSandboxPath(root, path); err != nil {
+	if err := boxshclient.ValidatePathWithinRoot(root, path); err != nil {
 		return "", err
 	}
 	return path, nil

--- a/plugins/sandbox/boxsh/session.go
+++ b/plugins/sandbox/boxsh/session.go
@@ -106,7 +106,10 @@ func (f *boxshFactory) CreateSession(ctx context.Context, policy Policy) (Sessio
 		return nil, err
 	}
 
-	annaHome := boxshclient.DefaultAnnaHome()
+	annaHome := policy.Process.Environment["ANNA_HOME"]
+	if annaHome == "" {
+		annaHome = boxshclient.DefaultAnnaHome()
+	}
 	binaryPath, err := boxshclient.ResolveManagedBoxshPath(annaHome)
 	if err != nil {
 		return nil, fmt.Errorf("boxsh session: %w", err)
@@ -115,7 +118,7 @@ func (f *boxshFactory) CreateSession(ctx context.Context, policy Policy) (Sessio
 	backendCfg := boxshclient.BackendConfig{
 		AnnaHome:     annaHome,
 		BinaryPath:   binaryPath,
-		Workspace:    policy.WorkspaceRootOrDefault(),
+		SandboxRoot:  policy.WorkspaceRootOrDefault(),
 		WorkDir:      policy.Filesystem.WorkingDir,
 		ReadOnlyDirs: policy.Filesystem.ReadOnlyPaths,
 		Sandbox: boxshclient.NetworkConfig{

--- a/plugins/sandbox/local/session.go
+++ b/plugins/sandbox/local/session.go
@@ -159,7 +159,7 @@ func (h *localHost) checkPath(path string) error {
 		return err
 	}
 
-	allowedDirs := []string{policy.WorkingDir}
+	allowedDirs := []string{h.session.policy.WorkspaceRootOrDefault()}
 	allowedDirs = append(allowedDirs, policy.ReadOnlyPaths...)
 	allowedDirs = append(allowedDirs, policy.ReadWritePaths...)
 
@@ -183,7 +183,7 @@ func (h *localHost) checkPath(path string) error {
 		}
 	}
 
-	// Path is outside allowed directories
+	// Path is outside the configured root and explicit exceptions.
 	return fmt.Errorf("sandbox: path %q is outside allowed directories", path)
 }
 

--- a/plugins/sandbox/local/session_test.go
+++ b/plugins/sandbox/local/session_test.go
@@ -1,0 +1,30 @@
+package local
+
+import (
+	"testing"
+
+	sandboxpkg "github.com/vaayne/anna/pkg/sandbox"
+)
+
+func TestCheckPathUsesWorkspaceRootBoundary(t *testing.T) {
+	root := t.TempDir()
+	policy := Policy{
+		Relaxed: false,
+		Filesystem: sandboxpkg.FilesystemPolicy{
+			WorkspaceRoot: root,
+			WorkingDir:    root + "/nested",
+			AllowEscapes:  false,
+		},
+	}
+	host := &localHost{session: newLocalSession(policy)}
+
+	if err := host.checkPath(root + "/file.txt"); err != nil {
+		t.Fatalf("checkPath(root child): %v", err)
+	}
+	if err := host.checkPath(root + "/nested/file.txt"); err != nil {
+		t.Fatalf("checkPath(workdir child): %v", err)
+	}
+	if err := host.checkPath(root + "/../outside.txt"); err == nil {
+		t.Fatal("expected outside-root path to be rejected")
+	}
+}

--- a/plugins/tools/registry.go
+++ b/plugins/tools/registry.go
@@ -3,14 +3,13 @@ package plugintools
 import pkgplugins "github.com/vaayne/anna/pkg/plugins"
 
 // BuildContext carries per-session configuration for tool construction.
-// Execution uses UserRoot + WorkDir. AnnaHome, HomeDir, AgentRoot, and
-// ProjectRoot are discovery/config inputs and do not redefine the writable root.
+// Execution uses UserRoot + WorkDir. AnnaHome, AgentRoot, and ProjectRoot are
+// discovery/config inputs and do not redefine the writable root.
 type BuildContext struct {
 	WorkDir     string // runtime working directory for tool execution; always inside UserRoot
 	ProjectRoot string // optional project-scoped discovery root for local/project-attached runs
 	UserRoot    string // runtime writable root and sandbox HOME
 	AnnaHome    string // anna home directory for builtin assets and shared state
-	HomeDir     string // host user home directory for config/discovery, not sandbox HOME
 	AgentRoot   string // agent-scoped discovery root, not the sandbox writable root
 	ToolsBinDir string // path to anna tools bin directory (prepended to PATH)
 	Runtime     pkgplugins.ToolRuntime

--- a/plugins/tools/registry.go
+++ b/plugins/tools/registry.go
@@ -3,13 +3,15 @@ package plugintools
 import pkgplugins "github.com/vaayne/anna/pkg/plugins"
 
 // BuildContext carries per-session configuration for tool construction.
+// Execution uses UserRoot + WorkDir. AnnaHome, HomeDir, AgentRoot, and
+// ProjectRoot are discovery/config inputs and do not redefine the writable root.
 type BuildContext struct {
-	WorkDir     string // working directory for tool execution
-	ProjectRoot string // optional project root for local/project-attached runs
-	UserRoot    string // per-user writable root used by prompts, skills, and sandbox setup
-	AnnaHome    string // anna home directory (e.g. ~/.anna)
-	HomeDir     string // user home directory for common config/skills lookup
-	AgentRoot   string // agent root dir
+	WorkDir     string // runtime working directory for tool execution; always inside UserRoot
+	ProjectRoot string // optional project-scoped discovery root for local/project-attached runs
+	UserRoot    string // runtime writable root and sandbox HOME
+	AnnaHome    string // anna home directory for builtin assets and shared state
+	HomeDir     string // host user home directory for config/discovery, not sandbox HOME
+	AgentRoot   string // agent-scoped discovery root, not the sandbox writable root
 	ToolsBinDir string // path to anna tools bin directory (prepended to PATH)
 	Runtime     pkgplugins.ToolRuntime
 }

--- a/plugins/tools/skills/plugin.go
+++ b/plugins/tools/skills/plugin.go
@@ -28,7 +28,7 @@ func init() {
 			Description: "Manage local agent skills.",
 			Required:    true,
 			Build: func(ctx pkgplugins.ToolContext) (tools.Tool, error) {
-				return NewTool(ctx.AnnaHome, ctx.HomeDir, ctx.AgentRoot, ctx.ProjectRoot, ctx.WorkDir, userSkillsDir(ctx.UserRoot), ctx.Runtime), nil
+				return NewTool(ctx.AnnaHome, ctx.AgentRoot, ctx.ProjectRoot, userSkillsDir(ctx.UserRoot), ctx.Runtime), nil
 			},
 		})
 		host.AddSystemPrompt(pkgplugins.SystemPromptSpec{

--- a/plugins/tools/skills/tool.go
+++ b/plugins/tools/skills/tool.go
@@ -56,22 +56,18 @@ var skillsInputSchema = func() map[string]any {
 }()
 
 type Tool struct {
-	homeDir       string
 	annaHome      string
 	agentRoot     string
 	projectRoot   string
-	cwd           string
 	userSkillsDir string
 	runtime       pkgplugins.ToolRuntime
 }
 
-func NewTool(annaHome, homeDir, agentRoot, projectRoot, cwd, userSkillsDir string, runtime pkgplugins.ToolRuntime) *Tool {
+func NewTool(annaHome, agentRoot, projectRoot, userSkillsDir string, runtime pkgplugins.ToolRuntime) *Tool {
 	return &Tool{
-		homeDir:       homeDir,
 		annaHome:      annaHome,
 		agentRoot:     agentRoot,
 		projectRoot:   projectRoot,
-		cwd:           cwd,
 		userSkillsDir: userSkillsDir,
 		runtime:       runtime,
 	}

--- a/plugins/tools/skills/tool_test.go
+++ b/plugins/tools/skills/tool_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestDefinition(t *testing.T) {
-	tool := NewTool("/tmp/anna", "", "/tmp/agents", "", "/tmp/cwd", "", nil)
+	tool := NewTool("/tmp/anna", "/tmp/agents", "", "", nil)
 	def := tool.Definition()
 
 	if def.Name != "skills" {
@@ -25,7 +25,7 @@ func TestDefinition(t *testing.T) {
 }
 
 func TestExecuteUnknownAction(t *testing.T) {
-	tool := NewTool("/tmp/anna", "", "/tmp/agents", "", "/tmp/cwd", "", nil)
+	tool := NewTool("/tmp/anna", "/tmp/agents", "", "", nil)
 	_, err := tool.Execute(context.Background(), map[string]any{"action": "bogus"})
 	if err == nil {
 		t.Error("expected error for unknown action")
@@ -33,7 +33,7 @@ func TestExecuteUnknownAction(t *testing.T) {
 }
 
 func TestExecuteDispatch(t *testing.T) {
-	tool := NewTool("/tmp/anna", "", "/tmp/agents", "", "/tmp/cwd", "", nil)
+	tool := NewTool("/tmp/anna", "/tmp/agents", "", "", nil)
 	_, err := tool.Execute(context.Background(), map[string]any{"action": "search"})
 	if err == nil {
 		t.Error("expected error for search without query")
@@ -63,7 +63,7 @@ description: A test skill
 		t.Fatal(err)
 	}
 
-	tool := NewTool("/tmp/anna", "", filepath.Join(dir, ".agents"), dir, dir, "", nil)
+	tool := NewTool("/tmp/anna", filepath.Join(dir, ".agents"), dir, "", nil)
 	result, err := tool.list(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -95,7 +95,7 @@ func TestRemoveNotFound(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tool := NewTool("/tmp/anna", "", filepath.Join(dir, ".agents"), dir, dir, "", nil)
+	tool := NewTool("/tmp/anna", filepath.Join(dir, ".agents"), dir, "", nil)
 	_, err := tool.remove(context.Background(), map[string]any{"name": "nonexistent"})
 	if err == nil {
 		t.Error("expected error for nonexistent skill")
@@ -103,7 +103,7 @@ func TestRemoveNotFound(t *testing.T) {
 }
 
 func TestRemoveMissingName(t *testing.T) {
-	tool := NewTool("/tmp/anna", "", "/tmp/agents", "", "/tmp/cwd", "", nil)
+	tool := NewTool("/tmp/anna", "/tmp/agents", "", "", nil)
 	_, err := tool.remove(context.Background(), map[string]any{})
 	if err == nil {
 		t.Error("expected error for missing name")
@@ -111,7 +111,7 @@ func TestRemoveMissingName(t *testing.T) {
 }
 
 func TestRemoveInvalidName(t *testing.T) {
-	tool := NewTool("/tmp/anna", "", "/tmp/agents", "", "/tmp/cwd", "", nil)
+	tool := NewTool("/tmp/anna", "/tmp/agents", "", "", nil)
 	_, err := tool.remove(context.Background(), map[string]any{"name": "../../../etc"})
 	if err == nil {
 		t.Error("expected error for path traversal name")
@@ -128,7 +128,7 @@ func TestRemoveSuccess(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tool := NewTool("/tmp/anna", "", filepath.Join(dir, ".agents"), dir, dir, "", nil)
+	tool := NewTool("/tmp/anna", filepath.Join(dir, ".agents"), dir, "", nil)
 	result, err := tool.remove(context.Background(), map[string]any{"name": "my-skill"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -142,7 +142,7 @@ func TestRemoveSuccess(t *testing.T) {
 }
 
 func TestSearchMissingQuery(t *testing.T) {
-	tool := NewTool("/tmp/anna", "", "/tmp/agents", "", "/tmp/cwd", "", nil)
+	tool := NewTool("/tmp/anna", "/tmp/agents", "", "", nil)
 	_, err := tool.search(context.Background(), map[string]any{})
 	if err == nil {
 		t.Error("expected error for missing query")
@@ -150,7 +150,7 @@ func TestSearchMissingQuery(t *testing.T) {
 }
 
 func TestInstallMissingSource(t *testing.T) {
-	tool := NewTool("/tmp/anna", "", "/tmp/agents", "", "/tmp/cwd", "", nil)
+	tool := NewTool("/tmp/anna", "/tmp/agents", "", "", nil)
 	_, err := tool.install(context.Background(), map[string]any{})
 	if err == nil {
 		t.Error("expected error for missing source")
@@ -178,7 +178,7 @@ description: Test
 		t.Fatal(err)
 	}
 
-	tool := NewTool("/tmp/anna", "", workspace, projectDir, projectDir, "", nil)
+	tool := NewTool("/tmp/anna", workspace, projectDir, "", nil)
 	result, err := tool.install(context.Background(), map[string]any{"source": srcDir})
 	if err != nil {
 		t.Fatalf("install error: %v", err)
@@ -204,7 +204,7 @@ func TestLoadSkill(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tool := NewTool("/tmp/anna", "", filepath.Join(dir, ".agents"), dir, dir, "", nil)
+	tool := NewTool("/tmp/anna", filepath.Join(dir, ".agents"), dir, "", nil)
 
 	t.Run("loads existing skill", func(t *testing.T) {
 		result, err := tool.load(context.Background(), map[string]any{"name": "test-skill"})
@@ -247,7 +247,7 @@ func TestRemoveSingleCharName(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tool := NewTool("/tmp/anna", "", filepath.Join(dir, ".agents"), dir, dir, "", nil)
+	tool := NewTool("/tmp/anna", filepath.Join(dir, ".agents"), dir, "", nil)
 	_, err := tool.remove(context.Background(), map[string]any{"name": "x"})
 	if err != nil {
 		t.Fatalf("unexpected error removing single-char skill: %v", err)
@@ -280,7 +280,7 @@ description: User skill
 		t.Fatal(err)
 	}
 
-	tool := NewTool("/tmp/anna", "", agentWS, "", "", userSkillsDir, nil)
+	tool := NewTool("/tmp/anna", agentWS, "", userSkillsDir, nil)
 	result, err := tool.install(context.Background(), map[string]any{"source": srcDir})
 	if err != nil {
 		t.Fatalf("install error: %v", err)
@@ -334,7 +334,7 @@ description: User-specific skill
 		t.Fatal(err)
 	}
 
-	tool := NewTool("/tmp/anna", "", agentWS, "", "", filepath.Join(agentWS, "users", "42", ".agents", "skills"), nil)
+	tool := NewTool("/tmp/anna", agentWS, "", filepath.Join(agentWS, "users", "42", ".agents", "skills"), nil)
 	result, err := tool.list(context.Background())
 	if err != nil {
 		t.Fatalf("list error: %v", err)
@@ -354,7 +354,7 @@ func TestAgentLevelToolBackwardCompat(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tool := NewTool("/tmp/anna", "", agentWS, "", "", "", nil)
+	tool := NewTool("/tmp/anna", agentWS, "", "", nil)
 	got := tool.skillsDir()
 	want := filepath.Join(agentWS, "skills")
 	if got != want {
@@ -366,7 +366,7 @@ func TestPerUserToolSkillsDir(t *testing.T) {
 	base := t.TempDir()
 	agentWS := filepath.Join(base, "workspaces", "agent-1")
 
-	tool := NewTool("/tmp/anna", "", agentWS, "", "", filepath.Join(agentWS, "users", "7", ".agents", "skills"), nil)
+	tool := NewTool("/tmp/anna", agentWS, "", filepath.Join(agentWS, "users", "7", ".agents", "skills"), nil)
 	got := tool.skillsDir()
 	want := filepath.Join(agentWS, "users", "7", ".agents", "skills")
 	if got != want {


### PR DESCRIPTION
## Summary
- normalize runner sandbox setup around `AnnaHome`, `UserRoot`, and `WorkDir`
- remove stale sandbox path coupling to host `~/.agents` and ambient `ANNA_HOME` mutation
- collapse boxshclient root selection to a single `SandboxRoot`

## Testing
- mise run format
- mise run test
