### PR TITLE
Error hygiene: stop leaking raw err.Error() in client-facing API responses

### DIFF
--- a/api/spec/components/common.yaml
+++ b/api/spec/components/common.yaml
@@ -28,6 +28,10 @@ components:
             status:
               type: string
               description: canonical status name (e.g. NOT_FOUND, INVALID_ARGUMENT)
+            details:
+              type: object
+              additionalProperties: true
+              description: optional machine-readable error details; keys use snake_case
 
   responses:
     Unauthorized:

--- a/internal/server/agent_users.go
+++ b/internal/server/agent_users.go
@@ -15,7 +15,7 @@ func (s *Server) ListAgentUsers(w http.ResponseWriter, r *http.Request, id strin
 
 	userIDs, err := s.authStore.ListAgentUserIDs(ctx, agentID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to list agent users: "+err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 
@@ -46,7 +46,7 @@ func (s *Server) AssignAgentUser(w http.ResponseWriter, r *http.Request, id stri
 		UserID string `json:"user_id"`
 	}
 	if err := decodeJSON(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 	if body.UserID == "" {
@@ -65,7 +65,7 @@ func (s *Server) AssignAgentUser(w http.ResponseWriter, r *http.Request, id stri
 	}
 
 	if err := s.authStore.AssignAgent(ctx, body.UserID, agentID); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to assign user: "+err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 
@@ -80,7 +80,7 @@ func (s *Server) RemoveAgentUser(w http.ResponseWriter, r *http.Request, id stri
 	ctx := r.Context()
 
 	if err := s.authStore.RemoveAgent(ctx, userId, agentID); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to remove user: "+err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 

--- a/internal/server/agents.go
+++ b/internal/server/agents.go
@@ -65,7 +65,7 @@ func (s *Server) ListAgents(w http.ResponseWriter, r *http.Request) {
 		agents, err = s.store.ListAccessibleAgents(ctx, info.UserID)
 	}
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 
@@ -84,7 +84,7 @@ func (s *Server) CreateAgent(w http.ResponseWriter, r *http.Request) {
 
 	var req createAgentRequest
 	if err := decodeJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 	a := req.Agent
@@ -93,12 +93,12 @@ func (s *Server) CreateAgent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := applyTemplate(&a, req.TemplateID); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeError(w, http.StatusBadRequest, "invalid request")
 		return
 	}
 	// backend is global; only network is per-agent (no Backend field to clear)
 	if err := a.Sandbox.Validate(); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeError(w, http.StatusBadRequest, "invalid request")
 		return
 	}
 
@@ -135,7 +135,7 @@ func (s *Server) CreateAgent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := s.store.CreateAgent(ctx, a); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 
@@ -179,7 +179,7 @@ func (s *Server) UpdateAgent(w http.ResponseWriter, r *http.Request, id string) 
 
 	var a config.Agent
 	if err := decodeJSON(r, &a); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 	a.ID = id
@@ -188,7 +188,7 @@ func (s *Server) UpdateAgent(w http.ResponseWriter, r *http.Request, id string) 
 	}
 	// backend is global; only network is per-agent (no Backend field to clear)
 	if err := a.Sandbox.Validate(); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeError(w, http.StatusBadRequest, "invalid request")
 		return
 	}
 
@@ -206,7 +206,7 @@ func (s *Server) UpdateAgent(w http.ResponseWriter, r *http.Request, id string) 
 	}
 
 	if err := s.store.UpdateAgent(ctx, a); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	if s.poolManager != nil {
@@ -225,7 +225,7 @@ func (s *Server) DeleteAgent(w http.ResponseWriter, r *http.Request, id string) 
 	}
 
 	if err := s.store.DeleteAgent(ctx, id); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	if s.poolManager != nil {

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -58,7 +58,7 @@ func (s *Server) ListAuthSessions(w http.ResponseWriter, r *http.Request) {
 	}
 	sessions, err := s.sessions.ListSessionsByUser(r.Context(), info.UserID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	items := make([]map[string]any, len(sessions))
@@ -93,7 +93,7 @@ func (s *Server) DeleteAuthSession(w http.ResponseWriter, r *http.Request, id st
 		return
 	}
 	if err := s.sessions.DeleteSession(r.Context(), id); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	writeNoContent(w)

--- a/internal/server/auth_users.go
+++ b/internal/server/auth_users.go
@@ -103,7 +103,7 @@ func (s *Server) writeAuthUser(w http.ResponseWriter, r *http.Request, id string
 
 	resp, err := s.buildAuthUserResponse(r, u)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to load user details: "+err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 
@@ -120,7 +120,7 @@ func (s *Server) UpdateAuthUserRole(w http.ResponseWriter, r *http.Request, id s
 		Role string `json:"role"`
 	}
 	if err := decodeJSON(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 
@@ -136,7 +136,7 @@ func (s *Server) UpdateAuthUserRole(w http.ResponseWriter, r *http.Request, id s
 	}
 
 	if err := s.users.UpdateUserRole(r.Context(), targetUserID, body.Role); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to update role: "+err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 
@@ -157,7 +157,7 @@ func (s *Server) ListAuthUserAgents(w http.ResponseWriter, r *http.Request, id s
 	targetUserID := resolveTargetUserID(info, id)
 	agentIDs, err := s.authStore.ListUserAgentIDs(r.Context(), targetUserID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to list user agents: "+err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 
@@ -175,7 +175,7 @@ func (s *Server) UpdateAuthUserAgents(w http.ResponseWriter, r *http.Request, id
 		AgentIDs []string `json:"agent_ids"`
 	}
 	if err := decodeJSON(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 
@@ -190,7 +190,7 @@ func (s *Server) UpdateAuthUserAgents(w http.ResponseWriter, r *http.Request, id
 	// Get current assignments.
 	currentIDs, err := s.authStore.ListUserAgentIDs(ctx, targetUserID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to list current agents: "+err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 
@@ -223,7 +223,7 @@ func (s *Server) UpdateAuthUserAgents(w http.ResponseWriter, r *http.Request, id
 
 	updated, err := s.authStore.ListUserAgentIDs(ctx, targetUserID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to list user agents: "+err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	writeData(w, http.StatusOK, map[string]any{"agent_ids": updated})
@@ -274,7 +274,7 @@ func (s *Server) UpdateAuthUserActive(w http.ResponseWriter, r *http.Request, id
 		IsActive bool `json:"is_active"`
 	}
 	if err := decodeJSON(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 
@@ -289,7 +289,7 @@ func (s *Server) UpdateAuthUserActive(w http.ResponseWriter, r *http.Request, id
 	}
 
 	if err := s.users.UpdateUserActive(r.Context(), targetUserID, body.IsActive); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to update active status: "+err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 
@@ -318,7 +318,7 @@ func (s *Server) ListAuthUserLoginIdentities(w http.ResponseWriter, r *http.Requ
 	}
 	identities, err := s.logins.ListLoginIdentitiesByUser(r.Context(), targetUserID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to list login identities: "+err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	writeData(w, http.StatusOK, map[string]any{"identities": identities})
@@ -343,7 +343,7 @@ func (s *Server) LinkAuthUserLoginIdentity(w http.ResponseWriter, r *http.Reques
 		Name            string `json:"name"`
 	}
 	if err := decodeJSON(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 	if body.Provider == "" || body.ProviderSubject == "" || body.Email == "" {
@@ -359,7 +359,7 @@ func (s *Server) LinkAuthUserLoginIdentity(w http.ResponseWriter, r *http.Reques
 	// Ensure the identity is not already owned by another user.
 	existing, err := s.logins.GetLoginIdentityByProvider(r.Context(), body.Provider, body.ProviderSubject)
 	if err != nil && !errors.Is(err, auth.ErrNotFound) {
-		writeError(w, http.StatusInternalServerError, "failed to check existing identity: "+err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	if err == nil && existing.UserID != targetUserID {
@@ -381,7 +381,7 @@ func (s *Server) LinkAuthUserLoginIdentity(w http.ResponseWriter, r *http.Reques
 	})
 	if err != nil {
 		s.log.Error("admin link login identity", "user_id", targetUserID, "provider", body.Provider, "error", err)
-		writeError(w, http.StatusInternalServerError, "failed to link identity: "+err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 
@@ -406,7 +406,7 @@ func (s *Server) ListAuthUserChannelIdentities(w http.ResponseWriter, r *http.Re
 	}
 	identities, err := s.users.ListChannelIdentitiesByUser(r.Context(), targetUserID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to list channel identities: "+err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	writeData(w, http.StatusOK, map[string]any{"identities": identities})

--- a/internal/server/builtin.go
+++ b/internal/server/builtin.go
@@ -55,7 +55,7 @@ func (s *Server) ListBuiltinResources(w http.ResponseWriter, r *http.Request, ki
 	}
 	reg, err := resources.Default()
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	resources := reg.List(kind)
@@ -74,7 +74,7 @@ func (s *Server) GetBuiltinResource(w http.ResponseWriter, r *http.Request, kind
 	}
 	reg, err := resources.Default()
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	res, ok := reg.Get(kind, id)

--- a/internal/server/channels.go
+++ b/internal/server/channels.go
@@ -67,19 +67,19 @@ func (s *Server) ListPublicChannels(w http.ResponseWriter, r *http.Request) {
 
 	enabledTypes, err := s.enabledChannelTypes(r)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 
 	agentNames, err := s.accessibleAgentNames(r, info)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 
 	channels, err := s.store.ListChannels(r.Context())
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 
@@ -189,7 +189,7 @@ func (s *Server) ListChannels(w http.ResponseWriter, r *http.Request) {
 	}
 	channels, err := s.store.ListChannels(r.Context())
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	views := make([]channelView, len(channels))
@@ -217,7 +217,7 @@ func (s *Server) UpdateChannel(w http.ResponseWriter, r *http.Request, id string
 	}
 	var req channelWriteRequest
 	if err := decodeJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 	req.ID = id
@@ -226,7 +226,7 @@ func (s *Server) UpdateChannel(w http.ResponseWriter, r *http.Request, id string
 	existing, existingErr := s.store.GetChannel(ctx, id)
 	cfgMap, err := parseChannelConfig(req.Config)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid config JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid config JSON")
 		return
 	}
 
@@ -240,7 +240,7 @@ func (s *Server) CreateChannel(w http.ResponseWriter, r *http.Request) {
 	}
 	var req channelWriteRequest
 	if err := decodeJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 	channelType := requestChannelType(req)
@@ -251,7 +251,7 @@ func (s *Server) CreateChannel(w http.ResponseWriter, r *http.Request) {
 
 	cfgMap, err := parseChannelConfig(req.Config)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid config JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid config JSON")
 		return
 	}
 
@@ -312,17 +312,17 @@ func (s *Server) defaultChannelEnabled(r *http.Request, channelType string) bool
 func (s *Server) saveChannel(w http.ResponseWriter, r *http.Request, ch config.Channel, cfgMap map[string]any, status int) bool {
 	pluginID := config.PluginID(config.PluginKindChannel, ch.Type)
 	if err := s.pluginHost.ValidateConfig(pluginID, cfgMap); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeError(w, http.StatusBadRequest, "invalid request")
 		return false
 	}
 	cfgJSON, err := json.Marshal(cfgMap)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid config JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid config JSON")
 		return false
 	}
 	ch.Config = string(cfgJSON)
 	if err := s.store.UpsertChannel(r.Context(), ch); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return false
 	}
 	if ch.ID == ch.Type {
@@ -334,7 +334,7 @@ func (s *Server) saveChannel(w http.ResponseWriter, r *http.Request, ch config.C
 			Enabled: pluginEnabled,
 			Config:  map[string]any{},
 		}); err != nil {
-			writeError(w, http.StatusInternalServerError, err.Error())
+			s.writeInternalError(w, err)
 			return false
 		}
 	}
@@ -343,7 +343,7 @@ func (s *Server) saveChannel(w http.ResponseWriter, r *http.Request, ch config.C
 	}
 	saved, err := s.store.GetChannel(r.Context(), ch.ID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return false
 	}
 	writeData(w, status, channelToView(saved))
@@ -378,7 +378,7 @@ func (s *Server) DeleteChannel(w http.ResponseWriter, r *http.Request, id string
 		s.log.Error("failed to stop channel runtime", "channel_id", ch.ID, "channel_type", ch.Type, "error", err)
 	}
 	if err := s.store.DeleteChannel(ctx, id); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	writeNoContent(w)

--- a/internal/server/goals.go
+++ b/internal/server/goals.go
@@ -21,7 +21,7 @@ func (s *Server) loadGoal(ctx context.Context, w http.ResponseWriter, userID, go
 			writeError(w, http.StatusNotFound, "not_found")
 			return sqlc.AgentGoal{}, false
 		}
-		taskError(w, err)
+		s.taskError(w, err)
 		return sqlc.AgentGoal{}, false
 	}
 	if g.UserID != userID {
@@ -48,7 +48,7 @@ func (s *Server) ListGoals(w http.ResponseWriter, r *http.Request, params apiser
 	}
 	rows, err := s.tasksSvc.Facade.ListGoals(r.Context(), info.UserID, int64(limit+1), int64(offset))
 	if err != nil {
-		taskError(w, err)
+		s.taskError(w, err)
 		return
 	}
 	rows, nextToken := nextPageTokenForRows(rows, limit, offset)
@@ -100,7 +100,7 @@ func (s *Server) CreateGoal(w http.ResponseWriter, r *http.Request) {
 	}
 	g, err := s.tasksSvc.Facade.CreateGoal(r.Context(), in)
 	if err != nil {
-		taskError(w, err)
+		s.taskError(w, err)
 		return
 	}
 	writeData(w, http.StatusCreated, goalToAPI(g))
@@ -136,12 +136,12 @@ func (s *Server) ActivateGoal(w http.ResponseWriter, r *http.Request, goalID str
 		return
 	}
 	if err := s.tasksSvc.Facade.ActivateGoal(r.Context(), g.ID, authActor(r)); err != nil {
-		taskError(w, err)
+		s.taskError(w, err)
 		return
 	}
 	fresh, err := s.tasksSvc.Facade.GetGoal(r.Context(), g.ID)
 	if err != nil {
-		taskError(w, err)
+		s.taskError(w, err)
 		return
 	}
 	writeData(w, http.StatusOK, goalToAPI(fresh))
@@ -163,12 +163,12 @@ func (s *Server) CancelGoal(w http.ResponseWriter, r *http.Request, goalID strin
 	var req apitypes.CancelGoalRequest
 	_ = decodeJSON(r, &req)
 	if err := s.tasksSvc.Facade.CancelGoal(r.Context(), g.ID, strPtr(req.Reason), authActor(r)); err != nil {
-		taskError(w, err)
+		s.taskError(w, err)
 		return
 	}
 	fresh, err := s.tasksSvc.Facade.GetGoal(r.Context(), g.ID)
 	if err != nil {
-		taskError(w, err)
+		s.taskError(w, err)
 		return
 	}
 	writeData(w, http.StatusOK, goalToAPI(fresh))
@@ -194,7 +194,7 @@ func (s *Server) ListGoalTasks(w http.ResponseWriter, r *http.Request, goalID st
 	}
 	rows, err := s.tasksSvc.Facade.ListGoalTasks(r.Context(), g.ID, int64(limit+1), int64(offset))
 	if err != nil {
-		taskError(w, err)
+		s.taskError(w, err)
 		return
 	}
 	rows, nextToken := nextPageTokenForRows(rows, limit, offset)
@@ -229,7 +229,7 @@ func (s *Server) ListGoalReviews(w http.ResponseWriter, r *http.Request, goalID 
 	}
 	rows, err := s.tasksSvc.Facade.ListGoalReviews(r.Context(), g.ID, int64(limit+1), int64(offset))
 	if err != nil {
-		taskError(w, err)
+		s.taskError(w, err)
 		return
 	}
 	rows, nextToken := nextPageTokenForRows(rows, limit, offset)
@@ -277,7 +277,7 @@ func (s *Server) EscalateGoalReview(w http.ResponseWriter, r *http.Request, goal
 	var req apitypes.EscalateReviewRequest
 	_ = decodeJSON(r, &req)
 	if err := s.tasksSvc.Facade.EscalateReview(r.Context(), reviewID, strPtr(req.Reason), authActor(r)); err != nil {
-		taskError(w, err)
+		s.taskError(w, err)
 		return
 	}
 	fresh, err := s.tasksSvc.Facade.GetReview(r.Context(), reviewID)
@@ -318,7 +318,7 @@ func (s *Server) decideGoalReview(w http.ResponseWriter, r *http.Request, goalID
 		err = s.tasksSvc.Facade.RequestChanges(r.Context(), reviewID, strPtr(req.Summary), strPtr(req.Feedback), actor)
 	}
 	if err != nil {
-		taskError(w, err)
+		s.taskError(w, err)
 		return
 	}
 	fresh, gerr := s.tasksSvc.Facade.GetReview(r.Context(), reviewID)

--- a/internal/server/manifest_plugins.go
+++ b/internal/server/manifest_plugins.go
@@ -46,7 +46,7 @@ func (s *Server) ListManifestPlugins(w http.ResponseWriter, r *http.Request) {
 	}
 	merged, err := s.resolveManifestPlugins(r)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	writeData(w, http.StatusOK, manifestPluginsResponse{Plugins: merged.Plugins, OAuthProviders: merged.OAuthProviders})
@@ -60,13 +60,13 @@ func (s *Server) SaveManifestPlugins(w http.ResponseWriter, r *http.Request) {
 		Plugins []manifestplugins.ManifestPlugin `json:"plugins"`
 	}
 	if err := decodeJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 
 	builtin, err := manifestplugins.LoadBuiltin()
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	builtinByID := make(map[string]manifestplugins.ManifestPlugin, len(builtin.Plugins))
@@ -85,14 +85,14 @@ func (s *Server) SaveManifestPlugins(w http.ResponseWriter, r *http.Request) {
 		// existing row so we preserve that binding instead of clobbering it.
 		existing, _, err := s.store.GetManifestPluginOverride(r.Context(), plugin.ID)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, err.Error())
+			s.writeInternalError(w, err)
 			return
 		}
 		// Drop the row only when nothing is left to override: the requested
 		// state matches the default and no session env binding is set.
 		if plugin.Enabled == def.Enabled && existing.SessionEnvVaultKey == "" {
 			if err := s.store.DeleteManifestPluginOverride(r.Context(), plugin.ID); err != nil {
-				writeError(w, http.StatusInternalServerError, err.Error())
+				s.writeInternalError(w, err)
 				return
 			}
 			continue
@@ -109,14 +109,14 @@ func (s *Server) SaveManifestPlugins(w http.ResponseWriter, r *http.Request) {
 			Enabled:            enabled,
 			SessionEnvVaultKey: existing.SessionEnvVaultKey,
 		}); err != nil {
-			writeError(w, http.StatusInternalServerError, err.Error())
+			s.writeInternalError(w, err)
 			return
 		}
 	}
 
 	merged, err := s.resolveManifestPlugins(r)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	s.pluginHost.RegisterManifestPlugins(merged)
@@ -137,7 +137,7 @@ func (s *Server) SyncManifestPlugins(w http.ResponseWriter, r *http.Request) {
 	}
 	merged, err := s.resolveManifestPlugins(r)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	result := manifestplugins.Reconcile(r.Context(), merged, config.StellaHome())

--- a/internal/server/models.go
+++ b/internal/server/models.go
@@ -17,7 +17,7 @@ func (s *Server) ListModels(w http.ResponseWriter, r *http.Request) {
 	}
 	providers, err := s.store.ListProviders(r.Context())
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "list provider config: "+err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 

--- a/internal/server/oauth.go
+++ b/internal/server/oauth.go
@@ -76,6 +76,7 @@ func (s *Server) PollOAuthFlow(w http.ResponseWriter, r *http.Request, provider 
 
 	status, _, err := s.credSvc.PollFlow(r.Context(), info.UserID, provider, flowID)
 	if err != nil {
+		s.log.Error("poll oauth flow", "provider", provider, "flow_id", flowID, "error", err)
 		writeError(w, http.StatusBadRequest, "invalid request")
 		return
 	}

--- a/internal/server/oauth.go
+++ b/internal/server/oauth.go
@@ -56,7 +56,7 @@ func (s *Server) StartOAuthFlow(w http.ResponseWriter, r *http.Request, provider
 	status, err := s.credSvc.StartFlowWithOrigin(r.Context(), info.UserID, provider, requestOrigin(r))
 	if err != nil {
 		s.log.Error("start oauth flow", "provider", provider, "user_id", info.UserID, "error", err)
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeError(w, http.StatusBadRequest, "invalid request")
 		return
 	}
 	writeData(w, http.StatusOK, toFlowStatusJSON(status))
@@ -76,7 +76,7 @@ func (s *Server) PollOAuthFlow(w http.ResponseWriter, r *http.Request, provider 
 
 	status, _, err := s.credSvc.PollFlow(r.Context(), info.UserID, provider, flowID)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeError(w, http.StatusBadRequest, "invalid request")
 		return
 	}
 	writeData(w, http.StatusOK, toFlowStatusJSON(status))
@@ -124,7 +124,7 @@ func (s *Server) DisconnectOAuth(w http.ResponseWriter, r *http.Request, provide
 
 	if err := s.credSvc.Disconnect(r.Context(), info.UserID, provider); err != nil {
 		s.log.Error("disconnect oauth", "provider", provider, "user_id", info.UserID, "error", err)
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeError(w, http.StatusBadRequest, "invalid request")
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/internal/server/oauth_providers.go
+++ b/internal/server/oauth_providers.go
@@ -14,7 +14,7 @@ func (s *Server) GetOAuthProviderConfig(w http.ResponseWriter, r *http.Request, 
 	}
 	cfg, err := s.credSvc.GetOAuthProviderConfig(r.Context(), id)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	writeData(w, http.StatusOK, toAPIProviderConfig(cfg))
@@ -26,7 +26,7 @@ func (s *Server) DeleteOAuthProviderConfig(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	if err := s.credSvc.DeleteOAuthProviderConfig(r.Context(), id); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -39,7 +39,7 @@ func (s *Server) SetOAuthProviderConfig(w http.ResponseWriter, r *http.Request, 
 	}
 	var body apiserver.SetOAuthProviderConfigJSONRequestBody
 	if err := decodeJSON(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeError(w, http.StatusBadRequest, "invalid request")
 		return
 	}
 	if body.ClientId == "" {
@@ -53,12 +53,12 @@ func (s *Server) SetOAuthProviderConfig(w http.ResponseWriter, r *http.Request, 
 		RedirectURL:  stringVal(body.RedirectUrl),
 	})
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	cfg, err := s.credSvc.GetOAuthProviderConfig(r.Context(), id)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	writeData(w, http.StatusOK, toAPIProviderConfig(cfg))

--- a/internal/server/plugins.go
+++ b/internal/server/plugins.go
@@ -16,7 +16,7 @@ func (s *Server) ListPlugins(w http.ResponseWriter, r *http.Request) {
 	}
 	plugins, err := s.pluginHost.ListAdminVisiblePlugins(r.Context())
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	writeData(w, http.StatusOK, map[string]any{"plugins": flattenRegisteredPlugins(s, plugins)})
@@ -69,7 +69,7 @@ func (s *Server) GetPluginStatus(w http.ResponseWriter, r *http.Request, kind st
 	id := pluginRouteID(kind, name)
 	status, err := s.pluginHost.Status(r.Context(), id)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	writeData(w, http.StatusOK, status)
@@ -86,7 +86,7 @@ func (s *Server) GetPluginConfig(w http.ResponseWriter, r *http.Request, kind st
 	id := pluginRouteID(kind, name)
 	state, err := s.pluginHost.Config().Get(r.Context(), id)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	writeData(w, http.StatusOK, state.Config)
@@ -109,17 +109,17 @@ func (s *Server) TogglePlugin(w http.ResponseWriter, r *http.Request, kind strin
 		Enabled bool `json:"enabled"`
 	}
 	if err := decodeJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 	if err := s.pluginHost.SetEnabled(r.Context(), id, req.Enabled); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	// Re-fetch the updated plugin to return current state.
 	p, err := s.store.GetPlugin(r.Context(), id)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	// Hot-reload tool plugins so the change takes effect without restart.
@@ -159,7 +159,7 @@ func (s *Server) UpdatePluginConfig(w http.ResponseWriter, r *http.Request, kind
 		Config map[string]any `json:"config"`
 	}
 	if err := decodeJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 	if req.Config == nil {
@@ -170,16 +170,16 @@ func (s *Server) UpdatePluginConfig(w http.ResponseWriter, r *http.Request, kind
 		return
 	}
 	if err := s.pluginHost.ValidateConfig(id, req.Config); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeError(w, http.StatusBadRequest, "invalid request")
 		return
 	}
 	if err := s.pluginHost.Config().Set(r.Context(), id, req.Config); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	p, err := s.store.GetPlugin(r.Context(), id)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	if err := s.pluginHost.ApplyPlugin(r.Context(), id); err != nil {

--- a/internal/server/profile.go
+++ b/internal/server/profile.go
@@ -46,7 +46,7 @@ func (s *Server) ChangePassword(w http.ResponseWriter, r *http.Request) {
 		NewPassword     string `json:"new_password"`
 	}
 	if err := decodeJSON(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 
@@ -111,7 +111,7 @@ func (s *Server) GenerateLinkCode(w http.ResponseWriter, r *http.Request) {
 		Platform string `json:"platform"`
 	}
 	if err := decodeJSON(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 
@@ -193,12 +193,12 @@ func (s *Server) SetProfileSoul(w http.ResponseWriter, r *http.Request, agentID 
 		Soul string `json:"soul"`
 	}
 	if err := decodeJSON(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 	ctx := memory.WithChangeSource(r.Context(), memory.SourceUser)
 	if err := memorywrite.SetAgentSoul(ctx, s.db, s.q, info.UserID, agentID, body.Soul); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	s.writeProfileMemory(w, r, info.UserID, agentID)
@@ -209,7 +209,7 @@ func (s *Server) SetProfileSoul(w http.ResponseWriter, r *http.Request, agentID 
 func (s *Server) writeProfileMemory(w http.ResponseWriter, r *http.Request, userID, agentID string) {
 	mem, err := s.q.GetUserAgentMemory(r.Context(), sqlc.GetUserAgentMemoryParams{UserID: userID, AgentID: agentID})
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	if mem.Soul == "" {

--- a/internal/server/profile.go
+++ b/internal/server/profile.go
@@ -247,7 +247,7 @@ func (s *Server) OauthCallback(w http.ResponseWriter, r *http.Request, provider 
 
 	if err := s.credSvc.CompleteAuthCodeFlowWithOrigin(r.Context(), provider, flowID, code, requestOrigin(r)); err != nil {
 		s.log.Error("oauth callback complete", "provider", provider, "user_id", flow.UserID, "flow_id", flowID, "error", err)
-		http.Error(w, "failed to complete authorization: "+err.Error(), http.StatusInternalServerError)
+		s.writeInternalError(w, err)
 		return
 	}
 

--- a/internal/server/projects.go
+++ b/internal/server/projects.go
@@ -21,7 +21,7 @@ func validateBaseDir(w http.ResponseWriter, agentID, userID, baseDir string) boo
 		return false
 	}
 	if err := agent.ValidateProjectDir(baseDir, userRoot); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid base_dir: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid base_dir")
 		return false
 	}
 	return true
@@ -54,7 +54,7 @@ func (s *Server) ListProjects(w http.ResponseWriter, r *http.Request, agentID st
 		})
 	}
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 
@@ -78,7 +78,7 @@ func (s *Server) CreateProject(w http.ResponseWriter, r *http.Request, agentID s
 
 	var body apiserver.CreateProjectJSONRequestBody
 	if err := decodeJSON(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeError(w, http.StatusBadRequest, "invalid request")
 		return
 	}
 
@@ -104,7 +104,7 @@ func (s *Server) CreateProject(w http.ResponseWriter, r *http.Request, agentID s
 		Description: sql.NullString{String: derefStr(body.Description), Valid: body.Description != nil},
 	})
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 
@@ -131,7 +131,7 @@ func (s *Server) GetProject(w http.ResponseWriter, r *http.Request, agentID stri
 		return
 	}
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	if p.AgentID != agentID {
@@ -162,7 +162,7 @@ func (s *Server) UpdateProject(w http.ResponseWriter, r *http.Request, agentID s
 		return
 	}
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	if existing.AgentID != agentID {
@@ -172,7 +172,7 @@ func (s *Server) UpdateProject(w http.ResponseWriter, r *http.Request, agentID s
 
 	var body apiserver.UpdateProjectJSONRequestBody
 	if err := decodeJSON(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeError(w, http.StatusBadRequest, "invalid request")
 		return
 	}
 
@@ -200,7 +200,7 @@ func (s *Server) UpdateProject(w http.ResponseWriter, r *http.Request, agentID s
 		UserID:      auth.UserID,
 	})
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 
@@ -227,7 +227,7 @@ func (s *Server) DeleteProject(w http.ResponseWriter, r *http.Request, agentID s
 		return
 	}
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	if existing.AgentID != agentID {
@@ -239,7 +239,7 @@ func (s *Server) DeleteProject(w http.ResponseWriter, r *http.Request, agentID s
 		ID:     projectID,
 		UserID: auth.UserID,
 	}); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 

--- a/internal/server/providers.go
+++ b/internal/server/providers.go
@@ -17,7 +17,7 @@ func (s *Server) ListProviders(w http.ResponseWriter, r *http.Request) {
 	}
 	pList, err := s.store.ListProviders(r.Context())
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	writeData(w, http.StatusOK, map[string]any{"providers": pList})
@@ -29,7 +29,7 @@ func (s *Server) CreateProvider(w http.ResponseWriter, r *http.Request) {
 	}
 	var p config.Provider
 	if err := decodeJSON(r, &p); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 	if p.ID == "" {
@@ -47,7 +47,7 @@ func (s *Server) CreateProvider(w http.ResponseWriter, r *http.Request) {
 	}
 	ctx := r.Context()
 	if err := s.store.CreateProvider(ctx, p); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	s.reloadProviders(ctx)
@@ -73,7 +73,7 @@ func (s *Server) UpdateProvider(w http.ResponseWriter, r *http.Request, id strin
 	ctx := r.Context()
 	var p config.Provider
 	if err := decodeJSON(r, &p); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 	existing, err := s.store.GetProvider(ctx, id)
@@ -89,7 +89,7 @@ func (s *Server) UpdateProvider(w http.ResponseWriter, r *http.Request, id strin
 		p.Name = id
 	}
 	if err := s.store.UpdateProvider(ctx, p); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	s.reloadProviders(ctx)
@@ -106,7 +106,7 @@ func (s *Server) DeleteProvider(w http.ResponseWriter, r *http.Request, id strin
 		return
 	}
 	if err := s.store.DeleteProvider(ctx, id); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	s.reloadProviders(ctx)
@@ -154,7 +154,7 @@ func (s *Server) FetchProviderModels(w http.ResponseWriter, r *http.Request, id 
 		BaseURL string `json:"base_url"`
 	}
 	if err := decodeJSON(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 
@@ -206,7 +206,7 @@ func (s *Server) FetchProviderModels(w http.ResponseWriter, r *http.Request, id 
 
 	listed, err := lister.ListModels(fetchCtx)
 	if err != nil {
-		writeError(w, http.StatusBadGateway, "fetch failed: "+err.Error())
+		s.writeBadGatewayError(w, err)
 		return
 	}
 
@@ -221,7 +221,7 @@ func (s *Server) FetchProviderModels(w http.ResponseWriter, r *http.Request, id 
 
 	providerCfg, err = s.store.GetProvider(r.Context(), id)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "reload provider config: "+err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 

--- a/internal/server/recally_handlers.go
+++ b/internal/server/recally_handlers.go
@@ -30,8 +30,8 @@ type recallyHandlers struct {
 	log   *slog.Logger
 }
 
-func newRecallyHandlers(store *recally.Store, files *recally.FileManager) *recallyHandlers {
-	return &recallyHandlers{store: store, files: files, feeds: gofeed.NewParser(), log: slog.With("component", "recally-api")}
+func newRecallyHandlers(store *recally.Store, files *recally.FileManager, log *slog.Logger) *recallyHandlers {
+	return &recallyHandlers{store: store, files: files, feeds: gofeed.NewParser(), log: log.With("component", "recally-api")}
 }
 
 func (h *recallyHandlers) writeInternalError(w http.ResponseWriter, err error) {

--- a/internal/server/recally_handlers.go
+++ b/internal/server/recally_handlers.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 	"maps"
 	"net/http"
@@ -28,10 +27,19 @@ type recallyHandlers struct {
 	store *recally.Store
 	files *recally.FileManager
 	feeds *gofeed.Parser
+	log   *slog.Logger
 }
 
 func newRecallyHandlers(store *recally.Store, files *recally.FileManager) *recallyHandlers {
-	return &recallyHandlers{store: store, files: files, feeds: gofeed.NewParser()}
+	return &recallyHandlers{store: store, files: files, feeds: gofeed.NewParser(), log: slog.With("component", "recally-api")}
+}
+
+func (h *recallyHandlers) writeInternalError(w http.ResponseWriter, err error) {
+	writeLoggedError(w, h.log, http.StatusInternalServerError, "internal error", err)
+}
+
+func (h *recallyHandlers) writeBadGatewayError(w http.ResponseWriter, err error) {
+	writeLoggedError(w, h.log, http.StatusBadGateway, "upstream service error", err)
 }
 
 // requireUser enforces bearer/session auth and returns the user ID. It writes
@@ -50,7 +58,7 @@ func (h *recallyHandlers) requireUser(w http.ResponseWriter, r *http.Request) (s
 func (h *recallyHandlers) articleOwned(w http.ResponseWriter, ctx context.Context, articleID string, userID string) (*recally.Article, bool) {
 	article, err := h.store.GetArticle(ctx, userID, articleID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, err.Error())
+		writeError(w, http.StatusNotFound, "not found")
 		return nil, false
 	}
 	if article.UserID != userID {
@@ -63,7 +71,7 @@ func (h *recallyHandlers) articleOwned(w http.ResponseWriter, ctx context.Contex
 func (h *recallyHandlers) feedOwned(w http.ResponseWriter, ctx context.Context, feedID string, userID string) (*recally.Feed, bool) {
 	feed, err := h.store.GetFeed(ctx, userID, feedID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, err.Error())
+		writeError(w, http.StatusNotFound, "not found")
 		return nil, false
 	}
 	if feed.UserID != userID {
@@ -100,7 +108,7 @@ func (h *recallyHandlers) ListArticles(w http.ResponseWriter, r *http.Request, p
 	if params.Q != nil && *params.Q != "" {
 		articles, err := h.store.SearchArticles(ctx, userID, *params.Q, limit)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, err.Error())
+			h.writeInternalError(w, err)
 			return
 		}
 		writeData(w, http.StatusOK, apiserver.ArticleList{Articles: toAPIArticles(articles)})
@@ -119,7 +127,7 @@ func (h *recallyHandlers) ListArticles(w http.ResponseWriter, r *http.Request, p
 	}
 	articles, err := h.store.ListArticles(ctx, userID, filter)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		h.writeInternalError(w, err)
 		return
 	}
 	articles, nextToken := nextPageTokenForRows(articles, limit, offset)
@@ -179,7 +187,7 @@ func (h *recallyHandlers) SaveArticle(w http.ResponseWriter, r *http.Request) {
 
 	article, isNew, err := h.store.SaveArticle(r.Context(), userID, req)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		h.writeInternalError(w, err)
 		return
 	}
 
@@ -207,12 +215,12 @@ func (h *recallyHandlers) SaveArticle(w http.ResponseWriter, r *http.Request) {
 		filePath = h.files.ArticlePath(userID, article.ID, article.Title, article.SavedAt)
 	}
 	if err := h.files.WriteArticle(filePath, article, content); err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("write article file: %v", err))
+		h.writeInternalError(w, err)
 		return
 	}
 	relPath := h.files.RelativePath(filePath)
 	if err := h.store.UpdateArticleFilePath(r.Context(), userID, article.ID, relPath); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		h.writeInternalError(w, err)
 		return
 	}
 	article.FilePath = relPath
@@ -294,7 +302,7 @@ func (h *recallyHandlers) UpdateArticle(w http.ResponseWriter, r *http.Request, 
 	if len(updates) > 0 {
 		next, err := h.store.UpdateArticle(r.Context(), userID, id, updates)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, err.Error())
+			h.writeInternalError(w, err)
 			return
 		}
 		updated = next
@@ -302,7 +310,7 @@ func (h *recallyHandlers) UpdateArticle(w http.ResponseWriter, r *http.Request, 
 
 	if body.Content != nil || len(updates) > 0 {
 		if err := h.rewriteArticleFile(updated, strDeref(body.Content)); err != nil {
-			writeError(w, http.StatusInternalServerError, err.Error())
+			h.writeInternalError(w, err)
 			return
 		}
 	}
@@ -320,7 +328,7 @@ func (h *recallyHandlers) DeleteArticle(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 	if err := h.store.DeleteArticle(r.Context(), userID, id); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		h.writeInternalError(w, err)
 		return
 	}
 	if article.FilePath != "" {
@@ -356,7 +364,7 @@ func (h *recallyHandlers) ListFeeds(w http.ResponseWriter, r *http.Request, para
 	}
 	feeds, err := h.store.ListFeeds(r.Context(), userID, limit+1, offset)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		h.writeInternalError(w, err)
 		return
 	}
 	feeds, nextToken := nextPageTokenForRows(feeds, limit, offset)
@@ -395,7 +403,7 @@ func (h *recallyHandlers) CreateFeed(w http.ResponseWriter, r *http.Request) {
 	parsed, err := h.feeds.ParseURLWithContext(body.Url, parseCtx)
 	cancel()
 	if err != nil {
-		writeError(w, http.StatusBadGateway, fmt.Sprintf("fetch feed: %v", err))
+		h.writeBadGatewayError(w, err)
 		return
 	}
 	if title == "" {
@@ -405,7 +413,7 @@ func (h *recallyHandlers) CreateFeed(w http.ResponseWriter, r *http.Request) {
 
 	feed, err := h.store.CreateFeed(r.Context(), userID, body.Url, title, description, body.AgentId)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		h.writeInternalError(w, err)
 		return
 	}
 	w.Header().Set("Location", "/api/recally/feeds/"+feed.ID)
@@ -452,7 +460,7 @@ func (h *recallyHandlers) UpdateFeed(w http.ResponseWriter, r *http.Request, id 
 	}
 	updated, err := h.store.UpdateFeed(r.Context(), userID, id, updates)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		h.writeInternalError(w, err)
 		return
 	}
 	writeData(w, http.StatusOK, toAPIFeed(updated))
@@ -467,7 +475,7 @@ func (h *recallyHandlers) DeleteFeed(w http.ResponseWriter, r *http.Request, id 
 		return
 	}
 	if err := h.store.DeleteFeed(r.Context(), userID, id); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		h.writeInternalError(w, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -556,7 +564,7 @@ func (h *recallyHandlers) ListFeedEntries(w http.ResponseWriter, r *http.Request
 	}
 	entries, err := h.store.ListPendingFeedEntries(r.Context(), feedId, limit+1, offset)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		h.writeInternalError(w, err)
 		return
 	}
 	entries, nextToken := nextPageTokenForRows(entries, limit, offset)
@@ -581,7 +589,7 @@ func (h *recallyHandlers) UpdateFeedEntry(w http.ResponseWriter, r *http.Request
 	}
 	entry, err := h.store.GetFeedEntry(r.Context(), feedId, id)
 	if err != nil {
-		writeError(w, http.StatusNotFound, err.Error())
+		writeError(w, http.StatusNotFound, "not found")
 		return
 	}
 	if entry.FeedID != feedId {
@@ -606,7 +614,7 @@ func (h *recallyHandlers) UpdateFeedEntry(w http.ResponseWriter, r *http.Request
 	}
 	updated, err := h.store.MarkFeedEntry(r.Context(), feedId, id, status, body.ArticleId, strDeref(body.ErrorMsg))
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		h.writeInternalError(w, err)
 		return
 	}
 	writeData(w, http.StatusOK, toAPIFeedEntry(updated))
@@ -621,7 +629,7 @@ func (h *recallyHandlers) GetDigest(w http.ResponseWriter, r *http.Request) {
 	}
 	digest, err := h.store.GetDigest(r.Context(), userID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		h.writeInternalError(w, err)
 		return
 	}
 	writeData(w, http.StatusOK, toAPIDigest(digest))
@@ -640,7 +648,7 @@ func (h *recallyHandlers) ListStoredDigests(w http.ResponseWriter, r *http.Reque
 	limit, offset := int64(limitInt), int64(offsetInt)
 	summaries, total, err := h.store.ListStoredDigests(r.Context(), userID, limit, offset)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		h.writeInternalError(w, err)
 		return
 	}
 	items := make([]apitypes.StoredDigestSummary, 0, len(summaries))
@@ -662,7 +670,7 @@ func (h *recallyHandlers) SaveDigest(w http.ResponseWriter, r *http.Request) {
 	}
 	var body apitypes.SaveDigestRequest
 	if err := decodeJSON(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeError(w, http.StatusBadRequest, "invalid request")
 		return
 	}
 	if body.Narrative == "" {
@@ -675,7 +683,7 @@ func (h *recallyHandlers) SaveDigest(w http.ResponseWriter, r *http.Request) {
 	}
 	stored, err := h.store.SaveDigest(r.Context(), userID, body.Narrative, date)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		h.writeInternalError(w, err)
 		return
 	}
 	w.Header().Set("Location", "/api/recally/digests/"+stored.Date)

--- a/internal/server/recally_handlers.go
+++ b/internal/server/recally_handlers.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"log/slog"
 	"maps"
@@ -58,7 +59,11 @@ func (h *recallyHandlers) requireUser(w http.ResponseWriter, r *http.Request) (s
 func (h *recallyHandlers) articleOwned(w http.ResponseWriter, ctx context.Context, articleID string, userID string) (*recally.Article, bool) {
 	article, err := h.store.GetArticle(ctx, userID, articleID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "not found")
+		if errors.Is(err, sql.ErrNoRows) {
+			writeError(w, http.StatusNotFound, "not found")
+		} else {
+			h.writeInternalError(w, err)
+		}
 		return nil, false
 	}
 	if article.UserID != userID {
@@ -71,7 +76,11 @@ func (h *recallyHandlers) articleOwned(w http.ResponseWriter, ctx context.Contex
 func (h *recallyHandlers) feedOwned(w http.ResponseWriter, ctx context.Context, feedID string, userID string) (*recally.Feed, bool) {
 	feed, err := h.store.GetFeed(ctx, userID, feedID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "not found")
+		if errors.Is(err, sql.ErrNoRows) {
+			writeError(w, http.StatusNotFound, "not found")
+		} else {
+			h.writeInternalError(w, err)
+		}
 		return nil, false
 	}
 	if feed.UserID != userID {
@@ -504,7 +513,8 @@ func (h *recallyHandlers) PollFeed(w http.ResponseWriter, r *http.Request, id st
 	parsed, err := h.feeds.ParseURLWithContext(feed.URL, parseCtx)
 	cancel()
 	if err != nil {
-		msg := err.Error()
+		h.log.Warn("feed poll upstream error", "feed_id", feed.ID, "url", feed.URL, "error", err)
+		msg := "failed to fetch feed"
 		result.Error = &msg
 		writeData(w, http.StatusOK, result)
 		return
@@ -697,7 +707,11 @@ func (h *recallyHandlers) GetStoredDigest(w http.ResponseWriter, r *http.Request
 	}
 	stored, err := h.store.GetStoredDigestByDate(r.Context(), userID, date)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "digest not found")
+		if errors.Is(err, sql.ErrNoRows) {
+			writeError(w, http.StatusNotFound, "digest not found")
+		} else {
+			h.writeInternalError(w, err)
+		}
 		return
 	}
 	writeData(w, http.StatusOK, toAPIStoredDigest(stored))

--- a/internal/server/response.go
+++ b/internal/server/response.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strconv"
 )
@@ -65,6 +66,21 @@ func writeError(w http.ResponseWriter, status int, msg string) {
 			"status":  statusName(status),
 		},
 	})
+}
+
+func writeLoggedError(w http.ResponseWriter, log *slog.Logger, status int, clientMessage string, err error) {
+	if log != nil {
+		log.Error("http handler error", "status", status, "error", err)
+	}
+	writeError(w, status, clientMessage)
+}
+
+func (s *Server) writeInternalError(w http.ResponseWriter, err error) {
+	writeLoggedError(w, s.log, http.StatusInternalServerError, "internal error", err)
+}
+
+func (s *Server) writeBadGatewayError(w http.ResponseWriter, err error) {
+	writeLoggedError(w, s.log, http.StatusBadGateway, "upstream service error", err)
 }
 
 // statusName maps an HTTP status code to its canonical AIP status name.

--- a/internal/server/response.go
+++ b/internal/server/response.go
@@ -57,15 +57,21 @@ func writeData(w http.ResponseWriter, status int, data any) {
 // writeError writes a structured error response per AIP-193:
 // {"error": {"code", "message", "status"}}.
 func writeError(w http.ResponseWriter, status int, msg string) {
+	writeErrorDetails(w, status, msg, nil)
+}
+
+func writeErrorDetails(w http.ResponseWriter, status int, msg string, details map[string]any) {
+	errorBody := map[string]any{
+		"code":    status,
+		"message": msg,
+		"status":  statusName(status),
+	}
+	if len(details) > 0 {
+		errorBody["details"] = details
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(map[string]any{
-		"error": map[string]any{
-			"code":    status,
-			"message": msg,
-			"status":  statusName(status),
-		},
-	})
+	_ = json.NewEncoder(w).Encode(map[string]any{"error": errorBody})
 }
 
 func writeLoggedError(w http.ResponseWriter, log *slog.Logger, status int, clientMessage string, err error) {

--- a/internal/server/response.go
+++ b/internal/server/response.go
@@ -69,9 +69,7 @@ func writeError(w http.ResponseWriter, status int, msg string) {
 }
 
 func writeLoggedError(w http.ResponseWriter, log *slog.Logger, status int, clientMessage string, err error) {
-	if log != nil {
-		log.Error("http handler error", "status", status, "error", err)
-	}
+	log.Error("http handler error", "status", status, "error", err)
 	writeError(w, status, clientMessage)
 }
 

--- a/internal/server/scheduler.go
+++ b/internal/server/scheduler.go
@@ -326,7 +326,7 @@ func (s *Server) DeleteSchedulerJob(w http.ResponseWriter, r *http.Request, agen
 		deleteErr = s.q.DeleteSchedulerJob(r.Context(), jobID)
 	}
 	if deleteErr != nil {
-		writeError(w, http.StatusInternalServerError, deleteErr.Error())
+		s.writeInternalError(w, deleteErr)
 		return
 	}
 	writeNoContent(w)

--- a/internal/server/scheduler.go
+++ b/internal/server/scheduler.go
@@ -50,7 +50,7 @@ func (s *Server) CreateSchedulerJob(w http.ResponseWriter, r *http.Request, agen
 
 	var body apiserver.JobInput
 	if err := decodeJSON(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 	if body.Name == nil || *body.Name == "" || body.Message == nil || *body.Message == "" {
@@ -58,7 +58,7 @@ func (s *Server) CreateSchedulerJob(w http.ResponseWriter, r *http.Request, agen
 		return
 	}
 	if err := validateScheduleInput(body); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeError(w, http.StatusBadRequest, "invalid request")
 		return
 	}
 	sessionMode := "reuse"
@@ -80,7 +80,7 @@ func (s *Server) CreateSchedulerJob(w http.ResponseWriter, r *http.Request, agen
 		}
 		job, err := s.schedulerSvc.AddJobWithOwner(*body.Name, *body.Message, sched, sessionMode, agentID, userID)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, err.Error())
+			s.writeInternalError(w, err)
 			return
 		}
 		writeData(w, http.StatusCreated, schedulerJobToAPI(job))
@@ -124,7 +124,7 @@ func (s *Server) CreateSchedulerJob(w http.ResponseWriter, r *http.Request, agen
 		LastError:     "",
 	})
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 
@@ -203,7 +203,7 @@ func (s *Server) UpdateSchedulerJob(w http.ResponseWriter, r *http.Request, agen
 
 	var body apiserver.JobInput
 	if err := decodeJSON(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 
@@ -264,7 +264,7 @@ func (s *Server) UpdateSchedulerJob(w http.ResponseWriter, r *http.Request, agen
 		LastError:     existing.LastError,
 	})
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 
@@ -368,7 +368,7 @@ func (s *Server) TriggerSchedulerJob(w http.ResponseWriter, r *http.Request, age
 
 	runID, err := s.schedulerSvc.RunJobNow(r.Context(), jobID)
 	if err != nil {
-		writeError(w, http.StatusConflict, err.Error())
+		writeError(w, http.StatusConflict, "resource conflict")
 		return
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -85,6 +85,7 @@ func New(ctx context.Context, store config.Store, authStore auth.AuthStore, engi
 	flowStore := oauth.NewFlowStore()
 	credSvc := credentials.NewService(nil, sqlc.New(db), flowStore, corsOrigin)
 
+	log := slog.With("component", "admin")
 	s := &Server{
 		store:       store,
 		authStore:   authStore,
@@ -97,10 +98,10 @@ func New(ctx context.Context, store config.Store, authStore auth.AuthStore, engi
 		pluginHost:  pluginHost,
 		q:           sqlc.New(db),
 		mux:         http.NewServeMux(),
-		log:         slog.With("component", "admin"),
+		log:         log,
 		corsOriginV: corsOrigin,
 		credSvc:     credSvc,
-		recally:     newRecallyHandlers(recally.NewStore(db), recally.NewFileManager(config.StellaHome())),
+		recally:     newRecallyHandlers(recally.NewStore(db), recally.NewFileManager(config.StellaHome()), log),
 		startedAt:   time.Now(),
 	}
 

--- a/internal/server/sessions.go
+++ b/internal/server/sessions.go
@@ -42,7 +42,7 @@ func (s *Server) CreateSession(w http.ResponseWriter, r *http.Request, agentID s
 
 	var body apiserver.CreateSessionJSONRequestBody
 	if err := decodeJSON(r, &body); err != nil && err.Error() != "EOF" {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeError(w, http.StatusBadRequest, "invalid request")
 		return
 	}
 
@@ -63,7 +63,7 @@ func (s *Server) CreateSession(w http.ResponseWriter, r *http.Request, agentID s
 
 	info, err := pool.CreateSessionWithKind("admin", kind, projectID, authInfo.UserID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 
@@ -84,7 +84,7 @@ func (s *Server) SendSessionMessage(w http.ResponseWriter, r *http.Request, agen
 
 	var body apiserver.SendSessionMessageJSONRequestBody
 	if err := decodeJSON(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeError(w, http.StatusBadRequest, "invalid request")
 		return
 	}
 	if len(body.Parts) == 0 {
@@ -101,7 +101,7 @@ func (s *Server) SendSessionMessage(w http.ResponseWriter, r *http.Request, agen
 	ctx := memoryContext(r, agentID)
 	si, err := sm.LoadInfo(ctx, sessionID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, err.Error())
+		writeError(w, http.StatusNotFound, "not found")
 		return
 	}
 
@@ -461,7 +461,7 @@ func (s *Server) ListSessions(w http.ResponseWriter, r *http.Request, agentID st
 	}
 	sessions, err := sm.ListInfo(memoryContext(r, agentID), opts)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 
@@ -493,7 +493,7 @@ func (s *Server) GetSession(w http.ResponseWriter, r *http.Request, agentID stri
 	}
 	si, err := sm.LoadInfo(memoryContext(r, agentID), sessionID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, err.Error())
+		writeError(w, http.StatusNotFound, "not found")
 		return
 	}
 
@@ -555,7 +555,7 @@ func (s *Server) GetSessionMessages(w http.ResponseWriter, r *http.Request, agen
 	}
 	rows, err := s.q.GetMessagesByConversation(r.Context(), conv.ID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 
@@ -610,7 +610,7 @@ func (s *Server) checkSessionAccess(w http.ResponseWriter, r *http.Request, agen
 	}
 	si, err := sm.LoadInfo(memoryContext(r, agentID), sessionID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, err.Error())
+		writeError(w, http.StatusNotFound, "not found")
 		return err
 	}
 	if si.UserID != info.UserID {
@@ -639,7 +639,7 @@ func (s *Server) GetSessionWorkspace(w http.ResponseWriter, r *http.Request, age
 	}
 	info, err := sm.LoadInfo(memoryContext(r, agentID), sessionID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, err.Error())
+		writeError(w, http.StatusNotFound, "not found")
 		return
 	}
 	if info.UserID == "" || info.AgentID == "" {
@@ -648,7 +648,7 @@ func (s *Server) GetSessionWorkspace(w http.ResponseWriter, r *http.Request, age
 	}
 	userDir, err := agent.SetupUserWorkspace(info.AgentID, config.StellaHome(), info.UserID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	root := userDir
@@ -663,7 +663,7 @@ func (s *Server) GetSessionWorkspace(w http.ResponseWriter, r *http.Request, age
 	}
 	diskInfo, err := collectWorkspaceDiskInfo(root, showHidden, listPath, depth)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	writeData(w, http.StatusOK, diskInfo)
@@ -757,7 +757,7 @@ func (s *Server) sessionWorkspaceRoot(w http.ResponseWriter, r *http.Request, ag
 	}
 	info, err := sm.LoadInfo(memoryContext(r, agentID), sessionID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, err.Error())
+		writeError(w, http.StatusNotFound, "not found")
 		return "", err
 	}
 	if info.UserID == "" || info.AgentID == "" {
@@ -766,7 +766,7 @@ func (s *Server) sessionWorkspaceRoot(w http.ResponseWriter, r *http.Request, ag
 	}
 	userDir, err := agent.SetupUserWorkspace(info.AgentID, config.StellaHome(), info.UserID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return "", err
 	}
 	return userDir, nil
@@ -790,7 +790,7 @@ func (s *Server) CreateWorkspaceFile(w http.ResponseWriter, r *http.Request, age
 	}
 	var body apiserver.CreateWorkspaceFileJSONRequestBody
 	if err := decodeJSON(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeError(w, http.StatusBadRequest, "invalid request")
 		return
 	}
 	if body.Path == "" {
@@ -799,17 +799,17 @@ func (s *Server) CreateWorkspaceFile(w http.ResponseWriter, r *http.Request, age
 	}
 	abs, err := safePath(root, body.Path)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeError(w, http.StatusBadRequest, "invalid request")
 		return
 	}
 	if body.IsDir != nil && *body.IsDir {
 		if err := os.MkdirAll(abs, 0o755); err != nil {
-			writeError(w, http.StatusInternalServerError, err.Error())
+			s.writeInternalError(w, err)
 			return
 		}
 	} else {
 		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
-			writeError(w, http.StatusInternalServerError, err.Error())
+			s.writeInternalError(w, err)
 			return
 		}
 		content := ""
@@ -817,13 +817,13 @@ func (s *Server) CreateWorkspaceFile(w http.ResponseWriter, r *http.Request, age
 			content = *body.Content
 		}
 		if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
-			writeError(w, http.StatusInternalServerError, err.Error())
+			s.writeInternalError(w, err)
 			return
 		}
 	}
 	diskInfo, err := collectWorkspaceDiskInfo(root, false, "", 0)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	writeData(w, http.StatusCreated, diskInfo)
@@ -836,7 +836,7 @@ func (s *Server) DeleteWorkspaceFile(w http.ResponseWriter, r *http.Request, age
 	}
 	var body apiserver.DeleteWorkspaceFileJSONRequestBody
 	if err := decodeJSON(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeError(w, http.StatusBadRequest, "invalid request")
 		return
 	}
 	if body.Path == "" {
@@ -845,11 +845,11 @@ func (s *Server) DeleteWorkspaceFile(w http.ResponseWriter, r *http.Request, age
 	}
 	abs, err := safePath(root, body.Path)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeError(w, http.StatusBadRequest, "invalid request")
 		return
 	}
 	if err := os.RemoveAll(abs); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	writeNoContent(w)
@@ -862,7 +862,7 @@ func (s *Server) MoveWorkspaceFile(w http.ResponseWriter, r *http.Request, agent
 	}
 	var body apiserver.MoveWorkspaceFileJSONRequestBody
 	if err := decodeJSON(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeError(w, http.StatusBadRequest, "invalid request")
 		return
 	}
 	if body.Path == "" || body.NewPath == "" {
@@ -871,25 +871,25 @@ func (s *Server) MoveWorkspaceFile(w http.ResponseWriter, r *http.Request, agent
 	}
 	src, err := safePath(root, body.Path)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeError(w, http.StatusBadRequest, "invalid request")
 		return
 	}
 	dst, err := safePath(root, body.NewPath)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeError(w, http.StatusBadRequest, "invalid request")
 		return
 	}
 	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	if err := os.Rename(src, dst); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	diskInfo, err := collectWorkspaceDiskInfo(root, false, "", 0)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	writeData(w, http.StatusOK, diskInfo)
@@ -906,12 +906,12 @@ func (s *Server) GetWorkspaceFileContent(w http.ResponseWriter, r *http.Request,
 	}
 	abs, err := safePath(root, params.Path)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeError(w, http.StatusBadRequest, "invalid request")
 		return
 	}
 	info, err := os.Stat(abs)
 	if err != nil {
-		writeError(w, http.StatusNotFound, err.Error())
+		writeError(w, http.StatusNotFound, "not found")
 		return
 	}
 	if info.IsDir() {
@@ -925,7 +925,7 @@ func (s *Server) GetWorkspaceFileContent(w http.ResponseWriter, r *http.Request,
 	}
 	data, err := os.ReadFile(abs)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	// Refuse binary files: check first 512 bytes for null byte.
@@ -952,7 +952,7 @@ func (s *Server) UpdateWorkspaceFileContent(w http.ResponseWriter, r *http.Reque
 	}
 	var body apiserver.UpdateWorkspaceFileContentJSONRequestBody
 	if err := decodeJSON(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeError(w, http.StatusBadRequest, "invalid request")
 		return
 	}
 	if body.Path == "" {
@@ -961,15 +961,15 @@ func (s *Server) UpdateWorkspaceFileContent(w http.ResponseWriter, r *http.Reque
 	}
 	abs, err := safePath(root, body.Path)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeError(w, http.StatusBadRequest, "invalid request")
 		return
 	}
 	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	if err := os.WriteFile(abs, []byte(body.Content), 0o644); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	lang := detectLanguage(body.Path)
@@ -986,19 +986,19 @@ func (s *Server) UploadWorkspaceFile(w http.ResponseWriter, r *http.Request, age
 		return
 	}
 	if err := r.ParseMultipartForm(32 << 20); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid multipart form: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid multipart form")
 		return
 	}
 	file, header, err := r.FormFile("file")
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "missing file field: "+err.Error())
+		writeError(w, http.StatusBadRequest, "missing file field")
 		return
 	}
 	defer func() { _ = file.Close() }()
 
 	data, err := io.ReadAll(file)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 
@@ -1006,13 +1006,13 @@ func (s *Server) UploadWorkspaceFile(w http.ResponseWriter, r *http.Request, age
 	hash := fmt.Sprintf("%06x", now.UnixNano()&0xFFFFFF)
 	dir := filepath.Join(root, ".assets", now.Format("200601"))
 	if err := os.MkdirAll(dir, 0o755); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	name := fmt.Sprintf("%s-%s-%s", now.Format("20060102"), hash, filepath.Base(header.Filename))
 	abs := filepath.Join(dir, name)
 	if err := os.WriteFile(abs, data, 0o644); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	rel, _ := filepath.Rel(root, abs)
@@ -1086,7 +1086,7 @@ func (s *Server) GetSessionSystemPrompt(w http.ResponseWriter, r *http.Request, 
 
 	info, err := sm.LoadInfo(memoryContext(r, agentID), sessionID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, err.Error())
+		writeError(w, http.StatusNotFound, "not found")
 		return
 	}
 
@@ -1103,13 +1103,13 @@ func (s *Server) GetSessionSystemPrompt(w http.ResponseWriter, r *http.Request, 
 	}
 	projectRoot, err := s.projectRootForSession(memoryContext(r, agentID), agentID, &sessionID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	homeDir, _ := os.UserHomeDir()
 	pluginView, err := s.pluginHost.SessionPluginView(r.Context())
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	promptBuild := pkgplugins.SystemPromptContext{
@@ -1126,11 +1126,11 @@ func (s *Server) GetSessionSystemPrompt(w http.ResponseWriter, r *http.Request, 
 	}
 	promptSections, err := s.pluginHost.SystemPromptSections(r.Context(), promptBuild)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	if skillsSection, err := skillstool.BuildPromptSection(r.Context(), promptBuild); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	} else if skillsSection.Title != "" && skillsSection.Content != "" {
 		promptSections = append(promptSections, skillsSection)

--- a/internal/server/shares.go
+++ b/internal/server/shares.go
@@ -75,7 +75,7 @@ func (s *Server) CreateShare(w http.ResponseWriter, r *http.Request) {
 
 	var body apitypes.CreateShareRequest
 	if err := decodeJSON(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 
@@ -86,12 +86,12 @@ func (s *Server) CreateShare(w http.ResponseWriter, r *http.Request) {
 
 	token, tokenHash, err := newShareToken()
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	expiresAt, err := shareExpiry(body.ExpiresIn)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeError(w, http.StatusBadRequest, "invalid request")
 		return
 	}
 	share, err := s.q.CreateShare(r.Context(), sqlc.CreateShareParams{
@@ -104,7 +104,7 @@ func (s *Server) CreateShare(w http.ResponseWriter, r *http.Request) {
 		ExpiresAt: expiresAt,
 	})
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	writeData(w, http.StatusCreated, apitypes.Share{
@@ -152,12 +152,12 @@ func (s *Server) resolveArtifactContent(w http.ResponseWriter, r *http.Request, 
 	}
 	abs, err := safePath(root, path)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeError(w, http.StatusBadRequest, "invalid request")
 		return "", "", nil, err
 	}
 	fi, err := os.Stat(abs)
 	if err != nil {
-		writeError(w, http.StatusNotFound, err.Error())
+		writeError(w, http.StatusNotFound, "not found")
 		return "", "", nil, err
 	}
 	if fi.IsDir() {
@@ -175,7 +175,7 @@ func (s *Server) resolveArtifactContent(w http.ResponseWriter, r *http.Request, 
 	}
 	data, err := os.ReadFile(abs)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return "", "", nil, err
 	}
 	return filepath.Base(path), mt, data, nil
@@ -232,7 +232,7 @@ func (s *Server) RevokeShare(w http.ResponseWriter, r *http.Request, id string) 
 	}
 	rows, err := s.q.DeleteShareByUser(r.Context(), sqlc.DeleteShareByUserParams{ID: id, UserID: info.UserID})
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	if rows == 0 {

--- a/internal/server/skills.go
+++ b/internal/server/skills.go
@@ -66,7 +66,7 @@ func (s *Server) applySkillUpdate(w http.ResponseWriter, r *http.Request, id str
 	}
 	var req updateSkillRequest
 	if err := decodeJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 	patch := skills.UpdatePatch{
@@ -80,7 +80,7 @@ func (s *Server) applySkillUpdate(w http.ResponseWriter, r *http.Request, id str
 			if errors.Is(err, sql.ErrNoRows) {
 				writeError(w, http.StatusNotFound, "skill not found")
 			} else {
-				writeError(w, http.StatusInternalServerError, err.Error())
+				s.writeInternalError(w, err)
 			}
 			return
 		}
@@ -89,7 +89,7 @@ func (s *Server) applySkillUpdate(w http.ResponseWriter, r *http.Request, id str
 				UpdateSystemSkill(context.Context, string, skills.UpdatePatch) error
 			}); ok {
 				if err := systemStore.UpdateSystemSkill(r.Context(), id, patch); err != nil {
-					writeError(w, http.StatusInternalServerError, err.Error())
+					s.writeInternalError(w, err)
 					return
 				}
 				s.upsertSkillFiles(w, store, r.Context(), id, req.Files)
@@ -99,7 +99,7 @@ func (s *Server) applySkillUpdate(w http.ResponseWriter, r *http.Request, id str
 		vc = skillOwnerViewContext(*sk)
 	}
 	if err := store.Update(r.Context(), id, vc, patch); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	s.upsertSkillFiles(w, store, r.Context(), id, req.Files)
@@ -108,7 +108,7 @@ func (s *Server) applySkillUpdate(w http.ResponseWriter, r *http.Request, id str
 func (s *Server) upsertSkillFiles(w http.ResponseWriter, store skills.Store, ctx context.Context, id string, files map[string]string) {
 	for path, content := range files {
 		if err := store.UpsertFile(ctx, id, path, content); err != nil {
-			writeError(w, http.StatusInternalServerError, err.Error())
+			s.writeInternalError(w, err)
 			return
 		}
 	}
@@ -139,7 +139,7 @@ func (s *Server) doDeleteSkill(w http.ResponseWriter, r *http.Request, id string
 			if errors.Is(err, sql.ErrNoRows) {
 				writeError(w, http.StatusNotFound, "skill not found")
 			} else {
-				writeError(w, http.StatusInternalServerError, err.Error())
+				s.writeInternalError(w, err)
 			}
 			return
 		}
@@ -148,7 +148,7 @@ func (s *Server) doDeleteSkill(w http.ResponseWriter, r *http.Request, id string
 				DeleteSystemSkill(context.Context, string) error
 			}); ok {
 				if err := systemStore.DeleteSystemSkill(r.Context(), id); err != nil {
-					writeError(w, http.StatusInternalServerError, err.Error())
+					s.writeInternalError(w, err)
 					return
 				}
 				writeNoContent(w)
@@ -158,7 +158,7 @@ func (s *Server) doDeleteSkill(w http.ResponseWriter, r *http.Request, id string
 		vc = skillOwnerViewContext(*sk)
 	}
 	if err := store.Delete(r.Context(), id, vc); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	writeNoContent(w)
@@ -180,7 +180,7 @@ func (s *Server) doDeleteSkillFile(w http.ResponseWriter, r *http.Request, id, p
 		return
 	}
 	if err := store.DeleteFile(r.Context(), id, path); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	writeNoContent(w)
@@ -202,7 +202,7 @@ func (s *Server) SearchSkills(w http.ResponseWriter, r *http.Request, params api
 
 	results, err := mcpskills.Search(ctx, q, limit)
 	if err != nil {
-		writeError(w, http.StatusBadGateway, err.Error())
+		s.writeBadGatewayError(w, err)
 		return
 	}
 	writeData(w, http.StatusOK, map[string]any{"skills": results})

--- a/internal/server/skills_scoped.go
+++ b/internal/server/skills_scoped.go
@@ -282,12 +282,12 @@ func (s *Server) ListAgentSkills(w http.ResponseWriter, r *http.Request, id stri
 	}
 	projectRoot, err := s.projectRootForSession(memoryContext(r, agentID), agentID, params.SessionId)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	dbSkills, err := s.skillStore().ListForAgentContext(r.Context(), info.UserID, agentID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	merged := s.skillService().ListMergedWithDB(dbSkillsToPluginSkills(dbSkills), projectRoot)
@@ -305,7 +305,7 @@ func (s *Server) CreateAgentSkill(w http.ResponseWriter, r *http.Request, id str
 	agentID := id
 	var req createSkillRequest
 	if err := decodeJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 	if req.Name == "" {
@@ -342,7 +342,7 @@ func (s *Server) CreateAgentSkill(w http.ResponseWriter, r *http.Request, id str
 	}
 	createdID, err := s.skillStore().Create(r.Context(), sk, files)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	writeData(w, http.StatusCreated, map[string]string{"id": createdID, "name": req.Name})
@@ -386,7 +386,7 @@ func (s *Server) UpdateAgentSkill(w http.ResponseWriter, r *http.Request, id str
 		}
 		var req updateSkillRequest
 		if err := decodeJSON(r, &req); err != nil {
-			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+			writeError(w, http.StatusBadRequest, "invalid JSON")
 			return
 		}
 		for p, content := range req.Files {
@@ -396,11 +396,11 @@ func (s *Server) UpdateAgentSkill(w http.ResponseWriter, r *http.Request, id str
 				return
 			}
 			if err := os.MkdirAll(filepath.Dir(file), 0o755); err != nil {
-				writeError(w, http.StatusInternalServerError, err.Error())
+				s.writeInternalError(w, err)
 				return
 			}
 			if err := os.WriteFile(file, []byte(content), 0o644); err != nil {
-				writeError(w, http.StatusInternalServerError, err.Error())
+				s.writeInternalError(w, err)
 				return
 			}
 		}
@@ -434,7 +434,7 @@ func (s *Server) DeleteAgentSkill(w http.ResponseWriter, r *http.Request, id str
 			return
 		}
 		if err := os.RemoveAll(rs.Dir); err != nil {
-			writeError(w, http.StatusInternalServerError, err.Error())
+			s.writeInternalError(w, err)
 			return
 		}
 		writeNoContent(w)
@@ -468,7 +468,7 @@ func (s *Server) GetAgentSkillFile(w http.ResponseWriter, r *http.Request, id st
 	}
 	content, err := s.loadSkillFile(r.Context(), rs, params.Path)
 	if err != nil {
-		writeError(w, http.StatusNotFound, err.Error())
+		writeError(w, http.StatusNotFound, "not found")
 		return
 	}
 	writeData(w, http.StatusOK, map[string]string{"path": params.Path, "content": content})
@@ -496,7 +496,7 @@ func (s *Server) DeleteAgentSkillFile(w http.ResponseWriter, r *http.Request, id
 			return
 		}
 		if err := os.Remove(file); err != nil && !errors.Is(err, fs.ErrNotExist) {
-			writeError(w, http.StatusInternalServerError, err.Error())
+			s.writeInternalError(w, err)
 			return
 		}
 		writeNoContent(w)
@@ -519,7 +519,7 @@ func (s *Server) InstallAgentSkill(w http.ResponseWriter, r *http.Request, id st
 	agentID := id
 	var req installSkillRequest
 	if err := decodeJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 	if req.Source == "" {
@@ -541,7 +541,7 @@ func (s *Server) InstallAgentSkill(w http.ResponseWriter, r *http.Request, id st
 	}
 	name, err := skillstool.InstallToStore(r.Context(), pluginhost.NewSkillStoreAdapter(s.skillStore()), req.Source, scope, storeUserID, agentID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	writeData(w, http.StatusCreated, map[string]string{"name": name})

--- a/internal/server/skills_scoped.go
+++ b/internal/server/skills_scoped.go
@@ -49,7 +49,8 @@ func (s *Server) requireAgentAccess(ctx context.Context, agentID string) (config
 		if errors.Is(err, sql.ErrNoRows) {
 			return config.Agent{}, http.StatusNotFound, "agent not found"
 		}
-		return config.Agent{}, http.StatusInternalServerError, err.Error()
+		s.log.Error("get agent", "agent_id", agentID, "error", err)
+		return config.Agent{}, http.StatusInternalServerError, "internal error"
 	}
 	if !info.IsAdmin && !s.canAccessAgent(ctx, info, a) {
 		return config.Agent{}, http.StatusForbidden, "forbidden"
@@ -80,7 +81,8 @@ func (s *Server) requireSkillScope(ctx context.Context, id, scope string, userID
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, http.StatusNotFound, "skill not found"
 		}
-		return nil, http.StatusInternalServerError, err.Error()
+		s.log.Error("find skill", "skill_id", id, "error", err)
+		return nil, http.StatusInternalServerError, "internal error"
 	}
 	if sk.Scope != scope {
 		return nil, http.StatusNotFound, "skill not found"
@@ -213,7 +215,8 @@ func (s *Server) resolveSkillAny(ctx context.Context, agentID, skillName string,
 	vc := pkgplugins.SkillViewContext{UserID: info.UserID, AgentID: agentID}
 	rs, err := s.skillService().Resolve(ctx, skillName, vc, projectRoot)
 	if err != nil {
-		return nil, "", http.StatusInternalServerError, err.Error()
+		s.log.Error("resolve skill", "agent_id", agentID, "skill", skillName, "error", err)
+		return nil, "", http.StatusInternalServerError, "internal error"
 	}
 	if rs == nil {
 		return nil, "", http.StatusNotFound, "skill not found"
@@ -234,7 +237,8 @@ func (s *Server) resolveSkill(ctx context.Context, agentID, skillName, scope str
 	vc := pkgplugins.SkillViewContext{UserID: info.UserID, AgentID: agentID}
 	rs, err := s.skillService().ResolveScoped(ctx, skillName, scope, vc, projectRoot)
 	if err != nil {
-		return nil, "", http.StatusInternalServerError, err.Error()
+		s.log.Error("resolve scoped skill", "agent_id", agentID, "skill", skillName, "scope", scope, "error", err)
+		return nil, "", http.StatusInternalServerError, "internal error"
 	}
 	if rs == nil {
 		return nil, "", http.StatusNotFound, "skill not found"

--- a/internal/server/skills_upload.go
+++ b/internal/server/skills_upload.go
@@ -70,7 +70,7 @@ func (s *Server) uploadAgentSkill(w http.ResponseWriter, r *http.Request, agentI
 	}
 	skillID, err := s.skillStore().Create(r.Context(), sk, up.files)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	writeData(w, http.StatusCreated, map[string]string{"id": skillID, "name": up.name})

--- a/internal/server/skills_upload.go
+++ b/internal/server/skills_upload.go
@@ -79,7 +79,7 @@ func (s *Server) uploadAgentSkill(w http.ResponseWriter, r *http.Request, agentI
 func parseUploadedSkill(r *http.Request) (*uploadedSkill, int, string) {
 	r.Body = http.MaxBytesReader(nil, r.Body, maxSkillUploadZipBytes+(1<<20))
 	if err := r.ParseMultipartForm(maxSkillUploadZipBytes); err != nil {
-		return nil, http.StatusBadRequest, "invalid multipart form: " + err.Error()
+		return nil, http.StatusBadRequest, "invalid multipart form"
 	}
 	defer func() {
 		if r.MultipartForm != nil {
@@ -93,7 +93,7 @@ func parseUploadedSkill(r *http.Request) (*uploadedSkill, int, string) {
 	defer func() { _ = file.Close() }()
 	up, err := readUploadedSkillArchive(file, header)
 	if err != nil {
-		return nil, http.StatusBadRequest, err.Error()
+		return nil, http.StatusBadRequest, "invalid skill archive"
 	}
 	return up, 0, ""
 }

--- a/internal/server/status.go
+++ b/internal/server/status.go
@@ -53,7 +53,8 @@ func (s *Server) statusDatabase(ctx context.Context) *types.StatusDatabase {
 	defer cancel()
 	start := time.Now()
 	if err := s.db.PingContext(ctx); err != nil {
-		msg := err.Error()
+		s.log.Error("database health check failed", "error", err)
+		msg := "database unreachable"
 		return &types.StatusDatabase{Status: "error", Error: &msg}
 	}
 	latency := float64(time.Since(start).Microseconds()) / 1000

--- a/internal/server/tasks.go
+++ b/internal/server/tasks.go
@@ -51,17 +51,8 @@ func (s *Server) taskError(w http.ResponseWriter, err error) {
 	default:
 		var conflict *tasks.ErrReopenConflict
 		if errors.As(err, &conflict) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusConflict)
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"error": map[string]any{
-					"code":    http.StatusConflict,
-					"message": "reopen_conflict",
-					"status":  "ABORTED",
-					"details": map[string]any{
-						"downstream_ids": conflict.DownstreamIDs,
-					},
-				},
+			writeErrorDetails(w, http.StatusConflict, "reopen_conflict", map[string]any{
+				"downstream_ids": conflict.DownstreamIDs,
 			})
 			return
 		}

--- a/internal/server/tasks.go
+++ b/internal/server/tasks.go
@@ -51,9 +51,17 @@ func (s *Server) taskError(w http.ResponseWriter, err error) {
 	default:
 		var conflict *tasks.ErrReopenConflict
 		if errors.As(err, &conflict) {
-			writeData(w, http.StatusConflict, map[string]any{
-				"error":          "reopen_conflict",
-				"downstream_ids": conflict.DownstreamIDs,
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusConflict)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{
+					"code":    http.StatusConflict,
+					"message": "reopen_conflict",
+					"status":  "ABORTED",
+					"details": map[string]any{
+						"downstream_ids": conflict.DownstreamIDs,
+					},
+				},
 			})
 			return
 		}

--- a/internal/server/tasks.go
+++ b/internal/server/tasks.go
@@ -34,7 +34,7 @@ func authActor(r *http.Request) tasks.Actor {
 }
 
 // taskError centralizes the error → HTTP mapping (D4).
-func taskError(w http.ResponseWriter, err error) {
+func (s *Server) taskError(w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, tasks.ErrTaskNotFound), errors.Is(err, tasks.ErrBlockerNotFound), errors.Is(err, tasks.ErrReviewNotFound):
 		writeError(w, http.StatusNotFound, "not_found")
@@ -57,7 +57,7 @@ func taskError(w http.ResponseWriter, err error) {
 			})
 			return
 		}
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 	}
 }
 
@@ -71,7 +71,7 @@ func (s *Server) loadTask(ctx context.Context, w http.ResponseWriter, taskID str
 			writeError(w, http.StatusNotFound, "not_found")
 			return sqlc.AgentTask{}, false
 		}
-		taskError(w, err)
+		s.taskError(w, err)
 		return sqlc.AgentTask{}, false
 	}
 	info := UserFromContext(ctx)
@@ -118,7 +118,7 @@ func (s *Server) ListTasks(w http.ResponseWriter, r *http.Request, params apiser
 	}
 	rows, err := s.tasksSvc.Facade.ListTasksByUser(r.Context(), info.UserID, agentID, status, int64(limit+1), int64(offset))
 	if err != nil {
-		taskError(w, err)
+		s.taskError(w, err)
 		return
 	}
 	rows, nextToken := nextPageTokenForRows(rows, limit, offset)
@@ -194,7 +194,7 @@ func (s *Server) CreateTask(w http.ResponseWriter, r *http.Request) {
 	}
 	t, err := s.tasksSvc.Facade.CreateTask(r.Context(), in)
 	if err != nil {
-		taskError(w, err)
+		s.taskError(w, err)
 		return
 	}
 	writeData(w, http.StatusCreated, taskToAPI(t))
@@ -234,12 +234,12 @@ func (s *Server) CancelTask(w http.ResponseWriter, r *http.Request, taskID strin
 	var req apitypes.CancelRequest
 	_ = decodeJSON(r, &req) // body is optional
 	if err := s.tasksSvc.Facade.CancelTask(r.Context(), t.ID, strPtr(req.Reason), authActor(r)); err != nil {
-		taskError(w, err)
+		s.taskError(w, err)
 		return
 	}
 	fresh, err := s.tasksSvc.Facade.GetTask(r.Context(), t.ID)
 	if err != nil {
-		taskError(w, err)
+		s.taskError(w, err)
 		return
 	}
 	writeData(w, http.StatusOK, taskToAPI(fresh))
@@ -261,12 +261,12 @@ func (s *Server) ReopenTask(w http.ResponseWriter, r *http.Request, taskID strin
 	_ = decodeJSON(r, &req)
 	cascade := req.Cascade != nil && *req.Cascade
 	if err := s.tasksSvc.Facade.ReopenTask(r.Context(), t.ID, cascade, authActor(r)); err != nil {
-		taskError(w, err)
+		s.taskError(w, err)
 		return
 	}
 	fresh, err := s.tasksSvc.Facade.GetTask(r.Context(), t.ID)
 	if err != nil {
-		taskError(w, err)
+		s.taskError(w, err)
 		return
 	}
 	writeData(w, http.StatusOK, taskToAPI(fresh))
@@ -290,7 +290,7 @@ func (s *Server) GetTaskReadiness(w http.ResponseWriter, r *http.Request, taskID
 	}
 	rd, err := s.tasksSvc.Facade.GetReadiness(r.Context(), t.ID)
 	if err != nil {
-		taskError(w, err)
+		s.taskError(w, err)
 		return
 	}
 	writeData(w, http.StatusOK, readinessToAPI(rd))
@@ -315,7 +315,7 @@ func (s *Server) ListTaskEvents(w http.ResponseWriter, r *http.Request, taskID s
 	}
 	rows, err := s.tasksSvc.Facade.ListEvents(r.Context(), t.ID, int64(limit+1), int64(offset))
 	if err != nil {
-		taskError(w, err)
+		s.taskError(w, err)
 		return
 	}
 	rows, nextToken := nextPageTokenForRows(rows, limit, offset)
@@ -349,7 +349,7 @@ func (s *Server) ListTaskRuns(w http.ResponseWriter, r *http.Request, taskID str
 	}
 	rows, err := s.tasksSvc.Facade.ListRuns(r.Context(), t.ID, int64(limit+1), int64(offset))
 	if err != nil {
-		taskError(w, err)
+		s.taskError(w, err)
 		return
 	}
 	rows, nextToken := nextPageTokenForRows(rows, limit, offset)
@@ -387,7 +387,7 @@ func (s *Server) ListTaskDeps(w http.ResponseWriter, r *http.Request, taskID str
 	}
 	rows, err := s.tasksSvc.Facade.ListDeps(r.Context(), t.ID, int64(limit+1), int64(offset))
 	if err != nil {
-		taskError(w, err)
+		s.taskError(w, err)
 		return
 	}
 	rows, nextToken := nextPageTokenForRows(rows, limit, offset)
@@ -436,7 +436,7 @@ func (s *Server) AddTaskDep(w http.ResponseWriter, r *http.Request, taskID strin
 		onFailure = string(*req.OnFailure)
 	}
 	if err := s.tasksSvc.Facade.AddDep(r.Context(), t.ID, dep.ID, kind, onFailure); err != nil {
-		taskError(w, err)
+		s.taskError(w, err)
 		return
 	}
 	w.WriteHeader(http.StatusCreated)
@@ -465,7 +465,7 @@ func (s *Server) WaiveTaskDep(w http.ResponseWriter, r *http.Request, taskID str
 	var req apitypes.WaiveDepRequest
 	_ = decodeJSON(r, &req)
 	if err := s.tasksSvc.Facade.WaiveDep(r.Context(), t.ID, depTaskID, userID, strPtr(req.Reason), authActor(r)); err != nil {
-		taskError(w, err)
+		s.taskError(w, err)
 		return
 	}
 	w.WriteHeader(http.StatusOK)
@@ -499,12 +499,12 @@ func (s *Server) ResolveTaskBlocker(w http.ResponseWriter, r *http.Request, task
 	var req apitypes.ResolveBlockerRequest
 	_ = decodeJSON(r, &req)
 	if err := s.tasksSvc.Facade.ResolveBlocker(r.Context(), blockerID, strPtr(req.Resolution), authActor(r)); err != nil {
-		taskError(w, err)
+		s.taskError(w, err)
 		return
 	}
 	fresh, err := s.tasksSvc.Facade.GetTask(r.Context(), t.ID)
 	if err != nil {
-		taskError(w, err)
+		s.taskError(w, err)
 		return
 	}
 	writeData(w, http.StatusOK, taskToAPI(fresh))
@@ -533,7 +533,7 @@ func (s *Server) ListTaskReviews(w http.ResponseWriter, r *http.Request, taskID 
 	}
 	rows, err := s.tasksSvc.Facade.ListReviews(r.Context(), t.ID, int64(limit+1), int64(offset))
 	if err != nil {
-		taskError(w, err)
+		s.taskError(w, err)
 		return
 	}
 	rows, nextToken := nextPageTokenForRows(rows, limit, offset)
@@ -580,7 +580,7 @@ func (s *Server) EscalateTaskReview(w http.ResponseWriter, r *http.Request, task
 	var req apitypes.EscalateReviewRequest
 	_ = decodeJSON(r, &req)
 	if err := s.tasksSvc.Facade.EscalateReview(r.Context(), reviewID, strPtr(req.Reason), authActor(r)); err != nil {
-		taskError(w, err)
+		s.taskError(w, err)
 		return
 	}
 	fresh, err := s.tasksSvc.Facade.GetReview(r.Context(), reviewID)
@@ -622,7 +622,7 @@ func (s *Server) decideReview(w http.ResponseWriter, r *http.Request, taskID, re
 		err = s.tasksSvc.Facade.RequestChanges(r.Context(), reviewID, strPtr(req.Summary), strPtr(req.Feedback), actor)
 	}
 	if err != nil {
-		taskError(w, err)
+		s.taskError(w, err)
 		return
 	}
 	fresh, gerr := s.tasksSvc.Facade.GetReview(r.Context(), reviewID)

--- a/internal/server/users.go
+++ b/internal/server/users.go
@@ -39,7 +39,7 @@ func (s *Server) UpdateUserDefaultAgent(w http.ResponseWriter, r *http.Request, 
 		DefaultAgentID string `json:"default_agent_id"`
 	}
 	if err := decodeJSON(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 	if !info.IsAdmin {
@@ -49,7 +49,7 @@ func (s *Server) UpdateUserDefaultAgent(w http.ResponseWriter, r *http.Request, 
 		}
 	}
 	if err := s.users.UpdateUserDefaultAgent(r.Context(), targetUserID, body.DefaultAgentID); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	s.writeAuthUser(w, r, targetUserID)
@@ -64,7 +64,7 @@ func (s *Server) UpdateUserNotifyIdentity(w http.ResponseWriter, r *http.Request
 		NotifyIdentityID *string `json:"notify_identity_id"`
 	}
 	if err := decodeJSON(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 	if body.NotifyIdentityID != nil {
@@ -79,7 +79,7 @@ func (s *Server) UpdateUserNotifyIdentity(w http.ResponseWriter, r *http.Request
 		}
 	}
 	if err := s.users.UpdateUserNotifyIdentity(r.Context(), targetUserID, body.NotifyIdentityID); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	s.writeAuthUser(w, r, targetUserID)
@@ -92,7 +92,7 @@ func (s *Server) ListUserMemories(w http.ResponseWriter, r *http.Request, id str
 	}
 	memories, err := s.q.ListUserAgentMemoriesByUser(r.Context(), targetUserID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	defaultSoul := prompt.DefaultAgentSoul()
@@ -117,7 +117,7 @@ func (s *Server) SetUserMemory(w http.ResponseWriter, r *http.Request, id string
 		Content string `json:"content"`
 	}
 	if err := decodeJSON(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 	source := memory.SourceSystem
@@ -126,7 +126,7 @@ func (s *Server) SetUserMemory(w http.ResponseWriter, r *http.Request, id string
 	}
 	ctx := memory.WithChangeSource(r.Context(), source)
 	if err := memorywrite.SetProfile(ctx, s.db, s.q, targetUserID, agentID, body.Content); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	s.writeProfileMemory(w, r, targetUserID, agentID)
@@ -147,7 +147,7 @@ func (s *Server) DeleteUserMemory(w http.ResponseWriter, r *http.Request, id str
 	}
 	ctx := memory.WithChangeSource(r.Context(), source)
 	if err := memorywrite.DeleteProfile(ctx, s.db, s.q, targetUserID, agentID); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+		s.writeInternalError(w, err)
 		return
 	}
 	writeNoContent(w)

--- a/internal/server/vault.go
+++ b/internal/server/vault.go
@@ -99,7 +99,7 @@ func (s *Server) SetVaultEntry(w http.ResponseWriter, r *http.Request, name stri
 		Value string `json:"value"`
 	}
 	if err := decodeJSON(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		writeError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
 	if body.Value == "" {
@@ -109,7 +109,7 @@ func (s *Server) SetVaultEntry(w http.ResponseWriter, r *http.Request, name stri
 
 	if err := s.vaultSvc.Set(r.Context(), info.UserID, name, body.Value); err != nil {
 		s.log.Error("set vault entry", "user_id", info.UserID, "name", name, "error", err)
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeError(w, http.StatusBadRequest, "invalid request")
 		return
 	}
 

--- a/internal/server/weixin_qr.go
+++ b/internal/server/weixin_qr.go
@@ -21,7 +21,7 @@ func (s *Server) StartWeixinQR(w http.ResponseWriter, r *http.Request) {
 	client := weixin.NewClient("", "", "", "")
 	qr, err := client.GetQRCode()
 	if err != nil {
-		writeError(w, http.StatusBadGateway, "failed to get QR code: "+err.Error())
+		s.writeBadGatewayError(w, err)
 		return
 	}
 	writeData(w, http.StatusOK, qr)
@@ -47,7 +47,7 @@ func (s *Server) PollWeixinQRStatus(w http.ResponseWriter, r *http.Request, para
 	client := weixin.NewClient("", "", "", "")
 	status, err := client.GetQRCodeStatus(qrcode)
 	if err != nil {
-		writeError(w, http.StatusBadGateway, "failed to poll QR status: "+err.Error())
+		s.writeBadGatewayError(w, err)
 		return
 	}
 
@@ -55,7 +55,7 @@ func (s *Server) PollWeixinQRStatus(w http.ResponseWriter, r *http.Request, para
 	if status.Status == "confirmed" && status.BotToken != "" {
 		if err := s.saveWeixinCredentials(r.Context(), status); err != nil {
 			s.log.Error("save weixin credentials", "error", err)
-			writeError(w, http.StatusInternalServerError, "QR confirmed but failed to save credentials: "+err.Error())
+			s.writeInternalError(w, err)
 			return
 		}
 

--- a/web/content/docs/development/rules/api-design.md
+++ b/web/content/docs/development/rules/api-design.md
@@ -300,9 +300,11 @@ Every error response uses HTTP status codes **and** this structured body
 }
 ```
 
-Every error uses this exact shape — **never the flat `{"error": "message"}`
+Every error uses this shape — **never the flat `{"error": "message"}`
 form**. The `code` mirrors the HTTP status, `status` is the canonical name,
-`message` is human-readable.
+`message` is human-readable. Some errors may include an optional `details`
+object for machine-readable context; detail keys use `snake_case` and must be
+safe to expose to clients.
 
 ### Status code reference
 
@@ -415,7 +417,8 @@ Before approving any API change:
 3. Is the resource schema consistent across all methods that return it?
 4. Do list endpoints return a resource-named array (not a bare array) and
    support `page_size` / `page_token` / `next_page_token` when paginated?
-5. Are errors returned with `{ "error": { "code", "message", "status" } }` and
+5. Are errors returned with `{ "error": { "code", "message", "status" } }`,
+   optional safe `details` only when clients need machine-readable context, and
    the correct HTTP status?
 6. Are field names `snake_case`?
 7. Do Create and Update return the full resource (Update with 200, not 204)?

--- a/web/content/docs/development/task-system.md
+++ b/web/content/docs/development/task-system.md
@@ -226,12 +226,12 @@ authenticated session.
 
 Typed error codes:
 
-| Condition                        | HTTP | Code                                            |
-| -------------------------------- | ---- | ----------------------------------------------- |
-| Unknown task / blocker / review  | 404  | `not_found`                                     |
-| Invalid lifecycle transition     | 409  | `invalid_transition`                            |
-| Dep edge would close a cycle     | 409  | `dep_cycle`                                     |
-| Review already resolved          | 409  | `review_closed`                                 |
-| Dep-failure blocker (use waiver) | 409  | `dep_failure_requires_waiver`                   |
-| Blocker not open                 | 409  | `blocker_already_closed`                        |
-| Reopen would orphan downstream   | 409  | `reopen_conflict` (body lists `downstream_ids`) |
+| Condition                        | HTTP | Code                                                  |
+| -------------------------------- | ---- | ----------------------------------------------------- |
+| Unknown task / blocker / review  | 404  | `not_found`                                           |
+| Invalid lifecycle transition     | 409  | `invalid_transition`                                  |
+| Dep edge would close a cycle     | 409  | `dep_cycle`                                           |
+| Review already resolved          | 409  | `review_closed`                                       |
+| Dep-failure blocker (use waiver) | 409  | `dep_failure_requires_waiver`                         |
+| Blocker not open                 | 409  | `blocker_already_closed`                              |
+| Reopen would orphan downstream   | 409  | `reopen_conflict` with `error.details.downstream_ids` |

--- a/web/content/docs/development/task-system.zh.md
+++ b/web/content/docs/development/task-system.zh.md
@@ -208,12 +208,12 @@ Slice 1(MVP)已落地:
 
 典型错误编码:
 
-| 条件                               | HTTP | code                                        |
-| ---------------------------------- | ---- | ------------------------------------------- |
-| 任务 / blocker / 评审不存在        | 404  | `not_found`                                 |
-| 非法状态迁移                       | 409  | `invalid_transition`                        |
-| 依赖边会形成环                     | 409  | `dep_cycle`                                 |
-| 评审已结束                         | 409  | `review_closed`                             |
-| dep_failure 类型 blocker(需要豁免) | 409  | `dep_failure_requires_waiver`               |
-| blocker 已关闭                     | 409  | `blocker_already_closed`                    |
-| reopen 会使下游孤立                | 409  | `reopen_conflict`(body 含 `downstream_ids`) |
+| 条件                               | HTTP | code                                                 |
+| ---------------------------------- | ---- | ---------------------------------------------------- |
+| 任务 / blocker / 评审不存在        | 404  | `not_found`                                          |
+| 非法状态迁移                       | 409  | `invalid_transition`                                 |
+| 依赖边会形成环                     | 409  | `dep_cycle`                                          |
+| 评审已结束                         | 409  | `review_closed`                                      |
+| dep_failure 类型 blocker(需要豁免) | 409  | `dep_failure_requires_waiver`                        |
+| blocker 已关闭                     | 409  | `blocker_already_closed`                             |
+| reopen 会使下游孤立                | 409  | `reopen_conflict`，含 `error.details.downstream_ids` |


### PR DESCRIPTION
Closes #256.\n\nSanitizes call sites in internal/server where raw err.Error() was passed directly to the client in 5xx/4xx responses.\n\nChanges:\n- 5xx/BadGateway errors now log the raw error server-side and return generic messages to the client.\n- 4xx errors keep actionable messages but no longer echo internal error chains.\n- Adds writeLoggedError / writeInternalError / writeBadGatewayError helpers to centralize the pattern.\n- taskError converted to a (s *Server) method to reuse logging.\n\nNo functional changes beyond error message text.