### PR TITLE
♻️ refactor(sandbox): deepen sandbox modules

### DIFF
--- a/internal/agent/coretools_builder.go
+++ b/internal/agent/coretools_builder.go
@@ -2,15 +2,15 @@ package agent
 
 import (
 	"github.com/CherryHQ/stella/internal/agent/coretools"
-	"github.com/CherryHQ/stella/internal/agent/sandbox"
+	pkgsandbox "github.com/CherryHQ/stella/pkg/sandbox"
 	"github.com/CherryHQ/stella/pkg/tools"
 	plugintools "github.com/CherryHQ/stella/plugins/tools"
 )
 
 // buildSandboxCoreTools creates core tools using the active sandbox session.
-func buildSandboxCoreTools(session *sandbox.Session, bc plugintools.BuildContext) []tools.Tool {
-	if session == nil || session.Session() == nil {
+func buildSandboxCoreTools(session pkgsandbox.Session, bc plugintools.BuildContext) []tools.Tool {
+	if session == nil {
 		return nil
 	}
-	return coretools.New(session.Session(), bc.Paths.ToolsBinDir, bc.Paths.ProjectRoot)
+	return coretools.New(session, bc.Paths.ToolsBinDir, bc.Paths.ProjectRoot)
 }

--- a/internal/agent/coretools_builder_test.go
+++ b/internal/agent/coretools_builder_test.go
@@ -4,15 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/CherryHQ/stella/internal/agent/sandbox"
 	pkgplugins "github.com/CherryHQ/stella/pkg/plugins"
 	pkgsandbox "github.com/CherryHQ/stella/pkg/sandbox"
 	plugintools "github.com/CherryHQ/stella/plugins/tools"
 )
-
-func fakeRunnerSession(_ string, sess pkgsandbox.Session) *sandbox.Session {
-	return sandbox.NewSession(sess)
-}
 
 type fakeSession struct {
 	alive  bool
@@ -47,7 +42,7 @@ func TestBuildSandboxCoreTools_NoSessionFailsClosed(t *testing.T) {
 }
 
 func TestBuildSandboxCoreTools_WithSessionUsesHostTools(t *testing.T) {
-	session := fakeRunnerSession("local", &fakeSession{alive: true})
+	session := &fakeSession{alive: true}
 	tools := buildSandboxCoreTools(session, plugintools.BuildContext{})
 	if len(tools) != 4 {
 		t.Fatalf("expected 4 tools, got %d", len(tools))
@@ -58,13 +53,5 @@ func TestBuildSandboxCoreTools_WithSessionUsesHostTools(t *testing.T) {
 		if gotNames[i] != want[i] {
 			t.Fatalf("tool[%d] = %q, want %q", i, gotNames[i], want[i])
 		}
-	}
-}
-
-func TestBuildSandboxCoreTools_NilSessionReturnsNil(t *testing.T) {
-	session := fakeRunnerSession("docker", nil)
-	got := buildSandboxCoreTools(session, plugintools.BuildContext{})
-	if got != nil {
-		t.Fatalf("expected nil core tools without session, got %v", got)
 	}
 }

--- a/internal/agent/factory.go
+++ b/internal/agent/factory.go
@@ -144,7 +144,7 @@ func NewRunnerFactory(cfg RunnerFactoryConfig) (NewRunnerFunc, error) {
 				Sandbox: sandbox.Config{
 					SandboxConfig:    cfg.Snap.Sandbox,
 					SandboxBackendFn: cfg.SandboxBackendFn,
-					Paths: sandbox.PathConfig{
+					Paths: sandbox.Paths{
 						StellaHome: config.StellaHome(),
 						AgentRoot:  cfg.Snap.Workspace,
 						UserRoot:   userRoot,

--- a/internal/agent/integration_test.go
+++ b/internal/agent/integration_test.go
@@ -46,7 +46,7 @@ func TestIntegrationPoolWithRunner(t *testing.T) {
 				Builder: integrationProviderStreamBuilder,
 			},
 			Sandbox: sandbox.Config{
-				Paths: sandbox.PathConfig{
+				Paths: sandbox.Paths{
 					StellaHome: stellaHome,
 					AgentRoot:  workspace,
 					UserRoot:   userRoot,

--- a/internal/agent/paths_test.go
+++ b/internal/agent/paths_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestResolvePathsDefaultsWorkDirToUserRoot(t *testing.T) {
 	paths, err := sandbox.ResolvePaths(sandbox.Config{
-		Paths: sandbox.PathConfig{
+		Paths: sandbox.Paths{
 			AgentRoot: "/workspace/agent",
 			UserRoot:  "/workspace/agent/users/1",
 		},

--- a/internal/agent/runner_impl.go
+++ b/internal/agent/runner_impl.go
@@ -18,6 +18,7 @@ import (
 	"github.com/CherryHQ/stella/pkg/memory"
 	pkgplugins "github.com/CherryHQ/stella/pkg/plugins"
 	"github.com/CherryHQ/stella/pkg/providers"
+	pkgsandbox "github.com/CherryHQ/stella/pkg/sandbox"
 	"github.com/CherryHQ/stella/pkg/tools"
 	plugintools "github.com/CherryHQ/stella/plugins/tools"
 	agenttool "github.com/CherryHQ/stella/plugins/tools/agent"
@@ -58,7 +59,7 @@ type runner struct {
 	hookSet       *hooks.HookSet
 	toolLifecycle *coreagent.ToolLifecycle
 	chatTimeout   time.Duration
-	session       *sandbox.Session // runner-owned sandbox session lifecycle
+	session       pkgsandbox.Session // runner-owned sandbox session lifecycle
 
 	mu           sync.Mutex
 	lastActivity time.Time
@@ -93,7 +94,7 @@ func newRunner(ctx context.Context, cfg runnerConfig) (*runner, error) {
 			ProjectRoot: paths.ProjectRoot,
 			UserRoot:    paths.UserRoot,
 			Sections:    cfg.Sections,
-			Host:        session.Session(),
+			Host:        session,
 		})
 	}
 
@@ -185,7 +186,7 @@ func buildStreamFunc(cfg runnerConfig) (providers.StreamFunc, error) {
 }
 
 // buildToolRegistry creates the tool registry with core, builtin, and external tools.
-func buildToolRegistry(ctx context.Context, cfg runnerConfig, session *sandbox.Session) (*tools.Registry, error) {
+func buildToolRegistry(ctx context.Context, cfg runnerConfig, session pkgsandbox.Session) (*tools.Registry, error) {
 	paths, _ := sandbox.ResolvePaths(cfg.Sandbox)
 	toolReg := tools.NewRegistry()
 
@@ -203,7 +204,7 @@ func buildToolRegistry(ctx context.Context, cfg runnerConfig, session *sandbox.S
 			AgentRoot:   paths.AgentRoot,
 			ProjectRoot: paths.ProjectRoot,
 		},
-		Runtime: session.Session(),
+		Runtime: session,
 	}
 
 	coreTools := buildSandboxCoreTools(session, bc)
@@ -391,7 +392,7 @@ func (r *runner) Chat(ctx context.Context, history []ai.Message, message Message
 		}
 
 		if r.session != nil {
-			if err := r.session.Sync(); err != nil {
+			if err := sandbox.SyncSession(r.session); err != nil {
 				slog.Warn("runner: sync session after chat", "error", err)
 			}
 		}

--- a/internal/agent/runner_impl_integration_test.go
+++ b/internal/agent/runner_impl_integration_test.go
@@ -33,7 +33,7 @@ func integrationConfig(t *testing.T) runnerConfig {
 			Builder: integrationProviderStreamBuilder,
 		},
 		Sandbox: sandbox.Config{
-			Paths: sandbox.PathConfig{
+			Paths: sandbox.Paths{
 				StellaHome: stellaHome,
 				AgentRoot:  workspace,
 				UserRoot:   userRoot,

--- a/internal/agent/runner_impl_test.go
+++ b/internal/agent/runner_impl_test.go
@@ -102,8 +102,8 @@ func TestNewRunnerRequiresConfig(t *testing.T) {
 		{"missing api", runnerConfig{Provider: providerConfig{Model: "m", APIKey: "k"}}},
 		{"missing model", runnerConfig{Provider: providerConfig{API: "anthropic", APIKey: "k"}}},
 		{"missing api_key", runnerConfig{Provider: providerConfig{API: "anthropic", Model: "m"}}},
-		{"missing workspace", runnerConfig{Provider: providerConfig{API: "anthropic", Model: "m", APIKey: "k"}, Sandbox: sandbox.Config{Paths: sandbox.PathConfig{UserRoot: "/tmp/user"}}}},
-		{"missing user_data_dir", runnerConfig{Provider: providerConfig{API: "anthropic", Model: "m", APIKey: "k"}, Sandbox: sandbox.Config{Paths: sandbox.PathConfig{AgentRoot: "/tmp/workspace"}}}},
+		{"missing workspace", runnerConfig{Provider: providerConfig{API: "anthropic", Model: "m", APIKey: "k"}, Sandbox: sandbox.Config{Paths: sandbox.Paths{UserRoot: "/tmp/user"}}}},
+		{"missing user_data_dir", runnerConfig{Provider: providerConfig{API: "anthropic", Model: "m", APIKey: "k"}, Sandbox: sandbox.Config{Paths: sandbox.Paths{AgentRoot: "/tmp/workspace"}}}},
 	}
 
 	for _, tt := range tests {

--- a/internal/agent/sandbox/backend_test.go
+++ b/internal/agent/sandbox/backend_test.go
@@ -59,7 +59,7 @@ func (s *stubOAuthVaultStore) LoadEnv(_ context.Context, userID string) (map[str
 // TestResolveSessionRequiresUserRoot tests that ResolveSession fails without a UserRoot.
 func TestResolveSessionRequiresUserRoot(t *testing.T) {
 	_, err := ResolveSession(context.Background(), Config{
-		Paths: PathConfig{
+		Paths: Paths{
 			AgentRoot: "/workspace/agent",
 			// UserRoot intentionally omitted
 		},
@@ -71,7 +71,7 @@ func TestResolveSessionRequiresUserRoot(t *testing.T) {
 
 func TestSandboxProcessEnvLeavesHomeUnsetForDocker(t *testing.T) {
 	cfg := Config{
-		Paths: PathConfig{
+		Paths: Paths{
 			StellaHome: "/stella",
 			AgentRoot:  "/workspace/agent",
 			UserRoot:   "/workspace/agent/users/1",
@@ -156,7 +156,7 @@ func TestResolveSessionDockerUnreachableDaemonReturnsError(t *testing.T) {
 	workspace := t.TempDir()
 	userRoot := workspace + "/users/1"
 	_, err := ResolveSession(context.Background(), Config{
-		Paths: PathConfig{
+		Paths: Paths{
 			AgentRoot: workspace,
 			UserRoot:  userRoot,
 		},
@@ -176,7 +176,7 @@ func TestResolveSessionDockerUnreachableDaemonReturnsError(t *testing.T) {
 // any same-named vault entry.
 func TestBuildSandboxEnv_vaultSecretsInjected(t *testing.T) {
 	cfg := Config{
-		Paths: PathConfig{
+		Paths: Paths{
 			StellaHome: "/stella",
 			AgentRoot:  "/workspace/agent",
 			UserRoot:   "/workspace/users/1",
@@ -215,7 +215,7 @@ func TestBuildSandboxEnv_vaultSecretsInjected(t *testing.T) {
 // correctly (returns runner env vars) when no vault loader is configured.
 func TestBuildSandboxEnv_noVaultLoader(t *testing.T) {
 	cfg := Config{
-		Paths: PathConfig{
+		Paths: Paths{
 			StellaHome: "/stella",
 			AgentRoot:  "/workspace/agent",
 			UserRoot:   "/workspace/users/1",
@@ -242,7 +242,7 @@ func TestBuildSandboxEnv_noVaultLoader(t *testing.T) {
 // present in the vault.
 func TestBuildSandboxEnv_OAuthBundleKeysStripped(t *testing.T) {
 	cfg := Config{
-		Paths: PathConfig{
+		Paths: Paths{
 			StellaHome: "/stella",
 			AgentRoot:  "/workspace/agent",
 			UserRoot:   "/workspace/users/1",
@@ -319,7 +319,7 @@ func TestBuildSandboxEnv_RuntimeOAuthEnvInjected(t *testing.T) {
 	}
 
 	cfg := Config{
-		Paths: PathConfig{
+		Paths: Paths{
 			StellaHome: "/stella",
 			AgentRoot:  "/workspace/agent",
 			UserRoot:   "/workspace/users/1",
@@ -386,7 +386,7 @@ func TestBuildSandboxEnv_TokenInjectionErrorsAreSkipped(t *testing.T) {
 	}
 
 	cfg := Config{
-		Paths: PathConfig{
+		Paths: Paths{
 			StellaHome: "/stella",
 			AgentRoot:  "/workspace/agent",
 			UserRoot:   "/workspace/users/1",

--- a/internal/agent/sandbox/backend_test.go
+++ b/internal/agent/sandbox/backend_test.go
@@ -10,7 +10,6 @@ import (
 	oauth "github.com/CherryHQ/stella/internal/credentials/oauth"
 	pkgplugins "github.com/CherryHQ/stella/pkg/plugins"
 	pkgsandbox "github.com/CherryHQ/stella/pkg/sandbox"
-	"github.com/CherryHQ/stella/pkg/sandbox/hostenv"
 )
 
 // stubVaultLoader is a test-only VaultEnvLoader that returns a fixed map.
@@ -98,7 +97,7 @@ func TestCopyLocalHostEnvAllowlist(t *testing.T) {
 	t.Setenv("HTTPS_PROXY", "http://proxy.example:8080")
 
 	env := map[string]string{}
-	hostenv.CopyHostEnv(env)
+	pkgsandbox.HostEnvCopy(env)
 
 	if _, ok := env["STELLA_TEST_SECRET"]; ok {
 		t.Fatal("local sandbox env copied non-allowlisted host variable")
@@ -122,12 +121,12 @@ func TestLocalSandboxPathAllowed(t *testing.T) {
 		"/nix/store/abc/bin",
 		"/run/current-system/sw/bin",
 	} {
-		if !hostenv.PathAllowed(entry, stellaBin) {
+		if !pkgsandbox.HostEnvPathAllowed(entry, stellaBin) {
 			t.Fatalf("expected %q to be allowed", entry)
 		}
 	}
 	for _, entry := range []string{"", "/home/me/bin", "/tmp/bin", "/binary"} {
-		if hostenv.PathAllowed(entry, stellaBin) {
+		if pkgsandbox.HostEnvPathAllowed(entry, stellaBin) {
 			t.Fatalf("expected %q to be rejected", entry)
 		}
 	}

--- a/internal/agent/sandbox/backend_test.go
+++ b/internal/agent/sandbox/backend_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/CherryHQ/stella/internal/config"
 	oauth "github.com/CherryHQ/stella/internal/credentials/oauth"
 	pkgplugins "github.com/CherryHQ/stella/pkg/plugins"
+	"github.com/CherryHQ/stella/pkg/sandbox/hostenv"
 )
 
 // stubVaultLoader is a test-only VaultEnvLoader that returns a fixed map.
@@ -96,7 +97,7 @@ func TestCopyLocalHostEnvAllowlist(t *testing.T) {
 	t.Setenv("HTTPS_PROXY", "http://proxy.example:8080")
 
 	env := map[string]string{}
-	copyLocalHostEnv(env)
+	hostenv.CopyHostEnv(env)
 
 	if _, ok := env["STELLA_TEST_SECRET"]; ok {
 		t.Fatal("local sandbox env copied non-allowlisted host variable")
@@ -120,12 +121,12 @@ func TestLocalSandboxPathAllowed(t *testing.T) {
 		"/nix/store/abc/bin",
 		"/run/current-system/sw/bin",
 	} {
-		if !localSandboxPathAllowed(entry, stellaBin) {
+		if !hostenv.PathAllowed(entry, stellaBin) {
 			t.Fatalf("expected %q to be allowed", entry)
 		}
 	}
 	for _, entry := range []string{"", "/home/me/bin", "/tmp/bin", "/binary"} {
-		if localSandboxPathAllowed(entry, stellaBin) {
+		if hostenv.PathAllowed(entry, stellaBin) {
 			t.Fatalf("expected %q to be rejected", entry)
 		}
 	}

--- a/internal/agent/sandbox/backend_test.go
+++ b/internal/agent/sandbox/backend_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/CherryHQ/stella/internal/config"
 	oauth "github.com/CherryHQ/stella/internal/credentials/oauth"
 	pkgplugins "github.com/CherryHQ/stella/pkg/plugins"
+	pkgsandbox "github.com/CherryHQ/stella/pkg/sandbox"
 	"github.com/CherryHQ/stella/pkg/sandbox/hostenv"
 )
 
@@ -132,29 +133,16 @@ func TestLocalSandboxPathAllowed(t *testing.T) {
 	}
 }
 
-// TestRunnerSessionLifecycle tests the Session lifecycle using a nil session
-// (alwaysAlive=true path) to avoid requiring a live sandbox backend.
-func TestRunnerSessionLifecycle(t *testing.T) {
-	rs := &Session{
-		alwaysAlive: true,
+// TestSyncSessionNoop verifies that SyncSession is a no-op for nil and
+// for sessions that don't implement Sync.
+func TestSyncSessionNoop(t *testing.T) {
+	if err := SyncSession(nil); err != nil {
+		t.Errorf("SyncSession(nil): %v", err)
 	}
 
-	// Test Alive
-	if !rs.Alive() {
-		t.Error("session should be alive")
-	}
-
-	// Test Done channel — nil session returns an already-closed channel.
-	select {
-	case <-rs.Done():
-		// Expected: nil session Done() is immediately closed.
-	default:
-		t.Error("nil-session Done() should be closed")
-	}
-
-	// Test Close (no-op for nil inner session)
-	if err := rs.Close(); err != nil {
-		t.Errorf("Close: %v", err)
+	nop := pkgsandbox.NopSession()
+	if err := SyncSession(nop); err != nil {
+		t.Errorf("SyncSession(nop): %v", err)
 	}
 }
 
@@ -181,30 +169,6 @@ func TestResolveSessionDockerUnreachableDaemonReturnsError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "docker") {
 		t.Fatalf("expected error to mention 'docker', got: %v", err)
-	}
-}
-
-// TestRunnerSessionNilHandling tests nil session safety.
-func TestRunnerSessionNilHandling(t *testing.T) {
-	var rs *Session
-
-	// Should handle nil gracefully
-	if rs.Alive() {
-		t.Error("nil session should not be alive")
-	}
-
-	// Done should return closed channel for nil
-	done := rs.Done()
-	select {
-	case <-done:
-		// Expected
-	default:
-		t.Error("nil session Done() should be closed")
-	}
-
-	// Close should not panic
-	if err := rs.Close(); err != nil {
-		t.Errorf("Close on nil: %v", err)
 	}
 }
 

--- a/internal/agent/sandbox/config.go
+++ b/internal/agent/sandbox/config.go
@@ -14,20 +14,12 @@ type VaultEnvLoader interface {
 	LoadEnv(ctx context.Context, userID string) (map[string]string, error)
 }
 
-// PathConfig contains the host paths passed to sandbox operations.
-type PathConfig struct {
-	StellaHome  string
-	AgentRoot   string
-	UserRoot    string
-	ProjectRoot string
-}
-
 // Config is passed to sandbox operations.
 // It is constructed from the runner config in the parent agent package.
 type Config struct {
 	SandboxConfig    config.SandboxConfig
 	SandboxBackendFn func(ctx context.Context) string
-	Paths            PathConfig
+	Paths            Paths
 	UserID           string
 	SessionEnvSpecs  []pkgplugins.SessionEnvSpec
 	VaultEnvLoader   VaultEnvLoader

--- a/internal/agent/sandbox/env.go
+++ b/internal/agent/sandbox/env.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
-	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	oauth "github.com/CherryHQ/stella/internal/credentials/oauth"
@@ -166,88 +164,4 @@ func injectSessionEnv(ctx context.Context, cfg Config, env map[string]string) er
 		}
 	}
 	return nil
-}
-
-func prependPathEntry(entry, existing string) string {
-	if entry == "" {
-		return existing
-	}
-	if existing == "" {
-		return entry
-	}
-	return entry + string(os.PathListSeparator) + existing
-}
-
-func localSandboxHome(workDir string) string {
-	if runtime.GOOS == "linux" {
-		return "/workspace"
-	}
-	return workDir
-}
-
-func localSandboxPath(stellaHome string) string {
-	stellaBin := filepath.Join(stellaHome, "bin")
-	if runtime.GOOS != "linux" {
-		return prependPathEntry(stellaBin, os.Getenv("PATH"))
-	}
-
-	entries := []string{stellaBin}
-	for entry := range strings.SplitSeq(os.Getenv("PATH"), string(os.PathListSeparator)) {
-		if localSandboxPathAllowed(entry, stellaBin) {
-			entries = append(entries, entry)
-		}
-	}
-	entries = append(entries,
-		"/run/current-system/sw/bin",
-		"/usr/local/sbin",
-		"/usr/local/bin",
-		"/usr/sbin",
-		"/usr/bin",
-		"/sbin",
-		"/bin",
-	)
-	return strings.Join(dedupePathEntries(entries), string(os.PathListSeparator))
-}
-
-func localSandboxPathAllowed(entry, stellaBin string) bool {
-	if entry == "" {
-		return false
-	}
-	if stellaBin != "" && entry == stellaBin {
-		return true
-	}
-	for _, root := range []string{"/usr", "/bin", "/sbin", "/nix", "/run/current-system/sw"} {
-		if entry == root || strings.HasPrefix(entry, root+"/") {
-			return true
-		}
-	}
-	return false
-}
-
-func dedupePathEntries(entries []string) []string {
-	seen := make(map[string]struct{}, len(entries))
-	out := make([]string, 0, len(entries))
-	for _, entry := range entries {
-		if entry == "" {
-			continue
-		}
-		if _, ok := seen[entry]; ok {
-			continue
-		}
-		seen[entry] = struct{}{}
-		out = append(out, entry)
-	}
-	return out
-}
-
-func copyLocalHostEnv(env map[string]string) {
-	for _, key := range []string{
-		"TERM", "COLORTERM", "LANG", "LC_ALL", "LC_CTYPE", "TZ",
-		"HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY",
-		"http_proxy", "https_proxy", "all_proxy", "no_proxy",
-	} {
-		if value := os.Getenv(key); value != "" {
-			env[key] = value
-		}
-	}
 }

--- a/internal/agent/sandbox/paths.go
+++ b/internal/agent/sandbox/paths.go
@@ -7,41 +7,36 @@ import (
 	"github.com/CherryHQ/stella/internal/config"
 )
 
-// Paths is the minimal path set sandbox policy creation depends on.
-// Sandbox execution is defined entirely by the user-scoped writable root and an
-// internal working directory derived from that root.
+// Paths is the path set sandbox policy creation and tool registration depend on.
 type Paths struct {
 	StellaHome  string
-	UserRoot    string
-	WorkDir     string
 	AgentRoot   string
+	UserRoot    string
 	ProjectRoot string
+	// WorkDir is the initial working directory inside the sandbox.
+	// Set by ResolvePaths to the absolute form of UserRoot.
+	WorkDir string
 }
 
-// ResolvePaths converts a Config into the minimal path set the sandbox needs.
+// ResolvePaths validates cfg.Paths and fills derived fields (StellaHome default, WorkDir).
 func ResolvePaths(cfg Config) (Paths, error) {
-	stellaHome := cfg.Paths.StellaHome
-	if stellaHome == "" {
-		stellaHome = config.StellaHome()
+	p := cfg.Paths
+	if p.StellaHome == "" {
+		p.StellaHome = config.StellaHome()
 	}
-	if cfg.Paths.AgentRoot == "" {
+	if p.AgentRoot == "" {
 		return Paths{}, fmt.Errorf("agent_root is required")
 	}
-	if cfg.Paths.UserRoot == "" {
+	if p.UserRoot == "" {
 		return Paths{}, fmt.Errorf("user_root is required")
 	}
-
-	userRoot, err := filepath.Abs(cfg.Paths.UserRoot)
+	userRoot, err := filepath.Abs(p.UserRoot)
 	if err != nil {
 		return Paths{}, fmt.Errorf("resolve user_root: %w", err)
 	}
-	return Paths{
-		StellaHome:  stellaHome,
-		UserRoot:    userRoot,
-		WorkDir:     userRoot,
-		AgentRoot:   cfg.Paths.AgentRoot,
-		ProjectRoot: cfg.Paths.ProjectRoot,
-	}, nil
+	p.UserRoot = userRoot
+	p.WorkDir = userRoot
+	return p, nil
 }
 
 // ProcessEnv builds the baseline process environment injected into

--- a/internal/agent/sandbox/session.go
+++ b/internal/agent/sandbox/session.go
@@ -30,28 +30,11 @@ func SyncSession(session pkgsandbox.Session) error {
 }
 
 func createDockerSession(ctx context.Context, cfg Config) (pkgsandbox.Session, error) {
-	ctx, span := sandboxTracer.Start(ctx, "sandbox.create_session",
-		trace.WithAttributes(
-			attribute.String("stella.sandbox.backend", config.SandboxBackendDocker),
-			attribute.String("stella.sandbox.agent_root", cfg.Paths.AgentRoot),
-			attribute.String("stella.sandbox.user_root", cfg.Paths.UserRoot),
-			attribute.String("stella.sandbox.project_root", cfg.Paths.ProjectRoot),
-		),
-	)
-	defer span.End()
-
 	paths, policy, err := buildBasePolicy(ctx, cfg)
 	if err != nil {
-		recordSandboxError(span, err)
 		return nil, err
 	}
 	policy.InheritEnv = true
-
-	span.SetAttributes(
-		attribute.String("stella.sandbox.resolved_user_root", paths.UserRoot),
-		attribute.String("stella.sandbox.work_dir", paths.WorkDir),
-		attribute.String("stella.sandbox.network.mode", cfg.SandboxConfig.Network.Mode),
-	)
 
 	slog.Info("creating docker session",
 		"component", "runner_sandbox",
@@ -65,7 +48,6 @@ func createDockerSession(ctx context.Context, cfg Config) (pkgsandbox.Session, e
 		StellaHome: paths.StellaHome,
 	})
 	if err != nil {
-		recordSandboxError(span, err)
 		return nil, err
 	}
 
@@ -76,7 +58,6 @@ func createDockerSession(ctx context.Context, cfg Config) (pkgsandbox.Session, e
 		} else {
 			err = fmt.Errorf("docker not available; install and start Docker Desktop or the docker daemon: %w", err)
 		}
-		recordSandboxError(span, err)
 		return nil, err
 	}
 
@@ -168,14 +149,31 @@ func ResolveSession(ctx context.Context, cfg Config) (pkgsandbox.Session, error)
 		}
 	}
 
+	ctx, span := sandboxTracer.Start(ctx, "sandbox.create_session",
+		trace.WithAttributes(
+			attribute.String("stella.sandbox.backend", name),
+			attribute.String("stella.sandbox.agent_root", cfg.Paths.AgentRoot),
+			attribute.String("stella.sandbox.user_root", cfg.Paths.UserRoot),
+			attribute.String("stella.sandbox.project_root", cfg.Paths.ProjectRoot),
+		),
+	)
+	defer span.End()
+
+	var session pkgsandbox.Session
+	var err error
 	switch name {
 	case config.SandboxBackendDocker:
-		return createDockerSession(ctx, cfg)
+		session, err = createDockerSession(ctx, cfg)
 	case config.SandboxBackendLocal:
-		return createLocalSession(ctx, cfg)
+		session, err = createLocalSession(ctx, cfg)
 	case config.SandboxBackendNone:
-		return createHostSession(ctx, cfg)
+		session, err = createHostSession(ctx, cfg)
 	default:
-		return nil, fmt.Errorf("unknown sandbox backend: %q", name)
+		err = fmt.Errorf("unknown sandbox backend: %q", name)
 	}
+	if err != nil {
+		recordSandboxError(span, err)
+		return nil, err
+	}
+	return session, nil
 }

--- a/internal/agent/sandbox/session.go
+++ b/internal/agent/sandbox/session.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"sync"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -16,7 +15,6 @@ import (
 	"github.com/CherryHQ/stella/internal/manifestplugins"
 	pkgsandbox "github.com/CherryHQ/stella/pkg/sandbox"
 	dockerplugin "github.com/CherryHQ/stella/plugins/sandbox/docker"
-	dockerclient "github.com/CherryHQ/stella/plugins/sandbox/docker/dockerclient"
 	localplugin "github.com/CherryHQ/stella/plugins/sandbox/local"
 	noneplugin "github.com/CherryHQ/stella/plugins/sandbox/none"
 )
@@ -132,26 +130,12 @@ func createDockerSession(ctx context.Context, cfg Config) (*Session, error) {
 	)
 	defer span.End()
 
-	paths, err := ResolvePaths(cfg)
-	if err != nil {
-		err = fmt.Errorf("resolve sandbox paths: %w", err)
-		recordSandboxError(span, err)
-		return nil, err
-	}
-	env, err := buildSandboxEnv(ctx, cfg, paths)
+	paths, policy, err := buildBasePolicy(ctx, cfg)
 	if err != nil {
 		recordSandboxError(span, err)
 		return nil, err
 	}
-
-	policy := pkgsandbox.Policy{
-		Filesystem: runnerFilesystemPolicy(paths),
-		Network: pkgsandbox.NetworkPolicy{
-			Mode: pkgsandbox.NetworkMode(cfg.SandboxConfig.Network.Mode),
-		},
-		Env:        env,
-		InheritEnv: true,
-	}
+	policy.InheritEnv = true
 
 	span.SetAttributes(
 		attribute.String("stella.sandbox.resolved_user_root", paths.UserRoot),
@@ -166,21 +150,8 @@ func createDockerSession(ctx context.Context, cfg Config) (*Session, error) {
 		"network_mode", cfg.SandboxConfig.Network.Mode,
 	)
 
-	dockerCfg, err := ResolveDockerConfig()
+	dockerCfg, err := ResolveDockerConfig(paths.StellaHome)
 	if err != nil {
-		recordSandboxError(span, err)
-		return nil, err
-	}
-	CleanupOrphanedDockerContainers(ctx, dockerCfg.TranslateToDaemonPath(paths.StellaHome))
-	if err := dockerplugin.Preflight(ctx, dockerplugin.PreflightConfig{
-		StellaHome: paths.StellaHome,
-		Docker:     dockerCfg,
-	}); err != nil {
-		if config.SandboxDockerImageIsDev() {
-			err = fmt.Errorf("%w (run `mise run sandbox:docker:build` to build the local %q image)", err, config.SandboxDockerImage())
-		} else {
-			err = fmt.Errorf("docker not available; install and start Docker Desktop or the docker daemon: %w", err)
-		}
 		recordSandboxError(span, err)
 		return nil, err
 	}
@@ -192,13 +163,15 @@ func createDockerSession(ctx context.Context, cfg Config) (*Session, error) {
 	}
 	dockerCfg.UserToolBinaries = userTools
 
-	// Construct a per-runner factory with the resolved config. The global
-	// registry carries a zero-value Config for probe/contract-test use only.
 	factory := dockerplugin.NewFactory(dockerCfg)
 
 	session, err := factory.CreateSession(ctx, policy)
 	if err != nil {
-		err = fmt.Errorf("create docker session: %w", err)
+		if config.SandboxDockerImageIsDev() {
+			err = fmt.Errorf("%w (run `mise run sandbox:docker:build` to build the local %q image)", err, config.SandboxDockerImage())
+		} else {
+			err = fmt.Errorf("docker not available; install and start Docker Desktop or the docker daemon: %w", err)
+		}
 		recordSandboxError(span, err)
 		return nil, err
 	}
@@ -212,27 +185,9 @@ func createDockerSession(ctx context.Context, cfg Config) (*Session, error) {
 // createLocalSession creates a local (no container isolation) session.
 // WARNING: commands run directly on the host OS with no container isolation.
 func createLocalSession(ctx context.Context, cfg Config) (*Session, error) {
-	paths, err := ResolvePaths(cfg)
-	if err != nil {
-		return nil, fmt.Errorf("resolve sandbox paths: %w", err)
-	}
-	env, err := buildSandboxEnv(ctx, cfg, paths)
+	paths, policy, err := buildBasePolicy(ctx, cfg)
 	if err != nil {
 		return nil, err
-	}
-	env["PATH"] = localSandboxPath(paths.StellaHome)
-	if paths.WorkDir != "" {
-		env["HOME"] = localSandboxHome(paths.WorkDir)
-	}
-	copyLocalHostEnv(env)
-
-	policy := pkgsandbox.Policy{
-		Filesystem: runnerFilesystemPolicy(paths),
-		Network: pkgsandbox.NetworkPolicy{
-			Mode: pkgsandbox.NetworkMode(cfg.SandboxConfig.Network.Mode),
-		},
-		Env:        env,
-		InheritEnv: false,
 	}
 
 	slog.Info("creating local session",
@@ -242,35 +197,23 @@ func createLocalSession(ctx context.Context, cfg Config) (*Session, error) {
 		"network_mode", cfg.SandboxConfig.Network.Mode,
 	)
 
-	session, err := localplugin.NewFactory().CreateSession(ctx, policy)
+	session, err := localplugin.NewFactory(localplugin.Config{
+		StellaHome: paths.StellaHome,
+	}).CreateSession(ctx, policy)
 	if err != nil {
 		return nil, fmt.Errorf("create local session: %w", err)
 	}
 
 	return &Session{
 		session: session,
-		policy:  policy,
+		policy:  session.Policy(),
 	}, nil
 }
 
 func createHostSession(ctx context.Context, cfg Config) (*Session, error) {
-	paths, err := ResolvePaths(cfg)
-	if err != nil {
-		return nil, fmt.Errorf("resolve sandbox paths: %w", err)
-	}
-	env, err := buildSandboxEnv(ctx, cfg, paths)
+	paths, policy, err := buildBasePolicy(ctx, cfg)
 	if err != nil {
 		return nil, err
-	}
-	env["PATH"] = localSandboxPath(paths.StellaHome)
-
-	policy := pkgsandbox.Policy{
-		Filesystem: runnerFilesystemPolicy(paths),
-		Network: pkgsandbox.NetworkPolicy{
-			Mode: pkgsandbox.NetworkAllowAll,
-		},
-		Env:        env,
-		InheritEnv: true,
 	}
 
 	slog.Info("creating host session",
@@ -278,25 +221,28 @@ func createHostSession(ctx context.Context, cfg Config) (*Session, error) {
 		"work_dir", paths.WorkDir,
 	)
 
-	session, err := noneplugin.NewFactory().CreateSession(ctx, policy)
+	session, err := noneplugin.NewFactory(noneplugin.Config{
+		StellaHome: paths.StellaHome,
+	}).CreateSession(ctx, policy)
 	if err != nil {
 		return nil, fmt.Errorf("create host session: %w", err)
 	}
 
 	return &Session{
 		session: session,
-		policy:  policy,
+		policy:  session.Policy(),
 	}, nil
 }
 
 // ResolveDockerConfig builds the docker plugin Config used by the runner,
 // including any DooD path-translation prefixes derived from STELLA_HOME_HOST.
-// Shared by session creation, preflight, and orphan cleanup so all three scope
-// to the same daemon-view paths.
-func ResolveDockerConfig() (dockerplugin.Config, error) {
+func ResolveDockerConfig(stellaHome string) (dockerplugin.Config, error) {
+	if stellaHome == "" {
+		stellaHome = config.StellaHome()
+	}
 	return applyDooDDefaults(
-		dockerplugin.Config{Image: config.SandboxDockerImage()},
-		config.StellaHome(),
+		dockerplugin.Config{Image: config.SandboxDockerImage(), StellaHome: stellaHome},
+		stellaHome,
 	)
 }
 
@@ -336,22 +282,27 @@ func resolveDockerUserToolBinaries(stellaHome string) ([]dockerplugin.ToolBinary
 	return out, nil
 }
 
-var dockerOrphanCleanupOnce sync.Once
+// buildBasePolicy resolves paths and builds the backend-agnostic base policy
+// (filesystem, network, env). Backend-specific adjustments are applied by
+// each factory's CreateSession.
+func buildBasePolicy(ctx context.Context, cfg Config) (Paths, pkgsandbox.Policy, error) {
+	paths, err := ResolvePaths(cfg)
+	if err != nil {
+		return Paths{}, pkgsandbox.Policy{}, fmt.Errorf("resolve sandbox paths: %w", err)
+	}
+	env, err := buildSandboxEnv(ctx, cfg, paths)
+	if err != nil {
+		return Paths{}, pkgsandbox.Policy{}, err
+	}
 
-// CleanupOrphanedDockerContainers removes stale stella containers from previous
-// crashed processes. Runs at most once per process. The stellaHome argument must
-// already be translated to the daemon-view path so it matches the label set at
-// container creation time.
-func CleanupOrphanedDockerContainers(ctx context.Context, stellaHome string) {
-	dockerOrphanCleanupOnce.Do(func() {
-		client, err := dockerclient.New()
-		if err != nil {
-			slog.Warn("docker orphan cleanup skipped: cannot construct docker client",
-				"component", "runner_sandbox", "error", err)
-			return
-		}
-		dockerclient.CleanupOrphanedContainers(ctx, client, stellaHome)
-	})
+	policy := pkgsandbox.Policy{
+		Filesystem: runnerFilesystemPolicy(paths),
+		Network: pkgsandbox.NetworkPolicy{
+			Mode: pkgsandbox.NetworkMode(cfg.SandboxConfig.Network.Mode),
+		},
+		Env: env,
+	}
+	return paths, policy, nil
 }
 
 // ResolveSession creates a Session from configuration.

--- a/internal/agent/sandbox/session.go
+++ b/internal/agent/sandbox/session.go
@@ -32,16 +32,6 @@ func SyncSession(session pkgsandbox.Session) error {
 	return nil
 }
 
-// sessionFactory creates a session from configuration.
-type sessionFactory func(context.Context, Config) (pkgsandbox.Session, error)
-
-// registry manages session factories by name.
-var sessionRegistry = map[string]sessionFactory{
-	config.SandboxBackendDocker: createDockerSession,
-	config.SandboxBackendLocal:  createLocalSession,
-	config.SandboxBackendNone:   createHostSession,
-}
-
 func createDockerSession(ctx context.Context, cfg Config) (pkgsandbox.Session, error) {
 	ctx, span := sandboxTracer.Start(ctx, "sandbox.create_session",
 		trace.WithAttributes(
@@ -222,6 +212,11 @@ func buildBasePolicy(ctx context.Context, cfg Config) (Paths, pkgsandbox.Policy,
 // ResolveSession creates a sandbox session from configuration.
 // The active backend is determined by SandboxBackendFn (global Plugins page
 // selection), defaulting to local when no backend is explicitly enabled.
+//
+// This dispatches directly rather than using pkg/sandbox.Registry because the
+// runtime path needs Config→Policy transformation that is per-backend, while
+// the pkg Registry operates on Policy alone (useful for contract tests and
+// external plugin registration).
 func ResolveSession(ctx context.Context, cfg Config) (pkgsandbox.Session, error) {
 	name := config.SandboxBackendLocal
 	if cfg.SandboxBackendFn != nil {
@@ -230,9 +225,14 @@ func ResolveSession(ctx context.Context, cfg Config) (pkgsandbox.Session, error)
 		}
 	}
 
-	factory, ok := sessionRegistry[name]
-	if !ok {
+	switch name {
+	case config.SandboxBackendDocker:
+		return createDockerSession(ctx, cfg)
+	case config.SandboxBackendLocal:
+		return createLocalSession(ctx, cfg)
+	case config.SandboxBackendNone:
+		return createHostSession(ctx, cfg)
+	default:
 		return nil, fmt.Errorf("unknown sandbox backend: %q", name)
 	}
-	return factory(ctx, cfg)
 }

--- a/internal/agent/sandbox/session.go
+++ b/internal/agent/sandbox/session.go
@@ -4,14 +4,11 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"path/filepath"
-	"reflect"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/CherryHQ/stella/internal/config"
-	"github.com/CherryHQ/stella/internal/manifestplugins"
 	pkgsandbox "github.com/CherryHQ/stella/pkg/sandbox"
 	dockerplugin "github.com/CherryHQ/stella/plugins/sandbox/docker"
 	localplugin "github.com/CherryHQ/stella/plugins/sandbox/local"
@@ -63,20 +60,14 @@ func createDockerSession(ctx context.Context, cfg Config) (pkgsandbox.Session, e
 		"network_mode", cfg.SandboxConfig.Network.Mode,
 	)
 
-	dockerCfg, err := ResolveDockerConfig(paths.StellaHome)
+	factory, err := dockerplugin.NewFactory(dockerplugin.Config{
+		Image:      config.SandboxDockerImage(),
+		StellaHome: paths.StellaHome,
+	})
 	if err != nil {
 		recordSandboxError(span, err)
 		return nil, err
 	}
-	userTools, err := resolveDockerUserToolBinaries(paths.StellaHome)
-	if err != nil {
-		err = fmt.Errorf("resolve docker user tools: %w", err)
-		recordSandboxError(span, err)
-		return nil, err
-	}
-	dockerCfg.UserToolBinaries = userTools
-
-	factory := dockerplugin.NewFactory(dockerCfg)
 
 	session, err := factory.CreateSession(ctx, policy)
 	if err != nil {
@@ -136,54 +127,6 @@ func createHostSession(ctx context.Context, cfg Config) (pkgsandbox.Session, err
 	}
 
 	return session, nil
-}
-
-// ResolveDockerConfig builds the docker plugin Config used by the runner,
-// including any DooD path-translation prefixes derived from STELLA_HOME_HOST.
-func ResolveDockerConfig(stellaHome string) (dockerplugin.Config, error) {
-	if stellaHome == "" {
-		stellaHome = config.StellaHome()
-	}
-	return applyDooDDefaults(
-		dockerplugin.Config{Image: config.SandboxDockerImage(), StellaHome: stellaHome},
-		stellaHome,
-	)
-}
-
-func resolveDockerUserToolBinaries(stellaHome string) ([]dockerplugin.ToolBinary, error) {
-	builtin, err := manifestplugins.LoadBuiltin()
-	if err != nil {
-		return nil, err
-	}
-	user, err := manifestplugins.LoadUser(filepath.Join(stellaHome, "plugins.yaml"))
-	if err != nil {
-		return nil, err
-	}
-	merged := manifestplugins.Merge(builtin, user)
-
-	builtinByID := make(map[string]manifestplugins.ManifestPlugin, len(builtin.Plugins))
-	for _, plugin := range builtin.Plugins {
-		builtinByID[plugin.ID] = plugin
-	}
-
-	var out []dockerplugin.ToolBinary
-	for _, plugin := range merged.Plugins {
-		if !plugin.Enabled || len(plugin.Binaries) == 0 {
-			continue
-		}
-		if builtinPlugin, ok := builtinByID[plugin.ID]; ok && reflect.DeepEqual(plugin.Binaries, builtinPlugin.Binaries) {
-			continue
-		}
-		for _, binary := range plugin.Binaries {
-			out = append(out, dockerplugin.ToolBinary{
-				Name:    binary.Name,
-				Tool:    binary.Tool,
-				Version: binary.Version,
-				Options: binary.Options,
-			})
-		}
-	}
-	return out, nil
 }
 
 // buildBasePolicy resolves paths and builds the backend-agnostic base policy

--- a/internal/agent/sandbox/session.go
+++ b/internal/agent/sandbox/session.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os"
 	"path/filepath"
 	"reflect"
 
@@ -19,98 +18,22 @@ import (
 	noneplugin "github.com/CherryHQ/stella/plugins/sandbox/none"
 )
 
-// Session wraps a pkgsandbox.Session for runner use.
-type Session struct {
-	session     pkgsandbox.Session
-	policy      pkgsandbox.Policy
-	alwaysAlive bool
-}
-
-// SessionDir returns the session workspace directory.
-func (r *Session) SessionDir() string {
-	if r == nil || r.session == nil {
-		return ""
-	}
-	resolved, err := r.session.ResolvePath(string(os.PathSeparator))
-	if err != nil {
-		return ""
-	}
-	return resolved
-}
-
-func (r *Session) Host() pkgsandbox.Host {
-	if r == nil || r.session == nil {
-		return nil
-	}
-	return r.session
-}
-
-// Session returns the underlying sandbox session.
-func (r *Session) Session() pkgsandbox.Session {
-	if r == nil {
-		return nil
-	}
-	return r.session
-}
-
-// Policy returns the session's effective policy.
-func (r *Session) Policy() pkgsandbox.Policy {
-	if r == nil {
-		return pkgsandbox.Policy{}
-	}
-	return r.policy
-}
-
-// Alive reports whether the session is healthy.
-func (r *Session) Alive() bool {
-	if r == nil {
-		return false
-	}
-	if r.session == nil {
-		return r.alwaysAlive
-	}
-	return r.session.Alive()
-}
-
-// Done returns a channel that closes when the session terminates.
-func (r *Session) Done() <-chan struct{} {
-	if r == nil || r.session == nil {
-		ch := make(chan struct{})
-		close(ch)
-		return ch
-	}
-	return r.session.Done()
-}
-
-// Sync copies changed files from the session overlay back to the source
+// SyncSession copies changed files from the session overlay back to the source
 // workspace without closing the session. No-op for sessions that don't
 // support mid-session sync.
-func (r *Session) Sync() error {
-	if r == nil || r.session == nil {
+func SyncSession(session pkgsandbox.Session) error {
+	if session == nil {
 		return nil
 	}
 	type syncer interface{ Sync() error }
-	if s, ok := r.session.(syncer); ok {
+	if s, ok := session.(syncer); ok {
 		return s.Sync()
 	}
 	return nil
 }
 
-// Close shuts down the session.
-func (r *Session) Close() error {
-	if r == nil || r.session == nil {
-		return nil
-	}
-	return r.session.Close()
-}
-
-// NewSession wraps a pkg/sandbox.Session for use by the parent agent package.
-func NewSession(session pkgsandbox.Session) *Session {
-	return &Session{session: session}
-}
-
-// sessionFactory creates a Session from configuration.
-type sessionFactory func(context.Context, Config) (*Session, error)
+// sessionFactory creates a session from configuration.
+type sessionFactory func(context.Context, Config) (pkgsandbox.Session, error)
 
 // registry manages session factories by name.
 var sessionRegistry = map[string]sessionFactory{
@@ -119,7 +42,7 @@ var sessionRegistry = map[string]sessionFactory{
 	config.SandboxBackendNone:   createHostSession,
 }
 
-func createDockerSession(ctx context.Context, cfg Config) (*Session, error) {
+func createDockerSession(ctx context.Context, cfg Config) (pkgsandbox.Session, error) {
 	ctx, span := sandboxTracer.Start(ctx, "sandbox.create_session",
 		trace.WithAttributes(
 			attribute.String("stella.sandbox.backend", config.SandboxBackendDocker),
@@ -176,15 +99,12 @@ func createDockerSession(ctx context.Context, cfg Config) (*Session, error) {
 		return nil, err
 	}
 
-	return &Session{
-		session: session,
-		policy:  policy,
-	}, nil
+	return session, nil
 }
 
 // createLocalSession creates a local (no container isolation) session.
 // WARNING: commands run directly on the host OS with no container isolation.
-func createLocalSession(ctx context.Context, cfg Config) (*Session, error) {
+func createLocalSession(ctx context.Context, cfg Config) (pkgsandbox.Session, error) {
 	paths, policy, err := buildBasePolicy(ctx, cfg)
 	if err != nil {
 		return nil, err
@@ -204,13 +124,10 @@ func createLocalSession(ctx context.Context, cfg Config) (*Session, error) {
 		return nil, fmt.Errorf("create local session: %w", err)
 	}
 
-	return &Session{
-		session: session,
-		policy:  session.Policy(),
-	}, nil
+	return session, nil
 }
 
-func createHostSession(ctx context.Context, cfg Config) (*Session, error) {
+func createHostSession(ctx context.Context, cfg Config) (pkgsandbox.Session, error) {
 	paths, policy, err := buildBasePolicy(ctx, cfg)
 	if err != nil {
 		return nil, err
@@ -228,10 +145,7 @@ func createHostSession(ctx context.Context, cfg Config) (*Session, error) {
 		return nil, fmt.Errorf("create host session: %w", err)
 	}
 
-	return &Session{
-		session: session,
-		policy:  session.Policy(),
-	}, nil
+	return session, nil
 }
 
 // ResolveDockerConfig builds the docker plugin Config used by the runner,
@@ -305,10 +219,10 @@ func buildBasePolicy(ctx context.Context, cfg Config) (Paths, pkgsandbox.Policy,
 	return paths, policy, nil
 }
 
-// ResolveSession creates a Session from configuration.
+// ResolveSession creates a sandbox session from configuration.
 // The active backend is determined by SandboxBackendFn (global Plugins page
 // selection), defaulting to local when no backend is explicitly enabled.
-func ResolveSession(ctx context.Context, cfg Config) (*Session, error) {
+func ResolveSession(ctx context.Context, cfg Config) (pkgsandbox.Session, error) {
 	name := config.SandboxBackendLocal
 	if cfg.SandboxBackendFn != nil {
 		if override := cfg.SandboxBackendFn(ctx); override != "" {

--- a/pkg/sandbox/hostenv.go
+++ b/pkg/sandbox/hostenv.go
@@ -1,4 +1,4 @@
-package hostenv
+package sandbox
 
 import (
 	"os"
@@ -7,18 +7,18 @@ import (
 	"strings"
 )
 
-// BuildPath returns a sanitized PATH suitable for host-execution sandbox
+// HostEnvBuildPath returns a sanitized PATH suitable for host-execution sandbox
 // backends (local, none). It prepends the stella bin directory and filters
 // host PATH entries to a safe allowlist on Linux.
-func BuildPath(stellaHome string) string {
+func HostEnvBuildPath(stellaHome string) string {
 	stellaBin := filepath.Join(stellaHome, "bin")
 	if runtime.GOOS != "linux" {
-		return prependPathEntry(stellaBin, os.Getenv("PATH"))
+		return hostEnvPrependPath(stellaBin, os.Getenv("PATH"))
 	}
 
 	entries := []string{stellaBin}
 	for entry := range strings.SplitSeq(os.Getenv("PATH"), string(os.PathListSeparator)) {
-		if pathAllowed(entry, stellaBin) {
+		if hostEnvPathAllowed(entry, stellaBin) {
 			entries = append(entries, entry)
 		}
 	}
@@ -31,22 +31,22 @@ func BuildPath(stellaHome string) string {
 		"/sbin",
 		"/bin",
 	)
-	return strings.Join(dedupeEntries(entries), string(os.PathListSeparator))
+	return strings.Join(hostEnvDedupeEntries(entries), string(os.PathListSeparator))
 }
 
-// BuildHome returns the HOME value for host-execution sandbox backends.
+// HostEnvBuildHome returns the HOME value for host-execution sandbox backends.
 // On Linux (with bwrap), HOME is remapped to /workspace; elsewhere it
 // mirrors the working directory.
-func BuildHome(workDir string) string {
+func HostEnvBuildHome(workDir string) string {
 	if runtime.GOOS == "linux" {
 		return "/workspace"
 	}
 	return workDir
 }
 
-// CopyHostEnv copies a fixed allowlist of host environment variables into env.
+// HostEnvCopy copies a fixed allowlist of host environment variables into env.
 // Only locale, terminal, and proxy variables are included.
-func CopyHostEnv(env map[string]string) {
+func HostEnvCopy(env map[string]string) {
 	for _, key := range []string{
 		"TERM", "COLORTERM", "LANG", "LC_ALL", "LC_CTYPE", "TZ",
 		"HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY",
@@ -58,13 +58,12 @@ func CopyHostEnv(env map[string]string) {
 	}
 }
 
-// PathAllowed reports whether a PATH entry is in the safe allowlist.
-// Exported for testing.
-func PathAllowed(entry, stellaBin string) bool {
-	return pathAllowed(entry, stellaBin)
+// HostEnvPathAllowed reports whether a PATH entry is in the safe allowlist.
+func HostEnvPathAllowed(entry, stellaBin string) bool {
+	return hostEnvPathAllowed(entry, stellaBin)
 }
 
-func pathAllowed(entry, stellaBin string) bool {
+func hostEnvPathAllowed(entry, stellaBin string) bool {
 	if entry == "" {
 		return false
 	}
@@ -79,7 +78,7 @@ func pathAllowed(entry, stellaBin string) bool {
 	return false
 }
 
-func prependPathEntry(entry, existing string) string {
+func hostEnvPrependPath(entry, existing string) string {
 	if entry == "" {
 		return existing
 	}
@@ -89,7 +88,7 @@ func prependPathEntry(entry, existing string) string {
 	return entry + string(os.PathListSeparator) + existing
 }
 
-func dedupeEntries(entries []string) []string {
+func hostEnvDedupeEntries(entries []string) []string {
 	seen := make(map[string]struct{}, len(entries))
 	out := make([]string, 0, len(entries))
 	for _, entry := range entries {

--- a/pkg/sandbox/hostenv/hostenv.go
+++ b/pkg/sandbox/hostenv/hostenv.go
@@ -1,0 +1,106 @@
+package hostenv
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// BuildPath returns a sanitized PATH suitable for host-execution sandbox
+// backends (local, none). It prepends the stella bin directory and filters
+// host PATH entries to a safe allowlist on Linux.
+func BuildPath(stellaHome string) string {
+	stellaBin := filepath.Join(stellaHome, "bin")
+	if runtime.GOOS != "linux" {
+		return prependPathEntry(stellaBin, os.Getenv("PATH"))
+	}
+
+	entries := []string{stellaBin}
+	for entry := range strings.SplitSeq(os.Getenv("PATH"), string(os.PathListSeparator)) {
+		if pathAllowed(entry, stellaBin) {
+			entries = append(entries, entry)
+		}
+	}
+	entries = append(entries,
+		"/run/current-system/sw/bin",
+		"/usr/local/sbin",
+		"/usr/local/bin",
+		"/usr/sbin",
+		"/usr/bin",
+		"/sbin",
+		"/bin",
+	)
+	return strings.Join(dedupeEntries(entries), string(os.PathListSeparator))
+}
+
+// BuildHome returns the HOME value for host-execution sandbox backends.
+// On Linux (with bwrap), HOME is remapped to /workspace; elsewhere it
+// mirrors the working directory.
+func BuildHome(workDir string) string {
+	if runtime.GOOS == "linux" {
+		return "/workspace"
+	}
+	return workDir
+}
+
+// CopyHostEnv copies a fixed allowlist of host environment variables into env.
+// Only locale, terminal, and proxy variables are included.
+func CopyHostEnv(env map[string]string) {
+	for _, key := range []string{
+		"TERM", "COLORTERM", "LANG", "LC_ALL", "LC_CTYPE", "TZ",
+		"HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY",
+		"http_proxy", "https_proxy", "all_proxy", "no_proxy",
+	} {
+		if value := os.Getenv(key); value != "" {
+			env[key] = value
+		}
+	}
+}
+
+// PathAllowed reports whether a PATH entry is in the safe allowlist.
+// Exported for testing.
+func PathAllowed(entry, stellaBin string) bool {
+	return pathAllowed(entry, stellaBin)
+}
+
+func pathAllowed(entry, stellaBin string) bool {
+	if entry == "" {
+		return false
+	}
+	if stellaBin != "" && entry == stellaBin {
+		return true
+	}
+	for _, root := range []string{"/usr", "/bin", "/sbin", "/nix", "/run/current-system/sw"} {
+		if entry == root || strings.HasPrefix(entry, root+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+func prependPathEntry(entry, existing string) string {
+	if entry == "" {
+		return existing
+	}
+	if existing == "" {
+		return entry
+	}
+	return entry + string(os.PathListSeparator) + existing
+}
+
+func dedupeEntries(entries []string) []string {
+	seen := make(map[string]struct{}, len(entries))
+	out := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry == "" {
+			continue
+		}
+		if _, ok := seen[entry]; ok {
+			continue
+		}
+		seen[entry] = struct{}{}
+		out = append(out, entry)
+	}
+	return out
+}

--- a/plugins/sandbox/docker/config.go
+++ b/plugins/sandbox/docker/config.go
@@ -2,24 +2,20 @@ package docker
 
 import "strings"
 
-// Config configures the docker sandbox factory. All fields are populated by
-// the runner glue layer — there are no user-facing knobs. The image is
-// version-locked to the stella binary (via internal/config.SandboxDockerImage)
-// and the path-prefix fields are auto-derived from STELLA_HOME_HOST when stella
-// runs inside a container (see internal/agent/sandbox_dood.go).
+// Config configures the docker sandbox factory.
 type Config struct {
 	// Image is the container image to use. Required.
 	Image string
 
 	// StellaHome is the host-view stella home directory. Used for orphan
-	// cleanup scoping and preflight checks. When running under DooD, this
-	// is the in-container path (TranslateToDaemonPath converts it).
+	// cleanup scoping, preflight checks, DooD path translation, and
+	// resolving user tool binaries from the plugins manifest.
 	StellaHome string
 
 	// ContainerPathPrefix / HostPathPrefix enable path alignment when stella
 	// runs inside a container and talks to the daemon on the host (DooD).
-	// Both fields are filled by applyDooDDefaults in the runner; callers
-	// outside that path should leave them empty.
+	// Normally auto-derived from STELLA_HOME_HOST by NewFactory; only set
+	// explicitly in tests or when overriding the default detection.
 	ContainerPathPrefix string
 	HostPathPrefix      string
 
@@ -27,6 +23,7 @@ type Config struct {
 	// baked into the versioned sandbox image. They are installed in a Linux
 	// helper container and exposed to sessions through a Docker-managed tool
 	// cache, never through host $STELLA_HOME/bin.
+	// Normally auto-resolved by NewFactory from $STELLA_HOME/plugins.yaml.
 	UserToolBinaries []ToolBinary
 }
 

--- a/plugins/sandbox/docker/config.go
+++ b/plugins/sandbox/docker/config.go
@@ -11,6 +11,11 @@ type Config struct {
 	// Image is the container image to use. Required.
 	Image string
 
+	// StellaHome is the host-view stella home directory. Used for orphan
+	// cleanup scoping and preflight checks. When running under DooD, this
+	// is the in-container path (TranslateToDaemonPath converts it).
+	StellaHome string
+
 	// ContainerPathPrefix / HostPathPrefix enable path alignment when stella
 	// runs inside a container and talks to the daemon on the host (DooD).
 	// Both fields are filled by applyDooDDefaults in the runner; callers

--- a/plugins/sandbox/docker/contract_test.go
+++ b/plugins/sandbox/docker/contract_test.go
@@ -43,7 +43,11 @@ func TestSessionContract(t *testing.T) {
 			t.Skip("docker daemon not reachable; skipping DockerFactory contract test")
 		}
 		dockerPreflightForTest(t, ctx)
-		testSessionContract(t, dockerplugin.NewFactory(dockerplugin.Config{Image: dockerContractImage}))
+		factory, err := dockerplugin.NewFactory(dockerplugin.Config{Image: dockerContractImage})
+		if err != nil {
+			t.Fatalf("NewFactory: %v", err)
+		}
+		testSessionContract(t, factory)
 	})
 }
 

--- a/plugins/sandbox/docker/dood.go
+++ b/plugins/sandbox/docker/dood.go
@@ -1,12 +1,10 @@
-package sandbox
+package docker
 
 import (
 	"fmt"
 	"log/slog"
 	"os"
 	"strings"
-
-	dockerplugin "github.com/CherryHQ/stella/plugins/sandbox/docker"
 )
 
 // containerFilesystemMarkers are the well-known files created by container
@@ -43,7 +41,7 @@ var lookupStellaHomeHost = func() string {
 //     the host.
 //   - Not in a container + STELLA_HOME_HOST set → warn and ignore; "host path"
 //     is meaningless when stella already runs on the host.
-func applyDooDDefaults(cfg dockerplugin.Config, stellaHome string) (dockerplugin.Config, error) {
+func applyDooDDefaults(cfg Config, stellaHome string) (Config, error) {
 	if cfg.ContainerPathPrefix != "" || cfg.HostPathPrefix != "" {
 		return cfg, nil
 	}

--- a/plugins/sandbox/docker/dood_test.go
+++ b/plugins/sandbox/docker/dood_test.go
@@ -1,10 +1,8 @@
-package sandbox
+package docker
 
 import (
 	"strings"
 	"testing"
-
-	dockerplugin "github.com/CherryHQ/stella/plugins/sandbox/docker"
 )
 
 func withDooDEnv(t *testing.T, inContainer bool, stellaHomeHost string) {
@@ -21,7 +19,7 @@ func withDooDEnv(t *testing.T, inContainer bool, stellaHomeHost string) {
 
 func TestApplyDooDDefaults_ExplicitPrefixWins(t *testing.T) {
 	withDooDEnv(t, true, "/host/stella")
-	in := dockerplugin.Config{
+	in := Config{
 		ContainerPathPrefix: "/explicit/container",
 		HostPathPrefix:      "/explicit/host",
 	}
@@ -36,7 +34,7 @@ func TestApplyDooDDefaults_ExplicitPrefixWins(t *testing.T) {
 
 func TestApplyDooDDefaults_InContainerWithEnv(t *testing.T) {
 	withDooDEnv(t, true, "/Users/v/.stella-dev")
-	out, err := applyDooDDefaults(dockerplugin.Config{}, "/workspace")
+	out, err := applyDooDDefaults(Config{}, "/workspace")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -50,7 +48,7 @@ func TestApplyDooDDefaults_InContainerWithEnv(t *testing.T) {
 
 func TestApplyDooDDefaults_InContainerWithoutEnvErrors(t *testing.T) {
 	withDooDEnv(t, true, "")
-	_, err := applyDooDDefaults(dockerplugin.Config{}, "/workspace")
+	_, err := applyDooDDefaults(Config{}, "/workspace")
 	if err == nil {
 		t.Fatal("expected error when in-container and STELLA_HOME_HOST unset")
 	}
@@ -64,7 +62,7 @@ func TestApplyDooDDefaults_InContainerWithoutEnvErrors(t *testing.T) {
 
 func TestApplyDooDDefaults_NotInContainerEnvSetIgnored(t *testing.T) {
 	withDooDEnv(t, false, "/some/host/path")
-	out, err := applyDooDDefaults(dockerplugin.Config{}, "/workspace")
+	out, err := applyDooDDefaults(Config{}, "/workspace")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -75,7 +73,7 @@ func TestApplyDooDDefaults_NotInContainerEnvSetIgnored(t *testing.T) {
 
 func TestApplyDooDDefaults_NotInContainerNoEnv(t *testing.T) {
 	withDooDEnv(t, false, "")
-	out, err := applyDooDDefaults(dockerplugin.Config{}, "/workspace")
+	out, err := applyDooDDefaults(Config{}, "/workspace")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/plugins/sandbox/docker/session.go
+++ b/plugins/sandbox/docker/session.go
@@ -45,10 +45,16 @@ type dockerFactory struct {
 }
 
 // NewFactory returns a Factory backed by a Docker container-per-session strategy.
-// If StellaHome is set, DooD path-translation prefixes are auto-derived from
-// STELLA_HOME_HOST and user tool binaries are resolved from the plugins manifest.
-// Returns an error if DooD detection fails (e.g. running in a container without
-// STELLA_HOME_HOST).
+//
+// When cfg.StellaHome is non-empty, construction performs I/O:
+//   - DooD detection: reads /.dockerenv, /run/.containerenv, and $STELLA_HOME_HOST
+//     to auto-derive path-translation prefixes. Fails if stella is inside a
+//     container but STELLA_HOME_HOST is not set.
+//   - User tool resolution: loads the builtin and user plugin manifests
+//     ($STELLA_HOME/plugins.yaml) to populate UserToolBinaries.
+//
+// Both steps are skipped when StellaHome is empty (e.g. unit tests), making
+// construction cheap and infallible in that case.
 func NewFactory(cfg Config) (sandboxpkg.Factory, error) {
 	if cfg.StellaHome != "" {
 		var err error

--- a/plugins/sandbox/docker/session.go
+++ b/plugins/sandbox/docker/session.go
@@ -40,7 +40,8 @@ func logSessionClosed(sessionID, backend, reason string) {
 
 // dockerFactory creates docker-backed sandbox sessions.
 type dockerFactory struct {
-	cfg Config
+	cfg                Config
+	cleanupOrphansOnce sync.Once
 }
 
 // NewFactory returns a Factory backed by a Docker container-per-session strategy.
@@ -76,6 +77,26 @@ func (f *dockerFactory) Supported(policy sandboxpkg.Policy) error {
 	return nil
 }
 
+// EnsureReady performs preflight checks (daemon reachability, image availability)
+// and orphan cleanup. Safe to call multiple times; orphan cleanup runs at most once.
+func (f *dockerFactory) EnsureReady(ctx context.Context) error {
+	if err := Preflight(ctx, PreflightConfig{StellaHome: f.cfg.StellaHome, Docker: f.cfg}); err != nil {
+		return err
+	}
+	f.cleanupOrphansOnce.Do(func() {
+		daemonHome := f.cfg.TranslateToDaemonPath(f.cfg.StellaHome)
+		if daemonHome == "" {
+			return
+		}
+		client, err := getSharedClient()
+		if err != nil {
+			return
+		}
+		dockerclient.CleanupOrphanedContainers(ctx, client, daemonHome)
+	})
+	return nil
+}
+
 // CreateSession starts a new container and returns a dockerSession.
 func (f *dockerFactory) CreateSession(ctx context.Context, policy sandboxpkg.Policy) (sandboxpkg.Session, error) {
 	if err := f.Supported(policy); err != nil {
@@ -84,6 +105,12 @@ func (f *dockerFactory) CreateSession(ctx context.Context, policy sandboxpkg.Pol
 
 	if f.cfg.Image == "" {
 		return nil, fmt.Errorf("docker session: Image is required")
+	}
+
+	if f.cfg.StellaHome != "" {
+		if err := f.EnsureReady(ctx); err != nil {
+			return nil, err
+		}
 	}
 
 	sessionID := nextSessionID()

--- a/plugins/sandbox/docker/session.go
+++ b/plugins/sandbox/docker/session.go
@@ -45,7 +45,27 @@ type dockerFactory struct {
 }
 
 // NewFactory returns a Factory backed by a Docker container-per-session strategy.
-func NewFactory(cfg Config) sandboxpkg.Factory { return &dockerFactory{cfg: cfg} }
+// If StellaHome is set, DooD path-translation prefixes are auto-derived from
+// STELLA_HOME_HOST and user tool binaries are resolved from the plugins manifest.
+// Returns an error if DooD detection fails (e.g. running in a container without
+// STELLA_HOME_HOST).
+func NewFactory(cfg Config) (sandboxpkg.Factory, error) {
+	if cfg.StellaHome != "" {
+		var err error
+		cfg, err = applyDooDDefaults(cfg, cfg.StellaHome)
+		if err != nil {
+			return nil, err
+		}
+		if len(cfg.UserToolBinaries) == 0 {
+			tools, err := resolveUserToolBinaries(cfg.StellaHome)
+			if err != nil {
+				return nil, fmt.Errorf("resolve docker user tools: %w", err)
+			}
+			cfg.UserToolBinaries = tools
+		}
+	}
+	return &dockerFactory{cfg: cfg}, nil
+}
 
 func (f *dockerFactory) Name() string { return "docker" }
 

--- a/plugins/sandbox/docker/session_test.go
+++ b/plugins/sandbox/docker/session_test.go
@@ -18,7 +18,7 @@ func pointToUnreachableDaemon(t *testing.T) {
 }
 
 func TestFactoryName(t *testing.T) {
-	f := NewFactory(Config{})
+	f, _ := NewFactory(Config{})
 	if f.Name() != "docker" {
 		t.Fatalf("expected %q, got %q", "docker", f.Name())
 	}
@@ -26,7 +26,7 @@ func TestFactoryName(t *testing.T) {
 
 func TestFactoryAvailable_DaemonUnreachable(t *testing.T) {
 	pointToUnreachableDaemon(t)
-	f := NewFactory(Config{})
+	f, _ := NewFactory(Config{})
 	if f.Available() {
 		t.Fatal("expected Available() == false when daemon is unreachable")
 	}
@@ -34,7 +34,7 @@ func TestFactoryAvailable_DaemonUnreachable(t *testing.T) {
 
 func TestFactorySupported_DaemonUnreachable(t *testing.T) {
 	pointToUnreachableDaemon(t)
-	f := NewFactory(Config{})
+	f, _ := NewFactory(Config{})
 	policy := sandboxpkg.Policy{
 		Filesystem: sandboxpkg.FilesystemPolicy{WorkingDir: t.TempDir()},
 	}

--- a/plugins/sandbox/docker/session_test.go
+++ b/plugins/sandbox/docker/session_test.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	sandboxpkg "github.com/CherryHQ/stella/pkg/sandbox"
@@ -17,10 +18,24 @@ func pointToUnreachableDaemon(t *testing.T) {
 	t.Setenv("DOCKER_CERT_PATH", "")
 }
 
-func TestFactoryName(t *testing.T) {
-	f, _ := NewFactory(Config{})
+func TestNewFactory_NoStellaHome_Infallible(t *testing.T) {
+	f, err := NewFactory(Config{})
+	if err != nil {
+		t.Fatalf("NewFactory(Config{}) should not fail: %v", err)
+	}
 	if f.Name() != "docker" {
 		t.Fatalf("expected %q, got %q", "docker", f.Name())
+	}
+}
+
+func TestNewFactory_DooDError_Propagated(t *testing.T) {
+	withDooDEnv(t, true, "")
+	_, err := NewFactory(Config{StellaHome: "/fake/stella"})
+	if err == nil {
+		t.Fatal("expected error when in-container and STELLA_HOME_HOST unset")
+	}
+	if !strings.Contains(err.Error(), "STELLA_HOME_HOST") {
+		t.Fatalf("error should mention STELLA_HOME_HOST, got: %v", err)
 	}
 }
 

--- a/plugins/sandbox/docker/toolcache.go
+++ b/plugins/sandbox/docker/toolcache.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"path/filepath"
+	"reflect"
 	"strings"
 	"time"
 
@@ -15,6 +17,7 @@ import (
 	mobyclient "github.com/moby/moby/client"
 	"github.com/pelletier/go-toml/v2"
 
+	"github.com/CherryHQ/stella/internal/manifestplugins"
 	"github.com/CherryHQ/stella/plugins/sandbox/docker/dockerclient"
 )
 
@@ -265,4 +268,43 @@ func shellQuoteForDoubleQuotedPath(s string) string {
 	s = strings.ReplaceAll(s, "$", "\\$")
 	s = strings.ReplaceAll(s, "`", "\\`")
 	return s
+}
+
+// resolveUserToolBinaries loads manifest plugins and returns user-configured
+// tool binaries that differ from builtins. Called by NewFactory when
+// StellaHome is set.
+func resolveUserToolBinaries(stellaHome string) ([]ToolBinary, error) {
+	builtin, err := manifestplugins.LoadBuiltin()
+	if err != nil {
+		return nil, err
+	}
+	user, err := manifestplugins.LoadUser(filepath.Join(stellaHome, "plugins.yaml"))
+	if err != nil {
+		return nil, err
+	}
+	merged := manifestplugins.Merge(builtin, user)
+
+	builtinByID := make(map[string]manifestplugins.ManifestPlugin, len(builtin.Plugins))
+	for _, plugin := range builtin.Plugins {
+		builtinByID[plugin.ID] = plugin
+	}
+
+	var out []ToolBinary
+	for _, plugin := range merged.Plugins {
+		if !plugin.Enabled || len(plugin.Binaries) == 0 {
+			continue
+		}
+		if builtinPlugin, ok := builtinByID[plugin.ID]; ok && reflect.DeepEqual(plugin.Binaries, builtinPlugin.Binaries) {
+			continue
+		}
+		for _, binary := range plugin.Binaries {
+			out = append(out, ToolBinary{
+				Name:    binary.Name,
+				Tool:    binary.Tool,
+				Version: binary.Version,
+				Options: binary.Options,
+			})
+		}
+	}
+	return out, nil
 }

--- a/plugins/sandbox/local/session.go
+++ b/plugins/sandbox/local/session.go
@@ -19,7 +19,6 @@ import (
 	"sync"
 
 	sandboxpkg "github.com/CherryHQ/stella/pkg/sandbox"
-	"github.com/CherryHQ/stella/pkg/sandbox/hostenv"
 )
 
 // sandboxEnvDenyList is the set of host environment variable names that must
@@ -103,11 +102,11 @@ func (f *Factory) adjustPolicy(policy sandboxpkg.Policy) sandboxpkg.Policy {
 	if env == nil {
 		env = make(map[string]string)
 	}
-	env["PATH"] = hostenv.BuildPath(f.cfg.StellaHome)
+	env["PATH"] = sandboxpkg.HostEnvBuildPath(f.cfg.StellaHome)
 	if policy.Filesystem.WorkingDir != "" {
-		env["HOME"] = hostenv.BuildHome(policy.Filesystem.WorkingDir)
+		env["HOME"] = sandboxpkg.HostEnvBuildHome(policy.Filesystem.WorkingDir)
 	}
-	hostenv.CopyHostEnv(env)
+	sandboxpkg.HostEnvCopy(env)
 	policy.Env = env
 	policy.InheritEnv = false
 	return policy

--- a/plugins/sandbox/local/session.go
+++ b/plugins/sandbox/local/session.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 
 	sandboxpkg "github.com/CherryHQ/stella/pkg/sandbox"
+	"github.com/CherryHQ/stella/pkg/sandbox/hostenv"
 )
 
 // sandboxEnvDenyList is the set of host environment variable names that must
@@ -27,11 +28,26 @@ import (
 // access.
 var sandboxEnvDenyList = []string{"STELLA_VAULT_KEY"}
 
+// Config configures the local sandbox factory.
+type Config struct {
+	// StellaHome is the host path to the stella home directory, used for
+	// building a sandboxed PATH that includes $STELLA_HOME/bin.
+	StellaHome string
+}
+
 // Factory creates local sandbox sessions that run directly on the host OS.
-type Factory struct{}
+type Factory struct {
+	cfg Config
+}
 
 // NewFactory returns a Factory for the local backend.
-func NewFactory() sandboxpkg.Factory { return &Factory{} }
+func NewFactory(cfg ...Config) sandboxpkg.Factory {
+	var c Config
+	if len(cfg) > 0 {
+		c = cfg[0]
+	}
+	return &Factory{cfg: c}
+}
 
 // Name returns the backend name.
 func (f *Factory) Name() string { return "local" }
@@ -49,11 +65,17 @@ type tmpMount struct {
 }
 
 // CreateSession creates a new localSession.
+// If a StellaHome was provided via Config, the factory adjusts the policy env
+// with a sandboxed PATH, HOME, and an allowlist of host variables so callers
+// don't need to know about host-execution specifics.
 func (f *Factory) CreateSession(_ context.Context, policy sandboxpkg.Policy) (sandboxpkg.Session, error) {
 	sessionID := sandboxpkg.NewSessionID()
 	if err := checkSandboxRequirements(); err != nil {
 		return nil, err
 	}
+
+	policy = f.adjustPolicy(policy)
+
 	sandboxRoot, realRoot := resolveSandboxRoot(policy)
 	tmpMounts, ownsTmp, err := createSessionTmpMounts()
 	if err != nil {
@@ -70,6 +92,25 @@ func (f *Factory) CreateSession(_ context.Context, policy sandboxpkg.Policy) (sa
 	}
 	sandboxpkg.LogSessionCreated(sessionID, "local", policy)
 	return s, nil
+}
+
+// adjustPolicy applies local-backend-specific environment adjustments.
+func (f *Factory) adjustPolicy(policy sandboxpkg.Policy) sandboxpkg.Policy {
+	if f.cfg.StellaHome == "" {
+		return policy
+	}
+	env := maps.Clone(policy.Env)
+	if env == nil {
+		env = make(map[string]string)
+	}
+	env["PATH"] = hostenv.BuildPath(f.cfg.StellaHome)
+	if policy.Filesystem.WorkingDir != "" {
+		env["HOME"] = hostenv.BuildHome(policy.Filesystem.WorkingDir)
+	}
+	hostenv.CopyHostEnv(env)
+	policy.Env = env
+	policy.InheritEnv = false
+	return policy
 }
 
 // ─────────────────────────── localSession ─────────────────────────────

--- a/plugins/sandbox/none/session.go
+++ b/plugins/sandbox/none/session.go
@@ -15,7 +15,6 @@ import (
 	"sync"
 
 	sandboxpkg "github.com/CherryHQ/stella/pkg/sandbox"
-	"github.com/CherryHQ/stella/pkg/sandbox/hostenv"
 )
 
 // Config configures the none factory.
@@ -74,7 +73,7 @@ func (f *Factory) adjustPolicy(policy sandboxpkg.Policy) sandboxpkg.Policy {
 	if env == nil {
 		env = make(map[string]string)
 	}
-	env["PATH"] = hostenv.BuildPath(f.cfg.StellaHome)
+	env["PATH"] = sandboxpkg.HostEnvBuildPath(f.cfg.StellaHome)
 	policy.Env = env
 	return policy
 }

--- a/plugins/sandbox/none/session.go
+++ b/plugins/sandbox/none/session.go
@@ -15,13 +15,29 @@ import (
 	"sync"
 
 	sandboxpkg "github.com/CherryHQ/stella/pkg/sandbox"
+	"github.com/CherryHQ/stella/pkg/sandbox/hostenv"
 )
 
+// Config configures the none factory.
+type Config struct {
+	// StellaHome is the host path to the stella home directory, used for
+	// building a PATH that includes $STELLA_HOME/bin.
+	StellaHome string
+}
+
 // Factory creates sessions that execute directly on the host with no sandboxing.
-type Factory struct{}
+type Factory struct {
+	cfg Config
+}
 
 // NewFactory returns a Factory for the none backend.
-func NewFactory() sandboxpkg.Factory { return &Factory{} }
+func NewFactory(cfg ...Config) sandboxpkg.Factory {
+	var c Config
+	if len(cfg) > 0 {
+		c = cfg[0]
+	}
+	return &Factory{cfg: c}
+}
 
 // Name returns the backend name.
 func (f *Factory) Name() string { return "none" }
@@ -33,7 +49,11 @@ func (f *Factory) Available() bool { return platformAvailable() }
 func (f *Factory) Supported(_ sandboxpkg.Policy) error { return nil }
 
 // CreateSession creates a new noneSession.
+// If a StellaHome was provided via Config, the factory adjusts the policy env
+// with a sandboxed PATH. Network mode is always overridden to AllowAll since
+// the none backend cannot enforce network restrictions.
 func (f *Factory) CreateSession(_ context.Context, policy sandboxpkg.Policy) (sandboxpkg.Session, error) {
+	policy = f.adjustPolicy(policy)
 	id := sandboxpkg.NewSessionID()
 	s := &noneSession{
 		id:     id,
@@ -42,6 +62,21 @@ func (f *Factory) CreateSession(_ context.Context, policy sandboxpkg.Policy) (sa
 	}
 	sandboxpkg.LogSessionCreated(id, "none", policy)
 	return s, nil
+}
+
+// adjustPolicy applies none-backend-specific policy adjustments.
+func (f *Factory) adjustPolicy(policy sandboxpkg.Policy) sandboxpkg.Policy {
+	policy.Network.Mode = sandboxpkg.NetworkAllowAll
+	if f.cfg.StellaHome == "" {
+		return policy
+	}
+	env := maps.Clone(policy.Env)
+	if env == nil {
+		env = make(map[string]string)
+	}
+	env["PATH"] = hostenv.BuildPath(f.cfg.StellaHome)
+	policy.Env = env
+	return policy
 }
 
 // noneSession implements sandboxpkg.Session with zero isolation.


### PR DESCRIPTION
## Summary

Deepen the sandbox module hierarchy so each layer earns its keep: factories internalize their own configuration, the glue layer shrinks to Config→Policy translation + backend dispatch, and redundant types/wrappers are eliminated.

### What changed

- **Absorb policy/env into factories** — Backend-specific environment construction (PATH filtering, HOME remapping, host env copying, DooD defaults, Docker preflight) moved from the glue layer into each factory's `CreateSession`. Shared host-execution helpers extracted to `pkg/sandbox/hostenv.go`.
- **Eliminate Session wrapper** — Deleted the ~100-line pass-through `sandbox.Session` struct. Callers now use `pkgsandbox.Session` directly.
- **Replace registry map with direct dispatch** — Replaced `sessionRegistry` map and `sessionFactory` type with a plain `switch` in `ResolveSession`.
- **Inline hostenv package** — Moved `pkg/sandbox/hostenv/` into `pkg/sandbox/hostenv.go`, eliminating a single-purpose sub-package. Functions prefixed with `HostEnv` to stay unambiguous.
- **Move DooD + user-tool resolution into docker plugin** — `dood.go` and `resolveDockerUserToolBinaries` moved from the glue layer into `plugins/sandbox/docker/`. `NewFactory` now handles DooD detection and manifest plugin resolution internally.
- **Unify tracing and merge PathConfig into Paths** — Lifted the tracing span from `createDockerSession` into `ResolveSession` so all backends are traced uniformly. Eliminated `PathConfig` — `Config` now uses `Paths` directly.

### Result

`internal/agent/sandbox/` shrinks from 8 files to 5, no longer imports `manifestplugins`, `reflect`, or `path/filepath`. The three `create*Session` functions follow a uniform pattern: `buildBasePolicy` → `NewFactory(cfg)` → `CreateSession(ctx, policy)`. Net: 502 additions, 544 deletions.

## Test plan

- [x] `mise run format` — passes, 0 lint issues
- [x] `mise run build` — compiles cleanly
- [x] `mise run test` — all tests pass
- [ ] Manual: verify docker backend creates sessions correctly (requires Docker)
- [ ] Manual: verify local backend sandbox env isolation