### PR TITLE
Unify agents/recally design + redesign landing page

### DIFF
--- a/web/src/features/recally/components/ArticleCard.tsx
+++ b/web/src/features/recally/components/ArticleCard.tsx
@@ -18,32 +18,30 @@ export function ArticleCard({
   return (
     <button
       onClick={onClick}
-      className={`w-full rounded-md border p-3 text-left transition-colors ${
-        selected
-          ? "border-input bg-accent/70 shadow-sm"
-          : "border-border bg-card hover:bg-accent/30"
+      className={`w-full rounded-lg p-3 text-left transition-all duration-150 ${
+        selected ? "bg-sidebar-accent" : "hover:bg-muted/50"
       }`}
     >
       <div className="flex items-start justify-between gap-2">
-        <h3 className="text-sm font-medium leading-snug text-foreground">{article.title}</h3>
-        {article.starred && (
-          <Star className="size-4 text-amber-500 fill-amber-500 shrink-0 mt-0.5" />
-        )}
+        <h3 className="text-[12px] font-medium leading-snug text-foreground">{article.title}</h3>
+        {article.starred && <Star className="size-3.5 text-primary fill-primary shrink-0 mt-0.5" />}
       </div>
       {article.summary && (
         <div className="mt-1.5 flex items-start gap-1.5">
-          <Sparkles className="mt-0.5 size-3 shrink-0 text-primary" />
-          <p className="line-clamp-2 text-xs leading-relaxed text-muted-foreground">
+          <Sparkles className="mt-0.5 size-2.5 shrink-0 text-primary/60" />
+          <p className="line-clamp-2 text-[11px] leading-relaxed text-muted-foreground/70">
             {article.summary}
           </p>
         </div>
       )}
-      <div className="mt-2 flex flex-wrap items-center gap-1.5 font-mono text-xs">
+      <div className="mt-2 flex flex-wrap items-center gap-1.5 font-mono text-[10px]">
         <StatusBadge status={article.status} t={t} />
-        <span className="text-muted-foreground">{t(SOURCE_LABEL_KEYS[article.source_type])}</span>
-        <span className="text-muted-foreground">{formatSavedAt(article.saved_at, t)}</span>
+        <span className="text-muted-foreground/50">
+          {t(SOURCE_LABEL_KEYS[article.source_type])}
+        </span>
+        <span className="text-muted-foreground/50">{formatSavedAt(article.saved_at, t)}</span>
         {article.tags?.map((tag) => (
-          <span key={tag} className="rounded-full bg-muted px-1.5 py-0.5 text-muted-foreground">
+          <span key={tag} className="rounded-full bg-muted px-1.5 py-0.5 text-muted-foreground/60">
             {tag}
           </span>
         ))}

--- a/web/src/features/recally/components/FilterChip.tsx
+++ b/web/src/features/recally/components/FilterChip.tsx
@@ -10,10 +10,10 @@ export function FilterChip({
   return (
     <button
       onClick={onClick}
-      className={`rounded-full border px-2 py-1 text-xs transition-colors ${
+      className={`rounded-full px-2.5 py-1 text-xs font-mono transition-colors duration-150 ${
         active
-          ? "border-input bg-accent font-medium text-foreground"
-          : "border-border bg-background text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+          ? "bg-foreground text-background font-medium"
+          : "bg-muted text-muted-foreground hover:bg-muted/80 hover:text-foreground"
       }`}
     >
       {label}

--- a/web/src/features/recally/components/RecallyArticleList.tsx
+++ b/web/src/features/recally/components/RecallyArticleList.tsx
@@ -1,5 +1,4 @@
 import type { Dispatch, SetStateAction } from "react";
-import { Search, PanelLeft } from "lucide-react";
 import type { Article, ArticleStatus } from "@/lib/api-client/types.gen";
 import type { TFunction } from "../constants";
 import { ArticleCard } from "./ArticleCard";
@@ -40,37 +39,54 @@ export function RecallyArticleList({
 }) {
   return (
     <section className="flex min-h-0 flex-col overflow-hidden border-r border-border bg-background">
-      {/* Header with stats */}
-      <div className="shrink-0 border-b border-border bg-background px-4 py-4">
-        <div className="flex items-start justify-between gap-3">
+      {/* Header */}
+      <div className="shrink-0 border-b border-border bg-background px-4 py-3">
+        <div className="flex items-center justify-between gap-3">
           <div className="flex items-center gap-2">
             <button
               onClick={() => setLeftOpen((v) => !v)}
               className="hidden shrink-0 text-muted-foreground transition-colors hover:text-foreground md:inline-flex"
               title={t("recally.toggleSidebar")}
             >
-              <PanelLeft className="size-4" />
+              <svg
+                className="w-4 h-4"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+              >
+                <rect x="3" y="3" width="18" height="18" rx="2" />
+                <path d="M9 3v18" />
+              </svg>
             </button>
-            <div>
-              <h1 className="text-xl font-semibold tracking-tight text-foreground">
-                {t("recally.title")}
-              </h1>
-              <p className="mt-0.5 text-xs text-muted-foreground">{t("recally.subtitle")}</p>
-            </div>
+            <h1 className="text-[13px] font-semibold tracking-tight text-foreground">
+              {t("recally.title")}
+            </h1>
           </div>
-          <div className="hidden rounded-md border border-border bg-card px-2 py-1 font-mono text-[11px] text-muted-foreground md:block">
+          <span className="font-mono text-[10px] text-muted-foreground/50 tabular-nums">
             {displayArticles.length} / 50
-          </div>
+          </span>
         </div>
-        <div className="mt-3 space-y-2 md:hidden">
+
+        {/* Mobile search and filters */}
+        <div className="mt-2.5 space-y-2 md:hidden">
           <div className="relative">
-            <Search className="pointer-events-none absolute left-3 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+            <svg
+              className="absolute left-2 top-1/2 -translate-y-1/2 w-3 h-3 text-muted-foreground/50 pointer-events-none"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+            >
+              <circle cx="11" cy="11" r="8" />
+              <path d="m21 21-4.35-4.35" />
+            </svg>
             <input
               type="text"
               value={searchText}
               onChange={(e) => setSearchText(e.target.value)}
               placeholder={t("recally.searchPlaceholder")}
-              className="h-9 w-full rounded-md border border-border bg-background pl-8 pr-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+              className="w-full pl-7 pr-3 py-1.5 text-xs font-mono rounded-lg bg-muted/50 border border-transparent hover:border-border focus:border-primary/40 focus:outline-none transition-all duration-150 text-foreground placeholder:text-muted-foreground/50"
             />
           </div>
           <div className="flex gap-1.5 overflow-x-auto pb-1">
@@ -91,8 +107,10 @@ export function RecallyArticleList({
             />
           </div>
         </div>
+
+        {/* Inline stats */}
         {digest && (
-          <div className="mt-3 grid grid-cols-2 gap-2 lg:grid-cols-4">
+          <div className="mt-2.5 flex flex-wrap items-center gap-4">
             <StatCard value={digest.total_articles ?? 0} label={t("recally.stat.total")} />
             <StatCard value={digest.unread_count ?? 0} label={t("recally.stat.unread")} />
             <StatCard value={digest.starred_count ?? 0} label={t("recally.stat.starred")} />
@@ -107,19 +125,23 @@ export function RecallyArticleList({
       {/* Articles */}
       <div className="flex-1 space-y-1 overflow-auto p-2">
         {articlesQuery.isLoading && (
-          <div className="flex items-center justify-center h-32 text-sm text-muted-foreground">
-            {t("common.loading")}
+          <div className="flex items-center justify-center h-32">
+            <div className="w-3 h-3 border border-muted-foreground/30 border-t-muted-foreground/70 rounded-full animate-spin" />
           </div>
         )}
         {articlesQuery.isError && (
-          <div className="flex items-center justify-center h-32 text-sm text-destructive">
+          <div className="flex items-center justify-center h-32 text-xs font-mono text-destructive">
             {t("common.error")}
           </div>
         )}
         {!articlesQuery.isLoading && !articlesQuery.isError && displayArticles.length === 0 && (
-          <div className="flex flex-col items-center justify-center h-32 text-sm text-muted-foreground">
-            <p className="font-medium">{t("recally.empty.noArticles")}</p>
-            <p className="text-xs mt-1">{t("recally.empty.noArticlesDesc")}</p>
+          <div className="flex flex-col items-center justify-center h-32">
+            <p className="text-xs font-mono text-muted-foreground/60">
+              {t("recally.empty.noArticles")}
+            </p>
+            <p className="text-[10px] font-mono text-muted-foreground/40 mt-1">
+              {t("recally.empty.noArticlesDesc")}
+            </p>
           </div>
         )}
         {displayArticles.map((article) => (

--- a/web/src/features/recally/components/RecallySidebar.tsx
+++ b/web/src/features/recally/components/RecallySidebar.tsx
@@ -1,10 +1,18 @@
 import type { Dispatch, SetStateAction } from "react";
-import { Search, Plus, RefreshCw, AlertCircle } from "lucide-react";
+import { Plus, RefreshCw, AlertCircle } from "lucide-react";
 import type { Feed, ArticleStatus, SourceType } from "@/lib/api-client/types.gen";
 import type { TFunction } from "../constants";
 import { SOURCE_TYPES, SOURCE_LABEL_KEYS } from "../constants";
 import { SidebarNavItem } from "./SidebarNavItem";
 import { FilterChip } from "./FilterChip";
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="px-3.5 pt-3 pb-1.5 text-[10px] font-mono font-medium uppercase tracking-widest text-muted-foreground/70">
+      {children}
+    </div>
+  );
+}
 
 export function RecallySidebar({
   t,
@@ -78,13 +86,34 @@ export function RecallySidebar({
   clearFilters: () => void;
 }) {
   return (
-    <div className="space-y-5 p-3">
-      {/* Views */}
-      <div>
-        <div className="mb-1.5 px-2 text-[11px] font-mono font-medium uppercase tracking-wider text-muted-foreground">
-          {t("recally.section.library")}
+    <div className="flex flex-col h-full overflow-y-auto">
+      {/* Search */}
+      <div className="flex-shrink-0 px-2.5 pt-3 pb-1">
+        <div className="relative">
+          <input
+            type="text"
+            value={searchText}
+            onChange={(e) => setSearchText(e.target.value)}
+            placeholder={t("recally.searchPlaceholder")}
+            className="w-full pl-7 pr-3 py-1.5 text-xs font-mono rounded-lg bg-muted/50 border border-transparent hover:border-border focus:border-primary/40 focus:outline-none transition-all duration-150 text-foreground placeholder:text-muted-foreground/50"
+          />
+          <svg
+            className="absolute left-2 top-1/2 -translate-y-1/2 w-3 h-3 text-muted-foreground/50 pointer-events-none"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+          >
+            <circle cx="11" cy="11" r="8" />
+            <path d="m21 21-4.35-4.35" />
+          </svg>
         </div>
-        <nav className="space-y-0.5">
+      </div>
+
+      {/* Library */}
+      <div>
+        <SectionLabel>{t("recally.section.library")}</SectionLabel>
+        <nav className="space-y-0.5 px-1">
           <SidebarNavItem
             label={t("recally.nav.inbox")}
             count={digest?.total_articles}
@@ -132,101 +161,77 @@ export function RecallySidebar({
         </nav>
       </div>
 
-      {/* Refine */}
-      <div className="space-y-3">
-        <div className="mb-1.5 px-2 text-[11px] font-mono font-medium uppercase tracking-wider text-muted-foreground">
-          {t("recally.section.find")}
-        </div>
-        <div className="relative px-1">
-          <Search className="pointer-events-none absolute left-3 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
-          <input
-            type="text"
-            value={searchText}
-            onChange={(e) => setSearchText(e.target.value)}
-            placeholder={t("recally.searchPlaceholder")}
-            className="h-8 w-full rounded-md border border-border bg-background pl-8 pr-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+      {/* Filters */}
+      <div>
+        <SectionLabel>{t("recally.section.status")}</SectionLabel>
+        <div className="flex flex-wrap gap-1.5 px-3">
+          <FilterChip
+            label={t("recally.status.all")}
+            active={statusFilter === null}
+            onClick={() => setStatusFilter(null)}
+          />
+          <FilterChip
+            label={t("recally.status.unread")}
+            active={statusFilter === "unread"}
+            onClick={() => setStatusFilter("unread")}
+          />
+          <FilterChip
+            label={t("recally.status.read")}
+            active={statusFilter === "read"}
+            onClick={() => setStatusFilter("read")}
           />
         </div>
+      </div>
 
-        <div>
-          <div className="mb-1 px-2 text-[11px] font-mono font-medium uppercase tracking-wider text-muted-foreground">
-            {t("recally.section.status")}
-          </div>
-          <div className="flex flex-wrap gap-1.5 px-1">
+      <div>
+        <SectionLabel>{t("recally.section.sources")}</SectionLabel>
+        <div className="flex flex-wrap gap-1.5 px-3">
+          <FilterChip
+            label={t("recally.status.all")}
+            active={sourceTypeFilter === null}
+            onClick={() => setSourceTypeFilter(null)}
+          />
+          {SOURCE_TYPES.map((type) => (
             <FilterChip
-              label={t("recally.status.all")}
-              active={statusFilter === null}
-              onClick={() => setStatusFilter(null)}
+              key={type}
+              label={t(SOURCE_LABEL_KEYS[type])}
+              active={sourceTypeFilter === type}
+              onClick={() => setSourceTypeFilter(sourceTypeFilter === type ? null : type)}
             />
-            <FilterChip
-              label={t("recally.status.unread")}
-              active={statusFilter === "unread"}
-              onClick={() => setStatusFilter("unread")}
-            />
-            <FilterChip
-              label={t("recally.status.read")}
-              active={statusFilter === "read"}
-              onClick={() => setStatusFilter("read")}
-            />
-          </div>
+          ))}
         </div>
+      </div>
 
+      {sortedTags.length > 0 && (
         <div>
-          <div className="mb-1 px-2 text-[11px] font-mono font-medium uppercase tracking-wider text-muted-foreground">
-            {t("recally.section.sources")}
-          </div>
-          <div className="flex flex-wrap gap-1.5 px-1">
-            <FilterChip
-              label={t("recally.status.all")}
-              active={sourceTypeFilter === null}
-              onClick={() => setSourceTypeFilter(null)}
-            />
-            {SOURCE_TYPES.map((type) => (
+          <SectionLabel>{t("recally.section.tags")}</SectionLabel>
+          <div className="flex flex-wrap gap-1 px-3">
+            {visibleTags.map((tag) => (
               <FilterChip
-                key={type}
-                label={t(SOURCE_LABEL_KEYS[type])}
-                active={sourceTypeFilter === type}
-                onClick={() => setSourceTypeFilter(sourceTypeFilter === type ? null : type)}
+                key={tag}
+                label={`${tag} ${tagCounts[tag]}`}
+                active={tagFilter === tag}
+                onClick={() => setTagFilter(tagFilter === tag ? null : tag)}
               />
             ))}
+            {hasMoreTags && (
+              <button
+                onClick={() => setShowAllTags(!showAllTags)}
+                className="rounded-full bg-muted px-2 py-1 text-xs font-mono text-muted-foreground transition-colors hover:text-foreground"
+              >
+                {showAllTags
+                  ? t("recally.tags.less")
+                  : t("recally.tags.more", { count: sortedTags.length - 10 })}
+              </button>
+            )}
           </div>
         </div>
-
-        {sortedTags.length > 0 && (
-          <div>
-            <div className="mb-1 px-2 text-[11px] font-mono font-medium uppercase tracking-wider text-muted-foreground">
-              {t("recally.section.tags")}
-            </div>
-            <div className="flex flex-wrap gap-1 px-1">
-              {visibleTags.map((tag) => (
-                <FilterChip
-                  key={tag}
-                  label={`${tag} ${tagCounts[tag]}`}
-                  active={tagFilter === tag}
-                  onClick={() => setTagFilter(tagFilter === tag ? null : tag)}
-                />
-              ))}
-              {hasMoreTags && (
-                <button
-                  onClick={() => setShowAllTags(!showAllTags)}
-                  className="rounded-full border border-border bg-background px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
-                >
-                  {showAllTags
-                    ? t("recally.tags.less")
-                    : t("recally.tags.more", { count: sortedTags.length - 10 })}
-                </button>
-              )}
-            </div>
-          </div>
-        )}
-      </div>
+      )}
 
       {/* Feeds */}
       <div>
-        <div className="mb-1.5 px-2 text-[11px] font-mono font-medium uppercase tracking-wider text-muted-foreground">
-          {t("recally.section.feeds")}
-        </div>
-        <div className="px-1 space-y-1.5">
+        <SectionLabel>{t("recally.section.feeds")}</SectionLabel>
+        <div className="px-3 space-y-1.5">
           <div className="flex items-center gap-1">
             <input
               type="text"
@@ -238,7 +243,7 @@ export function RecallySidebar({
                   createFeedMut.mutate({ body: { url: feedUrl.trim() } });
                 }
               }}
-              className="h-7 flex-1 rounded-md border border-border bg-background px-2 text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+              className="h-7 flex-1 rounded-lg bg-muted/50 border border-transparent px-2 text-xs font-mono placeholder:text-muted-foreground/50 hover:border-border focus:border-primary/40 focus:outline-none transition-all duration-150"
             />
             <button
               onClick={() => {
@@ -247,31 +252,33 @@ export function RecallySidebar({
                 }
               }}
               disabled={createFeedMut.isPending || !feedUrl.trim()}
-              className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border bg-background transition-colors hover:bg-accent disabled:opacity-50"
+              className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-muted/50 transition-colors hover:bg-muted disabled:opacity-50"
               title={t("recally.feeds.addFeed")}
             >
               {createFeedMut.isPending ? (
-                <RefreshCw className="size-3 animate-spin" />
+                <RefreshCw className="size-3 animate-spin text-muted-foreground" />
               ) : (
-                <Plus className="size-3" />
+                <Plus className="size-3 text-muted-foreground" />
               )}
             </button>
           </div>
           {feedsQuery.isLoading && (
-            <div className="text-xs text-muted-foreground py-1">{t("common.loading")}</div>
+            <div className="text-xs font-mono text-muted-foreground/50 py-1">
+              {t("common.loading")}
+            </div>
           )}
           {feedsQuery.isError && (
-            <div className="text-xs text-destructive py-1">{t("common.error")}</div>
+            <div className="text-xs font-mono text-destructive py-1">{t("common.error")}</div>
           )}
           {!feedsQuery.isLoading && !feedsQuery.isError && feeds.length === 0 && (
-            <div className="text-xs text-muted-foreground py-1">
+            <div className="text-xs font-mono text-muted-foreground/50 py-1">
               {t("recally.feeds.noFeedsDesc")}
             </div>
           )}
           {feeds.map((feed: Feed) => (
             <div key={feed.id} className="flex items-center justify-between gap-1.5 py-0.5">
               <span
-                className="truncate text-xs text-muted-foreground"
+                className="truncate text-[12px] text-foreground/80"
                 title={feed.title || feed.url}
               >
                 {feed.title || feed.url}
@@ -279,26 +286,26 @@ export function RecallySidebar({
               <button
                 onClick={() => pollFeedMut.mutate({ path: { id: feed.id } })}
                 disabled={pollFeedMut.isPending}
-                className="inline-flex shrink-0 items-center gap-1 rounded border border-border bg-background px-1.5 py-0.5 font-mono text-[10px] transition-colors hover:bg-accent disabled:opacity-50"
+                className="inline-flex shrink-0 items-center gap-1 rounded-md bg-muted/50 px-1.5 py-0.5 font-mono text-[10px] transition-colors hover:bg-muted disabled:opacity-50"
                 title={t("recally.feeds.poll")}
               >
                 {pollFeedMut.isPending && pollFeedMut.variables?.path.id === feed.id ? (
-                  <RefreshCw className="size-3 animate-spin" />
+                  <RefreshCw className="size-3 animate-spin text-muted-foreground" />
                 ) : feedPollResults[feed.id]?.error ? (
                   <>
                     <AlertCircle className="size-3 text-destructive" />
                     <span className="text-destructive">{t("recally.feeds.pollError")}</span>
                   </>
                 ) : feedPollResults[feed.id] ? (
-                  <span className="text-success-foreground">
+                  <span className="text-primary">
                     {t("recally.feeds.pollNewEntries", {
                       count: feedPollResults[feed.id].newCount,
                     })}
                   </span>
                 ) : (
                   <>
-                    <RefreshCw className="size-3" />
-                    <span>{t("recally.feeds.poll")}</span>
+                    <RefreshCw className="size-3 text-muted-foreground" />
+                    <span className="text-muted-foreground">{t("recally.feeds.poll")}</span>
                   </>
                 )}
               </button>
@@ -309,7 +316,7 @@ export function RecallySidebar({
 
       {/* Digest note */}
       {digest && (
-        <div className="mx-1 rounded-md border border-border bg-card px-2.5 py-2 text-xs text-muted-foreground">
+        <div className="mx-3 mt-3 rounded-lg bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
           <span className="font-medium text-foreground">{t("recally.nav.digest")}: </span>
           {t("recally.digest.savedYesterday", { count: digest.saved_yesterday_count ?? 0 })}
           {(digest.worth_revisiting_count ?? 0) > 0 && (

--- a/web/src/features/recally/components/SidebarNavItem.tsx
+++ b/web/src/features/recally/components/SidebarNavItem.tsx
@@ -12,15 +12,15 @@ export function SidebarNavItem({
   return (
     <button
       onClick={onClick}
-      className={`flex w-full items-center justify-between rounded-md px-2 py-1.5 text-sm transition-colors ${
+      className={`flex w-full items-center justify-between mx-1 rounded-lg px-2.5 py-1.5 text-[12px] transition-all duration-150 ${
         active
-          ? "bg-accent font-medium text-foreground"
-          : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+          ? "bg-sidebar-accent font-medium text-foreground"
+          : "text-foreground/80 hover:bg-muted/50"
       }`}
     >
       <span>{label}</span>
       {count !== undefined && (
-        <span className="font-mono text-xs text-muted-foreground">{count}</span>
+        <span className="text-[10px] font-mono text-muted-foreground/50 tabular-nums">{count}</span>
       )}
     </button>
   );

--- a/web/src/features/recally/components/StatCard.tsx
+++ b/web/src/features/recally/components/StatCard.tsx
@@ -1,8 +1,10 @@
 export function StatCard({ value, label }: { value: number; label: string }) {
   return (
-    <div className="rounded-md border border-border bg-card px-3 py-2 shadow-sm">
-      <div className="font-mono text-lg font-semibold text-foreground">{value}</div>
-      <div className="text-xs text-muted-foreground">{label}</div>
+    <div className="flex items-baseline gap-1.5">
+      <span className="font-mono text-sm font-semibold tabular-nums text-foreground">{value}</span>
+      <span className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground/60">
+        {label}
+      </span>
     </div>
   );
 }

--- a/web/src/features/settings/SettingsDetailLayout.tsx
+++ b/web/src/features/settings/SettingsDetailLayout.tsx
@@ -25,7 +25,7 @@ export function SettingsDetailLayout({
     <div className="flex h-full overflow-hidden">
       {/* Left list panel — full width on mobile when mobileView=list, hidden otherwise */}
       <div
-        className={`${mobileView === "list" ? "flex" : "hidden"} md:flex w-full md:w-[200px] shrink-0 border-r border-border bg-muted/30 overflow-y-auto flex-col`}
+        className={`${mobileView === "list" ? "flex" : "hidden"} md:flex w-full md:w-[200px] shrink-0 border-r border-border bg-sidebar overflow-y-auto flex-col`}
       >
         <div className="shrink-0">{listHeader}</div>
         <div className="flex-1 overflow-y-auto">{list}</div>

--- a/web/src/features/settings/SettingsLayout.tsx
+++ b/web/src/features/settings/SettingsLayout.tsx
@@ -214,7 +214,7 @@ function NavItems({ isAdmin, onItemClick }: { isAdmin: boolean; onItemClick?: ()
         if (visibleItems.length === 0) return null;
         return (
           <div key={group.section}>
-            <div className="px-5 pt-6 pb-2 text-[11px] font-mono font-medium uppercase tracking-wider text-muted-foreground">
+            <div className="px-3.5 pt-5 pb-1.5 text-[10px] font-mono font-medium uppercase tracking-widest text-muted-foreground/70">
               {group.section}
             </div>
             {visibleItems.map((item) => (
@@ -223,10 +223,10 @@ function NavItems({ isAdmin, onItemClick }: { isAdmin: boolean; onItemClick?: ()
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 to={item.href as any}
                 onClick={onItemClick}
-                className="group/item flex items-center gap-2.5 px-5 py-2 text-[13px] font-medium transition-colors text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+                className="group/item flex items-center gap-2 mx-2 px-2.5 py-1.5 rounded-lg text-[12px] font-medium transition-all duration-150 text-foreground/80 hover:bg-muted/50"
                 activeProps={{
                   className:
-                    "group/item active flex items-center gap-2.5 px-5 py-2 text-[13px] font-medium bg-primary/5 text-primary transition-colors",
+                    "group/item active flex items-center gap-2 mx-2 px-2.5 py-1.5 rounded-lg text-[12px] font-medium bg-sidebar-accent text-foreground transition-all duration-150",
                 }}
               >
                 {item.icon}

--- a/web/src/features/settings/SettingsPageHeader.tsx
+++ b/web/src/features/settings/SettingsPageHeader.tsx
@@ -10,7 +10,7 @@ export function SettingsPageHeader({ title, description, action }: SettingsPageH
   return (
     <div className="mb-8 flex items-start justify-between gap-4">
       <div>
-        <h1 className="font-serif text-2xl tracking-tight mb-1">{title}</h1>
+        <h1 className="text-[1.25rem] font-semibold tracking-tight leading-snug mb-1">{title}</h1>
         <p className="text-sm text-muted-foreground">{description}</p>
       </div>
       {action && <div className="shrink-0">{action}</div>}

--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -182,47 +182,6 @@
   --shadow-2xl: 0px 1px 3px 0px hsl(0 0% 10.1961% / 0.25);
 }
 
-.home-page {
-  font-family: Outfit, system-ui, sans-serif;
-}
-
-.home-page h1,
-.home-page h2,
-.home-page h3 {
-  font-family: Merriweather, Georgia, serif;
-}
-
-@keyframes fade-up {
-  from {
-    opacity: 0;
-    transform: translateY(12px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.animate-fade-up {
-  animation: fade-up 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
-}
-
-.stagger-1 {
-  animation-delay: 0ms;
-}
-.stagger-2 {
-  animation-delay: 80ms;
-}
-.stagger-3 {
-  animation-delay: 160ms;
-}
-.stagger-4 {
-  animation-delay: 240ms;
-}
-.stagger-5 {
-  animation-delay: 320ms;
-}
-
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/web/src/lib/docs/translations.ts
+++ b/web/src/lib/docs/translations.ts
@@ -5,28 +5,74 @@ const translations = {
     docs: "Docs",
     // Index - Hero
     heroTag: "AI assistant / self-hosted",
-    heroTitle1: "Your assistant",
-    heroTitle2: "that never",
-    heroTitle3: "forgets",
+    heroTitle1: "Your agent",
+    heroTitle2: "that just",
+    heroTitle3: "works",
     heroDescription:
-      "Single binary, lossless context management. Talk from your terminal or any messenger — stella remembers everything.",
+      "Stella remembers every conversation, connects to your messengers, and handles tasks on your behalf. One binary, your machine, your data.",
     readTheDocs: "Read the docs",
     sourceOnGithub: "Source on GitHub",
+    // Index - Conversation
+    memoryLabel: "Memory that lasts",
+    memoryTitle: "She remembers so you don't have to",
+    memoryBody:
+      "Ask about last week's decisions or a detail from months ago. Stella keeps the full picture and recalls it when you need it.",
+    conversationLabel: "conversation",
     // Index - Features
-    featuresTitle: "What makes stella different",
-    feature1Title: "Lossless memory",
+    featuresTitle: "What makes Stella different",
+    feature1Title: "Remembers everything",
     feature1Body:
-      "DAG-based context compression. Conversations grow without bounds and without losing a single detail. Every thread, every tangent, preserved.",
-    feature2Title: "Multi-channel",
+      "Your conversations grow without bounds. Stella compresses older context in the background but never loses a detail. Ask about anything you discussed, anytime.",
+    feature2Title: "Works across channels",
     feature2Body:
-      "Terminal TUI, Telegram, QQ, Feishu. All channels share the same session and memory. Start a thought in your terminal, pick it up on Telegram.",
-    feature3Title: "Self-hosted",
+      "Telegram, QQ, Feishu, WeChat, or the Web UI. All channels share the same memory. Start on your phone, continue on your laptop.",
+    feature3Title: "Runs on your machine",
     feature3Body:
-      "Single Go binary + SQLite. Your machine, your API keys. Nothing leaves your network. Deploy with Docker, systemd, or just run the binary.",
-    feature4Title: "Built-in scheduler",
+      "Single binary, SQLite, your API keys. Nothing leaves your network. Install with Homebrew, Docker, or just download the binary.",
+    feature4Title: "Works while you're away",
     feature4Body:
-      "Scheduled tasks, heartbeat monitoring, and cross-channel notifications. stella works even when you're not talking to it.",
-    // Index - Meet Stella
+      "Schedule reminders, recurring checks, RSS digests, and automated tasks. Stella keeps running and notifies you when something needs attention.",
+    feature5Title: "Async agent work",
+    feature5Body:
+      "Hand off complex tasks and keep chatting. Stella works in the background, asks questions when stuck, and notifies you when done. Research, analysis, multi-step workflows.",
+    // Index - Capabilities
+    capabilitiesTitle: "Built-in capabilities",
+    capabilitiesSubtitle: "Everything you need, nothing you don't.",
+    capSkills: "Skills",
+    capSkillsDesc:
+      "Installable playbooks that teach Stella new workflows. Browse registries or write your own.",
+    capReading: "Reading assistant",
+    capReadingDesc:
+      "Save articles, subscribe to RSS feeds, get daily digests. Your personal library that summarizes everything.",
+    capEmail: "Email",
+    capEmailDesc:
+      "Read, send, and manage email through IMAP/SMTP. Stella handles your inbox from the conversation.",
+    capVault: "Secrets vault",
+    capVaultDesc:
+      "Store API keys and tokens encrypted. Available at runtime, never exposed in conversations.",
+    capOAuth: "OAuth connections",
+    capOAuthDesc:
+      "Connect GitHub, Google, and other services. Stella acts on your behalf with proper authorization.",
+    capPlugins: "Plugins",
+    capPluginsDesc:
+      "Extend with custom code. Build integrations, add tools, or connect to internal services.",
+    capMCP: "MCP tools",
+    capMCPDesc:
+      "Connect any Model Context Protocol server. Industry-standard tool integration, zero custom wiring.",
+    capModels: "Multi-provider models",
+    capModelsDesc:
+      "Anthropic, OpenAI, or any compatible API. Switch models per agent, per task. Your keys, your choice.",
+    capAgents: "Specialized agents",
+    capAgentsDesc:
+      "Pre-built templates for coding, research, writing, and review. Create focused agents in seconds.",
+    capNotifications: "Proactive notifications",
+    capNotificationsDesc:
+      "Stella reaches out when something needs attention. Task done, job failed, or something you should know.",
+    // Index - Footer CTA
+    getStarted: "Get started in seconds",
+    getStartedBody: "Two commands. No containers required.",
+    getStartedAlt: "Also available via go install and direct binary download.",
+    // Index - Meet Stella (used on About page)
     meetStella: "Meet Stella",
     meetStellaTitle: "A calm digital companion",
     meetStellaBody1:
@@ -34,9 +80,6 @@ const translations = {
     meetStellaBody2:
       "Built with real warmth and digital precision. Local-first, memory-aware, and always composed.",
     learnMoreAboutStella: "Learn more about Stella",
-    // Index - Footer CTA
-    getStarted: "Get started in seconds",
-    getStartedBody: "One binary, one config file. No containers required.",
     // About - Hero
     aboutHeroTitle1: "A quiet,",
     aboutHeroTitle2: "reliable",
@@ -94,33 +137,64 @@ const translations = {
     about: "关于",
     docs: "文档",
     heroTag: "AI 助手 / 自托管",
-    heroTitle1: "你的助手",
-    heroTitle2: "永远不会",
-    heroTitle3: "遗忘",
+    heroTitle1: "你的智能助手",
+    heroTitle2: "开箱",
+    heroTitle3: "即用",
     heroDescription:
-      "单一二进制文件，无损上下文管理。在终端或任何即时通讯中对话——stella 记住一切。",
+      "Stella 记住每一次对话，连接你的聊天工具，替你处理日常事务。一个二进制文件，你的机器，你的数据。",
     readTheDocs: "阅读文档",
     sourceOnGithub: "GitHub 源码",
-    featuresTitle: "stella 的独特之处",
-    feature1Title: "无损记忆",
+    memoryLabel: "持久记忆",
+    memoryTitle: "她替你记住一切",
+    memoryBody: "随时问起上周的决策或几个月前的细节。Stella 保持完整的上下文，在你需要时随时调用。",
+    conversationLabel: "对话",
+    featuresTitle: "Stella 的独特之处",
+    feature1Title: "记住一切",
     feature1Body:
-      "基于 DAG 的上下文压缩。对话无限增长而不丢失任何细节。每个线程、每个分支，完整保留。",
-    feature2Title: "多渠道",
+      "对话无限增长。Stella 在后台压缩旧的上下文，但不会丢失任何细节。随时询问你讨论过的任何内容。",
+    feature2Title: "跨渠道工作",
     feature2Body:
-      "终端 TUI、Telegram、QQ、飞书。所有渠道共享同一会话和记忆。在终端开始的想法，可以在 Telegram 上继续。",
-    feature3Title: "自托管",
+      "Telegram、QQ、飞书、微信或 Web UI。所有渠道共享同一份记忆。在手机上开始，在电脑上继续。",
+    feature3Title: "运行在你的机器上",
     feature3Body:
-      "单一 Go 二进制文件 + SQLite。你的机器，你的 API 密钥。数据不会离开你的网络。支持 Docker、systemd 或直接运行。",
-    feature4Title: "内置调度器",
-    feature4Body: "定时任务、心跳监控和跨渠道通知。即使你不和 stella 对话，她也在工作。",
+      "单一二进制文件，SQLite，你的 API 密钥。数据不会离开你的网络。支持 Homebrew、Docker 或直接下载。",
+    feature4Title: "你不在时也在工作",
+    feature4Body:
+      "安排提醒、定期检查、RSS 摘要和自动化任务。Stella 持续运行，在需要你关注时通知你。",
+    feature5Title: "异步智能体",
+    feature5Body:
+      "交出复杂任务，继续聊天。Stella 在后台工作，遇到问题会询问你，完成后通知你。研究、分析、多步骤工作流。",
+    capabilitiesTitle: "内置能力",
+    capabilitiesSubtitle: "你需要的都有，不需要的都没有。",
+    capSkills: "技能",
+    capSkillsDesc: "可安装的工作流剧本，教 Stella 学习新流程。浏览注册表或自己编写。",
+    capReading: "阅读助手",
+    capReadingDesc: "保存文章、订阅 RSS 源、获取每日摘要。你的个人图书馆，自动总结一切。",
+    capEmail: "邮件",
+    capEmailDesc: "通过 IMAP/SMTP 阅读、发送和管理邮件。Stella 在对话中处理你的收件箱。",
+    capVault: "密钥保险库",
+    capVaultDesc: "加密存储 API 密钥和令牌。运行时可用，对话中不会暴露。",
+    capOAuth: "OAuth 连接",
+    capOAuthDesc: "连接 GitHub、Google 等服务。Stella 以你的身份操作，具有正确的授权。",
+    capPlugins: "插件",
+    capPluginsDesc: "用自定义代码扩展。构建集成、添加工具或连接内部服务。",
+    capMCP: "MCP 工具",
+    capMCPDesc: "连接任何 Model Context Protocol 服务器。行业标准工具集成，零自定义配线。",
+    capModels: "多供应商模型",
+    capModelsDesc: "Anthropic、OpenAI 或任何兼容 API。按智能体、按任务切换模型。你的密钥，你做主。",
+    capAgents: "专业智能体",
+    capAgentsDesc: "预建编程、研究、写作和审查模板。几秒钟内创建专注的智能体。",
+    capNotifications: "主动通知",
+    capNotificationsDesc: "需要你关注时 Stella 会主动联系你。任务完成、作业失败或你应该知道的事。",
+    getStarted: "几秒钟即可开始",
+    getStartedBody: "两条命令，无需容器。",
+    getStartedAlt: "也支持 go install 和直接下载二进制文件。",
     meetStella: "认识 Stella",
     meetStellaTitle: "一位沉静的数字伙伴",
     meetStellaBody1:
       "Stella 不仅仅是一个工具——她是一位安静、值得信赖的助手，为长期陪伴而设计。她记住你的上下文，连接你跨设备的工作流，始终可靠地陪伴而不打扰。",
     meetStellaBody2: "融合真实温度与数字精确。本地优先、记忆感知、始终沉着。",
     learnMoreAboutStella: "了解更多关于 Stella",
-    getStarted: "几秒钟即可开始",
-    getStartedBody: "一个二进制文件，一个配置文件。无需容器。",
     aboutHeroTitle1: "安静、",
     aboutHeroTitle2: "可靠的",
     aboutHeroTitle3: "伙伴",

--- a/web/src/routes/index.css
+++ b/web/src/routes/index.css
@@ -1,0 +1,113 @@
+.home-page {
+  font-family: Outfit, system-ui, sans-serif;
+}
+
+.home-page h1,
+.home-page h2,
+.home-page h3 {
+  font-family: Merriweather, Georgia, serif;
+  text-wrap: balance;
+}
+
+/* Hero headline — fluid type, big and confident */
+.hero-headline {
+  font-size: clamp(2.5rem, 5.5vw, 4.5rem);
+  line-height: 1.08;
+  letter-spacing: -0.025em;
+  font-weight: 700;
+}
+
+/* Hero warm background — tinted toward primary */
+.hero-warm-bg {
+  background:
+    radial-gradient(
+      ellipse 80% 60% at 70% 50%,
+      color-mix(in oklch, var(--primary) 8%, transparent),
+      transparent
+    ),
+    var(--background);
+}
+
+/*
+  Conversation section — forced dark scope.
+  Uses .dark token overrides so it always renders as a dark surface
+  regardless of the page theme, creating visual rhythm.
+*/
+.conversation-section {
+  background: var(--background);
+  color: var(--foreground);
+}
+.conversation-body-text {
+  color: var(--muted-foreground);
+}
+.conversation-window {
+  background: var(--card);
+  border: 1px solid var(--border);
+}
+.conversation-window-titlebar {
+  border-bottom: 1px solid var(--border);
+}
+.conversation-user-bubble {
+  background: var(--muted);
+  color: var(--foreground);
+}
+.conversation-stella-bubble {
+  color: var(--foreground);
+}
+
+/* Feature decorative numbers */
+.feature-number {
+  font-size: clamp(4rem, 8vw, 7rem);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+}
+
+/* Capabilities section */
+.capabilities-section {
+  background: var(--muted);
+}
+
+/* Footer CTA warm background — tinted toward primary */
+.cta-warm-bg {
+  background:
+    radial-gradient(
+      ellipse 90% 70% at 30% 60%,
+      color-mix(in oklch, var(--primary) 10%, transparent),
+      transparent
+    ),
+    var(--background);
+}
+
+/* CTA code blocks */
+.cta-code-block {
+  background: var(--card);
+  border: 1px solid var(--border);
+  color: var(--foreground);
+}
+
+/* Entrance animation */
+@keyframes fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-fade-up {
+  animation: fade-up 0.8s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.stagger-2 {
+  animation-delay: 150ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade-up {
+    animation: none;
+    opacity: 1;
+  }
+}

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -2,18 +2,21 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { t } from "@/lib/docs/translations";
 import { SiteHeader } from "@/components/SiteHeader";
 import { useI18n } from "@/lib/i18n";
+import "./index.css";
 
 export const Route = createFileRoute("/")({ component: Home });
 
-const terminalLines = [
-  { prompt: true, text: "stella --open" },
-  { prompt: false, text: "Admin panel running at http://localhost:8787" },
-  { prompt: true, text: "stella" },
-  { prompt: false, text: "Daemon started (bots + scheduler)" },
-  { prompt: false, text: 'you: "summarize yesterday\'s conversation"' },
-  { prompt: false, text: "stella: Yesterday you discussed migrating the" },
-  { prompt: false, text: "      auth service to JWT tokens. Key decisions:" },
-  { prompt: false, text: "      1. RS256 signing with key rotation ..." },
+const conversationLines = [
+  { role: "user" as const, text: "summarize yesterday's conversation" },
+  {
+    role: "stella" as const,
+    text: "Yesterday you discussed migrating the auth service to JWT tokens. Key decisions: RS256 signing with key rotation, 7-day refresh window. You asked me to remember that staging uses the old session cookies until March.",
+  },
+  { role: "user" as const, text: "what was the refresh window again?" },
+  {
+    role: "stella" as const,
+    text: "7 days. You chose that over 30 days because the security team flagged long-lived tokens in the Q3 audit.",
+  },
 ];
 
 function Home() {
@@ -24,73 +27,131 @@ function Home() {
       <SiteHeader />
       <main className="flex-1 home-page">
         <HeroSection lang={lang} />
+        <ConversationSection lang={lang} />
         <FeaturesSection lang={lang} />
-        <MeetStellaSection lang={lang} />
+        <CapabilitiesSection lang={lang} />
         <FooterCTA lang={lang} />
       </main>
     </div>
   );
 }
 
+/* ─── Hero ─── */
+
 function HeroSection({ lang }: { lang: string }) {
   const tr = t(lang);
   return (
-    <section className="px-6 pt-28 pb-24 md:px-12 lg:px-20 max-w-7xl mx-auto">
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-16 items-start">
-        <div>
-          <div className="animate-fade-up stagger-1">
-            <p className="text-xs font-medium tracking-[0.2em] uppercase text-primary mb-8 font-[family-name:var(--font-mono)]">
+    <section className="hero-warm-bg relative overflow-hidden">
+      {/* Decorative gold radial behind the avatar */}
+      <div className="absolute top-1/2 right-[10%] -translate-y-1/2 w-[500px] h-[500px] rounded-full bg-primary/8 blur-[100px] pointer-events-none dark:bg-primary/5" />
+
+      <div className="relative px-6 pt-28 pb-24 md:px-12 lg:px-20 max-w-7xl mx-auto">
+        <div className="grid grid-cols-1 lg:grid-cols-[1.1fr_auto] gap-16 lg:gap-24 items-center">
+          {/* Text column */}
+          <div className="animate-fade-up">
+            <p className="text-[11px] font-medium tracking-[0.2em] uppercase text-primary mb-8 font-mono">
               {tr.heroTag}
             </p>
-          </div>
-          <h1 className="animate-fade-up stagger-2 text-5xl md:text-6xl lg:text-[4.5rem] tracking-tight text-foreground leading-[0.92] mb-10">
-            {tr.heroTitle1}
-            <br />
-            {tr.heroTitle2}
-            <br />
-            <span className="italic text-primary">{tr.heroTitle3}</span>
-          </h1>
-          <div className="animate-fade-up stagger-3 max-w-md">
-            <p className="text-muted-foreground text-base leading-relaxed mb-12">
+            <h1 className="hero-headline text-foreground mb-8">
+              {tr.heroTitle1}
+              <br />
+              {tr.heroTitle2} <span className="italic text-primary">{tr.heroTitle3}</span>
+            </h1>
+            <p className="text-muted-foreground text-lg leading-relaxed max-w-[52ch] mb-12">
               {tr.heroDescription}
             </p>
+            <div className="flex flex-wrap items-center gap-5">
+              <Link
+                to="/docs/$"
+                params={{ _splat: "" }}
+                className="inline-flex items-center gap-2.5 px-7 py-3.5 bg-primary text-primary-foreground text-sm font-semibold rounded-xl hover:bg-primary/90 active:scale-[0.98] transition-all shadow-md"
+              >
+                {tr.readTheDocs}
+                <span aria-hidden="true" className="text-primary-foreground/70">
+                  &rarr;
+                </span>
+              </Link>
+              <a
+                href="https://github.com/CherryHQ/stella"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 px-5 py-3.5 text-muted-foreground text-sm font-medium rounded-xl border border-border hover:bg-accent hover:text-foreground transition-colors"
+              >
+                {tr.sourceOnGithub}
+              </a>
+            </div>
           </div>
-          <div className="animate-fade-up stagger-4 flex items-center gap-5">
-            <Link
-              to="/docs/$"
-              params={{ _splat: "" }}
-              className="inline-flex items-center gap-2 px-5 py-2.5 bg-primary text-primary-foreground text-sm font-medium rounded-md hover:bg-primary/90 transition-colors"
-            >
-              {tr.readTheDocs}
-              <span aria-hidden="true">&rarr;</span>
-            </Link>
-            <a
-              href="https://github.com/CherryHQ/stella"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 text-muted-foreground text-sm font-medium underline underline-offset-4 decoration-border hover:text-foreground hover:decoration-foreground transition-colors"
-            >
-              {tr.sourceOnGithub}
-            </a>
+
+          {/* Avatar column */}
+          <div className="animate-fade-up stagger-2 flex justify-center lg:justify-end">
+            <div className="relative">
+              <div className="absolute -inset-6 rounded-3xl bg-primary/12 blur-3xl dark:bg-primary/8" />
+              <div className="absolute -inset-1 rounded-2xl bg-primary/20 dark:bg-primary/10" />
+              <img
+                src="/avatar.png"
+                alt="Stella"
+                className="relative w-56 h-56 md:w-68 md:h-68 lg:w-80 lg:h-80 rounded-2xl object-cover"
+              />
+            </div>
           </div>
         </div>
-        <div className="animate-fade-up stagger-5 lg:pt-8">
-          <div className="bg-neutral-900 rounded-lg overflow-hidden ring-1 ring-white/[0.08]">
-            <div className="flex items-center gap-1.5 px-4 py-3 border-b border-white/[0.06]">
-              <div className="w-2.5 h-2.5 rounded-full bg-white/15" />
-              <div className="w-2.5 h-2.5 rounded-full bg-white/15" />
-              <div className="w-2.5 h-2.5 rounded-full bg-white/15" />
-              <span className="ml-3 text-xs text-white/30 font-[family-name:var(--font-mono)]">
-                terminal
+      </div>
+    </section>
+  );
+}
+
+/* ─── Conversation (dark inverted section) ─── */
+
+function ConversationSection({ lang }: { lang: string }) {
+  const tr = t(lang);
+  return (
+    <section className="conversation-section dark relative overflow-hidden">
+      <div className="absolute top-0 left-[20%] w-[400px] h-[400px] rounded-full bg-primary/6 blur-[80px] pointer-events-none" />
+
+      <div className="relative px-6 py-24 md:px-12 lg:px-20 max-w-7xl mx-auto">
+        <div className="grid grid-cols-1 lg:grid-cols-[1fr_1.3fr] gap-16 lg:gap-24 items-center">
+          <div>
+            <p className="text-[11px] font-medium tracking-[0.2em] uppercase text-primary mb-5 font-mono">
+              {tr.memoryLabel}
+            </p>
+            <h2 className="text-3xl md:text-4xl tracking-tight mb-5 leading-tight">
+              {tr.memoryTitle}
+            </h2>
+            <p className="conversation-body-text text-base leading-relaxed max-w-md">
+              {tr.memoryBody}
+            </p>
+          </div>
+
+          {/* Conversation mock */}
+          <div className="conversation-window rounded-2xl overflow-hidden shadow-xl">
+            <div className="flex items-center gap-2 px-5 py-3 conversation-window-titlebar">
+              <div className="w-2.5 h-2.5 rounded-full opacity-30 bg-current" />
+              <div className="w-2.5 h-2.5 rounded-full opacity-20 bg-current" />
+              <div className="w-2.5 h-2.5 rounded-full opacity-15 bg-current" />
+              <span className="ml-3 text-[11px] opacity-40 font-mono tracking-wider uppercase">
+                {tr.conversationLabel}
               </span>
             </div>
-            <div className="p-6 font-[family-name:var(--font-mono)] text-[13px] leading-7">
-              {terminalLines.map((line, i) => (
-                <div key={i} className={line.prompt ? "mt-3 first:mt-0" : ""}>
-                  {line.prompt && <span className="text-primary select-none">$ </span>}
-                  <span className={line.prompt ? "text-white/90" : "text-white/50"}>
+            <div className="px-5 py-6 space-y-5">
+              {conversationLines.map((line, i) => (
+                <div
+                  key={i}
+                  className={`flex ${line.role === "user" ? "justify-end" : "justify-start"}`}
+                >
+                  <div
+                    className={`max-w-[85%] rounded-xl px-4 py-3 text-[13px] leading-relaxed ${
+                      line.role === "user"
+                        ? "conversation-user-bubble"
+                        : "conversation-stella-bubble"
+                    }`}
+                  >
+                    {line.role === "stella" && (
+                      <span className="text-primary font-semibold text-[11px] tracking-wide uppercase block mb-1.5">
+                        stella
+                      </span>
+                    )}
                     {line.text}
-                  </span>
+                  </div>
                 </div>
               ))}
             </div>
@@ -101,6 +162,8 @@ function HeroSection({ lang }: { lang: string }) {
   );
 }
 
+/* ─── Features ─── */
+
 function FeaturesSection({ lang }: { lang: string }) {
   const tr = t(lang);
   const features = [
@@ -108,86 +171,124 @@ function FeaturesSection({ lang }: { lang: string }) {
     { label: "02", title: tr.feature2Title, body: tr.feature2Body },
     { label: "03", title: tr.feature3Title, body: tr.feature3Body },
     { label: "04", title: tr.feature4Title, body: tr.feature4Body },
+    { label: "05", title: tr.feature5Title, body: tr.feature5Body },
   ];
 
   return (
-    <section className="px-6 pt-20 pb-24 md:px-12 lg:px-20 max-w-7xl mx-auto border-t border-border">
-      <h2 className="text-3xl md:text-4xl tracking-tight text-foreground mb-20">
+    <section className="px-6 py-28 md:px-12 lg:px-20 max-w-7xl mx-auto">
+      <p className="text-[11px] font-medium tracking-[0.2em] uppercase text-primary mb-5 font-mono">
         {tr.featuresTitle}
-      </h2>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-x-20 gap-y-16">
-        {features.map((f) => (
-          <FeatureItem key={f.label} {...f} />
+      </p>
+      <div className="h-px bg-border mb-20" />
+
+      <div className="space-y-24 md:space-y-32">
+        {features.map((f, i) => (
+          <div
+            key={f.label}
+            className="grid grid-cols-1 md:grid-cols-12 gap-6 md:gap-8 items-start"
+          >
+            {/* Large decorative number */}
+            <div
+              className={`hidden md:block md:col-span-2 ${i % 2 === 1 ? "md:col-start-11 md:text-right" : ""}`}
+            >
+              <span className="feature-number font-mono text-primary/10 dark:text-primary/8 select-none leading-none">
+                {f.label}
+              </span>
+            </div>
+
+            {/* Content */}
+            <div className={`md:col-span-6 ${i % 2 === 1 ? "md:col-start-3" : "md:col-start-4"}`}>
+              <span className="md:hidden text-[11px] font-medium tracking-[0.15em] text-primary uppercase mb-3 block font-mono">
+                {f.label}
+              </span>
+              <h3 className="text-2xl md:text-3xl tracking-tight text-foreground mb-4">
+                {f.title}
+              </h3>
+              <p className="text-muted-foreground text-base leading-relaxed max-w-lg">{f.body}</p>
+            </div>
+          </div>
         ))}
       </div>
     </section>
   );
 }
 
-function FeatureItem({ label, title, body }: { label: string; title: string; body: string }) {
-  return (
-    <div>
-      <span className="text-[11px] font-medium tracking-[0.15em] text-primary uppercase mb-3 block font-[family-name:var(--font-mono)]">
-        {label}
-      </span>
-      <h3 className="text-xl md:text-2xl tracking-tight text-foreground mb-3">{title}</h3>
-      <p className="text-muted-foreground text-sm leading-relaxed">{body}</p>
-    </div>
-  );
-}
+/* ─── Capabilities ─── */
 
-function MeetStellaSection({ lang }: { lang: string }) {
+function CapabilitiesSection({ lang }: { lang: string }) {
   const tr = t(lang);
+  const capabilities = [
+    { title: tr.capSkills, desc: tr.capSkillsDesc },
+    { title: tr.capAgents, desc: tr.capAgentsDesc },
+    { title: tr.capReading, desc: tr.capReadingDesc },
+    { title: tr.capEmail, desc: tr.capEmailDesc },
+    { title: tr.capVault, desc: tr.capVaultDesc },
+    { title: tr.capOAuth, desc: tr.capOAuthDesc },
+    { title: tr.capPlugins, desc: tr.capPluginsDesc },
+    { title: tr.capMCP, desc: tr.capMCPDesc },
+    { title: tr.capModels, desc: tr.capModelsDesc },
+    { title: tr.capNotifications, desc: tr.capNotificationsDesc },
+  ];
+
   return (
-    <section className="px-6 pt-20 pb-24 md:px-12 lg:px-20 max-w-7xl mx-auto border-t border-border">
-      <div className="grid grid-cols-1 lg:grid-cols-[1fr_auto] gap-12 lg:gap-20 items-center">
-        <div>
-          <p className="text-xs font-medium tracking-[0.2em] uppercase text-primary mb-6 font-[family-name:var(--font-mono)]">
-            {tr.meetStella}
-          </p>
-          <h2 className="text-3xl md:text-4xl tracking-tight text-foreground mb-6">
-            {tr.meetStellaTitle}
-          </h2>
-          <p className="text-muted-foreground text-base leading-relaxed max-w-lg mb-4">
-            {tr.meetStellaBody1}
-          </p>
-          <p className="text-muted-foreground text-base leading-relaxed max-w-lg mb-8">
-            {tr.meetStellaBody2}
-          </p>
-          <Link
-            to="/docs/$"
-            className="inline-flex items-center gap-2 text-primary text-sm font-medium hover:text-primary/80 transition-colors"
-          >
-            {tr.learnMoreAboutStella}
-            <span aria-hidden="true">&rarr;</span>
-          </Link>
-        </div>
-        <div className="flex justify-center lg:justify-end">
-          <img
-            src="/avatar.png"
-            alt="Stella — AI assistant"
-            className="w-48 h-48 md:w-56 md:h-56 rounded-2xl object-cover ring-1 ring-border"
-          />
+    <section className="capabilities-section">
+      <div className="px-6 py-28 md:px-12 lg:px-20 max-w-7xl mx-auto">
+        <div className="grid grid-cols-1 lg:grid-cols-[1fr_2fr] gap-12 lg:gap-24">
+          {/* Left: sticky heading */}
+          <div className="lg:sticky lg:top-24 lg:self-start">
+            <p className="text-[11px] font-medium tracking-[0.2em] uppercase text-primary mb-5 font-mono">
+              {tr.capabilitiesTitle}
+            </p>
+            <h2 className="text-3xl md:text-4xl tracking-tight text-foreground leading-tight">
+              {tr.capabilitiesSubtitle}
+            </h2>
+          </div>
+
+          {/* Right: capabilities list */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-12 gap-y-10">
+            {capabilities.map((cap) => (
+              <div key={cap.title}>
+                <h3 className="font-sans text-base font-semibold text-foreground mb-1.5">
+                  {cap.title}
+                </h3>
+                <p className="text-muted-foreground text-sm leading-relaxed">{cap.desc}</p>
+              </div>
+            ))}
+          </div>
         </div>
       </div>
     </section>
   );
 }
 
+/* ─── Footer CTA ─── */
+
 function FooterCTA({ lang }: { lang: string }) {
   const tr = t(lang);
   return (
-    <section className="px-6 pt-16 pb-24 md:px-12 lg:px-20 max-w-7xl mx-auto">
-      <div className="border-t border-border pt-16 flex flex-col gap-8 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-          <h2 className="text-2xl md:text-3xl tracking-tight text-foreground mb-3">
-            {tr.getStarted}
-          </h2>
-          <p className="text-muted-foreground text-sm">{tr.getStartedBody}</p>
+    <section className="cta-warm-bg">
+      <div className="px-6 py-24 md:px-12 lg:px-20 max-w-7xl mx-auto">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-12 md:gap-20 items-end">
+          <div>
+            <h2 className="text-3xl md:text-4xl tracking-tight text-foreground mb-4">
+              {tr.getStarted}
+            </h2>
+            <p className="text-muted-foreground text-base">{tr.getStartedBody}</p>
+          </div>
+          <div>
+            <div className="space-y-3">
+              <div className="cta-code-block rounded-xl px-5 py-4 font-mono text-sm">
+                <span className="text-primary select-none">$ </span>
+                brew install CherryHQ/tap/stella
+              </div>
+              <div className="cta-code-block rounded-xl px-5 py-4 font-mono text-sm">
+                <span className="text-primary select-none">$ </span>
+                stella server
+              </div>
+            </div>
+            <p className="text-muted-foreground text-xs mt-4">{tr.getStartedAlt}</p>
+          </div>
         </div>
-        <code className="text-[13px] font-[family-name:var(--font-mono)] bg-muted px-4 py-2.5 rounded-md text-foreground whitespace-nowrap shrink-0">
-          go install github.com/CherryHQ/stella@latest
-        </code>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary

- **Recally & Settings pages**: Unify visual language with the agent sidebar design (consistent card styles, filter chips, stat cards, sidebar nav items)
- **Landing page total redesign**: Brand-driven 6-section layout with hero (fluid headline + avatar gold glow), forced-dark conversation demo, alternating feature grid with decorative numbers, 10-capability showcase, and warm CTA footer
- **Colocated styles**: Extract all landing-page CSS from `globals.css` into `routes/index.css` using semantic CSS variables (no hardcoded colors)
- **Copy refresh**: Updated EN/ZH translations with user-facing messaging ("Your agent that just works"), added async tasks feature, and expanded capabilities to cover all Stella features (vault, OAuth, skills, reading assistant, email, plugins, MCP, agents, notifications)

## Test plan

- [ ] Verify landing page renders correctly in both light and dark mode
- [ ] Verify conversation section uses forced dark scope (always dark surface in light mode)
- [ ] Verify recally and settings pages maintain consistent styling with agent sidebar
- [ ] Check mobile responsiveness at 375px, 768px, and 1280px breakpoints
- [ ] Toggle EN/ZH locale and verify all new translation strings render
- [ ] Confirm `globals.css` contains no landing-page-specific styles