### PR TITLE
✨ feat(recally): website feed kind for no-RSS pages

### DIFF
--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -1289,8 +1289,8 @@ components:
       enum: [pending, saved, skipped, error]
     FeedKind:
       type: string
-      description: "Extraction-dispatch hint. 'rss' uses the built-in poller; other kinds are extracted by the recally skill."
-      enum: [rss, twitter]
+      description: "Extraction-dispatch hint. 'rss' uses the built-in poller; other kinds (twitter, website) are extracted by the recally skill."
+      enum: [rss, twitter, website]
     Article:
       type: object
       required: [

--- a/api/spec/domain/recally/schemas.yaml
+++ b/api/spec/domain/recally/schemas.yaml
@@ -20,8 +20,8 @@ components:
 
     FeedKind:
       type: string
-      description: "Extraction-dispatch hint. 'rss' uses the built-in poller; other kinds are extracted by the recally skill."
-      enum: [rss, twitter]
+      description: "Extraction-dispatch hint. 'rss' uses the built-in poller; other kinds (twitter, website) are extracted by the recally skill."
+      enum: [rss, twitter, website]
 
     Article:
       type: object

--- a/cmd/stella/recally_feeds.go
+++ b/cmd/stella/recally_feeds.go
@@ -35,7 +35,7 @@ func recallyFeedAddCommand() *ucli.Command {
 		Usage:     "Subscribe to a feed (kind is sniffed from the URL unless --kind is set)",
 		ArgsUsage: "<feed-url>",
 		Flags: []ucli.Flag{
-			&ucli.StringFlag{Name: "kind", Usage: "Force feed kind: rss, twitter (default: sniff from URL)"},
+			&ucli.StringFlag{Name: "kind", Usage: "Force feed kind: rss, twitter, website (default: sniff from URL)"},
 			cli.JSONFlag(),
 		},
 		Action: func(c *ucli.Context) error {

--- a/internal/recally/feedkind_test.go
+++ b/internal/recally/feedkind_test.go
@@ -27,6 +27,17 @@ func TestSniffFeedKind(t *testing.T) {
 	}
 }
 
+func TestFeedKindValid(t *testing.T) {
+	for _, k := range []FeedKind{FeedKindRSS, FeedKindTwitter, FeedKindWebsite} {
+		if !k.Valid() {
+			t.Errorf("FeedKind(%q).Valid() = false, want true", k)
+		}
+	}
+	if FeedKind("bogus").Valid() {
+		t.Errorf("FeedKind(\"bogus\").Valid() = true, want false")
+	}
+}
+
 func TestValidateFeedSubscription(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -56,6 +67,11 @@ func TestValidateFeedSubscription(t *testing.T) {
 		{"rss feed", "https://example.com/feed.xml", FeedKindRSS, false},
 		{"youtube rss", "https://www.youtube.com/feeds/videos.xml?channel_id=abc", FeedKindRSS, false},
 		{"lookalike host", "https://notx.com/i/lists/1", FeedKindRSS, false},
+		// website: any non-X page accepted (skill scrapes it).
+		{"website page", "https://example.com/blog", FeedKindWebsite, false},
+		{"website index with path", "https://example.com/news/latest", FeedKindWebsite, false},
+		// website on an X host is still blocked by the X-host guard.
+		{"website on x lists rejected", "https://x.com/i/lists/1", FeedKindWebsite, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/recally/types.go
+++ b/internal/recally/types.go
@@ -71,12 +71,13 @@ type FeedKind string
 const (
 	FeedKindRSS     FeedKind = "rss"
 	FeedKindTwitter FeedKind = "twitter"
+	FeedKindWebsite FeedKind = "website"
 )
 
 // Valid reports whether k is a known feed kind.
 func (k FeedKind) Valid() bool {
 	switch k {
-	case FeedKindRSS, FeedKindTwitter:
+	case FeedKindRSS, FeedKindTwitter, FeedKindWebsite:
 		return true
 	default:
 		return false

--- a/internal/scheduler/builtin_rss.go
+++ b/internal/scheduler/builtin_rss.go
@@ -6,7 +6,7 @@ var RecallyRSSBuiltin = BuiltinJob{
 	Name: "recally-rss",
 	Message: `1. Discover new entries for every enabled feed. Load the recally skill, then dispatch by feed kind:
    - rss: run "stella recally feed poll --limit 20 --json" once (no feed-id polls every enabled feed; non-rss feeds are skipped server-side).
-   - twitter (and other non-rss kinds): run "stella recally feed list --json", and for each feed whose kind is not "rss", follow that kind's workflow in the recally skill (e.g. the Twitter workflow) to list items and push them via "stella recally feed entry add" (Go dedups on guid).
+   - twitter / website (and other non-rss kinds): run "stella recally feed list --json", and for each feed whose kind is not "rss", follow that kind's workflow in the recally skill (e.g. the Twitter or website workflow) to list items and push them via "stella recally feed entry add" (Go dedups on guid).
 2. For each pending entry (across all feeds), follow the save workflow defined in the recally skill (fetch → generate metadata → save with the entry's source type → mark).
 3. Notify only when at least one article was saved: count articles saved in step 2. If zero, do NOT call the notify tool — stop here. If one or more, call notify once:
    - For each article (up to 5): Worth-Reading label (emoji + text), title, author, and the "# Summary" section from the structured summary.

--- a/resources/skills/system/recally/SKILL.md
+++ b/resources/skills/system/recally/SKILL.md
@@ -22,6 +22,7 @@ open the SQLite database directly.
 | Saving an article (fetch → generate → save) | [references/save-workflow.md](references/save-workflow.md)       |
 | RSS batch processing                        | [references/rss-workflow.md](references/rss-workflow.md)         |
 | Twitter/X feed discovery                    | [references/twitter-workflow.md](references/twitter-workflow.md) |
+| Website (no-RSS) feed discovery             | [references/website-workflow.md](references/website-workflow.md) |
 
 ## Search and Retrieve
 
@@ -55,10 +56,12 @@ stella recally feed entry add --feed-id <id> --guid <guid> --url <url> --title <
 ```
 
 `feed add` sniffs the kind from the URL: `x.com` / `twitter.com` hosts become
-`twitter`, everything else defaults to `rss`. Pass `--kind rss|twitter` to force it.
+`twitter`, everything else defaults to `rss`. Pass `--kind rss|twitter|website` to
+force it. Use `--kind website` for a page that lists items but has no RSS.
 
 - **rss** feeds: poll server-side, then process pending entries — see [references/rss-workflow.md](references/rss-workflow.md).
 - **twitter** feeds: discover entries via the skill — see [references/twitter-workflow.md](references/twitter-workflow.md).
+- **website** feeds: scrape item links from a no-RSS page — see [references/website-workflow.md](references/website-workflow.md).
 
 `feed entry add` is the source-agnostic discovery sink: it dedups on `(feed-id, guid)`
 and prints `new` or `dup`. YouTube channels work today with no new code — subscribe

--- a/resources/skills/system/recally/references/website-workflow.md
+++ b/resources/skills/system/recally/references/website-workflow.md
@@ -1,0 +1,65 @@
+# Website Feed Workflow
+
+Discovery workflow for feeds with `kind=website` — pages that list items but have
+**no RSS** (blog indexes, release notes, "What's new", news sections). Go owns
+dedup and storage; this workflow only finds item links and pushes them as entries.
+Correctness rests on guid dedup, **not** a watermark — a failed run just discovers
+nothing, and the next run re-lists and Go drops the duplicates.
+
+## 1. Identify website feeds
+
+```bash
+stella recally feed list --json
+```
+
+Process each feed whose `kind` is `website`. The `url` is the index page to scan.
+
+## 2. Fetch the index page
+
+```bash
+tap fetch --json <feed-url>
+```
+
+Returns `{markdown, title, ...}`. If the page is JS-heavy and the markdown lacks the
+item list, escalate per the tap-web skill: `tap fetch --lp <url>`, then
+`tap fetch -b <url>`, then `tap browser open <url>` + `tap browser snapshot`.
+
+## 3. Pick item links (skill judgment)
+
+From the fetched page, select the links that are **actual content items** — articles,
+posts, releases, videos. This is fuzzy; use judgment:
+
+- **Keep**: links into the site's content (e.g. `/blog/<slug>`, `/posts/...`, dated paths).
+- **Skip**: nav, header/footer, pagination ("next", page numbers), category/tag/author
+  index pages, "subscribe"/"login"/social links, and ads.
+- Resolve relative links to absolute URLs against the feed URL.
+
+If unsure whether the page is an index at all (e.g. it's a single article), push
+nothing — `website` is for pages that list items.
+
+## 4. Normalize the guid (dedup key)
+
+A web item has no stable native id, so **guid = the item's canonical URL**:
+
+- Strip tracking query params (`utm_*`, `fbclid`, `gclid`, `ref`, `source`).
+- Strip the URL fragment (`#...`).
+- Keep meaningful path/query that identifies the item.
+
+Use the same normalized URL for both `--guid` and `--url`.
+
+## 5. Push entries (Go dedups)
+
+```bash
+stella recally feed entry add --feed-id <feed-id> --guid <item-url> --url <item-url> --title "<title>"
+```
+
+Prints `new` (inserted) or `dup` (guid already existed). Pushing extras is harmless;
+stop once you hit a run of `dup` if you want to save calls. `title` = the link text
+or the item's heading.
+
+## 6. Process pending entries
+
+New entries land as `pending`, exactly like RSS entries. Process them with the
+standard [save-workflow.md](save-workflow.md) using `--source-type web` (fetch each
+item URL), then mark each entry saved / skipped / error as described in
+[rss-workflow.md](rss-workflow.md).

--- a/web/content/docs/recally/overview.md
+++ b/web/content/docs/recally/overview.md
@@ -40,8 +40,9 @@ Beyond RSS, you can follow:
 
 - **Twitter/X accounts** — subscribe with a profile URL like `https://x.com/<handle>` and Recally treats new tweets as feed entries, saved and summarized like any other source. Only profile timelines are subscribable; lists, search, individual posts, and bookmarks are rejected.
 - **YouTube channels** — subscribe to the channel's RSS feed (`https://www.youtube.com/feeds/videos.xml?channel_id=...`) to track new uploads.
+- **Websites with no RSS** — subscribe to a page that lists items (a blog index, release notes, a "What's new" page) with `--kind website`. Recally scrapes the item links from the page and saves each one like any other source.
 
-Recally detects the source type from the URL, so subscribing is the same one step regardless of where the content lives.
+Recally detects the source type from the URL, so subscribing is the same one step regardless of where the content lives. For RSS-less pages, pass `--kind website` to tell Recally to scrape the page instead of looking for a feed.
 
 ## Maintain a reading list
 

--- a/web/content/docs/recally/overview.zh.md
+++ b/web/content/docs/recally/overview.zh.md
@@ -40,8 +40,9 @@ Recally 可以订阅 feeds，并持续获取新条目。适合长期关注的来
 
 - **Twitter/X 账号** —— 用类似 `https://x.com/<handle>` 的主页地址订阅，Recally 会把新推文当作 feed 条目，像其他来源一样保存和总结。仅支持个人主页 timeline；列表、搜索、单条推文和书签会被拒绝。
 - **YouTube 频道** —— 订阅频道的 RSS 地址（`https://www.youtube.com/feeds/videos.xml?channel_id=...`）即可跟进新视频。
+- **没有 RSS 的网站** —— 对于列出条目的页面（博客索引、release notes、"What's new" 页），用 `--kind website` 订阅。Recally 会从页面里抓取条目链接，并像其他来源一样逐条保存。
 
-Recally 会从 URL 自动识别来源类型，所以无论内容在哪，订阅都是同样的一步。
+Recally 会从 URL 自动识别来源类型，所以无论内容在哪，订阅都是同样的一步。对于没有 RSS 的页面，加 `--kind website` 让 Recally 直接抓取页面，而不是去找 feed。
 
 ## 维护阅读列表
 


### PR DESCRIPTION
## What

Add a `website` feed kind so users can subscribe to pages that list items but have **no RSS** (blog indexes, release notes, "What's new", news sections) with `stella recally feed add <page-url> --kind website`.

## Why

Many high-value sources publish no feed. Non-X URLs default to `rss` and the server-side parse fails on a plain HTML page. Per epic #316, reach to RSS-less sites comes from the skill + tap, not a Go-per-source path.

## How

Follows the #316 contract — Go only learns `website` as a valid kind; per-source discovery lives in the recally skill.

- `FeedKind` enum + `FeedKindWebsite` const + `Valid()` (handler/validation/sniff unchanged — `website` naturally skips server-side parse, X hosts stay guarded).
- New `references/website-workflow.md`: `tap fetch --json` the index page → skill picks item links (skips nav/pagination/tag pages) → **guid = normalized item URL** (strip tracking params + fragment) → `feed entry add` (Go dedups on `(feed_id, guid)`) → save-workflow `--source-type web`.
- Scheduler dispatch text + `SKILL.md` updated; `--kind website` CLI hint; docs (EN/ZH).
- `sniff` still defaults to `rss`; `website` is an explicit `--kind` escape hatch (URL alone can't tell a feed from an index page).

## Refs

- Closes #321
- Epic: #316
- Verified: `mise run format && build && test` green; `go test ./internal/recally/...` passes.

## Test plan

- [ ] `stella recally feed add https://example.com/blog --kind website` → accepted, `kind=website`, no parse error
- [ ] `stella recally feed add https://example.com/blog` → still tries rss
- [ ] Run website-workflow on a real index page → `tap fetch --json` → pick links → `feed entry add` → pending entries appear, deduped on re-run