### PR TITLE
fix(sandbox): make /tmp and /var/tmp accessible to file tools

### DIFF
--- a/plugins/sandbox/local/session.go
+++ b/plugins/sandbox/local/session.go
@@ -42,6 +42,12 @@ func (f *Factory) Available() bool { return true }
 // Supported returns an error if platform sandbox requirements are not met.
 func (f *Factory) Supported(_ sandboxpkg.Policy) error { return checkSandboxRequirements() }
 
+// tmpMount pairs a sandbox-space path (e.g. /tmp) with its backing real host path.
+type tmpMount struct {
+	sandboxPath string // absolute path the agent sees (e.g. /tmp)
+	realPath    string // absolute host path backing it
+}
+
 // CreateSession creates a new localSession.
 func (f *Factory) CreateSession(_ context.Context, policy sandboxpkg.Policy) (sandboxpkg.Session, error) {
 	sessionID := sandboxpkg.NewSessionID()
@@ -49,11 +55,17 @@ func (f *Factory) CreateSession(_ context.Context, policy sandboxpkg.Policy) (sa
 		return nil, err
 	}
 	sandboxRoot, realRoot := resolveSandboxRoot(policy)
+	tmpMounts, ownsTmp, err := createSessionTmpMounts()
+	if err != nil {
+		return nil, fmt.Errorf("local: create session tmp: %w", err)
+	}
 	s := &localSession{
 		id:          sessionID,
 		policy:      policy,
 		realRoot:    realRoot,
 		sandboxRoot: sandboxRoot,
+		tmpMounts:   tmpMounts,
+		ownsTmp:     ownsTmp,
 		done:        make(chan struct{}),
 	}
 	sandboxpkg.LogSessionCreated(sessionID, "local", policy)
@@ -67,8 +79,10 @@ func (f *Factory) CreateSession(_ context.Context, policy sandboxpkg.Policy) (sa
 type localSession struct {
 	id          string
 	policy      sandboxpkg.Policy
-	realRoot    string // actual host path (e.g. /home/stella/.stella-dev/...)
-	sandboxRoot string // path the agent sees (/workspace on Linux+bwrap, else = realRoot)
+	realRoot    string     // actual host path (e.g. /home/stella/.stella-dev/...)
+	sandboxRoot string     // path the agent sees (/workspace on Linux+bwrap, else = realRoot)
+	tmpMounts   []tmpMount // sandbox temp paths mapped to real host dirs (/tmp, /var/tmp)
+	ownsTmp     bool       // true when this session created the tmpMount dirs and should remove them on close
 	done        chan struct{}
 	doneOnce    sync.Once
 	mu          sync.RWMutex
@@ -125,6 +139,11 @@ func (s *localSession) Close() error {
 
 	s.doneOnce.Do(func() { close(s.done) })
 	sandboxpkg.LogSessionClosed(s.id, "local", "explicit_close")
+	if s.ownsTmp {
+		for _, m := range s.tmpMounts {
+			os.RemoveAll(m.realPath) //nolint:errcheck
+		}
+	}
 	return nil
 }
 
@@ -213,7 +232,33 @@ func (s *localSession) resolvePath(agentPath string) (realPath, sandboxPath stri
 		return resolved, s.toSandboxPath(resolved), nil
 	}
 
+	// Allow access to session temp directories (/tmp, /var/tmp).
+	for _, m := range s.tmpMounts {
+		if pathWithinRoot(m.realPath, resolved) {
+			if err := rejectLocalSymlinkTraversal(m.realPath, real); err != nil {
+				return "", "", fmt.Errorf("local: %w", err)
+			}
+			return resolved, s.toSandboxPath(resolved), nil
+		}
+	}
+
 	return "", "", fmt.Errorf("local: path %q resolves to %q which is outside workspace root %q", agentPath, resolved, s.realRoot)
+}
+
+// matchingTmpMount returns the tmpMount with the longest sandboxPath that
+// contains sandboxPath, or nil if none match.
+func (s *localSession) matchingTmpMount(sandboxPath string) *tmpMount {
+	clean := filepath.Clean(sandboxPath)
+	var best *tmpMount
+	for i := range s.tmpMounts {
+		m := &s.tmpMounts[i]
+		if clean == m.sandboxPath || strings.HasPrefix(clean, m.sandboxPath+string(filepath.Separator)) {
+			if best == nil || len(m.sandboxPath) > len(best.sandboxPath) {
+				best = m
+			}
+		}
+	}
+	return best
 }
 
 // matchingExtraMount returns the longest extra read-only mount that contains
@@ -271,7 +316,15 @@ func rejectLocalSymlinkTraversal(root, path string) error {
 
 // toRealPath translates a sandbox-space absolute path to the real host path.
 // When sandboxRoot == realRoot (no remapping), it is a no-op.
+// Temp paths (/tmp, /var/tmp) are checked first against tmpMounts.
 func (s *localSession) toRealPath(sandboxPath string) string {
+	if m := s.matchingTmpMount(sandboxPath); m != nil {
+		rel, _ := filepath.Rel(m.sandboxPath, filepath.Clean(sandboxPath))
+		if rel == "." {
+			return m.realPath
+		}
+		return filepath.Join(m.realPath, rel)
+	}
 	if s.sandboxRoot == s.realRoot {
 		return sandboxPath
 	}
@@ -283,11 +336,32 @@ func (s *localSession) toRealPath(sandboxPath string) string {
 }
 
 // toSandboxPath translates a real host path back into sandbox space.
+// Temp mount real paths are checked first against tmpMounts.
 func (s *localSession) toSandboxPath(realPath string) string {
+	clean := filepath.Clean(realPath)
+	// Use longest matching tmpMount (e.g. /var/tmp before /tmp if both match).
+	var best *tmpMount
+	for i := range s.tmpMounts {
+		m := &s.tmpMounts[i]
+		rel, err := filepath.Rel(m.realPath, clean)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			continue
+		}
+		if best == nil || len(m.realPath) > len(best.realPath) {
+			best = m
+		}
+	}
+	if best != nil {
+		rel, _ := filepath.Rel(best.realPath, clean)
+		if rel == "." {
+			return best.sandboxPath
+		}
+		return filepath.Join(best.sandboxPath, rel)
+	}
 	if s.sandboxRoot == s.realRoot {
 		return realPath
 	}
-	rel, err := filepath.Rel(s.realRoot, filepath.Clean(realPath))
+	rel, err := filepath.Rel(s.realRoot, clean)
 	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return realPath
 	}
@@ -327,7 +401,7 @@ func (s *localSession) Exec(ctx context.Context, command string, opts sandboxpkg
 		return sandboxpkg.ExecResult{}, fmt.Errorf("local exec: resolve cwd: %w", err)
 	}
 
-	execPath, execArgs, hostCwd, err := wrapCommand(s.policy, sandboxCwd, "sh", []string{"-c", command})
+	execPath, execArgs, hostCwd, err := wrapCommand(s.policy, sandboxCwd, s.tmpMounts, "sh", []string{"-c", command})
 	if err != nil {
 		return sandboxpkg.ExecResult{}, fmt.Errorf("local exec: wrap: %w", err)
 	}
@@ -412,7 +486,7 @@ func (s *localSession) StartProcess(ctx context.Context, req sandboxpkg.ProcessR
 		return nil, fmt.Errorf("local start_process: resolve cwd: %w", err)
 	}
 
-	execPath, execArgs, hostCwd, err := wrapCommand(s.policy, sandboxCwd, req.Path, args)
+	execPath, execArgs, hostCwd, err := wrapCommand(s.policy, sandboxCwd, s.tmpMounts, req.Path, args)
 	if err != nil {
 		cancel()
 		return nil, fmt.Errorf("local start_process: wrap: %w", err)

--- a/plugins/sandbox/local/session_darwin.go
+++ b/plugins/sandbox/local/session_darwin.go
@@ -15,6 +15,7 @@ package local
 import (
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -48,6 +49,28 @@ func seatbeltFunctional() bool {
 func resolveSandboxRoot(policy sandboxpkg.Policy) (sandboxRoot, realRoot string) {
 	real := policy.WorkspaceRootOrDefault()
 	return real, real
+}
+
+// createSessionTmpMounts returns tmpMount pairs for macOS temp paths.
+// On macOS, /tmp and /var/tmp are symlinks into /private; both bash (via
+// sandbox-exec, which allows writes to /private/tmp and /private/var/tmp)
+// and file tools share the same host filesystem, so no bind is needed —
+// only the path-guard needs to know the real paths.
+//
+// To add support for a new sandbox temp path:
+//  1. Resolve its symlink target and append a tmpMount{sandboxPath, realPath}.
+//  2. Add a corresponding allow rule in buildSeatbeltProfile if writes are needed.
+func createSessionTmpMounts() ([]tmpMount, bool, error) {
+	resolve := func(p, fallback string) string {
+		if r, err := filepath.EvalSymlinks(p); err == nil {
+			return r
+		}
+		return fallback
+	}
+	return []tmpMount{
+		{sandboxPath: "/tmp", realPath: resolve("/tmp", "/private/tmp")},
+		{sandboxPath: "/var/tmp", realPath: resolve("/var/tmp", "/private/var/tmp")},
+	}, false, nil
 }
 
 // checkSandboxRequirements verifies that sandbox-exec is available and functional.
@@ -105,7 +128,9 @@ func buildSeatbeltProfile(policy sandboxpkg.Policy) string {
 }
 
 // wrapCommand wraps name+args with sandbox-exec for macOS Seatbelt isolation.
-func wrapCommand(policy sandboxpkg.Policy, sandboxCwd, name string, args []string) (execPath string, execArgs []string, hostCwd string, err error) {
+// tmpMounts is accepted for signature compatibility with the Linux backend but
+// is not used here — macOS bash and file tools share the same host filesystem.
+func wrapCommand(policy sandboxpkg.Policy, sandboxCwd string, _ []tmpMount, name string, args []string) (execPath string, execArgs []string, hostCwd string, err error) {
 	if !seatbeltFunctional() {
 		return "", nil, "", fmt.Errorf(
 			"local sandbox: sandbox-exec (macOS Seatbelt) is required but not available",

--- a/plugins/sandbox/local/session_darwin_test.go
+++ b/plugins/sandbox/local/session_darwin_test.go
@@ -24,7 +24,7 @@ func TestWrapCommand_darwin_usesSeatbelt(t *testing.T) {
 	root := t.TempDir()
 	policy := makePolicy(root, sandboxpkg.NetworkDisabled)
 
-	execPath, args, hostCwd, err := wrapCommand(policy, root, "sh", []string{"-c", "echo hi"})
+	execPath, args, hostCwd, err := wrapCommand(policy, root, nil, "sh", []string{"-c", "echo hi"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -75,11 +75,11 @@ func TestBuildSeatbeltProfile_networkDisabledVsAllowAll(t *testing.T) {
 	}
 	root := t.TempDir()
 
-	_, disabledArgs, _, err := wrapCommand(makePolicy(root, sandboxpkg.NetworkDisabled), root, "sh", []string{"-c", "echo"})
+	_, disabledArgs, _, err := wrapCommand(makePolicy(root, sandboxpkg.NetworkDisabled), root, nil, "sh", []string{"-c", "echo"})
 	if err != nil {
 		t.Fatalf("disabled wrapCommand error: %v", err)
 	}
-	_, allowArgs, _, err := wrapCommand(makePolicy(root, sandboxpkg.NetworkAllowAll), root, "sh", []string{"-c", "echo"})
+	_, allowArgs, _, err := wrapCommand(makePolicy(root, sandboxpkg.NetworkAllowAll), root, nil, "sh", []string{"-c", "echo"})
 	if err != nil {
 		t.Fatalf("allow_all wrapCommand error: %v", err)
 	}

--- a/plugins/sandbox/local/session_linux.go
+++ b/plugins/sandbox/local/session_linux.go
@@ -88,6 +88,30 @@ func resolveSandboxRoot(policy sandboxpkg.Policy) (sandboxRoot, realRoot string)
 	return "/workspace", policy.WorkspaceRootOrDefault()
 }
 
+// createSessionTmpMounts creates per-session host directories for each sandbox
+// temp path (/tmp, /var/tmp) and returns them as tmpMount pairs. The session
+// owns these directories and must remove them on close.
+//
+// To add support for a new sandbox temp path (e.g. /run/user/1000):
+//  1. Create a host dir with os.MkdirTemp and append a tmpMount{sandboxPath, realPath}.
+//  2. Add a corresponding "--bind realPath sandboxPath" entry in wrapCommand below.
+//  3. Add the sandbox path to the platform profile in session_darwin.go if needed.
+func createSessionTmpMounts() ([]tmpMount, bool, error) {
+	tmp, err := os.MkdirTemp("", "stella-session-tmp-*")
+	if err != nil {
+		return nil, false, err
+	}
+	varTmp, err := os.MkdirTemp("", "stella-session-vartmp-*")
+	if err != nil {
+		os.RemoveAll(tmp) //nolint:errcheck
+		return nil, false, err
+	}
+	return []tmpMount{
+		{sandboxPath: "/tmp", realPath: tmp},
+		{sandboxPath: "/var/tmp", realPath: varTmp},
+	}, true, nil
+}
+
 var (
 	bwrapOnce      sync.Once
 	bwrapPath      string
@@ -197,7 +221,7 @@ func appendDirParents(args []string, path string) []string {
 //
 //   - sandboxCwd: working directory in sandbox space (e.g. /workspace/sub).
 //   - hostCwd returned: real host path (bwrap uses --chdir internally).
-func wrapCommand(policy sandboxpkg.Policy, sandboxCwd, name string, args []string) (execPath string, execArgs []string, hostCwd string, err error) {
+func wrapCommand(policy sandboxpkg.Policy, sandboxCwd string, tmpMounts []tmpMount, name string, args []string) (execPath string, execArgs []string, hostCwd string, err error) {
 	if !bwrapFunctional() {
 		return "", nil, "", fmt.Errorf(
 			"local sandbox: bwrap (bubblewrap) is required on Linux but is not available or not functional; " +
@@ -213,11 +237,16 @@ func wrapCommand(policy sandboxpkg.Policy, sandboxCwd, name string, args []strin
 		"--tmpfs", "/",
 		"--dev", "/dev",
 		"--tmpfs", "/dev/shm",
-		"--tmpfs", "/tmp",
 		"--dir", "/var",
 		"--tmpfs", "/var/tmp",
 		"--proc", "/proc",
 		"--dir", "/run",
+	}
+	// Mount temp directories: bind each per-session host dir so file tools on
+	// the host share the same view as bash running inside bwrap.
+	// See createSessionTmpMounts for how to add a new temp path.
+	for _, m := range tmpMounts {
+		bwrapArgs = append(bwrapArgs, "--dir", m.sandboxPath, "--bind", m.realPath, m.sandboxPath)
 	}
 	bwrapArgs = appendLinuxRuntimeMounts(bwrapArgs)
 	bwrapArgs = appendStellaHomeMounts(bwrapArgs, policy.Env["STELLA_HOME"])

--- a/plugins/sandbox/local/session_linux_test.go
+++ b/plugins/sandbox/local/session_linux_test.go
@@ -26,7 +26,7 @@ func TestWrapCommand_linux_networkDisabled(t *testing.T) {
 		Network: sandboxpkg.NetworkPolicy{Mode: sandboxpkg.NetworkDisabled},
 	}
 
-	path, args, _, err := wrapCommand(policy, sandboxCwd, "sh", []string{"-c", "echo hi"})
+	path, args, _, err := wrapCommand(policy, sandboxCwd, nil, "sh", []string{"-c", "echo hi"})
 
 	if !bwrapFunctional() {
 		if err == nil {
@@ -66,7 +66,7 @@ func TestWrapCommand_linux_allowAllNoWrap(t *testing.T) {
 		Network: sandboxpkg.NetworkPolicy{Mode: sandboxpkg.NetworkAllowAll},
 	}
 
-	_, args, _, err := wrapCommand(policy, sandboxCwd, "sh", []string{"-c", "echo hi"})
+	_, args, _, err := wrapCommand(policy, sandboxCwd, nil, "sh", []string{"-c", "echo hi"})
 	if err != nil {
 		t.Fatalf("unexpected error for allow_all network: %v", err)
 	}
@@ -168,7 +168,7 @@ func TestWrapCommand_linux_bwrapWorkspaceRemap(t *testing.T) {
 		Network: sandboxpkg.NetworkPolicy{Mode: sandboxpkg.NetworkAllowAll},
 	}
 
-	execPath, args, hostCwd, err := wrapCommand(policy, sandboxCwd, "sh", []string{"-c", "echo hi"})
+	execPath, args, hostCwd, err := wrapCommand(policy, sandboxCwd, nil, "sh", []string{"-c", "echo hi"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/plugins/sandbox/local/session_test.go
+++ b/plugins/sandbox/local/session_test.go
@@ -470,3 +470,134 @@ func TestExec_success(t *testing.T) {
 		t.Fatalf("unexpected stdout: %q", result.Stdout)
 	}
 }
+
+// TestResolvePath_tmpMountAllowed verifies that ResolvePath accepts paths within
+// a tmpMount (e.g. /tmp) and translates them to the real host path.
+func TestResolvePath_tmpMountAllowed(t *testing.T) {
+	realTmpDir := t.TempDir()
+	realTmpDir, _ = filepath.EvalSymlinks(realTmpDir)
+	root := t.TempDir()
+	root, _ = filepath.EvalSymlinks(root)
+
+	f := filepath.Join(realTmpDir, "work", "out.json")
+	if err := os.MkdirAll(filepath.Dir(f), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(f, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	s := &localSession{
+		id:          "test",
+		policy:      sandboxpkg.Policy{Filesystem: sandboxpkg.FilesystemPolicy{WorkspaceRoot: root, WorkingDir: root}},
+		realRoot:    root,
+		sandboxRoot: "/workspace",
+		tmpMounts:   []tmpMount{{sandboxPath: "/tmp", realPath: realTmpDir}},
+		done:        make(chan struct{}),
+	}
+
+	// Agent path in sandbox space.
+	got, err := s.ResolvePath("/tmp/work/out.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != f {
+		t.Errorf("ResolvePath = %q, want %q", got, f)
+	}
+}
+
+// TestResolvePath_varTmpMountAllowed verifies that /var/tmp paths are accepted
+// when a tmpMount covers /var/tmp.
+func TestResolvePath_varTmpMountAllowed(t *testing.T) {
+	realVarTmp := t.TempDir()
+	realVarTmp, _ = filepath.EvalSymlinks(realVarTmp)
+	root := t.TempDir()
+	root, _ = filepath.EvalSymlinks(root)
+
+	f := filepath.Join(realVarTmp, "cache.bin")
+	if err := os.WriteFile(f, []byte("data"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	s := &localSession{
+		id:          "test",
+		policy:      sandboxpkg.Policy{Filesystem: sandboxpkg.FilesystemPolicy{WorkspaceRoot: root, WorkingDir: root}},
+		realRoot:    root,
+		sandboxRoot: "/workspace",
+		tmpMounts:   []tmpMount{{sandboxPath: "/var/tmp", realPath: realVarTmp}},
+		done:        make(chan struct{}),
+	}
+
+	got, err := s.ResolvePath("/var/tmp/cache.bin")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != f {
+		t.Errorf("ResolvePath = %q, want %q", got, f)
+	}
+}
+
+// TestToRealPath_tmpMapping verifies that /tmp and /var/tmp sandbox paths are
+// translated to their real host paths via tmpMounts, while workspace paths
+// still go through the sandboxRoot→realRoot mapping.
+func TestToRealPath_tmpMapping(t *testing.T) {
+	realTmp := t.TempDir()
+	realVarTmp := t.TempDir()
+	root := t.TempDir()
+
+	s := &localSession{
+		realRoot:    root,
+		sandboxRoot: "/workspace",
+		tmpMounts: []tmpMount{
+			{sandboxPath: "/tmp", realPath: realTmp},
+			{sandboxPath: "/var/tmp", realPath: realVarTmp},
+		},
+	}
+
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"/tmp/foo.txt", filepath.Join(realTmp, "foo.txt")},
+		{"/tmp", realTmp},
+		{"/var/tmp/bar", filepath.Join(realVarTmp, "bar")},
+		{"/workspace/src/main.go", filepath.Join(root, "src/main.go")},
+	}
+	for _, tc := range tests {
+		got := s.toRealPath(tc.in)
+		if got != tc.want {
+			t.Errorf("toRealPath(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestResolveWritePath_allowsTmp verifies that ResolveWritePath permits paths
+// inside tmpMounts (they are writable, not read-only).
+func TestResolveWritePath_allowsTmp(t *testing.T) {
+	realTmpDir := t.TempDir()
+	realTmpDir, _ = filepath.EvalSymlinks(realTmpDir)
+	root := t.TempDir()
+	root, _ = filepath.EvalSymlinks(root)
+
+	f := filepath.Join(realTmpDir, "out.txt")
+	if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	s := &localSession{
+		id:          "test",
+		policy:      sandboxpkg.Policy{Filesystem: sandboxpkg.FilesystemPolicy{WorkspaceRoot: root, WorkingDir: root}},
+		realRoot:    root,
+		sandboxRoot: "/workspace",
+		tmpMounts:   []tmpMount{{sandboxPath: "/tmp", realPath: realTmpDir}},
+		done:        make(chan struct{}),
+	}
+
+	got, err := s.ResolveWritePath("/tmp/out.txt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != f {
+		t.Errorf("ResolveWritePath = %q, want %q", got, f)
+	}
+}


### PR DESCRIPTION
## Summary

- **Root cause:** On Linux (bwrap), `/tmp` and `/var/tmp` were mounted as isolated `--tmpfs` volumes. Bash running inside bwrap could write there, but file tools (Read/Write/Edit) run on the host and had no access to those in-memory filesystems — plus the path guard explicitly rejected anything outside the workspace root. Same guard blocked `/tmp` on macOS even though bash and file tools share the same host filesystem.
- **Fix (Linux):** `createSessionTmpMounts()` creates per-session host directories with `os.MkdirTemp` and bind-mounts them at `/tmp` and `/var/tmp` inside bwrap (replacing `--tmpfs`). Both bash and file tools now see the same real files. Dirs are removed in `Close()`.
- **Fix (macOS):** `createSessionTmpMounts()` resolves `/tmp` → `/private/tmp` and `/var/tmp` → `/private/var/tmp`. No bind needed; only the path guard is updated to allow these paths.
- **Design:** `realTmp string` replaced by `[]tmpMount{sandboxPath, realPath}` with longest-prefix matching in `toRealPath`, `toSandboxPath`, and `resolvePath`. Adding a future temp path only requires appending to `createSessionTmpMounts()` (documented with a step-by-step comment) and one bwrap `--bind` entry.

## Test plan

- [ ] `TestResolvePath_tmpMountAllowed` — `/tmp/...` resolves to the real host dir
- [ ] `TestResolvePath_varTmpMountAllowed` — `/var/tmp/...` resolves correctly
- [ ] `TestToRealPath_tmpMapping` — path translation table for `/tmp`, `/var/tmp`, and workspace paths
- [ ] `TestResolveWritePath_allowsTmp` — tmp paths are writable (not blocked like `ExtraReadOnlyMounts`)
- [ ] All existing sandbox/local tests pass (`mise run test`)
- [ ] Manual: run an agent that writes to `/tmp/foo`, then Read `/tmp/foo` — should succeed on both Linux and macOS