### PR TITLE
feat: per-org CLI tools via mise shims

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,5 @@ web/src/lib/api-client/
 # Embedded tool binaries (downloaded via builddeps sync)
 resources/binaries/binaries/*/*.gz
 
-cmd/stella/.agents/
 internal/agent/runner/.agents/
 .chorus/
-stella

--- a/cmd/stella/commands.go
+++ b/cmd/stella/commands.go
@@ -17,6 +17,7 @@ import (
 	"github.com/CherryHQ/stella/internal/config"
 	oauth "github.com/CherryHQ/stella/internal/credentials/oauth"
 	appdb "github.com/CherryHQ/stella/internal/db"
+	"github.com/CherryHQ/stella/internal/manifestplugins"
 	"github.com/CherryHQ/stella/internal/memory"
 	"github.com/CherryHQ/stella/internal/notify"
 	"github.com/CherryHQ/stella/internal/orgruntime"
@@ -242,6 +243,7 @@ func setup(parent context.Context, _ bool) (*setupResult, error) {
 		Syncer:   poolMgr,
 		Channels: nil, // Channels wired later in runServer
 		Jobs:     schedulerSvc,
+		CLITools: manifestplugins.NewOrgCLISyncer(store, config.StellaHome()),
 	})
 
 	backgroundTasks := &sync.WaitGroup{}

--- a/internal/agent/factory.go
+++ b/internal/agent/factory.go
@@ -161,6 +161,7 @@ func NewRunnerFactory(cfg RunnerFactoryConfig) (NewRunnerFunc, error) {
 						UserRoot:    userRoot,
 						ProjectRoot: projectRoot,
 					},
+					OrgID:           config.OrgIDFromContext(ctx),
 					UserID:          params.UserID,
 					AgentID:         params.AgentID,
 					SessionID:       params.SessionID,

--- a/internal/agent/sandbox/config.go
+++ b/internal/agent/sandbox/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	SandboxConfig    config.SandboxConfig
 	SandboxBackendFn func(ctx context.Context) string
 	Paths            Paths
+	OrgID            string
 	UserID           string
 	AgentID          string
 	SessionID        string

--- a/internal/agent/sandbox/env.go
+++ b/internal/agent/sandbox/env.go
@@ -8,7 +8,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/CherryHQ/stella/internal/config"
 	oauth "github.com/CherryHQ/stella/internal/credentials/oauth"
+	"github.com/CherryHQ/stella/internal/manifestplugins"
 	pkgplugins "github.com/CherryHQ/stella/pkg/plugins"
 	pkgsandbox "github.com/CherryHQ/stella/pkg/sandbox"
 )
@@ -80,6 +82,13 @@ func buildSandboxEnv(ctx context.Context, cfg Config, paths Paths) (map[string]s
 
 	// Runner-set vars overlay vault entries so they always take precedence.
 	maps.Copy(env, ProcessEnv(paths))
+
+	// Host-execution backends (none, local) run tools via mise shims on the host
+	// PATH, so they need the mise env pointed at the org's config. Docker carries
+	// its own in-image mise tree and PATH, so host-side paths must not leak in.
+	if resolveBackendName(ctx, cfg) != config.SandboxBackendDocker {
+		maps.Copy(env, manifestplugins.RuntimeMiseEnv(paths.StellaHome, cfg.OrgID))
+	}
 
 	return env, nil
 }

--- a/internal/config/cli_plugin.go
+++ b/internal/config/cli_plugin.go
@@ -1,0 +1,50 @@
+package config
+
+// CLITool is an org-configured CLI tool provisioned through mise. It is stored
+// as a settings_plugin row with kind=cli; the mise-specific fields live in the
+// plugin's Config JSON under "mise_tool", "version", and "options".
+//
+// Unlike builtin tool plugins, cli plugins are purely DB-driven and per-org —
+// they never appear in BuiltinPlugins(). The plugin Name doubles as the binary
+// (mise shim) name exposed on PATH.
+type CLITool struct {
+	Name    string         // plugin Name; also the shim/binary name on PATH
+	Tool    string         // mise tool key, e.g. "github:owner/repo", "npm:pkg", "uv"
+	Version string         // mise version spec; empty means "latest"
+	Options map[string]any // extra mise tool options, using mise.toml option names
+	Enabled bool
+}
+
+// CLIToolFromPlugin decodes a kind=cli plugin row into a CLITool. The second
+// return is false when the plugin is not a cli plugin or lacks a mise tool key.
+func CLIToolFromPlugin(p Plugin) (CLITool, bool) {
+	if p.Kind != PluginKindCLI {
+		return CLITool{}, false
+	}
+	t := CLITool{Name: p.Name, Enabled: p.Enabled}
+	if v, ok := p.Config["mise_tool"].(string); ok {
+		t.Tool = v
+	}
+	if v, ok := p.Config["version"].(string); ok {
+		t.Version = v
+	}
+	if v, ok := p.Config["options"].(map[string]any); ok {
+		t.Options = v
+	}
+	if t.Tool == "" {
+		return CLITool{}, false
+	}
+	return t, true
+}
+
+// CLIToolsFromPlugins maps plugin rows (typically from ListPluginsByKind with
+// PluginKindCLI) to CLITool specs, skipping malformed entries.
+func CLIToolsFromPlugins(plugins []Plugin) []CLITool {
+	out := make([]CLITool, 0, len(plugins))
+	for _, p := range plugins {
+		if t, ok := CLIToolFromPlugin(p); ok {
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/internal/config/cli_plugin.go
+++ b/internal/config/cli_plugin.go
@@ -1,5 +1,7 @@
 package config
 
+import "log/slog"
+
 // CLITool is an org-configured CLI tool provisioned through mise. It is stored
 // as a settings_plugin row with kind=cli; the mise-specific fields live in the
 // plugin's Config JSON under "mise_tool", "version", and "options".
@@ -22,14 +24,26 @@ func CLIToolFromPlugin(p Plugin) (CLITool, bool) {
 		return CLITool{}, false
 	}
 	t := CLITool{Name: p.Name, Enabled: p.Enabled}
-	if v, ok := p.Config["mise_tool"].(string); ok {
-		t.Tool = v
+	if raw, present := p.Config["mise_tool"]; present {
+		if v, ok := raw.(string); ok {
+			t.Tool = v
+		} else {
+			slog.Warn("config: cli plugin mise_tool is not a string", "plugin", p.Name)
+		}
 	}
-	if v, ok := p.Config["version"].(string); ok {
-		t.Version = v
+	if raw, present := p.Config["version"]; present {
+		if v, ok := raw.(string); ok {
+			t.Version = v
+		} else {
+			slog.Warn("config: cli plugin version is not a string", "plugin", p.Name)
+		}
 	}
-	if v, ok := p.Config["options"].(map[string]any); ok {
-		t.Options = v
+	if raw, present := p.Config["options"]; present {
+		if v, ok := raw.(map[string]any); ok {
+			t.Options = v
+		} else {
+			slog.Warn("config: cli plugin options is not an object", "plugin", p.Name)
+		}
 	}
 	if t.Tool == "" {
 		return CLITool{}, false

--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -5,6 +5,7 @@ import "sync"
 // Plugin kind constants.
 const (
 	PluginKindTool     = "tool"
+	PluginKindCLI      = "cli"
 	PluginKindChannel  = "channel"
 	PluginKindHook     = "hook"
 	PluginKindProvider = "provider"

--- a/internal/manifestplugins/mise_config.go
+++ b/internal/manifestplugins/mise_config.go
@@ -24,25 +24,47 @@ func scopeForOrg(orgID string) string {
 	return orgID
 }
 
+// miseBaseEnv returns the mise env entries shared by every Stella mise
+// invocation — the isolated data-dir layout plus the non-interactive flags.
+// Both the install side (isolatedMiseEnv) and the runtime side (RuntimeMiseEnv)
+// build on this, so the directories they must agree on cannot silently drift.
+func miseBaseEnv(stellaHome string) map[string]string {
+	dataDir := miseToolsDir(stellaHome)
+	return map[string]string{
+		"MISE_DATA_DIR":     dataDir,
+		"MISE_CONFIG_DIR":   filepath.Join(dataDir, "config"),
+		"MISE_CACHE_DIR":    filepath.Join(dataDir, "cache"),
+		"MISE_STATE_DIR":    filepath.Join(dataDir, "state"),
+		"MISE_YES":          "1",
+		"MISE_NO_ANALYTICS": "1",
+		"MISE_EXPERIMENTAL": "1",
+	}
+}
+
+// runtimeScopeConfigPath returns the mise config the sandbox resolves against.
+// It points at the org's own scope, but falls back to the builtin base when the
+// org config was never written (e.g. org CLI sync failed and was logged
+// non-fatally) so builtin tools still resolve instead of mise running against a
+// missing global config.
+func runtimeScopeConfigPath(stellaHome, orgID string) string {
+	orgPath := ScopeConfigPath(stellaHome, scopeForOrg(orgID))
+	if _, err := os.Stat(orgPath); err == nil {
+		return orgPath
+	}
+	return ScopeConfigPath(stellaHome, builtinScope)
+}
+
 // RuntimeMiseEnv returns the mise environment variables a sandbox needs so its
 // shims resolve tool versions from the org's persisted config against the shared
 // install dir. HOME/XDG are intentionally left untouched — the sandbox owns
 // those. Auto-install is disabled so runtime never reaches the network.
 func RuntimeMiseEnv(stellaHome, orgID string) map[string]string {
-	dataDir := miseToolsDir(stellaHome)
-	configPath := ScopeConfigPath(stellaHome, scopeForOrg(orgID))
-	return map[string]string{
-		"MISE_DATA_DIR":               dataDir,
-		"MISE_CONFIG_DIR":             filepath.Join(dataDir, "config"),
-		"MISE_CACHE_DIR":              filepath.Join(dataDir, "cache"),
-		"MISE_STATE_DIR":              filepath.Join(dataDir, "state"),
-		"MISE_GLOBAL_CONFIG_FILE":     configPath,
-		"MISE_TRUSTED_CONFIG_PATHS":   configPath,
-		"MISE_NOT_FOUND_AUTO_INSTALL": "false",
-		"MISE_YES":                    "1",
-		"MISE_NO_ANALYTICS":           "1",
-		"MISE_EXPERIMENTAL":           "1",
-	}
+	env := miseBaseEnv(stellaHome)
+	configPath := runtimeScopeConfigPath(stellaHome, orgID)
+	env["MISE_GLOBAL_CONFIG_FILE"] = configPath
+	env["MISE_TRUSTED_CONFIG_PATHS"] = configPath
+	env["MISE_NOT_FOUND_AUTO_INSTALL"] = "false"
+	return env
 }
 
 // miseTool is a single entry rendered into a mise config. Both manifest

--- a/internal/manifestplugins/mise_config.go
+++ b/internal/manifestplugins/mise_config.go
@@ -8,12 +8,19 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/pelletier/go-toml/v2"
 )
 
 // builtinScope is the scope name for the manifest-wide (all-org) base config.
 const builtinScope = "_builtin"
+
+// miseInstallMu serializes installs into the shared MISE_DATA_DIR. mise reshim
+// rewrites the whole shims directory, so concurrent scope installs (different
+// orgs starting at once, or an org start overlapping the builtin reconcile)
+// must not run in parallel or they clobber each other's shims.
+var miseInstallMu sync.Mutex
 
 // scopeForOrg maps an org ID to its mise config scope. The empty org (default /
 // no-org) resolves to the builtin base config.
@@ -89,12 +96,22 @@ func ScopeConfigPath(stellaHome, scope string) string {
 }
 
 // renderMiseTOML builds a mise.toml [tools] table from the given tools. On a
-// duplicate key the last entry wins, letting org tools override builtins.
+// duplicate key the last entry wins, letting org tools override builtins. Two
+// different keys exposing the same shim name (Lookup) are rejected: shims live
+// in one shared directory, so the collision would non-deterministically shadow
+// one tool with the other.
 func renderMiseTOML(tools []miseTool) (string, error) {
 	out := make(map[string]any, len(tools))
+	lookupKey := make(map[string]string, len(tools))
 	for _, t := range tools {
 		if t.Key == "" {
 			return "", fmt.Errorf("mise tool with empty key")
+		}
+		if t.Lookup != "" {
+			if prev, ok := lookupKey[t.Lookup]; ok && prev != t.Key {
+				return "", fmt.Errorf("mise tools %q and %q both expose shim %q", prev, t.Key, t.Lookup)
+			}
+			lookupKey[t.Lookup] = t.Key
 		}
 		ver := t.Version
 		if ver == "" {
@@ -139,6 +156,9 @@ func writeScopeConfig(stellaHome, scope string, tools []miseTool) (string, error
 // PATH; nothing is copied to $STELLA_HOME/bin. mise runs in a neutral cwd so no
 // ambient project mise.toml is picked up.
 func runScopeInstall(ctx context.Context, stellaHome, scope string) error {
+	miseInstallMu.Lock()
+	defer miseInstallMu.Unlock()
+
 	miseBin, err := findMiseBin(stellaHome)
 	if err != nil {
 		return err
@@ -176,13 +196,19 @@ func installScope(ctx context.Context, stellaHome, scope string, tools []miseToo
 }
 
 // scopeMiseEnv returns the isolated mise env with MISE_GLOBAL_CONFIG_FILE
-// pointed at the scope's persisted config.
+// pointed at the scope's persisted config. MISE_TRUSTED_CONFIG_PATHS mirrors
+// RuntimeMiseEnv so install, resolve, and runtime all trust the config the same
+// way rather than depending on the persisted trust store under the isolated HOME.
 func scopeMiseEnv(stellaHome, scope string) ([]string, error) {
 	env, err := isolatedMiseEnv(stellaHome)
 	if err != nil {
 		return nil, err
 	}
-	return append(env, "MISE_GLOBAL_CONFIG_FILE="+ScopeConfigPath(stellaHome, scope)), nil
+	configPath := ScopeConfigPath(stellaHome, scope)
+	return append(env,
+		"MISE_GLOBAL_CONFIG_FILE="+configPath,
+		"MISE_TRUSTED_CONFIG_PATHS="+configPath,
+	), nil
 }
 
 // resolveToolVersion returns the concrete installed version mise resolves for

--- a/internal/manifestplugins/mise_config.go
+++ b/internal/manifestplugins/mise_config.go
@@ -1,0 +1,214 @@
+package manifestplugins
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+// builtinScope is the scope name for the manifest-wide (all-org) base config.
+const builtinScope = "_builtin"
+
+// scopeForOrg maps an org ID to its mise config scope. The empty org (default /
+// no-org) resolves to the builtin base config.
+func scopeForOrg(orgID string) string {
+	if orgID == "" {
+		return builtinScope
+	}
+	return orgID
+}
+
+// RuntimeMiseEnv returns the mise environment variables a sandbox needs so its
+// shims resolve tool versions from the org's persisted config against the shared
+// install dir. HOME/XDG are intentionally left untouched — the sandbox owns
+// those. Auto-install is disabled so runtime never reaches the network.
+func RuntimeMiseEnv(stellaHome, orgID string) map[string]string {
+	dataDir := miseToolsDir(stellaHome)
+	configPath := ScopeConfigPath(stellaHome, scopeForOrg(orgID))
+	return map[string]string{
+		"MISE_DATA_DIR":               dataDir,
+		"MISE_CONFIG_DIR":             filepath.Join(dataDir, "config"),
+		"MISE_CACHE_DIR":              filepath.Join(dataDir, "cache"),
+		"MISE_STATE_DIR":              filepath.Join(dataDir, "state"),
+		"MISE_GLOBAL_CONFIG_FILE":     configPath,
+		"MISE_TRUSTED_CONFIG_PATHS":   configPath,
+		"MISE_NOT_FOUND_AUTO_INSTALL": "false",
+		"MISE_YES":                    "1",
+		"MISE_NO_ANALYTICS":           "1",
+		"MISE_EXPERIMENTAL":           "1",
+	}
+}
+
+// miseTool is a single entry rendered into a mise config. Both manifest
+// binaries and per-org CLI tools collapse to this shape before install.
+type miseTool struct {
+	Key     string         // mise tool key, e.g. "github:cli/cli", "npm:serve", "uv"
+	Version string         // version spec; empty means "latest"
+	Options map[string]any // extra mise tool options (mise.toml option names)
+	Lookup  string         // binary name passed to `mise which` for verification
+}
+
+// miseConfigsDir holds the persisted per-scope mise configs. Runtime points
+// MISE_GLOBAL_CONFIG_FILE at one of these so shims resolve the right version.
+func miseConfigsDir(stellaHome string) string {
+	return filepath.Join(miseToolsDir(stellaHome), "configs")
+}
+
+// ScopeConfigPath returns the persisted mise config path for a scope. The
+// builtin base uses builtinScope; per-org configs use the org ID.
+func ScopeConfigPath(stellaHome, scope string) string {
+	return filepath.Join(miseConfigsDir(stellaHome), scope+".toml")
+}
+
+// renderMiseTOML builds a mise.toml [tools] table from the given tools. On a
+// duplicate key the last entry wins, letting org tools override builtins.
+func renderMiseTOML(tools []miseTool) (string, error) {
+	out := make(map[string]any, len(tools))
+	for _, t := range tools {
+		if t.Key == "" {
+			return "", fmt.Errorf("mise tool with empty key")
+		}
+		ver := t.Version
+		if ver == "" {
+			ver = "latest"
+		}
+		options := maps.Clone(t.Options)
+		if len(options) > 0 {
+			if _, ok := options["version"]; !ok {
+				options["version"] = ver
+			}
+			out[t.Key] = options
+		} else {
+			out[t.Key] = ver
+		}
+	}
+	data, err := toml.Marshal(map[string]any{"tools": out})
+	if err != nil {
+		return "", fmt.Errorf("marshal mise.toml: %w", err)
+	}
+	return string(data), nil
+}
+
+// writeScopeConfig renders and persists the scope's mise config. It touches no
+// network and runs no mise commands, so it is always safe to call.
+func writeScopeConfig(stellaHome, scope string, tools []miseTool) (string, error) {
+	tomlContent, err := renderMiseTOML(tools)
+	if err != nil {
+		return "", err
+	}
+	configPath := ScopeConfigPath(stellaHome, scope)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		return "", fmt.Errorf("create mise configs dir: %w", err)
+	}
+	if err := os.WriteFile(configPath, []byte(tomlContent), 0o644); err != nil {
+		return "", fmt.Errorf("write mise config %s: %w", configPath, err)
+	}
+	return configPath, nil
+}
+
+// runScopeInstall installs every tool in the scope's persisted config into the
+// shared MISE_DATA_DIR and regenerates shims. Tools are exposed via shims on
+// PATH; nothing is copied to $STELLA_HOME/bin. mise runs in a neutral cwd so no
+// ambient project mise.toml is picked up.
+func runScopeInstall(ctx context.Context, stellaHome, scope string) error {
+	miseBin, err := findMiseBin(stellaHome)
+	if err != nil {
+		return err
+	}
+	configPath := ScopeConfigPath(stellaHome, scope)
+	env, err := scopeMiseEnv(stellaHome, scope)
+	if err != nil {
+		return err
+	}
+	dir, err := os.MkdirTemp("", "stella-mise-*")
+	if err != nil {
+		return fmt.Errorf("create temp dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	if err := runMise(ctx, miseBin, env, dir, "trust", configPath); err != nil {
+		return fmt.Errorf("mise trust: %w", err)
+	}
+	if err := runMise(ctx, miseBin, env, dir, "install"); err != nil {
+		return fmt.Errorf("mise install: %w", err)
+	}
+	if err := runMise(ctx, miseBin, env, dir, "reshim"); err != nil {
+		return fmt.Errorf("mise reshim: %w", err)
+	}
+	return nil
+}
+
+// installScope persists the scope config and installs its tools. Convenience
+// wrapper for callers that always want both (org sync, tests).
+func installScope(ctx context.Context, stellaHome, scope string, tools []miseTool) error {
+	if _, err := writeScopeConfig(stellaHome, scope, tools); err != nil {
+		return err
+	}
+	return runScopeInstall(ctx, stellaHome, scope)
+}
+
+// scopeMiseEnv returns the isolated mise env with MISE_GLOBAL_CONFIG_FILE
+// pointed at the scope's persisted config.
+func scopeMiseEnv(stellaHome, scope string) ([]string, error) {
+	env, err := isolatedMiseEnv(stellaHome)
+	if err != nil {
+		return nil, err
+	}
+	return append(env, "MISE_GLOBAL_CONFIG_FILE="+ScopeConfigPath(stellaHome, scope)), nil
+}
+
+// resolveToolVersion returns the concrete installed version mise resolves for
+// the given lookup name under the provided env, running in a neutral cwd.
+func resolveToolVersion(ctx context.Context, miseBin string, env []string, dir, lookup string) (string, error) {
+	var stdout, stderr bytes.Buffer
+	cmd := managedCommandContext(ctx, miseBin, "which", lookup, "--version")
+	cmd.Dir = dir
+	cmd.Env = env
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("mise which --version %s: %w\nstderr: %s", lookup, err, stderr.String())
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+// runMise runs a mise subcommand in dir with the given env, capturing stderr.
+func runMise(ctx context.Context, miseBin string, env []string, dir string, args ...string) error {
+	var stderr bytes.Buffer
+	cmd := managedCommandContext(ctx, miseBin, args...)
+	cmd.Dir = dir
+	cmd.Env = env
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%w\nstderr: %s", err, stderr.String())
+	}
+	return nil
+}
+
+// binaryLookupName returns the name used to verify a manifest binary via
+// `mise which`. rename_exe wins (archive rename), then bin, then the tool name.
+func binaryLookupName(b ManifestBinary) string {
+	if renameExe, ok := stringOption(b.Options, "rename_exe"); ok {
+		return renameExe
+	}
+	if bin, ok := stringOption(b.Options, "bin"); ok {
+		return bin
+	}
+	return b.Name
+}
+
+// miseToolFromBinary maps a manifest binary to a renderable mise tool entry.
+func miseToolFromBinary(b ManifestBinary) miseTool {
+	return miseTool{
+		Key:     b.Tool,
+		Version: b.Version,
+		Options: b.Options,
+		Lookup:  binaryLookupName(b),
+	}
+}

--- a/internal/manifestplugins/mise_installer.go
+++ b/internal/manifestplugins/mise_installer.go
@@ -1,19 +1,14 @@
 package manifestplugins
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"sort"
-	"strings"
-
-	"github.com/pelletier/go-toml/v2"
 )
 
 // miseToolsDir returns the MISE_DATA_DIR path for isolated mise installs.
@@ -118,150 +113,7 @@ func runtimeBinaryName(name string) string {
 	return name
 }
 
-// miseToolKey returns the mise tool key used in mise.toml and CLI commands.
-func (b ManifestBinary) miseToolKey() string {
-	return b.Tool
-}
-
-// generateMiseTOML returns a valid mise.toml for the binary.
-func generateMiseTOML(b ManifestBinary) (string, error) {
-	toolKey := b.miseToolKey()
-	if toolKey == "" {
-		return "", fmt.Errorf("cannot determine mise tool key")
-	}
-
-	ver := b.Version
-	if ver == "" {
-		ver = "latest"
-	}
-
-	options := maps.Clone(b.Options)
-	if options == nil {
-		options = make(map[string]any)
-	}
-
-	var toolValue any = ver
-	if len(options) > 0 {
-		if _, ok := options["version"]; !ok {
-			options["version"] = ver
-		}
-		toolValue = options
-	}
-
-	data, err := toml.Marshal(map[string]any{
-		"tools": map[string]any{toolKey: toolValue},
-	})
-	if err != nil {
-		return "", fmt.Errorf("marshal mise.toml: %w", err)
-	}
-	return string(data), nil
-}
-
-// installBinaryWithMise installs a single binary via mise and copies the resulting
-// binary to $STELLA_HOME/bin/.
-func installBinaryWithMise(ctx context.Context, b ManifestBinary, stellaHome string) (string, error) {
-	miseBin, err := findMiseBin(stellaHome)
-	if err != nil {
-		return "", err
-	}
-
-	tmpDir, err := os.MkdirTemp("", "stella-mise-*")
-	if err != nil {
-		return "", fmt.Errorf("create temp dir: %w", err)
-	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
-
-	tomlContent, err := generateMiseTOML(b)
-	if err != nil {
-		return "", err
-	}
-	tomlPath := filepath.Join(tmpDir, "mise.toml")
-	if err := os.WriteFile(tomlPath, []byte(tomlContent), 0o644); err != nil {
-		return "", fmt.Errorf("write mise.toml: %w", err)
-	}
-
-	env, err := isolatedMiseEnv(stellaHome)
-	if err != nil {
-		return "", err
-	}
-
-	// Trust the temp config so mise doesn't refuse to read it.
-	var stderr bytes.Buffer
-	trustCmd := managedCommandContext(ctx, miseBin, "trust", tmpDir)
-	trustCmd.Dir = tmpDir
-	trustCmd.Env = env
-	trustCmd.Stderr = &stderr
-	if err := trustCmd.Run(); err != nil {
-		return "", fmt.Errorf("mise trust: %w\nstderr: %s", err, stderr.String())
-	}
-
-	// Run mise install for only the manifest tool. Avoid installing any global or
-	// inherited mise config that may be visible to the Stella process.
-	toolKey := b.miseToolKey()
-	stderr.Reset()
-	installCmd := managedCommandContext(ctx, miseBin, "install", toolKey)
-	installCmd.Dir = tmpDir
-	installCmd.Env = env
-	installCmd.Stderr = &stderr
-	if err := installCmd.Run(); err != nil {
-		return "", fmt.Errorf("mise install: %w\nstderr: %s", err, stderr.String())
-	}
-
-	// Determine which binary name to pass to mise which.
-	// rename_exe takes precedence (archive extraction rename), then bin (single
-	// binary rename), then the tool name.
-	lookupName := b.Name
-	if renameExe, ok := stringOption(b.Options, "rename_exe"); ok {
-		lookupName = renameExe
-	} else if bin, ok := stringOption(b.Options, "bin"); ok {
-		lookupName = bin
-	}
-
-	// Resolve the binary path via mise which — it handles any archive layout.
-	var stdout bytes.Buffer
-	stderr.Reset()
-	whichCmd := managedCommandContext(ctx, miseBin, "which", lookupName)
-	whichCmd.Dir = tmpDir
-	whichCmd.Env = env
-	whichCmd.Stdout = &stdout
-	whichCmd.Stderr = &stderr
-	if err := whichCmd.Run(); err != nil {
-		return "", fmt.Errorf("mise which %s: %w\nstderr: %s", lookupName, err, stderr.String())
-	}
-	srcPath := strings.TrimSpace(stdout.String())
-	if srcPath == "" {
-		return "", fmt.Errorf("mise which %s returned empty path", lookupName)
-	}
-
-	// Resolve the installed version via mise which --version.
-	stdout.Reset()
-	stderr.Reset()
-	verCmd := managedCommandContext(ctx, miseBin, "which", lookupName, "--version")
-	verCmd.Dir = tmpDir
-	verCmd.Env = env
-	verCmd.Stdout = &stdout
-	verCmd.Stderr = &stderr
-	if err := verCmd.Run(); err != nil {
-		return "", fmt.Errorf("mise which --version %s: %w\nstderr: %s", lookupName, err, stderr.String())
-	}
-	version := strings.TrimSpace(stdout.String())
-
-	// Always install as b.Name in $STELLA_HOME/bin/ regardless of exe alias.
-	dstName := b.Name
-	if runtime.GOOS == "windows" {
-		dstName += ".exe"
-	}
-	binDir := filepath.Join(stellaHome, "bin")
-	if err := os.MkdirAll(binDir, 0o755); err != nil {
-		return "", fmt.Errorf("create bin dir: %w", err)
-	}
-	dstPath := filepath.Join(binDir, dstName)
-	if err := atomicCopy(srcPath, dstPath, 0o755); err != nil {
-		return "", err
-	}
-	return version, nil
-}
-
+// stringOption returns a non-empty string tool option value.
 func stringOption(options map[string]any, key string) (string, bool) {
 	value, ok := options[key]
 	if !ok {
@@ -269,40 +121,4 @@ func stringOption(options map[string]any, key string) (string, bool) {
 	}
 	s, ok := value.(string)
 	return s, ok && s != ""
-}
-
-// atomicCopy copies src to dst using a temp file + rename.
-func atomicCopy(src, dst string, mode os.FileMode) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return fmt.Errorf("open source: %w", err)
-	}
-	defer func() { _ = in.Close() }()
-
-	dir := filepath.Dir(dst)
-	base := filepath.Base(dst)
-	tmp, err := os.CreateTemp(dir, base+".tmp.*")
-	if err != nil {
-		return fmt.Errorf("create temp file: %w", err)
-	}
-	tmpPath := tmp.Name()
-
-	if _, err := io.Copy(tmp, in); err != nil {
-		_ = tmp.Close()
-		_ = os.Remove(tmpPath)
-		return fmt.Errorf("copy: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		_ = os.Remove(tmpPath)
-		return fmt.Errorf("close temp: %w", err)
-	}
-	if err := os.Chmod(tmpPath, mode); err != nil {
-		_ = os.Remove(tmpPath)
-		return fmt.Errorf("chmod: %w", err)
-	}
-	if err := os.Rename(tmpPath, dst); err != nil {
-		_ = os.Remove(tmpPath)
-		return fmt.Errorf("rename: %w", err)
-	}
-	return nil
 }

--- a/internal/manifestplugins/mise_installer.go
+++ b/internal/manifestplugins/mise_installer.go
@@ -9,11 +9,15 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+
+	pkgsandbox "github.com/CherryHQ/stella/pkg/sandbox"
 )
 
-// miseToolsDir returns the MISE_DATA_DIR path for isolated mise installs.
+// miseToolsDir returns the MISE_DATA_DIR path for isolated mise installs. The
+// layout is owned by pkg/sandbox so the install side and the sandbox PATH stay
+// in lockstep.
 func miseToolsDir(stellaHome string) string {
-	return filepath.Join(stellaHome, ".mise-tools")
+	return pkgsandbox.MiseToolsDir(stellaHome)
 }
 
 // findMiseBin returns the path to the mise binary. It prefers the Stella-managed
@@ -61,11 +65,10 @@ var misePassthroughEnv = []string{
 
 func isolatedMiseEnv(stellaHome string) ([]string, error) {
 	dataDir := miseToolsDir(stellaHome)
-	paths := map[string]string{
-		"MISE_DATA_DIR":   dataDir,
-		"MISE_CONFIG_DIR": filepath.Join(dataDir, "config"),
-		"MISE_CACHE_DIR":  filepath.Join(dataDir, "cache"),
-		"MISE_STATE_DIR":  filepath.Join(dataDir, "state"),
+	// Directories the install needs on disk; the shared base (miseBaseEnv)
+	// already covers DATA/CONFIG/CACHE/STATE, install adds shims + an isolated
+	// HOME/XDG so nothing leaks into the host user's profile.
+	installDirs := map[string]string{
 		"MISE_SHIMS_DIR":  filepath.Join(dataDir, "shims"),
 		"HOME":            filepath.Join(dataDir, "home"),
 		"XDG_CONFIG_HOME": filepath.Join(dataDir, "xdg", "config"),
@@ -73,25 +76,28 @@ func isolatedMiseEnv(stellaHome string) ([]string, error) {
 		"XDG_STATE_HOME":  filepath.Join(dataDir, "xdg", "state"),
 	}
 	if runtime.GOOS == "windows" {
-		paths["USERPROFILE"] = paths["HOME"]
+		installDirs["USERPROFILE"] = installDirs["HOME"]
 	}
 
-	for _, dir := range paths {
+	base := miseBaseEnv(stellaHome)
+	for _, dir := range []string{
+		base["MISE_DATA_DIR"], base["MISE_CONFIG_DIR"], base["MISE_CACHE_DIR"], base["MISE_STATE_DIR"],
+		installDirs["MISE_SHIMS_DIR"], installDirs["HOME"],
+		installDirs["XDG_CONFIG_HOME"], installDirs["XDG_CACHE_HOME"], installDirs["XDG_STATE_HOME"],
+	} {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			return nil, fmt.Errorf("create isolated mise dir %s: %w", dir, err)
 		}
 	}
 
-	env := make(map[string]string, len(misePassthroughEnv)+len(paths)+2)
+	env := make(map[string]string, len(misePassthroughEnv)+len(base)+len(installDirs))
 	for _, key := range misePassthroughEnv {
 		if value, ok := os.LookupEnv(key); ok {
 			env[key] = value
 		}
 	}
-	maps.Copy(env, paths)
-	env["MISE_YES"] = "1"
-	env["MISE_NO_ANALYTICS"] = "1"
-	env["MISE_EXPERIMENTAL"] = "1"
+	maps.Copy(env, base)
+	maps.Copy(env, installDirs)
 
 	keys := make([]string, 0, len(env))
 	for key := range env {

--- a/internal/manifestplugins/mise_installer_test.go
+++ b/internal/manifestplugins/mise_installer_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestGenerateMiseTOMLSimpleForm(t *testing.T) {
-	got, err := generateMiseTOML(ManifestBinary{
+	got, err := renderBinaryTOML(ManifestBinary{
 		Name:    "mytool",
 		Tool:    "github:owner/repo",
 		Version: "1.0.0",
@@ -25,7 +25,7 @@ func TestGenerateMiseTOMLSimpleForm(t *testing.T) {
 }
 
 func TestGenerateMiseTOMLRegistryTool(t *testing.T) {
-	got, err := generateMiseTOML(ManifestBinary{
+	got, err := renderBinaryTOML(ManifestBinary{
 		Name: "uv",
 		Tool: "uv",
 	})
@@ -39,7 +39,7 @@ func TestGenerateMiseTOMLRegistryTool(t *testing.T) {
 }
 
 func TestGenerateMiseTOMLTableFormDefaultsVersion(t *testing.T) {
-	got, err := generateMiseTOML(ManifestBinary{
+	got, err := renderBinaryTOML(ManifestBinary{
 		Name:    "gh",
 		Tool:    "github:cli/cli",
 		Options: map[string]any{"bin_path": "bin"},
@@ -59,7 +59,7 @@ func TestGenerateMiseTOMLTableFormDefaultsVersion(t *testing.T) {
 }
 
 func TestGenerateMiseTOMLAssetPatternAloneTriggersTableForm(t *testing.T) {
-	got, err := generateMiseTOML(ManifestBinary{
+	got, err := renderBinaryTOML(ManifestBinary{
 		Name:    "gh",
 		Tool:    "github:cli/cli",
 		Version: "2.40.1",
@@ -80,7 +80,7 @@ func TestGenerateMiseTOMLAssetPatternAloneTriggersTableForm(t *testing.T) {
 }
 
 func TestGenerateMiseTOMLAdvancedOptions(t *testing.T) {
-	got, err := generateMiseTOML(ManifestBinary{
+	got, err := renderBinaryTOML(ManifestBinary{
 		Name:    "pandoc",
 		Tool:    "github:jgm/pandoc",
 		Version: "3.1.0",
@@ -121,7 +121,7 @@ func TestGenerateMiseTOMLAdvancedOptions(t *testing.T) {
 }
 
 func TestGenerateMiseTOMLBinField(t *testing.T) {
-	got, err := generateMiseTOML(ManifestBinary{
+	got, err := renderBinaryTOML(ManifestBinary{
 		Name:    "docker-compose",
 		Tool:    "github:docker/compose",
 		Version: "2.29.1",
@@ -141,7 +141,7 @@ func TestGenerateMiseTOMLBinField(t *testing.T) {
 }
 
 func TestGenerateMiseTOMLHTTPBackend(t *testing.T) {
-	got, err := generateMiseTOML(ManifestBinary{
+	got, err := renderBinaryTOML(ManifestBinary{
 		Name:    "sentinel",
 		Tool:    "http:sentinel",
 		Version: "0.26.3",
@@ -162,7 +162,7 @@ func TestGenerateMiseTOMLHTTPBackend(t *testing.T) {
 }
 
 func TestGenerateMiseTOMLHTTPWithFormat(t *testing.T) {
-	got, err := generateMiseTOML(ManifestBinary{
+	got, err := renderBinaryTOML(ManifestBinary{
 		Name:    "mytool",
 		Tool:    "http:mytool",
 		Version: "1.2.0",
@@ -185,7 +185,7 @@ func TestGenerateMiseTOMLHTTPWithFormat(t *testing.T) {
 }
 
 func TestGenerateMiseTOMLPipxSimple(t *testing.T) {
-	got, err := generateMiseTOML(ManifestBinary{
+	got, err := renderBinaryTOML(ManifestBinary{
 		Name:    "mypy",
 		Tool:    "pipx:mypy",
 		Version: "1.8.0",
@@ -200,7 +200,7 @@ func TestGenerateMiseTOMLPipxSimple(t *testing.T) {
 }
 
 func TestGenerateMiseTOMLPipxWithExtras(t *testing.T) {
-	got, err := generateMiseTOML(ManifestBinary{
+	got, err := renderBinaryTOML(ManifestBinary{
 		Name:    "pylint",
 		Tool:    "pipx:pylint",
 		Options: map[string]any{"extras": "spelling"},
@@ -219,7 +219,7 @@ func TestGenerateMiseTOMLPipxWithExtras(t *testing.T) {
 }
 
 func TestGenerateMiseTOMLNPM(t *testing.T) {
-	got, err := generateMiseTOML(ManifestBinary{
+	got, err := renderBinaryTOML(ManifestBinary{
 		Name:    "serve",
 		Tool:    "npm:serve",
 		Version: "14.2.0",
@@ -234,14 +234,14 @@ func TestGenerateMiseTOMLNPM(t *testing.T) {
 }
 
 func TestGenerateMiseTOMLNoToolErrors(t *testing.T) {
-	_, err := generateMiseTOML(ManifestBinary{Name: "x"})
+	_, err := renderBinaryTOML(ManifestBinary{Name: "x"})
 	if err == nil {
 		t.Fatal("expected error for binary with no tool")
 	}
 }
 
 func TestGenerateMiseTOMLLeavesToolKeyToMise(t *testing.T) {
-	got, err := generateMiseTOML(ManifestBinary{Name: "x", Tool: "github:repo"})
+	got, err := renderBinaryTOML(ManifestBinary{Name: "x", Tool: "github:repo"})
 	if err != nil {
 		t.Fatalf("generateMiseTOML: %v", err)
 	}
@@ -251,7 +251,12 @@ func TestGenerateMiseTOMLLeavesToolKeyToMise(t *testing.T) {
 	}
 }
 
-func TestInstallBinaryWithMiseIsolatesHostEnvAndTargetsTool(t *testing.T) {
+// renderBinaryTOML renders a single manifest binary the way the installer does.
+func renderBinaryTOML(b ManifestBinary) (string, error) {
+	return renderMiseTOML([]miseTool{miseToolFromBinary(b)})
+}
+
+func TestInstallScopeIsolatesHostEnvAndPersistsConfig(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("fake mise script uses POSIX shell")
 	}
@@ -270,35 +275,13 @@ set -eu
   printf 'args:%s\n' "$*"
   printf 'MISE_DATA_DIR=%s\n' "${MISE_DATA_DIR-}"
   printf 'MISE_CONFIG_DIR=%s\n' "${MISE_CONFIG_DIR-}"
-  printf 'MISE_CACHE_DIR=%s\n' "${MISE_CACHE_DIR-}"
-  printf 'MISE_STATE_DIR=%s\n' "${MISE_STATE_DIR-}"
-  printf 'MISE_SHIMS_DIR=%s\n' "${MISE_SHIMS_DIR-}"
+  printf 'MISE_GLOBAL_CONFIG_FILE=%s\n' "${MISE_GLOBAL_CONFIG_FILE-}"
   printf 'MISE_PROJECT_ROOT=%s\n' "${MISE_PROJECT_ROOT-}"
   printf 'HOME=%s\n' "${HOME-}"
   printf 'XDG_CONFIG_HOME=%s\n' "${XDG_CONFIG_HOME-}"
 } >> ` + shellQuote(logPath) + `
 case "$1" in
-  trust)
-    exit 0
-    ;;
-  install)
-    if [ "$2" != "github:owner/repo" ]; then
-      echo "unexpected install target: $*" >&2
-      exit 7
-    fi
-    mkdir -p "$MISE_DATA_DIR/installs/github-owner-repo/1.2.3/bin"
-    printf '#!/bin/sh\n' > "$MISE_DATA_DIR/installs/github-owner-repo/1.2.3/bin/mytool"
-    chmod +x "$MISE_DATA_DIR/installs/github-owner-repo/1.2.3/bin/mytool"
-    exit 0
-    ;;
-  which)
-    # which <name> --version
-    if [ "${3:-}" = "--version" ]; then
-      printf '1.2.3\n'
-      exit 0
-    fi
-    # which <name>
-    printf '%s\n' "$MISE_DATA_DIR/installs/github-owner-repo/1.2.3/bin/$2"
+  trust|install|reshim)
     exit 0
     ;;
   *)
@@ -317,19 +300,28 @@ esac
 	t.Setenv("XDG_CONFIG_HOME", "/danger/xdg")
 	t.Setenv("HOME", "/danger/home")
 
-	version, err := installBinaryWithMise(context.Background(), ManifestBinary{
-		Name:    "mytool",
-		Tool:    "github:owner/repo",
+	err := installScope(context.Background(), stellaHome, builtinScope, []miseTool{{
+		Key:     "github:owner/repo",
 		Version: "1.2.3",
-	}, stellaHome)
+		Lookup:  "mytool",
+	}})
 	if err != nil {
-		t.Fatalf("installBinaryWithMise: %v", err)
+		t.Fatalf("installScope: %v", err)
 	}
-	if version != "1.2.3" {
-		t.Fatalf("version = %q, want 1.2.3", version)
+
+	// Config is persisted (not a temp dir) so runtime can point at it.
+	configPath := ScopeConfigPath(stellaHome, builtinScope)
+	cfg, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read persisted config: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(binDir, "mytool")); err != nil {
-		t.Fatalf("installed binary missing: %v", err)
+	if !strings.Contains(string(cfg), `'github:owner/repo' = '1.2.3'`) {
+		t.Fatalf("persisted config missing tool entry:\n%s", cfg)
+	}
+
+	// Nothing is copied into $STELLA_HOME/bin (shims-only).
+	if _, err := os.Stat(filepath.Join(binDir, "mytool")); !os.IsNotExist(err) {
+		t.Fatalf("expected no copied binary, stat err = %v", err)
 	}
 
 	logData, err := os.ReadFile(logPath)
@@ -337,23 +329,20 @@ esac
 		t.Fatalf("read fake mise log: %v", err)
 	}
 	log := string(logData)
-	if !strings.Contains(log, "args:install github:owner/repo") {
-		t.Fatalf("mise install was not targeted to the manifest tool; log:\n%s", log)
-	}
-	if !strings.Contains(log, "args:which mytool") {
-		t.Fatalf("mise which was not called for the binary; log:\n%s", log)
+	for _, want := range []string{"args:trust ", "args:install\n", "args:reshim\n"} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("missing %q in mise log:\n%s", want, log)
+		}
 	}
 	if strings.Contains(log, "/danger") {
 		t.Fatalf("host mise env leaked into installer; log:\n%s", log)
 	}
-
 	wantData := "MISE_DATA_DIR=" + filepath.Join(stellaHome, ".mise-tools")
 	if !strings.Contains(log, wantData) {
 		t.Fatalf("isolated data dir not used, want %q in log:\n%s", wantData, log)
 	}
-	wantConfig := "MISE_CONFIG_DIR=" + filepath.Join(stellaHome, ".mise-tools", "config")
-	if !strings.Contains(log, wantConfig) {
-		t.Fatalf("isolated config dir not used, want %q in log:\n%s", wantConfig, log)
+	if !strings.Contains(log, "MISE_GLOBAL_CONFIG_FILE="+configPath) {
+		t.Fatalf("scope config file not pointed at, want %q in log:\n%s", configPath, log)
 	}
 	if !strings.Contains(log, "MISE_PROJECT_ROOT=\n") {
 		t.Fatalf("MISE_PROJECT_ROOT should be stripped; log:\n%s", log)

--- a/internal/manifestplugins/mise_installer_unix_test.go
+++ b/internal/manifestplugins/mise_installer_unix_test.go
@@ -14,7 +14,7 @@ import (
 	"time"
 )
 
-func TestInstallBinaryWithMiseCancelKillsChildProcessGroup(t *testing.T) {
+func TestInstallScopeCancelKillsChildProcessGroup(t *testing.T) {
 	stellaHome := t.TempDir()
 	binDir := filepath.Join(stellaHome, "bin")
 	if err := os.MkdirAll(binDir, 0o755); err != nil {
@@ -46,7 +46,7 @@ esac
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
 	go func() {
-		_, err := installBinaryWithMise(ctx, ManifestBinary{Name: "mytool", Tool: "github:owner/repo"}, stellaHome)
+		err := installScope(ctx, stellaHome, builtinScope, []miseTool{{Key: "github:owner/repo", Lookup: "mytool"}})
 		errCh <- err
 	}()
 

--- a/internal/manifestplugins/org_sync.go
+++ b/internal/manifestplugins/org_sync.go
@@ -3,9 +3,36 @@ package manifestplugins
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"strings"
 
 	"github.com/CherryHQ/stella/internal/config"
 )
+
+// safeOrgToolBackends is the allowlist of mise backends an org may use for cli
+// plugins. Every entry installs a precompiled binary by download only. Backends
+// that build or run arbitrary code at install time (asdf, vfox, cargo, go, npm,
+// pipx, gem, ...) are rejected: org cli tools are installed on the host, outside
+// any sandbox, so a code-executing backend would be host RCE driven by org input.
+var safeOrgToolBackends = map[string]bool{
+	"github": true,
+	"gitlab": true,
+	"ubi":    true,
+	"aqua":   true,
+	"http":   true,
+}
+
+// orgToolKeyAllowed reports whether an org-supplied mise tool key uses an
+// allowlisted precompiled-binary backend. Keys without an explicit safe backend
+// prefix — including bare registry names, which may resolve to a code-executing
+// backend — are rejected.
+func orgToolKeyAllowed(key string) bool {
+	backend, _, ok := strings.Cut(key, ":")
+	if !ok {
+		return false
+	}
+	return safeOrgToolBackends[backend]
+}
 
 // PluginLister lists CLI plugin rows for the org carried in ctx.
 type PluginLister interface {
@@ -41,6 +68,11 @@ func (s *OrgCLISyncer) SyncOrgCLITools(ctx context.Context, orgID string) error 
 	}
 	for _, t := range config.CLIToolsFromPlugins(plugins) {
 		if !t.Enabled {
+			continue
+		}
+		if !orgToolKeyAllowed(t.Tool) {
+			slog.Warn("manifestplugins: skipping org cli tool with disallowed mise backend",
+				"org_id", orgID, "tool", t.Name, "key", t.Tool)
 			continue
 		}
 		tools = append(tools, miseToolFromCLITool(t))

--- a/internal/manifestplugins/org_sync.go
+++ b/internal/manifestplugins/org_sync.go
@@ -19,7 +19,12 @@ var safeOrgToolBackends = map[string]bool{
 	"gitlab": true,
 	"ubi":    true,
 	"aqua":   true,
-	"http":   true,
+	// TODO(security): "http" takes an org-admin-supplied `url` option that mise
+	// fetches on the host, outside any sandbox — host-side SSRF and arbitrary
+	// binary placement, contradicting the "download precompiled binary only"
+	// guarantee above. Before this ships widely, either drop "http" or validate
+	// the url (https-only, reject link-local / private / metadata IPs).
+	"http": true,
 }
 
 // orgToolKeyAllowed reports whether an org-supplied mise tool key uses an
@@ -56,6 +61,11 @@ func NewOrgCLISyncer(store PluginLister, stellaHome string) *OrgCLISyncer {
 // org ID so ListPluginsByKind returns that org's rows. The builtin base is
 // always included so the org's shims resolve builtin tools, not just org extras.
 func (s *OrgCLISyncer) SyncOrgCLITools(ctx context.Context, orgID string) error {
+	if orgID == "" {
+		// scopeForOrg("") maps to the builtin scope, which reconcile owns; an
+		// empty-org sync would clobber the shared base config.
+		return fmt.Errorf("sync cli tools: empty org id")
+	}
 	builtin, err := LoadBuiltin()
 	if err != nil {
 		return fmt.Errorf("load builtin manifest: %w", err)

--- a/internal/manifestplugins/org_sync.go
+++ b/internal/manifestplugins/org_sync.go
@@ -1,0 +1,74 @@
+package manifestplugins
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/CherryHQ/stella/internal/config"
+)
+
+// PluginLister lists CLI plugin rows for the org carried in ctx.
+type PluginLister interface {
+	ListPluginsByKind(ctx context.Context, kind string) ([]config.Plugin, error)
+}
+
+// OrgCLISyncer installs an org's self-contained mise config: the builtin base
+// tools plus the org's own kind=cli plugins. Installs land in the shared
+// MISE_DATA_DIR; the per-org scope config lets runtime shims resolve them.
+type OrgCLISyncer struct {
+	store      PluginLister
+	stellaHome string
+}
+
+// NewOrgCLISyncer wires a syncer over the plugin store and stella home.
+func NewOrgCLISyncer(store PluginLister, stellaHome string) *OrgCLISyncer {
+	return &OrgCLISyncer{store: store, stellaHome: stellaHome}
+}
+
+// SyncOrgCLITools writes and installs the org's scope config. ctx must carry the
+// org ID so ListPluginsByKind returns that org's rows. The builtin base is
+// always included so the org's shims resolve builtin tools, not just org extras.
+func (s *OrgCLISyncer) SyncOrgCLITools(ctx context.Context, orgID string) error {
+	builtin, err := LoadBuiltin()
+	if err != nil {
+		return fmt.Errorf("load builtin manifest: %w", err)
+	}
+	tools := enabledBuiltinTools(builtin)
+
+	plugins, err := s.store.ListPluginsByKind(ctx, config.PluginKindCLI)
+	if err != nil {
+		return fmt.Errorf("list cli plugins: %w", err)
+	}
+	for _, t := range config.CLIToolsFromPlugins(plugins) {
+		if !t.Enabled {
+			continue
+		}
+		tools = append(tools, miseToolFromCLITool(t))
+	}
+
+	return installScope(ctx, s.stellaHome, scopeForOrg(orgID), tools)
+}
+
+// enabledBuiltinTools collects mise tools from every enabled builtin plugin.
+func enabledBuiltinTools(m *Manifest) []miseTool {
+	var tools []miseTool
+	for _, p := range m.Plugins {
+		if !p.Enabled {
+			continue
+		}
+		for _, b := range p.Binaries {
+			tools = append(tools, miseToolFromBinary(b))
+		}
+	}
+	return tools
+}
+
+// miseToolFromCLITool maps an org cli plugin tool to a renderable mise entry.
+func miseToolFromCLITool(t config.CLITool) miseTool {
+	return miseTool{
+		Key:     t.Tool,
+		Version: t.Version,
+		Options: t.Options,
+		Lookup:  t.Name,
+	}
+}

--- a/internal/manifestplugins/org_sync_test.go
+++ b/internal/manifestplugins/org_sync_test.go
@@ -84,8 +84,8 @@ func TestSyncOrgCLITools_PerOrgVersionsDiffer(t *testing.T) {
 	stellaHome := t.TempDir()
 	writeFakeMise(t, stellaHome)
 
-	store1 := &fakePluginLister{plugins: []config.Plugin{cliPlugin("shared", "npm:shared", "1.0.0")}}
-	store2 := &fakePluginLister{plugins: []config.Plugin{cliPlugin("shared", "npm:shared", "2.0.0")}}
+	store1 := &fakePluginLister{plugins: []config.Plugin{cliPlugin("shared", "ubi:acme/shared", "1.0.0")}}
+	store2 := &fakePluginLister{plugins: []config.Plugin{cliPlugin("shared", "ubi:acme/shared", "2.0.0")}}
 
 	if err := NewOrgCLISyncer(store1, stellaHome).SyncOrgCLITools(context.Background(), "orgA"); err != nil {
 		t.Fatalf("sync orgA: %v", err)
@@ -102,10 +102,44 @@ func TestSyncOrgCLITools_PerOrgVersionsDiffer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read orgB: %v", err)
 	}
-	if !strings.Contains(string(a), `'npm:shared' = '1.0.0'`) {
+	if !strings.Contains(string(a), `'ubi:acme/shared' = '1.0.0'`) {
 		t.Errorf("orgA wrong version:\n%s", a)
 	}
-	if !strings.Contains(string(b), `'npm:shared' = '2.0.0'`) {
+	if !strings.Contains(string(b), `'ubi:acme/shared' = '2.0.0'`) {
 		t.Errorf("orgB wrong version:\n%s", b)
+	}
+}
+
+func TestSyncOrgCLITools_RejectsUnsafeBackend(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake mise script uses POSIX shell")
+	}
+	stellaHome := t.TempDir()
+	writeFakeMise(t, stellaHome)
+
+	store := &fakePluginLister{plugins: []config.Plugin{
+		cliPlugin("safe", "github:acme/safe", "1.0.0"),
+		cliPlugin("evil", "npm:evil", "1.0.0"), // code-executing backend
+		cliPlugin("bare", "ripgrep", "1.0.0"),  // no explicit safe backend
+	}}
+
+	if err := NewOrgCLISyncer(store, stellaHome).SyncOrgCLITools(context.Background(), "org1"); err != nil {
+		t.Fatalf("SyncOrgCLITools: %v", err)
+	}
+
+	data, err := os.ReadFile(ScopeConfigPath(stellaHome, "org1"))
+	if err != nil {
+		t.Fatalf("read org config: %v", err)
+	}
+	cfg := string(data)
+
+	if !strings.Contains(cfg, "github:acme/safe") {
+		t.Errorf("safe tool was dropped:\n%s", cfg)
+	}
+	if strings.Contains(cfg, "npm:evil") {
+		t.Errorf("code-executing backend was not rejected:\n%s", cfg)
+	}
+	if strings.Contains(cfg, "'ripgrep'") {
+		t.Errorf("bare registry name was not rejected:\n%s", cfg)
 	}
 }

--- a/internal/manifestplugins/org_sync_test.go
+++ b/internal/manifestplugins/org_sync_test.go
@@ -1,0 +1,111 @@
+package manifestplugins
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/CherryHQ/stella/internal/config"
+)
+
+type fakePluginLister struct {
+	plugins []config.Plugin
+}
+
+func (f *fakePluginLister) ListPluginsByKind(_ context.Context, kind string) ([]config.Plugin, error) {
+	if kind != config.PluginKindCLI {
+		return nil, nil
+	}
+	return f.plugins, nil
+}
+
+func cliPlugin(name, tool, version string) config.Plugin {
+	return config.Plugin{
+		Name:    name,
+		Kind:    config.PluginKindCLI,
+		Enabled: true,
+		Config:  map[string]any{"mise_tool": tool, "version": version},
+	}
+}
+
+// writeFakeMise installs a no-op mise that succeeds for trust/install/reshim so
+// SyncOrgCLITools exercises config rendering without touching the network.
+func writeFakeMise(t *testing.T, stellaHome string) {
+	t.Helper()
+	binDir := filepath.Join(stellaHome, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("create bin dir: %v", err)
+	}
+	fake := "#!/bin/sh\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(binDir, "mise"), []byte(fake), 0o755); err != nil {
+		t.Fatalf("write fake mise: %v", err)
+	}
+}
+
+func TestSyncOrgCLITools_SelfContainedConfig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake mise script uses POSIX shell")
+	}
+	stellaHome := t.TempDir()
+	writeFakeMise(t, stellaHome)
+
+	store := &fakePluginLister{plugins: []config.Plugin{
+		cliPlugin("orgtool", "github:acme/orgtool", "9.9.9"),
+	}}
+	syncer := NewOrgCLISyncer(store, stellaHome)
+
+	if err := syncer.SyncOrgCLITools(context.Background(), "org1"); err != nil {
+		t.Fatalf("SyncOrgCLITools: %v", err)
+	}
+
+	data, err := os.ReadFile(ScopeConfigPath(stellaHome, "org1"))
+	if err != nil {
+		t.Fatalf("read org config: %v", err)
+	}
+	cfg := string(data)
+
+	// Org tool is present.
+	if !strings.Contains(cfg, `'github:acme/orgtool' = '9.9.9'`) {
+		t.Errorf("org config missing org tool:\n%s", cfg)
+	}
+	// Builtin base is folded in (self-contained), e.g. gh from plugins.yaml.
+	if !strings.Contains(cfg, "github:cli/cli") {
+		t.Errorf("org config missing builtin base tools:\n%s", cfg)
+	}
+}
+
+func TestSyncOrgCLITools_PerOrgVersionsDiffer(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake mise script uses POSIX shell")
+	}
+	stellaHome := t.TempDir()
+	writeFakeMise(t, stellaHome)
+
+	store1 := &fakePluginLister{plugins: []config.Plugin{cliPlugin("shared", "npm:shared", "1.0.0")}}
+	store2 := &fakePluginLister{plugins: []config.Plugin{cliPlugin("shared", "npm:shared", "2.0.0")}}
+
+	if err := NewOrgCLISyncer(store1, stellaHome).SyncOrgCLITools(context.Background(), "orgA"); err != nil {
+		t.Fatalf("sync orgA: %v", err)
+	}
+	if err := NewOrgCLISyncer(store2, stellaHome).SyncOrgCLITools(context.Background(), "orgB"); err != nil {
+		t.Fatalf("sync orgB: %v", err)
+	}
+
+	a, err := os.ReadFile(ScopeConfigPath(stellaHome, "orgA"))
+	if err != nil {
+		t.Fatalf("read orgA: %v", err)
+	}
+	b, err := os.ReadFile(ScopeConfigPath(stellaHome, "orgB"))
+	if err != nil {
+		t.Fatalf("read orgB: %v", err)
+	}
+	if !strings.Contains(string(a), `'npm:shared' = '1.0.0'`) {
+		t.Errorf("orgA wrong version:\n%s", a)
+	}
+	if !strings.Contains(string(b), `'npm:shared' = '2.0.0'`) {
+		t.Errorf("orgB wrong version:\n%s", b)
+	}
+}

--- a/internal/manifestplugins/reconcile.go
+++ b/internal/manifestplugins/reconcile.go
@@ -129,6 +129,52 @@ func Reconcile(ctx context.Context, m *Manifest, stellaHome string) ReconcileRes
 
 	errorCount := 0
 
+	// Collect every enabled binary into one builtin-scope mise config. The
+	// config always reflects the full enabled set so runtime shims resolve any
+	// of them; persisting it is offline and runs no mise commands.
+	var tools []miseTool
+	needInstall := false
+	for _, plugin := range m.Plugins {
+		if !plugin.Enabled {
+			continue
+		}
+		for _, binary := range plugin.Binaries {
+			tools = append(tools, miseToolFromBinary(binary))
+			if !isCacheHit(state, plugin.ID, binary.Name, binary.Version) {
+				needInstall = true
+			}
+		}
+	}
+
+	var configErr, installErr error
+	if len(tools) > 0 {
+		if _, configErr = writeScopeConfig(stellaHome, builtinScope, tools); configErr != nil {
+			slog.Error("manifest builtin config write failed", "error", configErr)
+		} else if needInstall {
+			slog.Info("manifest builtin tools installing", "tools", len(tools))
+			if installErr = runScopeInstall(ctx, stellaHome, builtinScope); installErr != nil {
+				slog.Error("manifest builtin tools install failed", "error", installErr)
+			}
+		}
+	}
+
+	// Resolve concrete versions for cache misses via the persisted config in a
+	// neutral cwd (no ambient project mise.toml). Cache hits skip mise entirely.
+	miseBin, miseErr := findMiseBin(stellaHome)
+	var resolveEnv []string
+	if miseErr == nil {
+		resolveEnv, miseErr = scopeMiseEnv(stellaHome, builtinScope)
+	}
+	resolveDir, dirErr := os.MkdirTemp("", "stella-mise-resolve-*")
+	if dirErr != nil && miseErr == nil {
+		miseErr = dirErr
+	}
+	defer func() {
+		if resolveDir != "" {
+			_ = os.RemoveAll(resolveDir)
+		}
+	}()
+
 	for _, plugin := range m.Plugins {
 		if !plugin.Enabled {
 			continue
@@ -143,7 +189,8 @@ func Reconcile(ctx context.Context, m *Manifest, stellaHome string) ReconcileRes
 				goto done
 			}
 
-			// Cache hit check (skipped for latest/empty version)
+			// Cache hit: state already records this version — report it without
+			// shelling out to mise.
 			if isCacheHit(state, plugin.ID, binary.Name, binary.Version) {
 				slog.Info("manifest binary cache hit",
 					"plugin", plugin.ID,
@@ -157,21 +204,34 @@ func Reconcile(ctx context.Context, m *Manifest, stellaHome string) ReconcileRes
 				continue
 			}
 
-			slog.Info("manifest binary installing",
-				"plugin", plugin.ID,
-				"binary", binary.Name,
-				"version", binary.Version)
+			// Cache miss: resolve the concrete installed version via the shims
+			// config. Surface config/install/resolution failures per binary.
+			version := binary.Version
+			var binErr error
+			switch {
+			case configErr != nil:
+				binErr = configErr
+			case installErr != nil:
+				binErr = installErr
+			case miseErr != nil:
+				binErr = miseErr
+			default:
+				if v, verr := resolveToolVersion(ctx, miseBin, resolveEnv, resolveDir, binaryLookupName(binary)); verr != nil {
+					binErr = verr
+				} else {
+					version = v
+				}
+			}
 
-			installedVersion, installErr := installBinaryWithMise(ctx, binary, stellaHome)
-			if installErr != nil {
+			if binErr != nil {
 				slog.Error("manifest binary install failed",
 					"plugin", plugin.ID,
 					"binary", binary.Name,
-					"error", installErr)
+					"error", binErr)
 				pr.Binaries = append(pr.Binaries, BinaryReconcileResult{
 					Name:    binary.Name,
 					Version: binary.Version,
-					Err:     installErr,
+					Err:     binErr,
 				})
 				errorCount++
 				continue
@@ -180,17 +240,17 @@ func Reconcile(ctx context.Context, m *Manifest, stellaHome string) ReconcileRes
 			slog.Info("manifest binary installed",
 				"plugin", plugin.ID,
 				"binary", binary.Name,
-				"version", installedVersion)
+				"version", version)
 
 			pr.Binaries = append(pr.Binaries, BinaryReconcileResult{
 				Name:    binary.Name,
-				Version: installedVersion,
+				Version: version,
 			})
 
 			upsertBinaryState(state, plugin.ID, BinaryInstallState{
 				Name:        binary.Name,
 				Tool:        binary.Tool,
-				Version:     installedVersion,
+				Version:     version,
 				InstalledAt: time.Now(),
 			})
 		}

--- a/internal/manifestplugins/reconcile.go
+++ b/internal/manifestplugins/reconcile.go
@@ -66,10 +66,13 @@ func SaveState(path string, s *ManifestState) error {
 	return os.Rename(tmp, path)
 }
 
-// isCacheHit returns true if the state already records the binary at the given version.
-// Returns false for empty version (latest) so mise always verifies the install.
-func isCacheHit(state *ManifestState, pluginID, binaryName, version string) bool {
-	if version == "" {
+// isCacheHit returns true if the state already records the binary at the given
+// version spec. It compares against the requested spec, not the resolved
+// version, so a partial spec (e.g. "2.40") still hits after resolving to a
+// concrete version. Returns false for an empty spec (latest) so mise always
+// verifies the install.
+func isCacheHit(state *ManifestState, pluginID, binaryName, spec string) bool {
+	if spec == "" {
 		return false
 	}
 	ps, ok := state.Plugins[pluginID]
@@ -77,7 +80,7 @@ func isCacheHit(state *ManifestState, pluginID, binaryName, version string) bool
 		return false
 	}
 	for _, b := range ps.Binaries {
-		if b.Name == binaryName && b.Version == version {
+		if b.Name == binaryName && b.Spec == spec {
 			return true
 		}
 	}
@@ -132,14 +135,13 @@ func Reconcile(ctx context.Context, m *Manifest, stellaHome string) ReconcileRes
 	// Collect every enabled binary into one builtin-scope mise config. The
 	// config always reflects the full enabled set so runtime shims resolve any
 	// of them; persisting it is offline and runs no mise commands.
-	var tools []miseTool
+	tools := enabledBuiltinTools(m)
 	needInstall := false
 	for _, plugin := range m.Plugins {
 		if !plugin.Enabled {
 			continue
 		}
 		for _, binary := range plugin.Binaries {
-			tools = append(tools, miseToolFromBinary(binary))
 			if !isCacheHit(state, plugin.ID, binary.Name, binary.Version) {
 				needInstall = true
 			}
@@ -250,6 +252,7 @@ func Reconcile(ctx context.Context, m *Manifest, stellaHome string) ReconcileRes
 			upsertBinaryState(state, plugin.ID, BinaryInstallState{
 				Name:        binary.Name,
 				Tool:        binary.Tool,
+				Spec:        binary.Version,
 				Version:     version,
 				InstalledAt: time.Now(),
 			})

--- a/internal/manifestplugins/reconcile_test.go
+++ b/internal/manifestplugins/reconcile_test.go
@@ -41,6 +41,7 @@ func seedState(t *testing.T, stellaHome, pluginID, binaryName, version string) {
 					{
 						Name:        binaryName,
 						Tool:        "github:owner/repo",
+						Spec:        version,
 						Version:     version,
 						InstalledAt: time.Now(),
 					},

--- a/internal/manifestplugins/state.go
+++ b/internal/manifestplugins/state.go
@@ -21,8 +21,13 @@ type PluginInstallState struct {
 }
 
 type BinaryInstallState struct {
-	Name        string    `json:"name"`
-	Tool        string    `json:"tool"`
+	Name string `json:"name"`
+	Tool string `json:"tool"`
+	// Spec is the version spec requested by the manifest (e.g. "2.40", "latest").
+	// Cache hits key on it; an empty Spec (pre-Spec state files) always misses
+	// and re-resolves, repopulating it.
+	Spec string `json:"spec,omitempty"`
+	// Version is the concrete version mise resolved for Spec at install time.
 	Version     string    `json:"version"`
 	InstalledAt time.Time `json:"installed_at"`
 }

--- a/internal/orgruntime/orgruntime.go
+++ b/internal/orgruntime/orgruntime.go
@@ -32,13 +32,19 @@ type CLIToolSyncer interface {
 
 // OrgRuntime holds per-org lifecycle state while using shared infrastructure.
 type OrgRuntime struct {
-	orgID    string
-	once     sync.Once
-	startErr error
+	orgID       string
+	once        sync.Once
+	startErr    error
+	cliToolsErr error
 }
 
 // OrgID returns the org's ID.
 func (r *OrgRuntime) OrgID() string { return r.orgID }
+
+// CLIToolsErr returns the error from provisioning the org's CLI tools, if any.
+// Non-fatal: the org still starts with builtin tools, but its own cli plugins
+// will not resolve. Safe to read after Start has returned.
+func (r *OrgRuntime) CLIToolsErr() error { return r.cliToolsErr }
 
 // Start initializes runtime services for this org: syncs agent pools,
 // starts channel runtimes, and ensures builtin scheduler jobs.
@@ -56,6 +62,7 @@ func (r *OrgRuntime) doStart(ctx context.Context, store config.Store, syncer Age
 
 	if cliTools != nil {
 		if err := cliTools.SyncOrgCLITools(orgCtx, r.orgID); err != nil {
+			r.cliToolsErr = err
 			slog.Warn("orgruntime: sync cli tools failed", "org_id", r.orgID, "error", err)
 		}
 	}

--- a/internal/orgruntime/orgruntime.go
+++ b/internal/orgruntime/orgruntime.go
@@ -24,6 +24,12 @@ type BuiltinJobSeeder interface {
 	EnsureBuiltinJobs(orgID string)
 }
 
+// CLIToolSyncer installs an org's self-contained CLI tool set (builtin base
+// plus the org's own cli plugins) so its sandbox shims resolve at runtime.
+type CLIToolSyncer interface {
+	SyncOrgCLITools(ctx context.Context, orgID string) error
+}
+
 // OrgRuntime holds per-org lifecycle state while using shared infrastructure.
 type OrgRuntime struct {
 	orgID    string
@@ -38,15 +44,21 @@ func (r *OrgRuntime) OrgID() string { return r.orgID }
 // starts channel runtimes, and ensures builtin scheduler jobs.
 // Safe for concurrent calls — only the first caller does the work,
 // all others block until it completes.
-func (r *OrgRuntime) Start(ctx context.Context, store config.Store, syncer AgentSyncer, channels ChannelStarter, jobs BuiltinJobSeeder) error {
+func (r *OrgRuntime) Start(ctx context.Context, store config.Store, syncer AgentSyncer, channels ChannelStarter, jobs BuiltinJobSeeder, cliTools CLIToolSyncer) error {
 	r.once.Do(func() {
-		r.startErr = r.doStart(ctx, store, syncer, channels, jobs)
+		r.startErr = r.doStart(ctx, store, syncer, channels, jobs, cliTools)
 	})
 	return r.startErr
 }
 
-func (r *OrgRuntime) doStart(ctx context.Context, store config.Store, syncer AgentSyncer, channels ChannelStarter, jobs BuiltinJobSeeder) error {
+func (r *OrgRuntime) doStart(ctx context.Context, store config.Store, syncer AgentSyncer, channels ChannelStarter, jobs BuiltinJobSeeder, cliTools CLIToolSyncer) error {
 	orgCtx := config.WithOrgID(ctx, r.orgID)
+
+	if cliTools != nil {
+		if err := cliTools.SyncOrgCLITools(orgCtx, r.orgID); err != nil {
+			slog.Warn("orgruntime: sync cli tools failed", "org_id", r.orgID, "error", err)
+		}
+	}
 
 	agents, err := store.ListEnabledAgents(orgCtx)
 	if err != nil {
@@ -81,6 +93,7 @@ type Manager struct {
 	syncer   AgentSyncer
 	channels ChannelStarter
 	jobs     BuiltinJobSeeder
+	cliTools CLIToolSyncer
 }
 
 // ManagerDeps holds the shared dependencies injected into Manager.
@@ -89,6 +102,7 @@ type ManagerDeps struct {
 	Syncer   AgentSyncer
 	Channels ChannelStarter
 	Jobs     BuiltinJobSeeder
+	CLITools CLIToolSyncer
 }
 
 // NewManager creates a Manager with the given shared dependencies.
@@ -99,6 +113,7 @@ func NewManager(deps ManagerDeps) *Manager {
 		syncer:   deps.Syncer,
 		channels: deps.Channels,
 		jobs:     deps.Jobs,
+		cliTools: deps.CLITools,
 	}
 }
 
@@ -114,7 +129,7 @@ func (m *Manager) GetOrInit(ctx context.Context, orgID string) (*OrgRuntime, err
 	}
 	m.mu.Unlock()
 
-	if err := rt.Start(ctx, m.store, m.syncer, m.channels, m.jobs); err != nil {
+	if err := rt.Start(ctx, m.store, m.syncer, m.channels, m.jobs, m.cliTools); err != nil {
 		m.mu.Lock()
 		delete(m.runtimes, orgID)
 		m.mu.Unlock()

--- a/internal/orgruntime/orgruntime_test.go
+++ b/internal/orgruntime/orgruntime_test.go
@@ -194,10 +194,10 @@ func TestStart_Idempotent(t *testing.T) {
 	syncer := &fakeSyncer{}
 	rt := &OrgRuntime{orgID: "org1"}
 
-	if err := rt.Start(context.Background(), store, syncer, nil, nil); err != nil {
+	if err := rt.Start(context.Background(), store, syncer, nil, nil, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := rt.Start(context.Background(), store, syncer, nil, nil); err != nil {
+	if err := rt.Start(context.Background(), store, syncer, nil, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	if len(syncer.synced) != 1 {

--- a/pkg/sandbox/hostenv.go
+++ b/pkg/sandbox/hostenv.go
@@ -7,11 +7,19 @@ import (
 	"strings"
 )
 
+// MiseToolsDir returns the root MISE_DATA_DIR for Stella-managed mise installs.
+// This is the single source of truth for the on-disk layout: the manifest/org
+// reconcilers install into it and the sandbox PATH is built from it, so both
+// sides must derive their paths from here to stay in lockstep.
+func MiseToolsDir(stellaHome string) string {
+	return filepath.Join(stellaHome, ".mise-tools")
+}
+
 // MiseShimsDir returns the mise shims directory for host-execution sandbox
 // backends. Tools installed by the manifest/org reconcilers are exposed here as
 // shims (not copied into bin), so it must be on PATH for them to resolve.
 func MiseShimsDir(stellaHome string) string {
-	return filepath.Join(stellaHome, ".mise-tools", "shims")
+	return filepath.Join(MiseToolsDir(stellaHome), "shims")
 }
 
 // HostEnvBuildPath returns a sanitized PATH suitable for host-execution sandbox

--- a/pkg/sandbox/hostenv.go
+++ b/pkg/sandbox/hostenv.go
@@ -7,16 +7,26 @@ import (
 	"strings"
 )
 
+// MiseShimsDir returns the mise shims directory for host-execution sandbox
+// backends. Tools installed by the manifest/org reconcilers are exposed here as
+// shims (not copied into bin), so it must be on PATH for them to resolve.
+func MiseShimsDir(stellaHome string) string {
+	return filepath.Join(stellaHome, ".mise-tools", "shims")
+}
+
 // HostEnvBuildPath returns a sanitized PATH suitable for host-execution sandbox
-// backends (local, none). It prepends the stella bin directory and filters
-// host PATH entries to a safe allowlist on Linux.
+// backends (local, none). It prepends the mise shims and stella bin directories
+// and filters host PATH entries to a safe allowlist on Linux.
 func HostEnvBuildPath(stellaHome string) string {
 	stellaBin := filepath.Join(stellaHome, "bin")
+	shimsDir := MiseShimsDir(stellaHome)
 	if runtime.GOOS != "linux" {
-		return hostEnvPrependPath(stellaBin, os.Getenv("PATH"))
+		return strings.Join(hostEnvDedupeEntries([]string{
+			shimsDir, stellaBin, os.Getenv("PATH"),
+		}), string(os.PathListSeparator))
 	}
 
-	entries := []string{stellaBin}
+	entries := []string{shimsDir, stellaBin}
 	for entry := range strings.SplitSeq(os.Getenv("PATH"), string(os.PathListSeparator)) {
 		if hostEnvPathAllowed(entry, stellaBin) {
 			entries = append(entries, entry)
@@ -76,16 +86,6 @@ func hostEnvPathAllowed(entry, stellaBin string) bool {
 		}
 	}
 	return false
-}
-
-func hostEnvPrependPath(entry, existing string) string {
-	if entry == "" {
-		return existing
-	}
-	if existing == "" {
-		return entry
-	}
-	return entry + string(os.PathListSeparator) + existing
 }
 
 func hostEnvDedupeEntries(entries []string) []string {

--- a/resources/binaries/embedded.go
+++ b/resources/binaries/embedded.go
@@ -190,7 +190,9 @@ func toolNameForEntry(entry string) (string, bool) {
 		return "", false
 	}
 	name := strings.TrimSuffix(entry, ".gz")
-	if !infraTools[name] {
+	// On Windows the embedded entry is "mise.exe.gz"; infraTools keys are the
+	// platform-neutral tool name, so strip a trailing ".exe" before the lookup.
+	if !infraTools[strings.TrimSuffix(name, ".exe")] {
 		return "", false
 	}
 	return name, true

--- a/resources/binaries/embedded.go
+++ b/resources/binaries/embedded.go
@@ -22,9 +22,11 @@ var (
 	ensureStates = make(map[string]*ensureState)
 )
 
-// EnsureTools extracts all embedded tool binaries to stellaHome/bin/.
-// Gzip-compressed binaries in the embed FS are decompressed on extraction.
-// Already-extracted binaries are skipped. Safe for concurrent calls.
+// EnsureTools extracts the embedded infrastructure binaries (see infraTools)
+// to stellaHome/bin/. Gzip-compressed binaries in the embed FS are
+// decompressed on extraction. All other embedded archives are ignored — those
+// tools resolve through mise shims, not bin. Already-extracted binaries are
+// skipped. Safe for concurrent calls.
 func EnsureTools(stellaHome string) error {
 	destDir := BinDir(stellaHome)
 
@@ -175,11 +177,23 @@ func platformEntries() ([]fs.DirEntry, error) {
 	return filtered, nil
 }
 
+// infraTools lists the embedded binaries that are extracted to
+// $STELLA_HOME/bin. Only mise belongs here: it bootstraps the install/shim
+// machinery before any shim exists. Every other tool (gh, fd, rg, tap,
+// lark-cli, boxsh, rtk, ...) is provided through mise shims on the sandbox
+// PATH and must never be copied into bin, even if a stale archive happens to
+// sit in the embed directory.
+var infraTools = map[string]bool{"mise": true}
+
 func toolNameForEntry(entry string) (string, bool) {
 	if !strings.HasSuffix(entry, ".gz") {
 		return "", false
 	}
-	return strings.TrimSuffix(entry, ".gz"), true
+	name := strings.TrimSuffix(entry, ".gz")
+	if !infraTools[name] {
+		return "", false
+	}
+	return name, true
 }
 
 func extractGzip(srcPath, destPath string) error {

--- a/resources/binaries/embedded_test.go
+++ b/resources/binaries/embedded_test.go
@@ -6,6 +6,26 @@ import (
 	"testing"
 )
 
+func TestToolNameForEntry(t *testing.T) {
+	cases := []struct {
+		entry    string
+		wantName string
+		wantOK   bool
+	}{
+		{"mise.gz", "mise", true},
+		{"mise.exe.gz", "mise.exe", true}, // windows: extracted, not filtered out
+		{"gh.gz", "", false},              // non-infra tools resolve via shims
+		{"mise", "", false},               // uncompressed entries are ignored
+	}
+	for _, c := range cases {
+		name, ok := toolNameForEntry(c.entry)
+		if name != c.wantName || ok != c.wantOK {
+			t.Errorf("toolNameForEntry(%q) = (%q, %v), want (%q, %v)",
+				c.entry, name, ok, c.wantName, c.wantOK)
+		}
+	}
+}
+
 func TestExtractTools(t *testing.T) {
 	dest := filepath.Join(t.TempDir(), "bin")
 


### PR DESCRIPTION
## Summary

Adds multi-tenant (per-org) CLI tool isolation and switches manifest tool
provisioning from binary-copy to mise shims.

- **mise shims, not copies** — manifest tools install into a shared
  `MISE_DATA_DIR` and resolve via shims on PATH (`$STELLA_HOME/.mise-tools/shims`),
  instead of copying binaries into `$STELLA_HOME/bin` (which broke tools like npm
  packages that need their surrounding tree). mise itself still lives in `bin` for
  bootstrap. Reconcile renders the builtin-scope config offline and only shells to
  mise on a cache miss, resolving versions in a neutral cwd so no ambient
  `mise.toml` leaks in.
- **Per-org CLI tools** — org admins provision their own tools as `settings_plugin`
  rows with `kind=cli` (mise tool key / version / options in `Config`), no schema
  change. On org start, `OrgCLISyncer` renders a self-contained config (builtin base
  + the org's cli plugins) and installs it, so each org's sandbox shims resolve its
  own tool set. Wired into `orgruntime` as an optional, non-fatal dependency.
- **Runtime env** — host-execution backends (`none`, `local`) get the shims dir on
  PATH and mise env pointed at the org's scope config; `docker` keeps its own
  in-image mise tree (host-side paths are not injected).

## Code review fixes

Addressed multi-perspective review findings (commit `c025cf02`):

- **Concurrency (High)** — serialize installs into the shared `MISE_DATA_DIR` with a
  process-wide mutex so concurrent org starts (and reconcile overlap) don't clobber
  each other's shims during `install`/`reshim`.
- **Cache key (Medium)** — `BinaryInstallState` now stores the requested `Spec`
  alongside the resolved `Version`; `isCacheHit` keys on the spec, so partial specs
  (e.g. `2.40`) no longer miss forever.
- **Shim collisions (Medium)** — reject two different mise keys exposing the same
  shim name within a scope (non-deterministic shadowing in the shared shims dir).
- **Sync failure visibility (Medium)** — per-org CLI sync errors are recorded on
  `OrgRuntime.CLIToolsErr()` instead of only logged.
- **Dedup (Medium)** — reconcile reuses `enabledBuiltinTools`; single source of truth
  for the builtin tool set.
- **Low** — guard `SyncOrgCLITools` against an empty org id (would clobber the builtin
  scope), mirror `MISE_TRUSTED_CONFIG_PATHS` into `scopeMiseEnv`, and warn on
  wrong-typed cli plugin config fields instead of silently dropping them.

## Known follow-ups

- **`http:` org tool backend (security TODO)** — the `http:` backend takes an
  org-admin-supplied `url` that mise fetches on the host outside any sandbox
  (host-side SSRF / arbitrary binary placement). Marked with a `TODO(security)`;
  must be dropped or have its url validated (https-only, reject link-local /
  private / metadata IPs) before wider rollout.
- **Linux `local` (bwrap)**: `.mise-tools` (shims + installs) needs a read-only
  sandbox mount for shim resolution. darwin `none`/`local` run on the host, so this
  is not yet exercised.
- **docker backend** per-org version handling is a separate later phase.
- Org sync re-runs `mise install` over the full builtin set on each org's first
  start (once per process); exact-versioned tools are offline no-ops, only
  `nightly`/`latest` entries re-check.

## Test plan

- [x] `mise run format` (0 lint issues)
- [x] `mise run build`
- [x] `mise run test` (full suite green, incl. sandbox none/local/docker, orgruntime, manifestplugins)
- [ ] Manual: verify shim resolution on darwin `none`/`local` backend in a live session