### PR TITLE
🐳 fix: install user CLIs in Docker cache

### DIFF
--- a/docs/content/docs/plugins/manifest-tools.md
+++ b/docs/content/docs/plugins/manifest-tools.md
@@ -19,7 +19,27 @@ At startup, Anna:
 4. Registers enabled manifest plugins into the plugin host
 5. Starts binary reconciliation in the background: downloads missing binaries into `$ANNA_HOME/bin`
 
-Startup is not blocked by binary downloads. A newly added or updated manifest binary becomes available on `PATH` inside agent sandbox sessions after the background sync completes.
+Startup is not blocked by binary downloads. A newly added or updated manifest binary becomes available on `PATH` inside agent sandbox sessions after the background sync completes. For local sandbox sessions the binary is available from `$ANNA_HOME/bin`. Docker sandbox sessions need separate handling because host binaries may target the host OS/architecture rather than Linux.
+
+## Docker sandbox CLI availability
+
+Do not treat host `$ANNA_HOME/bin` as the source of Docker sandbox executables. On macOS and Windows, manifest sync can install host-platform binaries, which cannot run in a Linux container. Binding that directory into Docker also blurs the boundary between host-side tool management and the container runtime.
+
+For Docker:
+
+- Built-in CLI plugins that must work out of the box are pre-installed in the versioned sandbox image. The sandbox image tag is tied to the Anna release, so one release image can contain the built-in tool set for that Anna version. Keep the Docker image tool list in `plugins/sandbox/docker/_mise.toml` aligned with built-in CLI plugin declarations in `internal/manifestplugins/builtin_plugins.yaml`.
+- `$ANNA_HOME/plugins.yaml` remains the source of plugin metadata, enablement, session environment, OAuth injection, and local-sandbox binary installation.
+- User-configured CLI binaries need a container-native provisioning path. They should be installed for Linux inside the Docker environment, not copied from the host's `$ANNA_HOME/bin`.
+
+A safe Docker loading design for user-configured CLIs is:
+
+1. Build a container tool manifest from enabled user manifest plugins' `binaries` entries, excluding built-in tools already present in the release image.
+2. Use a short-lived helper container based on the same sandbox image to run `mise install` in a Linux context.
+3. Store the resulting tools in a Docker-managed tool cache or volume keyed by the sandbox image tag plus user manifest hash.
+4. Mount that cache into sandbox sessions at a container-only path and prepend it to the in-container `PATH`.
+5. Rebuild or refresh the cache when the enabled user plugin set or binary versions change.
+
+This keeps the release sandbox image stable while still allowing user-added CLIs. The installed user binaries are Linux container binaries, and the host `$ANNA_HOME/bin` is not part of Docker executable resolution.
 
 ## The manifest file format
 

--- a/docs/content/docs/plugins/manifest-tools.zh.md
+++ b/docs/content/docs/plugins/manifest-tools.zh.md
@@ -19,7 +19,27 @@ Anna 内置了一个默认清单，声明了默认由清单管理的 CLI 集成�
 4. 将已启用的清单插件注册到插件主机
 5. 在后台启动二进制协调：将缺失的二进制文件下载到 `$ANNA_HOME/bin`
 
-启动不会被二进制下载阻塞。新增或更新的清单二进制会在后台同步完成后，出现在 Agent 沙箱会话的 `PATH` 中。
+启动不会被二进制下载阻塞。新增或更新的清单二进制会在后台同步完成后，出现在 Agent 沙箱会话的 `PATH` 中。对于本地沙箱会话，二进制文件通过 `$ANNA_HOME/bin` 提供。Docker 沙箱会话需要单独处理，因为宿主机二进制可能面向宿主机 OS/架构，而不是 Linux。
+
+## Docker 沙箱中的 CLI 可用性
+
+不要把宿主机 `$ANNA_HOME/bin` 当作 Docker 沙箱可执行文件的来源。在 macOS 和 Windows 上，清单同步可能安装宿主机平台的二进制文件，它们无法在 Linux 容器中运行。把该目录绑定挂载进 Docker 也会模糊宿主机工具管理和容器运行时之间的边界。
+
+对于 Docker：
+
+- 必须开箱即用的内置 CLI 插件会预装到带版本的沙箱镜像中。沙箱镜像标签与 Anna release 绑定，因此一个 release 镜像可以包含该 Anna 版本对应的内置工具集合。保持 Docker 镜像工具列表 `plugins/sandbox/docker/_mise.toml` 与内置 CLI 插件声明 `internal/manifestplugins/builtin_plugins.yaml` 对齐。
+- `$ANNA_HOME/plugins.yaml` 仍然是插件元数据、启用状态、会话环境变量、OAuth 注入以及本地沙箱二进制安装的来源。
+- 用户配置的 CLI 二进制需要一条容器原生的加载路径。它们应在 Docker 环境内按 Linux 目标安装，而不是从宿主机 `$ANNA_HOME/bin` 复制。
+
+一种用于用户配置 CLI 的安全 Docker 加载设计是：
+
+1. 从已启用的用户清单插件 `binaries` 条目生成容器工具清单，排除 release 镜像中已经存在的内置工具。
+2. 基于同一个沙箱镜像启动短生命周期 helper 容器，在 Linux 上下文中运行 `mise install`。
+3. 将安装结果保存到由 Docker 管理的工具缓存或 volume，并用沙箱镜像标签加用户清单哈希作为缓存键。
+4. 将该缓存挂载到沙箱会话中的容器专用路径，并前置到容器内 `PATH`。
+5. 当已启用的用户插件集合或二进制版本变化时，重建或刷新缓存。
+
+这样可以保持 release 沙箱镜像稳定，同时仍支持用户新增 CLI。安装得到的用户二进制是 Linux 容器二进制，宿主机 `$ANNA_HOME/bin` 不参与 Docker 可执行文件解析。
 
 ## 清单文件格式
 

--- a/internal/agent/runner/context_test.go
+++ b/internal/agent/runner/context_test.go
@@ -26,7 +26,7 @@ func TestWithSystemOverride(t *testing.T) {
 	}
 
 	// nil context
-	_, ok = SystemOverrideFromContext(nil)
+	_, ok = SystemOverrideFromContext(context.Background())
 	if ok {
 		t.Error("expected false for nil context")
 	}
@@ -46,7 +46,7 @@ func TestWithChannel(t *testing.T) {
 		t.Errorf("ChannelFromContext = %q, %v", ch, ok)
 	}
 
-	_, ok = ChannelFromContext(nil)
+	_, ok = ChannelFromContext(context.Background())
 	if ok {
 		t.Error("expected false for nil context")
 	}
@@ -70,7 +70,7 @@ func TestWithExcludedTools(t *testing.T) {
 	}
 
 	// nil context
-	if got := ExcludedToolsFromContext(nil); len(got) != 0 {
+	if got := ExcludedToolsFromContext(context.Background()); len(got) != 0 {
 		t.Errorf("expected nil for nil context, got %v", got)
 	}
 

--- a/internal/agent/runner/sandbox_backend.go
+++ b/internal/agent/runner/sandbox_backend.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 	"maps"
 	"os"
+	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"sync"
@@ -15,6 +17,7 @@ import (
 
 	"github.com/vaayne/anna/internal/config"
 	oauth "github.com/vaayne/anna/internal/credentials/oauth"
+	"github.com/vaayne/anna/internal/manifestplugins"
 	"github.com/vaayne/anna/internal/sandbox"
 	internaltools "github.com/vaayne/anna/internal/tools"
 	pkgplugins "github.com/vaayne/anna/pkg/plugins"
@@ -367,6 +370,13 @@ func createDockerSession(ctx context.Context, cfg GoRunnerConfig) (*runnerSessio
 		recordSandboxError(span, err)
 		return nil, err
 	}
+	userTools, err := resolveDockerUserToolBinaries(paths.AnnaHome)
+	if err != nil {
+		err = fmt.Errorf("resolve docker user tools: %w", err)
+		recordSandboxError(span, err)
+		return nil, err
+	}
+	dockerCfg.UserToolBinaries = userTools
 
 	// Construct a per-runner factory with the resolved config. The global
 	// registry carries a zero-value Config for probe/contract-test use only.
@@ -440,6 +450,43 @@ func resolveDockerConfig() (dockerplugin.Config, error) {
 		dockerplugin.Config{Image: config.SandboxDockerImage()},
 		config.AnnaHome(),
 	)
+}
+
+func resolveDockerUserToolBinaries(annaHome string) ([]dockerplugin.ToolBinary, error) {
+	builtin, err := manifestplugins.LoadBuiltin()
+	if err != nil {
+		return nil, err
+	}
+	user, err := manifestplugins.LoadUser(filepath.Join(annaHome, "plugins.yaml"))
+	if err != nil {
+		return nil, err
+	}
+	merged := manifestplugins.Merge(builtin, user)
+
+	builtinByID := make(map[string]manifestplugins.ManifestPlugin, len(builtin.Plugins))
+	for _, plugin := range builtin.Plugins {
+		builtinByID[plugin.ID] = plugin
+	}
+
+	var out []dockerplugin.ToolBinary
+	for _, plugin := range merged.Plugins {
+		if !plugin.Enabled || len(plugin.Binaries) == 0 {
+			continue
+		}
+		if builtinPlugin, ok := builtinByID[plugin.ID]; ok && reflect.DeepEqual(plugin.Binaries, builtinPlugin.Binaries) {
+			continue
+		}
+		for _, binary := range plugin.Binaries {
+			out = append(out, dockerplugin.ToolBinary{
+				Name:    binary.Name,
+				Repo:    binary.Repo,
+				Version: binary.Version,
+				BinPath: binary.BinPath,
+				Exe:     binary.Exe,
+			})
+		}
+	}
+	return out, nil
 }
 
 // cleanupOrphanedDockerContainers removes stale anna containers from previous

--- a/plugins/sandbox/docker/config.go
+++ b/plugins/sandbox/docker/config.go
@@ -17,6 +17,12 @@ type Config struct {
 	// outside that path should leave them empty.
 	ContainerPathPrefix string
 	HostPathPrefix      string
+
+	// UserToolBinaries are manifest-declared, user-configured CLIs that are not
+	// baked into the versioned sandbox image. They are installed in a Linux
+	// helper container and exposed to sessions through a Docker-managed tool
+	// cache, never through host $ANNA_HOME/bin.
+	UserToolBinaries []ToolBinary
 }
 
 // TranslateToDaemonPath rewrites an anna-view absolute path into the path the

--- a/plugins/sandbox/docker/dockerclient/client.go
+++ b/plugins/sandbox/docker/dockerclient/client.go
@@ -26,6 +26,8 @@ type API interface {
 	ContainerInspect(ctx context.Context, container string, opts mobyclient.ContainerInspectOptions) (mobyclient.ContainerInspectResult, error)
 	ContainerList(ctx context.Context, opts mobyclient.ContainerListOptions) (mobyclient.ContainerListResult, error)
 
+	VolumeCreate(ctx context.Context, opts mobyclient.VolumeCreateOptions) (mobyclient.VolumeCreateResult, error)
+
 	ExecCreate(ctx context.Context, container string, opts mobyclient.ExecCreateOptions) (mobyclient.ExecCreateResult, error)
 	ExecAttach(ctx context.Context, execID string, opts mobyclient.ExecAttachOptions) (mobyclient.ExecAttachResult, error)
 	ExecInspect(ctx context.Context, execID string, opts mobyclient.ExecInspectOptions) (mobyclient.ExecInspectResult, error)
@@ -105,6 +107,14 @@ func (c *Client) ImageExists(ctx context.Context, image string) (bool, error) {
 }
 
 // PullImage pulls an image, draining the JSON progress stream into slog.Info.
+func (c *Client) VolumeCreate(ctx context.Context, opts mobyclient.VolumeCreateOptions) (mobyclient.VolumeCreateResult, error) {
+	res, err := c.api.VolumeCreate(ctx, opts)
+	if err != nil {
+		return mobyclient.VolumeCreateResult{}, fmt.Errorf("dockerclient: volume create %s: %w", opts.Name, err)
+	}
+	return res, nil
+}
+
 func (c *Client) PullImage(ctx context.Context, image string) error {
 	resp, err := c.api.ImagePull(ctx, image, mobyclient.ImagePullOptions{})
 	if err != nil {

--- a/plugins/sandbox/docker/dockerclient/container.go
+++ b/plugins/sandbox/docker/dockerclient/container.go
@@ -115,6 +115,31 @@ func (c *Client) ContainerAlive(ctx context.Context, containerID string) (bool, 
 	return res.Container.State.Running, nil
 }
 
+// ContainerState holds the container running state and last exit code.
+type ContainerState struct {
+	Running  bool
+	ExitCode int
+}
+
+// InspectContainerState returns the running state and exit code of a container
+// referenced by ID or name. Returns (nil, nil) when the container does not exist.
+func (c *Client) InspectContainerState(ctx context.Context, containerRef string) (*ContainerState, error) {
+	res, err := c.api.ContainerInspect(ctx, containerRef, mobyclient.ContainerInspectOptions{})
+	if err != nil {
+		if errdefs.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("dockerclient: container inspect %s: %w", containerRef, err)
+	}
+	if res.Container.State == nil {
+		return &ContainerState{}, nil
+	}
+	return &ContainerState{
+		Running:  res.Container.State.Running,
+		ExitCode: res.Container.State.ExitCode,
+	}, nil
+}
+
 // buildContainerCreateOptions translates CreateOptions into the SDK request.
 // Pure function so tests can assert the wiring without a daemon.
 func buildContainerCreateOptions(opts CreateOptions) mobyclient.ContainerCreateOptions {

--- a/plugins/sandbox/docker/dockerclient/container.go
+++ b/plugins/sandbox/docker/dockerclient/container.go
@@ -20,13 +20,23 @@ const (
 	NetworkAllowAll NetworkMode = "allow_all"
 )
 
-// Mount represents a bind-mount from host to container. Source is interpreted
-// by the daemon, so when anna runs inside a container it must already be
-// translated to a daemon-visible path before reaching this struct.
+// MountType identifies how Docker should mount Source into the container.
+type MountType string
+
+const (
+	MountTypeBind   MountType = "bind"
+	MountTypeVolume MountType = "volume"
+)
+
+// Mount represents a mount from a daemon-visible source to a container path.
+// Bind mount sources are interpreted by the daemon, so when anna runs inside a
+// container they must already be translated to daemon-visible paths before
+// reaching this struct. Volume mount sources are Docker volume names.
 type Mount struct {
 	HostPath      string
 	ContainerPath string
 	ReadOnly      bool
+	Type          MountType
 }
 
 // CreateOptions configures a new sandbox container.
@@ -37,6 +47,7 @@ type CreateOptions struct {
 	ReadOnlyMounts []Mount     // host -> container, read-only
 	NetworkMode    NetworkMode // disabled | allow_all
 	Env            map[string]string
+	User           string            // optional container user override
 	Labels         map[string]string // must include LabelSessionID + LabelAnnaHome + LabelCreatedAt
 	Name           string            // optional; caller builds "anna-sandbox-<session-id>"
 }
@@ -117,6 +128,7 @@ func buildContainerCreateOptions(opts CreateOptions) mobyclient.ContainerCreateO
 func buildContainerConfig(opts CreateOptions) *container.Config {
 	cfg := &container.Config{
 		Image:      opts.Image,
+		User:       opts.User,
 		Labels:     opts.Labels,
 		Entrypoint: []string{"/bin/sh"},
 		Cmd:        []string{"-c", "tail -f /dev/null"},
@@ -161,13 +173,22 @@ func buildMounts(opts CreateOptions) []mount.Mount {
 	}
 	for _, m := range opts.ReadOnlyMounts {
 		mounts = append(mounts, mount.Mount{
-			Type:     mount.TypeBind,
+			Type:     dockerMountType(m.Type),
 			Source:   m.HostPath,
 			Target:   m.ContainerPath,
-			ReadOnly: true,
+			ReadOnly: m.ReadOnly,
 		})
 	}
 	return mounts
+}
+
+func dockerMountType(t MountType) mount.Type {
+	switch t {
+	case MountTypeVolume:
+		return mount.TypeVolume
+	default:
+		return mount.TypeBind
+	}
 }
 
 // envSlice returns env in deterministic KEY=VALUE form sorted by key.

--- a/plugins/sandbox/docker/dockerclient/container_test.go
+++ b/plugins/sandbox/docker/dockerclient/container_test.go
@@ -84,6 +84,21 @@ func TestBuildMounts(t *testing.T) {
 			t.Fatal("expected ReadOnly=true")
 		}
 	})
+
+	t.Run("volume mounts included", func(t *testing.T) {
+		opts := CreateOptions{
+			ReadOnlyMounts: []Mount{
+				{HostPath: "anna-tools-abc", ContainerPath: "/tools", ReadOnly: true, Type: MountTypeVolume},
+			},
+		}
+		mounts := buildMounts(opts)
+		if len(mounts) != 1 {
+			t.Fatalf("expected 1 mount, got %d", len(mounts))
+		}
+		if mounts[0].Type != mount.TypeVolume || mounts[0].Source != "anna-tools-abc" || mounts[0].Target != "/tools" || !mounts[0].ReadOnly {
+			t.Fatalf("unexpected volume mount: %+v", mounts[0])
+		}
+	})
 	t.Run("workspace plus readonly", func(t *testing.T) {
 		opts := CreateOptions{
 			WorkspaceHost:  "/host/ws",

--- a/plugins/sandbox/docker/host_test.go
+++ b/plugins/sandbox/docker/host_test.go
@@ -203,7 +203,6 @@ func TestTranslateEnvPaths(t *testing.T) {
 	mounts := []dockerclient.Mount{
 		{HostPath: "/host/workspace", ContainerPath: "/workspace"},
 		{HostPath: "/host/.anna", ContainerPath: "/home/anna/.anna", ReadOnly: true},
-		{HostPath: "/host/.anna/bin", ContainerPath: "/home/anna/.anna/bin", ReadOnly: true},
 		{HostPath: "/host/.anna/skills", ContainerPath: "/home/anna/.anna/skills", ReadOnly: true},
 	}
 

--- a/plugins/sandbox/docker/session.go
+++ b/plugins/sandbox/docker/session.go
@@ -132,16 +132,28 @@ func (f *dockerFactory) CreateSession(ctx context.Context, policy sandboxpkg.Pol
 	if annaHome != "" {
 		opts.ReadOnlyMounts = []dockerclient.Mount{
 			{
-				HostPath:      filepath.Join(annaHome, "bin"),
-				ContainerPath: filepath.Join(annaHomeMount, "bin"),
-				ReadOnly:      true,
-			},
-			{
 				HostPath:      filepath.Join(annaHome, "skills"),
 				ContainerPath: filepath.Join(annaHomeMount, "skills"),
 				ReadOnly:      true,
 			},
 		}
+	}
+
+	var toolBinPaths []string
+	toolCache, err := ensureUserToolCache(ctx, client, f.cfg)
+	if err != nil {
+		recordError(span, err)
+		span.End()
+		return nil, err
+	}
+	if toolCache != nil {
+		opts.ReadOnlyMounts = append(opts.ReadOnlyMounts, dockerclient.Mount{
+			HostPath:      toolCache.VolumeName,
+			ContainerPath: containerUserToolsRoot,
+			ReadOnly:      true,
+			Type:          dockerclient.MountTypeVolume,
+		})
+		toolBinPaths = append(toolBinPaths, toolCache.BinPath)
 	}
 
 	containerID, err := client.CreateAndStart(ctx, opts)
@@ -155,17 +167,18 @@ func (f *dockerFactory) CreateSession(ctx context.Context, policy sandboxpkg.Pol
 		attribute.String("anna.sandbox.container_id", containerID),
 	))
 
-	// Build mount table for the workspace plus mounted ANNA_HOME/bin and /skills.
+	// Build mount table for the workspace plus mounted ANNA_HOME assets.
 	mountTable := buildMountTable(workspaceHost, workspaceMount, policy.Env["ANNA_HOME"], annaHomeMount)
 
 	session := &dockerSession{
-		id:          sessionID,
-		policy:      policy,
-		client:      client,
-		containerID: containerID,
-		mountTable:  mountTable,
-		done:        make(chan struct{}),
-		traceSpan:   span,
+		id:           sessionID,
+		policy:       policy,
+		client:       client,
+		containerID:  containerID,
+		mountTable:   mountTable,
+		toolBinPaths: toolBinPaths,
+		done:         make(chan struct{}),
+		traceSpan:    span,
 	}
 	session.host = &dockerHost{session: session}
 
@@ -199,11 +212,6 @@ func buildMountTable(workspaceHost, workspaceMount, annaHomeHost, annaHomeContai
 			dockerclient.Mount{
 				HostPath:      annaHomeHost,
 				ContainerPath: annaHomeContainer,
-				ReadOnly:      true,
-			},
-			dockerclient.Mount{
-				HostPath:      filepath.Join(annaHomeHost, "bin"),
-				ContainerPath: filepath.Join(annaHomeContainer, "bin"),
 				ReadOnly:      true,
 			},
 			dockerclient.Mount{
@@ -267,39 +275,44 @@ func translateEnvPaths(env map[string]string, mountTable []dockerclient.Mount) m
 
 // containerDefaultPATH is the image-baked PATH from the Dockerfile ENV directive.
 // It is used as the base when building a container exec PATH that prepends
-// $ANNA_HOME/bin. Keep in sync with the ENV PATH line in plugins/sandbox/docker/Dockerfile.
+// container-native user tool cache paths. Keep in sync with the ENV PATH line
+// in plugins/sandbox/docker/Dockerfile.
 const containerDefaultPATH = "/home/anna/.local/bin:/home/anna/.local/share/mise/shims:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
-// injectAnnaHomeBinPath prepends $ANNA_HOME/bin to the container exec PATH so
-// embedded and plugin-managed CLIs resolve directly without a wrapper layer.
-func injectAnnaHomeBinPath(env map[string]string) map[string]string {
-	annaHome, ok := env["ANNA_HOME"]
-	if !ok || annaHome == "" {
+// injectToolPaths prepends container-native user tool directories to PATH.
+// Built-in tools come from the image-baked PATH; host $ANNA_HOME/bin is never
+// used for docker executable resolution because it may contain host-platform
+// binaries.
+func injectToolPaths(env map[string]string, toolBinPaths []string) map[string]string {
+	if len(toolBinPaths) == 0 {
 		return env
 	}
 	base := env["PATH"]
 	if base == "" {
 		base = containerDefaultPATH
 	}
-	env["PATH"] = filepath.Join(annaHome, "bin") + ":" + base
+	entries := append([]string(nil), toolBinPaths...)
+	entries = append(entries, base)
+	env["PATH"] = strings.Join(entries, ":")
 	return env
 }
 
 // dockerSession is a docker-backed sandbox session backed by a single container.
 type dockerSession struct {
-	id          string
-	policy      sandboxpkg.Policy
-	client      *dockerclient.Client
-	containerID string
-	mountTable  []dockerclient.Mount
-	host        *dockerHost
-	done        chan struct{}
-	doneOnce    sync.Once
-	closed      bool
-	closeErr    error
-	traceSpan   trace.Span
-	traceOnce   sync.Once
-	mu          sync.RWMutex
+	id           string
+	policy       sandboxpkg.Policy
+	client       *dockerclient.Client
+	containerID  string
+	mountTable   []dockerclient.Mount
+	toolBinPaths []string
+	host         *dockerHost
+	done         chan struct{}
+	doneOnce     sync.Once
+	closed       bool
+	closeErr     error
+	traceSpan    trace.Span
+	traceOnce    sync.Once
+	mu           sync.RWMutex
 }
 
 func (s *dockerSession) Policy() sandboxpkg.Policy { return s.policy }
@@ -540,7 +553,7 @@ func (h *dockerHost) Exec(ctx context.Context, command string, opts sandboxpkg.E
 		return sandboxpkg.ExecResult{}, fmt.Errorf("docker host exec: cwd not in any mount: %w", err)
 	}
 
-	env := injectAnnaHomeBinPath(translateEnvPaths(mergeEnv(h.session.policy.Env, opts.Env), h.session.mountTable))
+	env := injectToolPaths(translateEnvPaths(mergeEnv(h.session.policy.Env, opts.Env), h.session.mountTable), h.session.toolBinPaths)
 
 	timeout := opts.Timeout
 	if timeout == 0 {
@@ -585,7 +598,7 @@ func (h *dockerHost) StartProcess(ctx context.Context, req sandboxpkg.ProcessReq
 		return nil, fmt.Errorf("docker host start_process: cwd not in any mount: %w", err)
 	}
 
-	env := injectAnnaHomeBinPath(translateEnvPaths(mergeEnv(h.session.policy.Env, req.Env), h.session.mountTable))
+	env := injectToolPaths(translateEnvPaths(mergeEnv(h.session.policy.Env, req.Env), h.session.mountTable), h.session.toolBinPaths)
 
 	timeout := req.Timeout
 	if timeout == 0 {

--- a/plugins/sandbox/docker/session_pure_test.go
+++ b/plugins/sandbox/docker/session_pure_test.go
@@ -36,8 +36,8 @@ func TestMergeEnv(t *testing.T) {
 
 func TestBuildMountTable(t *testing.T) {
 	table := buildMountTable("/host/ws", "/container/ws", "/host/.anna", "/home/anna/.anna")
-	if len(table) != 4 {
-		t.Fatalf("expected 4 entries, got %d", len(table))
+	if len(table) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(table))
 	}
 	if table[0].HostPath != "/host/ws" || table[0].ContainerPath != "/container/ws" {
 		t.Fatalf("unexpected workspace mount: %+v", table[0])
@@ -48,11 +48,8 @@ func TestBuildMountTable(t *testing.T) {
 	if table[1].HostPath != "/host/.anna" || table[1].ContainerPath != "/home/anna/.anna" || !table[1].ReadOnly {
 		t.Fatalf("unexpected anna home synthetic mount: %+v", table[1])
 	}
-	if table[2].HostPath != "/host/.anna/bin" || table[2].ContainerPath != "/home/anna/.anna/bin" || !table[2].ReadOnly {
-		t.Fatalf("unexpected anna bin mount: %+v", table[2])
-	}
-	if table[3].HostPath != "/host/.anna/skills" || table[3].ContainerPath != "/home/anna/.anna/skills" || !table[3].ReadOnly {
-		t.Fatalf("unexpected anna skills mount: %+v", table[3])
+	if table[2].HostPath != "/host/.anna/skills" || table[2].ContainerPath != "/home/anna/.anna/skills" || !table[2].ReadOnly {
+		t.Fatalf("unexpected anna skills mount: %+v", table[2])
 	}
 }
 
@@ -73,51 +70,32 @@ func TestMapNetworkMode(t *testing.T) {
 	}
 }
 
-func TestInjectAnnaHomeBinPath_PrependedWhenSet(t *testing.T) {
-	env := map[string]string{
-		"ANNA_HOME": "/home/anna/.anna",
-		"PATH":      "/usr/bin:/bin",
-	}
-	got := injectAnnaHomeBinPath(env)
-	want := "/home/anna/.anna/bin:/usr/bin:/bin"
+func TestInjectToolPaths_PrependedWhenSet(t *testing.T) {
+	env := map[string]string{"PATH": "/usr/bin:/bin"}
+	got := injectToolPaths(env, []string{"/home/anna/.anna-tools/bin"})
+	want := "/home/anna/.anna-tools/bin:/usr/bin:/bin"
 	if got["PATH"] != want {
 		t.Errorf("PATH = %q, want %q", got["PATH"], want)
 	}
 }
 
-func TestInjectAnnaHomeBinPath_UsesDefaultPathWhenPATHAbsent(t *testing.T) {
-	env := map[string]string{
-		"ANNA_HOME": "/home/anna/.anna",
-	}
-	got := injectAnnaHomeBinPath(env)
+func TestInjectToolPaths_UsesDefaultPathWhenPATHAbsent(t *testing.T) {
+	got := injectToolPaths(map[string]string{}, []string{"/home/anna/.anna-tools/bin"})
 	if got["PATH"] == "" {
-		t.Fatal("PATH should not be empty when ANNA_HOME is set")
+		t.Fatal("PATH should not be empty when tool paths are set")
 	}
-	if got["PATH"][:len("/home/anna/.anna/bin:")] != "/home/anna/.anna/bin:" {
-		t.Errorf("PATH does not start with ANNA_HOME/bin: %q", got["PATH"])
+	if got["PATH"][:len("/home/anna/.anna-tools/bin:")] != "/home/anna/.anna-tools/bin:" {
+		t.Errorf("PATH does not start with user tool bin: %q", got["PATH"])
 	}
-	if len(got["PATH"]) <= len("/home/anna/.anna/bin:") {
-		t.Error("PATH should include containerDefaultPATH after ANNA_HOME/bin")
-	}
-}
-
-func TestInjectAnnaHomeBinPath_NoOpWhenAbsent(t *testing.T) {
-	env := map[string]string{
-		"PATH": "/usr/bin:/bin",
-	}
-	got := injectAnnaHomeBinPath(env)
-	if got["PATH"] != "/usr/bin:/bin" {
-		t.Errorf("PATH changed when ANNA_HOME absent: %q", got["PATH"])
+	if len(got["PATH"]) <= len("/home/anna/.anna-tools/bin:") {
+		t.Error("PATH should include containerDefaultPATH after user tool bin")
 	}
 }
 
-func TestInjectAnnaHomeBinPath_NoOpWhenEmpty(t *testing.T) {
-	env := map[string]string{
-		"ANNA_HOME": "",
-		"PATH":      "/usr/bin:/bin",
-	}
-	got := injectAnnaHomeBinPath(env)
+func TestInjectToolPaths_NoOpWhenEmpty(t *testing.T) {
+	env := map[string]string{"PATH": "/usr/bin:/bin"}
+	got := injectToolPaths(env, nil)
 	if got["PATH"] != "/usr/bin:/bin" {
-		t.Errorf("PATH changed when ANNA_HOME is empty: %q", got["PATH"])
+		t.Errorf("PATH changed when tool paths absent: %q", got["PATH"])
 	}
 }

--- a/plugins/sandbox/docker/testhelpers_test.go
+++ b/plugins/sandbox/docker/testhelpers_test.go
@@ -47,6 +47,10 @@ func (noopAPI) ContainerList(context.Context, mobyclient.ContainerListOptions) (
 	return mobyclient.ContainerListResult{}, nil
 }
 
+func (noopAPI) VolumeCreate(context.Context, mobyclient.VolumeCreateOptions) (mobyclient.VolumeCreateResult, error) {
+	return mobyclient.VolumeCreateResult{}, nil
+}
+
 func (noopAPI) ExecCreate(context.Context, string, mobyclient.ExecCreateOptions) (mobyclient.ExecCreateResult, error) {
 	return mobyclient.ExecCreateResult{}, nil
 }

--- a/plugins/sandbox/docker/toolcache.go
+++ b/plugins/sandbox/docker/toolcache.go
@@ -8,10 +8,17 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
+	"github.com/containerd/errdefs"
 	mobyclient "github.com/moby/moby/client"
 	"github.com/pelletier/go-toml/v2"
 	"github.com/vaayne/anna/plugins/sandbox/docker/dockerclient"
+)
+
+const (
+	toolCacheHelperWaitTimeout  = 5 * time.Minute
+	toolCacheHelperPollInterval = 2 * time.Second
 )
 
 const (
@@ -41,6 +48,7 @@ func ensureUserToolCache(ctx context.Context, client *dockerclient.Client, cfg C
 
 	hash := userToolCacheHash(cfg.Image, cfg.UserToolBinaries)
 	volumeName := "anna-tools-" + hash[:16]
+	installerName := "anna-tool-cache-" + hash[:16]
 	cache := &userToolCache{VolumeName: volumeName, BinPath: containerUserToolsBin}
 
 	if _, err := client.VolumeCreate(ctx, mobyclient.VolumeCreateOptions{
@@ -73,9 +81,14 @@ func ensureUserToolCache(ctx context.Context, client *dockerclient.Client, cfg C
 			"anna.tool_cache_helper": "true",
 			"anna.tool_cache":        volumeName,
 		},
-		Name: "anna-tool-cache-" + hash[:12] + "-" + nextSessionID(),
+		Name: installerName,
 	})
 	if err != nil {
+		if errdefs.IsConflict(err) {
+			// Another app instance is already running the installer for this
+			// tool set. Wait for it to finish instead of racing.
+			return waitForToolCache(ctx, client, installerName, cache)
+		}
 		return nil, fmt.Errorf("docker user tool cache: start helper: %w", err)
 	}
 	defer func() {
@@ -98,6 +111,42 @@ func ensureUserToolCache(ctx context.Context, client *dockerclient.Client, cfg C
 	}
 
 	return cache, nil
+}
+
+// waitForToolCache waits for a concurrently running installer container to
+// finish and returns the cache if it succeeded. Used when another app instance
+// already holds the installer container name (the distributed mutex).
+func waitForToolCache(ctx context.Context, client *dockerclient.Client, installerName string, cache *userToolCache) (*userToolCache, error) {
+	deadline := time.Now().Add(toolCacheHelperWaitTimeout)
+	for {
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("docker user tool cache: timed out waiting for installer %s", installerName)
+		}
+
+		state, err := client.InspectContainerState(ctx, installerName)
+		if err != nil {
+			return nil, fmt.Errorf("docker user tool cache: inspect installer: %w", err)
+		}
+		if state == nil {
+			// Installer finished and was already cleaned up — volume is ready.
+			return cache, nil
+		}
+		if !state.Running {
+			if stopErr := client.Stop(context.Background(), installerName); stopErr != nil {
+				slog.Warn("docker user tool cache: cleanup stopped installer", "name", installerName, "error", stopErr)
+			}
+			if state.ExitCode != 0 {
+				return nil, fmt.Errorf("docker user tool cache: installer %s exited with %d", installerName, state.ExitCode)
+			}
+			return cache, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(toolCacheHelperPollInterval):
+		}
+	}
 }
 
 func userToolCacheHash(image string, binaries []ToolBinary) string {

--- a/plugins/sandbox/docker/toolcache.go
+++ b/plugins/sandbox/docker/toolcache.go
@@ -1,0 +1,206 @@
+package docker
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	mobyclient "github.com/moby/moby/client"
+	"github.com/pelletier/go-toml/v2"
+	"github.com/vaayne/anna/plugins/sandbox/docker/dockerclient"
+)
+
+const (
+	containerUserToolsRoot = "/home/anna/.anna-tools"
+	containerUserToolsBin  = containerUserToolsRoot + "/bin"
+)
+
+// ToolBinary describes a user-configured CLI that must be installed in a Linux
+// container context before docker sandbox sessions can execute it.
+type ToolBinary struct {
+	Name    string
+	Repo    string
+	Version string
+	BinPath string
+	Exe     string
+}
+
+type userToolCache struct {
+	VolumeName string
+	BinPath    string
+}
+
+func ensureUserToolCache(ctx context.Context, client *dockerclient.Client, cfg Config) (*userToolCache, error) {
+	if len(cfg.UserToolBinaries) == 0 {
+		return nil, nil
+	}
+
+	hash := userToolCacheHash(cfg.Image, cfg.UserToolBinaries)
+	volumeName := "anna-tools-" + hash[:16]
+	cache := &userToolCache{VolumeName: volumeName, BinPath: containerUserToolsBin}
+
+	if _, err := client.VolumeCreate(ctx, mobyclient.VolumeCreateOptions{
+		Name: volumeName,
+		Labels: map[string]string{
+			"anna.tool_cache": "true",
+			"anna.image":      cfg.Image,
+			"anna.hash":       hash,
+		},
+	}); err != nil {
+		return nil, fmt.Errorf("docker user tool cache: create volume %s: %w", volumeName, err)
+	}
+
+	containerID, err := client.CreateAndStart(ctx, dockerclient.CreateOptions{
+		Image:       cfg.Image,
+		NetworkMode: dockerclient.NetworkAllowAll,
+		User:        "root",
+		Env: map[string]string{
+			"HOME": "/root",
+		},
+		ReadOnlyMounts: []dockerclient.Mount{
+			{
+				HostPath:      volumeName,
+				ContainerPath: containerUserToolsRoot,
+				ReadOnly:      false,
+				Type:          dockerclient.MountTypeVolume,
+			},
+		},
+		Labels: map[string]string{
+			"anna.tool_cache_helper": "true",
+			"anna.tool_cache":        volumeName,
+		},
+		Name: "anna-tool-cache-" + hash[:12] + "-" + nextSessionID(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("docker user tool cache: start helper: %w", err)
+	}
+	defer func() {
+		if stopErr := client.Stop(context.Background(), containerID); stopErr != nil {
+			slog.Warn("docker user tool cache helper cleanup failed", "container_id", containerID, "error", stopErr)
+		}
+	}()
+
+	result, err := client.Exec(ctx, dockerclient.ExecOptions{
+		ContainerID: containerID,
+		Command:     []string{"/bin/sh", "-s"},
+		Cwd:         containerUserToolsRoot,
+		Stdin:       strings.NewReader(userToolInstallScript(hash, cfg.UserToolBinaries)),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("docker user tool cache: run installer: %w", err)
+	}
+	if result.ExitCode != 0 {
+		return nil, fmt.Errorf("docker user tool cache: installer failed with exit %d\nstdout: %s\nstderr: %s", result.ExitCode, result.Stdout, result.Stderr)
+	}
+
+	return cache, nil
+}
+
+func userToolCacheHash(image string, binaries []ToolBinary) string {
+	var buf bytes.Buffer
+	buf.WriteString("image=")
+	buf.WriteString(image)
+	buf.WriteByte('\n')
+	for _, b := range binaries {
+		buf.WriteString(b.Name)
+		buf.WriteByte('\t')
+		buf.WriteString(b.Repo)
+		buf.WriteByte('\t')
+		buf.WriteString(b.Version)
+		buf.WriteByte('\t')
+		buf.WriteString(b.BinPath)
+		buf.WriteByte('\t')
+		buf.WriteString(b.Exe)
+		buf.WriteByte('\n')
+	}
+	sum := sha256.Sum256(buf.Bytes())
+	return hex.EncodeToString(sum[:])
+}
+
+func userToolsMiseTOML(binaries []ToolBinary) (string, error) {
+	tools := make(map[string]any, len(binaries))
+	for _, b := range binaries {
+		key := "github:" + b.Repo
+		if b.BinPath == "" && b.Exe == "" {
+			version := b.Version
+			if version == "" {
+				version = "latest"
+			}
+			tools[key] = version
+			continue
+		}
+		entry := map[string]any{}
+		if b.Version != "" {
+			entry["version"] = b.Version
+		}
+		if b.BinPath != "" {
+			entry["bin_path"] = b.BinPath
+		}
+		if b.Exe != "" {
+			entry["exe"] = b.Exe
+		}
+		tools[key] = entry
+	}
+	data, err := toml.Marshal(map[string]any{"tools": tools})
+	if err != nil {
+		return "", fmt.Errorf("marshal user tools mise.toml: %w", err)
+	}
+	return string(data), nil
+}
+
+func userToolInstallScript(hash string, binaries []ToolBinary) string {
+	miseTOML, err := userToolsMiseTOML(binaries)
+	if err != nil {
+		// userToolCacheHash currently validates nothing, and TOML marshal for this
+		// shape should not fail. Surface the error in-shell if that ever changes.
+		return "echo " + shellQuote(err.Error()) + " >&2\nexit 1\n"
+	}
+
+	var script strings.Builder
+	script.WriteString("set -eu\n")
+	script.WriteString("ROOT=" + shellQuote(containerUserToolsRoot) + "\n")
+	script.WriteString("HASH=" + shellQuote(hash) + "\n")
+	script.WriteString("if [ -f \"$ROOT/.anna-tools-ready\" ] && [ \"$(cat \"$ROOT/.anna-tools-ready\")\" = \"$HASH\" ]; then exit 0; fi\n")
+	script.WriteString("rm -rf \"$ROOT/bin\" \"$ROOT/mise-data\" \"$ROOT/mise.toml\" \"$ROOT/.anna-tools-ready\"\n")
+	script.WriteString("mkdir -p \"$ROOT/bin\" \"$ROOT/mise-data\"\n")
+	script.WriteString("cat > \"$ROOT/mise.toml\" <<'ANNA_MISE_TOML'\n")
+	script.WriteString(miseTOML)
+	if !strings.HasSuffix(miseTOML, "\n") {
+		script.WriteByte('\n')
+	}
+	script.WriteString("ANNA_MISE_TOML\n")
+	script.WriteString("cd \"$ROOT\"\n")
+	script.WriteString("MISE_DATA_DIR=\"$ROOT/mise-data\" MISE_TRUSTED_CONFIG_PATHS=\"$ROOT\" mise trust -y \"$ROOT/mise.toml\" >/dev/null 2>&1 || true\n")
+	script.WriteString("MISE_DATA_DIR=\"$ROOT/mise-data\" MISE_TRUSTED_CONFIG_PATHS=\"$ROOT\" mise install\n")
+	for _, b := range binaries {
+		lookup := b.Name
+		if b.Exe != "" {
+			lookup = b.Exe
+		}
+		script.WriteString("install_dir=$(MISE_DATA_DIR=\"$ROOT/mise-data\" MISE_TRUSTED_CONFIG_PATHS=\"$ROOT\" mise where " + shellQuote("github:"+b.Repo) + ")\n")
+		script.WriteString("src=\"\"\n")
+		script.WriteString("if [ -f \"$install_dir/bin/" + shellQuoteForDoubleQuotedPath(lookup) + "\" ]; then src=\"$install_dir/bin/" + shellQuoteForDoubleQuotedPath(lookup) + "\"; fi\n")
+		script.WriteString("if [ -z \"$src\" ] && [ -f \"$install_dir/" + shellQuoteForDoubleQuotedPath(lookup) + "\" ]; then src=\"$install_dir/" + shellQuoteForDoubleQuotedPath(lookup) + "\"; fi\n")
+		script.WriteString("if [ -z \"$src\" ]; then echo " + shellQuote("binary "+lookup+" not found for github:"+b.Repo) + " >&2; exit 1; fi\n")
+		script.WriteString("cp \"$src\" \"$ROOT/bin/" + shellQuoteForDoubleQuotedPath(b.Name) + "\"\n")
+		script.WriteString("chmod 0755 \"$ROOT/bin/" + shellQuoteForDoubleQuotedPath(b.Name) + "\"\n")
+	}
+	script.WriteString("printf '%s' \"$HASH\" > \"$ROOT/.anna-tools-ready\"\n")
+	return script.String()
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+func shellQuoteForDoubleQuotedPath(s string) string {
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, "\"", "\\\"")
+	s = strings.ReplaceAll(s, "$", "\\$")
+	s = strings.ReplaceAll(s, "`", "\\`")
+	return s
+}


### PR DESCRIPTION
## Summary
- stop using host `/bin` for Docker sandbox executable resolution
- install user-configured manifest CLI binaries in a Docker-managed Linux tool cache volume
- keep built-in CLI plugins as release-image tools and document the Docker/local split

## Verification
- `mise run format`
- skipped local tests per request; CI should run the full suite