### PR TITLE
✨ feat: add clawhub.ai skill search and install support

### DIFF
--- a/docs/content/docs/features/meta.json
+++ b/docs/content/docs/features/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Features",
-  "pages": ["plugin-system", "scheduler-system", "notification-system", "agent-templates", "vault", "cli-oauth"]
+  "pages": ["plugin-system", "scheduler-system", "notification-system", "agent-templates", "skills", "vault", "cli-oauth"]
 }

--- a/docs/content/docs/features/meta.zh.json
+++ b/docs/content/docs/features/meta.zh.json
@@ -1,4 +1,4 @@
 {
   "title": "功能",
-  "pages": ["plugin-system", "scheduler-system", "notification-system", "agent-templates", "vault", "cli-oauth"]
+  "pages": ["plugin-system", "scheduler-system", "notification-system", "agent-templates", "skills", "vault", "cli-oauth"]
 }

--- a/docs/content/docs/features/skills.md
+++ b/docs/content/docs/features/skills.md
@@ -1,0 +1,111 @@
+---
+title: Skills
+---
+
+## Overview
+
+Skills are reusable playbooks — markdown files that tell the agent how to perform a specific task. They are loaded on demand during a conversation and can be installed from external registries or created locally.
+
+Anna supports three skill scopes:
+
+| Scope       | Location                              | Who can write   |
+| ----------- | ------------------------------------- | --------------- |
+| **project** | `{PROJECT_ROOT}/.agents/skills/`      | Git (read-only) |
+| **user**    | DB, encrypted per user                | User            |
+| **agent**   | DB, scoped to a specific agent        | User            |
+
+Project skills ship with the repository and take precedence over user/agent skills of the same name.
+
+## Registries
+
+### clawhub.ai
+
+[clawhub.ai](https://clawhub.ai) is the primary skill registry. Search and install skills directly from a conversation:
+
+```
+skills action=search query=<term>
+skills action=install source="clawhub:<slug>"
+skills action=install source="clawhub:<slug>@<version>"
+```
+
+**Rate limits.** Anonymous access has a low request quota. If you hit a 429 error, set a free API token:
+
+1. Sign up or log in at [https://clawhub.ai](https://clawhub.ai)
+2. Go to **Settings → API Tokens** → create a token → copy it
+3. Send in chat:
+   ```
+   /config CLAWHUB_TOKEN <your-token>
+   ```
+
+Anna also automatically falls back to the CN mirror (`cn.clawhub-mirror.com`) on 429, so most users never need a token.
+
+**Environment variables**
+
+| Variable        | Purpose                                        |
+| --------------- | ---------------------------------------------- |
+| `CLAWHUB_TOKEN` | Bearer token for authenticated access          |
+| `CLAWHUB_URL`   | Override the registry base URL (default: clawhub.ai) |
+
+### skills.sh
+
+[skills.sh](https://skills.sh) is a secondary registry. Results are merged with clawhub.ai results in every `search` call. Install format:
+
+```
+skills action=install source="owner/repo@skill-name"
+```
+
+### GitHub / GitLab
+
+Install any skill hosted in a Git repository:
+
+```
+skills action=install source="owner/repo@skill-name"
+skills action=install source="https://github.com/owner/repo/tree/main/path/to/skill"
+```
+
+### Local path
+
+```
+skills action=install source="/path/to/skill"
+skills action=install source="./relative/path"
+```
+
+## Managing skills
+
+| Action      | Example                                              |
+| ----------- | ---------------------------------------------------- |
+| Search      | `skills action=search query=git`                     |
+| Install     | `skills action=install source="clawhub:git-helper"`  |
+| List        | `skills action=list`                                 |
+| Load        | `skills action=load name=git-helper`                 |
+| Remove      | `skills action=remove name=git-helper`               |
+| Create      | `skills action=create name=my-skill description=...` |
+| Patch       | `skills action=patch name=my-skill status=active`    |
+| Deprecate   | `skills action=deprecate name=my-skill`              |
+
+Use `scope=agent` on install/remove/create to target the current agent scope instead of the default user scope.
+
+## Skill format
+
+A skill is a directory containing at minimum a `SKILL.md` file with a YAML frontmatter header:
+
+```markdown
+---
+name: my-skill
+description: One-line description shown in search results.
+status: active
+---
+
+# My Skill
+
+Instructions for the agent go here.
+```
+
+**Frontmatter fields**
+
+| Field                      | Required | Description                                      |
+| -------------------------- | -------- | ------------------------------------------------ |
+| `name`                     | Yes      | Lowercase, hyphens only, max 64 chars            |
+| `description`              | Yes      | Shown in `list` and `search` output              |
+| `status`                   | No       | `draft` / `active` (default) / `deprecated`      |
+| `disable-model-invocation` | No       | If `true`, skill is injected but model cannot call it directly |

--- a/docs/content/docs/features/skills.zh.md
+++ b/docs/content/docs/features/skills.zh.md
@@ -1,0 +1,111 @@
+---
+title: Skills（技能）
+---
+
+## 概述
+
+Skills（技能）是可复用的操作手册——以 Markdown 文件的形式告诉 Agent 如何完成某项任务。对话中可按需加载，支持从外部注册表安装或在本地创建。
+
+Anna 支持三种技能作用域：
+
+| 作用域      | 位置                                  | 可写权限         |
+| ----------- | ------------------------------------- | ---------------- |
+| **project** | `{PROJECT_ROOT}/.agents/skills/`      | Git（只读）      |
+| **user**    | 数据库，按用户加密存储                | 用户             |
+| **agent**   | 数据库，绑定到特定 Agent              | 用户             |
+
+Project 技能随代码仓库一起分发，优先级高于同名的 user/agent 技能。
+
+## 注册表
+
+### clawhub.ai
+
+[clawhub.ai](https://clawhub.ai) 是主要技能注册表，可在对话中直接搜索和安装：
+
+```
+skills action=search query=<关键词>
+skills action=install source="clawhub:<slug>"
+skills action=install source="clawhub:<slug>@<版本>"
+```
+
+**速率限制。** 匿名访问的请求配额较低。遇到 429 错误时，请设置免费 API Token：
+
+1. 在 [https://clawhub.ai](https://clawhub.ai) 注册或登录
+2. 进入 **Settings → API Tokens** → 创建 Token → 复制
+3. 在对话中发送：
+   ```
+   /config CLAWHUB_TOKEN <你的token>
+   ```
+
+Anna 在遇到 429 时会自动切换到国内镜像（`cn.clawhub-mirror.com`），大多数用户无需设置 Token。
+
+**环境变量**
+
+| 变量            | 说明                                              |
+| --------------- | ------------------------------------------------- |
+| `CLAWHUB_TOKEN` | 认证访问的 Bearer Token                           |
+| `CLAWHUB_URL`   | 覆盖注册表地址（默认：clawhub.ai）                |
+
+### skills.sh
+
+[skills.sh](https://skills.sh) 是备用注册表，每次 `search` 调用会与 clawhub.ai 结果合并返回。安装格式：
+
+```
+skills action=install source="owner/repo@skill-name"
+```
+
+### GitHub / GitLab
+
+从 Git 仓库安装任意技能：
+
+```
+skills action=install source="owner/repo@skill-name"
+skills action=install source="https://github.com/owner/repo/tree/main/path/to/skill"
+```
+
+### 本地路径
+
+```
+skills action=install source="/path/to/skill"
+skills action=install source="./relative/path"
+```
+
+## 管理技能
+
+| 操作     | 示例                                                    |
+| -------- | ------------------------------------------------------- |
+| 搜索     | `skills action=search query=git`                        |
+| 安装     | `skills action=install source="clawhub:git-helper"`     |
+| 列表     | `skills action=list`                                    |
+| 加载     | `skills action=load name=git-helper`                    |
+| 删除     | `skills action=remove name=git-helper`                  |
+| 创建     | `skills action=create name=my-skill description=...`    |
+| 更新     | `skills action=patch name=my-skill status=active`       |
+| 弃用     | `skills action=deprecate name=my-skill`                 |
+
+在 install/remove/create 时加上 `scope=agent` 可将目标切换为当前 Agent 作用域（默认为 user）。
+
+## 技能格式
+
+一个技能是包含至少一个 `SKILL.md` 文件的目录，文件需带有 YAML frontmatter：
+
+```markdown
+---
+name: my-skill
+description: 在搜索结果中显示的单行描述。
+status: active
+---
+
+# My Skill
+
+此处填写给 Agent 的操作说明。
+```
+
+**Frontmatter 字段说明**
+
+| 字段                       | 必填 | 说明                                              |
+| -------------------------- | ---- | ------------------------------------------------- |
+| `name`                     | 是   | 小写字母，仅允许连字符，最多 64 个字符            |
+| `description`              | 是   | 显示在 `list` 和 `search` 输出中                  |
+| `status`                   | 否   | `draft` / `active`（默认）/ `deprecated`          |
+| `disable-model-invocation` | 否   | 为 `true` 时，技能注入系统提示但模型不可直接调用  |

--- a/plugins/tools/skills/clawhub.go
+++ b/plugins/tools/skills/clawhub.go
@@ -4,21 +4,20 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"net/url"
 	"os"
 	"path"
 	"strings"
-	"time"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/vaayne/anna/pkg/httpclient"
 )
 
 const (
 	clawhubDefaultBaseURL = "https://clawhub.ai"
 	clawhubCNMirrorURL    = "https://cn.clawhub-mirror.com"
-	clawhubTimeout        = 30 * time.Second
 )
 
 type clawhubSearchResult struct {
@@ -68,85 +67,87 @@ To fix this:
    /config CLAWHUB_TOKEN <your-token>
 4. Retry the install`
 
-// clawhubDo performs a GET request for the given path+query, trying each base URL in order.
-// On 429 from the primary site with no token, it automatically falls back to the CN mirror.
-// If all URLs are rate-limited, it returns the user-facing rate-limit guidance message.
-func clawhubDo(ctx context.Context, apiPath string, query url.Values) (*http.Response, error) {
-	token := clawhubToken()
-	client := &http.Client{Timeout: clawhubTimeout}
+func newClawhubClient() *resty.Client {
+	client := httpclient.New().SetHeader("User-Agent", "anna")
+	if token := clawhubToken(); token != "" {
+		client.SetAuthToken(token)
+	}
+	return client
+}
+
+// clawhubWithFallback calls fn(base) for each base URL in order, stopping on the first
+// success. fn returns (is429, err): is429=true signals a rate-limit so the next URL is
+// tried; any other error stops immediately. If all URLs return 429, the rate-limit
+// guidance message is returned.
+func clawhubWithFallback(fn func(base string) (is429 bool, err error)) error {
 	rateLimited := false
-
 	for _, base := range clawhubBaseURLs() {
-		u, err := url.Parse(base + apiPath)
-		if err != nil {
-			return nil, err
-		}
-		u.RawQuery = query.Encode()
-
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
-		if err != nil {
-			return nil, err
-		}
-		if token != "" {
-			req.Header.Set("Authorization", "Bearer "+token)
-		}
-		req.Header.Set("User-Agent", "anna")
-
-		resp, err := client.Do(req)
-		if err != nil {
-			return nil, err
-		}
-		if resp.StatusCode == http.StatusTooManyRequests {
-			_ = resp.Body.Close()
+		is429, err := fn(base)
+		if is429 {
 			rateLimited = true
 			continue
 		}
-		return resp, nil
+		return err
 	}
-
 	if rateLimited {
-		return nil, fmt.Errorf("%s", clawhubRateLimitMsg)
+		return fmt.Errorf("%s", clawhubRateLimitMsg)
 	}
-	return nil, fmt.Errorf("clawhub: all endpoints unavailable")
+	return fmt.Errorf("clawhub: all endpoints unavailable")
 }
 
 func clawhubSearch(ctx context.Context, query string, limit int) ([]clawhubSearchResult, error) {
 	if limit <= 0 {
 		limit = 10
 	}
-	q := url.Values{}
-	q.Set("q", query)
-	q.Set("limit", fmt.Sprintf("%d", limit))
-
-	resp, err := clawhubDo(ctx, "/api/v1/search", q)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("clawhub search returned HTTP %d", resp.StatusCode)
-	}
+	client := newClawhubClient()
 	var result struct {
 		Results []clawhubSearchResult `json:"results"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("clawhub search decode: %w", err)
+	err := clawhubWithFallback(func(base string) (bool, error) {
+		resp, err := client.R().
+			SetContext(ctx).
+			SetQueryParam("q", query).
+			SetQueryParam("limit", fmt.Sprintf("%d", limit)).
+			SetResult(&result).
+			Get(base + "/api/v1/search")
+		if err != nil {
+			return false, err
+		}
+		if resp.StatusCode() == 429 {
+			return true, nil
+		}
+		if resp.IsError() {
+			return false, fmt.Errorf("clawhub search returned HTTP %d", resp.StatusCode())
+		}
+		return false, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	return result.Results, nil
 }
 
 func clawhubFetchDetail(ctx context.Context, slug string) (*clawhubSkillDetail, error) {
-	resp, err := clawhubDo(ctx, "/api/v1/skills/"+url.PathEscape(slug), nil)
+	client := newClawhubClient()
+	var detail clawhubSkillDetail
+	err := clawhubWithFallback(func(base string) (bool, error) {
+		resp, err := client.R().
+			SetContext(ctx).
+			SetResult(&detail).
+			Get(base + "/api/v1/skills/" + url.PathEscape(slug))
+		if err != nil {
+			return false, err
+		}
+		if resp.StatusCode() == 429 {
+			return true, nil
+		}
+		if resp.IsError() {
+			return false, fmt.Errorf("clawhub detail returned HTTP %d for %q", resp.StatusCode(), slug)
+		}
+		return false, nil
+	})
 	if err != nil {
 		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("clawhub detail returned HTTP %d for %q", resp.StatusCode, slug)
-	}
-	var detail clawhubSkillDetail
-	if err := json.NewDecoder(resp.Body).Decode(&detail); err != nil {
-		return nil, fmt.Errorf("clawhub detail decode: %w", err)
 	}
 	return &detail, nil
 }
@@ -168,22 +169,28 @@ func clawhubFetchSkillFiles(ctx context.Context, slug, version string) (skillNam
 		version = detail.LatestVersion.Version
 	}
 
-	q := url.Values{}
-	q.Set("slug", slug)
-	q.Set("version", version)
-
-	resp, err := clawhubDo(ctx, "/api/v1/download", q)
-	if err != nil {
-		return "", nil, nil, fmt.Errorf("clawhub download: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		return "", nil, nil, fmt.Errorf("clawhub download returned HTTP %d for %q@%s", resp.StatusCode, slug, version)
-	}
-
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", nil, nil, fmt.Errorf("clawhub download read: %w", err)
+	client := newClawhubClient()
+	var data []byte
+	dlErr := clawhubWithFallback(func(base string) (bool, error) {
+		resp, err := client.R().
+			SetContext(ctx).
+			SetQueryParam("slug", slug).
+			SetQueryParam("version", version).
+			Get(base + "/api/v1/download")
+		if err != nil {
+			return false, err
+		}
+		if resp.StatusCode() == 429 {
+			return true, nil
+		}
+		if resp.IsError() {
+			return false, fmt.Errorf("clawhub download returned HTTP %d for %q@%s", resp.StatusCode(), slug, version)
+		}
+		data = resp.Body()
+		return false, nil
+	})
+	if dlErr != nil {
+		return "", nil, nil, fmt.Errorf("clawhub download: %w", dlErr)
 	}
 
 	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))

--- a/plugins/tools/skills/clawhub.go
+++ b/plugins/tools/skills/clawhub.go
@@ -1,0 +1,250 @@
+package skills
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"strings"
+	"time"
+)
+
+const (
+	clawhubDefaultBaseURL = "https://clawhub.ai"
+	clawhubTimeout        = 30 * time.Second
+)
+
+type clawhubSearchResult struct {
+	Score       float64 `json:"score"`
+	Slug        string  `json:"slug"`
+	DisplayName string  `json:"displayName"`
+	Summary     string  `json:"summary,omitempty"`
+	Version     *string `json:"version,omitempty"`
+	UpdatedAt   int64   `json:"updatedAt,omitempty"`
+}
+
+type clawhubSkillDetail struct {
+	Skill *struct {
+		Slug        string `json:"slug"`
+		DisplayName string `json:"displayName"`
+		Summary     string `json:"summary"`
+	} `json:"skill"`
+	LatestVersion *struct {
+		Version string `json:"version"`
+	} `json:"latestVersion"`
+}
+
+func clawhubBaseURL() string {
+	if v := os.Getenv("CLAWHUB_URL"); v != "" {
+		return strings.TrimRight(v, "/")
+	}
+	return clawhubDefaultBaseURL
+}
+
+func clawhubToken() string {
+	return os.Getenv("CLAWHUB_TOKEN")
+}
+
+const clawhubRateLimitMsg = `ClawHub rate limit exceeded (HTTP 429). Anonymous access has a very low quota — a free API token is required.
+
+To fix this:
+1. Open https://clawhub.ai → sign up / log in (free)
+2. Go to Settings → API Tokens → create a token → copy it
+3. Send the following message in this chat (value is stored securely, never shown to the model):
+   /config CLAWHUB_TOKEN <your-token>
+4. Retry the install`
+
+func clawhubRequest(ctx context.Context, rawURL string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	if token := clawhubToken(); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	req.Header.Set("User-Agent", "anna")
+	client := &http.Client{Timeout: clawhubTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusTooManyRequests {
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("%s", clawhubRateLimitMsg)
+	}
+	return resp, nil
+}
+
+func clawhubSearch(ctx context.Context, query string, limit int) ([]clawhubSearchResult, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	u, err := url.Parse(clawhubBaseURL() + "/api/v1/search")
+	if err != nil {
+		return nil, err
+	}
+	q := u.Query()
+	q.Set("q", query)
+	q.Set("limit", fmt.Sprintf("%d", limit))
+	u.RawQuery = q.Encode()
+
+	resp, err := clawhubRequest(ctx, u.String())
+	if err != nil {
+		return nil, fmt.Errorf("clawhub search: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("clawhub search returned HTTP %d", resp.StatusCode)
+	}
+	var result struct {
+		Results []clawhubSearchResult `json:"results"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("clawhub search decode: %w", err)
+	}
+	return result.Results, nil
+}
+
+func clawhubFetchDetail(ctx context.Context, slug string) (*clawhubSkillDetail, error) {
+	rawURL := clawhubBaseURL() + "/api/v1/skills/" + url.PathEscape(slug)
+	resp, err := clawhubRequest(ctx, rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("clawhub detail: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("clawhub detail returned HTTP %d for %q", resp.StatusCode, slug)
+	}
+	var detail clawhubSkillDetail
+	if err := json.NewDecoder(resp.Body).Decode(&detail); err != nil {
+		return nil, fmt.Errorf("clawhub detail decode: %w", err)
+	}
+	return &detail, nil
+}
+
+// clawhubFetchSkillFiles downloads a skill archive from clawhub.ai and returns its files.
+// version may be empty; in that case the latest version is resolved first.
+func clawhubFetchSkillFiles(ctx context.Context, slug, version string) (skillName string, files map[string]string, cleanup func(), err error) {
+	if version == "" {
+		detail, detailErr := clawhubFetchDetail(ctx, slug)
+		if detailErr != nil {
+			return "", nil, nil, fmt.Errorf("resolve clawhub version for %q: %w", slug, detailErr)
+		}
+		if detail.Skill == nil {
+			return "", nil, nil, fmt.Errorf("skill %q not found on clawhub", slug)
+		}
+		if detail.LatestVersion == nil || detail.LatestVersion.Version == "" {
+			return "", nil, nil, fmt.Errorf("skill %q has no installable version on clawhub", slug)
+		}
+		version = detail.LatestVersion.Version
+	}
+
+	u, err := url.Parse(clawhubBaseURL() + "/api/v1/download")
+	if err != nil {
+		return "", nil, nil, err
+	}
+	q := u.Query()
+	q.Set("slug", slug)
+	q.Set("version", version)
+	u.RawQuery = q.Encode()
+
+	resp, err := clawhubRequest(ctx, u.String())
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("clawhub download: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return "", nil, nil, fmt.Errorf("clawhub download returned HTTP %d for %q@%s", resp.StatusCode, slug, version)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("clawhub download read: %w", err)
+	}
+
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("clawhub zip open for %q: %w", slug, err)
+	}
+
+	skillRoot, found := findZipSkillRoot(zr)
+	if !found {
+		return "", nil, nil, fmt.Errorf("clawhub archive for %q is missing SKILL.md", slug)
+	}
+
+	files = make(map[string]string)
+	for _, f := range zr.File {
+		if f.FileInfo().IsDir() {
+			continue
+		}
+		name := path.Clean(f.Name)
+		var rel string
+		if skillRoot == "" {
+			rel = name
+		} else {
+			prefix := skillRoot + "/"
+			if !strings.HasPrefix(name, prefix) {
+				continue
+			}
+			rel = strings.TrimPrefix(name, prefix)
+		}
+		if rel == "" || rel == "." {
+			continue
+		}
+		rc, openErr := f.Open()
+		if openErr != nil {
+			return "", nil, nil, fmt.Errorf("clawhub zip entry %q: %w", f.Name, openErr)
+		}
+		content, readErr := io.ReadAll(rc)
+		_ = rc.Close()
+		if readErr != nil {
+			return "", nil, nil, fmt.Errorf("clawhub zip read %q: %w", f.Name, readErr)
+		}
+		files[rel] = string(content)
+	}
+
+	return slug, files, func() {}, nil
+}
+
+// findZipSkillRoot returns the directory prefix within the ZIP that contains SKILL.md,
+// and whether SKILL.md was found at all. Empty prefix means SKILL.md is at the archive root.
+func findZipSkillRoot(zr *zip.Reader) (prefix string, found bool) {
+	for _, f := range zr.File {
+		name := path.Clean(f.Name)
+		if strings.EqualFold(path.Base(name), "SKILL.md") {
+			dir := path.Dir(name)
+			if dir == "." {
+				return "", true
+			}
+			return dir, true
+		}
+	}
+	return "", false
+}
+
+// parseClawhubSource parses a "clawhub:<slug>[@version]" string.
+// Returns slug, version (may be empty), and whether the prefix matched.
+func parseClawhubSource(source string) (slug, version string, ok bool) {
+	const prefix = "clawhub:"
+	if !strings.HasPrefix(strings.ToLower(source), prefix) {
+		return "", "", false
+	}
+	spec := strings.TrimSpace(source[len(prefix):])
+	if spec == "" {
+		return "", "", false
+	}
+	idx := strings.LastIndex(spec, "@")
+	if idx <= 0 {
+		return spec, "", true
+	}
+	if idx >= len(spec)-1 {
+		return "", "", false
+	}
+	return strings.TrimSpace(spec[:idx]), strings.TrimSpace(spec[idx+1:]), true
+}

--- a/plugins/tools/skills/clawhub.go
+++ b/plugins/tools/skills/clawhub.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	clawhubDefaultBaseURL = "https://clawhub.ai"
+	clawhubCNMirrorURL    = "https://cn.clawhub-mirror.com"
 	clawhubTimeout        = 30 * time.Second
 )
 
@@ -40,15 +41,22 @@ type clawhubSkillDetail struct {
 	} `json:"latestVersion"`
 }
 
-func clawhubBaseURL() string {
-	if v := os.Getenv("CLAWHUB_URL"); v != "" {
-		return strings.TrimRight(v, "/")
-	}
-	return clawhubDefaultBaseURL
-}
-
 func clawhubToken() string {
 	return os.Getenv("CLAWHUB_TOKEN")
+}
+
+// clawhubBaseURLs returns the ordered list of base URLs to try.
+// If CLAWHUB_URL is set, only that URL is used.
+// If a token is configured, only the main site is used.
+// Otherwise the CN mirror is tried automatically as a fallback after 429.
+func clawhubBaseURLs() []string {
+	if v := os.Getenv("CLAWHUB_URL"); v != "" {
+		return []string{strings.TrimRight(v, "/")}
+	}
+	if clawhubToken() != "" {
+		return []string{clawhubDefaultBaseURL}
+	}
+	return []string{clawhubDefaultBaseURL, clawhubCNMirrorURL}
 }
 
 const clawhubRateLimitMsg = `ClawHub rate limit exceeded (HTTP 429). Anonymous access has a very low quota — a free API token is required.
@@ -60,43 +68,59 @@ To fix this:
    /config CLAWHUB_TOKEN <your-token>
 4. Retry the install`
 
-func clawhubRequest(ctx context.Context, rawURL string) (*http.Response, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
-	if err != nil {
-		return nil, err
-	}
-	if token := clawhubToken(); token != "" {
-		req.Header.Set("Authorization", "Bearer "+token)
-	}
-	req.Header.Set("User-Agent", "anna")
+// clawhubDo performs a GET request for the given path+query, trying each base URL in order.
+// On 429 from the primary site with no token, it automatically falls back to the CN mirror.
+// If all URLs are rate-limited, it returns the user-facing rate-limit guidance message.
+func clawhubDo(ctx context.Context, apiPath string, query url.Values) (*http.Response, error) {
+	token := clawhubToken()
 	client := &http.Client{Timeout: clawhubTimeout}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
+	rateLimited := false
+
+	for _, base := range clawhubBaseURLs() {
+		u, err := url.Parse(base + apiPath)
+		if err != nil {
+			return nil, err
+		}
+		u.RawQuery = query.Encode()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+		if err != nil {
+			return nil, err
+		}
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		req.Header.Set("User-Agent", "anna")
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode == http.StatusTooManyRequests {
+			_ = resp.Body.Close()
+			rateLimited = true
+			continue
+		}
+		return resp, nil
 	}
-	if resp.StatusCode == http.StatusTooManyRequests {
-		_ = resp.Body.Close()
+
+	if rateLimited {
 		return nil, fmt.Errorf("%s", clawhubRateLimitMsg)
 	}
-	return resp, nil
+	return nil, fmt.Errorf("clawhub: all endpoints unavailable")
 }
 
 func clawhubSearch(ctx context.Context, query string, limit int) ([]clawhubSearchResult, error) {
 	if limit <= 0 {
 		limit = 10
 	}
-	u, err := url.Parse(clawhubBaseURL() + "/api/v1/search")
-	if err != nil {
-		return nil, err
-	}
-	q := u.Query()
+	q := url.Values{}
 	q.Set("q", query)
 	q.Set("limit", fmt.Sprintf("%d", limit))
-	u.RawQuery = q.Encode()
 
-	resp, err := clawhubRequest(ctx, u.String())
+	resp, err := clawhubDo(ctx, "/api/v1/search", q)
 	if err != nil {
-		return nil, fmt.Errorf("clawhub search: %w", err)
+		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
@@ -112,10 +136,9 @@ func clawhubSearch(ctx context.Context, query string, limit int) ([]clawhubSearc
 }
 
 func clawhubFetchDetail(ctx context.Context, slug string) (*clawhubSkillDetail, error) {
-	rawURL := clawhubBaseURL() + "/api/v1/skills/" + url.PathEscape(slug)
-	resp, err := clawhubRequest(ctx, rawURL)
+	resp, err := clawhubDo(ctx, "/api/v1/skills/"+url.PathEscape(slug), nil)
 	if err != nil {
-		return nil, fmt.Errorf("clawhub detail: %w", err)
+		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
@@ -145,16 +168,11 @@ func clawhubFetchSkillFiles(ctx context.Context, slug, version string) (skillNam
 		version = detail.LatestVersion.Version
 	}
 
-	u, err := url.Parse(clawhubBaseURL() + "/api/v1/download")
-	if err != nil {
-		return "", nil, nil, err
-	}
-	q := u.Query()
+	q := url.Values{}
 	q.Set("slug", slug)
 	q.Set("version", version)
-	u.RawQuery = q.Encode()
 
-	resp, err := clawhubRequest(ctx, u.String())
+	resp, err := clawhubDo(ctx, "/api/v1/download", q)
 	if err != nil {
 		return "", nil, nil, fmt.Errorf("clawhub download: %w", err)
 	}

--- a/plugins/tools/skills/install.go
+++ b/plugins/tools/skills/install.go
@@ -4,12 +4,21 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/vaayne/anna/pkg/memory"
 	pkgplugins "github.com/vaayne/anna/pkg/plugins"
 	mcpskills "github.com/vaayne/mcphub/pkg/skills"
 )
+
+// skillSearchResult is a normalized result combining both search providers.
+type skillSearchResult struct {
+	Provider    string `json:"provider"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Source      string `json:"source"`
+}
 
 func (t *Tool) search(ctx context.Context, args map[string]any) (string, error) {
 	query, _ := args["query"].(string)
@@ -22,17 +31,71 @@ func (t *Tool) search(ctx context.Context, args map[string]any) (string, error) 
 		limit = int(v)
 	}
 
-	results, err := mcpskills.Search(ctx, query, limit)
-	if err != nil {
-		return "", err
-	}
+	var (
+		mu      sync.Mutex
+		results []skillSearchResult
+		errs    []string
+		wg      sync.WaitGroup
+	)
+
+	// Search clawhub.ai concurrently.
+	wg.Go(func() {
+		hits, err := clawhubSearch(ctx, query, limit)
+		mu.Lock()
+		defer mu.Unlock()
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("clawhub: %v", err))
+			return
+		}
+		for _, h := range hits {
+			r := skillSearchResult{
+				Provider: "clawhub",
+				Name:     h.Slug,
+				Source:   "clawhub:" + h.Slug,
+			}
+			if h.Summary != "" {
+				r.Description = h.Summary
+			} else if h.DisplayName != "" {
+				r.Description = h.DisplayName
+			}
+			results = append(results, r)
+		}
+	})
+
+	// Search skills.sh concurrently.
+	wg.Go(func() {
+		hits, err := mcpskills.Search(ctx, query, limit)
+		mu.Lock()
+		defer mu.Unlock()
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("skills.sh: %v", err))
+			return
+		}
+		for _, h := range hits {
+			results = append(results, skillSearchResult{
+				Provider:    "skills.sh",
+				Name:        h.Name,
+				Description: h.Source,
+				Source:      h.Source,
+			})
+		}
+	})
+
+	wg.Wait()
 
 	if len(results) == 0 {
+		if len(errs) > 0 {
+			return "", fmt.Errorf("search failed: %s", errs[0])
+		}
 		return "No skills found.", nil
 	}
 
 	out, _ := json.MarshalIndent(results, "", "  ")
-	return fmt.Sprintf("Found %d skills:\n%s\n\nInstall with: skills tool action=install source=\"owner/repo@skill-name\"\nOptional: add scope=\"agent\" to install into agent scope.", len(results), out), nil
+	msg := fmt.Sprintf("Found %d skills:\n%s\n\nInstall with: skills tool action=install source=<source from results above>\nOptional: add scope=\"agent\" to install into agent scope.", len(results), out)
+	if len(errs) > 0 {
+		msg += fmt.Sprintf("\n\nNote: some providers failed: %v", errs)
+	}
+	return msg, nil
 }
 
 func (t *Tool) install(ctx context.Context, args map[string]any) (string, error) {

--- a/plugins/tools/skills/install.go
+++ b/plugins/tools/skills/install.go
@@ -72,11 +72,15 @@ func (t *Tool) search(ctx context.Context, args map[string]any) (string, error) 
 			return
 		}
 		for _, h := range hits {
+			source := h.Source
+			if h.SkillID != "" {
+				source = h.Source + "@" + h.SkillID
+			}
 			results = append(results, skillSearchResult{
 				Provider:    "skills.sh",
 				Name:        h.Name,
 				Description: h.Source,
-				Source:      h.Source,
+				Source:      source,
 			})
 		}
 	})

--- a/plugins/tools/skills/install_lib.go
+++ b/plugins/tools/skills/install_lib.go
@@ -75,7 +75,18 @@ func InstallToStore(ctx context.Context, store pkgplugins.SkillStore, source, sc
 // cleanup is a no-op for git sources (their path is a shared cache — do NOT
 // delete it). For local sources it is also a no-op because the path is the
 // user's local directory.
+//
+// Supported source formats:
+//   - clawhub:<slug>[@version]    — download from clawhub.ai
+//   - owner/repo@skill-name       — GitHub shorthand (via mcphub)
+//   - GitHub/GitLab URLs          — cloned via git
+//   - local paths                 — read from filesystem
 func FetchSkillFiles(ctx context.Context, source string) (skillName string, files map[string]string, cleanup func(), err error) {
+	// Handle clawhub: prefix before any other parsing.
+	if slug, version, ok := parseClawhubSource(source); ok {
+		return clawhubFetchSkillFiles(ctx, slug, version)
+	}
+
 	ref := ""
 	if !strings.HasPrefix(source, "http://") && !strings.HasPrefix(source, "https://") &&
 		!strings.HasPrefix(source, "/") && !strings.HasPrefix(source, ".") {

--- a/plugins/tools/skills/tool.go
+++ b/plugins/tools/skills/tool.go
@@ -34,7 +34,7 @@ var skillsInputSchema = func() map[string]any {
     },
     "source": {
       "type": "string",
-      "description": "Skill source to install. Supports: 'owner/repo@skill-name' (GitHub shorthand), 'owner/repo@skill-name#ref' (with branch/tag), GitHub/GitLab URLs, or local paths (required for install)"
+      "description": "Skill source to install. Supports: 'clawhub:<slug>' or 'clawhub:<slug>@<version>' (from clawhub.ai), 'owner/repo@skill-name' (GitHub shorthand), 'owner/repo@skill-name#ref' (with branch/tag), GitHub/GitLab URLs, or local paths (required for install)"
     },
     "scope": {
       "type": "string",


### PR DESCRIPTION
## Summary

- Add `clawhub.go`: HTTP client for [clawhub.ai](https://clawhub.ai) using `httpclient.New()` (resty + OTel transport)
- `FetchSkillFiles` now recognises `clawhub:<slug>[@version]` source strings, downloads the skill ZIP archive, and extracts it
- `search` queries clawhub.ai and skills.sh concurrently, merging results with `provider` and `source` fields so the model knows the exact install command to use
- Auto-fallback to CN mirror (`cn.clawhub-mirror.com`) on HTTP 429 when no token is set — no user action required in most cases
- On rate limit with no token, returns a clear one-shot message directing the user to `/config CLAWHUB_TOKEN <token>`
- Auth via `CLAWHUB_TOKEN` env var only; `CLAWHUB_URL` overrides the base URL

## Test plan

- [x] `skills action=search query=<term>` returns results from both clawhub and skills.sh
- [x] `skills action=install source="clawhub:<slug>"` installs latest version
- [x] `skills action=install source="clawhub:<slug>@<version>"` installs pinned version
- [x] Without `CLAWHUB_TOKEN`, hitting 429 on main site silently retries against CN mirror
- [x] With `CLAWHUB_TOKEN` set, only main site is used
- [x] `CLAWHUB_URL` env var overrides base URL