### PR TITLE
Per-org lazy runtime initialization

### DIFF
--- a/cmd/stella/commands.go
+++ b/cmd/stella/commands.go
@@ -183,7 +183,6 @@ func setup(parent context.Context, _ bool) (*setupResult, error) {
 
 	skillStoreAdapter := pluginhost.NewSkillStoreAdapter(ss.diskSync)
 	poolMgr = agent.NewPoolManager(store, memProvider,
-		agent.WithIdleTimeoutPM(0),
 		agent.WithCompactionPM(agent.CompactionConfig{}.WithDefaults()),
 		agent.WithBuiltinTools(builtinTools),
 		agent.WithPluginToolsBuilder(pluginToolsBuilder),
@@ -215,6 +214,7 @@ func setup(parent context.Context, _ bool) (*setupResult, error) {
 		Store:    store,
 		Syncer:   poolMgr,
 		Channels: nil, // Channels wired later in runServer
+		Jobs:     schedulerSvc,
 	})
 
 	backgroundTasks := &sync.WaitGroup{}

--- a/cmd/stella/commands.go
+++ b/cmd/stella/commands.go
@@ -8,19 +8,18 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"time"
 
 	ucli "github.com/urfave/cli/v2"
 
 	"github.com/CherryHQ/stella/internal/agent"
 	"github.com/CherryHQ/stella/internal/agent/prompt"
-	"github.com/CherryHQ/stella/internal/auth"
 	"github.com/CherryHQ/stella/internal/cli"
 	"github.com/CherryHQ/stella/internal/config"
 	oauth "github.com/CherryHQ/stella/internal/credentials/oauth"
 	appdb "github.com/CherryHQ/stella/internal/db"
 	"github.com/CherryHQ/stella/internal/memory"
 	"github.com/CherryHQ/stella/internal/notify"
+	"github.com/CherryHQ/stella/internal/orgruntime"
 	"github.com/CherryHQ/stella/internal/pluginhost"
 	"github.com/CherryHQ/stella/internal/scheduler"
 	cfgstore "github.com/CherryHQ/stella/internal/store"
@@ -88,12 +87,10 @@ type setupResult struct {
 	ctx                      context.Context
 	db                       *sql.DB
 	mem                      memory.Provider
-	snap                     *config.Snapshot
 	store                    config.Store
 	pluginHost               *pluginhost.Host
 	channelRuntimeServices   *pluginhost.ChannelPlatform
 	poolManager              *agent.PoolManager
-	pool                     *agent.Pool
 	schedulerSvc             *scheduler.Service
 	tasksSvc                 *tasks.Service
 	builtinTools             []pkgtools.Tool
@@ -104,7 +101,7 @@ type setupResult struct {
 	sessionPluginViewBuilder agent.SessionPluginViewBuilder
 	toolLifecycle            *coreagent.ToolLifecycle
 	skillStore               pkgplugins.SkillStore
-	defaultOrgID             string
+	orgRuntimeManager        *orgruntime.Manager
 	cliUserID                int64
 	oauthRegistry            *oauth.ProviderRegistry
 	backgroundTasks          *sync.WaitGroup
@@ -122,39 +119,10 @@ func setup(parent context.Context, _ bool) (*setupResult, error) {
 		return nil, err
 	}
 
-	orgID, err := appdb.EnsureDefaultOrg(parent, db)
-	if err != nil {
-		return nil, fmt.Errorf("ensure default org: %w", err)
-	}
-	// Enrich context so all Store calls are org-scoped.
-	parent = config.WithOrgID(parent, orgID)
-
-	ss, err := setupSkillStores(parent, db, orgID)
+	ss, err := setupSkillStores(parent, db, "")
 	if err != nil {
 		return nil, err
 	}
-
-	if err := store.SeedDefaults(parent, orgID); err != nil {
-		return nil, fmt.Errorf("seed defaults: %w", err)
-	}
-
-	authStore := appdb.NewAuthStore(db)
-	if err := auth.SeedPolicies(parent, authStore, orgID); err != nil {
-		return nil, fmt.Errorf("seed auth: %w", err)
-	}
-
-	agents, err := store.ListEnabledAgents(parent)
-	if err != nil || len(agents) == 0 {
-		return nil, fmt.Errorf("no enabled agents found")
-	}
-	defaultAgentID := agents[0].ID
-
-	snap, err := store.Snapshot(parent, defaultAgentID)
-	if err != nil {
-		return nil, fmt.Errorf("load config snapshot: %w", err)
-	}
-
-	migrateFilesystemSkills(parent, ss.raw, snap)
 
 	dispatcher := notify.NewDispatcher()
 	dispatcher.SetChannelStore(store)
@@ -165,7 +133,7 @@ func setup(parent context.Context, _ bool) (*setupResult, error) {
 	}
 	phost := ps.host
 
-	schedulerSvc, err := setupScheduler(db, snap, phost, orgID)
+	schedulerSvc, err := setupScheduler(db, phost)
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +145,7 @@ func setup(parent context.Context, _ bool) (*setupResult, error) {
 		})
 	}
 
-	memProvider, err := setupMemoryProvider(parent, db, store, defaultAgentID, providerStreamBuilder)
+	memProvider, err := setupMemoryProvider(parent, db, store, providerStreamBuilder)
 	if err != nil {
 		return nil, fmt.Errorf("memory provider: %w", err)
 	}
@@ -196,7 +164,7 @@ func setup(parent context.Context, _ bool) (*setupResult, error) {
 	pluginToolsBuilder := func(ctx context.Context, build pkgplugins.ToolBuildContext) []pkgtools.Tool {
 		return phost.BuildEnabledTools(ctx, build)
 	}
-	ps.reflectRuntimeServices.Set(parent, memProvider, store, snap.Workspace, providerStreamBuilder)
+	ps.reflectRuntimeServices.Set(parent, memProvider, store, config.StellaHome(), providerStreamBuilder)
 
 	pluginHooksBuilder := func(ctx context.Context) []hooks.HookPlugin {
 		return phost.BuildEnabledHooks(ctx, pluginhooks.BuildContext{ToolsBinDir: binaries.BinDir(config.StellaHome())})
@@ -211,16 +179,12 @@ func setup(parent context.Context, _ bool) (*setupResult, error) {
 		return phost.SessionPluginView(ctx)
 	}
 
-	tasksSvc := buildTasksService(db, dispatcher, memProvider, &poolMgr, defaultAgentID)
+	tasksSvc := buildTasksService(db, dispatcher, memProvider, &poolMgr)
 
 	skillStoreAdapter := pluginhost.NewSkillStoreAdapter(ss.diskSync)
-	idleTimeout := time.Duration(snap.Runner.IdleTimeout) * time.Minute
 	poolMgr = agent.NewPoolManager(store, memProvider,
-		agent.WithIdleTimeoutPM(idleTimeout),
-		agent.WithCompactionPM(agent.CompactionConfig{
-			MaxTokens: snap.Runner.Compaction.MaxTokens,
-			KeepTail:  snap.Runner.Compaction.KeepTail,
-		}.WithDefaults()),
+		agent.WithIdleTimeoutPM(0),
+		agent.WithCompactionPM(agent.CompactionConfig{}.WithDefaults()),
 		agent.WithBuiltinTools(builtinTools),
 		agent.WithPluginToolsBuilder(pluginToolsBuilder),
 		agent.WithPluginHooksBuilder(pluginHooksBuilder),
@@ -247,12 +211,11 @@ func setup(parent context.Context, _ bool) (*setupResult, error) {
 		return nil, fmt.Errorf("start pool manager: %w", err)
 	}
 
-	pool := poolMgr.Get(defaultAgentID)
-	if pool == nil {
-		pool = poolMgr.DefaultPool()
-	}
-
-	wireSchedulerCallbacks(schedulerSvc, snap, pool, poolMgr, dispatcher)
+	orgRtMgr := orgruntime.NewManager(orgruntime.ManagerDeps{
+		Store:    store,
+		Syncer:   poolMgr,
+		Channels: nil, // Channels wired later in runServer
+	})
 
 	backgroundTasks := &sync.WaitGroup{}
 	if ps.manifestToReconcile != nil {
@@ -263,12 +226,10 @@ func setup(parent context.Context, _ bool) (*setupResult, error) {
 		ctx:                      parent,
 		db:                       db,
 		mem:                      memProvider,
-		snap:                     snap,
 		store:                    store,
 		pluginHost:               phost,
 		channelRuntimeServices:   ps.channelRuntimeServices,
 		poolManager:              poolMgr,
-		pool:                     pool,
 		schedulerSvc:             schedulerSvc,
 		tasksSvc:                 tasksSvc,
 		builtinTools:             builtinTools,
@@ -279,7 +240,7 @@ func setup(parent context.Context, _ bool) (*setupResult, error) {
 		sessionPluginViewBuilder: sessionPluginViewBuilder,
 		toolLifecycle:            toolLifecycle,
 		skillStore:               skillStoreAdapter,
-		defaultOrgID:             orgID,
+		orgRuntimeManager:        orgRtMgr,
 		cliUserID:                0,
 		oauthRegistry:            ps.oauthRegistry,
 		backgroundTasks:          backgroundTasks,
@@ -302,49 +263,34 @@ func ensureEmbeddedAssets() error {
 	return nil
 }
 
-func setupScheduler(db *sql.DB, snap *config.Snapshot, phost *pluginhost.Host, orgID string) (*scheduler.Service, error) {
+func setupScheduler(db *sql.DB, phost *pluginhost.Host) (*scheduler.Service, error) {
 	svc, err := scheduler.New(db)
 	if err != nil {
 		return nil, fmt.Errorf("create scheduler service: %w", err)
 	}
-	svc.SetDefaultOrgID(orgID)
-	dataDir := snap.Scheduler.DataDir
-	if dataDir == "" {
-		dataDir = filepath.Join(snap.Workspace, "scheduler")
-	}
-	svc.SetLegacyDataPath(dataDir)
-	svc.SetUserJobsEnabled(snap.Scheduler.IsEnabled())
+	svc.SetLegacyDataPath(config.StellaHome() + "/scheduler")
 	phost.SetSchedulerService(newSchedulerServiceAdapter(svc, phost.Runtime()))
 	return svc, nil
 }
 
-func wireSchedulerCallbacks(svc *scheduler.Service, snap *config.Snapshot, pool *agent.Pool, poolMgr *agent.PoolManager, dispatcher *notify.Dispatcher) {
+func wireSchedulerCallbacks(svc *scheduler.Service, poolMgr *agent.PoolManager, dispatcher *notify.Dispatcher) {
 	if svc == nil {
 		return
-	}
-	if snap.Heartbeat.IsEnabled() {
-		svc.SetHeartbeat(scheduler.HeartbeatConfig{
-			File:      snap.Heartbeat.FilePath(snap.Workspace),
-			FastModel: snap.ResolveModelID(config.ModelTierFast),
-		}, func(ctx context.Context, sessionID, message, model string) <-chan agent.Event {
-			if model != "" {
-				return pool.Chat(ctx, sessionID, message, agent.WithModel(model))
-			}
-			return pool.Chat(ctx, sessionID, message)
-		}, dispatcher)
 	}
 	svc.SetOnJob(func(ctx context.Context, job scheduler.Job) error {
 		if scheduler.IsPluginJob(job) {
 			return nil
 		}
-		targetPool := pool
-		if job.AgentID != "" {
-			if p := poolMgr.Get(job.AgentID); p != nil {
-				targetPool = p
-			}
+		pool := poolMgr.Get(job.AgentID)
+		if pool == nil {
+			pool = poolMgr.DefaultPool()
+		}
+		if pool == nil {
+			slog.Warn("scheduler: no pool available for job", "job_id", job.ID, "agent_id", job.AgentID)
+			return fmt.Errorf("no agent pool available for job %s", job.ID)
 		}
 		sessionID := job.SessionID()
-		ch := targetPool.Chat(schedulerJobContext(ctx, targetPool, job), sessionID, schedulerJobMessage(job))
+		ch := pool.Chat(schedulerJobContext(ctx, pool, job), sessionID, schedulerJobMessage(job))
 		var runErr error
 		for evt := range ch {
 			if evt.Err != nil {
@@ -356,13 +302,10 @@ func wireSchedulerCallbacks(svc *scheduler.Service, snap *config.Snapshot, pool 
 	})
 }
 
-func buildTasksService(db *sql.DB, dispatcher *notify.Dispatcher, mem memory.Provider, poolMgr **agent.PoolManager, defaultAgentID string) *tasks.Service {
+func buildTasksService(db *sql.DB, dispatcher *notify.Dispatcher, mem memory.Provider, poolMgr **agent.PoolManager) *tasks.Service {
 	runnerFactory := tasks.RunnerFactoryFn(func(agentID string) (agent.NewRunnerFunc, bool) {
 		if *poolMgr == nil {
 			return nil, false
-		}
-		if agentID == "" {
-			agentID = defaultAgentID
 		}
 		p := (*poolMgr).Get(agentID)
 		if p == nil {

--- a/cmd/stella/commands_test.go
+++ b/cmd/stella/commands_test.go
@@ -7,15 +7,12 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/CherryHQ/stella/internal/agent"
 	"github.com/CherryHQ/stella/internal/config"
 	appdb "github.com/CherryHQ/stella/internal/db"
-	"github.com/CherryHQ/stella/internal/memory"
 	"github.com/CherryHQ/stella/internal/pluginhost"
 	cfgstore "github.com/CherryHQ/stella/internal/store"
-	coreagent "github.com/CherryHQ/stella/pkg/agent"
 	"github.com/CherryHQ/stella/pkg/ai"
 	pkgplugins "github.com/CherryHQ/stella/pkg/plugins"
 	"github.com/CherryHQ/stella/pkg/providers"
@@ -125,20 +122,6 @@ func (commandTestStore) SetSetting(context.Context, string, string) error       
 func (commandTestStore) Snapshot(context.Context, string) (*config.Snapshot, error)    { return nil, nil }
 func (commandTestStore) SeedDefaults(context.Context, string) error                    { return nil }
 
-type commandTestMemory struct{}
-
-func (commandTestMemory) Name() string                                                { return "test" }
-func (commandTestMemory) Bootstrap(context.Context, memory.Session) error             { return nil }
-func (commandTestMemory) Append(context.Context, memory.Session, ...ai.Message) error { return nil }
-func (commandTestMemory) Assemble(context.Context, memory.Session, int, int) ([]ai.Message, error) {
-	return nil, nil
-}
-
-func (commandTestMemory) Stats(context.Context, memory.Session) (memory.SessionStats, error) {
-	return memory.SessionStats{}, nil
-}
-func (commandTestMemory) Close() error { return nil }
-
 func setupCommandTestStellaHome(t *testing.T) string {
 	t.Helper()
 	stellaHome := t.TempDir()
@@ -247,70 +230,5 @@ func TestRunHelpShort(t *testing.T) {
 	err := app.Run([]string{"stella", "-h"})
 	if err != nil {
 		t.Fatalf("run -h: %v", err)
-	}
-}
-
-func TestModelSwitcherPreservesPromptBuilders(t *testing.T) {
-	setupCommandTestStellaHome(t)
-
-	snap := &config.Snapshot{
-		AgentID:  "test-agent",
-		Provider: "anthropic",
-		Model:    "anthropic/old-model",
-		APIKey:   "test-key",
-		Runner:   config.RunnerConfig{Type: "go"},
-	}
-	snap.Workspace = t.TempDir()
-
-	initialFactory, err := agent.NewRunnerFactory(agent.RunnerFactoryConfig{
-		Snap:                  snap,
-		ProviderStreamBuilder: testProviderStreamBuilder,
-	})
-	if err != nil {
-		t.Fatalf("NewRunnerFactory: %v", err)
-	}
-
-	pool := agent.NewPool(initialFactory, commandTestMemory{}, agent.WithAgentID(snap.AgentID), agent.WithDefaultModel(snap.Model))
-
-	promptToolsCalls := 0
-	promptSectionsCalls := 0
-	switchFn := modelSwitcher(
-		snap,
-		commandTestStore{},
-		pool,
-		nil,
-		nil,
-		testProviderStreamBuilder,
-		func(context.Context) ([]pkgplugins.PromptToolInfo, error) {
-			promptToolsCalls++
-			return nil, nil
-		},
-		func(context.Context, pkgplugins.SystemPromptContext) ([]pkgplugins.SystemPromptSection, error) {
-			promptSectionsCalls++
-			return nil, nil
-		},
-		nil,
-		&coreagent.ToolLifecycle{},
-	)
-
-	if err := switchFn("anthropic", "new-model"); err != nil {
-		t.Fatalf("switchFn: %v", err)
-	}
-
-	session, err := pool.CreateSession("cli", "1")
-	if err != nil {
-		t.Fatalf("CreateSession: %v", err)
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	for range pool.Chat(ctx, session.ID, "hello") {
-	}
-
-	if promptToolsCalls == 0 {
-		t.Fatal("expected prompt tools builder to be preserved after model switch")
-	}
-	if promptSectionsCalls == 0 {
-		t.Fatal("expected prompt sections builder to be preserved after model switch")
 	}
 }

--- a/cmd/stella/gateway.go
+++ b/cmd/stella/gateway.go
@@ -192,6 +192,14 @@ func runServer(ctx context.Context, s *setupResult, listFn func() []pkgchannel.M
 		s.channelRuntimeServices.Set(gctx, coordinator, s.notifier)
 	}
 
+	// Wire channel startup into OrgRuntime so channels start per-org.
+	if s.orgRuntimeManager != nil {
+		s.orgRuntimeManager.SetChannels(channelStarterFunc(func(ctx context.Context) error {
+			applyManagedChannelPlugins(ctx, s.pluginHost)
+			return nil
+		}))
+	}
+
 	// Start Web UI server.
 	listenAddr := adminListenAddress(adminHost, adminPort)
 	ln, err := net.Listen("tcp", listenAddr)
@@ -255,6 +263,11 @@ func runServer(ctx context.Context, s *setupResult, listFn func() []pkgchannel.M
 	slog.Info("gateway stopped")
 	return waitErr
 }
+
+// channelStarterFunc adapts a plain function to orgruntime.ChannelStarter.
+type channelStarterFunc func(ctx context.Context) error
+
+func (f channelStarterFunc) StartChannels(ctx context.Context) error { return f(ctx) }
 
 func schedulerJobContext(ctx context.Context, pool *agent.Pool, job scheduler.Job) context.Context {
 	if job.UserID != "" {

--- a/cmd/stella/gateway.go
+++ b/cmd/stella/gateway.go
@@ -163,6 +163,7 @@ func runServer(ctx context.Context, s *setupResult, listFn func() []pkgchannel.M
 		slog.Warn("oidc: setup failed", "error", err)
 	} else {
 		oidcResult.AuthSvc.SetOrgSeeder(&orgSeeder{store: s.store, authStore: authStore})
+		oidcResult.AuthSvc.SetOrgInitializer(s.orgRuntimeManager)
 		adminSrv.SetLoginIdentityStore(oidcStore)
 		adminSrv.SetMembershipStore(oidcStore)
 		adminSrv.SetUserStore(oidcStore)
@@ -175,6 +176,9 @@ func runServer(ctx context.Context, s *setupResult, listFn func() []pkgchannel.M
 
 	intentClassifier := newIntentClassifier(s.store, s.pluginHost)
 	coordOpts = append(coordOpts, channel.WithIntentClassifier(intentClassifier))
+	if s.orgRuntimeManager != nil {
+		coordOpts = append(coordOpts, channel.WithOrgRuntimeInitializer(s.orgRuntimeManager))
+	}
 
 	// Create the coordinator that implements MessageHandler for all channels.
 	coordinator := channel.NewCoordinator(

--- a/cmd/stella/gateway.go
+++ b/cmd/stella/gateway.go
@@ -85,12 +85,17 @@ func serverAction(c *ucli.Context) error {
 		s.waitBackgroundTasks()
 		_ = s.poolManager.Close()
 	}()
-	return runServer(s.ctx, s, s.modelListFunc(s.snap), s.modelSwitchFunc(s.snap, s.pool), c.String("host"), c.Int("port"))
+
+	listFn := func() []pkgchannel.ModelOption {
+		return collectModelsFromStore(s.ctx, s.store)
+	}
+	switchFn := func(_, _ string) error { return nil }
+
+	return runServer(s.ctx, s, listFn, switchFn, c.String("host"), c.Int("port"))
 }
 
 func runServer(ctx context.Context, s *setupResult, listFn func() []pkgchannel.ModelOption, switchFn func(string, string) error, adminHost string, adminPort int) error {
-	g, gctx := errgroup.WithContext(config.WithOrgID(ctx, s.defaultOrgID))
-	channels := make([]pkgchannel.Channel, 0)
+	g, gctx := errgroup.WithContext(ctx)
 
 	// Create auth store and policy engine for channel bots and Web UI.
 	as := appdb.NewAuthStore(s.db)
@@ -183,8 +188,6 @@ func runServer(ctx context.Context, s *setupResult, listFn func() []pkgchannel.M
 		s.channelRuntimeServices.Set(gctx, coordinator, s.notifier)
 	}
 
-	managedChannels := applyManagedChannelPlugins(gctx, s.pluginHost)
-
 	// Start Web UI server.
 	listenAddr := adminListenAddress(adminHost, adminPort)
 	ln, err := net.Listen("tcp", listenAddr)
@@ -209,29 +212,17 @@ func runServer(ctx context.Context, s *setupResult, listFn func() []pkgchannel.M
 		return nil
 	})
 
-	if len(channels) == 0 && managedChannels.Started == 0 {
-		reason := noRunningChannelReason(managedChannels)
-		slog.Warn(reason+"; running Web UI only", "configured_channels", managedChannels.Configured)
-	}
-
-	// Start all channels.
-	for _, ch := range channels {
-		g.Go(func() error {
-			if err := ch.Start(gctx); err != nil && gctx.Err() == nil {
-				return fmt.Errorf("%s: %w", ch.Name(), err)
-			}
-			return nil
-		})
-	}
-
 	// Wire auth directory into dispatcher for per-user notification routing.
 	s.notifier.SetAuthService(s.pluginHost.Auth())
 
-	// Wire scheduler notifications and start the scheduler AFTER channels
-	// are registered, so early-firing jobs already use the dispatcher.
+	// Wire scheduler and start it. Builtin jobs and heartbeat are configured
+	// per-org via OrgRuntime.Start(), not at boot.
 	if s.schedulerSvc != nil {
 		adminSrv.SetSchedulerService(s.schedulerSvc)
-		wireSchedulerNotifier(s.schedulerSvc, s.poolManager, s.pool)
+		wireSchedulerCallbacks(s.schedulerSvc, s.poolManager, s.notifier)
+		s.schedulerSvc.SetListActiveUsersFunc(func(ctx context.Context, orgID string) ([]string, error) {
+			return as.ListActiveUserIDs(ctx, orgID)
+		})
 		if err := s.schedulerSvc.Start(ctx); err != nil {
 			return fmt.Errorf("start scheduler: %w", err)
 		}
@@ -252,20 +243,6 @@ func runServer(ctx context.Context, s *setupResult, listFn func() []pkgchannel.M
 		}
 	}
 
-	if s.schedulerSvc != nil {
-		orgID := s.defaultOrgID
-		s.schedulerSvc.SetListActiveUsersFunc(func(ctx context.Context) ([]string, error) {
-			return as.ListActiveUserIDs(ctx, orgID)
-		})
-		s.schedulerSvc.EnsureBuiltinJobs()
-	}
-
-	if s.snap.Heartbeat.IsEnabled() && s.schedulerSvc != nil {
-		if err := s.schedulerSvc.StartHeartbeat(ctx, s.snap.Heartbeat.Interval()); err != nil {
-			return fmt.Errorf("schedule heartbeat: %w", err)
-		}
-	}
-
 	if err := s.pluginHost.ApplyPlugin(gctx, reflectplugin.PluginID); err != nil {
 		return fmt.Errorf("apply reflect runtime: %w", err)
 	}
@@ -275,47 +252,6 @@ func runServer(ctx context.Context, s *setupResult, listFn func() []pkgchannel.M
 	return waitErr
 }
 
-// wireSchedulerNotifier overrides the scheduler callback to run the agent.
-// The agent decides whether to notify the user by calling the notify tool.
-func wireSchedulerNotifier(schedulerSvc *scheduler.Service, poolMgr *agent.PoolManager, defaultPool *agent.Pool) {
-	schedulerSvc.SetOnJob(func(ctx context.Context, job scheduler.Job) error {
-		if scheduler.IsPluginJob(job) {
-			return nil
-		}
-
-		pool := schedulerPool(job, poolMgr, defaultPool)
-		sessionID := scheduler.RunSessionIDFromContext(ctx)
-		if sessionID == "" {
-			sessionID = job.SessionID()
-		}
-		msg := schedulerJobMessage(job)
-
-		jobCtx := schedulerJobContext(ctx, pool, job)
-
-		for evt := range pool.Chat(jobCtx, sessionID, msg) {
-			if evt.Err != nil {
-				slog.Error("scheduler job error", "job_id", job.ID, "error", evt.Err)
-			}
-		}
-		return nil
-	})
-}
-
-func schedulerPool(job scheduler.Job, poolMgr *agent.PoolManager, defaultPool *agent.Pool) *agent.Pool {
-	if job.AgentID == "" {
-		return defaultPool
-	}
-
-	pool := poolMgr.Get(job.AgentID)
-	if pool != nil {
-		return pool
-	}
-
-	slog.Warn("scheduler job references unknown agent, using default pool",
-		"job_id", job.ID, "agent_id", job.AgentID)
-	return defaultPool
-}
-
 func schedulerJobContext(ctx context.Context, pool *agent.Pool, job scheduler.Job) context.Context {
 	if job.UserID != "" {
 		ctx = memory.WithUserID(ctx, job.UserID)
@@ -323,7 +259,6 @@ func schedulerJobContext(ctx context.Context, pool *agent.Pool, job scheduler.Jo
 	if pool.AgentID() != "" {
 		ctx = memory.WithAgentID(ctx, pool.AgentID())
 	}
-	// Prevent scheduled jobs from mutating scheduler control-plane state.
 	ctx = agent.WithExcludedTools(ctx, "scheduler")
 	return ctx
 }
@@ -339,8 +274,6 @@ func adminListenAddress(host string, port int) string {
 	return net.JoinHostPort(host, fmt.Sprintf("%d", port))
 }
 
-// adminBaseURL returns the canonical HTTP base URL for the admin server. Used
-// to build OIDC issuer URLs and redirect URIs for the auto-configured local issuer.
 func adminBaseURL(host string, port int) string {
 	h := host
 	if h == "" {
@@ -349,9 +282,6 @@ func adminBaseURL(host string, port int) string {
 	return "http://" + net.JoinHostPort(h, fmt.Sprintf("%d", port))
 }
 
-// resolveBaseURL returns the public base URL for OIDC issuer and redirect URI
-// construction. STELLA_BASE_URL takes precedence; falls back to the local listen
-// address. Set STELLA_BASE_URL when running behind a reverse proxy.
 func resolveBaseURL(adminHost string, adminPort int) string {
 	if v := os.Getenv("STELLA_BASE_URL"); v != "" {
 		return strings.TrimRight(v, "/")
@@ -413,12 +343,4 @@ func (s *orgSeeder) SeedOrg(ctx context.Context, orgID string) error {
 		return fmt.Errorf("seed policies: %w", err)
 	}
 	return nil
-}
-
-func noRunningChannelReason(managedChannels managedChannelRuntimeSummary) string {
-	if managedChannels.Configured > 0 {
-		return "configured channels failed to start"
-	}
-
-	return "no channels configured"
 }

--- a/cmd/stella/models.go
+++ b/cmd/stella/models.go
@@ -9,9 +9,8 @@ import (
 
 // collectModelsFromStore builds the list of available provider/model pairs
 // using the Store and models cache.
-func collectModelsFromStore(ctx context.Context, store config.Store, snap *config.Snapshot) []pkgchannel.ModelOption {
+func collectModelsFromStore(ctx context.Context, store config.Store) []pkgchannel.ModelOption {
 	collector := newModelOptionCollector()
-	collector.Add(snap.Provider, snap.Model)
 
 	if cache, err := config.LoadModelsCache(); err == nil {
 		for _, model := range cache.Models {
@@ -23,7 +22,7 @@ func collectModelsFromStore(ctx context.Context, store config.Store, snap *confi
 	providers, err := store.ListProviders(ctx)
 	if err == nil {
 		for _, provider := range providers {
-			collector.Add(provider.ID, snap.Model)
+			collector.Add(provider.ID, "")
 		}
 	}
 

--- a/cmd/stella/plugin_services.go
+++ b/cmd/stella/plugin_services.go
@@ -58,7 +58,7 @@ func (a schedulerServiceAdapter) ReconcilePluginJobs(ctx context.Context, plugin
 		if err := a.service.RemoveJob(current.ID); err != nil {
 			return err
 		}
-		if _, err := a.createPluginJob(pluginID, spec); err != nil {
+		if _, err := a.createPluginJob(ctx, pluginID, spec); err != nil {
 			return err
 		}
 	}
@@ -70,7 +70,7 @@ func (a schedulerServiceAdapter) ReconcilePluginJobs(ctx context.Context, plugin
 		if _, exists := existingByKey[key]; exists {
 			continue
 		}
-		if _, err := a.createPluginJob(pluginID, spec); err != nil {
+		if _, err := a.createPluginJob(ctx, pluginID, spec); err != nil {
 			return err
 		}
 	}
@@ -117,8 +117,9 @@ func (a schedulerServiceAdapter) ListPluginJobs(ctx context.Context, pluginID st
 	return out, nil
 }
 
-func (a schedulerServiceAdapter) createPluginJob(pluginID string, spec pkgplugins.SchedulerJobSpec) (pkgplugins.SchedulerJob, error) {
+func (a schedulerServiceAdapter) createPluginJob(ctx context.Context, pluginID string, spec pkgplugins.SchedulerJobSpec) (pkgplugins.SchedulerJob, error) {
 	job, err := a.service.AddPluginJob(
+		ctx,
 		pluginID,
 		spec.Key,
 		spec.RuntimeName,

--- a/cmd/stella/setup_memory.go
+++ b/cmd/stella/setup_memory.go
@@ -16,11 +16,11 @@ import (
 	"github.com/CherryHQ/stella/pkg/providers"
 )
 
-func buildMemorySummarizer(defaultAgentID string, store config.Store, providerStreamBuilder agent.ProviderStreamBuilder) func(context.Context, string) (string, error) {
+func buildMemorySummarizer(store config.Store, providerStreamBuilder agent.ProviderStreamBuilder) func(context.Context, string) (string, error) {
 	return func(ctx context.Context, prompt string) (string, error) {
 		agentID := memory.AgentIDFromContext(ctx)
 		if agentID == "" {
-			agentID = defaultAgentID
+			return "", fmt.Errorf("no agent ID in context for memory summarizer")
 		}
 		currentSnap, err := store.Snapshot(ctx, agentID)
 		if err != nil {
@@ -61,8 +61,8 @@ func buildMemorySummarizer(defaultAgentID string, store config.Store, providerSt
 	}
 }
 
-func setupMemoryProvider(ctx context.Context, db *sql.DB, store config.Store, defaultAgentID string, providerStreamBuilder agent.ProviderStreamBuilder) (memory.Provider, error) {
-	summarizer := buildMemorySummarizer(defaultAgentID, store, providerStreamBuilder)
+func setupMemoryProvider(ctx context.Context, db *sql.DB, store config.Store, providerStreamBuilder agent.ProviderStreamBuilder) (memory.Provider, error) {
+	summarizer := buildMemorySummarizer(store, providerStreamBuilder)
 
 	name := "lcm"
 	cfg := map[string]any{}

--- a/cmd/stella/setup_memory.go
+++ b/cmd/stella/setup_memory.go
@@ -20,6 +20,11 @@ func buildMemorySummarizer(store config.Store, providerStreamBuilder agent.Provi
 	return func(ctx context.Context, prompt string) (string, error) {
 		agentID := memory.AgentIDFromContext(ctx)
 		if agentID == "" {
+			if agents, err := store.ListEnabledAgents(ctx); err == nil && len(agents) > 0 {
+				agentID = agents[0].ID
+			}
+		}
+		if agentID == "" {
 			return "", fmt.Errorf("no agent ID in context for memory summarizer")
 		}
 		currentSnap, err := store.Snapshot(ctx, agentID)

--- a/cmd/stella/setup_pool.go
+++ b/cmd/stella/setup_pool.go
@@ -3,20 +3,15 @@ package main
 import (
 	"context"
 	"database/sql"
-	"maps"
 
 	"github.com/google/uuid"
 
 	"github.com/CherryHQ/stella/internal/agent"
-	"github.com/CherryHQ/stella/internal/agent/prompt"
 	"github.com/CherryHQ/stella/internal/config"
 	"github.com/CherryHQ/stella/internal/pluginhost"
 	coreagent "github.com/CherryHQ/stella/pkg/agent"
-	pkgchannel "github.com/CherryHQ/stella/pkg/channel"
 	"github.com/CherryHQ/stella/pkg/db/sqlc"
 	pkgplugins "github.com/CherryHQ/stella/pkg/plugins"
-	"github.com/CherryHQ/stella/pkg/providers"
-	pkgtools "github.com/CherryHQ/stella/pkg/tools"
 )
 
 func buildToolLifecycle(phost *pluginhost.Host) *coreagent.ToolLifecycle {
@@ -97,70 +92,4 @@ func buildProjectEnsurer(db *sql.DB, store config.Store) agent.ProjectEnsurerFun
 		}
 		return p.ID, nil
 	}
-}
-
-func modelSwitcher(base *config.Snapshot, store config.Store, pool *agent.Pool, builtinTools []pkgtools.Tool, pluginToolsBuilder agent.PluginToolsBuilder, providerStreamBuilder agent.ProviderStreamBuilder, promptToolsFn prompt.ToolsBuilder, promptSectionsFn prompt.SectionsBuilder, sessionPluginViewFn agent.SessionPluginViewBuilder, toolLifecycle *coreagent.ToolLifecycle) func(string, string) error {
-	return func(provider, model string) error {
-		snap := *base
-		snap.Provider = provider
-		snap.Model = provider + "/" + model
-
-		if p, err := store.GetProvider(context.Background(), provider); err == nil {
-			providers := make(map[string]config.ProviderCreds, len(base.Providers)+1)
-			maps.Copy(providers, base.Providers)
-			providers[provider] = config.ProviderCreds{Type: p.Type, APIKey: p.APIKey, BaseURL: p.BaseURL}
-			snap.Providers = providers
-		}
-
-		factory, err := agent.NewRunnerFactory(agent.RunnerFactoryConfig{
-			Snap:                     &snap,
-			BuiltinTools:             builtinTools,
-			PluginToolsBuilder:       pluginToolsBuilder,
-			ProviderStreamBuilder:    providerStreamBuilder,
-			PromptToolsBuilder:       promptToolsFn,
-			PromptSectionsBuilder:    promptSectionsFn,
-			SessionPluginViewBuilder: sessionPluginViewFn,
-			ToolLifecycle:            toolLifecycle,
-		})
-		if err != nil {
-			return err
-		}
-		pool.SetFactory(factory)
-		pool.SetDefaultModel(snap.Model)
-		return nil
-	}
-}
-
-func (s *setupResult) modelListFunc(snap *config.Snapshot) func() []pkgchannel.ModelOption {
-	return func() []pkgchannel.ModelOption {
-		return collectModelsFromStore(s.ctx, s.store, snap)
-	}
-}
-
-func (s *setupResult) modelSwitchFunc(snap *config.Snapshot, pool *agent.Pool) func(string, string) error {
-	return modelSwitcher(
-		snap,
-		s.store,
-		pool,
-		s.builtinTools,
-		s.pluginToolsBuilder,
-		func(api, apiKey, baseURL string) (providers.StreamFunc, error) {
-			provider, err := s.store.GetProvider(s.ctx, api)
-			if err != nil {
-				return nil, err
-			}
-			providerType := provider.Type
-			if providerType == "" {
-				providerType = provider.ID
-			}
-			return s.pluginHost.BuildStreamFunc(providerType, map[string]any{
-				"api_key":  apiKey,
-				"base_url": baseURL,
-			})
-		},
-		s.promptToolsBuilder,
-		s.promptSectionsBuilder,
-		s.sessionPluginViewBuilder,
-		s.toolLifecycle,
-	)
 }

--- a/cmd/stella/setup_skills.go
+++ b/cmd/stella/setup_skills.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"log/slog"
 	"path/filepath"
 
 	"github.com/CherryHQ/stella/internal/agent"
@@ -63,24 +62,4 @@ func setupSkillStores(ctx context.Context, db *sql.DB, orgID string) (skillStore
 	}
 
 	return skillStores{raw: raw, diskSync: diskSync}, nil
-}
-
-func migrateFilesystemSkills(ctx context.Context, rawStore *skills.SQLiteStore, snap *config.Snapshot) {
-	userSkillsDir, err := cliUserSkillsDir(snap)
-	if err != nil {
-		slog.Warn("skip filesystem skill migration", "error", err)
-		return
-	}
-	fsCfg := skills.MigrateFSConfig{
-		AgentRoot:     snap.Workspace,
-		AgentID:       snap.AgentID,
-		UserSkillsDir: userSkillsDir,
-		UserID:        cliSkillsUserID,
-	}
-	fsResult, fsErr := skills.MigrateFilesystem(ctx, rawStore, fsCfg)
-	if fsErr != nil {
-		slog.Warn("filesystem skill migration failed", "error", fsErr)
-	} else if fsResult.Imported > 0 {
-		slog.Info("migrated on-disk skills", "imported", fsResult.Imported, "skipped", fsResult.Skipped)
-	}
 }

--- a/internal/agent/pool_manager.go
+++ b/internal/agent/pool_manager.go
@@ -277,7 +277,8 @@ func (pm *PoolManager) StartAll(ctx context.Context) error {
 		return fmt.Errorf("list enabled agents: %w", err)
 	}
 	if len(agents) == 0 {
-		return fmt.Errorf("no enabled agents found")
+		pm.log.Info("no enabled agents found, pool manager started empty")
+		return nil
 	}
 
 	for _, ag := range agents {
@@ -292,7 +293,8 @@ func (pm *PoolManager) StartAll(ctx context.Context) error {
 	pm.mu.RUnlock()
 
 	if count == 0 {
-		return fmt.Errorf("no agents could be started")
+		pm.log.Warn("agents found but none could be started")
+		return nil
 	}
 
 	pm.log.Info("all agents started", "count", count)

--- a/internal/agent/pool_manager_test.go
+++ b/internal/agent/pool_manager_test.go
@@ -278,7 +278,10 @@ func TestPoolManagerStartAllNoAgents(t *testing.T) {
 	pm := NewPoolManager(store, mem)
 
 	err := pm.StartAll(context.Background())
-	if err == nil {
-		t.Fatal("expected error for no agents")
+	if err != nil {
+		t.Fatalf("StartAll with no agents should succeed, got: %v", err)
+	}
+	if pm.DefaultPool() != nil {
+		t.Fatal("expected no pools after starting with zero agents")
 	}
 }

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -26,6 +26,7 @@ type AuthService struct {
 	memberships   MembershipStore
 	invites       InviteStore
 	seeder        OrgSeeder
+	orgInit       OrgInitializer
 	db            *sql.DB
 }
 
@@ -53,14 +54,31 @@ func NewAuthService(
 // SetOrgSeeder registers a seeder that populates default resources when a new org is created.
 func (s *AuthService) SetOrgSeeder(seeder OrgSeeder) { s.seeder = seeder }
 
+// OrgInitializer is called after successful login to ensure per-org runtime is started.
+type OrgInitializer interface {
+	EnsureStarted(ctx context.Context, orgID string) error
+}
+
+// SetOrgInitializer registers a callback to initialize per-org runtime after login.
+func (s *AuthService) SetOrgInitializer(init OrgInitializer) { s.orgInit = init }
+
+// InitOrg initializes per-org runtime for the given org, if an initializer is set.
+func (s *AuthService) InitOrg(ctx context.Context, orgID string) error {
+	if s.orgInit != nil {
+		return s.orgInit.EnsureStarted(ctx, orgID)
+	}
+	return nil
+}
+
 // OIDCLoginResult holds everything the HTTP handler needs after a successful
 // OIDC callback.
 type OIDCLoginResult struct {
-	User         User
-	Session      Session
-	Membership   Membership
-	IsNewUser    bool
-	SessionToken string // raw token for the session cookie (not stored in DB)
+	User           User
+	Session        Session
+	Membership     Membership
+	IsNewUser      bool
+	NeedsSeedOrgID string // non-empty when a new org was created and needs seeding
+	SessionToken   string // raw token for the session cookie (not stored in DB)
 }
 
 // ProcessOIDCLogin is the single transaction entry point for an OIDC callback.
@@ -97,7 +115,6 @@ func (s *AuthService) processOIDCLoginTx(ctx context.Context, txner Transactione
 		organizations: stores.Organizations,
 		memberships:   stores.Memberships,
 		invites:       stores.Invites,
-		seeder:        s.seeder,
 		db:            s.db,
 	}
 	// Session insert must also run inside the transaction.
@@ -110,6 +127,14 @@ func (s *AuthService) processOIDCLoginTx(ctx context.Context, txner Transactione
 	if err := commit(); err != nil {
 		return OIDCLoginResult{}, fmt.Errorf("auth: commit login tx: %w", err)
 	}
+
+	// Seed after commit using the outer (non-tx) seeder.
+	if result.NeedsSeedOrgID != "" && s.seeder != nil {
+		if err := s.seeder.SeedOrg(ctx, result.NeedsSeedOrgID); err != nil {
+			return OIDCLoginResult{}, fmt.Errorf("auth: seed new org: %w", err)
+		}
+	}
+
 	return result, nil
 }
 
@@ -120,9 +145,15 @@ func (s *AuthService) processOIDCLoginNoTx(ctx context.Context, ext ExternalIden
 		return OIDCLoginResult{}, fmt.Errorf("auth: resolve user: %w", err)
 	}
 
-	membership, err := s.ensureMembership(ctx, user.ID)
+	membership, needsSeedOrgID, err := s.ensureMembership(ctx, user.ID)
 	if err != nil {
 		return OIDCLoginResult{}, fmt.Errorf("auth: manage membership: %w", err)
+	}
+
+	if needsSeedOrgID != "" && s.seeder != nil {
+		if err := s.seeder.SeedOrg(ctx, needsSeedOrgID); err != nil {
+			return OIDCLoginResult{}, fmt.Errorf("auth: seed new org: %w", err)
+		}
 	}
 
 	rawToken, session, err := sessionMgr.Create(ctx, user.ID)
@@ -131,11 +162,12 @@ func (s *AuthService) processOIDCLoginNoTx(ctx context.Context, ext ExternalIden
 	}
 
 	return OIDCLoginResult{
-		User:         user,
-		Session:      session,
-		Membership:   membership,
-		IsNewUser:    isNewUser,
-		SessionToken: rawToken,
+		User:           user,
+		Session:        session,
+		Membership:     membership,
+		IsNewUser:      isNewUser,
+		NeedsSeedOrgID: needsSeedOrgID,
+		SessionToken:   rawToken,
 	}, nil
 }
 
@@ -177,9 +209,18 @@ func (s *AuthService) PrincipalFromToken(ctx context.Context, rawToken string) (
 }
 
 // EnsureMembership returns the user's existing membership or creates a new org
-// (with default seed data) and membership if they don't have one yet.
+// and membership if they don't have one yet. Seeds the new org if a seeder is set.
 func (s *AuthService) EnsureMembership(ctx context.Context, userID string) (Membership, error) {
-	return s.ensureMembership(ctx, userID)
+	m, needsSeedOrgID, err := s.ensureMembership(ctx, userID)
+	if err != nil {
+		return Membership{}, err
+	}
+	if needsSeedOrgID != "" && s.seeder != nil {
+		if err := s.seeder.SeedOrg(ctx, needsSeedOrgID); err != nil {
+			return Membership{}, fmt.Errorf("auth: seed new org: %w", err)
+		}
+	}
+	return m, nil
 }
 
 // GetUserMembership returns the user's current org membership.
@@ -406,31 +447,31 @@ func (s *AuthService) resolveUser(ctx context.Context, ext ExternalIdentity) (Us
 }
 
 // ensureMembership returns the user's existing membership or creates a new org
-// (with seeded defaults) and membership if they don't have one yet.
-func (s *AuthService) ensureMembership(ctx context.Context, userID string) (Membership, error) {
+// and membership if they don't have one yet. Does NOT seed the org — the caller
+// must check needsSeedOrgID and call SeedOrg after commit.
+func (s *AuthService) ensureMembership(ctx context.Context, userID string) (membership Membership, needsSeedOrgID string, err error) {
 	existing, err := s.memberships.GetUserMembership(ctx, userID)
 	if err == nil {
-		return existing, nil
+		return existing, "", nil
 	}
 	if !errors.Is(err, sql.ErrNoRows) {
-		return Membership{}, err
+		return Membership{}, "", err
 	}
 
 	org, err := s.createOrganization(ctx)
 	if err != nil {
-		return Membership{}, fmt.Errorf("auth: create org for new user: %w", err)
-	}
-	if s.seeder != nil {
-		if err := s.seeder.SeedOrg(ctx, org.ID); err != nil {
-			return Membership{}, fmt.Errorf("auth: seed new org: %w", err)
-		}
+		return Membership{}, "", fmt.Errorf("auth: create org for new user: %w", err)
 	}
 
-	return s.memberships.CreateMembership(ctx, Membership{
+	m, err := s.memberships.CreateMembership(ctx, Membership{
 		ID:             uuid.NewString(),
 		UserID:         userID,
 		OrganizationID: org.ID,
 		Role:           RoleAdmin,
 		IsActive:       true,
 	})
+	if err != nil {
+		return Membership{}, "", err
+	}
+	return m, org.ID, nil
 }

--- a/internal/channel/coordinator.go
+++ b/internal/channel/coordinator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"filippo.io/age"
@@ -29,6 +30,11 @@ type channelAuthStore interface {
 // management, command handling, account linking, and model/agent switching.
 // A per-session message queue ensures that only one chat turn runs at a time
 // per resolved Stella session; later messages are serialised in arrival order.
+// OrgRuntimeInitializer ensures per-org runtime is started before processing messages.
+type OrgRuntimeInitializer interface {
+	EnsureStarted(ctx context.Context, orgID string) error
+}
+
 type Coordinator struct {
 	poolManager      *agent.PoolManager
 	store            config.Store
@@ -41,6 +47,7 @@ type Coordinator struct {
 	switchFn         func(provider, model string) error
 	queue            *sessionQueue
 	intentClassifier IntentClassifier
+	orgInit          OrgRuntimeInitializer
 }
 
 // CoordinatorOption configures the Coordinator.
@@ -97,12 +104,33 @@ func WithIntentClassifier(classifier IntentClassifier) CoordinatorOption {
 	}
 }
 
+// WithOrgRuntimeInitializer sets the org runtime initializer for lazy per-org startup.
+func WithOrgRuntimeInitializer(init OrgRuntimeInitializer) CoordinatorOption {
+	return func(c *Coordinator) {
+		c.orgInit = init
+	}
+}
+
 // resolve performs the full user -> agent -> pool -> session key resolution.
+// If an org runtime initializer is set, it ensures the user's org runtime is
+// started before resolving the agent pool.
 func (c *Coordinator) resolve(ctx context.Context, msg pkgchannel.IncomingMessage) (*ResolvedChat, error) {
 	channelID := msg.ChannelID
 	if channelID == "" {
 		channelID = msg.Platform
 	}
+
+	if c.orgInit != nil && c.auth != nil {
+		resolved, _, err := ResolveUserCandidates(ctx, c.auth, msg.Platform, append([]string{msg.SenderID}, msg.SenderIDs...))
+		if err == nil && resolved.User.ID != "" {
+			if membership, err := c.auth.GetUserMembership(ctx, resolved.User.ID); err == nil {
+				if err := c.orgInit.EnsureStarted(ctx, membership.OrganizationID); err != nil {
+					slog.Warn("channel: org runtime init failed", "org_id", membership.OrganizationID, "error", err)
+				}
+			}
+		}
+	}
+
 	return ResolveWithChannel(ctx, c.poolManager, c.store, c.auth, c.engine, msg.Platform, channelID, msg.SenderID, msg.SenderIDs, msg.SenderName, msg.ChatID, msg.IsGroup)
 }
 

--- a/internal/channel/coordinator.go
+++ b/internal/channel/coordinator.go
@@ -113,7 +113,9 @@ func WithOrgRuntimeInitializer(init OrgRuntimeInitializer) CoordinatorOption {
 
 // resolve performs the full user -> agent -> pool -> session key resolution.
 // If an org runtime initializer is set, it ensures the user's org runtime is
-// started before resolving the agent pool.
+// started before resolving the agent pool (which requires synced agents).
+// The org init only fires for users with an existing membership — unregistered
+// senders are skipped.
 func (c *Coordinator) resolve(ctx context.Context, msg pkgchannel.IncomingMessage) (*ResolvedChat, error) {
 	channelID := msg.ChannelID
 	if channelID == "" {

--- a/internal/db/queries/sched_job.sql
+++ b/internal/db/queries/sched_job.sql
@@ -11,6 +11,9 @@ RETURNING *;
 -- name: ListSchedulerJobs :many
 SELECT * FROM sched_job WHERE org_id = ? ORDER BY created_at;
 
+-- name: ListAllSchedulerJobs :many
+SELECT * FROM sched_job ORDER BY created_at;
+
 -- name: ListSchedulerJobsByAgent :many
 SELECT * FROM sched_job
 WHERE org_id = ?

--- a/internal/orgruntime/orgruntime.go
+++ b/internal/orgruntime/orgruntime.go
@@ -1,0 +1,113 @@
+package orgruntime
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/CherryHQ/stella/internal/config"
+)
+
+// AgentSyncer syncs an agent's pool by ID using an org-scoped context.
+type AgentSyncer interface {
+	SyncAgent(ctx context.Context, agentID string) error
+}
+
+// ChannelStarter starts all managed channel runtimes for an org-scoped context.
+type ChannelStarter interface {
+	StartChannels(ctx context.Context) error
+}
+
+// OrgRuntime holds per-org lifecycle state while using shared infrastructure.
+type OrgRuntime struct {
+	orgID   string
+	started bool
+	mu      sync.Mutex
+}
+
+// OrgID returns the org's ID.
+func (r *OrgRuntime) OrgID() string { return r.orgID }
+
+// Start initializes runtime services for this org: syncs agent pools,
+// starts channel runtimes, and ensures builtin scheduler jobs.
+func (r *OrgRuntime) Start(ctx context.Context, store config.Store, syncer AgentSyncer, channels ChannelStarter) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.started {
+		return nil
+	}
+
+	orgCtx := config.WithOrgID(ctx, r.orgID)
+
+	agents, err := store.ListEnabledAgents(orgCtx)
+	if err != nil {
+		return fmt.Errorf("orgruntime: list agents for org %s: %w", r.orgID, err)
+	}
+	for _, a := range agents {
+		if err := syncer.SyncAgent(orgCtx, a.ID); err != nil {
+			slog.Warn("orgruntime: sync agent failed", "org_id", r.orgID, "agent_id", a.ID, "error", err)
+		}
+	}
+
+	if channels != nil {
+		if err := channels.StartChannels(orgCtx); err != nil {
+			slog.Warn("orgruntime: start channels failed", "org_id", r.orgID, "error", err)
+		}
+	}
+
+	r.started = true
+	slog.Info("orgruntime: started", "org_id", r.orgID, "agents", len(agents))
+	return nil
+}
+
+// Manager creates and caches OrgRuntime instances. Thread-safe.
+type Manager struct {
+	mu       sync.Mutex
+	runtimes map[string]*OrgRuntime
+
+	store    config.Store
+	syncer   AgentSyncer
+	channels ChannelStarter
+}
+
+// ManagerDeps holds the shared dependencies injected into Manager.
+type ManagerDeps struct {
+	Store    config.Store
+	Syncer   AgentSyncer
+	Channels ChannelStarter
+}
+
+// NewManager creates a Manager with the given shared dependencies.
+func NewManager(deps ManagerDeps) *Manager {
+	return &Manager{
+		runtimes: make(map[string]*OrgRuntime),
+		store:    deps.Store,
+		syncer:   deps.Syncer,
+		channels: deps.Channels,
+	}
+}
+
+// GetOrInit returns the cached OrgRuntime for orgID, or creates and starts one.
+// It does NOT seed the org — the org must already exist with seeded data.
+// Idempotent and safe for concurrent calls.
+func (m *Manager) GetOrInit(ctx context.Context, orgID string) (*OrgRuntime, error) {
+	m.mu.Lock()
+	if rt, ok := m.runtimes[orgID]; ok {
+		m.mu.Unlock()
+		return rt, nil
+	}
+
+	rt := &OrgRuntime{orgID: orgID}
+	m.runtimes[orgID] = rt
+	m.mu.Unlock()
+
+	if err := rt.Start(ctx, m.store, m.syncer, m.channels); err != nil {
+		m.mu.Lock()
+		delete(m.runtimes, orgID)
+		m.mu.Unlock()
+		return nil, fmt.Errorf("orgruntime: init org %s: %w", orgID, err)
+	}
+
+	return rt, nil
+}

--- a/internal/orgruntime/orgruntime.go
+++ b/internal/orgruntime/orgruntime.go
@@ -19,11 +19,16 @@ type ChannelStarter interface {
 	StartChannels(ctx context.Context) error
 }
 
+// BuiltinJobSeeder ensures builtin scheduler jobs exist for an org.
+type BuiltinJobSeeder interface {
+	EnsureBuiltinJobs(orgID string)
+}
+
 // OrgRuntime holds per-org lifecycle state while using shared infrastructure.
 type OrgRuntime struct {
-	orgID   string
-	started bool
-	mu      sync.Mutex
+	orgID    string
+	once     sync.Once
+	startErr error
 }
 
 // OrgID returns the org's ID.
@@ -31,13 +36,16 @@ func (r *OrgRuntime) OrgID() string { return r.orgID }
 
 // Start initializes runtime services for this org: syncs agent pools,
 // starts channel runtimes, and ensures builtin scheduler jobs.
-func (r *OrgRuntime) Start(ctx context.Context, store config.Store, syncer AgentSyncer, channels ChannelStarter) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if r.started {
-		return nil
-	}
+// Safe for concurrent calls — only the first caller does the work,
+// all others block until it completes.
+func (r *OrgRuntime) Start(ctx context.Context, store config.Store, syncer AgentSyncer, channels ChannelStarter, jobs BuiltinJobSeeder) error {
+	r.once.Do(func() {
+		r.startErr = r.doStart(ctx, store, syncer, channels, jobs)
+	})
+	return r.startErr
+}
 
+func (r *OrgRuntime) doStart(ctx context.Context, store config.Store, syncer AgentSyncer, channels ChannelStarter, jobs BuiltinJobSeeder) error {
 	orgCtx := config.WithOrgID(ctx, r.orgID)
 
 	agents, err := store.ListEnabledAgents(orgCtx)
@@ -56,7 +64,10 @@ func (r *OrgRuntime) Start(ctx context.Context, store config.Store, syncer Agent
 		}
 	}
 
-	r.started = true
+	if jobs != nil {
+		jobs.EnsureBuiltinJobs(r.orgID)
+	}
+
 	slog.Info("orgruntime: started", "org_id", r.orgID, "agents", len(agents))
 	return nil
 }
@@ -69,6 +80,7 @@ type Manager struct {
 	store    config.Store
 	syncer   AgentSyncer
 	channels ChannelStarter
+	jobs     BuiltinJobSeeder
 }
 
 // ManagerDeps holds the shared dependencies injected into Manager.
@@ -76,6 +88,7 @@ type ManagerDeps struct {
 	Store    config.Store
 	Syncer   AgentSyncer
 	Channels ChannelStarter
+	Jobs     BuiltinJobSeeder
 }
 
 // NewManager creates a Manager with the given shared dependencies.
@@ -85,24 +98,23 @@ func NewManager(deps ManagerDeps) *Manager {
 		store:    deps.Store,
 		syncer:   deps.Syncer,
 		channels: deps.Channels,
+		jobs:     deps.Jobs,
 	}
 }
 
 // GetOrInit returns the cached OrgRuntime for orgID, or creates and starts one.
 // It does NOT seed the org — the org must already exist with seeded data.
-// Idempotent and safe for concurrent calls.
+// Concurrent calls for the same orgID block until the first caller's Start completes.
 func (m *Manager) GetOrInit(ctx context.Context, orgID string) (*OrgRuntime, error) {
 	m.mu.Lock()
-	if rt, ok := m.runtimes[orgID]; ok {
-		m.mu.Unlock()
-		return rt, nil
+	rt, ok := m.runtimes[orgID]
+	if !ok {
+		rt = &OrgRuntime{orgID: orgID}
+		m.runtimes[orgID] = rt
 	}
-
-	rt := &OrgRuntime{orgID: orgID}
-	m.runtimes[orgID] = rt
 	m.mu.Unlock()
 
-	if err := rt.Start(ctx, m.store, m.syncer, m.channels); err != nil {
+	if err := rt.Start(ctx, m.store, m.syncer, m.channels, m.jobs); err != nil {
 		m.mu.Lock()
 		delete(m.runtimes, orgID)
 		m.mu.Unlock()

--- a/internal/orgruntime/orgruntime.go
+++ b/internal/orgruntime/orgruntime.go
@@ -111,3 +111,10 @@ func (m *Manager) GetOrInit(ctx context.Context, orgID string) (*OrgRuntime, err
 
 	return rt, nil
 }
+
+// EnsureStarted satisfies auth.OrgInitializer — starts the org runtime,
+// discarding the *OrgRuntime value.
+func (m *Manager) EnsureStarted(ctx context.Context, orgID string) error {
+	_, err := m.GetOrInit(ctx, orgID)
+	return err
+}

--- a/internal/orgruntime/orgruntime.go
+++ b/internal/orgruntime/orgruntime.go
@@ -124,6 +124,14 @@ func (m *Manager) GetOrInit(ctx context.Context, orgID string) (*OrgRuntime, err
 	return rt, nil
 }
 
+// SetChannels wires the ChannelStarter after construction (the coordinator
+// is created after the Manager and implements this interface).
+func (m *Manager) SetChannels(ch ChannelStarter) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.channels = ch
+}
+
 // EnsureStarted satisfies auth.OrgInitializer — starts the org runtime,
 // discarding the *OrgRuntime value.
 func (m *Manager) EnsureStarted(ctx context.Context, orgID string) error {

--- a/internal/orgruntime/orgruntime_test.go
+++ b/internal/orgruntime/orgruntime_test.go
@@ -1,0 +1,206 @@
+package orgruntime
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/CherryHQ/stella/internal/config"
+)
+
+type fakeStore struct {
+	config.Store
+	agents []config.Agent
+	err    error
+}
+
+func (s *fakeStore) ListEnabledAgents(_ context.Context) ([]config.Agent, error) {
+	return s.agents, s.err
+}
+
+type fakeSyncer struct {
+	mu      sync.Mutex
+	synced  []string
+	failFor map[string]bool
+}
+
+func (s *fakeSyncer) SyncAgent(_ context.Context, agentID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.failFor[agentID] {
+		return errors.New("sync failed")
+	}
+	s.synced = append(s.synced, agentID)
+	return nil
+}
+
+type fakeChannels struct {
+	started bool
+	err     error
+}
+
+func (c *fakeChannels) StartChannels(_ context.Context) error {
+	c.started = true
+	return c.err
+}
+
+func TestGetOrInit_CachesRuntime(t *testing.T) {
+	store := &fakeStore{agents: []config.Agent{{ID: "a1"}}}
+	syncer := &fakeSyncer{}
+	mgr := NewManager(ManagerDeps{Store: store, Syncer: syncer})
+
+	rt1, err := mgr.GetOrInit(context.Background(), "org1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt2, err := mgr.GetOrInit(context.Background(), "org1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rt1 != rt2 {
+		t.Error("expected same OrgRuntime instance for same orgID")
+	}
+	if len(syncer.synced) != 1 {
+		t.Errorf("expected 1 SyncAgent call, got %d", len(syncer.synced))
+	}
+}
+
+func TestGetOrInit_SyncsAllAgents(t *testing.T) {
+	store := &fakeStore{agents: []config.Agent{{ID: "a1"}, {ID: "a2"}, {ID: "a3"}}}
+	syncer := &fakeSyncer{}
+	mgr := NewManager(ManagerDeps{Store: store, Syncer: syncer})
+
+	_, err := mgr.GetOrInit(context.Background(), "org1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(syncer.synced) != 3 {
+		t.Errorf("expected 3 SyncAgent calls, got %d", len(syncer.synced))
+	}
+}
+
+func TestGetOrInit_StartsChannels(t *testing.T) {
+	store := &fakeStore{agents: []config.Agent{}}
+	syncer := &fakeSyncer{}
+	channels := &fakeChannels{}
+	mgr := NewManager(ManagerDeps{Store: store, Syncer: syncer, Channels: channels})
+
+	_, err := mgr.GetOrInit(context.Background(), "org1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !channels.started {
+		t.Error("expected channels to be started")
+	}
+}
+
+func TestGetOrInit_NilChannels(t *testing.T) {
+	store := &fakeStore{agents: []config.Agent{}}
+	syncer := &fakeSyncer{}
+	mgr := NewManager(ManagerDeps{Store: store, Syncer: syncer})
+
+	_, err := mgr.GetOrInit(context.Background(), "org1")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGetOrInit_ListAgentsError(t *testing.T) {
+	store := &fakeStore{err: errors.New("db down")}
+	syncer := &fakeSyncer{}
+	mgr := NewManager(ManagerDeps{Store: store, Syncer: syncer})
+
+	_, err := mgr.GetOrInit(context.Background(), "org1")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	// After failure, cache should not retain the failed runtime.
+	store.err = nil
+	store.agents = []config.Agent{{ID: "a1"}}
+	rt, err := mgr.GetOrInit(context.Background(), "org1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rt.OrgID() != "org1" {
+		t.Errorf("expected org1, got %s", rt.OrgID())
+	}
+}
+
+func TestGetOrInit_NoImplicitSeeding(t *testing.T) {
+	store := &fakeStore{agents: []config.Agent{}}
+	syncer := &fakeSyncer{}
+	mgr := NewManager(ManagerDeps{Store: store, Syncer: syncer})
+
+	rt, err := mgr.GetOrInit(context.Background(), "org1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rt.OrgID() != "org1" {
+		t.Errorf("expected org1, got %s", rt.OrgID())
+	}
+}
+
+func TestGetOrInit_Concurrent(t *testing.T) {
+	store := &fakeStore{agents: []config.Agent{{ID: "a1"}}}
+	syncer := &fakeSyncer{}
+	mgr := NewManager(ManagerDeps{Store: store, Syncer: syncer})
+
+	var wg sync.WaitGroup
+	results := make([]*OrgRuntime, 10)
+	errs := make([]error, 10)
+	for i := range 10 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			results[i], errs[i] = mgr.GetOrInit(context.Background(), "org1")
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("goroutine %d got error: %v", i, err)
+		}
+	}
+	for i := 1; i < len(results); i++ {
+		if results[i] != results[0] {
+			t.Error("expected all goroutines to get the same OrgRuntime")
+		}
+	}
+}
+
+func TestGetOrInit_DifferentOrgs(t *testing.T) {
+	store := &fakeStore{agents: []config.Agent{{ID: "a1"}}}
+	syncer := &fakeSyncer{}
+	mgr := NewManager(ManagerDeps{Store: store, Syncer: syncer})
+
+	rt1, err := mgr.GetOrInit(context.Background(), "org1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt2, err := mgr.GetOrInit(context.Background(), "org2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rt1 == rt2 {
+		t.Error("expected different OrgRuntime instances for different orgIDs")
+	}
+}
+
+func TestStart_Idempotent(t *testing.T) {
+	store := &fakeStore{agents: []config.Agent{{ID: "a1"}}}
+	syncer := &fakeSyncer{}
+	rt := &OrgRuntime{orgID: "org1"}
+
+	if err := rt.Start(context.Background(), store, syncer, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.Start(context.Background(), store, syncer, nil); err != nil {
+		t.Fatal(err)
+	}
+	if len(syncer.synced) != 1 {
+		t.Errorf("expected 1 SyncAgent call (idempotent), got %d", len(syncer.synced))
+	}
+}

--- a/internal/orgruntime/orgruntime_test.go
+++ b/internal/orgruntime/orgruntime_test.go
@@ -116,7 +116,7 @@ func TestGetOrInit_ListAgentsError(t *testing.T) {
 		t.Fatal("expected error")
 	}
 
-	// After failure, cache should not retain the failed runtime.
+	// After failure, cache entry is removed so a fresh OrgRuntime is created on retry.
 	store.err = nil
 	store.agents = []config.Agent{{ID: "a1"}}
 	rt, err := mgr.GetOrInit(context.Background(), "org1")
@@ -194,10 +194,10 @@ func TestStart_Idempotent(t *testing.T) {
 	syncer := &fakeSyncer{}
 	rt := &OrgRuntime{orgID: "org1"}
 
-	if err := rt.Start(context.Background(), store, syncer, nil); err != nil {
+	if err := rt.Start(context.Background(), store, syncer, nil, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := rt.Start(context.Background(), store, syncer, nil); err != nil {
+	if err := rt.Start(context.Background(), store, syncer, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	if len(syncer.synced) != 1 {

--- a/internal/scheduler/builtin.go
+++ b/internal/scheduler/builtin.go
@@ -30,16 +30,16 @@ func RegisterBuiltin(job BuiltinJob) {
 	builtinJobs = append(builtinJobs, job)
 }
 
-// EnsureBuiltinJobs creates or updates all builtin jobs (one DB row per job regardless of ExecScope).
+// EnsureBuiltinJobs creates or updates all builtin jobs for the given org.
 // For ExecScopeAllUsers jobs the scheduler fans out to all active users at execution time.
-func (s *Service) EnsureBuiltinJobs() {
+func (s *Service) EnsureBuiltinJobs(orgID string) {
 	builtinMu.Lock()
 	jobs := append([]BuiltinJob(nil), builtinJobs...)
 	builtinMu.Unlock()
 
 	for _, j := range jobs {
-		if _, err := s.EnsureJob(j.Name, j.Message, j.Schedule, j.SessionMode, j.AgentID, j.ExecScope); err != nil {
-			s.log.Warn("failed to ensure builtin job", "name", j.Name, "error", err)
+		if _, err := s.EnsureJob(j.Name, j.Message, j.Schedule, j.SessionMode, j.AgentID, j.ExecScope, orgID); err != nil {
+			s.log.Warn("failed to ensure builtin job", "name", j.Name, "org_id", orgID, "error", err)
 		}
 	}
 }

--- a/internal/scheduler/builtin_test.go
+++ b/internal/scheduler/builtin_test.go
@@ -45,10 +45,10 @@ func TestBuiltinDigestJobRegistered(t *testing.T) {
 }
 
 func TestEnsureBuiltinJobs(t *testing.T) {
-	svc := testService(t)
+	svc, orgID := testService(t)
 
 	// EnsureBuiltinJobs creates one row per builtin regardless of ExecScope.
-	svc.EnsureBuiltinJobs()
+	svc.EnsureBuiltinJobs(orgID)
 
 	found := false
 	for _, j := range svc.ListJobs() {
@@ -67,7 +67,7 @@ func TestEnsureBuiltinJobs(t *testing.T) {
 	}
 
 	// Idempotent: second call does not duplicate.
-	svc.EnsureBuiltinJobs()
+	svc.EnsureBuiltinJobs(orgID)
 	count := 0
 	for _, j := range svc.ListJobs() {
 		if j.Name == "recally-rss" {

--- a/internal/scheduler/persistence.go
+++ b/internal/scheduler/persistence.go
@@ -18,7 +18,7 @@ const dbTimeLayout = "2006-01-02 15:04:05"
 
 // loadJobs reads all persisted jobs from the database.
 func (s *Service) loadJobs(ctx context.Context) ([]Job, error) {
-	rows, err := s.q.ListSchedulerJobs(ctx, s.defaultOrgID)
+	rows, err := s.q.ListAllSchedulerJobs(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list scheduler jobs: %w", err)
 	}
@@ -46,18 +46,26 @@ func (s *Service) recordJobRun(ctx context.Context, id string, ranAt time.Time, 
 	if runErr != nil {
 		lastError = runErr.Error()
 	}
+	job, ok := s.jobs[id]
+	if !ok {
+		return fmt.Errorf("job %q not found in memory", id)
+	}
 	return s.q.RecordSchedulerJobRun(ctx, sqlc.RecordSchedulerJobRunParams{
 		LastRunAt: sql.NullString{String: ranAt.UTC().Format(dbTimeLayout), Valid: true},
 		LastError: lastError,
 		UpdatedAt: ranAt.UTC().Format(dbTimeLayout),
 		ID:        id,
-		OrgID:     s.defaultOrgID,
+		OrgID:     job.OrgID,
 	})
 }
 
 // deleteJob removes a job from the database.
 func (s *Service) deleteJob(ctx context.Context, id string) error {
-	return s.q.DeleteSchedulerJob(ctx, sqlc.DeleteSchedulerJobParams{ID: id, OrgID: s.defaultOrgID})
+	job, ok := s.jobs[id]
+	if !ok {
+		return fmt.Errorf("job %q not found in memory", id)
+	}
+	return s.q.DeleteSchedulerJob(ctx, sqlc.DeleteSchedulerJobParams{ID: id, OrgID: job.OrgID})
 }
 
 // migrateJobsFile imports jobs from the legacy jobs.json file into the database
@@ -92,9 +100,6 @@ func (s *Service) migrateJobsFile(ctx context.Context, dataPath string) error {
 
 	qtx := s.q.WithTx(tx)
 	for _, job := range jobs {
-		if job.OrgID == "" {
-			job.OrgID = s.defaultOrgID
-		}
 		if _, err := qtx.CreateSchedulerJob(ctx, createSchedulerJobParams(job)); err != nil {
 			return fmt.Errorf("migrate job %s: %w", job.ID, err)
 		}
@@ -112,7 +117,7 @@ func (s *Service) migrateJobsFile(ctx context.Context, dataPath string) error {
 // migrateLegacyPluginJobs converts plugin-owned jobs that still use the old
 // reserved message envelope into first-class ownership columns.
 func (s *Service) migrateLegacyPluginJobs(ctx context.Context) error {
-	rows, err := s.q.ListSchedulerJobs(ctx, s.defaultOrgID)
+	rows, err := s.q.ListAllSchedulerJobs(ctx)
 	if err != nil {
 		return fmt.Errorf("list scheduler jobs: %w", err)
 	}

--- a/internal/scheduler/persistence.go
+++ b/internal/scheduler/persistence.go
@@ -41,31 +41,23 @@ func (s *Service) updateJob(ctx context.Context, job Job) error {
 }
 
 // recordJobRun persists execution metadata for a job.
-func (s *Service) recordJobRun(ctx context.Context, id string, ranAt time.Time, runErr error) error {
+func (s *Service) recordJobRun(ctx context.Context, id, orgID string, ranAt time.Time, runErr error) error {
 	lastError := ""
 	if runErr != nil {
 		lastError = runErr.Error()
-	}
-	job, ok := s.jobs[id]
-	if !ok {
-		return fmt.Errorf("job %q not found in memory", id)
 	}
 	return s.q.RecordSchedulerJobRun(ctx, sqlc.RecordSchedulerJobRunParams{
 		LastRunAt: sql.NullString{String: ranAt.UTC().Format(dbTimeLayout), Valid: true},
 		LastError: lastError,
 		UpdatedAt: ranAt.UTC().Format(dbTimeLayout),
 		ID:        id,
-		OrgID:     job.OrgID,
+		OrgID:     orgID,
 	})
 }
 
 // deleteJob removes a job from the database.
-func (s *Service) deleteJob(ctx context.Context, id string) error {
-	job, ok := s.jobs[id]
-	if !ok {
-		return fmt.Errorf("job %q not found in memory", id)
-	}
-	return s.q.DeleteSchedulerJob(ctx, sqlc.DeleteSchedulerJobParams{ID: id, OrgID: job.OrgID})
+func (s *Service) deleteJob(ctx context.Context, id, orgID string) error {
+	return s.q.DeleteSchedulerJob(ctx, sqlc.DeleteSchedulerJobParams{ID: id, OrgID: orgID})
 }
 
 // migrateJobsFile imports jobs from the legacy jobs.json file into the database
@@ -92,6 +84,11 @@ func (s *Service) migrateJobsFile(ctx context.Context, dataPath string) error {
 		return nil
 	}
 
+	// Legacy jobs may lack OrgID. Look up the first existing org before
+	// starting the transaction to avoid SQLite lock contention.
+	var fallbackOrgID string
+	_ = s.db.QueryRowContext(ctx, `SELECT id FROM auth_organization ORDER BY created_at ASC LIMIT 1`).Scan(&fallbackOrgID)
+
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin migration tx: %w", err)
@@ -100,6 +97,13 @@ func (s *Service) migrateJobsFile(ctx context.Context, dataPath string) error {
 
 	qtx := s.q.WithTx(tx)
 	for _, job := range jobs {
+		if job.OrgID == "" {
+			if fallbackOrgID == "" {
+				s.log.Warn("skipping legacy job with no org_id (no orgs exist)", "job_id", job.ID)
+				continue
+			}
+			job.OrgID = fallbackOrgID
+		}
 		if _, err := qtx.CreateSchedulerJob(ctx, createSchedulerJobParams(job)); err != nil {
 			return fmt.Errorf("migrate job %s: %w", job.ID, err)
 		}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -35,37 +35,43 @@ func ensureTestOrg(t *testing.T, db *sql.DB) string {
 	return orgID
 }
 
-// newServiceWithOrg wraps New and sets the defaultOrgID.
-func newServiceWithOrg(t *testing.T, db *sql.DB) *Service {
+// newServiceWithOrg wraps New and returns the test org ID.
+func newServiceWithOrg(t *testing.T, db *sql.DB) (*Service, string) {
 	t.Helper()
 	orgID := ensureTestOrg(t, db)
 	svc, err := New(db)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	svc.SetDefaultOrgID(orgID)
-	return svc
+	return svc, orgID
 }
 
-func testService(t *testing.T) *Service {
+func testService(t *testing.T) (*Service, string) {
 	t.Helper()
 	db := testDB(t)
-	svc := newServiceWithOrg(t, db)
+	svc, orgID := newServiceWithOrg(t, db)
 	if err := svc.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 	t.Cleanup(func() { _ = svc.Stop() })
-	return svc
+	return svc, orgID
+}
+
+// addTestJob is a convenience wrapper around AddJobWithOwner for tests.
+func addTestJob(t *testing.T, svc *Service, orgID, name, message string, sched Schedule, sessionMode string) Job {
+	t.Helper()
+	job, err := svc.AddJobWithOwner(name, message, sched, sessionMode, "", "", orgID)
+	if err != nil {
+		t.Fatalf("AddJobWithOwner: %v", err)
+	}
+	return job
 }
 
 func TestAddListRemoveJob(t *testing.T) {
-	svc := testService(t)
+	svc, orgID := testService(t)
 
 	// Add a job.
-	job, err := svc.AddJob("test", "say hello", Schedule{Every: "1h"}, "")
-	if err != nil {
-		t.Fatalf("AddJob: %v", err)
-	}
+	job := addTestJob(t, svc, orgID, "test", "say hello", Schedule{Every: "1h"}, "")
 	if job.ID == "" {
 		t.Fatal("expected non-empty job ID")
 	}
@@ -86,7 +92,7 @@ func TestAddListRemoveJob(t *testing.T) {
 	}
 
 	// Verify persistence in DB.
-	row, err := svc.q.GetSchedulerJob(context.Background(), sqlc.GetSchedulerJobParams{ID: job.ID, OrgID: svc.defaultOrgID})
+	row, err := svc.q.GetSchedulerJob(context.Background(), sqlc.GetSchedulerJobParams{ID: job.ID, OrgID: orgID})
 	if err != nil {
 		t.Fatalf("GetSchedulerJob: %v", err)
 	}
@@ -104,7 +110,7 @@ func TestAddListRemoveJob(t *testing.T) {
 }
 
 func TestAddJobValidation(t *testing.T) {
-	svc := testService(t)
+	svc, orgID := testService(t)
 
 	pastTime := time.Now().Add(-1 * time.Hour).Format(time.RFC3339)
 	tests := []struct {
@@ -127,7 +133,7 @@ func TestAddJobValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := svc.AddJob(tt.jName, tt.message, tt.sched, "")
+			_, err := svc.AddJobWithOwner(tt.jName, tt.message, tt.sched, "", "", "", orgID)
 			if err == nil {
 				t.Error("expected error")
 			}
@@ -136,7 +142,7 @@ func TestAddJobValidation(t *testing.T) {
 }
 
 func TestRemoveJobNotFound(t *testing.T) {
-	svc := testService(t)
+	svc, _ := testService(t)
 
 	if err := svc.RemoveJob("nonexistent"); err == nil {
 		t.Error("expected error for nonexistent job")
@@ -151,14 +157,11 @@ func TestJobPersistenceAcrossRestart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenDB: %v", err)
 	}
-	svc1 := newServiceWithOrg(t, db1)
+	svc1, orgID := newServiceWithOrg(t, db1)
 	if err := svc1.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
-	job, err := svc1.AddJob("persist-test", "check weather", Schedule{Cron: "0 9 * * *"}, "")
-	if err != nil {
-		t.Fatalf("AddJob: %v", err)
-	}
+	job := addTestJob(t, svc1, orgID, "persist-test", "check weather", Schedule{Cron: "0 9 * * *"}, "")
 	_ = svc1.Stop()
 	_ = db1.Close()
 
@@ -167,7 +170,7 @@ func TestJobPersistenceAcrossRestart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenDB: %v", err)
 	}
-	svc2 := newServiceWithOrg(t, db2)
+	svc2, _ := newServiceWithOrg(t, db2)
 	if err := svc2.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -195,14 +198,11 @@ func TestStartEphemeralSkipsPersistedJobs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenDB: %v", err)
 	}
-	svc1 := newServiceWithOrg(t, db1)
+	svc1, orgID := newServiceWithOrg(t, db1)
 	if err := svc1.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
-	_, err = svc1.AddJob("persist-test", "check weather", Schedule{Every: "1h"}, "")
-	if err != nil {
-		t.Fatalf("AddJob: %v", err)
-	}
+	addTestJob(t, svc1, orgID, "persist-test", "check weather", Schedule{Every: "1h"}, "")
 	_ = svc1.Stop()
 	_ = db1.Close()
 
@@ -210,7 +210,7 @@ func TestStartEphemeralSkipsPersistedJobs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenDB: %v", err)
 	}
-	svc2 := newServiceWithOrg(t, db2)
+	svc2, _ := newServiceWithOrg(t, db2)
 	if err := svc2.StartEphemeral(context.Background()); err != nil {
 		t.Fatalf("StartEphemeral: %v", err)
 	}
@@ -225,7 +225,7 @@ func TestStartEphemeralSkipsPersistedJobs(t *testing.T) {
 }
 
 func TestOnJobCallbackFires(t *testing.T) {
-	svc := testService(t)
+	svc, orgID := testService(t)
 
 	var mu sync.Mutex
 	var fired []string
@@ -236,10 +236,7 @@ func TestOnJobCallbackFires(t *testing.T) {
 		return nil
 	})
 
-	_, err := svc.AddJob("quick", "ping", Schedule{Every: "100ms"}, "")
-	if err != nil {
-		t.Fatalf("AddJob: %v", err)
-	}
+	addTestJob(t, svc, orgID, "quick", "ping", Schedule{Every: "100ms"}, "")
 
 	// Wait for the callback to fire.
 	deadline := time.After(2 * time.Second)
@@ -259,9 +256,9 @@ func TestOnJobCallbackFires(t *testing.T) {
 }
 
 func TestAddJobWithOwner(t *testing.T) {
-	svc := testService(t)
+	svc, orgID := testService(t)
 
-	job, err := svc.AddJobWithOwner("owned-job", "do work", Schedule{Every: "1h"}, "", "agent-x", "99")
+	job, err := svc.AddJobWithOwner("owned-job", "do work", Schedule{Every: "1h"}, "", "agent-x", "99", orgID)
 	if err != nil {
 		t.Fatalf("AddJobWithOwner: %v", err)
 	}
@@ -286,13 +283,10 @@ func TestAddJobWithOwner(t *testing.T) {
 }
 
 func TestOneTimeJobCreation(t *testing.T) {
-	svc := testService(t)
+	svc, orgID := testService(t)
 
 	futureTime := time.Now().Add(1 * time.Hour).Format(time.RFC3339)
-	job, err := svc.AddJob("one-time-test", "do something once", Schedule{At: futureTime}, "")
-	if err != nil {
-		t.Fatalf("AddJob: %v", err)
-	}
+	job := addTestJob(t, svc, orgID, "one-time-test", "do something once", Schedule{At: futureTime}, "")
 	if job.Schedule.At != futureTime {
 		t.Errorf("At = %q, want %q", job.Schedule.At, futureTime)
 	}
@@ -304,7 +298,7 @@ func TestOneTimeJobCreation(t *testing.T) {
 }
 
 func TestOneTimeJobFiresAndAutoRemoves(t *testing.T) {
-	svc := testService(t)
+	svc, orgID := testService(t)
 
 	var mu sync.Mutex
 	var fired []string
@@ -317,10 +311,7 @@ func TestOneTimeJobFiresAndAutoRemoves(t *testing.T) {
 
 	// Schedule 200ms from now.
 	at := time.Now().Add(200 * time.Millisecond).Format(time.RFC3339Nano)
-	job, err := svc.AddJob("fire-once", "ping once", Schedule{At: at}, "")
-	if err != nil {
-		t.Fatalf("AddJob: %v", err)
-	}
+	job := addTestJob(t, svc, orgID, "fire-once", "ping once", Schedule{At: at}, "")
 
 	// Wait for the callback to fire and cleanup to happen.
 	deadline := time.After(3 * time.Second)
@@ -363,15 +354,12 @@ func TestOneTimeJobSkippedOnRestartIfPast(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenDB: %v", err)
 	}
-	svc1 := newServiceWithOrg(t, db1)
+	svc1, orgID := newServiceWithOrg(t, db1)
 	if err := svc1.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 	futureTime := time.Now().Add(1 * time.Hour).Format(time.RFC3339)
-	_, err = svc1.AddJob("restart-test", "do once", Schedule{At: futureTime}, "")
-	if err != nil {
-		t.Fatalf("AddJob: %v", err)
-	}
+	addTestJob(t, svc1, orgID, "restart-test", "do once", Schedule{At: futureTime}, "")
 	_ = svc1.Stop()
 
 	// Manually tamper the job to have a past timestamp to simulate missed window.
@@ -387,7 +375,7 @@ func TestOneTimeJobSkippedOnRestartIfPast(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenDB: %v", err)
 	}
-	svc2 := newServiceWithOrg(t, db2)
+	svc2, _ := newServiceWithOrg(t, db2)
 	if err := svc2.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -411,25 +399,19 @@ func TestOneTimeJobSkippedOnRestartIfPast(t *testing.T) {
 }
 
 func TestSessionModeDefault(t *testing.T) {
-	svc := testService(t)
+	svc, orgID := testService(t)
 
 	// Empty session_mode defaults to "reuse".
-	job, err := svc.AddJob("default-mode", "msg", Schedule{Every: "1h"}, "")
-	if err != nil {
-		t.Fatalf("AddJob: %v", err)
-	}
+	job := addTestJob(t, svc, orgID, "default-mode", "msg", Schedule{Every: "1h"}, "")
 	if job.SessionMode != SessionReuse {
 		t.Errorf("SessionMode = %q, want %q", job.SessionMode, SessionReuse)
 	}
 }
 
 func TestSessionModeReuse(t *testing.T) {
-	svc := testService(t)
+	svc, orgID := testService(t)
 
-	job, err := svc.AddJob("reuse-mode", "msg", Schedule{Every: "1h"}, SessionReuse)
-	if err != nil {
-		t.Fatalf("AddJob: %v", err)
-	}
+	job := addTestJob(t, svc, orgID, "reuse-mode", "msg", Schedule{Every: "1h"}, SessionReuse)
 
 	// Reuse mode: SessionID is stable across calls.
 	id1 := job.SessionID()
@@ -443,12 +425,9 @@ func TestSessionModeReuse(t *testing.T) {
 }
 
 func TestSessionModeNew(t *testing.T) {
-	svc := testService(t)
+	svc, orgID := testService(t)
 
-	job, err := svc.AddJob("new-mode", "msg", Schedule{Every: "1h"}, SessionNew)
-	if err != nil {
-		t.Fatalf("AddJob: %v", err)
-	}
+	job := addTestJob(t, svc, orgID, "new-mode", "msg", Schedule{Every: "1h"}, SessionNew)
 	if job.SessionMode != SessionNew {
 		t.Errorf("SessionMode = %q, want %q", job.SessionMode, SessionNew)
 	}
@@ -463,9 +442,9 @@ func TestSessionModeNew(t *testing.T) {
 }
 
 func TestSessionModeInvalid(t *testing.T) {
-	svc := testService(t)
+	svc, orgID := testService(t)
 
-	_, err := svc.AddJob("bad-mode", "msg", Schedule{Every: "1h"}, "invalid")
+	_, err := svc.AddJobWithOwner("bad-mode", "msg", Schedule{Every: "1h"}, "invalid", "", "", orgID)
 	if err == nil {
 		t.Error("expected error for invalid session_mode")
 	}
@@ -474,6 +453,14 @@ func TestSessionModeInvalid(t *testing.T) {
 func TestMigrateJobsFile(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "test.db")
+
+	// Need the org ID for the legacy job to satisfy FK constraint.
+	db0, err := appdb.OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	orgID := ensureTestOrg(t, db0)
+	_ = db0.Close()
 
 	// Write a legacy jobs.json.
 	jobs := []Job{
@@ -484,6 +471,7 @@ func TestMigrateJobsFile(t *testing.T) {
 			Message:     "do legacy things",
 			SessionMode: SessionReuse,
 			Enabled:     true,
+			OrgID:       orgID,
 			CreatedAt:   time.Now(),
 		},
 	}
@@ -504,7 +492,7 @@ func TestMigrateJobsFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenDB: %v", err)
 	}
-	svc := newServiceWithOrg(t, db)
+	svc, _ := newServiceWithOrg(t, db)
 	svc.SetLegacyDataPath(legacyDir)
 	if err := svc.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -530,14 +518,14 @@ func TestMigrateJobsFile(t *testing.T) {
 }
 
 func TestEnsureJobCreatesOnce(t *testing.T) {
-	svc := testService(t)
+	svc, orgID := testService(t)
 
-	job1, err := svc.EnsureJob("rss-poll", "poll feeds", Schedule{Every: "1h"}, SessionReuse, "", ExecScopeSystem)
+	job1, err := svc.EnsureJob("rss-poll", "poll feeds", Schedule{Every: "1h"}, SessionReuse, "", ExecScopeSystem, orgID)
 	if err != nil {
 		t.Fatalf("first EnsureJob: %v", err)
 	}
 
-	job2, err := svc.EnsureJob("rss-poll", "poll feeds", Schedule{Every: "1h"}, SessionReuse, "", ExecScopeSystem)
+	job2, err := svc.EnsureJob("rss-poll", "poll feeds", Schedule{Every: "1h"}, SessionReuse, "", ExecScopeSystem, orgID)
 	if err != nil {
 		t.Fatalf("second EnsureJob: %v", err)
 	}
@@ -552,14 +540,14 @@ func TestEnsureJobCreatesOnce(t *testing.T) {
 }
 
 func TestEnsureJobUpdatesExisting(t *testing.T) {
-	svc := testService(t)
+	svc, orgID := testService(t)
 
-	job1, err := svc.EnsureJob("rss-poll", "poll feeds v1", Schedule{Every: "1h"}, SessionReuse, "", ExecScopeSystem)
+	job1, err := svc.EnsureJob("rss-poll", "poll feeds v1", Schedule{Every: "1h"}, SessionReuse, "", ExecScopeSystem, orgID)
 	if err != nil {
 		t.Fatalf("first EnsureJob: %v", err)
 	}
 
-	job2, err := svc.EnsureJob("rss-poll", "poll feeds v2", Schedule{Every: "30m"}, SessionNew, "", ExecScopeSystem)
+	job2, err := svc.EnsureJob("rss-poll", "poll feeds v2", Schedule{Every: "30m"}, SessionNew, "", ExecScopeSystem, orgID)
 	if err != nil {
 		t.Fatalf("second EnsureJob: %v", err)
 	}
@@ -589,11 +577,11 @@ func TestEnsureJobPersistsAcrossRestart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenDB: %v", err)
 	}
-	svc1 := newServiceWithOrg(t, db1)
+	svc1, orgID := newServiceWithOrg(t, db1)
 	if err := svc1.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
-	job1, err := svc1.EnsureJob("rss-poll", "poll feeds", Schedule{Every: "1h"}, SessionReuse, "", ExecScopeSystem)
+	job1, err := svc1.EnsureJob("rss-poll", "poll feeds", Schedule{Every: "1h"}, SessionReuse, "", ExecScopeSystem, orgID)
 	if err != nil {
 		t.Fatalf("EnsureJob: %v", err)
 	}
@@ -604,7 +592,7 @@ func TestEnsureJobPersistsAcrossRestart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenDB: %v", err)
 	}
-	svc2 := newServiceWithOrg(t, db2)
+	svc2, orgID2 := newServiceWithOrg(t, db2)
 	if err := svc2.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -613,7 +601,7 @@ func TestEnsureJobPersistsAcrossRestart(t *testing.T) {
 		_ = db2.Close()
 	}()
 
-	job2, err := svc2.EnsureJob("rss-poll", "poll feeds", Schedule{Every: "1h"}, SessionReuse, "", ExecScopeSystem)
+	job2, err := svc2.EnsureJob("rss-poll", "poll feeds", Schedule{Every: "1h"}, SessionReuse, "", ExecScopeSystem, orgID2)
 	if err != nil {
 		t.Fatalf("EnsureJob after restart: %v", err)
 	}
@@ -628,7 +616,7 @@ func TestEnsureJobPersistsAcrossRestart(t *testing.T) {
 }
 
 func TestRunJobNow_SingleRun(t *testing.T) {
-	svc := testService(t)
+	svc, orgID := testService(t)
 
 	var fired []string
 	var mu sync.Mutex
@@ -639,10 +627,7 @@ func TestRunJobNow_SingleRun(t *testing.T) {
 		return nil
 	})
 
-	job, err := svc.AddJob("run-now-test", "hello", Schedule{Every: "24h"}, SessionReuse)
-	if err != nil {
-		t.Fatalf("AddJob: %v", err)
-	}
+	job := addTestJob(t, svc, orgID, "run-now-test", "hello", Schedule{Every: "24h"}, SessionReuse)
 
 	runID, err := svc.RunJobNow(context.Background(), job.ID)
 	if err != nil {
@@ -683,7 +668,7 @@ func TestRunJobNow_SingleRun(t *testing.T) {
 }
 
 func TestRunJobNow_PreventsConcurrentRun(t *testing.T) {
-	svc := testService(t)
+	svc, orgID := testService(t)
 
 	// Slow job so we can attempt a second trigger while it's still running.
 	started := make(chan struct{})
@@ -694,10 +679,7 @@ func TestRunJobNow_PreventsConcurrentRun(t *testing.T) {
 		return nil
 	})
 
-	job, err := svc.AddJob("concurrent-test", "block", Schedule{Every: "24h"}, SessionReuse)
-	if err != nil {
-		t.Fatalf("AddJob: %v", err)
-	}
+	job := addTestJob(t, svc, orgID, "concurrent-test", "block", Schedule{Every: "24h"}, SessionReuse)
 
 	runID, err := svc.RunJobNow(context.Background(), job.ID)
 	if err != nil {
@@ -719,7 +701,7 @@ func TestRunJobNow_PreventsConcurrentRun(t *testing.T) {
 }
 
 func TestRunJobNow_NotFound(t *testing.T) {
-	svc := testService(t)
+	svc, _ := testService(t)
 	_, err := svc.RunJobNow(context.Background(), "nonexistent")
 	if err == nil {
 		t.Fatal("expected error for unknown job ID")
@@ -727,7 +709,7 @@ func TestRunJobNow_NotFound(t *testing.T) {
 }
 
 func TestRunJobNow_AllUsers(t *testing.T) {
-	svc := testService(t)
+	svc, orgID := testService(t)
 
 	var calledWith []string
 	var mu sync.Mutex
@@ -737,11 +719,11 @@ func TestRunJobNow_AllUsers(t *testing.T) {
 		mu.Unlock()
 		return nil
 	})
-	svc.SetListActiveUsersFunc(func(_ context.Context) ([]string, error) {
+	svc.SetListActiveUsersFunc(func(_ context.Context, _ string) ([]string, error) {
 		return []string{"1", "2"}, nil
 	})
 
-	job, err := svc.EnsureJob("all-users-test", "hello", Schedule{Every: "1h"}, SessionReuse, "", ExecScopeAllUsers)
+	job, err := svc.EnsureJob("all-users-test", "hello", Schedule{Every: "1h"}, SessionReuse, "", ExecScopeAllUsers, orgID)
 	if err != nil {
 		t.Fatalf("EnsureJob: %v", err)
 	}
@@ -774,7 +756,7 @@ func TestRunJobNow_AllUsers(t *testing.T) {
 }
 
 func TestExecuteJobForAllUsers_NoListFunc(t *testing.T) {
-	svc := testService(t)
+	svc, orgID := testService(t)
 
 	var called int
 	svc.SetOnJob(func(_ context.Context, _ Job) error {
@@ -783,7 +765,7 @@ func TestExecuteJobForAllUsers_NoListFunc(t *testing.T) {
 	})
 	// Intentionally do NOT call SetListActiveUsersFunc.
 
-	job, err := svc.EnsureJob("no-list-func", "hello", Schedule{Every: "1h"}, SessionReuse, "", ExecScopeAllUsers)
+	job, err := svc.EnsureJob("no-list-func", "hello", Schedule{Every: "1h"}, SessionReuse, "", ExecScopeAllUsers, orgID)
 	if err != nil {
 		t.Fatalf("EnsureJob: %v", err)
 	}

--- a/internal/scheduler/service.go
+++ b/internal/scheduler/service.go
@@ -748,10 +748,10 @@ func (s *Service) removeOneTimeJob(id string) {
 		_ = s.scheduler.RemoveJob(gid)
 		delete(s.gids, id)
 	}
-	delete(s.jobs, id)
 	if err := s.deleteJob(s.ctx, id); err != nil {
 		s.log.Warn("failed to remove one-time job after execution", "id", id, "error", err)
 	} else {
 		s.log.Info("one-time job auto-removed after execution", "id", id)
 	}
+	delete(s.jobs, id)
 }

--- a/internal/scheduler/service.go
+++ b/internal/scheduler/service.go
@@ -417,7 +417,8 @@ func (s *Service) RemoveJob(id string) error {
 		delete(s.gids, id)
 	}
 
-	if err := s.deleteJob(s.ctx, id); err != nil {
+	orgID := s.jobs[id].OrgID
+	if err := s.deleteJob(s.ctx, id, orgID); err != nil {
 		return fmt.Errorf("persist after remove: %w", err)
 	}
 
@@ -625,7 +626,7 @@ func (s *Service) executeSingleRun(ctx context.Context, job Job, userID string, 
 	}
 	s.mu.Unlock()
 
-	if err := s.recordJobRun(ctx, job.ID, finishedAt, runErr); err != nil {
+	if err := s.recordJobRun(ctx, job.ID, job.OrgID, finishedAt, runErr); err != nil {
 		s.log.Warn("failed to record scheduler job run", "id", job.ID, "error", err)
 	}
 
@@ -699,7 +700,7 @@ func (s *Service) RunJobNow(ctx context.Context, jobID string) (string, error) {
 		if err := s.finishJobRun(svcCtx, runID, jobID, status, finishedAt, errStr); err != nil {
 			s.log.Warn("failed to finish job run record", "run_id", runID, "error", err)
 		}
-		if err := s.recordJobRun(svcCtx, jobID, finishedAt, runErr); err != nil {
+		if err := s.recordJobRun(svcCtx, jobID, job.OrgID, finishedAt, runErr); err != nil {
 			s.log.Warn("failed to record scheduler job run", "id", jobID, "error", err)
 		}
 
@@ -748,7 +749,11 @@ func (s *Service) removeOneTimeJob(id string) {
 		_ = s.scheduler.RemoveJob(gid)
 		delete(s.gids, id)
 	}
-	if err := s.deleteJob(s.ctx, id); err != nil {
+	orgID := ""
+	if j, ok := s.jobs[id]; ok {
+		orgID = j.OrgID
+	}
+	if err := s.deleteJob(s.ctx, id, orgID); err != nil {
 		s.log.Warn("failed to remove one-time job after execution", "id", id, "error", err)
 	} else {
 		s.log.Info("one-time job auto-removed after execution", "id", id)

--- a/internal/scheduler/service.go
+++ b/internal/scheduler/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-co-op/gocron/v2"
 	"github.com/google/uuid"
 
+	"github.com/CherryHQ/stella/internal/config"
 	appdb "github.com/CherryHQ/stella/internal/db"
 	"github.com/CherryHQ/stella/internal/memory"
 	"github.com/CherryHQ/stella/internal/notify"
@@ -32,9 +33,9 @@ type OnJobFunc func(ctx context.Context, job Job) error
 // TaskFunc is a lightweight scheduled callback that is not persisted as a scheduled job.
 type TaskFunc func(ctx context.Context)
 
-// ListActiveUsersFunc returns the IDs of all currently active users.
+// ListActiveUsersFunc returns the IDs of all currently active users for the given org.
 // Used by the scheduler to fan out ExecScopeAllUsers jobs.
-type ListActiveUsersFunc func(ctx context.Context) ([]string, error)
+type ListActiveUsersFunc func(ctx context.Context, orgID string) ([]string, error)
 
 // Service manages scheduled jobs backed by gocron/v2 with database persistence.
 type Service struct {
@@ -52,8 +53,6 @@ type Service struct {
 	log             *slog.Logger
 	userJobsEnabled bool
 	listActiveUsers ListActiveUsersFunc
-
-	defaultOrgID string
 
 	// Heartbeat (optional, configured via SetHeartbeat).
 	heartbeatCfg      *HeartbeatConfig
@@ -79,8 +78,8 @@ func New(db *sql.DB) (*Service, error) {
 	}, nil
 }
 
-// SetDefaultOrgID sets the fallback org ID used when creating jobs without an explicit OrgID.
-func (s *Service) SetDefaultOrgID(orgID string) { s.defaultOrgID = orgID }
+// SetDefaultOrgID is deprecated and a no-op. OrgID is now set per-job.
+func (s *Service) SetDefaultOrgID(_ string) {}
 
 // NewFromPath creates a scheduler service that opens its own SQLite database
 // at the given path. The database is closed when Stop is called.
@@ -234,35 +233,29 @@ func (s *Service) ScheduleEvery(ctx context.Context, every string, fn TaskFunc) 
 	return nil
 }
 
-// AddJob creates, persists, and schedules a new system-scoped job (no user context).
-// sessionMode controls session reuse: "reuse" (default) or "new".
-func (s *Service) AddJob(name, message string, sched Schedule, sessionMode string) (Job, error) {
-	return s.addJobInternal(name, message, sched, sessionMode, "", "", JobOwnerUser, ExecScopeSystem)
-}
-
 // AddJobForContext creates a user-owned job bound to the current execution context.
-// When the caller context carries agent/user scope, scheduled executions inherit it.
+// OrgID is read from the context via config.OrgIDFromContext.
 func (s *Service) AddJobForContext(ctx context.Context, name, message string, sched Schedule, sessionMode string) (Job, error) {
 	userID := memory.UserIDFromContext(ctx)
 	agentID := memory.AgentIDFromContext(ctx)
+	orgID := config.OrgIDFromContext(ctx)
 	execScope := ExecScopeSystem
 	if userID != "" {
 		execScope = ExecScopeUser
 	}
-	return s.addJobInternal(name, message, sched, sessionMode, agentID, userID, JobOwnerUser, execScope)
+	return s.addJobInternal(name, message, sched, sessionMode, agentID, userID, JobOwnerUser, execScope, orgID)
 }
 
 // AddJobWithOwner creates a user-owned job with explicit owner parameters.
-// Use AddJobForContext when a Go context carries agent/user scope.
-func (s *Service) AddJobWithOwner(name, message string, sched Schedule, sessionMode, agentID string, userID string) (Job, error) {
+func (s *Service) AddJobWithOwner(name, message string, sched Schedule, sessionMode, agentID string, userID string, orgID string) (Job, error) {
 	execScope := ExecScopeSystem
 	if userID != "" {
 		execScope = ExecScopeUser
 	}
-	return s.addJobInternal(name, message, sched, sessionMode, agentID, userID, JobOwnerUser, execScope)
+	return s.addJobInternal(name, message, sched, sessionMode, agentID, userID, JobOwnerUser, execScope, orgID)
 }
 
-func (s *Service) addJobInternal(name, message string, sched Schedule, sessionMode, agentID string, userID string, ownerKind, execScope string) (Job, error) {
+func (s *Service) addJobInternal(name, message string, sched Schedule, sessionMode, agentID string, userID string, ownerKind, execScope, orgID string) (Job, error) {
 	if name == "" {
 		return Job{}, fmt.Errorf("name is required")
 	}
@@ -292,7 +285,7 @@ func (s *Service) addJobInternal(name, message string, sched Schedule, sessionMo
 		Enabled:     true,
 		AgentID:     agentID,
 		UserID:      userID,
-		OrgID:       s.defaultOrgID,
+		OrgID:       orgID,
 		CreatedAt:   now,
 		UpdatedAt:   now,
 	}
@@ -320,7 +313,8 @@ func (s *Service) addJobInternal(name, message string, sched Schedule, sessionMo
 }
 
 // AddPluginJob creates, persists, and schedules a plugin-owned job.
-func (s *Service) AddPluginJob(pluginID, key, runtimeName, name, description string, sched Schedule, payload map[string]any) (Job, error) {
+// OrgID is read from ctx via config.OrgIDFromContext.
+func (s *Service) AddPluginJob(ctx context.Context, pluginID, key, runtimeName, name, description string, sched Schedule, payload map[string]any) (Job, error) {
 	if pluginID == "" {
 		return Job{}, fmt.Errorf("plugin_id is required")
 	}
@@ -350,6 +344,7 @@ func (s *Service) AddPluginJob(pluginID, key, runtimeName, name, description str
 		Payload:     clonePayload(payload),
 		SessionMode: SessionReuse,
 		Enabled:     true,
+		OrgID:       config.OrgIDFromContext(ctx),
 		CreatedAt:   now,
 		UpdatedAt:   now,
 	}
@@ -436,7 +431,7 @@ func (s *Service) RemoveJob(id string) error {
 // the existing job when any field has changed.
 // It is intended for builtin jobs that should be seeded on startup.
 // Jobs created by EnsureJob are owned by the system (JobOwnerSystem).
-func (s *Service) EnsureJob(name, message string, sched Schedule, sessionMode, agentID, execScope string) (Job, error) {
+func (s *Service) EnsureJob(name, message string, sched Schedule, sessionMode, agentID, execScope, orgID string) (Job, error) {
 	if sessionMode == "" {
 		sessionMode = SessionReuse
 	}
@@ -446,7 +441,7 @@ func (s *Service) EnsureJob(name, message string, sched Schedule, sessionMode, a
 
 	s.mu.Lock()
 	for _, j := range s.jobs {
-		if j.Name != name {
+		if j.Name != name || j.OrgID != orgID {
 			continue
 		}
 		if j.Message == message && j.Schedule == sched && j.SessionMode == sessionMode && j.AgentID == agentID && j.ExecScope == execScope {
@@ -478,7 +473,7 @@ func (s *Service) EnsureJob(name, message string, sched Schedule, sessionMode, a
 		return j, nil
 	}
 	s.mu.Unlock()
-	return s.addJobInternal(name, message, sched, sessionMode, agentID, "", JobOwnerSystem, execScope)
+	return s.addJobInternal(name, message, sched, sessionMode, agentID, "", JobOwnerSystem, execScope, orgID)
 }
 
 // ListJobs returns all jobs.
@@ -551,7 +546,7 @@ func (s *Service) executeJobForAllUsers(ctx context.Context, job Job, isOneTime 
 		return
 	}
 
-	userIDs, err := fn(ctx)
+	userIDs, err := fn(ctx, job.OrgID)
 	if err != nil {
 		s.log.Warn("failed to list active users for all_users job", "job_id", job.ID, "error", err)
 		return

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -72,11 +73,13 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 
 		ctx := r.Context()
 		if info := s.authInfoFromBearer(ctx, r.Header.Get("Authorization")); info != nil {
+			s.ensureOrgRuntime(ctx, info.OrgID)
 			next.ServeHTTP(w, r.WithContext(withAuthInfo(ctx, info)))
 			return
 		}
 
 		if info := s.authInfoFromOIDCSession(ctx, r); info != nil {
+			s.ensureOrgRuntime(ctx, info.OrgID)
 			next.ServeHTTP(w, r.WithContext(withAuthInfo(ctx, info)))
 			return
 		}
@@ -168,6 +171,16 @@ func requireAdmin(w http.ResponseWriter, r *http.Request) *AuthInfo {
 		return nil
 	}
 	return info
+}
+
+// ensureOrgRuntime triggers lazy OrgRuntime initialization for the user's org.
+func (s *Server) ensureOrgRuntime(ctx context.Context, orgID string) {
+	if s.authSvc == nil || orgID == "" {
+		return
+	}
+	if err := s.authSvc.InitOrg(ctx, orgID); err != nil {
+		slog.Warn("auth: org runtime init failed", "org_id", orgID, "error", err)
+	}
 }
 
 // denyAccess returns 401 for API routes or redirects to /login for page routes.

--- a/internal/server/oidc.go
+++ b/internal/server/oidc.go
@@ -122,8 +122,13 @@ func (s *Server) handleOIDCCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Provision vault age keys for brand-new OIDC users.
-	if result.IsNewUser && s.vaultRecipient != nil {
+	// Initialize per-org runtime (lazy; idempotent for returning users).
+	if err := s.authSvc.InitOrg(r.Context(), result.Membership.OrganizationID); err != nil {
+		slog.Warn("oidc: org runtime init failed", "org_id", result.Membership.OrganizationID, "error", err)
+	}
+
+	// Provision vault age keys when the user doesn't have them yet.
+	if result.User.AgePublicKey == "" && s.vaultRecipient != nil {
 		pubKey, encPrivKey, err := vault.GenerateUserKeys(s.vaultRecipient)
 		if err != nil {
 			slog.Warn("oidc: generate age keys failed", "user_id", result.User.ID, "error", err)

--- a/internal/server/scheduler.go
+++ b/internal/server/scheduler.go
@@ -80,7 +80,8 @@ func (s *Server) CreateSchedulerJob(w http.ResponseWriter, r *http.Request, agen
 			Every: derefStr(body.Every),
 			At:    derefStr(body.At),
 		}
-		job, err := s.schedulerSvc.AddJobWithOwner(*body.Name, *body.Message, sched, sessionMode, agentID, userID)
+		orgID := config.OrgIDFromContext(r.Context())
+		job, err := s.schedulerSvc.AddJobWithOwner(*body.Name, *body.Message, sched, sessionMode, agentID, userID, orgID)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())
 			return

--- a/pkg/db/sqlc/sched_job.sql.go
+++ b/pkg/db/sqlc/sched_job.sql.go
@@ -152,6 +152,56 @@ func (q *Queries) GetSchedulerJob(ctx context.Context, arg GetSchedulerJobParams
 	return i, err
 }
 
+const listAllSchedulerJobs = `-- name: ListAllSchedulerJobs :many
+SELECT id, owner_kind, exec_scope, plugin_id, job_key, runtime_name, name, description, schedule_cron, schedule_every, schedule_at, message, payload, session_mode, enabled, agent_id, user_id, org_id, created_at, updated_at, last_run_at, last_error FROM sched_job ORDER BY created_at
+`
+
+func (q *Queries) ListAllSchedulerJobs(ctx context.Context) ([]SchedJob, error) {
+	rows, err := q.db.QueryContext(ctx, listAllSchedulerJobs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []SchedJob{}
+	for rows.Next() {
+		var i SchedJob
+		if err := rows.Scan(
+			&i.ID,
+			&i.OwnerKind,
+			&i.ExecScope,
+			&i.PluginID,
+			&i.JobKey,
+			&i.RuntimeName,
+			&i.Name,
+			&i.Description,
+			&i.ScheduleCron,
+			&i.ScheduleEvery,
+			&i.ScheduleAt,
+			&i.Message,
+			&i.Payload,
+			&i.SessionMode,
+			&i.Enabled,
+			&i.AgentID,
+			&i.UserID,
+			&i.OrgID,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.LastRunAt,
+			&i.LastError,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listSchedulerJobs = `-- name: ListSchedulerJobs :many
 SELECT id, owner_kind, exec_scope, plugin_id, job_key, runtime_name, name, description, schedule_cron, schedule_every, schedule_at, message, payload, session_mode, enabled, agent_id, user_id, org_id, created_at, updated_at, last_run_at, last_error FROM sched_job WHERE org_id = ? ORDER BY created_at
 `


### PR DESCRIPTION
## Summary

- **OrgRuntime + Manager**: per-org lifecycle struct that lazily syncs agent pools, starts channels, and ensures builtin scheduler jobs when a user's org is first accessed
- **Multi-org scheduler**: removed `defaultOrgID` — every operation uses `job.OrgID` directly, loads all orgs' jobs at startup
- **Boot-time org removal**: `setup()` no longer creates/seeds a default org; server starts with zero orgs
- **Auth → OrgRuntime integration**: `ensureMembership` returns a `NeedsSeedOrgID` signal so seeding happens after TX commit; `OrgInitializer` interface connects AuthService to OrgRuntimeManager
- **Lazy init on every auth path**: auth middleware, OIDC callback, and channel Coordinator all call `EnsureStarted` to initialize the org runtime on first access
- **Vault key fix**: checks `AgePublicKey == ""` instead of `IsNewUser` for key provisioning

## Test plan

- [x] `mise run format` — clean
- [x] `mise run build` — passes
- [x] `mise run test` — all tests pass
- [ ] Manual: fresh DB → `stella server` → register user A → org seeded, channels start → register user B → separate org