### PR TITLE
feat(auth): auth finalization — local credentials, OIDC issuer, org-scoped resources

### DIFF
--- a/api/client/gen.go
+++ b/api/client/gen.go
@@ -643,6 +643,9 @@ type UpdateAuthUserActiveJSONRequestBody = externalRef0.UpdateActiveRequest
 // UpdateAuthUserAgentsJSONRequestBody defines body for UpdateAuthUserAgents for application/json ContentType.
 type UpdateAuthUserAgentsJSONRequestBody = externalRef0.UpdateAgentsRequest
 
+// LinkAuthUserLoginIdentityJSONRequestBody defines body for LinkAuthUserLoginIdentity for application/json ContentType.
+type LinkAuthUserLoginIdentityJSONRequestBody = externalRef0.LinkLoginIdentityRequest
+
 // UpdateAuthUserRoleJSONRequestBody defines body for UpdateAuthUserRole for application/json ContentType.
 type UpdateAuthUserRoleJSONRequestBody = externalRef0.UpdateRoleRequest
 
@@ -1070,6 +1073,17 @@ type ClientInterface interface {
 	UpdateAuthUserAgentsWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	UpdateAuthUserAgents(ctx context.Context, id string, body UpdateAuthUserAgentsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListAuthUserChannelIdentities request
+	ListAuthUserChannelIdentities(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListAuthUserLoginIdentities request
+	ListAuthUserLoginIdentities(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// LinkAuthUserLoginIdentityWithBody request with any body
+	LinkAuthUserLoginIdentityWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	LinkAuthUserLoginIdentity(ctx context.Context, id string, body LinkAuthUserLoginIdentityJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// DeleteAuthUserIdentity request
 	DeleteAuthUserIdentity(ctx context.Context, id string, identityId string, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -2585,6 +2599,54 @@ func (c *Client) UpdateAuthUserAgentsWithBody(ctx context.Context, id string, co
 
 func (c *Client) UpdateAuthUserAgents(ctx context.Context, id string, body UpdateAuthUserAgentsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUpdateAuthUserAgentsRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListAuthUserChannelIdentities(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListAuthUserChannelIdentitiesRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListAuthUserLoginIdentities(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListAuthUserLoginIdentitiesRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) LinkAuthUserLoginIdentityWithBody(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewLinkAuthUserLoginIdentityRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) LinkAuthUserLoginIdentity(ctx context.Context, id string, body LinkAuthUserLoginIdentityJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewLinkAuthUserLoginIdentityRequest(c.Server, id, body)
 	if err != nil {
 		return nil, err
 	}
@@ -7282,6 +7344,121 @@ func NewUpdateAuthUserAgentsRequestWithBody(server string, id string, contentTyp
 	return req, nil
 }
 
+// NewListAuthUserChannelIdentitiesRequest generates requests for ListAuthUserChannelIdentities
+func NewListAuthUserChannelIdentitiesRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/users/%s/identities/channel", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewListAuthUserLoginIdentitiesRequest generates requests for ListAuthUserLoginIdentities
+func NewListAuthUserLoginIdentitiesRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/users/%s/identities/login", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewLinkAuthUserLoginIdentityRequest calls the generic LinkAuthUserLoginIdentity builder with application/json body
+func NewLinkAuthUserLoginIdentityRequest(server string, id string, body LinkAuthUserLoginIdentityJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewLinkAuthUserLoginIdentityRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewLinkAuthUserLoginIdentityRequestWithBody generates requests for LinkAuthUserLoginIdentity with any type of body
+func NewLinkAuthUserLoginIdentityRequestWithBody(server string, id string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/auth/users/%s/identities/login", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewDeleteAuthUserIdentityRequest generates requests for DeleteAuthUserIdentity
 func NewDeleteAuthUserIdentityRequest(server string, id string, identityId string) (*http.Request, error) {
 	var err error
@@ -10074,6 +10251,17 @@ type ClientWithResponsesInterface interface {
 	UpdateAuthUserAgentsWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateAuthUserAgentsResponse, error)
 
 	UpdateAuthUserAgentsWithResponse(ctx context.Context, id string, body UpdateAuthUserAgentsJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateAuthUserAgentsResponse, error)
+
+	// ListAuthUserChannelIdentitiesWithResponse request
+	ListAuthUserChannelIdentitiesWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*ListAuthUserChannelIdentitiesResponse, error)
+
+	// ListAuthUserLoginIdentitiesWithResponse request
+	ListAuthUserLoginIdentitiesWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*ListAuthUserLoginIdentitiesResponse, error)
+
+	// LinkAuthUserLoginIdentityWithBodyWithResponse request with any body
+	LinkAuthUserLoginIdentityWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*LinkAuthUserLoginIdentityResponse, error)
+
+	LinkAuthUserLoginIdentityWithResponse(ctx context.Context, id string, body LinkAuthUserLoginIdentityJSONRequestBody, reqEditors ...RequestEditorFn) (*LinkAuthUserLoginIdentityResponse, error)
 
 	// DeleteAuthUserIdentityWithResponse request
 	DeleteAuthUserIdentityWithResponse(ctx context.Context, id string, identityId string, reqEditors ...RequestEditorFn) (*DeleteAuthUserIdentityResponse, error)
@@ -12875,6 +13063,107 @@ func (r UpdateAuthUserAgentsResponse) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r UpdateAuthUserAgentsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListAuthUserChannelIdentitiesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]externalRef0.ChannelIdentity
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r ListAuthUserChannelIdentitiesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListAuthUserChannelIdentitiesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListAuthUserChannelIdentitiesResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListAuthUserLoginIdentitiesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]externalRef0.LoginIdentity
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+	JSON404      *externalRef0.NotFound
+}
+
+// Status returns HTTPResponse.Status
+func (r ListAuthUserLoginIdentitiesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListAuthUserLoginIdentitiesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListAuthUserLoginIdentitiesResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type LinkAuthUserLoginIdentityResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *externalRef0.LoginIdentity
+	JSON400      *externalRef0.BadRequest
+	JSON401      *externalRef0.Unauthorized
+	JSON403      *externalRef0.Forbidden
+	JSON404      *externalRef0.NotFound
+	JSON409      *externalRef0.Conflict
+}
+
+// Status returns HTTPResponse.Status
+func (r LinkAuthUserLoginIdentityResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r LinkAuthUserLoginIdentityResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r LinkAuthUserLoginIdentityResponse) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -15735,6 +16024,41 @@ func (c *ClientWithResponses) UpdateAuthUserAgentsWithResponse(ctx context.Conte
 		return nil, err
 	}
 	return ParseUpdateAuthUserAgentsResponse(rsp)
+}
+
+// ListAuthUserChannelIdentitiesWithResponse request returning *ListAuthUserChannelIdentitiesResponse
+func (c *ClientWithResponses) ListAuthUserChannelIdentitiesWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*ListAuthUserChannelIdentitiesResponse, error) {
+	rsp, err := c.ListAuthUserChannelIdentities(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListAuthUserChannelIdentitiesResponse(rsp)
+}
+
+// ListAuthUserLoginIdentitiesWithResponse request returning *ListAuthUserLoginIdentitiesResponse
+func (c *ClientWithResponses) ListAuthUserLoginIdentitiesWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*ListAuthUserLoginIdentitiesResponse, error) {
+	rsp, err := c.ListAuthUserLoginIdentities(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListAuthUserLoginIdentitiesResponse(rsp)
+}
+
+// LinkAuthUserLoginIdentityWithBodyWithResponse request with arbitrary body returning *LinkAuthUserLoginIdentityResponse
+func (c *ClientWithResponses) LinkAuthUserLoginIdentityWithBodyWithResponse(ctx context.Context, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*LinkAuthUserLoginIdentityResponse, error) {
+	rsp, err := c.LinkAuthUserLoginIdentityWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseLinkAuthUserLoginIdentityResponse(rsp)
+}
+
+func (c *ClientWithResponses) LinkAuthUserLoginIdentityWithResponse(ctx context.Context, id string, body LinkAuthUserLoginIdentityJSONRequestBody, reqEditors ...RequestEditorFn) (*LinkAuthUserLoginIdentityResponse, error) {
+	rsp, err := c.LinkAuthUserLoginIdentity(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseLinkAuthUserLoginIdentityResponse(rsp)
 }
 
 // DeleteAuthUserIdentityWithResponse request returning *DeleteAuthUserIdentityResponse
@@ -19812,6 +20136,161 @@ func ParseUpdateAuthUserAgentsResponse(rsp *http.Response) (*UpdateAuthUserAgent
 			return nil, err
 		}
 		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListAuthUserChannelIdentitiesResponse parses an HTTP response from a ListAuthUserChannelIdentitiesWithResponse call
+func ParseListAuthUserChannelIdentitiesResponse(rsp *http.Response) (*ListAuthUserChannelIdentitiesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListAuthUserChannelIdentitiesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []externalRef0.ChannelIdentity
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListAuthUserLoginIdentitiesResponse parses an HTTP response from a ListAuthUserLoginIdentitiesWithResponse call
+func ParseListAuthUserLoginIdentitiesResponse(rsp *http.Response) (*ListAuthUserLoginIdentitiesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListAuthUserLoginIdentitiesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []externalRef0.LoginIdentity
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseLinkAuthUserLoginIdentityResponse parses an HTTP response from a LinkAuthUserLoginIdentityWithResponse call
+func ParseLinkAuthUserLoginIdentityResponse(rsp *http.Response) (*LinkAuthUserLoginIdentityResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &LinkAuthUserLoginIdentityResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest externalRef0.LoginIdentity
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest externalRef0.BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest externalRef0.Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest externalRef0.Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest externalRef0.NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest externalRef0.Conflict
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
 
 	}
 

--- a/api/server/gen.go
+++ b/api/server/gen.go
@@ -641,6 +641,9 @@ type UpdateAuthUserActiveJSONRequestBody = externalRef0.UpdateActiveRequest
 // UpdateAuthUserAgentsJSONRequestBody defines body for UpdateAuthUserAgents for application/json ContentType.
 type UpdateAuthUserAgentsJSONRequestBody = externalRef0.UpdateAgentsRequest
 
+// LinkAuthUserLoginIdentityJSONRequestBody defines body for LinkAuthUserLoginIdentity for application/json ContentType.
+type LinkAuthUserLoginIdentityJSONRequestBody = externalRef0.LinkLoginIdentityRequest
+
 // UpdateAuthUserRoleJSONRequestBody defines body for UpdateAuthUserRole for application/json ContentType.
 type UpdateAuthUserRoleJSONRequestBody = externalRef0.UpdateRoleRequest
 
@@ -940,6 +943,15 @@ type ServerInterface interface {
 	// Update agents assigned to an auth user (admin only)
 	// (PUT /api/auth/users/{id}/agents)
 	UpdateAuthUserAgents(w http.ResponseWriter, r *http.Request, id string)
+	// List channel identities for an auth user (admin only)
+	// (GET /api/auth/users/{id}/identities/channel)
+	ListAuthUserChannelIdentities(w http.ResponseWriter, r *http.Request, id string)
+	// List OIDC login identities for an auth user (admin only)
+	// (GET /api/auth/users/{id}/identities/login)
+	ListAuthUserLoginIdentities(w http.ResponseWriter, r *http.Request, id string)
+	// Link an OIDC login identity to an auth user (admin only)
+	// (POST /api/auth/users/{id}/identities/login)
+	LinkAuthUserLoginIdentity(w http.ResponseWriter, r *http.Request, id string)
 	// Delete an identity linked to an auth user (admin only)
 	// (DELETE /api/auth/users/{id}/identities/{identityId})
 	DeleteAuthUserIdentity(w http.ResponseWriter, r *http.Request, id string, identityId string)
@@ -4211,6 +4223,102 @@ func (siw *ServerInterfaceWrapper) UpdateAuthUserAgents(w http.ResponseWriter, r
 	handler.ServeHTTP(w, r)
 }
 
+// ListAuthUserChannelIdentities operation middleware
+func (siw *ServerInterfaceWrapper) ListAuthUserChannelIdentities(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListAuthUserChannelIdentities(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListAuthUserLoginIdentities operation middleware
+func (siw *ServerInterfaceWrapper) ListAuthUserLoginIdentities(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListAuthUserLoginIdentities(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// LinkAuthUserLoginIdentity operation middleware
+func (siw *ServerInterfaceWrapper) LinkAuthUserLoginIdentity(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.LinkAuthUserLoginIdentity(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // DeleteAuthUserIdentity operation middleware
 func (siw *ServerInterfaceWrapper) DeleteAuthUserIdentity(w http.ResponseWriter, r *http.Request) {
 
@@ -6324,6 +6432,9 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/api/auth/users/{id}/active", wrapper.UpdateAuthUserActive)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/auth/users/{id}/agents", wrapper.ListAuthUserAgents)
 	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/api/auth/users/{id}/agents", wrapper.UpdateAuthUserAgents)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/auth/users/{id}/identities/channel", wrapper.ListAuthUserChannelIdentities)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/auth/users/{id}/identities/login", wrapper.ListAuthUserLoginIdentities)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/api/auth/users/{id}/identities/login", wrapper.LinkAuthUserLoginIdentity)
 	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/api/auth/users/{id}/identities/{identityId}", wrapper.DeleteAuthUserIdentity)
 	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/api/auth/users/{id}/role", wrapper.UpdateAuthUserRole)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/api/builtin/{kind}", wrapper.ListBuiltinResources)

--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -1970,3 +1970,75 @@ components:
       properties:
         is_active:
           type: boolean
+    LoginIdentity:
+      type: object
+      required: [
+        id,
+        user_id,
+        provider,
+        provider_subject,
+        email,
+        created_at,
+        updated_at,
+      ]
+      properties:
+        id:
+          type: string
+        user_id:
+          type: string
+        provider:
+          type: string
+        provider_subject:
+          type: string
+        email:
+          type: string
+        name:
+          type: string
+        avatar_url:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    ChannelIdentity:
+      type: object
+      required: [
+        id,
+        user_id,
+        platform,
+        external_id,
+        name,
+        created_at,
+        updated_at,
+      ]
+      properties:
+        id:
+          type: string
+        user_id:
+          type: string
+        platform:
+          type: string
+        external_id:
+          type: string
+        name:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    LinkLoginIdentityRequest:
+      type: object
+      required: [provider, provider_subject, email]
+      properties:
+        provider:
+          type: string
+        provider_subject:
+          type: string
+        email:
+          type: string
+        name:
+          type: string

--- a/api/spec/domain/users/paths.yaml
+++ b/api/spec/domain/users/paths.yaml
@@ -283,6 +283,80 @@ paths:
         }
         "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
 
+  /api/auth/users/{id}/identities/login:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: string } }
+    get:
+      tags: [auth-users]
+      summary: List OIDC login identities for an auth user (admin only)
+      operationId: listAuthUserLoginIdentities
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items: {
+                  $ref: "../../components.yaml#/components/schemas/LoginIdentity",
+                }
+        "401": {
+          $ref: "../../components.yaml#/components/responses/Unauthorized",
+        }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+    post:
+      tags: [auth-users]
+      summary: Link an OIDC login identity to an auth user (admin only)
+      operationId: linkAuthUserLoginIdentity
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {
+              $ref: "../../components.yaml#/components/schemas/LinkLoginIdentityRequest",
+            }
+      responses:
+        "200":
+          description: linked
+          content:
+            application/json:
+              schema: {
+                $ref: "../../components.yaml#/components/schemas/LoginIdentity",
+              }
+        "400": {
+          $ref: "../../components.yaml#/components/responses/BadRequest",
+        }
+        "401": {
+          $ref: "../../components.yaml#/components/responses/Unauthorized",
+        }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+        "409": { $ref: "../../components.yaml#/components/responses/Conflict" }
+
+  /api/auth/users/{id}/identities/channel:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: string } }
+    get:
+      tags: [auth-users]
+      summary: List channel identities for an auth user (admin only)
+      operationId: listAuthUserChannelIdentities
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items: {
+                  $ref: "../../components.yaml#/components/schemas/ChannelIdentity",
+                }
+        "401": {
+          $ref: "../../components.yaml#/components/responses/Unauthorized",
+        }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+
   /api/auth/users/{id}/identities/{identityId}:
     parameters:
       - {

--- a/api/spec/domain/users/schemas.yaml
+++ b/api/spec/domain/users/schemas.yaml
@@ -88,3 +88,54 @@ components:
       required: [is_active]
       properties:
         is_active: { type: boolean }
+
+    LoginIdentity:
+      type: object
+      required: [
+        id,
+        user_id,
+        provider,
+        provider_subject,
+        email,
+        created_at,
+        updated_at,
+      ]
+      properties:
+        id: { type: string }
+        user_id: { type: string }
+        provider: { type: string }
+        provider_subject: { type: string }
+        email: { type: string }
+        name: { type: string }
+        avatar_url: { type: string }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+
+    ChannelIdentity:
+      type: object
+      required: [
+        id,
+        user_id,
+        platform,
+        external_id,
+        name,
+        created_at,
+        updated_at,
+      ]
+      properties:
+        id: { type: string }
+        user_id: { type: string }
+        platform: { type: string }
+        external_id: { type: string }
+        name: { type: string }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+
+    LinkLoginIdentityRequest:
+      type: object
+      required: [provider, provider_subject, email]
+      properties:
+        provider: { type: string }
+        provider_subject: { type: string }
+        email: { type: string }
+        name: { type: string }

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -191,6 +191,10 @@ paths:
     $ref: "./domain/users/paths.yaml#/paths/~1api~1auth~1users~1{id}~1role"
   /api/auth/users/{id}/agents:
     $ref: "./domain/users/paths.yaml#/paths/~1api~1auth~1users~1{id}~1agents"
+  /api/auth/users/{id}/identities/login:
+    $ref: "./domain/users/paths.yaml#/paths/~1api~1auth~1users~1{id}~1identities~1login"
+  /api/auth/users/{id}/identities/channel:
+    $ref: "./domain/users/paths.yaml#/paths/~1api~1auth~1users~1{id}~1identities~1channel"
   /api/auth/users/{id}/identities/{identityId}:
     $ref: "./domain/users/paths.yaml#/paths/~1api~1auth~1users~1{id}~1identities~1{identityId}"
   /api/auth/users/{id}/active:

--- a/api/types/gen.go
+++ b/api/types/gen.go
@@ -621,6 +621,17 @@ type Channel struct {
 	Type    string `json:"type"`
 }
 
+// ChannelIdentity defines model for ChannelIdentity.
+type ChannelIdentity struct {
+	CreatedAt  time.Time `json:"created_at"`
+	ExternalId string    `json:"external_id"`
+	Id         string    `json:"id"`
+	Name       string    `json:"name"`
+	Platform   string    `json:"platform"`
+	UpdatedAt  time.Time `json:"updated_at"`
+	UserId     string    `json:"user_id"`
+}
+
 // ChannelList defines model for ChannelList.
 type ChannelList struct {
 	Items []Channel `json:"items"`
@@ -908,6 +919,27 @@ type JobRunList = []JobRun
 type LinkCodeResponse struct {
 	Code     string `json:"code"`
 	Platform string `json:"platform"`
+}
+
+// LinkLoginIdentityRequest defines model for LinkLoginIdentityRequest.
+type LinkLoginIdentityRequest struct {
+	Email           string  `json:"email"`
+	Name            *string `json:"name,omitempty"`
+	Provider        string  `json:"provider"`
+	ProviderSubject string  `json:"provider_subject"`
+}
+
+// LoginIdentity defines model for LoginIdentity.
+type LoginIdentity struct {
+	AvatarUrl       *string   `json:"avatar_url,omitempty"`
+	CreatedAt       time.Time `json:"created_at"`
+	Email           string    `json:"email"`
+	Id              string    `json:"id"`
+	Name            *string   `json:"name,omitempty"`
+	Provider        string    `json:"provider"`
+	ProviderSubject string    `json:"provider_subject"`
+	UpdatedAt       time.Time `json:"updated_at"`
+	UserId          string    `json:"user_id"`
 }
 
 // LoginRequest defines model for LoginRequest.

--- a/cmd/stella/auth.go
+++ b/cmd/stella/auth.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	ucli "github.com/urfave/cli/v2"
+
+	apiclient "github.com/CherryHQ/stella/api/client"
+	apitypes "github.com/CherryHQ/stella/api/types"
+)
+
+func authCommand() *ucli.Command {
+	return &ucli.Command{
+		Name:     "auth",
+		Usage:    "Manage authentication and user identities",
+		Category: "Admin",
+		Subcommands: []*ucli.Command{
+			authLinkUserCommand(),
+		},
+	}
+}
+
+func authLinkUserCommand() *ucli.Command {
+	return &ucli.Command{
+		Name:  "link-user",
+		Usage: "Link an OIDC login identity to a user (admin recovery)",
+		Description: `Creates an OIDC login identity for an existing user, allowing them to
+log in via the configured OIDC provider. Useful for migrating legacy
+username/password accounts or recovering access after an identity loss.
+
+Requires an active stella server and admin credentials.`,
+		Flags: []ucli.Flag{
+			&ucli.StringFlag{
+				Name:     "user-id",
+				Usage:    "User ID to link the identity to",
+				Required: true,
+			},
+			&ucli.StringFlag{
+				Name:     "provider",
+				Usage:    "OIDC provider identifier (issuer URL or short name, e.g. 'local')",
+				Required: true,
+			},
+			&ucli.StringFlag{
+				Name:     "provider-subject",
+				Usage:    "Subject claim from the provider (e.g. user ID at the provider)",
+				Required: true,
+			},
+			&ucli.StringFlag{
+				Name:     "email",
+				Usage:    "Email address associated with this login identity",
+				Required: true,
+			},
+			&ucli.StringFlag{
+				Name:  "name",
+				Usage: "Display name for this identity (optional)",
+			},
+		},
+		Action: func(c *ucli.Context) error {
+			req := apitypes.LinkLoginIdentityRequest{
+				Provider:        c.String("provider"),
+				ProviderSubject: c.String("provider-subject"),
+				Email:           c.String("email"),
+			}
+			if name := c.String("name"); name != "" {
+				req.Name = &name
+			}
+			userID := c.String("user-id")
+
+			identity, err := apiclient.Call[apitypes.LoginIdentity](func(api *apiclient.Client) (*http.Response, error) {
+				return api.LinkAuthUserLoginIdentity(c.Context, userID, req)
+			})
+			if err != nil {
+				return fmt.Errorf("link identity: %w", err)
+			}
+
+			fmt.Printf("Linked identity %s\n", identity.Id)
+			fmt.Printf("  User:     %s\n", identity.UserId)
+			fmt.Printf("  Provider: %s\n", identity.Provider)
+			fmt.Printf("  Subject:  %s\n", identity.ProviderSubject)
+			fmt.Printf("  Email:    %s\n", identity.Email)
+			return nil
+		},
+	}
+}

--- a/cmd/stella/commands.go
+++ b/cmd/stella/commands.go
@@ -78,6 +78,7 @@ schedules, and more.`,
 			shareCommand(),
 			taskCommand(),
 			denyInSandbox(serviceCommand()),
+			authCommand(),
 		},
 	}
 }

--- a/cmd/stella/commands_test.go
+++ b/cmd/stella/commands_test.go
@@ -67,17 +67,25 @@ func (commandTestStore) ListProviders(context.Context) ([]config.Provider, error
 func (commandTestStore) GetProvider(context.Context, string) (config.Provider, error) {
 	return config.Provider{}, errors.New("not found")
 }
-func (commandTestStore) CreateProvider(context.Context, config.Provider) error     { return nil }
-func (commandTestStore) UpdateProvider(context.Context, config.Provider) error     { return nil }
-func (commandTestStore) DeleteProvider(context.Context, string) error              { return nil }
+func (commandTestStore) CreateProvider(context.Context, config.Provider) error { return nil }
+func (commandTestStore) UpdateProvider(context.Context, config.Provider) error { return nil }
+func (commandTestStore) DeleteProvider(context.Context, string) error          { return nil }
+func (commandTestStore) ListProvidersForOrg(context.Context, string) ([]config.Provider, error) {
+	return nil, nil
+}
+func (commandTestStore) SetProviderOrg(context.Context, string, string) error      { return nil }
 func (commandTestStore) ListAgents(context.Context) ([]config.Agent, error)        { return nil, nil }
 func (commandTestStore) ListEnabledAgents(context.Context) ([]config.Agent, error) { return nil, nil }
 func (commandTestStore) GetAgent(context.Context, string) (config.Agent, error) {
 	return config.Agent{}, nil
 }
-func (commandTestStore) CreateAgent(context.Context, config.Agent) error        { return nil }
-func (commandTestStore) UpdateAgent(context.Context, config.Agent) error        { return nil }
-func (commandTestStore) DeleteAgent(context.Context, string) error              { return nil }
+func (commandTestStore) CreateAgent(context.Context, config.Agent) error { return nil }
+func (commandTestStore) UpdateAgent(context.Context, config.Agent) error { return nil }
+func (commandTestStore) DeleteAgent(context.Context, string) error       { return nil }
+func (commandTestStore) ListAgentsForOrg(context.Context, string) ([]config.Agent, error) {
+	return nil, nil
+}
+func (commandTestStore) SetAgentOrg(context.Context, string, string) error      { return nil }
 func (commandTestStore) ListChannels(context.Context) ([]config.Channel, error) { return nil, nil }
 func (commandTestStore) ListChannelsByType(context.Context, string) ([]config.Channel, error) {
 	return nil, nil
@@ -88,6 +96,10 @@ func (commandTestStore) GetChannel(context.Context, string) (config.Channel, err
 }
 func (commandTestStore) UpsertChannel(context.Context, config.Channel) error { return nil }
 func (commandTestStore) DeleteChannel(context.Context, string) error         { return nil }
+func (commandTestStore) ListChannelsForOrg(context.Context, string) ([]config.Channel, error) {
+	return nil, nil
+}
+func (commandTestStore) SetChannelOrg(context.Context, string, string) error { return nil }
 func (commandTestStore) ListPlugins(context.Context) ([]config.Plugin, error) {
 	return nil, nil
 }

--- a/cmd/stella/gateway.go
+++ b/cmd/stella/gateway.go
@@ -164,6 +164,11 @@ func runServer(ctx context.Context, s *setupResult, listFn func() []pkgchannel.M
 		slog.Info("credential backfill: copied password hashes", "count", n)
 	}
 
+	// Assign existing settings resources to the legacy org when available.
+	if err := appdb.BackfillOrgScopedSettings(gctx, s.db); err != nil {
+		slog.Warn("org settings backfill failed", "error", err)
+	}
+
 	// Wire local OIDC issuer if configured via environment variables.
 	// The local issuer is configured independently from the external OIDC client.
 	if localOIDCCfg, err := localoidc.ConfigFromEnv(); err != nil {

--- a/cmd/stella/gateway.go
+++ b/cmd/stella/gateway.go
@@ -190,6 +190,8 @@ func runServer(ctx context.Context, s *setupResult, listFn func() []pkgchannel.M
 			sessionMgrForIssuer,
 		)
 		adminSrv.SetLocalOIDCIssuer(issuer)
+		adminSrv.SetLoginIdentityStore(oidcStore)
+		adminSrv.SetMembershipStore(oidcStore)
 		slog.Info("local oidc: issuer configured", "issuer_url", localOIDCCfg.IssuerURL)
 	}
 
@@ -202,6 +204,8 @@ func runServer(ctx context.Context, s *setupResult, listFn func() []pkgchannel.M
 		} else {
 			vaultKey := os.Getenv("STELLA_VAULT_KEY")
 			oidcStore := appdb.NewOIDCStore(s.db)
+			adminSrv.SetLoginIdentityStore(oidcStore)
+			adminSrv.SetMembershipStore(oidcStore)
 			authSvc := auth.NewAuthService(s.db, oidcStore, oidcStore, oidcStore, oidcStore, oidcStore, oidcStore)
 			sessionMgr, err := auth.NewSessionManager(oidcStore, vaultKey)
 			if err != nil {

--- a/cmd/stella/gateway.go
+++ b/cmd/stella/gateway.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/CherryHQ/stella/internal/agent"
 	"github.com/CherryHQ/stella/internal/auth"
+	"github.com/CherryHQ/stella/internal/auth/localoidc"
 	authoidc "github.com/CherryHQ/stella/internal/auth/oidc"
 	authzitadel "github.com/CherryHQ/stella/internal/auth/zitadel"
 	"github.com/CherryHQ/stella/internal/channel"
@@ -154,6 +155,42 @@ func runServer(ctx context.Context, s *setupResult, listFn func() []pkgchannel.M
 		slog.Warn("oidc backfill failed", "error", err)
 	} else if n > 0 {
 		slog.Info("oidc backfill: migrated users to new auth tables", "count", n)
+	}
+
+	// Backfill password hashes from legacy auth_users into auth_credential.
+	if n, err := appdb.BackfillCredentials(gctx, s.db); err != nil {
+		slog.Warn("credential backfill failed", "error", err)
+	} else if n > 0 {
+		slog.Info("credential backfill: copied password hashes", "count", n)
+	}
+
+	// Wire local OIDC issuer if configured via environment variables.
+	// The local issuer is configured independently from the external OIDC client.
+	if localOIDCCfg, err := localoidc.ConfigFromEnv(); err != nil {
+		slog.Warn("local oidc: invalid configuration", "error", err)
+	} else if localOIDCCfg != nil {
+		vaultKey := os.Getenv("STELLA_VAULT_KEY")
+		oidcStore := appdb.NewOIDCStore(s.db)
+		var authSvcForIssuer *auth.AuthService
+		var sessionMgrForIssuer *auth.SessionManager
+		if vaultKey != "" {
+			authSvcForIssuer = auth.NewAuthService(s.db, oidcStore, oidcStore, oidcStore, oidcStore, oidcStore, oidcStore)
+			sessionMgrForIssuer, err = auth.NewSessionManager(oidcStore, vaultKey)
+			if err != nil {
+				slog.Warn("local oidc: session manager init failed", "error", err)
+				sessionMgrForIssuer = nil
+				authSvcForIssuer = nil
+			}
+		}
+		issuer := localoidc.NewIssuer(
+			localOIDCCfg,
+			oidcStore, oidcStore,
+			oidcStore, oidcStore, oidcStore,
+			authSvcForIssuer,
+			sessionMgrForIssuer,
+		)
+		adminSrv.SetLocalOIDCIssuer(issuer)
+		slog.Info("local oidc: issuer configured", "issuer_url", localOIDCCfg.IssuerURL)
 	}
 
 	// Wire OIDC authentication if configured via environment variables.

--- a/internal/agent/pool_manager_test.go
+++ b/internal/agent/pool_manager_test.go
@@ -55,7 +55,11 @@ func (m *mockStore) GetProvider(_ context.Context, _ string) (config.Provider, e
 func (m *mockStore) CreateProvider(_ context.Context, _ config.Provider) error { return nil }
 func (m *mockStore) UpdateProvider(_ context.Context, _ config.Provider) error { return nil }
 func (m *mockStore) DeleteProvider(_ context.Context, _ string) error          { return nil }
-func (m *mockStore) ListAgents(_ context.Context) ([]config.Agent, error)      { return nil, nil }
+func (m *mockStore) ListProvidersForOrg(_ context.Context, _ string) ([]config.Provider, error) {
+	return nil, nil
+}
+func (m *mockStore) SetProviderOrg(_ context.Context, _, _ string) error  { return nil }
+func (m *mockStore) ListAgents(_ context.Context) ([]config.Agent, error) { return nil, nil }
 func (m *mockStore) GetAgent(_ context.Context, id string) (config.Agent, error) {
 	for _, a := range m.agents {
 		if a.ID == id {
@@ -64,9 +68,13 @@ func (m *mockStore) GetAgent(_ context.Context, id string) (config.Agent, error)
 	}
 	return config.Agent{}, fmt.Errorf("agent %q not found", id)
 }
-func (m *mockStore) CreateAgent(_ context.Context, _ config.Agent) error      { return nil }
-func (m *mockStore) UpdateAgent(_ context.Context, _ config.Agent) error      { return nil }
-func (m *mockStore) DeleteAgent(_ context.Context, _ string) error            { return nil }
+func (m *mockStore) CreateAgent(_ context.Context, _ config.Agent) error { return nil }
+func (m *mockStore) UpdateAgent(_ context.Context, _ config.Agent) error { return nil }
+func (m *mockStore) DeleteAgent(_ context.Context, _ string) error       { return nil }
+func (m *mockStore) ListAgentsForOrg(_ context.Context, _ string) ([]config.Agent, error) {
+	return nil, nil
+}
+func (m *mockStore) SetAgentOrg(_ context.Context, _, _ string) error         { return nil }
 func (m *mockStore) ListChannels(_ context.Context) ([]config.Channel, error) { return nil, nil }
 func (m *mockStore) ListChannelsByType(context.Context, string) ([]config.Channel, error) {
 	return nil, nil
@@ -77,6 +85,10 @@ func (m *mockStore) GetChannel(_ context.Context, _ string) (config.Channel, err
 }
 func (m *mockStore) UpsertChannel(_ context.Context, _ config.Channel) error { return nil }
 func (m *mockStore) DeleteChannel(_ context.Context, _ string) error         { return nil }
+func (m *mockStore) ListChannelsForOrg(_ context.Context, _ string) ([]config.Channel, error) {
+	return nil, nil
+}
+func (m *mockStore) SetChannelOrg(_ context.Context, _, _ string) error { return nil }
 func (m *mockStore) GetChatAgent(_ context.Context, _, _, _ string) (string, error) {
 	return "", nil
 }

--- a/internal/auth/credential.go
+++ b/internal/auth/credential.go
@@ -1,0 +1,77 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// CredentialService manages local password credentials stored in auth_credential.
+// These credentials are used exclusively by the local OIDC authorize screen;
+// they are not an alternative app-login path.
+type CredentialService struct {
+	store CredentialStore
+}
+
+// NewCredentialService creates a CredentialService backed by the given store.
+func NewCredentialService(store CredentialStore) *CredentialService {
+	return &CredentialService{store: store}
+}
+
+// SetPassword creates or replaces the local password for a user.
+func (s *CredentialService) SetPassword(ctx context.Context, userID, plainPassword string) error {
+	hash, err := HashPassword(plainPassword)
+	if err != nil {
+		return fmt.Errorf("credential: hash password: %w", err)
+	}
+
+	_, lookupErr := s.store.GetCredentialByUserID(ctx, userID)
+	if lookupErr == nil {
+		return s.store.UpdateCredentialHash(ctx, userID, hash)
+	}
+	if !errors.Is(lookupErr, ErrNotFound) {
+		return fmt.Errorf("credential: lookup: %w", lookupErr)
+	}
+
+	_, err = s.store.CreateCredential(ctx, Credential{
+		ID:           uuid.NewString(),
+		UserID:       userID,
+		PasswordHash: hash,
+	})
+	return err
+}
+
+// VerifyPassword checks plainPassword against the stored hash for userID.
+// Returns ErrNotFound if no credential exists, ErrInvalidCredentials on mismatch.
+func (s *CredentialService) VerifyPassword(ctx context.Context, userID, plainPassword string) error {
+	cred, err := s.store.GetCredentialByUserID(ctx, userID)
+	if err != nil {
+		return err
+	}
+	if err := CheckPassword(cred.PasswordHash, plainPassword); err != nil {
+		return ErrInvalidCredentials
+	}
+	return nil
+}
+
+// HasCredential reports whether a credential row exists for userID.
+func (s *CredentialService) HasCredential(ctx context.Context, userID string) (bool, error) {
+	_, err := s.store.GetCredentialByUserID(ctx, userID)
+	if errors.Is(err, ErrNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// Sentinel errors used across auth domain.
+var (
+	ErrNotFound           = errors.New("not found")
+	ErrInvalidCredentials = errors.New("invalid credentials")
+	ErrAlreadyConsumed    = errors.New("already consumed")
+	ErrExpired            = errors.New("expired")
+)

--- a/internal/auth/credential_test.go
+++ b/internal/auth/credential_test.go
@@ -1,0 +1,131 @@
+package auth_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/CherryHQ/stella/internal/auth"
+)
+
+// fakeCredentialStore is an in-memory CredentialStore for unit tests.
+type fakeCredentialStore struct {
+	byUser map[string]auth.Credential
+}
+
+func newFakeCredentialStore() *fakeCredentialStore {
+	return &fakeCredentialStore{byUser: make(map[string]auth.Credential)}
+}
+
+func (f *fakeCredentialStore) CreateCredential(_ context.Context, c auth.Credential) (auth.Credential, error) {
+	if _, ok := f.byUser[c.UserID]; ok {
+		return auth.Credential{}, errors.New("already exists")
+	}
+	f.byUser[c.UserID] = c
+	return c, nil
+}
+
+func (f *fakeCredentialStore) GetCredentialByUserID(_ context.Context, userID string) (auth.Credential, error) {
+	c, ok := f.byUser[userID]
+	if !ok {
+		return auth.Credential{}, auth.ErrNotFound
+	}
+	return c, nil
+}
+
+func (f *fakeCredentialStore) UpdateCredentialHash(_ context.Context, userID, hash string) error {
+	c, ok := f.byUser[userID]
+	if !ok {
+		return auth.ErrNotFound
+	}
+	c.PasswordHash = hash
+	f.byUser[userID] = c
+	return nil
+}
+
+func (f *fakeCredentialStore) DeleteCredential(_ context.Context, userID string) error {
+	delete(f.byUser, userID)
+	return nil
+}
+
+func TestCredentialServiceSetAndVerify(t *testing.T) {
+	svc := auth.NewCredentialService(newFakeCredentialStore())
+	ctx := context.Background()
+	userID := uuid.NewString()
+
+	if err := svc.SetPassword(ctx, userID, "correct-password"); err != nil {
+		t.Fatalf("SetPassword: %v", err)
+	}
+
+	if err := svc.VerifyPassword(ctx, userID, "correct-password"); err != nil {
+		t.Fatalf("VerifyPassword correct: %v", err)
+	}
+}
+
+func TestCredentialServiceWrongPassword(t *testing.T) {
+	svc := auth.NewCredentialService(newFakeCredentialStore())
+	ctx := context.Background()
+	userID := uuid.NewString()
+
+	if err := svc.SetPassword(ctx, userID, "correct"); err != nil {
+		t.Fatalf("SetPassword: %v", err)
+	}
+
+	err := svc.VerifyPassword(ctx, userID, "wrong")
+	if !errors.Is(err, auth.ErrInvalidCredentials) {
+		t.Errorf("got %v, want ErrInvalidCredentials", err)
+	}
+}
+
+func TestCredentialServiceVerifyNotFound(t *testing.T) {
+	svc := auth.NewCredentialService(newFakeCredentialStore())
+	ctx := context.Background()
+
+	err := svc.VerifyPassword(ctx, "no-such-user", "any")
+	if !errors.Is(err, auth.ErrNotFound) {
+		t.Errorf("got %v, want ErrNotFound", err)
+	}
+}
+
+func TestCredentialServiceSetPasswordUpdatesExisting(t *testing.T) {
+	store := newFakeCredentialStore()
+	svc := auth.NewCredentialService(store)
+	ctx := context.Background()
+	userID := uuid.NewString()
+
+	if err := svc.SetPassword(ctx, userID, "first"); err != nil {
+		t.Fatalf("SetPassword first: %v", err)
+	}
+	if err := svc.SetPassword(ctx, userID, "second"); err != nil {
+		t.Fatalf("SetPassword second: %v", err)
+	}
+
+	if err := svc.VerifyPassword(ctx, userID, "second"); err != nil {
+		t.Fatalf("VerifyPassword second: %v", err)
+	}
+	if err := svc.VerifyPassword(ctx, userID, "first"); !errors.Is(err, auth.ErrInvalidCredentials) {
+		t.Errorf("old password should be rejected, got %v", err)
+	}
+}
+
+func TestCredentialServiceHasCredential(t *testing.T) {
+	svc := auth.NewCredentialService(newFakeCredentialStore())
+	ctx := context.Background()
+	userID := uuid.NewString()
+
+	has, err := svc.HasCredential(ctx, userID)
+	if err != nil || has {
+		t.Errorf("HasCredential before set: has=%v err=%v", has, err)
+	}
+
+	if err := svc.SetPassword(ctx, userID, "pw"); err != nil {
+		t.Fatalf("SetPassword: %v", err)
+	}
+
+	has, err = svc.HasCredential(ctx, userID)
+	if err != nil || !has {
+		t.Errorf("HasCredential after set: has=%v err=%v", has, err)
+	}
+}

--- a/internal/auth/localoidc/config.go
+++ b/internal/auth/localoidc/config.go
@@ -1,0 +1,175 @@
+// Package localoidc implements a minimal built-in OIDC issuer for Stella.
+// It is designed for development and single-user/self-contained deployments.
+// The issuer supports authorization-code + PKCE only. All configuration is
+// loaded from environment variables at startup; no UI/API runtime mutation.
+package localoidc
+
+import (
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+)
+
+// Config holds the configuration for the built-in local OIDC issuer.
+// All values are loaded from environment variables; see ConfigFromEnv.
+type Config struct {
+	// IssuerURL is the base URL for the local OIDC issuer, e.g.
+	// "http://localhost:25678/oidc/local". It appears as the "iss" claim
+	// in ID tokens and as the issuer in the discovery document.
+	IssuerURL string
+
+	// ClientID is the bootstrap relying-party client ID. Stella's own OIDC
+	// client (OIDC_CLIENT_ID) must match this value when using the local issuer.
+	ClientID string
+
+	// ClientSecret is optional. Empty string means the client is public and
+	// must use PKCE S256. Non-empty means confidential client.
+	ClientSecret string
+
+	// RedirectURIs is the exact-match allowlist of permitted redirect URIs.
+	// Must contain at least one entry.
+	RedirectURIs []string
+
+	// SigningKey is the ECDSA P-256 private key used to sign ID tokens.
+	// Loaded from LOCAL_OIDC_SIGNING_KEY (PEM-encoded or base64 of PEM).
+	SigningKey *ecdsa.PrivateKey
+
+	// KeyID is the "kid" value for the signing key in the JWKS response.
+	// Defaults to "local-1".
+	KeyID string
+
+	// AccessTokenTTL is the access token lifetime in seconds. Default: 3600.
+	AccessTokenTTL int
+
+	// AuthCodeTTL is the authorization code lifetime in seconds. Default: 120.
+	AuthCodeTTL int
+}
+
+// ConfigFromEnv reads local OIDC issuer configuration from environment variables.
+//
+// Required:
+//
+//	LOCAL_OIDC_ENABLED=true             (must be exactly "true" to enable)
+//	LOCAL_OIDC_ISSUER_URL               (e.g. "http://localhost:25678/oidc/local")
+//	LOCAL_OIDC_CLIENT_ID                (bootstrap client ID)
+//	LOCAL_OIDC_REDIRECT_URIS            (comma-separated exact-match allowlist)
+//	LOCAL_OIDC_SIGNING_KEY              (PEM-encoded ECDSA P-256 private key, or base64 of PEM)
+//
+// Optional:
+//
+//	LOCAL_OIDC_CLIENT_SECRET            (empty = public client; must use PKCE)
+//	LOCAL_OIDC_KEY_ID                   (default: "local-1")
+//
+// Returns nil, nil when LOCAL_OIDC_ENABLED is not "true".
+func ConfigFromEnv() (*Config, error) {
+	if os.Getenv("LOCAL_OIDC_ENABLED") != "true" {
+		return nil, nil
+	}
+
+	rawKey := os.Getenv("LOCAL_OIDC_SIGNING_KEY")
+	if rawKey == "" {
+		return nil, errors.New("local oidc: LOCAL_OIDC_SIGNING_KEY is required when LOCAL_OIDC_ENABLED=true")
+	}
+	key, err := parseSigningKey(rawKey)
+	if err != nil {
+		return nil, fmt.Errorf("local oidc: parse signing key: %w", err)
+	}
+
+	keyID := os.Getenv("LOCAL_OIDC_KEY_ID")
+	if keyID == "" {
+		keyID = "local-1"
+	}
+
+	cfg := &Config{
+		IssuerURL:      os.Getenv("LOCAL_OIDC_ISSUER_URL"),
+		ClientID:       os.Getenv("LOCAL_OIDC_CLIENT_ID"),
+		ClientSecret:   os.Getenv("LOCAL_OIDC_CLIENT_SECRET"),
+		SigningKey:     key,
+		KeyID:          keyID,
+		AccessTokenTTL: 3600,
+		AuthCodeTTL:    120,
+	}
+
+	if raw := os.Getenv("LOCAL_OIDC_REDIRECT_URIS"); raw != "" {
+		cfg.RedirectURIs = splitTrimmed(raw)
+	}
+
+	return cfg, cfg.Validate()
+}
+
+// Validate returns an error if any required field is missing or invalid.
+func (c *Config) Validate() error {
+	var errs []string
+	if c.IssuerURL == "" {
+		errs = append(errs, "LOCAL_OIDC_ISSUER_URL is required")
+	}
+	if c.ClientID == "" {
+		errs = append(errs, "LOCAL_OIDC_CLIENT_ID is required")
+	}
+	if len(c.RedirectURIs) == 0 {
+		errs = append(errs, "LOCAL_OIDC_REDIRECT_URIS is required")
+	}
+	if c.SigningKey == nil {
+		errs = append(errs, "signing key is required")
+	}
+	if len(errs) > 0 {
+		return errors.New("local oidc config: " + strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+// IsRedirectURIAllowed reports whether uri is in the exact-match allowlist.
+func (c *Config) IsRedirectURIAllowed(uri string) bool {
+	return slices.Contains(c.RedirectURIs, uri)
+}
+
+// IsPublicClient reports whether the client is public (no secret).
+func (c *Config) IsPublicClient() bool { return c.ClientSecret == "" }
+
+// parseSigningKey decodes an ECDSA P-256 private key from a PEM string or
+// base64-encoded PEM string.
+func parseSigningKey(raw string) (*ecdsa.PrivateKey, error) {
+	pemBytes := []byte(raw)
+
+	// Try base64 decode first (for env var transport).
+	if decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(raw)); err == nil {
+		pemBytes = decoded
+	}
+
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, errors.New("no PEM block found")
+	}
+
+	key, err := x509.ParseECPrivateKey(block.Bytes)
+	if err != nil {
+		// Try PKCS8.
+		parsed, err2 := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err2 != nil {
+			return nil, fmt.Errorf("parse EC key (SEC1: %w; PKCS8: %w)", err, err2)
+		}
+		ecKey, ok := parsed.(*ecdsa.PrivateKey)
+		if !ok {
+			return nil, errors.New("signing key is not ECDSA")
+		}
+		return ecKey, nil
+	}
+	return key, nil
+}
+
+func splitTrimmed(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/internal/auth/localoidc/issuer.go
+++ b/internal/auth/localoidc/issuer.go
@@ -1,0 +1,658 @@
+package localoidc
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"html/template"
+	"math/big"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/CherryHQ/stella/internal/auth"
+)
+
+// Issuer implements the built-in local OIDC issuer endpoints.
+// It exposes discovery, JWKS, authorize, token, and userinfo under a stable
+// URL prefix (recommended: /oidc/local).
+type Issuer struct {
+	cfg         *Config
+	codes       auth.OIDCCodeStore
+	tokens      auth.OIDCAccessTokenStore
+	users       auth.UserStore
+	memberships auth.MembershipStore
+	credentials auth.CredentialStore
+	// authSvc is used to validate an existing Stella OIDC session on the authorize endpoint.
+	// May be nil; when nil, the authorize endpoint always shows the login form.
+	authSvc    *auth.AuthService
+	sessionMgr *auth.SessionManager
+}
+
+// NewIssuer creates a new local OIDC issuer.
+func NewIssuer(
+	cfg *Config,
+	codes auth.OIDCCodeStore,
+	tokens auth.OIDCAccessTokenStore,
+	users auth.UserStore,
+	memberships auth.MembershipStore,
+	credentials auth.CredentialStore,
+	authSvc *auth.AuthService,
+	sessionMgr *auth.SessionManager,
+) *Issuer {
+	return &Issuer{
+		cfg:         cfg,
+		codes:       codes,
+		tokens:      tokens,
+		users:       users,
+		memberships: memberships,
+		credentials: credentials,
+		authSvc:     authSvc,
+		sessionMgr:  sessionMgr,
+	}
+}
+
+// DiscoveryDocument is the OpenID Connect discovery document served at
+// /.well-known/openid-configuration under the issuer base path.
+type DiscoveryDocument struct {
+	Issuer                            string   `json:"issuer"`
+	AuthorizationEndpoint             string   `json:"authorization_endpoint"`
+	TokenEndpoint                     string   `json:"token_endpoint"`
+	UserinfoEndpoint                  string   `json:"userinfo_endpoint"`
+	JWKSUri                           string   `json:"jwks_uri"`
+	ResponseTypesSupported            []string `json:"response_types_supported"`
+	SubjectTypesSupported             []string `json:"subject_types_supported"`
+	IDTokenSigningAlgValuesSupported  []string `json:"id_token_signing_alg_values_supported"`
+	ScopesSupported                   []string `json:"scopes_supported"`
+	TokenEndpointAuthMethodsSupported []string `json:"token_endpoint_auth_methods_supported"`
+	ClaimsSupported                   []string `json:"claims_supported"`
+	CodeChallengeMethodsSupported     []string `json:"code_challenge_methods_supported"`
+}
+
+// HandleDiscovery serves GET /.well-known/openid-configuration.
+func (is *Issuer) HandleDiscovery(w http.ResponseWriter, r *http.Request) {
+	base := strings.TrimRight(is.cfg.IssuerURL, "/")
+	doc := DiscoveryDocument{
+		Issuer:                            is.cfg.IssuerURL,
+		AuthorizationEndpoint:             base + "/authorize",
+		TokenEndpoint:                     base + "/token",
+		UserinfoEndpoint:                  base + "/userinfo",
+		JWKSUri:                           base + "/jwks.json",
+		ResponseTypesSupported:            []string{"code"},
+		SubjectTypesSupported:             []string{"public"},
+		IDTokenSigningAlgValuesSupported:  []string{"ES256"},
+		ScopesSupported:                   []string{"openid", "email", "profile"},
+		TokenEndpointAuthMethodsSupported: []string{"client_secret_basic", "none"},
+		ClaimsSupported: []string{
+			"sub", "iss", "aud", "iat", "exp", "nonce",
+			"email", "email_verified", "name", "picture",
+			"org_id", "org_name", "role",
+		},
+		CodeChallengeMethodsSupported: []string{"S256"},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(doc)
+}
+
+// JWK is a JSON Web Key entry in the JWKS response.
+type JWK struct {
+	Kty string `json:"kty"`
+	Crv string `json:"crv"`
+	X   string `json:"x"`
+	Y   string `json:"y"`
+	Kid string `json:"kid"`
+	Use string `json:"use"`
+	Alg string `json:"alg"`
+}
+
+// HandleJWKS serves GET /jwks.json.
+func (is *Issuer) HandleJWKS(w http.ResponseWriter, r *http.Request) {
+	pub := &is.cfg.SigningKey.PublicKey
+	jwk := JWK{
+		Kty: "EC",
+		Crv: "P-256",
+		X:   base64.RawURLEncoding.EncodeToString(pub.X.Bytes()),
+		Y:   base64.RawURLEncoding.EncodeToString(pub.Y.Bytes()),
+		Kid: is.cfg.KeyID,
+		Use: "sig",
+		Alg: "ES256",
+	}
+	resp := map[string]any{"keys": []JWK{jwk}}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// HandleAuthorize serves GET and POST /authorize.
+// GET: if a valid Stella OIDC session exists, issues a code and redirects.
+//
+//	Otherwise renders the local credential login form.
+//
+// POST: verifies credentials, then issues a code and redirects.
+func (is *Issuer) HandleAuthorize(w http.ResponseWriter, r *http.Request) {
+	// Validate OIDC request params (from query string on GET, also query string on POST
+	// since the form POSTs back with the same query string).
+	params, err := is.parseAuthorizeParams(r)
+	if err != nil {
+		http.Error(w, "invalid_request: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	ctx := r.Context()
+
+	if r.Method == http.MethodPost {
+		is.handleAuthorizePost(w, r, ctx, params)
+		return
+	}
+
+	// GET: check for existing Stella OIDC session.
+	if is.sessionMgr != nil && is.authSvc != nil {
+		if rawToken, err := is.sessionMgr.GetToken(r); err == nil {
+			if principal, err := is.authSvc.PrincipalFromToken(ctx, rawToken); err == nil {
+				is.issueCodeAndRedirect(w, r, ctx, principal.UserID, principal.OrgID, params)
+				return
+			}
+		}
+	}
+
+	// No session — show the credential login form.
+	is.renderLoginForm(w, params, "")
+}
+
+type authorizeParams struct {
+	clientID            string
+	redirectURI         string
+	state               string
+	nonce               string
+	scopes              []string
+	pkceChallenge       string
+	pkceChallengeMethod string
+}
+
+func (is *Issuer) parseAuthorizeParams(r *http.Request) (*authorizeParams, error) {
+	q := r.URL.Query()
+	clientID := q.Get("client_id")
+	if clientID != is.cfg.ClientID {
+		return nil, fmt.Errorf("unknown client_id")
+	}
+	redirectURI := q.Get("redirect_uri")
+	if !is.cfg.IsRedirectURIAllowed(redirectURI) {
+		return nil, fmt.Errorf("redirect_uri not allowed")
+	}
+	if q.Get("response_type") != "code" {
+		return nil, fmt.Errorf("only response_type=code is supported")
+	}
+	pkceChallenge := q.Get("code_challenge")
+	pkceMethod := q.Get("code_challenge_method")
+	if is.cfg.IsPublicClient() {
+		if pkceChallenge == "" {
+			return nil, fmt.Errorf("code_challenge required for public clients")
+		}
+		if pkceMethod != "S256" {
+			return nil, fmt.Errorf("only code_challenge_method=S256 is supported")
+		}
+	}
+	scopes := splitTrimmed(strings.ReplaceAll(q.Get("scope"), " ", ","))
+	return &authorizeParams{
+		clientID:            clientID,
+		redirectURI:         redirectURI,
+		state:               q.Get("state"),
+		nonce:               q.Get("nonce"),
+		scopes:              scopes,
+		pkceChallenge:       pkceChallenge,
+		pkceChallengeMethod: pkceMethod,
+	}, nil
+}
+
+func (is *Issuer) handleAuthorizePost(w http.ResponseWriter, r *http.Request, ctx context.Context, params *authorizeParams) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "invalid form", http.StatusBadRequest)
+		return
+	}
+	email := strings.TrimSpace(r.FormValue("email"))
+	password := r.FormValue("password")
+	if email == "" || password == "" {
+		is.renderLoginForm(w, params, "Email and password are required.")
+		return
+	}
+
+	user, err := is.users.GetUserByEmail(ctx, email)
+	if err != nil {
+		is.renderLoginForm(w, params, "Invalid email or password.")
+		return
+	}
+
+	credSvc := auth.NewCredentialService(is.credentials)
+	if err := credSvc.VerifyPassword(ctx, user.ID, password); err != nil {
+		is.renderLoginForm(w, params, "Invalid email or password.")
+		return
+	}
+
+	// Check membership is active.
+	membership, err := is.memberships.GetUserMembership(ctx, user.ID)
+	if err != nil || !membership.IsActive {
+		is.renderLoginForm(w, params, "Account is disabled.")
+		return
+	}
+
+	is.issueCodeAndRedirect(w, r, ctx, user.ID, membership.OrganizationID, params)
+}
+
+func (is *Issuer) issueCodeAndRedirect(w http.ResponseWriter, r *http.Request, ctx context.Context, userID, orgID string, params *authorizeParams) {
+	rawCode := generateOpaqueToken()
+	codeHash := hashToken(rawCode)
+
+	_, err := is.codes.CreateOIDCCode(ctx, auth.OIDCCode{
+		ID:            uuid.NewString(),
+		CodeHash:      codeHash,
+		UserID:        userID,
+		OrgID:         orgID,
+		ClientID:      params.clientID,
+		RedirectURI:   params.redirectURI,
+		Scopes:        params.scopes,
+		Nonce:         params.nonce,
+		PKCEChallenge: params.pkceChallenge,
+		PKCEMethod:    params.pkceChallengeMethod,
+		ExpiresAt:     time.Now().Add(time.Duration(is.cfg.AuthCodeTTL) * time.Second),
+	})
+	if err != nil {
+		http.Error(w, "server_error: could not create authorization code", http.StatusInternalServerError)
+		return
+	}
+
+	redirectURL := params.redirectURI + "?code=" + rawCode
+	if params.state != "" {
+		redirectURL += "&state=" + params.state
+	}
+	http.Redirect(w, r, redirectURL, http.StatusFound)
+}
+
+var loginFormTmpl = template.Must(template.New("login").Parse(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Sign in — Stella</title>
+<style>
+body{font-family:system-ui,sans-serif;background:#f5f5f5;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0}
+.card{background:#fff;border-radius:8px;box-shadow:0 2px 8px rgba(0,0,0,.12);padding:2rem;width:100%;max-width:360px}
+h1{font-size:1.25rem;margin:0 0 1.5rem}
+label{display:block;font-size:.875rem;margin-bottom:.25rem;color:#555}
+input[type=email],input[type=password]{width:100%;box-sizing:border-box;padding:.5rem .75rem;border:1px solid #ccc;border-radius:4px;font-size:1rem;margin-bottom:1rem}
+button{width:100%;padding:.625rem;background:#0070f3;color:#fff;border:none;border-radius:4px;font-size:1rem;cursor:pointer}
+button:hover{background:#0051bb}
+.error{background:#fef2f2;color:#dc2626;border:1px solid #fca5a5;border-radius:4px;padding:.5rem .75rem;margin-bottom:1rem;font-size:.875rem}
+</style>
+</head>
+<body>
+<div class="card">
+  <h1>Sign in to Stella</h1>
+  {{if .Error}}<div class="error">{{.Error}}</div>{{end}}
+  <form method="POST" action="{{.Action}}">
+    <label for="email">Email</label>
+    <input type="email" id="email" name="email" autocomplete="email" required>
+    <label for="password">Password</label>
+    <input type="password" id="password" name="password" autocomplete="current-password" required>
+    <button type="submit">Sign in</button>
+  </form>
+</div>
+</body>
+</html>`))
+
+func (is *Issuer) renderLoginForm(w http.ResponseWriter, params *authorizeParams, errMsg string) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_ = loginFormTmpl.Execute(w, map[string]any{
+		"Action": buildAuthorizeAction(params),
+		"Error":  errMsg,
+	})
+}
+
+func buildAuthorizeAction(p *authorizeParams) string {
+	// POST back to authorize with the same OIDC params preserved in the query string.
+	q := "?client_id=" + p.clientID +
+		"&redirect_uri=" + p.redirectURI +
+		"&response_type=code" +
+		"&scope=" + strings.Join(p.scopes, "+")
+	if p.state != "" {
+		q += "&state=" + p.state
+	}
+	if p.nonce != "" {
+		q += "&nonce=" + p.nonce
+	}
+	if p.pkceChallenge != "" {
+		q += "&code_challenge=" + p.pkceChallenge +
+			"&code_challenge_method=" + p.pkceChallengeMethod
+	}
+	return "authorize" + q
+}
+
+// HandleToken serves POST /token.
+// Supports grant_type=authorization_code only.
+func (is *Issuer) HandleToken(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method_not_allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		is.tokenError(w, "invalid_request", "cannot parse form")
+		return
+	}
+
+	if r.FormValue("grant_type") != "authorization_code" {
+		is.tokenError(w, "unsupported_grant_type", "only authorization_code is supported")
+		return
+	}
+
+	clientID, _, err := is.authenticateClient(r)
+	if err != nil {
+		is.tokenError(w, "invalid_client", err.Error())
+		return
+	}
+
+	rawCode := r.FormValue("code")
+	if rawCode == "" {
+		is.tokenError(w, "invalid_request", "code is required")
+		return
+	}
+	redirectURI := r.FormValue("redirect_uri")
+	codeVerifier := r.FormValue("code_verifier")
+
+	ctx := r.Context()
+	code, err := is.codes.ConsumeOIDCCode(ctx, hashToken(rawCode))
+	if errors.Is(err, auth.ErrNotFound) {
+		is.tokenError(w, "invalid_grant", "unknown code")
+		return
+	}
+	if errors.Is(err, auth.ErrAlreadyConsumed) {
+		is.tokenError(w, "invalid_grant", "code already used")
+		return
+	}
+	if errors.Is(err, auth.ErrExpired) {
+		is.tokenError(w, "invalid_grant", "code expired")
+		return
+	}
+	if err != nil {
+		is.tokenError(w, "server_error", "could not consume code")
+		return
+	}
+
+	// Validate code params.
+	if code.ClientID != clientID {
+		is.tokenError(w, "invalid_grant", "client mismatch")
+		return
+	}
+	if code.RedirectURI != redirectURI {
+		is.tokenError(w, "invalid_grant", "redirect_uri mismatch")
+		return
+	}
+	if code.PKCEChallenge != "" {
+		if err := verifyPKCE(codeVerifier, code.PKCEChallenge, code.PKCEMethod); err != nil {
+			is.tokenError(w, "invalid_grant", "PKCE verification failed")
+			return
+		}
+	}
+
+	// Load user and membership for claims.
+	user, err := is.users.GetUser(ctx, code.UserID)
+	if err != nil {
+		is.tokenError(w, "server_error", "could not load user")
+		return
+	}
+	membership, err := is.memberships.GetUserMembership(ctx, code.UserID)
+	if err != nil || !membership.IsActive {
+		is.tokenError(w, "access_denied", "account disabled")
+		return
+	}
+
+	// Issue opaque access token.
+	rawAccessToken := generateOpaqueToken()
+	accessTokenHash := hashToken(rawAccessToken)
+	ttl := time.Duration(is.cfg.AccessTokenTTL) * time.Second
+	_, err = is.tokens.CreateOIDCAccessToken(ctx, auth.OIDCAccessToken{
+		ID:        uuid.NewString(),
+		TokenHash: accessTokenHash,
+		UserID:    code.UserID,
+		OrgID:     code.OrgID,
+		ClientID:  clientID,
+		Scopes:    code.Scopes,
+		ExpiresAt: time.Now().Add(ttl),
+	})
+	if err != nil {
+		is.tokenError(w, "server_error", "could not issue access token")
+		return
+	}
+
+	// Build ID token.
+	idToken, err := is.buildIDToken(user, membership, code.Scopes, code.Nonce, clientID, ttl)
+	if err != nil {
+		is.tokenError(w, "server_error", "could not build ID token")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"access_token": rawAccessToken,
+		"token_type":   "Bearer",
+		"expires_in":   int(ttl.Seconds()),
+		"id_token":     idToken,
+	})
+}
+
+// HandleUserinfo serves GET /userinfo.
+func (is *Issuer) HandleUserinfo(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	rawToken := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+	rawToken = strings.TrimSpace(rawToken)
+	if rawToken == "" {
+		http.Error(w, "missing bearer token", http.StatusUnauthorized)
+		return
+	}
+
+	tok, err := is.tokens.GetOIDCAccessTokenByHash(ctx, hashToken(rawToken))
+	if errors.Is(err, auth.ErrNotFound) || (err == nil && time.Now().After(tok.ExpiresAt)) {
+		http.Error(w, "invalid_token", http.StatusUnauthorized)
+		return
+	}
+	if err != nil {
+		http.Error(w, "server_error", http.StatusInternalServerError)
+		return
+	}
+
+	user, err := is.users.GetUser(ctx, tok.UserID)
+	if err != nil {
+		http.Error(w, "server_error", http.StatusInternalServerError)
+		return
+	}
+	membership, err := is.memberships.GetUserMembership(ctx, tok.UserID)
+	if err != nil || !membership.IsActive {
+		http.Error(w, "access_denied", http.StatusForbidden)
+		return
+	}
+
+	claims := map[string]any{"sub": user.ID}
+	for _, s := range tok.Scopes {
+		switch strings.ToLower(s) {
+		case "email":
+			claims["email"] = user.Email
+			claims["email_verified"] = true
+		case "profile":
+			claims["name"] = user.Name
+			claims["picture"] = user.AvatarURL
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(claims)
+}
+
+// --- JWT helpers ---
+
+func (is *Issuer) buildIDToken(user auth.User, membership auth.Membership, scopes []string, nonce, audience string, ttl time.Duration) (string, error) {
+	now := time.Now()
+	claims := map[string]any{
+		"iss": is.cfg.IssuerURL,
+		"sub": user.ID,
+		"aud": audience,
+		"iat": now.Unix(),
+		"exp": now.Add(ttl).Unix(),
+	}
+	if nonce != "" {
+		claims["nonce"] = nonce
+	}
+	for _, s := range scopes {
+		switch strings.ToLower(s) {
+		case "email":
+			claims["email"] = user.Email
+			claims["email_verified"] = true
+		case "profile":
+			claims["name"] = user.Name
+			claims["picture"] = user.AvatarURL
+		}
+	}
+	// Always include org and role in ID token for membership resolution.
+	claims["org_id"] = membership.OrganizationID
+	claims["role"] = membership.Role
+
+	return signES256(is.cfg.SigningKey, is.cfg.KeyID, claims)
+}
+
+// signES256 produces a compact JWS (JWT) signed with ECDSA P-256.
+func signES256(key *ecdsa.PrivateKey, kid string, claims map[string]any) (string, error) {
+	header := map[string]any{"alg": "ES256", "typ": "JWT", "kid": kid}
+	headerJSON, err := json.Marshal(header)
+	if err != nil {
+		return "", err
+	}
+	claimsJSON, err := json.Marshal(claims)
+	if err != nil {
+		return "", err
+	}
+	signingInput := base64.RawURLEncoding.EncodeToString(headerJSON) + "." +
+		base64.RawURLEncoding.EncodeToString(claimsJSON)
+
+	hash := sha256.Sum256([]byte(signingInput))
+	r, s, err := ecdsa.Sign(rand.Reader, key, hash[:])
+	if err != nil {
+		return "", fmt.Errorf("sign JWT: %w", err)
+	}
+
+	// Encode r and s as big-endian 32-byte values (P-256 curve order is 32 bytes).
+	sig := make([]byte, 64)
+	rBytes := r.Bytes()
+	sBytes := s.Bytes()
+	copy(sig[32-len(rBytes):32], rBytes)
+	copy(sig[64-len(sBytes):64], sBytes)
+
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sig), nil
+}
+
+// ExportPublicKeyPEM exports the public key as a PEM block (for debugging).
+func ExportPublicKeyPEM(key *ecdsa.PrivateKey) (string, error) {
+	der, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		return "", err
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})), nil
+}
+
+// VerifyES256 verifies a compact JWT produced by signES256. Used in tests.
+func VerifyES256(tokenStr string, pub *ecdsa.PublicKey) (map[string]any, error) {
+	parts := strings.Split(tokenStr, ".")
+	if len(parts) != 3 {
+		return nil, errors.New("malformed JWT")
+	}
+	signingInput := parts[0] + "." + parts[1]
+	hash := sha256.Sum256([]byte(signingInput))
+
+	sigBytes, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return nil, fmt.Errorf("decode signature: %w", err)
+	}
+	if len(sigBytes) != 64 {
+		return nil, fmt.Errorf("unexpected signature length %d", len(sigBytes))
+	}
+	r := new(big.Int).SetBytes(sigBytes[:32])
+	s := new(big.Int).SetBytes(sigBytes[32:])
+	if !ecdsa.Verify(pub, hash[:], r, s) {
+		return nil, errors.New("invalid signature")
+	}
+
+	claimsJSON, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("decode claims: %w", err)
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(claimsJSON, &claims); err != nil {
+		return nil, err
+	}
+	return claims, nil
+}
+
+// --- PKCE ---
+
+func verifyPKCE(verifier, challenge, method string) error {
+	if method != "S256" {
+		return fmt.Errorf("unsupported method %q", method)
+	}
+	sum := sha256.Sum256([]byte(verifier))
+	computed := base64.RawURLEncoding.EncodeToString(sum[:])
+	if computed != challenge {
+		return errors.New("challenge mismatch")
+	}
+	return nil
+}
+
+// --- Client authentication ---
+
+func (is *Issuer) authenticateClient(r *http.Request) (clientID, secret string, err error) {
+	// Try HTTP Basic auth first.
+	if id, sec, ok := r.BasicAuth(); ok {
+		clientID, secret = id, sec
+	} else {
+		clientID = r.FormValue("client_id")
+		secret = r.FormValue("client_secret")
+	}
+	if clientID != is.cfg.ClientID {
+		return "", "", fmt.Errorf("unknown client")
+	}
+	if !is.cfg.IsPublicClient() && secret != is.cfg.ClientSecret {
+		return "", "", fmt.Errorf("invalid client_secret")
+	}
+	return clientID, secret, nil
+}
+
+// --- Token helpers ---
+
+func generateOpaqueToken() string {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		panic("localoidc: crypto/rand failed: " + err.Error())
+	}
+	return hex.EncodeToString(b)
+}
+
+func hashToken(raw string) string {
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}
+
+func (is *Issuer) tokenError(w http.ResponseWriter, code, desc string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusBadRequest)
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"error":             code,
+		"error_description": desc,
+	})
+}

--- a/internal/auth/localoidc/issuer_test.go
+++ b/internal/auth/localoidc/issuer_test.go
@@ -1,0 +1,791 @@
+package localoidc_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/CherryHQ/stella/internal/auth"
+	"github.com/CherryHQ/stella/internal/auth/localoidc"
+)
+
+// --- in-memory fakes ---
+
+type fakeUserStore struct{ byID, byEmail map[string]auth.User }
+
+func newFakeUserStore(users ...auth.User) *fakeUserStore {
+	f := &fakeUserStore{byID: make(map[string]auth.User), byEmail: make(map[string]auth.User)}
+	for _, u := range users {
+		f.byID[u.ID] = u
+		f.byEmail[u.Email] = u
+	}
+	return f
+}
+
+func (f *fakeUserStore) GetUser(_ context.Context, id string) (auth.User, error) {
+	u, ok := f.byID[id]
+	if !ok {
+		return auth.User{}, auth.ErrNotFound
+	}
+	return u, nil
+}
+
+func (f *fakeUserStore) GetUserByEmail(_ context.Context, email string) (auth.User, error) {
+	u, ok := f.byEmail[email]
+	if !ok {
+		return auth.User{}, auth.ErrNotFound
+	}
+	return u, nil
+}
+func (f *fakeUserStore) CreateUser(_ context.Context, u auth.User) (auth.User, error) { return u, nil }
+func (f *fakeUserStore) ListUsers(_ context.Context) ([]auth.User, error)             { return nil, nil }
+func (f *fakeUserStore) UpdateUser(_ context.Context, _ auth.User) error              { return nil }
+func (f *fakeUserStore) DeleteUser(_ context.Context, _ string) error                 { return nil }
+func (f *fakeUserStore) CountUsers(_ context.Context) (int64, error)                  { return 0, nil }
+func (f *fakeUserStore) UpdateUserAgeKeys(_ context.Context, _, _, _ string) error    { return nil }
+func (f *fakeUserStore) UpdateUserDefaultAgent(_ context.Context, _, _ string) error  { return nil }
+func (f *fakeUserStore) UpdateUserNotifyIdentity(_ context.Context, _ string, _ *string) error {
+	return nil
+}
+
+type fakeMembershipStore struct{ byUser map[string]auth.Membership }
+
+func newFakeMembershipStore(ms ...auth.Membership) *fakeMembershipStore {
+	f := &fakeMembershipStore{byUser: make(map[string]auth.Membership)}
+	for _, m := range ms {
+		f.byUser[m.UserID] = m
+	}
+	return f
+}
+
+func (f *fakeMembershipStore) GetUserMembership(_ context.Context, userID string) (auth.Membership, error) {
+	m, ok := f.byUser[userID]
+	if !ok {
+		return auth.Membership{}, auth.ErrNotFound
+	}
+	return m, nil
+}
+
+func (f *fakeMembershipStore) CreateMembership(_ context.Context, m auth.Membership) (auth.Membership, error) {
+	return m, nil
+}
+
+func (f *fakeMembershipStore) GetMembership(_ context.Context, _, _ string) (auth.Membership, error) {
+	return auth.Membership{}, auth.ErrNotFound
+}
+func (f *fakeMembershipStore) UpdateMembershipRole(_ context.Context, _, _ string) error { return nil }
+func (f *fakeMembershipStore) UpdateMembershipActive(_ context.Context, _ string, _ bool) error {
+	return nil
+}
+func (f *fakeMembershipStore) DeleteMembership(_ context.Context, _ string) error { return nil }
+func (f *fakeMembershipStore) CountOrgMembers(_ context.Context, _ string) (int64, error) {
+	return 0, nil
+}
+
+type fakeCredStore struct{ byUser map[string]auth.Credential }
+
+func newFakeCredStore(creds ...auth.Credential) *fakeCredStore {
+	f := &fakeCredStore{byUser: make(map[string]auth.Credential)}
+	for _, c := range creds {
+		f.byUser[c.UserID] = c
+	}
+	return f
+}
+
+func (f *fakeCredStore) CreateCredential(_ context.Context, c auth.Credential) (auth.Credential, error) {
+	f.byUser[c.UserID] = c
+	return c, nil
+}
+
+func (f *fakeCredStore) GetCredentialByUserID(_ context.Context, userID string) (auth.Credential, error) {
+	c, ok := f.byUser[userID]
+	if !ok {
+		return auth.Credential{}, auth.ErrNotFound
+	}
+	return c, nil
+}
+
+func (f *fakeCredStore) UpdateCredentialHash(_ context.Context, userID, hash string) error {
+	c := f.byUser[userID]
+	c.PasswordHash = hash
+	f.byUser[userID] = c
+	return nil
+}
+
+func (f *fakeCredStore) DeleteCredential(_ context.Context, userID string) error {
+	delete(f.byUser, userID)
+	return nil
+}
+
+type fakeCodeStore struct{ codes map[string]auth.OIDCCode }
+
+func newFakeCodeStore() *fakeCodeStore {
+	return &fakeCodeStore{codes: make(map[string]auth.OIDCCode)}
+}
+
+func (f *fakeCodeStore) CreateOIDCCode(_ context.Context, c auth.OIDCCode) (auth.OIDCCode, error) {
+	f.codes[c.CodeHash] = c
+	return c, nil
+}
+
+func (f *fakeCodeStore) ConsumeOIDCCode(_ context.Context, hash string) (auth.OIDCCode, error) {
+	c, ok := f.codes[hash]
+	if !ok {
+		return auth.OIDCCode{}, auth.ErrNotFound
+	}
+	if c.ConsumedAt != nil {
+		return auth.OIDCCode{}, auth.ErrAlreadyConsumed
+	}
+	if time.Now().After(c.ExpiresAt) {
+		return auth.OIDCCode{}, auth.ErrExpired
+	}
+	now := time.Now()
+	c.ConsumedAt = &now
+	f.codes[hash] = c
+	return c, nil
+}
+
+type fakeTokenStore struct {
+	tokens map[string]auth.OIDCAccessToken
+}
+
+func newFakeTokenStore() *fakeTokenStore {
+	return &fakeTokenStore{tokens: make(map[string]auth.OIDCAccessToken)}
+}
+
+func (f *fakeTokenStore) CreateOIDCAccessToken(_ context.Context, t auth.OIDCAccessToken) (auth.OIDCAccessToken, error) {
+	f.tokens[t.TokenHash] = t
+	return t, nil
+}
+
+func (f *fakeTokenStore) GetOIDCAccessTokenByHash(_ context.Context, hash string) (auth.OIDCAccessToken, error) {
+	t, ok := f.tokens[hash]
+	if !ok {
+		return auth.OIDCAccessToken{}, auth.ErrNotFound
+	}
+	return t, nil
+}
+func (f *fakeTokenStore) DeleteExpiredOIDCAccessTokens(_ context.Context) error { return nil }
+
+// --- test helpers ---
+
+func generateTestKey(t *testing.T) *ecdsa.PrivateKey {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	return key
+}
+
+func keyToPEM(key *ecdsa.PrivateKey) string {
+	der, _ := x509.MarshalECPrivateKey(key)
+	return string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der}))
+}
+
+func confidentialConfig(t *testing.T, key *ecdsa.PrivateKey) *localoidc.Config {
+	t.Helper()
+	return &localoidc.Config{
+		IssuerURL:      "http://localhost:25678/oidc/local",
+		ClientID:       "test-client",
+		ClientSecret:   "test-secret",
+		RedirectURIs:   []string{"http://localhost/callback"},
+		SigningKey:     key,
+		KeyID:          "k1",
+		AccessTokenTTL: 3600,
+		AuthCodeTTL:    120,
+	}
+}
+
+func publicConfig(t *testing.T, key *ecdsa.PrivateKey) *localoidc.Config {
+	t.Helper()
+	return &localoidc.Config{
+		IssuerURL:      "http://localhost:25678/oidc/local",
+		ClientID:       "test-client",
+		RedirectURIs:   []string{"http://localhost/callback"},
+		SigningKey:     key,
+		KeyID:          "k1",
+		AccessTokenTTL: 3600,
+		AuthCodeTTL:    120,
+	}
+}
+
+func pkceS256(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func tokenHash(raw string) string {
+	sum := sha256.Sum256([]byte(raw))
+	var sb strings.Builder
+	for _, b := range sum {
+		sb.WriteString(strings.ToLower(string([]byte{hexChar(b >> 4), hexChar(b & 0xf)})))
+	}
+	return sb.String()
+}
+
+func hexChar(b byte) byte {
+	if b < 10 {
+		return '0' + b
+	}
+	return 'a' + b - 10
+}
+
+func seedUserAndMembership(userID, orgID, email, password string) (*fakeUserStore, *fakeMembershipStore, *fakeCredStore) {
+	hash, _ := auth.HashPassword(password)
+	users := newFakeUserStore(auth.User{ID: userID, Email: email, Name: "Test User"})
+	memberships := newFakeMembershipStore(auth.Membership{
+		ID: uuid.NewString(), UserID: userID, OrganizationID: orgID, Role: "user", IsActive: true,
+	})
+	creds := newFakeCredStore(auth.Credential{ID: uuid.NewString(), UserID: userID, PasswordHash: hash})
+	return users, memberships, creds
+}
+
+// --- tests ---
+
+func TestDiscovery(t *testing.T) {
+	key := generateTestKey(t)
+	cfg := confidentialConfig(t, key)
+	issuer := localoidc.NewIssuer(cfg,
+		newFakeCodeStore(), newFakeTokenStore(),
+		newFakeUserStore(), newFakeMembershipStore(),
+		newFakeCredStore(), nil, nil)
+
+	r := httptest.NewRequest(http.MethodGet, "/oidc/local/.well-known/openid-configuration", nil)
+	w := httptest.NewRecorder()
+	issuer.HandleDiscovery(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200", w.Code)
+	}
+	var doc localoidc.DiscoveryDocument
+	if err := json.Unmarshal(w.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("unmarshal discovery: %v", err)
+	}
+	if doc.Issuer != cfg.IssuerURL {
+		t.Errorf("issuer %q, want %q", doc.Issuer, cfg.IssuerURL)
+	}
+	if !strings.Contains(doc.AuthorizationEndpoint, "/authorize") {
+		t.Errorf("unexpected auth endpoint: %s", doc.AuthorizationEndpoint)
+	}
+	if !strings.Contains(doc.JWKSUri, "/jwks.json") {
+		t.Errorf("unexpected jwks uri: %s", doc.JWKSUri)
+	}
+}
+
+func TestJWKS(t *testing.T) {
+	key := generateTestKey(t)
+	cfg := confidentialConfig(t, key)
+	issuer := localoidc.NewIssuer(cfg,
+		newFakeCodeStore(), newFakeTokenStore(),
+		newFakeUserStore(), newFakeMembershipStore(),
+		newFakeCredStore(), nil, nil)
+
+	r := httptest.NewRequest(http.MethodGet, "/oidc/local/jwks.json", nil)
+	w := httptest.NewRecorder()
+	issuer.HandleJWKS(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200", w.Code)
+	}
+	var resp map[string][]localoidc.JWK
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal jwks: %v", err)
+	}
+	keys := resp["keys"]
+	if len(keys) != 1 {
+		t.Fatalf("got %d keys, want 1", len(keys))
+	}
+	if keys[0].Kty != "EC" || keys[0].Crv != "P-256" {
+		t.Errorf("unexpected key: kty=%s crv=%s", keys[0].Kty, keys[0].Crv)
+	}
+	if keys[0].Kid != "k1" {
+		t.Errorf("kid %q, want k1", keys[0].Kid)
+	}
+}
+
+func TestAuthorizeRejectsUnknownRedirectURI(t *testing.T) {
+	key := generateTestKey(t)
+	cfg := confidentialConfig(t, key)
+	issuer := localoidc.NewIssuer(cfg,
+		newFakeCodeStore(), newFakeTokenStore(),
+		newFakeUserStore(), newFakeMembershipStore(),
+		newFakeCredStore(), nil, nil)
+
+	q := url.Values{
+		"client_id":     {cfg.ClientID},
+		"redirect_uri":  {"http://evil.example/callback"},
+		"response_type": {"code"},
+		"scope":         {"openid"},
+	}
+	r := httptest.NewRequest(http.MethodGet, "/oidc/local/authorize?"+q.Encode(), nil)
+	w := httptest.NewRecorder()
+	issuer.HandleAuthorize(w, r)
+
+	if w.Code == http.StatusFound {
+		t.Error("should not redirect for unknown redirect_uri")
+	}
+}
+
+func TestAuthorizeShowsLoginFormWithNoSession(t *testing.T) {
+	key := generateTestKey(t)
+	cfg := confidentialConfig(t, key)
+	issuer := localoidc.NewIssuer(cfg,
+		newFakeCodeStore(), newFakeTokenStore(),
+		newFakeUserStore(), newFakeMembershipStore(),
+		newFakeCredStore(), nil, nil)
+
+	q := url.Values{
+		"client_id":     {cfg.ClientID},
+		"redirect_uri":  {cfg.RedirectURIs[0]},
+		"response_type": {"code"},
+		"scope":         {"openid email"},
+	}
+	r := httptest.NewRequest(http.MethodGet, "/oidc/local/authorize?"+q.Encode(), nil)
+	w := httptest.NewRecorder()
+	issuer.HandleAuthorize(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "<form") {
+		t.Error("response should contain a login form")
+	}
+}
+
+func TestAuthorizePostIssuesCode(t *testing.T) {
+	key := generateTestKey(t)
+	cfg := confidentialConfig(t, key)
+	userID, orgID := uuid.NewString(), uuid.NewString()
+	users, memberships, creds := seedUserAndMembership(userID, orgID, "user@test.example", "pass123")
+	codeStore := newFakeCodeStore()
+
+	issuer := localoidc.NewIssuer(cfg, codeStore, newFakeTokenStore(), users, memberships, creds, nil, nil)
+
+	q := url.Values{
+		"client_id":     {cfg.ClientID},
+		"redirect_uri":  {cfg.RedirectURIs[0]},
+		"response_type": {"code"},
+		"scope":         {"openid email"},
+		"state":         {"mystate"},
+	}
+	form := url.Values{"email": {"user@test.example"}, "password": {"pass123"}}
+	r := httptest.NewRequest(http.MethodPost, "/oidc/local/authorize?"+q.Encode(), strings.NewReader(form.Encode()))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	issuer.HandleAuthorize(w, r)
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("status %d, want 302. body: %s", w.Code, w.Body.String())
+	}
+	loc := w.Result().Header.Get("Location")
+	u, _ := url.Parse(loc)
+	if u.Query().Get("code") == "" {
+		t.Errorf("no code in redirect: %s", loc)
+	}
+	if u.Query().Get("state") != "mystate" {
+		t.Errorf("state mismatch: %s", loc)
+	}
+}
+
+func TestTokenExchangeAndIDToken(t *testing.T) {
+	key := generateTestKey(t)
+	cfg := confidentialConfig(t, key)
+	userID, orgID := uuid.NewString(), uuid.NewString()
+	users, memberships, creds := seedUserAndMembership(userID, orgID, "user@test.example", "pass")
+	codeStore := newFakeCodeStore()
+	tokenStore := newFakeTokenStore()
+
+	issuer := localoidc.NewIssuer(cfg, codeStore, tokenStore, users, memberships, creds, nil, nil)
+
+	// Step 1: authorize POST → get code.
+	q := url.Values{
+		"client_id":     {cfg.ClientID},
+		"redirect_uri":  {cfg.RedirectURIs[0]},
+		"response_type": {"code"},
+		"scope":         {"openid email profile"},
+		"nonce":         {"testnonce"},
+	}
+	form := url.Values{"email": {"user@test.example"}, "password": {"pass"}}
+	r := httptest.NewRequest(http.MethodPost, "/oidc/local/authorize?"+q.Encode(), strings.NewReader(form.Encode()))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	issuer.HandleAuthorize(w, r)
+	if w.Code != http.StatusFound {
+		t.Fatalf("authorize: status %d. body: %s", w.Code, w.Body.String())
+	}
+	loc, _ := url.Parse(w.Result().Header.Get("Location"))
+	rawCode := loc.Query().Get("code")
+
+	// Step 2: token endpoint.
+	tokenForm := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {rawCode},
+		"redirect_uri":  {cfg.RedirectURIs[0]},
+		"client_id":     {cfg.ClientID},
+		"client_secret": {cfg.ClientSecret},
+	}
+	tr := httptest.NewRequest(http.MethodPost, "/oidc/local/token", strings.NewReader(tokenForm.Encode()))
+	tr.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tw := httptest.NewRecorder()
+	issuer.HandleToken(tw, tr)
+	if tw.Code != http.StatusOK {
+		t.Fatalf("token: status %d. body: %s", tw.Code, tw.Body.String())
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(tw.Body.Bytes(), &resp)
+
+	rawAccessToken, _ := resp["access_token"].(string)
+	idToken, _ := resp["id_token"].(string)
+	if rawAccessToken == "" || idToken == "" {
+		t.Fatalf("missing access_token or id_token in response: %v", resp)
+	}
+
+	// Verify ID token signature and claims.
+	claims, err := localoidc.VerifyES256(idToken, &key.PublicKey)
+	if err != nil {
+		t.Fatalf("verify id_token: %v", err)
+	}
+	if claims["sub"] != userID {
+		t.Errorf("sub = %v, want %s", claims["sub"], userID)
+	}
+	if claims["email"] != "user@test.example" {
+		t.Errorf("email = %v", claims["email"])
+	}
+	if claims["email_verified"] != true {
+		t.Errorf("email_verified = %v, want true", claims["email_verified"])
+	}
+	if claims["nonce"] != "testnonce" {
+		t.Errorf("nonce = %v, want testnonce", claims["nonce"])
+	}
+	if claims["iss"] != cfg.IssuerURL {
+		t.Errorf("iss = %v, want %s", claims["iss"], cfg.IssuerURL)
+	}
+}
+
+func TestCodeCannotBeReused(t *testing.T) {
+	key := generateTestKey(t)
+	cfg := confidentialConfig(t, key)
+	userID, orgID := uuid.NewString(), uuid.NewString()
+	users, memberships, creds := seedUserAndMembership(userID, orgID, "u@test.example", "pass")
+	codeStore := newFakeCodeStore()
+
+	issuer := localoidc.NewIssuer(cfg, codeStore, newFakeTokenStore(), users, memberships, creds, nil, nil)
+
+	// Authorize.
+	q := url.Values{
+		"client_id":     {cfg.ClientID},
+		"redirect_uri":  {cfg.RedirectURIs[0]},
+		"response_type": {"code"},
+		"scope":         {"openid"},
+	}
+	form := url.Values{"email": {"u@test.example"}, "password": {"pass"}}
+	r := httptest.NewRequest(http.MethodPost, "/oidc/local/authorize?"+q.Encode(), strings.NewReader(form.Encode()))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	issuer.HandleAuthorize(w, r)
+	loc, _ := url.Parse(w.Result().Header.Get("Location"))
+	rawCode := loc.Query().Get("code")
+
+	tokenForm := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {rawCode},
+		"redirect_uri":  {cfg.RedirectURIs[0]},
+		"client_id":     {cfg.ClientID},
+		"client_secret": {cfg.ClientSecret},
+	}
+
+	// First exchange succeeds.
+	tr := httptest.NewRequest(http.MethodPost, "/oidc/local/token", strings.NewReader(tokenForm.Encode()))
+	tr.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tw := httptest.NewRecorder()
+	issuer.HandleToken(tw, tr)
+	if tw.Code != http.StatusOK {
+		t.Fatalf("first exchange: status %d", tw.Code)
+	}
+
+	// Second exchange with same code fails.
+	tr2 := httptest.NewRequest(http.MethodPost, "/oidc/local/token", strings.NewReader(tokenForm.Encode()))
+	tr2.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tw2 := httptest.NewRecorder()
+	issuer.HandleToken(tw2, tr2)
+	if tw2.Code != http.StatusBadRequest {
+		t.Errorf("reuse: status %d, want 400", tw2.Code)
+	}
+	var errResp map[string]string
+	_ = json.Unmarshal(tw2.Body.Bytes(), &errResp)
+	if errResp["error"] != "invalid_grant" {
+		t.Errorf("error %q, want invalid_grant", errResp["error"])
+	}
+}
+
+func TestPKCERequired(t *testing.T) {
+	key := generateTestKey(t)
+	cfg := publicConfig(t, key) // public client requires PKCE
+	issuer := localoidc.NewIssuer(cfg,
+		newFakeCodeStore(), newFakeTokenStore(),
+		newFakeUserStore(), newFakeMembershipStore(),
+		newFakeCredStore(), nil, nil)
+
+	q := url.Values{
+		"client_id":     {cfg.ClientID},
+		"redirect_uri":  {cfg.RedirectURIs[0]},
+		"response_type": {"code"},
+		"scope":         {"openid"},
+		// No code_challenge → should be rejected.
+	}
+	r := httptest.NewRequest(http.MethodGet, "/oidc/local/authorize?"+q.Encode(), nil)
+	w := httptest.NewRecorder()
+	issuer.HandleAuthorize(w, r)
+
+	if w.Code == http.StatusFound {
+		t.Error("public client without PKCE should not redirect")
+	}
+}
+
+func TestPKCEVerification(t *testing.T) {
+	key := generateTestKey(t)
+	cfg := publicConfig(t, key)
+	userID, orgID := uuid.NewString(), uuid.NewString()
+	users, memberships, creds := seedUserAndMembership(userID, orgID, "u@test.example", "pass")
+	codeStore := newFakeCodeStore()
+
+	issuer := localoidc.NewIssuer(cfg, codeStore, newFakeTokenStore(), users, memberships, creds, nil, nil)
+
+	verifier := strings.Repeat("v", 43)
+	challenge := pkceS256(verifier)
+
+	q := url.Values{
+		"client_id":             {cfg.ClientID},
+		"redirect_uri":          {cfg.RedirectURIs[0]},
+		"response_type":         {"code"},
+		"scope":                 {"openid"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+	}
+	form := url.Values{"email": {"u@test.example"}, "password": {"pass"}}
+	r := httptest.NewRequest(http.MethodPost, "/oidc/local/authorize?"+q.Encode(), strings.NewReader(form.Encode()))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	issuer.HandleAuthorize(w, r)
+	if w.Code != http.StatusFound {
+		t.Fatalf("authorize: %d. body: %s", w.Code, w.Body.String())
+	}
+	loc, _ := url.Parse(w.Result().Header.Get("Location"))
+	rawCode := loc.Query().Get("code")
+
+	// Token with wrong verifier → rejected.
+	tokenForm := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {rawCode},
+		"redirect_uri":  {cfg.RedirectURIs[0]},
+		"client_id":     {cfg.ClientID},
+		"code_verifier": {"wrong-verifier"},
+	}
+	tr := httptest.NewRequest(http.MethodPost, "/oidc/local/token", strings.NewReader(tokenForm.Encode()))
+	tr.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tw := httptest.NewRecorder()
+	issuer.HandleToken(tw, tr)
+	if tw.Code != http.StatusBadRequest {
+		t.Errorf("wrong verifier: status %d, want 400", tw.Code)
+	}
+}
+
+func TestUserinfoWithValidToken(t *testing.T) {
+	key := generateTestKey(t)
+	cfg := confidentialConfig(t, key)
+	userID, orgID := uuid.NewString(), uuid.NewString()
+	users := newFakeUserStore(auth.User{ID: userID, Email: "info@test.example", Name: "Info User"})
+	memberships := newFakeMembershipStore(auth.Membership{
+		ID: uuid.NewString(), UserID: userID, OrganizationID: orgID, Role: "user", IsActive: true,
+	})
+	tokenStore := newFakeTokenStore()
+
+	issuer := localoidc.NewIssuer(cfg,
+		newFakeCodeStore(), tokenStore,
+		users, memberships, newFakeCredStore(), nil, nil)
+
+	// Seed an access token directly.
+	rawToken := strings.Repeat("a", 64)
+	hash := tokenHash(rawToken)
+	tokenStore.tokens[hash] = auth.OIDCAccessToken{
+		ID:        uuid.NewString(),
+		TokenHash: hash,
+		UserID:    userID,
+		OrgID:     orgID,
+		ClientID:  cfg.ClientID,
+		Scopes:    []string{"openid", "email", "profile"},
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/oidc/local/userinfo", nil)
+	r.Header.Set("Authorization", "Bearer "+rawToken)
+	w := httptest.NewRecorder()
+	issuer.HandleUserinfo(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("userinfo: status %d. body: %s", w.Code, w.Body.String())
+	}
+	var claims map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &claims)
+	if claims["sub"] != userID {
+		t.Errorf("sub = %v, want %s", claims["sub"], userID)
+	}
+	if claims["email"] != "info@test.example" {
+		t.Errorf("email = %v", claims["email"])
+	}
+}
+
+func TestUserinfoWithNoToken(t *testing.T) {
+	key := generateTestKey(t)
+	cfg := confidentialConfig(t, key)
+	issuer := localoidc.NewIssuer(cfg,
+		newFakeCodeStore(), newFakeTokenStore(),
+		newFakeUserStore(), newFakeMembershipStore(),
+		newFakeCredStore(), nil, nil)
+
+	r := httptest.NewRequest(http.MethodGet, "/oidc/local/userinfo", nil)
+	w := httptest.NewRecorder()
+	issuer.HandleUserinfo(w, r)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("no token: status %d, want 401", w.Code)
+	}
+}
+
+func TestDisabledMembershipCannotAuthorize(t *testing.T) {
+	key := generateTestKey(t)
+	cfg := confidentialConfig(t, key)
+	userID, orgID := uuid.NewString(), uuid.NewString()
+	hash, _ := auth.HashPassword("pass")
+	users := newFakeUserStore(auth.User{ID: userID, Email: "d@test.example", Name: "Disabled"})
+	memberships := newFakeMembershipStore(auth.Membership{
+		ID: uuid.NewString(), UserID: userID, OrganizationID: orgID, Role: "user", IsActive: false,
+	})
+	creds := newFakeCredStore(auth.Credential{ID: uuid.NewString(), UserID: userID, PasswordHash: hash})
+
+	issuer := localoidc.NewIssuer(cfg,
+		newFakeCodeStore(), newFakeTokenStore(),
+		users, memberships, creds, nil, nil)
+
+	q := url.Values{
+		"client_id":     {cfg.ClientID},
+		"redirect_uri":  {cfg.RedirectURIs[0]},
+		"response_type": {"code"},
+		"scope":         {"openid"},
+	}
+	form := url.Values{"email": {"d@test.example"}, "password": {"pass"}}
+	r := httptest.NewRequest(http.MethodPost, "/oidc/local/authorize?"+q.Encode(), strings.NewReader(form.Encode()))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	issuer.HandleAuthorize(w, r)
+
+	if w.Code == http.StatusFound {
+		t.Error("disabled membership should not get a code redirect")
+	}
+}
+
+func TestWrongClientIDRejected(t *testing.T) {
+	key := generateTestKey(t)
+	cfg := confidentialConfig(t, key)
+	issuer := localoidc.NewIssuer(cfg,
+		newFakeCodeStore(), newFakeTokenStore(),
+		newFakeUserStore(), newFakeMembershipStore(),
+		newFakeCredStore(), nil, nil)
+
+	form := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {"somecode"},
+		"redirect_uri":  {cfg.RedirectURIs[0]},
+		"client_id":     {"wrong-client"},
+		"client_secret": {cfg.ClientSecret},
+	}
+	r := httptest.NewRequest(http.MethodPost, "/oidc/local/token", strings.NewReader(form.Encode()))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	issuer.HandleToken(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("wrong client: status %d, want 400", w.Code)
+	}
+	body, _ := io.ReadAll(w.Body)
+	var resp map[string]string
+	_ = json.Unmarshal(body, &resp)
+	if resp["error"] != "invalid_client" {
+		t.Errorf("error %q, want invalid_client", resp["error"])
+	}
+}
+
+func TestConfigFromEnvDisabledByDefault(t *testing.T) {
+	cfg, err := localoidc.ConfigFromEnv()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg != nil {
+		t.Error("config should be nil when LOCAL_OIDC_ENABLED is not 'true'")
+	}
+}
+
+func TestConfigValidate(t *testing.T) {
+	key := generateTestKey(t)
+	cases := []struct {
+		name   string
+		cfg    localoidc.Config
+		wantOK bool
+	}{
+		{
+			name:   "valid",
+			cfg:    localoidc.Config{IssuerURL: "http://h/oidc/local", ClientID: "c", RedirectURIs: []string{"http://h/cb"}, SigningKey: key},
+			wantOK: true,
+		},
+		{
+			name:   "missing issuer_url",
+			cfg:    localoidc.Config{ClientID: "c", RedirectURIs: []string{"http://h/cb"}, SigningKey: key},
+			wantOK: false,
+		},
+		{
+			name:   "missing redirect_uris",
+			cfg:    localoidc.Config{IssuerURL: "http://h/oidc/local", ClientID: "c", SigningKey: key},
+			wantOK: false,
+		},
+		{
+			name:   "missing client_id",
+			cfg:    localoidc.Config{IssuerURL: "http://h/oidc/local", RedirectURIs: []string{"http://h/cb"}, SigningKey: key},
+			wantOK: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.Validate()
+			if tc.wantOK && err != nil {
+				t.Errorf("want valid, got: %v", err)
+			}
+			if !tc.wantOK && err == nil {
+				t.Error("want error, got nil")
+			}
+		})
+	}
+}
+
+func TestKeyPEMRoundTrip(t *testing.T) {
+	key := generateTestKey(t)
+	pemStr := keyToPEM(key)
+	der, _ := x509.MarshalECPrivateKey(key)
+	if string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der})) != pemStr {
+		t.Error("key PEM round-trip mismatch")
+	}
+}

--- a/internal/auth/store.go
+++ b/internal/auth/store.go
@@ -70,6 +70,29 @@ type MembershipStore interface {
 	CountOrgMembers(ctx context.Context, orgID string) (int64, error)
 }
 
+// OIDCCodeStore provides operations for local OIDC authorization codes.
+type OIDCCodeStore interface {
+	CreateOIDCCode(ctx context.Context, c OIDCCode) (OIDCCode, error)
+	// ConsumeOIDCCode atomically looks up a code by hash and marks it consumed.
+	// Returns ErrNotFound if the code does not exist, ErrAlreadyConsumed if already used.
+	ConsumeOIDCCode(ctx context.Context, codeHash string) (OIDCCode, error)
+}
+
+// OIDCAccessTokenStore provides operations for local OIDC access tokens.
+type OIDCAccessTokenStore interface {
+	CreateOIDCAccessToken(ctx context.Context, t OIDCAccessToken) (OIDCAccessToken, error)
+	GetOIDCAccessTokenByHash(ctx context.Context, tokenHash string) (OIDCAccessToken, error)
+	DeleteExpiredOIDCAccessTokens(ctx context.Context) error
+}
+
+// CredentialStore provides CRUD for auth_credential (local password hashes).
+type CredentialStore interface {
+	CreateCredential(ctx context.Context, c Credential) (Credential, error)
+	GetCredentialByUserID(ctx context.Context, userID string) (Credential, error)
+	UpdateCredentialHash(ctx context.Context, userID, passwordHash string) error
+	DeleteCredential(ctx context.Context, userID string) error
+}
+
 // AuthStores groups the stores needed for a single transactional login flow.
 type AuthStores struct {
 	Users         UserStore
@@ -77,6 +100,7 @@ type AuthStores struct {
 	Sessions      SessionStore
 	Organizations OrganizationStore
 	Memberships   MembershipStore
+	Credentials   CredentialStore
 }
 
 // Transactioner is an optional interface that store implementations may satisfy

--- a/internal/auth/types.go
+++ b/internal/auth/types.go
@@ -211,6 +211,47 @@ type UserToken struct {
 	UpdatedAt     time.Time  `json:"updated_at"`
 }
 
+// OIDCCode is an authorization code issued by the local OIDC issuer.
+// CodeHash is the SHA-256 hash of the raw opaque code sent to the client.
+type OIDCCode struct {
+	ID            string     `json:"id"`
+	CodeHash      string     `json:"-"`
+	UserID        string     `json:"user_id"`
+	OrgID         string     `json:"org_id"`
+	ClientID      string     `json:"client_id"`
+	RedirectURI   string     `json:"redirect_uri"`
+	Scopes        []string   `json:"scopes"`
+	Nonce         string     `json:"nonce"`
+	PKCEChallenge string     `json:"-"`
+	PKCEMethod    string     `json:"pkce_method"`
+	ExpiresAt     time.Time  `json:"expires_at"`
+	ConsumedAt    *time.Time `json:"consumed_at,omitempty"`
+	CreatedAt     time.Time  `json:"created_at"`
+}
+
+// OIDCAccessToken is an opaque access token issued by the local OIDC issuer.
+// TokenHash is the SHA-256 hash of the raw token sent to the client.
+type OIDCAccessToken struct {
+	ID        string    `json:"id"`
+	TokenHash string    `json:"-"`
+	UserID    string    `json:"user_id"`
+	OrgID     string    `json:"org_id"`
+	ClientID  string    `json:"client_id"`
+	Scopes    []string  `json:"scopes"`
+	ExpiresAt time.Time `json:"expires_at"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// Credential stores the bcrypt password hash for a local OIDC authorize screen.
+// It lives in auth_credential and is keyed by user_id (one per user).
+type Credential struct {
+	ID           string    `json:"id"`
+	UserID       string    `json:"user_id"`
+	PasswordHash string    `json:"-"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}
+
 // RoleAdmin and RoleUser are the built-in role IDs.
 const (
 	RoleAdmin = "admin"

--- a/internal/config/dbstore.go
+++ b/internal/config/dbstore.go
@@ -88,6 +88,26 @@ func (s *DBStore) UpdateProvider(ctx context.Context, p Provider) error {
 	return nil
 }
 
+func (s *DBStore) ListProvidersForOrg(ctx context.Context, orgID string) ([]Provider, error) {
+	rows, err := s.q.ListProvidersByOrg(ctx, sql.NullString{String: orgID, Valid: orgID != ""})
+	if err != nil {
+		return nil, fmt.Errorf("list providers for org %q: %w", orgID, err)
+	}
+	out := make([]Provider, len(rows))
+	for i, r := range rows {
+		out[i] = providerFromDB(r)
+		applyProviderEnvFallback(&out[i])
+	}
+	return out, nil
+}
+
+func (s *DBStore) SetProviderOrg(ctx context.Context, providerID, orgID string) error {
+	return s.q.SetProviderOrg(ctx, sqlc.SetProviderOrgParams{
+		OrgID: sql.NullString{String: orgID, Valid: orgID != ""},
+		ID:    providerID,
+	})
+}
+
 func (s *DBStore) DeleteProvider(ctx context.Context, id string) error {
 	return s.q.DeleteProvider(ctx, id)
 }
@@ -213,6 +233,29 @@ func (s *DBStore) UpdateAgent(ctx context.Context, a Agent) error {
 	return nil
 }
 
+func (s *DBStore) ListAgentsForOrg(ctx context.Context, orgID string) ([]Agent, error) {
+	rows, err := s.q.ListAgentsByOrg(ctx, sql.NullString{String: orgID, Valid: orgID != ""})
+	if err != nil {
+		return nil, fmt.Errorf("list agents for org %q: %w", orgID, err)
+	}
+	out := make([]Agent, len(rows))
+	for i, r := range rows {
+		agent, err := agentFromDB(r)
+		if err != nil {
+			return nil, fmt.Errorf("list agents for org %q: %w", orgID, err)
+		}
+		out[i] = agent
+	}
+	return out, nil
+}
+
+func (s *DBStore) SetAgentOrg(ctx context.Context, agentID, orgID string) error {
+	return s.q.SetAgentOrg(ctx, sqlc.SetAgentOrgParams{
+		OrgID: sql.NullString{String: orgID, Valid: orgID != ""},
+		ID:    agentID,
+	})
+}
+
 func (s *DBStore) DeleteAgent(ctx context.Context, id string) error {
 	return s.q.DeleteAgent(ctx, id)
 }
@@ -262,6 +305,25 @@ func (s *DBStore) UpsertChannel(ctx context.Context, ch Channel) error {
 		AgentID: sql.NullString{String: ch.AgentID, Valid: ch.AgentID != ""},
 		Enabled: boolToInt64(ch.Enabled),
 		Config:  ch.Config,
+	})
+}
+
+func (s *DBStore) ListChannelsForOrg(ctx context.Context, orgID string) ([]Channel, error) {
+	rows, err := s.q.ListChannelsByOrg(ctx, sql.NullString{String: orgID, Valid: orgID != ""})
+	if err != nil {
+		return nil, fmt.Errorf("list channels for org %q: %w", orgID, err)
+	}
+	out := make([]Channel, len(rows))
+	for i, r := range rows {
+		out[i] = channelFromDB(r)
+	}
+	return out, nil
+}
+
+func (s *DBStore) SetChannelOrg(ctx context.Context, channelID, orgID string) error {
+	return s.q.SetChannelOrg(ctx, sqlc.SetChannelOrgParams{
+		OrgID: sql.NullString{String: orgID, Valid: orgID != ""},
+		ID:    channelID,
 	})
 }
 
@@ -941,6 +1003,7 @@ func providerFromDB(r sqlc.SettingsProvider) Provider {
 		APIKey:  apiKey,
 		BaseURL: baseURL,
 		Models:  providerModelsFromAny(cfg["models"]),
+		OrgID:   r.OrgID.String,
 	}
 }
 
@@ -1108,6 +1171,7 @@ func agentFromDB(r sqlc.SettingsAgent) (Agent, error) {
 		Scope:        scope,
 		CreatorID:    r.CreatorID,
 		Enabled:      r.Enabled == 1,
+		OrgID:        r.OrgID.String,
 	}, nil
 }
 
@@ -1160,5 +1224,6 @@ func channelFromDB(r sqlc.SettingsChannel) Channel {
 		AgentID: agentID,
 		Enabled: r.Enabled == 1,
 		Config:  r.Config,
+		OrgID:   r.OrgID.String,
 	}
 }

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -30,6 +30,7 @@ type Provider struct {
 	APIKey  string                   `json:"api_key"`
 	BaseURL string                   `json:"base_url"`
 	Models  map[string]ProviderModel `json:"models,omitempty"`
+	OrgID   string                   `json:"org_id,omitempty"`
 }
 
 // AgentScope constants define the access scope for an agent.
@@ -53,6 +54,7 @@ type Agent struct {
 	Scope        string        `json:"scope"`
 	CreatorID    string        `json:"creator_id"`
 	Enabled      bool          `json:"enabled"`
+	OrgID        string        `json:"org_id,omitempty"`
 }
 
 // Channel represents a platform channel configuration.
@@ -62,31 +64,38 @@ type Channel struct {
 	AgentID string `json:"agent_id,omitempty"`
 	Enabled bool   `json:"enabled"`
 	Config  string `json:"config"`
+	OrgID   string `json:"org_id,omitempty"`
 }
 
 // Store provides typed access to configuration stored in the database.
 type Store interface {
 	// Providers
 	ListProviders(ctx context.Context) ([]Provider, error)
+	ListProvidersForOrg(ctx context.Context, orgID string) ([]Provider, error)
 	GetProvider(ctx context.Context, id string) (Provider, error)
 	CreateProvider(ctx context.Context, p Provider) error
 	UpdateProvider(ctx context.Context, p Provider) error
 	DeleteProvider(ctx context.Context, id string) error
+	SetProviderOrg(ctx context.Context, providerID, orgID string) error
 
 	// Agents
 	ListAgents(ctx context.Context) ([]Agent, error)
 	ListEnabledAgents(ctx context.Context) ([]Agent, error)
+	ListAgentsForOrg(ctx context.Context, orgID string) ([]Agent, error)
 	GetAgent(ctx context.Context, id string) (Agent, error)
 	CreateAgent(ctx context.Context, a Agent) error
 	UpdateAgent(ctx context.Context, a Agent) error
 	DeleteAgent(ctx context.Context, id string) error
+	SetAgentOrg(ctx context.Context, agentID, orgID string) error
 
 	// Channels
 	ListChannels(ctx context.Context) ([]Channel, error)
 	ListChannelsByType(ctx context.Context, channelType string) ([]Channel, error)
+	ListChannelsForOrg(ctx context.Context, orgID string) ([]Channel, error)
 	GetChannel(ctx context.Context, id string) (Channel, error)
 	UpsertChannel(ctx context.Context, ch Channel) error
 	DeleteChannel(ctx context.Context, id string) error
+	SetChannelOrg(ctx context.Context, channelID, orgID string) error
 
 	// Plugins
 	ListPlugins(ctx context.Context) ([]Plugin, error)

--- a/internal/db/authstore_oidc.go
+++ b/internal/db/authstore_oidc.go
@@ -254,7 +254,11 @@ func (s *OIDCStore) GetLoginIdentityByProvider(ctx context.Context, provider, pr
 	const q = `SELECT id, user_id, provider, provider_subject, email, name, avatar_url, raw_claims, created_at, updated_at
 	           FROM auth_identity WHERE provider=? AND provider_subject=?`
 	row := s.db.QueryRowContext(ctx, q, provider, providerSubject)
-	return scanLoginIdentity(row)
+	id, err := scanLoginIdentity(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return auth.LoginIdentity{}, auth.ErrNotFound
+	}
+	return id, err
 }
 
 func (s *OIDCStore) ListLoginIdentitiesByUser(ctx context.Context, userID string) ([]auth.LoginIdentity, error) {

--- a/internal/db/authstore_oidc.go
+++ b/internal/db/authstore_oidc.go
@@ -62,6 +62,7 @@ func (s *OIDCStore) BeginAuthTx(ctx context.Context) (auth.AuthStores, func() er
 		Sessions:      txStore,
 		Organizations: txStore,
 		Memberships:   txStore,
+		Credentials:   txStore,
 	}
 	rollback := func() { _ = tx.Rollback() }
 	return stores, tx.Commit, rollback, nil
@@ -78,6 +79,9 @@ var (
 	_ auth.SessionStore         = (*OIDCStore)(nil)
 	_ auth.OrganizationStore    = (*OIDCStore)(nil)
 	_ auth.MembershipStore      = (*OIDCStore)(nil)
+	_ auth.CredentialStore      = (*OIDCStore)(nil)
+	_ auth.OIDCCodeStore        = (*OIDCStore)(nil)
+	_ auth.OIDCAccessTokenStore = (*OIDCStore)(nil)
 )
 
 func parseOIDCTime(s string) time.Time {
@@ -547,4 +551,179 @@ func scanMembership(r rowScanner) (auth.Membership, error) {
 	m.CreatedAt = parseOIDCTime(createdAt)
 	m.UpdatedAt = parseOIDCTime(updatedAt)
 	return m, nil
+}
+
+// ---- CredentialStore ----
+
+func (s *OIDCStore) CreateCredential(ctx context.Context, c auth.Credential) (auth.Credential, error) {
+	const q = `INSERT INTO auth_credential (id, user_id, password_hash)
+	           VALUES (?, ?, ?) RETURNING id, user_id, password_hash, created_at, updated_at`
+	row := s.db.QueryRowContext(ctx, q, c.ID, c.UserID, c.PasswordHash)
+	return scanCredential(row)
+}
+
+func (s *OIDCStore) GetCredentialByUserID(ctx context.Context, userID string) (auth.Credential, error) {
+	const q = `SELECT id, user_id, password_hash, created_at, updated_at
+	           FROM auth_credential WHERE user_id = ?`
+	row := s.db.QueryRowContext(ctx, q, userID)
+	c, err := scanCredential(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return auth.Credential{}, auth.ErrNotFound
+	}
+	return c, err
+}
+
+func (s *OIDCStore) UpdateCredentialHash(ctx context.Context, userID, passwordHash string) error {
+	const q = `UPDATE auth_credential SET password_hash = ?, updated_at = datetime('now') WHERE user_id = ?`
+	res, err := s.db.ExecContext(ctx, q, passwordHash, userID)
+	if err != nil {
+		return fmt.Errorf("auth_credential update: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return fmt.Errorf("auth_credential update: user %s not found", userID)
+	}
+	return nil
+}
+
+func (s *OIDCStore) DeleteCredential(ctx context.Context, userID string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM auth_credential WHERE user_id = ?`, userID)
+	return err
+}
+
+func scanCredential(r rowScanner) (auth.Credential, error) {
+	var c auth.Credential
+	var createdAt, updatedAt string
+	if err := r.Scan(&c.ID, &c.UserID, &c.PasswordHash, &createdAt, &updatedAt); err != nil {
+		return auth.Credential{}, fmt.Errorf("auth_credential scan: %w", err)
+	}
+	c.CreatedAt = parseOIDCTime(createdAt)
+	c.UpdatedAt = parseOIDCTime(updatedAt)
+	return c, nil
+}
+
+// ---- OIDCCodeStore ----
+
+func (s *OIDCStore) CreateOIDCCode(ctx context.Context, c auth.OIDCCode) (auth.OIDCCode, error) {
+	scopesJSON, err := json.Marshal(c.Scopes)
+	if err != nil {
+		return auth.OIDCCode{}, fmt.Errorf("auth_oidc_codes: marshal scopes: %w", err)
+	}
+	const q = `INSERT INTO auth_oidc_codes
+		(id, code_hash, user_id, org_id, client_id, redirect_uri, scopes, nonce,
+		 pkce_challenge, pkce_method, expires_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		RETURNING id, code_hash, user_id, org_id, client_id, redirect_uri, scopes, nonce,
+		          pkce_challenge, pkce_method, expires_at, consumed_at, created_at`
+	row := s.db.QueryRowContext(ctx, q,
+		c.ID, c.CodeHash, c.UserID, c.OrgID, c.ClientID, c.RedirectURI,
+		string(scopesJSON), c.Nonce, c.PKCEChallenge, c.PKCEMethod,
+		c.ExpiresAt.UTC().Format(oidcTimeLayout),
+	)
+	return scanOIDCCode(row)
+}
+
+func (s *OIDCStore) ConsumeOIDCCode(ctx context.Context, codeHash string) (auth.OIDCCode, error) {
+	now := time.Now().UTC().Format(oidcTimeLayout)
+	const q = `UPDATE auth_oidc_codes SET consumed_at = ?
+		WHERE code_hash = ? AND consumed_at IS NULL AND expires_at > ?
+		RETURNING id, code_hash, user_id, org_id, client_id, redirect_uri, scopes, nonce,
+		          pkce_challenge, pkce_method, expires_at, consumed_at, created_at`
+	row := s.db.QueryRowContext(ctx, q, now, codeHash, now)
+	code, err := scanOIDCCode(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		// Distinguish "already consumed" from "not found" / "expired".
+		var dummy string
+		checkErr := s.db.QueryRowContext(ctx,
+			`SELECT id FROM auth_oidc_codes WHERE code_hash = ?`, codeHash,
+		).Scan(&dummy)
+		if errors.Is(checkErr, sql.ErrNoRows) {
+			return auth.OIDCCode{}, auth.ErrNotFound
+		}
+		// Row exists but was consumed or expired.
+		var consumedAt *string
+		var expiresAt string
+		_ = s.db.QueryRowContext(ctx,
+			`SELECT consumed_at, expires_at FROM auth_oidc_codes WHERE code_hash = ?`, codeHash,
+		).Scan(&consumedAt, &expiresAt)
+		if consumedAt != nil {
+			return auth.OIDCCode{}, auth.ErrAlreadyConsumed
+		}
+		return auth.OIDCCode{}, auth.ErrExpired
+	}
+	return code, err
+}
+
+func scanOIDCCode(r rowScanner) (auth.OIDCCode, error) {
+	var c auth.OIDCCode
+	var scopesJSON, expiresAt, createdAt string
+	var consumedAt *string
+	if err := r.Scan(
+		&c.ID, &c.CodeHash, &c.UserID, &c.OrgID, &c.ClientID, &c.RedirectURI,
+		&scopesJSON, &c.Nonce, &c.PKCEChallenge, &c.PKCEMethod,
+		&expiresAt, &consumedAt, &createdAt,
+	); err != nil {
+		return auth.OIDCCode{}, fmt.Errorf("auth_oidc_codes scan: %w", err)
+	}
+	if err := json.Unmarshal([]byte(scopesJSON), &c.Scopes); err != nil {
+		return auth.OIDCCode{}, fmt.Errorf("auth_oidc_codes: unmarshal scopes: %w", err)
+	}
+	c.ExpiresAt = parseOIDCTime(expiresAt)
+	c.CreatedAt = parseOIDCTime(createdAt)
+	if consumedAt != nil {
+		t := parseOIDCTime(*consumedAt)
+		c.ConsumedAt = &t
+	}
+	return c, nil
+}
+
+// ---- OIDCAccessTokenStore ----
+
+func (s *OIDCStore) CreateOIDCAccessToken(ctx context.Context, t auth.OIDCAccessToken) (auth.OIDCAccessToken, error) {
+	scopesJSON, err := json.Marshal(t.Scopes)
+	if err != nil {
+		return auth.OIDCAccessToken{}, fmt.Errorf("auth_oidc_access_tokens: marshal scopes: %w", err)
+	}
+	const q = `INSERT INTO auth_oidc_access_tokens
+		(id, token_hash, user_id, org_id, client_id, scopes, expires_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+		RETURNING id, token_hash, user_id, org_id, client_id, scopes, expires_at, created_at`
+	row := s.db.QueryRowContext(ctx, q,
+		t.ID, t.TokenHash, t.UserID, t.OrgID, t.ClientID,
+		string(scopesJSON), t.ExpiresAt.UTC().Format(oidcTimeLayout),
+	)
+	return scanOIDCAccessToken(row)
+}
+
+func (s *OIDCStore) GetOIDCAccessTokenByHash(ctx context.Context, tokenHash string) (auth.OIDCAccessToken, error) {
+	const q = `SELECT id, token_hash, user_id, org_id, client_id, scopes, expires_at, created_at
+		FROM auth_oidc_access_tokens WHERE token_hash = ?`
+	row := s.db.QueryRowContext(ctx, q, tokenHash)
+	t, err := scanOIDCAccessToken(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return auth.OIDCAccessToken{}, auth.ErrNotFound
+	}
+	return t, err
+}
+
+func (s *OIDCStore) DeleteExpiredOIDCAccessTokens(ctx context.Context) error {
+	now := time.Now().UTC().Format(oidcTimeLayout)
+	_, err := s.db.ExecContext(ctx, `DELETE FROM auth_oidc_access_tokens WHERE expires_at <= ?`, now)
+	return err
+}
+
+func scanOIDCAccessToken(r rowScanner) (auth.OIDCAccessToken, error) {
+	var t auth.OIDCAccessToken
+	var scopesJSON, expiresAt, createdAt string
+	if err := r.Scan(
+		&t.ID, &t.TokenHash, &t.UserID, &t.OrgID, &t.ClientID,
+		&scopesJSON, &expiresAt, &createdAt,
+	); err != nil {
+		return auth.OIDCAccessToken{}, fmt.Errorf("auth_oidc_access_tokens scan: %w", err)
+	}
+	if err := json.Unmarshal([]byte(scopesJSON), &t.Scopes); err != nil {
+		return auth.OIDCAccessToken{}, fmt.Errorf("auth_oidc_access_tokens: unmarshal scopes: %w", err)
+	}
+	t.ExpiresAt = parseOIDCTime(expiresAt)
+	t.CreatedAt = parseOIDCTime(createdAt)
+	return t, nil
 }

--- a/internal/db/backfill_oidc.go
+++ b/internal/db/backfill_oidc.go
@@ -198,3 +198,39 @@ func BackfillOIDCTables(ctx context.Context, db *sql.DB) (int, error) {
 
 	return len(users), nil
 }
+
+// BackfillOrgScopedSettings assigns existing settings resources (agents, providers,
+// channels, policies) that have no org_id to the oldest "backfill" organization.
+// This is the local-install "legacy org" created when the first user was migrated.
+// Idempotent: resources already assigned to an org are unchanged.
+//
+// In OIDC-only installs with no backfill org the function is a no-op.
+func BackfillOrgScopedSettings(ctx context.Context, db *sql.DB) error {
+	// Find the oldest backfill org (created by BackfillOIDCTables).
+	var legacyOrgID string
+	err := db.QueryRowContext(ctx,
+		`SELECT id FROM auth_organization WHERE source='backfill' ORDER BY created_at ASC LIMIT 1`,
+	).Scan(&legacyOrgID)
+	if err == sql.ErrNoRows {
+		return nil // no legacy org — fresh or OIDC-only install, nothing to do
+	}
+	if err != nil {
+		return fmt.Errorf("org backfill: find legacy org: %w", err)
+	}
+
+	tables := []string{"settings_agents", "settings_providers", "settings_channels", "auth_policies"}
+	for _, tbl := range tables {
+		res, err := db.ExecContext(ctx,
+			"UPDATE "+tbl+" SET org_id=? WHERE org_id IS NULL",
+			legacyOrgID,
+		)
+		if err != nil {
+			return fmt.Errorf("org backfill: update %s: %w", tbl, err)
+		}
+		n, _ := res.RowsAffected()
+		if n > 0 {
+			slog.Info("org backfill: assigned resources to legacy org", "table", tbl, "count", n, "org_id", legacyOrgID)
+		}
+	}
+	return nil
+}

--- a/internal/db/backfill_oidc.go
+++ b/internal/db/backfill_oidc.go
@@ -10,6 +10,47 @@ import (
 	"github.com/google/uuid"
 )
 
+// BackfillCredentials copies non-empty password_hash values from legacy auth_users
+// into auth_credential for any auth_user that lacks a credential row. It is
+// idempotent: rows that already exist are skipped.
+func BackfillCredentials(ctx context.Context, db *sql.DB) (int, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT u.id, u.password_hash
+		FROM auth_users u
+		INNER JOIN auth_user nu ON nu.id = u.id
+		LEFT JOIN auth_credential c ON c.user_id = u.id
+		WHERE u.password_hash != '' AND c.id IS NULL`)
+	if err != nil {
+		return 0, fmt.Errorf("credential backfill: query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	type row struct{ id, hash string }
+	var pending []row
+	for rows.Next() {
+		var r row
+		if err := rows.Scan(&r.id, &r.hash); err != nil {
+			return 0, fmt.Errorf("credential backfill: scan: %w", err)
+		}
+		pending = append(pending, r)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("credential backfill: iterate: %w", err)
+	}
+
+	for _, p := range pending {
+		credID := uuid.NewString()
+		_, err := db.ExecContext(ctx, `
+			INSERT OR IGNORE INTO auth_credential (id, user_id, password_hash)
+			VALUES (?, ?, ?)`, credID, p.id, p.hash)
+		if err != nil {
+			return 0, fmt.Errorf("credential backfill: insert for user %s: %w", p.id, err)
+		}
+		slog.Info("credential backfill: copied password hash", "user_id", p.id)
+	}
+	return len(pending), nil
+}
+
 // BackfillOIDCTables copies legacy auth data into the new OIDC tables on first
 // startup. It is idempotent: if auth_user already has rows it returns immediately.
 //

--- a/internal/db/backfill_org_test.go
+++ b/internal/db/backfill_org_test.go
@@ -1,0 +1,78 @@
+package db_test
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+
+	appdb "github.com/CherryHQ/stella/internal/db"
+)
+
+func TestBackfillOrgScopedSettingsNoOp(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "org_backfill_test.db")
+	db, err := appdb.OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	// No backfill orgs → should be a no-op.
+	if err := appdb.BackfillOrgScopedSettings(context.Background(), db); err != nil {
+		t.Fatalf("BackfillOrgScopedSettings: %v", err)
+	}
+}
+
+func TestBackfillOrgScopedSettingsAssignsToLegacyOrg(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "org_backfill2_test.db")
+	db, err := appdb.OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+	now := "2026-01-01 00:00:00"
+	orgID := uuid.NewString()
+
+	// Insert a backfill org.
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO auth_organization (id, name, external_id, source, created_at, updated_at) VALUES (?, ?, ?, 'backfill', ?, ?)`,
+		orgID, "Legacy Org", "ext1", now, now,
+	)
+	if err != nil {
+		t.Fatalf("insert org: %v", err)
+	}
+
+	// Insert an agent without org_id.
+	agentID := uuid.NewString()
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO settings_agents (id, name, workspace, model, soul) VALUES (?, 'TestAgent', '/tmp', '', '')`,
+		agentID,
+	)
+	if err != nil {
+		t.Fatalf("insert agent: %v", err)
+	}
+
+	// Run backfill.
+	if err := appdb.BackfillOrgScopedSettings(ctx, db); err != nil {
+		t.Fatalf("BackfillOrgScopedSettings: %v", err)
+	}
+
+	// Verify agent got org_id.
+	var gotOrgID sql.NullString
+	err = db.QueryRowContext(ctx, `SELECT org_id FROM settings_agents WHERE id=?`, agentID).Scan(&gotOrgID)
+	if err != nil {
+		t.Fatalf("query agent org_id: %v", err)
+	}
+	if !gotOrgID.Valid || gotOrgID.String != orgID {
+		t.Errorf("agent org_id = %v, want %q", gotOrgID, orgID)
+	}
+
+	// Running again should be idempotent (already assigned).
+	if err := appdb.BackfillOrgScopedSettings(ctx, db); err != nil {
+		t.Fatalf("BackfillOrgScopedSettings (second run): %v", err)
+	}
+}

--- a/internal/db/credential_test.go
+++ b/internal/db/credential_test.go
@@ -1,0 +1,172 @@
+package db_test
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/CherryHQ/stella/internal/auth"
+	appdb "github.com/CherryHQ/stella/internal/db"
+)
+
+func setupOIDCStore(t *testing.T) (*appdb.OIDCStore, context.Context) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "cred_test.db")
+	db, err := appdb.OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return appdb.NewOIDCStore(db), context.Background()
+}
+
+func createTestUser(t *testing.T, store *appdb.OIDCStore, ctx context.Context) auth.User {
+	t.Helper()
+	u, err := store.CreateUser(ctx, auth.User{
+		ID:    uuid.NewString(),
+		Email: uuid.NewString() + "@test.example",
+		Name:  "Test User",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	return u
+}
+
+func TestCredentialCreateAndGet(t *testing.T) {
+	store, ctx := setupOIDCStore(t)
+	u := createTestUser(t, store, ctx)
+
+	cred, err := store.CreateCredential(ctx, auth.Credential{
+		ID:           uuid.NewString(),
+		UserID:       u.ID,
+		PasswordHash: "$2a$12$fakehash",
+	})
+	if err != nil {
+		t.Fatalf("CreateCredential: %v", err)
+	}
+	if cred.UserID != u.ID {
+		t.Errorf("got user_id %q, want %q", cred.UserID, u.ID)
+	}
+
+	got, err := store.GetCredentialByUserID(ctx, u.ID)
+	if err != nil {
+		t.Fatalf("GetCredentialByUserID: %v", err)
+	}
+	if got.PasswordHash != "$2a$12$fakehash" {
+		t.Errorf("got hash %q, want %q", got.PasswordHash, "$2a$12$fakehash")
+	}
+}
+
+func TestCredentialGetNotFound(t *testing.T) {
+	store, ctx := setupOIDCStore(t)
+
+	_, err := store.GetCredentialByUserID(ctx, "nonexistent-user")
+	if !errors.Is(err, auth.ErrNotFound) {
+		t.Errorf("got error %v, want auth.ErrNotFound", err)
+	}
+}
+
+func TestCredentialUpdateHash(t *testing.T) {
+	store, ctx := setupOIDCStore(t)
+	u := createTestUser(t, store, ctx)
+
+	_, err := store.CreateCredential(ctx, auth.Credential{
+		ID:           uuid.NewString(),
+		UserID:       u.ID,
+		PasswordHash: "old-hash",
+	})
+	if err != nil {
+		t.Fatalf("CreateCredential: %v", err)
+	}
+
+	if err := store.UpdateCredentialHash(ctx, u.ID, "new-hash"); err != nil {
+		t.Fatalf("UpdateCredentialHash: %v", err)
+	}
+
+	got, err := store.GetCredentialByUserID(ctx, u.ID)
+	if err != nil {
+		t.Fatalf("GetCredentialByUserID: %v", err)
+	}
+	if got.PasswordHash != "new-hash" {
+		t.Errorf("got hash %q, want %q", got.PasswordHash, "new-hash")
+	}
+}
+
+func TestCredentialDelete(t *testing.T) {
+	store, ctx := setupOIDCStore(t)
+	u := createTestUser(t, store, ctx)
+
+	_, err := store.CreateCredential(ctx, auth.Credential{
+		ID:           uuid.NewString(),
+		UserID:       u.ID,
+		PasswordHash: "some-hash",
+	})
+	if err != nil {
+		t.Fatalf("CreateCredential: %v", err)
+	}
+
+	if err := store.DeleteCredential(ctx, u.ID); err != nil {
+		t.Fatalf("DeleteCredential: %v", err)
+	}
+
+	_, err = store.GetCredentialByUserID(ctx, u.ID)
+	if !errors.Is(err, auth.ErrNotFound) {
+		t.Errorf("after delete got error %v, want auth.ErrNotFound", err)
+	}
+}
+
+func TestBackfillCredentials(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "backfill_cred.db")
+	db, err := appdb.OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx := context.Background()
+
+	// Insert a legacy user with a password hash.
+	userID := uuid.NewString()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO auth_users (id, username, password_hash) VALUES (?, ?, ?)`,
+		userID, "legacyuser@example.com", "$2a$12$legacyhash"); err != nil {
+		t.Fatalf("insert legacy user: %v", err)
+	}
+
+	// Run OIDC backfill first (creates auth_user row).
+	if _, err := appdb.BackfillOIDCTables(ctx, db); err != nil {
+		t.Fatalf("BackfillOIDCTables: %v", err)
+	}
+
+	// Now backfill credentials.
+	n, err := appdb.BackfillCredentials(ctx, db)
+	if err != nil {
+		t.Fatalf("BackfillCredentials: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("BackfillCredentials returned %d, want 1", n)
+	}
+
+	// Verify credential was created.
+	store := appdb.NewOIDCStore(db)
+	cred, err := store.GetCredentialByUserID(ctx, userID)
+	if err != nil {
+		t.Fatalf("GetCredentialByUserID after backfill: %v", err)
+	}
+	if cred.PasswordHash != "$2a$12$legacyhash" {
+		t.Errorf("got hash %q, want %q", cred.PasswordHash, "$2a$12$legacyhash")
+	}
+
+	// Idempotency: running again should backfill 0.
+	n2, err := appdb.BackfillCredentials(ctx, db)
+	if err != nil {
+		t.Fatalf("BackfillCredentials (2nd run): %v", err)
+	}
+	if n2 != 0 {
+		t.Errorf("2nd BackfillCredentials returned %d, want 0", n2)
+	}
+}

--- a/internal/db/migrations/20260523154711_add-local-credentials.sql
+++ b/internal/db/migrations/20260523154711_add-local-credentials.sql
@@ -1,0 +1,14 @@
+-- Create "auth_credential" table
+CREATE TABLE `auth_credential` (
+  `id` text NOT NULL,
+  `user_id` text NOT NULL,
+  `password_hash` text NOT NULL,
+  `created_at` text NOT NULL DEFAULT (datetime('now')),
+  `updated_at` text NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (`id`),
+  CONSTRAINT `0` FOREIGN KEY (`user_id`) REFERENCES `auth_user` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Create index "auth_credential_user_id" to table: "auth_credential"
+CREATE UNIQUE INDEX `auth_credential_user_id` ON `auth_credential` (`user_id`);
+-- Create index "idx_auth_credential_user_id" to table: "auth_credential"
+CREATE INDEX `idx_auth_credential_user_id` ON `auth_credential` (`user_id`);

--- a/internal/db/migrations/20260524013342_add-local-oidc-issuer-tables.sql
+++ b/internal/db/migrations/20260524013342_add-local-oidc-issuer-tables.sql
@@ -1,0 +1,43 @@
+-- Create "auth_oidc_codes" table
+CREATE TABLE `auth_oidc_codes` (
+  `id` text NOT NULL,
+  `code_hash` text NOT NULL,
+  `user_id` text NOT NULL,
+  `org_id` text NOT NULL DEFAULT '',
+  `client_id` text NOT NULL,
+  `redirect_uri` text NOT NULL,
+  `scopes` text NOT NULL DEFAULT '[]',
+  `nonce` text NOT NULL DEFAULT '',
+  `pkce_challenge` text NOT NULL DEFAULT '',
+  `pkce_method` text NOT NULL DEFAULT 'S256',
+  `expires_at` text NOT NULL,
+  `consumed_at` text NULL,
+  `created_at` text NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (`id`),
+  CONSTRAINT `0` FOREIGN KEY (`user_id`) REFERENCES `auth_user` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Create index "auth_oidc_codes_code_hash" to table: "auth_oidc_codes"
+CREATE UNIQUE INDEX `auth_oidc_codes_code_hash` ON `auth_oidc_codes` (`code_hash`);
+-- Create index "idx_auth_oidc_codes_code_hash" to table: "auth_oidc_codes"
+CREATE INDEX `idx_auth_oidc_codes_code_hash` ON `auth_oidc_codes` (`code_hash`);
+-- Create index "idx_auth_oidc_codes_user_id" to table: "auth_oidc_codes"
+CREATE INDEX `idx_auth_oidc_codes_user_id` ON `auth_oidc_codes` (`user_id`);
+-- Create "auth_oidc_access_tokens" table
+CREATE TABLE `auth_oidc_access_tokens` (
+  `id` text NOT NULL,
+  `token_hash` text NOT NULL,
+  `user_id` text NOT NULL,
+  `org_id` text NOT NULL DEFAULT '',
+  `client_id` text NOT NULL,
+  `scopes` text NOT NULL DEFAULT '[]',
+  `expires_at` text NOT NULL,
+  `created_at` text NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (`id`),
+  CONSTRAINT `0` FOREIGN KEY (`user_id`) REFERENCES `auth_user` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Create index "auth_oidc_access_tokens_token_hash" to table: "auth_oidc_access_tokens"
+CREATE UNIQUE INDEX `auth_oidc_access_tokens_token_hash` ON `auth_oidc_access_tokens` (`token_hash`);
+-- Create index "idx_auth_oidc_access_tokens_token_hash" to table: "auth_oidc_access_tokens"
+CREATE INDEX `idx_auth_oidc_access_tokens_token_hash` ON `auth_oidc_access_tokens` (`token_hash`);
+-- Create index "idx_auth_oidc_access_tokens_user_id" to table: "auth_oidc_access_tokens"
+CREATE INDEX `idx_auth_oidc_access_tokens_user_id` ON `auth_oidc_access_tokens` (`user_id`);

--- a/internal/db/migrations/20260524020802_add-org-scoped-settings.sql
+++ b/internal/db/migrations/20260524020802_add-org-scoped-settings.sql
@@ -1,0 +1,102 @@
+-- Disable the enforcement of foreign-keys constraints
+PRAGMA foreign_keys = off;
+-- Create "new_auth_policies" table
+CREATE TABLE `new_auth_policies` (
+  `id` text NULL,
+  `name` text NOT NULL,
+  `effect` text NOT NULL,
+  `subjects` text NOT NULL DEFAULT '{}',
+  `actions` text NOT NULL DEFAULT '[]',
+  `resources` text NOT NULL DEFAULT '[]',
+  `conditions` text NOT NULL DEFAULT '{}',
+  `priority` integer NOT NULL DEFAULT 0,
+  `is_system` integer NOT NULL DEFAULT 0,
+  `enabled` integer NOT NULL DEFAULT 1,
+  `org_id` text NULL,
+  `created_at` text NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (`id`),
+  CONSTRAINT `0` FOREIGN KEY (`org_id`) REFERENCES `auth_organization` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+  CHECK (effect IN ('allow', 'deny'))
+);
+-- Copy rows from old table "auth_policies" to new temporary table "new_auth_policies"
+INSERT INTO `new_auth_policies` (`id`, `name`, `effect`, `subjects`, `actions`, `resources`, `conditions`, `priority`, `is_system`, `enabled`, `created_at`) SELECT `id`, `name`, `effect`, `subjects`, `actions`, `resources`, `conditions`, `priority`, `is_system`, `enabled`, `created_at` FROM `auth_policies`;
+-- Drop "auth_policies" table after copying rows
+DROP TABLE `auth_policies`;
+-- Rename temporary table "new_auth_policies" to "auth_policies"
+ALTER TABLE `new_auth_policies` RENAME TO `auth_policies`;
+-- Create index "idx_auth_policies_org_id" to table: "auth_policies"
+CREATE INDEX `idx_auth_policies_org_id` ON `auth_policies` (`org_id`);
+-- Create "new_settings_providers" table
+CREATE TABLE `new_settings_providers` (
+  `id` text NULL,
+  `type` text NOT NULL,
+  `name` text NOT NULL,
+  `enabled` integer NOT NULL DEFAULT 1,
+  `config` text NOT NULL DEFAULT '{}',
+  `org_id` text NULL,
+  `created_at` text NOT NULL DEFAULT (datetime('now')),
+  `updated_at` text NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (`id`),
+  CONSTRAINT `0` FOREIGN KEY (`org_id`) REFERENCES `auth_organization` (`id`) ON UPDATE NO ACTION ON DELETE SET NULL
+);
+-- Copy rows from old table "settings_providers" to new temporary table "new_settings_providers"
+INSERT INTO `new_settings_providers` (`id`, `type`, `name`, `enabled`, `config`, `created_at`, `updated_at`) SELECT `id`, `type`, `name`, `enabled`, `config`, `created_at`, `updated_at` FROM `settings_providers`;
+-- Drop "settings_providers" table after copying rows
+DROP TABLE `settings_providers`;
+-- Rename temporary table "new_settings_providers" to "settings_providers"
+ALTER TABLE `new_settings_providers` RENAME TO `settings_providers`;
+-- Create index "idx_settings_providers_org_id" to table: "settings_providers"
+CREATE INDEX `idx_settings_providers_org_id` ON `settings_providers` (`org_id`);
+-- Create "new_settings_channels" table
+CREATE TABLE `new_settings_channels` (
+  `id` text NULL,
+  `type` text NOT NULL DEFAULT '',
+  `agent_id` text NULL,
+  `enabled` integer NOT NULL DEFAULT 1,
+  `config` text NOT NULL DEFAULT '{}',
+  `org_id` text NULL,
+  `created_at` text NOT NULL DEFAULT (datetime('now')),
+  `updated_at` text NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (`id`),
+  CONSTRAINT `0` FOREIGN KEY (`org_id`) REFERENCES `auth_organization` (`id`) ON UPDATE NO ACTION ON DELETE SET NULL,
+  CONSTRAINT `1` FOREIGN KEY (`agent_id`) REFERENCES `settings_agents` (`id`) ON UPDATE NO ACTION ON DELETE SET NULL
+);
+-- Copy rows from old table "settings_channels" to new temporary table "new_settings_channels"
+INSERT INTO `new_settings_channels` (`id`, `type`, `agent_id`, `enabled`, `config`, `created_at`, `updated_at`) SELECT `id`, `type`, `agent_id`, `enabled`, `config`, `created_at`, `updated_at` FROM `settings_channels`;
+-- Drop "settings_channels" table after copying rows
+DROP TABLE `settings_channels`;
+-- Rename temporary table "new_settings_channels" to "settings_channels"
+ALTER TABLE `new_settings_channels` RENAME TO `settings_channels`;
+-- Create index "idx_settings_channels_org_id" to table: "settings_channels"
+CREATE INDEX `idx_settings_channels_org_id` ON `settings_channels` (`org_id`);
+-- Create "new_settings_agents" table
+CREATE TABLE `new_settings_agents` (
+  `id` text NULL,
+  `name` text NOT NULL,
+  `model` text NOT NULL DEFAULT '',
+  `model_strong` text NOT NULL DEFAULT '',
+  `model_fast` text NOT NULL DEFAULT '',
+  `system_prompt` text NOT NULL DEFAULT '',
+  `soul` text NOT NULL DEFAULT '',
+  `workspace` text NOT NULL,
+  `sandbox` text NOT NULL DEFAULT '{}',
+  `enabled_builtin_skills` text NOT NULL DEFAULT '[]',
+  `scope` text NOT NULL DEFAULT 'system',
+  `creator_id` text NOT NULL DEFAULT '',
+  `enabled` integer NOT NULL DEFAULT 1,
+  `org_id` text NULL,
+  `created_at` text NOT NULL DEFAULT (datetime('now')),
+  `updated_at` text NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (`id`),
+  CONSTRAINT `0` FOREIGN KEY (`org_id`) REFERENCES `auth_organization` (`id`) ON UPDATE NO ACTION ON DELETE SET NULL
+);
+-- Copy rows from old table "settings_agents" to new temporary table "new_settings_agents"
+INSERT INTO `new_settings_agents` (`id`, `name`, `model`, `model_strong`, `model_fast`, `system_prompt`, `soul`, `workspace`, `sandbox`, `enabled_builtin_skills`, `scope`, `creator_id`, `enabled`, `created_at`, `updated_at`) SELECT `id`, `name`, `model`, `model_strong`, `model_fast`, `system_prompt`, `soul`, `workspace`, `sandbox`, `enabled_builtin_skills`, `scope`, `creator_id`, `enabled`, `created_at`, `updated_at` FROM `settings_agents`;
+-- Drop "settings_agents" table after copying rows
+DROP TABLE `settings_agents`;
+-- Rename temporary table "new_settings_agents" to "settings_agents"
+ALTER TABLE `new_settings_agents` RENAME TO `settings_agents`;
+-- Create index "idx_settings_agents_org_id" to table: "settings_agents"
+CREATE INDEX `idx_settings_agents_org_id` ON `settings_agents` (`org_id`);
+-- Enable back the enforcement of foreign-keys constraints
+PRAGMA foreign_keys = on;

--- a/internal/db/migrations/atlas.sum
+++ b/internal/db/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:plNPH61eUkZjT9LssbdTYOAOLQYZ9P4U94MzLLSj1fo=
+h1:DAO9nFOvZdXgS0V3rcGps/Gl7Rvxl0C/LR8MEsSh0ok=
 20260317041843_rename_tables_with_prefixes.sql h1:Nfk81sAWddxDQvpo8pBhXJ5Sec5JcCF6tchqgt+777M=
 20260317065837_drop_agent_provider_id.sql h1:gb4CoI8GlT4P3QbksGw07M8SruOcR9pQI0Sj7/Q2rao=
 20260320104110_add-auth-tables.sql h1:6TjzFFeMMTJzy3/mGN4nrm4+SoYGhanOQY24nUbL3H4=
@@ -44,3 +44,4 @@ h1:plNPH61eUkZjT9LssbdTYOAOLQYZ9P4U94MzLLSj1fo=
 20260523114254_auth-oidc-redesign.sql h1:KTjA01cTWXvhM7K0O7cvtoazG4Xh9kaOoBspUqE0P7c=
 20260523154711_add-local-credentials.sql h1:DL/OEw4jpyiBdyF7J9XyZB5pGmBHVHu29QAzx+3FhSE=
 20260524013342_add-local-oidc-issuer-tables.sql h1:5dbM9OQEA1z57YWbThiWMbK3oWgaRsISOtkE0a1H9aQ=
+20260524020802_add-org-scoped-settings.sql h1:cXvcKNb0h+x5vMrApFZ+43aISqxutRc31NgoY6IsOJQ=

--- a/internal/db/migrations/atlas.sum
+++ b/internal/db/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:tK9dqBIHaYGjoBQxTI1X/DMCHjzYWMFG/4NrITbZs/A=
+h1:plNPH61eUkZjT9LssbdTYOAOLQYZ9P4U94MzLLSj1fo=
 20260317041843_rename_tables_with_prefixes.sql h1:Nfk81sAWddxDQvpo8pBhXJ5Sec5JcCF6tchqgt+777M=
 20260317065837_drop_agent_provider_id.sql h1:gb4CoI8GlT4P3QbksGw07M8SruOcR9pQI0Sj7/Q2rao=
 20260320104110_add-auth-tables.sql h1:6TjzFFeMMTJzy3/mGN4nrm4+SoYGhanOQY24nUbL3H4=
@@ -42,3 +42,5 @@ h1:tK9dqBIHaYGjoBQxTI1X/DMCHjzYWMFG/4NrITbZs/A=
 20260520020614_add_share.sql h1:c/dJy9ho0RWdWh3xJVaByMcxQeNN1Q2DJOXyBXNwIgU=
 20260521150045_agent_user_scoped_skills.sql h1:o2+NCfEBQjyD/CW6ei3q9n2QkX4BKzVN4wALIWEkLPM=
 20260523114254_auth-oidc-redesign.sql h1:KTjA01cTWXvhM7K0O7cvtoazG4Xh9kaOoBspUqE0P7c=
+20260523154711_add-local-credentials.sql h1:DL/OEw4jpyiBdyF7J9XyZB5pGmBHVHu29QAzx+3FhSE=
+20260524013342_add-local-oidc-issuer-tables.sql h1:5dbM9OQEA1z57YWbThiWMbK3oWgaRsISOtkE0a1H9aQ=

--- a/internal/db/oidc_issuer_test.go
+++ b/internal/db/oidc_issuer_test.go
@@ -1,0 +1,182 @@
+package db_test
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/CherryHQ/stella/internal/auth"
+	appdb "github.com/CherryHQ/stella/internal/db"
+)
+
+func setupOIDCIssuerStore(t *testing.T) (*appdb.OIDCStore, context.Context) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "issuer_test.db")
+	db, err := appdb.OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return appdb.NewOIDCStore(db), context.Background()
+}
+
+func createIssuerTestUser(t *testing.T, store *appdb.OIDCStore, ctx context.Context) auth.User {
+	t.Helper()
+	u, err := store.CreateUser(ctx, auth.User{
+		ID:    uuid.NewString(),
+		Email: uuid.NewString() + "@issuer.example",
+		Name:  "Issuer Test User",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	return u
+}
+
+func TestOIDCCodeCreateAndConsume(t *testing.T) {
+	store, ctx := setupOIDCIssuerStore(t)
+	u := createIssuerTestUser(t, store, ctx)
+
+	code, err := store.CreateOIDCCode(ctx, auth.OIDCCode{
+		ID:            uuid.NewString(),
+		CodeHash:      "hash1",
+		UserID:        u.ID,
+		OrgID:         "org1",
+		ClientID:      "client1",
+		RedirectURI:   "http://localhost/callback",
+		Scopes:        []string{"openid", "email"},
+		Nonce:         "nonce1",
+		PKCEChallenge: "challenge1",
+		PKCEMethod:    "S256",
+		ExpiresAt:     time.Now().Add(2 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("CreateOIDCCode: %v", err)
+	}
+	if code.CodeHash != "hash1" {
+		t.Errorf("code_hash %q, want hash1", code.CodeHash)
+	}
+
+	// Consume succeeds.
+	consumed, err := store.ConsumeOIDCCode(ctx, "hash1")
+	if err != nil {
+		t.Fatalf("ConsumeOIDCCode: %v", err)
+	}
+	if consumed.ConsumedAt == nil {
+		t.Error("consumed_at should be set")
+	}
+	if len(consumed.Scopes) != 2 {
+		t.Errorf("scopes len %d, want 2", len(consumed.Scopes))
+	}
+
+	// Second consume returns ErrAlreadyConsumed.
+	_, err = store.ConsumeOIDCCode(ctx, "hash1")
+	if !errors.Is(err, auth.ErrAlreadyConsumed) {
+		t.Errorf("second consume: got %v, want ErrAlreadyConsumed", err)
+	}
+}
+
+func TestOIDCCodeNotFound(t *testing.T) {
+	store, ctx := setupOIDCIssuerStore(t)
+	_, err := store.ConsumeOIDCCode(ctx, "no-such-hash")
+	if !errors.Is(err, auth.ErrNotFound) {
+		t.Errorf("not found: got %v, want ErrNotFound", err)
+	}
+}
+
+func TestOIDCCodeExpired(t *testing.T) {
+	store, ctx := setupOIDCIssuerStore(t)
+	u := createIssuerTestUser(t, store, ctx)
+
+	_, err := store.CreateOIDCCode(ctx, auth.OIDCCode{
+		ID:        uuid.NewString(),
+		CodeHash:  "expiredhash",
+		UserID:    u.ID,
+		ClientID:  "client",
+		ExpiresAt: time.Now().Add(-time.Minute), // already expired
+	})
+	if err != nil {
+		t.Fatalf("CreateOIDCCode: %v", err)
+	}
+
+	_, err = store.ConsumeOIDCCode(ctx, "expiredhash")
+	if !errors.Is(err, auth.ErrExpired) {
+		t.Errorf("expired: got %v, want ErrExpired", err)
+	}
+}
+
+func TestOIDCAccessTokenCreateAndGet(t *testing.T) {
+	store, ctx := setupOIDCIssuerStore(t)
+	u := createIssuerTestUser(t, store, ctx)
+
+	tok, err := store.CreateOIDCAccessToken(ctx, auth.OIDCAccessToken{
+		ID:        uuid.NewString(),
+		TokenHash: "tokenhash1",
+		UserID:    u.ID,
+		OrgID:     "org1",
+		ClientID:  "client1",
+		Scopes:    []string{"openid", "email", "profile"},
+		ExpiresAt: time.Now().Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("CreateOIDCAccessToken: %v", err)
+	}
+	if tok.TokenHash != "tokenhash1" {
+		t.Errorf("token_hash %q, want tokenhash1", tok.TokenHash)
+	}
+
+	got, err := store.GetOIDCAccessTokenByHash(ctx, "tokenhash1")
+	if err != nil {
+		t.Fatalf("GetOIDCAccessTokenByHash: %v", err)
+	}
+	if got.UserID != u.ID {
+		t.Errorf("user_id %q, want %s", got.UserID, u.ID)
+	}
+	if len(got.Scopes) != 3 {
+		t.Errorf("scopes len %d, want 3", len(got.Scopes))
+	}
+}
+
+func TestOIDCAccessTokenNotFound(t *testing.T) {
+	store, ctx := setupOIDCIssuerStore(t)
+	_, err := store.GetOIDCAccessTokenByHash(ctx, "nonexistent")
+	if !errors.Is(err, auth.ErrNotFound) {
+		t.Errorf("got %v, want ErrNotFound", err)
+	}
+}
+
+func TestDeleteExpiredOIDCAccessTokens(t *testing.T) {
+	store, ctx := setupOIDCIssuerStore(t)
+	u := createIssuerTestUser(t, store, ctx)
+
+	// Create one expired and one valid token.
+	_, _ = store.CreateOIDCAccessToken(ctx, auth.OIDCAccessToken{
+		ID:        uuid.NewString(),
+		TokenHash: "expired1",
+		UserID:    u.ID,
+		ExpiresAt: time.Now().Add(-time.Hour),
+	})
+	_, _ = store.CreateOIDCAccessToken(ctx, auth.OIDCAccessToken{
+		ID:        uuid.NewString(),
+		TokenHash: "valid1",
+		UserID:    u.ID,
+		ExpiresAt: time.Now().Add(time.Hour),
+	})
+
+	if err := store.DeleteExpiredOIDCAccessTokens(ctx); err != nil {
+		t.Fatalf("DeleteExpiredOIDCAccessTokens: %v", err)
+	}
+
+	_, err := store.GetOIDCAccessTokenByHash(ctx, "expired1")
+	if !errors.Is(err, auth.ErrNotFound) {
+		t.Errorf("expired token should be deleted, got %v", err)
+	}
+	_, err = store.GetOIDCAccessTokenByHash(ctx, "valid1")
+	if err != nil {
+		t.Errorf("valid token should still exist: %v", err)
+	}
+}

--- a/internal/db/queries/settings_agents.sql
+++ b/internal/db/queries/settings_agents.sql
@@ -30,3 +30,12 @@ WHERE id = ?;
 
 -- name: DeleteAgent :exec
 DELETE FROM settings_agents WHERE id = ?;
+
+-- name: ListAgentsByOrg :many
+SELECT * FROM settings_agents WHERE org_id = ? ORDER BY name;
+
+-- name: ListEnabledAgentsByOrg :many
+SELECT * FROM settings_agents WHERE org_id = ? AND enabled = 1 ORDER BY name;
+
+-- name: SetAgentOrg :exec
+UPDATE settings_agents SET org_id = ? WHERE id = ?;

--- a/internal/db/queries/settings_channels.sql
+++ b/internal/db/queries/settings_channels.sql
@@ -19,3 +19,12 @@ SELECT * FROM settings_channels WHERE type = ? ORDER BY id;
 
 -- name: DeleteChannel :exec
 DELETE FROM settings_channels WHERE id = ?;
+
+-- name: ListChannelsByOrg :many
+SELECT * FROM settings_channels WHERE org_id = ? ORDER BY type, id;
+
+-- name: ListChannelsByTypeAndOrg :many
+SELECT * FROM settings_channels WHERE type = ? AND org_id = ? ORDER BY id;
+
+-- name: SetChannelOrg :exec
+UPDATE settings_channels SET org_id = ? WHERE id = ?;

--- a/internal/db/queries/settings_providers.sql
+++ b/internal/db/queries/settings_providers.sql
@@ -27,3 +27,12 @@ DELETE FROM settings_providers WHERE id = ?;
 -- name: SeedProvider :exec
 INSERT OR IGNORE INTO settings_providers (id, type, name, enabled, config)
 VALUES (?, ?, ?, ?, ?);
+
+-- name: ListProvidersByOrg :many
+SELECT * FROM settings_providers WHERE org_id = ? ORDER BY name, id;
+
+-- name: ListEnabledProvidersByOrg :many
+SELECT * FROM settings_providers WHERE org_id = ? AND enabled = 1 ORDER BY name, id;
+
+-- name: SetProviderOrg :exec
+UPDATE settings_providers SET org_id = ? WHERE id = ?;

--- a/internal/db/schemas/main.sql
+++ b/internal/db/schemas/main.sql
@@ -29,6 +29,9 @@
 -- atlas:import tables/oidc/auth_identity.sql
 -- atlas:import tables/oidc/auth_session.sql
 -- atlas:import tables/oidc/auth_membership.sql
+-- atlas:import tables/oidc/auth_credential.sql
+-- atlas:import tables/oidc/auth_oidc_codes.sql
+-- atlas:import tables/oidc/auth_oidc_access_tokens.sql
 -- atlas:import tables/shares.sql
 -- atlas:import tables/plugin_state_entries.sql
 -- atlas:import tables/skills.sql

--- a/internal/db/schemas/main.sql
+++ b/internal/db/schemas/main.sql
@@ -1,3 +1,5 @@
+-- New OIDC auth tables first (settings tables reference auth_organization)
+-- atlas:import tables/oidc/auth_organization.sql
 -- atlas:import tables/settings.sql
 -- atlas:import tables/settings_agents.sql
 -- atlas:import tables/settings_channels.sql
@@ -22,8 +24,7 @@
 -- atlas:import tables/auth_user_agents.sql
 -- atlas:import tables/auth_sessions.sql
 -- atlas:import tables/auth_user_tokens.sql
--- New OIDC auth tables (additive migration — old tables above are kept unchanged)
--- atlas:import tables/oidc/auth_organization.sql
+-- Remaining OIDC auth tables
 -- atlas:import tables/oidc/auth_user.sql
 -- atlas:import tables/oidc/channel_identity.sql
 -- atlas:import tables/oidc/auth_identity.sql

--- a/internal/db/schemas/tables/auth_policies.sql
+++ b/internal/db/schemas/tables/auth_policies.sql
@@ -9,5 +9,8 @@ CREATE TABLE auth_policies (
     priority   INTEGER NOT NULL DEFAULT 0,
     is_system  INTEGER NOT NULL DEFAULT 0,
     enabled    INTEGER NOT NULL DEFAULT 1,
+    org_id     TEXT REFERENCES auth_organization(id) ON DELETE CASCADE,
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
+
+CREATE INDEX idx_auth_policies_org_id ON auth_policies(org_id);

--- a/internal/db/schemas/tables/oidc/auth_credential.sql
+++ b/internal/db/schemas/tables/oidc/auth_credential.sql
@@ -1,0 +1,10 @@
+CREATE TABLE auth_credential (
+    id           TEXT NOT NULL PRIMARY KEY,
+    user_id      TEXT NOT NULL REFERENCES auth_user(id) ON DELETE CASCADE,
+    password_hash TEXT NOT NULL,
+    created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at   TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(user_id)
+);
+
+CREATE INDEX idx_auth_credential_user_id ON auth_credential(user_id);

--- a/internal/db/schemas/tables/oidc/auth_oidc_access_tokens.sql
+++ b/internal/db/schemas/tables/oidc/auth_oidc_access_tokens.sql
@@ -1,0 +1,13 @@
+CREATE TABLE auth_oidc_access_tokens (
+    id         TEXT NOT NULL PRIMARY KEY,
+    token_hash TEXT NOT NULL UNIQUE,
+    user_id    TEXT NOT NULL REFERENCES auth_user(id) ON DELETE CASCADE,
+    org_id     TEXT NOT NULL DEFAULT '',
+    client_id  TEXT NOT NULL,
+    scopes     TEXT NOT NULL DEFAULT '[]',
+    expires_at TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_auth_oidc_access_tokens_token_hash ON auth_oidc_access_tokens(token_hash);
+CREATE INDEX idx_auth_oidc_access_tokens_user_id ON auth_oidc_access_tokens(user_id);

--- a/internal/db/schemas/tables/oidc/auth_oidc_codes.sql
+++ b/internal/db/schemas/tables/oidc/auth_oidc_codes.sql
@@ -1,0 +1,18 @@
+CREATE TABLE auth_oidc_codes (
+    id             TEXT NOT NULL PRIMARY KEY,
+    code_hash      TEXT NOT NULL UNIQUE,
+    user_id        TEXT NOT NULL REFERENCES auth_user(id) ON DELETE CASCADE,
+    org_id         TEXT NOT NULL DEFAULT '',
+    client_id      TEXT NOT NULL,
+    redirect_uri   TEXT NOT NULL,
+    scopes         TEXT NOT NULL DEFAULT '[]',
+    nonce          TEXT NOT NULL DEFAULT '',
+    pkce_challenge TEXT NOT NULL DEFAULT '',
+    pkce_method    TEXT NOT NULL DEFAULT 'S256',
+    expires_at     TEXT NOT NULL,
+    consumed_at    TEXT,
+    created_at     TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_auth_oidc_codes_code_hash ON auth_oidc_codes(code_hash);
+CREATE INDEX idx_auth_oidc_codes_user_id ON auth_oidc_codes(user_id);

--- a/internal/db/schemas/tables/settings_agents.sql
+++ b/internal/db/schemas/tables/settings_agents.sql
@@ -12,6 +12,9 @@ CREATE TABLE settings_agents (
     scope         TEXT NOT NULL DEFAULT 'system',
     creator_id    TEXT NOT NULL DEFAULT '',
     enabled       INTEGER NOT NULL DEFAULT 1,
+    org_id        TEXT REFERENCES auth_organization(id) ON DELETE SET NULL,
     created_at    TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at    TEXT NOT NULL DEFAULT (datetime('now'))
 );
+
+CREATE INDEX idx_settings_agents_org_id ON settings_agents(org_id);

--- a/internal/db/schemas/tables/settings_channels.sql
+++ b/internal/db/schemas/tables/settings_channels.sql
@@ -4,6 +4,9 @@ CREATE TABLE settings_channels (
     agent_id   TEXT REFERENCES settings_agents(id) ON DELETE SET NULL,
     enabled    INTEGER NOT NULL DEFAULT 1,
     config     TEXT NOT NULL DEFAULT '{}',
+    org_id     TEXT REFERENCES auth_organization(id) ON DELETE SET NULL,
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
+
+CREATE INDEX idx_settings_channels_org_id ON settings_channels(org_id);

--- a/internal/db/schemas/tables/settings_providers.sql
+++ b/internal/db/schemas/tables/settings_providers.sql
@@ -4,6 +4,9 @@ CREATE TABLE settings_providers (
     name       TEXT NOT NULL,
     enabled    INTEGER NOT NULL DEFAULT 1,
     config     TEXT NOT NULL DEFAULT '{}',
+    org_id     TEXT REFERENCES auth_organization(id) ON DELETE SET NULL,
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
+
+CREATE INDEX idx_settings_providers_org_id ON settings_providers(org_id);

--- a/internal/pluginhost/host_test.go
+++ b/internal/pluginhost/host_test.go
@@ -17,17 +17,25 @@ func (s *stubStore) ListProviders(context.Context) ([]config.Provider, error) { 
 func (s *stubStore) GetProvider(context.Context, string) (config.Provider, error) {
 	return config.Provider{}, nil
 }
-func (s *stubStore) CreateProvider(context.Context, config.Provider) error     { return nil }
-func (s *stubStore) UpdateProvider(context.Context, config.Provider) error     { return nil }
-func (s *stubStore) DeleteProvider(context.Context, string) error              { return nil }
+func (s *stubStore) CreateProvider(context.Context, config.Provider) error { return nil }
+func (s *stubStore) UpdateProvider(context.Context, config.Provider) error { return nil }
+func (s *stubStore) DeleteProvider(context.Context, string) error          { return nil }
+func (s *stubStore) ListProvidersForOrg(context.Context, string) ([]config.Provider, error) {
+	return nil, nil
+}
+func (s *stubStore) SetProviderOrg(context.Context, string, string) error      { return nil }
 func (s *stubStore) ListAgents(context.Context) ([]config.Agent, error)        { return nil, nil }
 func (s *stubStore) ListEnabledAgents(context.Context) ([]config.Agent, error) { return nil, nil }
 func (s *stubStore) GetAgent(context.Context, string) (config.Agent, error) {
 	return config.Agent{}, nil
 }
-func (s *stubStore) CreateAgent(context.Context, config.Agent) error        { return nil }
-func (s *stubStore) UpdateAgent(context.Context, config.Agent) error        { return nil }
-func (s *stubStore) DeleteAgent(context.Context, string) error              { return nil }
+func (s *stubStore) CreateAgent(context.Context, config.Agent) error { return nil }
+func (s *stubStore) UpdateAgent(context.Context, config.Agent) error { return nil }
+func (s *stubStore) DeleteAgent(context.Context, string) error       { return nil }
+func (s *stubStore) ListAgentsForOrg(context.Context, string) ([]config.Agent, error) {
+	return nil, nil
+}
+func (s *stubStore) SetAgentOrg(context.Context, string, string) error      { return nil }
 func (s *stubStore) ListChannels(context.Context) ([]config.Channel, error) { return nil, nil }
 func (s *stubStore) ListChannelsByType(context.Context, string) ([]config.Channel, error) {
 	return nil, nil
@@ -38,6 +46,10 @@ func (s *stubStore) GetChannel(context.Context, string) (config.Channel, error) 
 }
 func (s *stubStore) UpsertChannel(context.Context, config.Channel) error { return nil }
 func (s *stubStore) DeleteChannel(context.Context, string) error         { return nil }
+func (s *stubStore) ListChannelsForOrg(context.Context, string) ([]config.Channel, error) {
+	return nil, nil
+}
+func (s *stubStore) SetChannelOrg(context.Context, string, string) error { return nil }
 func (s *stubStore) ListPlugins(context.Context) ([]config.Plugin, error) {
 	plugins := make([]config.Plugin, 0, len(s.plugins))
 	for _, plugin := range s.plugins {

--- a/internal/server/agents.go
+++ b/internal/server/agents.go
@@ -54,13 +54,21 @@ func (s *Server) ListAgents(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	info := UserFromContext(ctx)
 
-	agents, err := s.store.ListAgents(ctx)
+	var (
+		agents []config.Agent
+		err    error
+	)
+	if info != nil && info.OrgID != "" {
+		agents, err = s.store.ListAgentsForOrg(ctx, info.OrgID)
+	} else {
+		agents, err = s.store.ListAgents(ctx)
+	}
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
-	// Admin sees all agents. Non-admin users see only accessible agents.
+	// Admin sees all agents in scope. Non-admin users see only accessible agents.
 	if info != nil && !info.IsAdmin {
 		agents, err = s.filterAccessibleAgents(ctx, info, agents)
 		if err != nil {
@@ -139,6 +147,15 @@ func (s *Server) CreateAgent(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+
+	// Stamp org when the creating user belongs to one.
+	if info != nil && info.OrgID != "" {
+		if err := s.store.SetAgentOrg(ctx, a.ID, info.OrgID); err != nil {
+			s.log.Error("stamp agent org", "agent_id", a.ID, "org_id", info.OrgID, "error", err)
+		}
+		a.OrgID = info.OrgID
+	}
+
 	if s.poolManager != nil {
 		if err := s.poolManager.SyncAgent(ctx, a.ID); err != nil {
 			s.log.Error("sync agent pool after create", "agent_id", a.ID, "error", err)
@@ -165,6 +182,12 @@ func (s *Server) GetAgent(w http.ResponseWriter, r *http.Request, id string) {
 		return
 	}
 
+	// Block cross-org access when the caller belongs to an org.
+	if info != nil && info.OrgID != "" && a.OrgID != "" && a.OrgID != info.OrgID {
+		writeError(w, http.StatusForbidden, "agent not found")
+		return
+	}
+
 	// Non-admin users can only access system or assigned agents.
 	if info != nil && !info.IsAdmin {
 		if !s.canAccessAgent(ctx, info, a) {
@@ -185,6 +208,11 @@ func (s *Server) UpdateAgent(w http.ResponseWriter, r *http.Request, id string) 
 	existing, err := s.store.GetAgent(ctx, id)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "agent not found")
+		return
+	}
+	// Block cross-org write.
+	if info != nil && info.OrgID != "" && existing.OrgID != "" && existing.OrgID != info.OrgID {
+		writeError(w, http.StatusForbidden, "agent not found")
 		return
 	}
 	if info != nil && !info.IsAdmin && existing.CreatorID != info.UserID {
@@ -240,6 +268,11 @@ func (s *Server) DeleteAgent(w http.ResponseWriter, r *http.Request, id string) 
 	existing, err := s.store.GetAgent(ctx, id)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "agent not found")
+		return
+	}
+	// Block cross-org delete.
+	if info != nil && info.OrgID != "" && existing.OrgID != "" && existing.OrgID != info.OrgID {
+		writeError(w, http.StatusForbidden, "agent not found")
 		return
 	}
 	if info != nil && existing.CreatorID != info.UserID {

--- a/internal/server/auth_users.go
+++ b/internal/server/auth_users.go
@@ -29,11 +29,20 @@ func (s *Server) buildAuthUserResponse(r *http.Request, u auth.AuthUser) (authUs
 		return authUserResponse{}, fmt.Errorf("list identities: %w", err)
 	}
 
+	role := u.Role
+	isActive := u.IsActive
+	if s.memberships != nil {
+		if m, err := s.memberships.GetUserMembership(r.Context(), u.ID); err == nil {
+			role = m.Role
+			isActive = m.IsActive
+		}
+	}
+
 	return authUserResponse{
 		ID:         u.ID,
 		Username:   u.Username,
-		Role:       u.Role,
-		IsActive:   u.IsActive,
+		Role:       role,
+		IsActive:   isActive,
 		Identities: identities,
 		CreatedAt:  u.CreatedAt.Format("2006-01-02 15:04:05"),
 		UpdatedAt:  u.UpdatedAt.Format("2006-01-02 15:04:05"),
@@ -112,6 +121,13 @@ func (s *Server) UpdateAuthUserRole(w http.ResponseWriter, r *http.Request, id s
 	if err := s.authStore.UpdateUserRole(r.Context(), id, body.Role); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to update role: "+err.Error())
 		return
+	}
+
+	// Mirror the role change to auth_membership when available.
+	if s.memberships != nil {
+		if m, err := s.memberships.GetUserMembership(r.Context(), id); err == nil {
+			_ = s.memberships.UpdateMembershipRole(r.Context(), m.ID, body.Role)
+		}
 	}
 
 	writeData(w, http.StatusOK, map[string]string{"status": "updated"})
@@ -248,6 +264,13 @@ func (s *Server) UpdateAuthUserActive(w http.ResponseWriter, r *http.Request, id
 	if err := s.authStore.UpdateUser(r.Context(), u); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to update user: "+err.Error())
 		return
+	}
+
+	// Mirror the active change to auth_membership when available.
+	if s.memberships != nil {
+		if m, err := s.memberships.GetUserMembership(r.Context(), id); err == nil {
+			_ = s.memberships.UpdateMembershipActive(r.Context(), m.ID, body.IsActive)
+		}
 	}
 
 	// If deactivating, delete all their sessions to force logout.

--- a/internal/server/auth_users.go
+++ b/internal/server/auth_users.go
@@ -1,8 +1,11 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
+
+	"github.com/google/uuid"
 
 	"github.com/CherryHQ/stella/internal/auth"
 )
@@ -253,4 +256,105 @@ func (s *Server) UpdateAuthUserActive(w http.ResponseWriter, r *http.Request, id
 	}
 
 	writeData(w, http.StatusOK, map[string]string{"status": "updated"})
+}
+
+// ListAuthUserLoginIdentities handles GET /api/auth/users/{id}/identities/login.
+func (s *Server) ListAuthUserLoginIdentities(w http.ResponseWriter, r *http.Request, id string) {
+	if !requireAdmin(w, r) {
+		return
+	}
+	if s.logins == nil {
+		writeData(w, http.StatusOK, []auth.LoginIdentity{})
+		return
+	}
+	if _, err := s.authStore.GetUser(r.Context(), id); err != nil {
+		writeError(w, http.StatusNotFound, "user not found")
+		return
+	}
+	identities, err := s.logins.ListLoginIdentitiesByUser(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list login identities: "+err.Error())
+		return
+	}
+	writeData(w, http.StatusOK, identities)
+}
+
+// LinkAuthUserLoginIdentity handles POST /api/auth/users/{id}/identities/login.
+func (s *Server) LinkAuthUserLoginIdentity(w http.ResponseWriter, r *http.Request, id string) {
+	if !requireAdmin(w, r) {
+		return
+	}
+	if s.logins == nil {
+		writeError(w, http.StatusServiceUnavailable, "login identity store not configured")
+		return
+	}
+
+	var body struct {
+		Provider        string `json:"provider"`
+		ProviderSubject string `json:"provider_subject"`
+		Email           string `json:"email"`
+		Name            string `json:"name"`
+	}
+	if err := decodeJSON(r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		return
+	}
+	if body.Provider == "" || body.ProviderSubject == "" || body.Email == "" {
+		writeError(w, http.StatusBadRequest, "provider, provider_subject, and email are required")
+		return
+	}
+
+	if _, err := s.authStore.GetUser(r.Context(), id); err != nil {
+		writeError(w, http.StatusNotFound, "user not found")
+		return
+	}
+
+	// Ensure the identity is not already owned by another user.
+	existing, err := s.logins.GetLoginIdentityByProvider(r.Context(), body.Provider, body.ProviderSubject)
+	if err != nil && !errors.Is(err, auth.ErrNotFound) {
+		writeError(w, http.StatusInternalServerError, "failed to check existing identity: "+err.Error())
+		return
+	}
+	if err == nil && existing.UserID != id {
+		writeError(w, http.StatusConflict, "identity is already linked to another user")
+		return
+	}
+	if err == nil && existing.UserID == id {
+		writeData(w, http.StatusOK, existing)
+		return
+	}
+
+	linked, err := s.logins.CreateLoginIdentity(r.Context(), auth.LoginIdentity{
+		ID:              uuid.NewString(),
+		UserID:          id,
+		Provider:        body.Provider,
+		ProviderSubject: body.ProviderSubject,
+		Email:           body.Email,
+		Name:            body.Name,
+	})
+	if err != nil {
+		s.log.Error("admin link login identity", "user_id", id, "provider", body.Provider, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to link identity: "+err.Error())
+		return
+	}
+
+	s.log.Info("admin linked login identity", "user_id", id, "provider", body.Provider, "subject", body.ProviderSubject)
+	writeData(w, http.StatusOK, linked)
+}
+
+// ListAuthUserChannelIdentities handles GET /api/auth/users/{id}/identities/channel.
+func (s *Server) ListAuthUserChannelIdentities(w http.ResponseWriter, r *http.Request, id string) {
+	if !requireAdmin(w, r) {
+		return
+	}
+	if _, err := s.authStore.GetUser(r.Context(), id); err != nil {
+		writeError(w, http.StatusNotFound, "user not found")
+		return
+	}
+	identities, err := s.authStore.ListIdentitiesByUser(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list channel identities: "+err.Error())
+		return
+	}
+	writeData(w, http.StatusOK, identities)
 }

--- a/internal/server/auth_users_test.go
+++ b/internal/server/auth_users_test.go
@@ -497,6 +497,147 @@ func TestListAuthUserChannelIdentitiesUserNotFound(t *testing.T) {
 	}
 }
 
+// --- Phase 4: membership-authoritative role/active tests ---
+
+func setupMembershipStore(t *testing.T, env *testEnv) *appdb.OIDCStore {
+	t.Helper()
+	store := appdb.NewOIDCStore(env.db)
+	env.srv.SetLoginIdentityStore(store)
+	env.srv.SetMembershipStore(store)
+	return store
+}
+
+// createUserWithMembership creates a legacy user in auth_users, a matching
+// auth_user record, and an auth_membership. Returns the legacy user and membership ID.
+func createUserWithMembership(t *testing.T, env *testEnv, store *appdb.OIDCStore, username, role string) (auth.AuthUser, auth.Membership) {
+	t.Helper()
+	ctx := context.Background()
+	hash, _ := auth.HashPassword("pw")
+	u, err := env.authStore.CreateUser(ctx, username, hash)
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	_ = env.authStore.UpdateUserRole(ctx, u.ID, role)
+
+	_, _ = store.CreateUser(ctx, auth.User{
+		ID:    u.ID,
+		Email: username + "@test.example",
+		Name:  username,
+	})
+	org, _ := store.CreateOrganization(ctx, auth.Organization{
+		ID:   uuid.NewString(),
+		Name: username + "-org",
+	})
+	m, err := store.CreateMembership(ctx, auth.Membership{
+		ID:             uuid.NewString(),
+		UserID:         u.ID,
+		OrganizationID: org.ID,
+		Role:           role,
+		IsActive:       true,
+	})
+	if err != nil {
+		t.Fatalf("CreateMembership: %v", err)
+	}
+	// Re-read user to get latest state.
+	u2, _ := env.authStore.GetUser(ctx, u.ID)
+	return u2, m
+}
+
+func TestRoleDowngradeReflectsInMembership(t *testing.T) {
+	env := setupAdmin(t)
+	store := setupMembershipStore(t, env)
+	ctx := context.Background()
+
+	u, m := createUserWithMembership(t, env, store, "roletest-"+uuid.NewString(), auth.RoleAdmin)
+	if m.Role != auth.RoleAdmin {
+		t.Fatalf("membership role = %q, want %q", m.Role, auth.RoleAdmin)
+	}
+
+	// Demote to user via admin API.
+	body := map[string]string{"role": auth.RoleUser}
+	rr := doRequest(t, env, "PUT", "/api/auth/users/"+u.ID+"/role", body)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
+	}
+
+	// Membership should now reflect user role.
+	updated, err := store.GetUserMembership(ctx, u.ID)
+	if err != nil {
+		t.Fatalf("GetUserMembership: %v", err)
+	}
+	if updated.Role != auth.RoleUser {
+		t.Errorf("membership role = %q, want %q", updated.Role, auth.RoleUser)
+	}
+}
+
+func TestInactiveMembershipBlocksLegacySession(t *testing.T) {
+	env := setupAdmin(t)
+	store := setupMembershipStore(t, env)
+	ctx := context.Background()
+
+	u, m := createUserWithMembership(t, env, store, "inactivetest-"+uuid.NewString(), auth.RoleUser)
+	_ = m
+
+	// Create a session for the user.
+	sessionID := auth.NewSessionID()
+	_, _ = env.authStore.CreateSession(ctx, auth.Session{
+		ID:        sessionID,
+		UserID:    u.ID,
+		ExpiresAt: time.Now().Add(auth.SessionDuration),
+	})
+
+	// Deactivate via admin API.
+	body := map[string]any{"is_active": false}
+	rr := doRequest(t, env, "PUT", "/api/auth/users/"+u.ID+"/active", body)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("deactivate status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
+	}
+
+	// Membership should be inactive.
+	updated, err := store.GetUserMembership(ctx, u.ID)
+	if err != nil {
+		t.Fatalf("GetUserMembership: %v", err)
+	}
+	if updated.IsActive {
+		t.Error("membership should be inactive after deactivation")
+	}
+
+	// A new session with the same user should be blocked by membership check.
+	newSessionID := auth.NewSessionID()
+	_, _ = env.authStore.CreateSession(ctx, auth.Session{
+		ID:        newSessionID,
+		UserID:    u.ID,
+		ExpiresAt: time.Now().Add(auth.SessionDuration),
+	})
+	rr = doRequestWithSession(t, env.srv, newSessionID, "GET", "/api/auth/users", nil)
+	// Should be denied because membership is inactive.
+	if rr.Code == http.StatusOK {
+		t.Error("expected denied access for inactive membership user, got 200")
+	}
+}
+
+func TestMembershipRoleOverridesLegacyRole(t *testing.T) {
+	env := setupAdmin(t)
+	store := setupMembershipStore(t, env)
+	ctx := context.Background()
+
+	u, _ := createUserWithMembership(t, env, store, "roleoverride-"+uuid.NewString(), auth.RoleUser)
+
+	// Create a session for the user.
+	sessionID := auth.NewSessionID()
+	_, _ = env.authStore.CreateSession(ctx, auth.Session{
+		ID:        sessionID,
+		UserID:    u.ID,
+		ExpiresAt: time.Now().Add(auth.SessionDuration),
+	})
+
+	// Attempting admin endpoint with user membership should be forbidden.
+	rr := doRequestWithSession(t, env.srv, sessionID, "GET", "/api/auth/users", nil)
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+}
+
 func TestAuthUserWithLinkedIdentities(t *testing.T) {
 	env := setupAdmin(t)
 	ctx := context.Background()

--- a/internal/server/auth_users_test.go
+++ b/internal/server/auth_users_test.go
@@ -7,7 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/CherryHQ/stella/internal/auth"
+	appdb "github.com/CherryHQ/stella/internal/db"
 )
 
 func TestListAuthUsers(t *testing.T) {
@@ -296,6 +299,201 @@ func TestNonAdminCannotAccessAuthUserAPIs(t *testing.T) {
 		if rr.Code != http.StatusForbidden {
 			t.Errorf("%s %s: status = %d, want %d", ep.method, ep.path, rr.Code, http.StatusForbidden)
 		}
+	}
+}
+
+// --- Phase 3: login identity admin API tests ---
+
+func setupOIDCStore(t *testing.T, env *testEnv) *appdb.OIDCStore {
+	t.Helper()
+	store := appdb.NewOIDCStore(env.db)
+	env.srv.SetLoginIdentityStore(store)
+	return store
+}
+
+func TestListAuthUserLoginIdentitiesEmpty(t *testing.T) {
+	env := setupAdmin(t)
+	setupOIDCStore(t, env)
+
+	rr := doRequest(t, env, "GET", "/api/auth/users/"+env.adminUser.ID+"/identities/login", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	resp := parseResponse(t, rr)
+	var identities []any
+	_ = json.Unmarshal(resp.Data, &identities)
+	if len(identities) != 0 {
+		t.Errorf("expected 0 login identities, got %d", len(identities))
+	}
+}
+
+func TestListAuthUserLoginIdentitiesUserNotFound(t *testing.T) {
+	env := setupAdmin(t)
+	setupOIDCStore(t, env)
+
+	rr := doRequest(t, env, "GET", "/api/auth/users/nonexistent/identities/login", nil)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusNotFound)
+	}
+}
+
+func TestLinkAuthUserLoginIdentity(t *testing.T) {
+	env := setupAdmin(t)
+	store := setupOIDCStore(t, env)
+	ctx := context.Background()
+
+	// First ensure auth_user exists (local OIDC backfill path).
+	_, err := store.CreateUser(ctx, auth.User{
+		ID:    env.adminUser.ID,
+		Email: "testadmin@example.com",
+		Name:  "Test Admin",
+	})
+	// Ignore duplicate error; admin user may already exist.
+	_ = err
+
+	body := map[string]string{
+		"provider":         "local",
+		"provider_subject": env.adminUser.ID,
+		"email":            "testadmin@example.com",
+		"name":             "Test Admin",
+	}
+	rr := doRequest(t, env, "POST", "/api/auth/users/"+env.adminUser.ID+"/identities/login", body)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
+	}
+
+	resp := parseResponse(t, rr)
+	var identity struct {
+		Provider        string `json:"provider"`
+		ProviderSubject string `json:"provider_subject"`
+		Email           string `json:"email"`
+		UserId          string `json:"user_id"`
+	}
+	if err := json.Unmarshal(resp.Data, &identity); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if identity.Provider != "local" {
+		t.Errorf("provider = %q, want %q", identity.Provider, "local")
+	}
+	if identity.Email != "testadmin@example.com" {
+		t.Errorf("email = %q, want %q", identity.Email, "testadmin@example.com")
+	}
+	if identity.UserId != env.adminUser.ID {
+		t.Errorf("user_id = %q, want %q", identity.UserId, env.adminUser.ID)
+	}
+}
+
+func TestLinkLoginIdentityOwnedByAnotherUserIsConflict(t *testing.T) {
+	env := setupAdmin(t)
+	store := setupOIDCStore(t, env)
+	ctx := context.Background()
+
+	// Create two users in both tables (legacy auth_users + new auth_user).
+	hash, _ := auth.HashPassword("pw")
+	u1, _ := env.authStore.CreateUser(ctx, "linktest1-"+uuid.NewString(), hash)
+	u2, _ := env.authStore.CreateUser(ctx, "linktest2-"+uuid.NewString(), hash)
+	for _, u := range []auth.AuthUser{u1, u2} {
+		_, _ = store.CreateUser(ctx, auth.User{ID: u.ID, Email: u.Username + "@test.example", Name: u.Username})
+	}
+
+	// Link the identity to u1.
+	_, err := store.CreateLoginIdentity(ctx, auth.LoginIdentity{
+		ID:              uuid.NewString(),
+		UserID:          u1.ID,
+		Provider:        "oidc",
+		ProviderSubject: "sub-abc",
+		Email:           "shared@example.com",
+	})
+	if err != nil {
+		t.Fatalf("CreateLoginIdentity: %v", err)
+	}
+
+	// Attempt to link the same identity to u2 — should conflict.
+	body := map[string]string{
+		"provider":         "oidc",
+		"provider_subject": "sub-abc",
+		"email":            "shared@example.com",
+	}
+	rr := doRequest(t, env, "POST", "/api/auth/users/"+u2.ID+"/identities/login", body)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusConflict, rr.Body.String())
+	}
+}
+
+func TestLinkLoginIdentityIdempotent(t *testing.T) {
+	env := setupAdmin(t)
+	store := setupOIDCStore(t, env)
+	ctx := context.Background()
+
+	hash, _ := auth.HashPassword("pw")
+	u, _ := env.authStore.CreateUser(ctx, "idemuser-"+uuid.NewString(), hash)
+	// Seed auth_user so the FK on auth_identity is satisfied.
+	_, _ = store.CreateUser(ctx, auth.User{ID: u.ID, Email: u.Username + "@test.example", Name: u.Username})
+
+	// Link once.
+	_, err := store.CreateLoginIdentity(ctx, auth.LoginIdentity{
+		ID:              uuid.NewString(),
+		UserID:          u.ID,
+		Provider:        "local",
+		ProviderSubject: u.ID,
+		Email:           u.Username + "@test.example",
+	})
+	if err != nil {
+		t.Fatalf("CreateLoginIdentity: %v", err)
+	}
+
+	// Linking again for the same user should return 200 (idempotent).
+	body := map[string]string{
+		"provider":         "local",
+		"provider_subject": u.ID,
+		"email":            u.Username + "@test.example",
+	}
+	rr := doRequest(t, env, "POST", "/api/auth/users/"+u.ID+"/identities/login", body)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
+	}
+}
+
+func TestListAuthUserChannelIdentities(t *testing.T) {
+	env := setupAdmin(t)
+	setupOIDCStore(t, env)
+	ctx := context.Background()
+
+	// Add a channel identity to the admin user.
+	_, err := env.authStore.CreateIdentity(ctx, auth.Identity{
+		UserID:     env.adminUser.ID,
+		Platform:   "telegram",
+		ExternalID: "tg-555",
+		Name:       "TG User",
+	})
+	if err != nil {
+		t.Fatalf("CreateIdentity: %v", err)
+	}
+
+	rr := doRequest(t, env, "GET", "/api/auth/users/"+env.adminUser.ID+"/identities/channel", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	resp := parseResponse(t, rr)
+	var identities []struct {
+		Platform   string `json:"platform"`
+		ExternalID string `json:"external_id"`
+	}
+	if err := json.Unmarshal(resp.Data, &identities); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(identities) != 1 || identities[0].Platform != "telegram" {
+		t.Errorf("unexpected identities: %v", identities)
+	}
+}
+
+func TestListAuthUserChannelIdentitiesUserNotFound(t *testing.T) {
+	env := setupAdmin(t)
+	setupOIDCStore(t, env)
+
+	rr := doRequest(t, env, "GET", "/api/auth/users/nonexistent/identities/channel", nil)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusNotFound)
 	}
 }
 

--- a/internal/server/channels.go
+++ b/internal/server/channels.go
@@ -185,7 +185,18 @@ func (s *Server) ListChannels(w http.ResponseWriter, r *http.Request) {
 	if !requireAdmin(w, r) {
 		return
 	}
-	channels, err := s.store.ListChannels(r.Context())
+	ctx := r.Context()
+	info := UserFromContext(ctx)
+
+	var (
+		channels []config.Channel
+		err      error
+	)
+	if info != nil && info.OrgID != "" {
+		channels, err = s.store.ListChannelsForOrg(ctx, info.OrgID)
+	} else {
+		channels, err = s.store.ListChannels(ctx)
+	}
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -201,9 +212,15 @@ func (s *Server) GetChannel(w http.ResponseWriter, r *http.Request, id string) {
 	if !requireAdmin(w, r) {
 		return
 	}
-	ch, err := s.store.GetChannel(r.Context(), id)
+	ctx := r.Context()
+	info := UserFromContext(ctx)
+	ch, err := s.store.GetChannel(ctx, id)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "channel not found")
+		return
+	}
+	if info != nil && info.OrgID != "" && ch.OrgID != "" && ch.OrgID != info.OrgID {
+		writeError(w, http.StatusForbidden, "channel not found")
 		return
 	}
 	writeData(w, http.StatusOK, channelToView(ch))
@@ -220,7 +237,13 @@ func (s *Server) UpdateChannel(w http.ResponseWriter, r *http.Request, id string
 	}
 	req.ID = id
 
-	existing, existingErr := s.store.GetChannel(r.Context(), id)
+	ctx := r.Context()
+	info := UserFromContext(ctx)
+	existing, existingErr := s.store.GetChannel(ctx, id)
+	if existingErr == nil && info != nil && info.OrgID != "" && existing.OrgID != "" && existing.OrgID != info.OrgID {
+		writeError(w, http.StatusForbidden, "channel not found")
+		return
+	}
 	cfgMap, err := parseChannelConfig(req.Config)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "invalid config JSON: "+err.Error())
@@ -258,7 +281,17 @@ func (s *Server) CreateChannel(w http.ResponseWriter, r *http.Request) {
 		AgentID: requestAgentID(req),
 		Enabled: s.defaultChannelEnabled(r, channelType),
 	}
-	s.saveChannel(w, r, ch, cfgMap, http.StatusCreated)
+	if !s.saveChannel(w, r, ch, cfgMap, http.StatusCreated) {
+		return
+	}
+	// Stamp org when the creating user belongs to one.
+	ctx := r.Context()
+	info := UserFromContext(ctx)
+	if info != nil && info.OrgID != "" {
+		if err := s.store.SetChannelOrg(ctx, ch.ID, info.OrgID); err != nil {
+			s.log.Error("stamp channel org", "channel_id", ch.ID, "org_id", info.OrgID, "error", err)
+		}
+	}
 }
 
 func requestChannelType(req channelWriteRequest) string {
@@ -364,16 +397,22 @@ func (s *Server) DeleteChannel(w http.ResponseWriter, r *http.Request, id string
 	if !requireAdmin(w, r) {
 		return
 	}
-	ch, err := s.store.GetChannel(r.Context(), id)
+	ctx := r.Context()
+	info := UserFromContext(ctx)
+	ch, err := s.store.GetChannel(ctx, id)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "channel not found")
 		return
 	}
+	if info != nil && info.OrgID != "" && ch.OrgID != "" && ch.OrgID != info.OrgID {
+		writeError(w, http.StatusForbidden, "channel not found")
+		return
+	}
 	ch.Enabled = false
-	if err := s.pluginHost.ApplyChannel(r.Context(), ch); err != nil {
+	if err := s.pluginHost.ApplyChannel(ctx, ch); err != nil {
 		s.log.Error("failed to stop channel runtime", "channel_id", ch.ID, "channel_type", ch.Type, "error", err)
 	}
-	if err := s.store.DeleteChannel(r.Context(), id); err != nil {
+	if err := s.store.DeleteChannel(ctx, id); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/internal/server/local_oidc.go
+++ b/internal/server/local_oidc.go
@@ -1,0 +1,26 @@
+package server
+
+// registerLocalOIDCRoutes mounts the built-in local OIDC issuer endpoints under
+// /oidc/local/. These routes are exempt from the auth middleware (they implement
+// the issuer side of the OIDC protocol).
+func (s *Server) registerLocalOIDCRoutes() {
+	if s.localOIDC == nil {
+		return
+	}
+	s.mux.HandleFunc("GET /oidc/local/.well-known/openid-configuration", s.localOIDC.HandleDiscovery)
+	s.mux.HandleFunc("GET /oidc/local/jwks.json", s.localOIDC.HandleJWKS)
+	s.mux.HandleFunc("GET /oidc/local/authorize", s.localOIDC.HandleAuthorize)
+	s.mux.HandleFunc("POST /oidc/local/authorize", s.localOIDC.HandleAuthorize)
+	s.mux.HandleFunc("POST /oidc/local/token", s.localOIDC.HandleToken)
+	s.mux.HandleFunc("GET /oidc/local/userinfo", s.localOIDC.HandleUserinfo)
+}
+
+// localOIDCExempt reports whether path is a local OIDC issuer endpoint that
+// must be exempt from the session auth middleware.
+func localOIDCExempt(path string) bool {
+	switch path {
+	case "/oidc/local/.well-known/openid-configuration", "/oidc/local/jwks.json", "/oidc/local/authorize", "/oidc/local/token", "/oidc/local/userinfo":
+		return true
+	}
+	return false
+}

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -131,7 +131,17 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		if !user.IsActive {
+		// When membership store is available, it is authoritative for role and active.
+		role := user.Role
+		isActive := user.IsActive
+		if s.memberships != nil {
+			if m, err := s.memberships.GetUserMembership(ctx, user.ID); err == nil {
+				role = m.Role
+				isActive = m.IsActive
+			}
+		}
+
+		if !isActive {
 			if path == "/api/status" {
 				next.ServeHTTP(w, r)
 				return
@@ -145,8 +155,8 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 		info := &AuthInfo{
 			UserID:   user.ID,
 			Username: user.Username,
-			Role:     user.Role,
-			IsAdmin:  user.IsAdmin(),
+			Role:     role,
+			IsAdmin:  role == auth.RoleAdmin,
 		}
 
 		next.ServeHTTP(w, r.WithContext(withAuthInfo(ctx, info)))

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -60,7 +60,8 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 			path == "/api/auth/providers" ||
 			strings.HasPrefix(path, "/auth/login/") ||
 			strings.HasPrefix(path, "/auth/callback/") ||
-			(strings.HasPrefix(path, "/api/auth/profile/oauth/") && strings.HasSuffix(path, "/callback")) {
+			(strings.HasPrefix(path, "/api/auth/profile/oauth/") && strings.HasSuffix(path, "/callback")) ||
+			localOIDCExempt(path) {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/internal/server/providers.go
+++ b/internal/server/providers.go
@@ -14,12 +14,23 @@ func (s *Server) ListProviders(w http.ResponseWriter, r *http.Request) {
 	if !requireAdmin(w, r) {
 		return
 	}
-	providers, err := s.store.ListProviders(r.Context())
+	ctx := r.Context()
+	info := UserFromContext(ctx)
+
+	var (
+		pList []config.Provider
+		err   error
+	)
+	if info != nil && info.OrgID != "" {
+		pList, err = s.store.ListProvidersForOrg(ctx, info.OrgID)
+	} else {
+		pList, err = s.store.ListProviders(ctx)
+	}
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	writeData(w, http.StatusOK, providers)
+	writeData(w, http.StatusOK, pList)
 }
 
 func (s *Server) CreateProvider(w http.ResponseWriter, r *http.Request) {
@@ -44,11 +55,19 @@ func (s *Server) CreateProvider(w http.ResponseWriter, r *http.Request) {
 	if !p.Enabled {
 		p.Enabled = true
 	}
-	if err := s.store.CreateProvider(r.Context(), p); err != nil {
+	ctx := r.Context()
+	info := UserFromContext(ctx)
+	if err := s.store.CreateProvider(ctx, p); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	s.reloadProviders(r.Context())
+	if info != nil && info.OrgID != "" {
+		if err := s.store.SetProviderOrg(ctx, p.ID, info.OrgID); err != nil {
+			s.log.Error("stamp provider org", "provider_id", p.ID, "org_id", info.OrgID, "error", err)
+		}
+		p.OrgID = info.OrgID
+	}
+	s.reloadProviders(ctx)
 	writeData(w, http.StatusCreated, p)
 }
 
@@ -56,9 +75,15 @@ func (s *Server) GetProvider(w http.ResponseWriter, r *http.Request, id string) 
 	if !requireAdmin(w, r) {
 		return
 	}
-	p, err := s.store.GetProvider(r.Context(), id)
+	ctx := r.Context()
+	info := UserFromContext(ctx)
+	p, err := s.store.GetProvider(ctx, id)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "provider not found")
+		return
+	}
+	if info != nil && info.OrgID != "" && p.OrgID != "" && p.OrgID != info.OrgID {
+		writeError(w, http.StatusForbidden, "provider not found")
 		return
 	}
 	writeData(w, http.StatusOK, p)
@@ -68,14 +93,20 @@ func (s *Server) UpdateProvider(w http.ResponseWriter, r *http.Request, id strin
 	if !requireAdmin(w, r) {
 		return
 	}
+	ctx := r.Context()
+	info := UserFromContext(ctx)
 	var p config.Provider
 	if err := decodeJSON(r, &p); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
 		return
 	}
-	existing, err := s.store.GetProvider(r.Context(), id)
+	existing, err := s.store.GetProvider(ctx, id)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "provider not found")
+		return
+	}
+	if info != nil && info.OrgID != "" && existing.OrgID != "" && existing.OrgID != info.OrgID {
+		writeError(w, http.StatusForbidden, "provider not found")
 		return
 	}
 	p.ID = id
@@ -85,11 +116,11 @@ func (s *Server) UpdateProvider(w http.ResponseWriter, r *http.Request, id strin
 	if p.Name == "" {
 		p.Name = id
 	}
-	if err := s.store.UpdateProvider(r.Context(), p); err != nil {
+	if err := s.store.UpdateProvider(ctx, p); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	s.reloadProviders(r.Context())
+	s.reloadProviders(ctx)
 	writeData(w, http.StatusOK, p)
 }
 
@@ -97,11 +128,22 @@ func (s *Server) DeleteProvider(w http.ResponseWriter, r *http.Request, id strin
 	if !requireAdmin(w, r) {
 		return
 	}
-	if err := s.store.DeleteProvider(r.Context(), id); err != nil {
+	ctx := r.Context()
+	info := UserFromContext(ctx)
+	existing, err := s.store.GetProvider(ctx, id)
+	if err != nil {
+		writeError(w, http.StatusNotFound, "provider not found")
+		return
+	}
+	if info != nil && info.OrgID != "" && existing.OrgID != "" && existing.OrgID != info.OrgID {
+		writeError(w, http.StatusForbidden, "provider not found")
+		return
+	}
+	if err := s.store.DeleteProvider(ctx, id); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	s.reloadProviders(r.Context())
+	s.reloadProviders(ctx)
 	writeData(w, http.StatusOK, map[string]string{"status": "deleted"})
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -58,6 +58,8 @@ type Server struct {
 	localOIDC *localoidc.Issuer
 	// logins provides access to OIDC login identities (optional).
 	logins auth.LoginIdentityStore
+	// memberships provides access to auth_membership (optional).
+	memberships auth.MembershipStore
 }
 
 // New creates an admin server with all API routes mounted.
@@ -145,6 +147,13 @@ func (s *Server) SetLocalOIDCIssuer(issuer *localoidc.Issuer) {
 // can list and link login identities. Call before serving requests.
 func (s *Server) SetLoginIdentityStore(store auth.LoginIdentityStore) {
 	s.logins = store
+}
+
+// SetMembershipStore wires the membership store so role and active writes
+// propagate to auth_membership in addition to the legacy auth_users table.
+// Call before serving requests.
+func (s *Server) SetMembershipStore(store auth.MembershipStore) {
+	s.memberships = store
 }
 
 // SetOIDCAuth wires all OIDC authentication components into the server.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,6 +12,7 @@ import (
 	apiserver "github.com/CherryHQ/stella/api/server"
 	"github.com/CherryHQ/stella/internal/agent"
 	"github.com/CherryHQ/stella/internal/auth"
+	"github.com/CherryHQ/stella/internal/auth/localoidc"
 	authoidc "github.com/CherryHQ/stella/internal/auth/oidc"
 	"github.com/CherryHQ/stella/internal/config"
 	"github.com/CherryHQ/stella/internal/credentials"
@@ -53,6 +54,8 @@ type Server struct {
 	authSvc       *auth.AuthService
 	sessionMgr    *auth.SessionManager
 	stateMgr      *authoidc.StateManager
+	// localOIDC is the built-in local OIDC issuer (optional).
+	localOIDC *localoidc.Issuer
 }
 
 // New creates an admin server with all API routes mounted.
@@ -126,6 +129,14 @@ func (s *Server) SetTokenService(svc *auth.TokenService) {
 // If not set, those handlers write DB-only.
 func (s *Server) SetSchedulerService(svc *scheduler.Service) {
 	s.schedulerSvc = svc
+}
+
+// SetLocalOIDCIssuer wires the built-in local OIDC issuer into the server.
+// When set, routes under /oidc/local/ are registered for the issuer endpoints.
+// Call before serving requests.
+func (s *Server) SetLocalOIDCIssuer(issuer *localoidc.Issuer) {
+	s.localOIDC = issuer
+	s.registerLocalOIDCRoutes()
 }
 
 // SetOIDCAuth wires all OIDC authentication components into the server.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -56,6 +56,8 @@ type Server struct {
 	stateMgr      *authoidc.StateManager
 	// localOIDC is the built-in local OIDC issuer (optional).
 	localOIDC *localoidc.Issuer
+	// logins provides access to OIDC login identities (optional).
+	logins auth.LoginIdentityStore
 }
 
 // New creates an admin server with all API routes mounted.
@@ -137,6 +139,12 @@ func (s *Server) SetSchedulerService(svc *scheduler.Service) {
 func (s *Server) SetLocalOIDCIssuer(issuer *localoidc.Issuer) {
 	s.localOIDC = issuer
 	s.registerLocalOIDCRoutes()
+}
+
+// SetLoginIdentityStore wires the OIDC login identity store so the admin API
+// can list and link login identities. Call before serving requests.
+func (s *Server) SetLoginIdentityStore(store auth.LoginIdentityStore) {
+	s.logins = store
 }
 
 // SetOIDCAuth wires all OIDC authentication components into the server.

--- a/pkg/db/sqlc/auth_policies.sql.go
+++ b/pkg/db/sqlc/auth_policies.sql.go
@@ -12,7 +12,7 @@ import (
 const createAuthPolicy = `-- name: CreateAuthPolicy :one
 INSERT INTO auth_policies (id, name, effect, subjects, actions, resources, conditions, priority, is_system, enabled)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-RETURNING id, name, effect, subjects, actions, resources, conditions, priority, is_system, enabled, created_at
+RETURNING id, name, effect, subjects, actions, resources, conditions, priority, is_system, enabled, org_id, created_at
 `
 
 type CreateAuthPolicyParams struct {
@@ -53,6 +53,7 @@ func (q *Queries) CreateAuthPolicy(ctx context.Context, arg CreateAuthPolicyPara
 		&i.Priority,
 		&i.IsSystem,
 		&i.Enabled,
+		&i.OrgID,
 		&i.CreatedAt,
 	)
 	return i, err
@@ -68,7 +69,7 @@ func (q *Queries) DeleteAuthPolicy(ctx context.Context, id string) error {
 }
 
 const getAuthPolicy = `-- name: GetAuthPolicy :one
-SELECT id, name, effect, subjects, actions, resources, conditions, priority, is_system, enabled, created_at FROM auth_policies WHERE id = ?
+SELECT id, name, effect, subjects, actions, resources, conditions, priority, is_system, enabled, org_id, created_at FROM auth_policies WHERE id = ?
 `
 
 func (q *Queries) GetAuthPolicy(ctx context.Context, id string) (AuthPolicy, error) {
@@ -85,13 +86,14 @@ func (q *Queries) GetAuthPolicy(ctx context.Context, id string) (AuthPolicy, err
 		&i.Priority,
 		&i.IsSystem,
 		&i.Enabled,
+		&i.OrgID,
 		&i.CreatedAt,
 	)
 	return i, err
 }
 
 const listAuthPolicies = `-- name: ListAuthPolicies :many
-SELECT id, name, effect, subjects, actions, resources, conditions, priority, is_system, enabled, created_at FROM auth_policies ORDER BY priority DESC, name
+SELECT id, name, effect, subjects, actions, resources, conditions, priority, is_system, enabled, org_id, created_at FROM auth_policies ORDER BY priority DESC, name
 `
 
 func (q *Queries) ListAuthPolicies(ctx context.Context) ([]AuthPolicy, error) {
@@ -114,6 +116,7 @@ func (q *Queries) ListAuthPolicies(ctx context.Context) ([]AuthPolicy, error) {
 			&i.Priority,
 			&i.IsSystem,
 			&i.Enabled,
+			&i.OrgID,
 			&i.CreatedAt,
 		); err != nil {
 			return nil, err
@@ -130,7 +133,7 @@ func (q *Queries) ListAuthPolicies(ctx context.Context) ([]AuthPolicy, error) {
 }
 
 const listEnabledAuthPolicies = `-- name: ListEnabledAuthPolicies :many
-SELECT id, name, effect, subjects, actions, resources, conditions, priority, is_system, enabled, created_at FROM auth_policies WHERE enabled = 1 ORDER BY priority DESC, name
+SELECT id, name, effect, subjects, actions, resources, conditions, priority, is_system, enabled, org_id, created_at FROM auth_policies WHERE enabled = 1 ORDER BY priority DESC, name
 `
 
 func (q *Queries) ListEnabledAuthPolicies(ctx context.Context) ([]AuthPolicy, error) {
@@ -153,6 +156,7 @@ func (q *Queries) ListEnabledAuthPolicies(ctx context.Context) ([]AuthPolicy, er
 			&i.Priority,
 			&i.IsSystem,
 			&i.Enabled,
+			&i.OrgID,
 			&i.CreatedAt,
 		); err != nil {
 			return nil, err

--- a/pkg/db/sqlc/models.go
+++ b/pkg/db/sqlc/models.go
@@ -78,17 +78,18 @@ type AuthOauthProvider struct {
 }
 
 type AuthPolicy struct {
-	ID         string `json:"id"`
-	Name       string `json:"name"`
-	Effect     string `json:"effect"`
-	Subjects   string `json:"subjects"`
-	Actions    string `json:"actions"`
-	Resources  string `json:"resources"`
-	Conditions string `json:"conditions"`
-	Priority   int64  `json:"priority"`
-	IsSystem   int64  `json:"is_system"`
-	Enabled    int64  `json:"enabled"`
-	CreatedAt  string `json:"created_at"`
+	ID         string         `json:"id"`
+	Name       string         `json:"name"`
+	Effect     string         `json:"effect"`
+	Subjects   string         `json:"subjects"`
+	Actions    string         `json:"actions"`
+	Resources  string         `json:"resources"`
+	Conditions string         `json:"conditions"`
+	Priority   int64          `json:"priority"`
+	IsSystem   int64          `json:"is_system"`
+	Enabled    int64          `json:"enabled"`
+	OrgID      sql.NullString `json:"org_id"`
+	CreatedAt  string         `json:"created_at"`
 }
 
 type AuthSession struct {
@@ -362,21 +363,22 @@ type Setting struct {
 }
 
 type SettingsAgent struct {
-	ID                   string `json:"id"`
-	Name                 string `json:"name"`
-	Model                string `json:"model"`
-	ModelStrong          string `json:"model_strong"`
-	ModelFast            string `json:"model_fast"`
-	SystemPrompt         string `json:"system_prompt"`
-	Soul                 string `json:"soul"`
-	Workspace            string `json:"workspace"`
-	Sandbox              string `json:"sandbox"`
-	EnabledBuiltinSkills string `json:"enabled_builtin_skills"`
-	Scope                string `json:"scope"`
-	CreatorID            string `json:"creator_id"`
-	Enabled              int64  `json:"enabled"`
-	CreatedAt            string `json:"created_at"`
-	UpdatedAt            string `json:"updated_at"`
+	ID                   string         `json:"id"`
+	Name                 string         `json:"name"`
+	Model                string         `json:"model"`
+	ModelStrong          string         `json:"model_strong"`
+	ModelFast            string         `json:"model_fast"`
+	SystemPrompt         string         `json:"system_prompt"`
+	Soul                 string         `json:"soul"`
+	Workspace            string         `json:"workspace"`
+	Sandbox              string         `json:"sandbox"`
+	EnabledBuiltinSkills string         `json:"enabled_builtin_skills"`
+	Scope                string         `json:"scope"`
+	CreatorID            string         `json:"creator_id"`
+	Enabled              int64          `json:"enabled"`
+	OrgID                sql.NullString `json:"org_id"`
+	CreatedAt            string         `json:"created_at"`
+	UpdatedAt            string         `json:"updated_at"`
 }
 
 type SettingsChannel struct {
@@ -385,6 +387,7 @@ type SettingsChannel struct {
 	AgentID   sql.NullString `json:"agent_id"`
 	Enabled   int64          `json:"enabled"`
 	Config    string         `json:"config"`
+	OrgID     sql.NullString `json:"org_id"`
 	CreatedAt string         `json:"created_at"`
 	UpdatedAt string         `json:"updated_at"`
 }
@@ -408,13 +411,14 @@ type SettingsPlugin struct {
 }
 
 type SettingsProvider struct {
-	ID        string `json:"id"`
-	Type      string `json:"type"`
-	Name      string `json:"name"`
-	Enabled   int64  `json:"enabled"`
-	Config    string `json:"config"`
-	CreatedAt string `json:"created_at"`
-	UpdatedAt string `json:"updated_at"`
+	ID        string         `json:"id"`
+	Type      string         `json:"type"`
+	Name      string         `json:"name"`
+	Enabled   int64          `json:"enabled"`
+	Config    string         `json:"config"`
+	OrgID     sql.NullString `json:"org_id"`
+	CreatedAt string         `json:"created_at"`
+	UpdatedAt string         `json:"updated_at"`
 }
 
 type Share struct {

--- a/pkg/db/sqlc/settings_agents.sql.go
+++ b/pkg/db/sqlc/settings_agents.sql.go
@@ -7,12 +7,13 @@ package sqlc
 
 import (
 	"context"
+	"database/sql"
 )
 
 const createAgent = `-- name: CreateAgent :one
 INSERT INTO settings_agents (id, name, model, model_strong, model_fast, system_prompt, soul, workspace, sandbox, enabled_builtin_skills, scope, creator_id, enabled)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-RETURNING id, name, model, model_strong, model_fast, system_prompt, soul, workspace, sandbox, enabled_builtin_skills, scope, creator_id, enabled, created_at, updated_at
+RETURNING id, name, model, model_strong, model_fast, system_prompt, soul, workspace, sandbox, enabled_builtin_skills, scope, creator_id, enabled, org_id, created_at, updated_at
 `
 
 type CreateAgentParams struct {
@@ -62,6 +63,7 @@ func (q *Queries) CreateAgent(ctx context.Context, arg CreateAgentParams) (Setti
 		&i.Scope,
 		&i.CreatorID,
 		&i.Enabled,
+		&i.OrgID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -78,7 +80,7 @@ func (q *Queries) DeleteAgent(ctx context.Context, id string) error {
 }
 
 const getAgent = `-- name: GetAgent :one
-SELECT id, name, model, model_strong, model_fast, system_prompt, soul, workspace, sandbox, enabled_builtin_skills, scope, creator_id, enabled, created_at, updated_at FROM settings_agents WHERE id = ?
+SELECT id, name, model, model_strong, model_fast, system_prompt, soul, workspace, sandbox, enabled_builtin_skills, scope, creator_id, enabled, org_id, created_at, updated_at FROM settings_agents WHERE id = ?
 `
 
 func (q *Queries) GetAgent(ctx context.Context, id string) (SettingsAgent, error) {
@@ -98,6 +100,7 @@ func (q *Queries) GetAgent(ctx context.Context, id string) (SettingsAgent, error
 		&i.Scope,
 		&i.CreatorID,
 		&i.Enabled,
+		&i.OrgID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -105,7 +108,7 @@ func (q *Queries) GetAgent(ctx context.Context, id string) (SettingsAgent, error
 }
 
 const listAgents = `-- name: ListAgents :many
-SELECT id, name, model, model_strong, model_fast, system_prompt, soul, workspace, sandbox, enabled_builtin_skills, scope, creator_id, enabled, created_at, updated_at FROM settings_agents ORDER BY name
+SELECT id, name, model, model_strong, model_fast, system_prompt, soul, workspace, sandbox, enabled_builtin_skills, scope, creator_id, enabled, org_id, created_at, updated_at FROM settings_agents ORDER BY name
 `
 
 func (q *Queries) ListAgents(ctx context.Context) ([]SettingsAgent, error) {
@@ -131,6 +134,51 @@ func (q *Queries) ListAgents(ctx context.Context) ([]SettingsAgent, error) {
 			&i.Scope,
 			&i.CreatorID,
 			&i.Enabled,
+			&i.OrgID,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listAgentsByOrg = `-- name: ListAgentsByOrg :many
+SELECT id, name, model, model_strong, model_fast, system_prompt, soul, workspace, sandbox, enabled_builtin_skills, scope, creator_id, enabled, org_id, created_at, updated_at FROM settings_agents WHERE org_id = ? ORDER BY name
+`
+
+func (q *Queries) ListAgentsByOrg(ctx context.Context, orgID sql.NullString) ([]SettingsAgent, error) {
+	rows, err := q.db.QueryContext(ctx, listAgentsByOrg, orgID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []SettingsAgent{}
+	for rows.Next() {
+		var i SettingsAgent
+		if err := rows.Scan(
+			&i.ID,
+			&i.Name,
+			&i.Model,
+			&i.ModelStrong,
+			&i.ModelFast,
+			&i.SystemPrompt,
+			&i.Soul,
+			&i.Workspace,
+			&i.Sandbox,
+			&i.EnabledBuiltinSkills,
+			&i.Scope,
+			&i.CreatorID,
+			&i.Enabled,
+			&i.OrgID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {
@@ -148,7 +196,7 @@ func (q *Queries) ListAgents(ctx context.Context) ([]SettingsAgent, error) {
 }
 
 const listEnabledAgents = `-- name: ListEnabledAgents :many
-SELECT id, name, model, model_strong, model_fast, system_prompt, soul, workspace, sandbox, enabled_builtin_skills, scope, creator_id, enabled, created_at, updated_at FROM settings_agents WHERE enabled = 1 ORDER BY name
+SELECT id, name, model, model_strong, model_fast, system_prompt, soul, workspace, sandbox, enabled_builtin_skills, scope, creator_id, enabled, org_id, created_at, updated_at FROM settings_agents WHERE enabled = 1 ORDER BY name
 `
 
 func (q *Queries) ListEnabledAgents(ctx context.Context) ([]SettingsAgent, error) {
@@ -174,6 +222,7 @@ func (q *Queries) ListEnabledAgents(ctx context.Context) ([]SettingsAgent, error
 			&i.Scope,
 			&i.CreatorID,
 			&i.Enabled,
+			&i.OrgID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {
@@ -188,6 +237,64 @@ func (q *Queries) ListEnabledAgents(ctx context.Context) ([]SettingsAgent, error
 		return nil, err
 	}
 	return items, nil
+}
+
+const listEnabledAgentsByOrg = `-- name: ListEnabledAgentsByOrg :many
+SELECT id, name, model, model_strong, model_fast, system_prompt, soul, workspace, sandbox, enabled_builtin_skills, scope, creator_id, enabled, org_id, created_at, updated_at FROM settings_agents WHERE org_id = ? AND enabled = 1 ORDER BY name
+`
+
+func (q *Queries) ListEnabledAgentsByOrg(ctx context.Context, orgID sql.NullString) ([]SettingsAgent, error) {
+	rows, err := q.db.QueryContext(ctx, listEnabledAgentsByOrg, orgID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []SettingsAgent{}
+	for rows.Next() {
+		var i SettingsAgent
+		if err := rows.Scan(
+			&i.ID,
+			&i.Name,
+			&i.Model,
+			&i.ModelStrong,
+			&i.ModelFast,
+			&i.SystemPrompt,
+			&i.Soul,
+			&i.Workspace,
+			&i.Sandbox,
+			&i.EnabledBuiltinSkills,
+			&i.Scope,
+			&i.CreatorID,
+			&i.Enabled,
+			&i.OrgID,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const setAgentOrg = `-- name: SetAgentOrg :exec
+UPDATE settings_agents SET org_id = ? WHERE id = ?
+`
+
+type SetAgentOrgParams struct {
+	OrgID sql.NullString `json:"org_id"`
+	ID    string         `json:"id"`
+}
+
+func (q *Queries) SetAgentOrg(ctx context.Context, arg SetAgentOrgParams) error {
+	_, err := q.db.ExecContext(ctx, setAgentOrg, arg.OrgID, arg.ID)
+	return err
 }
 
 const updateAgent = `-- name: UpdateAgent :exec

--- a/pkg/db/sqlc/settings_channels.sql.go
+++ b/pkg/db/sqlc/settings_channels.sql.go
@@ -20,7 +20,7 @@ func (q *Queries) DeleteChannel(ctx context.Context, id string) error {
 }
 
 const getChannel = `-- name: GetChannel :one
-SELECT id, type, agent_id, enabled, config, created_at, updated_at FROM settings_channels WHERE id = ?
+SELECT id, type, agent_id, enabled, config, org_id, created_at, updated_at FROM settings_channels WHERE id = ?
 `
 
 func (q *Queries) GetChannel(ctx context.Context, id string) (SettingsChannel, error) {
@@ -32,6 +32,7 @@ func (q *Queries) GetChannel(ctx context.Context, id string) (SettingsChannel, e
 		&i.AgentID,
 		&i.Enabled,
 		&i.Config,
+		&i.OrgID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -39,7 +40,7 @@ func (q *Queries) GetChannel(ctx context.Context, id string) (SettingsChannel, e
 }
 
 const listChannels = `-- name: ListChannels :many
-SELECT id, type, agent_id, enabled, config, created_at, updated_at FROM settings_channels ORDER BY type, id
+SELECT id, type, agent_id, enabled, config, org_id, created_at, updated_at FROM settings_channels ORDER BY type, id
 `
 
 func (q *Queries) ListChannels(ctx context.Context) ([]SettingsChannel, error) {
@@ -57,6 +58,43 @@ func (q *Queries) ListChannels(ctx context.Context) ([]SettingsChannel, error) {
 			&i.AgentID,
 			&i.Enabled,
 			&i.Config,
+			&i.OrgID,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listChannelsByOrg = `-- name: ListChannelsByOrg :many
+SELECT id, type, agent_id, enabled, config, org_id, created_at, updated_at FROM settings_channels WHERE org_id = ? ORDER BY type, id
+`
+
+func (q *Queries) ListChannelsByOrg(ctx context.Context, orgID sql.NullString) ([]SettingsChannel, error) {
+	rows, err := q.db.QueryContext(ctx, listChannelsByOrg, orgID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []SettingsChannel{}
+	for rows.Next() {
+		var i SettingsChannel
+		if err := rows.Scan(
+			&i.ID,
+			&i.Type,
+			&i.AgentID,
+			&i.Enabled,
+			&i.Config,
+			&i.OrgID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {
@@ -74,7 +112,7 @@ func (q *Queries) ListChannels(ctx context.Context) ([]SettingsChannel, error) {
 }
 
 const listChannelsByType = `-- name: ListChannelsByType :many
-SELECT id, type, agent_id, enabled, config, created_at, updated_at FROM settings_channels WHERE type = ? ORDER BY id
+SELECT id, type, agent_id, enabled, config, org_id, created_at, updated_at FROM settings_channels WHERE type = ? ORDER BY id
 `
 
 func (q *Queries) ListChannelsByType(ctx context.Context, type_ string) ([]SettingsChannel, error) {
@@ -92,6 +130,7 @@ func (q *Queries) ListChannelsByType(ctx context.Context, type_ string) ([]Setti
 			&i.AgentID,
 			&i.Enabled,
 			&i.Config,
+			&i.OrgID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {
@@ -106,6 +145,61 @@ func (q *Queries) ListChannelsByType(ctx context.Context, type_ string) ([]Setti
 		return nil, err
 	}
 	return items, nil
+}
+
+const listChannelsByTypeAndOrg = `-- name: ListChannelsByTypeAndOrg :many
+SELECT id, type, agent_id, enabled, config, org_id, created_at, updated_at FROM settings_channels WHERE type = ? AND org_id = ? ORDER BY id
+`
+
+type ListChannelsByTypeAndOrgParams struct {
+	Type  string         `json:"type"`
+	OrgID sql.NullString `json:"org_id"`
+}
+
+func (q *Queries) ListChannelsByTypeAndOrg(ctx context.Context, arg ListChannelsByTypeAndOrgParams) ([]SettingsChannel, error) {
+	rows, err := q.db.QueryContext(ctx, listChannelsByTypeAndOrg, arg.Type, arg.OrgID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []SettingsChannel{}
+	for rows.Next() {
+		var i SettingsChannel
+		if err := rows.Scan(
+			&i.ID,
+			&i.Type,
+			&i.AgentID,
+			&i.Enabled,
+			&i.Config,
+			&i.OrgID,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const setChannelOrg = `-- name: SetChannelOrg :exec
+UPDATE settings_channels SET org_id = ? WHERE id = ?
+`
+
+type SetChannelOrgParams struct {
+	OrgID sql.NullString `json:"org_id"`
+	ID    string         `json:"id"`
+}
+
+func (q *Queries) SetChannelOrg(ctx context.Context, arg SetChannelOrgParams) error {
+	_, err := q.db.ExecContext(ctx, setChannelOrg, arg.OrgID, arg.ID)
+	return err
 }
 
 const upsertChannel = `-- name: UpsertChannel :exec

--- a/pkg/db/sqlc/settings_providers.sql.go
+++ b/pkg/db/sqlc/settings_providers.sql.go
@@ -7,12 +7,13 @@ package sqlc
 
 import (
 	"context"
+	"database/sql"
 )
 
 const createProvider = `-- name: CreateProvider :one
 INSERT INTO settings_providers (id, type, name, enabled, config, updated_at)
 VALUES (?, ?, ?, ?, ?, datetime('now'))
-RETURNING id, type, name, enabled, config, created_at, updated_at
+RETURNING id, type, name, enabled, config, org_id, created_at, updated_at
 `
 
 type CreateProviderParams struct {
@@ -38,6 +39,7 @@ func (q *Queries) CreateProvider(ctx context.Context, arg CreateProviderParams) 
 		&i.Name,
 		&i.Enabled,
 		&i.Config,
+		&i.OrgID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -54,7 +56,7 @@ func (q *Queries) DeleteProvider(ctx context.Context, id string) error {
 }
 
 const getProvider = `-- name: GetProvider :one
-SELECT id, type, name, enabled, config, created_at, updated_at FROM settings_providers WHERE id = ?
+SELECT id, type, name, enabled, config, org_id, created_at, updated_at FROM settings_providers WHERE id = ?
 `
 
 func (q *Queries) GetProvider(ctx context.Context, id string) (SettingsProvider, error) {
@@ -66,6 +68,7 @@ func (q *Queries) GetProvider(ctx context.Context, id string) (SettingsProvider,
 		&i.Name,
 		&i.Enabled,
 		&i.Config,
+		&i.OrgID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -73,7 +76,7 @@ func (q *Queries) GetProvider(ctx context.Context, id string) (SettingsProvider,
 }
 
 const listEnabledProviders = `-- name: ListEnabledProviders :many
-SELECT id, type, name, enabled, config, created_at, updated_at FROM settings_providers WHERE enabled = 1 ORDER BY name, id
+SELECT id, type, name, enabled, config, org_id, created_at, updated_at FROM settings_providers WHERE enabled = 1 ORDER BY name, id
 `
 
 func (q *Queries) ListEnabledProviders(ctx context.Context) ([]SettingsProvider, error) {
@@ -91,6 +94,43 @@ func (q *Queries) ListEnabledProviders(ctx context.Context) ([]SettingsProvider,
 			&i.Name,
 			&i.Enabled,
 			&i.Config,
+			&i.OrgID,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listEnabledProvidersByOrg = `-- name: ListEnabledProvidersByOrg :many
+SELECT id, type, name, enabled, config, org_id, created_at, updated_at FROM settings_providers WHERE org_id = ? AND enabled = 1 ORDER BY name, id
+`
+
+func (q *Queries) ListEnabledProvidersByOrg(ctx context.Context, orgID sql.NullString) ([]SettingsProvider, error) {
+	rows, err := q.db.QueryContext(ctx, listEnabledProvidersByOrg, orgID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []SettingsProvider{}
+	for rows.Next() {
+		var i SettingsProvider
+		if err := rows.Scan(
+			&i.ID,
+			&i.Type,
+			&i.Name,
+			&i.Enabled,
+			&i.Config,
+			&i.OrgID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {
@@ -108,7 +148,7 @@ func (q *Queries) ListEnabledProviders(ctx context.Context) ([]SettingsProvider,
 }
 
 const listProviders = `-- name: ListProviders :many
-SELECT id, type, name, enabled, config, created_at, updated_at FROM settings_providers ORDER BY name, id
+SELECT id, type, name, enabled, config, org_id, created_at, updated_at FROM settings_providers ORDER BY name, id
 `
 
 func (q *Queries) ListProviders(ctx context.Context) ([]SettingsProvider, error) {
@@ -126,6 +166,43 @@ func (q *Queries) ListProviders(ctx context.Context) ([]SettingsProvider, error)
 			&i.Name,
 			&i.Enabled,
 			&i.Config,
+			&i.OrgID,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listProvidersByOrg = `-- name: ListProvidersByOrg :many
+SELECT id, type, name, enabled, config, org_id, created_at, updated_at FROM settings_providers WHERE org_id = ? ORDER BY name, id
+`
+
+func (q *Queries) ListProvidersByOrg(ctx context.Context, orgID sql.NullString) ([]SettingsProvider, error) {
+	rows, err := q.db.QueryContext(ctx, listProvidersByOrg, orgID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []SettingsProvider{}
+	for rows.Next() {
+		var i SettingsProvider
+		if err := rows.Scan(
+			&i.ID,
+			&i.Type,
+			&i.Name,
+			&i.Enabled,
+			&i.Config,
+			&i.OrgID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {
@@ -163,6 +240,20 @@ func (q *Queries) SeedProvider(ctx context.Context, arg SeedProviderParams) erro
 		arg.Enabled,
 		arg.Config,
 	)
+	return err
+}
+
+const setProviderOrg = `-- name: SetProviderOrg :exec
+UPDATE settings_providers SET org_id = ? WHERE id = ?
+`
+
+type SetProviderOrgParams struct {
+	OrgID sql.NullString `json:"org_id"`
+	ID    string         `json:"id"`
+}
+
+func (q *Queries) SetProviderOrg(ctx context.Context, arg SetProviderOrgParams) error {
+	_, err := q.db.ExecContext(ctx, setProviderOrg, arg.OrgID, arg.ID)
 	return err
 }
 

--- a/plugins/channels/telegram/plugin_test.go
+++ b/plugins/channels/telegram/plugin_test.go
@@ -91,17 +91,25 @@ func (s *stubStore) ListProviders(context.Context) ([]config.Provider, error) { 
 func (s *stubStore) GetProvider(context.Context, string) (config.Provider, error) {
 	return config.Provider{}, nil
 }
-func (s *stubStore) CreateProvider(context.Context, config.Provider) error     { return nil }
-func (s *stubStore) UpdateProvider(context.Context, config.Provider) error     { return nil }
-func (s *stubStore) DeleteProvider(context.Context, string) error              { return nil }
+func (s *stubStore) CreateProvider(context.Context, config.Provider) error { return nil }
+func (s *stubStore) UpdateProvider(context.Context, config.Provider) error { return nil }
+func (s *stubStore) DeleteProvider(context.Context, string) error          { return nil }
+func (s *stubStore) ListProvidersForOrg(context.Context, string) ([]config.Provider, error) {
+	return nil, nil
+}
+func (s *stubStore) SetProviderOrg(context.Context, string, string) error      { return nil }
 func (s *stubStore) ListAgents(context.Context) ([]config.Agent, error)        { return nil, nil }
 func (s *stubStore) ListEnabledAgents(context.Context) ([]config.Agent, error) { return nil, nil }
 func (s *stubStore) GetAgent(context.Context, string) (config.Agent, error) {
 	return config.Agent{}, nil
 }
-func (s *stubStore) CreateAgent(context.Context, config.Agent) error        { return nil }
-func (s *stubStore) UpdateAgent(context.Context, config.Agent) error        { return nil }
-func (s *stubStore) DeleteAgent(context.Context, string) error              { return nil }
+func (s *stubStore) CreateAgent(context.Context, config.Agent) error { return nil }
+func (s *stubStore) UpdateAgent(context.Context, config.Agent) error { return nil }
+func (s *stubStore) DeleteAgent(context.Context, string) error       { return nil }
+func (s *stubStore) ListAgentsForOrg(context.Context, string) ([]config.Agent, error) {
+	return nil, nil
+}
+func (s *stubStore) SetAgentOrg(context.Context, string, string) error      { return nil }
 func (s *stubStore) ListChannels(context.Context) ([]config.Channel, error) { return nil, nil }
 func (s *stubStore) ListChannelsByType(context.Context, string) ([]config.Channel, error) {
 	return nil, nil
@@ -112,6 +120,10 @@ func (s *stubStore) GetChannel(context.Context, string) (config.Channel, error) 
 }
 func (s *stubStore) UpsertChannel(context.Context, config.Channel) error { return nil }
 func (s *stubStore) DeleteChannel(context.Context, string) error         { return nil }
+func (s *stubStore) ListChannelsForOrg(context.Context, string) ([]config.Channel, error) {
+	return nil, nil
+}
+func (s *stubStore) SetChannelOrg(context.Context, string, string) error { return nil }
 func (s *stubStore) ListPlugins(context.Context) ([]config.Plugin, error) {
 	plugins := make([]config.Plugin, 0, len(s.plugins))
 	for _, plugin := range s.plugins {

--- a/web/content/docs/guides/oidc-authentication.md
+++ b/web/content/docs/guides/oidc-authentication.md
@@ -81,6 +81,64 @@ stella auth link-user --user-id <id> --email <your@email.com>
 
 This updates the stored email for that user so the OIDC login can find and link the account automatically.
 
+## Local OIDC issuer
+
+Stella can act as its own OIDC identity provider. This is useful for single-user or local deployments where you want your existing username/password credentials to power an OIDC login — for example, to use Stella as the OIDC provider for another app you run.
+
+**This is not a replacement for an external identity provider in production.** Use it only for local or self-contained deployments.
+
+### Enable the local issuer
+
+Generate a P-256 signing key:
+
+```bash
+openssl ecparam -name prime256v1 -genkey -noout -out local-oidc.key
+openssl pkcs8 -topk8 -nocrypt -in local-oidc.key -out local-oidc-pkcs8.pem
+```
+
+Then set:
+
+```bash
+LOCAL_OIDC_ENABLED=true
+LOCAL_OIDC_ISSUER_URL=https://your-stella-host/oidc/local
+LOCAL_OIDC_CLIENT_ID=stella-local
+LOCAL_OIDC_REDIRECT_URIS=https://your-app/callback
+LOCAL_OIDC_SIGNING_KEY="$(cat local-oidc-pkcs8.pem)"
+# Optional:
+LOCAL_OIDC_CLIENT_SECRET=         # leave blank to use public client (PKCE required)
+LOCAL_OIDC_KEY_ID=local-1
+```
+
+The issuer exposes standard OIDC endpoints under `/oidc/local`:
+
+| Endpoint      | Path                                           |
+| ------------- | ---------------------------------------------- |
+| Discovery     | `/oidc/local/.well-known/openid-configuration` |
+| JWKS          | `/oidc/local/jwks`                             |
+| Authorization | `/oidc/local/authorize`                        |
+| Token         | `/oidc/local/token`                            |
+| Userinfo      | `/oidc/local/userinfo`                         |
+
+### Environment variables
+
+| Variable                   | Required     | Description                                            |
+| -------------------------- | ------------ | ------------------------------------------------------ |
+| `LOCAL_OIDC_ENABLED`       | Yes (`true`) | Must be exactly `true` to enable                       |
+| `LOCAL_OIDC_ISSUER_URL`    | Yes          | Full URL to `/oidc/local` on your host                 |
+| `LOCAL_OIDC_CLIENT_ID`     | Yes          | Client ID for the relying party                        |
+| `LOCAL_OIDC_REDIRECT_URIS` | Yes          | Comma-separated exact-match redirect URIs              |
+| `LOCAL_OIDC_SIGNING_KEY`   | Yes          | PEM-encoded ECDSA P-256 private key (or base64 of PEM) |
+| `LOCAL_OIDC_CLIENT_SECRET` | No           | Client secret; leave blank for public PKCE clients     |
+| `LOCAL_OIDC_KEY_ID`        | No           | Key ID in the JWKS (default: `local-1`)                |
+
+### Security limitations
+
+- Only **Authorization Code + PKCE** flow is supported.
+- Redirect URIs are exact-match — no wildcards.
+- The signing key is loaded at startup; key rotation requires a server restart.
+- There is no dynamic client registration. Client config is static environment configuration.
+- Do not expose the local issuer publicly without TLS.
+
 ## Security notes
 
 - Sessions are stored as SHA-256 hashes — the raw token never leaves the browser cookie.

--- a/web/content/docs/guides/oidc-authentication.zh.md
+++ b/web/content/docs/guides/oidc-authentication.zh.md
@@ -81,6 +81,64 @@ stella auth link-user --user-id <id> --email <your@email.com>
 
 此命令会更新该用户存储的邮箱，使 OIDC 登录时能自动找到并关联账号。
 
+## 本地 OIDC 发行方
+
+Stella 可以作为自己的 OIDC 身份提供商。适用于单用户或本地部署场景——例如将 Stella 的用户名/密码凭证用于其他应用的 OIDC 登录。
+
+**这不是生产环境外部身份提供商的替代方案。** 仅适用于本地或自包含部署。
+
+### 启用本地发行方
+
+生成 P-256 签名密钥：
+
+```bash
+openssl ecparam -name prime256v1 -genkey -noout -out local-oidc.key
+openssl pkcs8 -topk8 -nocrypt -in local-oidc.key -out local-oidc-pkcs8.pem
+```
+
+然后设置：
+
+```bash
+LOCAL_OIDC_ENABLED=true
+LOCAL_OIDC_ISSUER_URL=https://your-stella-host/oidc/local
+LOCAL_OIDC_CLIENT_ID=stella-local
+LOCAL_OIDC_REDIRECT_URIS=https://your-app/callback
+LOCAL_OIDC_SIGNING_KEY="$(cat local-oidc-pkcs8.pem)"
+# 可选：
+LOCAL_OIDC_CLIENT_SECRET=         # 留空表示使用公开客户端（必须使用 PKCE）
+LOCAL_OIDC_KEY_ID=local-1
+```
+
+发行方在 `/oidc/local` 下暴露标准 OIDC 端点：
+
+| 端点      | 路径                                           |
+| --------- | ---------------------------------------------- |
+| Discovery | `/oidc/local/.well-known/openid-configuration` |
+| JWKS      | `/oidc/local/jwks`                             |
+| 授权      | `/oidc/local/authorize`                        |
+| Token     | `/oidc/local/token`                            |
+| Userinfo  | `/oidc/local/userinfo`                         |
+
+### 环境变量
+
+| 变量                       | 是否必填          | 说明                                            |
+| -------------------------- | ----------------- | ----------------------------------------------- |
+| `LOCAL_OIDC_ENABLED`       | 是（值为 `true`） | 必须恰好为 `true` 才会启用                      |
+| `LOCAL_OIDC_ISSUER_URL`    | 是                | 主机上 `/oidc/local` 的完整 URL                 |
+| `LOCAL_OIDC_CLIENT_ID`     | 是                | 依赖方的 Client ID                              |
+| `LOCAL_OIDC_REDIRECT_URIS` | 是                | 逗号分隔的精确匹配重定向 URI                    |
+| `LOCAL_OIDC_SIGNING_KEY`   | 是                | PEM 格式的 ECDSA P-256 私钥（或 PEM 的 base64） |
+| `LOCAL_OIDC_CLIENT_SECRET` | 否                | Client Secret；公开 PKCE 客户端请留空           |
+| `LOCAL_OIDC_KEY_ID`        | 否                | JWKS 中的 Key ID（默认：`local-1`）             |
+
+### 安全限制
+
+- 仅支持**授权码 + PKCE** 流程。
+- 重定向 URI 精确匹配——不支持通配符。
+- 签名密钥在启动时加载；密钥轮换需要重启服务器。
+- 不支持动态客户端注册，客户端配置为静态环境变量配置。
+- 未使用 TLS 时请勿将本地发行方暴露到公网。
+
 ## 安全说明
 
 - Session 以 SHA-256 哈希形式存储——原始 token 不会离开浏览器 cookie。


### PR DESCRIPTION
## Summary

This PR closes the auth gaps identified after PR #219 (Generic OIDC). It implements six phases of the auth finalization plan:

- **Phase 1 & 2: Local credential store + built-in OIDC issuer** — Password hashing via bcrypt (`auth_credential` table), and a full local OIDC issuer at `/oidc/local` (Authorization Code + PKCE, ES256 tokens, JWKS, discovery, userinfo). Useful for self-contained/local deployments.
- **Phase 3: Login identity admin API + CLI** — `GET/POST /api/auth/users/{id}/identities/login` and `GET /api/auth/users/{id}/identities/channel` endpoints; `stella auth link-user` CLI command for admins to manually link OIDC identities to existing accounts.
- **Phase 4: Membership-authoritative role/active** — Legacy session auth now reads role and active status from `auth_membership` when OIDC is configured, keeping them in sync with OIDC provider claims. No-OIDC installs are unaffected.
- **Phase 5: org_id on settings tables** — Adds nullable `org_id` FK to `settings_agents`, `settings_providers`, `settings_channels`, and `auth_policies`. Startup backfill assigns all existing resources to a synthetic legacy org so old installs keep working without OIDC.
- **Phase 6: Org-scoped handlers** — Agent, provider, and channel list/create/get/update/delete operations are now org-scoped. Users with an `org_id` see only their org's resources; cross-org access is blocked with a 404 to avoid leaking IDs. Creating a resource stamps it with the user's org.
- **Phase 9: Documentation** — OIDC guide (EN + ZH) updated with local OIDC issuer setup, environment variables, security limitations, and upgrade path for existing installs.

## What's deferred

- **Phase 7: Legacy FK migration** — Moving 12+ tables from `REFERENCES auth_users(id)` to `REFERENCES auth_user(id)`. Separate PR — high blast radius.
- **Phase 8: Legacy session/user cleanup** — Removing legacy login/register paths and old auth tables. Separate PR — depends on Phase 7.
- Plugin config remains global (known limitation; documented).

## Migration notes

- All DB migrations are Atlas-generated and additive. No destructive changes.
- Existing installs: startup backfill automatically creates a legacy org and assigns all existing resources to it. No manual migration needed.
- OIDC installs: if usernames are not email addresses, run `stella auth link-user --user-id <id> --email <email>` before enabling OIDC.

## Test plan

- [x] `mise run format` — clean
- [x] `mise run build` — clean
- [x] `mise run test` — all pass
- [ ] Manual smoke test: local OIDC issuer with a test relying party
- [ ] Manual smoke test: org isolation (two OIDC orgs cannot see each other's agents/providers/channels)
- [ ] Manual smoke test: legacy install upgrade with startup backfill