### PR TITLE
feat: sync skill DB+disk and expose skill_dir in sandbox

### DIFF
--- a/cmd/stella/commands.go
+++ b/cmd/stella/commands.go
@@ -106,17 +106,36 @@ func setup(parent context.Context, gateway bool) (*setupResult, error) {
 		return nil, fmt.Errorf("copy stella cli into sandbox path: %w", err)
 	}
 
-	if err := builtinres.ExtractSkills(filepath.Join(config.StellaHome(), "skills")); err != nil {
-		return nil, fmt.Errorf("extract builtin skills: %w", err)
-	}
+	rawSkillStore := skills.New(db)
+	skillStore := skills.NewDiskSyncStore(rawSkillStore, func(scope, agentID string, userID int64) string {
+		base := config.StellaHome()
+		switch scope {
+		case "system":
+			return filepath.Join(base, ".agents", "skills")
+		case "agent":
+			if agentID == "" {
+				return ""
+			}
+			return filepath.Join(base, "workspaces", agentID, ".agents", "skills")
+		case "user":
+			if agentID == "" || userID == 0 {
+				return ""
+			}
+			return filepath.Join(base, "workspaces", agentID, "users", fmt.Sprintf("%d", userID), ".agents", "skills")
+		default:
+			return ""
+		}
+	})
 
-	skillStore := skills.New(db)
 	builtinSkillsFS, ok := builtinres.SubFS(builtinres.KindSkill)
 	if !ok {
 		return nil, fmt.Errorf("builtin skills FS unavailable")
 	}
 	if err := skills.SyncBuiltin(parent, skillStore, builtinSkillsFS); err != nil {
 		return nil, fmt.Errorf("sync builtin skills: %w", err)
+	}
+	if err := skillStore.SyncAllToDisk(parent); err != nil {
+		return nil, fmt.Errorf("sync skills to disk: %w", err)
 	}
 
 	backgroundTasks := &sync.WaitGroup{}

--- a/internal/agent/paths.go
+++ b/internal/agent/paths.go
@@ -79,7 +79,7 @@ func (p runnerPaths) stellaSkillsDir() string {
 }
 
 func (p runnerPaths) stellaAgentsDir() string {
-	return filepath.Join(p.StellaHome, "agents")
+	return filepath.Join(p.StellaHome, ".agents", "agents")
 }
 
 // sandboxProcessEnv builds the baseline process environment injected into

--- a/internal/agent/paths.go
+++ b/internal/agent/paths.go
@@ -20,9 +20,11 @@ type runnerPaths struct {
 // Sandbox execution is defined entirely by the user-scoped writable root and an
 // internal working directory derived from that root.
 type sandboxPaths struct {
-	StellaHome string
-	UserRoot   string
-	WorkDir    string
+	StellaHome  string
+	UserRoot    string
+	WorkDir     string
+	AgentRoot   string
+	ProjectRoot string
 }
 
 // resolveRunnerPaths converts GoRunnerConfig into the minimal path set the
@@ -58,9 +60,11 @@ func resolveSandboxPaths(cfg GoRunnerConfig) (sandboxPaths, error) {
 	workDir := resolveSandboxWorkingDir(cfg, userRoot)
 
 	return sandboxPaths{
-		StellaHome: stellaHome,
-		UserRoot:   userRoot,
-		WorkDir:    workDir,
+		StellaHome:  stellaHome,
+		UserRoot:    userRoot,
+		WorkDir:     workDir,
+		AgentRoot:   cfg.AgentRoot,
+		ProjectRoot: cfg.ProjectRoot,
 	}, nil
 }
 
@@ -71,7 +75,7 @@ func resolveToolsBinDir(_ runnerPaths, _ string) string {
 }
 
 func (p runnerPaths) stellaSkillsDir() string {
-	return filepath.Join(p.StellaHome, "skills")
+	return filepath.Join(p.StellaHome, ".agents", "skills")
 }
 
 func (p runnerPaths) stellaAgentsDir() string {

--- a/internal/agent/sandbox_backend.go
+++ b/internal/agent/sandbox_backend.go
@@ -135,11 +135,18 @@ func runnerFilesystemPolicy(paths sandboxPaths) sandbox.FilesystemPolicy {
 // path (same-path strategy) so that skill_dir values returned by the skills
 // tool are valid inside the sandbox without any translation.
 func skillMountsForSandbox(paths sandboxPaths) []string {
+	seen := map[string]bool{}
 	var dirs []string
 	for _, base := range []string{paths.StellaHome, paths.AgentRoot, paths.UserRoot, paths.ProjectRoot} {
-		if base != "" {
-			dirs = append(dirs, filepath.Join(base, ".agents", "skills"))
+		if base == "" {
+			continue
 		}
+		dir := filepath.Join(base, ".agents", "skills")
+		if seen[dir] {
+			continue
+		}
+		seen[dir] = true
+		dirs = append(dirs, dir)
 	}
 	return dirs
 }

--- a/internal/agent/sandbox_backend.go
+++ b/internal/agent/sandbox_backend.go
@@ -124,9 +124,24 @@ var sessionRegistry = map[string]sessionFactory{
 
 func runnerFilesystemPolicy(paths sandboxPaths) sandbox.FilesystemPolicy {
 	return sandbox.FilesystemPolicy{
-		WorkspaceRoot: paths.UserRoot,
-		WorkingDir:    paths.WorkDir,
+		WorkspaceRoot:       paths.UserRoot,
+		WorkingDir:          paths.WorkDir,
+		ExtraReadOnlyMounts: skillMountsForSandbox(paths),
 	}
+}
+
+// skillMountsForSandbox returns host paths for all skill directories that must
+// be mounted read-only in the sandbox. Each path is mounted at its exact host
+// path (same-path strategy) so that skill_dir values returned by the skills
+// tool are valid inside the sandbox without any translation.
+func skillMountsForSandbox(paths sandboxPaths) []string {
+	var dirs []string
+	for _, base := range []string{paths.StellaHome, paths.AgentRoot, paths.UserRoot, paths.ProjectRoot} {
+		if base != "" {
+			dirs = append(dirs, filepath.Join(base, ".agents", "skills"))
+		}
+	}
+	return dirs
 }
 
 // buildSandboxEnv constructs the Policy.Env map for a sandbox session.

--- a/internal/resources/skills/system/tap-web/SKILL.md
+++ b/internal/resources/skills/system/tap-web/SKILL.md
@@ -1,14 +1,10 @@
 ---
-name: tap-web
+description: Access websites, search the web, and extract clean content using the `tap` CLI. Supports structured site scripts, readable page extraction, and browser automation for tabs, screenshots, forms, cookies, JavaScript evaluation, and network capture. Use for web lookup, page reading, content extraction, browser interaction, authenticated sessions, request interception, or CDP-connected desktop apps.
 metadata:
   author: vaayne/tap
-  version: "v0.4.6"
-description: >
-  Access websites, search the web, and extract clean content using the `tap` CLI.
-  Supports structured site scripts, readable page extraction, and browser automation
-  for tabs, screenshots, forms, cookies, JavaScript evaluation, and network capture.
-  Use for web lookup, page reading, content extraction, browser interaction,
-  authenticated sessions, request interception, or CDP-connected desktop apps.
+  owner_plugin: tool/tap-web
+  version: v0.4.4
+name: tap-web
 ---
 
 # tap-web
@@ -180,21 +176,6 @@ Preferred order:
 5. `tap browser text`
 6. targeted `tap browser evaluate`
 7. screenshot
-
-## Platform-specific tool selection
-
-### Search
-
-When searching the web, prefer `site exa/search` if available, before falling back to `tap fetch` on a search engine results page.
-
-### Twitter / X
-
-- **Get content**: Try `tap fetch --lp <url>` first. If it fails or returns incomplete data, try `site twitter/getxapi-article` or `site twitter/getxapi-tweet-detail`.
-- **Post content**: Use `site twitter post-tweet`.
-
-### WeChat Official Accounts (微信公众号)
-
-When accessing `https://mp.weixin.qq.com/` articles, prefer `tap fetch --lp <url>` for fast JS rendering without Chrome auth flows.
 
 ## References
 

--- a/internal/resources/skills/system/tap-web/SKILL.md
+++ b/internal/resources/skills/system/tap-web/SKILL.md
@@ -1,10 +1,14 @@
 ---
-description: Access websites, search the web, and extract clean content using the `tap` CLI. Supports structured site scripts, readable page extraction, and browser automation for tabs, screenshots, forms, cookies, JavaScript evaluation, and network capture. Use for web lookup, page reading, content extraction, browser interaction, authenticated sessions, request interception, or CDP-connected desktop apps.
+name: tap-web
 metadata:
   author: vaayne/tap
-  owner_plugin: tool/tap-web
-  version: v0.4.4
-name: tap-web
+  version: "v0.4.6"
+description: >
+  Access websites, search the web, and extract clean content using the `tap` CLI.
+  Supports structured site scripts, readable page extraction, and browser automation
+  for tabs, screenshots, forms, cookies, JavaScript evaluation, and network capture.
+  Use for web lookup, page reading, content extraction, browser interaction,
+  authenticated sessions, request interception, or CDP-connected desktop apps.
 ---
 
 # tap-web
@@ -176,6 +180,21 @@ Preferred order:
 5. `tap browser text`
 6. targeted `tap browser evaluate`
 7. screenshot
+
+## Platform-specific tool selection
+
+### Search
+
+When searching the web, prefer `site exa/search` if available, before falling back to `tap fetch` on a search engine results page.
+
+### Twitter / X
+
+- **Get content**: Try `tap fetch --lp <url>` first. If it fails or returns incomplete data, try `site twitter/getxapi-article` or `site twitter/getxapi-tweet-detail`.
+- **Post content**: Use `site twitter post-tweet`.
+
+### WeChat Official Accounts (微信公众号)
+
+When accessing `https://mp.weixin.qq.com/` articles, prefer `tap fetch --lp <url>` for fast JS rendering without Chrome auth flows.
 
 ## References
 

--- a/internal/skills/disk_sync.go
+++ b/internal/skills/disk_sync.go
@@ -1,0 +1,172 @@
+package skills
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// PathResolver maps a skill's (scope, agentID, userID) to the base directory
+// where the skill's subdirectory lives on disk (e.g. "$STELLA_HOME/.agents/skills").
+// Return empty string to skip disk mirroring for a given scope.
+type PathResolver func(scope, agentID string, userID int64) string
+
+// DiskSyncStore wraps a Store and mirrors every write to disk so that skill
+// scripts can be executed from the filesystem inside a sandbox.
+//
+// Write ordering is disk-first: if the disk write fails the DB write is skipped
+// and the error is propagated. On crash after disk write but before DB write,
+// MigrateFilesystem at next startup re-imports the orphaned disk files.
+//
+// For Delete, DB is removed first (disk after) to avoid orphaned skill
+// directories re-importing on next startup as if they were new skills.
+type DiskSyncStore struct {
+	Store
+	resolver PathResolver
+}
+
+// NewDiskSyncStore wraps inner with disk mirroring using the given resolver.
+func NewDiskSyncStore(inner Store, resolver PathResolver) *DiskSyncStore {
+	return &DiskSyncStore{Store: inner, resolver: resolver}
+}
+
+func (d *DiskSyncStore) Create(ctx context.Context, sk Skill, files map[string]string) (string, error) {
+	base := d.resolver(sk.Scope, sk.AgentID, sk.UserID)
+	if base != "" {
+		if err := d.writeFilesToDisk(base, sk.Name, files); err != nil {
+			return "", fmt.Errorf("disk_sync create %q: %w", sk.Name, err)
+		}
+	}
+	return d.Store.Create(ctx, sk, files)
+}
+
+func (d *DiskSyncStore) UpsertFile(ctx context.Context, skillID, path, content string) error {
+	sk, err := d.findByID(ctx, skillID)
+	if err != nil {
+		return err
+	}
+	if sk != nil {
+		base := d.resolver(sk.Scope, sk.AgentID, sk.UserID)
+		if base != "" {
+			diskPath := filepath.Join(base, sk.Name, filepath.FromSlash(path))
+			if err := writeFile(diskPath, content); err != nil {
+				return fmt.Errorf("disk_sync upsert file %q in skill %q: %w", path, sk.Name, err)
+			}
+		}
+	}
+	return d.Store.UpsertFile(ctx, skillID, path, content)
+}
+
+func (d *DiskSyncStore) DeleteFile(ctx context.Context, skillID, path string) error {
+	sk, err := d.findByID(ctx, skillID)
+	if err != nil {
+		return err
+	}
+	if sk != nil {
+		base := d.resolver(sk.Scope, sk.AgentID, sk.UserID)
+		if base != "" {
+			diskPath := filepath.Join(base, sk.Name, filepath.FromSlash(path))
+			if err := os.Remove(diskPath); err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("disk_sync delete file %q in skill %q: %w", path, sk.Name, err)
+			}
+		}
+	}
+	return d.Store.DeleteFile(ctx, skillID, path)
+}
+
+// Delete removes the DB row first, then removes the disk directory.
+// DB-first ordering prevents MigrateFilesystem from re-importing orphaned dirs.
+func (d *DiskSyncStore) Delete(ctx context.Context, id string) error {
+	sk, err := d.findByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	if err := d.Store.Delete(ctx, id); err != nil {
+		return err
+	}
+	if sk != nil {
+		base := d.resolver(sk.Scope, sk.AgentID, sk.UserID)
+		if base != "" {
+			skillDir := filepath.Join(base, sk.Name)
+			if err := os.RemoveAll(skillDir); err != nil {
+				// Log but don't fail — DB row is already gone; dir is orphaned but harmless.
+				_ = err
+			}
+		}
+	}
+	return nil
+}
+
+// SyncAllToDisk materializes every skill in the DB to disk, writing only files
+// that are absent on disk. Called once at startup to bring pre-DiskSyncStore
+// DB-only skills onto the filesystem.
+func (d *DiskSyncStore) SyncAllToDisk(ctx context.Context) error {
+	all, err := d.ListAll(ctx)
+	if err != nil {
+		return fmt.Errorf("disk_sync sync_all: list: %w", err)
+	}
+	for _, sk := range all {
+		base := d.resolver(sk.Scope, sk.AgentID, sk.UserID)
+		if base == "" {
+			continue
+		}
+		skillDir := filepath.Join(base, sk.Name)
+		paths, err := d.ListFiles(ctx, sk.ID)
+		if err != nil {
+			return fmt.Errorf("disk_sync sync_all: list files for %q: %w", sk.Name, err)
+		}
+		for _, p := range paths {
+			diskPath := filepath.Join(skillDir, filepath.FromSlash(p))
+			if _, statErr := os.Stat(diskPath); statErr == nil {
+				continue // already on disk
+			}
+			content, err := d.LoadFile(ctx, sk.ID, p)
+			if err != nil {
+				return fmt.Errorf("disk_sync sync_all: load %q in %q: %w", p, sk.Name, err)
+			}
+			if err := writeFile(diskPath, content); err != nil {
+				return fmt.Errorf("disk_sync sync_all: write %q in %q: %w", p, sk.Name, err)
+			}
+		}
+	}
+	return nil
+}
+
+func (d *DiskSyncStore) ExpireDrafts(ctx context.Context, before time.Time) error {
+	return d.Store.ExpireDrafts(ctx, before)
+}
+
+// findByID looks up a skill by ID using ListAll. This is only called on write
+// paths which are not hot.
+func (d *DiskSyncStore) findByID(ctx context.Context, id string) (*Skill, error) {
+	all, err := d.ListAll(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("disk_sync: look up skill %q: %w", id, err)
+	}
+	for i := range all {
+		if all[i].ID == id {
+			return &all[i], nil
+		}
+	}
+	return nil, nil
+}
+
+func (d *DiskSyncStore) writeFilesToDisk(base, skillName string, files map[string]string) error {
+	skillDir := filepath.Join(base, skillName)
+	for p, content := range files {
+		diskPath := filepath.Join(skillDir, filepath.FromSlash(p))
+		if err := writeFile(diskPath, content); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeFile(path, content string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(content), 0o644)
+}

--- a/internal/skills/disk_sync.go
+++ b/internal/skills/disk_sync.go
@@ -3,8 +3,10 @@ package skills
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -50,7 +52,10 @@ func (d *DiskSyncStore) UpsertFile(ctx context.Context, skillID, path, content s
 	if sk != nil {
 		base := d.resolver(sk.Scope, sk.AgentID, sk.UserID)
 		if base != "" {
-			diskPath := filepath.Join(base, sk.Name, filepath.FromSlash(path))
+			diskPath, err := safeDiskPath(base, sk.Name, filepath.FromSlash(path))
+			if err != nil {
+				return fmt.Errorf("disk_sync upsert file %q in skill %q: %w", path, sk.Name, err)
+			}
 			if err := writeFile(diskPath, content); err != nil {
 				return fmt.Errorf("disk_sync upsert file %q in skill %q: %w", path, sk.Name, err)
 			}
@@ -67,7 +72,10 @@ func (d *DiskSyncStore) DeleteFile(ctx context.Context, skillID, path string) er
 	if sk != nil {
 		base := d.resolver(sk.Scope, sk.AgentID, sk.UserID)
 		if base != "" {
-			diskPath := filepath.Join(base, sk.Name, filepath.FromSlash(path))
+			diskPath, err := safeDiskPath(base, sk.Name, filepath.FromSlash(path))
+			if err != nil {
+				return fmt.Errorf("disk_sync delete file %q in skill %q: %w", path, sk.Name, err)
+			}
 			if err := os.Remove(diskPath); err != nil && !os.IsNotExist(err) {
 				return fmt.Errorf("disk_sync delete file %q in skill %q: %w", path, sk.Name, err)
 			}
@@ -89,10 +97,12 @@ func (d *DiskSyncStore) Delete(ctx context.Context, id string) error {
 	if sk != nil {
 		base := d.resolver(sk.Scope, sk.AgentID, sk.UserID)
 		if base != "" {
-			skillDir := filepath.Join(base, sk.Name)
-			if err := os.RemoveAll(skillDir); err != nil {
-				// Log but don't fail — DB row is already gone; dir is orphaned but harmless.
-				_ = err
+			skillDir, pathErr := safeDiskPath(base, sk.Name)
+			if pathErr == nil {
+				if err := os.RemoveAll(skillDir); err != nil {
+					slog.WarnContext(ctx, "disk_sync: failed to remove skill dir after DB delete",
+						"skill", sk.Name, "dir", skillDir, "err", err)
+				}
 			}
 		}
 	}
@@ -112,13 +122,21 @@ func (d *DiskSyncStore) SyncAllToDisk(ctx context.Context) error {
 		if base == "" {
 			continue
 		}
-		skillDir := filepath.Join(base, sk.Name)
+		skillDir, pathErr := safeDiskPath(base, sk.Name)
+		if pathErr != nil {
+			slog.WarnContext(ctx, "disk_sync sync_all: skipping skill with unsafe name", "name", sk.Name, "err", pathErr)
+			continue
+		}
 		paths, err := d.ListFiles(ctx, sk.ID)
 		if err != nil {
 			return fmt.Errorf("disk_sync sync_all: list files for %q: %w", sk.Name, err)
 		}
 		for _, p := range paths {
-			diskPath := filepath.Join(skillDir, filepath.FromSlash(p))
+			diskPath, pathErr := safeDiskPath(skillDir, filepath.FromSlash(p))
+			if pathErr != nil {
+				slog.WarnContext(ctx, "disk_sync sync_all: skipping file with unsafe path", "skill", sk.Name, "path", p, "err", pathErr)
+				continue
+			}
 			if _, statErr := os.Stat(diskPath); statErr == nil {
 				continue // already on disk
 			}
@@ -132,10 +150,6 @@ func (d *DiskSyncStore) SyncAllToDisk(ctx context.Context) error {
 		}
 	}
 	return nil
-}
-
-func (d *DiskSyncStore) ExpireDrafts(ctx context.Context, before time.Time) error {
-	return d.Store.ExpireDrafts(ctx, before)
 }
 
 // ListKnowledge forwards to the inner store if it implements KnowledgeStore.
@@ -172,14 +186,31 @@ func (d *DiskSyncStore) findByID(ctx context.Context, id string) (*Skill, error)
 }
 
 func (d *DiskSyncStore) writeFilesToDisk(base, skillName string, files map[string]string) error {
-	skillDir := filepath.Join(base, skillName)
+	skillDir, err := safeDiskPath(base, skillName)
+	if err != nil {
+		return err
+	}
 	for p, content := range files {
-		diskPath := filepath.Join(skillDir, filepath.FromSlash(p))
+		diskPath, err := safeDiskPath(skillDir, filepath.FromSlash(p))
+		if err != nil {
+			return err
+		}
 		if err := writeFile(diskPath, content); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// safeDiskPath resolves a file path under base and ensures it doesn't escape
+// via directory traversal (e.g. "../" in skill name or file path).
+func safeDiskPath(base string, parts ...string) (string, error) {
+	joined := filepath.Join(append([]string{base}, parts...)...)
+	cleaned := filepath.Clean(joined)
+	if !strings.HasPrefix(cleaned, filepath.Clean(base)+string(filepath.Separator)) && cleaned != filepath.Clean(base) {
+		return "", fmt.Errorf("path %q escapes base %q", cleaned, base)
+	}
+	return cleaned, nil
 }
 
 func writeFile(path, content string) error {

--- a/internal/skills/disk_sync.go
+++ b/internal/skills/disk_sync.go
@@ -1,6 +1,7 @@
 package skills
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
@@ -127,22 +128,18 @@ func (d *DiskSyncStore) SyncAllToDisk(ctx context.Context) error {
 			slog.WarnContext(ctx, "disk_sync sync_all: skipping skill with unsafe name", "name", sk.Name, "err", pathErr)
 			continue
 		}
-		paths, err := d.ListFiles(ctx, sk.ID)
+		files, err := d.ListFilesWithContent(ctx, sk.ID)
 		if err != nil {
 			return fmt.Errorf("disk_sync sync_all: list files for %q: %w", sk.Name, err)
 		}
-		for _, p := range paths {
+		for p, content := range files {
 			diskPath, pathErr := safeDiskPath(skillDir, filepath.FromSlash(p))
 			if pathErr != nil {
 				slog.WarnContext(ctx, "disk_sync sync_all: skipping file with unsafe path", "skill", sk.Name, "path", p, "err", pathErr)
 				continue
 			}
-			if _, statErr := os.Stat(diskPath); statErr == nil {
-				continue // already on disk
-			}
-			content, err := d.LoadFile(ctx, sk.ID, p)
-			if err != nil {
-				return fmt.Errorf("disk_sync sync_all: load %q in %q: %w", p, sk.Name, err)
+			if existing, readErr := os.ReadFile(diskPath); readErr == nil && bytes.Equal(existing, []byte(content)) {
+				continue
 			}
 			if err := writeFile(diskPath, content); err != nil {
 				return fmt.Errorf("disk_sync sync_all: write %q in %q: %w", p, sk.Name, err)

--- a/internal/skills/disk_sync.go
+++ b/internal/skills/disk_sync.go
@@ -110,9 +110,9 @@ func (d *DiskSyncStore) Delete(ctx context.Context, id string) error {
 	return nil
 }
 
-// SyncAllToDisk materializes every skill in the DB to disk, writing only files
-// that are absent on disk. Called once at startup to bring pre-DiskSyncStore
-// DB-only skills onto the filesystem.
+// SyncAllToDisk materializes every skill in the DB to disk. The DB is the
+// single source of truth: files absent on disk are created, stale files are
+// overwritten, and disk files not present in the DB are removed.
 func (d *DiskSyncStore) SyncAllToDisk(ctx context.Context) error {
 	all, err := d.ListAll(ctx)
 	if err != nil {
@@ -145,8 +145,28 @@ func (d *DiskSyncStore) SyncAllToDisk(ctx context.Context) error {
 				return fmt.Errorf("disk_sync sync_all: write %q in %q: %w", p, sk.Name, err)
 			}
 		}
+		removeOrphanDiskFiles(ctx, skillDir, files, sk.Name)
 	}
 	return nil
+}
+
+// removeOrphanDiskFiles deletes files under skillDir that are not in dbFiles.
+func removeOrphanDiskFiles(ctx context.Context, skillDir string, dbFiles map[string]string, skillName string) {
+	_ = filepath.WalkDir(skillDir, func(p string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil || d.IsDir() {
+			return walkErr
+		}
+		rel, relErr := filepath.Rel(skillDir, p)
+		if relErr != nil {
+			return relErr
+		}
+		if _, inDB := dbFiles[filepath.ToSlash(rel)]; !inDB {
+			if rmErr := os.Remove(p); rmErr == nil {
+				slog.InfoContext(ctx, "disk_sync sync_all: removed orphan file", "skill", skillName, "path", rel)
+			}
+		}
+		return nil
+	})
 }
 
 // ListKnowledge forwards to the inner store if it implements KnowledgeStore.

--- a/internal/skills/disk_sync.go
+++ b/internal/skills/disk_sync.go
@@ -138,6 +138,24 @@ func (d *DiskSyncStore) ExpireDrafts(ctx context.Context, before time.Time) erro
 	return d.Store.ExpireDrafts(ctx, before)
 }
 
+// ListKnowledge forwards to the inner store if it implements KnowledgeStore.
+// DiskSyncStore embeds Store (not KnowledgeStore), so without this method,
+// skillStoreAdapter's type assertion to KnowledgeStore would fail silently.
+func (d *DiskSyncStore) ListKnowledge(ctx context.Context, vc ViewContext, types ...KnowledgeType) ([]KnowledgeEntry, error) {
+	if ks, ok := d.Store.(KnowledgeStore); ok {
+		return ks.ListKnowledge(ctx, vc, types...)
+	}
+	return nil, nil
+}
+
+// ExpireKnowledgeDraftsByType forwards to the inner store if it implements KnowledgeStore.
+func (d *DiskSyncStore) ExpireKnowledgeDraftsByType(ctx context.Context, knowledgeType KnowledgeType, before time.Time) error {
+	if ks, ok := d.Store.(KnowledgeStore); ok {
+		return ks.ExpireKnowledgeDraftsByType(ctx, knowledgeType, before)
+	}
+	return nil
+}
+
 // findByID looks up a skill by ID using ListAll. This is only called on write
 // paths which are not hot.
 func (d *DiskSyncStore) findByID(ctx context.Context, id string) (*Skill, error) {
@@ -170,3 +188,9 @@ func writeFile(path, content string) error {
 	}
 	return os.WriteFile(path, []byte(content), 0o644)
 }
+
+// Compile-time assertions.
+var (
+	_ Store          = (*DiskSyncStore)(nil)
+	_ KnowledgeStore = (*DiskSyncStore)(nil)
+)

--- a/internal/skills/migrate_fs.go
+++ b/internal/skills/migrate_fs.go
@@ -49,6 +49,11 @@ type migrateLoadedSkill struct {
 func MigrateFilesystem(ctx context.Context, store Store, cfg MigrateFSConfig) (MigrateFSResult, error) {
 	loaded := loadFSSkills(cfg)
 
+	allSkills, err := store.ListAll(ctx)
+	if err != nil {
+		return MigrateFSResult{}, fmt.Errorf("migrate_fs: list all skills: %w", err)
+	}
+
 	var result MigrateFSResult
 
 	for _, cs := range loaded {
@@ -63,7 +68,7 @@ func MigrateFilesystem(ctx context.Context, store Store, cfg MigrateFSConfig) (M
 		}
 
 		// Check for existing row — skip if already imported.
-		exists, checkErr := skillExistsInDB(ctx, store, scope, cs.Name, cfg)
+		exists, checkErr := skillExistsInDB(allSkills, scope, cs.Name, cfg)
 		if checkErr != nil {
 			return result, fmt.Errorf("migrate_fs: check existing %q: %w", cs.Name, checkErr)
 		}
@@ -222,12 +227,8 @@ func sourceToScope(source string) (string, error) {
 }
 
 // skillExistsInDB checks whether a skill with the given (scope, name, owner) is already
-// present in the DB using the Store interface.
-func skillExistsInDB(ctx context.Context, store Store, scope, name string, cfg MigrateFSConfig) (bool, error) {
-	all, err := store.ListAll(ctx)
-	if err != nil {
-		return false, err
-	}
+// present in the pre-fetched skill list.
+func skillExistsInDB(all []Skill, scope, name string, cfg MigrateFSConfig) (bool, error) {
 	for _, sk := range all {
 		if sk.Scope != scope || sk.Name != name {
 			continue

--- a/internal/skills/migrate_fs.go
+++ b/internal/skills/migrate_fs.go
@@ -2,7 +2,6 @@ package skills
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,8 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/CherryHQ/stella/pkg/db/sqlc"
 )
 
 // MigrateFSConfig controls how on-disk skills are discovered and mapped to DB rows.
@@ -49,7 +46,7 @@ type migrateLoadedSkill struct {
 //
 // Skills with source="stella" (builtin) are skipped — use SyncBuiltin for those.
 // The function is safe to call multiple times; existing rows are counted as Skipped.
-func MigrateFilesystem(ctx context.Context, store *SQLiteStore, cfg MigrateFSConfig) (MigrateFSResult, error) {
+func MigrateFilesystem(ctx context.Context, store Store, cfg MigrateFSConfig) (MigrateFSResult, error) {
 	loaded := loadFSSkills(cfg)
 
 	var result MigrateFSResult
@@ -66,7 +63,7 @@ func MigrateFilesystem(ctx context.Context, store *SQLiteStore, cfg MigrateFSCon
 		}
 
 		// Check for existing row — skip if already imported.
-		exists, checkErr := skillExistsInDB(ctx, store.q, scope, cs.Name, cfg)
+		exists, checkErr := skillExistsInDB(ctx, store, scope, cs.Name, cfg)
 		if checkErr != nil {
 			return result, fmt.Errorf("migrate_fs: check existing %q: %w", cs.Name, checkErr)
 		}
@@ -225,31 +222,28 @@ func sourceToScope(source string) (string, error) {
 }
 
 // skillExistsInDB checks whether a skill with the given (scope, name, owner) is already
-// present in the DB. It dispatches to the appropriate typed query to avoid NULL = NULL pitfalls.
-func skillExistsInDB(ctx context.Context, q *sqlc.Queries, scope, name string, cfg MigrateFSConfig) (bool, error) {
-	var err error
-	switch scope {
-	case "agent":
-		_, err = q.GetAgentSkillByName(ctx, sqlc.GetAgentSkillByNameParams{
-			AgentID: sql.NullString{String: cfg.AgentID, Valid: cfg.AgentID != ""},
-			Name:    name,
-		})
-	case "user":
-		_, err = q.GetUserSkillByName(ctx, sqlc.GetUserSkillByNameParams{
-			UserID: sql.NullInt64{Int64: cfg.UserID, Valid: cfg.UserID != 0},
-			Name:   name,
-		})
-	default:
-		return false, fmt.Errorf("unsupported scope %q", scope)
-	}
-
-	if errors.Is(err, sql.ErrNoRows) {
-		return false, nil
-	}
+// present in the DB using the Store interface.
+func skillExistsInDB(ctx context.Context, store Store, scope, name string, cfg MigrateFSConfig) (bool, error) {
+	all, err := store.ListAll(ctx)
 	if err != nil {
 		return false, err
 	}
-	return true, nil
+	for _, sk := range all {
+		if sk.Scope != scope || sk.Name != name {
+			continue
+		}
+		switch scope {
+		case "agent":
+			if sk.AgentID == cfg.AgentID {
+				return true, nil
+			}
+		case "user":
+			if sk.UserID == cfg.UserID {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }
 
 // walkSkillDir recursively collects all files under baseDir into a map keyed by

--- a/internal/skills/sqlite.go
+++ b/internal/skills/sqlite.go
@@ -66,6 +66,19 @@ func (s *SQLiteStore) ListFiles(ctx context.Context, skillID string) ([]string, 
 	return paths, nil
 }
 
+// ListFilesWithContent returns all files for a skill keyed by path.
+func (s *SQLiteStore) ListFilesWithContent(ctx context.Context, skillID string) (map[string]string, error) {
+	rows, err := s.q.ListSkillFiles(ctx, skillID)
+	if err != nil {
+		return nil, fmt.Errorf("skills: list files with content for %s: %w", skillID, err)
+	}
+	files := make(map[string]string, len(rows))
+	for _, r := range rows {
+		files[r.Path] = r.Content
+	}
+	return files, nil
+}
+
 // Resolve finds the highest-priority visible skill by name.
 func (s *SQLiteStore) Resolve(ctx context.Context, name string, vc ViewContext) (*Skill, error) {
 	row, err := s.q.ResolveSkill(ctx, sqlc.ResolveSkillParams{

--- a/internal/skills/store.go
+++ b/internal/skills/store.go
@@ -56,6 +56,9 @@ type Store interface {
 	// ListFiles returns all file paths for a skill (no content).
 	ListFiles(ctx context.Context, skillID string) ([]string, error)
 
+	// ListFilesWithContent returns all files for a skill keyed by path.
+	ListFilesWithContent(ctx context.Context, skillID string) (map[string]string, error)
+
 	// Create inserts the skill row and all its files (must include "SKILL.md").
 	Create(ctx context.Context, s Skill, files map[string]string) (string, error)
 

--- a/internal/skills/sync_builtin.go
+++ b/internal/skills/sync_builtin.go
@@ -113,25 +113,26 @@ func SyncBuiltin(ctx context.Context, store Store, builtinFS fs.FS) error {
 		return fmt.Errorf("sync_builtin: read root: %w", err)
 	}
 
+	allSkills, err := store.ListAll(ctx)
+	if err != nil {
+		return fmt.Errorf("sync_builtin: list all skills: %w", err)
+	}
+
 	desired := make(map[string]struct{}, len(skillRoots))
 	for _, skillRoot := range skillRoots {
 		desired[path.Base(skillRoot)] = struct{}{}
-		if err := syncBuiltinSkill(ctx, store, builtinFS, skillRoot); err != nil {
+		if err := syncBuiltinSkill(ctx, store, builtinFS, skillRoot, allSkills); err != nil {
 			slog.ErrorContext(ctx, "sync_builtin: failed to sync skill", "path", skillRoot, "err", err)
 			return fmt.Errorf("sync_builtin: skill %q: %w", skillRoot, err)
 		}
 	}
-	if err := deleteRemovedSystemSkills(ctx, store, desired); err != nil {
+	if err := deleteRemovedSystemSkills(ctx, store, allSkills, desired); err != nil {
 		return fmt.Errorf("sync_builtin: delete removed system skills: %w", err)
 	}
 	return nil
 }
 
-func deleteRemovedSystemSkills(ctx context.Context, store Store, desired map[string]struct{}) error {
-	rows, err := store.ListAll(ctx)
-	if err != nil {
-		return fmt.Errorf("list all skills: %w", err)
-	}
+func deleteRemovedSystemSkills(ctx context.Context, store Store, rows []Skill, desired map[string]struct{}) error {
 	for _, row := range rows {
 		if row.Scope != "system" {
 			continue
@@ -148,7 +149,7 @@ func deleteRemovedSystemSkills(ctx context.Context, store Store, desired map[str
 }
 
 // syncBuiltinSkill upserts a single builtin skill directory into the DB.
-func syncBuiltinSkill(ctx context.Context, store Store, builtinFS fs.FS, skillRoot string) error {
+func syncBuiltinSkill(ctx context.Context, store Store, builtinFS fs.FS, skillRoot string, allSkills []Skill) error {
 	skillName := path.Base(skillRoot)
 	// 1. Read and parse SKILL.md.
 	skillMDPath := path.Join(skillRoot, MainFile)
@@ -200,16 +201,10 @@ func syncBuiltinSkill(ctx context.Context, store Store, builtinFS fs.FS, skillRo
 
 	// 4. Check for existing system skill row.
 	var existing *Skill
-	{
-		all, err := store.ListAll(ctx)
-		if err != nil {
-			return fmt.Errorf("query existing: %w", err)
-		}
-		for i := range all {
-			if all[i].Scope == "system" && all[i].Name == fm.Name {
-				existing = &all[i]
-				break
-			}
+	for i := range allSkills {
+		if allSkills[i].Scope == "system" && allSkills[i].Name == fm.Name {
+			existing = &allSkills[i]
+			break
 		}
 	}
 	if existing == nil {

--- a/internal/skills/sync_builtin.go
+++ b/internal/skills/sync_builtin.go
@@ -3,9 +3,7 @@ package skills
 import (
 	"context"
 	"crypto/sha256"
-	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -96,7 +94,7 @@ func normalizeBuiltinStatus(status string) string {
 // TODO(orphan-cleanup): Skills that exist in the DB as scope='system' but are absent from
 // builtinFS are not deleted here. Phase 4+ should add an explicit tombstone pass once the
 // full lifecycle is understood.
-func SyncBuiltin(ctx context.Context, store *SQLiteStore, builtinFS fs.FS) error {
+func SyncBuiltin(ctx context.Context, store Store, builtinFS fs.FS) error {
 	var skillRoots []string
 	err := fs.WalkDir(builtinFS, ".", func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -129,8 +127,8 @@ func SyncBuiltin(ctx context.Context, store *SQLiteStore, builtinFS fs.FS) error
 	return nil
 }
 
-func deleteRemovedSystemSkills(ctx context.Context, store *SQLiteStore, desired map[string]struct{}) error {
-	rows, err := store.q.ListAllSkills(ctx)
+func deleteRemovedSystemSkills(ctx context.Context, store Store, desired map[string]struct{}) error {
+	rows, err := store.ListAll(ctx)
 	if err != nil {
 		return fmt.Errorf("list all skills: %w", err)
 	}
@@ -150,7 +148,7 @@ func deleteRemovedSystemSkills(ctx context.Context, store *SQLiteStore, desired 
 }
 
 // syncBuiltinSkill upserts a single builtin skill directory into the DB.
-func syncBuiltinSkill(ctx context.Context, store *SQLiteStore, builtinFS fs.FS, skillRoot string) error {
+func syncBuiltinSkill(ctx context.Context, store Store, builtinFS fs.FS, skillRoot string) error {
 	skillName := path.Base(skillRoot)
 	// 1. Read and parse SKILL.md.
 	skillMDPath := path.Join(skillRoot, MainFile)
@@ -201,8 +199,20 @@ func syncBuiltinSkill(ctx context.Context, store *SQLiteStore, builtinFS fs.FS, 
 	}
 
 	// 4. Check for existing system skill row.
-	existing, err := store.q.GetSystemSkillByName(ctx, fm.Name)
-	if errors.Is(err, sql.ErrNoRows) {
+	var existing *Skill
+	{
+		all, err := store.ListAll(ctx)
+		if err != nil {
+			return fmt.Errorf("query existing: %w", err)
+		}
+		for i := range all {
+			if all[i].Scope == "system" && all[i].Name == fm.Name {
+				existing = &all[i]
+				break
+			}
+		}
+	}
+	if existing == nil {
 		// New skill — insert.
 		sk := Skill{
 			Scope:                  "system",
@@ -218,21 +228,14 @@ func syncBuiltinSkill(ctx context.Context, store *SQLiteStore, builtinFS fs.FS, 
 		slog.InfoContext(ctx, "sync_builtin: created skill", "name", fm.Name)
 		return nil
 	}
-	if err != nil {
-		return fmt.Errorf("query existing: %w", err)
-	}
 
 	skillID := existing.ID
 
 	// 5. Update metadata if frontmatter changed.
-	disabledInt := int64(0)
-	if fm.DisableModelInvocation {
-		disabledInt = 1
-	}
 	if existing.Description != fm.Description ||
 		existing.Status != normalizeBuiltinStatus(fm.Status) ||
-		existing.DisableModelInvocation != disabledInt ||
-		existing.Metadata != string(meta) {
+		existing.DisableModelInvocation != fm.DisableModelInvocation ||
+		string(existing.Metadata) != string(meta) {
 		if err := store.Update(ctx, skillID, UpdatePatch{
 			Description:            &fm.Description,
 			Status:                 strPtr(normalizeBuiltinStatus(fm.Status)),
@@ -244,13 +247,17 @@ func syncBuiltinSkill(ctx context.Context, store *SQLiteStore, builtinFS fs.FS, 
 	}
 
 	// 6. Sync file contents — upsert changed files.
-	existingFiles, err := store.q.ListSkillFiles(ctx, skillID)
+	existingFilePaths, err := store.ListFiles(ctx, skillID)
 	if err != nil {
 		return fmt.Errorf("list existing files: %w", err)
 	}
 	existingByPath := map[string]string{}
-	for _, f := range existingFiles {
-		existingByPath[f.Path] = f.Content
+	for _, filePath := range existingFilePaths {
+		content, err := store.LoadFile(ctx, skillID, filePath)
+		if err != nil {
+			return fmt.Errorf("load existing file %q: %w", filePath, err)
+		}
+		existingByPath[filePath] = content
 	}
 
 	for path, content := range files {

--- a/internal/skills/sync_builtin.go
+++ b/internal/skills/sync_builtin.go
@@ -242,17 +242,9 @@ func syncBuiltinSkill(ctx context.Context, store Store, builtinFS fs.FS, skillRo
 	}
 
 	// 6. Sync file contents — upsert changed files.
-	existingFilePaths, err := store.ListFiles(ctx, skillID)
+	existingByPath, err := store.ListFilesWithContent(ctx, skillID)
 	if err != nil {
 		return fmt.Errorf("list existing files: %w", err)
-	}
-	existingByPath := map[string]string{}
-	for _, filePath := range existingFilePaths {
-		content, err := store.LoadFile(ctx, skillID, filePath)
-		if err != nil {
-			return fmt.Errorf("load existing file %q: %w", filePath, err)
-		}
-		existingByPath[filePath] = content
 	}
 
 	for path, content := range files {

--- a/pkg/sandbox/policy.go
+++ b/pkg/sandbox/policy.go
@@ -43,6 +43,11 @@ type FilesystemPolicy struct {
 
 	// WorkingDir is the logical working directory inside the sandbox root.
 	WorkingDir string
+
+	// ExtraReadOnlyMounts is a list of host paths to mount read-only inside the
+	// sandbox at their exact host path (same-path strategy). Used for skill dirs
+	// that live outside the workspace root but must be accessible for script execution.
+	ExtraReadOnlyMounts []string
 }
 
 // NetworkPolicy defines network constraints for a sandbox session.

--- a/plugins/sandbox/docker/session.go
+++ b/plugins/sandbox/docker/session.go
@@ -132,11 +132,20 @@ func (f *dockerFactory) CreateSession(ctx context.Context, policy sandboxpkg.Pol
 	if stellaHome != "" {
 		opts.ReadOnlyMounts = []dockerclient.Mount{
 			{
-				HostPath:      filepath.Join(stellaHome, "skills"),
-				ContainerPath: filepath.Join(stellaHomeMount, "skills"),
+				HostPath:      filepath.Join(stellaHome, ".agents", "skills"),
+				ContainerPath: filepath.Join(stellaHomeMount, ".agents", "skills"),
 				ReadOnly:      true,
 			},
 		}
+	}
+	// Mount extra read-only paths (e.g. skill dirs) at their host path inside the
+	// container (same-path strategy). HostPath is translated for DooD scenarios.
+	for _, hostPath := range policy.Filesystem.ExtraReadOnlyMounts {
+		opts.ReadOnlyMounts = append(opts.ReadOnlyMounts, dockerclient.Mount{
+			HostPath:      f.cfg.TranslateToDaemonPath(hostPath),
+			ContainerPath: hostPath,
+			ReadOnly:      true,
+		})
 	}
 
 	var toolBinPaths []string
@@ -167,8 +176,8 @@ func (f *dockerFactory) CreateSession(ctx context.Context, policy sandboxpkg.Pol
 		attribute.String("stella.sandbox.container_id", containerID),
 	))
 
-	// Build mount table for the workspace plus mounted STELLA_HOME assets.
-	mountTable := buildMountTable(workspaceHost, workspaceMount, policy.Env["STELLA_HOME"], stellaHomeMount)
+	// Build mount table for the workspace plus mounted STELLA_HOME assets and extra mounts.
+	mountTable := buildMountTable(workspaceHost, workspaceMount, policy.Env["STELLA_HOME"], stellaHomeMount, policy.Filesystem.ExtraReadOnlyMounts)
 
 	session := &dockerSession{
 		id:           sessionID,
@@ -199,7 +208,8 @@ func mapNetworkMode(policy sandboxpkg.Policy) dockerclient.NetworkMode {
 }
 
 // buildMountTable returns the bind mount set that toContainerPath should consult.
-func buildMountTable(workspaceHost, workspaceMount, stellaHomeHost, stellaHomeContainer string) []dockerclient.Mount {
+// extraHostPaths are same-path mounts: container path equals the original host path.
+func buildMountTable(workspaceHost, workspaceMount, stellaHomeHost, stellaHomeContainer string, extraHostPaths []string) []dockerclient.Mount {
 	mounts := []dockerclient.Mount{
 		{
 			HostPath:      workspaceHost,
@@ -215,11 +225,18 @@ func buildMountTable(workspaceHost, workspaceMount, stellaHomeHost, stellaHomeCo
 				ReadOnly:      true,
 			},
 			dockerclient.Mount{
-				HostPath:      filepath.Join(stellaHomeHost, "skills"),
-				ContainerPath: filepath.Join(stellaHomeContainer, "skills"),
+				HostPath:      filepath.Join(stellaHomeHost, ".agents", "skills"),
+				ContainerPath: filepath.Join(stellaHomeContainer, ".agents", "skills"),
 				ReadOnly:      true,
 			},
 		)
+	}
+	for _, hostPath := range extraHostPaths {
+		mounts = append(mounts, dockerclient.Mount{
+			HostPath:      hostPath,
+			ContainerPath: hostPath,
+			ReadOnly:      true,
+		})
 	}
 	return mounts
 }

--- a/plugins/sandbox/docker/session_pure_test.go
+++ b/plugins/sandbox/docker/session_pure_test.go
@@ -35,7 +35,7 @@ func TestMergeEnv(t *testing.T) {
 }
 
 func TestBuildMountTable(t *testing.T) {
-	table := buildMountTable("/host/ws", "/container/ws", "/host/.stella", "/home/stella/.stella")
+	table := buildMountTable("/host/ws", "/container/ws", "/host/.stella", "/home/stella/.stella", nil)
 	if len(table) != 3 {
 		t.Fatalf("expected 3 entries, got %d", len(table))
 	}
@@ -48,8 +48,15 @@ func TestBuildMountTable(t *testing.T) {
 	if table[1].HostPath != "/host/.stella" || table[1].ContainerPath != "/home/stella/.stella" || !table[1].ReadOnly {
 		t.Fatalf("unexpected stella home synthetic mount: %+v", table[1])
 	}
-	if table[2].HostPath != "/host/.stella/skills" || table[2].ContainerPath != "/home/stella/.stella/skills" || !table[2].ReadOnly {
+	if table[2].HostPath != "/host/.stella/.agents/skills" || table[2].ContainerPath != "/home/stella/.stella/.agents/skills" || !table[2].ReadOnly {
 		t.Fatalf("unexpected stella skills mount: %+v", table[2])
+	}
+	tableExtra := buildMountTable("/host/ws", "/container/ws", "", "", []string{"/extra/path"})
+	if len(tableExtra) != 2 {
+		t.Fatalf("expected 2 entries with extra, got %d", len(tableExtra))
+	}
+	if tableExtra[1].HostPath != "/extra/path" || tableExtra[1].ContainerPath != "/extra/path" || !tableExtra[1].ReadOnly {
+		t.Fatalf("unexpected extra mount: %+v", tableExtra[1])
 	}
 }
 

--- a/plugins/sandbox/local/session_linux.go
+++ b/plugins/sandbox/local/session_linux.go
@@ -144,7 +144,7 @@ func appendStellaHomeMounts(args []string, stellaHome string) []string {
 	if stellaHome == "" {
 		return args
 	}
-	for _, name := range []string{"bin", "skills"} {
+	for _, name := range []string{"bin", filepath.Join(".agents", "skills")} {
 		hostPath := filepath.Join(stellaHome, name)
 		args = appendRoBindIfExists(args, hostPath, hostPath)
 	}
@@ -220,6 +220,9 @@ func wrapCommand(policy sandboxpkg.Policy, sandboxCwd, name string, args []strin
 	}
 	bwrapArgs = appendLinuxRuntimeMounts(bwrapArgs)
 	bwrapArgs = appendStellaHomeMounts(bwrapArgs, policy.Env["STELLA_HOME"])
+	for _, extraPath := range policy.Filesystem.ExtraReadOnlyMounts {
+		bwrapArgs = appendRoBindIfExists(bwrapArgs, extraPath, extraPath)
+	}
 	bwrapArgs = append(bwrapArgs,
 		"--dir", "/workspace",
 		"--bind", realRoot, "/workspace",

--- a/plugins/tools/skills/tool.go
+++ b/plugins/tools/skills/tool.go
@@ -96,6 +96,31 @@ const (
 	skillScopeAgent = "agent"
 )
 
+// skillDirForScope returns the absolute host path to the skill's directory so
+// agents can execute scripts directly. Returns empty string if the path cannot
+// be determined.
+func (t *Tool) skillDirForScope(scope, agentID string, userID int64, skillName string) string {
+	switch scope {
+	case "system":
+		if t.stellaHome == "" {
+			return ""
+		}
+		return filepath.Join(t.stellaHome, ".agents", "skills", skillName)
+	case "agent":
+		if t.agentRoot == "" {
+			return ""
+		}
+		return filepath.Join(t.agentRoot, ".agents", "skills", skillName)
+	case "user":
+		if t.userSkillsDir == "" {
+			return ""
+		}
+		return filepath.Join(t.userSkillsDir, skillName)
+	default:
+		return ""
+	}
+}
+
 // errProjectScopeWriteRejected is the error returned when a write action is attempted on project scope.
 const errProjectScopeMsg = "scope=project is not supported for write operations — project skills live in {PROJECT_ROOT}/.agents/skills and come with the repo; edit the files directly in git"
 
@@ -213,7 +238,7 @@ func (t *Tool) load(ctx context.Context, args map[string]any) (string, error) {
 				if err != nil {
 					return "", fmt.Errorf("load project skill %q file %q: %w", name, path, err)
 				}
-				return fmt.Sprintf("<skill_content name=%q path=%q>\n%s\n</skill_content>", name, path, data), nil
+				return fmt.Sprintf("<skill_dir>%s</skill_dir>\n<skill_content name=%q path=%q>\n%s\n</skill_content>", skillDir, name, path, data), nil
 			}
 		}
 	}
@@ -236,7 +261,12 @@ func (t *Tool) load(ctx context.Context, args map[string]any) (string, error) {
 		return "", fmt.Errorf("load skill %q file %q: %w", name, path, err)
 	}
 
-	return fmt.Sprintf("<skill_content name=%q path=%q>\n%s\n</skill_content>", s.Name, path, data), nil
+	skillDir := t.skillDirForScope(s.Scope, s.AgentID, s.UserID, s.Name)
+	prefix := ""
+	if skillDir != "" {
+		prefix = fmt.Sprintf("<skill_dir>%s</skill_dir>\n", skillDir)
+	}
+	return prefix + fmt.Sprintf("<skill_content name=%q path=%q>\n%s\n</skill_content>", s.Name, path, data), nil
 }
 
 type installedSkill struct {


### PR DESCRIPTION
## Summary

- **DiskSyncStore**: new wrapper in `internal/skills/disk_sync.go` that mirrors every skill write (Create/UpsertFile/DeleteFile/Delete) to disk. `SyncAllToDisk` materializes pre-existing DB-only skills on first startup.
- **DB is the single source of truth**: `SyncAllToDisk` writes missing/stale files, overwrites diverged content, and removes orphan disk files not present in the DB.
- **Path traversal protection**: `safeDiskPath()` validates all resolved paths stay under their base directory, preventing `../` escape in skill names or file paths.
- **Consistent path convention**: all scopes use `<root>/.agents/skills/<name>/`. System skills moved from `$STELLA_HOME/skills/` → `$STELLA_HOME/.agents/skills/`.
- **Sandbox mounts**: `FilesystemPolicy.ExtraReadOnlyMounts []string` carries all four skill scope dirs (deduplicated). Both Docker and bwrap backends mount them at their exact host path (same-path strategy) so `skill_dir` values resolve inside the sandbox without translation.
- **`skills load` response**: now prepends `<skill_dir>/path/to/skill</skill_dir>` so agents can directly execute bundled scripts.
- **Store interface**: `SyncBuiltin` and `MigrateFilesystem` now accept `Store` interface instead of `*SQLiteStore`, making `DiskSyncStore` wrapping transparent. Added `ListFilesWithContent` to eliminate N+1 queries.
- **Performance**: `ListAll` is hoisted and called once in `SyncBuiltin` and `MigrateFilesystem` instead of per-skill, avoiding O(N²) lookups.

## Problem solved

Skills with bundled scripts (e.g. `skill-creator/scripts/*.py`) could be read via `skills load` but not executed — the files weren't on disk for user/agent-scoped skills, and even system skills didn't communicate their disk path. Agents inside sandboxes had no way to run the scripts.

## Test plan

- [x] `mise run format && mise run build && mise run test` — all pass
- [ ] Start server; verify `$STELLA_HOME/.agents/skills/` is populated with system skills after startup
- [x] Create a user-scoped skill via the UI; verify it appears on disk at `$STELLA_HOME/workspaces/<agentID>/users/<userID>/.agents/skills/<name>/`
- [ ] Load a skill with scripts in a sandbox session; verify `<skill_dir>` path is usable (e.g. `python <skill_dir>/scripts/run.py` succeeds)
- [ ] Delete a file from a skill in DB; verify `SyncAllToDisk` removes the orphan from disk on next startup