### PR TITLE
🔒 feat: require agent_id on task list and create

### DIFF
--- a/api/client/gen.go
+++ b/api/client/gen.go
@@ -551,7 +551,7 @@ type SearchSkillsParams struct {
 // ListAgentTasksParams defines parameters for ListAgentTasks.
 type ListAgentTasksParams struct {
 	Status  *string `form:"status,omitempty" json:"status,omitempty"`
-	AgentId *string `form:"agent_id,omitempty" json:"agent_id,omitempty"`
+	AgentId string  `form:"agent_id" json:"agent_id"`
 }
 
 // SetOAuthProviderConfigJSONRequestBody defines body for SetOAuthProviderConfig for application/json ContentType.
@@ -8970,16 +8970,12 @@ func NewListAgentTasksRequest(server string, params *ListAgentTasksParams) (*htt
 
 		}
 
-		if params.AgentId != nil {
-
-			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "agent_id", *params.AgentId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
-				return nil, err
-			} else {
-				for _, qp := range strings.Split(queryFrag, "&") {
-					rawQueryFragments = append(rawQueryFragments, qp)
-				}
+		if queryFrag, err := runtime.StyleParamWithOptions("form", true, "agent_id", params.AgentId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+			return nil, err
+		} else {
+			for _, qp := range strings.Split(queryFrag, "&") {
+				rawQueryFragments = append(rawQueryFragments, qp)
 			}
-
 		}
 
 		if encoded := queryValues.Encode(); encoded != "" {

--- a/api/server/gen.go
+++ b/api/server/gen.go
@@ -549,7 +549,7 @@ type SearchSkillsParams struct {
 // ListAgentTasksParams defines parameters for ListAgentTasks.
 type ListAgentTasksParams struct {
 	Status  *string `form:"status,omitempty" json:"status,omitempty"`
-	AgentId *string `form:"agent_id,omitempty" json:"agent_id,omitempty"`
+	AgentId string  `form:"agent_id" json:"agent_id"`
 }
 
 // SetOAuthProviderConfigJSONRequestBody defines body for SetOAuthProviderConfig for application/json ContentType.
@@ -5445,9 +5445,9 @@ func (siw *ServerInterfaceWrapper) ListAgentTasks(w http.ResponseWriter, r *http
 		return
 	}
 
-	// ------------- Optional query parameter "agent_id" -------------
+	// ------------- Required query parameter "agent_id" -------------
 
-	err = runtime.BindQueryParameterWithOptions("form", true, false, "agent_id", r.URL.Query(), &params.AgentId, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	err = runtime.BindQueryParameterWithOptions("form", true, true, "agent_id", r.URL.Query(), &params.AgentId, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
 	if err != nil {
 		var requiredError *runtime.RequiredParameterError
 		if errors.As(err, &requiredError) {

--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -1744,7 +1744,7 @@ components:
             $ref: "#/components/schemas/AgentTask"
     AgentTaskInput:
       type: object
-      required: [title]
+      required: [title, agent_id]
       description: "Fields for creating an agent task"
       properties:
         title:

--- a/api/spec/domain/tasks/paths.yaml
+++ b/api/spec/domain/tasks/paths.yaml
@@ -11,7 +11,7 @@ paths:
           schema: { type: string }
         - name: agent_id
           in: query
-          required: false
+          required: true
           schema: { type: string }
       responses:
         "200":

--- a/api/spec/domain/tasks/schemas.yaml
+++ b/api/spec/domain/tasks/schemas.yaml
@@ -57,7 +57,7 @@ components:
 
     AgentTaskInput:
       type: object
-      required: [title]
+      required: [title, agent_id]
       description: "Fields for creating an agent task"
       properties:
         title: { type: string }

--- a/api/types/gen.go
+++ b/api/types/gen.go
@@ -464,7 +464,7 @@ type AgentTaskEventList struct {
 
 // AgentTaskInput Fields for creating an agent task
 type AgentTaskInput struct {
-	AgentId *string `json:"agent_id,omitempty"`
+	AgentId string `json:"agent_id"`
 
 	// Deps IDs of tasks that must be done before this task can run
 	Deps        *[]string               `json:"deps,omitempty"`

--- a/cmd/stella/task.go
+++ b/cmd/stella/task.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -32,16 +33,31 @@ priorities, and human-in-the-loop actions like approve, reject, and respond.`,
 	}
 }
 
+func taskAgentID(c *ucli.Context) (string, error) {
+	if a := c.String("agent-id"); a != "" {
+		return a, nil
+	}
+	if a := os.Getenv("STELLA_AGENT_ID"); a != "" {
+		return a, nil
+	}
+	return "", fmt.Errorf("agent ID is required (pass --agent-id or set STELLA_AGENT_ID)")
+}
+
 func taskListCommand() *ucli.Command {
 	return &ucli.Command{
 		Name:  "list",
 		Usage: "List tasks",
 		Flags: []ucli.Flag{
+			&ucli.StringFlag{Name: "agent-id", Usage: "Agent ID (defaults to STELLA_AGENT_ID)"},
 			&ucli.StringFlag{Name: "status", Usage: "Filter by status (pending, running, blocked, review, done, cancelled, failed)"},
 			&ucli.BoolFlag{Name: "json", Usage: "Output as JSON"},
 		},
 		Action: func(c *ucli.Context) error {
-			params := &apiclient.ListAgentTasksParams{}
+			agentID, err := taskAgentID(c)
+			if err != nil {
+				return err
+			}
+			params := &apiclient.ListAgentTasksParams{AgentId: agentID}
 			if s := c.String("status"); s != "" {
 				params.Status = &s
 			}
@@ -101,12 +117,17 @@ func taskCreateCommand() *ucli.Command {
 			&ucli.StringFlag{Name: "title", Usage: "Task title (required)", Required: true},
 			&ucli.StringFlag{Name: "description", Usage: "Task description"},
 			&ucli.StringFlag{Name: "priority", Usage: "Priority: low, medium, high (default: medium)"},
-			&ucli.StringFlag{Name: "agent-id", Usage: "Agent ID to assign the task to"},
+			&ucli.StringFlag{Name: "agent-id", Usage: "Agent ID (defaults to STELLA_AGENT_ID)"},
 			&ucli.StringSliceFlag{Name: "dep", Usage: "Dependency task ID (can be repeated)"},
 		},
 		Action: func(c *ucli.Context) error {
+			agentID, err := taskAgentID(c)
+			if err != nil {
+				return err
+			}
 			body := apiclient.CreateAgentTaskJSONRequestBody{
-				Title: c.String("title"),
+				Title:   c.String("title"),
+				AgentId: agentID,
 			}
 			if d := c.String("description"); d != "" {
 				body.Description = &d
@@ -114,9 +135,6 @@ func taskCreateCommand() *ucli.Command {
 			if p := c.String("priority"); p != "" {
 				prio := apitypes.AgentTaskInputPriority(p)
 				body.Priority = &prio
-			}
-			if a := c.String("agent-id"); a != "" {
-				body.AgentId = &a
 			}
 			if deps := c.StringSlice("dep"); len(deps) > 0 {
 				body.Deps = &deps

--- a/internal/server/tasks.go
+++ b/internal/server/tasks.go
@@ -32,12 +32,8 @@ func (s *Server) ListAgentTasks(w http.ResponseWriter, r *http.Request, params a
 	if params.Status != nil {
 		statusFilter = *params.Status
 	}
-	var agentID string
-	if params.AgentId != nil {
-		agentID = *params.AgentId
-	}
 
-	list, err := s.tasksSvc.ListTasks(r.Context(), userID, agentID, statusFilter)
+	list, err := s.tasksSvc.ListTasks(r.Context(), userID, params.AgentId, statusFilter)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -66,15 +62,14 @@ func (s *Server) CreateAgentTask(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "title is required")
 		return
 	}
+	if body.AgentId == "" {
+		writeError(w, http.StatusBadRequest, "agent_id is required")
+		return
+	}
 
 	var userID string
 	if info != nil {
 		userID = info.UserID
-	}
-
-	agentID := ""
-	if body.AgentId != nil {
-		agentID = *body.AgentId
 	}
 	description := ""
 	if body.Description != nil {
@@ -93,7 +88,7 @@ func (s *Server) CreateAgentTask(w http.ResponseWriter, r *http.Request) {
 		Title:       body.Title,
 		Description: description,
 		Priority:    priority,
-		AgentID:     agentID,
+		AgentID:     body.AgentId,
 		UserID:      userID,
 		Deps:        deps,
 	})

--- a/internal/server/tasks.go
+++ b/internal/server/tasks.go
@@ -28,6 +28,11 @@ func (s *Server) ListAgentTasks(w http.ResponseWriter, r *http.Request, params a
 		userID = info.UserID
 	}
 
+	if _, code, msg := s.requireAgentAccess(r.Context(), params.AgentId); code != 0 {
+		writeError(w, code, msg)
+		return
+	}
+
 	var statusFilter string
 	if params.Status != nil {
 		statusFilter = *params.Status
@@ -64,6 +69,10 @@ func (s *Server) CreateAgentTask(w http.ResponseWriter, r *http.Request) {
 	}
 	if body.AgentId == "" {
 		writeError(w, http.StatusBadRequest, "agent_id is required")
+		return
+	}
+	if _, code, msg := s.requireAgentAccess(r.Context(), body.AgentId); code != 0 {
+		writeError(w, code, msg)
 		return
 	}
 

--- a/internal/tasks/service.go
+++ b/internal/tasks/service.go
@@ -360,19 +360,12 @@ func (s *Service) GetTask(ctx context.Context, id string, userID string) (sqlc.A
 	return task, nil
 }
 
-// ListTasks returns tasks filtered by userID, agentID, and status.
+// ListTasks returns tasks for a specific agent, filtered by status.
 func (s *Service) ListTasks(ctx context.Context, userID, agentID, status string) ([]sqlc.AgentTask, error) {
-	var tasks []sqlc.AgentTask
-	var err error
-
-	if agentID != "" {
-		tasks, err = s.q.ListAgentTasksByUserAndAgent(ctx, sqlc.ListAgentTasksByUserAndAgentParams{
-			UserID:  userID,
-			AgentID: sql.NullString{String: agentID, Valid: true},
-		})
-	} else {
-		tasks, err = s.q.ListAgentTasksByUser(ctx, userID)
-	}
+	tasks, err := s.q.ListAgentTasksByUserAndAgent(ctx, sqlc.ListAgentTasksByUserAndAgentParams{
+		UserID:  userID,
+		AgentID: sql.NullString{String: agentID, Valid: true},
+	})
 	if err != nil {
 		return nil, fmt.Errorf("tasks: list: %w", err)
 	}

--- a/web/src/features/sessions/panels/TaskBoardPanel.tsx
+++ b/web/src/features/sessions/panels/TaskBoardPanel.tsx
@@ -57,8 +57,10 @@ export function TaskBoardPanel({
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      const params = agentId ? `?agent_id=${encodeURIComponent(agentId)}` : "";
-      const res = await api<{ items: ComponentsAgentTask[] }>("GET", `/api/tasks${params}`);
+      const res = await api<{ items: ComponentsAgentTask[] }>(
+        "GET",
+        `/api/tasks?agent_id=${encodeURIComponent(agentId)}`,
+      );
       setTasks(res.items ?? []);
     } catch (e) {
       console.error(e);

--- a/web/src/features/sessions/panels/TaskPanel.tsx
+++ b/web/src/features/sessions/panels/TaskPanel.tsx
@@ -37,7 +37,7 @@ export function TaskPanel({ agentId, onCreated }: Props) {
         title: title.trim(),
         description: description.trim() || undefined,
         priority,
-        agent_id: agentId || undefined,
+        agent_id: agentId,
       });
       onCreated(task);
     } catch (e) {

--- a/web/src/lib/api-client/@tanstack/react-query.gen.ts
+++ b/web/src/lib/api-client/@tanstack/react-query.gen.ts
@@ -3977,13 +3977,13 @@ export const listSchedulerJobRunsOptions = (
     queryKey: listSchedulerJobRunsQueryKey(options),
   });
 
-export const listAgentTasksQueryKey = (options?: Options<ListAgentTasksData>) =>
+export const listAgentTasksQueryKey = (options: Options<ListAgentTasksData>) =>
   createQueryKey("listAgentTasks", options);
 
 /**
  * List agent tasks
  */
-export const listAgentTasksOptions = (options?: Options<ListAgentTasksData>) =>
+export const listAgentTasksOptions = (options: Options<ListAgentTasksData>) =>
   queryOptions<
     ListAgentTasksResponse,
     ListAgentTasksError,

--- a/web/src/lib/api-client/sdk.gen.ts
+++ b/web/src/lib/api-client/sdk.gen.ts
@@ -2536,9 +2536,9 @@ export const listSchedulerJobRuns = <ThrowOnError extends boolean = false>(
  * List agent tasks
  */
 export const listAgentTasks = <ThrowOnError extends boolean = false>(
-  options?: Options<ListAgentTasksData, ThrowOnError>,
+  options: Options<ListAgentTasksData, ThrowOnError>,
 ) =>
-  (options?.client ?? client).get<
+  (options.client ?? client).get<
     ListAgentTasksResponses,
     ListAgentTasksErrors,
     ThrowOnError

--- a/web/src/lib/api-client/types.gen.ts
+++ b/web/src/lib/api-client/types.gen.ts
@@ -315,7 +315,7 @@ export type ComponentsAgentTaskInput = {
   title: string;
   description?: string;
   priority?: "routine" | "urgent";
-  agent_id?: string;
+  agent_id: string;
   /**
    * IDs of tasks that must be done before this task can run
    */
@@ -6314,9 +6314,9 @@ export type ListSchedulerJobRunsResponse =
 export type ListAgentTasksData = {
   body?: never;
   path?: never;
-  query?: {
+  query: {
     status?: string;
-    agent_id?: string;
+    agent_id: string;
   };
   url: "/api/tasks";
 };


### PR DESCRIPTION
## Summary

- `GET /api/tasks` now requires `?agent_id=` as a mandatory query parameter (previously optional, silently falling back to all-user tasks)
- `POST /api/tasks` body now requires `agent_id` field
- API spec enforcement: missing `agent_id` returns `400 RequiredParamError` before reaching any handler
- Service layer removes `ListAgentTasksByUser` fallback — always queries `ListAgentTasksByUserAndAgent`
- CLI `stella task list` and `stella task create` follow the same pattern as skills: `--agent-id` flag with `STELLA_AGENT_ID` env var fallback
- Frontend `TaskBoardPanel` and `TaskPanel` cleaned up to always pass `agent_id` unconditionally

## Test plan

- [ ] `GET /api/tasks` without `agent_id` returns 400
- [ ] `GET /api/tasks?agent_id=<id>` returns only tasks for that agent
- [ ] `POST /api/tasks` without `agent_id` returns 400
- [ ] `stella task list` without `--agent-id` and without `STELLA_AGENT_ID` returns error
- [ ] `stella task list --agent-id <id>` works
- [ ] `STELLA_AGENT_ID=<id> stella task list` works
- [ ] Frontend task board loads correctly scoped to the current agent