### PR TITLE
🐛 fix: auto-recreate sandbox session when closed underneath active runner

### DIFF
--- a/internal/agent/pool_reaper.go
+++ b/internal/agent/pool_reaper.go
@@ -32,6 +32,10 @@ func (p *Pool) reap() {
 			continue
 		}
 
+		if sess.Runner.Busy() {
+			continue
+		}
+
 		if !sess.Runner.Alive() {
 			p.log.Warn("removing dead runner", "session_id", id)
 			_ = sess.Runner.Close()
@@ -40,9 +44,6 @@ func (p *Pool) reap() {
 		}
 
 		if now.Sub(sess.Runner.LastActivity()) > p.idleTimeout {
-			if sess.Runner.Busy() {
-				continue
-			}
 			p.log.Info("reaping idle runner", "session_id", id, "idle_duration", now.Sub(sess.Runner.LastActivity()).Round(time.Second))
 			_ = sess.Runner.Close()
 			sess.Runner = nil

--- a/internal/agent/pool_test.go
+++ b/internal/agent/pool_test.go
@@ -42,6 +42,7 @@ type mockRunner struct {
 	closed       bool
 	lastActivity time.Time
 	alive        bool
+	busy         bool
 }
 
 func newMockRunner(events []Event) *mockRunner {
@@ -96,7 +97,11 @@ func (m *mockRunner) LastActivity() time.Time {
 	return m.lastActivity
 }
 
-func (m *mockRunner) Busy() bool { return false }
+func (m *mockRunner) Busy() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.busy
+}
 
 func (m *mockRunner) SystemPrompt() string {
 	m.mu.Lock()
@@ -409,6 +414,45 @@ func TestPoolReapDead(t *testing.T) {
 	}
 	if !(*runners)[0].closed {
 		t.Error("dead runner should be closed during reap")
+	}
+}
+
+func TestPoolReapSkipsBusyDeadRunner(t *testing.T) {
+	factory, runners := mockRunnerFactory([]Event{{Text: "ok"}})
+	pool := NewPool(factory, testMemoryProvider(t), WithAgentID("test-agent"), WithIdleTimeout(10*time.Minute))
+	defer func() { _ = pool.Close() }()
+
+	ctx := testSessionContext()
+
+	_, _, err := pool.getOrCreateRunner(ctx, "busy-dead-sess", "")
+	if err != nil {
+		t.Fatalf("getOrCreateRunner: %v", err)
+	}
+
+	// Mark runner as dead but still busy (in-flight chat).
+	(*runners)[0].mu.Lock()
+	(*runners)[0].alive = false
+	(*runners)[0].busy = true
+	(*runners)[0].mu.Unlock()
+
+	pool.reap()
+
+	pool.mu.Lock()
+	sess, exists := pool.sessions["busy-dead-sess"]
+	var runnerNil bool
+	if exists {
+		runnerNil = sess.Runner == nil
+	}
+	pool.mu.Unlock()
+
+	if !exists {
+		t.Error("session should still exist")
+	}
+	if runnerNil {
+		t.Error("busy runner should not be reaped even if dead")
+	}
+	if (*runners)[0].closed {
+		t.Error("busy runner should not be closed by reaper")
 	}
 }
 

--- a/internal/agent/sandbox/session.go
+++ b/internal/agent/sandbox/session.go
@@ -159,21 +159,34 @@ func ResolveSession(ctx context.Context, cfg Config) (pkgsandbox.Session, error)
 	)
 	defer span.End()
 
-	var session pkgsandbox.Session
-	var err error
-	switch name {
-	case config.SandboxBackendDocker:
-		session, err = createDockerSession(ctx, cfg)
-	case config.SandboxBackendLocal:
-		session, err = createLocalSession(ctx, cfg)
-	case config.SandboxBackendNone:
-		session, err = createHostSession(ctx, cfg)
-	default:
-		err = fmt.Errorf("unknown sandbox backend: %q", name)
-	}
+	session, err := createSession(ctx, cfg)
 	if err != nil {
 		recordSandboxError(span, err)
 		return nil, err
 	}
-	return session, nil
+
+	return pkgsandbox.NewResilientSession(session, func(ctx context.Context) (pkgsandbox.Session, error) {
+		return createSession(ctx, cfg)
+	}), nil
+}
+
+// createSession creates a raw sandbox session without the resilient wrapper.
+func createSession(ctx context.Context, cfg Config) (pkgsandbox.Session, error) {
+	name := config.SandboxBackendLocal
+	if cfg.SandboxBackendFn != nil {
+		if override := cfg.SandboxBackendFn(ctx); override != "" {
+			name = override
+		}
+	}
+
+	switch name {
+	case config.SandboxBackendDocker:
+		return createDockerSession(ctx, cfg)
+	case config.SandboxBackendLocal:
+		return createLocalSession(ctx, cfg)
+	case config.SandboxBackendNone:
+		return createHostSession(ctx, cfg)
+	default:
+		return nil, fmt.Errorf("unknown sandbox backend: %q", name)
+	}
 }

--- a/pkg/sandbox/resilient.go
+++ b/pkg/sandbox/resilient.go
@@ -12,8 +12,9 @@ import (
 type SessionCreator func(ctx context.Context) (Session, error)
 
 // ResilientSession wraps a Session and transparently recreates it when the
-// underlying session has been closed (e.g. by an idle reaper or config reload).
-// Explicit Close calls are permanent — no recreation after that.
+// underlying session has been closed unexpectedly (e.g. container exited or
+// sandbox process crashed). Explicit Close calls are permanent — no recreation
+// after that.
 type ResilientSession struct {
 	create SessionCreator
 	mu     sync.Mutex

--- a/pkg/sandbox/resilient.go
+++ b/pkg/sandbox/resilient.go
@@ -1,0 +1,146 @@
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+)
+
+// SessionCreator creates a new session. Used by ResilientSession to recreate
+// the underlying session when it is found closed.
+type SessionCreator func(ctx context.Context) (Session, error)
+
+// ResilientSession wraps a Session and transparently recreates it when the
+// underlying session has been closed (e.g. by an idle reaper or config reload).
+// Explicit Close calls are permanent — no recreation after that.
+type ResilientSession struct {
+	create SessionCreator
+	mu     sync.Mutex
+	inner  Session
+	closed bool
+	log    *slog.Logger
+}
+
+// NewResilientSession wraps an existing session with auto-recreation support.
+func NewResilientSession(session Session, create SessionCreator) *ResilientSession {
+	return &ResilientSession{
+		create: create,
+		inner:  session,
+		log:    slog.With("component", "resilient_session"),
+	}
+}
+
+// ensureAlive returns the inner session if alive, or recreates it.
+// Caller must NOT hold r.mu.
+func (r *ResilientSession) ensureAlive(ctx context.Context) (Session, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.closed {
+		return nil, fmt.Errorf("sandbox: session is permanently closed")
+	}
+
+	if r.inner != nil && r.inner.Alive() {
+		return r.inner, nil
+	}
+
+	r.log.Info("recreating sandbox session")
+	session, err := r.create(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("sandbox: recreate session: %w", err)
+	}
+
+	r.inner = session
+	return session, nil
+}
+
+func (r *ResilientSession) Policy() Policy {
+	r.mu.Lock()
+	s := r.inner
+	r.mu.Unlock()
+	if s == nil {
+		return Policy{}
+	}
+	return s.Policy()
+}
+
+func (r *ResilientSession) WorkingDir() string {
+	r.mu.Lock()
+	s := r.inner
+	r.mu.Unlock()
+	if s == nil {
+		return ""
+	}
+	return s.WorkingDir()
+}
+
+func (r *ResilientSession) Alive() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return false
+	}
+	return r.inner != nil && r.inner.Alive()
+}
+
+func (r *ResilientSession) Done() <-chan struct{} {
+	r.mu.Lock()
+	s := r.inner
+	r.mu.Unlock()
+	if s == nil {
+		ch := make(chan struct{})
+		close(ch)
+		return ch
+	}
+	return s.Done()
+}
+
+func (r *ResilientSession) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return nil
+	}
+	r.closed = true
+	if r.inner != nil {
+		return r.inner.Close()
+	}
+	return nil
+}
+
+func (r *ResilientSession) Exec(ctx context.Context, command string, opts ExecOptions) (ExecResult, error) {
+	s, err := r.ensureAlive(ctx)
+	if err != nil {
+		return ExecResult{}, err
+	}
+	return s.Exec(ctx, command, opts)
+}
+
+func (r *ResilientSession) StartProcess(ctx context.Context, req ProcessRequest) (ProcessHandle, error) {
+	s, err := r.ensureAlive(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return s.StartProcess(ctx, req)
+}
+
+func (r *ResilientSession) ResolvePath(path string) (string, error) {
+	r.mu.Lock()
+	s := r.inner
+	r.mu.Unlock()
+	if s == nil {
+		return "", fmt.Errorf("sandbox: no active session")
+	}
+	return s.ResolvePath(path)
+}
+
+func (r *ResilientSession) ResolveWritePath(path string) (string, error) {
+	r.mu.Lock()
+	s := r.inner
+	r.mu.Unlock()
+	if s == nil {
+		return "", fmt.Errorf("sandbox: no active session")
+	}
+	return s.ResolveWritePath(path)
+}

--- a/pkg/sandbox/resilient_test.go
+++ b/pkg/sandbox/resilient_test.go
@@ -1,0 +1,170 @@
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// mockSession is a controllable Session for testing ResilientSession.
+type mockSession struct {
+	mu        sync.Mutex
+	alive     bool
+	closed    bool
+	execCount int
+	done      chan struct{}
+}
+
+func newMockSession() *mockSession {
+	return &mockSession{alive: true, done: make(chan struct{})}
+}
+
+func (m *mockSession) Policy() Policy        { return Policy{} }
+func (m *mockSession) WorkingDir() string    { return "/workspace" }
+func (m *mockSession) Done() <-chan struct{} { return m.done }
+
+func (m *mockSession) Alive() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.alive
+}
+
+func (m *mockSession) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.alive = false
+	m.closed = true
+	return nil
+}
+
+func (m *mockSession) Exec(_ context.Context, _ string, _ ExecOptions) (ExecResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.execCount++
+	return ExecResult{Stdout: "ok"}, nil
+}
+
+func (m *mockSession) StartProcess(_ context.Context, _ ProcessRequest) (ProcessHandle, error) {
+	return nil, nil
+}
+
+func (m *mockSession) ResolvePath(path string) (string, error)      { return path, nil }
+func (m *mockSession) ResolveWritePath(path string) (string, error) { return path, nil }
+
+func TestResilientSession_ExecUsesExistingSession(t *testing.T) {
+	s := newMockSession()
+	rs := NewResilientSession(s, func(_ context.Context) (Session, error) {
+		t.Fatal("should not recreate")
+		return nil, nil
+	})
+
+	result, err := rs.Exec(context.Background(), "echo hi", ExecOptions{})
+	if err != nil {
+		t.Fatalf("Exec error: %v", err)
+	}
+	if result.Stdout != "ok" {
+		t.Errorf("got %q, want %q", result.Stdout, "ok")
+	}
+}
+
+func TestResilientSession_RecreatesAfterClose(t *testing.T) {
+	first := newMockSession()
+	second := newMockSession()
+
+	var createCount atomic.Int32
+	rs := NewResilientSession(first, func(_ context.Context) (Session, error) {
+		createCount.Add(1)
+		return second, nil
+	})
+
+	// Close the underlying session (simulates reaper).
+	_ = first.Close()
+
+	result, err := rs.Exec(context.Background(), "echo hi", ExecOptions{})
+	if err != nil {
+		t.Fatalf("Exec error: %v", err)
+	}
+	if result.Stdout != "ok" {
+		t.Errorf("got %q, want %q", result.Stdout, "ok")
+	}
+	if createCount.Load() != 1 {
+		t.Errorf("create called %d times, want 1", createCount.Load())
+	}
+
+	// Second exec should reuse the recreated session.
+	_, err = rs.Exec(context.Background(), "echo hi", ExecOptions{})
+	if err != nil {
+		t.Fatalf("second Exec error: %v", err)
+	}
+	if createCount.Load() != 1 {
+		t.Errorf("create called %d times after second exec, want 1", createCount.Load())
+	}
+}
+
+func TestResilientSession_PermanentCloseRejectsExec(t *testing.T) {
+	s := newMockSession()
+	rs := NewResilientSession(s, func(_ context.Context) (Session, error) {
+		t.Fatal("should not recreate after permanent close")
+		return nil, nil
+	})
+
+	_ = rs.Close()
+
+	_, err := rs.Exec(context.Background(), "echo hi", ExecOptions{})
+	if err == nil {
+		t.Fatal("Exec should fail after permanent Close")
+	}
+}
+
+func TestResilientSession_RecreateFailurePropagates(t *testing.T) {
+	first := newMockSession()
+	_ = first.Close()
+
+	rs := NewResilientSession(first, func(_ context.Context) (Session, error) {
+		return nil, errors.New("docker daemon unreachable")
+	})
+
+	_, err := rs.Exec(context.Background(), "echo hi", ExecOptions{})
+	if err == nil {
+		t.Fatal("Exec should fail when recreate fails")
+	}
+}
+
+func TestResilientSession_AliveReflectsInner(t *testing.T) {
+	s := newMockSession()
+	rs := NewResilientSession(s, nil)
+
+	if !rs.Alive() {
+		t.Error("should be alive initially")
+	}
+
+	_ = s.Close()
+	if rs.Alive() {
+		t.Error("should not be alive after inner close")
+	}
+}
+
+func TestResilientSession_ConcurrentExecRecreatesOnce(t *testing.T) {
+	first := newMockSession()
+	_ = first.Close()
+
+	var createCount atomic.Int32
+	rs := NewResilientSession(first, func(_ context.Context) (Session, error) {
+		createCount.Add(1)
+		return newMockSession(), nil
+	})
+
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Go(func() {
+			_, _ = rs.Exec(context.Background(), "echo hi", ExecOptions{})
+		})
+	}
+	wg.Wait()
+
+	if createCount.Load() != 1 {
+		t.Errorf("create called %d times, want 1 (should deduplicate)", createCount.Load())
+	}
+}


### PR DESCRIPTION
## Summary

- Sandbox sessions could be closed by the idle reaper, config hot-reload, or credential invalidation while a Chat call was still in flight, causing all subsequent bash/tool commands to fail with `"session is closed"`
- Added `ResilientSession` wrapper (`pkg/sandbox/resilient.go`) that transparently recreates the underlying session on `Exec`/`StartProcess` when the inner session is found closed
- Wired into `ResolveSession` so all backends (local/bwrap, docker, none) benefit without per-backend changes

## Test plan

- [x] Unit tests for ResilientSession: normal use, recreate after close, permanent close rejection, recreate failure propagation, Alive state, concurrent recreate deduplication
- [x] Full test suite passes (`mise run test`)
- [x] Lint clean (`mise run format`)
- [ ] Manual test: trigger idle reaper or config reload during active Feishu conversation and verify bash commands recover