### PR TITLE
fix: persist manifest plugin config overrides

### DIFF
--- a/cmd/stella/setup_plugins.go
+++ b/cmd/stella/setup_plugins.go
@@ -26,7 +26,7 @@ type pluginSetup struct {
 	manifestToReconcile    *manifestplugins.Manifest
 }
 
-func setupPlugins(_ context.Context, db *sql.DB, store config.Store, skillStore *skills.DiskSyncStore, dispatcher *notify.Dispatcher) (*pluginSetup, error) {
+func setupPlugins(ctx context.Context, db *sql.DB, store config.Store, skillStore *skills.DiskSyncStore, dispatcher *notify.Dispatcher) (*pluginSetup, error) {
 	oidcStore := appdb.NewOIDCStore(db)
 	channelRuntimeServices := pluginhost.NewChannelRuntimeServices()
 	stateStore := pluginstate.New(db)
@@ -48,7 +48,7 @@ func setupPlugins(_ context.Context, db *sql.DB, store config.Store, skillStore 
 		manifestToReconcile *manifestplugins.Manifest
 	)
 
-	builtinManifest, err := manifestplugins.LoadBuiltin()
+	builtinManifest, err := loadBuiltinManifestWithOverrides(ctx, store)
 	if err != nil {
 		slog.Warn("manifest plugin: failed to load builtin manifest", "error", err)
 	} else {
@@ -63,6 +63,30 @@ func setupPlugins(_ context.Context, db *sql.DB, store config.Store, skillStore 
 		oauthRegistry:          oauthRegistry,
 		manifestToReconcile:    manifestToReconcile,
 	}, nil
+}
+
+func loadBuiltinManifestWithOverrides(ctx context.Context, store config.Store) (*manifestplugins.Manifest, error) {
+	builtin, err := manifestplugins.LoadBuiltin()
+	if err != nil {
+		return nil, err
+	}
+	if store == nil {
+		return builtin, nil
+	}
+	overrides, err := store.ListManifestPluginOverrides(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list manifest plugin overrides: %w", err)
+	}
+	byID := make(map[string]config.ManifestPluginOverride, len(overrides))
+	for _, ov := range overrides {
+		byID[ov.PluginID] = ov
+	}
+	for i := range builtin.Plugins {
+		if ov, ok := byID[builtin.Plugins[i].ID]; ok && ov.Enabled != nil {
+			builtin.Plugins[i].Enabled = *ov.Enabled
+		}
+	}
+	return builtin, nil
 }
 
 func buildOAuthRegistry(merged *manifestplugins.Manifest) *oauth.ProviderRegistry {

--- a/cmd/stella/version.go
+++ b/cmd/stella/version.go
@@ -31,6 +31,7 @@ var (
 	upgradeUserAgent    = "stella-upgrade"
 	errUnsupportedAsset = errors.New("no release asset for current platform")
 	errInvalidTarget    = errors.New("existing target is not a replaceable file")
+	executablePath      = os.Executable
 	renameFile          = os.Rename
 )
 
@@ -71,7 +72,7 @@ func upgradeCommand() *ucli.Command {
 		Flags: []ucli.Flag{
 			&ucli.StringFlag{
 				Name:  "install-dir",
-				Usage: "Directory to install the upgraded binary into",
+				Usage: "Directory to install the upgraded binary into (defaults to the running stella binary's directory)",
 			},
 		},
 		Action: func(c *ucli.Context) error {
@@ -109,11 +110,14 @@ func displayVersion() string {
 }
 
 func defaultInstallDir() (string, error) {
-	home, err := os.UserHomeDir()
+	exePath, err := executablePath()
 	if err != nil {
-		return "", fmt.Errorf("resolve home dir: %w", err)
+		return "", fmt.Errorf("resolve stella executable path: %w", err)
 	}
-	return filepath.Join(home, ".local", "bin"), nil
+	if exePath == "" {
+		return "", errors.New("resolve stella executable path: empty path")
+	}
+	return filepath.Dir(exePath), nil
 }
 
 func fetchLatestRelease(ctx context.Context) (*githubRelease, error) {
@@ -217,7 +221,7 @@ func installReleaseAsset(ctx context.Context, asset githubReleaseAsset, installD
 
 	targetPath = filepath.Join(installDir, binaryName)
 	if err := installBinary(extractedPath, targetPath, goos != "windows"); err != nil {
-		return "", err
+		return "", upgradeInstallError(err, targetPath, goos)
 	}
 	return targetPath, nil
 }
@@ -383,6 +387,13 @@ func installBinary(srcPath, targetPath string, executable bool) error {
 		return err
 	}
 
+	if runtime.GOOS != "windows" {
+		if err := renameFile(tmpPath, targetPath); err != nil {
+			return fmt.Errorf("install binary: %w", err)
+		}
+		return nil
+	}
+
 	if _, err := os.Lstat(targetPath); err == nil {
 		if err := renameFile(targetPath, backupPath); err != nil {
 			_ = os.Remove(tmpPath)
@@ -410,6 +421,20 @@ func installBinary(srcPath, targetPath string, executable bool) error {
 		}
 	}
 	return nil
+}
+
+func upgradeInstallError(err error, targetPath, goos string) error {
+	lower := strings.ToLower(err.Error())
+	if strings.Contains(lower, "text file busy") || strings.Contains(lower, "file busy") || strings.Contains(lower, "being used by another process") || strings.Contains(lower, "sharing violation") || strings.Contains(lower, "resource busy") {
+		if goos == "windows" {
+			return fmt.Errorf("%w\n%s is locked by a running process; stop stella first, then run the upgrade from another shell or install into a different directory with --install-dir", err, targetPath)
+		}
+		return fmt.Errorf("%w\n%s is busy; stop any running stella process or service that is using this binary, then retry", err, targetPath)
+	}
+	if errors.Is(err, os.ErrPermission) || strings.Contains(lower, "permission denied") || strings.Contains(lower, "access is denied") {
+		return fmt.Errorf("%w\npermission denied replacing %s; rerun as a user that can write to %s, or choose another target with --install-dir", err, targetPath, filepath.Dir(targetPath))
+	}
+	return err
 }
 
 func ensureReplaceableTarget(targetPath string) error {

--- a/cmd/stella/version.go
+++ b/cmd/stella/version.go
@@ -389,6 +389,7 @@ func installBinary(srcPath, targetPath string, executable bool) error {
 
 	if runtime.GOOS != "windows" {
 		if err := renameFile(tmpPath, targetPath); err != nil {
+			_ = os.Remove(tmpPath)
 			return fmt.Errorf("install binary: %w", err)
 		}
 		return nil

--- a/cmd/stella/version.go
+++ b/cmd/stella/version.go
@@ -76,16 +76,12 @@ func upgradeCommand() *ucli.Command {
 			},
 		},
 		Action: func(c *ucli.Context) error {
-			installDir := c.String("install-dir")
-			if installDir == "" {
-				dir, err := defaultInstallDir()
-				if err != nil {
-					return err
-				}
-				installDir = dir
+			targetPath, err := resolveUpgradeTarget(c.String("install-dir"), runtime.GOOS)
+			if err != nil {
+				return err
 			}
 
-			result, err := runUpgrade(c.Context, installDir, displayVersion(), runtime.GOOS, runtime.GOARCH)
+			result, err := runUpgrade(c.Context, targetPath, displayVersion(), runtime.GOOS, runtime.GOARCH)
 			if err != nil {
 				return err
 			}
@@ -109,7 +105,14 @@ func displayVersion() string {
 	return normalized
 }
 
-func defaultInstallDir() (string, error) {
+// resolveUpgradeTarget returns the full path to install the upgraded binary.
+// When installDir is empty, it returns the running executable's path so the
+// upgrade replaces the exact binary that's running. When installDir is set,
+// it uses the canonical release binary name within that directory.
+func resolveUpgradeTarget(installDir, goos string) (string, error) {
+	if installDir != "" {
+		return filepath.Join(installDir, binaryNameForGOOS(goos)), nil
+	}
 	exePath, err := executablePath()
 	if err != nil {
 		return "", fmt.Errorf("resolve stella executable path: %w", err)
@@ -117,7 +120,7 @@ func defaultInstallDir() (string, error) {
 	if exePath == "" {
 		return "", errors.New("resolve stella executable path: empty path")
 	}
-	return filepath.Dir(exePath), nil
+	return exePath, nil
 }
 
 func fetchLatestRelease(ctx context.Context) (*githubRelease, error) {
@@ -142,7 +145,7 @@ func fetchLatestRelease(ctx context.Context) (*githubRelease, error) {
 	return &parsed, nil
 }
 
-func runUpgrade(ctx context.Context, installDir, currentVersion, goos, goarch string) (*upgradeResult, error) {
+func runUpgrade(ctx context.Context, targetPath, currentVersion, goos, goarch string) (*upgradeResult, error) {
 	release, err := fetchLatestRelease(ctx)
 	if err != nil {
 		return nil, err
@@ -168,8 +171,7 @@ func runUpgrade(ctx context.Context, installDir, currentVersion, goos, goarch st
 		return nil, err
 	}
 
-	targetPath, err := installReleaseAsset(ctx, asset, installDir, goos)
-	if err != nil {
+	if err := installReleaseAsset(ctx, asset, targetPath, goos); err != nil {
 		return nil, err
 	}
 	result.TargetPath = targetPath
@@ -193,14 +195,15 @@ func releaseAssetSuffixes(goos, goarch string) []string {
 	return []string{base + ".tar.gz", base + ".zip"}
 }
 
-func installReleaseAsset(ctx context.Context, asset githubReleaseAsset, installDir, goos string) (targetPath string, err error) {
+func installReleaseAsset(ctx context.Context, asset githubReleaseAsset, targetPath, goos string) (err error) {
+	installDir := filepath.Dir(targetPath)
 	if err := os.MkdirAll(installDir, 0o755); err != nil {
-		return "", fmt.Errorf("create install dir: %w", err)
+		return fmt.Errorf("create install dir: %w", err)
 	}
 
 	tmpDir, err := os.MkdirTemp("", "stella-upgrade-*")
 	if err != nil {
-		return "", fmt.Errorf("create temp dir: %w", err)
+		return fmt.Errorf("create temp dir: %w", err)
 	}
 	defer func() {
 		if removeErr := os.RemoveAll(tmpDir); removeErr != nil && err == nil {
@@ -210,20 +213,18 @@ func installReleaseAsset(ctx context.Context, asset githubReleaseAsset, installD
 
 	archivePath := filepath.Join(tmpDir, asset.Name)
 	if err := downloadFile(ctx, asset.BrowserDownloadURL, archivePath); err != nil {
-		return "", err
+		return err
 	}
 
-	binaryName := binaryNameForGOOS(goos)
-	extractedPath, err := extractBinaryFromArchive(archivePath, tmpDir, binaryName)
+	extractedPath, err := extractBinaryFromArchive(archivePath, tmpDir, binaryNameForGOOS(goos))
 	if err != nil {
-		return "", err
+		return err
 	}
 
-	targetPath = filepath.Join(installDir, binaryName)
 	if err := installBinary(extractedPath, targetPath, goos != "windows"); err != nil {
-		return "", upgradeInstallError(err, targetPath, goos)
+		return upgradeInstallError(err, targetPath, goos)
 	}
-	return targetPath, nil
+	return nil
 }
 
 func downloadFile(ctx context.Context, url, dest string) error {

--- a/cmd/stella/version_test.go
+++ b/cmd/stella/version_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDefaultInstallDirUsesRunningExecutableDir(t *testing.T) {
+	oldExecutablePath := executablePath
+	executablePath = func() (string, error) {
+		return filepath.Join(string(filepath.Separator), "opt", "stella", binaryNameForGOOS("linux")), nil
+	}
+	t.Cleanup(func() { executablePath = oldExecutablePath })
+
+	dir, err := defaultInstallDir()
+	if err != nil {
+		t.Fatalf("defaultInstallDir: %v", err)
+	}
+
+	want := filepath.Join(string(filepath.Separator), "opt", "stella")
+	if dir != want {
+		t.Fatalf("defaultInstallDir() = %q, want %q", dir, want)
+	}
+}
+
+func TestDefaultInstallDirReportsExecutablePathError(t *testing.T) {
+	oldExecutablePath := executablePath
+	executablePath = func() (string, error) {
+		return "", errors.New("boom")
+	}
+	t.Cleanup(func() { executablePath = oldExecutablePath })
+
+	_, err := defaultInstallDir()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestUpgradeInstallErrorAddsPermissionHint(t *testing.T) {
+	err := upgradeInstallError(errors.New("rename stella.tmp stella: permission denied"), "/usr/local/bin/stella", "linux")
+
+	if !strings.Contains(err.Error(), "permission denied replacing /usr/local/bin/stella") {
+		t.Fatalf("error = %q, want permission hint", err.Error())
+	}
+}
+
+func TestUpgradeInstallErrorAddsWindowsBusyHint(t *testing.T) {
+	err := upgradeInstallError(errors.New("The process cannot access the file because it is being used by another process."), `C:\\bin\\stella.exe`, "windows")
+
+	if !strings.Contains(err.Error(), "locked by a running process") {
+		t.Fatalf("error = %q, want busy hint", err.Error())
+	}
+}

--- a/cmd/stella/version_test.go
+++ b/cmd/stella/version_test.go
@@ -7,32 +7,39 @@ import (
 	"testing"
 )
 
-func TestDefaultInstallDirUsesRunningExecutableDir(t *testing.T) {
+func TestResolveUpgradeTargetDefaultUsesExecutablePath(t *testing.T) {
 	oldExecutablePath := executablePath
-	executablePath = func() (string, error) {
-		return filepath.Join(string(filepath.Separator), "opt", "stella", binaryNameForGOOS("linux")), nil
-	}
+	exePath := filepath.Join(string(filepath.Separator), "opt", "stella", binaryNameForGOOS("linux"))
+	executablePath = func() (string, error) { return exePath, nil }
 	t.Cleanup(func() { executablePath = oldExecutablePath })
 
-	dir, err := defaultInstallDir()
+	got, err := resolveUpgradeTarget("", "linux")
 	if err != nil {
-		t.Fatalf("defaultInstallDir: %v", err)
+		t.Fatalf("resolveUpgradeTarget: %v", err)
 	}
-
-	want := filepath.Join(string(filepath.Separator), "opt", "stella")
-	if dir != want {
-		t.Fatalf("defaultInstallDir() = %q, want %q", dir, want)
+	if got != exePath {
+		t.Fatalf("resolveUpgradeTarget() = %q, want %q", got, exePath)
 	}
 }
 
-func TestDefaultInstallDirReportsExecutablePathError(t *testing.T) {
-	oldExecutablePath := executablePath
-	executablePath = func() (string, error) {
-		return "", errors.New("boom")
+func TestResolveUpgradeTargetWithInstallDir(t *testing.T) {
+	dir := filepath.Join(string(filepath.Separator), "usr", "local", "bin")
+	got, err := resolveUpgradeTarget(dir, "linux")
+	if err != nil {
+		t.Fatalf("resolveUpgradeTarget: %v", err)
 	}
+	want := filepath.Join(dir, binaryNameForGOOS("linux"))
+	if got != want {
+		t.Fatalf("resolveUpgradeTarget() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveUpgradeTargetReportsExecutablePathError(t *testing.T) {
+	oldExecutablePath := executablePath
+	executablePath = func() (string, error) { return "", errors.New("boom") }
 	t.Cleanup(func() { executablePath = oldExecutablePath })
 
-	_, err := defaultInstallDir()
+	_, err := resolveUpgradeTarget("", "linux")
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -22,6 +22,7 @@ type ManifestPluginOverride struct {
 	PluginID           string
 	Enabled            *bool  // nil = fallback to manifest default; non-nil = override
 	SessionEnvVaultKey string // empty = fallback; non-empty = vault blob with session_env override map
+	Config             string // JSON manifest plugin definition override; empty = fallback to builtin
 	UpdatedAt          string
 }
 

--- a/internal/db/migrations/20260601060943_add_config_to_plugin_override.sql
+++ b/internal/db/migrations/20260601060943_add_config_to_plugin_override.sql
@@ -1,0 +1,2 @@
+-- Add column "config" to table: "plugin_override"
+ALTER TABLE `plugin_override` ADD COLUMN `config` text NOT NULL DEFAULT '';

--- a/internal/db/migrations/atlas.sum
+++ b/internal/db/migrations/atlas.sum
@@ -1,2 +1,3 @@
-h1:tgeiKd3nOxdKIlVQ2HT+HXO8eKFiNZTQ6eiBLjj6Ue4=
+h1:EunuJRiX0I61VJWzOB6BoEhR/WSFDikbtlxWNfsLtBU=
 20260531120105_initial.sql h1:yFv08NKwCabgVkvWoSNzba6WMXjbXrI9xHctaJBir/8=
+20260601060943_add_config_to_plugin_override.sql h1:q2MIJRzEYGDQyjnLeFUrQ0zbnvdgxBh/MRANwRmPFn4=

--- a/internal/db/queries/plugin_override.sql
+++ b/internal/db/queries/plugin_override.sql
@@ -7,11 +7,12 @@ SELECT * FROM plugin_override
 ORDER BY plugin_id;
 
 -- name: UpsertManifestPluginOverride :exec
-INSERT INTO plugin_override (plugin_id, enabled, session_env_vault_key, updated_at)
-VALUES (?, ?, ?, datetime('now'))
+INSERT INTO plugin_override (plugin_id, enabled, session_env_vault_key, config, updated_at)
+VALUES (?, ?, ?, ?, datetime('now'))
 ON CONFLICT(plugin_id) DO UPDATE SET
     enabled               = excluded.enabled,
     session_env_vault_key = excluded.session_env_vault_key,
+    config                = excluded.config,
     updated_at            = datetime('now');
 
 -- name: DeleteManifestPluginOverride :exec

--- a/internal/db/schemas/tables/plugin_override.sql
+++ b/internal/db/schemas/tables/plugin_override.sql
@@ -2,6 +2,7 @@ CREATE TABLE plugin_override (
     plugin_id             TEXT NOT NULL PRIMARY KEY,
     enabled               INTEGER,                      -- nullable: NULL=fallback to manifest default
     session_env_vault_key TEXT NOT NULL DEFAULT '',     -- empty=fallback; non-empty=vault blob holding the session_env override map
+    config                TEXT NOT NULL DEFAULT '',     -- JSON manifest plugin override (binaries, session_env, oauth_provider, etc.)
     created_at            TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at            TEXT NOT NULL DEFAULT (datetime('now'))
 );

--- a/internal/manifestplugins/loader_test.go
+++ b/internal/manifestplugins/loader_test.go
@@ -21,8 +21,8 @@ func TestLoadBuiltinLarkCLIOAuthProvider(t *testing.T) {
 		if p.ID != "tool/lark-cli" {
 			continue
 		}
-		if p.OAuthProvider != "lark" {
-			t.Fatalf("OAuthProvider = %q, want lark", p.OAuthProvider)
+		if p.OAuthProvider != "feishu" {
+			t.Fatalf("OAuthProvider = %q, want feishu", p.OAuthProvider)
 		}
 		for _, se := range p.SessionEnvs {
 			if se.EnvVar == "LARKSUITE_CLI_BRAND" && se.Source != "oauth.brand" {

--- a/internal/server/manifest_plugins.go
+++ b/internal/server/manifest_plugins.go
@@ -44,7 +44,9 @@ func (s *Server) resolveManifestPlugins(r *http.Request) (*manifestplugins.Manif
 		}
 		if ov.Config != "" {
 			var p manifestplugins.ManifestPlugin
-			if err := json.Unmarshal([]byte(ov.Config), &p); err == nil {
+			if err := json.Unmarshal([]byte(ov.Config), &p); err != nil {
+				s.log.Warn("ignoring corrupt plugin config override", "plugin", id, "error", err)
+			} else {
 				p.ID = id
 				builtin.Plugins[i] = p
 			}
@@ -59,6 +61,7 @@ func (s *Server) resolveManifestPlugins(r *http.Request) (*manifestplugins.Manif
 		}
 		var p manifestplugins.ManifestPlugin
 		if err := json.Unmarshal([]byte(ov.Config), &p); err != nil {
+			s.log.Warn("ignoring corrupt custom plugin config", "plugin", ov.PluginID, "error", err)
 			continue
 		}
 		p.ID = ov.PluginID
@@ -113,8 +116,12 @@ func (s *Server) SaveManifestPlugins(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		// A toggle-only request sends {id, enabled} with zero-valued Kind.
+		// Don't treat that as a config override — it would clobber the builtin definition.
+		isFullDefinition := plugin.Kind != ""
+
 		configJSON := manifestPluginConfigJSON(plugin)
-		hasConfigOverride := !isBuiltin || configJSON != manifestPluginConfigJSON(def)
+		hasConfigOverride := isFullDefinition && (!isBuiltin || configJSON != manifestPluginConfigJSON(def))
 
 		enabledDiffers := isBuiltin && plugin.Enabled != def.Enabled
 		var enabled *bool
@@ -182,15 +189,29 @@ func manifestPluginConfigJSON(p manifestplugins.ManifestPlugin) string {
 		SessionEnvs   []manifestplugins.ManifestSessionEnv `json:"session_env,omitempty"`
 		OAuthProvider string                               `json:"oauth_provider,omitempty"`
 	}
+	// Normalize empty slices to nil so omitempty produces stable JSON
+	// regardless of whether the source was nil or [].
+	binaries := p.Binaries
+	if len(binaries) == 0 {
+		binaries = nil
+	}
+	skills := p.Skills
+	if len(skills) == 0 {
+		skills = nil
+	}
+	sessionEnvs := p.SessionEnvs
+	if len(sessionEnvs) == 0 {
+		sessionEnvs = nil
+	}
 	data, _ := json.Marshal(configOnly{
 		Kind:          p.Kind,
 		Name:          p.Name,
 		DisplayName:   p.DisplayName,
 		Description:   p.Description,
 		Prompt:        p.Prompt,
-		Binaries:      p.Binaries,
-		Skills:        p.Skills,
-		SessionEnvs:   p.SessionEnvs,
+		Binaries:      binaries,
+		Skills:        skills,
+		SessionEnvs:   sessionEnvs,
 		OAuthProvider: p.OAuthProvider,
 	})
 	return string(data)

--- a/internal/server/manifest_plugins.go
+++ b/internal/server/manifest_plugins.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"github.com/CherryHQ/stella/internal/config"
@@ -13,9 +14,10 @@ type manifestPluginsResponse struct {
 }
 
 // resolveManifestPlugins loads the builtin manifest and overlays
-// overrides from the DB. Each manifest plugin's Enabled flag reflects the
-// override row when present; the default otherwise. SessionEnvs are not
-// touched here — those are resolved at agent runtime against the vault.
+// overrides from the DB. Each override may carry a full plugin definition
+// (Config JSON) plus an Enabled toggle. When Config is present the entire
+// plugin definition is replaced; when only Enabled is set the builtin
+// definition is kept with the enabled flag toggled.
 func (s *Server) resolveManifestPlugins(r *http.Request) (*manifestplugins.Manifest, error) {
 	builtin, err := manifestplugins.LoadBuiltin()
 	if err != nil {
@@ -32,10 +34,38 @@ func (s *Server) resolveManifestPlugins(r *http.Request) (*manifestplugins.Manif
 	for _, ov := range overrides {
 		byID[ov.PluginID] = ov
 	}
+	seen := make(map[string]bool, len(builtin.Plugins))
 	for i := range builtin.Plugins {
-		if ov, ok := byID[builtin.Plugins[i].ID]; ok && ov.Enabled != nil {
+		id := builtin.Plugins[i].ID
+		seen[id] = true
+		ov, ok := byID[id]
+		if !ok {
+			continue
+		}
+		if ov.Config != "" {
+			var p manifestplugins.ManifestPlugin
+			if err := json.Unmarshal([]byte(ov.Config), &p); err == nil {
+				p.ID = id
+				builtin.Plugins[i] = p
+			}
+		}
+		if ov.Enabled != nil {
 			builtin.Plugins[i].Enabled = *ov.Enabled
 		}
+	}
+	for _, ov := range overrides {
+		if seen[ov.PluginID] || ov.Config == "" {
+			continue
+		}
+		var p manifestplugins.ManifestPlugin
+		if err := json.Unmarshal([]byte(ov.Config), &p); err != nil {
+			continue
+		}
+		p.ID = ov.PluginID
+		if ov.Enabled != nil {
+			p.Enabled = *ov.Enabled
+		}
+		builtin.Plugins = append(builtin.Plugins, p)
 	}
 	return builtin, nil
 }
@@ -75,39 +105,46 @@ func (s *Server) SaveManifestPlugins(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, plugin := range req.Plugins {
-		def, ok := builtinByID[plugin.ID]
-		if !ok {
-			// Unknown plugin (not in manifest); skip silently to avoid orphan DB rows.
-			continue
-		}
-		// The Save payload only carries the enable toggle; the
-		// session_env_vault_key is a separate override dimension. Read the
-		// existing row so we preserve that binding instead of clobbering it.
+		def, isBuiltin := builtinByID[plugin.ID]
+
 		existing, _, err := s.store.GetManifestPluginOverride(r.Context(), plugin.ID)
 		if err != nil {
 			s.writeInternalError(w, err)
 			return
 		}
-		// Drop the row only when nothing is left to override: the requested
-		// state matches the default and no session env binding is set.
-		if plugin.Enabled == def.Enabled && existing.SessionEnvVaultKey == "" {
+
+		configJSON := manifestPluginConfigJSON(plugin)
+		hasConfigOverride := !isBuiltin || configJSON != manifestPluginConfigJSON(def)
+
+		enabledDiffers := isBuiltin && plugin.Enabled != def.Enabled
+		var enabled *bool
+		if enabledDiffers {
+			e := plugin.Enabled
+			enabled = &e
+		}
+		if !isBuiltin {
+			e := plugin.Enabled
+			enabled = &e
+		}
+
+		needsRow := enabled != nil || existing.SessionEnvVaultKey != "" || hasConfigOverride
+		if !needsRow {
 			if err := s.store.DeleteManifestPluginOverride(r.Context(), plugin.ID); err != nil {
 				s.writeInternalError(w, err)
 				return
 			}
 			continue
 		}
-		// Store an explicit enabled pointer only when it diverges from the
-		// default; nil falls back to the manifest default at resolve time.
-		var enabled *bool
-		if plugin.Enabled != def.Enabled {
-			e := plugin.Enabled
-			enabled = &e
+
+		cfgStr := ""
+		if hasConfigOverride {
+			cfgStr = configJSON
 		}
 		if err := s.store.UpsertManifestPluginOverride(r.Context(), config.ManifestPluginOverride{
 			PluginID:           plugin.ID,
 			Enabled:            enabled,
 			SessionEnvVaultKey: existing.SessionEnvVaultKey,
+			Config:             cfgStr,
 		}); err != nil {
 			s.writeInternalError(w, err)
 			return
@@ -129,6 +166,34 @@ func (s *Server) SaveManifestPlugins(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	writeData(w, http.StatusOK, manifestPluginsResponse{Plugins: merged.Plugins, OAuthProviders: merged.OAuthProviders})
+}
+
+// manifestPluginConfigJSON serializes a ManifestPlugin (excluding Enabled and ID)
+// to a canonical JSON string for storage and comparison.
+func manifestPluginConfigJSON(p manifestplugins.ManifestPlugin) string {
+	type configOnly struct {
+		Kind          string                               `json:"kind"`
+		Name          string                               `json:"name"`
+		DisplayName   string                               `json:"display_name"`
+		Description   string                               `json:"description"`
+		Prompt        string                               `json:"prompt,omitempty"`
+		Binaries      []manifestplugins.ManifestBinary     `json:"binaries,omitempty"`
+		Skills        []manifestplugins.ManifestSkill      `json:"skills,omitempty"`
+		SessionEnvs   []manifestplugins.ManifestSessionEnv `json:"session_env,omitempty"`
+		OAuthProvider string                               `json:"oauth_provider,omitempty"`
+	}
+	data, _ := json.Marshal(configOnly{
+		Kind:          p.Kind,
+		Name:          p.Name,
+		DisplayName:   p.DisplayName,
+		Description:   p.Description,
+		Prompt:        p.Prompt,
+		Binaries:      p.Binaries,
+		Skills:        p.Skills,
+		SessionEnvs:   p.SessionEnvs,
+		OAuthProvider: p.OAuthProvider,
+	})
+	return string(data)
 }
 
 func (s *Server) SyncManifestPlugins(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/manifest_plugins.go
+++ b/internal/server/manifest_plugins.go
@@ -49,6 +49,7 @@ func (s *Server) resolveManifestPlugins(r *http.Request) (*manifestplugins.Manif
 				s.log.Warn("ignoring corrupt plugin config override", "plugin", id, "error", err)
 			} else {
 				p.ID = id
+				p.Enabled = builtin.Plugins[i].Enabled
 				builtin.Plugins[i] = p
 			}
 		}

--- a/internal/server/manifest_plugins.go
+++ b/internal/server/manifest_plugins.go
@@ -108,21 +108,6 @@ func (s *Server) SaveManifestPlugins(w http.ResponseWriter, r *http.Request) {
 		builtinByID[p.ID] = p
 	}
 
-	// Validate full definitions before persisting.
-	for _, plugin := range req.Plugins {
-		if plugin.Kind == "" {
-			continue
-		}
-		candidate := &manifestplugins.Manifest{
-			OAuthProviders: builtin.OAuthProviders,
-			Plugins:        []manifestplugins.ManifestPlugin{plugin},
-		}
-		if err := manifestplugins.Validate(candidate); err != nil {
-			writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid plugin %q: %v", plugin.ID, err))
-			return
-		}
-	}
-
 	for _, plugin := range req.Plugins {
 		def, isBuiltin := builtinByID[plugin.ID]
 
@@ -140,6 +125,14 @@ func (s *Server) SaveManifestPlugins(w http.ResponseWriter, r *http.Request) {
 		if isFullDefinition {
 			configJSON := manifestPluginConfigJSON(plugin)
 			if !isBuiltin || configJSON != manifestPluginConfigJSON(def) {
+				candidate := &manifestplugins.Manifest{
+					OAuthProviders: builtin.OAuthProviders,
+					Plugins:        []manifestplugins.ManifestPlugin{plugin},
+				}
+				if err := manifestplugins.Validate(candidate); err != nil {
+					writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid plugin %q: %v", plugin.ID, err))
+					return
+				}
 				cfgStr = configJSON
 			}
 		} else {

--- a/internal/server/manifest_plugins.go
+++ b/internal/server/manifest_plugins.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/CherryHQ/stella/internal/config"
@@ -107,6 +108,21 @@ func (s *Server) SaveManifestPlugins(w http.ResponseWriter, r *http.Request) {
 		builtinByID[p.ID] = p
 	}
 
+	// Validate full definitions before persisting.
+	for _, plugin := range req.Plugins {
+		if plugin.Kind == "" {
+			continue
+		}
+		candidate := &manifestplugins.Manifest{
+			OAuthProviders: builtin.OAuthProviders,
+			Plugins:        []manifestplugins.ManifestPlugin{plugin},
+		}
+		if err := manifestplugins.Validate(candidate); err != nil {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid plugin %q: %v", plugin.ID, err))
+			return
+		}
+	}
+
 	for _, plugin := range req.Plugins {
 		def, isBuiltin := builtinByID[plugin.ID]
 
@@ -117,11 +133,18 @@ func (s *Server) SaveManifestPlugins(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// A toggle-only request sends {id, enabled} with zero-valued Kind.
-		// Don't treat that as a config override — it would clobber the builtin definition.
+		// Don't treat that as a config override — it would clobber the existing definition.
 		isFullDefinition := plugin.Kind != ""
 
-		configJSON := manifestPluginConfigJSON(plugin)
-		hasConfigOverride := isFullDefinition && (!isBuiltin || configJSON != manifestPluginConfigJSON(def))
+		var cfgStr string
+		if isFullDefinition {
+			configJSON := manifestPluginConfigJSON(plugin)
+			if !isBuiltin || configJSON != manifestPluginConfigJSON(def) {
+				cfgStr = configJSON
+			}
+		} else {
+			cfgStr = existing.Config
+		}
 
 		enabledDiffers := isBuiltin && plugin.Enabled != def.Enabled
 		var enabled *bool
@@ -134,7 +157,7 @@ func (s *Server) SaveManifestPlugins(w http.ResponseWriter, r *http.Request) {
 			enabled = &e
 		}
 
-		needsRow := enabled != nil || existing.SessionEnvVaultKey != "" || hasConfigOverride
+		needsRow := enabled != nil || existing.SessionEnvVaultKey != "" || cfgStr != ""
 		if !needsRow {
 			if err := s.store.DeleteManifestPluginOverride(r.Context(), plugin.ID); err != nil {
 				s.writeInternalError(w, err)
@@ -143,10 +166,6 @@ func (s *Server) SaveManifestPlugins(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		cfgStr := ""
-		if hasConfigOverride {
-			cfgStr = configJSON
-		}
 		if err := s.store.UpsertManifestPluginOverride(r.Context(), config.ManifestPluginOverride{
 			PluginID:           plugin.ID,
 			Enabled:            enabled,

--- a/internal/server/plugins.go
+++ b/internal/server/plugins.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/CherryHQ/stella/internal/config"
@@ -116,33 +117,12 @@ func (s *Server) TogglePlugin(w http.ResponseWriter, r *http.Request, kind strin
 		s.writeInternalError(w, err)
 		return
 	}
-	// Re-fetch the updated plugin to return current state.
 	p, err := s.store.GetPlugin(r.Context(), id)
 	if err != nil {
 		s.writeInternalError(w, err)
 		return
 	}
-	// Hot-reload tool plugins so the change takes effect without restart.
-	if p.Kind == config.PluginKindTool && s.poolManager != nil {
-		if err := s.poolManager.ReloadPluginTools(r.Context()); err != nil {
-			s.log.Error("failed to reload plugin tools", "plugin", id, "error", err)
-		}
-	}
-	if err := s.pluginHost.ApplyPlugin(r.Context(), id); err != nil {
-		s.log.Error("failed to apply plugin runtime", "plugin", id, "error", err)
-	}
-	// Hot-reload hook plugins so the change takes effect without restart.
-	if p.Kind == config.PluginKindHook && s.poolManager != nil {
-		if err := s.poolManager.ReloadPluginHooks(r.Context()); err != nil {
-			s.log.Error("failed to reload plugin hooks", "plugin", id, "error", err)
-		}
-	}
-	// Hot-reload provider plugins so new sessions pick up the change.
-	if p.Kind == config.PluginKindProvider && s.poolManager != nil {
-		if err := s.poolManager.ReloadPluginProviders(r.Context()); err != nil {
-			s.log.Error("failed to reload plugin providers", "plugin", id, "error", err)
-		}
-	}
+	s.applyAndReloadPlugin(r.Context(), p)
 	writeData(w, http.StatusOK, p)
 }
 
@@ -182,25 +162,33 @@ func (s *Server) UpdatePluginConfig(w http.ResponseWriter, r *http.Request, kind
 		s.writeInternalError(w, err)
 		return
 	}
-	if err := s.pluginHost.ApplyPlugin(r.Context(), id); err != nil {
-		s.log.Error("failed to apply plugin runtime", "plugin", id, "error", err)
-	}
-	if p.Kind == config.PluginKindTool && s.poolManager != nil {
-		if err := s.poolManager.ReloadPluginTools(r.Context()); err != nil {
-			s.log.Error("failed to reload plugin tools", "plugin", id, "error", err)
-		}
-	}
-	if p.Kind == config.PluginKindHook && s.poolManager != nil {
-		if err := s.poolManager.ReloadPluginHooks(r.Context()); err != nil {
-			s.log.Error("failed to reload plugin hooks", "plugin", id, "error", err)
-		}
-	}
-	if p.Kind == config.PluginKindProvider && s.poolManager != nil {
-		if err := s.poolManager.ReloadPluginProviders(r.Context()); err != nil {
-			s.log.Error("failed to reload plugin providers", "plugin", id, "error", err)
-		}
-	}
+	s.applyAndReloadPlugin(r.Context(), p)
 	writeData(w, http.StatusOK, p)
+}
+
+// applyAndReloadPlugin updates a plugin's runtime state and hot-reloads
+// the pool manager so changes take effect without restart.
+func (s *Server) applyAndReloadPlugin(ctx context.Context, p config.Plugin) {
+	if err := s.pluginHost.ApplyPlugin(ctx, p.ID); err != nil {
+		s.log.Error("failed to apply plugin runtime", "plugin", p.ID, "error", err)
+	}
+	if s.poolManager == nil {
+		return
+	}
+	switch p.Kind {
+	case config.PluginKindTool:
+		if err := s.poolManager.ReloadPluginTools(ctx); err != nil {
+			s.log.Error("failed to reload plugin tools", "plugin", p.ID, "error", err)
+		}
+	case config.PluginKindHook:
+		if err := s.poolManager.ReloadPluginHooks(ctx); err != nil {
+			s.log.Error("failed to reload plugin hooks", "plugin", p.ID, "error", err)
+		}
+	case config.PluginKindProvider:
+		if err := s.poolManager.ReloadPluginProviders(ctx); err != nil {
+			s.log.Error("failed to reload plugin providers", "plugin", p.ID, "error", err)
+		}
+	}
 }
 
 func pluginRouteID(kind, name string) string {

--- a/internal/server/plugins.go
+++ b/internal/server/plugins.go
@@ -185,6 +185,21 @@ func (s *Server) UpdatePluginConfig(w http.ResponseWriter, r *http.Request, kind
 	if err := s.pluginHost.ApplyPlugin(r.Context(), id); err != nil {
 		s.log.Error("failed to apply plugin runtime", "plugin", id, "error", err)
 	}
+	if p.Kind == config.PluginKindTool && s.poolManager != nil {
+		if err := s.poolManager.ReloadPluginTools(r.Context()); err != nil {
+			s.log.Error("failed to reload plugin tools", "plugin", id, "error", err)
+		}
+	}
+	if p.Kind == config.PluginKindHook && s.poolManager != nil {
+		if err := s.poolManager.ReloadPluginHooks(r.Context()); err != nil {
+			s.log.Error("failed to reload plugin hooks", "plugin", id, "error", err)
+		}
+	}
+	if p.Kind == config.PluginKindProvider && s.poolManager != nil {
+		if err := s.poolManager.ReloadPluginProviders(r.Context()); err != nil {
+			s.log.Error("failed to reload plugin providers", "plugin", id, "error", err)
+		}
+	}
 	writeData(w, http.StatusOK, p)
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1178,3 +1178,42 @@ func TestSaveManifestPluginsPreservesSessionEnvVaultKey(t *testing.T) {
 		t.Fatalf("enabled should fall back to default (nil), got %v", *ov.Enabled)
 	}
 }
+
+// TestSaveManifestPluginsPreservesConfigOnToggle guards against toggle-only
+// saves clobbering a previously-stored config definition override.
+func TestSaveManifestPluginsPreservesConfigOnToggle(t *testing.T) {
+	env := setupAdmin(t)
+	octx := context.Background()
+
+	const pluginID = "tool/mise"
+	const configJSON = `{"kind":"tool","name":"mise","display_name":"Custom Mise","description":"custom"}`
+
+	// Pre-seed a config override row.
+	if err := env.store.UpsertManifestPluginOverride(octx, config.ManifestPluginOverride{
+		PluginID: pluginID,
+		Config:   configJSON,
+	}); err != nil {
+		t.Fatalf("seed override: %v", err)
+	}
+
+	// Toggle-only save: {id, enabled} with no Kind — must preserve existing config.
+	body := map[string]any{"plugins": []map[string]any{{"id": pluginID, "enabled": false}}}
+	rr := doRequest(t, env, "PATCH", "/api/manifest-plugins", body)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("save: status = %d, want 200 (body: %s)", rr.Code, rr.Body.String())
+	}
+
+	ov, ok, err := env.store.GetManifestPluginOverride(octx, pluginID)
+	if err != nil {
+		t.Fatalf("get override: %v", err)
+	}
+	if !ok {
+		t.Fatal("override row deleted by toggle-only save")
+	}
+	if ov.Config != configJSON {
+		t.Fatalf("config clobbered by toggle-only save: got %q, want %q", ov.Config, configJSON)
+	}
+	if ov.Enabled == nil || *ov.Enabled != false {
+		t.Fatalf("enabled not persisted: got %v, want explicit false", ov.Enabled)
+	}
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1152,6 +1152,9 @@ func TestSaveManifestPluginsPreservesSessionEnvVaultKey(t *testing.T) {
 	if ov.Enabled == nil || *ov.Enabled != false {
 		t.Fatalf("enabled override not persisted: got %v, want explicit false", ov.Enabled)
 	}
+	if ov.Config != "" {
+		t.Fatalf("toggle-only save must not store config override: got %q", ov.Config)
+	}
 
 	// Toggle back to the default (enabled=true). The row must survive because a
 	// session env binding still exists; only the enable override clears to nil.

--- a/internal/store/dbstore.go
+++ b/internal/store/dbstore.go
@@ -427,6 +427,7 @@ func (s *DBStore) UpsertManifestPluginOverride(ctx context.Context, ov config.Ma
 		PluginID:           ov.PluginID,
 		Enabled:            enabled,
 		SessionEnvVaultKey: ov.SessionEnvVaultKey,
+		Config:             ov.Config,
 	})
 }
 
@@ -438,6 +439,7 @@ func manifestOverrideFromDB(r sqlc.PluginOverride) config.ManifestPluginOverride
 	out := config.ManifestPluginOverride{
 		PluginID:           r.PluginID,
 		SessionEnvVaultKey: r.SessionEnvVaultKey,
+		Config:             r.Config,
 		UpdatedAt:          r.UpdatedAt,
 	}
 	if r.Enabled.Valid {

--- a/pkg/db/sqlc/models.go
+++ b/pkg/db/sqlc/models.go
@@ -457,6 +457,7 @@ type PluginOverride struct {
 	PluginID           string        `json:"plugin_id"`
 	Enabled            sql.NullInt64 `json:"enabled"`
 	SessionEnvVaultKey string        `json:"session_env_vault_key"`
+	Config             string        `json:"config"`
 	CreatedAt          string        `json:"created_at"`
 	UpdatedAt          string        `json:"updated_at"`
 }

--- a/pkg/db/sqlc/plugin_override.sql.go
+++ b/pkg/db/sqlc/plugin_override.sql.go
@@ -21,7 +21,7 @@ func (q *Queries) DeleteManifestPluginOverride(ctx context.Context, pluginID str
 }
 
 const getManifestPluginOverride = `-- name: GetManifestPluginOverride :one
-SELECT plugin_id, enabled, session_env_vault_key, created_at, updated_at FROM plugin_override
+SELECT plugin_id, enabled, session_env_vault_key, config, created_at, updated_at FROM plugin_override
 WHERE plugin_id = ?
 `
 
@@ -32,6 +32,7 @@ func (q *Queries) GetManifestPluginOverride(ctx context.Context, pluginID string
 		&i.PluginID,
 		&i.Enabled,
 		&i.SessionEnvVaultKey,
+		&i.Config,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -39,7 +40,7 @@ func (q *Queries) GetManifestPluginOverride(ctx context.Context, pluginID string
 }
 
 const listManifestPluginOverrides = `-- name: ListManifestPluginOverrides :many
-SELECT plugin_id, enabled, session_env_vault_key, created_at, updated_at FROM plugin_override
+SELECT plugin_id, enabled, session_env_vault_key, config, created_at, updated_at FROM plugin_override
 ORDER BY plugin_id
 `
 
@@ -56,6 +57,7 @@ func (q *Queries) ListManifestPluginOverrides(ctx context.Context) ([]PluginOver
 			&i.PluginID,
 			&i.Enabled,
 			&i.SessionEnvVaultKey,
+			&i.Config,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {
@@ -73,11 +75,12 @@ func (q *Queries) ListManifestPluginOverrides(ctx context.Context) ([]PluginOver
 }
 
 const upsertManifestPluginOverride = `-- name: UpsertManifestPluginOverride :exec
-INSERT INTO plugin_override (plugin_id, enabled, session_env_vault_key, updated_at)
-VALUES (?, ?, ?, datetime('now'))
+INSERT INTO plugin_override (plugin_id, enabled, session_env_vault_key, config, updated_at)
+VALUES (?, ?, ?, ?, datetime('now'))
 ON CONFLICT(plugin_id) DO UPDATE SET
     enabled               = excluded.enabled,
     session_env_vault_key = excluded.session_env_vault_key,
+    config                = excluded.config,
     updated_at            = datetime('now')
 `
 
@@ -85,9 +88,15 @@ type UpsertManifestPluginOverrideParams struct {
 	PluginID           string        `json:"plugin_id"`
 	Enabled            sql.NullInt64 `json:"enabled"`
 	SessionEnvVaultKey string        `json:"session_env_vault_key"`
+	Config             string        `json:"config"`
 }
 
 func (q *Queries) UpsertManifestPluginOverride(ctx context.Context, arg UpsertManifestPluginOverrideParams) error {
-	_, err := q.db.ExecContext(ctx, upsertManifestPluginOverride, arg.PluginID, arg.Enabled, arg.SessionEnvVaultKey)
+	_, err := q.db.ExecContext(ctx, upsertManifestPluginOverride,
+		arg.PluginID,
+		arg.Enabled,
+		arg.SessionEnvVaultKey,
+		arg.Config,
+	)
 	return err
 }

--- a/resources/plugins.yaml
+++ b/resources/plugins.yaml
@@ -409,7 +409,7 @@ plugins:
       - name: lark-cli
         tool: github:larksuite/cli
         version: "1.0.35"
-    oauth_provider: lark
+    oauth_provider: feishu
     session_env:
       - env_var: LARKSUITE_CLI_USER_ACCESS_TOKEN
         source: oauth.access_token

--- a/resources/skills/system/stella/references/update.md
+++ b/resources/skills/system/stella/references/update.md
@@ -13,7 +13,7 @@ stella upgrade
 stella upgrade --install-dir "$HOME/.local/bin"  # custom install path
 ```
 
-Downloads the latest stable release from GitHub for your platform and replaces the running `stella` binary by default.
+Downloads the latest stable release from GitHub for your platform and replaces the running `stella` binary by default. If the target directory is not writable, rerun with the required OS permission or use `--install-dir`. If the binary is locked or busy, stop the running Stella process or service first, then retry.
 
 ## Other methods
 

--- a/resources/skills/system/stella/references/update.md
+++ b/resources/skills/system/stella/references/update.md
@@ -13,7 +13,7 @@ stella upgrade
 stella upgrade --install-dir "$HOME/.local/bin"  # custom install path
 ```
 
-Downloads the latest stable release from GitHub for your platform.
+Downloads the latest stable release from GitHub for your platform and replaces the running `stella` binary by default.
 
 ## Other methods
 

--- a/web/content/docs/getting-started/deployment.md
+++ b/web/content/docs/getting-started/deployment.md
@@ -63,10 +63,10 @@ stella server --host 0.0.0.0 --port 8080  # bind to all interfaces
 ```bash
 stella version
 stella upgrade
-stella upgrade --install-dir "$HOME/.local/bin"
+stella upgrade --install-dir "$HOME/.local/bin"  # custom install path
 ```
 
-`stella upgrade` fetches the latest stable release from GitHub, downloads the matching archive for the current OS/architecture, and installs the binary into `$HOME/.local/bin` by default.
+`stella upgrade` fetches the latest stable release from GitHub, downloads the matching archive for the current OS/architecture, and replaces the running `stella` binary by default. If the target directory is not writable, rerun the command with the required OS permission or use `--install-dir`. If the binary is locked or busy, stop the running Stella process or service first, then retry.
 
 ## Run as a Background Service
 

--- a/web/content/docs/getting-started/deployment.zh.md
+++ b/web/content/docs/getting-started/deployment.zh.md
@@ -63,10 +63,10 @@ stella server --host 0.0.0.0 --port 8080   # 绑定所有网络接口
 ```bash
 stella version
 stella upgrade
-stella upgrade --install-dir "$HOME/.local/bin"
+stella upgrade --install-dir "$HOME/.local/bin"  # 自定义安装路径
 ```
 
-`stella upgrade` 从 GitHub 获取最新稳定版本，下载与当前操作系统/架构匹配的安装包，并将二进制文件安装到 `$HOME/.local/bin`（默认位置）。
+`stella upgrade` 从 GitHub 获取最新稳定版本，下载与当前操作系统/架构匹配的安装包，并默认替换当前正在运行的 `stella` 二进制文件。
 
 ## 作为后台服务运行
 

--- a/web/content/docs/getting-started/deployment.zh.md
+++ b/web/content/docs/getting-started/deployment.zh.md
@@ -66,7 +66,7 @@ stella upgrade
 stella upgrade --install-dir "$HOME/.local/bin"  # 自定义安装路径
 ```
 
-`stella upgrade` 从 GitHub 获取最新稳定版本，下载与当前操作系统/架构匹配的安装包，并默认替换当前正在运行的 `stella` 二进制文件。
+`stella upgrade` 从 GitHub 获取最新稳定版本，下载与当前操作系统/架构匹配的安装包，并默认替换当前正在运行的 `stella` 二进制文件。如果目标目录不可写，请用具备对应系统权限的用户重新运行，或使用 `--install-dir` 指定其他目录。如果二进制文件被锁定或显示 busy，请先停止正在运行的 Stella 进程或服务，再重试。
 
 ## 作为后台服务运行
 

--- a/web/src/features/plugins/ManifestInstallEditor.tsx
+++ b/web/src/features/plugins/ManifestInstallEditor.tsx
@@ -85,11 +85,7 @@ export function ManifestInstallEditor({ draft, oauthProviders, onChange, onSave,
         <div>
           <p className="text-sm font-semibold">Edit definition</p>
           <p className="text-xs text-muted-foreground mt-0.5">
-            Written to{" "}
-            <code className="font-mono text-[11px] bg-muted px-1 py-0.5 rounded">
-              $STELLA_HOME/plugins.yaml
-            </code>
-            . Binaries sync on save.
+            Override the manifest definition. Binaries sync on save.
           </p>
         </div>
         <div className="flex items-center gap-2 shrink-0">

--- a/web/src/features/plugins/PluginsPage.tsx
+++ b/web/src/features/plugins/PluginsPage.tsx
@@ -175,7 +175,6 @@ export function PluginsPage() {
     void (async () => {
       await loadPlugins();
       await loadManifestPlugins();
-      await syncManifest(true);
     })();
   }, [loadPlugins, loadManifestPlugins]);
 


### PR DESCRIPTION
## Summary

- **Manifest plugin config now persists**: `SaveManifestPlugins` previously only stored the `enabled` toggle to `plugin_override` — all other edits (binaries, session_env, oauth_provider, description, prompt) were silently discarded on page refresh. Added a `config TEXT` column to `plugin_override` that stores the full plugin definition as JSON. `resolveManifestPlugins` overlays saved config onto the builtin manifest, and also supports user-added plugins not in the builtin.
- **UpdatePluginConfig hot-reload**: `UpdatePluginConfig` was missing pool-level reload calls (`ReloadPluginTools`/`ReloadPluginHooks`/`ReloadPluginProviders`) that `TogglePlugin` already had — config changes now take effect immediately without restart.
- **Frontend text fix**: Removed misleading "$STELLA_HOME/plugins.yaml" reference from ManifestInstallEditor since no YAML file is written.

## Test plan

- [x] Edit a manifest plugin definition (e.g. add session_env to `tool/lark-cli`) → save → refresh page → verify edits persist
- [x] Add a new tool plugin via the UI → refresh → verify it still appears
- [x] Toggle a manifest plugin enabled/disabled → refresh → verify state persists
- [x] Reset a manifest plugin to match builtin defaults → verify the override row is cleaned up
- [x] Update a Go-registered plugin config (e.g. provider) → verify it takes effect without restart