### PR TITLE
🐛 fix: harden scheduler runtime stability

### DIFF
--- a/cmd/anna/commands.go
+++ b/cmd/anna/commands.go
@@ -301,7 +301,7 @@ func setup(parent context.Context, gateway bool) (*setupResult, error) {
 			}
 			sessionID := job.SessionID()
 			msg := fmt.Sprintf("[Scheduled Task] %s\n\nInstruction: %s", job.Name, job.Message)
-			ch := targetPool.Chat(ctx, sessionID, msg)
+			ch := targetPool.Chat(schedulerJobContext(ctx, targetPool, job), sessionID, msg)
 			var runErr error
 			for evt := range ch {
 				if evt.Err != nil {

--- a/cmd/anna/commands.go
+++ b/cmd/anna/commands.go
@@ -127,7 +127,9 @@ func setup(parent context.Context, gateway bool) (*setupResult, error) {
 
 	// Create the shared scheduler service before runner construction so both
 	// plugin-owned jobs and the user-facing scheduler tool can use it.
-	schedulerSvc, err := scheduler.NewFromPath(dbPath)
+	// Reuse the process-wide DB handle so scheduler persistence and memory writes
+	// do not contend through separate SQLite pools.
+	schedulerSvc, err := scheduler.New(db)
 	if err != nil {
 		return nil, fmt.Errorf("create scheduler service: %w", err)
 	}

--- a/cmd/anna/commands.go
+++ b/cmd/anna/commands.go
@@ -300,8 +300,7 @@ func setup(parent context.Context, gateway bool) (*setupResult, error) {
 				}
 			}
 			sessionID := job.SessionID()
-			msg := fmt.Sprintf("[Scheduled Task] %s\n\nInstruction: %s", job.Name, job.Message)
-			ch := targetPool.Chat(schedulerJobContext(ctx, targetPool, job), sessionID, msg)
+			ch := targetPool.Chat(schedulerJobContext(ctx, targetPool, job), sessionID, schedulerJobMessage(job))
 			var runErr error
 			for evt := range ch {
 				if evt.Err != nil {

--- a/cmd/anna/gateway.go
+++ b/cmd/anna/gateway.go
@@ -24,6 +24,7 @@ import (
 	"github.com/vaayne/anna/internal/pluginhost"
 	"github.com/vaayne/anna/internal/scheduler"
 	pkgchannel "github.com/vaayne/anna/pkg/channel"
+	"github.com/vaayne/anna/pkg/memory"
 	"github.com/vaayne/anna/pkg/providers"
 	reflectplugin "github.com/vaayne/anna/plugins/reflect"
 	"golang.org/x/sync/errgroup"
@@ -208,8 +209,10 @@ func wireSchedulerNotifier(schedulerSvc *scheduler.Service, poolMgr *agent.PoolM
 		sessionID := job.SessionID()
 		msg := fmt.Sprintf("[Scheduled Task] %s\n\nInstruction: %s", job.Name, job.Message)
 
+		jobCtx := schedulerJobContext(ctx, pool, job)
+
 		var result strings.Builder
-		for evt := range pool.Chat(ctx, sessionID, msg) {
+		for evt := range pool.Chat(jobCtx, sessionID, msg) {
 			if evt.Err != nil {
 				slog.Error("scheduler job error", "job_id", job.ID, "error", evt.Err)
 			}
@@ -254,6 +257,16 @@ func dispatchSchedulerNotification(ctx context.Context, dispatcher *notify.Dispa
 	}
 
 	return dispatcher.Notify(ctx, notification)
+}
+
+func schedulerJobContext(ctx context.Context, pool *agent.Pool, job scheduler.Job) context.Context {
+	if job.UserID != 0 {
+		ctx = memory.WithUserID(ctx, job.UserID)
+	}
+	if pool.AgentID() != "" {
+		ctx = memory.WithAgentID(ctx, pool.AgentID())
+	}
+	return ctx
 }
 
 func launchBrowser(url string) {

--- a/cmd/anna/gateway.go
+++ b/cmd/anna/gateway.go
@@ -16,6 +16,7 @@ import (
 	ucli "github.com/urfave/cli/v2"
 	"github.com/vaayne/anna/internal/admin"
 	"github.com/vaayne/anna/internal/agent"
+	"github.com/vaayne/anna/internal/agent/runner"
 	"github.com/vaayne/anna/internal/auth"
 	"github.com/vaayne/anna/internal/channel"
 	"github.com/vaayne/anna/internal/config"
@@ -266,6 +267,9 @@ func schedulerJobContext(ctx context.Context, pool *agent.Pool, job scheduler.Jo
 	if pool.AgentID() != "" {
 		ctx = memory.WithAgentID(ctx, pool.AgentID())
 	}
+	// Scheduled executions already have an external delivery path and should not
+	// mutate scheduler control-plane state while they run.
+	ctx = runner.WithExcludedTools(ctx, "notify", "scheduler")
 	return ctx
 }
 

--- a/cmd/anna/gateway.go
+++ b/cmd/anna/gateway.go
@@ -207,7 +207,7 @@ func wireSchedulerNotifier(schedulerSvc *scheduler.Service, poolMgr *agent.PoolM
 
 		pool := schedulerPool(job, poolMgr, defaultPool)
 		sessionID := job.SessionID()
-		msg := fmt.Sprintf("[Scheduled Task] %s\n\nInstruction: %s", job.Name, job.Message)
+		msg := schedulerJobMessage(job)
 
 		jobCtx := schedulerJobContext(ctx, pool, job)
 
@@ -267,6 +267,10 @@ func schedulerJobContext(ctx context.Context, pool *agent.Pool, job scheduler.Jo
 		ctx = memory.WithAgentID(ctx, pool.AgentID())
 	}
 	return ctx
+}
+
+func schedulerJobMessage(job scheduler.Job) string {
+	return fmt.Sprintf("[Scheduled Task] %s\n\nInstruction: %s\n\nDo not use the notify tool. Your final response will be delivered automatically.", job.Name, job.Message)
 }
 
 func launchBrowser(url string) {

--- a/internal/agent/pool_reaper.go
+++ b/internal/agent/pool_reaper.go
@@ -44,6 +44,9 @@ func (p *Pool) reap() {
 
 		if !aliver.Alive() {
 			p.log.Warn("removing dead runner", "session_id", id)
+			if closer, isCloser := sess.Runner.(io.Closer); isCloser {
+				_ = closer.Close()
+			}
 			sess.Runner = nil
 			continue
 		}

--- a/internal/agent/pool_runner.go
+++ b/internal/agent/pool_runner.go
@@ -55,6 +55,18 @@ func (p *Pool) getOrCreateRunner(ctx context.Context, sessionID string, model st
 			sess.Info = SessionInfo{ID: sessionID, CreatedAt: time.Now(), LastActive: time.Now()}
 		}
 	}
+	if sess.Info.UserID == 0 {
+		if userID := memory.UserIDFromContext(ctx); userID != 0 {
+			sess.Info.UserID = userID
+		}
+	}
+	if sess.Info.AgentID == "" {
+		if agentID := memory.AgentIDFromContext(ctx); agentID != "" {
+			sess.Info.AgentID = agentID
+		} else if p.agentID != "" {
+			sess.Info.AgentID = p.agentID
+		}
+	}
 
 	// Snapshot all mutable pool fields while still holding the lock.
 	factory := p.factory

--- a/internal/agent/pool_test.go
+++ b/internal/agent/pool_test.go
@@ -450,6 +450,9 @@ func TestPoolReapDead(t *testing.T) {
 	if !runnerNil {
 		t.Error("dead runner should be nil'd after reap")
 	}
+	if !(*runners)[0].closed {
+		t.Error("dead runner should be closed during reap")
+	}
 }
 
 func TestPoolStartReaperCancels(t *testing.T) {

--- a/internal/agent/pool_test.go
+++ b/internal/agent/pool_test.go
@@ -1350,6 +1350,33 @@ func TestPoolGetOrCreateRunnerRestoresFromMemEngine(t *testing.T) {
 	}
 }
 
+func TestPoolGetOrCreateRunnerSeedsScopeFromContext(t *testing.T) {
+	factory := func(_ context.Context, params runner.RunnerParams) (runner.Runner, error) {
+		if params.UserID != 42 {
+			return nil, fmt.Errorf("UserID = %d, want 42", params.UserID)
+		}
+		if params.AgentID != "agent-blue" {
+			return nil, fmt.Errorf("AgentID = %q, want %q", params.AgentID, "agent-blue")
+		}
+		return newMockRunner([]runner.Event{{Text: "ok"}}), nil
+	}
+	mem := testMemoryProvider(t)
+	pool := NewPool(factory, mem, WithAgentID("agent-blue"))
+	defer func() { _ = pool.Close() }()
+
+	ctx := memory.WithAgentID(memory.WithUserID(context.Background(), 42), "agent-blue")
+	sess, _, err := pool.getOrCreateRunner(ctx, "scoped-sess", "")
+	if err != nil {
+		t.Fatalf("getOrCreateRunner: %v", err)
+	}
+	if sess.Info.UserID != 42 {
+		t.Fatalf("session UserID = %d, want 42", sess.Info.UserID)
+	}
+	if sess.Info.AgentID != "agent-blue" {
+		t.Fatalf("session AgentID = %q, want %q", sess.Info.AgentID, "agent-blue")
+	}
+}
+
 func TestPoolChatToolUseEventPassthrough(t *testing.T) {
 	// ToolUse events should pass through without being stored.
 	toolUseEvt := &runner.ToolUseEvent{

--- a/internal/agent/runner/context.go
+++ b/internal/agent/runner/context.go
@@ -5,6 +5,7 @@ import "context"
 type (
 	systemOverrideKey struct{}
 	channelKey        struct{}
+	excludedToolsKey  struct{}
 )
 
 // WithSystemOverride returns a child context that carries a per-run system prompt override.
@@ -39,4 +40,38 @@ func ChannelFromContext(ctx context.Context) (string, bool) {
 	}
 	channel, ok := ctx.Value(channelKey{}).(string)
 	return channel, ok && channel != ""
+}
+
+// WithExcludedTools returns a child context that hides the named tools for a single run.
+func WithExcludedTools(ctx context.Context, names ...string) context.Context {
+	filtered := make([]string, 0, len(names))
+	seen := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		filtered = append(filtered, name)
+	}
+	if len(filtered) == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, excludedToolsKey{}, filtered)
+}
+
+// ExcludedToolsFromContext returns the per-run excluded tool names when present.
+func ExcludedToolsFromContext(ctx context.Context) []string {
+	if ctx == nil {
+		return nil
+	}
+	names, _ := ctx.Value(excludedToolsKey{}).([]string)
+	if len(names) == 0 {
+		return nil
+	}
+	out := make([]string, len(names))
+	copy(out, names)
+	return out
 }

--- a/internal/agent/runner/gorunner.go
+++ b/internal/agent/runner/gorunner.go
@@ -179,11 +179,17 @@ func NewGoRunner(ctx context.Context, cfg GoRunnerConfig) (*GoRunner, error) {
 }
 
 func newAgentRunner(reg *providers.Registry, toolReg *tools.Registry, model ai.Model, streamOptions ai.StreamOptions, system string, hookSet *hooks.HookSet, toolLifecycle *coreagent.ToolLifecycle) (*coreagent.Runner, error) {
+	toolSet := coreagent.ToolSetFromRegistry(toolReg)
+	toolDefs := toolReg.Definitions()
+	return newAgentRunnerWithTools(reg, model, streamOptions, system, hookSet, toolLifecycle, toolSet, toolDefs)
+}
+
+func newAgentRunnerWithTools(reg *providers.Registry, model ai.Model, streamOptions ai.StreamOptions, system string, hookSet *hooks.HookSet, toolLifecycle *coreagent.ToolLifecycle, toolSet coreagent.ToolSet, toolDefs []tools.Definition) (*coreagent.Runner, error) {
 	return coreagent.NewRunner(coreagent.RunnerConfig{
 		Providers:       reg,
 		Model:           model,
-		Tools:           coreagent.ToolSetFromRegistry(toolReg),
-		ToolDefinitions: toolReg.Definitions(),
+		Tools:           toolSet,
+		ToolDefinitions: toolDefs,
 	},
 		coreagent.WithStreamOptions(streamOptions),
 		coreagent.WithMaxTurns(maxToolIterations),
@@ -273,6 +279,27 @@ func collectSandboxReadOnlyDirs(extraDirs []string, toolsBinDir, pathEnv string)
 	return dirs
 }
 
+func filterRunnerTools(reg *tools.Registry, excluded []string) (coreagent.ToolSet, []tools.Definition, error) {
+	if len(excluded) == 0 {
+		return coreagent.ToolSetFromRegistry(reg), reg.Definitions(), nil
+	}
+	blocked := make(map[string]struct{}, len(excluded))
+	for _, name := range excluded {
+		if name == "" {
+			continue
+		}
+		blocked[name] = struct{}{}
+	}
+	allowed := make([]string, 0, len(reg.Definitions()))
+	for _, def := range reg.Definitions() {
+		if _, skip := blocked[def.Name]; skip {
+			continue
+		}
+		allowed = append(allowed, def.Name)
+	}
+	return coreagent.ToolSetFromRegistryFiltered(reg, allowed)
+}
+
 func buildAgentPresets(cfg GoRunnerConfig) *agenttool.PresetRegistry {
 	paths := resolveRunnerPaths(cfg)
 	if err := builtin.Extract(paths.builtinSkillsDir()); err != nil {
@@ -329,8 +356,24 @@ func (r *GoRunner) Chat(ctx context.Context, history []ai.Message, message Messa
 		defer close(out)
 
 		loopRunner := r.runner
-		if override, ok := SystemOverrideFromContext(ctx); ok && override != r.system {
-			tempRunner, err := newAgentRunner(r.reg, r.tools, r.model, r.streamOptions, override, r.hookSet, r.toolLifecycle)
+		effectiveSystem := r.system
+		if override, ok := SystemOverrideFromContext(ctx); ok && override != "" {
+			effectiveSystem = override
+		}
+		excludedTools := ExcludedToolsFromContext(ctx)
+		if effectiveSystem != r.system || len(excludedTools) > 0 {
+			toolSet := coreagent.ToolSetFromRegistry(r.tools)
+			toolDefs := r.tools.Definitions()
+			if len(excludedTools) > 0 {
+				filteredSet, filteredDefs, err := filterRunnerTools(r.tools, excludedTools)
+				if err != nil {
+					out <- Event{Err: fmt.Errorf("go runner: %w", err)}
+					return
+				}
+				toolSet = filteredSet
+				toolDefs = filteredDefs
+			}
+			tempRunner, err := newAgentRunnerWithTools(r.reg, r.model, r.streamOptions, effectiveSystem, r.hookSet, r.toolLifecycle, toolSet, toolDefs)
 			if err != nil {
 				out <- Event{Err: fmt.Errorf("go runner: %w", err)}
 				return

--- a/internal/agent/runner/gorunner.go
+++ b/internal/agent/runner/gorunner.go
@@ -25,7 +25,10 @@ import (
 	agenttool "github.com/vaayne/anna/plugins/tools/agent"
 )
 
-const maxToolIterations = 40
+// maxAgentLoopTurns caps one runner invocation's model/tool decision loop.
+// A single turn may include multiple tool calls; the limit is on loop rounds,
+// not individual tool executions.
+const maxAgentLoopTurns = 50
 
 type ProviderRegistryBuilder func(api, apiKey, baseURL string) (*providers.Registry, error)
 
@@ -192,7 +195,7 @@ func newAgentRunnerWithTools(reg *providers.Registry, model ai.Model, streamOpti
 		ToolDefinitions: toolDefs,
 	},
 		coreagent.WithStreamOptions(streamOptions),
-		coreagent.WithMaxTurns(maxToolIterations),
+		coreagent.WithMaxTurns(maxAgentLoopTurns),
 		coreagent.WithSystem(system),
 		coreagent.WithHooks(hookSet, hooks.HookMeta{}),
 		coreagent.WithToolLifecycle(toolLifecycle),

--- a/internal/agent/runner/gorunner_test.go
+++ b/internal/agent/runner/gorunner_test.go
@@ -14,10 +14,21 @@ import (
 	"github.com/vaayne/anna/internal/embedded"
 	"github.com/vaayne/anna/pkg/ai"
 	"github.com/vaayne/anna/pkg/providers"
+	"github.com/vaayne/anna/pkg/tools"
 	"github.com/vaayne/anna/plugins/sandbox/boxsh/boxshclient"
 )
 
 type stubProvider struct{}
+
+type stubTool struct{ name string }
+
+func (s *stubTool) Definition() tools.Definition {
+	return tools.Definition{Name: s.name, Description: "stub tool"}
+}
+
+func (s *stubTool) Execute(context.Context, map[string]any) (string, error) {
+	return s.name, nil
+}
 
 func (s *stubProvider) API() string { return "anthropic" }
 func (s *stubProvider) Stream(context.Context, ai.Model, ai.Context, ai.StreamOptions) (providers.AssistantEventStream, error) {
@@ -93,6 +104,38 @@ func withTestRunnerPaths(t *testing.T, cfg GoRunnerConfig) GoRunnerConfig {
 	cfg.AgentRoot = workspace
 	cfg.UserRoot = userRoot
 	return cfg
+}
+
+func TestFilterRunnerTools(t *testing.T) {
+	reg := tools.NewRegistry()
+	reg.Register(&stubTool{name: "bash"})
+	reg.Register(&stubTool{name: "notify"})
+	reg.Register(&stubTool{name: "scheduler"})
+
+	set, defs, err := filterRunnerTools(reg, []string{"notify", "scheduler"})
+	if err != nil {
+		t.Fatalf("filterRunnerTools: %v", err)
+	}
+	if len(defs) != 1 || defs[0].Name != "bash" {
+		t.Fatalf("defs = %#v, want only bash", defs)
+	}
+	if _, ok := set["notify"]; ok {
+		t.Fatal("notify should be excluded")
+	}
+	if _, ok := set["scheduler"]; ok {
+		t.Fatal("scheduler should be excluded")
+	}
+	if _, ok := set["bash"]; !ok {
+		t.Fatal("bash should remain available")
+	}
+
+	result, err := set["bash"](context.Background(), ai.ToolCall{Name: "bash"})
+	if err != nil {
+		t.Fatalf("execute filtered bash tool: %v", err)
+	}
+	if result.Text != "bash" {
+		t.Fatalf("filtered bash result = %q, want bash", result.Text)
+	}
 }
 
 func TestNewGoRunnerRequiresConfig(t *testing.T) {

--- a/internal/db/database.go
+++ b/internal/db/database.go
@@ -8,12 +8,17 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	_ "modernc.org/sqlite"
 )
 
+const (
+	sqliteBusyTimeout = 5 * time.Second
+)
+
 // OpenDB opens a SQLite database at the given path, configures it
-// (WAL mode, foreign keys) and runs migrations. The parent directory
+// (WAL mode, foreign keys, busy timeout) and runs migrations. The parent directory
 // is created if it doesn't exist.
 func OpenDB(dbPath string) (*sql.DB, error) {
 	dir := filepath.Dir(dbPath)
@@ -26,6 +31,7 @@ func OpenDB(dbPath string) (*sql.DB, error) {
 		return nil, fmt.Errorf("db: open: %w", err)
 	}
 
+	configurePool(db)
 	if err := ConfigureDB(db); err != nil {
 		_ = db.Close()
 		return nil, err
@@ -39,16 +45,38 @@ func OpenDB(dbPath string) (*sql.DB, error) {
 	return db, nil
 }
 
-// ConfigureDB enables WAL mode and foreign keys on an existing *sql.DB.
-// This is useful when multiple packages need to share the same connection.
+// ConfigureDB enables the SQLite connection policy Anna relies on.
+// Connection-level pragmas are safe here because OpenDB constrains each handle
+// to a single long-lived underlying connection.
 func ConfigureDB(db *sql.DB) error {
-	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
-		return fmt.Errorf("db: enable WAL: %w", err)
+	configurePool(db)
+	pragmas := []struct {
+		query string
+		name  string
+	}{
+		{query: "PRAGMA journal_mode=WAL", name: "enable WAL"},
+		{query: fmt.Sprintf("PRAGMA busy_timeout=%d", sqliteBusyTimeout.Milliseconds()), name: "set busy timeout"},
+		{query: "PRAGMA foreign_keys=ON", name: "enable foreign keys"},
 	}
-	if _, err := db.Exec("PRAGMA foreign_keys=ON"); err != nil {
-		return fmt.Errorf("db: enable foreign keys: %w", err)
+	for _, pragma := range pragmas {
+		if _, err := db.Exec(pragma.query); err != nil {
+			return fmt.Errorf("db: %s: %w", pragma.name, err)
+		}
 	}
 	return nil
+}
+
+func configurePool(db *sql.DB) {
+	if db == nil {
+		return
+	}
+	// SQLite only allows one writer at a time. Keeping one underlying
+	// connection per handle makes connection-scoped PRAGMAs deterministic and
+	// avoids self-contention inside a single *sql.DB pool.
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	db.SetConnMaxLifetime(0)
+	db.SetConnMaxIdleTime(0)
 }
 
 // migrate applies pending SQL migration files from the embedded migrations

--- a/internal/db/database_test.go
+++ b/internal/db/database_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	_ "modernc.org/sqlite"
 )
@@ -85,6 +86,45 @@ func TestOpenDBDropsLegacyFeishuTokensTableOnUpgrade(t *testing.T) {
 
 	if tableExists(t, upgraded, "feishu_tokens") {
 		t.Fatal("feishu_tokens table should be dropped during upgrade migrations")
+	}
+}
+
+func TestOpenDBConfiguresSQLiteContentionPolicy(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "contention.db")
+	db, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	if got := db.Stats().MaxOpenConnections; got != 1 {
+		t.Fatalf("MaxOpenConnections = %d, want 1", got)
+	}
+
+	var journalMode string
+	if err := db.QueryRow("PRAGMA journal_mode").Scan(&journalMode); err != nil {
+		t.Fatalf("PRAGMA journal_mode: %v", err)
+	}
+	if !strings.EqualFold(journalMode, "wal") {
+		t.Fatalf("journal_mode = %q, want wal", journalMode)
+	}
+
+	var busyTimeout int
+	if err := db.QueryRow("PRAGMA busy_timeout").Scan(&busyTimeout); err != nil {
+		t.Fatalf("PRAGMA busy_timeout: %v", err)
+	}
+	if busyTimeout != int(sqliteBusyTimeout/time.Millisecond) {
+		t.Fatalf("busy_timeout = %dms, want %dms", busyTimeout, sqliteBusyTimeout/time.Millisecond)
+	}
+
+	var foreignKeys int
+	if err := db.QueryRow("PRAGMA foreign_keys").Scan(&foreignKeys); err != nil {
+		t.Fatalf("PRAGMA foreign_keys: %v", err)
+	}
+	if foreignKeys != 1 {
+		t.Fatalf("foreign_keys = %d, want 1", foreignKeys)
 	}
 }
 

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	appdb "github.com/vaayne/anna/internal/db"
+	"github.com/vaayne/anna/pkg/memory"
 )
 
 func testDB(t *testing.T) *sql.DB {
@@ -553,6 +554,33 @@ func TestSchedulerToolSessionMode(t *testing.T) {
 	}
 	if jobs[0].SessionMode != SessionNew {
 		t.Errorf("SessionMode = %q, want %q", jobs[0].SessionMode, SessionNew)
+	}
+}
+
+func TestSchedulerToolCapturesContextOwnership(t *testing.T) {
+	svc := testService(t)
+	ct := NewTool(svc)
+
+	ctx := memory.WithAgentID(memory.WithUserID(context.Background(), 42), "agent-blue")
+	_, err := ct.Execute(ctx, map[string]any{
+		"action":  "add",
+		"name":    "owned-job",
+		"message": "do work",
+		"every":   "1h",
+	})
+	if err != nil {
+		t.Fatalf("Execute add: %v", err)
+	}
+
+	jobs := svc.ListJobs()
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs))
+	}
+	if jobs[0].UserID != 42 {
+		t.Fatalf("UserID = %d, want 42", jobs[0].UserID)
+	}
+	if jobs[0].AgentID != "agent-blue" {
+		t.Fatalf("AgentID = %q, want %q", jobs[0].AgentID, "agent-blue")
 	}
 }
 

--- a/internal/scheduler/service.go
+++ b/internal/scheduler/service.go
@@ -14,6 +14,7 @@ import (
 	appdb "github.com/vaayne/anna/internal/db"
 	"github.com/vaayne/anna/internal/notify"
 	"github.com/vaayne/anna/pkg/db/sqlc"
+	"github.com/vaayne/anna/pkg/memory"
 )
 
 // errOneTimeJobPast is returned by scheduleJob when a one-time job's timestamp
@@ -213,6 +214,23 @@ func (s *Service) ScheduleEvery(ctx context.Context, every string, fn TaskFunc) 
 // AddJob creates, persists, and schedules a new job.
 // sessionMode controls session reuse: "reuse" (default) or "new".
 func (s *Service) AddJob(name, message string, sched Schedule, sessionMode string) (Job, error) {
+	return s.addJobWithOwner(name, message, sched, sessionMode, "", 0)
+}
+
+// AddJobForContext creates a user-owned job bound to the current execution context.
+// When the caller context carries agent/user scope, scheduled executions inherit it.
+func (s *Service) AddJobForContext(ctx context.Context, name, message string, sched Schedule, sessionMode string) (Job, error) {
+	return s.addJobWithOwner(
+		name,
+		message,
+		sched,
+		sessionMode,
+		memory.AgentIDFromContext(ctx),
+		memory.UserIDFromContext(ctx),
+	)
+}
+
+func (s *Service) addJobWithOwner(name, message string, sched Schedule, sessionMode, agentID string, userID int64) (Job, error) {
 	if name == "" {
 		return Job{}, fmt.Errorf("name is required")
 	}
@@ -239,6 +257,8 @@ func (s *Service) AddJob(name, message string, sched Schedule, sessionMode strin
 		Message:     message,
 		SessionMode: sessionMode,
 		Enabled:     true,
+		AgentID:     agentID,
+		UserID:      userID,
 		CreatedAt:   now,
 		UpdatedAt:   now,
 	}
@@ -261,7 +281,7 @@ func (s *Service) AddJob(name, message string, sched Schedule, sessionMode strin
 
 	s.jobs[job.ID] = job
 
-	s.log.Info("job added", "id", job.ID, "name", name)
+	s.log.Info("job added", "id", job.ID, "name", name, "agent_id", agentID, "user_id", userID)
 	return job, nil
 }
 

--- a/internal/scheduler/tool.go
+++ b/internal/scheduler/tool.go
@@ -78,11 +78,11 @@ func (t *SchedulerTool) Definition() tools.Definition {
 }
 
 // Execute runs the scheduler tool action.
-func (t *SchedulerTool) Execute(_ context.Context, args map[string]any) (string, error) {
+func (t *SchedulerTool) Execute(ctx context.Context, args map[string]any) (string, error) {
 	action, _ := args["action"].(string)
 	switch action {
 	case "add":
-		return t.add(args)
+		return t.add(ctx, args)
 	case "list":
 		return t.list()
 	case "remove":
@@ -92,7 +92,7 @@ func (t *SchedulerTool) Execute(_ context.Context, args map[string]any) (string,
 	}
 }
 
-func (t *SchedulerTool) add(args map[string]any) (string, error) {
+func (t *SchedulerTool) add(ctx context.Context, args map[string]any) (string, error) {
 	name, _ := args["name"].(string)
 	message, _ := args["message"].(string)
 	cronExpr, _ := args["cron"].(string)
@@ -101,7 +101,7 @@ func (t *SchedulerTool) add(args map[string]any) (string, error) {
 	at, _ := args["at"].(string)
 	sessionMode, _ := args["session_mode"].(string)
 	sched := Schedule{Cron: cronExpr, Every: every, At: at}
-	job, err := t.service.AddJob(name, message, sched, sessionMode)
+	job, err := t.service.AddJobForContext(ctx, name, message, sched, sessionMode)
 	if err != nil {
 		return "", err
 	}

--- a/plugins/tools/notify/plugin.go
+++ b/plugins/tools/notify/plugin.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	pkgchannel "github.com/vaayne/anna/pkg/channel"
+	"github.com/vaayne/anna/pkg/memory"
 	pkgplugins "github.com/vaayne/anna/pkg/plugins"
 	"github.com/vaayne/anna/pkg/tools"
 )
@@ -57,7 +58,7 @@ var inputSchema = map[string]any{
 		},
 		"chat_id": map[string]any{
 			"type":        "string",
-			"description": "Target chat/channel within the backend. Omit to use the default.",
+			"description": "Target chat/channel within the backend. Usually omit this in user conversations so Anna can resolve the linked identity automatically.",
 		},
 		"silent": map[string]any{
 			"type":        "boolean",
@@ -70,7 +71,7 @@ var inputSchema = map[string]any{
 func (t *Tool) Definition() tools.Definition {
 	return tools.Definition{
 		Name:        "notify",
-		Description: "Send a notification message to the user. Supports multiple backends (Telegram, Slack, etc.). Omit 'channel' to broadcast to all configured backends. Use this for proactive messages, alerts, scheduler summaries, or long-running task results.",
+		Description: "Send a notification message to the user. In normal user conversations, omit 'chat_id' so Anna can route via the current user's linked identities automatically. Supports multiple backends (Telegram, Slack, etc.). Use this for proactive messages, alerts, scheduler summaries, or long-running task results.",
 		InputSchema: inputSchema,
 	}
 }
@@ -85,13 +86,24 @@ func (t *Tool) Execute(ctx context.Context, args map[string]any) (string, error)
 	chatID, _ := args["chat_id"].(string)
 	silent, _ := args["silent"].(bool)
 
-	err := t.service.Notify(ctx, pkgchannel.Notification{
+	notification := pkgchannel.Notification{
 		Channel: ch,
 		ChatID:  chatID,
 		AgentID: pkgchannel.NotificationAgentIDFromContext(ctx),
 		Text:    message,
 		Silent:  silent,
-	})
+	}
+
+	var err error
+	if ch == "" && chatID == "" {
+		if userID := memory.UserIDFromContext(ctx); userID != 0 {
+			err = t.service.NotifyUser(ctx, userID, notification)
+		} else {
+			err = t.service.Notify(ctx, notification)
+		}
+	} else {
+		err = t.service.Notify(ctx, notification)
+	}
 	if err != nil {
 		return "", fmt.Errorf("send notification: %w", err)
 	}

--- a/plugins/tools/notify/plugin_test.go
+++ b/plugins/tools/notify/plugin_test.go
@@ -1,0 +1,67 @@
+package notify
+
+import (
+	"context"
+	"testing"
+
+	pkgchannel "github.com/vaayne/anna/pkg/channel"
+	"github.com/vaayne/anna/pkg/memory"
+)
+
+type mockNotifier struct {
+	notifyCalls     []pkgchannel.Notification
+	notifyUserCalls []struct {
+		userID int64
+		n      pkgchannel.Notification
+	}
+}
+
+func (m *mockNotifier) Notify(_ context.Context, n pkgchannel.Notification) error {
+	m.notifyCalls = append(m.notifyCalls, n)
+	return nil
+}
+
+func (m *mockNotifier) NotifyUser(_ context.Context, userID int64, n pkgchannel.Notification) error {
+	m.notifyUserCalls = append(m.notifyUserCalls, struct {
+		userID int64
+		n      pkgchannel.Notification
+	}{userID: userID, n: n})
+	return nil
+}
+
+func TestToolExecuteUsesNotifyUserForScopedUser(t *testing.T) {
+	notifier := &mockNotifier{}
+	tool := &Tool{service: notifier}
+	ctx := memory.WithUserID(context.Background(), 7)
+
+	_, err := tool.Execute(ctx, map[string]any{"message": "hello"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(notifier.notifyUserCalls) != 1 {
+		t.Fatalf("NotifyUser calls = %d, want 1", len(notifier.notifyUserCalls))
+	}
+	if notifier.notifyUserCalls[0].userID != 7 {
+		t.Fatalf("NotifyUser userID = %d, want 7", notifier.notifyUserCalls[0].userID)
+	}
+	if len(notifier.notifyCalls) != 0 {
+		t.Fatalf("Notify calls = %d, want 0", len(notifier.notifyCalls))
+	}
+}
+
+func TestToolExecuteUsesNotifyForExplicitTarget(t *testing.T) {
+	notifier := &mockNotifier{}
+	tool := &Tool{service: notifier}
+	ctx := memory.WithUserID(context.Background(), 7)
+
+	_, err := tool.Execute(ctx, map[string]any{"message": "hello", "channel": "telegram"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(notifier.notifyCalls) != 1 {
+		t.Fatalf("Notify calls = %d, want 1", len(notifier.notifyCalls))
+	}
+	if len(notifier.notifyUserCalls) != 0 {
+		t.Fatalf("NotifyUser calls = %d, want 0", len(notifier.notifyUserCalls))
+	}
+}


### PR DESCRIPTION
## Summary
- reuse the process DB handle for the scheduler and apply consistent SQLite contention settings
- close dead runners during reap and document boxsh liveness-loss as runner recycling, not silent recovery
- exclude `notify` and `scheduler` from scheduled executions so jobs cannot loop back into control-plane tools

## Testing
- `mise run format`
- `mise run test` *(currently blocked by unrelated hanging test in `plugins/sandbox/boxsh/boxshclient TestClientStartHandshakeFailure`)*

## Notes
- This keeps scheduled jobs delivering through the existing scheduler notification path instead of letting the model call `notify` itself.
- SQLite now uses a consistent single-connection handle policy plus `busy_timeout`, which should reduce `SQLITE_BUSY` under scheduler + memory writes.