### PR TITLE
Fix reflect review context overflow

### DIFF
--- a/internal/memory/lcm/review.go
+++ b/internal/memory/lcm/review.go
@@ -12,7 +12,7 @@ import (
 	"github.com/CherryHQ/stella/pkg/db/sqlc"
 )
 
-const maxReviewMessages = 200
+const maxReviewTokens = 100_000
 
 // BuildReviewContext implements memory.Reviewer.
 func (p *Provider) BuildReviewContext(ctx context.Context, session memory.Session, since time.Time) (string, error) {
@@ -31,7 +31,6 @@ func (p *Provider) BuildReviewContext(ctx context.Context, session memory.Sessio
 	var b strings.Builder
 
 	if !since.IsZero() {
-		// Include summaries as prior context.
 		summaries, err := p.q.GetSummariesByConversation(ctx, conv.ID)
 		if err == nil && len(summaries) > 0 {
 			b.WriteString("<prior_context>\n")
@@ -42,7 +41,6 @@ func (p *Provider) BuildReviewContext(ctx context.Context, session memory.Sessio
 			b.WriteString("</prior_context>\n\n")
 		}
 
-		// Only include messages since the watermark.
 		msgs, err := p.q.GetMessagesSince(ctx, sqlc.GetMessagesSinceParams{
 			ConversationID: conv.ID,
 			CreatedAt:      since.UTC().Format("2006-01-02 15:04:05"),
@@ -52,7 +50,6 @@ func (p *Provider) BuildReviewContext(ctx context.Context, session memory.Sessio
 		}
 		appendReviewMessages(&b, msgs)
 	} else {
-		// Include all messages.
 		msgs, err := p.q.GetMessagesByConversation(ctx, conv.ID)
 		if err != nil {
 			return "", fmt.Errorf("get messages: %w", err)
@@ -64,13 +61,30 @@ func (p *Provider) BuildReviewContext(ctx context.Context, session memory.Sessio
 }
 
 func appendReviewMessages(b *strings.Builder, msgs []sqlc.CtxMessage) {
-	if len(msgs) == 0 {
+	// Filter out tool results — they're large and useless for the reviewer.
+	filtered := make([]sqlc.CtxMessage, 0, len(msgs))
+	for _, m := range msgs {
+		if m.Role != roleTool {
+			filtered = append(filtered, m)
+		}
+	}
+	if len(filtered) == 0 {
 		return
 	}
-	if len(msgs) > maxReviewMessages {
-		msgs = msgs[len(msgs)-maxReviewMessages:]
+
+	// Take the tail that fits within the token budget.
+	budget := maxReviewTokens
+	start := len(filtered)
+	for i := len(filtered) - 1; i >= 0; i-- {
+		cost := memory.EstimateTokens(filtered[i].Content) + memory.EstimateTokens(filtered[i].Role) + 4
+		if budget-cost < 0 {
+			break
+		}
+		budget -= cost
+		start = i
 	}
-	for _, m := range msgs {
+
+	for _, m := range filtered[start:] {
 		fmt.Fprintf(b, "[%s] %s\n", m.Role, m.Content)
 	}
 }

--- a/internal/memory/lcm/review_test.go
+++ b/internal/memory/lcm/review_test.go
@@ -1,0 +1,88 @@
+package lcm
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/CherryHQ/stella/pkg/db/sqlc"
+)
+
+func TestAppendReviewMessages_FiltersToolResults(t *testing.T) {
+	msgs := []sqlc.CtxMessage{
+		{Role: "user", Content: "hello"},
+		{Role: "assistant", Content: "hi there"},
+		{Role: roleTool, Content: strings.Repeat("x", 10000)},
+		{Role: "user", Content: "thanks"},
+	}
+
+	var b strings.Builder
+	appendReviewMessages(&b, msgs)
+	got := b.String()
+
+	if strings.Contains(got, "[tool]") {
+		t.Error("tool result should be filtered out")
+	}
+	if !strings.Contains(got, "hello") || !strings.Contains(got, "hi there") || !strings.Contains(got, "thanks") {
+		t.Errorf("expected user/assistant messages preserved, got %q", got)
+	}
+}
+
+func TestAppendReviewMessages_OnlyToolResults(t *testing.T) {
+	msgs := []sqlc.CtxMessage{
+		{Role: roleTool, Content: "result1"},
+		{Role: roleTool, Content: "result2"},
+	}
+
+	var b strings.Builder
+	appendReviewMessages(&b, msgs)
+
+	if b.Len() != 0 {
+		t.Errorf("expected empty output for tool-only messages, got %q", b.String())
+	}
+}
+
+func TestAppendReviewMessages_TokenBudgetTruncation(t *testing.T) {
+	// Each message is ~1000 tokens (4000 chars). With a 100K budget,
+	// only the last ~100 should fit.
+	content := strings.Repeat("a", 4000) // ~1000 tokens
+	msgs := make([]sqlc.CtxMessage, 200)
+	for i := range msgs {
+		msgs[i] = sqlc.CtxMessage{Role: "user", Content: content}
+	}
+
+	var b strings.Builder
+	appendReviewMessages(&b, msgs)
+	got := b.String()
+
+	lines := strings.Split(strings.TrimSpace(got), "\n")
+	if len(lines) >= 200 {
+		t.Errorf("expected token budget to truncate messages, got %d lines", len(lines))
+	}
+	if len(lines) == 0 {
+		t.Error("expected at least some messages in output")
+	}
+}
+
+func TestAppendReviewMessages_KeepsTailNotHead(t *testing.T) {
+	msgs := []sqlc.CtxMessage{
+		{Role: "user", Content: strings.Repeat("old ", 25000)},
+		{Role: "user", Content: "recent message"},
+	}
+
+	var b strings.Builder
+	appendReviewMessages(&b, msgs)
+	got := b.String()
+
+	if !strings.Contains(got, "recent message") {
+		t.Error("expected recent (tail) messages to be preserved")
+	}
+}
+
+func TestAppendReviewMessages_Empty(t *testing.T) {
+	var b strings.Builder
+	appendReviewMessages(&b, nil)
+
+	if b.Len() != 0 {
+		t.Errorf("expected empty output for nil messages, got %q", b.String())
+	}
+}

--- a/internal/reflect/contextbuilder.go
+++ b/internal/reflect/contextbuilder.go
@@ -9,7 +9,7 @@ import (
 	"github.com/CherryHQ/stella/internal/memory"
 )
 
-const maxFallbackMessages = 200
+const maxFallbackReviewTokens = 100_000
 
 // buildReviewContext formats conversation history for the reviewer.
 // Prefers the memory plugin's Reviewer.BuildReviewContext if available.
@@ -35,11 +35,12 @@ func (s *Service) buildReviewContext(ctx context.Context, sess memory.Session, s
 		return "", nil
 	}
 
-	// Split into prior context and fresh content.
-	// When timestamps are zero (provider doesn't track them), treat messages
-	// as fresh to avoid classifying everything as prior and returning empty.
+	// Split into prior context and fresh content, skipping tool results.
 	var prior, fresh []string
 	for _, m := range msgs {
+		if memory.MessageRole(m) == "tool" {
+			continue
+		}
 		line := fmt.Sprintf("[%s] %s", memory.MessageRole(m), memory.MessageText(m))
 		ts := memory.MessageTimestamp(m)
 		if !since.IsZero() && !ts.IsZero() && !ts.After(since) {
@@ -55,18 +56,16 @@ func (s *Service) buildReviewContext(ctx context.Context, sess memory.Session, s
 
 	var b strings.Builder
 
-	// Include truncated prior context.
 	if len(prior) > 0 {
 		b.WriteString("<prior_context>\n")
-		for _, line := range tailLines(prior, maxFallbackMessages) {
+		for _, line := range tailByBudget(prior, maxFallbackReviewTokens/4) {
 			b.WriteString(line)
 			b.WriteString("\n")
 		}
 		b.WriteString("</prior_context>\n\n")
 	}
 
-	// Write fresh messages verbatim.
-	for _, line := range tailLines(fresh, maxFallbackMessages) {
+	for _, line := range tailByBudget(fresh, maxFallbackReviewTokens) {
 		b.WriteString(line)
 		b.WriteString("\n")
 	}
@@ -74,9 +73,17 @@ func (s *Service) buildReviewContext(ctx context.Context, sess memory.Session, s
 	return b.String(), nil
 }
 
-func tailLines(lines []string, max int) []string {
-	if len(lines) <= max {
-		return lines
+// tailByBudget returns the longest suffix of lines that fits within the token budget.
+func tailByBudget(lines []string, budget int) []string {
+	remaining := budget
+	start := len(lines)
+	for i := len(lines) - 1; i >= 0; i-- {
+		cost := memory.EstimateTokens(lines[i])
+		if remaining-cost < 0 {
+			break
+		}
+		remaining -= cost
+		start = i
 	}
-	return lines[len(lines)-max:]
+	return lines[start:]
 }

--- a/internal/reflect/contextbuilder_test.go
+++ b/internal/reflect/contextbuilder_test.go
@@ -121,6 +121,76 @@ func TestBuildReviewContext_EmptySession(t *testing.T) {
 	}
 }
 
+func TestBuildReviewContext_FallbackFiltersToolResults(t *testing.T) {
+	fake := memorytest.New()
+	svc := &Service{memory: &nonReviewerProvider{fake}, log: testLogger()}
+
+	ctx := context.Background()
+	sess := memory.Session{ID: "s1", AgentID: "a", UserID: "1"}
+	if err := fake.Bootstrap(ctx, sess); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC()
+	if err := fake.Append(ctx, sess,
+		ai.UserMessage{Content: "request", Timestamp: now},
+		ai.AssistantMessage{
+			Content: []ai.ContentBlock{
+				ai.ToolCall{ID: "tc1", Name: "bash", Arguments: map[string]any{"command": "ls"}},
+			},
+			StopReason: ai.StopReasonToolUse,
+			Timestamp:  now.Add(time.Second),
+		},
+		ai.ToolResultMessage{
+			ToolCallID: "tc1",
+			Content:    []ai.ContentBlock{ai.TextContent{Text: strings.Repeat("x", 10000)}},
+			Timestamp:  now.Add(2 * time.Second),
+		},
+		ai.UserMessage{Content: "thanks", Timestamp: now.Add(3 * time.Second)},
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	text, err := svc.buildReviewContext(ctx, sess, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(text, "[tool]") {
+		t.Error("tool result should be filtered out in fallback path")
+	}
+	if !strings.Contains(text, "request") || !strings.Contains(text, "thanks") {
+		t.Errorf("expected user messages preserved, got %q", text)
+	}
+}
+
+func TestTailByBudget_FitsAll(t *testing.T) {
+	lines := []string{"short", "lines", "here"}
+	got := tailByBudget(lines, 10000)
+	if len(got) != 3 {
+		t.Errorf("expected all 3 lines, got %d", len(got))
+	}
+}
+
+func TestTailByBudget_Truncates(t *testing.T) {
+	big := strings.Repeat("x", 4000) // ~1000 tokens
+	lines := []string{big, big, big, "last"}
+	got := tailByBudget(lines, 1500)
+	// Budget 1500 tokens: "last" (~1 token) + one big (~1000) fits, two bigs don't.
+	if len(got) > 2 {
+		t.Errorf("expected at most 2 lines within budget, got %d", len(got))
+	}
+	if len(got) == 0 || got[len(got)-1] != "last" {
+		t.Error("expected tail to include the last element")
+	}
+}
+
+func TestTailByBudget_Empty(t *testing.T) {
+	got := tailByBudget(nil, 10000)
+	if len(got) != 0 {
+		t.Errorf("expected empty result, got %d", len(got))
+	}
+}
+
 // nonReviewerProvider wraps a Fake but hides the Reviewer interface.
 // This forces buildReviewContext to use the SessionManager fallback path.
 type nonReviewerProvider struct {


### PR DESCRIPTION
## What

Fix reflect review agent failing with "prompt too long" (668K tokens vs 262K model limit).

## Why

The review context builder was including tool result messages and only limiting by message count (200), not token size. Long conversations with large tool results (code output, API responses) easily exceeded the model's context window.

## How

- **Filter tool results**: Skip `role="tool"` messages in both the LCM primary path (`appendReviewMessages`) and the fallback path (`buildReviewContext`). Tool results are large and irrelevant for extracting skills/knowledge/memory.
- **Token budget**: Replace the 200-message count limit with a 100K token budget using `EstimateTokens`, matching the approach used by the summary/compaction engine. Messages are taken from the tail (most recent first) until the budget is exhausted.
- Both the LCM path (`internal/memory/lcm/review.go`) and the fallback path (`internal/reflect/contextbuilder.go`) are updated.

## Refs

- Closes #297

## Test plan

- [x] `mise run build` passes
- [x] `mise run test` passes (all existing tests green)
- [x] Unit tests for tool filtering, token budget truncation, tail preservation
- [x] Verify on a session with large tool results that the review agent no longer errors