### PR TITLE
fix: allow secure cookie for private network addresses

### DIFF
--- a/internal/admin/auth.go
+++ b/internal/admin/auth.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -214,11 +215,30 @@ func (s *Server) meHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // isLocalhost returns true if the request host is localhost or 127.0.0.1.
+// It also returns true for private network addresses like 192.168.x.x, 10.x.x.x, etc.
 func isLocalhost(r *http.Request) bool {
 	host := r.Host
-	return strings.HasPrefix(host, "localhost") ||
+	if strings.HasPrefix(host, "localhost") ||
 		strings.HasPrefix(host, "127.0.0.1") ||
-		strings.HasPrefix(host, "[::1]")
+		strings.HasPrefix(host, "[::1]") {
+		return true
+	}
+	// Check for private network IPs (192.168.x.x, 10.x.x.x, 172.16-31.x.x)
+	hostOnly := strings.Split(host, ":")[0]
+	if strings.HasPrefix(hostOnly, "192.168.") ||
+		strings.HasPrefix(hostOnly, "10.") ||
+		(strings.HasPrefix(hostOnly, "172.") && len(hostOnly) >= 7) {
+		// Check if second octet is 16-31 for 172.x.x.x
+		if strings.HasPrefix(hostOnly, "172.") {
+			secondOctet := strings.Split(strings.TrimPrefix(hostOnly, "172."), ".")[0]
+			second, _ := strconv.Atoi(secondOctet)
+			if second < 16 || second > 31 {
+				return false
+			}
+		}
+		return true
+	}
+	return false
 }
 
 // clientIP extracts the client IP from the request, checking X-Forwarded-For


### PR DESCRIPTION
## Summary

- Fixed cookie authentication for admin panel when accessed via private network IPs (192.168.x.x, 10.x.x.x, 172.16-31.x.x)
- The cookie was previously set with `Secure=true` which prevented browsers from saving it over HTTP connections
- Now `isLocalhost()` recognizes private network addresses, allowing cookie-based auth to work over LAN

## Problem

When accessing the Anna admin panel from a browser on the local network (e.g., `http://192.168.1.188:25678`), users could not stay logged in. The login would appear to succeed but immediately redirect back to the login page.

This was because:
1. `isLocalhost()` only returned `true` for `localhost`, `127.0.0.1`, and `[::1]`
2. For non-localhost requests, the cookie was set with `Secure=true`
3. Over HTTP (not HTTPS), browsers refuse to save cookies with `Secure=true`

## Solution

Extended `isLocalhost()` in `internal/admin/auth.go` to recognize private network addresses:
- `192.168.x.x`
- `10.x.x.x`  
- `172.16-31.x.x`

## Test plan

- [ ] Login via `http://192.168.x.x:25678` works and persists after page refresh
- [ ] Login via `http://localhost:25678` still works as before
- [ ] Login via `https://` domain still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)