### PR TITLE
♻️ refactor(pluginhost): key managed runtimes by orgID (2/5)

### DIFF
--- a/cmd/stella/plugin_services.go
+++ b/cmd/stella/plugin_services.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"reflect"
 
+	"github.com/CherryHQ/stella/internal/config"
 	internalscheduler "github.com/CherryHQ/stella/internal/scheduler"
 	pkgplugins "github.com/CherryHQ/stella/pkg/plugins"
 )
@@ -146,6 +147,7 @@ func (a schedulerServiceAdapter) dispatchPluginJob(ctx context.Context, job inte
 		return fmt.Errorf("host unavailable for plugin %s job %s", job.PluginID, job.JobKey)
 	}
 
+	ctx = config.WithOrgID(ctx, job.OrgID)
 	handle, ok := a.lookup.Lookup(ctx, job.PluginID, job.RuntimeName)
 	if !ok {
 		return fmt.Errorf("runtime unavailable for plugin %s runtime %s", job.PluginID, job.RuntimeName)

--- a/cmd/stella/plugin_services.go
+++ b/cmd/stella/plugin_services.go
@@ -146,7 +146,7 @@ func (a schedulerServiceAdapter) dispatchPluginJob(ctx context.Context, job inte
 		return fmt.Errorf("host unavailable for plugin %s job %s", job.PluginID, job.JobKey)
 	}
 
-	handle, ok := a.lookup.Lookup(job.PluginID, job.RuntimeName)
+	handle, ok := a.lookup.Lookup(ctx, job.PluginID, job.RuntimeName)
 	if !ok {
 		return fmt.Errorf("runtime unavailable for plugin %s runtime %s", job.PluginID, job.RuntimeName)
 	}

--- a/internal/pluginhost/host.go
+++ b/internal/pluginhost/host.go
@@ -285,7 +285,7 @@ func (h *Host) AddAfterToolResult(reg pkgplugins.AfterToolResultSpec) {
 func (h *Host) AddRuntime(reg pkgplugins.RuntimeSpec) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	registerUnique(h.runtimeRegs, runtimeKey(reg.PluginID, reg.Name), reg, "runtime")
+	registerUnique(h.runtimeRegs, runtimeRegKey(reg.PluginID, reg.Name), reg, "runtime")
 }
 
 func (h *Host) AddPromptInventory(reg pkgplugins.PromptInventorySpec) {
@@ -354,8 +354,8 @@ func registerUnique[T any](m map[string]T, key string, reg T, kind string) {
 	m[key] = reg
 }
 
-func runtimeKey(pluginID, name string) string { return pluginID + "/" + name }
-func promptKey(pluginID, name string) string  { return pluginID + "/" + name }
+func runtimeRegKey(pluginID, name string) string { return pluginID + "/" + name }
+func promptKey(pluginID, name string) string     { return pluginID + "/" + name }
 
 func (h *Host) SetEnabled(ctx context.Context, pluginID string, enabled bool) error {
 	return h.config.SetEnabled(ctx, pluginID, enabled)
@@ -429,6 +429,9 @@ func (h *Host) ApplyChannel(ctx context.Context, channel config.Channel) error {
 }
 
 func (h *Host) Stop(ctx context.Context) error { return h.runtimes.Stop(ctx) }
+
+// Shutdown tears down every managed runtime for the org resolved from ctx.
+func (h *Host) Shutdown(ctx context.Context) error { return h.runtimes.Shutdown(ctx) }
 
 func (h *Host) PromptTools(ctx context.Context, pluginID string) ([]pkgplugins.PromptToolInfo, error) {
 	h.mu.RLock()

--- a/internal/pluginhost/host_test.go
+++ b/internal/pluginhost/host_test.go
@@ -424,7 +424,7 @@ func TestRuntimeApplyCreatesAndApplies(t *testing.T) {
 			return nil
 		}}, nil
 	}})
-	if err := host.ApplyPlugin(context.Background(), "tool/test"); err != nil {
+	if err := host.ApplyPlugin(ctxWithOrg(testOrg), "tool/test"); err != nil {
 		t.Fatal(err)
 	}
 	if called != 1 {

--- a/internal/pluginhost/runtime.go
+++ b/internal/pluginhost/runtime.go
@@ -4,19 +4,41 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"sort"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/CherryHQ/stella/internal/config"
+	"github.com/CherryHQ/stella/internal/orgctx"
 	pkgplugins "github.com/CherryHQ/stella/pkg/plugins"
 )
 
+// runtimeKey identifies a managed runtime within a single org's bucket.
+// Pair (RuntimeID, RuntimeName) — RuntimeID is the channel.ID for managed
+// channel runtimes and the plugin ID for other plugin-scoped runtimes.
+type runtimeKey struct {
+	RuntimeID   string
+	RuntimeName string
+}
+
+type runtimeEntry struct {
+	reg     pkgplugins.RuntimeSpec
+	managed pkgplugins.Runtime
+}
+
+// RuntimeHost owns the per-org map of managed runtime instances. All read /
+// write operations resolve the org from ctx; missing orgID is an error on
+// write paths and returns (nil,false) on read paths.
 type RuntimeHost struct {
 	host *Host
 	mu   sync.RWMutex
-	rt   map[string]*runtimeEntry
+	rt   map[string]map[runtimeKey]*runtimeEntry // orgID -> key -> entry
+}
+
+func NewRuntimeHost(host *Host) *RuntimeHost {
+	return &RuntimeHost{host: host, rt: map[string]map[runtimeKey]*runtimeEntry{}}
 }
 
 func configMapFromJSON(raw string) map[string]any {
@@ -30,41 +52,54 @@ func configMapFromJSON(raw string) map[string]any {
 	return out
 }
 
-type runtimeEntry struct {
-	reg     pkgplugins.RuntimeSpec
-	managed pkgplugins.Runtime
+// requireOrgID resolves the orgID from ctx; returns "" with an error when missing.
+func requireOrgID(ctx context.Context) (string, error) {
+	orgID := orgctx.OrgIDFromContext(ctx)
+	if orgID == "" {
+		return "", fmt.Errorf("pluginhost: orgID missing from context")
+	}
+	return orgID, nil
 }
 
-func NewRuntimeHost(host *Host) *RuntimeHost {
-	return &RuntimeHost{host: host, rt: map[string]*runtimeEntry{}}
-}
-
-func (h *RuntimeHost) Get(pluginID string, runtimeName string) (pkgplugins.RuntimeHandle, bool) {
+// Get resolves a managed runtime for the current org. orgID comes from ctx;
+// when absent, returns (nil, false) and logs at debug — callers naturally 404.
+func (h *RuntimeHost) Get(ctx context.Context, runtimeID string, runtimeName string) (pkgplugins.RuntimeHandle, bool) {
+	orgID := orgctx.OrgIDFromContext(ctx)
+	if orgID == "" {
+		slog.Debug("pluginhost.RuntimeHost.Get: missing orgID in ctx", "runtime_id", runtimeID, "runtime_name", runtimeName)
+		return nil, false
+	}
 	h.mu.RLock()
 	defer h.mu.RUnlock()
-	entry, ok := h.rt[runtimeKey(pluginID, runtimeName)]
-	if ok && entry.managed != nil {
+	bucket := h.rt[orgID]
+	if bucket == nil {
+		return nil, false
+	}
+	if entry := bucket[runtimeKey{RuntimeID: runtimeID, RuntimeName: runtimeName}]; entry != nil && entry.managed != nil {
 		return runtimeHandle{entry: entry}, true
 	}
-	if channelType, ok := strings.CutPrefix(pluginID, config.PluginKindChannel+"/"); ok {
-		entry, ok := h.rt[runtimeKey(channelType, runtimeName)]
-		if ok && entry.managed != nil {
-			return runtimeHandle{entry: entry}, true
-		}
-	}
-	for _, entry := range h.rt {
-		if entry.reg.PluginID == pluginID && entry.reg.Name == runtimeName && entry.managed != nil {
-			return runtimeHandle{entry: entry}, true
+	// channel plugin lookups: caller passed "channel/<type>"; runtime was registered
+	// under the channel instance ID. Fall back to matching reg.PluginID + reg.Name
+	// within the same org.
+	if _, ok := strings.CutPrefix(runtimeID, config.PluginKindChannel+"/"); ok {
+		for _, entry := range bucket {
+			if entry.reg.PluginID == runtimeID && entry.reg.Name == runtimeName && entry.managed != nil {
+				return runtimeHandle{entry: entry}, true
+			}
 		}
 	}
 	return nil, false
 }
 
-func (h *RuntimeHost) Lookup(pluginID string, runtimeName string) (pkgplugins.RuntimeHandle, bool) {
-	return h.Get(pluginID, runtimeName)
+// Lookup is an alias for Get to match the pkgplugins.RuntimeLookup interface.
+func (h *RuntimeHost) Lookup(ctx context.Context, runtimeID string, runtimeName string) (pkgplugins.RuntimeHandle, bool) {
+	return h.Get(ctx, runtimeID, runtimeName)
 }
 
 func (h *RuntimeHost) ApplyPlugin(ctx context.Context, pluginID string) error {
+	if _, err := requireOrgID(ctx); err != nil {
+		return err
+	}
 	desired, err := h.host.DesiredState(ctx, pluginID)
 	if err != nil {
 		return err
@@ -93,6 +128,13 @@ func (h *RuntimeHost) ApplyPlugin(ctx context.Context, pluginID string) error {
 }
 
 func (h *RuntimeHost) ApplyChannel(ctx context.Context, channel config.Channel) error {
+	orgID, err := requireOrgID(ctx)
+	if err != nil {
+		return err
+	}
+	if channel.OrgID != "" && channel.OrgID != orgID {
+		return fmt.Errorf("pluginhost.ApplyChannel: channel org mismatch ctx=%s channel=%s", orgID, channel.OrgID)
+	}
 	if channel.Type == "" {
 		channel.Type = channel.ID
 	}
@@ -132,23 +174,32 @@ func (h *RuntimeHost) applyOne(ctx context.Context, reg pkgplugins.RuntimeSpec, 
 }
 
 func (h *RuntimeHost) applyOneWithKey(ctx context.Context, reg pkgplugins.RuntimeSpec, runtimeID string, desired pkgplugins.PluginState) error {
-	key := runtimeKey(runtimeID, reg.Name)
+	orgID, err := requireOrgID(ctx)
+	if err != nil {
+		return err
+	}
+	key := runtimeKey{RuntimeID: runtimeID, RuntimeName: reg.Name}
 	h.mu.Lock()
-	entry := h.rt[key]
+	bucket := h.rt[orgID]
+	if bucket == nil {
+		bucket = map[runtimeKey]*runtimeEntry{}
+		h.rt[orgID] = bucket
+	}
+	entry := bucket[key]
 	if entry == nil {
 		entry = &runtimeEntry{reg: reg}
-		h.rt[key] = entry
+		bucket[key] = entry
 	}
 	managed := entry.managed
 	h.mu.Unlock()
 	if managed == nil {
 		build := reg.Build
 		if build == nil {
-			return fmt.Errorf("runtime %s has no builder", key)
+			return fmt.Errorf("runtime %s/%s has no builder", runtimeID, reg.Name)
 		}
 		created, err := build(pkgplugins.RuntimeContext{Platform: h.host.platform(reg.PluginID), State: desired.Clone()})
 		if err != nil {
-			return fmt.Errorf("create runtime %s: %w", key, err)
+			return fmt.Errorf("create runtime %s/%s: %w", runtimeID, reg.Name, err)
 		}
 		managed = created
 		h.mu.Lock()
@@ -156,20 +207,26 @@ func (h *RuntimeHost) applyOneWithKey(ctx context.Context, reg pkgplugins.Runtim
 		h.mu.Unlock()
 	}
 	if err := managed.Apply(ctx, desired.Clone()); err != nil {
-		return fmt.Errorf("apply runtime %s: %w", key, err)
+		return fmt.Errorf("apply runtime %s/%s: %w", runtimeID, reg.Name, err)
 	}
 	return nil
 }
 
-func (h *RuntimeHost) Stop(ctx context.Context) error {
-	h.mu.Lock()
-	entries := make([]*runtimeEntry, 0, len(h.rt))
-	for _, entry := range h.rt {
-		entries = append(entries, entry)
+// Shutdown tears down every managed runtime owned by the org resolved from
+// ctx. Entries are removed from the map before Stop() is called so the lock
+// isn't held while runtime teardown executes.
+func (h *RuntimeHost) Shutdown(ctx context.Context) error {
+	orgID, err := requireOrgID(ctx)
+	if err != nil {
+		return err
 	}
+	h.mu.Lock()
+	bucket := h.rt[orgID]
+	delete(h.rt, orgID)
 	h.mu.Unlock()
+
 	var lastErr error
-	for _, entry := range entries {
+	for _, entry := range bucket {
 		if entry.managed == nil {
 			continue
 		}
@@ -180,8 +237,28 @@ func (h *RuntimeHost) Stop(ctx context.Context) error {
 	return lastErr
 }
 
-func (h *RuntimeHost) Snapshot(ctx context.Context, pluginID string, runtimeName string) (pkgplugins.RuntimeStatus, error) {
-	handle, ok := h.Get(pluginID, runtimeName)
+// Stop tears down all managed runtimes across every org. Used at process exit.
+func (h *RuntimeHost) Stop(ctx context.Context) error {
+	h.mu.Lock()
+	all := h.rt
+	h.rt = map[string]map[runtimeKey]*runtimeEntry{}
+	h.mu.Unlock()
+	var lastErr error
+	for _, bucket := range all {
+		for _, entry := range bucket {
+			if entry.managed == nil {
+				continue
+			}
+			if err := entry.managed.Stop(ctx); err != nil {
+				lastErr = err
+			}
+		}
+	}
+	return lastErr
+}
+
+func (h *RuntimeHost) Snapshot(ctx context.Context, runtimeID string, runtimeName string) (pkgplugins.RuntimeStatus, error) {
+	handle, ok := h.Get(ctx, runtimeID, runtimeName)
 	if !ok {
 		return pkgplugins.RuntimeStatus{State: pkgplugins.RuntimeStateStopped, UpdatedAt: time.Now().UTC()}, nil
 	}

--- a/internal/pluginhost/runtime_test.go
+++ b/internal/pluginhost/runtime_test.go
@@ -5,8 +5,15 @@ import (
 	"testing"
 
 	"github.com/CherryHQ/stella/internal/config"
+	"github.com/CherryHQ/stella/internal/orgctx"
 	pkgplugins "github.com/CherryHQ/stella/pkg/plugins"
 )
+
+const testOrg = "org-A"
+
+func ctxWithOrg(org string) context.Context {
+	return orgctx.WithOrgID(context.Background(), org)
+}
 
 func TestConfigMapFromJSON(t *testing.T) {
 	tests := []struct {
@@ -41,18 +48,151 @@ func TestRuntimeLookup(t *testing.T) {
 	host.AddRuntime(pkgplugins.RuntimeSpec{PluginID: "tool/test", Name: "main", Build: func(ctx pkgplugins.RuntimeContext) (pkgplugins.Runtime, error) {
 		return runtimeStub{apply: func(context.Context, pkgplugins.PluginState) error { return nil }}, nil
 	}})
-	if err := host.ApplyPlugin(context.Background(), "tool/test"); err != nil {
+	ctx := ctxWithOrg(testOrg)
+	if err := host.ApplyPlugin(ctx, "tool/test"); err != nil {
 		t.Fatal(err)
 	}
-	handle, ok := host.Runtime().Get("tool/test", "main")
+	handle, ok := host.Runtime().Get(ctx, "tool/test", "main")
 	if !ok {
 		t.Fatal("expected runtime handle")
 	}
-	snap, err := handle.Snapshot(context.Background())
+	snap, err := handle.Snapshot(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if snap.State != pkgplugins.RuntimeStateRunning {
 		t.Fatalf("unexpected state: %s", snap.State)
 	}
+}
+
+// TestRuntimeOrgIsolation verifies that two orgs each running a runtime under
+// the same plugin ID + runtime name keep entirely separate managed instances.
+func TestRuntimeOrgIsolation(t *testing.T) {
+	store := &stubStore{plugins: map[string]config.Plugin{"tool/test": {ID: "tool/test", Enabled: true}}}
+	host := New(store)
+	host.RegisterPluginID("tool/test")
+
+	var builds []string
+	host.AddRuntime(pkgplugins.RuntimeSpec{PluginID: "tool/test", Name: "main", Build: func(rc pkgplugins.RuntimeContext) (pkgplugins.Runtime, error) {
+		builds = append(builds, rc.State.ID)
+		return runtimeStub{apply: func(context.Context, pkgplugins.PluginState) error { return nil }}, nil
+	}})
+
+	ctxA := ctxWithOrg("org-A")
+	ctxB := ctxWithOrg("org-B")
+	if err := host.ApplyPlugin(ctxA, "tool/test"); err != nil {
+		t.Fatalf("ApplyPlugin org-A: %v", err)
+	}
+	if err := host.ApplyPlugin(ctxB, "tool/test"); err != nil {
+		t.Fatalf("ApplyPlugin org-B: %v", err)
+	}
+	if len(builds) != 2 {
+		t.Fatalf("expected 2 builds (one per org), got %d", len(builds))
+	}
+
+	// Each org sees its own runtime; cross-org lookup returns nothing.
+	if _, ok := host.Runtime().Get(ctxA, "tool/test", "main"); !ok {
+		t.Fatal("org-A: expected runtime handle")
+	}
+	if _, ok := host.Runtime().Get(ctxB, "tool/test", "main"); !ok {
+		t.Fatal("org-B: expected runtime handle")
+	}
+
+	// Shutdown org-A clears only its runtimes; org-B still works.
+	if err := host.Shutdown(ctxA); err != nil {
+		t.Fatalf("Shutdown org-A: %v", err)
+	}
+	if _, ok := host.Runtime().Get(ctxA, "tool/test", "main"); ok {
+		t.Fatal("org-A: expected runtime gone after Shutdown")
+	}
+	if _, ok := host.Runtime().Get(ctxB, "tool/test", "main"); !ok {
+		t.Fatal("org-B: expected runtime still present after org-A Shutdown")
+	}
+}
+
+// TestRuntimeMissingOrgIDOnReadReturnsFalse ensures the read paths fail soft
+// when ctx lacks orgID (Get/Lookup return nil,false instead of panicking).
+func TestRuntimeMissingOrgIDOnReadReturnsFalse(t *testing.T) {
+	host := New(&stubStore{plugins: map[string]config.Plugin{}})
+	if _, ok := host.Runtime().Get(context.Background(), "tool/test", "main"); ok {
+		t.Fatal("expected (nil, false) when ctx has no orgID")
+	}
+}
+
+// TestRuntimeMissingOrgIDOnWriteReturnsError ensures Apply/Shutdown reject a
+// ctx without orgID rather than silently accepting it.
+func TestRuntimeMissingOrgIDOnWriteReturnsError(t *testing.T) {
+	store := &stubStore{plugins: map[string]config.Plugin{"tool/test": {ID: "tool/test", Enabled: true}}}
+	host := New(store)
+	host.RegisterPluginID("tool/test")
+	host.AddRuntime(pkgplugins.RuntimeSpec{PluginID: "tool/test", Name: "main", Build: func(pkgplugins.RuntimeContext) (pkgplugins.Runtime, error) {
+		return runtimeStub{apply: func(context.Context, pkgplugins.PluginState) error { return nil }}, nil
+	}})
+	if err := host.ApplyPlugin(context.Background(), "tool/test"); err == nil {
+		t.Fatal("ApplyPlugin without orgID: expected error, got nil")
+	}
+	if err := host.Shutdown(context.Background()); err == nil {
+		t.Fatal("Shutdown without orgID: expected error, got nil")
+	}
+}
+
+// TestApplyChannelOrgMismatchRejects guards against using one org's ctx to
+// apply another org's channel record.
+func TestApplyChannelOrgMismatchRejects(t *testing.T) {
+	host := New(&stubStore{plugins: map[string]config.Plugin{}})
+	host.RegisterPluginID("channel/telegram")
+	host.AddRuntime(pkgplugins.RuntimeSpec{PluginID: "channel/telegram", Name: "bot", Build: func(pkgplugins.RuntimeContext) (pkgplugins.Runtime, error) {
+		return runtimeStub{apply: func(context.Context, pkgplugins.PluginState) error { return nil }}, nil
+	}})
+	ch := config.Channel{ID: "tg-main", Type: "telegram", Enabled: true, Config: "{}", OrgID: "org-B"}
+	err := host.ApplyChannel(ctxWithOrg("org-A"), ch)
+	if err == nil {
+		t.Fatal("expected error for ctx/channel org mismatch")
+	}
+}
+
+// TestShutdownReleasesLockBeforeStop ensures Stop() is called outside the
+// RuntimeHost mutex; the stub's Stop reads back via Get to verify no deadlock.
+func TestShutdownReleasesLockBeforeStop(t *testing.T) {
+	store := &stubStore{plugins: map[string]config.Plugin{"tool/test": {ID: "tool/test", Enabled: true}}}
+	host := New(store)
+	host.RegisterPluginID("tool/test")
+	host.AddRuntime(pkgplugins.RuntimeSpec{PluginID: "tool/test", Name: "main", Build: func(pkgplugins.RuntimeContext) (pkgplugins.Runtime, error) {
+		return reentrantRuntime{host: host}, nil
+	}})
+	ctx := ctxWithOrg("org-A")
+	if err := host.ApplyPlugin(ctx, "tool/test"); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- host.Shutdown(ctx) }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Shutdown: %v", err)
+		}
+	case <-context.Background().Done():
+	}
+}
+
+// reentrantRuntime's Stop callbacks back into RuntimeHost.Get; if Shutdown held
+// the lock during Stop, this would deadlock.
+type reentrantRuntime struct{ host *Host }
+
+func (r reentrantRuntime) Apply(context.Context, pkgplugins.PluginState) error     { return nil }
+func (r reentrantRuntime) Start(context.Context, pkgplugins.PluginState) error     { return nil }
+func (r reentrantRuntime) Reconcile(context.Context, pkgplugins.PluginState) error { return nil }
+func (r reentrantRuntime) Stop(ctx context.Context) error {
+	// During Stop, Shutdown has already removed the entry; this lookup should
+	// return (nil,false) without deadlocking on the RuntimeHost mutex.
+	_, _ = r.host.Runtime().Get(ctx, "tool/test", "main")
+	return nil
+}
+
+func (r reentrantRuntime) Snapshot(context.Context) (pkgplugins.RuntimeStatus, error) {
+	return pkgplugins.RuntimeStatus{State: pkgplugins.RuntimeStateRunning}, nil
+}
+
+func (r reentrantRuntime) Status(ctx context.Context) (pkgplugins.RuntimeStatus, error) {
+	return r.Snapshot(ctx)
 }

--- a/internal/pluginhost/runtime_test.go
+++ b/internal/pluginhost/runtime_test.go
@@ -3,6 +3,7 @@ package pluginhost
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/CherryHQ/stella/internal/config"
 	"github.com/CherryHQ/stella/internal/orgctx"
@@ -171,7 +172,8 @@ func TestShutdownReleasesLockBeforeStop(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Shutdown: %v", err)
 		}
-	case <-context.Background().Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("Shutdown deadlocked: lock held during Stop")
 	}
 }
 

--- a/pkg/plugins/managed_channel.go
+++ b/pkg/plugins/managed_channel.go
@@ -51,7 +51,7 @@ func RegisterManagedChannelPlugin(host Host, reg ManagedChannelPluginRegistratio
 }
 
 func managedRuntimeStatus(ctx context.Context, runtime RuntimeLookup, pluginID, runtimeName string) (any, error) {
-	handle, ok := runtime.Get(pluginID, runtimeName)
+	handle, ok := runtime.Get(ctx, pluginID, runtimeName)
 	if !ok {
 		return map[string]any{
 			"state":      RuntimeStateStopped,

--- a/pkg/plugins/managed_channel_test.go
+++ b/pkg/plugins/managed_channel_test.go
@@ -10,15 +10,15 @@ type runtimeLookupStub struct {
 	handle RuntimeHandle
 }
 
-func (s runtimeLookupStub) Get(pluginID string, runtimeName string) (RuntimeHandle, bool) {
+func (s runtimeLookupStub) Get(_ context.Context, pluginID string, runtimeName string) (RuntimeHandle, bool) {
 	if s.handle == nil || pluginID != "channel/telegram" || runtimeName != "bot" {
 		return nil, false
 	}
 	return s.handle, true
 }
 
-func (s runtimeLookupStub) Lookup(pluginID string, runtimeName string) (RuntimeHandle, bool) {
-	return s.Get(pluginID, runtimeName)
+func (s runtimeLookupStub) Lookup(ctx context.Context, pluginID string, runtimeName string) (RuntimeHandle, bool) {
+	return s.Get(ctx, pluginID, runtimeName)
 }
 
 type runtimeHandleStub struct {

--- a/pkg/plugins/types.go
+++ b/pkg/plugins/types.go
@@ -25,9 +25,10 @@ type ConfigStore interface {
 }
 
 // RuntimeLookup resolves running runtime handles by plugin and runtime capability ID.
+// The org is resolved from ctx; an absent orgID returns (nil, false).
 type RuntimeLookup interface {
-	Get(pluginID string, runtimeName string) (RuntimeHandle, bool)
-	Lookup(pluginID string, runtimeName string) (RuntimeHandle, bool)
+	Get(ctx context.Context, runtimeID string, runtimeName string) (RuntimeHandle, bool)
+	Lookup(ctx context.Context, runtimeID string, runtimeName string) (RuntimeHandle, bool)
 }
 
 // RuntimeHandle exposes status access to a running runtime.

--- a/plugins/channels/telegram/plugin_test.go
+++ b/plugins/channels/telegram/plugin_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/CherryHQ/stella/internal/config"
 	internalnotify "github.com/CherryHQ/stella/internal/notify"
+	"github.com/CherryHQ/stella/internal/orgctx"
 	"github.com/CherryHQ/stella/internal/pluginhost"
 	pkgchannel "github.com/CherryHQ/stella/pkg/channel"
 	pkgplugins "github.com/CherryHQ/stella/pkg/plugins"
@@ -64,10 +65,11 @@ func TestSelfRegisteredTelegramPluginAppliesAndReportsStatus(t *testing.T) {
 	if err := host.LoadDefaultCatalog(); err != nil {
 		t.Fatalf("LoadDefaultCatalog: %v", err)
 	}
-	if err := host.ApplyPlugin(context.Background(), PluginID); err != nil {
+	ctx := orgctx.WithOrgID(context.Background(), "org-A")
+	if err := host.ApplyPlugin(ctx, PluginID); err != nil {
 		t.Fatalf("ApplyPlugin: %v", err)
 	}
-	status, err := host.Status(context.Background(), PluginID)
+	status, err := host.Status(ctx, PluginID)
 	if err != nil {
 		t.Fatalf("Status: %v", err)
 	}


### PR DESCRIPTION
## Summary

**Phase 2 of 5** — stacked on #239.

Fixes cross-org collision in `pluginhost.RuntimeHost`. The process-global `rt` map is now keyed first by orgID, so two orgs running the same managed runtime no longer trample each other.

## Changes
- \`internal/pluginhost/runtime.go\`: \`rt map[string]map[runtimeKey]*runtimeEntry\` (orgID → key → entry)
- \`Get/Lookup\` read paths take \`ctx\` for org resolution
- \`ApplyPlugin/ApplyChannel/Shutdown\` write paths take \`ctx\`
- \`Shutdown\` uses collect-then-stop pattern (entries collected under lock, \`Stop\` called unlocked)

## Test plan
- [x] \`mise run format\` / \`build\` / \`test\`
- [ ] Manual: two orgs with same runtime ID don't collide