### PR TITLE
♻️ refactor: flatten tool path context

### DIFF
--- a/docs/content/docs/plugins/capabilities.md
+++ b/docs/content/docs/plugins/capabilities.md
@@ -47,13 +47,15 @@ Important fields:
 Use `ToolContext` when building:
 
 - `Platform`
-- `State`
-- `WorkDir`
-- `UserDataDir`
-- `AnnaHome`
-- `HomeDir`
-- `Workspace`
-- `ToolsBinDir`
+- `Execution`
+  - `WorkDir`
+  - `UserRoot`
+  - `ToolsBinDir`
+- `Discovery`
+  - `AnnaHome`
+  - `AgentRoot`
+  - `ProjectRoot`
+  - `UserRoot`
 - `Runtime`
 
 `Runtime` is the tool-facing file and process capability surface. Use it instead of depending on sandbox internals; the runner decides whether those operations are local, sandboxed, or otherwise mediated.

--- a/docs/content/docs/plugins/capabilities.md
+++ b/docs/content/docs/plugins/capabilities.md
@@ -49,12 +49,13 @@ Use `ToolContext` when building:
 - `Platform`
 - `Paths`
   - `UserRoot`
-  - `WorkDir`
   - `ToolsBinDir`
   - `AnnaHome`
   - `AgentRoot`
   - `ProjectRoot`
 - `Runtime`
+
+`ProjectRoot` is the current attached project, if any. Project-aware tools should resolve relative paths from `ProjectRoot` instead of depending on runner cwd details.
 
 `Runtime` is the tool-facing file and process capability surface. Use it instead of depending on sandbox internals; the runner decides whether those operations are local, sandboxed, or otherwise mediated.
 

--- a/docs/content/docs/plugins/capabilities.md
+++ b/docs/content/docs/plugins/capabilities.md
@@ -47,15 +47,13 @@ Important fields:
 Use `ToolContext` when building:
 
 - `Platform`
-- `Execution`
-  - `WorkDir`
+- `Paths`
   - `UserRoot`
+  - `WorkDir`
   - `ToolsBinDir`
-- `Discovery`
   - `AnnaHome`
   - `AgentRoot`
   - `ProjectRoot`
-  - `UserRoot`
 - `Runtime`
 
 `Runtime` is the tool-facing file and process capability surface. Use it instead of depending on sandbox internals; the runner decides whether those operations are local, sandboxed, or otherwise mediated.

--- a/docs/content/docs/plugins/platform.md
+++ b/docs/content/docs/plugins/platform.md
@@ -179,12 +179,13 @@ Examples:
 - `Platform`
 - `Paths`
   - `UserRoot`
-  - `WorkDir`
   - `ToolsBinDir`
   - `AnnaHome`
   - `AgentRoot`
   - `ProjectRoot`
 - `Runtime`
+
+`ProjectRoot` is the current attached project, if any. Project-aware tools should resolve relative paths from `ProjectRoot` instead of depending on runner cwd details.
 
 `Runtime` is a capability interface for tool file and process operations. Plugin tools should use it rather than importing sandbox internals directly.
 

--- a/docs/content/docs/plugins/platform.md
+++ b/docs/content/docs/plugins/platform.md
@@ -177,15 +177,13 @@ Examples:
 `ToolContext`:
 
 - `Platform`
-- `Execution`
-  - `WorkDir`
+- `Paths`
   - `UserRoot`
+  - `WorkDir`
   - `ToolsBinDir`
-- `Discovery`
   - `AnnaHome`
   - `AgentRoot`
   - `ProjectRoot`
-  - `UserRoot`
 - `Runtime`
 
 `Runtime` is a capability interface for tool file and process operations. Plugin tools should use it rather than importing sandbox internals directly.

--- a/docs/content/docs/plugins/platform.md
+++ b/docs/content/docs/plugins/platform.md
@@ -177,8 +177,15 @@ Examples:
 `ToolContext`:
 
 - `Platform`
-- `State`
-- working directory paths
+- `Execution`
+  - `WorkDir`
+  - `UserRoot`
+  - `ToolsBinDir`
+- `Discovery`
+  - `AnnaHome`
+  - `AgentRoot`
+  - `ProjectRoot`
+  - `UserRoot`
 - `Runtime`
 
 `Runtime` is a capability interface for tool file and process operations. Plugin tools should use it rather than importing sandbox internals directly.

--- a/internal/agent/runner/coretools_builder.go
+++ b/internal/agent/runner/coretools_builder.go
@@ -11,5 +11,5 @@ func buildSandboxCoreTools(session *runnerSession, bc plugintools.BuildContext) 
 	if session == nil || session.Session() == nil || session.Session().Host() == nil {
 		return nil
 	}
-	return sandbox.NewCoreTools(session.Session().Host(), bc.Execution.ToolsBinDir)
+	return sandbox.NewCoreTools(session.Session().Host(), bc.Paths.ToolsBinDir)
 }

--- a/internal/agent/runner/coretools_builder.go
+++ b/internal/agent/runner/coretools_builder.go
@@ -11,5 +11,5 @@ func buildSandboxCoreTools(session *runnerSession, bc plugintools.BuildContext) 
 	if session == nil || session.Session() == nil || session.Session().Host() == nil {
 		return nil
 	}
-	return sandbox.NewCoreTools(session.Session().Host(), bc.Paths.ToolsBinDir)
+	return sandbox.NewCoreTools(session.Session().Host(), bc.Paths.ToolsBinDir, bc.Paths.ProjectRoot)
 }

--- a/internal/agent/runner/coretools_builder.go
+++ b/internal/agent/runner/coretools_builder.go
@@ -11,5 +11,5 @@ func buildSandboxCoreTools(session *runnerSession, bc plugintools.BuildContext) 
 	if session == nil || session.Session() == nil || session.Session().Host() == nil {
 		return nil
 	}
-	return sandbox.NewCoreTools(session.Session().Host(), bc.ToolsBinDir)
+	return sandbox.NewCoreTools(session.Session().Host(), bc.Execution.ToolsBinDir)
 }

--- a/internal/agent/runner/coretools_builder_test.go
+++ b/internal/agent/runner/coretools_builder_test.go
@@ -33,7 +33,7 @@ func (f *fakeSession) Done() <-chan struct{} {
 }
 
 func TestBuildSandboxCoreTools_NoSessionFailsClosed(t *testing.T) {
-	tools := buildSandboxCoreTools(nil, plugintools.BuildContext{Paths: pkgplugins.ToolPaths{WorkDir: "/tmp", ToolsBinDir: "/tmp/bin"}})
+	tools := buildSandboxCoreTools(nil, plugintools.BuildContext{Paths: pkgplugins.ToolPaths{ToolsBinDir: "/tmp/bin"}})
 	if tools != nil {
 		t.Fatalf("expected no tools without sandbox session, got %v", tools)
 	}

--- a/internal/agent/runner/coretools_builder_test.go
+++ b/internal/agent/runner/coretools_builder_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/vaayne/anna/internal/sandbox"
+	pkgplugins "github.com/vaayne/anna/pkg/plugins"
 	plugintools "github.com/vaayne/anna/plugins/tools"
 )
 
@@ -32,7 +33,7 @@ func (f *fakeSession) Done() <-chan struct{} {
 }
 
 func TestBuildSandboxCoreTools_NoSessionFailsClosed(t *testing.T) {
-	tools := buildSandboxCoreTools(nil, plugintools.BuildContext{Execution: plugintools.ExecutionContext{WorkDir: "/tmp", ToolsBinDir: "/tmp/bin"}})
+	tools := buildSandboxCoreTools(nil, plugintools.BuildContext{Paths: pkgplugins.ToolPaths{WorkDir: "/tmp", ToolsBinDir: "/tmp/bin"}})
 	if tools != nil {
 		t.Fatalf("expected no tools without sandbox session, got %v", tools)
 	}

--- a/internal/agent/runner/coretools_builder_test.go
+++ b/internal/agent/runner/coretools_builder_test.go
@@ -32,7 +32,7 @@ func (f *fakeSession) Done() <-chan struct{} {
 }
 
 func TestBuildSandboxCoreTools_NoSessionFailsClosed(t *testing.T) {
-	tools := buildSandboxCoreTools(nil, plugintools.BuildContext{WorkDir: "/tmp", ToolsBinDir: "/tmp/bin"})
+	tools := buildSandboxCoreTools(nil, plugintools.BuildContext{Execution: plugintools.ExecutionContext{WorkDir: "/tmp", ToolsBinDir: "/tmp/bin"}})
 	if tools != nil {
 		t.Fatalf("expected no tools without sandbox session, got %v", tools)
 	}

--- a/internal/agent/runner/gorunner.go
+++ b/internal/agent/runner/gorunner.go
@@ -219,13 +219,18 @@ func buildToolRegistry(ctx context.Context, cfg GoRunnerConfig, session *runnerS
 
 	// Runtime capabilities are injected from the active runner session.
 	bc := plugintools.BuildContext{
-		WorkDir:     paths.WorkDir,
-		ProjectRoot: "",
-		UserRoot:    paths.UserRoot,
-		AnnaHome:    paths.AnnaHome,
-		AgentRoot:   paths.AgentRoot,
-		ToolsBinDir: paths.toolsBinDir(),
-		Runtime:     cfg.ToolRuntime,
+		Execution: plugintools.ExecutionContext{
+			WorkDir:     paths.WorkDir,
+			UserRoot:    paths.UserRoot,
+			ToolsBinDir: paths.toolsBinDir(),
+		},
+		Discovery: plugintools.DiscoveryContext{
+			AnnaHome:    paths.AnnaHome,
+			AgentRoot:   paths.AgentRoot,
+			ProjectRoot: "",
+			UserRoot:    paths.UserRoot,
+		},
+		Runtime: cfg.ToolRuntime,
 	}
 
 	coreTools := buildSandboxCoreTools(session, bc)

--- a/internal/agent/runner/gorunner.go
+++ b/internal/agent/runner/gorunner.go
@@ -219,16 +219,13 @@ func buildToolRegistry(ctx context.Context, cfg GoRunnerConfig, session *runnerS
 
 	// Runtime capabilities are injected from the active runner session.
 	bc := plugintools.BuildContext{
-		Execution: plugintools.ExecutionContext{
-			WorkDir:     paths.WorkDir,
+		Paths: pkgplugins.ToolPaths{
 			UserRoot:    paths.UserRoot,
+			WorkDir:     paths.WorkDir,
 			ToolsBinDir: paths.toolsBinDir(),
-		},
-		Discovery: plugintools.DiscoveryContext{
 			AnnaHome:    paths.AnnaHome,
 			AgentRoot:   paths.AgentRoot,
 			ProjectRoot: "",
-			UserRoot:    paths.UserRoot,
 		},
 		Runtime: cfg.ToolRuntime,
 	}

--- a/internal/agent/runner/gorunner.go
+++ b/internal/agent/runner/gorunner.go
@@ -221,7 +221,6 @@ func buildToolRegistry(ctx context.Context, cfg GoRunnerConfig, session *runnerS
 	bc := plugintools.BuildContext{
 		Paths: pkgplugins.ToolPaths{
 			UserRoot:    paths.UserRoot,
-			WorkDir:     paths.WorkDir,
 			ToolsBinDir: paths.toolsBinDir(),
 			AnnaHome:    paths.AnnaHome,
 			AgentRoot:   paths.AgentRoot,

--- a/internal/pluginhost/builders.go
+++ b/internal/pluginhost/builders.go
@@ -33,10 +33,9 @@ func (h *Host) BuildEnabledTools(ctx context.Context, bc plugintools.BuildContex
 			continue
 		}
 		t, err := reg.Build(pkgplugins.ToolContext{
-			Platform:  h.platform(reg.PluginID),
-			Execution: pkgplugins.ExecutionContext(bc.Execution),
-			Discovery: pkgplugins.DiscoveryContext(bc.Discovery),
-			Runtime:   bc.Runtime,
+			Platform: h.platform(reg.PluginID),
+			Paths:    bc.Paths,
+			Runtime:  bc.Runtime,
 		})
 		if err == nil && t != nil {
 			out = append(out, t)

--- a/internal/pluginhost/builders.go
+++ b/internal/pluginhost/builders.go
@@ -33,14 +33,10 @@ func (h *Host) BuildEnabledTools(ctx context.Context, bc plugintools.BuildContex
 			continue
 		}
 		t, err := reg.Build(pkgplugins.ToolContext{
-			Platform:    h.platform(reg.PluginID),
-			WorkDir:     bc.WorkDir,
-			ProjectRoot: bc.ProjectRoot,
-			UserRoot:    bc.UserRoot,
-			AnnaHome:    bc.AnnaHome,
-			AgentRoot:   bc.AgentRoot,
-			ToolsBinDir: bc.ToolsBinDir,
-			Runtime:     bc.Runtime,
+			Platform:  h.platform(reg.PluginID),
+			Execution: pkgplugins.ExecutionContext(bc.Execution),
+			Discovery: pkgplugins.DiscoveryContext(bc.Discovery),
+			Runtime:   bc.Runtime,
 		})
 		if err == nil && t != nil {
 			out = append(out, t)

--- a/internal/pluginhost/builders_test.go
+++ b/internal/pluginhost/builders_test.go
@@ -27,8 +27,7 @@ func TestBuildEnabledToolsBuildsAllOptionalToolsWithRuntimeContext(t *testing.T)
 	host.RegisterPluginID("tool/b")
 
 	var runtimeSeen int
-	var executions []pkgplugins.ExecutionContext
-	var discoveries []pkgplugins.DiscoveryContext
+	var seenPaths []pkgplugins.ToolPaths
 	fakeRuntime := pkgplugins.NewLocalToolRuntime(t.TempDir())
 	host.AddTool(pkgplugins.ToolSpec{
 		PluginID: "tool/a",
@@ -37,8 +36,7 @@ func TestBuildEnabledToolsBuildsAllOptionalToolsWithRuntimeContext(t *testing.T)
 			if ctx.Runtime != nil {
 				runtimeSeen++
 			}
-			executions = append(executions, ctx.Execution)
-			discoveries = append(discoveries, ctx.Discovery)
+			seenPaths = append(seenPaths, ctx.Paths)
 			return &testTool{name: "a"}, nil
 		},
 	})
@@ -49,16 +47,21 @@ func TestBuildEnabledToolsBuildsAllOptionalToolsWithRuntimeContext(t *testing.T)
 			if ctx.Runtime != nil {
 				runtimeSeen++
 			}
-			executions = append(executions, ctx.Execution)
-			discoveries = append(discoveries, ctx.Discovery)
+			seenPaths = append(seenPaths, ctx.Paths)
 			return &testTool{name: "b"}, nil
 		},
 	})
 
 	build := plugintools.BuildContext{
-		Execution: plugintools.ExecutionContext{WorkDir: "/work", UserRoot: "/user", ToolsBinDir: "/tools/bin"},
-		Discovery: plugintools.DiscoveryContext{AnnaHome: "/anna", AgentRoot: "/agent", ProjectRoot: "/project", UserRoot: "/user"},
-		Runtime:   fakeRuntime,
+		Paths: pkgplugins.ToolPaths{
+			WorkDir:     "/work",
+			UserRoot:    "/user",
+			ToolsBinDir: "/tools/bin",
+			AnnaHome:    "/anna",
+			AgentRoot:   "/agent",
+			ProjectRoot: "/project",
+		},
+		Runtime: fakeRuntime,
 	}
 	got := host.BuildEnabledTools(context.Background(), build)
 	if len(got) != 2 {
@@ -67,14 +70,9 @@ func TestBuildEnabledToolsBuildsAllOptionalToolsWithRuntimeContext(t *testing.T)
 	if runtimeSeen != 2 {
 		t.Fatalf("runtime seen = %d, want 2", runtimeSeen)
 	}
-	for i, execution := range executions {
-		if execution.WorkDir != build.Execution.WorkDir || execution.UserRoot != build.Execution.UserRoot || execution.ToolsBinDir != build.Execution.ToolsBinDir {
-			t.Fatalf("execution[%d] = %+v, want %+v", i, execution, build.Execution)
-		}
-	}
-	for i, discovery := range discoveries {
-		if discovery.AnnaHome != build.Discovery.AnnaHome || discovery.AgentRoot != build.Discovery.AgentRoot || discovery.ProjectRoot != build.Discovery.ProjectRoot || discovery.UserRoot != build.Discovery.UserRoot {
-			t.Fatalf("discovery[%d] = %+v, want %+v", i, discovery, build.Discovery)
+	for i, paths := range seenPaths {
+		if paths != build.Paths {
+			t.Fatalf("paths[%d] = %+v, want %+v", i, paths, build.Paths)
 		}
 	}
 }

--- a/internal/pluginhost/builders_test.go
+++ b/internal/pluginhost/builders_test.go
@@ -27,6 +27,8 @@ func TestBuildEnabledToolsBuildsAllOptionalToolsWithRuntimeContext(t *testing.T)
 	host.RegisterPluginID("tool/b")
 
 	var runtimeSeen int
+	var executions []pkgplugins.ExecutionContext
+	var discoveries []pkgplugins.DiscoveryContext
 	fakeRuntime := pkgplugins.NewLocalToolRuntime(t.TempDir())
 	host.AddTool(pkgplugins.ToolSpec{
 		PluginID: "tool/a",
@@ -35,6 +37,8 @@ func TestBuildEnabledToolsBuildsAllOptionalToolsWithRuntimeContext(t *testing.T)
 			if ctx.Runtime != nil {
 				runtimeSeen++
 			}
+			executions = append(executions, ctx.Execution)
+			discoveries = append(discoveries, ctx.Discovery)
 			return &testTool{name: "a"}, nil
 		},
 	})
@@ -45,15 +49,32 @@ func TestBuildEnabledToolsBuildsAllOptionalToolsWithRuntimeContext(t *testing.T)
 			if ctx.Runtime != nil {
 				runtimeSeen++
 			}
+			executions = append(executions, ctx.Execution)
+			discoveries = append(discoveries, ctx.Discovery)
 			return &testTool{name: "b"}, nil
 		},
 	})
 
-	got := host.BuildEnabledTools(context.Background(), plugintools.BuildContext{Runtime: fakeRuntime})
+	build := plugintools.BuildContext{
+		Execution: plugintools.ExecutionContext{WorkDir: "/work", UserRoot: "/user", ToolsBinDir: "/tools/bin"},
+		Discovery: plugintools.DiscoveryContext{AnnaHome: "/anna", AgentRoot: "/agent", ProjectRoot: "/project", UserRoot: "/user"},
+		Runtime:   fakeRuntime,
+	}
+	got := host.BuildEnabledTools(context.Background(), build)
 	if len(got) != 2 {
 		t.Fatalf("BuildEnabledTools() len = %d, want 2", len(got))
 	}
 	if runtimeSeen != 2 {
 		t.Fatalf("runtime seen = %d, want 2", runtimeSeen)
+	}
+	for i, execution := range executions {
+		if execution.WorkDir != build.Execution.WorkDir || execution.UserRoot != build.Execution.UserRoot || execution.ToolsBinDir != build.Execution.ToolsBinDir {
+			t.Fatalf("execution[%d] = %+v, want %+v", i, execution, build.Execution)
+		}
+	}
+	for i, discovery := range discoveries {
+		if discovery.AnnaHome != build.Discovery.AnnaHome || discovery.AgentRoot != build.Discovery.AgentRoot || discovery.ProjectRoot != build.Discovery.ProjectRoot || discovery.UserRoot != build.Discovery.UserRoot {
+			t.Fatalf("discovery[%d] = %+v, want %+v", i, discovery, build.Discovery)
+		}
 	}
 }

--- a/internal/pluginhost/builders_test.go
+++ b/internal/pluginhost/builders_test.go
@@ -54,7 +54,6 @@ func TestBuildEnabledToolsBuildsAllOptionalToolsWithRuntimeContext(t *testing.T)
 
 	build := plugintools.BuildContext{
 		Paths: pkgplugins.ToolPaths{
-			WorkDir:     "/work",
 			UserRoot:    "/user",
 			ToolsBinDir: "/tools/bin",
 			AnnaHome:    "/anna",

--- a/internal/sandbox/tools.go
+++ b/internal/sandbox/tools.go
@@ -12,30 +12,46 @@ import (
 )
 
 // NewCoreTools returns the unified host-backed core tools.
-func NewCoreTools(host Host, toolsBinDir string) []tools.Tool {
+func NewCoreTools(host Host, toolsBinDir, projectRoot string) []tools.Tool {
 	if host == nil {
 		return nil
 	}
 	return []tools.Tool{
-		newBashTool(host, toolsBinDir),
-		newReadTool(host),
-		newWriteTool(host),
-		newEditTool(host),
+		newBashTool(host, toolsBinDir, projectRoot),
+		newReadTool(host, projectRoot),
+		newWriteTool(host, projectRoot),
+		newEditTool(host, projectRoot),
 	}
 }
 
-func newBashTool(host Host, toolsBinDir string) tools.Tool {
-	return &hostBashTool{host: host, normalizer: newToolNormalizer(), toolsBinDir: toolsBinDir}
+func newBashTool(host Host, toolsBinDir, projectRoot string) tools.Tool {
+	return &hostBashTool{host: host, normalizer: newToolNormalizer(), toolsBinDir: toolsBinDir, projectRoot: projectRoot}
 }
 
-func newReadTool(host Host) tools.Tool  { return &hostReadTool{host: host} }
-func newWriteTool(host Host) tools.Tool { return &hostWriteTool{host: host} }
-func newEditTool(host Host) tools.Tool  { return &hostEditTool{host: host} }
+func newReadTool(host Host, projectRoot string) tools.Tool {
+	return &hostReadTool{host: host, projectRoot: projectRoot}
+}
+
+func newWriteTool(host Host, projectRoot string) tools.Tool {
+	return &hostWriteTool{host: host, projectRoot: projectRoot}
+}
+
+func newEditTool(host Host, projectRoot string) tools.Tool {
+	return &hostEditTool{host: host, projectRoot: projectRoot}
+}
+
+func resolveToolPath(host Host, projectRoot, path string) (string, error) {
+	if projectRoot != "" {
+		return tools.ResolveProjectPath(projectRoot, path)
+	}
+	return host.ResolvePath(path)
+}
 
 type hostBashTool struct {
 	host        Host
 	normalizer  *toolNormalizer
 	toolsBinDir string
+	projectRoot string
 }
 
 func (t *hostBashTool) Definition() tools.Definition {
@@ -65,7 +81,11 @@ func (t *hostBashTool) Execute(ctx context.Context, args map[string]any) (string
 	if t.toolsBinDir != "" {
 		env["PATH"] = t.toolsBinDir + string(os.PathListSeparator) + os.Getenv("PATH")
 	}
-	result, err := t.host.Exec(ctx, command, ExecOptions{Timeout: time.Duration(timeoutSeconds) * time.Second, Env: env})
+	execOpts := ExecOptions{Timeout: time.Duration(timeoutSeconds) * time.Second, Env: env}
+	if t.projectRoot != "" {
+		execOpts.Cwd = t.projectRoot
+	}
+	result, err := t.host.Exec(ctx, command, execOpts)
 	if err != nil {
 		norm := t.normalizer.NormalizeError(err, "bash")
 		return norm.Content, fmt.Errorf("bash: %w", err)
@@ -88,7 +108,10 @@ type LineOrientedReaderHost interface {
 	ReadAllFile(ctx context.Context, path string) ([]byte, error)
 }
 
-type hostReadTool struct{ host Host }
+type hostReadTool struct {
+	host        Host
+	projectRoot string
+}
 
 func (t *hostReadTool) Definition() tools.Definition {
 	return tools.Definition{
@@ -115,11 +138,16 @@ func (t *hostReadTool) Execute(ctx context.Context, args map[string]any) (string
 	offset := max(toolIntArg(args, "offset", 1), 1)
 	limit := toolIntArg(args, "limit", 0)
 
-	if reader, ok := t.host.(LineOrientedReaderHost); ok {
-		return t.executeLineReader(ctx, reader, path, offset, limit)
+	resolvedPath, err := resolveToolPath(t.host, t.projectRoot, path)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", path, err)
 	}
 
-	result, err := t.host.ReadFile(ctx, path, 0, 0)
+	if reader, ok := t.host.(LineOrientedReaderHost); ok {
+		return t.executeLineReader(ctx, reader, resolvedPath, offset, limit)
+	}
+
+	result, err := t.host.ReadFile(ctx, resolvedPath, 0, 0)
 	if err != nil {
 		return "", fmt.Errorf("read %s: %w", path, err)
 	}
@@ -152,7 +180,10 @@ func (t *hostReadTool) Execute(ctx context.Context, args map[string]any) (string
 	return tr.Content, nil
 }
 
-type hostWriteTool struct{ host Host }
+type hostWriteTool struct {
+	host        Host
+	projectRoot string
+}
 
 func (t *hostWriteTool) Definition() tools.Definition {
 	return tools.Definition{
@@ -176,18 +207,26 @@ func (t *hostWriteTool) Execute(ctx context.Context, args map[string]any) (strin
 		return "", fmt.Errorf("write: path is required")
 	}
 
-	if err := t.host.MkdirAll(ctx, filepath.Dir(path), 0o755); err != nil {
-		return "", fmt.Errorf("write: mkdir %s: %w", filepath.Dir(path), err)
+	resolvedPath, err := resolveToolPath(t.host, t.projectRoot, path)
+	if err != nil {
+		return "", fmt.Errorf("write %s: %w", path, err)
 	}
 
-	result, err := t.host.WriteFile(ctx, path, []byte(content))
+	if err := t.host.MkdirAll(ctx, filepath.Dir(resolvedPath), 0o755); err != nil {
+		return "", fmt.Errorf("write: mkdir %s: %w", filepath.Dir(resolvedPath), err)
+	}
+
+	result, err := t.host.WriteFile(ctx, resolvedPath, []byte(content))
 	if err != nil {
 		return "", fmt.Errorf("write %s: %w", path, err)
 	}
 	return fmt.Sprintf("Wrote %s (%d bytes)", path, result.BytesWritten), nil
 }
 
-type hostEditTool struct{ host Host }
+type hostEditTool struct {
+	host        Host
+	projectRoot string
+}
 
 func (t *hostEditTool) Definition() tools.Definition {
 	return tools.Definition{
@@ -221,7 +260,12 @@ func (t *hostEditTool) Execute(ctx context.Context, args map[string]any) (string
 		return "", fmt.Errorf("edit: oldText is required")
 	}
 
-	content, err := readAllForEdit(ctx, t.host, path)
+	resolvedPath, err := resolveToolPath(t.host, t.projectRoot, path)
+	if err != nil {
+		return "", fmt.Errorf("edit %s: %w", path, err)
+	}
+
+	content, err := readAllForEdit(ctx, t.host, resolvedPath)
 	if err != nil {
 		return "", fmt.Errorf("edit: read %s: %w", path, err)
 	}
@@ -233,7 +277,7 @@ func (t *hostEditTool) Execute(ctx context.Context, args map[string]any) (string
 		return "", fmt.Errorf("edit: oldText matches %d times in %s (must be unique)", count, path)
 	}
 
-	result, err := t.host.EditFile(ctx, path, []Edit{{OldText: oldStr, NewText: newStr}})
+	result, err := t.host.EditFile(ctx, resolvedPath, []Edit{{OldText: oldStr, NewText: newStr}})
 	if err != nil {
 		return "", fmt.Errorf("edit %s: %w", path, err)
 	}

--- a/internal/sandbox/tools_boxsh_integration_test.go
+++ b/internal/sandbox/tools_boxsh_integration_test.go
@@ -65,7 +65,7 @@ func TestNewCoreToolsBoxshUsesWorkingDirAndSharedState(t *testing.T) {
 	defer cancel()
 
 	session, workspace := newBoxshToolTestSession(t, ctx, map[string]string{"notes.txt": "old value\n"})
-	toolByName := mapToolsByName(NewCoreTools(session.Host(), ""))
+	toolByName := mapToolsByName(NewCoreTools(session.Host(), "", "/docs"))
 
 	readResult, err := toolByName["read"].Execute(ctx, map[string]any{"path": "notes.txt"})
 	if err != nil {
@@ -113,7 +113,7 @@ func TestNewCoreToolsBoxshReadPaginationAndEditPreflightAcrossPages(t *testing.T
 	defer cancel()
 
 	session, _ := newBoxshToolTestSession(t, ctx, map[string]string{"long.txt": "needle line1\nline2\nline3\nline4\nneedle line5\n"})
-	toolByName := mapToolsByName(NewCoreTools(session.Host(), ""))
+	toolByName := mapToolsByName(NewCoreTools(session.Host(), "", "/docs"))
 
 	readResult, err := toolByName["read"].Execute(ctx, map[string]any{"path": "long.txt"})
 	if err != nil {

--- a/internal/sandbox/tools_test.go
+++ b/internal/sandbox/tools_test.go
@@ -32,7 +32,7 @@ func TestNewCoreToolsLocalParity(t *testing.T) {
 	})
 	defer func() { _ = session.Close() }()
 
-	toolByName := mapToolsByName(NewCoreTools(session.Host(), binDir))
+	toolByName := mapToolsByName(NewCoreTools(session.Host(), binDir, workspace))
 
 	writeResult, err := toolByName["write"].Execute(context.Background(), map[string]any{
 		"path":    "nested/notes.txt",
@@ -78,6 +78,36 @@ func TestNewCoreToolsLocalParity(t *testing.T) {
 	}
 }
 
+func TestNewCoreToolsFallsBackToHostWorkingDirWithoutProjectRoot(t *testing.T) {
+	workspace := t.TempDir()
+	session := mustCreateLocalSession(t, Policy{
+		Backend:    "local",
+		Relaxed:    true,
+		Filesystem: FilesystemPolicy{WorkspaceRoot: workspace, WorkingDir: workspace},
+		Process:    ProcessPolicy{InheritEnv: true},
+	})
+	defer func() { _ = session.Close() }()
+
+	toolByName := mapToolsByName(NewCoreTools(session.Host(), "", ""))
+	if _, err := toolByName["write"].Execute(context.Background(), map[string]any{"path": "fallback.txt", "content": "hello"}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	readResult, err := toolByName["read"].Execute(context.Background(), map[string]any{"path": "fallback.txt"})
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(readResult, "hello") {
+		t.Fatalf("unexpected read result: %q", readResult)
+	}
+	bashResult, err := toolByName["bash"].Execute(context.Background(), map[string]any{"command": "pwd"})
+	if err != nil {
+		t.Fatalf("bash: %v", err)
+	}
+	if !strings.Contains(bashResult, workspace) {
+		t.Fatalf("expected bash to use host working dir, got %q", bashResult)
+	}
+}
+
 func TestNewCoreToolsReadRejectsBinaryFiles(t *testing.T) {
 	workspace := t.TempDir()
 	session := mustCreateLocalSession(t, Policy{
@@ -87,7 +117,7 @@ func TestNewCoreToolsReadRejectsBinaryFiles(t *testing.T) {
 	})
 	defer func() { _ = session.Close() }()
 
-	toolByName := mapToolsByName(NewCoreTools(session.Host(), ""))
+	toolByName := mapToolsByName(NewCoreTools(session.Host(), "", workspace))
 	path := filepath.Join(workspace, "blob.bin")
 	if err := os.WriteFile(path, []byte{0, 1, 2, 3}, 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
@@ -108,7 +138,7 @@ func TestNewCoreToolsReadLongFirstLineWithLimitKeepsContinuationAccurate(t *test
 	})
 	defer func() { _ = session.Close() }()
 
-	toolByName := mapToolsByName(NewCoreTools(session.Host(), ""))
+	toolByName := mapToolsByName(NewCoreTools(session.Host(), "", workspace))
 	path := filepath.Join(workspace, "long.txt")
 	longLine := strings.Repeat("a", 60*1024)
 	if err := os.WriteFile(path, []byte(longLine+"\nline2\nline3\n"), 0o644); err != nil {
@@ -137,7 +167,7 @@ func TestNewCoreToolsEditRequiresUniqueMatch(t *testing.T) {
 	})
 	defer func() { _ = session.Close() }()
 
-	toolByName := mapToolsByName(NewCoreTools(session.Host(), ""))
+	toolByName := mapToolsByName(NewCoreTools(session.Host(), "", workspace))
 	path := filepath.Join(workspace, "notes.txt")
 	if err := os.WriteFile(path, []byte("same\nsame\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
@@ -162,7 +192,7 @@ func TestNewCoreToolsBashTimeout(t *testing.T) {
 	})
 	defer func() { _ = session.Close() }()
 
-	toolByName := mapToolsByName(NewCoreTools(session.Host(), ""))
+	toolByName := mapToolsByName(NewCoreTools(session.Host(), "", workspace))
 	result, err := toolByName["bash"].Execute(context.Background(), map[string]any{
 		"command": "sleep 2",
 		"timeout": 1,

--- a/pkg/plugins/context.go
+++ b/pkg/plugins/context.go
@@ -9,23 +9,29 @@ import (
 	"github.com/vaayne/anna/pkg/channel"
 )
 
-// ToolContext is the narrow build context for tool capabilities.
-// Execution paths are UserRoot + WorkDir. Discovery/config paths are AnnaHome,
-// AgentRoot, and ProjectRoot.
-type ToolContext struct {
-	Platform Platform
-	// WorkDir is the runtime working directory for tool execution. It is inside UserRoot.
-	WorkDir string
-	// ProjectRoot is optional project-scoped discovery context for local/project-attached runs.
-	ProjectRoot string
-	// UserRoot is the runtime writable root and sandbox HOME for tool execution.
-	UserRoot string
-	// AnnaHome is the app/runtime home used for builtin assets and shared state.
-	AnnaHome string
-	// AgentRoot is the agent-scoped discovery root, not the sandbox writable root.
-	AgentRoot   string
+// ExecutionContext is the runtime execution scope exposed to tools.
+// WorkDir is always inside UserRoot, and ToolsBinDir is prepended to PATH when needed.
+type ExecutionContext struct {
+	WorkDir     string
+	UserRoot    string
 	ToolsBinDir string
-	Runtime     ToolRuntime
+}
+
+// DiscoveryContext is the filesystem discovery scope exposed to tools.
+// These paths control where tools look for assets/config, not where they execute.
+type DiscoveryContext struct {
+	AnnaHome    string
+	AgentRoot   string
+	ProjectRoot string
+	UserRoot    string
+}
+
+// ToolContext is the narrow build context for tool capabilities.
+type ToolContext struct {
+	Platform  Platform
+	Execution ExecutionContext
+	Discovery DiscoveryContext
+	Runtime   ToolRuntime
 }
 
 // ProviderContext is the narrow build context for provider capabilities.

--- a/pkg/plugins/context.go
+++ b/pkg/plugins/context.go
@@ -11,14 +11,14 @@ import (
 
 // ToolPaths is the tool-facing session path surface.
 // UserRoot is the writable execution root and process HOME.
-// WorkDir must stay within UserRoot. AnnaHome, AgentRoot, and ProjectRoot are discovery roots.
+// ProjectRoot is the tool-facing current-project directory; relative paths in project-aware tools
+// resolve against it. AnnaHome and AgentRoot are discovery roots.
 type ToolPaths struct {
 	UserRoot    string
-	WorkDir     string
 	ToolsBinDir string
 	AnnaHome    string
 	AgentRoot   string
-	ProjectRoot string
+	ProjectRoot string // tool-facing project root for relative path resolution
 }
 
 // ToolContext is the narrow build context for tool capabilities.

--- a/pkg/plugins/context.go
+++ b/pkg/plugins/context.go
@@ -9,29 +9,23 @@ import (
 	"github.com/vaayne/anna/pkg/channel"
 )
 
-// ExecutionContext is the runtime execution scope exposed to tools.
-// WorkDir is always inside UserRoot, and ToolsBinDir is prepended to PATH when needed.
-type ExecutionContext struct {
-	WorkDir     string
+// ToolPaths is the tool-facing session path surface.
+// UserRoot is the writable execution root and process HOME.
+// WorkDir must stay within UserRoot. AnnaHome, AgentRoot, and ProjectRoot are discovery roots.
+type ToolPaths struct {
 	UserRoot    string
+	WorkDir     string
 	ToolsBinDir string
-}
-
-// DiscoveryContext is the filesystem discovery scope exposed to tools.
-// These paths control where tools look for assets/config, not where they execute.
-type DiscoveryContext struct {
 	AnnaHome    string
 	AgentRoot   string
 	ProjectRoot string
-	UserRoot    string
 }
 
 // ToolContext is the narrow build context for tool capabilities.
 type ToolContext struct {
-	Platform  Platform
-	Execution ExecutionContext
-	Discovery DiscoveryContext
-	Runtime   ToolRuntime
+	Platform Platform
+	Paths    ToolPaths
+	Runtime  ToolRuntime
 }
 
 // ProviderContext is the narrow build context for provider capabilities.

--- a/pkg/tools/coreargs.go
+++ b/pkg/tools/coreargs.go
@@ -1,6 +1,9 @@
 package tools
 
-import "path/filepath"
+import (
+	"fmt"
+	"path/filepath"
+)
 
 // StringArg returns the first non-empty string value found for the provided keys.
 func StringArg(args map[string]any, keys ...string) string {
@@ -25,4 +28,19 @@ func ResolvePath(workDir, path string) (string, error) {
 		return filepath.Abs(path)
 	}
 	return filepath.Abs(filepath.Join(workDir, path))
+}
+
+// ResolveProjectPath resolves path relative to projectRoot when it is not already absolute.
+// Relative paths require a non-empty project root.
+func ResolveProjectPath(projectRoot, path string) (string, error) {
+	if path == "" {
+		path = "."
+	}
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path), nil
+	}
+	if projectRoot == "" {
+		return "", fmt.Errorf("relative path %q requires a project root", path)
+	}
+	return filepath.Abs(filepath.Join(projectRoot, path))
 }

--- a/plugins/tools/bash/bash.go
+++ b/plugins/tools/bash/bash.go
@@ -32,7 +32,7 @@ func init() {
 			Description: "Execute bash commands.",
 			Required:    true,
 			Build: func(ctx pkgplugins.ToolContext) (tools.Tool, error) {
-				return NewBashTool(ctx.Execution.WorkDir, ctx.Execution.ToolsBinDir), nil
+				return NewBashTool(ctx.Paths.WorkDir, ctx.Paths.ToolsBinDir), nil
 			},
 		})
 	}))

--- a/plugins/tools/bash/bash.go
+++ b/plugins/tools/bash/bash.go
@@ -32,7 +32,7 @@ func init() {
 			Description: "Execute bash commands.",
 			Required:    true,
 			Build: func(ctx pkgplugins.ToolContext) (tools.Tool, error) {
-				return NewBashTool(ctx.WorkDir, ctx.ToolsBinDir), nil
+				return NewBashTool(ctx.Execution.WorkDir, ctx.Execution.ToolsBinDir), nil
 			},
 		})
 	}))

--- a/plugins/tools/bash/bash.go
+++ b/plugins/tools/bash/bash.go
@@ -32,7 +32,7 @@ func init() {
 			Description: "Execute bash commands.",
 			Required:    true,
 			Build: func(ctx pkgplugins.ToolContext) (tools.Tool, error) {
-				return NewBashTool(ctx.Paths.WorkDir, ctx.Paths.ToolsBinDir), nil
+				return NewBashTool(ctx.Paths.ProjectRoot, ctx.Paths.ToolsBinDir), nil
 			},
 		})
 	}))
@@ -40,14 +40,15 @@ func init() {
 
 // BashTool executes bash commands.
 type BashTool struct {
-	workDir string
-	binDir  string
+	projectRoot string
+	binDir      string
 }
 
-// NewBashTool creates a BashTool with the given working directory and
+// NewBashTool creates a BashTool with the given project root and
 // optional tools bin directory (prepended to PATH).
-func NewBashTool(workDir, binDir string) *BashTool {
-	return &BashTool{workDir: workDir, binDir: binDir}
+// If projectRoot is empty, commands run with no explicit working directory.
+func NewBashTool(projectRoot, binDir string) *BashTool {
+	return &BashTool{projectRoot: projectRoot, binDir: binDir}
 }
 
 func (t *BashTool) Definition() tools.Definition {
@@ -89,8 +90,8 @@ func (t *BashTool) Execute(ctx context.Context, args map[string]any) (string, er
 	}
 
 	cmd := exec.CommandContext(execCtx, "bash", "-c", command)
-	if t.workDir != "" {
-		cmd.Dir = t.workDir
+	if t.projectRoot != "" {
+		cmd.Dir = t.projectRoot
 	}
 	cmd.Env = env
 

--- a/plugins/tools/bash/bash_test.go
+++ b/plugins/tools/bash/bash_test.go
@@ -2,6 +2,8 @@ package bash
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -25,6 +27,25 @@ func TestBashTool_SimpleCommand(t *testing.T) {
 	}
 	if !strings.Contains(result, "hello") {
 		t.Errorf("expected 'hello' in output, got %q", result)
+	}
+}
+
+func TestBashTool_UsesProjectRootAsWorkingDirectory(t *testing.T) {
+	projectRoot := t.TempDir()
+	marker := filepath.Join(projectRoot, "marker.txt")
+	if err := os.WriteFile(marker, []byte("ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tool := NewBashTool(projectRoot, "")
+	result, err := tool.Execute(context.Background(), map[string]any{
+		"command": "pwd && test -f marker.txt && echo found",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(result, projectRoot) || !strings.Contains(result, "found") {
+		t.Fatalf("expected command to run in project root, got %q", result)
 	}
 }
 

--- a/plugins/tools/edit/edit.go
+++ b/plugins/tools/edit/edit.go
@@ -28,7 +28,7 @@ func init() {
 			Description: "Edit existing files.",
 			Required:    true,
 			Build: func(ctx pkgplugins.ToolContext) (tools.Tool, error) {
-				return NewEditTool(ctx.Execution.WorkDir), nil
+				return NewEditTool(ctx.Paths.WorkDir), nil
 			},
 		})
 	}))

--- a/plugins/tools/edit/edit.go
+++ b/plugins/tools/edit/edit.go
@@ -28,7 +28,7 @@ func init() {
 			Description: "Edit existing files.",
 			Required:    true,
 			Build: func(ctx pkgplugins.ToolContext) (tools.Tool, error) {
-				return NewEditTool(ctx.WorkDir), nil
+				return NewEditTool(ctx.Execution.WorkDir), nil
 			},
 		})
 	}))

--- a/plugins/tools/edit/edit.go
+++ b/plugins/tools/edit/edit.go
@@ -28,7 +28,7 @@ func init() {
 			Description: "Edit existing files.",
 			Required:    true,
 			Build: func(ctx pkgplugins.ToolContext) (tools.Tool, error) {
-				return NewEditTool(ctx.Paths.WorkDir), nil
+				return NewEditTool(ctx.Paths.ProjectRoot), nil
 			},
 		})
 	}))
@@ -36,11 +36,11 @@ func init() {
 
 // EditTool makes surgical edits to files by exact string replacement.
 type EditTool struct {
-	workDir string
+	projectRoot string
 }
 
-func NewEditTool(workDir string) *EditTool {
-	return &EditTool{workDir: workDir}
+func NewEditTool(projectRoot string) *EditTool {
+	return &EditTool{projectRoot: projectRoot}
 }
 
 func (t *EditTool) Definition() tools.Definition {
@@ -91,7 +91,7 @@ func (t *EditTool) Execute(_ context.Context, args map[string]any) (string, erro
 		return "", fmt.Errorf("edit: oldText is required")
 	}
 
-	path, err := tools.ResolvePath(t.workDir, requestedPath)
+	path, err := tools.ResolveProjectPath(t.projectRoot, requestedPath)
 	if err != nil {
 		return "", fmt.Errorf("edit %s: %w", requestedPath, err)
 	}

--- a/plugins/tools/edit/edit_test.go
+++ b/plugins/tools/edit/edit_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -44,9 +45,9 @@ func TestEditTool_BasicReplace(t *testing.T) {
 	}
 }
 
-func TestEditTool_ResolvesRelativePathFromWorkDir(t *testing.T) {
-	workDir := t.TempDir()
-	path := filepath.Join(workDir, "nested", "file.txt")
+func TestEditTool_ResolvesRelativePathFromProjectRoot(t *testing.T) {
+	projectRoot := t.TempDir()
+	path := filepath.Join(projectRoot, "nested", "file.txt")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -54,7 +55,7 @@ func TestEditTool_ResolvesRelativePathFromWorkDir(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tool := NewEditTool(workDir)
+	tool := NewEditTool(projectRoot)
 	_, err := tool.Execute(context.Background(), map[string]any{
 		"path":       "nested/file.txt",
 		"old_string": "world",
@@ -70,6 +71,18 @@ func TestEditTool_ResolvesRelativePathFromWorkDir(t *testing.T) {
 	}
 	if string(data) != "hello Anna" {
 		t.Fatalf("expected edited content, got %q", string(data))
+	}
+}
+
+func TestEditTool_RejectsRelativePathWithoutProjectRoot(t *testing.T) {
+	tool := NewEditTool("")
+	_, err := tool.Execute(context.Background(), map[string]any{
+		"path":       "relative.txt",
+		"old_string": "x",
+		"new_string": "y",
+	})
+	if err == nil || err.Error() == "" || !strings.Contains(err.Error(), "requires a project root") {
+		t.Fatalf("expected project root error, got %v", err)
 	}
 }
 

--- a/plugins/tools/read/read.go
+++ b/plugins/tools/read/read.go
@@ -29,7 +29,7 @@ func init() {
 			Description: "Read file contents.",
 			Required:    true,
 			Build: func(ctx pkgplugins.ToolContext) (tools.Tool, error) {
-				return NewReadTool(ctx.Execution.WorkDir), nil
+				return NewReadTool(ctx.Paths.WorkDir), nil
 			},
 		})
 	}))

--- a/plugins/tools/read/read.go
+++ b/plugins/tools/read/read.go
@@ -29,7 +29,7 @@ func init() {
 			Description: "Read file contents.",
 			Required:    true,
 			Build: func(ctx pkgplugins.ToolContext) (tools.Tool, error) {
-				return NewReadTool(ctx.Paths.WorkDir), nil
+				return NewReadTool(ctx.Paths.ProjectRoot), nil
 			},
 		})
 	}))
@@ -37,11 +37,11 @@ func init() {
 
 // ReadTool reads file contents.
 type ReadTool struct {
-	workDir string
+	projectRoot string
 }
 
-func NewReadTool(workDir string) *ReadTool {
-	return &ReadTool{workDir: workDir}
+func NewReadTool(projectRoot string) *ReadTool {
+	return &ReadTool{projectRoot: projectRoot}
 }
 
 func (t *ReadTool) Definition() tools.Definition {
@@ -75,7 +75,7 @@ func (t *ReadTool) Execute(_ context.Context, args map[string]any) (string, erro
 		return "", fmt.Errorf("read: path is required")
 	}
 
-	path, err := tools.ResolvePath(t.workDir, requestedPath)
+	path, err := tools.ResolveProjectPath(t.projectRoot, requestedPath)
 	if err != nil {
 		return "", fmt.Errorf("read %s: %w", requestedPath, err)
 	}

--- a/plugins/tools/read/read.go
+++ b/plugins/tools/read/read.go
@@ -29,7 +29,7 @@ func init() {
 			Description: "Read file contents.",
 			Required:    true,
 			Build: func(ctx pkgplugins.ToolContext) (tools.Tool, error) {
-				return NewReadTool(ctx.WorkDir), nil
+				return NewReadTool(ctx.Execution.WorkDir), nil
 			},
 		})
 	}))

--- a/plugins/tools/read/read_test.go
+++ b/plugins/tools/read/read_test.go
@@ -35,9 +35,9 @@ func TestReadTool_BasicRead(t *testing.T) {
 	}
 }
 
-func TestReadTool_ResolvesRelativePathFromWorkDir(t *testing.T) {
-	workDir := t.TempDir()
-	path := filepath.Join(workDir, "nested", "file.txt")
+func TestReadTool_ResolvesRelativePathFromProjectRoot(t *testing.T) {
+	projectRoot := t.TempDir()
+	path := filepath.Join(projectRoot, "nested", "file.txt")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -45,7 +45,7 @@ func TestReadTool_ResolvesRelativePathFromWorkDir(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tool := NewReadTool(workDir)
+	tool := NewReadTool(projectRoot)
 	result, err := tool.Execute(context.Background(), map[string]any{
 		"path": "nested/file.txt",
 	})
@@ -110,6 +110,16 @@ func TestReadTool_MissingPath(t *testing.T) {
 	_, err := tool.Execute(context.Background(), map[string]any{})
 	if err == nil {
 		t.Error("expected error when path is missing")
+	}
+}
+
+func TestReadTool_RejectsRelativePathWithoutProjectRoot(t *testing.T) {
+	tool := NewReadTool("")
+	_, err := tool.Execute(context.Background(), map[string]any{
+		"path": "relative.txt",
+	})
+	if err == nil || !strings.Contains(err.Error(), "requires a project root") {
+		t.Fatalf("expected project root error, got %v", err)
 	}
 }
 

--- a/plugins/tools/registry.go
+++ b/plugins/tools/registry.go
@@ -2,15 +2,26 @@ package plugintools
 
 import pkgplugins "github.com/vaayne/anna/pkg/plugins"
 
-// BuildContext carries per-session configuration for tool construction.
-// Execution uses UserRoot + WorkDir. AnnaHome, AgentRoot, and ProjectRoot are
-// discovery/config inputs and do not redefine the writable root.
-type BuildContext struct {
+// ExecutionContext carries runtime execution paths for tool construction.
+// WorkDir is always inside UserRoot, and ToolsBinDir is prepended to PATH when needed.
+type ExecutionContext struct {
 	WorkDir     string // runtime working directory for tool execution; always inside UserRoot
-	ProjectRoot string // optional project-scoped discovery root for local/project-attached runs
 	UserRoot    string // runtime writable root and sandbox HOME
+	ToolsBinDir string // path to anna tools bin directory (prepended to PATH)
+}
+
+// DiscoveryContext carries filesystem discovery scope for tool construction.
+// These paths are used to locate assets/config and do not redefine the writable root.
+type DiscoveryContext struct {
 	AnnaHome    string // anna home directory for builtin assets and shared state
 	AgentRoot   string // agent-scoped discovery root, not the sandbox writable root
-	ToolsBinDir string // path to anna tools bin directory (prepended to PATH)
-	Runtime     pkgplugins.ToolRuntime
+	ProjectRoot string // optional project-scoped discovery root for local/project-attached runs
+	UserRoot    string // user-scoped discovery root for per-user assets
+}
+
+// BuildContext carries per-session configuration for tool construction.
+type BuildContext struct {
+	Execution ExecutionContext
+	Discovery DiscoveryContext
+	Runtime   pkgplugins.ToolRuntime
 }

--- a/plugins/tools/registry.go
+++ b/plugins/tools/registry.go
@@ -2,26 +2,8 @@ package plugintools
 
 import pkgplugins "github.com/vaayne/anna/pkg/plugins"
 
-// ExecutionContext carries runtime execution paths for tool construction.
-// WorkDir is always inside UserRoot, and ToolsBinDir is prepended to PATH when needed.
-type ExecutionContext struct {
-	WorkDir     string // runtime working directory for tool execution; always inside UserRoot
-	UserRoot    string // runtime writable root and sandbox HOME
-	ToolsBinDir string // path to anna tools bin directory (prepended to PATH)
-}
-
-// DiscoveryContext carries filesystem discovery scope for tool construction.
-// These paths are used to locate assets/config and do not redefine the writable root.
-type DiscoveryContext struct {
-	AnnaHome    string // anna home directory for builtin assets and shared state
-	AgentRoot   string // agent-scoped discovery root, not the sandbox writable root
-	ProjectRoot string // optional project-scoped discovery root for local/project-attached runs
-	UserRoot    string // user-scoped discovery root for per-user assets
-}
-
 // BuildContext carries per-session configuration for tool construction.
 type BuildContext struct {
-	Execution ExecutionContext
-	Discovery DiscoveryContext
-	Runtime   pkgplugins.ToolRuntime
+	Paths   pkgplugins.ToolPaths
+	Runtime pkgplugins.ToolRuntime
 }

--- a/plugins/tools/skills/plugin.go
+++ b/plugins/tools/skills/plugin.go
@@ -29,10 +29,10 @@ func init() {
 			Required:    true,
 			Build: func(ctx pkgplugins.ToolContext) (tools.Tool, error) {
 				return NewTool(
-					ctx.Discovery.AnnaHome,
-					ctx.Discovery.AgentRoot,
-					ctx.Discovery.ProjectRoot,
-					userSkillsDir(ctx.Discovery.UserRoot),
+					ctx.Paths.AnnaHome,
+					ctx.Paths.AgentRoot,
+					ctx.Paths.ProjectRoot,
+					userSkillsDir(ctx.Paths.UserRoot),
 					ctx.Runtime,
 				), nil
 			},

--- a/plugins/tools/skills/plugin.go
+++ b/plugins/tools/skills/plugin.go
@@ -28,7 +28,13 @@ func init() {
 			Description: "Manage local agent skills.",
 			Required:    true,
 			Build: func(ctx pkgplugins.ToolContext) (tools.Tool, error) {
-				return NewTool(ctx.AnnaHome, ctx.AgentRoot, ctx.ProjectRoot, userSkillsDir(ctx.UserRoot), ctx.Runtime), nil
+				return NewTool(
+					ctx.Discovery.AnnaHome,
+					ctx.Discovery.AgentRoot,
+					ctx.Discovery.ProjectRoot,
+					userSkillsDir(ctx.Discovery.UserRoot),
+					ctx.Runtime,
+				), nil
 			},
 		})
 		host.AddSystemPrompt(pkgplugins.SystemPromptSpec{

--- a/plugins/tools/write/write.go
+++ b/plugins/tools/write/write.go
@@ -28,7 +28,7 @@ func init() {
 			Description: "Write complete file contents.",
 			Required:    true,
 			Build: func(ctx pkgplugins.ToolContext) (tools.Tool, error) {
-				return NewWriteTool(ctx.WorkDir), nil
+				return NewWriteTool(ctx.Execution.WorkDir), nil
 			},
 		})
 	}))

--- a/plugins/tools/write/write.go
+++ b/plugins/tools/write/write.go
@@ -28,7 +28,7 @@ func init() {
 			Description: "Write complete file contents.",
 			Required:    true,
 			Build: func(ctx pkgplugins.ToolContext) (tools.Tool, error) {
-				return NewWriteTool(ctx.Paths.WorkDir), nil
+				return NewWriteTool(ctx.Paths.ProjectRoot), nil
 			},
 		})
 	}))
@@ -36,11 +36,11 @@ func init() {
 
 // WriteTool creates new files or completely overwrites existing ones.
 type WriteTool struct {
-	workDir string
+	projectRoot string
 }
 
-func NewWriteTool(workDir string) *WriteTool {
-	return &WriteTool{workDir: workDir}
+func NewWriteTool(projectRoot string) *WriteTool {
+	return &WriteTool{projectRoot: projectRoot}
 }
 
 func (t *WriteTool) Definition() tools.Definition {
@@ -72,7 +72,7 @@ func (t *WriteTool) Execute(_ context.Context, args map[string]any) (string, err
 		return "", fmt.Errorf("write: path is required")
 	}
 
-	path, err := tools.ResolvePath(t.workDir, requestedPath)
+	path, err := tools.ResolveProjectPath(t.projectRoot, requestedPath)
 	if err != nil {
 		return "", fmt.Errorf("write %s: %w", requestedPath, err)
 	}

--- a/plugins/tools/write/write.go
+++ b/plugins/tools/write/write.go
@@ -28,7 +28,7 @@ func init() {
 			Description: "Write complete file contents.",
 			Required:    true,
 			Build: func(ctx pkgplugins.ToolContext) (tools.Tool, error) {
-				return NewWriteTool(ctx.Execution.WorkDir), nil
+				return NewWriteTool(ctx.Paths.WorkDir), nil
 			},
 		})
 	}))

--- a/plugins/tools/write/write_test.go
+++ b/plugins/tools/write/write_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -42,9 +43,9 @@ func TestWriteTool_CreateNewFile(t *testing.T) {
 	}
 }
 
-func TestWriteTool_ResolvesRelativePathFromWorkDir(t *testing.T) {
-	workDir := t.TempDir()
-	tool := NewWriteTool(workDir)
+func TestWriteTool_ResolvesRelativePathFromProjectRoot(t *testing.T) {
+	projectRoot := t.TempDir()
+	tool := NewWriteTool(projectRoot)
 
 	_, err := tool.Execute(context.Background(), map[string]any{
 		"path":    "nested/file.txt",
@@ -54,12 +55,23 @@ func TestWriteTool_ResolvesRelativePathFromWorkDir(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	data, err := os.ReadFile(filepath.Join(workDir, "nested", "file.txt"))
+	data, err := os.ReadFile(filepath.Join(projectRoot, "nested", "file.txt"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if string(data) != "hello" {
 		t.Fatalf("expected written content, got %q", string(data))
+	}
+}
+
+func TestWriteTool_RejectsRelativePathWithoutProjectRoot(t *testing.T) {
+	tool := NewWriteTool("")
+	_, err := tool.Execute(context.Background(), map[string]any{
+		"path":    "nested/file.txt",
+		"content": "hello",
+	})
+	if err == nil || !strings.Contains(err.Error(), "requires a project root") {
+		t.Fatalf("expected project root error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- replace flat top-level tool/build path fields with a single `Paths` surface
- update plugin host wiring and tool builders to use `ctx.Paths.*`
- refresh plugin docs to match the simpler `ToolContext` shape

## Details
This is a behavior-preserving follow-up to the sandbox path cleanup merged in #100.

I first tried splitting tool-facing paths into `Execution` and `Discovery`, but that added structure without making the API easier to understand. This version flattens the tool path surface back down to one concept:

- `Platform`
- `Paths`
- `Runtime`

`Paths` contains:
- `UserRoot`
- `WorkDir`
- `ToolsBinDir`
- `AnnaHome`
- `AgentRoot`
- `ProjectRoot`

That keeps current semantics intact while removing the extra `Execution` / `Discovery` taxonomy and the duplicate `UserRoot` concept.

## Affected areas
- `pkg/plugins/context.go`
- `plugins/tools/registry.go`
- `internal/pluginhost/builders.go`
- `internal/agent/runner/gorunner.go`
- core tool builders under `plugins/tools/*`
- plugin docs under `docs/content/docs/plugins/`

## Validation
- `mise run format`
- `mise run test`

## Follow-up
A natural next step after this is replacing raw discovery-related paths inside `Paths` with a resolver/service-style discovery API where that actually improves tool ergonomics.