### PR TITLE
Extract ChatComposer with slash commands and compact layout

### DIFF
--- a/web/src/features/sessions/ChatComposer.tsx
+++ b/web/src/features/sessions/ChatComposer.tsx
@@ -17,7 +17,7 @@ export interface ComposerSkill {
 interface Props {
   value: string;
   onChange: (value: string) => void;
-  onSend: () => void;
+  onSend: (overrideText?: string) => void;
   onStop?: () => void;
   isStreaming: boolean;
   disabled?: boolean;
@@ -62,9 +62,9 @@ export function ChatComposer({
     if (selectedSkills.length > 0) {
       const prefix = selectedSkills.map((s) => `/${s.name}`).join(" ");
       const full = value.trim() ? `${prefix} ${value}` : prefix;
-      onChange(full);
       setSelectedSkills([]);
-      setTimeout(() => onSend(), 0);
+      onChange("");
+      onSend(full);
     } else {
       onSend();
     }

--- a/web/src/features/sessions/ChatComposer.tsx
+++ b/web/src/features/sessions/ChatComposer.tsx
@@ -1,0 +1,377 @@
+import type { ReactNode, RefObject } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ArrowUp, Paperclip, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface Attachment {
+  name: string;
+  path: string;
+  uploading: boolean;
+}
+
+export interface ComposerSkill {
+  name: string;
+  description: string;
+}
+
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+  onSend: () => void;
+  onStop?: () => void;
+  isStreaming: boolean;
+  disabled?: boolean;
+  placeholder?: string;
+  attachments?: Attachment[];
+  onFileSelect?: (files: FileList) => void;
+  onRemoveAttachment?: (idx: number) => void;
+  overlay?: ReactNode;
+  textareaRef?: RefObject<HTMLTextAreaElement | null>;
+  skills?: ComposerSkill[];
+}
+
+export function ChatComposer({
+  value,
+  onChange,
+  onSend,
+  onStop,
+  isStreaming,
+  disabled,
+  placeholder = "Send a message…",
+  attachments,
+  onFileSelect,
+  onRemoveAttachment,
+  overlay,
+  textareaRef,
+  skills,
+}: Props) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const internalTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const taRef = textareaRef ?? internalTextareaRef;
+
+  const [selectedSkills, setSelectedSkills] = useState<ComposerSkill[]>([]);
+
+  const hasAttachments = attachments && attachments.length > 0;
+  const canSend =
+    (value.trim() ||
+      selectedSkills.length > 0 ||
+      (hasAttachments && attachments.some((a) => !a.uploading))) &&
+    !attachments?.some((a) => a.uploading);
+
+  const handleSend = useCallback(() => {
+    if (selectedSkills.length > 0) {
+      const prefix = selectedSkills.map((s) => `/${s.name}`).join(" ");
+      const full = value.trim() ? `${prefix} ${value}` : prefix;
+      onChange(full);
+      setSelectedSkills([]);
+      setTimeout(() => onSend(), 0);
+    } else {
+      onSend();
+    }
+  }, [selectedSkills, value, onChange, onSend]);
+
+  const [slashQuery, setSlashQuery] = useState<string | null>(null);
+  const [slashIndex, setSlashIndex] = useState(0);
+  const slashListRef = useRef<HTMLDivElement>(null);
+
+  const detectSlash = useCallback(
+    (val: string) => {
+      if (!skills || skills.length === 0) {
+        setSlashQuery(null);
+        return;
+      }
+      const textarea = taRef.current;
+      const pos = textarea?.selectionStart ?? val.length;
+      const before = val.slice(0, pos);
+      const match = before.match(/(?:^|\s)\/(\S*)$/);
+      setSlashQuery(match ? match[1] : null);
+    },
+    [skills, taRef],
+  );
+
+  const handleChange = useCallback(
+    (val: string) => {
+      onChange(val);
+      detectSlash(val);
+    },
+    [onChange, detectSlash],
+  );
+
+  const slashCandidates = useMemo(() => {
+    if (slashQuery === null || !skills) return [];
+    const q = slashQuery.toLowerCase();
+    const alreadySelected = new Set(selectedSkills.map((s) => s.name));
+    return skills.filter(
+      (s) =>
+        !alreadySelected.has(s.name) &&
+        (s.name.toLowerCase().includes(q) || s.description.toLowerCase().includes(q)),
+    );
+  }, [slashQuery, skills, selectedSkills]);
+
+  useEffect(() => {
+    setSlashIndex(0);
+  }, [slashCandidates.length]);
+
+  const slashOpen = slashQuery !== null && slashCandidates.length > 0;
+
+  const insertSkill = useCallback(
+    (skill: ComposerSkill) => {
+      const textarea = taRef.current;
+      if (!textarea) return;
+
+      const pos = textarea.selectionStart ?? value.length;
+      const before = value.slice(0, pos);
+      const after = value.slice(pos);
+      const slashIdx = before.lastIndexOf("/");
+      if (slashIdx < 0) return;
+
+      const newVal = (before.slice(0, slashIdx) + after).trim();
+      onChange(newVal);
+      setSelectedSkills((prev) => [...prev, skill]);
+      setSlashQuery(null);
+      textarea.focus();
+    },
+    [value, onChange, taRef],
+  );
+
+  const removeSkill = useCallback((name: string) => {
+    setSelectedSkills((prev) => prev.filter((s) => s.name !== name));
+  }, []);
+
+  const slashOverlay = slashOpen ? (
+    <div
+      ref={slashListRef}
+      className="absolute bottom-full left-0 right-0 z-10 mb-1 max-h-48 overflow-y-auto rounded-lg border border-border bg-popover shadow-lg"
+    >
+      <div className="p-1.5">
+        {slashCandidates.map((s, i) => (
+          <button
+            key={s.name}
+            type="button"
+            data-index={i}
+            onClick={() => insertSkill(s)}
+            onMouseEnter={() => setSlashIndex(i)}
+            className={cn(
+              "group flex w-full items-baseline gap-3 rounded-md px-2.5 py-2 text-left transition-colors",
+              i === slashIndex ? "bg-primary/5" : "",
+            )}
+          >
+            <code
+              className={cn(
+                "shrink-0 rounded px-1.5 py-0.5 font-mono text-xs font-semibold",
+                i === slashIndex ? "bg-primary/10 text-primary" : "bg-muted text-primary",
+              )}
+            >
+              /{s.name}
+            </code>
+            <span
+              className={cn(
+                "truncate text-xs leading-tight",
+                i === slashIndex ? "text-foreground/70" : "text-muted-foreground",
+              )}
+            >
+              {s.description}
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  ) : null;
+
+  const hasChips = (hasAttachments && attachments.length > 0) || selectedSkills.length > 0;
+
+  return (
+    <div className="relative flex-shrink-0 px-4 pt-2 pb-3 sm:px-8">
+      {overlay}
+      {onFileSelect && (
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          className="hidden"
+          onChange={(e) => {
+            if (e.target.files) onFileSelect(e.target.files);
+            e.target.value = "";
+          }}
+        />
+      )}
+      <div
+        className={cn(
+          "relative mx-auto max-w-3xl rounded-xl border bg-card transition-all duration-120 flex flex-col p-1.5 shadow-none",
+          isStreaming
+            ? "border-primary focus-within:ring-2 focus-within:ring-primary/20"
+            : "border-border focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/20",
+        )}
+        onDragOver={(e) => {
+          if (!onFileSelect) return;
+          e.preventDefault();
+          e.stopPropagation();
+        }}
+        onDrop={(e) => {
+          if (!onFileSelect || isStreaming) return;
+          e.preventDefault();
+          e.stopPropagation();
+          onFileSelect(e.dataTransfer.files);
+        }}
+      >
+        {slashOverlay}
+        {hasChips && (
+          <div className="flex flex-wrap gap-1.5 px-4 pt-3 pb-1">
+            {selectedSkills.map((s) => (
+              <span
+                key={s.name}
+                className="inline-flex items-center gap-1 rounded-md border border-primary/20 bg-primary/5 px-2.5 py-1 font-mono text-[11px] font-semibold text-primary"
+              >
+                /{s.name}
+                <button
+                  type="button"
+                  onClick={() => removeSkill(s.name)}
+                  className="ml-0.5 shrink-0 cursor-pointer text-primary/40 transition-colors hover:text-primary"
+                >
+                  <X className="size-3" />
+                </button>
+              </span>
+            ))}
+            {hasAttachments &&
+              attachments.map((a, i) => (
+                <span
+                  key={i}
+                  className={cn(
+                    "inline-flex items-center gap-1.5 text-[11px] font-mono rounded-md px-3 py-1 max-w-48 border",
+                    a.uploading
+                      ? "bg-muted/50 text-muted-foreground/50 border-border"
+                      : "bg-primary/5 text-primary border-primary/20",
+                  )}
+                >
+                  {a.uploading ? (
+                    <div className="w-3 h-3 border border-muted-foreground/30 border-t-muted-foreground rounded-full animate-spin shrink-0" />
+                  ) : (
+                    <Paperclip className="w-3 h-3 shrink-0 text-primary/70" />
+                  )}
+                  <span className="truncate">{a.name}</span>
+                  {!a.uploading && onRemoveAttachment && (
+                    <button
+                      onClick={() => onRemoveAttachment(i)}
+                      className="text-muted-foreground/50 hover:text-foreground cursor-pointer shrink-0 font-bold ml-0.5"
+                    >
+                      ×
+                    </button>
+                  )}
+                </span>
+              ))}
+          </div>
+        )}
+        <div className="relative">
+          <textarea
+            ref={taRef}
+            value={value}
+            onChange={(e) => handleChange(e.target.value)}
+            onKeyDown={(e) => {
+              if (slashOpen) {
+                if (e.key === "ArrowDown") {
+                  e.preventDefault();
+                  const next = (slashIndex + 1) % slashCandidates.length;
+                  setSlashIndex(next);
+                  slashListRef.current
+                    ?.querySelector(`[data-index="${next}"]`)
+                    ?.scrollIntoView({ block: "nearest" });
+                  return;
+                }
+                if (e.key === "ArrowUp") {
+                  e.preventDefault();
+                  const next = (slashIndex - 1 + slashCandidates.length) % slashCandidates.length;
+                  setSlashIndex(next);
+                  slashListRef.current
+                    ?.querySelector(`[data-index="${next}"]`)
+                    ?.scrollIntoView({ block: "nearest" });
+                  return;
+                }
+                if (e.key === "Enter" || e.key === "Tab") {
+                  e.preventDefault();
+                  insertSkill(slashCandidates[slashIndex]);
+                  return;
+                }
+                if (e.key === "Escape") {
+                  e.preventDefault();
+                  setSlashQuery(null);
+                  return;
+                }
+              }
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                handleSend();
+              }
+            }}
+            onInput={(e) => {
+              const el = e.currentTarget;
+              el.style.height = "auto";
+              el.style.height = Math.min(el.scrollHeight, 160) + "px";
+            }}
+            onPaste={(e) => {
+              if (!onFileSelect || isStreaming) return;
+              const files = e.clipboardData.files;
+              if (files.length > 0) {
+                e.preventDefault();
+                onFileSelect(files);
+              }
+            }}
+            placeholder={placeholder}
+            className="w-full resize-none overflow-y-auto border-0 bg-transparent px-4 pt-3 pb-1.5 pr-12 text-[15px] leading-relaxed focus:outline-none placeholder:text-muted-foreground/60 text-foreground"
+            style={{ minHeight: 40, maxHeight: 160 }}
+            rows={1}
+            disabled={disabled ?? isStreaming}
+          />
+          <div className="absolute bottom-1.5 right-2">
+            {isStreaming && onStop ? (
+              <button
+                type="button"
+                onClick={onStop}
+                className="text-destructive hover:bg-destructive/10 bg-destructive/5 border border-destructive/25 font-semibold text-xs rounded-lg px-3 h-7 transition-colors flex items-center gap-1.5 cursor-pointer"
+              >
+                <div className="w-2 h-2 bg-destructive rounded-xs" />
+                <span>Stop</span>
+              </button>
+            ) : (
+              <button
+                type="button"
+                disabled={!canSend}
+                onClick={handleSend}
+                className={cn(
+                  "w-7 h-7 rounded-lg flex items-center justify-center transition-colors cursor-pointer",
+                  !canSend
+                    ? "bg-muted text-muted-foreground/30 cursor-not-allowed"
+                    : "bg-primary text-primary-foreground hover:bg-primary-hover",
+                )}
+                title="Send message"
+              >
+                <ArrowUp className="w-4 h-4 stroke-[2.5]" />
+              </button>
+            )}
+          </div>
+        </div>
+        <div className="flex items-center gap-1.5 px-2 pb-0.5">
+          {!isStreaming && onFileSelect && (
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="text-muted-foreground hover:text-foreground hover:bg-muted transition-colors p-1 rounded-md w-6 h-6 flex items-center justify-center cursor-pointer"
+              title="Attach files"
+            >
+              <Paperclip className="w-3.5 h-3.5" />
+            </button>
+          )}
+          {!isStreaming && (
+            <span className="text-[9px] font-mono text-muted-foreground/30 select-none">
+              ↵ send · ⇧↵ new line{skills && skills.length > 0 ? " · / skills" : ""}
+            </span>
+          )}
+          {isStreaming && (
+            <span className="text-[9px] font-mono text-primary/70 select-none animate-pulse">
+              generating…
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/sessions/SessionDetail.tsx
+++ b/web/src/features/sessions/SessionDetail.tsx
@@ -180,29 +180,33 @@ export function SessionDetail({
     }
   }, [loadOlderMessages]);
 
-  const sendMessage = useCallback(async () => {
-    if ((!userInput.trim() && attachments.length === 0) || isStreaming || !session) return;
-    if (attachments.some((a) => a.uploading)) return;
+  const sendMessage = useCallback(
+    async (overrideText?: string) => {
+      const input = overrideText ?? userInput;
+      if ((!input.trim() && attachments.length === 0) || isStreaming || !session) return;
+      if (attachments.some((a) => a.uploading)) return;
 
-    const text = buildMessageText(userInput);
-    setUserInput("");
-    clearAttachments();
-    shouldAutoScrollRef.current = true;
-    setTimeout(() => {
-      if (transcriptRef.current)
-        transcriptRef.current.scrollTop = transcriptRef.current.scrollHeight;
-    }, 0);
+      const text = buildMessageText(input);
+      setUserInput("");
+      clearAttachments();
+      shouldAutoScrollRef.current = true;
+      setTimeout(() => {
+        if (transcriptRef.current)
+          transcriptRef.current.scrollTop = transcriptRef.current.scrollHeight;
+      }, 0);
 
-    void chatSendMessage({ text });
-  }, [
-    userInput,
-    isStreaming,
-    session,
-    attachments,
-    buildMessageText,
-    clearAttachments,
-    chatSendMessage,
-  ]);
+      void chatSendMessage({ text });
+    },
+    [
+      userInput,
+      isStreaming,
+      session,
+      attachments,
+      buildMessageText,
+      clearAttachments,
+      chatSendMessage,
+    ],
+  );
 
   const { setHeaderTitle, setHeaderActions } = useAppShell();
 
@@ -295,7 +299,7 @@ export function SessionDetail({
             <ChatComposer
               value={userInput}
               onChange={setUserInput}
-              onSend={() => void sendMessage()}
+              onSend={(text) => void sendMessage(text)}
               onStop={() => chatStop()}
               isStreaming={isStreaming}
               placeholder={t("sessions.composer.placeholder")}

--- a/web/src/features/sessions/SessionDetail.tsx
+++ b/web/src/features/sessions/SessionDetail.tsx
@@ -1,17 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useInfiniteQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { useChat } from "@ai-sdk/react";
-import {
-  MessageCircleDashed,
-  PanelRightClose,
-  PanelRightOpen,
-  ArrowUp,
-  Paperclip,
-} from "lucide-react";
+import { MessageCircleDashed, PanelRightClose, PanelRightOpen } from "lucide-react";
 import { useI18n } from "@/lib/i18n";
 import { getSessionMessages, uploadWorkspaceFile } from "@/lib/api-client/sdk.gen";
+import { agentSkillsOptions } from "@/lib/queries/agents";
 import type { Message, Session } from "@/lib/types";
-import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "@/components/ui/tooltip";
 import {
@@ -21,7 +15,9 @@ import {
   uiMessageToMessage,
 } from "@/lib/chat-transport";
 import { useAppShell } from "@/layouts/AppShell";
+import { ChatComposer } from "./ChatComposer";
 import { Transcript } from "./Transcript";
+import { useFileAttachments } from "./useFileAttachments";
 
 interface Props {
   session: Session | null;
@@ -45,18 +41,34 @@ export function SessionDetail({
 }: Props) {
   const { t } = useI18n();
   const [userInput, setUserInput] = useState("");
-  const [attachments, setAttachments] = useState<
-    { name: string; path: string; uploading: boolean }[]
-  >([]);
 
   const transcriptRef = useRef<HTMLDivElement>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
   const sessionIDRef = useRef<string | null>(null);
   const initialScrollSessionRef = useRef<string | null>(null);
   const shouldAutoScrollRef = useRef(true);
 
   const sessionId = session?.id ?? "";
   const agentId = session?.agent_id ?? "";
+
+  const uploadFn = useCallback(
+    async (file: File): Promise<string> => {
+      const { data } = await uploadWorkspaceFile({
+        path: { agentId, sessionId },
+        body: { file },
+        throwOnError: true,
+      });
+      return data.path;
+    },
+    [agentId, sessionId],
+  );
+  const { attachments, selectFiles, removeAttachment, clearAttachments, buildMessageText } =
+    useFileAttachments(uploadFn);
+
+  const { data: skills = [] } = useQuery(agentSkillsOptions(agentId));
+  const composerSkills = useMemo(
+    () => skills.map((s) => ({ name: s.name, description: s.description })),
+    [skills],
+  );
 
   const transport = useMemo(
     () => (session ? createSessionTransport(session.agent_id, session.id) : undefined),
@@ -112,7 +124,7 @@ export function SessionDetail({
   useEffect(() => {
     if (!session) {
       setChatMessages([]);
-      setAttachments([]);
+      clearAttachments();
       return;
     }
     sessionIDRef.current = session.id;
@@ -168,49 +180,13 @@ export function SessionDetail({
     }
   }, [loadOlderMessages]);
 
-  const handleFileSelect = useCallback(
-    async (files: FileList | null) => {
-      if (!files || files.length === 0 || !session) return;
-      for (const file of Array.from(files)) {
-        const placeholder = { name: file.name, path: "", uploading: true };
-        setAttachments((prev) => [...prev, placeholder]);
-        try {
-          const { data: res } = await uploadWorkspaceFile({
-            path: { agentId: agentId, sessionId: sessionId },
-            body: { file },
-            throwOnError: true,
-          });
-          setAttachments((prev) =>
-            prev.map((a) => (a === placeholder ? { ...a, path: res.path, uploading: false } : a)),
-          );
-        } catch (e) {
-          console.error("upload failed:", e);
-          setAttachments((prev) => prev.filter((a) => a !== placeholder));
-        }
-      }
-    },
-    [session, agentId, sessionId],
-  );
-
-  const removeAttachment = useCallback((idx: number) => {
-    setAttachments((prev) => prev.filter((_, i) => i !== idx));
-  }, []);
-
   const sendMessage = useCallback(async () => {
     if ((!userInput.trim() && attachments.length === 0) || isStreaming || !session) return;
-    const uploading = attachments.some((a) => a.uploading);
-    if (uploading) return;
+    if (attachments.some((a) => a.uploading)) return;
 
-    const filePaths = attachments.filter((a) => a.path).map((a) => a.path);
-    const parts: string[] = [];
-    for (const p of filePaths) {
-      parts.push(`[file: ${p}]`);
-    }
-    if (userInput.trim()) parts.push(userInput.trim());
-    const text = parts.join("\n");
-
+    const text = buildMessageText(userInput);
     setUserInput("");
-    setAttachments([]);
+    clearAttachments();
     shouldAutoScrollRef.current = true;
     setTimeout(() => {
       if (transcriptRef.current)
@@ -218,7 +194,15 @@ export function SessionDetail({
     }, 0);
 
     void chatSendMessage({ text });
-  }, [userInput, isStreaming, session, attachments, chatSendMessage]);
+  }, [
+    userInput,
+    isStreaming,
+    session,
+    attachments,
+    buildMessageText,
+    clearAttachments,
+    chatSendMessage,
+  ]);
 
   const { setHeaderTitle, setHeaderActions } = useAppShell();
 
@@ -308,151 +292,18 @@ export function SessionDetail({
 
           {/* Message input */}
           {session.user_id === currentUserID && (
-            <div className="flex-shrink-0 bg-gradient-to-t from-background via-background to-transparent px-4 pt-4 pb-5 sm:px-8">
-              <input
-                ref={fileInputRef}
-                type="file"
-                multiple
-                className="hidden"
-                onChange={(e) => {
-                  handleFileSelect(e.target.files).catch(console.error);
-                  e.target.value = "";
-                }}
-              />
-              <div
-                className={cn(
-                  "mx-auto max-w-3xl rounded-xl border bg-card transition-all duration-120 flex flex-col p-1.5 shadow-none",
-                  isStreaming
-                    ? "border-primary focus-within:ring-2 focus-within:ring-primary/20"
-                    : "border-border focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/20",
-                )}
-                onDragOver={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                }}
-                onDrop={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  if (!isStreaming) handleFileSelect(e.dataTransfer.files).catch(console.error);
-                }}
-              >
-                {attachments.length > 0 && (
-                  <div className="flex flex-wrap gap-1.5 px-4 pt-3 pb-1">
-                    {attachments.map((a, i) => (
-                      <span
-                        key={i}
-                        className={cn(
-                          "inline-flex items-center gap-1.5 text-[11px] font-mono rounded-md px-3 py-1 max-w-48 border",
-                          a.uploading
-                            ? "bg-muted/50 text-muted-foreground/50 border-border"
-                            : "bg-primary/5 text-primary border-primary/20",
-                        )}
-                      >
-                        {a.uploading ? (
-                          <div className="w-3 h-3 border border-muted-foreground/30 border-t-muted-foreground rounded-full animate-spin shrink-0" />
-                        ) : (
-                          <Paperclip className="w-3 h-3 shrink-0 text-primary/70" />
-                        )}
-                        <span className="truncate">{a.name}</span>
-                        {!a.uploading && (
-                          <button
-                            onClick={() => removeAttachment(i)}
-                            className="text-muted-foreground/50 hover:text-foreground cursor-pointer shrink-0 font-bold ml-0.5"
-                          >
-                            ×
-                          </button>
-                        )}
-                      </span>
-                    ))}
-                  </div>
-                )}
-                <textarea
-                  value={userInput}
-                  onChange={(e) => setUserInput(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" && !e.shiftKey) {
-                      e.preventDefault();
-                      sendMessage().catch(console.error);
-                    }
-                  }}
-                  onInput={(e) => {
-                    const el = e.currentTarget;
-                    el.style.height = "auto";
-                    el.style.height = Math.min(el.scrollHeight, 160) + "px";
-                  }}
-                  onPaste={(e) => {
-                    const files = e.clipboardData.files;
-                    if (files.length > 0 && !isStreaming) {
-                      e.preventDefault();
-                      handleFileSelect(files).catch(console.error);
-                    }
-                  }}
-                  placeholder={t("sessions.composer.placeholder")}
-                  className={cn(
-                    "w-full resize-none overflow-y-auto border-0 bg-transparent px-4 pt-3 pb-2 text-[15px] leading-relaxed focus:outline-none placeholder:text-muted-foreground/60 text-foreground",
-                  )}
-                  style={{ minHeight: 44, maxHeight: 160 }}
-                  rows={1}
-                  disabled={isStreaming}
-                />
-                <div className="flex items-center justify-between px-3 pb-1.5 pt-2.5 border-t border-border/30 bg-muted/15 rounded-b-[10px]">
-                  <div className="flex items-center gap-1.5">
-                    {!isStreaming && (
-                      <button
-                        type="button"
-                        onClick={() => fileInputRef.current?.click()}
-                        className="text-muted-foreground hover:text-foreground hover:bg-muted transition-colors p-1.5 rounded-lg w-8 h-8 flex items-center justify-center cursor-pointer"
-                        title="Attach files"
-                      >
-                        <Paperclip className="w-4 h-4" />
-                      </button>
-                    )}
-                    {!isStreaming && (
-                      <span className="text-[10px] font-mono text-muted-foreground/45 select-none pl-1">
-                        ↵ send · ⇧↵ new line
-                      </span>
-                    )}
-                    {isStreaming && (
-                      <span className="text-[10px] font-mono text-primary/80 select-none animate-pulse pl-1">
-                        generating…
-                      </span>
-                    )}
-                  </div>
-                  <div className="flex items-center gap-2">
-                    {isStreaming && (
-                      <button
-                        type="button"
-                        onClick={() => chatStop()}
-                        className="text-destructive hover:bg-destructive/10 bg-destructive/5 border border-destructive/25 font-semibold text-xs rounded-lg px-3.5 h-8 transition-colors flex items-center gap-1.5 cursor-pointer"
-                      >
-                        <div className="w-2 h-2 bg-destructive rounded-xs" />
-                        <span>Stop</span>
-                      </button>
-                    )}
-                    {!isStreaming && (
-                      <button
-                        type="button"
-                        disabled={
-                          (!userInput.trim() && attachments.length === 0) ||
-                          attachments.some((a) => a.uploading)
-                        }
-                        onClick={() => sendMessage().catch(console.error)}
-                        className={cn(
-                          "w-8 h-8 rounded-lg flex items-center justify-center transition-colors cursor-pointer",
-                          (!userInput.trim() && attachments.length === 0) ||
-                            attachments.some((a) => a.uploading)
-                            ? "bg-muted text-muted-foreground/30 cursor-not-allowed"
-                            : "bg-primary text-primary-foreground hover:bg-primary-hover",
-                        )}
-                        title="Send message"
-                      >
-                        <ArrowUp className="w-4 h-4 stroke-[2.5]" />
-                      </button>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </div>
+            <ChatComposer
+              value={userInput}
+              onChange={setUserInput}
+              onSend={() => void sendMessage()}
+              onStop={() => chatStop()}
+              isStreaming={isStreaming}
+              placeholder={t("sessions.composer.placeholder")}
+              attachments={attachments}
+              onFileSelect={(files) => void selectFiles(files)}
+              onRemoveAttachment={removeAttachment}
+              skills={composerSkills}
+            />
           )}
         </div>
       </div>

--- a/web/src/features/sessions/useFileAttachments.ts
+++ b/web/src/features/sessions/useFileAttachments.ts
@@ -1,0 +1,52 @@
+import { useCallback, useState } from "react";
+import type { Attachment } from "./ChatComposer";
+
+export function useFileAttachments(uploadFn: (file: File) => Promise<string>) {
+  const [attachments, setAttachments] = useState<Attachment[]>([]);
+
+  const selectFiles = useCallback(
+    async (files: FileList) => {
+      for (const file of Array.from(files)) {
+        const placeholder: Attachment = { name: file.name, path: "", uploading: true };
+        setAttachments((prev) => [...prev, placeholder]);
+        try {
+          const path = await uploadFn(file);
+          setAttachments((prev) =>
+            prev.map((a) => (a === placeholder ? { ...a, path, uploading: false } : a)),
+          );
+        } catch (e) {
+          console.error("upload failed:", e);
+          setAttachments((prev) => prev.filter((a) => a !== placeholder));
+        }
+      }
+    },
+    [uploadFn],
+  );
+
+  const removeAttachment = useCallback((idx: number) => {
+    setAttachments((prev) => prev.filter((_, i) => i !== idx));
+  }, []);
+
+  const clearAttachments = useCallback(() => setAttachments([]), []);
+
+  const buildMessageText = useCallback(
+    (userInput: string): string => {
+      const parts: string[] = [];
+      for (const a of attachments.filter((a) => a.path)) {
+        parts.push(`[file: ${a.path}]`);
+      }
+      if (userInput.trim()) parts.push(userInput.trim());
+      return parts.join("\n");
+    },
+    [attachments],
+  );
+
+  return {
+    attachments,
+    selectFiles,
+    removeAttachment,
+    clearAttachments,
+    buildMessageText,
+    isUploading: attachments.some((a) => a.uploading),
+  };
+}


### PR DESCRIPTION
## What
Extract the inline chat composer from SessionDetail into a shared `ChatComposer` component with slash command support, compact layout, and a reusable file upload hook.

## Why
The agent and group chat pages need identical input UX. Extracting the composer enables reuse and ensures visual/behavioral consistency. Slash commands let users invoke agent skills directly from the input.

## How
- **`ChatComposer.tsx`** (new): Card-style input with auto-expand textarea, inline send/stop button (bottom-right), file attachment support (drag/drop/paste/paperclip), compact footer with hints. Slash command dropdown with keyboard navigation (↑↓ Enter/Tab Escape), selected skills shown as removable chips above textarea.
- **`useFileAttachments.ts`** (new): Reusable hook managing attachment state — upload tracking, remove, clear, and `buildMessageText` to prepend `[file: path]` refs.
- **`SessionDetail.tsx`** (refactored): Replaced ~200 lines of inline composer + file upload code with `<ChatComposer />` + `useFileAttachments()`.

## Test plan
- [x] Agent chat: send messages, verify input auto-expands, Enter sends, Shift+Enter newlines
- [ ] Agent chat: attach files via paperclip/drag/paste, verify chips appear, send with attachment
- [ ] Agent chat: type `/` to open skill dropdown, arrow keys to navigate, Enter to select, Escape to dismiss
- [ ] Agent chat: verify selected skill chip appears, can be removed with ×, message sends with skill prefix
- [ ] Agent chat: stop button works during streaming
- [ ] Verify no visual regression in existing agent chat layout