### PR TITLE
🐛 fix: escape local OIDC authorize form URLs

### DIFF
--- a/internal/auth/oidc/local/issuer.go
+++ b/internal/auth/oidc/local/issuer.go
@@ -15,6 +15,7 @@ import (
 	"html/template"
 	"math/big"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -409,24 +410,26 @@ func (is *Issuer) renderRegisterForm(w http.ResponseWriter, params *authorizePar
 }
 
 func buildAuthorizeAction(p *authorizeParams, mode string) string {
-	q := "?client_id=" + p.clientID +
-		"&redirect_uri=" + p.redirectURI +
-		"&response_type=code" +
-		"&scope=" + strings.Join(p.scopes, "+")
+	q := url.Values{
+		"client_id":     {p.clientID},
+		"redirect_uri":  {p.redirectURI},
+		"response_type": {"code"},
+		"scope":         {strings.Join(p.scopes, " ")},
+	}
 	if p.state != "" {
-		q += "&state=" + p.state
+		q.Set("state", p.state)
 	}
 	if p.nonce != "" {
-		q += "&nonce=" + p.nonce
+		q.Set("nonce", p.nonce)
 	}
 	if p.pkceChallenge != "" {
-		q += "&code_challenge=" + p.pkceChallenge +
-			"&code_challenge_method=" + p.pkceChallengeMethod
+		q.Set("code_challenge", p.pkceChallenge)
+		q.Set("code_challenge_method", p.pkceChallengeMethod)
 	}
 	if mode != "" {
-		q += "&mode=" + mode
+		q.Set("mode", mode)
 	}
-	return "authorize" + q
+	return "authorize?" + q.Encode()
 }
 
 // HandleToken serves POST /token.

--- a/internal/auth/oidc/local/issuer_test.go
+++ b/internal/auth/oidc/local/issuer_test.go
@@ -336,6 +336,43 @@ func TestAuthorizeShowsLoginFormWithNoSession(t *testing.T) {
 	}
 }
 
+func TestAuthorizeLoginFormURLsAreEscaped(t *testing.T) {
+	key := generateTestKey(t)
+	cfg := confidentialConfig(t, key)
+	cfg.RedirectURIs = []string{"https://stella.cherry-ai.com/auth/callback/local"}
+	issuer := local.NewIssuer(cfg,
+		newFakeCodeStore(), newFakeTokenStore(),
+		newFakeUserStore(),
+		newFakeCredStore(), nil, nil)
+
+	q := url.Values{
+		"client_id":             {cfg.ClientID},
+		"redirect_uri":          {cfg.RedirectURIs[0]},
+		"response_type":         {"code"},
+		"scope":                 {"openid email profile"},
+		"state":                 {"state-with-safe-chars"},
+		"code_challenge":        {"QV-Zas6OPNdkq7Cfo9FWNBNTW40jy1_aVcJiR1hbGNY"},
+		"code_challenge_method": {"S256"},
+	}
+	r := httptest.NewRequest(http.MethodGet, "/oidc/local/authorize?"+q.Encode(), nil)
+	w := httptest.NewRecorder()
+	issuer.HandleAuthorize(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200", w.Code)
+	}
+	body := w.Body.String()
+	if strings.Contains(body, "ZgotmplZ") {
+		t.Fatalf("response contains unsafe template fallback: %s", body)
+	}
+	if !strings.Contains(body, "redirect_uri=https%3A%2F%2Fstella.cherry-ai.com%2Fauth%2Fcallback%2Flocal") {
+		t.Fatalf("response does not contain escaped redirect_uri: %s", body)
+	}
+	if !strings.Contains(body, "mode=register") {
+		t.Fatalf("response does not contain register mode link: %s", body)
+	}
+}
+
 func TestAuthorizePostIssuesCode(t *testing.T) {
 	key := generateTestKey(t)
 	cfg := confidentialConfig(t, key)


### PR DESCRIPTION
## Problem

Opening the local OIDC authorize page and clicking **Sign up** did nothing. The rendered HTML contained `href="#ZgotmplZ"` / `action="#ZgotmplZ"`.

## Root cause

`buildAuthorizeAction` manually concatenated a relative URL containing a raw `redirect_uri` (e.g. `redirect_uri=https://...`). When this string was rendered into the login/register form templates, Go's `html/template` URL sanitization rejected the unsafe value and emitted `#ZgotmplZ` for the form `action` and the "Sign up" / "Sign in" links, breaking navigation on the authorize page.

## Fix

Build the query with `net/url.Values` + `Encode()` so every parameter is properly percent-encoded.

- **Scope round-trips identically**: space-joined, encoded as `+`, decoded back to spaces server-side (`parseAuthorizeParams`). No OIDC behavior change.
- `state` / `nonce` and other values are now correctly escaped too (previously raw).
- Parameter order changes (`Encode()` sorts keys), which is not semantically significant for query params.

## Test

Added `TestAuthorizeLoginFormURLsAreEscaped` covering the regression: asserts no `ZgotmplZ`, a properly escaped `redirect_uri`, and the `mode=register` link.

## Verification

- `mise run format` — dprint + `go mod tidy` + golangci-lint (0 issues) + web check (0 warnings/errors)
- `mise run build` — full codegen + binary build pass
- `mise run test` — all tests pass
- Local browser flow: `/login` → click **Sign up** → reaches Sign up page with `mode=register`, no `ZgotmplZ`

🤖 Generated with [Claude Code](https://claude.com/claude-code)