### PR TITLE
⚡ perf: add database hot path indexes

### DIFF
--- a/internal/db/database.go
+++ b/internal/db/database.go
@@ -53,6 +53,7 @@ func OpenDB(dbPath string) (*sql.DB, error) {
 func dataSourceName(dbPath string) string {
 	q := url.Values{}
 	q.Add("_pragma", "journal_mode(WAL)")
+	q.Add("_pragma", "synchronous(NORMAL)")
 	q.Add("_pragma", fmt.Sprintf("busy_timeout(%d)", sqliteBusyTimeout.Milliseconds()))
 	q.Add("_pragma", "foreign_keys(ON)")
 	return dbPath + "?" + q.Encode()

--- a/internal/db/migrations/20260603011945_add_hot_path_indexes.sql
+++ b/internal/db/migrations/20260603011945_add_hot_path_indexes.sql
@@ -1,0 +1,20 @@
+-- Create index "idx_ctx_conversation_user_agent_active" to table: "ctx_conversation"
+CREATE INDEX `idx_ctx_conversation_user_agent_active` ON `ctx_conversation` (`user_id`, `agent_id`, `archived`, `last_active` DESC);
+-- Create index "idx_ctx_conversation_user_agent_kind_active" to table: "ctx_conversation"
+CREATE INDEX `idx_ctx_conversation_user_agent_kind_active` ON `ctx_conversation` (`user_id`, `agent_id`, `kind`, `archived`, `last_active` DESC);
+-- Create index "idx_ctx_conversation_review_agent_active" to table: "ctx_conversation"
+CREATE INDEX `idx_ctx_conversation_review_agent_active` ON `ctx_conversation` (`agent_id`, `archived`, `last_active` DESC);
+-- Create index "idx_agent_goal_user_created" to table: "agent_goal"
+CREATE INDEX `idx_agent_goal_user_created` ON `agent_goal` (`user_id`, `created_at` DESC, `id` DESC);
+-- Create index "idx_agent_goal_planning_candidates" to table: "agent_goal"
+CREATE INDEX `idx_agent_goal_planning_candidates` ON `agent_goal` (`priority` DESC, `created_at`) WHERE status = 'draft';
+-- Create index "idx_agent_goal_synthesis_candidates" to table: "agent_goal"
+CREATE INDEX `idx_agent_goal_synthesis_candidates` ON `agent_goal` (`priority` DESC, `updated_at`) WHERE status = 'running' AND review_policy != 'none';
+-- Create index "idx_agent_task_user_created" to table: "agent_task"
+CREATE INDEX `idx_agent_task_user_created` ON `agent_task` (`user_id`, `created_at` DESC, `id` DESC);
+-- Create index "idx_agent_task_user_agent_status_created" to table: "agent_task"
+CREATE INDEX `idx_agent_task_user_agent_status_created` ON `agent_task` (`user_id`, `agent_id`, `status`, `created_at` DESC, `id` DESC);
+-- Create index "idx_agent_task_user_agent_project_created" to table: "agent_task"
+CREATE INDEX `idx_agent_task_user_agent_project_created` ON `agent_task` (`user_id`, `agent_id`, `project_id`, `created_at` DESC, `id` DESC);
+-- Create index "idx_agent_task_ready_candidates" to table: "agent_task"
+CREATE INDEX `idx_agent_task_ready_candidates` ON `agent_task` (`priority` DESC, `created_at`) WHERE status = 'ready' AND active_run_id IS NULL;

--- a/internal/db/migrations/atlas.sum
+++ b/internal/db/migrations/atlas.sum
@@ -1,6 +1,7 @@
-h1:PxD21lt+1wn2cfkAMjdiIo/9i37DpmzBMVrHk6gzvY8=
+h1:0JFB82011y+MMMV4GR/QIWi5OOT3GgKCn7u8pnCZ1Bs=
 20260531120105_initial.sql h1:yFv08NKwCabgVkvWoSNzba6WMXjbXrI9xHctaJBir/8=
 20260601060943_add_config_to_plugin_override.sql h1:q2MIJRzEYGDQyjnLeFUrQ0zbnvdgxBh/MRANwRmPFn4=
 20260602031701_add-channel-name.sql h1:1ZGYJvwMOOShxLGIN9SJihmcfQtFRpTPXHhOWDv29fc=
 20260602120907_task_context_model.sql h1:Wn53ucGMFLpk4DAHWHfhF3kwcixyFKBDQEfhk4W3Qjs=
 20260602153709_drop_local_oidc_tables.sql h1:DliooDQgspiVvm0S2zdy9ormXlErapW40epHEeg88ac=
+20260603011945_add_hot_path_indexes.sql h1:GJ+e4PxFRlbOWi1BZrDhgzp47cZGB0CWMqDYQ0fc17c=

--- a/internal/db/schemas/tables/agent_goal.sql
+++ b/internal/db/schemas/tables/agent_goal.sql
@@ -24,3 +24,10 @@ CREATE TABLE agent_goal (
 
 CREATE INDEX idx_agent_goal_agent_project ON agent_goal(agent_id, project_id);
 CREATE INDEX idx_agent_goal_project       ON agent_goal(project_id);
+CREATE INDEX idx_agent_goal_user_created  ON agent_goal(user_id, created_at DESC, id DESC);
+CREATE INDEX idx_agent_goal_planning_candidates
+    ON agent_goal(priority DESC, created_at ASC)
+    WHERE status = 'draft';
+CREATE INDEX idx_agent_goal_synthesis_candidates
+    ON agent_goal(priority DESC, updated_at ASC)
+    WHERE status = 'running' AND review_policy != 'none';

--- a/internal/db/schemas/tables/agent_task.sql
+++ b/internal/db/schemas/tables/agent_task.sql
@@ -33,6 +33,12 @@ CREATE TABLE agent_task (
 CREATE UNIQUE INDEX uniq_agent_task_session ON agent_task(session_id);
 CREATE INDEX idx_agent_task_agent_status_not_before ON agent_task(agent_id, status, not_before);
 CREATE INDEX idx_agent_task_user_agent        ON agent_task(user_id, agent_id);
+CREATE INDEX idx_agent_task_user_created      ON agent_task(user_id, created_at DESC, id DESC);
+CREATE INDEX idx_agent_task_user_agent_status_created ON agent_task(user_id, agent_id, status, created_at DESC, id DESC);
+CREATE INDEX idx_agent_task_user_agent_project_created ON agent_task(user_id, agent_id, project_id, created_at DESC, id DESC);
+CREATE INDEX idx_agent_task_ready_candidates
+    ON agent_task(priority DESC, created_at ASC)
+    WHERE status = 'ready' AND active_run_id IS NULL;
 CREATE INDEX idx_agent_task_session           ON agent_task(session_id);
 CREATE INDEX idx_agent_task_goal              ON agent_task(goal_id);
 CREATE INDEX idx_agent_task_project           ON agent_task(project_id);

--- a/internal/db/schemas/tables/ctx_conversation.sql
+++ b/internal/db/schemas/tables/ctx_conversation.sql
@@ -21,3 +21,12 @@ CREATE UNIQUE INDEX idx_one_agent_main
 CREATE UNIQUE INDEX idx_one_project_main
   ON ctx_conversation(project_id)
   WHERE kind = 'main' AND project_id IS NOT NULL AND archived = 0;
+
+CREATE INDEX idx_ctx_conversation_user_agent_active
+  ON ctx_conversation(user_id, agent_id, archived, last_active DESC);
+
+CREATE INDEX idx_ctx_conversation_user_agent_kind_active
+  ON ctx_conversation(user_id, agent_id, kind, archived, last_active DESC);
+
+CREATE INDEX idx_ctx_conversation_review_agent_active
+  ON ctx_conversation(agent_id, archived, last_active DESC);


### PR DESCRIPTION
## Summary
- add Atlas-managed indexes for hot session, task, and goal queries
- add partial indexes for task/goal dispatcher candidate scans
- configure SQLite WAL connections with synchronous=NORMAL

## Verification
- mise run db:validate
- mise run format
- mise run build
- mise run test