### PR TITLE
fix(sandbox): allow file tools to read extra mounts; block writes to them

### DIFF
--- a/internal/agent/coretools/tools.go
+++ b/internal/agent/coretools/tools.go
@@ -50,7 +50,11 @@ func resolveToolPath(host sandbox.Host, projectRoot, path string) (string, error
 
 func resolveWritableToolPath(host sandbox.Host, projectRoot, path string) (string, error) {
 	if projectRoot != "" {
-		return tools.ResolveProjectPath(projectRoot, path)
+		resolved, err := tools.ResolveProjectPath(projectRoot, path)
+		if err != nil {
+			return "", err
+		}
+		return host.ResolveWritePath(resolved)
 	}
 	return host.ResolveWritePath(path)
 }

--- a/internal/agent/coretools/tools.go
+++ b/internal/agent/coretools/tools.go
@@ -48,6 +48,13 @@ func resolveToolPath(host sandbox.Host, projectRoot, path string) (string, error
 	return host.ResolvePath(path)
 }
 
+func resolveWritableToolPath(host sandbox.Host, projectRoot, path string) (string, error) {
+	if projectRoot != "" {
+		return tools.ResolveProjectPath(projectRoot, path)
+	}
+	return host.ResolveWritePath(path)
+}
+
 type hostBashTool struct {
 	host        sandbox.Host
 	normalizer  *toolNormalizer
@@ -199,7 +206,7 @@ func (t *hostWriteTool) Execute(_ context.Context, args map[string]any) (string,
 		return "", fmt.Errorf("write: path is required")
 	}
 
-	resolvedPath, err := resolveToolPath(t.host, t.projectRoot, path)
+	resolvedPath, err := resolveWritableToolPath(t.host, t.projectRoot, path)
 	if err != nil {
 		return "", fmt.Errorf("write %s: %w", path, err)
 	}
@@ -246,7 +253,7 @@ func (t *hostEditTool) Execute(_ context.Context, args map[string]any) (string, 
 		return "", fmt.Errorf("edit: old_string is required")
 	}
 
-	resolvedPath, err := resolveToolPath(t.host, t.projectRoot, path)
+	resolvedPath, err := resolveWritableToolPath(t.host, t.projectRoot, path)
 	if err != nil {
 		return "", fmt.Errorf("edit %s: %w", path, err)
 	}

--- a/internal/agent/coretools/tools_test.go
+++ b/internal/agent/coretools/tools_test.go
@@ -21,6 +21,10 @@ func (s *stubHost) ResolvePath(path string) (string, error) {
 	return path, nil
 }
 
+func (s *stubHost) ResolveWritePath(path string) (string, error) {
+	return s.ResolvePath(path)
+}
+
 func TestToolIntArg(t *testing.T) {
 	tests := []struct {
 		args map[string]any

--- a/internal/agent/coretools_builder_test.go
+++ b/internal/agent/coretools_builder_test.go
@@ -35,8 +35,9 @@ func (f *fakeSession) Exec(_ context.Context, _ string, _ pkgsandbox.ExecOptions
 func (f *fakeSession) StartProcess(_ context.Context, _ pkgsandbox.ProcessRequest) (pkgsandbox.ProcessHandle, error) {
 	return nil, nil
 }
-func (f *fakeSession) ResolvePath(path string) (string, error) { return path, nil }
-func (f *fakeSession) WorkingDir() string                      { return "/tmp" }
+func (f *fakeSession) ResolvePath(path string) (string, error)      { return path, nil }
+func (f *fakeSession) ResolveWritePath(path string) (string, error) { return path, nil }
+func (f *fakeSession) WorkingDir() string                           { return "/tmp" }
 
 func TestBuildSandboxCoreTools_NoSessionFailsClosed(t *testing.T) {
 	tools := buildSandboxCoreTools(nil, plugintools.BuildContext{Paths: pkgplugins.ToolPaths{ToolsBinDir: "/tmp/bin"}})

--- a/pkg/sandbox/session.go
+++ b/pkg/sandbox/session.go
@@ -21,7 +21,11 @@ type Session interface {
 	StartProcess(ctx context.Context, req ProcessRequest) (ProcessHandle, error)
 
 	// Path resolution — use os.* with the resolved path for file I/O.
+	// ResolvePath validates read access; use ResolveWritePath for write operations.
 	ResolvePath(path string) (string, error)
+	// ResolveWritePath is like ResolvePath but additionally rejects paths in
+	// read-only mounts (e.g. ExtraReadOnlyMounts / skill directories).
+	ResolveWritePath(path string) (string, error)
 	WorkingDir() string
 }
 
@@ -100,5 +104,6 @@ func (s *nopSession) Exec(_ context.Context, _ string, _ ExecOptions) (ExecResul
 func (s *nopSession) StartProcess(_ context.Context, _ ProcessRequest) (ProcessHandle, error) {
 	return nil, nil
 }
-func (s *nopSession) ResolvePath(path string) (string, error) { return path, nil }
-func (s *nopSession) WorkingDir() string                      { return "" }
+func (s *nopSession) ResolvePath(path string) (string, error)      { return path, nil }
+func (s *nopSession) ResolveWritePath(path string) (string, error) { return path, nil }
+func (s *nopSession) WorkingDir() string                           { return "" }

--- a/plugins/sandbox/docker/session.go
+++ b/plugins/sandbox/docker/session.go
@@ -146,6 +146,17 @@ func (f *dockerFactory) CreateSession(ctx context.Context, policy sandboxpkg.Pol
 			ContainerPath: hostPath,
 			ReadOnly:      true,
 		})
+		// For paths that live inside the workspace host dir, also mount them
+		// read-only at their workspace-relative container path. Without this,
+		// bash can write to them via the writable workspace mount.
+		rel, relErr := filepath.Rel(workspaceHost, hostPath)
+		if relErr == nil && !strings.HasPrefix(rel, "..") && rel != "." {
+			opts.ReadOnlyMounts = append(opts.ReadOnlyMounts, dockerclient.Mount{
+				HostPath:      f.cfg.TranslateToDaemonPath(hostPath),
+				ContainerPath: filepath.Join(workspaceMount, rel),
+				ReadOnly:      true,
+			})
+		}
 	}
 
 	var toolBinPaths []string

--- a/plugins/sandbox/docker/session.go
+++ b/plugins/sandbox/docker/session.go
@@ -342,7 +342,10 @@ func (s *dockerSession) StartProcess(ctx context.Context, req sandboxpkg.Process
 	return s.host.StartProcess(ctx, req)
 }
 func (s *dockerSession) ResolvePath(path string) (string, error) { return s.host.ResolvePath(path) }
-func (s *dockerSession) WorkingDir() string                      { return s.host.WorkingDir() }
+func (s *dockerSession) ResolveWritePath(path string) (string, error) {
+	return s.host.ResolveWritePath(path)
+}
+func (s *dockerSession) WorkingDir() string { return s.host.WorkingDir() }
 
 func (s *dockerSession) Alive() bool {
 	s.mu.RLock()
@@ -552,6 +555,39 @@ func deepestMountRoot(mounts []dockerclient.Mount, path string) string {
 		}
 	}
 	return best
+}
+
+// deepestMount returns the mount with the longest HostPath prefix containing
+// path, or nil if no mount covers it.
+func deepestMount(mounts []dockerclient.Mount, path string) *dockerclient.Mount {
+	var best *dockerclient.Mount
+	for i := range mounts {
+		m := &mounts[i]
+		rel, err := filepath.Rel(m.HostPath, path)
+		if err != nil {
+			continue
+		}
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			continue
+		}
+		if best == nil || len(m.HostPath) > len(best.HostPath) {
+			best = m
+		}
+	}
+	return best
+}
+
+// ResolveWritePath is like ResolvePath but additionally rejects paths that
+// fall within a read-only mount.
+func (h *dockerHost) ResolveWritePath(path string) (string, error) {
+	resolved, err := h.ResolvePath(path)
+	if err != nil {
+		return "", err
+	}
+	if m := deepestMount(h.session.mountTable, resolved); m != nil && m.ReadOnly {
+		return "", fmt.Errorf("docker host: path %q is in a read-only mount", path)
+	}
+	return resolved, nil
 }
 
 func (h *dockerHost) Exec(ctx context.Context, command string, opts sandboxpkg.ExecOptions) (sandboxpkg.ExecResult, error) {

--- a/plugins/sandbox/local/session.go
+++ b/plugins/sandbox/local/session.go
@@ -150,6 +150,19 @@ func (s *localSession) ResolvePath(agentPath string) (string, error) {
 	return resolved, err
 }
 
+// ResolveWritePath is like ResolvePath but additionally rejects paths that
+// fall within ExtraReadOnlyMounts.
+func (s *localSession) ResolveWritePath(agentPath string) (string, error) {
+	resolved, _, err := s.resolvePath(agentPath)
+	if err != nil {
+		return "", err
+	}
+	if matchingExtraMount(s.policy.Filesystem.ExtraReadOnlyMounts, resolved) != "" {
+		return "", fmt.Errorf("local: path %q is in a read-only mount", agentPath)
+	}
+	return resolved, nil
+}
+
 // resolveCwd validates a requested working directory, then returns both its
 // real host path and sandbox-space path. Linux bwrap needs the sandbox-space
 // path for --chdir; direct local execution uses the real path.
@@ -185,14 +198,35 @@ func (s *localSession) resolvePath(agentPath string) (realPath, sandboxPath stri
 	resolved = filepath.Clean(resolved)
 
 	cleanRoot := filepath.Clean(s.realRoot)
-	if !pathWithinRoot(cleanRoot, resolved) {
-		return "", "", fmt.Errorf("local: path %q resolves to %q which is outside workspace root %q", agentPath, resolved, s.realRoot)
-	}
-	if err := rejectLocalSymlinkTraversal(cleanRoot, real); err != nil {
-		return "", "", fmt.Errorf("local: %w", err)
+	if pathWithinRoot(cleanRoot, resolved) {
+		if err := rejectLocalSymlinkTraversal(cleanRoot, real); err != nil {
+			return "", "", fmt.Errorf("local: %w", err)
+		}
+		return resolved, s.toSandboxPath(resolved), nil
 	}
 
-	return resolved, s.toSandboxPath(resolved), nil
+	// Also allow access to extra read-only mounts (e.g. agent-level skill dirs).
+	if mountRoot := matchingExtraMount(s.policy.Filesystem.ExtraReadOnlyMounts, resolved); mountRoot != "" {
+		if err := rejectLocalSymlinkTraversal(mountRoot, real); err != nil {
+			return "", "", fmt.Errorf("local: %w", err)
+		}
+		return resolved, s.toSandboxPath(resolved), nil
+	}
+
+	return "", "", fmt.Errorf("local: path %q resolves to %q which is outside workspace root %q", agentPath, resolved, s.realRoot)
+}
+
+// matchingExtraMount returns the longest extra read-only mount that contains
+// resolved, or "" if none match.
+func matchingExtraMount(mounts []string, resolved string) string {
+	best := ""
+	for _, m := range mounts {
+		clean := filepath.Clean(m)
+		if pathWithinRoot(clean, resolved) && len(clean) > len(best) {
+			best = clean
+		}
+	}
+	return best
 }
 
 // pathWithinRoot reports whether path is the root itself or is contained under it.

--- a/plugins/sandbox/local/session_linux.go
+++ b/plugins/sandbox/local/session_linux.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 

--- a/plugins/sandbox/local/session_linux.go
+++ b/plugins/sandbox/local/session_linux.go
@@ -228,6 +228,16 @@ func wrapCommand(policy sandboxpkg.Policy, sandboxCwd, name string, args []strin
 		"--bind", realRoot, "/workspace",
 		"--chdir", sandboxCwd,
 	)
+	// Re-mount workspace-contained extra paths read-only at their /workspace/...
+	// equivalent. This overrides the writable workspace bind for those subdirectories
+	// so bash cannot write to them via /workspace.
+	for _, extraPath := range policy.Filesystem.ExtraReadOnlyMounts {
+		rel, relErr := filepath.Rel(realRoot, filepath.Clean(extraPath))
+		if relErr != nil || strings.HasPrefix(rel, "..") || rel == "." {
+			continue
+		}
+		bwrapArgs = appendRoBindIfExists(bwrapArgs, extraPath, filepath.Join("/workspace", rel))
+	}
 	if networkMode != sandboxpkg.NetworkAllowAll {
 		bwrapArgs = append(bwrapArgs, "--unshare-net")
 	}

--- a/plugins/sandbox/local/session_test.go
+++ b/plugins/sandbox/local/session_test.go
@@ -245,6 +245,133 @@ func TestResolvePath_remapped(t *testing.T) {
 	}
 }
 
+// TestResolvePath_extraMountAllowed verifies that ResolvePath accepts paths
+// within an ExtraReadOnlyMount even when they are outside the workspace root.
+func TestResolvePath_extraMountAllowed(t *testing.T) {
+	root := t.TempDir()
+	root, _ = filepath.EvalSymlinks(root)
+	mountDir := t.TempDir()
+	mountDir, _ = filepath.EvalSymlinks(mountDir)
+
+	skillFile := filepath.Join(mountDir, "skill.py")
+	if err := os.WriteFile(skillFile, []byte("# skill"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	policy := sandboxpkg.Policy{
+		Filesystem: sandboxpkg.FilesystemPolicy{
+			WorkspaceRoot:       root,
+			WorkingDir:          root,
+			ExtraReadOnlyMounts: []string{mountDir},
+		},
+	}
+	s := &localSession{
+		id:          "test",
+		policy:      policy,
+		realRoot:    root,
+		sandboxRoot: root,
+		done:        make(chan struct{}),
+	}
+
+	got, err := s.ResolvePath(skillFile)
+	if err != nil {
+		t.Fatalf("unexpected error for extra mount path: %v", err)
+	}
+	if got != skillFile {
+		t.Errorf("ResolvePath = %q, want %q", got, skillFile)
+	}
+}
+
+// TestResolvePath_rejectsAdjacentToExtraMount verifies that a path adjacent to
+// (but not within) an ExtraReadOnlyMount is still rejected.
+// TestResolveWritePath_rejectsExtraMount verifies that ResolveWritePath rejects
+// paths within ExtraReadOnlyMounts even though ResolvePath accepts them.
+func TestResolveWritePath_rejectsExtraMount(t *testing.T) {
+	root := t.TempDir()
+	root, _ = filepath.EvalSymlinks(root)
+	mountDir := t.TempDir()
+	mountDir, _ = filepath.EvalSymlinks(mountDir)
+
+	skillFile := filepath.Join(mountDir, "skill.py")
+	if err := os.WriteFile(skillFile, []byte("# skill"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	policy := sandboxpkg.Policy{
+		Filesystem: sandboxpkg.FilesystemPolicy{
+			WorkspaceRoot:       root,
+			WorkingDir:          root,
+			ExtraReadOnlyMounts: []string{mountDir},
+		},
+	}
+	s := &localSession{
+		id:          "test",
+		policy:      policy,
+		realRoot:    root,
+		sandboxRoot: root,
+		done:        make(chan struct{}),
+	}
+
+	// ResolvePath should accept it.
+	if _, err := s.ResolvePath(skillFile); err != nil {
+		t.Fatalf("ResolvePath unexpectedly rejected extra mount path: %v", err)
+	}
+
+	// ResolveWritePath must reject it.
+	_, err := s.ResolveWritePath(skillFile)
+	if err == nil {
+		t.Fatal("expected ResolveWritePath to reject read-only mount path, got nil")
+	}
+}
+
+// TestResolveWritePath_acceptsWorkspace verifies that ResolveWritePath allows
+// paths within the writable workspace root.
+func TestResolveWritePath_acceptsWorkspace(t *testing.T) {
+	s, root := newTestSession(t)
+
+	f := filepath.Join(root, "output.txt")
+	if err := os.WriteFile(f, []byte("data"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got, err := s.ResolveWritePath(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != f {
+		t.Errorf("ResolveWritePath = %q, want %q", got, f)
+	}
+}
+
+func TestResolvePath_rejectsAdjacentToExtraMount(t *testing.T) {
+	root := t.TempDir()
+	root, _ = filepath.EvalSymlinks(root)
+	mountDir := t.TempDir()
+	mountDir, _ = filepath.EvalSymlinks(mountDir)
+
+	policy := sandboxpkg.Policy{
+		Filesystem: sandboxpkg.FilesystemPolicy{
+			WorkspaceRoot:       root,
+			WorkingDir:          root,
+			ExtraReadOnlyMounts: []string{mountDir},
+		},
+	}
+	s := &localSession{
+		id:          "test",
+		policy:      policy,
+		realRoot:    root,
+		sandboxRoot: root,
+		done:        make(chan struct{}),
+	}
+
+	// A sibling directory of mountDir — not inside any mount.
+	adjacent := filepath.Join(filepath.Dir(mountDir), "adjacent")
+	_, err := s.ResolvePath(adjacent)
+	if err == nil {
+		t.Fatal("expected error for path adjacent to extra mount, got nil")
+	}
+}
+
 func TestResolvePath_rejectsSymlinkParentForMissingPath(t *testing.T) {
 	s, root := newTestSession(t)
 	outside := t.TempDir()

--- a/plugins/sandbox/none/session.go
+++ b/plugins/sandbox/none/session.go
@@ -99,6 +99,12 @@ func (s *noneSession) ResolvePath(path string) (string, error) {
 	return filepath.Join(s.WorkingDir(), path), nil
 }
 
+// ResolveWritePath is the same as ResolvePath for the none backend, which has
+// no mount-level isolation.
+func (s *noneSession) ResolveWritePath(path string) (string, error) {
+	return s.ResolvePath(path)
+}
+
 func (s *noneSession) Exec(ctx context.Context, command string, opts sandboxpkg.ExecOptions) (sandboxpkg.ExecResult, error) {
 	s.mu.RLock()
 	closed := s.closed

--- a/plugins/tools/mcp/session_test.go
+++ b/plugins/tools/mcp/session_test.go
@@ -136,8 +136,9 @@ func (h *stdioHostStub) StartProcess(_ context.Context, req sandbox.ProcessReque
 	h.req = req
 	return stdioProcessStub{}, nil
 }
-func (h *stdioHostStub) ResolvePath(path string) (string, error) { return path, nil }
-func (h *stdioHostStub) WorkingDir() string                      { return "/" }
+func (h *stdioHostStub) ResolvePath(path string) (string, error)      { return path, nil }
+func (h *stdioHostStub) ResolveWritePath(path string) (string, error) { return path, nil }
+func (h *stdioHostStub) WorkingDir() string                           { return "/" }
 
 type stdioProcessStub struct{}
 


### PR DESCRIPTION
## Summary

- **Bug fix**: `ResolvePath` now accepts paths within `ExtraReadOnlyMounts` (agent-level and system skill dirs), so the `read` tool can access system skill scripts. Previously bwrap mounted these dirs correctly but the path guard rejected them for file tools with _"outside workspace root"_.
- **Security fix**: New `ResolveWritePath` method on the `Session` interface rejects paths in read-only mounts. The `write` and `edit` tools now call this instead of `ResolvePath`, closing a gap where they could bypass `--ro-bind` protection by doing `os.WriteFile` directly on the host.
- Both the local (bwrap) and docker backends implement `ResolveWritePath`, checking `ExtraReadOnlyMounts` and `mountTable.ReadOnly` respectively.

## Root cause

`resolvePath` in `plugins/sandbox/local/session.go` only validated against `realRoot` (user workspace `users/<id>`). The docker backend uses a `mountTable` and was unaffected. The `none` backend has no isolation so `ResolveWritePath` is a passthrough.

## Test plan

- [ ] `TestResolvePath_extraMountAllowed` — read tool accepts skill dir paths
- [ ] `TestResolvePath_rejectsAdjacentToExtraMount` — paths adjacent to (not within) extra mounts are still rejected
- [ ] `TestResolveWritePath_rejectsExtraMount` — write tool rejects skill dir paths
- [ ] `TestResolveWritePath_acceptsWorkspace` — write tool still works on workspace paths
- [ ] `mise run build && mise run test` — all green