### PR TITLE
Binary split follow-ups: upgrade hardening, email API migration, service path security

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+        stages: [pre-commit]
       - id: post-checkout-build
         name: mise trust and build after branch switch
         entry: ./scripts/post-checkout.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     hooks:
       - id: mise-format
         name: mise run format
-        entry: mise run format
+        entry: sh -c 'if [ "$PRE_COMMIT_HOOK_STAGE" = "post-checkout" ]; then exit 0; fi; mise run format'
         language: system
         pass_filenames: false
         always_run: true

--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -477,6 +477,112 @@ components:
           type: string
         baseurl:
           type: string
+    EmailFolderList:
+      type: object
+      required: [folders]
+      properties:
+        folders:
+          type: array
+          items:
+            type: string
+    EmailEnvelope:
+      type: object
+      required: [uid, from, subject, date]
+      properties:
+        uid:
+          type: integer
+        message_id:
+          type: string
+        from:
+          type: string
+        from_name:
+          type: string
+        from_addr:
+          type: string
+        to:
+          type: array
+          items:
+            type: string
+        subject:
+          type: string
+        date:
+          type: string
+          format: date-time
+        flags:
+          type: array
+          items:
+            type: string
+        has_attachments:
+          type: boolean
+        size:
+          type: integer
+    EmailEnvelopeList:
+      type: object
+      required: [messages]
+      properties:
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/EmailEnvelope"
+    EmailMessage:
+      allOf:
+        - $ref: "#/components/schemas/EmailEnvelope"
+        - type: object
+          properties:
+            text_body: { type: string }
+            html_body: { type: string }
+            attachments:
+              type: array
+              items: { $ref: "#/components/schemas/EmailAttachmentInfo" }
+    EmailAttachmentInfo:
+      type: object
+      properties:
+        filename:
+          type: string
+        size:
+          type: integer
+        mime_type:
+          type: string
+    EmailSendRequest:
+      type: object
+      required: [to, subject, body]
+      properties:
+        to:
+          type: array
+          items:
+            type: string
+        cc:
+          type: array
+          items:
+            type: string
+        bcc:
+          type: array
+          items:
+            type: string
+        subject:
+          type: string
+        body:
+          type: string
+        html:
+          type: boolean
+        from:
+          type: string
+        reply_to:
+          type: string
+        in_reply_to:
+          type: string
+    EmailSendResult:
+      type: object
+      required: [sent]
+      properties:
+        sent:
+          type: boolean
+    EmailMarkRequest:
+      type: object
+      required: [seen]
+      properties:
+        seen:
+          type: boolean
     Goal:
       type: object
       required: [

--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -549,20 +549,26 @@ components:
       properties:
         to:
           type: array
+          minItems: 1
           items:
             type: string
+            minLength: 1
         cc:
           type: array
           items:
             type: string
+            minLength: 1
         bcc:
           type: array
           items:
             type: string
+            minLength: 1
         subject:
           type: string
+          minLength: 1
         body:
           type: string
+          minLength: 1
         html:
           type: boolean
         from:

--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -577,12 +577,6 @@ components:
           type: string
         in_reply_to:
           type: string
-    EmailSendResult:
-      type: object
-      required: [sent]
-      properties:
-        sent:
-          type: boolean
     EmailMarkRequest:
       type: object
       required: [seen]

--- a/api/spec/domain/email/paths.yaml
+++ b/api/spec/domain/email/paths.yaml
@@ -43,7 +43,7 @@ paths:
             name: limit,
             in: query,
             required: false,
-            schema: { type: integer, default: 20 },
+            schema: { type: integer, default: 20, minimum: 1, maximum: 500 },
           }
         - {
             name: unread,
@@ -78,13 +78,21 @@ paths:
               schema: {
                 $ref: "../../components.yaml#/components/schemas/EmailEnvelopeList",
               }
+        "400": {
+          $ref: "../../components.yaml#/components/responses/BadRequest",
+        }
         "401": {
           $ref: "../../components.yaml#/components/responses/Unauthorized",
         }
 
   /api/email/messages/{uid}:
     parameters:
-      - { name: uid, in: path, required: true, schema: { type: integer } }
+      - {
+          name: uid,
+          in: path,
+          required: true,
+          schema: { type: integer, minimum: 1, maximum: 4294967295 },
+        }
     get:
       tags: [email]
       summary: Read an email message
@@ -110,8 +118,14 @@ paths:
               schema: {
                 $ref: "../../components.yaml#/components/schemas/EmailMessage",
               }
+        "400": {
+          $ref: "../../components.yaml#/components/responses/BadRequest",
+        }
         "401": {
           $ref: "../../components.yaml#/components/responses/Unauthorized",
+        }
+        "404": {
+          $ref: "../../components.yaml#/components/responses/NotFound",
         }
 
   /api/email/send:
@@ -141,13 +155,21 @@ paths:
               schema: {
                 $ref: "../../components.yaml#/components/schemas/EmailSendResult",
               }
+        "400": {
+          $ref: "../../components.yaml#/components/responses/BadRequest",
+        }
         "401": {
           $ref: "../../components.yaml#/components/responses/Unauthorized",
         }
 
   /api/email/messages/{uid}/mark:
     parameters:
-      - { name: uid, in: path, required: true, schema: { type: integer } }
+      - {
+          name: uid,
+          in: path,
+          required: true,
+          schema: { type: integer, minimum: 1, maximum: 4294967295 },
+        }
     post:
       tags: [email]
       summary: Mark an email message as read or unread
@@ -175,6 +197,12 @@ paths:
       responses:
         "204":
           description: marked
+        "400": {
+          $ref: "../../components.yaml#/components/responses/BadRequest",
+        }
         "401": {
           $ref: "../../components.yaml#/components/responses/Unauthorized",
+        }
+        "404": {
+          $ref: "../../components.yaml#/components/responses/NotFound",
         }

--- a/api/spec/domain/email/paths.yaml
+++ b/api/spec/domain/email/paths.yaml
@@ -148,13 +148,8 @@ paths:
               $ref: "../../components.yaml#/components/schemas/EmailSendRequest",
             }
       responses:
-        "200":
+        "204":
           description: sent
-          content:
-            application/json:
-              schema: {
-                $ref: "../../components.yaml#/components/schemas/EmailSendResult",
-              }
         "400": {
           $ref: "../../components.yaml#/components/responses/BadRequest",
         }

--- a/api/spec/domain/email/paths.yaml
+++ b/api/spec/domain/email/paths.yaml
@@ -1,0 +1,180 @@
+paths:
+  /api/email/folders:
+    get:
+      tags: [email]
+      summary: List email folders
+      operationId: listEmailFolders
+      parameters:
+        - name: account
+          in: query
+          required: false
+          schema: { type: string }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: {
+                $ref: "../../components.yaml#/components/schemas/EmailFolderList",
+              }
+        "401": {
+          $ref: "../../components.yaml#/components/responses/Unauthorized",
+        }
+
+  /api/email/messages:
+    get:
+      tags: [email]
+      summary: List email messages
+      operationId: listEmailMessages
+      parameters:
+        - {
+            name: account,
+            in: query,
+            required: false,
+            schema: { type: string },
+          }
+        - {
+            name: folder,
+            in: query,
+            required: false,
+            schema: { type: string, default: "INBOX" },
+          }
+        - {
+            name: limit,
+            in: query,
+            required: false,
+            schema: { type: integer, default: 20 },
+          }
+        - {
+            name: unread,
+            in: query,
+            required: false,
+            schema: { type: boolean },
+          }
+        - { name: from, in: query, required: false, schema: { type: string } }
+        - {
+            name: subject,
+            in: query,
+            required: false,
+            schema: { type: string },
+          }
+        - {
+            name: since,
+            in: query,
+            required: false,
+            schema: { type: string, format: date },
+          }
+        - {
+            name: before,
+            in: query,
+            required: false,
+            schema: { type: string, format: date },
+          }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: {
+                $ref: "../../components.yaml#/components/schemas/EmailEnvelopeList",
+              }
+        "401": {
+          $ref: "../../components.yaml#/components/responses/Unauthorized",
+        }
+
+  /api/email/messages/{uid}:
+    parameters:
+      - { name: uid, in: path, required: true, schema: { type: integer } }
+    get:
+      tags: [email]
+      summary: Read an email message
+      operationId: getEmailMessage
+      parameters:
+        - {
+            name: account,
+            in: query,
+            required: false,
+            schema: { type: string },
+          }
+        - {
+            name: folder,
+            in: query,
+            required: false,
+            schema: { type: string, default: "INBOX" },
+          }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: {
+                $ref: "../../components.yaml#/components/schemas/EmailMessage",
+              }
+        "401": {
+          $ref: "../../components.yaml#/components/responses/Unauthorized",
+        }
+
+  /api/email/send:
+    post:
+      tags: [email]
+      summary: Send an email
+      operationId: sendEmail
+      parameters:
+        - {
+            name: account,
+            in: query,
+            required: false,
+            schema: { type: string },
+          }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {
+              $ref: "../../components.yaml#/components/schemas/EmailSendRequest",
+            }
+      responses:
+        "200":
+          description: sent
+          content:
+            application/json:
+              schema: {
+                $ref: "../../components.yaml#/components/schemas/EmailSendResult",
+              }
+        "401": {
+          $ref: "../../components.yaml#/components/responses/Unauthorized",
+        }
+
+  /api/email/messages/{uid}/mark:
+    parameters:
+      - { name: uid, in: path, required: true, schema: { type: integer } }
+    post:
+      tags: [email]
+      summary: Mark an email message as read or unread
+      operationId: markEmailMessage
+      parameters:
+        - {
+            name: account,
+            in: query,
+            required: false,
+            schema: { type: string },
+          }
+        - {
+            name: folder,
+            in: query,
+            required: false,
+            schema: { type: string, default: "INBOX" },
+          }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {
+              $ref: "../../components.yaml#/components/schemas/EmailMarkRequest",
+            }
+      responses:
+        "204":
+          description: marked
+        "401": {
+          $ref: "../../components.yaml#/components/responses/Unauthorized",
+        }

--- a/api/spec/domain/email/schemas.yaml
+++ b/api/spec/domain/email/schemas.yaml
@@ -67,12 +67,6 @@ components:
         reply_to: { type: string }
         in_reply_to: { type: string }
 
-    EmailSendResult:
-      type: object
-      required: [sent]
-      properties:
-        sent: { type: boolean }
-
     EmailMarkRequest:
       type: object
       required: [seen]

--- a/api/spec/domain/email/schemas.yaml
+++ b/api/spec/domain/email/schemas.yaml
@@ -57,11 +57,11 @@ components:
       type: object
       required: [to, subject, body]
       properties:
-        to: { type: array, items: { type: string } }
-        cc: { type: array, items: { type: string } }
-        bcc: { type: array, items: { type: string } }
-        subject: { type: string }
-        body: { type: string }
+        to: { type: array, minItems: 1, items: { type: string, minLength: 1 } }
+        cc: { type: array, items: { type: string, minLength: 1 } }
+        bcc: { type: array, items: { type: string, minLength: 1 } }
+        subject: { type: string, minLength: 1 }
+        body: { type: string, minLength: 1 }
         html: { type: boolean }
         from: { type: string }
         reply_to: { type: string }

--- a/api/spec/domain/email/schemas.yaml
+++ b/api/spec/domain/email/schemas.yaml
@@ -1,0 +1,80 @@
+openapi: 3.0.3
+info:
+  title: Email Components
+  version: "1"
+paths: {}
+components:
+  schemas:
+    EmailFolderList:
+      type: object
+      required: [folders]
+      properties:
+        folders: { type: array, items: { type: string } }
+
+    EmailEnvelope:
+      type: object
+      required: [uid, from, subject, date]
+      properties:
+        uid: { type: integer }
+        message_id: { type: string }
+        from: { type: string }
+        from_name: { type: string }
+        from_addr: { type: string }
+        to: { type: array, items: { type: string } }
+        subject: { type: string }
+        date: { type: string, format: date-time }
+        flags: { type: array, items: { type: string } }
+        has_attachments: { type: boolean }
+        size: { type: integer }
+
+    EmailEnvelopeList:
+      type: object
+      required: [messages]
+      properties:
+        messages:
+          type: array
+          items: { $ref: "#/components/schemas/EmailEnvelope" }
+
+    EmailMessage:
+      allOf:
+        - $ref: "#/components/schemas/EmailEnvelope"
+        - type: object
+          properties:
+            text_body: { type: string }
+            html_body: { type: string }
+            attachments:
+              type: array
+              items: { $ref: "#/components/schemas/EmailAttachmentInfo" }
+
+    EmailAttachmentInfo:
+      type: object
+      properties:
+        filename: { type: string }
+        size: { type: integer }
+        mime_type: { type: string }
+
+    EmailSendRequest:
+      type: object
+      required: [to, subject, body]
+      properties:
+        to: { type: array, items: { type: string } }
+        cc: { type: array, items: { type: string } }
+        bcc: { type: array, items: { type: string } }
+        subject: { type: string }
+        body: { type: string }
+        html: { type: boolean }
+        from: { type: string }
+        reply_to: { type: string }
+        in_reply_to: { type: string }
+
+    EmailSendResult:
+      type: object
+      required: [sent]
+      properties:
+        sent: { type: boolean }
+
+    EmailMarkRequest:
+      type: object
+      required: [seen]
+      properties:
+        seen: { type: boolean }

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -30,6 +30,7 @@ servers:
 security:
   - BearerAuth: []
 tags:
+  - name: email
   - name: articles
   - name: feeds
   - name: feed-entries
@@ -243,6 +244,17 @@ paths:
   # ── Admin: OAuth provider config ───────────────────────────────────────────
   /api/admin/oauth-providers/{id}/config:
     $ref: "./domain/profile/paths.yaml#/paths/~1api~1admin~1oauth-providers~1{id}~1config"
+  # ── Email ───────────────────────────────────────────────────────────────────
+  /api/email/folders:
+    $ref: "./domain/email/paths.yaml#/paths/~1api~1email~1folders"
+  /api/email/messages:
+    $ref: "./domain/email/paths.yaml#/paths/~1api~1email~1messages"
+  /api/email/messages/{uid}:
+    $ref: "./domain/email/paths.yaml#/paths/~1api~1email~1messages~1{uid}"
+  /api/email/send:
+    $ref: "./domain/email/paths.yaml#/paths/~1api~1email~1send"
+  /api/email/messages/{uid}/mark:
+    $ref: "./domain/email/paths.yaml#/paths/~1api~1email~1messages~1{uid}~1mark"
   # ── Scheduler ──────────────────────────────────────────────────────────────
   /api/agents/{agentId}/scheduler/jobs:
     $ref: "./domain/scheduler/paths.yaml#/paths/~1api~1agents~1{agentId}~1scheduler~1jobs"
@@ -608,4 +620,28 @@ components:
     }
     ChangelogList: {
       $ref: "./components.yaml#/components/schemas/ChangelogList",
+    }
+    EmailFolderList: {
+      $ref: "./components.yaml#/components/schemas/EmailFolderList",
+    }
+    EmailEnvelope: {
+      $ref: "./components.yaml#/components/schemas/EmailEnvelope",
+    }
+    EmailEnvelopeList: {
+      $ref: "./components.yaml#/components/schemas/EmailEnvelopeList",
+    }
+    EmailMessage: {
+      $ref: "./components.yaml#/components/schemas/EmailMessage",
+    }
+    EmailAttachmentInfo: {
+      $ref: "./components.yaml#/components/schemas/EmailAttachmentInfo",
+    }
+    EmailSendRequest: {
+      $ref: "./components.yaml#/components/schemas/EmailSendRequest",
+    }
+    EmailSendResult: {
+      $ref: "./components.yaml#/components/schemas/EmailSendResult",
+    }
+    EmailMarkRequest: {
+      $ref: "./components.yaml#/components/schemas/EmailMarkRequest",
     }

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -639,9 +639,6 @@ components:
     EmailSendRequest: {
       $ref: "./components.yaml#/components/schemas/EmailSendRequest",
     }
-    EmailSendResult: {
-      $ref: "./components.yaml#/components/schemas/EmailSendResult",
-    }
     EmailMarkRequest: {
       $ref: "./components.yaml#/components/schemas/EmailMarkRequest",
     }

--- a/cmd/stella/email.go
+++ b/cmd/stella/email.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -529,7 +530,7 @@ func emailReadCommand() *ucli.Command {
 			&ucli.StringFlag{Name: "account", Aliases: []string{"a"}, Usage: "Account name (uses default if not set)"},
 			&ucli.StringFlag{Name: "folder", Usage: "Folder name", Value: "INBOX"},
 			&ucli.BoolFlag{Name: "raw", Usage: "Print full raw message"},
-			&ucli.StringFlag{Name: "save-attachments", Usage: "Directory to save attachments"},
+			&ucli.StringFlag{Name: "save-attachments", Usage: "Directory to save attachments (connects to IMAP directly from this host, not through the daemon; requires local network access to the mail server)"},
 			&ucli.BoolFlag{Name: "json", Usage: "Output as JSON"},
 		},
 		Action: func(c *ucli.Context) error {
@@ -543,6 +544,10 @@ func emailReadCommand() *ucli.Command {
 			}
 
 			if dir := c.String("save-attachments"); dir != "" {
+				// Attachment download is not exposed over the daemon API yet, so
+				// this path talks IMAP directly. It only works when the CLI host
+				// can reach the mail server; a remote CLI pointed at a remote
+				// daemon will fail here. See the flag help for the caveat.
 				cfg, err := loadEmailConfig(c.Context)
 				if err != nil {
 					return err
@@ -625,7 +630,7 @@ func emailSendCommand() *ucli.Command {
 			&ucli.StringFlag{Name: "body", Aliases: []string{"b"}, Usage: "Message body"},
 			&ucli.StringFlag{Name: "body-file", Aliases: []string{"f"}, Usage: "File containing message body"},
 			&ucli.BoolFlag{Name: "html", Usage: "Send as HTML"},
-			&ucli.StringSliceFlag{Name: "attach", Usage: "Attachment file path(s)"},
+			&ucli.StringSliceFlag{Name: "attach", Usage: "Attachment file path(s) (sent via direct SMTP from this host, not through the daemon; requires local network access to the mail server)"},
 			&ucli.StringFlag{Name: "from", Usage: "Override From address"},
 			&ucli.StringFlag{Name: "reply-to", Usage: "Reply-To address"},
 			&ucli.StringFlag{Name: "in-reply-to", Usage: "Message-ID of the message being replied to (sets In-Reply-To header)"},
@@ -717,6 +722,10 @@ func emailSendCommand() *ucli.Command {
 			}
 
 			if len(opts.Attachments) > 0 {
+				// Attachments are not supported over the daemon API yet, so this
+				// path sends via direct SMTP from the CLI host. It only works
+				// when the CLI can reach the mail server; a remote CLI pointed at
+				// a remote daemon will fail here. See the flag help for the caveat.
 				cfg, err := loadEmailConfig(c.Context)
 				if err != nil {
 					return err
@@ -800,8 +809,8 @@ func emailMarkCommand() *ucli.Command {
 }
 
 func parseEmailUID(value string) (int, uint32, error) {
-	var uid int64
-	if _, err := fmt.Sscan(value, &uid); err != nil {
+	uid, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
 		return 0, 0, fmt.Errorf("invalid uid %q: %w", value, err)
 	}
 	const maxIMAPUID = int64(^uint32(0))

--- a/cmd/stella/email.go
+++ b/cmd/stella/email.go
@@ -537,13 +537,28 @@ func emailReadCommand() *ucli.Command {
 			if uidStr == "" {
 				return fmt.Errorf("uid is required")
 			}
-			var uid int
-			if _, err := fmt.Sscan(uidStr, &uid); err != nil {
-				return fmt.Errorf("invalid uid %q: %w", uidStr, err)
+			uid, imapUID, err := parseEmailUID(uidStr)
+			if err != nil {
+				return err
 			}
 
-			if c.String("save-attachments") != "" {
-				return fmt.Errorf("--save-attachments is not yet supported via the API")
+			if dir := c.String("save-attachments"); dir != "" {
+				cfg, err := loadEmailConfig(c.Context)
+				if err != nil {
+					return err
+				}
+				acct, err := cfg.Resolve(c.String("account"))
+				if err != nil {
+					return err
+				}
+				paths, err := email.SaveAttachments(acct, c.String("folder"), imapUID, dir)
+				if err != nil {
+					return err
+				}
+				for _, p := range paths {
+					fmt.Println(p)
+				}
+				return nil
 			}
 
 			msg, err := apiclient.Call[apiclient.EmailMessage](func(api *apiclient.Client) (*http.Response, error) {
@@ -618,10 +633,6 @@ func emailSendCommand() *ucli.Command {
 			cli.JSONFlag(),
 		},
 		Action: func(c *ucli.Context) error {
-			if len(c.StringSlice("attach")) > 0 {
-				return fmt.Errorf("--attach is not yet supported via the API")
-			}
-
 			// Resolve body.
 			var body string
 			switch {
@@ -645,15 +656,16 @@ func emailSendCommand() *ucli.Command {
 			}
 
 			opts := email.SendOptions{
-				To:        c.StringSlice("to"),
-				Cc:        c.StringSlice("cc"),
-				Bcc:       c.StringSlice("bcc"),
-				Subject:   c.String("subject"),
-				Body:      body,
-				HTML:      c.Bool("html"),
-				From:      c.String("from"),
-				ReplyTo:   c.String("reply-to"),
-				InReplyTo: c.String("in-reply-to"),
+				To:          c.StringSlice("to"),
+				Cc:          c.StringSlice("cc"),
+				Bcc:         c.StringSlice("bcc"),
+				Subject:     c.String("subject"),
+				Body:        body,
+				HTML:        c.Bool("html"),
+				Attachments: c.StringSlice("attach"),
+				From:        c.String("from"),
+				ReplyTo:     c.String("reply-to"),
+				InReplyTo:   c.String("in-reply-to"),
 			}
 
 			if c.Bool("dry-run") {
@@ -704,6 +716,26 @@ func emailSendCommand() *ucli.Command {
 				reqBody.InReplyTo = &opts.InReplyTo
 			}
 
+			if len(opts.Attachments) > 0 {
+				cfg, err := loadEmailConfig(c.Context)
+				if err != nil {
+					return err
+				}
+				acct, err := cfg.Resolve(c.String("account"))
+				if err != nil {
+					return err
+				}
+				if err := email.Send(acct, opts); err != nil {
+					return err
+				}
+				if cli.IsJSON(c) {
+					return cli.PrintJSON(c, map[string]any{"sent": true, "to": opts.To, "subject": opts.Subject})
+				}
+				o := cli.Stdout(c)
+				o.Println("Email sent successfully.")
+				return o.Err()
+			}
+
 			if err := apiclient.Do(func(api *apiclient.Client) (*http.Response, error) {
 				return api.SendEmail(c.Context, &apiclient.SendEmailParams{Account: optStr(c, "account")}, reqBody)
 			}); err != nil {
@@ -736,9 +768,9 @@ func emailMarkCommand() *ucli.Command {
 			if uidStr == "" {
 				return fmt.Errorf("uid is required")
 			}
-			var uid int
-			if _, err := fmt.Sscan(uidStr, &uid); err != nil {
-				return fmt.Errorf("invalid uid %q: %w", uidStr, err)
+			uid, _, err := parseEmailUID(uidStr)
+			if err != nil {
+				return err
 			}
 			if c.Bool("seen") == c.Bool("unseen") {
 				return fmt.Errorf("exactly one of --seen or --unseen is required")
@@ -765,6 +797,18 @@ func emailMarkCommand() *ucli.Command {
 			return o.Err()
 		},
 	}
+}
+
+func parseEmailUID(value string) (int, uint32, error) {
+	var uid int64
+	if _, err := fmt.Sscan(value, &uid); err != nil {
+		return 0, 0, fmt.Errorf("invalid uid %q: %w", value, err)
+	}
+	const maxIMAPUID = int64(^uint32(0))
+	if uid < 1 || uid > maxIMAPUID {
+		return 0, 0, fmt.Errorf("uid must be between 1 and 4294967295")
+	}
+	return int(uid), uint32(uid), nil
 }
 
 // optStr returns a pointer to the CLI flag value if non-empty, else nil.

--- a/cmd/stella/email.go
+++ b/cmd/stella/email.go
@@ -12,6 +12,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	openapi_types "github.com/oapi-codegen/runtime/types"
 	ucli "github.com/urfave/cli/v2"
 	"golang.org/x/term"
 
@@ -420,24 +421,18 @@ func emailFoldersCommand() *ucli.Command {
 			&ucli.BoolFlag{Name: "json", Usage: "Output as JSON"},
 		},
 		Action: func(c *ucli.Context) error {
-			cfg, err := loadEmailConfig(c.Context)
-			if err != nil {
-				return err
-			}
-			acct, err := cfg.Resolve(c.String("account"))
-			if err != nil {
-				return err
-			}
-
-			folders, err := email.Folders(acct)
+			accountPtr := optStr(c, "account")
+			result, err := apiclient.Call[apiclient.EmailFolderList](func(api *apiclient.Client) (*http.Response, error) {
+				return api.ListEmailFolders(c.Context, &apiclient.ListEmailFoldersParams{Account: accountPtr})
+			})
 			if err != nil {
 				return err
 			}
 
 			if c.Bool("json") {
-				return cli.PrintJSON(c, folders)
+				return cli.PrintJSON(c, result.Folders)
 			}
-			for _, f := range folders {
+			for _, f := range result.Folders {
 				fmt.Println(f)
 			}
 			return nil
@@ -461,21 +456,18 @@ func emailListCommand() *ucli.Command {
 			&ucli.BoolFlag{Name: "json", Usage: "Output as JSON"},
 		},
 		Action: func(c *ucli.Context) error {
-			cfg, err := loadEmailConfig(c.Context)
-			if err != nil {
-				return err
+			params := &apiclient.ListEmailMessagesParams{
+				Account: optStr(c, "account"),
+				Folder:  optStr(c, "folder"),
+				From:    optStr(c, "from"),
+				Subject: optStr(c, "subject"),
 			}
-			acct, err := cfg.Resolve(c.String("account"))
-			if err != nil {
-				return err
+			if limit := c.Int("limit"); limit != 0 {
+				params.Limit = &limit
 			}
-
-			opts := email.ListOptions{
-				Folder:  c.String("folder"),
-				Limit:   c.Int("limit"),
-				Unread:  c.Bool("unread"),
-				From:    c.String("from"),
-				Subject: c.String("subject"),
+			if c.Bool("unread") {
+				unread := true
+				params.Unread = &unread
 			}
 
 			if since := c.String("since"); since != "" {
@@ -483,38 +475,44 @@ func emailListCommand() *ucli.Command {
 				if err != nil {
 					return fmt.Errorf("parse --since: %w", err)
 				}
-				opts.Since = &t
+				params.Since = &openapi_types.Date{Time: t}
 			}
 			if before := c.String("before"); before != "" {
 				t, err := time.Parse("2006-01-02", before)
 				if err != nil {
 					return fmt.Errorf("parse --before: %w", err)
 				}
-				opts.Before = &t
+				params.Before = &openapi_types.Date{Time: t}
 			}
 
-			msgs, err := email.List(acct, opts)
+			result, err := apiclient.Call[apiclient.EmailEnvelopeList](func(api *apiclient.Client) (*http.Response, error) {
+				return api.ListEmailMessages(c.Context, params)
+			})
 			if err != nil {
 				return err
 			}
 
 			if c.Bool("json") {
-				return cli.PrintJSON(c, msgs)
+				return cli.PrintJSON(c, result.Messages)
 			}
 
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 			_, _ = fmt.Fprintln(w, "UID\tDATE\tFROM\tSUBJECT\tFLAGS")
-			for _, m := range msgs {
+			for _, m := range result.Messages {
 				subject := m.Subject
 				if len(subject) > 80 {
 					subject = subject[:80]
 				}
+				var flags string
+				if m.Flags != nil {
+					flags = strings.Join(*m.Flags, ",")
+				}
 				_, _ = fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\n",
-					m.UID,
+					m.Uid,
 					m.Date.Format("2006-01-02 15:04"),
 					m.From,
 					subject,
-					strings.Join(m.Flags, ","),
+					flags,
 				)
 			}
 			return w.Flush()
@@ -539,34 +537,21 @@ func emailReadCommand() *ucli.Command {
 			if uidStr == "" {
 				return fmt.Errorf("uid is required")
 			}
-			var uid uint32
+			var uid int
 			if _, err := fmt.Sscan(uidStr, &uid); err != nil {
 				return fmt.Errorf("invalid uid %q: %w", uidStr, err)
 			}
 
-			cfg, err := loadEmailConfig(c.Context)
-			if err != nil {
-				return err
-			}
-			acct, err := cfg.Resolve(c.String("account"))
-			if err != nil {
-				return err
+			if c.String("save-attachments") != "" {
+				return fmt.Errorf("--save-attachments is not yet supported via the API")
 			}
 
-			folder := c.String("folder")
-
-			if dir := c.String("save-attachments"); dir != "" {
-				paths, err := email.SaveAttachments(acct, folder, uid, dir)
-				if err != nil {
-					return err
-				}
-				for _, p := range paths {
-					fmt.Println(p)
-				}
-				return nil
-			}
-
-			msg, err := email.Read(acct, folder, uid)
+			msg, err := apiclient.Call[apiclient.EmailMessage](func(api *apiclient.Client) (*http.Response, error) {
+				return api.GetEmailMessage(c.Context, uid, &apiclient.GetEmailMessageParams{
+					Account: optStr(c, "account"),
+					Folder:  optStr(c, "folder"),
+				})
+			})
 			if err != nil {
 				return err
 			}
@@ -575,31 +560,36 @@ func emailReadCommand() *ucli.Command {
 				return cli.PrintJSON(c, msg)
 			}
 
+			to := derefStrSlice(msg.To)
+			flags := derefStrSlice(msg.Flags)
+			textBody := derefStr(msg.TextBody)
+			htmlBody := derefStr(msg.HtmlBody)
+
 			if c.Bool("raw") {
-				fmt.Printf("UID:     %d\n", msg.UID)
+				fmt.Printf("UID:     %d\n", msg.Uid)
 				fmt.Printf("From:    %s\n", msg.From)
-				fmt.Printf("To:      %s\n", strings.Join(msg.To, ", "))
+				fmt.Printf("To:      %s\n", strings.Join(to, ", "))
 				fmt.Printf("Date:    %s\n", msg.Date.Format(time.RFC1123Z))
 				fmt.Printf("Subject: %s\n", msg.Subject)
-				fmt.Printf("Flags:   %s\n", strings.Join(msg.Flags, ", "))
+				fmt.Printf("Flags:   %s\n", strings.Join(flags, ", "))
 				fmt.Println("---")
-				fmt.Println(msg.TextBody)
-				if msg.HTMLBody != "" {
+				fmt.Println(textBody)
+				if htmlBody != "" {
 					fmt.Println("--- HTML ---")
-					fmt.Println(msg.HTMLBody)
+					fmt.Println(htmlBody)
 				}
 				return nil
 			}
 
 			// Default formatted output.
 			fmt.Printf("From:    %s\n", msg.From)
-			fmt.Printf("To:      %s\n", strings.Join(msg.To, ", "))
+			fmt.Printf("To:      %s\n", strings.Join(to, ", "))
 			fmt.Printf("Date:    %s\n", msg.Date.Format(time.RFC1123Z))
 			fmt.Printf("Subject: %s\n", msg.Subject)
 			fmt.Println()
-			body := msg.TextBody
+			body := textBody
 			if body == "" {
-				body = msg.HTMLBody
+				body = htmlBody
 			}
 			fmt.Println(body)
 			return nil
@@ -628,13 +618,8 @@ func emailSendCommand() *ucli.Command {
 			cli.JSONFlag(),
 		},
 		Action: func(c *ucli.Context) error {
-			cfg, err := loadEmailConfig(c.Context)
-			if err != nil {
-				return err
-			}
-			acct, err := cfg.Resolve(c.String("account"))
-			if err != nil {
-				return err
+			if len(c.StringSlice("attach")) > 0 {
+				return fmt.Errorf("--attach is not yet supported via the API")
 			}
 
 			// Resolve body.
@@ -660,16 +645,15 @@ func emailSendCommand() *ucli.Command {
 			}
 
 			opts := email.SendOptions{
-				To:          c.StringSlice("to"),
-				Cc:          c.StringSlice("cc"),
-				Bcc:         c.StringSlice("bcc"),
-				Subject:     c.String("subject"),
-				Body:        body,
-				HTML:        c.Bool("html"),
-				Attachments: c.StringSlice("attach"),
-				From:        c.String("from"),
-				ReplyTo:     c.String("reply-to"),
-				InReplyTo:   c.String("in-reply-to"),
+				To:        c.StringSlice("to"),
+				Cc:        c.StringSlice("cc"),
+				Bcc:       c.StringSlice("bcc"),
+				Subject:   c.String("subject"),
+				Body:      body,
+				HTML:      c.Bool("html"),
+				From:      c.String("from"),
+				ReplyTo:   c.String("reply-to"),
+				InReplyTo: c.String("in-reply-to"),
 			}
 
 			if c.Bool("dry-run") {
@@ -682,12 +666,47 @@ func emailSendCommand() *ucli.Command {
 						"subject": opts.Subject,
 					})
 				}
+				// Dry-run needs account config for the From address; load from vault.
+				cfg, err := loadEmailConfig(c.Context)
+				if err != nil {
+					return err
+				}
+				acct, err := cfg.Resolve(c.String("account"))
+				if err != nil {
+					return err
+				}
 				o := cli.Stdout(c)
 				o.Println(email.FormatDryRun(acct, opts))
 				return o.Err()
 			}
 
-			if err := email.Send(acct, opts); err != nil {
+			reqBody := apiclient.SendEmailJSONRequestBody{
+				To:      opts.To,
+				Subject: opts.Subject,
+				Body:    opts.Body,
+			}
+			if len(opts.Cc) > 0 {
+				reqBody.Cc = &opts.Cc
+			}
+			if len(opts.Bcc) > 0 {
+				reqBody.Bcc = &opts.Bcc
+			}
+			if opts.HTML {
+				reqBody.Html = &opts.HTML
+			}
+			if opts.From != "" {
+				reqBody.From = &opts.From
+			}
+			if opts.ReplyTo != "" {
+				reqBody.ReplyTo = &opts.ReplyTo
+			}
+			if opts.InReplyTo != "" {
+				reqBody.InReplyTo = &opts.InReplyTo
+			}
+
+			if err := apiclient.Do(func(api *apiclient.Client) (*http.Response, error) {
+				return api.SendEmail(c.Context, &apiclient.SendEmailParams{Account: optStr(c, "account")}, reqBody)
+			}); err != nil {
 				return err
 			}
 			if cli.IsJSON(c) {
@@ -717,7 +736,7 @@ func emailMarkCommand() *ucli.Command {
 			if uidStr == "" {
 				return fmt.Errorf("uid is required")
 			}
-			var uid uint32
+			var uid int
 			if _, err := fmt.Sscan(uidStr, &uid); err != nil {
 				return fmt.Errorf("invalid uid %q: %w", uidStr, err)
 			}
@@ -725,23 +744,20 @@ func emailMarkCommand() *ucli.Command {
 				return fmt.Errorf("exactly one of --seen or --unseen is required")
 			}
 
-			cfg, err := loadEmailConfig(c.Context)
-			if err != nil {
-				return err
-			}
-			acct, err := cfg.Resolve(c.String("account"))
-			if err != nil {
-				return err
-			}
-
-			if err := email.MarkSeen(acct, c.String("folder"), uid, c.Bool("seen")); err != nil {
+			seen := c.Bool("seen")
+			if err := apiclient.Do(func(api *apiclient.Client) (*http.Response, error) {
+				return api.MarkEmailMessage(c.Context, uid, &apiclient.MarkEmailMessageParams{
+					Account: optStr(c, "account"),
+					Folder:  optStr(c, "folder"),
+				}, apiclient.MarkEmailMessageJSONRequestBody{Seen: seen})
+			}); err != nil {
 				return err
 			}
 			if cli.IsJSON(c) {
-				return cli.PrintJSON(c, map[string]any{"uid": uid, "seen": c.Bool("seen")})
+				return cli.PrintJSON(c, map[string]any{"uid": uid, "seen": seen})
 			}
 			o := cli.Stdout(c)
-			if c.Bool("seen") {
+			if seen {
 				o.Printf("Message %d marked as read.\n", uid)
 			} else {
 				o.Printf("Message %d marked as unread.\n", uid)
@@ -749,6 +765,30 @@ func emailMarkCommand() *ucli.Command {
 			return o.Err()
 		},
 	}
+}
+
+// optStr returns a pointer to the CLI flag value if non-empty, else nil.
+func optStr(c *ucli.Context, name string) *string {
+	if v := c.String(name); v != "" {
+		return &v
+	}
+	return nil
+}
+
+// derefStr returns the string pointed to, or "" if nil.
+func derefStr(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}
+
+// derefStrSlice returns the slice pointed to, or nil if the pointer is nil.
+func derefStrSlice(p *[]string) []string {
+	if p == nil {
+		return nil
+	}
+	return *p
 }
 
 // maskConfigPasswords returns a copy of cfg with passwords replaced by "****".

--- a/cmd/stellad/gateway.go
+++ b/cmd/stellad/gateway.go
@@ -74,6 +74,12 @@ func serverAction(c *ucli.Context) error {
 		)
 	}
 
+	// Clean up stale upgrade artifacts (.tmp/.bak/.old) from interrupted upgrades.
+	if installDir, err := resolveUpgradeDir(""); err == nil {
+		warnStaleUpgradeArtifacts(installDir)
+		cleanStaleUpgradeArtifacts(installDir)
+	}
+
 	ctx, cancel := signal.NotifyContext(c.Context, syscall.SIGINT, syscall.SIGTERM)
 
 	startDiagnostics(ctx)

--- a/cmd/stellad/service_darwin.go
+++ b/cmd/stellad/service_darwin.go
@@ -78,6 +78,10 @@ func (m *launchdManager) Install() error {
 		return fmt.Errorf("resolve executable path: %w", err)
 	}
 
+	if info, statErr := os.Stat(bin); statErr == nil && info.Mode()&0o002 != 0 {
+		fmt.Fprintf(os.Stderr, "WARNING: %s is world-writable — consider installing to a protected path\n", bin)
+	}
+
 	plist := strings.ReplaceAll(plistTemplate, "HOME_DIR", home)
 	plist = strings.ReplaceAll(plist, "STELLAD_BIN", bin)
 

--- a/cmd/stellad/service_linux.go
+++ b/cmd/stellad/service_linux.go
@@ -289,10 +289,42 @@ func dotenvHasKey(data []byte, key string) bool {
 }
 
 func checkSystemServiceRuntime(bin string) error {
+	if err := checkBinaryPathSecurity(bin); err != nil {
+		return err
+	}
 	if err := runAsSystemUser("test", "-x", bin); err != nil {
 		return fmt.Errorf("%s cannot execute %s; install stella somewhere world-executable, such as /usr/local/bin/stella: %w", systemUser, bin, err)
 	}
 	return checkBwrapAsSystemUser()
+}
+
+// checkBinaryPathSecurity rejects binaries in user-writable directories.
+// A system service should not execute binaries that non-root users can replace.
+func checkBinaryPathSecurity(bin string) error {
+	for _, path := range []string{bin, filepath.Dir(bin)} {
+		info, err := os.Stat(path)
+		if err != nil {
+			return fmt.Errorf("stat %s: %w", path, err)
+		}
+		mode := info.Mode()
+		if mode&0o002 != 0 {
+			return fmt.Errorf(
+				"%s is world-writable (mode %s) — a non-root user could replace the binary\n"+
+					"  install stellad to a root-owned directory such as /usr/local/bin:\n"+
+					"  sudo cp %s /usr/local/bin/stellad && sudo chmod 755 /usr/local/bin/stellad",
+				path, mode.String(), bin,
+			)
+		}
+		if mode&0o020 != 0 {
+			return fmt.Errorf(
+				"%s is group-writable (mode %s) — members of the owning group could replace the binary\n"+
+					"  install stellad to a root-owned directory such as /usr/local/bin:\n"+
+					"  sudo cp %s /usr/local/bin/stellad && sudo chmod 755 /usr/local/bin/stellad",
+				path, mode.String(), bin,
+			)
+		}
+	}
+	return nil
 }
 
 func checkBwrapAsSystemUser() error {

--- a/cmd/stellad/service_linux.go
+++ b/cmd/stellad/service_linux.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 )
 
 const systemUnitTemplate = `[Unit]
@@ -298,31 +299,74 @@ func checkSystemServiceRuntime(bin string) error {
 	return checkBwrapAsSystemUser()
 }
 
-// checkBinaryPathSecurity rejects binaries in user-writable directories.
-// A system service should not execute binaries that non-root users can replace.
+// checkBinaryPathSecurity rejects binaries outside root-owned, non-user-writable
+// paths. A system service should not execute binaries that non-root users can replace.
 func checkBinaryPathSecurity(bin string) error {
-	for _, path := range []string{bin, filepath.Dir(bin)} {
-		info, err := os.Stat(path)
-		if err != nil {
-			return fmt.Errorf("stat %s: %w", path, err)
+	resolved, err := filepath.EvalSymlinks(bin)
+	if err != nil {
+		return fmt.Errorf("resolve binary path %s: %w", bin, err)
+	}
+
+	seen := map[string]bool{}
+	for _, path := range append(pathChain(bin), pathChain(resolved)...) {
+		if seen[path] {
+			continue
 		}
-		mode := info.Mode()
-		if mode&0o002 != 0 {
-			return fmt.Errorf(
-				"%s is world-writable (mode %s) — a non-root user could replace the binary\n"+
-					"  install stellad to a root-owned directory such as /usr/local/bin:\n"+
-					"  sudo cp %s /usr/local/bin/stellad && sudo chmod 755 /usr/local/bin/stellad",
-				path, mode.String(), bin,
-			)
+		seen[path] = true
+		if err := checkRootOwnedNotWritable(path, bin); err != nil {
+			return err
 		}
-		if mode&0o020 != 0 {
-			return fmt.Errorf(
-				"%s is group-writable (mode %s) — members of the owning group could replace the binary\n"+
-					"  install stellad to a root-owned directory such as /usr/local/bin:\n"+
-					"  sudo cp %s /usr/local/bin/stellad && sudo chmod 755 /usr/local/bin/stellad",
-				path, mode.String(), bin,
-			)
+	}
+	return nil
+}
+
+func pathChain(path string) []string {
+	clean := filepath.Clean(path)
+	paths := []string{clean}
+	for {
+		parent := filepath.Dir(clean)
+		if parent == clean {
+			break
 		}
+		paths = append(paths, parent)
+		clean = parent
+	}
+	return paths
+}
+
+func checkRootOwnedNotWritable(path, bin string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", path, err)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("stat %s: unsupported file info", path)
+	}
+	if stat.Uid != 0 {
+		return fmt.Errorf(
+			"%s is owned by uid %d — a system service must execute a root-owned binary path\n"+
+				"  install stellad to a root-owned directory such as /usr/local/bin:\n"+
+				"  sudo cp %s /usr/local/bin/stellad && sudo chmod 755 /usr/local/bin/stellad",
+			path, stat.Uid, bin,
+		)
+	}
+	mode := info.Mode()
+	if mode&0o002 != 0 {
+		return fmt.Errorf(
+			"%s is world-writable (mode %s) — a non-root user could replace the binary\n"+
+				"  install stellad to a root-owned directory such as /usr/local/bin:\n"+
+				"  sudo cp %s /usr/local/bin/stellad && sudo chmod 755 /usr/local/bin/stellad",
+			path, mode.String(), bin,
+		)
+	}
+	if mode&0o020 != 0 {
+		return fmt.Errorf(
+			"%s is group-writable (mode %s) — members of the owning group could replace the binary\n"+
+				"  install stellad to a root-owned directory such as /usr/local/bin:\n"+
+				"  sudo cp %s /usr/local/bin/stellad && sudo chmod 755 /usr/local/bin/stellad",
+			path, mode.String(), bin,
+		)
 	}
 	return nil
 }

--- a/cmd/stellad/service_linux_test.go
+++ b/cmd/stellad/service_linux_test.go
@@ -1,0 +1,30 @@
+//go:build linux
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCheckBinaryPathSecurityRejectsUserOwnedBinary(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root-owned temp files do not exercise user-owned rejection")
+	}
+
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "stellad")
+	if err := os.WriteFile(bin, []byte("fake"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := checkBinaryPathSecurity(bin)
+	if err == nil {
+		t.Fatal("expected user-owned binary path to be rejected")
+	}
+	if !strings.Contains(err.Error(), "root-owned") {
+		t.Fatalf("error = %q, want root-owned hint", err.Error())
+	}
+}

--- a/cmd/stellad/version.go
+++ b/cmd/stellad/version.go
@@ -403,7 +403,8 @@ func verifyChecksum(ctx context.Context, release *githubRelease, archiveName, ar
 		return err
 	}
 
-	if actual != expected {
+	// Hex digests are case-insensitive; some tooling emits uppercase.
+	if !strings.EqualFold(actual, expected) {
 		return fmt.Errorf("checksum mismatch for %s: expected %s, got %s", archiveName, expected, actual)
 	}
 	return nil

--- a/cmd/stellad/version.go
+++ b/cmd/stellad/version.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -33,6 +34,8 @@ var (
 	errInvalidTarget    = errors.New("existing target is not a replaceable file")
 	executablePath      = os.Executable
 	renameFile          = os.Rename
+	removeFile          = os.Remove
+	currentGOOS         = runtime.GOOS
 )
 
 type githubRelease struct {
@@ -326,13 +329,27 @@ func stageBinary(srcPath, targetPath string, executable bool) (string, error) {
 }
 
 // rollbackUpgrade removes newly committed binaries and restores their backups.
-// On Windows os.Rename cannot overwrite, so the new file must be removed first.
+// On Windows os.Remove can fail because the binary is locked by a running
+// process. In that case we rename the locked file to .old — it will be cleaned
+// up by cleanStaleUpgradeArtifacts on next startup.
 func rollbackUpgrade(committed, backedUp []string) {
 	removeFailed := make(map[string]bool, len(committed))
 	for _, p := range committed {
-		if err := os.Remove(p); err != nil {
+		if err := removeFile(p); err != nil {
+			// On Windows, try renaming the locked binary out of the way.
+			if currentGOOS == "windows" {
+				oldPath := p + ".old"
+				if renameErr := renameFile(p, oldPath); renameErr == nil {
+					_, _ = fmt.Fprintf(os.Stderr, "WARNING: could not remove %s (file locked); renamed to %s — it will be cleaned up on next startup\n", p, oldPath)
+					continue
+				}
+			}
 			removeFailed[p] = true
-			_, _ = fmt.Fprintf(os.Stderr, "WARNING: could not remove %s: %v\n", p, err)
+			if currentGOOS == "windows" {
+				_, _ = fmt.Fprintf(os.Stderr, "WARNING: could not remove %s: %v\nThe file is likely locked by a running process. Stop all stella processes and manually delete %s, then rename %s.bak to %s\n", p, err, p, p, p)
+			} else {
+				_, _ = fmt.Fprintf(os.Stderr, "WARNING: could not remove %s: %v\n", p, err)
+			}
 		}
 	}
 	for _, p := range backedUp {
@@ -494,4 +511,70 @@ func ensureReplaceableTarget(targetPath string) error {
 		return nil
 	}
 	return fmt.Errorf("%w: %s", errInvalidTarget, targetPath)
+}
+
+// staleUpgradeExtensions are file suffixes left behind by interrupted upgrades.
+var staleUpgradeExtensions = []string{".tmp", ".bak", ".old"}
+
+// cleanStaleUpgradeArtifacts removes leftover .tmp, .bak, and .old files from
+// previous interrupted upgrades. It is best-effort: failures are logged but
+// never returned.
+func cleanStaleUpgradeArtifacts(dir string) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		slog.Debug("cleanStaleUpgradeArtifacts: cannot read dir", "dir", dir, "error", err)
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !isStaleUpgradeArtifact(name) {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		if err := removeFile(path); err != nil {
+			slog.Warn("cleanStaleUpgradeArtifacts: could not remove stale file", "path", path, "error", err)
+		} else {
+			slog.Info("cleanStaleUpgradeArtifacts: removed stale upgrade artifact", "path", path)
+		}
+	}
+}
+
+// warnStaleUpgradeArtifacts checks for leftover upgrade artifacts and logs a
+// warning if any are found. Call this early in the server startup path.
+func warnStaleUpgradeArtifacts(dir string) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	var stale []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if isStaleUpgradeArtifact(e.Name()) {
+			stale = append(stale, e.Name())
+		}
+	}
+	if len(stale) > 0 {
+		slog.Warn("detected stale upgrade artifacts — a previous upgrade may have been interrupted; cleaning up", "dir", dir, "files", stale)
+	}
+}
+
+// isStaleUpgradeArtifact returns true if the filename looks like a leftover
+// stella/stellad binary from a failed upgrade.
+func isStaleUpgradeArtifact(name string) bool {
+	for _, ext := range staleUpgradeExtensions {
+		if !strings.HasSuffix(name, ext) {
+			continue
+		}
+		base := strings.TrimSuffix(name, ext)
+		// Match stella, stellad, stella.exe, stellad.exe
+		if base == "stella" || base == "stellad" || base == "stella.exe" || base == "stellad.exe" {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/stellad/version.go
+++ b/cmd/stellad/version.go
@@ -557,6 +557,9 @@ func extractBinaryFromZip(archivePath, destDir, binaryName string) (outPath stri
 		if filepath.Base(file.Name) != binaryName {
 			continue
 		}
+		if file.UncompressedSize64 > maxArchiveBytes {
+			return "", fmt.Errorf("archive entry %q exceeds %d MB size limit", file.Name, maxArchiveBytes>>20)
+		}
 		rc, err := file.Open()
 		if err != nil {
 			return "", fmt.Errorf("open zip entry: %w", err)
@@ -581,13 +584,16 @@ func writeReaderToFile(path string, reader io.Reader, mode os.FileMode) error {
 		return fmt.Errorf("create extracted binary: %w", err)
 	}
 
-	limited := io.LimitReader(reader, maxArchiveBytes)
+	// Read one byte past the limit so a payload of exactly maxArchiveBytes is
+	// accepted; only a genuine overflow (n > maxArchiveBytes) is rejected. This
+	// matches the inclusive `> maxArchiveBytes` guard on tar entry headers.
+	limited := io.LimitReader(reader, maxArchiveBytes+1)
 	n, err := io.Copy(out, limited)
 	if err != nil {
 		_ = out.Close()
 		return fmt.Errorf("write extracted binary: %w", err)
 	}
-	if n >= maxArchiveBytes {
+	if n > maxArchiveBytes {
 		_ = out.Close()
 		_ = os.Remove(path)
 		return fmt.Errorf("extracted binary exceeds %d MB size limit", maxArchiveBytes>>20)
@@ -675,11 +681,11 @@ func cleanupBackupArtifact(dir, name, path string) {
 		return
 	}
 
-	if err := removeFile(path); err != nil {
-		slog.Warn("cleanStaleUpgradeArtifacts: could not remove stale backup", "path", path, "error", err)
-	} else {
-		slog.Info("cleanStaleUpgradeArtifacts: removed stale backup", "path", path)
-	}
+	// A successful upgrade removes its own .bak (see runUpgrade), so a backup
+	// surviving alongside an existing target means a rollback could not restore
+	// it. Preserve it and warn — deleting it here would destroy the only
+	// recovery artifact the rollback warning told the operator to keep.
+	slog.Warn("cleanStaleUpgradeArtifacts: interrupted upgrade left a backup; target still exists — leaving backup in place for manual recovery", "backup", path, "target", target)
 }
 
 // warnStaleUpgradeArtifacts checks for leftover upgrade artifacts and logs a

--- a/cmd/stellad/version.go
+++ b/cmd/stellad/version.go
@@ -5,6 +5,8 @@ import (
 	"archive/zip"
 	"compress/gzip"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -24,6 +26,10 @@ import (
 const (
 	githubOwner = "CherryHQ"
 	githubRepo  = "stella"
+
+	// maxArchiveBytes caps the total decompressed size of a release archive
+	// to defend against decompression bombs or CDN compromise.
+	maxArchiveBytes = 100 << 20 // 100 MB
 )
 
 var (
@@ -177,7 +183,7 @@ func runUpgrade(ctx context.Context, installDir, currentVersion, goos, goarch st
 		return nil, err
 	}
 
-	if err := installReleaseAsset(ctx, asset, installDir, goos); err != nil {
+	if err := installReleaseAsset(ctx, asset, installDir, goos, release); err != nil {
 		return nil, err
 	}
 	result.InstallDir = installDir
@@ -201,7 +207,7 @@ func releaseAssetSuffixes(goos, goarch string) []string {
 	return []string{base + ".tar.gz", base + ".zip"}
 }
 
-func installReleaseAsset(ctx context.Context, asset githubReleaseAsset, installDir, goos string) (err error) {
+func installReleaseAsset(ctx context.Context, asset githubReleaseAsset, installDir, goos string, release *githubRelease) (err error) {
 	if err := os.MkdirAll(installDir, 0o755); err != nil {
 		return fmt.Errorf("create install dir: %w", err)
 	}
@@ -218,6 +224,10 @@ func installReleaseAsset(ctx context.Context, asset githubReleaseAsset, installD
 
 	archivePath := filepath.Join(tmpDir, filepath.Base(asset.Name))
 	if err := downloadFile(ctx, asset.BrowserDownloadURL, archivePath); err != nil {
+		return err
+	}
+
+	if err := verifyChecksum(ctx, release, asset.Name, archivePath); err != nil {
 		return err
 	}
 
@@ -363,6 +373,83 @@ func rollbackUpgrade(committed, backedUp []string) {
 	}
 }
 
+// verifyChecksum fetches the checksums.txt asset from the release,
+// computes the SHA-256 of the downloaded archive, and rejects mismatches.
+func verifyChecksum(ctx context.Context, release *githubRelease, archiveName, archivePath string) error {
+	csAsset, found := findChecksumAsset(release.Assets)
+	if !found {
+		slog.Warn("skipping checksum verification — checksums.txt not found in release")
+		return nil
+	}
+
+	resp, err := upgradeHTTPClient.R().
+		SetContext(ctx).
+		SetHeader("User-Agent", upgradeUserAgent).
+		Get(csAsset.BrowserDownloadURL)
+	if err != nil {
+		return fmt.Errorf("fetch checksums.txt: %w", err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return fmt.Errorf("fetch checksums.txt: unexpected status %d", resp.StatusCode())
+	}
+
+	expected, err := parseChecksumForFile(resp.String(), archiveName)
+	if err != nil {
+		return err
+	}
+
+	actual, err := sha256File(archivePath)
+	if err != nil {
+		return err
+	}
+
+	if actual != expected {
+		return fmt.Errorf("checksum mismatch for %s: expected %s, got %s", archiveName, expected, actual)
+	}
+	return nil
+}
+
+func findChecksumAsset(assets []githubReleaseAsset) (githubReleaseAsset, bool) {
+	for _, a := range assets {
+		if strings.EqualFold(filepath.Base(a.Name), "checksums.txt") {
+			return a, true
+		}
+	}
+	return githubReleaseAsset{}, false
+}
+
+func parseChecksumForFile(checksumsTxt, filename string) (string, error) {
+	for line := range strings.SplitSeq(checksumsTxt, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// GoReleaser format: "<sha256>  <filename>"
+		parts := strings.Fields(line)
+		if len(parts) != 2 {
+			continue
+		}
+		if parts[1] == filename {
+			return parts[0], nil
+		}
+	}
+	return "", fmt.Errorf("no checksum found for %s in checksums.txt", filename)
+}
+
+func sha256File(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("open file for checksum: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", fmt.Errorf("compute checksum: %w", err)
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
 func downloadFile(ctx context.Context, url, dest string) error {
 	resp, err := upgradeHTTPClient.R().
 		SetContext(ctx).
@@ -473,9 +560,16 @@ func writeReaderToFile(path string, reader io.Reader, mode os.FileMode) error {
 		return fmt.Errorf("create extracted binary: %w", err)
 	}
 
-	if _, err := io.Copy(out, reader); err != nil {
+	limited := io.LimitReader(reader, maxArchiveBytes)
+	n, err := io.Copy(out, limited)
+	if err != nil {
 		_ = out.Close()
 		return fmt.Errorf("write extracted binary: %w", err)
+	}
+	if n >= maxArchiveBytes {
+		_ = out.Close()
+		_ = os.Remove(path)
+		return fmt.Errorf("extracted binary exceeds %d MB size limit", maxArchiveBytes>>20)
 	}
 	if err := out.Close(); err != nil {
 		return fmt.Errorf("close extracted binary: %w", err)

--- a/cmd/stellad/version.go
+++ b/cmd/stellad/version.go
@@ -497,7 +497,8 @@ func extractBinaryFromTarGz(archivePath, destDir, binaryName string) (outPath st
 		}
 	}()
 
-	tarReader := tar.NewReader(gzReader)
+	counted := &limitReader{reader: gzReader, remaining: maxArchiveBytes}
+	tarReader := tar.NewReader(counted)
 	for {
 		header, err := tarReader.Next()
 		if errors.Is(err, io.EOF) {
@@ -509,6 +510,9 @@ func extractBinaryFromTarGz(archivePath, destDir, binaryName string) (outPath st
 		if header.Typeflag != tar.TypeReg {
 			continue
 		}
+		if header.Size > maxArchiveBytes {
+			return "", fmt.Errorf("archive entry %q exceeds %d MB size limit", header.Name, maxArchiveBytes>>20)
+		}
 		if filepath.Base(header.Name) != binaryName {
 			continue
 		}
@@ -519,6 +523,23 @@ func extractBinaryFromTarGz(archivePath, destDir, binaryName string) (outPath st
 		return outPath, nil
 	}
 	return "", fmt.Errorf("binary %q not found in archive", binaryName)
+}
+
+type limitReader struct {
+	reader    io.Reader
+	remaining int64
+}
+
+func (r *limitReader) Read(p []byte) (int, error) {
+	if r.remaining <= 0 {
+		return 0, fmt.Errorf("decompressed archive exceeds %d MB size limit", maxArchiveBytes>>20)
+	}
+	if int64(len(p)) > r.remaining {
+		p = p[:r.remaining]
+	}
+	n, err := r.reader.Read(p)
+	r.remaining -= int64(n)
+	return n, err
 }
 
 func extractBinaryFromZip(archivePath, destDir, binaryName string) (outPath string, err error) {
@@ -610,9 +631,9 @@ func ensureReplaceableTarget(targetPath string) error {
 // staleUpgradeExtensions are file suffixes left behind by interrupted upgrades.
 var staleUpgradeExtensions = []string{".tmp", ".bak", ".old"}
 
-// cleanStaleUpgradeArtifacts removes leftover .tmp, .bak, and .old files from
-// previous interrupted upgrades. It is best-effort: failures are logged but
-// never returned.
+// cleanStaleUpgradeArtifacts removes leftover .tmp and .old files, and treats
+// .bak files as rollback state: restore them when the target is missing.
+// It is best-effort: failures are logged but never returned.
 func cleanStaleUpgradeArtifacts(dir string) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -628,11 +649,36 @@ func cleanStaleUpgradeArtifacts(dir string) {
 			continue
 		}
 		path := filepath.Join(dir, name)
+		if strings.HasSuffix(name, ".bak") {
+			cleanupBackupArtifact(dir, name, path)
+			continue
+		}
 		if err := removeFile(path); err != nil {
 			slog.Warn("cleanStaleUpgradeArtifacts: could not remove stale file", "path", path, "error", err)
 		} else {
 			slog.Info("cleanStaleUpgradeArtifacts: removed stale upgrade artifact", "path", path)
 		}
+	}
+}
+
+func cleanupBackupArtifact(dir, name, path string) {
+	target := filepath.Join(dir, strings.TrimSuffix(name, ".bak"))
+	if _, err := os.Lstat(target); os.IsNotExist(err) {
+		if err := renameFile(path, target); err != nil {
+			slog.Warn("cleanStaleUpgradeArtifacts: could not restore backup", "backup", path, "target", target, "error", err)
+		} else {
+			slog.Warn("cleanStaleUpgradeArtifacts: restored interrupted upgrade backup", "backup", path, "target", target)
+		}
+		return
+	} else if err != nil {
+		slog.Warn("cleanStaleUpgradeArtifacts: cannot stat target for backup", "backup", path, "target", target, "error", err)
+		return
+	}
+
+	if err := removeFile(path); err != nil {
+		slog.Warn("cleanStaleUpgradeArtifacts: could not remove stale backup", "path", path, "error", err)
+	} else {
+		slog.Info("cleanStaleUpgradeArtifacts: removed stale backup", "path", path)
 	}
 }
 

--- a/cmd/stellad/version_test.go
+++ b/cmd/stellad/version_test.go
@@ -77,3 +77,175 @@ func TestUpgradeInstallErrorAddsWindowsBusyHint(t *testing.T) {
 		t.Fatalf("error = %q, want busy hint", err.Error())
 	}
 }
+
+func TestCleanStaleUpgradeArtifacts(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create stale files that should be removed.
+	staleFiles := []string{
+		"stella.tmp", "stellad.tmp",
+		"stella.bak", "stellad.bak",
+		"stella.old", "stellad.old",
+		"stella.exe.tmp", "stellad.exe.bak",
+	}
+	for _, name := range staleFiles {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Create files that should NOT be removed.
+	keepFiles := []string{
+		"stella", "stellad",
+		"unrelated.tmp", "other.bak",
+	}
+	for _, name := range keepFiles {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cleanStaleUpgradeArtifacts(dir)
+
+	for _, name := range staleFiles {
+		if _, err := os.Stat(filepath.Join(dir, name)); !os.IsNotExist(err) {
+			t.Errorf("expected %s to be removed, but it still exists", name)
+		}
+	}
+	for _, name := range keepFiles {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Errorf("expected %s to be kept, but it was removed", name)
+		}
+	}
+}
+
+func TestCleanStaleUpgradeArtifactsNonexistentDir(t *testing.T) {
+	// Should not panic on a nonexistent directory.
+	cleanStaleUpgradeArtifacts(filepath.Join(t.TempDir(), "nope"))
+}
+
+func TestIsStaleUpgradeArtifact(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"stella.tmp", true},
+		{"stellad.bak", true},
+		{"stella.old", true},
+		{"stellad.exe.tmp", true},
+		{"stella.exe.bak", true},
+		{"stellad.exe.old", true},
+		{"stella", false},
+		{"stellad", false},
+		{"unrelated.tmp", false},
+		{"stellar.bak", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isStaleUpgradeArtifact(tt.name); got != tt.want {
+				t.Errorf("isStaleUpgradeArtifact(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRollbackUpgradeRemoveFailureFallsBack(t *testing.T) {
+	dir := t.TempDir()
+
+	committed := filepath.Join(dir, "stella")
+	if err := os.WriteFile(committed, []byte("new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	bakPath := committed + ".bak"
+	if err := os.WriteFile(bakPath, []byte("original"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Mock removeFile to always fail.
+	oldRemoveFile := removeFile
+	removeFile = func(name string) error { return errors.New("simulated lock") }
+	oldGOOS := currentGOOS
+	currentGOOS = "linux"
+	t.Cleanup(func() {
+		removeFile = oldRemoveFile
+		currentGOOS = oldGOOS
+	})
+
+	rollbackUpgrade([]string{committed}, []string{committed})
+
+	// The committed file should still exist (remove failed).
+	if _, err := os.Stat(committed); err != nil {
+		t.Fatal("committed file should still exist after failed remove")
+	}
+	// The backup should also still exist (rollback skipped restore for this path).
+	if _, err := os.Stat(bakPath); err != nil {
+		t.Fatal("backup should still exist because remove failed")
+	}
+}
+
+func TestRollbackUpgradeWindowsRenamesToOld(t *testing.T) {
+	dir := t.TempDir()
+
+	committed := filepath.Join(dir, "stella.exe")
+	if err := os.WriteFile(committed, []byte("new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	bakPath := committed + ".bak"
+	if err := os.WriteFile(bakPath, []byte("original"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Mock removeFile to fail (simulating Windows file lock),
+	// but allow renameFile to succeed (renaming to .old).
+	oldRemoveFile := removeFile
+	removeFile = func(name string) error { return errors.New("file locked") }
+	oldGOOS := currentGOOS
+	currentGOOS = "windows"
+	t.Cleanup(func() {
+		removeFile = oldRemoveFile
+		currentGOOS = oldGOOS
+	})
+
+	rollbackUpgrade([]string{committed}, []string{committed})
+
+	// The committed file should have been renamed to .old.
+	oldPath := committed + ".old"
+	if _, err := os.Stat(oldPath); err != nil {
+		t.Fatal("expected .old file to exist after Windows rollback rename")
+	}
+
+	// Since rename-to-.old succeeded, removeFailed is NOT set, so the backup
+	// restore loop runs renameFile(bakPath, committed) — restoring the original.
+	data, err := os.ReadFile(committed)
+	if err != nil {
+		t.Fatalf("expected backup to be restored at %s: %v", committed, err)
+	}
+	if string(data) != "original" {
+		t.Fatalf("restored file = %q, want %q", string(data), "original")
+	}
+
+	// The .bak file should be gone (renamed back).
+	if _, err := os.Stat(bakPath); !os.IsNotExist(err) {
+		t.Fatal("expected .bak file to be gone after successful restore")
+	}
+}
+
+func TestWarnStaleUpgradeArtifacts(t *testing.T) {
+	dir := t.TempDir()
+
+	// No stale files — should not panic.
+	warnStaleUpgradeArtifacts(dir)
+
+	// Add a stale file.
+	if err := os.WriteFile(filepath.Join(dir, "stella.bak"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Should not panic; we just verify it doesn't error.
+	warnStaleUpgradeArtifacts(dir)
+
+	// Nonexistent dir — should not panic.
+	warnStaleUpgradeArtifacts(filepath.Join(dir, "nope"))
+}

--- a/cmd/stellad/version_test.go
+++ b/cmd/stellad/version_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -229,6 +232,120 @@ func TestRollbackUpgradeWindowsRenamesToOld(t *testing.T) {
 	// The .bak file should be gone (renamed back).
 	if _, err := os.Stat(bakPath); !os.IsNotExist(err) {
 		t.Fatal("expected .bak file to be gone after successful restore")
+	}
+}
+
+func TestParseChecksumForFile(t *testing.T) {
+	checksums := "abc123  stella_linux_amd64.tar.gz\ndef456  stella_darwin_arm64.tar.gz\n"
+
+	got, err := parseChecksumForFile(checksums, "stella_linux_amd64.tar.gz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "abc123" {
+		t.Fatalf("got %q, want %q", got, "abc123")
+	}
+
+	_, err = parseChecksumForFile(checksums, "nonexistent.tar.gz")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestSha256File(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.bin")
+	content := []byte("hello world")
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := sha256File(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h := sha256.Sum256(content)
+	want := hex.EncodeToString(h[:])
+	if got != want {
+		t.Fatalf("sha256File = %q, want %q", got, want)
+	}
+}
+
+func TestWriteReaderToFileSizeLimit(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "big.bin")
+
+	// Create a reader that produces more than maxArchiveBytes
+	oldMax := maxArchiveBytes
+	// Temporarily set a small limit for testing
+	defer func() { /* maxArchiveBytes is const, we test with a real small file */ }()
+	_ = oldMax
+
+	// Instead, test that a normal file works fine
+	content := strings.NewReader("small content")
+	if err := writeReaderToFile(path, content, 0o755); err != nil {
+		t.Fatalf("writeReaderToFile: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "small content" {
+		t.Fatalf("got %q, want %q", string(data), "small content")
+	}
+}
+
+func TestFindChecksumAsset(t *testing.T) {
+	assets := []githubReleaseAsset{
+		{Name: "stella_linux_amd64.tar.gz", BrowserDownloadURL: "https://example.com/archive"},
+		{Name: "checksums.txt", BrowserDownloadURL: "https://example.com/checksums"},
+	}
+
+	got, ok := findChecksumAsset(assets)
+	if !ok {
+		t.Fatal("expected to find checksums.txt")
+	}
+	if got.Name != "checksums.txt" {
+		t.Fatalf("got %q, want checksums.txt", got.Name)
+	}
+
+	_, ok = findChecksumAsset([]githubReleaseAsset{{Name: "archive.tar.gz"}})
+	if ok {
+		t.Fatal("expected not found when checksums.txt missing")
+	}
+}
+
+func TestVerifyChecksumIntegration(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "stella_linux_amd64.tar.gz")
+	content := []byte("fake archive content")
+	if err := os.WriteFile(archivePath, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	h := sha256.Sum256(content)
+	correctHash := hex.EncodeToString(h[:])
+	checksumsTxt := fmt.Sprintf("%s  stella_linux_amd64.tar.gz\n", correctHash)
+
+	// Test correct checksum passes
+	expected, err := parseChecksumForFile(checksumsTxt, "stella_linux_amd64.tar.gz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	actual, err := sha256File(archivePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if actual != expected {
+		t.Fatalf("checksum mismatch: got %s, want %s", actual, expected)
+	}
+
+	// Test wrong checksum fails
+	badChecksum := "0000000000000000000000000000000000000000000000000000000000000000"
+	if actual == badChecksum {
+		t.Fatal("bad test: bad checksum matches actual")
 	}
 }
 

--- a/cmd/stellad/version_test.go
+++ b/cmd/stellad/version_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -99,7 +101,7 @@ func TestCleanStaleUpgradeArtifacts(t *testing.T) {
 
 	// Create files that should NOT be removed.
 	keepFiles := []string{
-		"stella", "stellad",
+		"stella", "stellad", "stellad.exe",
 		"unrelated.tmp", "other.bak",
 	}
 	for _, name := range keepFiles {
@@ -119,6 +121,28 @@ func TestCleanStaleUpgradeArtifacts(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
 			t.Errorf("expected %s to be kept, but it was removed", name)
 		}
+	}
+}
+
+func TestCleanStaleUpgradeArtifactsRestoresBackupWhenTargetMissing(t *testing.T) {
+	dir := t.TempDir()
+	backup := filepath.Join(dir, "stella.bak")
+	if err := os.WriteFile(backup, []byte("original"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cleanStaleUpgradeArtifacts(dir)
+
+	restored := filepath.Join(dir, "stella")
+	data, err := os.ReadFile(restored)
+	if err != nil {
+		t.Fatalf("expected backup to be restored: %v", err)
+	}
+	if string(data) != "original" {
+		t.Fatalf("restored content = %q, want original", string(data))
+	}
+	if _, err := os.Stat(backup); !os.IsNotExist(err) {
+		t.Fatal("expected backup path to be gone after restore")
 	}
 }
 
@@ -294,6 +318,34 @@ func TestWriteReaderToFileSizeLimit(t *testing.T) {
 	}
 	if string(data) != "small content" {
 		t.Fatalf("got %q, want %q", string(data), "small content")
+	}
+}
+
+func TestExtractBinaryFromTarGzRejectsOversizedSkippedEntry(t *testing.T) {
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "stella_linux_amd64.tar.gz")
+	file, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gz := gzip.NewWriter(file)
+	tarWriter := tar.NewWriter(gz)
+	if err := tarWriter.WriteHeader(&tar.Header{Name: "padding.bin", Mode: 0o644, Size: maxArchiveBytes + 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = extractBinaryFromTarGz(archivePath, dir, "stella")
+	if err == nil {
+		t.Fatal("expected oversized skipped entry to fail")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("error = %q, want size-limit error", err.Error())
 	}
 }
 

--- a/cmd/stellad/version_test.go
+++ b/cmd/stellad/version_test.go
@@ -3,15 +3,30 @@ package main
 import (
 	"archive/tar"
 	"compress/gzip"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// infiniteZeroReader yields an endless stream of zero bytes without allocating,
+// so size-limit tests can drive past maxArchiveBytes cheaply.
+type infiniteZeroReader struct{}
+
+func (infiniteZeroReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}
 
 func TestResolveUpgradeDirDefaultUsesExecutableDir(t *testing.T) {
 	tmpDir := t.TempDir()
@@ -300,26 +315,47 @@ func TestSha256File(t *testing.T) {
 
 func TestWriteReaderToFileSizeLimit(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, "big.bin")
 
-	// Create a reader that produces more than maxArchiveBytes
-	oldMax := maxArchiveBytes
-	// Temporarily set a small limit for testing
-	defer func() { /* maxArchiveBytes is const, we test with a real small file */ }()
-	_ = oldMax
-
-	// Instead, test that a normal file works fine
-	content := strings.NewReader("small content")
-	if err := writeReaderToFile(path, content, 0o755); err != nil {
+	// Happy path: a normal small file is written verbatim.
+	smallPath := filepath.Join(dir, "small.bin")
+	if err := writeReaderToFile(smallPath, strings.NewReader("small content"), 0o755); err != nil {
 		t.Fatalf("writeReaderToFile: %v", err)
 	}
-
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(smallPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if string(data) != "small content" {
 		t.Fatalf("got %q, want %q", string(data), "small content")
+	}
+
+	if testing.Short() {
+		t.Skip("skipping multi-hundred-MB boundary cases in -short mode")
+	}
+
+	// Boundary: a payload of exactly maxArchiveBytes is accepted (the guard is
+	// inclusive — it must not reject a file at the limit).
+	atLimitPath := filepath.Join(dir, "at_limit.bin")
+	if err := writeReaderToFile(atLimitPath, io.LimitReader(infiniteZeroReader{}, maxArchiveBytes), 0o755); err != nil {
+		t.Fatalf("writeReaderToFile at limit: %v", err)
+	}
+	if fi, err := os.Stat(atLimitPath); err != nil {
+		t.Fatal(err)
+	} else if fi.Size() != maxArchiveBytes {
+		t.Fatalf("at-limit size = %d, want %d", fi.Size(), maxArchiveBytes)
+	}
+
+	// Over limit: one byte past the cap is rejected and the partial file removed.
+	overPath := filepath.Join(dir, "over.bin")
+	err = writeReaderToFile(overPath, io.LimitReader(infiniteZeroReader{}, maxArchiveBytes+1), 0o755)
+	if err == nil {
+		t.Fatal("expected over-limit reader to be rejected")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("error = %q, want size-limit error", err.Error())
+	}
+	if _, err := os.Stat(overPath); !os.IsNotExist(err) {
+		t.Fatal("expected partial file to be removed after over-limit rejection")
 	}
 }
 
@@ -372,35 +408,63 @@ func TestFindChecksumAsset(t *testing.T) {
 }
 
 func TestVerifyChecksumIntegration(t *testing.T) {
-	dir := t.TempDir()
-	archivePath := filepath.Join(dir, "stella_linux_amd64.tar.gz")
+	const archiveName = "stella_linux_amd64.tar.gz"
 	content := []byte("fake archive content")
-	if err := os.WriteFile(archivePath, content, 0o644); err != nil {
-		t.Fatal(err)
-	}
-
 	h := sha256.Sum256(content)
 	correctHash := hex.EncodeToString(h[:])
-	checksumsTxt := fmt.Sprintf("%s  stella_linux_amd64.tar.gz\n", correctHash)
 
-	// Test correct checksum passes
-	expected, err := parseChecksumForFile(checksumsTxt, "stella_linux_amd64.tar.gz")
-	if err != nil {
-		t.Fatal(err)
-	}
-	actual, err := sha256File(archivePath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if actual != expected {
-		t.Fatalf("checksum mismatch: got %s, want %s", actual, expected)
+	// serveChecksums spins an HTTP server returning the given checksums body and
+	// builds a release whose checksums.txt asset points at it.
+	releaseServing := func(t *testing.T, body string) *githubRelease {
+		t.Helper()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = io.WriteString(w, body)
+		}))
+		t.Cleanup(srv.Close)
+		return &githubRelease{Assets: []githubReleaseAsset{
+			{Name: archiveName, BrowserDownloadURL: srv.URL + "/archive"},
+			{Name: "checksums.txt", BrowserDownloadURL: srv.URL},
+		}}
 	}
 
-	// Test wrong checksum fails
-	badChecksum := "0000000000000000000000000000000000000000000000000000000000000000"
-	if actual == badChecksum {
-		t.Fatal("bad test: bad checksum matches actual")
+	writeArchive := func(t *testing.T) string {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), archiveName)
+		if err := os.WriteFile(path, content, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return path
 	}
+
+	t.Run("matching checksum passes", func(t *testing.T) {
+		rel := releaseServing(t, fmt.Sprintf("%s  %s\n", correctHash, archiveName))
+		if err := verifyChecksum(context.Background(), rel, archiveName, writeArchive(t)); err != nil {
+			t.Fatalf("verifyChecksum: %v", err)
+		}
+	})
+
+	t.Run("uppercase digest passes (case-insensitive)", func(t *testing.T) {
+		rel := releaseServing(t, fmt.Sprintf("%s  %s\n", strings.ToUpper(correctHash), archiveName))
+		if err := verifyChecksum(context.Background(), rel, archiveName, writeArchive(t)); err != nil {
+			t.Fatalf("verifyChecksum with uppercase digest: %v", err)
+		}
+	})
+
+	t.Run("wrong checksum is rejected", func(t *testing.T) {
+		bad := strings.Repeat("0", 64)
+		rel := releaseServing(t, fmt.Sprintf("%s  %s\n", bad, archiveName))
+		err := verifyChecksum(context.Background(), rel, archiveName, writeArchive(t))
+		if err == nil || !strings.Contains(err.Error(), "mismatch") {
+			t.Fatalf("error = %v, want checksum mismatch", err)
+		}
+	})
+
+	t.Run("missing checksums.txt asset skips verification", func(t *testing.T) {
+		rel := &githubRelease{Assets: []githubReleaseAsset{{Name: archiveName, BrowserDownloadURL: "http://unused"}}}
+		if err := verifyChecksum(context.Background(), rel, archiveName, writeArchive(t)); err != nil {
+			t.Fatalf("expected missing checksums.txt to skip, got %v", err)
+		}
+	})
 }
 
 func TestWarnStaleUpgradeArtifacts(t *testing.T) {

--- a/cmd/stellad/version_test.go
+++ b/cmd/stellad/version_test.go
@@ -89,9 +89,8 @@ func TestCleanStaleUpgradeArtifacts(t *testing.T) {
 	// Create stale files that should be removed.
 	staleFiles := []string{
 		"stella.tmp", "stellad.tmp",
-		"stella.bak", "stellad.bak",
 		"stella.old", "stellad.old",
-		"stella.exe.tmp", "stellad.exe.bak",
+		"stella.exe.tmp",
 	}
 	for _, name := range staleFiles {
 		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o644); err != nil {
@@ -99,10 +98,13 @@ func TestCleanStaleUpgradeArtifacts(t *testing.T) {
 		}
 	}
 
-	// Create files that should NOT be removed.
+	// Create files that should NOT be removed. The .bak files are kept because
+	// their targets exist: a backup surviving next to its target means a
+	// rollback could not restore it, so it is preserved for manual recovery.
 	keepFiles := []string{
 		"stella", "stellad", "stellad.exe",
 		"unrelated.tmp", "other.bak",
+		"stella.bak", "stellad.bak", "stellad.exe.bak",
 	}
 	for _, name := range keepFiles {
 		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o644); err != nil {

--- a/internal/email/egress.go
+++ b/internal/email/egress.go
@@ -12,9 +12,25 @@ import (
 
 const emailDialTimeout = 30 * time.Second
 
+// Ranges that netip.IsPrivate does not cover but are still effectively internal:
+// carrier-grade NAT (RFC 6598) and the NAT64 well-known prefix (RFC 6052).
+var (
+	cgnatPrefix = netip.MustParsePrefix("100.64.0.0/10")
+	nat64Prefix = netip.MustParsePrefix("64:ff9b::/96")
+)
+
 // ValidateAccountEgress rejects email server hosts that would make stellad
 // connect to local or private infrastructure on behalf of an authenticated user.
 func ValidateAccountEgress(acct EmailAccount) error {
+	// Server-side egress reaches public hosts only (see validatePublicAddr), so
+	// an unencrypted connection would put the account credentials on the wire in
+	// cleartext. Reject TLS=none for the daemon path.
+	if acct.IMAPTLS == "none" {
+		return fmt.Errorf("imap_tls=none is not allowed for server-side email; use ssl or starttls")
+	}
+	if acct.SMTPTLS == "none" {
+		return fmt.Errorf("smtp_tls=none is not allowed for server-side email; use ssl or starttls")
+	}
 	if _, err := ResolvePublicHost("imap", acct.IMAPHost); err != nil {
 		return err
 	}
@@ -90,7 +106,7 @@ func DialPublicTCP(ctx context.Context, kind, host string, port int) (net.Conn, 
 }
 
 func validatePublicAddr(kind, host string, addr netip.Addr) error {
-	if !addr.IsGlobalUnicast() || addr.IsPrivate() || addr.IsLoopback() || addr.IsLinkLocalUnicast() || addr.IsLinkLocalMulticast() || addr.IsMulticast() || addr.IsUnspecified() {
+	if !addr.IsGlobalUnicast() || addr.IsPrivate() || addr.IsLoopback() || addr.IsLinkLocalUnicast() || addr.IsLinkLocalMulticast() || addr.IsMulticast() || addr.IsUnspecified() || cgnatPrefix.Contains(addr) || nat64Prefix.Contains(addr) {
 		return fmt.Errorf("%s_host %q resolves to disallowed address %s", kind, host, addr)
 	}
 	return nil

--- a/internal/email/egress.go
+++ b/internal/email/egress.go
@@ -1,0 +1,97 @@
+package email
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const emailDialTimeout = 30 * time.Second
+
+// ValidateAccountEgress rejects email server hosts that would make stellad
+// connect to local or private infrastructure on behalf of an authenticated user.
+func ValidateAccountEgress(acct EmailAccount) error {
+	if _, err := ResolvePublicHost("imap", acct.IMAPHost); err != nil {
+		return err
+	}
+	if _, err := ResolvePublicHost("smtp", acct.SMTPHost); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ResolvePublicHost resolves host and rejects any result that is not safe for
+// server-side email egress. Callers must connect to the returned IPs, not resolve
+// the original hostname again, or DNS rebinding reopens the SSRF hole.
+func ResolvePublicHost(kind, host string) ([]netip.Addr, error) {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return nil, fmt.Errorf("%s_host is required", kind)
+	}
+	if splitHost, _, err := net.SplitHostPort(host); err == nil && splitHost != "" {
+		return nil, fmt.Errorf("%s_host must not include a port", kind)
+	}
+
+	literal := strings.Trim(host, "[]")
+	if addr, err := netip.ParseAddr(literal); err == nil {
+		addr = addr.Unmap()
+		if err := validatePublicAddr(kind, host, addr); err != nil {
+			return nil, err
+		}
+		return []netip.Addr{addr}, nil
+	}
+
+	ips, err := net.LookupIP(host)
+	if err != nil {
+		return nil, fmt.Errorf("resolve %s_host %q: %w", kind, host, err)
+	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("resolve %s_host %q: no addresses", kind, host)
+	}
+	addrs := make([]netip.Addr, 0, len(ips))
+	for _, ip := range ips {
+		addr, ok := netip.AddrFromSlice(ip)
+		if !ok {
+			return nil, fmt.Errorf("resolve %s_host %q: invalid address %q", kind, host, ip.String())
+		}
+		addr = addr.Unmap()
+		if err := validatePublicAddr(kind, host, addr); err != nil {
+			return nil, err
+		}
+		addrs = append(addrs, addr)
+	}
+	return addrs, nil
+}
+
+func DialPublicTCP(ctx context.Context, kind, host string, port int) (net.Conn, error) {
+	if port < 1 || port > 65535 {
+		return nil, fmt.Errorf("%s_port must be between 1 and 65535", kind)
+	}
+	addrs, err := ResolvePublicHost(kind, host)
+	if err != nil {
+		return nil, err
+	}
+
+	dialer := &net.Dialer{Timeout: emailDialTimeout}
+	portString := strconv.Itoa(port)
+	var lastErr error
+	for _, addr := range addrs {
+		conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(addr.String(), portString))
+		if err == nil {
+			return conn, nil
+		}
+		lastErr = err
+	}
+	return nil, fmt.Errorf("dial %s_host %q: %w", kind, host, lastErr)
+}
+
+func validatePublicAddr(kind, host string, addr netip.Addr) error {
+	if !addr.IsGlobalUnicast() || addr.IsPrivate() || addr.IsLoopback() || addr.IsLinkLocalUnicast() || addr.IsLinkLocalMulticast() || addr.IsMulticast() || addr.IsUnspecified() {
+		return fmt.Errorf("%s_host %q resolves to disallowed address %s", kind, host, addr)
+	}
+	return nil
+}

--- a/internal/email/email_test.go
+++ b/internal/email/email_test.go
@@ -41,6 +41,25 @@ func TestValidateAccountName(t *testing.T) {
 	}
 }
 
+func TestValidateAccountEgressRejectsPrivateHosts(t *testing.T) {
+	acct := email.EmailAccount{IMAPHost: "127.0.0.1", SMTPHost: "8.8.8.8"}
+	if err := email.ValidateAccountEgress(acct); err == nil {
+		t.Fatal("expected loopback IMAP host to be rejected")
+	}
+
+	acct = email.EmailAccount{IMAPHost: "8.8.8.8", SMTPHost: "10.0.0.1"}
+	if err := email.ValidateAccountEgress(acct); err == nil {
+		t.Fatal("expected private SMTP host to be rejected")
+	}
+}
+
+func TestValidateAccountEgressAllowsPublicLiteralHosts(t *testing.T) {
+	acct := email.EmailAccount{IMAPHost: "8.8.8.8", SMTPHost: "1.1.1.1"}
+	if err := email.ValidateAccountEgress(acct); err != nil {
+		t.Fatalf("expected public literal hosts to pass: %v", err)
+	}
+}
+
 func TestConfigJSONRoundTrip(t *testing.T) {
 	cfg := &email.Config{
 		Default: "work",

--- a/internal/email/imap.go
+++ b/internal/email/imap.go
@@ -3,6 +3,8 @@ package email
 import (
 	"bytes"
 	"cmp"
+	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -24,25 +26,33 @@ const maxAttachmentSize = 50 * 1024 * 1024 // 50 MB
 
 // dialIMAP connects to the IMAP server described by acct and logs in.
 func dialIMAP(acct EmailAccount) (*imapclient.Client, error) {
-	addr := fmt.Sprintf("%s:%d", acct.IMAPHost, acct.IMAPPort)
+	conn, err := DialPublicTCP(context.Background(), "imap", acct.IMAPHost, acct.IMAPPort)
+	if err != nil {
+		return nil, err
+	}
+
+	tlsConfig := &tls.Config{ServerName: acct.IMAPHost, NextProtos: []string{"imap"}}
 	opts := &imapclient.Options{
+		TLSConfig:   tlsConfig,
 		WordDecoder: &mime.WordDecoder{CharsetReader: charset.Reader},
 	}
 
-	var (
-		c   *imapclient.Client
-		err error
-	)
+	var c *imapclient.Client
 	switch acct.IMAPTLS {
 	case "starttls":
-		c, err = imapclient.DialStartTLS(addr, opts)
+		c, err = imapclient.NewStartTLS(conn, opts)
 	case "none":
-		c, err = imapclient.DialInsecure(addr, opts)
+		c = imapclient.New(conn, opts)
 	default: // "ssl" or ""
-		c, err = imapclient.DialTLS(addr, opts)
+		tlsConn := tls.Client(conn, tlsConfig)
+		if err := tlsConn.Handshake(); err != nil {
+			_ = conn.Close()
+			return nil, fmt.Errorf("dial imap %s:%d: %w", acct.IMAPHost, acct.IMAPPort, err)
+		}
+		c = imapclient.New(tlsConn, opts)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("dial imap %s: %w", addr, err)
+		return nil, fmt.Errorf("dial imap %s:%d: %w", acct.IMAPHost, acct.IMAPPort, err)
 	}
 
 	if err := c.Login(acct.Username, acct.Password).Wait(); err != nil {
@@ -180,7 +190,7 @@ func Read(acct EmailAccount, folder string, uid uint32) (*Message, error) {
 		return nil, fmt.Errorf("fetch message uid=%d: %w", uid, err)
 	}
 	if len(msgs) == 0 {
-		return nil, fmt.Errorf("message uid=%d not found", uid)
+		return nil, fmt.Errorf("%w: uid=%d", ErrMessageNotFound, uid)
 	}
 
 	buf := msgs[0]
@@ -271,7 +281,7 @@ func SaveAttachments(acct EmailAccount, folder string, uid uint32, dir string) (
 		return nil, fmt.Errorf("fetch message uid=%d: %w", uid, err)
 	}
 	if len(msgs) == 0 {
-		return nil, fmt.Errorf("message uid=%d not found", uid)
+		return nil, fmt.Errorf("%w: uid=%d", ErrMessageNotFound, uid)
 	}
 
 	rawSection := &imap.FetchItemBodySection{Peek: true}
@@ -382,6 +392,9 @@ func MarkSeen(acct EmailAccount, folder string, uid uint32, seen bool) error {
 	if _, err := c.Select(folder, nil).Wait(); err != nil {
 		return fmt.Errorf("select %q: %w", folder, err)
 	}
+	if err := ensureMessageExists(c, uid); err != nil {
+		return err
+	}
 
 	op := imap.StoreFlagsDel
 	if seen {
@@ -394,6 +407,18 @@ func MarkSeen(acct EmailAccount, folder string, uid uint32, seen bool) error {
 	}
 	if _, err := c.Store(imap.UIDSetNum(imap.UID(uid)), storeFlags, nil).Collect(); err != nil {
 		return fmt.Errorf("store flags uid=%d: %w", uid, err)
+	}
+	return nil
+}
+
+func ensureMessageExists(c *imapclient.Client, uid uint32) error {
+	fetchOpts := &imap.FetchOptions{UID: true}
+	msgs, err := c.Fetch(imap.UIDSetNum(imap.UID(uid)), fetchOpts).Collect()
+	if err != nil {
+		return fmt.Errorf("fetch message uid=%d: %w", uid, err)
+	}
+	if len(msgs) == 0 {
+		return fmt.Errorf("%w: uid=%d", ErrMessageNotFound, uid)
 	}
 	return nil
 }

--- a/internal/email/message.go
+++ b/internal/email/message.go
@@ -1,6 +1,11 @@
 package email
 
-import "time"
+import (
+	"errors"
+	"time"
+)
+
+var ErrMessageNotFound = errors.New("message not found")
 
 // Envelope holds metadata about an email message.
 type Envelope struct {

--- a/internal/email/smtp.go
+++ b/internal/email/smtp.go
@@ -1,7 +1,10 @@
 package email
 
 import (
+	"context"
+	"crypto/tls"
 	"fmt"
+	"net"
 	"strings"
 
 	mail "github.com/wneessen/go-mail"
@@ -93,6 +96,7 @@ func newSMTPClient(acct EmailAccount) (*mail.Client, error) {
 		mail.WithSMTPAuth(mail.SMTPAuthPlain),
 		mail.WithUsername(acct.Username),
 		mail.WithPassword(acct.Password),
+		mail.WithDialContextFunc(safeSMTPDialer(acct)),
 	}
 
 	var tlsOpts []mail.Option
@@ -106,6 +110,28 @@ func newSMTPClient(acct EmailAccount) (*mail.Client, error) {
 	}
 
 	return mail.NewClient(acct.SMTPHost, append(baseOpts, tlsOpts...)...)
+}
+
+func safeSMTPDialer(acct EmailAccount) mail.DialContextFunc {
+	return func(ctx context.Context, network, _ string) (net.Conn, error) {
+		if network != "tcp" {
+			return nil, fmt.Errorf("unsupported SMTP network %q", network)
+		}
+		conn, err := DialPublicTCP(ctx, "smtp", acct.SMTPHost, acct.SMTPPort)
+		if err != nil {
+			return nil, err
+		}
+		if acct.SMTPTLS != "ssl" {
+			return conn, nil
+		}
+
+		tlsConn := tls.Client(conn, &tls.Config{ServerName: acct.SMTPHost, MinVersion: tls.VersionTLS12})
+		if err := tlsConn.HandshakeContext(ctx); err != nil {
+			_ = conn.Close()
+			return nil, err
+		}
+		return tlsConn, nil
+	}
 }
 
 // FormatDryRun returns a human-readable representation of the email that would

--- a/internal/server/email.go
+++ b/internal/server/email.go
@@ -1,0 +1,309 @@
+package server
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	apiserver "github.com/CherryHQ/stella/api/server"
+	apitypes "github.com/CherryHQ/stella/api/types"
+	"github.com/CherryHQ/stella/internal/email"
+)
+
+// loadEmailAccount loads the EMAIL_CONFIG vault entry for the authenticated
+// user, parses it, and resolves the requested account name. On failure it
+// writes an error response and returns a zero value + false.
+func (s *Server) loadEmailAccount(w http.ResponseWriter, r *http.Request, accountParam *string) (email.EmailAccount, bool) {
+	if s.vaultSvc == nil {
+		writeError(w, http.StatusServiceUnavailable, "vault not configured")
+		return email.EmailAccount{}, false
+	}
+
+	info := UserFromContext(r.Context())
+	if info == nil {
+		writeError(w, http.StatusUnauthorized, "not authenticated")
+		return email.EmailAccount{}, false
+	}
+
+	value, err := s.vaultSvc.Get(r.Context(), info.UserID, "EMAIL_CONFIG")
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			writeError(w, http.StatusBadRequest, "no email accounts configured — use 'stella email config add' first")
+			return email.EmailAccount{}, false
+		}
+		s.log.Error("load email config from vault", "user_id", info.UserID, "error", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return email.EmailAccount{}, false
+	}
+
+	cfg := &email.Config{Accounts: make(map[string]email.EmailAccount)}
+	if value != "" && value != "{}" {
+		if err := json.Unmarshal([]byte(value), cfg); err != nil {
+			writeError(w, http.StatusInternalServerError, "malformed EMAIL_CONFIG in vault")
+			return email.EmailAccount{}, false
+		}
+	}
+	if cfg.Accounts == nil {
+		cfg.Accounts = make(map[string]email.EmailAccount)
+	}
+	if len(cfg.Accounts) == 0 {
+		writeError(w, http.StatusBadRequest, "no email accounts configured — use 'stella email config add' first")
+		return email.EmailAccount{}, false
+	}
+
+	var name string
+	if accountParam != nil {
+		name = *accountParam
+	}
+	acct, err := cfg.Resolve(name)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("resolve email account: %v", err))
+		return email.EmailAccount{}, false
+	}
+	return acct, true
+}
+
+// ListEmailFolders handles GET /api/email/folders.
+func (s *Server) ListEmailFolders(w http.ResponseWriter, r *http.Request, params apiserver.ListEmailFoldersParams) {
+	acct, ok := s.loadEmailAccount(w, r, params.Account)
+	if !ok {
+		return
+	}
+
+	folders, err := email.Folders(acct)
+	if err != nil {
+		s.writeInternalError(w, err)
+		return
+	}
+
+	writeData(w, http.StatusOK, apitypes.EmailFolderList{Folders: folders})
+}
+
+// ListEmailMessages handles GET /api/email/messages.
+func (s *Server) ListEmailMessages(w http.ResponseWriter, r *http.Request, params apiserver.ListEmailMessagesParams) {
+	acct, ok := s.loadEmailAccount(w, r, params.Account)
+	if !ok {
+		return
+	}
+
+	opts := email.ListOptions{}
+	if params.Folder != nil {
+		opts.Folder = *params.Folder
+	}
+	if params.Limit != nil {
+		opts.Limit = *params.Limit
+	}
+	if params.Unread != nil {
+		opts.Unread = *params.Unread
+	}
+	if params.From != nil {
+		opts.From = *params.From
+	}
+	if params.Subject != nil {
+		opts.Subject = *params.Subject
+	}
+	if params.Since != nil {
+		t := params.Since.Time
+		opts.Since = &t
+	}
+	if params.Before != nil {
+		t := params.Before.Time
+		opts.Before = &t
+	}
+
+	msgs, err := email.List(acct, opts)
+	if err != nil {
+		s.writeInternalError(w, err)
+		return
+	}
+
+	envelopes := make([]apitypes.EmailEnvelope, 0, len(msgs))
+	for _, m := range msgs {
+		envelopes = append(envelopes, emailEnvelopeToAPI(m))
+	}
+	writeData(w, http.StatusOK, apitypes.EmailEnvelopeList{Messages: envelopes})
+}
+
+// GetEmailMessage handles GET /api/email/messages/{uid}.
+func (s *Server) GetEmailMessage(w http.ResponseWriter, r *http.Request, uid int, params apiserver.GetEmailMessageParams) {
+	acct, ok := s.loadEmailAccount(w, r, params.Account)
+	if !ok {
+		return
+	}
+
+	folder := "INBOX"
+	if params.Folder != nil {
+		folder = *params.Folder
+	}
+
+	msg, err := email.Read(acct, folder, uint32(uid))
+	if err != nil {
+		s.writeInternalError(w, err)
+		return
+	}
+
+	writeData(w, http.StatusOK, emailMessageToAPI(msg))
+}
+
+// SendEmail handles POST /api/email/send.
+func (s *Server) SendEmail(w http.ResponseWriter, r *http.Request, params apiserver.SendEmailParams) {
+	acct, ok := s.loadEmailAccount(w, r, params.Account)
+	if !ok {
+		return
+	}
+
+	var body apitypes.EmailSendRequest
+	if err := decodeJSON(r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+
+	opts := email.SendOptions{
+		To:      body.To,
+		Subject: body.Subject,
+		Body:    body.Body,
+	}
+	if body.Cc != nil {
+		opts.Cc = *body.Cc
+	}
+	if body.Bcc != nil {
+		opts.Bcc = *body.Bcc
+	}
+	if body.Html != nil {
+		opts.HTML = *body.Html
+	}
+	if body.From != nil {
+		opts.From = *body.From
+	}
+	if body.ReplyTo != nil {
+		opts.ReplyTo = *body.ReplyTo
+	}
+	if body.InReplyTo != nil {
+		opts.InReplyTo = *body.InReplyTo
+	}
+
+	if err := email.Send(acct, opts); err != nil {
+		s.writeInternalError(w, err)
+		return
+	}
+
+	writeData(w, http.StatusOK, apitypes.EmailSendResult{Sent: true})
+}
+
+// MarkEmailMessage handles POST /api/email/messages/{uid}/mark.
+func (s *Server) MarkEmailMessage(w http.ResponseWriter, r *http.Request, uid int, params apiserver.MarkEmailMessageParams) {
+	acct, ok := s.loadEmailAccount(w, r, params.Account)
+	if !ok {
+		return
+	}
+
+	var body apitypes.EmailMarkRequest
+	if err := decodeJSON(r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+
+	folder := "INBOX"
+	if params.Folder != nil {
+		folder = *params.Folder
+	}
+
+	if err := email.MarkSeen(acct, folder, uint32(uid), body.Seen); err != nil {
+		s.writeInternalError(w, err)
+		return
+	}
+
+	writeNoContent(w)
+}
+
+// --------------- converters ---------------
+
+func emailEnvelopeToAPI(e email.Envelope) apitypes.EmailEnvelope {
+	env := apitypes.EmailEnvelope{
+		Uid:     int(e.UID),
+		From:    e.From,
+		Subject: e.Subject,
+		Date:    e.Date.UTC(),
+	}
+	if e.MessageID != "" {
+		env.MessageId = &e.MessageID
+	}
+	if e.FromName != "" {
+		env.FromName = &e.FromName
+	}
+	if e.FromAddr != "" {
+		env.FromAddr = &e.FromAddr
+	}
+	if len(e.To) > 0 {
+		env.To = &e.To
+	}
+	if len(e.Flags) > 0 {
+		env.Flags = &e.Flags
+	}
+	if e.HasAttachments {
+		env.HasAttachments = &e.HasAttachments
+	}
+	if e.Size > 0 {
+		size := int(e.Size)
+		env.Size = &size
+	}
+	return env
+}
+
+func emailMessageToAPI(m *email.Message) apitypes.EmailMessage {
+	msg := apitypes.EmailMessage{
+		Uid:     int(m.UID),
+		From:    m.From,
+		Subject: m.Subject,
+		Date:    m.Date.UTC(),
+	}
+	if m.MessageID != "" {
+		msg.MessageId = &m.MessageID
+	}
+	if m.FromName != "" {
+		msg.FromName = &m.FromName
+	}
+	if m.FromAddr != "" {
+		msg.FromAddr = &m.FromAddr
+	}
+	if len(m.To) > 0 {
+		msg.To = &m.To
+	}
+	if len(m.Flags) > 0 {
+		msg.Flags = &m.Flags
+	}
+	if m.HasAttachments {
+		msg.HasAttachments = &m.HasAttachments
+	}
+	if m.Size > 0 {
+		size := int(m.Size)
+		msg.Size = &size
+	}
+	if m.TextBody != "" {
+		msg.TextBody = &m.TextBody
+	}
+	if m.HTMLBody != "" {
+		msg.HtmlBody = &m.HTMLBody
+	}
+	if len(m.Attachments) > 0 {
+		atts := make([]apitypes.EmailAttachmentInfo, 0, len(m.Attachments))
+		for _, a := range m.Attachments {
+			att := apitypes.EmailAttachmentInfo{}
+			if a.Filename != "" {
+				att.Filename = &a.Filename
+			}
+			if a.Size > 0 {
+				size := int(a.Size)
+				att.Size = &size
+			}
+			if a.MIMEType != "" {
+				att.MimeType = &a.MIMEType
+			}
+			atts = append(atts, att)
+		}
+		msg.Attachments = &atts
+	}
+	return msg
+}

--- a/internal/server/email.go
+++ b/internal/server/email.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	apiserver "github.com/CherryHQ/stella/api/server"
 	apitypes "github.com/CherryHQ/stella/api/types"
@@ -62,6 +63,10 @@ func (s *Server) loadEmailAccount(w http.ResponseWriter, r *http.Request, accoun
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("resolve email account: %v", err))
 		return email.EmailAccount{}, false
 	}
+	if err := email.ValidateAccountEgress(acct); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return email.EmailAccount{}, false
+	}
 	return acct, true
 }
 
@@ -88,12 +93,18 @@ func (s *Server) ListEmailMessages(w http.ResponseWriter, r *http.Request, param
 		return
 	}
 
-	opts := email.ListOptions{}
+	limit := 20
+	if params.Limit != nil {
+		limit = *params.Limit
+	}
+	if limit < 1 || limit > 500 {
+		writeError(w, http.StatusBadRequest, "limit must be between 1 and 500")
+		return
+	}
+
+	opts := email.ListOptions{Limit: limit}
 	if params.Folder != nil {
 		opts.Folder = *params.Folder
-	}
-	if params.Limit != nil {
-		opts.Limit = *params.Limit
 	}
 	if params.Unread != nil {
 		opts.Unread = *params.Unread
@@ -133,14 +144,23 @@ func (s *Server) GetEmailMessage(w http.ResponseWriter, r *http.Request, uid int
 		return
 	}
 
+	imapUID, ok := parseIMAPUID(w, uid)
+	if !ok {
+		return
+	}
+
 	folder := "INBOX"
 	if params.Folder != nil {
 		folder = *params.Folder
 	}
 
-	msg, err := email.Read(acct, folder, uint32(uid))
+	msg, err := email.Read(acct, folder, imapUID)
 	if err != nil {
-		s.writeInternalError(w, err)
+		if errors.Is(err, email.ErrMessageNotFound) {
+			writeError(w, http.StatusNotFound, "message not found")
+		} else {
+			s.writeInternalError(w, err)
+		}
 		return
 	}
 
@@ -157,6 +177,18 @@ func (s *Server) SendEmail(w http.ResponseWriter, r *http.Request, params apiser
 	var body apitypes.EmailSendRequest
 	if err := decodeJSON(r, &body); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	if len(body.To) == 0 {
+		writeError(w, http.StatusBadRequest, "to must contain at least one recipient")
+		return
+	}
+	if strings.TrimSpace(body.Subject) == "" {
+		writeError(w, http.StatusBadRequest, "subject is required")
+		return
+	}
+	if strings.TrimSpace(body.Body) == "" {
+		writeError(w, http.StatusBadRequest, "body is required")
 		return
 	}
 
@@ -199,9 +231,20 @@ func (s *Server) MarkEmailMessage(w http.ResponseWriter, r *http.Request, uid in
 		return
 	}
 
-	var body apitypes.EmailMarkRequest
+	imapUID, ok := parseIMAPUID(w, uid)
+	if !ok {
+		return
+	}
+
+	var body struct {
+		Seen *bool `json:"seen"`
+	}
 	if err := decodeJSON(r, &body); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	if body.Seen == nil {
+		writeError(w, http.StatusBadRequest, "seen is required")
 		return
 	}
 
@@ -210,12 +253,25 @@ func (s *Server) MarkEmailMessage(w http.ResponseWriter, r *http.Request, uid in
 		folder = *params.Folder
 	}
 
-	if err := email.MarkSeen(acct, folder, uint32(uid), body.Seen); err != nil {
-		s.writeInternalError(w, err)
+	if err := email.MarkSeen(acct, folder, imapUID, *body.Seen); err != nil {
+		if errors.Is(err, email.ErrMessageNotFound) {
+			writeError(w, http.StatusNotFound, "message not found")
+		} else {
+			s.writeInternalError(w, err)
+		}
 		return
 	}
 
 	writeNoContent(w)
+}
+
+func parseIMAPUID(w http.ResponseWriter, uid int) (uint32, bool) {
+	const maxIMAPUID = int64(^uint32(0))
+	if uid < 1 || int64(uid) > maxIMAPUID {
+		writeError(w, http.StatusBadRequest, "uid must be between 1 and 4294967295")
+		return 0, false
+	}
+	return uint32(uid), true
 }
 
 // --------------- converters ---------------

--- a/internal/server/email.go
+++ b/internal/server/email.go
@@ -13,6 +13,11 @@ import (
 	"github.com/CherryHQ/stella/internal/email"
 )
 
+// maxEmailRequestBytes caps the JSON body of email write endpoints. Attachments
+// are not accepted over the API, so a few MB is ample for headers and text body
+// while bounding memory use from an authenticated client.
+const maxEmailRequestBytes = 5 << 20
+
 // loadEmailAccount loads the EMAIL_CONFIG vault entry for the authenticated
 // user, parses it, and resolves the requested account name. On failure it
 // writes an error response and returns a zero value + false.
@@ -31,7 +36,7 @@ func (s *Server) loadEmailAccount(w http.ResponseWriter, r *http.Request, accoun
 	value, err := s.vaultSvc.Get(r.Context(), info.UserID, "EMAIL_CONFIG")
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			writeError(w, http.StatusBadRequest, "no email accounts configured — use 'stella email config add' first")
+			writeError(w, http.StatusBadRequest, "no email accounts configured")
 			return email.EmailAccount{}, false
 		}
 		s.log.Error("load email config from vault", "user_id", info.UserID, "error", err)
@@ -50,7 +55,7 @@ func (s *Server) loadEmailAccount(w http.ResponseWriter, r *http.Request, accoun
 		cfg.Accounts = make(map[string]email.EmailAccount)
 	}
 	if len(cfg.Accounts) == 0 {
-		writeError(w, http.StatusBadRequest, "no email accounts configured — use 'stella email config add' first")
+		writeError(w, http.StatusBadRequest, "no email accounts configured")
 		return email.EmailAccount{}, false
 	}
 
@@ -174,6 +179,7 @@ func (s *Server) SendEmail(w http.ResponseWriter, r *http.Request, params apiser
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, maxEmailRequestBytes)
 	var body apitypes.EmailSendRequest
 	if err := decodeJSON(r, &body); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON")
@@ -221,7 +227,7 @@ func (s *Server) SendEmail(w http.ResponseWriter, r *http.Request, params apiser
 		return
 	}
 
-	writeData(w, http.StatusOK, apitypes.EmailSendResult{Sent: true})
+	writeNoContent(w)
 }
 
 // MarkEmailMessage handles POST /api/email/messages/{uid}/mark.
@@ -236,6 +242,7 @@ func (s *Server) MarkEmailMessage(w http.ResponseWriter, r *http.Request, uid in
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, maxEmailRequestBytes)
 	var body struct {
 		Seen *bool `json:"seen"`
 	}


### PR DESCRIPTION
## What

Five follow-up items from the stella/stellad binary split (#298):

1. **#305** — Improve Windows upgrade rollback and stale artifact cleanup
2. **#306** — Migrate email CLI commands to stellad API endpoints
3. **#299** — Verify release archive checksums during upgrade
4. **#300** — Add size limits to upgrade archive extraction
5. **#301** — Harden service install against user-writable binary paths

## Why

These were identified as accepted risks/side quests during the code review of PR #295. They harden the upgrade path, enforce the CLI/daemon architectural boundary for email, and prevent service install from referencing user-writable binaries.

## How

### Commit 1: Windows upgrade fix (#305)
- Rename locked binaries to `.old` on Windows instead of failing
- `cleanStaleUpgradeArtifacts` removes `.tmp`/`.bak`/`.old` on startup
- `warnStaleUpgradeArtifacts` detects interrupted upgrades
- 5 new tests

### Commit 2: Email API migration (#306)
- OpenAPI spec: `api/spec/domain/email/` — 8 schemas, 5 endpoints
- Server handlers: `internal/server/email.go` — vault-based config per user
- CLI conversion: all IMAP/SMTP ops go through `apiclient.Call`/`Do`
- `--attach` and `--save-attachments` not yet supported via API

### Commit 3: Checksum verification + size limits (#299, #300)
- Fetch `checksums.txt` from release, verify SHA-256 before extraction
- Graceful fallback if checksums.txt absent
- `io.LimitReader` caps extracted binary at 100 MB
- 5 new tests (parseChecksum, sha256File, findChecksumAsset, etc.)

### Commit 4: Service path security (#301)
- Linux: `checkBinaryPathSecurity` rejects world/group-writable paths
- macOS: warns if binary is world-writable
- Actionable error messages with fix instructions

## Refs

- Closes #299, #300, #301, #305, #306
- Parent: #298