### PR TITLE
🐛 fix: diagnose boxsh sandbox startup failures

### DIFF
--- a/docs/content/docs/plugins/trace.md
+++ b/docs/content/docs/plugins/trace.md
@@ -151,6 +151,18 @@ Memory operations (append, assemble, compact, search, etc.) are captured as `mem
 - Token delta (for compaction)
 - Errors
 
+### Sandbox Lifecycle
+
+Sandbox startup is captured with `sandbox.*` spans so boxsh failures can be traced past the final broken-pipe symptom:
+
+- Session creation in the runner
+- Backend startup and overlay/session directory setup
+- Boxsh client process startup
+- JSON-RPC handshake
+- Session close or liveness loss reason
+
+These spans include Anna-specific attributes such as sandbox backend, source/destination roots, working directory, network mode, read-only bind count, and captured error type.
+
 ### Trace Structure
 
 Spans are organized into a hierarchy per chat session:
@@ -199,6 +211,27 @@ Memory spans use anna-specific attributes:
 | `anna.memory.token_count` | Token count |
 | `anna.memory.token_delta` | Tokens saved by compaction (negative = reduction) |
 | `anna.memory.message_count` | Message count |
+
+Sandbox lifecycle spans use these Anna-specific attributes:
+
+| Attribute | Description |
+| --- | --- |
+| `anna.sandbox.backend` | Sandbox backend name, currently `boxsh` |
+| `anna.sandbox.agent_root` | Agent workspace root from runner config |
+| `anna.sandbox.user_root` | Requested sandbox user root |
+| `anna.sandbox.resolved_user_root` | Resolved absolute user root used to build policy |
+| `anna.sandbox.project_root` | Project root when present |
+| `anna.sandbox.work_dir` | Requested or resolved working directory |
+| `anna.sandbox.src` | Boxsh copy-on-write source root |
+| `anna.sandbox.dst` | Overlay/session destination root |
+| `anna.sandbox.cwd` | Remapped working directory inside the session |
+| `anna.sandbox.network.mode` | Effective network mode |
+| `anna.sandbox.network.allowlist` | Network allowlist when configured |
+| `anna.sandbox.readonly_dir_count` | Number of read-only bind directories |
+| `anna.sandbox.close_reason` | Why the session span ended |
+| `anna.sandbox.server.name` | Handshake-reported sandbox server name |
+| `anna.sandbox.server.version` | Handshake-reported sandbox server version |
+| `anna.sandbox.protocol_version` | RPC protocol version returned by boxsh |
 
 ## Managing the Plugin
 

--- a/internal/agent/runner/gorunner.go
+++ b/internal/agent/runner/gorunner.go
@@ -253,8 +253,15 @@ func buildToolRegistry(ctx context.Context, cfg GoRunnerConfig, session *runnerS
 
 // buildAgentPresets extracts builtin skills and loads agent presets from filesystem.
 func collectSandboxReadOnlyDirs(extraDirs []string, toolsBinDir, pathEnv string) []string {
-	dirs := append([]string{}, extraDirs...)
-	dirs = append(dirs, toolsBinDir)
+	dirs := make([]string, 0, len(extraDirs)+1)
+	for _, dir := range append(append([]string{}, extraDirs...), toolsBinDir) {
+		if dir == "" || !filepath.IsAbs(dir) {
+			continue
+		}
+		if info, err := os.Stat(dir); err == nil && info.IsDir() {
+			dirs = append(dirs, dir)
+		}
+	}
 	for _, dir := range filepath.SplitList(pathEnv) {
 		if dir == "" || !filepath.IsAbs(dir) {
 			continue

--- a/internal/agent/runner/sandbox_backend.go
+++ b/internal/agent/runner/sandbox_backend.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -167,6 +168,15 @@ func createBoxshSession(ctx context.Context, cfg GoRunnerConfig) (*runnerSession
 			InheritEnv:  true,
 		},
 	}
+
+	slog.Info("creating boxsh session",
+		"component", "runner_sandbox",
+		"user_root", paths.UserRoot,
+		"work_dir", paths.WorkDir,
+		"readonly_dirs", readOnlyDirs,
+		"network_mode", cfg.Sandbox.Network.Mode,
+		"network_allowlist", cfg.Sandbox.Network.Allowlist,
+	)
 
 	factory := sandbox.GlobalRegistry().Get(config.SandboxBackendBoxsh)
 	if factory == nil {

--- a/internal/agent/runner/sandbox_backend.go
+++ b/internal/agent/runner/sandbox_backend.go
@@ -9,6 +9,9 @@ import (
 	"runtime"
 	"strings"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/vaayne/anna/internal/config"
 	"github.com/vaayne/anna/internal/sandbox"
 	"github.com/vaayne/anna/plugins/sandbox/boxsh/boxshclient"
@@ -140,14 +143,28 @@ func createLocalSession(_ context.Context, cfg GoRunnerConfig) (*runnerSession, 
 }
 
 func createBoxshSession(ctx context.Context, cfg GoRunnerConfig) (*runnerSession, error) {
+	ctx, span := sandboxTracer.Start(ctx, "sandbox.create_session",
+		trace.WithAttributes(
+			attribute.String("anna.sandbox.backend", config.SandboxBackendBoxsh),
+			attribute.String("anna.sandbox.agent_root", cfg.AgentRoot),
+			attribute.String("anna.sandbox.user_root", cfg.UserRoot),
+			attribute.String("anna.sandbox.project_root", cfg.ProjectRoot),
+		),
+	)
+	defer span.End()
+
 	if !platformSupportsBoxsh() {
-		return nil, fmt.Errorf("sandbox backend %q is not supported on %s", config.SandboxBackendBoxsh, runtime.GOOS)
+		err := fmt.Errorf("sandbox backend %q is not supported on %s", config.SandboxBackendBoxsh, runtime.GOOS)
+		recordSandboxError(span, err)
+		return nil, err
 	}
 
 	runnerPaths := resolveRunnerPaths(cfg)
 	paths, err := resolveSandboxPaths(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("resolve sandbox paths: %w", err)
+		err = fmt.Errorf("resolve sandbox paths: %w", err)
+		recordSandboxError(span, err)
+		return nil, err
 	}
 	readOnlyDirs := collectSandboxReadOnlyDirs(
 		sandboxReadableDirs(runnerPaths),
@@ -169,6 +186,16 @@ func createBoxshSession(ctx context.Context, cfg GoRunnerConfig) (*runnerSession
 		},
 	}
 
+	span.SetAttributes(
+		attribute.String("anna.sandbox.resolved_user_root", paths.UserRoot),
+		attribute.String("anna.sandbox.work_dir", paths.WorkDir),
+		attribute.Int("anna.sandbox.readonly_dir_count", len(readOnlyDirs)),
+		attribute.String("anna.sandbox.network.mode", cfg.Sandbox.Network.Mode),
+	)
+	if len(cfg.Sandbox.Network.Allowlist) > 0 {
+		span.SetAttributes(attribute.StringSlice("anna.sandbox.network.allowlist", cfg.Sandbox.Network.Allowlist))
+	}
+
 	slog.Info("creating boxsh session",
 		"component", "runner_sandbox",
 		"user_root", paths.UserRoot,
@@ -180,12 +207,16 @@ func createBoxshSession(ctx context.Context, cfg GoRunnerConfig) (*runnerSession
 
 	factory := sandbox.GlobalRegistry().Get(config.SandboxBackendBoxsh)
 	if factory == nil {
-		return nil, fmt.Errorf("boxsh factory not available")
+		err := fmt.Errorf("boxsh factory not available")
+		recordSandboxError(span, err)
+		return nil, err
 	}
 
 	session, err := factory.CreateSession(ctx, policy)
 	if err != nil {
-		return nil, fmt.Errorf("create boxsh session: %w", err)
+		err = fmt.Errorf("create boxsh session: %w", err)
+		recordSandboxError(span, err)
+		return nil, err
 	}
 
 	return &runnerSession{

--- a/internal/agent/runner/sandbox_backend_test.go
+++ b/internal/agent/runner/sandbox_backend_test.go
@@ -2,6 +2,8 @@ package runner
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -135,6 +137,33 @@ func TestSandboxReadableDirsSkipsProjectPathsInsideUserRoot(t *testing.T) {
 	for _, dir := range got {
 		if strings.HasPrefix(dir, "/workspace/agent/users/1/data/repo/") {
 			t.Fatalf("project path %q should not be mounted read-only inside user root", dir)
+		}
+	}
+}
+
+func TestCollectSandboxReadOnlyDirsSkipsMissingExtraDirs(t *testing.T) {
+	root := t.TempDir()
+	extraDir := filepath.Join(root, "skills")
+	if err := os.MkdirAll(extraDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	toolsBinDir := filepath.Join(root, "bin")
+	if err := os.MkdirAll(toolsBinDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	pathDir := filepath.Join(root, "path-bin")
+	if err := os.MkdirAll(pathDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	got := collectSandboxReadOnlyDirs([]string{extraDir, filepath.Join(root, "missing")}, toolsBinDir, pathDir)
+	want := []string{extraDir, toolsBinDir, pathDir}
+	if len(got) != len(want) {
+		t.Fatalf("len(got) = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got[%d] = %q, want %q", i, got[i], want[i])
 		}
 	}
 }

--- a/internal/agent/runner/sandbox_trace.go
+++ b/internal/agent/runner/sandbox_trace.go
@@ -1,0 +1,21 @@
+package runner
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+var sandboxTracer = otel.Tracer("anna/sandbox")
+
+func recordSandboxError(span trace.Span, err error) {
+	if span == nil || err == nil {
+		return
+	}
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
+	span.SetAttributes(attribute.String("error.type", fmt.Sprintf("%T", err)))
+}

--- a/plugins/sandbox/boxsh/boxshclient/backend.go
+++ b/plugins/sandbox/boxsh/boxshclient/backend.go
@@ -125,6 +125,17 @@ func (b *SharedBackend) Start(ctx context.Context, cfg BackendConfig) error {
 	// Create and start the client.
 	client := New(b.binaryPath, sessionCfg)
 	if err := client.Start(ctx); err != nil {
+		slog.Warn("boxsh backend failed to start client",
+			"component", "boxsh_backend",
+			"binary", b.binaryPath,
+			"src", src,
+			"dst", sessionDir,
+			"cwd", cwd,
+			"readonly_dirs", uniqueCleanAbsPaths(cfg.ReadOnlyDirs),
+			"network_mode", sessionCfg.NetworkMode,
+			"stderr", client.Stderr(),
+			"error", err,
+		)
 		_ = CleanupSessionDir(sessionDir)
 		b.sessionDir = ""
 		return fmt.Errorf("boxshclient: start client: %w", err)

--- a/plugins/sandbox/boxsh/boxshclient/backend.go
+++ b/plugins/sandbox/boxsh/boxshclient/backend.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
 )
 
 // SharedBackend provides a shared boxsh session for all core tools.
@@ -77,15 +79,27 @@ func NewSharedBackend(cfg BackendConfig) (*SharedBackend, error) {
 // Start initializes the shared backend by creating the session directory
 // and starting the boxsh RPC process.
 func (b *SharedBackend) Start(ctx context.Context, cfg BackendConfig) error {
+	ctx, span := tracer.Start(ctx, "sandbox.boxsh.backend_start")
+	defer span.End()
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	if b.client != nil {
-		return fmt.Errorf("boxshclient: backend already started")
+		err := fmt.Errorf("boxshclient: backend already started")
+		recordTraceError(span, err)
+		return err
 	}
 
 	// Determine user root (SRC).
 	src := cfg.UserRoot
+	span.SetAttributes(
+		attribute.String("anna.sandbox.binary", b.binaryPath),
+		attribute.String("anna.sandbox.src", src),
+		attribute.String("anna.sandbox.work_dir", cfg.WorkDir),
+		attribute.Int("anna.sandbox.readonly_dir_count", len(uniqueCleanAbsPaths(cfg.ReadOnlyDirs))),
+		attribute.String("anna.sandbox.network.mode", cfg.Sandbox.ModeOrDefault()),
+	)
 
 	// Create an ephemeral overlay root on the same filesystem as SRC.
 	// boxsh's current overlay implementation requires that to avoid cross-device
@@ -97,13 +111,19 @@ func (b *SharedBackend) Start(ctx context.Context, cfg BackendConfig) error {
 
 	sessionDir, err := CreateSessionDir(sessionBaseDir)
 	if err != nil {
-		return fmt.Errorf("boxshclient: create session dir: %w", err)
+		err = fmt.Errorf("boxshclient: create session dir: %w", err)
+		recordTraceError(span, err)
+		return err
 	}
 	if err := os.Remove(sessionDir); err != nil {
-		return fmt.Errorf("boxshclient: prepare session dir: %w", err)
+		err = fmt.Errorf("boxshclient: prepare session dir: %w", err)
+		recordTraceError(span, err)
+		return err
 	}
 	if err := os.Mkdir(sessionDir, 0o755); err != nil {
-		return fmt.Errorf("boxshclient: recreate session dir: %w", err)
+		err = fmt.Errorf("boxshclient: recreate session dir: %w", err)
+		recordTraceError(span, err)
+		return err
 	}
 	b.sessionDir = sessionDir
 	b.sessionSrc = src
@@ -111,6 +131,10 @@ func (b *SharedBackend) Start(ctx context.Context, cfg BackendConfig) error {
 	// boxsh mounts the overlay at DST, so remap the requested workdir from SRC
 	// into the overlay root.
 	cwd := remapCwdToSessionRoot(src, sessionDir, cfg.WorkDir)
+	span.SetAttributes(
+		attribute.String("anna.sandbox.dst", sessionDir),
+		attribute.String("anna.sandbox.cwd", cwd),
+	)
 
 	// Build session configuration.
 	sessionCfg := SessionConfig{
@@ -125,6 +149,7 @@ func (b *SharedBackend) Start(ctx context.Context, cfg BackendConfig) error {
 	// Create and start the client.
 	client := New(b.binaryPath, sessionCfg)
 	if err := client.Start(ctx); err != nil {
+		recordTraceError(span, err)
 		slog.Warn("boxsh backend failed to start client",
 			"component", "boxsh_backend",
 			"binary", b.binaryPath,
@@ -142,6 +167,7 @@ func (b *SharedBackend) Start(ctx context.Context, cfg BackendConfig) error {
 	}
 
 	b.client = client
+	span.AddEvent("sandbox.boxsh.backend.started")
 	slog.Info("boxsh backend started",
 		"component", "boxsh_backend",
 		"binary", b.binaryPath,

--- a/plugins/sandbox/boxsh/boxshclient/client.go
+++ b/plugins/sandbox/boxsh/boxshclient/client.go
@@ -29,6 +29,7 @@ type Client struct {
 
 	mu          sync.Mutex
 	writeMu     sync.Mutex
+	stderrMu    sync.RWMutex
 	cmd         *exec.Cmd
 	stdin       io.WriteCloser
 	stdout      io.ReadCloser
@@ -179,7 +180,9 @@ func (c *Client) Start(ctx context.Context) error {
 	c.readerErr = nil
 	c.processDone = processDone
 	c.pending = make(map[uint64]chan responseWrapper)
+	c.stderrMu.Lock()
 	c.stderrBuf.Reset()
+	c.stderrMu.Unlock()
 	c.mu.Unlock()
 
 	go c.readLoop(stdout)
@@ -188,6 +191,7 @@ func (c *Client) Start(ctx context.Context) error {
 
 	if err := c.handshake(ctx); err != nil {
 		recordTraceError(span, err)
+		diagnostics := c.snapshotDiagnostics()
 		slog.Warn("boxsh client handshake failed",
 			"component", "boxsh_client",
 			"binary", c.binaryPath,
@@ -197,9 +201,9 @@ func (c *Client) Start(ctx context.Context) error {
 			"cwd", c.sessionConfig.Cwd,
 			"readonly_dirs", uniqueCleanAbsPaths(c.sessionConfig.ReadOnlyDirs),
 			"network_mode", c.sessionConfig.NetworkMode,
-			"wait_err", c.waitErr,
-			"reader_err", c.readerErr,
-			"stderr", c.Stderr(),
+			"wait_err", diagnostics.waitErr,
+			"reader_err", diagnostics.readerErr,
+			"stderr", diagnostics.stderr,
 			"error", err,
 		)
 		_ = c.Close()
@@ -378,6 +382,8 @@ func (c *Client) captureStderr(stderr io.Reader) {
 	if stderr == nil {
 		return
 	}
+	c.stderrMu.Lock()
+	defer c.stderrMu.Unlock()
 	_, _ = io.Copy(&c.stderrBuf, stderr)
 }
 
@@ -535,8 +541,28 @@ func (c *Client) terminalErrLocked() error {
 	return fmt.Errorf("boxshclient: process exited")
 }
 
+type diagnosticsSnapshot struct {
+	waitErr   error
+	readerErr error
+	stderr    string
+}
+
+func (c *Client) snapshotDiagnostics() diagnosticsSnapshot {
+	c.mu.Lock()
+	waitErr := c.waitErr
+	readerErr := c.readerErr
+	c.mu.Unlock()
+	return diagnosticsSnapshot{
+		waitErr:   waitErr,
+		readerErr: readerErr,
+		stderr:    c.Stderr(),
+	}
+}
+
 // Stderr returns buffered stderr output from the boxsh process.
 func (c *Client) Stderr() string {
+	c.stderrMu.RLock()
+	defer c.stderrMu.RUnlock()
 	return strings.TrimSpace(c.stderrBuf.String())
 }
 

--- a/plugins/sandbox/boxsh/boxshclient/client.go
+++ b/plugins/sandbox/boxsh/boxshclient/client.go
@@ -18,6 +18,9 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // Client manages a boxsh --rpc subprocess and provides typed RPC methods.
@@ -109,39 +112,59 @@ func New(binaryPath string, cfg SessionConfig) *Client {
 
 // Start launches the boxsh --rpc subprocess and initializes the session.
 func (c *Client) Start(ctx context.Context) error {
+	ctx, span := tracer.Start(ctx, "sandbox.boxsh.client_start",
+		trace.WithAttributes(commonTraceAttrs(c.sessionConfig)...),
+	)
+	defer span.End()
+
 	c.mu.Lock()
 	if c.closed {
 		c.mu.Unlock()
-		return fmt.Errorf("boxshclient: client is closed")
+		err := fmt.Errorf("boxshclient: client is closed")
+		recordTraceError(span, err)
+		return err
 	}
 	if c.started {
 		c.mu.Unlock()
-		return fmt.Errorf("boxshclient: client already started")
+		err := fmt.Errorf("boxshclient: client already started")
+		recordTraceError(span, err)
+		return err
 	}
 	c.mu.Unlock()
 
 	args, err := c.buildArgs()
 	if err != nil {
+		recordTraceError(span, err)
 		return err
 	}
+	span.SetAttributes(attribute.Int("anna.sandbox.arg_count", len(args)))
 	cmd := exec.CommandContext(ctx, c.binaryPath, args...)
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		return fmt.Errorf("boxshclient: stdin pipe: %w", err)
+		err = fmt.Errorf("boxshclient: stdin pipe: %w", err)
+		recordTraceError(span, err)
+		return err
 	}
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return fmt.Errorf("boxshclient: stdout pipe: %w", err)
+		err = fmt.Errorf("boxshclient: stdout pipe: %w", err)
+		recordTraceError(span, err)
+		return err
 	}
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
-		return fmt.Errorf("boxshclient: stderr pipe: %w", err)
+		err = fmt.Errorf("boxshclient: stderr pipe: %w", err)
+		recordTraceError(span, err)
+		return err
 	}
 
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("boxshclient: start: %w", err)
+		err = fmt.Errorf("boxshclient: start: %w", err)
+		recordTraceError(span, err)
+		return err
 	}
+	span.SetAttributes(attribute.Int("process.pid", cmd.Process.Pid))
 
 	processDone := make(chan struct{})
 
@@ -164,6 +187,7 @@ func (c *Client) Start(ctx context.Context) error {
 	go c.captureStderr(stderr)
 
 	if err := c.handshake(ctx); err != nil {
+		recordTraceError(span, err)
 		slog.Warn("boxsh client handshake failed",
 			"component", "boxsh_client",
 			"binary", c.binaryPath,
@@ -182,6 +206,7 @@ func (c *Client) Start(ctx context.Context) error {
 		return fmt.Errorf("boxshclient: handshake: %w", err)
 	}
 
+	span.AddEvent("sandbox.boxsh.client.ready")
 	return nil
 }
 
@@ -213,6 +238,11 @@ func (c *Client) buildArgs() ([]string, error) {
 
 // handshake verifies the session is ready using boxsh's initialize request.
 func (c *Client) handshake(ctx context.Context) error {
+	ctx, span := tracer.Start(ctx, "sandbox.boxsh.handshake",
+		trace.WithAttributes(commonTraceAttrs(c.sessionConfig)...),
+	)
+	defer span.End()
+
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
@@ -231,11 +261,19 @@ func (c *Client) handshake(ctx context.Context) error {
 			"version": "dev",
 		},
 	}, &result); err != nil {
+		recordTraceError(span, err)
 		return err
 	}
 	if !strings.EqualFold(result.ServerInfo.Name, "boxsh") {
-		return fmt.Errorf("unexpected initialize response from %q", result.ServerInfo.Name)
+		err := fmt.Errorf("unexpected initialize response from %q", result.ServerInfo.Name)
+		recordTraceError(span, err)
+		return err
 	}
+	span.SetAttributes(
+		attribute.String("anna.sandbox.server.name", result.ServerInfo.Name),
+		attribute.String("anna.sandbox.server.version", result.ServerInfo.Version),
+		attribute.String("anna.sandbox.protocol_version", result.ProtocolVersion),
+	)
 	return nil
 }
 

--- a/plugins/sandbox/boxsh/boxshclient/client.go
+++ b/plugins/sandbox/boxsh/boxshclient/client.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -163,6 +164,20 @@ func (c *Client) Start(ctx context.Context) error {
 	go c.captureStderr(stderr)
 
 	if err := c.handshake(ctx); err != nil {
+		slog.Warn("boxsh client handshake failed",
+			"component", "boxsh_client",
+			"binary", c.binaryPath,
+			"args", args,
+			"src", c.sessionConfig.Src,
+			"dst", c.sessionConfig.Dst,
+			"cwd", c.sessionConfig.Cwd,
+			"readonly_dirs", uniqueCleanAbsPaths(c.sessionConfig.ReadOnlyDirs),
+			"network_mode", c.sessionConfig.NetworkMode,
+			"wait_err", c.waitErr,
+			"reader_err", c.readerErr,
+			"stderr", c.Stderr(),
+			"error", err,
+		)
 		_ = c.Close()
 		return fmt.Errorf("boxshclient: handshake: %w", err)
 	}

--- a/plugins/sandbox/boxsh/boxshclient/trace.go
+++ b/plugins/sandbox/boxsh/boxshclient/trace.go
@@ -1,0 +1,32 @@
+package boxshclient
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+var tracer = otel.Tracer("anna/sandbox/boxshclient")
+
+func commonTraceAttrs(cfg SessionConfig) []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("anna.sandbox.backend", "boxsh"),
+		attribute.String("anna.sandbox.src", cfg.Src),
+		attribute.String("anna.sandbox.dst", cfg.Dst),
+		attribute.String("anna.sandbox.cwd", cfg.Cwd),
+		attribute.Int("anna.sandbox.readonly_dir_count", len(uniqueCleanAbsPaths(cfg.ReadOnlyDirs))),
+		attribute.String("anna.sandbox.network.mode", cfg.NetworkMode),
+	}
+}
+
+func recordTraceError(span trace.Span, err error) {
+	if span == nil || err == nil {
+		return
+	}
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
+	span.SetAttributes(attribute.String("error.type", fmt.Sprintf("%T", err)))
+}

--- a/plugins/sandbox/boxsh/session.go
+++ b/plugins/sandbox/boxsh/session.go
@@ -11,6 +11,9 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
 	sandboxpkg "github.com/vaayne/anna/pkg/sandbox"
 	"github.com/vaayne/anna/plugins/sandbox/boxsh/boxshclient"
 )
@@ -130,20 +133,33 @@ func (f *boxshFactory) CreateSession(ctx context.Context, policy Policy) (Sessio
 		backendCfg.Sandbox.Mode = boxshclient.NetworkAllowAll
 	}
 
+	sessionID := nextSessionID()
+	ctx, span := tracer.Start(ctx, "sandbox.boxsh.session",
+		trace.WithAttributes(sessionTraceAttrs(sessionID, policy, backendCfg)...),
+	)
+
 	backend, err := boxshclient.NewSharedBackend(backendCfg)
 	if err != nil {
+		recordError(span, err)
+		span.End()
 		return nil, fmt.Errorf("boxsh session: %w", err)
 	}
 	if err := backend.Start(ctx, backendCfg); err != nil {
+		recordError(span, err)
+		span.End()
 		return nil, fmt.Errorf("boxsh session: start backend: %w", err)
 	}
+	span.AddEvent("sandbox.boxsh.session.ready", trace.WithAttributes(
+		attribute.String("anna.sandbox.binary", binaryPath),
+	))
 
 	session := &boxshSession{
-		id:      nextSessionID(),
-		policy:  policy,
-		backend: backend,
-		client:  backend.Client(),
-		done:    make(chan struct{}),
+		id:        sessionID,
+		policy:    policy,
+		backend:   backend,
+		client:    backend.Client(),
+		done:      make(chan struct{}),
+		traceSpan: span,
 	}
 	if policy.RequiresWhitelist() && policy.Relaxed {
 		logRelaxedMode(session.id, f.Name(), "boxsh whitelist mode relaxed to allow_all", policy, "network whitelist treated as allow_all")
@@ -155,16 +171,18 @@ func (f *boxshFactory) CreateSession(ctx context.Context, policy Policy) (Sessio
 
 // boxshSession is a boxsh-backed sandbox session.
 type boxshSession struct {
-	id       string
-	policy   Policy
-	backend  *boxshclient.SharedBackend
-	client   *boxshclient.Client
-	host     *boxshHost
-	done     chan struct{}
-	doneOnce sync.Once
-	closed   bool
-	closeErr error
-	mu       sync.RWMutex
+	id        string
+	policy    Policy
+	backend   *boxshclient.SharedBackend
+	client    *boxshclient.Client
+	host      *boxshHost
+	done      chan struct{}
+	doneOnce  sync.Once
+	closed    bool
+	closeErr  error
+	traceSpan trace.Span
+	traceOnce sync.Once
+	mu        sync.RWMutex
 }
 
 func (s *boxshSession) Host() Host {
@@ -206,11 +224,26 @@ func (s *boxshSession) watchBackend() {
 			return
 		}
 		if backend == nil || !backend.Alive() {
+			err := fmt.Errorf("boxsh backend liveness lost")
+			s.endTrace("liveness_lost", err)
 			logSessionClosed(s.id, "boxsh", "liveness_lost")
 			s.closeDone()
 			return
 		}
 	}
+}
+
+func (s *boxshSession) endTrace(reason string, err error) {
+	s.traceOnce.Do(func() {
+		if s.traceSpan == nil {
+			return
+		}
+		s.traceSpan.AddEvent("sandbox.boxsh.session.closed", trace.WithAttributes(
+			attribute.String("anna.sandbox.close_reason", reason),
+		))
+		recordError(s.traceSpan, err)
+		s.traceSpan.End()
+	})
 }
 
 func (s *boxshSession) Close() error {
@@ -230,6 +263,7 @@ func (s *boxshSession) Close() error {
 	}
 
 	s.closeDone()
+	s.endTrace("explicit_close", s.closeErr)
 	logSessionClosed(s.id, "boxsh", "explicit_close")
 	return s.closeErr
 }

--- a/plugins/sandbox/boxsh/trace.go
+++ b/plugins/sandbox/boxsh/trace.go
@@ -1,0 +1,35 @@
+package boxsh
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/vaayne/anna/plugins/sandbox/boxsh/boxshclient"
+)
+
+var tracer = otel.Tracer("anna/sandbox/boxsh")
+
+func sessionTraceAttrs(sessionID string, policy Policy, cfg boxshclient.BackendConfig) []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("anna.sandbox.backend", "boxsh"),
+		attribute.String("anna.sandbox.session.id", sessionID),
+		attribute.String("anna.sandbox.user_root", cfg.UserRoot),
+		attribute.String("anna.sandbox.work_dir", cfg.WorkDir),
+		attribute.String("anna.sandbox.network.mode", cfg.Sandbox.ModeOrDefault()),
+		attribute.Int("anna.sandbox.readonly_dir_count", len(cfg.ReadOnlyDirs)),
+		attribute.Bool("anna.sandbox.relaxed", policy.Relaxed),
+	}
+}
+
+func recordError(span trace.Span, err error) {
+	if span == nil || err == nil {
+		return
+	}
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
+	span.SetAttributes(attribute.String("error.type", fmt.Sprintf("%T", err)))
+}


### PR DESCRIPTION
## Summary
- log boxsh startup inputs and captured stderr around backend/client startup failures
- add OpenTelemetry spans for sandbox session creation, backend startup, client startup, handshake, and shutdown
- document the new sandbox lifecycle spans and attributes in the trace plugin docs

## Testing
- mise run format
- mise run test -- ./plugins/sandbox/boxsh/... ./internal/agent/runner ./plugins/hooks/trace

## Context
This helps debug the v0.11.0 regression where boxsh session startup fails with a broken pipe during handshake by exposing the full sandbox lifecycle in logs and traces.
