### PR TITLE
✨ feat(channels): inject orgID into channel SDK callback ctx (3/5)

### DIFF
--- a/internal/channel/coordinator.go
+++ b/internal/channel/coordinator.go
@@ -142,9 +142,9 @@ func (c *Coordinator) resolve(ctx context.Context, msg pkgchannel.IncomingMessag
 // resolution when a plugin needs to try commands before messaging.
 func (c *Coordinator) HandleIncoming(ctx context.Context, msg pkgchannel.IncomingMessage, command, args string) (string, bool, *pkgchannel.ChatStream, error) {
 	if orgctx.OrgIDFromContext(ctx) == "" {
-		slog.Error("coordinator: inbound message dropped: orgID missing from ctx",
+		slog.Error("coordinator: inbound message dropped: orgID missing from ctx; the channel runtime was built without an org, so HandlerWithOrgID degraded to passthrough — check this channel's OrgID",
 			"platform", msg.Platform, "channel_id", msg.ChannelID, "sender", msg.SenderID)
-		return "", false, nil, fmt.Errorf("coordinator: orgID missing from context")
+		return "", false, nil, fmt.Errorf("coordinator: orgID missing from context (channel %s built without org)", msg.ChannelID)
 	}
 
 	// Try link code first (before auth resolution, since it creates identity).

--- a/internal/channel/coordinator.go
+++ b/internal/channel/coordinator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/CherryHQ/stella/internal/agent"
 	"github.com/CherryHQ/stella/internal/auth"
 	"github.com/CherryHQ/stella/internal/config"
+	"github.com/CherryHQ/stella/internal/orgctx"
 	"github.com/CherryHQ/stella/internal/vault"
 	"github.com/CherryHQ/stella/pkg/ai"
 	pkgchannel "github.com/CherryHQ/stella/pkg/channel"
@@ -140,6 +141,12 @@ func (c *Coordinator) resolve(ctx context.Context, msg pkgchannel.IncomingMessag
 // command is not handled, streams a chat response. This avoids double
 // resolution when a plugin needs to try commands before messaging.
 func (c *Coordinator) HandleIncoming(ctx context.Context, msg pkgchannel.IncomingMessage, command, args string) (string, bool, *pkgchannel.ChatStream, error) {
+	if orgctx.OrgIDFromContext(ctx) == "" {
+		slog.Error("coordinator: inbound message dropped: orgID missing from ctx",
+			"platform", msg.Platform, "channel_id", msg.ChannelID, "sender", msg.SenderID)
+		return "", false, nil, fmt.Errorf("coordinator: orgID missing from context")
+	}
+
 	// Try link code first (before auth resolution, since it creates identity).
 	if c.auth != nil && c.linkCodes != nil {
 		fullText := command

--- a/internal/pluginhost/runtime.go
+++ b/internal/pluginhost/runtime.go
@@ -197,7 +197,11 @@ func (h *RuntimeHost) applyOneWithKey(ctx context.Context, reg pkgplugins.Runtim
 		if build == nil {
 			return fmt.Errorf("runtime %s/%s has no builder", runtimeID, reg.Name)
 		}
-		created, err := build(pkgplugins.RuntimeContext{Platform: h.host.platform(reg.PluginID), State: desired.Clone()})
+		created, err := build(pkgplugins.RuntimeContext{
+			Platform: h.host.platform(reg.PluginID),
+			State:    desired.Clone(),
+			OrgID:    orgID,
+		})
 		if err != nil {
 			return fmt.Errorf("create runtime %s/%s: %w", runtimeID, reg.Name, err)
 		}

--- a/pkg/channel/handler_org.go
+++ b/pkg/channel/handler_org.go
@@ -1,0 +1,85 @@
+package channel
+
+import (
+	"context"
+
+	"github.com/CherryHQ/stella/internal/orgctx"
+)
+
+// HandlerWithOrgID returns a Handler that injects orgID into the context of
+// every call before delegating to inner. Channel plugins receive callbacks
+// from their SDKs (larkws, telegram poller, etc.) on a context that does not
+// carry any HTTP middleware state. Wrapping the handler at runtime construction
+// time ensures downstream consumers (coordinator, agent pool) see the correct
+// org without each channel implementation having to know about org plumbing.
+//
+// The returned wrapper preserves inner's optional interfaces (Provisioner,
+// UserRootResolver) via type-assertion fanout so channel plugins that branch on
+// `b.handler.(channel.UserRootResolver)` keep working.
+//
+// orgID may be empty if the caller cannot resolve it; in that case the wrapper
+// is a passthrough (no value injected). Callers that require non-empty orgID
+// should validate before calling.
+func HandlerWithOrgID(orgID string, inner Handler) Handler {
+	if orgID == "" {
+		return inner
+	}
+	base := orgScopedHandler{orgID: orgID, inner: inner}
+	_, hasResolver := inner.(UserRootResolver)
+	_, hasProvisioner := inner.(Provisioner)
+	switch {
+	case hasResolver && hasProvisioner:
+		return orgScopedResolverProvisioner{orgScopedHandler: base}
+	case hasResolver:
+		return orgScopedResolver{orgScopedHandler: base}
+	case hasProvisioner:
+		return orgScopedProvisioner{orgScopedHandler: base}
+	default:
+		return base
+	}
+}
+
+type orgScopedResolver struct{ orgScopedHandler }
+
+func (h orgScopedResolver) ResolveUserRoot(ctx context.Context, msg IncomingMessage) (string, error) {
+	return h.inner.(UserRootResolver).ResolveUserRoot(orgctx.WithOrgID(ctx, h.orgID), msg)
+}
+
+type orgScopedProvisioner struct{ orgScopedHandler }
+
+func (h orgScopedProvisioner) ProvisionUser(ctx context.Context, req ProvisionRequest) error {
+	return h.inner.(Provisioner).ProvisionUser(orgctx.WithOrgID(ctx, h.orgID), req)
+}
+
+type orgScopedResolverProvisioner struct{ orgScopedHandler }
+
+func (h orgScopedResolverProvisioner) ResolveUserRoot(ctx context.Context, msg IncomingMessage) (string, error) {
+	return h.inner.(UserRootResolver).ResolveUserRoot(orgctx.WithOrgID(ctx, h.orgID), msg)
+}
+
+func (h orgScopedResolverProvisioner) ProvisionUser(ctx context.Context, req ProvisionRequest) error {
+	return h.inner.(Provisioner).ProvisionUser(orgctx.WithOrgID(ctx, h.orgID), req)
+}
+
+type orgScopedHandler struct {
+	orgID string
+	inner Handler
+}
+
+func (h orgScopedHandler) HandleIncoming(ctx context.Context, msg IncomingMessage, command, args string) (string, bool, *ChatStream, error) {
+	return h.inner.HandleIncoming(orgctx.WithOrgID(ctx, h.orgID), msg, command, args)
+}
+
+func (h orgScopedHandler) ListModels() []ModelOption { return h.inner.ListModels() }
+
+func (h orgScopedHandler) SwitchModel(provider, model string) error {
+	return h.inner.SwitchModel(provider, model)
+}
+
+func (h orgScopedHandler) ListAgents(ctx context.Context, msg IncomingMessage) ([]AgentInfo, string, error) {
+	return h.inner.ListAgents(orgctx.WithOrgID(ctx, h.orgID), msg)
+}
+
+func (h orgScopedHandler) SwitchAgent(ctx context.Context, msg IncomingMessage, agentSlug string) error {
+	return h.inner.SwitchAgent(orgctx.WithOrgID(ctx, h.orgID), msg, agentSlug)
+}

--- a/pkg/channel/handler_org_test.go
+++ b/pkg/channel/handler_org_test.go
@@ -1,0 +1,96 @@
+package channel
+
+import (
+	"context"
+	"testing"
+
+	"github.com/CherryHQ/stella/internal/orgctx"
+)
+
+type recordingHandler struct {
+	gotOrg     string
+	provOrg    string
+	resolveOrg string
+}
+
+func (h *recordingHandler) HandleIncoming(ctx context.Context, _ IncomingMessage, _ string, _ string) (string, bool, *ChatStream, error) {
+	h.gotOrg = orgctx.OrgIDFromContext(ctx)
+	return "", true, nil, nil
+}
+func (h *recordingHandler) ListModels() []ModelOption     { return nil }
+func (h *recordingHandler) SwitchModel(_, _ string) error { return nil }
+func (h *recordingHandler) ListAgents(context.Context, IncomingMessage) ([]AgentInfo, string, error) {
+	return nil, "", nil
+}
+func (h *recordingHandler) SwitchAgent(context.Context, IncomingMessage, string) error { return nil }
+
+type fullHandler struct {
+	recordingHandler
+}
+
+func (h *fullHandler) ResolveUserRoot(ctx context.Context, _ IncomingMessage) (string, error) {
+	h.resolveOrg = orgctx.OrgIDFromContext(ctx)
+	return "/tmp", nil
+}
+
+func (h *fullHandler) ProvisionUser(ctx context.Context, _ ProvisionRequest) error {
+	h.provOrg = orgctx.OrgIDFromContext(ctx)
+	return nil
+}
+
+func TestHandlerWithOrgID_InjectsOrgIntoHandleIncoming(t *testing.T) {
+	inner := &recordingHandler{}
+	wrapped := HandlerWithOrgID("org-A", inner)
+	if _, _, _, err := wrapped.HandleIncoming(context.Background(), IncomingMessage{}, "", ""); err != nil {
+		t.Fatalf("HandleIncoming: %v", err)
+	}
+	if inner.gotOrg != "org-A" {
+		t.Fatalf("HandleIncoming ctx org = %q, want org-A", inner.gotOrg)
+	}
+}
+
+func TestHandlerWithOrgID_EmptyOrgIsPassthrough(t *testing.T) {
+	inner := &recordingHandler{}
+	wrapped := HandlerWithOrgID("", inner)
+	if any(wrapped) != any(inner) {
+		t.Fatalf("empty orgID should return inner as-is")
+	}
+}
+
+func TestHandlerWithOrgID_PreservesOptionalInterfaces(t *testing.T) {
+	inner := &fullHandler{}
+	wrapped := HandlerWithOrgID("org-X", inner)
+
+	resolver, ok := wrapped.(UserRootResolver)
+	if !ok {
+		t.Fatal("expected wrapper to satisfy UserRootResolver when inner does")
+	}
+	if _, err := resolver.ResolveUserRoot(context.Background(), IncomingMessage{}); err != nil {
+		t.Fatalf("ResolveUserRoot: %v", err)
+	}
+	if inner.resolveOrg != "org-X" {
+		t.Fatalf("ResolveUserRoot ctx org = %q, want org-X", inner.resolveOrg)
+	}
+
+	provisioner, ok := wrapped.(Provisioner)
+	if !ok {
+		t.Fatal("expected wrapper to satisfy Provisioner when inner does")
+	}
+	if err := provisioner.ProvisionUser(context.Background(), ProvisionRequest{}); err != nil {
+		t.Fatalf("ProvisionUser: %v", err)
+	}
+	if inner.provOrg != "org-X" {
+		t.Fatalf("ProvisionUser ctx org = %q, want org-X", inner.provOrg)
+	}
+}
+
+func TestHandlerWithOrgID_DoesNotFakeOptionalInterfaces(t *testing.T) {
+	inner := &recordingHandler{} // does NOT implement UserRootResolver/Provisioner
+	wrapped := HandlerWithOrgID("org-A", inner)
+	if _, ok := wrapped.(UserRootResolver); ok {
+		t.Fatal("wrapper should not satisfy UserRootResolver when inner does not")
+	}
+	if _, ok := wrapped.(Provisioner); ok {
+		t.Fatal("wrapper should not satisfy Provisioner when inner does not")
+	}
+}

--- a/pkg/plugins/context.go
+++ b/pkg/plugins/context.go
@@ -55,9 +55,14 @@ type ChannelContext struct {
 }
 
 // RuntimeContext is the narrow construction context for runtime capabilities.
+//
+// OrgID is populated by the host when calling Build; runtimes should hold onto
+// it and wrap any inbound ctx (e.g. SDK callbacks that originate outside an
+// HTTP handler) with orgctx.WithOrgID before dispatching downstream.
 type RuntimeContext struct {
 	Platform Platform
 	State    PluginState
+	OrgID    string
 }
 
 // AdminContext is the narrow build context for plugin admin/status behavior.

--- a/pkg/plugins/managed_channel.go
+++ b/pkg/plugins/managed_channel.go
@@ -12,7 +12,7 @@ type ManagedChannelPluginRegistration struct {
 	Validate       func(raw map[string]any) error
 	Redact         func(raw map[string]any) map[string]any
 	Configured     func(raw map[string]any) bool
-	RuntimeFactory func(Platform) (Runtime, error)
+	RuntimeFactory func(rc RuntimeContext) (Runtime, error)
 }
 
 func RegisterManagedChannelPlugin(host Host, reg ManagedChannelPluginRegistration) {
@@ -44,8 +44,8 @@ func RegisterManagedChannelPlugin(host Host, reg ManagedChannelPluginRegistratio
 	host.AddRuntime(RuntimeSpec{
 		PluginID: reg.PluginID,
 		Name:     reg.RuntimeName,
-		Build: func(ctx RuntimeContext) (Runtime, error) {
-			return reg.RuntimeFactory(ctx.Platform)
+		Build: func(rc RuntimeContext) (Runtime, error) {
+			return reg.RuntimeFactory(rc)
 		},
 	})
 }

--- a/plugins/channels/feishu/plugin.go
+++ b/plugins/channels/feishu/plugin.go
@@ -12,7 +12,8 @@ const (
 	RuntimeName = "bot"
 )
 
-var newRuntime = func(platform pkgplugins.Platform) (pkgplugins.Runtime, error) {
+var newRuntime = func(rc pkgplugins.RuntimeContext) (pkgplugins.Runtime, error) {
+	platform := rc.Platform
 	channelRuntime := platform.ChannelPlatform()
 	if channelRuntime == nil {
 		return nil, fmt.Errorf("feishu: channel runtime services unavailable")
@@ -25,6 +26,7 @@ var newRuntime = func(platform pkgplugins.Platform) (pkgplugins.Runtime, error) 
 	if handler == nil {
 		return nil, fmt.Errorf("feishu: missing channel handler")
 	}
+	handler = pkgchannel.HandlerWithOrgID(rc.OrgID, handler)
 	return NewFeishuManagedRuntime(FeishuRuntimeDeps{
 		Parent:        parent,
 		Handler:       handler,
@@ -80,8 +82,8 @@ func init() {
 // SetRuntimeFactoryForTesting swaps the Feishu managed runtime factory for tests.
 func SetRuntimeFactoryForTesting(factory func(platform pkgplugins.Platform) (pkgplugins.Runtime, error)) func() {
 	prev := newRuntime
-	newRuntime = func(platform pkgplugins.Platform) (pkgplugins.Runtime, error) {
-		return factory(platform)
+	newRuntime = func(rc pkgplugins.RuntimeContext) (pkgplugins.Runtime, error) {
+		return factory(rc.Platform)
 	}
 	return func() { newRuntime = prev }
 }

--- a/plugins/channels/qq/plugin.go
+++ b/plugins/channels/qq/plugin.go
@@ -12,7 +12,8 @@ const (
 	RuntimeName = "bot"
 )
 
-var newRuntime = func(platform pkgplugins.Platform) (pkgplugins.Runtime, error) {
+var newRuntime = func(rc pkgplugins.RuntimeContext) (pkgplugins.Runtime, error) {
+	platform := rc.Platform
 	channelRuntime := platform.ChannelPlatform()
 	if channelRuntime == nil {
 		return nil, fmt.Errorf("qq: channel runtime services unavailable")
@@ -25,6 +26,7 @@ var newRuntime = func(platform pkgplugins.Platform) (pkgplugins.Runtime, error) 
 	if handler == nil {
 		return nil, fmt.Errorf("qq: missing channel handler")
 	}
+	handler = pkgchannel.HandlerWithOrgID(rc.OrgID, handler)
 	return NewQQManagedRuntime(QQRuntimeDeps{
 		Parent:        parent,
 		Handler:       handler,

--- a/plugins/channels/telegram/plugin.go
+++ b/plugins/channels/telegram/plugin.go
@@ -12,7 +12,8 @@ const (
 	RuntimeName = "bot"
 )
 
-var newRuntime = func(platform pkgplugins.Platform) (pkgplugins.Runtime, error) {
+var newRuntime = func(rc pkgplugins.RuntimeContext) (pkgplugins.Runtime, error) {
+	platform := rc.Platform
 	channelRuntime := platform.ChannelPlatform()
 	if channelRuntime == nil {
 		return nil, fmt.Errorf("telegram: channel runtime services unavailable")
@@ -25,6 +26,7 @@ var newRuntime = func(platform pkgplugins.Platform) (pkgplugins.Runtime, error) 
 	if handler == nil {
 		return nil, fmt.Errorf("telegram: missing channel handler")
 	}
+	handler = pkgchannel.HandlerWithOrgID(rc.OrgID, handler)
 	return NewManagedRuntime(RuntimeDeps{
 		Parent:        parent,
 		Handler:       handler,
@@ -61,9 +63,7 @@ func init() {
 				cfg, err := DecodeConfig(raw)
 				return err == nil && validateConfig(cfg) == ""
 			},
-			RuntimeFactory: func(platform pkgplugins.Platform) (pkgplugins.Runtime, error) {
-				return newRuntime(platform)
-			},
+			RuntimeFactory: newRuntime,
 		})
 	}))
 }
@@ -93,8 +93,8 @@ func configSchema() map[string]any {
 // SetRuntimeFactoryForTesting swaps the Telegram managed runtime factory for tests.
 func SetRuntimeFactoryForTesting(factory func(platform pkgplugins.Platform) (pkgplugins.Runtime, error)) func() {
 	prev := newRuntime
-	newRuntime = func(platform pkgplugins.Platform) (pkgplugins.Runtime, error) {
-		return factory(platform)
+	newRuntime = func(rc pkgplugins.RuntimeContext) (pkgplugins.Runtime, error) {
+		return factory(rc.Platform)
 	}
 	return func() { newRuntime = prev }
 }

--- a/plugins/channels/weixin/plugin.go
+++ b/plugins/channels/weixin/plugin.go
@@ -12,7 +12,8 @@ const (
 	RuntimeName = "bot"
 )
 
-var newRuntime = func(platform pkgplugins.Platform) (pkgplugins.Runtime, error) {
+var newRuntime = func(rc pkgplugins.RuntimeContext) (pkgplugins.Runtime, error) {
+	platform := rc.Platform
 	channelRuntime := platform.ChannelPlatform()
 	if channelRuntime == nil {
 		return nil, fmt.Errorf("weixin: channel runtime services unavailable")
@@ -25,6 +26,7 @@ var newRuntime = func(platform pkgplugins.Platform) (pkgplugins.Runtime, error) 
 	if handler == nil {
 		return nil, fmt.Errorf("weixin: missing channel handler")
 	}
+	handler = pkgchannel.HandlerWithOrgID(rc.OrgID, handler)
 	return NewWeixinManagedRuntime(WeixinRuntimeDeps{
 		Parent:        parent,
 		Handler:       handler,
@@ -77,8 +79,8 @@ func init() {
 // SetRuntimeFactoryForTesting swaps the Weixin managed runtime factory for tests.
 func SetRuntimeFactoryForTesting(factory func(platform pkgplugins.Platform) (pkgplugins.Runtime, error)) func() {
 	prev := newRuntime
-	newRuntime = func(platform pkgplugins.Platform) (pkgplugins.Runtime, error) {
-		return factory(platform)
+	newRuntime = func(rc pkgplugins.RuntimeContext) (pkgplugins.Runtime, error) {
+		return factory(rc.Platform)
 	}
 	return func() { newRuntime = prev }
 }


### PR DESCRIPTION
## Summary

**Phase 3 of 5** — stacked on #240.

Channel SDK callbacks (Feishu/Telegram/WeiXin/QQ long-conn) now carry orgID via \`context.Context\`. Downstream code can rely on \`orgctx.OrgIDFromContext(ctx)\` returning a non-empty value.

## Changes
- New \`pkg/channel/handler_org.go\`: \`HandlerWithOrgID(orgID, inner)\` wrapper with 4-variant fanout to preserve optional interfaces (\`UserRootResolver\`, \`Provisioner\`)
- \`pkg/plugins/context.go\`: \`RuntimeContext\` gains \`OrgID string\`
- \`pkg/plugins/managed_channel.go\`: \`RuntimeFactory func(rc RuntimeContext) (Runtime, error)\`
- All four channel plugins (\`feishu\`, \`telegram\`, \`weixin\`, \`qq\`) wrap their handler with \`HandlerWithOrgID(rc.OrgID, handler)\`
- \`internal/channel/coordinator.go\`: defensive check — drops inbound msg + logs if orgID missing from ctx

## Test plan
- [x] \`mise run format\` / \`build\` / \`test\`
- [ ] Manual: each channel callback resolves to the correct org