### PR TITLE
📝 docs(plugins): document plugin org isolation model (5/5)

### DIFF
--- a/web/content/docs/development/meta.json
+++ b/web/content/docs/development/meta.json
@@ -7,6 +7,7 @@
     "memory-internals",
     "session-compaction",
     "plugin-system",
+    "plugin-org-isolation",
     "task-system",
     "goal-system"
   ]

--- a/web/content/docs/development/meta.zh.json
+++ b/web/content/docs/development/meta.zh.json
@@ -7,6 +7,7 @@
     "memory-internals",
     "session-compaction",
     "plugin-system",
+    "plugin-org-isolation",
     "task-system",
     "goal-system"
   ]

--- a/web/content/docs/development/plugin-org-isolation.md
+++ b/web/content/docs/development/plugin-org-isolation.md
@@ -1,0 +1,77 @@
+---
+title: Plugin Org Isolation
+description: How Stella scopes plugin runtimes, manifest overrides, and channel callbacks to a single org.
+---
+
+## Overview
+
+Stella is multi-tenant. Every plugin runtime, manifest override, OAuth provider configuration, and channel callback must resolve to exactly one org. This page documents the contracts that enforce that.
+
+## The org context contract
+
+Org identity travels with `context.Context`. The helpers live in `internal/orgctx`:
+
+```go
+ctx = orgctx.WithOrgID(ctx, orgID)
+got := orgctx.OrgIDFromContext(ctx) // returns "" when absent
+```
+
+Two layers enforce the contract:
+
+- **HTTP middleware** injects the authenticated user's `orgID` into every `/api/*` handler's `r.Context()`.
+- **Channel runtime** (one per `(org, channel.ID, runtimeName)`) wraps the shared coordinator handler with `pkgchannel.HandlerWithOrgID(orgID, inner)` at build time. Every SDK callback (`onMessage`, `onReaction`, telegram poller, etc.) is dispatched through that wrapper, so the coordinator sees the right org even when the SDK provides a bare context.
+
+Downstream code uses `requireOrgID(ctx)` (`internal/store/dbstore.go`, `internal/pluginhost/runtime.go`, `internal/channel/coordinator.go`) to fail loud if context is missing the org. Read paths fall back to `(nil, false)`; write paths return an error.
+
+## RuntimeHost is keyed by org
+
+`internal/pluginhost/runtime.go` stores managed runtimes in a two-level map:
+
+```go
+rt map[string]map[runtimeKey]*runtimeEntry  // orgID -> {RuntimeID, RuntimeName} -> entry
+```
+
+This means two orgs that each configure a channel named `feishu-main` get **two independent runtime instances**, each with its own SDK client. The `runtimeKey` is a struct, not a string concat, so there is no collision via separator escaping.
+
+`Host.Shutdown(ctx)` tears down only the current org's bucket; `Host.Stop(ctx)` is reserved for process-exit and walks every bucket.
+
+## Manifest plugin defaults + per-org overrides
+
+The manifest baked into the binary (`resources.BuiltinPluginsYAML()`) is the **single source of truth** for plugin defaults. Per-tenant overrides live in `settings_manifest_plugin_override` (PK = `(plugin_id, org_id)`):
+
+| Column                  | Semantics                                                                             |
+| ----------------------- | ------------------------------------------------------------------------------------- |
+| `plugin_id`             | manifest plugin ID                                                                    |
+| `org_id`                | tenant                                                                                |
+| `enabled`               | nullable; `NULL` = use manifest default, non-`NULL` = explicit override               |
+| `session_env_vault_key` | empty = fallback default, non-empty = vault blob holding the session_env override map |
+
+Override semantics are sparse: only fields that diverge from the default are persisted. `SaveManifestPlugins` drops the row only when nothing is left to override — the requested `enabled` matches the manifest default **and** no `session_env_vault_key` binding is set. When a session env binding exists, the row is kept and `enabled` is stored as `NULL` so it still falls back to the default. This keeps the DB minimal-diff without clobbering the session env dimension.
+
+Reads go through `Server.resolveManifestPlugins(r)` which overlays `ListManifestPluginOverrides` onto the builtin manifest before returning. The builtin manifest itself is never mutated.
+
+`Reconcile` (binary / skill installation) installs into `$STELLA_HOME/bin` and the system skill directory — **system-wide resources with no org dimension**. `SyncManifestPlugins` does pass the override-applied manifest to `Reconcile`, so per-org enable state reaches it, but the install layer (`StellaHome`, the bin directory, the reconcile state file) is shared across all orgs. Per-org enable/disable only governs whether the agent runtime invokes the plugin, not which binaries are installed. Making the install layer org-aware is tracked separately (see issue #244).
+
+## OAuth provider per-org overrides
+
+A separate table, `plugin_oauth_provider`, holds per-org OAuth client overrides:
+
+- `client_id`, `client_secret_enc` (vault-encrypted), `redirect_url`, `org_id`
+- Updated via `PUT /api/admin/oauth-providers/{id}/config`
+- Read by `credentials.Service.GetEffectiveOAuthConfig(ctx, providerID)` which merges DB override over manifest YAML defaults
+- `GET` responses redact the secret (returns `"***"` when set)
+
+The OAuth flow's `state` parameter binds the `orgID` (`oauth.FlowStatus.OrgID`); `CompleteAuthCodeFlowWithOrigin` injects it into ctx before the token exchange, so callbacks always run under the right org.
+
+## What was removed
+
+- `~/.stella/plugins.yaml` and the `manifestplugins.LoadUser` / `Merge` / `MergeRaw` loaders. Per-tenant tunables now go through the REST API → DB.
+- The MCP plugin (`internal/tools/mcp`). The runtime model and `RegisterBuiltinTools` it relied on are gone. Any legacy `settings_plugin` row with `id='tool/mcp'` is inert — no plugin is registered under that ID, so it never resolves to a runtime.
+
+## Migrating from the old plugins.yaml
+
+If you previously ran a fork that wrote `~/.stella/plugins.yaml`:
+
+1. The file is now ignored at startup; no error, no migration.
+2. Re-apply any per-tenant overrides via the Plugins page in the Web UI (one org at a time), or programmatically via `PUT /api/manifest-plugins`.
+3. Delete the stale file once you've finished migrating.

--- a/web/content/docs/development/plugin-org-isolation.zh.md
+++ b/web/content/docs/development/plugin-org-isolation.zh.md
@@ -1,0 +1,77 @@
+---
+title: 插件按 Org 隔离
+description: Stella 如何把插件运行时、manifest override、OAuth provider 配置和 channel 回调严格归属到单个 org。
+---
+
+## 概览
+
+Stella 是多租户系统。每个插件运行时、manifest override、OAuth provider 配置、channel 回调必须精确归属到一个 org。本文记录了实现这一保证的契约。
+
+## Org context 契约
+
+Org 标识随 `context.Context` 流动，helper 在 `internal/orgctx`：
+
+```go
+ctx = orgctx.WithOrgID(ctx, orgID)
+got := orgctx.OrgIDFromContext(ctx) // 缺失时返回 ""
+```
+
+两层执行这个契约：
+
+- **HTTP 中间件** 给每个 `/api/*` handler 的 `r.Context()` 注入已登录用户的 `orgID`。
+- **Channel runtime**（每 `(org, channel.ID, runtimeName)` 一个实例）在 Build 时用 `pkgchannel.HandlerWithOrgID(orgID, inner)` 包装共享的 coordinator handler。所有 SDK 回调（`onMessage`、`onReaction`、telegram poller 等）经过这层 wrapper 后，coordinator 看到的 ctx 一定带正确的 org，即便 SDK 本身只给一个裸 context。
+
+下游代码（`internal/store/dbstore.go`、`internal/pluginhost/runtime.go`、`internal/channel/coordinator.go`）用 `requireOrgID(ctx)` 在缺 org 时显式失败。读路径返回 `(nil, false)`；写路径返回 error。
+
+## RuntimeHost 按 org 分桶
+
+`internal/pluginhost/runtime.go` 用两层 map 存运行时：
+
+```go
+rt map[string]map[runtimeKey]*runtimeEntry  // orgID -> {RuntimeID, RuntimeName} -> entry
+```
+
+两个 org 都配置了名为 `feishu-main` 的 channel？**各自拥有独立的 runtime 实例和 SDK 客户端**，互不影响。`runtimeKey` 是 struct 不是字符串拼接，避免分隔符转义碰撞。
+
+`Host.Shutdown(ctx)` 只清除当前 org 的桶；`Host.Stop(ctx)` 留给进程退出时遍历所有桶。
+
+## Manifest 默认值 + per-org override
+
+打进二进制的 manifest（`resources.BuiltinPluginsYAML()`）是插件默认值的**唯一来源**。per-tenant override 存在 `settings_manifest_plugin_override`（PK = `(plugin_id, org_id)`）：
+
+| 列                      | 语义                                                              |
+| ----------------------- | ----------------------------------------------------------------- |
+| `plugin_id`             | manifest 插件 ID                                                  |
+| `org_id`                | 租户                                                              |
+| `enabled`               | nullable；`NULL` = 用 manifest 默认，非 `NULL` = 显式 override    |
+| `session_env_vault_key` | 空 = fallback 默认，非空 = vault 中存的 session_env override 映射 |
+
+Override 是稀疏存储：只有真正偏离默认值的字段才会写 DB。`SaveManifestPlugins` 仅在**没有任何东西需要 override 时**才删除该行——即请求的 `enabled` 与 manifest 默认一致**且**没有 `session_env_vault_key` 绑定。若存在 session env 绑定，则保留该行,并把 `enabled` 存为 `NULL`,使其仍回退到默认。这样既保持 DB 最小差异，又不会抹掉 session env 维度。
+
+读路径走 `Server.resolveManifestPlugins(r)`，把 `ListManifestPluginOverrides` 叠加到 builtin manifest 上后返回。builtin manifest 本身永远不可变。
+
+`Reconcile`（二进制 / skill 安装）装到 `$STELLA_HOME/bin` 和系统 skill 目录——**系统级资源，没有 org 维度**。`SyncManifestPlugins` 确实会把已叠加 override 的 manifest 传给 `Reconcile`，所以 per-org 启用状态会到达它,但安装层（`StellaHome`、bin 目录、reconcile 状态文件）在所有 org 间共享。per-org 启用/禁用只决定 agent runtime 是否调用该插件,不决定安装哪些二进制。让安装层 org 化由单独的 issue 跟踪（见 issue #244）。
+
+## OAuth provider per-org override
+
+`plugin_oauth_provider` 表存 per-org OAuth client override：
+
+- `client_id`、`client_secret_enc`（vault 加密）、`redirect_url`、`org_id`
+- 通过 `PUT /api/admin/oauth-providers/{id}/config` 更新
+- `credentials.Service.GetEffectiveOAuthConfig(ctx, providerID)` 把 DB override 合并到 manifest YAML 默认上
+- `GET` 响应把 secret redact 成 `"***"`
+
+OAuth 流的 `state` 参数绑定了 `orgID`（`oauth.FlowStatus.OrgID`）；`CompleteAuthCodeFlowWithOrigin` 在 token exchange 前把 orgID 注入 ctx，保证 callback 始终在正确 org 下执行。
+
+## 已移除的内容
+
+- `~/.stella/plugins.yaml` 与 `manifestplugins.LoadUser` / `Merge` / `MergeRaw` 加载器。per-tenant 配置一律走 REST API → DB。
+- MCP 插件（`internal/tools/mcp`）。它依赖的运行时模型和 `RegisterBuiltinTools` 都已删除。DB 中遗留的 `settings_plugin` 中 `id='tool/mcp'` 的行是惰性的——没有任何插件注册在该 ID 下,因此永远不会解析成 runtime。
+
+## 从旧 plugins.yaml 迁移
+
+如果你之前的 fork 写过 `~/.stella/plugins.yaml`：
+
+1. 该文件启动时被忽略；不报错也不迁移。
+2. 通过 Web UI 的 Plugins 页面（每个 org 单独操作）重新设置 per-tenant override，或通过 `PUT /api/manifest-plugins` 编程式写入。
+3. 迁移完成后删掉这个旧文件。

--- a/web/content/docs/development/plugin-system.md
+++ b/web/content/docs/development/plugin-system.md
@@ -61,6 +61,10 @@ Stella ships built-in plugins across several areas:
 | memory   | `lcm`, `simple`                          |
 | runtime  | `reflect`                                |
 
+## Per-Org Isolation
+
+Stella is multi-tenant. Every plugin runtime, manifest override, OAuth provider configuration, and channel callback resolves to a single org via `context.Context`. See [Plugin Org Isolation](/docs/development/plugin-org-isolation) for the contracts and tables.
+
 ## Read The Plugin Docs
 
 The feature overview is intentionally short. For the actual plugin API and authoring model, use the dedicated plugin docs:

--- a/web/content/docs/development/plugin-system.zh.md
+++ b/web/content/docs/development/plugin-system.zh.md
@@ -61,6 +61,10 @@ Stella 在多个领域提供内置插件：
 | memory   | `lcm`、`simple`                          |
 | runtime  | `reflect`                                |
 
+## 按 Org 隔离
+
+Stella 是多租户系统。每个插件运行时、manifest override、OAuth provider 配置、channel 回调都通过 `context.Context` 归属到单个 org。详见[插件按 Org 隔离](/docs/development/plugin-org-isolation)。
+
 ## 阅读插件文档
 
 功能概述有意保持简短。要了解实际的插件 API 和开发模型，请使用专门的插件文档：


### PR DESCRIPTION
## Summary

**Phase 5 of 5** — stacked on #242. Final phase.

Architectural reference documentation for the per-org plugin isolation model established by PRs #239–#242.

## Changes
- New \`web/content/docs/development/plugin-org-isolation.md\` + \`.zh.md\`: covers \`orgctx\` contract, RuntimeHost two-level map, manifest override semantics, OAuth provider override (already existing)
- \`web/content/docs/development/plugin-system.{md,zh.md}\`: cross-link to new doc
- \`meta.json\` / \`meta.zh.json\`: register new page

## Test plan
- [x] \`mise run format\` / \`build\` / \`test\`
- [ ] Manual: docs render in web UI, cross-links resolve