### PR TITLE
feat(email): add MessageID/FromName/FromAddr, InReplyTo, and mark command

### DIFF
--- a/cmd/stella/email.go
+++ b/cmd/stella/email.go
@@ -35,6 +35,7 @@ func emailCommand() *ucli.Command {
 			emailListCommand(),
 			emailReadCommand(),
 			emailSendCommand(),
+			emailMarkCommand(),
 		},
 	}
 }
@@ -618,6 +619,7 @@ func emailSendCommand() *ucli.Command {
 			&ucli.StringSliceFlag{Name: "attach", Usage: "Attachment file path(s)"},
 			&ucli.StringFlag{Name: "from", Usage: "Override From address"},
 			&ucli.StringFlag{Name: "reply-to", Usage: "Reply-To address"},
+			&ucli.StringFlag{Name: "in-reply-to", Usage: "Message-ID of the message being replied to (sets In-Reply-To header)"},
 			&ucli.BoolFlag{Name: "dry-run", Usage: "Print composed message without sending"},
 		},
 		Action: func(c *ucli.Context) error {
@@ -662,6 +664,7 @@ func emailSendCommand() *ucli.Command {
 				Attachments: c.StringSlice("attach"),
 				From:        c.String("from"),
 				ReplyTo:     c.String("reply-to"),
+				InReplyTo:   c.String("in-reply-to"),
 			}
 
 			if c.Bool("dry-run") {
@@ -673,6 +676,52 @@ func emailSendCommand() *ucli.Command {
 				return err
 			}
 			fmt.Println("Email sent successfully.")
+			return nil
+		},
+	}
+}
+
+func emailMarkCommand() *ucli.Command {
+	return &ucli.Command{
+		Name:      "mark",
+		Usage:     "Add or remove the \\Seen flag on a message",
+		ArgsUsage: "<uid>",
+		Flags: []ucli.Flag{
+			&ucli.StringFlag{Name: "account", Aliases: []string{"a"}, Usage: "Account name"},
+			&ucli.StringFlag{Name: "folder", Usage: "Folder name", Value: "INBOX"},
+			&ucli.BoolFlag{Name: "seen", Usage: "Mark message as read"},
+			&ucli.BoolFlag{Name: "unseen", Usage: "Mark message as unread"},
+		},
+		Action: func(c *ucli.Context) error {
+			uidStr := c.Args().First()
+			if uidStr == "" {
+				return fmt.Errorf("uid is required")
+			}
+			var uid uint32
+			if _, err := fmt.Sscan(uidStr, &uid); err != nil {
+				return fmt.Errorf("invalid uid %q: %w", uidStr, err)
+			}
+			if c.Bool("seen") == c.Bool("unseen") {
+				return fmt.Errorf("exactly one of --seen or --unseen is required")
+			}
+
+			cfg, err := loadEmailConfig(c.Context)
+			if err != nil {
+				return err
+			}
+			acct, err := cfg.Resolve(c.String("account"))
+			if err != nil {
+				return err
+			}
+
+			if err := email.MarkSeen(acct, c.String("folder"), uid, c.Bool("seen")); err != nil {
+				return err
+			}
+			if c.Bool("seen") {
+				fmt.Printf("Message %d marked as read.\n", uid)
+			} else {
+				fmt.Printf("Message %d marked as unread.\n", uid)
+			}
 			return nil
 		},
 	}

--- a/dprint.json
+++ b/dprint.json
@@ -5,7 +5,7 @@
   "dockerfile": {},
   "markup": {},
   "yaml": {},
-  "excludes": ["**/*-lock.json", "web/**"],
+  "excludes": ["**/*-lock.json", "web/**", "**/scheduler-jobs.json"],
   "plugins": [
     "https://plugins.dprint.dev/json-0.21.3.wasm",
     "https://plugins.dprint.dev/markdown-0.21.1.wasm",

--- a/dprint.json
+++ b/dprint.json
@@ -5,7 +5,7 @@
   "dockerfile": {},
   "markup": {},
   "yaml": {},
-  "excludes": ["**/*-lock.json", "web/**", "**/scheduler-jobs.json"],
+  "excludes": ["**/*-lock.json", "web/**"],
   "plugins": [
     "https://plugins.dprint.dev/json-0.21.3.wasm",
     "https://plugins.dprint.dev/markdown-0.21.1.wasm",

--- a/internal/email/imap.go
+++ b/internal/email/imap.go
@@ -369,6 +369,35 @@ func safeDestPath(absDir, filename string) (string, error) {
 	return "", fmt.Errorf("cannot find a free filename for %q", filename)
 }
 
+// MarkSeen adds or removes the \Seen flag on a message identified by UID.
+// seen=true marks the message as read; seen=false marks it as unread.
+func MarkSeen(acct EmailAccount, folder string, uid uint32, seen bool) error {
+	c, err := dialIMAP(acct)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = c.Logout().Wait(); _ = c.Close() }()
+
+	folder = cmp.Or(folder, "INBOX")
+	if _, err := c.Select(folder, nil).Wait(); err != nil {
+		return fmt.Errorf("select %q: %w", folder, err)
+	}
+
+	op := imap.StoreFlagsDel
+	if seen {
+		op = imap.StoreFlagsAdd
+	}
+	storeFlags := &imap.StoreFlags{
+		Op:     op,
+		Silent: true,
+		Flags:  []imap.Flag{imap.FlagSeen},
+	}
+	if _, err := c.Store(imap.UIDSetNum(imap.UID(uid)), storeFlags, nil).Collect(); err != nil {
+		return fmt.Errorf("store flags uid=%d: %w", uid, err)
+	}
+	return nil
+}
+
 // buildEnvelope converts a FetchMessageBuffer into our Envelope type.
 func buildEnvelope(msg *imapclient.FetchMessageBuffer) Envelope {
 	env := Envelope{
@@ -380,9 +409,12 @@ func buildEnvelope(msg *imapclient.FetchMessageBuffer) Envelope {
 		e := msg.Envelope
 		env.Subject = e.Subject
 		env.Date = e.Date
+		env.MessageID = e.MessageID
 
 		if len(e.From) > 0 {
 			env.From = formatAddress(e.From[0])
+			env.FromName = e.From[0].Name
+			env.FromAddr = e.From[0].Mailbox + "@" + e.From[0].Host
 		}
 		for _, addr := range e.To {
 			env.To = append(env.To, formatAddress(addr))

--- a/internal/email/message.go
+++ b/internal/email/message.go
@@ -5,7 +5,10 @@ import "time"
 // Envelope holds metadata about an email message.
 type Envelope struct {
 	UID            uint32    `json:"uid"`
+	MessageID      string    `json:"message_id,omitempty"`
 	From           string    `json:"from"`
+	FromName       string    `json:"from_name,omitempty"`
+	FromAddr       string    `json:"from_addr,omitempty"`
 	To             []string  `json:"to"`
 	Subject        string    `json:"subject"`
 	Date           time.Time `json:"date"`

--- a/internal/email/smtp.go
+++ b/internal/email/smtp.go
@@ -18,6 +18,7 @@ type SendOptions struct {
 	Attachments []string // file paths
 	From        string   // override sender
 	ReplyTo     string
+	InReplyTo   string // Message-ID of the message being replied to
 }
 
 // Send composes and sends an email via SMTP using the provided account configuration.
@@ -64,6 +65,10 @@ func Send(acct EmailAccount, opts SendOptions) error {
 		if err := msg.ReplyTo(opts.ReplyTo); err != nil {
 			return fmt.Errorf("set Reply-To header: %w", err)
 		}
+	}
+
+	if opts.InReplyTo != "" {
+		msg.SetGenHeader("In-Reply-To", opts.InReplyTo)
 	}
 
 	for _, path := range opts.Attachments {
@@ -128,6 +133,9 @@ func FormatDryRun(acct EmailAccount, opts SendOptions) string {
 	}
 	if opts.ReplyTo != "" {
 		fmt.Fprintf(&sb, "Reply-To: %s\n", opts.ReplyTo)
+	}
+	if opts.InReplyTo != "" {
+		fmt.Fprintf(&sb, "In-Reply-To: %s\n", opts.InReplyTo)
 	}
 	fmt.Fprintf(&sb, "Subject: %s\n", opts.Subject)
 	fmt.Fprintf(&sb, "Content-Type: %s\n", contentType)


### PR DESCRIPTION
## Summary

- Add `MessageID`, `FromName`, and `FromAddr` fields to `Envelope` for richer message metadata
- Add `--in-reply-to` flag to `email send` to set the `In-Reply-To` header for threaded replies
- Add `email mark` subcommand to toggle `\Seen` flag (read/unread) on a message by UID
- Exclude `scheduler-jobs.json` from dprint formatting

## Test plan

- [ ] `stella email send --in-reply-to "<msg-id@example.com>" ...` sets the `In-Reply-To` header (verify with `--dry-run`)
- [ ] `stella email mark --seen <uid>` marks a message as read
- [ ] `stella email mark --unseen <uid>` marks a message as unread
- [ ] `stella email mark` without `--seen`/`--unseen` (or with both) returns an error
- [ ] `stella email list` JSON output includes `message_id`, `from_name`, `from_addr`