### PR TITLE
♻️ refactor: replace hard turn limit with timeout + milestone nudges

### DIFF
--- a/internal/agent/gorunner.go
+++ b/internal/agent/gorunner.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -354,6 +355,9 @@ func buildHookSet(cfg GoRunnerConfig) *hooks.HookSet {
 
 const defaultChatTimeout = 30 * time.Minute
 
+// ErrChatTimeout is returned when the main agent chat exceeds its wall-clock timeout.
+var ErrChatTimeout = errors.New("chat timeout exceeded")
+
 // Chat runs the Engine agent loop with the provided history and forwards events.
 func (r *GoRunner) Chat(ctx context.Context, history []ai.Message, message MessageContent) <-chan Event {
 	out := make(chan Event, 100)
@@ -449,6 +453,9 @@ func (r *GoRunner) Chat(ctx context.Context, history []ai.Message, message Messa
 				out <- evt
 			}
 		}); err != nil {
+			if ctx.Err() == context.DeadlineExceeded {
+				err = fmt.Errorf("%w: %w", ErrChatTimeout, err)
+			}
 			out <- Event{Err: err}
 		}
 

--- a/internal/agent/gorunner.go
+++ b/internal/agent/gorunner.go
@@ -25,11 +25,6 @@ import (
 	agenttool "github.com/CherryHQ/stella/plugins/tools/agent"
 )
 
-// maxAgentLoopTurns caps one runner invocation's model/tool decision loop.
-// A single turn may include multiple tool calls; the limit is on loop rounds,
-// not individual tool executions.
-const maxAgentLoopTurns = 50
-
 // VaultEnvLoader loads decrypted vault entries for a user as a name→value map.
 // It is a subset of vault.Service and is defined here to avoid a circular
 // import between the runner and vault packages.
@@ -196,7 +191,6 @@ func newAgentRunnerWithTools(reg *providers.Registry, model ai.Model, streamOpti
 		ToolDefinitions: toolDefs,
 	},
 		coreagent.WithStreamOptions(streamOptions),
-		coreagent.WithMaxTurns(maxAgentLoopTurns),
 		coreagent.WithSystem(system),
 		coreagent.WithHooks(hookSet, hooks.HookMeta{}),
 		coreagent.WithToolLifecycle(toolLifecycle),

--- a/internal/agent/gorunner.go
+++ b/internal/agent/gorunner.go
@@ -58,6 +58,7 @@ type GoRunnerConfig struct {
 	TokenService     *auth.TokenService               // optional; if set, ensures STELLA_TOKEN before vault env injection
 	TokenManager     *oauth.TokenManager              // optional; if set, runtime OAuth tokens are injected into sandbox env
 	SubagentTimeout  time.Duration                    // default wall-clock timeout per subagent (0 = 15m)
+	ChatTimeout      time.Duration                    // wall-clock timeout per main agent chat turn (0 = 30m)
 }
 
 // GoRunner implements Runner by calling LLM providers directly via agent.Runner.
@@ -70,6 +71,7 @@ type GoRunner struct {
 	system        string
 	hookSet       *hooks.HookSet
 	toolLifecycle *coreagent.ToolLifecycle
+	chatTimeout   time.Duration
 	session       *runnerSession // runner-owned sandbox session lifecycle
 
 	mu           sync.Mutex
@@ -171,6 +173,7 @@ func NewGoRunner(ctx context.Context, cfg GoRunnerConfig) (*GoRunner, error) {
 		system:        system,
 		hookSet:       hookSet,
 		toolLifecycle: cfg.ToolLifecycle,
+		chatTimeout:   cfg.ChatTimeout,
 		session:       session,
 		lastActivity:  time.Now(),
 		log:           slog.With("component", "go_runner"),
@@ -349,9 +352,17 @@ func buildHookSet(cfg GoRunnerConfig) *hooks.HookSet {
 	return nil
 }
 
+const defaultChatTimeout = 30 * time.Minute
+
 // Chat runs the Engine agent loop with the provided history and forwards events.
 func (r *GoRunner) Chat(ctx context.Context, history []ai.Message, message MessageContent) <-chan Event {
 	out := make(chan Event, 100)
+
+	timeout := r.chatTimeout
+	if timeout <= 0 {
+		timeout = defaultChatTimeout
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 
 	r.mu.Lock()
 	r.lastActivity = time.Now()
@@ -359,6 +370,7 @@ func (r *GoRunner) Chat(ctx context.Context, history []ai.Message, message Messa
 	r.mu.Unlock()
 
 	go func() {
+		defer cancel()
 		defer close(out)
 		defer func() {
 			r.mu.Lock()
@@ -402,6 +414,25 @@ func (r *GoRunner) Chat(ctx context.Context, history []ai.Message, message Messa
 				channel, _ := ChannelFromContext(ctx)
 				return channel
 			}(),
+		})
+
+		// Inject progress nudges at milestone turns so the model can summarize
+		// its state before the timeout fires.
+		chatStart := time.Now()
+		loopRunner.SetTurnNotify(func(turn int, _ time.Duration) *string {
+			elapsed := time.Since(chatStart).Round(time.Second)
+			var msg string
+			switch turn {
+			case 50:
+				msg = fmt.Sprintf("You have been running for %s and completed 50 turns. Please report your current progress. If the user's request is not yet resolved, suggest alternative approaches.", elapsed)
+			case 80:
+				msg = fmt.Sprintf("You have been running for %s and completed 80 turns. Please report your progress again and consider whether a simpler approach could resolve the problem.", elapsed)
+			case 100:
+				msg = fmt.Sprintf("You have been running for %s and completed 100 turns. Please summarize the current state clearly and stop further attempts. Wait for the user's instructions before continuing.", elapsed)
+			default:
+				return nil
+			}
+			return &msg
 		})
 
 		messages := make([]ai.Message, len(history))

--- a/internal/agent/integration_tool_test.go
+++ b/internal/agent/integration_tool_test.go
@@ -99,7 +99,6 @@ func TestIntegrationToolUseAllProviders(t *testing.T) {
 				ToolDefinitions: []ai.ToolDefinition{toolDef},
 			},
 				agent.WithStreamOptions(ai.StreamOptions{APIKey: apiKey}),
-				agent.WithMaxTurns(5),
 				agent.WithSystem("You are a helpful assistant. When asked about weather, always use the get_weather tool. Be concise."),
 			)
 			if err != nil {

--- a/internal/agent/pool_chat.go
+++ b/internal/agent/pool_chat.go
@@ -220,7 +220,7 @@ func (p *Pool) streamEvents(ctx context.Context, sessionID string, memSession me
 			// On timeout, emit a friendly status notice instead of a raw error
 			// so the user sees context rather than a crash. The session remains
 			// intact; the user can send a new message to continue.
-			if errors.Is(evt.Err, context.DeadlineExceeded) {
+			if errors.Is(evt.Err, ErrChatTimeout) {
 				notice := "I've been working on this for a while and have reached the time limit. Here's where things stand — feel free to send a message to continue or change direction."
 				noticeMsg := ai.AssistantMessage{Content: []ai.ContentBlock{ai.TextContent{Text: notice}}}
 				if err := p.mem.Append(persistCtx, memSession, noticeMsg); err != nil {

--- a/internal/agent/pool_chat.go
+++ b/internal/agent/pool_chat.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -214,6 +215,19 @@ func (p *Pool) streamEvents(ctx context.Context, sessionID string, memSession me
 				if err := p.mem.Append(persistCtx, memSession, flushMsg); err != nil {
 					p.log.Warn("memory append error-flush failed", "session_id", sessionID, "error", err)
 				}
+				textBuf.Reset()
+			}
+			// On timeout, emit a friendly status notice instead of a raw error
+			// so the user sees context rather than a crash. The session remains
+			// intact; the user can send a new message to continue.
+			if errors.Is(evt.Err, context.DeadlineExceeded) {
+				notice := "I've been working on this for a while and have reached the time limit. Here's where things stand — feel free to send a message to continue or change direction."
+				noticeMsg := ai.AssistantMessage{Content: []ai.ContentBlock{ai.TextContent{Text: notice}}}
+				if err := p.mem.Append(persistCtx, memSession, noticeMsg); err != nil {
+					p.log.Warn("memory append timeout notice failed", "session_id", sessionID, "error", err)
+				}
+				out <- Event{Text: notice}
+				return
 			}
 			out <- evt
 			return

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -38,12 +38,7 @@ func run(ctx context.Context, cfg loopConfig, pg providers.ProviderGetter, histo
 }
 
 func runLoop(ctx context.Context, cfg loopConfig, pg providers.ProviderGetter, history []ai.Message, emit func(LoopEvent)) ([]ai.Message, error) {
-	maxTurns := cfg.MaxTurns
-	if maxTurns <= 0 {
-		maxTurns = 128
-	}
-
-	for turn := 1; turn <= maxTurns; turn++ {
+	for turn := 1; ; turn++ {
 		if emit != nil {
 			emit(TurnStarted{Turn: turn})
 		}
@@ -173,8 +168,6 @@ func runLoop(ctx context.Context, cfg loopConfig, pg providers.ProviderGetter, h
 			emit(TurnFinished{Turn: turn})
 		}
 	}
-
-	return history, fmt.Errorf("agent loop exceeded maximum turns (%d)", maxTurns)
 }
 
 // streamAssistant opens a provider stream, emits granular assistant events,

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -38,7 +38,14 @@ func run(ctx context.Context, cfg loopConfig, pg providers.ProviderGetter, histo
 }
 
 func runLoop(ctx context.Context, cfg loopConfig, pg providers.ProviderGetter, history []ai.Message, emit func(LoopEvent)) ([]ai.Message, error) {
+	loopStart := time.Now()
 	for turn := 1; ; turn++ {
+		if cfg.TurnNotify != nil {
+			if msg := cfg.TurnNotify(turn, time.Since(loopStart)); msg != nil {
+				history = append(history, ai.UserMessage{Content: *msg})
+			}
+		}
+
 		if emit != nil {
 			emit(TurnStarted{Turn: turn})
 		}

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -177,7 +177,7 @@ func TestRunMultiTurnLoop(t *testing.T) {
 		},
 	}
 
-	runner := newTestRunner(provider, WithMaxTurns(0)) // 0 = use default 128
+	runner := newTestRunner(provider)
 	// Override tools after construction — tests use the unexported run() path via Runner.
 	runner.tools = ToolSet{
 		"test_tool": func(_ context.Context, _ ai.ToolCall) (ai.TextContent, error) {
@@ -206,32 +206,6 @@ func TestRunMultiTurnLoop(t *testing.T) {
 	}
 	if countEvents[AssistantFinished](events) != 3 {
 		t.Fatalf("expected 3 AssistantFinished, got %d", countEvents[AssistantFinished](events))
-	}
-}
-
-func TestRunMaxTurnsEnforced(t *testing.T) {
-	provider := fakeProvider{
-		streamFunc: func(_ ai.Model, _ ai.Context, _ ai.StreamOptions) (providers.AssistantEventStream, error) {
-			out := providers.NewChannelEventStream(8)
-			go func() {
-				out.Emit(ai.EventToolCallDelta{ID: "call_1", Name: "test_tool", Arguments: "{}"})
-				out.Emit(ai.EventStop{Reason: ai.StopReasonToolUse})
-				out.Finish(nil)
-			}()
-			return out, nil
-		},
-	}
-
-	runner := newTestRunner(provider, WithMaxTurns(2))
-	runner.tools = ToolSet{
-		"test_tool": func(_ context.Context, _ ai.ToolCall) (ai.TextContent, error) {
-			return ai.TextContent{Text: "ok"}, nil
-		},
-	}
-
-	_, _, err := collectEvents(runner, []ai.Message{ai.UserMessage{Content: "go"}})
-	if err == nil {
-		t.Fatalf("expected max turns error")
 	}
 }
 

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"maps"
+	"time"
 
 	"github.com/CherryHQ/stella/pkg/ai"
 	"github.com/CherryHQ/stella/pkg/hooks"
@@ -23,6 +24,7 @@ type Runner struct {
 	hooks         *hooks.HookSet
 	hookMeta      hooks.HookMeta
 	toolLifecycle *ToolLifecycle
+	turnNotify    func(turn int, elapsed time.Duration) *string
 }
 
 // RunnerConfig holds the required fields for constructing a Runner.
@@ -66,6 +68,13 @@ func WithToolLifecycle(tl *ToolLifecycle) Option {
 	}
 }
 
+// WithTurnNotify sets a callback invoked at the start of each turn.
+// If it returns a non-nil string, that text is injected as a UserMessage
+// before the model call for that turn.
+func WithTurnNotify(fn func(turn int, elapsed time.Duration) *string) Option {
+	return func(r *Runner) { r.turnNotify = fn }
+}
+
 // NewRunner constructs a Runner with the given config and options.
 func NewRunner(cfg RunnerConfig, opts ...Option) (*Runner, error) {
 	if cfg.Providers == nil {
@@ -93,6 +102,12 @@ func NewRunner(cfg RunnerConfig, opts ...Option) (*Runner, error) {
 // Safe to call between Run invocations; not safe during a Run.
 func (r *Runner) SetHookMeta(meta hooks.HookMeta) {
 	r.hookMeta = meta
+}
+
+// SetTurnNotify updates the turn notify callback.
+// Safe to call between Run invocations; not safe during a Run.
+func (r *Runner) SetTurnNotify(fn func(turn int, elapsed time.Duration) *string) {
+	r.turnNotify = fn
 }
 
 // Run executes the agent loop from scratch.
@@ -124,5 +139,6 @@ func (r *Runner) loopConfig() loopConfig {
 		Hooks:           r.hooks,
 		HookMeta:        r.hookMeta,
 		ToolLifecycle:   r.toolLifecycle,
+		TurnNotify:      r.turnNotify,
 	}
 }

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -16,7 +16,6 @@ type Runner struct {
 	providers     providers.ProviderGetter
 	model         ai.Model
 	streamOptions ai.StreamOptions
-	maxTurns      int
 	tools         ToolSet
 	toolDefs      []ai.ToolDefinition
 	system        string
@@ -40,11 +39,6 @@ type Option func(*Runner)
 // WithStreamOptions sets stream options (API key, base URL, etc.).
 func WithStreamOptions(opts ai.StreamOptions) Option {
 	return func(r *Runner) { r.streamOptions = opts }
-}
-
-// WithMaxTurns sets the maximum number of loop turns.
-func WithMaxTurns(n int) Option {
-	return func(r *Runner) { r.maxTurns = n }
 }
 
 // WithSystem sets the system prompt.
@@ -123,7 +117,6 @@ func (r *Runner) loopConfig() loopConfig {
 	return loopConfig{
 		Model:           r.model,
 		StreamOptions:   r.streamOptions,
-		MaxTurns:        r.maxTurns,
 		Tools:           r.tools,
 		ToolDefinitions: r.toolDefs,
 		System:          r.system,

--- a/pkg/agent/runner_test.go
+++ b/pkg/agent/runner_test.go
@@ -41,7 +41,6 @@ func TestNewRunner_WithOptions(t *testing.T) {
 	r, err := NewRunner(
 		RunnerConfig{Providers: &fakeProviders{}},
 		WithSystem("you are helpful"),
-		WithMaxTurns(5),
 		WithHooks(hs, meta),
 		WithStreamOptions(ai.StreamOptions{}),
 	)
@@ -50,9 +49,6 @@ func TestNewRunner_WithOptions(t *testing.T) {
 	}
 	if r.system != "you are helpful" {
 		t.Errorf("expected system prompt, got %q", r.system)
-	}
-	if r.maxTurns != 5 {
-		t.Errorf("expected maxTurns=5, got %d", r.maxTurns)
 	}
 	if r.hooks != hs {
 		t.Error("expected hooks to be set")

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -29,6 +29,7 @@ type loopConfig struct {
 	// string, that text is injected as a UserMessage before the model call.
 	// Intended for progress nudges at milestone turns (e.g. 50, 80, 100).
 	// The injected messages are ephemeral — they exist only in the in-memory
-	// history slice and are not persisted to the session store.
+	// history slice and are not persisted to the session store. The model's
+	// responses to nudges ARE persisted, so they should read coherently standalone.
 	TurnNotify func(turn int, elapsed time.Duration) *string
 }

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"time"
 
 	"github.com/CherryHQ/stella/pkg/ai"
 	"github.com/CherryHQ/stella/pkg/hooks"
@@ -24,4 +25,10 @@ type loopConfig struct {
 	Hooks           *hooks.HookSet
 	HookMeta        hooks.HookMeta
 	ToolLifecycle   *ToolLifecycle
+	// TurnNotify is called at the start of each turn. If it returns a non-nil
+	// string, that text is injected as a UserMessage before the model call.
+	// Intended for progress nudges at milestone turns (e.g. 50, 80, 100).
+	// The injected messages are ephemeral — they exist only in the in-memory
+	// history slice and are not persisted to the session store.
+	TurnNotify func(turn int, elapsed time.Duration) *string
 }

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -17,7 +17,6 @@ type ToolSet map[string]ToolFunc
 type loopConfig struct {
 	Model           ai.Model
 	StreamOptions   ai.StreamOptions
-	MaxTurns        int
 	Tools           ToolSet
 	ToolDefinitions []ai.ToolDefinition
 	System          string

--- a/plugins/reflect/reviewer.go
+++ b/plugins/reflect/reviewer.go
@@ -55,7 +55,6 @@ func newReviewer(cfg reviewerConfig) (*reviewer, error) {
 		Tools:           agent.ToolSetFromRegistry(reg),
 		ToolDefinitions: reg.Definitions(),
 	},
-		agent.WithMaxTurns(3),
 		agent.WithSystem(system),
 	)
 	if err != nil {

--- a/plugins/reflect/reviewer.go
+++ b/plugins/reflect/reviewer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/CherryHQ/stella/pkg/agent"
 	"github.com/CherryHQ/stella/pkg/ai"
@@ -64,7 +65,12 @@ func newReviewer(cfg reviewerConfig) (*reviewer, error) {
 	return &reviewer{runner: r}, nil
 }
 
+const reviewerTimeout = 2 * time.Minute
+
 func (r *reviewer) review(ctx context.Context, conversationText string) (reviewResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, reviewerTimeout)
+	defer cancel()
+
 	history := []ai.Message{
 		ai.UserMessage{Content: conversationText},
 	}

--- a/plugins/tools/agent/agent.go
+++ b/plugins/tools/agent/agent.go
@@ -233,7 +233,6 @@ func (t *AgentTool) runSubAgent(parentCtx context.Context, tc agentTaskConfig) (
 		}
 	}
 
-	// Two independent limits bound every subagent run:
 	// The wall-clock timeout is the only limit applied to subagent runs.
 	// It kills the run if it takes too long regardless of what the agent is doing.
 	// Configurable via runner.subagent_timeout (admin settings) or per-preset

--- a/plugins/tools/agent/agent.go
+++ b/plugins/tools/agent/agent.go
@@ -21,9 +21,6 @@ import (
 const (
 	agentToolName = "agent"
 
-	// defaultMaxTurns is a fixed internal safety rail. It is not user-configurable;
-	// use the timeout to bound long subagent tasks by wall-clock time instead.
-	defaultMaxTurns = 50
 	// defaultTimeout is the wall-clock deadline applied to every subagent run.
 	// Overridable globally via AgentConfig.DefaultTimeout (runner.subagent_timeout
 	// in admin settings) or per-preset via the timeout front-matter field.
@@ -237,12 +234,10 @@ func (t *AgentTool) runSubAgent(parentCtx context.Context, tc agentTaskConfig) (
 	}
 
 	// Two independent limits bound every subagent run:
-	//   1. Wall-clock timeout: kills the run if it takes too long regardless of
-	//      what the agent is doing. Configurable via runner.subagent_timeout
-	//      (admin settings) or per-preset timeout front-matter. Default: 15m.
-	//   2. Turn limit (defaultMaxTurns): a fixed internal safety rail that stops
-	//      a runaway LLM loop after N turns. Not user-configurable by design —
-	//      use the timeout to bound long tasks instead.
+	// The wall-clock timeout is the only limit applied to subagent runs.
+	// It kills the run if it takes too long regardless of what the agent is doing.
+	// Configurable via runner.subagent_timeout (admin settings) or per-preset
+	// timeout front-matter. Default: 15m.
 	timeout := t.cfg.subagentTimeout()
 	if tc.TimeoutSeconds > 0 {
 		timeout = time.Duration(tc.TimeoutSeconds) * time.Second
@@ -283,7 +278,6 @@ func (t *AgentTool) runSubAgent(parentCtx context.Context, tc agentTaskConfig) (
 		ToolDefinitions: toolDefs,
 	},
 		agent.WithStreamOptions(ai.StreamOptions{APIKey: t.cfg.APIKey, BaseURL: t.cfg.BaseURL}),
-		agent.WithMaxTurns(defaultMaxTurns),
 		agent.WithSystem(system),
 		agent.WithHooks(t.cfg.Hooks, subMeta),
 		agent.WithToolLifecycle(t.cfg.ToolLifecycle),
@@ -296,7 +290,7 @@ func (t *AgentTool) runSubAgent(parentCtx context.Context, tc agentTaskConfig) (
 		ai.UserMessage{Content: tc.Task},
 	}
 
-	log.Info("subagent started", "preset", tc.Preset, "model", model.Name, "max_turns", defaultMaxTurns, "timeout", timeout)
+	log.Info("subagent started", "preset", tc.Preset, "model", model.Name, "timeout", timeout)
 	start := time.Now()
 
 	t.emit(SubAgentStarted{TaskID: tc.ID, Preset: tc.Preset})


### PR DESCRIPTION
## Summary

- **Remove `MaxTurns` entirely** — the hard turn cap (50 turns) was causing abrupt agent session termination with a raw error. All agent paths (main runner, subagents, reviewer) now run as infinite loops bounded only by context cancellation.
- **Add 30m wall-clock timeout to main agent** — `GoRunner.Chat()` wraps the context with `context.WithTimeout` (30m default, configurable via `GoRunnerConfig.ChatTimeout`). Subagents already had a 15m timeout.
- **Milestone turn nudges** — at turns 50, 80, and 100 the loop injects a `UserMessage` telling the model how long it has been running and asking it to report progress or suggest alternatives. This gives the model a chance to summarize before the timeout fires.
- **Friendly timeout UX** — when `DeadlineExceeded` fires, `pool_chat` intercepts the error and emits a human-readable status notice instead of a raw error. The session remains intact so the user can send a new message to continue.

## Changes

| File | What changed |
|---|---|
| `pkg/agent/types.go` | Add `TurnNotify` field to `loopConfig` |
| `pkg/agent/runner.go` | Add `WithTurnNotify` option + `SetTurnNotify` method; remove `WithMaxTurns` + `maxTurns` field |
| `pkg/agent/loop.go` | Infinite `for` loop (no turn cap); call `TurnNotify` at each turn start |
| `internal/agent/gorunner.go` | Add `ChatTimeout` config field; wrap `Chat()` context with 30m timeout; wire milestone `TurnNotify` at turns 50/80/100; remove `maxAgentLoopTurns` |
| `internal/agent/pool_chat.go` | Intercept `context.DeadlineExceeded` → emit friendly notice, persist it, return cleanly |
| `plugins/tools/agent/agent.go` | Remove `defaultMaxTurns` and `WithMaxTurns` from subagent runner |
| `plugins/reflect/reviewer.go` | Remove `WithMaxTurns(3)`; reviewer relies on caller context timeout |
| Tests | Remove `TestRunMaxTurnsEnforced` and all `WithMaxTurns` references |

## Test plan

- [ ] Build passes: `mise run build`
- [ ] Unit tests pass: `go test ./pkg/agent/... ./internal/agent/...`
- [ ] Manual: start a long-running agent task and verify it runs past 50 turns
- [ ] Manual: verify turn 50/80/100 progress messages appear in the conversation
- [ ] Manual: let a session hit 30m timeout and verify the friendly notice appears instead of an error