### PR TITLE
♻️ refactor: make skill install scope explicit

### DIFF
--- a/cmd/anna/commands_test.go
+++ b/cmd/anna/commands_test.go
@@ -182,6 +182,70 @@ func TestNewRunnerFactoryUnknown(t *testing.T) {
 	}
 }
 
+func TestCLIUserSkillsDirUsesUserScope(t *testing.T) {
+	setupCommandTestAnnaHome(t)
+	store, err := openStore()
+	if err != nil {
+		t.Fatalf("openStore: %v", err)
+	}
+	snap, err := defaultSnapshot(context.Background(), store)
+	if err != nil {
+		t.Fatalf("defaultSnapshot: %v", err)
+	}
+
+	dir, err := cliUserSkillsDir(snap)
+	if err != nil {
+		t.Fatalf("cliUserSkillsDir: %v", err)
+	}
+	want := filepath.Join(config.AnnaHome(), "workspaces", snap.AgentID, "users", "1", ".agents", "skills")
+	if dir != want {
+		t.Fatalf("cliUserSkillsDir() = %q, want %q", dir, want)
+	}
+}
+
+func TestLoadInstalledSkillsIncludesCLIUserSkills(t *testing.T) {
+	setupCommandTestAnnaHome(t)
+	store, err := openStore()
+	if err != nil {
+		t.Fatalf("openStore: %v", err)
+	}
+	snap, err := defaultSnapshot(context.Background(), store)
+	if err != nil {
+		t.Fatalf("defaultSnapshot: %v", err)
+	}
+	skillsDir, err := cliUserSkillsDir(snap)
+	if err != nil {
+		t.Fatalf("cliUserSkillsDir: %v", err)
+	}
+	skillDir := filepath.Join(skillsDir, "cli-test-skill")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(`---
+name: cli-test-skill
+description: CLI test skill
+status: active
+---
+body
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	loaded, err := loadInstalledSkills(context.Background())
+	if err != nil {
+		t.Fatalf("loadInstalledSkills: %v", err)
+	}
+	for _, s := range loaded {
+		if s.Name == "cli-test-skill" {
+			if s.Source != "user" {
+				t.Fatalf("skill source = %q, want user", s.Source)
+			}
+			return
+		}
+	}
+	t.Fatal("expected cli-test-skill to be discovered from CLI user scope")
+}
+
 func TestRunHelp(t *testing.T) {
 	app := newApp()
 	err := app.Run([]string{"anna", "--help"})

--- a/cmd/anna/skills.go
+++ b/cmd/anna/skills.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	ucli "github.com/urfave/cli/v2"
+	"github.com/vaayne/anna/internal/agent"
 	"github.com/vaayne/anna/internal/config"
 	skillstool "github.com/vaayne/anna/plugins/tools/skills"
 	mcpskills "github.com/vaayne/mcphub/pkg/skills"
@@ -74,6 +75,16 @@ func skillsSearchCommand() *ucli.Command {
 	}
 }
 
+const cliSkillsUserID int64 = 1
+
+func cliUserSkillsDir(snap *config.Snapshot) (string, error) {
+	userDir, err := agent.SetupUserWorkspace(snap.AgentID, config.AnnaHome(), cliSkillsUserID)
+	if err != nil {
+		return "", err
+	}
+	return agent.UserSkillsDir(userDir), nil
+}
+
 func skillsInstallCommand() *ucli.Command {
 	return &ucli.Command{
 		Name:      "install",
@@ -94,9 +105,12 @@ func skillsInstallCommand() *ucli.Command {
 			if err != nil {
 				return err
 			}
-			targetDir := snap.SkillsPath()
+			targetDir, err := cliUserSkillsDir(snap)
+			if err != nil {
+				return err
+			}
 
-			fmt.Fprintf(os.Stderr, "Installing from %s...\n", source)
+			fmt.Fprintf(os.Stderr, "Installing from %s into user scope (user=%d)...\n", source, cliSkillsUserID)
 
 			name, err := skillstool.Install(c.Context, source, targetDir)
 			if err != nil {
@@ -202,11 +216,16 @@ func loadInstalledSkills(ctx context.Context) ([]skillstool.Skill, error) {
 	if err != nil {
 		return nil, err
 	}
+	userSkillsDir, err := cliUserSkillsDir(snap)
+	if err != nil {
+		return nil, err
+	}
 	cwd, _ := os.Getwd()
 	return skillstool.LoadSkills(ctx, skillstool.LoadSkillsConfig{
-		AnnaHome:    config.AnnaHome(),
-		AgentRoot:   snap.Workspace,
-		ProjectRoot: cwd,
+		AnnaHome:      config.AnnaHome(),
+		AgentRoot:     snap.Workspace,
+		ProjectRoot:   cwd,
+		UserSkillsDir: userSkillsDir,
 	}), nil
 }
 
@@ -230,7 +249,11 @@ func skillsRemoveCommand() *ucli.Command {
 			if err != nil {
 				return err
 			}
-			skillDir := filepath.Join(snap.SkillsPath(), name)
+			targetDir, err := cliUserSkillsDir(snap)
+			if err != nil {
+				return err
+			}
+			skillDir := filepath.Join(targetDir, name)
 
 			if err := skillstool.Remove(c.Context, nil, name, skillDir); err != nil {
 				return err

--- a/internal/pluginhost/builders.go
+++ b/internal/pluginhost/builders.go
@@ -25,12 +25,14 @@ func (h *Host) BuildEnabledTools(ctx context.Context, bc plugintools.BuildContex
 	sort.Slice(regs, func(i, j int) bool { return regs[i].Name < regs[j].Name })
 	var out []tools.Tool
 	for _, reg := range regs {
-		if reg.Required {
+		if reg.Build == nil {
 			continue
 		}
-		state, err := h.DesiredState(ctx, reg.PluginID)
-		if err != nil || !state.Enabled || reg.Build == nil {
-			continue
+		if !reg.Required {
+			state, err := h.DesiredState(ctx, reg.PluginID)
+			if err != nil || !state.Enabled {
+				continue
+			}
 		}
 		t, err := reg.Build(pkgplugins.ToolContext{
 			Platform: h.platform(reg.PluginID),

--- a/internal/pluginhost/builders_test.go
+++ b/internal/pluginhost/builders_test.go
@@ -17,7 +17,7 @@ func (t *testTool) Execute(context.Context, map[string]any) (string, error) {
 	return "ok", nil
 }
 
-func TestBuildEnabledToolsBuildsAllOptionalToolsWithRuntimeContext(t *testing.T) {
+func TestBuildEnabledToolsBuildsOptionalAndRequiredToolsWithRuntimeContext(t *testing.T) {
 	store := &stubStore{plugins: map[string]config.Plugin{
 		"tool/a": {ID: "tool/a", Enabled: true},
 		"tool/b": {ID: "tool/b", Enabled: true},
@@ -25,6 +25,7 @@ func TestBuildEnabledToolsBuildsAllOptionalToolsWithRuntimeContext(t *testing.T)
 	host := New(store)
 	host.RegisterPluginID("tool/a")
 	host.RegisterPluginID("tool/b")
+	host.RegisterPluginID("tool/c")
 
 	var runtimeSeen int
 	var seenPaths []pkgplugins.ToolPaths
@@ -43,12 +44,21 @@ func TestBuildEnabledToolsBuildsAllOptionalToolsWithRuntimeContext(t *testing.T)
 	host.AddTool(pkgplugins.ToolSpec{
 		PluginID: "tool/b",
 		Name:     "b",
+		Required: true,
 		Build: func(ctx pkgplugins.ToolContext) (tools.Tool, error) {
 			if ctx.Runtime != nil {
 				runtimeSeen++
 			}
 			seenPaths = append(seenPaths, ctx.Paths)
 			return &testTool{name: "b"}, nil
+		},
+	})
+	host.AddTool(pkgplugins.ToolSpec{
+		PluginID: "tool/c",
+		Name:     "c",
+		Build: func(ctx pkgplugins.ToolContext) (tools.Tool, error) {
+			t.Fatal("disabled optional tool should not be built")
+			return nil, nil
 		},
 	})
 
@@ -65,6 +75,9 @@ func TestBuildEnabledToolsBuildsAllOptionalToolsWithRuntimeContext(t *testing.T)
 	got := host.BuildEnabledTools(context.Background(), build)
 	if len(got) != 2 {
 		t.Fatalf("BuildEnabledTools() len = %d, want 2", len(got))
+	}
+	if got[0].Definition().Name != "a" || got[1].Definition().Name != "b" {
+		t.Fatalf("unexpected tools: %q, %q", got[0].Definition().Name, got[1].Definition().Name)
 	}
 	if runtimeSeen != 2 {
 		t.Fatalf("runtime seen = %d, want 2", runtimeSeen)

--- a/plugins/tools/skills/install.go
+++ b/plugins/tools/skills/install.go
@@ -39,7 +39,11 @@ func (t *Tool) install(ctx context.Context, args map[string]any) (string, error)
 		return "", fmt.Errorf("source is required for install action (e.g. owner/repo@skill-name)")
 	}
 
-	scope, targetDir, err := t.targetSkillsDir(ctx, scopeArg(args))
+	rawScope, err := scopeArg(args)
+	if err != nil {
+		return "", err
+	}
+	scope, targetDir, err := t.targetSkillsDir(ctx, rawScope)
 	if err != nil {
 		return "", err
 	}
@@ -59,7 +63,11 @@ func (t *Tool) remove(ctx context.Context, args map[string]any) (string, error) 
 		return "", fmt.Errorf("name is required for remove action")
 	}
 
-	scope, targetDir, err := t.targetSkillsDir(ctx, scopeArg(args))
+	rawScope, err := scopeArg(args)
+	if err != nil {
+		return "", err
+	}
+	scope, targetDir, err := t.targetSkillsDir(ctx, rawScope)
 	if err != nil {
 		return "", err
 	}

--- a/plugins/tools/skills/install.go
+++ b/plugins/tools/skills/install.go
@@ -30,7 +30,7 @@ func (t *Tool) search(ctx context.Context, args map[string]any) (string, error) 
 	}
 
 	out, _ := json.MarshalIndent(results, "", "  ")
-	return fmt.Sprintf("Found %d skills:\n%s\n\nInstall with: skills tool action=install source=\"owner/repo@skill-name\"", len(results), out), nil
+	return fmt.Sprintf("Found %d skills:\n%s\n\nInstall with: skills tool action=install source=\"owner/repo@skill-name\"\nOptional: add scope=\"project\" to install into ProjectRoot/.agents/skills.", len(results), out), nil
 }
 
 func (t *Tool) install(ctx context.Context, args map[string]any) (string, error) {
@@ -39,14 +39,18 @@ func (t *Tool) install(ctx context.Context, args map[string]any) (string, error)
 		return "", fmt.Errorf("source is required for install action (e.g. owner/repo@skill-name)")
 	}
 
-	targetDir := t.skillsDir()
+	scope, targetDir, err := t.targetSkillsDir(ctx, scopeArg(args))
+	if err != nil {
+		return "", err
+	}
+
 	skillName, err := Install(ctx, source, targetDir)
 	if err != nil {
 		return "", err
 	}
 
 	installed := filepath.Join(targetDir, skillName)
-	return fmt.Sprintf("Skill %q installed to %s.", skillName, installed), nil
+	return fmt.Sprintf("Skill %q installed to %s (scope=%s).", skillName, installed, scope), nil
 }
 
 func (t *Tool) remove(ctx context.Context, args map[string]any) (string, error) {
@@ -55,10 +59,15 @@ func (t *Tool) remove(ctx context.Context, args map[string]any) (string, error) 
 		return "", fmt.Errorf("name is required for remove action")
 	}
 
-	skillDir := filepath.Join(t.skillsDir(), name)
-	if err := Remove(ctx, t.runtime, name, skillDir); err != nil {
-		return "", fmt.Errorf("%w (only skills in %s can be removed)", err, t.skillsDir())
+	scope, targetDir, err := t.targetSkillsDir(ctx, scopeArg(args))
+	if err != nil {
+		return "", err
 	}
 
-	return fmt.Sprintf("Skill %q removed from %s.", name, skillDir), nil
+	skillDir := filepath.Join(targetDir, name)
+	if err := Remove(ctx, t.runtime, name, skillDir); err != nil {
+		return "", fmt.Errorf("%w (only skills in %s scope at %s can be removed)", err, scope, targetDir)
+	}
+
+	return fmt.Sprintf("Skill %q removed from %s (scope=%s).", name, skillDir, scope), nil
 }

--- a/plugins/tools/skills/tool.go
+++ b/plugins/tools/skills/tool.go
@@ -159,7 +159,11 @@ func (t *Tool) create(ctx context.Context, args map[string]any) (string, error) 
 	description, _ := args["description"].(string)
 	content, _ := args["content"].(string)
 
-	_, targetDir, err := t.targetSkillsDir(ctx, scopeArg(args))
+	scope, err := scopeArg(args)
+	if err != nil {
+		return "", err
+	}
+	_, targetDir, err := t.targetSkillsDir(ctx, scope)
 	if err != nil {
 		return "", err
 	}
@@ -187,7 +191,11 @@ func (t *Tool) patch(ctx context.Context, args map[string]any) (string, error) {
 		updates["content"] = v
 	}
 
-	_, targetDir, err := t.targetSkillsDir(ctx, scopeArg(args))
+	scope, err := scopeArg(args)
+	if err != nil {
+		return "", err
+	}
+	_, targetDir, err := t.targetSkillsDir(ctx, scope)
 	if err != nil {
 		return "", err
 	}
@@ -204,7 +212,11 @@ func (t *Tool) deprecate(ctx context.Context, args map[string]any) (string, erro
 		return "", fmt.Errorf("name is required for deprecate action")
 	}
 
-	_, targetDir, err := t.targetSkillsDir(ctx, scopeArg(args))
+	scope, err := scopeArg(args)
+	if err != nil {
+		return "", err
+	}
+	_, targetDir, err := t.targetSkillsDir(ctx, scope)
 	if err != nil {
 		return "", err
 	}
@@ -252,9 +264,19 @@ func (t *Tool) list(ctx context.Context) (string, error) {
 	return string(out), nil
 }
 
-func scopeArg(args map[string]any) string {
-	scope, _ := args["scope"].(string)
-	return scope
+func scopeArg(args map[string]any) (string, error) {
+	if args == nil {
+		return "", nil
+	}
+	v, ok := args["scope"]
+	if !ok || v == nil {
+		return "", nil
+	}
+	scope, ok := v.(string)
+	if !ok {
+		return "", fmt.Errorf("scope must be a string")
+	}
+	return scope, nil
 }
 
 func (t *Tool) load(ctx context.Context, args map[string]any) (string, error) {

--- a/plugins/tools/skills/tool.go
+++ b/plugins/tools/skills/tool.go
@@ -18,7 +18,7 @@ var skillsInputSchema = func() map[string]any {
     "action": {
       "type": "string",
       "enum": ["load", "search", "install", "list", "remove", "create", "patch", "deprecate"],
-      "description": "Action to perform: 'load' reads a skill's content by name, 'search' finds skills from the ecosystem, 'install' adds a skill to the project, 'list' shows installed skills, 'remove' deletes an installed skill, 'create' creates a new skill (draft), 'patch' updates an existing skill's fields, 'deprecate' marks a skill as deprecated"
+      "description": "Action to perform: 'load' reads a skill's content by name, 'search' finds skills from the ecosystem, 'install' adds a skill, 'list' shows installed skills, 'remove' deletes an installed skill, 'create' creates a new skill (draft), 'patch' updates an existing skill's fields, 'deprecate' marks a skill as deprecated"
     },
     "query": {
       "type": "string",
@@ -31,6 +31,11 @@ var skillsInputSchema = func() map[string]any {
     "source": {
       "type": "string",
       "description": "Skill source to install. Supports: 'owner/repo@skill-name' (GitHub shorthand), 'owner/repo@skill-name#ref' (with branch/tag), GitHub/GitLab URLs, or local paths (required for install)"
+    },
+    "scope": {
+      "type": "string",
+      "enum": ["user", "project"],
+      "description": "Writable scope for install/remove/create/patch/deprecate. Defaults to 'user' (UserRoot/.agents/skills). Set to 'project' to target ProjectRoot/.agents/skills."
     },
     "name": {
       "type": "string",
@@ -73,17 +78,50 @@ func NewTool(annaHome, agentRoot, projectRoot, userSkillsDir string, runtime pkg
 	}
 }
 
-func (t *Tool) skillsDir() string {
-	if t.userSkillsDir != "" {
-		return t.userSkillsDir
+const (
+	skillScopeUser    = "user"
+	skillScopeProject = "project"
+)
+
+func normalizeSkillScope(scope string) (string, error) {
+	scope = filepath.Clean(scope)
+	switch scope {
+	case "", ".", skillScopeUser:
+		return skillScopeUser, nil
+	case skillScopeProject:
+		return skillScopeProject, nil
+	default:
+		return "", fmt.Errorf("invalid scope %q, expected user or project", scope)
 	}
-	return filepath.Join(t.agentRoot, "skills")
+}
+
+func (t *Tool) targetSkillsDir(ctx context.Context, rawScope string) (string, string, error) {
+	scope, err := normalizeSkillScope(rawScope)
+	if err != nil {
+		return "", "", err
+	}
+
+	switch scope {
+	case skillScopeUser:
+		if t.userSkillsDir == "" {
+			return "", "", fmt.Errorf("user skill scope is unavailable")
+		}
+		return scope, t.userSkillsDir, nil
+	case skillScopeProject:
+		projectRoot := projectRootFromContext(ctx, t.projectRoot)
+		if projectRoot == "" {
+			return "", "", fmt.Errorf("project skill scope requested but ProjectRoot is unavailable")
+		}
+		return scope, filepath.Join(projectRoot, ".agents", "skills"), nil
+	default:
+		return "", "", fmt.Errorf("unsupported scope %q", scope)
+	}
 }
 
 func pkgskillsToolDefinition() tools.Definition {
 	return tools.Definition{
 		Name:        "skills",
-		Description: "Manage agent skills. Use 'load' to read a skill by name, 'search' to find skills from the ecosystem, 'install' to add a skill (e.g. owner/repo@skill-name), 'list' to see installed skills, 'remove' to delete one, 'create' to create a new skill (draft), 'patch' to update fields, 'deprecate' to mark as deprecated.",
+		Description: "Manage agent skills. Use 'load' to read a skill by name, 'search' to find skills from the ecosystem, 'install' to add a skill (defaults to scope=user; set scope=project for ProjectRoot), 'list' to see installed skills, 'remove' to delete one, 'create' to create a new skill (draft), 'patch' to update fields, 'deprecate' to mark as deprecated.",
 		InputSchema: skillsInputSchema,
 	}
 }
@@ -121,7 +159,10 @@ func (t *Tool) create(ctx context.Context, args map[string]any) (string, error) 
 	description, _ := args["description"].(string)
 	content, _ := args["content"].(string)
 
-	targetDir := t.skillsDir()
+	_, targetDir, err := t.targetSkillsDir(ctx, scopeArg(args))
+	if err != nil {
+		return "", err
+	}
 	if err := Create(ctx, t.runtime, name, description, content, targetDir); err != nil {
 		return "", err
 	}
@@ -146,7 +187,10 @@ func (t *Tool) patch(ctx context.Context, args map[string]any) (string, error) {
 		updates["content"] = v
 	}
 
-	targetDir := t.skillsDir()
+	_, targetDir, err := t.targetSkillsDir(ctx, scopeArg(args))
+	if err != nil {
+		return "", err
+	}
 	if err := Patch(ctx, t.runtime, name, updates, targetDir); err != nil {
 		return "", err
 	}
@@ -160,7 +204,10 @@ func (t *Tool) deprecate(ctx context.Context, args map[string]any) (string, erro
 		return "", fmt.Errorf("name is required for deprecate action")
 	}
 
-	targetDir := t.skillsDir()
+	_, targetDir, err := t.targetSkillsDir(ctx, scopeArg(args))
+	if err != nil {
+		return "", err
+	}
 	if err := Deprecate(ctx, t.runtime, name, targetDir); err != nil {
 		return "", err
 	}
@@ -203,6 +250,11 @@ func (t *Tool) list(ctx context.Context) (string, error) {
 
 	out, _ := json.MarshalIndent(results, "", "  ")
 	return string(out), nil
+}
+
+func scopeArg(args map[string]any) string {
+	scope, _ := args["scope"].(string)
+	return scope
 }
 
 func (t *Tool) load(ctx context.Context, args map[string]any) (string, error) {

--- a/plugins/tools/skills/tool_test.go
+++ b/plugins/tools/skills/tool_test.go
@@ -128,8 +128,8 @@ func TestRemoveSuccess(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tool := NewTool("/tmp/anna", filepath.Join(dir, ".agents"), dir, "", nil)
-	result, err := tool.remove(context.Background(), map[string]any{"name": "my-skill"})
+	tool := NewTool("/tmp/anna", filepath.Join(dir, ".agents"), dir, filepath.Join(dir, ".agents", "skills"), nil)
+	result, err := tool.remove(context.Background(), map[string]any{"name": "my-skill", "scope": "user"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -157,7 +157,7 @@ func TestInstallMissingSource(t *testing.T) {
 	}
 }
 
-func TestInstallFromLocalDirViaTool(t *testing.T) {
+func TestInstallFromLocalDirViaToolDefaultsToUserScope(t *testing.T) {
 	srcDir := t.TempDir()
 	skillDir := filepath.Join(srcDir, "test-skill")
 	if err := os.MkdirAll(skillDir, 0o755); err != nil {
@@ -173,23 +173,98 @@ description: Test
 	}
 
 	projectDir := t.TempDir()
-	workspace := filepath.Join(projectDir, ".agents")
-	if err := os.MkdirAll(filepath.Join(workspace, "skills"), 0o755); err != nil {
+	userRoot := filepath.Join(t.TempDir(), "users", "7")
+	userSkillsDir := filepath.Join(userRoot, ".agents", "skills")
+	if err := os.MkdirAll(userSkillsDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
-	tool := NewTool("/tmp/anna", workspace, projectDir, "", nil)
+	tool := NewTool("/tmp/anna", filepath.Join(projectDir, ".agents"), projectDir, userSkillsDir, nil)
 	result, err := tool.install(context.Background(), map[string]any{"source": srcDir})
 	if err != nil {
 		t.Fatalf("install error: %v", err)
 	}
-	if result == "" {
-		t.Error("expected non-empty result")
+	if !strings.Contains(result, "scope=user") {
+		t.Fatalf("expected user scope in result, got %q", result)
 	}
 
-	installed := filepath.Join(workspace, "skills", "test-skill", "SKILL.md")
+	installed := filepath.Join(userSkillsDir, "test-skill", "SKILL.md")
 	if _, err := os.Stat(installed); err != nil {
-		t.Fatalf("installed SKILL.md not found: %v", err)
+		t.Fatalf("installed SKILL.md not found in user scope: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(projectDir, ".agents", "skills", "test-skill")); !os.IsNotExist(err) {
+		t.Fatal("skill should not be installed into project scope by default")
+	}
+}
+
+func TestInstallFromLocalDirViaToolProjectScope(t *testing.T) {
+	srcDir := t.TempDir()
+	skillDir := filepath.Join(srcDir, "test-skill")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(`---
+name: test-skill
+description: Test
+---
+# Test
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectDir := t.TempDir()
+	userRoot := filepath.Join(t.TempDir(), "users", "7")
+	userSkillsDir := filepath.Join(userRoot, ".agents", "skills")
+	if err := os.MkdirAll(userSkillsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	tool := NewTool("/tmp/anna", filepath.Join(projectDir, ".agents"), projectDir, userSkillsDir, nil)
+	result, err := tool.install(context.Background(), map[string]any{"source": srcDir, "scope": "project"})
+	if err != nil {
+		t.Fatalf("install error: %v", err)
+	}
+	if !strings.Contains(result, "scope=project") {
+		t.Fatalf("expected project scope in result, got %q", result)
+	}
+
+	installed := filepath.Join(projectDir, ".agents", "skills", "test-skill", "SKILL.md")
+	if _, err := os.Stat(installed); err != nil {
+		t.Fatalf("installed SKILL.md not found in project scope: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(userSkillsDir, "test-skill")); !os.IsNotExist(err) {
+		t.Fatal("skill should not be installed into user scope when project scope is requested")
+	}
+}
+
+func TestInstallProjectScopeRequiresProjectRoot(t *testing.T) {
+	srcDir := t.TempDir()
+	skillDir := filepath.Join(srcDir, "test-skill")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(`---
+name: test-skill
+description: Test
+---
+# Test
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	userRoot := filepath.Join(t.TempDir(), "users", "7")
+	userSkillsDir := filepath.Join(userRoot, ".agents", "skills")
+	if err := os.MkdirAll(userSkillsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	tool := NewTool("/tmp/anna", t.TempDir(), "", userSkillsDir, nil)
+	_, err := tool.install(context.Background(), map[string]any{"source": srcDir, "scope": "project"})
+	if err == nil {
+		t.Fatal("expected error when project scope is requested without ProjectRoot")
+	}
+	if !strings.Contains(err.Error(), "ProjectRoot") {
+		t.Fatalf("expected ProjectRoot error, got %v", err)
 	}
 }
 
@@ -247,8 +322,8 @@ func TestRemoveSingleCharName(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tool := NewTool("/tmp/anna", filepath.Join(dir, ".agents"), dir, "", nil)
-	_, err := tool.remove(context.Background(), map[string]any{"name": "x"})
+	tool := NewTool("/tmp/anna", filepath.Join(dir, ".agents"), dir, filepath.Join(dir, ".agents", "skills"), nil)
+	_, err := tool.remove(context.Background(), map[string]any{"name": "x", "scope": "user"})
 	if err != nil {
 		t.Fatalf("unexpected error removing single-char skill: %v", err)
 	}
@@ -347,29 +422,39 @@ description: User-specific skill
 	}
 }
 
-func TestAgentLevelToolBackwardCompat(t *testing.T) {
+func TestTargetSkillsDirDefaultsToUserScope(t *testing.T) {
 	base := t.TempDir()
 	agentWS := filepath.Join(base, "workspaces", "agent-1")
-	if err := os.MkdirAll(filepath.Join(agentWS, "skills"), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	userSkillsDir := filepath.Join(agentWS, "users", "7", ".agents", "skills")
 
-	tool := NewTool("/tmp/anna", agentWS, "", "", nil)
-	got := tool.skillsDir()
-	want := filepath.Join(agentWS, "skills")
-	if got != want {
-		t.Errorf("skillsDir() = %q, want %q", got, want)
+	tool := NewTool("/tmp/anna", agentWS, filepath.Join(base, "project"), userSkillsDir, nil)
+	scope, got, err := tool.targetSkillsDir(context.Background(), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if scope != skillScopeUser {
+		t.Fatalf("scope = %q, want %q", scope, skillScopeUser)
+	}
+	if got != userSkillsDir {
+		t.Errorf("targetSkillsDir() = %q, want %q", got, userSkillsDir)
 	}
 }
 
-func TestPerUserToolSkillsDir(t *testing.T) {
+func TestTargetSkillsDirProjectScope(t *testing.T) {
 	base := t.TempDir()
 	agentWS := filepath.Join(base, "workspaces", "agent-1")
+	projectRoot := filepath.Join(base, "project")
 
-	tool := NewTool("/tmp/anna", agentWS, "", filepath.Join(agentWS, "users", "7", ".agents", "skills"), nil)
-	got := tool.skillsDir()
-	want := filepath.Join(agentWS, "users", "7", ".agents", "skills")
+	tool := NewTool("/tmp/anna", agentWS, projectRoot, filepath.Join(agentWS, "users", "7", ".agents", "skills"), nil)
+	scope, got, err := tool.targetSkillsDir(context.Background(), "project")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if scope != skillScopeProject {
+		t.Fatalf("scope = %q, want %q", scope, skillScopeProject)
+	}
+	want := filepath.Join(projectRoot, ".agents", "skills")
 	if got != want {
-		t.Errorf("skillsDir() = %q, want %q", got, want)
+		t.Errorf("targetSkillsDir() = %q, want %q", got, want)
 	}
 }

--- a/plugins/tools/skills/tool_test.go
+++ b/plugins/tools/skills/tool_test.go
@@ -268,6 +268,37 @@ description: Test
 	}
 }
 
+func TestInstallRejectsNonStringScope(t *testing.T) {
+	srcDir := t.TempDir()
+	skillDir := filepath.Join(srcDir, "test-skill")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(`---
+name: test-skill
+description: Test
+---
+# Test
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	userRoot := filepath.Join(t.TempDir(), "users", "7")
+	userSkillsDir := filepath.Join(userRoot, ".agents", "skills")
+	if err := os.MkdirAll(userSkillsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	tool := NewTool("/tmp/anna", t.TempDir(), t.TempDir(), userSkillsDir, nil)
+	_, err := tool.install(context.Background(), map[string]any{"source": srcDir, "scope": 1})
+	if err == nil {
+		t.Fatal("expected error when scope is not a string")
+	}
+	if !strings.Contains(err.Error(), "scope must be a string") {
+		t.Fatalf("expected scope type error, got %v", err)
+	}
+}
+
 func TestLoadSkill(t *testing.T) {
 	dir := t.TempDir()
 	skillDir := filepath.Join(dir, ".agents", "skills", "test-skill")


### PR DESCRIPTION
## Summary
- default skill writes to user scope (`UserRoot/.agents/skills`)
- add explicit `scope=project` support for project installs and other mutating skill actions
- error when project scope is requested without `ProjectRoot`
- keep skill search ecosystem-wide and discovery order unchanged

## Details
This removes the old implicit fallback to `agentRoot/skills` for writes so the skills tool matches the new `UserRoot` / `ProjectRoot` model.

I reused the same scope resolver for `install`, `remove`, `create`, `patch`, and `deprecate` so project-scoped installs remain manageable after creation.

`install_lib.go` still bypasses runtime/sandbox mediation and writes via `mcphub/pkg/skills`; I left that as a focused follow-up instead of mixing API and transport changes in one PR.

## Testing
- `mise run format`
- `mise run test -- ./plugins/tools/skills/...`
