### PR TITLE
feat(sandbox): macOS Seatbelt isolation for local backend

### DIFF
--- a/plugins/sandbox/local/session.go
+++ b/plugins/sandbox/local/session.go
@@ -1,7 +1,6 @@
-// WARNING: commands run directly on the host OS with limited hardening only.
 // Hardening layers applied: process-group isolation on Unix, rlimits on Linux,
-// bwrap filesystem/network isolation on Linux. macOS local execution currently runs
-// without additional OS sandboxing.
+// bwrap filesystem/network isolation on Linux, macOS Seatbelt (sandbox-exec)
+// filesystem and network isolation on macOS.
 // Use the docker backend when full container isolation is required.
 package local
 

--- a/plugins/sandbox/local/session_darwin.go
+++ b/plugins/sandbox/local/session_darwin.go
@@ -1,37 +1,122 @@
 //go:build darwin
 
+// macOS Seatbelt (sandbox-exec) isolation for the local backend.
+// sandbox-exec is deprecated since macOS 10.15 but still ships and works;
+// if Apple ever removes it, checkSandboxRequirements will catch the absence
+// and the factory will fall through to the next available backend.
+//
+// Profile strategy: start with (allow default) so that dynamic linking,
+// mach IPC, and getcwd all work without enumeration, then deny writes to the
+// whole filesystem and re-allow writes only to the workspace root, temp dirs,
+// and /dev. Network access is denied unless the policy requests allow_all.
+// SBPL uses last-match-wins semantics, so ordering matters.
 package local
 
 import (
 	"fmt"
 	"os/exec"
+	"strings"
+	"sync"
 
 	sandboxpkg "github.com/CherryHQ/stella/pkg/sandbox"
 )
 
+const seatbeltExecPath = "/usr/bin/sandbox-exec"
+
+var (
+	seatbeltOnce      sync.Once
+	seatbeltAvailable bool
+)
+
+// seatbeltFunctional returns true when sandbox-exec is present and can run.
+// Result is cached after the first call.
+func seatbeltFunctional() bool {
+	seatbeltOnce.Do(func() {
+		if _, err := exec.LookPath(seatbeltExecPath); err != nil {
+			return
+		}
+		// Probe with an allow-all profile to verify the binary works.
+		if exec.Command(seatbeltExecPath, "-p", "(version 1)(allow default)", "/usr/bin/true").Run() == nil {
+			seatbeltAvailable = true
+		}
+	})
+	return seatbeltAvailable
+}
+
 // resolveSandboxRoot returns the sandbox-space root and the real host root.
-// On macOS there is no path remapping, so both are always identical.
+// On macOS there is no path remapping; both are always identical.
 func resolveSandboxRoot(policy sandboxpkg.Policy) (sandboxRoot, realRoot string) {
 	real := policy.WorkspaceRootOrDefault()
 	return real, real
 }
 
-// checkSandboxRequirements is a no-op on macOS — no additional isolation tools
-// are required; commands run directly on the host OS.
-func checkSandboxRequirements() error { return nil }
+// checkSandboxRequirements verifies that sandbox-exec is available and functional.
+func checkSandboxRequirements() error {
+	if !seatbeltFunctional() {
+		return fmt.Errorf(
+			"local sandbox: sandbox-exec (macOS Seatbelt) is required but not available; " +
+				"this binary ships with macOS at /usr/bin/sandbox-exec",
+		)
+	}
+	return nil
+}
 
-// wrapCommand is a no-op on macOS.
+// buildSeatbeltProfile returns an SBPL profile string for the given policy.
 //
-// The local backend now runs commands directly on the host OS without applying
-// sandbox-exec or any other macOS-specific isolation layer. Filesystem and
-// network policy enforcement is therefore not provided on this platform when
-// the local backend is active.
-func wrapCommand(_ sandboxpkg.Policy, sandboxCwd, name string, args []string) (execPath string, execArgs []string, hostCwd string, err error) {
+// The profile uses (allow default) as the base so that system operations
+// (dynamic linking, mach IPC, getcwd) work without enumerating every required
+// path. All filesystem writes are then denied globally and re-allowed only for
+// the workspace, temp directories, and device nodes. Network is denied when
+// the policy requests NetworkDisabled.
+//
+// SBPL evaluates rules in order and the last match wins.
+func buildSeatbeltProfile(policy sandboxpkg.Policy) string {
+	workspace := policy.WorkspaceRootOrDefault()
+	networkMode := policy.NetworkModeOrDefault()
+
+	var sb strings.Builder
+	sb.WriteString("(version 1)\n")
+
+	// Base: allow everything so the toolchain and shell work out of the box.
+	sb.WriteString("(allow default)\n")
+
+	// Deny all filesystem writes. Re-allows below (last-match-wins) carve out
+	// the locations that the sandbox legitimately needs to write to.
+	sb.WriteString("(deny file-write* (subpath \"/\"))\n")
+
+	// Temp directories: process-local scratch space and macOS per-user temp.
+	sb.WriteString("(allow file-write* (subpath \"/private/tmp\"))\n")
+	sb.WriteString("(allow file-write* (subpath \"/private/var/folders\"))\n")
+
+	// Dev nodes: required for stdout/stderr, pseudo-terminals, /dev/null, etc.
+	sb.WriteString("(allow file-write* (subpath \"/dev\"))\n")
+
+	// Workspace root: the only user-controlled path that is fully writable.
+	fmt.Fprintf(&sb, "(allow file-write* (subpath %q))\n", workspace)
+
+	// Network: deny unless the policy explicitly requests unrestricted access.
+	if networkMode != sandboxpkg.NetworkAllowAll {
+		sb.WriteString("(deny network*)\n")
+	}
+
+	return sb.String()
+}
+
+// wrapCommand wraps name+args with sandbox-exec for macOS Seatbelt isolation.
+func wrapCommand(policy sandboxpkg.Policy, sandboxCwd, name string, args []string) (execPath string, execArgs []string, hostCwd string, err error) {
+	if !seatbeltFunctional() {
+		return "", nil, "", fmt.Errorf(
+			"local sandbox: sandbox-exec (macOS Seatbelt) is required but not available",
+		)
+	}
+
 	resolved, lookErr := exec.LookPath(name)
 	if lookErr != nil {
 		return "", nil, "", fmt.Errorf("local exec: look up %q: %w", name, lookErr)
 	}
 
-	passthroughArgs := append([]string(nil), args...)
-	return resolved, passthroughArgs, sandboxCwd, nil
+	profile := buildSeatbeltProfile(policy)
+	seatbeltArgs := []string{"-p", profile, resolved}
+	seatbeltArgs = append(seatbeltArgs, args...)
+	return seatbeltExecPath, seatbeltArgs, sandboxCwd, nil
 }

--- a/plugins/sandbox/local/session_darwin.go
+++ b/plugins/sandbox/local/session_darwin.go
@@ -84,9 +84,11 @@ func buildSeatbeltProfile(policy sandboxpkg.Policy) string {
 	// the locations that the sandbox legitimately needs to write to.
 	sb.WriteString("(deny file-write* (subpath \"/\"))\n")
 
-	// Temp directories: process-local scratch space and macOS per-user temp.
+	// Temp directories: process-local scratch space, macOS per-user temp, and
+	// persistent scratch (mirrors Linux /var/tmp).
 	sb.WriteString("(allow file-write* (subpath \"/private/tmp\"))\n")
 	sb.WriteString("(allow file-write* (subpath \"/private/var/folders\"))\n")
+	sb.WriteString("(allow file-write* (subpath \"/private/var/tmp\"))\n")
 
 	// Dev nodes: required for stdout/stderr, pseudo-terminals, /dev/null, etc.
 	sb.WriteString("(allow file-write* (subpath \"/dev\"))\n")

--- a/plugins/sandbox/local/session_darwin_test.go
+++ b/plugins/sandbox/local/session_darwin_test.go
@@ -49,6 +49,7 @@ func TestBuildSeatbeltProfile_structure(t *testing.T) {
 		`(deny file-write* (subpath "/"))`,
 		`(allow file-write* (subpath "/private/tmp"))`,
 		`(allow file-write* (subpath "/private/var/folders"))`,
+		`(allow file-write* (subpath "/private/var/tmp"))`,
 		`(allow file-write* (subpath "/dev"))`,
 		`(allow file-write* (subpath "/tmp/ws"))`,
 		"(deny network*)",

--- a/plugins/sandbox/local/session_darwin_test.go
+++ b/plugins/sandbox/local/session_darwin_test.go
@@ -1,67 +1,97 @@
 package local
 
 import (
-	"os/exec"
-	"reflect"
+	"strings"
 	"testing"
 
 	sandboxpkg "github.com/CherryHQ/stella/pkg/sandbox"
 )
 
-func TestWrapCommand_darwin_passthrough(t *testing.T) {
-	root := "/tmp/test-workspace"
-	policy := sandboxpkg.Policy{
+func makePolicy(root string, net sandboxpkg.NetworkMode) sandboxpkg.Policy {
+	return sandboxpkg.Policy{
 		Filesystem: sandboxpkg.FilesystemPolicy{
 			WorkspaceRoot: root,
 			WorkingDir:    root,
 		},
-		Network: sandboxpkg.NetworkPolicy{Mode: sandboxpkg.NetworkDisabled},
+		Network: sandboxpkg.NetworkPolicy{Mode: net},
 	}
+}
+
+func TestWrapCommand_darwin_usesSeatbelt(t *testing.T) {
+	if !seatbeltFunctional() {
+		t.Skip("sandbox-exec not available")
+	}
+	root := t.TempDir()
+	policy := makePolicy(root, sandboxpkg.NetworkDisabled)
 
 	execPath, args, hostCwd, err := wrapCommand(policy, root, "sh", []string{"-c", "echo hi"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
-	wantExecPath, err := exec.LookPath("sh")
-	if err != nil {
-		t.Fatalf("look up sh: %v", err)
+	if execPath != seatbeltExecPath {
+		t.Fatalf("execPath = %q, want %q", execPath, seatbeltExecPath)
 	}
-	if execPath != wantExecPath {
-		t.Fatalf("execPath = %q, want %q", execPath, wantExecPath)
-	}
-	if !reflect.DeepEqual(args, []string{"-c", "echo hi"}) {
-		t.Fatalf("args = %#v, want passthrough args", args)
+	// args: ["-p", <profile>, <resolved-sh>, "-c", "echo hi"]
+	if len(args) < 3 || args[0] != "-p" {
+		t.Fatalf("expected -p <profile> <cmd> ..., got %v", args)
 	}
 	if hostCwd != root {
 		t.Fatalf("hostCwd = %q, want %q", hostCwd, root)
 	}
 }
 
-func TestWrapCommand_darwin_ignoresNetworkPolicy(t *testing.T) {
-	root := "/tmp/test-workspace"
-	allowAll := sandboxpkg.Policy{
-		Filesystem: sandboxpkg.FilesystemPolicy{
-			WorkspaceRoot: root,
-			WorkingDir:    root,
-		},
-		Network: sandboxpkg.NetworkPolicy{Mode: sandboxpkg.NetworkAllowAll},
-	}
-	disabled := sandboxpkg.Policy{
-		Filesystem: allowAll.Filesystem,
-		Network:    sandboxpkg.NetworkPolicy{Mode: sandboxpkg.NetworkDisabled},
-	}
+func TestBuildSeatbeltProfile_structure(t *testing.T) {
+	policy := makePolicy("/tmp/ws", sandboxpkg.NetworkDisabled)
+	profile := buildSeatbeltProfile(policy)
 
-	_, allowArgs, _, err := wrapCommand(allowAll, root, "sh", []string{"-c", "echo hi"})
-	if err != nil {
-		t.Fatalf("allow_all wrapCommand error: %v", err)
+	for _, want := range []string{
+		"(allow default)",
+		`(deny file-write* (subpath "/"))`,
+		`(allow file-write* (subpath "/private/tmp"))`,
+		`(allow file-write* (subpath "/private/var/folders"))`,
+		`(allow file-write* (subpath "/dev"))`,
+		`(allow file-write* (subpath "/tmp/ws"))`,
+		"(deny network*)",
+	} {
+		if !strings.Contains(profile, want) {
+			t.Errorf("profile missing: %s", want)
+		}
 	}
-	_, disabledArgs, _, err := wrapCommand(disabled, root, "sh", []string{"-c", "echo hi"})
+}
+
+func TestBuildSeatbeltProfile_networkAllowAll(t *testing.T) {
+	policy := makePolicy("/tmp/ws", sandboxpkg.NetworkAllowAll)
+	profile := buildSeatbeltProfile(policy)
+
+	if strings.Contains(profile, "(deny network*)") {
+		t.Error("profile must not deny network when mode is allow_all")
+	}
+}
+
+func TestBuildSeatbeltProfile_networkDisabledVsAllowAll(t *testing.T) {
+	if !seatbeltFunctional() {
+		t.Skip("sandbox-exec not available")
+	}
+	root := t.TempDir()
+
+	_, disabledArgs, _, err := wrapCommand(makePolicy(root, sandboxpkg.NetworkDisabled), root, "sh", []string{"-c", "echo"})
 	if err != nil {
 		t.Fatalf("disabled wrapCommand error: %v", err)
 	}
+	_, allowArgs, _, err := wrapCommand(makePolicy(root, sandboxpkg.NetworkAllowAll), root, "sh", []string{"-c", "echo"})
+	if err != nil {
+		t.Fatalf("allow_all wrapCommand error: %v", err)
+	}
 
-	if !reflect.DeepEqual(allowArgs, disabledArgs) {
-		t.Fatalf("network policy should not affect darwin local wrapping: allow=%#v disabled=%#v", allowArgs, disabledArgs)
+	disabledProfile := disabledArgs[1]
+	allowProfile := allowArgs[1]
+	if disabledProfile == allowProfile {
+		t.Error("network policies should produce different profiles")
+	}
+	if !strings.Contains(disabledProfile, "(deny network*)") {
+		t.Error("disabled profile must contain network deny")
+	}
+	if strings.Contains(allowProfile, "(deny network*)") {
+		t.Error("allow_all profile must not contain network deny")
 	}
 }

--- a/plugins/sandbox/plugin.go
+++ b/plugins/sandbox/plugin.go
@@ -20,7 +20,7 @@ func init() {
 		{
 			name:        config.SandboxBackendLocal,
 			displayName: "Local",
-			description: "Default Docker-free sandbox; uses bwrap for filesystem and network isolation on Linux.",
+			description: "Default Docker-free sandbox; uses bwrap on Linux and macOS Seatbelt (sandbox-exec) on macOS for filesystem and network isolation.",
 		},
 		{
 			name:        config.SandboxBackendNone,


### PR DESCRIPTION
## Summary

- Replace the macOS no-op passthrough in the `local` sandbox backend with real OS-level isolation via `sandbox-exec` (Apple Seatbelt / SBPL)
- Uses an allow-default + targeted write-deny strategy (last-match-wins SBPL semantics): all reads pass through, writes are blocked everywhere except the workspace, temp dirs, and device nodes
- Network is denied via `(deny network*)` when `NetworkDisabled` is set
- Adds `/private/var/tmp` to the write allowlist for parity with Linux bwrap's `/var/tmp`
- Updates plugin description to mention both bwrap (Linux) and Seatbelt (macOS)

## Profile strategy

```
(version 1)
(allow default)                              ; reads + system calls all work
(deny file-write* (subpath "/"))             ; block all writes...
(allow file-write* (subpath "/private/tmp")) ; ...except /tmp
(allow file-write* (subpath "/private/var/folders")) ; ...and macOS per-user temp
(allow file-write* (subpath "/private/var/tmp"))     ; ...and persistent scratch (/var/tmp parity)
(allow file-write* (subpath "/dev"))         ; ...and device nodes (stdout/stderr/null)
(allow file-write* (subpath "<workspace>"))  ; ...and the workspace
(deny network*)                              ; block network when NetworkDisabled
```

## Tradeoff vs Docker / Linux bwrap

macOS has no kernel namespace API, so Seatbelt cannot *hide* paths — only restrict operations on them. A sandboxed process can still *read* any file the host user can read. For full read isolation, the Docker backend remains the right choice.

## Test plan

- [ ] `go test ./plugins/sandbox/local/... -v` — all existing + new seatbelt tests pass
- [ ] Manual: `sandbox-exec -p "<profile>" sh -c "echo ok > $WORKSPACE/f.txt"` succeeds
- [ ] Manual: `sandbox-exec -p "<profile>" sh -c "echo fail > /tmp/outside.txt"` returns `Operation not permitted`
- [ ] Manual: `sandbox-exec -p "<profile>" curl https://example.com` is blocked