### PR TITLE
Make task context first-class

### DIFF
--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -482,6 +482,7 @@ components:
       required: [
         id,
         user_id,
+        agent_id,
         title,
         status,
         priority,
@@ -496,6 +497,10 @@ components:
           type: string
         agent_id:
           type: string
+          description: Owner/manager agent context.
+        project_id:
+          type: string
+          description: Optional project/workspace context.
         title:
           type: string
         description:
@@ -552,7 +557,7 @@ components:
           description: Opaque pagination token; null when no further pages.
     CreateGoalRequest:
       type: object
-      required: [title]
+      required: [title, agent_id]
       properties:
         title:
           type: string
@@ -563,6 +568,9 @@ components:
           enum: [routine, urgent]
         agent_id:
           type: string
+        project_id:
+          type: string
+          description: Optional project/workspace context. Must belong to the caller and agent.
         review_policy:
           type: string
           enum: [none]
@@ -2000,6 +2008,8 @@ components:
       required: [
         id,
         user_id,
+        agent_id,
+        session_id,
         title,
         status,
         priority,
@@ -2017,10 +2027,16 @@ components:
           type: string
         agent_id:
           type: string
-          description: Creator agent (D12); empty when the task was created by a user.
+          description: Owner/manager agent context.
+        session_id:
+          type: string
+          description: Durable worker session for this task.
         goal_id:
           type: string
-          description: Parent goal.
+          description: Optional parent goal.
+        project_id:
+          type: string
+          description: Optional project/workspace context.
         title:
           type: string
         description:
@@ -2057,8 +2073,6 @@ components:
         deadline_at:
           type: string
           format: date-time
-        session_id:
-          type: string
         active_run_id:
           type: string
         active_blocker_id:
@@ -2124,10 +2138,13 @@ components:
           enum: [routine, urgent]
         agent_id:
           type: string
-          description: Creator agent (optional).
+          description: Owner/manager agent context. Required unless inherited from goal_id.
         goal_id:
           type: string
-          description: Parent goal. When set, it must belong to the caller and the same agent.
+          description: Optional parent goal. When set, it must belong to the caller and the same agent.
+        project_id:
+          type: string
+          description: Optional project/workspace context. Must belong to the caller and resolved agent.
         executor_agent_id:
           type: string
           description: Explicit executor (D13); written as a dispatch hint.

--- a/api/spec/domain/goals/schemas.yaml
+++ b/api/spec/domain/goals/schemas.yaml
@@ -11,6 +11,7 @@ components:
         [
           id,
           user_id,
+          agent_id,
           title,
           status,
           priority,
@@ -21,7 +22,12 @@ components:
       properties:
         id: { type: string }
         user_id: { type: string }
-        agent_id: { type: string }
+        agent_id:
+          type: string
+          description: Owner/manager agent context.
+        project_id:
+          type: string
+          description: Optional project/workspace context.
         title: { type: string }
         description: { type: string }
         status:
@@ -69,7 +75,7 @@ components:
 
     CreateGoalRequest:
       type: object
-      required: [title]
+      required: [title, agent_id]
       properties:
         title: { type: string }
         description: { type: string }
@@ -77,6 +83,9 @@ components:
           type: string
           enum: [routine, urgent]
         agent_id: { type: string }
+        project_id:
+          type: string
+          description: Optional project/workspace context. Must belong to the caller and agent.
         review_policy:
           type: string
           enum: [none]

--- a/api/spec/domain/tasks/paths.yaml
+++ b/api/spec/domain/tasks/paths.yaml
@@ -13,6 +13,12 @@ paths:
             schema: { type: string },
           }
         - {
+            name: project_id,
+            in: query,
+            required: false,
+            schema: { type: string },
+          }
+        - {
             name: page_size,
             in: query,
             required: false,

--- a/api/spec/domain/tasks/schemas.yaml
+++ b/api/spec/domain/tasks/schemas.yaml
@@ -11,6 +11,8 @@ components:
         [
           id,
           user_id,
+          agent_id,
+          session_id,
           title,
           status,
           priority,
@@ -26,10 +28,16 @@ components:
         user_id: { type: string }
         agent_id:
           type: string
-          description: Creator agent (D12); empty when the task was created by a user.
+          description: Owner/manager agent context.
+        session_id:
+          type: string
+          description: Durable worker session for this task.
         goal_id:
           type: string
-          description: Parent goal.
+          description: Optional parent goal.
+        project_id:
+          type: string
+          description: Optional project/workspace context.
         title: { type: string }
         description: { type: string }
         status:
@@ -47,7 +55,6 @@ components:
         max_retries: { type: integer, format: int64 }
         not_before: { type: string, format: date-time }
         deadline_at: { type: string, format: date-time }
-        session_id: { type: string }
         active_run_id: { type: string }
         active_blocker_id: { type: string }
         active_review_id: { type: string }
@@ -101,10 +108,13 @@ components:
           enum: [routine, urgent]
         agent_id:
           type: string
-          description: Creator agent (optional).
+          description: Owner/manager agent context. Required unless inherited from goal_id.
         goal_id:
           type: string
-          description: Parent goal. When set, it must belong to the caller and the same agent.
+          description: Optional parent goal. When set, it must belong to the caller and the same agent.
+        project_id:
+          type: string
+          description: Optional project/workspace context. Must belong to the caller and resolved agent.
         executor_agent_id:
           type: string
           description: Explicit executor (D13); written as a dispatch hint.

--- a/cmd/stella/task.go
+++ b/cmd/stella/task.go
@@ -66,6 +66,7 @@ func taskListCmd() *ucli.Command {
 		Usage: "List tasks",
 		Flags: append(taskAgentFlags(),
 			&ucli.StringFlag{Name: "status", Usage: "Filter by status"},
+			&ucli.StringFlag{Name: "project-id", Usage: "Filter by project/workspace context"},
 			jsonFlag(),
 		),
 		Action: func(c *ucli.Context) error {
@@ -76,6 +77,9 @@ func taskListCmd() *ucli.Command {
 			params := &apiclient.ListTasksParams{AgentId: &agentID}
 			if s := c.String("status"); s != "" {
 				params.Status = &s
+			}
+			if p := c.String("project-id"); p != "" {
+				params.ProjectId = &p
 			}
 			list, err := apiclient.Call[apitypes.TaskList](func(api *apiclient.Client) (*http.Response, error) {
 				return api.ListTasks(c.Context, params)
@@ -128,6 +132,7 @@ func taskCreateCmd() *ucli.Command {
 			&ucli.StringFlag{Name: "title", Required: true, Usage: "Task title"},
 			&ucli.StringFlag{Name: "description", Usage: "Task description"},
 			&ucli.StringFlag{Name: "goal-id", Usage: "Parent goal ID"},
+			&ucli.StringFlag{Name: "project-id", Usage: "Project/workspace context"},
 			&ucli.StringFlag{Name: "executor", Usage: "Explicit executor agent ID"},
 			&ucli.StringFlag{Name: "priority", Value: "routine", Usage: "routine | urgent"},
 			&ucli.StringSliceFlag{Name: "dep", Usage: "Dependency: <task-id>[:kind[:on_failure]]; may be repeated"},
@@ -147,6 +152,9 @@ func taskCreateCmd() *ucli.Command {
 			}
 			if g := c.String("goal-id"); g != "" {
 				body.GoalId = &g
+			}
+			if p := c.String("project-id"); p != "" {
+				body.ProjectId = &p
 			}
 			if e := c.String("executor"); e != "" {
 				body.ExecutorAgentId = &e

--- a/cmd/stella/task_create_test.go
+++ b/cmd/stella/task_create_test.go
@@ -63,6 +63,9 @@ func TestTaskListUsesAgentIDFromEnv(t *testing.T) {
 		if got := r.URL.Query().Get("agent_id"); got != "agent-1" {
 			t.Fatalf("agent_id query = %q", got)
 		}
+		if got := r.URL.Query().Get("project_id"); got != "project-1" {
+			t.Fatalf("project_id query = %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"tasks":[]}`))
 	}))
@@ -73,7 +76,7 @@ func TestTaskListUsesAgentIDFromEnv(t *testing.T) {
 
 	app := ucli.NewApp()
 	app.Commands = []*ucli.Command{taskCommand()}
-	if err := app.Run([]string{"stella", "task", "list"}); err != nil {
+	if err := app.Run([]string{"stella", "task", "list", "--project-id", "project-1"}); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 }

--- a/cmd/stella/task_goal.go
+++ b/cmd/stella/task_goal.go
@@ -117,7 +117,8 @@ func goalCreateCmd() *ucli.Command {
 		Flags: []ucli.Flag{
 			&ucli.StringFlag{Name: "title", Required: true, Usage: "Goal title"},
 			&ucli.StringFlag{Name: "description", Usage: "Goal description"},
-			&ucli.StringFlag{Name: "agent-id", Usage: "Creator/manager agent ID (defaults to STELLA_AGENT_ID)"},
+			&ucli.StringFlag{Name: "agent-id", Usage: "Owner/manager agent ID (defaults to STELLA_AGENT_ID)"},
+			&ucli.StringFlag{Name: "project-id", Usage: "Project/workspace context"},
 			&ucli.StringFlag{Name: "priority", Value: "routine", Usage: "routine | urgent"},
 			&ucli.StringFlag{Name: "review-policy", Usage: "none (only supported value in this build)"},
 			&ucli.BoolFlag{Name: "activate", Usage: "Activate (draft -> ready) immediately"},
@@ -132,9 +133,12 @@ func goalCreateCmd() *ucli.Command {
 				return fmt.Errorf("agent ID is required (pass --agent-id or set STELLA_AGENT_ID)")
 			}
 
-			body := apitypes.CreateGoalRequest{Title: c.String("title"), AgentId: &agentID}
+			body := apitypes.CreateGoalRequest{Title: c.String("title"), AgentId: agentID}
 			if d := c.String("description"); d != "" {
 				body.Description = &d
+			}
+			if p := c.String("project-id"); p != "" {
+				body.ProjectId = &p
 			}
 			if p := c.String("priority"); p != "" {
 				prio := apitypes.CreateGoalRequestPriority(p)

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -217,12 +217,13 @@ func (s *Service) NewSession(ctx context.Context, userID, agentID, projectID str
 	})
 }
 
-// MintTaskSession creates a new task session under the resolved executor agent.
+// MintTaskSession creates a new task worker session under the resolved agent.
 // The session is always new (generated ID) and uses KindTask/ChannelTask.
-func (s *Service) MintTaskSession(ctx context.Context, userID, executorAgentID string) (session.Info, error) {
+func (s *Service) MintTaskSession(ctx context.Context, userID, executorAgentID, projectID string) (session.Info, error) {
 	return s.Sessions.Ensure(ctx, session.Request{
 		UserID:          userID,
 		AgentID:         executorAgentID,
+		ProjectID:       projectID,
 		Kind:            session.KindTask,
 		Channel:         session.ChannelTask,
 		CreateIfMissing: true,

--- a/internal/db/migrations/20260602120907_task_context_model.sql
+++ b/internal/db/migrations/20260602120907_task_context_model.sql
@@ -1,0 +1,93 @@
+-- Disable the enforcement of foreign-keys constraints
+PRAGMA foreign_keys = off;
+-- Create "new_agent_goal" table
+CREATE TABLE `new_agent_goal` (
+  `id` text NOT NULL,
+  `user_id` text NOT NULL,
+  `agent_id` text NOT NULL,
+  `project_id` text NULL,
+  `title` text NOT NULL,
+  `description` text NOT NULL DEFAULT '',
+  `status` text NOT NULL DEFAULT 'draft',
+  `priority` text NOT NULL DEFAULT 'routine',
+  `review_policy` text NOT NULL DEFAULT 'none',
+  `active_review_id` text NULL,
+  `context` text NOT NULL DEFAULT '{}',
+  `output` text NOT NULL DEFAULT '{}',
+  `created_at` text NOT NULL DEFAULT (datetime('now')),
+  `updated_at` text NOT NULL DEFAULT (datetime('now')),
+  `completed_at` text NULL,
+  `cancelled_at` text NULL,
+  PRIMARY KEY (`id`),
+  CONSTRAINT `0` FOREIGN KEY (`active_review_id`) REFERENCES `agent_review` (`id`) ON UPDATE NO ACTION ON DELETE RESTRICT,
+  CONSTRAINT `1` FOREIGN KEY (`project_id`) REFERENCES `project` (`id`) ON UPDATE NO ACTION ON DELETE SET NULL,
+  CONSTRAINT `2` FOREIGN KEY (`agent_id`) REFERENCES `agent` (`id`) ON UPDATE NO ACTION ON DELETE RESTRICT,
+  CONSTRAINT `3` FOREIGN KEY (`user_id`) REFERENCES `auth_user` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Copy rows from old table "agent_goal" to new temporary table "new_agent_goal"
+INSERT INTO `new_agent_goal` (`id`, `user_id`, `agent_id`, `title`, `description`, `status`, `priority`, `review_policy`, `active_review_id`, `context`, `output`, `created_at`, `updated_at`, `completed_at`, `cancelled_at`) SELECT `id`, `user_id`, `agent_id`, `title`, `description`, `status`, `priority`, `review_policy`, `active_review_id`, `context`, `output`, `created_at`, `updated_at`, `completed_at`, `cancelled_at` FROM `agent_goal`;
+-- Drop "agent_goal" table after copying rows
+DROP TABLE `agent_goal`;
+-- Rename temporary table "new_agent_goal" to "agent_goal"
+ALTER TABLE `new_agent_goal` RENAME TO `agent_goal`;
+-- Create index "idx_agent_goal_agent_project" to table: "agent_goal"
+CREATE INDEX `idx_agent_goal_agent_project` ON `agent_goal` (`agent_id`, `project_id`);
+-- Create index "idx_agent_goal_project" to table: "agent_goal"
+CREATE INDEX `idx_agent_goal_project` ON `agent_goal` (`project_id`);
+-- Create "new_agent_task" table
+CREATE TABLE `new_agent_task` (
+  `id` text NOT NULL,
+  `user_id` text NOT NULL,
+  `agent_id` text NOT NULL,
+  `session_id` text NOT NULL,
+  `goal_id` text NULL,
+  `project_id` text NULL,
+  `title` text NOT NULL,
+  `description` text NOT NULL DEFAULT '',
+  `status` text NOT NULL DEFAULT 'draft',
+  `priority` text NOT NULL DEFAULT 'routine',
+  `review_policy` text NOT NULL DEFAULT 'none',
+  `active_review_id` text NULL,
+  `required` integer NOT NULL DEFAULT 1,
+  `retry_count` integer NOT NULL DEFAULT 0,
+  `max_retries` integer NOT NULL DEFAULT 3,
+  `not_before` text NULL,
+  `deadline_at` text NULL,
+  `active_run_id` text NULL,
+  `active_blocker_id` text NULL,
+  `context` text NOT NULL DEFAULT '{}',
+  `output` text NOT NULL DEFAULT '{}',
+  `created_at` text NOT NULL DEFAULT (datetime('now')),
+  `updated_at` text NOT NULL DEFAULT (datetime('now')),
+  `completed_at` text NULL,
+  `cancelled_at` text NULL,
+  PRIMARY KEY (`id`),
+  CONSTRAINT `0` FOREIGN KEY (`active_blocker_id`) REFERENCES `agent_task_blocker` (`id`) ON UPDATE NO ACTION ON DELETE RESTRICT,
+  CONSTRAINT `1` FOREIGN KEY (`active_run_id`) REFERENCES `agent_task_run` (`id`) ON UPDATE NO ACTION ON DELETE RESTRICT,
+  CONSTRAINT `2` FOREIGN KEY (`active_review_id`) REFERENCES `agent_review` (`id`) ON UPDATE NO ACTION ON DELETE RESTRICT,
+  CONSTRAINT `3` FOREIGN KEY (`project_id`) REFERENCES `project` (`id`) ON UPDATE NO ACTION ON DELETE SET NULL,
+  CONSTRAINT `4` FOREIGN KEY (`goal_id`) REFERENCES `agent_goal` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT `5` FOREIGN KEY (`session_id`) REFERENCES `ctx_conversation` (`session_id`) ON UPDATE NO ACTION ON DELETE RESTRICT,
+  CONSTRAINT `6` FOREIGN KEY (`agent_id`) REFERENCES `agent` (`id`) ON UPDATE NO ACTION ON DELETE RESTRICT,
+  CONSTRAINT `7` FOREIGN KEY (`user_id`) REFERENCES `auth_user` (`id`) ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Copy rows from old table "agent_task" to new temporary table "new_agent_task"
+INSERT INTO `new_agent_task` (`id`, `user_id`, `agent_id`, `session_id`, `goal_id`, `title`, `description`, `status`, `priority`, `review_policy`, `active_review_id`, `required`, `retry_count`, `max_retries`, `not_before`, `deadline_at`, `active_run_id`, `active_blocker_id`, `context`, `output`, `created_at`, `updated_at`, `completed_at`, `cancelled_at`) SELECT `id`, `user_id`, `agent_id`, `session_id`, `goal_id`, `title`, `description`, `status`, `priority`, `review_policy`, `active_review_id`, `required`, `retry_count`, `max_retries`, `not_before`, `deadline_at`, `active_run_id`, `active_blocker_id`, `context`, `output`, `created_at`, `updated_at`, `completed_at`, `cancelled_at` FROM `agent_task`;
+-- Drop "agent_task" table after copying rows
+DROP TABLE `agent_task`;
+-- Rename temporary table "new_agent_task" to "agent_task"
+ALTER TABLE `new_agent_task` RENAME TO `agent_task`;
+-- Create index "uniq_agent_task_session" to table: "agent_task"
+CREATE UNIQUE INDEX `uniq_agent_task_session` ON `agent_task` (`session_id`);
+-- Create index "idx_agent_task_agent_status_not_before" to table: "agent_task"
+CREATE INDEX `idx_agent_task_agent_status_not_before` ON `agent_task` (`agent_id`, `status`, `not_before`);
+-- Create index "idx_agent_task_user_agent" to table: "agent_task"
+CREATE INDEX `idx_agent_task_user_agent` ON `agent_task` (`user_id`, `agent_id`);
+-- Create index "idx_agent_task_session" to table: "agent_task"
+CREATE INDEX `idx_agent_task_session` ON `agent_task` (`session_id`);
+-- Create index "idx_agent_task_goal" to table: "agent_task"
+CREATE INDEX `idx_agent_task_goal` ON `agent_task` (`goal_id`);
+-- Create index "idx_agent_task_project" to table: "agent_task"
+CREATE INDEX `idx_agent_task_project` ON `agent_task` (`project_id`);
+-- Enable back the enforcement of foreign-keys constraints
+PRAGMA foreign_keys = on;

--- a/internal/db/migrations/atlas.sum
+++ b/internal/db/migrations/atlas.sum
@@ -1,4 +1,5 @@
-h1:1Pk+qLJ6iOtAu0gaDCK8VaoKffi3MaNeec9FHPv/0hU=
+h1:MgAzUkcTYjbKHsyR2+pFfprc0UKbRis58otCZyiC+7k=
 20260531120105_initial.sql h1:yFv08NKwCabgVkvWoSNzba6WMXjbXrI9xHctaJBir/8=
 20260601060943_add_config_to_plugin_override.sql h1:q2MIJRzEYGDQyjnLeFUrQ0zbnvdgxBh/MRANwRmPFn4=
 20260602031701_add-channel-name.sql h1:1ZGYJvwMOOShxLGIN9SJihmcfQtFRpTPXHhOWDv29fc=
+20260602120907_task_context_model.sql h1:PPdWj1iCx5Q0vhWdoDKICiRX258Lej6iZKoSJkqKQ2g=

--- a/internal/db/queries/agent_goal.sql
+++ b/internal/db/queries/agent_goal.sql
@@ -2,10 +2,10 @@
 
 -- name: CreateAgentGoal :one
 INSERT INTO agent_goal (
-    id, user_id, agent_id, title, description, status, priority,
+    id, user_id, agent_id, project_id, title, description, status, priority,
     review_policy, context, output, created_at, updated_at
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 RETURNING *;
 
 -- name: GetAgentGoal :one

--- a/internal/db/queries/agent_task.sql
+++ b/internal/db/queries/agent_task.sql
@@ -5,11 +5,11 @@
 
 -- name: CreateAgentTask :one
 INSERT INTO agent_task (
-    id, user_id, agent_id, goal_id, title, description, status, priority,
+    id, user_id, agent_id, session_id, goal_id, project_id, title, description, status, priority,
     required, retry_count, max_retries, not_before, deadline_at,
-    session_id, context, output, created_at, updated_at
+    context, output, created_at, updated_at
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 RETURNING *;
 
 -- name: GetAgentTask :one
@@ -23,6 +23,7 @@ SELECT * FROM agent_task
 WHERE user_id = sqlc.arg('user_id')
   AND (sqlc.narg('agent_id') IS NULL OR agent_id = sqlc.narg('agent_id'))
   AND (sqlc.narg('status') IS NULL OR status = sqlc.narg('status'))
+  AND (sqlc.narg('project_id') IS NULL OR project_id = sqlc.narg('project_id'))
 ORDER BY created_at DESC, id DESC
 LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');
 
@@ -53,12 +54,11 @@ UPDATE agent_task
 SET status = ?, updated_at = ?
 WHERE id = ? AND status = ?;
 
--- Atomic claim: ready + no active run  running, set active_run_id and session_id.
+-- Atomic claim: ready + no active run -> running. session_id is required at task creation.
 -- name: ClaimAgentTask :execrows
 UPDATE agent_task
 SET status = 'running',
     active_run_id = ?,
-    session_id = COALESCE(session_id, ?),
     updated_at = ?
 WHERE id = ?
   AND status = 'ready'
@@ -97,11 +97,6 @@ WHERE id = ?;
 -- name: SetAgentTaskCancelled :exec
 UPDATE agent_task
 SET cancelled_at = ?, updated_at = ?
-WHERE id = ?;
-
--- name: ClearAgentTaskSession :exec
-UPDATE agent_task
-SET session_id = NULL, updated_at = ?
 WHERE id = ?;
 
 -- name: DeleteAgentTask :exec

--- a/internal/db/schemas/main.sql
+++ b/internal/db/schemas/main.sql
@@ -36,6 +36,7 @@
 -- atlas:import tables/recally_article.sql
 -- atlas:import tables/recally_rss_feed.sql
 -- atlas:import tables/recally_digest.sql
+-- atlas:import tables/project.sql
 -- agent_task and agent_task_run reference each other (active_run_id  task_id).
 -- Order here is a readability hint; atlas resolves declaration order itself.
 -- atlas:import tables/agent_goal.sql
@@ -48,5 +49,4 @@
 -- atlas:import tables/agent_task_dep.sql
 -- atlas:import tables/agent_task_dispatch_hint.sql
 -- atlas:import tables/agent_task_event.sql
--- atlas:import tables/project.sql
 -- atlas:import tables/plugin_override.sql

--- a/internal/db/schemas/tables/agent_goal.sql
+++ b/internal/db/schemas/tables/agent_goal.sql
@@ -6,7 +6,8 @@
 CREATE TABLE agent_goal (
     id              TEXT NOT NULL PRIMARY KEY,
     user_id         TEXT NOT NULL REFERENCES auth_user(id) ON DELETE CASCADE,
-    agent_id        TEXT REFERENCES agent(id) ON DELETE SET NULL,
+    agent_id        TEXT NOT NULL REFERENCES agent(id) ON DELETE RESTRICT,
+    project_id      TEXT REFERENCES project(id) ON DELETE SET NULL,
     title           TEXT NOT NULL,
     description     TEXT NOT NULL DEFAULT '',
     status          TEXT NOT NULL DEFAULT 'draft',
@@ -20,3 +21,6 @@ CREATE TABLE agent_goal (
     completed_at    TEXT,
     cancelled_at    TEXT
 );
+
+CREATE INDEX idx_agent_goal_agent_project ON agent_goal(agent_id, project_id);
+CREATE INDEX idx_agent_goal_project       ON agent_goal(project_id);

--- a/internal/db/schemas/tables/agent_task.sql
+++ b/internal/db/schemas/tables/agent_task.sql
@@ -5,8 +5,10 @@
 CREATE TABLE agent_task (
     id                  TEXT NOT NULL PRIMARY KEY,
     user_id             TEXT NOT NULL REFERENCES auth_user(id) ON DELETE CASCADE,
-    agent_id            TEXT REFERENCES agent(id) ON DELETE SET NULL,  -- D12: creator, NOT assignee
+    agent_id            TEXT NOT NULL REFERENCES agent(id) ON DELETE RESTRICT,  -- owner/manager agent context
+    session_id          TEXT NOT NULL REFERENCES ctx_conversation(session_id) ON DELETE RESTRICT, -- durable worker session
     goal_id             TEXT REFERENCES agent_goal(id) ON DELETE CASCADE,        -- Slice 3
+    project_id          TEXT REFERENCES project(id) ON DELETE SET NULL,
     title               TEXT NOT NULL,
     description         TEXT NOT NULL DEFAULT '',
     status              TEXT NOT NULL DEFAULT 'draft',
@@ -18,7 +20,6 @@ CREATE TABLE agent_task (
     max_retries         INTEGER NOT NULL DEFAULT 3,
     not_before          TEXT,
     deadline_at         TEXT,
-    session_id          TEXT,                                                    -- D12: null  next run mints fresh
     active_run_id       TEXT REFERENCES agent_task_run(id) ON DELETE RESTRICT,
     active_blocker_id   TEXT REFERENCES agent_task_blocker(id) ON DELETE RESTRICT,
     context             TEXT NOT NULL DEFAULT '{}',
@@ -29,6 +30,9 @@ CREATE TABLE agent_task (
     cancelled_at        TEXT
 );
 
-CREATE INDEX idx_agent_task_status_not_before ON agent_task(status, not_before);
+CREATE UNIQUE INDEX uniq_agent_task_session ON agent_task(session_id);
+CREATE INDEX idx_agent_task_agent_status_not_before ON agent_task(agent_id, status, not_before);
+CREATE INDEX idx_agent_task_user_agent        ON agent_task(user_id, agent_id);
 CREATE INDEX idx_agent_task_session           ON agent_task(session_id);
 CREATE INDEX idx_agent_task_goal              ON agent_task(goal_id);
+CREATE INDEX idx_agent_task_project           ON agent_task(project_id);

--- a/internal/server/goals.go
+++ b/internal/server/goals.go
@@ -89,7 +89,8 @@ func (s *Server) CreateGoal(w http.ResponseWriter, r *http.Request) {
 		UserID:      info.UserID,
 		Title:       req.Title,
 		Description: strPtr(req.Description),
-		AgentID:     strPtr(req.AgentId),
+		AgentID:     req.AgentId,
+		ProjectID:   strPtr(req.ProjectId),
 		Context:     marshalContext(req.Context),
 	}
 	if req.Priority != nil {
@@ -342,9 +343,10 @@ func goalToAPI(g sqlc.AgentGoal) apitypes.Goal {
 		CreatedAt:    parseTS(g.CreatedAt),
 		UpdatedAt:    parseTS(g.UpdatedAt),
 	}
-	if g.AgentID.Valid {
-		v := g.AgentID.String
-		out.AgentId = &v
+	out.AgentId = g.AgentID
+	if g.ProjectID.Valid {
+		v := g.ProjectID.String
+		out.ProjectId = &v
 	}
 	if g.ActiveReviewID.Valid {
 		v := g.ActiveReviewID.String

--- a/internal/server/tasks.go
+++ b/internal/server/tasks.go
@@ -50,6 +50,8 @@ func (s *Server) taskError(w http.ResponseWriter, err error) {
 		writeError(w, http.StatusConflict, "blocker_already_closed")
 	case errors.Is(err, tasks.ErrUnsupportedReviewPolicy):
 		writeError(w, http.StatusBadRequest, "unsupported_review_policy")
+	case errors.Is(err, tasks.ErrInvalidTaskContext):
+		writeError(w, http.StatusBadRequest, "invalid_task_context")
 	default:
 		var conflict *tasks.ErrReopenConflict
 		if errors.As(err, &conflict) {
@@ -113,11 +115,15 @@ func (s *Server) ListTasks(w http.ResponseWriter, r *http.Request, params apiser
 	if params.AgentId != nil {
 		agentID = *params.AgentId
 	}
+	projectID := ""
+	if params.ProjectId != nil {
+		projectID = *params.ProjectId
+	}
 	status := ""
 	if params.Status != nil {
 		status = *params.Status
 	}
-	rows, err := s.tasksSvc.Facade.ListTasksByUser(r.Context(), info.UserID, agentID, status, int64(limit+1), int64(offset))
+	rows, err := s.tasksSvc.Facade.ListTasksByUser(r.Context(), info.UserID, agentID, projectID, status, int64(limit+1), int64(offset))
 	if err != nil {
 		s.taskError(w, err)
 		return
@@ -159,29 +165,13 @@ func (s *Server) CreateTask(w http.ResponseWriter, r *http.Request) {
 
 	agentID := strPtr(req.AgentId)
 	goalID := strPtr(req.GoalId)
-	if goalID != "" {
-		g, ok := s.loadGoal(r.Context(), w, info.UserID, goalID)
-		if !ok {
-			return
-		}
-		if !g.AgentID.Valid || g.AgentID.String == "" {
-			writeError(w, http.StatusBadRequest, "goal has no agent_id")
-			return
-		}
-		if agentID == "" {
-			agentID = g.AgentID.String
-		} else if agentID != g.AgentID.String {
-			writeError(w, http.StatusBadRequest, "goal_id must belong to the same agent_id")
-			return
-		}
-	}
-
 	in := tasks.CreateTaskInput{
 		UserID:          info.UserID,
 		Title:           req.Title,
 		Description:     strPtr(req.Description),
 		AgentID:         agentID,
 		GoalID:          goalID,
+		ProjectID:       strPtr(req.ProjectId),
 		ExecutorAgentID: strPtr(req.ExecutorAgentId),
 		Required:        req.Required,
 		Context:         marshalContext(req.Context),
@@ -673,13 +663,14 @@ func taskToAPI(t sqlc.AgentTask) apitypes.Task {
 		CreatedAt:    parseTS(t.CreatedAt),
 		UpdatedAt:    parseTS(t.UpdatedAt),
 	}
-	if t.AgentID.Valid {
-		v := t.AgentID.String
-		out.AgentId = &v
-	}
+	out.AgentId = t.AgentID
 	if t.GoalID.Valid {
 		v := t.GoalID.String
 		out.GoalId = &v
+	}
+	if t.ProjectID.Valid {
+		v := t.ProjectID.String
+		out.ProjectId = &v
 	}
 	if t.NotBefore.Valid {
 		v := parseTS(t.NotBefore.String)
@@ -689,10 +680,7 @@ func taskToAPI(t sqlc.AgentTask) apitypes.Task {
 		v := parseTS(t.DeadlineAt.String)
 		out.DeadlineAt = &v
 	}
-	if t.SessionID.Valid {
-		v := t.SessionID.String
-		out.SessionId = &v
-	}
+	out.SessionId = t.SessionID
 	if t.ActiveRunID.Valid {
 		v := t.ActiveRunID.String
 		out.ActiveRunId = &v

--- a/internal/server/tasks_test.go
+++ b/internal/server/tasks_test.go
@@ -19,11 +19,31 @@ func withTasks(t *testing.T, env *testEnv) {
 	env.srv.SetTasksService(svc)
 }
 
+func taskTestAgentID(t *testing.T, env *testEnv) string {
+	t.Helper()
+	agents, err := env.store.ListAgents(context.Background())
+	if err != nil || len(agents) == 0 {
+		t.Fatalf("ListAgents: %v", err)
+	}
+	return agents[0].ID
+}
+
+func taskCreateBody(t *testing.T, env *testEnv, title string) apitypes.CreateTaskRequest {
+	t.Helper()
+	agentID := taskTestAgentID(t, env)
+	return apitypes.CreateTaskRequest{Title: title, AgentId: &agentID}
+}
+
+func goalCreateBody(t *testing.T, env *testEnv, title string) apitypes.CreateGoalRequest {
+	t.Helper()
+	return apitypes.CreateGoalRequest{Title: title, AgentId: taskTestAgentID(t, env)}
+}
+
 func TestTasks_CreateGetRoundTrip(t *testing.T) {
 	env := setupAdmin(t)
 	withTasks(t, env)
 
-	body := apitypes.CreateTaskRequest{Title: "hello"}
+	body := taskCreateBody(t, env, "hello")
 	rr := doRequest(t, env, http.MethodPost, "/api/tasks", body)
 	if rr.Code != http.StatusCreated {
 		t.Fatalf("create: status=%d body=%s", rr.Code, rr.Body.String())
@@ -51,7 +71,7 @@ func TestTasks_CreateWithGoalIDLinksGoalChild(t *testing.T) {
 	}
 	agentID := agents[0].ID
 
-	goalBody := apitypes.CreateGoalRequest{Title: "parent", AgentId: &agentID}
+	goalBody := goalCreateBody(t, env, "parent")
 	rr := doRequest(t, env, http.MethodPost, "/api/goals", goalBody)
 	if rr.Code != http.StatusCreated {
 		t.Fatalf("create goal: status=%d body=%s", rr.Code, rr.Body.String())
@@ -96,7 +116,7 @@ func TestTasks_CreateRejectsGoalIDFromDifferentAgent(t *testing.T) {
 	}
 	agentID := agents[0].ID
 
-	goalBody := apitypes.CreateGoalRequest{Title: "parent", AgentId: &agentID}
+	goalBody := goalCreateBody(t, env, "parent")
 	rr := doRequest(t, env, http.MethodPost, "/api/goals", goalBody)
 	if rr.Code != http.StatusCreated {
 		t.Fatalf("create goal: status=%d body=%s", rr.Code, rr.Body.String())
@@ -139,10 +159,9 @@ func TestTasks_OtherUserCannotAccessTaskByID(t *testing.T) {
 	_, otherToken := createTestUserWithToken(t, env.authStore, env.oidcStore, "task-other", auth.RoleUser)
 
 	active := true
-	rr := doBearerRequest(t, env.srv, ownerToken, http.MethodPost, "/api/tasks", apitypes.CreateTaskRequest{
-		Title:            "owned",
-		ActivateOnCreate: &active,
-	})
+	body := taskCreateBody(t, env, "owned")
+	body.ActivateOnCreate = &active
+	rr := doBearerRequest(t, env.srv, ownerToken, http.MethodPost, "/api/tasks", body)
 	if rr.Code != http.StatusCreated {
 		t.Fatalf("create: status=%d body=%s", rr.Code, rr.Body.String())
 	}
@@ -181,7 +200,7 @@ func TestTasks_CannotAddDependencyOnOtherUsersTask(t *testing.T) {
 	_, otherToken := createTestUserWithToken(t, env.authStore, env.oidcStore, "dep-other", auth.RoleUser)
 
 	create := func(token, title string) apitypes.Task {
-		rr := doBearerRequest(t, env.srv, token, http.MethodPost, "/api/tasks", apitypes.CreateTaskRequest{Title: title})
+		rr := doBearerRequest(t, env.srv, token, http.MethodPost, "/api/tasks", taskCreateBody(t, env, title))
 		if rr.Code != http.StatusCreated {
 			t.Fatalf("create %q: status=%d body=%s", title, rr.Code, rr.Body.String())
 		}
@@ -205,7 +224,7 @@ func TestTasks_ListReturnsCreatedTasks(t *testing.T) {
 	withTasks(t, env)
 
 	for _, title := range []string{"one", "two", "three"} {
-		rr := doRequest(t, env, http.MethodPost, "/api/tasks", apitypes.CreateTaskRequest{Title: title})
+		rr := doRequest(t, env, http.MethodPost, "/api/tasks", taskCreateBody(t, env, title))
 		if rr.Code != http.StatusCreated {
 			t.Fatalf("create %q: status=%d body=%s", title, rr.Code, rr.Body.String())
 		}
@@ -227,7 +246,7 @@ func TestTasks_ReadinessForDraftReportsDraft(t *testing.T) {
 	env := setupAdmin(t)
 	withTasks(t, env)
 
-	rr := doRequest(t, env, http.MethodPost, "/api/tasks", apitypes.CreateTaskRequest{Title: "x"})
+	rr := doRequest(t, env, http.MethodPost, "/api/tasks", taskCreateBody(t, env, "x"))
 	if rr.Code != http.StatusCreated {
 		t.Fatalf("create: status=%d body=%s", rr.Code, rr.Body.String())
 	}
@@ -251,7 +270,7 @@ func TestTasks_CancelMovesDraftToCancelled(t *testing.T) {
 	env := setupAdmin(t)
 	withTasks(t, env)
 
-	rr := doRequest(t, env, http.MethodPost, "/api/tasks", apitypes.CreateTaskRequest{Title: "x"})
+	rr := doRequest(t, env, http.MethodPost, "/api/tasks", taskCreateBody(t, env, "x"))
 	if rr.Code != http.StatusCreated {
 		t.Fatalf("create: status=%d body=%s", rr.Code, rr.Body.String())
 	}
@@ -274,7 +293,7 @@ func TestTasks_AddDepCycleReturns409(t *testing.T) {
 	withTasks(t, env)
 
 	create := func(title string) string {
-		rr := doRequest(t, env, http.MethodPost, "/api/tasks", apitypes.CreateTaskRequest{Title: title})
+		rr := doRequest(t, env, http.MethodPost, "/api/tasks", taskCreateBody(t, env, title))
 		if rr.Code != http.StatusCreated {
 			t.Fatalf("create %q: %d %s", title, rr.Code, rr.Body.String())
 		}
@@ -301,7 +320,9 @@ func TestTasks_EventsListReturnsActivateEvent(t *testing.T) {
 	withTasks(t, env)
 
 	tt := true
-	rr := doRequest(t, env, http.MethodPost, "/api/tasks", apitypes.CreateTaskRequest{Title: "x", ActivateOnCreate: &tt})
+	body := taskCreateBody(t, env, "x")
+	body.ActivateOnCreate = &tt
+	rr := doRequest(t, env, http.MethodPost, "/api/tasks", body)
 	if rr.Code != http.StatusCreated {
 		t.Fatalf("create: status=%d body=%s", rr.Code, rr.Body.String())
 	}
@@ -330,7 +351,7 @@ func TestGoals_CreateGetRoundTrip(t *testing.T) {
 	env := setupAdmin(t)
 	withTasks(t, env)
 
-	body := apitypes.CreateGoalRequest{Title: "ship it"}
+	body := goalCreateBody(t, env, "ship it")
 	rr := doRequest(t, env, http.MethodPost, "/api/goals", body)
 	if rr.Code != http.StatusCreated {
 		t.Fatalf("create: status=%d body=%s", rr.Code, rr.Body.String())
@@ -352,7 +373,7 @@ func TestGoals_CreateGetRoundTrip(t *testing.T) {
 func TestGoals_Activate_DraftToRunning(t *testing.T) {
 	env := setupAdmin(t)
 	withTasks(t, env)
-	rr := doRequest(t, env, http.MethodPost, "/api/goals", apitypes.CreateGoalRequest{Title: "x"})
+	rr := doRequest(t, env, http.MethodPost, "/api/goals", goalCreateBody(t, env, "x"))
 	if rr.Code != http.StatusCreated {
 		t.Fatalf("create: %d %s", rr.Code, rr.Body.String())
 	}
@@ -382,7 +403,7 @@ func TestGoals_GetUnknown_404(t *testing.T) {
 func TestGoals_CancelRunningCascade(t *testing.T) {
 	env := setupAdmin(t)
 	withTasks(t, env)
-	rr := doRequest(t, env, http.MethodPost, "/api/goals", apitypes.CreateGoalRequest{Title: "x"})
+	rr := doRequest(t, env, http.MethodPost, "/api/goals", goalCreateBody(t, env, "x"))
 	var goal apitypes.Goal
 	_ = json.Unmarshal(rr.Body.Bytes(), &goal)
 	_ = doRequest(t, env, http.MethodPost, "/api/goals/"+goal.Id+"/activate", nil)

--- a/internal/tasks/boot.go
+++ b/internal/tasks/boot.go
@@ -46,7 +46,6 @@ type BootConfig struct {
 func New(cfg BootConfig) *Service {
 	q := sqlc.New(cfg.DB)
 	svc := NewTransitionService(cfg.DB, q)
-	facade := NewServiceFacade(cfg.DB, q, svc)
 	logger := cfg.Logger
 	if logger == nil {
 		logger = slog.Default().With("component", "tasks")
@@ -63,8 +62,9 @@ func New(cfg BootConfig) *Service {
 	if cfg.Services != nil {
 		newSession = registrySessionMinter(cfg.Services, logger)
 	} else {
-		newSession = legacySessionMinter(cfg.Memory, logger)
+		newSession = legacySessionMinter(cfg.Memory, q, logger)
 	}
+	facade := NewServiceFacade(cfg.DB, q, svc, newSession)
 
 	disp := NewDispatcher(DispatcherConfig{
 		Service:    svc,
@@ -98,21 +98,21 @@ func noopExecutor(log *slog.Logger) Executor {
 
 // sessionOwnerResolver resolves the executor for a task that has already run by
 // reusing the executor_agent_id of its latest worker run. This sits between the
-// dispatch hint and the creator fallback in the dispatcher's precedence chain
+// dispatch hint and owner-agent fallback in the dispatcher's precedence chain
 // (D13), so a retry keeps the original executor and runs in the task's
-// persisted session — even when the first run was handed to an agent other than
-// the task creator via a dispatch hint.
+// persisted session — even when the first run was handed to another agent via a
+// dispatch hint.
 //
 // It resolves from durable task-run data rather than memory.SessionManager:
 // LoadInfo requires user_id+agent_id already in the context scope, but the
-// dispatcher's scheduler context has neither, and agent_id is precisely the
-// owner we are trying to discover — a circular dependency that made the old
-// memory-backed lookup always fail and silently fall back to the creator.
+// dispatcher's scheduler context has neither, and agent_id was precisely the
+// owner the old resolver tried to discover — a circular dependency that made the
+// memory-backed lookup fail and silently fall back to the owner-agent path.
 // Returns (false) when the task has no recorded session/run or that run carried
 // no executor, letting the dispatcher fall back to task.agent_id.
 func sessionOwnerResolver(q *sqlc.Queries, logger *slog.Logger) ExecutorResolver {
 	return func(ctx context.Context, task sqlc.AgentTask) (string, bool) {
-		if !task.SessionID.Valid || task.SessionID.String == "" {
+		if task.SessionID == "" {
 			return "", false
 		}
 		run, err := q.LatestAgentTaskRunForTask(ctx, sqlc.LatestAgentTaskRunForTaskParams{
@@ -132,18 +132,12 @@ func sessionOwnerResolver(q *sqlc.Queries, logger *slog.Logger) ExecutorResolver
 }
 
 // registrySessionMinter creates task sessions through the session.Registry for
-// the executor agent. Sessions are created with KindTask/ChannelTask so they
+// the resolved agent. Sessions are created with KindTask/ChannelTask so they
 // are excluded from user-facing session lists and review candidates.
 func registrySessionMinter(sm agent.ServiceManager, _ *slog.Logger) SessionMinter {
-	return func(ctx context.Context, task sqlc.AgentTask, executorAgentID string) (string, error) {
-		if task.UserID == "" {
+	return func(ctx context.Context, userID, agentID, projectID string) (string, error) {
+		if userID == "" {
 			return "", fmt.Errorf("task has no user_id; cannot mint session")
-		}
-		agentID := executorAgentID
-		if agentID == "" {
-			if task.AgentID.Valid {
-				agentID = task.AgentID.String
-			}
 		}
 		if agentID == "" {
 			return "", fmt.Errorf("task has no agent_id; cannot mint session")
@@ -152,7 +146,7 @@ func registrySessionMinter(sm agent.ServiceManager, _ *slog.Logger) SessionMinte
 		if svc == nil {
 			return "", fmt.Errorf("no service for executor agent %q", agentID)
 		}
-		info, err := svc.MintTaskSession(ctx, task.UserID, agentID)
+		info, err := svc.MintTaskSession(ctx, userID, agentID, projectID)
 		if err != nil {
 			return "", err
 		}
@@ -161,15 +155,38 @@ func registrySessionMinter(sm agent.ServiceManager, _ *slog.Logger) SessionMinte
 }
 
 // legacySessionMinter is the pre-registry fallback used when ServiceManager is nil.
-func legacySessionMinter(_ memory.Provider, _ *slog.Logger) SessionMinter {
-	return func(_ context.Context, task sqlc.AgentTask, _ string) (string, error) {
-		if task.UserID == "" {
+func legacySessionMinter(mem memory.Provider, q *sqlc.Queries, _ *slog.Logger) SessionMinter {
+	return func(ctx context.Context, userID, agentID, projectID string) (string, error) {
+		if userID == "" {
 			return "", fmt.Errorf("task has no user_id; cannot mint session")
 		}
-		return legacyMintSession(task.UserID)
+		if agentID == "" {
+			return "", fmt.Errorf("task has no agent_id; cannot mint session")
+		}
+		sessionID := legacyMintSession(userID)
+		now := time.Now().UTC()
+		if sm, ok := mem.(memory.SessionManager); ok {
+			if err := sm.SaveInfo(ctx, memory.SessionInfo{
+				ID: sessionID, UserID: userID, AgentID: agentID, ProjectID: projectID,
+				Kind: "task", Channel: "task", CreatedAt: now, LastActive: now,
+			}); err != nil {
+				return "", err
+			}
+		} else {
+			if _, err := q.CreateConversation(ctx, sqlc.CreateConversationParams{
+				ID: uuid.NewString(), SessionID: sessionID,
+				Title:   sql.NullString{String: "Task", Valid: true},
+				Channel: "task", Kind: "task", ProjectID: nullable(projectID), Archived: 0,
+				LastActive: now.Format("2006-01-02 15:04:05"),
+				AgentID:    nullable(agentID), UserID: nullable(userID),
+			}); err != nil {
+				return "", err
+			}
+		}
+		return sessionID, nil
 	}
 }
 
-func legacyMintSession(_ string) (string, error) {
-	return "task-" + uuid.NewString(), nil
+func legacyMintSession(_ string) string {
+	return "task-" + uuid.NewString()
 }

--- a/internal/tasks/boot_test.go
+++ b/internal/tasks/boot_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // seedAgent inserts an extra agent row and returns its id, for tests that need
-// an executor distinct from the task creator.
+// an executor distinct from the task owner.
 func (h *testHarness) seedAgent(t *testing.T, name string) string {
 	t.Helper()
 	id := uuid.NewString()
@@ -22,7 +22,7 @@ func (h *testHarness) seedAgent(t *testing.T, name string) string {
 }
 
 // TestSessionOwnerResolver_ReusesLatestRunExecutor proves the resolver returns
-// the executor of the task's latest worker run — not the task creator — so a
+// the executor of the task's latest worker run — not merely the task owner — so a
 // task first dispatched to another agent via a hint keeps that executor on
 // retry. (CR-002)
 func TestSessionOwnerResolver_ReusesLatestRunExecutor(t *testing.T) {
@@ -30,9 +30,9 @@ func TestSessionOwnerResolver_ReusesLatestRunExecutor(t *testing.T) {
 	h := newHarness(t)
 	execB := h.seedAgent(t, "executor-b")
 
-	id := h.createTask(t, StatusReady) // creator is h.agentID
+	id := h.createTask(t, StatusReady) // owner is h.agentID
 	if _, err := h.svc.Claim(ctx, ClaimParams{
-		TaskID: id, ExecutorAgentID: execB, NewSessionID: "sess-1",
+		TaskID: id, ExecutorAgentID: execB, SessionID: "sess-1",
 	}); err != nil {
 		t.Fatalf("claim: %v", err)
 	}
@@ -44,9 +44,9 @@ func TestSessionOwnerResolver_ReusesLatestRunExecutor(t *testing.T) {
 	}
 }
 
-// TestSessionOwnerResolver_NoSessionFalls: a task that has never run carries no
-// session_id, so the resolver declines and the dispatcher falls back to the
-// creator.
+// TestSessionOwnerResolver_NoSessionFalls: a task that has never run has no
+// worker run to derive an executor from, so the resolver declines and the
+// dispatcher falls back to the owner agent.
 func TestSessionOwnerResolver_NoSessionFalls(t *testing.T) {
 	h := newHarness(t)
 	id := h.createTask(t, StatusReady)
@@ -57,14 +57,14 @@ func TestSessionOwnerResolver_NoSessionFalls(t *testing.T) {
 }
 
 // TestSessionOwnerResolver_NoExecutorOnRunFalls: a session exists but its run
-// recorded no executor (creator-dispatched, executor agent unknown), so the
+// recorded no executor (owner-dispatched, executor agent unknown), so the
 // resolver declines rather than inventing one.
 func TestSessionOwnerResolver_NoExecutorOnRunFalls(t *testing.T) {
 	ctx := context.Background()
 	h := newHarness(t)
 	id := h.createTask(t, StatusReady)
 	if _, err := h.svc.Claim(ctx, ClaimParams{
-		TaskID: id, ExecutorAgentID: "", NewSessionID: "sess-1",
+		TaskID: id, ExecutorAgentID: "", SessionID: "sess-1",
 	}); err != nil {
 		t.Fatalf("claim: %v", err)
 	}

--- a/internal/tasks/dispatcher.go
+++ b/internal/tasks/dispatcher.go
@@ -19,16 +19,15 @@ type SchedulerLike interface {
 }
 
 // ExecutorResolver decides which agent should execute a given run.
-// Resolution per D13: live dispatch hint -> session-derived -> creator
+// Resolution per D13: live dispatch hint -> latest-run executor -> owner agent
 // fallback. The function may return ("", false) if it cannot resolve; the
 // dispatcher will refuse the claim and emit a protocol_error event.
 type ExecutorResolver func(ctx context.Context, task sqlc.AgentTask) (agentID string, ok bool)
 
-// SessionMinter returns a fresh session id for a first-run dispatch (i.e.
-// task.session_id IS NULL). It must produce a unique id per call.
-// executorAgentID is the resolved agent that will run the task — the session
-// must be attributed to this agent, not the task's creator.
-type SessionMinter func(ctx context.Context, task sqlc.AgentTask, executorAgentID string) (string, error)
+// SessionMinter returns a fresh durable worker session id for a task. It must
+// produce a unique id per call and scope the session to the resolved agent and
+// optional project context.
+type SessionMinter func(ctx context.Context, userID, agentID, projectID string) (string, error)
 
 // DispatcherConfig holds the wiring for a Dispatcher.
 type DispatcherConfig struct {
@@ -247,26 +246,15 @@ func (d *Dispatcher) scanAndDispatch(ctx context.Context, now time.Time) {
 			d.emitProtocolError(ctx, task.ID, "no executor resolved")
 			continue
 		}
-		// Reuse the task's persisted session on a retry; mint a fresh one only
-		// for a first claim. Claim's D12 rule keeps an existing session_id and
-		// ignores NewSessionID, so unconditionally minting here would orphan a
-		// session per retry tick.
-		sessionID := ""
-		if task.SessionID.Valid && task.SessionID.String != "" {
-			sessionID = task.SessionID.String
-		} else {
-			var err error
-			sessionID, err = d.cfg.NewSession(ctx, task, execID)
-			if err != nil {
-				d.cfg.Logger.Warn("dispatcher: mint session", "task", task.ID, "err", err)
-				continue
-			}
+		sessionID := task.SessionID
+		if sessionID == "" {
+			d.emitProtocolError(ctx, task.ID, "task has no worker session")
+			continue
 		}
 		res, err := d.cfg.Service.Claim(ctx, ClaimParams{
 			TaskID: task.ID, ExecutorAgentID: execID,
 			WorkerID: "", LeaseDuration: d.cfg.LeaseTTL,
-			NewSessionID: sessionID, Actor: SystemActor(),
-			HintID: hintID,
+			Actor: SystemActor(), HintID: hintID,
 		})
 		if errors.Is(err, ErrInvalidTransition) {
 			continue // lost the race
@@ -309,15 +297,15 @@ func (d *Dispatcher) resolveExecutor(ctx context.Context, task sqlc.AgentTask) (
 	if err == nil && hint.ExecutorAgentID != "" {
 		return hint.ExecutorAgentID, hint.ID, true
 	}
-	// 2) Caller-supplied resolver (session/creator chain).
+	// 2) Caller-supplied resolver (latest-run executor preservation).
 	if d.cfg.Resolver != nil {
 		if a, ok := d.cfg.Resolver(ctx, task); ok {
 			return a, "", true
 		}
 	}
-	// 3) Creator fallback.
-	if task.AgentID.Valid && task.AgentID.String != "" {
-		return task.AgentID.String, "", true
+	// 3) Owner/manager agent fallback.
+	if task.AgentID != "" {
+		return task.AgentID, "", true
 	}
 	return "", "", false
 }

--- a/internal/tasks/dispatcher_test.go
+++ b/internal/tasks/dispatcher_test.go
@@ -30,7 +30,7 @@ func newDispatcherHarness(t *testing.T, exec Executor) (*testHarness, *Dispatche
 		Resolver: func(_ context.Context, _ sqlc.AgentTask) (string, bool) {
 			return h.agentID, true
 		},
-		NewSession: func(_ context.Context, _ sqlc.AgentTask, _ string) (string, error) {
+		NewSession: func(_ context.Context, _, _, _ string) (string, error) {
 			return "sess-" + uuid.NewString()[:8], nil
 		},
 		TickEvery:  0,
@@ -112,7 +112,7 @@ func TestDispatcher_StaleRunGetsInterrupted(t *testing.T) {
 	h, d := newDispatcherHarness(t, noTerminal)
 	id := h.createTask(t, StatusReady)
 	res, err := h.svc.Claim(context.Background(), ClaimParams{
-		TaskID: id, NewSessionID: "sess", LeaseDuration: time.Second,
+		TaskID: id, SessionID: "sess", LeaseDuration: time.Second,
 	})
 	if err != nil {
 		t.Fatalf("Claim: %v", err)
@@ -153,7 +153,7 @@ func TestDispatcher_RetryReusesSessionNoOrphan(t *testing.T) {
 		Queries:  h.q,
 		Executor: exec,
 		Resolver: func(_ context.Context, _ sqlc.AgentTask) (string, bool) { return h.agentID, true },
-		NewSession: func(_ context.Context, _ sqlc.AgentTask, _ string) (string, error) {
+		NewSession: func(_ context.Context, _, _, _ string) (string, error) {
 			mintCalls.Add(1)
 			return "sess-fixed", nil
 		},
@@ -172,8 +172,8 @@ func TestDispatcher_RetryReusesSessionNoOrphan(t *testing.T) {
 	if got := h.getTask(t, id).Status; got != StatusDone {
 		t.Fatalf("after second tick status=%q want done", got)
 	}
-	if mintCalls.Load() != 1 {
-		t.Errorf("NewSession called %d times, want 1 (no orphan session on retry)", mintCalls.Load())
+	if mintCalls.Load() != 0 {
+		t.Errorf("NewSession called %d times, want 0 (sessions are minted at task creation)", mintCalls.Load())
 	}
 }
 
@@ -227,7 +227,7 @@ func TestDispatcher_DispatchHintWinsOverResolver(t *testing.T) {
 		Resolver: func(_ context.Context, _ sqlc.AgentTask) (string, bool) {
 			return "resolver-agent", true // should be ignored
 		},
-		NewSession: func(_ context.Context, _ sqlc.AgentTask, _ string) (string, error) {
+		NewSession: func(_ context.Context, _, _, _ string) (string, error) {
 			return "sess", nil
 		},
 	})
@@ -252,7 +252,7 @@ func TestDispatcher_DispatchHintWinsOverResolver(t *testing.T) {
 	}
 }
 
-func TestDispatcher_NoExecutorResolved_EmitsProtocolError(t *testing.T) {
+func TestDispatcher_OwnerAgentFallbackDispatches(t *testing.T) {
 	h := newHarness(t)
 	id := h.createTask(t, StatusReady)
 	d := NewDispatcher(DispatcherConfig{
@@ -260,26 +260,14 @@ func TestDispatcher_NoExecutorResolved_EmitsProtocolError(t *testing.T) {
 		Resolver: func(_ context.Context, _ sqlc.AgentTask) (string, bool) {
 			return "", false
 		},
-		NewSession: func(_ context.Context, _ sqlc.AgentTask, _ string) (string, error) {
+		NewSession: func(_ context.Context, _, _, _ string) (string, error) {
 			return "sess", nil
 		},
 	})
 	d.Tick(context.Background())
 	d.WaitIdle()
-	// Task is unchanged (still ready); event log records protocol_error.
-	if got := h.getTask(t, id).Status; got != StatusReady {
-		t.Errorf("status=%q want ready (claim refused)", got)
-	}
-	events, _ := h.q.ListAgentTaskEvents(context.Background(), sqlc.ListAgentTaskEventsParams{TaskID: nullable(id), Limit: 1000})
-	found := false
-	for _, e := range events {
-		if e.EventType == "protocol_error" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Errorf("expected protocol_error event on task %s", id)
+	if got := h.getTask(t, id).Status; got != StatusDone {
+		t.Errorf("status=%q want done via owner-agent fallback", got)
 	}
 }
 
@@ -309,9 +297,9 @@ func TestDispatcher_ConcurrencyCapHonored(t *testing.T) {
 	d := NewDispatcher(DispatcherConfig{
 		Service: h.svc, Queries: h.q, Executor: exec,
 		Resolver: func(_ context.Context, _ sqlc.AgentTask) (string, bool) {
-			return "agent", true
+			return h.agentID, true
 		},
-		NewSession: func(_ context.Context, _ sqlc.AgentTask, _ string) (string, error) {
+		NewSession: func(_ context.Context, _, _, _ string) (string, error) {
 			return uuid.NewString(), nil
 		},
 		MaxWorkers: cap,

--- a/internal/tasks/dispatcher_test.go
+++ b/internal/tasks/dispatcher_test.go
@@ -75,7 +75,17 @@ func TestDispatcher_DraftTaskNotPickedUp(t *testing.T) {
 
 func TestDispatcher_DepGatedTask_WaitsForUpstream(t *testing.T) {
 	called := atomic.Int32{}
+	// Block the first dispatched run (upstream) so it stays 'running' while the
+	// same-tick scan evaluates downstream. Without this, a fast upstream worker
+	// can reach 'done' mid-tick, satisfying the hard dep and letting downstream
+	// dispatch in the same tick — a real eager cascade, but it makes the
+	// one-level-per-tick assertion below racy under load.
+	firstRun := atomic.Bool{}
+	release := make(chan struct{})
 	exec := executorFunc(func(_ context.Context, _ Request) (Result, error) {
+		if firstRun.CompareAndSwap(false, true) {
+			<-release
+		}
 		called.Add(1)
 		return Result{Action: TerminalSubmit, Output: map[string]any{}}, nil
 	})
@@ -85,8 +95,11 @@ func TestDispatcher_DepGatedTask_WaitsForUpstream(t *testing.T) {
 	if err := h.svc.AddDep(context.Background(), downstream, upstream, DepKindHard, OnFailureBlock); err != nil {
 		t.Fatalf("AddDep: %v", err)
 	}
-	// First tick: only upstream should dispatch.
+	// First tick: only upstream should dispatch. Tick returns once workers are
+	// spawned; upstream is claimed ('running') and parked in its executor, so
+	// the same-tick downstream evaluation sees an unsatisfied hard dep.
 	d.Tick(context.Background())
+	close(release)
 	d.WaitIdle()
 	if called.Load() != 1 {
 		t.Errorf("only upstream should have run; got %d calls", called.Load())

--- a/internal/tasks/executor_test.go
+++ b/internal/tasks/executor_test.go
@@ -54,7 +54,7 @@ func claimSetup(t *testing.T, h *testHarness) (string, string) {
 	t.Helper()
 	id := h.createTask(t, StatusReady)
 	res, err := h.svc.Claim(context.Background(), ClaimParams{
-		TaskID: id, NewSessionID: "sess-test", LeaseDuration: time.Minute,
+		TaskID: id, SessionID: "sess-test", LeaseDuration: time.Minute,
 	})
 	if err != nil {
 		t.Fatalf("Claim: %v", err)

--- a/internal/tasks/goal_transitions_test.go
+++ b/internal/tasks/goal_transitions_test.go
@@ -18,7 +18,7 @@ func (h *testHarness) createGoal(t *testing.T, status, policy string) string {
 	id := uuid.NewString()
 	now := time.Now().Format(time.RFC3339Nano)
 	if _, err := h.q.CreateAgentGoal(context.Background(), sqlc.CreateAgentGoalParams{
-		ID: id, UserID: h.userID,
+		ID: id, UserID: h.userID, AgentID: h.agentID,
 		Title: "g-" + id[:8], Description: "", Status: status, Priority: "routine",
 		ReviewPolicy: policy, Context: "{}", Output: "{}",
 		CreatedAt: now, UpdatedAt: now,
@@ -32,12 +32,13 @@ func (h *testHarness) createGoal(t *testing.T, status, policy string) string {
 func (h *testHarness) createChildTask(t *testing.T, goalID, status string) string {
 	t.Helper()
 	id := uuid.NewString()
+	sessionID := h.createTaskSession(t, "child-"+id[:8])
 	now := time.Now().Format(time.RFC3339Nano)
 	if _, err := h.db.ExecContext(context.Background(), `
-		INSERT INTO agent_task (id, user_id, goal_id, title, status, priority,
+		INSERT INTO agent_task (id, user_id, agent_id, session_id, goal_id, title, status, priority,
 		    required, retry_count, max_retries, context, output, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, 'routine', 1, 0, 3, '{}', '{}', ?, ?)`,
-		id, h.userID, goalID, "child-"+id[:8], status, now, now,
+		VALUES (?, ?, ?, ?, ?, ?, ?, 'routine', 1, 0, 3, '{}', '{}', ?, ?)`,
+		id, h.userID, h.agentID, sessionID, goalID, "child-"+id[:8], status, now, now,
 	); err != nil {
 		t.Fatalf("create child: %v", err)
 	}
@@ -90,10 +91,10 @@ func TestActivateGoal_NonNonePolicy_Rejected(t *testing.T) {
 
 func TestCreateGoal_NonNonePolicy_Rejected(t *testing.T) {
 	h := newHarness(t)
-	f := NewServiceFacade(h.db, h.q, h.svc)
+	f := NewServiceFacade(h.db, h.q, h.svc, testSessionMinter)
 	for _, policy := range []string{ReviewPolicyAuto, ReviewPolicyAgent, ReviewPolicyHuman} {
 		_, err := f.CreateGoal(context.Background(), CreateGoalInput{
-			UserID: h.userID, Title: "g", ReviewPolicy: policy,
+			UserID: h.userID, AgentID: h.agentID, Title: "g", ReviewPolicy: policy,
 		})
 		if !errors.Is(err, ErrUnsupportedReviewPolicy) {
 			t.Errorf("policy=%q: got %v want ErrUnsupportedReviewPolicy", policy, err)
@@ -103,8 +104,8 @@ func TestCreateGoal_NonNonePolicy_Rejected(t *testing.T) {
 
 func TestCreateGoal_NonePolicy_OK(t *testing.T) {
 	h := newHarness(t)
-	f := NewServiceFacade(h.db, h.q, h.svc)
-	g, err := f.CreateGoal(context.Background(), CreateGoalInput{UserID: h.userID, Title: "g"})
+	f := NewServiceFacade(h.db, h.q, h.svc, testSessionMinter)
+	g, err := f.CreateGoal(context.Background(), CreateGoalInput{UserID: h.userID, AgentID: h.agentID, Title: "g"})
 	if err != nil {
 		t.Fatalf("CreateGoal(none): %v", err)
 	}

--- a/internal/tasks/reopen_test.go
+++ b/internal/tasks/reopen_test.go
@@ -8,7 +8,7 @@ import (
 // completeTask helper drives a task to done.
 func completeTask(t *testing.T, h *testHarness, id string) {
 	t.Helper()
-	res, err := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, NewSessionID: "s-" + id[:6]})
+	res, err := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, SessionID: "s-" + id[:6]})
 	if err != nil {
 		t.Fatalf("Claim: %v", err)
 	}

--- a/internal/tasks/review_test.go
+++ b/internal/tasks/review_test.go
@@ -19,7 +19,7 @@ func setReviewPolicy(t *testing.T, h *testHarness, taskID, policy string) {
 func TestReview_NonePolicy_BehavesLikeSubmit(t *testing.T) {
 	h := newHarness(t)
 	id := h.createTask(t, StatusReady)
-	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, NewSessionID: "s"})
+	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, SessionID: "s"})
 	if err := h.svc.Submit(context.Background(), id, res.RunID, "{}", SystemActor()); err != nil {
 		t.Fatalf("Submit: %v", err)
 	}
@@ -32,7 +32,7 @@ func TestReview_AutoPolicy_LogsReview_ThenDone(t *testing.T) {
 	h := newHarness(t)
 	id := h.createTask(t, StatusReady)
 	setReviewPolicy(t, h, id, ReviewPolicyAuto)
-	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, NewSessionID: "s"})
+	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, SessionID: "s"})
 	if err := h.svc.Submit(context.Background(), id, res.RunID, "{}", SystemActor()); err != nil {
 		t.Fatalf("Submit: %v", err)
 	}
@@ -49,7 +49,7 @@ func TestReview_HumanPolicy_TaskGoesToReviewing(t *testing.T) {
 	h := newHarness(t)
 	id := h.createTask(t, StatusReady)
 	setReviewPolicy(t, h, id, ReviewPolicyHuman)
-	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, NewSessionID: "s"})
+	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, SessionID: "s"})
 	if err := h.svc.Submit(context.Background(), id, res.RunID, `{"draft":true}`, SystemActor()); err != nil {
 		t.Fatalf("Submit: %v", err)
 	}
@@ -73,7 +73,7 @@ func TestReview_RequestChanges_WithBudget_ReturnsToReady(t *testing.T) {
 	h := newHarness(t)
 	id := h.createTask(t, StatusReady)
 	setReviewPolicy(t, h, id, ReviewPolicyHuman)
-	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, NewSessionID: "s"})
+	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, SessionID: "s"})
 	_ = h.svc.Submit(context.Background(), id, res.RunID, "{}", SystemActor())
 	task := h.getTask(t, id)
 	if err := h.svc.RequestChanges(context.Background(), task.ActiveReviewID.String, "tighten it", "please", SystemActor()); err != nil {
@@ -92,7 +92,7 @@ func TestReview_RejectReview_TaskFails(t *testing.T) {
 	h := newHarness(t)
 	id := h.createTask(t, StatusReady)
 	setReviewPolicy(t, h, id, ReviewPolicyHuman)
-	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, NewSessionID: "s"})
+	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, SessionID: "s"})
 	_ = h.svc.Submit(context.Background(), id, res.RunID, "{}", SystemActor())
 	task := h.getTask(t, id)
 	if err := h.svc.RejectReview(context.Background(), task.ActiveReviewID.String, "no", "doesn't fit", SystemActor()); err != nil {
@@ -107,7 +107,7 @@ func TestReview_EscalateFromAgent_CreatesHumanReview(t *testing.T) {
 	h := newHarness(t)
 	id := h.createTask(t, StatusReady)
 	setReviewPolicy(t, h, id, ReviewPolicyAgent)
-	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, NewSessionID: "s"})
+	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, SessionID: "s"})
 	_ = h.svc.Submit(context.Background(), id, res.RunID, "{}", SystemActor())
 	task := h.getTask(t, id)
 	agentReviewID := task.ActiveReviewID.String
@@ -140,7 +140,7 @@ func TestReview_Escalate_OnHumanReview_Rejected(t *testing.T) {
 	h := newHarness(t)
 	id := h.createTask(t, StatusReady)
 	setReviewPolicy(t, h, id, ReviewPolicyHuman)
-	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, NewSessionID: "s"})
+	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, SessionID: "s"})
 	_ = h.svc.Submit(context.Background(), id, res.RunID, "{}", SystemActor())
 	task := h.getTask(t, id)
 	err := h.svc.EscalateReview(context.Background(), task.ActiveReviewID.String, "nope", SystemActor())
@@ -153,7 +153,7 @@ func TestReview_DoubleDecide_Rejected(t *testing.T) {
 	h := newHarness(t)
 	id := h.createTask(t, StatusReady)
 	setReviewPolicy(t, h, id, ReviewPolicyHuman)
-	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, NewSessionID: "s"})
+	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, SessionID: "s"})
 	_ = h.svc.Submit(context.Background(), id, res.RunID, "{}", SystemActor())
 	task := h.getTask(t, id)
 	rev := task.ActiveReviewID.String

--- a/internal/tasks/service_facade.go
+++ b/internal/tasks/service_facade.go
@@ -21,14 +21,18 @@ import (
 // All mutating methods route through TransitionService so the
 // status-write-only-via-transition invariant holds.
 type ServiceFacade struct {
-	svc *TransitionService
-	q   *sqlc.Queries
-	db  *sql.DB
+	svc        *TransitionService
+	q          *sqlc.Queries
+	db         *sql.DB
+	newSession SessionMinter
 }
 
+// ErrInvalidTaskContext marks invalid task/goal ownership context at the write boundary.
+var ErrInvalidTaskContext = errors.New("tasks: invalid task context")
+
 // NewServiceFacade builds the facade.
-func NewServiceFacade(db *sql.DB, q *sqlc.Queries, svc *TransitionService) *ServiceFacade {
-	return &ServiceFacade{svc: svc, q: q, db: db}
+func NewServiceFacade(db *sql.DB, q *sqlc.Queries, svc *TransitionService, newSession SessionMinter) *ServiceFacade {
+	return &ServiceFacade{svc: svc, q: q, db: db, newSession: newSession}
 }
 
 // CreateTaskInput is the request body for CreateTask. Fields are optional
@@ -38,8 +42,9 @@ type CreateTaskInput struct {
 	Title            string // required
 	Description      string
 	Priority         string // routine | urgent; "" => routine
-	AgentID          string // creator agent (D12); optional
+	AgentID          string // owner/manager agent context; required unless inherited from goal
 	GoalID           string // parent goal; optional
+	ProjectID        string // project/workspace context; optional
 	ExecutorAgentID  string // explicit override (D13); optional, written as dispatch hint
 	Required         *bool  // nil => true (default); explicit false => optional task
 	MaxRetries       int64
@@ -76,6 +81,17 @@ func (f *ServiceFacade) CreateTask(ctx context.Context, in CreateTaskInput) (sql
 	if in.Context == "" {
 		in.Context = "{}"
 	}
+	resolvedAgentID, resolvedProjectID, err := f.resolveTaskContext(ctx, in)
+	if err != nil {
+		return sqlc.AgentTask{}, err
+	}
+	if f.newSession == nil {
+		return sqlc.AgentTask{}, fmt.Errorf("%w: task session minter is not configured", ErrInvalidTaskContext)
+	}
+	sessionID, err := f.newSession(ctx, in.UserID, resolvedAgentID, resolvedProjectID)
+	if err != nil {
+		return sqlc.AgentTask{}, fmt.Errorf("mint task session: %w", err)
+	}
 	id := uuid.NewString()
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 	required := int64(1)
@@ -84,13 +100,15 @@ func (f *ServiceFacade) CreateTask(ctx context.Context, in CreateTaskInput) (sql
 	}
 
 	var task sqlc.AgentTask
-	err := f.svc.WithTx(ctx, func(q *sqlc.Queries) error {
+	err = f.svc.WithTx(ctx, func(q *sqlc.Queries) error {
 		var err error
 		task, err = q.CreateAgentTask(ctx, sqlc.CreateAgentTaskParams{
 			ID:          id,
 			UserID:      in.UserID,
-			AgentID:     nullable(in.AgentID),
+			AgentID:     resolvedAgentID,
+			SessionID:   sessionID,
 			GoalID:      nullable(in.GoalID),
+			ProjectID:   nullable(resolvedProjectID),
 			Title:       in.Title,
 			Description: in.Description,
 			Status:      StatusDraft,
@@ -138,6 +156,54 @@ func (f *ServiceFacade) CreateTask(ctx context.Context, in CreateTaskInput) (sql
 	return task, nil
 }
 
+func (f *ServiceFacade) resolveTaskContext(ctx context.Context, in CreateTaskInput) (string, string, error) {
+	agentID := in.AgentID
+	projectID := in.ProjectID
+	if in.GoalID != "" {
+		goal, err := f.q.GetAgentGoal(ctx, in.GoalID)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return "", "", ErrGoalNotFound
+			}
+			return "", "", err
+		}
+		if goal.UserID != in.UserID {
+			return "", "", ErrGoalNotFound
+		}
+		if goal.AgentID == "" {
+			return "", "", fmt.Errorf("%w: goal has no agent_id", ErrInvalidTaskContext)
+		}
+		if agentID == "" {
+			agentID = goal.AgentID
+		} else if agentID != goal.AgentID {
+			return "", "", fmt.Errorf("%w: goal_id must belong to the same agent_id", ErrInvalidTaskContext)
+		}
+		if goal.ProjectID.Valid {
+			if projectID == "" {
+				projectID = goal.ProjectID.String
+			} else if projectID != goal.ProjectID.String {
+				return "", "", fmt.Errorf("%w: goal_id must belong to the same project_id", ErrInvalidTaskContext)
+			}
+		}
+	}
+	if agentID == "" {
+		return "", "", fmt.Errorf("%w: agent_id is required", ErrInvalidTaskContext)
+	}
+	if projectID != "" {
+		project, err := f.q.GetProject(ctx, sqlc.GetProjectParams{ID: projectID, UserID: in.UserID})
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return "", "", fmt.Errorf("%w: project_id not found", ErrInvalidTaskContext)
+			}
+			return "", "", err
+		}
+		if project.AgentID != agentID {
+			return "", "", fmt.Errorf("%w: project_id must belong to the same agent_id", ErrInvalidTaskContext)
+		}
+	}
+	return agentID, projectID, nil
+}
+
 // GetTask returns a task by id.
 func (f *ServiceFacade) GetTask(ctx context.Context, taskID string) (sqlc.AgentTask, error) {
 	t, err := f.q.GetAgentTask(ctx, taskID)
@@ -151,17 +217,18 @@ func (f *ServiceFacade) GetTask(ctx context.Context, taskID string) (sqlc.AgentT
 }
 
 // ListTasksByUser returns paginated tasks owned by the given user, optionally
-// filtered by agent and status. Empty filter strings match all rows.
-func (f *ServiceFacade) ListTasksByUser(ctx context.Context, userID, agentID, status string, limit, offset int64) ([]sqlc.AgentTask, error) {
+// filtered by agent, project, and status. Empty filter strings match all rows.
+func (f *ServiceFacade) ListTasksByUser(ctx context.Context, userID, agentID, projectID, status string, limit, offset int64) ([]sqlc.AgentTask, error) {
 	if limit <= 0 {
 		limit = 50
 	}
 	return f.q.ListAgentTasksByUser(ctx, sqlc.ListAgentTasksByUserParams{
-		UserID:  userID,
-		AgentID: nilIfEmpty(agentID),
-		Status:  nilIfEmpty(status),
-		Limit:   limit,
-		Offset:  offset,
+		UserID:    userID,
+		AgentID:   nilIfEmpty(agentID),
+		ProjectID: nilIfEmpty(projectID),
+		Status:    nilIfEmpty(status),
+		Limit:     limit,
+		Offset:    offset,
 	})
 }
 
@@ -309,6 +376,7 @@ func (f *ServiceFacade) GetReview(ctx context.Context, reviewID string) (sqlc.Ag
 type CreateGoalInput struct {
 	UserID       string
 	AgentID      string
+	ProjectID    string
 	Title        string
 	Description  string
 	Priority     string
@@ -316,12 +384,14 @@ type CreateGoalInput struct {
 	Context      string
 }
 
-// CreateGoal inserts an agent_goal row in 'draft'. The dispatcher's planner
-// scan will pick it up next tick when status=draft and an executor is
-// resolvable.
+// CreateGoal inserts an agent_goal row in 'draft'. Goal planning/synthesis is
+// not dispatched in this release; callers create child tasks explicitly.
 func (f *ServiceFacade) CreateGoal(ctx context.Context, in CreateGoalInput) (sqlc.AgentGoal, error) {
 	if in.UserID == "" || in.Title == "" {
 		return sqlc.AgentGoal{}, fmt.Errorf("CreateGoal: user_id and title are required")
+	}
+	if in.AgentID == "" {
+		return sqlc.AgentGoal{}, fmt.Errorf("%w: agent_id is required", ErrInvalidTaskContext)
 	}
 	priority := in.Priority
 	if priority == "" {
@@ -345,11 +415,24 @@ func (f *ServiceFacade) CreateGoal(ctx context.Context, in CreateGoalInput) (sql
 	if in.Context == "" {
 		in.Context = "{}"
 	}
+	if in.ProjectID != "" {
+		project, err := f.q.GetProject(ctx, sqlc.GetProjectParams{ID: in.ProjectID, UserID: in.UserID})
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return sqlc.AgentGoal{}, fmt.Errorf("%w: project_id not found", ErrInvalidTaskContext)
+			}
+			return sqlc.AgentGoal{}, err
+		}
+		if project.AgentID != in.AgentID {
+			return sqlc.AgentGoal{}, fmt.Errorf("%w: project_id must belong to the same agent_id", ErrInvalidTaskContext)
+		}
+	}
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 	return f.q.CreateAgentGoal(ctx, sqlc.CreateAgentGoalParams{
 		ID:           uuid.NewString(),
 		UserID:       in.UserID,
-		AgentID:      nullable(in.AgentID),
+		AgentID:      in.AgentID,
+		ProjectID:    nullable(in.ProjectID),
 		Title:        in.Title,
 		Description:  in.Description,
 		Status:       GoalStatusDraft,

--- a/internal/tasks/transition.go
+++ b/internal/tasks/transition.go
@@ -166,8 +166,7 @@ func (s *TransitionService) activateInTx(ctx context.Context, q *sqlc.Queries, t
 }
 
 // ClaimResult describes the run that was minted by Claim. SessionID is the
-// session the worker should run in; on a first claim the dispatcher minted a
-// fresh one, on a retry it's the task's persisted session.
+// task's durable worker session.
 type ClaimResult struct {
 	RunID     string
 	SessionID string
@@ -180,7 +179,7 @@ type ClaimParams struct {
 	ExecutorAgentID string
 	WorkerID        string
 	LeaseDuration   time.Duration // 0 => no lease
-	NewSessionID    string        // used when task.session_id is null
+	SessionID       string        // ignored; task.session_id is the source of truth
 	Actor           Actor
 	// HintID, when set, identifies the live dispatch hint the dispatcher used
 	// to resolve ExecutorAgentID. Claim consumes that exact hint inside its
@@ -194,14 +193,10 @@ type ClaimParams struct {
 // Returns ErrInvalidTransition if the row's status changed underfoot — the
 // caller (dispatcher) should re-scan candidates and try again.
 //
-// Session-id rule (D12): if task.session_id is non-null, reuse it; otherwise
-// adopt p.NewSessionID and persist it on the task row.
+// Session-id rule: task.session_id is required at creation time and reused for every run.
 func (s *TransitionService) Claim(ctx context.Context, p ClaimParams) (ClaimResult, error) {
 	if p.TaskID == "" {
 		return ClaimResult{}, fmt.Errorf("Claim: task id required")
-	}
-	if p.NewSessionID == "" {
-		return ClaimResult{}, fmt.Errorf("Claim: new session id required")
 	}
 	var out ClaimResult
 	err := s.withTx(ctx, func(q *sqlc.Queries) error {
@@ -228,17 +223,16 @@ func (s *TransitionService) Claim(ctx context.Context, p ClaimParams) (ClaimResu
 		if p.LeaseDuration > 0 {
 			leaseExpires = sql.NullString{String: s.clock().Add(p.LeaseDuration).UTC().Format(time.RFC3339Nano), Valid: true}
 		}
-		// Choose the session per D12 before inserting the run.
-		sessionID := p.NewSessionID
-		if task.SessionID.Valid && task.SessionID.String != "" {
-			sessionID = task.SessionID.String
+		if task.SessionID == "" {
+			return fmt.Errorf("Claim: task has no worker session")
 		}
+		sessionID := task.SessionID
 		_, err = q.CreateAgentTaskRun(ctx, sqlc.CreateAgentTaskRunParams{
 			ID:              runID,
 			TaskID:          nullable(p.TaskID),
 			GoalID:          sql.NullString{},
 			UserID:          task.UserID,
-			AgentID:         task.AgentID,
+			AgentID:         nullable(task.AgentID),
 			ExecutorAgentID: nullable(p.ExecutorAgentID),
 			Kind:            RunKindWorker,
 			AttemptNo:       nextAttempt,
@@ -256,11 +250,9 @@ func (s *TransitionService) Claim(ctx context.Context, p ClaimParams) (ClaimResu
 		if err != nil {
 			return fmt.Errorf("create run: %w", err)
 		}
-		// Atomic claim: ready + no active run -> running, set active_run_id and
-		// persist session if first time.
+		// Atomic claim: ready + no active run -> running, set active_run_id.
 		n, err := q.ClaimAgentTask(ctx, sqlc.ClaimAgentTaskParams{
 			ActiveRunID: nullable(runID),
-			SessionID:   nullable(sessionID),
 			UpdatedAt:   now,
 			ID:          p.TaskID,
 		})

--- a/internal/tasks/transition_test.go
+++ b/internal/tasks/transition_test.go
@@ -54,9 +54,10 @@ func newHarness(t *testing.T) *testHarness {
 func (h *testHarness) createTask(t *testing.T, status string) string {
 	t.Helper()
 	id := uuid.NewString()
+	sessionID := h.createTaskSession(t, "task-"+id[:8])
 	now := time.Now().Format(time.RFC3339Nano)
 	if _, err := h.q.CreateAgentTask(context.Background(), sqlc.CreateAgentTaskParams{
-		ID: id, UserID: h.userID,
+		ID: id, UserID: h.userID, AgentID: h.agentID, SessionID: sessionID,
 		Title: "t-" + id[:8], Status: status, Priority: "routine",
 		Required: 1, RetryCount: 0, MaxRetries: 3,
 		Context: "{}", Output: "{}",
@@ -65,6 +66,23 @@ func (h *testHarness) createTask(t *testing.T, status string) string {
 		t.Fatalf("create task: %v", err)
 	}
 	return id
+}
+
+func (h *testHarness) createTaskSession(t *testing.T, title string) string {
+	t.Helper()
+	sessionID := "task-" + uuid.NewString()
+	now := time.Now().UTC().Format("2006-01-02 15:04:05")
+	if _, err := h.db.ExecContext(context.Background(), `
+		INSERT INTO ctx_conversation (id, session_id, title, channel, kind, agent_id, user_id, last_active, created_at, updated_at)
+		VALUES (?, ?, ?, 'task', 'task', ?, ?, ?, ?, ?)`,
+		uuid.NewString(), sessionID, title, h.agentID, h.userID, now, now, now); err != nil {
+		t.Fatalf("create task session: %v", err)
+	}
+	return sessionID
+}
+
+func testSessionMinter(ctx context.Context, userID, agentID, projectID string) (string, error) {
+	return "task-" + uuid.NewString(), nil
 }
 
 func (h *testHarness) getTask(t *testing.T, id string) sqlc.AgentTask {
@@ -103,15 +121,16 @@ func TestActivate_FromReady_ReturnsInvalidTransition(t *testing.T) {
 func TestClaim_ReadyToRunning_InsertsRun_SetsActiveRun(t *testing.T) {
 	h := newHarness(t)
 	id := h.createTask(t, StatusReady)
+	before := h.getTask(t, id)
 	res, err := h.svc.Claim(context.Background(), ClaimParams{
-		TaskID: id, ExecutorAgentID: "", NewSessionID: "sess-1",
+		TaskID: id, ExecutorAgentID: "", SessionID: "sess-1",
 		WorkerID: "w-1", LeaseDuration: 30 * time.Second,
 		Actor: SystemActor(),
 	})
 	if err != nil {
 		t.Fatalf("Claim: %v", err)
 	}
-	if res.RunID == "" || res.SessionID != "sess-1" {
+	if res.RunID == "" || res.SessionID != before.SessionID {
 		t.Fatalf("ClaimResult: %+v", res)
 	}
 	task := h.getTask(t, id)
@@ -121,16 +140,17 @@ func TestClaim_ReadyToRunning_InsertsRun_SetsActiveRun(t *testing.T) {
 	if !task.ActiveRunID.Valid || task.ActiveRunID.String != res.RunID {
 		t.Errorf("active_run_id=%v want %s", task.ActiveRunID, res.RunID)
 	}
-	if !task.SessionID.Valid || task.SessionID.String != "sess-1" {
-		t.Errorf("session_id=%v want sess-1 (persisted on first run)", task.SessionID)
+	if task.SessionID != before.SessionID {
+		t.Errorf("session_id=%v want %s", task.SessionID, before.SessionID)
 	}
 }
 
 func TestClaim_SecondClaimReusesSession(t *testing.T) {
 	h := newHarness(t)
 	id := h.createTask(t, StatusReady)
+	before := h.getTask(t, id)
 	if _, err := h.svc.Claim(context.Background(), ClaimParams{
-		TaskID: id, NewSessionID: "sess-1",
+		TaskID: id, SessionID: "sess-1",
 	}); err != nil {
 		t.Fatalf("first claim: %v", err)
 	}
@@ -143,12 +163,12 @@ func TestClaim_SecondClaimReusesSession(t *testing.T) {
 		t.Fatalf("Fail: %v", err)
 	}
 	res, err := h.svc.Claim(context.Background(), ClaimParams{
-		TaskID: id, NewSessionID: "sess-2", // ignored because task already has session
+		TaskID: id, SessionID: "sess-2", // ignored because task already has session
 	})
 	if err != nil {
 		t.Fatalf("second claim: %v", err)
 	}
-	if res.SessionID != "sess-1" {
+	if res.SessionID != before.SessionID {
 		t.Errorf("retry should reuse session, got %q", res.SessionID)
 	}
 }
@@ -156,7 +176,7 @@ func TestClaim_SecondClaimReusesSession(t *testing.T) {
 func TestClaim_FromDraft_Rejected(t *testing.T) {
 	h := newHarness(t)
 	id := h.createTask(t, StatusDraft)
-	_, err := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, NewSessionID: "s"})
+	_, err := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, SessionID: "s"})
 	if !errors.Is(err, ErrInvalidTransition) {
 		t.Fatalf("want ErrInvalidTransition, got %v", err)
 	}
@@ -165,7 +185,7 @@ func TestClaim_FromDraft_Rejected(t *testing.T) {
 func TestSubmit_RunningToDone_FinalizesRun_ClearsActiveRun(t *testing.T) {
 	h := newHarness(t)
 	id := h.createTask(t, StatusReady)
-	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, NewSessionID: "s"})
+	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, SessionID: "s"})
 	if err := h.svc.Submit(context.Background(), id, res.RunID, `{"ok":true}`, SystemActor()); err != nil {
 		t.Fatalf("Submit: %v", err)
 	}
@@ -187,7 +207,7 @@ func TestSubmit_RunningToDone_FinalizesRun_ClearsActiveRun(t *testing.T) {
 func TestBlock_RunningToBlocked_CreatesBlocker(t *testing.T) {
 	h := newHarness(t)
 	id := h.createTask(t, StatusReady)
-	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, NewSessionID: "s"})
+	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, SessionID: "s"})
 	err := h.svc.Block(context.Background(), BlockParams{
 		TaskID: id, Kind: BlockerKindUserInput, Question: "need approval",
 		RunID: res.RunID, Actor: SystemActor(),
@@ -214,7 +234,7 @@ func TestBlock_RunningToBlocked_CreatesBlocker(t *testing.T) {
 func TestBlock_SecondBlockMergesIntoExistingDetail(t *testing.T) {
 	h := newHarness(t)
 	id := h.createTask(t, StatusReady)
-	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, NewSessionID: "s"})
+	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, SessionID: "s"})
 	if err := h.svc.Block(context.Background(), BlockParams{
 		TaskID: id, Kind: BlockerKindUserInput, Question: "Q1", RunID: res.RunID,
 	}); err != nil {
@@ -241,7 +261,7 @@ func TestBlock_SecondBlockMergesIntoExistingDetail(t *testing.T) {
 func TestResolveBlocker_BlockedToReady(t *testing.T) {
 	h := newHarness(t)
 	id := h.createTask(t, StatusReady)
-	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, NewSessionID: "s"})
+	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, SessionID: "s"})
 	_ = h.svc.Block(context.Background(), BlockParams{TaskID: id, Kind: BlockerKindUserInput, RunID: res.RunID})
 	bl, _ := h.q.GetOpenBlockerForTask(context.Background(), id)
 	if err := h.svc.ResolveBlocker(context.Background(), bl.ID, `{"answer":"ok"}`, SystemActor()); err != nil {
@@ -301,7 +321,7 @@ func TestWaiveDep_UnblocksTask(t *testing.T) {
 func TestFail_RetryableReturnsToReady_IncrementsRetry(t *testing.T) {
 	h := newHarness(t)
 	id := h.createTask(t, StatusReady)
-	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, NewSessionID: "s"})
+	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, SessionID: "s"})
 	if err := h.svc.Fail(context.Background(), FailParams{
 		TaskID: id, RunID: res.RunID, Reason: "transient", Retryable: true,
 	}); err != nil {
@@ -324,12 +344,12 @@ func TestFail_BudgetExhausted_GoesTerminal(t *testing.T) {
 		t.Fatalf("set max_retries: %v", err)
 	}
 	// First fail: should retry.
-	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, NewSessionID: "s"})
+	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, SessionID: "s"})
 	if err := h.svc.Fail(context.Background(), FailParams{TaskID: id, RunID: res.RunID, Retryable: true}); err != nil {
 		t.Fatalf("first fail: %v", err)
 	}
 	// Second fail: budget exhausted → failed.
-	res, _ = h.svc.Claim(context.Background(), ClaimParams{TaskID: id, NewSessionID: "s"})
+	res, _ = h.svc.Claim(context.Background(), ClaimParams{TaskID: id, SessionID: "s"})
 	if err := h.svc.Fail(context.Background(), FailParams{TaskID: id, RunID: res.RunID, Retryable: true}); err != nil {
 		t.Fatalf("second fail: %v", err)
 	}
@@ -347,7 +367,7 @@ func TestRunIdentityGuard_StaleWorkerCannotTransitionRetry(t *testing.T) {
 	id := h.createTask(t, StatusReady)
 
 	// Run 1 claims the task, then fails retryably -> task back to ready.
-	r1, err := h.svc.Claim(ctx, ClaimParams{TaskID: id, NewSessionID: "s"})
+	r1, err := h.svc.Claim(ctx, ClaimParams{TaskID: id, SessionID: "s"})
 	if err != nil {
 		t.Fatalf("claim r1: %v", err)
 	}
@@ -356,7 +376,7 @@ func TestRunIdentityGuard_StaleWorkerCannotTransitionRetry(t *testing.T) {
 	}
 
 	// Run 2 re-claims the task: it is now the live run.
-	r2, err := h.svc.Claim(ctx, ClaimParams{TaskID: id, NewSessionID: "s"})
+	r2, err := h.svc.Claim(ctx, ClaimParams{TaskID: id, SessionID: "s"})
 	if err != nil {
 		t.Fatalf("claim r2: %v", err)
 	}
@@ -406,7 +426,7 @@ func TestCancel_FromAnyNonTerminal_Works(t *testing.T) {
 func TestCancel_FromRunning_CancelsActiveRun(t *testing.T) {
 	h := newHarness(t)
 	id := h.createTask(t, StatusReady)
-	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, NewSessionID: "s"})
+	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, SessionID: "s"})
 	if err := h.svc.Cancel(context.Background(), id, "user cancelled", SystemActor()); err != nil {
 		t.Fatalf("Cancel: %v", err)
 	}
@@ -491,7 +511,7 @@ func TestResolveBlocker_NotFound(t *testing.T) {
 func TestCancel_FromTerminal_Rejected(t *testing.T) {
 	h := newHarness(t)
 	id := h.createTask(t, StatusReady)
-	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, NewSessionID: "s"})
+	res, _ := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, SessionID: "s"})
 	_ = h.svc.Submit(context.Background(), id, res.RunID, "{}", SystemActor())
 	// Now done → cancel rejected.
 	err := h.svc.Cancel(context.Background(), id, "after-the-fact", SystemActor())
@@ -570,7 +590,7 @@ func TestAddDep_ThreeNodeTransitiveCycleRejected(t *testing.T) {
 func TestInvariant_RunningHasActiveRun(t *testing.T) {
 	h := newHarness(t)
 	id := h.createTask(t, StatusReady)
-	if _, err := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, NewSessionID: "s"}); err != nil {
+	if _, err := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, SessionID: "s"}); err != nil {
 		t.Fatalf("Claim: %v", err)
 	}
 	task := h.getTask(t, id)
@@ -601,11 +621,11 @@ func TestInvariant_BlockedHasOpenBlocker(t *testing.T) {
 func TestInvariant_AtMostOneActiveWorkerRun(t *testing.T) {
 	h := newHarness(t)
 	id := h.createTask(t, StatusReady)
-	if _, err := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, NewSessionID: "s"}); err != nil {
+	if _, err := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, SessionID: "s"}); err != nil {
 		t.Fatalf("first claim: %v", err)
 	}
 	// Second claim should fail — task is running.
-	_, err := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, NewSessionID: "s2"})
+	_, err := h.svc.Claim(context.Background(), ClaimParams{TaskID: id, SessionID: "s2"})
 	if !errors.Is(err, ErrInvalidTransition) {
 		t.Fatalf("want ErrInvalidTransition on double claim, got %v", err)
 	}

--- a/internal/tasks/worker_test.go
+++ b/internal/tasks/worker_test.go
@@ -13,7 +13,7 @@ func claimedHarness(t *testing.T, exec Executor) (*testHarness, string, string, 
 	h := newHarness(t)
 	taskID := h.createTask(t, StatusReady)
 	res, err := h.svc.Claim(context.Background(), ClaimParams{
-		TaskID: taskID, NewSessionID: "sess", WorkerID: "w-1",
+		TaskID: taskID, SessionID: "sess", WorkerID: "w-1",
 		LeaseDuration: 60 * time.Second,
 	})
 	if err != nil {

--- a/pkg/db/sqlc/agent_goal.sql.go
+++ b/pkg/db/sqlc/agent_goal.sql.go
@@ -13,17 +13,18 @@ import (
 const createAgentGoal = `-- name: CreateAgentGoal :one
 
 INSERT INTO agent_goal (
-    id, user_id, agent_id, title, description, status, priority,
+    id, user_id, agent_id, project_id, title, description, status, priority,
     review_policy, context, output, created_at, updated_at
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-RETURNING id, user_id, agent_id, title, description, status, priority, review_policy, active_review_id, context, output, created_at, updated_at, completed_at, cancelled_at
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+RETURNING id, user_id, agent_id, project_id, title, description, status, priority, review_policy, active_review_id, context, output, created_at, updated_at, completed_at, cancelled_at
 `
 
 type CreateAgentGoalParams struct {
 	ID           string         `json:"id"`
 	UserID       string         `json:"user_id"`
-	AgentID      sql.NullString `json:"agent_id"`
+	AgentID      string         `json:"agent_id"`
+	ProjectID    sql.NullString `json:"project_id"`
 	Title        string         `json:"title"`
 	Description  string         `json:"description"`
 	Status       string         `json:"status"`
@@ -41,6 +42,7 @@ func (q *Queries) CreateAgentGoal(ctx context.Context, arg CreateAgentGoalParams
 		arg.ID,
 		arg.UserID,
 		arg.AgentID,
+		arg.ProjectID,
 		arg.Title,
 		arg.Description,
 		arg.Status,
@@ -56,6 +58,7 @@ func (q *Queries) CreateAgentGoal(ctx context.Context, arg CreateAgentGoalParams
 		&i.ID,
 		&i.UserID,
 		&i.AgentID,
+		&i.ProjectID,
 		&i.Title,
 		&i.Description,
 		&i.Status,
@@ -73,7 +76,7 @@ func (q *Queries) CreateAgentGoal(ctx context.Context, arg CreateAgentGoalParams
 }
 
 const getAgentGoal = `-- name: GetAgentGoal :one
-SELECT id, user_id, agent_id, title, description, status, priority, review_policy, active_review_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_goal WHERE id = ?
+SELECT id, user_id, agent_id, project_id, title, description, status, priority, review_policy, active_review_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_goal WHERE id = ?
 `
 
 func (q *Queries) GetAgentGoal(ctx context.Context, id string) (AgentGoal, error) {
@@ -83,6 +86,7 @@ func (q *Queries) GetAgentGoal(ctx context.Context, id string) (AgentGoal, error
 		&i.ID,
 		&i.UserID,
 		&i.AgentID,
+		&i.ProjectID,
 		&i.Title,
 		&i.Description,
 		&i.Status,
@@ -136,7 +140,7 @@ func (q *Queries) GoalChildCounts(ctx context.Context, goalID sql.NullString) (G
 }
 
 const listAgentGoals = `-- name: ListAgentGoals :many
-SELECT id, user_id, agent_id, title, description, status, priority, review_policy, active_review_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_goal ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?
+SELECT id, user_id, agent_id, project_id, title, description, status, priority, review_policy, active_review_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_goal ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?
 `
 
 type ListAgentGoalsParams struct {
@@ -157,6 +161,7 @@ func (q *Queries) ListAgentGoals(ctx context.Context, arg ListAgentGoalsParams) 
 			&i.ID,
 			&i.UserID,
 			&i.AgentID,
+			&i.ProjectID,
 			&i.Title,
 			&i.Description,
 			&i.Status,
@@ -184,7 +189,7 @@ func (q *Queries) ListAgentGoals(ctx context.Context, arg ListAgentGoalsParams) 
 }
 
 const listAgentGoalsByUser = `-- name: ListAgentGoalsByUser :many
-SELECT id, user_id, agent_id, title, description, status, priority, review_policy, active_review_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_goal WHERE user_id = ? ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?
+SELECT id, user_id, agent_id, project_id, title, description, status, priority, review_policy, active_review_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_goal WHERE user_id = ? ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?
 `
 
 type ListAgentGoalsByUserParams struct {
@@ -206,6 +211,7 @@ func (q *Queries) ListAgentGoalsByUser(ctx context.Context, arg ListAgentGoalsBy
 			&i.ID,
 			&i.UserID,
 			&i.AgentID,
+			&i.ProjectID,
 			&i.Title,
 			&i.Description,
 			&i.Status,
@@ -233,7 +239,7 @@ func (q *Queries) ListAgentGoalsByUser(ctx context.Context, arg ListAgentGoalsBy
 }
 
 const listChildrenByGoal = `-- name: ListChildrenByGoal :many
-SELECT id, user_id, agent_id, goal_id, title, description, status, priority, review_policy, active_review_id, required, retry_count, max_retries, not_before, deadline_at, session_id, active_run_id, active_blocker_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_task WHERE goal_id = ? ORDER BY created_at ASC
+SELECT id, user_id, agent_id, session_id, goal_id, project_id, title, description, status, priority, review_policy, active_review_id, required, retry_count, max_retries, not_before, deadline_at, active_run_id, active_blocker_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_task WHERE goal_id = ? ORDER BY created_at ASC
 `
 
 func (q *Queries) ListChildrenByGoal(ctx context.Context, goalID sql.NullString) ([]AgentTask, error) {
@@ -249,7 +255,9 @@ func (q *Queries) ListChildrenByGoal(ctx context.Context, goalID sql.NullString)
 			&i.ID,
 			&i.UserID,
 			&i.AgentID,
+			&i.SessionID,
 			&i.GoalID,
+			&i.ProjectID,
 			&i.Title,
 			&i.Description,
 			&i.Status,
@@ -261,7 +269,6 @@ func (q *Queries) ListChildrenByGoal(ctx context.Context, goalID sql.NullString)
 			&i.MaxRetries,
 			&i.NotBefore,
 			&i.DeadlineAt,
-			&i.SessionID,
 			&i.ActiveRunID,
 			&i.ActiveBlockerID,
 			&i.Context,
@@ -285,7 +292,7 @@ func (q *Queries) ListChildrenByGoal(ctx context.Context, goalID sql.NullString)
 }
 
 const listChildrenByGoalPaged = `-- name: ListChildrenByGoalPaged :many
-SELECT id, user_id, agent_id, goal_id, title, description, status, priority, review_policy, active_review_id, required, retry_count, max_retries, not_before, deadline_at, session_id, active_run_id, active_blocker_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_task WHERE goal_id = ? ORDER BY created_at ASC, id ASC LIMIT ? OFFSET ?
+SELECT id, user_id, agent_id, session_id, goal_id, project_id, title, description, status, priority, review_policy, active_review_id, required, retry_count, max_retries, not_before, deadline_at, active_run_id, active_blocker_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_task WHERE goal_id = ? ORDER BY created_at ASC, id ASC LIMIT ? OFFSET ?
 `
 
 type ListChildrenByGoalPagedParams struct {
@@ -307,7 +314,9 @@ func (q *Queries) ListChildrenByGoalPaged(ctx context.Context, arg ListChildrenB
 			&i.ID,
 			&i.UserID,
 			&i.AgentID,
+			&i.SessionID,
 			&i.GoalID,
+			&i.ProjectID,
 			&i.Title,
 			&i.Description,
 			&i.Status,
@@ -319,7 +328,6 @@ func (q *Queries) ListChildrenByGoalPaged(ctx context.Context, arg ListChildrenB
 			&i.MaxRetries,
 			&i.NotBefore,
 			&i.DeadlineAt,
-			&i.SessionID,
 			&i.ActiveRunID,
 			&i.ActiveBlockerID,
 			&i.Context,
@@ -343,7 +351,7 @@ func (q *Queries) ListChildrenByGoalPaged(ctx context.Context, arg ListChildrenB
 }
 
 const listGoalPlanningCandidates = `-- name: ListGoalPlanningCandidates :many
-SELECT id, user_id, agent_id, title, description, status, priority, review_policy, active_review_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_goal
+SELECT id, user_id, agent_id, project_id, title, description, status, priority, review_policy, active_review_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_goal
 WHERE status = 'draft'
 ORDER BY priority DESC, created_at ASC
 LIMIT ?
@@ -362,6 +370,7 @@ func (q *Queries) ListGoalPlanningCandidates(ctx context.Context, limit int64) (
 			&i.ID,
 			&i.UserID,
 			&i.AgentID,
+			&i.ProjectID,
 			&i.Title,
 			&i.Description,
 			&i.Status,
@@ -389,7 +398,7 @@ func (q *Queries) ListGoalPlanningCandidates(ctx context.Context, limit int64) (
 }
 
 const listGoalSynthesisCandidates = `-- name: ListGoalSynthesisCandidates :many
-SELECT id, user_id, agent_id, title, description, status, priority, review_policy, active_review_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_goal
+SELECT id, user_id, agent_id, project_id, title, description, status, priority, review_policy, active_review_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_goal
 WHERE status = 'running' AND review_policy != 'none'
 ORDER BY priority DESC, updated_at ASC
 LIMIT ?
@@ -408,6 +417,7 @@ func (q *Queries) ListGoalSynthesisCandidates(ctx context.Context, limit int64) 
 			&i.ID,
 			&i.UserID,
 			&i.AgentID,
+			&i.ProjectID,
 			&i.Title,
 			&i.Description,
 			&i.Status,

--- a/pkg/db/sqlc/agent_task.sql.go
+++ b/pkg/db/sqlc/agent_task.sql.go
@@ -14,7 +14,6 @@ const claimAgentTask = `-- name: ClaimAgentTask :execrows
 UPDATE agent_task
 SET status = 'running',
     active_run_id = ?,
-    session_id = COALESCE(session_id, ?),
     updated_at = ?
 WHERE id = ?
   AND status = 'ready'
@@ -23,39 +22,17 @@ WHERE id = ?
 
 type ClaimAgentTaskParams struct {
 	ActiveRunID sql.NullString `json:"active_run_id"`
-	SessionID   sql.NullString `json:"session_id"`
 	UpdatedAt   string         `json:"updated_at"`
 	ID          string         `json:"id"`
 }
 
-// Atomic claim: ready + no active run  running, set active_run_id and session_id.
+// Atomic claim: ready + no active run -> running. session_id is required at task creation.
 func (q *Queries) ClaimAgentTask(ctx context.Context, arg ClaimAgentTaskParams) (int64, error) {
-	result, err := q.db.ExecContext(ctx, claimAgentTask,
-		arg.ActiveRunID,
-		arg.SessionID,
-		arg.UpdatedAt,
-		arg.ID,
-	)
+	result, err := q.db.ExecContext(ctx, claimAgentTask, arg.ActiveRunID, arg.UpdatedAt, arg.ID)
 	if err != nil {
 		return 0, err
 	}
 	return result.RowsAffected()
-}
-
-const clearAgentTaskSession = `-- name: ClearAgentTaskSession :exec
-UPDATE agent_task
-SET session_id = NULL, updated_at = ?
-WHERE id = ?
-`
-
-type ClearAgentTaskSessionParams struct {
-	UpdatedAt string `json:"updated_at"`
-	ID        string `json:"id"`
-}
-
-func (q *Queries) ClearAgentTaskSession(ctx context.Context, arg ClearAgentTaskSessionParams) error {
-	_, err := q.db.ExecContext(ctx, clearAgentTaskSession, arg.UpdatedAt, arg.ID)
-	return err
 }
 
 const countRunningAgentTasks = `-- name: CountRunningAgentTasks :one
@@ -72,19 +49,21 @@ func (q *Queries) CountRunningAgentTasks(ctx context.Context) (int64, error) {
 const createAgentTask = `-- name: CreateAgentTask :one
 
 INSERT INTO agent_task (
-    id, user_id, agent_id, goal_id, title, description, status, priority,
+    id, user_id, agent_id, session_id, goal_id, project_id, title, description, status, priority,
     required, retry_count, max_retries, not_before, deadline_at,
-    session_id, context, output, created_at, updated_at
+    context, output, created_at, updated_at
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-RETURNING id, user_id, agent_id, goal_id, title, description, status, priority, review_policy, active_review_id, required, retry_count, max_retries, not_before, deadline_at, session_id, active_run_id, active_blocker_id, context, output, created_at, updated_at, completed_at, cancelled_at
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+RETURNING id, user_id, agent_id, session_id, goal_id, project_id, title, description, status, priority, review_policy, active_review_id, required, retry_count, max_retries, not_before, deadline_at, active_run_id, active_blocker_id, context, output, created_at, updated_at, completed_at, cancelled_at
 `
 
 type CreateAgentTaskParams struct {
 	ID          string         `json:"id"`
 	UserID      string         `json:"user_id"`
-	AgentID     sql.NullString `json:"agent_id"`
+	AgentID     string         `json:"agent_id"`
+	SessionID   string         `json:"session_id"`
 	GoalID      sql.NullString `json:"goal_id"`
+	ProjectID   sql.NullString `json:"project_id"`
 	Title       string         `json:"title"`
 	Description string         `json:"description"`
 	Status      string         `json:"status"`
@@ -94,7 +73,6 @@ type CreateAgentTaskParams struct {
 	MaxRetries  int64          `json:"max_retries"`
 	NotBefore   sql.NullString `json:"not_before"`
 	DeadlineAt  sql.NullString `json:"deadline_at"`
-	SessionID   sql.NullString `json:"session_id"`
 	Context     string         `json:"context"`
 	Output      string         `json:"output"`
 	CreatedAt   string         `json:"created_at"`
@@ -110,7 +88,9 @@ func (q *Queries) CreateAgentTask(ctx context.Context, arg CreateAgentTaskParams
 		arg.ID,
 		arg.UserID,
 		arg.AgentID,
+		arg.SessionID,
 		arg.GoalID,
+		arg.ProjectID,
 		arg.Title,
 		arg.Description,
 		arg.Status,
@@ -120,7 +100,6 @@ func (q *Queries) CreateAgentTask(ctx context.Context, arg CreateAgentTaskParams
 		arg.MaxRetries,
 		arg.NotBefore,
 		arg.DeadlineAt,
-		arg.SessionID,
 		arg.Context,
 		arg.Output,
 		arg.CreatedAt,
@@ -131,7 +110,9 @@ func (q *Queries) CreateAgentTask(ctx context.Context, arg CreateAgentTaskParams
 		&i.ID,
 		&i.UserID,
 		&i.AgentID,
+		&i.SessionID,
 		&i.GoalID,
+		&i.ProjectID,
 		&i.Title,
 		&i.Description,
 		&i.Status,
@@ -143,7 +124,6 @@ func (q *Queries) CreateAgentTask(ctx context.Context, arg CreateAgentTaskParams
 		&i.MaxRetries,
 		&i.NotBefore,
 		&i.DeadlineAt,
-		&i.SessionID,
 		&i.ActiveRunID,
 		&i.ActiveBlockerID,
 		&i.Context,
@@ -166,7 +146,7 @@ func (q *Queries) DeleteAgentTask(ctx context.Context, id string) error {
 }
 
 const getAgentTask = `-- name: GetAgentTask :one
-SELECT id, user_id, agent_id, goal_id, title, description, status, priority, review_policy, active_review_id, required, retry_count, max_retries, not_before, deadline_at, session_id, active_run_id, active_blocker_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_task WHERE id = ?
+SELECT id, user_id, agent_id, session_id, goal_id, project_id, title, description, status, priority, review_policy, active_review_id, required, retry_count, max_retries, not_before, deadline_at, active_run_id, active_blocker_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_task WHERE id = ?
 `
 
 func (q *Queries) GetAgentTask(ctx context.Context, id string) (AgentTask, error) {
@@ -176,7 +156,9 @@ func (q *Queries) GetAgentTask(ctx context.Context, id string) (AgentTask, error
 		&i.ID,
 		&i.UserID,
 		&i.AgentID,
+		&i.SessionID,
 		&i.GoalID,
+		&i.ProjectID,
 		&i.Title,
 		&i.Description,
 		&i.Status,
@@ -188,7 +170,6 @@ func (q *Queries) GetAgentTask(ctx context.Context, id string) (AgentTask, error
 		&i.MaxRetries,
 		&i.NotBefore,
 		&i.DeadlineAt,
-		&i.SessionID,
 		&i.ActiveRunID,
 		&i.ActiveBlockerID,
 		&i.Context,
@@ -218,7 +199,7 @@ func (q *Queries) IncrementAgentTaskRetry(ctx context.Context, arg IncrementAgen
 }
 
 const listAgentTasks = `-- name: ListAgentTasks :many
-SELECT id, user_id, agent_id, goal_id, title, description, status, priority, review_policy, active_review_id, required, retry_count, max_retries, not_before, deadline_at, session_id, active_run_id, active_blocker_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_task ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?
+SELECT id, user_id, agent_id, session_id, goal_id, project_id, title, description, status, priority, review_policy, active_review_id, required, retry_count, max_retries, not_before, deadline_at, active_run_id, active_blocker_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_task ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?
 `
 
 type ListAgentTasksParams struct {
@@ -239,7 +220,9 @@ func (q *Queries) ListAgentTasks(ctx context.Context, arg ListAgentTasksParams) 
 			&i.ID,
 			&i.UserID,
 			&i.AgentID,
+			&i.SessionID,
 			&i.GoalID,
+			&i.ProjectID,
 			&i.Title,
 			&i.Description,
 			&i.Status,
@@ -251,7 +234,6 @@ func (q *Queries) ListAgentTasks(ctx context.Context, arg ListAgentTasksParams) 
 			&i.MaxRetries,
 			&i.NotBefore,
 			&i.DeadlineAt,
-			&i.SessionID,
 			&i.ActiveRunID,
 			&i.ActiveBlockerID,
 			&i.Context,
@@ -275,20 +257,22 @@ func (q *Queries) ListAgentTasks(ctx context.Context, arg ListAgentTasksParams) 
 }
 
 const listAgentTasksByUser = `-- name: ListAgentTasksByUser :many
-SELECT id, user_id, agent_id, goal_id, title, description, status, priority, review_policy, active_review_id, required, retry_count, max_retries, not_before, deadline_at, session_id, active_run_id, active_blocker_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_task
+SELECT id, user_id, agent_id, session_id, goal_id, project_id, title, description, status, priority, review_policy, active_review_id, required, retry_count, max_retries, not_before, deadline_at, active_run_id, active_blocker_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_task
 WHERE user_id = ?1
   AND (?2 IS NULL OR agent_id = ?2)
   AND (?3 IS NULL OR status = ?3)
+  AND (?4 IS NULL OR project_id = ?4)
 ORDER BY created_at DESC, id DESC
-LIMIT ?5 OFFSET ?4
+LIMIT ?6 OFFSET ?5
 `
 
 type ListAgentTasksByUserParams struct {
-	UserID  string      `json:"user_id"`
-	AgentID interface{} `json:"agent_id"`
-	Status  interface{} `json:"status"`
-	Offset  int64       `json:"offset"`
-	Limit   int64       `json:"limit"`
+	UserID    string      `json:"user_id"`
+	AgentID   interface{} `json:"agent_id"`
+	Status    interface{} `json:"status"`
+	ProjectID interface{} `json:"project_id"`
+	Offset    int64       `json:"offset"`
+	Limit     int64       `json:"limit"`
 }
 
 func (q *Queries) ListAgentTasksByUser(ctx context.Context, arg ListAgentTasksByUserParams) ([]AgentTask, error) {
@@ -296,6 +280,7 @@ func (q *Queries) ListAgentTasksByUser(ctx context.Context, arg ListAgentTasksBy
 		arg.UserID,
 		arg.AgentID,
 		arg.Status,
+		arg.ProjectID,
 		arg.Offset,
 		arg.Limit,
 	)
@@ -310,7 +295,9 @@ func (q *Queries) ListAgentTasksByUser(ctx context.Context, arg ListAgentTasksBy
 			&i.ID,
 			&i.UserID,
 			&i.AgentID,
+			&i.SessionID,
 			&i.GoalID,
+			&i.ProjectID,
 			&i.Title,
 			&i.Description,
 			&i.Status,
@@ -322,7 +309,6 @@ func (q *Queries) ListAgentTasksByUser(ctx context.Context, arg ListAgentTasksBy
 			&i.MaxRetries,
 			&i.NotBefore,
 			&i.DeadlineAt,
-			&i.SessionID,
 			&i.ActiveRunID,
 			&i.ActiveBlockerID,
 			&i.Context,
@@ -346,7 +332,7 @@ func (q *Queries) ListAgentTasksByUser(ctx context.Context, arg ListAgentTasksBy
 }
 
 const listReadyCandidates = `-- name: ListReadyCandidates :many
-SELECT id, user_id, agent_id, goal_id, title, description, status, priority, review_policy, active_review_id, required, retry_count, max_retries, not_before, deadline_at, session_id, active_run_id, active_blocker_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_task
+SELECT id, user_id, agent_id, session_id, goal_id, project_id, title, description, status, priority, review_policy, active_review_id, required, retry_count, max_retries, not_before, deadline_at, active_run_id, active_blocker_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_task
 WHERE status = 'ready'
   AND active_run_id IS NULL
   AND (not_before IS NULL OR not_before <= ?)
@@ -374,7 +360,9 @@ func (q *Queries) ListReadyCandidates(ctx context.Context, arg ListReadyCandidat
 			&i.ID,
 			&i.UserID,
 			&i.AgentID,
+			&i.SessionID,
 			&i.GoalID,
+			&i.ProjectID,
 			&i.Title,
 			&i.Description,
 			&i.Status,
@@ -386,7 +374,6 @@ func (q *Queries) ListReadyCandidates(ctx context.Context, arg ListReadyCandidat
 			&i.MaxRetries,
 			&i.NotBefore,
 			&i.DeadlineAt,
-			&i.SessionID,
 			&i.ActiveRunID,
 			&i.ActiveBlockerID,
 			&i.Context,

--- a/pkg/db/sqlc/agent_task_dep.sql.go
+++ b/pkg/db/sqlc/agent_task_dep.sql.go
@@ -247,7 +247,7 @@ WITH RECURSIVE downstream(id, depth) AS (
     JOIN downstream ds ON atd.dep_task_id = ds.id
     WHERE ds.depth < 1000
 )
-SELECT t.id, t.user_id, t.agent_id, t.goal_id, t.title, t.description, t.status, t.priority, t.review_policy, t.active_review_id, t.required, t.retry_count, t.max_retries, t.not_before, t.deadline_at, t.session_id, t.active_run_id, t.active_blocker_id, t.context, t.output, t.created_at, t.updated_at, t.completed_at, t.cancelled_at FROM agent_task t JOIN downstream ds ON t.id = ds.id
+SELECT t.id, t.user_id, t.agent_id, t.session_id, t.goal_id, t.project_id, t.title, t.description, t.status, t.priority, t.review_policy, t.active_review_id, t.required, t.retry_count, t.max_retries, t.not_before, t.deadline_at, t.active_run_id, t.active_blocker_id, t.context, t.output, t.created_at, t.updated_at, t.completed_at, t.cancelled_at FROM agent_task t JOIN downstream ds ON t.id = ds.id
 `
 
 // Reachable downstream tasks of a given task (Slice 4 reopen cascade).
@@ -267,7 +267,9 @@ func (q *Queries) ListReachableDownstream(ctx context.Context, depTaskID string)
 			&i.ID,
 			&i.UserID,
 			&i.AgentID,
+			&i.SessionID,
 			&i.GoalID,
+			&i.ProjectID,
 			&i.Title,
 			&i.Description,
 			&i.Status,
@@ -279,7 +281,6 @@ func (q *Queries) ListReachableDownstream(ctx context.Context, depTaskID string)
 			&i.MaxRetries,
 			&i.NotBefore,
 			&i.DeadlineAt,
-			&i.SessionID,
 			&i.ActiveRunID,
 			&i.ActiveBlockerID,
 			&i.Context,

--- a/pkg/db/sqlc/models.go
+++ b/pkg/db/sqlc/models.go
@@ -29,7 +29,8 @@ type Agent struct {
 type AgentGoal struct {
 	ID             string         `json:"id"`
 	UserID         string         `json:"user_id"`
-	AgentID        sql.NullString `json:"agent_id"`
+	AgentID        string         `json:"agent_id"`
+	ProjectID      sql.NullString `json:"project_id"`
 	Title          string         `json:"title"`
 	Description    string         `json:"description"`
 	Status         string         `json:"status"`
@@ -73,8 +74,10 @@ type AgentReviewItem struct {
 type AgentTask struct {
 	ID              string         `json:"id"`
 	UserID          string         `json:"user_id"`
-	AgentID         sql.NullString `json:"agent_id"`
+	AgentID         string         `json:"agent_id"`
+	SessionID       string         `json:"session_id"`
 	GoalID          sql.NullString `json:"goal_id"`
+	ProjectID       sql.NullString `json:"project_id"`
 	Title           string         `json:"title"`
 	Description     string         `json:"description"`
 	Status          string         `json:"status"`
@@ -86,7 +89,6 @@ type AgentTask struct {
 	MaxRetries      int64          `json:"max_retries"`
 	NotBefore       sql.NullString `json:"not_before"`
 	DeadlineAt      sql.NullString `json:"deadline_at"`
-	SessionID       sql.NullString `json:"session_id"`
 	ActiveRunID     sql.NullString `json:"active_run_id"`
 	ActiveBlockerID sql.NullString `json:"active_blocker_id"`
 	Context         string         `json:"context"`

--- a/resources/skills/system/stella/references/tasks.md
+++ b/resources/skills/system/stella/references/tasks.md
@@ -54,12 +54,12 @@ goal ──rolls up from──▶ task ──one attempt──▶ run
 
 - **Goal** — container; status rolls up from child tasks. Managed under `stella task goal`.
 - **Task** — smallest executable unit, with a strict lifecycle status.
-- **Run** — one execution attempt; carries session, heartbeat, and lease.
+- **Run** — one execution attempt; records the task's worker session, heartbeat, and lease.
 - **Dep edge** — DAG link, `hard` or `soft`, with an `on_failure` policy.
 - **Blocker** — why a task is paused; at most one open blocker per task.
 - **Review** — approval gate before `done`; task policy decides who reviews.
 
-Tasks and goals require agent context. Inside Stella sessions, `stella task create` and `stella task goal create` default to `STELLA_AGENT_ID`. Outside Stella, pass `--agent-id` explicitly.
+Tasks and goals require agent context. Inside Stella sessions, `stella task create` and `stella task goal create` default to `STELLA_AGENT_ID`. Outside Stella, pass `--agent-id` explicitly. A task always has a durable worker session minted at creation time. Use `--project-id` when the work should run in a project/workspace context. If `--goal-id` is set and `--agent-id` is omitted, the task inherits the goal's agent.
 
 ## Lifecycle
 
@@ -77,9 +77,9 @@ A task does nothing until activated. `ready` means eligible for readiness checks
 
 All commands are `stella task ...` or `stella task goal ...`.
 
-**Create one background task.** Use `stella task create ... --activate`. Without `--activate`, the task stays `draft` and never runs.
+**Create one background task.** Use `stella task create ... --activate`. Add `--project-id <project-id>` for project-scoped work. Without `--activate`, the task stays `draft` and never runs.
 
-**Build a goal.** Create the goal first, then create child tasks with `stella task create --goal-id <goal-id> ...`. A task created without `--goal-id` is standalone and will not appear under `stella task goal tasks <goal-id>` or the Automations goal detail page.
+**Build a goal.** Create the goal first, optionally with `--project-id`, then create child tasks with `stella task create --goal-id <goal-id> ...`. A task created without `--goal-id` is standalone and will not appear under `stella task goal tasks <goal-id>` or the Automations goal detail page.
 
 **Build a dependency graph.** Create upstream tasks first, note their IDs, then create downstream tasks with `--dep <upstream-id>` or add edges later with `stella task dep add`. Default dependency behavior is `hard` + `block`: downstream waits for upstream success.
 

--- a/web/content/docs/development/agent-architecture.md
+++ b/web/content/docs/development/agent-architecture.md
@@ -285,13 +285,14 @@ Rules:
 ### Task worker session
 
 ```text
-task dispatcher resolves executor agent
-    -> Service.MintTaskSession(userID, executorAgentID)
-    -> run row records session_id and executor_agent_id
-    -> worker runner uses the same executor agent scope
+task creation resolves owner agent and optional project
+    -> Service.MintTaskSession(userID, agentID, projectID)
+    -> task row stores session_id
+    -> run row records the task session_id and executor_agent_id
+    -> worker runner uses the resolved executor agent scope
 ```
 
-The session owner is the resolved executor agent, not necessarily the task creator agent.
+The task's worker session is created under the task owner/manager agent and optional project. A later run may still use a run-level executor override via dispatch hints.
 
 ### Reflect review
 

--- a/web/content/docs/development/agent-architecture.zh.md
+++ b/web/content/docs/development/agent-architecture.zh.md
@@ -285,13 +285,14 @@ parent runner executes delegate tool
 ### Task worker session
 
 ```text
-task dispatcher resolves executor agent
-    -> Service.MintTaskSession(userID, executorAgentID)
-    -> run row records session_id and executor_agent_id
-    -> worker runner uses the same executor agent scope
+task creation resolves owner agent and optional project
+    -> Service.MintTaskSession(userID, agentID, projectID)
+    -> task row stores session_id
+    -> run row records the task session_id and executor_agent_id
+    -> worker runner uses the resolved executor agent scope
 ```
 
-Session owner 是 resolved executor agent，不一定是 task creator agent。
+Task worker session 创建在 task owner/manager agent 和可选 project 下。后续 run 仍可通过 dispatch hint 使用 run-level executor override。
 
 ### Reflect review
 

--- a/web/content/docs/development/goal-system.md
+++ b/web/content/docs/development/goal-system.md
@@ -37,11 +37,20 @@ It is not an automatic planning system yet. Stella does not currently split a go
 
 Supported container mode:
 
-```text
-draft --ActivateGoal--> running --all required children done--> done
-                              |--required child failed--------> failed
-                              |--required child blocked-------> blocked --child unblocks--> running
-non-terminal --CancelGoal-------------------------------------> cancelled
+```mermaid
+stateDiagram-v2
+    [*] --> draft
+    draft --> running: ActivateGoal
+    running --> done: all required children done
+    running --> failed: required child failed
+    running --> blocked: required child blocked
+    blocked --> running: child unblocks (UnblockGoal)
+    draft --> cancelled: CancelGoal
+    running --> cancelled: CancelGoal
+    blocked --> cancelled: CancelGoal
+    done --> [*]
+    failed --> [*]
+    cancelled --> [*]
 ```
 
 Activation promotes draft child tasks to ready in the same transaction. The dispatcher then picks up those tasks through the normal task readiness path.

--- a/web/content/docs/development/goal-system.md
+++ b/web/content/docs/development/goal-system.md
@@ -26,12 +26,12 @@ It is not an automatic planning system yet. Stella does not currently split a go
 
 ## Mental model
 
-| Concept                  | Purpose                                                                                                                   |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
-| `agent_goal`             | Container for a related set of tasks. Stores status, priority, review policy, context, output, and active review pointer. |
-| `agent_task.goal_id`     | Optional link from a task to one goal. Standalone tasks have no goal.                                                     |
-| `agent_task_run.goal_id` | Schema support for future goal-targeted planner/synthesizer runs. Dispatcher scan paths are removed in this release.      |
-| `agent_review.goal_id`   | Schema support for future goal-parented reviews. API validation gates this off in this release.                           |
+| Concept                  | Purpose                                                                                                                                                           |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent_goal`             | Container for a related set of tasks. Stores required owner agent, optional project, status, priority, review policy, context, output, and active review pointer. |
+| `agent_task.goal_id`     | Optional link from a task to one goal. Standalone tasks have no goal. Child tasks inherit/validate the goal's agent and project context.                          |
+| `agent_task_run.goal_id` | Schema support for future goal-targeted planner/synthesizer runs. Dispatcher scan paths are removed in this release.                                              |
+| `agent_review.goal_id`   | Schema support for future goal-parented reviews. API validation gates this off in this release.                                                                   |
 
 ## Supported lifecycle
 

--- a/web/content/docs/development/goal-system.zh.md
+++ b/web/content/docs/development/goal-system.zh.md
@@ -26,12 +26,12 @@ description: 由子任务和任务汇总支持的 goal 容器。本版本 gate o
 
 ## 心智模型
 
-| 概念                     | 作用                                                                                                 |
-| ------------------------ | ---------------------------------------------------------------------------------------------------- |
-| `agent_goal`             | 一组相关 tasks 的容器。存储 status、priority、review policy、context、output 和 active review 指针。 |
-| `agent_task.goal_id`     | 从 task 到一个 goal 的可选链接。Standalone task 没有 goal。                                          |
-| `agent_task_run.goal_id` | Schema 支持未来 goal-targeted planner/synthesizer runs；本版本删除 dispatcher scan paths。           |
-| `agent_review.goal_id`   | Schema 支持未来 goal-parented reviews；本版本通过 API validation gate off。                          |
+| 概念                     | 作用                                                                                                                                |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `agent_goal`             | 一组相关 tasks 的容器。存储必填 owner agent、可选 project、status、priority、review policy、context、output 和 active review 指针。 |
+| `agent_task.goal_id`     | 从 task 到一个 goal 的可选链接。Standalone task 没有 goal。Child task 会继承/校验 goal 的 agent 和 project context。                |
+| `agent_task_run.goal_id` | Schema 支持未来 goal-targeted planner/synthesizer runs；本版本删除 dispatcher scan paths。                                          |
+| `agent_review.goal_id`   | Schema 支持未来 goal-parented reviews；本版本通过 API validation gate off。                                                         |
 
 ## 支持的生命周期
 

--- a/web/content/docs/development/goal-system.zh.md
+++ b/web/content/docs/development/goal-system.zh.md
@@ -37,11 +37,20 @@ description: 由子任务和任务汇总支持的 goal 容器。本版本 gate o
 
 支持的容器模式：
 
-```text
-draft --ActivateGoal--> running --all required children done--> done
-                              |--required child failed--------> failed
-                              |--required child blocked-------> blocked --child unblocks--> running
-non-terminal --CancelGoal-------------------------------------> cancelled
+```mermaid
+stateDiagram-v2
+    [*] --> draft
+    draft --> running: ActivateGoal
+    running --> done: 所有 required children 完成
+    running --> failed: required child 失败
+    running --> blocked: required child 被阻塞
+    blocked --> running: child 解除阻塞 (UnblockGoal)
+    draft --> cancelled: CancelGoal
+    running --> cancelled: CancelGoal
+    blocked --> cancelled: CancelGoal
+    done --> [*]
+    failed --> [*]
+    cancelled --> [*]
 ```
 
 Activation 会在同一个事务中把 draft child tasks 提升到 ready。随后 dispatcher 通过普通 task readiness 路径派发这些 tasks。

--- a/web/content/docs/development/task-system.md
+++ b/web/content/docs/development/task-system.md
@@ -56,12 +56,31 @@ Progress is the exception: the task-control progress action may persist a shallo
 
 ## Task lifecycle
 
-```text
-draft --activate--> ready --claim--> running --submit--> done or reviewing
-  |                    |              |
-  |                    |              +-- block --> blocked --resolve/waive--> ready
-  |                    |              +-- fail  --> ready (retry) or failed
-  +-- cancel --> cancelled
+```mermaid
+stateDiagram-v2
+    [*] --> draft
+    draft --> ready: activate
+    ready --> running: claim
+    running --> done: submit (policy none/auto)
+    running --> reviewing: submit (policy human)
+    running --> blocked: block
+    ready --> blocked: dep failure (on_failure=block)
+    running --> ready: fail (retry budget)
+    running --> failed: fail (budget exhausted)
+    blocked --> ready: resolve / waive
+    reviewing --> done: approve
+    reviewing --> failed: reject
+    reviewing --> ready: request-changes (retry budget)
+    reviewing --> failed: request-changes (budget exhausted)
+    draft --> cancelled: cancel
+    ready --> cancelled: cancel
+    running --> cancelled: cancel
+    blocked --> cancelled: cancel
+    done --> ready: reopen
+    failed --> ready: reopen
+    done --> [*]
+    failed --> [*]
+    cancelled --> [*]
 ```
 
 `reviewing` is entered only when a supported review policy requires a decision. `human` reviews wait for API/CLI decisions. `auto` is decided immediately. `agent` review is not a supported runtime path yet.

--- a/web/content/docs/development/task-system.md
+++ b/web/content/docs/development/task-system.md
@@ -25,18 +25,20 @@ This page describes the implementation contract. User-facing task behavior is do
 
 Durable state is stored in SQLite-backed tables, not in the runtime process.
 
-| Table                      | Purpose                                                                                                                      |
-| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `agent_task`               | One executable unit. Stores business status, goal link, review policy, context, output, retry counters, and active pointers. |
-| `agent_task_run`           | One execution attempt. Stores run kind, attempt number, executor, session, lease, heartbeat, result, and error.              |
-| `agent_task_event`         | Append-only audit log for transitions and protocol errors.                                                                   |
-| `agent_task_dep`           | DAG edges between tasks, including hard/soft semantics and failure policy.                                                   |
-| `agent_task_blocker`       | Why a task is paused. At most one open blocker per task.                                                                     |
-| `agent_review`             | Human/auto review records for tasks and goals.                                                                               |
-| `agent_goal`               | Container for related tasks; status rolls up from children in the supported mode.                                            |
-| `agent_task_dispatch_hint` | One-shot hint that tells the dispatcher which executor agent to use for the next claim.                                      |
+| Table                      | Purpose                                                                                                                                                                                       |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent_task`               | One executable unit. Stores required owner agent, required worker session, optional goal/project links, business status, review policy, context, output, retry counters, and active pointers. |
+| `agent_task_run`           | One execution attempt. Stores run kind, attempt number, executor, session, lease, heartbeat, result, and error.                                                                               |
+| `agent_task_event`         | Append-only audit log for transitions and protocol errors.                                                                                                                                    |
+| `agent_task_dep`           | DAG edges between tasks, including hard/soft semantics and failure policy.                                                                                                                    |
+| `agent_task_blocker`       | Why a task is paused. At most one open blocker per task.                                                                                                                                      |
+| `agent_review`             | Human/auto review records for tasks and goals.                                                                                                                                                |
+| `agent_goal`               | Container for related tasks; status rolls up from children in the supported mode.                                                                                                             |
+| `agent_task_dispatch_hint` | One-shot hint that tells the dispatcher which executor agent to use for the next claim.                                                                                                       |
 
 Runtime state is intentionally small and temporary. During one run, the worker executor records only the terminal action the agent declared (`submit`, `block`, or `fail`) plus its payload. The worker then applies that result through `TransitionService`.
+
+Migration note: the task context-model migration makes `agent_task.agent_id` and `agent_task.session_id` required and adds a unique task-session index. Databases with old experimental rows that have NULL/duplicate task sessions must be reset or manually repaired before applying that migration; Stella does not include a runtime backfill path for those rows.
 
 ## State authority
 
@@ -136,24 +138,27 @@ Planner, synthesizer, and agent-reviewer scan paths are not part of the supporte
 When claiming a worker task, the dispatcher resolves the executor in this order:
 
 1. Live dispatch hint for `(task_id, kind='worker')`.
-2. Existing task session owner, when `task.session_id` is set.
-3. Task creator agent (`agent_task.agent_id`).
+2. Latest worker run executor for the task, when the task has previous runs.
+3. Task owner/manager agent (`agent_task.agent_id`).
 4. Reject by writing an event and leaving the task unclaimed.
 
 The system must not silently choose a default agent. If no executor can be resolved, the task is misconfigured.
 
 ## Session continuity
 
-Each run records the session it used in `agent_task_run.session_id`. The task row also stores `session_id` as the default session for the next worker run.
+Each task is created with a durable worker session in `agent_task.session_id`; each run records the same session in `agent_task_run.session_id`. The dispatcher never mints worker sessions for normal tasks — creation does.
 
 ```text
-if task.session_id exists:
-    reuse it for the next worker run
-else:
-    mint a new task session and store it on the task
+CreateTask
+  -> resolve required agent_id, optional goal_id/project_id
+  -> mint task worker session (kind=task, channel=task)
+  -> persist agent_task.session_id
+
+Claim
+  -> reuse agent_task.session_id for every worker run
 ```
 
-Clear `task.session_id` only when you intentionally want a fresh worker conversation on the next run.
+`agent_task.session_id` is the worker session, not the source chat session that requested the task.
 
 ## Worker executor runtime
 

--- a/web/content/docs/development/task-system.zh.md
+++ b/web/content/docs/development/task-system.zh.md
@@ -25,18 +25,20 @@ description: 持久化任务执行，包含计算型 readiness、运行尝试、
 
 持久化状态存储在 SQLite 表中，而不是 runtime 进程内存中。
 
-| 表                         | 作用                                                                                                  |
-| -------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `agent_task`               | 一个可执行工作单元。存储业务状态、goal 关联、review policy、context、output、重试计数和 active 指针。 |
-| `agent_task_run`           | 一次执行尝试。存储 run kind、attempt number、executor、session、lease、heartbeat、result 和 error。   |
-| `agent_task_event`         | 追加式审计日志，记录 transition 和 protocol error。                                                   |
-| `agent_task_dep`           | Task 之间的 DAG 边，包括 hard/soft 语义和失败策略。                                                   |
-| `agent_task_blocker`       | Task 暂停的原因。每个 task 最多一个 open blocker。                                                    |
-| `agent_review`             | Task 和 goal 的 human/auto review 记录。                                                              |
-| `agent_goal`               | 相关 tasks 的容器；支持模式下状态从 children 汇总。                                                   |
-| `agent_task_dispatch_hint` | 一次性 hint，告诉 dispatcher 下一次 claim 使用哪个 executor agent。                                   |
+| 表                         | 作用                                                                                                                                                      |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent_task`               | 一个可执行工作单元。存储必填 owner agent、必填 worker session、可选 goal/project 关联、业务状态、review policy、context、output、重试计数和 active 指针。 |
+| `agent_task_run`           | 一次执行尝试。存储 run kind、attempt number、executor、session、lease、heartbeat、result 和 error。                                                       |
+| `agent_task_event`         | 追加式审计日志，记录 transition 和 protocol error。                                                                                                       |
+| `agent_task_dep`           | Task 之间的 DAG 边，包括 hard/soft 语义和失败策略。                                                                                                       |
+| `agent_task_blocker`       | Task 暂停的原因。每个 task 最多一个 open blocker。                                                                                                        |
+| `agent_review`             | Task 和 goal 的 human/auto review 记录。                                                                                                                  |
+| `agent_goal`               | 相关 tasks 的容器；支持模式下状态从 children 汇总。                                                                                                       |
+| `agent_task_dispatch_hint` | 一次性 hint，告诉 dispatcher 下一次 claim 使用哪个 executor agent。                                                                                       |
 
 Runtime 状态应该很小且短暂。一次 run 期间，worker executor 只记录 Agent 声明的终止动作（`submit`、`block` 或 `fail`）及其 payload。随后 worker 通过 `TransitionService` 应用这个结果。
+
+Migration note：task context-model migration 会把 `agent_task.agent_id` 和 `agent_task.session_id` 变成必填，并给 task session 加唯一索引。包含旧实验 rows（NULL/重复 task session）的数据库需要在应用迁移前 reset 或手动修复；Stella 不提供 runtime backfill。
 
 ## 状态权威
 
@@ -136,24 +138,27 @@ Planner、synthesizer 和 agent-reviewer scan paths 不属于当前支持的 run
 Claim worker task 时，dispatcher 按以下顺序解析 executor：
 
 1. `(task_id, kind='worker')` 的 live dispatch hint。
-2. 如果 `task.session_id` 存在，使用该 session 的 owner。
-3. Task 创建者 Agent（`agent_task.agent_id`）。
+2. 如果 task 已有 worker runs，使用最新 worker run 的 executor。
+3. Task owner/manager Agent（`agent_task.agent_id`）。
 4. 写事件并保持 task 未 claim。
 
 系统不能静默选择默认 Agent。无法解析 executor 说明 task 配置错误。
 
 ## Session 连续性
 
-每个 run 都在 `agent_task_run.session_id` 记录使用的 session。Task 行也保存 `session_id`，作为下一次 worker run 的默认 session。
+每个 task 创建时都会在 `agent_task.session_id` 绑定一个 durable worker session；每个 run 也会在 `agent_task_run.session_id` 记录同一个 session。Dispatcher 不再为正常 task 铸造 worker session —— 创建 task 时就完成。
 
 ```text
-if task.session_id exists:
-    reuse it for the next worker run
-else:
-    mint a new task session and store it on the task
+CreateTask
+  -> resolve required agent_id, optional goal_id/project_id
+  -> mint task worker session (kind=task, channel=task)
+  -> persist agent_task.session_id
+
+Claim
+  -> reuse agent_task.session_id for every worker run
 ```
 
-只有在你明确希望下一次 run 使用全新 worker 对话时，才清空 `task.session_id`。
+`agent_task.session_id` 表示 worker session，不表示请求创建 task 的 source chat session。
 
 ## Worker executor runtime
 

--- a/web/content/docs/development/task-system.zh.md
+++ b/web/content/docs/development/task-system.zh.md
@@ -56,12 +56,31 @@ Progress 是例外：task-control progress action 可以在执行期间把 shall
 
 ## Task 生命周期
 
-```text
-draft --activate--> ready --claim--> running --submit--> done or reviewing
-  |                    |              |
-  |                    |              +-- block --> blocked --resolve/waive--> ready
-  |                    |              +-- fail  --> ready (retry) or failed
-  +-- cancel --> cancelled
+```mermaid
+stateDiagram-v2
+    [*] --> draft
+    draft --> ready: activate
+    ready --> running: claim
+    running --> done: submit (policy none/auto)
+    running --> reviewing: submit (policy human)
+    running --> blocked: block
+    ready --> blocked: 依赖失败 (on_failure=block)
+    running --> ready: fail (有重试预算)
+    running --> failed: fail (预算耗尽)
+    blocked --> ready: resolve / waive
+    reviewing --> done: approve
+    reviewing --> failed: reject
+    reviewing --> ready: request-changes (有重试预算)
+    reviewing --> failed: request-changes (预算耗尽)
+    draft --> cancelled: cancel
+    ready --> cancelled: cancel
+    running --> cancelled: cancel
+    blocked --> cancelled: cancel
+    done --> ready: reopen
+    failed --> ready: reopen
+    done --> [*]
+    failed --> [*]
+    cancelled --> [*]
 ```
 
 只有支持的 review policy 需要决策时才进入 `reviewing`。`human` review 等待 API/CLI 决策。`auto` 立即决策。`agent` review 当前不是支持的 runtime 路径。

--- a/web/content/docs/guides/tasks.md
+++ b/web/content/docs/guides/tasks.md
@@ -23,12 +23,12 @@ Every task has a lifecycle:
 
 ## Creating a task
 
-Create a standalone task when the work is independent. Create a goal first when several tasks belong to one larger outcome, then attach child tasks to it.
+Create a standalone task when the work is independent. Create a goal first when several tasks belong to one larger outcome, then attach child tasks to it. Every task belongs to an agent and gets its own durable worker session when it is created; you can optionally attach it to a goal or project.
 
 A typical goal workflow is:
 
 1. Create the goal.
-2. Create child tasks with the goal ID.
+2. Create child tasks with the goal ID. If the task does not pass an agent ID, it inherits the goal's agent.
 3. Add dependencies between tasks when order matters.
 4. Activate the goal and tasks.
 5. Watch task events, blockers, runs, and reviews as work progresses.

--- a/web/content/docs/guides/tasks.zh.md
+++ b/web/content/docs/guides/tasks.zh.md
@@ -23,12 +23,12 @@ Task 是当前对话之外的一个可执行工作单元。当工作需要时间
 
 ## 创建任务
 
-如果工作是独立的，就创建 standalone task。如果多个 task 属于同一个大目标，先创建 goal，再把 child tasks 挂到它下面。
+如果工作是独立的，就创建 standalone task。如果多个 task 属于同一个大目标，先创建 goal，再把 child tasks 挂到它下面。每个 task 都属于一个 Agent，并在创建时获得自己的 durable worker session；你也可以把它挂到 goal 或 project。
 
 典型 goal 工作流：
 
 1. 创建 goal。
-2. 用 goal ID 创建子 tasks。
+2. 用 goal ID 创建子 tasks。如果 task 没有传 agent ID，它会继承 goal 的 Agent。
 3. 在有顺序要求时添加任务依赖。
 4. 激活 goal 和 tasks。
 5. 通过 events、blockers、runs 和 reviews 查看进展。

--- a/web/package.json
+++ b/web/package.json
@@ -24,6 +24,7 @@
     "geist": "^1.7.0",
     "i18next": "^26.0.10",
     "lucide-react": "^1.14.0",
+    "mermaid": "^11.15.0",
     "qrcode": "^1.5.4",
     "react": "^19.2.5",
     "react-day-picker": "^9.14.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -70,7 +70,7 @@ importers:
         specifier: ^1.14.0
         version: 1.16.0(react@19.2.6)
       mermaid:
-        specifier: ^11.15.0
+        specifier: '>=11.15.0'
         version: 11.15.0
       qrcode:
         specifier: ^1.5.4

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       lucide-react:
         specifier: ^1.14.0
         version: 1.16.0(react@19.2.6)
+      mermaid:
+        specifier: ^11.15.0
+        version: 11.15.0
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4

--- a/web/src/components/docs/Mermaid.tsx
+++ b/web/src/components/docs/Mermaid.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from "react";
+
+let seq = 0;
+
+function isDark(): boolean {
+  return document.documentElement.classList.contains("dark");
+}
+
+export function Mermaid({ chart }: { chart: string }) {
+  const [svg, setSvg] = useState("");
+  const [error, setError] = useState<string>();
+
+  useEffect(() => {
+    let active = true;
+    void (async () => {
+      try {
+        const mermaid = (await import("mermaid")).default;
+        mermaid.initialize({
+          startOnLoad: false,
+          securityLevel: "strict",
+          theme: isDark() ? "dark" : "default",
+        });
+        const { svg } = await mermaid.render(`mermaid-${seq++}`, chart);
+        if (active) setSvg(svg);
+      } catch (e) {
+        if (active) setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [chart]);
+
+  if (error) {
+    return (
+      <pre className="bg-muted rounded-lg p-4 my-4 overflow-x-auto text-sm text-destructive">
+        {error}
+        {"\n\n"}
+        {chart}
+      </pre>
+    );
+  }
+
+  return (
+    // eslint-disable-next-line react/no-danger
+    <div
+      className="my-6 flex justify-center [&_svg]:max-w-full"
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
+  );
+}

--- a/web/src/components/docs/mdx-components.tsx
+++ b/web/src/components/docs/mdx-components.tsx
@@ -1,5 +1,7 @@
-import type { ComponentPropsWithoutRef, ReactNode } from "react";
+import type { ComponentPropsWithoutRef, ReactElement, ReactNode } from "react";
+import { isValidElement } from "react";
 import { Link } from "@tanstack/react-router";
+import { Mermaid } from "./Mermaid";
 
 function slugify(text: string): string {
   return text
@@ -120,12 +122,24 @@ export const mdxComponents = {
       </code>
     );
   },
-  pre: (props: ComponentPropsWithoutRef<"pre">) => (
-    <pre
-      className="bg-muted rounded-lg p-4 my-4 overflow-x-auto text-sm leading-6 font-mono"
-      {...props}
-    />
-  ),
+  pre: (props: ComponentPropsWithoutRef<"pre">) => {
+    const child = props.children;
+    if (isValidElement(child)) {
+      const codeProps = (child as ReactElement<{ className?: string; children?: ReactNode }>).props;
+      if (
+        codeProps.className?.includes("language-mermaid") &&
+        typeof codeProps.children === "string"
+      ) {
+        return <Mermaid chart={codeProps.children.replace(/\n$/, "")} />;
+      }
+    }
+    return (
+      <pre
+        className="bg-muted rounded-lg p-4 my-4 overflow-x-auto text-sm leading-6 font-mono"
+        {...props}
+      />
+    );
+  },
   table: (props: ComponentPropsWithoutRef<"table">) => (
     <div className="my-4 overflow-x-auto">
       <table className="w-full text-sm border-collapse" {...props} />


### PR DESCRIPTION
## Summary
- make task ownership explicit: `agent_task.agent_id` and `agent_goal.agent_id` are now required owner/manager context
- mint and persist a unique durable task worker session at task creation via `agent_task.session_id`
- add first-class optional `project_id` context to tasks and goals, with user/agent validation and goal inheritance
- stop dispatcher lazy session minting; task claims reuse the persisted worker session
- add API/CLI support for project context, including `task list --project-id`
- add Mermaid rendering for lifecycle diagrams in docs

## Migration note
This migration intentionally does not backfill old experimental task/goal rows. Dev databases with NULL/duplicate `agent_id` or `session_id` values must be reset or manually repaired before applying the migration.

## Verification
- `mise run format`
- `mise run build`
- `mise run test`
