### PR TITLE
🎨 style: redesign Stella landing workflow hero

### DIFF
--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -129,6 +129,18 @@
   --shadow-xl: 0px 1px 3px 0px hsl(0 0% 10.1961% / 0.1), 0px 8px 10px -1px hsl(0 0% 10.1961% / 0.1);
   --shadow-2xl: 0px 1px 3px 0px hsl(0 0% 10.1961% / 0.25);
   --tracking-normal: 0em;
+  --stella-os-canvas: var(--background);
+  --stella-os-canvas-muted: var(--secondary);
+  --stella-os-surface: var(--card);
+  --stella-os-surface-raised: var(--popover);
+  --stella-os-ink: var(--foreground);
+  --stella-os-muted: var(--muted-foreground);
+  --stella-os-rule: var(--border);
+  --stella-os-accent: var(--primary);
+  --stella-os-accent-soft: var(--accent);
+  --stella-os-warning: oklch(0.72 0.14 78);
+  --stella-os-success: oklch(0.62 0.15 150);
+  --stella-os-danger: var(--destructive);
 }
 
 .dark {
@@ -186,6 +198,18 @@
   --shadow-lg: 0px 1px 3px 0px hsl(0 0% 10.1961% / 0.1), 0px 4px 6px -1px hsl(0 0% 10.1961% / 0.1);
   --shadow-xl: 0px 1px 3px 0px hsl(0 0% 10.1961% / 0.1), 0px 8px 10px -1px hsl(0 0% 10.1961% / 0.1);
   --shadow-2xl: 0px 1px 3px 0px hsl(0 0% 10.1961% / 0.25);
+  --stella-os-canvas: var(--background);
+  --stella-os-canvas-muted: var(--secondary);
+  --stella-os-surface: var(--card);
+  --stella-os-surface-raised: var(--popover);
+  --stella-os-ink: var(--foreground);
+  --stella-os-muted: var(--muted-foreground);
+  --stella-os-rule: var(--border);
+  --stella-os-accent: var(--primary);
+  --stella-os-accent-soft: var(--accent);
+  --stella-os-warning: oklch(0.74 0.13 78);
+  --stella-os-success: oklch(0.7 0.13 150);
+  --stella-os-danger: var(--destructive);
 }
 
 @layer base {

--- a/web/src/routes/index.css
+++ b/web/src/routes/index.css
@@ -1,13 +1,21 @@
 .home-page {
-  --home-ink: var(--foreground);
-  --home-muted: color-mix(in oklch, var(--foreground) 56%, var(--background));
-  --home-faint: color-mix(in oklch, var(--foreground) 8%, transparent);
-  --home-rule: color-mix(in oklch, var(--foreground) 12%, transparent);
-  --home-surface: color-mix(in oklch, var(--background) 50%, var(--card));
-  --home-gold: var(--primary);
+  --home-ink: oklch(22% 0.02 240);
+  --home-muted: oklch(50% 0.018 240);
+  --home-faint: oklch(96% 0.006 245);
+  --home-rule: oklch(90% 0.008 240);
+  --home-surface: oklch(100% 0 0);
+  --home-gold: oklch(58% 0.16 145);
+  --home-warn: oklch(70% 0.15 70);
+  --home-danger: oklch(62% 0.18 28);
   --home-success: oklch(0.65 0.17 145);
   --home-shadow: oklch(0.15 0.005 260);
-  font-family: Outfit, system-ui, sans-serif;
+  background:
+    linear-gradient(var(--home-rule) 1px, transparent 1px),
+    linear-gradient(90deg, var(--home-rule) 1px, transparent 1px), oklch(98% 0.005 250);
+  background-size: 56px 56px;
+  color: var(--home-ink);
+  font-family: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", system-ui, sans-serif;
+  font-variant-numeric: tabular-nums;
 }
 
 /* ─── Skip Link ─── */
@@ -55,67 +63,54 @@
 
 .home-eyebrow {
   display: inline-block;
-  padding: 0.35rem 0.85rem;
-  border-radius: 9999px;
-  background: color-mix(in oklch, var(--home-gold) 12%, transparent);
+  padding: 0.3rem 0.65rem;
+  border: 1px solid color-mix(in oklch, var(--home-gold) 32%, transparent);
+  border-radius: 6px;
+  background: color-mix(in oklch, var(--home-gold) 9%, white);
   color: var(--home-gold);
-  font-family:
-    Fira Code,
-    monospace;
+  font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, Menlo, monospace;
   font-size: 0.7rem;
-  font-weight: 500;
+  font-weight: 650;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  background-size: 200% 100%;
-  background-image: linear-gradient(
-    90deg,
-    color-mix(in oklch, var(--home-gold) 12%, transparent) 40%,
-    color-mix(in oklch, var(--home-gold) 24%, transparent) 50%,
-    color-mix(in oklch, var(--home-gold) 12%, transparent) 60%
-  );
-  animation: shimmer 3s ease-in-out 1s 1;
 }
 
 /* ─── Hero ─── */
 
 .home-hero {
   position: relative;
-  padding: clamp(6rem, 10vw, 11rem) 0 clamp(4rem, 7vw, 8rem);
+  padding: clamp(4.5rem, 8vw, 8rem) 0 clamp(3rem, 6vw, 6rem);
   overflow: hidden;
-}
-
-.home-hero-orb {
-  position: absolute;
-  top: -20%;
-  right: -10%;
-  width: 70%;
-  height: 120%;
-  border-radius: 50%;
-  background: radial-gradient(
-    ellipse at center,
-    color-mix(in oklch, var(--home-gold) 8%, transparent) 0%,
-    color-mix(in oklch, var(--secondary) 4%, transparent) 40%,
-    transparent 70%
-  );
-  filter: blur(60px);
-  animation: orb-drift 20s ease-in-out infinite;
-  pointer-events: none;
 }
 
 .home-hero-grain {
   position: absolute;
   inset: 0;
-  opacity: 0.03;
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
-  background-repeat: repeat;
-  background-size: 200px 200px;
+  background: linear-gradient(180deg, color-mix(in oklch, white 78%, transparent), transparent 42%);
+  opacity: 0.75;
   pointer-events: none;
+}
+
+.home-hero-frame {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 2rem;
+  padding: 0.7rem 0;
+  border-block: 1px solid var(--home-rule);
+  color: var(--home-muted);
+  font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, Menlo, monospace;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 .home-hero-layout {
   display: grid;
-  grid-template-columns: 1fr 1.3fr;
-  gap: clamp(2.5rem, 5vw, 5rem);
+  grid-template-columns: minmax(19rem, 0.82fr) minmax(0, 1.18fr);
+  gap: clamp(2rem, 4vw, 4rem);
   align-items: center;
 }
 
@@ -126,11 +121,11 @@
 
 .home-hero-title {
   margin: 1.75rem 0 1.5rem;
-  font-family: Merriweather, Georgia, serif;
-  font-size: clamp(2.6rem, 6vw, 4.5rem);
-  font-weight: 800;
-  line-height: 1.05;
-  letter-spacing: -0.03em;
+  max-width: 13ch;
+  font-size: clamp(3rem, 7.2vw, 6.9rem);
+  font-weight: 760;
+  line-height: 0.88;
+  letter-spacing: -0.055em;
   color: var(--home-ink);
 }
 
@@ -146,18 +141,18 @@
   left: -0.05em;
   right: -0.05em;
   bottom: 0.02em;
-  height: 0.12em;
-  background: color-mix(in oklch, var(--home-gold) 20%, transparent);
+  height: 0.08em;
+  background: color-mix(in oklch, var(--home-gold) 22%, transparent);
   border-radius: 0.06em;
 }
 
 .home-hero-body {
-  max-width: 36rem;
+  max-width: 33rem;
   margin: 0;
   color: var(--home-muted);
-  font-size: 1.1rem;
-  font-weight: 300;
-  line-height: 1.75;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.7;
 }
 
 .home-actions {
@@ -172,7 +167,7 @@
   align-items: center;
   gap: 0.5rem;
   padding: 0.7rem 1.25rem;
-  border-radius: 10px;
+  border-radius: 8px;
   font-size: 0.88rem;
   font-weight: 600;
   text-decoration: none;
@@ -193,19 +188,18 @@
 
 .home-btn-primary {
   background: var(--home-gold);
-  color: var(--primary-foreground);
-  box-shadow: 0 1px 3px color-mix(in oklch, var(--home-gold) 30%, transparent);
+  color: white;
+  box-shadow: none;
 }
 
 .home-btn-primary:hover {
-  box-shadow: 0 4px 14px color-mix(in oklch, var(--home-gold) 24%, transparent);
   transform: translateY(-1px);
 }
 
 .home-btn-ghost {
   border: 1px solid var(--home-rule);
   color: var(--home-ink);
-  background: transparent;
+  background: var(--home-surface);
 }
 
 .home-btn-ghost:hover {
@@ -213,42 +207,82 @@
   transform: translateY(-1px);
 }
 
+.home-hero-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0;
+  margin: 2rem 0 0;
+  border: 1px solid var(--home-rule);
+  background: color-mix(in oklch, white 82%, transparent);
+}
+
+.home-hero-metrics div {
+  min-width: 0;
+  padding: 0.85rem;
+  border-right: 1px solid var(--home-rule);
+}
+
+.home-hero-metrics div:last-child {
+  border-right: 0;
+}
+
+.home-hero-metrics dt {
+  margin: 0 0 0.35rem;
+  color: var(--home-muted);
+  font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, Menlo, monospace;
+  font-size: 0.64rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.home-hero-metrics dd {
+  margin: 0;
+  color: var(--home-ink);
+  font-size: 0.78rem;
+  font-weight: 650;
+  line-height: 1.35;
+}
+
 /* ─── Product Preview ─── */
 
 .home-product {
   position: relative;
   border: 1px solid var(--home-rule);
-  border-radius: 14px;
+  border-radius: 10px;
   background: var(--home-surface);
   overflow: hidden;
-  box-shadow:
-    0 1px 2px color-mix(in oklch, var(--home-shadow) 8%, transparent),
-    0 8px 24px color-mix(in oklch, var(--home-shadow) 14%, transparent),
-    0 24px 48px color-mix(in oklch, var(--home-shadow) 10%, transparent);
+  box-shadow: 0 18px 44px color-mix(in oklch, var(--home-shadow) 10%, transparent);
   animation: fade-up 900ms cubic-bezier(0.16, 1, 0.3, 1) 300ms both;
 }
 
 .home-product-chrome {
   display: flex;
   align-items: center;
-  gap: 0.45rem;
-  padding: 0.65rem 1rem;
+  gap: 0.55rem;
+  padding: 0.7rem 0.85rem;
   border-bottom: 1px solid var(--home-rule);
-  background: color-mix(in oklch, var(--foreground) 2%, transparent);
+  background: oklch(97% 0.004 250);
 }
 
-.home-product-dot {
-  width: 9px;
-  height: 9px;
+.home-product-status {
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
-  background: color-mix(in oklch, var(--foreground) 14%, transparent);
+  background: var(--home-success);
+  box-shadow: 0 0 0 4px color-mix(in oklch, var(--home-success) 14%, transparent);
+}
+
+.home-product-chrome-label {
+  color: var(--home-muted);
+  font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, Menlo, monospace;
+  font-size: 0.64rem;
+  font-weight: 650;
+  letter-spacing: 0.06em;
 }
 
 .home-product-title {
   margin: 0 0 0 auto;
-  font-family:
-    Fira Code,
-    monospace;
+  font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, Menlo, monospace;
   font-size: 0.68rem;
   font-weight: 500;
   color: var(--home-muted);
@@ -257,151 +291,244 @@
 
 .home-product-body {
   display: grid;
-  grid-template-columns: 7.5rem 1fr;
-  min-height: 320px;
+  grid-template-columns: 0.86fr 1.25fr 0.92fr;
+  gap: 0;
+  min-height: 410px;
 }
 
-.home-product-sidebar {
-  padding: 0.75rem 0;
-  border-right: 1px solid var(--home-rule);
-  background: color-mix(in oklch, var(--foreground) 1.5%, transparent);
-}
-
-.home-product-nav-item {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 0.75rem;
-  font-size: 0.72rem;
-  font-weight: 500;
-  color: var(--home-muted);
-  cursor: default;
-}
-
-.home-product-nav-active {
-  color: var(--home-gold);
-  background: color-mix(in oklch, var(--home-gold) 8%, transparent);
-  border-right: 2px solid var(--home-gold);
-}
-
-.home-product-chat {
-  display: flex;
-  flex-direction: column;
+.home-product-panel {
+  min-width: 0;
   padding: 1rem;
-  gap: 0.75rem;
-  overflow: hidden;
+  border-right: 1px solid var(--home-rule);
+  background: var(--home-surface);
 }
 
-.home-product-msg {
-  max-width: 92%;
+.home-product-panel:last-child {
+  border-right: 0;
 }
 
-.home-product-msg-user {
-  align-self: flex-end;
-}
-
-.home-product-msg-user p {
-  margin: 0;
-  padding: 0.55rem 0.85rem;
-  border-radius: 12px 12px 3px 12px;
-  background: color-mix(in oklch, var(--foreground) 6%, transparent);
-  font-size: 0.78rem;
-  line-height: 1.5;
-  color: var(--home-ink);
-}
-
-.home-product-msg-assistant {
-  display: flex;
-  gap: 0.5rem;
-  align-items: flex-start;
-}
-
-.home-product-avatar {
-  flex-shrink: 0;
-  width: 1.5rem;
-  height: 1.5rem;
-  border-radius: 50%;
-  background: color-mix(in oklch, var(--home-gold) 14%, transparent);
-  color: var(--home-gold);
-  font-family: Merriweather, Georgia, serif;
-  font-size: 0.65rem;
-  font-weight: 700;
+.home-product-panel-head {
   display: flex;
   align-items: center;
-  justify-content: center;
-}
-
-.home-product-msg-content {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-}
-
-.home-product-msg-content > p {
-  margin: 0;
-  font-size: 0.78rem;
-  line-height: 1.55;
-  color: var(--home-ink);
-}
-
-.home-product-tool {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.25rem 0.55rem;
-  border-radius: 6px;
-  background: color-mix(in oklch, var(--foreground) 4%, transparent);
-  font-family:
-    Fira Code,
-    monospace;
-  font-size: 0.65rem;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.9rem;
   color: var(--home-muted);
-  width: fit-content;
+  font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, Menlo, monospace;
+  font-size: 0.68rem;
+  font-weight: 650;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
 
-.home-product-tool-status {
-  color: var(--home-success);
-  font-weight: 600;
+.home-agent-list {
+  display: grid;
+  gap: 0.6rem;
 }
 
-.home-product-tool-running {
-  border: 1px solid color-mix(in oklch, var(--home-gold) 20%, transparent);
-  background: color-mix(in oklch, var(--home-gold) 5%, transparent);
-}
-
-.home-product-dots {
-  display: inline-flex;
-  gap: 2px;
-  margin-left: 0.25rem;
-}
-
-.home-product-dots span {
-  width: 4px;
-  height: 4px;
-  border-radius: 50%;
-  background: var(--home-gold);
-  animation: dot-bounce 1.2s ease-in-out infinite;
-}
-
-.home-product-dots span:nth-child(2) {
-  animation-delay: 0.15s;
-}
-
-.home-product-dots span:nth-child(3) {
-  animation-delay: 0.3s;
-}
-
-.home-product-input {
-  margin-top: auto;
-  padding: 0.6rem 0.85rem;
-  border-radius: 10px;
+.home-agent-row {
+  padding: 0.72rem;
   border: 1px solid var(--home-rule);
-  background: var(--background);
+  border-radius: 8px;
+  background: oklch(99% 0.002 250);
 }
 
-.home-product-input-placeholder {
-  font-size: 0.75rem;
-  color: color-mix(in oklch, var(--foreground) 30%, transparent);
+.home-agent-row.is-active {
+  border-color: color-mix(in oklch, var(--home-gold) 44%, var(--home-rule));
+  background: color-mix(in oklch, var(--home-gold) 8%, white);
+}
+
+.home-agent-row div {
+  display: grid;
+  gap: 0.22rem;
+}
+
+.home-agent-row strong {
+  color: var(--home-ink);
+  font-size: 0.82rem;
+}
+
+.home-agent-row span,
+.home-agent-row small {
+  color: var(--home-muted);
+  font-size: 0.68rem;
+  line-height: 1.35;
+}
+
+.home-agent-row small {
+  display: inline-block;
+  margin-top: 0.55rem;
+  font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, Menlo, monospace;
+}
+
+.home-agent-policy {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.45rem;
+  margin-top: 1rem;
+  padding-top: 0.9rem;
+  border-top: 1px dashed var(--home-rule);
+  color: var(--home-gold);
+  font-size: 0.72rem;
+  line-height: 1.45;
+}
+
+.home-product-panel-work {
+  background:
+    linear-gradient(var(--home-rule) 1px, transparent 1px),
+    linear-gradient(90deg, var(--home-rule) 1px, transparent 1px), oklch(99% 0.002 250);
+  background-size: 28px 28px;
+}
+
+.home-goal-card {
+  padding: 0.9rem;
+  border: 1px solid var(--home-rule);
+  border-radius: 8px;
+  background: var(--home-surface);
+}
+
+.home-goal-card p {
+  margin: 0;
+  color: var(--home-ink);
+  font-size: 0.83rem;
+  line-height: 1.55;
+}
+
+.home-goal-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.8rem;
+}
+
+.home-goal-meta span {
+  padding: 0.25rem 0.45rem;
+  border: 1px solid var(--home-rule);
+  border-radius: 5px;
+  background: oklch(98% 0.004 250);
+  color: var(--home-muted);
+  font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, Menlo, monospace;
+  font-size: 0.61rem;
+}
+
+.home-task-dag {
+  position: relative;
+  display: grid;
+  gap: 0.62rem;
+  margin-top: 1rem;
+}
+
+.home-task-node {
+  position: relative;
+  display: grid;
+  grid-template-columns: 2rem 1fr auto;
+  gap: 0.6rem;
+  align-items: center;
+  min-height: 2.65rem;
+  padding: 0.62rem 0.7rem;
+  border: 1px solid var(--home-rule);
+  border-radius: 8px;
+  background: var(--home-surface);
+}
+
+.home-task-node::before {
+  content: "";
+  position: absolute;
+  left: 1.68rem;
+  top: -0.64rem;
+  width: 1px;
+  height: 0.64rem;
+  background: var(--home-rule);
+}
+
+.home-task-node:first-child::before {
+  display: none;
+}
+
+.home-task-node span,
+.home-task-node small {
+  font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, Menlo, monospace;
+  font-size: 0.64rem;
+  color: var(--home-muted);
+}
+
+.home-task-node strong {
+  min-width: 0;
+  color: var(--home-ink);
+  font-size: 0.78rem;
+  line-height: 1.35;
+}
+
+.home-task-node.is-done {
+  border-color: color-mix(in oklch, var(--home-success) 34%, var(--home-rule));
+}
+
+.home-task-node.is-done small {
+  color: var(--home-success);
+}
+
+.home-task-node.is-blocked {
+  border-color: color-mix(in oklch, var(--home-warn) 48%, var(--home-rule));
+  background: color-mix(in oklch, var(--home-warn) 6%, white);
+}
+
+.home-task-node.is-blocked small {
+  color: color-mix(in oklch, var(--home-warn) 70%, black);
+}
+
+.home-task-node.is-review {
+  border-color: color-mix(in oklch, var(--home-gold) 42%, var(--home-rule));
+  background: color-mix(in oklch, var(--home-gold) 7%, white);
+}
+
+.home-task-node.is-review small {
+  color: var(--home-gold);
+}
+
+.home-review-card {
+  padding: 0.85rem;
+  border: 1px solid color-mix(in oklch, var(--home-warn) 48%, var(--home-rule));
+  border-radius: 8px;
+  background: color-mix(in oklch, var(--home-warn) 7%, white);
+}
+
+.home-review-state {
+  display: inline-flex;
+  margin-bottom: 0.75rem;
+  color: color-mix(in oklch, var(--home-warn) 62%, black);
+  font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, Menlo, monospace;
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+}
+
+.home-review-card strong {
+  display: block;
+  color: var(--home-ink);
+  font-size: 0.84rem;
+  line-height: 1.35;
+}
+
+.home-review-card p {
+  margin: 0.6rem 0 0;
+  color: var(--home-muted);
+  font-size: 0.72rem;
+  line-height: 1.55;
+}
+
+.home-review-actions {
+  display: grid;
+  gap: 0.55rem;
+  margin-top: 1rem;
+}
+
+.home-review-actions span {
+  padding: 0.55rem 0.65rem;
+  border: 1px solid var(--home-rule);
+  border-radius: 7px;
+  background: oklch(99% 0.002 250);
+  color: var(--home-muted);
+  font-size: 0.72rem;
 }
 
 /* Feature badges */
@@ -417,13 +544,13 @@
   align-items: center;
   gap: 0.35rem;
   padding: 0.3rem 0.65rem;
-  border-radius: 8px;
+  border-radius: 7px;
   background: var(--card);
   border: 1px solid var(--home-rule);
   font-size: 0.65rem;
   font-weight: 500;
   color: var(--home-muted);
-  box-shadow: 0 4px 12px color-mix(in oklch, var(--home-shadow) 14%, transparent);
+  box-shadow: 0 10px 24px color-mix(in oklch, var(--home-shadow) 10%, transparent);
   opacity: 0;
   animation: badge-in 600ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
   white-space: nowrap;
@@ -452,7 +579,7 @@
 .home-systems {
   padding: clamp(4rem, 8vw, 8rem) 0;
   border-top: 1px solid var(--home-rule);
-  background: color-mix(in oklch, var(--foreground) 3%, var(--background));
+  background: oklch(96% 0.006 245);
 }
 
 .home-system--hero {
@@ -476,8 +603,8 @@
 }
 
 .home-system {
-  padding: 2rem;
-  border-radius: 14px;
+  padding: 1.35rem;
+  border-radius: 10px;
   border: 1px solid var(--home-rule);
   background: var(--home-surface);
   transition:
@@ -488,7 +615,6 @@
 
 .home-system:hover {
   border-color: color-mix(in oklch, var(--home-gold) 30%, transparent);
-  box-shadow: 0 6px 24px color-mix(in oklch, var(--home-shadow) 10%, transparent);
   transform: translateY(-2px);
 }
 
@@ -498,7 +624,7 @@
   justify-content: center;
   width: 2.5rem;
   height: 2.5rem;
-  border-radius: 10px;
+  border-radius: 8px;
   background: color-mix(in oklch, var(--home-gold) 10%, transparent);
   color: var(--home-gold);
   margin-bottom: 1rem;
@@ -514,7 +640,7 @@
 .home-system-desc {
   margin: 0;
   font-size: 0.88rem;
-  font-weight: 300;
+  font-weight: 400;
   line-height: 1.7;
   color: var(--home-muted);
 }
@@ -542,20 +668,18 @@
 .home-pillars {
   padding: clamp(5rem, 9vw, 9rem) 0;
   border-top: 1px solid var(--home-rule);
-  background: var(--foreground);
-  color: var(--background);
+  background: oklch(18% 0.018 245);
+  color: white;
 }
 
 .home-pillars-heading {
   margin: 0 0 3rem;
-  font-family:
-    Fira Code,
-    monospace;
+  font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, Menlo, monospace;
   font-size: 0.72rem;
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: var(--primary);
+  color: var(--home-gold);
 }
 
 .home-pillars-list {
@@ -573,7 +697,7 @@
   gap: 1rem;
   align-items: baseline;
   padding: 2rem 0;
-  border-top: 1px solid color-mix(in oklch, var(--background) 10%, transparent);
+  border-top: 1px solid color-mix(in oklch, white 12%, transparent);
 }
 
 .home-pillar:last-child {
@@ -585,24 +709,21 @@
 }
 
 .home-pillar:hover .home-pillar-title {
-  color: var(--primary);
+  color: var(--home-gold);
 }
 
 .home-pillar-num {
-  font-family:
-    Fira Code,
-    monospace;
+  font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, Menlo, monospace;
   font-size: 0.75rem;
   font-weight: 500;
-  color: var(--primary);
+  color: var(--home-gold);
   letter-spacing: 0.02em;
 }
 
 .home-pillar-title {
   margin: 0 0 0.65rem;
-  font-family: Merriweather, Georgia, serif;
   font-size: clamp(1.3rem, 2.5vw, 1.65rem);
-  font-weight: 800;
+  font-weight: 720;
   line-height: 1.15;
   letter-spacing: -0.015em;
   color: color-mix(in oklch, var(--background) 94%, transparent);
@@ -612,7 +733,7 @@
   margin: 0;
   max-width: 48rem;
   font-size: 0.92rem;
-  font-weight: 300;
+  font-weight: 400;
   line-height: 1.8;
   color: color-mix(in oklch, var(--background) 56%, transparent);
 }
@@ -630,9 +751,8 @@
 
 .home-section-title {
   margin: 0;
-  font-family: Merriweather, Georgia, serif;
   font-size: clamp(2rem, 4vw, 3.2rem);
-  font-weight: 800;
+  font-weight: 760;
   line-height: 1.1;
   letter-spacing: -0.025em;
   color: var(--home-ink);
@@ -643,7 +763,7 @@
   max-width: 38rem;
   color: var(--home-muted);
   font-size: 1.05rem;
-  font-weight: 300;
+  font-weight: 400;
   line-height: 1.7;
 }
 
@@ -657,9 +777,7 @@
   margin: 0 0 1.25rem;
   padding-bottom: 0.75rem;
   border-bottom: 2px solid var(--home-gold);
-  font-family:
-    Fira Code,
-    monospace;
+  font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, Menlo, monospace;
   font-size: 0.72rem;
   font-weight: 600;
   letter-spacing: 0.04em;
@@ -693,7 +811,7 @@
 .home-cap p {
   margin: 0;
   font-size: 0.82rem;
-  font-weight: 300;
+  font-weight: 400;
   line-height: 1.6;
   color: var(--home-muted);
 }
@@ -703,7 +821,7 @@
 .home-cta {
   padding: clamp(5rem, 8vw, 8rem) 0;
   border-top: 1px solid var(--home-rule);
-  background: color-mix(in oklch, var(--foreground) 3%, var(--background));
+  background: oklch(96% 0.006 245);
 }
 
 .home-cta-layout {
@@ -721,10 +839,10 @@
   display: grid;
   gap: 0.5rem;
   padding: 1.25rem;
-  border-radius: 12px;
-  background: var(--foreground);
-  color: var(--background);
-  box-shadow: 0 8px 32px color-mix(in oklch, var(--home-shadow) 30%, transparent);
+  border-radius: 10px;
+  background: oklch(18% 0.018 245);
+  color: white;
+  box-shadow: none;
 }
 
 .home-terminal code {
@@ -732,9 +850,7 @@
   padding: 0.7rem 0.9rem;
   border-radius: 8px;
   background: color-mix(in oklch, var(--background) 8%, transparent);
-  font-family:
-    Fira Code,
-    monospace;
+  font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, Menlo, monospace;
   font-size: 0.82rem;
   line-height: 1.5;
   white-space: nowrap;
@@ -742,7 +858,7 @@
 }
 
 .home-terminal-prompt {
-  color: var(--primary);
+  color: var(--home-gold);
   margin-right: 0.5rem;
 }
 
@@ -764,44 +880,6 @@
   to {
     opacity: 1;
     transform: translateY(0);
-  }
-}
-
-@keyframes shimmer {
-  0% {
-    background-position: -200% center;
-  }
-  100% {
-    background-position: 200% center;
-  }
-}
-
-@keyframes orb-drift {
-  0%,
-  100% {
-    transform: translate(0, 0) scale(1);
-  }
-  25% {
-    transform: translate(-3%, 4%) scale(1.02);
-  }
-  50% {
-    transform: translate(2%, -2%) scale(0.98);
-  }
-  75% {
-    transform: translate(-1%, -3%) scale(1.01);
-  }
-}
-
-@keyframes dot-bounce {
-  0%,
-  80%,
-  100% {
-    transform: scale(0.6);
-    opacity: 0.4;
-  }
-  40% {
-    transform: scale(1);
-    opacity: 1;
   }
 }
 
@@ -944,12 +1022,17 @@
     min-height: 2.75rem;
   }
 
-  .home-product-sidebar {
-    display: none;
-  }
-
   .home-product-body {
     grid-template-columns: 1fr;
+  }
+
+  .home-product-panel {
+    border-right: 0;
+    border-bottom: 1px solid var(--home-rule);
+  }
+
+  .home-product-panel:last-child {
+    border-bottom: 0;
   }
 
   .home-pillar {
@@ -983,10 +1066,7 @@
     transition: none;
   }
 
-  .home-eyebrow,
-  .home-hero-orb,
-  .home-product-badge,
-  .home-product-dots span {
+  .home-product-badge {
     animation: none;
   }
 

--- a/web/src/routes/index.css
+++ b/web/src/routes/index.css
@@ -1,20 +1,18 @@
 .home-page {
-  --home-ink: oklch(22% 0.02 240);
-  --home-muted: oklch(50% 0.018 240);
-  --home-faint: oklch(96% 0.006 245);
-  --home-rule: oklch(90% 0.008 240);
-  --home-surface: oklch(100% 0 0);
-  --home-gold: oklch(58% 0.16 145);
-  --home-warn: oklch(70% 0.15 70);
-  --home-danger: oklch(62% 0.18 28);
-  --home-success: oklch(0.65 0.17 145);
-  --home-shadow: oklch(0.15 0.005 260);
   background:
-    linear-gradient(var(--home-rule) 1px, transparent 1px),
-    linear-gradient(90deg, var(--home-rule) 1px, transparent 1px), oklch(98% 0.005 250);
+    linear-gradient(
+      color-mix(in oklch, var(--stella-os-rule) 58%, transparent) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      90deg,
+      color-mix(in oklch, var(--stella-os-rule) 58%, transparent) 1px,
+      transparent 1px
+    ),
+    var(--stella-os-canvas);
   background-size: 56px 56px;
-  color: var(--home-ink);
-  font-family: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", system-ui, sans-serif;
+  color: var(--stella-os-ink);
+  font-family: var(--font-sans);
   font-variant-numeric: tabular-nums;
 }
 
@@ -26,7 +24,7 @@
   left: 1rem;
   z-index: 200;
   padding: 0.5rem 1rem;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   background: var(--foreground);
   color: var(--background);
   font-size: 0.85rem;
@@ -55,6 +53,8 @@
 /* ─── Shell ─── */
 
 .home-shell {
+  position: relative;
+  z-index: 1;
   width: min(100% - 3rem, 72rem);
   margin-inline: auto;
 }
@@ -64,11 +64,11 @@
 .home-eyebrow {
   display: inline-block;
   padding: 0.3rem 0.65rem;
-  border: 1px solid color-mix(in oklch, var(--home-gold) 32%, transparent);
-  border-radius: 6px;
-  background: color-mix(in oklch, var(--home-gold) 9%, white);
-  color: var(--home-gold);
-  font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, Menlo, monospace;
+  border: 1px solid color-mix(in oklch, var(--stella-os-accent) 32%, transparent);
+  border-radius: var(--radius-sm);
+  background: color-mix(in oklch, var(--stella-os-accent-soft) 74%, transparent);
+  color: var(--stella-os-accent);
+  font-family: var(--font-mono);
   font-size: 0.7rem;
   font-weight: 650;
   letter-spacing: 0.04em;
@@ -86,7 +86,11 @@
 .home-hero-grain {
   position: absolute;
   inset: 0;
-  background: linear-gradient(180deg, color-mix(in oklch, white 78%, transparent), transparent 42%);
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklch, var(--stella-os-surface) 78%, transparent),
+    transparent 42%
+  );
   opacity: 0.75;
   pointer-events: none;
 }
@@ -99,9 +103,9 @@
   gap: 1rem;
   margin-bottom: 2rem;
   padding: 0.7rem 0;
-  border-block: 1px solid var(--home-rule);
-  color: var(--home-muted);
-  font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, Menlo, monospace;
+  border-block: 1px solid var(--stella-os-rule);
+  color: var(--stella-os-muted);
+  font-family: var(--font-mono);
   font-size: 0.72rem;
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -125,13 +129,13 @@
   font-size: clamp(3rem, 7.2vw, 6.9rem);
   font-weight: 760;
   line-height: 0.88;
-  letter-spacing: -0.055em;
-  color: var(--home-ink);
+  letter-spacing: var(--letter-spacing);
+  color: var(--stella-os-ink);
 }
 
 .home-hero-title em {
   font-style: normal;
-  color: var(--home-gold);
+  color: var(--stella-os-accent);
   position: relative;
 }
 
@@ -142,14 +146,14 @@
   right: -0.05em;
   bottom: 0.02em;
   height: 0.08em;
-  background: color-mix(in oklch, var(--home-gold) 22%, transparent);
+  background: color-mix(in oklch, var(--stella-os-accent) 22%, transparent);
   border-radius: 0.06em;
 }
 
 .home-hero-body {
   max-width: 33rem;
   margin: 0;
-  color: var(--home-muted);
+  color: var(--stella-os-muted);
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.7;
@@ -167,7 +171,7 @@
   align-items: center;
   gap: 0.5rem;
   padding: 0.7rem 1.25rem;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   font-size: 0.88rem;
   font-weight: 600;
   text-decoration: none;
@@ -182,13 +186,13 @@
 }
 
 .home-btn:focus-visible {
-  outline: 2px solid var(--home-gold);
+  outline: 2px solid var(--stella-os-accent);
   outline-offset: 2px;
 }
 
 .home-btn-primary {
-  background: var(--home-gold);
-  color: white;
+  background: var(--stella-os-accent);
+  color: var(--primary-foreground);
   box-shadow: none;
 }
 
@@ -197,13 +201,13 @@
 }
 
 .home-btn-ghost {
-  border: 1px solid var(--home-rule);
-  color: var(--home-ink);
-  background: var(--home-surface);
+  border: 1px solid var(--stella-os-rule);
+  color: var(--stella-os-ink);
+  background: var(--stella-os-surface);
 }
 
 .home-btn-ghost:hover {
-  background: var(--home-faint);
+  background: var(--stella-os-canvas-muted);
   transform: translateY(-1px);
 }
 
@@ -212,14 +216,16 @@
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 0;
   margin: 2rem 0 0;
-  border: 1px solid var(--home-rule);
-  background: color-mix(in oklch, white 82%, transparent);
+  border: 1px solid var(--stella-os-rule);
+  border-radius: var(--radius-lg);
+  background: color-mix(in oklch, var(--stella-os-surface) 82%, transparent);
+  overflow: hidden;
 }
 
 .home-hero-metrics div {
   min-width: 0;
   padding: 0.85rem;
-  border-right: 1px solid var(--home-rule);
+  border-right: 1px solid var(--stella-os-rule);
 }
 
 .home-hero-metrics div:last-child {
@@ -228,8 +234,8 @@
 
 .home-hero-metrics dt {
   margin: 0 0 0.35rem;
-  color: var(--home-muted);
-  font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, Menlo, monospace;
+  color: var(--stella-os-muted);
+  font-family: var(--font-mono);
   font-size: 0.64rem;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -237,7 +243,7 @@
 
 .home-hero-metrics dd {
   margin: 0;
-  color: var(--home-ink);
+  color: var(--stella-os-ink);
   font-size: 0.78rem;
   font-weight: 650;
   line-height: 1.35;
@@ -247,11 +253,11 @@
 
 .home-product {
   position: relative;
-  border: 1px solid var(--home-rule);
-  border-radius: 10px;
-  background: var(--home-surface);
+  border: 1px solid var(--stella-os-rule);
+  border-radius: var(--radius-xl);
+  background: var(--stella-os-surface);
   overflow: hidden;
-  box-shadow: 0 18px 44px color-mix(in oklch, var(--home-shadow) 10%, transparent);
+  box-shadow: var(--shadow-xl);
   animation: fade-up 900ms cubic-bezier(0.16, 1, 0.3, 1) 300ms both;
 }
 
@@ -260,21 +266,21 @@
   align-items: center;
   gap: 0.55rem;
   padding: 0.7rem 0.85rem;
-  border-bottom: 1px solid var(--home-rule);
-  background: oklch(97% 0.004 250);
+  border-bottom: 1px solid var(--stella-os-rule);
+  background: var(--stella-os-canvas-muted);
 }
 
 .home-product-status {
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background: var(--home-success);
-  box-shadow: 0 0 0 4px color-mix(in oklch, var(--home-success) 14%, transparent);
+  background: var(--stella-os-success);
+  box-shadow: 0 0 0 4px color-mix(in oklch, var(--stella-os-success) 14%, transparent);
 }
 
 .home-product-chrome-label {
-  color: var(--home-muted);
-  font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, Menlo, monospace;
+  color: var(--stella-os-muted);
+  font-family: var(--font-mono);
   font-size: 0.64rem;
   font-weight: 650;
   letter-spacing: 0.06em;
@@ -282,10 +288,10 @@
 
 .home-product-title {
   margin: 0 0 0 auto;
-  font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, Menlo, monospace;
+  font-family: var(--font-mono);
   font-size: 0.68rem;
   font-weight: 500;
-  color: var(--home-muted);
+  color: var(--stella-os-muted);
   letter-spacing: 0.02em;
 }
 
@@ -299,8 +305,8 @@
 .home-product-panel {
   min-width: 0;
   padding: 1rem;
-  border-right: 1px solid var(--home-rule);
-  background: var(--home-surface);
+  border-right: 1px solid var(--stella-os-rule);
+  background: var(--stella-os-surface);
 }
 
 .home-product-panel:last-child {
@@ -313,12 +319,39 @@
   justify-content: space-between;
   gap: 1rem;
   margin-bottom: 0.9rem;
-  color: var(--home-muted);
-  font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, Menlo, monospace;
+  color: var(--stella-os-muted);
+  font-family: var(--font-mono);
   font-size: 0.68rem;
   font-weight: 650;
   text-transform: uppercase;
   letter-spacing: 0.05em;
+}
+
+.home-product-panel-head-sub {
+  margin: 1rem 0 0.7rem;
+  color: color-mix(in oklch, var(--stella-os-muted) 78%, transparent);
+  font-size: 0.62rem;
+}
+
+.home-app-nav {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.home-app-nav span {
+  display: flex;
+  align-items: center;
+  min-height: 2rem;
+  padding: 0.35rem 0.6rem;
+  border-radius: var(--radius-md);
+  color: var(--stella-os-muted);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.home-app-nav span.is-active {
+  background: var(--stella-os-accent-soft);
+  color: var(--stella-os-accent);
 }
 
 .home-agent-list {
@@ -328,14 +361,14 @@
 
 .home-agent-row {
   padding: 0.72rem;
-  border: 1px solid var(--home-rule);
-  border-radius: 8px;
-  background: oklch(99% 0.002 250);
+  border: 1px solid var(--stella-os-rule);
+  border-radius: var(--radius-md);
+  background: var(--stella-os-surface-raised);
 }
 
 .home-agent-row.is-active {
-  border-color: color-mix(in oklch, var(--home-gold) 44%, var(--home-rule));
-  background: color-mix(in oklch, var(--home-gold) 8%, white);
+  border-color: color-mix(in oklch, var(--stella-os-accent) 44%, var(--stella-os-rule));
+  background: var(--stella-os-accent-soft);
 }
 
 .home-agent-row div {
@@ -344,13 +377,13 @@
 }
 
 .home-agent-row strong {
-  color: var(--home-ink);
+  color: var(--stella-os-ink);
   font-size: 0.82rem;
 }
 
 .home-agent-row span,
 .home-agent-row small {
-  color: var(--home-muted);
+  color: var(--stella-os-muted);
   font-size: 0.68rem;
   line-height: 1.35;
 }
@@ -358,7 +391,7 @@
 .home-agent-row small {
   display: inline-block;
   margin-top: 0.55rem;
-  font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, Menlo, monospace;
+  font-family: var(--font-mono);
 }
 
 .home-agent-policy {
@@ -367,29 +400,37 @@
   gap: 0.45rem;
   margin-top: 1rem;
   padding-top: 0.9rem;
-  border-top: 1px dashed var(--home-rule);
-  color: var(--home-gold);
+  border-top: 1px dashed var(--stella-os-rule);
+  color: var(--stella-os-accent);
   font-size: 0.72rem;
   line-height: 1.45;
 }
 
 .home-product-panel-work {
   background:
-    linear-gradient(var(--home-rule) 1px, transparent 1px),
-    linear-gradient(90deg, var(--home-rule) 1px, transparent 1px), oklch(99% 0.002 250);
+    linear-gradient(
+      color-mix(in oklch, var(--stella-os-rule) 42%, transparent) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      90deg,
+      color-mix(in oklch, var(--stella-os-rule) 42%, transparent) 1px,
+      transparent 1px
+    ),
+    var(--stella-os-canvas);
   background-size: 28px 28px;
 }
 
 .home-goal-card {
   padding: 0.9rem;
-  border: 1px solid var(--home-rule);
-  border-radius: 8px;
-  background: var(--home-surface);
+  border: 1px solid var(--stella-os-rule);
+  border-radius: var(--radius-md);
+  background: var(--stella-os-surface);
 }
 
 .home-goal-card p {
   margin: 0;
-  color: var(--home-ink);
+  color: var(--stella-os-ink);
   font-size: 0.83rem;
   line-height: 1.55;
 }
@@ -403,11 +444,11 @@
 
 .home-goal-meta span {
   padding: 0.25rem 0.45rem;
-  border: 1px solid var(--home-rule);
-  border-radius: 5px;
-  background: oklch(98% 0.004 250);
-  color: var(--home-muted);
-  font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, Menlo, monospace;
+  border: 1px solid var(--stella-os-rule);
+  border-radius: calc(var(--radius-sm) * 0.72);
+  background: var(--stella-os-canvas-muted);
+  color: var(--stella-os-muted);
+  font-family: var(--font-mono);
   font-size: 0.61rem;
 }
 
@@ -426,9 +467,9 @@
   align-items: center;
   min-height: 2.65rem;
   padding: 0.62rem 0.7rem;
-  border: 1px solid var(--home-rule);
-  border-radius: 8px;
-  background: var(--home-surface);
+  border: 1px solid var(--stella-os-rule);
+  border-radius: var(--radius-md);
+  background: var(--stella-os-surface);
 }
 
 .home-task-node::before {
@@ -438,7 +479,7 @@
   top: -0.64rem;
   width: 1px;
   height: 0.64rem;
-  background: var(--home-rule);
+  background: var(--stella-os-rule);
 }
 
 .home-task-node:first-child::before {
@@ -447,56 +488,56 @@
 
 .home-task-node span,
 .home-task-node small {
-  font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, Menlo, monospace;
+  font-family: var(--font-mono);
   font-size: 0.64rem;
-  color: var(--home-muted);
+  color: var(--stella-os-muted);
 }
 
 .home-task-node strong {
   min-width: 0;
-  color: var(--home-ink);
+  color: var(--stella-os-ink);
   font-size: 0.78rem;
   line-height: 1.35;
 }
 
 .home-task-node.is-done {
-  border-color: color-mix(in oklch, var(--home-success) 34%, var(--home-rule));
+  border-color: color-mix(in oklch, var(--stella-os-success) 34%, var(--stella-os-rule));
 }
 
 .home-task-node.is-done small {
-  color: var(--home-success);
+  color: var(--stella-os-success);
 }
 
 .home-task-node.is-blocked {
-  border-color: color-mix(in oklch, var(--home-warn) 48%, var(--home-rule));
-  background: color-mix(in oklch, var(--home-warn) 6%, white);
+  border-color: color-mix(in oklch, var(--stella-os-warning) 48%, var(--stella-os-rule));
+  background: color-mix(in oklch, var(--stella-os-warning) 12%, var(--stella-os-surface));
 }
 
 .home-task-node.is-blocked small {
-  color: color-mix(in oklch, var(--home-warn) 70%, black);
+  color: color-mix(in oklch, var(--stella-os-warning) 82%, var(--stella-os-ink));
 }
 
 .home-task-node.is-review {
-  border-color: color-mix(in oklch, var(--home-gold) 42%, var(--home-rule));
-  background: color-mix(in oklch, var(--home-gold) 7%, white);
+  border-color: color-mix(in oklch, var(--stella-os-accent) 42%, var(--stella-os-rule));
+  background: var(--stella-os-accent-soft);
 }
 
 .home-task-node.is-review small {
-  color: var(--home-gold);
+  color: var(--stella-os-accent);
 }
 
 .home-review-card {
   padding: 0.85rem;
-  border: 1px solid color-mix(in oklch, var(--home-warn) 48%, var(--home-rule));
-  border-radius: 8px;
-  background: color-mix(in oklch, var(--home-warn) 7%, white);
+  border: 1px solid color-mix(in oklch, var(--stella-os-warning) 48%, var(--stella-os-rule));
+  border-radius: var(--radius-md);
+  background: color-mix(in oklch, var(--stella-os-warning) 13%, var(--stella-os-surface));
 }
 
 .home-review-state {
   display: inline-flex;
   margin-bottom: 0.75rem;
-  color: color-mix(in oklch, var(--home-warn) 62%, black);
-  font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, Menlo, monospace;
+  color: color-mix(in oklch, var(--stella-os-warning) 82%, var(--stella-os-ink));
+  font-family: var(--font-mono);
   font-size: 0.62rem;
   font-weight: 700;
   letter-spacing: 0.06em;
@@ -504,14 +545,14 @@
 
 .home-review-card strong {
   display: block;
-  color: var(--home-ink);
+  color: var(--stella-os-ink);
   font-size: 0.84rem;
   line-height: 1.35;
 }
 
 .home-review-card p {
   margin: 0.6rem 0 0;
-  color: var(--home-muted);
+  color: var(--stella-os-muted);
   font-size: 0.72rem;
   line-height: 1.55;
 }
@@ -524,10 +565,10 @@
 
 .home-review-actions span {
   padding: 0.55rem 0.65rem;
-  border: 1px solid var(--home-rule);
-  border-radius: 7px;
-  background: oklch(99% 0.002 250);
-  color: var(--home-muted);
+  border: 1px solid var(--stella-os-rule);
+  border-radius: var(--radius-md);
+  background: var(--stella-os-surface-raised);
+  color: var(--stella-os-muted);
   font-size: 0.72rem;
 }
 
@@ -544,13 +585,13 @@
   align-items: center;
   gap: 0.35rem;
   padding: 0.3rem 0.65rem;
-  border-radius: 7px;
-  background: var(--card);
-  border: 1px solid var(--home-rule);
+  border-radius: var(--radius-md);
+  background: var(--stella-os-surface-raised);
+  border: 1px solid var(--stella-os-rule);
   font-size: 0.65rem;
   font-weight: 500;
-  color: var(--home-muted);
-  box-shadow: 0 10px 24px color-mix(in oklch, var(--home-shadow) 10%, transparent);
+  color: var(--stella-os-muted);
+  box-shadow: var(--shadow-lg);
   opacity: 0;
   animation: badge-in 600ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
   white-space: nowrap;
@@ -578,8 +619,8 @@
 
 .home-systems {
   padding: clamp(4rem, 8vw, 8rem) 0;
-  border-top: 1px solid var(--home-rule);
-  background: oklch(96% 0.006 245);
+  border-top: 1px solid var(--stella-os-rule);
+  background: var(--stella-os-canvas-muted);
 }
 
 .home-system--hero {
@@ -604,9 +645,9 @@
 
 .home-system {
   padding: 1.35rem;
-  border-radius: 10px;
-  border: 1px solid var(--home-rule);
-  background: var(--home-surface);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--stella-os-rule);
+  background: var(--stella-os-surface);
   transition:
     border-color 200ms ease,
     box-shadow 200ms ease,
@@ -614,7 +655,8 @@
 }
 
 .home-system:hover {
-  border-color: color-mix(in oklch, var(--home-gold) 30%, transparent);
+  border-color: color-mix(in oklch, var(--stella-os-accent) 30%, transparent);
+  box-shadow: var(--shadow-md);
   transform: translateY(-2px);
 }
 
@@ -624,9 +666,9 @@
   justify-content: center;
   width: 2.5rem;
   height: 2.5rem;
-  border-radius: 8px;
-  background: color-mix(in oklch, var(--home-gold) 10%, transparent);
-  color: var(--home-gold);
+  border-radius: var(--radius-md);
+  background: var(--stella-os-accent-soft);
+  color: var(--stella-os-accent);
   margin-bottom: 1rem;
 }
 
@@ -634,7 +676,7 @@
   margin: 0 0 0.6rem;
   font-size: 1.1rem;
   font-weight: 650;
-  color: var(--home-ink);
+  color: var(--stella-os-ink);
 }
 
 .home-system-desc {
@@ -642,7 +684,7 @@
   font-size: 0.88rem;
   font-weight: 400;
   line-height: 1.7;
-  color: var(--home-muted);
+  color: var(--stella-os-muted);
 }
 
 .home-system-highlights {
@@ -656,9 +698,9 @@
 
 .home-system-highlights li {
   padding: 0.3rem 0.7rem;
-  border-radius: 6px;
-  background: color-mix(in oklch, var(--home-gold) 8%, transparent);
-  color: var(--home-gold);
+  border-radius: var(--radius-sm);
+  background: var(--stella-os-accent-soft);
+  color: var(--stella-os-accent);
   font-size: 0.72rem;
   font-weight: 500;
 }
@@ -667,19 +709,19 @@
 
 .home-pillars {
   padding: clamp(5rem, 9vw, 9rem) 0;
-  border-top: 1px solid var(--home-rule);
-  background: oklch(18% 0.018 245);
-  color: white;
+  border-top: 1px solid var(--stella-os-rule);
+  background: color-mix(in oklch, var(--stella-os-ink) 94%, var(--stella-os-accent) 6%);
+  color: var(--stella-os-surface);
 }
 
 .home-pillars-heading {
   margin: 0 0 3rem;
-  font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, Menlo, monospace;
+  font-family: var(--font-mono);
   font-size: 0.72rem;
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: var(--home-gold);
+  color: var(--stella-os-accent);
 }
 
 .home-pillars-list {
@@ -697,7 +739,7 @@
   gap: 1rem;
   align-items: baseline;
   padding: 2rem 0;
-  border-top: 1px solid color-mix(in oklch, white 12%, transparent);
+  border-top: 1px solid color-mix(in oklch, var(--stella-os-surface) 12%, transparent);
 }
 
 .home-pillar:last-child {
@@ -709,14 +751,14 @@
 }
 
 .home-pillar:hover .home-pillar-title {
-  color: var(--home-gold);
+  color: var(--stella-os-accent);
 }
 
 .home-pillar-num {
-  font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, Menlo, monospace;
+  font-family: var(--font-mono);
   font-size: 0.75rem;
   font-weight: 500;
-  color: var(--home-gold);
+  color: var(--stella-os-accent);
   letter-spacing: 0.02em;
 }
 
@@ -725,8 +767,8 @@
   font-size: clamp(1.3rem, 2.5vw, 1.65rem);
   font-weight: 720;
   line-height: 1.15;
-  letter-spacing: -0.015em;
-  color: color-mix(in oklch, var(--background) 94%, transparent);
+  letter-spacing: var(--letter-spacing);
+  color: color-mix(in oklch, var(--stella-os-surface) 94%, transparent);
 }
 
 .home-pillar-body {
@@ -735,14 +777,14 @@
   font-size: 0.92rem;
   font-weight: 400;
   line-height: 1.8;
-  color: color-mix(in oklch, var(--background) 56%, transparent);
+  color: color-mix(in oklch, var(--stella-os-surface) 56%, transparent);
 }
 
 /* ─── Capabilities ─── */
 
 .home-caps {
   padding: clamp(4rem, 6vw, 6rem) 0;
-  border-top: 1px solid var(--home-rule);
+  border-top: 1px solid var(--stella-os-rule);
 }
 
 .home-caps-header {
@@ -754,14 +796,14 @@
   font-size: clamp(2rem, 4vw, 3.2rem);
   font-weight: 760;
   line-height: 1.1;
-  letter-spacing: -0.025em;
-  color: var(--home-ink);
+  letter-spacing: var(--letter-spacing);
+  color: var(--stella-os-ink);
 }
 
 .home-section-sub {
   margin: 1rem 0 0;
   max-width: 38rem;
-  color: var(--home-muted);
+  color: var(--stella-os-muted);
   font-size: 1.05rem;
   font-weight: 400;
   line-height: 1.7;
@@ -776,13 +818,13 @@
 .home-cap-group-label {
   margin: 0 0 1.25rem;
   padding-bottom: 0.75rem;
-  border-bottom: 2px solid var(--home-gold);
-  font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, Menlo, monospace;
+  border-bottom: 2px solid var(--stella-os-accent);
+  font-family: var(--font-mono);
   font-size: 0.72rem;
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: var(--home-gold);
+  color: var(--stella-os-accent);
 }
 
 .home-cap-group-items {
@@ -798,14 +840,14 @@
   margin: 0 0 0.3rem;
   font-size: 0.9rem;
   font-weight: 650;
-  color: var(--home-ink);
+  color: var(--stella-os-ink);
 }
 
 .home-cap-inline-icon {
   width: 0.9rem;
   height: 0.9rem;
   flex-shrink: 0;
-  color: var(--home-gold);
+  color: var(--stella-os-accent);
 }
 
 .home-cap p {
@@ -813,15 +855,15 @@
   font-size: 0.82rem;
   font-weight: 400;
   line-height: 1.6;
-  color: var(--home-muted);
+  color: var(--stella-os-muted);
 }
 
 /* ─── CTA ─── */
 
 .home-cta {
   padding: clamp(5rem, 8vw, 8rem) 0;
-  border-top: 1px solid var(--home-rule);
-  background: oklch(96% 0.006 245);
+  border-top: 1px solid var(--stella-os-rule);
+  background: var(--stella-os-canvas-muted);
 }
 
 .home-cta-layout {
@@ -839,18 +881,18 @@
   display: grid;
   gap: 0.5rem;
   padding: 1.25rem;
-  border-radius: 10px;
-  background: oklch(18% 0.018 245);
-  color: white;
-  box-shadow: none;
+  border-radius: var(--radius-xl);
+  background: color-mix(in oklch, var(--stella-os-ink) 94%, var(--stella-os-accent) 6%);
+  color: var(--stella-os-surface);
+  box-shadow: var(--shadow-lg);
 }
 
 .home-terminal code {
   display: block;
   padding: 0.7rem 0.9rem;
-  border-radius: 8px;
-  background: color-mix(in oklch, var(--background) 8%, transparent);
-  font-family: "JetBrains Mono", "IBM Plex Mono", ui-monospace, Menlo, monospace;
+  border-radius: var(--radius-md);
+  background: color-mix(in oklch, var(--stella-os-surface) 8%, transparent);
+  font-family: var(--font-mono);
   font-size: 0.82rem;
   line-height: 1.5;
   white-space: nowrap;
@@ -858,7 +900,7 @@
 }
 
 .home-terminal-prompt {
-  color: var(--home-gold);
+  color: var(--stella-os-accent);
   margin-right: 0.5rem;
 }
 
@@ -866,7 +908,7 @@
   margin: 0.25rem 0 0;
   padding-inline: 0.9rem;
   font-size: 0.76rem;
-  color: color-mix(in oklch, var(--background) 52%, transparent);
+  color: color-mix(in oklch, var(--stella-os-surface) 52%, transparent);
   line-height: 1.5;
 }
 
@@ -1028,7 +1070,7 @@
 
   .home-product-panel {
     border-right: 0;
-    border-bottom: 1px solid var(--home-rule);
+    border-bottom: 1px solid var(--stella-os-rule);
   }
 
   .home-product-panel:last-child {

--- a/web/src/routes/index.css
+++ b/web/src/routes/index.css
@@ -1,16 +1,11 @@
 .home-page {
   background:
-    linear-gradient(
-      color-mix(in oklch, var(--stella-os-rule) 58%, transparent) 1px,
-      transparent 1px
+    radial-gradient(
+      circle at 82% 8%,
+      color-mix(in oklch, var(--stella-os-accent) 9%, transparent),
+      transparent 30rem
     ),
-    linear-gradient(
-      90deg,
-      color-mix(in oklch, var(--stella-os-rule) 58%, transparent) 1px,
-      transparent 1px
-    ),
-    var(--stella-os-canvas);
-  background-size: 56px 56px;
+    linear-gradient(180deg, var(--stella-os-canvas) 0%, var(--stella-os-canvas-muted) 100%);
   color: var(--stella-os-ink);
   font-family: var(--font-sans);
   font-variant-numeric: tabular-nums;
@@ -78,20 +73,48 @@
 /* ─── Hero ─── */
 
 .home-hero {
+  --hero-bg: var(--stella-os-canvas);
+  --hero-fg: var(--stella-os-ink);
+  --hero-muted: var(--stella-os-muted);
+  --hero-soft: color-mix(in oklch, var(--stella-os-surface) 88%, transparent);
+  --hero-rule: color-mix(in oklch, var(--stella-os-rule) 72%, transparent);
   position: relative;
-  padding: clamp(4.5rem, 8vw, 8rem) 0 clamp(3rem, 6vw, 6rem);
+  min-height: min(58rem, calc(100svh - 3.5rem));
+  padding: clamp(3.35rem, 5.4vw, 5.3rem) 0 clamp(3rem, 5vw, 4.25rem);
+  background:
+    linear-gradient(var(--hero-rule) 1px, transparent 1px),
+    linear-gradient(90deg, var(--hero-rule) 1px, transparent 1px),
+    linear-gradient(
+      180deg,
+      color-mix(in oklch, var(--stella-os-canvas) 96%, var(--stella-os-accent) 4%) 0%,
+      var(--stella-os-canvas) 58%,
+      var(--stella-os-canvas-muted) 100%
+    );
+  background-size:
+    56px 56px,
+    56px 56px,
+    auto;
+  color: var(--hero-fg);
   overflow: hidden;
 }
 
 .home-hero-grain {
   position: absolute;
-  inset: 0;
-  background: linear-gradient(
-    180deg,
-    color-mix(in oklch, var(--stella-os-surface) 78%, transparent),
-    transparent 42%
-  );
-  opacity: 0.75;
+  inset: auto -10% -34% 45%;
+  height: 42rem;
+  background:
+    radial-gradient(
+      circle at 44% 45%,
+      color-mix(in oklch, var(--stella-os-accent) 18%, transparent),
+      transparent 66%
+    ),
+    radial-gradient(
+      circle at 76% 26%,
+      color-mix(in oklch, var(--stella-os-success) 10%, transparent),
+      transparent 42%
+    );
+  filter: blur(8px);
+  opacity: 0.8;
   pointer-events: none;
 }
 
@@ -101,10 +124,10 @@
   display: flex;
   justify-content: space-between;
   gap: 1rem;
-  margin-bottom: 2rem;
-  padding: 0.7rem 0;
-  border-block: 1px solid var(--stella-os-rule);
-  color: var(--stella-os-muted);
+  margin-bottom: 2.35rem;
+  padding: 0.75rem 0;
+  border-block: 1px solid var(--hero-rule);
+  color: var(--hero-muted);
   font-family: var(--font-mono);
   font-size: 0.72rem;
   text-transform: uppercase;
@@ -113,8 +136,8 @@
 
 .home-hero-layout {
   display: grid;
-  grid-template-columns: minmax(19rem, 0.82fr) minmax(0, 1.18fr);
-  gap: clamp(2rem, 4vw, 4rem);
+  grid-template-columns: minmax(21rem, 0.86fr) minmax(0, 1.14fr);
+  gap: clamp(2.5rem, 5vw, 5rem);
   align-items: center;
 }
 
@@ -124,19 +147,26 @@
 }
 
 .home-hero-title {
-  margin: 1.75rem 0 1.5rem;
-  max-width: 13ch;
-  font-size: clamp(3rem, 7.2vw, 6.9rem);
-  font-weight: 760;
-  line-height: 0.88;
+  margin: 1.45rem 0 1.3rem;
+  max-width: 12ch;
+  font-size: clamp(3.05rem, 5.65vw, 5.85rem);
+  font-weight: 800;
+  line-height: 0.95;
   letter-spacing: var(--letter-spacing);
-  color: var(--stella-os-ink);
+  color: var(--hero-fg);
+  text-wrap: balance;
+}
+
+.home-hero-title span,
+.home-hero-title em {
+  display: block;
 }
 
 .home-hero-title em {
   font-style: normal;
   color: var(--stella-os-accent);
   position: relative;
+  z-index: 0;
 }
 
 .home-hero-title em::after {
@@ -144,19 +174,21 @@
   position: absolute;
   left: -0.05em;
   right: -0.05em;
-  bottom: 0.02em;
-  height: 0.08em;
-  background: color-mix(in oklch, var(--stella-os-accent) 22%, transparent);
+  bottom: 0;
+  height: 0.11em;
+  background: color-mix(in oklch, var(--stella-os-accent) 16%, transparent);
   border-radius: 0.06em;
+  z-index: -1;
 }
 
 .home-hero-body {
-  max-width: 33rem;
+  max-width: 34rem;
   margin: 0;
-  color: var(--stella-os-muted);
-  font-size: 1rem;
+  color: var(--hero-muted);
+  font-size: 1.02rem;
   font-weight: 400;
   line-height: 1.7;
+  text-wrap: pretty;
 }
 
 .home-actions {
@@ -201,13 +233,13 @@
 }
 
 .home-btn-ghost {
-  border: 1px solid var(--stella-os-rule);
-  color: var(--stella-os-ink);
-  background: var(--stella-os-surface);
+  border: 1px solid var(--hero-rule);
+  color: var(--hero-fg);
+  background: color-mix(in oklch, var(--stella-os-surface) 74%, transparent);
 }
 
 .home-btn-ghost:hover {
-  background: var(--stella-os-canvas-muted);
+  background: var(--stella-os-surface);
   transform: translateY(-1px);
 }
 
@@ -216,16 +248,16 @@
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 0;
   margin: 2rem 0 0;
-  border: 1px solid var(--stella-os-rule);
+  border: 1px solid var(--hero-rule);
   border-radius: var(--radius-lg);
-  background: color-mix(in oklch, var(--stella-os-surface) 82%, transparent);
+  background: color-mix(in oklch, var(--stella-os-surface) 76%, transparent);
   overflow: hidden;
 }
 
 .home-hero-metrics div {
   min-width: 0;
   padding: 0.85rem;
-  border-right: 1px solid var(--stella-os-rule);
+  border-right: 1px solid var(--hero-rule);
 }
 
 .home-hero-metrics div:last-child {
@@ -234,7 +266,7 @@
 
 .home-hero-metrics dt {
   margin: 0 0 0.35rem;
-  color: var(--stella-os-muted);
+  color: color-mix(in oklch, var(--hero-muted) 70%, transparent);
   font-family: var(--font-mono);
   font-size: 0.64rem;
   text-transform: uppercase;
@@ -243,376 +275,159 @@
 
 .home-hero-metrics dd {
   margin: 0;
-  color: var(--stella-os-ink);
+  color: var(--hero-fg);
   font-size: 0.78rem;
   font-weight: 650;
   line-height: 1.35;
 }
 
-/* ─── Product Preview ─── */
+/* ─── Workflow Preview ─── */
 
-.home-product {
+.home-workflow-preview {
   position: relative;
-  border: 1px solid var(--stella-os-rule);
-  border-radius: var(--radius-xl);
-  background: var(--stella-os-surface);
-  overflow: hidden;
-  box-shadow: var(--shadow-xl);
+  display: grid;
+  gap: 0.9rem;
+  padding: 1rem;
+  border: 1px solid var(--hero-rule);
+  border-radius: var(--radius-2xl);
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklch, var(--stella-os-surface) 98%, var(--stella-os-accent) 2%),
+    color-mix(in oklch, var(--stella-os-surface) 78%, var(--stella-os-canvas-muted))
+  );
+  box-shadow:
+    0 1px 0 color-mix(in oklch, var(--stella-os-surface) 80%, transparent) inset,
+    0 28px 80px color-mix(in oklch, var(--stella-os-ink) 12%, transparent);
   animation: fade-up 900ms cubic-bezier(0.16, 1, 0.3, 1) 300ms both;
 }
 
-.home-product-chrome {
-  display: flex;
-  align-items: center;
-  gap: 0.55rem;
-  padding: 0.7rem 0.85rem;
-  border-bottom: 1px solid var(--stella-os-rule);
-  background: var(--stella-os-canvas-muted);
-}
-
-.home-product-status {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--stella-os-success);
-  box-shadow: 0 0 0 4px color-mix(in oklch, var(--stella-os-success) 14%, transparent);
-}
-
-.home-product-chrome-label {
-  color: var(--stella-os-muted);
-  font-family: var(--font-mono);
-  font-size: 0.64rem;
-  font-weight: 650;
-  letter-spacing: 0.06em;
-}
-
-.home-product-title {
-  margin: 0 0 0 auto;
-  font-family: var(--font-mono);
-  font-size: 0.68rem;
-  font-weight: 500;
-  color: var(--stella-os-muted);
-  letter-spacing: 0.02em;
-}
-
-.home-product-body {
-  display: grid;
-  grid-template-columns: 0.86fr 1.25fr 0.92fr;
-  gap: 0;
-  min-height: 410px;
-}
-
-.home-product-panel {
-  min-width: 0;
-  padding: 1rem;
-  border-right: 1px solid var(--stella-os-rule);
-  background: var(--stella-os-surface);
-}
-
-.home-product-panel:last-child {
-  border-right: 0;
-}
-
-.home-product-panel-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  margin-bottom: 0.9rem;
-  color: var(--stella-os-muted);
-  font-family: var(--font-mono);
-  font-size: 0.68rem;
-  font-weight: 650;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.home-product-panel-head-sub {
-  margin: 1rem 0 0.7rem;
-  color: color-mix(in oklch, var(--stella-os-muted) 78%, transparent);
-  font-size: 0.62rem;
-}
-
-.home-app-nav {
-  display: grid;
-  gap: 0.35rem;
-}
-
-.home-app-nav span {
-  display: flex;
-  align-items: center;
-  min-height: 2rem;
-  padding: 0.35rem 0.6rem;
-  border-radius: var(--radius-md);
-  color: var(--stella-os-muted);
-  font-size: 0.75rem;
-  font-weight: 600;
-}
-
-.home-app-nav span.is-active {
-  background: var(--stella-os-accent-soft);
-  color: var(--stella-os-accent);
-}
-
-.home-agent-list {
-  display: grid;
-  gap: 0.6rem;
-}
-
-.home-agent-row {
-  padding: 0.72rem;
-  border: 1px solid var(--stella-os-rule);
-  border-radius: var(--radius-md);
-  background: var(--stella-os-surface-raised);
-}
-
-.home-agent-row.is-active {
-  border-color: color-mix(in oklch, var(--stella-os-accent) 44%, var(--stella-os-rule));
-  background: var(--stella-os-accent-soft);
-}
-
-.home-agent-row div {
-  display: grid;
-  gap: 0.22rem;
-}
-
-.home-agent-row strong {
-  color: var(--stella-os-ink);
-  font-size: 0.82rem;
-}
-
-.home-agent-row span,
-.home-agent-row small {
-  color: var(--stella-os-muted);
-  font-size: 0.68rem;
-  line-height: 1.35;
-}
-
-.home-agent-row small {
-  display: inline-block;
-  margin-top: 0.55rem;
-  font-family: var(--font-mono);
-}
-
-.home-agent-policy {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.45rem;
-  margin-top: 1rem;
-  padding-top: 0.9rem;
-  border-top: 1px dashed var(--stella-os-rule);
-  color: var(--stella-os-accent);
-  font-size: 0.72rem;
-  line-height: 1.45;
-}
-
-.home-product-panel-work {
-  background:
-    linear-gradient(
-      color-mix(in oklch, var(--stella-os-rule) 42%, transparent) 1px,
-      transparent 1px
-    ),
-    linear-gradient(
-      90deg,
-      color-mix(in oklch, var(--stella-os-rule) 42%, transparent) 1px,
-      transparent 1px
-    ),
-    var(--stella-os-canvas);
-  background-size: 28px 28px;
-}
-
-.home-goal-card {
-  padding: 0.9rem;
-  border: 1px solid var(--stella-os-rule);
-  border-radius: var(--radius-md);
-  background: var(--stella-os-surface);
-}
-
-.home-goal-card p {
-  margin: 0;
-  color: var(--stella-os-ink);
-  font-size: 0.83rem;
-  line-height: 1.55;
-}
-
-.home-goal-meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
-  margin-top: 0.8rem;
-}
-
-.home-goal-meta span {
-  padding: 0.25rem 0.45rem;
-  border: 1px solid var(--stella-os-rule);
-  border-radius: calc(var(--radius-sm) * 0.72);
-  background: var(--stella-os-canvas-muted);
-  color: var(--stella-os-muted);
-  font-family: var(--font-mono);
-  font-size: 0.61rem;
-}
-
-.home-task-dag {
-  position: relative;
-  display: grid;
-  gap: 0.62rem;
-  margin-top: 1rem;
-}
-
-.home-task-node {
-  position: relative;
-  display: grid;
-  grid-template-columns: 2rem 1fr auto;
-  gap: 0.6rem;
-  align-items: center;
-  min-height: 2.65rem;
-  padding: 0.62rem 0.7rem;
-  border: 1px solid var(--stella-os-rule);
-  border-radius: var(--radius-md);
-  background: var(--stella-os-surface);
-}
-
-.home-task-node::before {
+.home-workflow-preview::before {
   content: "";
   position: absolute;
-  left: 1.68rem;
-  top: -0.64rem;
-  width: 1px;
-  height: 0.64rem;
-  background: var(--stella-os-rule);
-}
-
-.home-task-node:first-child::before {
-  display: none;
-}
-
-.home-task-node span,
-.home-task-node small {
-  font-family: var(--font-mono);
-  font-size: 0.64rem;
-  color: var(--stella-os-muted);
-}
-
-.home-task-node strong {
-  min-width: 0;
-  color: var(--stella-os-ink);
-  font-size: 0.78rem;
-  line-height: 1.35;
-}
-
-.home-task-node.is-done {
-  border-color: color-mix(in oklch, var(--stella-os-success) 34%, var(--stella-os-rule));
-}
-
-.home-task-node.is-done small {
-  color: var(--stella-os-success);
-}
-
-.home-task-node.is-blocked {
-  border-color: color-mix(in oklch, var(--stella-os-warning) 48%, var(--stella-os-rule));
-  background: color-mix(in oklch, var(--stella-os-warning) 12%, var(--stella-os-surface));
-}
-
-.home-task-node.is-blocked small {
-  color: color-mix(in oklch, var(--stella-os-warning) 82%, var(--stella-os-ink));
-}
-
-.home-task-node.is-review {
-  border-color: color-mix(in oklch, var(--stella-os-accent) 42%, var(--stella-os-rule));
-  background: var(--stella-os-accent-soft);
-}
-
-.home-task-node.is-review small {
-  color: var(--stella-os-accent);
-}
-
-.home-review-card {
-  padding: 0.85rem;
-  border: 1px solid color-mix(in oklch, var(--stella-os-warning) 48%, var(--stella-os-rule));
-  border-radius: var(--radius-md);
-  background: color-mix(in oklch, var(--stella-os-warning) 13%, var(--stella-os-surface));
-}
-
-.home-review-state {
-  display: inline-flex;
-  margin-bottom: 0.75rem;
-  color: color-mix(in oklch, var(--stella-os-warning) 82%, var(--stella-os-ink));
-  font-family: var(--font-mono);
-  font-size: 0.62rem;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-}
-
-.home-review-card strong {
-  display: block;
-  color: var(--stella-os-ink);
-  font-size: 0.84rem;
-  line-height: 1.35;
-}
-
-.home-review-card p {
-  margin: 0.6rem 0 0;
-  color: var(--stella-os-muted);
-  font-size: 0.72rem;
-  line-height: 1.55;
-}
-
-.home-review-actions {
-  display: grid;
-  gap: 0.55rem;
-  margin-top: 1rem;
-}
-
-.home-review-actions span {
-  padding: 0.55rem 0.65rem;
-  border: 1px solid var(--stella-os-rule);
-  border-radius: var(--radius-md);
-  background: var(--stella-os-surface-raised);
-  color: var(--stella-os-muted);
-  font-size: 0.72rem;
-}
-
-/* Feature badges */
-.home-product-features {
-  position: absolute;
-  inset: 0;
+  inset: 0.7rem;
+  z-index: -1;
+  border-radius: inherit;
+  background: color-mix(in oklch, var(--stella-os-accent) 12%, transparent);
+  filter: blur(34px);
+  opacity: 0.65;
   pointer-events: none;
 }
 
-.home-product-badge {
-  position: absolute;
-  display: inline-flex;
+.home-workflow-chrome {
+  display: flex;
   align-items: center;
-  gap: 0.35rem;
-  padding: 0.3rem 0.65rem;
-  border-radius: var(--radius-md);
-  background: var(--stella-os-surface-raised);
-  border: 1px solid var(--stella-os-rule);
-  font-size: 0.65rem;
-  font-weight: 500;
-  color: var(--stella-os-muted);
-  box-shadow: var(--shadow-lg);
-  opacity: 0;
-  animation: badge-in 600ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
-  white-space: nowrap;
+  justify-content: space-between;
+  min-height: 2.25rem;
+  padding: 0.35rem 0.55rem;
+  border: 1px solid var(--hero-rule);
+  border-radius: var(--radius-lg);
+  background: color-mix(in oklch, var(--stella-os-surface) 86%, transparent);
+  color: var(--hero-muted);
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
-.home-product-badge-1 {
-  top: 12%;
-  right: -3rem;
-  animation-delay: 1.2s;
+.home-workflow-chrome::before {
+  content: "";
+  width: 2.1rem;
+  height: 0.5rem;
+  border-radius: 999px;
+  background:
+    radial-gradient(circle, var(--stella-os-danger) 48%, transparent 52%) 0 50% / 0.5rem 0.5rem
+      no-repeat,
+    radial-gradient(circle, var(--stella-os-warning) 48%, transparent 52%) 0.8rem 50% / 0.5rem
+      0.5rem no-repeat,
+    radial-gradient(circle, var(--stella-os-success) 48%, transparent 52%) 1.6rem 50% / 0.5rem
+      0.5rem no-repeat;
 }
 
-.home-product-badge-2 {
-  bottom: 30%;
-  right: -2.5rem;
-  animation-delay: 1.6s;
+.home-workflow-topline {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  color: var(--hero-muted);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  font-weight: 650;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
-.home-product-badge-3 {
-  bottom: 8%;
-  left: -2rem;
-  animation-delay: 2s;
+.home-workflow-rows {
+  display: grid;
+  gap: 0.75rem;
+  position: relative;
+  z-index: 1;
+}
+
+.home-workflow-row {
+  display: grid;
+  grid-template-columns: minmax(6.75rem, 0.58fr) minmax(14rem, 1.55fr) minmax(7.75rem, 0.74fr);
+  gap: 0.75rem;
+}
+
+.home-flow-cell {
+  min-width: 0;
+  min-height: 7rem;
+  padding: 1rem;
+  border: 1px solid var(--hero-rule);
+  border-radius: var(--radius-lg);
+  background: color-mix(in oklch, var(--stella-os-surface) 94%, transparent);
+  box-shadow: 0 1px 0 color-mix(in oklch, var(--stella-os-surface) 76%, transparent) inset;
+}
+
+.home-flow-cell strong {
+  display: block;
+  margin: 0.45rem 0 0.45rem;
+  color: var(--hero-fg);
+  font-size: 0.98rem;
+  font-weight: 760;
+}
+
+.home-flow-cell p {
+  margin: 0;
+  color: var(--hero-muted);
+  font-size: 0.76rem;
+  line-height: 1.55;
+}
+
+.home-flow-agent {
+  position: relative;
+  background: linear-gradient(
+    135deg,
+    color-mix(in oklch, var(--stella-os-accent) 90%, var(--stella-os-surface) 10%),
+    color-mix(in oklch, var(--stella-os-accent) 72%, var(--stella-os-ink) 28%)
+  );
+  border-color: color-mix(in oklch, var(--stella-os-accent) 54%, var(--hero-rule));
+  box-shadow:
+    0 1px 0 color-mix(in oklch, var(--stella-os-surface) 28%, transparent) inset,
+    0 16px 42px color-mix(in oklch, var(--stella-os-accent) 22%, transparent);
+}
+
+.home-flow-agent strong {
+  color: var(--primary-foreground);
+}
+
+.home-flow-agent p {
+  color: color-mix(in oklch, var(--primary-foreground) 78%, transparent);
+}
+
+.home-flow-label {
+  color: color-mix(in oklch, var(--hero-muted) 78%, transparent);
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.home-flow-agent .home-flow-label {
+  color: color-mix(in oklch, var(--primary-foreground) 62%, transparent);
 }
 
 /* ─── Systems ─── */
@@ -943,7 +758,6 @@
 .home-caps-header,
 .home-cta-copy,
 .home-terminal,
-.home-product-features,
 .home-system,
 .home-system--hero {
   opacity: 0;
@@ -958,7 +772,6 @@
 .home-caps-header.is-visible,
 .home-cta-copy.is-visible,
 .home-terminal.is-visible,
-.home-product-features.is-visible,
 .home-system.is-visible,
 .home-system--hero.is-visible {
   opacity: 1;
@@ -996,13 +809,27 @@
 
 @media (max-width: 920px) {
   .home-hero {
-    padding: 6rem 0 4rem;
+    min-height: auto;
+    padding: 4.5rem 0 3.5rem;
   }
 
   .home-hero-layout,
   .home-cta-layout {
     grid-template-columns: 1fr;
-    gap: 3rem;
+    gap: 1.75rem;
+  }
+
+  .home-hero-title {
+    max-width: 14ch;
+    font-size: clamp(2.65rem, 6.2vw, 3.45rem);
+  }
+
+  .home-actions {
+    margin-top: 1.5rem;
+  }
+
+  .home-hero-metrics {
+    display: none;
   }
 
   .home-system--hero {
@@ -1021,13 +848,13 @@
   .home-caps-groups {
     grid-template-columns: 1fr 1fr;
   }
-
-  .home-product-badge {
-    display: none;
-  }
 }
 
 @media (max-width: 680px) {
+  .home-workflow-row {
+    grid-template-columns: 1fr;
+  }
+
   .home-systems-grid {
     grid-template-columns: 1fr;
   }
@@ -1043,19 +870,28 @@
   }
 
   .home-hero {
-    padding: 4rem 0 3rem;
+    padding: 3rem 0 3rem;
+  }
+
+  .home-hero-frame {
+    margin-bottom: 1.35rem;
+    font-size: 0.64rem;
+    line-height: 1.35;
   }
 
   .home-hero-title {
-    font-size: clamp(1.8rem, 7vw, 2.4rem);
+    max-width: 12ch;
+    font-size: clamp(2.45rem, 12vw, 3.45rem);
+    line-height: 1;
   }
 
   .home-hero-body {
-    font-size: 1rem;
+    font-size: 0.95rem;
   }
 
   .home-actions {
     flex-direction: column;
+    margin-top: 1.5rem;
   }
 
   .home-btn {
@@ -1064,17 +900,44 @@
     min-height: 2.75rem;
   }
 
-  .home-product-body {
-    grid-template-columns: 1fr;
+  .home-workflow-topline {
+    flex-direction: column;
   }
 
-  .home-product-panel {
-    border-right: 0;
-    border-bottom: 1px solid var(--stella-os-rule);
+  .home-hero-metrics {
+    display: none;
   }
 
-  .home-product-panel:last-child {
-    border-bottom: 0;
+  .home-workflow-preview {
+    padding: 0.7rem;
+  }
+
+  .home-workflow-row {
+    grid-template-columns: minmax(4.75rem, 0.7fr) minmax(8.5rem, 1.38fr) minmax(4.75rem, 0.7fr);
+    gap: 0.45rem;
+  }
+
+  .home-flow-cell {
+    min-height: 5.1rem;
+    padding: 0.72rem;
+  }
+
+  .home-flow-cell strong {
+    margin: 0.3rem 0 0.25rem;
+    font-size: 0.82rem;
+  }
+
+  .home-flow-cell p {
+    font-size: 0.66rem;
+    line-height: 1.35;
+  }
+
+  .home-flow-cell:not(.home-flow-agent) p {
+    display: none;
+  }
+
+  .home-flow-label {
+    font-size: 0.54rem;
   }
 
   .home-pillar {
@@ -1089,7 +952,7 @@
 @media (prefers-reduced-motion: reduce) {
   .home-btn,
   .home-hero-copy,
-  .home-product {
+  .home-workflow-preview {
     animation: none !important;
     transition: none !important;
   }
@@ -1100,21 +963,11 @@
   .home-caps-header,
   .home-cta-copy,
   .home-terminal,
-  .home-product-features,
   .home-system,
   .home-system--hero {
     opacity: 1;
     transform: none;
     transition: none;
-  }
-
-  .home-product-badge {
-    animation: none;
-  }
-
-  .home-product-badge {
-    opacity: 1;
-    transform: none;
   }
 
   .home-progress {

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -463,16 +463,25 @@ function ProductPreview({ lang }: { lang: keyof typeof copy }) {
     <div className="home-product" aria-label={c.productLabel}>
       <div className="home-product-chrome">
         <span className="home-product-status" />
-        <span className="home-product-chrome-label">
-          {isZh ? "ORG WORKBENCH" : "ORG WORKBENCH"}
-        </span>
+        <span className="home-product-chrome-label">{isZh ? "STELLA OS" : "STELLA OS"}</span>
         <span className="home-product-title">{c.productLabel}</span>
       </div>
       <div className="home-product-body">
         <section className="home-product-panel home-product-panel-agents">
           <div className="home-product-panel-head">
-            <span>{isZh ? "共享 Agent" : "Shared agents"}</span>
+            <span>{isZh ? "Apps" : "Apps"}</span>
             <Bot className="size-4" />
+          </div>
+          <div
+            className="home-app-nav"
+            aria-label={isZh ? "Stella 应用导航" : "Stella app navigation"}
+          >
+            <span className="is-active">{isZh ? "Agents" : "Agents"}</span>
+            <span>Recally</span>
+            <span>{isZh ? "Tasks" : "Tasks"}</span>
+          </div>
+          <div className="home-product-panel-head home-product-panel-head-sub">
+            <span>{isZh ? "共享 Agent" : "Shared agents"}</span>
           </div>
           <div className="home-agent-list">
             {agents.map(([name, desc, meta], index) => (

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -2,7 +2,6 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
 import {
   ArrowRight,
-  Sparkles,
   Shield,
   MessageCircle,
   Clock,
@@ -323,7 +322,6 @@ const ICON_MAP = {
   shield: Shield,
   message: MessageCircle,
   clock: Clock,
-  sparkles: Sparkles,
   users: Users,
   bot: Bot,
   zap: Zap,
@@ -362,12 +360,33 @@ function Home() {
 function HeroSection({ lang }: { lang: keyof typeof copy }) {
   const tr = t(lang);
   const c = copy[lang];
+  const isZh = lang === "zh";
+  const metrics = isZh
+    ? [
+        ["Agent", "财务 / HR / 工程"],
+        ["Work", "Goal 到任务 DAG"],
+        ["Review", "验收 + 人工确认"],
+      ]
+    : [
+        ["Agent", "Finance / HR / Eng"],
+        ["Work", "Goal to task DAG"],
+        ["Review", "Criteria + approval"],
+      ];
 
   return (
     <section className="home-hero">
-      <div className="home-hero-orb" />
       <div className="home-hero-grain" />
       <div className="home-shell">
+        <div className="home-hero-frame">
+          <span>
+            {isZh ? "Self-hosted agent operating surface" : "Self-hosted agent operating surface"}
+          </span>
+          <span>
+            {isZh
+              ? "Multi-user / shared agents / reviewable work"
+              : "Multi-user / shared agents / reviewable work"}
+          </span>
+        </div>
         <div className="home-hero-layout">
           <div className="home-hero-copy">
             <span className="home-eyebrow">{c.heroEyebrow}</span>
@@ -392,6 +411,17 @@ function HeroSection({ lang }: { lang: keyof typeof copy }) {
                 {tr.sourceOnGithub}
               </a>
             </div>
+            <dl
+              className="home-hero-metrics"
+              aria-label={isZh ? "Stella 核心模型" : "Stella operating model"}
+            >
+              {metrics.map(([label, value]) => (
+                <div key={label}>
+                  <dt>{label}</dt>
+                  <dd>{value}</dd>
+                </div>
+              ))}
+            </dl>
           </div>
 
           <ProductPreview lang={lang} />
@@ -404,95 +434,116 @@ function HeroSection({ lang }: { lang: keyof typeof copy }) {
 function ProductPreview({ lang }: { lang: keyof typeof copy }) {
   const c = copy[lang];
   const isZh = lang === "zh";
+  const agents = isZh
+    ? [
+        ["Finance", "报销 / 发票 / 审批", "4.2k memories"],
+        ["HR", "内推 / 筛选 / 面试", "12 workflows"],
+        ["Engineering", "评审 / 发布 / 事故", "38 skills"],
+      ]
+    : [
+        ["Finance", "Reimbursements / invoices", "4.2k memories"],
+        ["HR", "Referrals / screening", "12 workflows"],
+        ["Engineering", "Review / release / incidents", "38 skills"],
+      ];
+  const tasks = isZh
+    ? [
+        ["01", "提取票据字段", "done"],
+        ["02", "检查报销制度", "done"],
+        ["03", "补齐参与人名单", "blocked"],
+        ["04", "财务 review", "review"],
+      ]
+    : [
+        ["01", "Extract receipt fields", "done"],
+        ["02", "Check reimbursement policy", "done"],
+        ["03", "Collect attendee details", "blocked"],
+        ["04", "Finance review", "review"],
+      ];
 
   return (
     <div className="home-product" aria-label={c.productLabel}>
       <div className="home-product-chrome">
-        <span className="home-product-dot" />
-        <span className="home-product-dot" />
-        <span className="home-product-dot" />
+        <span className="home-product-status" />
+        <span className="home-product-chrome-label">
+          {isZh ? "ORG WORKBENCH" : "ORG WORKBENCH"}
+        </span>
         <span className="home-product-title">{c.productLabel}</span>
       </div>
       <div className="home-product-body">
-        <div className="home-product-sidebar">
-          <div className="home-product-nav-item home-product-nav-active">
-            <Bot className="size-3.5" />
-            <span>{isZh ? "财务 Agent" : "Finance Agent"}</span>
+        <section className="home-product-panel home-product-panel-agents">
+          <div className="home-product-panel-head">
+            <span>{isZh ? "共享 Agent" : "Shared agents"}</span>
+            <Bot className="size-4" />
           </div>
-          <div className="home-product-nav-item">
-            <ListTodo className="size-3.5" />
-            <span>{isZh ? "任务 DAG" : "Task DAG"}</span>
-          </div>
-          <div className="home-product-nav-item">
-            <BookOpen className="size-3.5" />
-            <span>{isZh ? "阅读" : "Recally"}</span>
-          </div>
-          <div className="home-product-nav-item">
-            <CalendarClock className="size-3.5" />
-            <span>{isZh ? "调度" : "Scheduler"}</span>
-          </div>
-          <div className="home-product-nav-item">
-            <ListTodo className="size-3.5" />
-            <span>{isZh ? "任务" : "Tasks"}</span>
-          </div>
-        </div>
-
-        <div className="home-product-chat">
-          <div className="home-product-msg home-product-msg-user">
-            <p>
-              {isZh
-                ? "帮我处理这次客户晚餐报销。检查材料是否完整，需要 review 的地方请建任务"
-                : "Help me prepare this client dinner reimbursement. Check what is missing and create review tasks if needed"}
-            </p>
-          </div>
-          <div className="home-product-msg home-product-msg-assistant">
-            <div className="home-product-avatar">S</div>
-            <div className="home-product-msg-content">
-              <div className="home-product-tool">
-                <Zap className="size-3" />
-                <span>{isZh ? "读取票据和制度" : "read receipts and policy"}</span>
-                <span className="home-product-tool-status">✓</span>
+          <div className="home-agent-list">
+            {agents.map(([name, desc, meta], index) => (
+              <div
+                key={name}
+                className={index === 0 ? "home-agent-row is-active" : "home-agent-row"}
+              >
+                <div>
+                  <strong>{name}</strong>
+                  <span>{desc}</span>
+                </div>
+                <small>{meta}</small>
               </div>
-              <div className="home-product-tool">
-                <Zap className="size-3" />
-                <span>{isZh ? "生成任务 DAG" : "create task DAG"}</span>
-                <span className="home-product-tool-status">✓</span>
-              </div>
-              <p>
-                {isZh
-                  ? "我已拆成 4 个任务：提取票据信息、检查报销制度、补齐参与人名单、提交财务 review。"
-                  : "I split this into 4 tasks: extract receipt data, check policy, collect attendee details, and route finance review."}
-              </p>
-            </div>
+            ))}
           </div>
-          <div className="home-product-msg home-product-msg-user">
-            <p>
-              {isZh
-                ? "把例外项发给财务，其他材料先准备好"
-                : "Send exceptions to finance and prepare the rest of the packet"}
-            </p>
-          </div>
-          <div className="home-product-msg home-product-msg-assistant">
-            <div className="home-product-avatar">S</div>
-            <div className="home-product-msg-content">
-              <div className="home-product-tool home-product-tool-running">
-                <Zap className="size-3" />
-                <span>{isZh ? "等待财务 review" : "waiting for finance review"}</span>
-                <span className="home-product-dots">
-                  <span />
-                  <span />
-                  <span />
-                </span>
-              </div>
-            </div>
-          </div>
-
-          <div className="home-product-input">
-            <span className="home-product-input-placeholder">
-              {isZh ? "发送消息..." : "Send a message..."}
+          <div className="home-agent-policy">
+            <Lock className="size-3.5" />
+            <span>
+              {isZh ? "每用户记忆 + 共享知识边界" : "Per-user memory + shared knowledge boundary"}
             </span>
           </div>
-        </div>
+        </section>
+
+        <section className="home-product-panel home-product-panel-work">
+          <div className="home-product-panel-head">
+            <span>{isZh ? "Goal intake" : "Goal intake"}</span>
+            <MessageCircle className="size-4" />
+          </div>
+          <div className="home-goal-card">
+            <p>
+              {isZh
+                ? "检查客户晚餐报销材料；缺什么告诉我，有例外就安排财务 review。"
+                : "Check this client dinner reimbursement. Tell me what is missing and route exceptions to finance review."}
+            </p>
+            <div className="home-goal-meta">
+              <span>{isZh ? "Agent: Finance" : "Agent: Finance"}</span>
+              <span>{isZh ? "Tools: files, policy, notify" : "Tools: files, policy, notify"}</span>
+            </div>
+          </div>
+          <div className="home-task-dag" aria-label={isZh ? "任务 DAG" : "Task DAG"}>
+            {tasks.map(([id, title, state]) => (
+              <div key={id} className={`home-task-node is-${state}`}>
+                <span>{id}</span>
+                <strong>{title}</strong>
+                <small>{state}</small>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="home-product-panel home-product-panel-review">
+          <div className="home-product-panel-head">
+            <span>{isZh ? "Review queue" : "Review queue"}</span>
+            <Shield className="size-4" />
+          </div>
+          <div className="home-review-card">
+            <span className="home-review-state">{isZh ? "NEEDS HUMAN" : "NEEDS HUMAN"}</span>
+            <strong>
+              {isZh ? "票据金额超出团队晚餐阈值" : "Receipt exceeds team dinner threshold"}
+            </strong>
+            <p>
+              {isZh
+                ? "Agent 已引用制度条款并准备 review packet。"
+                : "Agent cited the policy rule and prepared the review packet."}
+            </p>
+          </div>
+          <div className="home-review-actions">
+            <span>{isZh ? "验收标准 4/5" : "Criteria 4/5"}</span>
+            <span>{isZh ? "等待财务确认" : "Waiting on finance"}</span>
+          </div>
+        </section>
       </div>
 
       <div className="home-product-features">

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -10,11 +10,11 @@ import {
   Bot,
   Zap,
   BookOpen,
-  Lock,
   Plug,
   CalendarClock,
   ListTodo,
   Rss,
+  type LucideIcon,
 } from "lucide-react";
 import { siGithub } from "simple-icons";
 import { t } from "@/lib/docs/translations";
@@ -28,7 +28,7 @@ function useReveal() {
     const el = ref.current;
     if (!el) return;
     const targets = el.querySelectorAll(
-      ".home-pillar, .home-cap, .home-caps-header, .home-cta-copy, .home-terminal, .home-product, .home-product-features, .home-system, .home-system--hero",
+      ".home-pillar, .home-cap, .home-caps-header, .home-cta-copy, .home-terminal, .home-system, .home-system--hero",
     );
     const observer = new IntersectionObserver(
       (entries) => {
@@ -67,9 +67,9 @@ export const Route = createFileRoute("/")({ component: Home });
 const copy = {
   en: {
     heroEyebrow: "Shared AI coworkers",
-    heroTitle: ["Give every team", "professional", "agents."],
+    heroTitle: ["Skip specialist software.", "Give the goal", "to the agent that knows the work."],
     heroSub:
-      "Stella lets domain owners create shared agents with instructions, skills, tools, knowledge, and memory rules. Everyone else just chats, gives the agent a goal, and tracks the work.",
+      "Finance, HR, research, and engineering teams create shared agents with instructions, skills, tools, knowledge, and memory rules. Everyone else just chats with the right agent and gives it a goal.",
     productLabel: "stella — goal workspace",
     systemsTitle: "From shared expertise to finished work",
     systemsSub:
@@ -192,12 +192,39 @@ const copy = {
     ctaSub:
       "Start locally, create one shared professional agent, then add users, tools, tasks, and channels.",
     ctaAlt: "Also available via go install and direct binary download.",
+    workflowLabel: "How work moves",
+    workflowRows: [
+      {
+        owner: "HR",
+        ownerBody: "Defines referral rules, candidate screens, and interview steps.",
+        agent: "Referral Agent",
+        agentBody: "Reads candidate material, plans screening tasks, and routes follow-up.",
+        user: "Employee",
+        userBody: '"Help me process this referral."',
+      },
+      {
+        owner: "Finance",
+        ownerBody: "Maintains expense policy, invoice knowledge, and approval boundaries.",
+        agent: "Expense Agent",
+        agentBody: "Checks receipts, asks for missing details, and sends exceptions to review.",
+        user: "Sales",
+        userBody: '"Can this receipt be reimbursed?"',
+      },
+      {
+        owner: "Research",
+        ownerBody: "Subscribes to feeds, curates reading lists, and sets summary rules.",
+        agent: "Recally Agent",
+        agentBody: "Summarizes pages and PDFs, then keeps the conversation grounded.",
+        user: "Anyone",
+        userBody: '"What changed on this topic lately?"',
+      },
+    ],
   },
   zh: {
     heroEyebrow: "共享 AI 同事",
-    heroTitle: ["为每个团队创建", "专业", "Agent。"],
+    heroTitle: ["不用学习专业软件。", "把目标交给", "懂业务的 Agent。"],
     heroSub:
-      "Stella 让业务负责人创建带 instructions、skills、tools、knowledge 和记忆策略的共享 Agent。其他人只需要聊天、交付 goal，并追踪工作进展。",
+      "财务、HR、研究和工程团队创建带 instructions、skills、tools、knowledge 和记忆策略的共享 Agent。其他人只需要找到对应 Agent，像找同事一样说明目标。",
     productLabel: "stella — goal 工作区",
     systemsTitle: "从共享专业能力到完成工作",
     systemsSub: "一次创建专业 Agent，让组织像使用真正同事一样使用它。",
@@ -314,10 +341,37 @@ const copy = {
     ctaTitle: "自己运行",
     ctaSub: "从本地开始，创建一个共享专业 Agent，然后添加用户、tools、tasks 和渠道。",
     ctaAlt: "也支持 go install 和直接下载二进制文件。",
+    workflowLabel: "工作如何流转",
+    workflowRows: [
+      {
+        owner: "HR",
+        ownerBody: "定义内推规则、候选人筛选标准和面试流程。",
+        agent: "Referral Agent",
+        agentBody: "读取候选人材料，规划筛选任务，并安排下一步 follow-up。",
+        user: "员工",
+        userBody: "“帮我处理这个内推。”",
+      },
+      {
+        owner: "Finance",
+        ownerBody: "维护报销制度、发票知识库和审批边界。",
+        agent: "Expense Agent",
+        agentBody: "检查票据、拆任务、要求补充材料，并把例外送入 review。",
+        user: "销售",
+        userBody: "“这张票能报吗？”",
+      },
+      {
+        owner: "Research",
+        ownerBody: "订阅 RSS，维护主题、阅读列表和摘要规则。",
+        agent: "Recally Agent",
+        agentBody: "总结网页和 PDF，并围绕文章继续深入追问。",
+        user: "任何人",
+        userBody: "“这个主题最近有什么变化？”",
+      },
+    ],
   },
 };
 
-const ICON_MAP = {
+const ICON_MAP: Record<string, LucideIcon> = {
   brain: Brain,
   shield: Shield,
   message: MessageCircle,
@@ -326,7 +380,6 @@ const ICON_MAP = {
   bot: Bot,
   zap: Zap,
   book: BookOpen,
-  lock: Lock,
   plug: Plug,
   recally: Rss,
   scheduler: CalendarClock,
@@ -383,7 +436,7 @@ function HeroSection({ lang }: { lang: keyof typeof copy }) {
           </span>
           <span>
             {isZh
-              ? "Multi-user / shared agents / reviewable work"
+              ? "多用户 / 共享 Agent / 可 review 的工作"
               : "Multi-user / shared agents / reviewable work"}
           </span>
         </div>
@@ -391,7 +444,9 @@ function HeroSection({ lang }: { lang: keyof typeof copy }) {
           <div className="home-hero-copy">
             <span className="home-eyebrow">{c.heroEyebrow}</span>
             <h1 className="home-hero-title">
-              {c.heroTitle[0]} <em>{c.heroTitle[1]}</em> {c.heroTitle[2]}
+              <span>{c.heroTitle[0]}</span>
+              <em>{c.heroTitle[1]}</em>
+              <span>{c.heroTitle[2]}</span>
             </h1>
             <p className="home-hero-body">{c.heroSub}</p>
             <div className="home-actions">
@@ -424,150 +479,47 @@ function HeroSection({ lang }: { lang: keyof typeof copy }) {
             </dl>
           </div>
 
-          <ProductPreview lang={lang} />
+          <WorkflowPreview lang={lang} />
         </div>
       </div>
     </section>
   );
 }
 
-function ProductPreview({ lang }: { lang: keyof typeof copy }) {
+function WorkflowPreview({ lang }: { lang: keyof typeof copy }) {
   const c = copy[lang];
   const isZh = lang === "zh";
-  const agents = isZh
-    ? [
-        ["Finance", "报销 / 发票 / 审批", "4.2k memories"],
-        ["HR", "内推 / 筛选 / 面试", "12 workflows"],
-        ["Engineering", "评审 / 发布 / 事故", "38 skills"],
-      ]
-    : [
-        ["Finance", "Reimbursements / invoices", "4.2k memories"],
-        ["HR", "Referrals / screening", "12 workflows"],
-        ["Engineering", "Review / release / incidents", "38 skills"],
-      ];
-  const tasks = isZh
-    ? [
-        ["01", "提取票据字段", "done"],
-        ["02", "检查报销制度", "done"],
-        ["03", "补齐参与人名单", "blocked"],
-        ["04", "财务 review", "review"],
-      ]
-    : [
-        ["01", "Extract receipt fields", "done"],
-        ["02", "Check reimbursement policy", "done"],
-        ["03", "Collect attendee details", "blocked"],
-        ["04", "Finance review", "review"],
-      ];
 
   return (
-    <div className="home-product" aria-label={c.productLabel}>
-      <div className="home-product-chrome">
-        <span className="home-product-status" />
-        <span className="home-product-chrome-label">{isZh ? "STELLA OS" : "STELLA OS"}</span>
-        <span className="home-product-title">{c.productLabel}</span>
+    <div className="home-workflow-preview" aria-label={c.workflowLabel}>
+      <div className="home-workflow-chrome" aria-hidden>
+        <span>Stella OS</span>
+        <span>{isZh ? "Shared agents" : "Shared agents"}</span>
       </div>
-      <div className="home-product-body">
-        <section className="home-product-panel home-product-panel-agents">
-          <div className="home-product-panel-head">
-            <span>{isZh ? "Apps" : "Apps"}</span>
-            <Bot className="size-4" />
-          </div>
-          <div
-            className="home-app-nav"
-            aria-label={isZh ? "Stella 应用导航" : "Stella app navigation"}
-          >
-            <span className="is-active">{isZh ? "Agents" : "Agents"}</span>
-            <span>Recally</span>
-            <span>{isZh ? "Tasks" : "Tasks"}</span>
-          </div>
-          <div className="home-product-panel-head home-product-panel-head-sub">
-            <span>{isZh ? "共享 Agent" : "Shared agents"}</span>
-          </div>
-          <div className="home-agent-list">
-            {agents.map(([name, desc, meta], index) => (
-              <div
-                key={name}
-                className={index === 0 ? "home-agent-row is-active" : "home-agent-row"}
-              >
-                <div>
-                  <strong>{name}</strong>
-                  <span>{desc}</span>
-                </div>
-                <small>{meta}</small>
-              </div>
-            ))}
-          </div>
-          <div className="home-agent-policy">
-            <Lock className="size-3.5" />
-            <span>
-              {isZh ? "每用户记忆 + 共享知识边界" : "Per-user memory + shared knowledge boundary"}
-            </span>
-          </div>
-        </section>
-
-        <section className="home-product-panel home-product-panel-work">
-          <div className="home-product-panel-head">
-            <span>{isZh ? "Goal intake" : "Goal intake"}</span>
-            <MessageCircle className="size-4" />
-          </div>
-          <div className="home-goal-card">
-            <p>
-              {isZh
-                ? "检查客户晚餐报销材料；缺什么告诉我，有例外就安排财务 review。"
-                : "Check this client dinner reimbursement. Tell me what is missing and route exceptions to finance review."}
-            </p>
-            <div className="home-goal-meta">
-              <span>{isZh ? "Agent: Finance" : "Agent: Finance"}</span>
-              <span>{isZh ? "Tools: files, policy, notify" : "Tools: files, policy, notify"}</span>
+      <div className="home-workflow-topline">
+        <span>{c.workflowLabel}</span>
+        <span>{isZh ? "Owner / Agent / User" : "Owner / Agent / User"}</span>
+      </div>
+      <div className="home-workflow-rows">
+        {c.workflowRows.map((row) => (
+          <div key={row.agent} className="home-workflow-row">
+            <div className="home-flow-cell">
+              <span className="home-flow-label">{isZh ? "Owner" : "Owner"}</span>
+              <strong>{row.owner}</strong>
+              <p>{row.ownerBody}</p>
+            </div>
+            <div className="home-flow-cell home-flow-agent">
+              <span className="home-flow-label">{isZh ? "Agent" : "Agent"}</span>
+              <strong>{row.agent}</strong>
+              <p>{row.agentBody}</p>
+            </div>
+            <div className="home-flow-cell">
+              <span className="home-flow-label">{isZh ? "User" : "User"}</span>
+              <strong>{row.user}</strong>
+              <p>{row.userBody}</p>
             </div>
           </div>
-          <div className="home-task-dag" aria-label={isZh ? "任务 DAG" : "Task DAG"}>
-            {tasks.map(([id, title, state]) => (
-              <div key={id} className={`home-task-node is-${state}`}>
-                <span>{id}</span>
-                <strong>{title}</strong>
-                <small>{state}</small>
-              </div>
-            ))}
-          </div>
-        </section>
-
-        <section className="home-product-panel home-product-panel-review">
-          <div className="home-product-panel-head">
-            <span>{isZh ? "Review queue" : "Review queue"}</span>
-            <Shield className="size-4" />
-          </div>
-          <div className="home-review-card">
-            <span className="home-review-state">{isZh ? "NEEDS HUMAN" : "NEEDS HUMAN"}</span>
-            <strong>
-              {isZh ? "票据金额超出团队晚餐阈值" : "Receipt exceeds team dinner threshold"}
-            </strong>
-            <p>
-              {isZh
-                ? "Agent 已引用制度条款并准备 review packet。"
-                : "Agent cited the policy rule and prepared the review packet."}
-            </p>
-          </div>
-          <div className="home-review-actions">
-            <span>{isZh ? "验收标准 4/5" : "Criteria 4/5"}</span>
-            <span>{isZh ? "等待财务确认" : "Waiting on finance"}</span>
-          </div>
-        </section>
-      </div>
-
-      <div className="home-product-features">
-        <span className="home-product-badge home-product-badge-1">
-          <Brain className="size-3" />
-          {isZh ? "按用户记忆偏好" : "Per-user memory"}
-        </span>
-        <span className="home-product-badge home-product-badge-2">
-          <ListTodo className="size-3" />
-          {isZh ? "Goal 到任务 DAG" : "Goal to task DAG"}
-        </span>
-        <span className="home-product-badge home-product-badge-3">
-          <Lock className="size-3" />
-          {isZh ? "Review gate" : "Review gates"}
-        </span>
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
## What

- Redesigns the Stella landing hero around the clearer Owner / Agent / User workflow model.
- Replaces the dense product preview with a workflow board showing HR, Finance, and Research agents.
- Refines the hero copy to emphasize that users give goals to shared professional agents instead of learning specialist software.
- Aligns the page styling with Stella OS tokens from `globals.css`, including the light canvas, rule system, accent color, radii, and responsive behavior.

## Why

The previous landing page still required too much explanation. Stella's core value is easier to understand when the first screen shows the organizational pattern directly: domain experts create shared agents, everyone else chats with those agents, and work becomes reviewable tasks.

This PR keeps the docs/narrative work in the parent PR and isolates the higher-fidelity landing redesign as a stacked visual iteration.

## How

- Adds localized workflow rows for HR referral handling, Finance reimbursements, and Recally research workflows.
- Introduces `WorkflowPreview` and removes the older product-preview composition.
- Reworks the hero CSS into a light OS-style grid canvas with a high-contrast Agent column and compact mobile layout.
- Uses existing Stella OS variables instead of one-off page-specific color systems.

## Verification

- `mise run format`
- `mise run build`
- `mise run test`
- Opened `https://stella.localhost/` in the Codex in-app browser.
- Verified desktop 1440px and mobile 390px layouts: no horizontal overflow, desktop shows headline and workflow board in the first viewport, and mobile keeps the workflow preview reachable directly after the primary actions.

Stacked on: #255
