### PR TITLE
feat: AI SDK data stream protocol for sendSessionMessage

### DIFF
--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -1320,13 +1320,34 @@ components:
       properties:
         agent_id:
           type: string
+    MessagePart:
+      type: object
+      required: [type]
+      properties:
+        type:
+          type: string
+          enum: [text, image, file]
+        text:
+          type: string
+          description: Text content (when type is "text")
+        image:
+          type: string
+          description: Base64-encoded image data (when type is "image")
+        url:
+          type: string
+          description: File URL (when type is "file")
+        mimeType:
+          type: string
+          description: MIME type of the image or file
     SendMessageRequest:
       type: object
-      required: [content]
+      required: [parts]
       properties:
-        content:
-          type: string
-          description: "Message content (required)"
+        parts:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessagePart"
+          description: Message content parts (text, image, file)
     SystemPromptResponse:
       type: object
       required: [system_prompt]

--- a/api/spec/domain/sessions/schemas.yaml
+++ b/api/spec/domain/sessions/schemas.yaml
@@ -40,13 +40,35 @@ components:
       properties:
         agent_id: { type: string }
 
+    MessagePart:
+      type: object
+      required: [type]
+      properties:
+        type:
+          type: string
+          enum: [text, image, file]
+        text:
+          type: string
+          description: Text content (when type is "text")
+        image:
+          type: string
+          description: Base64-encoded image data (when type is "image")
+        url:
+          type: string
+          description: File URL (when type is "file")
+        mimeType:
+          type: string
+          description: MIME type of the image or file
+
     SendMessageRequest:
       type: object
-      required: [content]
+      required: [parts]
       properties:
-        content:
-          type: string
-          description: "Message content (required)"
+        parts:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessagePart"
+          description: Message content parts (text, image, file)
 
     SystemPromptResponse:
       type: object

--- a/api/types/gen.go
+++ b/api/types/gen.go
@@ -217,6 +217,27 @@ func (e FeedEntryStatus) Valid() bool {
 	}
 }
 
+// Defines values for MessagePartType.
+const (
+	File  MessagePartType = "file"
+	Image MessagePartType = "image"
+	Text  MessagePartType = "text"
+)
+
+// Valid indicates whether the value is a known member of the MessagePartType enum.
+func (e MessagePartType) Valid() bool {
+	switch e {
+	case File:
+		return true
+	case Image:
+		return true
+	case Text:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for SourceType.
 const (
 	Github  SourceType = "github"
@@ -778,6 +799,25 @@ type MeResponse struct {
 	Username string `json:"username"`
 }
 
+// MessagePart defines model for MessagePart.
+type MessagePart struct {
+	// Image Base64-encoded image data (when type is "image")
+	Image *string `json:"image,omitempty"`
+
+	// MimeType MIME type of the image or file
+	MimeType *string `json:"mimeType,omitempty"`
+
+	// Text Text content (when type is "text")
+	Text *string         `json:"text,omitempty"`
+	Type MessagePartType `json:"type"`
+
+	// Url File URL (when type is "file")
+	Url *string `json:"url,omitempty"`
+}
+
+// MessagePartType defines model for MessagePart.Type.
+type MessagePartType string
+
 // OAuthConnectedResponse defines model for OAuthConnectedResponse.
 type OAuthConnectedResponse struct {
 	Connected bool    `json:"connected"`
@@ -948,8 +988,8 @@ type SaveDigestRequest struct {
 
 // SendMessageRequest defines model for SendMessageRequest.
 type SendMessageRequest struct {
-	// Content Message content (required)
-	Content string `json:"content"`
+	// Parts Message content parts (text, image, file)
+	Parts []MessagePart `json:"parts"`
 }
 
 // Session defines model for Session.

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -12,12 +12,13 @@ import (
 
 // ToolUseEvent describes a tool invocation in progress or completed.
 type ToolUseEvent struct {
-	ID      string // provider-assigned tool call ID
-	Tool    string // tool name, e.g. "bash", "read"
-	Status  string // "running", "done", "error"
-	Input   string // short summary of the tool input
-	Detail  string // error detail or result summary (for "error" status)
-	Content string // full tool result text (for "done"/"error" status)
+	ID        string         // provider-assigned tool call ID
+	Tool      string         // tool name, e.g. "bash", "read"
+	Status    string         // "running", "done", "error"
+	Input     string         // short summary of the tool input
+	Arguments map[string]any // raw tool arguments
+	Detail    string         // error detail or result summary (for "error" status)
+	Content   string         // full tool result text (for "done"/"error" status)
 }
 
 // StepEvent marks the boundary of an agentic step (one LLM call + tool executions).

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -12,11 +12,17 @@ import (
 
 // ToolUseEvent describes a tool invocation in progress or completed.
 type ToolUseEvent struct {
+	ID      string // provider-assigned tool call ID
 	Tool    string // tool name, e.g. "bash", "read"
 	Status  string // "running", "done", "error"
 	Input   string // short summary of the tool input
 	Detail  string // error detail or result summary (for "error" status)
 	Content string // full tool result text (for "done"/"error" status)
+}
+
+// StepEvent marks the boundary of an agentic step (one LLM call + tool executions).
+type StepEvent struct {
+	Kind string // "start" or "finish"
 }
 
 // ImageEvent carries a base64-encoded image to be sent to the channel.
@@ -34,12 +40,14 @@ type FileEvent struct {
 // Event is the consumer-facing stream event. Channels read these from the
 // stream returned by Pool.Chat().
 type Event struct {
-	Text    string
-	Image   *ImageEvent
-	File    *FileEvent
-	ToolUse *ToolUseEvent
-	Store   ai.Message // if non-nil, Pool appends to session history
-	Err     error
+	Text      string
+	Reasoning string
+	Image     *ImageEvent
+	File      *FileEvent
+	ToolUse   *ToolUseEvent
+	Step      *StepEvent
+	Store     ai.Message // if non-nil, Pool appends to session history
+	Err       error
 }
 
 // MessageContent is the type for user messages passed through the runner pipeline.

--- a/internal/agent/runner_impl.go
+++ b/internal/agent/runner_impl.go
@@ -452,18 +452,28 @@ func (r *runner) Close() error {
 // convertLoopEvent bridges agent.LoopEvent to Event(s).
 func convertLoopEvent(e coreagent.LoopEvent) []Event {
 	switch e := e.(type) {
+	case coreagent.TurnStarted:
+		return []Event{{Step: &StepEvent{Kind: "start"}}}
+
+	case coreagent.TurnFinished:
+		return []Event{{Step: &StepEvent{Kind: "finish"}}}
+
 	case coreagent.AssistantDelta:
-		if d, ok := e.Event.(ai.EventTextDelta); ok && d.Text != "" {
-			return []Event{{Text: d.Text}}
+		switch d := e.Event.(type) {
+		case ai.EventTextDelta:
+			if d.Text != "" {
+				return []Event{{Text: d.Text}}
+			}
+		case ai.EventThinkingDelta:
+			if d.Thinking != "" {
+				return []Event{{Reasoning: d.Thinking}}
+			}
 		}
 
 	case coreagent.AssistantFinished:
-		// Emit Store events for tool calls in the final message.
 		var events []Event
 		for _, block := range e.Message.Content {
 			if _, ok := block.(ai.ToolCall); ok {
-				// Store the full assistant message (text + all tool calls) once
-				// when we see the first tool call.
 				msg := ai.AssistantMessage{Content: e.Message.Content}
 				events = append(events, Event{Store: msg})
 				return events
@@ -473,6 +483,7 @@ func convertLoopEvent(e coreagent.LoopEvent) []Event {
 
 	case coreagent.ToolStarted:
 		return []Event{{ToolUse: &ToolUseEvent{
+			ID:     e.ToolCall.ID,
 			Tool:   e.ToolCall.Name,
 			Status: "running",
 			Input:  summarizeToolInput(e.ToolCall.Name, e.ToolCall.Arguments),
@@ -493,6 +504,7 @@ func convertLoopEvent(e coreagent.LoopEvent) []Event {
 		}
 		return []Event{
 			{ToolUse: &ToolUseEvent{
+				ID:      e.Result.ToolCallID,
 				Tool:    e.Result.ToolName,
 				Status:  status,
 				Detail:  detail,

--- a/internal/agent/runner_impl.go
+++ b/internal/agent/runner_impl.go
@@ -483,10 +483,11 @@ func convertLoopEvent(e coreagent.LoopEvent) []Event {
 
 	case coreagent.ToolStarted:
 		return []Event{{ToolUse: &ToolUseEvent{
-			ID:     e.ToolCall.ID,
-			Tool:   e.ToolCall.Name,
-			Status: "running",
-			Input:  summarizeToolInput(e.ToolCall.Name, e.ToolCall.Arguments),
+			ID:        e.ToolCall.ID,
+			Tool:      e.ToolCall.Name,
+			Status:    "running",
+			Input:     summarizeToolInput(e.ToolCall.Name, e.ToolCall.Arguments),
+			Arguments: e.ToolCall.Arguments,
 		}}}
 
 	case coreagent.ToolFinished:

--- a/internal/server/sessions.go
+++ b/internal/server/sessions.go
@@ -248,28 +248,34 @@ func (s *Server) SendSessionMessage(w http.ResponseWriter, r *http.Request, sess
 				tu := evt.ToolUse
 				switch tu.Status {
 				case "running":
-					writeData(map[string]string{
+					writeData(map[string]any{
 						"type":       "tool-input-start",
 						"toolCallId": tu.ID,
 						"toolName":   tu.Tool,
+						"dynamic":    true,
 					})
+					args := tu.Arguments
+					if args == nil {
+						args = map[string]any{"input": tu.Input}
+					}
 					writeData(map[string]any{
 						"type":       "tool-input-available",
 						"toolCallId": tu.ID,
 						"toolName":   tu.Tool,
-						"input":      map[string]string{"input": tu.Input},
+						"dynamic":    true,
+						"input":      args,
 					})
 				case "done":
 					writeData(map[string]any{
 						"type":       "tool-output-available",
 						"toolCallId": tu.ID,
-						"output":     map[string]string{"content": tu.Content},
+						"output":     tu.Content,
 					})
 				case "error":
 					writeData(map[string]any{
-						"type":       "tool-output-available",
+						"type":       "tool-output-error",
 						"toolCallId": tu.ID,
-						"output":     map[string]string{"error": tu.Content},
+						"errorText":  tu.Content,
 					})
 				}
 				continue

--- a/internal/server/sessions.go
+++ b/internal/server/sessions.go
@@ -11,12 +11,16 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
+
 	apiserver "github.com/CherryHQ/stella/api/server"
+	apitypes "github.com/CherryHQ/stella/api/types"
 	"github.com/CherryHQ/stella/internal/agent"
 	"github.com/CherryHQ/stella/internal/agent/prompt"
 	"github.com/CherryHQ/stella/internal/config"
 	"github.com/CherryHQ/stella/internal/memory"
 	mcpplugin "github.com/CherryHQ/stella/internal/tools/mcp"
+	"github.com/CherryHQ/stella/pkg/ai"
 	"github.com/CherryHQ/stella/pkg/db/sqlc"
 	pkgplugins "github.com/CherryHQ/stella/pkg/plugins"
 )
@@ -71,8 +75,8 @@ func (s *Server) SendSessionMessage(w http.ResponseWriter, r *http.Request, sess
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if body.Content == "" {
-		writeError(w, http.StatusBadRequest, "content is required")
+	if len(body.Parts) == 0 {
+		writeError(w, http.StatusBadRequest, "parts is required")
 		return
 	}
 
@@ -111,76 +115,247 @@ func (s *Server) SendSessionMessage(w http.ResponseWriter, r *http.Request, sess
 		return
 	}
 
+	// Convert AI SDK parts to internal MessageContent.
+	msgContent := partsToMessageContent(body.Parts)
+
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("X-Accel-Buffering", "no")
+	w.Header().Set("X-Vercel-AI-UI-Message-Stream", "v1")
 	w.WriteHeader(http.StatusOK)
 	flusher.Flush()
 
-	writeSSEEvent := func(event, data string) {
-		_, _ = fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event, data)
+	writeData := func(v any) {
+		data, _ := json.Marshal(v)
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", data)
+		flusher.Flush()
+	}
+	writeDone := func() {
+		_, _ = fmt.Fprintf(w, "data: [DONE]\n\n")
 		flusher.Flush()
 	}
 
-	// runningToolID maps tool name to the generated ID for the running invocation.
-	runningToolID := make(map[string]string)
+	messageID := uuid.New().String()
+	writeData(map[string]string{"type": "start", "messageId": messageID})
 
-	ch := pool.Chat(r.Context(), sessionID, body.Content)
+	var (
+		inText      bool
+		textID      string
+		inReasoning bool
+		reasoningID string
+		stepOpen    bool
+	)
+
+	closeText := func() {
+		if inText {
+			writeData(map[string]string{"type": "text-end", "id": textID})
+			inText = false
+		}
+	}
+	closeReasoning := func() {
+		if inReasoning {
+			writeData(map[string]string{"type": "reasoning-end", "id": reasoningID})
+			inReasoning = false
+		}
+	}
+
+	ch := pool.Chat(r.Context(), sessionID, msgContent)
 	for {
 		select {
 		case <-r.Context().Done():
+			closeText()
+			closeReasoning()
+			if stepOpen {
+				writeData(map[string]string{"type": "finish-step"})
+			}
+			writeData(map[string]string{"type": "finish"})
+			writeDone()
 			return
 		case evt, open := <-ch:
 			if !open {
+				closeText()
+				closeReasoning()
+				if stepOpen {
+					writeData(map[string]string{"type": "finish-step"})
+				}
+				writeData(map[string]string{"type": "finish"})
+				writeDone()
 				return
 			}
+
 			if evt.Err != nil {
-				data, _ := json.Marshal(map[string]string{"error": evt.Err.Error()})
-				writeSSEEvent("error", string(data))
+				closeText()
+				closeReasoning()
+				writeData(map[string]string{"type": "error", "errorText": evt.Err.Error()})
+				if stepOpen {
+					writeData(map[string]string{"type": "finish-step"})
+				}
+				writeData(map[string]string{"type": "finish"})
+				writeDone()
 				return
 			}
+
 			if evt.Store != nil {
 				continue
 			}
-			if evt.ToolUse != nil {
-				tu := evt.ToolUse
-				switch tu.Status {
-				case "running":
-					id := fmt.Sprintf("%s-%d", tu.Tool, time.Now().UnixNano())
-					runningToolID[tu.Tool] = id
-					payload := map[string]any{
-						"type": "tool_call",
-						"id":   id,
-						"name": tu.Tool,
-						"arguments": map[string]string{
-							"input": tu.Input,
-						},
-						"status": "running",
+
+			if evt.Step != nil {
+				switch evt.Step.Kind {
+				case "start":
+					closeText()
+					closeReasoning()
+					if stepOpen {
+						writeData(map[string]string{"type": "finish-step"})
 					}
-					data, _ := json.Marshal(payload)
-					writeSSEEvent("tool_use", string(data))
-				case "done", "error":
-					id := runningToolID[tu.Tool]
-					if id == "" {
-						id = fmt.Sprintf("%s-%d", tu.Tool, time.Now().UnixNano())
+					writeData(map[string]string{"type": "start-step"})
+					stepOpen = true
+				case "finish":
+					closeText()
+					closeReasoning()
+					if stepOpen {
+						writeData(map[string]string{"type": "finish-step"})
+						stepOpen = false
 					}
-					delete(runningToolID, tu.Tool)
-					payload := map[string]any{
-						"type":         "tool_result",
-						"tool_call_id": id,
-						"content":      tu.Content,
-						"is_error":     tu.Status == "error",
-					}
-					data, _ := json.Marshal(payload)
-					writeSSEEvent("tool_use", string(data))
 				}
 				continue
 			}
+
+			if evt.Reasoning != "" {
+				closeText()
+				if !inReasoning {
+					reasoningID = uuid.New().String()
+					writeData(map[string]string{"type": "reasoning-start", "id": reasoningID})
+					inReasoning = true
+				}
+				writeData(map[string]any{"type": "reasoning-delta", "id": reasoningID, "delta": evt.Reasoning})
+				continue
+			}
+
 			if evt.Text != "" {
-				data, _ := json.Marshal(map[string]string{"text": evt.Text})
-				writeSSEEvent("text", string(data))
+				closeReasoning()
+				if !inText {
+					textID = uuid.New().String()
+					writeData(map[string]string{"type": "text-start", "id": textID})
+					inText = true
+				}
+				writeData(map[string]any{"type": "text-delta", "id": textID, "delta": evt.Text})
+				continue
+			}
+
+			if evt.ToolUse != nil {
+				closeText()
+				closeReasoning()
+				tu := evt.ToolUse
+				switch tu.Status {
+				case "running":
+					writeData(map[string]string{
+						"type":       "tool-input-start",
+						"toolCallId": tu.ID,
+						"toolName":   tu.Tool,
+					})
+					writeData(map[string]any{
+						"type":       "tool-input-available",
+						"toolCallId": tu.ID,
+						"toolName":   tu.Tool,
+						"input":      map[string]string{"input": tu.Input},
+					})
+				case "done":
+					writeData(map[string]any{
+						"type":       "tool-output-available",
+						"toolCallId": tu.ID,
+						"output":     map[string]string{"content": tu.Content},
+					})
+				case "error":
+					writeData(map[string]any{
+						"type":       "tool-output-available",
+						"toolCallId": tu.ID,
+						"output":     map[string]string{"error": tu.Content},
+					})
+				}
+				continue
+			}
+
+			if evt.Image != nil {
+				closeText()
+				closeReasoning()
+				dataURI := "data:" + evt.Image.MimeType + ";base64," + evt.Image.Data
+				writeData(map[string]string{
+					"type":      "file",
+					"url":       dataURI,
+					"mediaType": evt.Image.MimeType,
+				})
+				continue
+			}
+
+			if evt.File != nil {
+				closeText()
+				closeReasoning()
+				fileURL := fmt.Sprintf("/api/sessions/%s/workspace/file-content?path=%s&raw=true",
+					sessionID, evt.File.Path)
+				mediaType := detectMIME(evt.File.Name)
+				writeData(map[string]string{
+					"type":      "file",
+					"url":       fileURL,
+					"mediaType": mediaType,
+				})
+				continue
 			}
 		}
+	}
+}
+
+// partsToMessageContent converts API MessageParts to internal MessageContent.
+func partsToMessageContent(parts []apitypes.MessagePart) agent.MessageContent {
+	if len(parts) == 1 && parts[0].Type == apitypes.Text && parts[0].Text != nil {
+		return *parts[0].Text
+	}
+	var blocks []ai.ContentBlock
+	for _, p := range parts {
+		switch p.Type {
+		case apitypes.Text:
+			if p.Text != nil {
+				blocks = append(blocks, ai.TextContent{Text: *p.Text})
+			}
+		case apitypes.Image:
+			if p.Image != nil {
+				mime := "image/png"
+				if p.MimeType != nil {
+					mime = *p.MimeType
+				}
+				blocks = append(blocks, ai.ImageContent{Data: *p.Image, MimeType: mime})
+			}
+		}
+	}
+	if len(blocks) == 0 {
+		return ""
+	}
+	return blocks
+}
+
+// detectMIME returns a MIME type based on file extension.
+func detectMIME(name string) string {
+	ext := strings.ToLower(filepath.Ext(name))
+	switch ext {
+	case ".png":
+		return "image/png"
+	case ".jpg", ".jpeg":
+		return "image/jpeg"
+	case ".gif":
+		return "image/gif"
+	case ".webp":
+		return "image/webp"
+	case ".svg":
+		return "image/svg+xml"
+	case ".pdf":
+		return "application/pdf"
+	case ".txt":
+		return "text/plain"
+	case ".json":
+		return "application/json"
+	case ".csv":
+		return "text/csv"
+	default:
+		return "application/octet-stream"
 	}
 }
 

--- a/web/package.json
+++ b/web/package.json
@@ -8,6 +8,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@ai-sdk/react": "^3.0.186",
     "@base-ui/react": "^1.4.1",
     "@fontsource-variable/inter": "^5.2.8",
     "@mdx-js/react": "^3.1.1",
@@ -17,6 +18,7 @@
     "@tanstack/react-query": "latest",
     "@tanstack/react-router": "latest",
     "@types/qrcode": "^1.5.6",
+    "ai": "^6.0.184",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "geist": "^1.7.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
 
   .:
     dependencies:
+      '@ai-sdk/react':
+        specifier: ^3.0.186
+        version: 3.0.186(react@19.2.5)(zod@3.25.76)
       '@base-ui/react':
         specifier: ^1.4.1
         version: 1.4.1(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -45,6 +48,9 @@ importers:
       '@types/qrcode':
         specifier: ^1.5.6
         version: 1.5.6
+      ai:
+        specifier: ^6.0.184
+        version: 6.0.184(zod@3.25.76)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -53,7 +59,7 @@ importers:
         version: 2.1.1
       geist:
         specifier: ^1.7.0
-        version: 1.7.0(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
+        version: 1.7.0(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       i18next:
         specifier: ^26.0.10
         version: 26.0.10(typescript@6.0.3)
@@ -129,9 +135,31 @@ importers:
         version: '@voidzero-dev/vite-plus-core@0.1.20(@types/node@25.6.0)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.8.4)'
       vite-plus:
         specifier: 'catalog:'
-        version: 0.1.20(@types/node@25.6.0)(@voidzero-dev/vite-plus-core@0.1.20(@types/node@25.6.0)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.8.4))(jiti@2.7.0)(typescript@6.0.3)(yaml@2.8.4)
+        version: 0.1.20(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@voidzero-dev/vite-plus-core@0.1.20(@types/node@25.6.0)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.8.4))(jiti@2.7.0)(typescript@6.0.3)(yaml@2.8.4)
 
 packages:
+
+  '@ai-sdk/gateway@3.0.115':
+    resolution: {integrity: sha512-xonmGfN9pt54WdKqMzWe68BRYS3rsYvraBzioyA0gfNcecHs8Ir5qk/X8grJSyZ95hghjWiOphrK6bAc11E6SA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.27':
+    resolution: {integrity: sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@3.0.10':
+    resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/react@3.0.186':
+    resolution: {integrity: sha512-fy8wuy8pBghYD1ECw/M5vAsGsZp2D3y/oSTp1iOlAnJqRXzvz4rWLBz1n+rjL+aHZNgJK3kR3NHlnifoKYERfA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
@@ -570,6 +598,10 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
 
   '@oxc-project/runtime@0.127.0':
     resolution: {integrity: sha512-UQYLxAhDDPHm++szfa4z0RTdcPq5vaywrAoEA2n1YaAKeanXQdjHsoT6x1gP3U97RN8LZ7yHsSOrKPCcA6mCqw==}
@@ -1367,6 +1399,10 @@ packages:
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1532,6 +1568,12 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  ai@6.0.184:
+    resolution: {integrity: sha512-j//zHkKvj5ra27l8izHco8cj1g1Pr7vx1ZK+hrzrkHvndgIRmdfZKOb6+RAPpvbk42qGIsuYvlYbGlVAu3erNQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -1988,6 +2030,10 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
@@ -2193,6 +2239,9 @@ packages:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
     hasBin: true
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -2905,6 +2954,11 @@ packages:
   stylis@4.4.0:
     resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
 
+  swr@2.4.1:
+    resolution: {integrity: sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   tailwind-merge@3.5.0:
     resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
@@ -2914,6 +2968,10 @@ packages:
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
+
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -3103,6 +3161,34 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@ai-sdk/gateway@3.0.115(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@3.25.76)
+      '@vercel/oidc': 3.2.0
+      zod: 3.25.76
+
+  '@ai-sdk/provider-utils@4.0.27(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 3.25.76
+
+  '@ai-sdk/provider@3.0.10':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/react@3.0.186(react@19.2.5)(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider-utils': 4.0.27(zod@3.25.76)
+      ai: 6.0.184(zod@3.25.76)
+      react: 19.2.5
+      swr: 2.4.1(react@19.2.5)
+      throttleit: 2.1.0
+    transitivePeerDependencies:
+      - zod
 
   '@antfu/install-pkg@1.1.0':
     dependencies:
@@ -3544,6 +3630,8 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.2.4':
     optional: true
+
+  '@opentelemetry/api@1.9.1': {}
 
   '@oxc-project/runtime@0.127.0': {}
 
@@ -4155,6 +4243,8 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
+  '@vercel/oidc@3.2.0': {}
+
   '@vitejs/plugin-react@6.0.1(@voidzero-dev/vite-plus-core@0.1.20(@types/node@25.6.0)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.8.4))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
@@ -4191,7 +4281,7 @@ snapshots:
   '@voidzero-dev/vite-plus-linux-x64-musl@0.1.20':
     optional: true
 
-  '@voidzero-dev/vite-plus-test@0.1.20(@types/node@25.6.0)(@voidzero-dev/vite-plus-core@0.1.20(@types/node@25.6.0)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.8.4))(jiti@2.7.0)(typescript@6.0.3)(yaml@2.8.4)':
+  '@voidzero-dev/vite-plus-test@0.1.20(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@voidzero-dev/vite-plus-core@0.1.20(@types/node@25.6.0)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.8.4))(jiti@2.7.0)(typescript@6.0.3)(yaml@2.8.4)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
@@ -4208,6 +4298,7 @@ snapshots:
       vite: '@voidzero-dev/vite-plus-core@0.1.20(@types/node@25.6.0)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.8.4)'
       ws: 8.20.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 25.6.0
     transitivePeerDependencies:
       - '@arethetypeswrong/core'
@@ -4241,6 +4332,14 @@ snapshots:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  ai@6.0.184(zod@3.25.76):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.115(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@3.25.76)
+      '@opentelemetry/api': 1.9.1
+      zod: 3.25.76
 
   ansi-colors@4.1.3: {}
 
@@ -4711,6 +4810,8 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  eventsource-parser@3.0.8: {}
+
   exsolve@1.0.8: {}
 
   extend@3.0.2: {}
@@ -4737,9 +4838,9 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  geist@1.7.0(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)):
+  geist@1.7.0(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)):
     dependencies:
-      next: 16.2.4(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
   gensync@1.0.0-beta.2: {}
 
@@ -4949,6 +5050,8 @@ snapshots:
       argparse: 2.0.1
 
   jsesc@3.1.0: {}
+
+  json-schema@0.4.0: {}
 
   json5@2.2.3: {}
 
@@ -5523,7 +5626,7 @@ snapshots:
 
   nanoid@3.3.12: {}
 
-  next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@next/env': 16.2.4
       '@swc/helpers': 0.5.15
@@ -5542,6 +5645,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.4
       '@next/swc-win32-arm64-msvc': 16.2.4
       '@next/swc-win32-x64-msvc': 16.2.4
+      '@opentelemetry/api': 1.9.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -6069,11 +6173,19 @@ snapshots:
 
   stylis@4.4.0: {}
 
+  swr@2.4.1(react@19.2.5):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.5
+      use-sync-external-store: 1.6.0(react@19.2.5)
+
   tailwind-merge@3.5.0: {}
 
   tailwindcss@4.2.4: {}
 
   tapable@2.3.3: {}
+
+  throttleit@2.1.0: {}
 
   tinybench@2.9.0: {}
 
@@ -6186,11 +6298,11 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plus@0.1.20(@types/node@25.6.0)(@voidzero-dev/vite-plus-core@0.1.20(@types/node@25.6.0)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.8.4))(jiti@2.7.0)(typescript@6.0.3)(yaml@2.8.4):
+  vite-plus@0.1.20(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@voidzero-dev/vite-plus-core@0.1.20(@types/node@25.6.0)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.8.4))(jiti@2.7.0)(typescript@6.0.3)(yaml@2.8.4):
     dependencies:
       '@oxc-project/types': 0.127.0
       '@voidzero-dev/vite-plus-core': 0.1.20(@types/node@25.6.0)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.8.4)
-      '@voidzero-dev/vite-plus-test': 0.1.20(@types/node@25.6.0)(@voidzero-dev/vite-plus-core@0.1.20(@types/node@25.6.0)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.8.4))(jiti@2.7.0)(typescript@6.0.3)(yaml@2.8.4)
+      '@voidzero-dev/vite-plus-test': 0.1.20(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@voidzero-dev/vite-plus-core@0.1.20(@types/node@25.6.0)(jiti@2.7.0)(typescript@6.0.3)(yaml@2.8.4))(jiti@2.7.0)(typescript@6.0.3)(yaml@2.8.4)
       oxfmt: 0.46.0
       oxlint: 1.61.0(oxlint-tsgolint@0.22.0)
       oxlint-tsgolint: 0.22.0

--- a/web/src/features/sessions/SessionConversation.tsx
+++ b/web/src/features/sessions/SessionConversation.tsx
@@ -5,6 +5,7 @@ import { api } from "@/lib/api";
 import type { Message } from "@/lib/types";
 import {
   createSessionTransport,
+  mergeToolResults,
   messageToUIMessage,
   uiMessageToMessage,
 } from "@/lib/chat-transport";
@@ -65,9 +66,9 @@ export function SessionConversation({
 
   useEffect(() => {
     if (!messagesQuery.data) return;
-    const historical = [...messagesQuery.data.pages].reverse().flat();
-    if (historical.length === 0) return;
-    const uiMessages = historical.map(messageToUIMessage);
+    const merged = mergeToolResults([...messagesQuery.data.pages].reverse().flat());
+    if (merged.length === 0) return;
+    const uiMessages = merged.map(messageToUIMessage);
     const newIDs = new Set(uiMessages.map((m) => m.id));
     historicalIDsRef.current = newIDs;
     setChatMessages((prev) => {

--- a/web/src/features/sessions/SessionConversation.tsx
+++ b/web/src/features/sessions/SessionConversation.tsx
@@ -61,17 +61,17 @@ export function SessionConversation({
       lastPage.length === 20 ? allPages.reduce((sum, page) => sum + page.length, 0) : undefined,
   });
 
-  const historicalCountRef = useRef(0);
+  const historicalIDsRef = useRef(new Set<string>());
 
   useEffect(() => {
     if (!messagesQuery.data) return;
     const historical = [...messagesQuery.data.pages].reverse().flat();
-    const prevCount = historicalCountRef.current;
-    historicalCountRef.current = historical.length;
     if (historical.length === 0) return;
     const uiMessages = historical.map(messageToUIMessage);
+    const newIDs = new Set(uiMessages.map((m) => m.id));
+    historicalIDsRef.current = newIDs;
     setChatMessages((prev) => {
-      const liveSlice = prev.slice(prevCount);
+      const liveSlice = prev.filter((m) => !newIDs.has(m.id));
       return [...uiMessages, ...liveSlice];
     });
   }, [messagesQuery.data, setChatMessages]);
@@ -80,7 +80,7 @@ export function SessionConversation({
 
   useEffect(() => {
     initialScrollSessionRef.current = null;
-    historicalCountRef.current = 0;
+    historicalIDsRef.current = new Set();
     setChatMessages([]);
   }, [sessionId, setChatMessages]);
 

--- a/web/src/features/sessions/SessionConversation.tsx
+++ b/web/src/features/sessions/SessionConversation.tsx
@@ -1,7 +1,13 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useInfiniteQuery } from "@tanstack/react-query";
+import { useChat } from "@ai-sdk/react";
 import { api } from "@/lib/api";
 import type { Message } from "@/lib/types";
+import {
+  createSessionTransport,
+  messageToUIMessage,
+  uiMessageToMessage,
+} from "@/lib/chat-transport";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -25,14 +31,26 @@ export function SessionConversation({
   className = "",
   bodyClassName = "h-[28rem]",
 }: Props) {
-  const [input, setInput] = useState("");
-  const [liveMessages, setLiveMessages] = useState<Message[]>([]);
-  const [isStreaming, setIsStreaming] = useState(false);
+  const [userInput, setUserInput] = useState("");
   const [mobileOpen, setMobileOpen] = useState(false);
   const transcriptRef = useRef<HTMLDivElement>(null);
-  const abortRef = useRef<AbortController | null>(null);
   const initialScrollSessionRef = useRef<string | null>(null);
   const enc = encodeURIComponent(sessionId);
+
+  const transport = useMemo(() => createSessionTransport(sessionId), [sessionId]);
+
+  const {
+    messages: chatMessages,
+    sendMessage: chatSendMessage,
+    setMessages: setChatMessages,
+    status: chatStatus,
+    stop: chatStop,
+  } = useChat({
+    id: `conv-${sessionId}`,
+    transport,
+  });
+
+  const isStreaming = chatStatus === "streaming" || chatStatus === "submitted";
 
   const messagesQuery = useInfiniteQuery({
     queryKey: ["session-messages", sessionId],
@@ -43,12 +61,28 @@ export function SessionConversation({
       lastPage.length === 20 ? allPages.reduce((sum, page) => sum + page.length, 0) : undefined,
   });
 
-  const messages = [...(messagesQuery.data?.pages ?? [])].reverse().flat().concat(liveMessages);
+  const historicalCountRef = useRef(0);
+
+  useEffect(() => {
+    if (!messagesQuery.data) return;
+    const historical = [...messagesQuery.data.pages].reverse().flat();
+    const prevCount = historicalCountRef.current;
+    historicalCountRef.current = historical.length;
+    if (historical.length === 0) return;
+    const uiMessages = historical.map(messageToUIMessage);
+    setChatMessages((prev) => {
+      const liveSlice = prev.slice(prevCount);
+      return [...uiMessages, ...liveSlice];
+    });
+  }, [messagesQuery.data, setChatMessages]);
+
+  const messages = useMemo(() => chatMessages.map(uiMessageToMessage), [chatMessages]);
 
   useEffect(() => {
     initialScrollSessionRef.current = null;
-    setLiveMessages([]);
-  }, [sessionId]);
+    historicalCountRef.current = 0;
+    setChatMessages([]);
+  }, [sessionId, setChatMessages]);
 
   useEffect(() => {
     if (!messagesQuery.isSuccess || initialScrollSessionRef.current === sessionId) return;
@@ -71,163 +105,19 @@ export function SessionConversation({
     }, 0);
   }, [messagesQuery]);
 
-  const scrollToBottom = useCallback(() => {
-    if (!transcriptRef.current) return;
-    const el = transcriptRef.current;
-    if (el.scrollHeight - el.scrollTop - el.clientHeight < 200) {
-      el.scrollTop = el.scrollHeight;
-    }
-  }, []);
-
-  const sendMessage = useCallback(async () => {
-    const content = input.trim();
+  const sendMessage = useCallback(() => {
+    const content = userInput.trim();
     if (!content || isStreaming) return;
 
-    setInput("");
-    setLiveMessages((prev) => [
-      ...prev,
-      { role: "user", content, timestamp: new Date().toISOString() },
-    ]);
-    setIsStreaming(true);
-    abortRef.current = new AbortController();
-
+    setUserInput("");
     setTimeout(() => {
       if (transcriptRef.current) {
         transcriptRef.current.scrollTop = transcriptRef.current.scrollHeight;
       }
     }, 0);
 
-    try {
-      const res = await fetch(`/api/sessions/${enc}/messages`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ content }),
-        signal: abortRef.current.signal,
-      });
-      if (!res.ok) throw new Error((await res.text()) || res.statusText);
-      if (!res.body) return;
-
-      const reader = res.body.getReader();
-      const decoder = new TextDecoder();
-      let buffer = "";
-      let currentEvent = "";
-      let currentData = "";
-
-      const dispatch = (event: string, dataStr: string) => {
-        if (!dataStr) return;
-        let data: Record<string, unknown>;
-        try {
-          data = JSON.parse(dataStr) as Record<string, unknown>;
-        } catch {
-          return;
-        }
-
-        if (event === "text") {
-          const text = (data.text as string) || "";
-          setLiveMessages((prev) => {
-            const last = prev[prev.length - 1];
-            if (last?.role === "assistant" && last._streaming) {
-              const blocks = [...(last.blocks ?? [])];
-              const lastBlock = blocks[blocks.length - 1];
-              if (lastBlock?.type === "text") {
-                blocks[blocks.length - 1] = { ...lastBlock, text: lastBlock.text + text };
-              } else {
-                blocks.push({ type: "text", text });
-              }
-              return [...prev.slice(0, -1), { ...last, blocks }];
-            }
-            return [
-              ...prev,
-              {
-                role: "assistant",
-                blocks: [{ type: "text", text }],
-                timestamp: new Date().toISOString(),
-                _streaming: true,
-              },
-            ];
-          });
-          scrollToBottom();
-        } else if (event === "tool_use") {
-          if ((data.type as string) === "tool_call") {
-            setLiveMessages((prev) => {
-              const last = prev[prev.length - 1];
-              const newBlock = {
-                type: "tool_call" as const,
-                id: data.id as string,
-                name: data.name as string,
-                arguments: data.arguments as Record<string, unknown>,
-                status: "running" as const,
-              };
-              if (last?.role === "assistant" && last._streaming) {
-                return [
-                  ...prev.slice(0, -1),
-                  { ...last, blocks: [...(last.blocks ?? []), newBlock] },
-                ];
-              }
-              return [
-                ...prev,
-                {
-                  role: "assistant",
-                  blocks: [newBlock],
-                  timestamp: new Date().toISOString(),
-                  _streaming: true,
-                },
-              ];
-            });
-            scrollToBottom();
-          } else if ((data.type as string) === "tool_result") {
-            setLiveMessages((prev) =>
-              prev.map((msg) => {
-                if (msg.role !== "assistant") return msg;
-                const blocks = (msg.blocks ?? []).map((block) => {
-                  if (block.type === "tool_call" && block.id === (data.tool_call_id as string)) {
-                    return {
-                      ...block,
-                      result: {
-                        tool_call_id: data.tool_call_id as string,
-                        content: data.content as string,
-                        is_error: data.is_error as boolean,
-                      },
-                      status: "done" as const,
-                    };
-                  }
-                  return block;
-                });
-                return { ...msg, blocks };
-              }),
-            );
-          }
-        }
-      };
-
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split("\n");
-        buffer = lines.pop() ?? "";
-        for (const line of lines) {
-          if (line.startsWith("event: ")) currentEvent = line.slice(7).trim();
-          else if (line.startsWith("data: ")) currentData = line.slice(6).trim();
-          else if (line === "") {
-            if (currentEvent) dispatch(currentEvent, currentData);
-            currentEvent = "";
-            currentData = "";
-          }
-        }
-      }
-    } catch (e) {
-      if ((e as Error).name !== "AbortError") console.error(e);
-    } finally {
-      setLiveMessages((prev) => {
-        const last = prev[prev.length - 1];
-        if (last?._streaming) return [...prev.slice(0, -1), { ...last, _streaming: undefined }];
-        return prev;
-      });
-      setIsStreaming(false);
-      abortRef.current = null;
-    }
-  }, [enc, input, isStreaming, scrollToBottom]);
+    void chatSendMessage({ text: content });
+  }, [userInput, isStreaming, chatSendMessage]);
 
   const renderBody = () => (
     <div className="flex h-full min-h-0 flex-col">
@@ -239,26 +129,36 @@ export function SessionConversation({
       />
       <div className="flex flex-col gap-2 border-t border-border p-2 sm:flex-row sm:p-3">
         <input
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
+          value={userInput}
+          onChange={(e) => setUserInput(e.target.value)}
           onKeyDown={(e) => {
             if (e.key === "Enter" && !e.shiftKey) {
               e.preventDefault();
-              void sendMessage();
+              sendMessage();
             }
           }}
           placeholder={placeholder}
           className="min-w-0 flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm outline-hidden focus:ring-2 focus:ring-ring"
         />
-        <Button
-          size="sm"
-          className="w-full sm:w-auto"
-          loading={isStreaming}
-          disabled={!input.trim()}
-          onClick={sendMessage}
-        >
-          Continue
-        </Button>
+        {isStreaming ? (
+          <Button
+            size="sm"
+            variant="outline"
+            className="w-full sm:w-auto"
+            onClick={() => chatStop()}
+          >
+            Stop
+          </Button>
+        ) : (
+          <Button
+            size="sm"
+            className="w-full sm:w-auto"
+            disabled={!userInput.trim()}
+            onClick={sendMessage}
+          >
+            Continue
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/web/src/features/sessions/SessionDetail.tsx
+++ b/web/src/features/sessions/SessionDetail.tsx
@@ -80,17 +80,17 @@ export function SessionDetail({
       lastPage.length === 20 ? allPages.reduce((sum, page) => sum + page.length, 0) : undefined,
   });
 
-  const historicalCountRef = useRef(0);
+  const historicalIDsRef = useRef(new Set<string>());
 
   useEffect(() => {
     if (!messagesQuery.data) return;
     const historical = [...messagesQuery.data.pages].reverse().flat();
-    const prevCount = historicalCountRef.current;
-    historicalCountRef.current = historical.length;
     if (historical.length === 0) return;
     const uiMessages = historical.map(messageToUIMessage);
+    const newIDs = new Set(uiMessages.map((m) => m.id));
+    historicalIDsRef.current = newIDs;
     setChatMessages((prev) => {
-      const liveSlice = prev.slice(prevCount);
+      const liveSlice = prev.filter((m) => !newIDs.has(m.id));
       return [...uiMessages, ...liveSlice];
     });
   }, [messagesQuery.data, setChatMessages]);

--- a/web/src/features/sessions/SessionDetail.tsx
+++ b/web/src/features/sessions/SessionDetail.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import {
   createSessionTransport,
+  mergeToolResults,
   messageToUIMessage,
   uiMessageToMessage,
 } from "@/lib/chat-transport";
@@ -84,9 +85,9 @@ export function SessionDetail({
 
   useEffect(() => {
     if (!messagesQuery.data) return;
-    const historical = [...messagesQuery.data.pages].reverse().flat();
-    if (historical.length === 0) return;
-    const uiMessages = historical.map(messageToUIMessage);
+    const merged = mergeToolResults([...messagesQuery.data.pages].reverse().flat());
+    if (merged.length === 0) return;
+    const uiMessages = merged.map(messageToUIMessage);
     const newIDs = new Set(uiMessages.map((m) => m.id));
     historicalIDsRef.current = newIDs;
     setChatMessages((prev) => {

--- a/web/src/features/sessions/SessionDetail.tsx
+++ b/web/src/features/sessions/SessionDetail.tsx
@@ -1,11 +1,13 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useInfiniteQuery } from "@tanstack/react-query";
+import { useChat } from "@ai-sdk/react";
 import { useI18n } from "@/lib/i18n";
 import { api } from "@/lib/api";
 import { formatTime } from "@/lib/time";
 import type { Message, Session, Skill, Tool } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
+import { createSessionTransport, uiMessageToMessage } from "@/lib/chat-transport";
 import { Transcript } from "./Transcript";
 
 interface Props {
@@ -25,7 +27,6 @@ export function SessionDetail({
   onToggleRight,
 }: Props) {
   const { t } = useI18n();
-  const [liveMessages, setLiveMessages] = useState<Message[]>([]);
   const [systemPrompt, setSystemPrompt] = useState("");
   const [tools, setTools] = useState<Tool[]>([]);
   const [toolsLoading, setToolsLoading] = useState(false);
@@ -36,18 +37,35 @@ export function SessionDetail({
     "session",
   );
   const [userInput, setUserInput] = useState("");
-  const [isStreaming, setIsStreaming] = useState(false);
   const [attachments, setAttachments] = useState<
     { name: string; path: string; uploading: boolean }[]
   >([]);
 
-  const abortRef = useRef<AbortController | null>(null);
   const transcriptRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const sessionIDRef = useRef<string | null>(null);
   const initialScrollSessionRef = useRef<string | null>(null);
 
   const enc = session ? encodeURIComponent(session.id) : "";
+
+  const transport = useMemo(
+    () => (session ? createSessionTransport(session.id) : undefined),
+    [session?.id],
+  );
+
+  const {
+    messages: chatMessages,
+    sendMessage: chatSendMessage,
+    setMessages: setChatMessages,
+    status: chatStatus,
+    stop: chatStop,
+  } = useChat({
+    id: session?.id ?? "empty",
+    transport,
+  });
+
+  const isStreaming = chatStatus === "streaming" || chatStatus === "submitted";
+
   const messagesQuery = useInfiniteQuery({
     queryKey: ["session-messages", session?.id],
     enabled: !!session,
@@ -57,11 +75,22 @@ export function SessionDetail({
     getNextPageParam: (lastPage, allPages) =>
       lastPage.length === 20 ? allPages.reduce((sum, page) => sum + page.length, 0) : undefined,
   });
-  const messages = [...(messagesQuery.data?.pages ?? [])].reverse().flat().concat(liveMessages);
+
+  const historicalMessages = useMemo(
+    () => [...(messagesQuery.data?.pages ?? [])].reverse().flat(),
+    [messagesQuery.data],
+  );
+
+  const liveMessages = useMemo(() => chatMessages.map(uiMessageToMessage), [chatMessages]);
+
+  const messages = useMemo(
+    () => [...historicalMessages, ...liveMessages],
+    [historicalMessages, liveMessages],
+  );
 
   useEffect(() => {
     if (!session) {
-      setLiveMessages([]);
+      setChatMessages([]);
       setSystemPrompt("");
       setInspectOpen(false);
       setAttachments([]);
@@ -69,7 +98,7 @@ export function SessionDetail({
     }
     sessionIDRef.current = session.id;
     initialScrollSessionRef.current = null;
-    setLiveMessages([]);
+    setChatMessages([]);
     setSkills([]);
 
     const load = async () => {
@@ -209,164 +238,17 @@ export function SessionDetail({
       parts.push(`[file: ${p}]`);
     }
     if (userInput.trim()) parts.push(userInput.trim());
-    const content = parts.join("\n");
+    const text = parts.join("\n");
 
     setUserInput("");
     setAttachments([]);
-    setLiveMessages((prev) => [
-      ...prev,
-      { role: "user", content, timestamp: new Date().toISOString() },
-    ]);
-    setIsStreaming(true);
-    abortRef.current = new AbortController();
     setTimeout(() => {
       if (transcriptRef.current)
         transcriptRef.current.scrollTop = transcriptRef.current.scrollHeight;
     }, 0);
 
-    try {
-      const res = await fetch(`/api/sessions/${enc}/messages`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ content }),
-        signal: abortRef.current.signal,
-      });
-      if (!res.ok) throw new Error((await res.text()) || res.statusText);
-
-      const reader = res.body!.getReader();
-      const decoder = new TextDecoder();
-      let buffer = "";
-      let currentEvent = "";
-      let currentData = "";
-
-      const scrollToBottom = () => {
-        if (transcriptRef.current) {
-          const el = transcriptRef.current;
-          if (el.scrollHeight - el.scrollTop - el.clientHeight < 200)
-            el.scrollTop = el.scrollHeight;
-        }
-      };
-
-      const dispatch = (event: string, dataStr: string) => {
-        if (!dataStr) return;
-        let data: Record<string, unknown>;
-        try {
-          data = JSON.parse(dataStr) as Record<string, unknown>;
-        } catch {
-          return;
-        }
-
-        if (event === "text") {
-          const text = (data.text as string) || "";
-          setLiveMessages((prev) => {
-            const last = prev[prev.length - 1];
-            if (last?.role === "assistant" && last._streaming) {
-              const blocks = [...(last.blocks ?? [])];
-              const lastBlock = blocks[blocks.length - 1];
-              if (lastBlock?.type === "text") {
-                blocks[blocks.length - 1] = { ...lastBlock, text: lastBlock.text + text };
-              } else {
-                blocks.push({ type: "text", text });
-              }
-              return [...prev.slice(0, -1), { ...last, blocks }];
-            }
-            return [
-              ...prev,
-              {
-                role: "assistant",
-                blocks: [{ type: "text", text }],
-                timestamp: new Date().toISOString(),
-                _streaming: true,
-              },
-            ];
-          });
-          scrollToBottom();
-        } else if (event === "tool_use") {
-          if ((data.type as string) === "tool_call") {
-            setLiveMessages((prev) => {
-              const last = prev[prev.length - 1];
-              const newBlock = {
-                type: "tool_call" as const,
-                id: data.id as string,
-                name: data.name as string,
-                arguments: data.arguments as Record<string, unknown>,
-                status: "running" as const,
-              };
-              if (last?.role === "assistant" && last._streaming) {
-                return [
-                  ...prev.slice(0, -1),
-                  { ...last, blocks: [...(last.blocks ?? []), newBlock] },
-                ];
-              }
-              return [
-                ...prev,
-                {
-                  role: "assistant",
-                  blocks: [newBlock],
-                  timestamp: new Date().toISOString(),
-                  _streaming: true,
-                },
-              ];
-            });
-            scrollToBottom();
-          } else if ((data.type as string) === "tool_result") {
-            setLiveMessages((prev) =>
-              prev.map((msg) => {
-                if (msg.role !== "assistant") return msg;
-                const blocks = (msg.blocks ?? []).map((block) => {
-                  if (block.type === "tool_call" && block.id === (data.tool_call_id as string)) {
-                    return {
-                      ...block,
-                      result: {
-                        tool_call_id: data.tool_call_id as string,
-                        content: data.content as string,
-                        is_error: data.is_error as boolean,
-                      },
-                      status: "done" as const,
-                    };
-                  }
-                  return block;
-                });
-                return { ...msg, blocks };
-              }),
-            );
-          }
-        }
-      };
-
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split("\n");
-        buffer = lines.pop() ?? "";
-        for (const line of lines) {
-          if (line.startsWith("event: ")) currentEvent = line.slice(7).trim();
-          else if (line.startsWith("data: ")) currentData = line.slice(6).trim();
-          else if (line === "") {
-            if (currentEvent) dispatch(currentEvent, currentData);
-            currentEvent = "";
-            currentData = "";
-          }
-        }
-      }
-      setLiveMessages((prev) => {
-        const last = prev[prev.length - 1];
-        if (last?._streaming) return [...prev.slice(0, -1), { ...last, _streaming: undefined }];
-        return prev;
-      });
-    } catch (e) {
-      if ((e as Error).name !== "AbortError") console.error(e);
-      setLiveMessages((prev) => {
-        const last = prev[prev.length - 1];
-        if (last?._streaming) return [...prev.slice(0, -1), { ...last, _streaming: undefined }];
-        return prev;
-      });
-    } finally {
-      setIsStreaming(false);
-      abortRef.current = null;
-    }
-  }, [userInput, isStreaming, session, enc, attachments]);
+    void chatSendMessage({ text });
+  }, [userInput, isStreaming, session, attachments, chatSendMessage]);
 
   const copyID = useCallback(async () => {
     if (!session?.id) return;
@@ -655,7 +537,7 @@ export function SessionDetail({
                       <Button
                         size="xs"
                         variant="ghost"
-                        onClick={() => abortRef.current?.abort()}
+                        onClick={() => chatStop()}
                         className="text-destructive gap-1 rounded-lg"
                       >
                         Stop

--- a/web/src/features/sessions/SessionDetail.tsx
+++ b/web/src/features/sessions/SessionDetail.tsx
@@ -7,7 +7,11 @@ import { formatTime } from "@/lib/time";
 import type { Message, Session, Skill, Tool } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
-import { createSessionTransport, uiMessageToMessage } from "@/lib/chat-transport";
+import {
+  createSessionTransport,
+  messageToUIMessage,
+  uiMessageToMessage,
+} from "@/lib/chat-transport";
 import { Transcript } from "./Transcript";
 
 interface Props {
@@ -76,17 +80,22 @@ export function SessionDetail({
       lastPage.length === 20 ? allPages.reduce((sum, page) => sum + page.length, 0) : undefined,
   });
 
-  const historicalMessages = useMemo(
-    () => [...(messagesQuery.data?.pages ?? [])].reverse().flat(),
-    [messagesQuery.data],
-  );
+  const historicalCountRef = useRef(0);
 
-  const liveMessages = useMemo(() => chatMessages.map(uiMessageToMessage), [chatMessages]);
+  useEffect(() => {
+    if (!messagesQuery.data) return;
+    const historical = [...messagesQuery.data.pages].reverse().flat();
+    const prevCount = historicalCountRef.current;
+    historicalCountRef.current = historical.length;
+    if (historical.length === 0) return;
+    const uiMessages = historical.map(messageToUIMessage);
+    setChatMessages((prev) => {
+      const liveSlice = prev.slice(prevCount);
+      return [...uiMessages, ...liveSlice];
+    });
+  }, [messagesQuery.data, setChatMessages]);
 
-  const messages = useMemo(
-    () => [...historicalMessages, ...liveMessages],
-    [historicalMessages, liveMessages],
-  );
+  const messages = useMemo(() => chatMessages.map(uiMessageToMessage), [chatMessages]);
 
   useEffect(() => {
     if (!session) {

--- a/web/src/features/sessions/Transcript.tsx
+++ b/web/src/features/sessions/Transcript.tsx
@@ -134,7 +134,7 @@ function ThinkingBlock({ block }: { block: ContentBlock & { type: "thinking" } }
 
 function ToolCallBlock({ block }: { block: ContentBlock & { type: "tool_call" } }) {
   const [expanded, setExpanded] = useState(false);
-  const colorClass = toolColor(block.name);
+  const colorClass = toolColor(block.name ?? "");
 
   return (
     <div className="pl-3 rounded-lg bg-muted/20">
@@ -235,7 +235,7 @@ function toolArgText(value: unknown): string {
 }
 
 function ToolInputRenderer({ block }: { block: ContentBlock & { type: "tool_call" } }) {
-  const n = block.name.toLowerCase();
+  const n = (block.name ?? "").toLowerCase();
   const args = block.arguments ?? {};
 
   if (n === "bash")
@@ -287,7 +287,7 @@ function toolColor(name: string): string {
 
 function toolPreview(block: ContentBlock & { type: "tool_call" }): string {
   const args = block.arguments ?? {};
-  const n = block.name.toLowerCase();
+  const n = (block.name ?? "").toLowerCase();
   const trunc = (s: string, len = 55) => (s.length > len ? s.slice(0, len) + "…" : s);
   const shortPath = (p: string) => {
     const pts = (p || "").split("/");

--- a/web/src/features/sessions/Transcript.tsx
+++ b/web/src/features/sessions/Transcript.tsx
@@ -322,6 +322,7 @@ interface ProcessedMessage extends Message {
 }
 
 function processMessages(messages: Message[]): ProcessedMessage[] {
+  // Collect standalone tool-result messages (legacy format) by tool_call_id.
   const resultsByID: Record<string, Message> = {};
   for (const msg of messages) {
     if (msg.role === "tool" && msg.tool_call_id) {
@@ -335,14 +336,15 @@ function processMessages(messages: Message[]): ProcessedMessage[] {
       return {
         ...msg,
         blocks: (msg.blocks ?? []).map((block) => {
-          if (block.type === "tool_call" && block.id && resultsByID[block.id]) {
+          // Only backfill from standalone tool messages if block has no result yet.
+          if (block.type === "tool_call" && block.id && !block.result && resultsByID[block.id]) {
             const r = resultsByID[block.id];
             return {
               ...block,
               result: {
                 tool_call_id: block.id,
                 content: r.content ?? "",
-                is_error: false,
+                is_error: !!r.blocks?.some((b) => b.type === "tool_call" && b.result?.is_error),
               },
             };
           }

--- a/web/src/features/sessions/Transcript.tsx
+++ b/web/src/features/sessions/Transcript.tsx
@@ -322,36 +322,8 @@ interface ProcessedMessage extends Message {
 }
 
 function processMessages(messages: Message[]): ProcessedMessage[] {
-  // Collect standalone tool-result messages (legacy format) by tool_call_id.
-  const resultsByID: Record<string, Message> = {};
-  for (const msg of messages) {
-    if (msg.role === "tool" && msg.tool_call_id) {
-      resultsByID[msg.tool_call_id] = msg;
-    }
-  }
-  const msgs = messages
-    .filter((m) => m.role !== "tool")
-    .map((msg) => {
-      if (msg.role !== "assistant") return msg;
-      return {
-        ...msg,
-        blocks: (msg.blocks ?? []).map((block) => {
-          // Only backfill from standalone tool messages if block has no result yet.
-          if (block.type === "tool_call" && block.id && !block.result && resultsByID[block.id]) {
-            const r = resultsByID[block.id];
-            return {
-              ...block,
-              result: {
-                tool_call_id: block.id,
-                content: r.content ?? "",
-                is_error: !!r.blocks?.some((b) => b.type === "tool_call" && b.result?.is_error),
-              },
-            };
-          }
-          return block;
-        }),
-      };
-    });
+  // Tool results are merged upstream by mergeToolResults; filter any stragglers.
+  const msgs = messages.filter((m) => m.role !== "tool");
   return msgs.map((msg, i) => ({
     ...msg,
     showTimestamp: i === msgs.length - 1 || msgs[i + 1].role !== msg.role,

--- a/web/src/lib/api-client/index.ts
+++ b/web/src/lib/api-client/index.ts
@@ -911,6 +911,7 @@ export type {
   ManifestPlugin,
   ManifestPluginsResponse,
   MeResponse,
+  MessagePart,
   MoveWorkspaceFileData,
   MoveWorkspaceFileError,
   MoveWorkspaceFileErrors,

--- a/web/src/lib/api-client/types.gen.ts
+++ b/web/src/lib/api-client/types.gen.ts
@@ -742,6 +742,26 @@ export type ComponentsMeResponse = {
   is_admin: boolean;
 };
 
+export type MessagePart = {
+  type: "text" | "image" | "file";
+  /**
+   * Text content (when type is "text")
+   */
+  text?: string;
+  /**
+   * Base64-encoded image data (when type is "image")
+   */
+  image?: string;
+  /**
+   * File URL (when type is "file")
+   */
+  url?: string;
+  /**
+   * MIME type of the image or file
+   */
+  mimeType?: string;
+};
+
 export type ComponentsOAuthConnectedResponse = {
   connected: boolean;
   username?: string;
@@ -902,9 +922,9 @@ export type SaveDigestRequest = {
 
 export type ComponentsSendMessageRequest = {
   /**
-   * Message content (required)
+   * Message content parts (text, image, file)
    */
-  content: string;
+  parts: Array<MessagePart>;
 };
 
 export type ComponentsSession = {

--- a/web/src/lib/chat-transport.ts
+++ b/web/src/lib/chat-transport.ts
@@ -20,6 +20,8 @@ export function createSessionTransport(sessionId: string) {
   });
 }
 
+let msgSeq = 0;
+
 export function messageToUIMessage(m: Message): UIMessage {
   const parts: UIMessage["parts"] = [];
 
@@ -39,9 +41,14 @@ export function messageToUIMessage(m: Message): UIMessage {
             type: "dynamic-tool",
             toolName: block.name,
             toolCallId: block.id,
-            state: block.result ? "output-available" : "input-available",
+            state: block.result
+              ? block.result.is_error
+                ? "output-error"
+                : "output-available"
+              : "input-available",
             input: block.arguments ?? {},
-            ...(block.result ? { output: block.result.content } : {}),
+            ...(block.result && !block.result.is_error ? { output: block.result.content } : {}),
+            ...(block.result?.is_error ? { errorText: block.result.content } : {}),
           } as UIMessage["parts"][number]);
           break;
       }
@@ -51,7 +58,7 @@ export function messageToUIMessage(m: Message): UIMessage {
   }
 
   return {
-    id: `${m.timestamp}-${m.role}`,
+    id: `${m.timestamp}-${m.role}-${msgSeq++}`,
     role: m.role === "tool" ? "assistant" : m.role,
     parts,
     metadata: {
@@ -80,7 +87,7 @@ function isToolPart(
 
 function extractToolName(part: AnyToolPart): string {
   if (part.toolName) return part.toolName;
-  if (part.type.startsWith("tool-")) return part.type.slice(5);
+  if (part.type.startsWith("tool-") && part.type.length > 5) return part.type.slice(5);
   return "";
 }
 

--- a/web/src/lib/chat-transport.ts
+++ b/web/src/lib/chat-transport.ts
@@ -10,8 +10,6 @@ export function createSessionTransport(sessionId: string) {
       const parts = last.parts
         .map((p) => {
           if (p.type === "text") return { type: "text" as const, text: p.text };
-          if (p.type === "file" && "url" in p)
-            return { type: "file" as const, url: p.url, mimeType: p.mediaType };
           return null;
         })
         .filter(Boolean);
@@ -20,9 +18,40 @@ export function createSessionTransport(sessionId: string) {
   });
 }
 
-let msgSeq = 0;
+/**
+ * Merge standalone role:"tool" messages into the preceding assistant message's
+ * tool_call blocks so that the conversion to UIMessage never produces orphan
+ * tool-result rows. Returns a new array (no mutation).
+ */
+export function mergeToolResults(messages: Message[]): Message[] {
+  const out: Message[] = [];
+  for (const m of messages) {
+    if (m.role === "tool" && m.tool_call_id) {
+      const prev = out.length > 0 ? out[out.length - 1] : undefined;
+      if (prev?.role === "assistant" && prev.blocks) {
+        prev.blocks = prev.blocks.map((block) => {
+          if (block.type === "tool_call" && block.id === m.tool_call_id && !block.result) {
+            return {
+              ...block,
+              status: "done" as const,
+              result: {
+                tool_call_id: m.tool_call_id!,
+                content: m.content ?? "",
+                is_error: false,
+              },
+            };
+          }
+          return block;
+        });
+        continue;
+      }
+    }
+    out.push({ ...m });
+  }
+  return out;
+}
 
-export function messageToUIMessage(m: Message): UIMessage {
+export function messageToUIMessage(m: Message, index: number): UIMessage {
   const parts: UIMessage["parts"] = [];
 
   if (m.blocks && m.blocks.length > 0) {
@@ -58,7 +87,7 @@ export function messageToUIMessage(m: Message): UIMessage {
   }
 
   return {
-    id: `${m.timestamp}-${m.role}-${msgSeq++}`,
+    id: `hist-${m.timestamp}-${m.role}-${index}`,
     role: m.role === "tool" ? "assistant" : m.role,
     parts,
     metadata: {

--- a/web/src/lib/chat-transport.ts
+++ b/web/src/lib/chat-transport.ts
@@ -54,13 +54,18 @@ export function messageToUIMessage(m: Message): UIMessage {
     id: `${m.timestamp}-${m.role}`,
     role: m.role === "tool" ? "assistant" : m.role,
     parts,
+    metadata: {
+      timestamp: m.timestamp,
+      token_count: m.token_count,
+      model: m.model,
+    },
   };
 }
 
 type AnyToolPart = {
   type: string;
   toolCallId: string;
-  toolName: string;
+  toolName?: string;
   state: string;
   input?: unknown;
   output?: unknown;
@@ -71,6 +76,12 @@ function isToolPart(
   part: UIMessage["parts"][number],
 ): part is AnyToolPart & UIMessage["parts"][number] {
   return part.type === "dynamic-tool" || part.type.startsWith("tool-");
+}
+
+function extractToolName(part: AnyToolPart): string {
+  if (part.toolName) return part.toolName;
+  if (part.type.startsWith("tool-")) return part.type.slice(5);
+  return "";
 }
 
 export function uiMessageToMessage(m: UIMessage): Message {
@@ -89,22 +100,24 @@ export function uiMessageToMessage(m: UIMessage): Message {
       default:
         if (isToolPart(part)) {
           const hasOutput = part.state === "output-available" || part.state === "output-error";
+          const outputContent = hasOutput
+            ? part.state === "output-error"
+              ? (part.errorText ?? "error")
+              : typeof part.output === "string"
+                ? part.output
+                : JSON.stringify(part.output)
+            : undefined;
           blocks.push({
             type: "tool_call",
             id: part.toolCallId,
-            name: part.toolName,
+            name: extractToolName(part),
             arguments: (part.input as Record<string, unknown>) ?? {},
             status: hasOutput ? "done" : "running",
             ...(hasOutput
               ? {
                   result: {
                     tool_call_id: part.toolCallId,
-                    content:
-                      part.state === "output-error"
-                        ? (part.errorText ?? "error")
-                        : typeof part.output === "string"
-                          ? part.output
-                          : JSON.stringify(part.output),
+                    content: outputContent!,
                     is_error: part.state === "output-error",
                   },
                 }
@@ -115,10 +128,14 @@ export function uiMessageToMessage(m: UIMessage): Message {
     }
   }
 
+  const meta = (m.metadata ?? {}) as Record<string, unknown>;
+
   return {
     role: m.role === "system" ? "assistant" : m.role,
     content: content || undefined,
     blocks: blocks.length > 0 ? blocks : undefined,
-    timestamp: new Date().toISOString(),
+    timestamp: (meta.timestamp as string) || new Date().toISOString(),
+    token_count: meta.token_count as number | undefined,
+    model: meta.model as string | undefined,
   };
 }

--- a/web/src/lib/chat-transport.ts
+++ b/web/src/lib/chat-transport.ts
@@ -1,0 +1,124 @@
+import { DefaultChatTransport } from "ai";
+import type { UIMessage } from "ai";
+import type { Message } from "./types";
+
+export function createSessionTransport(sessionId: string) {
+  return new DefaultChatTransport({
+    api: `/api/sessions/${encodeURIComponent(sessionId)}/messages`,
+    prepareSendMessagesRequest: ({ messages }) => {
+      const last = messages[messages.length - 1];
+      const parts = last.parts
+        .map((p) => {
+          if (p.type === "text") return { type: "text" as const, text: p.text };
+          if (p.type === "file" && "url" in p)
+            return { type: "file" as const, url: p.url, mimeType: p.mediaType };
+          return null;
+        })
+        .filter(Boolean);
+      return { body: { parts } };
+    },
+  });
+}
+
+export function messageToUIMessage(m: Message): UIMessage {
+  const parts: UIMessage["parts"] = [];
+
+  if (m.blocks && m.blocks.length > 0) {
+    for (const block of m.blocks) {
+      switch (block.type) {
+        case "text":
+          parts.push({ type: "text", text: block.text });
+          break;
+        case "thinking":
+          if (block.thinking) {
+            parts.push({ type: "reasoning", text: block.thinking, providerMetadata: {} });
+          }
+          break;
+        case "tool_call":
+          parts.push({
+            type: "dynamic-tool",
+            toolName: block.name,
+            toolCallId: block.id,
+            state: block.result ? "output-available" : "input-available",
+            input: block.arguments ?? {},
+            ...(block.result ? { output: block.result.content } : {}),
+          } as UIMessage["parts"][number]);
+          break;
+      }
+    }
+  } else if (m.content) {
+    parts.push({ type: "text", text: m.content });
+  }
+
+  return {
+    id: `${m.timestamp}-${m.role}`,
+    role: m.role === "tool" ? "assistant" : m.role,
+    parts,
+  };
+}
+
+type AnyToolPart = {
+  type: string;
+  toolCallId: string;
+  toolName: string;
+  state: string;
+  input?: unknown;
+  output?: unknown;
+  errorText?: string;
+};
+
+function isToolPart(
+  part: UIMessage["parts"][number],
+): part is AnyToolPart & UIMessage["parts"][number] {
+  return part.type === "dynamic-tool" || part.type.startsWith("tool-");
+}
+
+export function uiMessageToMessage(m: UIMessage): Message {
+  const blocks: Message["blocks"] = [];
+  let content = "";
+
+  for (const part of m.parts) {
+    switch (part.type) {
+      case "text":
+        blocks.push({ type: "text", text: part.text });
+        content += part.text;
+        break;
+      case "reasoning":
+        blocks.push({ type: "thinking", thinking: part.text });
+        break;
+      default:
+        if (isToolPart(part)) {
+          const hasOutput = part.state === "output-available" || part.state === "output-error";
+          blocks.push({
+            type: "tool_call",
+            id: part.toolCallId,
+            name: part.toolName,
+            arguments: (part.input as Record<string, unknown>) ?? {},
+            status: hasOutput ? "done" : "running",
+            ...(hasOutput
+              ? {
+                  result: {
+                    tool_call_id: part.toolCallId,
+                    content:
+                      part.state === "output-error"
+                        ? (part.errorText ?? "error")
+                        : typeof part.output === "string"
+                          ? part.output
+                          : JSON.stringify(part.output),
+                    is_error: part.state === "output-error",
+                  },
+                }
+              : {}),
+          });
+        }
+        break;
+    }
+  }
+
+  return {
+    role: m.role === "system" ? "assistant" : m.role,
+    content: content || undefined,
+    blocks: blocks.length > 0 ? blocks : undefined,
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -13,7 +13,7 @@ export interface Session {
 export interface ToolBlock {
   type: "tool_call";
   id: string;
-  name: string;
+  name?: string;
   arguments: Record<string, unknown>;
   status?: "running" | "done";
   result?: ToolResult;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -46,7 +46,6 @@ export interface Message {
   timestamp: string;
   token_count?: number;
   model?: string;
-  _streaming?: boolean;
 }
 
 export interface Agent {


### PR DESCRIPTION
## Summary

Migrate session streaming from manual SSE parsing to the AI SDK data stream protocol (`@ai-sdk/react` `useChat` hook), unifying how historical and streaming messages render.

### Server (`internal/server/sessions.go`)
- Implement AI SDK UI Message Stream v1 protocol for `SendSessionMessage`
- Emit proper typed events: `text-start/delta/end`, `reasoning-start/delta/end`, `start-step/finish-step`, `tool-input-start/available`, `tool-output-available`, `tool-output-error`
- Send `dynamic: true` on tool events so AI SDK creates `dynamic-tool` parts with explicit `toolName`
- Send real tool `Arguments` instead of summary wrapper
- Send tool output as plain string; use `tool-output-error` for error results

### Agent pipeline (`internal/agent/runner.go`, `runner_impl.go`)
- Add step boundary events (`start`/`finish`) to the event pipeline
- Add reasoning event support
- Propagate tool call IDs through the event chain
- Add `Arguments map[string]any` to `ToolUseEvent` for raw tool args

### Frontend (`web/src/`)
- Replace manual SSE `fetch` + `ReadableStream` parsing in `SessionConversation` with `useChat` + `createSessionTransport`
- Unify data path: historical messages load into `useChat` via `setChatMessages` so all messages render through single `uiMessageToMessage` pipeline
- Add `mergeToolResults()` to fold standalone `role:"tool"` messages into assistant tool_call blocks before UIMessage conversion
- Preserve metadata (timestamp, token_count, model) through `UIMessage.metadata` round-trip
- Use deterministic IDs (`hist-{timestamp}-{role}-{index}`) for stable pagination/dedup
- ID-based deduplication for pagination + streaming concurrency safety
- `extractToolName()` fallback for static tool parts (`tool-{name}` type)
- Preserve `is_error` state through `messageToUIMessage` ↔ `uiMessageToMessage` round-trip
- Simplify Transcript `processMessages` — tool merging now handled upstream
- Remove dead `_streaming` field from Message type
- Remove unused file parts from transport (files use workspace upload path)

## Test plan

- [ ] Open a session, send a message — verify text streams correctly
- [ ] Verify tool calls show name, arguments, and result during streaming
- [ ] Verify tool errors display with error styling (not as success)
- [ ] Reload page — verify historical messages render identically to streamed
- [ ] Scroll up to load older messages during active stream — no duplicates or lost messages
- [ ] Test SessionConversation in Automation and TaskBoard panels
- [ ] Verify stop button cancels streaming
- [ ] Test reasoning/thinking blocks expand correctly