### PR TITLE
✨ feat(recally): reject non-timeline X URLs on feed add

### DIFF
--- a/internal/recally/feedkind_test.go
+++ b/internal/recally/feedkind_test.go
@@ -26,3 +26,43 @@ func TestSniffFeedKind(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateFeedSubscription(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		kind    FeedKind
+		wantErr bool
+	}{
+		{"x profile", "https://x.com/jack", FeedKindTwitter, false},
+		{"twitter profile", "https://twitter.com/jack", FeedKindTwitter, false},
+		{"x profile trailing slash", "https://x.com/jack/", FeedKindTwitter, false},
+		{"x profile with @", "https://x.com/@jack", FeedKindTwitter, false},
+		{"x profile trailing whitespace", "  https://x.com/jack  ", FeedKindTwitter, false},
+		{"x lists rejected", "https://x.com/i/lists/123", FeedKindTwitter, true},
+		{"x handle lists rejected", "https://x.com/jack/lists/123", FeedKindTwitter, true},
+		{"x status rejected", "https://x.com/jack/status/1", FeedKindTwitter, true},
+		{"x with_replies rejected", "https://x.com/jack/with_replies", FeedKindTwitter, true},
+		{"x search rejected", "https://x.com/search?q=go", FeedKindTwitter, true},
+		{"x home rejected", "https://x.com/home", FeedKindTwitter, true},
+		{"x bookmarks rejected", "https://x.com/i/bookmarks", FeedKindTwitter, true},
+		{"x root rejected", "https://x.com/", FeedKindTwitter, true},
+		// X hosts are rejected even when kind sniffed to rss — they never serve RSS.
+		{"x lists rejected as rss", "https://x.com/i/lists/123", FeedKindRSS, true},
+		{"x search rejected as rss", "https://x.com/search?q=go", FeedKindRSS, true},
+		// kind=twitter forced on a non-X host is rejected.
+		{"non-x host forced twitter", "https://example.com/feed.xml", FeedKindTwitter, true},
+		// RSS feeds: any non-X URL accepted (validated at fetch time).
+		{"rss feed", "https://example.com/feed.xml", FeedKindRSS, false},
+		{"youtube rss", "https://www.youtube.com/feeds/videos.xml?channel_id=abc", FeedKindRSS, false},
+		{"lookalike host", "https://notx.com/i/lists/1", FeedKindRSS, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateFeedSubscription(tt.url, tt.kind)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateFeedSubscription(%q, %q) error = %v, wantErr %v", tt.url, tt.kind, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/recally/types.go
+++ b/internal/recally/types.go
@@ -4,6 +4,7 @@ package recally
 import (
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"net/url"
 	"strings"
 	"time"
@@ -82,22 +83,88 @@ func (k FeedKind) Valid() bool {
 	}
 }
 
+// isTwitterHost reports whether host is an X/Twitter web host (ignoring a www. prefix).
+func isTwitterHost(host string) bool {
+	host = strings.TrimPrefix(strings.ToLower(host), "www.")
+	switch host {
+	case "x.com", "twitter.com", "mobile.twitter.com", "mobile.x.com":
+		return true
+	default:
+		return false
+	}
+}
+
+// twitterReservedPaths are first path segments on X/Twitter that are not
+// subscribable profile handles (system pages, search, lists, etc.).
+var twitterReservedPaths = map[string]bool{
+	"i":             true,
+	"home":          true,
+	"explore":       true,
+	"search":        true,
+	"hashtag":       true,
+	"messages":      true,
+	"notifications": true,
+	"settings":      true,
+	"compose":       true,
+	"intent":        true,
+}
+
+// twitterHandle returns the profile handle of an X/Twitter timeline URL. It
+// succeeds only when the path is a single handle segment (/<handle>), rejecting
+// system pages, search, lists, individual statuses, replies, and bookmarks —
+// none of which are pollable as a profile timeline.
+func twitterHandle(rawURL string) (string, bool) {
+	u, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || !isTwitterHost(u.Hostname()) {
+		return "", false
+	}
+	segs := strings.Split(strings.Trim(u.EscapedPath(), "/"), "/")
+	if len(segs) != 1 || segs[0] == "" {
+		return "", false
+	}
+	handle := strings.TrimPrefix(segs[0], "@")
+	if handle == "" || twitterReservedPaths[strings.ToLower(handle)] {
+		return "", false
+	}
+	for _, r := range handle {
+		if (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') && (r < '0' || r > '9') && r != '_' {
+			return "", false
+		}
+	}
+	return handle, true
+}
+
 // SniffFeedKind infers a feed kind from a subscription URL. x.com / twitter.com
 // hosts map to twitter; everything else defaults to rss. The caller may override
-// the result with an explicit kind.
+// the result with an explicit kind. URL shape is enforced separately by
+// ValidateFeedSubscription.
 func SniffFeedKind(rawURL string) FeedKind {
 	u, err := url.Parse(strings.TrimSpace(rawURL))
 	if err != nil {
 		return FeedKindRSS
 	}
-	host := strings.ToLower(u.Hostname())
-	host = strings.TrimPrefix(host, "www.")
-	switch host {
-	case "x.com", "twitter.com", "mobile.twitter.com", "mobile.x.com":
+	if isTwitterHost(u.Hostname()) {
 		return FeedKindTwitter
-	default:
-		return FeedKindRSS
 	}
+	return FeedKindRSS
+}
+
+// ValidateFeedSubscription reports whether rawURL can be subscribed as kind.
+// X/Twitter hosts are only subscribable as profile timelines (/<handle>) — they
+// never serve RSS, so lists, search, individual posts, and bookmarks are
+// rejected regardless of kind. RSS feeds are validated when fetched, so any
+// non-X URL is accepted here.
+func ValidateFeedSubscription(rawURL string, kind FeedKind) error {
+	if u, err := url.Parse(strings.TrimSpace(rawURL)); err == nil && isTwitterHost(u.Hostname()) {
+		if _, ok := twitterHandle(rawURL); !ok {
+			return fmt.Errorf("x/twitter feeds must be a profile timeline like https://x.com/<handle>; lists, search, individual posts, and bookmarks are not subscribable")
+		}
+		return nil
+	}
+	if kind == FeedKindTwitter {
+		return fmt.Errorf("kind=twitter requires an x.com/<handle> profile URL")
+	}
+	return nil
 }
 
 // Article represents a saved article with its metadata.

--- a/internal/server/recally_handlers.go
+++ b/internal/server/recally_handlers.go
@@ -415,6 +415,10 @@ func (h *recallyHandlers) CreateFeed(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid feed kind")
 		return
 	}
+	if err := recally.ValidateFeedSubscription(body.Url, kind); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 
 	title := strDeref(body.Title)
 	description := ""

--- a/web/content/docs/recally/overview.md
+++ b/web/content/docs/recally/overview.md
@@ -38,7 +38,7 @@ Recally can subscribe to feeds and keep a live stream of new entries. Use this f
 
 Beyond RSS, you can follow:
 
-- **Twitter/X accounts** — subscribe with a profile URL like `https://x.com/<handle>` and Recally treats new tweets as feed entries, saved and summarized like any other source.
+- **Twitter/X accounts** — subscribe with a profile URL like `https://x.com/<handle>` and Recally treats new tweets as feed entries, saved and summarized like any other source. Only profile timelines are subscribable; lists, search, individual posts, and bookmarks are rejected.
 - **YouTube channels** — subscribe to the channel's RSS feed (`https://www.youtube.com/feeds/videos.xml?channel_id=...`) to track new uploads.
 
 Recally detects the source type from the URL, so subscribing is the same one step regardless of where the content lives.

--- a/web/content/docs/recally/overview.zh.md
+++ b/web/content/docs/recally/overview.zh.md
@@ -38,7 +38,7 @@ Recally 可以订阅 feeds，并持续获取新条目。适合长期关注的来
 
 除了 RSS，你还可以关注：
 
-- **Twitter/X 账号** —— 用类似 `https://x.com/<handle>` 的主页地址订阅，Recally 会把新推文当作 feed 条目，像其他来源一样保存和总结。
+- **Twitter/X 账号** —— 用类似 `https://x.com/<handle>` 的主页地址订阅，Recally 会把新推文当作 feed 条目，像其他来源一样保存和总结。仅支持个人主页 timeline；列表、搜索、单条推文和书签会被拒绝。
 - **YouTube 频道** —— 订阅频道的 RSS 地址（`https://www.youtube.com/feeds/videos.xml?channel_id=...`）即可跟进新视频。
 
 Recally 会从 URL 自动识别来源类型，所以无论内容在哪，订阅都是同样的一步。


### PR DESCRIPTION
## What

Harden `feed add`: X/Twitter feeds are only subscribable as profile timelines
(`x.com/<handle>`). Lists, search, individual posts, bookmarks, and system pages
are rejected with a clear 400.

## Why

`SniffFeedKind` mapped any X host to `kind=twitter` without validating the path, so
non-timeline URLs (`x.com/i/lists/*`, `x.com/search`, `x.com/<handle>/status/*`,
`x.com/i/bookmarks`) were accepted as profile feeds and would fail or mis-fetch during
skill-driven extraction. #316 explicitly calls for rejecting these.

## How

- `internal/recally/types.go`: extract `isTwitterHost`; add `twitterHandle` (single
  `/<handle>` segment only, reserved prefixes + multi-segment paths rejected) and
  `ValidateFeedSubscription`. X hosts that aren't profile timelines are rejected
  regardless of resolved kind; forcing `--kind twitter` on a non-X host is rejected too.
  `SniffFeedKind` stays host-based; shape enforcement lives in validation.
- `internal/server/recally_handlers.go`: `CreateFeed` calls `ValidateFeedSubscription` → 400.
- Tests: table-driven `TestValidateFeedSubscription` (profile/lists/search/status/
  bookmarks/home + non-X forced-twitter); existing sniff tests unchanged.
- Docs: `recally/overview.md` + `.zh.md` note only profile timelines are supported.

Verification: `mise run format && mise run build && mise run test` all pass.

## Refs

- Closes #319
- Epic: #316