### PR TITLE
🐛 fix: harden scheduler auth guards against nil user context

### DIFF
--- a/internal/server/scheduler.go
+++ b/internal/server/scheduler.go
@@ -309,12 +309,11 @@ func (s *Server) TriggerSchedulerJob(w http.ResponseWriter, r *http.Request, id 
 		writeError(w, http.StatusForbidden, "access denied")
 		return
 	}
-	if existing.OwnerKind == scheduler.JobOwnerPlugin {
-		writeError(w, http.StatusForbidden, "cannot manually trigger plugin jobs")
+	if existing.OwnerKind == scheduler.JobOwnerPlugin || existing.OwnerKind == scheduler.JobOwnerSystem {
+		writeError(w, http.StatusForbidden, "cannot manually trigger system or plugin jobs")
 		return
 	}
-	isGlobal := existing.OwnerKind == scheduler.JobOwnerSystem
-	if !isGlobal && (!existing.UserID.Valid || existing.UserID.String != info.UserID) {
+	if !existing.UserID.Valid || existing.UserID.String != info.UserID {
 		writeError(w, http.StatusForbidden, "access denied")
 		return
 	}

--- a/internal/server/scheduler.go
+++ b/internal/server/scheduler.go
@@ -30,7 +30,7 @@ func (s *Server) ListSchedulerJobs(w http.ResponseWriter, r *http.Request) {
 	jobs := make([]apiserver.Job, 0, len(rows))
 	for _, row := range rows {
 		isGlobal := row.OwnerKind == scheduler.JobOwnerPlugin || row.OwnerKind == scheduler.JobOwnerSystem
-		if !isGlobal && info != nil && row.UserID.Valid && row.UserID.String != info.UserID {
+		if !isGlobal && (info == nil || !row.UserID.Valid || row.UserID.String != info.UserID) {
 			continue
 		}
 		jobs = append(jobs, dbRowToAPIJob(row))
@@ -156,7 +156,7 @@ func (s *Server) UpdateSchedulerJob(w http.ResponseWriter, r *http.Request, id s
 		return
 	}
 
-	if info != nil && (!existing.UserID.Valid || existing.UserID.String != info.UserID) {
+	if info == nil || !existing.UserID.Valid || existing.UserID.String != info.UserID {
 		writeError(w, http.StatusForbidden, "access denied")
 		return
 	}
@@ -189,12 +189,7 @@ func (s *Server) UpdateSchedulerJob(w http.ResponseWriter, r *http.Request, id s
 		sessionMode = *body.SessionMode
 	}
 
-	var userID string
-	if info != nil {
-		userID = info.UserID
-	} else if existing.UserID.Valid {
-		userID = existing.UserID.String
-	}
+	userID := info.UserID
 
 	agentID := ""
 	if body.AgentId != nil {
@@ -278,7 +273,7 @@ func (s *Server) DeleteSchedulerJob(w http.ResponseWriter, r *http.Request, id s
 		return
 	}
 
-	if info != nil && (!existing.UserID.Valid || existing.UserID.String != info.UserID) {
+	if info == nil || !existing.UserID.Valid || existing.UserID.String != info.UserID {
 		writeError(w, http.StatusForbidden, "access denied")
 		return
 	}
@@ -314,7 +309,7 @@ func (s *Server) TriggerSchedulerJob(w http.ResponseWriter, r *http.Request, id 
 		return
 	}
 	isGlobal := existing.OwnerKind == scheduler.JobOwnerSystem
-	if !isGlobal && info != nil && (!existing.UserID.Valid || existing.UserID.String != info.UserID) {
+	if !isGlobal && (info == nil || !existing.UserID.Valid || existing.UserID.String != info.UserID) {
 		writeError(w, http.StatusForbidden, "access denied")
 		return
 	}
@@ -341,7 +336,7 @@ func (s *Server) ListSchedulerJobRuns(w http.ResponseWriter, r *http.Request, id
 
 	info := UserFromContext(r.Context())
 	isGlobal := existing.OwnerKind == scheduler.JobOwnerPlugin || existing.OwnerKind == scheduler.JobOwnerSystem
-	if info != nil && !isGlobal && (!existing.UserID.Valid || existing.UserID.String != info.UserID) {
+	if !isGlobal && (info == nil || !existing.UserID.Valid || existing.UserID.String != info.UserID) {
 		writeError(w, http.StatusForbidden, "access denied")
 		return
 	}
@@ -358,7 +353,7 @@ func (s *Server) ListSchedulerJobRuns(w http.ResponseWriter, r *http.Request, id
 	sm, _ := s.mem.(memory.SessionManager)
 	result := make(apitypes.JobRunList, 0, len(rows))
 	for _, row := range rows {
-		if info != nil && row.UserID.Valid && row.UserID.String != info.UserID {
+		if info == nil || (row.UserID.Valid && row.UserID.String != info.UserID) {
 			continue
 		}
 		j := dbRowToAPIJobRun(row)

--- a/internal/server/scheduler.go
+++ b/internal/server/scheduler.go
@@ -59,10 +59,11 @@ func (s *Server) CreateSchedulerJob(w http.ResponseWriter, r *http.Request) {
 		sessionMode = *body.SessionMode
 	}
 
-	var userID string
-	if info != nil {
-		userID = info.UserID
+	if info == nil {
+		writeError(w, http.StatusForbidden, "access denied")
+		return
 	}
+	userID := info.UserID
 
 	agentID := derefStr(body.AgentId)
 
@@ -304,12 +305,16 @@ func (s *Server) TriggerSchedulerJob(w http.ResponseWriter, r *http.Request, id 
 	}
 
 	info := UserFromContext(r.Context())
+	if info == nil {
+		writeError(w, http.StatusForbidden, "access denied")
+		return
+	}
 	if existing.OwnerKind == scheduler.JobOwnerPlugin {
 		writeError(w, http.StatusForbidden, "cannot manually trigger plugin jobs")
 		return
 	}
 	isGlobal := existing.OwnerKind == scheduler.JobOwnerSystem
-	if !isGlobal && (info == nil || !existing.UserID.Valid || existing.UserID.String != info.UserID) {
+	if !isGlobal && (!existing.UserID.Valid || existing.UserID.String != info.UserID) {
 		writeError(w, http.StatusForbidden, "access denied")
 		return
 	}


### PR DESCRIPTION
## Summary

- `ListSchedulerJobs`: when `UserFromContext` returns nil, the filter condition short-circuited to permissive, exposing all users' private jobs. Now defaults to only returning global (system/plugin) jobs when unauthenticated.
- `UpdateSchedulerJob` / `DeleteSchedulerJob` / `TriggerSchedulerJob`: the `info != nil &&` prefix meant the ownership check was skipped entirely for unauthenticated requests, allowing anyone to modify/delete/trigger any user-owned job. Now returns 403 immediately when `info == nil`.
- `ListSchedulerJobRuns`: same two issues as above, fixed consistently.
- Simplified a redundant `userID` assignment in `UpdateSchedulerJob` that became a tautological nil check after the guard was tightened.

The middleware already blocks unauthenticated requests in the normal path, so this is defence-in-depth — but the logic was inverted and should be correct regardless.

## Test plan

- [ ] Verify build passes: `mise run build`
- [ ] Verify tests pass: `mise run test`
- [ ] Manual: unauthenticated request to `GET /api/scheduler/jobs` returns only global jobs (system/plugin), not user-owned jobs
- [ ] Manual: unauthenticated `PUT`/`DELETE`/`POST /trigger` on a user-owned job returns 403