### PR TITLE
✨ feat: add none sandbox backend for trusted host execution

### DIFF
--- a/docs/content/docs/core/sandbox-backend-abstraction.md
+++ b/docs/content/docs/core/sandbox-backend-abstraction.md
@@ -4,11 +4,11 @@ title: Sandbox Backend Abstraction
 
 ## Status
 
-Implemented. Docker is the recommended sandbox backend. A local backend is also available for Docker-free environments; Linux keeps OS-level hardening, while macOS currently runs local commands directly on the host without additional sandboxing. Anna's execution boundary is described by `pkg/sandbox` contracts, with runner-facing registry wiring in `internal/sandbox`.
+Implemented. Docker is the recommended sandbox backend. A local backend is also available for Docker-free environments; Linux keeps OS-level hardening, while macOS currently runs local commands directly on the host without additional sandboxing. A `none` backend is also available for fully trusted workloads — it runs the agent directly on the host with the current user's permissions and no isolation of any kind. Anna's execution boundary is described by `pkg/sandbox` contracts, with runner-facing registry wiring in `internal/sandbox`.
 
 ## Purpose
 
-The sandbox abstraction exists so runner code, plugin wiring, and tool execution do not depend on concrete backend types. Execution always runs through the active backend selected by the runner. Docker provides the strongest isolation; the local backend is a host-execution fallback for environments where Docker is unavailable or undesirable.
+The sandbox abstraction exists so runner code, plugin wiring, and tool execution do not depend on concrete backend types. Execution always runs through the active backend selected by the runner. Docker provides the strongest isolation; the local backend is a fallback for environments where Docker is unavailable or undesirable; the none backend skips all isolation for fully trusted single-user workloads.
 
 The top-level model is:
 
@@ -45,7 +45,7 @@ Docker provides full container-level process, filesystem, and network isolation.
 - unsupported policy → `PolicyCompatibilityError`, runner does not start
 - no silent downgrade path exists
 
-All platforms (Linux, macOS, Windows) support the Docker backend. There is no `auto`, `boxsh`, or `Relaxed` mode.
+All platforms (Linux, macOS, Windows) support the Docker backend. There is no `auto` or `Relaxed` mode.
 
 ### Local (Docker-free)
 
@@ -86,6 +86,17 @@ No additional dependency is required. The current local backend runs commands di
 
 On Linux the agent always sees its workspace at `/workspace` regardless of the real host path (bwrap bind-mounts it). This mirrors Docker's bind-mount behaviour. On macOS the agent sees the real host path.
 
+### None (host execution)
+
+The none backend runs the agent directly on the host OS with the current user's permissions. It imposes no isolation of any kind — no filesystem confinement, no network restrictions, no process group kill, and no rlimits. The agent inherits the full host environment merged with any runner-injected session variables.
+
+**Use only for fully trusted agents in single-user local deployments.** This backend is not safe for untrusted agents or multi-user environments.
+
+- No external dependencies — works on all platforms
+- `ResolvePath` resolves relative paths against the working directory; absolute paths pass through unchanged
+- Network policy is always `allow_all`; the configured per-agent network mode is ignored
+- Session creation never fails due to missing tooling
+
 ## Configuration
 
 Per-agent sandbox configuration is limited to network policy (mode and allowlist). Each agent independently controls whether its sandbox allows outbound network access and which hosts are reachable.
@@ -107,7 +118,7 @@ The runner creates a `sandbox.Session` for each run and keeps ownership of its l
 
 ### Backend resolution
 
-The runner resolves the active backend from plugin state and dispatches to a backend-specific factory. Built-in factories currently support `docker` and `local`.
+The runner resolves the active backend from plugin state and dispatches to a backend-specific factory. Built-in factories currently support `docker`, `local`, and `none`.
 
 ### Execution-time mediation
 
@@ -155,6 +166,21 @@ The abstraction is covered by:
 - core tool parity tests
 - Docker backend integration tests
 - static bypass regression guards for migrated runtime paths
+
+## Adding a New Backend
+
+Every new sandbox backend requires changes in all of the following locations — missing any one causes a runtime error:
+
+| Step | File | What to do |
+|---|---|---|
+| 1 | `internal/config/sandbox.go` | Add `SandboxBackend<Name> = "<name>"` constant |
+| 2 | `internal/config/plugin.go` | Append name to `builtinSandboxNames` so the DB row is seeded |
+| 3 | `plugins/sandbox/<name>/session.go` | Implement `sandbox.Factory` and `sandbox.Session` |
+| 4 | `plugins/sandbox/plugin.go` | Add entry to the `backends` slice in `init()` to register `AdminVisible` plugin metadata |
+| 5 | `internal/sandbox/factory.go` | Call `mustRegisterFactory(r, <name>plugin.NewFactory(), true)` in `DefaultRegistry()` |
+| 6 | `internal/agent/sandbox_backend.go` | Add `config.SandboxBackend<Name>: create<Name>Session` to `sessionRegistry` and implement the factory function |
+| 7 | `internal/admin/ui/static/js/pages/plugins.js` | Add `"sandbox/<name>"` to `validBackends` and a `sandboxMeta` entry with features/limitations |
+| 8 | Docs | Update this file and `sandbox-backend-abstraction.zh.md` |
 
 ## Related Docs
 

--- a/docs/content/docs/core/sandbox-backend-abstraction.zh.md
+++ b/docs/content/docs/core/sandbox-backend-abstraction.zh.md
@@ -4,11 +4,11 @@ title: 沙箱后端抽象
 
 ## 状态
 
-已实现。Docker 是推荐的沙箱后端。本地后端也可用于无 Docker 环境；Linux 保留操作系统级加固，而 macOS 当前会直接在宿主机上运行本地命令，不再附加额外沙箱。Anna 的执行边界由 `pkg/sandbox` 契约描述，runner 侧注册配置位于 `internal/sandbox`。
+已实现。Docker 是推荐的沙箱后端。本地后端也可用于无 Docker 环境；Linux 保留操作系统级加固，而 macOS 当前会直接在宿主机上运行本地命令，不再附加额外沙箱。`none` 后端也可用于完全受信任的工作负载——它以当前用户权限直接在宿主机上运行代理，不提供任何隔离。Anna 的执行边界由 `pkg/sandbox` 契约描述，runner 侧注册配置位于 `internal/sandbox`。
 
 ## 目的
 
-沙箱抽象的目的是使 runner 代码、插件配置和工具执行不依赖于具体的后端类型。执行总是通过 runner 选中的活动后端进行。Docker 提供最强隔离；本地后端则是在 Docker 不可用或不想使用时的宿主机执行回退方案。
+沙箱抽象的目的是使 runner 代码、插件配置和工具执行不依赖于具体的后端类型。执行总是通过 runner 选中的活动后端进行。Docker 提供最强隔离；本地后端是 Docker 不可用或不想使用时的回退方案；`none` 后端则为完全受信任的单用户本地部署跳过所有隔离。
 
 顶层模型：
 
@@ -45,7 +45,7 @@ Docker 提供完整的容器级进程、文件系统和网络隔离。Docker 守
 - 不支持的策略 → `PolicyCompatibilityError`，runner 不启动
 - 不存在静默降级路径
 
-所有平台（Linux、macOS、Windows）均支持 Docker 后端。不存在 `auto`、`boxsh` 或 `Relaxed` 模式。
+所有平台（Linux、macOS、Windows）均支持 Docker 后端。不存在 `auto` 或 `Relaxed` 模式。
 
 ### 本地后端（无 Docker）
 
@@ -86,6 +86,17 @@ bwrap 必须实际可用，仅安装不够。在未启用 `--privileged` 的 Doc
 
 在 Linux 上，无论真实宿主机路径如何，代理始终将工作区看作 `/workspace`（bwrap 负责绑定挂载），与 Docker 绑定挂载行为一致。在 macOS 上，代理看到的是真实宿主机路径。
 
+### None（宿主机直接执行）
+
+`none` 后端以当前用户权限直接在宿主机 OS 上运行代理，不提供任何隔离——无文件系统限制、无网络限制、无进程组终止，也无资源限制（rlimits）。代理继承完整宿主机环境，并与 runner 注入的会话变量合并。
+
+**仅在单用户本地部署中对完全受信任的代理使用。** 此后端不适用于不受信任的代理或多用户环境。
+
+- 无外部依赖——适用于所有平台
+- `ResolvePath` 将相对路径解析为工作目录下的绝对路径；绝对路径原样返回
+- 网络策略始终为 `allow_all`；每个代理配置的网络模式将被忽略
+- 不会因缺少工具而导致会话创建失败
+
 ## 配置
 
 每个代理的沙箱配置仅限于网络策略（模式和允许列表）。每个代理独立控制其沙箱是否允许出站网络访问以及哪些主机可达。
@@ -107,7 +118,7 @@ runner 为每次运行创建一个 `sandbox.Session` 并持有其生命周期所
 
 ### 后端解析
 
-runner 会根据插件状态解析当前活动后端，并分派到对应的后端工厂。内置工厂当前支持 `docker` 和 `local`。
+runner 会根据插件状态解析当前活动后端，并分派到对应的后端工厂。内置工厂当前支持 `docker`、`local` 和 `none`。
 
 ### 执行时中介
 
@@ -155,6 +166,21 @@ Anna 优先选择显式拒绝而非静默降级：
 - 核心工具一致性测试
 - Docker 后端集成测试
 - 已迁移运行时路径的静态绕过回归保护
+
+## 添加新后端
+
+每个新沙箱后端需要在以下所有位置进行修改——遗漏任何一处都会导致运行时错误：
+
+| 步骤 | 文件 | 操作 |
+|---|---|---|
+| 1 | `internal/config/sandbox.go` | 添加 `SandboxBackend<Name> = "<name>"` 常量 |
+| 2 | `internal/config/plugin.go` | 将名称追加到 `builtinSandboxNames`，确保 DB 行被初始化 |
+| 3 | `plugins/sandbox/<name>/session.go` | 实现 `sandbox.Factory` 和 `sandbox.Session` |
+| 4 | `plugins/sandbox/plugin.go` | 在 `init()` 的 `backends` 切片中添加条目，注册 `AdminVisible` 插件元数据 |
+| 5 | `internal/sandbox/factory.go` | 在 `DefaultRegistry()` 中调用 `mustRegisterFactory(r, <name>plugin.NewFactory(), true)` |
+| 6 | `internal/agent/sandbox_backend.go` | 在 `sessionRegistry` 中添加 `config.SandboxBackend<Name>: create<Name>Session`，并实现工厂函数 |
+| 7 | `internal/admin/ui/static/js/pages/plugins.js` | 将 `"sandbox/<name>"` 添加到 `validBackends`，并在 `sandboxMeta` 中添加包含特性/限制的条目 |
+| 8 | 文档 | 更新本文件及 `sandbox-backend-abstraction.zh.md` |
 
 ## 相关文档
 

--- a/internal/admin/ui/static/js/pages/plugins.js
+++ b/internal/admin/ui/static/js/pages/plugins.js
@@ -60,7 +60,7 @@ export function register(Alpine) {
     },
 
     get sandboxPlugins() {
-      const validBackends = new Set(['sandbox/docker', 'sandbox/local'])
+      const validBackends = new Set(['sandbox/docker', 'sandbox/local', 'sandbox/none'])
       return this.plugins.filter(p => p.kind === 'sandbox' && validBackends.has(p.id))
     },
 
@@ -811,6 +811,20 @@ export function register(Alpine) {
             'macOS: no filesystem or network policy enforcement',
             'Windows: not supported',
             'Linux: bwrap is required; sessions fail closed if unavailable',
+          ],
+        },
+        'sandbox/none': {
+          recommended: false,
+          isDefault: false,
+          features: [
+            'No external dependencies — works everywhere',
+            'Agent inherits full host environment and permissions',
+            'Suitable for trusted workloads or single-user local deployments',
+          ],
+          limitations: [
+            'No isolation of any kind — agent runs as the current user',
+            'No filesystem, network, or process restrictions enforced',
+            'Not safe for untrusted agents or multi-user environments',
           ],
         },
       }

--- a/internal/agent/sandbox_backend.go
+++ b/internal/agent/sandbox_backend.go
@@ -24,6 +24,7 @@ import (
 	dockerplugin "github.com/vaayne/anna/plugins/sandbox/docker"
 	"github.com/vaayne/anna/plugins/sandbox/docker/dockerclient"
 	localplugin "github.com/vaayne/anna/plugins/sandbox/local"
+	noneplugin "github.com/vaayne/anna/plugins/sandbox/none"
 )
 
 // runnerSession wraps a sandbox.Session for runner use.
@@ -118,6 +119,7 @@ type sessionFactory func(context.Context, GoRunnerConfig) (*runnerSession, error
 var sessionRegistry = map[string]sessionFactory{
 	config.SandboxBackendDocker: createDockerSession,
 	config.SandboxBackendLocal:  createLocalSession,
+	config.SandboxBackendNone:   createHostSession,
 }
 
 func runnerFilesystemPolicy(paths sandboxPaths) sandbox.FilesystemPolicy {
@@ -431,6 +433,41 @@ func createLocalSession(ctx context.Context, cfg GoRunnerConfig) (*runnerSession
 	session, err := localplugin.NewFactory().CreateSession(ctx, policy)
 	if err != nil {
 		return nil, fmt.Errorf("create local session: %w", err)
+	}
+
+	return &runnerSession{
+		session: session,
+		policy:  policy,
+	}, nil
+}
+
+func createHostSession(ctx context.Context, cfg GoRunnerConfig) (*runnerSession, error) {
+	paths, err := resolveSandboxPaths(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("resolve sandbox paths: %w", err)
+	}
+	env, err := buildSandboxEnv(ctx, cfg, paths)
+	if err != nil {
+		return nil, err
+	}
+
+	policy := sandbox.Policy{
+		Filesystem: runnerFilesystemPolicy(paths),
+		Network: sandbox.NetworkPolicy{
+			Mode: sandbox.NetworkAllowAll,
+		},
+		Env:        env,
+		InheritEnv: true,
+	}
+
+	slog.Info("creating host session",
+		"component", "runner_sandbox",
+		"work_dir", paths.WorkDir,
+	)
+
+	session, err := noneplugin.NewFactory().CreateSession(ctx, policy)
+	if err != nil {
+		return nil, fmt.Errorf("create host session: %w", err)
 	}
 
 	return &runnerSession{

--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -41,7 +41,7 @@ var builtinProviderNames = []string{"anthropic", "openai", "openai-response"}
 var builtinMemoryNames = []string{"lcm", "simple"}
 
 // builtinSandboxNames lists the built-in sandbox backend plugins.
-var builtinSandboxNames = []string{SandboxBackendDocker, SandboxBackendLocal}
+var builtinSandboxNames = []string{SandboxBackendDocker, SandboxBackendLocal, SandboxBackendNone}
 
 // builtinStandalonePlugins lists plugins that don't follow the kind/name pattern.
 var builtinStandalonePlugins = []string{"reflect"}

--- a/internal/config/sandbox.go
+++ b/internal/config/sandbox.go
@@ -6,8 +6,8 @@ import (
 
 const (
 	SandboxBackendDocker = "docker"
-	SandboxBackendBoxsh  = "boxsh"
 	SandboxBackendLocal  = "local"
+	SandboxBackendNone   = "none"
 
 	SandboxNetworkDisabled = "disabled"
 	SandboxNetworkAllowAll = "allow_all"

--- a/internal/sandbox/factory.go
+++ b/internal/sandbox/factory.go
@@ -3,6 +3,7 @@ package sandbox
 import (
 	sandboxpkg "github.com/vaayne/anna/pkg/sandbox"
 	dockerplugin "github.com/vaayne/anna/plugins/sandbox/docker"
+	noneplugin "github.com/vaayne/anna/plugins/sandbox/none"
 )
 
 type (
@@ -23,6 +24,7 @@ func NewRegistry() *Registry {
 func DefaultRegistry() *Registry {
 	r := NewRegistry()
 	mustRegisterFactory(r, dockerplugin.NewFactory(dockerplugin.Config{}), true)
+	mustRegisterFactory(r, noneplugin.NewFactory(), true)
 	return r
 }
 

--- a/internal/sandbox/factory.go
+++ b/internal/sandbox/factory.go
@@ -3,7 +3,6 @@ package sandbox
 import (
 	sandboxpkg "github.com/vaayne/anna/pkg/sandbox"
 	dockerplugin "github.com/vaayne/anna/plugins/sandbox/docker"
-	noneplugin "github.com/vaayne/anna/plugins/sandbox/none"
 )
 
 type (
@@ -24,7 +23,6 @@ func NewRegistry() *Registry {
 func DefaultRegistry() *Registry {
 	r := NewRegistry()
 	mustRegisterFactory(r, dockerplugin.NewFactory(dockerplugin.Config{}), true)
-	mustRegisterFactory(r, noneplugin.NewFactory(), true)
 	return r
 }
 

--- a/internal/sandbox/policy_compat_test.go
+++ b/internal/sandbox/policy_compat_test.go
@@ -220,14 +220,8 @@ func TestPolicyCompatibilityErrorMessage(t *testing.T) {
 func TestDefaultRegistry(t *testing.T) {
 	registry := DefaultRegistry()
 
-	// local and boxsh factories are no longer registered
-	local := registry.Get("local")
-	if local != nil {
+	if registry.Get("local") != nil {
 		t.Error("DefaultRegistry should not include local factory")
-	}
-	boxsh := registry.Get("boxsh")
-	if boxsh != nil {
-		t.Error("DefaultRegistry should not include boxsh factory")
 	}
 
 	// Docker is always registered (regardless of daemon availability)

--- a/plugins/sandbox/none/platform_unix.go
+++ b/plugins/sandbox/none/platform_unix.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package none
+
+func shell() (string, string) { return "sh", "-c" }
+
+func platformAvailable() bool { return true }

--- a/plugins/sandbox/none/platform_windows.go
+++ b/plugins/sandbox/none/platform_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package none
+
+func shell() (string, string) { return "cmd", "/c" }
+
+func platformAvailable() bool { return false }

--- a/plugins/sandbox/none/session.go
+++ b/plugins/sandbox/none/session.go
@@ -25,8 +25,8 @@ func NewFactory() sandboxpkg.Factory { return &Factory{} }
 // Name returns the backend name.
 func (f *Factory) Name() string { return "none" }
 
-// Available always returns true — no external dependencies.
-func (f *Factory) Available() bool { return true }
+// Available returns true on all platforms except Windows.
+func (f *Factory) Available() bool { return platformAvailable() }
 
 // Supported accepts any policy; the none backend imposes no restrictions.
 func (f *Factory) Supported(_ sandboxpkg.Policy) error { return nil }
@@ -121,7 +121,8 @@ func (s *noneSession) Exec(ctx context.Context, command string, opts sandboxpkg.
 		defer cancel()
 	}
 
-	cmd := exec.Command("sh", "-c", command)
+	sh, shFlag := shell()
+	cmd := exec.Command(sh, shFlag, command)
 	cmd.Dir = cwd
 	cmd.Env = buildEnv(s.policy, opts.Env)
 

--- a/plugins/sandbox/none/session.go
+++ b/plugins/sandbox/none/session.go
@@ -1,0 +1,366 @@
+// Package none provides a no-op sandbox backend that runs commands directly on
+// the host with the same permissions as the current user and no isolation.
+// Use only when agent workloads are fully trusted.
+package none
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+
+	sandboxpkg "github.com/vaayne/anna/pkg/sandbox"
+)
+
+// Factory creates sessions that execute directly on the host with no sandboxing.
+type Factory struct{}
+
+// NewFactory returns a Factory for the none backend.
+func NewFactory() sandboxpkg.Factory { return &Factory{} }
+
+// Name returns the backend name.
+func (f *Factory) Name() string { return "none" }
+
+// Available always returns true — no external dependencies.
+func (f *Factory) Available() bool { return true }
+
+// Supported accepts any policy; the none backend imposes no restrictions.
+func (f *Factory) Supported(_ sandboxpkg.Policy) error { return nil }
+
+// CreateSession creates a new noneSession.
+func (f *Factory) CreateSession(_ context.Context, policy sandboxpkg.Policy) (sandboxpkg.Session, error) {
+	id := sandboxpkg.NewSessionID()
+	s := &noneSession{
+		id:     id,
+		policy: policy,
+		done:   make(chan struct{}),
+	}
+	sandboxpkg.LogSessionCreated(id, "none", policy)
+	return s, nil
+}
+
+// noneSession implements sandboxpkg.Session with zero isolation.
+type noneSession struct {
+	id       string
+	policy   sandboxpkg.Policy
+	done     chan struct{}
+	doneOnce sync.Once
+	mu       sync.RWMutex
+	closed   bool
+	procs    []*noneProcess
+}
+
+func (s *noneSession) Policy() sandboxpkg.Policy { return s.policy }
+
+func (s *noneSession) WorkingDir() string {
+	if s.policy.Filesystem.WorkingDir != "" {
+		return s.policy.Filesystem.WorkingDir
+	}
+	wd, _ := os.Getwd()
+	return wd
+}
+
+func (s *noneSession) Alive() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return !s.closed
+}
+
+func (s *noneSession) Done() <-chan struct{} { return s.done }
+
+func (s *noneSession) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	procs := s.procs
+	s.procs = nil
+	for _, p := range procs {
+		p.Close() //nolint:errcheck
+	}
+	s.doneOnce.Do(func() { close(s.done) })
+	sandboxpkg.LogSessionClosed(s.id, "none", "explicit_close")
+	return nil
+}
+
+// ResolvePath resolves a relative path against the working directory.
+// Absolute paths are returned as-is.
+func (s *noneSession) ResolvePath(path string) (string, error) {
+	if filepath.IsAbs(path) {
+		return path, nil
+	}
+	return filepath.Join(s.WorkingDir(), path), nil
+}
+
+func (s *noneSession) Exec(ctx context.Context, command string, opts sandboxpkg.ExecOptions) (sandboxpkg.ExecResult, error) {
+	s.mu.RLock()
+	closed := s.closed
+	s.mu.RUnlock()
+	if closed {
+		return sandboxpkg.ExecResult{}, errors.New("none: session is closed")
+	}
+
+	cwd := opts.Cwd
+	if cwd == "" {
+		cwd = s.WorkingDir()
+	}
+
+	timeout := opts.Timeout
+	if timeout == 0 {
+		timeout = s.policy.Timeout
+	}
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	cmd := exec.Command("sh", "-c", command)
+	cmd.Dir = cwd
+	cmd.Env = buildEnv(s.policy, opts.Env)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Start(); err != nil {
+		return sandboxpkg.ExecResult{}, err
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	select {
+	case <-ctx.Done():
+		_ = cmd.Process.Kill()
+		<-done
+		return sandboxpkg.ExecResult{}, ctx.Err()
+	case waitErr := <-done:
+		exitCode := 0
+		if waitErr != nil {
+			exitErr := &exec.ExitError{}
+			if errors.As(waitErr, &exitErr) {
+				exitCode = exitErr.ExitCode()
+			} else {
+				return sandboxpkg.ExecResult{}, waitErr
+			}
+		}
+		return sandboxpkg.ExecResult{
+			Stdout:   stdout.String(),
+			Stderr:   stderr.String(),
+			ExitCode: exitCode,
+		}, nil
+	}
+}
+
+func (s *noneSession) StartProcess(ctx context.Context, req sandboxpkg.ProcessRequest) (sandboxpkg.ProcessHandle, error) {
+	s.mu.RLock()
+	closed := s.closed
+	s.mu.RUnlock()
+	if closed {
+		return nil, errors.New("none: session is closed")
+	}
+
+	cwd := req.Cwd
+	if cwd == "" {
+		cwd = s.WorkingDir()
+	}
+
+	timeout := req.Timeout
+	if timeout == 0 {
+		timeout = s.policy.Timeout
+	}
+
+	var execCtx context.Context
+	var cancel context.CancelFunc
+	if timeout > 0 {
+		execCtx, cancel = context.WithTimeout(ctx, timeout)
+	} else {
+		execCtx, cancel = context.WithCancel(ctx)
+	}
+
+	cmd := exec.Command(req.Path, req.Args...)
+	cmd.Dir = cwd
+	cmd.Env = buildEnv(s.policy, req.Env)
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		_ = stdin.Close()
+		cancel()
+		return nil, err
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		_ = stdin.Close()
+		_ = stdout.Close()
+		cancel()
+		return nil, err
+	}
+
+	if err := cmd.Start(); err != nil {
+		_ = stdin.Close()
+		_ = stdout.Close()
+		_ = stderr.Close()
+		cancel()
+		return nil, err
+	}
+
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		cancel()
+		return nil, errors.New("none: session is closed")
+	}
+	proc := &noneProcess{
+		session: s,
+		cmd:     cmd,
+		cancel:  cancel,
+		stdin:   stdin,
+		stdout:  stdout,
+		stderr:  stderr,
+		exitCh:  make(chan struct{}),
+	}
+	go func() {
+		select {
+		case <-execCtx.Done():
+			proc.Close() //nolint:errcheck
+		case <-proc.exitCh:
+		}
+	}()
+	s.procs = append(s.procs, proc)
+	s.mu.Unlock()
+
+	return proc, nil
+}
+
+func (s *noneSession) deregisterProcess(p *noneProcess) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, proc := range s.procs {
+		if proc == p {
+			s.procs = append(s.procs[:i], s.procs[i+1:]...)
+			return
+		}
+	}
+}
+
+// buildEnv merges host env with policy env and per-call overrides.
+func buildEnv(policy sandboxpkg.Policy, overrides map[string]string) []string {
+	merged := make(map[string]string)
+	for _, kv := range os.Environ() {
+		k, v, ok := cutEnv(kv)
+		if ok {
+			merged[k] = v
+		}
+	}
+	for k, v := range policy.Env {
+		merged[k] = v
+	}
+	for k, v := range overrides {
+		merged[k] = v
+	}
+	env := make([]string, 0, len(merged))
+	for k, v := range merged {
+		env = append(env, k+"="+v)
+	}
+	return env
+}
+
+func cutEnv(kv string) (string, string, bool) {
+	for i := 0; i < len(kv); i++ {
+		if kv[i] == '=' {
+			return kv[:i], kv[i+1:], true
+		}
+	}
+	return "", "", false
+}
+
+// noneProcess implements sandboxpkg.ProcessHandle.
+type noneProcess struct {
+	session *noneSession
+	cmd     *exec.Cmd
+	cancel  context.CancelFunc
+	stdin   io.WriteCloser
+	stdout  io.ReadCloser
+	stderr  io.ReadCloser
+	mu      sync.Mutex
+	closed  bool
+	exitCh  chan struct{}
+}
+
+func (p *noneProcess) PID() int {
+	if p.cmd.Process != nil {
+		return p.cmd.Process.Pid
+	}
+	return 0
+}
+
+func (p *noneProcess) Stdin() io.WriteCloser { return p.stdin }
+func (p *noneProcess) Stdout() io.ReadCloser { return p.stdout }
+func (p *noneProcess) Stderr() io.ReadCloser { return p.stderr }
+
+func (p *noneProcess) Wait(ctx context.Context) (sandboxpkg.ExecResult, error) {
+	type result struct {
+		code int
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		err := p.cmd.Wait()
+		code := 0
+		if err != nil {
+			exitErr := &exec.ExitError{}
+			if errors.As(err, &exitErr) {
+				code = exitErr.ExitCode()
+				err = nil
+			}
+		}
+		p.mu.Lock()
+		if !p.closed {
+			p.closed = true
+			close(p.exitCh)
+		}
+		p.mu.Unlock()
+		if p.session != nil {
+			p.session.deregisterProcess(p)
+		}
+		done <- result{code, err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		_ = p.Close()
+		return sandboxpkg.ExecResult{}, ctx.Err()
+	case r := <-done:
+		return sandboxpkg.ExecResult{ExitCode: r.code}, r.err
+	}
+}
+
+func (p *noneProcess) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		return nil
+	}
+	p.closed = true
+	close(p.exitCh)
+	p.cancel()
+	if p.cmd.Process != nil {
+		_ = p.cmd.Process.Kill()
+	}
+	return nil
+}
+

--- a/plugins/sandbox/plugin.go
+++ b/plugins/sandbox/plugin.go
@@ -22,6 +22,11 @@ func init() {
 			displayName: "Local",
 			description: "Default Docker-free sandbox; uses bwrap for filesystem and network isolation on Linux.",
 		},
+		{
+			name:        config.SandboxBackendNone,
+			displayName: "None",
+			description: "No sandbox. Agent runs directly on the host with the current user's permissions. Use only for trusted workloads.",
+		},
 	}
 	for _, b := range backends {
 		id := config.PluginID(config.PluginKindSandbox, b.name)


### PR DESCRIPTION
## Summary

- Adds a `none` sandbox backend that runs agents directly on the host with the current user's permissions and zero isolation — useful for trusted single-user local deployments without Docker or bwrap
- Removes the stale `SandboxBackendBoxsh` constant and cleans up related test assertions
- Adds an **"Adding a New Backend"** checklist to the sandbox docs (en + zh) to prevent missing touch points in future

## Changes

| Area | File | Change |
|---|---|---|
| Plugin | `plugins/sandbox/none/session.go` | New Factory + Session implementation |
| Plugin registration | `plugins/sandbox/plugin.go` | Register AdminVisible metadata |
| Registry | `internal/sandbox/factory.go` | Register in DefaultRegistry |
| Config | `internal/config/sandbox.go` | Add `SandboxBackendNone`, drop `SandboxBackendBoxsh` |
| DB seed | `internal/config/plugin.go` | Add `none` to `builtinSandboxNames` |
| Runner | `internal/agent/sandbox_backend.go` | Add `createHostSession` factory |
| Admin UI | `internal/admin/ui/static/js/pages/plugins.js` | Expose in sandbox plugins page with features/limitations |
| Test | `internal/sandbox/policy_compat_test.go` | Clean up stale boxsh assertion |
| Docs | `sandbox-backend-abstraction.md` + `.zh.md` | Document none backend + new backend checklist |

## Test plan

- [ ] Build passes (`go build ./...`)
- [ ] Sandbox tests pass (`go test ./internal/sandbox/... ./internal/config/...`)
- [ ] Enable `none` backend on the Plugins page — agent runs without Docker or bwrap
- [ ] Switching back to `docker` or `local` works normally