### PR TITLE
✨ Add uv and bun manifest tools

### DIFF
--- a/internal/agent/sandbox_backend.go
+++ b/internal/agent/sandbox_backend.go
@@ -553,31 +553,10 @@ func resolveDockerUserToolBinaries(stellaHome string) ([]dockerplugin.ToolBinary
 		}
 		for _, binary := range plugin.Binaries {
 			out = append(out, dockerplugin.ToolBinary{
-				Name:            binary.Name,
-				Tool:            binary.Tool,
-				URL:             binary.URL,
-				Version:         binary.Version,
-				StripComponents: binary.StripComponents,
-				BinPath:         binary.BinPath,
-				Bin:             binary.Bin,
-				RenameExe:       binary.RenameExe,
-				Checksum:        binary.Checksum,
-				AssetPattern:    binary.AssetPattern,
-				VersionPrefix:   binary.VersionPrefix,
-				NoApp:           binary.NoApp,
-				FilterBins:      binary.FilterBins,
-				Prerelease:      binary.Prerelease,
-				APIURL:          binary.APIURL,
-				Size:            binary.Size,
-				Format:          binary.Format,
-				VersionListURL:  binary.VersionListURL,
-				VersionRegex:    binary.VersionRegex,
-				VersionJSONPath: binary.VersionJSONPath,
-				VersionExpr:     binary.VersionExpr,
-				Extras:          binary.Extras,
-				PipxArgs:        binary.PipxArgs,
-				UVX:             binary.UVX,
-				UVXArgs:         binary.UVXArgs,
+				Name:    binary.Name,
+				Tool:    binary.Tool,
+				Version: binary.Version,
+				Options: binary.Options,
 			})
 		}
 	}

--- a/internal/manifestplugins/mise_installer.go
+++ b/internal/manifestplugins/mise_installer.go
@@ -118,45 +118,16 @@ func runtimeBinaryName(name string) string {
 	return name
 }
 
-// resolvedBackend returns the backend prefix from the Tool key (e.g. "github").
-func (b ManifestBinary) resolvedBackend() string {
-	if idx := strings.IndexByte(b.Tool, ':'); idx >= 0 {
-		return b.Tool[:idx]
-	}
-	return ""
-}
-
 // miseToolKey returns the mise tool key used in mise.toml and CLI commands.
 func (b ManifestBinary) miseToolKey() string {
 	return b.Tool
 }
 
-// sharedOptions populates the options shared across github and http backends.
-func sharedOptions(b ManifestBinary, m map[string]any) {
-	if b.StripComponents > 0 {
-		m["strip_components"] = b.StripComponents
-	}
-	if b.BinPath != "" {
-		m["bin_path"] = b.BinPath
-	}
-	if b.Bin != "" {
-		m["bin"] = b.Bin
-	}
-	if b.RenameExe != "" {
-		m["rename_exe"] = b.RenameExe
-	}
-	if b.Checksum != "" {
-		m["checksum"] = b.Checksum
-	}
-}
-
-// generateMiseTOML returns a valid mise.toml for the binary's backend.
-// When Version is empty, "latest" is used for github/pipx/npm. For the http
-// backend with a templated URL, an explicit version is required.
+// generateMiseTOML returns a valid mise.toml for the binary.
 func generateMiseTOML(b ManifestBinary) (string, error) {
 	toolKey := b.miseToolKey()
 	if toolKey == "" {
-		return "", fmt.Errorf("cannot determine mise tool key: set backend or repo/url/package")
+		return "", fmt.Errorf("cannot determine mise tool key")
 	}
 
 	ver := b.Version
@@ -164,84 +135,17 @@ func generateMiseTOML(b ManifestBinary) (string, error) {
 		ver = "latest"
 	}
 
-	var toolValue any
-	switch b.resolvedBackend() {
-	case "github":
-		m := map[string]any{"version": ver}
-		if b.AssetPattern != "" {
-			m["asset_pattern"] = b.AssetPattern
-		}
-		if b.VersionPrefix != "" {
-			m["version_prefix"] = b.VersionPrefix
-		}
-		if b.NoApp {
-			m["no_app"] = true
-		}
-		if b.FilterBins != "" {
-			m["filter_bins"] = b.FilterBins
-		}
-		if b.Prerelease {
-			m["prerelease"] = true
-		}
-		if b.APIURL != "" {
-			m["api_url"] = b.APIURL
-		}
-		sharedOptions(b, m)
-		if len(m) == 1 {
-			toolValue = ver
-		} else {
-			toolValue = m
-		}
+	options := maps.Clone(b.Options)
+	if options == nil {
+		options = make(map[string]any)
+	}
 
-	case "http":
-		m := map[string]any{"version": ver, "url": b.URL}
-		if b.Size != "" {
-			m["size"] = b.Size
+	var toolValue any = ver
+	if len(options) > 0 {
+		if _, ok := options["version"]; !ok {
+			options["version"] = ver
 		}
-		if b.Format != "" {
-			m["format"] = b.Format
-		}
-		if b.VersionListURL != "" {
-			m["version_list_url"] = b.VersionListURL
-		}
-		if b.VersionRegex != "" {
-			m["version_regex"] = b.VersionRegex
-		}
-		if b.VersionJSONPath != "" {
-			m["version_json_path"] = b.VersionJSONPath
-		}
-		if b.VersionExpr != "" {
-			m["version_expr"] = b.VersionExpr
-		}
-		sharedOptions(b, m)
-		toolValue = m
-
-	case "pipx":
-		m := map[string]any{"version": ver}
-		if b.Extras != "" {
-			m["extras"] = b.Extras
-		}
-		if b.PipxArgs != "" {
-			m["pipx_args"] = b.PipxArgs
-		}
-		if b.UVX {
-			m["uvx"] = true
-		}
-		if b.UVXArgs != "" {
-			m["uvx_args"] = b.UVXArgs
-		}
-		if len(m) == 1 {
-			toolValue = ver
-		} else {
-			toolValue = m
-		}
-
-	case "npm":
-		// npm has no per-tool options beyond version
-		toolValue = ver
-
-	default:
-		return "", fmt.Errorf("unsupported backend %q", b.resolvedBackend())
+		toolValue = options
 	}
 
 	data, err := toml.Marshal(map[string]any{
@@ -253,8 +157,8 @@ func generateMiseTOML(b ManifestBinary) (string, error) {
 	return string(data), nil
 }
 
-// installBinaryWithMise installs a single binary via mise's github backend and
-// copies the resulting binary to $STELLA_HOME/bin/.
+// installBinaryWithMise installs a single binary via mise and copies the resulting
+// binary to $STELLA_HOME/bin/.
 func installBinaryWithMise(ctx context.Context, b ManifestBinary, stellaHome string) (string, error) {
 	miseBin, err := findMiseBin(stellaHome)
 	if err != nil {
@@ -307,10 +211,10 @@ func installBinaryWithMise(ctx context.Context, b ManifestBinary, stellaHome str
 	// rename_exe takes precedence (archive extraction rename), then bin (single
 	// binary rename), then the tool name.
 	lookupName := b.Name
-	if b.RenameExe != "" {
-		lookupName = b.RenameExe
-	} else if b.Bin != "" {
-		lookupName = b.Bin
+	if renameExe, ok := stringOption(b.Options, "rename_exe"); ok {
+		lookupName = renameExe
+	} else if bin, ok := stringOption(b.Options, "bin"); ok {
+		lookupName = bin
 	}
 
 	// Resolve the binary path via mise which — it handles any archive layout.
@@ -356,6 +260,15 @@ func installBinaryWithMise(ctx context.Context, b ManifestBinary, stellaHome str
 		return "", err
 	}
 	return version, nil
+}
+
+func stringOption(options map[string]any, key string) (string, bool) {
+	value, ok := options[key]
+	if !ok {
+		return "", false
+	}
+	s, ok := value.(string)
+	return s, ok && s != ""
 }
 
 // atomicCopy copies src to dst using a temp file + rename.

--- a/internal/manifestplugins/mise_installer_test.go
+++ b/internal/manifestplugins/mise_installer_test.go
@@ -24,11 +24,25 @@ func TestGenerateMiseTOMLSimpleForm(t *testing.T) {
 	}
 }
 
+func TestGenerateMiseTOMLRegistryTool(t *testing.T) {
+	got, err := generateMiseTOML(ManifestBinary{
+		Name: "uv",
+		Tool: "uv",
+	})
+	if err != nil {
+		t.Fatalf("generateMiseTOML: %v", err)
+	}
+	want := `uv = 'latest'`
+	if !strings.Contains(got, want) {
+		t.Fatalf("expected registry tool form %q in:\n%s", want, got)
+	}
+}
+
 func TestGenerateMiseTOMLTableFormDefaultsVersion(t *testing.T) {
 	got, err := generateMiseTOML(ManifestBinary{
 		Name:    "gh",
 		Tool:    "github:cli/cli",
-		BinPath: "bin",
+		Options: map[string]any{"bin_path": "bin"},
 	})
 	if err != nil {
 		t.Fatalf("generateMiseTOML: %v", err)
@@ -46,10 +60,10 @@ func TestGenerateMiseTOMLTableFormDefaultsVersion(t *testing.T) {
 
 func TestGenerateMiseTOMLAssetPatternAloneTriggersTableForm(t *testing.T) {
 	got, err := generateMiseTOML(ManifestBinary{
-		Name:         "gh",
-		Tool:         "github:cli/cli",
-		Version:      "2.40.1",
-		AssetPattern: "gh_*_linux_x64.tar.gz",
+		Name:    "gh",
+		Tool:    "github:cli/cli",
+		Version: "2.40.1",
+		Options: map[string]any{"asset_pattern": "gh_*_linux_x64.tar.gz"},
 	})
 	if err != nil {
 		t.Fatalf("generateMiseTOML: %v", err)
@@ -67,19 +81,21 @@ func TestGenerateMiseTOMLAssetPatternAloneTriggersTableForm(t *testing.T) {
 
 func TestGenerateMiseTOMLAdvancedOptions(t *testing.T) {
 	got, err := generateMiseTOML(ManifestBinary{
-		Name:            "pandoc",
-		Tool:            "github:jgm/pandoc",
-		Version:         "3.1.0",
-		AssetPattern:    "pandoc-*-linux-amd64.tar.gz",
-		VersionPrefix:   "release-",
-		StripComponents: 1,
-		BinPath:         "bin",
-		RenameExe:       "pandoc",
-		NoApp:           true,
-		FilterBins:      "pandoc",
-		Checksum:        "sha256:abc123",
-		Prerelease:      true,
-		APIURL:          "https://github.example.com/api/v3",
+		Name:    "pandoc",
+		Tool:    "github:jgm/pandoc",
+		Version: "3.1.0",
+		Options: map[string]any{
+			"asset_pattern":    "pandoc-*-linux-amd64.tar.gz",
+			"version_prefix":   "release-",
+			"strip_components": 1,
+			"bin_path":         "bin",
+			"rename_exe":       "pandoc",
+			"no_app":           true,
+			"filter_bins":      "pandoc",
+			"checksum":         "sha256:abc123",
+			"prerelease":       true,
+			"api_url":          "https://github.example.com/api/v3",
+		},
 	})
 	if err != nil {
 		t.Fatalf("generateMiseTOML: %v", err)
@@ -109,7 +125,7 @@ func TestGenerateMiseTOMLBinField(t *testing.T) {
 		Name:    "docker-compose",
 		Tool:    "github:docker/compose",
 		Version: "2.29.1",
-		Bin:     "docker-compose",
+		Options: map[string]any{"bin": "docker-compose"},
 	})
 	if err != nil {
 		t.Fatalf("generateMiseTOML: %v", err)
@@ -128,8 +144,8 @@ func TestGenerateMiseTOMLHTTPBackend(t *testing.T) {
 	got, err := generateMiseTOML(ManifestBinary{
 		Name:    "sentinel",
 		Tool:    "http:sentinel",
-		URL:     "https://releases.hashicorp.com/sentinel/{{version}}/sentinel_{{version}}_linux_amd64.zip",
 		Version: "0.26.3",
+		Options: map[string]any{"url": "https://releases.hashicorp.com/sentinel/{{version}}/sentinel_{{version}}_linux_amd64.zip"},
 	})
 	if err != nil {
 		t.Fatalf("generateMiseTOML: %v", err)
@@ -149,9 +165,11 @@ func TestGenerateMiseTOMLHTTPWithFormat(t *testing.T) {
 	got, err := generateMiseTOML(ManifestBinary{
 		Name:    "mytool",
 		Tool:    "http:mytool",
-		URL:     "https://example.com/mytool-{{version}}-linux-amd64.tar.gz",
 		Version: "1.2.0",
-		Format:  "tar.gz",
+		Options: map[string]any{
+			"url":    "https://example.com/mytool-{{version}}-linux-amd64.tar.gz",
+			"format": "tar.gz",
+		},
 	})
 	if err != nil {
 		t.Fatalf("generateMiseTOML: %v", err)
@@ -183,9 +201,9 @@ func TestGenerateMiseTOMLPipxSimple(t *testing.T) {
 
 func TestGenerateMiseTOMLPipxWithExtras(t *testing.T) {
 	got, err := generateMiseTOML(ManifestBinary{
-		Name:   "pylint",
-		Tool:   "pipx:pylint",
-		Extras: "spelling",
+		Name:    "pylint",
+		Tool:    "pipx:pylint",
+		Options: map[string]any{"extras": "spelling"},
 	})
 	if err != nil {
 		t.Fatalf("generateMiseTOML: %v", err)
@@ -215,10 +233,21 @@ func TestGenerateMiseTOMLNPM(t *testing.T) {
 	}
 }
 
-func TestGenerateMiseTOMLUnknownBackendErrors(t *testing.T) {
+func TestGenerateMiseTOMLNoToolErrors(t *testing.T) {
 	_, err := generateMiseTOML(ManifestBinary{Name: "x"})
 	if err == nil {
-		t.Fatal("expected error for binary with no identity fields")
+		t.Fatal("expected error for binary with no tool")
+	}
+}
+
+func TestGenerateMiseTOMLLeavesToolKeyToMise(t *testing.T) {
+	got, err := generateMiseTOML(ManifestBinary{Name: "x", Tool: "github:repo"})
+	if err != nil {
+		t.Fatalf("generateMiseTOML: %v", err)
+	}
+	want := `'github:repo' = 'latest'`
+	if !strings.Contains(got, want) {
+		t.Fatalf("expected mise tool key form %q in:\n%s", want, got)
 	}
 }
 

--- a/internal/manifestplugins/types.go
+++ b/internal/manifestplugins/types.go
@@ -18,44 +18,15 @@ type ManifestBinary struct {
 	// Name is the binary name written to $STELLA_HOME/bin/.
 	Name string `json:"name" yaml:"name"`
 
-	// Tool is the mise tool key in "backend:identifier" format, e.g.:
-	//   github:cli/cli   pipx:mypy   npm:serve   http:sentinel
+	// Tool is the mise tool key, e.g.:
+	//   uv   bun   github:cli/cli   pipx:mypy   npm:serve   http:sentinel
 	Tool string `json:"tool" yaml:"tool"`
-
-	// URL is required for the http backend (the download URL template).
-	URL string `json:"url,omitempty" yaml:"url,omitempty"`
 
 	// Version to install; defaults to "latest" when omitted.
 	Version string `json:"version,omitempty" yaml:"version,omitempty"`
 
-	// Shared asset options (github + http)
-	StripComponents int    `json:"strip_components,omitempty" yaml:"strip_components,omitempty"`
-	BinPath         string `json:"bin_path,omitempty" yaml:"bin_path,omitempty"`
-	Bin             string `json:"bin,omitempty" yaml:"bin,omitempty"`
-	RenameExe       string `json:"rename_exe,omitempty" yaml:"rename_exe,omitempty"`
-	Checksum        string `json:"checksum,omitempty" yaml:"checksum,omitempty"`
-
-	// GitHub-only options
-	AssetPattern  string `json:"asset_pattern,omitempty" yaml:"asset_pattern,omitempty"`
-	VersionPrefix string `json:"version_prefix,omitempty" yaml:"version_prefix,omitempty"`
-	NoApp         bool   `json:"no_app,omitempty" yaml:"no_app,omitempty"`
-	FilterBins    string `json:"filter_bins,omitempty" yaml:"filter_bins,omitempty"`
-	Prerelease    bool   `json:"prerelease,omitempty" yaml:"prerelease,omitempty"`
-	APIURL        string `json:"api_url,omitempty" yaml:"api_url,omitempty"`
-
-	// HTTP-only options
-	Size            string `json:"size,omitempty" yaml:"size,omitempty"`
-	Format          string `json:"format,omitempty" yaml:"format,omitempty"`
-	VersionListURL  string `json:"version_list_url,omitempty" yaml:"version_list_url,omitempty"`
-	VersionRegex    string `json:"version_regex,omitempty" yaml:"version_regex,omitempty"`
-	VersionJSONPath string `json:"version_json_path,omitempty" yaml:"version_json_path,omitempty"`
-	VersionExpr     string `json:"version_expr,omitempty" yaml:"version_expr,omitempty"`
-
-	// Pipx-only options
-	Extras   string `json:"extras,omitempty" yaml:"extras,omitempty"`
-	PipxArgs string `json:"pipx_args,omitempty" yaml:"pipx_args,omitempty"`
-	UVX      bool   `json:"uvx,omitempty" yaml:"uvx,omitempty"`
-	UVXArgs  string `json:"uvx_args,omitempty" yaml:"uvx_args,omitempty"`
+	// Options are mise tool options, using the same names as mise.toml.
+	Options map[string]any `json:"options,omitempty" yaml:",inline"`
 }
 
 type ManifestSkill struct {

--- a/internal/manifestplugins/validate.go
+++ b/internal/manifestplugins/validate.go
@@ -70,35 +70,7 @@ func Validate(m *Manifest) error {
 				errs = append(errs, fmt.Errorf("plugin %q binary[%d]: name is required", p.ID, j))
 			}
 			if b.Tool == "" {
-				errs = append(errs, fmt.Errorf("plugin %q binary[%d]: tool is required (e.g. github:owner/repo)", p.ID, j))
-			} else {
-				idx := strings.IndexByte(b.Tool, ':')
-				if idx < 0 {
-					errs = append(errs, fmt.Errorf("plugin %q binary[%d]: tool must be in backend:identifier format (e.g. github:owner/repo)", p.ID, j))
-				} else {
-					backend := b.Tool[:idx]
-					identifier := b.Tool[idx+1:]
-					switch backend {
-					case "github":
-						if !strings.Contains(identifier, "/") {
-							errs = append(errs, fmt.Errorf("plugin %q binary[%d]: github tool identifier must be owner/repo (got %q)", p.ID, j, identifier))
-						}
-					case "http":
-						if b.URL == "" {
-							errs = append(errs, fmt.Errorf("plugin %q binary[%d]: url is required for http backend", p.ID, j))
-						}
-					case "pipx", "npm":
-						// identifier is the package name; no format constraint
-					default:
-						errs = append(errs, fmt.Errorf("plugin %q binary[%d]: unknown backend %q; must be one of: github, http, pipx, npm", p.ID, j, backend))
-					}
-				}
-			}
-			if b.StripComponents < 0 {
-				errs = append(errs, fmt.Errorf("plugin %q binary[%d]: strip_components must be non-negative", p.ID, j))
-			}
-			if b.Checksum != "" && !strings.Contains(b.Checksum, ":") {
-				errs = append(errs, fmt.Errorf("plugin %q binary[%d]: checksum must be in algo:hex format (e.g. sha256:...)", p.ID, j))
+				errs = append(errs, fmt.Errorf("plugin %q binary[%d]: tool is required (e.g. uv or github:owner/repo)", p.ID, j))
 			}
 		}
 		for j, s := range p.Skills {

--- a/internal/manifestplugins/validate_test.go
+++ b/internal/manifestplugins/validate_test.go
@@ -34,15 +34,27 @@ func TestValidate_BinaryNoTool(t *testing.T) {
 	}
 }
 
-func TestValidate_BinaryGithubNoSlash(t *testing.T) {
+func TestValidate_BinaryMiseRegistryTool(t *testing.T) {
+	m := &Manifest{Plugins: []ManifestPlugin{
+		{
+			ID:       "tool/uv",
+			Binaries: []ManifestBinary{{Name: "uv", Tool: "uv"}},
+		},
+	}}
+	if err := Validate(m); err != nil {
+		t.Errorf("expected no error for mise registry tool, got: %v", err)
+	}
+}
+
+func TestValidate_LeavesToolKeysToMise(t *testing.T) {
 	m := &Manifest{Plugins: []ManifestPlugin{
 		{
 			ID:       "tool/x",
 			Binaries: []ManifestBinary{{Name: "x", Tool: "github:repo"}},
 		},
 	}}
-	if err := Validate(m); err == nil {
-		t.Error("expected error for github tool without owner/repo format")
+	if err := Validate(m); err != nil {
+		t.Errorf("expected no error for mise-owned tool key validation, got: %v", err)
 	}
 }
 

--- a/plugins/sandbox/docker/toolcache.go
+++ b/plugins/sandbox/docker/toolcache.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log/slog"
+	"maps"
 	"strings"
 	"time"
 
@@ -32,45 +33,9 @@ const (
 // Fields mirror manifestplugins.ManifestBinary 1:1; keep them in sync.
 type ToolBinary struct {
 	Name    string
-	Tool    string // mise tool key: github:owner/repo, pipx:pkg, npm:pkg, http:name
-	URL     string // required for http backend
+	Tool    string // mise tool key: uv, bun, github:owner/repo, pipx:pkg, npm:pkg, http:name
 	Version string
-
-	// Shared asset options (github + http)
-	StripComponents int
-	BinPath         string
-	Bin             string
-	RenameExe       string
-	Checksum        string
-
-	// GitHub-only
-	AssetPattern  string
-	VersionPrefix string
-	NoApp         bool
-	FilterBins    string
-	Prerelease    bool
-	APIURL        string
-
-	// HTTP-only
-	Size            string
-	Format          string
-	VersionListURL  string
-	VersionRegex    string
-	VersionJSONPath string
-	VersionExpr     string
-
-	// Pipx-only
-	Extras   string
-	PipxArgs string
-	UVX      bool
-	UVXArgs  string
-}
-
-func (b ToolBinary) resolvedBackend() string {
-	if idx := strings.IndexByte(b.Tool, ':'); idx >= 0 {
-		return b.Tool[:idx]
-	}
-	return ""
+	Options map[string]any // mise tool options, using the same names as mise.toml
 }
 
 func (b ToolBinary) miseToolKey() string {
@@ -196,35 +161,13 @@ func userToolCacheHash(image string, binaries []ToolBinary) string {
 	buf.WriteString(image)
 	buf.WriteByte('\n')
 	for _, b := range binaries {
-		// Include all identity and option fields so any change busts the cache.
-		fmt.Fprintf(&buf, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
-			b.Name, b.Tool, b.URL, b.Version,
-			b.Checksum, b.StripComponents, b.BinPath, b.Bin, b.RenameExe,
-			b.AssetPattern, b.VersionPrefix, b.FilterBins, b.NoApp, b.APIURL,
-			b.Size, b.Format, b.VersionListURL, b.VersionRegex, b.VersionJSONPath, b.VersionExpr,
-			b.UVX, b.Extras, b.PipxArgs, b.UVXArgs,
-		)
+		fmt.Fprintf(&buf, "%v\t%v\t%v\t", b.Name, b.Tool, b.Version)
+		options, _ := toml.Marshal(b.Options)
+		buf.Write(options)
+		buf.WriteByte('\n')
 	}
 	sum := sha256.Sum256(buf.Bytes())
 	return hex.EncodeToString(sum[:])
-}
-
-func toolBinarySharedOptions(b ToolBinary, m map[string]any) {
-	if b.StripComponents > 0 {
-		m["strip_components"] = b.StripComponents
-	}
-	if b.BinPath != "" {
-		m["bin_path"] = b.BinPath
-	}
-	if b.Bin != "" {
-		m["bin"] = b.Bin
-	}
-	if b.RenameExe != "" {
-		m["rename_exe"] = b.RenameExe
-	}
-	if b.Checksum != "" {
-		m["checksum"] = b.Checksum
-	}
 }
 
 func userToolsMiseTOML(binaries []ToolBinary) (string, error) {
@@ -239,85 +182,18 @@ func userToolsMiseTOML(binaries []ToolBinary) (string, error) {
 			ver = "latest"
 		}
 
-		var toolValue any
-		switch b.resolvedBackend() {
-		case "github":
-			m := map[string]any{"version": ver}
-			if b.AssetPattern != "" {
-				m["asset_pattern"] = b.AssetPattern
-			}
-			if b.VersionPrefix != "" {
-				m["version_prefix"] = b.VersionPrefix
-			}
-			if b.NoApp {
-				m["no_app"] = true
-			}
-			if b.FilterBins != "" {
-				m["filter_bins"] = b.FilterBins
-			}
-			if b.Prerelease {
-				m["prerelease"] = true
-			}
-			if b.APIURL != "" {
-				m["api_url"] = b.APIURL
-			}
-			toolBinarySharedOptions(b, m)
-			if len(m) == 1 {
-				toolValue = ver
-			} else {
-				toolValue = m
-			}
-
-		case "http":
-			m := map[string]any{"version": ver, "url": b.URL}
-			if b.Size != "" {
-				m["size"] = b.Size
-			}
-			if b.Format != "" {
-				m["format"] = b.Format
-			}
-			if b.VersionListURL != "" {
-				m["version_list_url"] = b.VersionListURL
-			}
-			if b.VersionRegex != "" {
-				m["version_regex"] = b.VersionRegex
-			}
-			if b.VersionJSONPath != "" {
-				m["version_json_path"] = b.VersionJSONPath
-			}
-			if b.VersionExpr != "" {
-				m["version_expr"] = b.VersionExpr
-			}
-			toolBinarySharedOptions(b, m)
-			toolValue = m
-
-		case "pipx":
-			m := map[string]any{"version": ver}
-			if b.Extras != "" {
-				m["extras"] = b.Extras
-			}
-			if b.PipxArgs != "" {
-				m["pipx_args"] = b.PipxArgs
-			}
-			if b.UVX {
-				m["uvx"] = true
-			}
-			if b.UVXArgs != "" {
-				m["uvx_args"] = b.UVXArgs
-			}
-			if len(m) == 1 {
-				toolValue = ver
-			} else {
-				toolValue = m
-			}
-
-		case "npm":
-			toolValue = ver
-
-		default:
-			return "", fmt.Errorf("binary %q: unsupported backend %q", b.Name, b.resolvedBackend())
+		options := maps.Clone(b.Options)
+		if options == nil {
+			options = make(map[string]any)
 		}
 
+		var toolValue any = ver
+		if len(options) > 0 {
+			if _, ok := options["version"]; !ok {
+				options["version"] = ver
+			}
+			toolValue = options
+		}
 		tools[key] = toolValue
 	}
 	data, err := toml.Marshal(map[string]any{"tools": tools})
@@ -353,10 +229,10 @@ func userToolInstallScript(hash string, binaries []ToolBinary) string {
 	script.WriteString("MISE_DATA_DIR=\"$ROOT/mise-data\" MISE_TRUSTED_CONFIG_PATHS=\"$ROOT\" mise install\n")
 	for _, b := range binaries {
 		lookup := b.Name
-		if b.RenameExe != "" {
-			lookup = b.RenameExe
-		} else if b.Bin != "" {
-			lookup = b.Bin
+		if renameExe, ok := stringOption(b.Options, "rename_exe"); ok {
+			lookup = renameExe
+		} else if bin, ok := stringOption(b.Options, "bin"); ok {
+			lookup = bin
 		}
 		script.WriteString("install_dir=$(MISE_DATA_DIR=\"$ROOT/mise-data\" MISE_TRUSTED_CONFIG_PATHS=\"$ROOT\" mise where " + shellQuote(b.miseToolKey()) + ")\n")
 		script.WriteString("src=\"\"\n")
@@ -368,6 +244,15 @@ func userToolInstallScript(hash string, binaries []ToolBinary) string {
 	}
 	script.WriteString("printf '%s' \"$HASH\" > \"$ROOT/.stella-tools-ready\"\n")
 	return script.String()
+}
+
+func stringOption(options map[string]any, key string) (string, bool) {
+	value, ok := options[key]
+	if !ok {
+		return "", false
+	}
+	s, ok := value.(string)
+	return s, ok && s != ""
 }
 
 func shellQuote(s string) string {

--- a/plugins/sandbox/docker/toolcache_test.go
+++ b/plugins/sandbox/docker/toolcache_test.go
@@ -1,0 +1,17 @@
+package docker
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUserToolsMiseTOMLRegistryTool(t *testing.T) {
+	got, err := userToolsMiseTOML([]ToolBinary{{Name: "uv", Tool: "uv"}})
+	if err != nil {
+		t.Fatalf("userToolsMiseTOML: %v", err)
+	}
+	want := `uv = 'latest'`
+	if !strings.Contains(got, want) {
+		t.Fatalf("expected registry tool form %q in:\n%s", want, got)
+	}
+}

--- a/resources/plugins.yaml
+++ b/resources/plugins.yaml
@@ -366,6 +366,7 @@ plugins:
     binaries:
       - name: tap
         tool: github:vaayne/tap
+        version: "0.4.7"
       - name: lightpanda
         tool: github:lightpanda-io/browser
         version: "nightly"
@@ -456,3 +457,23 @@ plugins:
         tool: github:kreuzberg-dev/kreuzberg
         version: 4.9.5
         asset_pattern: "kreuzberg-cli-*.tar.gz"
+
+  - id: tool/uv
+    kind: tool
+    name: uv
+    display_name: uv
+    description: "An extremely fast Python package manager and resolver written in Rust."
+    enabled: true
+    binaries:
+      - name: uv
+        tool: uv
+
+  - id: tool/bun
+    kind: tool
+    name: bun
+    display_name: Bun
+    description: "An incredibly fast JavaScript runtime, bundler, test runner, and package manager."
+    enabled: true
+    binaries:
+      - name: bun
+        tool: bun

--- a/resources/skills/system/tap-web/SKILL.md
+++ b/resources/skills/system/tap-web/SKILL.md
@@ -1,10 +1,14 @@
 ---
-description: Access websites, search the web, and extract clean content using the `tap` CLI. Supports structured site scripts, readable page extraction, and browser automation for tabs, screenshots, forms, cookies, JavaScript evaluation, and network capture. Use for web lookup, page reading, content extraction, browser interaction, authenticated sessions, request interception, or CDP-connected desktop apps.
+name: tap-web
 metadata:
   author: vaayne/tap
-  owner_plugin: tool/tap-web
-  version: v0.4.4
-name: tap-web
+  version: "v0.4.7"
+description: >
+  Access websites, search the web, and extract clean content using the `tap` CLI.
+  Supports structured site scripts, readable page extraction, and browser automation
+  for tabs, screenshots, forms, cookies, JavaScript evaluation, and network capture.
+  Use for web lookup, page reading, content extraction, browser interaction,
+  authenticated sessions, request interception, or CDP-connected desktop apps.
 ---
 
 # tap-web


### PR DESCRIPTION
## Summary
- add uv and bun as built-in manifest tools using mise registry tool names
- support bare mise registry tool names in manifest validation, local install, and Docker tool cache
- update tap-web skill metadata to v0.4.7

## Verification
- mise run format
- mise run test