### PR TITLE
feat(feishu): auto-provision bot as group member

### DIFF
--- a/cmd/stellad/gateway.go
+++ b/cmd/stellad/gateway.go
@@ -219,6 +219,7 @@ func runServer(ctx context.Context, s *setupResult, listFn func() []pkgchannel.M
 	}))
 	botRegistry := channel.NewBotIdentityRegistry()
 	publisherRegistry := channel.NewPublisherRegistry()
+	coordOpts = append(coordOpts, channel.WithDB(s.db))
 	coordOpts = append(coordOpts, channel.WithEventLog(elStore))
 	coordOpts = append(coordOpts, channel.WithBotRegistry(botRegistry))
 	coordOpts = append(coordOpts, channel.WithPublisherRegistry(publisherRegistry))

--- a/internal/channel/coordinator.go
+++ b/internal/channel/coordinator.go
@@ -2,8 +2,10 @@ package channel
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"filippo.io/age"
@@ -15,6 +17,7 @@ import (
 	"github.com/CherryHQ/stella/internal/vault"
 	"github.com/CherryHQ/stella/pkg/ai"
 	pkgchannel "github.com/CherryHQ/stella/pkg/channel"
+	"github.com/CherryHQ/stella/pkg/db/sqlc"
 )
 
 // channelAuthStore is the subset of auth store interfaces needed by the channel coordinator.
@@ -57,6 +60,7 @@ type Coordinator struct {
 	semanticGroupArbiter SemanticGroupArbiter
 	publisherRegistry    *PublisherRegistry
 	groupDispatcher      *GroupDispatcher
+	db                   *sql.DB
 }
 
 // CoordinatorOption configures the Coordinator.
@@ -180,6 +184,69 @@ func WithGroupDispatcher(dispatcher *GroupDispatcher) CoordinatorOption {
 
 func (c *Coordinator) SetGroupDispatcher(dispatcher *GroupDispatcher) {
 	c.groupDispatcher = dispatcher
+}
+
+// WithDB gives the coordinator direct DB access for group member management.
+func WithDB(db *sql.DB) CoordinatorOption {
+	return func(c *Coordinator) {
+		c.db = db
+	}
+}
+
+// EnsurePlatformGroupMember resolves the internal group ID for a platform group
+// and registers the channel's agent as a member. Safe to call repeatedly.
+func (c *Coordinator) EnsurePlatformGroupMember(ctx context.Context, platform, platformGroupID, channelID string) error {
+	if c.eventLog == nil || c.db == nil {
+		return errors.New("group member provisioning not configured")
+	}
+	groupID, err := c.eventLog.ResolveGroupID(ctx, platform, platformGroupID, "")
+	if err != nil {
+		return fmt.Errorf("resolve group: %w", err)
+	}
+	ch, err := c.store.GetChannel(ctx, channelID)
+	if err != nil {
+		return fmt.Errorf("get channel %q: %w", channelID, err)
+	}
+	if ch.AgentID == "" {
+		return fmt.Errorf("channel %q has no agent", channelID)
+	}
+	q := sqlc.New(c.db)
+	if _, err := q.AddGroupMember(ctx, sqlc.AddGroupMemberParams{
+		GroupID:        groupID,
+		AgentID:        ch.AgentID,
+		ReplyChannelID: channelID,
+	}); err != nil {
+		return fmt.Errorf("add group member: %w", err)
+	}
+	slog.Info("ensured platform group member", "platform", platform, "platform_group_id", platformGroupID, "group_id", groupID, "agent_id", ch.AgentID, "channel_id", channelID)
+	return nil
+}
+
+// RemovePlatformGroupMember removes the channel's agent from a platform group.
+func (c *Coordinator) RemovePlatformGroupMember(ctx context.Context, platform, platformGroupID, channelID string) error {
+	if c.eventLog == nil || c.db == nil {
+		return errors.New("group member provisioning not configured")
+	}
+	groupID, err := c.eventLog.ResolveGroupID(ctx, platform, platformGroupID, "")
+	if err != nil {
+		return fmt.Errorf("resolve group: %w", err)
+	}
+	ch, err := c.store.GetChannel(ctx, channelID)
+	if err != nil {
+		return fmt.Errorf("get channel %q: %w", channelID, err)
+	}
+	if ch.AgentID == "" {
+		return nil
+	}
+	q := sqlc.New(c.db)
+	if err := q.RemoveGroupMember(ctx, sqlc.RemoveGroupMemberParams{
+		GroupID: groupID,
+		AgentID: ch.AgentID,
+	}); err != nil {
+		return fmt.Errorf("remove group member: %w", err)
+	}
+	slog.Info("removed platform group member", "platform", platform, "platform_group_id", platformGroupID, "group_id", groupID, "agent_id", ch.AgentID)
+	return nil
 }
 
 // RegisterBotIdentity records a bot's platform identity for mention resolution.

--- a/internal/channel/group_dispatch.go
+++ b/internal/channel/group_dispatch.go
@@ -77,6 +77,23 @@ func (c *Coordinator) appendGroupMessage(ctx context.Context, msg pkgchannel.Inc
 		if err != nil {
 			return fmt.Errorf("list group members: %w", err)
 		}
+		// Auto-provision: for platform groups with no members, register the
+		// source channel's agent so the bot can respond.
+		if len(members) == 0 && channelID != "" && channelID != msg.Platform {
+			ch, chErr := q.GetChannel(ctx, channelID)
+			if chErr == nil && ch.AgentID.Valid && ch.AgentID.String != "" {
+				if _, addErr := q.AddGroupMember(ctx, sqlc.AddGroupMemberParams{
+					GroupID:        result.GroupID,
+					AgentID:        ch.AgentID.String,
+					ReplyChannelID: channelID,
+				}); addErr != nil {
+					slog.Warn("auto-provision group member failed", "group_id", result.GroupID, "agent_id", ch.AgentID.String, "error", addErr)
+				} else {
+					slog.Info("auto-provisioned group member", "group_id", result.GroupID, "agent_id", ch.AgentID.String, "channel_id", channelID)
+					members, _ = q.ListGroupMembers(ctx, result.GroupID)
+				}
+			}
+		}
 		groupMembers := make([]GroupMember, len(members))
 		for i, m := range members {
 			groupMembers[i] = GroupMember{AgentID: m.AgentID, ReplyChannelID: m.ReplyChannelID}

--- a/internal/channel/group_dispatch.go
+++ b/internal/channel/group_dispatch.go
@@ -77,23 +77,6 @@ func (c *Coordinator) appendGroupMessage(ctx context.Context, msg pkgchannel.Inc
 		if err != nil {
 			return fmt.Errorf("list group members: %w", err)
 		}
-		// Auto-provision: for platform groups with no members, register the
-		// source channel's agent so the bot can respond.
-		if len(members) == 0 && channelID != "" && channelID != msg.Platform {
-			ch, chErr := q.GetChannel(ctx, channelID)
-			if chErr == nil && ch.AgentID.Valid && ch.AgentID.String != "" {
-				if _, addErr := q.AddGroupMember(ctx, sqlc.AddGroupMemberParams{
-					GroupID:        result.GroupID,
-					AgentID:        ch.AgentID.String,
-					ReplyChannelID: channelID,
-				}); addErr != nil {
-					slog.Warn("auto-provision group member failed", "group_id", result.GroupID, "agent_id", ch.AgentID.String, "error", addErr)
-				} else {
-					slog.Info("auto-provisioned group member", "group_id", result.GroupID, "agent_id", ch.AgentID.String, "channel_id", channelID)
-					members, _ = q.ListGroupMembers(ctx, result.GroupID)
-				}
-			}
-		}
 		groupMembers := make([]GroupMember, len(members))
 		for i, m := range members {
 			groupMembers[i] = GroupMember{AgentID: m.AgentID, ReplyChannelID: m.ReplyChannelID}

--- a/plugins/channels/feishu/feishu.go
+++ b/plugins/channels/feishu/feishu.go
@@ -57,10 +57,13 @@ type Config struct {
 }
 
 // Bot wraps a Feishu bot with agent pool integration.
+type listChatsFunc func(context.Context, *larkim.ListChatReq) (*larkim.ListChatResp, error)
+
 type Bot struct {
-	client   *lark.Client
-	wsClient *larkws.Client
-	handler  channel.Handler
+	client    *lark.Client
+	wsClient  *larkws.Client
+	listChats listChatsFunc
+	handler   channel.Handler
 
 	botOpenID atomic.Value // bot's own open_id (string), fetched on startup
 
@@ -142,6 +145,11 @@ func (b *Bot) Start(ctx context.Context) error {
 		larkws.WithEventHandler(eventHandler),
 		larkws.WithLogLevel(larkcore.LogLevelInfo),
 	)
+	if b.listChats == nil {
+		b.listChats = func(ctx context.Context, req *larkim.ListChatReq) (*larkim.ListChatResp, error) {
+			return b.client.Im.Chat.List(ctx, req)
+		}
+	}
 
 	go b.syncGroups()
 

--- a/plugins/channels/feishu/feishu.go
+++ b/plugins/channels/feishu/feishu.go
@@ -132,7 +132,8 @@ func (b *Bot) Start(ctx context.Context) error {
 
 	eventHandler := dispatcher.NewEventDispatcher(b.cfg.VerificationToken, b.cfg.EncryptKey).
 		OnP2MessageReceiveV1(b.onMessage).
-		OnP2MessageReactionCreatedV1(b.onReaction)
+		OnP2MessageReactionCreatedV1(b.onReaction).
+		OnP2MessageReadV1(b.onMessageRead)
 
 	b.wsClient = larkws.NewClient(b.cfg.AppID, b.cfg.AppSecret,
 		larkws.WithEventHandler(eventHandler),

--- a/plugins/channels/feishu/feishu.go
+++ b/plugins/channels/feishu/feishu.go
@@ -133,6 +133,7 @@ func (b *Bot) Start(ctx context.Context) error {
 	eventHandler := dispatcher.NewEventDispatcher(b.cfg.VerificationToken, b.cfg.EncryptKey).
 		OnP2MessageReceiveV1(b.onMessage).
 		OnP2MessageReactionCreatedV1(b.onReaction).
+		OnP2MessageReactionDeletedV1(b.onReactionDeleted).
 		OnP2MessageReadV1(b.onMessageRead)
 
 	b.wsClient = larkws.NewClient(b.cfg.AppID, b.cfg.AppSecret,

--- a/plugins/channels/feishu/feishu.go
+++ b/plugins/channels/feishu/feishu.go
@@ -134,12 +134,16 @@ func (b *Bot) Start(ctx context.Context) error {
 		OnP2MessageReceiveV1(b.onMessage).
 		OnP2MessageReactionCreatedV1(b.onReaction).
 		OnP2MessageReactionDeletedV1(b.onReactionDeleted).
-		OnP2MessageReadV1(b.onMessageRead)
+		OnP2MessageReadV1(b.onMessageRead).
+		OnP2ChatMemberBotAddedV1(b.onBotAdded).
+		OnP2ChatMemberBotDeletedV1(b.onBotDeleted)
 
 	b.wsClient = larkws.NewClient(b.cfg.AppID, b.cfg.AppSecret,
 		larkws.WithEventHandler(eventHandler),
 		larkws.WithLogLevel(larkcore.LogLevelInfo),
 	)
+
+	go b.syncGroups()
 
 	logger().Info("feishu bot starting (WebSocket mode)")
 

--- a/plugins/channels/feishu/feishu_test.go
+++ b/plugins/channels/feishu/feishu_test.go
@@ -1156,6 +1156,48 @@ func TestGroupSystemPromptEmpty(t *testing.T) {
 	}
 }
 
+func TestSyncGroupsEnsuresMembersAcrossPages(t *testing.T) {
+	provisioner := &mockGroupProvisioner{}
+	calls := 0
+	bot := &Bot{
+		handler: provisioner,
+		cfg:     Config{InstanceID: "feishu-work"},
+		listChats: func(_ context.Context, _ *larkim.ListChatReq) (*larkim.ListChatResp, error) {
+			calls++
+			switch calls {
+			case 1:
+				return &larkim.ListChatResp{Data: &larkim.ListChatRespData{
+					Items: []*larkim.ListChat{
+						{ChatId: testStringPtr("oc_1")},
+						{},
+						{ChatId: testStringPtr("oc_2")},
+					},
+					HasMore:   testBoolPtr(true),
+					PageToken: testStringPtr("next"),
+				}}, nil
+			case 2:
+				return &larkim.ListChatResp{Data: &larkim.ListChatRespData{
+					Items:   []*larkim.ListChat{{ChatId: testStringPtr("oc_3")}},
+					HasMore: testBoolPtr(false),
+				}}, nil
+			default:
+				t.Fatalf("unexpected ListChat call %d", calls)
+				return nil, nil
+			}
+		},
+	}
+
+	bot.syncGroups()
+
+	if calls != 2 {
+		t.Fatalf("ListChat calls = %d, want 2", calls)
+	}
+	want := []string{"feishu:oc_1:feishu-work", "feishu:oc_2:feishu-work", "feishu:oc_3:feishu-work"}
+	if strings.Join(provisioner.ensured, ",") != strings.Join(want, ",") {
+		t.Fatalf("ensured = %v, want %v", provisioner.ensured, want)
+	}
+}
+
 func TestPrependSystemPromptText(t *testing.T) {
 	content := channel.TextContent("hello")
 	got := prependSystemPrompt(content, "Be concise.")
@@ -1263,6 +1305,26 @@ func TestHandleIncomingAbortDelegatesToCoordinator(t *testing.T) {
 }
 
 // --- mockHandler for tests ---
+
+type mockGroupProvisioner struct {
+	mockHandler
+	ensured []string
+	removed []string
+}
+
+func (m *mockGroupProvisioner) EnsurePlatformGroupMember(_ context.Context, platform, platformGroupID, channelID string) error {
+	m.ensured = append(m.ensured, strings.Join([]string{platform, platformGroupID, channelID}, ":"))
+	return nil
+}
+
+func (m *mockGroupProvisioner) RemovePlatformGroupMember(_ context.Context, platform, platformGroupID, channelID string) error {
+	m.removed = append(m.removed, strings.Join([]string{platform, platformGroupID, channelID}, ":"))
+	return nil
+}
+
+func testStringPtr(v string) *string { return &v }
+
+func testBoolPtr(v bool) *bool { return &v }
 
 type mockHandler struct {
 	handleIncomingFn func(context.Context, channel.IncomingMessage, string, string) (string, bool, *channel.ChatStream, error)

--- a/plugins/channels/feishu/group.go
+++ b/plugins/channels/feishu/group.go
@@ -1,7 +1,11 @@
 package feishu
 
 import (
+	"context"
+
 	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
+
+	"github.com/CherryHQ/stella/pkg/channel"
 )
 
 // groupMode returns the effective group mode for the given chat.
@@ -36,6 +40,100 @@ func (b *Bot) groupSystemPrompt(chatID string) string {
 		return gc.SystemPrompt
 	}
 	return ""
+}
+
+// groupMemberProvisioner is the subset of the coordinator needed for group
+// member management. Feishu type-asserts the handler for this.
+type groupMemberProvisioner interface {
+	EnsurePlatformGroupMember(ctx context.Context, platform, platformGroupID, channelID string) error
+	RemovePlatformGroupMember(ctx context.Context, platform, platformGroupID, channelID string) error
+}
+
+func (b *Bot) onBotAdded(_ context.Context, event *larkim.P2ChatMemberBotAddedV1) error {
+	if event == nil || event.Event == nil || event.Event.ChatId == nil {
+		return nil
+	}
+	chatID := *event.Event.ChatId
+	name := derefStr(event.Event.Name)
+	logger().Info("bot added to group", "chat_id", chatID, "group_name", name)
+
+	if provisioner, ok := b.handler.(groupMemberProvisioner); ok {
+		ctx, cancel := b.apiContext()
+		defer cancel()
+		if err := provisioner.EnsurePlatformGroupMember(ctx, channel.PlatformFeishu, chatID, b.Name()); err != nil {
+			logger().Error("ensure group member on bot_added failed", "chat_id", chatID, "error", err)
+		}
+	}
+	return nil
+}
+
+func (b *Bot) onBotDeleted(_ context.Context, event *larkim.P2ChatMemberBotDeletedV1) error {
+	if event == nil || event.Event == nil || event.Event.ChatId == nil {
+		return nil
+	}
+	chatID := *event.Event.ChatId
+	name := derefStr(event.Event.Name)
+	logger().Info("bot removed from group", "chat_id", chatID, "group_name", name)
+
+	if provisioner, ok := b.handler.(groupMemberProvisioner); ok {
+		ctx, cancel := b.apiContext()
+		defer cancel()
+		if err := provisioner.RemovePlatformGroupMember(ctx, channel.PlatformFeishu, chatID, b.Name()); err != nil {
+			logger().Error("remove group member on bot_deleted failed", "chat_id", chatID, "error", err)
+		}
+	}
+	return nil
+}
+
+// syncGroups lists all groups the bot is in via the Feishu API and ensures
+// group membership for each. Called once at startup.
+func (b *Bot) syncGroups() {
+	provisioner, ok := b.handler.(groupMemberProvisioner)
+	if !ok {
+		return
+	}
+
+	var pageToken string
+	var synced int
+	for {
+		reqBuilder := larkim.NewListChatReqBuilder()
+		if pageToken != "" {
+			reqBuilder.PageToken(pageToken)
+		}
+		ctx, cancel := b.apiContext()
+		resp, err := b.client.Im.Chat.List(ctx, reqBuilder.Build())
+		cancel()
+		if err != nil {
+			logger().Error("sync groups: list chats failed", "error", err)
+			return
+		}
+		if !resp.Success() {
+			logger().Error("sync groups: list chats api error", "code", resp.Code, "msg", resp.Msg)
+			return
+		}
+		for _, chat := range resp.Data.Items {
+			if chat.ChatId == nil {
+				continue
+			}
+			chatID := *chat.ChatId
+			ctx, cancel := b.apiContext()
+			if err := provisioner.EnsurePlatformGroupMember(ctx, channel.PlatformFeishu, chatID, b.Name()); err != nil {
+				logger().Warn("sync groups: ensure member failed", "chat_id", chatID, "error", err)
+			} else {
+				synced++
+			}
+			cancel()
+		}
+		if resp.Data.HasMore == nil || !*resp.Data.HasMore {
+			break
+		}
+		if resp.Data.PageToken != nil {
+			pageToken = *resp.Data.PageToken
+		} else {
+			break
+		}
+	}
+	logger().Info("sync groups completed", "synced", synced)
 }
 
 // isBotMentioned checks if the bot was @mentioned by comparing each mention's

--- a/plugins/channels/feishu/group.go
+++ b/plugins/channels/feishu/group.go
@@ -101,7 +101,7 @@ func (b *Bot) syncGroups() {
 			reqBuilder.PageToken(pageToken)
 		}
 		ctx, cancel := b.apiContext()
-		resp, err := b.client.Im.Chat.List(ctx, reqBuilder.Build())
+		resp, err := b.listChats(ctx, reqBuilder.Build())
 		cancel()
 		if err != nil {
 			logger().Error("sync groups: list chats failed", "error", err)

--- a/plugins/channels/feishu/handler.go
+++ b/plugins/channels/feishu/handler.go
@@ -216,6 +216,10 @@ func (b *Bot) onMessageRead(_ context.Context, _ *larkim.P2MessageReadV1) error 
 	return nil
 }
 
+func (b *Bot) onReactionDeleted(_ context.Context, _ *larkim.P2MessageReactionDeletedV1) error {
+	return nil
+}
+
 // prependSystemPrompt adds a system prompt prefix to message content.
 func prependSystemPrompt(content []ai.ContentBlock, prompt string) []ai.ContentBlock {
 	prefix := ai.TextContent{Text: fmt.Sprintf("[System: %s]", prompt)}

--- a/plugins/channels/feishu/handler.go
+++ b/plugins/channels/feishu/handler.go
@@ -212,6 +212,10 @@ func (b *Bot) onMessage(ctx context.Context, event *larkim.P2MessageReceiveV1) e
 	return nil
 }
 
+func (b *Bot) onMessageRead(_ context.Context, _ *larkim.P2MessageReadV1) error {
+	return nil
+}
+
 // prependSystemPrompt adds a system prompt prefix to message content.
 func prependSystemPrompt(content []ai.ContentBlock, prompt string) []ai.ContentBlock {
 	prefix := ai.TextContent{Text: fmt.Sprintf("[System: %s]", prompt)}


### PR DESCRIPTION
## What

Fix Feishu group chat not responding — even when the bot is @mentioned — by properly managing group membership lifecycle.

## Why

When a Feishu group first receives a message, `ctx_group_states` is auto-created but `channel_group_member` stays empty. The arbiter sees no members and no mentions, so it silently drops every message. This affects all platform groups (Feishu/TG/QQ) that don't go through the Web UI group creation flow.

## How

- **Startup sync**: `syncGroups()` calls Feishu `Chat.List` API to discover all groups the bot is in, registers the channel's agent as a member for each
- **Real-time events**: `onBotAdded` / `onBotDeleted` handlers for `im.chat.member.bot.added_v1` / `im.chat.member.bot.deleted_v1`
- **Coordinator API**: `EnsurePlatformGroupMember` / `RemovePlatformGroupMember` — resolves internal group ID via eventlog, upserts/removes `channel_group_member` row
- **Cleanup**: no-op handlers for `message_read_v1` and `reaction.deleted_v1` to suppress error log noise

## Refs

- Closes #332