### PR TITLE
feat(recally): subscribe to Twitter/X user feeds via fxembed

### DIFF
--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -1287,6 +1287,10 @@ components:
     FeedEntryStatus:
       type: string
       enum: [pending, saved, skipped, error]
+    FeedKind:
+      type: string
+      description: "Extraction-dispatch hint. 'rss' uses the built-in poller; other kinds are extracted by the recally skill."
+      enum: [rss, twitter]
     Article:
       type: object
       required: [
@@ -1438,6 +1442,7 @@ components:
       required: [
         id,
         url,
+        kind,
         title,
         check_interval,
         enabled,
@@ -1453,6 +1458,12 @@ components:
         url:
           type: string
           format: uri
+        kind:
+          $ref: "#/components/schemas/FeedKind"
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
         title:
           type: string
         description:
@@ -1493,9 +1504,12 @@ components:
         url:
           type: string
           format: uri
+        kind:
+          allOf: [{ $ref: "#/components/schemas/FeedKind" }]
+          description: "Escape hatch to force the feed kind. Omit to let the server sniff it from the URL (x.com/twitter.com → twitter, otherwise rss)."
         title:
           type: string
-          description: "Optional override; server fetches feed metadata if omitted"
+          description: "Optional override; server fetches feed metadata if omitted (rss only)"
         agent_id:
           type: string
           nullable: true
@@ -1562,6 +1576,28 @@ components:
           nullable: true
         error_msg:
           type: string
+    CreateFeedEntryRequest:
+      type: object
+      required: [guid]
+      properties:
+        guid:
+          type: string
+          description: "Stable per-source item id; the dedup key (unique per feed)"
+        url:
+          type: string
+        title:
+          type: string
+    CreateFeedEntryResult:
+      type: object
+      required: [created]
+      properties:
+        created:
+          type: boolean
+          description: "true if a new entry was inserted; false if the guid already existed (dup)"
+        entry:
+          allOf: [{ $ref: "#/components/schemas/FeedEntry" }]
+          nullable: true
+          description: "The inserted entry; null on dup (ON CONFLICT DO NOTHING returns no row)"
     FeedPollResult:
       type: object
       required: [feed, new_entries]

--- a/api/spec/domain/recally/paths.yaml
+++ b/api/spec/domain/recally/paths.yaml
@@ -321,6 +321,33 @@ paths:
           $ref: "../../components.yaml#/components/responses/Unauthorized",
         }
         "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+    post:
+      tags: [feed-entries]
+      summary: Add an entry by guid (source-agnostic; dedups via ON CONFLICT)
+      description: "Skill-driven extraction pushes discovered items here. Idempotent on (feed_id, guid): a returned created=false means the item already existed."
+      operationId: createFeedEntry
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {
+              $ref: "../../components.yaml#/components/schemas/CreateFeedEntryRequest",
+            }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: {
+                $ref: "../../components.yaml#/components/schemas/CreateFeedEntryResult",
+              }
+        "400": {
+          $ref: "../../components.yaml#/components/responses/BadRequest",
+        }
+        "401": {
+          $ref: "../../components.yaml#/components/responses/Unauthorized",
+        }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
 
   /api/recally/feeds/{feedId}/entries/{id}:
     parameters:

--- a/api/spec/domain/recally/schemas.yaml
+++ b/api/spec/domain/recally/schemas.yaml
@@ -18,6 +18,11 @@ components:
       type: string
       enum: [pending, saved, skipped, error]
 
+    FeedKind:
+      type: string
+      description: "Extraction-dispatch hint. 'rss' uses the built-in poller; other kinds are extracted by the recally skill."
+      enum: [rss, twitter]
+
     Article:
       type: object
       required: [
@@ -113,6 +118,7 @@ components:
       required: [
         id,
         url,
+        kind,
         title,
         check_interval,
         enabled,
@@ -123,6 +129,10 @@ components:
         id: { type: string }
         agent_id: { type: string, nullable: true }
         url: { type: string, format: uri }
+        kind: { $ref: "#/components/schemas/FeedKind" }
+        metadata:
+          type: object
+          additionalProperties: { type: string }
         title: { type: string }
         description: { type: string }
         check_interval: { type: string }
@@ -145,9 +155,12 @@ components:
       required: [url]
       properties:
         url: { type: string, format: uri }
+        kind:
+          allOf: [{ $ref: "#/components/schemas/FeedKind" }]
+          description: "Escape hatch to force the feed kind. Omit to let the server sniff it from the URL (x.com/twitter.com → twitter, otherwise rss)."
         title: {
           type: string,
-          description: "Optional override; server fetches feed metadata if omitted",
+          description: "Optional override; server fetches feed metadata if omitted (rss only)",
         }
         agent_id: { type: string, nullable: true }
 
@@ -192,6 +205,30 @@ components:
         status: { $ref: "#/components/schemas/FeedEntryStatus" }
         article_id: { type: string, nullable: true }
         error_msg: { type: string }
+
+    CreateFeedEntryRequest:
+      type: object
+      required: [guid]
+      properties:
+        guid: {
+          type: string,
+          description: "Stable per-source item id; the dedup key (unique per feed)",
+        }
+        url: { type: string }
+        title: { type: string }
+
+    CreateFeedEntryResult:
+      type: object
+      required: [created]
+      properties:
+        created: {
+          type: boolean,
+          description: "true if a new entry was inserted; false if the guid already existed (dup)",
+        }
+        entry:
+          allOf: [{ $ref: "#/components/schemas/FeedEntry" }]
+          nullable: true
+          description: "The inserted entry; null on dup (ON CONFLICT DO NOTHING returns no row)"
 
     FeedPollResult:
       type: object

--- a/cmd/stella/recally_feeds.go
+++ b/cmd/stella/recally_feeds.go
@@ -24,6 +24,7 @@ check all feeds at once or target a single feed by ID.`,
 			recallyFeedRemoveCommand(),
 			recallyFeedPollCommand(),
 			recallyFeedMarkCommand(),
+			recallyFeedEntryCommand(),
 		},
 	}
 }
@@ -31,16 +32,24 @@ check all feeds at once or target a single feed by ID.`,
 func recallyFeedAddCommand() *ucli.Command {
 	return &ucli.Command{
 		Name:      "add",
-		Usage:     "Subscribe to an RSS feed (server fetches feed metadata)",
+		Usage:     "Subscribe to a feed (kind is sniffed from the URL unless --kind is set)",
 		ArgsUsage: "<feed-url>",
-		Flags:     []ucli.Flag{cli.JSONFlag()},
+		Flags: []ucli.Flag{
+			&ucli.StringFlag{Name: "kind", Usage: "Force feed kind: rss, twitter (default: sniff from URL)"},
+			cli.JSONFlag(),
+		},
 		Action: func(c *ucli.Context) error {
 			feedURL := c.Args().First()
 			if feedURL == "" {
 				return fmt.Errorf("usage: stella recally feed add <feed-url>")
 			}
+			body := apiclient.CreateFeedJSONRequestBody{Url: feedURL}
+			if v := c.String("kind"); v != "" {
+				kind := apitypes.FeedKind(v)
+				body.Kind = &kind
+			}
 			feed, err := apiclient.Call[apiclient.Feed](func(api *apiclient.Client) (*http.Response, error) {
-				return api.CreateFeed(c.Context, apiclient.CreateFeedJSONRequestBody{Url: feedURL})
+				return api.CreateFeed(c.Context, body)
 			})
 			if err != nil {
 				return err
@@ -50,8 +59,62 @@ func recallyFeedAddCommand() *ucli.Command {
 			}
 			o := cli.Stdout(c)
 			o.Printf("Subscribed to feed: %s\n", feed.Id)
+			o.Printf("  Kind: %s\n", feed.Kind)
 			o.Printf("  Title: %s\n", feed.Title)
 			o.Printf("  URL: %s\n", feed.Url)
+			return o.Err()
+		},
+	}
+}
+
+func recallyFeedEntryCommand() *ucli.Command {
+	return &ucli.Command{
+		Name:  "entry",
+		Usage: "Manage feed entries",
+		Subcommands: []*ucli.Command{
+			recallyFeedEntryAddCommand(),
+		},
+	}
+}
+
+func recallyFeedEntryAddCommand() *ucli.Command {
+	return &ucli.Command{
+		Name:  "add",
+		Usage: "Add an entry by guid (source-agnostic; dedups on guid)",
+		Description: `Push a discovered item into a feed. Idempotent on (feed-id, guid):
+prints "new" when inserted, "dup" when the guid already existed. This is
+how skill-driven extraction (e.g. Twitter) feeds items into the library.`,
+		Flags: []ucli.Flag{
+			&ucli.StringFlag{Name: "feed-id", Usage: "Feed ID", Required: true},
+			&ucli.StringFlag{Name: "guid", Usage: "Stable per-source item id (dedup key)", Required: true},
+			&ucli.StringFlag{Name: "url", Usage: "Item URL"},
+			&ucli.StringFlag{Name: "title", Usage: "Item title"},
+			cli.JSONFlag(),
+		},
+		Action: func(c *ucli.Context) error {
+			feedID := c.String("feed-id")
+			body := apiclient.CreateFeedEntryJSONRequestBody{Guid: c.String("guid")}
+			if v := c.String("url"); v != "" {
+				body.Url = &v
+			}
+			if v := c.String("title"); v != "" {
+				body.Title = &v
+			}
+			result, err := apiclient.Call[apitypes.CreateFeedEntryResult](func(api *apiclient.Client) (*http.Response, error) {
+				return api.CreateFeedEntry(c.Context, feedID, body)
+			})
+			if err != nil {
+				return err
+			}
+			if cli.IsJSON(c) {
+				return cli.PrintJSON(c, result)
+			}
+			o := cli.Stdout(c)
+			if result.Created {
+				o.Println("new")
+			} else {
+				o.Println("dup")
+			}
 			return o.Err()
 		},
 	}

--- a/internal/db/migrations/20260606092158_add_recally_feed_kind_metadata.sql
+++ b/internal/db/migrations/20260606092158_add_recally_feed_kind_metadata.sql
@@ -1,0 +1,4 @@
+-- Add column "kind" to table: "recally_rss_feed"
+ALTER TABLE `recally_rss_feed` ADD COLUMN `kind` text NOT NULL DEFAULT 'rss';
+-- Add column "metadata" to table: "recally_rss_feed"
+ALTER TABLE `recally_rss_feed` ADD COLUMN `metadata` text NOT NULL DEFAULT '{}';

--- a/internal/db/migrations/atlas.sum
+++ b/internal/db/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:JSquVLJEETQ7l9kHXPac5Vu7o8HfZtA+Ek5ofUvBmLk=
+h1:AgjhW5BfKa2tX/OduWQId4npIE5qYifr1tbpj6qqoZM=
 20260531120105_initial.sql h1:yFv08NKwCabgVkvWoSNzba6WMXjbXrI9xHctaJBir/8=
 20260601060943_add_config_to_plugin_override.sql h1:q2MIJRzEYGDQyjnLeFUrQ0zbnvdgxBh/MRANwRmPFn4=
 20260602031701_add-channel-name.sql h1:1ZGYJvwMOOShxLGIN9SJihmcfQtFRpTPXHhOWDv29fc=
@@ -13,3 +13,4 @@ h1:JSquVLJEETQ7l9kHXPac5Vu7o8HfZtA+Ek5ofUvBmLk=
 20260605043849_add_group_message_reasoning.sql h1:rkAQA4up0srgOBnZXn+PmtcwP8aXYBqhPR6bHfVYewk=
 20260605054406_add_group_message_session_id.sql h1:mxlQCPtjczlzw+FL5jDB3opXF9VPWvgptnvQ9L+J2rQ=
 20260605174634_add_group_dispatch_tables.sql h1:Q2/OVyqgQR7O21FB0kHg/TO1AZVXmes5Hv06ns9rqDA=
+20260606092158_add_recally_feed_kind_metadata.sql h1:HBJAVIFYvAuVoCB7lrb7WGrvK7aS7TO8yOtpRCyxvzc=

--- a/internal/db/queries/recally_rss_feed.sql
+++ b/internal/db/queries/recally_rss_feed.sql
@@ -1,9 +1,9 @@
 -- name: CreateRSSFeed :one
 INSERT INTO recally_rss_feed (
-    id, user_id, agent_id, url, title, description, check_interval,
+    id, user_id, agent_id, url, kind, metadata, title, description, check_interval,
     last_checked_at, last_etag, last_modified, enabled
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 RETURNING *;
 
 -- name: GetRSSFeed :one
@@ -22,6 +22,7 @@ LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');
 UPDATE recally_rss_feed
 SET title           = sqlc.arg('title'),
     description     = sqlc.arg('description'),
+    metadata        = sqlc.arg('metadata'),
     check_interval  = sqlc.arg('check_interval'),
     last_checked_at = sqlc.arg('last_checked_at'),
     last_etag       = sqlc.arg('last_etag'),

--- a/internal/db/schemas/tables/recally_rss_feed.sql
+++ b/internal/db/schemas/tables/recally_rss_feed.sql
@@ -3,6 +3,8 @@ CREATE TABLE recally_rss_feed (
     user_id         TEXT NOT NULL REFERENCES auth_user(id) ON DELETE CASCADE,
     agent_id        TEXT REFERENCES agent(id) ON DELETE SET NULL,
     url             TEXT NOT NULL,
+    kind            TEXT NOT NULL DEFAULT 'rss',
+    metadata        TEXT NOT NULL DEFAULT '{}',
     title           TEXT NOT NULL DEFAULT '',
     description     TEXT NOT NULL DEFAULT '',
     check_interval  TEXT NOT NULL DEFAULT '1h',

--- a/internal/recally/feedkind_test.go
+++ b/internal/recally/feedkind_test.go
@@ -1,0 +1,28 @@
+package recally
+
+import "testing"
+
+func TestSniffFeedKind(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want FeedKind
+	}{
+		{"x.com profile", "https://x.com/jack", FeedKindTwitter},
+		{"twitter.com profile", "https://twitter.com/jack", FeedKindTwitter},
+		{"www.x.com", "https://www.x.com/jack", FeedKindTwitter},
+		{"mobile.twitter.com", "https://mobile.twitter.com/jack", FeedKindTwitter},
+		{"trailing whitespace", "  https://x.com/jack  ", FeedKindTwitter},
+		{"rss feed", "https://example.com/feed.xml", FeedKindRSS},
+		{"youtube rss", "https://www.youtube.com/feeds/videos.xml?channel_id=abc", FeedKindRSS},
+		{"lookalike host is not twitter", "https://notx.com/jack", FeedKindRSS},
+		{"empty url", "", FeedKindRSS},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SniffFeedKind(tt.url); got != tt.want {
+				t.Errorf("SniffFeedKind(%q) = %q, want %q", tt.url, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/recally/store.go
+++ b/internal/recally/store.go
@@ -275,13 +275,20 @@ func (s *Store) SearchArticles(ctx context.Context, userID string, query string,
 	return articles, nil
 }
 
-// CreateFeed creates a new RSS feed subscription.
-func (s *Store) CreateFeed(ctx context.Context, userID string, feedURL, title, description string, agentID *string) (*Feed, error) {
+// CreateFeed creates a new feed subscription. kind is the extraction-dispatch
+// hint ("rss", "twitter"); metadata carries source-specific bookkeeping such as
+// a stable numeric user id.
+func (s *Store) CreateFeed(ctx context.Context, userID string, feedURL string, kind FeedKind, metadata map[string]string, title, description string, agentID *string) (*Feed, error) {
+	if kind == "" {
+		kind = FeedKindRSS
+	}
 	row, err := s.q.CreateRSSFeed(ctx, sqlc.CreateRSSFeedParams{
 		ID:            generateID(),
 		UserID:        userID,
 		AgentID:       toNullString(agentID),
 		Url:           feedURL,
+		Kind:          string(kind),
+		Metadata:      encodeMetadata(metadata),
 		Title:         title,
 		Description:   description,
 		CheckInterval: "1h",
@@ -360,6 +367,7 @@ func (s *Store) UpdateFeed(ctx context.Context, userID string, feedID string, up
 
 	title := current.Title
 	description := current.Description
+	metadata := current.Metadata
 	checkInterval := current.CheckInterval
 	lastCheckedAt := current.LastCheckedAt
 	lastETag := current.LastEtag
@@ -371,6 +379,9 @@ func (s *Store) UpdateFeed(ctx context.Context, userID string, feedID string, up
 	}
 	if v, ok := updates["description"].(string); ok {
 		description = v
+	}
+	if v, ok := updates["metadata"].(map[string]string); ok {
+		metadata = encodeMetadata(v)
 	}
 	if v, ok := updates["check_interval"].(string); ok {
 		checkInterval = v
@@ -393,6 +404,7 @@ func (s *Store) UpdateFeed(ctx context.Context, userID string, feedID string, up
 		UserID:        userID,
 		Title:         title,
 		Description:   description,
+		Metadata:      metadata,
 		CheckInterval: checkInterval,
 		LastCheckedAt: lastCheckedAt,
 		LastEtag:      lastETag,

--- a/internal/recally/store_test.go
+++ b/internal/recally/store_test.go
@@ -72,6 +72,8 @@ CREATE TABLE IF NOT EXISTS recally_rss_feed (
     user_id INTEGER NOT NULL,
     agent_id TEXT,
     url TEXT NOT NULL,
+    kind TEXT NOT NULL DEFAULT 'rss',
+    metadata TEXT NOT NULL DEFAULT '{}',
     title TEXT NOT NULL DEFAULT '',
     description TEXT NOT NULL DEFAULT '',
     check_interval TEXT NOT NULL DEFAULT '1h',
@@ -379,7 +381,7 @@ func TestStore_Feeds(t *testing.T) {
 	ctx := t.Context()
 
 	// Create feed
-	feed, err := store.CreateFeed(ctx, "1", "https://example.com/feed.xml", "Test Feed", "A test feed", nil)
+	feed, err := store.CreateFeed(ctx, "1", "https://example.com/feed.xml", FeedKindRSS, nil, "Test Feed", "A test feed", nil)
 	if err != nil {
 		t.Fatalf("CreateFeed failed: %v", err)
 	}
@@ -456,7 +458,7 @@ func TestStore_FeedEntries(t *testing.T) {
 	ctx := t.Context()
 
 	// Create feed
-	feed, err := store.CreateFeed(ctx, "1", "https://example.com/feed.xml", "Test Feed", "", nil)
+	feed, err := store.CreateFeed(ctx, "1", "https://example.com/feed.xml", FeedKindRSS, nil, "Test Feed", "", nil)
 	if err != nil {
 		t.Fatalf("CreateFeed failed: %v", err)
 	}

--- a/internal/recally/types.go
+++ b/internal/recally/types.go
@@ -4,6 +4,8 @@ package recally
 import (
 	"database/sql"
 	"encoding/json"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/CherryHQ/stella/pkg/db/sqlc"
@@ -60,6 +62,44 @@ const (
 	EntryStatusError   RSSEntryStatus = "error"
 )
 
+// FeedKind is the extraction-dispatch hint for a feed subscription. Go stores
+// it and routes scheduling on it, but does not branch business logic on it —
+// per-source item discovery lives in the recally skill.
+type FeedKind string
+
+const (
+	FeedKindRSS     FeedKind = "rss"
+	FeedKindTwitter FeedKind = "twitter"
+)
+
+// Valid reports whether k is a known feed kind.
+func (k FeedKind) Valid() bool {
+	switch k {
+	case FeedKindRSS, FeedKindTwitter:
+		return true
+	default:
+		return false
+	}
+}
+
+// SniffFeedKind infers a feed kind from a subscription URL. x.com / twitter.com
+// hosts map to twitter; everything else defaults to rss. The caller may override
+// the result with an explicit kind.
+func SniffFeedKind(rawURL string) FeedKind {
+	u, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return FeedKindRSS
+	}
+	host := strings.ToLower(u.Hostname())
+	host = strings.TrimPrefix(host, "www.")
+	switch host {
+	case "x.com", "twitter.com", "mobile.twitter.com", "mobile.x.com":
+		return FeedKindTwitter
+	default:
+		return FeedKindRSS
+	}
+}
+
 // Article represents a saved article with its metadata.
 type Article struct {
 	ID           string            `json:"id"`
@@ -86,19 +126,21 @@ type Article struct {
 
 // Feed represents an RSS feed subscription.
 type Feed struct {
-	ID            string     `json:"id"`
-	UserID        string     `json:"user_id"`
-	AgentID       *string    `json:"agent_id,omitempty"`
-	URL           string     `json:"url"`
-	Title         string     `json:"title"`
-	Description   string     `json:"description"`
-	CheckInterval string     `json:"check_interval"`
-	LastCheckedAt *time.Time `json:"last_checked_at,omitempty"`
-	LastETag      string     `json:"last_etag"`
-	LastModified  string     `json:"last_modified"`
-	Enabled       bool       `json:"enabled"`
-	CreatedAt     time.Time  `json:"created_at"`
-	UpdatedAt     time.Time  `json:"updated_at"`
+	ID            string            `json:"id"`
+	UserID        string            `json:"user_id"`
+	AgentID       *string           `json:"agent_id,omitempty"`
+	URL           string            `json:"url"`
+	Kind          FeedKind          `json:"kind"`
+	Metadata      map[string]string `json:"metadata"`
+	Title         string            `json:"title"`
+	Description   string            `json:"description"`
+	CheckInterval string            `json:"check_interval"`
+	LastCheckedAt *time.Time        `json:"last_checked_at,omitempty"`
+	LastETag      string            `json:"last_etag"`
+	LastModified  string            `json:"last_modified"`
+	Enabled       bool              `json:"enabled"`
+	CreatedAt     time.Time         `json:"created_at"`
+	UpdatedAt     time.Time         `json:"updated_at"`
 }
 
 // FeedEntry represents an entry/item from an RSS feed.
@@ -265,6 +307,8 @@ func (f *Feed) FromSQLCFeed(sf sqlc.RecallyRssFeed) {
 		f.AgentID = nil
 	}
 	f.URL = sf.Url
+	f.Kind = FeedKind(sf.Kind)
+	f.Metadata = decodeMetadata(sf.Metadata)
 	f.Title = sf.Title
 	f.Description = sf.Description
 	f.CheckInterval = sf.CheckInterval

--- a/internal/scheduler/builtin_rss.go
+++ b/internal/scheduler/builtin_rss.go
@@ -4,8 +4,10 @@ package scheduler
 // builtin job. Registered from gateway wiring via (*Service).RegisterBuiltin.
 var RecallyRSSBuiltin = BuiltinJob{
 	Name: "recally-rss",
-	Message: `1. Poll all feeds: run "stella recally feed poll --limit 20 --json" (no feed-id polls every enabled feed).
-2. Load the recally skill. For each pending entry, follow the RSS workflow defined in the recally skill (fetch → generate metadata → save → mark).
+	Message: `1. Discover new entries for every enabled feed. Load the recally skill, then dispatch by feed kind:
+   - rss: run "stella recally feed poll --limit 20 --json" once (no feed-id polls every enabled feed; non-rss feeds are skipped server-side).
+   - twitter (and other non-rss kinds): run "stella recally feed list --json", and for each feed whose kind is not "rss", follow that kind's workflow in the recally skill (e.g. the Twitter workflow) to list items and push them via "stella recally feed entry add" (Go dedups on guid).
+2. For each pending entry (across all feeds), follow the save workflow defined in the recally skill (fetch → generate metadata → save with the entry's source type → mark).
 3. Notify only when at least one article was saved: count articles saved in step 2. If zero, do NOT call the notify tool — stop here. If one or more, call notify once:
    - For each article (up to 5): Worth-Reading label (emoji + text), title, author, and the "# Summary" section from the structured summary.
    - If more than 5 were saved, list the remaining as title + author only.`,

--- a/internal/server/recally_handlers.go
+++ b/internal/server/recally_handlers.go
@@ -406,21 +406,34 @@ func (h *recallyHandlers) CreateFeed(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusConflict, "feed already subscribed")
 		return
 	}
-	title := strDeref(body.Title)
-	description := ""
-	parseCtx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
-	parsed, err := h.feeds.ParseURLWithContext(body.Url, parseCtx)
-	cancel()
-	if err != nil {
-		h.writeBadGatewayError(w, err)
+
+	kind := recally.SniffFeedKind(body.Url)
+	if body.Kind != nil {
+		kind = recally.FeedKind(*body.Kind)
+	}
+	if !kind.Valid() {
+		writeError(w, http.StatusBadRequest, "invalid feed kind")
 		return
 	}
-	if title == "" {
-		title = parsed.Title
-	}
-	description = parsed.Description
 
-	feed, err := h.store.CreateFeed(r.Context(), userID, body.Url, title, description, body.AgentId)
+	title := strDeref(body.Title)
+	description := ""
+	// Only rss kinds are parsed server-side; skill-driven kinds backfill metadata later.
+	if kind == recally.FeedKindRSS {
+		parseCtx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+		parsed, err := h.feeds.ParseURLWithContext(body.Url, parseCtx)
+		cancel()
+		if err != nil {
+			h.writeBadGatewayError(w, err)
+			return
+		}
+		if title == "" {
+			title = parsed.Title
+		}
+		description = parsed.Description
+	}
+
+	feed, err := h.store.CreateFeed(r.Context(), userID, body.Url, kind, nil, title, description, body.AgentId)
 	if err != nil {
 		h.writeInternalError(w, err)
 		return
@@ -508,6 +521,12 @@ func (h *recallyHandlers) PollFeed(w http.ResponseWriter, r *http.Request, id st
 		writeData(w, http.StatusOK, result)
 		return
 	}
+	// Only rss feeds are polled server-side; skill-driven kinds discover entries
+	// via the recally extraction workflow, so this is a no-op for them.
+	if feed.Kind != recally.FeedKindRSS {
+		writeData(w, http.StatusOK, result)
+		return
+	}
 
 	parseCtx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	parsed, err := h.feeds.ParseURLWithContext(feed.URL, parseCtx)
@@ -587,6 +606,36 @@ func (h *recallyHandlers) ListFeedEntries(w http.ResponseWriter, r *http.Request
 		list.NextPageToken = &nextToken
 	}
 	writeData(w, http.StatusOK, list)
+}
+
+func (h *recallyHandlers) CreateFeedEntry(w http.ResponseWriter, r *http.Request, feedId string) {
+	userID, ok := h.requireUser(w, r)
+	if !ok {
+		return
+	}
+	if _, ok := h.feedOwned(w, r.Context(), feedId, userID); !ok {
+		return
+	}
+	var body apitypes.CreateFeedEntryRequest
+	if err := decodeJSON(r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if body.Guid == "" {
+		writeError(w, http.StatusBadRequest, "guid is required")
+		return
+	}
+	entry, err := h.store.CreateFeedEntry(r.Context(), feedId, body.Guid, strDeref(body.Url), strDeref(body.Title))
+	if err != nil {
+		h.writeInternalError(w, err)
+		return
+	}
+	result := apitypes.CreateFeedEntryResult{Created: entry != nil}
+	if entry != nil {
+		apiEntry := toAPIFeedEntry(entry)
+		result.Entry = &apiEntry
+	}
+	writeData(w, http.StatusOK, result)
 }
 
 func (h *recallyHandlers) UpdateFeedEntry(w http.ResponseWriter, r *http.Request, feedId string, id string) {
@@ -834,10 +883,17 @@ func toAPIArticles(articles []recally.Article) []apiserver.Article {
 }
 
 func toAPIFeed(f *recally.Feed) apiserver.Feed {
+	var metadata *map[string]string
+	if len(f.Metadata) > 0 {
+		m := f.Metadata
+		metadata = &m
+	}
 	return apiserver.Feed{
 		Id:            f.ID,
 		AgentId:       f.AgentID,
 		Url:           f.URL,
+		Kind:          apitypes.FeedKind(f.Kind),
+		Metadata:      metadata,
 		Title:         f.Title,
 		Description:   ptrStr(f.Description),
 		CheckInterval: f.CheckInterval,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -259,6 +259,10 @@ func (s *Server) ListFeedEntries(w http.ResponseWriter, r *http.Request, feedId 
 	s.recally.ListFeedEntries(w, r, feedId, params)
 }
 
+func (s *Server) CreateFeedEntry(w http.ResponseWriter, r *http.Request, feedId string) {
+	s.recally.CreateFeedEntry(w, r, feedId)
+}
+
 func (s *Server) UpdateFeedEntry(w http.ResponseWriter, r *http.Request, feedId string, id string) {
 	s.recally.UpdateFeedEntry(w, r, feedId, id)
 }

--- a/pkg/db/sqlc/models.go
+++ b/pkg/db/sqlc/models.go
@@ -614,6 +614,8 @@ type RecallyRssFeed struct {
 	UserID        string         `json:"user_id"`
 	AgentID       sql.NullString `json:"agent_id"`
 	Url           string         `json:"url"`
+	Kind          string         `json:"kind"`
+	Metadata      string         `json:"metadata"`
 	Title         string         `json:"title"`
 	Description   string         `json:"description"`
 	CheckInterval string         `json:"check_interval"`

--- a/pkg/db/sqlc/recally_rss_feed.sql.go
+++ b/pkg/db/sqlc/recally_rss_feed.sql.go
@@ -12,11 +12,11 @@ import (
 
 const createRSSFeed = `-- name: CreateRSSFeed :one
 INSERT INTO recally_rss_feed (
-    id, user_id, agent_id, url, title, description, check_interval,
+    id, user_id, agent_id, url, kind, metadata, title, description, check_interval,
     last_checked_at, last_etag, last_modified, enabled
 )
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-RETURNING id, user_id, agent_id, url, title, description, check_interval, last_checked_at, last_etag, last_modified, enabled, created_at, updated_at
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+RETURNING id, user_id, agent_id, url, kind, metadata, title, description, check_interval, last_checked_at, last_etag, last_modified, enabled, created_at, updated_at
 `
 
 type CreateRSSFeedParams struct {
@@ -24,6 +24,8 @@ type CreateRSSFeedParams struct {
 	UserID        string         `json:"user_id"`
 	AgentID       sql.NullString `json:"agent_id"`
 	Url           string         `json:"url"`
+	Kind          string         `json:"kind"`
+	Metadata      string         `json:"metadata"`
 	Title         string         `json:"title"`
 	Description   string         `json:"description"`
 	CheckInterval string         `json:"check_interval"`
@@ -39,6 +41,8 @@ func (q *Queries) CreateRSSFeed(ctx context.Context, arg CreateRSSFeedParams) (R
 		arg.UserID,
 		arg.AgentID,
 		arg.Url,
+		arg.Kind,
+		arg.Metadata,
 		arg.Title,
 		arg.Description,
 		arg.CheckInterval,
@@ -53,6 +57,8 @@ func (q *Queries) CreateRSSFeed(ctx context.Context, arg CreateRSSFeedParams) (R
 		&i.UserID,
 		&i.AgentID,
 		&i.Url,
+		&i.Kind,
+		&i.Metadata,
 		&i.Title,
 		&i.Description,
 		&i.CheckInterval,
@@ -148,7 +154,7 @@ func (q *Queries) DeleteRSSFeed(ctx context.Context, arg DeleteRSSFeedParams) er
 }
 
 const getRSSFeed = `-- name: GetRSSFeed :one
-SELECT id, user_id, agent_id, url, title, description, check_interval, last_checked_at, last_etag, last_modified, enabled, created_at, updated_at FROM recally_rss_feed WHERE id = ? AND user_id = ?
+SELECT id, user_id, agent_id, url, kind, metadata, title, description, check_interval, last_checked_at, last_etag, last_modified, enabled, created_at, updated_at FROM recally_rss_feed WHERE id = ? AND user_id = ?
 `
 
 type GetRSSFeedParams struct {
@@ -164,6 +170,8 @@ func (q *Queries) GetRSSFeed(ctx context.Context, arg GetRSSFeedParams) (Recally
 		&i.UserID,
 		&i.AgentID,
 		&i.Url,
+		&i.Kind,
+		&i.Metadata,
 		&i.Title,
 		&i.Description,
 		&i.CheckInterval,
@@ -178,7 +186,7 @@ func (q *Queries) GetRSSFeed(ctx context.Context, arg GetRSSFeedParams) (Recally
 }
 
 const getRSSFeedByURL = `-- name: GetRSSFeedByURL :one
-SELECT id, user_id, agent_id, url, title, description, check_interval, last_checked_at, last_etag, last_modified, enabled, created_at, updated_at FROM recally_rss_feed WHERE user_id = ? AND url = ?
+SELECT id, user_id, agent_id, url, kind, metadata, title, description, check_interval, last_checked_at, last_etag, last_modified, enabled, created_at, updated_at FROM recally_rss_feed WHERE user_id = ? AND url = ?
 `
 
 type GetRSSFeedByURLParams struct {
@@ -194,6 +202,8 @@ func (q *Queries) GetRSSFeedByURL(ctx context.Context, arg GetRSSFeedByURLParams
 		&i.UserID,
 		&i.AgentID,
 		&i.Url,
+		&i.Kind,
+		&i.Metadata,
 		&i.Title,
 		&i.Description,
 		&i.CheckInterval,
@@ -335,7 +345,7 @@ func (q *Queries) ListRSSFeedEntries(ctx context.Context, arg ListRSSFeedEntries
 }
 
 const listRSSFeeds = `-- name: ListRSSFeeds :many
-SELECT id, user_id, agent_id, url, title, description, check_interval, last_checked_at, last_etag, last_modified, enabled, created_at, updated_at FROM recally_rss_feed
+SELECT id, user_id, agent_id, url, kind, metadata, title, description, check_interval, last_checked_at, last_etag, last_modified, enabled, created_at, updated_at FROM recally_rss_feed
 WHERE user_id = ?1
 ORDER BY created_at DESC, id DESC
 LIMIT ?3 OFFSET ?2
@@ -361,6 +371,8 @@ func (q *Queries) ListRSSFeeds(ctx context.Context, arg ListRSSFeedsParams) ([]R
 			&i.UserID,
 			&i.AgentID,
 			&i.Url,
+			&i.Kind,
+			&i.Metadata,
 			&i.Title,
 			&i.Description,
 			&i.CheckInterval,
@@ -388,19 +400,21 @@ const updateRSSFeed = `-- name: UpdateRSSFeed :one
 UPDATE recally_rss_feed
 SET title           = ?1,
     description     = ?2,
-    check_interval  = ?3,
-    last_checked_at = ?4,
-    last_etag       = ?5,
-    last_modified   = ?6,
-    enabled         = ?7,
+    metadata        = ?3,
+    check_interval  = ?4,
+    last_checked_at = ?5,
+    last_etag       = ?6,
+    last_modified   = ?7,
+    enabled         = ?8,
     updated_at      = datetime('now')
-WHERE id = ?8 AND user_id = ?9
-RETURNING id, user_id, agent_id, url, title, description, check_interval, last_checked_at, last_etag, last_modified, enabled, created_at, updated_at
+WHERE id = ?9 AND user_id = ?10
+RETURNING id, user_id, agent_id, url, kind, metadata, title, description, check_interval, last_checked_at, last_etag, last_modified, enabled, created_at, updated_at
 `
 
 type UpdateRSSFeedParams struct {
 	Title         string         `json:"title"`
 	Description   string         `json:"description"`
+	Metadata      string         `json:"metadata"`
 	CheckInterval string         `json:"check_interval"`
 	LastCheckedAt sql.NullString `json:"last_checked_at"`
 	LastEtag      string         `json:"last_etag"`
@@ -414,6 +428,7 @@ func (q *Queries) UpdateRSSFeed(ctx context.Context, arg UpdateRSSFeedParams) (R
 	row := q.db.QueryRowContext(ctx, updateRSSFeed,
 		arg.Title,
 		arg.Description,
+		arg.Metadata,
 		arg.CheckInterval,
 		arg.LastCheckedAt,
 		arg.LastEtag,
@@ -428,6 +443,8 @@ func (q *Queries) UpdateRSSFeed(ctx context.Context, arg UpdateRSSFeedParams) (R
 		&i.UserID,
 		&i.AgentID,
 		&i.Url,
+		&i.Kind,
+		&i.Metadata,
 		&i.Title,
 		&i.Description,
 		&i.CheckInterval,

--- a/resources/skills/system/recally/SKILL.md
+++ b/resources/skills/system/recally/SKILL.md
@@ -17,10 +17,11 @@ open the SQLite database directly.
 
 ## References
 
-| Topic                                       | File                                                       |
-| ------------------------------------------- | ---------------------------------------------------------- |
-| Saving an article (fetch → generate → save) | [references/save-workflow.md](references/save-workflow.md) |
-| RSS batch processing                        | [references/rss-workflow.md](references/rss-workflow.md)   |
+| Topic                                       | File                                                             |
+| ------------------------------------------- | ---------------------------------------------------------------- |
+| Saving an article (fetch → generate → save) | [references/save-workflow.md](references/save-workflow.md)       |
+| RSS batch processing                        | [references/rss-workflow.md](references/rss-workflow.md)         |
+| Twitter/X feed discovery                    | [references/twitter-workflow.md](references/twitter-workflow.md) |
 
 ## Search and Retrieve
 
@@ -43,16 +44,25 @@ stella recally update <id> --summary "..."
 stella recally delete <id>
 ```
 
-## RSS Feeds
+## Feeds
 
 ```bash
-stella recally feed add <feed-url>
-stella recally feed poll --limit 20 --json     # returns pending entries
-stella recally feed list
+stella recally feed add <feed-url>             # kind sniffed from URL (x.com → twitter, else rss); override with --kind
+stella recally feed poll --limit 20 --json     # rss fast-path; non-rss feeds are skipped server-side
+stella recally feed list --json                # includes each feed's kind
 stella recally feed remove <feed-id>
+stella recally feed entry add --feed-id <id> --guid <guid> --url <url> --title <title>   # source-agnostic; prints new/dup
 ```
 
-For processing pending entries, see [references/rss-workflow.md](references/rss-workflow.md).
+`feed add` sniffs the kind from the URL: `x.com` / `twitter.com` hosts become
+`twitter`, everything else defaults to `rss`. Pass `--kind rss|twitter` to force it.
+
+- **rss** feeds: poll server-side, then process pending entries — see [references/rss-workflow.md](references/rss-workflow.md).
+- **twitter** feeds: discover entries via the skill — see [references/twitter-workflow.md](references/twitter-workflow.md).
+
+`feed entry add` is the source-agnostic discovery sink: it dedups on `(feed-id, guid)`
+and prints `new` or `dup`. YouTube channels work today with no new code — subscribe
+to the channel's RSS feed (`https://www.youtube.com/feeds/videos.xml?channel_id=...`).
 
 ## Daily Digest
 

--- a/resources/skills/system/recally/references/twitter-workflow.md
+++ b/resources/skills/system/recally/references/twitter-workflow.md
@@ -1,0 +1,53 @@
+# Twitter Feed Workflow
+
+Discovery workflow for feeds with `kind=twitter`. Go owns dedup and storage; this
+workflow only lists tweets and pushes them as entries. Correctness rests on guid
+dedup, **not** a watermark — a failed run just discovers nothing, and the next run
+re-lists and Go drops the duplicates.
+
+## 1. Identify Twitter feeds
+
+```bash
+stella recally feed list --json
+```
+
+Process each feed whose `kind` is `twitter`. The feed's `metadata.external_id`
+holds the stable numeric X user id (rename-proof); fall back to the handle in the
+feed `url` if it is missing.
+
+## 2. List recent tweets
+
+Use the FxEmbed profile-statuses tap script (see the tap-web skill). Prefer the
+numeric id; `since` is a best-effort optimization only — never rely on it for
+correctness.
+
+```bash
+tap site twitter/fxembed-profile-statuses handle=id:<numeric-user-id> --json
+```
+
+For each returned status:
+
+- **Skip retweets** by default (`is_repost` / `is_retweet` true).
+- Map fields:
+  - `guid` = tweet id (stable; the dedup key)
+  - `url` = tweet url
+  - `title` = tweet text; when empty, fall back to `(media: <author>)`
+
+## 3. Push entries (Go dedups)
+
+```bash
+stella recally feed entry add --feed-id <feed-id> --guid <tweet-id> --url <tweet-url> --title "<text>"
+```
+
+Prints `new` (inserted) or `dup` (guid already existed). Pinned and edited tweets
+are handled automatically by guid dedup — just push them all. Stop pushing a feed
+once you hit a run of `dup` results if you want to save calls, but pushing extras
+is harmless.
+
+## 4. Process pending entries
+
+New entries land as `pending`, exactly like RSS entries. Process them with the
+standard [save-workflow.md](save-workflow.md) using `--source-type twitter`
+(fetch tweet content via `tap site twitter/fxembed-status id=<tweet-id>`), then
+mark each entry saved / skipped / error as described in
+[rss-workflow.md](rss-workflow.md).

--- a/web/content/docs/recally/overview.md
+++ b/web/content/docs/recally/overview.md
@@ -32,9 +32,16 @@ After saving an article, you can ask questions about it:
 
 This turns reading from passive collection into active understanding.
 
-## Subscribe to RSS
+## Subscribe to feeds
 
-Recally can subscribe to RSS feeds and keep a live stream of new entries. Use this for sources you care about repeatedly: company blogs, release notes, journals, newsletters, and policy updates.
+Recally can subscribe to feeds and keep a live stream of new entries. Use this for sources you care about repeatedly: company blogs, release notes, journals, newsletters, and policy updates.
+
+Beyond RSS, you can follow:
+
+- **Twitter/X accounts** — subscribe with a profile URL like `https://x.com/<handle>` and Recally treats new tweets as feed entries, saved and summarized like any other source.
+- **YouTube channels** — subscribe to the channel's RSS feed (`https://www.youtube.com/feeds/videos.xml?channel_id=...`) to track new uploads.
+
+Recally detects the source type from the URL, so subscribing is the same one step regardless of where the content lives.
 
 ## Maintain a reading list
 

--- a/web/content/docs/recally/overview.zh.md
+++ b/web/content/docs/recally/overview.zh.md
@@ -32,9 +32,16 @@ Recally 可以总结已保存内容，让你快速判断什么值得深入阅读
 
 这会把阅读从被动收藏变成主动理解。
 
-## 订阅 RSS
+## 订阅 feeds
 
-Recally 可以订阅 RSS feeds，并持续获取新条目。适合长期关注的来源：公司博客、release notes、期刊、newsletter 和政策更新。
+Recally 可以订阅 feeds，并持续获取新条目。适合长期关注的来源：公司博客、release notes、期刊、newsletter 和政策更新。
+
+除了 RSS，你还可以关注：
+
+- **Twitter/X 账号** —— 用类似 `https://x.com/<handle>` 的主页地址订阅，Recally 会把新推文当作 feed 条目，像其他来源一样保存和总结。
+- **YouTube 频道** —— 订阅频道的 RSS 地址（`https://www.youtube.com/feeds/videos.xml?channel_id=...`）即可跟进新视频。
+
+Recally 会从 URL 自动识别来源类型，所以无论内容在哪，订阅都是同样的一步。
 
 ## 维护阅读列表
 

--- a/web/public/docs/recally-dataflow.html
+++ b/web/public/docs/recally-dataflow.html
@@ -1,0 +1,1237 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Recally 订阅数据流</title>
+    <style>
+      :root {
+        --bg: oklch(14% 0.01 260);
+        --surface: oklch(18% 0.012 260);
+        --surface-2: oklch(22% 0.014 260);
+        --fg: oklch(92% 0.008 250);
+        --muted: oklch(58% 0.014 250);
+        --border: oklch(28% 0.012 260);
+        --accent-blue: oklch(68% 0.16 240);
+        --accent-green: oklch(72% 0.16 155);
+        --accent-amber: oklch(78% 0.14 75);
+        --accent-red: oklch(68% 0.18 25);
+        --accent-purple: oklch(68% 0.14 300);
+        --accent-cyan: oklch(72% 0.12 200);
+        --code-bg: oklch(12% 0.008 260);
+
+        --font-display: "SF Pro Display", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+        --font-body: "SF Pro Text", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+        --font-mono: "JetBrains Mono", "SF Mono", ui-monospace, Menlo, monospace;
+      }
+
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: var(--font-body);
+        font-size: 14px;
+        line-height: 1.6;
+        -webkit-font-smoothing: antialiased;
+      }
+
+      .container {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: 48px 24px 80px;
+      }
+
+      header {
+        margin-bottom: 48px;
+      }
+
+      header h1 {
+        font-family: var(--font-display);
+        font-size: 28px;
+        font-weight: 600;
+        letter-spacing: -0.02em;
+        margin-bottom: 12px;
+      }
+
+      header p {
+        color: var(--muted);
+        font-size: 14px;
+        max-width: 720px;
+      }
+
+      /* Entry point diagram */
+      .entry-diagram {
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        gap: 0;
+        align-items: center;
+        margin-bottom: 40px;
+      }
+
+      .entry-column {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+      }
+
+      .entry-card {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 12px 16px;
+        font-size: 13px;
+      }
+
+      .entry-card-label {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        margin-bottom: 4px;
+      }
+
+      .entry-card-label.web {
+        color: var(--accent-blue);
+      }
+      .entry-card-label.platform {
+        color: var(--accent-purple);
+      }
+      .entry-card-label.shared {
+        color: var(--accent-green);
+      }
+
+      .entry-card dd {
+        font-family: var(--font-mono);
+        font-size: 12px;
+        color: oklch(78% 0.008 250);
+      }
+
+      .entry-merge {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 0 24px;
+        color: var(--muted);
+        font-family: var(--font-mono);
+        font-size: 11px;
+        gap: 4px;
+      }
+
+      .entry-merge .arrow-down {
+        font-size: 20px;
+        opacity: 0.4;
+      }
+
+      .merge-target {
+        grid-column: 1 / -1;
+        margin-top: 12px;
+        background: oklch(72% 0.16 155 / 0.06);
+        border: 1px solid oklch(72% 0.16 155 / 0.25);
+        border-radius: 6px;
+        padding: 14px 20px;
+        text-align: center;
+      }
+
+      .merge-target-label {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        color: var(--accent-green);
+        font-weight: 600;
+        margin-bottom: 4px;
+      }
+
+      .merge-target p {
+        font-size: 13px;
+        color: oklch(78% 0.01 250);
+      }
+
+      /* Scenario */
+      .scenario {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 20px 24px;
+        margin-bottom: 40px;
+      }
+
+      .scenario-label {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--accent-amber);
+        margin-bottom: 10px;
+      }
+
+      .scenario-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr;
+        gap: 16px;
+      }
+
+      .scenario-item {
+        font-size: 13px;
+      }
+
+      .scenario-item dt {
+        color: var(--muted);
+        font-size: 11px;
+        margin-bottom: 2px;
+      }
+
+      .scenario-item dd {
+        font-family: var(--font-mono);
+        font-size: 12px;
+      }
+
+      /* Flow stages */
+      .flow {
+        position: relative;
+      }
+
+      .flow::before {
+        content: "";
+        position: absolute;
+        left: 23px;
+        top: 0;
+        bottom: 0;
+        width: 1px;
+        background: linear-gradient(
+          to bottom,
+          var(--border) 0%,
+          var(--accent-blue) 10%,
+          var(--accent-green) 30%,
+          var(--accent-amber) 50%,
+          var(--accent-purple) 75%,
+          var(--border) 100%
+        );
+        opacity: 0.5;
+      }
+
+      .stage {
+        position: relative;
+        padding-left: 56px;
+        margin-bottom: 32px;
+      }
+
+      .stage-dot {
+        position: absolute;
+        left: 16px;
+        top: 4px;
+        width: 15px;
+        height: 15px;
+        border-radius: 50%;
+        border: 2px solid;
+        background: var(--bg);
+        z-index: 1;
+      }
+
+      .stage-dot.blue {
+        border-color: var(--accent-blue);
+      }
+      .stage-dot.green {
+        border-color: var(--accent-green);
+      }
+      .stage-dot.amber {
+        border-color: var(--accent-amber);
+      }
+      .stage-dot.red {
+        border-color: var(--accent-red);
+      }
+      .stage-dot.purple {
+        border-color: var(--accent-purple);
+      }
+      .stage-dot.cyan {
+        border-color: var(--accent-cyan);
+      }
+
+      .stage-header {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        margin-bottom: 8px;
+      }
+
+      .stage-number {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        color: var(--muted);
+        min-width: 20px;
+      }
+
+      .stage-title {
+        font-family: var(--font-display);
+        font-size: 16px;
+        font-weight: 600;
+        letter-spacing: -0.01em;
+        color: oklch(82% 0.008 250);
+      }
+
+      .stage-file {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        color: var(--muted);
+        background: var(--surface);
+        padding: 2px 6px;
+        border-radius: 3px;
+        border: 1px solid var(--border);
+      }
+
+      .stage-desc {
+        color: var(--muted);
+        font-size: 13px;
+        margin-bottom: 12px;
+        max-width: 720px;
+      }
+
+      .stage-body {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      /* Data cards */
+      .data-card {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        overflow: hidden;
+      }
+
+      .data-card-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 8px 14px;
+        border-bottom: 1px solid var(--border);
+        background: var(--surface-2);
+      }
+
+      .data-card-label {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: var(--muted);
+      }
+
+      .data-card-tag {
+        font-family: var(--font-mono);
+        font-size: 10px;
+        padding: 2px 6px;
+        border-radius: 3px;
+        border: 1px solid;
+      }
+
+      .tag-go {
+        color: var(--accent-blue);
+        border-color: oklch(68% 0.16 240 / 0.3);
+        background: oklch(68% 0.16 240 / 0.08);
+      }
+      .tag-sql {
+        color: var(--accent-green);
+        border-color: oklch(72% 0.16 155 / 0.3);
+        background: oklch(72% 0.16 155 / 0.08);
+      }
+      .tag-sse {
+        color: var(--accent-purple);
+        border-color: oklch(68% 0.14 300 / 0.3);
+        background: oklch(68% 0.14 300 / 0.08);
+      }
+      .tag-skill {
+        color: var(--accent-amber);
+        border-color: oklch(78% 0.14 75 / 0.3);
+        background: oklch(78% 0.14 75 / 0.08);
+      }
+      .tag-cli {
+        color: var(--accent-purple);
+        border-color: oklch(68% 0.14 300 / 0.3);
+        background: oklch(68% 0.14 300 / 0.08);
+      }
+      .tag-db {
+        color: var(--accent-green);
+        border-color: oklch(72% 0.16 155 / 0.3);
+        background: oklch(72% 0.16 155 / 0.08);
+      }
+      .tag-tap {
+        color: var(--accent-cyan);
+        border-color: oklch(72% 0.12 200 / 0.3);
+        background: oklch(72% 0.12 200 / 0.08);
+      }
+      .tag-llm {
+        color: var(--accent-red);
+        border-color: oklch(68% 0.18 25 / 0.3);
+        background: oklch(68% 0.18 25 / 0.08);
+      }
+
+      .data-card pre {
+        padding: 12px 14px;
+        font-family: var(--font-mono);
+        font-size: 12px;
+        line-height: 1.7;
+        color: oklch(82% 0.008 250);
+        overflow-x: auto;
+        white-space: pre;
+        background: var(--code-bg);
+      }
+
+      /* DB table */
+      .db-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-family: var(--font-mono);
+        font-size: 11.5px;
+      }
+
+      .db-table th {
+        text-align: left;
+        padding: 6px 12px;
+        color: var(--muted);
+        font-weight: 500;
+        font-size: 10.5px;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        border-bottom: 1px solid var(--border);
+        background: var(--surface-2);
+      }
+
+      .db-table td {
+        padding: 6px 12px;
+        border-bottom: 1px solid oklch(22% 0.01 260);
+        color: oklch(78% 0.008 250);
+        white-space: nowrap;
+      }
+
+      .db-table tr:last-child td {
+        border-bottom: none;
+      }
+
+      .db-table .highlight td {
+        background: oklch(68% 0.16 240 / 0.06);
+        color: var(--fg);
+      }
+
+      .db-table .new td {
+        background: oklch(72% 0.16 155 / 0.06);
+      }
+      .db-table .dim td {
+        color: var(--muted);
+      }
+
+      /* Arrow */
+      .arrow {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 4px 0;
+        color: var(--muted);
+        font-family: var(--font-mono);
+        font-size: 11px;
+      }
+
+      .arrow::before {
+        content: "↓";
+        font-size: 14px;
+        opacity: 0.5;
+      }
+
+      /* Callouts */
+      .risk-callout {
+        background: oklch(68% 0.18 25 / 0.06);
+        border: 1px solid oklch(68% 0.18 25 / 0.25);
+        border-radius: 6px;
+        padding: 12px 16px;
+        font-size: 13px;
+      }
+
+      .risk-callout-label {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        color: var(--accent-red);
+        font-weight: 600;
+        margin-bottom: 4px;
+      }
+
+      .risk-callout p {
+        color: oklch(78% 0.01 250);
+      }
+
+      .info-callout {
+        background: oklch(68% 0.16 240 / 0.06);
+        border: 1px solid oklch(68% 0.16 240 / 0.25);
+        border-radius: 6px;
+        padding: 12px 16px;
+        font-size: 13px;
+      }
+
+      .info-callout-label {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        color: var(--accent-blue);
+        font-weight: 600;
+        margin-bottom: 4px;
+      }
+
+      .info-callout p {
+        color: oklch(78% 0.01 250);
+      }
+
+      .design-callout {
+        background: oklch(72% 0.16 155 / 0.06);
+        border: 1px solid oklch(72% 0.16 155 / 0.25);
+        border-radius: 6px;
+        padding: 12px 16px;
+        font-size: 13px;
+      }
+
+      .design-callout-label {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        color: var(--accent-green);
+        font-weight: 600;
+        margin-bottom: 4px;
+      }
+
+      .design-callout p {
+        color: oklch(78% 0.01 250);
+      }
+
+      /* Inline code */
+      code {
+        font-family: var(--font-mono);
+        font-size: 11.5px;
+        background: var(--surface-2);
+        padding: 1px 5px;
+        border-radius: 3px;
+        border: 1px solid var(--border);
+        color: oklch(78% 0.06 240);
+      }
+
+      /* Sub-stage */
+      .sub-stage {
+        margin-left: 20px;
+        padding-left: 16px;
+        border-left: 1px solid var(--border);
+      }
+
+      .sub-label {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        color: var(--accent-green);
+        margin-bottom: 6px;
+      }
+
+      /* Decision tree */
+      .decision-tree {
+        border: 1px dashed oklch(72% 0.12 200 / 0.3);
+        border-radius: 6px;
+        padding: 16px;
+        background: oklch(72% 0.12 200 / 0.03);
+      }
+
+      .decision-label {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        color: var(--accent-cyan);
+        margin-bottom: 12px;
+      }
+
+      .decision-branch {
+        display: flex;
+        gap: 12px;
+        margin-bottom: 8px;
+        align-items: flex-start;
+      }
+
+      .decision-condition {
+        font-family: var(--font-mono);
+        font-size: 11px;
+        color: var(--accent-cyan);
+        background: oklch(72% 0.12 200 / 0.1);
+        border: 1px solid oklch(72% 0.12 200 / 0.2);
+        border-radius: 4px;
+        padding: 4px 8px;
+        white-space: nowrap;
+        min-width: 120px;
+      }
+
+      .decision-result {
+        font-size: 13px;
+        color: oklch(78% 0.008 250);
+        padding-top: 2px;
+      }
+
+      .decision-result code {
+        font-size: 11px;
+      }
+
+      /* Two col */
+      .two-col {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 12px;
+      }
+
+      .three-col {
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr;
+        gap: 12px;
+      }
+
+      /* Section divider */
+      .section-divider {
+        border-top: 1px solid var(--border);
+        margin: 48px 0 40px;
+        padding-top: 40px;
+      }
+
+      .section-divider h2 {
+        font-family: var(--font-display);
+        font-size: 20px;
+        font-weight: 600;
+        letter-spacing: -0.01em;
+        margin-bottom: 8px;
+      }
+
+      .section-divider p {
+        color: var(--muted);
+        font-size: 13px;
+        max-width: 680px;
+      }
+
+      /* Syntax highlight */
+      .cm {
+        color: oklch(50% 0.01 250);
+      }
+      .kw {
+        color: oklch(72% 0.12 300);
+      }
+      .str {
+        color: oklch(72% 0.12 155);
+      }
+      .num {
+        color: oklch(78% 0.12 75);
+      }
+      .fn {
+        color: oklch(72% 0.14 240);
+      }
+      .err {
+        color: var(--accent-red);
+      }
+      .ok {
+        color: var(--accent-green);
+      }
+
+      @media (max-width: 768px) {
+        .scenario-grid {
+          grid-template-columns: 1fr;
+        }
+        .two-col,
+        .three-col {
+          grid-template-columns: 1fr;
+        }
+        .entry-diagram {
+          grid-template-columns: 1fr;
+        }
+        .entry-merge {
+          padding: 12px 0;
+        }
+        .stage {
+          padding-left: 44px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <header>
+        <h1>Recally 订阅数据流</h1>
+        <p>
+          目标模型：Go 只拥有<strong>源无关的记账</strong>（feed / entry 表、guid
+          去重、调度、重试）； 抓取与总结下沉到 recally
+          <strong>skill + tap</strong>。一个源加进来，只动 skill workflow（+ 也许一个 tap
+          脚本），不动 Go。核心翻转：正确性建立在
+          <code>ON CONFLICT(feed_id, guid)</code> 去重上，<strong>不靠 since 水位</strong>。
+          本文档追踪一条新条目从「发现」到「入库 + 通知」的完整路径。
+        </p>
+      </header>
+
+      <!-- ───────── Entry Points ───────── -->
+      <div class="entry-diagram">
+        <div class="entry-column">
+          <div class="entry-card">
+            <div class="entry-card-label web">kind = rss（公开 / 免登录）</div>
+            <dd>stella recally feed poll</dd>
+            <dd style="color: var(--muted); font-size: 11px; margin-top: 4px">
+              server 端 gofeed 解析，便宜稳定，零 LLM
+            </dd>
+          </div>
+        </div>
+        <div class="entry-merge">
+          <span class="arrow-down">→</span>
+          <span>汇入</span>
+          <span class="arrow-down">←</span>
+        </div>
+        <div class="entry-column">
+          <div class="entry-card">
+            <div class="entry-card-label platform">kind ≠ rss（twitter / 未来源）</div>
+            <dd>recally skill workflow</dd>
+            <dd style="color: var(--muted); font-size: 11px; margin-top: 4px">
+              tap fxembed / browser 列出条目
+            </dd>
+          </div>
+        </div>
+        <div class="merge-target">
+          <div class="merge-target-label">源无关 dedup sink</div>
+          <p>
+            <code>stella recally feed entry add --feed-id --guid --url --title</code>
+            → <code>POST /feeds/{id}/entries</code> → <code>CreateRSSFeedEntry</code> （<code
+              >ON CONFLICT(feed_id, guid) DO NOTHING RETURNING *</code
+            >）：有行 = <span style="color: var(--accent-green)">new</span>，空 =
+            <span style="color: var(--muted)">dup</span>
+          </p>
+        </div>
+      </div>
+
+      <!-- ───────── Scenario ───────── -->
+      <div class="scenario">
+        <div class="scenario-label">场景实例 — 订阅一个 X 账号</div>
+        <div class="scenario-grid">
+          <div class="scenario-item">
+            <dt>用户</dt>
+            <dd>Alice (user_id=u_42)</dd>
+          </div>
+          <div class="scenario-item">
+            <dt>订阅 URL</dt>
+            <dd>https://x.com/karpathy</dd>
+          </div>
+          <div class="scenario-item">
+            <dt>嗅探出 kind</dt>
+            <dd>twitter</dd>
+          </div>
+          <div class="scenario-item">
+            <dt>feed_id</dt>
+            <dd>feed_7c (UUID)</dd>
+          </div>
+          <div class="scenario-item">
+            <dt>metadata.external_id</dt>
+            <dd>33836629（数字 user-id）</dd>
+          </div>
+          <div class="scenario-item">
+            <dt>调度周期</dt>
+            <dd>recally-rss builtin / 6h</dd>
+          </div>
+          <div class="scenario-item">
+            <dt>已存条目 (上轮)</dt>
+            <dd>guid=tw_1001 (saved)</dd>
+          </div>
+          <div class="scenario-item">
+            <dt>本轮 fxembed 列出</dt>
+            <dd>tw_1002(新), tw_1001(旧), rt_99(retweet)</dd>
+          </div>
+          <div class="scenario-item">
+            <dt>预期结果</dt>
+            <dd>仅 tw_1002 入库 + 总结一次</dd>
+          </div>
+        </div>
+      </div>
+
+      <!-- ───────── Flow ───────── -->
+      <div class="flow">
+        <!-- Stage 1: Subscribe -->
+        <div class="stage">
+          <div class="stage-dot blue"></div>
+          <div class="stage-header">
+            <span class="stage-number">01</span>
+            <span class="stage-title">订阅 — URL 嗅探出 kind</span>
+            <span class="stage-file">recally_handlers.go · types.go</span>
+          </div>
+          <div class="stage-desc">
+            <code>feed add</code> 从 URL 嗅探来源类型并落库。<code>x.com</code> /
+            <code>twitter.com</code> 主机 → <code>kind=twitter</code>，其余默认
+            <code>rss</code>；<code>--kind</code> 是逃生舱。 非 rss kind
+            <strong>不走 server 端 gofeed 解析</strong>（那解析不了 x.com），title/description 留给
+            skill 回填。
+          </div>
+          <div class="stage-body">
+            <div class="data-card">
+              <div class="data-card-header">
+                <span class="data-card-label">CreateFeed — 嗅探 + 跳过解析</span>
+                <span class="data-card-tag tag-go">Go</span>
+              </div>
+              <pre><span class="fn">kind</span> := recally.<span class="fn">SniffFeedKind</span>(body.Url)  <span class="cm">// x.com → twitter</span>
+<span class="kw">if</span> body.Kind != <span class="kw">nil</span> { kind = recally.FeedKind(*body.Kind) }  <span class="cm">// --kind 覆盖</span>
+<span class="kw">if</span> !kind.<span class="fn">Valid</span>() { <span class="cm">/* 400 写入边界校验枚举 */</span> }
+
+<span class="kw">if</span> kind == recally.FeedKindRSS {
+    parsed, err := h.feeds.<span class="fn">ParseURLWithContext</span>(body.Url, ctx)  <span class="cm">// 仅 rss 解析</span>
+    title, description = parsed.Title, parsed.Description
+}
+<span class="cm">// 非 rss：跳过解析，title 空着等 skill 回填</span>
+feed, _ := h.store.<span class="fn">CreateFeed</span>(ctx, userID, body.Url, kind, <span class="kw">nil</span>, title, description, agentID)</pre>
+            </div>
+            <div class="data-card">
+              <div class="data-card-header">
+                <span class="data-card-label">recally_rss_feed — 新增 kind / metadata 列</span>
+                <span class="data-card-tag tag-db">SQLite</span>
+              </div>
+              <table class="db-table">
+                <tr>
+                  <th>id</th>
+                  <th>user_id</th>
+                  <th>url</th>
+                  <th>kind</th>
+                  <th>metadata</th>
+                  <th>title</th>
+                </tr>
+                <tr class="new">
+                  <td>feed_7c</td>
+                  <td>u_42</td>
+                  <td>x.com/karpathy</td>
+                  <td style="color: var(--accent-green)">twitter</td>
+                  <td>{"external_id":"33836629"}</td>
+                  <td>Andrej Karpathy</td>
+                </tr>
+                <tr class="dim">
+                  <td>feed_3a</td>
+                  <td>u_42</td>
+                  <td>example.com/feed.xml</td>
+                  <td>rss</td>
+                  <td>{}</td>
+                  <td>Example Blog</td>
+                </tr>
+              </table>
+            </div>
+            <div class="info-callout">
+              <div class="info-callout-label">kind 是分流提示，不是业务分支</div>
+              <p>
+                Go 存
+                <code>kind</code> 只为决定「调度走哪条路」，<strong>不在它上面分业务逻辑</strong>。
+                枚举（rss / twitter）在 Go 写入边界校验，schema 用 plain <code>TEXT</code> —— 新增
+                kind 不用迁移。 <code>metadata</code> 是 JSON blob，存数字 user-id
+                这种改名不变的标识。
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Stage 2: Schedule dispatch -->
+        <div class="stage">
+          <div class="stage-dot cyan"></div>
+          <div class="stage-header">
+            <span class="stage-number">02</span>
+            <span class="stage-title">调度 — recally-rss builtin 按 kind 分流</span>
+            <span class="stage-file">scheduler/builtin_rss.go</span>
+          </div>
+          <div class="stage-desc">
+            每 6h 起一个 <strong>agent session</strong>（<code>ExecScopeAllUsers</code>）。builtin
+            是一段 prompt，指示 agent 按 feed 的 kind 分发发现逻辑 —— rss 走 Go 快路径，非 rss 走
+            skill。
+          </div>
+          <div class="stage-body">
+            <div class="decision-tree">
+              <div class="decision-label">dispatch by feed.kind</div>
+              <div class="decision-branch">
+                <span class="decision-condition">kind == "rss"</span>
+                <span class="decision-result">
+                  <code>stella recally feed poll --json</code> 一次跑完所有 enabled feed。 server 端
+                  gofeed 解析 + <code>CreateFeedEntry</code> 去重，<strong
+                    >非 rss feed 在 server 被短路成 no-op</strong
+                  >。
+                </span>
+              </div>
+              <div class="decision-branch">
+                <span class="decision-condition">kind != "rss"</span>
+                <span class="decision-result">
+                  <code>feed list --json</code> 取出 kind=twitter 的 feed，逐个跑该 kind 的 workflow
+                  （见 <code>twitter-workflow.md</code>）→ Stage 03。
+                </span>
+              </div>
+            </div>
+            <div class="data-card">
+              <div class="data-card-header">
+                <span class="data-card-label">PollFeed — 非 rss 短路</span>
+                <span class="data-card-tag tag-go">Go</span>
+              </div>
+              <pre><span class="cm">// 只有 rss feed 在 server 端轮询；skill 驱动的 kind 在这里是 no-op</span>
+<span class="kw">if</span> feed.Kind != recally.FeedKindRSS {
+    <span class="fn">writeData</span>(w, http.StatusOK, result)  <span class="cm">// 空 new_entries，无害</span>
+    <span class="kw">return</span>
+}</pre>
+            </div>
+          </div>
+        </div>
+
+        <!-- Stage 3: Discover (Twitter) -->
+        <div class="stage">
+          <div class="stage-dot amber"></div>
+          <div class="stage-header">
+            <span class="stage-number">03</span>
+            <span class="stage-title">发现 — skill 列推文（仅 twitter 路径）</span>
+            <span class="stage-file">references/twitter-workflow.md</span>
+          </div>
+          <div class="stage-desc">
+            agent 用 tap 的 FxEmbed 脚本列出最近推文。<code>since</code> 只是省流量的优化，
+            <strong>坏了不影响正确性</strong> —— 每轮把列出的推文全部推给 sink，去重交给 Go。
+          </div>
+          <div class="stage-body">
+            <div class="data-card">
+              <div class="data-card-header">
+                <span class="data-card-label">tap fxembed-profile-statuses</span>
+                <span class="data-card-tag tag-tap">tap</span>
+              </div>
+              <pre><span class="cm"># 用 metadata.external_id 的数字 id，防 handle 改名</span>
+tap site twitter/fxembed-profile-statuses handle=id:33836629 --json</pre>
+            </div>
+            <div class="data-card">
+              <div class="data-card-header">
+                <span class="data-card-label">每条 status 的处理</span>
+                <span class="data-card-tag tag-skill">skill</span>
+              </div>
+              <pre><span class="cm">tw_1002</span>  is_repost=false  → guid=tw_1002  url=…/status/1002  title="<span class="str">New post on …</span>"  <span class="ok">push</span>
+<span class="cm">tw_1001</span>  is_repost=false  → guid=tw_1001  <span class="cm">(上轮已 saved)</span>                          <span class="ok">push</span>
+<span class="cm">rt_99</span>   is_repost=<span class="err">true</span>   → <span class="err">skip</span> retweet（默认跳过）
+<span class="cm">空正文</span>  → title fallback "<span class="str">(media: Andrej Karpathy)</span>"</pre>
+            </div>
+            <div class="design-callout">
+              <div class="design-callout-label">为什么不在 skill 里判断「这条是不是新的」</div>
+              <p>
+                判新是有状态的，扔给 LLM loop 就脆。skill 只做<strong>无状态</strong>的「列出 + 映射
+                + 推送」， 有状态的去重收口在 Go/SQLite 的一句 <code>ON CONFLICT</code> 里。
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Stage 4: Dedup sink -->
+        <div class="stage">
+          <div class="stage-dot green"></div>
+          <div class="stage-header">
+            <span class="stage-number">04</span>
+            <span class="stage-title">去重 sink — guid upsert，只有 new 变 pending</span>
+            <span class="stage-file">queries/recally_rss_feed.sql · store.go</span>
+          </div>
+          <div class="stage-desc">
+            两条发现路径汇到同一个端点。这是整条流的<strong>命门</strong>：去重发生在抓取/总结<strong>之前</strong>。
+            一条重复的推文在这里被 <code>DO NOTHING</code> 挡掉，<strong
+              >根本不会产生新的 pending 条目</strong
+            >。
+          </div>
+          <div class="stage-body">
+            <div class="data-card">
+              <div class="data-card-header">
+                <span class="data-card-label">CreateRSSFeedEntry — 仓库现成的去重</span>
+                <span class="data-card-tag tag-sql">SQLite</span>
+              </div>
+              <pre><span class="kw">INSERT INTO</span> recally_rss_feed_entry (id, feed_id, guid, url, title, status, ...)
+<span class="kw">VALUES</span> (?, 'feed_7c', ?, ?, ?, <span class="str">'pending'</span>, ...)
+<span class="kw">ON CONFLICT</span>(feed_id, guid) <span class="kw">DO NOTHING</span>
+<span class="kw">RETURNING</span> *;   <span class="cm">-- 有行 = new；DO NOTHING 命中冲突 → 无行 = dup</span></pre>
+            </div>
+            <div class="data-card">
+              <div class="data-card-header">
+                <span class="data-card-label">本轮两次 push 的结果</span>
+                <span class="data-card-tag tag-cli">CLI</span>
+              </div>
+              <pre>feed entry add --guid tw_1002  → <span class="ok">new</span>   <span class="cm">// 插入 status=pending</span>
+feed entry add --guid tw_1001  → <span class="cm">dup</span>   <span class="cm">// 已存在，什么都不做</span></pre>
+            </div>
+            <div class="data-card">
+              <div class="data-card-header">
+                <span class="data-card-label">recally_rss_feed_entry — sink 之后</span>
+                <span class="data-card-tag tag-db">SQLite</span>
+              </div>
+              <table class="db-table">
+                <tr>
+                  <th>id</th>
+                  <th>feed_id</th>
+                  <th>guid</th>
+                  <th>status</th>
+                  <th>attempts</th>
+                  <th>article_id</th>
+                </tr>
+                <tr class="dim">
+                  <td>en_a1</td>
+                  <td>feed_7c</td>
+                  <td>tw_1001</td>
+                  <td>saved</td>
+                  <td>1</td>
+                  <td>art_x</td>
+                </tr>
+                <tr class="new">
+                  <td>en_b2</td>
+                  <td>feed_7c</td>
+                  <td>tw_1002</td>
+                  <td style="color: var(--accent-green)">pending</td>
+                  <td>0</td>
+                  <td>—</td>
+                </tr>
+              </table>
+            </div>
+            <div class="info-callout">
+              <div class="info-callout-label">会重复总结吗？不会。</div>
+              <p>
+                总结发生在 Stage 05（save-workflow），而 save-workflow
+                <strong>只处理 pending 条目</strong>。 <code>tw_1001</code> 在 sink 返回
+                <code>dup</code>、未产生新 pending → 轮不到它被抓取和总结。 每轮重复的只是「列推文 +
+                guid upsert」这种零成本操作，<strong
+                  >贵的 LLM 总结永远只对真正新增的条目跑一次</strong
+                >。
+              </p>
+            </div>
+            <div class="design-callout">
+              <div class="design-callout-label">correctness = guid dedup, not watermark</div>
+              <p>
+                抓取失败那轮就是「没发现新条目」，下一轮重列、重推，重复的被
+                <code>DO NOTHING</code> 丢掉 → 永不丢条目，也不需要脆弱的「成功才推进
+                since」逻辑。这条把 reviewer 当初的 BLOCK 直接消解。
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Stage 5: Fetch + Summarize -->
+        <div class="stage">
+          <div class="stage-dot red"></div>
+          <div class="stage-header">
+            <span class="stage-number">05</span>
+            <span class="stage-title">抓取 + 总结 — agent 自己干，无 Go 代码</span>
+            <span class="stage-file">references/save-workflow.md</span>
+          </div>
+          <div class="stage-desc">
+            对每个 <code>pending</code> 条目（含重试：<code
+              >status IN ('pending','error') AND attempts &lt; 3</code
+            >）， agent 跑 save-workflow。这一步的「总结」<strong
+              >不是 Go 里的代码，也不是单独的 LLM API 调用</strong
+            >
+            —— 就是当前 agent（即 LLM 本身）读完正文后生成的一段文本。
+          </div>
+          <div class="stage-body">
+            <div class="sub-stage">
+              <div class="sub-label">5a · Fetch 全文到临时文件</div>
+              <div class="data-card">
+                <div class="data-card-header">
+                  <span class="data-card-label">tap 抓取（含升级链）</span>
+                  <span class="data-card-tag tag-tap">tap</span>
+                </div>
+                <pre>tap site twitter/fxembed-status id=tw_1002 format=markdown -f raw &gt; $f
+<span class="cm"># 通用页面升级链：tap fetch → --lp → Jina → -b → browser network intercept</span></pre>
+              </div>
+            </div>
+            <div class="sub-stage" style="margin-top: 12px">
+              <div class="sub-label">5b · Generate Metadata — agent 读 $f，写结构化总结</div>
+              <div class="data-card">
+                <div class="data-card-header">
+                  <span class="data-card-label">$sf — agent 生成（非代码）</span>
+                  <span class="data-card-tag tag-llm">LLM</span>
+                </div>
+                <pre><span class="cm"># Summary</span>      (2-3 句) 摘要
+<span class="cm"># Abstract</span>     (150-200 词)
+<span class="cm"># Key Points</span>   要点 bullet
+<span class="cm"># Insights and Implications</span>
+<span class="cm"># Actionable Takeaways</span> (如适用)
+<span class="cm"># Critical Analysis</span>
+<span class="cm">+ Title / Author / Tags(3-7) / Worth-Reading tier (⭐/👍/📖)</span></pre>
+              </div>
+            </div>
+            <div class="risk-callout" style="margin-top: 12px">
+              <div class="risk-callout-label">总结「跑」在哪</div>
+              <p>
+                不在 stellad 进程里（Go 不调 LLM 做总结）；不是对 Anthropic/OpenAI 的独立请求。
+                就在<strong>当前这个 agent 会话的上下文</strong>里 —— 调度器起的 agent
+                一路抓取、总结、调 CLI 保存， 总结只是它的一段文本输出。skill 文件本质是
+                prompt，不是可执行代码。
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Stage 6: Save + mark -->
+        <div class="stage">
+          <div class="stage-dot purple"></div>
+          <div class="stage-header">
+            <span class="stage-number">06</span>
+            <span class="stage-title">入库 + 标记 — 文章持久化，条目转 saved</span>
+            <span class="stage-file">recally save · feed mark</span>
+          </div>
+          <div class="stage-desc">
+            <code>stella recally save</code> 是纯持久化命令：给它
+            <code>--summary</code> 字符串，它原样存进
+            <code>recally_article</code>，<strong>不关心这字符串怎么来的</strong>。保存后把 entry
+            标记为 saved。
+          </div>
+          <div class="stage-body">
+            <div class="data-card">
+              <div class="data-card-header">
+                <span class="data-card-label">save → mark</span>
+                <span class="data-card-tag tag-cli">CLI</span>
+              </div>
+              <pre>art=$(stella recally save "https://x.com/karpathy/status/1002" --json \
+    --content-file "$f" --summary "$(cat $sf)" \
+    --title "…" --author "Andrej Karpathy" --tags "ai" --tags "ml" \
+    --source-type <span class="str">twitter</span> \
+    --metadata '{"worth_reading":"Top pick"}')
+
+stella recally feed mark feed_7c en_b2 --status <span class="ok">saved</span> --article-id $(echo $art | jq -r .id)
+<span class="cm"># 失败：--status error --error "&lt;reason&gt;"  ／ 跳过：--status skipped</span></pre>
+            </div>
+            <div class="data-card">
+              <div class="data-card-header">
+                <span class="data-card-label">recally_article — 落库一条</span>
+                <span class="data-card-tag tag-db">SQLite</span>
+              </div>
+              <table class="db-table">
+                <tr>
+                  <th>id</th>
+                  <th>user_id</th>
+                  <th>source_type</th>
+                  <th>title</th>
+                  <th>status</th>
+                </tr>
+                <tr class="new">
+                  <td>art_y</td>
+                  <td>u_42</td>
+                  <td style="color: var(--accent-amber)">twitter</td>
+                  <td>New post on …</td>
+                  <td>unread</td>
+                </tr>
+              </table>
+            </div>
+            <div class="info-callout">
+              <div class="info-callout-label">第二层保险 — 文章级去重</div>
+              <p>
+                即便 dup 漏到这步，<code>recally save</code> 还按
+                <strong>canonical URL</strong> 做文章级去重 （mobile/desktop
+                变体可能各算一份）。但正常路径在 Stage 04 就拦住了，到不了这层。
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Stage 7: Notify / Digest -->
+        <div class="stage">
+          <div class="stage-dot green"></div>
+          <div class="stage-header">
+            <span class="stage-number">07</span>
+            <span class="stage-title">通知 + 摘要</span>
+            <span class="stage-file">builtin_rss.go · recally digest</span>
+          </div>
+          <div class="stage-desc">
+            仅当本轮 ≥1 篇文章被保存时才调一次 notify（零保存就停手，不打扰）。每日 digest
+            另行汇总。
+          </div>
+          <div class="stage-body">
+            <div class="data-card">
+              <div class="data-card-header">
+                <span class="data-card-label">notify 门槛（builtin prompt）</span>
+                <span class="data-card-tag tag-skill">skill</span>
+              </div>
+              <pre>saved == 0  → <span class="err">不调 notify</span>，结束
+saved &gt;= 1  → notify 一次：
+  · 每篇(最多5)：Worth-Reading 标签 + 标题 + 作者 + "# Summary" 段
+  · 超过5篇：其余仅列 标题 + 作者</pre>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ───────── Path Comparison ───────── -->
+      <div class="section-divider">
+        <h2>RSS vs Twitter 差异点</h2>
+        <p>
+          两条路只在「发现」环节不同 —— auth 边界才是真正的分界，不是源类型。一旦成了 pending
+          条目，抓取 / 总结 / 入库 / 通知走的是同一条路。
+        </p>
+      </div>
+
+      <div class="data-card">
+        <table class="db-table" style="font-size: 12px">
+          <tr>
+            <th style="width: 20%">阶段</th>
+            <th style="width: 40%">RSS (kind=rss)</th>
+            <th style="width: 40%">Twitter (kind=twitter)</th>
+          </tr>
+          <tr>
+            <td style="color: var(--accent-blue)">订阅嗅探</td>
+            <td>默认 kind=rss</td>
+            <td>x.com / twitter.com → kind=twitter</td>
+          </tr>
+          <tr>
+            <td style="color: var(--accent-blue)">入库时解析</td>
+            <td>server gofeed 取 title/description</td>
+            <td>跳过解析，skill 回填 + 存数字 user-id</td>
+          </tr>
+          <tr>
+            <td style="color: var(--accent-cyan)">发现执行者</td>
+            <td>server（Go 快路径，零 LLM）</td>
+            <td>agent skill + tap fxembed</td>
+          </tr>
+          <tr>
+            <td style="color: var(--accent-amber)">列出条目</td>
+            <td>gofeed 解析 RSS items</td>
+            <td>fxembed-profile-statuses，跳 retweet</td>
+          </tr>
+          <tr>
+            <td style="color: var(--accent-green)">去重</td>
+            <td colspan="2" style="text-align: center">
+              共享 <code>feed entry add</code> — <code>ON CONFLICT(feed_id, guid) DO NOTHING</code>
+            </td>
+          </tr>
+          <tr>
+            <td style="color: var(--accent-red)">抓取 + 总结</td>
+            <td colspan="2" style="text-align: center">
+              共享 save-workflow — agent 读全文，LLM 生成结构化总结（仅对 pending 条目）
+            </td>
+          </tr>
+          <tr>
+            <td style="color: var(--accent-purple)">入库</td>
+            <td colspan="2" style="text-align: center">
+              共享 <code>recally save</code> → recally_article（canonical URL 二次去重）
+            </td>
+          </tr>
+          <tr>
+            <td style="color: var(--accent-purple)">source_type</td>
+            <td>rss</td>
+            <td>twitter</td>
+          </tr>
+          <tr>
+            <td style="color: var(--accent-green)">通知 / 摘要</td>
+            <td colspan="2" style="text-align: center">共享 notify 门槛 + 每日 digest</td>
+          </tr>
+          <tr>
+            <td style="color: var(--accent-cyan)">成本优化空间</td>
+            <td>已是最便宜路径</td>
+            <td>per-source 缓存折叠重复抓取（v2 / #316）</td>
+          </tr>
+        </table>
+      </div>
+
+      <div class="section-divider">
+        <h2>auth 边界 — 框架的真正分界（#316）</h2>
+        <p>决定一个源能不能留 Go 快路径的，不是「它是什么源」，而是「需不需要登录」。</p>
+      </div>
+      <div class="two-col">
+        <div class="design-callout">
+          <div class="design-callout-label">公开 / 免登录</div>
+          <p>
+            RSS、YouTube 频道 RSS、fxtwitter 公开主页 —— <strong>可</strong>留 Go 快路径作成本优化，
+            避免每轮起一个 LLM。YouTube 频道今天就能用：直接订阅
+            <code>youtube.com/feeds/videos.xml?channel_id=…</code>，零新代码。
+          </p>
+        </div>
+        <div class="risk-callout">
+          <div class="risk-callout-label">登录态</div>
+          <p>
+            X following / for-you / bookmarks、付费内容 —— <strong>只能</strong>走 tap 的 attached
+            browser， 在 agent 会话内执行 → skill-only，没有 Go 路径可言。
+          </p>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## What

Pilot of skill-driven feed extraction (#314). Adds a `kind` dispatch hint + `metadata` JSON to recally feeds, a source-agnostic entry-add endpoint/CLI that dedups on `(feed_id, guid)`, and a Twitter discovery workflow in the recally skill. RSS keeps its cheap server-side fast-path; non-rss kinds are extracted by the skill.

## Why

You can't *follow* an X account today — many high-signal sources are X-only with no RSS. Extraction lives in the skill + tap (not Go) on purpose: it extends to RSS-less sites later, and rot-prone scrapers/embed APIs hot-swap via `tap site sync` instead of riding the `stellad` release cycle.

**Correctness rests on guid dedup, not a watermark.** A failed poll just yields no new entries; the next run re-lists and `ON CONFLICT(feed_id, guid) DO NOTHING` drops dups → no lost tweets, no fragile "advance-since-only-on-success" logic.

## How

- **Schema** — `kind TEXT DEFAULT 'rss'` + `metadata TEXT DEFAULT '{}'` on `recally_rss_feed` (Atlas additive migration). Enum validated in Go at the write boundary, not via `CHECK`.
- **Entry-add endpoint** — `POST /api/recally/feeds/{id}/entries {guid,url,title}` reuses `CreateRSSFeedEntry`; returns `created: bool` (new vs dup). CLI: `stella recally feed entry add … ` prints `new`/`dup`.
- **feed add** — `SniffFeedKind` maps `x.com`/`twitter.com` → `twitter`, else `rss`; `--kind` escape hatch overrides. Non-rss kinds skip server gofeed parse (metadata backfilled by skill).
- **Scheduler** — `recally-rss` builtin dispatches by kind: rss → `feed poll` (server, skips non-rss), non-rss → recally skill workflow. `PollFeed` is a no-op for non-rss kinds.
- **Skill** — new `references/twitter-workflow.md` (list via `fxembed-profile-statuses` → skip retweets → `feed entry add` → reuse save-workflow with `--source-type twitter`); `SKILL.md` updated.
- **Docs** — `recally/overview` (EN+zh) cover Twitter/X subscriptions and YouTube-as-RSS.

Explicitly **not** here (→ #316): table rename `recally_rss_feed → recally_feed`, arbitrary-website subscription, login-gated X, per-source caching.

## Test plan

- [x] `mise run format && mise run build && mise run test` green
- [x] Unit test for `SniffFeedKind` (x.com/twitter.com/www/mobile variants, rss/youtube fallbacks, lookalike host, empty)
- [x] Store tests pass with new columns
- [ ] Manual: `feed add https://x.com/<handle>` → kind=twitter; `feed entry add` idempotency (new then dup); scheduler discovers + saves a tweet

## Refs

- Pilot issue: #314
- Mainline epic: #316