### PR TITLE
⚡ perf: batch database hot path queries

### DIFF
--- a/internal/db/queries/agent_task_dep.sql
+++ b/internal/db/queries/agent_task_dep.sql
@@ -24,6 +24,15 @@ FROM agent_task_dep d
 JOIN agent_task t ON t.id = d.dep_task_id
 WHERE d.task_id = ?;
 
+-- name: ListAgentTaskDepsWithUpstreamByTasks :many
+SELECT
+    sqlc.embed(d),
+    t.status AS upstream_status
+FROM agent_task_dep d
+JOIN agent_task t ON t.id = d.dep_task_id
+WHERE d.task_id IN (sqlc.slice('task_ids'))
+ORDER BY d.task_id, d.dep_task_id;
+
 -- name: ListAgentTaskDepsWithUpstreamPaged :many
 SELECT
     sqlc.embed(d),

--- a/internal/db/queries/auth_user.sql
+++ b/internal/db/queries/auth_user.sql
@@ -1,3 +1,6 @@
+-- name: ListAuthUsersByIDs :many
+SELECT * FROM auth_user WHERE id IN (sqlc.slice('ids')) ORDER BY id;
+
 -- name: UpdateUserRole :exec
 UPDATE auth_user SET role = ?, updated_at = datetime('now') WHERE id = ?;
 

--- a/internal/db/queries/ctx_message.sql
+++ b/internal/db/queries/ctx_message.sql
@@ -9,6 +9,33 @@ SELECT * FROM ctx_message WHERE id = ? AND conversation_id = ?;
 -- name: GetMessagesByConversation :many
 SELECT * FROM ctx_message WHERE conversation_id = ? ORDER BY seq ASC;
 
+-- name: ListMessagesByLogicalPage :many
+WITH ordered AS (
+    SELECT
+        *,
+        lag(role) OVER (ORDER BY seq ASC) AS prev_role
+    FROM ctx_message
+    WHERE conversation_id = sqlc.arg('conversation_id')
+      AND (sqlc.narg('after') IS NULL OR created_at >= sqlc.narg('after'))
+      AND (sqlc.narg('before') IS NULL OR created_at <= sqlc.narg('before'))
+), grouped AS (
+    SELECT
+        *,
+        sum(CASE WHEN role = 'assistant' AND prev_role = 'assistant' THEN 0 ELSE 1 END)
+            OVER (ORDER BY seq ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS logical_idx
+    FROM ordered
+), selected_groups AS (
+    SELECT logical_idx
+    FROM grouped
+    GROUP BY logical_idx
+    ORDER BY logical_idx DESC
+    LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset')
+)
+SELECT id, conversation_id, seq, role, event_type, content, token_count, created_at
+FROM grouped
+WHERE logical_idx IN (SELECT logical_idx FROM selected_groups)
+ORDER BY seq ASC;
+
 -- name: GetMessagesByConversationRange :many
 SELECT * FROM ctx_message
 WHERE conversation_id = ? AND seq >= ? AND seq <= ?
@@ -23,6 +50,9 @@ SELECT CAST(COALESCE(MAX(seq), 0) AS INTEGER) FROM ctx_message WHERE conversatio
 -- name: CreateMessagePart :exec
 INSERT INTO ctx_message_part (id, message_id, part_type, ordinal, text_content, tool_call_id, tool_name, tool_input, tool_output, metadata)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+
+-- name: ListMessagesByIDs :many
+SELECT * FROM ctx_message WHERE conversation_id = ? AND id IN (sqlc.slice('message_ids')) ORDER BY seq ASC;
 
 -- name: GetMessageParts :many
 SELECT * FROM ctx_message_part WHERE message_id = ? ORDER BY ordinal ASC;

--- a/internal/db/queries/ctx_message.sql
+++ b/internal/db/queries/ctx_message.sql
@@ -10,6 +10,9 @@ SELECT * FROM ctx_message WHERE id = ? AND conversation_id = ?;
 SELECT * FROM ctx_message WHERE conversation_id = ? ORDER BY seq ASC;
 
 -- name: ListMessagesByLogicalPage :many
+-- Keep this logical-message boundary in sync with serializeDBMessages in
+-- internal/server/sessions.go: consecutive assistant rows render as one
+-- response message, so SQL pagination must count them as one too.
 WITH ordered AS (
     SELECT
         *,

--- a/internal/db/queries/ctx_summary.sql
+++ b/internal/db/queries/ctx_summary.sql
@@ -5,6 +5,9 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 -- name: GetSummary :one
 SELECT * FROM ctx_summary WHERE id = ? AND conversation_id = ?;
 
+-- name: ListSummariesByIDs :many
+SELECT * FROM ctx_summary WHERE conversation_id = ? AND id IN (sqlc.slice('summary_ids')) ORDER BY created_at ASC;
+
 -- name: GetSummaryByID :one
 SELECT * FROM ctx_summary WHERE id = ?;
 

--- a/internal/memory/lcm/assembler.go
+++ b/internal/memory/lcm/assembler.go
@@ -2,6 +2,7 @@ package lcm
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -37,9 +38,17 @@ func (a *assembler) assemble(ctx context.Context, convID string, budget int, fre
 
 	// Separate fresh tail (last N message items) from older items.
 	tail, older := splitFreshTail(items, freshTail)
+	messages, err := a.loadMessagesByItem(ctx, items)
+	if err != nil {
+		return nil, err
+	}
+	summaries, err := a.loadSummariesByItem(ctx, items)
+	if err != nil {
+		return nil, err
+	}
 
 	// Resolve fresh tail — these are always included.
-	tailMsgs, err := a.resolveItems(ctx, tail)
+	tailMsgs, err := a.resolveItemsFromCaches(ctx, tail, messages, summaries)
 	if err != nil {
 		return nil, fmt.Errorf("resolve tail: %w", err)
 	}
@@ -79,7 +88,7 @@ func (a *assembler) assemble(ctx context.Context, convID string, budget int, fre
 	// Select older items that fit within remaining budget, newest first.
 	var olderMsgs []ai.Message
 	for i := len(older) - 1; i >= 0; i-- {
-		msgs, err := a.resolveItem(ctx, older[i])
+		msgs, err := a.resolveItemsFromCaches(ctx, older[i:i+1], messages, summaries)
 		if err != nil {
 			return nil, fmt.Errorf("resolve item %d: %w", older[i].Ordinal, err)
 		}
@@ -171,51 +180,91 @@ func splitFreshTail(items []sqlc.CtxItem, freshTail int) (tail []sqlc.CtxItem, o
 	return items[splitIdx:], items[:splitIdx]
 }
 
-// resolveItems resolves a slice of context items to ai.Messages.
-func (a *assembler) resolveItems(ctx context.Context, items []sqlc.CtxItem) ([]ai.Message, error) {
+// resolveItemsFromCaches resolves a slice of context items to ai.Messages.
+func (a *assembler) resolveItemsFromCaches(ctx context.Context, items []sqlc.CtxItem, messages map[string]sqlc.CtxMessage, summaries map[string]sqlc.CtxSummary) ([]ai.Message, error) {
 	var result []ai.Message
 	for _, item := range items {
-		msgs, err := a.resolveItem(ctx, item)
-		if err != nil {
-			return nil, err
+		switch item.ItemType {
+		case itemTypeMessage:
+			if !item.MessageID.Valid {
+				continue
+			}
+			msg, ok := messages[item.MessageID.String]
+			if !ok {
+				return nil, fmt.Errorf("get message %s: %w", item.MessageID.String, sql.ErrNoRows)
+			}
+			// Preserve the pre-existing one-context-item-to-one-message reconstruction.
+			result = append(result, rowsToMessages([]sqlc.CtxMessage{msg})...)
+		case itemTypeSummary:
+			if !item.SummaryID.Valid {
+				continue
+			}
+			sum, ok := summaries[item.SummaryID.String]
+			if !ok {
+				return nil, fmt.Errorf("get summary %s: %w", item.SummaryID.String, sql.ErrNoRows)
+			}
+			parents, err := a.q.GetSummaryParents(ctx, sum.ID)
+			if err != nil {
+				return nil, fmt.Errorf("get summary parents %s: %w", sum.ID, err)
+			}
+			result = append(result, ai.UserMessage{Content: FormatSummaryXML(sum, parents)})
 		}
-		result = append(result, msgs...)
 	}
 	return result, nil
 }
 
-// resolveItem converts a single context item to ai.Messages.
-func (a *assembler) resolveItem(ctx context.Context, item sqlc.CtxItem) ([]ai.Message, error) {
-	switch item.ItemType {
-	case itemTypeMessage:
-		if !item.MessageID.Valid {
-			return nil, nil
+func (a *assembler) loadMessagesByItem(ctx context.Context, items []sqlc.CtxItem) (map[string]sqlc.CtxMessage, error) {
+	idsByConversation := make(map[string][]string)
+	seen := make(map[string]struct{})
+	for _, item := range items {
+		if item.ItemType != itemTypeMessage || !item.MessageID.Valid {
+			continue
 		}
-		msg, err := a.q.GetMessage(ctx, sqlc.GetMessageParams{ID: item.MessageID.String, ConversationID: item.ConversationID})
-		if err != nil {
-			return nil, fmt.Errorf("get message %s: %w", item.MessageID.String, err)
+		key := item.ConversationID + "\x00" + item.MessageID.String
+		if _, ok := seen[key]; ok {
+			continue
 		}
-		// Use rowsToMessages for single-row slices to get proper type reconstruction.
-		return rowsToMessages([]sqlc.CtxMessage{msg}), nil
-
-	case itemTypeSummary:
-		if !item.SummaryID.Valid {
-			return nil, nil
-		}
-		sum, err := a.q.GetSummary(ctx, sqlc.GetSummaryParams{ID: item.SummaryID.String, ConversationID: item.ConversationID})
-		if err != nil {
-			return nil, fmt.Errorf("get summary %s: %w", item.SummaryID.String, err)
-		}
-		parents, err := a.q.GetSummaryParents(ctx, sum.ID)
-		if err != nil {
-			return nil, fmt.Errorf("get summary parents %s: %w", sum.ID, err)
-		}
-		xml := FormatSummaryXML(sum, parents)
-		return []ai.Message{ai.UserMessage{Content: xml}}, nil
-
-	default:
-		return nil, nil
+		seen[key] = struct{}{}
+		idsByConversation[item.ConversationID] = append(idsByConversation[item.ConversationID], item.MessageID.String)
 	}
+	out := make(map[string]sqlc.CtxMessage)
+	for convID, ids := range idsByConversation {
+		rows, err := a.q.ListMessagesByIDs(ctx, sqlc.ListMessagesByIDsParams{ConversationID: convID, MessageIds: ids})
+		if err != nil {
+			return nil, fmt.Errorf("list messages: %w", err)
+		}
+		for _, row := range rows {
+			out[row.ID] = row
+		}
+	}
+	return out, nil
+}
+
+func (a *assembler) loadSummariesByItem(ctx context.Context, items []sqlc.CtxItem) (map[string]sqlc.CtxSummary, error) {
+	idsByConversation := make(map[string][]string)
+	seen := make(map[string]struct{})
+	for _, item := range items {
+		if item.ItemType != itemTypeSummary || !item.SummaryID.Valid {
+			continue
+		}
+		key := item.ConversationID + "\x00" + item.SummaryID.String
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		idsByConversation[item.ConversationID] = append(idsByConversation[item.ConversationID], item.SummaryID.String)
+	}
+	out := make(map[string]sqlc.CtxSummary)
+	for convID, ids := range idsByConversation {
+		rows, err := a.q.ListSummariesByIDs(ctx, sqlc.ListSummariesByIDsParams{ConversationID: convID, SummaryIds: ids})
+		if err != nil {
+			return nil, fmt.Errorf("list summaries: %w", err)
+		}
+		for _, row := range rows {
+			out[row.ID] = row
+		}
+	}
+	return out, nil
 }
 
 // FormatSummaryXML formats a summary as XML for model consumption.

--- a/internal/memory/lcm/assembler.go
+++ b/internal/memory/lcm/assembler.go
@@ -11,6 +11,8 @@ import (
 	"github.com/CherryHQ/stella/pkg/db/sqlc"
 )
 
+const olderResolveBatchSize = 32
+
 // assembler builds context for the model within a token budget.
 type assembler struct {
 	q   *sqlc.Queries
@@ -38,17 +40,17 @@ func (a *assembler) assemble(ctx context.Context, convID string, budget int, fre
 
 	// Separate fresh tail (last N message items) from older items.
 	tail, older := splitFreshTail(items, freshTail)
-	messages, err := a.loadMessagesByItem(ctx, items)
+	tailMessages, err := a.loadMessagesByItem(ctx, tail)
 	if err != nil {
 		return nil, err
 	}
-	summaries, err := a.loadSummariesByItem(ctx, items)
+	tailSummaries, err := a.loadSummariesByItem(ctx, tail)
 	if err != nil {
 		return nil, err
 	}
 
 	// Resolve fresh tail — these are always included.
-	tailMsgs, err := a.resolveItemsFromCaches(ctx, tail, messages, summaries)
+	tailMsgs, err := a.resolveItemsFromCaches(ctx, tail, tailMessages, tailSummaries)
 	if err != nil {
 		return nil, fmt.Errorf("resolve tail: %w", err)
 	}
@@ -86,21 +88,9 @@ func (a *assembler) assemble(ctx context.Context, convID string, budget int, fre
 	remaining := max(budget-tailTokens, 0)
 
 	// Select older items that fit within remaining budget, newest first.
-	var olderMsgs []ai.Message
-	for i := len(older) - 1; i >= 0; i-- {
-		msgs, err := a.resolveItemsFromCaches(ctx, older[i:i+1], messages, summaries)
-		if err != nil {
-			return nil, fmt.Errorf("resolve item %d: %w", older[i].Ordinal, err)
-		}
-		tokens := 0
-		for _, m := range msgs {
-			tokens += estimateMessageTokens(m)
-		}
-		if tokens > remaining {
-			break // stop including older items
-		}
-		remaining -= tokens
-		olderMsgs = append(olderMsgs, msgs...)
+	olderMsgs, err := a.resolveOlderWithinBudget(ctx, older, remaining)
+	if err != nil {
+		return nil, err
 	}
 
 	// Reverse olderMsgs (they were added newest-first).
@@ -178,6 +168,40 @@ func splitFreshTail(items []sqlc.CtxItem, freshTail int) (tail []sqlc.CtxItem, o
 		}
 	}
 	return items[splitIdx:], items[:splitIdx]
+}
+
+func (a *assembler) resolveOlderWithinBudget(ctx context.Context, older []sqlc.CtxItem, remaining int) ([]ai.Message, error) {
+	var olderMsgs []ai.Message
+	for end := len(older); end > 0; {
+		start := max(end-olderResolveBatchSize, 0)
+		batch := older[start:end]
+		messages, err := a.loadMessagesByItem(ctx, batch)
+		if err != nil {
+			return nil, err
+		}
+		summaries, err := a.loadSummariesByItem(ctx, batch)
+		if err != nil {
+			return nil, err
+		}
+		for i := len(batch) - 1; i >= 0; i-- {
+			item := batch[i]
+			msgs, err := a.resolveItemsFromCaches(ctx, batch[i:i+1], messages, summaries)
+			if err != nil {
+				return nil, fmt.Errorf("resolve item %d: %w", item.Ordinal, err)
+			}
+			tokens := 0
+			for _, m := range msgs {
+				tokens += estimateMessageTokens(m)
+			}
+			if tokens > remaining {
+				return olderMsgs, nil
+			}
+			remaining -= tokens
+			olderMsgs = append(olderMsgs, msgs...)
+		}
+		end = start
+	}
+	return olderMsgs, nil
 }
 
 // resolveItemsFromCaches resolves a slice of context items to ai.Messages.

--- a/internal/memory/lcm/compaction.go
+++ b/internal/memory/lcm/compaction.go
@@ -197,13 +197,27 @@ func (c *compactionEngine) compactMessageRun(ctx context.Context, convID string,
 	var totalTokens int64
 	var earliestAt, latestAt string
 
+	messageIDs := make([]string, 0, len(run.items))
+	for _, item := range run.items {
+		if item.MessageID.Valid {
+			messageIDs = append(messageIDs, item.MessageID.String)
+		}
+	}
+	loadedMessages, err := c.q.ListMessagesByIDs(ctx, sqlc.ListMessagesByIDsParams{ConversationID: convID, MessageIds: messageIDs})
+	if err != nil {
+		return fmt.Errorf("list messages: %w", err)
+	}
+	messagesByID := make(map[string]sqlc.CtxMessage, len(loadedMessages))
+	for _, msg := range loadedMessages {
+		messagesByID[msg.ID] = msg
+	}
 	for _, item := range run.items {
 		if !item.MessageID.Valid {
 			continue
 		}
-		msg, err := c.q.GetMessage(ctx, sqlc.GetMessageParams{ID: item.MessageID.String, ConversationID: convID})
-		if err != nil {
-			return fmt.Errorf("get message %s: %w", item.MessageID.String, err)
+		msg, ok := messagesByID[item.MessageID.String]
+		if !ok {
+			return fmt.Errorf("get message %s: %w", item.MessageID.String, sql.ErrNoRows)
 		}
 		messages = append(messages, msg)
 		textParts = append(textParts, formatMessageForSummarizer(msg))
@@ -304,18 +318,13 @@ func (c *compactionEngine) compactMessageRun(ctx context.Context, convID string,
 // condensedPass finds eligible same-depth summaries and creates condensed summaries.
 func (c *compactionEngine) condensedPass(ctx context.Context, convID string, items []sqlc.CtxItem, result *memory.CompactionResult) error {
 	// Pre-fetch all summary items so we can group by depth and avoid re-fetching.
-	sumCache := make(map[string]sqlc.CtxSummary)
-	depthOf := make(map[string]int64)
-	for _, item := range items {
-		if item.ItemType != itemTypeSummary || !item.SummaryID.Valid {
-			continue
-		}
-		sum, err := c.q.GetSummary(ctx, sqlc.GetSummaryParams{ID: item.SummaryID.String, ConversationID: convID})
-		if err != nil {
-			return fmt.Errorf("get summary depth %s: %w", item.SummaryID.String, err)
-		}
-		sumCache[item.SummaryID.String] = sum
-		depthOf[item.SummaryID.String] = sum.Depth
+	sumCache, err := c.loadSummaryCache(ctx, convID, items)
+	if err != nil {
+		return err
+	}
+	depthOf := make(map[string]int64, len(sumCache))
+	for id, sum := range sumCache {
+		depthOf[id] = sum.Depth
 	}
 
 	// Find runs of consecutive summary items at the same depth.
@@ -331,6 +340,39 @@ func (c *compactionEngine) condensedPass(ctx context.Context, convID string, ite
 	}
 
 	return nil
+}
+
+func (c *compactionEngine) loadSummaryCache(ctx context.Context, convID string, items []sqlc.CtxItem) (map[string]sqlc.CtxSummary, error) {
+	summaryIDs := make([]string, 0, len(items))
+	seen := make(map[string]struct{})
+	for _, item := range items {
+		if item.ItemType != itemTypeSummary || !item.SummaryID.Valid {
+			continue
+		}
+		id := item.SummaryID.String
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		summaryIDs = append(summaryIDs, id)
+	}
+	if len(summaryIDs) == 0 {
+		return map[string]sqlc.CtxSummary{}, nil
+	}
+	summaries, err := c.q.ListSummariesByIDs(ctx, sqlc.ListSummariesByIDsParams{ConversationID: convID, SummaryIds: summaryIDs})
+	if err != nil {
+		return nil, fmt.Errorf("list summaries: %w", err)
+	}
+	out := make(map[string]sqlc.CtxSummary, len(summaries))
+	for _, sum := range summaries {
+		out[sum.ID] = sum
+	}
+	for _, id := range summaryIDs {
+		if _, ok := out[id]; !ok {
+			return nil, fmt.Errorf("get summary depth %s: %w", id, sql.ErrNoRows)
+		}
+	}
+	return out, nil
 }
 
 // summaryRun represents a contiguous sequence of summary context items.

--- a/internal/memory/lcm/provider.go
+++ b/internal/memory/lcm/provider.go
@@ -236,18 +236,44 @@ func (p *Provider) hasCompactableRun(ctx context.Context, items []sqlc.CtxItem) 
 		return true
 	}
 
-	depthOf := make(map[string]int64)
+	depthOf, err := p.summaryDepths(ctx, items)
+	if err != nil {
+		return false
+	}
+	return len(findSummaryRuns(items, 2, depthOf)) > 0
+}
+
+func (p *Provider) summaryDepths(ctx context.Context, items []sqlc.CtxItem) (map[string]int64, error) {
+	byConversation := make(map[string][]string)
+	seen := make(map[string]struct{})
 	for _, item := range items {
 		if item.ItemType != itemTypeSummary || !item.SummaryID.Valid {
 			continue
 		}
-		sum, err := p.q.GetSummary(ctx, sqlc.GetSummaryParams{ID: item.SummaryID.String, ConversationID: item.ConversationID})
-		if err != nil {
-			return false
+		key := item.ConversationID + "\x00" + item.SummaryID.String
+		if _, ok := seen[key]; ok {
+			continue
 		}
-		depthOf[item.SummaryID.String] = sum.Depth
+		seen[key] = struct{}{}
+		byConversation[item.ConversationID] = append(byConversation[item.ConversationID], item.SummaryID.String)
 	}
-	return len(findSummaryRuns(items, 2, depthOf)) > 0
+
+	depthOf := make(map[string]int64)
+	for convID, ids := range byConversation {
+		summaries, err := p.q.ListSummariesByIDs(ctx, sqlc.ListSummariesByIDsParams{ConversationID: convID, SummaryIds: ids})
+		if err != nil {
+			return nil, err
+		}
+		for _, sum := range summaries {
+			depthOf[sum.ID] = sum.Depth
+		}
+		for _, id := range ids {
+			if _, ok := depthOf[id]; !ok {
+				return nil, sql.ErrNoRows
+			}
+		}
+	}
+	return depthOf, nil
 }
 
 // Compact implements memory.Compactor.

--- a/internal/server/agent_users.go
+++ b/internal/server/agent_users.go
@@ -23,13 +23,21 @@ func (s *Server) ListAgentUsers(w http.ResponseWriter, r *http.Request, id strin
 		ID       string `json:"id"`
 		Username string `json:"username"`
 	}
+	rows, err := s.q.ListAuthUsersByIDs(ctx, userIDs)
+	if err != nil {
+		s.writeInternalError(w, err)
+		return
+	}
+	byID := make(map[string]string, len(rows))
+	for _, u := range rows {
+		byID[u.ID] = u.Email
+	}
+
 	users := make([]agentUser, 0, len(userIDs))
 	for _, uid := range userIDs {
-		u, err := s.users.GetUser(ctx, uid)
-		if err != nil {
-			continue
+		if email, ok := byID[uid]; ok {
+			users = append(users, agentUser{ID: uid, Username: email})
 		}
-		users = append(users, agentUser{ID: u.ID, Username: u.Email})
 	}
 
 	writeData(w, http.StatusOK, map[string]any{"users": users})

--- a/internal/server/agent_users.go
+++ b/internal/server/agent_users.go
@@ -33,6 +33,8 @@ func (s *Server) ListAgentUsers(w http.ResponseWriter, r *http.Request, id strin
 		byID[u.ID] = u.Email
 	}
 
+	// Stale auth_user_agent links should not break the admin list; real query
+	// failures are surfaced above, while missing users are intentionally skipped.
 	users := make([]agentUser, 0, len(userIDs))
 	for _, uid := range userIDs {
 		if email, ok := byID[uid]; ok {

--- a/internal/server/sessions.go
+++ b/internal/server/sessions.go
@@ -1191,7 +1191,9 @@ func filterMessageRowsByTime(rows []sqlc.CtxMessage, after, before *string) []sq
 }
 
 // serializeDBMessages converts raw DB message rows to JSON-friendly maps,
-// preserving the created_at timestamp from the database.
+// preserving the created_at timestamp from the database. Keep assistant-row
+// grouping in sync with ListMessagesByLogicalPage: the SQL query uses the same
+// logical-message boundary so paginated responses never split a rendered message.
 func serializeDBMessages(rows []sqlc.CtxMessage) []map[string]any {
 	result := make([]map[string]any, 0, len(rows))
 	i := 0

--- a/internal/server/sessions.go
+++ b/internal/server/sessions.go
@@ -577,46 +577,31 @@ func (s *Server) GetSessionMessages(w http.ResponseWriter, r *http.Request, agen
 		writeError(w, http.StatusNotFound, "session not found")
 		return
 	}
-	rows, err := s.q.GetMessagesByConversation(r.Context(), conv.ID)
-	if err != nil {
-		s.writeInternalError(w, err)
-		return
-	}
-
-	// Filter by time range when after/before are provided (used by automation
-	// run detail to show only messages from a specific run).
-	if params.After != nil || params.Before != nil {
-		filtered := rows[:0]
-		for _, row := range rows {
-			if params.After != nil && row.CreatedAt < *params.After {
-				continue
-			}
-			if params.Before != nil && row.CreatedAt > *params.Before {
-				continue
-			}
-			filtered = append(filtered, row)
-		}
-		rows = filtered
-	}
-
-	// Serialize first so that skip/limit count logical (serialized) messages,
-	// matching what the frontend tracks in sessionMessagesSkip. Without this,
-	// consecutive assistant rows (tool-call turns) collapse into fewer messages
-	// than DB rows, causing the frontend skip cursor to drift and pages to
-	// overlap or go missing.
-	all := serializeDBMessages(rows)
-	total := len(all)
+	var rows []sqlc.CtxMessage
 	if limit > 0 {
-		end := total - skip
-		if end <= 0 {
-			all = nil
-		} else {
-			start := max(end-limit, 0)
-			all = all[start:end]
+		pageRows, err := s.q.ListMessagesByLogicalPage(r.Context(), sqlc.ListMessagesByLogicalPageParams{
+			ConversationID: conv.ID,
+			After:          nilIfStringPtr(params.After),
+			Before:         nilIfStringPtr(params.Before),
+			Limit:          int64(limit),
+			Offset:         int64(skip),
+		})
+		if err != nil {
+			s.writeInternalError(w, err)
+			return
 		}
+		rows = logicalPageRowsToMessages(pageRows)
+	} else {
+		var err error
+		rows, err = s.q.GetMessagesByConversation(r.Context(), conv.ID)
+		if err != nil {
+			s.writeInternalError(w, err)
+			return
+		}
+		rows = filterMessageRowsByTime(rows, params.After, params.Before)
 	}
 
-	writeData(w, http.StatusOK, map[string]any{"messages": all})
+	writeData(w, http.StatusOK, map[string]any{"messages": serializeDBMessages(rows)})
 }
 
 // checkSessionAccess verifies the current user has access to the session.
@@ -1171,6 +1156,38 @@ func (s *Server) GetSessionSystemPrompt(w http.ResponseWriter, r *http.Request, 
 	})
 
 	writeData(w, http.StatusOK, map[string]string{"system_prompt": systemPrompt})
+}
+
+func nilIfStringPtr(p *string) any {
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+
+func logicalPageRowsToMessages(rows []sqlc.ListMessagesByLogicalPageRow) []sqlc.CtxMessage {
+	out := make([]sqlc.CtxMessage, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, sqlc.CtxMessage(row))
+	}
+	return out
+}
+
+func filterMessageRowsByTime(rows []sqlc.CtxMessage, after, before *string) []sqlc.CtxMessage {
+	if after == nil && before == nil {
+		return rows
+	}
+	filtered := rows[:0]
+	for _, row := range rows {
+		if after != nil && row.CreatedAt < *after {
+			continue
+		}
+		if before != nil && row.CreatedAt > *before {
+			continue
+		}
+		filtered = append(filtered, row)
+	}
+	return filtered
 }
 
 // serializeDBMessages converts raw DB message rows to JSON-friendly maps,

--- a/internal/server/sessions_test.go
+++ b/internal/server/sessions_test.go
@@ -1,10 +1,14 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
+	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 
+	appdb "github.com/CherryHQ/stella/internal/db"
 	"github.com/CherryHQ/stella/internal/memory"
 	sqlc "github.com/CherryHQ/stella/pkg/db/sqlc"
 )
@@ -112,6 +116,65 @@ func TestSerializeDBMessages_mixed(t *testing.T) {
 	}
 	if result[0]["role"] != "user" {
 		t.Errorf("first role = %v", result[0]["role"])
+	}
+}
+
+func TestListMessagesByLogicalPageMatchesSerializedWindow(t *testing.T) {
+	ctx := context.Background()
+	db, err := appdb.OpenDB(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	q := sqlc.New(db)
+
+	conv, err := q.CreateConversation(ctx, sqlc.CreateConversationParams{
+		ID:         "conv-1",
+		SessionID:  "session-1",
+		Channel:    "chat",
+		Kind:       "chat",
+		Archived:   0,
+		LastActive: "2026-01-01 00:00:00",
+	})
+	if err != nil {
+		t.Fatalf("CreateConversation: %v", err)
+	}
+
+	toolCall, _ := json.Marshal(map[string]any{"id": "c1", "tool": "bash", "args": map[string]any{"command": "ls"}})
+	toolResult, _ := json.Marshal(map[string]any{"id": "c1", "tool": "bash", "result": "output"})
+	rows := []sqlc.CreateMessageParams{
+		{ID: "m1", ConversationID: conv.ID, Seq: 1, Role: "user", EventType: "text", Content: "u1"},
+		{ID: "m2", ConversationID: conv.ID, Seq: 2, Role: "assistant", EventType: "text", Content: "a1"},
+		{ID: "m3", ConversationID: conv.ID, Seq: 3, Role: "assistant", EventType: "tool_call", Content: string(toolCall)},
+		{ID: "m4", ConversationID: conv.ID, Seq: 4, Role: "tool", EventType: "text", Content: string(toolResult)},
+		{ID: "m5", ConversationID: conv.ID, Seq: 5, Role: "assistant", EventType: "text", Content: "a2"},
+		{ID: "m6", ConversationID: conv.ID, Seq: 6, Role: "assistant", EventType: "thinking", Content: "think"},
+		{ID: "m7", ConversationID: conv.ID, Seq: 7, Role: "user", EventType: "text", Content: "u2"},
+	}
+	for _, row := range rows {
+		if _, err := q.CreateMessage(ctx, row); err != nil {
+			t.Fatalf("CreateMessage %s: %v", row.ID, err)
+		}
+	}
+
+	allRows, err := q.GetMessagesByConversation(ctx, conv.ID)
+	if err != nil {
+		t.Fatalf("GetMessagesByConversation: %v", err)
+	}
+	all := serializeDBMessages(allRows)
+
+	pageRows, err := q.ListMessagesByLogicalPage(ctx, sqlc.ListMessagesByLogicalPageParams{
+		ConversationID: conv.ID,
+		Limit:          3,
+		Offset:         1,
+	})
+	if err != nil {
+		t.Fatalf("ListMessagesByLogicalPage: %v", err)
+	}
+	got := serializeDBMessages(logicalPageRowsToMessages(pageRows))
+	want := all[1:4]
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("logical page mismatch\ngot:  %#v\nwant: %#v", got, want)
 	}
 }
 

--- a/internal/tasks/dispatcher.go
+++ b/internal/tasks/dispatcher.go
@@ -169,12 +169,13 @@ func (d *Dispatcher) propagateDepFailures(ctx context.Context, now time.Time) {
 		d.cfg.Logger.Warn("dispatcher: list candidates", "err", err)
 		return
 	}
+	depsByTask, err := d.loadDepRowsByTask(ctx, candidates)
+	if err != nil {
+		d.cfg.Logger.Warn("dispatcher: list candidate deps", "err", err)
+		return
+	}
 	for _, task := range candidates {
-		deps, err := d.cfg.Queries.ListAgentTaskDepsWithUpstream(ctx, task.ID)
-		if err != nil {
-			continue
-		}
-		for _, row := range deps {
+		for _, row := range depsByTask[task.ID] {
 			edge := row.AgentTaskDep
 			if edge.DepKind != DepKindHard {
 				continue
@@ -226,6 +227,11 @@ func (d *Dispatcher) scanAndDispatch(ctx context.Context, now time.Time) {
 		d.cfg.Logger.Warn("dispatcher: list candidates", "err", err)
 		return
 	}
+	depsByTask, err := d.loadDepViewsByTask(ctx, candidates)
+	if err != nil {
+		d.cfg.Logger.Warn("dispatcher: list candidate deps", "err", err)
+		return
+	}
 	for _, task := range candidates {
 		if d.isStopped() {
 			return
@@ -233,11 +239,7 @@ func (d *Dispatcher) scanAndDispatch(ctx context.Context, now time.Time) {
 		if !d.underCap() {
 			continue
 		}
-		depViews, err := d.loadDepViews(ctx, task.ID)
-		if err != nil {
-			continue
-		}
-		r := Compute(task, depViews, now)
+		r := Compute(task, depsByTask[task.ID], now)
 		if !r.Dispatchable {
 			continue
 		}
@@ -267,20 +269,44 @@ func (d *Dispatcher) scanAndDispatch(ctx context.Context, now time.Time) {
 	}
 }
 
-func (d *Dispatcher) loadDepViews(ctx context.Context, taskID string) ([]DepEdgeView, error) {
-	rows, err := d.cfg.Queries.ListAgentTaskDepsWithUpstream(ctx, taskID)
+func (d *Dispatcher) loadDepRowsByTask(ctx context.Context, tasks []sqlc.AgentTask) (map[string][]sqlc.ListAgentTaskDepsWithUpstreamByTasksRow, error) {
+	out := make(map[string][]sqlc.ListAgentTaskDepsWithUpstreamByTasksRow, len(tasks))
+	ids := make([]string, 0, len(tasks))
+	for _, task := range tasks {
+		out[task.ID] = nil
+		ids = append(ids, task.ID)
+	}
+	if len(ids) == 0 {
+		return out, nil
+	}
+	rows, err := d.cfg.Queries.ListAgentTaskDepsWithUpstreamByTasks(ctx, ids)
 	if err != nil {
 		return nil, err
 	}
-	out := make([]DepEdgeView, 0, len(rows))
-	for _, r := range rows {
-		out = append(out, DepEdgeView{
-			DepTaskID:      r.AgentTaskDep.DepTaskID,
-			Kind:           r.AgentTaskDep.DepKind,
-			OnFailure:      r.AgentTaskDep.OnFailure,
-			Waived:         r.AgentTaskDep.WaivedAt.Valid,
-			UpstreamStatus: r.UpstreamStatus,
-		})
+	for _, row := range rows {
+		out[row.AgentTaskDep.TaskID] = append(out[row.AgentTaskDep.TaskID], row)
+	}
+	return out, nil
+}
+
+func (d *Dispatcher) loadDepViewsByTask(ctx context.Context, tasks []sqlc.AgentTask) (map[string][]DepEdgeView, error) {
+	rowsByTask, err := d.loadDepRowsByTask(ctx, tasks)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string][]DepEdgeView, len(rowsByTask))
+	for taskID, rows := range rowsByTask {
+		views := make([]DepEdgeView, 0, len(rows))
+		for _, r := range rows {
+			views = append(views, DepEdgeView{
+				DepTaskID:      r.AgentTaskDep.DepTaskID,
+				Kind:           r.AgentTaskDep.DepKind,
+				OnFailure:      r.AgentTaskDep.OnFailure,
+				Waived:         r.AgentTaskDep.WaivedAt.Valid,
+				UpstreamStatus: r.UpstreamStatus,
+			})
+		}
+		out[taskID] = views
 	}
 	return out, nil
 }

--- a/pkg/db/sqlc/agent_task_dep.sql.go
+++ b/pkg/db/sqlc/agent_task_dep.sql.go
@@ -8,6 +8,7 @@ package sqlc
 import (
 	"context"
 	"database/sql"
+	"strings"
 )
 
 const createAgentTaskDep = `-- name: CreateAgentTaskDep :one
@@ -159,6 +160,64 @@ func (q *Queries) ListAgentTaskDepsWithUpstream(ctx context.Context, taskID stri
 	items := []ListAgentTaskDepsWithUpstreamRow{}
 	for rows.Next() {
 		var i ListAgentTaskDepsWithUpstreamRow
+		if err := rows.Scan(
+			&i.AgentTaskDep.TaskID,
+			&i.AgentTaskDep.DepTaskID,
+			&i.AgentTaskDep.DepKind,
+			&i.AgentTaskDep.OnFailure,
+			&i.AgentTaskDep.WaivedAt,
+			&i.AgentTaskDep.WaivedByUser,
+			&i.AgentTaskDep.WaiverReason,
+			&i.AgentTaskDep.CreatedAt,
+			&i.UpstreamStatus,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listAgentTaskDepsWithUpstreamByTasks = `-- name: ListAgentTaskDepsWithUpstreamByTasks :many
+SELECT
+    d.task_id, d.dep_task_id, d.dep_kind, d.on_failure, d.waived_at, d.waived_by_user, d.waiver_reason, d.created_at,
+    t.status AS upstream_status
+FROM agent_task_dep d
+JOIN agent_task t ON t.id = d.dep_task_id
+WHERE d.task_id IN (/*SLICE:task_ids*/?)
+ORDER BY d.task_id, d.dep_task_id
+`
+
+type ListAgentTaskDepsWithUpstreamByTasksRow struct {
+	AgentTaskDep   AgentTaskDep `json:"agent_task_dep"`
+	UpstreamStatus string       `json:"upstream_status"`
+}
+
+func (q *Queries) ListAgentTaskDepsWithUpstreamByTasks(ctx context.Context, taskIds []string) ([]ListAgentTaskDepsWithUpstreamByTasksRow, error) {
+	query := listAgentTaskDepsWithUpstreamByTasks
+	var queryParams []interface{}
+	if len(taskIds) > 0 {
+		for _, v := range taskIds {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:task_ids*/?", strings.Repeat(",?", len(taskIds))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:task_ids*/?", "NULL", 1)
+	}
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListAgentTaskDepsWithUpstreamByTasksRow{}
+	for rows.Next() {
+		var i ListAgentTaskDepsWithUpstreamByTasksRow
 		if err := rows.Scan(
 			&i.AgentTaskDep.TaskID,
 			&i.AgentTaskDep.DepTaskID,

--- a/pkg/db/sqlc/auth_user.sql.go
+++ b/pkg/db/sqlc/auth_user.sql.go
@@ -7,7 +7,58 @@ package sqlc
 
 import (
 	"context"
+	"strings"
 )
+
+const listAuthUsersByIDs = `-- name: ListAuthUsersByIDs :many
+SELECT id, email, name, avatar_url, role, is_active, default_agent_id, notify_identity_id, age_public_key, age_private_key, created_at, updated_at FROM auth_user WHERE id IN (/*SLICE:ids*/?) ORDER BY id
+`
+
+func (q *Queries) ListAuthUsersByIDs(ctx context.Context, ids []string) ([]AuthUser, error) {
+	query := listAuthUsersByIDs
+	var queryParams []interface{}
+	if len(ids) > 0 {
+		for _, v := range ids {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:ids*/?", strings.Repeat(",?", len(ids))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:ids*/?", "NULL", 1)
+	}
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []AuthUser{}
+	for rows.Next() {
+		var i AuthUser
+		if err := rows.Scan(
+			&i.ID,
+			&i.Email,
+			&i.Name,
+			&i.AvatarUrl,
+			&i.Role,
+			&i.IsActive,
+			&i.DefaultAgentID,
+			&i.NotifyIdentityID,
+			&i.AgePublicKey,
+			&i.AgePrivateKey,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
 
 const updateUserActive = `-- name: UpdateUserActive :exec
 UPDATE auth_user SET is_active = ?, updated_at = datetime('now') WHERE id = ?

--- a/pkg/db/sqlc/ctx_message.sql.go
+++ b/pkg/db/sqlc/ctx_message.sql.go
@@ -341,6 +341,143 @@ func (q *Queries) GetMessagesSince(ctx context.Context, arg GetMessagesSincePara
 	return items, nil
 }
 
+const listMessagesByIDs = `-- name: ListMessagesByIDs :many
+SELECT id, conversation_id, seq, role, event_type, content, token_count, created_at FROM ctx_message WHERE conversation_id = ? AND id IN (/*SLICE:message_ids*/?) ORDER BY seq ASC
+`
+
+type ListMessagesByIDsParams struct {
+	ConversationID string   `json:"conversation_id"`
+	MessageIds     []string `json:"message_ids"`
+}
+
+func (q *Queries) ListMessagesByIDs(ctx context.Context, arg ListMessagesByIDsParams) ([]CtxMessage, error) {
+	query := listMessagesByIDs
+	var queryParams []interface{}
+	queryParams = append(queryParams, arg.ConversationID)
+	if len(arg.MessageIds) > 0 {
+		for _, v := range arg.MessageIds {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:message_ids*/?", strings.Repeat(",?", len(arg.MessageIds))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:message_ids*/?", "NULL", 1)
+	}
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []CtxMessage{}
+	for rows.Next() {
+		var i CtxMessage
+		if err := rows.Scan(
+			&i.ID,
+			&i.ConversationID,
+			&i.Seq,
+			&i.Role,
+			&i.EventType,
+			&i.Content,
+			&i.TokenCount,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listMessagesByLogicalPage = `-- name: ListMessagesByLogicalPage :many
+WITH ordered AS (
+    SELECT
+        id, conversation_id, seq, role, event_type, content, token_count, created_at,
+        lag(role) OVER (ORDER BY seq ASC) AS prev_role
+    FROM ctx_message
+    WHERE conversation_id = ?1
+      AND (?2 IS NULL OR created_at >= ?2)
+      AND (?3 IS NULL OR created_at <= ?3)
+), grouped AS (
+    SELECT
+        id, conversation_id, seq, role, event_type, content, token_count, created_at, prev_role,
+        sum(CASE WHEN role = 'assistant' AND prev_role = 'assistant' THEN 0 ELSE 1 END)
+            OVER (ORDER BY seq ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS logical_idx
+    FROM ordered
+), selected_groups AS (
+    SELECT logical_idx
+    FROM grouped
+    GROUP BY logical_idx
+    ORDER BY logical_idx DESC
+    LIMIT ?5 OFFSET ?4
+)
+SELECT id, conversation_id, seq, role, event_type, content, token_count, created_at
+FROM grouped
+WHERE logical_idx IN (SELECT logical_idx FROM selected_groups)
+ORDER BY seq ASC
+`
+
+type ListMessagesByLogicalPageParams struct {
+	ConversationID string      `json:"conversation_id"`
+	After          interface{} `json:"after"`
+	Before         interface{} `json:"before"`
+	Offset         int64       `json:"offset"`
+	Limit          int64       `json:"limit"`
+}
+
+type ListMessagesByLogicalPageRow struct {
+	ID             string `json:"id"`
+	ConversationID string `json:"conversation_id"`
+	Seq            int64  `json:"seq"`
+	Role           string `json:"role"`
+	EventType      string `json:"event_type"`
+	Content        string `json:"content"`
+	TokenCount     int64  `json:"token_count"`
+	CreatedAt      string `json:"created_at"`
+}
+
+func (q *Queries) ListMessagesByLogicalPage(ctx context.Context, arg ListMessagesByLogicalPageParams) ([]ListMessagesByLogicalPageRow, error) {
+	rows, err := q.db.QueryContext(ctx, listMessagesByLogicalPage,
+		arg.ConversationID,
+		arg.After,
+		arg.Before,
+		arg.Offset,
+		arg.Limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListMessagesByLogicalPageRow{}
+	for rows.Next() {
+		var i ListMessagesByLogicalPageRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.ConversationID,
+			&i.Seq,
+			&i.Role,
+			&i.EventType,
+			&i.Content,
+			&i.TokenCount,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const searchMessages = `-- name: SearchMessages :many
 SELECT id, conversation_id, seq, role, event_type, content, token_count, created_at FROM ctx_message
 WHERE conversation_id = ? AND content LIKE ?

--- a/pkg/db/sqlc/ctx_message.sql.go
+++ b/pkg/db/sqlc/ctx_message.sql.go
@@ -440,6 +440,9 @@ type ListMessagesByLogicalPageRow struct {
 	CreatedAt      string `json:"created_at"`
 }
 
+// Keep this logical-message boundary in sync with serializeDBMessages in
+// internal/server/sessions.go: consecutive assistant rows render as one
+// response message, so SQL pagination must count them as one too.
 func (q *Queries) ListMessagesByLogicalPage(ctx context.Context, arg ListMessagesByLogicalPageParams) ([]ListMessagesByLogicalPageRow, error) {
 	rows, err := q.db.QueryContext(ctx, listMessagesByLogicalPage,
 		arg.ConversationID,

--- a/pkg/db/sqlc/ctx_summary.sql.go
+++ b/pkg/db/sqlc/ctx_summary.sql.go
@@ -8,6 +8,7 @@ package sqlc
 import (
 	"context"
 	"database/sql"
+	"strings"
 )
 
 const createSummary = `-- name: CreateSummary :exec
@@ -341,6 +342,62 @@ type LinkSummaryToParentParams struct {
 func (q *Queries) LinkSummaryToParent(ctx context.Context, arg LinkSummaryToParentParams) error {
 	_, err := q.db.ExecContext(ctx, linkSummaryToParent, arg.SummaryID, arg.ParentSummaryID, arg.Ordinal)
 	return err
+}
+
+const listSummariesByIDs = `-- name: ListSummariesByIDs :many
+SELECT id, conversation_id, kind, depth, content, token_count, earliest_at, latest_at, descendant_count, descendant_token_count, source_message_token_count, created_at FROM ctx_summary WHERE conversation_id = ? AND id IN (/*SLICE:summary_ids*/?) ORDER BY created_at ASC
+`
+
+type ListSummariesByIDsParams struct {
+	ConversationID string   `json:"conversation_id"`
+	SummaryIds     []string `json:"summary_ids"`
+}
+
+func (q *Queries) ListSummariesByIDs(ctx context.Context, arg ListSummariesByIDsParams) ([]CtxSummary, error) {
+	query := listSummariesByIDs
+	var queryParams []interface{}
+	queryParams = append(queryParams, arg.ConversationID)
+	if len(arg.SummaryIds) > 0 {
+		for _, v := range arg.SummaryIds {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:summary_ids*/?", strings.Repeat(",?", len(arg.SummaryIds))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:summary_ids*/?", "NULL", 1)
+	}
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []CtxSummary{}
+	for rows.Next() {
+		var i CtxSummary
+		if err := rows.Scan(
+			&i.ID,
+			&i.ConversationID,
+			&i.Kind,
+			&i.Depth,
+			&i.Content,
+			&i.TokenCount,
+			&i.EarliestAt,
+			&i.LatestAt,
+			&i.DescendantCount,
+			&i.DescendantTokenCount,
+			&i.SourceMessageTokenCount,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const searchSummaries = `-- name: SearchSummaries :many


### PR DESCRIPTION
## Summary
- page session messages in SQL by logical serialized messages instead of loading full conversation history
- batch LCM message/summary lookups during assembly and compaction
- batch dispatcher dependency loading for ready candidate batches
- batch agent user lookups for the agent assignment endpoint

## Notes
- This PR is stacked on #273 (perf/db-hotpath-indexes).
- Channel identity candidate fallback is left unchanged because it has auto-link side effects and should be handled separately if needed.

## Verification
- mise run format
- mise run build
- mise run test
