### PR TITLE
fix(feishu): handle inline images in post messages

### DIFF
--- a/plugins/channels/feishu/download.go
+++ b/plugins/channels/feishu/download.go
@@ -10,6 +10,11 @@ import (
 	"github.com/CherryHQ/stella/internal/agent"
 )
 
+// maxImageBytes caps a single downloaded image. base64-encoding holds ~1.33x of
+// this in memory on top of the raw bytes, so the limit bounds per-message peak
+// memory even when a post references many inline images.
+const maxImageBytes = 20 << 20 // 20 MiB
+
 // downloadImage downloads an image from Feishu using the MessageResource API.
 func (b *Bot) downloadImage(messageID, imageKey string) ([]byte, string, error) {
 	apiCtx, cancel := b.apiContext()
@@ -34,9 +39,12 @@ func (b *Bot) downloadImage(messageID, imageKey string) ([]byte, string, error) 
 		defer func() { _ = closer.Close() }()
 	}
 
-	data, err := io.ReadAll(resp.File)
+	data, err := io.ReadAll(io.LimitReader(resp.File, maxImageBytes+1))
 	if err != nil {
 		return nil, "", fmt.Errorf("read file: %w", err)
+	}
+	if len(data) > maxImageBytes {
+		return nil, "", fmt.Errorf("image exceeds %d bytes", maxImageBytes)
 	}
 
 	mime := http.DetectContentType(data)

--- a/plugins/channels/feishu/feishu_test.go
+++ b/plugins/channels/feishu/feishu_test.go
@@ -874,6 +874,55 @@ func TestParsePostBlocksInvalidJSON(t *testing.T) {
 	}
 }
 
+func TestParsePostBlocksLink(t *testing.T) {
+	raw := `{"title":"","content":[[{"tag":"text","text":"see "},{"tag":"a","text":"docs","href":"https://x.io"}]]}`
+	text, images := parsePostBlocks(raw)
+	if text != "see docs (https://x.io)" {
+		t.Errorf("text = %q, want link with href", text)
+	}
+	if len(images) != 0 {
+		t.Errorf("images = %v, want empty", images)
+	}
+}
+
+func TestParsePostBlocksMention(t *testing.T) {
+	raw := `{"title":"","content":[[{"tag":"at","user_id":"ou_1","user_name":"Alice"},{"tag":"text","text":" ping"}]]}`
+	text, _ := parsePostBlocks(raw)
+	if text != "@Alice ping" {
+		t.Errorf("text = %q, want %q", text, "@Alice ping")
+	}
+}
+
+func TestParsePostBlocksMedia(t *testing.T) {
+	raw := `{"title":"","content":[[{"tag":"media","file_key":"f1","image_key":"i1"}]]}`
+	text, images := parsePostBlocks(raw)
+	if text != "[Video]" {
+		t.Errorf("text = %q, want %q", text, "[Video]")
+	}
+	if len(images) != 0 {
+		t.Errorf("images = %v, want empty", images)
+	}
+}
+
+func TestParsePostBlocksDedupImages(t *testing.T) {
+	raw := `{"title":"","content":[[{"tag":"img","image_key":"dup"}],[{"tag":"img","image_key":"dup"}]]}`
+	_, images := parsePostBlocks(raw)
+	if len(images) != 1 || images[0] != "dup" {
+		t.Errorf("images = %v, want [dup]", images)
+	}
+}
+
+func TestParsePostBlocksLocaleWrapped(t *testing.T) {
+	raw := `{"zh_cn":{"title":"标题","content":[[{"tag":"text","text":"hi"},{"tag":"img","image_key":"img_w"}]]}}`
+	text, images := parsePostBlocks(raw)
+	if text != "标题\nhi" {
+		t.Errorf("text = %q, want %q", text, "标题\nhi")
+	}
+	if len(images) != 1 || images[0] != "img_w" {
+		t.Errorf("images = %v, want [img_w]", images)
+	}
+}
+
 func TestBuildMessageContentUnsupportedType(t *testing.T) {
 	bot := &Bot{}
 	msgType := "card_action"

--- a/plugins/channels/feishu/feishu_test.go
+++ b/plugins/channels/feishu/feishu_test.go
@@ -797,6 +797,83 @@ func TestParseMergeForwardContent(t *testing.T) {
 	}
 }
 
+// --- parsePostBlocks ---
+
+func TestParsePostBlocksTextOnly(t *testing.T) {
+	raw := `{"title":"","content":[[{"tag":"text","text":"hello world"}]]}`
+	text, images := parsePostBlocks(raw)
+	if text != "hello world" {
+		t.Errorf("text = %q, want %q", text, "hello world")
+	}
+	if len(images) != 0 {
+		t.Errorf("images = %v, want empty", images)
+	}
+}
+
+func TestParsePostBlocksWithTitle(t *testing.T) {
+	raw := `{"title":"My Title","content":[[{"tag":"text","text":"body"}]]}`
+	text, images := parsePostBlocks(raw)
+	if text != "My Title\nbody" {
+		t.Errorf("text = %q, want %q", text, "My Title\nbody")
+	}
+	if len(images) != 0 {
+		t.Errorf("images = %v, want empty", images)
+	}
+}
+
+func TestParsePostBlocksWithImage(t *testing.T) {
+	raw := `{"title":"","content":[[{"tag":"text","text":"see this: "},{"tag":"img","image_key":"img_v3_abc"}]]}`
+	text, images := parsePostBlocks(raw)
+	if text != "see this: " {
+		t.Errorf("text = %q, want %q", text, "see this: ")
+	}
+	if len(images) != 1 || images[0] != "img_v3_abc" {
+		t.Errorf("images = %v, want [img_v3_abc]", images)
+	}
+}
+
+func TestParsePostBlocksImageOnly(t *testing.T) {
+	raw := `{"title":"","content":[[{"tag":"img","image_key":"img_v3_xyz"}]]}`
+	text, images := parsePostBlocks(raw)
+	if text != "" {
+		t.Errorf("text = %q, want empty", text)
+	}
+	if len(images) != 1 || images[0] != "img_v3_xyz" {
+		t.Errorf("images = %v, want [img_v3_xyz]", images)
+	}
+}
+
+func TestParsePostBlocksMultipleParagraphs(t *testing.T) {
+	raw := `{"title":"","content":[[{"tag":"text","text":"line1"}],[{"tag":"text","text":"line2"},{"tag":"img","image_key":"img1"}]]}`
+	text, images := parsePostBlocks(raw)
+	if text != "line1\nline2" {
+		t.Errorf("text = %q, want %q", text, "line1\nline2")
+	}
+	if len(images) != 1 || images[0] != "img1" {
+		t.Errorf("images = %v, want [img1]", images)
+	}
+}
+
+func TestParsePostBlocksEmpty(t *testing.T) {
+	text, images := parsePostBlocks("")
+	if text != "" {
+		t.Errorf("text = %q, want empty", text)
+	}
+	if images != nil {
+		t.Errorf("images = %v, want nil", images)
+	}
+}
+
+func TestParsePostBlocksInvalidJSON(t *testing.T) {
+	text, images := parsePostBlocks("not json")
+	if text != "not json" {
+		t.Errorf("text = %q, want fallback", text)
+	}
+	if images != nil {
+		t.Errorf("images = %v, want nil", images)
+	}
+}
+
 func TestBuildMessageContentUnsupportedType(t *testing.T) {
 	bot := &Bot{}
 	msgType := "card_action"

--- a/plugins/channels/feishu/handler.go
+++ b/plugins/channels/feishu/handler.go
@@ -239,7 +239,33 @@ func (b *Bot) buildMessageContent(msg *larkim.EventMessage, assetsDir string) []
 		if strings.TrimSpace(rawContent) == "" {
 			return nil
 		}
-		return channel.TextContent(rawContent)
+		text, imageKeys := parsePostBlocks(rawContent)
+		if len(imageKeys) == 0 {
+			// No inline images — return extracted text (or raw content as fallback).
+			if strings.TrimSpace(text) == "" {
+				return nil
+			}
+			return channel.TextContent(text)
+		}
+		// Build mixed content: text + downloaded images.
+		var blocks []ai.ContentBlock
+		if strings.TrimSpace(text) != "" {
+			blocks = append(blocks, ai.TextContent{Text: text})
+		}
+		for _, imgKey := range imageKeys {
+			data, mime, err := b.downloadImage(messageID, imgKey)
+			if err != nil {
+				logger().Error("download post image failed", "image_key", imgKey, "error", err)
+				blocks = append(blocks, ai.TextContent{Text: fmt.Sprintf("[Failed to download image: %s]", imgKey)})
+				continue
+			}
+			encoded := base64.StdEncoding.EncodeToString(data)
+			blocks = append(blocks, ai.ImageContent{Data: encoded, MimeType: mime})
+		}
+		if len(blocks) == 0 {
+			return nil
+		}
+		return blocks
 
 	case "image":
 		imageKey := extractJSONField(rawContent, "image_key")
@@ -250,7 +276,7 @@ func (b *Bot) buildMessageContent(msg *larkim.EventMessage, assetsDir string) []
 		data, mime, err := b.downloadImage(messageID, imageKey)
 		if err != nil {
 			logger().Error("download image failed", "image_key", imageKey, "error", err)
-			return nil
+			return channel.TextContent("[Failed to download image]")
 		}
 		encoded := base64.StdEncoding.EncodeToString(data)
 		logger().Debug("image received", "size", len(data), "mime", mime)

--- a/plugins/channels/feishu/handler.go
+++ b/plugins/channels/feishu/handler.go
@@ -218,6 +218,19 @@ func prependSystemPrompt(content []ai.ContentBlock, prompt string) []ai.ContentB
 	return append([]ai.ContentBlock{prefix}, content...)
 }
 
+// imageContentBlock downloads an image by key and returns it as an ImageContent
+// block. The bool is false when the download fails (already logged), letting
+// callers decide whether to drop the message or emit a text fallback.
+func (b *Bot) imageContentBlock(messageID, imageKey string) (ai.ImageContent, bool) {
+	data, mime, err := b.downloadImage(messageID, imageKey)
+	if err != nil {
+		logger().Error("download image failed", "image_key", imageKey, "error", err)
+		return ai.ImageContent{}, false
+	}
+	logger().Debug("image received", "size", len(data), "mime", mime)
+	return ai.ImageContent{Data: base64.StdEncoding.EncodeToString(data), MimeType: mime}, true
+}
+
 // buildMessageContent constructs the message content from a Feishu message.
 // assetsDir is the resolved per-user assets directory; pass "" to fall back to
 // the filename-only placeholder when the path is not yet known.
@@ -240,9 +253,10 @@ func (b *Bot) buildMessageContent(msg *larkim.EventMessage, assetsDir string) []
 			return nil
 		}
 		text, imageKeys := parsePostBlocks(rawContent)
+		text = stripMentions(text, msg.Mentions)
 		if len(imageKeys) == 0 {
-			// No inline images — return extracted text (or raw content as fallback).
 			if strings.TrimSpace(text) == "" {
+				logger().Warn("post message produced no usable content", "message_id", messageID)
 				return nil
 			}
 			return channel.TextContent(text)
@@ -253,14 +267,12 @@ func (b *Bot) buildMessageContent(msg *larkim.EventMessage, assetsDir string) []
 			blocks = append(blocks, ai.TextContent{Text: text})
 		}
 		for _, imgKey := range imageKeys {
-			data, mime, err := b.downloadImage(messageID, imgKey)
-			if err != nil {
-				logger().Error("download post image failed", "image_key", imgKey, "error", err)
+			block, ok := b.imageContentBlock(messageID, imgKey)
+			if !ok {
 				blocks = append(blocks, ai.TextContent{Text: fmt.Sprintf("[Failed to download image: %s]", imgKey)})
 				continue
 			}
-			encoded := base64.StdEncoding.EncodeToString(data)
-			blocks = append(blocks, ai.ImageContent{Data: encoded, MimeType: mime})
+			blocks = append(blocks, block)
 		}
 		if len(blocks) == 0 {
 			return nil
@@ -273,16 +285,11 @@ func (b *Bot) buildMessageContent(msg *larkim.EventMessage, assetsDir string) []
 			logger().Warn("image message missing image_key")
 			return nil
 		}
-		data, mime, err := b.downloadImage(messageID, imageKey)
-		if err != nil {
-			logger().Error("download image failed", "image_key", imageKey, "error", err)
+		block, ok := b.imageContentBlock(messageID, imageKey)
+		if !ok {
 			return channel.TextContent("[Failed to download image]")
 		}
-		encoded := base64.StdEncoding.EncodeToString(data)
-		logger().Debug("image received", "size", len(data), "mime", mime)
-		return []ai.ContentBlock{
-			ai.ImageContent{Data: encoded, MimeType: mime},
-		}
+		return []ai.ContentBlock{block}
 
 	case "audio":
 		return channel.TextContent(parseAudioContent(rawContent))

--- a/plugins/channels/feishu/parse.go
+++ b/plugins/channels/feishu/parse.go
@@ -3,6 +3,7 @@ package feishu
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 // extractJSONField extracts a string field from a JSON object.
@@ -126,4 +127,51 @@ func parseShareUserContent(raw string) string {
 // parseMergeForwardContent returns descriptive text for a merge-forwarded message.
 func parseMergeForwardContent(_ string) string {
 	return "[Forwarded messages]"
+}
+
+// postNode represents a single element inside a Feishu "post" rich-text message.
+type postNode struct {
+	Tag      string `json:"tag"`
+	Text     string `json:"text,omitempty"`
+	ImageKey string `json:"image_key,omitempty"`
+}
+
+// parsePostBlocks parses Feishu post (rich text) JSON content and returns the
+// concatenated plain text along with any image keys found across all paragraphs.
+// Post content format: {"title":"...","content":[[{node},{node}],[{node}]]}
+func parsePostBlocks(raw string) (text string, imageKeys []string) {
+	if raw == "" {
+		return "", nil
+	}
+
+	var post struct {
+		Title   string       `json:"title"`
+		Content [][]postNode `json:"content"`
+	}
+	if err := json.Unmarshal([]byte(raw), &post); err != nil {
+		return raw, nil
+	}
+
+	var textParts []string
+	if post.Title != "" {
+		textParts = append(textParts, post.Title)
+	}
+	for _, paragraph := range post.Content {
+		var line string
+		for _, node := range paragraph {
+			switch node.Tag {
+			case "text":
+				line += node.Text
+			case "img":
+				if node.ImageKey != "" {
+					imageKeys = append(imageKeys, node.ImageKey)
+				}
+			}
+		}
+		if line != "" {
+			textParts = append(textParts, line)
+		}
+	}
+
+	return strings.Join(textParts, "\n"), imageKeys
 }

--- a/plugins/channels/feishu/parse.go
+++ b/plugins/channels/feishu/parse.go
@@ -133,12 +133,18 @@ func parseMergeForwardContent(_ string) string {
 type postNode struct {
 	Tag      string `json:"tag"`
 	Text     string `json:"text,omitempty"`
+	Href     string `json:"href,omitempty"`
+	UserName string `json:"user_name,omitempty"`
 	ImageKey string `json:"image_key,omitempty"`
 }
 
 // parsePostBlocks parses Feishu post (rich text) JSON content and returns the
-// concatenated plain text along with any image keys found across all paragraphs.
-// Post content format: {"title":"...","content":[[{node},{node}],[{node}]]}
+// concatenated plain text along with the (deduplicated) image keys found across
+// all paragraphs. Received post content is the flat
+// {"title":"...","content":[[{node}]]} shape; the locale-wrapped
+// {"zh_cn":{...}} form is unwrapped first as a defensive fallback. Supported
+// nodes: text, a (link), at (mention), img; media renders as a placeholder and
+// other tags are ignored.
 func parsePostBlocks(raw string) (text string, imageKeys []string) {
 	if raw == "" {
 		return "", nil
@@ -148,10 +154,11 @@ func parsePostBlocks(raw string) (text string, imageKeys []string) {
 		Title   string       `json:"title"`
 		Content [][]postNode `json:"content"`
 	}
-	if err := json.Unmarshal([]byte(raw), &post); err != nil {
+	if err := json.Unmarshal(unwrapPostLocale(raw), &post); err != nil {
 		return raw, nil
 	}
 
+	seen := make(map[string]bool)
 	var textParts []string
 	if post.Title != "" {
 		textParts = append(textParts, post.Title)
@@ -162,8 +169,17 @@ func parsePostBlocks(raw string) (text string, imageKeys []string) {
 			switch node.Tag {
 			case "text":
 				line += node.Text
+			case "a":
+				line += postLinkText(node)
+			case "at":
+				if node.UserName != "" {
+					line += "@" + node.UserName
+				}
+			case "media":
+				line += "[Video]"
 			case "img":
-				if node.ImageKey != "" {
+				if node.ImageKey != "" && !seen[node.ImageKey] {
+					seen[node.ImageKey] = true
 					imageKeys = append(imageKeys, node.ImageKey)
 				}
 			}
@@ -174,4 +190,33 @@ func parsePostBlocks(raw string) (text string, imageKeys []string) {
 	}
 
 	return strings.Join(textParts, "\n"), imageKeys
+}
+
+// postLinkText renders an "a" (link) node, keeping both display text and URL
+// when they differ so the model sees the destination.
+func postLinkText(node postNode) string {
+	switch {
+	case node.Text != "" && node.Href != "" && node.Text != node.Href:
+		return node.Text + " (" + node.Href + ")"
+	case node.Text != "":
+		return node.Text
+	default:
+		return node.Href
+	}
+}
+
+// unwrapPostLocale returns the inner content of a locale-wrapped post
+// ({"zh_cn":{...}}) when present, otherwise the original bytes. Received post
+// events are already flat, so this only guards against the send-shaped form.
+func unwrapPostLocale(raw string) []byte {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		return []byte(raw)
+	}
+	for _, locale := range []string{"zh_cn", "en_us", "ja_jp"} {
+		if v, ok := m[locale]; ok {
+			return v
+		}
+	}
+	return []byte(raw)
 }


### PR DESCRIPTION
## Summary
- Parse Feishu "post" (rich text) messages to extract inline images (`tag:"img"`), download them via the message resource API, and pass them as `ImageContent` blocks to the LLM — previously the raw JSON with `image_key` references was passed as plain text
- Return `[Failed to download image]` text feedback instead of silently dropping the entire message when image download fails
- Add `parsePostBlocks()` function in `parse.go` with 7 unit tests covering text-only, image-only, mixed, multi-paragraph, title, empty, and invalid JSON cases

## Test plan
- [x] `go vet` passes
- [x] `go build` passes  
- [x] All existing tests pass (feishu plugin: 50+ tests)
- [x] 7 new `TestParsePostBlocks*` tests pass
- [ ] Manual test: send a rich text post with inline image in Feishu group → bot should see the actual image
- [ ] Manual test: send a pure image message when bot lacks `im:resource` permission → should get error text instead of silence

🤖 Generated with [Claude Code](https://claude.com/claude-code)