### PR TITLE
Fix tenant-scoped query isolation

### DIFF
--- a/cmd/stella/commands.go
+++ b/cmd/stella/commands.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"sync"
 	"time"
@@ -36,6 +37,25 @@ import (
 	"github.com/CherryHQ/stella/resources/binaries"
 )
 
+// TODO: STELLA_SESSION_ID is not a robust sandbox indicator — add a dedicated STELLA_SANDBOX env var.
+func inSandbox() bool {
+	return os.Getenv("STELLA_SESSION_ID") != ""
+}
+
+func denyInSandbox(cmd *ucli.Command) *ucli.Command {
+	prev := cmd.Before
+	cmd.Before = func(c *ucli.Context) error {
+		if inSandbox() {
+			return fmt.Errorf("%q is a system command and cannot be run inside an agent sandbox", cmd.Name)
+		}
+		if prev != nil {
+			return prev(c)
+		}
+		return nil
+	}
+	return cmd
+}
+
 func newApp() *ucli.App {
 	return &ucli.App{
 		Name:  "stella",
@@ -46,10 +66,10 @@ server, then use the subcommands below to manage models, content,
 schedules, and more.`,
 		Version: displayVersion(),
 		Commands: []*ucli.Command{
-			serverCommand(),
+			denyInSandbox(serverCommand()),
 			skillsCommand(),
 			versionCommand(),
-			upgradeCommand(),
+			denyInSandbox(upgradeCommand()),
 			recallyCommand(),
 			schedulerCommand(),
 			emailCommand(),
@@ -57,7 +77,7 @@ schedules, and more.`,
 			oauthCommand(),
 			shareCommand(),
 			taskCommand(),
-			serviceCommand(),
+			denyInSandbox(serviceCommand()),
 		},
 	}
 }

--- a/cmd/stella/setup_skills.go
+++ b/cmd/stella/setup_skills.go
@@ -7,10 +7,21 @@ import (
 	"log/slog"
 	"path/filepath"
 
+	"github.com/CherryHQ/stella/internal/agent"
 	"github.com/CherryHQ/stella/internal/config"
 	skills "github.com/CherryHQ/stella/internal/skills"
 	"github.com/CherryHQ/stella/resources"
 )
+
+const cliSkillsUserID = "1"
+
+func cliUserSkillsDir(snap *config.Snapshot) (string, error) {
+	userDir, err := agent.SetupUserWorkspace(snap.AgentID, config.StellaHome(), cliSkillsUserID)
+	if err != nil {
+		return "", err
+	}
+	return agent.UserSkillsDir(userDir), nil
+}
 
 type skillStores struct {
 	raw      *skills.SQLiteStore

--- a/cmd/stella/skills.go
+++ b/cmd/stella/skills.go
@@ -11,8 +11,6 @@ import (
 
 	apiclient "github.com/CherryHQ/stella/api/client"
 	apitypes "github.com/CherryHQ/stella/api/types"
-	"github.com/CherryHQ/stella/internal/agent"
-	"github.com/CherryHQ/stella/internal/config"
 	skillstool "github.com/CherryHQ/stella/internal/tools/skills"
 )
 
@@ -81,16 +79,6 @@ func skillsSearchCommand() *ucli.Command {
 	}
 }
 
-const cliSkillsUserID = "1"
-
-func cliUserSkillsDir(snap *config.Snapshot) (string, error) {
-	userDir, err := agent.SetupUserWorkspace(snap.AgentID, config.StellaHome(), cliSkillsUserID)
-	if err != nil {
-		return "", err
-	}
-	return agent.UserSkillsDir(userDir), nil
-}
-
 func skillsInstallCommand() *ucli.Command {
 	return &ucli.Command{
 		Name:      "install",
@@ -105,11 +93,9 @@ func skillsInstallCommand() *ucli.Command {
 
 			fmt.Fprintf(os.Stderr, "Installing from %s...\n", source)
 
-			scope := "user"
 			result, err := apiclient.Call[map[string]string](func(api *apiclient.Client) (*http.Response, error) {
-				return api.InstallSkill(c.Context, apiclient.InstallSkillJSONRequestBody{
+				return api.InstallProfileSkill(c.Context, apiclient.InstallProfileSkillJSONRequestBody{
 					Source: source,
-					Scope:  &scope,
 				})
 			})
 			if err != nil {
@@ -232,7 +218,7 @@ func skillsRemoveCommand() *ucli.Command {
 			}
 
 			skills, err := apiclient.Call[[]apitypes.Skill](func(api *apiclient.Client) (*http.Response, error) {
-				return api.ListSkills(c.Context)
+				return api.ListProfileSkills(c.Context)
 			})
 			if err != nil {
 				return err
@@ -246,14 +232,11 @@ func skillsRemoveCommand() *ucli.Command {
 				}
 			}
 			if skill == nil {
-				return fmt.Errorf("skill %q not found", name)
-			}
-			if derefStr(skill.Scope) == "system" {
-				return fmt.Errorf("cannot remove system skill %q", name)
+				return fmt.Errorf("skill %q not found in your user skills", name)
 			}
 
 			if err := apiclient.Do(func(api *apiclient.Client) (*http.Response, error) {
-				return api.DeleteSkill(c.Context, derefStr(skill.Id))
+				return api.DeleteProfileSkill(c.Context, derefStr(skill.Id))
 			}); err != nil {
 				return err
 			}

--- a/internal/agent/pool_runner.go
+++ b/internal/agent/pool_runner.go
@@ -40,7 +40,7 @@ func (p *Pool) getOrCreateRunner(ctx context.Context, sessionID string, model st
 
 		// Restore metadata from memory provider if available.
 		if sm, ok := p.mem.(memory.SessionManager); ok {
-			if info, err := sm.LoadInfo(context.Background(), sessionID); err == nil {
+			if info, err := sm.LoadInfo(ctx, sessionID); err == nil {
 				sess.Info = info
 			} else {
 				sess.Info = SessionInfo{ID: sessionID, CreatedAt: time.Now(), LastActive: time.Now()}
@@ -96,7 +96,7 @@ func (p *Pool) getOrCreateRunner(ctx context.Context, sessionID string, model st
 
 	// Memory: bootstrap the conversation for this session.
 	memSession := memory.Session{ID: sessionID, AgentID: p.agentID, UserID: sess.Info.UserID}
-	if err := p.mem.Bootstrap(context.Background(), memSession); err != nil {
+	if err := p.mem.Bootstrap(ctx, memSession); err != nil {
 		p.log.Warn("memory bootstrap failed", "session_id", sessionID, "error", err)
 	}
 

--- a/internal/agent/pool_session.go
+++ b/internal/agent/pool_session.go
@@ -309,6 +309,7 @@ func (p *Pool) ListSessions(includeArchived bool) ([]SessionInfo, error) {
 func (p *Pool) ArchiveSession(sessionID string) error {
 	p.mu.Lock()
 	sess, ok := p.sessions[sessionID]
+	hadSession := ok
 	var r Runner
 	if ok {
 		r = sess.Runner
@@ -317,10 +318,14 @@ func (p *Pool) ArchiveSession(sessionID string) error {
 	p.mu.Unlock()
 
 	if sm, ok := p.mem.(memory.SessionManager); ok {
-		info, err := sm.LoadInfo(context.Background(), sessionID)
+		ctx := context.Background()
+		if hadSession {
+			ctx = p.sessionContext(ctx, sess.Info.UserID)
+		}
+		info, err := sm.LoadInfo(ctx, sessionID)
 		if err == nil {
 			info.Archived = true
-			if err := sm.SaveInfo(context.Background(), info); err != nil {
+			if err := sm.SaveInfo(ctx, info); err != nil {
 				p.log.Warn("failed to persist archive", "session_id", sessionID, "error", err)
 			}
 		}

--- a/internal/agent/pool_session.go
+++ b/internal/agent/pool_session.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -30,7 +31,7 @@ func (p *Pool) CreateSessionWithKind(channel, kind, projectID string, userID ...
 		sess.Info.ProjectID = projectID
 	}
 	p.mu.Unlock()
-	return p.persistNewSession(info)
+	return p.persistNewSession(context.Background(), info)
 }
 
 // createSessionLocked creates a new session and adds it to the in-memory map.
@@ -52,9 +53,10 @@ func (p *Pool) createSessionLocked(channel string, userID ...string) SessionInfo
 }
 
 // persistNewSession saves session metadata to the memory provider and logs creation.
-func (p *Pool) persistNewSession(info SessionInfo) (SessionInfo, error) {
+func (p *Pool) persistNewSession(ctx context.Context, info SessionInfo) (SessionInfo, error) {
 	if sm, ok := p.mem.(memory.SessionManager); ok {
-		if err := sm.SaveInfo(context.Background(), info); err != nil {
+		ctx = p.sessionContext(ctx, info.UserID)
+		if err := sm.SaveInfo(ctx, info); err != nil {
 			return info, fmt.Errorf("persist session info: %w", err)
 		}
 	}
@@ -62,15 +64,51 @@ func (p *Pool) persistNewSession(info SessionInfo) (SessionInfo, error) {
 	return info, nil
 }
 
+func (p *Pool) sessionContext(ctx context.Context, userID string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if userID != "" && memory.UserIDFromContext(ctx) == "" {
+		ctx = memory.WithUserID(ctx, userID)
+	}
+	if p.agentID != "" && memory.AgentIDFromContext(ctx) == "" {
+		ctx = memory.WithAgentID(ctx, p.agentID)
+	}
+	return ctx
+}
+
+func resolveUserID(userID []string) string {
+	if len(userID) == 0 {
+		return ""
+	}
+	return userID[0]
+}
+
+func isPrivateMainChannel(channel string, userID string) bool {
+	return userID != "" && !strings.Contains(channel, ":group:") && !strings.HasPrefix(channel, "task:")
+}
+
+func mainCandidate(info SessionInfo, userID string) bool {
+	if info.Archived || info.UserID != userID || info.ProjectID != "" {
+		return false
+	}
+	if info.Kind == "task" || info.Kind == "scheduler" {
+		return false
+	}
+	return isPrivateMainChannel(info.Channel, userID)
+}
+
 // activeSessionLocked returns the most recent non-archived session for a channel
 // from the in-memory map and persistent store. Caller must hold p.mu.
-func (p *Pool) activeSessionLocked(channel string) (SessionInfo, bool) {
+func (p *Pool) activeSessionLocked(ctx context.Context, channel string, userID string) (SessionInfo, bool) {
 	var best *SessionInfo
 	seen := make(map[string]struct{})
 
-	// Check in-memory sessions (have the freshest LastActive).
 	for _, sess := range p.sessions {
 		if sess.Info.Archived || sess.Info.Channel != channel {
+			continue
+		}
+		if userID != "" && sess.Info.UserID != userID {
 			continue
 		}
 		seen[sess.Info.ID] = struct{}{}
@@ -80,9 +118,8 @@ func (p *Pool) activeSessionLocked(channel string) (SessionInfo, bool) {
 		}
 	}
 
-	// Check persistent store for sessions not yet in memory.
 	if sm, ok := p.mem.(memory.SessionManager); ok {
-		items, err := sm.ListInfo(context.Background(), memory.ListOptions{})
+		items, err := sm.ListInfo(p.sessionContext(ctx, userID), memory.ListOptions{AgentID: p.agentID, UserID: userID})
 		if err == nil {
 			for _, info := range items {
 				if info.Channel != channel {
@@ -107,14 +144,15 @@ func (p *Pool) activeSessionLocked(channel string) (SessionInfo, bool) {
 
 // mainSessionLocked returns the non-archived main session from the in-memory
 // map and persistent store. Caller must hold p.mu.
-func (p *Pool) mainSessionLocked() (SessionInfo, bool) {
+func (p *Pool) mainSessionLocked(ctx context.Context, userID string) (SessionInfo, bool) {
 	for _, sess := range p.sessions {
-		if !sess.Info.Archived && sess.Info.Kind == "main" {
-			return sess.Info, true
+		if sess.Info.Archived || sess.Info.Kind != "main" || sess.Info.UserID != userID {
+			continue
 		}
+		return sess.Info, true
 	}
 	if sm, ok := p.mem.(memory.SessionManager); ok {
-		items, err := sm.ListInfo(context.Background(), memory.ListOptions{Kind: "main"})
+		items, err := sm.ListInfo(p.sessionContext(ctx, userID), memory.ListOptions{Kind: "main", AgentID: p.agentID, UserID: userID})
 		if err == nil {
 			for _, info := range items {
 				return info, true
@@ -124,13 +162,13 @@ func (p *Pool) mainSessionLocked() (SessionInfo, bool) {
 	return SessionInfo{}, false
 }
 
-// latestSessionLocked returns the most recent non-archived session across all
-// channels. Caller must hold p.mu.
-func (p *Pool) latestSessionLocked() (SessionInfo, bool) {
+// latestSessionLocked returns the most recent non-archived private session for a user.
+// Caller must hold p.mu.
+func (p *Pool) latestSessionLocked(ctx context.Context, userID string) (SessionInfo, bool) {
 	var best *SessionInfo
 	seen := make(map[string]struct{})
 	for _, sess := range p.sessions {
-		if sess.Info.Archived {
+		if !mainCandidate(sess.Info, userID) {
 			continue
 		}
 		seen[sess.Info.ID] = struct{}{}
@@ -140,10 +178,10 @@ func (p *Pool) latestSessionLocked() (SessionInfo, bool) {
 		}
 	}
 	if sm, ok := p.mem.(memory.SessionManager); ok {
-		items, err := sm.ListInfo(context.Background(), memory.ListOptions{})
+		items, err := sm.ListInfo(p.sessionContext(ctx, userID), memory.ListOptions{AgentID: p.agentID, UserID: userID})
 		if err == nil {
 			for _, info := range items {
-				if _, inSeen := seen[info.ID]; inSeen {
+				if _, inSeen := seen[info.ID]; inSeen || !mainCandidate(info, userID) {
 					continue
 				}
 				if best == nil || info.LastActive.After(best.LastActive) {
@@ -160,60 +198,72 @@ func (p *Pool) latestSessionLocked() (SessionInfo, bool) {
 }
 
 // ActiveSession returns the most recent non-archived session for a channel.
-func (p *Pool) ActiveSession(channel string) (SessionInfo, bool) {
+func (p *Pool) ActiveSession(channel string, userID ...string) (SessionInfo, bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	return p.activeSessionLocked(channel)
+	return p.activeSessionLocked(context.Background(), channel, resolveUserID(userID))
 }
 
-// ResolveSession returns the main session for a channel, creating or promoting one if needed.
-// An optional userID associates the session with a user (stored in conversations table).
+// ResolveSession returns the session for a channel, creating or promoting one if needed.
+// Private user channels resolve to a per-agent/user main session. Group and other
+// shared channels resolve by exact channel and remain chat sessions.
 func (p *Pool) ResolveSession(ctx context.Context, channel string, userID ...string) (SessionInfo, error) {
+	uid := resolveUserID(userID)
+	ctx = p.sessionContext(ctx, uid)
+	privateMain := isPrivateMainChannel(channel, uid)
+
 	p.mu.Lock()
 
-	// 1. Look for an existing main session.
-	if info, ok := p.mainSessionLocked(); ok {
+	if privateMain {
+		if info, ok := p.mainSessionLocked(ctx, uid); ok {
+			p.mu.Unlock()
+			return info, nil
+		}
+
+		if info, ok := p.latestSessionLocked(ctx, uid); ok {
+			info.Kind = "main"
+			if sess, exists := p.sessions[info.ID]; exists {
+				sess.Info.Kind = "main"
+			}
+			ensurer := p.projectEnsurer
+			p.mu.Unlock()
+			if ensurer != nil && info.UserID != "" {
+				if _, err := ensurer(ctx, p.agentID, info.UserID); err != nil {
+					p.log.Warn("project ensurer failed", "agent_id", p.agentID, "user_id", info.UserID, "error", err)
+				}
+			}
+			return p.persistNewSession(ctx, info)
+		}
+	} else if info, ok := p.activeSessionLocked(ctx, channel, uid); ok {
 		p.mu.Unlock()
 		return info, nil
 	}
 
-	// 2. Promote the latest active session (any channel) to main.
-	if info, ok := p.latestSessionLocked(); ok {
-		info.Kind = "main"
-		if sess, exists := p.sessions[info.ID]; exists {
-			sess.Info.Kind = "main"
-		}
-		ensurer := p.projectEnsurer
-		p.mu.Unlock()
-		if ensurer != nil && info.UserID != "" {
-			if _, err := ensurer(ctx, p.agentID, info.UserID); err != nil {
-				p.log.Warn("project ensurer failed", "agent_id", p.agentID, "user_id", info.UserID, "error", err)
-			}
-		}
-		return p.persistNewSession(info)
-	}
-
-	// 3. Create a new main session.
 	info := p.createSessionLocked(channel, userID...)
-	info.Kind = "main"
+	if privateMain {
+		info.Kind = "main"
+	} else {
+		info.Kind = "chat"
+	}
 	if sess, exists := p.sessions[info.ID]; exists {
-		sess.Info.Kind = "main"
+		sess.Info.Kind = info.Kind
 	}
 	ensurer := p.projectEnsurer
 	p.mu.Unlock()
 
-	if ensurer != nil && info.UserID != "" {
+	if privateMain && ensurer != nil && info.UserID != "" {
 		if _, err := ensurer(ctx, p.agentID, info.UserID); err != nil {
 			p.log.Warn("project ensurer failed", "agent_id", p.agentID, "user_id", info.UserID, "error", err)
 		}
 	}
 
-	return p.persistNewSession(info)
+	return p.persistNewSession(ctx, info)
 }
 
 // RotateSession archives the active session for a channel (if any) and creates a new one.
 func (p *Pool) RotateSession(channel string, userID ...string) (SessionInfo, error) {
-	if old, ok := p.ActiveSession(channel); ok {
+	uid := resolveUserID(userID)
+	if old, ok := p.ActiveSession(channel, uid); ok {
 		if err := p.ArchiveSession(old.ID); err != nil {
 			p.log.Warn("archive failed during rotate", "session_id", old.ID, "error", err)
 		}

--- a/internal/agent/pool_session.go
+++ b/internal/agent/pool_session.go
@@ -85,7 +85,7 @@ func resolveUserID(userID []string) string {
 }
 
 func isPrivateMainChannel(channel string, userID string) bool {
-	return userID != "" && !strings.Contains(channel, ":group:") && !strings.HasPrefix(channel, "task:")
+	return userID != "" && strings.Contains(channel, ":user:")
 }
 
 func mainCandidate(info SessionInfo, userID string) bool {

--- a/internal/agent/pool_test.go
+++ b/internal/agent/pool_test.go
@@ -613,6 +613,78 @@ func TestPoolResolveSession(t *testing.T) {
 	}
 }
 
+func TestPoolResolveSessionTwoUsersSameAgent(t *testing.T) {
+	factory, _ := mockRunnerFactory(nil)
+	pool := NewPool(factory, testMemoryProvider(t), WithAgentID("agentA"))
+	defer func() { _ = pool.Close() }()
+
+	ctxA := memory.WithAgentID(memory.WithUserID(context.Background(), "userA"), "agentA")
+	ctxB := memory.WithAgentID(memory.WithUserID(context.Background(), "userB"), "agentA")
+
+	sessionA, err := pool.ResolveSession(ctxA, "agentA:user:userA:private", "userA")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessionB, err := pool.ResolveSession(ctxB, "agentA:user:userB:private", "userB")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sessionA.ID == sessionB.ID {
+		t.Fatalf("expected different sessions for different users, got %q", sessionA.ID)
+	}
+	if sessionA.UserID != "userA" {
+		t.Errorf("sessionA user = %q, want userA", sessionA.UserID)
+	}
+	if sessionB.UserID != "userB" {
+		t.Errorf("sessionB user = %q, want userB", sessionB.UserID)
+	}
+
+	againA, err := pool.ResolveSession(ctxA, "agentA:user:userA:private", "userA")
+	if err != nil {
+		t.Fatal(err)
+	}
+	againB, err := pool.ResolveSession(ctxB, "agentA:user:userB:private", "userB")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if againA.ID != sessionA.ID {
+		t.Errorf("userA resolve = %q, want %q", againA.ID, sessionA.ID)
+	}
+	if againB.ID != sessionB.ID {
+		t.Errorf("userB resolve = %q, want %q", againB.ID, sessionB.ID)
+	}
+}
+
+func TestPoolResolveSessionGroupDoesNotUsePrivateMain(t *testing.T) {
+	factory, _ := mockRunnerFactory(nil)
+	pool := NewPool(factory, testMemoryProvider(t), WithAgentID("agentA"))
+	defer func() { _ = pool.Close() }()
+
+	ctx := memory.WithAgentID(memory.WithUserID(context.Background(), "userA"), "agentA")
+	privateSession, err := pool.ResolveSession(ctx, "agentA:user:userA:private", "userA")
+	if err != nil {
+		t.Fatal(err)
+	}
+	groupSession, err := pool.ResolveSession(ctx, "agentA:telegram:externalA:group:chat1", "userA")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if groupSession.ID == privateSession.ID {
+		t.Fatal("group session reused private main session")
+	}
+	if groupSession.Kind != "chat" {
+		t.Errorf("group session kind = %q, want chat", groupSession.Kind)
+	}
+
+	againGroup, err := pool.ResolveSession(ctx, "agentA:telegram:externalA:group:chat1", "userA")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if againGroup.ID != groupSession.ID {
+		t.Errorf("group resolve = %q, want %q", againGroup.ID, groupSession.ID)
+	}
+}
+
 func TestPoolRotateSession(t *testing.T) {
 	factory, _ := mockRunnerFactory([]Event{{Text: "ok"}})
 	pool := NewPool(factory, testMemoryProvider(t))
@@ -726,16 +798,16 @@ func TestPoolActiveSessionIgnoresLegacySessions(t *testing.T) {
 		t.Error("legacy session with empty Channel should not match 'cli'")
 	}
 
-	// ResolveSession promotes the latest session to main.
+	// ResolveSession should not promote legacy sessions without user/channel scope.
 	info, err := pool.ResolveSession(context.Background(), "cli")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if info.ID != "legacy-abc" {
-		t.Errorf("expected legacy session to be promoted, got %q", info.ID)
+	if info.ID == "legacy-abc" {
+		t.Error("legacy session should not be promoted")
 	}
-	if info.Kind != "main" {
-		t.Errorf("Kind = %q, want main", info.Kind)
+	if info.Channel != "cli" {
+		t.Errorf("Channel = %q, want cli", info.Channel)
 	}
 }
 

--- a/internal/agent/pool_test.go
+++ b/internal/agent/pool_test.go
@@ -685,6 +685,36 @@ func TestPoolResolveSessionGroupDoesNotUsePrivateMain(t *testing.T) {
 	}
 }
 
+func TestPoolResolveSessionNonUserChannelDoesNotUsePrivateMain(t *testing.T) {
+	factory, _ := mockRunnerFactory(nil)
+	pool := NewPool(factory, testMemoryProvider(t), WithAgentID("agentA"))
+	defer func() { _ = pool.Close() }()
+
+	ctx := memory.WithAgentID(memory.WithUserID(context.Background(), "userA"), "agentA")
+	privateSession, err := pool.ResolveSession(ctx, "agentA:user:userA:private", "userA")
+	if err != nil {
+		t.Fatal(err)
+	}
+	jobSession, err := pool.ResolveSession(ctx, "agentA:scheduler:job1", "userA")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if jobSession.ID == privateSession.ID {
+		t.Fatal("non-user channel reused private main session")
+	}
+	if jobSession.Kind != "chat" {
+		t.Errorf("job session kind = %q, want chat", jobSession.Kind)
+	}
+
+	againJob, err := pool.ResolveSession(ctx, "agentA:scheduler:job1", "userA")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if againJob.ID != jobSession.ID {
+		t.Errorf("job resolve = %q, want %q", againJob.ID, jobSession.ID)
+	}
+}
+
 func TestPoolRotateSession(t *testing.T) {
 	factory, _ := mockRunnerFactory([]Event{{Text: "ok"}})
 	pool := NewPool(factory, testMemoryProvider(t))

--- a/internal/db/queries/agent_task.sql
+++ b/internal/db/queries/agent_task.sql
@@ -7,7 +7,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 RETURNING *;
 
 -- name: GetAgentTask :one
-SELECT * FROM agent_task WHERE id = ?;
+SELECT * FROM agent_task WHERE id = ? AND user_id = ?;
 
 -- name: ListAgentTasksByUser :many
 SELECT * FROM agent_task WHERE user_id = ? ORDER BY created_at DESC;
@@ -32,32 +32,32 @@ ORDER BY notify_at ASC;
 -- name: UpdateAgentTask :exec
 UPDATE agent_task
 SET title = ?, description = ?, priority = ?, agent_id = ?, updated_at = ?
-WHERE id = ?;
+WHERE id = ? AND user_id = ?;
 
 -- name: UpdateAgentTaskStatus :exec
 UPDATE agent_task
 SET status = ?, updated_at = ?
-WHERE id = ?;
+WHERE id = ? AND user_id = ?;
 
 -- name: UpdateAgentTaskStatusFrom :exec
 UPDATE agent_task
 SET status = ?, updated_at = ?
-WHERE id = ? AND status = ?;
+WHERE id = ? AND user_id = ? AND status = ?;
 
 -- name: UpdateAgentTaskContext :exec
 UPDATE agent_task
 SET context = ?, updated_at = ?
-WHERE id = ?;
+WHERE id = ? AND user_id = ?;
 
 -- name: UpdateAgentTaskReviewRequest :exec
 UPDATE agent_task
 SET review_request = ?, updated_at = ?
-WHERE id = ?;
+WHERE id = ? AND user_id = ?;
 
 -- name: UpdateAgentTaskNotifyAt :exec
 UPDATE agent_task
 SET notify_at = ?, updated_at = ?
-WHERE id = ?;
+WHERE id = ? AND user_id = ?;
 
 -- name: DeleteAgentTask :exec
-DELETE FROM agent_task WHERE id = ?;
+DELETE FROM agent_task WHERE id = ? AND user_id = ?;

--- a/internal/db/queries/articles.sql
+++ b/internal/db/queries/articles.sql
@@ -8,7 +8,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 RETURNING *;
 
 -- name: GetArticle :one
-SELECT * FROM articles WHERE id = ?;
+SELECT * FROM articles WHERE id = ? AND user_id = ?;
 
 -- name: GetArticleByCanonicalURL :one
 SELECT * FROM articles WHERE user_id = ? AND canonical_url = ?;
@@ -35,11 +35,11 @@ SET title       = sqlc.arg('title'),
     published_at = sqlc.arg('published_at'),
     read_at     = sqlc.arg('read_at'),
     updated_at  = datetime('now')
-WHERE id = sqlc.arg('id')
+WHERE id = sqlc.arg('id') AND user_id = sqlc.arg('user_id')
 RETURNING *;
 
 -- name: DeleteArticle :exec
-DELETE FROM articles WHERE id = ?;
+DELETE FROM articles WHERE id = ? AND user_id = ?;
 
 -- name: SearchArticles :many
 -- Phase 1 MVP: LIKE-based search. Upgrade to FTS5 in future phase.

--- a/internal/db/queries/ctx_conversations.sql
+++ b/internal/db/queries/ctx_conversations.sql
@@ -1,48 +1,62 @@
 -- name: CreateConversation :one
-INSERT INTO ctx_conversations (id, session_id, title)
-VALUES (?, ?, ?)
-RETURNING *;
-
--- name: GetConversation :one
-SELECT * FROM ctx_conversations WHERE id = ?;
-
--- name: GetConversationBySessionID :one
-SELECT * FROM ctx_conversations WHERE session_id = ?;
-
--- name: UpdateConversationTitle :exec
-UPDATE ctx_conversations SET title = ?, updated_at = datetime('now') WHERE id = ?;
-
--- name: UpdateConversationBootstrapped :exec
-UPDATE ctx_conversations SET bootstrapped_at = datetime('now'), updated_at = datetime('now') WHERE id = ?;
-
--- name: CreateConversationFull :one
 INSERT INTO ctx_conversations (id, session_id, title, channel, kind, project_id, archived, last_active, agent_id, user_id)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 RETURNING *;
 
--- name: UpdateConversationAgentUser :exec
-UPDATE ctx_conversations SET agent_id = ?, user_id = ?, updated_at = datetime('now') WHERE session_id = ?;
+-- name: GetConversation :one
+SELECT * FROM ctx_conversations
+WHERE id = sqlc.arg(id)
+  AND (sqlc.narg(user_id) IS NULL OR user_id = sqlc.narg(user_id))
+  AND (sqlc.narg(agent_id) IS NULL OR agent_id = sqlc.narg(agent_id));
+
+-- name: GetConversationBySessionID :one
+SELECT * FROM ctx_conversations
+WHERE session_id = sqlc.arg(session_id)
+  AND (sqlc.narg(user_id) IS NULL OR user_id = sqlc.narg(user_id));
+
+-- name: UpdateConversationTitle :exec
+UPDATE ctx_conversations SET title = sqlc.arg(title), updated_at = datetime('now')
+WHERE id = sqlc.arg(id) AND (sqlc.narg(user_id) IS NULL OR user_id = sqlc.narg(user_id));
+
+-- name: UpdateConversationBootstrapped :exec
+UPDATE ctx_conversations SET bootstrapped_at = datetime('now'), updated_at = datetime('now')
+WHERE id = sqlc.arg(id) AND (sqlc.narg(user_id) IS NULL OR user_id = sqlc.narg(user_id));
 
 -- name: UpdateConversationArchived :exec
-UPDATE ctx_conversations SET archived = ?, updated_at = datetime('now') WHERE session_id = ?;
+UPDATE ctx_conversations SET archived = sqlc.arg(archived), updated_at = datetime('now')
+WHERE session_id = sqlc.arg(session_id) AND (sqlc.narg(user_id) IS NULL OR user_id = sqlc.narg(user_id));
 
 -- name: UpdateConversationLastActive :exec
-UPDATE ctx_conversations SET last_active = datetime('now'), updated_at = datetime('now') WHERE session_id = ?;
+UPDATE ctx_conversations SET last_active = datetime('now'), updated_at = datetime('now')
+WHERE session_id = sqlc.arg(session_id) AND (sqlc.narg(user_id) IS NULL OR user_id = sqlc.narg(user_id));
 
 -- name: UpdateConversationTitleBySessionID :exec
-UPDATE ctx_conversations SET title = ?, updated_at = datetime('now') WHERE session_id = ?;
+UPDATE ctx_conversations SET title = sqlc.arg(title), updated_at = datetime('now')
+WHERE session_id = sqlc.arg(session_id) AND (sqlc.narg(user_id) IS NULL OR user_id = sqlc.narg(user_id));
 
 -- name: ListConversations :many
-SELECT * FROM ctx_conversations WHERE archived = 0 ORDER BY last_active DESC;
+SELECT * FROM ctx_conversations
+WHERE (sqlc.narg(user_id) IS NULL OR user_id = sqlc.narg(user_id))
+  AND (sqlc.narg(agent_id) IS NULL OR agent_id = sqlc.narg(agent_id))
+  AND archived = 0
+ORDER BY last_active DESC;
 
 -- name: ListConversationsAll :many
-SELECT * FROM ctx_conversations ORDER BY last_active DESC;
+SELECT * FROM ctx_conversations
+WHERE (sqlc.narg(user_id) IS NULL OR user_id = sqlc.narg(user_id))
+  AND (sqlc.narg(agent_id) IS NULL OR agent_id = sqlc.narg(agent_id))
+ORDER BY last_active DESC;
 
 -- name: ListConversationsByKind :many
 SELECT * FROM ctx_conversations WHERE agent_id = ? AND user_id = ? AND kind = ? AND archived = 0 ORDER BY last_active DESC;
 
 -- name: GetMainConversationByProject :one
-SELECT * FROM ctx_conversations WHERE project_id = ? AND kind = 'main' AND archived = 0 LIMIT 1;
+SELECT * FROM ctx_conversations
+WHERE project_id = ?
+  AND (sqlc.narg(user_id) IS NULL OR user_id = sqlc.narg(user_id))
+  AND (sqlc.narg(agent_id) IS NULL OR agent_id = sqlc.narg(agent_id))
+  AND kind = 'main' AND archived = 0 LIMIT 1;
 
 -- name: UpdateConversationKindProject :exec
-UPDATE ctx_conversations SET kind = ?, project_id = ?, updated_at = datetime('now') WHERE session_id = ?;
+UPDATE ctx_conversations SET kind = sqlc.arg(kind), project_id = sqlc.arg(project_id), updated_at = datetime('now')
+WHERE session_id = sqlc.arg(session_id) AND (sqlc.narg(user_id) IS NULL OR user_id = sqlc.narg(user_id));

--- a/internal/db/queries/ctx_conversations.sql
+++ b/internal/db/queries/ctx_conversations.sql
@@ -6,44 +6,44 @@ RETURNING *;
 -- name: GetConversation :one
 SELECT * FROM ctx_conversations
 WHERE id = sqlc.arg(id)
-  AND (sqlc.narg(user_id) IS NULL OR user_id = sqlc.narg(user_id))
-  AND (sqlc.narg(agent_id) IS NULL OR agent_id = sqlc.narg(agent_id));
+  AND user_id = sqlc.arg(user_id)
+  AND agent_id = sqlc.arg(agent_id);
 
 -- name: GetConversationBySessionID :one
 SELECT * FROM ctx_conversations
 WHERE session_id = sqlc.arg(session_id)
-  AND (sqlc.narg(user_id) IS NULL OR user_id = sqlc.narg(user_id));
+  AND user_id = sqlc.arg(user_id);
 
 -- name: UpdateConversationTitle :exec
 UPDATE ctx_conversations SET title = sqlc.arg(title), updated_at = datetime('now')
-WHERE id = sqlc.arg(id) AND (sqlc.narg(user_id) IS NULL OR user_id = sqlc.narg(user_id));
+WHERE id = sqlc.arg(id) AND user_id = sqlc.arg(user_id);
 
 -- name: UpdateConversationBootstrapped :exec
 UPDATE ctx_conversations SET bootstrapped_at = datetime('now'), updated_at = datetime('now')
-WHERE id = sqlc.arg(id) AND (sqlc.narg(user_id) IS NULL OR user_id = sqlc.narg(user_id));
+WHERE id = sqlc.arg(id) AND user_id = sqlc.arg(user_id);
 
 -- name: UpdateConversationArchived :exec
 UPDATE ctx_conversations SET archived = sqlc.arg(archived), updated_at = datetime('now')
-WHERE session_id = sqlc.arg(session_id) AND (sqlc.narg(user_id) IS NULL OR user_id = sqlc.narg(user_id));
+WHERE session_id = sqlc.arg(session_id) AND user_id = sqlc.arg(user_id);
 
 -- name: UpdateConversationLastActive :exec
 UPDATE ctx_conversations SET last_active = datetime('now'), updated_at = datetime('now')
-WHERE session_id = sqlc.arg(session_id) AND (sqlc.narg(user_id) IS NULL OR user_id = sqlc.narg(user_id));
+WHERE session_id = sqlc.arg(session_id) AND user_id = sqlc.arg(user_id);
 
 -- name: UpdateConversationTitleBySessionID :exec
 UPDATE ctx_conversations SET title = sqlc.arg(title), updated_at = datetime('now')
-WHERE session_id = sqlc.arg(session_id) AND (sqlc.narg(user_id) IS NULL OR user_id = sqlc.narg(user_id));
+WHERE session_id = sqlc.arg(session_id) AND user_id = sqlc.arg(user_id);
 
 -- name: ListConversations :many
 SELECT * FROM ctx_conversations
-WHERE (sqlc.narg(user_id) IS NULL OR user_id = sqlc.narg(user_id))
+WHERE user_id = sqlc.arg(user_id)
   AND (sqlc.narg(agent_id) IS NULL OR agent_id = sqlc.narg(agent_id))
   AND archived = 0
 ORDER BY last_active DESC;
 
 -- name: ListConversationsAll :many
 SELECT * FROM ctx_conversations
-WHERE (sqlc.narg(user_id) IS NULL OR user_id = sqlc.narg(user_id))
+WHERE user_id = sqlc.arg(user_id)
   AND (sqlc.narg(agent_id) IS NULL OR agent_id = sqlc.narg(agent_id))
 ORDER BY last_active DESC;
 
@@ -52,11 +52,11 @@ SELECT * FROM ctx_conversations WHERE agent_id = ? AND user_id = ? AND kind = ? 
 
 -- name: GetMainConversationByProject :one
 SELECT * FROM ctx_conversations
-WHERE project_id = ?
-  AND (sqlc.narg(user_id) IS NULL OR user_id = sqlc.narg(user_id))
-  AND (sqlc.narg(agent_id) IS NULL OR agent_id = sqlc.narg(agent_id))
+WHERE project_id = sqlc.arg(project_id)
+  AND user_id = sqlc.arg(user_id)
+  AND agent_id = sqlc.arg(agent_id)
   AND kind = 'main' AND archived = 0 LIMIT 1;
 
 -- name: UpdateConversationKindProject :exec
 UPDATE ctx_conversations SET kind = sqlc.arg(kind), project_id = sqlc.arg(project_id), updated_at = datetime('now')
-WHERE session_id = sqlc.arg(session_id) AND (sqlc.narg(user_id) IS NULL OR user_id = sqlc.narg(user_id));
+WHERE session_id = sqlc.arg(session_id) AND user_id = sqlc.arg(user_id);

--- a/internal/db/queries/ctx_conversations.sql
+++ b/internal/db/queries/ctx_conversations.sql
@@ -14,6 +14,17 @@ SELECT * FROM ctx_conversations
 WHERE session_id = sqlc.arg(session_id)
   AND user_id = sqlc.arg(user_id);
 
+-- name: GetUnownedConversationBySessionID :one
+SELECT * FROM ctx_conversations
+WHERE session_id = sqlc.arg(session_id)
+  AND user_id IS NULL;
+
+-- name: ClaimConversationUserBySessionID :exec
+UPDATE ctx_conversations
+SET user_id = sqlc.arg(user_id), updated_at = datetime('now')
+WHERE session_id = sqlc.arg(session_id)
+  AND user_id IS NULL;
+
 -- name: UpdateConversationTitle :exec
 UPDATE ctx_conversations SET title = sqlc.arg(title), updated_at = datetime('now')
 WHERE id = sqlc.arg(id) AND user_id = sqlc.arg(user_id);

--- a/internal/db/queries/ctx_conversations.sql
+++ b/internal/db/queries/ctx_conversations.sql
@@ -14,17 +14,6 @@ SELECT * FROM ctx_conversations
 WHERE session_id = sqlc.arg(session_id)
   AND user_id = sqlc.arg(user_id);
 
--- name: GetUnownedConversationBySessionID :one
-SELECT * FROM ctx_conversations
-WHERE session_id = sqlc.arg(session_id)
-  AND user_id IS NULL;
-
--- name: ClaimConversationUserBySessionID :exec
-UPDATE ctx_conversations
-SET user_id = sqlc.arg(user_id), updated_at = datetime('now')
-WHERE session_id = sqlc.arg(session_id)
-  AND user_id IS NULL;
-
 -- name: UpdateConversationTitle :exec
 UPDATE ctx_conversations SET title = sqlc.arg(title), updated_at = datetime('now')
 WHERE id = sqlc.arg(id) AND user_id = sqlc.arg(user_id);

--- a/internal/db/queries/rss_feeds.sql
+++ b/internal/db/queries/rss_feeds.sql
@@ -7,7 +7,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 RETURNING *;
 
 -- name: GetRSSFeed :one
-SELECT * FROM rss_feeds WHERE id = ?;
+SELECT * FROM rss_feeds WHERE id = ? AND user_id = ?;
 
 -- name: GetRSSFeedByURL :one
 SELECT * FROM rss_feeds WHERE user_id = ? AND url = ?;
@@ -27,11 +27,11 @@ SET title           = sqlc.arg('title'),
     last_modified   = sqlc.arg('last_modified'),
     enabled         = sqlc.arg('enabled'),
     updated_at      = datetime('now')
-WHERE id = sqlc.arg('id')
+WHERE id = sqlc.arg('id') AND user_id = sqlc.arg('user_id')
 RETURNING *;
 
 -- name: DeleteRSSFeed :exec
-DELETE FROM rss_feeds WHERE id = ?;
+DELETE FROM rss_feeds WHERE id = ? AND user_id = ?;
 
 -- name: CreateRSSFeedEntry :one
 INSERT INTO rss_feed_entries (

--- a/internal/db/queries/skills.sql
+++ b/internal/db/queries/skills.sql
@@ -4,7 +4,9 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 RETURNING *;
 
 -- name: GetSkill :one
-SELECT * FROM skills WHERE id = ?;
+SELECT * FROM skills
+WHERE id = sqlc.arg(id)
+  AND ((sqlc.narg(agent_id) IS NULL AND sqlc.narg(user_id) IS NULL) OR scope='system' OR (scope='agent' AND agent_id=sqlc.narg(agent_id)) OR (scope='user' AND user_id=sqlc.narg(user_id)));
 
 -- name: ListSkillsVisible :many
 SELECT * FROM skills
@@ -37,15 +39,22 @@ LIMIT 1;
 
 -- name: UpdateSkillMetadata :exec
 UPDATE skills
-SET description              = ?,
-    status                   = ?,
-    disable_model_invocation = ?,
-    metadata                 = ?,
+SET description              = sqlc.arg(description),
+    status                   = sqlc.arg(status),
+    disable_model_invocation = sqlc.arg(disable_model_invocation),
+    metadata                 = sqlc.arg(metadata),
     updated_at               = datetime('now')
-WHERE id = ?;
+WHERE id = sqlc.arg(id)
+  AND ((sqlc.narg(agent_id) IS NULL AND sqlc.narg(user_id) IS NULL)
+    OR (scope='agent' AND agent_id=sqlc.narg(agent_id))
+    OR (scope='user' AND user_id=sqlc.narg(user_id)));
 
 -- name: DeleteSkill :exec
-DELETE FROM skills WHERE id = ?;
+DELETE FROM skills
+WHERE id = sqlc.arg(id)
+  AND ((sqlc.narg(agent_id) IS NULL AND sqlc.narg(user_id) IS NULL)
+    OR (scope='agent' AND agent_id=sqlc.narg(agent_id))
+    OR (scope='user' AND user_id=sqlc.narg(user_id)));
 
 -- name: UpsertSkillFile :exec
 INSERT INTO skill_files (skill_id, path, content)

--- a/internal/db/queries/skills.sql
+++ b/internal/db/queries/skills.sql
@@ -45,16 +45,26 @@ SET description              = sqlc.arg(description),
     metadata                 = sqlc.arg(metadata),
     updated_at               = datetime('now')
 WHERE id = sqlc.arg(id)
-  AND ((sqlc.narg(agent_id) IS NULL AND sqlc.narg(user_id) IS NULL)
-    OR (scope='agent' AND agent_id=sqlc.narg(agent_id))
+  AND ((scope='agent' AND agent_id=sqlc.narg(agent_id))
     OR (scope='user' AND user_id=sqlc.narg(user_id)));
 
 -- name: DeleteSkill :exec
 DELETE FROM skills
 WHERE id = sqlc.arg(id)
-  AND ((sqlc.narg(agent_id) IS NULL AND sqlc.narg(user_id) IS NULL)
-    OR (scope='agent' AND agent_id=sqlc.narg(agent_id))
+  AND ((scope='agent' AND agent_id=sqlc.narg(agent_id))
     OR (scope='user' AND user_id=sqlc.narg(user_id)));
+
+-- name: UpdateSystemSkillMetadata :exec
+UPDATE skills
+SET description              = sqlc.arg(description),
+    status                   = sqlc.arg(status),
+    disable_model_invocation = sqlc.arg(disable_model_invocation),
+    metadata                 = sqlc.arg(metadata),
+    updated_at               = datetime('now')
+WHERE id = sqlc.arg(id) AND scope = 'system';
+
+-- name: DeleteSystemSkill :exec
+DELETE FROM skills WHERE id = ? AND scope = 'system';
 
 -- name: UpsertSkillFile :exec
 INSERT INTO skill_files (skill_id, path, content)

--- a/internal/memory/lcm/engine.go
+++ b/internal/memory/lcm/engine.go
@@ -68,7 +68,7 @@ func (p *Provider) getOrCreateConversation(ctx context.Context, session memory.S
 	}
 	p.globalMu.Unlock()
 
-	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: session.ID, UserID: sql.NullString{String: session.UserID, Valid: session.UserID != ""}})
+	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: session.ID, UserID: sql.NullString{String: session.UserID, Valid: true}})
 	if err == nil {
 		p.cacheConvID(session.ID, conv.ID)
 		return conv.ID, nil
@@ -84,7 +84,7 @@ func (p *Provider) getOrCreateConversation(ctx context.Context, session memory.S
 		Channel:    session.Channel,
 		Kind:       "chat",
 		AgentID:    sql.NullString{String: session.AgentID, Valid: session.AgentID != ""},
-		UserID:     sql.NullString{String: session.UserID, Valid: session.UserID != ""},
+		UserID:     sql.NullString{String: session.UserID, Valid: true},
 		LastActive: now,
 	})
 	if err != nil {

--- a/internal/memory/lcm/engine.go
+++ b/internal/memory/lcm/engine.go
@@ -68,7 +68,7 @@ func (p *Provider) getOrCreateConversation(ctx context.Context, session memory.S
 	}
 	p.globalMu.Unlock()
 
-	conv, err := p.q.GetConversationBySessionID(ctx, session.ID)
+	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: session.ID, UserID: sql.NullString{String: session.UserID, Valid: session.UserID != ""}})
 	if err == nil {
 		p.cacheConvID(session.ID, conv.ID)
 		return conv.ID, nil
@@ -78,7 +78,7 @@ func (p *Provider) getOrCreateConversation(ctx context.Context, session memory.S
 	}
 
 	now := time.Now().UTC().Format("2006-01-02 15:04:05")
-	conv, err = p.q.CreateConversationFull(ctx, sqlc.CreateConversationFullParams{
+	conv, err = p.q.CreateConversation(ctx, sqlc.CreateConversationParams{
 		ID:         uuid.NewString(),
 		SessionID:  session.ID,
 		Channel:    session.Channel,

--- a/internal/memory/lcm/engine.go
+++ b/internal/memory/lcm/engine.go
@@ -69,18 +69,6 @@ func (p *Provider) getOrCreateConversation(ctx context.Context, session memory.S
 	p.globalMu.Unlock()
 
 	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: session.ID, UserID: sql.NullString{String: session.UserID, Valid: true}})
-	if errors.Is(err, sql.ErrNoRows) {
-		legacy, legacyErr := p.q.GetUnownedConversationBySessionID(ctx, session.ID)
-		if legacyErr == nil {
-			if err := p.q.ClaimConversationUserBySessionID(ctx, sqlc.ClaimConversationUserBySessionIDParams{SessionID: session.ID, UserID: sql.NullString{String: session.UserID, Valid: true}}); err != nil {
-				return "", fmt.Errorf("claim conversation user: %w", err)
-			}
-			conv = legacy
-			err = nil
-		} else if !errors.Is(legacyErr, sql.ErrNoRows) {
-			return "", fmt.Errorf("get unowned conversation: %w", legacyErr)
-		}
-	}
 	if err == nil {
 		p.cacheConvID(session.ID, conv.ID)
 		return conv.ID, nil

--- a/internal/memory/lcm/engine.go
+++ b/internal/memory/lcm/engine.go
@@ -69,6 +69,18 @@ func (p *Provider) getOrCreateConversation(ctx context.Context, session memory.S
 	p.globalMu.Unlock()
 
 	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: session.ID, UserID: sql.NullString{String: session.UserID, Valid: true}})
+	if errors.Is(err, sql.ErrNoRows) {
+		legacy, legacyErr := p.q.GetUnownedConversationBySessionID(ctx, session.ID)
+		if legacyErr == nil {
+			if err := p.q.ClaimConversationUserBySessionID(ctx, sqlc.ClaimConversationUserBySessionIDParams{SessionID: session.ID, UserID: sql.NullString{String: session.UserID, Valid: true}}); err != nil {
+				return "", fmt.Errorf("claim conversation user: %w", err)
+			}
+			conv = legacy
+			err = nil
+		} else if !errors.Is(legacyErr, sql.ErrNoRows) {
+			return "", fmt.Errorf("get unowned conversation: %w", legacyErr)
+		}
+	}
 	if err == nil {
 		p.cacheConvID(session.ID, conv.ID)
 		return conv.ID, nil

--- a/internal/memory/lcm/provider.go
+++ b/internal/memory/lcm/provider.go
@@ -164,7 +164,7 @@ func (p *Provider) Assemble(ctx context.Context, session memory.Session, budget,
 
 // Stats implements memory.Provider.
 func (p *Provider) Stats(ctx context.Context, session memory.Session) (memory.SessionStats, error) {
-	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: session.ID, UserID: sql.NullString{String: session.UserID, Valid: session.UserID != ""}})
+	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: session.ID, UserID: sql.NullString{String: session.UserID, Valid: true}})
 	if errors.Is(err, sql.ErrNoRows) {
 		return memory.SessionStats{}, nil
 	}
@@ -209,7 +209,7 @@ func (p *Provider) Close() error {
 
 // NeedsCompaction implements memory.Compactor.
 func (p *Provider) NeedsCompaction(ctx context.Context, session memory.Session, threshold float64) bool {
-	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: session.ID, UserID: sql.NullString{String: session.UserID, Valid: session.UserID != ""}})
+	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: session.ID, UserID: sql.NullString{String: session.UserID, Valid: true}})
 	if err != nil {
 		return false
 	}

--- a/internal/memory/lcm/provider.go
+++ b/internal/memory/lcm/provider.go
@@ -164,7 +164,7 @@ func (p *Provider) Assemble(ctx context.Context, session memory.Session, budget,
 
 // Stats implements memory.Provider.
 func (p *Provider) Stats(ctx context.Context, session memory.Session) (memory.SessionStats, error) {
-	conv, err := p.q.GetConversationBySessionID(ctx, session.ID)
+	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: session.ID, UserID: sql.NullString{String: session.UserID, Valid: session.UserID != ""}})
 	if errors.Is(err, sql.ErrNoRows) {
 		return memory.SessionStats{}, nil
 	}
@@ -209,7 +209,7 @@ func (p *Provider) Close() error {
 
 // NeedsCompaction implements memory.Compactor.
 func (p *Provider) NeedsCompaction(ctx context.Context, session memory.Session, threshold float64) bool {
-	conv, err := p.q.GetConversationBySessionID(ctx, session.ID)
+	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: session.ID, UserID: sql.NullString{String: session.UserID, Valid: session.UserID != ""}})
 	if err != nil {
 		return false
 	}

--- a/internal/memory/lcm/provider_extra_test.go
+++ b/internal/memory/lcm/provider_extra_test.go
@@ -217,8 +217,8 @@ func TestLCMProvider_LoadHistory(t *testing.T) {
 	p, cleanup := newLCMTestProvider(t)
 	defer cleanup()
 
-	ctx := context.Background()
 	sess := newLCMTestSession("history")
+	ctx := memory.WithAgentID(memory.WithUserID(context.Background(), sess.UserID), sess.AgentID)
 
 	if err := p.Bootstrap(ctx, sess); err != nil {
 		t.Fatal(err)

--- a/internal/memory/lcm/retrieval.go
+++ b/internal/memory/lcm/retrieval.go
@@ -2,6 +2,7 @@ package lcm
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"unicode/utf8"
 
@@ -27,7 +28,7 @@ func newRetrievalEngine(q *sqlc.Queries) *retrievalEngine {
 
 // Search implements memory.Searcher.
 func (p *Provider) Search(ctx context.Context, session memory.Session, query memory.SearchQuery) ([]memory.SearchResult, error) {
-	conv, err := p.q.GetConversationBySessionID(ctx, session.ID)
+	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: session.ID, UserID: sql.NullString{String: session.UserID, Valid: session.UserID != ""}})
 	if err != nil {
 		return nil, fmt.Errorf("get conversation: %w", err)
 	}

--- a/internal/memory/lcm/retrieval.go
+++ b/internal/memory/lcm/retrieval.go
@@ -28,7 +28,7 @@ func newRetrievalEngine(q *sqlc.Queries) *retrievalEngine {
 
 // Search implements memory.Searcher.
 func (p *Provider) Search(ctx context.Context, session memory.Session, query memory.SearchQuery) ([]memory.SearchResult, error) {
-	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: session.ID, UserID: sql.NullString{String: session.UserID, Valid: session.UserID != ""}})
+	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: session.ID, UserID: sql.NullString{String: session.UserID, Valid: true}})
 	if err != nil {
 		return nil, fmt.Errorf("get conversation: %w", err)
 	}

--- a/internal/memory/lcm/review.go
+++ b/internal/memory/lcm/review.go
@@ -16,7 +16,7 @@ const maxReviewMessages = 200
 
 // BuildReviewContext implements memory.Reviewer.
 func (p *Provider) BuildReviewContext(ctx context.Context, session memory.Session, since time.Time) (string, error) {
-	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: session.ID, UserID: sql.NullString{String: session.UserID, Valid: session.UserID != ""}})
+	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: session.ID, UserID: sql.NullString{String: session.UserID, Valid: true}})
 	if errors.Is(err, sql.ErrNoRows) {
 		return "", nil
 	}

--- a/internal/memory/lcm/review.go
+++ b/internal/memory/lcm/review.go
@@ -16,7 +16,7 @@ const maxReviewMessages = 200
 
 // BuildReviewContext implements memory.Reviewer.
 func (p *Provider) BuildReviewContext(ctx context.Context, session memory.Session, since time.Time) (string, error) {
-	conv, err := p.q.GetConversationBySessionID(ctx, session.ID)
+	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: session.ID, UserID: sql.NullString{String: session.UserID, Valid: session.UserID != ""}})
 	if errors.Is(err, sql.ErrNoRows) {
 		return "", nil
 	}

--- a/internal/memory/lcm/sessions.go
+++ b/internal/memory/lcm/sessions.go
@@ -16,7 +16,7 @@ import (
 
 // SaveInfo implements memory.SessionManager.
 func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error {
-	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: info.ID, UserID: sql.NullString{String: info.UserID, Valid: info.UserID != ""}})
+	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: info.ID, UserID: sql.NullString{String: info.UserID, Valid: true}})
 	if errors.Is(err, sql.ErrNoRows) {
 		lastActive := info.LastActive
 		if lastActive.IsZero() {
@@ -36,7 +36,7 @@ func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error 
 			Archived:   boolToInt(info.Archived),
 			LastActive: lastActive.UTC().Format("2006-01-02 15:04:05"),
 			AgentID:    sql.NullString{String: info.AgentID, Valid: info.AgentID != ""},
-			UserID:     sql.NullString{String: info.UserID, Valid: info.UserID != ""},
+			UserID:     sql.NullString{String: info.UserID, Valid: true},
 		})
 		if err != nil {
 			return fmt.Errorf("create conversation: %w", err)
@@ -52,7 +52,7 @@ func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error 
 		if err := p.q.UpdateConversationTitleBySessionID(ctx, sqlc.UpdateConversationTitleBySessionIDParams{
 			Title:     sql.NullString{String: info.Title, Valid: true},
 			SessionID: info.ID,
-			UserID:    sql.NullString{String: info.UserID, Valid: info.UserID != ""},
+			UserID:    sql.NullString{String: info.UserID, Valid: true},
 		}); err != nil {
 			return fmt.Errorf("update title: %w", err)
 		}
@@ -61,7 +61,7 @@ func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error 
 		if err := p.q.UpdateConversationArchived(ctx, sqlc.UpdateConversationArchivedParams{
 			Archived:  boolToInt(info.Archived),
 			SessionID: info.ID,
-			UserID:    sql.NullString{String: info.UserID, Valid: info.UserID != ""},
+			UserID:    sql.NullString{String: info.UserID, Valid: true},
 		}); err != nil {
 			return fmt.Errorf("update archived: %w", err)
 		}
@@ -79,13 +79,13 @@ func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error 
 			Kind:      kind,
 			ProjectID: projectID,
 			SessionID: info.ID,
-			UserID:    sql.NullString{String: info.UserID, Valid: info.UserID != ""},
+			UserID:    sql.NullString{String: info.UserID, Valid: true},
 		}); err != nil {
 			return fmt.Errorf("update kind/project: %w", err)
 		}
 	}
 
-	if err := p.q.UpdateConversationLastActive(ctx, sqlc.UpdateConversationLastActiveParams{SessionID: info.ID, UserID: sql.NullString{String: info.UserID, Valid: info.UserID != ""}}); err != nil {
+	if err := p.q.UpdateConversationLastActive(ctx, sqlc.UpdateConversationLastActiveParams{SessionID: info.ID, UserID: sql.NullString{String: info.UserID, Valid: true}}); err != nil {
 		return fmt.Errorf("update last_active: %w", err)
 	}
 	return nil
@@ -93,7 +93,7 @@ func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error 
 
 // LoadInfo implements memory.SessionManager.
 func (p *Provider) LoadInfo(ctx context.Context, sessionID string) (memory.SessionInfo, error) {
-	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: sessionID, UserID: sql.NullString{String: memory.UserIDFromContext(ctx), Valid: memory.UserIDFromContext(ctx) != ""}})
+	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: sessionID, UserID: sql.NullString{String: memory.UserIDFromContext(ctx), Valid: true}})
 	if err != nil {
 		return memory.SessionInfo{}, fmt.Errorf("get conversation: %w", err)
 	}
@@ -110,9 +110,9 @@ func (p *Provider) ListInfo(ctx context.Context, opts memory.ListOptions) ([]mem
 	}
 	agentID := sql.NullString{String: opts.AgentID, Valid: opts.AgentID != ""}
 	if opts.IncludeArchived {
-		convs, err = p.q.ListConversationsAll(ctx, sqlc.ListConversationsAllParams{UserID: sql.NullString{String: userID, Valid: userID != ""}, AgentID: agentID})
+		convs, err = p.q.ListConversationsAll(ctx, sqlc.ListConversationsAllParams{UserID: sql.NullString{String: userID, Valid: true}, AgentID: agentID})
 	} else {
-		convs, err = p.q.ListConversations(ctx, sqlc.ListConversationsParams{UserID: sql.NullString{String: userID, Valid: userID != ""}, AgentID: agentID})
+		convs, err = p.q.ListConversations(ctx, sqlc.ListConversationsParams{UserID: sql.NullString{String: userID, Valid: true}, AgentID: agentID})
 	}
 	if err != nil {
 		return nil, fmt.Errorf("list conversations: %w", err)
@@ -149,7 +149,7 @@ func (p *Provider) ListInfo(ctx context.Context, opts memory.ListOptions) ([]mem
 
 // LoadHistory implements memory.SessionManager.
 func (p *Provider) LoadHistory(ctx context.Context, sessionID string) ([]ai.Message, error) {
-	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: sessionID, UserID: sql.NullString{String: memory.UserIDFromContext(ctx), Valid: memory.UserIDFromContext(ctx) != ""}})
+	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: sessionID, UserID: sql.NullString{String: memory.UserIDFromContext(ctx), Valid: true}})
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}

--- a/internal/memory/lcm/sessions.go
+++ b/internal/memory/lcm/sessions.go
@@ -52,6 +52,7 @@ func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error 
 		if err := p.q.UpdateConversationTitleBySessionID(ctx, sqlc.UpdateConversationTitleBySessionIDParams{
 			Title:     sql.NullString{String: info.Title, Valid: true},
 			SessionID: info.ID,
+			UserID:    sql.NullString{String: info.UserID, Valid: info.UserID != ""},
 		}); err != nil {
 			return fmt.Errorf("update title: %w", err)
 		}
@@ -60,6 +61,7 @@ func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error 
 		if err := p.q.UpdateConversationArchived(ctx, sqlc.UpdateConversationArchivedParams{
 			Archived:  boolToInt(info.Archived),
 			SessionID: info.ID,
+			UserID:    sql.NullString{String: info.UserID, Valid: info.UserID != ""},
 		}); err != nil {
 			return fmt.Errorf("update archived: %w", err)
 		}
@@ -77,11 +79,11 @@ func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error 
 			Kind:      kind,
 			ProjectID: projectID,
 			SessionID: info.ID,
+			UserID:    sql.NullString{String: info.UserID, Valid: info.UserID != ""},
 		}); err != nil {
 			return fmt.Errorf("update kind/project: %w", err)
 		}
 	}
-	// Update agent_id/user_id if provided and different.
 
 	if err := p.q.UpdateConversationLastActive(ctx, sqlc.UpdateConversationLastActiveParams{SessionID: info.ID, UserID: sql.NullString{String: info.UserID, Valid: info.UserID != ""}}); err != nil {
 		return fmt.Errorf("update last_active: %w", err)

--- a/internal/memory/lcm/sessions.go
+++ b/internal/memory/lcm/sessions.go
@@ -64,6 +64,23 @@ func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error 
 			return fmt.Errorf("update archived: %w", err)
 		}
 	}
+	if (info.Kind != "" && info.Kind != conv.Kind) || (info.ProjectID != "" && (!conv.ProjectID.Valid || info.ProjectID != conv.ProjectID.String)) {
+		kind := info.Kind
+		if kind == "" {
+			kind = conv.Kind
+		}
+		projectID := sql.NullString{String: info.ProjectID, Valid: info.ProjectID != ""}
+		if info.ProjectID == "" && conv.ProjectID.Valid {
+			projectID = conv.ProjectID
+		}
+		if err := p.q.UpdateConversationKindProject(ctx, sqlc.UpdateConversationKindProjectParams{
+			Kind:      kind,
+			ProjectID: projectID,
+			SessionID: info.ID,
+		}); err != nil {
+			return fmt.Errorf("update kind/project: %w", err)
+		}
+	}
 	// Update agent_id/user_id if provided and different.
 	if info.AgentID != "" || info.UserID != "" {
 		agentMatch := conv.AgentID.Valid && conv.AgentID.String == info.AgentID

--- a/internal/memory/lcm/sessions.go
+++ b/internal/memory/lcm/sessions.go
@@ -18,18 +18,6 @@ import (
 func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error {
 	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: info.ID, UserID: sql.NullString{String: info.UserID, Valid: true}})
 	if errors.Is(err, sql.ErrNoRows) {
-		legacy, legacyErr := p.q.GetUnownedConversationBySessionID(ctx, info.ID)
-		if legacyErr == nil {
-			if err := p.q.ClaimConversationUserBySessionID(ctx, sqlc.ClaimConversationUserBySessionIDParams{SessionID: info.ID, UserID: sql.NullString{String: info.UserID, Valid: true}}); err != nil {
-				return fmt.Errorf("claim conversation user: %w", err)
-			}
-			conv = legacy
-			err = nil
-		} else if !errors.Is(legacyErr, sql.ErrNoRows) {
-			return fmt.Errorf("get unowned conversation: %w", legacyErr)
-		}
-	}
-	if errors.Is(err, sql.ErrNoRows) {
 		lastActive := info.LastActive
 		if lastActive.IsZero() {
 			lastActive = time.Now().UTC()

--- a/internal/memory/lcm/sessions.go
+++ b/internal/memory/lcm/sessions.go
@@ -16,7 +16,7 @@ import (
 
 // SaveInfo implements memory.SessionManager.
 func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error {
-	conv, err := p.q.GetConversationBySessionID(ctx, info.ID)
+	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: info.ID, UserID: sql.NullString{String: info.UserID, Valid: info.UserID != ""}})
 	if errors.Is(err, sql.ErrNoRows) {
 		lastActive := info.LastActive
 		if lastActive.IsZero() {
@@ -26,7 +26,7 @@ func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error 
 		if kind == "" {
 			kind = "chat"
 		}
-		_, err = p.q.CreateConversationFull(ctx, sqlc.CreateConversationFullParams{
+		_, err = p.q.CreateConversation(ctx, sqlc.CreateConversationParams{
 			ID:         uuid.NewString(),
 			SessionID:  info.ID,
 			Title:      sql.NullString{String: info.Title, Valid: info.Title != ""},
@@ -82,21 +82,8 @@ func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error 
 		}
 	}
 	// Update agent_id/user_id if provided and different.
-	if info.AgentID != "" || info.UserID != "" {
-		agentMatch := conv.AgentID.Valid && conv.AgentID.String == info.AgentID
-		userMatch := conv.UserID.Valid && conv.UserID.String == info.UserID
-		if !agentMatch || !userMatch {
-			if err := p.q.UpdateConversationAgentUser(ctx, sqlc.UpdateConversationAgentUserParams{
-				AgentID:   sql.NullString{String: info.AgentID, Valid: info.AgentID != ""},
-				UserID:    sql.NullString{String: info.UserID, Valid: info.UserID != ""},
-				SessionID: info.ID,
-			}); err != nil {
-				return fmt.Errorf("update agent/user: %w", err)
-			}
-		}
-	}
 
-	if err := p.q.UpdateConversationLastActive(ctx, info.ID); err != nil {
+	if err := p.q.UpdateConversationLastActive(ctx, sqlc.UpdateConversationLastActiveParams{SessionID: info.ID, UserID: sql.NullString{String: info.UserID, Valid: info.UserID != ""}}); err != nil {
 		return fmt.Errorf("update last_active: %w", err)
 	}
 	return nil
@@ -104,7 +91,7 @@ func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error 
 
 // LoadInfo implements memory.SessionManager.
 func (p *Provider) LoadInfo(ctx context.Context, sessionID string) (memory.SessionInfo, error) {
-	conv, err := p.q.GetConversationBySessionID(ctx, sessionID)
+	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: sessionID, UserID: sql.NullString{String: memory.UserIDFromContext(ctx), Valid: memory.UserIDFromContext(ctx) != ""}})
 	if err != nil {
 		return memory.SessionInfo{}, fmt.Errorf("get conversation: %w", err)
 	}
@@ -115,10 +102,15 @@ func (p *Provider) LoadInfo(ctx context.Context, sessionID string) (memory.Sessi
 func (p *Provider) ListInfo(ctx context.Context, opts memory.ListOptions) ([]memory.SessionInfo, error) {
 	var convs []sqlc.CtxConversation
 	var err error
+	userID := opts.UserID
+	if userID == "" {
+		userID = memory.UserIDFromContext(ctx)
+	}
+	agentID := sql.NullString{String: opts.AgentID, Valid: opts.AgentID != ""}
 	if opts.IncludeArchived {
-		convs, err = p.q.ListConversationsAll(ctx)
+		convs, err = p.q.ListConversationsAll(ctx, sqlc.ListConversationsAllParams{UserID: sql.NullString{String: userID, Valid: userID != ""}, AgentID: agentID})
 	} else {
-		convs, err = p.q.ListConversations(ctx)
+		convs, err = p.q.ListConversations(ctx, sqlc.ListConversationsParams{UserID: sql.NullString{String: userID, Valid: userID != ""}, AgentID: agentID})
 	}
 	if err != nil {
 		return nil, fmt.Errorf("list conversations: %w", err)
@@ -155,7 +147,7 @@ func (p *Provider) ListInfo(ctx context.Context, opts memory.ListOptions) ([]mem
 
 // LoadHistory implements memory.SessionManager.
 func (p *Provider) LoadHistory(ctx context.Context, sessionID string) ([]ai.Message, error) {
-	conv, err := p.q.GetConversationBySessionID(ctx, sessionID)
+	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: sessionID, UserID: sql.NullString{String: memory.UserIDFromContext(ctx), Valid: memory.UserIDFromContext(ctx) != ""}})
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}

--- a/internal/memory/lcm/sessions.go
+++ b/internal/memory/lcm/sessions.go
@@ -18,6 +18,18 @@ import (
 func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error {
 	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: info.ID, UserID: sql.NullString{String: info.UserID, Valid: true}})
 	if errors.Is(err, sql.ErrNoRows) {
+		legacy, legacyErr := p.q.GetUnownedConversationBySessionID(ctx, info.ID)
+		if legacyErr == nil {
+			if err := p.q.ClaimConversationUserBySessionID(ctx, sqlc.ClaimConversationUserBySessionIDParams{SessionID: info.ID, UserID: sql.NullString{String: info.UserID, Valid: true}}); err != nil {
+				return fmt.Errorf("claim conversation user: %w", err)
+			}
+			conv = legacy
+			err = nil
+		} else if !errors.Is(legacyErr, sql.ErrNoRows) {
+			return fmt.Errorf("get unowned conversation: %w", legacyErr)
+		}
+	}
+	if errors.Is(err, sql.ErrNoRows) {
 		lastActive := info.LastActive
 		if lastActive.IsZero() {
 			lastActive = time.Now().UTC()

--- a/internal/memory/memorytest/conformance.go
+++ b/internal/memory/memorytest/conformance.go
@@ -16,13 +16,13 @@ import (
 func RunConformance(t *testing.T, provider memory.Provider) {
 	t.Helper()
 
-	ctx := context.Background()
 	session := memory.Session{
 		ID:      "test:cli:1:main",
 		AgentID: "test",
 		UserID:  "user-1",
 		Channel: "cli",
 	}
+	ctx := memory.WithAgentID(memory.WithUserID(context.Background(), session.UserID), session.AgentID)
 
 	t.Run("Name", func(t *testing.T) {
 		name := provider.Name()

--- a/internal/memory/simple/provider.go
+++ b/internal/memory/simple/provider.go
@@ -148,7 +148,7 @@ func (p *Provider) Assemble(ctx context.Context, session memory.Session, budget,
 
 // Stats implements memory.Provider.
 func (p *Provider) Stats(ctx context.Context, session memory.Session) (memory.SessionStats, error) {
-	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: session.ID, UserID: sql.NullString{String: session.UserID, Valid: session.UserID != ""}})
+	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: session.ID, UserID: sql.NullString{String: session.UserID, Valid: true}})
 	if errors.Is(err, sql.ErrNoRows) {
 		return memory.SessionStats{}, nil
 	}
@@ -471,7 +471,7 @@ func changelogRowToEntry(r sqlc.MemoryChangelog) memory.ChangeEntry {
 
 // SaveInfo implements memory.SessionManager.
 func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error {
-	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: info.ID, UserID: sql.NullString{String: info.UserID, Valid: info.UserID != ""}})
+	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: info.ID, UserID: sql.NullString{String: info.UserID, Valid: true}})
 	if errors.Is(err, sql.ErrNoRows) {
 		lastActive := info.LastActive
 		if lastActive.IsZero() {
@@ -491,7 +491,7 @@ func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error 
 			Archived:   boolToInt(info.Archived),
 			LastActive: lastActive.UTC().Format("2006-01-02 15:04:05"),
 			AgentID:    sql.NullString{String: info.AgentID, Valid: info.AgentID != ""},
-			UserID:     sql.NullString{String: info.UserID, Valid: info.UserID != ""},
+			UserID:     sql.NullString{String: info.UserID, Valid: true},
 		})
 		if err != nil {
 			return fmt.Errorf("create conversation: %w", err)
@@ -506,7 +506,7 @@ func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error 
 		if err := p.q.UpdateConversationTitleBySessionID(ctx, sqlc.UpdateConversationTitleBySessionIDParams{
 			Title:     sql.NullString{String: info.Title, Valid: true},
 			SessionID: info.ID,
-			UserID:    sql.NullString{String: info.UserID, Valid: info.UserID != ""},
+			UserID:    sql.NullString{String: info.UserID, Valid: true},
 		}); err != nil {
 			return fmt.Errorf("update title: %w", err)
 		}
@@ -515,7 +515,7 @@ func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error 
 		if err := p.q.UpdateConversationArchived(ctx, sqlc.UpdateConversationArchivedParams{
 			Archived:  boolToInt(info.Archived),
 			SessionID: info.ID,
-			UserID:    sql.NullString{String: info.UserID, Valid: info.UserID != ""},
+			UserID:    sql.NullString{String: info.UserID, Valid: true},
 		}); err != nil {
 			return fmt.Errorf("update archived: %w", err)
 		}
@@ -533,13 +533,13 @@ func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error 
 			Kind:      kind,
 			ProjectID: projectID,
 			SessionID: info.ID,
-			UserID:    sql.NullString{String: info.UserID, Valid: info.UserID != ""},
+			UserID:    sql.NullString{String: info.UserID, Valid: true},
 		}); err != nil {
 			return fmt.Errorf("update kind/project: %w", err)
 		}
 	}
 
-	if err := p.q.UpdateConversationLastActive(ctx, sqlc.UpdateConversationLastActiveParams{SessionID: info.ID, UserID: sql.NullString{String: info.UserID, Valid: info.UserID != ""}}); err != nil {
+	if err := p.q.UpdateConversationLastActive(ctx, sqlc.UpdateConversationLastActiveParams{SessionID: info.ID, UserID: sql.NullString{String: info.UserID, Valid: true}}); err != nil {
 		return fmt.Errorf("update last_active: %w", err)
 	}
 	return nil
@@ -548,7 +548,7 @@ func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error 
 // LoadInfo implements memory.SessionManager.
 func (p *Provider) LoadInfo(ctx context.Context, sessionID string) (memory.SessionInfo, error) {
 	userID := memory.UserIDFromContext(ctx)
-	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: sessionID, UserID: sql.NullString{String: userID, Valid: userID != ""}})
+	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: sessionID, UserID: sql.NullString{String: userID, Valid: true}})
 	if err != nil {
 		return memory.SessionInfo{}, fmt.Errorf("get conversation: %w", err)
 	}
@@ -565,9 +565,9 @@ func (p *Provider) ListInfo(ctx context.Context, opts memory.ListOptions) ([]mem
 	}
 	agentID := sql.NullString{String: opts.AgentID, Valid: opts.AgentID != ""}
 	if opts.IncludeArchived {
-		convs, err = p.q.ListConversationsAll(ctx, sqlc.ListConversationsAllParams{UserID: sql.NullString{String: userID, Valid: userID != ""}, AgentID: agentID})
+		convs, err = p.q.ListConversationsAll(ctx, sqlc.ListConversationsAllParams{UserID: sql.NullString{String: userID, Valid: true}, AgentID: agentID})
 	} else {
-		convs, err = p.q.ListConversations(ctx, sqlc.ListConversationsParams{UserID: sql.NullString{String: userID, Valid: userID != ""}, AgentID: agentID})
+		convs, err = p.q.ListConversations(ctx, sqlc.ListConversationsParams{UserID: sql.NullString{String: userID, Valid: true}, AgentID: agentID})
 	}
 	if err != nil {
 		return nil, fmt.Errorf("list conversations: %w", err)
@@ -603,7 +603,7 @@ func (p *Provider) ListInfo(ctx context.Context, opts memory.ListOptions) ([]mem
 
 // LoadHistory implements memory.SessionManager.
 func (p *Provider) LoadHistory(ctx context.Context, sessionID string) ([]ai.Message, error) {
-	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: sessionID, UserID: sql.NullString{String: memory.UserIDFromContext(ctx), Valid: memory.UserIDFromContext(ctx) != ""}})
+	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: sessionID, UserID: sql.NullString{String: memory.UserIDFromContext(ctx), Valid: true}})
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
@@ -644,7 +644,7 @@ func (p *Provider) getOrCreateConversation(ctx context.Context, session memory.S
 	}
 	p.globalMu.Unlock()
 
-	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: sessionID, UserID: sql.NullString{String: memory.UserIDFromContext(ctx), Valid: memory.UserIDFromContext(ctx) != ""}})
+	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: sessionID, UserID: sql.NullString{String: session.UserID, Valid: true}})
 	if err == nil {
 		p.cacheConvID(sessionID, conv.ID)
 		return conv.ID, nil
@@ -659,7 +659,7 @@ func (p *Provider) getOrCreateConversation(ctx context.Context, session memory.S
 		Channel:    session.Channel,
 		Kind:       "chat",
 		AgentID:    sql.NullString{String: session.AgentID, Valid: session.AgentID != ""},
-		UserID:     sql.NullString{String: session.UserID, Valid: session.UserID != ""},
+		UserID:     sql.NullString{String: session.UserID, Valid: true},
 		LastActive: time.Now().UTC().Format("2006-01-02 15:04:05"),
 	})
 	if err != nil {

--- a/internal/memory/simple/provider.go
+++ b/internal/memory/simple/provider.go
@@ -657,6 +657,18 @@ func (p *Provider) getOrCreateConversation(ctx context.Context, session memory.S
 	p.globalMu.Unlock()
 
 	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: sessionID, UserID: sql.NullString{String: session.UserID, Valid: true}})
+	if errors.Is(err, sql.ErrNoRows) {
+		legacy, legacyErr := p.q.GetUnownedConversationBySessionID(ctx, sessionID)
+		if legacyErr == nil {
+			if err := p.q.ClaimConversationUserBySessionID(ctx, sqlc.ClaimConversationUserBySessionIDParams{SessionID: sessionID, UserID: sql.NullString{String: session.UserID, Valid: true}}); err != nil {
+				return "", fmt.Errorf("claim conversation user: %w", err)
+			}
+			conv = legacy
+			err = nil
+		} else if !errors.Is(legacyErr, sql.ErrNoRows) {
+			return "", fmt.Errorf("get unowned conversation: %w", legacyErr)
+		}
+	}
 	if err == nil {
 		p.cacheConvID(sessionID, conv.ID)
 		return conv.ID, nil

--- a/internal/memory/simple/provider.go
+++ b/internal/memory/simple/provider.go
@@ -506,6 +506,7 @@ func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error 
 		if err := p.q.UpdateConversationTitleBySessionID(ctx, sqlc.UpdateConversationTitleBySessionIDParams{
 			Title:     sql.NullString{String: info.Title, Valid: true},
 			SessionID: info.ID,
+			UserID:    sql.NullString{String: info.UserID, Valid: info.UserID != ""},
 		}); err != nil {
 			return fmt.Errorf("update title: %w", err)
 		}
@@ -514,6 +515,7 @@ func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error 
 		if err := p.q.UpdateConversationArchived(ctx, sqlc.UpdateConversationArchivedParams{
 			Archived:  boolToInt(info.Archived),
 			SessionID: info.ID,
+			UserID:    sql.NullString{String: info.UserID, Valid: info.UserID != ""},
 		}); err != nil {
 			return fmt.Errorf("update archived: %w", err)
 		}
@@ -531,6 +533,7 @@ func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error 
 			Kind:      kind,
 			ProjectID: projectID,
 			SessionID: info.ID,
+			UserID:    sql.NullString{String: info.UserID, Valid: info.UserID != ""},
 		}); err != nil {
 			return fmt.Errorf("update kind/project: %w", err)
 		}

--- a/internal/memory/simple/provider.go
+++ b/internal/memory/simple/provider.go
@@ -473,18 +473,6 @@ func changelogRowToEntry(r sqlc.MemoryChangelog) memory.ChangeEntry {
 func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error {
 	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: info.ID, UserID: sql.NullString{String: info.UserID, Valid: true}})
 	if errors.Is(err, sql.ErrNoRows) {
-		legacy, legacyErr := p.q.GetUnownedConversationBySessionID(ctx, info.ID)
-		if legacyErr == nil {
-			if err := p.q.ClaimConversationUserBySessionID(ctx, sqlc.ClaimConversationUserBySessionIDParams{SessionID: info.ID, UserID: sql.NullString{String: info.UserID, Valid: true}}); err != nil {
-				return fmt.Errorf("claim conversation user: %w", err)
-			}
-			conv = legacy
-			err = nil
-		} else if !errors.Is(legacyErr, sql.ErrNoRows) {
-			return fmt.Errorf("get unowned conversation: %w", legacyErr)
-		}
-	}
-	if errors.Is(err, sql.ErrNoRows) {
 		lastActive := info.LastActive
 		if lastActive.IsZero() {
 			lastActive = time.Now().UTC()
@@ -657,18 +645,6 @@ func (p *Provider) getOrCreateConversation(ctx context.Context, session memory.S
 	p.globalMu.Unlock()
 
 	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: sessionID, UserID: sql.NullString{String: session.UserID, Valid: true}})
-	if errors.Is(err, sql.ErrNoRows) {
-		legacy, legacyErr := p.q.GetUnownedConversationBySessionID(ctx, sessionID)
-		if legacyErr == nil {
-			if err := p.q.ClaimConversationUserBySessionID(ctx, sqlc.ClaimConversationUserBySessionIDParams{SessionID: sessionID, UserID: sql.NullString{String: session.UserID, Valid: true}}); err != nil {
-				return "", fmt.Errorf("claim conversation user: %w", err)
-			}
-			conv = legacy
-			err = nil
-		} else if !errors.Is(legacyErr, sql.ErrNoRows) {
-			return "", fmt.Errorf("get unowned conversation: %w", legacyErr)
-		}
-	}
 	if err == nil {
 		p.cacheConvID(sessionID, conv.ID)
 		return conv.ID, nil

--- a/internal/memory/simple/provider.go
+++ b/internal/memory/simple/provider.go
@@ -60,7 +60,7 @@ func (p *Provider) Name() string { return "simple" }
 
 // Bootstrap implements memory.Provider.
 func (p *Provider) Bootstrap(ctx context.Context, session memory.Session) error {
-	_, err := p.getOrCreateConversation(ctx, session.ID)
+	_, err := p.getOrCreateConversation(ctx, session)
 	return err
 }
 
@@ -70,7 +70,7 @@ func (p *Provider) Append(ctx context.Context, session memory.Session, msgs ...a
 		return nil
 	}
 	return p.withSessionLock(session.ID, func() error {
-		convID, err := p.getOrCreateConversation(ctx, session.ID)
+		convID, err := p.getOrCreateConversation(ctx, session)
 		if err != nil {
 			return err
 		}
@@ -114,7 +114,7 @@ func (p *Provider) Append(ctx context.Context, session memory.Session, msgs ...a
 // Assemble implements memory.Provider.
 // Returns the last N messages that fit within budget, always honouring freshTail.
 func (p *Provider) Assemble(ctx context.Context, session memory.Session, budget, freshTail int) ([]ai.Message, error) {
-	convID, err := p.getOrCreateConversation(ctx, session.ID)
+	convID, err := p.getOrCreateConversation(ctx, session)
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +148,7 @@ func (p *Provider) Assemble(ctx context.Context, session memory.Session, budget,
 
 // Stats implements memory.Provider.
 func (p *Provider) Stats(ctx context.Context, session memory.Session) (memory.SessionStats, error) {
-	conv, err := p.q.GetConversationBySessionID(ctx, session.ID)
+	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: session.ID, UserID: sql.NullString{String: session.UserID, Valid: session.UserID != ""}})
 	if errors.Is(err, sql.ErrNoRows) {
 		return memory.SessionStats{}, nil
 	}
@@ -471,7 +471,7 @@ func changelogRowToEntry(r sqlc.MemoryChangelog) memory.ChangeEntry {
 
 // SaveInfo implements memory.SessionManager.
 func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error {
-	conv, err := p.q.GetConversationBySessionID(ctx, info.ID)
+	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: info.ID, UserID: sql.NullString{String: info.UserID, Valid: info.UserID != ""}})
 	if errors.Is(err, sql.ErrNoRows) {
 		lastActive := info.LastActive
 		if lastActive.IsZero() {
@@ -481,7 +481,7 @@ func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error 
 		if kind == "" {
 			kind = "chat"
 		}
-		_, err = p.q.CreateConversationFull(ctx, sqlc.CreateConversationFullParams{
+		_, err = p.q.CreateConversation(ctx, sqlc.CreateConversationParams{
 			ID:         uuid.NewString(),
 			SessionID:  info.ID,
 			Title:      sql.NullString{String: info.Title, Valid: info.Title != ""},
@@ -535,21 +535,8 @@ func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error 
 			return fmt.Errorf("update kind/project: %w", err)
 		}
 	}
-	if info.AgentID != "" || info.UserID != "" {
-		agentMatch := conv.AgentID.Valid && conv.AgentID.String == info.AgentID
-		userMatch := conv.UserID.Valid && conv.UserID.String == info.UserID
-		if !agentMatch || !userMatch {
-			if err := p.q.UpdateConversationAgentUser(ctx, sqlc.UpdateConversationAgentUserParams{
-				AgentID:   sql.NullString{String: info.AgentID, Valid: info.AgentID != ""},
-				UserID:    sql.NullString{String: info.UserID, Valid: info.UserID != ""},
-				SessionID: info.ID,
-			}); err != nil {
-				return fmt.Errorf("update agent/user: %w", err)
-			}
-		}
-	}
 
-	if err := p.q.UpdateConversationLastActive(ctx, info.ID); err != nil {
+	if err := p.q.UpdateConversationLastActive(ctx, sqlc.UpdateConversationLastActiveParams{SessionID: info.ID, UserID: sql.NullString{String: info.UserID, Valid: info.UserID != ""}}); err != nil {
 		return fmt.Errorf("update last_active: %w", err)
 	}
 	return nil
@@ -557,7 +544,8 @@ func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error 
 
 // LoadInfo implements memory.SessionManager.
 func (p *Provider) LoadInfo(ctx context.Context, sessionID string) (memory.SessionInfo, error) {
-	conv, err := p.q.GetConversationBySessionID(ctx, sessionID)
+	userID := memory.UserIDFromContext(ctx)
+	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: sessionID, UserID: sql.NullString{String: userID, Valid: userID != ""}})
 	if err != nil {
 		return memory.SessionInfo{}, fmt.Errorf("get conversation: %w", err)
 	}
@@ -568,10 +556,15 @@ func (p *Provider) LoadInfo(ctx context.Context, sessionID string) (memory.Sessi
 func (p *Provider) ListInfo(ctx context.Context, opts memory.ListOptions) ([]memory.SessionInfo, error) {
 	var convs []sqlc.CtxConversation
 	var err error
+	userID := opts.UserID
+	if userID == "" {
+		userID = memory.UserIDFromContext(ctx)
+	}
+	agentID := sql.NullString{String: opts.AgentID, Valid: opts.AgentID != ""}
 	if opts.IncludeArchived {
-		convs, err = p.q.ListConversationsAll(ctx)
+		convs, err = p.q.ListConversationsAll(ctx, sqlc.ListConversationsAllParams{UserID: sql.NullString{String: userID, Valid: userID != ""}, AgentID: agentID})
 	} else {
-		convs, err = p.q.ListConversations(ctx)
+		convs, err = p.q.ListConversations(ctx, sqlc.ListConversationsParams{UserID: sql.NullString{String: userID, Valid: userID != ""}, AgentID: agentID})
 	}
 	if err != nil {
 		return nil, fmt.Errorf("list conversations: %w", err)
@@ -607,7 +600,7 @@ func (p *Provider) ListInfo(ctx context.Context, opts memory.ListOptions) ([]mem
 
 // LoadHistory implements memory.SessionManager.
 func (p *Provider) LoadHistory(ctx context.Context, sessionID string) ([]ai.Message, error) {
-	conv, err := p.q.GetConversationBySessionID(ctx, sessionID)
+	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: sessionID, UserID: sql.NullString{String: memory.UserIDFromContext(ctx), Valid: memory.UserIDFromContext(ctx) != ""}})
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
@@ -639,7 +632,8 @@ func (p *Provider) withSessionLock(sessionID string, fn func() error) error {
 	return fn()
 }
 
-func (p *Provider) getOrCreateConversation(ctx context.Context, sessionID string) (string, error) {
+func (p *Provider) getOrCreateConversation(ctx context.Context, session memory.Session) (string, error) {
+	sessionID := session.ID
 	p.globalMu.Lock()
 	if id, ok := p.convCache[sessionID]; ok {
 		p.globalMu.Unlock()
@@ -647,7 +641,7 @@ func (p *Provider) getOrCreateConversation(ctx context.Context, sessionID string
 	}
 	p.globalMu.Unlock()
 
-	conv, err := p.q.GetConversationBySessionID(ctx, sessionID)
+	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: sessionID, UserID: sql.NullString{String: memory.UserIDFromContext(ctx), Valid: memory.UserIDFromContext(ctx) != ""}})
 	if err == nil {
 		p.cacheConvID(sessionID, conv.ID)
 		return conv.ID, nil
@@ -657,8 +651,13 @@ func (p *Provider) getOrCreateConversation(ctx context.Context, sessionID string
 	}
 
 	conv, err = p.q.CreateConversation(ctx, sqlc.CreateConversationParams{
-		ID:        uuid.NewString(),
-		SessionID: sessionID,
+		ID:         uuid.NewString(),
+		SessionID:  sessionID,
+		Channel:    session.Channel,
+		Kind:       "chat",
+		AgentID:    sql.NullString{String: session.AgentID, Valid: session.AgentID != ""},
+		UserID:     sql.NullString{String: session.UserID, Valid: session.UserID != ""},
+		LastActive: time.Now().UTC().Format("2006-01-02 15:04:05"),
 	})
 	if err != nil {
 		return "", fmt.Errorf("create conversation: %w", err)

--- a/internal/memory/simple/provider.go
+++ b/internal/memory/simple/provider.go
@@ -518,6 +518,23 @@ func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error 
 			return fmt.Errorf("update archived: %w", err)
 		}
 	}
+	if (info.Kind != "" && info.Kind != conv.Kind) || (info.ProjectID != "" && (!conv.ProjectID.Valid || info.ProjectID != conv.ProjectID.String)) {
+		kind := info.Kind
+		if kind == "" {
+			kind = conv.Kind
+		}
+		projectID := sql.NullString{String: info.ProjectID, Valid: info.ProjectID != ""}
+		if info.ProjectID == "" && conv.ProjectID.Valid {
+			projectID = conv.ProjectID
+		}
+		if err := p.q.UpdateConversationKindProject(ctx, sqlc.UpdateConversationKindProjectParams{
+			Kind:      kind,
+			ProjectID: projectID,
+			SessionID: info.ID,
+		}); err != nil {
+			return fmt.Errorf("update kind/project: %w", err)
+		}
+	}
 	if info.AgentID != "" || info.UserID != "" {
 		agentMatch := conv.AgentID.Valid && conv.AgentID.String == info.AgentID
 		userMatch := conv.UserID.Valid && conv.UserID.String == info.UserID

--- a/internal/memory/simple/provider.go
+++ b/internal/memory/simple/provider.go
@@ -473,6 +473,18 @@ func changelogRowToEntry(r sqlc.MemoryChangelog) memory.ChangeEntry {
 func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error {
 	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: info.ID, UserID: sql.NullString{String: info.UserID, Valid: true}})
 	if errors.Is(err, sql.ErrNoRows) {
+		legacy, legacyErr := p.q.GetUnownedConversationBySessionID(ctx, info.ID)
+		if legacyErr == nil {
+			if err := p.q.ClaimConversationUserBySessionID(ctx, sqlc.ClaimConversationUserBySessionIDParams{SessionID: info.ID, UserID: sql.NullString{String: info.UserID, Valid: true}}); err != nil {
+				return fmt.Errorf("claim conversation user: %w", err)
+			}
+			conv = legacy
+			err = nil
+		} else if !errors.Is(legacyErr, sql.ErrNoRows) {
+			return fmt.Errorf("get unowned conversation: %w", legacyErr)
+		}
+	}
+	if errors.Is(err, sql.ErrNoRows) {
 		lastActive := info.LastActive
 		if lastActive.IsZero() {
 			lastActive = time.Now().UTC()

--- a/internal/memory/simple/provider_extra_test.go
+++ b/internal/memory/simple/provider_extra_test.go
@@ -122,8 +122,8 @@ func TestSimpleProvider_LoadHistory_WithMixedMessages(t *testing.T) {
 	p, cleanup := newTestDB(t)
 	defer cleanup()
 
-	ctx := context.Background()
 	sess := newTestSession()
+	ctx := memory.WithAgentID(memory.WithUserID(context.Background(), sess.UserID), sess.AgentID)
 	sess.ID = "test:cli:1:main-history"
 
 	if err := p.Bootstrap(ctx, sess); err != nil {

--- a/internal/pluginhost/platform.go
+++ b/internal/pluginhost/platform.go
@@ -53,7 +53,7 @@ func (a skillStoreAdapter) Create(ctx context.Context, s pkgplugins.Skill, files
 }
 
 func (a skillStoreAdapter) Update(ctx context.Context, id string, patch pkgplugins.SkillUpdatePatch) error {
-	return a.s.Update(ctx, id, skills.UpdatePatch{
+	return a.s.Update(ctx, id, skills.ViewContext{}, skills.UpdatePatch{
 		Description:            patch.Description,
 		Status:                 patch.Status,
 		DisableModelInvocation: patch.DisableModelInvocation,
@@ -70,7 +70,7 @@ func (a skillStoreAdapter) DeleteFile(ctx context.Context, skillID, path string)
 }
 
 func (a skillStoreAdapter) Delete(ctx context.Context, id string) error {
-	return a.s.Delete(ctx, id)
+	return a.s.Delete(ctx, id, skills.ViewContext{})
 }
 
 func (a skillStoreAdapter) ExpireDrafts(ctx context.Context, before time.Time) error {

--- a/internal/pluginhost/platform.go
+++ b/internal/pluginhost/platform.go
@@ -53,7 +53,11 @@ func (a skillStoreAdapter) Create(ctx context.Context, s pkgplugins.Skill, files
 }
 
 func (a skillStoreAdapter) Update(ctx context.Context, id string, patch pkgplugins.SkillUpdatePatch) error {
-	return a.s.Update(ctx, id, skills.ViewContext{}, skills.UpdatePatch{
+	vc, err := a.viewContextForSkill(ctx, id)
+	if err != nil {
+		return err
+	}
+	return a.s.Update(ctx, id, vc, skills.UpdatePatch{
 		Description:            patch.Description,
 		Status:                 patch.Status,
 		DisableModelInvocation: patch.DisableModelInvocation,
@@ -70,7 +74,32 @@ func (a skillStoreAdapter) DeleteFile(ctx context.Context, skillID, path string)
 }
 
 func (a skillStoreAdapter) Delete(ctx context.Context, id string) error {
-	return a.s.Delete(ctx, id, skills.ViewContext{})
+	vc, err := a.viewContextForSkill(ctx, id)
+	if err != nil {
+		return err
+	}
+	return a.s.Delete(ctx, id, vc)
+}
+
+func (a skillStoreAdapter) viewContextForSkill(ctx context.Context, id string) (skills.ViewContext, error) {
+	rows, err := a.s.ListAll(ctx)
+	if err != nil {
+		return skills.ViewContext{}, err
+	}
+	for _, row := range rows {
+		if row.ID != id {
+			continue
+		}
+		switch row.Scope {
+		case "agent":
+			return skills.ViewContext{AgentID: row.AgentID}, nil
+		case "user":
+			return skills.ViewContext{UserID: row.UserID}, nil
+		default:
+			return skills.ViewContext{}, nil
+		}
+	}
+	return skills.ViewContext{}, nil
 }
 
 func (a skillStoreAdapter) ExpireDrafts(ctx context.Context, before time.Time) error {

--- a/internal/recally/store.go
+++ b/internal/recally/store.go
@@ -42,6 +42,7 @@ func (s *Store) SaveArticle(ctx context.Context, userID string, req SaveRequest)
 	case err == nil:
 		updated, err := s.q.UpdateArticle(ctx, sqlc.UpdateArticleParams{
 			ID:          existing.ID,
+			UserID:      userID,
 			Title:       req.Title,
 			Author:      req.Author,
 			Summary:     req.Summary,
@@ -108,8 +109,8 @@ func (s *Store) GetArticleByCanonicalURL(ctx context.Context, userID string, can
 }
 
 // GetArticle retrieves an article by ID.
-func (s *Store) GetArticle(ctx context.Context, articleID string) (*Article, error) {
-	row, err := s.q.GetArticle(ctx, articleID)
+func (s *Store) GetArticle(ctx context.Context, userID string, articleID string) (*Article, error) {
+	row, err := s.q.GetArticle(ctx, sqlc.GetArticleParams{ID: articleID, UserID: userID})
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, fmt.Errorf("article not found: %s", articleID)
@@ -122,8 +123,8 @@ func (s *Store) GetArticle(ctx context.Context, articleID string) (*Article, err
 }
 
 // UpdateArticle updates article metadata.
-func (s *Store) UpdateArticle(ctx context.Context, articleID string, updates map[string]any) (*Article, error) {
-	current, err := s.q.GetArticle(ctx, articleID)
+func (s *Store) UpdateArticle(ctx context.Context, userID string, articleID string, updates map[string]any) (*Article, error) {
+	current, err := s.q.GetArticle(ctx, sqlc.GetArticleParams{ID: articleID, UserID: userID})
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, fmt.Errorf("article not found: %s", articleID)
@@ -175,6 +176,7 @@ func (s *Store) UpdateArticle(ctx context.Context, articleID string, updates map
 
 	updated, err := s.q.UpdateArticle(ctx, sqlc.UpdateArticleParams{
 		ID:          articleID,
+		UserID:      userID,
 		Title:       title,
 		Author:      author,
 		Summary:     summary,
@@ -196,8 +198,8 @@ func (s *Store) UpdateArticle(ctx context.Context, articleID string, updates map
 }
 
 // DeleteArticle removes an article from the database.
-func (s *Store) DeleteArticle(ctx context.Context, articleID string) error {
-	if err := s.q.DeleteArticle(ctx, articleID); err != nil {
+func (s *Store) DeleteArticle(ctx context.Context, userID string, articleID string) error {
+	if err := s.q.DeleteArticle(ctx, sqlc.DeleteArticleParams{ID: articleID, UserID: userID}); err != nil {
 		return fmt.Errorf("delete article: %w", err)
 	}
 	return nil
@@ -472,8 +474,8 @@ func (s *Store) MarkFeedEntry(ctx context.Context, entryID string, status RSSEnt
 }
 
 // UpdateArticleFilePath updates only the file path of an article.
-func (s *Store) UpdateArticleFilePath(ctx context.Context, articleID, filePath string) error {
-	_, err := s.UpdateArticle(ctx, articleID, map[string]any{"file_path": filePath})
+func (s *Store) UpdateArticleFilePath(ctx context.Context, userID, articleID, filePath string) error {
+	_, err := s.UpdateArticle(ctx, userID, articleID, map[string]any{"file_path": filePath})
 	if err != nil {
 		return fmt.Errorf("update file path: %w", err)
 	}

--- a/internal/recally/store.go
+++ b/internal/recally/store.go
@@ -289,8 +289,8 @@ func (s *Store) CreateFeed(ctx context.Context, userID string, feedURL, title, d
 }
 
 // GetFeed retrieves a feed by ID.
-func (s *Store) GetFeed(ctx context.Context, feedID string) (*Feed, error) {
-	row, err := s.q.GetRSSFeed(ctx, feedID)
+func (s *Store) GetFeed(ctx context.Context, userID string, feedID string) (*Feed, error) {
+	row, err := s.q.GetRSSFeed(ctx, sqlc.GetRSSFeedParams{ID: feedID, UserID: userID})
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, fmt.Errorf("feed not found: %s", feedID)
@@ -332,8 +332,8 @@ func (s *Store) ListFeeds(ctx context.Context, userID string) ([]Feed, error) {
 }
 
 // UpdateFeed updates feed metadata.
-func (s *Store) UpdateFeed(ctx context.Context, feedID string, updates map[string]any) (*Feed, error) {
-	current, err := s.q.GetRSSFeed(ctx, feedID)
+func (s *Store) UpdateFeed(ctx context.Context, userID string, feedID string, updates map[string]any) (*Feed, error) {
+	current, err := s.q.GetRSSFeed(ctx, sqlc.GetRSSFeedParams{ID: feedID, UserID: userID})
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, fmt.Errorf("feed not found: %s", feedID)
@@ -373,6 +373,7 @@ func (s *Store) UpdateFeed(ctx context.Context, feedID string, updates map[strin
 
 	updated, err := s.q.UpdateRSSFeed(ctx, sqlc.UpdateRSSFeedParams{
 		ID:            feedID,
+		UserID:        userID,
 		Title:         title,
 		Description:   description,
 		CheckInterval: checkInterval,
@@ -391,8 +392,8 @@ func (s *Store) UpdateFeed(ctx context.Context, feedID string, updates map[strin
 }
 
 // DeleteFeed removes a feed and all its entries.
-func (s *Store) DeleteFeed(ctx context.Context, feedID string) error {
-	if err := s.q.DeleteRSSFeed(ctx, feedID); err != nil {
+func (s *Store) DeleteFeed(ctx context.Context, userID string, feedID string) error {
+	if err := s.q.DeleteRSSFeed(ctx, sqlc.DeleteRSSFeedParams{ID: feedID, UserID: userID}); err != nil {
 		return fmt.Errorf("delete feed: %w", err)
 	}
 	return nil

--- a/internal/recally/store_test.go
+++ b/internal/recally/store_test.go
@@ -209,7 +209,7 @@ func TestStore_GetArticle(t *testing.T) {
 	}
 
 	// Get the article
-	article, err := store.GetArticle(ctx, created.ID)
+	article, err := store.GetArticle(ctx, "1", created.ID)
 	if err != nil {
 		t.Fatalf("GetArticle failed: %v", err)
 	}
@@ -218,7 +218,7 @@ func TestStore_GetArticle(t *testing.T) {
 	}
 
 	// Get non-existent article
-	_, err = store.GetArticle(ctx, "nonexistent")
+	_, err = store.GetArticle(ctx, "1", "nonexistent")
 	if err == nil {
 		t.Error("Expected error for non-existent article")
 	}
@@ -250,7 +250,7 @@ func TestStore_UpdateArticle(t *testing.T) {
 		"starred": true,
 	}
 
-	updated, err := store.UpdateArticle(ctx, created.ID, updates)
+	updated, err := store.UpdateArticle(ctx, "1", created.ID, updates)
 	if err != nil {
 		t.Fatalf("UpdateArticle failed: %v", err)
 	}
@@ -288,13 +288,13 @@ func TestStore_DeleteArticle(t *testing.T) {
 	}
 
 	// Delete article
-	err = store.DeleteArticle(ctx, created.ID)
+	err = store.DeleteArticle(ctx, "1", created.ID)
 	if err != nil {
 		t.Fatalf("DeleteArticle failed: %v", err)
 	}
 
 	// Verify deletion
-	_, err = store.GetArticle(ctx, created.ID)
+	_, err = store.GetArticle(ctx, "1", created.ID)
 	if err == nil {
 		t.Error("Expected error after deleting article")
 	}

--- a/internal/recally/store_test.go
+++ b/internal/recally/store_test.go
@@ -391,7 +391,7 @@ func TestStore_Feeds(t *testing.T) {
 	}
 
 	// Get feed
-	retrieved, err := store.GetFeed(ctx, feed.ID)
+	retrieved, err := store.GetFeed(ctx, "1", feed.ID)
 	if err != nil {
 		t.Fatalf("GetFeed failed: %v", err)
 	}
@@ -424,7 +424,7 @@ func TestStore_Feeds(t *testing.T) {
 		"last_etag":     "\"abc123\"",
 		"last_modified": "Wed, 29 Apr 2026 12:00:00 GMT",
 	}
-	updated, err := store.UpdateFeed(ctx, feed.ID, updates)
+	updated, err := store.UpdateFeed(ctx, "1", feed.ID, updates)
 	if err != nil {
 		t.Fatalf("UpdateFeed failed: %v", err)
 	}
@@ -436,13 +436,13 @@ func TestStore_Feeds(t *testing.T) {
 	}
 
 	// Delete feed
-	err = store.DeleteFeed(ctx, feed.ID)
+	err = store.DeleteFeed(ctx, "1", feed.ID)
 	if err != nil {
 		t.Fatalf("DeleteFeed failed: %v", err)
 	}
 
 	// Verify deletion
-	_, err = store.GetFeed(ctx, feed.ID)
+	_, err = store.GetFeed(ctx, "1", feed.ID)
 	if err == nil {
 		t.Error("Expected error after deleting feed")
 	}

--- a/internal/server/agents.go
+++ b/internal/server/agents.go
@@ -181,14 +181,14 @@ func (s *Server) UpdateAgent(w http.ResponseWriter, r *http.Request, id string) 
 	ctx := r.Context()
 	info := UserFromContext(ctx)
 
-	// Check access: admin or creator.
+	// Check access: creator only.
 	existing, err := s.store.GetAgent(ctx, id)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "agent not found")
 		return
 	}
-	if info != nil && !info.IsAdmin && existing.CreatorID != info.UserID {
-		writeError(w, http.StatusForbidden, "only the creator or an admin can edit this agent")
+	if info != nil && existing.CreatorID != info.UserID {
+		writeError(w, http.StatusForbidden, "only the creator can edit this agent")
 		return
 	}
 
@@ -236,14 +236,14 @@ func (s *Server) DeleteAgent(w http.ResponseWriter, r *http.Request, id string) 
 	ctx := r.Context()
 	info := UserFromContext(ctx)
 
-	// Check access: admin or creator.
+	// Check access: creator only.
 	existing, err := s.store.GetAgent(ctx, id)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "agent not found")
 		return
 	}
-	if info != nil && !info.IsAdmin && existing.CreatorID != info.UserID {
-		writeError(w, http.StatusForbidden, "only the creator or an admin can delete this agent")
+	if info != nil && existing.CreatorID != info.UserID {
+		writeError(w, http.StatusForbidden, "only the creator can delete this agent")
 		return
 	}
 

--- a/internal/server/agents_test.go
+++ b/internal/server/agents_test.go
@@ -115,25 +115,31 @@ func TestAgentScopeDefaultsToSystem(t *testing.T) {
 func TestAgentScopeInUpdate(t *testing.T) {
 	env := setupAdmin(t)
 
-	// Update stella to restricted scope.
-	body := config.Agent{
-		Name:    "Stella",
+	agentID := createTestAgent(t, env, config.Agent{
+		Name:    "Updatable Scope",
 		Model:   "anthropic/claude-sonnet-4-6",
 		Scope:   "restricted",
 		Enabled: true,
+	})
+
+	body := config.Agent{
+		Name:    "Updatable Scope",
+		Model:   "anthropic/claude-sonnet-4-6",
+		Scope:   "system",
+		Enabled: true,
 	}
-	rr := doRequest(t, env, "PUT", "/api/agents/stella", body)
+	rr := doRequest(t, env, "PUT", "/api/agents/"+agentID, body)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("update status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
 	}
 
 	// Verify scope persisted.
-	rr = doRequest(t, env, "GET", "/api/agents/stella", nil)
+	rr = doRequest(t, env, "GET", "/api/agents/"+agentID, nil)
 	resp := parseResponse(t, rr)
 	var a config.Agent
 	_ = json.Unmarshal(resp.Data, &a)
-	if a.Scope != "restricted" {
-		t.Errorf("Scope = %q, want %q", a.Scope, "restricted")
+	if a.Scope != "system" {
+		t.Errorf("Scope = %q, want %q", a.Scope, "system")
 	}
 }
 
@@ -170,13 +176,19 @@ func TestAgentInvalidSandbox(t *testing.T) {
 func TestAgentInvalidSandboxOnUpdate(t *testing.T) {
 	env := setupAdmin(t)
 
+	agentID := createTestAgent(t, env, config.Agent{
+		Name:    "Sandbox Update",
+		Model:   "anthropic/claude-sonnet-4-6",
+		Enabled: true,
+	})
+
 	body := config.Agent{
-		Name:    "Stella",
+		Name:    "Sandbox Update",
 		Model:   "anthropic/claude-sonnet-4-6",
 		Enabled: true,
 		Sandbox: config.SandboxConfig{Network: config.SandboxNetworkConfig{Mode: "bogus"}},
 	}
-	rr := doRequest(t, env, "PUT", "/api/agents/stella", body)
+	rr := doRequest(t, env, "PUT", "/api/agents/"+agentID, body)
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusBadRequest, rr.Body.String())
 	}

--- a/internal/server/recally_handlers.go
+++ b/internal/server/recally_handlers.go
@@ -49,7 +49,7 @@ func (h *recallyHandlers) requireUser(w http.ResponseWriter, r *http.Request) (s
 // articleOwned loads an article and returns it only if the caller owns it.
 // Returns false (with the appropriate error response written) otherwise.
 func (h *recallyHandlers) articleOwned(w http.ResponseWriter, ctx context.Context, articleID string, userID string) (*recally.Article, bool) {
-	article, err := h.store.GetArticle(ctx, articleID)
+	article, err := h.store.GetArticle(ctx, userID, articleID)
 	if err != nil {
 		writeError(w, http.StatusNotFound, err.Error())
 		return nil, false
@@ -206,7 +206,7 @@ func (h *recallyHandlers) SaveArticle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	relPath := h.files.RelativePath(filePath)
-	if err := h.store.UpdateArticleFilePath(r.Context(), article.ID, relPath); err != nil {
+	if err := h.store.UpdateArticleFilePath(r.Context(), userID, article.ID, relPath); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -287,7 +287,7 @@ func (h *recallyHandlers) UpdateArticle(w http.ResponseWriter, r *http.Request, 
 
 	updated := article
 	if len(updates) > 0 {
-		next, err := h.store.UpdateArticle(r.Context(), id, updates)
+		next, err := h.store.UpdateArticle(r.Context(), userID, id, updates)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())
 			return
@@ -314,7 +314,7 @@ func (h *recallyHandlers) DeleteArticle(w http.ResponseWriter, r *http.Request, 
 	if !ok {
 		return
 	}
-	if err := h.store.DeleteArticle(r.Context(), id); err != nil {
+	if err := h.store.DeleteArticle(r.Context(), userID, id); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/internal/server/recally_handlers.go
+++ b/internal/server/recally_handlers.go
@@ -62,7 +62,7 @@ func (h *recallyHandlers) articleOwned(w http.ResponseWriter, ctx context.Contex
 }
 
 func (h *recallyHandlers) feedOwned(w http.ResponseWriter, ctx context.Context, feedID string, userID string) (*recally.Feed, bool) {
-	feed, err := h.store.GetFeed(ctx, feedID)
+	feed, err := h.store.GetFeed(ctx, userID, feedID)
 	if err != nil {
 		writeError(w, http.StatusNotFound, err.Error())
 		return nil, false
@@ -435,7 +435,7 @@ func (h *recallyHandlers) UpdateFeed(w http.ResponseWriter, r *http.Request, id 
 	if body.Enabled != nil {
 		updates["enabled"] = *body.Enabled
 	}
-	updated, err := h.store.UpdateFeed(r.Context(), id, updates)
+	updated, err := h.store.UpdateFeed(r.Context(), userID, id, updates)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -451,7 +451,7 @@ func (h *recallyHandlers) DeleteFeed(w http.ResponseWriter, r *http.Request, id 
 	if _, ok := h.feedOwned(w, r.Context(), id, userID); !ok {
 		return
 	}
-	if err := h.store.DeleteFeed(r.Context(), id); err != nil {
+	if err := h.store.DeleteFeed(r.Context(), userID, id); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -507,7 +507,7 @@ func (h *recallyHandlers) PollFeed(w http.ResponseWriter, r *http.Request, id st
 	}
 
 	now := time.Now().UTC()
-	if updated, err := h.store.UpdateFeed(r.Context(), feed.ID, map[string]any{"last_checked_at": &now}); err == nil {
+	if updated, err := h.store.UpdateFeed(r.Context(), userID, feed.ID, map[string]any{"last_checked_at": &now}); err == nil {
 		result.Feed = toAPIFeed(updated)
 	} else {
 		slog.Warn("failed to update feed last_checked_at", "feed_id", feed.ID, "error", err)

--- a/internal/server/scheduler.go
+++ b/internal/server/scheduler.go
@@ -363,7 +363,11 @@ func (s *Server) ListSchedulerJobRuns(w http.ResponseWriter, r *http.Request, id
 		}
 		j := dbRowToAPIJobRun(row)
 		if j.SessionId != "" && sm != nil {
-			if _, err := sm.LoadInfo(r.Context(), j.SessionId); err != nil {
+			ctx := r.Context()
+			if row.UserID.Valid {
+				ctx = memory.WithUserID(ctx, row.UserID.String)
+			}
+			if _, err := sm.LoadInfo(ctx, j.SessionId); err != nil {
 				j.SessionId = ""
 			}
 		}

--- a/internal/server/scheduler.go
+++ b/internal/server/scheduler.go
@@ -59,12 +59,8 @@ func (s *Server) CreateSchedulerJob(w http.ResponseWriter, r *http.Request) {
 		sessionMode = *body.SessionMode
 	}
 
-	// Non-admin users always own their jobs; only admins can create system jobs (user_id="").
 	var userID string
-	if body.UserId != nil {
-		userID = *body.UserId
-	}
-	if info != nil && !info.IsAdmin {
+	if info != nil {
 		userID = info.UserID
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1231,8 +1231,8 @@ func TestSkillsList_NonAdmin(t *testing.T) {
 	}
 
 	rr := doRequestWithSession(t, env.srv, sessionID, "GET", "/api/skills", nil)
-	if rr.Code != http.StatusForbidden {
-		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusForbidden, rr.Body.String())
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
 	}
 }
 

--- a/internal/server/sessions.go
+++ b/internal/server/sessions.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -96,7 +97,8 @@ func (s *Server) SendSessionMessage(w http.ResponseWriter, r *http.Request, sess
 		return
 	}
 
-	si, err := sm.LoadInfo(r.Context(), sessionID)
+	ctx := memoryUserContext(r)
+	si, err := sm.LoadInfo(ctx, sessionID)
 	if err != nil {
 		writeError(w, http.StatusNotFound, err.Error())
 		return
@@ -169,7 +171,7 @@ func (s *Server) SendSessionMessage(w http.ResponseWriter, r *http.Request, sess
 		}
 	}
 
-	ch := pool.Chat(r.Context(), sessionID, msgContent)
+	ch := pool.Chat(ctx, sessionID, msgContent)
 	for {
 		select {
 		case <-r.Context().Done():
@@ -411,6 +413,14 @@ func toSessionResponse(info memory.SessionInfo) sessionResponse {
 	}
 }
 
+func memoryUserContext(r *http.Request) context.Context {
+	ctx := r.Context()
+	if info := UserFromContext(ctx); info != nil && info.UserID != "" {
+		ctx = memory.WithUserID(ctx, info.UserID)
+	}
+	return ctx
+}
+
 func (s *Server) ListSessions(w http.ResponseWriter, r *http.Request, params apiserver.ListSessionsParams) {
 	sm, ok := s.mem.(memory.SessionManager)
 	if !ok {
@@ -441,7 +451,7 @@ func (s *Server) ListSessions(w http.ResponseWriter, r *http.Request, params api
 	if params.ProjectId != nil {
 		opts.ProjectID = *params.ProjectId
 	}
-	sessions, err := sm.ListInfo(r.Context(), opts)
+	sessions, err := sm.ListInfo(memoryUserContext(r), opts)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -466,7 +476,7 @@ func (s *Server) GetSession(w http.ResponseWriter, r *http.Request, sessionID st
 	}
 
 	authInfo := UserFromContext(r.Context())
-	si, err := sm.LoadInfo(r.Context(), sessionID)
+	si, err := sm.LoadInfo(memoryUserContext(r), sessionID)
 	if err != nil {
 		writeError(w, http.StatusNotFound, err.Error())
 		return
@@ -528,7 +538,7 @@ func (s *Server) GetSessionMessages(w http.ResponseWriter, r *http.Request, sess
 	if info := UserFromContext(r.Context()); info != nil {
 		userID = info.UserID
 	}
-	conv, err := s.q.GetConversationBySessionID(r.Context(), sqlc.GetConversationBySessionIDParams{SessionID: sessionID, UserID: sql.NullString{String: userID, Valid: userID != ""}})
+	conv, err := s.q.GetConversationBySessionID(memoryUserContext(r), sqlc.GetConversationBySessionIDParams{SessionID: sessionID, UserID: sql.NullString{String: userID, Valid: true}})
 	if err != nil {
 		writeError(w, http.StatusNotFound, "session not found")
 		return
@@ -583,7 +593,7 @@ func (s *Server) checkSessionAccess(w http.ResponseWriter, r *http.Request, sess
 	if info == nil || !ok {
 		return nil
 	}
-	si, err := sm.LoadInfo(r.Context(), sessionID)
+	si, err := sm.LoadInfo(memoryUserContext(r), sessionID)
 	if err != nil {
 		writeError(w, http.StatusNotFound, err.Error())
 		return err
@@ -608,7 +618,7 @@ func (s *Server) GetSessionWorkspace(w http.ResponseWriter, r *http.Request, ses
 		writeError(w, http.StatusNotFound, "memory provider does not support sessions")
 		return
 	}
-	info, err := sm.LoadInfo(r.Context(), sessionID)
+	info, err := sm.LoadInfo(memoryUserContext(r), sessionID)
 	if err != nil {
 		writeError(w, http.StatusNotFound, err.Error())
 		return
@@ -726,7 +736,7 @@ func (s *Server) sessionWorkspaceRoot(w http.ResponseWriter, r *http.Request, se
 		writeError(w, http.StatusNotFound, "memory provider does not support sessions")
 		return "", fmt.Errorf("unsupported")
 	}
-	info, err := sm.LoadInfo(r.Context(), sessionID)
+	info, err := sm.LoadInfo(memoryUserContext(r), sessionID)
 	if err != nil {
 		writeError(w, http.StatusNotFound, err.Error())
 		return "", err
@@ -1060,7 +1070,7 @@ func (s *Server) GetSessionSystemPrompt(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
-	info, err := sm.LoadInfo(r.Context(), sessionID)
+	info, err := sm.LoadInfo(memoryUserContext(r), sessionID)
 	if err != nil {
 		writeError(w, http.StatusNotFound, err.Error())
 		return

--- a/internal/server/sessions.go
+++ b/internal/server/sessions.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -523,7 +524,11 @@ func (s *Server) GetSessionMessages(w http.ResponseWriter, r *http.Request, sess
 	}
 
 	// Load raw DB rows to preserve created_at timestamps.
-	conv, err := s.q.GetConversationBySessionID(r.Context(), sessionID)
+	userID := ""
+	if info := UserFromContext(r.Context()); info != nil {
+		userID = info.UserID
+	}
+	conv, err := s.q.GetConversationBySessionID(r.Context(), sqlc.GetConversationBySessionIDParams{SessionID: sessionID, UserID: sql.NullString{String: userID, Valid: userID != ""}})
 	if err != nil {
 		writeError(w, http.StatusNotFound, "session not found")
 		return

--- a/internal/server/shares.go
+++ b/internal/server/shares.go
@@ -168,7 +168,7 @@ func (s *Server) resolveArticleContent(w http.ResponseWriter, r *http.Request, u
 		writeError(w, http.StatusBadRequest, "article_id is required for article shares")
 		return "", "", nil, errors.New("missing article_id")
 	}
-	article, err := s.recally.store.GetArticle(r.Context(), articleID)
+	article, err := s.recally.store.GetArticle(r.Context(), userID, articleID)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "article not found")
 		return "", "", nil, err

--- a/internal/server/skills.go
+++ b/internal/server/skills.go
@@ -280,7 +280,8 @@ func (s *Server) applySkillUpdate(w http.ResponseWriter, r *http.Request, id str
 					writeError(w, http.StatusInternalServerError, err.Error())
 					return
 				}
-				goto files
+				s.upsertSkillFiles(w, store, r.Context(), id, req.Files)
+				return
 			}
 		}
 		vc = skillOwnerViewContext(*sk)
@@ -289,9 +290,12 @@ func (s *Server) applySkillUpdate(w http.ResponseWriter, r *http.Request, id str
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-files:
-	for path, content := range req.Files {
-		if err := store.UpsertFile(r.Context(), id, path, content); err != nil {
+	s.upsertSkillFiles(w, store, r.Context(), id, req.Files)
+}
+
+func (s *Server) upsertSkillFiles(w http.ResponseWriter, store skills.Store, ctx context.Context, id string, files map[string]string) {
+	for path, content := range files {
+		if err := store.UpsertFile(ctx, id, path, content); err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())
 			return
 		}

--- a/internal/server/skills.go
+++ b/internal/server/skills.go
@@ -242,11 +242,11 @@ func (s *Server) UpdateSkill(w http.ResponseWriter, r *http.Request, id string) 
 	if !requireAdmin(w, r) {
 		return
 	}
-	s.applySkillUpdate(w, r, id)
+	s.applySkillUpdate(w, r, id, skills.ViewContext{})
 }
 
 // applySkillUpdate is the shared body for PUT .../skills/{id}.
-func (s *Server) applySkillUpdate(w http.ResponseWriter, r *http.Request, id string) {
+func (s *Server) applySkillUpdate(w http.ResponseWriter, r *http.Request, id string, vc skills.ViewContext) {
 	store := s.skillStore()
 	if store == nil {
 		writeError(w, http.StatusServiceUnavailable, "skills store not available")
@@ -262,7 +262,7 @@ func (s *Server) applySkillUpdate(w http.ResponseWriter, r *http.Request, id str
 		Status:                 req.Status,
 		DisableModelInvocation: req.DisableModelInvocation,
 	}
-	if err := store.Update(r.Context(), id, patch); err != nil {
+	if err := store.Update(r.Context(), id, vc, patch); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -279,17 +279,17 @@ func (s *Server) DeleteSkill(w http.ResponseWriter, r *http.Request, id string) 
 	if !requireAdmin(w, r) {
 		return
 	}
-	s.doDeleteSkill(w, r, id)
+	s.doDeleteSkill(w, r, id, skills.ViewContext{})
 }
 
 // doDeleteSkill is the shared body for DELETE .../skills/{id}.
-func (s *Server) doDeleteSkill(w http.ResponseWriter, r *http.Request, id string) {
+func (s *Server) doDeleteSkill(w http.ResponseWriter, r *http.Request, id string, vc skills.ViewContext) {
 	store := s.skillStore()
 	if store == nil {
 		writeError(w, http.StatusServiceUnavailable, "skills store not available")
 		return
 	}
-	if err := store.Delete(r.Context(), id); err != nil {
+	if err := store.Delete(r.Context(), id, vc); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/internal/server/skills.go
+++ b/internal/server/skills.go
@@ -35,7 +35,9 @@ func (s *Server) skillStore() skills.Store {
 }
 
 func (s *Server) ListSkills(w http.ResponseWriter, r *http.Request) {
-	if !requireAdmin(w, r) {
+	info := UserFromContext(r.Context())
+	if info == nil {
+		writeError(w, http.StatusUnauthorized, "authentication required")
 		return
 	}
 	store := s.skillStore()
@@ -43,7 +45,14 @@ func (s *Server) ListSkills(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusServiceUnavailable, "skills store not available")
 		return
 	}
-	all, err := store.ListAll(r.Context())
+
+	var all []skills.Skill
+	var err error
+	if info.IsAdmin {
+		all, err = store.ListAll(r.Context())
+	} else {
+		all, err = store.List(r.Context(), skills.ViewContext{UserID: info.UserID})
+	}
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return

--- a/internal/server/skills.go
+++ b/internal/server/skills.go
@@ -263,7 +263,16 @@ func (s *Server) applySkillUpdate(w http.ResponseWriter, r *http.Request, id str
 		DisableModelInvocation: req.DisableModelInvocation,
 	}
 	if vc.AgentID == "" && vc.UserID == "" {
-		if sk, err := s.findSkillByID(r.Context(), id); err == nil && sk.Scope == "system" {
+		sk, err := s.findSkillByID(r.Context(), id)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				writeError(w, http.StatusNotFound, "skill not found")
+			} else {
+				writeError(w, http.StatusInternalServerError, err.Error())
+			}
+			return
+		}
+		if sk.Scope == "system" {
 			if systemStore, ok := store.(interface {
 				UpdateSystemSkill(context.Context, string, skills.UpdatePatch) error
 			}); ok {
@@ -274,6 +283,7 @@ func (s *Server) applySkillUpdate(w http.ResponseWriter, r *http.Request, id str
 				goto files
 			}
 		}
+		vc = skillOwnerViewContext(*sk)
 	}
 	if err := store.Update(r.Context(), id, vc, patch); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
@@ -296,6 +306,17 @@ func (s *Server) DeleteSkill(w http.ResponseWriter, r *http.Request, id string) 
 	s.doDeleteSkill(w, r, id, skills.ViewContext{})
 }
 
+func skillOwnerViewContext(sk skills.Skill) skills.ViewContext {
+	switch sk.Scope {
+	case "agent":
+		return skills.ViewContext{AgentID: sk.AgentID}
+	case "user":
+		return skills.ViewContext{UserID: sk.UserID}
+	default:
+		return skills.ViewContext{}
+	}
+}
+
 // doDeleteSkill is the shared body for DELETE .../skills/{id}.
 func (s *Server) doDeleteSkill(w http.ResponseWriter, r *http.Request, id string, vc skills.ViewContext) {
 	store := s.skillStore()
@@ -304,7 +325,16 @@ func (s *Server) doDeleteSkill(w http.ResponseWriter, r *http.Request, id string
 		return
 	}
 	if vc.AgentID == "" && vc.UserID == "" {
-		if sk, err := s.findSkillByID(r.Context(), id); err == nil && sk.Scope == "system" {
+		sk, err := s.findSkillByID(r.Context(), id)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				writeError(w, http.StatusNotFound, "skill not found")
+			} else {
+				writeError(w, http.StatusInternalServerError, err.Error())
+			}
+			return
+		}
+		if sk.Scope == "system" {
 			if systemStore, ok := store.(interface {
 				DeleteSystemSkill(context.Context, string) error
 			}); ok {
@@ -316,6 +346,7 @@ func (s *Server) doDeleteSkill(w http.ResponseWriter, r *http.Request, id string
 				return
 			}
 		}
+		vc = skillOwnerViewContext(*sk)
 	}
 	if err := store.Delete(r.Context(), id, vc); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())

--- a/internal/server/skills.go
+++ b/internal/server/skills.go
@@ -262,10 +262,24 @@ func (s *Server) applySkillUpdate(w http.ResponseWriter, r *http.Request, id str
 		Status:                 req.Status,
 		DisableModelInvocation: req.DisableModelInvocation,
 	}
+	if vc.AgentID == "" && vc.UserID == "" {
+		if sk, err := s.findSkillByID(r.Context(), id); err == nil && sk.Scope == "system" {
+			if systemStore, ok := store.(interface {
+				UpdateSystemSkill(context.Context, string, skills.UpdatePatch) error
+			}); ok {
+				if err := systemStore.UpdateSystemSkill(r.Context(), id, patch); err != nil {
+					writeError(w, http.StatusInternalServerError, err.Error())
+					return
+				}
+				goto files
+			}
+		}
+	}
 	if err := store.Update(r.Context(), id, vc, patch); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+files:
 	for path, content := range req.Files {
 		if err := store.UpsertFile(r.Context(), id, path, content); err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())
@@ -288,6 +302,20 @@ func (s *Server) doDeleteSkill(w http.ResponseWriter, r *http.Request, id string
 	if store == nil {
 		writeError(w, http.StatusServiceUnavailable, "skills store not available")
 		return
+	}
+	if vc.AgentID == "" && vc.UserID == "" {
+		if sk, err := s.findSkillByID(r.Context(), id); err == nil && sk.Scope == "system" {
+			if systemStore, ok := store.(interface {
+				DeleteSystemSkill(context.Context, string) error
+			}); ok {
+				if err := systemStore.DeleteSystemSkill(r.Context(), id); err != nil {
+					writeError(w, http.StatusInternalServerError, err.Error())
+					return
+				}
+				writeData(w, http.StatusOK, map[string]string{"id": id})
+				return
+			}
+		}
 	}
 	if err := store.Delete(r.Context(), id, vc); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())

--- a/internal/server/skills_scoped.go
+++ b/internal/server/skills_scoped.go
@@ -192,7 +192,7 @@ func (s *Server) UpdateAgentSkill(w http.ResponseWriter, r *http.Request, id str
 		writeError(w, code, msg)
 		return
 	}
-	s.applySkillUpdate(w, r, skillID)
+	s.applySkillUpdate(w, r, skillID, skills.ViewContext{AgentID: agentID})
 }
 
 func (s *Server) DeleteAgentSkill(w http.ResponseWriter, r *http.Request, id string, skillId string) {
@@ -206,7 +206,7 @@ func (s *Server) DeleteAgentSkill(w http.ResponseWriter, r *http.Request, id str
 		writeError(w, code, msg)
 		return
 	}
-	s.doDeleteSkill(w, r, skillID)
+	s.doDeleteSkill(w, r, skillID, skills.ViewContext{AgentID: agentID})
 }
 
 func (s *Server) DeleteAgentSkillFile(w http.ResponseWriter, r *http.Request, id string, skillId string, params apiserver.DeleteAgentSkillFileParams) {
@@ -380,7 +380,7 @@ func (s *Server) UpdateProfileSkill(w http.ResponseWriter, r *http.Request, skil
 		writeError(w, code, msg)
 		return
 	}
-	s.applySkillUpdate(w, r, skillID)
+	s.applySkillUpdate(w, r, skillID, skills.ViewContext{UserID: info.UserID})
 }
 
 func (s *Server) DeleteProfileSkill(w http.ResponseWriter, r *http.Request, skillId string) {
@@ -394,7 +394,7 @@ func (s *Server) DeleteProfileSkill(w http.ResponseWriter, r *http.Request, skil
 		writeError(w, code, msg)
 		return
 	}
-	s.doDeleteSkill(w, r, skillID)
+	s.doDeleteSkill(w, r, skillID, skills.ViewContext{UserID: info.UserID})
 }
 
 func (s *Server) DeleteProfileSkillFile(w http.ResponseWriter, r *http.Request, skillId string, params apiserver.DeleteProfileSkillFileParams) {

--- a/internal/server/skills_scoped.go
+++ b/internal/server/skills_scoped.go
@@ -31,7 +31,7 @@ func (s *Server) findSkillByID(ctx context.Context, id string) (*skills.Skill, e
 	return nil, sql.ErrNoRows
 }
 
-// requireAgentManage verifies the caller is admin or the agent's creator.
+// requireAgentManage verifies the caller is the agent creator.
 // Returns (agent, 0, "") on success, (_, status, msg) on failure.
 func (s *Server) requireAgentManage(ctx context.Context, agentID string) (config.Agent, int, string) {
 	info := UserFromContext(ctx)
@@ -45,7 +45,7 @@ func (s *Server) requireAgentManage(ctx context.Context, agentID string) (config
 		}
 		return config.Agent{}, http.StatusInternalServerError, err.Error()
 	}
-	if !info.IsAdmin && a.CreatorID != info.UserID {
+	if a.CreatorID != info.UserID {
 		return config.Agent{}, http.StatusForbidden, "forbidden"
 	}
 	return a, 0, ""

--- a/internal/server/skills_scoped_test.go
+++ b/internal/server/skills_scoped_test.go
@@ -150,10 +150,10 @@ func TestAgentSkills_ListCreatorAccess(t *testing.T) {
 		t.Fatalf("other status = %d, want 403 (body: %s)", rr.Code, rr.Body.String())
 	}
 
-	// Admin: 200.
+	// Admin who is not the creator: 403.
 	rr = doRequest(t, env, "GET", "/api/agents/"+agentID+"/skills", nil)
-	if rr.Code != http.StatusOK {
-		t.Fatalf("admin status = %d, want 200 (body: %s)", rr.Code, rr.Body.String())
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("admin status = %d, want 403 (body: %s)", rr.Code, rr.Body.String())
 	}
 
 	// Unauth: 401.
@@ -245,13 +245,8 @@ func TestAgentSkills_UploadZipAdminOnly(t *testing.T) {
 	})
 
 	rr := doMultipartRequestWithSession(t, env.srv.Handler(), creatorSID, "POST", "/api/agents/"+agentID+"/skills/upload", "file", "uploaded-skill.zip", archive)
-	if rr.Code != http.StatusForbidden {
-		t.Fatalf("creator upload status = %d, want 403 (body: %s)", rr.Code, rr.Body.String())
-	}
-
-	rr = doMultipartRequestWithSession(t, env.srv.Handler(), env.sessionID, "POST", "/api/agents/"+agentID+"/skills/upload", "file", "uploaded-skill.zip", archive)
 	if rr.Code != http.StatusCreated {
-		t.Fatalf("admin upload status = %d, want 201 (body: %s)", rr.Code, rr.Body.String())
+		t.Fatalf("creator upload status = %d, want 201 (body: %s)", rr.Code, rr.Body.String())
 	}
 
 	resp := parseResponse(t, rr)
@@ -263,7 +258,7 @@ func TestAgentSkills_UploadZipAdminOnly(t *testing.T) {
 		t.Fatalf("uploaded name = %v, want uploaded-skill", created["name"])
 	}
 
-	rr = doRequest(t, env, "GET", "/api/agents/"+agentID+"/skills", nil)
+	rr = doRequestWithSession(t, env.srv, creatorSID, "GET", "/api/agents/"+agentID+"/skills", nil)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("list uploaded agent skills status = %d, want 200 (body: %s)", rr.Code, rr.Body.String())
 	}

--- a/internal/server/skills_upload.go
+++ b/internal/server/skills_upload.go
@@ -50,11 +50,8 @@ func (s *Server) UploadAgentSkill(w http.ResponseWriter, r *http.Request, id str
 		writeError(w, http.StatusUnauthorized, "unauthorized")
 		return
 	}
-	if !info.IsAdmin {
-		writeError(w, http.StatusForbidden, "forbidden")
-		return
-	}
-	if _, err := s.store.GetAgent(r.Context(), agentID); err != nil {
+	agent, err := s.store.GetAgent(r.Context(), agentID)
+	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			writeError(w, http.StatusNotFound, "agent not found")
 			return
@@ -62,12 +59,16 @@ func (s *Server) UploadAgentSkill(w http.ResponseWriter, r *http.Request, id str
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	if agent.CreatorID != info.UserID {
+		writeError(w, http.StatusForbidden, "only the creator can manage this agent")
+		return
+	}
 	up, code, msg := parseUploadedSkill(r)
 	if code != 0 {
 		writeError(w, code, msg)
 		return
 	}
-	id, err := s.skillStore().Create(r.Context(), skills.Skill{
+	skillID, err := s.skillStore().Create(r.Context(), skills.Skill{
 		Scope:                  "agent",
 		AgentID:                agentID,
 		Name:                   up.name,
@@ -80,7 +81,7 @@ func (s *Server) UploadAgentSkill(w http.ResponseWriter, r *http.Request, id str
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	writeData(w, http.StatusCreated, map[string]string{"id": id, "name": up.name})
+	writeData(w, http.StatusCreated, map[string]string{"id": skillID, "name": up.name})
 }
 
 func (s *Server) UploadProfileSkill(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/tasks.go
+++ b/internal/server/tasks.go
@@ -111,7 +111,7 @@ func (s *Server) GetAgentTask(w http.ResponseWriter, r *http.Request, id string)
 	}
 	info := UserFromContext(r.Context())
 
-	task, err := s.tasksSvc.GetTask(r.Context(), id)
+	task, err := s.tasksSvc.GetTask(r.Context(), id, info.UserID)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "task not found")
 		return
@@ -158,7 +158,7 @@ func (s *Server) UpdateAgentTask(w http.ResponseWriter, r *http.Request, id stri
 		agentID = *body.AgentId
 	}
 
-	task, err := s.tasksSvc.UpdateTask(r.Context(), id, userID, false, tasks.UpdateTaskParams{
+	task, err := s.tasksSvc.UpdateTask(r.Context(), id, userID, tasks.UpdateTaskParams{
 		Title:       title,
 		Description: description,
 		Priority:    priority,
@@ -186,7 +186,7 @@ func (s *Server) DeleteAgentTask(w http.ResponseWriter, r *http.Request, id stri
 		userID = info.UserID
 	}
 
-	if err := s.tasksSvc.DeleteTask(r.Context(), id, userID, false); err != nil {
+	if err := s.tasksSvc.DeleteTask(r.Context(), id, userID); err != nil {
 		if strings.Contains(err.Error(), "forbidden") {
 			writeError(w, http.StatusForbidden, "access denied")
 			return
@@ -219,7 +219,7 @@ func (s *Server) AgentTaskAction(w http.ResponseWriter, r *http.Request, id stri
 		message = *body.Message
 	}
 
-	task, err := s.tasksSvc.HandleAction(r.Context(), id, userID, false, tasks.ActionParams{
+	task, err := s.tasksSvc.HandleAction(r.Context(), id, userID, tasks.ActionParams{
 		Action:  string(body.Type),
 		Message: message,
 	})
@@ -241,7 +241,7 @@ func (s *Server) ListAgentTaskEvents(w http.ResponseWriter, r *http.Request, id 
 	}
 	info := UserFromContext(r.Context())
 
-	task, err := s.tasksSvc.GetTask(r.Context(), id)
+	task, err := s.tasksSvc.GetTask(r.Context(), id, info.UserID)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "task not found")
 		return

--- a/internal/skills/disk_sync.go
+++ b/internal/skills/disk_sync.go
@@ -87,12 +87,12 @@ func (d *DiskSyncStore) DeleteFile(ctx context.Context, skillID, path string) er
 
 // Delete removes the DB row first, then removes the disk directory.
 // DB-first ordering prevents MigrateFilesystem from re-importing orphaned dirs.
-func (d *DiskSyncStore) Delete(ctx context.Context, id string) error {
+func (d *DiskSyncStore) Delete(ctx context.Context, id string, vc ViewContext) error {
 	sk, err := d.findByID(ctx, id)
 	if err != nil {
 		return err
 	}
-	if err := d.Store.Delete(ctx, id); err != nil {
+	if err := d.Store.Delete(ctx, id, vc); err != nil {
 		return err
 	}
 	if sk != nil {

--- a/internal/skills/disk_sync.go
+++ b/internal/skills/disk_sync.go
@@ -95,19 +95,54 @@ func (d *DiskSyncStore) Delete(ctx context.Context, id string, vc ViewContext) e
 	if err := d.Store.Delete(ctx, id, vc); err != nil {
 		return err
 	}
-	if sk != nil {
-		base := d.resolver(sk.Scope, sk.AgentID, sk.UserID)
-		if base != "" {
-			skillDir, pathErr := safeDiskPath(base, sk.Name)
-			if pathErr == nil {
-				if err := os.RemoveAll(skillDir); err != nil {
-					slog.WarnContext(ctx, "disk_sync: failed to remove skill dir after DB delete",
-						"skill", sk.Name, "dir", skillDir, "err", err)
-				}
-			}
-		}
-	}
+	d.removeSkillDir(ctx, sk)
 	return nil
+}
+
+func (d *DiskSyncStore) UpdateSystemSkill(ctx context.Context, id string, patch UpdatePatch) error {
+	store, ok := d.Store.(interface {
+		UpdateSystemSkill(context.Context, string, UpdatePatch) error
+	})
+	if !ok {
+		return fmt.Errorf("disk_sync: inner store does not support system skill update")
+	}
+	return store.UpdateSystemSkill(ctx, id, patch)
+}
+
+func (d *DiskSyncStore) DeleteSystemSkill(ctx context.Context, id string) error {
+	sk, err := d.findByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	store, ok := d.Store.(interface {
+		DeleteSystemSkill(context.Context, string) error
+	})
+	if !ok {
+		return fmt.Errorf("disk_sync: inner store does not support system skill delete")
+	}
+	if err := store.DeleteSystemSkill(ctx, id); err != nil {
+		return err
+	}
+	d.removeSkillDir(ctx, sk)
+	return nil
+}
+
+func (d *DiskSyncStore) removeSkillDir(ctx context.Context, sk *Skill) {
+	if sk == nil {
+		return
+	}
+	base := d.resolver(sk.Scope, sk.AgentID, sk.UserID)
+	if base == "" {
+		return
+	}
+	skillDir, pathErr := safeDiskPath(base, sk.Name)
+	if pathErr != nil {
+		return
+	}
+	if err := os.RemoveAll(skillDir); err != nil {
+		slog.WarnContext(ctx, "disk_sync: failed to remove skill dir after DB delete",
+			"skill", sk.Name, "dir", skillDir, "err", err)
+	}
 }
 
 // SyncAllToDisk materializes every skill in the DB to disk. The DB is the

--- a/internal/skills/sqlite.go
+++ b/internal/skills/sqlite.go
@@ -185,6 +185,39 @@ func (s *SQLiteStore) Create(ctx context.Context, sk Skill, files map[string]str
 	return sk.ID, nil
 }
 
+type resolvedPatch struct {
+	Description            string
+	Status                 string
+	DisableModelInvocation int64
+	Metadata               string
+}
+
+func applyPatch(row sqlc.Skill, patch UpdatePatch) resolvedPatch {
+	r := resolvedPatch{
+		Description:            row.Description,
+		Status:                 row.Status,
+		DisableModelInvocation: row.DisableModelInvocation,
+		Metadata:               row.Metadata,
+	}
+	if patch.Description != nil {
+		r.Description = *patch.Description
+	}
+	if patch.Status != nil {
+		r.Status = *patch.Status
+	}
+	if patch.DisableModelInvocation != nil {
+		if *patch.DisableModelInvocation {
+			r.DisableModelInvocation = 1
+		} else {
+			r.DisableModelInvocation = 0
+		}
+	}
+	if len(patch.Metadata) > 0 {
+		r.Metadata = string(patch.Metadata)
+	}
+	return r
+}
+
 // Update patches metadata fields using read-modify-write.
 func (s *SQLiteStore) Update(ctx context.Context, id string, vc ViewContext, patch UpdatePatch) error {
 	agentID, userID := viewSQLParams(vc)
@@ -192,39 +225,15 @@ func (s *SQLiteStore) Update(ctx context.Context, id string, vc ViewContext, pat
 	if err != nil {
 		return fmt.Errorf("skills: update get %s: %w", id, err)
 	}
-
-	description := row.Description
-	if patch.Description != nil {
-		description = *patch.Description
-	}
-
-	status := row.Status
-	if patch.Status != nil {
-		status = *patch.Status
-	}
-
-	disabled := row.DisableModelInvocation
-	if patch.DisableModelInvocation != nil {
-		if *patch.DisableModelInvocation {
-			disabled = 1
-		} else {
-			disabled = 0
-		}
-	}
-
-	meta := row.Metadata
-	if len(patch.Metadata) > 0 {
-		meta = string(patch.Metadata)
-	}
-
+	p := applyPatch(row, patch)
 	if err := s.q.UpdateSkillMetadata(ctx, sqlc.UpdateSkillMetadataParams{
 		ID:                     id,
 		AgentID:                agentID,
 		UserID:                 userID,
-		Description:            description,
-		Status:                 status,
-		DisableModelInvocation: disabled,
-		Metadata:               meta,
+		Description:            p.Description,
+		Status:                 p.Status,
+		DisableModelInvocation: p.DisableModelInvocation,
+		Metadata:               p.Metadata,
 	}); err != nil {
 		return fmt.Errorf("skills: update %s: %w", id, err)
 	}
@@ -271,32 +280,13 @@ func (s *SQLiteStore) UpdateSystemSkill(ctx context.Context, id string, patch Up
 	if row.Scope != "system" {
 		return fmt.Errorf("skills: %s is not a system skill", id)
 	}
-	description := row.Description
-	if patch.Description != nil {
-		description = *patch.Description
-	}
-	status := row.Status
-	if patch.Status != nil {
-		status = *patch.Status
-	}
-	disabled := row.DisableModelInvocation
-	if patch.DisableModelInvocation != nil {
-		if *patch.DisableModelInvocation {
-			disabled = 1
-		} else {
-			disabled = 0
-		}
-	}
-	meta := row.Metadata
-	if len(patch.Metadata) > 0 {
-		meta = string(patch.Metadata)
-	}
+	p := applyPatch(row, patch)
 	if err := s.q.UpdateSystemSkillMetadata(ctx, sqlc.UpdateSystemSkillMetadataParams{
 		ID:                     id,
-		Description:            description,
-		Status:                 status,
-		DisableModelInvocation: disabled,
-		Metadata:               meta,
+		Description:            p.Description,
+		Status:                 p.Status,
+		DisableModelInvocation: p.DisableModelInvocation,
+		Metadata:               p.Metadata,
 	}); err != nil {
 		return fmt.Errorf("skills: system update %s: %w", id, err)
 	}

--- a/internal/skills/sqlite.go
+++ b/internal/skills/sqlite.go
@@ -24,6 +24,10 @@ func New(db *sql.DB) *SQLiteStore {
 	return &SQLiteStore{db: db, q: sqlc.New(db)}
 }
 
+func viewSQLParams(vc ViewContext) (sql.NullString, sql.NullString) {
+	return sql.NullString{String: vc.AgentID, Valid: vc.AgentID != ""}, sql.NullString{String: vc.UserID, Valid: vc.UserID != ""}
+}
+
 // List returns all visible skills for the given context.
 func (s *SQLiteStore) List(ctx context.Context, vc ViewContext) ([]Skill, error) {
 	rows, err := s.q.ListSkillsVisible(ctx, sqlc.ListSkillsVisibleParams{
@@ -182,8 +186,9 @@ func (s *SQLiteStore) Create(ctx context.Context, sk Skill, files map[string]str
 }
 
 // Update patches metadata fields using read-modify-write.
-func (s *SQLiteStore) Update(ctx context.Context, id string, patch UpdatePatch) error {
-	row, err := s.q.GetSkill(ctx, id)
+func (s *SQLiteStore) Update(ctx context.Context, id string, vc ViewContext, patch UpdatePatch) error {
+	agentID, userID := viewSQLParams(vc)
+	row, err := s.q.GetSkill(ctx, sqlc.GetSkillParams{ID: id, AgentID: agentID, UserID: userID})
 	if err != nil {
 		return fmt.Errorf("skills: update get %s: %w", id, err)
 	}
@@ -214,6 +219,8 @@ func (s *SQLiteStore) Update(ctx context.Context, id string, patch UpdatePatch) 
 
 	if err := s.q.UpdateSkillMetadata(ctx, sqlc.UpdateSkillMetadataParams{
 		ID:                     id,
+		AgentID:                agentID,
+		UserID:                 userID,
 		Description:            description,
 		Status:                 status,
 		DisableModelInvocation: disabled,
@@ -248,8 +255,9 @@ func (s *SQLiteStore) DeleteFile(ctx context.Context, skillID, path string) erro
 }
 
 // Delete removes a skill and (via ON DELETE CASCADE) all its files.
-func (s *SQLiteStore) Delete(ctx context.Context, id string) error {
-	if err := s.q.DeleteSkill(ctx, id); err != nil {
+func (s *SQLiteStore) Delete(ctx context.Context, id string, vc ViewContext) error {
+	agentID, userID := viewSQLParams(vc)
+	if err := s.q.DeleteSkill(ctx, sqlc.DeleteSkillParams{ID: id, AgentID: agentID, UserID: userID}); err != nil {
 		return fmt.Errorf("skills: delete %s: %w", id, err)
 	}
 	return nil

--- a/internal/skills/sqlite.go
+++ b/internal/skills/sqlite.go
@@ -263,6 +263,53 @@ func (s *SQLiteStore) Delete(ctx context.Context, id string, vc ViewContext) err
 	return nil
 }
 
+func (s *SQLiteStore) UpdateSystemSkill(ctx context.Context, id string, patch UpdatePatch) error {
+	row, err := s.q.GetSkill(ctx, sqlc.GetSkillParams{ID: id})
+	if err != nil {
+		return fmt.Errorf("skills: system update get %s: %w", id, err)
+	}
+	if row.Scope != "system" {
+		return fmt.Errorf("skills: %s is not a system skill", id)
+	}
+	description := row.Description
+	if patch.Description != nil {
+		description = *patch.Description
+	}
+	status := row.Status
+	if patch.Status != nil {
+		status = *patch.Status
+	}
+	disabled := row.DisableModelInvocation
+	if patch.DisableModelInvocation != nil {
+		if *patch.DisableModelInvocation {
+			disabled = 1
+		} else {
+			disabled = 0
+		}
+	}
+	meta := row.Metadata
+	if len(patch.Metadata) > 0 {
+		meta = string(patch.Metadata)
+	}
+	if err := s.q.UpdateSystemSkillMetadata(ctx, sqlc.UpdateSystemSkillMetadataParams{
+		ID:                     id,
+		Description:            description,
+		Status:                 status,
+		DisableModelInvocation: disabled,
+		Metadata:               meta,
+	}); err != nil {
+		return fmt.Errorf("skills: system update %s: %w", id, err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) DeleteSystemSkill(ctx context.Context, id string) error {
+	if err := s.q.DeleteSystemSkill(ctx, id); err != nil {
+		return fmt.Errorf("skills: system delete %s: %w", id, err)
+	}
+	return nil
+}
+
 // ExpireDrafts deprecates all draft skills (disable_model_invocation=0) whose
 // created-at metadata timestamp is before the given cutoff.
 func (s *SQLiteStore) ExpireDrafts(ctx context.Context, before time.Time) error {

--- a/internal/skills/sqlite_test.go
+++ b/internal/skills/sqlite_test.go
@@ -160,7 +160,7 @@ func TestResolvePrecedence(t *testing.T) {
 	})
 
 	t.Run("agent wins after user deleted", func(t *testing.T) {
-		if err := store.Delete(ctx, userSkID); err != nil {
+		if err := store.Delete(ctx, userSkID, ViewContext{UserID: userID}); err != nil {
 			t.Fatalf("Delete user: %v", err)
 		}
 		sk, err := store.Resolve(ctx, "foo", vc)
@@ -173,7 +173,7 @@ func TestResolvePrecedence(t *testing.T) {
 	})
 
 	t.Run("system wins after agent deleted", func(t *testing.T) {
-		if err := store.Delete(ctx, agentSkID); err != nil {
+		if err := store.Delete(ctx, agentSkID, ViewContext{AgentID: agentID}); err != nil {
 			t.Fatalf("Delete agent: %v", err)
 		}
 		sk, err := store.Resolve(ctx, "foo", vc)
@@ -262,7 +262,7 @@ func TestDeprecatedAndDisabled(t *testing.T) {
 			t.Fatalf("Create: %v", err)
 		}
 		status := "deprecated"
-		if err := store.Update(ctx, id, UpdatePatch{Status: &status}); err != nil {
+		if err := store.Update(ctx, id, ViewContext{UserID: userID}, UpdatePatch{Status: &status}); err != nil {
 			t.Fatalf("Update: %v", err)
 		}
 
@@ -297,7 +297,7 @@ func TestDeprecatedAndDisabled(t *testing.T) {
 			t.Fatalf("Create: %v", err)
 		}
 		disabled := true
-		if err := store.Update(ctx, id, UpdatePatch{DisableModelInvocation: &disabled}); err != nil {
+		if err := store.Update(ctx, id, ViewContext{UserID: userID}, UpdatePatch{DisableModelInvocation: &disabled}); err != nil {
 			t.Fatalf("Update: %v", err)
 		}
 
@@ -386,7 +386,7 @@ func TestDeleteCascadesSkillFiles(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 
-	if err := store.Delete(ctx, id); err != nil {
+	if err := store.Delete(ctx, id, ViewContext{UserID: userID}); err != nil {
 		t.Fatalf("Delete: %v", err)
 	}
 

--- a/internal/skills/store.go
+++ b/internal/skills/store.go
@@ -63,13 +63,13 @@ type Store interface {
 	Create(ctx context.Context, s Skill, files map[string]string) (string, error)
 
 	// Update patches metadata fields. Use UpsertFile to change file content.
-	Update(ctx context.Context, id string, patch UpdatePatch) error
+	Update(ctx context.Context, id string, vc ViewContext, patch UpdatePatch) error
 
 	// UpsertFile creates or replaces a single file under a skill.
 	UpsertFile(ctx context.Context, skillID, path, content string) error
 
 	DeleteFile(ctx context.Context, skillID, path string) error
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, id string, vc ViewContext) error
 
 	// ExpireDrafts deprecates all draft skills (disable_model_invocation=0) whose
 	// created-at timestamp is before the given cutoff. Knowledge entries are excluded.

--- a/internal/skills/sync_builtin.go
+++ b/internal/skills/sync_builtin.go
@@ -133,6 +133,12 @@ func SyncBuiltin(ctx context.Context, store Store, builtinFS fs.FS) error {
 }
 
 func deleteRemovedSystemSkills(ctx context.Context, store Store, rows []Skill, desired map[string]struct{}) error {
+	systemStore, ok := store.(interface {
+		DeleteSystemSkill(context.Context, string) error
+	})
+	if !ok {
+		return fmt.Errorf("sync_builtin: store does not support system skill delete")
+	}
 	for _, row := range rows {
 		if row.Scope != "system" {
 			continue
@@ -140,7 +146,7 @@ func deleteRemovedSystemSkills(ctx context.Context, store Store, rows []Skill, d
 		if _, ok := desired[row.Name]; ok {
 			continue
 		}
-		if err := store.Delete(ctx, row.ID, ViewContext{}); err != nil {
+		if err := systemStore.DeleteSystemSkill(ctx, row.ID); err != nil {
 			return fmt.Errorf("delete skill %q (%s): %w", row.Name, row.ID, err)
 		}
 		slog.InfoContext(ctx, "sync_builtin: deleted removed system skill", "name", row.Name, "id", row.ID)
@@ -231,7 +237,13 @@ func syncBuiltinSkill(ctx context.Context, store Store, builtinFS fs.FS, skillRo
 		existing.Status != normalizeBuiltinStatus(fm.Status) ||
 		existing.DisableModelInvocation != fm.DisableModelInvocation ||
 		string(existing.Metadata) != string(meta) {
-		if err := store.Update(ctx, skillID, ViewContext{}, UpdatePatch{
+		systemStore, ok := store.(interface {
+			UpdateSystemSkill(context.Context, string, UpdatePatch) error
+		})
+		if !ok {
+			return fmt.Errorf("store does not support system skill update")
+		}
+		if err := systemStore.UpdateSystemSkill(ctx, skillID, UpdatePatch{
 			Description:            &fm.Description,
 			Status:                 strPtr(normalizeBuiltinStatus(fm.Status)),
 			DisableModelInvocation: &fm.DisableModelInvocation,

--- a/internal/skills/sync_builtin.go
+++ b/internal/skills/sync_builtin.go
@@ -140,7 +140,7 @@ func deleteRemovedSystemSkills(ctx context.Context, store Store, rows []Skill, d
 		if _, ok := desired[row.Name]; ok {
 			continue
 		}
-		if err := store.Delete(ctx, row.ID); err != nil {
+		if err := store.Delete(ctx, row.ID, ViewContext{}); err != nil {
 			return fmt.Errorf("delete skill %q (%s): %w", row.Name, row.ID, err)
 		}
 		slog.InfoContext(ctx, "sync_builtin: deleted removed system skill", "name", row.Name, "id", row.ID)
@@ -231,7 +231,7 @@ func syncBuiltinSkill(ctx context.Context, store Store, builtinFS fs.FS, skillRo
 		existing.Status != normalizeBuiltinStatus(fm.Status) ||
 		existing.DisableModelInvocation != fm.DisableModelInvocation ||
 		string(existing.Metadata) != string(meta) {
-		if err := store.Update(ctx, skillID, UpdatePatch{
+		if err := store.Update(ctx, skillID, ViewContext{}, UpdatePatch{
 			Description:            &fm.Description,
 			Status:                 strPtr(normalizeBuiltinStatus(fm.Status)),
 			DisableModelInvocation: &fm.DisableModelInvocation,

--- a/internal/tasks/control_tool.go
+++ b/internal/tasks/control_tool.go
@@ -18,13 +18,15 @@ const controlToolName = "task_control"
 type TaskControlTool struct {
 	q      *sqlc.Queries
 	taskID string
+	userID string
 	cancel context.CancelFunc
 }
 
-func newTaskControlTool(q *sqlc.Queries, taskID string, cancel context.CancelFunc) *TaskControlTool {
+func newTaskControlTool(q *sqlc.Queries, taskID string, userID string, cancel context.CancelFunc) *TaskControlTool {
 	return &TaskControlTool{
 		q:      q,
 		taskID: taskID,
+		userID: userID,
 		cancel: cancel,
 	}
 }
@@ -83,6 +85,7 @@ func (t *TaskControlTool) Execute(ctx context.Context, args map[string]any) (str
 			Context:   contextJSON,
 			UpdatedAt: now,
 			ID:        t.taskID,
+			UserID:    t.userID,
 		}); err != nil {
 			return "", fmt.Errorf("task_control: update context: %w", err)
 		}
@@ -95,6 +98,7 @@ func (t *TaskControlTool) Execute(ctx context.Context, args map[string]any) (str
 					NotifyAt:  sql.NullString{String: notifyAt, Valid: true},
 					UpdatedAt: now,
 					ID:        t.taskID,
+					UserID:    t.userID,
 				})
 			}
 		}
@@ -108,6 +112,7 @@ func (t *TaskControlTool) Execute(ctx context.Context, args map[string]any) (str
 			Status:    "blocked",
 			UpdatedAt: now,
 			ID:        t.taskID,
+			UserID:    t.userID,
 		}); err != nil {
 			return "", fmt.Errorf("task_control: set blocked: %w", err)
 		}
@@ -115,6 +120,7 @@ func (t *TaskControlTool) Execute(ctx context.Context, args map[string]any) (str
 			NotifyAt:  sql.NullString{String: now, Valid: true},
 			UpdatedAt: now,
 			ID:        t.taskID,
+			UserID:    t.userID,
 		}); err != nil {
 			return "", fmt.Errorf("task_control: set notify_at: %w", err)
 		}
@@ -138,6 +144,7 @@ func (t *TaskControlTool) Execute(ctx context.Context, args map[string]any) (str
 			Status:    "review_requested",
 			UpdatedAt: now,
 			ID:        t.taskID,
+			UserID:    t.userID,
 		}); err != nil {
 			return "", fmt.Errorf("task_control: set review_requested: %w", err)
 		}
@@ -145,6 +152,7 @@ func (t *TaskControlTool) Execute(ctx context.Context, args map[string]any) (str
 			ReviewRequest: reviewJSON,
 			UpdatedAt:     now,
 			ID:            t.taskID,
+			UserID:        t.userID,
 		}); err != nil {
 			return "", fmt.Errorf("task_control: update review_request: %w", err)
 		}
@@ -152,6 +160,7 @@ func (t *TaskControlTool) Execute(ctx context.Context, args map[string]any) (str
 			NotifyAt:  sql.NullString{String: now, Valid: true},
 			UpdatedAt: now,
 			ID:        t.taskID,
+			UserID:    t.userID,
 		}); err != nil {
 			return "", fmt.Errorf("task_control: set notify_at: %w", err)
 		}
@@ -171,6 +180,7 @@ func (t *TaskControlTool) Execute(ctx context.Context, args map[string]any) (str
 				Context:   string(outputJSON),
 				UpdatedAt: now,
 				ID:        t.taskID,
+				UserID:    t.userID,
 			}); err != nil {
 				return "", fmt.Errorf("task_control: store output: %w", err)
 			}
@@ -179,6 +189,7 @@ func (t *TaskControlTool) Execute(ctx context.Context, args map[string]any) (str
 			Status:    "done",
 			UpdatedAt: now,
 			ID:        t.taskID,
+			UserID:    t.userID,
 		}); err != nil {
 			return "", fmt.Errorf("task_control: set done: %w", err)
 		}
@@ -193,6 +204,7 @@ func (t *TaskControlTool) Execute(ctx context.Context, args map[string]any) (str
 			Status:    "failed",
 			UpdatedAt: now,
 			ID:        t.taskID,
+			UserID:    t.userID,
 		}); err != nil {
 			return "", fmt.Errorf("task_control: set failed: %w", err)
 		}

--- a/internal/tasks/service.go
+++ b/internal/tasks/service.go
@@ -113,6 +113,7 @@ func (s *Service) Start(ctx context.Context) error {
 			Status:    "pending",
 			UpdatedAt: now,
 			ID:        t.ID,
+			UserID:    t.UserID,
 		}); err != nil {
 			s.log.Warn("failed to reset running task", "task_id", t.ID, "error", err)
 		}
@@ -159,6 +160,7 @@ func (s *Service) sweepNotifications(ctx context.Context, now string) {
 			NotifyAt:  sql.NullString{Valid: false},
 			UpdatedAt: now,
 			ID:        t.ID,
+			UserID:    t.UserID,
 		})
 	}
 }
@@ -197,7 +199,7 @@ func (s *Service) sweepDepFailures(ctx context.Context, now string) {
 			continue
 		}
 		for _, depID := range deps {
-			dep, err := s.q.GetAgentTask(ctx, depID)
+			dep, err := s.q.GetAgentTask(ctx, sqlc.GetAgentTaskParams{ID: depID, UserID: t.UserID})
 			if err != nil {
 				continue
 			}
@@ -206,11 +208,13 @@ func (s *Service) sweepDepFailures(ctx context.Context, now string) {
 					Status:    "blocked",
 					UpdatedAt: now,
 					ID:        t.ID,
+					UserID:    t.UserID,
 				})
 				_ = s.q.UpdateAgentTaskNotifyAt(ctx, sqlc.UpdateAgentTaskNotifyAtParams{
 					NotifyAt:  sql.NullString{String: now, Valid: true},
 					UpdatedAt: now,
 					ID:        t.ID,
+					UserID:    t.UserID,
 				})
 				_, _ = s.q.InsertAgentTaskEvent(ctx, sqlc.InsertAgentTaskEventParams{
 					ID:        newID(),
@@ -262,7 +266,7 @@ func (s *Service) sweepDispatch(ctx context.Context) {
 // depsAllDone returns true if all dep tasks are in "done" status.
 func (s *Service) depsAllDone(ctx context.Context, t sqlc.AgentTask) bool {
 	for _, depID := range parseDeps(t.Deps) {
-		dep, err := s.q.GetAgentTask(ctx, depID)
+		dep, err := s.q.GetAgentTask(ctx, sqlc.GetAgentTaskParams{ID: depID, UserID: t.UserID})
 		if err != nil || dep.Status != "done" {
 			return false
 		}
@@ -278,7 +282,7 @@ func (s *Service) CreateTask(ctx context.Context, params CreateTaskParams) (sqlc
 	}
 
 	// Validate deps exist.
-	if err := s.validateDeps(ctx, params.Deps); err != nil {
+	if err := s.validateDeps(ctx, params.UserID, params.Deps); err != nil {
 		return sqlc.AgentTask{}, err
 	}
 
@@ -313,9 +317,9 @@ func (s *Service) CreateTask(ctx context.Context, params CreateTaskParams) (sqlc
 }
 
 // validateDeps checks that all dep IDs exist and that adding them introduces no cycle.
-func (s *Service) validateDeps(ctx context.Context, deps []string) error {
+func (s *Service) validateDeps(ctx context.Context, userID string, deps []string) error {
 	for _, id := range deps {
-		if _, err := s.q.GetAgentTask(ctx, id); err != nil {
+		if _, err := s.q.GetAgentTask(ctx, sqlc.GetAgentTaskParams{ID: id, UserID: userID}); err != nil {
 			return fmt.Errorf("tasks: dep %q not found: %w", id, err)
 		}
 	}
@@ -328,7 +332,7 @@ func (s *Service) validateDeps(ctx context.Context, deps []string) error {
 		}
 		inStack[id] = true
 		defer func() { inStack[id] = false }()
-		t, err := s.q.GetAgentTask(ctx, id)
+		t, err := s.q.GetAgentTask(ctx, sqlc.GetAgentTaskParams{ID: id, UserID: userID})
 		if err != nil {
 			return nil
 		}
@@ -348,8 +352,8 @@ func (s *Service) validateDeps(ctx context.Context, deps []string) error {
 }
 
 // GetTask returns a single task by ID.
-func (s *Service) GetTask(ctx context.Context, id string) (sqlc.AgentTask, error) {
-	task, err := s.q.GetAgentTask(ctx, id)
+func (s *Service) GetTask(ctx context.Context, id string, userID string) (sqlc.AgentTask, error) {
+	task, err := s.q.GetAgentTask(ctx, sqlc.GetAgentTaskParams{ID: id, UserID: userID})
 	if err != nil {
 		return sqlc.AgentTask{}, fmt.Errorf("tasks: get %s: %w", id, err)
 	}
@@ -386,13 +390,10 @@ func (s *Service) ListTasks(ctx context.Context, userID, agentID, status string)
 }
 
 // UpdateTask updates mutable task fields (title, description, priority, agent_id).
-func (s *Service) UpdateTask(ctx context.Context, id string, userID string, isAdmin bool, update UpdateTaskParams) (sqlc.AgentTask, error) {
-	task, err := s.q.GetAgentTask(ctx, id)
+func (s *Service) UpdateTask(ctx context.Context, id string, userID string, update UpdateTaskParams) (sqlc.AgentTask, error) {
+	task, err := s.q.GetAgentTask(ctx, sqlc.GetAgentTaskParams{ID: id, UserID: userID})
 	if err != nil {
 		return sqlc.AgentTask{}, fmt.Errorf("tasks: get for update: %w", err)
-	}
-	if !isAdmin && task.UserID != userID {
-		return sqlc.AgentTask{}, fmt.Errorf("tasks: forbidden")
 	}
 	title := update.Title
 	if title == "" {
@@ -417,20 +418,18 @@ func (s *Service) UpdateTask(ctx context.Context, id string, userID string, isAd
 		AgentID:     sql.NullString{String: agentID, Valid: agentID != ""},
 		UpdatedAt:   time.Now().Format(time.RFC3339),
 		ID:          id,
+		UserID:      userID,
 	}); err != nil {
 		return sqlc.AgentTask{}, fmt.Errorf("tasks: update: %w", err)
 	}
-	return s.q.GetAgentTask(ctx, id)
+	return s.q.GetAgentTask(ctx, sqlc.GetAgentTaskParams{ID: id, UserID: userID})
 }
 
 // DeleteTask deletes a task (cancels running worker if present).
-func (s *Service) DeleteTask(ctx context.Context, id string, userID string, isAdmin bool) error {
-	task, err := s.q.GetAgentTask(ctx, id)
+func (s *Service) DeleteTask(ctx context.Context, id string, userID string) error {
+	_, err := s.q.GetAgentTask(ctx, sqlc.GetAgentTaskParams{ID: id, UserID: userID})
 	if err != nil {
 		return fmt.Errorf("tasks: get for delete: %w", err)
-	}
-	if !isAdmin && task.UserID != userID {
-		return fmt.Errorf("tasks: forbidden")
 	}
 	s.mu.Lock()
 	cancel, running := s.workers[id]
@@ -438,17 +437,14 @@ func (s *Service) DeleteTask(ctx context.Context, id string, userID string, isAd
 	if running {
 		cancel()
 	}
-	return s.q.DeleteAgentTask(ctx, id)
+	return s.q.DeleteAgentTask(ctx, sqlc.DeleteAgentTaskParams{ID: id, UserID: userID})
 }
 
 // HandleAction processes approve/reject/respond/cancel actions on a task.
-func (s *Service) HandleAction(ctx context.Context, id string, userID string, isAdmin bool, action ActionParams) (sqlc.AgentTask, error) {
-	task, err := s.q.GetAgentTask(ctx, id)
+func (s *Service) HandleAction(ctx context.Context, id string, userID string, action ActionParams) (sqlc.AgentTask, error) {
+	task, err := s.q.GetAgentTask(ctx, sqlc.GetAgentTaskParams{ID: id, UserID: userID})
 	if err != nil {
 		return sqlc.AgentTask{}, fmt.Errorf("tasks: get for action: %w", err)
-	}
-	if !isAdmin && task.UserID != userID {
-		return sqlc.AgentTask{}, fmt.Errorf("tasks: forbidden")
 	}
 
 	now := time.Now().Format(time.RFC3339)
@@ -461,6 +457,7 @@ func (s *Service) HandleAction(ctx context.Context, id string, userID string, is
 				Status:    "cancelled",
 				UpdatedAt: now,
 				ID:        id,
+				UserID:    userID,
 			}); err != nil {
 				return sqlc.AgentTask{}, fmt.Errorf("tasks: cancel: %w", err)
 			}
@@ -475,6 +472,7 @@ func (s *Service) HandleAction(ctx context.Context, id string, userID string, is
 				Status:    "cancelled",
 				UpdatedAt: now,
 				ID:        id,
+				UserID:    userID,
 			}); err != nil {
 				return sqlc.AgentTask{}, fmt.Errorf("tasks: cancel running: %w", err)
 			}
@@ -490,6 +488,7 @@ func (s *Service) HandleAction(ctx context.Context, id string, userID string, is
 			ReviewRequest: "{}",
 			UpdatedAt:     now,
 			ID:            id,
+			UserID:        userID,
 		}); err != nil {
 			return sqlc.AgentTask{}, fmt.Errorf("tasks: clear review_request: %w", err)
 		}
@@ -497,6 +496,7 @@ func (s *Service) HandleAction(ctx context.Context, id string, userID string, is
 			Status:    "pending",
 			UpdatedAt: now,
 			ID:        id,
+			UserID:    userID,
 		}); err != nil {
 			return sqlc.AgentTask{}, fmt.Errorf("tasks: approve set pending: %w", err)
 		}
@@ -509,6 +509,7 @@ func (s *Service) HandleAction(ctx context.Context, id string, userID string, is
 			Status:    "failed",
 			UpdatedAt: now,
 			ID:        id,
+			UserID:    userID,
 		}); err != nil {
 			return sqlc.AgentTask{}, fmt.Errorf("tasks: reject: %w", err)
 		}
@@ -542,6 +543,7 @@ func (s *Service) HandleAction(ctx context.Context, id string, userID string, is
 			ReviewRequest: "{}",
 			UpdatedAt:     now,
 			ID:            id,
+			UserID:        userID,
 		}); err != nil {
 			return sqlc.AgentTask{}, fmt.Errorf("tasks: respond clear review_request: %w", err)
 		}
@@ -549,6 +551,7 @@ func (s *Service) HandleAction(ctx context.Context, id string, userID string, is
 			Status:    "pending",
 			UpdatedAt: now,
 			ID:        id,
+			UserID:    userID,
 		}); err != nil {
 			return sqlc.AgentTask{}, fmt.Errorf("tasks: respond set pending: %w", err)
 		}
@@ -557,7 +560,7 @@ func (s *Service) HandleAction(ctx context.Context, id string, userID string, is
 		return sqlc.AgentTask{}, fmt.Errorf("tasks: unknown action %q", action.Action)
 	}
 
-	return s.q.GetAgentTask(ctx, id)
+	return s.q.GetAgentTask(ctx, sqlc.GetAgentTaskParams{ID: id, UserID: userID})
 }
 
 // ListTaskEvents returns all events for a task ordered by creation time.

--- a/internal/tasks/worker.go
+++ b/internal/tasks/worker.go
@@ -30,13 +30,14 @@ func runWorker(ctx context.Context, cancel context.CancelFunc, cfg workerConfig,
 		Status:    "running",
 		UpdatedAt: now,
 		ID:        task.ID,
+		UserID:    task.UserID,
 		Status_2:  "pending",
 	}); err != nil {
 		log.Error("failed to claim task", "error", err)
 		return
 	}
 	// Verify the claim succeeded (UpdateAgentTaskStatusFrom returns nil even on 0 rows).
-	claimed, err := cfg.q.GetAgentTask(ctx, task.ID)
+	claimed, err := cfg.q.GetAgentTask(ctx, sqlc.GetAgentTaskParams{ID: task.ID, UserID: task.UserID})
 	if err != nil {
 		log.Error("failed to verify task claim", "error", err)
 		return
@@ -62,12 +63,12 @@ func runWorker(ctx context.Context, cancel context.CancelFunc, cfg workerConfig,
 	factory, ok := cfg.runnerFactory(agentID)
 	if !ok {
 		log.Error("no runner factory for agent", "agent_id", agentID)
-		markFailed(ctx, cfg.q, task.ID, fmt.Sprintf("no runner available for agent %q", agentID))
+		markFailed(ctx, cfg.q, task.ID, task.UserID, fmt.Sprintf("no runner available for agent %q", agentID))
 		return
 	}
 
 	// Build the control tool with the worker's cancel func.
-	controlTool := newTaskControlTool(cfg.q, task.ID, cancel)
+	controlTool := newTaskControlTool(cfg.q, task.ID, task.UserID, cancel)
 
 	// Create a full runner (with sandbox tools) via the agent factory,
 	// injecting task_control as an extra tool.
@@ -79,7 +80,7 @@ func runWorker(ctx context.Context, cancel context.CancelFunc, cfg workerConfig,
 	})
 	if err != nil {
 		log.Error("create runner failed", "error", err)
-		markFailed(ctx, cfg.q, task.ID, fmt.Sprintf("create runner: %v", err))
+		markFailed(ctx, cfg.q, task.ID, task.UserID, fmt.Sprintf("create runner: %v", err))
 		return
 	}
 	defer func() { _ = runner.Close() }()
@@ -92,12 +93,12 @@ func runWorker(ctx context.Context, cancel context.CancelFunc, cfg workerConfig,
 
 	if err := saveTaskSessionInfo(memCtx, cfg.mem, task, session); err != nil {
 		log.Error("memory session info failed", "error", err)
-		markFailed(ctx, cfg.q, task.ID, fmt.Sprintf("memory session info failed: %v", err))
+		markFailed(ctx, cfg.q, task.ID, task.UserID, fmt.Sprintf("memory session info failed: %v", err))
 		return
 	}
 	if err := cfg.mem.Bootstrap(memCtx, session); err != nil {
 		log.Error("memory bootstrap failed", "error", err)
-		markFailed(ctx, cfg.q, task.ID, fmt.Sprintf("memory bootstrap failed: %v", err))
+		markFailed(ctx, cfg.q, task.ID, task.UserID, fmt.Sprintf("memory bootstrap failed: %v", err))
 		return
 	}
 
@@ -105,7 +106,7 @@ func runWorker(ctx context.Context, cancel context.CancelFunc, cfg workerConfig,
 	history, err := cfg.mem.Assemble(memCtx, session, 100_000, 20)
 	if err != nil {
 		log.Error("assemble history failed", "error", err)
-		markFailed(ctx, cfg.q, task.ID, fmt.Sprintf("assemble history: %v", err))
+		markFailed(ctx, cfg.q, task.ID, task.UserID, fmt.Sprintf("assemble history: %v", err))
 		return
 	}
 
@@ -143,7 +144,7 @@ func runWorker(ctx context.Context, cancel context.CancelFunc, cfg workerConfig,
 	}
 
 	// If the task is still running (agent exited without calling task_control), finalize it.
-	final, err := cfg.q.GetAgentTask(cleanupCtx, task.ID)
+	final, err := cfg.q.GetAgentTask(cleanupCtx, sqlc.GetAgentTaskParams{ID: task.ID, UserID: task.UserID})
 	if err != nil {
 		log.Error("failed to read final task status", "error", err)
 		return
@@ -152,10 +153,10 @@ func runWorker(ctx context.Context, cancel context.CancelFunc, cfg workerConfig,
 	if final.Status == "running" {
 		if runErr != nil {
 			log.Error("agent loop failed", "error", runErr)
-			markFailed(cleanupCtx, cfg.q, task.ID, runErr.Error())
+			markFailed(cleanupCtx, cfg.q, task.ID, task.UserID, runErr.Error())
 		} else {
 			log.Info("agent loop finished without explicit task_control done call, marking done")
-			markDone(cleanupCtx, cfg.q, task.ID)
+			markDone(cleanupCtx, cfg.q, task.ID, task.UserID)
 		}
 	}
 }
@@ -176,12 +177,13 @@ func taskResumeMessage(task sqlc.AgentTask) string {
 	return fmt.Sprintf("[Resume] Task ID: %s\nTask: %s\nStatus before resume: %s\nStored context: %s\n\nContinue from the persisted conversation and this task context.", task.ID, task.Title, task.Status, task.Context)
 }
 
-func markFailed(ctx context.Context, q *sqlc.Queries, taskID, reason string) {
+func markFailed(ctx context.Context, q *sqlc.Queries, taskID, userID, reason string) {
 	now := time.Now().Format(time.RFC3339)
 	_ = q.UpdateAgentTaskStatus(ctx, sqlc.UpdateAgentTaskStatusParams{
 		Status:    "failed",
 		UpdatedAt: now,
 		ID:        taskID,
+		UserID:    userID,
 	})
 	_, _ = q.InsertAgentTaskEvent(ctx, sqlc.InsertAgentTaskEventParams{
 		ID:        newID(),
@@ -193,12 +195,13 @@ func markFailed(ctx context.Context, q *sqlc.Queries, taskID, reason string) {
 	})
 }
 
-func markDone(ctx context.Context, q *sqlc.Queries, taskID string) {
+func markDone(ctx context.Context, q *sqlc.Queries, taskID, userID string) {
 	now := time.Now().Format(time.RFC3339)
 	_ = q.UpdateAgentTaskStatus(ctx, sqlc.UpdateAgentTaskStatusParams{
 		Status:    "done",
 		UpdatedAt: now,
 		ID:        taskID,
+		UserID:    userID,
 	})
 	_, _ = q.InsertAgentTaskEvent(ctx, sqlc.InsertAgentTaskEventParams{
 		ID:        newID(),

--- a/internal/tools/skills/tool_test.go
+++ b/internal/tools/skills/tool_test.go
@@ -142,7 +142,7 @@ func (s *testSkillStore) Create(ctx context.Context, sk pkgplugins.Skill, files 
 }
 
 func (s *testSkillStore) Update(ctx context.Context, id string, patch pkgplugins.SkillUpdatePatch) error {
-	row, err := s.q.GetSkill(ctx, id)
+	row, err := s.q.GetSkill(ctx, sqlc.GetSkillParams{ID: id})
 	if err != nil {
 		return err
 	}
@@ -180,7 +180,7 @@ func (s *testSkillStore) DeleteFile(ctx context.Context, skillID, path string) e
 }
 
 func (s *testSkillStore) Delete(ctx context.Context, id string) error {
-	return s.q.DeleteSkill(ctx, id)
+	return s.q.DeleteSkill(ctx, sqlc.DeleteSkillParams{ID: id})
 }
 
 func (s *testSkillStore) ExpireDrafts(ctx context.Context, before time.Time) error {

--- a/internal/tools/skills/tool_test.go
+++ b/internal/tools/skills/tool_test.go
@@ -166,9 +166,16 @@ func (s *testSkillStore) Update(ctx context.Context, id string, patch pkgplugins
 	if len(patch.Metadata) > 0 {
 		meta = string(patch.Metadata)
 	}
-	return s.q.UpdateSkillMetadata(ctx, sqlc.UpdateSkillMetadataParams{
+	params := sqlc.UpdateSkillMetadataParams{
 		ID: id, Description: desc, Status: status, DisableModelInvocation: disabled, Metadata: meta,
-	})
+	}
+	if row.Scope == "agent" {
+		params.AgentID = row.AgentID
+	}
+	if row.Scope == "user" {
+		params.UserID = row.UserID
+	}
+	return s.q.UpdateSkillMetadata(ctx, params)
 }
 
 func (s *testSkillStore) UpsertFile(ctx context.Context, skillID, path, content string) error {
@@ -180,7 +187,18 @@ func (s *testSkillStore) DeleteFile(ctx context.Context, skillID, path string) e
 }
 
 func (s *testSkillStore) Delete(ctx context.Context, id string) error {
-	return s.q.DeleteSkill(ctx, sqlc.DeleteSkillParams{ID: id})
+	row, err := s.q.GetSkill(ctx, sqlc.GetSkillParams{ID: id})
+	if err != nil {
+		return err
+	}
+	params := sqlc.DeleteSkillParams{ID: id}
+	if row.Scope == "agent" {
+		params.AgentID = row.AgentID
+	}
+	if row.Scope == "user" {
+		params.UserID = row.UserID
+	}
+	return s.q.DeleteSkill(ctx, params)
 }
 
 func (s *testSkillStore) ExpireDrafts(ctx context.Context, before time.Time) error {

--- a/pkg/db/sqlc/agent_task.sql.go
+++ b/pkg/db/sqlc/agent_task.sql.go
@@ -89,20 +89,30 @@ func (q *Queries) CreateAgentTask(ctx context.Context, arg CreateAgentTaskParams
 }
 
 const deleteAgentTask = `-- name: DeleteAgentTask :exec
-DELETE FROM agent_task WHERE id = ?
+DELETE FROM agent_task WHERE id = ? AND user_id = ?
 `
 
-func (q *Queries) DeleteAgentTask(ctx context.Context, id string) error {
-	_, err := q.db.ExecContext(ctx, deleteAgentTask, id)
+type DeleteAgentTaskParams struct {
+	ID     string `json:"id"`
+	UserID string `json:"user_id"`
+}
+
+func (q *Queries) DeleteAgentTask(ctx context.Context, arg DeleteAgentTaskParams) error {
+	_, err := q.db.ExecContext(ctx, deleteAgentTask, arg.ID, arg.UserID)
 	return err
 }
 
 const getAgentTask = `-- name: GetAgentTask :one
-SELECT id, title, description, status, priority, session_id, context, review_request, deps, notify_at, scheduler_job_id, scheduler_run_id, agent_id, user_id, created_at, updated_at FROM agent_task WHERE id = ?
+SELECT id, title, description, status, priority, session_id, context, review_request, deps, notify_at, scheduler_job_id, scheduler_run_id, agent_id, user_id, created_at, updated_at FROM agent_task WHERE id = ? AND user_id = ?
 `
 
-func (q *Queries) GetAgentTask(ctx context.Context, id string) (AgentTask, error) {
-	row := q.db.QueryRowContext(ctx, getAgentTask, id)
+type GetAgentTaskParams struct {
+	ID     string `json:"id"`
+	UserID string `json:"user_id"`
+}
+
+func (q *Queries) GetAgentTask(ctx context.Context, arg GetAgentTaskParams) (AgentTask, error) {
+	row := q.db.QueryRowContext(ctx, getAgentTask, arg.ID, arg.UserID)
 	var i AgentTask
 	err := row.Scan(
 		&i.ID,
@@ -355,7 +365,7 @@ func (q *Queries) ListRunningAgentTasks(ctx context.Context) ([]AgentTask, error
 const updateAgentTask = `-- name: UpdateAgentTask :exec
 UPDATE agent_task
 SET title = ?, description = ?, priority = ?, agent_id = ?, updated_at = ?
-WHERE id = ?
+WHERE id = ? AND user_id = ?
 `
 
 type UpdateAgentTaskParams struct {
@@ -365,6 +375,7 @@ type UpdateAgentTaskParams struct {
 	AgentID     sql.NullString `json:"agent_id"`
 	UpdatedAt   string         `json:"updated_at"`
 	ID          string         `json:"id"`
+	UserID      string         `json:"user_id"`
 }
 
 func (q *Queries) UpdateAgentTask(ctx context.Context, arg UpdateAgentTaskParams) error {
@@ -375,6 +386,7 @@ func (q *Queries) UpdateAgentTask(ctx context.Context, arg UpdateAgentTaskParams
 		arg.AgentID,
 		arg.UpdatedAt,
 		arg.ID,
+		arg.UserID,
 	)
 	return err
 }
@@ -382,81 +394,106 @@ func (q *Queries) UpdateAgentTask(ctx context.Context, arg UpdateAgentTaskParams
 const updateAgentTaskContext = `-- name: UpdateAgentTaskContext :exec
 UPDATE agent_task
 SET context = ?, updated_at = ?
-WHERE id = ?
+WHERE id = ? AND user_id = ?
 `
 
 type UpdateAgentTaskContextParams struct {
 	Context   string `json:"context"`
 	UpdatedAt string `json:"updated_at"`
 	ID        string `json:"id"`
+	UserID    string `json:"user_id"`
 }
 
 func (q *Queries) UpdateAgentTaskContext(ctx context.Context, arg UpdateAgentTaskContextParams) error {
-	_, err := q.db.ExecContext(ctx, updateAgentTaskContext, arg.Context, arg.UpdatedAt, arg.ID)
+	_, err := q.db.ExecContext(ctx, updateAgentTaskContext,
+		arg.Context,
+		arg.UpdatedAt,
+		arg.ID,
+		arg.UserID,
+	)
 	return err
 }
 
 const updateAgentTaskNotifyAt = `-- name: UpdateAgentTaskNotifyAt :exec
 UPDATE agent_task
 SET notify_at = ?, updated_at = ?
-WHERE id = ?
+WHERE id = ? AND user_id = ?
 `
 
 type UpdateAgentTaskNotifyAtParams struct {
 	NotifyAt  sql.NullString `json:"notify_at"`
 	UpdatedAt string         `json:"updated_at"`
 	ID        string         `json:"id"`
+	UserID    string         `json:"user_id"`
 }
 
 func (q *Queries) UpdateAgentTaskNotifyAt(ctx context.Context, arg UpdateAgentTaskNotifyAtParams) error {
-	_, err := q.db.ExecContext(ctx, updateAgentTaskNotifyAt, arg.NotifyAt, arg.UpdatedAt, arg.ID)
+	_, err := q.db.ExecContext(ctx, updateAgentTaskNotifyAt,
+		arg.NotifyAt,
+		arg.UpdatedAt,
+		arg.ID,
+		arg.UserID,
+	)
 	return err
 }
 
 const updateAgentTaskReviewRequest = `-- name: UpdateAgentTaskReviewRequest :exec
 UPDATE agent_task
 SET review_request = ?, updated_at = ?
-WHERE id = ?
+WHERE id = ? AND user_id = ?
 `
 
 type UpdateAgentTaskReviewRequestParams struct {
 	ReviewRequest string `json:"review_request"`
 	UpdatedAt     string `json:"updated_at"`
 	ID            string `json:"id"`
+	UserID        string `json:"user_id"`
 }
 
 func (q *Queries) UpdateAgentTaskReviewRequest(ctx context.Context, arg UpdateAgentTaskReviewRequestParams) error {
-	_, err := q.db.ExecContext(ctx, updateAgentTaskReviewRequest, arg.ReviewRequest, arg.UpdatedAt, arg.ID)
+	_, err := q.db.ExecContext(ctx, updateAgentTaskReviewRequest,
+		arg.ReviewRequest,
+		arg.UpdatedAt,
+		arg.ID,
+		arg.UserID,
+	)
 	return err
 }
 
 const updateAgentTaskStatus = `-- name: UpdateAgentTaskStatus :exec
 UPDATE agent_task
 SET status = ?, updated_at = ?
-WHERE id = ?
+WHERE id = ? AND user_id = ?
 `
 
 type UpdateAgentTaskStatusParams struct {
 	Status    string `json:"status"`
 	UpdatedAt string `json:"updated_at"`
 	ID        string `json:"id"`
+	UserID    string `json:"user_id"`
 }
 
 func (q *Queries) UpdateAgentTaskStatus(ctx context.Context, arg UpdateAgentTaskStatusParams) error {
-	_, err := q.db.ExecContext(ctx, updateAgentTaskStatus, arg.Status, arg.UpdatedAt, arg.ID)
+	_, err := q.db.ExecContext(ctx, updateAgentTaskStatus,
+		arg.Status,
+		arg.UpdatedAt,
+		arg.ID,
+		arg.UserID,
+	)
 	return err
 }
 
 const updateAgentTaskStatusFrom = `-- name: UpdateAgentTaskStatusFrom :exec
 UPDATE agent_task
 SET status = ?, updated_at = ?
-WHERE id = ? AND status = ?
+WHERE id = ? AND user_id = ? AND status = ?
 `
 
 type UpdateAgentTaskStatusFromParams struct {
 	Status    string `json:"status"`
 	UpdatedAt string `json:"updated_at"`
 	ID        string `json:"id"`
+	UserID    string `json:"user_id"`
 	Status_2  string `json:"status_2"`
 }
 
@@ -465,6 +502,7 @@ func (q *Queries) UpdateAgentTaskStatusFrom(ctx context.Context, arg UpdateAgent
 		arg.Status,
 		arg.UpdatedAt,
 		arg.ID,
+		arg.UserID,
 		arg.Status_2,
 	)
 	return err

--- a/pkg/db/sqlc/articles.sql.go
+++ b/pkg/db/sqlc/articles.sql.go
@@ -113,20 +113,30 @@ func (q *Queries) CreateArticle(ctx context.Context, arg CreateArticleParams) (A
 }
 
 const deleteArticle = `-- name: DeleteArticle :exec
-DELETE FROM articles WHERE id = ?
+DELETE FROM articles WHERE id = ? AND user_id = ?
 `
 
-func (q *Queries) DeleteArticle(ctx context.Context, id string) error {
-	_, err := q.db.ExecContext(ctx, deleteArticle, id)
+type DeleteArticleParams struct {
+	ID     string `json:"id"`
+	UserID string `json:"user_id"`
+}
+
+func (q *Queries) DeleteArticle(ctx context.Context, arg DeleteArticleParams) error {
+	_, err := q.db.ExecContext(ctx, deleteArticle, arg.ID, arg.UserID)
 	return err
 }
 
 const getArticle = `-- name: GetArticle :one
-SELECT id, user_id, agent_id, url, canonical_url, source_type, title, author, summary, tags, status, starred, file_path, metadata, published_at, saved_at, read_at, created_at, updated_at FROM articles WHERE id = ?
+SELECT id, user_id, agent_id, url, canonical_url, source_type, title, author, summary, tags, status, starred, file_path, metadata, published_at, saved_at, read_at, created_at, updated_at FROM articles WHERE id = ? AND user_id = ?
 `
 
-func (q *Queries) GetArticle(ctx context.Context, id string) (Article, error) {
-	row := q.db.QueryRowContext(ctx, getArticle, id)
+type GetArticleParams struct {
+	ID     string `json:"id"`
+	UserID string `json:"user_id"`
+}
+
+func (q *Queries) GetArticle(ctx context.Context, arg GetArticleParams) (Article, error) {
+	row := q.db.QueryRowContext(ctx, getArticle, arg.ID, arg.UserID)
 	var i Article
 	err := row.Scan(
 		&i.ID,
@@ -497,7 +507,7 @@ SET title       = ?1,
     published_at = ?9,
     read_at     = ?10,
     updated_at  = datetime('now')
-WHERE id = ?11
+WHERE id = ?11 AND user_id = ?12
 RETURNING id, user_id, agent_id, url, canonical_url, source_type, title, author, summary, tags, status, starred, file_path, metadata, published_at, saved_at, read_at, created_at, updated_at
 `
 
@@ -513,6 +523,7 @@ type UpdateArticleParams struct {
 	PublishedAt sql.NullString `json:"published_at"`
 	ReadAt      sql.NullString `json:"read_at"`
 	ID          string         `json:"id"`
+	UserID      string         `json:"user_id"`
 }
 
 func (q *Queries) UpdateArticle(ctx context.Context, arg UpdateArticleParams) (Article, error) {
@@ -528,6 +539,7 @@ func (q *Queries) UpdateArticle(ctx context.Context, arg UpdateArticleParams) (A
 		arg.PublishedAt,
 		arg.ReadAt,
 		arg.ID,
+		arg.UserID,
 	)
 	var i Article
 	err := row.Scan(

--- a/pkg/db/sqlc/ctx_conversations.sql.go
+++ b/pkg/db/sqlc/ctx_conversations.sql.go
@@ -10,23 +10,6 @@ import (
 	"database/sql"
 )
 
-const claimConversationUserBySessionID = `-- name: ClaimConversationUserBySessionID :exec
-UPDATE ctx_conversations
-SET user_id = ?1, updated_at = datetime('now')
-WHERE session_id = ?2
-  AND user_id IS NULL
-`
-
-type ClaimConversationUserBySessionIDParams struct {
-	UserID    sql.NullString `json:"user_id"`
-	SessionID string         `json:"session_id"`
-}
-
-func (q *Queries) ClaimConversationUserBySessionID(ctx context.Context, arg ClaimConversationUserBySessionIDParams) error {
-	_, err := q.db.ExecContext(ctx, claimConversationUserBySessionID, arg.UserID, arg.SessionID)
-	return err
-}
-
 const createConversation = `-- name: CreateConversation :one
 INSERT INTO ctx_conversations (id, session_id, title, channel, kind, project_id, archived, last_active, agent_id, user_id)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -160,33 +143,6 @@ type GetMainConversationByProjectParams struct {
 
 func (q *Queries) GetMainConversationByProject(ctx context.Context, arg GetMainConversationByProjectParams) (CtxConversation, error) {
 	row := q.db.QueryRowContext(ctx, getMainConversationByProject, arg.ProjectID, arg.UserID, arg.AgentID)
-	var i CtxConversation
-	err := row.Scan(
-		&i.ID,
-		&i.SessionID,
-		&i.Title,
-		&i.Channel,
-		&i.Kind,
-		&i.ProjectID,
-		&i.Archived,
-		&i.LastActive,
-		&i.BootstrappedAt,
-		&i.AgentID,
-		&i.UserID,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-	)
-	return i, err
-}
-
-const getUnownedConversationBySessionID = `-- name: GetUnownedConversationBySessionID :one
-SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at FROM ctx_conversations
-WHERE session_id = ?1
-  AND user_id IS NULL
-`
-
-func (q *Queries) GetUnownedConversationBySessionID(ctx context.Context, sessionID string) (CtxConversation, error) {
-	row := q.db.QueryRowContext(ctx, getUnownedConversationBySessionID, sessionID)
 	var i CtxConversation
 	err := row.Scan(
 		&i.ID,

--- a/pkg/db/sqlc/ctx_conversations.sql.go
+++ b/pkg/db/sqlc/ctx_conversations.sql.go
@@ -10,6 +10,23 @@ import (
 	"database/sql"
 )
 
+const claimConversationUserBySessionID = `-- name: ClaimConversationUserBySessionID :exec
+UPDATE ctx_conversations
+SET user_id = ?1, updated_at = datetime('now')
+WHERE session_id = ?2
+  AND user_id IS NULL
+`
+
+type ClaimConversationUserBySessionIDParams struct {
+	UserID    sql.NullString `json:"user_id"`
+	SessionID string         `json:"session_id"`
+}
+
+func (q *Queries) ClaimConversationUserBySessionID(ctx context.Context, arg ClaimConversationUserBySessionIDParams) error {
+	_, err := q.db.ExecContext(ctx, claimConversationUserBySessionID, arg.UserID, arg.SessionID)
+	return err
+}
+
 const createConversation = `-- name: CreateConversation :one
 INSERT INTO ctx_conversations (id, session_id, title, channel, kind, project_id, archived, last_active, agent_id, user_id)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -143,6 +160,33 @@ type GetMainConversationByProjectParams struct {
 
 func (q *Queries) GetMainConversationByProject(ctx context.Context, arg GetMainConversationByProjectParams) (CtxConversation, error) {
 	row := q.db.QueryRowContext(ctx, getMainConversationByProject, arg.ProjectID, arg.UserID, arg.AgentID)
+	var i CtxConversation
+	err := row.Scan(
+		&i.ID,
+		&i.SessionID,
+		&i.Title,
+		&i.Channel,
+		&i.Kind,
+		&i.ProjectID,
+		&i.Archived,
+		&i.LastActive,
+		&i.BootstrappedAt,
+		&i.AgentID,
+		&i.UserID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getUnownedConversationBySessionID = `-- name: GetUnownedConversationBySessionID :one
+SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at FROM ctx_conversations
+WHERE session_id = ?1
+  AND user_id IS NULL
+`
+
+func (q *Queries) GetUnownedConversationBySessionID(ctx context.Context, sessionID string) (CtxConversation, error) {
+	row := q.db.QueryRowContext(ctx, getUnownedConversationBySessionID, sessionID)
 	var i CtxConversation
 	err := row.Scan(
 		&i.ID,

--- a/pkg/db/sqlc/ctx_conversations.sql.go
+++ b/pkg/db/sqlc/ctx_conversations.sql.go
@@ -64,14 +64,14 @@ func (q *Queries) CreateConversation(ctx context.Context, arg CreateConversation
 const getConversation = `-- name: GetConversation :one
 SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at FROM ctx_conversations
 WHERE id = ?1
-  AND (?2 IS NULL OR user_id = ?2)
-  AND (?3 IS NULL OR agent_id = ?3)
+  AND user_id = ?2
+  AND agent_id = ?3
 `
 
 type GetConversationParams struct {
-	ID      string      `json:"id"`
-	UserID  interface{} `json:"user_id"`
-	AgentID interface{} `json:"agent_id"`
+	ID      string         `json:"id"`
+	UserID  sql.NullString `json:"user_id"`
+	AgentID sql.NullString `json:"agent_id"`
 }
 
 func (q *Queries) GetConversation(ctx context.Context, arg GetConversationParams) (CtxConversation, error) {
@@ -98,12 +98,12 @@ func (q *Queries) GetConversation(ctx context.Context, arg GetConversationParams
 const getConversationBySessionID = `-- name: GetConversationBySessionID :one
 SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at FROM ctx_conversations
 WHERE session_id = ?1
-  AND (?2 IS NULL OR user_id = ?2)
+  AND user_id = ?2
 `
 
 type GetConversationBySessionIDParams struct {
-	SessionID string      `json:"session_id"`
-	UserID    interface{} `json:"user_id"`
+	SessionID string         `json:"session_id"`
+	UserID    sql.NullString `json:"user_id"`
 }
 
 func (q *Queries) GetConversationBySessionID(ctx context.Context, arg GetConversationBySessionIDParams) (CtxConversation, error) {
@@ -129,16 +129,16 @@ func (q *Queries) GetConversationBySessionID(ctx context.Context, arg GetConvers
 
 const getMainConversationByProject = `-- name: GetMainConversationByProject :one
 SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at FROM ctx_conversations
-WHERE project_id = ?
-  AND (?2 IS NULL OR user_id = ?2)
-  AND (?3 IS NULL OR agent_id = ?3)
+WHERE project_id = ?1
+  AND user_id = ?2
+  AND agent_id = ?3
   AND kind = 'main' AND archived = 0 LIMIT 1
 `
 
 type GetMainConversationByProjectParams struct {
 	ProjectID sql.NullString `json:"project_id"`
-	UserID    interface{}    `json:"user_id"`
-	AgentID   interface{}    `json:"agent_id"`
+	UserID    sql.NullString `json:"user_id"`
+	AgentID   sql.NullString `json:"agent_id"`
 }
 
 func (q *Queries) GetMainConversationByProject(ctx context.Context, arg GetMainConversationByProjectParams) (CtxConversation, error) {
@@ -164,15 +164,15 @@ func (q *Queries) GetMainConversationByProject(ctx context.Context, arg GetMainC
 
 const listConversations = `-- name: ListConversations :many
 SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at FROM ctx_conversations
-WHERE (?1 IS NULL OR user_id = ?1)
+WHERE user_id = ?1
   AND (?2 IS NULL OR agent_id = ?2)
   AND archived = 0
 ORDER BY last_active DESC
 `
 
 type ListConversationsParams struct {
-	UserID  interface{} `json:"user_id"`
-	AgentID interface{} `json:"agent_id"`
+	UserID  sql.NullString `json:"user_id"`
+	AgentID interface{}    `json:"agent_id"`
 }
 
 func (q *Queries) ListConversations(ctx context.Context, arg ListConversationsParams) ([]CtxConversation, error) {
@@ -214,14 +214,14 @@ func (q *Queries) ListConversations(ctx context.Context, arg ListConversationsPa
 
 const listConversationsAll = `-- name: ListConversationsAll :many
 SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at FROM ctx_conversations
-WHERE (?1 IS NULL OR user_id = ?1)
+WHERE user_id = ?1
   AND (?2 IS NULL OR agent_id = ?2)
 ORDER BY last_active DESC
 `
 
 type ListConversationsAllParams struct {
-	UserID  interface{} `json:"user_id"`
-	AgentID interface{} `json:"agent_id"`
+	UserID  sql.NullString `json:"user_id"`
+	AgentID interface{}    `json:"agent_id"`
 }
 
 func (q *Queries) ListConversationsAll(ctx context.Context, arg ListConversationsAllParams) ([]CtxConversation, error) {
@@ -310,13 +310,13 @@ func (q *Queries) ListConversationsByKind(ctx context.Context, arg ListConversat
 
 const updateConversationArchived = `-- name: UpdateConversationArchived :exec
 UPDATE ctx_conversations SET archived = ?1, updated_at = datetime('now')
-WHERE session_id = ?2 AND (?3 IS NULL OR user_id = ?3)
+WHERE session_id = ?2 AND user_id = ?3
 `
 
 type UpdateConversationArchivedParams struct {
-	Archived  int64       `json:"archived"`
-	SessionID string      `json:"session_id"`
-	UserID    interface{} `json:"user_id"`
+	Archived  int64          `json:"archived"`
+	SessionID string         `json:"session_id"`
+	UserID    sql.NullString `json:"user_id"`
 }
 
 func (q *Queries) UpdateConversationArchived(ctx context.Context, arg UpdateConversationArchivedParams) error {
@@ -326,12 +326,12 @@ func (q *Queries) UpdateConversationArchived(ctx context.Context, arg UpdateConv
 
 const updateConversationBootstrapped = `-- name: UpdateConversationBootstrapped :exec
 UPDATE ctx_conversations SET bootstrapped_at = datetime('now'), updated_at = datetime('now')
-WHERE id = ?1 AND (?2 IS NULL OR user_id = ?2)
+WHERE id = ?1 AND user_id = ?2
 `
 
 type UpdateConversationBootstrappedParams struct {
-	ID     string      `json:"id"`
-	UserID interface{} `json:"user_id"`
+	ID     string         `json:"id"`
+	UserID sql.NullString `json:"user_id"`
 }
 
 func (q *Queries) UpdateConversationBootstrapped(ctx context.Context, arg UpdateConversationBootstrappedParams) error {
@@ -341,14 +341,14 @@ func (q *Queries) UpdateConversationBootstrapped(ctx context.Context, arg Update
 
 const updateConversationKindProject = `-- name: UpdateConversationKindProject :exec
 UPDATE ctx_conversations SET kind = ?1, project_id = ?2, updated_at = datetime('now')
-WHERE session_id = ?3 AND (?4 IS NULL OR user_id = ?4)
+WHERE session_id = ?3 AND user_id = ?4
 `
 
 type UpdateConversationKindProjectParams struct {
 	Kind      string         `json:"kind"`
 	ProjectID sql.NullString `json:"project_id"`
 	SessionID string         `json:"session_id"`
-	UserID    interface{}    `json:"user_id"`
+	UserID    sql.NullString `json:"user_id"`
 }
 
 func (q *Queries) UpdateConversationKindProject(ctx context.Context, arg UpdateConversationKindProjectParams) error {
@@ -363,12 +363,12 @@ func (q *Queries) UpdateConversationKindProject(ctx context.Context, arg UpdateC
 
 const updateConversationLastActive = `-- name: UpdateConversationLastActive :exec
 UPDATE ctx_conversations SET last_active = datetime('now'), updated_at = datetime('now')
-WHERE session_id = ?1 AND (?2 IS NULL OR user_id = ?2)
+WHERE session_id = ?1 AND user_id = ?2
 `
 
 type UpdateConversationLastActiveParams struct {
-	SessionID string      `json:"session_id"`
-	UserID    interface{} `json:"user_id"`
+	SessionID string         `json:"session_id"`
+	UserID    sql.NullString `json:"user_id"`
 }
 
 func (q *Queries) UpdateConversationLastActive(ctx context.Context, arg UpdateConversationLastActiveParams) error {
@@ -378,13 +378,13 @@ func (q *Queries) UpdateConversationLastActive(ctx context.Context, arg UpdateCo
 
 const updateConversationTitle = `-- name: UpdateConversationTitle :exec
 UPDATE ctx_conversations SET title = ?1, updated_at = datetime('now')
-WHERE id = ?2 AND (?3 IS NULL OR user_id = ?3)
+WHERE id = ?2 AND user_id = ?3
 `
 
 type UpdateConversationTitleParams struct {
 	Title  sql.NullString `json:"title"`
 	ID     string         `json:"id"`
-	UserID interface{}    `json:"user_id"`
+	UserID sql.NullString `json:"user_id"`
 }
 
 func (q *Queries) UpdateConversationTitle(ctx context.Context, arg UpdateConversationTitleParams) error {
@@ -394,13 +394,13 @@ func (q *Queries) UpdateConversationTitle(ctx context.Context, arg UpdateConvers
 
 const updateConversationTitleBySessionID = `-- name: UpdateConversationTitleBySessionID :exec
 UPDATE ctx_conversations SET title = ?1, updated_at = datetime('now')
-WHERE session_id = ?2 AND (?3 IS NULL OR user_id = ?3)
+WHERE session_id = ?2 AND user_id = ?3
 `
 
 type UpdateConversationTitleBySessionIDParams struct {
 	Title     sql.NullString `json:"title"`
 	SessionID string         `json:"session_id"`
-	UserID    interface{}    `json:"user_id"`
+	UserID    sql.NullString `json:"user_id"`
 }
 
 func (q *Queries) UpdateConversationTitleBySessionID(ctx context.Context, arg UpdateConversationTitleBySessionIDParams) error {

--- a/pkg/db/sqlc/ctx_conversations.sql.go
+++ b/pkg/db/sqlc/ctx_conversations.sql.go
@@ -11,45 +11,12 @@ import (
 )
 
 const createConversation = `-- name: CreateConversation :one
-INSERT INTO ctx_conversations (id, session_id, title)
-VALUES (?, ?, ?)
-RETURNING id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at
-`
-
-type CreateConversationParams struct {
-	ID        string         `json:"id"`
-	SessionID string         `json:"session_id"`
-	Title     sql.NullString `json:"title"`
-}
-
-func (q *Queries) CreateConversation(ctx context.Context, arg CreateConversationParams) (CtxConversation, error) {
-	row := q.db.QueryRowContext(ctx, createConversation, arg.ID, arg.SessionID, arg.Title)
-	var i CtxConversation
-	err := row.Scan(
-		&i.ID,
-		&i.SessionID,
-		&i.Title,
-		&i.Channel,
-		&i.Kind,
-		&i.ProjectID,
-		&i.Archived,
-		&i.LastActive,
-		&i.BootstrappedAt,
-		&i.AgentID,
-		&i.UserID,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-	)
-	return i, err
-}
-
-const createConversationFull = `-- name: CreateConversationFull :one
 INSERT INTO ctx_conversations (id, session_id, title, channel, kind, project_id, archived, last_active, agent_id, user_id)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 RETURNING id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at
 `
 
-type CreateConversationFullParams struct {
+type CreateConversationParams struct {
 	ID         string         `json:"id"`
 	SessionID  string         `json:"session_id"`
 	Title      sql.NullString `json:"title"`
@@ -62,8 +29,8 @@ type CreateConversationFullParams struct {
 	UserID     sql.NullString `json:"user_id"`
 }
 
-func (q *Queries) CreateConversationFull(ctx context.Context, arg CreateConversationFullParams) (CtxConversation, error) {
-	row := q.db.QueryRowContext(ctx, createConversationFull,
+func (q *Queries) CreateConversation(ctx context.Context, arg CreateConversationParams) (CtxConversation, error) {
+	row := q.db.QueryRowContext(ctx, createConversation,
 		arg.ID,
 		arg.SessionID,
 		arg.Title,
@@ -95,11 +62,20 @@ func (q *Queries) CreateConversationFull(ctx context.Context, arg CreateConversa
 }
 
 const getConversation = `-- name: GetConversation :one
-SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at FROM ctx_conversations WHERE id = ?
+SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at FROM ctx_conversations
+WHERE id = ?1
+  AND (?2 IS NULL OR user_id = ?2)
+  AND (?3 IS NULL OR agent_id = ?3)
 `
 
-func (q *Queries) GetConversation(ctx context.Context, id string) (CtxConversation, error) {
-	row := q.db.QueryRowContext(ctx, getConversation, id)
+type GetConversationParams struct {
+	ID      string      `json:"id"`
+	UserID  interface{} `json:"user_id"`
+	AgentID interface{} `json:"agent_id"`
+}
+
+func (q *Queries) GetConversation(ctx context.Context, arg GetConversationParams) (CtxConversation, error) {
+	row := q.db.QueryRowContext(ctx, getConversation, arg.ID, arg.UserID, arg.AgentID)
 	var i CtxConversation
 	err := row.Scan(
 		&i.ID,
@@ -120,11 +96,18 @@ func (q *Queries) GetConversation(ctx context.Context, id string) (CtxConversati
 }
 
 const getConversationBySessionID = `-- name: GetConversationBySessionID :one
-SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at FROM ctx_conversations WHERE session_id = ?
+SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at FROM ctx_conversations
+WHERE session_id = ?1
+  AND (?2 IS NULL OR user_id = ?2)
 `
 
-func (q *Queries) GetConversationBySessionID(ctx context.Context, sessionID string) (CtxConversation, error) {
-	row := q.db.QueryRowContext(ctx, getConversationBySessionID, sessionID)
+type GetConversationBySessionIDParams struct {
+	SessionID string      `json:"session_id"`
+	UserID    interface{} `json:"user_id"`
+}
+
+func (q *Queries) GetConversationBySessionID(ctx context.Context, arg GetConversationBySessionIDParams) (CtxConversation, error) {
+	row := q.db.QueryRowContext(ctx, getConversationBySessionID, arg.SessionID, arg.UserID)
 	var i CtxConversation
 	err := row.Scan(
 		&i.ID,
@@ -145,11 +128,21 @@ func (q *Queries) GetConversationBySessionID(ctx context.Context, sessionID stri
 }
 
 const getMainConversationByProject = `-- name: GetMainConversationByProject :one
-SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at FROM ctx_conversations WHERE project_id = ? AND kind = 'main' AND archived = 0 LIMIT 1
+SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at FROM ctx_conversations
+WHERE project_id = ?
+  AND (?2 IS NULL OR user_id = ?2)
+  AND (?3 IS NULL OR agent_id = ?3)
+  AND kind = 'main' AND archived = 0 LIMIT 1
 `
 
-func (q *Queries) GetMainConversationByProject(ctx context.Context, projectID sql.NullString) (CtxConversation, error) {
-	row := q.db.QueryRowContext(ctx, getMainConversationByProject, projectID)
+type GetMainConversationByProjectParams struct {
+	ProjectID sql.NullString `json:"project_id"`
+	UserID    interface{}    `json:"user_id"`
+	AgentID   interface{}    `json:"agent_id"`
+}
+
+func (q *Queries) GetMainConversationByProject(ctx context.Context, arg GetMainConversationByProjectParams) (CtxConversation, error) {
+	row := q.db.QueryRowContext(ctx, getMainConversationByProject, arg.ProjectID, arg.UserID, arg.AgentID)
 	var i CtxConversation
 	err := row.Scan(
 		&i.ID,
@@ -170,11 +163,20 @@ func (q *Queries) GetMainConversationByProject(ctx context.Context, projectID sq
 }
 
 const listConversations = `-- name: ListConversations :many
-SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at FROM ctx_conversations WHERE archived = 0 ORDER BY last_active DESC
+SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at FROM ctx_conversations
+WHERE (?1 IS NULL OR user_id = ?1)
+  AND (?2 IS NULL OR agent_id = ?2)
+  AND archived = 0
+ORDER BY last_active DESC
 `
 
-func (q *Queries) ListConversations(ctx context.Context) ([]CtxConversation, error) {
-	rows, err := q.db.QueryContext(ctx, listConversations)
+type ListConversationsParams struct {
+	UserID  interface{} `json:"user_id"`
+	AgentID interface{} `json:"agent_id"`
+}
+
+func (q *Queries) ListConversations(ctx context.Context, arg ListConversationsParams) ([]CtxConversation, error) {
+	rows, err := q.db.QueryContext(ctx, listConversations, arg.UserID, arg.AgentID)
 	if err != nil {
 		return nil, err
 	}
@@ -211,11 +213,19 @@ func (q *Queries) ListConversations(ctx context.Context) ([]CtxConversation, err
 }
 
 const listConversationsAll = `-- name: ListConversationsAll :many
-SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at FROM ctx_conversations ORDER BY last_active DESC
+SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at FROM ctx_conversations
+WHERE (?1 IS NULL OR user_id = ?1)
+  AND (?2 IS NULL OR agent_id = ?2)
+ORDER BY last_active DESC
 `
 
-func (q *Queries) ListConversationsAll(ctx context.Context) ([]CtxConversation, error) {
-	rows, err := q.db.QueryContext(ctx, listConversationsAll)
+type ListConversationsAllParams struct {
+	UserID  interface{} `json:"user_id"`
+	AgentID interface{} `json:"agent_id"`
+}
+
+func (q *Queries) ListConversationsAll(ctx context.Context, arg ListConversationsAllParams) ([]CtxConversation, error) {
+	rows, err := q.db.QueryContext(ctx, listConversationsAll, arg.UserID, arg.AgentID)
 	if err != nil {
 		return nil, err
 	}
@@ -298,92 +308,102 @@ func (q *Queries) ListConversationsByKind(ctx context.Context, arg ListConversat
 	return items, nil
 }
 
-const updateConversationAgentUser = `-- name: UpdateConversationAgentUser :exec
-UPDATE ctx_conversations SET agent_id = ?, user_id = ?, updated_at = datetime('now') WHERE session_id = ?
-`
-
-type UpdateConversationAgentUserParams struct {
-	AgentID   sql.NullString `json:"agent_id"`
-	UserID    sql.NullString `json:"user_id"`
-	SessionID string         `json:"session_id"`
-}
-
-func (q *Queries) UpdateConversationAgentUser(ctx context.Context, arg UpdateConversationAgentUserParams) error {
-	_, err := q.db.ExecContext(ctx, updateConversationAgentUser, arg.AgentID, arg.UserID, arg.SessionID)
-	return err
-}
-
 const updateConversationArchived = `-- name: UpdateConversationArchived :exec
-UPDATE ctx_conversations SET archived = ?, updated_at = datetime('now') WHERE session_id = ?
+UPDATE ctx_conversations SET archived = ?1, updated_at = datetime('now')
+WHERE session_id = ?2 AND (?3 IS NULL OR user_id = ?3)
 `
 
 type UpdateConversationArchivedParams struct {
-	Archived  int64  `json:"archived"`
-	SessionID string `json:"session_id"`
+	Archived  int64       `json:"archived"`
+	SessionID string      `json:"session_id"`
+	UserID    interface{} `json:"user_id"`
 }
 
 func (q *Queries) UpdateConversationArchived(ctx context.Context, arg UpdateConversationArchivedParams) error {
-	_, err := q.db.ExecContext(ctx, updateConversationArchived, arg.Archived, arg.SessionID)
+	_, err := q.db.ExecContext(ctx, updateConversationArchived, arg.Archived, arg.SessionID, arg.UserID)
 	return err
 }
 
 const updateConversationBootstrapped = `-- name: UpdateConversationBootstrapped :exec
-UPDATE ctx_conversations SET bootstrapped_at = datetime('now'), updated_at = datetime('now') WHERE id = ?
+UPDATE ctx_conversations SET bootstrapped_at = datetime('now'), updated_at = datetime('now')
+WHERE id = ?1 AND (?2 IS NULL OR user_id = ?2)
 `
 
-func (q *Queries) UpdateConversationBootstrapped(ctx context.Context, id string) error {
-	_, err := q.db.ExecContext(ctx, updateConversationBootstrapped, id)
+type UpdateConversationBootstrappedParams struct {
+	ID     string      `json:"id"`
+	UserID interface{} `json:"user_id"`
+}
+
+func (q *Queries) UpdateConversationBootstrapped(ctx context.Context, arg UpdateConversationBootstrappedParams) error {
+	_, err := q.db.ExecContext(ctx, updateConversationBootstrapped, arg.ID, arg.UserID)
 	return err
 }
 
 const updateConversationKindProject = `-- name: UpdateConversationKindProject :exec
-UPDATE ctx_conversations SET kind = ?, project_id = ?, updated_at = datetime('now') WHERE session_id = ?
+UPDATE ctx_conversations SET kind = ?1, project_id = ?2, updated_at = datetime('now')
+WHERE session_id = ?3 AND (?4 IS NULL OR user_id = ?4)
 `
 
 type UpdateConversationKindProjectParams struct {
 	Kind      string         `json:"kind"`
 	ProjectID sql.NullString `json:"project_id"`
 	SessionID string         `json:"session_id"`
+	UserID    interface{}    `json:"user_id"`
 }
 
 func (q *Queries) UpdateConversationKindProject(ctx context.Context, arg UpdateConversationKindProjectParams) error {
-	_, err := q.db.ExecContext(ctx, updateConversationKindProject, arg.Kind, arg.ProjectID, arg.SessionID)
+	_, err := q.db.ExecContext(ctx, updateConversationKindProject,
+		arg.Kind,
+		arg.ProjectID,
+		arg.SessionID,
+		arg.UserID,
+	)
 	return err
 }
 
 const updateConversationLastActive = `-- name: UpdateConversationLastActive :exec
-UPDATE ctx_conversations SET last_active = datetime('now'), updated_at = datetime('now') WHERE session_id = ?
+UPDATE ctx_conversations SET last_active = datetime('now'), updated_at = datetime('now')
+WHERE session_id = ?1 AND (?2 IS NULL OR user_id = ?2)
 `
 
-func (q *Queries) UpdateConversationLastActive(ctx context.Context, sessionID string) error {
-	_, err := q.db.ExecContext(ctx, updateConversationLastActive, sessionID)
+type UpdateConversationLastActiveParams struct {
+	SessionID string      `json:"session_id"`
+	UserID    interface{} `json:"user_id"`
+}
+
+func (q *Queries) UpdateConversationLastActive(ctx context.Context, arg UpdateConversationLastActiveParams) error {
+	_, err := q.db.ExecContext(ctx, updateConversationLastActive, arg.SessionID, arg.UserID)
 	return err
 }
 
 const updateConversationTitle = `-- name: UpdateConversationTitle :exec
-UPDATE ctx_conversations SET title = ?, updated_at = datetime('now') WHERE id = ?
+UPDATE ctx_conversations SET title = ?1, updated_at = datetime('now')
+WHERE id = ?2 AND (?3 IS NULL OR user_id = ?3)
 `
 
 type UpdateConversationTitleParams struct {
-	Title sql.NullString `json:"title"`
-	ID    string         `json:"id"`
+	Title  sql.NullString `json:"title"`
+	ID     string         `json:"id"`
+	UserID interface{}    `json:"user_id"`
 }
 
 func (q *Queries) UpdateConversationTitle(ctx context.Context, arg UpdateConversationTitleParams) error {
-	_, err := q.db.ExecContext(ctx, updateConversationTitle, arg.Title, arg.ID)
+	_, err := q.db.ExecContext(ctx, updateConversationTitle, arg.Title, arg.ID, arg.UserID)
 	return err
 }
 
 const updateConversationTitleBySessionID = `-- name: UpdateConversationTitleBySessionID :exec
-UPDATE ctx_conversations SET title = ?, updated_at = datetime('now') WHERE session_id = ?
+UPDATE ctx_conversations SET title = ?1, updated_at = datetime('now')
+WHERE session_id = ?2 AND (?3 IS NULL OR user_id = ?3)
 `
 
 type UpdateConversationTitleBySessionIDParams struct {
 	Title     sql.NullString `json:"title"`
 	SessionID string         `json:"session_id"`
+	UserID    interface{}    `json:"user_id"`
 }
 
 func (q *Queries) UpdateConversationTitleBySessionID(ctx context.Context, arg UpdateConversationTitleBySessionIDParams) error {
-	_, err := q.db.ExecContext(ctx, updateConversationTitleBySessionID, arg.Title, arg.SessionID)
+	_, err := q.db.ExecContext(ctx, updateConversationTitleBySessionID, arg.Title, arg.SessionID, arg.UserID)
 	return err
 }

--- a/pkg/db/sqlc/rss_feeds.sql.go
+++ b/pkg/db/sqlc/rss_feeds.sql.go
@@ -134,20 +134,30 @@ func (q *Queries) DeleteOldRSSEntries(ctx context.Context, feedID string) error 
 }
 
 const deleteRSSFeed = `-- name: DeleteRSSFeed :exec
-DELETE FROM rss_feeds WHERE id = ?
+DELETE FROM rss_feeds WHERE id = ? AND user_id = ?
 `
 
-func (q *Queries) DeleteRSSFeed(ctx context.Context, id string) error {
-	_, err := q.db.ExecContext(ctx, deleteRSSFeed, id)
+type DeleteRSSFeedParams struct {
+	ID     string `json:"id"`
+	UserID string `json:"user_id"`
+}
+
+func (q *Queries) DeleteRSSFeed(ctx context.Context, arg DeleteRSSFeedParams) error {
+	_, err := q.db.ExecContext(ctx, deleteRSSFeed, arg.ID, arg.UserID)
 	return err
 }
 
 const getRSSFeed = `-- name: GetRSSFeed :one
-SELECT id, user_id, agent_id, url, title, description, check_interval, last_checked_at, last_etag, last_modified, enabled, created_at, updated_at FROM rss_feeds WHERE id = ?
+SELECT id, user_id, agent_id, url, title, description, check_interval, last_checked_at, last_etag, last_modified, enabled, created_at, updated_at FROM rss_feeds WHERE id = ? AND user_id = ?
 `
 
-func (q *Queries) GetRSSFeed(ctx context.Context, id string) (RssFeed, error) {
-	row := q.db.QueryRowContext(ctx, getRSSFeed, id)
+type GetRSSFeedParams struct {
+	ID     string `json:"id"`
+	UserID string `json:"user_id"`
+}
+
+func (q *Queries) GetRSSFeed(ctx context.Context, arg GetRSSFeedParams) (RssFeed, error) {
+	row := q.db.QueryRowContext(ctx, getRSSFeed, arg.ID, arg.UserID)
 	var i RssFeed
 	err := row.Scan(
 		&i.ID,
@@ -371,7 +381,7 @@ SET title           = ?1,
     last_modified   = ?6,
     enabled         = ?7,
     updated_at      = datetime('now')
-WHERE id = ?8
+WHERE id = ?8 AND user_id = ?9
 RETURNING id, user_id, agent_id, url, title, description, check_interval, last_checked_at, last_etag, last_modified, enabled, created_at, updated_at
 `
 
@@ -384,6 +394,7 @@ type UpdateRSSFeedParams struct {
 	LastModified  string         `json:"last_modified"`
 	Enabled       int64          `json:"enabled"`
 	ID            string         `json:"id"`
+	UserID        string         `json:"user_id"`
 }
 
 func (q *Queries) UpdateRSSFeed(ctx context.Context, arg UpdateRSSFeedParams) (RssFeed, error) {
@@ -396,6 +407,7 @@ func (q *Queries) UpdateRSSFeed(ctx context.Context, arg UpdateRSSFeedParams) (R
 		arg.LastModified,
 		arg.Enabled,
 		arg.ID,
+		arg.UserID,
 	)
 	var i RssFeed
 	err := row.Scan(

--- a/pkg/db/sqlc/skills.sql.go
+++ b/pkg/db/sqlc/skills.sql.go
@@ -58,11 +58,21 @@ func (q *Queries) CreateSkill(ctx context.Context, arg CreateSkillParams) (Skill
 }
 
 const deleteSkill = `-- name: DeleteSkill :exec
-DELETE FROM skills WHERE id = ?
+DELETE FROM skills
+WHERE id = ?1
+  AND ((?2 IS NULL AND ?3 IS NULL)
+    OR (scope='agent' AND agent_id=?2)
+    OR (scope='user' AND user_id=?3))
 `
 
-func (q *Queries) DeleteSkill(ctx context.Context, id string) error {
-	_, err := q.db.ExecContext(ctx, deleteSkill, id)
+type DeleteSkillParams struct {
+	ID      string      `json:"id"`
+	AgentID interface{} `json:"agent_id"`
+	UserID  interface{} `json:"user_id"`
+}
+
+func (q *Queries) DeleteSkill(ctx context.Context, arg DeleteSkillParams) error {
+	_, err := q.db.ExecContext(ctx, deleteSkill, arg.ID, arg.AgentID, arg.UserID)
 	return err
 }
 
@@ -141,11 +151,19 @@ func (q *Queries) GetAgentSkillByName(ctx context.Context, arg GetAgentSkillByNa
 }
 
 const getSkill = `-- name: GetSkill :one
-SELECT id, scope, user_id, agent_id, name, description, status, disable_model_invocation, metadata, created_at, updated_at FROM skills WHERE id = ?
+SELECT id, scope, user_id, agent_id, name, description, status, disable_model_invocation, metadata, created_at, updated_at FROM skills
+WHERE id = ?1
+  AND ((?2 IS NULL AND ?3 IS NULL) OR scope='system' OR (scope='agent' AND agent_id=?2) OR (scope='user' AND user_id=?3))
 `
 
-func (q *Queries) GetSkill(ctx context.Context, id string) (Skill, error) {
-	row := q.db.QueryRowContext(ctx, getSkill, id)
+type GetSkillParams struct {
+	ID      string      `json:"id"`
+	AgentID interface{} `json:"agent_id"`
+	UserID  interface{} `json:"user_id"`
+}
+
+func (q *Queries) GetSkill(ctx context.Context, arg GetSkillParams) (Skill, error) {
+	row := q.db.QueryRowContext(ctx, getSkill, arg.ID, arg.AgentID, arg.UserID)
 	var i Skill
 	err := row.Scan(
 		&i.ID,
@@ -448,20 +466,25 @@ func (q *Queries) ResolveSkill(ctx context.Context, arg ResolveSkillParams) (Ski
 
 const updateSkillMetadata = `-- name: UpdateSkillMetadata :exec
 UPDATE skills
-SET description              = ?,
-    status                   = ?,
-    disable_model_invocation = ?,
-    metadata                 = ?,
+SET description              = ?1,
+    status                   = ?2,
+    disable_model_invocation = ?3,
+    metadata                 = ?4,
     updated_at               = datetime('now')
-WHERE id = ?
+WHERE id = ?5
+  AND ((?6 IS NULL AND ?7 IS NULL)
+    OR (scope='agent' AND agent_id=?6)
+    OR (scope='user' AND user_id=?7))
 `
 
 type UpdateSkillMetadataParams struct {
-	Description            string `json:"description"`
-	Status                 string `json:"status"`
-	DisableModelInvocation int64  `json:"disable_model_invocation"`
-	Metadata               string `json:"metadata"`
-	ID                     string `json:"id"`
+	Description            string      `json:"description"`
+	Status                 string      `json:"status"`
+	DisableModelInvocation int64       `json:"disable_model_invocation"`
+	Metadata               string      `json:"metadata"`
+	ID                     string      `json:"id"`
+	AgentID                interface{} `json:"agent_id"`
+	UserID                 interface{} `json:"user_id"`
 }
 
 func (q *Queries) UpdateSkillMetadata(ctx context.Context, arg UpdateSkillMetadataParams) error {
@@ -471,6 +494,8 @@ func (q *Queries) UpdateSkillMetadata(ctx context.Context, arg UpdateSkillMetada
 		arg.DisableModelInvocation,
 		arg.Metadata,
 		arg.ID,
+		arg.AgentID,
+		arg.UserID,
 	)
 	return err
 }

--- a/pkg/db/sqlc/skills.sql.go
+++ b/pkg/db/sqlc/skills.sql.go
@@ -60,15 +60,14 @@ func (q *Queries) CreateSkill(ctx context.Context, arg CreateSkillParams) (Skill
 const deleteSkill = `-- name: DeleteSkill :exec
 DELETE FROM skills
 WHERE id = ?1
-  AND ((?2 IS NULL AND ?3 IS NULL)
-    OR (scope='agent' AND agent_id=?2)
+  AND ((scope='agent' AND agent_id=?2)
     OR (scope='user' AND user_id=?3))
 `
 
 type DeleteSkillParams struct {
-	ID      string      `json:"id"`
-	AgentID interface{} `json:"agent_id"`
-	UserID  interface{} `json:"user_id"`
+	ID      string         `json:"id"`
+	AgentID sql.NullString `json:"agent_id"`
+	UserID  sql.NullString `json:"user_id"`
 }
 
 func (q *Queries) DeleteSkill(ctx context.Context, arg DeleteSkillParams) error {
@@ -87,6 +86,15 @@ type DeleteSkillFileParams struct {
 
 func (q *Queries) DeleteSkillFile(ctx context.Context, arg DeleteSkillFileParams) error {
 	_, err := q.db.ExecContext(ctx, deleteSkillFile, arg.SkillID, arg.Path)
+	return err
+}
+
+const deleteSystemSkill = `-- name: DeleteSystemSkill :exec
+DELETE FROM skills WHERE id = ? AND scope = 'system'
+`
+
+func (q *Queries) DeleteSystemSkill(ctx context.Context, id string) error {
+	_, err := q.db.ExecContext(ctx, deleteSystemSkill, id)
 	return err
 }
 
@@ -472,19 +480,18 @@ SET description              = ?1,
     metadata                 = ?4,
     updated_at               = datetime('now')
 WHERE id = ?5
-  AND ((?6 IS NULL AND ?7 IS NULL)
-    OR (scope='agent' AND agent_id=?6)
+  AND ((scope='agent' AND agent_id=?6)
     OR (scope='user' AND user_id=?7))
 `
 
 type UpdateSkillMetadataParams struct {
-	Description            string      `json:"description"`
-	Status                 string      `json:"status"`
-	DisableModelInvocation int64       `json:"disable_model_invocation"`
-	Metadata               string      `json:"metadata"`
-	ID                     string      `json:"id"`
-	AgentID                interface{} `json:"agent_id"`
-	UserID                 interface{} `json:"user_id"`
+	Description            string         `json:"description"`
+	Status                 string         `json:"status"`
+	DisableModelInvocation int64          `json:"disable_model_invocation"`
+	Metadata               string         `json:"metadata"`
+	ID                     string         `json:"id"`
+	AgentID                sql.NullString `json:"agent_id"`
+	UserID                 sql.NullString `json:"user_id"`
 }
 
 func (q *Queries) UpdateSkillMetadata(ctx context.Context, arg UpdateSkillMetadataParams) error {
@@ -496,6 +503,35 @@ func (q *Queries) UpdateSkillMetadata(ctx context.Context, arg UpdateSkillMetada
 		arg.ID,
 		arg.AgentID,
 		arg.UserID,
+	)
+	return err
+}
+
+const updateSystemSkillMetadata = `-- name: UpdateSystemSkillMetadata :exec
+UPDATE skills
+SET description              = ?1,
+    status                   = ?2,
+    disable_model_invocation = ?3,
+    metadata                 = ?4,
+    updated_at               = datetime('now')
+WHERE id = ?5 AND scope = 'system'
+`
+
+type UpdateSystemSkillMetadataParams struct {
+	Description            string `json:"description"`
+	Status                 string `json:"status"`
+	DisableModelInvocation int64  `json:"disable_model_invocation"`
+	Metadata               string `json:"metadata"`
+	ID                     string `json:"id"`
+}
+
+func (q *Queries) UpdateSystemSkillMetadata(ctx context.Context, arg UpdateSystemSkillMetadataParams) error {
+	_, err := q.db.ExecContext(ctx, updateSystemSkillMetadata,
+		arg.Description,
+		arg.Status,
+		arg.DisableModelInvocation,
+		arg.Metadata,
+		arg.ID,
 	)
 	return err
 }


### PR DESCRIPTION
## Summary
- isolate agent main session routing by user and keep group chats on exact session keys
- add SQL-level user/tenant filters for tasks, conversations, articles, feeds, and skills
- remove admin ownership bypasses from mutable server handlers

## Verification
- mise run generate
- mise run format
- mise run build
- mise run test