### PR TITLE
♻️ refactor: align sandbox user root with skill path layers

### DIFF
--- a/internal/agent/factory.go
+++ b/internal/agent/factory.go
@@ -89,9 +89,6 @@ func NewRunnerFactory(snap *config.Snapshot, extraTools []tools.Tool, pluginTool
 				PromptSections: promptSections,
 			})
 
-			// Runner execution is always user-scoped, so tools start in the user root.
-			workDir := userRoot
-
 			// Resolve hooks from RunnerParams — injected by Pool, not the factory.
 			var hookPlugins []hooks.HookPlugin
 			if params.HooksFn != nil {
@@ -109,7 +106,6 @@ func NewRunnerFactory(snap *config.Snapshot, extraTools []tools.Tool, pluginTool
 				PromptSections: promptSections,
 				ExtraTools:     extraTools,
 				PluginTools:    pluginToolsBuilder,
-				WorkDir:        workDir,
 				UserRoot:       userRoot,
 				Sandbox:        snap.Sandbox,
 				HookPlugins:    hookPlugins,

--- a/internal/agent/runner/gorunner.go
+++ b/internal/agent/runner/gorunner.go
@@ -35,7 +35,6 @@ type GoRunnerConfig struct {
 	Model          string // e.g. "claude-sonnet-4-20250514"
 	APIKey         string
 	BaseURL        string // optional provider base URL override
-	WorkDir        string // working directory for tool execution; defaults to UserRoot when empty
 	AgentRoot      string // agent root directory
 	AnnaHome       string // anna home directory (e.g. ~/.anna)
 	ProjectRoot    string // optional project root for project-aware tools and prompt/context loading

--- a/internal/agent/runner/gorunner.go
+++ b/internal/agent/runner/gorunner.go
@@ -38,6 +38,7 @@ type GoRunnerConfig struct {
 	WorkDir        string // working directory for tool execution; defaults to UserRoot when empty
 	AgentRoot      string // agent root directory
 	AnnaHome       string // anna home directory (e.g. ~/.anna)
+	ProjectRoot    string // optional project root for project-aware tools and prompt/context loading
 	System         string // optional system prompt override (bypasses default prompt building)
 	PromptSections []pkgplugins.SystemPromptSection
 	ExtraTools     []tools.Tool // additional tools to register
@@ -115,6 +116,7 @@ func NewGoRunner(ctx context.Context, cfg GoRunnerConfig) (*GoRunner, error) {
 		system = BuildSystemPromptFromDB(context.Background(), DBPromptParams{
 			AnnaHome:       paths.AnnaHome,
 			AgentRoot:      paths.AgentRoot,
+			ProjectRoot:    paths.ProjectRoot,
 			UserRoot:       paths.UserRoot,
 			PromptSections: cfg.PromptSections,
 			Host:           session.Host(),
@@ -224,7 +226,7 @@ func buildToolRegistry(ctx context.Context, cfg GoRunnerConfig, session *runnerS
 			ToolsBinDir: paths.toolsBinDir(),
 			AnnaHome:    paths.AnnaHome,
 			AgentRoot:   paths.AgentRoot,
-			ProjectRoot: "",
+			ProjectRoot: paths.ProjectRoot,
 		},
 		Runtime: cfg.ToolRuntime,
 	}
@@ -251,8 +253,9 @@ func buildToolRegistry(ctx context.Context, cfg GoRunnerConfig, session *runnerS
 }
 
 // buildAgentPresets extracts builtin skills and loads agent presets from filesystem.
-func collectSandboxReadOnlyDirs(toolsBinDir, pathEnv string) []string {
-	dirs := []string{toolsBinDir}
+func collectSandboxReadOnlyDirs(extraDirs []string, toolsBinDir, pathEnv string) []string {
+	dirs := append([]string{}, extraDirs...)
+	dirs = append(dirs, toolsBinDir)
 	for _, dir := range filepath.SplitList(pathEnv) {
 		if dir == "" || !filepath.IsAbs(dir) {
 			continue
@@ -273,7 +276,7 @@ func buildAgentPresets(cfg GoRunnerConfig) *agenttool.PresetRegistry {
 		AnnaHome:         paths.AnnaHome,
 		AgentRoot:        paths.AgentRoot,
 		UserRoot:         paths.UserRoot,
-		ProjectRoot:      "",
+		ProjectRoot:      paths.ProjectRoot,
 		BuiltinSkillsDir: paths.builtinSkillsDir(),
 		Runtime:          cfg.ToolRuntime,
 	}))

--- a/internal/agent/runner/gorunner_integration_test.go
+++ b/internal/agent/runner/gorunner_integration_test.go
@@ -33,7 +33,7 @@ func integrationConfig(t *testing.T) GoRunnerConfig {
 	}
 	annaHome := t.TempDir()
 	workspace := t.TempDir()
-	userRoot := workspace + "/users/1/data"
+	userRoot := workspace + "/users/1"
 	if err := os.MkdirAll(userRoot, 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}

--- a/internal/agent/runner/gorunner_test.go
+++ b/internal/agent/runner/gorunner_test.go
@@ -92,9 +92,6 @@ func withTestRunnerPaths(t *testing.T, cfg GoRunnerConfig) GoRunnerConfig {
 	cfg.AnnaHome = annaHome
 	cfg.AgentRoot = workspace
 	cfg.UserRoot = userRoot
-	if cfg.WorkDir == "" {
-		cfg.WorkDir = userRoot
-	}
 	return cfg
 }
 
@@ -452,7 +449,6 @@ func (f *sequentialFakeProvider) StreamSimple(goCtx context.Context, _ ai.Model,
 }
 
 func TestChatToolUseLoop(t *testing.T) {
-	dir := t.TempDir()
 	fp := &sequentialFakeProvider{
 		api: "anthropic",
 		rounds: [][]ai.AssistantEvent{
@@ -474,7 +470,6 @@ func TestChatToolUseLoop(t *testing.T) {
 		APIKey:    "test-key",
 		Providers: testProviderRegistryBuilder,
 	})
-	cfg.WorkDir = filepath.Join(cfg.UserRoot, filepath.Base(dir))
 	r, err := NewGoRunner(context.Background(), cfg)
 	if err != nil {
 		t.Fatalf("NewGoRunner: %v", err)

--- a/internal/agent/runner/gorunner_test.go
+++ b/internal/agent/runner/gorunner_test.go
@@ -44,7 +44,7 @@ func testRunnerPaths(t *testing.T) (annaHome, workspace, userRoot string) {
 	}
 	annaHome = t.TempDir()
 	workspace = t.TempDir()
-	userRoot = filepath.Join(workspace, "users", "1", "data")
+	userRoot = filepath.Join(workspace, "users", "1")
 	if err := os.MkdirAll(userRoot, 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
@@ -147,7 +147,7 @@ func TestNewGoRunnerPreflightExtractsManagedTools(t *testing.T) {
 	}
 	annaHome := t.TempDir()
 	workspace := t.TempDir()
-	userRoot := filepath.Join(workspace, "users", "1", "data")
+	userRoot := filepath.Join(workspace, "users", "1")
 	if err := os.MkdirAll(userRoot, 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
@@ -178,7 +178,7 @@ func TestNewGoRunnerUsesBoxshCoreToolsAndCleansUp(t *testing.T) {
 
 	annaHome := t.TempDir()
 	workspace := t.TempDir()
-	userRoot := filepath.Join(workspace, "users", "1", "data")
+	userRoot := filepath.Join(workspace, "users", "1")
 	if err := os.MkdirAll(userRoot, 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
@@ -236,7 +236,7 @@ func TestGoRunnerAliveTracksDeadBoxshBackend(t *testing.T) {
 
 	annaHome := t.TempDir()
 	workspace := t.TempDir()
-	userRoot := filepath.Join(workspace, "users", "1", "data")
+	userRoot := filepath.Join(workspace, "users", "1")
 	if err := os.MkdirAll(userRoot, 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}

--- a/internal/agent/runner/paths.go
+++ b/internal/agent/runner/paths.go
@@ -3,7 +3,6 @@ package runner
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/vaayne/anna/internal/config"
 	"github.com/vaayne/anna/internal/embedded"
@@ -16,12 +15,11 @@ type runnerPaths struct {
 	AgentRoot   string
 	UserRoot    string
 	ProjectRoot string
-	WorkDir     string
 }
 
 // sandboxPaths is the minimal path set sandbox policy creation depends on.
-// Sandbox execution is defined entirely by the user-scoped writable root and a
-// working directory constrained to that root.
+// Sandbox execution is defined entirely by the user-scoped writable root and an
+// internal working directory derived from that root.
 type sandboxPaths struct {
 	AnnaHome string
 	UserRoot string
@@ -38,8 +36,11 @@ func resolveRunnerPaths(cfg GoRunnerConfig) runnerPaths {
 		AgentRoot:   cfg.AgentRoot,
 		UserRoot:    paths.UserRoot,
 		ProjectRoot: cfg.ProjectRoot,
-		WorkDir:     paths.WorkDir,
 	}
+}
+
+func resolveSandboxWorkingDir(cfg GoRunnerConfig, userRoot string) string {
+	return userRoot
 }
 
 func resolveSandboxPaths(cfg GoRunnerConfig) (sandboxPaths, error) {
@@ -55,18 +56,7 @@ func resolveSandboxPaths(cfg GoRunnerConfig) (sandboxPaths, error) {
 	if err != nil {
 		return sandboxPaths{}, fmt.Errorf("resolve user_root: %w", err)
 	}
-	workDir := cfg.WorkDir
-	if workDir == "" {
-		workDir = userRoot
-	}
-	if !filepath.IsAbs(workDir) {
-		workDir = filepath.Join(userRoot, workDir)
-	}
-	workDir = filepath.Clean(workDir)
-
-	if !isWithinPathRoot(userRoot, workDir) {
-		return sandboxPaths{}, fmt.Errorf("work_dir %q must stay within user_root %q", workDir, userRoot)
-	}
+	workDir := resolveSandboxWorkingDir(cfg, userRoot)
 
 	return sandboxPaths{
 		AnnaHome: annaHome,
@@ -122,12 +112,4 @@ func sandboxProcessEnv(paths sandboxPaths) map[string]string {
 		env["ANNA_HOME"] = paths.AnnaHome
 	}
 	return env
-}
-
-func isWithinPathRoot(root, path string) bool {
-	rel, err := filepath.Rel(root, path)
-	if err != nil {
-		return false
-	}
-	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }

--- a/internal/agent/runner/paths.go
+++ b/internal/agent/runner/paths.go
@@ -12,10 +12,11 @@ import (
 // runnerPaths keeps only the runner's primary inputs.
 // Everything else used by the runner is derived from these values.
 type runnerPaths struct {
-	AnnaHome  string
-	AgentRoot string
-	UserRoot  string
-	WorkDir   string
+	AnnaHome    string
+	AgentRoot   string
+	UserRoot    string
+	ProjectRoot string
+	WorkDir     string
 }
 
 // sandboxPaths is the minimal path set sandbox policy creation depends on.
@@ -33,10 +34,11 @@ type sandboxPaths struct {
 func resolveRunnerPaths(cfg GoRunnerConfig) runnerPaths {
 	paths, _ := resolveSandboxPaths(cfg)
 	return runnerPaths{
-		AnnaHome:  paths.AnnaHome,
-		AgentRoot: cfg.AgentRoot,
-		UserRoot:  paths.UserRoot,
-		WorkDir:   paths.WorkDir,
+		AnnaHome:    paths.AnnaHome,
+		AgentRoot:   cfg.AgentRoot,
+		UserRoot:    paths.UserRoot,
+		ProjectRoot: cfg.ProjectRoot,
+		WorkDir:     paths.WorkDir,
 	}
 }
 
@@ -76,6 +78,36 @@ func resolveSandboxPaths(cfg GoRunnerConfig) (sandboxPaths, error) {
 func (p runnerPaths) toolsBinDir() string { return embedded.BinDir(p.AnnaHome) }
 func (p runnerPaths) builtinSkillsDir() string {
 	return filepath.Join(p.AnnaHome, "cache", "builtin-skills")
+}
+
+func (p runnerPaths) annaSkillsDir() string {
+	return filepath.Join(p.AnnaHome, "skills")
+}
+
+func (p runnerPaths) annaAgentsDir() string {
+	return filepath.Join(p.AnnaHome, "agents")
+}
+
+func (p runnerPaths) agentSkillsDir() string {
+	return filepath.Join(p.AgentRoot, "skills")
+}
+
+func (p runnerPaths) agentAgentsDir() string {
+	return filepath.Join(p.AgentRoot, "agents")
+}
+
+func (p runnerPaths) projectSkillsDir() string {
+	if p.ProjectRoot == "" {
+		return ""
+	}
+	return filepath.Join(p.ProjectRoot, ".agents", "skills")
+}
+
+func (p runnerPaths) projectAgentsDir() string {
+	if p.ProjectRoot == "" {
+		return ""
+	}
+	return filepath.Join(p.ProjectRoot, ".agents", "agents")
 }
 
 // sandboxProcessEnv builds the baseline process environment injected into

--- a/internal/agent/runner/sandbox_backend.go
+++ b/internal/agent/runner/sandbox_backend.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/vaayne/anna/internal/config"
 	"github.com/vaayne/anna/internal/sandbox"
@@ -195,7 +197,7 @@ func resolveSession(ctx context.Context, cfg GoRunnerConfig) (*runnerSession, er
 }
 
 func sandboxReadableDirs(paths runnerPaths) []string {
-	return []string{
+	candidates := []string{
 		paths.builtinSkillsDir(),
 		paths.annaSkillsDir(),
 		paths.annaAgentsDir(),
@@ -204,6 +206,26 @@ func sandboxReadableDirs(paths runnerPaths) []string {
 		paths.projectSkillsDir(),
 		paths.projectAgentsDir(),
 	}
+
+	readOnly := make([]string, 0, len(candidates))
+	for _, dir := range candidates {
+		if dir == "" || isWithinPathRoot(paths.UserRoot, dir) {
+			continue
+		}
+		readOnly = append(readOnly, dir)
+	}
+	return readOnly
+}
+
+func isWithinPathRoot(root, path string) bool {
+	if root == "" || path == "" {
+		return false
+	}
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }
 
 func resolveSessionBackendName(cfg config.SandboxConfig) string {

--- a/internal/agent/runner/sandbox_backend.go
+++ b/internal/agent/runner/sandbox_backend.go
@@ -147,10 +147,10 @@ func createBoxshSession(ctx context.Context, cfg GoRunnerConfig) (*runnerSession
 		return nil, fmt.Errorf("resolve sandbox paths: %w", err)
 	}
 	readOnlyDirs := collectSandboxReadOnlyDirs(
+		sandboxReadableDirs(runnerPaths),
 		runnerPaths.toolsBinDir(),
 		os.Getenv("PATH"),
 	)
-	readOnlyDirs = append(readOnlyDirs, runnerPaths.builtinSkillsDir())
 
 	policy := sandbox.Policy{
 		Backend:    config.SandboxBackendBoxsh,
@@ -192,6 +192,18 @@ func resolveSession(ctx context.Context, cfg GoRunnerConfig) (*runnerSession, er
 		return nil, fmt.Errorf("unknown sandbox backend: %q", name)
 	}
 	return factory(ctx, cfg)
+}
+
+func sandboxReadableDirs(paths runnerPaths) []string {
+	return []string{
+		paths.builtinSkillsDir(),
+		paths.annaSkillsDir(),
+		paths.annaAgentsDir(),
+		paths.agentSkillsDir(),
+		paths.agentAgentsDir(),
+		paths.projectSkillsDir(),
+		paths.projectAgentsDir(),
+	}
 }
 
 func resolveSessionBackendName(cfg config.SandboxConfig) string {

--- a/internal/agent/runner/sandbox_backend_test.go
+++ b/internal/agent/runner/sandbox_backend_test.go
@@ -30,7 +30,6 @@ func TestResolveSessionAutoFallsBackToLocalWhenBoxshUnsupported(t *testing.T) {
 	rs, err := resolveSession(context.Background(), GoRunnerConfig{
 		AgentRoot: workspace,
 		UserRoot:  userRoot,
-		WorkDir:   ".",
 		Sandbox: config.SandboxConfig{
 			Backend: config.SandboxBackendAuto,
 		},
@@ -67,34 +66,11 @@ func TestResolveRunnerPathsDefaultsWorkDirToUserRoot(t *testing.T) {
 	}
 
 	paths := resolveRunnerPaths(cfg)
-	if paths.WorkDir != cfg.UserRoot {
-		t.Fatalf("WorkDir = %q, want %q", paths.WorkDir, cfg.UserRoot)
+	if got := resolveSandboxWorkingDir(cfg, cfg.UserRoot); got != cfg.UserRoot {
+		t.Fatalf("resolveSandboxWorkingDir() = %q, want %q", got, cfg.UserRoot)
 	}
-}
-
-func TestResolveSandboxPathsJoinsRelativeWorkDirToUserRoot(t *testing.T) {
-	cfg := GoRunnerConfig{
-		AnnaHome: "/anna",
-		UserRoot: "/workspace/agent/users/1",
-		WorkDir:  "logs",
-	}
-
-	paths, err := resolveSandboxPaths(cfg)
-	if err != nil {
-		t.Fatalf("resolveSandboxPaths: %v", err)
-	}
-	if want := "/workspace/agent/users/1/logs"; paths.WorkDir != want {
-		t.Fatalf("WorkDir = %q, want %q", paths.WorkDir, want)
-	}
-}
-
-func TestResolveSandboxPathsRejectsWorkDirOutsideUserRoot(t *testing.T) {
-	_, err := resolveSandboxPaths(GoRunnerConfig{
-		UserRoot: "/workspace/agent/users/1",
-		WorkDir:  "/workspace/agent",
-	})
-	if err == nil {
-		t.Fatal("expected error for workdir outside user root")
+	if paths.UserRoot != cfg.UserRoot {
+		t.Fatalf("UserRoot = %q, want %q", paths.UserRoot, cfg.UserRoot)
 	}
 }
 

--- a/internal/agent/runner/sandbox_backend_test.go
+++ b/internal/agent/runner/sandbox_backend_test.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/vaayne/anna/internal/config"
@@ -118,6 +119,22 @@ func TestSandboxReadableDirsIncludesSkillAndPresetRoots(t *testing.T) {
 	for i := range want {
 		if got[i] != want[i] {
 			t.Fatalf("got[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestSandboxReadableDirsSkipsProjectPathsInsideUserRoot(t *testing.T) {
+	paths := runnerPaths{
+		AnnaHome:    "/anna",
+		AgentRoot:   "/workspace/agent",
+		UserRoot:    "/workspace/agent/users/1",
+		ProjectRoot: "/workspace/agent/users/1/data/repo",
+	}
+
+	got := sandboxReadableDirs(paths)
+	for _, dir := range got {
+		if strings.HasPrefix(dir, "/workspace/agent/users/1/data/repo/") {
+			t.Fatalf("project path %q should not be mounted read-only inside user root", dir)
 		}
 	}
 }

--- a/internal/agent/runner/sandbox_backend_test.go
+++ b/internal/agent/runner/sandbox_backend_test.go
@@ -26,7 +26,7 @@ func TestResolveSessionAutoFallsBackToLocalWhenBoxshUnsupported(t *testing.T) {
 	t.Cleanup(func() { platformSupportsBoxsh = previous })
 
 	workspace := t.TempDir()
-	userRoot := workspace + "/users/1/data"
+	userRoot := workspace + "/users/1"
 	rs, err := resolveSession(context.Background(), GoRunnerConfig{
 		AgentRoot: workspace,
 		UserRoot:  userRoot,
@@ -63,7 +63,7 @@ func TestResolveSessionExplicitBoxshRejectsUnsupportedPlatform(t *testing.T) {
 func TestResolveRunnerPathsDefaultsWorkDirToUserRoot(t *testing.T) {
 	cfg := GoRunnerConfig{
 		AgentRoot: "/workspace/agent",
-		UserRoot:  "/workspace/agent/users/1/data",
+		UserRoot:  "/workspace/agent/users/1",
 	}
 
 	paths := resolveRunnerPaths(cfg)
@@ -75,7 +75,7 @@ func TestResolveRunnerPathsDefaultsWorkDirToUserRoot(t *testing.T) {
 func TestResolveSandboxPathsJoinsRelativeWorkDirToUserRoot(t *testing.T) {
 	cfg := GoRunnerConfig{
 		AnnaHome: "/anna",
-		UserRoot: "/workspace/agent/users/1/data",
+		UserRoot: "/workspace/agent/users/1",
 		WorkDir:  "logs",
 	}
 
@@ -83,14 +83,14 @@ func TestResolveSandboxPathsJoinsRelativeWorkDirToUserRoot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveSandboxPaths: %v", err)
 	}
-	if want := "/workspace/agent/users/1/data/logs"; paths.WorkDir != want {
+	if want := "/workspace/agent/users/1/logs"; paths.WorkDir != want {
 		t.Fatalf("WorkDir = %q, want %q", paths.WorkDir, want)
 	}
 }
 
 func TestResolveSandboxPathsRejectsWorkDirOutsideUserRoot(t *testing.T) {
 	_, err := resolveSandboxPaths(GoRunnerConfig{
-		UserRoot: "/workspace/agent/users/1/data",
+		UserRoot: "/workspace/agent/users/1",
 		WorkDir:  "/workspace/agent",
 	})
 	if err == nil {
@@ -102,7 +102,7 @@ func TestSandboxProcessEnvUsesUserRootAsHome(t *testing.T) {
 	cfg := GoRunnerConfig{
 		AnnaHome:  "/anna",
 		AgentRoot: "/workspace/agent",
-		UserRoot:  "/workspace/agent/users/1/data",
+		UserRoot:  "/workspace/agent/users/1",
 	}
 
 	paths, err := resolveSandboxPaths(cfg)
@@ -115,6 +115,34 @@ func TestSandboxProcessEnvUsesUserRootAsHome(t *testing.T) {
 	}
 	if got := env["ANNA_HOME"]; got != cfg.AnnaHome {
 		t.Fatalf("ANNA_HOME = %q, want %q", got, cfg.AnnaHome)
+	}
+}
+
+func TestSandboxReadableDirsIncludesSkillAndPresetRoots(t *testing.T) {
+	paths := runnerPaths{
+		AnnaHome:    "/anna",
+		AgentRoot:   "/workspace/agent",
+		UserRoot:    "/workspace/agent/users/1",
+		ProjectRoot: "/project",
+	}
+
+	got := sandboxReadableDirs(paths)
+	want := []string{
+		"/anna/cache/builtin-skills",
+		"/anna/skills",
+		"/anna/agents",
+		"/workspace/agent/skills",
+		"/workspace/agent/agents",
+		"/project/.agents/skills",
+		"/project/.agents/agents",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len(got) = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got[%d] = %q, want %q", i, got[i], want[i])
+		}
 	}
 }
 

--- a/internal/agent/workspace.go
+++ b/internal/agent/workspace.go
@@ -50,6 +50,11 @@ func UserSkillsDir(userWorkspace string) string {
 }
 
 // UserRoot returns the per-user writable root path within a user workspace.
+//
+// User-owned runtime data, skills, and presets all live under this root:
+//   - users/{id}/data/
+//   - users/{id}/.agents/skills/
+//   - users/{id}/.agents/agents/
 func UserRoot(userWorkspace string) string {
-	return filepath.Join(userWorkspace, "data")
+	return userWorkspace
 }

--- a/internal/agent/workspace_test.go
+++ b/internal/agent/workspace_test.go
@@ -156,7 +156,7 @@ func TestUserSkillsDir(t *testing.T) {
 
 func TestUserRoot(t *testing.T) {
 	got := UserRoot("/base/users/42")
-	want := filepath.Join("/base/users/42", "data")
+	want := "/base/users/42"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}

--- a/plugins/tools/agent/preset_loader.go
+++ b/plugins/tools/agent/preset_loader.go
@@ -16,14 +16,14 @@ import (
 type LoadAgentPresetsConfig struct {
 	AnnaHome         string // anna home dir (e.g. ~/.anna)
 	AgentRoot        string // agent root dir (e.g. ~/.anna/workspaces/{agentID})
-	UserRoot         string // user root dir (e.g. ~/.anna/workspaces/{agentID}/users/{userID}/data)
+	UserRoot         string // user root dir (e.g. ~/.anna/workspaces/{agentID}/users/{userID})
 	ProjectRoot      string // optional project root for local/project-attached runs
 	BuiltinSkillsDir string // pre-extracted builtin skills directory (caller ensures extraction)
 	Runtime          pkgplugins.ToolRuntime
 }
 
 // LoadAgentPresets discovers agent presets in increasing priority order:
-// builtin -> ANNA_HOME -> agent root -> user root -> cwd.
+// builtin -> ANNA_HOME -> agent root -> user root -> project root.
 func LoadAgentPresets(cfg LoadAgentPresetsConfig) []AgentPreset {
 	return loadAgentPresets(context.Background(), cfg.Runtime, cfg.AnnaHome, cfg.AgentRoot, cfg.UserRoot, cfg.ProjectRoot, cfg.BuiltinSkillsDir)
 }
@@ -63,7 +63,7 @@ func loadAgentPresets(ctx context.Context, runtime pkgplugins.ToolRuntime, annaH
 		addDir(filepath.Join(agentRoot, "agents"), "agent")
 	}
 	if userRoot != "" {
-		addDir(filepath.Join(filepath.Dir(userRoot), ".agents", "agents"), "user")
+		addDir(filepath.Join(userRoot, ".agents", "agents"), "user")
 	}
 	if projectRoot != "" {
 		addDir(filepath.Join(projectRoot, ".agents", "agents"), "project")

--- a/plugins/tools/agent/preset_loader_test.go
+++ b/plugins/tools/agent/preset_loader_test.go
@@ -325,13 +325,13 @@ func TestLoadAgentPresetsAllFourTiers(t *testing.T) {
 
 	cwd := t.TempDir()
 	agentRoot := t.TempDir()
-	userRoot := filepath.Join(t.TempDir(), "users", "7", "data")
+	userRoot := filepath.Join(t.TempDir(), "users", "7")
 	annaHome := t.TempDir()
 	builtin := t.TempDir()
 
 	mkdirAll(t, filepath.Join(cwd, ".agents", "agents"), 0o755)
 	mkdirAll(t, filepath.Join(agentRoot, "agents"), 0o755)
-	mkdirAll(t, filepath.Join(filepath.Dir(userRoot), ".agents", "agents"), 0o755)
+	mkdirAll(t, filepath.Join(userRoot, ".agents", "agents"), 0o755)
 	mkdirAll(t, filepath.Join(annaHome, "agents"), 0o755)
 	mkdirAll(t, filepath.Join(builtin, "agents"), 0o755)
 
@@ -348,8 +348,8 @@ func TestLoadAgentPresetsAllFourTiers(t *testing.T) {
 	writeTestFile(t, filepath.Join(agentRoot, "agents", "agent-only.md"), preset("agent-only", "From agent root"), 0o644)
 	writeTestFile(t, filepath.Join(agentRoot, "agents", "overlap.md"), preset("overlap", "Agent loses"), 0o644)
 
-	writeTestFile(t, filepath.Join(filepath.Dir(userRoot), ".agents", "agents", "user-only.md"), preset("user-only", "From user root"), 0o644)
-	writeTestFile(t, filepath.Join(filepath.Dir(userRoot), ".agents", "agents", "overlap.md"), preset("overlap", "User loses"), 0o644)
+	writeTestFile(t, filepath.Join(userRoot, ".agents", "agents", "user-only.md"), preset("user-only", "From user root"), 0o644)
+	writeTestFile(t, filepath.Join(userRoot, ".agents", "agents", "overlap.md"), preset("overlap", "User loses"), 0o644)
 
 	writeTestFile(t, filepath.Join(cwd, ".agents", "agents", "project-only.md"), preset("project-only", "From project"), 0o644)
 	writeTestFile(t, filepath.Join(cwd, ".agents", "agents", "overlap.md"), preset("overlap", "Project wins"), 0o644)

--- a/plugins/tools/skills/catalog.go
+++ b/plugins/tools/skills/catalog.go
@@ -56,7 +56,7 @@ const (
 var validNameRe = regexp.MustCompile(`^[a-z0-9-]+$`)
 
 // LoadSkills discovers skills in increasing priority order:
-// builtin -> ANNA_HOME -> agent root -> user root -> cwd.
+// builtin -> ANNA_HOME -> agent root -> user root -> project root.
 func LoadSkills(ctx context.Context, cfg LoadSkillsConfig) []Skill {
 	return loadSkills(ctx, cfg.Runtime, cfg.AnnaHome, cfg.AgentRoot, cfg.UserRoot, cfg.ProjectRoot, cfg.UserSkillsDir)
 }
@@ -99,7 +99,7 @@ func loadSkills(ctx context.Context, runtime pkgplugins.ToolRuntime, annaHome, a
 		addDir(filepath.Join(agentRoot, "skills"), "agent")
 	}
 	if userSkillsDir == "" && userRoot != "" {
-		userSkillsDir = filepath.Join(filepath.Dir(userRoot), ".agents", "skills")
+		userSkillsDir = filepath.Join(userRoot, ".agents", "skills")
 	}
 	if userSkillsDir != "" {
 		addDir(userSkillsDir, "user")

--- a/plugins/tools/skills/catalog_test.go
+++ b/plugins/tools/skills/catalog_test.go
@@ -12,13 +12,13 @@ func TestLoadSkillsPriorityLowToHigh(t *testing.T) {
 
 	annaHome := t.TempDir()
 	agentRoot := t.TempDir()
-	userRoot := filepath.Join(t.TempDir(), "users", "7", "data")
+	userRoot := filepath.Join(t.TempDir(), "users", "7")
 	cwd := t.TempDir()
 
 	builtinDir := filepath.Join(annaHome, "cache", "builtin-skills", "shared")
 	annaDir := filepath.Join(annaHome, "skills", "shared")
 	agentDir := filepath.Join(agentRoot, "skills", "shared")
-	userDir := filepath.Join(filepath.Dir(userRoot), ".agents", "skills", "shared")
+	userDir := filepath.Join(userRoot, ".agents", "skills", "shared")
 	projectDir := filepath.Join(cwd, ".agents", "skills", "shared")
 	for _, dir := range []string{builtinDir, annaDir, agentDir, userDir, projectDir} {
 		if err := os.MkdirAll(dir, 0o755); err != nil {

--- a/plugins/tools/skills/plugin.go
+++ b/plugins/tools/skills/plugin.go
@@ -50,7 +50,7 @@ func userSkillsDir(userRoot string) string {
 	if userRoot == "" {
 		return ""
 	}
-	return filepath.Join(filepath.Dir(userRoot), ".agents", "skills")
+	return filepath.Join(userRoot, ".agents", "skills")
 }
 
 func SkillsDefinition() tools.Definition {

--- a/plugins/tools/skills/prompt_test.go
+++ b/plugins/tools/skills/prompt_test.go
@@ -28,11 +28,11 @@ project body
 		t.Fatal(err)
 	}
 
-	userDataDir := filepath.Join(workspace, "users", "42", "data")
-	if err := os.MkdirAll(userDataDir, 0o755); err != nil {
+	userRoot := filepath.Join(workspace, "users", "42")
+	if err := os.MkdirAll(userRoot, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	userSkillDir := filepath.Join(filepath.Dir(userDataDir), ".agents", "skills", "user-skill")
+	userSkillDir := filepath.Join(userRoot, ".agents", "skills", "user-skill")
 	if err := os.MkdirAll(userSkillDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +64,7 @@ old body
 		HomeDir:     homeDir,
 		AgentRoot:   workspace,
 		ProjectRoot: cwd,
-		UserRoot:    userDataDir,
+		UserRoot:    userRoot,
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Make UserRoot point at users/{id} instead of users/{id}/data so user-owned skills and presets live under the sandbox writable root.

Pass readable skill/preset roots for anna, agent, and project layers into the sandbox policy and thread ProjectRoot through runner-owned tool and preset loading.

Assisted-by: pi:api-session
