### PR TITLE
♻️ Unify user API routes and user-target authz

### DIFF
--- a/api/spec/domain/profile/paths.yaml
+++ b/api/spec/domain/profile/paths.yaml
@@ -1,6 +1,6 @@
 paths:
   # ── Identities ──────────────────────────────────────────────────────────────
-  /api/auth/profile/identities:
+  /api/users/me/identities:
     get:
       tags: [profile]
       summary: List linked identities for the current user
@@ -17,7 +17,7 @@ paths:
           $ref: "../../components.yaml#/components/responses/Unauthorized",
         }
 
-  /api/auth/profile/identities/{id}:
+  /api/users/me/identities/{id}:
     parameters:
       - {
           name: id,
@@ -41,7 +41,7 @@ paths:
         "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
         "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
 
-  /api/auth/profile/password:
+  /api/users/me/password:
     patch:
       tags: [profile]
       summary: Change the current user's password
@@ -65,7 +65,7 @@ paths:
           $ref: "../../components.yaml#/components/responses/Unauthorized",
         }
 
-  /api/auth/profile/link-code:
+  /api/users/me/link-code:
     post:
       tags: [profile]
       summary: Generate a short-lived link code for a platform
@@ -93,7 +93,7 @@ paths:
         }
 
   # ── Memories ────────────────────────────────────────────────────────────────
-  /api/auth/profile/memories:
+  /api/users/me/memories:
     get:
       tags: [profile]
       summary: List per-agent memories for the current user
@@ -110,7 +110,7 @@ paths:
           $ref: "../../components.yaml#/components/responses/Unauthorized",
         }
 
-  /api/auth/profile/memories/{agentId}:
+  /api/users/me/memories/{agentId}:
     parameters:
       - { name: agentId, in: path, required: true, schema: { type: string } }
     patch:
@@ -150,7 +150,7 @@ paths:
         }
 
   # ── Soul ────────────────────────────────────────────────────────────────────
-  /api/auth/profile/soul/{agentId}:
+  /api/users/me/soul/{agentId}:
     parameters:
       - { name: agentId, in: path, required: true, schema: { type: string } }
     patch:
@@ -180,7 +180,7 @@ paths:
         }
 
   # ── Vault ───────────────────────────────────────────────────────────────────
-  /api/auth/profile/vault:
+  /api/users/me/vault:
     get:
       tags: [profile]
       summary: List vault entries for the current user
@@ -197,7 +197,7 @@ paths:
           $ref: "../../components.yaml#/components/responses/Unauthorized",
         }
 
-  /api/auth/profile/vault/{name}:
+  /api/users/me/vault/{name}:
     parameters:
       - { name: name, in: path, required: true, schema: { type: string } }
     get:
@@ -253,7 +253,7 @@ paths:
         }
 
   # ── OAuth ───────────────────────────────────────────────────────────────────
-  /api/auth/profile/oauth/providers:
+  /api/users/me/oauth/providers:
     get:
       tags: [profile]
       summary: List OAuth provider statuses for the current user
@@ -270,7 +270,7 @@ paths:
           $ref: "../../components.yaml#/components/responses/Unauthorized",
         }
 
-  /api/auth/profile/oauth/{provider}/start:
+  /api/users/me/oauth/{provider}/start:
     parameters:
       - { name: provider, in: path, required: true, schema: { type: string } }
     post:
@@ -292,7 +292,7 @@ paths:
           $ref: "../../components.yaml#/components/responses/Unauthorized",
         }
 
-  /api/auth/profile/oauth/{provider}/status/{flowId}:
+  /api/users/me/oauth/{provider}/status/{flowId}:
     parameters:
       - { name: provider, in: path, required: true, schema: { type: string } }
       - { name: flowId, in: path, required: true, schema: { type: string } }
@@ -315,7 +315,7 @@ paths:
           $ref: "../../components.yaml#/components/responses/Unauthorized",
         }
 
-  /api/auth/profile/oauth/{provider}/connected:
+  /api/users/me/oauth/{provider}/connected:
     parameters:
       - { name: provider, in: path, required: true, schema: { type: string } }
     get:
@@ -337,7 +337,7 @@ paths:
           $ref: "../../components.yaml#/components/responses/Unauthorized",
         }
 
-  /api/auth/profile/oauth/{provider}:
+  /api/users/me/oauth/{provider}:
     parameters:
       - { name: provider, in: path, required: true, schema: { type: string } }
     delete:
@@ -354,13 +354,33 @@ paths:
           $ref: "../../components.yaml#/components/responses/Unauthorized",
         }
 
-  /api/auth/profile/oauth/{provider}/callback:
+  /api/auth/oauth/{provider}/callback:
     parameters:
       - { name: provider, in: path, required: true, schema: { type: string } }
     get:
       tags: [profile]
       summary: OAuth callback (browser redirect, unauthenticated)
       operationId: oauthCallback
+      security: []
+      parameters:
+        - { name: code, in: query, required: true, schema: { type: string } }
+        - { name: state, in: query, required: true, schema: { type: string } }
+      responses:
+        "302":
+          description: redirect on success
+        "400":
+          description: bad request
+        "500":
+          description: internal server error
+
+  /api/auth/profile/oauth/{provider}/callback:
+    parameters:
+      - { name: provider, in: path, required: true, schema: { type: string } }
+    get:
+      tags: [profile]
+      summary: Deprecated OAuth callback alias (browser redirect, unauthenticated)
+      operationId: oauthCallbackLegacy
+      deprecated: true
       security: []
       parameters:
         - { name: code, in: query, required: true, schema: { type: string } }

--- a/api/spec/domain/users/paths.yaml
+++ b/api/spec/domain/users/paths.yaml
@@ -6,10 +6,12 @@ paths:
           in: path,
           required: true,
           schema: { type: string },
+          description: Canonical user ID,
+          or `me` for the current user.,
         }
     patch:
       tags: [users]
-      summary: Update the default agent for a user (admin only)
+      summary: Update the default agent for a user (admin or current user)
       operationId: updateUserDefaultAgent
       requestBody:
         required: true
@@ -33,6 +35,7 @@ paths:
           $ref: "../../components.yaml#/components/responses/Unauthorized",
         }
         "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
 
   /api/users/{id}/notify-identity:
     parameters:
@@ -41,10 +44,12 @@ paths:
           in: path,
           required: true,
           schema: { type: string },
+          description: Canonical user ID,
+          or `me` for the current user.,
         }
     patch:
       tags: [users]
-      summary: Update the notify identity for a user (admin only)
+      summary: Update the notify identity for a user (admin or current user)
       operationId: updateUserNotifyIdentity
       requestBody:
         required: true
@@ -68,6 +73,7 @@ paths:
           $ref: "../../components.yaml#/components/responses/Unauthorized",
         }
         "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
 
   /api/users/{id}/memories:
     parameters:
@@ -76,10 +82,12 @@ paths:
           in: path,
           required: true,
           schema: { type: string },
+          description: Canonical user ID,
+          or `me` for the current user.,
         }
     get:
       tags: [users]
-      summary: List memories for a user (admin only)
+      summary: List memories for a user (admin or current user)
       operationId: listUserMemories
       responses:
         "200":
@@ -96,6 +104,7 @@ paths:
           $ref: "../../components.yaml#/components/responses/Unauthorized",
         }
         "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
 
   /api/users/{id}/memories/{agentId}:
     parameters:
@@ -104,11 +113,13 @@ paths:
           in: path,
           required: true,
           schema: { type: string },
+          description: Canonical user ID,
+          or `me` for the current user.,
         }
       - { name: agentId, in: path, required: true, schema: { type: string } }
     patch:
       tags: [users]
-      summary: Set memory for a user and agent (admin only)
+      summary: Set memory for a user and agent (admin or current user)
       operationId: setUserMemory
       requestBody:
         required: true
@@ -132,9 +143,10 @@ paths:
           $ref: "../../components.yaml#/components/responses/Unauthorized",
         }
         "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
     delete:
       tags: [users]
-      summary: Delete memory for a user and agent (admin only)
+      summary: Delete memory for a user and agent (admin or current user)
       operationId: deleteUserMemory
       responses:
         "204":
@@ -143,11 +155,12 @@ paths:
           $ref: "../../components.yaml#/components/responses/Unauthorized",
         }
         "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
 
-  /api/auth/users:
+  /api/users:
     get:
-      tags: [auth-users]
-      summary: List all auth users (admin only)
+      tags: [users]
+      summary: List users (admin only)
       operationId: listAuthUsers
       parameters:
         - {
@@ -175,7 +188,7 @@ paths:
         }
         "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
 
-  /api/auth/users/{id}:
+  /api/users/{id}:
     parameters:
       - {
           name: id,
@@ -184,8 +197,8 @@ paths:
           schema: { type: string },
         }
     get:
-      tags: [auth-users]
-      summary: Get an auth user by ID (admin only)
+      tags: [users]
+      summary: Get a user by ID (admin or current user)
       operationId: getAuthUser
       responses:
         "200":
@@ -201,7 +214,7 @@ paths:
         "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
         "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
 
-  /api/auth/users/{id}/role:
+  /api/users/{id}/role:
     parameters:
       - {
           name: id,
@@ -210,8 +223,8 @@ paths:
           schema: { type: string },
         }
     patch:
-      tags: [auth-users]
-      summary: Update the role of an auth user (admin only)
+      tags: [users]
+      summary: Update the role of a user (admin only)
       operationId: updateAuthUserRole
       requestBody:
         required: true
@@ -236,7 +249,7 @@ paths:
         }
         "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
 
-  /api/auth/users/{id}/agents:
+  /api/users/{id}/agents:
     parameters:
       - {
           name: id,
@@ -245,8 +258,8 @@ paths:
           schema: { type: string },
         }
     get:
-      tags: [auth-users]
-      summary: List agents assigned to an auth user (admin only)
+      tags: [users]
+      summary: List agents assigned to a user (admin only)
       operationId: listAuthUserAgents
       responses:
         "200":
@@ -261,8 +274,8 @@ paths:
         }
         "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
     patch:
-      tags: [auth-users]
-      summary: Update agents assigned to an auth user (admin only)
+      tags: [users]
+      summary: Update agents assigned to a user (admin only)
       operationId: updateAuthUserAgents
       requestBody:
         required: true
@@ -287,12 +300,12 @@ paths:
         }
         "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
 
-  /api/auth/users/{id}/identities/login:
+  /api/users/{id}/identities/login:
     parameters:
       - { name: id, in: path, required: true, schema: { type: string } }
     get:
-      tags: [auth-users]
-      summary: List OIDC login identities for an auth user (admin only)
+      tags: [users]
+      summary: List OIDC login identities for a user (admin only)
       operationId: listAuthUserLoginIdentities
       responses:
         "200":
@@ -308,8 +321,8 @@ paths:
         "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
         "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
     post:
-      tags: [auth-users]
-      summary: Link an OIDC login identity to an auth user (admin only)
+      tags: [users]
+      summary: Link an OIDC login identity to a user (admin only)
       operationId: linkAuthUserLoginIdentity
       requestBody:
         required: true
@@ -336,12 +349,12 @@ paths:
         "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
         "409": { $ref: "../../components.yaml#/components/responses/Conflict" }
 
-  /api/auth/users/{id}/identities/channel:
+  /api/users/{id}/identities/channel:
     parameters:
       - { name: id, in: path, required: true, schema: { type: string } }
     get:
-      tags: [auth-users]
-      summary: List channel identities for an auth user (admin only)
+      tags: [users]
+      summary: List channel identities for a user (admin only)
       operationId: listAuthUserChannelIdentities
       responses:
         "200":
@@ -357,7 +370,7 @@ paths:
         "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
         "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
 
-  /api/auth/users/{id}/identities/{identityId}:
+  /api/users/{id}/identities/{identityId}:
     parameters:
       - {
           name: id,
@@ -372,8 +385,8 @@ paths:
           schema: { type: string },
         }
     delete:
-      tags: [auth-users]
-      summary: Delete an identity linked to an auth user (admin only)
+      tags: [users]
+      summary: Delete an identity linked to a user (admin only)
       operationId: deleteAuthUserIdentity
       responses:
         "204":
@@ -387,7 +400,7 @@ paths:
         "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
         "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
 
-  /api/auth/users/{id}/active:
+  /api/users/{id}/active:
     parameters:
       - {
           name: id,
@@ -396,8 +409,8 @@ paths:
           schema: { type: string },
         }
     patch:
-      tags: [auth-users]
-      summary: Update the active status of an auth user (admin only)
+      tags: [users]
+      summary: Update the active status of a user (admin only)
       operationId: updateAuthUserActive
       requestBody:
         required: true

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -181,51 +181,53 @@ paths:
   /api/users/{id}/memories/{agentId}:
     $ref: "./domain/users/paths.yaml#/paths/~1api~1users~1{id}~1memories~1{agentId}"
   # ── Auth Users ─────────────────────────────────────────────────────────────
-  /api/auth/users:
-    $ref: "./domain/users/paths.yaml#/paths/~1api~1auth~1users"
-  /api/auth/users/{id}:
-    $ref: "./domain/users/paths.yaml#/paths/~1api~1auth~1users~1{id}"
-  /api/auth/users/{id}/role:
-    $ref: "./domain/users/paths.yaml#/paths/~1api~1auth~1users~1{id}~1role"
-  /api/auth/users/{id}/agents:
-    $ref: "./domain/users/paths.yaml#/paths/~1api~1auth~1users~1{id}~1agents"
-  /api/auth/users/{id}/identities/login:
-    $ref: "./domain/users/paths.yaml#/paths/~1api~1auth~1users~1{id}~1identities~1login"
-  /api/auth/users/{id}/identities/channel:
-    $ref: "./domain/users/paths.yaml#/paths/~1api~1auth~1users~1{id}~1identities~1channel"
-  /api/auth/users/{id}/identities/{identityId}:
-    $ref: "./domain/users/paths.yaml#/paths/~1api~1auth~1users~1{id}~1identities~1{identityId}"
-  /api/auth/users/{id}/active:
-    $ref: "./domain/users/paths.yaml#/paths/~1api~1auth~1users~1{id}~1active"
+  /api/users:
+    $ref: "./domain/users/paths.yaml#/paths/~1api~1users"
+  /api/users/{id}:
+    $ref: "./domain/users/paths.yaml#/paths/~1api~1users~1{id}"
+  /api/users/{id}/role:
+    $ref: "./domain/users/paths.yaml#/paths/~1api~1users~1{id}~1role"
+  /api/users/{id}/agents:
+    $ref: "./domain/users/paths.yaml#/paths/~1api~1users~1{id}~1agents"
+  /api/users/{id}/identities/login:
+    $ref: "./domain/users/paths.yaml#/paths/~1api~1users~1{id}~1identities~1login"
+  /api/users/{id}/identities/channel:
+    $ref: "./domain/users/paths.yaml#/paths/~1api~1users~1{id}~1identities~1channel"
+  /api/users/{id}/identities/{identityId}:
+    $ref: "./domain/users/paths.yaml#/paths/~1api~1users~1{id}~1identities~1{identityId}"
+  /api/users/{id}/active:
+    $ref: "./domain/users/paths.yaml#/paths/~1api~1users~1{id}~1active"
   # ── Profile ────────────────────────────────────────────────────────────────
-  /api/auth/profile/identities:
-    $ref: "./domain/profile/paths.yaml#/paths/~1api~1auth~1profile~1identities"
-  /api/auth/profile/identities/{id}:
-    $ref: "./domain/profile/paths.yaml#/paths/~1api~1auth~1profile~1identities~1{id}"
-  /api/auth/profile/password:
-    $ref: "./domain/profile/paths.yaml#/paths/~1api~1auth~1profile~1password"
-  /api/auth/profile/link-code:
-    $ref: "./domain/profile/paths.yaml#/paths/~1api~1auth~1profile~1link-code"
-  /api/auth/profile/memories:
-    $ref: "./domain/profile/paths.yaml#/paths/~1api~1auth~1profile~1memories"
-  /api/auth/profile/memories/{agentId}:
-    $ref: "./domain/profile/paths.yaml#/paths/~1api~1auth~1profile~1memories~1{agentId}"
-  /api/auth/profile/soul/{agentId}:
-    $ref: "./domain/profile/paths.yaml#/paths/~1api~1auth~1profile~1soul~1{agentId}"
-  /api/auth/profile/vault:
-    $ref: "./domain/profile/paths.yaml#/paths/~1api~1auth~1profile~1vault"
-  /api/auth/profile/vault/{name}:
-    $ref: "./domain/profile/paths.yaml#/paths/~1api~1auth~1profile~1vault~1{name}"
-  /api/auth/profile/oauth/providers:
-    $ref: "./domain/profile/paths.yaml#/paths/~1api~1auth~1profile~1oauth~1providers"
-  /api/auth/profile/oauth/{provider}/start:
-    $ref: "./domain/profile/paths.yaml#/paths/~1api~1auth~1profile~1oauth~1{provider}~1start"
-  /api/auth/profile/oauth/{provider}/status/{flowId}:
-    $ref: "./domain/profile/paths.yaml#/paths/~1api~1auth~1profile~1oauth~1{provider}~1status~1{flowId}"
-  /api/auth/profile/oauth/{provider}/connected:
-    $ref: "./domain/profile/paths.yaml#/paths/~1api~1auth~1profile~1oauth~1{provider}~1connected"
-  /api/auth/profile/oauth/{provider}:
-    $ref: "./domain/profile/paths.yaml#/paths/~1api~1auth~1profile~1oauth~1{provider}"
+  /api/users/me/identities:
+    $ref: "./domain/profile/paths.yaml#/paths/~1api~1users~1me~1identities"
+  /api/users/me/identities/{id}:
+    $ref: "./domain/profile/paths.yaml#/paths/~1api~1users~1me~1identities~1{id}"
+  /api/users/me/password:
+    $ref: "./domain/profile/paths.yaml#/paths/~1api~1users~1me~1password"
+  /api/users/me/link-code:
+    $ref: "./domain/profile/paths.yaml#/paths/~1api~1users~1me~1link-code"
+  /api/users/me/memories:
+    $ref: "./domain/profile/paths.yaml#/paths/~1api~1users~1me~1memories"
+  /api/users/me/memories/{agentId}:
+    $ref: "./domain/profile/paths.yaml#/paths/~1api~1users~1me~1memories~1{agentId}"
+  /api/users/me/soul/{agentId}:
+    $ref: "./domain/profile/paths.yaml#/paths/~1api~1users~1me~1soul~1{agentId}"
+  /api/users/me/vault:
+    $ref: "./domain/profile/paths.yaml#/paths/~1api~1users~1me~1vault"
+  /api/users/me/vault/{name}:
+    $ref: "./domain/profile/paths.yaml#/paths/~1api~1users~1me~1vault~1{name}"
+  /api/users/me/oauth/providers:
+    $ref: "./domain/profile/paths.yaml#/paths/~1api~1users~1me~1oauth~1providers"
+  /api/users/me/oauth/{provider}/start:
+    $ref: "./domain/profile/paths.yaml#/paths/~1api~1users~1me~1oauth~1{provider}~1start"
+  /api/users/me/oauth/{provider}/status/{flowId}:
+    $ref: "./domain/profile/paths.yaml#/paths/~1api~1users~1me~1oauth~1{provider}~1status~1{flowId}"
+  /api/users/me/oauth/{provider}/connected:
+    $ref: "./domain/profile/paths.yaml#/paths/~1api~1users~1me~1oauth~1{provider}~1connected"
+  /api/users/me/oauth/{provider}:
+    $ref: "./domain/profile/paths.yaml#/paths/~1api~1users~1me~1oauth~1{provider}"
+  /api/auth/oauth/{provider}/callback:
+    $ref: "./domain/profile/paths.yaml#/paths/~1api~1auth~1oauth~1{provider}~1callback"
   /api/auth/profile/oauth/{provider}/callback:
     $ref: "./domain/profile/paths.yaml#/paths/~1api~1auth~1profile~1oauth~1{provider}~1callback"
   # ── Admin: OAuth provider config ───────────────────────────────────────────

--- a/internal/credentials/service.go
+++ b/internal/credentials/service.go
@@ -154,7 +154,7 @@ func (s *Service) providerCredentialsWithOrigin(_ context.Context, providerID st
 	if origin != "" {
 		baseOrigin = origin
 	}
-	redirectFallback := baseOrigin + "/api/auth/profile/oauth/" + providerID + "/callback"
+	redirectFallback := baseOrigin + "/api/auth/oauth/" + providerID + "/callback"
 
 	// DB override wins over YAML default.
 	if s.q != nil {

--- a/internal/server/auth_users.go
+++ b/internal/server/auth_users.go
@@ -48,7 +48,7 @@ func (s *Server) buildAuthUserResponse(r *http.Request, u auth.User) (authUserRe
 	}, nil
 }
 
-// ListAuthUsers handles GET /api/auth/users.
+// ListAuthUsers handles GET /api/users.
 func (s *Server) ListAuthUsers(w http.ResponseWriter, r *http.Request, params apiserver.ListAuthUsersParams) {
 	info := requireAdmin(w, r)
 	if info == nil {
@@ -84,12 +84,13 @@ func (s *Server) ListAuthUsers(w http.ResponseWriter, r *http.Request, params ap
 	writeData(w, http.StatusOK, out)
 }
 
-// GetAuthUser handles GET /api/auth/users/{id}.
+// GetAuthUser handles GET /api/users/{id}.
 func (s *Server) GetAuthUser(w http.ResponseWriter, r *http.Request, id string) {
-	if requireAdmin(w, r) == nil {
+	_, targetUserID, ok := s.requireUserTarget(w, r, id)
+	if !ok {
 		return
 	}
-	s.writeAuthUser(w, r, id)
+	s.writeAuthUser(w, r, targetUserID)
 }
 
 // writeAuthUser loads the auth user by ID and writes the full AuthUser resource.
@@ -109,7 +110,7 @@ func (s *Server) writeAuthUser(w http.ResponseWriter, r *http.Request, id string
 	writeData(w, http.StatusOK, resp)
 }
 
-// UpdateAuthUserRole handles PATCH /api/auth/users/{id}/role.
+// UpdateAuthUserRole handles PATCH /api/users/{id}/role.
 func (s *Server) UpdateAuthUserRole(w http.ResponseWriter, r *http.Request, id string) {
 	info := requireAdmin(w, r)
 	if info == nil {
@@ -128,30 +129,33 @@ func (s *Server) UpdateAuthUserRole(w http.ResponseWriter, r *http.Request, id s
 		return
 	}
 
-	if info.UserID == id && body.Role != auth.RoleAdmin {
+	targetUserID := resolveTargetUserID(info, id)
+	if info.UserID == targetUserID && body.Role != auth.RoleAdmin {
 		writeError(w, http.StatusBadRequest, "cannot remove your own admin role")
 		return
 	}
 
-	if err := s.users.UpdateUserRole(r.Context(), id, body.Role); err != nil {
+	if err := s.users.UpdateUserRole(r.Context(), targetUserID, body.Role); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to update role: "+err.Error())
 		return
 	}
 
 	// Force re-authentication so new role takes effect in tokens.
 	if s.sessions != nil {
-		_ = s.sessions.DeleteUserSessions(r.Context(), id)
+		_ = s.sessions.DeleteUserSessions(r.Context(), targetUserID)
 	}
 
-	s.writeAuthUser(w, r, id)
+	s.writeAuthUser(w, r, targetUserID)
 }
 
-// ListAuthUserAgents handles GET /api/auth/users/{id}/agents.
+// ListAuthUserAgents handles GET /api/users/{id}/agents.
 func (s *Server) ListAuthUserAgents(w http.ResponseWriter, r *http.Request, id string) {
-	if requireAdmin(w, r) == nil {
+	info := requireAdmin(w, r)
+	if info == nil {
 		return
 	}
-	agentIDs, err := s.authStore.ListUserAgentIDs(r.Context(), id)
+	targetUserID := resolveTargetUserID(info, id)
+	agentIDs, err := s.authStore.ListUserAgentIDs(r.Context(), targetUserID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list user agents: "+err.Error())
 		return
@@ -160,11 +164,13 @@ func (s *Server) ListAuthUserAgents(w http.ResponseWriter, r *http.Request, id s
 	writeData(w, http.StatusOK, map[string]any{"agent_ids": agentIDs})
 }
 
-// UpdateAuthUserAgents handles PATCH /api/auth/users/{id}/agents.
+// UpdateAuthUserAgents handles PATCH /api/users/{id}/agents.
 func (s *Server) UpdateAuthUserAgents(w http.ResponseWriter, r *http.Request, id string) {
-	if requireAdmin(w, r) == nil {
+	info := requireAdmin(w, r)
+	if info == nil {
 		return
 	}
+	targetUserID := resolveTargetUserID(info, id)
 	var body struct {
 		AgentIDs []string `json:"agent_ids"`
 	}
@@ -174,7 +180,7 @@ func (s *Server) UpdateAuthUserAgents(w http.ResponseWriter, r *http.Request, id
 	}
 
 	// Verify user exists.
-	if _, err := s.users.GetUser(r.Context(), id); err != nil {
+	if _, err := s.users.GetUser(r.Context(), targetUserID); err != nil {
 		writeError(w, http.StatusNotFound, "user not found")
 		return
 	}
@@ -182,7 +188,7 @@ func (s *Server) UpdateAuthUserAgents(w http.ResponseWriter, r *http.Request, id
 	ctx := r.Context()
 
 	// Get current assignments.
-	currentIDs, err := s.authStore.ListUserAgentIDs(ctx, id)
+	currentIDs, err := s.authStore.ListUserAgentIDs(ctx, targetUserID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list current agents: "+err.Error())
 		return
@@ -200,8 +206,8 @@ func (s *Server) UpdateAuthUserAgents(w http.ResponseWriter, r *http.Request, id
 	// Remove agents not in desired set.
 	for _, aid := range currentIDs {
 		if !desiredSet[aid] {
-			if err := s.authStore.RemoveAgent(ctx, id, aid); err != nil {
-				s.log.Error("remove agent assignment", "user_id", id, "agent_id", aid, "error", err)
+			if err := s.authStore.RemoveAgent(ctx, targetUserID, aid); err != nil {
+				s.log.Error("remove agent assignment", "user_id", targetUserID, "agent_id", aid, "error", err)
 			}
 		}
 	}
@@ -209,13 +215,13 @@ func (s *Server) UpdateAuthUserAgents(w http.ResponseWriter, r *http.Request, id
 	// Add agents not in current set.
 	for _, aid := range body.AgentIDs {
 		if !currentSet[aid] {
-			if err := s.authStore.AssignAgent(ctx, id, aid); err != nil {
-				s.log.Error("assign agent", "user_id", id, "agent_id", aid, "error", err)
+			if err := s.authStore.AssignAgent(ctx, targetUserID, aid); err != nil {
+				s.log.Error("assign agent", "user_id", targetUserID, "agent_id", aid, "error", err)
 			}
 		}
 	}
 
-	updated, err := s.authStore.ListUserAgentIDs(ctx, id)
+	updated, err := s.authStore.ListUserAgentIDs(ctx, targetUserID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list user agents: "+err.Error())
 		return
@@ -223,11 +229,13 @@ func (s *Server) UpdateAuthUserAgents(w http.ResponseWriter, r *http.Request, id
 	writeData(w, http.StatusOK, map[string]any{"agent_ids": updated})
 }
 
-// DeleteAuthUserIdentity handles DELETE /api/auth/users/{id}/identities/{identityId}.
+// DeleteAuthUserIdentity handles DELETE /api/users/{id}/identities/{identityId}.
 func (s *Server) DeleteAuthUserIdentity(w http.ResponseWriter, r *http.Request, id string, identityId string) {
-	if requireAdmin(w, r) == nil {
+	info := requireAdmin(w, r)
+	if info == nil {
 		return
 	}
+	targetUserID := resolveTargetUserID(info, id)
 	if s.users == nil {
 		writeError(w, http.StatusServiceUnavailable, "channel identity store not configured")
 		return
@@ -241,7 +249,7 @@ func (s *Server) DeleteAuthUserIdentity(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
-	if identity.UserID != id {
+	if identity.UserID != targetUserID {
 		writeError(w, http.StatusBadRequest, "identity does not belong to this user")
 		return
 	}
@@ -255,12 +263,13 @@ func (s *Server) DeleteAuthUserIdentity(w http.ResponseWriter, r *http.Request, 
 	writeNoContent(w)
 }
 
-// UpdateAuthUserActive handles PATCH /api/auth/users/{id}/active.
+// UpdateAuthUserActive handles PATCH /api/users/{id}/active.
 func (s *Server) UpdateAuthUserActive(w http.ResponseWriter, r *http.Request, id string) {
 	info := requireAdmin(w, r)
 	if info == nil {
 		return
 	}
+	targetUserID := resolveTargetUserID(info, id)
 	var body struct {
 		IsActive bool `json:"is_active"`
 	}
@@ -269,43 +278,45 @@ func (s *Server) UpdateAuthUserActive(w http.ResponseWriter, r *http.Request, id
 		return
 	}
 
-	if info.UserID == id && !body.IsActive {
+	if info.UserID == targetUserID && !body.IsActive {
 		writeError(w, http.StatusBadRequest, "cannot deactivate your own account")
 		return
 	}
 
-	if _, err := s.users.GetUser(r.Context(), id); err != nil {
+	if _, err := s.users.GetUser(r.Context(), targetUserID); err != nil {
 		writeError(w, http.StatusNotFound, "user not found")
 		return
 	}
 
-	if err := s.users.UpdateUserActive(r.Context(), id, body.IsActive); err != nil {
+	if err := s.users.UpdateUserActive(r.Context(), targetUserID, body.IsActive); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to update active status: "+err.Error())
 		return
 	}
 
 	// If deactivating, delete all their sessions to force logout.
 	if !body.IsActive && s.sessions != nil {
-		_ = s.sessions.DeleteUserSessions(r.Context(), id)
+		_ = s.sessions.DeleteUserSessions(r.Context(), targetUserID)
 	}
 
-	s.writeAuthUser(w, r, id)
+	s.writeAuthUser(w, r, targetUserID)
 }
 
-// ListAuthUserLoginIdentities handles GET /api/auth/users/{id}/identities/login.
+// ListAuthUserLoginIdentities handles GET /api/users/{id}/identities/login.
 func (s *Server) ListAuthUserLoginIdentities(w http.ResponseWriter, r *http.Request, id string) {
-	if requireAdmin(w, r) == nil {
+	info := requireAdmin(w, r)
+	if info == nil {
 		return
 	}
+	targetUserID := resolveTargetUserID(info, id)
 	if s.logins == nil {
 		writeData(w, http.StatusOK, map[string]any{"identities": []auth.LoginIdentity{}})
 		return
 	}
-	if _, err := s.users.GetUser(r.Context(), id); err != nil {
+	if _, err := s.users.GetUser(r.Context(), targetUserID); err != nil {
 		writeError(w, http.StatusNotFound, "user not found")
 		return
 	}
-	identities, err := s.logins.ListLoginIdentitiesByUser(r.Context(), id)
+	identities, err := s.logins.ListLoginIdentitiesByUser(r.Context(), targetUserID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list login identities: "+err.Error())
 		return
@@ -313,11 +324,13 @@ func (s *Server) ListAuthUserLoginIdentities(w http.ResponseWriter, r *http.Requ
 	writeData(w, http.StatusOK, map[string]any{"identities": identities})
 }
 
-// LinkAuthUserLoginIdentity handles POST /api/auth/users/{id}/identities/login.
+// LinkAuthUserLoginIdentity handles POST /api/users/{id}/identities/login.
 func (s *Server) LinkAuthUserLoginIdentity(w http.ResponseWriter, r *http.Request, id string) {
-	if requireAdmin(w, r) == nil {
+	info := requireAdmin(w, r)
+	if info == nil {
 		return
 	}
+	targetUserID := resolveTargetUserID(info, id)
 	if s.logins == nil {
 		writeError(w, http.StatusServiceUnavailable, "login identity store not configured")
 		return
@@ -338,7 +351,7 @@ func (s *Server) LinkAuthUserLoginIdentity(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	if _, err := s.users.GetUser(r.Context(), id); err != nil {
+	if _, err := s.users.GetUser(r.Context(), targetUserID); err != nil {
 		writeError(w, http.StatusNotFound, "user not found")
 		return
 	}
@@ -349,39 +362,41 @@ func (s *Server) LinkAuthUserLoginIdentity(w http.ResponseWriter, r *http.Reques
 		writeError(w, http.StatusInternalServerError, "failed to check existing identity: "+err.Error())
 		return
 	}
-	if err == nil && existing.UserID != id {
+	if err == nil && existing.UserID != targetUserID {
 		writeError(w, http.StatusConflict, "identity is already linked to another user")
 		return
 	}
-	if err == nil && existing.UserID == id {
+	if err == nil && existing.UserID == targetUserID {
 		writeData(w, http.StatusOK, existing)
 		return
 	}
 
 	linked, err := s.logins.CreateLoginIdentity(r.Context(), auth.LoginIdentity{
 		ID:              uuid.NewString(),
-		UserID:          id,
+		UserID:          targetUserID,
 		Provider:        body.Provider,
 		ProviderSubject: body.ProviderSubject,
 		Email:           body.Email,
 		Name:            body.Name,
 	})
 	if err != nil {
-		s.log.Error("admin link login identity", "user_id", id, "provider", body.Provider, "error", err)
+		s.log.Error("admin link login identity", "user_id", targetUserID, "provider", body.Provider, "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to link identity: "+err.Error())
 		return
 	}
 
-	s.log.Info("admin linked login identity", "user_id", id, "provider", body.Provider, "subject", body.ProviderSubject)
+	s.log.Info("admin linked login identity", "user_id", targetUserID, "provider", body.Provider, "subject", body.ProviderSubject)
 	writeData(w, http.StatusOK, linked)
 }
 
-// ListAuthUserChannelIdentities handles GET /api/auth/users/{id}/identities/channel.
+// ListAuthUserChannelIdentities handles GET /api/users/{id}/identities/channel.
 func (s *Server) ListAuthUserChannelIdentities(w http.ResponseWriter, r *http.Request, id string) {
-	if requireAdmin(w, r) == nil {
+	info := requireAdmin(w, r)
+	if info == nil {
 		return
 	}
-	if _, err := s.users.GetUser(r.Context(), id); err != nil {
+	targetUserID := resolveTargetUserID(info, id)
+	if _, err := s.users.GetUser(r.Context(), targetUserID); err != nil {
 		writeError(w, http.StatusNotFound, "user not found")
 		return
 	}
@@ -389,7 +404,7 @@ func (s *Server) ListAuthUserChannelIdentities(w http.ResponseWriter, r *http.Re
 		writeData(w, http.StatusOK, map[string]any{"identities": []auth.ChannelIdentity{}})
 		return
 	}
-	identities, err := s.users.ListChannelIdentitiesByUser(r.Context(), id)
+	identities, err := s.users.ListChannelIdentitiesByUser(r.Context(), targetUserID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list channel identities: "+err.Error())
 		return

--- a/internal/server/auth_users_test.go
+++ b/internal/server/auth_users_test.go
@@ -15,7 +15,7 @@ import (
 func TestListAuthUsers(t *testing.T) {
 	env := setupAdmin(t)
 
-	rr := doRequest(t, env, "GET", "/api/auth/users", nil)
+	rr := doRequest(t, env, "GET", "/api/users", nil)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
 	}
@@ -56,7 +56,7 @@ func TestListAuthUsers(t *testing.T) {
 func TestGetAuthUser(t *testing.T) {
 	env := setupAdmin(t)
 
-	rr := doRequest(t, env, "GET", "/api/auth/users/"+env.adminUser.ID, nil)
+	rr := doRequest(t, env, "GET", "/api/users/"+env.adminUser.ID, nil)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
 	}
@@ -81,7 +81,7 @@ func TestGetAuthUser(t *testing.T) {
 func TestGetAuthUserNotFound(t *testing.T) {
 	env := setupAdmin(t)
 
-	rr := doRequest(t, env, "GET", "/api/auth/users/99999", nil)
+	rr := doRequest(t, env, "GET", "/api/users/99999", nil)
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusNotFound)
 	}
@@ -93,7 +93,7 @@ func TestUpdateAuthUserRolePromote(t *testing.T) {
 	user, _ := createTestUserWithToken(t, env.authStore, env.oidcStore, "regular1", auth.RoleUser)
 
 	body := map[string]string{"role": "admin"}
-	rr := doRequest(t, env, "PATCH", "/api/auth/users/"+user.ID+"/role", body)
+	rr := doRequest(t, env, "PATCH", "/api/users/"+user.ID+"/role", body)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
 	}
@@ -105,7 +105,7 @@ func TestUpdateAuthUserRoleDemote(t *testing.T) {
 	user, _ := createTestUserWithToken(t, env.authStore, env.oidcStore, "admin2", auth.RoleAdmin)
 
 	body := map[string]string{"role": "user"}
-	rr := doRequest(t, env, "PATCH", "/api/auth/users/"+user.ID+"/role", body)
+	rr := doRequest(t, env, "PATCH", "/api/users/"+user.ID+"/role", body)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
 	}
@@ -115,7 +115,7 @@ func TestCannotDemoteSelf(t *testing.T) {
 	env := setupAdmin(t)
 
 	body := map[string]string{"role": "user"}
-	rr := doRequest(t, env, "PATCH", "/api/auth/users/"+env.adminUser.ID+"/role", body)
+	rr := doRequest(t, env, "PATCH", "/api/users/"+env.adminUser.ID+"/role", body)
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusBadRequest, rr.Body.String())
 	}
@@ -125,7 +125,7 @@ func TestUpdateAuthUserRoleInvalid(t *testing.T) {
 	env := setupAdmin(t)
 
 	body := map[string]string{"role": "superadmin"}
-	rr := doRequest(t, env, "PATCH", "/api/auth/users/"+env.adminUser.ID+"/role", body)
+	rr := doRequest(t, env, "PATCH", "/api/users/"+env.adminUser.ID+"/role", body)
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusBadRequest)
 	}
@@ -139,7 +139,7 @@ func TestListAndUpdateAuthUserAgents(t *testing.T) {
 	uid := user.ID
 
 	// List agents - initially empty.
-	rr := doRequest(t, env, "GET", "/api/auth/users/"+uid+"/agents", nil)
+	rr := doRequest(t, env, "GET", "/api/users/"+uid+"/agents", nil)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("list status = %d, want %d", rr.Code, http.StatusOK)
 	}
@@ -151,13 +151,13 @@ func TestListAndUpdateAuthUserAgents(t *testing.T) {
 
 	stellaID := findStellaID(t, env)
 	body := map[string]any{"agent_ids": []string{stellaID}}
-	rr = doRequest(t, env, "PATCH", "/api/auth/users/"+uid+"/agents", body)
+	rr = doRequest(t, env, "PATCH", "/api/users/"+uid+"/agents", body)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("update status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
 	}
 
 	// Verify assignment.
-	rr = doRequest(t, env, "GET", "/api/auth/users/"+uid+"/agents", nil)
+	rr = doRequest(t, env, "GET", "/api/users/"+uid+"/agents", nil)
 	_ = json.Unmarshal(parseListItems(t, rr, "agent_ids"), &agentIDs)
 	if len(agentIDs) != 1 || agentIDs[0] != stellaID {
 		t.Errorf("expected [%s], got %v", stellaID, agentIDs)
@@ -165,13 +165,13 @@ func TestListAndUpdateAuthUserAgents(t *testing.T) {
 
 	// Remove by setting empty.
 	body = map[string]any{"agent_ids": []string{}}
-	rr = doRequest(t, env, "PATCH", "/api/auth/users/"+uid+"/agents", body)
+	rr = doRequest(t, env, "PATCH", "/api/users/"+uid+"/agents", body)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("update status = %d, want %d", rr.Code, http.StatusOK)
 	}
 
 	// Verify empty.
-	rr = doRequest(t, env, "GET", "/api/auth/users/"+uid+"/agents", nil)
+	rr = doRequest(t, env, "GET", "/api/users/"+uid+"/agents", nil)
 	_ = json.Unmarshal(parseListItems(t, rr, "agent_ids"), &agentIDs)
 	if len(agentIDs) != 0 {
 		t.Errorf("expected 0 agents after removal, got %d", len(agentIDs))
@@ -185,13 +185,13 @@ func TestUpdateAuthUserActive(t *testing.T) {
 
 	// Deactivate.
 	body := map[string]any{"is_active": false}
-	rr := doRequest(t, env, "PATCH", "/api/auth/users/"+user.ID+"/active", body)
+	rr := doRequest(t, env, "PATCH", "/api/users/"+user.ID+"/active", body)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("deactivate status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
 	}
 
 	// Verify deactivated.
-	rr = doRequest(t, env, "GET", "/api/auth/users/"+user.ID, nil)
+	rr = doRequest(t, env, "GET", "/api/users/"+user.ID, nil)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("get status = %d, want %d", rr.Code, http.StatusOK)
 	}
@@ -208,7 +208,7 @@ func TestUpdateAuthUserActive(t *testing.T) {
 
 	// Reactivate.
 	body = map[string]any{"is_active": true}
-	rr = doRequest(t, env, "PATCH", "/api/auth/users/"+user.ID+"/active", body)
+	rr = doRequest(t, env, "PATCH", "/api/users/"+user.ID+"/active", body)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("reactivate status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
 	}
@@ -218,7 +218,7 @@ func TestCannotDeactivateSelf(t *testing.T) {
 	env := setupAdmin(t)
 
 	body := map[string]any{"is_active": false}
-	rr := doRequest(t, env, "PATCH", "/api/auth/users/"+env.adminUser.ID+"/active", body)
+	rr := doRequest(t, env, "PATCH", "/api/users/"+env.adminUser.ID+"/active", body)
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusBadRequest, rr.Body.String())
 	}
@@ -240,7 +240,7 @@ func TestListAuthUserLoginIdentitiesEmpty(t *testing.T) {
 	env := setupAdmin(t)
 	setupOIDCStore(t, env)
 
-	rr := doRequest(t, env, "GET", "/api/auth/users/"+env.adminUser.ID+"/identities/login", nil)
+	rr := doRequest(t, env, "GET", "/api/users/"+env.adminUser.ID+"/identities/login", nil)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
 	}
@@ -255,7 +255,7 @@ func TestListAuthUserLoginIdentitiesUserNotFound(t *testing.T) {
 	env := setupAdmin(t)
 	setupOIDCStore(t, env)
 
-	rr := doRequest(t, env, "GET", "/api/auth/users/nonexistent/identities/login", nil)
+	rr := doRequest(t, env, "GET", "/api/users/nonexistent/identities/login", nil)
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusNotFound)
 	}
@@ -282,7 +282,7 @@ func TestLinkAuthUserLoginIdentity(t *testing.T) {
 		"email":            "testadmin@example.com",
 		"name":             "Test Admin",
 	}
-	rr := doRequest(t, env, "POST", "/api/auth/users/"+env.adminUser.ID+"/identities/login", body)
+	rr := doRequest(t, env, "POST", "/api/users/"+env.adminUser.ID+"/identities/login", body)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
 	}
@@ -335,7 +335,7 @@ func TestLinkLoginIdentityOwnedByAnotherUserIsConflict(t *testing.T) {
 		"provider_subject": "sub-abc",
 		"email":            "shared@example.com",
 	}
-	rr := doRequest(t, env, "POST", "/api/auth/users/"+u2.ID+"/identities/login", body)
+	rr := doRequest(t, env, "POST", "/api/users/"+u2.ID+"/identities/login", body)
 	if rr.Code != http.StatusConflict {
 		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusConflict, rr.Body.String())
 	}
@@ -366,7 +366,7 @@ func TestLinkLoginIdentityIdempotent(t *testing.T) {
 		"provider_subject": u.ID,
 		"email":            u.Email,
 	}
-	rr := doRequest(t, env, "POST", "/api/auth/users/"+u.ID+"/identities/login", body)
+	rr := doRequest(t, env, "POST", "/api/users/"+u.ID+"/identities/login", body)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
 	}
@@ -389,7 +389,7 @@ func TestListAuthUserChannelIdentities(t *testing.T) {
 		t.Fatalf("CreateChannelIdentity: %v", err)
 	}
 
-	rr := doRequest(t, env, "GET", "/api/auth/users/"+env.adminUser.ID+"/identities/channel", nil)
+	rr := doRequest(t, env, "GET", "/api/users/"+env.adminUser.ID+"/identities/channel", nil)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
 	}
@@ -409,7 +409,7 @@ func TestListAuthUserChannelIdentitiesUserNotFound(t *testing.T) {
 	env := setupAdmin(t)
 	setupOIDCStore(t, env)
 
-	rr := doRequest(t, env, "GET", "/api/auth/users/nonexistent/identities/channel", nil)
+	rr := doRequest(t, env, "GET", "/api/users/nonexistent/identities/channel", nil)
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusNotFound)
 	}
@@ -432,7 +432,7 @@ func TestAuthUserWithLinkedIdentities(t *testing.T) {
 	}
 
 	// Get user details — should include the identity.
-	rr := doRequest(t, env, "GET", "/api/auth/users/"+env.adminUser.ID, nil)
+	rr := doRequest(t, env, "GET", "/api/users/"+env.adminUser.ID, nil)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
 	}

--- a/internal/server/integration_test.go
+++ b/internal/server/integration_test.go
@@ -156,18 +156,27 @@ func TestDeactivatedUserBlockedOnSessionAuth(t *testing.T) {
 func TestNonAdminCannotAccessAdminEndpoints(t *testing.T) {
 	env := setupAdmin(t)
 
-	_, userToken := createTestUserWithToken(t, env.authStore, env.oidcStore, "regular", auth.RoleUser)
+	user, userToken := createTestUserWithToken(t, env.authStore, env.oidcStore, "regular", auth.RoleUser)
+
+	rr := doBearerRequest(t, env.srv, userToken, "GET", "/api/users/"+user.ID, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET own user: status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
+	}
+
+	rr = doBearerRequest(t, env.srv, userToken, "GET", "/api/users/"+env.adminUser.ID, nil)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("GET other user: status = %d, want %d (body: %s)", rr.Code, http.StatusNotFound, rr.Body.String())
+	}
 
 	adminPaths := []struct {
 		method string
 		path   string
 	}{
-		{"GET", "/api/auth/users"},
-		{"GET", "/api/auth/users/" + env.adminUser.ID},
-		{"PATCH", "/api/auth/users/" + env.adminUser.ID + "/role"},
-		{"PATCH", "/api/auth/users/" + env.adminUser.ID + "/active"},
-		{"GET", "/api/auth/users/" + env.adminUser.ID + "/agents"},
-		{"PATCH", "/api/auth/users/" + env.adminUser.ID + "/agents"},
+		{"GET", "/api/users"},
+		{"PATCH", "/api/users/" + env.adminUser.ID + "/role"},
+		{"PATCH", "/api/users/" + env.adminUser.ID + "/active"},
+		{"GET", "/api/users/" + env.adminUser.ID + "/agents"},
+		{"PATCH", "/api/users/" + env.adminUser.ID + "/agents"},
 	}
 
 	for _, tc := range adminPaths {
@@ -176,6 +185,35 @@ func TestNonAdminCannotAccessAdminEndpoints(t *testing.T) {
 			t.Errorf("%s %s: status = %d, want %d (body: %s)",
 				tc.method, tc.path, rr.Code, http.StatusForbidden, rr.Body.String())
 		}
+	}
+}
+
+func TestLegacyUserRoutesRemoved(t *testing.T) {
+	env := setupAdmin(t)
+
+	for _, path := range []string{"/api/auth/users", "/api/auth/profile/identities"} {
+		rr := doRequest(t, env, "GET", path, nil)
+		if rr.Code != http.StatusNotFound {
+			t.Fatalf("GET %s: status = %d, want %d (body: %s)", path, rr.Code, http.StatusNotFound, rr.Body.String())
+		}
+	}
+}
+
+func TestLegacyOAuthCallbackAliasRemainsPublic(t *testing.T) {
+	env := setupAdmin(t)
+
+	rr := doUnauthRequest(t, env.srv, "GET", "/api/auth/profile/oauth/feishu/callback?code=x&state=y", nil)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("legacy callback alias: status = %d, want %d (body: %s)", rr.Code, http.StatusServiceUnavailable, rr.Body.String())
+	}
+}
+
+func TestAdminSelfMemoryRejectsUnknownAgent(t *testing.T) {
+	env := setupAdmin(t)
+
+	rr := doRequest(t, env, "PATCH", "/api/users/me/memories/not-an-agent", map[string]string{"content": "memory"})
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusNotFound, rr.Body.String())
 	}
 }
 
@@ -201,6 +239,49 @@ func TestNonAdminCanAccessOwnProfile(t *testing.T) {
 	}
 	if me.IsAdmin {
 		t.Error("expected is_admin = false for regular user")
+	}
+}
+
+func TestUserNotifyIdentityRequiresOwnedIdentity(t *testing.T) {
+	env := setupAdmin(t)
+	ctx := context.Background()
+
+	user, userToken := createTestUserWithToken(t, env.authStore, env.oidcStore, "notifyuser", auth.RoleUser)
+	other, _ := createTestUserWithToken(t, env.authStore, env.oidcStore, "notifyother", auth.RoleUser)
+	owned, err := env.oidcStore.CreateChannelIdentity(ctx, auth.ChannelIdentity{
+		ID:         uuid.NewString(),
+		UserID:     user.ID,
+		Platform:   "telegram",
+		ExternalID: "tg-notify-user",
+		Name:       "Notify User",
+	})
+	if err != nil {
+		t.Fatalf("CreateChannelIdentity owned: %v", err)
+	}
+	foreign, err := env.oidcStore.CreateChannelIdentity(ctx, auth.ChannelIdentity{
+		ID:         uuid.NewString(),
+		UserID:     other.ID,
+		Platform:   "telegram",
+		ExternalID: "tg-notify-other",
+		Name:       "Notify Other",
+	})
+	if err != nil {
+		t.Fatalf("CreateChannelIdentity foreign: %v", err)
+	}
+
+	rr := doBearerRequest(t, env.srv, userToken, "PATCH", "/api/users/me/notify-identity", map[string]any{"notify_identity_id": owned.ID})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("set owned identity: status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
+	}
+
+	rr = doBearerRequest(t, env.srv, userToken, "PATCH", "/api/users/me/notify-identity", map[string]any{"notify_identity_id": foreign.ID})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("set foreign identity: status = %d, want %d (body: %s)", rr.Code, http.StatusBadRequest, rr.Body.String())
+	}
+
+	rr = doBearerRequest(t, env.srv, userToken, "PATCH", "/api/users/me/notify-identity", map[string]any{"notify_identity_id": nil})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("clear identity: status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
 	}
 }
 
@@ -241,7 +322,7 @@ func TestRoleDemotionInvalidatesSessions(t *testing.T) {
 
 	// Demote via the admin API (using the original admin's bearer token).
 	body := map[string]string{"role": "user"}
-	rr = doRequest(t, env, "PATCH", "/api/auth/users/"+result.User.ID+"/role", body)
+	rr = doRequest(t, env, "PATCH", "/api/users/"+result.User.ID+"/role", body)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("demote: status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
 	}
@@ -284,7 +365,7 @@ func TestDeactivationInvalidatesSessions(t *testing.T) {
 	}
 
 	// Deactivate via admin API.
-	rr = doRequest(t, env, "PATCH", "/api/auth/users/"+result.User.ID+"/active", map[string]any{"is_active": false})
+	rr = doRequest(t, env, "PATCH", "/api/users/"+result.User.ID+"/active", map[string]any{"is_active": false})
 	if rr.Code != http.StatusOK {
 		t.Fatalf("deactivate: status = %d, want %d", rr.Code, http.StatusOK)
 	}
@@ -388,13 +469,13 @@ func TestFullUserLifecycle(t *testing.T) {
 	}
 
 	// 3. User cannot access admin endpoints.
-	rr = doBearerRequest(t, env.srv, userToken, "GET", "/api/auth/users", nil)
+	rr = doBearerRequest(t, env.srv, userToken, "GET", "/api/users", nil)
 	if rr.Code != http.StatusForbidden {
 		t.Fatalf("step 3: status = %d, want %d", rr.Code, http.StatusForbidden)
 	}
 
 	// 4. Admin promotes user to admin.
-	rr = doRequest(t, env, "PATCH", "/api/auth/users/"+user.ID+"/role", map[string]string{"role": "admin"})
+	rr = doRequest(t, env, "PATCH", "/api/users/"+user.ID+"/role", map[string]string{"role": "admin"})
 	if rr.Code != http.StatusOK {
 		t.Fatalf("step 4 promote: status = %d (body: %s)", rr.Code, rr.Body.String())
 	}
@@ -411,25 +492,25 @@ func TestFullUserLifecycle(t *testing.T) {
 	}
 
 	// 6. Admin can now access admin endpoints with their bearer token.
-	rr = doBearerRequest(t, env.srv, userToken, "GET", "/api/auth/users", nil)
+	rr = doBearerRequest(t, env.srv, userToken, "GET", "/api/users", nil)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("step 6: status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
 	}
 
 	// 7. Demote back to user.
-	rr = doRequest(t, env, "PATCH", "/api/auth/users/"+user.ID+"/role", map[string]string{"role": "user"})
+	rr = doRequest(t, env, "PATCH", "/api/users/"+user.ID+"/role", map[string]string{"role": "user"})
 	if rr.Code != http.StatusOK {
 		t.Fatalf("step 7 demote: status = %d (body: %s)", rr.Code, rr.Body.String())
 	}
 
 	// 8. Can no longer access admin endpoints.
-	rr = doBearerRequest(t, env.srv, userToken, "GET", "/api/auth/users", nil)
+	rr = doBearerRequest(t, env.srv, userToken, "GET", "/api/users", nil)
 	if rr.Code != http.StatusForbidden {
 		t.Fatalf("step 8: status = %d, want %d", rr.Code, http.StatusForbidden)
 	}
 
 	// 9. Deactivate user.
-	rr = doRequest(t, env, "PATCH", "/api/auth/users/"+user.ID+"/active", map[string]any{"is_active": false})
+	rr = doRequest(t, env, "PATCH", "/api/users/"+user.ID+"/active", map[string]any{"is_active": false})
 	if rr.Code != http.StatusOK {
 		t.Fatalf("step 9 deactivate: status = %d (body: %s)", rr.Code, rr.Body.String())
 	}
@@ -441,7 +522,7 @@ func TestFullUserLifecycle(t *testing.T) {
 	}
 
 	// 11. Reactivate user.
-	rr = doRequest(t, env, "PATCH", "/api/auth/users/"+user.ID+"/active", map[string]any{"is_active": true})
+	rr = doRequest(t, env, "PATCH", "/api/users/"+user.ID+"/active", map[string]any{"is_active": true})
 	if rr.Code != http.StatusOK {
 		t.Fatalf("step 11 reactivate: status = %d (body: %s)", rr.Code, rr.Body.String())
 	}
@@ -460,7 +541,7 @@ func TestAgentAssignmentLifecycle(t *testing.T) {
 	stellaID := findStellaID(t, env)
 
 	// Initially no agents assigned.
-	rr := doRequest(t, env, "GET", "/api/auth/users/"+user.ID+"/agents", nil)
+	rr := doRequest(t, env, "GET", "/api/users/"+user.ID+"/agents", nil)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("list: status = %d", rr.Code)
 	}
@@ -471,13 +552,13 @@ func TestAgentAssignmentLifecycle(t *testing.T) {
 	}
 
 	// Assign Stella.
-	rr = doRequest(t, env, "PATCH", "/api/auth/users/"+user.ID+"/agents", map[string]any{"agent_ids": []string{stellaID}})
+	rr = doRequest(t, env, "PATCH", "/api/users/"+user.ID+"/agents", map[string]any{"agent_ids": []string{stellaID}})
 	if rr.Code != http.StatusOK {
 		t.Fatalf("assign: status = %d", rr.Code)
 	}
 
 	// Verify.
-	rr = doRequest(t, env, "GET", "/api/auth/users/"+user.ID+"/agents", nil)
+	rr = doRequest(t, env, "GET", "/api/users/"+user.ID+"/agents", nil)
 	_ = json.Unmarshal(parseListItems(t, rr, "agent_ids"), &ids)
 	if len(ids) != 1 || ids[0] != stellaID {
 		t.Fatalf("expected [%s], got %v", stellaID, ids)
@@ -489,22 +570,22 @@ func TestAgentAssignmentLifecycle(t *testing.T) {
 		Enabled: true,
 		Scope:   "system",
 	})
-	rr = doRequest(t, env, "PATCH", "/api/auth/users/"+user.ID+"/agents", map[string]any{"agent_ids": []string{stellaID, secondAgent}})
+	rr = doRequest(t, env, "PATCH", "/api/users/"+user.ID+"/agents", map[string]any{"agent_ids": []string{stellaID, secondAgent}})
 	if rr.Code != http.StatusOK {
 		t.Fatalf("assign both: status = %d", rr.Code)
 	}
-	rr = doRequest(t, env, "GET", "/api/auth/users/"+user.ID+"/agents", nil)
+	rr = doRequest(t, env, "GET", "/api/users/"+user.ID+"/agents", nil)
 	_ = json.Unmarshal(parseListItems(t, rr, "agent_ids"), &ids)
 	if len(ids) != 2 {
 		t.Fatalf("expected 2 agents, got %d", len(ids))
 	}
 
 	// Remove all.
-	rr = doRequest(t, env, "PATCH", "/api/auth/users/"+user.ID+"/agents", map[string]any{"agent_ids": []string{}})
+	rr = doRequest(t, env, "PATCH", "/api/users/"+user.ID+"/agents", map[string]any{"agent_ids": []string{}})
 	if rr.Code != http.StatusOK {
 		t.Fatalf("remove all: status = %d", rr.Code)
 	}
-	rr = doRequest(t, env, "GET", "/api/auth/users/"+user.ID+"/agents", nil)
+	rr = doRequest(t, env, "GET", "/api/users/"+user.ID+"/agents", nil)
 	ids = nil
 	_ = json.Unmarshal(parseListItems(t, rr, "agent_ids"), &ids)
 	if len(ids) != 0 {
@@ -525,13 +606,13 @@ func TestIdentityManagementLifecycle(t *testing.T) {
 		"email":            "identuser@github.com",
 		"name":             "identuser",
 	}
-	rr := doRequest(t, env, "POST", "/api/auth/users/"+user.ID+"/identities/login", body)
+	rr := doRequest(t, env, "POST", "/api/users/"+user.ID+"/identities/login", body)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("link login identity: status = %d (body: %s)", rr.Code, rr.Body.String())
 	}
 
 	// List login identities.
-	rr = doRequest(t, env, "GET", "/api/auth/users/"+user.ID+"/identities/login", nil)
+	rr = doRequest(t, env, "GET", "/api/users/"+user.ID+"/identities/login", nil)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("list login identities: status = %d", rr.Code)
 	}
@@ -554,7 +635,7 @@ func TestIdentityManagementLifecycle(t *testing.T) {
 	}
 
 	// List channel identities.
-	rr = doRequest(t, env, "GET", "/api/auth/users/"+user.ID+"/identities/channel", nil)
+	rr = doRequest(t, env, "GET", "/api/users/"+user.ID+"/identities/channel", nil)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("list channel identities: status = %d", rr.Code)
 	}
@@ -565,13 +646,13 @@ func TestIdentityManagementLifecycle(t *testing.T) {
 	}
 
 	// Delete channel identity.
-	rr = doRequest(t, env, "DELETE", "/api/auth/users/"+user.ID+"/identities/"+chanIdent.ID, nil)
+	rr = doRequest(t, env, "DELETE", "/api/users/"+user.ID+"/identities/"+chanIdent.ID, nil)
 	if rr.Code != http.StatusNoContent {
 		t.Fatalf("delete identity: status = %d (body: %s)", rr.Code, rr.Body.String())
 	}
 
 	// Verify deleted.
-	rr = doRequest(t, env, "GET", "/api/auth/users/"+user.ID+"/identities/channel", nil)
+	rr = doRequest(t, env, "GET", "/api/users/"+user.ID+"/identities/channel", nil)
 	chanIdents = nil
 	_ = json.Unmarshal(parseListItems(t, rr, "identities"), &chanIdents)
 	if len(chanIdents) != 0 {

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -57,6 +57,7 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 			path == "/api/auth/providers" ||
 			strings.HasPrefix(path, "/auth/login/") ||
 			strings.HasPrefix(path, "/auth/callback/") ||
+			(strings.HasPrefix(path, "/api/auth/oauth/") && strings.HasSuffix(path, "/callback")) ||
 			(strings.HasPrefix(path, "/api/auth/profile/oauth/") && strings.HasSuffix(path, "/callback")) ||
 			strings.HasPrefix(path, "/oidc/local/") {
 			next.ServeHTTP(w, r)

--- a/internal/server/oauth.go
+++ b/internal/server/oauth.go
@@ -29,7 +29,7 @@ func toFlowStatusJSON(fs credentials.FlowStatus) flowStatusJSON {
 	}
 }
 
-// ListOAuthProviders handles GET /api/auth/profile/oauth/providers.
+// ListOAuthProviders handles GET /api/users/me/oauth/providers.
 func (s *Server) ListOAuthProviders(w http.ResponseWriter, r *http.Request) {
 	info := UserFromContext(r.Context())
 	if info == nil {
@@ -41,7 +41,7 @@ func (s *Server) ListOAuthProviders(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, map[string]any{"providers": providers})
 }
 
-// StartOAuthFlow handles POST /api/auth/profile/oauth/{provider}/start.
+// StartOAuthFlow handles POST /api/users/me/oauth/{provider}/start.
 func (s *Server) StartOAuthFlow(w http.ResponseWriter, r *http.Request, provider string) {
 	if s.vaultSvc == nil {
 		writeError(w, http.StatusServiceUnavailable, "vault not configured")
@@ -62,7 +62,7 @@ func (s *Server) StartOAuthFlow(w http.ResponseWriter, r *http.Request, provider
 	writeData(w, http.StatusOK, toFlowStatusJSON(status))
 }
 
-// PollOAuthFlow handles GET /api/auth/profile/oauth/{provider}/status/{flowID}.
+// PollOAuthFlow handles GET /api/users/me/oauth/{provider}/status/{flowID}.
 func (s *Server) PollOAuthFlow(w http.ResponseWriter, r *http.Request, provider string, flowID string) {
 	if s.vaultSvc == nil {
 		writeError(w, http.StatusServiceUnavailable, "vault not configured")
@@ -82,7 +82,7 @@ func (s *Server) PollOAuthFlow(w http.ResponseWriter, r *http.Request, provider 
 	writeData(w, http.StatusOK, toFlowStatusJSON(status))
 }
 
-// GetOAuthConnected handles GET /api/auth/profile/oauth/{provider}/connected.
+// GetOAuthConnected handles GET /api/users/me/oauth/{provider}/connected.
 func (s *Server) GetOAuthConnected(w http.ResponseWriter, r *http.Request, provider string) {
 	if s.vaultSvc == nil {
 		writeError(w, http.StatusServiceUnavailable, "vault not configured")
@@ -110,7 +110,7 @@ func (s *Server) GetOAuthConnected(w http.ResponseWriter, r *http.Request, provi
 	writeError(w, http.StatusBadRequest, "unsupported provider: "+provider)
 }
 
-// DisconnectOAuth handles DELETE /api/auth/profile/oauth/{provider}.
+// DisconnectOAuth handles DELETE /api/users/me/oauth/{provider}.
 func (s *Server) DisconnectOAuth(w http.ResponseWriter, r *http.Request, provider string) {
 	if s.vaultSvc == nil {
 		writeError(w, http.StatusServiceUnavailable, "vault not configured")

--- a/internal/server/oauth_test.go
+++ b/internal/server/oauth_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestRequestOriginUsesOriginHeader(t *testing.T) {
-	req := httptest.NewRequest(http.MethodPost, "http://localhost:8080/api/auth/profile/oauth/feishu/start", nil)
+	req := httptest.NewRequest(http.MethodPost, "http://localhost:8080/api/users/me/oauth/feishu/start", nil)
 	req.Header.Set("Origin", "http://localhost:25678")
 
 	if got := requestOrigin(req); got != "http://localhost:25678" {
@@ -16,7 +16,7 @@ func TestRequestOriginUsesOriginHeader(t *testing.T) {
 }
 
 func TestRequestOriginFallsBackToRequestHost(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "http://localhost:25678/api/auth/profile/oauth/feishu/callback", nil)
+	req := httptest.NewRequest(http.MethodGet, "http://localhost:25678/api/auth/oauth/feishu/callback", nil)
 
 	if got := requestOrigin(req); got != "http://localhost:25678" {
 		t.Fatalf("requestOrigin = %q, want http://localhost:25678", got)
@@ -24,7 +24,7 @@ func TestRequestOriginFallsBackToRequestHost(t *testing.T) {
 }
 
 func TestRequestOriginUsesForwardedHeaders(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/api/auth/profile/oauth/feishu/callback", nil)
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/api/auth/oauth/feishu/callback", nil)
 	req.Header.Set("X-Forwarded-Proto", "https")
 	req.Header.Set("X-Forwarded-Host", "stella.example.com")
 

--- a/internal/server/profile.go
+++ b/internal/server/profile.go
@@ -12,7 +12,7 @@ import (
 	"github.com/CherryHQ/stella/pkg/db/sqlc"
 )
 
-// ListProfileIdentities handles GET /api/auth/profile/identities.
+// ListProfileIdentities handles GET /api/users/me/identities.
 func (s *Server) ListProfileIdentities(w http.ResponseWriter, r *http.Request) {
 	info := UserFromContext(r.Context())
 	if info == nil {
@@ -34,7 +34,7 @@ func (s *Server) ListProfileIdentities(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, map[string]any{"identities": identities})
 }
 
-// ChangePassword handles PATCH /api/auth/profile/password.
+// ChangePassword handles PATCH /api/users/me/password.
 func (s *Server) ChangePassword(w http.ResponseWriter, r *http.Request) {
 	info := UserFromContext(r.Context())
 	if info == nil {
@@ -100,7 +100,7 @@ func (s *Server) ChangePassword(w http.ResponseWriter, r *http.Request) {
 	writeNoContent(w)
 }
 
-// GenerateLinkCode handles POST /api/auth/profile/link-code.
+// GenerateLinkCode handles POST /api/users/me/link-code.
 func (s *Server) GenerateLinkCode(w http.ResponseWriter, r *http.Request) {
 	info := UserFromContext(r.Context())
 	if info == nil {
@@ -131,7 +131,7 @@ func (s *Server) GenerateLinkCode(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// UnlinkProfileIdentity handles DELETE /api/auth/profile/identities/{id}.
+// UnlinkProfileIdentity handles DELETE /api/users/me/identities/{id}.
 func (s *Server) UnlinkProfileIdentity(w http.ResponseWriter, r *http.Request, id string) {
 	info := UserFromContext(r.Context())
 	if info == nil {
@@ -167,56 +167,17 @@ func (s *Server) UnlinkProfileIdentity(w http.ResponseWriter, r *http.Request, i
 	writeNoContent(w)
 }
 
-// ListProfileMemories handles GET /api/auth/profile/memories.
+// ListProfileMemories handles GET /api/users/me/memories.
 func (s *Server) ListProfileMemories(w http.ResponseWriter, r *http.Request) {
-	info := UserFromContext(r.Context())
-	if info == nil {
-		writeError(w, http.StatusUnauthorized, "not authenticated")
-		return
-	}
-
-	memories, err := s.q.ListUserAgentMemoriesByUser(r.Context(), info.UserID)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
-		return
-	}
-	defaultSoul := prompt.DefaultAgentSoul()
-	for i := range memories {
-		if memories[i].Soul == "" {
-			memories[i].Soul = defaultSoul
-		}
-	}
-	writeData(w, http.StatusOK, map[string]any{"memories": memories})
+	s.ListUserMemories(w, r, "me")
 }
 
-// SetProfileMemory handles PATCH /api/auth/profile/memories/{agentID}.
+// SetProfileMemory handles PATCH /api/users/me/memories/{agentID}.
 func (s *Server) SetProfileMemory(w http.ResponseWriter, r *http.Request, agentID string) {
-	info := UserFromContext(r.Context())
-	if info == nil {
-		writeError(w, http.StatusUnauthorized, "not authenticated")
-		return
-	}
-	if _, code, msg := s.requireAgentAccess(r.Context(), agentID); code != 0 {
-		writeError(w, code, msg)
-		return
-	}
-
-	var body struct {
-		Content string `json:"content"`
-	}
-	if err := decodeJSON(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
-		return
-	}
-	ctx := memory.WithChangeSource(r.Context(), memory.SourceUser)
-	if err := memorywrite.SetProfile(ctx, s.db, s.q, info.UserID, agentID, body.Content); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
-		return
-	}
-	s.writeProfileMemory(w, r, info.UserID, agentID)
+	s.SetUserMemory(w, r, "me", agentID)
 }
 
-// SetProfileSoul handles PATCH /api/auth/profile/soul/{agentID}.
+// SetProfileSoul handles PATCH /api/users/me/soul/{agentID}.
 func (s *Server) SetProfileSoul(w http.ResponseWriter, r *http.Request, agentID string) {
 	info := UserFromContext(r.Context())
 	if info == nil {
@@ -257,27 +218,12 @@ func (s *Server) writeProfileMemory(w http.ResponseWriter, r *http.Request, user
 	writeData(w, http.StatusOK, mem)
 }
 
-// DeleteProfileMemory handles DELETE /api/auth/profile/memories/{agentID}.
+// DeleteProfileMemory handles DELETE /api/users/me/memories/{agentID}.
 func (s *Server) DeleteProfileMemory(w http.ResponseWriter, r *http.Request, agentID string) {
-	info := UserFromContext(r.Context())
-	if info == nil {
-		writeError(w, http.StatusUnauthorized, "not authenticated")
-		return
-	}
-	if _, code, msg := s.requireAgentAccess(r.Context(), agentID); code != 0 {
-		writeError(w, code, msg)
-		return
-	}
-
-	ctx := memory.WithChangeSource(r.Context(), memory.SourceUser)
-	if err := memorywrite.DeleteProfile(ctx, s.db, s.q, info.UserID, agentID); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
-		return
-	}
-	writeNoContent(w)
+	s.DeleteUserMemory(w, r, "me", agentID)
 }
 
-// OauthCallback handles GET /api/auth/profile/oauth/{provider}/callback.
+// OauthCallback handles GET /api/auth/oauth/{provider}/callback.
 // This is intentionally a pass-through to the unexported helper so the
 // generated interface signature is satisfied.
 func (s *Server) OauthCallback(w http.ResponseWriter, r *http.Request, provider string, params apiserver.OauthCallbackParams) {
@@ -306,4 +252,9 @@ func (s *Server) OauthCallback(w http.ResponseWriter, r *http.Request, provider 
 	}
 
 	http.Redirect(w, r, "/settings/credentials", http.StatusFound)
+}
+
+// OauthCallbackLegacy handles the deprecated /api/auth/profile/oauth/{provider}/callback alias.
+func (s *Server) OauthCallbackLegacy(w http.ResponseWriter, r *http.Request, provider string, params apiserver.OauthCallbackLegacyParams) {
+	s.OauthCallback(w, r, provider, apiserver.OauthCallbackParams(params))
 }

--- a/internal/server/profile_test.go
+++ b/internal/server/profile_test.go
@@ -15,7 +15,7 @@ import (
 func TestListProfileIdentitiesEmpty(t *testing.T) {
 	env := setupAdmin(t)
 
-	rr := doRequest(t, env, "GET", "/api/auth/profile/identities", nil)
+	rr := doRequest(t, env, "GET", "/api/users/me/identities", nil)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
 	}
@@ -49,7 +49,7 @@ func TestListProfileIdentitiesWithLink(t *testing.T) {
 		t.Fatalf("CreateChannelIdentity: %v", err)
 	}
 
-	rr := doRequest(t, env, "GET", "/api/auth/profile/identities", nil)
+	rr := doRequest(t, env, "GET", "/api/users/me/identities", nil)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
 	}
@@ -77,7 +77,7 @@ func TestChangePasswordSuccess(t *testing.T) {
 		"current_password": "testpassword",
 		"new_password":     "newpassword123",
 	}
-	rr := doRequest(t, env, "PATCH", "/api/auth/profile/password", body)
+	rr := doRequest(t, env, "PATCH", "/api/users/me/password", body)
 	if rr.Code != http.StatusNoContent {
 		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusNoContent, rr.Body.String())
 	}
@@ -99,7 +99,7 @@ func TestChangePasswordWrongCurrent(t *testing.T) {
 		"current_password": "wrongpassword",
 		"new_password":     "newpassword123",
 	}
-	rr := doRequest(t, env, "PATCH", "/api/auth/profile/password", body)
+	rr := doRequest(t, env, "PATCH", "/api/users/me/password", body)
 	if rr.Code != http.StatusUnauthorized {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusUnauthorized)
 	}
@@ -112,7 +112,7 @@ func TestChangePasswordTooShort(t *testing.T) {
 		"current_password": "testpassword",
 		"new_password":     "short",
 	}
-	rr := doRequest(t, env, "PATCH", "/api/auth/profile/password", body)
+	rr := doRequest(t, env, "PATCH", "/api/users/me/password", body)
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusBadRequest)
 	}
@@ -124,7 +124,7 @@ func TestGenerateLinkCode(t *testing.T) {
 	body := map[string]string{
 		"platform": "telegram",
 	}
-	rr := doRequest(t, env, "POST", "/api/auth/profile/link-code", body)
+	rr := doRequest(t, env, "POST", "/api/users/me/link-code", body)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
 	}
@@ -151,7 +151,7 @@ func TestGenerateLinkCodeInvalidPlatform(t *testing.T) {
 	body := map[string]string{
 		"platform": "invalid",
 	}
-	rr := doRequest(t, env, "POST", "/api/auth/profile/link-code", body)
+	rr := doRequest(t, env, "POST", "/api/users/me/link-code", body)
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusBadRequest)
 	}
@@ -173,7 +173,7 @@ func TestUnlinkIdentity(t *testing.T) {
 		t.Fatalf("CreateChannelIdentity: %v", err)
 	}
 
-	rr := doRequest(t, env, "DELETE", "/api/auth/profile/identities/"+identity.ID, nil)
+	rr := doRequest(t, env, "DELETE", "/api/users/me/identities/"+identity.ID, nil)
 	if rr.Code != http.StatusNoContent {
 		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusNoContent, rr.Body.String())
 	}
@@ -208,7 +208,7 @@ func TestUnlinkIdentityOtherUser(t *testing.T) {
 	}
 
 	// Try to unlink it as the admin — should fail (not your identity).
-	rr := doRequest(t, env, "DELETE", "/api/auth/profile/identities/"+identity.ID, nil)
+	rr := doRequest(t, env, "DELETE", "/api/users/me/identities/"+identity.ID, nil)
 	if rr.Code != http.StatusForbidden {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusForbidden)
 	}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"net/http"
+
 	apiserver "github.com/CherryHQ/stella/api/server"
 	"github.com/CherryHQ/stella/web"
 )
@@ -15,6 +17,9 @@ func (s *Server) registerRoutes() {
 // Auth is enforced by the global authMiddleware (Bearer + session).
 func (s *Server) registerAPIRoutes() {
 	apiserver.HandlerFromMux(s, s.mux)
+	s.mux.HandleFunc("GET /api/{path...}", func(w http.ResponseWriter, r *http.Request) {
+		writeError(w, http.StatusNotFound, "api route not found")
+	})
 }
 
 func (s *Server) registerStaticRoutes() {

--- a/internal/server/users.go
+++ b/internal/server/users.go
@@ -3,13 +3,36 @@ package server
 import (
 	"net/http"
 
+	"github.com/CherryHQ/stella/internal/agent/prompt"
 	"github.com/CherryHQ/stella/internal/memory"
 	"github.com/CherryHQ/stella/internal/memory/memorywrite"
-	"github.com/CherryHQ/stella/pkg/db/sqlc"
 )
 
+func resolveTargetUserID(info *AuthInfo, id string) string {
+	if id == "me" {
+		return info.UserID
+	}
+	return id
+}
+
+// requireUserTarget resolves the users/me alias and permits access only to the
+// current user or admins. Cross-user IDs return 404 to avoid leaking existence.
+func (s *Server) requireUserTarget(w http.ResponseWriter, r *http.Request, id string) (*AuthInfo, string, bool) {
+	info := requireAuth(w, r)
+	if info == nil {
+		return nil, "", false
+	}
+	targetUserID := resolveTargetUserID(info, id)
+	if targetUserID == info.UserID || info.IsAdmin {
+		return info, targetUserID, true
+	}
+	writeError(w, http.StatusNotFound, "user not found")
+	return nil, "", false
+}
+
 func (s *Server) UpdateUserDefaultAgent(w http.ResponseWriter, r *http.Request, id string) {
-	if requireAdmin(w, r) == nil {
+	info, targetUserID, ok := s.requireUserTarget(w, r, id)
+	if !ok {
 		return
 	}
 	var body struct {
@@ -19,15 +42,22 @@ func (s *Server) UpdateUserDefaultAgent(w http.ResponseWriter, r *http.Request, 
 		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
 		return
 	}
-	if err := s.users.UpdateUserDefaultAgent(r.Context(), id, body.DefaultAgentID); err != nil {
+	if !info.IsAdmin {
+		if _, code, msg := s.requireAgentAccess(r.Context(), body.DefaultAgentID); code != 0 {
+			writeError(w, code, msg)
+			return
+		}
+	}
+	if err := s.users.UpdateUserDefaultAgent(r.Context(), targetUserID, body.DefaultAgentID); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	s.writeAuthUser(w, r, id)
+	s.writeAuthUser(w, r, targetUserID)
 }
 
 func (s *Server) UpdateUserNotifyIdentity(w http.ResponseWriter, r *http.Request, id string) {
-	if requireAdmin(w, r) == nil {
+	_, targetUserID, ok := s.requireUserTarget(w, r, id)
+	if !ok {
 		return
 	}
 	var body struct {
@@ -37,27 +67,50 @@ func (s *Server) UpdateUserNotifyIdentity(w http.ResponseWriter, r *http.Request
 		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
 		return
 	}
-	if err := s.users.UpdateUserNotifyIdentity(r.Context(), id, body.NotifyIdentityID); err != nil {
+	if body.NotifyIdentityID != nil {
+		identity, err := s.users.GetChannelIdentity(r.Context(), *body.NotifyIdentityID)
+		if err != nil {
+			writeError(w, http.StatusNotFound, "identity not found")
+			return
+		}
+		if identity.UserID != targetUserID {
+			writeError(w, http.StatusBadRequest, "identity does not belong to this user")
+			return
+		}
+	}
+	if err := s.users.UpdateUserNotifyIdentity(r.Context(), targetUserID, body.NotifyIdentityID); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	s.writeAuthUser(w, r, id)
+	s.writeAuthUser(w, r, targetUserID)
 }
 
 func (s *Server) ListUserMemories(w http.ResponseWriter, r *http.Request, id string) {
-	if requireAdmin(w, r) == nil {
+	_, targetUserID, ok := s.requireUserTarget(w, r, id)
+	if !ok {
 		return
 	}
-	memories, err := s.q.ListUserAgentMemoriesByUser(r.Context(), id)
+	memories, err := s.q.ListUserAgentMemoriesByUser(r.Context(), targetUserID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
+	}
+	defaultSoul := prompt.DefaultAgentSoul()
+	for i := range memories {
+		if memories[i].Soul == "" {
+			memories[i].Soul = defaultSoul
+		}
 	}
 	writeData(w, http.StatusOK, map[string]any{"memories": memories})
 }
 
 func (s *Server) SetUserMemory(w http.ResponseWriter, r *http.Request, id string, agentID string) {
-	if requireAdmin(w, r) == nil {
+	info, targetUserID, ok := s.requireUserTarget(w, r, id)
+	if !ok {
+		return
+	}
+	if _, code, msg := s.requireAgentAccess(r.Context(), agentID); code != 0 {
+		writeError(w, code, msg)
 		return
 	}
 	var body struct {
@@ -67,25 +120,33 @@ func (s *Server) SetUserMemory(w http.ResponseWriter, r *http.Request, id string
 		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
 		return
 	}
-	ctx := memory.WithChangeSource(r.Context(), memory.SourceSystem)
-	if err := memorywrite.SetProfile(ctx, s.db, s.q, id, agentID, body.Content); err != nil {
+	source := memory.SourceSystem
+	if !info.IsAdmin || targetUserID == info.UserID {
+		source = memory.SourceUser
+	}
+	ctx := memory.WithChangeSource(r.Context(), source)
+	if err := memorywrite.SetProfile(ctx, s.db, s.q, targetUserID, agentID, body.Content); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	mem, err := s.q.GetUserAgentMemory(r.Context(), sqlc.GetUserAgentMemoryParams{UserID: id, AgentID: agentID})
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
-		return
-	}
-	writeData(w, http.StatusOK, mem)
+	s.writeProfileMemory(w, r, targetUserID, agentID)
 }
 
 func (s *Server) DeleteUserMemory(w http.ResponseWriter, r *http.Request, id string, agentID string) {
-	if requireAdmin(w, r) == nil {
+	info, targetUserID, ok := s.requireUserTarget(w, r, id)
+	if !ok {
 		return
 	}
-	ctx := memory.WithChangeSource(r.Context(), memory.SourceSystem)
-	if err := memorywrite.DeleteProfile(ctx, s.db, s.q, id, agentID); err != nil {
+	if _, code, msg := s.requireAgentAccess(r.Context(), agentID); code != 0 {
+		writeError(w, code, msg)
+		return
+	}
+	source := memory.SourceSystem
+	if !info.IsAdmin || targetUserID == info.UserID {
+		source = memory.SourceUser
+	}
+	ctx := memory.WithChangeSource(r.Context(), source)
+	if err := memorywrite.DeleteProfile(ctx, s.db, s.q, targetUserID, agentID); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/internal/server/vault.go
+++ b/internal/server/vault.go
@@ -14,7 +14,7 @@ type vaultEntryResponse struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
-// ListVaultEntries handles GET /api/auth/profile/vault.
+// ListVaultEntries handles GET /api/users/me/vault.
 func (s *Server) ListVaultEntries(w http.ResponseWriter, r *http.Request) {
 	if s.vaultSvc == nil {
 		writeError(w, http.StatusServiceUnavailable, "vault not configured")
@@ -45,7 +45,7 @@ func (s *Server) ListVaultEntries(w http.ResponseWriter, r *http.Request) {
 	writeData(w, http.StatusOK, map[string]any{"entries": resp})
 }
 
-// GetVaultEntry handles GET /api/auth/profile/vault/{name}.
+// GetVaultEntry handles GET /api/users/me/vault/{name}.
 func (s *Server) GetVaultEntry(w http.ResponseWriter, r *http.Request, name string) {
 	if s.vaultSvc == nil {
 		writeError(w, http.StatusServiceUnavailable, "vault not configured")
@@ -77,7 +77,7 @@ func (s *Server) GetVaultEntry(w http.ResponseWriter, r *http.Request, name stri
 	writeData(w, http.StatusOK, map[string]string{"name": name, "value": value})
 }
 
-// SetVaultEntry handles PUT /api/auth/profile/vault/{name}.
+// SetVaultEntry handles PUT /api/users/me/vault/{name}.
 func (s *Server) SetVaultEntry(w http.ResponseWriter, r *http.Request, name string) {
 	if s.vaultSvc == nil {
 		writeError(w, http.StatusServiceUnavailable, "vault not configured")
@@ -126,7 +126,7 @@ func (s *Server) SetVaultEntry(w http.ResponseWriter, r *http.Request, name stri
 	})
 }
 
-// DeleteVaultEntry handles DELETE /api/auth/profile/vault/{name}.
+// DeleteVaultEntry handles DELETE /api/users/me/vault/{name}.
 func (s *Server) DeleteVaultEntry(w http.ResponseWriter, r *http.Request, name string) {
 	if s.vaultSvc == nil {
 		writeError(w, http.StatusServiceUnavailable, "vault not configured")

--- a/internal/server/vault_test.go
+++ b/internal/server/vault_test.go
@@ -67,7 +67,7 @@ func setupVaultEnv(t *testing.T) (*testEnv, *vault.Service) {
 func TestVaultNotConfigured(t *testing.T) {
 	env := setupAdmin(t)
 
-	rr := doRequest(t, env, "GET", "/api/auth/profile/vault", nil)
+	rr := doRequest(t, env, "GET", "/api/users/me/vault", nil)
 	if rr.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusServiceUnavailable)
 	}
@@ -77,7 +77,7 @@ func TestVaultCRUD(t *testing.T) {
 	env, _ := setupVaultEnv(t)
 
 	// List — empty.
-	rr := doRequest(t, env, "GET", "/api/auth/profile/vault", nil)
+	rr := doRequest(t, env, "GET", "/api/users/me/vault", nil)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("list status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
 	}
@@ -94,13 +94,13 @@ func TestVaultCRUD(t *testing.T) {
 	}
 
 	// Set a secret.
-	rr = doRequest(t, env, "PUT", "/api/auth/profile/vault/GITHUB_TOKEN", map[string]string{"value": "ghp_test123"})
+	rr = doRequest(t, env, "PUT", "/api/users/me/vault/GITHUB_TOKEN", map[string]string{"value": "ghp_test123"})
 	if rr.Code != http.StatusOK {
 		t.Fatalf("set status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
 	}
 
 	// List — one entry.
-	rr = doRequest(t, env, "GET", "/api/auth/profile/vault", nil)
+	rr = doRequest(t, env, "GET", "/api/users/me/vault", nil)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("list status = %d, want %d", rr.Code, http.StatusOK)
 	}
@@ -115,13 +115,13 @@ func TestVaultCRUD(t *testing.T) {
 	}
 
 	// Delete.
-	rr = doRequest(t, env, "DELETE", "/api/auth/profile/vault/GITHUB_TOKEN", nil)
+	rr = doRequest(t, env, "DELETE", "/api/users/me/vault/GITHUB_TOKEN", nil)
 	if rr.Code != http.StatusNoContent {
 		t.Fatalf("delete status = %d, want %d (body: %s)", rr.Code, http.StatusNoContent, rr.Body.String())
 	}
 
 	// List — empty again.
-	rr = doRequest(t, env, "GET", "/api/auth/profile/vault", nil)
+	rr = doRequest(t, env, "GET", "/api/users/me/vault", nil)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("list status = %d", rr.Code)
 	}
@@ -137,7 +137,7 @@ func TestVaultCRUD(t *testing.T) {
 func TestVaultSetValidationError(t *testing.T) {
 	env, _ := setupVaultEnv(t)
 
-	rr := doRequest(t, env, "PUT", "/api/auth/profile/vault/invalid_name", map[string]string{"value": "test"})
+	rr := doRequest(t, env, "PUT", "/api/users/me/vault/invalid_name", map[string]string{"value": "test"})
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusBadRequest, rr.Body.String())
 	}
@@ -146,7 +146,7 @@ func TestVaultSetValidationError(t *testing.T) {
 func TestVaultNotConfiguredPUT(t *testing.T) {
 	env := setupAdmin(t)
 
-	rr := doRequest(t, env, "PUT", "/api/auth/profile/vault/MY_KEY", map[string]string{"value": "v"})
+	rr := doRequest(t, env, "PUT", "/api/users/me/vault/MY_KEY", map[string]string{"value": "v"})
 	if rr.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusServiceUnavailable)
 	}
@@ -155,7 +155,7 @@ func TestVaultNotConfiguredPUT(t *testing.T) {
 func TestVaultNotConfiguredDELETE(t *testing.T) {
 	env := setupAdmin(t)
 
-	rr := doRequest(t, env, "DELETE", "/api/auth/profile/vault/MY_KEY", nil)
+	rr := doRequest(t, env, "DELETE", "/api/users/me/vault/MY_KEY", nil)
 	if rr.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusServiceUnavailable)
 	}
@@ -164,7 +164,7 @@ func TestVaultNotConfiguredDELETE(t *testing.T) {
 func TestVaultSetEmptyValue(t *testing.T) {
 	env, _ := setupVaultEnv(t)
 
-	rr := doRequest(t, env, "PUT", "/api/auth/profile/vault/MY_KEY", map[string]string{"value": ""})
+	rr := doRequest(t, env, "PUT", "/api/users/me/vault/MY_KEY", map[string]string{"value": ""})
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusBadRequest, rr.Body.String())
 	}
@@ -173,7 +173,7 @@ func TestVaultSetEmptyValue(t *testing.T) {
 func TestVaultSetEmptyName(t *testing.T) {
 	env, _ := setupVaultEnv(t)
 
-	rr := doRequest(t, env, "PUT", "/api/auth/profile/vault/", map[string]string{"value": "v"})
+	rr := doRequest(t, env, "PUT", "/api/users/me/vault/", map[string]string{"value": "v"})
 	// Empty name in path — either 400 or 404 depending on router
 	if rr.Code == http.StatusOK {
 		t.Fatal("expected error for empty name, got 200")
@@ -183,7 +183,7 @@ func TestVaultSetEmptyName(t *testing.T) {
 func TestVaultSetInvalidJSON(t *testing.T) {
 	env, _ := setupVaultEnv(t)
 
-	rr := doRequestWithSession(t, env.srv, env.bearerToken, "PUT", "/api/auth/profile/vault/MY_KEY", nil)
+	rr := doRequestWithSession(t, env.srv, env.bearerToken, "PUT", "/api/users/me/vault/MY_KEY", nil)
 	// No body → JSON decode error or empty value
 	if rr.Code == http.StatusOK {
 		t.Fatal("expected error for nil body, got 200")
@@ -194,19 +194,19 @@ func TestVaultUpdateExisting(t *testing.T) {
 	env, _ := setupVaultEnv(t)
 
 	// Set initial value.
-	rr := doRequest(t, env, "PUT", "/api/auth/profile/vault/MY_SECRET", map[string]string{"value": "v1"})
+	rr := doRequest(t, env, "PUT", "/api/users/me/vault/MY_SECRET", map[string]string{"value": "v1"})
 	if rr.Code != http.StatusOK {
 		t.Fatalf("set status = %d, want %d", rr.Code, http.StatusOK)
 	}
 
 	// Update with new value.
-	rr = doRequest(t, env, "PUT", "/api/auth/profile/vault/MY_SECRET", map[string]string{"value": "v2"})
+	rr = doRequest(t, env, "PUT", "/api/users/me/vault/MY_SECRET", map[string]string{"value": "v2"})
 	if rr.Code != http.StatusOK {
 		t.Fatalf("update status = %d, want %d", rr.Code, http.StatusOK)
 	}
 
 	// List — still one entry.
-	rr = doRequest(t, env, "GET", "/api/auth/profile/vault", nil)
+	rr = doRequest(t, env, "GET", "/api/users/me/vault", nil)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("list status = %d", rr.Code)
 	}


### PR DESCRIPTION
## Summary

- Move admin user routes from `/api/auth/users/*` to `/api/users/*`.
- Move current-user profile routes from `/api/auth/profile/*` to `/api/users/me/*`.
- Keep OAuth callback as a public auth handshake at `/api/auth/oauth/{provider}/callback`.
- Add `requireUserTarget` for `me` alias resolution and user-target authorization.
- Return API 404 for unknown GET `/api/*` routes instead of serving the SPA shell.

## Verification

- `mise run format`
- `mise run build`
- `mise run test`

Closes #253
Refs #258
