### PR TITLE
feat(api): OpenAPI spec as single source of truth for all /api/* routes

### DIFF
--- a/api/AGENTS.md
+++ b/api/AGENTS.md
@@ -12,12 +12,20 @@ api/
     components/
       common.yaml                 security schemes + shared responses
     domain/                       ← one sub-folder per domain (auto-discovered by codegen)
+      agents/                       agent CRUD + skill management
+      auth/                         login, logout, register, OAuth
+      auth_users/                   admin user management
+      channels/                     channel management
+      plugins/                      plugin management + manifest plugins
+      profile/                      user profile + vault
       recally/
         schemas.yaml                recally types (Article, Feed, Digest, …)
         paths.yaml                  recally REST paths
       scheduler/
         schemas.yaml                scheduler types (Job, JobList, …)
         paths.yaml                  scheduler REST paths
+      sessions/                     chat session management
+      …                             (agents, models, providers, skills, users, etc.)
   codegen/                      ← oapi-codegen configs
     types.yaml                    → api/types/gen.go
     server.yaml                   → api/server/gen.go  (import-mapping → api/types)
@@ -75,5 +83,5 @@ Every new or changed HTTP API must follow this workflow:
 
 - Edit domain files in `api/spec/domain/<domain>/`; never edit `api/spec/components.yaml` directly.
 - Domain path files reference schemas through `../../components.yaml`.
-- Never hand-write recally/scheduler server routing. Routing comes from `apiserver.HandlerFromMux(s, s.mux)` in `routes.go`.
+- Never hand-write server routing for any domain. All `/api/*` routing comes from `apiserver.HandlerFromMux(s, s.mux)` in `routes.go`.
 - Enum constants live in `api/types`, not `api/server` or `api/client`. Import `api/types` directly when constants are needed.

--- a/api/client/gen.go
+++ b/api/client/gen.go
@@ -46,6 +46,12 @@ type ArticleStatus = externalRef0.ArticleStatus
 // AssignAgentUserRequest defines model for AssignAgentUserRequest.
 type AssignAgentUserRequest = externalRef0.AssignAgentUserRequest
 
+// AuthUser defines model for AuthUser.
+type AuthUser = externalRef0.AuthUser
+
+// AuthUserList defines model for AuthUserList.
+type AuthUserList = externalRef0.AuthUserList
+
 // BuiltinResource defines model for BuiltinResource.
 type BuiltinResource = externalRef0.BuiltinResource
 
@@ -115,6 +121,9 @@ type FetchModelsRequest = externalRef0.FetchModelsRequest
 // GlobalInstallSkillRequest defines model for GlobalInstallSkillRequest.
 type GlobalInstallSkillRequest = externalRef0.GlobalInstallSkillRequest
 
+// Identity defines model for Identity.
+type Identity = externalRef0.Identity
+
 // InstallSkillRequest defines model for InstallSkillRequest.
 type InstallSkillRequest = externalRef0.InstallSkillRequest
 
@@ -169,6 +178,9 @@ type Session = externalRef0.Session
 // SessionDetail defines model for SessionDetail.
 type SessionDetail = externalRef0.SessionDetail
 
+// SetMemoryRequest defines model for SetMemoryRequest.
+type SetMemoryRequest = externalRef0.SetMemoryRequest
+
 // Skill defines model for Skill.
 type Skill = externalRef0.Skill
 
@@ -199,8 +211,17 @@ type TagCount = externalRef0.TagCount
 // Tool defines model for Tool.
 type Tool = externalRef0.Tool
 
+// UpdateActiveRequest defines model for UpdateActiveRequest.
+type UpdateActiveRequest = externalRef0.UpdateActiveRequest
+
+// UpdateAgentsRequest defines model for UpdateAgentsRequest.
+type UpdateAgentsRequest = externalRef0.UpdateAgentsRequest
+
 // UpdateArticleRequest Only provided fields are updated.
 type UpdateArticleRequest = externalRef0.UpdateArticleRequest
+
+// UpdateDefaultAgentRequest defines model for UpdateDefaultAgentRequest.
+type UpdateDefaultAgentRequest = externalRef0.UpdateDefaultAgentRequest
 
 // UpdateFeedEntryRequest defines model for UpdateFeedEntryRequest.
 type UpdateFeedEntryRequest = externalRef0.UpdateFeedEntryRequest
@@ -208,8 +229,17 @@ type UpdateFeedEntryRequest = externalRef0.UpdateFeedEntryRequest
 // UpdateFeedRequest defines model for UpdateFeedRequest.
 type UpdateFeedRequest = externalRef0.UpdateFeedRequest
 
+// UpdateNotifyIdentityRequest defines model for UpdateNotifyIdentityRequest.
+type UpdateNotifyIdentityRequest = externalRef0.UpdateNotifyIdentityRequest
+
+// UpdateRoleRequest defines model for UpdateRoleRequest.
+type UpdateRoleRequest = externalRef0.UpdateRoleRequest
+
 // UpdateSkillRequest defines model for UpdateSkillRequest.
 type UpdateSkillRequest = externalRef0.UpdateSkillRequest
+
+// UserMemory defines model for UserMemory.
+type UserMemory = externalRef0.UserMemory
 
 // WeixinQRCode defines model for WeixinQRCode.
 type WeixinQRCode = externalRef0.WeixinQRCode
@@ -344,6 +374,15 @@ type UploadProfileSkillMultipartRequestBody UploadProfileSkillMultipartBody
 // UpdateProfileSkillJSONRequestBody defines body for UpdateProfileSkill for application/json ContentType.
 type UpdateProfileSkillJSONRequestBody = externalRef0.UpdateSkillRequest
 
+// UpdateAuthUserActiveJSONRequestBody defines body for UpdateAuthUserActive for application/json ContentType.
+type UpdateAuthUserActiveJSONRequestBody = externalRef0.UpdateActiveRequest
+
+// UpdateAuthUserAgentsJSONRequestBody defines body for UpdateAuthUserAgents for application/json ContentType.
+type UpdateAuthUserAgentsJSONRequestBody = externalRef0.UpdateAgentsRequest
+
+// UpdateAuthUserRoleJSONRequestBody defines body for UpdateAuthUserRole for application/json ContentType.
+type UpdateAuthUserRoleJSONRequestBody = externalRef0.UpdateRoleRequest
+
 // CreateChannelJSONRequestBody defines body for CreateChannel for application/json ContentType.
 type CreateChannelJSONRequestBody = externalRef0.ChannelWriteRequest
 
@@ -394,6 +433,15 @@ type InstallSkillJSONRequestBody = externalRef0.GlobalInstallSkillRequest
 
 // UpdateSkillJSONRequestBody defines body for UpdateSkill for application/json ContentType.
 type UpdateSkillJSONRequestBody = externalRef0.UpdateSkillRequest
+
+// UpdateUserDefaultAgentJSONRequestBody defines body for UpdateUserDefaultAgent for application/json ContentType.
+type UpdateUserDefaultAgentJSONRequestBody = externalRef0.UpdateDefaultAgentRequest
+
+// SetUserMemoryJSONRequestBody defines body for SetUserMemory for application/json ContentType.
+type SetUserMemoryJSONRequestBody = externalRef0.SetMemoryRequest
+
+// UpdateUserNotifyIdentityJSONRequestBody defines body for UpdateUserNotifyIdentity for application/json ContentType.
+type UpdateUserNotifyIdentityJSONRequestBody = externalRef0.UpdateNotifyIdentityRequest
 
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(ctx context.Context, req *http.Request) error
@@ -556,6 +604,33 @@ type ClientInterface interface {
 
 	// GetProfileSkillFile request
 	GetProfileSkillFile(ctx context.Context, skillId string, params *GetProfileSkillFileParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListAuthUsers request
+	ListAuthUsers(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetAuthUser request
+	GetAuthUser(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateAuthUserActiveWithBody request with any body
+	UpdateAuthUserActiveWithBody(ctx context.Context, id int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateAuthUserActive(ctx context.Context, id int64, body UpdateAuthUserActiveJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListAuthUserAgents request
+	ListAuthUserAgents(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateAuthUserAgentsWithBody request with any body
+	UpdateAuthUserAgentsWithBody(ctx context.Context, id int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateAuthUserAgents(ctx context.Context, id int64, body UpdateAuthUserAgentsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteAuthUserIdentity request
+	DeleteAuthUserIdentity(ctx context.Context, id int64, identityId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateAuthUserRoleWithBody request with any body
+	UpdateAuthUserRoleWithBody(ctx context.Context, id int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateAuthUserRole(ctx context.Context, id int64, body UpdateAuthUserRoleJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListBuiltinResources request
 	ListBuiltinResources(ctx context.Context, kind string, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -755,6 +830,27 @@ type ClientInterface interface {
 
 	// ListTools request
 	ListTools(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateUserDefaultAgentWithBody request with any body
+	UpdateUserDefaultAgentWithBody(ctx context.Context, id int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateUserDefaultAgent(ctx context.Context, id int64, body UpdateUserDefaultAgentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListUserMemories request
+	ListUserMemories(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteUserMemory request
+	DeleteUserMemory(ctx context.Context, id int64, agentId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SetUserMemoryWithBody request with any body
+	SetUserMemoryWithBody(ctx context.Context, id int64, agentId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	SetUserMemory(ctx context.Context, id int64, agentId string, body SetUserMemoryJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateUserNotifyIdentityWithBody request with any body
+	UpdateUserNotifyIdentityWithBody(ctx context.Context, id int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateUserNotifyIdentity(ctx context.Context, id int64, body UpdateUserNotifyIdentityJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
 func (c *Client) ListAgents(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -1131,6 +1227,126 @@ func (c *Client) DeleteProfileSkillFile(ctx context.Context, skillId string, par
 
 func (c *Client) GetProfileSkillFile(ctx context.Context, skillId string, params *GetProfileSkillFileParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetProfileSkillFileRequest(c.Server, skillId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListAuthUsers(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListAuthUsersRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetAuthUser(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetAuthUserRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateAuthUserActiveWithBody(ctx context.Context, id int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateAuthUserActiveRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateAuthUserActive(ctx context.Context, id int64, body UpdateAuthUserActiveJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateAuthUserActiveRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListAuthUserAgents(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListAuthUserAgentsRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateAuthUserAgentsWithBody(ctx context.Context, id int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateAuthUserAgentsRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateAuthUserAgents(ctx context.Context, id int64, body UpdateAuthUserAgentsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateAuthUserAgentsRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteAuthUserIdentity(ctx context.Context, id int64, identityId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteAuthUserIdentityRequest(c.Server, id, identityId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateAuthUserRoleWithBody(ctx context.Context, id int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateAuthUserRoleRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateAuthUserRole(ctx context.Context, id int64, body UpdateAuthUserRoleJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateAuthUserRoleRequest(c.Server, id, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1995,6 +2211,102 @@ func (c *Client) GetSkillFile(ctx context.Context, id string, params *GetSkillFi
 
 func (c *Client) ListTools(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewListToolsRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateUserDefaultAgentWithBody(ctx context.Context, id int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateUserDefaultAgentRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateUserDefaultAgent(ctx context.Context, id int64, body UpdateUserDefaultAgentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateUserDefaultAgentRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListUserMemories(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListUserMemoriesRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteUserMemory(ctx context.Context, id int64, agentId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteUserMemoryRequest(c.Server, id, agentId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SetUserMemoryWithBody(ctx context.Context, id int64, agentId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSetUserMemoryRequestWithBody(c.Server, id, agentId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SetUserMemory(ctx context.Context, id int64, agentId string, body SetUserMemoryJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSetUserMemoryRequest(c.Server, id, agentId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateUserNotifyIdentityWithBody(ctx context.Context, id int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateUserNotifyIdentityRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateUserNotifyIdentity(ctx context.Context, id int64, body UpdateUserNotifyIdentityJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateUserNotifyIdentityRequest(c.Server, id, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3006,6 +3318,283 @@ func NewGetProfileSkillFileRequest(server string, skillId string, params *GetPro
 	if err != nil {
 		return nil, err
 	}
+
+	return req, nil
+}
+
+// NewListAuthUsersRequest generates requests for ListAuthUsers
+func NewListAuthUsersRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/users")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetAuthUserRequest generates requests for GetAuthUser
+func NewGetAuthUserRequest(server string, id int64) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "integer", Format: "int64"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/users/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateAuthUserActiveRequest calls the generic UpdateAuthUserActive builder with application/json body
+func NewUpdateAuthUserActiveRequest(server string, id int64, body UpdateAuthUserActiveJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateAuthUserActiveRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewUpdateAuthUserActiveRequestWithBody generates requests for UpdateAuthUserActive with any type of body
+func NewUpdateAuthUserActiveRequestWithBody(server string, id int64, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "integer", Format: "int64"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/users/%s/active", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewListAuthUserAgentsRequest generates requests for ListAuthUserAgents
+func NewListAuthUserAgentsRequest(server string, id int64) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "integer", Format: "int64"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/users/%s/agents", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateAuthUserAgentsRequest calls the generic UpdateAuthUserAgents builder with application/json body
+func NewUpdateAuthUserAgentsRequest(server string, id int64, body UpdateAuthUserAgentsJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateAuthUserAgentsRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewUpdateAuthUserAgentsRequestWithBody generates requests for UpdateAuthUserAgents with any type of body
+func NewUpdateAuthUserAgentsRequestWithBody(server string, id int64, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "integer", Format: "int64"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/users/%s/agents", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteAuthUserIdentityRequest generates requests for DeleteAuthUserIdentity
+func NewDeleteAuthUserIdentityRequest(server string, id int64, identityId int64) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "integer", Format: "int64"})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "identityId", identityId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "integer", Format: "int64"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/users/%s/identities/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateAuthUserRoleRequest calls the generic UpdateAuthUserRole builder with application/json body
+func NewUpdateAuthUserRoleRequest(server string, id int64, body UpdateAuthUserRoleJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateAuthUserRoleRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewUpdateAuthUserRoleRequestWithBody generates requests for UpdateAuthUserRole with any type of body
+func NewUpdateAuthUserRoleRequestWithBody(server string, id int64, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "integer", Format: "int64"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/users/%s/role", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -5343,6 +5932,229 @@ func NewListToolsRequest(server string) (*http.Request, error) {
 	return req, nil
 }
 
+// NewUpdateUserDefaultAgentRequest calls the generic UpdateUserDefaultAgent builder with application/json body
+func NewUpdateUserDefaultAgentRequest(server string, id int64, body UpdateUserDefaultAgentJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateUserDefaultAgentRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewUpdateUserDefaultAgentRequestWithBody generates requests for UpdateUserDefaultAgent with any type of body
+func NewUpdateUserDefaultAgentRequestWithBody(server string, id int64, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "integer", Format: "int64"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/users/%s/default-agent", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewListUserMemoriesRequest generates requests for ListUserMemories
+func NewListUserMemoriesRequest(server string, id int64) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "integer", Format: "int64"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/users/%s/memories", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewDeleteUserMemoryRequest generates requests for DeleteUserMemory
+func NewDeleteUserMemoryRequest(server string, id int64, agentId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "integer", Format: "int64"})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "agentId", agentId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/users/%s/memories/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewSetUserMemoryRequest calls the generic SetUserMemory builder with application/json body
+func NewSetUserMemoryRequest(server string, id int64, agentId string, body SetUserMemoryJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewSetUserMemoryRequestWithBody(server, id, agentId, "application/json", bodyReader)
+}
+
+// NewSetUserMemoryRequestWithBody generates requests for SetUserMemory with any type of body
+func NewSetUserMemoryRequestWithBody(server string, id int64, agentId string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "integer", Format: "int64"})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "agentId", agentId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/users/%s/memories/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewUpdateUserNotifyIdentityRequest calls the generic UpdateUserNotifyIdentity builder with application/json body
+func NewUpdateUserNotifyIdentityRequest(server string, id int64, body UpdateUserNotifyIdentityJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateUserNotifyIdentityRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewUpdateUserNotifyIdentityRequestWithBody generates requests for UpdateUserNotifyIdentity with any type of body
+func NewUpdateUserNotifyIdentityRequestWithBody(server string, id int64, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "integer", Format: "int64"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/users/%s/notify-identity", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 func (c *Client) applyEditors(ctx context.Context, req *http.Request, additionalEditors []RequestEditorFn) error {
 	for _, r := range c.RequestEditors {
 		if err := r(ctx, req); err != nil {
@@ -5474,6 +6286,33 @@ type ClientWithResponsesInterface interface {
 
 	// GetProfileSkillFileWithResponse request
 	GetProfileSkillFileWithResponse(ctx context.Context, skillId string, params *GetProfileSkillFileParams, reqEditors ...RequestEditorFn) (*GetProfileSkillFileResponse, error)
+
+	// ListAuthUsersWithResponse request
+	ListAuthUsersWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListAuthUsersResponse, error)
+
+	// GetAuthUserWithResponse request
+	GetAuthUserWithResponse(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*GetAuthUserResponse, error)
+
+	// UpdateAuthUserActiveWithBodyWithResponse request with any body
+	UpdateAuthUserActiveWithBodyWithResponse(ctx context.Context, id int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateAuthUserActiveResponse, error)
+
+	UpdateAuthUserActiveWithResponse(ctx context.Context, id int64, body UpdateAuthUserActiveJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateAuthUserActiveResponse, error)
+
+	// ListAuthUserAgentsWithResponse request
+	ListAuthUserAgentsWithResponse(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*ListAuthUserAgentsResponse, error)
+
+	// UpdateAuthUserAgentsWithBodyWithResponse request with any body
+	UpdateAuthUserAgentsWithBodyWithResponse(ctx context.Context, id int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateAuthUserAgentsResponse, error)
+
+	UpdateAuthUserAgentsWithResponse(ctx context.Context, id int64, body UpdateAuthUserAgentsJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateAuthUserAgentsResponse, error)
+
+	// DeleteAuthUserIdentityWithResponse request
+	DeleteAuthUserIdentityWithResponse(ctx context.Context, id int64, identityId int64, reqEditors ...RequestEditorFn) (*DeleteAuthUserIdentityResponse, error)
+
+	// UpdateAuthUserRoleWithBodyWithResponse request with any body
+	UpdateAuthUserRoleWithBodyWithResponse(ctx context.Context, id int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateAuthUserRoleResponse, error)
+
+	UpdateAuthUserRoleWithResponse(ctx context.Context, id int64, body UpdateAuthUserRoleJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateAuthUserRoleResponse, error)
 
 	// ListBuiltinResourcesWithResponse request
 	ListBuiltinResourcesWithResponse(ctx context.Context, kind string, reqEditors ...RequestEditorFn) (*ListBuiltinResourcesResponse, error)
@@ -5673,6 +6512,27 @@ type ClientWithResponsesInterface interface {
 
 	// ListToolsWithResponse request
 	ListToolsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListToolsResponse, error)
+
+	// UpdateUserDefaultAgentWithBodyWithResponse request with any body
+	UpdateUserDefaultAgentWithBodyWithResponse(ctx context.Context, id int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateUserDefaultAgentResponse, error)
+
+	UpdateUserDefaultAgentWithResponse(ctx context.Context, id int64, body UpdateUserDefaultAgentJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateUserDefaultAgentResponse, error)
+
+	// ListUserMemoriesWithResponse request
+	ListUserMemoriesWithResponse(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*ListUserMemoriesResponse, error)
+
+	// DeleteUserMemoryWithResponse request
+	DeleteUserMemoryWithResponse(ctx context.Context, id int64, agentId string, reqEditors ...RequestEditorFn) (*DeleteUserMemoryResponse, error)
+
+	// SetUserMemoryWithBodyWithResponse request with any body
+	SetUserMemoryWithBodyWithResponse(ctx context.Context, id int64, agentId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetUserMemoryResponse, error)
+
+	SetUserMemoryWithResponse(ctx context.Context, id int64, agentId string, body SetUserMemoryJSONRequestBody, reqEditors ...RequestEditorFn) (*SetUserMemoryResponse, error)
+
+	// UpdateUserNotifyIdentityWithBodyWithResponse request with any body
+	UpdateUserNotifyIdentityWithBodyWithResponse(ctx context.Context, id int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateUserNotifyIdentityResponse, error)
+
+	UpdateUserNotifyIdentityWithResponse(ctx context.Context, id int64, body UpdateUserNotifyIdentityJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateUserNotifyIdentityResponse, error)
 }
 
 type ListAgentsResponse struct {
@@ -6490,6 +7350,236 @@ func (r GetProfileSkillFileResponse) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r GetProfileSkillFileResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListAuthUsersResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]externalRef0.AuthUser
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r ListAuthUsersResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListAuthUsersResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListAuthUsersResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetAuthUserResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.AuthUser
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r GetAuthUserResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetAuthUserResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetAuthUserResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type UpdateAuthUserActiveResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.DeleteResult
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateAuthUserActiveResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateAuthUserActiveResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r UpdateAuthUserActiveResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListAuthUserAgentsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]string
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r ListAuthUserAgentsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListAuthUserAgentsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListAuthUserAgentsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type UpdateAuthUserAgentsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.DeleteResult
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateAuthUserAgentsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateAuthUserAgentsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r UpdateAuthUserAgentsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type DeleteAuthUserIdentityResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.DeleteResult
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteAuthUserIdentityResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteAuthUserIdentityResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r DeleteAuthUserIdentityResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type UpdateAuthUserRoleResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.DeleteResult
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateAuthUserRoleResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateAuthUserRoleResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r UpdateAuthUserRoleResponse) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -8291,6 +9381,170 @@ func (r ListToolsResponse) ContentType() string {
 	return ""
 }
 
+type UpdateUserDefaultAgentResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.DeleteResult
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateUserDefaultAgentResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateUserDefaultAgentResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r UpdateUserDefaultAgentResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListUserMemoriesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]externalRef0.UserMemory
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r ListUserMemoriesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListUserMemoriesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListUserMemoriesResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type DeleteUserMemoryResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.DeleteResult
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteUserMemoryResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteUserMemoryResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r DeleteUserMemoryResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type SetUserMemoryResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.DeleteResult
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r SetUserMemoryResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SetUserMemoryResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r SetUserMemoryResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type UpdateUserNotifyIdentityResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.DeleteResult
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateUserNotifyIdentityResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateUserNotifyIdentityResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r UpdateUserNotifyIdentityResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 // ListAgentsWithResponse request returning *ListAgentsResponse
 func (c *ClientWithResponses) ListAgentsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListAgentsResponse, error) {
 	rsp, err := c.ListAgents(ctx, reqEditors...)
@@ -8570,6 +9824,93 @@ func (c *ClientWithResponses) GetProfileSkillFileWithResponse(ctx context.Contex
 		return nil, err
 	}
 	return ParseGetProfileSkillFileResponse(rsp)
+}
+
+// ListAuthUsersWithResponse request returning *ListAuthUsersResponse
+func (c *ClientWithResponses) ListAuthUsersWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListAuthUsersResponse, error) {
+	rsp, err := c.ListAuthUsers(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListAuthUsersResponse(rsp)
+}
+
+// GetAuthUserWithResponse request returning *GetAuthUserResponse
+func (c *ClientWithResponses) GetAuthUserWithResponse(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*GetAuthUserResponse, error) {
+	rsp, err := c.GetAuthUser(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetAuthUserResponse(rsp)
+}
+
+// UpdateAuthUserActiveWithBodyWithResponse request with arbitrary body returning *UpdateAuthUserActiveResponse
+func (c *ClientWithResponses) UpdateAuthUserActiveWithBodyWithResponse(ctx context.Context, id int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateAuthUserActiveResponse, error) {
+	rsp, err := c.UpdateAuthUserActiveWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateAuthUserActiveResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateAuthUserActiveWithResponse(ctx context.Context, id int64, body UpdateAuthUserActiveJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateAuthUserActiveResponse, error) {
+	rsp, err := c.UpdateAuthUserActive(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateAuthUserActiveResponse(rsp)
+}
+
+// ListAuthUserAgentsWithResponse request returning *ListAuthUserAgentsResponse
+func (c *ClientWithResponses) ListAuthUserAgentsWithResponse(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*ListAuthUserAgentsResponse, error) {
+	rsp, err := c.ListAuthUserAgents(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListAuthUserAgentsResponse(rsp)
+}
+
+// UpdateAuthUserAgentsWithBodyWithResponse request with arbitrary body returning *UpdateAuthUserAgentsResponse
+func (c *ClientWithResponses) UpdateAuthUserAgentsWithBodyWithResponse(ctx context.Context, id int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateAuthUserAgentsResponse, error) {
+	rsp, err := c.UpdateAuthUserAgentsWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateAuthUserAgentsResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateAuthUserAgentsWithResponse(ctx context.Context, id int64, body UpdateAuthUserAgentsJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateAuthUserAgentsResponse, error) {
+	rsp, err := c.UpdateAuthUserAgents(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateAuthUserAgentsResponse(rsp)
+}
+
+// DeleteAuthUserIdentityWithResponse request returning *DeleteAuthUserIdentityResponse
+func (c *ClientWithResponses) DeleteAuthUserIdentityWithResponse(ctx context.Context, id int64, identityId int64, reqEditors ...RequestEditorFn) (*DeleteAuthUserIdentityResponse, error) {
+	rsp, err := c.DeleteAuthUserIdentity(ctx, id, identityId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteAuthUserIdentityResponse(rsp)
+}
+
+// UpdateAuthUserRoleWithBodyWithResponse request with arbitrary body returning *UpdateAuthUserRoleResponse
+func (c *ClientWithResponses) UpdateAuthUserRoleWithBodyWithResponse(ctx context.Context, id int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateAuthUserRoleResponse, error) {
+	rsp, err := c.UpdateAuthUserRoleWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateAuthUserRoleResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateAuthUserRoleWithResponse(ctx context.Context, id int64, body UpdateAuthUserRoleJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateAuthUserRoleResponse, error) {
+	rsp, err := c.UpdateAuthUserRole(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateAuthUserRoleResponse(rsp)
 }
 
 // ListBuiltinResourcesWithResponse request returning *ListBuiltinResourcesResponse
@@ -9201,6 +10542,75 @@ func (c *ClientWithResponses) ListToolsWithResponse(ctx context.Context, reqEdit
 		return nil, err
 	}
 	return ParseListToolsResponse(rsp)
+}
+
+// UpdateUserDefaultAgentWithBodyWithResponse request with arbitrary body returning *UpdateUserDefaultAgentResponse
+func (c *ClientWithResponses) UpdateUserDefaultAgentWithBodyWithResponse(ctx context.Context, id int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateUserDefaultAgentResponse, error) {
+	rsp, err := c.UpdateUserDefaultAgentWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateUserDefaultAgentResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateUserDefaultAgentWithResponse(ctx context.Context, id int64, body UpdateUserDefaultAgentJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateUserDefaultAgentResponse, error) {
+	rsp, err := c.UpdateUserDefaultAgent(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateUserDefaultAgentResponse(rsp)
+}
+
+// ListUserMemoriesWithResponse request returning *ListUserMemoriesResponse
+func (c *ClientWithResponses) ListUserMemoriesWithResponse(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*ListUserMemoriesResponse, error) {
+	rsp, err := c.ListUserMemories(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListUserMemoriesResponse(rsp)
+}
+
+// DeleteUserMemoryWithResponse request returning *DeleteUserMemoryResponse
+func (c *ClientWithResponses) DeleteUserMemoryWithResponse(ctx context.Context, id int64, agentId string, reqEditors ...RequestEditorFn) (*DeleteUserMemoryResponse, error) {
+	rsp, err := c.DeleteUserMemory(ctx, id, agentId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteUserMemoryResponse(rsp)
+}
+
+// SetUserMemoryWithBodyWithResponse request with arbitrary body returning *SetUserMemoryResponse
+func (c *ClientWithResponses) SetUserMemoryWithBodyWithResponse(ctx context.Context, id int64, agentId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetUserMemoryResponse, error) {
+	rsp, err := c.SetUserMemoryWithBody(ctx, id, agentId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSetUserMemoryResponse(rsp)
+}
+
+func (c *ClientWithResponses) SetUserMemoryWithResponse(ctx context.Context, id int64, agentId string, body SetUserMemoryJSONRequestBody, reqEditors ...RequestEditorFn) (*SetUserMemoryResponse, error) {
+	rsp, err := c.SetUserMemory(ctx, id, agentId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSetUserMemoryResponse(rsp)
+}
+
+// UpdateUserNotifyIdentityWithBodyWithResponse request with arbitrary body returning *UpdateUserNotifyIdentityResponse
+func (c *ClientWithResponses) UpdateUserNotifyIdentityWithBodyWithResponse(ctx context.Context, id int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateUserNotifyIdentityResponse, error) {
+	rsp, err := c.UpdateUserNotifyIdentityWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateUserNotifyIdentityResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateUserNotifyIdentityWithResponse(ctx context.Context, id int64, body UpdateUserNotifyIdentityJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateUserNotifyIdentityResponse, error) {
+	rsp, err := c.UpdateUserNotifyIdentity(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateUserNotifyIdentityResponse(rsp)
 }
 
 // ParseListAgentsResponse parses an HTTP response from a ListAgentsWithResponse call
@@ -10308,6 +11718,328 @@ func ParseGetProfileSkillFileResponse(rsp *http.Response) (*GetProfileSkillFileR
 			return nil, err
 		}
 		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListAuthUsersResponse parses an HTTP response from a ListAuthUsersWithResponse call
+func ParseListAuthUsersResponse(rsp *http.Response) (*ListAuthUsersResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListAuthUsersResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []externalRef0.AuthUser
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetAuthUserResponse parses an HTTP response from a GetAuthUserWithResponse call
+func ParseGetAuthUserResponse(rsp *http.Response) (*GetAuthUserResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetAuthUserResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.AuthUser
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateAuthUserActiveResponse parses an HTTP response from a UpdateAuthUserActiveWithResponse call
+func ParseUpdateAuthUserActiveResponse(rsp *http.Response) (*UpdateAuthUserActiveResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateAuthUserActiveResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.DeleteResult
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListAuthUserAgentsResponse parses an HTTP response from a ListAuthUserAgentsWithResponse call
+func ParseListAuthUserAgentsResponse(rsp *http.Response) (*ListAuthUserAgentsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListAuthUserAgentsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []string
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateAuthUserAgentsResponse parses an HTTP response from a UpdateAuthUserAgentsWithResponse call
+func ParseUpdateAuthUserAgentsResponse(rsp *http.Response) (*UpdateAuthUserAgentsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateAuthUserAgentsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.DeleteResult
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteAuthUserIdentityResponse parses an HTTP response from a DeleteAuthUserIdentityWithResponse call
+func ParseDeleteAuthUserIdentityResponse(rsp *http.Response) (*DeleteAuthUserIdentityResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteAuthUserIdentityResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.DeleteResult
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateAuthUserRoleResponse parses an HTTP response from a UpdateAuthUserRoleWithResponse call
+func ParseUpdateAuthUserRoleResponse(rsp *http.Response) (*UpdateAuthUserRoleResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateAuthUserRoleResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.DeleteResult
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
 
 	}
 
@@ -12705,6 +14437,234 @@ func ParseListToolsResponse(rsp *http.Response) (*ListToolsResponse, error) {
 			return nil, err
 		}
 		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateUserDefaultAgentResponse parses an HTTP response from a UpdateUserDefaultAgentWithResponse call
+func ParseUpdateUserDefaultAgentResponse(rsp *http.Response) (*UpdateUserDefaultAgentResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateUserDefaultAgentResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.DeleteResult
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListUserMemoriesResponse parses an HTTP response from a ListUserMemoriesWithResponse call
+func ParseListUserMemoriesResponse(rsp *http.Response) (*ListUserMemoriesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListUserMemoriesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []externalRef0.UserMemory
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteUserMemoryResponse parses an HTTP response from a DeleteUserMemoryWithResponse call
+func ParseDeleteUserMemoryResponse(rsp *http.Response) (*DeleteUserMemoryResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteUserMemoryResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.DeleteResult
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseSetUserMemoryResponse parses an HTTP response from a SetUserMemoryWithResponse call
+func ParseSetUserMemoryResponse(rsp *http.Response) (*SetUserMemoryResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SetUserMemoryResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.DeleteResult
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateUserNotifyIdentityResponse parses an HTTP response from a UpdateUserNotifyIdentityWithResponse call
+func ParseUpdateUserNotifyIdentityResponse(rsp *http.Response) (*UpdateUserNotifyIdentityResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateUserNotifyIdentityResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.DeleteResult
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
 
 	}
 

--- a/api/client/gen.go
+++ b/api/client/gen.go
@@ -151,6 +151,9 @@ type LinkCodeResponse = externalRef0.LinkCodeResponse
 // LoginRequest defines model for LoginRequest.
 type LoginRequest = externalRef0.LoginRequest
 
+// ManifestPlugin defines model for ManifestPlugin.
+type ManifestPlugin = externalRef0.ManifestPlugin
+
 // MeResponse defines model for MeResponse.
 type MeResponse = externalRef0.MeResponse
 
@@ -162,6 +165,9 @@ type OAuthFlowStatus = externalRef0.OAuthFlowStatus
 
 // OAuthProviderStatus defines model for OAuthProviderStatus.
 type OAuthProviderStatus = externalRef0.OAuthProviderStatus
+
+// PluginView defines model for PluginView.
+type PluginView = externalRef0.PluginView
 
 // ProfileInstallSkillRequest defines model for ProfileInstallSkillRequest.
 type ProfileInstallSkillRequest = externalRef0.ProfileInstallSkillRequest
@@ -244,6 +250,9 @@ type SystemPromptResponse = externalRef0.SystemPromptResponse
 // TagCount defines model for TagCount.
 type TagCount = externalRef0.TagCount
 
+// TogglePluginRequest defines model for TogglePluginRequest.
+type TogglePluginRequest = externalRef0.TogglePluginRequest
+
 // Tool defines model for Tool.
 type Tool = externalRef0.Tool
 
@@ -267,6 +276,9 @@ type UpdateFeedRequest = externalRef0.UpdateFeedRequest
 
 // UpdateNotifyIdentityRequest defines model for UpdateNotifyIdentityRequest.
 type UpdateNotifyIdentityRequest = externalRef0.UpdateNotifyIdentityRequest
+
+// UpdatePluginConfigRequest defines model for UpdatePluginConfigRequest.
+type UpdatePluginConfigRequest = externalRef0.UpdatePluginConfigRequest
 
 // UpdateRoleRequest defines model for UpdateRoleRequest.
 type UpdateRoleRequest = externalRef0.UpdateRoleRequest
@@ -319,6 +331,11 @@ type GetProfileSkillFileParams struct {
 type PollWeixinQRStatusParams struct {
 	// Qrcode QR code token from startWeixinQR
 	Qrcode string `form:"qrcode" json:"qrcode"`
+}
+
+// SaveManifestPluginsJSONBody defines parameters for SaveManifestPlugins.
+type SaveManifestPluginsJSONBody struct {
+	Plugins *[]externalRef0.ManifestPlugin `json:"plugins,omitempty"`
 }
 
 // ListArticlesParams defines parameters for ListArticles.
@@ -454,6 +471,15 @@ type CreateChannelJSONRequestBody = externalRef0.ChannelWriteRequest
 
 // UpdateChannelJSONRequestBody defines body for UpdateChannel for application/json ContentType.
 type UpdateChannelJSONRequestBody = externalRef0.ChannelWriteRequest
+
+// SaveManifestPluginsJSONRequestBody defines body for SaveManifestPlugins for application/json ContentType.
+type SaveManifestPluginsJSONRequestBody SaveManifestPluginsJSONBody
+
+// UpdatePluginConfigJSONRequestBody defines body for UpdatePluginConfig for application/json ContentType.
+type UpdatePluginConfigJSONRequestBody = externalRef0.UpdatePluginConfigRequest
+
+// TogglePluginJSONRequestBody defines body for TogglePlugin for application/json ContentType.
+type TogglePluginJSONRequestBody = externalRef0.TogglePluginRequest
 
 // CreateProviderJSONRequestBody defines body for CreateProvider for application/json ContentType.
 type CreateProviderJSONRequestBody = externalRef0.Provider
@@ -809,8 +835,41 @@ type ClientInterface interface {
 
 	UpdateChannel(ctx context.Context, id string, body UpdateChannelJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ListManifestPlugins request
+	ListManifestPlugins(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SaveManifestPluginsWithBody request with any body
+	SaveManifestPluginsWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	SaveManifestPlugins(ctx context.Context, body SaveManifestPluginsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SyncManifestPlugins request
+	SyncManifestPlugins(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ListModels request
 	ListModels(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetPluginConfigSchema request
+	GetPluginConfigSchema(ctx context.Context, kind string, name string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetPluginConfig request
+	GetPluginConfig(ctx context.Context, kind string, name string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdatePluginConfigWithBody request with any body
+	UpdatePluginConfigWithBody(ctx context.Context, kind string, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdatePluginConfig(ctx context.Context, kind string, name string, body UpdatePluginConfigJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetPluginStatus request
+	GetPluginStatus(ctx context.Context, kind string, name string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListPlugins request
+	ListPlugins(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// TogglePluginWithBody request with any body
+	TogglePluginWithBody(ctx context.Context, kind string, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	TogglePlugin(ctx context.Context, kind string, name string, body TogglePluginJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListProviderTypes request
 	ListProviderTypes(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1980,8 +2039,152 @@ func (c *Client) UpdateChannel(ctx context.Context, id string, body UpdateChanne
 	return c.Client.Do(req)
 }
 
+func (c *Client) ListManifestPlugins(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListManifestPluginsRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SaveManifestPluginsWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSaveManifestPluginsRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SaveManifestPlugins(ctx context.Context, body SaveManifestPluginsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSaveManifestPluginsRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SyncManifestPlugins(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSyncManifestPluginsRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) ListModels(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewListModelsRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetPluginConfigSchema(ctx context.Context, kind string, name string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetPluginConfigSchemaRequest(c.Server, kind, name)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetPluginConfig(ctx context.Context, kind string, name string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetPluginConfigRequest(c.Server, kind, name)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdatePluginConfigWithBody(ctx context.Context, kind string, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdatePluginConfigRequestWithBody(c.Server, kind, name, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdatePluginConfig(ctx context.Context, kind string, name string, body UpdatePluginConfigJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdatePluginConfigRequest(c.Server, kind, name, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetPluginStatus(ctx context.Context, kind string, name string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetPluginStatusRequest(c.Server, kind, name)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListPlugins(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListPluginsRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) TogglePluginWithBody(ctx context.Context, kind string, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewTogglePluginRequestWithBody(c.Server, kind, name, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) TogglePlugin(ctx context.Context, kind string, name string, body TogglePluginJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewTogglePluginRequest(c.Server, kind, name, body)
 	if err != nil {
 		return nil, err
 	}
@@ -5212,6 +5415,100 @@ func NewUpdateChannelRequestWithBody(server string, id string, contentType strin
 	return req, nil
 }
 
+// NewListManifestPluginsRequest generates requests for ListManifestPlugins
+func NewListManifestPluginsRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/manifest-plugins")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewSaveManifestPluginsRequest calls the generic SaveManifestPlugins builder with application/json body
+func NewSaveManifestPluginsRequest(server string, body SaveManifestPluginsJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewSaveManifestPluginsRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewSaveManifestPluginsRequestWithBody generates requests for SaveManifestPlugins with any type of body
+func NewSaveManifestPluginsRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/manifest-plugins")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewSyncManifestPluginsRequest generates requests for SyncManifestPlugins
+func NewSyncManifestPluginsRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/manifest-plugins/sync")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewListModelsRequest generates requests for ListModels
 func NewListModelsRequest(server string) (*http.Request, error) {
 	var err error
@@ -5235,6 +5532,264 @@ func NewListModelsRequest(server string) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	return req, nil
+}
+
+// NewGetPluginConfigSchemaRequest generates requests for GetPluginConfigSchema
+func NewGetPluginConfigSchemaRequest(server string, kind string, name string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "kind", kind, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/plugin-config-schema/%s/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetPluginConfigRequest generates requests for GetPluginConfig
+func NewGetPluginConfigRequest(server string, kind string, name string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "kind", kind, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/plugin-config/%s/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdatePluginConfigRequest calls the generic UpdatePluginConfig builder with application/json body
+func NewUpdatePluginConfigRequest(server string, kind string, name string, body UpdatePluginConfigJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdatePluginConfigRequestWithBody(server, kind, name, "application/json", bodyReader)
+}
+
+// NewUpdatePluginConfigRequestWithBody generates requests for UpdatePluginConfig with any type of body
+func NewUpdatePluginConfigRequestWithBody(server string, kind string, name string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "kind", kind, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/plugin-config/%s/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewGetPluginStatusRequest generates requests for GetPluginStatus
+func NewGetPluginStatusRequest(server string, kind string, name string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "kind", kind, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/plugin-status/%s/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewListPluginsRequest generates requests for ListPlugins
+func NewListPluginsRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/plugins")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewTogglePluginRequest calls the generic TogglePlugin builder with application/json body
+func NewTogglePluginRequest(server string, kind string, name string, body TogglePluginJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewTogglePluginRequestWithBody(server, kind, name, "application/json", bodyReader)
+}
+
+// NewTogglePluginRequestWithBody generates requests for TogglePlugin with any type of body
+func NewTogglePluginRequestWithBody(server string, kind string, name string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "kind", kind, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/plugins/%s/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPatch, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -7677,8 +8232,41 @@ type ClientWithResponsesInterface interface {
 
 	UpdateChannelWithResponse(ctx context.Context, id string, body UpdateChannelJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateChannelResponse, error)
 
+	// ListManifestPluginsWithResponse request
+	ListManifestPluginsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListManifestPluginsResponse, error)
+
+	// SaveManifestPluginsWithBodyWithResponse request with any body
+	SaveManifestPluginsWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SaveManifestPluginsResponse, error)
+
+	SaveManifestPluginsWithResponse(ctx context.Context, body SaveManifestPluginsJSONRequestBody, reqEditors ...RequestEditorFn) (*SaveManifestPluginsResponse, error)
+
+	// SyncManifestPluginsWithResponse request
+	SyncManifestPluginsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*SyncManifestPluginsResponse, error)
+
 	// ListModelsWithResponse request
 	ListModelsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListModelsResponse, error)
+
+	// GetPluginConfigSchemaWithResponse request
+	GetPluginConfigSchemaWithResponse(ctx context.Context, kind string, name string, reqEditors ...RequestEditorFn) (*GetPluginConfigSchemaResponse, error)
+
+	// GetPluginConfigWithResponse request
+	GetPluginConfigWithResponse(ctx context.Context, kind string, name string, reqEditors ...RequestEditorFn) (*GetPluginConfigResponse, error)
+
+	// UpdatePluginConfigWithBodyWithResponse request with any body
+	UpdatePluginConfigWithBodyWithResponse(ctx context.Context, kind string, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdatePluginConfigResponse, error)
+
+	UpdatePluginConfigWithResponse(ctx context.Context, kind string, name string, body UpdatePluginConfigJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdatePluginConfigResponse, error)
+
+	// GetPluginStatusWithResponse request
+	GetPluginStatusWithResponse(ctx context.Context, kind string, name string, reqEditors ...RequestEditorFn) (*GetPluginStatusResponse, error)
+
+	// ListPluginsWithResponse request
+	ListPluginsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListPluginsResponse, error)
+
+	// TogglePluginWithBodyWithResponse request with any body
+	TogglePluginWithBodyWithResponse(ctx context.Context, kind string, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*TogglePluginResponse, error)
+
+	TogglePluginWithResponse(ctx context.Context, kind string, name string, body TogglePluginJSONRequestBody, reqEditors ...RequestEditorFn) (*TogglePluginResponse, error)
 
 	// ListProviderTypesWithResponse request
 	ListProviderTypesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListProviderTypesResponse, error)
@@ -9902,6 +10490,103 @@ func (r UpdateChannelResponse) ContentType() string {
 	return ""
 }
 
+type ListManifestPluginsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]externalRef0.ManifestPlugin
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r ListManifestPluginsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListManifestPluginsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListManifestPluginsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type SaveManifestPluginsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]externalRef0.ManifestPlugin
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r SaveManifestPluginsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SaveManifestPluginsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r SaveManifestPluginsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type SyncManifestPluginsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *map[string]interface{}
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r SyncManifestPluginsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SyncManifestPluginsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r SyncManifestPluginsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 type ListModelsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -9927,6 +10612,201 @@ func (r ListModelsResponse) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r ListModelsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetPluginConfigSchemaResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *map[string]interface{}
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r GetPluginConfigSchemaResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetPluginConfigSchemaResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetPluginConfigSchemaResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetPluginConfigResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *map[string]interface{}
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r GetPluginConfigResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetPluginConfigResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetPluginConfigResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type UpdatePluginConfigResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *map[string]interface{}
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdatePluginConfigResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdatePluginConfigResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r UpdatePluginConfigResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetPluginStatusResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *map[string]interface{}
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r GetPluginStatusResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetPluginStatusResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetPluginStatusResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListPluginsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]externalRef0.PluginView
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r ListPluginsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListPluginsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListPluginsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type TogglePluginResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *map[string]interface{}
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r TogglePluginResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r TogglePluginResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r TogglePluginResponse) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -12255,6 +13135,41 @@ func (c *ClientWithResponses) UpdateChannelWithResponse(ctx context.Context, id 
 	return ParseUpdateChannelResponse(rsp)
 }
 
+// ListManifestPluginsWithResponse request returning *ListManifestPluginsResponse
+func (c *ClientWithResponses) ListManifestPluginsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListManifestPluginsResponse, error) {
+	rsp, err := c.ListManifestPlugins(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListManifestPluginsResponse(rsp)
+}
+
+// SaveManifestPluginsWithBodyWithResponse request with arbitrary body returning *SaveManifestPluginsResponse
+func (c *ClientWithResponses) SaveManifestPluginsWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SaveManifestPluginsResponse, error) {
+	rsp, err := c.SaveManifestPluginsWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSaveManifestPluginsResponse(rsp)
+}
+
+func (c *ClientWithResponses) SaveManifestPluginsWithResponse(ctx context.Context, body SaveManifestPluginsJSONRequestBody, reqEditors ...RequestEditorFn) (*SaveManifestPluginsResponse, error) {
+	rsp, err := c.SaveManifestPlugins(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSaveManifestPluginsResponse(rsp)
+}
+
+// SyncManifestPluginsWithResponse request returning *SyncManifestPluginsResponse
+func (c *ClientWithResponses) SyncManifestPluginsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*SyncManifestPluginsResponse, error) {
+	rsp, err := c.SyncManifestPlugins(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSyncManifestPluginsResponse(rsp)
+}
+
 // ListModelsWithResponse request returning *ListModelsResponse
 func (c *ClientWithResponses) ListModelsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListModelsResponse, error) {
 	rsp, err := c.ListModels(ctx, reqEditors...)
@@ -12262,6 +13177,76 @@ func (c *ClientWithResponses) ListModelsWithResponse(ctx context.Context, reqEdi
 		return nil, err
 	}
 	return ParseListModelsResponse(rsp)
+}
+
+// GetPluginConfigSchemaWithResponse request returning *GetPluginConfigSchemaResponse
+func (c *ClientWithResponses) GetPluginConfigSchemaWithResponse(ctx context.Context, kind string, name string, reqEditors ...RequestEditorFn) (*GetPluginConfigSchemaResponse, error) {
+	rsp, err := c.GetPluginConfigSchema(ctx, kind, name, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetPluginConfigSchemaResponse(rsp)
+}
+
+// GetPluginConfigWithResponse request returning *GetPluginConfigResponse
+func (c *ClientWithResponses) GetPluginConfigWithResponse(ctx context.Context, kind string, name string, reqEditors ...RequestEditorFn) (*GetPluginConfigResponse, error) {
+	rsp, err := c.GetPluginConfig(ctx, kind, name, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetPluginConfigResponse(rsp)
+}
+
+// UpdatePluginConfigWithBodyWithResponse request with arbitrary body returning *UpdatePluginConfigResponse
+func (c *ClientWithResponses) UpdatePluginConfigWithBodyWithResponse(ctx context.Context, kind string, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdatePluginConfigResponse, error) {
+	rsp, err := c.UpdatePluginConfigWithBody(ctx, kind, name, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdatePluginConfigResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdatePluginConfigWithResponse(ctx context.Context, kind string, name string, body UpdatePluginConfigJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdatePluginConfigResponse, error) {
+	rsp, err := c.UpdatePluginConfig(ctx, kind, name, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdatePluginConfigResponse(rsp)
+}
+
+// GetPluginStatusWithResponse request returning *GetPluginStatusResponse
+func (c *ClientWithResponses) GetPluginStatusWithResponse(ctx context.Context, kind string, name string, reqEditors ...RequestEditorFn) (*GetPluginStatusResponse, error) {
+	rsp, err := c.GetPluginStatus(ctx, kind, name, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetPluginStatusResponse(rsp)
+}
+
+// ListPluginsWithResponse request returning *ListPluginsResponse
+func (c *ClientWithResponses) ListPluginsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListPluginsResponse, error) {
+	rsp, err := c.ListPlugins(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListPluginsResponse(rsp)
+}
+
+// TogglePluginWithBodyWithResponse request with arbitrary body returning *TogglePluginResponse
+func (c *ClientWithResponses) TogglePluginWithBodyWithResponse(ctx context.Context, kind string, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*TogglePluginResponse, error) {
+	rsp, err := c.TogglePluginWithBody(ctx, kind, name, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseTogglePluginResponse(rsp)
+}
+
+func (c *ClientWithResponses) TogglePluginWithResponse(ctx context.Context, kind string, name string, body TogglePluginJSONRequestBody, reqEditors ...RequestEditorFn) (*TogglePluginResponse, error) {
+	rsp, err := c.TogglePlugin(ctx, kind, name, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseTogglePluginResponse(rsp)
 }
 
 // ListProviderTypesWithResponse request returning *ListProviderTypesResponse
@@ -15472,6 +16457,133 @@ func ParseUpdateChannelResponse(rsp *http.Response) (*UpdateChannelResponse, err
 	return response, nil
 }
 
+// ParseListManifestPluginsResponse parses an HTTP response from a ListManifestPluginsWithResponse call
+func ParseListManifestPluginsResponse(rsp *http.Response) (*ListManifestPluginsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListManifestPluginsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []externalRef0.ManifestPlugin
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseSaveManifestPluginsResponse parses an HTTP response from a SaveManifestPluginsWithResponse call
+func ParseSaveManifestPluginsResponse(rsp *http.Response) (*SaveManifestPluginsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SaveManifestPluginsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []externalRef0.ManifestPlugin
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseSyncManifestPluginsResponse parses an HTTP response from a SyncManifestPluginsWithResponse call
+func ParseSyncManifestPluginsResponse(rsp *http.Response) (*SyncManifestPluginsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SyncManifestPluginsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseListModelsResponse parses an HTTP response from a ListModelsWithResponse call
 func ParseListModelsResponse(rsp *http.Response) (*ListModelsResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -15499,6 +16611,267 @@ func ParseListModelsResponse(rsp *http.Response) (*ListModelsResponse, error) {
 			return nil, err
 		}
 		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetPluginConfigSchemaResponse parses an HTTP response from a GetPluginConfigSchemaWithResponse call
+func ParseGetPluginConfigSchemaResponse(rsp *http.Response) (*GetPluginConfigSchemaResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetPluginConfigSchemaResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetPluginConfigResponse parses an HTTP response from a GetPluginConfigWithResponse call
+func ParseGetPluginConfigResponse(rsp *http.Response) (*GetPluginConfigResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetPluginConfigResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdatePluginConfigResponse parses an HTTP response from a UpdatePluginConfigWithResponse call
+func ParseUpdatePluginConfigResponse(rsp *http.Response) (*UpdatePluginConfigResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdatePluginConfigResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetPluginStatusResponse parses an HTTP response from a GetPluginStatusWithResponse call
+func ParseGetPluginStatusResponse(rsp *http.Response) (*GetPluginStatusResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetPluginStatusResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListPluginsResponse parses an HTTP response from a ListPluginsWithResponse call
+func ParseListPluginsResponse(rsp *http.Response) (*ListPluginsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListPluginsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []externalRef0.PluginView
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseTogglePluginResponse parses an HTTP response from a TogglePluginWithResponse call
+func ParseTogglePluginResponse(rsp *http.Response) (*TogglePluginResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &TogglePluginResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
 
 	}
 

--- a/api/client/gen.go
+++ b/api/client/gen.go
@@ -14,12 +14,25 @@ import (
 	"strings"
 
 	"github.com/oapi-codegen/runtime"
+	openapi_types "github.com/oapi-codegen/runtime/types"
 	externalRef0 "github.com/vaayne/anna/api/types"
 )
 
 const (
 	BearerAuthScopes bearerAuthContextKey = "BearerAuth.Scopes"
 )
+
+// Agent defines model for Agent.
+type Agent = externalRef0.Agent
+
+// AgentList defines model for AgentList.
+type AgentList = externalRef0.AgentList
+
+// AgentUser defines model for AgentUser.
+type AgentUser = externalRef0.AgentUser
+
+// AgentUserList defines model for AgentUserList.
+type AgentUserList = externalRef0.AgentUserList
 
 // Article defines model for Article.
 type Article = externalRef0.Article
@@ -29,6 +42,9 @@ type ArticleList = externalRef0.ArticleList
 
 // ArticleStatus defines model for ArticleStatus.
 type ArticleStatus = externalRef0.ArticleStatus
+
+// AssignAgentUserRequest defines model for AssignAgentUserRequest.
+type AssignAgentUserRequest = externalRef0.AssignAgentUserRequest
 
 // BuiltinResource defines model for BuiltinResource.
 type BuiltinResource = externalRef0.BuiltinResource
@@ -48,6 +64,9 @@ type ChannelList = externalRef0.ChannelList
 // ChannelWriteRequest defines model for ChannelWriteRequest.
 type ChannelWriteRequest = externalRef0.ChannelWriteRequest
 
+// CreateAgentRequest defines model for CreateAgentRequest.
+type CreateAgentRequest = externalRef0.CreateAgentRequest
+
 // CreateFeedRequest defines model for CreateFeedRequest.
 type CreateFeedRequest = externalRef0.CreateFeedRequest
 
@@ -59,6 +78,9 @@ type DeleteResult = externalRef0.DeleteResult
 
 // Digest defines model for Digest.
 type Digest = externalRef0.Digest
+
+// DuplicateSkillResult defines model for DuplicateSkillResult.
+type DuplicateSkillResult = externalRef0.DuplicateSkillResult
 
 // Error defines model for Error.
 type Error = externalRef0.Error
@@ -83,6 +105,9 @@ type FeedPollResult = externalRef0.FeedPollResult
 
 // FetchModelsRequest defines model for FetchModelsRequest.
 type FetchModelsRequest = externalRef0.FetchModelsRequest
+
+// InstallSkillRequest defines model for InstallSkillRequest.
+type InstallSkillRequest = externalRef0.InstallSkillRequest
 
 // Job defines model for Job.
 type Job = externalRef0.Job
@@ -114,6 +139,12 @@ type PublicChannel = externalRef0.PublicChannel
 // PublicChannelList defines model for PublicChannelList.
 type PublicChannelList = externalRef0.PublicChannelList
 
+// SandboxConfig defines model for SandboxConfig.
+type SandboxConfig = externalRef0.SandboxConfig
+
+// SandboxNetworkConfig defines model for SandboxNetworkConfig.
+type SandboxNetworkConfig = externalRef0.SandboxNetworkConfig
+
 // SaveArticleRequest defines model for SaveArticleRequest.
 type SaveArticleRequest = externalRef0.SaveArticleRequest
 
@@ -125,6 +156,15 @@ type Session = externalRef0.Session
 
 // SessionDetail defines model for SessionDetail.
 type SessionDetail = externalRef0.SessionDetail
+
+// Skill defines model for Skill.
+type Skill = externalRef0.Skill
+
+// SkillList defines model for SkillList.
+type SkillList = externalRef0.SkillList
+
+// SkillUploadResult defines model for SkillUploadResult.
+type SkillUploadResult = externalRef0.SkillUploadResult
 
 // SourceType defines model for SourceType.
 type SourceType = externalRef0.SourceType
@@ -147,6 +187,9 @@ type UpdateFeedEntryRequest = externalRef0.UpdateFeedEntryRequest
 // UpdateFeedRequest defines model for UpdateFeedRequest.
 type UpdateFeedRequest = externalRef0.UpdateFeedRequest
 
+// UpdateSkillRequest defines model for UpdateSkillRequest.
+type UpdateSkillRequest = externalRef0.UpdateSkillRequest
+
 // WeixinQRCode defines model for WeixinQRCode.
 type WeixinQRCode = externalRef0.WeixinQRCode
 
@@ -155,6 +198,11 @@ type WeixinQRStatus = externalRef0.WeixinQRStatus
 
 // bearerAuthContextKey is the context key for BearerAuth security scheme
 type bearerAuthContextKey string
+
+// UploadAgentSkillMultipartBody defines parameters for UploadAgentSkill.
+type UploadAgentSkillMultipartBody struct {
+	File *openapi_types.File `json:"file,omitempty"`
+}
 
 // PollWeixinQRStatusParams defines parameters for PollWeixinQRStatus.
 type PollWeixinQRStatusParams struct {
@@ -216,6 +264,24 @@ type GetSessionMessagesParams struct {
 	// Skip Number of messages to skip from the end
 	Skip *int `form:"skip,omitempty" json:"skip,omitempty"`
 }
+
+// CreateAgentJSONRequestBody defines body for CreateAgent for application/json ContentType.
+type CreateAgentJSONRequestBody = externalRef0.CreateAgentRequest
+
+// UpdateAgentJSONRequestBody defines body for UpdateAgent for application/json ContentType.
+type UpdateAgentJSONRequestBody = externalRef0.Agent
+
+// InstallAgentSkillJSONRequestBody defines body for InstallAgentSkill for application/json ContentType.
+type InstallAgentSkillJSONRequestBody = externalRef0.InstallSkillRequest
+
+// UploadAgentSkillMultipartRequestBody defines body for UploadAgentSkill for multipart/form-data ContentType.
+type UploadAgentSkillMultipartRequestBody UploadAgentSkillMultipartBody
+
+// UpdateAgentSkillJSONRequestBody defines body for UpdateAgentSkill for application/json ContentType.
+type UpdateAgentSkillJSONRequestBody = externalRef0.UpdateSkillRequest
+
+// AssignAgentUserJSONRequestBody defines body for AssignAgentUser for application/json ContentType.
+type AssignAgentUserJSONRequestBody = externalRef0.AssignAgentUserRequest
 
 // CreateChannelJSONRequestBody defines body for CreateChannel for application/json ContentType.
 type CreateChannelJSONRequestBody = externalRef0.ChannelWriteRequest
@@ -332,6 +398,67 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 
 // The interface specification for the client above.
 type ClientInterface interface {
+	// ListAgents request
+	ListAgents(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateAgentWithBody request with any body
+	CreateAgentWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateAgent(ctx context.Context, body CreateAgentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteAgent request
+	DeleteAgent(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetAgent request
+	GetAgent(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateAgentWithBody request with any body
+	UpdateAgentWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateAgent(ctx context.Context, id string, body UpdateAgentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListAgentSkills request
+	ListAgentSkills(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DuplicateBuiltinSkillToAgent request
+	DuplicateBuiltinSkillToAgent(ctx context.Context, id string, skillId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// InstallAgentSkillWithBody request with any body
+	InstallAgentSkillWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	InstallAgentSkill(ctx context.Context, id string, body InstallAgentSkillJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UploadAgentSkillWithBody request with any body
+	UploadAgentSkillWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteAgentSkill request
+	DeleteAgentSkill(ctx context.Context, id string, skillId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetAgentSkill request
+	GetAgentSkill(ctx context.Context, id string, skillId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateAgentSkillWithBody request with any body
+	UpdateAgentSkillWithBody(ctx context.Context, id string, skillId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateAgentSkill(ctx context.Context, id string, skillId string, body UpdateAgentSkillJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteAgentSkillFile request
+	DeleteAgentSkillFile(ctx context.Context, id string, skillId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetAgentSkillFile request
+	GetAgentSkillFile(ctx context.Context, id string, skillId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListAgentUsers request
+	ListAgentUsers(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// AssignAgentUserWithBody request with any body
+	AssignAgentUserWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	AssignAgentUser(ctx context.Context, id string, body AssignAgentUserJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// RemoveAgentUser request
+	RemoveAgentUser(ctx context.Context, id string, userId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ListBuiltinResources request
 	ListBuiltinResources(ctx context.Context, kind string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -497,6 +624,270 @@ type ClientInterface interface {
 
 	// ListTools request
 	ListTools(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+}
+
+func (c *Client) ListAgents(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListAgentsRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateAgentWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateAgentRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateAgent(ctx context.Context, body CreateAgentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateAgentRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteAgent(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteAgentRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetAgent(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetAgentRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateAgentWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateAgentRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateAgent(ctx context.Context, id string, body UpdateAgentJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateAgentRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListAgentSkills(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListAgentSkillsRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DuplicateBuiltinSkillToAgent(ctx context.Context, id string, skillId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDuplicateBuiltinSkillToAgentRequest(c.Server, id, skillId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) InstallAgentSkillWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewInstallAgentSkillRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) InstallAgentSkill(ctx context.Context, id string, body InstallAgentSkillJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewInstallAgentSkillRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UploadAgentSkillWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUploadAgentSkillRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteAgentSkill(ctx context.Context, id string, skillId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteAgentSkillRequest(c.Server, id, skillId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetAgentSkill(ctx context.Context, id string, skillId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetAgentSkillRequest(c.Server, id, skillId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateAgentSkillWithBody(ctx context.Context, id string, skillId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateAgentSkillRequestWithBody(c.Server, id, skillId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateAgentSkill(ctx context.Context, id string, skillId string, body UpdateAgentSkillJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateAgentSkillRequest(c.Server, id, skillId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteAgentSkillFile(ctx context.Context, id string, skillId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteAgentSkillFileRequest(c.Server, id, skillId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetAgentSkillFile(ctx context.Context, id string, skillId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetAgentSkillFileRequest(c.Server, id, skillId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListAgentUsers(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListAgentUsersRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AssignAgentUserWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAssignAgentUserRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AssignAgentUser(ctx context.Context, id string, body AssignAgentUserJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAssignAgentUserRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RemoveAgentUser(ctx context.Context, id string, userId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRemoveAgentUserRequest(c.Server, id, userId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
 }
 
 func (c *Client) ListBuiltinResources(ctx context.Context, kind string, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -1217,6 +1608,686 @@ func (c *Client) ListTools(ctx context.Context, reqEditors ...RequestEditorFn) (
 		return nil, err
 	}
 	return c.Client.Do(req)
+}
+
+// NewListAgentsRequest generates requests for ListAgents
+func NewListAgentsRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/agents")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateAgentRequest calls the generic CreateAgent builder with application/json body
+func NewCreateAgentRequest(server string, body CreateAgentJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateAgentRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewCreateAgentRequestWithBody generates requests for CreateAgent with any type of body
+func NewCreateAgentRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/agents")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteAgentRequest generates requests for DeleteAgent
+func NewDeleteAgentRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/agents/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetAgentRequest generates requests for GetAgent
+func NewGetAgentRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/agents/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateAgentRequest calls the generic UpdateAgent builder with application/json body
+func NewUpdateAgentRequest(server string, id string, body UpdateAgentJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateAgentRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewUpdateAgentRequestWithBody generates requests for UpdateAgent with any type of body
+func NewUpdateAgentRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/agents/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewListAgentSkillsRequest generates requests for ListAgentSkills
+func NewListAgentSkillsRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/agents/%s/skills", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewDuplicateBuiltinSkillToAgentRequest generates requests for DuplicateBuiltinSkillToAgent
+func NewDuplicateBuiltinSkillToAgentRequest(server string, id string, skillId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "skillId", skillId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/agents/%s/skills/from-builtin/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewInstallAgentSkillRequest calls the generic InstallAgentSkill builder with application/json body
+func NewInstallAgentSkillRequest(server string, id string, body InstallAgentSkillJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewInstallAgentSkillRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewInstallAgentSkillRequestWithBody generates requests for InstallAgentSkill with any type of body
+func NewInstallAgentSkillRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/agents/%s/skills/install", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewUploadAgentSkillRequestWithBody generates requests for UploadAgentSkill with any type of body
+func NewUploadAgentSkillRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/agents/%s/skills/upload", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteAgentSkillRequest generates requests for DeleteAgentSkill
+func NewDeleteAgentSkillRequest(server string, id string, skillId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "skillId", skillId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/agents/%s/skills/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetAgentSkillRequest generates requests for GetAgentSkill
+func NewGetAgentSkillRequest(server string, id string, skillId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "skillId", skillId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/agents/%s/skills/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateAgentSkillRequest calls the generic UpdateAgentSkill builder with application/json body
+func NewUpdateAgentSkillRequest(server string, id string, skillId string, body UpdateAgentSkillJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateAgentSkillRequestWithBody(server, id, skillId, "application/json", bodyReader)
+}
+
+// NewUpdateAgentSkillRequestWithBody generates requests for UpdateAgentSkill with any type of body
+func NewUpdateAgentSkillRequestWithBody(server string, id string, skillId string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "skillId", skillId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/agents/%s/skills/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteAgentSkillFileRequest generates requests for DeleteAgentSkillFile
+func NewDeleteAgentSkillFileRequest(server string, id string, skillId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "skillId", skillId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/agents/%s/skills/%s/file", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetAgentSkillFileRequest generates requests for GetAgentSkillFile
+func NewGetAgentSkillFileRequest(server string, id string, skillId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "skillId", skillId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/agents/%s/skills/%s/file", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewListAgentUsersRequest generates requests for ListAgentUsers
+func NewListAgentUsersRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/agents/%s/users", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewAssignAgentUserRequest calls the generic AssignAgentUser builder with application/json body
+func NewAssignAgentUserRequest(server string, id string, body AssignAgentUserJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewAssignAgentUserRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewAssignAgentUserRequestWithBody generates requests for AssignAgentUser with any type of body
+func NewAssignAgentUserRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/agents/%s/users", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewRemoveAgentUserRequest generates requests for RemoveAgentUser
+func NewRemoveAgentUserRequest(server string, id string, userId int64) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "userId", userId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "integer", Format: "int64"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/agents/%s/users/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
 }
 
 // NewListBuiltinResourcesRequest generates requests for ListBuiltinResources
@@ -3197,6 +4268,67 @@ func WithBaseURL(baseURL string) ClientOption {
 
 // ClientWithResponsesInterface is the interface specification for the client with responses above.
 type ClientWithResponsesInterface interface {
+	// ListAgentsWithResponse request
+	ListAgentsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListAgentsResponse, error)
+
+	// CreateAgentWithBodyWithResponse request with any body
+	CreateAgentWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateAgentResponse, error)
+
+	CreateAgentWithResponse(ctx context.Context, body CreateAgentJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateAgentResponse, error)
+
+	// DeleteAgentWithResponse request
+	DeleteAgentWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*DeleteAgentResponse, error)
+
+	// GetAgentWithResponse request
+	GetAgentWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetAgentResponse, error)
+
+	// UpdateAgentWithBodyWithResponse request with any body
+	UpdateAgentWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateAgentResponse, error)
+
+	UpdateAgentWithResponse(ctx context.Context, id string, body UpdateAgentJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateAgentResponse, error)
+
+	// ListAgentSkillsWithResponse request
+	ListAgentSkillsWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*ListAgentSkillsResponse, error)
+
+	// DuplicateBuiltinSkillToAgentWithResponse request
+	DuplicateBuiltinSkillToAgentWithResponse(ctx context.Context, id string, skillId string, reqEditors ...RequestEditorFn) (*DuplicateBuiltinSkillToAgentResponse, error)
+
+	// InstallAgentSkillWithBodyWithResponse request with any body
+	InstallAgentSkillWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*InstallAgentSkillResponse, error)
+
+	InstallAgentSkillWithResponse(ctx context.Context, id string, body InstallAgentSkillJSONRequestBody, reqEditors ...RequestEditorFn) (*InstallAgentSkillResponse, error)
+
+	// UploadAgentSkillWithBodyWithResponse request with any body
+	UploadAgentSkillWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UploadAgentSkillResponse, error)
+
+	// DeleteAgentSkillWithResponse request
+	DeleteAgentSkillWithResponse(ctx context.Context, id string, skillId string, reqEditors ...RequestEditorFn) (*DeleteAgentSkillResponse, error)
+
+	// GetAgentSkillWithResponse request
+	GetAgentSkillWithResponse(ctx context.Context, id string, skillId string, reqEditors ...RequestEditorFn) (*GetAgentSkillResponse, error)
+
+	// UpdateAgentSkillWithBodyWithResponse request with any body
+	UpdateAgentSkillWithBodyWithResponse(ctx context.Context, id string, skillId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateAgentSkillResponse, error)
+
+	UpdateAgentSkillWithResponse(ctx context.Context, id string, skillId string, body UpdateAgentSkillJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateAgentSkillResponse, error)
+
+	// DeleteAgentSkillFileWithResponse request
+	DeleteAgentSkillFileWithResponse(ctx context.Context, id string, skillId string, reqEditors ...RequestEditorFn) (*DeleteAgentSkillFileResponse, error)
+
+	// GetAgentSkillFileWithResponse request
+	GetAgentSkillFileWithResponse(ctx context.Context, id string, skillId string, reqEditors ...RequestEditorFn) (*GetAgentSkillFileResponse, error)
+
+	// ListAgentUsersWithResponse request
+	ListAgentUsersWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*ListAgentUsersResponse, error)
+
+	// AssignAgentUserWithBodyWithResponse request with any body
+	AssignAgentUserWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AssignAgentUserResponse, error)
+
+	AssignAgentUserWithResponse(ctx context.Context, id string, body AssignAgentUserJSONRequestBody, reqEditors ...RequestEditorFn) (*AssignAgentUserResponse, error)
+
+	// RemoveAgentUserWithResponse request
+	RemoveAgentUserWithResponse(ctx context.Context, id string, userId int64, reqEditors ...RequestEditorFn) (*RemoveAgentUserResponse, error)
+
 	// ListBuiltinResourcesWithResponse request
 	ListBuiltinResourcesWithResponse(ctx context.Context, kind string, reqEditors ...RequestEditorFn) (*ListBuiltinResourcesResponse, error)
 
@@ -3362,6 +4494,563 @@ type ClientWithResponsesInterface interface {
 
 	// ListToolsWithResponse request
 	ListToolsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListToolsResponse, error)
+}
+
+type ListAgentsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.AgentList
+	JSON401      *externalRef0.Unauthorized
+}
+
+// Status returns HTTPResponse.Status
+func (r ListAgentsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListAgentsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListAgentsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type CreateAgentResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *externalRef0.Agent
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateAgentResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateAgentResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r CreateAgentResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type DeleteAgentResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.DeleteResult
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteAgentResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteAgentResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r DeleteAgentResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetAgentResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.Agent
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r GetAgentResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetAgentResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetAgentResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type UpdateAgentResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.Agent
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateAgentResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateAgentResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r UpdateAgentResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListAgentSkillsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.SkillList
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r ListAgentSkillsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListAgentSkillsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListAgentSkillsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type DuplicateBuiltinSkillToAgentResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *externalRef0.DuplicateSkillResult
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r DuplicateBuiltinSkillToAgentResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DuplicateBuiltinSkillToAgentResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r DuplicateBuiltinSkillToAgentResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type InstallAgentSkillResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *externalRef0.SkillUploadResult
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r InstallAgentSkillResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r InstallAgentSkillResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r InstallAgentSkillResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type UploadAgentSkillResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *externalRef0.SkillUploadResult
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r UploadAgentSkillResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UploadAgentSkillResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r UploadAgentSkillResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type DeleteAgentSkillResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.DeleteResult
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteAgentSkillResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteAgentSkillResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r DeleteAgentSkillResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetAgentSkillResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.Skill
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r GetAgentSkillResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetAgentSkillResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetAgentSkillResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type UpdateAgentSkillResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.Skill
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateAgentSkillResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateAgentSkillResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r UpdateAgentSkillResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type DeleteAgentSkillFileResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.DeleteResult
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteAgentSkillFileResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteAgentSkillFileResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r DeleteAgentSkillFileResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetAgentSkillFileResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r GetAgentSkillFileResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetAgentSkillFileResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetAgentSkillFileResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListAgentUsersResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.AgentUserList
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r ListAgentUsersResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListAgentUsersResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListAgentUsersResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type AssignAgentUserResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.DeleteResult
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r AssignAgentUserResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r AssignAgentUserResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r AssignAgentUserResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type RemoveAgentUserResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.DeleteResult
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r RemoveAgentUserResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RemoveAgentUserResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r RemoveAgentUserResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
 }
 
 type ListBuiltinResourcesResponse struct {
@@ -4853,6 +6542,199 @@ func (r ListToolsResponse) ContentType() string {
 	return ""
 }
 
+// ListAgentsWithResponse request returning *ListAgentsResponse
+func (c *ClientWithResponses) ListAgentsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListAgentsResponse, error) {
+	rsp, err := c.ListAgents(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListAgentsResponse(rsp)
+}
+
+// CreateAgentWithBodyWithResponse request with arbitrary body returning *CreateAgentResponse
+func (c *ClientWithResponses) CreateAgentWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateAgentResponse, error) {
+	rsp, err := c.CreateAgentWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateAgentResponse(rsp)
+}
+
+func (c *ClientWithResponses) CreateAgentWithResponse(ctx context.Context, body CreateAgentJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateAgentResponse, error) {
+	rsp, err := c.CreateAgent(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateAgentResponse(rsp)
+}
+
+// DeleteAgentWithResponse request returning *DeleteAgentResponse
+func (c *ClientWithResponses) DeleteAgentWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*DeleteAgentResponse, error) {
+	rsp, err := c.DeleteAgent(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteAgentResponse(rsp)
+}
+
+// GetAgentWithResponse request returning *GetAgentResponse
+func (c *ClientWithResponses) GetAgentWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetAgentResponse, error) {
+	rsp, err := c.GetAgent(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetAgentResponse(rsp)
+}
+
+// UpdateAgentWithBodyWithResponse request with arbitrary body returning *UpdateAgentResponse
+func (c *ClientWithResponses) UpdateAgentWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateAgentResponse, error) {
+	rsp, err := c.UpdateAgentWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateAgentResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateAgentWithResponse(ctx context.Context, id string, body UpdateAgentJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateAgentResponse, error) {
+	rsp, err := c.UpdateAgent(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateAgentResponse(rsp)
+}
+
+// ListAgentSkillsWithResponse request returning *ListAgentSkillsResponse
+func (c *ClientWithResponses) ListAgentSkillsWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*ListAgentSkillsResponse, error) {
+	rsp, err := c.ListAgentSkills(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListAgentSkillsResponse(rsp)
+}
+
+// DuplicateBuiltinSkillToAgentWithResponse request returning *DuplicateBuiltinSkillToAgentResponse
+func (c *ClientWithResponses) DuplicateBuiltinSkillToAgentWithResponse(ctx context.Context, id string, skillId string, reqEditors ...RequestEditorFn) (*DuplicateBuiltinSkillToAgentResponse, error) {
+	rsp, err := c.DuplicateBuiltinSkillToAgent(ctx, id, skillId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDuplicateBuiltinSkillToAgentResponse(rsp)
+}
+
+// InstallAgentSkillWithBodyWithResponse request with arbitrary body returning *InstallAgentSkillResponse
+func (c *ClientWithResponses) InstallAgentSkillWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*InstallAgentSkillResponse, error) {
+	rsp, err := c.InstallAgentSkillWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseInstallAgentSkillResponse(rsp)
+}
+
+func (c *ClientWithResponses) InstallAgentSkillWithResponse(ctx context.Context, id string, body InstallAgentSkillJSONRequestBody, reqEditors ...RequestEditorFn) (*InstallAgentSkillResponse, error) {
+	rsp, err := c.InstallAgentSkill(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseInstallAgentSkillResponse(rsp)
+}
+
+// UploadAgentSkillWithBodyWithResponse request with arbitrary body returning *UploadAgentSkillResponse
+func (c *ClientWithResponses) UploadAgentSkillWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UploadAgentSkillResponse, error) {
+	rsp, err := c.UploadAgentSkillWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUploadAgentSkillResponse(rsp)
+}
+
+// DeleteAgentSkillWithResponse request returning *DeleteAgentSkillResponse
+func (c *ClientWithResponses) DeleteAgentSkillWithResponse(ctx context.Context, id string, skillId string, reqEditors ...RequestEditorFn) (*DeleteAgentSkillResponse, error) {
+	rsp, err := c.DeleteAgentSkill(ctx, id, skillId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteAgentSkillResponse(rsp)
+}
+
+// GetAgentSkillWithResponse request returning *GetAgentSkillResponse
+func (c *ClientWithResponses) GetAgentSkillWithResponse(ctx context.Context, id string, skillId string, reqEditors ...RequestEditorFn) (*GetAgentSkillResponse, error) {
+	rsp, err := c.GetAgentSkill(ctx, id, skillId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetAgentSkillResponse(rsp)
+}
+
+// UpdateAgentSkillWithBodyWithResponse request with arbitrary body returning *UpdateAgentSkillResponse
+func (c *ClientWithResponses) UpdateAgentSkillWithBodyWithResponse(ctx context.Context, id string, skillId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateAgentSkillResponse, error) {
+	rsp, err := c.UpdateAgentSkillWithBody(ctx, id, skillId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateAgentSkillResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateAgentSkillWithResponse(ctx context.Context, id string, skillId string, body UpdateAgentSkillJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateAgentSkillResponse, error) {
+	rsp, err := c.UpdateAgentSkill(ctx, id, skillId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateAgentSkillResponse(rsp)
+}
+
+// DeleteAgentSkillFileWithResponse request returning *DeleteAgentSkillFileResponse
+func (c *ClientWithResponses) DeleteAgentSkillFileWithResponse(ctx context.Context, id string, skillId string, reqEditors ...RequestEditorFn) (*DeleteAgentSkillFileResponse, error) {
+	rsp, err := c.DeleteAgentSkillFile(ctx, id, skillId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteAgentSkillFileResponse(rsp)
+}
+
+// GetAgentSkillFileWithResponse request returning *GetAgentSkillFileResponse
+func (c *ClientWithResponses) GetAgentSkillFileWithResponse(ctx context.Context, id string, skillId string, reqEditors ...RequestEditorFn) (*GetAgentSkillFileResponse, error) {
+	rsp, err := c.GetAgentSkillFile(ctx, id, skillId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetAgentSkillFileResponse(rsp)
+}
+
+// ListAgentUsersWithResponse request returning *ListAgentUsersResponse
+func (c *ClientWithResponses) ListAgentUsersWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*ListAgentUsersResponse, error) {
+	rsp, err := c.ListAgentUsers(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListAgentUsersResponse(rsp)
+}
+
+// AssignAgentUserWithBodyWithResponse request with arbitrary body returning *AssignAgentUserResponse
+func (c *ClientWithResponses) AssignAgentUserWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AssignAgentUserResponse, error) {
+	rsp, err := c.AssignAgentUserWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAssignAgentUserResponse(rsp)
+}
+
+func (c *ClientWithResponses) AssignAgentUserWithResponse(ctx context.Context, id string, body AssignAgentUserJSONRequestBody, reqEditors ...RequestEditorFn) (*AssignAgentUserResponse, error) {
+	rsp, err := c.AssignAgentUser(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAssignAgentUserResponse(rsp)
+}
+
+// RemoveAgentUserWithResponse request returning *RemoveAgentUserResponse
+func (c *ClientWithResponses) RemoveAgentUserWithResponse(ctx context.Context, id string, userId int64, reqEditors ...RequestEditorFn) (*RemoveAgentUserResponse, error) {
+	rsp, err := c.RemoveAgentUser(ctx, id, userId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRemoveAgentUserResponse(rsp)
+}
+
 // ListBuiltinResourcesWithResponse request returning *ListBuiltinResourcesResponse
 func (c *ClientWithResponses) ListBuiltinResourcesWithResponse(ctx context.Context, kind string, reqEditors ...RequestEditorFn) (*ListBuiltinResourcesResponse, error) {
 	rsp, err := c.ListBuiltinResources(ctx, kind, reqEditors...)
@@ -5377,6 +7259,777 @@ func (c *ClientWithResponses) ListToolsWithResponse(ctx context.Context, reqEdit
 		return nil, err
 	}
 	return ParseListToolsResponse(rsp)
+}
+
+// ParseListAgentsResponse parses an HTTP response from a ListAgentsWithResponse call
+func ParseListAgentsResponse(rsp *http.Response) (*ListAgentsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListAgentsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.AgentList
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateAgentResponse parses an HTTP response from a CreateAgentWithResponse call
+func ParseCreateAgentResponse(rsp *http.Response) (*CreateAgentResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateAgentResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest externalRef0.Agent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteAgentResponse parses an HTTP response from a DeleteAgentWithResponse call
+func ParseDeleteAgentResponse(rsp *http.Response) (*DeleteAgentResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteAgentResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.DeleteResult
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetAgentResponse parses an HTTP response from a GetAgentWithResponse call
+func ParseGetAgentResponse(rsp *http.Response) (*GetAgentResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetAgentResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.Agent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateAgentResponse parses an HTTP response from a UpdateAgentWithResponse call
+func ParseUpdateAgentResponse(rsp *http.Response) (*UpdateAgentResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateAgentResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.Agent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListAgentSkillsResponse parses an HTTP response from a ListAgentSkillsWithResponse call
+func ParseListAgentSkillsResponse(rsp *http.Response) (*ListAgentSkillsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListAgentSkillsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.SkillList
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDuplicateBuiltinSkillToAgentResponse parses an HTTP response from a DuplicateBuiltinSkillToAgentWithResponse call
+func ParseDuplicateBuiltinSkillToAgentResponse(rsp *http.Response) (*DuplicateBuiltinSkillToAgentResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DuplicateBuiltinSkillToAgentResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest externalRef0.DuplicateSkillResult
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseInstallAgentSkillResponse parses an HTTP response from a InstallAgentSkillWithResponse call
+func ParseInstallAgentSkillResponse(rsp *http.Response) (*InstallAgentSkillResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &InstallAgentSkillResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest externalRef0.SkillUploadResult
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUploadAgentSkillResponse parses an HTTP response from a UploadAgentSkillWithResponse call
+func ParseUploadAgentSkillResponse(rsp *http.Response) (*UploadAgentSkillResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UploadAgentSkillResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest externalRef0.SkillUploadResult
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteAgentSkillResponse parses an HTTP response from a DeleteAgentSkillWithResponse call
+func ParseDeleteAgentSkillResponse(rsp *http.Response) (*DeleteAgentSkillResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteAgentSkillResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.DeleteResult
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetAgentSkillResponse parses an HTTP response from a GetAgentSkillWithResponse call
+func ParseGetAgentSkillResponse(rsp *http.Response) (*GetAgentSkillResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetAgentSkillResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.Skill
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateAgentSkillResponse parses an HTTP response from a UpdateAgentSkillWithResponse call
+func ParseUpdateAgentSkillResponse(rsp *http.Response) (*UpdateAgentSkillResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateAgentSkillResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.Skill
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteAgentSkillFileResponse parses an HTTP response from a DeleteAgentSkillFileWithResponse call
+func ParseDeleteAgentSkillFileResponse(rsp *http.Response) (*DeleteAgentSkillFileResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteAgentSkillFileResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.DeleteResult
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetAgentSkillFileResponse parses an HTTP response from a GetAgentSkillFileWithResponse call
+func ParseGetAgentSkillFileResponse(rsp *http.Response) (*GetAgentSkillFileResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetAgentSkillFileResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListAgentUsersResponse parses an HTTP response from a ListAgentUsersWithResponse call
+func ParseListAgentUsersResponse(rsp *http.Response) (*ListAgentUsersResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListAgentUsersResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.AgentUserList
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseAssignAgentUserResponse parses an HTTP response from a AssignAgentUserWithResponse call
+func ParseAssignAgentUserResponse(rsp *http.Response) (*AssignAgentUserResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &AssignAgentUserResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.DeleteResult
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseRemoveAgentUserResponse parses an HTTP response from a RemoveAgentUserWithResponse call
+func ParseRemoveAgentUserResponse(rsp *http.Response) (*RemoveAgentUserResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RemoveAgentUserResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.DeleteResult
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	}
+
+	return response, nil
 }
 
 // ParseListBuiltinResourcesResponse parses an HTTP response from a ListBuiltinResourcesWithResponse call

--- a/api/client/gen.go
+++ b/api/client/gen.go
@@ -78,6 +78,9 @@ type FeedList = externalRef0.FeedList
 // FeedPollResult defines model for FeedPollResult.
 type FeedPollResult = externalRef0.FeedPollResult
 
+// FetchModelsRequest defines model for FetchModelsRequest.
+type FetchModelsRequest = externalRef0.FetchModelsRequest
+
 // Job defines model for Job.
 type Job = externalRef0.Job
 
@@ -86,6 +89,21 @@ type JobInput = externalRef0.JobInput
 
 // JobList defines model for JobList.
 type JobList = externalRef0.JobList
+
+// Provider defines model for Provider.
+type Provider = externalRef0.Provider
+
+// ProviderModel defines model for ProviderModel.
+type ProviderModel = externalRef0.ProviderModel
+
+// ProviderModelCost defines model for ProviderModelCost.
+type ProviderModelCost = externalRef0.ProviderModelCost
+
+// ProviderModelItem defines model for ProviderModelItem.
+type ProviderModelItem = externalRef0.ProviderModelItem
+
+// ProviderType defines model for ProviderType.
+type ProviderType = externalRef0.ProviderType
 
 // PublicChannel defines model for PublicChannel.
 type PublicChannel = externalRef0.PublicChannel
@@ -171,6 +189,15 @@ type CreateChannelJSONRequestBody = externalRef0.ChannelWriteRequest
 
 // UpdateChannelJSONRequestBody defines body for UpdateChannel for application/json ContentType.
 type UpdateChannelJSONRequestBody = externalRef0.ChannelWriteRequest
+
+// CreateProviderJSONRequestBody defines body for CreateProvider for application/json ContentType.
+type CreateProviderJSONRequestBody = externalRef0.Provider
+
+// UpdateProviderJSONRequestBody defines body for UpdateProvider for application/json ContentType.
+type UpdateProviderJSONRequestBody = externalRef0.Provider
+
+// FetchProviderModelsJSONRequestBody defines body for FetchProviderModels for application/json ContentType.
+type FetchProviderModelsJSONRequestBody = externalRef0.FetchModelsRequest
 
 // SaveArticleJSONRequestBody defines body for SaveArticle for application/json ContentType.
 type SaveArticleJSONRequestBody = externalRef0.SaveArticleRequest
@@ -302,6 +329,36 @@ type ClientInterface interface {
 
 	// ListModels request
 	ListModels(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListProviderTypes request
+	ListProviderTypes(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListProviders request
+	ListProviders(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateProviderWithBody request with any body
+	CreateProviderWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateProvider(ctx context.Context, body CreateProviderJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteProvider request
+	DeleteProvider(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetProvider request
+	GetProvider(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateProviderWithBody request with any body
+	UpdateProviderWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateProvider(ctx context.Context, id string, body UpdateProviderJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListProviderModels request
+	ListProviderModels(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// FetchProviderModelsWithBody request with any body
+	FetchProviderModelsWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	FetchProviderModels(ctx context.Context, id string, body FetchProviderModelsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListArticles request
 	ListArticles(ctx context.Context, params *ListArticlesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -527,6 +584,138 @@ func (c *Client) UpdateChannel(ctx context.Context, id string, body UpdateChanne
 
 func (c *Client) ListModels(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewListModelsRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListProviderTypes(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListProviderTypesRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListProviders(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListProvidersRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateProviderWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateProviderRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateProvider(ctx context.Context, body CreateProviderJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateProviderRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteProvider(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteProviderRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetProvider(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetProviderRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateProviderWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateProviderRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateProvider(ctx context.Context, id string, body UpdateProviderJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateProviderRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListProviderModels(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListProviderModelsRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) FetchProviderModelsWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewFetchProviderModelsRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) FetchProviderModels(ctx context.Context, id string, body FetchProviderModelsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewFetchProviderModelsRequest(c.Server, id, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1257,6 +1446,296 @@ func NewListModelsRequest(server string) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	return req, nil
+}
+
+// NewListProviderTypesRequest generates requests for ListProviderTypes
+func NewListProviderTypesRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/provider-types")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewListProvidersRequest generates requests for ListProviders
+func NewListProvidersRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/providers")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateProviderRequest calls the generic CreateProvider builder with application/json body
+func NewCreateProviderRequest(server string, body CreateProviderJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateProviderRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewCreateProviderRequestWithBody generates requests for CreateProvider with any type of body
+func NewCreateProviderRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/providers")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteProviderRequest generates requests for DeleteProvider
+func NewDeleteProviderRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/providers/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetProviderRequest generates requests for GetProvider
+func NewGetProviderRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/providers/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateProviderRequest calls the generic UpdateProvider builder with application/json body
+func NewUpdateProviderRequest(server string, id string, body UpdateProviderJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateProviderRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewUpdateProviderRequestWithBody generates requests for UpdateProvider with any type of body
+func NewUpdateProviderRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/providers/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewListProviderModelsRequest generates requests for ListProviderModels
+func NewListProviderModelsRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/providers/%s/models", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewFetchProviderModelsRequest calls the generic FetchProviderModels builder with application/json body
+func NewFetchProviderModelsRequest(server string, id string, body FetchProviderModelsJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewFetchProviderModelsRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewFetchProviderModelsRequestWithBody generates requests for FetchProviderModels with any type of body
+func NewFetchProviderModelsRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/providers/%s/models", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -2304,6 +2783,36 @@ type ClientWithResponsesInterface interface {
 	// ListModelsWithResponse request
 	ListModelsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListModelsResponse, error)
 
+	// ListProviderTypesWithResponse request
+	ListProviderTypesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListProviderTypesResponse, error)
+
+	// ListProvidersWithResponse request
+	ListProvidersWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListProvidersResponse, error)
+
+	// CreateProviderWithBodyWithResponse request with any body
+	CreateProviderWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateProviderResponse, error)
+
+	CreateProviderWithResponse(ctx context.Context, body CreateProviderJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateProviderResponse, error)
+
+	// DeleteProviderWithResponse request
+	DeleteProviderWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*DeleteProviderResponse, error)
+
+	// GetProviderWithResponse request
+	GetProviderWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetProviderResponse, error)
+
+	// UpdateProviderWithBodyWithResponse request with any body
+	UpdateProviderWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateProviderResponse, error)
+
+	UpdateProviderWithResponse(ctx context.Context, id string, body UpdateProviderJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateProviderResponse, error)
+
+	// ListProviderModelsWithResponse request
+	ListProviderModelsWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*ListProviderModelsResponse, error)
+
+	// FetchProviderModelsWithBodyWithResponse request with any body
+	FetchProviderModelsWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*FetchProviderModelsResponse, error)
+
+	FetchProviderModelsWithResponse(ctx context.Context, id string, body FetchProviderModelsJSONRequestBody, reqEditors ...RequestEditorFn) (*FetchProviderModelsResponse, error)
+
 	// ListArticlesWithResponse request
 	ListArticlesWithResponse(ctx context.Context, params *ListArticlesParams, reqEditors ...RequestEditorFn) (*ListArticlesResponse, error)
 
@@ -2732,6 +3241,270 @@ func (r ListModelsResponse) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r ListModelsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListProviderTypesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]externalRef0.ProviderType
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r ListProviderTypesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListProviderTypesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListProviderTypesResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListProvidersResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]externalRef0.Provider
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r ListProvidersResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListProvidersResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListProvidersResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type CreateProviderResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *externalRef0.Provider
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateProviderResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateProviderResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r CreateProviderResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type DeleteProviderResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.DeleteResult
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteProviderResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteProviderResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r DeleteProviderResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetProviderResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.Provider
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r GetProviderResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetProviderResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetProviderResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type UpdateProviderResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.Provider
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateProviderResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateProviderResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r UpdateProviderResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListProviderModelsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]externalRef0.ProviderModelItem
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r ListProviderModelsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListProviderModelsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListProviderModelsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type FetchProviderModelsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]externalRef0.ProviderModelItem
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r FetchProviderModelsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r FetchProviderModelsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r FetchProviderModelsResponse) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -3528,6 +4301,102 @@ func (c *ClientWithResponses) ListModelsWithResponse(ctx context.Context, reqEdi
 	return ParseListModelsResponse(rsp)
 }
 
+// ListProviderTypesWithResponse request returning *ListProviderTypesResponse
+func (c *ClientWithResponses) ListProviderTypesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListProviderTypesResponse, error) {
+	rsp, err := c.ListProviderTypes(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListProviderTypesResponse(rsp)
+}
+
+// ListProvidersWithResponse request returning *ListProvidersResponse
+func (c *ClientWithResponses) ListProvidersWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListProvidersResponse, error) {
+	rsp, err := c.ListProviders(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListProvidersResponse(rsp)
+}
+
+// CreateProviderWithBodyWithResponse request with arbitrary body returning *CreateProviderResponse
+func (c *ClientWithResponses) CreateProviderWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateProviderResponse, error) {
+	rsp, err := c.CreateProviderWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateProviderResponse(rsp)
+}
+
+func (c *ClientWithResponses) CreateProviderWithResponse(ctx context.Context, body CreateProviderJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateProviderResponse, error) {
+	rsp, err := c.CreateProvider(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateProviderResponse(rsp)
+}
+
+// DeleteProviderWithResponse request returning *DeleteProviderResponse
+func (c *ClientWithResponses) DeleteProviderWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*DeleteProviderResponse, error) {
+	rsp, err := c.DeleteProvider(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteProviderResponse(rsp)
+}
+
+// GetProviderWithResponse request returning *GetProviderResponse
+func (c *ClientWithResponses) GetProviderWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetProviderResponse, error) {
+	rsp, err := c.GetProvider(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetProviderResponse(rsp)
+}
+
+// UpdateProviderWithBodyWithResponse request with arbitrary body returning *UpdateProviderResponse
+func (c *ClientWithResponses) UpdateProviderWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateProviderResponse, error) {
+	rsp, err := c.UpdateProviderWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateProviderResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateProviderWithResponse(ctx context.Context, id string, body UpdateProviderJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateProviderResponse, error) {
+	rsp, err := c.UpdateProvider(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateProviderResponse(rsp)
+}
+
+// ListProviderModelsWithResponse request returning *ListProviderModelsResponse
+func (c *ClientWithResponses) ListProviderModelsWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*ListProviderModelsResponse, error) {
+	rsp, err := c.ListProviderModels(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListProviderModelsResponse(rsp)
+}
+
+// FetchProviderModelsWithBodyWithResponse request with arbitrary body returning *FetchProviderModelsResponse
+func (c *ClientWithResponses) FetchProviderModelsWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*FetchProviderModelsResponse, error) {
+	rsp, err := c.FetchProviderModelsWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseFetchProviderModelsResponse(rsp)
+}
+
+func (c *ClientWithResponses) FetchProviderModelsWithResponse(ctx context.Context, id string, body FetchProviderModelsJSONRequestBody, reqEditors ...RequestEditorFn) (*FetchProviderModelsResponse, error) {
+	rsp, err := c.FetchProviderModels(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseFetchProviderModelsResponse(rsp)
+}
+
 // ListArticlesWithResponse request returning *ListArticlesResponse
 func (c *ClientWithResponses) ListArticlesWithResponse(ctx context.Context, params *ListArticlesParams, reqEditors ...RequestEditorFn) (*ListArticlesResponse, error) {
 	rsp, err := c.ListArticles(ctx, params, reqEditors...)
@@ -4235,6 +5104,382 @@ func ParseListModelsResponse(rsp *http.Response) (*ListModelsResponse, error) {
 			return nil, err
 		}
 		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListProviderTypesResponse parses an HTTP response from a ListProviderTypesWithResponse call
+func ParseListProviderTypesResponse(rsp *http.Response) (*ListProviderTypesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListProviderTypesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []externalRef0.ProviderType
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListProvidersResponse parses an HTTP response from a ListProvidersWithResponse call
+func ParseListProvidersResponse(rsp *http.Response) (*ListProvidersResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListProvidersResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []externalRef0.Provider
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateProviderResponse parses an HTTP response from a CreateProviderWithResponse call
+func ParseCreateProviderResponse(rsp *http.Response) (*CreateProviderResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateProviderResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest externalRef0.Provider
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteProviderResponse parses an HTTP response from a DeleteProviderWithResponse call
+func ParseDeleteProviderResponse(rsp *http.Response) (*DeleteProviderResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteProviderResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.DeleteResult
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetProviderResponse parses an HTTP response from a GetProviderWithResponse call
+func ParseGetProviderResponse(rsp *http.Response) (*GetProviderResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetProviderResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.Provider
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateProviderResponse parses an HTTP response from a UpdateProviderWithResponse call
+func ParseUpdateProviderResponse(rsp *http.Response) (*UpdateProviderResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateProviderResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.Provider
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListProviderModelsResponse parses an HTTP response from a ListProviderModelsWithResponse call
+func ParseListProviderModelsResponse(rsp *http.Response) (*ListProviderModelsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListProviderModelsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []externalRef0.ProviderModelItem
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseFetchProviderModelsResponse parses an HTTP response from a FetchProviderModelsWithResponse call
+func ParseFetchProviderModelsResponse(rsp *http.Response) (*FetchProviderModelsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &FetchProviderModelsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []externalRef0.ProviderModelItem
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
 
 	}
 

--- a/api/client/gen.go
+++ b/api/client/gen.go
@@ -46,6 +46,9 @@ type ArticleStatus = externalRef0.ArticleStatus
 // AssignAgentUserRequest defines model for AssignAgentUserRequest.
 type AssignAgentUserRequest = externalRef0.AssignAgentUserRequest
 
+// AuthResponse defines model for AuthResponse.
+type AuthResponse = externalRef0.AuthResponse
+
 // AuthUser defines model for AuthUser.
 type AuthUser = externalRef0.AuthUser
 
@@ -145,6 +148,12 @@ type JobList = externalRef0.JobList
 // LinkCodeResponse defines model for LinkCodeResponse.
 type LinkCodeResponse = externalRef0.LinkCodeResponse
 
+// LoginRequest defines model for LoginRequest.
+type LoginRequest = externalRef0.LoginRequest
+
+// MeResponse defines model for MeResponse.
+type MeResponse = externalRef0.MeResponse
+
 // OAuthConnectedResponse defines model for OAuthConnectedResponse.
 type OAuthConnectedResponse = externalRef0.OAuthConnectedResponse
 
@@ -177,6 +186,9 @@ type PublicChannel = externalRef0.PublicChannel
 
 // PublicChannelList defines model for PublicChannelList.
 type PublicChannelList = externalRef0.PublicChannelList
+
+// RegisterRequest defines model for RegisterRequest.
+type RegisterRequest = externalRef0.RegisterRequest
 
 // SandboxConfig defines model for SandboxConfig.
 type SandboxConfig = externalRef0.SandboxConfig
@@ -398,6 +410,9 @@ type UpdateAgentSkillJSONRequestBody = externalRef0.UpdateSkillRequest
 // AssignAgentUserJSONRequestBody defines body for AssignAgentUser for application/json ContentType.
 type AssignAgentUserJSONRequestBody = externalRef0.AssignAgentUserRequest
 
+// LoginJSONRequestBody defines body for Login for application/json ContentType.
+type LoginJSONRequestBody = externalRef0.LoginRequest
+
 // GenerateLinkCodeJSONRequestBody defines body for GenerateLinkCode for application/json ContentType.
 type GenerateLinkCodeJSONRequestBody = externalRef0.GenerateLinkCodeRequest
 
@@ -421,6 +436,9 @@ type SetProfileSoulJSONRequestBody = externalRef0.SetSoulRequest
 
 // SetVaultEntryJSONRequestBody defines body for SetVaultEntry for application/json ContentType.
 type SetVaultEntryJSONRequestBody = externalRef0.SetVaultEntryRequest
+
+// RegisterJSONRequestBody defines body for Register for application/json ContentType.
+type RegisterJSONRequestBody = externalRef0.RegisterRequest
 
 // UpdateAuthUserActiveJSONRequestBody defines body for UpdateAuthUserActive for application/json ContentType.
 type UpdateAuthUserActiveJSONRequestBody = externalRef0.UpdateActiveRequest
@@ -625,6 +643,17 @@ type ClientInterface interface {
 	// RemoveAgentUser request
 	RemoveAgentUser(ctx context.Context, id string, userId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// LoginWithBody request with any body
+	LoginWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	Login(ctx context.Context, body LoginJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// Logout request
+	Logout(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetMe request
+	GetMe(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ListProfileIdentities request
 	ListProfileIdentities(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -713,6 +742,11 @@ type ClientInterface interface {
 	SetVaultEntryWithBody(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	SetVaultEntry(ctx context.Context, name string, body SetVaultEntryJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// RegisterWithBody request with any body
+	RegisterWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	Register(ctx context.Context, body RegisterJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListAuthUsers request
 	ListAuthUsers(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1226,6 +1260,54 @@ func (c *Client) RemoveAgentUser(ctx context.Context, id string, userId int64, r
 	return c.Client.Do(req)
 }
 
+func (c *Client) LoginWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewLoginRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) Login(ctx context.Context, body LoginJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewLoginRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) Logout(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewLogoutRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetMe(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetMeRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) ListProfileIdentities(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewListProfileIdentitiesRequest(c.Server)
 	if err != nil {
@@ -1600,6 +1682,30 @@ func (c *Client) SetVaultEntryWithBody(ctx context.Context, name string, content
 
 func (c *Client) SetVaultEntry(ctx context.Context, name string, body SetVaultEntryJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewSetVaultEntryRequest(c.Server, name, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RegisterWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRegisterRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) Register(ctx context.Context, body RegisterJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRegisterRequest(c.Server, body)
 	if err != nil {
 		return nil, err
 	}
@@ -3370,6 +3476,100 @@ func NewRemoveAgentUserRequest(server string, id string, userId int64) (*http.Re
 	return req, nil
 }
 
+// NewLoginRequest calls the generic Login builder with application/json body
+func NewLoginRequest(server string, body LoginJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewLoginRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewLoginRequestWithBody generates requests for Login with any type of body
+func NewLoginRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/login")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewLogoutRequest generates requests for Logout
+func NewLogoutRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/logout")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetMeRequest generates requests for GetMe
+func NewGetMeRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/me")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewListProfileIdentitiesRequest generates requests for ListProfileIdentities
 func NewListProfileIdentitiesRequest(server string) (*http.Request, error) {
 	var err error
@@ -4325,6 +4525,46 @@ func NewSetVaultEntryRequestWithBody(server string, name string, contentType str
 	}
 
 	req, err := http.NewRequest(http.MethodPut, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewRegisterRequest calls the generic Register builder with application/json body
+func NewRegisterRequest(server string, body RegisterJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewRegisterRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewRegisterRequestWithBody generates requests for Register with any type of body
+func NewRegisterRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/register")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
 	if err != nil {
 		return nil, err
 	}
@@ -7271,6 +7511,17 @@ type ClientWithResponsesInterface interface {
 	// RemoveAgentUserWithResponse request
 	RemoveAgentUserWithResponse(ctx context.Context, id string, userId int64, reqEditors ...RequestEditorFn) (*RemoveAgentUserResponse, error)
 
+	// LoginWithBodyWithResponse request with any body
+	LoginWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*LoginResponse, error)
+
+	LoginWithResponse(ctx context.Context, body LoginJSONRequestBody, reqEditors ...RequestEditorFn) (*LoginResponse, error)
+
+	// LogoutWithResponse request
+	LogoutWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*LogoutResponse, error)
+
+	// GetMeWithResponse request
+	GetMeWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetMeResponse, error)
+
 	// ListProfileIdentitiesWithResponse request
 	ListProfileIdentitiesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListProfileIdentitiesResponse, error)
 
@@ -7359,6 +7610,11 @@ type ClientWithResponsesInterface interface {
 	SetVaultEntryWithBodyWithResponse(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetVaultEntryResponse, error)
 
 	SetVaultEntryWithResponse(ctx context.Context, name string, body SetVaultEntryJSONRequestBody, reqEditors ...RequestEditorFn) (*SetVaultEntryResponse, error)
+
+	// RegisterWithBodyWithResponse request with any body
+	RegisterWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RegisterResponse, error)
+
+	RegisterWithResponse(ctx context.Context, body RegisterJSONRequestBody, reqEditors ...RequestEditorFn) (*RegisterResponse, error)
 
 	// ListAuthUsersWithResponse request
 	ListAuthUsersWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListAuthUsersResponse, error)
@@ -8165,6 +8421,102 @@ func (r RemoveAgentUserResponse) ContentType() string {
 	return ""
 }
 
+type LoginResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.AuthResponse
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+}
+
+// Status returns HTTPResponse.Status
+func (r LoginResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r LoginResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r LoginResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type LogoutResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Status *string `json:"status,omitempty"`
+	}
+	JSON401 *externalRef0.Unauthorized
+}
+
+// Status returns HTTPResponse.Status
+func (r LogoutResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r LogoutResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r LogoutResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetMeResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.MeResponse
+	JSON401      *externalRef0.Unauthorized
+}
+
+// Status returns HTTPResponse.Status
+func (r GetMeResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetMeResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetMeResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 type ListProfileIdentitiesResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -8957,6 +9309,38 @@ func (r SetVaultEntryResponse) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r SetVaultEntryResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type RegisterResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *externalRef0.AuthResponse
+	JSON400      *externalRef0.BadRequest
+	JSON409      *externalRef0.Error
+}
+
+// Status returns HTTPResponse.Status
+func (r RegisterResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RegisterResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r RegisterResponse) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -11345,6 +11729,41 @@ func (c *ClientWithResponses) RemoveAgentUserWithResponse(ctx context.Context, i
 	return ParseRemoveAgentUserResponse(rsp)
 }
 
+// LoginWithBodyWithResponse request with arbitrary body returning *LoginResponse
+func (c *ClientWithResponses) LoginWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*LoginResponse, error) {
+	rsp, err := c.LoginWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseLoginResponse(rsp)
+}
+
+func (c *ClientWithResponses) LoginWithResponse(ctx context.Context, body LoginJSONRequestBody, reqEditors ...RequestEditorFn) (*LoginResponse, error) {
+	rsp, err := c.Login(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseLoginResponse(rsp)
+}
+
+// LogoutWithResponse request returning *LogoutResponse
+func (c *ClientWithResponses) LogoutWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*LogoutResponse, error) {
+	rsp, err := c.Logout(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseLogoutResponse(rsp)
+}
+
+// GetMeWithResponse request returning *GetMeResponse
+func (c *ClientWithResponses) GetMeWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetMeResponse, error) {
+	rsp, err := c.GetMe(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetMeResponse(rsp)
+}
+
 // ListProfileIdentitiesWithResponse request returning *ListProfileIdentitiesResponse
 func (c *ClientWithResponses) ListProfileIdentitiesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListProfileIdentitiesResponse, error) {
 	rsp, err := c.ListProfileIdentities(ctx, reqEditors...)
@@ -11624,6 +12043,23 @@ func (c *ClientWithResponses) SetVaultEntryWithResponse(ctx context.Context, nam
 		return nil, err
 	}
 	return ParseSetVaultEntryResponse(rsp)
+}
+
+// RegisterWithBodyWithResponse request with arbitrary body returning *RegisterResponse
+func (c *ClientWithResponses) RegisterWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RegisterResponse, error) {
+	rsp, err := c.RegisterWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRegisterResponse(rsp)
+}
+
+func (c *ClientWithResponses) RegisterWithResponse(ctx context.Context, body RegisterJSONRequestBody, reqEditors ...RequestEditorFn) (*RegisterResponse, error) {
+	rsp, err := c.Register(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRegisterResponse(rsp)
 }
 
 // ListAuthUsersWithResponse request returning *ListAuthUsersResponse
@@ -13184,6 +13620,114 @@ func ParseRemoveAgentUserResponse(rsp *http.Response) (*RemoveAgentUserResponse,
 	return response, nil
 }
 
+// ParseLoginResponse parses an HTTP response from a LoginWithResponse call
+func ParseLoginResponse(rsp *http.Response) (*LoginResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &LoginResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.AuthResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseLogoutResponse parses an HTTP response from a LogoutWithResponse call
+func ParseLogoutResponse(rsp *http.Response) (*LogoutResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &LogoutResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Status *string `json:"status,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetMeResponse parses an HTTP response from a GetMeWithResponse call
+func ParseGetMeResponse(rsp *http.Response) (*GetMeResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetMeResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.MeResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseListProfileIdentitiesResponse parses an HTTP response from a ListProfileIdentitiesWithResponse call
 func ParseListProfileIdentitiesResponse(rsp *http.Response) (*ListProfileIdentitiesResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -14125,6 +14669,46 @@ func ParseSetVaultEntryResponse(rsp *http.Response) (*SetVaultEntryResponse, err
 			return nil, err
 		}
 		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseRegisterResponse parses an HTTP response from a RegisterWithResponse call
+func ParseRegisterResponse(rsp *http.Response) (*RegisterResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RegisterResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest externalRef0.AuthResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest externalRef0.Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
 
 	}
 

--- a/api/client/gen.go
+++ b/api/client/gen.go
@@ -306,6 +306,16 @@ type UploadAgentSkillMultipartBody struct {
 	File *openapi_types.File `json:"file,omitempty"`
 }
 
+// DeleteAgentSkillFileParams defines parameters for DeleteAgentSkillFile.
+type DeleteAgentSkillFileParams struct {
+	Path string `form:"path" json:"path"`
+}
+
+// GetAgentSkillFileParams defines parameters for GetAgentSkillFile.
+type GetAgentSkillFileParams struct {
+	Path string `form:"path" json:"path"`
+}
+
 // OauthCallbackParams defines parameters for OauthCallback.
 type OauthCallbackParams struct {
 	Code  string `form:"code" json:"code"`
@@ -653,10 +663,10 @@ type ClientInterface interface {
 	UpdateAgentSkill(ctx context.Context, id string, skillId string, body UpdateAgentSkillJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// DeleteAgentSkillFile request
-	DeleteAgentSkillFile(ctx context.Context, id string, skillId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	DeleteAgentSkillFile(ctx context.Context, id string, skillId string, params *DeleteAgentSkillFileParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetAgentSkillFile request
-	GetAgentSkillFile(ctx context.Context, id string, skillId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetAgentSkillFile(ctx context.Context, id string, skillId string, params *GetAgentSkillFileParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListAgentUsers request
 	ListAgentUsers(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1247,8 +1257,8 @@ func (c *Client) UpdateAgentSkill(ctx context.Context, id string, skillId string
 	return c.Client.Do(req)
 }
 
-func (c *Client) DeleteAgentSkillFile(ctx context.Context, id string, skillId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewDeleteAgentSkillFileRequest(c.Server, id, skillId)
+func (c *Client) DeleteAgentSkillFile(ctx context.Context, id string, skillId string, params *DeleteAgentSkillFileParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteAgentSkillFileRequest(c.Server, id, skillId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -1259,8 +1269,8 @@ func (c *Client) DeleteAgentSkillFile(ctx context.Context, id string, skillId st
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetAgentSkillFile(ctx context.Context, id string, skillId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetAgentSkillFileRequest(c.Server, id, skillId)
+func (c *Client) GetAgentSkillFile(ctx context.Context, id string, skillId string, params *GetAgentSkillFileParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetAgentSkillFileRequest(c.Server, id, skillId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3476,7 +3486,7 @@ func NewUpdateAgentSkillRequestWithBody(server string, id string, skillId string
 }
 
 // NewDeleteAgentSkillFileRequest generates requests for DeleteAgentSkillFile
-func NewDeleteAgentSkillFileRequest(server string, id string, skillId string) (*http.Request, error) {
+func NewDeleteAgentSkillFileRequest(server string, id string, skillId string, params *DeleteAgentSkillFileParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -3506,6 +3516,29 @@ func NewDeleteAgentSkillFileRequest(server string, id string, skillId string) (*
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if queryFrag, err := runtime.StyleParamWithOptions("form", true, "path", params.Path, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+			return nil, err
+		} else {
+			for _, qp := range strings.Split(queryFrag, "&") {
+				rawQueryFragments = append(rawQueryFragments, qp)
+			}
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
 	}
 
 	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
@@ -3517,7 +3550,7 @@ func NewDeleteAgentSkillFileRequest(server string, id string, skillId string) (*
 }
 
 // NewGetAgentSkillFileRequest generates requests for GetAgentSkillFile
-func NewGetAgentSkillFileRequest(server string, id string, skillId string) (*http.Request, error) {
+func NewGetAgentSkillFileRequest(server string, id string, skillId string, params *GetAgentSkillFileParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -3547,6 +3580,29 @@ func NewGetAgentSkillFileRequest(server string, id string, skillId string) (*htt
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if queryFrag, err := runtime.StyleParamWithOptions("form", true, "path", params.Path, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+			return nil, err
+		} else {
+			for _, qp := range strings.Split(queryFrag, "&") {
+				rawQueryFragments = append(rawQueryFragments, qp)
+			}
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
 	}
 
 	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
@@ -8050,10 +8106,10 @@ type ClientWithResponsesInterface interface {
 	UpdateAgentSkillWithResponse(ctx context.Context, id string, skillId string, body UpdateAgentSkillJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateAgentSkillResponse, error)
 
 	// DeleteAgentSkillFileWithResponse request
-	DeleteAgentSkillFileWithResponse(ctx context.Context, id string, skillId string, reqEditors ...RequestEditorFn) (*DeleteAgentSkillFileResponse, error)
+	DeleteAgentSkillFileWithResponse(ctx context.Context, id string, skillId string, params *DeleteAgentSkillFileParams, reqEditors ...RequestEditorFn) (*DeleteAgentSkillFileResponse, error)
 
 	// GetAgentSkillFileWithResponse request
-	GetAgentSkillFileWithResponse(ctx context.Context, id string, skillId string, reqEditors ...RequestEditorFn) (*GetAgentSkillFileResponse, error)
+	GetAgentSkillFileWithResponse(ctx context.Context, id string, skillId string, params *GetAgentSkillFileParams, reqEditors ...RequestEditorFn) (*GetAgentSkillFileResponse, error)
 
 	// ListAgentUsersWithResponse request
 	ListAgentUsersWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*ListAgentUsersResponse, error)
@@ -12557,8 +12613,8 @@ func (c *ClientWithResponses) UpdateAgentSkillWithResponse(ctx context.Context, 
 }
 
 // DeleteAgentSkillFileWithResponse request returning *DeleteAgentSkillFileResponse
-func (c *ClientWithResponses) DeleteAgentSkillFileWithResponse(ctx context.Context, id string, skillId string, reqEditors ...RequestEditorFn) (*DeleteAgentSkillFileResponse, error) {
-	rsp, err := c.DeleteAgentSkillFile(ctx, id, skillId, reqEditors...)
+func (c *ClientWithResponses) DeleteAgentSkillFileWithResponse(ctx context.Context, id string, skillId string, params *DeleteAgentSkillFileParams, reqEditors ...RequestEditorFn) (*DeleteAgentSkillFileResponse, error) {
+	rsp, err := c.DeleteAgentSkillFile(ctx, id, skillId, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -12566,8 +12622,8 @@ func (c *ClientWithResponses) DeleteAgentSkillFileWithResponse(ctx context.Conte
 }
 
 // GetAgentSkillFileWithResponse request returning *GetAgentSkillFileResponse
-func (c *ClientWithResponses) GetAgentSkillFileWithResponse(ctx context.Context, id string, skillId string, reqEditors ...RequestEditorFn) (*GetAgentSkillFileResponse, error) {
-	rsp, err := c.GetAgentSkillFile(ctx, id, skillId, reqEditors...)
+func (c *ClientWithResponses) GetAgentSkillFileWithResponse(ctx context.Context, id string, skillId string, params *GetAgentSkillFileParams, reqEditors ...RequestEditorFn) (*GetAgentSkillFileResponse, error) {
+	rsp, err := c.GetAgentSkillFile(ctx, id, skillId, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}

--- a/api/client/gen.go
+++ b/api/client/gen.go
@@ -51,6 +51,9 @@ type ChannelWriteRequest = externalRef0.ChannelWriteRequest
 // CreateFeedRequest defines model for CreateFeedRequest.
 type CreateFeedRequest = externalRef0.CreateFeedRequest
 
+// CreateSessionRequest defines model for CreateSessionRequest.
+type CreateSessionRequest = externalRef0.CreateSessionRequest
+
 // DeleteResult defines model for DeleteResult.
 type DeleteResult = externalRef0.DeleteResult
 
@@ -114,8 +117,20 @@ type PublicChannelList = externalRef0.PublicChannelList
 // SaveArticleRequest defines model for SaveArticleRequest.
 type SaveArticleRequest = externalRef0.SaveArticleRequest
 
+// SendMessageRequest defines model for SendMessageRequest.
+type SendMessageRequest = externalRef0.SendMessageRequest
+
+// Session defines model for Session.
+type Session = externalRef0.Session
+
+// SessionDetail defines model for SessionDetail.
+type SessionDetail = externalRef0.SessionDetail
+
 // SourceType defines model for SourceType.
 type SourceType = externalRef0.SourceType
+
+// SystemPromptResponse defines model for SystemPromptResponse.
+type SystemPromptResponse = externalRef0.SystemPromptResponse
 
 // TagCount defines model for TagCount.
 type TagCount = externalRef0.TagCount
@@ -184,6 +199,24 @@ type PollFeedParams struct {
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
 }
 
+// ListSessionsParams defines parameters for ListSessions.
+type ListSessionsParams struct {
+	// Limit Maximum number of sessions to return
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Offset Number of sessions to skip
+	Offset *int `form:"offset,omitempty" json:"offset,omitempty"`
+}
+
+// GetSessionMessagesParams defines parameters for GetSessionMessages.
+type GetSessionMessagesParams struct {
+	// Limit Maximum number of messages to return
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Skip Number of messages to skip from the end
+	Skip *int `form:"skip,omitempty" json:"skip,omitempty"`
+}
+
 // CreateChannelJSONRequestBody defines body for CreateChannel for application/json ContentType.
 type CreateChannelJSONRequestBody = externalRef0.ChannelWriteRequest
 
@@ -219,6 +252,12 @@ type CreateSchedulerJobJSONRequestBody = externalRef0.JobInput
 
 // UpdateSchedulerJobJSONRequestBody defines body for UpdateSchedulerJob for application/json ContentType.
 type UpdateSchedulerJobJSONRequestBody = externalRef0.JobInput
+
+// CreateSessionJSONRequestBody defines body for CreateSession for application/json ContentType.
+type CreateSessionJSONRequestBody = externalRef0.CreateSessionRequest
+
+// SendSessionMessageJSONRequestBody defines body for SendSessionMessage for application/json ContentType.
+type SendSessionMessageJSONRequestBody = externalRef0.SendMessageRequest
 
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(ctx context.Context, req *http.Request) error
@@ -433,6 +472,28 @@ type ClientInterface interface {
 
 	// ListSchedulerJobRuns request
 	ListSchedulerJobRuns(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListSessions request
+	ListSessions(ctx context.Context, params *ListSessionsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateSessionWithBody request with any body
+	CreateSessionWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateSession(ctx context.Context, body CreateSessionJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetSession request
+	GetSession(ctx context.Context, sessionID string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetSessionMessages request
+	GetSessionMessages(ctx context.Context, sessionID string, params *GetSessionMessagesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SendSessionMessageWithBody request with any body
+	SendSessionMessageWithBody(ctx context.Context, sessionID string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	SendSessionMessage(ctx context.Context, sessionID string, body SendSessionMessageJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetSessionSystemPrompt request
+	GetSessionSystemPrompt(ctx context.Context, sessionID string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListTools request
 	ListTools(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1040,6 +1101,102 @@ func (c *Client) TriggerSchedulerJob(ctx context.Context, id string, reqEditors 
 
 func (c *Client) ListSchedulerJobRuns(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewListSchedulerJobRunsRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListSessions(ctx context.Context, params *ListSessionsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListSessionsRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateSessionWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateSessionRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateSession(ctx context.Context, body CreateSessionJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateSessionRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetSession(ctx context.Context, sessionID string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetSessionRequest(c.Server, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetSessionMessages(ctx context.Context, sessionID string, params *GetSessionMessagesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetSessionMessagesRequest(c.Server, sessionID, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SendSessionMessageWithBody(ctx context.Context, sessionID string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSendSessionMessageRequestWithBody(c.Server, sessionID, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SendSessionMessage(ctx context.Context, sessionID string, body SendSessionMessageJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSendSessionMessageRequest(c.Server, sessionID, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetSessionSystemPrompt(ctx context.Context, sessionID string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetSessionSystemPromptRequest(c.Server, sessionID)
 	if err != nil {
 		return nil, err
 	}
@@ -2676,6 +2833,300 @@ func NewListSchedulerJobRunsRequest(server string, id string) (*http.Request, er
 	return req, nil
 }
 
+// NewListSessionsRequest generates requests for ListSessions
+func NewListSessionsRequest(server string, params *ListSessionsParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/sessions")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "limit", *params.Limit, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Offset != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "offset", *params.Offset, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateSessionRequest calls the generic CreateSession builder with application/json body
+func NewCreateSessionRequest(server string, body CreateSessionJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateSessionRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewCreateSessionRequestWithBody generates requests for CreateSession with any type of body
+func NewCreateSessionRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/sessions")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewGetSessionRequest generates requests for GetSession
+func NewGetSessionRequest(server string, sessionID string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "sessionID", sessionID, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/sessions/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetSessionMessagesRequest generates requests for GetSessionMessages
+func NewGetSessionMessagesRequest(server string, sessionID string, params *GetSessionMessagesParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "sessionID", sessionID, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/sessions/%s/messages", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "limit", *params.Limit, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Skip != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "skip", *params.Skip, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewSendSessionMessageRequest calls the generic SendSessionMessage builder with application/json body
+func NewSendSessionMessageRequest(server string, sessionID string, body SendSessionMessageJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewSendSessionMessageRequestWithBody(server, sessionID, "application/json", bodyReader)
+}
+
+// NewSendSessionMessageRequestWithBody generates requests for SendSessionMessage with any type of body
+func NewSendSessionMessageRequestWithBody(server string, sessionID string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "sessionID", sessionID, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/sessions/%s/messages", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewGetSessionSystemPromptRequest generates requests for GetSessionSystemPrompt
+func NewGetSessionSystemPromptRequest(server string, sessionID string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "sessionID", sessionID, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/sessions/%s/system-prompt", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewListToolsRequest generates requests for ListTools
 func NewListToolsRequest(server string) (*http.Request, error) {
 	var err error
@@ -2886,6 +3337,28 @@ type ClientWithResponsesInterface interface {
 
 	// ListSchedulerJobRunsWithResponse request
 	ListSchedulerJobRunsWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*ListSchedulerJobRunsResponse, error)
+
+	// ListSessionsWithResponse request
+	ListSessionsWithResponse(ctx context.Context, params *ListSessionsParams, reqEditors ...RequestEditorFn) (*ListSessionsResponse, error)
+
+	// CreateSessionWithBodyWithResponse request with any body
+	CreateSessionWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateSessionResponse, error)
+
+	CreateSessionWithResponse(ctx context.Context, body CreateSessionJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateSessionResponse, error)
+
+	// GetSessionWithResponse request
+	GetSessionWithResponse(ctx context.Context, sessionID string, reqEditors ...RequestEditorFn) (*GetSessionResponse, error)
+
+	// GetSessionMessagesWithResponse request
+	GetSessionMessagesWithResponse(ctx context.Context, sessionID string, params *GetSessionMessagesParams, reqEditors ...RequestEditorFn) (*GetSessionMessagesResponse, error)
+
+	// SendSessionMessageWithBodyWithResponse request with any body
+	SendSessionMessageWithBodyWithResponse(ctx context.Context, sessionID string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SendSessionMessageResponse, error)
+
+	SendSessionMessageWithResponse(ctx context.Context, sessionID string, body SendSessionMessageJSONRequestBody, reqEditors ...RequestEditorFn) (*SendSessionMessageResponse, error)
+
+	// GetSessionSystemPromptWithResponse request
+	GetSessionSystemPromptWithResponse(ctx context.Context, sessionID string, reqEditors ...RequestEditorFn) (*GetSessionSystemPromptResponse, error)
 
 	// ListToolsWithResponse request
 	ListToolsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListToolsResponse, error)
@@ -4155,6 +4628,200 @@ func (r ListSchedulerJobRunsResponse) ContentType() string {
 	return ""
 }
 
+type ListSessionsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]externalRef0.Session
+	JSON401      *externalRef0.Unauthorized
+}
+
+// Status returns HTTPResponse.Status
+func (r ListSessionsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListSessionsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListSessionsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type CreateSessionResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *externalRef0.Session
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateSessionResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateSessionResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r CreateSessionResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetSessionResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.SessionDetail
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r GetSessionResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetSessionResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetSessionResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetSessionMessagesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]map[string]interface{}
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r GetSessionMessagesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetSessionMessagesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetSessionMessagesResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type SendSessionMessageResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r SendSessionMessageResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SendSessionMessageResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r SendSessionMessageResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetSessionSystemPromptResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.SystemPromptResponse
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r GetSessionSystemPromptResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetSessionSystemPromptResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetSessionSystemPromptResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 type ListToolsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -4631,6 +5298,76 @@ func (c *ClientWithResponses) ListSchedulerJobRunsWithResponse(ctx context.Conte
 		return nil, err
 	}
 	return ParseListSchedulerJobRunsResponse(rsp)
+}
+
+// ListSessionsWithResponse request returning *ListSessionsResponse
+func (c *ClientWithResponses) ListSessionsWithResponse(ctx context.Context, params *ListSessionsParams, reqEditors ...RequestEditorFn) (*ListSessionsResponse, error) {
+	rsp, err := c.ListSessions(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListSessionsResponse(rsp)
+}
+
+// CreateSessionWithBodyWithResponse request with arbitrary body returning *CreateSessionResponse
+func (c *ClientWithResponses) CreateSessionWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateSessionResponse, error) {
+	rsp, err := c.CreateSessionWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateSessionResponse(rsp)
+}
+
+func (c *ClientWithResponses) CreateSessionWithResponse(ctx context.Context, body CreateSessionJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateSessionResponse, error) {
+	rsp, err := c.CreateSession(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateSessionResponse(rsp)
+}
+
+// GetSessionWithResponse request returning *GetSessionResponse
+func (c *ClientWithResponses) GetSessionWithResponse(ctx context.Context, sessionID string, reqEditors ...RequestEditorFn) (*GetSessionResponse, error) {
+	rsp, err := c.GetSession(ctx, sessionID, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetSessionResponse(rsp)
+}
+
+// GetSessionMessagesWithResponse request returning *GetSessionMessagesResponse
+func (c *ClientWithResponses) GetSessionMessagesWithResponse(ctx context.Context, sessionID string, params *GetSessionMessagesParams, reqEditors ...RequestEditorFn) (*GetSessionMessagesResponse, error) {
+	rsp, err := c.GetSessionMessages(ctx, sessionID, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetSessionMessagesResponse(rsp)
+}
+
+// SendSessionMessageWithBodyWithResponse request with arbitrary body returning *SendSessionMessageResponse
+func (c *ClientWithResponses) SendSessionMessageWithBodyWithResponse(ctx context.Context, sessionID string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SendSessionMessageResponse, error) {
+	rsp, err := c.SendSessionMessageWithBody(ctx, sessionID, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSendSessionMessageResponse(rsp)
+}
+
+func (c *ClientWithResponses) SendSessionMessageWithResponse(ctx context.Context, sessionID string, body SendSessionMessageJSONRequestBody, reqEditors ...RequestEditorFn) (*SendSessionMessageResponse, error) {
+	rsp, err := c.SendSessionMessage(ctx, sessionID, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSendSessionMessageResponse(rsp)
+}
+
+// GetSessionSystemPromptWithResponse request returning *GetSessionSystemPromptResponse
+func (c *ClientWithResponses) GetSessionSystemPromptWithResponse(ctx context.Context, sessionID string, reqEditors ...RequestEditorFn) (*GetSessionSystemPromptResponse, error) {
+	rsp, err := c.GetSessionSystemPrompt(ctx, sessionID, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetSessionSystemPromptResponse(rsp)
 }
 
 // ListToolsWithResponse request returning *ListToolsResponse
@@ -6283,6 +7020,260 @@ func ParseListSchedulerJobRunsResponse(rsp *http.Response) (*ListSchedulerJobRun
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest externalRef0.JobRunList
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListSessionsResponse parses an HTTP response from a ListSessionsWithResponse call
+func ParseListSessionsResponse(rsp *http.Response) (*ListSessionsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListSessionsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []externalRef0.Session
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateSessionResponse parses an HTTP response from a CreateSessionWithResponse call
+func ParseCreateSessionResponse(rsp *http.Response) (*CreateSessionResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateSessionResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest externalRef0.Session
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetSessionResponse parses an HTTP response from a GetSessionWithResponse call
+func ParseGetSessionResponse(rsp *http.Response) (*GetSessionResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetSessionResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.SessionDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetSessionMessagesResponse parses an HTTP response from a GetSessionMessagesWithResponse call
+func ParseGetSessionMessagesResponse(rsp *http.Response) (*GetSessionMessagesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetSessionMessagesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseSendSessionMessageResponse parses an HTTP response from a SendSessionMessageWithResponse call
+func ParseSendSessionMessageResponse(rsp *http.Response) (*SendSessionMessageResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SendSessionMessageResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetSessionSystemPromptResponse parses an HTTP response from a GetSessionSystemPromptWithResponse call
+func ParseGetSessionSystemPromptResponse(rsp *http.Response) (*GetSessionSystemPromptResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetSessionSystemPromptResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.SystemPromptResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/api/client/gen.go
+++ b/api/client/gen.go
@@ -61,6 +61,9 @@ type BuiltinResourceDetail = externalRef0.BuiltinResourceDetail
 // CachedModel defines model for CachedModel.
 type CachedModel = externalRef0.CachedModel
 
+// ChangePasswordRequest defines model for ChangePasswordRequest.
+type ChangePasswordRequest = externalRef0.ChangePasswordRequest
+
 // Channel defines model for Channel.
 type Channel = externalRef0.Channel
 
@@ -118,6 +121,9 @@ type FeedPollResult = externalRef0.FeedPollResult
 // FetchModelsRequest defines model for FetchModelsRequest.
 type FetchModelsRequest = externalRef0.FetchModelsRequest
 
+// GenerateLinkCodeRequest defines model for GenerateLinkCodeRequest.
+type GenerateLinkCodeRequest = externalRef0.GenerateLinkCodeRequest
+
 // GlobalInstallSkillRequest defines model for GlobalInstallSkillRequest.
 type GlobalInstallSkillRequest = externalRef0.GlobalInstallSkillRequest
 
@@ -135,6 +141,18 @@ type JobInput = externalRef0.JobInput
 
 // JobList defines model for JobList.
 type JobList = externalRef0.JobList
+
+// LinkCodeResponse defines model for LinkCodeResponse.
+type LinkCodeResponse = externalRef0.LinkCodeResponse
+
+// OAuthConnectedResponse defines model for OAuthConnectedResponse.
+type OAuthConnectedResponse = externalRef0.OAuthConnectedResponse
+
+// OAuthFlowStatus defines model for OAuthFlowStatus.
+type OAuthFlowStatus = externalRef0.OAuthFlowStatus
+
+// OAuthProviderStatus defines model for OAuthProviderStatus.
+type OAuthProviderStatus = externalRef0.OAuthProviderStatus
 
 // ProfileInstallSkillRequest defines model for ProfileInstallSkillRequest.
 type ProfileInstallSkillRequest = externalRef0.ProfileInstallSkillRequest
@@ -180,6 +198,12 @@ type SessionDetail = externalRef0.SessionDetail
 
 // SetMemoryRequest defines model for SetMemoryRequest.
 type SetMemoryRequest = externalRef0.SetMemoryRequest
+
+// SetSoulRequest defines model for SetSoulRequest.
+type SetSoulRequest = externalRef0.SetSoulRequest
+
+// SetVaultEntryRequest defines model for SetVaultEntryRequest.
+type SetVaultEntryRequest = externalRef0.SetVaultEntryRequest
 
 // Skill defines model for Skill.
 type Skill = externalRef0.Skill
@@ -241,6 +265,9 @@ type UpdateSkillRequest = externalRef0.UpdateSkillRequest
 // UserMemory defines model for UserMemory.
 type UserMemory = externalRef0.UserMemory
 
+// VaultEntry defines model for VaultEntry.
+type VaultEntry = externalRef0.VaultEntry
+
 // WeixinQRCode defines model for WeixinQRCode.
 type WeixinQRCode = externalRef0.WeixinQRCode
 
@@ -253,6 +280,12 @@ type bearerAuthContextKey string
 // UploadAgentSkillMultipartBody defines parameters for UploadAgentSkill.
 type UploadAgentSkillMultipartBody struct {
 	File *openapi_types.File `json:"file,omitempty"`
+}
+
+// OauthCallbackParams defines parameters for OauthCallback.
+type OauthCallbackParams struct {
+	Code  string `form:"code" json:"code"`
+	State string `form:"state" json:"state"`
 }
 
 // UploadProfileSkillMultipartBody defines parameters for UploadProfileSkill.
@@ -365,6 +398,15 @@ type UpdateAgentSkillJSONRequestBody = externalRef0.UpdateSkillRequest
 // AssignAgentUserJSONRequestBody defines body for AssignAgentUser for application/json ContentType.
 type AssignAgentUserJSONRequestBody = externalRef0.AssignAgentUserRequest
 
+// GenerateLinkCodeJSONRequestBody defines body for GenerateLinkCode for application/json ContentType.
+type GenerateLinkCodeJSONRequestBody = externalRef0.GenerateLinkCodeRequest
+
+// SetProfileMemoryJSONRequestBody defines body for SetProfileMemory for application/json ContentType.
+type SetProfileMemoryJSONRequestBody = externalRef0.SetMemoryRequest
+
+// ChangePasswordJSONRequestBody defines body for ChangePassword for application/json ContentType.
+type ChangePasswordJSONRequestBody = externalRef0.ChangePasswordRequest
+
 // InstallProfileSkillJSONRequestBody defines body for InstallProfileSkill for application/json ContentType.
 type InstallProfileSkillJSONRequestBody = externalRef0.ProfileInstallSkillRequest
 
@@ -373,6 +415,12 @@ type UploadProfileSkillMultipartRequestBody UploadProfileSkillMultipartBody
 
 // UpdateProfileSkillJSONRequestBody defines body for UpdateProfileSkill for application/json ContentType.
 type UpdateProfileSkillJSONRequestBody = externalRef0.UpdateSkillRequest
+
+// SetProfileSoulJSONRequestBody defines body for SetProfileSoul for application/json ContentType.
+type SetProfileSoulJSONRequestBody = externalRef0.SetSoulRequest
+
+// SetVaultEntryJSONRequestBody defines body for SetVaultEntry for application/json ContentType.
+type SetVaultEntryJSONRequestBody = externalRef0.SetVaultEntryRequest
 
 // UpdateAuthUserActiveJSONRequestBody defines body for UpdateAuthUserActive for application/json ContentType.
 type UpdateAuthUserActiveJSONRequestBody = externalRef0.UpdateActiveRequest
@@ -577,6 +625,51 @@ type ClientInterface interface {
 	// RemoveAgentUser request
 	RemoveAgentUser(ctx context.Context, id string, userId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ListProfileIdentities request
+	ListProfileIdentities(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UnlinkProfileIdentity request
+	UnlinkProfileIdentity(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GenerateLinkCodeWithBody request with any body
+	GenerateLinkCodeWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	GenerateLinkCode(ctx context.Context, body GenerateLinkCodeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListProfileMemories request
+	ListProfileMemories(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteProfileMemory request
+	DeleteProfileMemory(ctx context.Context, agentId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SetProfileMemoryWithBody request with any body
+	SetProfileMemoryWithBody(ctx context.Context, agentId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	SetProfileMemory(ctx context.Context, agentId string, body SetProfileMemoryJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListOAuthProviders request
+	ListOAuthProviders(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DisconnectOAuth request
+	DisconnectOAuth(ctx context.Context, provider string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// OauthCallback request
+	OauthCallback(ctx context.Context, provider string, params *OauthCallbackParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetOAuthConnected request
+	GetOAuthConnected(ctx context.Context, provider string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// StartOAuthFlow request
+	StartOAuthFlow(ctx context.Context, provider string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PollOAuthFlow request
+	PollOAuthFlow(ctx context.Context, provider string, flowID string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ChangePasswordWithBody request with any body
+	ChangePasswordWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	ChangePassword(ctx context.Context, body ChangePasswordJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ListProfileSkills request
 	ListProfileSkills(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -604,6 +697,22 @@ type ClientInterface interface {
 
 	// GetProfileSkillFile request
 	GetProfileSkillFile(ctx context.Context, skillId string, params *GetProfileSkillFileParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SetProfileSoulWithBody request with any body
+	SetProfileSoulWithBody(ctx context.Context, agentId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	SetProfileSoul(ctx context.Context, agentId string, body SetProfileSoulJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListVaultEntries request
+	ListVaultEntries(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteVaultEntry request
+	DeleteVaultEntry(ctx context.Context, name string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SetVaultEntryWithBody request with any body
+	SetVaultEntryWithBody(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	SetVaultEntry(ctx context.Context, name string, body SetVaultEntryJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListAuthUsers request
 	ListAuthUsers(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1117,6 +1226,198 @@ func (c *Client) RemoveAgentUser(ctx context.Context, id string, userId int64, r
 	return c.Client.Do(req)
 }
 
+func (c *Client) ListProfileIdentities(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListProfileIdentitiesRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UnlinkProfileIdentity(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUnlinkProfileIdentityRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GenerateLinkCodeWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGenerateLinkCodeRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GenerateLinkCode(ctx context.Context, body GenerateLinkCodeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGenerateLinkCodeRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListProfileMemories(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListProfileMemoriesRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteProfileMemory(ctx context.Context, agentId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteProfileMemoryRequest(c.Server, agentId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SetProfileMemoryWithBody(ctx context.Context, agentId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSetProfileMemoryRequestWithBody(c.Server, agentId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SetProfileMemory(ctx context.Context, agentId string, body SetProfileMemoryJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSetProfileMemoryRequest(c.Server, agentId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListOAuthProviders(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListOAuthProvidersRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DisconnectOAuth(ctx context.Context, provider string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDisconnectOAuthRequest(c.Server, provider)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) OauthCallback(ctx context.Context, provider string, params *OauthCallbackParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewOauthCallbackRequest(c.Server, provider, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetOAuthConnected(ctx context.Context, provider string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetOAuthConnectedRequest(c.Server, provider)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) StartOAuthFlow(ctx context.Context, provider string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewStartOAuthFlowRequest(c.Server, provider)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PollOAuthFlow(ctx context.Context, provider string, flowID string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPollOAuthFlowRequest(c.Server, provider, flowID)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ChangePasswordWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewChangePasswordRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ChangePassword(ctx context.Context, body ChangePasswordJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewChangePasswordRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) ListProfileSkills(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewListProfileSkillsRequest(c.Server)
 	if err != nil {
@@ -1227,6 +1528,78 @@ func (c *Client) DeleteProfileSkillFile(ctx context.Context, skillId string, par
 
 func (c *Client) GetProfileSkillFile(ctx context.Context, skillId string, params *GetProfileSkillFileParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetProfileSkillFileRequest(c.Server, skillId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SetProfileSoulWithBody(ctx context.Context, agentId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSetProfileSoulRequestWithBody(c.Server, agentId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SetProfileSoul(ctx context.Context, agentId string, body SetProfileSoulJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSetProfileSoulRequest(c.Server, agentId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListVaultEntries(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListVaultEntriesRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteVaultEntry(ctx context.Context, name string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteVaultEntryRequest(c.Server, name)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SetVaultEntryWithBody(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSetVaultEntryRequestWithBody(c.Server, name, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SetVaultEntry(ctx context.Context, name string, body SetVaultEntryJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSetVaultEntryRequest(c.Server, name, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2997,6 +3370,490 @@ func NewRemoveAgentUserRequest(server string, id string, userId int64) (*http.Re
 	return req, nil
 }
 
+// NewListProfileIdentitiesRequest generates requests for ListProfileIdentities
+func NewListProfileIdentitiesRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/profile/identities")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUnlinkProfileIdentityRequest generates requests for UnlinkProfileIdentity
+func NewUnlinkProfileIdentityRequest(server string, id int64) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "integer", Format: "int64"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/profile/identities/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGenerateLinkCodeRequest calls the generic GenerateLinkCode builder with application/json body
+func NewGenerateLinkCodeRequest(server string, body GenerateLinkCodeJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewGenerateLinkCodeRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewGenerateLinkCodeRequestWithBody generates requests for GenerateLinkCode with any type of body
+func NewGenerateLinkCodeRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/profile/link-code")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewListProfileMemoriesRequest generates requests for ListProfileMemories
+func NewListProfileMemoriesRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/profile/memories")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewDeleteProfileMemoryRequest generates requests for DeleteProfileMemory
+func NewDeleteProfileMemoryRequest(server string, agentId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "agentId", agentId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/profile/memories/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewSetProfileMemoryRequest calls the generic SetProfileMemory builder with application/json body
+func NewSetProfileMemoryRequest(server string, agentId string, body SetProfileMemoryJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewSetProfileMemoryRequestWithBody(server, agentId, "application/json", bodyReader)
+}
+
+// NewSetProfileMemoryRequestWithBody generates requests for SetProfileMemory with any type of body
+func NewSetProfileMemoryRequestWithBody(server string, agentId string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "agentId", agentId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/profile/memories/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewListOAuthProvidersRequest generates requests for ListOAuthProviders
+func NewListOAuthProvidersRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/profile/oauth/providers")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewDisconnectOAuthRequest generates requests for DisconnectOAuth
+func NewDisconnectOAuthRequest(server string, provider string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/profile/oauth/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewOauthCallbackRequest generates requests for OauthCallback
+func NewOauthCallbackRequest(server string, provider string, params *OauthCallbackParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/profile/oauth/%s/callback", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if queryFrag, err := runtime.StyleParamWithOptions("form", true, "code", params.Code, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+			return nil, err
+		} else {
+			for _, qp := range strings.Split(queryFrag, "&") {
+				rawQueryFragments = append(rawQueryFragments, qp)
+			}
+		}
+
+		if queryFrag, err := runtime.StyleParamWithOptions("form", true, "state", params.State, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+			return nil, err
+		} else {
+			for _, qp := range strings.Split(queryFrag, "&") {
+				rawQueryFragments = append(rawQueryFragments, qp)
+			}
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetOAuthConnectedRequest generates requests for GetOAuthConnected
+func NewGetOAuthConnectedRequest(server string, provider string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/profile/oauth/%s/connected", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewStartOAuthFlowRequest generates requests for StartOAuthFlow
+func NewStartOAuthFlowRequest(server string, provider string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/profile/oauth/%s/start", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewPollOAuthFlowRequest generates requests for PollOAuthFlow
+func NewPollOAuthFlowRequest(server string, provider string, flowID string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "flowID", flowID, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/profile/oauth/%s/status/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewChangePasswordRequest calls the generic ChangePassword builder with application/json body
+func NewChangePasswordRequest(server string, body ChangePasswordJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewChangePasswordRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewChangePasswordRequestWithBody generates requests for ChangePassword with any type of body
+func NewChangePasswordRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/profile/password")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewListProfileSkillsRequest generates requests for ListProfileSkills
 func NewListProfileSkillsRequest(server string) (*http.Request, error) {
 	var err error
@@ -3318,6 +4175,161 @@ func NewGetProfileSkillFileRequest(server string, skillId string, params *GetPro
 	if err != nil {
 		return nil, err
 	}
+
+	return req, nil
+}
+
+// NewSetProfileSoulRequest calls the generic SetProfileSoul builder with application/json body
+func NewSetProfileSoulRequest(server string, agentId string, body SetProfileSoulJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewSetProfileSoulRequestWithBody(server, agentId, "application/json", bodyReader)
+}
+
+// NewSetProfileSoulRequestWithBody generates requests for SetProfileSoul with any type of body
+func NewSetProfileSoulRequestWithBody(server string, agentId string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "agentId", agentId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/profile/soul/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewListVaultEntriesRequest generates requests for ListVaultEntries
+func NewListVaultEntriesRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/profile/vault")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewDeleteVaultEntryRequest generates requests for DeleteVaultEntry
+func NewDeleteVaultEntryRequest(server string, name string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/profile/vault/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewSetVaultEntryRequest calls the generic SetVaultEntry builder with application/json body
+func NewSetVaultEntryRequest(server string, name string, body SetVaultEntryJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewSetVaultEntryRequestWithBody(server, name, "application/json", bodyReader)
+}
+
+// NewSetVaultEntryRequestWithBody generates requests for SetVaultEntry with any type of body
+func NewSetVaultEntryRequestWithBody(server string, name string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/profile/vault/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -6259,6 +7271,51 @@ type ClientWithResponsesInterface interface {
 	// RemoveAgentUserWithResponse request
 	RemoveAgentUserWithResponse(ctx context.Context, id string, userId int64, reqEditors ...RequestEditorFn) (*RemoveAgentUserResponse, error)
 
+	// ListProfileIdentitiesWithResponse request
+	ListProfileIdentitiesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListProfileIdentitiesResponse, error)
+
+	// UnlinkProfileIdentityWithResponse request
+	UnlinkProfileIdentityWithResponse(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*UnlinkProfileIdentityResponse, error)
+
+	// GenerateLinkCodeWithBodyWithResponse request with any body
+	GenerateLinkCodeWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*GenerateLinkCodeResponse, error)
+
+	GenerateLinkCodeWithResponse(ctx context.Context, body GenerateLinkCodeJSONRequestBody, reqEditors ...RequestEditorFn) (*GenerateLinkCodeResponse, error)
+
+	// ListProfileMemoriesWithResponse request
+	ListProfileMemoriesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListProfileMemoriesResponse, error)
+
+	// DeleteProfileMemoryWithResponse request
+	DeleteProfileMemoryWithResponse(ctx context.Context, agentId string, reqEditors ...RequestEditorFn) (*DeleteProfileMemoryResponse, error)
+
+	// SetProfileMemoryWithBodyWithResponse request with any body
+	SetProfileMemoryWithBodyWithResponse(ctx context.Context, agentId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetProfileMemoryResponse, error)
+
+	SetProfileMemoryWithResponse(ctx context.Context, agentId string, body SetProfileMemoryJSONRequestBody, reqEditors ...RequestEditorFn) (*SetProfileMemoryResponse, error)
+
+	// ListOAuthProvidersWithResponse request
+	ListOAuthProvidersWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListOAuthProvidersResponse, error)
+
+	// DisconnectOAuthWithResponse request
+	DisconnectOAuthWithResponse(ctx context.Context, provider string, reqEditors ...RequestEditorFn) (*DisconnectOAuthResponse, error)
+
+	// OauthCallbackWithResponse request
+	OauthCallbackWithResponse(ctx context.Context, provider string, params *OauthCallbackParams, reqEditors ...RequestEditorFn) (*OauthCallbackResponse, error)
+
+	// GetOAuthConnectedWithResponse request
+	GetOAuthConnectedWithResponse(ctx context.Context, provider string, reqEditors ...RequestEditorFn) (*GetOAuthConnectedResponse, error)
+
+	// StartOAuthFlowWithResponse request
+	StartOAuthFlowWithResponse(ctx context.Context, provider string, reqEditors ...RequestEditorFn) (*StartOAuthFlowResponse, error)
+
+	// PollOAuthFlowWithResponse request
+	PollOAuthFlowWithResponse(ctx context.Context, provider string, flowID string, reqEditors ...RequestEditorFn) (*PollOAuthFlowResponse, error)
+
+	// ChangePasswordWithBodyWithResponse request with any body
+	ChangePasswordWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ChangePasswordResponse, error)
+
+	ChangePasswordWithResponse(ctx context.Context, body ChangePasswordJSONRequestBody, reqEditors ...RequestEditorFn) (*ChangePasswordResponse, error)
+
 	// ListProfileSkillsWithResponse request
 	ListProfileSkillsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListProfileSkillsResponse, error)
 
@@ -6286,6 +7343,22 @@ type ClientWithResponsesInterface interface {
 
 	// GetProfileSkillFileWithResponse request
 	GetProfileSkillFileWithResponse(ctx context.Context, skillId string, params *GetProfileSkillFileParams, reqEditors ...RequestEditorFn) (*GetProfileSkillFileResponse, error)
+
+	// SetProfileSoulWithBodyWithResponse request with any body
+	SetProfileSoulWithBodyWithResponse(ctx context.Context, agentId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetProfileSoulResponse, error)
+
+	SetProfileSoulWithResponse(ctx context.Context, agentId string, body SetProfileSoulJSONRequestBody, reqEditors ...RequestEditorFn) (*SetProfileSoulResponse, error)
+
+	// ListVaultEntriesWithResponse request
+	ListVaultEntriesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListVaultEntriesResponse, error)
+
+	// DeleteVaultEntryWithResponse request
+	DeleteVaultEntryWithResponse(ctx context.Context, name string, reqEditors ...RequestEditorFn) (*DeleteVaultEntryResponse, error)
+
+	// SetVaultEntryWithBodyWithResponse request with any body
+	SetVaultEntryWithBodyWithResponse(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetVaultEntryResponse, error)
+
+	SetVaultEntryWithResponse(ctx context.Context, name string, body SetVaultEntryJSONRequestBody, reqEditors ...RequestEditorFn) (*SetVaultEntryResponse, error)
 
 	// ListAuthUsersWithResponse request
 	ListAuthUsersWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListAuthUsersResponse, error)
@@ -7092,6 +8165,416 @@ func (r RemoveAgentUserResponse) ContentType() string {
 	return ""
 }
 
+type ListProfileIdentitiesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]externalRef0.Identity
+	JSON401      *externalRef0.Unauthorized
+}
+
+// Status returns HTTPResponse.Status
+func (r ListProfileIdentitiesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListProfileIdentitiesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListProfileIdentitiesResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type UnlinkProfileIdentityResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *map[string]interface{}
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r UnlinkProfileIdentityResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UnlinkProfileIdentityResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r UnlinkProfileIdentityResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GenerateLinkCodeResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.LinkCodeResponse
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+}
+
+// Status returns HTTPResponse.Status
+func (r GenerateLinkCodeResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GenerateLinkCodeResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GenerateLinkCodeResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListProfileMemoriesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]externalRef0.UserMemory
+	JSON401      *externalRef0.Unauthorized
+}
+
+// Status returns HTTPResponse.Status
+func (r ListProfileMemoriesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListProfileMemoriesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListProfileMemoriesResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type DeleteProfileMemoryResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *map[string]interface{}
+	JSON401      *externalRef0.Unauthorized
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteProfileMemoryResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteProfileMemoryResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r DeleteProfileMemoryResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type SetProfileMemoryResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *map[string]interface{}
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+}
+
+// Status returns HTTPResponse.Status
+func (r SetProfileMemoryResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SetProfileMemoryResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r SetProfileMemoryResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListOAuthProvidersResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]externalRef0.OAuthProviderStatus
+	JSON401      *externalRef0.Unauthorized
+}
+
+// Status returns HTTPResponse.Status
+func (r ListOAuthProvidersResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListOAuthProvidersResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListOAuthProvidersResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type DisconnectOAuthResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+}
+
+// Status returns HTTPResponse.Status
+func (r DisconnectOAuthResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DisconnectOAuthResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r DisconnectOAuthResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type OauthCallbackResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r OauthCallbackResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r OauthCallbackResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r OauthCallbackResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetOAuthConnectedResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.OAuthConnectedResponse
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+}
+
+// Status returns HTTPResponse.Status
+func (r GetOAuthConnectedResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetOAuthConnectedResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetOAuthConnectedResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type StartOAuthFlowResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.OAuthFlowStatus
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+}
+
+// Status returns HTTPResponse.Status
+func (r StartOAuthFlowResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r StartOAuthFlowResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r StartOAuthFlowResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type PollOAuthFlowResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.OAuthFlowStatus
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+}
+
+// Status returns HTTPResponse.Status
+func (r PollOAuthFlowResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PollOAuthFlowResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r PollOAuthFlowResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ChangePasswordResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *map[string]interface{}
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+}
+
+// Status returns HTTPResponse.Status
+func (r ChangePasswordResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ChangePasswordResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ChangePasswordResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 type ListProfileSkillsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -7350,6 +8833,130 @@ func (r GetProfileSkillFileResponse) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r GetProfileSkillFileResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type SetProfileSoulResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *map[string]interface{}
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+}
+
+// Status returns HTTPResponse.Status
+func (r SetProfileSoulResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SetProfileSoulResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r SetProfileSoulResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListVaultEntriesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]externalRef0.VaultEntry
+	JSON401      *externalRef0.Unauthorized
+}
+
+// Status returns HTTPResponse.Status
+func (r ListVaultEntriesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListVaultEntriesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListVaultEntriesResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type DeleteVaultEntryResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON401      *externalRef0.Unauthorized
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteVaultEntryResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteVaultEntryResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r DeleteVaultEntryResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type SetVaultEntryResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+}
+
+// Status returns HTTPResponse.Status
+func (r SetVaultEntryResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SetVaultEntryResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r SetVaultEntryResponse) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -9738,6 +11345,147 @@ func (c *ClientWithResponses) RemoveAgentUserWithResponse(ctx context.Context, i
 	return ParseRemoveAgentUserResponse(rsp)
 }
 
+// ListProfileIdentitiesWithResponse request returning *ListProfileIdentitiesResponse
+func (c *ClientWithResponses) ListProfileIdentitiesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListProfileIdentitiesResponse, error) {
+	rsp, err := c.ListProfileIdentities(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListProfileIdentitiesResponse(rsp)
+}
+
+// UnlinkProfileIdentityWithResponse request returning *UnlinkProfileIdentityResponse
+func (c *ClientWithResponses) UnlinkProfileIdentityWithResponse(ctx context.Context, id int64, reqEditors ...RequestEditorFn) (*UnlinkProfileIdentityResponse, error) {
+	rsp, err := c.UnlinkProfileIdentity(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUnlinkProfileIdentityResponse(rsp)
+}
+
+// GenerateLinkCodeWithBodyWithResponse request with arbitrary body returning *GenerateLinkCodeResponse
+func (c *ClientWithResponses) GenerateLinkCodeWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*GenerateLinkCodeResponse, error) {
+	rsp, err := c.GenerateLinkCodeWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGenerateLinkCodeResponse(rsp)
+}
+
+func (c *ClientWithResponses) GenerateLinkCodeWithResponse(ctx context.Context, body GenerateLinkCodeJSONRequestBody, reqEditors ...RequestEditorFn) (*GenerateLinkCodeResponse, error) {
+	rsp, err := c.GenerateLinkCode(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGenerateLinkCodeResponse(rsp)
+}
+
+// ListProfileMemoriesWithResponse request returning *ListProfileMemoriesResponse
+func (c *ClientWithResponses) ListProfileMemoriesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListProfileMemoriesResponse, error) {
+	rsp, err := c.ListProfileMemories(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListProfileMemoriesResponse(rsp)
+}
+
+// DeleteProfileMemoryWithResponse request returning *DeleteProfileMemoryResponse
+func (c *ClientWithResponses) DeleteProfileMemoryWithResponse(ctx context.Context, agentId string, reqEditors ...RequestEditorFn) (*DeleteProfileMemoryResponse, error) {
+	rsp, err := c.DeleteProfileMemory(ctx, agentId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteProfileMemoryResponse(rsp)
+}
+
+// SetProfileMemoryWithBodyWithResponse request with arbitrary body returning *SetProfileMemoryResponse
+func (c *ClientWithResponses) SetProfileMemoryWithBodyWithResponse(ctx context.Context, agentId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetProfileMemoryResponse, error) {
+	rsp, err := c.SetProfileMemoryWithBody(ctx, agentId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSetProfileMemoryResponse(rsp)
+}
+
+func (c *ClientWithResponses) SetProfileMemoryWithResponse(ctx context.Context, agentId string, body SetProfileMemoryJSONRequestBody, reqEditors ...RequestEditorFn) (*SetProfileMemoryResponse, error) {
+	rsp, err := c.SetProfileMemory(ctx, agentId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSetProfileMemoryResponse(rsp)
+}
+
+// ListOAuthProvidersWithResponse request returning *ListOAuthProvidersResponse
+func (c *ClientWithResponses) ListOAuthProvidersWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListOAuthProvidersResponse, error) {
+	rsp, err := c.ListOAuthProviders(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListOAuthProvidersResponse(rsp)
+}
+
+// DisconnectOAuthWithResponse request returning *DisconnectOAuthResponse
+func (c *ClientWithResponses) DisconnectOAuthWithResponse(ctx context.Context, provider string, reqEditors ...RequestEditorFn) (*DisconnectOAuthResponse, error) {
+	rsp, err := c.DisconnectOAuth(ctx, provider, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDisconnectOAuthResponse(rsp)
+}
+
+// OauthCallbackWithResponse request returning *OauthCallbackResponse
+func (c *ClientWithResponses) OauthCallbackWithResponse(ctx context.Context, provider string, params *OauthCallbackParams, reqEditors ...RequestEditorFn) (*OauthCallbackResponse, error) {
+	rsp, err := c.OauthCallback(ctx, provider, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseOauthCallbackResponse(rsp)
+}
+
+// GetOAuthConnectedWithResponse request returning *GetOAuthConnectedResponse
+func (c *ClientWithResponses) GetOAuthConnectedWithResponse(ctx context.Context, provider string, reqEditors ...RequestEditorFn) (*GetOAuthConnectedResponse, error) {
+	rsp, err := c.GetOAuthConnected(ctx, provider, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetOAuthConnectedResponse(rsp)
+}
+
+// StartOAuthFlowWithResponse request returning *StartOAuthFlowResponse
+func (c *ClientWithResponses) StartOAuthFlowWithResponse(ctx context.Context, provider string, reqEditors ...RequestEditorFn) (*StartOAuthFlowResponse, error) {
+	rsp, err := c.StartOAuthFlow(ctx, provider, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseStartOAuthFlowResponse(rsp)
+}
+
+// PollOAuthFlowWithResponse request returning *PollOAuthFlowResponse
+func (c *ClientWithResponses) PollOAuthFlowWithResponse(ctx context.Context, provider string, flowID string, reqEditors ...RequestEditorFn) (*PollOAuthFlowResponse, error) {
+	rsp, err := c.PollOAuthFlow(ctx, provider, flowID, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePollOAuthFlowResponse(rsp)
+}
+
+// ChangePasswordWithBodyWithResponse request with arbitrary body returning *ChangePasswordResponse
+func (c *ClientWithResponses) ChangePasswordWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ChangePasswordResponse, error) {
+	rsp, err := c.ChangePasswordWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseChangePasswordResponse(rsp)
+}
+
+func (c *ClientWithResponses) ChangePasswordWithResponse(ctx context.Context, body ChangePasswordJSONRequestBody, reqEditors ...RequestEditorFn) (*ChangePasswordResponse, error) {
+	rsp, err := c.ChangePassword(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseChangePasswordResponse(rsp)
+}
+
 // ListProfileSkillsWithResponse request returning *ListProfileSkillsResponse
 func (c *ClientWithResponses) ListProfileSkillsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListProfileSkillsResponse, error) {
 	rsp, err := c.ListProfileSkills(ctx, reqEditors...)
@@ -9824,6 +11572,58 @@ func (c *ClientWithResponses) GetProfileSkillFileWithResponse(ctx context.Contex
 		return nil, err
 	}
 	return ParseGetProfileSkillFileResponse(rsp)
+}
+
+// SetProfileSoulWithBodyWithResponse request with arbitrary body returning *SetProfileSoulResponse
+func (c *ClientWithResponses) SetProfileSoulWithBodyWithResponse(ctx context.Context, agentId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetProfileSoulResponse, error) {
+	rsp, err := c.SetProfileSoulWithBody(ctx, agentId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSetProfileSoulResponse(rsp)
+}
+
+func (c *ClientWithResponses) SetProfileSoulWithResponse(ctx context.Context, agentId string, body SetProfileSoulJSONRequestBody, reqEditors ...RequestEditorFn) (*SetProfileSoulResponse, error) {
+	rsp, err := c.SetProfileSoul(ctx, agentId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSetProfileSoulResponse(rsp)
+}
+
+// ListVaultEntriesWithResponse request returning *ListVaultEntriesResponse
+func (c *ClientWithResponses) ListVaultEntriesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListVaultEntriesResponse, error) {
+	rsp, err := c.ListVaultEntries(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListVaultEntriesResponse(rsp)
+}
+
+// DeleteVaultEntryWithResponse request returning *DeleteVaultEntryResponse
+func (c *ClientWithResponses) DeleteVaultEntryWithResponse(ctx context.Context, name string, reqEditors ...RequestEditorFn) (*DeleteVaultEntryResponse, error) {
+	rsp, err := c.DeleteVaultEntry(ctx, name, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteVaultEntryResponse(rsp)
+}
+
+// SetVaultEntryWithBodyWithResponse request with arbitrary body returning *SetVaultEntryResponse
+func (c *ClientWithResponses) SetVaultEntryWithBodyWithResponse(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetVaultEntryResponse, error) {
+	rsp, err := c.SetVaultEntryWithBody(ctx, name, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSetVaultEntryResponse(rsp)
+}
+
+func (c *ClientWithResponses) SetVaultEntryWithResponse(ctx context.Context, name string, body SetVaultEntryJSONRequestBody, reqEditors ...RequestEditorFn) (*SetVaultEntryResponse, error) {
+	rsp, err := c.SetVaultEntry(ctx, name, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSetVaultEntryResponse(rsp)
 }
 
 // ListAuthUsersWithResponse request returning *ListAuthUsersResponse
@@ -11384,6 +13184,481 @@ func ParseRemoveAgentUserResponse(rsp *http.Response) (*RemoveAgentUserResponse,
 	return response, nil
 }
 
+// ParseListProfileIdentitiesResponse parses an HTTP response from a ListProfileIdentitiesWithResponse call
+func ParseListProfileIdentitiesResponse(rsp *http.Response) (*ListProfileIdentitiesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListProfileIdentitiesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []externalRef0.Identity
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUnlinkProfileIdentityResponse parses an HTTP response from a UnlinkProfileIdentityWithResponse call
+func ParseUnlinkProfileIdentityResponse(rsp *http.Response) (*UnlinkProfileIdentityResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UnlinkProfileIdentityResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGenerateLinkCodeResponse parses an HTTP response from a GenerateLinkCodeWithResponse call
+func ParseGenerateLinkCodeResponse(rsp *http.Response) (*GenerateLinkCodeResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GenerateLinkCodeResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.LinkCodeResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListProfileMemoriesResponse parses an HTTP response from a ListProfileMemoriesWithResponse call
+func ParseListProfileMemoriesResponse(rsp *http.Response) (*ListProfileMemoriesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListProfileMemoriesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []externalRef0.UserMemory
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteProfileMemoryResponse parses an HTTP response from a DeleteProfileMemoryWithResponse call
+func ParseDeleteProfileMemoryResponse(rsp *http.Response) (*DeleteProfileMemoryResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteProfileMemoryResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseSetProfileMemoryResponse parses an HTTP response from a SetProfileMemoryWithResponse call
+func ParseSetProfileMemoryResponse(rsp *http.Response) (*SetProfileMemoryResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SetProfileMemoryResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListOAuthProvidersResponse parses an HTTP response from a ListOAuthProvidersWithResponse call
+func ParseListOAuthProvidersResponse(rsp *http.Response) (*ListOAuthProvidersResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListOAuthProvidersResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []externalRef0.OAuthProviderStatus
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDisconnectOAuthResponse parses an HTTP response from a DisconnectOAuthWithResponse call
+func ParseDisconnectOAuthResponse(rsp *http.Response) (*DisconnectOAuthResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DisconnectOAuthResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseOauthCallbackResponse parses an HTTP response from a OauthCallbackWithResponse call
+func ParseOauthCallbackResponse(rsp *http.Response) (*OauthCallbackResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &OauthCallbackResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseGetOAuthConnectedResponse parses an HTTP response from a GetOAuthConnectedWithResponse call
+func ParseGetOAuthConnectedResponse(rsp *http.Response) (*GetOAuthConnectedResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetOAuthConnectedResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.OAuthConnectedResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseStartOAuthFlowResponse parses an HTTP response from a StartOAuthFlowWithResponse call
+func ParseStartOAuthFlowResponse(rsp *http.Response) (*StartOAuthFlowResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &StartOAuthFlowResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.OAuthFlowStatus
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePollOAuthFlowResponse parses an HTTP response from a PollOAuthFlowWithResponse call
+func ParsePollOAuthFlowResponse(rsp *http.Response) (*PollOAuthFlowResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PollOAuthFlowResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.OAuthFlowStatus
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseChangePasswordResponse parses an HTTP response from a ChangePasswordWithResponse call
+func ParseChangePasswordResponse(rsp *http.Response) (*ChangePasswordResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ChangePasswordResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseListProfileSkillsResponse parses an HTTP response from a ListProfileSkillsWithResponse call
 func ParseListProfileSkillsResponse(rsp *http.Response) (*ListProfileSkillsResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -11718,6 +13993,138 @@ func ParseGetProfileSkillFileResponse(rsp *http.Response) (*GetProfileSkillFileR
 			return nil, err
 		}
 		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseSetProfileSoulResponse parses an HTTP response from a SetProfileSoulWithResponse call
+func ParseSetProfileSoulResponse(rsp *http.Response) (*SetProfileSoulResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SetProfileSoulResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListVaultEntriesResponse parses an HTTP response from a ListVaultEntriesWithResponse call
+func ParseListVaultEntriesResponse(rsp *http.Response) (*ListVaultEntriesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListVaultEntriesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []externalRef0.VaultEntry
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteVaultEntryResponse parses an HTTP response from a DeleteVaultEntryWithResponse call
+func ParseDeleteVaultEntryResponse(rsp *http.Response) (*DeleteVaultEntryResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteVaultEntryResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseSetVaultEntryResponse parses an HTTP response from a SetVaultEntryWithResponse call
+func ParseSetVaultEntryResponse(rsp *http.Response) (*SetVaultEntryResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SetVaultEntryResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
 
 	}
 

--- a/api/client/gen.go
+++ b/api/client/gen.go
@@ -39,6 +39,15 @@ type BuiltinResourceDetail = externalRef0.BuiltinResourceDetail
 // CachedModel defines model for CachedModel.
 type CachedModel = externalRef0.CachedModel
 
+// Channel defines model for Channel.
+type Channel = externalRef0.Channel
+
+// ChannelList defines model for ChannelList.
+type ChannelList = externalRef0.ChannelList
+
+// ChannelWriteRequest defines model for ChannelWriteRequest.
+type ChannelWriteRequest = externalRef0.ChannelWriteRequest
+
 // CreateFeedRequest defines model for CreateFeedRequest.
 type CreateFeedRequest = externalRef0.CreateFeedRequest
 
@@ -78,6 +87,12 @@ type JobInput = externalRef0.JobInput
 // JobList defines model for JobList.
 type JobList = externalRef0.JobList
 
+// PublicChannel defines model for PublicChannel.
+type PublicChannel = externalRef0.PublicChannel
+
+// PublicChannelList defines model for PublicChannelList.
+type PublicChannelList = externalRef0.PublicChannelList
+
 // SaveArticleRequest defines model for SaveArticleRequest.
 type SaveArticleRequest = externalRef0.SaveArticleRequest
 
@@ -99,8 +114,20 @@ type UpdateFeedEntryRequest = externalRef0.UpdateFeedEntryRequest
 // UpdateFeedRequest defines model for UpdateFeedRequest.
 type UpdateFeedRequest = externalRef0.UpdateFeedRequest
 
+// WeixinQRCode defines model for WeixinQRCode.
+type WeixinQRCode = externalRef0.WeixinQRCode
+
+// WeixinQRStatus defines model for WeixinQRStatus.
+type WeixinQRStatus = externalRef0.WeixinQRStatus
+
 // bearerAuthContextKey is the context key for BearerAuth security scheme
 type bearerAuthContextKey string
+
+// PollWeixinQRStatusParams defines parameters for PollWeixinQRStatus.
+type PollWeixinQRStatusParams struct {
+	// Qrcode QR code token from startWeixinQR
+	Qrcode string `form:"qrcode" json:"qrcode"`
+}
 
 // ListArticlesParams defines parameters for ListArticles.
 type ListArticlesParams struct {
@@ -138,6 +165,12 @@ type ListFeedEntriesParams struct {
 type PollFeedParams struct {
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
 }
+
+// CreateChannelJSONRequestBody defines body for CreateChannel for application/json ContentType.
+type CreateChannelJSONRequestBody = externalRef0.ChannelWriteRequest
+
+// UpdateChannelJSONRequestBody defines body for UpdateChannel for application/json ContentType.
+type UpdateChannelJSONRequestBody = externalRef0.ChannelWriteRequest
 
 // SaveArticleJSONRequestBody defines body for SaveArticle for application/json ContentType.
 type SaveArticleJSONRequestBody = externalRef0.SaveArticleRequest
@@ -239,6 +272,34 @@ type ClientInterface interface {
 	// GetBuiltinResource request
 	GetBuiltinResource(ctx context.Context, kind string, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ListChannels request
+	ListChannels(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateChannelWithBody request with any body
+	CreateChannelWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateChannel(ctx context.Context, body CreateChannelJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListPublicChannels request
+	ListPublicChannels(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// StartWeixinQR request
+	StartWeixinQR(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PollWeixinQRStatus request
+	PollWeixinQRStatus(ctx context.Context, params *PollWeixinQRStatusParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteChannel request
+	DeleteChannel(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetChannel request
+	GetChannel(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateChannelWithBody request with any body
+	UpdateChannelWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateChannel(ctx context.Context, id string, body UpdateChannelJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ListModels request
 	ListModels(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -334,6 +395,126 @@ func (c *Client) ListBuiltinResources(ctx context.Context, kind string, reqEdito
 
 func (c *Client) GetBuiltinResource(ctx context.Context, kind string, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetBuiltinResourceRequest(c.Server, kind, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListChannels(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListChannelsRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateChannelWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateChannelRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateChannel(ctx context.Context, body CreateChannelJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateChannelRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListPublicChannels(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListPublicChannelsRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) StartWeixinQR(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewStartWeixinQRRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PollWeixinQRStatus(ctx context.Context, params *PollWeixinQRStatusParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPollWeixinQRStatusRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteChannel(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteChannelRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetChannel(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetChannelRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateChannelWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateChannelRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateChannel(ctx context.Context, id string, body UpdateChannelJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateChannelRequest(c.Server, id, body)
 	if err != nil {
 		return nil, err
 	}
@@ -763,6 +944,292 @@ func NewGetBuiltinResourceRequest(server string, kind string, id string) (*http.
 	if err != nil {
 		return nil, err
 	}
+
+	return req, nil
+}
+
+// NewListChannelsRequest generates requests for ListChannels
+func NewListChannelsRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/channels")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateChannelRequest calls the generic CreateChannel builder with application/json body
+func NewCreateChannelRequest(server string, body CreateChannelJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateChannelRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewCreateChannelRequestWithBody generates requests for CreateChannel with any type of body
+func NewCreateChannelRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/channels")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewListPublicChannelsRequest generates requests for ListPublicChannels
+func NewListPublicChannelsRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/channels/public")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewStartWeixinQRRequest generates requests for StartWeixinQR
+func NewStartWeixinQRRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/channels/weixin/qr")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewPollWeixinQRStatusRequest generates requests for PollWeixinQRStatus
+func NewPollWeixinQRStatusRequest(server string, params *PollWeixinQRStatusParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/channels/weixin/qr/status")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if queryFrag, err := runtime.StyleParamWithOptions("form", true, "qrcode", params.Qrcode, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+			return nil, err
+		} else {
+			for _, qp := range strings.Split(queryFrag, "&") {
+				rawQueryFragments = append(rawQueryFragments, qp)
+			}
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewDeleteChannelRequest generates requests for DeleteChannel
+func NewDeleteChannelRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/channels/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetChannelRequest generates requests for GetChannel
+func NewGetChannelRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/channels/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateChannelRequest calls the generic UpdateChannel builder with application/json body
+func NewUpdateChannelRequest(server string, id string, body UpdateChannelJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateChannelRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewUpdateChannelRequestWithBody generates requests for UpdateChannel with any type of body
+func NewUpdateChannelRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/channels/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -1806,6 +2273,34 @@ type ClientWithResponsesInterface interface {
 	// GetBuiltinResourceWithResponse request
 	GetBuiltinResourceWithResponse(ctx context.Context, kind string, id string, reqEditors ...RequestEditorFn) (*GetBuiltinResourceResponse, error)
 
+	// ListChannelsWithResponse request
+	ListChannelsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListChannelsResponse, error)
+
+	// CreateChannelWithBodyWithResponse request with any body
+	CreateChannelWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateChannelResponse, error)
+
+	CreateChannelWithResponse(ctx context.Context, body CreateChannelJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateChannelResponse, error)
+
+	// ListPublicChannelsWithResponse request
+	ListPublicChannelsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListPublicChannelsResponse, error)
+
+	// StartWeixinQRWithResponse request
+	StartWeixinQRWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*StartWeixinQRResponse, error)
+
+	// PollWeixinQRStatusWithResponse request
+	PollWeixinQRStatusWithResponse(ctx context.Context, params *PollWeixinQRStatusParams, reqEditors ...RequestEditorFn) (*PollWeixinQRStatusResponse, error)
+
+	// DeleteChannelWithResponse request
+	DeleteChannelWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*DeleteChannelResponse, error)
+
+	// GetChannelWithResponse request
+	GetChannelWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetChannelResponse, error)
+
+	// UpdateChannelWithBodyWithResponse request with any body
+	UpdateChannelWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateChannelResponse, error)
+
+	UpdateChannelWithResponse(ctx context.Context, id string, body UpdateChannelJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateChannelResponse, error)
+
 	// ListModelsWithResponse request
 	ListModelsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListModelsResponse, error)
 
@@ -1945,6 +2440,267 @@ func (r GetBuiltinResourceResponse) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r GetBuiltinResourceResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListChannelsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.ChannelList
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r ListChannelsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListChannelsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListChannelsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type CreateChannelResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *externalRef0.Channel
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateChannelResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateChannelResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r CreateChannelResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListPublicChannelsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.PublicChannelList
+	JSON401      *externalRef0.Unauthorized
+}
+
+// Status returns HTTPResponse.Status
+func (r ListPublicChannelsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListPublicChannelsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListPublicChannelsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type StartWeixinQRResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.WeixinQRCode
+	JSON401      *externalRef0.Unauthorized
+	JSON502      *externalRef0.Error
+}
+
+// Status returns HTTPResponse.Status
+func (r StartWeixinQRResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r StartWeixinQRResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r StartWeixinQRResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type PollWeixinQRStatusResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.WeixinQRStatus
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+	JSON502      *externalRef0.Error
+}
+
+// Status returns HTTPResponse.Status
+func (r PollWeixinQRStatusResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PollWeixinQRStatusResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r PollWeixinQRStatusResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type DeleteChannelResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.DeleteResult
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteChannelResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteChannelResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r DeleteChannelResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetChannelResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.Channel
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r GetChannelResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetChannelResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetChannelResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type UpdateChannelResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.Channel
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateChannelResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateChannelResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r UpdateChannelResponse) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -2675,6 +3431,94 @@ func (c *ClientWithResponses) GetBuiltinResourceWithResponse(ctx context.Context
 	return ParseGetBuiltinResourceResponse(rsp)
 }
 
+// ListChannelsWithResponse request returning *ListChannelsResponse
+func (c *ClientWithResponses) ListChannelsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListChannelsResponse, error) {
+	rsp, err := c.ListChannels(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListChannelsResponse(rsp)
+}
+
+// CreateChannelWithBodyWithResponse request with arbitrary body returning *CreateChannelResponse
+func (c *ClientWithResponses) CreateChannelWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateChannelResponse, error) {
+	rsp, err := c.CreateChannelWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateChannelResponse(rsp)
+}
+
+func (c *ClientWithResponses) CreateChannelWithResponse(ctx context.Context, body CreateChannelJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateChannelResponse, error) {
+	rsp, err := c.CreateChannel(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateChannelResponse(rsp)
+}
+
+// ListPublicChannelsWithResponse request returning *ListPublicChannelsResponse
+func (c *ClientWithResponses) ListPublicChannelsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListPublicChannelsResponse, error) {
+	rsp, err := c.ListPublicChannels(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListPublicChannelsResponse(rsp)
+}
+
+// StartWeixinQRWithResponse request returning *StartWeixinQRResponse
+func (c *ClientWithResponses) StartWeixinQRWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*StartWeixinQRResponse, error) {
+	rsp, err := c.StartWeixinQR(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseStartWeixinQRResponse(rsp)
+}
+
+// PollWeixinQRStatusWithResponse request returning *PollWeixinQRStatusResponse
+func (c *ClientWithResponses) PollWeixinQRStatusWithResponse(ctx context.Context, params *PollWeixinQRStatusParams, reqEditors ...RequestEditorFn) (*PollWeixinQRStatusResponse, error) {
+	rsp, err := c.PollWeixinQRStatus(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePollWeixinQRStatusResponse(rsp)
+}
+
+// DeleteChannelWithResponse request returning *DeleteChannelResponse
+func (c *ClientWithResponses) DeleteChannelWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*DeleteChannelResponse, error) {
+	rsp, err := c.DeleteChannel(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteChannelResponse(rsp)
+}
+
+// GetChannelWithResponse request returning *GetChannelResponse
+func (c *ClientWithResponses) GetChannelWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetChannelResponse, error) {
+	rsp, err := c.GetChannel(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetChannelResponse(rsp)
+}
+
+// UpdateChannelWithBodyWithResponse request with arbitrary body returning *UpdateChannelResponse
+func (c *ClientWithResponses) UpdateChannelWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateChannelResponse, error) {
+	rsp, err := c.UpdateChannelWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateChannelResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateChannelWithResponse(ctx context.Context, id string, body UpdateChannelJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateChannelResponse, error) {
+	rsp, err := c.UpdateChannel(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateChannelResponse(rsp)
+}
+
 // ListModelsWithResponse request returning *ListModelsResponse
 func (c *ClientWithResponses) ListModelsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListModelsResponse, error) {
 	rsp, err := c.ListModels(ctx, reqEditors...)
@@ -2996,6 +3840,361 @@ func ParseGetBuiltinResourceResponse(rsp *http.Response) (*GetBuiltinResourceRes
 			return nil, err
 		}
 		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListChannelsResponse parses an HTTP response from a ListChannelsWithResponse call
+func ParseListChannelsResponse(rsp *http.Response) (*ListChannelsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListChannelsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.ChannelList
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateChannelResponse parses an HTTP response from a CreateChannelWithResponse call
+func ParseCreateChannelResponse(rsp *http.Response) (*CreateChannelResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateChannelResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest externalRef0.Channel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListPublicChannelsResponse parses an HTTP response from a ListPublicChannelsWithResponse call
+func ParseListPublicChannelsResponse(rsp *http.Response) (*ListPublicChannelsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListPublicChannelsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.PublicChannelList
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseStartWeixinQRResponse parses an HTTP response from a StartWeixinQRWithResponse call
+func ParseStartWeixinQRResponse(rsp *http.Response) (*StartWeixinQRResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &StartWeixinQRResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.WeixinQRCode
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 502:
+		var dest externalRef0.Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON502 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePollWeixinQRStatusResponse parses an HTTP response from a PollWeixinQRStatusWithResponse call
+func ParsePollWeixinQRStatusResponse(rsp *http.Response) (*PollWeixinQRStatusResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PollWeixinQRStatusResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.WeixinQRStatus
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 502:
+		var dest externalRef0.Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON502 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteChannelResponse parses an HTTP response from a DeleteChannelWithResponse call
+func ParseDeleteChannelResponse(rsp *http.Response) (*DeleteChannelResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteChannelResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.DeleteResult
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetChannelResponse parses an HTTP response from a GetChannelWithResponse call
+func ParseGetChannelResponse(rsp *http.Response) (*GetChannelResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetChannelResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.Channel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateChannelResponse parses an HTTP response from a UpdateChannelWithResponse call
+func ParseUpdateChannelResponse(rsp *http.Response) (*UpdateChannelResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateChannelResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.Channel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
 		var dest externalRef0.NotFound

--- a/api/client/gen.go
+++ b/api/client/gen.go
@@ -73,6 +73,12 @@ type CreateFeedRequest = externalRef0.CreateFeedRequest
 // CreateSessionRequest defines model for CreateSessionRequest.
 type CreateSessionRequest = externalRef0.CreateSessionRequest
 
+// CreateSkillRequest defines model for CreateSkillRequest.
+type CreateSkillRequest = externalRef0.CreateSkillRequest
+
+// DeleteFileResult defines model for DeleteFileResult.
+type DeleteFileResult = externalRef0.DeleteFileResult
+
 // DeleteResult defines model for DeleteResult.
 type DeleteResult = externalRef0.DeleteResult
 
@@ -106,6 +112,9 @@ type FeedPollResult = externalRef0.FeedPollResult
 // FetchModelsRequest defines model for FetchModelsRequest.
 type FetchModelsRequest = externalRef0.FetchModelsRequest
 
+// GlobalInstallSkillRequest defines model for GlobalInstallSkillRequest.
+type GlobalInstallSkillRequest = externalRef0.GlobalInstallSkillRequest
+
 // InstallSkillRequest defines model for InstallSkillRequest.
 type InstallSkillRequest = externalRef0.InstallSkillRequest
 
@@ -117,6 +126,9 @@ type JobInput = externalRef0.JobInput
 
 // JobList defines model for JobList.
 type JobList = externalRef0.JobList
+
+// ProfileInstallSkillRequest defines model for ProfileInstallSkillRequest.
+type ProfileInstallSkillRequest = externalRef0.ProfileInstallSkillRequest
 
 // Provider defines model for Provider.
 type Provider = externalRef0.Provider
@@ -160,8 +172,17 @@ type SessionDetail = externalRef0.SessionDetail
 // Skill defines model for Skill.
 type Skill = externalRef0.Skill
 
+// SkillFileResponse defines model for SkillFileResponse.
+type SkillFileResponse = externalRef0.SkillFileResponse
+
 // SkillList defines model for SkillList.
 type SkillList = externalRef0.SkillList
+
+// SkillSearchResult defines model for SkillSearchResult.
+type SkillSearchResult = externalRef0.SkillSearchResult
+
+// SkillSearchResultList defines model for SkillSearchResultList.
+type SkillSearchResultList = externalRef0.SkillSearchResultList
 
 // SkillUploadResult defines model for SkillUploadResult.
 type SkillUploadResult = externalRef0.SkillUploadResult
@@ -202,6 +223,21 @@ type bearerAuthContextKey string
 // UploadAgentSkillMultipartBody defines parameters for UploadAgentSkill.
 type UploadAgentSkillMultipartBody struct {
 	File *openapi_types.File `json:"file,omitempty"`
+}
+
+// UploadProfileSkillMultipartBody defines parameters for UploadProfileSkill.
+type UploadProfileSkillMultipartBody struct {
+	File *openapi_types.File `json:"file,omitempty"`
+}
+
+// DeleteProfileSkillFileParams defines parameters for DeleteProfileSkillFile.
+type DeleteProfileSkillFileParams struct {
+	Path string `form:"path" json:"path"`
+}
+
+// GetProfileSkillFileParams defines parameters for GetProfileSkillFile.
+type GetProfileSkillFileParams struct {
+	Path string `form:"path" json:"path"`
 }
 
 // PollWeixinQRStatusParams defines parameters for PollWeixinQRStatus.
@@ -265,6 +301,22 @@ type GetSessionMessagesParams struct {
 	Skip *int `form:"skip,omitempty" json:"skip,omitempty"`
 }
 
+// SearchSkillsParams defines parameters for SearchSkills.
+type SearchSkillsParams struct {
+	Q     string `form:"q" json:"q"`
+	Limit *int   `form:"limit,omitempty" json:"limit,omitempty"`
+}
+
+// DeleteSkillFileParams defines parameters for DeleteSkillFile.
+type DeleteSkillFileParams struct {
+	Path string `form:"path" json:"path"`
+}
+
+// GetSkillFileParams defines parameters for GetSkillFile.
+type GetSkillFileParams struct {
+	Path string `form:"path" json:"path"`
+}
+
 // CreateAgentJSONRequestBody defines body for CreateAgent for application/json ContentType.
 type CreateAgentJSONRequestBody = externalRef0.CreateAgentRequest
 
@@ -282,6 +334,15 @@ type UpdateAgentSkillJSONRequestBody = externalRef0.UpdateSkillRequest
 
 // AssignAgentUserJSONRequestBody defines body for AssignAgentUser for application/json ContentType.
 type AssignAgentUserJSONRequestBody = externalRef0.AssignAgentUserRequest
+
+// InstallProfileSkillJSONRequestBody defines body for InstallProfileSkill for application/json ContentType.
+type InstallProfileSkillJSONRequestBody = externalRef0.ProfileInstallSkillRequest
+
+// UploadProfileSkillMultipartRequestBody defines body for UploadProfileSkill for multipart/form-data ContentType.
+type UploadProfileSkillMultipartRequestBody UploadProfileSkillMultipartBody
+
+// UpdateProfileSkillJSONRequestBody defines body for UpdateProfileSkill for application/json ContentType.
+type UpdateProfileSkillJSONRequestBody = externalRef0.UpdateSkillRequest
 
 // CreateChannelJSONRequestBody defines body for CreateChannel for application/json ContentType.
 type CreateChannelJSONRequestBody = externalRef0.ChannelWriteRequest
@@ -324,6 +385,15 @@ type CreateSessionJSONRequestBody = externalRef0.CreateSessionRequest
 
 // SendSessionMessageJSONRequestBody defines body for SendSessionMessage for application/json ContentType.
 type SendSessionMessageJSONRequestBody = externalRef0.SendMessageRequest
+
+// CreateSkillJSONRequestBody defines body for CreateSkill for application/json ContentType.
+type CreateSkillJSONRequestBody = externalRef0.CreateSkillRequest
+
+// InstallSkillJSONRequestBody defines body for InstallSkill for application/json ContentType.
+type InstallSkillJSONRequestBody = externalRef0.GlobalInstallSkillRequest
+
+// UpdateSkillJSONRequestBody defines body for UpdateSkill for application/json ContentType.
+type UpdateSkillJSONRequestBody = externalRef0.UpdateSkillRequest
 
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(ctx context.Context, req *http.Request) error
@@ -458,6 +528,34 @@ type ClientInterface interface {
 
 	// RemoveAgentUser request
 	RemoveAgentUser(ctx context.Context, id string, userId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListProfileSkills request
+	ListProfileSkills(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// InstallProfileSkillWithBody request with any body
+	InstallProfileSkillWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	InstallProfileSkill(ctx context.Context, body InstallProfileSkillJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UploadProfileSkillWithBody request with any body
+	UploadProfileSkillWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteProfileSkill request
+	DeleteProfileSkill(ctx context.Context, skillId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetProfileSkill request
+	GetProfileSkill(ctx context.Context, skillId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateProfileSkillWithBody request with any body
+	UpdateProfileSkillWithBody(ctx context.Context, skillId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateProfileSkill(ctx context.Context, skillId string, body UpdateProfileSkillJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteProfileSkillFile request
+	DeleteProfileSkillFile(ctx context.Context, skillId string, params *DeleteProfileSkillFileParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetProfileSkillFile request
+	GetProfileSkillFile(ctx context.Context, skillId string, params *GetProfileSkillFileParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListBuiltinResources request
 	ListBuiltinResources(ctx context.Context, kind string, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -621,6 +719,39 @@ type ClientInterface interface {
 
 	// GetSessionSystemPrompt request
 	GetSessionSystemPrompt(ctx context.Context, sessionID string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListSkills request
+	ListSkills(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateSkillWithBody request with any body
+	CreateSkillWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateSkill(ctx context.Context, body CreateSkillJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// InstallSkillWithBody request with any body
+	InstallSkillWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	InstallSkill(ctx context.Context, body InstallSkillJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SearchSkills request
+	SearchSkills(ctx context.Context, params *SearchSkillsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteSkill request
+	DeleteSkill(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetSkill request
+	GetSkill(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateSkillWithBody request with any body
+	UpdateSkillWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateSkill(ctx context.Context, id string, body UpdateSkillJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteSkillFile request
+	DeleteSkillFile(ctx context.Context, id string, params *DeleteSkillFileParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetSkillFile request
+	GetSkillFile(ctx context.Context, id string, params *GetSkillFileParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListTools request
 	ListTools(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -880,6 +1011,126 @@ func (c *Client) AssignAgentUser(ctx context.Context, id string, body AssignAgen
 
 func (c *Client) RemoveAgentUser(ctx context.Context, id string, userId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewRemoveAgentUserRequest(c.Server, id, userId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListProfileSkills(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListProfileSkillsRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) InstallProfileSkillWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewInstallProfileSkillRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) InstallProfileSkill(ctx context.Context, body InstallProfileSkillJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewInstallProfileSkillRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UploadProfileSkillWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUploadProfileSkillRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteProfileSkill(ctx context.Context, skillId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteProfileSkillRequest(c.Server, skillId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetProfileSkill(ctx context.Context, skillId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetProfileSkillRequest(c.Server, skillId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateProfileSkillWithBody(ctx context.Context, skillId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateProfileSkillRequestWithBody(c.Server, skillId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateProfileSkill(ctx context.Context, skillId string, body UpdateProfileSkillJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateProfileSkillRequest(c.Server, skillId, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteProfileSkillFile(ctx context.Context, skillId string, params *DeleteProfileSkillFileParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteProfileSkillFileRequest(c.Server, skillId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetProfileSkillFile(ctx context.Context, skillId string, params *GetProfileSkillFileParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetProfileSkillFileRequest(c.Server, skillId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -1598,6 +1849,150 @@ func (c *Client) GetSessionSystemPrompt(ctx context.Context, sessionID string, r
 	return c.Client.Do(req)
 }
 
+func (c *Client) ListSkills(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListSkillsRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateSkillWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateSkillRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateSkill(ctx context.Context, body CreateSkillJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateSkillRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) InstallSkillWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewInstallSkillRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) InstallSkill(ctx context.Context, body InstallSkillJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewInstallSkillRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SearchSkills(ctx context.Context, params *SearchSkillsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSearchSkillsRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteSkill(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteSkillRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetSkill(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetSkillRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateSkillWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateSkillRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateSkill(ctx context.Context, id string, body UpdateSkillJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateSkillRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteSkillFile(ctx context.Context, id string, params *DeleteSkillFileParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteSkillFileRequest(c.Server, id, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetSkillFile(ctx context.Context, id string, params *GetSkillFileParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetSkillFileRequest(c.Server, id, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) ListTools(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewListToolsRequest(c.Server)
 	if err != nil {
@@ -2283,6 +2678,331 @@ func NewRemoveAgentUserRequest(server string, id string, userId int64) (*http.Re
 	}
 
 	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewListProfileSkillsRequest generates requests for ListProfileSkills
+func NewListProfileSkillsRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/profile/skills")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewInstallProfileSkillRequest calls the generic InstallProfileSkill builder with application/json body
+func NewInstallProfileSkillRequest(server string, body InstallProfileSkillJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewInstallProfileSkillRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewInstallProfileSkillRequestWithBody generates requests for InstallProfileSkill with any type of body
+func NewInstallProfileSkillRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/profile/skills/install")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewUploadProfileSkillRequestWithBody generates requests for UploadProfileSkill with any type of body
+func NewUploadProfileSkillRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/profile/skills/upload")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteProfileSkillRequest generates requests for DeleteProfileSkill
+func NewDeleteProfileSkillRequest(server string, skillId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "skillId", skillId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/profile/skills/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetProfileSkillRequest generates requests for GetProfileSkill
+func NewGetProfileSkillRequest(server string, skillId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "skillId", skillId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/profile/skills/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateProfileSkillRequest calls the generic UpdateProfileSkill builder with application/json body
+func NewUpdateProfileSkillRequest(server string, skillId string, body UpdateProfileSkillJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateProfileSkillRequestWithBody(server, skillId, "application/json", bodyReader)
+}
+
+// NewUpdateProfileSkillRequestWithBody generates requests for UpdateProfileSkill with any type of body
+func NewUpdateProfileSkillRequestWithBody(server string, skillId string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "skillId", skillId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/profile/skills/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteProfileSkillFileRequest generates requests for DeleteProfileSkillFile
+func NewDeleteProfileSkillFileRequest(server string, skillId string, params *DeleteProfileSkillFileParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "skillId", skillId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/profile/skills/%s/file", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if queryFrag, err := runtime.StyleParamWithOptions("form", true, "path", params.Path, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+			return nil, err
+		} else {
+			for _, qp := range strings.Split(queryFrag, "&") {
+				rawQueryFragments = append(rawQueryFragments, qp)
+			}
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetProfileSkillFileRequest generates requests for GetProfileSkillFile
+func NewGetProfileSkillFileRequest(server string, skillId string, params *GetProfileSkillFileParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "skillId", skillId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/profile/skills/%s/file", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if queryFrag, err := runtime.StyleParamWithOptions("form", true, "path", params.Path, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+			return nil, err
+		} else {
+			for _, qp := range strings.Split(queryFrag, "&") {
+				rawQueryFragments = append(rawQueryFragments, qp)
+			}
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -4198,6 +4918,404 @@ func NewGetSessionSystemPromptRequest(server string, sessionID string) (*http.Re
 	return req, nil
 }
 
+// NewListSkillsRequest generates requests for ListSkills
+func NewListSkillsRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/skills")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateSkillRequest calls the generic CreateSkill builder with application/json body
+func NewCreateSkillRequest(server string, body CreateSkillJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateSkillRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewCreateSkillRequestWithBody generates requests for CreateSkill with any type of body
+func NewCreateSkillRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/skills")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewInstallSkillRequest calls the generic InstallSkill builder with application/json body
+func NewInstallSkillRequest(server string, body InstallSkillJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewInstallSkillRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewInstallSkillRequestWithBody generates requests for InstallSkill with any type of body
+func NewInstallSkillRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/skills/install")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewSearchSkillsRequest generates requests for SearchSkills
+func NewSearchSkillsRequest(server string, params *SearchSkillsParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/skills/search")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if queryFrag, err := runtime.StyleParamWithOptions("form", true, "q", params.Q, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+			return nil, err
+		} else {
+			for _, qp := range strings.Split(queryFrag, "&") {
+				rawQueryFragments = append(rawQueryFragments, qp)
+			}
+		}
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "limit", *params.Limit, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewDeleteSkillRequest generates requests for DeleteSkill
+func NewDeleteSkillRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/skills/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetSkillRequest generates requests for GetSkill
+func NewGetSkillRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/skills/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateSkillRequest calls the generic UpdateSkill builder with application/json body
+func NewUpdateSkillRequest(server string, id string, body UpdateSkillJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateSkillRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewUpdateSkillRequestWithBody generates requests for UpdateSkill with any type of body
+func NewUpdateSkillRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/skills/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteSkillFileRequest generates requests for DeleteSkillFile
+func NewDeleteSkillFileRequest(server string, id string, params *DeleteSkillFileParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/skills/%s/file", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if queryFrag, err := runtime.StyleParamWithOptions("form", true, "path", params.Path, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+			return nil, err
+		} else {
+			for _, qp := range strings.Split(queryFrag, "&") {
+				rawQueryFragments = append(rawQueryFragments, qp)
+			}
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetSkillFileRequest generates requests for GetSkillFile
+func NewGetSkillFileRequest(server string, id string, params *GetSkillFileParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/skills/%s/file", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if queryFrag, err := runtime.StyleParamWithOptions("form", true, "path", params.Path, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+			return nil, err
+		} else {
+			for _, qp := range strings.Split(queryFrag, "&") {
+				rawQueryFragments = append(rawQueryFragments, qp)
+			}
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewListToolsRequest generates requests for ListTools
 func NewListToolsRequest(server string) (*http.Request, error) {
 	var err error
@@ -4328,6 +5446,34 @@ type ClientWithResponsesInterface interface {
 
 	// RemoveAgentUserWithResponse request
 	RemoveAgentUserWithResponse(ctx context.Context, id string, userId int64, reqEditors ...RequestEditorFn) (*RemoveAgentUserResponse, error)
+
+	// ListProfileSkillsWithResponse request
+	ListProfileSkillsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListProfileSkillsResponse, error)
+
+	// InstallProfileSkillWithBodyWithResponse request with any body
+	InstallProfileSkillWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*InstallProfileSkillResponse, error)
+
+	InstallProfileSkillWithResponse(ctx context.Context, body InstallProfileSkillJSONRequestBody, reqEditors ...RequestEditorFn) (*InstallProfileSkillResponse, error)
+
+	// UploadProfileSkillWithBodyWithResponse request with any body
+	UploadProfileSkillWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UploadProfileSkillResponse, error)
+
+	// DeleteProfileSkillWithResponse request
+	DeleteProfileSkillWithResponse(ctx context.Context, skillId string, reqEditors ...RequestEditorFn) (*DeleteProfileSkillResponse, error)
+
+	// GetProfileSkillWithResponse request
+	GetProfileSkillWithResponse(ctx context.Context, skillId string, reqEditors ...RequestEditorFn) (*GetProfileSkillResponse, error)
+
+	// UpdateProfileSkillWithBodyWithResponse request with any body
+	UpdateProfileSkillWithBodyWithResponse(ctx context.Context, skillId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateProfileSkillResponse, error)
+
+	UpdateProfileSkillWithResponse(ctx context.Context, skillId string, body UpdateProfileSkillJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateProfileSkillResponse, error)
+
+	// DeleteProfileSkillFileWithResponse request
+	DeleteProfileSkillFileWithResponse(ctx context.Context, skillId string, params *DeleteProfileSkillFileParams, reqEditors ...RequestEditorFn) (*DeleteProfileSkillFileResponse, error)
+
+	// GetProfileSkillFileWithResponse request
+	GetProfileSkillFileWithResponse(ctx context.Context, skillId string, params *GetProfileSkillFileParams, reqEditors ...RequestEditorFn) (*GetProfileSkillFileResponse, error)
 
 	// ListBuiltinResourcesWithResponse request
 	ListBuiltinResourcesWithResponse(ctx context.Context, kind string, reqEditors ...RequestEditorFn) (*ListBuiltinResourcesResponse, error)
@@ -4491,6 +5637,39 @@ type ClientWithResponsesInterface interface {
 
 	// GetSessionSystemPromptWithResponse request
 	GetSessionSystemPromptWithResponse(ctx context.Context, sessionID string, reqEditors ...RequestEditorFn) (*GetSessionSystemPromptResponse, error)
+
+	// ListSkillsWithResponse request
+	ListSkillsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListSkillsResponse, error)
+
+	// CreateSkillWithBodyWithResponse request with any body
+	CreateSkillWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateSkillResponse, error)
+
+	CreateSkillWithResponse(ctx context.Context, body CreateSkillJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateSkillResponse, error)
+
+	// InstallSkillWithBodyWithResponse request with any body
+	InstallSkillWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*InstallSkillResponse, error)
+
+	InstallSkillWithResponse(ctx context.Context, body InstallSkillJSONRequestBody, reqEditors ...RequestEditorFn) (*InstallSkillResponse, error)
+
+	// SearchSkillsWithResponse request
+	SearchSkillsWithResponse(ctx context.Context, params *SearchSkillsParams, reqEditors ...RequestEditorFn) (*SearchSkillsResponse, error)
+
+	// DeleteSkillWithResponse request
+	DeleteSkillWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*DeleteSkillResponse, error)
+
+	// GetSkillWithResponse request
+	GetSkillWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetSkillResponse, error)
+
+	// UpdateSkillWithBodyWithResponse request with any body
+	UpdateSkillWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateSkillResponse, error)
+
+	UpdateSkillWithResponse(ctx context.Context, id string, body UpdateSkillJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateSkillResponse, error)
+
+	// DeleteSkillFileWithResponse request
+	DeleteSkillFileWithResponse(ctx context.Context, id string, params *DeleteSkillFileParams, reqEditors ...RequestEditorFn) (*DeleteSkillFileResponse, error)
+
+	// GetSkillFileWithResponse request
+	GetSkillFileWithResponse(ctx context.Context, id string, params *GetSkillFileParams, reqEditors ...RequestEditorFn) (*GetSkillFileResponse, error)
 
 	// ListToolsWithResponse request
 	ListToolsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListToolsResponse, error)
@@ -5047,6 +6226,270 @@ func (r RemoveAgentUserResponse) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r RemoveAgentUserResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListProfileSkillsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.SkillList
+	JSON401      *externalRef0.Unauthorized
+}
+
+// Status returns HTTPResponse.Status
+func (r ListProfileSkillsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListProfileSkillsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListProfileSkillsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type InstallProfileSkillResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *struct {
+		Name *string `json:"name,omitempty"`
+	}
+	JSON400 *externalRef0.BadRequest
+	JSON401 *externalRef0.Unauthorized
+}
+
+// Status returns HTTPResponse.Status
+func (r InstallProfileSkillResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r InstallProfileSkillResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r InstallProfileSkillResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type UploadProfileSkillResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *externalRef0.SkillUploadResult
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+}
+
+// Status returns HTTPResponse.Status
+func (r UploadProfileSkillResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UploadProfileSkillResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r UploadProfileSkillResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type DeleteProfileSkillResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Id *string `json:"id,omitempty"`
+	}
+	JSON401 *externalRef0.Unauthorized
+	JSON404 *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteProfileSkillResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteProfileSkillResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r DeleteProfileSkillResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetProfileSkillResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.Skill
+	JSON401      *externalRef0.Unauthorized
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r GetProfileSkillResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetProfileSkillResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetProfileSkillResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type UpdateProfileSkillResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Id *string `json:"id,omitempty"`
+	}
+	JSON400 *externalRef0.BadRequest
+	JSON401 *externalRef0.Unauthorized
+	JSON404 *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateProfileSkillResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateProfileSkillResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r UpdateProfileSkillResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type DeleteProfileSkillFileResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.DeleteFileResult
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteProfileSkillFileResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteProfileSkillFileResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r DeleteProfileSkillFileResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetProfileSkillFileResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.SkillFileResponse
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r GetProfileSkillFileResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetProfileSkillFileResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetProfileSkillFileResponse) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -6511,6 +7954,312 @@ func (r GetSessionSystemPromptResponse) ContentType() string {
 	return ""
 }
 
+type ListSkillsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.SkillList
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r ListSkillsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListSkillsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListSkillsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type CreateSkillResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *struct {
+		Id *string `json:"id,omitempty"`
+	}
+	JSON400 *externalRef0.BadRequest
+	JSON401 *externalRef0.Unauthorized
+	JSON403 *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateSkillResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateSkillResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r CreateSkillResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type InstallSkillResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *struct {
+		Name *string `json:"name,omitempty"`
+	}
+	JSON400 *externalRef0.BadRequest
+	JSON401 *externalRef0.Unauthorized
+	JSON403 *externalRef0.Forbidden
+}
+
+// Status returns HTTPResponse.Status
+func (r InstallSkillResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r InstallSkillResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r InstallSkillResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type SearchSkillsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]externalRef0.SkillSearchResult
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+}
+
+// Status returns HTTPResponse.Status
+func (r SearchSkillsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SearchSkillsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r SearchSkillsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type DeleteSkillResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Id *string `json:"id,omitempty"`
+	}
+	JSON401 *externalRef0.Unauthorized
+	JSON403 *externalRef0.Forbidden
+	JSON404 *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteSkillResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteSkillResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r DeleteSkillResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetSkillResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.Skill
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r GetSkillResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetSkillResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetSkillResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type UpdateSkillResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Id *string `json:"id,omitempty"`
+	}
+	JSON400 *externalRef0.BadRequest
+	JSON401 *externalRef0.Unauthorized
+	JSON403 *externalRef0.Forbidden
+	JSON404 *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateSkillResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateSkillResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r UpdateSkillResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type DeleteSkillFileResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.DeleteFileResult
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteSkillFileResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteSkillFileResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r DeleteSkillFileResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetSkillFileResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.SkillFileResponse
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r GetSkillFileResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetSkillFileResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetSkillFileResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 type ListToolsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -6733,6 +8482,94 @@ func (c *ClientWithResponses) RemoveAgentUserWithResponse(ctx context.Context, i
 		return nil, err
 	}
 	return ParseRemoveAgentUserResponse(rsp)
+}
+
+// ListProfileSkillsWithResponse request returning *ListProfileSkillsResponse
+func (c *ClientWithResponses) ListProfileSkillsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListProfileSkillsResponse, error) {
+	rsp, err := c.ListProfileSkills(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListProfileSkillsResponse(rsp)
+}
+
+// InstallProfileSkillWithBodyWithResponse request with arbitrary body returning *InstallProfileSkillResponse
+func (c *ClientWithResponses) InstallProfileSkillWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*InstallProfileSkillResponse, error) {
+	rsp, err := c.InstallProfileSkillWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseInstallProfileSkillResponse(rsp)
+}
+
+func (c *ClientWithResponses) InstallProfileSkillWithResponse(ctx context.Context, body InstallProfileSkillJSONRequestBody, reqEditors ...RequestEditorFn) (*InstallProfileSkillResponse, error) {
+	rsp, err := c.InstallProfileSkill(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseInstallProfileSkillResponse(rsp)
+}
+
+// UploadProfileSkillWithBodyWithResponse request with arbitrary body returning *UploadProfileSkillResponse
+func (c *ClientWithResponses) UploadProfileSkillWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UploadProfileSkillResponse, error) {
+	rsp, err := c.UploadProfileSkillWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUploadProfileSkillResponse(rsp)
+}
+
+// DeleteProfileSkillWithResponse request returning *DeleteProfileSkillResponse
+func (c *ClientWithResponses) DeleteProfileSkillWithResponse(ctx context.Context, skillId string, reqEditors ...RequestEditorFn) (*DeleteProfileSkillResponse, error) {
+	rsp, err := c.DeleteProfileSkill(ctx, skillId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteProfileSkillResponse(rsp)
+}
+
+// GetProfileSkillWithResponse request returning *GetProfileSkillResponse
+func (c *ClientWithResponses) GetProfileSkillWithResponse(ctx context.Context, skillId string, reqEditors ...RequestEditorFn) (*GetProfileSkillResponse, error) {
+	rsp, err := c.GetProfileSkill(ctx, skillId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetProfileSkillResponse(rsp)
+}
+
+// UpdateProfileSkillWithBodyWithResponse request with arbitrary body returning *UpdateProfileSkillResponse
+func (c *ClientWithResponses) UpdateProfileSkillWithBodyWithResponse(ctx context.Context, skillId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateProfileSkillResponse, error) {
+	rsp, err := c.UpdateProfileSkillWithBody(ctx, skillId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateProfileSkillResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateProfileSkillWithResponse(ctx context.Context, skillId string, body UpdateProfileSkillJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateProfileSkillResponse, error) {
+	rsp, err := c.UpdateProfileSkill(ctx, skillId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateProfileSkillResponse(rsp)
+}
+
+// DeleteProfileSkillFileWithResponse request returning *DeleteProfileSkillFileResponse
+func (c *ClientWithResponses) DeleteProfileSkillFileWithResponse(ctx context.Context, skillId string, params *DeleteProfileSkillFileParams, reqEditors ...RequestEditorFn) (*DeleteProfileSkillFileResponse, error) {
+	rsp, err := c.DeleteProfileSkillFile(ctx, skillId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteProfileSkillFileResponse(rsp)
+}
+
+// GetProfileSkillFileWithResponse request returning *GetProfileSkillFileResponse
+func (c *ClientWithResponses) GetProfileSkillFileWithResponse(ctx context.Context, skillId string, params *GetProfileSkillFileParams, reqEditors ...RequestEditorFn) (*GetProfileSkillFileResponse, error) {
+	rsp, err := c.GetProfileSkillFile(ctx, skillId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetProfileSkillFileResponse(rsp)
 }
 
 // ListBuiltinResourcesWithResponse request returning *ListBuiltinResourcesResponse
@@ -7250,6 +9087,111 @@ func (c *ClientWithResponses) GetSessionSystemPromptWithResponse(ctx context.Con
 		return nil, err
 	}
 	return ParseGetSessionSystemPromptResponse(rsp)
+}
+
+// ListSkillsWithResponse request returning *ListSkillsResponse
+func (c *ClientWithResponses) ListSkillsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListSkillsResponse, error) {
+	rsp, err := c.ListSkills(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListSkillsResponse(rsp)
+}
+
+// CreateSkillWithBodyWithResponse request with arbitrary body returning *CreateSkillResponse
+func (c *ClientWithResponses) CreateSkillWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateSkillResponse, error) {
+	rsp, err := c.CreateSkillWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateSkillResponse(rsp)
+}
+
+func (c *ClientWithResponses) CreateSkillWithResponse(ctx context.Context, body CreateSkillJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateSkillResponse, error) {
+	rsp, err := c.CreateSkill(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateSkillResponse(rsp)
+}
+
+// InstallSkillWithBodyWithResponse request with arbitrary body returning *InstallSkillResponse
+func (c *ClientWithResponses) InstallSkillWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*InstallSkillResponse, error) {
+	rsp, err := c.InstallSkillWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseInstallSkillResponse(rsp)
+}
+
+func (c *ClientWithResponses) InstallSkillWithResponse(ctx context.Context, body InstallSkillJSONRequestBody, reqEditors ...RequestEditorFn) (*InstallSkillResponse, error) {
+	rsp, err := c.InstallSkill(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseInstallSkillResponse(rsp)
+}
+
+// SearchSkillsWithResponse request returning *SearchSkillsResponse
+func (c *ClientWithResponses) SearchSkillsWithResponse(ctx context.Context, params *SearchSkillsParams, reqEditors ...RequestEditorFn) (*SearchSkillsResponse, error) {
+	rsp, err := c.SearchSkills(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSearchSkillsResponse(rsp)
+}
+
+// DeleteSkillWithResponse request returning *DeleteSkillResponse
+func (c *ClientWithResponses) DeleteSkillWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*DeleteSkillResponse, error) {
+	rsp, err := c.DeleteSkill(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteSkillResponse(rsp)
+}
+
+// GetSkillWithResponse request returning *GetSkillResponse
+func (c *ClientWithResponses) GetSkillWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetSkillResponse, error) {
+	rsp, err := c.GetSkill(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetSkillResponse(rsp)
+}
+
+// UpdateSkillWithBodyWithResponse request with arbitrary body returning *UpdateSkillResponse
+func (c *ClientWithResponses) UpdateSkillWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateSkillResponse, error) {
+	rsp, err := c.UpdateSkillWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateSkillResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateSkillWithResponse(ctx context.Context, id string, body UpdateSkillJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateSkillResponse, error) {
+	rsp, err := c.UpdateSkill(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateSkillResponse(rsp)
+}
+
+// DeleteSkillFileWithResponse request returning *DeleteSkillFileResponse
+func (c *ClientWithResponses) DeleteSkillFileWithResponse(ctx context.Context, id string, params *DeleteSkillFileParams, reqEditors ...RequestEditorFn) (*DeleteSkillFileResponse, error) {
+	rsp, err := c.DeleteSkillFile(ctx, id, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteSkillFileResponse(rsp)
+}
+
+// GetSkillFileWithResponse request returning *GetSkillFileResponse
+func (c *ClientWithResponses) GetSkillFileWithResponse(ctx context.Context, id string, params *GetSkillFileParams, reqEditors ...RequestEditorFn) (*GetSkillFileResponse, error) {
+	rsp, err := c.GetSkillFile(ctx, id, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetSkillFileResponse(rsp)
 }
 
 // ListToolsWithResponse request returning *ListToolsResponse
@@ -8026,6 +9968,346 @@ func ParseRemoveAgentUserResponse(rsp *http.Response) (*RemoveAgentUserResponse,
 			return nil, err
 		}
 		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListProfileSkillsResponse parses an HTTP response from a ListProfileSkillsWithResponse call
+func ParseListProfileSkillsResponse(rsp *http.Response) (*ListProfileSkillsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListProfileSkillsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.SkillList
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseInstallProfileSkillResponse parses an HTTP response from a InstallProfileSkillWithResponse call
+func ParseInstallProfileSkillResponse(rsp *http.Response) (*InstallProfileSkillResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &InstallProfileSkillResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest struct {
+			Name *string `json:"name,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUploadProfileSkillResponse parses an HTTP response from a UploadProfileSkillWithResponse call
+func ParseUploadProfileSkillResponse(rsp *http.Response) (*UploadProfileSkillResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UploadProfileSkillResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest externalRef0.SkillUploadResult
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteProfileSkillResponse parses an HTTP response from a DeleteProfileSkillWithResponse call
+func ParseDeleteProfileSkillResponse(rsp *http.Response) (*DeleteProfileSkillResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteProfileSkillResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Id *string `json:"id,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetProfileSkillResponse parses an HTTP response from a GetProfileSkillWithResponse call
+func ParseGetProfileSkillResponse(rsp *http.Response) (*GetProfileSkillResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetProfileSkillResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.Skill
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateProfileSkillResponse parses an HTTP response from a UpdateProfileSkillWithResponse call
+func ParseUpdateProfileSkillResponse(rsp *http.Response) (*UpdateProfileSkillResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateProfileSkillResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Id *string `json:"id,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteProfileSkillFileResponse parses an HTTP response from a DeleteProfileSkillFileWithResponse call
+func ParseDeleteProfileSkillFileResponse(rsp *http.Response) (*DeleteProfileSkillFileResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteProfileSkillFileResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.DeleteFileResult
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetProfileSkillFileResponse parses an HTTP response from a GetProfileSkillFileWithResponse call
+func ParseGetProfileSkillFileResponse(rsp *http.Response) (*GetProfileSkillFileResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetProfileSkillFileResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.SkillFileResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
 
 	}
 
@@ -9931,6 +12213,444 @@ func ParseGetSessionSystemPromptResponse(rsp *http.Response) (*GetSessionSystemP
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListSkillsResponse parses an HTTP response from a ListSkillsWithResponse call
+func ParseListSkillsResponse(rsp *http.Response) (*ListSkillsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListSkillsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.SkillList
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateSkillResponse parses an HTTP response from a CreateSkillWithResponse call
+func ParseCreateSkillResponse(rsp *http.Response) (*CreateSkillResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateSkillResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest struct {
+			Id *string `json:"id,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseInstallSkillResponse parses an HTTP response from a InstallSkillWithResponse call
+func ParseInstallSkillResponse(rsp *http.Response) (*InstallSkillResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &InstallSkillResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest struct {
+			Name *string `json:"name,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseSearchSkillsResponse parses an HTTP response from a SearchSkillsWithResponse call
+func ParseSearchSkillsResponse(rsp *http.Response) (*SearchSkillsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SearchSkillsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []externalRef0.SkillSearchResult
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteSkillResponse parses an HTTP response from a DeleteSkillWithResponse call
+func ParseDeleteSkillResponse(rsp *http.Response) (*DeleteSkillResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteSkillResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Id *string `json:"id,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetSkillResponse parses an HTTP response from a GetSkillWithResponse call
+func ParseGetSkillResponse(rsp *http.Response) (*GetSkillResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetSkillResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.Skill
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateSkillResponse parses an HTTP response from a UpdateSkillWithResponse call
+func ParseUpdateSkillResponse(rsp *http.Response) (*UpdateSkillResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateSkillResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Id *string `json:"id,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteSkillFileResponse parses an HTTP response from a DeleteSkillFileWithResponse call
+func ParseDeleteSkillFileResponse(rsp *http.Response) (*DeleteSkillFileResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteSkillFileResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.DeleteFileResult
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetSkillFileResponse parses an HTTP response from a GetSkillFileWithResponse call
+func ParseGetSkillFileResponse(rsp *http.Response) (*GetSkillFileResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetSkillFileResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.SkillFileResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
 		var dest externalRef0.Unauthorized

--- a/api/client/gen.go
+++ b/api/client/gen.go
@@ -30,6 +30,15 @@ type ArticleList = externalRef0.ArticleList
 // ArticleStatus defines model for ArticleStatus.
 type ArticleStatus = externalRef0.ArticleStatus
 
+// BuiltinResource defines model for BuiltinResource.
+type BuiltinResource = externalRef0.BuiltinResource
+
+// BuiltinResourceDetail defines model for BuiltinResourceDetail.
+type BuiltinResourceDetail = externalRef0.BuiltinResourceDetail
+
+// CachedModel defines model for CachedModel.
+type CachedModel = externalRef0.CachedModel
+
 // CreateFeedRequest defines model for CreateFeedRequest.
 type CreateFeedRequest = externalRef0.CreateFeedRequest
 
@@ -77,6 +86,9 @@ type SourceType = externalRef0.SourceType
 
 // TagCount defines model for TagCount.
 type TagCount = externalRef0.TagCount
+
+// Tool defines model for Tool.
+type Tool = externalRef0.Tool
 
 // UpdateArticleRequest Only provided fields are updated.
 type UpdateArticleRequest = externalRef0.UpdateArticleRequest
@@ -221,6 +233,15 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 
 // The interface specification for the client above.
 type ClientInterface interface {
+	// ListBuiltinResources request
+	ListBuiltinResources(ctx context.Context, kind string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetBuiltinResource request
+	GetBuiltinResource(ctx context.Context, kind string, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListModels request
+	ListModels(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ListArticles request
 	ListArticles(ctx context.Context, params *ListArticlesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -294,6 +315,45 @@ type ClientInterface interface {
 
 	// ListSchedulerJobRuns request
 	ListSchedulerJobRuns(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListTools request
+	ListTools(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+}
+
+func (c *Client) ListBuiltinResources(ctx context.Context, kind string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListBuiltinResourcesRequest(c.Server, kind)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetBuiltinResource(ctx context.Context, kind string, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetBuiltinResourceRequest(c.Server, kind, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListModels(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListModelsRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
 }
 
 func (c *Client) ListArticles(ctx context.Context, params *ListArticlesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -618,6 +678,120 @@ func (c *Client) ListSchedulerJobRuns(ctx context.Context, id string, reqEditors
 		return nil, err
 	}
 	return c.Client.Do(req)
+}
+
+func (c *Client) ListTools(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListToolsRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// NewListBuiltinResourcesRequest generates requests for ListBuiltinResources
+func NewListBuiltinResourcesRequest(server string, kind string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "kind", kind, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/builtin/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetBuiltinResourceRequest generates requests for GetBuiltinResource
+func NewGetBuiltinResourceRequest(server string, kind string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "kind", kind, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/builtin/%s/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewListModelsRequest generates requests for ListModels
+func NewListModelsRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/models")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
 }
 
 // NewListArticlesRequest generates requests for ListArticles
@@ -1556,6 +1730,33 @@ func NewListSchedulerJobRunsRequest(server string, id string) (*http.Request, er
 	return req, nil
 }
 
+// NewListToolsRequest generates requests for ListTools
+func NewListToolsRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/tools")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 func (c *Client) applyEditors(ctx context.Context, req *http.Request, additionalEditors []RequestEditorFn) error {
 	for _, r := range c.RequestEditors {
 		if err := r(ctx, req); err != nil {
@@ -1599,6 +1800,15 @@ func WithBaseURL(baseURL string) ClientOption {
 
 // ClientWithResponsesInterface is the interface specification for the client with responses above.
 type ClientWithResponsesInterface interface {
+	// ListBuiltinResourcesWithResponse request
+	ListBuiltinResourcesWithResponse(ctx context.Context, kind string, reqEditors ...RequestEditorFn) (*ListBuiltinResourcesResponse, error)
+
+	// GetBuiltinResourceWithResponse request
+	GetBuiltinResourceWithResponse(ctx context.Context, kind string, id string, reqEditors ...RequestEditorFn) (*GetBuiltinResourceResponse, error)
+
+	// ListModelsWithResponse request
+	ListModelsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListModelsResponse, error)
+
 	// ListArticlesWithResponse request
 	ListArticlesWithResponse(ctx context.Context, params *ListArticlesParams, reqEditors ...RequestEditorFn) (*ListArticlesResponse, error)
 
@@ -1672,6 +1882,104 @@ type ClientWithResponsesInterface interface {
 
 	// ListSchedulerJobRunsWithResponse request
 	ListSchedulerJobRunsWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*ListSchedulerJobRunsResponse, error)
+
+	// ListToolsWithResponse request
+	ListToolsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListToolsResponse, error)
+}
+
+type ListBuiltinResourcesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]externalRef0.BuiltinResource
+	JSON401      *externalRef0.Unauthorized
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r ListBuiltinResourcesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListBuiltinResourcesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListBuiltinResourcesResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetBuiltinResourceResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.BuiltinResourceDetail
+	JSON401      *externalRef0.Unauthorized
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r GetBuiltinResourceResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetBuiltinResourceResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetBuiltinResourceResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListModelsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]externalRef0.CachedModel
+	JSON401      *externalRef0.Unauthorized
+}
+
+// Status returns HTTPResponse.Status
+func (r ListModelsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListModelsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListModelsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
 }
 
 type ListArticlesResponse struct {
@@ -2318,6 +2626,64 @@ func (r ListSchedulerJobRunsResponse) ContentType() string {
 	return ""
 }
 
+type ListToolsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]externalRef0.Tool
+	JSON401      *externalRef0.Unauthorized
+}
+
+// Status returns HTTPResponse.Status
+func (r ListToolsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListToolsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListToolsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+// ListBuiltinResourcesWithResponse request returning *ListBuiltinResourcesResponse
+func (c *ClientWithResponses) ListBuiltinResourcesWithResponse(ctx context.Context, kind string, reqEditors ...RequestEditorFn) (*ListBuiltinResourcesResponse, error) {
+	rsp, err := c.ListBuiltinResources(ctx, kind, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListBuiltinResourcesResponse(rsp)
+}
+
+// GetBuiltinResourceWithResponse request returning *GetBuiltinResourceResponse
+func (c *ClientWithResponses) GetBuiltinResourceWithResponse(ctx context.Context, kind string, id string, reqEditors ...RequestEditorFn) (*GetBuiltinResourceResponse, error) {
+	rsp, err := c.GetBuiltinResource(ctx, kind, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetBuiltinResourceResponse(rsp)
+}
+
+// ListModelsWithResponse request returning *ListModelsResponse
+func (c *ClientWithResponses) ListModelsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListModelsResponse, error) {
+	rsp, err := c.ListModels(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListModelsResponse(rsp)
+}
+
 // ListArticlesWithResponse request returning *ListArticlesResponse
 func (c *ClientWithResponses) ListArticlesWithResponse(ctx context.Context, params *ListArticlesParams, reqEditors ...RequestEditorFn) (*ListArticlesResponse, error) {
 	rsp, err := c.ListArticles(ctx, params, reqEditors...)
@@ -2552,6 +2918,128 @@ func (c *ClientWithResponses) ListSchedulerJobRunsWithResponse(ctx context.Conte
 		return nil, err
 	}
 	return ParseListSchedulerJobRunsResponse(rsp)
+}
+
+// ListToolsWithResponse request returning *ListToolsResponse
+func (c *ClientWithResponses) ListToolsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListToolsResponse, error) {
+	rsp, err := c.ListTools(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListToolsResponse(rsp)
+}
+
+// ParseListBuiltinResourcesResponse parses an HTTP response from a ListBuiltinResourcesWithResponse call
+func ParseListBuiltinResourcesResponse(rsp *http.Response) (*ListBuiltinResourcesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListBuiltinResourcesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []externalRef0.BuiltinResource
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetBuiltinResourceResponse parses an HTTP response from a GetBuiltinResourceWithResponse call
+func ParseGetBuiltinResourceResponse(rsp *http.Response) (*GetBuiltinResourceResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetBuiltinResourceResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.BuiltinResourceDetail
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListModelsResponse parses an HTTP response from a ListModelsWithResponse call
+func ParseListModelsResponse(rsp *http.Response) (*ListModelsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListModelsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []externalRef0.CachedModel
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	}
+
+	return response, nil
 }
 
 // ParseListArticlesResponse parses an HTTP response from a ListArticlesWithResponse call
@@ -3376,6 +3864,39 @@ func ParseListSchedulerJobRunsResponse(rsp *http.Response) (*ListSchedulerJobRun
 			return nil, err
 		}
 		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListToolsResponse parses an HTTP response from a ListToolsWithResponse call
+func ParseListToolsResponse(rsp *http.Response) (*ListToolsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListToolsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []externalRef0.Tool
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
 
 	}
 

--- a/api/server/gen.go
+++ b/api/server/gen.go
@@ -149,6 +149,9 @@ type LinkCodeResponse = externalRef0.LinkCodeResponse
 // LoginRequest defines model for LoginRequest.
 type LoginRequest = externalRef0.LoginRequest
 
+// ManifestPlugin defines model for ManifestPlugin.
+type ManifestPlugin = externalRef0.ManifestPlugin
+
 // MeResponse defines model for MeResponse.
 type MeResponse = externalRef0.MeResponse
 
@@ -160,6 +163,9 @@ type OAuthFlowStatus = externalRef0.OAuthFlowStatus
 
 // OAuthProviderStatus defines model for OAuthProviderStatus.
 type OAuthProviderStatus = externalRef0.OAuthProviderStatus
+
+// PluginView defines model for PluginView.
+type PluginView = externalRef0.PluginView
 
 // ProfileInstallSkillRequest defines model for ProfileInstallSkillRequest.
 type ProfileInstallSkillRequest = externalRef0.ProfileInstallSkillRequest
@@ -242,6 +248,9 @@ type SystemPromptResponse = externalRef0.SystemPromptResponse
 // TagCount defines model for TagCount.
 type TagCount = externalRef0.TagCount
 
+// TogglePluginRequest defines model for TogglePluginRequest.
+type TogglePluginRequest = externalRef0.TogglePluginRequest
+
 // Tool defines model for Tool.
 type Tool = externalRef0.Tool
 
@@ -265,6 +274,9 @@ type UpdateFeedRequest = externalRef0.UpdateFeedRequest
 
 // UpdateNotifyIdentityRequest defines model for UpdateNotifyIdentityRequest.
 type UpdateNotifyIdentityRequest = externalRef0.UpdateNotifyIdentityRequest
+
+// UpdatePluginConfigRequest defines model for UpdatePluginConfigRequest.
+type UpdatePluginConfigRequest = externalRef0.UpdatePluginConfigRequest
 
 // UpdateRoleRequest defines model for UpdateRoleRequest.
 type UpdateRoleRequest = externalRef0.UpdateRoleRequest
@@ -317,6 +329,11 @@ type GetProfileSkillFileParams struct {
 type PollWeixinQRStatusParams struct {
 	// Qrcode QR code token from startWeixinQR
 	Qrcode string `form:"qrcode" json:"qrcode"`
+}
+
+// SaveManifestPluginsJSONBody defines parameters for SaveManifestPlugins.
+type SaveManifestPluginsJSONBody struct {
+	Plugins *[]externalRef0.ManifestPlugin `json:"plugins,omitempty"`
 }
 
 // ListArticlesParams defines parameters for ListArticles.
@@ -452,6 +469,15 @@ type CreateChannelJSONRequestBody = externalRef0.ChannelWriteRequest
 
 // UpdateChannelJSONRequestBody defines body for UpdateChannel for application/json ContentType.
 type UpdateChannelJSONRequestBody = externalRef0.ChannelWriteRequest
+
+// SaveManifestPluginsJSONRequestBody defines body for SaveManifestPlugins for application/json ContentType.
+type SaveManifestPluginsJSONRequestBody SaveManifestPluginsJSONBody
+
+// UpdatePluginConfigJSONRequestBody defines body for UpdatePluginConfig for application/json ContentType.
+type UpdatePluginConfigJSONRequestBody = externalRef0.UpdatePluginConfigRequest
+
+// TogglePluginJSONRequestBody defines body for TogglePlugin for application/json ContentType.
+type TogglePluginJSONRequestBody = externalRef0.TogglePluginRequest
 
 // CreateProviderJSONRequestBody defines body for CreateProvider for application/json ContentType.
 type CreateProviderJSONRequestBody = externalRef0.Provider
@@ -698,9 +724,36 @@ type ServerInterface interface {
 	// Update a channel (admin only)
 	// (PUT /api/channels/{id})
 	UpdateChannel(w http.ResponseWriter, r *http.Request, id string)
+	// List manifest plugins (admin only)
+	// (GET /api/manifest-plugins)
+	ListManifestPlugins(w http.ResponseWriter, r *http.Request)
+	// Save manifest plugins (admin only)
+	// (PUT /api/manifest-plugins)
+	SaveManifestPlugins(w http.ResponseWriter, r *http.Request)
+	// Sync manifest plugins (admin only)
+	// (POST /api/manifest-plugins/sync)
+	SyncManifestPlugins(w http.ResponseWriter, r *http.Request)
 	// List enabled models from provider config and cache
 	// (GET /api/models)
 	ListModels(w http.ResponseWriter, r *http.Request)
+	// Get plugin config schema (admin only)
+	// (GET /api/plugin-config-schema/{kind}/{name})
+	GetPluginConfigSchema(w http.ResponseWriter, r *http.Request, kind string, name string)
+	// Get plugin config (admin only)
+	// (GET /api/plugin-config/{kind}/{name})
+	GetPluginConfig(w http.ResponseWriter, r *http.Request, kind string, name string)
+	// Update plugin config (admin only)
+	// (PUT /api/plugin-config/{kind}/{name})
+	UpdatePluginConfig(w http.ResponseWriter, r *http.Request, kind string, name string)
+	// Get plugin status (admin only)
+	// (GET /api/plugin-status/{kind}/{name})
+	GetPluginStatus(w http.ResponseWriter, r *http.Request, kind string, name string)
+	// List all plugins (admin only)
+	// (GET /api/plugins)
+	ListPlugins(w http.ResponseWriter, r *http.Request)
+	// Toggle plugin enabled state (admin only)
+	// (PATCH /api/plugins/{kind}/{name})
+	TogglePlugin(w http.ResponseWriter, r *http.Request, kind string, name string)
 	// List available provider types (admin only)
 	// (GET /api/provider-types)
 	ListProviderTypes(w http.ResponseWriter, r *http.Request)
@@ -2775,6 +2828,66 @@ func (siw *ServerInterfaceWrapper) UpdateChannel(w http.ResponseWriter, r *http.
 	handler.ServeHTTP(w, r)
 }
 
+// ListManifestPlugins operation middleware
+func (siw *ServerInterfaceWrapper) ListManifestPlugins(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListManifestPlugins(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// SaveManifestPlugins operation middleware
+func (siw *ServerInterfaceWrapper) SaveManifestPlugins(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.SaveManifestPlugins(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// SyncManifestPlugins operation middleware
+func (siw *ServerInterfaceWrapper) SyncManifestPlugins(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.SyncManifestPlugins(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // ListModels operation middleware
 func (siw *ServerInterfaceWrapper) ListModels(w http.ResponseWriter, r *http.Request) {
 
@@ -2786,6 +2899,231 @@ func (siw *ServerInterfaceWrapper) ListModels(w http.ResponseWriter, r *http.Req
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.ListModels(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetPluginConfigSchema operation middleware
+func (siw *ServerInterfaceWrapper) GetPluginConfigSchema(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "kind" -------------
+	var kind string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "kind", r.PathValue("kind"), &kind, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "kind", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "name" -------------
+	var name string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "name", r.PathValue("name"), &name, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "name", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetPluginConfigSchema(w, r, kind, name)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetPluginConfig operation middleware
+func (siw *ServerInterfaceWrapper) GetPluginConfig(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "kind" -------------
+	var kind string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "kind", r.PathValue("kind"), &kind, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "kind", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "name" -------------
+	var name string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "name", r.PathValue("name"), &name, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "name", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetPluginConfig(w, r, kind, name)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UpdatePluginConfig operation middleware
+func (siw *ServerInterfaceWrapper) UpdatePluginConfig(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "kind" -------------
+	var kind string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "kind", r.PathValue("kind"), &kind, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "kind", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "name" -------------
+	var name string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "name", r.PathValue("name"), &name, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "name", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdatePluginConfig(w, r, kind, name)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetPluginStatus operation middleware
+func (siw *ServerInterfaceWrapper) GetPluginStatus(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "kind" -------------
+	var kind string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "kind", r.PathValue("kind"), &kind, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "kind", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "name" -------------
+	var name string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "name", r.PathValue("name"), &name, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "name", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetPluginStatus(w, r, kind, name)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListPlugins operation middleware
+func (siw *ServerInterfaceWrapper) ListPlugins(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListPlugins(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// TogglePlugin operation middleware
+func (siw *ServerInterfaceWrapper) TogglePlugin(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "kind" -------------
+	var kind string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "kind", r.PathValue("kind"), &kind, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "kind", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "name" -------------
+	var name string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "name", r.PathValue("name"), &name, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "name", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.TogglePlugin(w, r, kind, name)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -4658,7 +4996,16 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/channels/{id}", wrapper.DeleteChannel)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/channels/{id}", wrapper.GetChannel)
 	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/api/channels/{id}", wrapper.UpdateChannel)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/manifest-plugins", wrapper.ListManifestPlugins)
+	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/api/manifest-plugins", wrapper.SaveManifestPlugins)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/manifest-plugins/sync", wrapper.SyncManifestPlugins)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/models", wrapper.ListModels)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/plugin-config-schema/{kind}/{name}", wrapper.GetPluginConfigSchema)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/plugin-config/{kind}/{name}", wrapper.GetPluginConfig)
+	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/api/plugin-config/{kind}/{name}", wrapper.UpdatePluginConfig)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/plugin-status/{kind}/{name}", wrapper.GetPluginStatus)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/plugins", wrapper.ListPlugins)
+	m.HandleFunc(http.MethodPatch+" "+options.BaseURL+"/api/plugins/{kind}/{name}", wrapper.TogglePlugin)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/provider-types", wrapper.ListProviderTypes)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/providers", wrapper.ListProviders)
 	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/providers", wrapper.CreateProvider)

--- a/api/server/gen.go
+++ b/api/server/gen.go
@@ -71,6 +71,12 @@ type CreateFeedRequest = externalRef0.CreateFeedRequest
 // CreateSessionRequest defines model for CreateSessionRequest.
 type CreateSessionRequest = externalRef0.CreateSessionRequest
 
+// CreateSkillRequest defines model for CreateSkillRequest.
+type CreateSkillRequest = externalRef0.CreateSkillRequest
+
+// DeleteFileResult defines model for DeleteFileResult.
+type DeleteFileResult = externalRef0.DeleteFileResult
+
 // DeleteResult defines model for DeleteResult.
 type DeleteResult = externalRef0.DeleteResult
 
@@ -104,6 +110,9 @@ type FeedPollResult = externalRef0.FeedPollResult
 // FetchModelsRequest defines model for FetchModelsRequest.
 type FetchModelsRequest = externalRef0.FetchModelsRequest
 
+// GlobalInstallSkillRequest defines model for GlobalInstallSkillRequest.
+type GlobalInstallSkillRequest = externalRef0.GlobalInstallSkillRequest
+
 // InstallSkillRequest defines model for InstallSkillRequest.
 type InstallSkillRequest = externalRef0.InstallSkillRequest
 
@@ -115,6 +124,9 @@ type JobInput = externalRef0.JobInput
 
 // JobList defines model for JobList.
 type JobList = externalRef0.JobList
+
+// ProfileInstallSkillRequest defines model for ProfileInstallSkillRequest.
+type ProfileInstallSkillRequest = externalRef0.ProfileInstallSkillRequest
 
 // Provider defines model for Provider.
 type Provider = externalRef0.Provider
@@ -158,8 +170,17 @@ type SessionDetail = externalRef0.SessionDetail
 // Skill defines model for Skill.
 type Skill = externalRef0.Skill
 
+// SkillFileResponse defines model for SkillFileResponse.
+type SkillFileResponse = externalRef0.SkillFileResponse
+
 // SkillList defines model for SkillList.
 type SkillList = externalRef0.SkillList
+
+// SkillSearchResult defines model for SkillSearchResult.
+type SkillSearchResult = externalRef0.SkillSearchResult
+
+// SkillSearchResultList defines model for SkillSearchResultList.
+type SkillSearchResultList = externalRef0.SkillSearchResultList
 
 // SkillUploadResult defines model for SkillUploadResult.
 type SkillUploadResult = externalRef0.SkillUploadResult
@@ -200,6 +221,21 @@ type bearerAuthContextKey string
 // UploadAgentSkillMultipartBody defines parameters for UploadAgentSkill.
 type UploadAgentSkillMultipartBody struct {
 	File *openapi_types.File `json:"file,omitempty"`
+}
+
+// UploadProfileSkillMultipartBody defines parameters for UploadProfileSkill.
+type UploadProfileSkillMultipartBody struct {
+	File *openapi_types.File `json:"file,omitempty"`
+}
+
+// DeleteProfileSkillFileParams defines parameters for DeleteProfileSkillFile.
+type DeleteProfileSkillFileParams struct {
+	Path string `form:"path" json:"path"`
+}
+
+// GetProfileSkillFileParams defines parameters for GetProfileSkillFile.
+type GetProfileSkillFileParams struct {
+	Path string `form:"path" json:"path"`
 }
 
 // PollWeixinQRStatusParams defines parameters for PollWeixinQRStatus.
@@ -263,6 +299,22 @@ type GetSessionMessagesParams struct {
 	Skip *int `form:"skip,omitempty" json:"skip,omitempty"`
 }
 
+// SearchSkillsParams defines parameters for SearchSkills.
+type SearchSkillsParams struct {
+	Q     string `form:"q" json:"q"`
+	Limit *int   `form:"limit,omitempty" json:"limit,omitempty"`
+}
+
+// DeleteSkillFileParams defines parameters for DeleteSkillFile.
+type DeleteSkillFileParams struct {
+	Path string `form:"path" json:"path"`
+}
+
+// GetSkillFileParams defines parameters for GetSkillFile.
+type GetSkillFileParams struct {
+	Path string `form:"path" json:"path"`
+}
+
 // CreateAgentJSONRequestBody defines body for CreateAgent for application/json ContentType.
 type CreateAgentJSONRequestBody = externalRef0.CreateAgentRequest
 
@@ -280,6 +332,15 @@ type UpdateAgentSkillJSONRequestBody = externalRef0.UpdateSkillRequest
 
 // AssignAgentUserJSONRequestBody defines body for AssignAgentUser for application/json ContentType.
 type AssignAgentUserJSONRequestBody = externalRef0.AssignAgentUserRequest
+
+// InstallProfileSkillJSONRequestBody defines body for InstallProfileSkill for application/json ContentType.
+type InstallProfileSkillJSONRequestBody = externalRef0.ProfileInstallSkillRequest
+
+// UploadProfileSkillMultipartRequestBody defines body for UploadProfileSkill for multipart/form-data ContentType.
+type UploadProfileSkillMultipartRequestBody UploadProfileSkillMultipartBody
+
+// UpdateProfileSkillJSONRequestBody defines body for UpdateProfileSkill for application/json ContentType.
+type UpdateProfileSkillJSONRequestBody = externalRef0.UpdateSkillRequest
 
 // CreateChannelJSONRequestBody defines body for CreateChannel for application/json ContentType.
 type CreateChannelJSONRequestBody = externalRef0.ChannelWriteRequest
@@ -322,6 +383,15 @@ type CreateSessionJSONRequestBody = externalRef0.CreateSessionRequest
 
 // SendSessionMessageJSONRequestBody defines body for SendSessionMessage for application/json ContentType.
 type SendSessionMessageJSONRequestBody = externalRef0.SendMessageRequest
+
+// CreateSkillJSONRequestBody defines body for CreateSkill for application/json ContentType.
+type CreateSkillJSONRequestBody = externalRef0.CreateSkillRequest
+
+// InstallSkillJSONRequestBody defines body for InstallSkill for application/json ContentType.
+type InstallSkillJSONRequestBody = externalRef0.GlobalInstallSkillRequest
+
+// UpdateSkillJSONRequestBody defines body for UpdateSkill for application/json ContentType.
+type UpdateSkillJSONRequestBody = externalRef0.UpdateSkillRequest
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
@@ -376,6 +446,30 @@ type ServerInterface interface {
 	// Remove a user from an agent (admin only)
 	// (DELETE /api/agents/{id}/users/{userId})
 	RemoveAgentUser(w http.ResponseWriter, r *http.Request, id string, userId int64)
+	// List profile skills (current user)
+	// (GET /api/auth/profile/skills)
+	ListProfileSkills(w http.ResponseWriter, r *http.Request)
+	// Install a skill to the current user's profile
+	// (POST /api/auth/profile/skills/install)
+	InstallProfileSkill(w http.ResponseWriter, r *http.Request)
+	// Upload a skill zip to the current user's profile
+	// (POST /api/auth/profile/skills/upload)
+	UploadProfileSkill(w http.ResponseWriter, r *http.Request)
+	// Delete a profile skill
+	// (DELETE /api/auth/profile/skills/{skillId})
+	DeleteProfileSkill(w http.ResponseWriter, r *http.Request, skillId string)
+	// Get a profile skill by ID
+	// (GET /api/auth/profile/skills/{skillId})
+	GetProfileSkill(w http.ResponseWriter, r *http.Request, skillId string)
+	// Update a profile skill
+	// (PUT /api/auth/profile/skills/{skillId})
+	UpdateProfileSkill(w http.ResponseWriter, r *http.Request, skillId string)
+	// Delete a profile skill file
+	// (DELETE /api/auth/profile/skills/{skillId}/file)
+	DeleteProfileSkillFile(w http.ResponseWriter, r *http.Request, skillId string, params DeleteProfileSkillFileParams)
+	// Get a profile skill file
+	// (GET /api/auth/profile/skills/{skillId}/file)
+	GetProfileSkillFile(w http.ResponseWriter, r *http.Request, skillId string, params GetProfileSkillFileParams)
 	// List builtin resources of a given kind
 	// (GET /api/builtin/{kind})
 	ListBuiltinResources(w http.ResponseWriter, r *http.Request, kind string)
@@ -511,6 +605,33 @@ type ServerInterface interface {
 	// Get the system prompt for a session
 	// (GET /api/sessions/{sessionID}/system-prompt)
 	GetSessionSystemPrompt(w http.ResponseWriter, r *http.Request, sessionID string)
+	// List all skills (admin only)
+	// (GET /api/skills)
+	ListSkills(w http.ResponseWriter, r *http.Request)
+	// Create a skill (admin only)
+	// (POST /api/skills)
+	CreateSkill(w http.ResponseWriter, r *http.Request)
+	// Install a skill from a remote source (admin only)
+	// (POST /api/skills/install)
+	InstallSkill(w http.ResponseWriter, r *http.Request)
+	// Search skills from mcphub (any authenticated user)
+	// (GET /api/skills/search)
+	SearchSkills(w http.ResponseWriter, r *http.Request, params SearchSkillsParams)
+	// Delete a skill (admin only)
+	// (DELETE /api/skills/{id})
+	DeleteSkill(w http.ResponseWriter, r *http.Request, id string)
+	// Get a skill by ID (admin only)
+	// (GET /api/skills/{id})
+	GetSkill(w http.ResponseWriter, r *http.Request, id string)
+	// Update a skill (admin only)
+	// (PUT /api/skills/{id})
+	UpdateSkill(w http.ResponseWriter, r *http.Request, id string)
+	// Delete a skill file (admin only)
+	// (DELETE /api/skills/{id}/file)
+	DeleteSkillFile(w http.ResponseWriter, r *http.Request, id string, params DeleteSkillFileParams)
+	// Get a skill file (admin only)
+	// (GET /api/skills/{id}/file)
+	GetSkillFile(w http.ResponseWriter, r *http.Request, id string, params GetSkillFileParams)
 	// List available agent tools
 	// (GET /api/tools)
 	ListTools(w http.ResponseWriter, r *http.Request)
@@ -1099,6 +1220,258 @@ func (siw *ServerInterfaceWrapper) RemoveAgentUser(w http.ResponseWriter, r *htt
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.RemoveAgentUser(w, r, id, userId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListProfileSkills operation middleware
+func (siw *ServerInterfaceWrapper) ListProfileSkills(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListProfileSkills(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// InstallProfileSkill operation middleware
+func (siw *ServerInterfaceWrapper) InstallProfileSkill(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.InstallProfileSkill(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UploadProfileSkill operation middleware
+func (siw *ServerInterfaceWrapper) UploadProfileSkill(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UploadProfileSkill(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeleteProfileSkill operation middleware
+func (siw *ServerInterfaceWrapper) DeleteProfileSkill(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "skillId" -------------
+	var skillId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "skillId", r.PathValue("skillId"), &skillId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "skillId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteProfileSkill(w, r, skillId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetProfileSkill operation middleware
+func (siw *ServerInterfaceWrapper) GetProfileSkill(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "skillId" -------------
+	var skillId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "skillId", r.PathValue("skillId"), &skillId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "skillId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetProfileSkill(w, r, skillId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UpdateProfileSkill operation middleware
+func (siw *ServerInterfaceWrapper) UpdateProfileSkill(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "skillId" -------------
+	var skillId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "skillId", r.PathValue("skillId"), &skillId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "skillId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdateProfileSkill(w, r, skillId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeleteProfileSkillFile operation middleware
+func (siw *ServerInterfaceWrapper) DeleteProfileSkillFile(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "skillId" -------------
+	var skillId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "skillId", r.PathValue("skillId"), &skillId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "skillId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params DeleteProfileSkillFileParams
+
+	// ------------- Required query parameter "path" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, true, "path", r.URL.Query(), &params.Path, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "path"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "path", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteProfileSkillFile(w, r, skillId, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetProfileSkillFile operation middleware
+func (siw *ServerInterfaceWrapper) GetProfileSkillFile(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "skillId" -------------
+	var skillId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "skillId", r.PathValue("skillId"), &skillId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "skillId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetProfileSkillFileParams
+
+	// ------------- Required query parameter "path" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, true, "path", r.URL.Query(), &params.Path, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "path"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "path", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetProfileSkillFile(w, r, skillId, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -2594,6 +2967,310 @@ func (siw *ServerInterfaceWrapper) GetSessionSystemPrompt(w http.ResponseWriter,
 	handler.ServeHTTP(w, r)
 }
 
+// ListSkills operation middleware
+func (siw *ServerInterfaceWrapper) ListSkills(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListSkills(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// CreateSkill operation middleware
+func (siw *ServerInterfaceWrapper) CreateSkill(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CreateSkill(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// InstallSkill operation middleware
+func (siw *ServerInterfaceWrapper) InstallSkill(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.InstallSkill(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// SearchSkills operation middleware
+func (siw *ServerInterfaceWrapper) SearchSkills(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params SearchSkillsParams
+
+	// ------------- Required query parameter "q" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, true, "q", r.URL.Query(), &params.Q, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "q"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "q", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "limit", r.URL.Query(), &params.Limit, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "limit"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.SearchSkills(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeleteSkill operation middleware
+func (siw *ServerInterfaceWrapper) DeleteSkill(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteSkill(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetSkill operation middleware
+func (siw *ServerInterfaceWrapper) GetSkill(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetSkill(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UpdateSkill operation middleware
+func (siw *ServerInterfaceWrapper) UpdateSkill(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdateSkill(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeleteSkillFile operation middleware
+func (siw *ServerInterfaceWrapper) DeleteSkillFile(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params DeleteSkillFileParams
+
+	// ------------- Required query parameter "path" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, true, "path", r.URL.Query(), &params.Path, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "path"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "path", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteSkillFile(w, r, id, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetSkillFile operation middleware
+func (siw *ServerInterfaceWrapper) GetSkillFile(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetSkillFileParams
+
+	// ------------- Required query parameter "path" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, true, "path", r.URL.Query(), &params.Path, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "path"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "path", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetSkillFile(w, r, id, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // ListTools operation middleware
 func (siw *ServerInterfaceWrapper) ListTools(w http.ResponseWriter, r *http.Request) {
 
@@ -2751,6 +3428,14 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/agents/{id}/users", wrapper.ListAgentUsers)
 	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/agents/{id}/users", wrapper.AssignAgentUser)
 	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/agents/{id}/users/{userId}", wrapper.RemoveAgentUser)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/auth/profile/skills", wrapper.ListProfileSkills)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/auth/profile/skills/install", wrapper.InstallProfileSkill)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/auth/profile/skills/upload", wrapper.UploadProfileSkill)
+	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/auth/profile/skills/{skillId}", wrapper.DeleteProfileSkill)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/auth/profile/skills/{skillId}", wrapper.GetProfileSkill)
+	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/api/auth/profile/skills/{skillId}", wrapper.UpdateProfileSkill)
+	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/auth/profile/skills/{skillId}/file", wrapper.DeleteProfileSkillFile)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/auth/profile/skills/{skillId}/file", wrapper.GetProfileSkillFile)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/builtin/{kind}", wrapper.ListBuiltinResources)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/builtin/{kind}/{id}", wrapper.GetBuiltinResource)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/channels", wrapper.ListChannels)
@@ -2796,6 +3481,15 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/sessions/{sessionID}/messages", wrapper.GetSessionMessages)
 	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/sessions/{sessionID}/messages", wrapper.SendSessionMessage)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/sessions/{sessionID}/system-prompt", wrapper.GetSessionSystemPrompt)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/skills", wrapper.ListSkills)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/skills", wrapper.CreateSkill)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/skills/install", wrapper.InstallSkill)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/skills/search", wrapper.SearchSkills)
+	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/skills/{id}", wrapper.DeleteSkill)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/skills/{id}", wrapper.GetSkill)
+	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/api/skills/{id}", wrapper.UpdateSkill)
+	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/skills/{id}/file", wrapper.DeleteSkillFile)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/skills/{id}/file", wrapper.GetSkillFile)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/tools", wrapper.ListTools)
 
 	return m

--- a/api/server/gen.go
+++ b/api/server/gen.go
@@ -37,6 +37,15 @@ type BuiltinResourceDetail = externalRef0.BuiltinResourceDetail
 // CachedModel defines model for CachedModel.
 type CachedModel = externalRef0.CachedModel
 
+// Channel defines model for Channel.
+type Channel = externalRef0.Channel
+
+// ChannelList defines model for ChannelList.
+type ChannelList = externalRef0.ChannelList
+
+// ChannelWriteRequest defines model for ChannelWriteRequest.
+type ChannelWriteRequest = externalRef0.ChannelWriteRequest
+
 // CreateFeedRequest defines model for CreateFeedRequest.
 type CreateFeedRequest = externalRef0.CreateFeedRequest
 
@@ -76,6 +85,12 @@ type JobInput = externalRef0.JobInput
 // JobList defines model for JobList.
 type JobList = externalRef0.JobList
 
+// PublicChannel defines model for PublicChannel.
+type PublicChannel = externalRef0.PublicChannel
+
+// PublicChannelList defines model for PublicChannelList.
+type PublicChannelList = externalRef0.PublicChannelList
+
 // SaveArticleRequest defines model for SaveArticleRequest.
 type SaveArticleRequest = externalRef0.SaveArticleRequest
 
@@ -97,8 +112,20 @@ type UpdateFeedEntryRequest = externalRef0.UpdateFeedEntryRequest
 // UpdateFeedRequest defines model for UpdateFeedRequest.
 type UpdateFeedRequest = externalRef0.UpdateFeedRequest
 
+// WeixinQRCode defines model for WeixinQRCode.
+type WeixinQRCode = externalRef0.WeixinQRCode
+
+// WeixinQRStatus defines model for WeixinQRStatus.
+type WeixinQRStatus = externalRef0.WeixinQRStatus
+
 // bearerAuthContextKey is the context key for BearerAuth security scheme
 type bearerAuthContextKey string
+
+// PollWeixinQRStatusParams defines parameters for PollWeixinQRStatus.
+type PollWeixinQRStatusParams struct {
+	// Qrcode QR code token from startWeixinQR
+	Qrcode string `form:"qrcode" json:"qrcode"`
+}
 
 // ListArticlesParams defines parameters for ListArticles.
 type ListArticlesParams struct {
@@ -137,6 +164,12 @@ type PollFeedParams struct {
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
 }
 
+// CreateChannelJSONRequestBody defines body for CreateChannel for application/json ContentType.
+type CreateChannelJSONRequestBody = externalRef0.ChannelWriteRequest
+
+// UpdateChannelJSONRequestBody defines body for UpdateChannel for application/json ContentType.
+type UpdateChannelJSONRequestBody = externalRef0.ChannelWriteRequest
+
 // SaveArticleJSONRequestBody defines body for SaveArticle for application/json ContentType.
 type SaveArticleJSONRequestBody = externalRef0.SaveArticleRequest
 
@@ -166,6 +199,30 @@ type ServerInterface interface {
 	// Get a specific builtin resource
 	// (GET /api/builtin/{kind}/{id})
 	GetBuiltinResource(w http.ResponseWriter, r *http.Request, kind string, id string)
+	// List all channels (admin only)
+	// (GET /api/channels)
+	ListChannels(w http.ResponseWriter, r *http.Request)
+	// Create a channel (admin only)
+	// (POST /api/channels)
+	CreateChannel(w http.ResponseWriter, r *http.Request)
+	// List public channels (any authenticated user)
+	// (GET /api/channels/public)
+	ListPublicChannels(w http.ResponseWriter, r *http.Request)
+	// Start WeChat QR login flow (any authenticated user)
+	// (POST /api/channels/weixin/qr)
+	StartWeixinQR(w http.ResponseWriter, r *http.Request)
+	// Poll WeChat QR login status (any authenticated user)
+	// (GET /api/channels/weixin/qr/status)
+	PollWeixinQRStatus(w http.ResponseWriter, r *http.Request, params PollWeixinQRStatusParams)
+	// Delete a channel (admin only)
+	// (DELETE /api/channels/{id})
+	DeleteChannel(w http.ResponseWriter, r *http.Request, id string)
+	// Get a channel (admin only)
+	// (GET /api/channels/{id})
+	GetChannel(w http.ResponseWriter, r *http.Request, id string)
+	// Update a channel (admin only)
+	// (PUT /api/channels/{id})
+	UpdateChannel(w http.ResponseWriter, r *http.Request, id string)
 	// List enabled models from provider config and cache
 	// (GET /api/models)
 	ListModels(w http.ResponseWriter, r *http.Request)
@@ -307,6 +364,221 @@ func (siw *ServerInterfaceWrapper) GetBuiltinResource(w http.ResponseWriter, r *
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetBuiltinResource(w, r, kind, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListChannels operation middleware
+func (siw *ServerInterfaceWrapper) ListChannels(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListChannels(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// CreateChannel operation middleware
+func (siw *ServerInterfaceWrapper) CreateChannel(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CreateChannel(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListPublicChannels operation middleware
+func (siw *ServerInterfaceWrapper) ListPublicChannels(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListPublicChannels(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// StartWeixinQR operation middleware
+func (siw *ServerInterfaceWrapper) StartWeixinQR(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.StartWeixinQR(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// PollWeixinQRStatus operation middleware
+func (siw *ServerInterfaceWrapper) PollWeixinQRStatus(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params PollWeixinQRStatusParams
+
+	// ------------- Required query parameter "qrcode" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, true, "qrcode", r.URL.Query(), &params.Qrcode, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "qrcode"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "qrcode", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PollWeixinQRStatus(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeleteChannel operation middleware
+func (siw *ServerInterfaceWrapper) DeleteChannel(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteChannel(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetChannel operation middleware
+func (siw *ServerInterfaceWrapper) GetChannel(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetChannel(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UpdateChannel operation middleware
+func (siw *ServerInterfaceWrapper) UpdateChannel(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdateChannel(w, r, id)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -1207,6 +1479,14 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/builtin/{kind}", wrapper.ListBuiltinResources)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/builtin/{kind}/{id}", wrapper.GetBuiltinResource)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/channels", wrapper.ListChannels)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/channels", wrapper.CreateChannel)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/channels/public", wrapper.ListPublicChannels)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/channels/weixin/qr", wrapper.StartWeixinQR)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/channels/weixin/qr/status", wrapper.PollWeixinQRStatus)
+	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/channels/{id}", wrapper.DeleteChannel)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/channels/{id}", wrapper.GetChannel)
+	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/api/channels/{id}", wrapper.UpdateChannel)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/models", wrapper.ListModels)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/recally/articles", wrapper.ListArticles)
 	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/recally/articles", wrapper.SaveArticle)

--- a/api/server/gen.go
+++ b/api/server/gen.go
@@ -304,6 +304,16 @@ type UploadAgentSkillMultipartBody struct {
 	File *openapi_types.File `json:"file,omitempty"`
 }
 
+// DeleteAgentSkillFileParams defines parameters for DeleteAgentSkillFile.
+type DeleteAgentSkillFileParams struct {
+	Path string `form:"path" json:"path"`
+}
+
+// GetAgentSkillFileParams defines parameters for GetAgentSkillFile.
+type GetAgentSkillFileParams struct {
+	Path string `form:"path" json:"path"`
+}
+
 // OauthCallbackParams defines parameters for OauthCallback.
 type OauthCallbackParams struct {
 	Code  string `form:"code" json:"code"`
@@ -573,10 +583,10 @@ type ServerInterface interface {
 	UpdateAgentSkill(w http.ResponseWriter, r *http.Request, id string, skillId string)
 	// Delete a skill file (creator or admin)
 	// (DELETE /api/agents/{id}/skills/{skillId}/file)
-	DeleteAgentSkillFile(w http.ResponseWriter, r *http.Request, id string, skillId string)
+	DeleteAgentSkillFile(w http.ResponseWriter, r *http.Request, id string, skillId string, params DeleteAgentSkillFileParams)
 	// Download a skill file (creator or admin)
 	// (GET /api/agents/{id}/skills/{skillId}/file)
-	GetAgentSkillFile(w http.ResponseWriter, r *http.Request, id string, skillId string)
+	GetAgentSkillFile(w http.ResponseWriter, r *http.Request, id string, skillId string, params GetAgentSkillFileParams)
 	// List users assigned to an agent (admin only)
 	// (GET /api/agents/{id}/users)
 	ListAgentUsers(w http.ResponseWriter, r *http.Request, id string)
@@ -1338,8 +1348,24 @@ func (siw *ServerInterfaceWrapper) DeleteAgentSkillFile(w http.ResponseWriter, r
 
 	r = r.WithContext(ctx)
 
+	// Parameter object where we will unmarshal all parameters from the context
+	var params DeleteAgentSkillFileParams
+
+	// ------------- Required query parameter "path" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, true, "path", r.URL.Query(), &params.Path, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "path"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "path", Err: err})
+		}
+		return
+	}
+
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.DeleteAgentSkillFile(w, r, id, skillId)
+		siw.Handler.DeleteAgentSkillFile(w, r, id, skillId, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -1379,8 +1405,24 @@ func (siw *ServerInterfaceWrapper) GetAgentSkillFile(w http.ResponseWriter, r *h
 
 	r = r.WithContext(ctx)
 
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetAgentSkillFileParams
+
+	// ------------- Required query parameter "path" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, true, "path", r.URL.Query(), &params.Path, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "path"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "path", Err: err})
+		}
+		return
+	}
+
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetAgentSkillFile(w, r, id, skillId)
+		siw.Handler.GetAgentSkillFile(w, r, id, skillId, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {

--- a/api/server/gen.go
+++ b/api/server/gen.go
@@ -44,6 +44,9 @@ type ArticleStatus = externalRef0.ArticleStatus
 // AssignAgentUserRequest defines model for AssignAgentUserRequest.
 type AssignAgentUserRequest = externalRef0.AssignAgentUserRequest
 
+// AuthResponse defines model for AuthResponse.
+type AuthResponse = externalRef0.AuthResponse
+
 // AuthUser defines model for AuthUser.
 type AuthUser = externalRef0.AuthUser
 
@@ -143,6 +146,12 @@ type JobList = externalRef0.JobList
 // LinkCodeResponse defines model for LinkCodeResponse.
 type LinkCodeResponse = externalRef0.LinkCodeResponse
 
+// LoginRequest defines model for LoginRequest.
+type LoginRequest = externalRef0.LoginRequest
+
+// MeResponse defines model for MeResponse.
+type MeResponse = externalRef0.MeResponse
+
 // OAuthConnectedResponse defines model for OAuthConnectedResponse.
 type OAuthConnectedResponse = externalRef0.OAuthConnectedResponse
 
@@ -175,6 +184,9 @@ type PublicChannel = externalRef0.PublicChannel
 
 // PublicChannelList defines model for PublicChannelList.
 type PublicChannelList = externalRef0.PublicChannelList
+
+// RegisterRequest defines model for RegisterRequest.
+type RegisterRequest = externalRef0.RegisterRequest
 
 // SandboxConfig defines model for SandboxConfig.
 type SandboxConfig = externalRef0.SandboxConfig
@@ -396,6 +408,9 @@ type UpdateAgentSkillJSONRequestBody = externalRef0.UpdateSkillRequest
 // AssignAgentUserJSONRequestBody defines body for AssignAgentUser for application/json ContentType.
 type AssignAgentUserJSONRequestBody = externalRef0.AssignAgentUserRequest
 
+// LoginJSONRequestBody defines body for Login for application/json ContentType.
+type LoginJSONRequestBody = externalRef0.LoginRequest
+
 // GenerateLinkCodeJSONRequestBody defines body for GenerateLinkCode for application/json ContentType.
 type GenerateLinkCodeJSONRequestBody = externalRef0.GenerateLinkCodeRequest
 
@@ -419,6 +434,9 @@ type SetProfileSoulJSONRequestBody = externalRef0.SetSoulRequest
 
 // SetVaultEntryJSONRequestBody defines body for SetVaultEntry for application/json ContentType.
 type SetVaultEntryJSONRequestBody = externalRef0.SetVaultEntryRequest
+
+// RegisterJSONRequestBody defines body for Register for application/json ContentType.
+type RegisterJSONRequestBody = externalRef0.RegisterRequest
 
 // UpdateAuthUserActiveJSONRequestBody defines body for UpdateAuthUserActive for application/json ContentType.
 type UpdateAuthUserActiveJSONRequestBody = externalRef0.UpdateActiveRequest
@@ -542,6 +560,15 @@ type ServerInterface interface {
 	// Remove a user from an agent (admin only)
 	// (DELETE /api/agents/{id}/users/{userId})
 	RemoveAgentUser(w http.ResponseWriter, r *http.Request, id string, userId int64)
+	// Authenticate and start a session
+	// (POST /api/auth/login)
+	Login(w http.ResponseWriter, r *http.Request)
+	// End the current session
+	// (POST /api/auth/logout)
+	Logout(w http.ResponseWriter, r *http.Request)
+	// Get the currently authenticated user
+	// (GET /api/auth/me)
+	GetMe(w http.ResponseWriter, r *http.Request)
 	// List linked identities for the current user
 	// (GET /api/auth/profile/identities)
 	ListProfileIdentities(w http.ResponseWriter, r *http.Request)
@@ -617,6 +644,9 @@ type ServerInterface interface {
 	// Create or update a vault entry
 	// (PUT /api/auth/profile/vault/{name})
 	SetVaultEntry(w http.ResponseWriter, r *http.Request, name string)
+	// Register a new user account
+	// (POST /api/auth/register)
+	Register(w http.ResponseWriter, r *http.Request)
 	// List all auth users (admin only)
 	// (GET /api/auth/users)
 	ListAuthUsers(w http.ResponseWriter, r *http.Request)
@@ -1412,6 +1442,60 @@ func (siw *ServerInterfaceWrapper) RemoveAgentUser(w http.ResponseWriter, r *htt
 	handler.ServeHTTP(w, r)
 }
 
+// Login operation middleware
+func (siw *ServerInterfaceWrapper) Login(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.Login(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// Logout operation middleware
+func (siw *ServerInterfaceWrapper) Logout(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.Logout(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetMe operation middleware
+func (siw *ServerInterfaceWrapper) GetMe(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetMe(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // ListProfileIdentities operation middleware
 func (siw *ServerInterfaceWrapper) ListProfileIdentities(w http.ResponseWriter, r *http.Request) {
 
@@ -2159,6 +2243,20 @@ func (siw *ServerInterfaceWrapper) SetVaultEntry(w http.ResponseWriter, r *http.
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.SetVaultEntry(w, r, name)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// Register operation middleware
+func (siw *ServerInterfaceWrapper) Register(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.Register(w, r)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -4514,6 +4612,9 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/agents/{id}/users", wrapper.ListAgentUsers)
 	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/agents/{id}/users", wrapper.AssignAgentUser)
 	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/agents/{id}/users/{userId}", wrapper.RemoveAgentUser)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/auth/login", wrapper.Login)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/auth/logout", wrapper.Logout)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/auth/me", wrapper.GetMe)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/auth/profile/identities", wrapper.ListProfileIdentities)
 	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/auth/profile/identities/{id}", wrapper.UnlinkProfileIdentity)
 	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/auth/profile/link-code", wrapper.GenerateLinkCode)
@@ -4539,6 +4640,7 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/auth/profile/vault", wrapper.ListVaultEntries)
 	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/auth/profile/vault/{name}", wrapper.DeleteVaultEntry)
 	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/api/auth/profile/vault/{name}", wrapper.SetVaultEntry)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/auth/register", wrapper.Register)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/auth/users", wrapper.ListAuthUsers)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/auth/users/{id}", wrapper.GetAuthUser)
 	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/api/auth/users/{id}/active", wrapper.UpdateAuthUserActive)

--- a/api/server/gen.go
+++ b/api/server/gen.go
@@ -12,12 +12,25 @@ import (
 	"net/http"
 
 	"github.com/oapi-codegen/runtime"
+	openapi_types "github.com/oapi-codegen/runtime/types"
 	externalRef0 "github.com/vaayne/anna/api/types"
 )
 
 const (
 	BearerAuthScopes bearerAuthContextKey = "BearerAuth.Scopes"
 )
+
+// Agent defines model for Agent.
+type Agent = externalRef0.Agent
+
+// AgentList defines model for AgentList.
+type AgentList = externalRef0.AgentList
+
+// AgentUser defines model for AgentUser.
+type AgentUser = externalRef0.AgentUser
+
+// AgentUserList defines model for AgentUserList.
+type AgentUserList = externalRef0.AgentUserList
 
 // Article defines model for Article.
 type Article = externalRef0.Article
@@ -27,6 +40,9 @@ type ArticleList = externalRef0.ArticleList
 
 // ArticleStatus defines model for ArticleStatus.
 type ArticleStatus = externalRef0.ArticleStatus
+
+// AssignAgentUserRequest defines model for AssignAgentUserRequest.
+type AssignAgentUserRequest = externalRef0.AssignAgentUserRequest
 
 // BuiltinResource defines model for BuiltinResource.
 type BuiltinResource = externalRef0.BuiltinResource
@@ -46,6 +62,9 @@ type ChannelList = externalRef0.ChannelList
 // ChannelWriteRequest defines model for ChannelWriteRequest.
 type ChannelWriteRequest = externalRef0.ChannelWriteRequest
 
+// CreateAgentRequest defines model for CreateAgentRequest.
+type CreateAgentRequest = externalRef0.CreateAgentRequest
+
 // CreateFeedRequest defines model for CreateFeedRequest.
 type CreateFeedRequest = externalRef0.CreateFeedRequest
 
@@ -57,6 +76,9 @@ type DeleteResult = externalRef0.DeleteResult
 
 // Digest defines model for Digest.
 type Digest = externalRef0.Digest
+
+// DuplicateSkillResult defines model for DuplicateSkillResult.
+type DuplicateSkillResult = externalRef0.DuplicateSkillResult
 
 // Error defines model for Error.
 type Error = externalRef0.Error
@@ -81,6 +103,9 @@ type FeedPollResult = externalRef0.FeedPollResult
 
 // FetchModelsRequest defines model for FetchModelsRequest.
 type FetchModelsRequest = externalRef0.FetchModelsRequest
+
+// InstallSkillRequest defines model for InstallSkillRequest.
+type InstallSkillRequest = externalRef0.InstallSkillRequest
 
 // Job defines model for Job.
 type Job = externalRef0.Job
@@ -112,6 +137,12 @@ type PublicChannel = externalRef0.PublicChannel
 // PublicChannelList defines model for PublicChannelList.
 type PublicChannelList = externalRef0.PublicChannelList
 
+// SandboxConfig defines model for SandboxConfig.
+type SandboxConfig = externalRef0.SandboxConfig
+
+// SandboxNetworkConfig defines model for SandboxNetworkConfig.
+type SandboxNetworkConfig = externalRef0.SandboxNetworkConfig
+
 // SaveArticleRequest defines model for SaveArticleRequest.
 type SaveArticleRequest = externalRef0.SaveArticleRequest
 
@@ -123,6 +154,15 @@ type Session = externalRef0.Session
 
 // SessionDetail defines model for SessionDetail.
 type SessionDetail = externalRef0.SessionDetail
+
+// Skill defines model for Skill.
+type Skill = externalRef0.Skill
+
+// SkillList defines model for SkillList.
+type SkillList = externalRef0.SkillList
+
+// SkillUploadResult defines model for SkillUploadResult.
+type SkillUploadResult = externalRef0.SkillUploadResult
 
 // SourceType defines model for SourceType.
 type SourceType = externalRef0.SourceType
@@ -145,6 +185,9 @@ type UpdateFeedEntryRequest = externalRef0.UpdateFeedEntryRequest
 // UpdateFeedRequest defines model for UpdateFeedRequest.
 type UpdateFeedRequest = externalRef0.UpdateFeedRequest
 
+// UpdateSkillRequest defines model for UpdateSkillRequest.
+type UpdateSkillRequest = externalRef0.UpdateSkillRequest
+
 // WeixinQRCode defines model for WeixinQRCode.
 type WeixinQRCode = externalRef0.WeixinQRCode
 
@@ -153,6 +196,11 @@ type WeixinQRStatus = externalRef0.WeixinQRStatus
 
 // bearerAuthContextKey is the context key for BearerAuth security scheme
 type bearerAuthContextKey string
+
+// UploadAgentSkillMultipartBody defines parameters for UploadAgentSkill.
+type UploadAgentSkillMultipartBody struct {
+	File *openapi_types.File `json:"file,omitempty"`
+}
 
 // PollWeixinQRStatusParams defines parameters for PollWeixinQRStatus.
 type PollWeixinQRStatusParams struct {
@@ -215,6 +263,24 @@ type GetSessionMessagesParams struct {
 	Skip *int `form:"skip,omitempty" json:"skip,omitempty"`
 }
 
+// CreateAgentJSONRequestBody defines body for CreateAgent for application/json ContentType.
+type CreateAgentJSONRequestBody = externalRef0.CreateAgentRequest
+
+// UpdateAgentJSONRequestBody defines body for UpdateAgent for application/json ContentType.
+type UpdateAgentJSONRequestBody = externalRef0.Agent
+
+// InstallAgentSkillJSONRequestBody defines body for InstallAgentSkill for application/json ContentType.
+type InstallAgentSkillJSONRequestBody = externalRef0.InstallSkillRequest
+
+// UploadAgentSkillMultipartRequestBody defines body for UploadAgentSkill for multipart/form-data ContentType.
+type UploadAgentSkillMultipartRequestBody UploadAgentSkillMultipartBody
+
+// UpdateAgentSkillJSONRequestBody defines body for UpdateAgentSkill for application/json ContentType.
+type UpdateAgentSkillJSONRequestBody = externalRef0.UpdateSkillRequest
+
+// AssignAgentUserJSONRequestBody defines body for AssignAgentUser for application/json ContentType.
+type AssignAgentUserJSONRequestBody = externalRef0.AssignAgentUserRequest
+
 // CreateChannelJSONRequestBody defines body for CreateChannel for application/json ContentType.
 type CreateChannelJSONRequestBody = externalRef0.ChannelWriteRequest
 
@@ -259,6 +325,57 @@ type SendSessionMessageJSONRequestBody = externalRef0.SendMessageRequest
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
+	// List agents (any authenticated user; non-admin sees accessible only)
+	// (GET /api/agents)
+	ListAgents(w http.ResponseWriter, r *http.Request)
+	// Create an agent
+	// (POST /api/agents)
+	CreateAgent(w http.ResponseWriter, r *http.Request)
+	// Delete an agent
+	// (DELETE /api/agents/{id})
+	DeleteAgent(w http.ResponseWriter, r *http.Request, id string)
+	// Get an agent
+	// (GET /api/agents/{id})
+	GetAgent(w http.ResponseWriter, r *http.Request, id string)
+	// Update an agent
+	// (PUT /api/agents/{id})
+	UpdateAgent(w http.ResponseWriter, r *http.Request, id string)
+	// List skills for an agent (creator or admin)
+	// (GET /api/agents/{id}/skills)
+	ListAgentSkills(w http.ResponseWriter, r *http.Request, id string)
+	// Duplicate a builtin skill to an agent (admin only)
+	// (POST /api/agents/{id}/skills/from-builtin/{skillId})
+	DuplicateBuiltinSkillToAgent(w http.ResponseWriter, r *http.Request, id string, skillId string)
+	// Install a skill to an agent from a remote source (admin only)
+	// (POST /api/agents/{id}/skills/install)
+	InstallAgentSkill(w http.ResponseWriter, r *http.Request, id string)
+	// Upload a skill zip to an agent (admin only)
+	// (POST /api/agents/{id}/skills/upload)
+	UploadAgentSkill(w http.ResponseWriter, r *http.Request, id string)
+	// Delete an agent skill (creator or admin)
+	// (DELETE /api/agents/{id}/skills/{skillId})
+	DeleteAgentSkill(w http.ResponseWriter, r *http.Request, id string, skillId string)
+	// Get an agent skill (creator or admin)
+	// (GET /api/agents/{id}/skills/{skillId})
+	GetAgentSkill(w http.ResponseWriter, r *http.Request, id string, skillId string)
+	// Update an agent skill (creator or admin)
+	// (PUT /api/agents/{id}/skills/{skillId})
+	UpdateAgentSkill(w http.ResponseWriter, r *http.Request, id string, skillId string)
+	// Delete a skill file (creator or admin)
+	// (DELETE /api/agents/{id}/skills/{skillId}/file)
+	DeleteAgentSkillFile(w http.ResponseWriter, r *http.Request, id string, skillId string)
+	// Download a skill file (creator or admin)
+	// (GET /api/agents/{id}/skills/{skillId}/file)
+	GetAgentSkillFile(w http.ResponseWriter, r *http.Request, id string, skillId string)
+	// List users assigned to an agent (admin only)
+	// (GET /api/agents/{id}/users)
+	ListAgentUsers(w http.ResponseWriter, r *http.Request, id string)
+	// Assign a user to an agent (admin only)
+	// (POST /api/agents/{id}/users)
+	AssignAgentUser(w http.ResponseWriter, r *http.Request, id string)
+	// Remove a user from an agent (admin only)
+	// (DELETE /api/agents/{id}/users/{userId})
+	RemoveAgentUser(w http.ResponseWriter, r *http.Request, id string, userId int64)
 	// List builtin resources of a given kind
 	// (GET /api/builtin/{kind})
 	ListBuiltinResources(w http.ResponseWriter, r *http.Request, kind string)
@@ -407,6 +524,589 @@ type ServerInterfaceWrapper struct {
 }
 
 type MiddlewareFunc func(http.Handler) http.Handler
+
+// ListAgents operation middleware
+func (siw *ServerInterfaceWrapper) ListAgents(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListAgents(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// CreateAgent operation middleware
+func (siw *ServerInterfaceWrapper) CreateAgent(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CreateAgent(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeleteAgent operation middleware
+func (siw *ServerInterfaceWrapper) DeleteAgent(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteAgent(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetAgent operation middleware
+func (siw *ServerInterfaceWrapper) GetAgent(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetAgent(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UpdateAgent operation middleware
+func (siw *ServerInterfaceWrapper) UpdateAgent(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdateAgent(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListAgentSkills operation middleware
+func (siw *ServerInterfaceWrapper) ListAgentSkills(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListAgentSkills(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DuplicateBuiltinSkillToAgent operation middleware
+func (siw *ServerInterfaceWrapper) DuplicateBuiltinSkillToAgent(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "skillId" -------------
+	var skillId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "skillId", r.PathValue("skillId"), &skillId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "skillId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DuplicateBuiltinSkillToAgent(w, r, id, skillId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// InstallAgentSkill operation middleware
+func (siw *ServerInterfaceWrapper) InstallAgentSkill(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.InstallAgentSkill(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UploadAgentSkill operation middleware
+func (siw *ServerInterfaceWrapper) UploadAgentSkill(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UploadAgentSkill(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeleteAgentSkill operation middleware
+func (siw *ServerInterfaceWrapper) DeleteAgentSkill(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "skillId" -------------
+	var skillId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "skillId", r.PathValue("skillId"), &skillId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "skillId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteAgentSkill(w, r, id, skillId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetAgentSkill operation middleware
+func (siw *ServerInterfaceWrapper) GetAgentSkill(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "skillId" -------------
+	var skillId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "skillId", r.PathValue("skillId"), &skillId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "skillId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetAgentSkill(w, r, id, skillId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UpdateAgentSkill operation middleware
+func (siw *ServerInterfaceWrapper) UpdateAgentSkill(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "skillId" -------------
+	var skillId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "skillId", r.PathValue("skillId"), &skillId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "skillId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdateAgentSkill(w, r, id, skillId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeleteAgentSkillFile operation middleware
+func (siw *ServerInterfaceWrapper) DeleteAgentSkillFile(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "skillId" -------------
+	var skillId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "skillId", r.PathValue("skillId"), &skillId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "skillId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteAgentSkillFile(w, r, id, skillId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetAgentSkillFile operation middleware
+func (siw *ServerInterfaceWrapper) GetAgentSkillFile(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "skillId" -------------
+	var skillId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "skillId", r.PathValue("skillId"), &skillId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "skillId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetAgentSkillFile(w, r, id, skillId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListAgentUsers operation middleware
+func (siw *ServerInterfaceWrapper) ListAgentUsers(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListAgentUsers(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// AssignAgentUser operation middleware
+func (siw *ServerInterfaceWrapper) AssignAgentUser(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.AssignAgentUser(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// RemoveAgentUser operation middleware
+func (siw *ServerInterfaceWrapper) RemoveAgentUser(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "userId" -------------
+	var userId int64
+
+	err = runtime.BindStyledParameterWithOptions("simple", "userId", r.PathValue("userId"), &userId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "integer", Format: "int64"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "userId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.RemoveAgentUser(w, r, id, userId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
 
 // ListBuiltinResources operation middleware
 func (siw *ServerInterfaceWrapper) ListBuiltinResources(w http.ResponseWriter, r *http.Request) {
@@ -2034,6 +2734,23 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 		ErrorHandlerFunc:   options.ErrorHandlerFunc,
 	}
 
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/agents", wrapper.ListAgents)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/agents", wrapper.CreateAgent)
+	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/agents/{id}", wrapper.DeleteAgent)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/agents/{id}", wrapper.GetAgent)
+	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/api/agents/{id}", wrapper.UpdateAgent)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/agents/{id}/skills", wrapper.ListAgentSkills)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/agents/{id}/skills/from-builtin/{skillId}", wrapper.DuplicateBuiltinSkillToAgent)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/agents/{id}/skills/install", wrapper.InstallAgentSkill)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/agents/{id}/skills/upload", wrapper.UploadAgentSkill)
+	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/agents/{id}/skills/{skillId}", wrapper.DeleteAgentSkill)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/agents/{id}/skills/{skillId}", wrapper.GetAgentSkill)
+	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/api/agents/{id}/skills/{skillId}", wrapper.UpdateAgentSkill)
+	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/agents/{id}/skills/{skillId}/file", wrapper.DeleteAgentSkillFile)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/agents/{id}/skills/{skillId}/file", wrapper.GetAgentSkillFile)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/agents/{id}/users", wrapper.ListAgentUsers)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/agents/{id}/users", wrapper.AssignAgentUser)
+	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/agents/{id}/users/{userId}", wrapper.RemoveAgentUser)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/builtin/{kind}", wrapper.ListBuiltinResources)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/builtin/{kind}/{id}", wrapper.GetBuiltinResource)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/channels", wrapper.ListChannels)

--- a/api/server/gen.go
+++ b/api/server/gen.go
@@ -76,6 +76,9 @@ type FeedList = externalRef0.FeedList
 // FeedPollResult defines model for FeedPollResult.
 type FeedPollResult = externalRef0.FeedPollResult
 
+// FetchModelsRequest defines model for FetchModelsRequest.
+type FetchModelsRequest = externalRef0.FetchModelsRequest
+
 // Job defines model for Job.
 type Job = externalRef0.Job
 
@@ -84,6 +87,21 @@ type JobInput = externalRef0.JobInput
 
 // JobList defines model for JobList.
 type JobList = externalRef0.JobList
+
+// Provider defines model for Provider.
+type Provider = externalRef0.Provider
+
+// ProviderModel defines model for ProviderModel.
+type ProviderModel = externalRef0.ProviderModel
+
+// ProviderModelCost defines model for ProviderModelCost.
+type ProviderModelCost = externalRef0.ProviderModelCost
+
+// ProviderModelItem defines model for ProviderModelItem.
+type ProviderModelItem = externalRef0.ProviderModelItem
+
+// ProviderType defines model for ProviderType.
+type ProviderType = externalRef0.ProviderType
 
 // PublicChannel defines model for PublicChannel.
 type PublicChannel = externalRef0.PublicChannel
@@ -170,6 +188,15 @@ type CreateChannelJSONRequestBody = externalRef0.ChannelWriteRequest
 // UpdateChannelJSONRequestBody defines body for UpdateChannel for application/json ContentType.
 type UpdateChannelJSONRequestBody = externalRef0.ChannelWriteRequest
 
+// CreateProviderJSONRequestBody defines body for CreateProvider for application/json ContentType.
+type CreateProviderJSONRequestBody = externalRef0.Provider
+
+// UpdateProviderJSONRequestBody defines body for UpdateProvider for application/json ContentType.
+type UpdateProviderJSONRequestBody = externalRef0.Provider
+
+// FetchProviderModelsJSONRequestBody defines body for FetchProviderModels for application/json ContentType.
+type FetchProviderModelsJSONRequestBody = externalRef0.FetchModelsRequest
+
 // SaveArticleJSONRequestBody defines body for SaveArticle for application/json ContentType.
 type SaveArticleJSONRequestBody = externalRef0.SaveArticleRequest
 
@@ -226,6 +253,30 @@ type ServerInterface interface {
 	// List enabled models from provider config and cache
 	// (GET /api/models)
 	ListModels(w http.ResponseWriter, r *http.Request)
+	// List available provider types (admin only)
+	// (GET /api/provider-types)
+	ListProviderTypes(w http.ResponseWriter, r *http.Request)
+	// List all providers (admin only)
+	// (GET /api/providers)
+	ListProviders(w http.ResponseWriter, r *http.Request)
+	// Create a provider (admin only)
+	// (POST /api/providers)
+	CreateProvider(w http.ResponseWriter, r *http.Request)
+	// Delete a provider (admin only)
+	// (DELETE /api/providers/{id})
+	DeleteProvider(w http.ResponseWriter, r *http.Request, id string)
+	// Get a provider (admin only)
+	// (GET /api/providers/{id})
+	GetProvider(w http.ResponseWriter, r *http.Request, id string)
+	// Update a provider (admin only)
+	// (PUT /api/providers/{id})
+	UpdateProvider(w http.ResponseWriter, r *http.Request, id string)
+	// List models for a provider (admin only)
+	// (GET /api/providers/{id}/models)
+	ListProviderModels(w http.ResponseWriter, r *http.Request, id string)
+	// Fetch and cache models from upstream provider (admin only)
+	// (POST /api/providers/{id}/models)
+	FetchProviderModels(w http.ResponseWriter, r *http.Request, id string)
 	// List or search articles
 	// (GET /api/recally/articles)
 	ListArticles(w http.ResponseWriter, r *http.Request, params ListArticlesParams)
@@ -599,6 +650,226 @@ func (siw *ServerInterfaceWrapper) ListModels(w http.ResponseWriter, r *http.Req
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.ListModels(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListProviderTypes operation middleware
+func (siw *ServerInterfaceWrapper) ListProviderTypes(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListProviderTypes(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListProviders operation middleware
+func (siw *ServerInterfaceWrapper) ListProviders(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListProviders(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// CreateProvider operation middleware
+func (siw *ServerInterfaceWrapper) CreateProvider(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CreateProvider(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeleteProvider operation middleware
+func (siw *ServerInterfaceWrapper) DeleteProvider(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteProvider(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetProvider operation middleware
+func (siw *ServerInterfaceWrapper) GetProvider(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetProvider(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UpdateProvider operation middleware
+func (siw *ServerInterfaceWrapper) UpdateProvider(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdateProvider(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListProviderModels operation middleware
+func (siw *ServerInterfaceWrapper) ListProviderModels(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListProviderModels(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// FetchProviderModels operation middleware
+func (siw *ServerInterfaceWrapper) FetchProviderModels(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.FetchProviderModels(w, r, id)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -1488,6 +1759,14 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/channels/{id}", wrapper.GetChannel)
 	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/api/channels/{id}", wrapper.UpdateChannel)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/models", wrapper.ListModels)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/provider-types", wrapper.ListProviderTypes)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/providers", wrapper.ListProviders)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/providers", wrapper.CreateProvider)
+	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/providers/{id}", wrapper.DeleteProvider)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/providers/{id}", wrapper.GetProvider)
+	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/api/providers/{id}", wrapper.UpdateProvider)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/providers/{id}/models", wrapper.ListProviderModels)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/providers/{id}/models", wrapper.FetchProviderModels)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/recally/articles", wrapper.ListArticles)
 	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/recally/articles", wrapper.SaveArticle)
 	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/recally/articles/{id}", wrapper.DeleteArticle)

--- a/api/server/gen.go
+++ b/api/server/gen.go
@@ -49,6 +49,9 @@ type ChannelWriteRequest = externalRef0.ChannelWriteRequest
 // CreateFeedRequest defines model for CreateFeedRequest.
 type CreateFeedRequest = externalRef0.CreateFeedRequest
 
+// CreateSessionRequest defines model for CreateSessionRequest.
+type CreateSessionRequest = externalRef0.CreateSessionRequest
+
 // DeleteResult defines model for DeleteResult.
 type DeleteResult = externalRef0.DeleteResult
 
@@ -112,8 +115,20 @@ type PublicChannelList = externalRef0.PublicChannelList
 // SaveArticleRequest defines model for SaveArticleRequest.
 type SaveArticleRequest = externalRef0.SaveArticleRequest
 
+// SendMessageRequest defines model for SendMessageRequest.
+type SendMessageRequest = externalRef0.SendMessageRequest
+
+// Session defines model for Session.
+type Session = externalRef0.Session
+
+// SessionDetail defines model for SessionDetail.
+type SessionDetail = externalRef0.SessionDetail
+
 // SourceType defines model for SourceType.
 type SourceType = externalRef0.SourceType
+
+// SystemPromptResponse defines model for SystemPromptResponse.
+type SystemPromptResponse = externalRef0.SystemPromptResponse
 
 // TagCount defines model for TagCount.
 type TagCount = externalRef0.TagCount
@@ -182,6 +197,24 @@ type PollFeedParams struct {
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
 }
 
+// ListSessionsParams defines parameters for ListSessions.
+type ListSessionsParams struct {
+	// Limit Maximum number of sessions to return
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Offset Number of sessions to skip
+	Offset *int `form:"offset,omitempty" json:"offset,omitempty"`
+}
+
+// GetSessionMessagesParams defines parameters for GetSessionMessages.
+type GetSessionMessagesParams struct {
+	// Limit Maximum number of messages to return
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Skip Number of messages to skip from the end
+	Skip *int `form:"skip,omitempty" json:"skip,omitempty"`
+}
+
 // CreateChannelJSONRequestBody defines body for CreateChannel for application/json ContentType.
 type CreateChannelJSONRequestBody = externalRef0.ChannelWriteRequest
 
@@ -217,6 +250,12 @@ type CreateSchedulerJobJSONRequestBody = externalRef0.JobInput
 
 // UpdateSchedulerJobJSONRequestBody defines body for UpdateSchedulerJob for application/json ContentType.
 type UpdateSchedulerJobJSONRequestBody = externalRef0.JobInput
+
+// CreateSessionJSONRequestBody defines body for CreateSession for application/json ContentType.
+type CreateSessionJSONRequestBody = externalRef0.CreateSessionRequest
+
+// SendSessionMessageJSONRequestBody defines body for SendSessionMessage for application/json ContentType.
+type SendSessionMessageJSONRequestBody = externalRef0.SendMessageRequest
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
@@ -337,6 +376,24 @@ type ServerInterface interface {
 	// List scheduler job runs
 	// (GET /api/scheduler/jobs/{id}/runs)
 	ListSchedulerJobRuns(w http.ResponseWriter, r *http.Request, id string)
+	// List sessions (all users see their own; admins see all)
+	// (GET /api/sessions)
+	ListSessions(w http.ResponseWriter, r *http.Request, params ListSessionsParams)
+	// Create a new session
+	// (POST /api/sessions)
+	CreateSession(w http.ResponseWriter, r *http.Request)
+	// Get session detail
+	// (GET /api/sessions/{sessionID})
+	GetSession(w http.ResponseWriter, r *http.Request, sessionID string)
+	// Get messages for a session
+	// (GET /api/sessions/{sessionID}/messages)
+	GetSessionMessages(w http.ResponseWriter, r *http.Request, sessionID string, params GetSessionMessagesParams)
+	// Send a message to a session (SSE streaming)
+	// (POST /api/sessions/{sessionID}/messages)
+	SendSessionMessage(w http.ResponseWriter, r *http.Request, sessionID string)
+	// Get the system prompt for a session
+	// (GET /api/sessions/{sessionID}/system-prompt)
+	GetSessionSystemPrompt(w http.ResponseWriter, r *http.Request, sessionID string)
 	// List available agent tools
 	// (GET /api/tools)
 	ListTools(w http.ResponseWriter, r *http.Request)
@@ -1608,6 +1665,235 @@ func (siw *ServerInterfaceWrapper) ListSchedulerJobRuns(w http.ResponseWriter, r
 	handler.ServeHTTP(w, r)
 }
 
+// ListSessions operation middleware
+func (siw *ServerInterfaceWrapper) ListSessions(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListSessionsParams
+
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "limit", r.URL.Query(), &params.Limit, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "limit"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "offset" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "offset", r.URL.Query(), &params.Offset, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "offset"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "offset", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListSessions(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// CreateSession operation middleware
+func (siw *ServerInterfaceWrapper) CreateSession(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CreateSession(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetSession operation middleware
+func (siw *ServerInterfaceWrapper) GetSession(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "sessionID" -------------
+	var sessionID string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "sessionID", r.PathValue("sessionID"), &sessionID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "sessionID", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetSession(w, r, sessionID)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetSessionMessages operation middleware
+func (siw *ServerInterfaceWrapper) GetSessionMessages(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "sessionID" -------------
+	var sessionID string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "sessionID", r.PathValue("sessionID"), &sessionID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "sessionID", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetSessionMessagesParams
+
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "limit", r.URL.Query(), &params.Limit, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "limit"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "skip" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "skip", r.URL.Query(), &params.Skip, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "skip"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "skip", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetSessionMessages(w, r, sessionID, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// SendSessionMessage operation middleware
+func (siw *ServerInterfaceWrapper) SendSessionMessage(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "sessionID" -------------
+	var sessionID string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "sessionID", r.PathValue("sessionID"), &sessionID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "sessionID", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.SendSessionMessage(w, r, sessionID)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetSessionSystemPrompt operation middleware
+func (siw *ServerInterfaceWrapper) GetSessionSystemPrompt(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "sessionID" -------------
+	var sessionID string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "sessionID", r.PathValue("sessionID"), &sessionID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "sessionID", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetSessionSystemPrompt(w, r, sessionID)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // ListTools operation middleware
 func (siw *ServerInterfaceWrapper) ListTools(w http.ResponseWriter, r *http.Request) {
 
@@ -1787,6 +2073,12 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/api/scheduler/jobs/{id}", wrapper.UpdateSchedulerJob)
 	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/scheduler/jobs/{id}/run", wrapper.TriggerSchedulerJob)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/scheduler/jobs/{id}/runs", wrapper.ListSchedulerJobRuns)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/sessions", wrapper.ListSessions)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/sessions", wrapper.CreateSession)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/sessions/{sessionID}", wrapper.GetSession)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/sessions/{sessionID}/messages", wrapper.GetSessionMessages)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/sessions/{sessionID}/messages", wrapper.SendSessionMessage)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/sessions/{sessionID}/system-prompt", wrapper.GetSessionSystemPrompt)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/tools", wrapper.ListTools)
 
 	return m

--- a/api/server/gen.go
+++ b/api/server/gen.go
@@ -44,6 +44,12 @@ type ArticleStatus = externalRef0.ArticleStatus
 // AssignAgentUserRequest defines model for AssignAgentUserRequest.
 type AssignAgentUserRequest = externalRef0.AssignAgentUserRequest
 
+// AuthUser defines model for AuthUser.
+type AuthUser = externalRef0.AuthUser
+
+// AuthUserList defines model for AuthUserList.
+type AuthUserList = externalRef0.AuthUserList
+
 // BuiltinResource defines model for BuiltinResource.
 type BuiltinResource = externalRef0.BuiltinResource
 
@@ -113,6 +119,9 @@ type FetchModelsRequest = externalRef0.FetchModelsRequest
 // GlobalInstallSkillRequest defines model for GlobalInstallSkillRequest.
 type GlobalInstallSkillRequest = externalRef0.GlobalInstallSkillRequest
 
+// Identity defines model for Identity.
+type Identity = externalRef0.Identity
+
 // InstallSkillRequest defines model for InstallSkillRequest.
 type InstallSkillRequest = externalRef0.InstallSkillRequest
 
@@ -167,6 +176,9 @@ type Session = externalRef0.Session
 // SessionDetail defines model for SessionDetail.
 type SessionDetail = externalRef0.SessionDetail
 
+// SetMemoryRequest defines model for SetMemoryRequest.
+type SetMemoryRequest = externalRef0.SetMemoryRequest
+
 // Skill defines model for Skill.
 type Skill = externalRef0.Skill
 
@@ -197,8 +209,17 @@ type TagCount = externalRef0.TagCount
 // Tool defines model for Tool.
 type Tool = externalRef0.Tool
 
+// UpdateActiveRequest defines model for UpdateActiveRequest.
+type UpdateActiveRequest = externalRef0.UpdateActiveRequest
+
+// UpdateAgentsRequest defines model for UpdateAgentsRequest.
+type UpdateAgentsRequest = externalRef0.UpdateAgentsRequest
+
 // UpdateArticleRequest Only provided fields are updated.
 type UpdateArticleRequest = externalRef0.UpdateArticleRequest
+
+// UpdateDefaultAgentRequest defines model for UpdateDefaultAgentRequest.
+type UpdateDefaultAgentRequest = externalRef0.UpdateDefaultAgentRequest
 
 // UpdateFeedEntryRequest defines model for UpdateFeedEntryRequest.
 type UpdateFeedEntryRequest = externalRef0.UpdateFeedEntryRequest
@@ -206,8 +227,17 @@ type UpdateFeedEntryRequest = externalRef0.UpdateFeedEntryRequest
 // UpdateFeedRequest defines model for UpdateFeedRequest.
 type UpdateFeedRequest = externalRef0.UpdateFeedRequest
 
+// UpdateNotifyIdentityRequest defines model for UpdateNotifyIdentityRequest.
+type UpdateNotifyIdentityRequest = externalRef0.UpdateNotifyIdentityRequest
+
+// UpdateRoleRequest defines model for UpdateRoleRequest.
+type UpdateRoleRequest = externalRef0.UpdateRoleRequest
+
 // UpdateSkillRequest defines model for UpdateSkillRequest.
 type UpdateSkillRequest = externalRef0.UpdateSkillRequest
+
+// UserMemory defines model for UserMemory.
+type UserMemory = externalRef0.UserMemory
 
 // WeixinQRCode defines model for WeixinQRCode.
 type WeixinQRCode = externalRef0.WeixinQRCode
@@ -342,6 +372,15 @@ type UploadProfileSkillMultipartRequestBody UploadProfileSkillMultipartBody
 // UpdateProfileSkillJSONRequestBody defines body for UpdateProfileSkill for application/json ContentType.
 type UpdateProfileSkillJSONRequestBody = externalRef0.UpdateSkillRequest
 
+// UpdateAuthUserActiveJSONRequestBody defines body for UpdateAuthUserActive for application/json ContentType.
+type UpdateAuthUserActiveJSONRequestBody = externalRef0.UpdateActiveRequest
+
+// UpdateAuthUserAgentsJSONRequestBody defines body for UpdateAuthUserAgents for application/json ContentType.
+type UpdateAuthUserAgentsJSONRequestBody = externalRef0.UpdateAgentsRequest
+
+// UpdateAuthUserRoleJSONRequestBody defines body for UpdateAuthUserRole for application/json ContentType.
+type UpdateAuthUserRoleJSONRequestBody = externalRef0.UpdateRoleRequest
+
 // CreateChannelJSONRequestBody defines body for CreateChannel for application/json ContentType.
 type CreateChannelJSONRequestBody = externalRef0.ChannelWriteRequest
 
@@ -392,6 +431,15 @@ type InstallSkillJSONRequestBody = externalRef0.GlobalInstallSkillRequest
 
 // UpdateSkillJSONRequestBody defines body for UpdateSkill for application/json ContentType.
 type UpdateSkillJSONRequestBody = externalRef0.UpdateSkillRequest
+
+// UpdateUserDefaultAgentJSONRequestBody defines body for UpdateUserDefaultAgent for application/json ContentType.
+type UpdateUserDefaultAgentJSONRequestBody = externalRef0.UpdateDefaultAgentRequest
+
+// SetUserMemoryJSONRequestBody defines body for SetUserMemory for application/json ContentType.
+type SetUserMemoryJSONRequestBody = externalRef0.SetMemoryRequest
+
+// UpdateUserNotifyIdentityJSONRequestBody defines body for UpdateUserNotifyIdentity for application/json ContentType.
+type UpdateUserNotifyIdentityJSONRequestBody = externalRef0.UpdateNotifyIdentityRequest
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
@@ -470,6 +518,27 @@ type ServerInterface interface {
 	// Get a profile skill file
 	// (GET /api/auth/profile/skills/{skillId}/file)
 	GetProfileSkillFile(w http.ResponseWriter, r *http.Request, skillId string, params GetProfileSkillFileParams)
+	// List all auth users (admin only)
+	// (GET /api/auth/users)
+	ListAuthUsers(w http.ResponseWriter, r *http.Request)
+	// Get an auth user by ID (admin only)
+	// (GET /api/auth/users/{id})
+	GetAuthUser(w http.ResponseWriter, r *http.Request, id int64)
+	// Update the active status of an auth user (admin only)
+	// (PUT /api/auth/users/{id}/active)
+	UpdateAuthUserActive(w http.ResponseWriter, r *http.Request, id int64)
+	// List agents assigned to an auth user (admin only)
+	// (GET /api/auth/users/{id}/agents)
+	ListAuthUserAgents(w http.ResponseWriter, r *http.Request, id int64)
+	// Update agents assigned to an auth user (admin only)
+	// (PUT /api/auth/users/{id}/agents)
+	UpdateAuthUserAgents(w http.ResponseWriter, r *http.Request, id int64)
+	// Delete an identity linked to an auth user (admin only)
+	// (DELETE /api/auth/users/{id}/identities/{identityId})
+	DeleteAuthUserIdentity(w http.ResponseWriter, r *http.Request, id int64, identityId int64)
+	// Update the role of an auth user (admin only)
+	// (PUT /api/auth/users/{id}/role)
+	UpdateAuthUserRole(w http.ResponseWriter, r *http.Request, id int64)
 	// List builtin resources of a given kind
 	// (GET /api/builtin/{kind})
 	ListBuiltinResources(w http.ResponseWriter, r *http.Request, kind string)
@@ -635,6 +704,21 @@ type ServerInterface interface {
 	// List available agent tools
 	// (GET /api/tools)
 	ListTools(w http.ResponseWriter, r *http.Request)
+	// Update the default agent for a user (admin only)
+	// (PUT /api/users/{id}/default-agent)
+	UpdateUserDefaultAgent(w http.ResponseWriter, r *http.Request, id int64)
+	// List memories for a user (admin only)
+	// (GET /api/users/{id}/memories)
+	ListUserMemories(w http.ResponseWriter, r *http.Request, id int64)
+	// Delete memory for a user and agent (admin only)
+	// (DELETE /api/users/{id}/memories/{agentId})
+	DeleteUserMemory(w http.ResponseWriter, r *http.Request, id int64, agentId string)
+	// Set memory for a user and agent (admin only)
+	// (PUT /api/users/{id}/memories/{agentId})
+	SetUserMemory(w http.ResponseWriter, r *http.Request, id int64, agentId string)
+	// Update the notify identity for a user (admin only)
+	// (PUT /api/users/{id}/notify-identity)
+	UpdateUserNotifyIdentity(w http.ResponseWriter, r *http.Request, id int64)
 }
 
 // ServerInterfaceWrapper converts contexts to parameters.
@@ -1472,6 +1556,227 @@ func (siw *ServerInterfaceWrapper) GetProfileSkillFile(w http.ResponseWriter, r 
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetProfileSkillFile(w, r, skillId, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListAuthUsers operation middleware
+func (siw *ServerInterfaceWrapper) ListAuthUsers(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListAuthUsers(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetAuthUser operation middleware
+func (siw *ServerInterfaceWrapper) GetAuthUser(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id int64
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "integer", Format: "int64"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetAuthUser(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UpdateAuthUserActive operation middleware
+func (siw *ServerInterfaceWrapper) UpdateAuthUserActive(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id int64
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "integer", Format: "int64"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdateAuthUserActive(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListAuthUserAgents operation middleware
+func (siw *ServerInterfaceWrapper) ListAuthUserAgents(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id int64
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "integer", Format: "int64"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListAuthUserAgents(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UpdateAuthUserAgents operation middleware
+func (siw *ServerInterfaceWrapper) UpdateAuthUserAgents(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id int64
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "integer", Format: "int64"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdateAuthUserAgents(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeleteAuthUserIdentity operation middleware
+func (siw *ServerInterfaceWrapper) DeleteAuthUserIdentity(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id int64
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "integer", Format: "int64"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "identityId" -------------
+	var identityId int64
+
+	err = runtime.BindStyledParameterWithOptions("simple", "identityId", r.PathValue("identityId"), &identityId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "integer", Format: "int64"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "identityId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteAuthUserIdentity(w, r, id, identityId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UpdateAuthUserRole operation middleware
+func (siw *ServerInterfaceWrapper) UpdateAuthUserRole(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id int64
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "integer", Format: "int64"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdateAuthUserRole(w, r, id)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -3291,6 +3596,184 @@ func (siw *ServerInterfaceWrapper) ListTools(w http.ResponseWriter, r *http.Requ
 	handler.ServeHTTP(w, r)
 }
 
+// UpdateUserDefaultAgent operation middleware
+func (siw *ServerInterfaceWrapper) UpdateUserDefaultAgent(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id int64
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "integer", Format: "int64"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdateUserDefaultAgent(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListUserMemories operation middleware
+func (siw *ServerInterfaceWrapper) ListUserMemories(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id int64
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "integer", Format: "int64"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListUserMemories(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeleteUserMemory operation middleware
+func (siw *ServerInterfaceWrapper) DeleteUserMemory(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id int64
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "integer", Format: "int64"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "agentId" -------------
+	var agentId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "agentId", r.PathValue("agentId"), &agentId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "agentId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteUserMemory(w, r, id, agentId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// SetUserMemory operation middleware
+func (siw *ServerInterfaceWrapper) SetUserMemory(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id int64
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "integer", Format: "int64"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "agentId" -------------
+	var agentId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "agentId", r.PathValue("agentId"), &agentId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "agentId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.SetUserMemory(w, r, id, agentId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UpdateUserNotifyIdentity operation middleware
+func (siw *ServerInterfaceWrapper) UpdateUserNotifyIdentity(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id int64
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "integer", Format: "int64"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdateUserNotifyIdentity(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 type UnescapedCookieParamError struct {
 	ParamName string
 	Err       error
@@ -3436,6 +3919,13 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/api/auth/profile/skills/{skillId}", wrapper.UpdateProfileSkill)
 	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/auth/profile/skills/{skillId}/file", wrapper.DeleteProfileSkillFile)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/auth/profile/skills/{skillId}/file", wrapper.GetProfileSkillFile)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/auth/users", wrapper.ListAuthUsers)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/auth/users/{id}", wrapper.GetAuthUser)
+	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/api/auth/users/{id}/active", wrapper.UpdateAuthUserActive)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/auth/users/{id}/agents", wrapper.ListAuthUserAgents)
+	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/api/auth/users/{id}/agents", wrapper.UpdateAuthUserAgents)
+	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/auth/users/{id}/identities/{identityId}", wrapper.DeleteAuthUserIdentity)
+	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/api/auth/users/{id}/role", wrapper.UpdateAuthUserRole)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/builtin/{kind}", wrapper.ListBuiltinResources)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/builtin/{kind}/{id}", wrapper.GetBuiltinResource)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/channels", wrapper.ListChannels)
@@ -3491,6 +3981,11 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/skills/{id}/file", wrapper.DeleteSkillFile)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/skills/{id}/file", wrapper.GetSkillFile)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/tools", wrapper.ListTools)
+	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/api/users/{id}/default-agent", wrapper.UpdateUserDefaultAgent)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/users/{id}/memories", wrapper.ListUserMemories)
+	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/users/{id}/memories/{agentId}", wrapper.DeleteUserMemory)
+	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/api/users/{id}/memories/{agentId}", wrapper.SetUserMemory)
+	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/api/users/{id}/notify-identity", wrapper.UpdateUserNotifyIdentity)
 
 	return m
 }

--- a/api/server/gen.go
+++ b/api/server/gen.go
@@ -28,6 +28,15 @@ type ArticleList = externalRef0.ArticleList
 // ArticleStatus defines model for ArticleStatus.
 type ArticleStatus = externalRef0.ArticleStatus
 
+// BuiltinResource defines model for BuiltinResource.
+type BuiltinResource = externalRef0.BuiltinResource
+
+// BuiltinResourceDetail defines model for BuiltinResourceDetail.
+type BuiltinResourceDetail = externalRef0.BuiltinResourceDetail
+
+// CachedModel defines model for CachedModel.
+type CachedModel = externalRef0.CachedModel
+
 // CreateFeedRequest defines model for CreateFeedRequest.
 type CreateFeedRequest = externalRef0.CreateFeedRequest
 
@@ -75,6 +84,9 @@ type SourceType = externalRef0.SourceType
 
 // TagCount defines model for TagCount.
 type TagCount = externalRef0.TagCount
+
+// Tool defines model for Tool.
+type Tool = externalRef0.Tool
 
 // UpdateArticleRequest Only provided fields are updated.
 type UpdateArticleRequest = externalRef0.UpdateArticleRequest
@@ -148,6 +160,15 @@ type UpdateSchedulerJobJSONRequestBody = externalRef0.JobInput
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
+	// List builtin resources of a given kind
+	// (GET /api/builtin/{kind})
+	ListBuiltinResources(w http.ResponseWriter, r *http.Request, kind string)
+	// Get a specific builtin resource
+	// (GET /api/builtin/{kind}/{id})
+	GetBuiltinResource(w http.ResponseWriter, r *http.Request, kind string, id string)
+	// List enabled models from provider config and cache
+	// (GET /api/models)
+	ListModels(w http.ResponseWriter, r *http.Request)
 	// List or search articles
 	// (GET /api/recally/articles)
 	ListArticles(w http.ResponseWriter, r *http.Request, params ListArticlesParams)
@@ -208,6 +229,9 @@ type ServerInterface interface {
 	// List scheduler job runs
 	// (GET /api/scheduler/jobs/{id}/runs)
 	ListSchedulerJobRuns(w http.ResponseWriter, r *http.Request, id string)
+	// List available agent tools
+	// (GET /api/tools)
+	ListTools(w http.ResponseWriter, r *http.Request)
 }
 
 // ServerInterfaceWrapper converts contexts to parameters.
@@ -218,6 +242,99 @@ type ServerInterfaceWrapper struct {
 }
 
 type MiddlewareFunc func(http.Handler) http.Handler
+
+// ListBuiltinResources operation middleware
+func (siw *ServerInterfaceWrapper) ListBuiltinResources(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "kind" -------------
+	var kind string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "kind", r.PathValue("kind"), &kind, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "kind", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListBuiltinResources(w, r, kind)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetBuiltinResource operation middleware
+func (siw *ServerInterfaceWrapper) GetBuiltinResource(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "kind" -------------
+	var kind string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "kind", r.PathValue("kind"), &kind, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "kind", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetBuiltinResource(w, r, kind, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListModels operation middleware
+func (siw *ServerInterfaceWrapper) ListModels(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListModels(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
 
 // ListArticles operation middleware
 func (siw *ServerInterfaceWrapper) ListArticles(w http.ResponseWriter, r *http.Request) {
@@ -948,6 +1065,26 @@ func (siw *ServerInterfaceWrapper) ListSchedulerJobRuns(w http.ResponseWriter, r
 	handler.ServeHTTP(w, r)
 }
 
+// ListTools operation middleware
+func (siw *ServerInterfaceWrapper) ListTools(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListTools(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 type UnescapedCookieParamError struct {
 	ParamName string
 	Err       error
@@ -1068,6 +1205,9 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 		ErrorHandlerFunc:   options.ErrorHandlerFunc,
 	}
 
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/builtin/{kind}", wrapper.ListBuiltinResources)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/builtin/{kind}/{id}", wrapper.GetBuiltinResource)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/models", wrapper.ListModels)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/recally/articles", wrapper.ListArticles)
 	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/recally/articles", wrapper.SaveArticle)
 	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/recally/articles/{id}", wrapper.DeleteArticle)
@@ -1088,6 +1228,7 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/api/scheduler/jobs/{id}", wrapper.UpdateSchedulerJob)
 	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/scheduler/jobs/{id}/run", wrapper.TriggerSchedulerJob)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/scheduler/jobs/{id}/runs", wrapper.ListSchedulerJobRuns)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/tools", wrapper.ListTools)
 
 	return m
 }

--- a/api/server/gen.go
+++ b/api/server/gen.go
@@ -59,6 +59,9 @@ type BuiltinResourceDetail = externalRef0.BuiltinResourceDetail
 // CachedModel defines model for CachedModel.
 type CachedModel = externalRef0.CachedModel
 
+// ChangePasswordRequest defines model for ChangePasswordRequest.
+type ChangePasswordRequest = externalRef0.ChangePasswordRequest
+
 // Channel defines model for Channel.
 type Channel = externalRef0.Channel
 
@@ -116,6 +119,9 @@ type FeedPollResult = externalRef0.FeedPollResult
 // FetchModelsRequest defines model for FetchModelsRequest.
 type FetchModelsRequest = externalRef0.FetchModelsRequest
 
+// GenerateLinkCodeRequest defines model for GenerateLinkCodeRequest.
+type GenerateLinkCodeRequest = externalRef0.GenerateLinkCodeRequest
+
 // GlobalInstallSkillRequest defines model for GlobalInstallSkillRequest.
 type GlobalInstallSkillRequest = externalRef0.GlobalInstallSkillRequest
 
@@ -133,6 +139,18 @@ type JobInput = externalRef0.JobInput
 
 // JobList defines model for JobList.
 type JobList = externalRef0.JobList
+
+// LinkCodeResponse defines model for LinkCodeResponse.
+type LinkCodeResponse = externalRef0.LinkCodeResponse
+
+// OAuthConnectedResponse defines model for OAuthConnectedResponse.
+type OAuthConnectedResponse = externalRef0.OAuthConnectedResponse
+
+// OAuthFlowStatus defines model for OAuthFlowStatus.
+type OAuthFlowStatus = externalRef0.OAuthFlowStatus
+
+// OAuthProviderStatus defines model for OAuthProviderStatus.
+type OAuthProviderStatus = externalRef0.OAuthProviderStatus
 
 // ProfileInstallSkillRequest defines model for ProfileInstallSkillRequest.
 type ProfileInstallSkillRequest = externalRef0.ProfileInstallSkillRequest
@@ -178,6 +196,12 @@ type SessionDetail = externalRef0.SessionDetail
 
 // SetMemoryRequest defines model for SetMemoryRequest.
 type SetMemoryRequest = externalRef0.SetMemoryRequest
+
+// SetSoulRequest defines model for SetSoulRequest.
+type SetSoulRequest = externalRef0.SetSoulRequest
+
+// SetVaultEntryRequest defines model for SetVaultEntryRequest.
+type SetVaultEntryRequest = externalRef0.SetVaultEntryRequest
 
 // Skill defines model for Skill.
 type Skill = externalRef0.Skill
@@ -239,6 +263,9 @@ type UpdateSkillRequest = externalRef0.UpdateSkillRequest
 // UserMemory defines model for UserMemory.
 type UserMemory = externalRef0.UserMemory
 
+// VaultEntry defines model for VaultEntry.
+type VaultEntry = externalRef0.VaultEntry
+
 // WeixinQRCode defines model for WeixinQRCode.
 type WeixinQRCode = externalRef0.WeixinQRCode
 
@@ -251,6 +278,12 @@ type bearerAuthContextKey string
 // UploadAgentSkillMultipartBody defines parameters for UploadAgentSkill.
 type UploadAgentSkillMultipartBody struct {
 	File *openapi_types.File `json:"file,omitempty"`
+}
+
+// OauthCallbackParams defines parameters for OauthCallback.
+type OauthCallbackParams struct {
+	Code  string `form:"code" json:"code"`
+	State string `form:"state" json:"state"`
 }
 
 // UploadProfileSkillMultipartBody defines parameters for UploadProfileSkill.
@@ -363,6 +396,15 @@ type UpdateAgentSkillJSONRequestBody = externalRef0.UpdateSkillRequest
 // AssignAgentUserJSONRequestBody defines body for AssignAgentUser for application/json ContentType.
 type AssignAgentUserJSONRequestBody = externalRef0.AssignAgentUserRequest
 
+// GenerateLinkCodeJSONRequestBody defines body for GenerateLinkCode for application/json ContentType.
+type GenerateLinkCodeJSONRequestBody = externalRef0.GenerateLinkCodeRequest
+
+// SetProfileMemoryJSONRequestBody defines body for SetProfileMemory for application/json ContentType.
+type SetProfileMemoryJSONRequestBody = externalRef0.SetMemoryRequest
+
+// ChangePasswordJSONRequestBody defines body for ChangePassword for application/json ContentType.
+type ChangePasswordJSONRequestBody = externalRef0.ChangePasswordRequest
+
 // InstallProfileSkillJSONRequestBody defines body for InstallProfileSkill for application/json ContentType.
 type InstallProfileSkillJSONRequestBody = externalRef0.ProfileInstallSkillRequest
 
@@ -371,6 +413,12 @@ type UploadProfileSkillMultipartRequestBody UploadProfileSkillMultipartBody
 
 // UpdateProfileSkillJSONRequestBody defines body for UpdateProfileSkill for application/json ContentType.
 type UpdateProfileSkillJSONRequestBody = externalRef0.UpdateSkillRequest
+
+// SetProfileSoulJSONRequestBody defines body for SetProfileSoul for application/json ContentType.
+type SetProfileSoulJSONRequestBody = externalRef0.SetSoulRequest
+
+// SetVaultEntryJSONRequestBody defines body for SetVaultEntry for application/json ContentType.
+type SetVaultEntryJSONRequestBody = externalRef0.SetVaultEntryRequest
 
 // UpdateAuthUserActiveJSONRequestBody defines body for UpdateAuthUserActive for application/json ContentType.
 type UpdateAuthUserActiveJSONRequestBody = externalRef0.UpdateActiveRequest
@@ -494,6 +542,45 @@ type ServerInterface interface {
 	// Remove a user from an agent (admin only)
 	// (DELETE /api/agents/{id}/users/{userId})
 	RemoveAgentUser(w http.ResponseWriter, r *http.Request, id string, userId int64)
+	// List linked identities for the current user
+	// (GET /api/auth/profile/identities)
+	ListProfileIdentities(w http.ResponseWriter, r *http.Request)
+	// Unlink an identity from the current user
+	// (DELETE /api/auth/profile/identities/{id})
+	UnlinkProfileIdentity(w http.ResponseWriter, r *http.Request, id int64)
+	// Generate a short-lived link code for a platform
+	// (POST /api/auth/profile/link-code)
+	GenerateLinkCode(w http.ResponseWriter, r *http.Request)
+	// List per-agent memories for the current user
+	// (GET /api/auth/profile/memories)
+	ListProfileMemories(w http.ResponseWriter, r *http.Request)
+	// Delete the memory for a specific agent
+	// (DELETE /api/auth/profile/memories/{agentId})
+	DeleteProfileMemory(w http.ResponseWriter, r *http.Request, agentId string)
+	// Set the memory for a specific agent
+	// (PUT /api/auth/profile/memories/{agentId})
+	SetProfileMemory(w http.ResponseWriter, r *http.Request, agentId string)
+	// List OAuth provider statuses for the current user
+	// (GET /api/auth/profile/oauth/providers)
+	ListOAuthProviders(w http.ResponseWriter, r *http.Request)
+	// Disconnect an OAuth provider
+	// (DELETE /api/auth/profile/oauth/{provider})
+	DisconnectOAuth(w http.ResponseWriter, r *http.Request, provider string)
+	// OAuth callback (browser redirect, unauthenticated)
+	// (GET /api/auth/profile/oauth/{provider}/callback)
+	OauthCallback(w http.ResponseWriter, r *http.Request, provider string, params OauthCallbackParams)
+	// Check if the current user is connected to an OAuth provider
+	// (GET /api/auth/profile/oauth/{provider}/connected)
+	GetOAuthConnected(w http.ResponseWriter, r *http.Request, provider string)
+	// Start an OAuth device flow for a provider
+	// (POST /api/auth/profile/oauth/{provider}/start)
+	StartOAuthFlow(w http.ResponseWriter, r *http.Request, provider string)
+	// Poll the status of an OAuth flow
+	// (GET /api/auth/profile/oauth/{provider}/status/{flowID})
+	PollOAuthFlow(w http.ResponseWriter, r *http.Request, provider string, flowID string)
+	// Change the current user's password
+	// (PUT /api/auth/profile/password)
+	ChangePassword(w http.ResponseWriter, r *http.Request)
 	// List profile skills (current user)
 	// (GET /api/auth/profile/skills)
 	ListProfileSkills(w http.ResponseWriter, r *http.Request)
@@ -518,6 +605,18 @@ type ServerInterface interface {
 	// Get a profile skill file
 	// (GET /api/auth/profile/skills/{skillId}/file)
 	GetProfileSkillFile(w http.ResponseWriter, r *http.Request, skillId string, params GetProfileSkillFileParams)
+	// Set the soul for a specific agent
+	// (PUT /api/auth/profile/soul/{agentId})
+	SetProfileSoul(w http.ResponseWriter, r *http.Request, agentId string)
+	// List vault entries for the current user
+	// (GET /api/auth/profile/vault)
+	ListVaultEntries(w http.ResponseWriter, r *http.Request)
+	// Delete a vault entry
+	// (DELETE /api/auth/profile/vault/{name})
+	DeleteVaultEntry(w http.ResponseWriter, r *http.Request, name string)
+	// Create or update a vault entry
+	// (PUT /api/auth/profile/vault/{name})
+	SetVaultEntry(w http.ResponseWriter, r *http.Request, name string)
 	// List all auth users (admin only)
 	// (GET /api/auth/users)
 	ListAuthUsers(w http.ResponseWriter, r *http.Request)
@@ -1313,6 +1412,394 @@ func (siw *ServerInterfaceWrapper) RemoveAgentUser(w http.ResponseWriter, r *htt
 	handler.ServeHTTP(w, r)
 }
 
+// ListProfileIdentities operation middleware
+func (siw *ServerInterfaceWrapper) ListProfileIdentities(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListProfileIdentities(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UnlinkProfileIdentity operation middleware
+func (siw *ServerInterfaceWrapper) UnlinkProfileIdentity(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id int64
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "integer", Format: "int64"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UnlinkProfileIdentity(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GenerateLinkCode operation middleware
+func (siw *ServerInterfaceWrapper) GenerateLinkCode(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GenerateLinkCode(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListProfileMemories operation middleware
+func (siw *ServerInterfaceWrapper) ListProfileMemories(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListProfileMemories(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeleteProfileMemory operation middleware
+func (siw *ServerInterfaceWrapper) DeleteProfileMemory(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "agentId" -------------
+	var agentId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "agentId", r.PathValue("agentId"), &agentId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "agentId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteProfileMemory(w, r, agentId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// SetProfileMemory operation middleware
+func (siw *ServerInterfaceWrapper) SetProfileMemory(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "agentId" -------------
+	var agentId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "agentId", r.PathValue("agentId"), &agentId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "agentId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.SetProfileMemory(w, r, agentId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListOAuthProviders operation middleware
+func (siw *ServerInterfaceWrapper) ListOAuthProviders(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListOAuthProviders(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DisconnectOAuth operation middleware
+func (siw *ServerInterfaceWrapper) DisconnectOAuth(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "provider" -------------
+	var provider string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "provider", r.PathValue("provider"), &provider, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "provider", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DisconnectOAuth(w, r, provider)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// OauthCallback operation middleware
+func (siw *ServerInterfaceWrapper) OauthCallback(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "provider" -------------
+	var provider string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "provider", r.PathValue("provider"), &provider, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "provider", Err: err})
+		return
+	}
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params OauthCallbackParams
+
+	// ------------- Required query parameter "code" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, true, "code", r.URL.Query(), &params.Code, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "code"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "code", Err: err})
+		}
+		return
+	}
+
+	// ------------- Required query parameter "state" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, true, "state", r.URL.Query(), &params.State, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "state"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "state", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.OauthCallback(w, r, provider, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetOAuthConnected operation middleware
+func (siw *ServerInterfaceWrapper) GetOAuthConnected(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "provider" -------------
+	var provider string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "provider", r.PathValue("provider"), &provider, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "provider", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetOAuthConnected(w, r, provider)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// StartOAuthFlow operation middleware
+func (siw *ServerInterfaceWrapper) StartOAuthFlow(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "provider" -------------
+	var provider string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "provider", r.PathValue("provider"), &provider, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "provider", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.StartOAuthFlow(w, r, provider)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// PollOAuthFlow operation middleware
+func (siw *ServerInterfaceWrapper) PollOAuthFlow(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "provider" -------------
+	var provider string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "provider", r.PathValue("provider"), &provider, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "provider", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "flowID" -------------
+	var flowID string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "flowID", r.PathValue("flowID"), &flowID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "flowID", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PollOAuthFlow(w, r, provider, flowID)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ChangePassword operation middleware
+func (siw *ServerInterfaceWrapper) ChangePassword(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ChangePassword(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // ListProfileSkills operation middleware
 func (siw *ServerInterfaceWrapper) ListProfileSkills(w http.ResponseWriter, r *http.Request) {
 
@@ -1556,6 +2043,122 @@ func (siw *ServerInterfaceWrapper) GetProfileSkillFile(w http.ResponseWriter, r 
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetProfileSkillFile(w, r, skillId, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// SetProfileSoul operation middleware
+func (siw *ServerInterfaceWrapper) SetProfileSoul(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "agentId" -------------
+	var agentId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "agentId", r.PathValue("agentId"), &agentId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "agentId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.SetProfileSoul(w, r, agentId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListVaultEntries operation middleware
+func (siw *ServerInterfaceWrapper) ListVaultEntries(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListVaultEntries(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeleteVaultEntry operation middleware
+func (siw *ServerInterfaceWrapper) DeleteVaultEntry(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "name" -------------
+	var name string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "name", r.PathValue("name"), &name, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "name", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteVaultEntry(w, r, name)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// SetVaultEntry operation middleware
+func (siw *ServerInterfaceWrapper) SetVaultEntry(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "name" -------------
+	var name string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "name", r.PathValue("name"), &name, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "name", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.SetVaultEntry(w, r, name)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -3911,6 +4514,19 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/agents/{id}/users", wrapper.ListAgentUsers)
 	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/agents/{id}/users", wrapper.AssignAgentUser)
 	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/agents/{id}/users/{userId}", wrapper.RemoveAgentUser)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/auth/profile/identities", wrapper.ListProfileIdentities)
+	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/auth/profile/identities/{id}", wrapper.UnlinkProfileIdentity)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/auth/profile/link-code", wrapper.GenerateLinkCode)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/auth/profile/memories", wrapper.ListProfileMemories)
+	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/auth/profile/memories/{agentId}", wrapper.DeleteProfileMemory)
+	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/api/auth/profile/memories/{agentId}", wrapper.SetProfileMemory)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/auth/profile/oauth/providers", wrapper.ListOAuthProviders)
+	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/auth/profile/oauth/{provider}", wrapper.DisconnectOAuth)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/auth/profile/oauth/{provider}/callback", wrapper.OauthCallback)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/auth/profile/oauth/{provider}/connected", wrapper.GetOAuthConnected)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/auth/profile/oauth/{provider}/start", wrapper.StartOAuthFlow)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/auth/profile/oauth/{provider}/status/{flowID}", wrapper.PollOAuthFlow)
+	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/api/auth/profile/password", wrapper.ChangePassword)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/auth/profile/skills", wrapper.ListProfileSkills)
 	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/auth/profile/skills/install", wrapper.InstallProfileSkill)
 	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/auth/profile/skills/upload", wrapper.UploadProfileSkill)
@@ -3919,6 +4535,10 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/api/auth/profile/skills/{skillId}", wrapper.UpdateProfileSkill)
 	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/auth/profile/skills/{skillId}/file", wrapper.DeleteProfileSkillFile)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/auth/profile/skills/{skillId}/file", wrapper.GetProfileSkillFile)
+	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/api/auth/profile/soul/{agentId}", wrapper.SetProfileSoul)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/auth/profile/vault", wrapper.ListVaultEntries)
+	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/auth/profile/vault/{name}", wrapper.DeleteVaultEntry)
+	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/api/auth/profile/vault/{name}", wrapper.SetVaultEntry)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/auth/users", wrapper.ListAuthUsers)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/auth/users/{id}", wrapper.GetAuthUser)
 	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/api/auth/users/{id}/active", wrapper.UpdateAuthUserActive)

--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -370,6 +370,88 @@ components:
           type: string
         model:
           type: string
+    ChangePasswordRequest:
+      type: object
+      required: [current_password, new_password]
+      properties:
+        current_password:
+          type: string
+        new_password:
+          type: string
+    GenerateLinkCodeRequest:
+      type: object
+      required: [platform]
+      properties:
+        platform:
+          type: string
+    LinkCodeResponse:
+      type: object
+      required: [code, platform]
+      properties:
+        code:
+          type: string
+        platform:
+          type: string
+    SetSoulRequest:
+      type: object
+      required: [soul]
+      properties:
+        soul:
+          type: string
+    VaultEntry:
+      type: object
+      required: [name, created_at, updated_at]
+      properties:
+        name:
+          type: string
+        created_at:
+          type: string
+        updated_at:
+          type: string
+    SetVaultEntryRequest:
+      type: object
+      required: [value]
+      properties:
+        value:
+          type: string
+    OAuthProviderStatus:
+      type: object
+      required: [provider, available, connected]
+      properties:
+        provider:
+          type: string
+        available:
+          type: boolean
+        connected:
+          type: boolean
+        username:
+          type: string
+        unavailable:
+          type: string
+    OAuthFlowStatus:
+      type: object
+      required: [provider, flow_id, verification_uri, expires_at, state]
+      properties:
+        provider:
+          type: string
+        flow_id:
+          type: string
+        verification_uri:
+          type: string
+        user_code:
+          type: string
+        expires_at:
+          type: string
+        state:
+          type: string
+    OAuthConnectedResponse:
+      type: object
+      required: [connected]
+      properties:
+        connected:
+          type: boolean
+        username:
+          type: string
     ProviderModelCost:
       type: object
       properties:

--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -62,6 +62,58 @@ components:
               error:
                 type: string
   schemas:
+    BuiltinResource:
+      type: object
+      required: [kind, id, name]
+      properties:
+        kind:
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        metadata:
+          type: object
+          additionalProperties: true
+        hash:
+          type: string
+    BuiltinResourceDetail:
+      type: object
+      required: [kind, id, name, content]
+      properties:
+        kind:
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        metadata:
+          type: object
+          additionalProperties: true
+        hash:
+          type: string
+        content:
+          type: string
+    CachedModel:
+      type: object
+      required: [provider, model]
+      properties:
+        provider:
+          type: string
+        model:
+          type: string
     # ── Shared ─────────────────────────────────────────────────────────────────
     Error:
       type: object
@@ -528,4 +580,17 @@ components:
       required: [status]
       properties:
         status:
+          type: string
+    Tool:
+      type: object
+      required: [name, description, category]
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        input_schema:
+          type: object
+          additionalProperties: true
+        category:
           type: string

--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -195,6 +195,98 @@ components:
           type: string
         model:
           type: string
+    ProviderModelCost:
+      type: object
+      properties:
+        input:
+          type: number
+          format: double
+        output:
+          type: number
+          format: double
+        cacheRead:
+          type: number
+          format: double
+        cacheWrite:
+          type: number
+          format: double
+    ProviderModel:
+      type: object
+      required: [enabled]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        enabled:
+          type: boolean
+        reasoning:
+          type: boolean
+        input:
+          type: array
+          items:
+            type: string
+        output:
+          type: array
+          items:
+            type: string
+        contextWindow:
+          type: integer
+        maxTokens:
+          type: integer
+        cost:
+          $ref: "#/components/schemas/ProviderModelCost"
+    Provider:
+      type: object
+      required: [id, type, name, enabled, api_key, base_url]
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        name:
+          type: string
+        enabled:
+          type: boolean
+        api_key:
+          type: string
+        base_url:
+          type: string
+        models:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/ProviderModel"
+    ProviderModelItem:
+      type: object
+      required: [id, source, enabled]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        source:
+          type: string
+        enabled:
+          type: boolean
+        config:
+          $ref: "#/components/schemas/ProviderModel"
+    ProviderType:
+      type: object
+      required: [id, name, default_url]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        default_url:
+          type: string
+    FetchModelsRequest:
+      type: object
+      properties:
+        api_key:
+          type: string
+        base_url:
+          type: string
     # ── Shared ─────────────────────────────────────────────────────────────────
     Error:
       type: object

--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -754,6 +754,52 @@ components:
       properties:
         status:
           type: string
+    Session:
+      type: object
+      required: [id, channel, title, agent_id, user_id, created_at, last_active, archived]
+      properties:
+        id:
+          type: string
+        channel:
+          type: string
+        title:
+          type: string
+        agent_id:
+          type: string
+        user_id:
+          type: integer
+          format: int64
+        created_at:
+          type: string
+        last_active:
+          type: string
+        archived:
+          type: boolean
+    SessionDetail:
+      allOf:
+        - $ref: "#/components/schemas/Session"
+        - type: object
+          properties:
+            agent_name: {type: string}
+            user_name: {type: string}
+    CreateSessionRequest:
+      type: object
+      properties:
+        agent_id:
+          type: string
+    SendMessageRequest:
+      type: object
+      required: [content]
+      properties:
+        content:
+          type: string
+          description: "Message content (required)"
+    SystemPromptResponse:
+      type: object
+      required: [system_prompt]
+      properties:
+        system_prompt:
+          type: string
     Tool:
       type: object
       required: [name, description, category]

--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -1062,3 +1062,93 @@ components:
           additionalProperties: true
         category:
           type: string
+    Identity:
+      type: object
+      required: [id, user_id, platform, external_id, name, linked_at]
+      properties:
+        id:
+          type: integer
+          format: int64
+        user_id:
+          type: integer
+          format: int64
+        platform:
+          type: string
+        external_id:
+          type: string
+        name:
+          type: string
+        linked_at:
+          type: string
+          format: date-time
+    AuthUser:
+      type: object
+      required: [id, username, role, is_active, identities, created_at, updated_at]
+      properties:
+        id:
+          type: integer
+          format: int64
+        username:
+          type: string
+        role:
+          type: string
+        is_active:
+          type: boolean
+        identities:
+          type: array
+          items:
+            $ref: "#/components/schemas/Identity"
+        created_at:
+          type: string
+        updated_at:
+          type: string
+    AuthUserList:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/AuthUser"
+    UserMemory:
+      type: object
+      additionalProperties: {}
+    UpdateDefaultAgentRequest:
+      type: object
+      required: [default_agent_id]
+      properties:
+        default_agent_id:
+          type: string
+    UpdateNotifyIdentityRequest:
+      type: object
+      properties:
+        notify_identity_id:
+          type: integer
+          format: int64
+          nullable: true
+    SetMemoryRequest:
+      type: object
+      required: [content]
+      properties:
+        content:
+          type: string
+    UpdateRoleRequest:
+      type: object
+      required: [role]
+      properties:
+        role:
+          type: string
+    UpdateAgentsRequest:
+      type: object
+      required: [agent_ids]
+      properties:
+        agent_ids:
+          type: array
+          items:
+            type: string
+    UpdateActiveRequest:
+      type: object
+      required: [is_active]
+      properties:
+        is_active:
+          type: boolean

--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -408,6 +408,55 @@ components:
           type: string
         model:
           type: string
+    PluginView:
+      type: object
+      properties:
+        id:
+          type: string
+        kind:
+          type: string
+        name:
+          type: string
+        enabled:
+          type: boolean
+        config:
+          type: object
+          additionalProperties: true
+        display_name:
+          type: string
+        description:
+          type: string
+        managed:
+          type: boolean
+        admin_visible:
+          type: boolean
+        has_config:
+          type: boolean
+        has_status:
+          type: boolean
+        capabilities:
+          type: array
+          items:
+            type: string
+        persisted:
+          type: boolean
+        persisted_id:
+          type: string
+    TogglePluginRequest:
+      type: object
+      required: [enabled]
+      properties:
+        enabled:
+          type: boolean
+    UpdatePluginConfigRequest:
+      type: object
+      properties:
+        config:
+          type: object
+          additionalProperties: true
+    ManifestPlugin:
+      type: object
+      additionalProperties: true
     ChangePasswordRequest:
       type: object
       required: [current_password, new_password]

--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -62,6 +62,181 @@ components:
               error:
                 type: string
   schemas:
+    SandboxNetworkConfig:
+      type: object
+      properties:
+        mode:
+          type: string
+        allowlist:
+          type: array
+          items:
+            type: string
+    SandboxConfig:
+      type: object
+      properties:
+        network:
+          $ref: "#/components/schemas/SandboxNetworkConfig"
+    Agent:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        model:
+          type: string
+        model_strong:
+          type: string
+        model_fast:
+          type: string
+        system_prompt:
+          type: string
+        soul:
+          type: string
+        workspace:
+          type: string
+        sandbox:
+          $ref: "#/components/schemas/SandboxConfig"
+        scope:
+          type: string
+        creator_id:
+          type: integer
+          format: int64
+        enabled:
+          type: boolean
+    AgentList:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/Agent"
+    CreateAgentRequest:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        model:
+          type: string
+        model_strong:
+          type: string
+        model_fast:
+          type: string
+        system_prompt:
+          type: string
+        soul:
+          type: string
+        workspace:
+          type: string
+        sandbox:
+          $ref: "#/components/schemas/SandboxConfig"
+        scope:
+          type: string
+        creator_id:
+          type: integer
+          format: int64
+        enabled:
+          type: boolean
+        template_id:
+          type: string
+    AgentUser:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        username:
+          type: string
+    AgentUserList:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/AgentUser"
+    AssignAgentUserRequest:
+      type: object
+      required: [user_id]
+      properties:
+        user_id:
+          type: integer
+          format: int64
+    Skill:
+      type: object
+      properties:
+        id:
+          type: string
+        scope:
+          type: string
+        user_id:
+          type: integer
+          format: int64
+        agent_id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        status:
+          type: string
+        disable_model_invocation:
+          type: boolean
+        files:
+          type: array
+          items:
+            type: string
+        created_at:
+          type: string
+        updated_at:
+          type: string
+    SkillList:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/Skill"
+    InstallSkillRequest:
+      type: object
+      required: [source]
+      properties:
+        source:
+          type: string
+    UpdateSkillRequest:
+      type: object
+      properties:
+        description:
+          type: string
+          nullable: true
+        status:
+          type: string
+          nullable: true
+        disable_model_invocation:
+          type: boolean
+          nullable: true
+        files:
+          type: object
+          additionalProperties:
+            type: string
+    SkillUploadResult:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+    DuplicateSkillResult:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
     BuiltinResource:
       type: object
       required: [kind, id, name]

--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -237,6 +237,44 @@ components:
           type: string
         name:
           type: string
+    LoginRequest:
+      type: object
+      required: [username, password]
+      properties:
+        username:
+          type: string
+        password:
+          type: string
+    RegisterRequest:
+      type: object
+      required: [username, password]
+      properties:
+        username:
+          type: string
+        password:
+          type: string
+    AuthResponse:
+      type: object
+      required: [id, username]
+      properties:
+        id:
+          type: integer
+          format: int64
+        username:
+          type: string
+    MeResponse:
+      type: object
+      required: [id, username, role, is_admin]
+      properties:
+        id:
+          type: integer
+          format: int64
+        username:
+          type: string
+        role:
+          type: string
+        is_admin:
+          type: boolean
     BuiltinResource:
       type: object
       required: [kind, id, name]

--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -106,6 +106,87 @@ components:
           type: string
         content:
           type: string
+    Channel:
+      type: object
+      required: [id, type, enabled, config]
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        agent_id:
+          type: string
+        enabled:
+          type: boolean
+        config:
+          type: string
+          description: "JSON string of the channel config"
+    ChannelList:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/Channel"
+    PublicChannel:
+      type: object
+      required: [id, type, label, enabled]
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        label:
+          type: string
+        agent_id:
+          type: string
+        agent_name:
+          type: string
+        enabled:
+          type: boolean
+    PublicChannelList:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/PublicChannel"
+    ChannelWriteRequest:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+          nullable: true
+        agent_id:
+          type: string
+          nullable: true
+        config:
+          type: string
+          description: "JSON string of the channel config"
+    WeixinQRCode:
+      type: object
+      properties:
+        qrcode:
+          type: string
+        qrcode_img_content:
+          type: string
+    WeixinQRStatus:
+      type: object
+      properties:
+        status:
+          type: string
+        bot_token:
+          type: string
+        ilink_bot_id:
+          type: string
+        ilink_user_id:
+          type: string
+        baseurl:
+          type: string
     CachedModel:
       type: object
       required: [provider, model]

--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -975,6 +975,80 @@ components:
       properties:
         system_prompt:
           type: string
+    CreateSkillRequest:
+      type: object
+      properties:
+        scope:
+          type: string
+        user_id:
+          type: integer
+          format: int64
+        agent_id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        status:
+          type: string
+        disable_model_invocation:
+          type: boolean
+        files:
+          type: object
+          additionalProperties:
+            type: string
+    GlobalInstallSkillRequest:
+      type: object
+      required: [source]
+      properties:
+        source:
+          type: string
+        scope:
+          type: string
+        user_id:
+          type: integer
+          format: int64
+        agent_id:
+          type: string
+    ProfileInstallSkillRequest:
+      type: object
+      required: [source]
+      properties:
+        source:
+          type: string
+    SkillSearchResult:
+      type: object
+      properties:
+        id:
+          type: string
+        skillId:
+          type: string
+        name:
+          type: string
+        installs:
+          type: integer
+        source:
+          type: string
+    SkillSearchResultList:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/SkillSearchResult"
+    SkillFileResponse:
+      type: object
+      properties:
+        path:
+          type: string
+        content:
+          type: string
+    DeleteFileResult:
+      type: object
+      properties:
+        path:
+          type: string
     Tool:
       type: object
       required: [name, description, category]

--- a/api/spec/domain/agents/paths.yaml
+++ b/api/spec/domain/agents/paths.yaml
@@ -271,6 +271,8 @@ paths:
       tags: [agents]
       summary: Download a skill file (creator or admin)
       operationId: getAgentSkillFile
+      parameters:
+        - { name: path, in: query, required: true, schema: { type: string } }
       responses:
         "200":
           description: ok
@@ -284,6 +286,8 @@ paths:
       tags: [agents]
       summary: Delete a skill file (creator or admin)
       operationId: deleteAgentSkillFile
+      parameters:
+        - { name: path, in: query, required: true, schema: { type: string } }
       responses:
         "200":
           description: deleted

--- a/api/spec/domain/agents/paths.yaml
+++ b/api/spec/domain/agents/paths.yaml
@@ -1,0 +1,295 @@
+paths:
+  /api/agents:
+    get:
+      tags: [agents]
+      summary: List agents (any authenticated user; non-admin sees accessible only)
+      operationId: listAgents
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/AgentList" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+    post:
+      tags: [agents]
+      summary: Create an agent
+      operationId: createAgent
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "../../components.yaml#/components/schemas/CreateAgentRequest" }
+      responses:
+        "201":
+          description: created
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/Agent" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+
+  /api/agents/{id}:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: string } }
+    get:
+      tags: [agents]
+      summary: Get an agent
+      operationId: getAgent
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/Agent" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+    put:
+      tags: [agents]
+      summary: Update an agent
+      operationId: updateAgent
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "../../components.yaml#/components/schemas/Agent" }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/Agent" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+    delete:
+      tags: [agents]
+      summary: Delete an agent
+      operationId: deleteAgent
+      responses:
+        "200":
+          description: deleted
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/DeleteResult" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+
+  /api/agents/{id}/users:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: string } }
+    get:
+      tags: [agents]
+      summary: List users assigned to an agent (admin only)
+      operationId: listAgentUsers
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/AgentUserList" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+    post:
+      tags: [agents]
+      summary: Assign a user to an agent (admin only)
+      operationId: assignAgentUser
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "../../components.yaml#/components/schemas/AssignAgentUserRequest" }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/DeleteResult" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+
+  /api/agents/{id}/users/{userId}:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: string } }
+      - { name: userId, in: path, required: true, schema: { type: integer, format: int64 } }
+    delete:
+      tags: [agents]
+      summary: Remove a user from an agent (admin only)
+      operationId: removeAgentUser
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/DeleteResult" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+
+  /api/agents/{id}/skills:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: string } }
+    get:
+      tags: [agents]
+      summary: List skills for an agent (creator or admin)
+      operationId: listAgentSkills
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/SkillList" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+
+  /api/agents/{id}/skills/install:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: string } }
+    post:
+      tags: [agents]
+      summary: Install a skill to an agent from a remote source (admin only)
+      operationId: installAgentSkill
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "../../components.yaml#/components/schemas/InstallSkillRequest" }
+      responses:
+        "201":
+          description: installed
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/SkillUploadResult" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+
+  /api/agents/{id}/skills/upload:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: string } }
+    post:
+      tags: [agents]
+      summary: Upload a skill zip to an agent (admin only)
+      operationId: uploadAgentSkill
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        "201":
+          description: uploaded
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/SkillUploadResult" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+
+  /api/agents/{id}/skills/from-builtin/{skillId}:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: string } }
+      - { name: skillId, in: path, required: true, schema: { type: string } }
+    post:
+      tags: [agents]
+      summary: Duplicate a builtin skill to an agent (admin only)
+      operationId: duplicateBuiltinSkillToAgent
+      responses:
+        "201":
+          description: duplicated
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/DuplicateSkillResult" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+
+  /api/agents/{id}/skills/{skillId}:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: string } }
+      - { name: skillId, in: path, required: true, schema: { type: string } }
+    get:
+      tags: [agents]
+      summary: Get an agent skill (creator or admin)
+      operationId: getAgentSkill
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/Skill" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+    put:
+      tags: [agents]
+      summary: Update an agent skill (creator or admin)
+      operationId: updateAgentSkill
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "../../components.yaml#/components/schemas/UpdateSkillRequest" }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/Skill" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+    delete:
+      tags: [agents]
+      summary: Delete an agent skill (creator or admin)
+      operationId: deleteAgentSkill
+      responses:
+        "200":
+          description: deleted
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/DeleteResult" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+
+  /api/agents/{id}/skills/{skillId}/file:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: string } }
+      - { name: skillId, in: path, required: true, schema: { type: string } }
+    get:
+      tags: [agents]
+      summary: Download a skill file (creator or admin)
+      operationId: getAgentSkillFile
+      responses:
+        "200":
+          description: ok
+          content:
+            application/octet-stream:
+              schema: { type: string, format: binary }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+    delete:
+      tags: [agents]
+      summary: Delete a skill file (creator or admin)
+      operationId: deleteAgentSkillFile
+      responses:
+        "200":
+          description: deleted
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/DeleteResult" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }

--- a/api/spec/domain/agents/schemas.yaml
+++ b/api/spec/domain/agents/schemas.yaml
@@ -1,0 +1,123 @@
+openapi: 3.0.3
+info:
+  title: Agents Components
+  version: "1"
+paths: {}
+components:
+  schemas:
+    SandboxNetworkConfig:
+      type: object
+      properties:
+        mode:      { type: string }
+        allowlist: { type: array, items: { type: string } }
+
+    SandboxConfig:
+      type: object
+      properties:
+        network: { $ref: "#/components/schemas/SandboxNetworkConfig" }
+
+    Agent:
+      type: object
+      properties:
+        id:            { type: string }
+        name:          { type: string }
+        model:         { type: string }
+        model_strong:  { type: string }
+        model_fast:    { type: string }
+        system_prompt: { type: string }
+        soul:          { type: string }
+        workspace:     { type: string }
+        sandbox:       { $ref: "#/components/schemas/SandboxConfig" }
+        scope:         { type: string }
+        creator_id:    { type: integer, format: int64 }
+        enabled:       { type: boolean }
+
+    AgentList:
+      type: object
+      required: [items]
+      properties:
+        items: { type: array, items: { $ref: "#/components/schemas/Agent" } }
+
+    CreateAgentRequest:
+      type: object
+      properties:
+        id:            { type: string }
+        name:          { type: string }
+        model:         { type: string }
+        model_strong:  { type: string }
+        model_fast:    { type: string }
+        system_prompt: { type: string }
+        soul:          { type: string }
+        workspace:     { type: string }
+        sandbox:       { $ref: "#/components/schemas/SandboxConfig" }
+        scope:         { type: string }
+        creator_id:    { type: integer, format: int64 }
+        enabled:       { type: boolean }
+        template_id:   { type: string }
+
+    AgentUser:
+      type: object
+      properties:
+        id:       { type: integer, format: int64 }
+        username: { type: string }
+
+    AgentUserList:
+      type: object
+      required: [items]
+      properties:
+        items: { type: array, items: { $ref: "#/components/schemas/AgentUser" } }
+
+    AssignAgentUserRequest:
+      type: object
+      required: [user_id]
+      properties:
+        user_id: { type: integer, format: int64 }
+
+    Skill:
+      type: object
+      properties:
+        id:                       { type: string }
+        scope:                    { type: string }
+        user_id:                  { type: integer, format: int64 }
+        agent_id:                 { type: string }
+        name:                     { type: string }
+        description:              { type: string }
+        status:                   { type: string }
+        disable_model_invocation: { type: boolean }
+        files:                    { type: array, items: { type: string } }
+        created_at:               { type: string }
+        updated_at:               { type: string }
+
+    SkillList:
+      type: object
+      required: [items]
+      properties:
+        items: { type: array, items: { $ref: "#/components/schemas/Skill" } }
+
+    InstallSkillRequest:
+      type: object
+      required: [source]
+      properties:
+        source: { type: string }
+
+    UpdateSkillRequest:
+      type: object
+      properties:
+        description:              { type: string, nullable: true }
+        status:                   { type: string, nullable: true }
+        disable_model_invocation: { type: boolean, nullable: true }
+        files:
+          type: object
+          additionalProperties: { type: string }
+
+    SkillUploadResult:
+      type: object
+      properties:
+        id:   { type: string }
+        name: { type: string }
+
+    DuplicateSkillResult:
+      type: object
+      properties:
+        id:   { type: string }
+        name: { type: string }

--- a/api/spec/domain/auth/paths.yaml
+++ b/api/spec/domain/auth/paths.yaml
@@ -1,0 +1,73 @@
+paths:
+  /api/auth/register:
+    post:
+      tags: [auth]
+      summary: Register a new user account
+      operationId: register
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "../../components.yaml#/components/schemas/RegisterRequest" }
+      responses:
+        "201":
+          description: created
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/AuthResponse" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "409":
+          description: username already taken
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/Error" }
+
+  /api/auth/login:
+    post:
+      tags: [auth]
+      summary: Authenticate and start a session
+      operationId: login
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "../../components.yaml#/components/schemas/LoginRequest" }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/AuthResponse" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+
+  /api/auth/logout:
+    post:
+      tags: [auth]
+      summary: End the current session
+      operationId: logout
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+
+  /api/auth/me:
+    get:
+      tags: [auth]
+      summary: Get the currently authenticated user
+      operationId: getMe
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/MeResponse" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }

--- a/api/spec/domain/auth/schemas.yaml
+++ b/api/spec/domain/auth/schemas.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.3
+info:
+  title: Auth Components
+  version: "1"
+paths: {}
+components:
+  schemas:
+    LoginRequest:
+      type: object
+      required: [username, password]
+      properties:
+        username: { type: string }
+        password: { type: string }
+
+    RegisterRequest:
+      type: object
+      required: [username, password]
+      properties:
+        username: { type: string }
+        password: { type: string }
+
+    AuthResponse:
+      type: object
+      required: [id, username]
+      properties:
+        id:       { type: integer, format: int64 }
+        username: { type: string }
+
+    MeResponse:
+      type: object
+      required: [id, username, role, is_admin]
+      properties:
+        id:       { type: integer, format: int64 }
+        username: { type: string }
+        role:     { type: string }
+        is_admin: { type: boolean }

--- a/api/spec/domain/builtin/paths.yaml
+++ b/api/spec/domain/builtin/paths.yaml
@@ -1,0 +1,35 @@
+paths:
+  /api/builtin/{kind}:
+    parameters:
+      - { name: kind, in: path, required: true, schema: { type: string } }
+    get:
+      tags: [builtin]
+      summary: List builtin resources of a given kind
+      operationId: listBuiltinResources
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "../../components.yaml#/components/schemas/BuiltinResource" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+
+  /api/builtin/{kind}/{id}:
+    parameters:
+      - { name: kind, in: path, required: true, schema: { type: string } }
+      - { name: id,   in: path, required: true, schema: { type: string } }
+    get:
+      tags: [builtin]
+      summary: Get a specific builtin resource
+      operationId: getBuiltinResource
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/BuiltinResourceDetail" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }

--- a/api/spec/domain/builtin/schemas.yaml
+++ b/api/spec/domain/builtin/schemas.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.3
+info:
+  title: Builtin Components
+  version: "1"
+paths: {}
+components:
+  schemas:
+    BuiltinResource:
+      type: object
+      required: [kind, id, name]
+      properties:
+        kind: { type: string }
+        id: { type: string }
+        name: { type: string }
+        description: { type: string }
+        tags:
+          type: array
+          items: { type: string }
+        metadata:
+          type: object
+          additionalProperties: true
+        hash: { type: string }
+    BuiltinResourceDetail:
+      type: object
+      required: [kind, id, name, content]
+      properties:
+        kind: { type: string }
+        id: { type: string }
+        name: { type: string }
+        description: { type: string }
+        tags:
+          type: array
+          items: { type: string }
+        metadata:
+          type: object
+          additionalProperties: true
+        hash: { type: string }
+        content: { type: string }

--- a/api/spec/domain/channels/paths.yaml
+++ b/api/spec/domain/channels/paths.yaml
@@ -1,0 +1,133 @@
+paths:
+  /api/channels/public:
+    get:
+      tags: [channels]
+      summary: List public channels (any authenticated user)
+      operationId: listPublicChannels
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/PublicChannelList" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+
+  /api/channels:
+    get:
+      tags: [channels]
+      summary: List all channels (admin only)
+      operationId: listChannels
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/ChannelList" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+    post:
+      tags: [channels]
+      summary: Create a channel (admin only)
+      operationId: createChannel
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "../../components.yaml#/components/schemas/ChannelWriteRequest" }
+      responses:
+        "201":
+          description: created
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/Channel" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+
+  /api/channels/{id}:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: string } }
+    get:
+      tags: [channels]
+      summary: Get a channel (admin only)
+      operationId: getChannel
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/Channel" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+    put:
+      tags: [channels]
+      summary: Update a channel (admin only)
+      operationId: updateChannel
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "../../components.yaml#/components/schemas/ChannelWriteRequest" }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/Channel" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+    delete:
+      tags: [channels]
+      summary: Delete a channel (admin only)
+      operationId: deleteChannel
+      responses:
+        "200":
+          description: deleted
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/DeleteResult" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+
+  /api/channels/weixin/qr:
+    post:
+      tags: [weixin]
+      summary: Start WeChat QR login flow (any authenticated user)
+      operationId: startWeixinQR
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/WeixinQRCode" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "502":
+          description: upstream error from iLink API
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/Error" }
+
+  /api/channels/weixin/qr/status:
+    get:
+      tags: [weixin]
+      summary: Poll WeChat QR login status (any authenticated user)
+      operationId: pollWeixinQRStatus
+      parameters:
+        - { name: qrcode, in: query, required: true, schema: { type: string }, description: "QR code token from startWeixinQR" }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/WeixinQRStatus" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "502":
+          description: upstream error from iLink API
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/Error" }

--- a/api/spec/domain/channels/schemas.yaml
+++ b/api/spec/domain/channels/schemas.yaml
@@ -1,0 +1,64 @@
+openapi: 3.0.3
+info:
+  title: Channels Components
+  version: "1"
+paths: {}
+components:
+  schemas:
+    Channel:
+      type: object
+      required: [id, type, enabled, config]
+      properties:
+        id:       { type: string }
+        type:     { type: string }
+        agent_id: { type: string }
+        enabled:  { type: boolean }
+        config:
+          type: string
+          description: "JSON string of the channel config"
+
+    ChannelList:
+      type: object
+      required: [items]
+      properties:
+        items: { type: array, items: { $ref: "#/components/schemas/Channel" } }
+
+    PublicChannel:
+      type: object
+      required: [id, type, label, enabled]
+      properties:
+        id:         { type: string }
+        type:       { type: string }
+        label:      { type: string }
+        agent_id:   { type: string }
+        agent_name: { type: string }
+        enabled:    { type: boolean }
+
+    PublicChannelList:
+      type: object
+      required: [items]
+      properties:
+        items: { type: array, items: { $ref: "#/components/schemas/PublicChannel" } }
+
+    ChannelWriteRequest:
+      type: object
+      properties:
+        id:       { type: string }
+        type:     { type: string, nullable: true }
+        agent_id: { type: string, nullable: true }
+        config:   { type: string, description: "JSON string of the channel config" }
+
+    WeixinQRCode:
+      type: object
+      properties:
+        qrcode:            { type: string }
+        qrcode_img_content: { type: string }
+
+    WeixinQRStatus:
+      type: object
+      properties:
+        status:        { type: string }
+        bot_token:     { type: string }
+        ilink_bot_id:  { type: string }
+        ilink_user_id: { type: string }
+        baseurl:       { type: string }

--- a/api/spec/domain/models/paths.yaml
+++ b/api/spec/domain/models/paths.yaml
@@ -1,0 +1,15 @@
+paths:
+  /api/models:
+    get:
+      tags: [models]
+      summary: List enabled models from provider config and cache
+      operationId: listModels
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "../../components.yaml#/components/schemas/CachedModel" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }

--- a/api/spec/domain/models/schemas.yaml
+++ b/api/spec/domain/models/schemas.yaml
@@ -1,0 +1,13 @@
+openapi: 3.0.3
+info:
+  title: Models Components
+  version: "1"
+paths: {}
+components:
+  schemas:
+    CachedModel:
+      type: object
+      required: [provider, model]
+      properties:
+        provider: { type: string }
+        model: { type: string }

--- a/api/spec/domain/plugins/paths.yaml
+++ b/api/spec/domain/plugins/paths.yaml
@@ -1,0 +1,164 @@
+paths:
+  /api/plugins:
+    get:
+      tags: [plugins]
+      summary: List all plugins (admin only)
+      operationId: listPlugins
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "../../components.yaml#/components/schemas/PluginView" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+
+  /api/plugins/{kind}/{name}:
+    parameters:
+      - { name: kind, in: path, required: true, schema: { type: string } }
+      - { name: name, in: path, required: true, schema: { type: string } }
+    patch:
+      tags: [plugins]
+      summary: Toggle plugin enabled state (admin only)
+      operationId: togglePlugin
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "../../components.yaml#/components/schemas/TogglePluginRequest" }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { type: object, additionalProperties: true }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+
+  /api/plugin-status/{kind}/{name}:
+    parameters:
+      - { name: kind, in: path, required: true, schema: { type: string } }
+      - { name: name, in: path, required: true, schema: { type: string } }
+    get:
+      tags: [plugins]
+      summary: Get plugin status (admin only)
+      operationId: getPluginStatus
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { type: object, additionalProperties: true }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+
+  /api/plugin-config/{kind}/{name}:
+    parameters:
+      - { name: kind, in: path, required: true, schema: { type: string } }
+      - { name: name, in: path, required: true, schema: { type: string } }
+    get:
+      tags: [plugins]
+      summary: Get plugin config (admin only)
+      operationId: getPluginConfig
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { type: object, additionalProperties: true }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+    put:
+      tags: [plugins]
+      summary: Update plugin config (admin only)
+      operationId: updatePluginConfig
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "../../components.yaml#/components/schemas/UpdatePluginConfigRequest" }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { type: object, additionalProperties: true }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+
+  /api/plugin-config-schema/{kind}/{name}:
+    parameters:
+      - { name: kind, in: path, required: true, schema: { type: string } }
+      - { name: name, in: path, required: true, schema: { type: string } }
+    get:
+      tags: [plugins]
+      summary: Get plugin config schema (admin only)
+      operationId: getPluginConfigSchema
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { type: object, additionalProperties: true }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+
+  /api/manifest-plugins:
+    get:
+      tags: [plugins]
+      summary: List manifest plugins (admin only)
+      operationId: listManifestPlugins
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "../../components.yaml#/components/schemas/ManifestPlugin" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+    put:
+      tags: [plugins]
+      summary: Save manifest plugins (admin only)
+      operationId: saveManifestPlugins
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                plugins:
+                  type: array
+                  items: { $ref: "../../components.yaml#/components/schemas/ManifestPlugin" }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "../../components.yaml#/components/schemas/ManifestPlugin" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+
+  /api/manifest-plugins/sync:
+    post:
+      tags: [plugins]
+      summary: Sync manifest plugins (admin only)
+      operationId: syncManifestPlugins
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { type: object, additionalProperties: true }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }

--- a/api/spec/domain/plugins/schemas.yaml
+++ b/api/spec/domain/plugins/schemas.yaml
@@ -1,0 +1,39 @@
+openapi: 3.0.3
+info:
+  title: Plugins Components
+  version: "1"
+paths: {}
+components:
+  schemas:
+    PluginView:
+      type: object
+      properties:
+        id:           { type: string }
+        kind:         { type: string }
+        name:         { type: string }
+        enabled:      { type: boolean }
+        config:       { type: object, additionalProperties: true }
+        display_name: { type: string }
+        description:  { type: string }
+        managed:      { type: boolean }
+        admin_visible: { type: boolean }
+        has_config:   { type: boolean }
+        has_status:   { type: boolean }
+        capabilities: { type: array, items: { type: string } }
+        persisted:    { type: boolean }
+        persisted_id: { type: string }
+
+    TogglePluginRequest:
+      type: object
+      required: [enabled]
+      properties:
+        enabled: { type: boolean }
+
+    UpdatePluginConfigRequest:
+      type: object
+      properties:
+        config: { type: object, additionalProperties: true }
+
+    ManifestPlugin:
+      type: object
+      additionalProperties: true

--- a/api/spec/domain/profile/paths.yaml
+++ b/api/spec/domain/profile/paths.yaml
@@ -1,0 +1,281 @@
+paths:
+  # ── Identities ──────────────────────────────────────────────────────────────
+  /api/auth/profile/identities:
+    get:
+      tags: [profile]
+      summary: List linked identities for the current user
+      operationId: listProfileIdentities
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "../../components.yaml#/components/schemas/Identity" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+
+  /api/auth/profile/identities/{id}:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: integer, format: int64 } }
+    delete:
+      tags: [profile]
+      summary: Unlink an identity from the current user
+      operationId: unlinkProfileIdentity
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { type: object }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+
+  /api/auth/profile/password:
+    put:
+      tags: [profile]
+      summary: Change the current user's password
+      operationId: changePassword
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "../../components.yaml#/components/schemas/ChangePasswordRequest" }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { type: object }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+
+  /api/auth/profile/link-code:
+    post:
+      tags: [profile]
+      summary: Generate a short-lived link code for a platform
+      operationId: generateLinkCode
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "../../components.yaml#/components/schemas/GenerateLinkCodeRequest" }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/LinkCodeResponse" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+
+  # ── Memories ────────────────────────────────────────────────────────────────
+  /api/auth/profile/memories:
+    get:
+      tags: [profile]
+      summary: List per-agent memories for the current user
+      operationId: listProfileMemories
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "../../components.yaml#/components/schemas/UserMemory" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+
+  /api/auth/profile/memories/{agentId}:
+    parameters:
+      - { name: agentId, in: path, required: true, schema: { type: string } }
+    put:
+      tags: [profile]
+      summary: Set the memory for a specific agent
+      operationId: setProfileMemory
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "../../components.yaml#/components/schemas/SetMemoryRequest" }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { type: object }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+    delete:
+      tags: [profile]
+      summary: Delete the memory for a specific agent
+      operationId: deleteProfileMemory
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { type: object }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+
+  # ── Soul ────────────────────────────────────────────────────────────────────
+  /api/auth/profile/soul/{agentId}:
+    parameters:
+      - { name: agentId, in: path, required: true, schema: { type: string } }
+    put:
+      tags: [profile]
+      summary: Set the soul for a specific agent
+      operationId: setProfileSoul
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "../../components.yaml#/components/schemas/SetSoulRequest" }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { type: object }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+
+  # ── Vault ───────────────────────────────────────────────────────────────────
+  /api/auth/profile/vault:
+    get:
+      tags: [profile]
+      summary: List vault entries for the current user
+      operationId: listVaultEntries
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "../../components.yaml#/components/schemas/VaultEntry" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+
+  /api/auth/profile/vault/{name}:
+    parameters:
+      - { name: name, in: path, required: true, schema: { type: string } }
+    put:
+      tags: [profile]
+      summary: Create or update a vault entry
+      operationId: setVaultEntry
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "../../components.yaml#/components/schemas/SetVaultEntryRequest" }
+      responses:
+        "204":
+          description: no content
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+    delete:
+      tags: [profile]
+      summary: Delete a vault entry
+      operationId: deleteVaultEntry
+      responses:
+        "204":
+          description: no content
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+
+  # ── OAuth ───────────────────────────────────────────────────────────────────
+  /api/auth/profile/oauth/providers:
+    get:
+      tags: [profile]
+      summary: List OAuth provider statuses for the current user
+      operationId: listOAuthProviders
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "../../components.yaml#/components/schemas/OAuthProviderStatus" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+
+  /api/auth/profile/oauth/{provider}/start:
+    parameters:
+      - { name: provider, in: path, required: true, schema: { type: string } }
+    post:
+      tags: [profile]
+      summary: Start an OAuth device flow for a provider
+      operationId: startOAuthFlow
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/OAuthFlowStatus" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+
+  /api/auth/profile/oauth/{provider}/status/{flowID}:
+    parameters:
+      - { name: provider, in: path, required: true, schema: { type: string } }
+      - { name: flowID, in: path, required: true, schema: { type: string } }
+    get:
+      tags: [profile]
+      summary: Poll the status of an OAuth flow
+      operationId: pollOAuthFlow
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/OAuthFlowStatus" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+
+  /api/auth/profile/oauth/{provider}/connected:
+    parameters:
+      - { name: provider, in: path, required: true, schema: { type: string } }
+    get:
+      tags: [profile]
+      summary: Check if the current user is connected to an OAuth provider
+      operationId: getOAuthConnected
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/OAuthConnectedResponse" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+
+  /api/auth/profile/oauth/{provider}:
+    parameters:
+      - { name: provider, in: path, required: true, schema: { type: string } }
+    delete:
+      tags: [profile]
+      summary: Disconnect an OAuth provider
+      operationId: disconnectOAuth
+      responses:
+        "204":
+          description: no content
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+
+  /api/auth/profile/oauth/{provider}/callback:
+    parameters:
+      - { name: provider, in: path, required: true, schema: { type: string } }
+    get:
+      tags: [profile]
+      summary: OAuth callback (browser redirect, unauthenticated)
+      operationId: oauthCallback
+      security: []
+      parameters:
+        - { name: code, in: query, required: true, schema: { type: string } }
+        - { name: state, in: query, required: true, schema: { type: string } }
+      responses:
+        "302":
+          description: redirect on success
+        "400":
+          description: bad request
+        "500":
+          description: internal server error

--- a/api/spec/domain/profile/schemas.yaml
+++ b/api/spec/domain/profile/schemas.yaml
@@ -1,0 +1,74 @@
+openapi: 3.0.3
+info:
+  title: Profile Components
+  version: "1"
+paths: {}
+components:
+  schemas:
+    ChangePasswordRequest:
+      type: object
+      required: [current_password, new_password]
+      properties:
+        current_password: { type: string }
+        new_password:     { type: string }
+
+    GenerateLinkCodeRequest:
+      type: object
+      required: [platform]
+      properties:
+        platform: { type: string }
+
+    LinkCodeResponse:
+      type: object
+      required: [code, platform]
+      properties:
+        code:     { type: string }
+        platform: { type: string }
+
+    SetSoulRequest:
+      type: object
+      required: [soul]
+      properties:
+        soul: { type: string }
+
+    VaultEntry:
+      type: object
+      required: [name, created_at, updated_at]
+      properties:
+        name:       { type: string }
+        created_at: { type: string }
+        updated_at: { type: string }
+
+    SetVaultEntryRequest:
+      type: object
+      required: [value]
+      properties:
+        value: { type: string }
+
+    OAuthProviderStatus:
+      type: object
+      required: [provider, available, connected]
+      properties:
+        provider:    { type: string }
+        available:   { type: boolean }
+        connected:   { type: boolean }
+        username:    { type: string }
+        unavailable: { type: string }
+
+    OAuthFlowStatus:
+      type: object
+      required: [provider, flow_id, verification_uri, expires_at, state]
+      properties:
+        provider:         { type: string }
+        flow_id:          { type: string }
+        verification_uri: { type: string }
+        user_code:        { type: string }
+        expires_at:       { type: string }
+        state:            { type: string }
+
+    OAuthConnectedResponse:
+      type: object
+      required: [connected]
+      properties:
+        connected: { type: boolean }
+        username:  { type: string }

--- a/api/spec/domain/providers/paths.yaml
+++ b/api/spec/domain/providers/paths.yaml
@@ -1,0 +1,139 @@
+paths:
+  /api/providers:
+    get:
+      tags: [providers]
+      summary: List all providers (admin only)
+      operationId: listProviders
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "../../components.yaml#/components/schemas/Provider" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+    post:
+      tags: [providers]
+      summary: Create a provider (admin only)
+      operationId: createProvider
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "../../components.yaml#/components/schemas/Provider" }
+      responses:
+        "201":
+          description: created
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/Provider" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+
+  /api/providers/{id}:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: string } }
+    get:
+      tags: [providers]
+      summary: Get a provider (admin only)
+      operationId: getProvider
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/Provider" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+    put:
+      tags: [providers]
+      summary: Update a provider (admin only)
+      operationId: updateProvider
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "../../components.yaml#/components/schemas/Provider" }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/Provider" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+    delete:
+      tags: [providers]
+      summary: Delete a provider (admin only)
+      operationId: deleteProvider
+      responses:
+        "200":
+          description: deleted
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/DeleteResult" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+
+  /api/providers/{id}/models:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: string } }
+    get:
+      tags: [providers]
+      summary: List models for a provider (admin only)
+      operationId: listProviderModels
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "../../components.yaml#/components/schemas/ProviderModelItem" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+    post:
+      tags: [providers]
+      summary: Fetch and cache models from upstream provider (admin only)
+      operationId: fetchProviderModels
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema: { $ref: "../../components.yaml#/components/schemas/FetchModelsRequest" }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "../../components.yaml#/components/schemas/ProviderModelItem" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+
+  /api/provider-types:
+    get:
+      tags: [providers]
+      summary: List available provider types (admin only)
+      operationId: listProviderTypes
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "../../components.yaml#/components/schemas/ProviderType" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }

--- a/api/spec/domain/providers/schemas.yaml
+++ b/api/spec/domain/providers/schemas.yaml
@@ -1,0 +1,67 @@
+openapi: 3.0.3
+info:
+  title: Providers Components
+  version: "1"
+paths: {}
+components:
+  schemas:
+    ProviderModelCost:
+      type: object
+      properties:
+        input:      { type: number, format: double }
+        output:     { type: number, format: double }
+        cacheRead:  { type: number, format: double }
+        cacheWrite: { type: number, format: double }
+
+    ProviderModel:
+      type: object
+      required: [enabled]
+      properties:
+        id:            { type: string }
+        name:          { type: string }
+        enabled:       { type: boolean }
+        reasoning:     { type: boolean }
+        input:         { type: array, items: { type: string } }
+        output:        { type: array, items: { type: string } }
+        contextWindow: { type: integer }
+        maxTokens:     { type: integer }
+        cost:          { $ref: "#/components/schemas/ProviderModelCost" }
+
+    Provider:
+      type: object
+      required: [id, type, name, enabled, api_key, base_url]
+      properties:
+        id:       { type: string }
+        type:     { type: string }
+        name:     { type: string }
+        enabled:  { type: boolean }
+        api_key:  { type: string }
+        base_url: { type: string }
+        models:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/ProviderModel"
+
+    ProviderModelItem:
+      type: object
+      required: [id, source, enabled]
+      properties:
+        id:      { type: string }
+        name:    { type: string }
+        source:  { type: string }
+        enabled: { type: boolean }
+        config:  { $ref: "#/components/schemas/ProviderModel" }
+
+    ProviderType:
+      type: object
+      required: [id, name, default_url]
+      properties:
+        id:          { type: string }
+        name:        { type: string }
+        default_url: { type: string }
+
+    FetchModelsRequest:
+      type: object
+      properties:
+        api_key:  { type: string }
+        base_url: { type: string }

--- a/api/spec/domain/sessions/paths.yaml
+++ b/api/spec/domain/sessions/paths.yaml
@@ -1,0 +1,123 @@
+paths:
+  /api/sessions:
+    get:
+      tags: [sessions]
+      summary: List sessions (all users see their own; admins see all)
+      operationId: listSessions
+      parameters:
+        - name: limit
+          in: query
+          schema: { type: integer, default: 10 }
+          description: Maximum number of sessions to return
+        - name: offset
+          in: query
+          schema: { type: integer, default: 0 }
+          description: Number of sessions to skip
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "../../components.yaml#/components/schemas/Session" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+    post:
+      tags: [sessions]
+      summary: Create a new session
+      operationId: createSession
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema: { $ref: "../../components.yaml#/components/schemas/CreateSessionRequest" }
+      responses:
+        "201":
+          description: created
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/Session" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+
+  /api/sessions/{sessionID}:
+    parameters:
+      - { name: sessionID, in: path, required: true, schema: { type: string } }
+    get:
+      tags: [sessions]
+      summary: Get session detail
+      operationId: getSession
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/SessionDetail" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+
+  /api/sessions/{sessionID}/messages:
+    parameters:
+      - { name: sessionID, in: path, required: true, schema: { type: string } }
+    get:
+      tags: [sessions]
+      summary: Get messages for a session
+      operationId: getSessionMessages
+      parameters:
+        - name: limit
+          in: query
+          schema: { type: integer, default: 20 }
+          description: Maximum number of messages to return
+        - name: skip
+          in: query
+          schema: { type: integer, default: 0 }
+          description: Number of messages to skip from the end
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  additionalProperties: {}
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+    post:
+      tags: [sessions]
+      summary: Send a message to a session (SSE streaming)
+      operationId: sendSessionMessage
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "../../components.yaml#/components/schemas/SendMessageRequest" }
+      responses:
+        "200":
+          description: SSE stream of session events
+          content:
+            text/event-stream:
+              schema: { type: string }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+
+  /api/sessions/{sessionID}/system-prompt:
+    parameters:
+      - { name: sessionID, in: path, required: true, schema: { type: string } }
+    get:
+      tags: [sessions]
+      summary: Get the system prompt for a session
+      operationId: getSessionSystemPrompt
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/SystemPromptResponse" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }

--- a/api/spec/domain/sessions/schemas.yaml
+++ b/api/spec/domain/sessions/schemas.yaml
@@ -1,0 +1,46 @@
+openapi: 3.0.3
+info:
+  title: Sessions Components
+  version: "1"
+paths: {}
+components:
+  schemas:
+    Session:
+      type: object
+      required: [id, channel, title, agent_id, user_id, created_at, last_active, archived]
+      properties:
+        id:          { type: string }
+        channel:     { type: string }
+        title:       { type: string }
+        agent_id:    { type: string }
+        user_id:     { type: integer, format: int64 }
+        created_at:  { type: string }
+        last_active: { type: string }
+        archived:    { type: boolean }
+
+    SessionDetail:
+      allOf:
+        - $ref: "#/components/schemas/Session"
+        - type: object
+          properties:
+            agent_name: { type: string }
+            user_name:  { type: string }
+
+    CreateSessionRequest:
+      type: object
+      properties:
+        agent_id: { type: string }
+
+    SendMessageRequest:
+      type: object
+      required: [content]
+      properties:
+        content:
+          type: string
+          description: "Message content (required)"
+
+    SystemPromptResponse:
+      type: object
+      required: [system_prompt]
+      properties:
+        system_prompt: { type: string }

--- a/api/spec/domain/skills/paths.yaml
+++ b/api/spec/domain/skills/paths.yaml
@@ -1,0 +1,335 @@
+paths:
+  # ── Global skills (admin) ──────────────────────────────────────────────────
+
+  /api/skills:
+    get:
+      tags: [skills]
+      summary: List all skills (admin only)
+      operationId: listSkills
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/SkillList" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+    post:
+      tags: [skills]
+      summary: Create a skill (admin only)
+      operationId: createSkill
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "../../components.yaml#/components/schemas/CreateSkillRequest" }
+      responses:
+        "201":
+          description: created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: { type: string }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+
+  /api/skills/search:
+    get:
+      tags: [skills]
+      summary: Search skills from mcphub (any authenticated user)
+      operationId: searchSkills
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema: { type: string }
+        - name: limit
+          in: query
+          required: false
+          schema: { type: integer, default: 10 }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "../../components.yaml#/components/schemas/SkillSearchResult" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+
+  /api/skills/install:
+    post:
+      tags: [skills]
+      summary: Install a skill from a remote source (admin only)
+      operationId: installSkill
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "../../components.yaml#/components/schemas/GlobalInstallSkillRequest" }
+      responses:
+        "201":
+          description: installed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name: { type: string }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+
+  /api/skills/{id}:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: string } }
+    get:
+      tags: [skills]
+      summary: Get a skill by ID (admin only)
+      operationId: getSkill
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/Skill" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+    put:
+      tags: [skills]
+      summary: Update a skill (admin only)
+      operationId: updateSkill
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "../../components.yaml#/components/schemas/UpdateSkillRequest" }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: { type: string }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+    delete:
+      tags: [skills]
+      summary: Delete a skill (admin only)
+      operationId: deleteSkill
+      responses:
+        "200":
+          description: deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: { type: string }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+
+  /api/skills/{id}/file:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: string } }
+    get:
+      tags: [skills]
+      summary: Get a skill file (admin only)
+      operationId: getSkillFile
+      parameters:
+        - name: path
+          in: query
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/SkillFileResponse" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+    delete:
+      tags: [skills]
+      summary: Delete a skill file (admin only)
+      operationId: deleteSkillFile
+      parameters:
+        - name: path
+          in: query
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/DeleteFileResult" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+
+  # ── Profile-scoped skills ──────────────────────────────────────────────────
+
+  /api/auth/profile/skills:
+    get:
+      tags: [skills]
+      summary: List profile skills (current user)
+      operationId: listProfileSkills
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/SkillList" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+
+  /api/auth/profile/skills/install:
+    post:
+      tags: [skills]
+      summary: Install a skill to the current user's profile
+      operationId: installProfileSkill
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "../../components.yaml#/components/schemas/ProfileInstallSkillRequest" }
+      responses:
+        "201":
+          description: installed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name: { type: string }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+
+  /api/auth/profile/skills/upload:
+    post:
+      tags: [skills]
+      summary: Upload a skill zip to the current user's profile
+      operationId: uploadProfileSkill
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        "201":
+          description: uploaded
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/SkillUploadResult" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+
+  /api/auth/profile/skills/{skillId}:
+    parameters:
+      - { name: skillId, in: path, required: true, schema: { type: string } }
+    get:
+      tags: [skills]
+      summary: Get a profile skill by ID
+      operationId: getProfileSkill
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/Skill" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+    put:
+      tags: [skills]
+      summary: Update a profile skill
+      operationId: updateProfileSkill
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "../../components.yaml#/components/schemas/UpdateSkillRequest" }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: { type: string }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+    delete:
+      tags: [skills]
+      summary: Delete a profile skill
+      operationId: deleteProfileSkill
+      responses:
+        "200":
+          description: deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: { type: string }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+
+  /api/auth/profile/skills/{skillId}/file:
+    parameters:
+      - { name: skillId, in: path, required: true, schema: { type: string } }
+    get:
+      tags: [skills]
+      summary: Get a profile skill file
+      operationId: getProfileSkillFile
+      parameters:
+        - name: path
+          in: query
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/SkillFileResponse" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+    delete:
+      tags: [skills]
+      summary: Delete a profile skill file
+      operationId: deleteProfileSkillFile
+      parameters:
+        - name: path
+          in: query
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/DeleteFileResult" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }

--- a/api/spec/domain/skills/schemas.yaml
+++ b/api/spec/domain/skills/schemas.yaml
@@ -1,0 +1,61 @@
+openapi: 3.0.3
+info:
+  title: Skills Components
+  version: "1"
+paths: {}
+components:
+  schemas:
+    CreateSkillRequest:
+      type: object
+      properties:
+        scope:                    { type: string }
+        user_id:                  { type: integer, format: int64 }
+        agent_id:                 { type: string }
+        name:                     { type: string }
+        description:              { type: string }
+        status:                   { type: string }
+        disable_model_invocation: { type: boolean }
+        files:
+          type: object
+          additionalProperties: { type: string }
+
+    GlobalInstallSkillRequest:
+      type: object
+      required: [source]
+      properties:
+        source:   { type: string }
+        scope:    { type: string }
+        user_id:  { type: integer, format: int64 }
+        agent_id: { type: string }
+
+    ProfileInstallSkillRequest:
+      type: object
+      required: [source]
+      properties:
+        source: { type: string }
+
+    SkillSearchResult:
+      type: object
+      properties:
+        id:       { type: string }
+        skillId:  { type: string }
+        name:     { type: string }
+        installs: { type: integer }
+        source:   { type: string }
+
+    SkillSearchResultList:
+      type: object
+      required: [items]
+      properties:
+        items: { type: array, items: { $ref: "#/components/schemas/SkillSearchResult" } }
+
+    SkillFileResponse:
+      type: object
+      properties:
+        path:    { type: string }
+        content: { type: string }
+
+    DeleteFileResult:
+      type: object
+      properties:
+        path: { type: string }

--- a/api/spec/domain/tools/paths.yaml
+++ b/api/spec/domain/tools/paths.yaml
@@ -1,0 +1,15 @@
+paths:
+  /api/tools:
+    get:
+      tags: [tools]
+      summary: List available agent tools
+      operationId: listTools
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "../../components.yaml#/components/schemas/Tool" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }

--- a/api/spec/domain/tools/schemas.yaml
+++ b/api/spec/domain/tools/schemas.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.3
+info:
+  title: Tools Components
+  version: "1"
+paths: {}
+components:
+  schemas:
+    Tool:
+      type: object
+      required: [name, description, category]
+      properties:
+        name: { type: string }
+        description: { type: string }
+        input_schema:
+          type: object
+          additionalProperties: true
+        category: { type: string }

--- a/api/spec/domain/users/paths.yaml
+++ b/api/spec/domain/users/paths.yaml
@@ -1,0 +1,230 @@
+paths:
+  /api/users/{id}/default-agent:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: integer, format: int64 } }
+    put:
+      tags: [users]
+      summary: Update the default agent for a user (admin only)
+      operationId: updateUserDefaultAgent
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "../../components.yaml#/components/schemas/UpdateDefaultAgentRequest" }
+      responses:
+        "200":
+          description: updated
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/DeleteResult" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+
+  /api/users/{id}/notify-identity:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: integer, format: int64 } }
+    put:
+      tags: [users]
+      summary: Update the notify identity for a user (admin only)
+      operationId: updateUserNotifyIdentity
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "../../components.yaml#/components/schemas/UpdateNotifyIdentityRequest" }
+      responses:
+        "200":
+          description: updated
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/DeleteResult" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+
+  /api/users/{id}/memories:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: integer, format: int64 } }
+    get:
+      tags: [users]
+      summary: List memories for a user (admin only)
+      operationId: listUserMemories
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "../../components.yaml#/components/schemas/UserMemory" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+
+  /api/users/{id}/memories/{agentId}:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: integer, format: int64 } }
+      - { name: agentId, in: path, required: true, schema: { type: string } }
+    put:
+      tags: [users]
+      summary: Set memory for a user and agent (admin only)
+      operationId: setUserMemory
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "../../components.yaml#/components/schemas/SetMemoryRequest" }
+      responses:
+        "200":
+          description: saved
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/DeleteResult" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+    delete:
+      tags: [users]
+      summary: Delete memory for a user and agent (admin only)
+      operationId: deleteUserMemory
+      responses:
+        "200":
+          description: deleted
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/DeleteResult" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+
+  /api/auth/users:
+    get:
+      tags: [auth-users]
+      summary: List all auth users (admin only)
+      operationId: listAuthUsers
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "../../components.yaml#/components/schemas/AuthUser" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+
+  /api/auth/users/{id}:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: integer, format: int64 } }
+    get:
+      tags: [auth-users]
+      summary: Get an auth user by ID (admin only)
+      operationId: getAuthUser
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/AuthUser" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+
+  /api/auth/users/{id}/role:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: integer, format: int64 } }
+    put:
+      tags: [auth-users]
+      summary: Update the role of an auth user (admin only)
+      operationId: updateAuthUserRole
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "../../components.yaml#/components/schemas/UpdateRoleRequest" }
+      responses:
+        "200":
+          description: updated
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/DeleteResult" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+
+  /api/auth/users/{id}/agents:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: integer, format: int64 } }
+    get:
+      tags: [auth-users]
+      summary: List agents assigned to an auth user (admin only)
+      operationId: listAuthUserAgents
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { type: string }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+    put:
+      tags: [auth-users]
+      summary: Update agents assigned to an auth user (admin only)
+      operationId: updateAuthUserAgents
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "../../components.yaml#/components/schemas/UpdateAgentsRequest" }
+      responses:
+        "200":
+          description: updated
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/DeleteResult" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+
+  /api/auth/users/{id}/identities/{identityId}:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: integer, format: int64 } }
+      - { name: identityId, in: path, required: true, schema: { type: integer, format: int64 } }
+    delete:
+      tags: [auth-users]
+      summary: Delete an identity linked to an auth user (admin only)
+      operationId: deleteAuthUserIdentity
+      responses:
+        "200":
+          description: unlinked
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/DeleteResult" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+
+  /api/auth/users/{id}/active:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: integer, format: int64 } }
+    put:
+      tags: [auth-users]
+      summary: Update the active status of an auth user (admin only)
+      operationId: updateAuthUserActive
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "../../components.yaml#/components/schemas/UpdateActiveRequest" }
+      responses:
+        "200":
+          description: updated
+          content:
+            application/json:
+              schema: { $ref: "../../components.yaml#/components/schemas/DeleteResult" }
+        "400": { $ref: "../../components.yaml#/components/responses/BadRequest" }
+        "401": { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }

--- a/api/spec/domain/users/schemas.yaml
+++ b/api/spec/domain/users/schemas.yaml
@@ -1,0 +1,83 @@
+openapi: 3.0.3
+info:
+  title: Users Components
+  version: "1"
+paths: {}
+components:
+  schemas:
+    Identity:
+      type: object
+      required: [id, user_id, platform, external_id, name, linked_at]
+      properties:
+        id:          { type: integer, format: int64 }
+        user_id:     { type: integer, format: int64 }
+        platform:    { type: string }
+        external_id: { type: string }
+        name:        { type: string }
+        linked_at:   { type: string, format: date-time }
+
+    AuthUser:
+      type: object
+      required: [id, username, role, is_active, identities, created_at, updated_at]
+      properties:
+        id:         { type: integer, format: int64 }
+        username:   { type: string }
+        role:       { type: string }
+        is_active:  { type: boolean }
+        identities:
+          type: array
+          items: { $ref: "#/components/schemas/Identity" }
+        created_at: { type: string }
+        updated_at: { type: string }
+
+    AuthUserList:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items: { $ref: "#/components/schemas/AuthUser" }
+
+    UserMemory:
+      type: object
+      additionalProperties: {}
+
+    UpdateDefaultAgentRequest:
+      type: object
+      required: [default_agent_id]
+      properties:
+        default_agent_id: { type: string }
+
+    UpdateNotifyIdentityRequest:
+      type: object
+      properties:
+        notify_identity_id:
+          type: integer
+          format: int64
+          nullable: true
+
+    SetMemoryRequest:
+      type: object
+      required: [content]
+      properties:
+        content: { type: string }
+
+    UpdateRoleRequest:
+      type: object
+      required: [role]
+      properties:
+        role: { type: string }
+
+    UpdateAgentsRequest:
+      type: object
+      required: [agent_ids]
+      properties:
+        agent_ids:
+          type: array
+          items: { type: string }
+
+    UpdateActiveRequest:
+      type: object
+      required: [is_active]
+      properties:
+        is_active: { type: boolean }

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -41,6 +41,8 @@ tags:
   - name: sessions
   - name: agents
   - name: skills
+  - name: users
+  - name: auth-users
 paths:
   # ── Agents ─────────────────────────────────────────────────────────────────
   /api/agents:
@@ -141,6 +143,28 @@ paths:
     $ref: './domain/sessions/paths.yaml#/paths/~1api~1sessions~1{sessionID}~1messages'
   /api/sessions/{sessionID}/system-prompt:
     $ref: './domain/sessions/paths.yaml#/paths/~1api~1sessions~1{sessionID}~1system-prompt'
+  # ── Users ──────────────────────────────────────────────────────────────────
+  /api/users/{id}/default-agent:
+    $ref: './domain/users/paths.yaml#/paths/~1api~1users~1{id}~1default-agent'
+  /api/users/{id}/notify-identity:
+    $ref: './domain/users/paths.yaml#/paths/~1api~1users~1{id}~1notify-identity'
+  /api/users/{id}/memories:
+    $ref: './domain/users/paths.yaml#/paths/~1api~1users~1{id}~1memories'
+  /api/users/{id}/memories/{agentId}:
+    $ref: './domain/users/paths.yaml#/paths/~1api~1users~1{id}~1memories~1{agentId}'
+  # ── Auth Users ─────────────────────────────────────────────────────────────
+  /api/auth/users:
+    $ref: './domain/users/paths.yaml#/paths/~1api~1auth~1users'
+  /api/auth/users/{id}:
+    $ref: './domain/users/paths.yaml#/paths/~1api~1auth~1users~1{id}'
+  /api/auth/users/{id}/role:
+    $ref: './domain/users/paths.yaml#/paths/~1api~1auth~1users~1{id}~1role'
+  /api/auth/users/{id}/agents:
+    $ref: './domain/users/paths.yaml#/paths/~1api~1auth~1users~1{id}~1agents'
+  /api/auth/users/{id}/identities/{identityId}:
+    $ref: './domain/users/paths.yaml#/paths/~1api~1auth~1users~1{id}~1identities~1{identityId}'
+  /api/auth/users/{id}/active:
+    $ref: './domain/users/paths.yaml#/paths/~1api~1auth~1users~1{id}~1active'
   # ── Scheduler ──────────────────────────────────────────────────────────────
   /api/scheduler/jobs:
     $ref: './domain/scheduler/paths.yaml#/paths/~1api~1scheduler~1jobs'
@@ -221,3 +245,13 @@ components:
     SkillSearchResultList:      { $ref: './components.yaml#/components/schemas/SkillSearchResultList' }
     SkillFileResponse:          { $ref: './components.yaml#/components/schemas/SkillFileResponse' }
     DeleteFileResult:           { $ref: './components.yaml#/components/schemas/DeleteFileResult' }
+    Identity:                   { $ref: './components.yaml#/components/schemas/Identity' }
+    AuthUser:                   { $ref: './components.yaml#/components/schemas/AuthUser' }
+    AuthUserList:               { $ref: './components.yaml#/components/schemas/AuthUserList' }
+    UserMemory:                 { $ref: './components.yaml#/components/schemas/UserMemory' }
+    UpdateDefaultAgentRequest:  { $ref: './components.yaml#/components/schemas/UpdateDefaultAgentRequest' }
+    UpdateNotifyIdentityRequest: { $ref: './components.yaml#/components/schemas/UpdateNotifyIdentityRequest' }
+    SetMemoryRequest:           { $ref: './components.yaml#/components/schemas/SetMemoryRequest' }
+    UpdateRoleRequest:          { $ref: './components.yaml#/components/schemas/UpdateRoleRequest' }
+    UpdateAgentsRequest:        { $ref: './components.yaml#/components/schemas/UpdateAgentsRequest' }
+    UpdateActiveRequest:        { $ref: './components.yaml#/components/schemas/UpdateActiveRequest' }

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -40,6 +40,7 @@ tags:
   - name: providers
   - name: sessions
   - name: agents
+  - name: skills
 paths:
   # ── Agents ─────────────────────────────────────────────────────────────────
   /api/agents:
@@ -62,6 +63,27 @@ paths:
     $ref: './domain/agents/paths.yaml#/paths/~1api~1agents~1{id}~1skills~1{skillId}'
   /api/agents/{id}/skills/{skillId}/file:
     $ref: './domain/agents/paths.yaml#/paths/~1api~1agents~1{id}~1skills~1{skillId}~1file'
+  # ── Skills ─────────────────────────────────────────────────────────────────
+  /api/skills:
+    $ref: './domain/skills/paths.yaml#/paths/~1api~1skills'
+  /api/skills/search:
+    $ref: './domain/skills/paths.yaml#/paths/~1api~1skills~1search'
+  /api/skills/install:
+    $ref: './domain/skills/paths.yaml#/paths/~1api~1skills~1install'
+  /api/skills/{id}:
+    $ref: './domain/skills/paths.yaml#/paths/~1api~1skills~1{id}'
+  /api/skills/{id}/file:
+    $ref: './domain/skills/paths.yaml#/paths/~1api~1skills~1{id}~1file'
+  /api/auth/profile/skills:
+    $ref: './domain/skills/paths.yaml#/paths/~1api~1auth~1profile~1skills'
+  /api/auth/profile/skills/install:
+    $ref: './domain/skills/paths.yaml#/paths/~1api~1auth~1profile~1skills~1install'
+  /api/auth/profile/skills/upload:
+    $ref: './domain/skills/paths.yaml#/paths/~1api~1auth~1profile~1skills~1upload'
+  /api/auth/profile/skills/{skillId}:
+    $ref: './domain/skills/paths.yaml#/paths/~1api~1auth~1profile~1skills~1{skillId}'
+  /api/auth/profile/skills/{skillId}/file:
+    $ref: './domain/skills/paths.yaml#/paths/~1api~1auth~1profile~1skills~1{skillId}~1file'
   # ── Recally ────────────────────────────────────────────────────────────────
   /api/recally/articles:
     $ref: './domain/recally/paths.yaml#/paths/~1api~1recally~1articles'
@@ -192,3 +214,10 @@ components:
     UpdateSkillRequest:   { $ref: './components.yaml#/components/schemas/UpdateSkillRequest' }
     SkillUploadResult:    { $ref: './components.yaml#/components/schemas/SkillUploadResult' }
     DuplicateSkillResult: { $ref: './components.yaml#/components/schemas/DuplicateSkillResult' }
+    CreateSkillRequest:         { $ref: './components.yaml#/components/schemas/CreateSkillRequest' }
+    GlobalInstallSkillRequest:  { $ref: './components.yaml#/components/schemas/GlobalInstallSkillRequest' }
+    ProfileInstallSkillRequest: { $ref: './components.yaml#/components/schemas/ProfileInstallSkillRequest' }
+    SkillSearchResult:          { $ref: './components.yaml#/components/schemas/SkillSearchResult' }
+    SkillSearchResultList:      { $ref: './components.yaml#/components/schemas/SkillSearchResultList' }
+    SkillFileResponse:          { $ref: './components.yaml#/components/schemas/SkillFileResponse' }
+    DeleteFileResult:           { $ref: './components.yaml#/components/schemas/DeleteFileResult' }

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -35,6 +35,8 @@ tags:
   - name: models
   - name: tools
   - name: builtin
+  - name: channels
+  - name: weixin
 paths:
   # ── Recally ────────────────────────────────────────────────────────────────
   /api/recally/articles:
@@ -64,6 +66,17 @@ paths:
     $ref: './domain/builtin/paths.yaml#/paths/~1api~1builtin~1{kind}'
   /api/builtin/{kind}/{id}:
     $ref: './domain/builtin/paths.yaml#/paths/~1api~1builtin~1{kind}~1{id}'
+  # ── Channels ───────────────────────────────────────────────────────────────
+  /api/channels/public:
+    $ref: './domain/channels/paths.yaml#/paths/~1api~1channels~1public'
+  /api/channels:
+    $ref: './domain/channels/paths.yaml#/paths/~1api~1channels'
+  /api/channels/{id}:
+    $ref: './domain/channels/paths.yaml#/paths/~1api~1channels~1{id}'
+  /api/channels/weixin/qr:
+    $ref: './domain/channels/paths.yaml#/paths/~1api~1channels~1weixin~1qr'
+  /api/channels/weixin/qr/status:
+    $ref: './domain/channels/paths.yaml#/paths/~1api~1channels~1weixin~1qr~1status'
   # ── Scheduler ──────────────────────────────────────────────────────────────
   /api/scheduler/jobs:
     $ref: './domain/scheduler/paths.yaml#/paths/~1api~1scheduler~1jobs'
@@ -105,3 +118,10 @@ components:
     Tool:                 { $ref: './components.yaml#/components/schemas/Tool' }
     BuiltinResource:      { $ref: './components.yaml#/components/schemas/BuiltinResource' }
     BuiltinResourceDetail: { $ref: './components.yaml#/components/schemas/BuiltinResourceDetail' }
+    Channel:              { $ref: './components.yaml#/components/schemas/Channel' }
+    ChannelList:          { $ref: './components.yaml#/components/schemas/ChannelList' }
+    PublicChannel:        { $ref: './components.yaml#/components/schemas/PublicChannel' }
+    PublicChannelList:    { $ref: './components.yaml#/components/schemas/PublicChannelList' }
+    ChannelWriteRequest:  { $ref: './components.yaml#/components/schemas/ChannelWriteRequest' }
+    WeixinQRCode:         { $ref: './components.yaml#/components/schemas/WeixinQRCode' }
+    WeixinQRStatus:       { $ref: './components.yaml#/components/schemas/WeixinQRStatus' }

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -2,11 +2,14 @@ openapi: 3.0.3
 info:
   title: anna API
   description: |
-    Full REST API for anna. This is the aggregated entry point; individual
-    feature specs live in sub-files:
+    Full REST API for anna covering ALL /api/* routes. This is the aggregated
+    entry point; individual feature specs live in sub-files under api/spec/domain/:
 
-    - Recally (reading assistant): api/spec/domain/recally/paths.yaml
-    - Scheduler (job scheduling):  api/spec/domain/scheduler/paths.yaml
+    - Agents, Skills, Sessions, Models, Providers
+    - Auth, Auth-Users, Profile, OAuth
+    - Channels, Plugins, Manifest-Plugins
+    - Recally (reading assistant), Scheduler (job scheduling)
+    - Users, Vault, Builtin, Tools, Weixin
 
     Schema source of truth (human-edited, domain-organized):
       api/spec/components/common.yaml    — security schemes, shared responses

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -38,6 +38,7 @@ tags:
   - name: channels
   - name: weixin
   - name: providers
+  - name: sessions
 paths:
   # ── Recally ────────────────────────────────────────────────────────────────
   /api/recally/articles:
@@ -87,6 +88,15 @@ paths:
     $ref: './domain/providers/paths.yaml#/paths/~1api~1providers~1{id}~1models'
   /api/provider-types:
     $ref: './domain/providers/paths.yaml#/paths/~1api~1provider-types'
+  # ── Sessions ───────────────────────────────────────────────────────────────
+  /api/sessions:
+    $ref: './domain/sessions/paths.yaml#/paths/~1api~1sessions'
+  /api/sessions/{sessionID}:
+    $ref: './domain/sessions/paths.yaml#/paths/~1api~1sessions~1{sessionID}'
+  /api/sessions/{sessionID}/messages:
+    $ref: './domain/sessions/paths.yaml#/paths/~1api~1sessions~1{sessionID}~1messages'
+  /api/sessions/{sessionID}/system-prompt:
+    $ref: './domain/sessions/paths.yaml#/paths/~1api~1sessions~1{sessionID}~1system-prompt'
   # ── Scheduler ──────────────────────────────────────────────────────────────
   /api/scheduler/jobs:
     $ref: './domain/scheduler/paths.yaml#/paths/~1api~1scheduler~1jobs'
@@ -141,3 +151,8 @@ components:
     ProviderModelItem:    { $ref: './components.yaml#/components/schemas/ProviderModelItem' }
     ProviderType:         { $ref: './components.yaml#/components/schemas/ProviderType' }
     FetchModelsRequest:   { $ref: './components.yaml#/components/schemas/FetchModelsRequest' }
+    Session:              { $ref: './components.yaml#/components/schemas/Session' }
+    SessionDetail:        { $ref: './components.yaml#/components/schemas/SessionDetail' }
+    CreateSessionRequest: { $ref: './components.yaml#/components/schemas/CreateSessionRequest' }
+    SendMessageRequest:   { $ref: './components.yaml#/components/schemas/SendMessageRequest' }
+    SystemPromptResponse: { $ref: './components.yaml#/components/schemas/SystemPromptResponse' }

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -32,6 +32,9 @@ tags:
   - name: feed-entries
   - name: digest
   - name: jobs
+  - name: models
+  - name: tools
+  - name: builtin
 paths:
   # ── Recally ────────────────────────────────────────────────────────────────
   /api/recally/articles:
@@ -50,6 +53,17 @@ paths:
     $ref: './domain/recally/paths.yaml#/paths/~1api~1recally~1feeds~1{feedId}~1entries~1{id}'
   /api/recally/digest:
     $ref: './domain/recally/paths.yaml#/paths/~1api~1recally~1digest'
+  # ── Models ─────────────────────────────────────────────────────────────────
+  /api/models:
+    $ref: './domain/models/paths.yaml#/paths/~1api~1models'
+  # ── Tools ──────────────────────────────────────────────────────────────────
+  /api/tools:
+    $ref: './domain/tools/paths.yaml#/paths/~1api~1tools'
+  # ── Builtin ────────────────────────────────────────────────────────────────
+  /api/builtin/{kind}:
+    $ref: './domain/builtin/paths.yaml#/paths/~1api~1builtin~1{kind}'
+  /api/builtin/{kind}/{id}:
+    $ref: './domain/builtin/paths.yaml#/paths/~1api~1builtin~1{kind}~1{id}'
   # ── Scheduler ──────────────────────────────────────────────────────────────
   /api/scheduler/jobs:
     $ref: './domain/scheduler/paths.yaml#/paths/~1api~1scheduler~1jobs'
@@ -87,3 +101,7 @@ components:
     JobList:      { $ref: './components.yaml#/components/schemas/JobList' }
     JobInput:     { $ref: './components.yaml#/components/schemas/JobInput' }
     DeleteResult: { $ref: './components.yaml#/components/schemas/DeleteResult' }
+    CachedModel:          { $ref: './components.yaml#/components/schemas/CachedModel' }
+    Tool:                 { $ref: './components.yaml#/components/schemas/Tool' }
+    BuiltinResource:      { $ref: './components.yaml#/components/schemas/BuiltinResource' }
+    BuiltinResourceDetail: { $ref: './components.yaml#/components/schemas/BuiltinResourceDetail' }

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -45,6 +45,7 @@ tags:
   - name: auth-users
   - name: profile
   - name: auth
+  - name: plugins
 paths:
   # ── Auth ───────────────────────────────────────────────────────────────────
   /api/auth/register:
@@ -216,6 +217,21 @@ paths:
     $ref: './domain/scheduler/paths.yaml#/paths/~1api~1scheduler~1jobs~1{id}~1run'
   /api/scheduler/jobs/{id}/runs:
     $ref: './domain/scheduler/paths.yaml#/paths/~1api~1scheduler~1jobs~1{id}~1runs'
+  # ── Plugins ────────────────────────────────────────────────────────────────
+  /api/plugins:
+    $ref: './domain/plugins/paths.yaml#/paths/~1api~1plugins'
+  /api/plugins/{kind}/{name}:
+    $ref: './domain/plugins/paths.yaml#/paths/~1api~1plugins~1{kind}~1{name}'
+  /api/plugin-status/{kind}/{name}:
+    $ref: './domain/plugins/paths.yaml#/paths/~1api~1plugin-status~1{kind}~1{name}'
+  /api/plugin-config/{kind}/{name}:
+    $ref: './domain/plugins/paths.yaml#/paths/~1api~1plugin-config~1{kind}~1{name}'
+  /api/plugin-config-schema/{kind}/{name}:
+    $ref: './domain/plugins/paths.yaml#/paths/~1api~1plugin-config-schema~1{kind}~1{name}'
+  /api/manifest-plugins:
+    $ref: './domain/plugins/paths.yaml#/paths/~1api~1manifest-plugins'
+  /api/manifest-plugins/sync:
+    $ref: './domain/plugins/paths.yaml#/paths/~1api~1manifest-plugins~1sync'
 components:
   securitySchemes:
     BearerAuth:
@@ -310,3 +326,7 @@ components:
     RegisterRequest:            { $ref: './components.yaml#/components/schemas/RegisterRequest' }
     AuthResponse:               { $ref: './components.yaml#/components/schemas/AuthResponse' }
     MeResponse:                 { $ref: './components.yaml#/components/schemas/MeResponse' }
+    PluginView:                 { $ref: './components.yaml#/components/schemas/PluginView' }
+    TogglePluginRequest:        { $ref: './components.yaml#/components/schemas/TogglePluginRequest' }
+    UpdatePluginConfigRequest:  { $ref: './components.yaml#/components/schemas/UpdatePluginConfigRequest' }
+    ManifestPlugin:             { $ref: './components.yaml#/components/schemas/ManifestPlugin' }

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -39,7 +39,29 @@ tags:
   - name: weixin
   - name: providers
   - name: sessions
+  - name: agents
 paths:
+  # ── Agents ─────────────────────────────────────────────────────────────────
+  /api/agents:
+    $ref: './domain/agents/paths.yaml#/paths/~1api~1agents'
+  /api/agents/{id}:
+    $ref: './domain/agents/paths.yaml#/paths/~1api~1agents~1{id}'
+  /api/agents/{id}/users:
+    $ref: './domain/agents/paths.yaml#/paths/~1api~1agents~1{id}~1users'
+  /api/agents/{id}/users/{userId}:
+    $ref: './domain/agents/paths.yaml#/paths/~1api~1agents~1{id}~1users~1{userId}'
+  /api/agents/{id}/skills:
+    $ref: './domain/agents/paths.yaml#/paths/~1api~1agents~1{id}~1skills'
+  /api/agents/{id}/skills/install:
+    $ref: './domain/agents/paths.yaml#/paths/~1api~1agents~1{id}~1skills~1install'
+  /api/agents/{id}/skills/upload:
+    $ref: './domain/agents/paths.yaml#/paths/~1api~1agents~1{id}~1skills~1upload'
+  /api/agents/{id}/skills/from-builtin/{skillId}:
+    $ref: './domain/agents/paths.yaml#/paths/~1api~1agents~1{id}~1skills~1from-builtin~1{skillId}'
+  /api/agents/{id}/skills/{skillId}:
+    $ref: './domain/agents/paths.yaml#/paths/~1api~1agents~1{id}~1skills~1{skillId}'
+  /api/agents/{id}/skills/{skillId}/file:
+    $ref: './domain/agents/paths.yaml#/paths/~1api~1agents~1{id}~1skills~1{skillId}~1file'
   # ── Recally ────────────────────────────────────────────────────────────────
   /api/recally/articles:
     $ref: './domain/recally/paths.yaml#/paths/~1api~1recally~1articles'
@@ -156,3 +178,17 @@ components:
     CreateSessionRequest: { $ref: './components.yaml#/components/schemas/CreateSessionRequest' }
     SendMessageRequest:   { $ref: './components.yaml#/components/schemas/SendMessageRequest' }
     SystemPromptResponse: { $ref: './components.yaml#/components/schemas/SystemPromptResponse' }
+    SandboxNetworkConfig: { $ref: './components.yaml#/components/schemas/SandboxNetworkConfig' }
+    SandboxConfig:        { $ref: './components.yaml#/components/schemas/SandboxConfig' }
+    Agent:                { $ref: './components.yaml#/components/schemas/Agent' }
+    AgentList:            { $ref: './components.yaml#/components/schemas/AgentList' }
+    CreateAgentRequest:   { $ref: './components.yaml#/components/schemas/CreateAgentRequest' }
+    AgentUser:            { $ref: './components.yaml#/components/schemas/AgentUser' }
+    AgentUserList:        { $ref: './components.yaml#/components/schemas/AgentUserList' }
+    AssignAgentUserRequest: { $ref: './components.yaml#/components/schemas/AssignAgentUserRequest' }
+    Skill:                { $ref: './components.yaml#/components/schemas/Skill' }
+    SkillList:            { $ref: './components.yaml#/components/schemas/SkillList' }
+    InstallSkillRequest:  { $ref: './components.yaml#/components/schemas/InstallSkillRequest' }
+    UpdateSkillRequest:   { $ref: './components.yaml#/components/schemas/UpdateSkillRequest' }
+    SkillUploadResult:    { $ref: './components.yaml#/components/schemas/SkillUploadResult' }
+    DuplicateSkillResult: { $ref: './components.yaml#/components/schemas/DuplicateSkillResult' }

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -37,6 +37,7 @@ tags:
   - name: builtin
   - name: channels
   - name: weixin
+  - name: providers
 paths:
   # ── Recally ────────────────────────────────────────────────────────────────
   /api/recally/articles:
@@ -77,6 +78,15 @@ paths:
     $ref: './domain/channels/paths.yaml#/paths/~1api~1channels~1weixin~1qr'
   /api/channels/weixin/qr/status:
     $ref: './domain/channels/paths.yaml#/paths/~1api~1channels~1weixin~1qr~1status'
+  # ── Providers ──────────────────────────────────────────────────────────────
+  /api/providers:
+    $ref: './domain/providers/paths.yaml#/paths/~1api~1providers'
+  /api/providers/{id}:
+    $ref: './domain/providers/paths.yaml#/paths/~1api~1providers~1{id}'
+  /api/providers/{id}/models:
+    $ref: './domain/providers/paths.yaml#/paths/~1api~1providers~1{id}~1models'
+  /api/provider-types:
+    $ref: './domain/providers/paths.yaml#/paths/~1api~1provider-types'
   # ── Scheduler ──────────────────────────────────────────────────────────────
   /api/scheduler/jobs:
     $ref: './domain/scheduler/paths.yaml#/paths/~1api~1scheduler~1jobs'
@@ -125,3 +135,9 @@ components:
     ChannelWriteRequest:  { $ref: './components.yaml#/components/schemas/ChannelWriteRequest' }
     WeixinQRCode:         { $ref: './components.yaml#/components/schemas/WeixinQRCode' }
     WeixinQRStatus:       { $ref: './components.yaml#/components/schemas/WeixinQRStatus' }
+    ProviderModelCost:    { $ref: './components.yaml#/components/schemas/ProviderModelCost' }
+    ProviderModel:        { $ref: './components.yaml#/components/schemas/ProviderModel' }
+    Provider:             { $ref: './components.yaml#/components/schemas/Provider' }
+    ProviderModelItem:    { $ref: './components.yaml#/components/schemas/ProviderModelItem' }
+    ProviderType:         { $ref: './components.yaml#/components/schemas/ProviderType' }
+    FetchModelsRequest:   { $ref: './components.yaml#/components/schemas/FetchModelsRequest' }

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -44,7 +44,17 @@ tags:
   - name: users
   - name: auth-users
   - name: profile
+  - name: auth
 paths:
+  # ── Auth ───────────────────────────────────────────────────────────────────
+  /api/auth/register:
+    $ref: './domain/auth/paths.yaml#/paths/~1api~1auth~1register'
+  /api/auth/login:
+    $ref: './domain/auth/paths.yaml#/paths/~1api~1auth~1login'
+  /api/auth/logout:
+    $ref: './domain/auth/paths.yaml#/paths/~1api~1auth~1logout'
+  /api/auth/me:
+    $ref: './domain/auth/paths.yaml#/paths/~1api~1auth~1me'
   # ── Agents ─────────────────────────────────────────────────────────────────
   /api/agents:
     $ref: './domain/agents/paths.yaml#/paths/~1api~1agents'
@@ -296,3 +306,7 @@ components:
     OAuthProviderStatus:        { $ref: './components.yaml#/components/schemas/OAuthProviderStatus' }
     OAuthFlowStatus:            { $ref: './components.yaml#/components/schemas/OAuthFlowStatus' }
     OAuthConnectedResponse:     { $ref: './components.yaml#/components/schemas/OAuthConnectedResponse' }
+    LoginRequest:               { $ref: './components.yaml#/components/schemas/LoginRequest' }
+    RegisterRequest:            { $ref: './components.yaml#/components/schemas/RegisterRequest' }
+    AuthResponse:               { $ref: './components.yaml#/components/schemas/AuthResponse' }
+    MeResponse:                 { $ref: './components.yaml#/components/schemas/MeResponse' }

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -43,6 +43,7 @@ tags:
   - name: skills
   - name: users
   - name: auth-users
+  - name: profile
 paths:
   # ── Agents ─────────────────────────────────────────────────────────────────
   /api/agents:
@@ -165,6 +166,37 @@ paths:
     $ref: './domain/users/paths.yaml#/paths/~1api~1auth~1users~1{id}~1identities~1{identityId}'
   /api/auth/users/{id}/active:
     $ref: './domain/users/paths.yaml#/paths/~1api~1auth~1users~1{id}~1active'
+  # ── Profile ────────────────────────────────────────────────────────────────
+  /api/auth/profile/identities:
+    $ref: './domain/profile/paths.yaml#/paths/~1api~1auth~1profile~1identities'
+  /api/auth/profile/identities/{id}:
+    $ref: './domain/profile/paths.yaml#/paths/~1api~1auth~1profile~1identities~1{id}'
+  /api/auth/profile/password:
+    $ref: './domain/profile/paths.yaml#/paths/~1api~1auth~1profile~1password'
+  /api/auth/profile/link-code:
+    $ref: './domain/profile/paths.yaml#/paths/~1api~1auth~1profile~1link-code'
+  /api/auth/profile/memories:
+    $ref: './domain/profile/paths.yaml#/paths/~1api~1auth~1profile~1memories'
+  /api/auth/profile/memories/{agentId}:
+    $ref: './domain/profile/paths.yaml#/paths/~1api~1auth~1profile~1memories~1{agentId}'
+  /api/auth/profile/soul/{agentId}:
+    $ref: './domain/profile/paths.yaml#/paths/~1api~1auth~1profile~1soul~1{agentId}'
+  /api/auth/profile/vault:
+    $ref: './domain/profile/paths.yaml#/paths/~1api~1auth~1profile~1vault'
+  /api/auth/profile/vault/{name}:
+    $ref: './domain/profile/paths.yaml#/paths/~1api~1auth~1profile~1vault~1{name}'
+  /api/auth/profile/oauth/providers:
+    $ref: './domain/profile/paths.yaml#/paths/~1api~1auth~1profile~1oauth~1providers'
+  /api/auth/profile/oauth/{provider}/start:
+    $ref: './domain/profile/paths.yaml#/paths/~1api~1auth~1profile~1oauth~1{provider}~1start'
+  /api/auth/profile/oauth/{provider}/status/{flowID}:
+    $ref: './domain/profile/paths.yaml#/paths/~1api~1auth~1profile~1oauth~1{provider}~1status~1{flowID}'
+  /api/auth/profile/oauth/{provider}/connected:
+    $ref: './domain/profile/paths.yaml#/paths/~1api~1auth~1profile~1oauth~1{provider}~1connected'
+  /api/auth/profile/oauth/{provider}:
+    $ref: './domain/profile/paths.yaml#/paths/~1api~1auth~1profile~1oauth~1{provider}'
+  /api/auth/profile/oauth/{provider}/callback:
+    $ref: './domain/profile/paths.yaml#/paths/~1api~1auth~1profile~1oauth~1{provider}~1callback'
   # ── Scheduler ──────────────────────────────────────────────────────────────
   /api/scheduler/jobs:
     $ref: './domain/scheduler/paths.yaml#/paths/~1api~1scheduler~1jobs'
@@ -255,3 +287,12 @@ components:
     UpdateRoleRequest:          { $ref: './components.yaml#/components/schemas/UpdateRoleRequest' }
     UpdateAgentsRequest:        { $ref: './components.yaml#/components/schemas/UpdateAgentsRequest' }
     UpdateActiveRequest:        { $ref: './components.yaml#/components/schemas/UpdateActiveRequest' }
+    ChangePasswordRequest:      { $ref: './components.yaml#/components/schemas/ChangePasswordRequest' }
+    GenerateLinkCodeRequest:    { $ref: './components.yaml#/components/schemas/GenerateLinkCodeRequest' }
+    LinkCodeResponse:           { $ref: './components.yaml#/components/schemas/LinkCodeResponse' }
+    SetSoulRequest:             { $ref: './components.yaml#/components/schemas/SetSoulRequest' }
+    VaultEntry:                 { $ref: './components.yaml#/components/schemas/VaultEntry' }
+    SetVaultEntryRequest:       { $ref: './components.yaml#/components/schemas/SetVaultEntryRequest' }
+    OAuthProviderStatus:        { $ref: './components.yaml#/components/schemas/OAuthProviderStatus' }
+    OAuthFlowStatus:            { $ref: './components.yaml#/components/schemas/OAuthFlowStatus' }
+    OAuthConnectedResponse:     { $ref: './components.yaml#/components/schemas/OAuthConnectedResponse' }

--- a/api/types/gen.go
+++ b/api/types/gen.go
@@ -487,6 +487,9 @@ type LoginRequest struct {
 	Username string `json:"username"`
 }
 
+// ManifestPlugin defines model for ManifestPlugin.
+type ManifestPlugin map[string]interface{}
+
 // MeResponse defines model for MeResponse.
 type MeResponse struct {
 	Id       int64  `json:"id"`
@@ -518,6 +521,24 @@ type OAuthProviderStatus struct {
 	Provider    string  `json:"provider"`
 	Unavailable *string `json:"unavailable,omitempty"`
 	Username    *string `json:"username,omitempty"`
+}
+
+// PluginView defines model for PluginView.
+type PluginView struct {
+	AdminVisible *bool                   `json:"admin_visible,omitempty"`
+	Capabilities *[]string               `json:"capabilities,omitempty"`
+	Config       *map[string]interface{} `json:"config,omitempty"`
+	Description  *string                 `json:"description,omitempty"`
+	DisplayName  *string                 `json:"display_name,omitempty"`
+	Enabled      *bool                   `json:"enabled,omitempty"`
+	HasConfig    *bool                   `json:"has_config,omitempty"`
+	HasStatus    *bool                   `json:"has_status,omitempty"`
+	Id           *string                 `json:"id,omitempty"`
+	Kind         *string                 `json:"kind,omitempty"`
+	Managed      *bool                   `json:"managed,omitempty"`
+	Name         *string                 `json:"name,omitempty"`
+	Persisted    *bool                   `json:"persisted,omitempty"`
+	PersistedId  *string                 `json:"persisted_id,omitempty"`
 }
 
 // ProfileInstallSkillRequest defines model for ProfileInstallSkillRequest.
@@ -729,6 +750,11 @@ type TagCount struct {
 	Tag   string `json:"tag"`
 }
 
+// TogglePluginRequest defines model for TogglePluginRequest.
+type TogglePluginRequest struct {
+	Enabled bool `json:"enabled"`
+}
+
 // Tool defines model for Tool.
 type Tool struct {
 	Category    string                  `json:"category"`
@@ -792,6 +818,11 @@ type UpdateFeedRequest struct {
 // UpdateNotifyIdentityRequest defines model for UpdateNotifyIdentityRequest.
 type UpdateNotifyIdentityRequest struct {
 	NotifyIdentityId *int64 `json:"notify_identity_id,omitempty"`
+}
+
+// UpdatePluginConfigRequest defines model for UpdatePluginConfigRequest.
+type UpdatePluginConfigRequest struct {
+	Config *map[string]interface{} `json:"config,omitempty"`
 }
 
 // UpdateRoleRequest defines model for UpdateRoleRequest.

--- a/api/types/gen.go
+++ b/api/types/gen.go
@@ -152,6 +152,12 @@ type AssignAgentUserRequest struct {
 	UserId int64 `json:"user_id"`
 }
 
+// AuthResponse defines model for AuthResponse.
+type AuthResponse struct {
+	Id       int64  `json:"id"`
+	Username string `json:"username"`
+}
+
 // AuthUser defines model for AuthUser.
 type AuthUser struct {
 	CreatedAt  string     `json:"created_at"`
@@ -475,6 +481,20 @@ type LinkCodeResponse struct {
 	Platform string `json:"platform"`
 }
 
+// LoginRequest defines model for LoginRequest.
+type LoginRequest struct {
+	Password string `json:"password"`
+	Username string `json:"username"`
+}
+
+// MeResponse defines model for MeResponse.
+type MeResponse struct {
+	Id       int64  `json:"id"`
+	IsAdmin  bool   `json:"is_admin"`
+	Role     string `json:"role"`
+	Username string `json:"username"`
+}
+
 // OAuthConnectedResponse defines model for OAuthConnectedResponse.
 type OAuthConnectedResponse struct {
 	Connected bool    `json:"connected"`
@@ -566,6 +586,12 @@ type PublicChannel struct {
 // PublicChannelList defines model for PublicChannelList.
 type PublicChannelList struct {
 	Items []PublicChannel `json:"items"`
+}
+
+// RegisterRequest defines model for RegisterRequest.
+type RegisterRequest struct {
+	Password string `json:"password"`
+	Username string `json:"username"`
 }
 
 // SandboxConfig defines model for SandboxConfig.

--- a/api/types/gen.go
+++ b/api/types/gen.go
@@ -256,6 +256,12 @@ type FeedPollResult struct {
 	NewEntries []FeedEntry `json:"new_entries"`
 }
 
+// FetchModelsRequest defines model for FetchModelsRequest.
+type FetchModelsRequest struct {
+	ApiKey  *string `json:"api_key,omitempty"`
+	BaseUrl *string `json:"base_url,omitempty"`
+}
+
 // Job defines model for Job.
 type Job struct {
 	AgentId *string `json:"agent_id,omitempty"`
@@ -330,6 +336,54 @@ type JobRun struct {
 
 // JobRunList defines model for JobRunList.
 type JobRunList = []JobRun
+
+// Provider defines model for Provider.
+type Provider struct {
+	ApiKey  string                    `json:"api_key"`
+	BaseUrl string                    `json:"base_url"`
+	Enabled bool                      `json:"enabled"`
+	Id      string                    `json:"id"`
+	Models  *map[string]ProviderModel `json:"models,omitempty"`
+	Name    string                    `json:"name"`
+	Type    string                    `json:"type"`
+}
+
+// ProviderModel defines model for ProviderModel.
+type ProviderModel struct {
+	ContextWindow *int               `json:"contextWindow,omitempty"`
+	Cost          *ProviderModelCost `json:"cost,omitempty"`
+	Enabled       bool               `json:"enabled"`
+	Id            *string            `json:"id,omitempty"`
+	Input         *[]string          `json:"input,omitempty"`
+	MaxTokens     *int               `json:"maxTokens,omitempty"`
+	Name          *string            `json:"name,omitempty"`
+	Output        *[]string          `json:"output,omitempty"`
+	Reasoning     *bool              `json:"reasoning,omitempty"`
+}
+
+// ProviderModelCost defines model for ProviderModelCost.
+type ProviderModelCost struct {
+	CacheRead  *float64 `json:"cacheRead,omitempty"`
+	CacheWrite *float64 `json:"cacheWrite,omitempty"`
+	Input      *float64 `json:"input,omitempty"`
+	Output     *float64 `json:"output,omitempty"`
+}
+
+// ProviderModelItem defines model for ProviderModelItem.
+type ProviderModelItem struct {
+	Config  *ProviderModel `json:"config,omitempty"`
+	Enabled bool           `json:"enabled"`
+	Id      string         `json:"id"`
+	Name    *string        `json:"name,omitempty"`
+	Source  string         `json:"source"`
+}
+
+// ProviderType defines model for ProviderType.
+type ProviderType struct {
+	DefaultUrl string `json:"default_url"`
+	Id         string `json:"id"`
+	Name       string `json:"name"`
+}
 
 // PublicChannel defines model for PublicChannel.
 type PublicChannel struct {

--- a/api/types/gen.go
+++ b/api/types/gen.go
@@ -197,6 +197,12 @@ type CachedModel struct {
 	Provider string `json:"provider"`
 }
 
+// ChangePasswordRequest defines model for ChangePasswordRequest.
+type ChangePasswordRequest struct {
+	CurrentPassword string `json:"current_password"`
+	NewPassword     string `json:"new_password"`
+}
+
 // Channel defines model for Channel.
 type Channel struct {
 	AgentId *string `json:"agent_id,omitempty"`
@@ -360,6 +366,11 @@ type FetchModelsRequest struct {
 	BaseUrl *string `json:"base_url,omitempty"`
 }
 
+// GenerateLinkCodeRequest defines model for GenerateLinkCodeRequest.
+type GenerateLinkCodeRequest struct {
+	Platform string `json:"platform"`
+}
+
 // GlobalInstallSkillRequest defines model for GlobalInstallSkillRequest.
 type GlobalInstallSkillRequest struct {
 	AgentId *string `json:"agent_id,omitempty"`
@@ -457,6 +468,37 @@ type JobRun struct {
 
 // JobRunList defines model for JobRunList.
 type JobRunList = []JobRun
+
+// LinkCodeResponse defines model for LinkCodeResponse.
+type LinkCodeResponse struct {
+	Code     string `json:"code"`
+	Platform string `json:"platform"`
+}
+
+// OAuthConnectedResponse defines model for OAuthConnectedResponse.
+type OAuthConnectedResponse struct {
+	Connected bool    `json:"connected"`
+	Username  *string `json:"username,omitempty"`
+}
+
+// OAuthFlowStatus defines model for OAuthFlowStatus.
+type OAuthFlowStatus struct {
+	ExpiresAt       string  `json:"expires_at"`
+	FlowId          string  `json:"flow_id"`
+	Provider        string  `json:"provider"`
+	State           string  `json:"state"`
+	UserCode        *string `json:"user_code,omitempty"`
+	VerificationUri string  `json:"verification_uri"`
+}
+
+// OAuthProviderStatus defines model for OAuthProviderStatus.
+type OAuthProviderStatus struct {
+	Available   bool    `json:"available"`
+	Connected   bool    `json:"connected"`
+	Provider    string  `json:"provider"`
+	Unavailable *string `json:"unavailable,omitempty"`
+	Username    *string `json:"username,omitempty"`
+}
 
 // ProfileInstallSkillRequest defines model for ProfileInstallSkillRequest.
 type ProfileInstallSkillRequest struct {
@@ -589,6 +631,16 @@ type SessionDetail struct {
 // SetMemoryRequest defines model for SetMemoryRequest.
 type SetMemoryRequest struct {
 	Content string `json:"content"`
+}
+
+// SetSoulRequest defines model for SetSoulRequest.
+type SetSoulRequest struct {
+	Soul string `json:"soul"`
+}
+
+// SetVaultEntryRequest defines model for SetVaultEntryRequest.
+type SetVaultEntryRequest struct {
+	Value string `json:"value"`
 }
 
 // Skill defines model for Skill.
@@ -731,6 +783,13 @@ type UpdateSkillRequest struct {
 
 // UserMemory defines model for UserMemory.
 type UserMemory map[string]interface{}
+
+// VaultEntry defines model for VaultEntry.
+type VaultEntry struct {
+	CreatedAt string `json:"created_at"`
+	Name      string `json:"name"`
+	UpdatedAt string `json:"updated_at"`
+}
 
 // WeixinQRCode defines model for WeixinQRCode.
 type WeixinQRCode struct {

--- a/api/types/gen.go
+++ b/api/types/gen.go
@@ -82,6 +82,38 @@ func (e SourceType) Valid() bool {
 	}
 }
 
+// Agent defines model for Agent.
+type Agent struct {
+	CreatorId    *int64         `json:"creator_id,omitempty"`
+	Enabled      *bool          `json:"enabled,omitempty"`
+	Id           *string        `json:"id,omitempty"`
+	Model        *string        `json:"model,omitempty"`
+	ModelFast    *string        `json:"model_fast,omitempty"`
+	ModelStrong  *string        `json:"model_strong,omitempty"`
+	Name         *string        `json:"name,omitempty"`
+	Sandbox      *SandboxConfig `json:"sandbox,omitempty"`
+	Scope        *string        `json:"scope,omitempty"`
+	Soul         *string        `json:"soul,omitempty"`
+	SystemPrompt *string        `json:"system_prompt,omitempty"`
+	Workspace    *string        `json:"workspace,omitempty"`
+}
+
+// AgentList defines model for AgentList.
+type AgentList struct {
+	Items []Agent `json:"items"`
+}
+
+// AgentUser defines model for AgentUser.
+type AgentUser struct {
+	Id       *int64  `json:"id,omitempty"`
+	Username *string `json:"username,omitempty"`
+}
+
+// AgentUserList defines model for AgentUserList.
+type AgentUserList struct {
+	Items []AgentUser `json:"items"`
+}
+
 // Article defines model for Article.
 type Article struct {
 	AgentId      *string `json:"agent_id,omitempty"`
@@ -114,6 +146,11 @@ type ArticleList struct {
 
 // ArticleStatus defines model for ArticleStatus.
 type ArticleStatus string
+
+// AssignAgentUserRequest defines model for AssignAgentUserRequest.
+type AssignAgentUserRequest struct {
+	UserId int64 `json:"user_id"`
+}
 
 // BuiltinResource defines model for BuiltinResource.
 type BuiltinResource struct {
@@ -170,6 +207,23 @@ type ChannelWriteRequest struct {
 	Type   *string `json:"type,omitempty"`
 }
 
+// CreateAgentRequest defines model for CreateAgentRequest.
+type CreateAgentRequest struct {
+	CreatorId    *int64         `json:"creator_id,omitempty"`
+	Enabled      *bool          `json:"enabled,omitempty"`
+	Id           *string        `json:"id,omitempty"`
+	Model        *string        `json:"model,omitempty"`
+	ModelFast    *string        `json:"model_fast,omitempty"`
+	ModelStrong  *string        `json:"model_strong,omitempty"`
+	Name         *string        `json:"name,omitempty"`
+	Sandbox      *SandboxConfig `json:"sandbox,omitempty"`
+	Scope        *string        `json:"scope,omitempty"`
+	Soul         *string        `json:"soul,omitempty"`
+	SystemPrompt *string        `json:"system_prompt,omitempty"`
+	TemplateId   *string        `json:"template_id,omitempty"`
+	Workspace    *string        `json:"workspace,omitempty"`
+}
+
 // CreateFeedRequest defines model for CreateFeedRequest.
 type CreateFeedRequest struct {
 	AgentId *string `json:"agent_id,omitempty"`
@@ -202,6 +256,12 @@ type Digest struct {
 	UnreadCount          int64      `json:"unread_count"`
 	WorthRevisiting      []Article  `json:"worth_revisiting"`
 	WorthRevisitingCount int        `json:"worth_revisiting_count"`
+}
+
+// DuplicateSkillResult defines model for DuplicateSkillResult.
+type DuplicateSkillResult struct {
+	Id   *string `json:"id,omitempty"`
+	Name *string `json:"name,omitempty"`
 }
 
 // Error defines model for Error.
@@ -265,6 +325,11 @@ type FeedPollResult struct {
 type FetchModelsRequest struct {
 	ApiKey  *string `json:"api_key,omitempty"`
 	BaseUrl *string `json:"base_url,omitempty"`
+}
+
+// InstallSkillRequest defines model for InstallSkillRequest.
+type InstallSkillRequest struct {
+	Source string `json:"source"`
 }
 
 // Job defines model for Job.
@@ -405,6 +470,17 @@ type PublicChannelList struct {
 	Items []PublicChannel `json:"items"`
 }
 
+// SandboxConfig defines model for SandboxConfig.
+type SandboxConfig struct {
+	Network *SandboxNetworkConfig `json:"network,omitempty"`
+}
+
+// SandboxNetworkConfig defines model for SandboxNetworkConfig.
+type SandboxNetworkConfig struct {
+	Allowlist *[]string `json:"allowlist,omitempty"`
+	Mode      *string   `json:"mode,omitempty"`
+}
+
 // SaveArticleRequest defines model for SaveArticleRequest.
 type SaveArticleRequest struct {
 	AgentId      *string `json:"agent_id,omitempty"`
@@ -452,6 +528,32 @@ type SessionDetail struct {
 	Title      string  `json:"title"`
 	UserId     int64   `json:"user_id"`
 	UserName   *string `json:"user_name,omitempty"`
+}
+
+// Skill defines model for Skill.
+type Skill struct {
+	AgentId                *string   `json:"agent_id,omitempty"`
+	CreatedAt              *string   `json:"created_at,omitempty"`
+	Description            *string   `json:"description,omitempty"`
+	DisableModelInvocation *bool     `json:"disable_model_invocation,omitempty"`
+	Files                  *[]string `json:"files,omitempty"`
+	Id                     *string   `json:"id,omitempty"`
+	Name                   *string   `json:"name,omitempty"`
+	Scope                  *string   `json:"scope,omitempty"`
+	Status                 *string   `json:"status,omitempty"`
+	UpdatedAt              *string   `json:"updated_at,omitempty"`
+	UserId                 *int64    `json:"user_id,omitempty"`
+}
+
+// SkillList defines model for SkillList.
+type SkillList struct {
+	Items []Skill `json:"items"`
+}
+
+// SkillUploadResult defines model for SkillUploadResult.
+type SkillUploadResult struct {
+	Id   *string `json:"id,omitempty"`
+	Name *string `json:"name,omitempty"`
 }
 
 // SourceType defines model for SourceType.
@@ -511,6 +613,14 @@ type UpdateFeedRequest struct {
 	Description   *string `json:"description,omitempty"`
 	Enabled       *bool   `json:"enabled,omitempty"`
 	Title         *string `json:"title,omitempty"`
+}
+
+// UpdateSkillRequest defines model for UpdateSkillRequest.
+type UpdateSkillRequest struct {
+	Description            *string            `json:"description,omitempty"`
+	DisableModelInvocation *bool              `json:"disable_model_invocation,omitempty"`
+	Files                  *map[string]string `json:"files,omitempty"`
+	Status                 *string            `json:"status,omitempty"`
 }
 
 // WeixinQRCode defines model for WeixinQRCode.

--- a/api/types/gen.go
+++ b/api/types/gen.go
@@ -152,6 +152,22 @@ type AssignAgentUserRequest struct {
 	UserId int64 `json:"user_id"`
 }
 
+// AuthUser defines model for AuthUser.
+type AuthUser struct {
+	CreatedAt  string     `json:"created_at"`
+	Id         int64      `json:"id"`
+	Identities []Identity `json:"identities"`
+	IsActive   bool       `json:"is_active"`
+	Role       string     `json:"role"`
+	UpdatedAt  string     `json:"updated_at"`
+	Username   string     `json:"username"`
+}
+
+// AuthUserList defines model for AuthUserList.
+type AuthUserList struct {
+	Items []AuthUser `json:"items"`
+}
+
 // BuiltinResource defines model for BuiltinResource.
 type BuiltinResource struct {
 	Description *string                 `json:"description,omitempty"`
@@ -350,6 +366,16 @@ type GlobalInstallSkillRequest struct {
 	Scope   *string `json:"scope,omitempty"`
 	Source  string  `json:"source"`
 	UserId  *int64  `json:"user_id,omitempty"`
+}
+
+// Identity defines model for Identity.
+type Identity struct {
+	ExternalId string    `json:"external_id"`
+	Id         int64     `json:"id"`
+	LinkedAt   time.Time `json:"linked_at"`
+	Name       string    `json:"name"`
+	Platform   string    `json:"platform"`
+	UserId     int64     `json:"user_id"`
 }
 
 // InstallSkillRequest defines model for InstallSkillRequest.
@@ -560,6 +586,11 @@ type SessionDetail struct {
 	UserName   *string `json:"user_name,omitempty"`
 }
 
+// SetMemoryRequest defines model for SetMemoryRequest.
+type SetMemoryRequest struct {
+	Content string `json:"content"`
+}
+
 // Skill defines model for Skill.
 type Skill struct {
 	AgentId                *string   `json:"agent_id,omitempty"`
@@ -634,6 +665,16 @@ type TriggerJobResult struct {
 	Status string  `json:"status"`
 }
 
+// UpdateActiveRequest defines model for UpdateActiveRequest.
+type UpdateActiveRequest struct {
+	IsActive bool `json:"is_active"`
+}
+
+// UpdateAgentsRequest defines model for UpdateAgentsRequest.
+type UpdateAgentsRequest struct {
+	AgentIds []string `json:"agent_ids"`
+}
+
 // UpdateArticleRequest Only provided fields are updated.
 type UpdateArticleRequest struct {
 	Author *string `json:"author,omitempty"`
@@ -648,6 +689,11 @@ type UpdateArticleRequest struct {
 	Summary     *string            `json:"summary,omitempty"`
 	Tags        *[]string          `json:"tags,omitempty"`
 	Title       *string            `json:"title,omitempty"`
+}
+
+// UpdateDefaultAgentRequest defines model for UpdateDefaultAgentRequest.
+type UpdateDefaultAgentRequest struct {
+	DefaultAgentId string `json:"default_agent_id"`
 }
 
 // UpdateFeedEntryRequest defines model for UpdateFeedEntryRequest.
@@ -665,6 +711,16 @@ type UpdateFeedRequest struct {
 	Title         *string `json:"title,omitempty"`
 }
 
+// UpdateNotifyIdentityRequest defines model for UpdateNotifyIdentityRequest.
+type UpdateNotifyIdentityRequest struct {
+	NotifyIdentityId *int64 `json:"notify_identity_id,omitempty"`
+}
+
+// UpdateRoleRequest defines model for UpdateRoleRequest.
+type UpdateRoleRequest struct {
+	Role string `json:"role"`
+}
+
 // UpdateSkillRequest defines model for UpdateSkillRequest.
 type UpdateSkillRequest struct {
 	Description            *string            `json:"description,omitempty"`
@@ -672,6 +728,9 @@ type UpdateSkillRequest struct {
 	Files                  *map[string]string `json:"files,omitempty"`
 	Status                 *string            `json:"status,omitempty"`
 }
+
+// UserMemory defines model for UserMemory.
+type UserMemory map[string]interface{}
 
 // WeixinQRCode defines model for WeixinQRCode.
 type WeixinQRCode struct {

--- a/api/types/gen.go
+++ b/api/types/gen.go
@@ -179,6 +179,11 @@ type CreateFeedRequest struct {
 	Url   string  `json:"url"`
 }
 
+// CreateSessionRequest defines model for CreateSessionRequest.
+type CreateSessionRequest struct {
+	AgentId *string `json:"agent_id,omitempty"`
+}
+
 // DeleteResult defines model for DeleteResult.
 type DeleteResult struct {
 	Status string `json:"status"`
@@ -417,8 +422,45 @@ type SaveArticleRequest struct {
 	Url         string             `json:"url"`
 }
 
+// SendMessageRequest defines model for SendMessageRequest.
+type SendMessageRequest struct {
+	// Content Message content (required)
+	Content string `json:"content"`
+}
+
+// Session defines model for Session.
+type Session struct {
+	AgentId    string `json:"agent_id"`
+	Archived   bool   `json:"archived"`
+	Channel    string `json:"channel"`
+	CreatedAt  string `json:"created_at"`
+	Id         string `json:"id"`
+	LastActive string `json:"last_active"`
+	Title      string `json:"title"`
+	UserId     int64  `json:"user_id"`
+}
+
+// SessionDetail defines model for SessionDetail.
+type SessionDetail struct {
+	AgentId    string  `json:"agent_id"`
+	AgentName  *string `json:"agent_name,omitempty"`
+	Archived   bool    `json:"archived"`
+	Channel    string  `json:"channel"`
+	CreatedAt  string  `json:"created_at"`
+	Id         string  `json:"id"`
+	LastActive string  `json:"last_active"`
+	Title      string  `json:"title"`
+	UserId     int64   `json:"user_id"`
+	UserName   *string `json:"user_name,omitempty"`
+}
+
 // SourceType defines model for SourceType.
 type SourceType string
+
+// SystemPromptResponse defines model for SystemPromptResponse.
+type SystemPromptResponse struct {
+	SystemPrompt string `json:"system_prompt"`
+}
 
 // TagCount defines model for TagCount.
 type TagCount struct {

--- a/api/types/gen.go
+++ b/api/types/gen.go
@@ -238,6 +238,23 @@ type CreateSessionRequest struct {
 	AgentId *string `json:"agent_id,omitempty"`
 }
 
+// CreateSkillRequest defines model for CreateSkillRequest.
+type CreateSkillRequest struct {
+	AgentId                *string            `json:"agent_id,omitempty"`
+	Description            *string            `json:"description,omitempty"`
+	DisableModelInvocation *bool              `json:"disable_model_invocation,omitempty"`
+	Files                  *map[string]string `json:"files,omitempty"`
+	Name                   *string            `json:"name,omitempty"`
+	Scope                  *string            `json:"scope,omitempty"`
+	Status                 *string            `json:"status,omitempty"`
+	UserId                 *int64             `json:"user_id,omitempty"`
+}
+
+// DeleteFileResult defines model for DeleteFileResult.
+type DeleteFileResult struct {
+	Path *string `json:"path,omitempty"`
+}
+
 // DeleteResult defines model for DeleteResult.
 type DeleteResult struct {
 	Status string `json:"status"`
@@ -327,6 +344,14 @@ type FetchModelsRequest struct {
 	BaseUrl *string `json:"base_url,omitempty"`
 }
 
+// GlobalInstallSkillRequest defines model for GlobalInstallSkillRequest.
+type GlobalInstallSkillRequest struct {
+	AgentId *string `json:"agent_id,omitempty"`
+	Scope   *string `json:"scope,omitempty"`
+	Source  string  `json:"source"`
+	UserId  *int64  `json:"user_id,omitempty"`
+}
+
 // InstallSkillRequest defines model for InstallSkillRequest.
 type InstallSkillRequest struct {
 	Source string `json:"source"`
@@ -406,6 +431,11 @@ type JobRun struct {
 
 // JobRunList defines model for JobRunList.
 type JobRunList = []JobRun
+
+// ProfileInstallSkillRequest defines model for ProfileInstallSkillRequest.
+type ProfileInstallSkillRequest struct {
+	Source string `json:"source"`
+}
 
 // Provider defines model for Provider.
 type Provider struct {
@@ -545,9 +575,29 @@ type Skill struct {
 	UserId                 *int64    `json:"user_id,omitempty"`
 }
 
+// SkillFileResponse defines model for SkillFileResponse.
+type SkillFileResponse struct {
+	Content *string `json:"content,omitempty"`
+	Path    *string `json:"path,omitempty"`
+}
+
 // SkillList defines model for SkillList.
 type SkillList struct {
 	Items []Skill `json:"items"`
+}
+
+// SkillSearchResult defines model for SkillSearchResult.
+type SkillSearchResult struct {
+	Id       *string `json:"id,omitempty"`
+	Installs *int    `json:"installs,omitempty"`
+	Name     *string `json:"name,omitempty"`
+	SkillId  *string `json:"skillId,omitempty"`
+	Source   *string `json:"source,omitempty"`
+}
+
+// SkillSearchResultList defines model for SkillSearchResultList.
+type SkillSearchResultList struct {
+	Items []SkillSearchResult `json:"items"`
 }
 
 // SkillUploadResult defines model for SkillUploadResult.

--- a/api/types/gen.go
+++ b/api/types/gen.go
@@ -144,6 +144,32 @@ type CachedModel struct {
 	Provider string `json:"provider"`
 }
 
+// Channel defines model for Channel.
+type Channel struct {
+	AgentId *string `json:"agent_id,omitempty"`
+
+	// Config JSON string of the channel config
+	Config  string `json:"config"`
+	Enabled bool   `json:"enabled"`
+	Id      string `json:"id"`
+	Type    string `json:"type"`
+}
+
+// ChannelList defines model for ChannelList.
+type ChannelList struct {
+	Items []Channel `json:"items"`
+}
+
+// ChannelWriteRequest defines model for ChannelWriteRequest.
+type ChannelWriteRequest struct {
+	AgentId *string `json:"agent_id,omitempty"`
+
+	// Config JSON string of the channel config
+	Config *string `json:"config,omitempty"`
+	Id     *string `json:"id,omitempty"`
+	Type   *string `json:"type,omitempty"`
+}
+
 // CreateFeedRequest defines model for CreateFeedRequest.
 type CreateFeedRequest struct {
 	AgentId *string `json:"agent_id,omitempty"`
@@ -305,6 +331,21 @@ type JobRun struct {
 // JobRunList defines model for JobRunList.
 type JobRunList = []JobRun
 
+// PublicChannel defines model for PublicChannel.
+type PublicChannel struct {
+	AgentId   *string `json:"agent_id,omitempty"`
+	AgentName *string `json:"agent_name,omitempty"`
+	Enabled   bool    `json:"enabled"`
+	Id        string  `json:"id"`
+	Label     string  `json:"label"`
+	Type      string  `json:"type"`
+}
+
+// PublicChannelList defines model for PublicChannelList.
+type PublicChannelList struct {
+	Items []PublicChannel `json:"items"`
+}
+
 // SaveArticleRequest defines model for SaveArticleRequest.
 type SaveArticleRequest struct {
 	AgentId      *string `json:"agent_id,omitempty"`
@@ -374,6 +415,21 @@ type UpdateFeedRequest struct {
 	Description   *string `json:"description,omitempty"`
 	Enabled       *bool   `json:"enabled,omitempty"`
 	Title         *string `json:"title,omitempty"`
+}
+
+// WeixinQRCode defines model for WeixinQRCode.
+type WeixinQRCode struct {
+	Qrcode           *string `json:"qrcode,omitempty"`
+	QrcodeImgContent *string `json:"qrcode_img_content,omitempty"`
+}
+
+// WeixinQRStatus defines model for WeixinQRStatus.
+type WeixinQRStatus struct {
+	Baseurl     *string `json:"baseurl,omitempty"`
+	BotToken    *string `json:"bot_token,omitempty"`
+	IlinkBotId  *string `json:"ilink_bot_id,omitempty"`
+	IlinkUserId *string `json:"ilink_user_id,omitempty"`
+	Status      *string `json:"status,omitempty"`
 }
 
 // BadRequest defines model for BadRequest.

--- a/api/types/gen.go
+++ b/api/types/gen.go
@@ -115,6 +115,35 @@ type ArticleList struct {
 // ArticleStatus defines model for ArticleStatus.
 type ArticleStatus string
 
+// BuiltinResource defines model for BuiltinResource.
+type BuiltinResource struct {
+	Description *string                 `json:"description,omitempty"`
+	Hash        *string                 `json:"hash,omitempty"`
+	Id          string                  `json:"id"`
+	Kind        string                  `json:"kind"`
+	Metadata    *map[string]interface{} `json:"metadata,omitempty"`
+	Name        string                  `json:"name"`
+	Tags        *[]string               `json:"tags,omitempty"`
+}
+
+// BuiltinResourceDetail defines model for BuiltinResourceDetail.
+type BuiltinResourceDetail struct {
+	Content     string                  `json:"content"`
+	Description *string                 `json:"description,omitempty"`
+	Hash        *string                 `json:"hash,omitempty"`
+	Id          string                  `json:"id"`
+	Kind        string                  `json:"kind"`
+	Metadata    *map[string]interface{} `json:"metadata,omitempty"`
+	Name        string                  `json:"name"`
+	Tags        *[]string               `json:"tags,omitempty"`
+}
+
+// CachedModel defines model for CachedModel.
+type CachedModel struct {
+	Model    string `json:"model"`
+	Provider string `json:"provider"`
+}
+
 // CreateFeedRequest defines model for CreateFeedRequest.
 type CreateFeedRequest struct {
 	AgentId *string `json:"agent_id,omitempty"`
@@ -300,6 +329,14 @@ type SourceType string
 type TagCount struct {
 	Count int64  `json:"count"`
 	Tag   string `json:"tag"`
+}
+
+// Tool defines model for Tool.
+type Tool struct {
+	Category    string                  `json:"category"`
+	Description string                  `json:"description"`
+	InputSchema *map[string]interface{} `json:"input_schema,omitempty"`
+	Name        string                  `json:"name"`
 }
 
 // TriggerJobResult defines model for TriggerJobResult.

--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -39,6 +39,8 @@ server/
 ### API Conventions
 
 - All API routes: `/api/*` with JSON `Content-Type`
+- All `/api/*` routes are generated from the OpenAPI spec via `apiserver.HandlerFromMux(s, s.mux)` in `routes.go`. Do not hand-register API routes.
+- To add a new API route: follow the spec-first workflow in `api/CLAUDE.md` (write spec → `mise run generate:api` → implement the generated `ServerInterface` method).
 - Response envelope: `{"data": ...}` on success, `{"error": "message"}` on failure
 - Handler helpers: `writeData(w, status, data)`, `writeError(w, status, msg)`, `decodeJSON(r, &dst)`
 - Models cache: `GET /api/models` reads `~/.anna/cache/models.json` (no provider API calls). Cache is updated when "Fetch models" is clicked on the providers page.

--- a/server/agent_users.go
+++ b/server/agent_users.go
@@ -2,13 +2,15 @@ package server
 
 import (
 	"net/http"
-	"strconv"
 )
 
 // --- Agent user assignment API (admin-only) ---
 
-func (s *Server) listAgentUsers(w http.ResponseWriter, r *http.Request) {
-	agentID := r.PathValue("id")
+func (s *Server) ListAgentUsers(w http.ResponseWriter, r *http.Request, id string) {
+	if !requireAdmin(w, r) {
+		return
+	}
+	agentID := id
 	ctx := r.Context()
 
 	userIDs, err := s.authStore.ListAgentUserIDs(ctx, agentID)
@@ -33,8 +35,11 @@ func (s *Server) listAgentUsers(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, users)
 }
 
-func (s *Server) assignAgentUser(w http.ResponseWriter, r *http.Request) {
-	agentID := r.PathValue("id")
+func (s *Server) AssignAgentUser(w http.ResponseWriter, r *http.Request, id string) {
+	if !requireAdmin(w, r) {
+		return
+	}
+	agentID := id
 	ctx := r.Context()
 
 	var body struct {
@@ -66,18 +71,14 @@ func (s *Server) assignAgentUser(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, map[string]string{"status": "assigned"})
 }
 
-func (s *Server) removeAgentUser(w http.ResponseWriter, r *http.Request) {
-	agentID := r.PathValue("id")
-	userIDStr := r.PathValue("userId")
-	ctx := r.Context()
-
-	userID, err := strconv.ParseInt(userIDStr, 10, 64)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid user ID")
+func (s *Server) RemoveAgentUser(w http.ResponseWriter, r *http.Request, id string, userId int64) {
+	if !requireAdmin(w, r) {
 		return
 	}
+	agentID := id
+	ctx := r.Context()
 
-	if err := s.authStore.RemoveAgent(ctx, userID, agentID); err != nil {
+	if err := s.authStore.RemoveAgent(ctx, userId, agentID); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to remove user: "+err.Error())
 		return
 	}

--- a/server/agents.go
+++ b/server/agents.go
@@ -50,7 +50,7 @@ func applyTemplate(a *config.Agent, templateID string) error {
 	return nil
 }
 
-func (s *Server) listAgents(w http.ResponseWriter, r *http.Request) {
+func (s *Server) ListAgents(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	info := UserFromContext(ctx)
 
@@ -76,7 +76,7 @@ func (s *Server) listAgents(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, agents)
 }
 
-func (s *Server) createAgent(w http.ResponseWriter, r *http.Request) {
+func (s *Server) CreateAgent(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	info := UserFromContext(ctx)
 
@@ -155,10 +155,9 @@ func (s *Server) createAgent(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusCreated, a)
 }
 
-func (s *Server) getAgent(w http.ResponseWriter, r *http.Request) {
+func (s *Server) GetAgent(w http.ResponseWriter, r *http.Request, id string) {
 	ctx := r.Context()
 	info := UserFromContext(ctx)
-	id := r.PathValue("id")
 
 	a, err := s.store.GetAgent(ctx, id)
 	if err != nil {
@@ -178,10 +177,9 @@ func (s *Server) getAgent(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, a)
 }
 
-func (s *Server) updateAgent(w http.ResponseWriter, r *http.Request) {
+func (s *Server) UpdateAgent(w http.ResponseWriter, r *http.Request, id string) {
 	ctx := r.Context()
 	info := UserFromContext(ctx)
-	id := r.PathValue("id")
 
 	// Check access: admin or creator.
 	existing, err := s.store.GetAgent(ctx, id)
@@ -234,10 +232,9 @@ func (s *Server) updateAgent(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, a)
 }
 
-func (s *Server) deleteAgent(w http.ResponseWriter, r *http.Request) {
+func (s *Server) DeleteAgent(w http.ResponseWriter, r *http.Request, id string) {
 	ctx := r.Context()
 	info := UserFromContext(ctx)
-	id := r.PathValue("id")
 
 	// Check access: admin or creator.
 	existing, err := s.store.GetAgent(ctx, id)

--- a/server/auth.go
+++ b/server/auth.go
@@ -9,8 +9,8 @@ import (
 	"github.com/vaayne/anna/internal/vault"
 )
 
-// registerHandler handles POST /api/auth/register.
-func (s *Server) registerHandler(w http.ResponseWriter, r *http.Request) {
+// Register handles POST /api/auth/register.
+func (s *Server) Register(w http.ResponseWriter, r *http.Request) {
 	// Rate limit registration by IP.
 	ip := clientIP(r)
 	if err := s.rateLimiter.CheckIP(ip); err != nil {
@@ -114,8 +114,8 @@ func (s *Server) registerHandler(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// loginHandler handles POST /api/auth/login.
-func (s *Server) loginHandler(w http.ResponseWriter, r *http.Request) {
+// Login handles POST /api/auth/login.
+func (s *Server) Login(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Username string `json:"username"`
 		Password string `json:"password"`
@@ -188,8 +188,8 @@ func (s *Server) loginHandler(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// logoutHandler handles POST /api/auth/logout.
-func (s *Server) logoutHandler(w http.ResponseWriter, r *http.Request) {
+// Logout handles POST /api/auth/logout.
+func (s *Server) Logout(w http.ResponseWriter, r *http.Request) {
 	sessionID, err := auth.GetSessionCookie(r)
 	if err == nil {
 		_ = s.authStore.DeleteSession(r.Context(), sessionID)
@@ -198,8 +198,8 @@ func (s *Server) logoutHandler(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, map[string]string{"status": "logged out"})
 }
 
-// meHandler handles GET /api/auth/me.
-func (s *Server) meHandler(w http.ResponseWriter, r *http.Request) {
+// GetMe handles GET /api/auth/me.
+func (s *Server) GetMe(w http.ResponseWriter, r *http.Request) {
 	info := UserFromContext(r.Context())
 	if info == nil {
 		writeError(w, http.StatusUnauthorized, "not authenticated")

--- a/server/auth_users.go
+++ b/server/auth_users.go
@@ -3,7 +3,6 @@ package server
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/vaayne/anna/internal/auth"
 )
@@ -38,8 +37,11 @@ func (s *Server) buildAuthUserResponse(r *http.Request, u auth.AuthUser) (authUs
 	}, nil
 }
 
-// listAuthUsers handles GET /api/auth/users.
-func (s *Server) listAuthUsers(w http.ResponseWriter, r *http.Request) {
+// ListAuthUsers handles GET /api/auth/users.
+func (s *Server) ListAuthUsers(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
 	users, err := s.authStore.ListUsers(r.Context())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list users: "+err.Error())
@@ -59,14 +61,11 @@ func (s *Server) listAuthUsers(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, result)
 }
 
-// getAuthUser handles GET /api/auth/users/{id}.
-func (s *Server) getAuthUser(w http.ResponseWriter, r *http.Request) {
-	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid user id")
+// GetAuthUser handles GET /api/auth/users/{id}.
+func (s *Server) GetAuthUser(w http.ResponseWriter, r *http.Request, id int64) {
+	if !requireAdmin(w, r) {
 		return
 	}
-
 	u, err := s.authStore.GetUser(r.Context(), id)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "user not found")
@@ -82,14 +81,11 @@ func (s *Server) getAuthUser(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, resp)
 }
 
-// updateAuthUserRole handles PUT /api/auth/users/{id}/role.
-func (s *Server) updateAuthUserRole(w http.ResponseWriter, r *http.Request) {
-	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid user id")
+// UpdateAuthUserRole handles PUT /api/auth/users/{id}/role.
+func (s *Server) UpdateAuthUserRole(w http.ResponseWriter, r *http.Request, id int64) {
+	if !requireAdmin(w, r) {
 		return
 	}
-
 	var body struct {
 		Role string `json:"role"`
 	}
@@ -118,14 +114,11 @@ func (s *Server) updateAuthUserRole(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, map[string]string{"status": "updated"})
 }
 
-// listAuthUserAgents handles GET /api/auth/users/{id}/agents.
-func (s *Server) listAuthUserAgents(w http.ResponseWriter, r *http.Request) {
-	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid user id")
+// ListAuthUserAgents handles GET /api/auth/users/{id}/agents.
+func (s *Server) ListAuthUserAgents(w http.ResponseWriter, r *http.Request, id int64) {
+	if !requireAdmin(w, r) {
 		return
 	}
-
 	agentIDs, err := s.authStore.ListUserAgentIDs(r.Context(), id)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list user agents: "+err.Error())
@@ -135,14 +128,11 @@ func (s *Server) listAuthUserAgents(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, agentIDs)
 }
 
-// updateAuthUserAgents handles PUT /api/auth/users/{id}/agents.
-func (s *Server) updateAuthUserAgents(w http.ResponseWriter, r *http.Request) {
-	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid user id")
+// UpdateAuthUserAgents handles PUT /api/auth/users/{id}/agents.
+func (s *Server) UpdateAuthUserAgents(w http.ResponseWriter, r *http.Request, id int64) {
+	if !requireAdmin(w, r) {
 		return
 	}
-
 	var body struct {
 		AgentIDs []string `json:"agent_ids"`
 	}
@@ -196,36 +186,28 @@ func (s *Server) updateAuthUserAgents(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, map[string]string{"status": "updated"})
 }
 
-// deleteAuthUserIdentity handles DELETE /api/auth/users/{id}/identities/{identityId}.
-func (s *Server) deleteAuthUserIdentity(w http.ResponseWriter, r *http.Request) {
-	identityID, err := strconv.ParseInt(r.PathValue("identityId"), 10, 64)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid identity id")
+// DeleteAuthUserIdentity handles DELETE /api/auth/users/{id}/identities/{identityId}.
+func (s *Server) DeleteAuthUserIdentity(w http.ResponseWriter, r *http.Request, id int64, identityId int64) {
+	if !requireAdmin(w, r) {
 		return
 	}
-
 	ctx := r.Context()
 
 	// Verify the identity exists.
-	identity, err := s.authStore.GetIdentity(ctx, identityID)
+	identity, err := s.authStore.GetIdentity(ctx, identityId)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "identity not found")
 		return
 	}
 
 	// Verify it belongs to the specified user.
-	userID, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid user id")
-		return
-	}
-	if identity.UserID != userID {
+	if identity.UserID != id {
 		writeError(w, http.StatusBadRequest, "identity does not belong to this user")
 		return
 	}
 
-	if err := s.authStore.DeleteIdentity(ctx, identityID); err != nil {
-		s.log.Error("admin delete identity", "id", identityID, "error", err)
+	if err := s.authStore.DeleteIdentity(ctx, identityId); err != nil {
+		s.log.Error("admin delete identity", "id", identityId, "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to delete identity")
 		return
 	}
@@ -233,14 +215,11 @@ func (s *Server) deleteAuthUserIdentity(w http.ResponseWriter, r *http.Request) 
 	writeData(w, http.StatusOK, map[string]string{"status": "unlinked"})
 }
 
-// updateAuthUserActive handles PUT /api/auth/users/{id}/active.
-func (s *Server) updateAuthUserActive(w http.ResponseWriter, r *http.Request) {
-	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid user id")
+// UpdateAuthUserActive handles PUT /api/auth/users/{id}/active.
+func (s *Server) UpdateAuthUserActive(w http.ResponseWriter, r *http.Request, id int64) {
+	if !requireAdmin(w, r) {
 		return
 	}
-
 	var body struct {
 		IsActive bool `json:"is_active"`
 	}

--- a/server/builtin.go
+++ b/server/builtin.go
@@ -47,8 +47,8 @@ func parseBuiltinKind(s string) (builtinres.Kind, bool) {
 	return "", false
 }
 
-func (s *Server) listBuiltinResources(w http.ResponseWriter, r *http.Request) {
-	kind, ok := parseBuiltinKind(r.PathValue("kind"))
+func (s *Server) ListBuiltinResources(w http.ResponseWriter, r *http.Request, kindStr string) {
+	kind, ok := parseBuiltinKind(kindStr)
 	if !ok {
 		writeError(w, http.StatusNotFound, "unknown builtin kind")
 		return
@@ -66,13 +66,12 @@ func (s *Server) listBuiltinResources(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, out)
 }
 
-func (s *Server) getBuiltinResource(w http.ResponseWriter, r *http.Request) {
-	kind, ok := parseBuiltinKind(r.PathValue("kind"))
+func (s *Server) GetBuiltinResource(w http.ResponseWriter, r *http.Request, kindStr string, id string) {
+	kind, ok := parseBuiltinKind(kindStr)
 	if !ok {
 		writeError(w, http.StatusNotFound, "unknown builtin kind")
 		return
 	}
-	id := r.PathValue("id")
 	reg, err := builtinres.Default()
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())

--- a/server/channels.go
+++ b/server/channels.go
@@ -60,7 +60,7 @@ func channelToView(ch config.Channel) channelView {
 	}
 }
 
-func (s *Server) listPublicChannels(w http.ResponseWriter, r *http.Request) {
+func (s *Server) ListPublicChannels(w http.ResponseWriter, r *http.Request) {
 	enabledTypes, err := s.enabledChannelTypes(r)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
@@ -181,7 +181,10 @@ func sortPublicChannels(channels []publicChannelView) {
 	})
 }
 
-func (s *Server) listChannels(w http.ResponseWriter, r *http.Request) {
+func (s *Server) ListChannels(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
 	channels, err := s.store.ListChannels(r.Context())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
@@ -194,8 +197,10 @@ func (s *Server) listChannels(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, views)
 }
 
-func (s *Server) getChannel(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
+func (s *Server) GetChannel(w http.ResponseWriter, r *http.Request, id string) {
+	if !requireAdmin(w, r) {
+		return
+	}
 	ch, err := s.store.GetChannel(r.Context(), id)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "channel not found")
@@ -204,8 +209,10 @@ func (s *Server) getChannel(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, channelToView(ch))
 }
 
-func (s *Server) updateChannel(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
+func (s *Server) UpdateChannel(w http.ResponseWriter, r *http.Request, id string) {
+	if !requireAdmin(w, r) {
+		return
+	}
 	var req channelWriteRequest
 	if err := decodeJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
@@ -224,7 +231,10 @@ func (s *Server) updateChannel(w http.ResponseWriter, r *http.Request) {
 	s.saveChannel(w, r, ch, cfgMap, http.StatusOK)
 }
 
-func (s *Server) createChannel(w http.ResponseWriter, r *http.Request) {
+func (s *Server) CreateChannel(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
 	var req channelWriteRequest
 	if err := decodeJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
@@ -350,8 +360,10 @@ func parseChannelConfig(raw string) (map[string]any, error) {
 	return cfgMap, nil
 }
 
-func (s *Server) deleteChannel(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
+func (s *Server) DeleteChannel(w http.ResponseWriter, r *http.Request, id string) {
+	if !requireAdmin(w, r) {
+		return
+	}
 	ch, err := s.store.GetChannel(r.Context(), id)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "channel not found")

--- a/server/manifest_plugins.go
+++ b/server/manifest_plugins.go
@@ -27,7 +27,10 @@ func loadMergedManifest() (*manifestplugins.Manifest, error) {
 	return manifestplugins.Merge(builtin, user), nil
 }
 
-func (s *Server) listManifestPlugins(w http.ResponseWriter, r *http.Request) {
+func (s *Server) ListManifestPlugins(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
 	merged, err := loadMergedManifest()
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
@@ -36,7 +39,10 @@ func (s *Server) listManifestPlugins(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, merged.Plugins)
 }
 
-func (s *Server) saveManifestPlugins(w http.ResponseWriter, r *http.Request) {
+func (s *Server) SaveManifestPlugins(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
 	var req struct {
 		Plugins []manifestplugins.ManifestPlugin `json:"plugins"`
 	}
@@ -80,7 +86,10 @@ func (s *Server) saveManifestPlugins(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, merged.Plugins)
 }
 
-func (s *Server) syncManifestPlugins(w http.ResponseWriter, r *http.Request) {
+func (s *Server) SyncManifestPlugins(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
 	merged, err := loadMergedManifest()
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -158,7 +158,7 @@ func (s *Server) adminOnlyMiddleware(next http.Handler) http.Handler {
 // requireAdmin checks that the authenticated user has the admin role.
 // It writes a 403 JSON error and returns false when the caller is not admin.
 // Returns true when the caller is admin. Intended for inline use in API handlers.
-func requireAdmin(w http.ResponseWriter, r *http.Request) bool { //nolint:unused
+func requireAdmin(w http.ResponseWriter, r *http.Request) bool {
 	info := UserFromContext(r.Context())
 	if info == nil || !info.IsAdmin {
 		writeError(w, http.StatusForbidden, "admin access required")

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -155,6 +155,18 @@ func (s *Server) adminOnlyMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+// requireAdmin checks that the authenticated user has the admin role.
+// It writes a 403 JSON error and returns false when the caller is not admin.
+// Returns true when the caller is admin. Intended for inline use in API handlers.
+func requireAdmin(w http.ResponseWriter, r *http.Request) bool { //nolint:unused
+	info := UserFromContext(r.Context())
+	if info == nil || !info.IsAdmin {
+		writeError(w, http.StatusForbidden, "admin access required")
+		return false
+	}
+	return true
+}
+
 // denyAccess returns 401 for API routes or redirects to /login for page routes.
 func (s *Server) denyAccess(w http.ResponseWriter, r *http.Request) {
 	if isAPIRoute(r.URL.Path) {

--- a/server/models.go
+++ b/server/models.go
@@ -7,10 +7,10 @@ import (
 	"github.com/vaayne/anna/internal/config"
 )
 
-// listCachedModels returns enabled models from provider config + fetched cache,
+// ListModels returns enabled models from provider config + fetched cache,
 // filtered to only include models whose provider instance is enabled.
 // No provider API calls — reads only from the DB and ~/.anna/cache/models.json.
-func (s *Server) listCachedModels(w http.ResponseWriter, r *http.Request) {
+func (s *Server) ListModels(w http.ResponseWriter, r *http.Request) {
 	providers, err := s.store.ListProviders(r.Context())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "list provider config: "+err.Error())

--- a/server/models_test.go
+++ b/server/models_test.go
@@ -70,7 +70,7 @@ func TestListCachedModelsMergesCustomAndFetchedAndFiltersDisabled(t *testing.T) 
 	req := httptest.NewRequest(http.MethodGet, "/api/models", nil)
 	rec := httptest.NewRecorder()
 
-	server.listCachedModels(rec, req)
+	server.ListModels(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)

--- a/server/oauth.go
+++ b/server/oauth.go
@@ -28,8 +28,8 @@ func toFlowStatusJSON(fs credentials.FlowStatus) flowStatusJSON {
 	}
 }
 
-// listOAuthProviders handles GET /api/auth/profile/oauth/providers.
-func (s *Server) listOAuthProviders(w http.ResponseWriter, r *http.Request) {
+// ListOAuthProviders handles GET /api/auth/profile/oauth/providers.
+func (s *Server) ListOAuthProviders(w http.ResponseWriter, r *http.Request) {
 	if s.vaultSvc == nil {
 		writeError(w, http.StatusServiceUnavailable, "vault not configured")
 		return
@@ -44,8 +44,8 @@ func (s *Server) listOAuthProviders(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, providers)
 }
 
-// startOAuthFlow handles POST /api/auth/profile/oauth/{provider}/start.
-func (s *Server) startOAuthFlow(w http.ResponseWriter, r *http.Request) {
+// StartOAuthFlow handles POST /api/auth/profile/oauth/{provider}/start.
+func (s *Server) StartOAuthFlow(w http.ResponseWriter, r *http.Request, provider string) {
 	if s.vaultSvc == nil {
 		writeError(w, http.StatusServiceUnavailable, "vault not configured")
 		return
@@ -56,7 +56,6 @@ func (s *Server) startOAuthFlow(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	provider := r.PathValue("provider")
 	status, err := s.credSvc.StartFlowWithOrigin(r.Context(), info.UserID, provider, requestOrigin(r))
 	if err != nil {
 		s.log.Error("start oauth flow", "provider", provider, "user_id", info.UserID, "error", err)
@@ -66,8 +65,8 @@ func (s *Server) startOAuthFlow(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, toFlowStatusJSON(status))
 }
 
-// pollOAuthFlow handles GET /api/auth/profile/oauth/{provider}/status/{flowID}.
-func (s *Server) pollOAuthFlow(w http.ResponseWriter, r *http.Request) {
+// PollOAuthFlow handles GET /api/auth/profile/oauth/{provider}/status/{flowID}.
+func (s *Server) PollOAuthFlow(w http.ResponseWriter, r *http.Request, provider string, flowID string) {
 	if s.vaultSvc == nil {
 		writeError(w, http.StatusServiceUnavailable, "vault not configured")
 		return
@@ -77,9 +76,6 @@ func (s *Server) pollOAuthFlow(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusUnauthorized, "not authenticated")
 		return
 	}
-
-	provider := r.PathValue("provider")
-	flowID := r.PathValue("flowID")
 
 	status, _, err := s.credSvc.PollFlow(r.Context(), info.UserID, provider, flowID)
 	if err != nil {
@@ -89,8 +85,8 @@ func (s *Server) pollOAuthFlow(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, toFlowStatusJSON(status))
 }
 
-// getOAuthConnected handles GET /api/auth/profile/oauth/{provider}/connected.
-func (s *Server) getOAuthConnected(w http.ResponseWriter, r *http.Request) {
+// GetOAuthConnected handles GET /api/auth/profile/oauth/{provider}/connected.
+func (s *Server) GetOAuthConnected(w http.ResponseWriter, r *http.Request, provider string) {
 	if s.vaultSvc == nil {
 		writeError(w, http.StatusServiceUnavailable, "vault not configured")
 		return
@@ -101,7 +97,6 @@ func (s *Server) getOAuthConnected(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	provider := r.PathValue("provider")
 	statuses := s.credSvc.GetProviderStatuses(r.Context(), info.UserID)
 
 	type connectedResp struct {
@@ -118,8 +113,8 @@ func (s *Server) getOAuthConnected(w http.ResponseWriter, r *http.Request) {
 	writeError(w, http.StatusBadRequest, "unsupported provider: "+provider)
 }
 
-// disconnectOAuth handles DELETE /api/auth/profile/oauth/{provider}.
-func (s *Server) disconnectOAuth(w http.ResponseWriter, r *http.Request) {
+// DisconnectOAuth handles DELETE /api/auth/profile/oauth/{provider}.
+func (s *Server) DisconnectOAuth(w http.ResponseWriter, r *http.Request, provider string) {
 	if s.vaultSvc == nil {
 		writeError(w, http.StatusServiceUnavailable, "vault not configured")
 		return
@@ -130,43 +125,12 @@ func (s *Server) disconnectOAuth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	provider := r.PathValue("provider")
 	if err := s.credSvc.Disconnect(r.Context(), info.UserID, provider); err != nil {
 		s.log.Error("disconnect oauth", "provider", provider, "user_id", info.UserID, "error", err)
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
-}
-
-// oauthCallback handles GET /api/auth/profile/oauth/{provider}/callback.
-func (s *Server) oauthCallback(w http.ResponseWriter, r *http.Request) {
-	if s.vaultSvc == nil {
-		http.Error(w, "vault not configured", http.StatusServiceUnavailable)
-		return
-	}
-
-	provider := r.PathValue("provider")
-	code := r.URL.Query().Get("code")
-	flowID := r.URL.Query().Get("state")
-	if code == "" || flowID == "" {
-		http.Error(w, "missing code or state", http.StatusBadRequest)
-		return
-	}
-
-	flow, ok := s.credSvc.GetFlowForCallback(flowID)
-	if !ok {
-		http.Error(w, "unknown or expired flow", http.StatusBadRequest)
-		return
-	}
-
-	if err := s.credSvc.CompleteAuthCodeFlowWithOrigin(r.Context(), provider, flowID, code, requestOrigin(r)); err != nil {
-		s.log.Error("oauth callback complete", "provider", provider, "user_id", flow.UserID, "flow_id", flowID, "error", err)
-		http.Error(w, "failed to complete authorization: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	http.Redirect(w, r, "/credentials", http.StatusFound)
 }
 
 func requestOrigin(r *http.Request) string {

--- a/server/plugins.go
+++ b/server/plugins.go
@@ -9,7 +9,10 @@ import (
 
 const channelPluginConfigError = "channel instance config lives on /channels, not plugin config"
 
-func (s *Server) listPlugins(w http.ResponseWriter, r *http.Request) {
+func (s *Server) ListPlugins(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
 	plugins, err := s.pluginHost.ListAdminVisiblePlugins(r.Context())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
@@ -58,8 +61,11 @@ func flattenRegisteredPlugins(s *Server, plugins []pkgplugins.RegisteredPlugin) 
 	return out
 }
 
-func (s *Server) getPluginStatus(w http.ResponseWriter, r *http.Request) {
-	id := pluginRouteID(r.PathValue("kind"), r.PathValue("name"))
+func (s *Server) GetPluginStatus(w http.ResponseWriter, r *http.Request, kind string, name string) {
+	if !requireAdmin(w, r) {
+		return
+	}
+	id := pluginRouteID(kind, name)
 	status, err := s.pluginHost.Status(r.Context(), id)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
@@ -68,12 +74,15 @@ func (s *Server) getPluginStatus(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, status)
 }
 
-func (s *Server) getPluginConfig(w http.ResponseWriter, r *http.Request) {
-	if channelPluginConfigRequest(r) {
+func (s *Server) GetPluginConfig(w http.ResponseWriter, r *http.Request, kind string, name string) {
+	if !requireAdmin(w, r) {
+		return
+	}
+	if kind == config.PluginKindChannel {
 		writeError(w, http.StatusBadRequest, channelPluginConfigError)
 		return
 	}
-	id := pluginRouteID(r.PathValue("kind"), r.PathValue("name"))
+	id := pluginRouteID(kind, name)
 	state, err := s.pluginHost.Config().Get(r.Context(), id)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
@@ -82,13 +91,19 @@ func (s *Server) getPluginConfig(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, state.Config)
 }
 
-func (s *Server) getPluginConfigSchema(w http.ResponseWriter, r *http.Request) {
-	id := pluginRouteID(r.PathValue("kind"), r.PathValue("name"))
+func (s *Server) GetPluginConfigSchema(w http.ResponseWriter, r *http.Request, kind string, name string) {
+	if !requireAdmin(w, r) {
+		return
+	}
+	id := pluginRouteID(kind, name)
 	writeData(w, http.StatusOK, s.pluginHost.ConfigSchema(id))
 }
 
-func (s *Server) togglePlugin(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
+func (s *Server) TogglePlugin(w http.ResponseWriter, r *http.Request, kind string, name string) {
+	if !requireAdmin(w, r) {
+		return
+	}
+	id := pluginRouteID(kind, name)
 	var req struct {
 		Enabled bool `json:"enabled"`
 	}
@@ -130,12 +145,15 @@ func (s *Server) togglePlugin(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, p)
 }
 
-func (s *Server) updatePluginConfig(w http.ResponseWriter, r *http.Request) {
-	if channelPluginConfigRequest(r) {
+func (s *Server) UpdatePluginConfig(w http.ResponseWriter, r *http.Request, kind string, name string) {
+	if !requireAdmin(w, r) {
+		return
+	}
+	if kind == config.PluginKindChannel {
 		writeError(w, http.StatusBadRequest, channelPluginConfigError)
 		return
 	}
-	id := pluginRouteID(r.PathValue("kind"), r.PathValue("name"))
+	id := pluginRouteID(kind, name)
 	var req struct {
 		Config map[string]any `json:"config"`
 	}
@@ -170,8 +188,4 @@ func pluginRouteID(kind, name string) string {
 		return name
 	}
 	return config.PluginID(kind, name)
-}
-
-func channelPluginConfigRequest(r *http.Request) bool {
-	return r.PathValue("kind") == config.PluginKindChannel
 }

--- a/server/profile.go
+++ b/server/profile.go
@@ -2,8 +2,8 @@ package server
 
 import (
 	"net/http"
-	"strconv"
 
+	apiserver "github.com/vaayne/anna/api/server"
 	"github.com/vaayne/anna/internal/agent"
 	"github.com/vaayne/anna/internal/auth"
 	"github.com/vaayne/anna/internal/memorywrite"
@@ -11,8 +11,8 @@ import (
 	"github.com/vaayne/anna/pkg/memory"
 )
 
-// listProfileIdentities handles GET /api/auth/profile/identities.
-func (s *Server) listProfileIdentities(w http.ResponseWriter, r *http.Request) {
+// ListProfileIdentities handles GET /api/auth/profile/identities.
+func (s *Server) ListProfileIdentities(w http.ResponseWriter, r *http.Request) {
 	info := UserFromContext(r.Context())
 	if info == nil {
 		writeError(w, http.StatusUnauthorized, "not authenticated")
@@ -29,8 +29,8 @@ func (s *Server) listProfileIdentities(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, identities)
 }
 
-// changePassword handles PUT /api/auth/profile/password.
-func (s *Server) changePassword(w http.ResponseWriter, r *http.Request) {
+// ChangePassword handles PUT /api/auth/profile/password.
+func (s *Server) ChangePassword(w http.ResponseWriter, r *http.Request) {
 	info := UserFromContext(r.Context())
 	if info == nil {
 		writeError(w, http.StatusUnauthorized, "not authenticated")
@@ -92,8 +92,8 @@ func (s *Server) changePassword(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, map[string]string{"status": "password changed"})
 }
 
-// generateLinkCode handles POST /api/auth/profile/link-code.
-func (s *Server) generateLinkCode(w http.ResponseWriter, r *http.Request) {
+// GenerateLinkCode handles POST /api/auth/profile/link-code.
+func (s *Server) GenerateLinkCode(w http.ResponseWriter, r *http.Request) {
 	info := UserFromContext(r.Context())
 	if info == nil {
 		writeError(w, http.StatusUnauthorized, "not authenticated")
@@ -124,18 +124,11 @@ func (s *Server) generateLinkCode(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// unlinkIdentity handles DELETE /api/auth/profile/identities/{id}.
-func (s *Server) unlinkIdentity(w http.ResponseWriter, r *http.Request) {
+// UnlinkProfileIdentity handles DELETE /api/auth/profile/identities/{id}.
+func (s *Server) UnlinkProfileIdentity(w http.ResponseWriter, r *http.Request, id int64) {
 	info := UserFromContext(r.Context())
 	if info == nil {
 		writeError(w, http.StatusUnauthorized, "not authenticated")
-		return
-	}
-
-	idStr := r.PathValue("id")
-	id, err := strconv.ParseInt(idStr, 10, 64)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid identity ID")
 		return
 	}
 
@@ -162,8 +155,8 @@ func (s *Server) unlinkIdentity(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, map[string]string{"status": "unlinked"})
 }
 
-// listProfileMemories handles GET /api/auth/profile/memories.
-func (s *Server) listProfileMemories(w http.ResponseWriter, r *http.Request) {
+// ListProfileMemories handles GET /api/auth/profile/memories.
+func (s *Server) ListProfileMemories(w http.ResponseWriter, r *http.Request) {
 	info := UserFromContext(r.Context())
 	if info == nil {
 		writeError(w, http.StatusUnauthorized, "not authenticated")
@@ -184,15 +177,14 @@ func (s *Server) listProfileMemories(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, memories)
 }
 
-// setProfileMemory handles PUT /api/auth/profile/memories/{agentId}.
-func (s *Server) setProfileMemory(w http.ResponseWriter, r *http.Request) {
+// SetProfileMemory handles PUT /api/auth/profile/memories/{agentId}.
+func (s *Server) SetProfileMemory(w http.ResponseWriter, r *http.Request, agentId string) {
 	info := UserFromContext(r.Context())
 	if info == nil {
 		writeError(w, http.StatusUnauthorized, "not authenticated")
 		return
 	}
 
-	agentID := r.PathValue("agentId")
 	var body struct {
 		Content string `json:"content"`
 	}
@@ -201,22 +193,21 @@ func (s *Server) setProfileMemory(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	ctx := memory.WithChangeSource(r.Context(), memory.SourceUser)
-	if err := memorywrite.SetProfile(ctx, s.db, s.q, info.UserID, agentID, body.Content); err != nil {
+	if err := memorywrite.SetProfile(ctx, s.db, s.q, info.UserID, agentId, body.Content); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 	writeData(w, http.StatusOK, map[string]string{"status": "saved"})
 }
 
-// setProfileSoul handles PUT /api/auth/profile/soul/{agentId}.
-func (s *Server) setProfileSoul(w http.ResponseWriter, r *http.Request) {
+// SetProfileSoul handles PUT /api/auth/profile/soul/{agentId}.
+func (s *Server) SetProfileSoul(w http.ResponseWriter, r *http.Request, agentId string) {
 	info := UserFromContext(r.Context())
 	if info == nil {
 		writeError(w, http.StatusUnauthorized, "not authenticated")
 		return
 	}
 
-	agentID := r.PathValue("agentId")
 	var body struct {
 		Soul string `json:"soul"`
 	}
@@ -225,26 +216,56 @@ func (s *Server) setProfileSoul(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	ctx := memory.WithChangeSource(r.Context(), memory.SourceUser)
-	if err := memorywrite.SetAgentSoul(ctx, s.db, s.q, info.UserID, agentID, body.Soul); err != nil {
+	if err := memorywrite.SetAgentSoul(ctx, s.db, s.q, info.UserID, agentId, body.Soul); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 	writeData(w, http.StatusOK, map[string]string{"status": "saved"})
 }
 
-// deleteProfileMemory handles DELETE /api/auth/profile/memories/{agentId}.
-func (s *Server) deleteProfileMemory(w http.ResponseWriter, r *http.Request) {
+// DeleteProfileMemory handles DELETE /api/auth/profile/memories/{agentId}.
+func (s *Server) DeleteProfileMemory(w http.ResponseWriter, r *http.Request, agentId string) {
 	info := UserFromContext(r.Context())
 	if info == nil {
 		writeError(w, http.StatusUnauthorized, "not authenticated")
 		return
 	}
 
-	agentID := r.PathValue("agentId")
 	ctx := memory.WithChangeSource(r.Context(), memory.SourceUser)
-	if err := memorywrite.DeleteProfile(ctx, s.db, s.q, info.UserID, agentID); err != nil {
+	if err := memorywrite.DeleteProfile(ctx, s.db, s.q, info.UserID, agentId); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 	writeData(w, http.StatusOK, map[string]string{"status": "deleted"})
+}
+
+// OauthCallback handles GET /api/auth/profile/oauth/{provider}/callback.
+// This is intentionally a pass-through to the unexported helper so the
+// generated interface signature is satisfied.
+func (s *Server) OauthCallback(w http.ResponseWriter, r *http.Request, provider string, params apiserver.OauthCallbackParams) {
+	if s.vaultSvc == nil {
+		http.Error(w, "vault not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	code := params.Code
+	flowID := params.State
+	if code == "" || flowID == "" {
+		http.Error(w, "missing code or state", http.StatusBadRequest)
+		return
+	}
+
+	flow, ok := s.credSvc.GetFlowForCallback(flowID)
+	if !ok {
+		http.Error(w, "unknown or expired flow", http.StatusBadRequest)
+		return
+	}
+
+	if err := s.credSvc.CompleteAuthCodeFlowWithOrigin(r.Context(), provider, flowID, code, requestOrigin(r)); err != nil {
+		s.log.Error("oauth callback complete", "provider", provider, "user_id", flow.UserID, "flow_id", flowID, "error", err)
+		http.Error(w, "failed to complete authorization: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	http.Redirect(w, r, "/credentials", http.StatusFound)
 }

--- a/server/providers.go
+++ b/server/providers.go
@@ -10,7 +10,10 @@ import (
 	"github.com/vaayne/anna/pkg/providers"
 )
 
-func (s *Server) listProviders(w http.ResponseWriter, r *http.Request) {
+func (s *Server) ListProviders(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
 	providers, err := s.store.ListProviders(r.Context())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
@@ -19,7 +22,10 @@ func (s *Server) listProviders(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, providers)
 }
 
-func (s *Server) createProvider(w http.ResponseWriter, r *http.Request) {
+func (s *Server) CreateProvider(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
 	var p config.Provider
 	if err := decodeJSON(r, &p); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
@@ -46,8 +52,10 @@ func (s *Server) createProvider(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusCreated, p)
 }
 
-func (s *Server) getProvider(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
+func (s *Server) GetProvider(w http.ResponseWriter, r *http.Request, id string) {
+	if !requireAdmin(w, r) {
+		return
+	}
 	p, err := s.store.GetProvider(r.Context(), id)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "provider not found")
@@ -56,8 +64,10 @@ func (s *Server) getProvider(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, p)
 }
 
-func (s *Server) updateProvider(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
+func (s *Server) UpdateProvider(w http.ResponseWriter, r *http.Request, id string) {
+	if !requireAdmin(w, r) {
+		return
+	}
 	var p config.Provider
 	if err := decodeJSON(r, &p); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
@@ -83,8 +93,10 @@ func (s *Server) updateProvider(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, p)
 }
 
-func (s *Server) deleteProvider(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
+func (s *Server) DeleteProvider(w http.ResponseWriter, r *http.Request, id string) {
+	if !requireAdmin(w, r) {
+		return
+	}
 	if err := s.store.DeleteProvider(r.Context(), id); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -111,8 +123,10 @@ type providerModelItem struct {
 	Config  config.ProviderModel `json:"config,omitzero"`
 }
 
-func (s *Server) listProviderModels(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
+func (s *Server) ListProviderModels(w http.ResponseWriter, r *http.Request, id string) {
+	if !requireAdmin(w, r) {
+		return
+	}
 	provider, err := s.store.GetProvider(r.Context(), id)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "provider not found")
@@ -122,8 +136,10 @@ func (s *Server) listProviderModels(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, s.mergedProviderModels(provider))
 }
 
-func (s *Server) fetchProviderModels(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
+func (s *Server) FetchProviderModels(w http.ResponseWriter, r *http.Request, id string) {
+	if !requireAdmin(w, r) {
+		return
+	}
 
 	var body struct {
 		APIKey  string `json:"api_key"`
@@ -277,7 +293,11 @@ func (s *Server) updateModelsCache(providerID string, modelIDs []string) {
 	}
 }
 
-func (s *Server) listProviderTypes(w http.ResponseWriter, r *http.Request) {
+func (s *Server) ListProviderTypes(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
+
 	type providerType struct {
 		ID         string `json:"id"`
 		Name       string `json:"name"`

--- a/server/routes.go
+++ b/server/routes.go
@@ -10,13 +10,11 @@ import (
 func (s *Server) registerRoutes() {
 	s.registerStaticRoutes()
 	s.registerPageRoutes()
-	s.registerPluginRoutes()
-	s.registerManifestPluginRoutes()
 	s.registerAPIRoutes()
 }
 
-// registerAPIRoutes mounts the generated recally + scheduler REST API onto the
-// admin mux. Auth is enforced by the global authMiddleware (Bearer + session).
+// registerAPIRoutes mounts all REST API routes onto the admin mux.
+// Auth is enforced by the global authMiddleware (Bearer + session).
 func (s *Server) registerAPIRoutes() {
 	apiserver.HandlerFromMux(s, s.mux)
 }
@@ -39,25 +37,4 @@ func (s *Server) registerPageRoutes() {
 	s.mux.HandleFunc("GET /profile", s.pageProfile)
 	s.mux.HandleFunc("GET /account", s.pageAccount)
 	s.mux.HandleFunc("GET /credentials", s.pageCredentials)
-}
-
-func (s *Server) registerPluginRoutes() {
-	adminAPI := func(handler http.HandlerFunc) http.Handler {
-		return s.adminOnlyMiddleware(handler)
-	}
-	s.mux.Handle("GET /api/plugins", adminAPI(s.listPlugins))
-	s.mux.Handle("GET /api/plugin-status/{kind}/{name}", adminAPI(s.getPluginStatus))
-	s.mux.Handle("GET /api/plugin-config/{kind}/{name}", adminAPI(s.getPluginConfig))
-	s.mux.Handle("GET /api/plugin-config-schema/{kind}/{name}", adminAPI(s.getPluginConfigSchema))
-	s.mux.Handle("PATCH /api/plugins/{id...}", adminAPI(s.togglePlugin))
-	s.mux.Handle("PUT /api/plugin-config/{kind}/{name}", adminAPI(s.updatePluginConfig))
-}
-
-func (s *Server) registerManifestPluginRoutes() {
-	adminAPI := func(handler http.HandlerFunc) http.Handler {
-		return s.adminOnlyMiddleware(handler)
-	}
-	s.mux.Handle("GET /api/manifest-plugins", adminAPI(s.listManifestPlugins))
-	s.mux.Handle("PUT /api/manifest-plugins", adminAPI(s.saveManifestPlugins))
-	s.mux.Handle("POST /api/manifest-plugins/sync", adminAPI(s.syncManifestPlugins))
 }

--- a/server/routes.go
+++ b/server/routes.go
@@ -10,7 +10,6 @@ import (
 func (s *Server) registerRoutes() {
 	s.registerStaticRoutes()
 	s.registerAuthRoutes()
-	s.registerProfileRoutes()
 	s.registerPageRoutes()
 	s.registerPluginRoutes()
 	s.registerManifestPluginRoutes()
@@ -34,30 +33,6 @@ func (s *Server) registerAuthRoutes() {
 	s.mux.HandleFunc("POST /api/auth/login", s.loginHandler)
 	s.mux.HandleFunc("POST /api/auth/logout", s.logoutHandler)
 	s.mux.HandleFunc("GET /api/auth/me", s.meHandler)
-}
-
-func (s *Server) registerProfileRoutes() {
-	s.mux.HandleFunc("GET /api/auth/profile/identities", s.listProfileIdentities)
-	s.mux.HandleFunc("PUT /api/auth/profile/password", s.changePassword)
-	s.mux.HandleFunc("POST /api/auth/profile/link-code", s.generateLinkCode)
-	s.mux.HandleFunc("DELETE /api/auth/profile/identities/{id}", s.unlinkIdentity)
-	s.mux.HandleFunc("GET /api/auth/profile/memories", s.listProfileMemories)
-	s.mux.HandleFunc("PUT /api/auth/profile/memories/{agentId}", s.setProfileMemory)
-	s.mux.HandleFunc("DELETE /api/auth/profile/memories/{agentId}", s.deleteProfileMemory)
-	s.mux.HandleFunc("PUT /api/auth/profile/soul/{agentId}", s.setProfileSoul)
-
-	// Vault (per-user encrypted secrets).
-	s.mux.HandleFunc("GET /api/auth/profile/vault", s.listVaultEntries)
-	s.mux.HandleFunc("PUT /api/auth/profile/vault/{name}", s.setVaultEntry)
-	s.mux.HandleFunc("DELETE /api/auth/profile/vault/{name}", s.deleteVaultEntry)
-
-	// OAuth CLI device-flow (connect/disconnect GitHub and Lark credentials).
-	s.mux.HandleFunc("GET /api/auth/profile/oauth/providers", s.listOAuthProviders)
-	s.mux.HandleFunc("POST /api/auth/profile/oauth/{provider}/start", s.startOAuthFlow)
-	s.mux.HandleFunc("GET /api/auth/profile/oauth/{provider}/status/{flowID}", s.pollOAuthFlow)
-	s.mux.HandleFunc("GET /api/auth/profile/oauth/{provider}/connected", s.getOAuthConnected)
-	s.mux.HandleFunc("DELETE /api/auth/profile/oauth/{provider}", s.disconnectOAuth)
-	s.mux.HandleFunc("GET /api/auth/profile/oauth/{provider}/callback", s.oauthCallback)
 }
 
 func (s *Server) registerPageRoutes() {

--- a/server/routes.go
+++ b/server/routes.go
@@ -9,7 +9,6 @@ import (
 
 func (s *Server) registerRoutes() {
 	s.registerStaticRoutes()
-	s.registerAuthRoutes()
 	s.registerPageRoutes()
 	s.registerPluginRoutes()
 	s.registerManifestPluginRoutes()
@@ -26,13 +25,6 @@ func (s *Server) registerStaticRoutes() {
 	s.mux.Handle("GET /static/", web.StaticHandler())
 	s.mux.HandleFunc("GET /login", s.pageLogin)
 	s.mux.HandleFunc("GET /{$}", s.redirectRoot)
-}
-
-func (s *Server) registerAuthRoutes() {
-	s.mux.HandleFunc("POST /api/auth/register", s.registerHandler)
-	s.mux.HandleFunc("POST /api/auth/login", s.loginHandler)
-	s.mux.HandleFunc("POST /api/auth/logout", s.logoutHandler)
-	s.mux.HandleFunc("GET /api/auth/me", s.meHandler)
 }
 
 func (s *Server) registerPageRoutes() {

--- a/server/routes.go
+++ b/server/routes.go
@@ -12,7 +12,6 @@ func (s *Server) registerRoutes() {
 	s.registerAuthRoutes()
 	s.registerProfileRoutes()
 	s.registerPageRoutes()
-	s.registerProviderRoutes()
 	s.registerAgentRoutes()
 	s.registerUserRoutes()
 	s.registerAuthUserRoutes()
@@ -88,20 +87,6 @@ func (s *Server) registerPageRoutes() {
 	s.mux.HandleFunc("GET /profile", s.pageProfile)
 	s.mux.HandleFunc("GET /account", s.pageAccount)
 	s.mux.HandleFunc("GET /credentials", s.pageCredentials)
-}
-
-func (s *Server) registerProviderRoutes() {
-	adminAPI := func(handler http.HandlerFunc) http.Handler {
-		return s.adminOnlyMiddleware(handler)
-	}
-	s.mux.Handle("GET /api/providers", adminAPI(s.listProviders))
-	s.mux.Handle("POST /api/providers", adminAPI(s.createProvider))
-	s.mux.Handle("GET /api/providers/{id}", adminAPI(s.getProvider))
-	s.mux.Handle("PUT /api/providers/{id}", adminAPI(s.updateProvider))
-	s.mux.Handle("DELETE /api/providers/{id}", adminAPI(s.deleteProvider))
-	s.mux.Handle("GET /api/providers/{id}/models", adminAPI(s.listProviderModels))
-	s.mux.Handle("POST /api/providers/{id}/models", adminAPI(s.fetchProviderModels))
-	s.mux.Handle("GET /api/provider-types", adminAPI(s.listProviderTypes))
 }
 
 func (s *Server) registerAgentRoutes() {

--- a/server/routes.go
+++ b/server/routes.go
@@ -12,7 +12,6 @@ func (s *Server) registerRoutes() {
 	s.registerAuthRoutes()
 	s.registerProfileRoutes()
 	s.registerPageRoutes()
-	s.registerAgentRoutes()
 	s.registerUserRoutes()
 	s.registerAuthUserRoutes()
 	s.registerPluginRoutes()
@@ -86,32 +85,6 @@ func (s *Server) registerPageRoutes() {
 	s.mux.HandleFunc("GET /profile", s.pageProfile)
 	s.mux.HandleFunc("GET /account", s.pageAccount)
 	s.mux.HandleFunc("GET /credentials", s.pageCredentials)
-}
-
-func (s *Server) registerAgentRoutes() {
-	adminAPI := func(handler http.HandlerFunc) http.Handler {
-		return s.adminOnlyMiddleware(handler)
-	}
-	s.mux.HandleFunc("GET /api/agents", s.listAgents)
-	s.mux.HandleFunc("POST /api/agents", s.createAgent)
-	s.mux.HandleFunc("GET /api/agents/{id}", s.getAgent)
-	s.mux.HandleFunc("PUT /api/agents/{id}", s.updateAgent)
-	s.mux.HandleFunc("DELETE /api/agents/{id}", s.deleteAgent)
-
-	s.mux.Handle("GET /api/agents/{id}/users", adminAPI(s.listAgentUsers))
-	s.mux.Handle("POST /api/agents/{id}/users", adminAPI(s.assignAgentUser))
-	s.mux.Handle("DELETE /api/agents/{id}/users/{userId}", adminAPI(s.removeAgentUser))
-
-	// Agent-scoped skills (creator or admin).
-	s.mux.HandleFunc("GET /api/agents/{id}/skills", s.listAgentSkills)
-	s.mux.HandleFunc("POST /api/agents/{id}/skills/install", s.installAgentSkill)
-	s.mux.HandleFunc("POST /api/agents/{id}/skills/upload", s.uploadAgentSkill)
-	s.mux.HandleFunc("POST /api/agents/{id}/skills/from-builtin/{skillId}", s.duplicateBuiltinSkillToAgent)
-	s.mux.HandleFunc("GET /api/agents/{id}/skills/{skillId}", s.getAgentSkill)
-	s.mux.HandleFunc("GET /api/agents/{id}/skills/{skillId}/file", s.getAgentSkillFile)
-	s.mux.HandleFunc("PUT /api/agents/{id}/skills/{skillId}", s.updateAgentSkill)
-	s.mux.HandleFunc("DELETE /api/agents/{id}/skills/{skillId}", s.deleteAgentSkill)
-	s.mux.HandleFunc("DELETE /api/agents/{id}/skills/{skillId}/file", s.deleteAgentSkillFile)
 }
 
 func (s *Server) registerUserRoutes() {

--- a/server/routes.go
+++ b/server/routes.go
@@ -14,7 +14,6 @@ func (s *Server) registerRoutes() {
 	s.registerPageRoutes()
 	s.registerProviderRoutes()
 	s.registerAgentRoutes()
-	s.registerChannelRoutes()
 	s.registerUserRoutes()
 	s.registerAuthUserRoutes()
 	s.registerSessionRoutes()
@@ -129,20 +128,6 @@ func (s *Server) registerAgentRoutes() {
 	s.mux.HandleFunc("PUT /api/agents/{id}/skills/{skillId}", s.updateAgentSkill)
 	s.mux.HandleFunc("DELETE /api/agents/{id}/skills/{skillId}", s.deleteAgentSkill)
 	s.mux.HandleFunc("DELETE /api/agents/{id}/skills/{skillId}/file", s.deleteAgentSkillFile)
-}
-
-func (s *Server) registerChannelRoutes() {
-	adminAPI := func(handler http.HandlerFunc) http.Handler {
-		return s.adminOnlyMiddleware(handler)
-	}
-	s.mux.HandleFunc("GET /api/channels/public", s.listPublicChannels)
-	s.mux.Handle("GET /api/channels", adminAPI(s.listChannels))
-	s.mux.Handle("POST /api/channels", adminAPI(s.createChannel))
-	s.mux.Handle("GET /api/channels/{id}", adminAPI(s.getChannel))
-	s.mux.Handle("PUT /api/channels/{id}", adminAPI(s.updateChannel))
-	s.mux.Handle("DELETE /api/channels/{id}", adminAPI(s.deleteChannel))
-	s.mux.HandleFunc("POST /api/channels/weixin/qr", s.startWeixinQR)
-	s.mux.HandleFunc("GET /api/channels/weixin/qr/status", s.pollWeixinQRStatus)
 }
 
 func (s *Server) registerUserRoutes() {

--- a/server/routes.go
+++ b/server/routes.go
@@ -12,8 +12,6 @@ func (s *Server) registerRoutes() {
 	s.registerAuthRoutes()
 	s.registerProfileRoutes()
 	s.registerPageRoutes()
-	s.registerUserRoutes()
-	s.registerAuthUserRoutes()
 	s.registerPluginRoutes()
 	s.registerManifestPluginRoutes()
 	s.registerAPIRoutes()
@@ -74,30 +72,6 @@ func (s *Server) registerPageRoutes() {
 	s.mux.HandleFunc("GET /profile", s.pageProfile)
 	s.mux.HandleFunc("GET /account", s.pageAccount)
 	s.mux.HandleFunc("GET /credentials", s.pageCredentials)
-}
-
-func (s *Server) registerUserRoutes() {
-	adminAPI := func(handler http.HandlerFunc) http.Handler {
-		return s.adminOnlyMiddleware(handler)
-	}
-	s.mux.Handle("PUT /api/users/{id}/default-agent", adminAPI(s.updateUserDefaultAgent))
-	s.mux.Handle("PUT /api/users/{id}/notify-identity", adminAPI(s.updateUserNotifyIdentity))
-	s.mux.Handle("GET /api/users/{id}/memories", adminAPI(s.listUserMemories))
-	s.mux.Handle("PUT /api/users/{id}/memories/{agentId}", adminAPI(s.setUserMemory))
-	s.mux.Handle("DELETE /api/users/{id}/memories/{agentId}", adminAPI(s.deleteUserMemory))
-}
-
-func (s *Server) registerAuthUserRoutes() {
-	adminAPI := func(handler http.HandlerFunc) http.Handler {
-		return s.adminOnlyMiddleware(handler)
-	}
-	s.mux.Handle("GET /api/auth/users", adminAPI(s.listAuthUsers))
-	s.mux.Handle("GET /api/auth/users/{id}", adminAPI(s.getAuthUser))
-	s.mux.Handle("PUT /api/auth/users/{id}/role", adminAPI(s.updateAuthUserRole))
-	s.mux.Handle("GET /api/auth/users/{id}/agents", adminAPI(s.listAuthUserAgents))
-	s.mux.Handle("PUT /api/auth/users/{id}/agents", adminAPI(s.updateAuthUserAgents))
-	s.mux.Handle("DELETE /api/auth/users/{id}/identities/{identityId}", adminAPI(s.deleteAuthUserIdentity))
-	s.mux.Handle("PUT /api/auth/users/{id}/active", adminAPI(s.updateAuthUserActive))
 }
 
 func (s *Server) registerPluginRoutes() {

--- a/server/routes.go
+++ b/server/routes.go
@@ -15,7 +15,6 @@ func (s *Server) registerRoutes() {
 	s.registerAgentRoutes()
 	s.registerUserRoutes()
 	s.registerAuthUserRoutes()
-	s.registerSessionRoutes()
 	s.registerPluginRoutes()
 	s.registerSkillRoutes()
 	s.registerManifestPluginRoutes()
@@ -137,15 +136,6 @@ func (s *Server) registerAuthUserRoutes() {
 	s.mux.Handle("PUT /api/auth/users/{id}/agents", adminAPI(s.updateAuthUserAgents))
 	s.mux.Handle("DELETE /api/auth/users/{id}/identities/{identityId}", adminAPI(s.deleteAuthUserIdentity))
 	s.mux.Handle("PUT /api/auth/users/{id}/active", adminAPI(s.updateAuthUserActive))
-}
-
-func (s *Server) registerSessionRoutes() {
-	s.mux.HandleFunc("GET /api/sessions", s.listSessions)
-	s.mux.HandleFunc("POST /api/sessions", s.createSession)
-	s.mux.HandleFunc("GET /api/sessions/{sessionID}", s.getSession)
-	s.mux.HandleFunc("GET /api/sessions/{sessionID}/messages", s.getSessionMessages)
-	s.mux.HandleFunc("GET /api/sessions/{sessionID}/system-prompt", s.getSessionSystemPrompt)
-	s.mux.HandleFunc("POST /api/sessions/{sessionID}/messages", s.sendSessionMessage)
 }
 
 func (s *Server) registerPluginRoutes() {

--- a/server/routes.go
+++ b/server/routes.go
@@ -15,7 +15,6 @@ func (s *Server) registerRoutes() {
 	s.registerUserRoutes()
 	s.registerAuthUserRoutes()
 	s.registerPluginRoutes()
-	s.registerSkillRoutes()
 	s.registerManifestPluginRoutes()
 	s.registerAPIRoutes()
 }
@@ -61,16 +60,6 @@ func (s *Server) registerProfileRoutes() {
 	s.mux.HandleFunc("GET /api/auth/profile/oauth/{provider}/connected", s.getOAuthConnected)
 	s.mux.HandleFunc("DELETE /api/auth/profile/oauth/{provider}", s.disconnectOAuth)
 	s.mux.HandleFunc("GET /api/auth/profile/oauth/{provider}/callback", s.oauthCallback)
-
-	// Self-service user skills.
-	s.mux.HandleFunc("GET /api/auth/profile/skills", s.listProfileSkills)
-	s.mux.HandleFunc("POST /api/auth/profile/skills/install", s.installProfileSkill)
-	s.mux.HandleFunc("POST /api/auth/profile/skills/upload", s.uploadProfileSkill)
-	s.mux.HandleFunc("GET /api/auth/profile/skills/{skillId}", s.getProfileSkill)
-	s.mux.HandleFunc("GET /api/auth/profile/skills/{skillId}/file", s.getProfileSkillFile)
-	s.mux.HandleFunc("PUT /api/auth/profile/skills/{skillId}", s.updateProfileSkill)
-	s.mux.HandleFunc("DELETE /api/auth/profile/skills/{skillId}", s.deleteProfileSkill)
-	s.mux.HandleFunc("DELETE /api/auth/profile/skills/{skillId}/file", s.deleteProfileSkillFile)
 }
 
 func (s *Server) registerPageRoutes() {
@@ -121,21 +110,6 @@ func (s *Server) registerPluginRoutes() {
 	s.mux.Handle("GET /api/plugin-config-schema/{kind}/{name}", adminAPI(s.getPluginConfigSchema))
 	s.mux.Handle("PATCH /api/plugins/{id...}", adminAPI(s.togglePlugin))
 	s.mux.Handle("PUT /api/plugin-config/{kind}/{name}", adminAPI(s.updatePluginConfig))
-}
-
-func (s *Server) registerSkillRoutes() {
-	adminAPI := func(handler http.HandlerFunc) http.Handler {
-		return s.adminOnlyMiddleware(handler)
-	}
-	s.mux.Handle("GET /api/skills", adminAPI(s.listSkills))
-	s.mux.HandleFunc("GET /api/skills/search", s.searchSkills)
-	s.mux.Handle("GET /api/skills/{id}", adminAPI(s.getSkill))
-	s.mux.Handle("GET /api/skills/{id}/file", adminAPI(s.getSkillFile))
-	s.mux.Handle("POST /api/skills", adminAPI(s.createSkill))
-	s.mux.Handle("POST /api/skills/install", adminAPI(s.installSkill))
-	s.mux.Handle("PUT /api/skills/{id}", adminAPI(s.updateSkill))
-	s.mux.Handle("DELETE /api/skills/{id}", adminAPI(s.deleteSkill))
-	s.mux.Handle("DELETE /api/skills/{id}/file", adminAPI(s.deleteSkillFile))
 }
 
 func (s *Server) registerManifestPluginRoutes() {

--- a/server/routes.go
+++ b/server/routes.go
@@ -19,10 +19,7 @@ func (s *Server) registerRoutes() {
 	s.registerAuthUserRoutes()
 	s.registerSessionRoutes()
 	s.registerPluginRoutes()
-	s.registerModelRoutes()
-	s.registerToolRoutes()
 	s.registerSkillRoutes()
-	s.registerBuiltinRoutes()
 	s.registerManifestPluginRoutes()
 	s.registerAPIRoutes()
 }
@@ -193,14 +190,6 @@ func (s *Server) registerPluginRoutes() {
 	s.mux.Handle("PUT /api/plugin-config/{kind}/{name}", adminAPI(s.updatePluginConfig))
 }
 
-func (s *Server) registerModelRoutes() {
-	s.mux.HandleFunc("GET /api/models", s.listCachedModels)
-}
-
-func (s *Server) registerToolRoutes() {
-	s.mux.HandleFunc("GET /api/tools", s.listAgentTools)
-}
-
 func (s *Server) registerSkillRoutes() {
 	adminAPI := func(handler http.HandlerFunc) http.Handler {
 		return s.adminOnlyMiddleware(handler)
@@ -214,11 +203,6 @@ func (s *Server) registerSkillRoutes() {
 	s.mux.Handle("PUT /api/skills/{id}", adminAPI(s.updateSkill))
 	s.mux.Handle("DELETE /api/skills/{id}", adminAPI(s.deleteSkill))
 	s.mux.Handle("DELETE /api/skills/{id}/file", adminAPI(s.deleteSkillFile))
-}
-
-func (s *Server) registerBuiltinRoutes() {
-	s.mux.HandleFunc("GET /api/builtin/{kind}", s.listBuiltinResources)
-	s.mux.HandleFunc("GET /api/builtin/{kind}/{id}", s.getBuiltinResource)
 }
 
 func (s *Server) registerManifestPluginRoutes() {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -572,7 +572,7 @@ func TestReflectPluginConfigAndStatus(t *testing.T) {
 		t.Fatalf("config status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
 	}
 
-	rr = doRequest(t, env, "PATCH", "/api/plugins/reflect", map[string]any{"enabled": true})
+	rr = doRequest(t, env, "PATCH", "/api/plugins/reflect/reflect", map[string]any{"enabled": true})
 	if rr.Code != http.StatusOK {
 		t.Fatalf("toggle status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
 	}
@@ -600,7 +600,7 @@ func TestReflectPluginConfigAndStatus(t *testing.T) {
 		t.Fatalf("batch metadata = %#v, want 3", payload.Metadata["batch"])
 	}
 
-	rr = doRequest(t, env, "PATCH", "/api/plugins/reflect", map[string]any{"enabled": false})
+	rr = doRequest(t, env, "PATCH", "/api/plugins/reflect/reflect", map[string]any{"enabled": false})
 	if rr.Code != http.StatusOK {
 		t.Fatalf("disable status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
 	}

--- a/server/sessions.go
+++ b/server/sessions.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strconv"
 	"time"
 
+	apiserver "github.com/vaayne/anna/api/server"
 	"github.com/vaayne/anna/internal/agent"
 	"github.com/vaayne/anna/internal/config"
 	"github.com/vaayne/anna/pkg/db/sqlc"
@@ -16,24 +16,22 @@ import (
 	mcpplugin "github.com/vaayne/anna/plugins/tools/mcp"
 )
 
-func (s *Server) createSession(w http.ResponseWriter, r *http.Request) {
+func (s *Server) CreateSession(w http.ResponseWriter, r *http.Request) {
 	authInfo := UserFromContext(r.Context())
 	if authInfo == nil {
 		writeError(w, http.StatusUnauthorized, "authentication required")
 		return
 	}
 
-	var body struct {
-		AgentID string `json:"agent_id"`
-	}
+	var body apiserver.CreateSessionJSONRequestBody
 	if err := decodeJSON(r, &body); err != nil && err.Error() != "EOF" {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
 	var pool *agent.Pool
-	if body.AgentID != "" {
-		pool = s.poolManager.Get(body.AgentID)
+	if body.AgentId != nil && *body.AgentId != "" {
+		pool = s.poolManager.Get(*body.AgentId)
 	} else {
 		pool = s.poolManager.DefaultPool()
 	}
@@ -51,8 +49,7 @@ func (s *Server) createSession(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusCreated, toSessionResponse(info))
 }
 
-func (s *Server) sendSessionMessage(w http.ResponseWriter, r *http.Request) {
-	sessionID := r.PathValue("sessionID")
+func (s *Server) SendSessionMessage(w http.ResponseWriter, r *http.Request, sessionID string) {
 	if sessionID == "" {
 		writeError(w, http.StatusBadRequest, "missing session ID")
 		return
@@ -64,9 +61,7 @@ func (s *Server) sendSessionMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var body struct {
-		Content string `json:"content"`
-	}
+	var body apiserver.SendSessionMessageJSONRequestBody
 	if err := decodeJSON(r, &body); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
@@ -216,7 +211,7 @@ func toSessionResponse(info memory.SessionInfo) sessionResponse {
 	}
 }
 
-func (s *Server) listSessions(w http.ResponseWriter, r *http.Request) {
+func (s *Server) ListSessions(w http.ResponseWriter, r *http.Request, params apiserver.ListSessionsParams) {
 	sm, ok := s.mem.(memory.SessionManager)
 	if !ok {
 		writeData(w, http.StatusOK, []any{})
@@ -225,16 +220,12 @@ func (s *Server) listSessions(w http.ResponseWriter, r *http.Request) {
 	info := UserFromContext(r.Context())
 
 	limit := 10
-	if lStr := r.URL.Query().Get("limit"); lStr != "" {
-		if l, err := strconv.Atoi(lStr); err == nil && l >= 0 {
-			limit = l
-		}
+	if params.Limit != nil && *params.Limit >= 0 {
+		limit = *params.Limit
 	}
 	offset := 0
-	if oStr := r.URL.Query().Get("offset"); oStr != "" {
-		if o, err := strconv.Atoi(oStr); err == nil && o >= 0 {
-			offset = o
-		}
+	if params.Offset != nil && *params.Offset >= 0 {
+		offset = *params.Offset
 	}
 
 	opts := memory.ListOptions{IncludeArchived: true, Limit: limit, Offset: offset}
@@ -255,8 +246,7 @@ func (s *Server) listSessions(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, resp)
 }
 
-func (s *Server) getSession(w http.ResponseWriter, r *http.Request) {
-	sessionID := r.PathValue("sessionID")
+func (s *Server) GetSession(w http.ResponseWriter, r *http.Request, sessionID string) {
 	if sessionID == "" {
 		writeError(w, http.StatusBadRequest, "missing session ID")
 		return
@@ -304,8 +294,7 @@ func (s *Server) getSession(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, resp)
 }
 
-func (s *Server) getSessionMessages(w http.ResponseWriter, r *http.Request) {
-	sessionID := r.PathValue("sessionID")
+func (s *Server) GetSessionMessages(w http.ResponseWriter, r *http.Request, sessionID string, params apiserver.GetSessionMessagesParams) {
 	if sessionID == "" {
 		writeError(w, http.StatusBadRequest, "missing session ID")
 		return
@@ -317,18 +306,14 @@ func (s *Server) getSessionMessages(w http.ResponseWriter, r *http.Request) {
 	}
 
 	limit := 20
-	if lStr := r.URL.Query().Get("limit"); lStr != "" {
-		if l, err := strconv.Atoi(lStr); err == nil && l >= 0 {
-			limit = l
-		}
+	if params.Limit != nil && *params.Limit >= 0 {
+		limit = *params.Limit
 	}
 	// skip counts serialized messages from the end, enabling backwards pagination.
 	// skip=0 → last 20 messages; skip=20 → messages 20–40 from the end, etc.
 	skip := 0
-	if sStr := r.URL.Query().Get("skip"); sStr != "" {
-		if s, err := strconv.Atoi(sStr); err == nil && s >= 0 {
-			skip = s
-		}
+	if params.Skip != nil && *params.Skip >= 0 {
+		skip = *params.Skip
 	}
 
 	// Load raw DB rows to preserve created_at timestamps.
@@ -383,8 +368,7 @@ func (s *Server) checkSessionAccess(w http.ResponseWriter, r *http.Request, sess
 	return nil
 }
 
-func (s *Server) getSessionSystemPrompt(w http.ResponseWriter, r *http.Request) {
-	sessionID := r.PathValue("sessionID")
+func (s *Server) GetSessionSystemPrompt(w http.ResponseWriter, r *http.Request, sessionID string) {
 	if sessionID == "" {
 		writeError(w, http.StatusBadRequest, "missing session ID")
 		return

--- a/server/skills.go
+++ b/server/skills.go
@@ -91,18 +91,17 @@ func (s *Server) GetSkillFile(w http.ResponseWriter, r *http.Request, id string,
 	if !requireAdmin(w, r) {
 		return
 	}
-	s.serveSkillFile(w, r, id)
+	s.serveSkillFile(w, r, id, params.Path)
 }
 
 // serveSkillFile is the shared body of GET .../skills/{id}/file?path=...
 // (reused by scoped handlers after their ownership checks).
-func (s *Server) serveSkillFile(w http.ResponseWriter, r *http.Request, id string) {
+func (s *Server) serveSkillFile(w http.ResponseWriter, r *http.Request, id, path string) {
 	store := s.skillStore()
 	if store == nil {
 		writeError(w, http.StatusServiceUnavailable, "skills store not available")
 		return
 	}
-	path := r.URL.Query().Get("path")
 	if path == "" {
 		writeError(w, http.StatusBadRequest, "path query parameter is required")
 		return
@@ -124,17 +123,16 @@ func (s *Server) DeleteSkillFile(w http.ResponseWriter, r *http.Request, id stri
 	if !requireAdmin(w, r) {
 		return
 	}
-	s.doDeleteSkillFile(w, r, id)
+	s.doDeleteSkillFile(w, r, id, params.Path)
 }
 
 // doDeleteSkillFile is the shared body of DELETE .../skills/{id}/file?path=...
-func (s *Server) doDeleteSkillFile(w http.ResponseWriter, r *http.Request, id string) {
+func (s *Server) doDeleteSkillFile(w http.ResponseWriter, r *http.Request, id, path string) {
 	store := s.skillStore()
 	if store == nil {
 		writeError(w, http.StatusServiceUnavailable, "skills store not available")
 		return
 	}
-	path := r.URL.Query().Get("path")
 	if path == "" {
 		writeError(w, http.StatusBadRequest, "path query parameter is required")
 		return

--- a/server/skills.go
+++ b/server/skills.go
@@ -5,9 +5,9 @@ import (
 	"database/sql"
 	"errors"
 	"net/http"
-	"strconv"
 	"time"
 
+	apiserver "github.com/vaayne/anna/api/server"
 	"github.com/vaayne/anna/internal/pluginhost"
 	"github.com/vaayne/anna/internal/skills"
 	skillstool "github.com/vaayne/anna/plugins/tools/skills"
@@ -33,7 +33,10 @@ func (s *Server) skillStore() skills.Store {
 	return s.pluginHost.SkillStore()
 }
 
-func (s *Server) listSkills(w http.ResponseWriter, r *http.Request) {
+func (s *Server) ListSkills(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
 	store := s.skillStore()
 	if store == nil {
 		writeError(w, http.StatusServiceUnavailable, "skills store not available")
@@ -51,13 +54,15 @@ func (s *Server) listSkills(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, out)
 }
 
-func (s *Server) getSkill(w http.ResponseWriter, r *http.Request) {
+func (s *Server) GetSkill(w http.ResponseWriter, r *http.Request, id string) {
+	if !requireAdmin(w, r) {
+		return
+	}
 	store := s.skillStore()
 	if store == nil {
 		writeError(w, http.StatusServiceUnavailable, "skills store not available")
 		return
 	}
-	id := r.PathValue("id")
 	row, err := store.ListAll(r.Context())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
@@ -82,8 +87,10 @@ func (s *Server) getSkill(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, skillToView(*found, paths))
 }
 
-func (s *Server) getSkillFile(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
+func (s *Server) GetSkillFile(w http.ResponseWriter, r *http.Request, id string, params apiserver.GetSkillFileParams) {
+	if !requireAdmin(w, r) {
+		return
+	}
 	s.serveSkillFile(w, r, id)
 }
 
@@ -112,9 +119,11 @@ func (s *Server) serveSkillFile(w http.ResponseWriter, r *http.Request, id strin
 	writeData(w, http.StatusOK, map[string]string{"path": path, "content": content})
 }
 
-// deleteSkillFile removes a single file under a skill (admin-only route).
-func (s *Server) deleteSkillFile(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
+// DeleteSkillFile removes a single file under a skill (admin-only route).
+func (s *Server) DeleteSkillFile(w http.ResponseWriter, r *http.Request, id string, params apiserver.DeleteSkillFileParams) {
+	if !requireAdmin(w, r) {
+		return
+	}
 	s.doDeleteSkillFile(w, r, id)
 }
 
@@ -152,7 +161,10 @@ type createSkillRequest struct {
 	Files                  map[string]string `json:"files"`
 }
 
-func (s *Server) createSkill(w http.ResponseWriter, r *http.Request) {
+func (s *Server) CreateSkill(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
 	store := s.skillStore()
 	if store == nil {
 		writeError(w, http.StatusServiceUnavailable, "skills store not available")
@@ -218,8 +230,10 @@ type updateSkillRequest struct {
 	Files                  map[string]string `json:"files"`
 }
 
-func (s *Server) updateSkill(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
+func (s *Server) UpdateSkill(w http.ResponseWriter, r *http.Request, id string) {
+	if !requireAdmin(w, r) {
+		return
+	}
 	s.applySkillUpdate(w, r, id)
 }
 
@@ -253,8 +267,10 @@ func (s *Server) applySkillUpdate(w http.ResponseWriter, r *http.Request, id str
 	writeData(w, http.StatusOK, map[string]string{"id": id})
 }
 
-func (s *Server) deleteSkill(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
+func (s *Server) DeleteSkill(w http.ResponseWriter, r *http.Request, id string) {
+	if !requireAdmin(w, r) {
+		return
+	}
 	s.doDeleteSkill(w, r, id)
 }
 
@@ -272,20 +288,14 @@ func (s *Server) doDeleteSkill(w http.ResponseWriter, r *http.Request, id string
 	writeData(w, http.StatusOK, map[string]string{"id": id})
 }
 
-// searchSkills handles GET /api/skills/search?q=<query>&limit=<n>.
+// SearchSkills handles GET /api/skills/search?q=<query>&limit=<n>.
 // It queries mcphub for skills matching the query. Errors from the upstream
 // search API are returned as 502 (bad gateway) since they are not our fault.
-func (s *Server) searchSkills(w http.ResponseWriter, r *http.Request) {
-	q := r.URL.Query().Get("q")
-	if q == "" {
-		writeError(w, http.StatusBadRequest, "q is required")
-		return
-	}
+func (s *Server) SearchSkills(w http.ResponseWriter, r *http.Request, params apiserver.SearchSkillsParams) {
+	q := params.Q
 	limit := 10
-	if l := r.URL.Query().Get("limit"); l != "" {
-		if n, err := strconv.Atoi(l); err == nil && n > 0 {
-			limit = n
-		}
+	if params.Limit != nil && *params.Limit > 0 {
+		limit = *params.Limit
 	}
 	if limit > 50 {
 		limit = 50
@@ -310,11 +320,14 @@ type installSkillRequest struct {
 	AgentID string `json:"agent_id"`
 }
 
-// installSkill handles POST /api/skills/install.
+// InstallSkill handles POST /api/skills/install.
 // It delegates to skillstool.InstallToStore to fetch and store the skill.
 // "Actually install from a real GitHub repo" is integration-level and should be
 // tested manually — unit tests cover only validation and auth.
-func (s *Server) installSkill(w http.ResponseWriter, r *http.Request) {
+func (s *Server) InstallSkill(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
 	store := s.skillStore()
 	if store == nil {
 		writeError(w, http.StatusServiceUnavailable, "skills store not available")

--- a/server/skills_scoped.go
+++ b/server/skills_scoped.go
@@ -167,7 +167,7 @@ func (s *Server) GetAgentSkill(w http.ResponseWriter, r *http.Request, id string
 	writeData(w, http.StatusOK, skillToView(*sk, paths))
 }
 
-func (s *Server) GetAgentSkillFile(w http.ResponseWriter, r *http.Request, id string, skillId string) {
+func (s *Server) GetAgentSkillFile(w http.ResponseWriter, r *http.Request, id string, skillId string, params apiserver.GetAgentSkillFileParams) {
 	agentID := id
 	skillID := skillId
 	if _, code, msg := s.requireAgentManage(r.Context(), agentID); code != 0 {
@@ -178,7 +178,7 @@ func (s *Server) GetAgentSkillFile(w http.ResponseWriter, r *http.Request, id st
 		writeError(w, code, msg)
 		return
 	}
-	s.serveSkillFile(w, r, skillID)
+	s.serveSkillFile(w, r, skillID, params.Path)
 }
 
 func (s *Server) UpdateAgentSkill(w http.ResponseWriter, r *http.Request, id string, skillId string) {
@@ -209,7 +209,7 @@ func (s *Server) DeleteAgentSkill(w http.ResponseWriter, r *http.Request, id str
 	s.doDeleteSkill(w, r, skillID)
 }
 
-func (s *Server) DeleteAgentSkillFile(w http.ResponseWriter, r *http.Request, id string, skillId string) {
+func (s *Server) DeleteAgentSkillFile(w http.ResponseWriter, r *http.Request, id string, skillId string, params apiserver.DeleteAgentSkillFileParams) {
 	agentID := id
 	skillID := skillId
 	if _, code, msg := s.requireAgentManage(r.Context(), agentID); code != 0 {
@@ -220,7 +220,7 @@ func (s *Server) DeleteAgentSkillFile(w http.ResponseWriter, r *http.Request, id
 		writeError(w, code, msg)
 		return
 	}
-	s.doDeleteSkillFile(w, r, skillID)
+	s.doDeleteSkillFile(w, r, skillID, params.Path)
 }
 
 func (s *Server) InstallAgentSkill(w http.ResponseWriter, r *http.Request, id string) {
@@ -366,7 +366,7 @@ func (s *Server) GetProfileSkillFile(w http.ResponseWriter, r *http.Request, ski
 		writeError(w, code, msg)
 		return
 	}
-	s.serveSkillFile(w, r, skillID)
+	s.serveSkillFile(w, r, skillID, params.Path)
 }
 
 func (s *Server) UpdateProfileSkill(w http.ResponseWriter, r *http.Request, skillId string) {
@@ -408,7 +408,7 @@ func (s *Server) DeleteProfileSkillFile(w http.ResponseWriter, r *http.Request, 
 		writeError(w, code, msg)
 		return
 	}
-	s.doDeleteSkillFile(w, r, skillID)
+	s.doDeleteSkillFile(w, r, skillID, params.Path)
 }
 
 func (s *Server) InstallProfileSkill(w http.ResponseWriter, r *http.Request) {

--- a/server/skills_scoped.go
+++ b/server/skills_scoped.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"path"
 
+	apiserver "github.com/vaayne/anna/api/server"
 	"github.com/vaayne/anna/internal/config"
 	"github.com/vaayne/anna/internal/pluginhost"
 	builtinres "github.com/vaayne/anna/internal/resources"
@@ -314,7 +315,7 @@ func (s *Server) DuplicateBuiltinSkillToAgent(w http.ResponseWriter, r *http.Req
 
 // ---- Profile (self-user) skills: /api/auth/profile/skills* ----
 
-func (s *Server) listProfileSkills(w http.ResponseWriter, r *http.Request) {
+func (s *Server) ListProfileSkills(w http.ResponseWriter, r *http.Request) {
 	info := UserFromContext(r.Context())
 	if info == nil {
 		writeError(w, http.StatusUnauthorized, "unauthorized")
@@ -334,13 +335,13 @@ func (s *Server) listProfileSkills(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, out)
 }
 
-func (s *Server) getProfileSkill(w http.ResponseWriter, r *http.Request) {
+func (s *Server) GetProfileSkill(w http.ResponseWriter, r *http.Request, skillId string) {
 	info := UserFromContext(r.Context())
 	if info == nil {
 		writeError(w, http.StatusUnauthorized, "unauthorized")
 		return
 	}
-	skillID := r.PathValue("skillId")
+	skillID := skillId
 	sk, code, msg := s.requireSkillScope(r.Context(), skillID, "user", info.UserID, "")
 	if code != 0 {
 		writeError(w, code, msg)
@@ -354,13 +355,13 @@ func (s *Server) getProfileSkill(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, skillToView(*sk, paths))
 }
 
-func (s *Server) getProfileSkillFile(w http.ResponseWriter, r *http.Request) {
+func (s *Server) GetProfileSkillFile(w http.ResponseWriter, r *http.Request, skillId string, params apiserver.GetProfileSkillFileParams) {
 	info := UserFromContext(r.Context())
 	if info == nil {
 		writeError(w, http.StatusUnauthorized, "unauthorized")
 		return
 	}
-	skillID := r.PathValue("skillId")
+	skillID := skillId
 	if _, code, msg := s.requireSkillScope(r.Context(), skillID, "user", info.UserID, ""); code != 0 {
 		writeError(w, code, msg)
 		return
@@ -368,13 +369,13 @@ func (s *Server) getProfileSkillFile(w http.ResponseWriter, r *http.Request) {
 	s.serveSkillFile(w, r, skillID)
 }
 
-func (s *Server) updateProfileSkill(w http.ResponseWriter, r *http.Request) {
+func (s *Server) UpdateProfileSkill(w http.ResponseWriter, r *http.Request, skillId string) {
 	info := UserFromContext(r.Context())
 	if info == nil {
 		writeError(w, http.StatusUnauthorized, "unauthorized")
 		return
 	}
-	skillID := r.PathValue("skillId")
+	skillID := skillId
 	if _, code, msg := s.requireSkillScope(r.Context(), skillID, "user", info.UserID, ""); code != 0 {
 		writeError(w, code, msg)
 		return
@@ -382,13 +383,13 @@ func (s *Server) updateProfileSkill(w http.ResponseWriter, r *http.Request) {
 	s.applySkillUpdate(w, r, skillID)
 }
 
-func (s *Server) deleteProfileSkill(w http.ResponseWriter, r *http.Request) {
+func (s *Server) DeleteProfileSkill(w http.ResponseWriter, r *http.Request, skillId string) {
 	info := UserFromContext(r.Context())
 	if info == nil {
 		writeError(w, http.StatusUnauthorized, "unauthorized")
 		return
 	}
-	skillID := r.PathValue("skillId")
+	skillID := skillId
 	if _, code, msg := s.requireSkillScope(r.Context(), skillID, "user", info.UserID, ""); code != 0 {
 		writeError(w, code, msg)
 		return
@@ -396,13 +397,13 @@ func (s *Server) deleteProfileSkill(w http.ResponseWriter, r *http.Request) {
 	s.doDeleteSkill(w, r, skillID)
 }
 
-func (s *Server) deleteProfileSkillFile(w http.ResponseWriter, r *http.Request) {
+func (s *Server) DeleteProfileSkillFile(w http.ResponseWriter, r *http.Request, skillId string, params apiserver.DeleteProfileSkillFileParams) {
 	info := UserFromContext(r.Context())
 	if info == nil {
 		writeError(w, http.StatusUnauthorized, "unauthorized")
 		return
 	}
-	skillID := r.PathValue("skillId")
+	skillID := skillId
 	if _, code, msg := s.requireSkillScope(r.Context(), skillID, "user", info.UserID, ""); code != 0 {
 		writeError(w, code, msg)
 		return
@@ -410,7 +411,7 @@ func (s *Server) deleteProfileSkillFile(w http.ResponseWriter, r *http.Request) 
 	s.doDeleteSkillFile(w, r, skillID)
 }
 
-func (s *Server) installProfileSkill(w http.ResponseWriter, r *http.Request) {
+func (s *Server) InstallProfileSkill(w http.ResponseWriter, r *http.Request) {
 	info := UserFromContext(r.Context())
 	if info == nil {
 		writeError(w, http.StatusUnauthorized, "unauthorized")

--- a/server/skills_scoped.go
+++ b/server/skills_scoped.go
@@ -126,8 +126,8 @@ func builtinSkillFiles(id string) (map[string]string, error) {
 
 // ---- Agent-scoped skills: /api/agents/{id}/skills* ----
 
-func (s *Server) listAgentSkills(w http.ResponseWriter, r *http.Request) {
-	agentID := r.PathValue("id")
+func (s *Server) ListAgentSkills(w http.ResponseWriter, r *http.Request, id string) {
+	agentID := id
 	if _, code, msg := s.requireAgentManage(r.Context(), agentID); code != 0 {
 		writeError(w, code, msg)
 		return
@@ -146,9 +146,9 @@ func (s *Server) listAgentSkills(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, out)
 }
 
-func (s *Server) getAgentSkill(w http.ResponseWriter, r *http.Request) {
-	agentID := r.PathValue("id")
-	skillID := r.PathValue("skillId")
+func (s *Server) GetAgentSkill(w http.ResponseWriter, r *http.Request, id string, skillId string) {
+	agentID := id
+	skillID := skillId
 	if _, code, msg := s.requireAgentManage(r.Context(), agentID); code != 0 {
 		writeError(w, code, msg)
 		return
@@ -166,9 +166,9 @@ func (s *Server) getAgentSkill(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, skillToView(*sk, paths))
 }
 
-func (s *Server) getAgentSkillFile(w http.ResponseWriter, r *http.Request) {
-	agentID := r.PathValue("id")
-	skillID := r.PathValue("skillId")
+func (s *Server) GetAgentSkillFile(w http.ResponseWriter, r *http.Request, id string, skillId string) {
+	agentID := id
+	skillID := skillId
 	if _, code, msg := s.requireAgentManage(r.Context(), agentID); code != 0 {
 		writeError(w, code, msg)
 		return
@@ -180,9 +180,9 @@ func (s *Server) getAgentSkillFile(w http.ResponseWriter, r *http.Request) {
 	s.serveSkillFile(w, r, skillID)
 }
 
-func (s *Server) updateAgentSkill(w http.ResponseWriter, r *http.Request) {
-	agentID := r.PathValue("id")
-	skillID := r.PathValue("skillId")
+func (s *Server) UpdateAgentSkill(w http.ResponseWriter, r *http.Request, id string, skillId string) {
+	agentID := id
+	skillID := skillId
 	if _, code, msg := s.requireAgentManage(r.Context(), agentID); code != 0 {
 		writeError(w, code, msg)
 		return
@@ -194,9 +194,9 @@ func (s *Server) updateAgentSkill(w http.ResponseWriter, r *http.Request) {
 	s.applySkillUpdate(w, r, skillID)
 }
 
-func (s *Server) deleteAgentSkill(w http.ResponseWriter, r *http.Request) {
-	agentID := r.PathValue("id")
-	skillID := r.PathValue("skillId")
+func (s *Server) DeleteAgentSkill(w http.ResponseWriter, r *http.Request, id string, skillId string) {
+	agentID := id
+	skillID := skillId
 	if _, code, msg := s.requireAgentManage(r.Context(), agentID); code != 0 {
 		writeError(w, code, msg)
 		return
@@ -208,9 +208,9 @@ func (s *Server) deleteAgentSkill(w http.ResponseWriter, r *http.Request) {
 	s.doDeleteSkill(w, r, skillID)
 }
 
-func (s *Server) deleteAgentSkillFile(w http.ResponseWriter, r *http.Request) {
-	agentID := r.PathValue("id")
-	skillID := r.PathValue("skillId")
+func (s *Server) DeleteAgentSkillFile(w http.ResponseWriter, r *http.Request, id string, skillId string) {
+	agentID := id
+	skillID := skillId
 	if _, code, msg := s.requireAgentManage(r.Context(), agentID); code != 0 {
 		writeError(w, code, msg)
 		return
@@ -222,8 +222,8 @@ func (s *Server) deleteAgentSkillFile(w http.ResponseWriter, r *http.Request) {
 	s.doDeleteSkillFile(w, r, skillID)
 }
 
-func (s *Server) installAgentSkill(w http.ResponseWriter, r *http.Request) {
-	agentID := r.PathValue("id")
+func (s *Server) InstallAgentSkill(w http.ResponseWriter, r *http.Request, id string) {
+	agentID := id
 	info := UserFromContext(r.Context())
 	if info == nil {
 		writeError(w, http.StatusUnauthorized, "unauthorized")
@@ -258,9 +258,9 @@ func (s *Server) installAgentSkill(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusCreated, map[string]string{"name": name})
 }
 
-func (s *Server) duplicateBuiltinSkillToAgent(w http.ResponseWriter, r *http.Request) {
-	agentID := r.PathValue("id")
-	skillID := r.PathValue("skillId")
+func (s *Server) DuplicateBuiltinSkillToAgent(w http.ResponseWriter, r *http.Request, id string, skillId string) {
+	agentID := id
+	skillID := skillId
 	info := UserFromContext(r.Context())
 	if info == nil {
 		writeError(w, http.StatusUnauthorized, "unauthorized")

--- a/server/skills_upload.go
+++ b/server/skills_upload.go
@@ -42,8 +42,8 @@ type uploadedSkillFrontmatter struct {
 	DisableModelInvocation bool   `yaml:"disable-model-invocation"`
 }
 
-func (s *Server) uploadAgentSkill(w http.ResponseWriter, r *http.Request) {
-	agentID := r.PathValue("id")
+func (s *Server) UploadAgentSkill(w http.ResponseWriter, r *http.Request, id string) {
+	agentID := id
 	info := UserFromContext(r.Context())
 	if info == nil {
 		writeError(w, http.StatusUnauthorized, "unauthorized")

--- a/server/skills_upload.go
+++ b/server/skills_upload.go
@@ -82,7 +82,7 @@ func (s *Server) UploadAgentSkill(w http.ResponseWriter, r *http.Request, id str
 	writeData(w, http.StatusCreated, map[string]string{"id": id, "name": up.name})
 }
 
-func (s *Server) uploadProfileSkill(w http.ResponseWriter, r *http.Request) {
+func (s *Server) UploadProfileSkill(w http.ResponseWriter, r *http.Request) {
 	info := UserFromContext(r.Context())
 	if info == nil {
 		writeError(w, http.StatusUnauthorized, "unauthorized")

--- a/server/tools.go
+++ b/server/tools.go
@@ -32,7 +32,7 @@ func defToJSON(def pkgtools.Definition, category string) toolJSON {
 	}
 }
 
-func (s *Server) listAgentTools(w http.ResponseWriter, r *http.Request) {
+func (s *Server) ListTools(w http.ResponseWriter, r *http.Request) {
 	var tools []toolJSON
 
 	// Built-in tools (Read, Bash, Edit, Write).

--- a/server/users.go
+++ b/server/users.go
@@ -2,16 +2,13 @@ package server
 
 import (
 	"net/http"
-	"strconv"
 
 	"github.com/vaayne/anna/internal/memorywrite"
 	"github.com/vaayne/anna/pkg/memory"
 )
 
-func (s *Server) updateUserDefaultAgent(w http.ResponseWriter, r *http.Request) {
-	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid user id")
+func (s *Server) UpdateUserDefaultAgent(w http.ResponseWriter, r *http.Request, id int64) {
+	if !requireAdmin(w, r) {
 		return
 	}
 	var body struct {
@@ -28,10 +25,8 @@ func (s *Server) updateUserDefaultAgent(w http.ResponseWriter, r *http.Request) 
 	writeData(w, http.StatusOK, map[string]string{"status": "updated"})
 }
 
-func (s *Server) updateUserNotifyIdentity(w http.ResponseWriter, r *http.Request) {
-	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid user id")
+func (s *Server) UpdateUserNotifyIdentity(w http.ResponseWriter, r *http.Request, id int64) {
+	if !requireAdmin(w, r) {
 		return
 	}
 	var body struct {
@@ -48,10 +43,8 @@ func (s *Server) updateUserNotifyIdentity(w http.ResponseWriter, r *http.Request
 	writeData(w, http.StatusOK, map[string]string{"status": "updated"})
 }
 
-func (s *Server) listUserMemories(w http.ResponseWriter, r *http.Request) {
-	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid user id")
+func (s *Server) ListUserMemories(w http.ResponseWriter, r *http.Request, id int64) {
+	if !requireAdmin(w, r) {
 		return
 	}
 	memories, err := s.q.ListUserAgentMemoriesByUser(r.Context(), id)
@@ -62,13 +55,10 @@ func (s *Server) listUserMemories(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, memories)
 }
 
-func (s *Server) setUserMemory(w http.ResponseWriter, r *http.Request) {
-	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid user id")
+func (s *Server) SetUserMemory(w http.ResponseWriter, r *http.Request, id int64, agentId string) {
+	if !requireAdmin(w, r) {
 		return
 	}
-	agentID := r.PathValue("agentId")
 	var body struct {
 		Content string `json:"content"`
 	}
@@ -77,22 +67,19 @@ func (s *Server) setUserMemory(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	ctx := memory.WithChangeSource(r.Context(), memory.SourceSystem)
-	if err := memorywrite.SetProfile(ctx, s.db, s.q, id, agentID, body.Content); err != nil {
+	if err := memorywrite.SetProfile(ctx, s.db, s.q, id, agentId, body.Content); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 	writeData(w, http.StatusOK, map[string]string{"status": "saved"})
 }
 
-func (s *Server) deleteUserMemory(w http.ResponseWriter, r *http.Request) {
-	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid user id")
+func (s *Server) DeleteUserMemory(w http.ResponseWriter, r *http.Request, id int64, agentId string) {
+	if !requireAdmin(w, r) {
 		return
 	}
-	agentID := r.PathValue("agentId")
 	ctx := memory.WithChangeSource(r.Context(), memory.SourceSystem)
-	if err := memorywrite.DeleteProfile(ctx, s.db, s.q, id, agentID); err != nil {
+	if err := memorywrite.DeleteProfile(ctx, s.db, s.q, id, agentId); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/server/vault.go
+++ b/server/vault.go
@@ -4,15 +4,15 @@ import (
 	"net/http"
 )
 
-// vaultEntryResponse is the JSON shape returned by listVaultEntries.
+// vaultEntryResponse is the JSON shape returned by ListVaultEntries.
 type vaultEntryResponse struct {
 	Name      string `json:"name"`
 	CreatedAt string `json:"created_at"`
 	UpdatedAt string `json:"updated_at"`
 }
 
-// listVaultEntries handles GET /api/auth/profile/vault.
-func (s *Server) listVaultEntries(w http.ResponseWriter, r *http.Request) {
+// ListVaultEntries handles GET /api/auth/profile/vault.
+func (s *Server) ListVaultEntries(w http.ResponseWriter, r *http.Request) {
 	if s.vaultSvc == nil {
 		writeError(w, http.StatusServiceUnavailable, "vault not configured")
 		return
@@ -42,8 +42,8 @@ func (s *Server) listVaultEntries(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, resp)
 }
 
-// setVaultEntry handles PUT /api/auth/profile/vault/{name}.
-func (s *Server) setVaultEntry(w http.ResponseWriter, r *http.Request) {
+// SetVaultEntry handles PUT /api/auth/profile/vault/{name}.
+func (s *Server) SetVaultEntry(w http.ResponseWriter, r *http.Request, name string) {
 	if s.vaultSvc == nil {
 		writeError(w, http.StatusServiceUnavailable, "vault not configured")
 		return
@@ -55,7 +55,6 @@ func (s *Server) setVaultEntry(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	name := r.PathValue("name")
 	if name == "" {
 		writeError(w, http.StatusBadRequest, "name is required")
 		return
@@ -82,8 +81,8 @@ func (s *Server) setVaultEntry(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// deleteVaultEntry handles DELETE /api/auth/profile/vault/{name}.
-func (s *Server) deleteVaultEntry(w http.ResponseWriter, r *http.Request) {
+// DeleteVaultEntry handles DELETE /api/auth/profile/vault/{name}.
+func (s *Server) DeleteVaultEntry(w http.ResponseWriter, r *http.Request, name string) {
 	if s.vaultSvc == nil {
 		writeError(w, http.StatusServiceUnavailable, "vault not configured")
 		return
@@ -95,7 +94,6 @@ func (s *Server) deleteVaultEntry(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	name := r.PathValue("name")
 	if name == "" {
 		writeError(w, http.StatusBadRequest, "name is required")
 		return

--- a/server/weixin_qr.go
+++ b/server/weixin_qr.go
@@ -5,16 +5,17 @@ import (
 	"encoding/json"
 	"net/http"
 
+	apiserver "github.com/vaayne/anna/api/server"
 	"github.com/vaayne/anna/internal/auth"
 	"github.com/vaayne/anna/internal/config"
 	pkgchannel "github.com/vaayne/anna/pkg/channel"
 	"github.com/vaayne/anna/plugins/channels/weixin"
 )
 
-// startWeixinQR initiates the WeChat QR login flow by requesting a QR code
+// StartWeixinQR initiates the WeChat QR login flow by requesting a QR code
 // from the iLink API. Any authenticated user can call this.
 // POST /api/channels/weixin/qr
-func (s *Server) startWeixinQR(w http.ResponseWriter, r *http.Request) {
+func (s *Server) StartWeixinQR(w http.ResponseWriter, r *http.Request) {
 	client := weixin.NewClient("", "", "")
 	qr, err := client.GetQRCode("")
 	if err != nil {
@@ -24,18 +25,18 @@ func (s *Server) startWeixinQR(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, qr)
 }
 
-// pollWeixinQRStatus polls the QR code scan status. On confirmed, saves
+// PollWeixinQRStatus polls the QR code scan status. On confirmed, saves
 // channel credentials to DB and creates an auth identity linking the
 // current user to the weixin account.
 // GET /api/channels/weixin/qr/status?qrcode=...
-func (s *Server) pollWeixinQRStatus(w http.ResponseWriter, r *http.Request) {
+func (s *Server) PollWeixinQRStatus(w http.ResponseWriter, r *http.Request, params apiserver.PollWeixinQRStatusParams) {
 	info := UserFromContext(r.Context())
 	if info == nil {
 		writeError(w, http.StatusUnauthorized, "not authenticated")
 		return
 	}
 
-	qrcode := r.URL.Query().Get("qrcode")
+	qrcode := params.Qrcode
 	if qrcode == "" {
 		writeError(w, http.StatusBadRequest, "qrcode parameter required")
 		return

--- a/web/static/js/pages/plugins.js
+++ b/web/static/js/pages/plugins.js
@@ -221,9 +221,19 @@ export function register(Alpine) {
       }
     },
 
+    pluginToggleURL(id) {
+      const p = this.plugins.find(p => p.id === id)
+      if (p) return `/api/plugins/${encodeURIComponent(p.kind)}/${encodeURIComponent(p.name)}`
+      // Fallback: id is "kind/name" or "name" (kind===name); split accordingly.
+      const slash = id.indexOf('/')
+      return slash !== -1
+        ? `/api/plugins/${encodeURIComponent(id.slice(0, slash))}/${encodeURIComponent(id.slice(slash + 1))}`
+        : `/api/plugins/${encodeURIComponent(id)}/${encodeURIComponent(id)}`
+    },
+
     async togglePlugin(id, enabled) {
       try {
-        await api('PATCH', '/api/plugins/' + encodeURIComponent(id), { enabled })
+        await api('PATCH', this.pluginToggleURL(id), { enabled })
         await this.loadPlugins()
         this.$store.toast.show(id + (enabled ? ' enabled' : ' disabled'))
       } catch (e) {
@@ -237,10 +247,10 @@ export function register(Alpine) {
           // Disable all other sandbox backends first (mutual exclusion).
           const others = this.sandboxPlugins.filter(p => p.id !== id && p.enabled)
           for (const other of others) {
-            await api('PATCH', '/api/plugins/' + encodeURIComponent(other.id), { enabled: false })
+            await api('PATCH', this.pluginToggleURL(other.id), { enabled: false })
           }
         }
-        await api('PATCH', '/api/plugins/' + encodeURIComponent(id), { enabled })
+        await api('PATCH', this.pluginToggleURL(id), { enabled })
         await this.loadPlugins()
         this.$store.toast.show(enabled ? id + ' set as active sandbox' : id + ' disabled')
       } catch (e) {


### PR DESCRIPTION
## Summary

- Migrates all 15 hand-registered route groups (~100 `/api/*` routes) to the OpenAPI spec-first workflow
- `routes.go` now contains only `registerStaticRoutes`, `registerPageRoutes`, and a single `apiserver.HandlerFromMux(s, s.mux)` call — no hand-registered API routes remain
- Full client SDK coverage: `api/client/gen.go` now covers the entire API surface instead of ~15%

## What changed

| Domain | Routes | Notes |
|--------|--------|-------|
| models, tools, builtin | 4 | |
| channels + weixin QR | 8 | |
| providers | 8 | |
| sessions | 6 | SSE endpoint preserved |
| agents + agent-users + agent-skills | 17 | |
| global skills + profile skills | 17 | multipart upload via spec |
| users + auth-users | 12 | |
| profile + vault + OAuth | 17 | |
| auth | 4 | login/register have `security: []` |
| plugins + manifest-plugins | 9 | catch-all `{id...}` → `{kind}/{name}` |

## Approach

- Added `requireAdmin(w, r) bool` helper to replace `adminOnlyMiddleware` wrapping (oapi-codegen's router doesn't support per-operation middleware)
- Integer path params declared as `integer/int64` in spec → oapi-codegen generates `int64` directly, eliminating `strconv.ParseInt` boilerplate
- All handler methods renamed from unexported camelCase to exported PascalCase to match generated `ServerInterface`
- Updated `server/CLAUDE.md` and `api/CLAUDE.md` to document the spec-first workflow

## Test plan

- [ ] `mise run build` passes
- [ ] `mise run test` passes
- [ ] Admin-only routes return 403 for non-admin users
- [ ] Plugin toggle works with new `/api/plugins/{kind}/{name}` path
- [ ] OAuth login flow still works (public endpoints have `security: []`)