### PR TITLE
🐛 fix(lcm): prevent compaction from splitting tool_call/tool_result pairs

### DIFF
--- a/internal/db/migrations/20260609105345_add_ctx_item_event_type.sql
+++ b/internal/db/migrations/20260609105345_add_ctx_item_event_type.sql
@@ -1,6 +1,7 @@
 -- Add column "event_type" to table: "ctx_item"
 ALTER TABLE `ctx_item` ADD COLUMN `event_type` text NOT NULL DEFAULT '';
 -- Backfill event_type from ctx_message for existing message items.
-UPDATE ctx_item SET event_type = (
-    SELECT m.event_type FROM ctx_message m WHERE m.id = ctx_item.message_id
+UPDATE ctx_item SET event_type = COALESCE(
+    (SELECT m.event_type FROM ctx_message m WHERE m.id = ctx_item.message_id),
+    ''
 ) WHERE item_type = 'message' AND message_id IS NOT NULL;

--- a/internal/db/migrations/20260609105345_add_ctx_item_event_type.sql
+++ b/internal/db/migrations/20260609105345_add_ctx_item_event_type.sql
@@ -1,0 +1,6 @@
+-- Add column "event_type" to table: "ctx_item"
+ALTER TABLE `ctx_item` ADD COLUMN `event_type` text NOT NULL DEFAULT '';
+-- Backfill event_type from ctx_message for existing message items.
+UPDATE ctx_item SET event_type = (
+    SELECT m.event_type FROM ctx_message m WHERE m.id = ctx_item.message_id
+) WHERE item_type = 'message' AND message_id IS NOT NULL;

--- a/internal/db/migrations/atlas.sum
+++ b/internal/db/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:brdgaO0d76dmsdmTKLjrCqhbgyp+oucok4Kq5w2DPJc=
+h1:chiCE/TIQQ8rrfQPjZwcIZcGyqSLSKFd+dsjXqCkQSM=
 20260531120105_initial.sql h1:yFv08NKwCabgVkvWoSNzba6WMXjbXrI9xHctaJBir/8=
 20260601060943_add_config_to_plugin_override.sql h1:q2MIJRzEYGDQyjnLeFUrQ0zbnvdgxBh/MRANwRmPFn4=
 20260602031701_add-channel-name.sql h1:1ZGYJvwMOOShxLGIN9SJihmcfQtFRpTPXHhOWDv29fc=
@@ -15,3 +15,4 @@ h1:brdgaO0d76dmsdmTKLjrCqhbgyp+oucok4Kq5w2DPJc=
 20260605174634_add_group_dispatch_tables.sql h1:Q2/OVyqgQR7O21FB0kHg/TO1AZVXmes5Hv06ns9rqDA=
 20260606092158_add_recally_feed_kind_metadata.sql h1:HBJAVIFYvAuVoCB7lrb7WGrvK7aS7TO8yOtpRCyxvzc=
 20260606104642_rename_recally_feed.sql h1:4fOp9kKwEa8qGluJlEAwIP/fdBwzOg0WhpLL+l3dnSA=
+20260609105345_add_ctx_item_event_type.sql h1:rmEX/gK/MPDOpRkAXUZ10n/+urqRfgN7a/XUWsN1byc=

--- a/internal/db/migrations/atlas.sum
+++ b/internal/db/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:chiCE/TIQQ8rrfQPjZwcIZcGyqSLSKFd+dsjXqCkQSM=
+h1:YETYxrfMKyW2m7fnCBolmMz4ECAKvUq79EbS+CN4T4U=
 20260531120105_initial.sql h1:yFv08NKwCabgVkvWoSNzba6WMXjbXrI9xHctaJBir/8=
 20260601060943_add_config_to_plugin_override.sql h1:q2MIJRzEYGDQyjnLeFUrQ0zbnvdgxBh/MRANwRmPFn4=
 20260602031701_add-channel-name.sql h1:1ZGYJvwMOOShxLGIN9SJihmcfQtFRpTPXHhOWDv29fc=
@@ -15,4 +15,4 @@ h1:chiCE/TIQQ8rrfQPjZwcIZcGyqSLSKFd+dsjXqCkQSM=
 20260605174634_add_group_dispatch_tables.sql h1:Q2/OVyqgQR7O21FB0kHg/TO1AZVXmes5Hv06ns9rqDA=
 20260606092158_add_recally_feed_kind_metadata.sql h1:HBJAVIFYvAuVoCB7lrb7WGrvK7aS7TO8yOtpRCyxvzc=
 20260606104642_rename_recally_feed.sql h1:4fOp9kKwEa8qGluJlEAwIP/fdBwzOg0WhpLL+l3dnSA=
-20260609105345_add_ctx_item_event_type.sql h1:rmEX/gK/MPDOpRkAXUZ10n/+urqRfgN7a/XUWsN1byc=
+20260609105345_add_ctx_item_event_type.sql h1:N+zrGeAGMj7atd5HO1fd0s+GTnKNAIxbjlkumhvoa60=

--- a/internal/db/queries/ctx_item.sql
+++ b/internal/db/queries/ctx_item.sql
@@ -1,6 +1,6 @@
 -- name: AppendContextItem :exec
-INSERT INTO ctx_item (conversation_id, ordinal, item_type, message_id, summary_id)
-VALUES (?, ?, ?, ?, ?);
+INSERT INTO ctx_item (conversation_id, ordinal, item_type, message_id, summary_id, event_type)
+VALUES (?, ?, ?, ?, ?, ?);
 
 -- name: GetContextItems :many
 SELECT * FROM ctx_item

--- a/internal/db/schemas/tables/ctx_item.sql
+++ b/internal/db/schemas/tables/ctx_item.sql
@@ -4,6 +4,7 @@ CREATE TABLE ctx_item (
     item_type TEXT NOT NULL,
     message_id TEXT REFERENCES ctx_message(id) ON DELETE RESTRICT,
     summary_id TEXT REFERENCES ctx_summary(id) ON DELETE RESTRICT,
+    event_type TEXT NOT NULL DEFAULT '',
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     PRIMARY KEY (conversation_id, ordinal),
     CHECK (

--- a/internal/memory/lcm/assembler.go
+++ b/internal/memory/lcm/assembler.go
@@ -101,6 +101,7 @@ func (a *assembler) assemble(ctx context.Context, convID string, budget int, fre
 	var result []ai.Message
 	result = append(result, olderMsgs...)
 	result = append(result, tailMsgs...)
+	result = sanitizeToolPairs(result)
 	return result, nil
 }
 
@@ -154,6 +155,7 @@ func compactOversizedTailResults(msgs []ai.Message) ([]ai.Message, int) {
 }
 
 // splitFreshTail separates the last freshTail message-type items from the rest.
+// The split point is adjusted so it never lands inside a tool_call/tool_result pair.
 func splitFreshTail(items []sqlc.CtxItem, freshTail int) (tail []sqlc.CtxItem, older []sqlc.CtxItem) {
 	// Count message items from the end.
 	msgCount := 0
@@ -166,6 +168,19 @@ func splitFreshTail(items []sqlc.CtxItem, freshTail int) (tail []sqlc.CtxItem, o
 				break
 			}
 		}
+	}
+	// Pull tool_results at the split boundary into the tail so they stay
+	// with their tool_calls (which are at lower ordinals, already in tail).
+	// Conversely, if the last item in "older" is a tool_call whose result
+	// is in the tail, pull it into the tail too.
+	for splitIdx > 0 && splitIdx < len(items) &&
+		items[splitIdx].ItemType == itemTypeMessage &&
+		items[splitIdx].EventType == eventTypeToolResult {
+		splitIdx--
+	}
+	for splitIdx > 0 && items[splitIdx-1].ItemType == itemTypeMessage &&
+		items[splitIdx-1].EventType == eventTypeToolCall {
+		splitIdx--
 	}
 	return items[splitIdx:], items[:splitIdx]
 }
@@ -194,6 +209,7 @@ func (a *assembler) resolveOlderWithinBudget(ctx context.Context, older []sqlc.C
 				tokens += estimateMessageTokens(m)
 			}
 			if tokens > remaining {
+				olderMsgs = stripTrailingOrphanResults(olderMsgs)
 				return olderMsgs, nil
 			}
 			remaining -= tokens
@@ -202,6 +218,34 @@ func (a *assembler) resolveOlderWithinBudget(ctx context.Context, older []sqlc.C
 		end = start
 	}
 	return olderMsgs, nil
+}
+
+// stripTrailingOrphanResults removes ToolResultMessages from the end of msgs
+// that have no matching ToolCall earlier in the slice. Since olderMsgs is built
+// newest-first (later reversed), trailing items are the most recent — which are
+// tool_results whose tool_calls we failed to include due to budget exhaustion.
+func stripTrailingOrphanResults(msgs []ai.Message) []ai.Message {
+	callIDs := make(map[string]struct{})
+	for _, m := range msgs {
+		if am, ok := m.(ai.AssistantMessage); ok {
+			for _, b := range am.Content {
+				if tc, ok := b.(ai.ToolCall); ok {
+					callIDs[tc.ID] = struct{}{}
+				}
+			}
+		}
+	}
+	for len(msgs) > 0 {
+		tr, ok := msgs[len(msgs)-1].(ai.ToolResultMessage)
+		if !ok {
+			break
+		}
+		if _, found := callIDs[tr.ToolCallID]; found {
+			break
+		}
+		msgs = msgs[:len(msgs)-1]
+	}
+	return msgs
 }
 
 // resolveItemsFromCaches resolves a slice of context items to ai.Messages.
@@ -289,6 +333,81 @@ func (a *assembler) loadSummariesByItem(ctx context.Context, items []sqlc.CtxIte
 		}
 	}
 	return out, nil
+}
+
+// sanitizeToolPairs is a defense-in-depth pass that ensures every ToolResultMessage
+// has a preceding ToolCall with a matching ID. Orphan tool_results are converted to
+// UserMessages to preserve context. Orphan tool_calls on non-final assistant messages
+// are stripped.
+func sanitizeToolPairs(msgs []ai.Message) []ai.Message {
+	callIDs := make(map[string]struct{})
+	for _, m := range msgs {
+		am, ok := m.(ai.AssistantMessage)
+		if !ok {
+			continue
+		}
+		for _, b := range am.Content {
+			if tc, ok := b.(ai.ToolCall); ok {
+				callIDs[tc.ID] = struct{}{}
+			}
+		}
+	}
+
+	result := make([]ai.Message, 0, len(msgs))
+	for _, m := range msgs {
+		tr, ok := m.(ai.ToolResultMessage)
+		if !ok {
+			result = append(result, m)
+			continue
+		}
+		if _, found := callIDs[tr.ToolCallID]; found {
+			result = append(result, m)
+			continue
+		}
+		text := ai.FlattenText(tr.Content)
+		if text == "" {
+			continue
+		}
+		result = append(result, ai.UserMessage{
+			Content:   fmt.Sprintf("[Previous tool result from %s]: %s", tr.ToolName, truncateUTF8(text, 500)),
+			Timestamp: tr.Timestamp,
+		})
+	}
+
+	resultIDs := make(map[string]struct{})
+	for _, m := range result {
+		if tr, ok := m.(ai.ToolResultMessage); ok {
+			resultIDs[tr.ToolCallID] = struct{}{}
+		}
+	}
+	lastAssistantIdx := -1
+	for i := len(result) - 1; i >= 0; i-- {
+		if _, ok := result[i].(ai.AssistantMessage); ok {
+			lastAssistantIdx = i
+			break
+		}
+	}
+	for i, m := range result {
+		am, ok := m.(ai.AssistantMessage)
+		if !ok || i == lastAssistantIdx {
+			continue
+		}
+		var filtered []ai.ContentBlock
+		for _, b := range am.Content {
+			if tc, isTC := b.(ai.ToolCall); isTC {
+				if _, found := resultIDs[tc.ID]; !found {
+					continue
+				}
+			}
+			filtered = append(filtered, b)
+		}
+		if len(filtered) == 0 {
+			filtered = []ai.ContentBlock{ai.TextContent{Text: "[tool calls compacted]"}}
+		}
+		result[i] = ai.AssistantMessage{Content: filtered}
+	}
+
+	return result
 }
 
 // FormatSummaryXML formats a summary as XML for model consumption.

--- a/internal/memory/lcm/assembler.go
+++ b/internal/memory/lcm/assembler.go
@@ -339,8 +339,8 @@ func (a *assembler) loadSummariesByItem(ctx context.Context, items []sqlc.CtxIte
 // contract: every ToolResultMessage must have a *preceding* AssistantMessage
 // containing a ToolCall with the same ID. Orphan tool_results are dropped
 // (not promoted to UserMessage — tool output is untrusted and must not gain
-// user-role privilege). Orphan tool_calls are stripped from non-final assistant
-// messages; in-progress calls are only preserved on the actual last message.
+// user-role privilege). Orphan tool_calls are stripped from assembled history;
+// memory assembly always runs before the next live user message is appended.
 func sanitizeToolPairs(msgs []ai.Message) []ai.Message {
 	// Forward scan: track call IDs as they appear, validate results against
 	// only previously-seen calls.
@@ -365,22 +365,18 @@ func sanitizeToolPairs(msgs []ai.Message) []ai.Message {
 		}
 	}
 
-	// Strip orphan tool_calls from non-final assistant messages. The final
-	// message is only exempt if nothing follows it (truly in-progress).
+	// Strip orphan tool_calls from assistant messages. Although a final assistant
+	// tool_call can be valid while a model turn is in progress, assembled memory
+	// history is always followed by the next live user message before provider IO.
 	resultIDs := make(map[string]struct{})
 	for _, m := range result {
 		if tr, ok := m.(ai.ToolResultMessage); ok {
 			resultIDs[tr.ToolCallID] = struct{}{}
 		}
 	}
-	lastIdx := len(result) - 1
 	for i, m := range result {
 		am, ok := m.(ai.AssistantMessage)
 		if !ok {
-			continue
-		}
-		// Only the very last message in the slice may keep in-progress calls.
-		if i == lastIdx {
 			continue
 		}
 		var filtered []ai.ContentBlock
@@ -395,7 +391,8 @@ func sanitizeToolPairs(msgs []ai.Message) []ai.Message {
 		if len(filtered) == 0 {
 			filtered = []ai.ContentBlock{ai.TextContent{Text: "[tool calls compacted]"}}
 		}
-		result[i] = ai.AssistantMessage{Content: filtered}
+		am.Content = filtered
+		result[i] = am
 	}
 
 	return result

--- a/internal/memory/lcm/assembler.go
+++ b/internal/memory/lcm/assembler.go
@@ -335,61 +335,52 @@ func (a *assembler) loadSummariesByItem(ctx context.Context, items []sqlc.CtxIte
 	return out, nil
 }
 
-// sanitizeToolPairs is a defense-in-depth pass that ensures every ToolResultMessage
-// has a preceding ToolCall with a matching ID. Orphan tool_results are converted to
-// UserMessages to preserve context. Orphan tool_calls on non-final assistant messages
-// are stripped.
+// sanitizeToolPairs is a defense-in-depth pass that enforces the tool pairing
+// contract: every ToolResultMessage must have a *preceding* AssistantMessage
+// containing a ToolCall with the same ID. Orphan tool_results are dropped
+// (not promoted to UserMessage — tool output is untrusted and must not gain
+// user-role privilege). Orphan tool_calls are stripped from non-final assistant
+// messages; in-progress calls are only preserved on the actual last message.
 func sanitizeToolPairs(msgs []ai.Message) []ai.Message {
-	callIDs := make(map[string]struct{})
-	for _, m := range msgs {
-		am, ok := m.(ai.AssistantMessage)
-		if !ok {
-			continue
-		}
-		for _, b := range am.Content {
-			if tc, ok := b.(ai.ToolCall); ok {
-				callIDs[tc.ID] = struct{}{}
-			}
-		}
-	}
-
+	// Forward scan: track call IDs as they appear, validate results against
+	// only previously-seen calls.
+	seenCalls := make(map[string]struct{})
 	result := make([]ai.Message, 0, len(msgs))
 	for _, m := range msgs {
-		tr, ok := m.(ai.ToolResultMessage)
-		if !ok {
+		switch msg := m.(type) {
+		case ai.AssistantMessage:
+			for _, b := range msg.Content {
+				if tc, ok := b.(ai.ToolCall); ok {
+					seenCalls[tc.ID] = struct{}{}
+				}
+			}
 			result = append(result, m)
-			continue
-		}
-		if _, found := callIDs[tr.ToolCallID]; found {
+		case ai.ToolResultMessage:
+			if _, found := seenCalls[msg.ToolCallID]; found {
+				result = append(result, m)
+			}
+			// Orphan tool_result: drop silently.
+		default:
 			result = append(result, m)
-			continue
 		}
-		text := ai.FlattenText(tr.Content)
-		if text == "" {
-			continue
-		}
-		result = append(result, ai.UserMessage{
-			Content:   fmt.Sprintf("[Previous tool result from %s]: %s", tr.ToolName, truncateUTF8(text, 500)),
-			Timestamp: tr.Timestamp,
-		})
 	}
 
+	// Strip orphan tool_calls from non-final assistant messages. The final
+	// message is only exempt if nothing follows it (truly in-progress).
 	resultIDs := make(map[string]struct{})
 	for _, m := range result {
 		if tr, ok := m.(ai.ToolResultMessage); ok {
 			resultIDs[tr.ToolCallID] = struct{}{}
 		}
 	}
-	lastAssistantIdx := -1
-	for i := len(result) - 1; i >= 0; i-- {
-		if _, ok := result[i].(ai.AssistantMessage); ok {
-			lastAssistantIdx = i
-			break
-		}
-	}
+	lastIdx := len(result) - 1
 	for i, m := range result {
 		am, ok := m.(ai.AssistantMessage)
-		if !ok || i == lastAssistantIdx {
+		if !ok {
+			continue
+		}
+		// Only the very last message in the slice may keep in-progress calls.
+		if i == lastIdx {
 			continue
 		}
 		var filtered []ai.ContentBlock

--- a/internal/memory/lcm/compaction.go
+++ b/internal/memory/lcm/compaction.go
@@ -121,34 +121,53 @@ type messageRun struct {
 }
 
 // findMessageRuns finds contiguous sequences of message items with at least minSize messages.
+// Runs are trimmed so they never start with an orphan tool_result or end with an orphan
+// tool_call — this prevents compaction from splitting tool_call/tool_result pairs.
 func findMessageRuns(items []sqlc.CtxItem, minSize int) []messageRun {
 	var runs []messageRun
 	var current []sqlc.CtxItem
+
+	flush := func() {
+		current = trimOrphanedToolPairs(current)
+		if len(current) >= minSize {
+			runs = append(runs, messageRun{
+				items:    current,
+				startOrd: current[0].Ordinal,
+				endOrd:   current[len(current)-1].Ordinal,
+			})
+		}
+		current = nil
+	}
 
 	for _, item := range items {
 		if item.ItemType == itemTypeMessage {
 			current = append(current, item)
 		} else {
-			if len(current) >= minSize {
-				runs = append(runs, messageRun{
-					items:    current,
-					startOrd: current[0].Ordinal,
-					endOrd:   current[len(current)-1].Ordinal,
-				})
-			}
-			current = nil
+			flush()
 		}
 	}
-	// Don't forget the last run.
-	if len(current) >= minSize {
-		runs = append(runs, messageRun{
-			items:    current,
-			startOrd: current[0].Ordinal,
-			endOrd:   current[len(current)-1].Ordinal,
-		})
-	}
+	flush()
 
 	return runs
+}
+
+// trimOrphanedToolPairs removes leading tool_results (whose tool_call is outside
+// this run) and trailing tool_calls (whose tool_result is outside this run).
+// The trimmed items stay as raw context items and will be handled in a future
+// compaction pass when they naturally pair with their counterparts.
+func trimOrphanedToolPairs(items []sqlc.CtxItem) []sqlc.CtxItem {
+	if len(items) == 0 {
+		return items
+	}
+	start := 0
+	for start < len(items) && items[start].EventType == eventTypeToolResult {
+		start++
+	}
+	end := len(items)
+	for end > start && items[end-1].EventType == eventTypeToolCall {
+		end--
+	}
+	return items[start:end]
 }
 
 // formatMessageForSummarizer formats a CtxMessage for compaction summarization.

--- a/internal/memory/lcm/group_assembler.go
+++ b/internal/memory/lcm/group_assembler.go
@@ -89,7 +89,7 @@ func (p *Provider) assembleGroup(ctx context.Context, session memory.Session, bu
 		cutIdx++
 	}
 
-	return merged[cutIdx:], nil
+	return sanitizeToolPairs(merged[cutIdx:]), nil
 }
 
 func (p *Provider) CommitGroupCursor(ctx context.Context, session memory.Session, triggerSeq int64) error {

--- a/internal/memory/lcm/lcm_helpers_test.go
+++ b/internal/memory/lcm/lcm_helpers_test.go
@@ -626,7 +626,7 @@ func TestStripTrailingOrphanResults(t *testing.T) {
 }
 
 func TestSanitizeToolPairs_OrphanResult(t *testing.T) {
-	// A tool_result with no matching tool_call should become a UserMessage.
+	// A tool_result with no matching tool_call should be dropped.
 	msgs := []ai.Message{
 		ai.UserMessage{Content: "hello"},
 		ai.ToolResultMessage{
@@ -636,16 +636,11 @@ func TestSanitizeToolPairs_OrphanResult(t *testing.T) {
 		},
 	}
 	got := sanitizeToolPairs(msgs)
-	if len(got) != 2 {
-		t.Fatalf("expected 2 messages, got %d", len(got))
+	if len(got) != 1 {
+		t.Fatalf("expected 1 message (orphan dropped), got %d", len(got))
 	}
-	um, ok := got[1].(ai.UserMessage)
-	if !ok {
-		t.Fatalf("expected UserMessage, got %T", got[1])
-	}
-	content, _ := um.Content.(string)
-	if !strings.Contains(content, "bash") || !strings.Contains(content, "some output") {
-		t.Errorf("converted UserMessage should mention tool name and content, got %q", content)
+	if _, ok := got[0].(ai.UserMessage); !ok {
+		t.Fatalf("expected UserMessage, got %T", got[0])
 	}
 }
 
@@ -654,7 +649,7 @@ func TestSanitizeToolPairs_OrphanCallInNonFinal(t *testing.T) {
 	asst1 := ai.AssistantMessage{Content: []ai.ContentBlock{tc}}
 	asst2 := ai.AssistantMessage{Content: []ai.ContentBlock{ai.TextContent{Text: "final"}}}
 
-	// asst1 has a tool_call with no result, and it's not the final assistant message.
+	// asst1 has a tool_call with no result, and it's not the last message.
 	msgs := []ai.Message{asst1, ai.UserMessage{Content: "next"}, asst2}
 	got := sanitizeToolPairs(msgs)
 	if len(got) != 3 {
@@ -726,5 +721,47 @@ func TestSanitizeToolPairs_EmptyOrphanResultDropped(t *testing.T) {
 	got := sanitizeToolPairs(msgs)
 	if len(got) != 0 {
 		t.Fatalf("expected empty orphan result to be dropped, got %d messages", len(got))
+	}
+}
+
+func TestSanitizeToolPairs_ResultBeforeCallIsOrphan(t *testing.T) {
+	// Forward scan: tool_result appearing before its tool_call is an orphan.
+	tc := ai.ToolCall{ID: "call1", Name: "bash"}
+	tr := ai.ToolResultMessage{ToolCallID: "call1", ToolName: "bash", Content: []ai.ContentBlock{ai.TextContent{Text: "ok"}}}
+	asst := ai.AssistantMessage{Content: []ai.ContentBlock{tc}}
+
+	msgs := []ai.Message{tr, asst} // result before call
+	got := sanitizeToolPairs(msgs)
+	// tool_result should be dropped (call not yet seen at that point).
+	if len(got) != 1 {
+		t.Fatalf("expected 1 message (result dropped), got %d", len(got))
+	}
+	if _, ok := got[0].(ai.AssistantMessage); !ok {
+		t.Fatalf("expected AssistantMessage, got %T", got[0])
+	}
+}
+
+func TestSanitizeToolPairs_InProgressCallNotFinal(t *testing.T) {
+	// In-progress tool_call on a non-final assistant message (followed by user)
+	// should be stripped — it's not truly in-progress.
+	tc := ai.ToolCall{ID: "call1", Name: "bash"}
+	asst := ai.AssistantMessage{Content: []ai.ContentBlock{tc}}
+	user := ai.UserMessage{Content: "next question"}
+
+	msgs := []ai.Message{asst, user}
+	got := sanitizeToolPairs(msgs)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(got))
+	}
+	cleaned, ok := got[0].(ai.AssistantMessage)
+	if !ok {
+		t.Fatalf("expected AssistantMessage at 0, got %T", got[0])
+	}
+	if len(cleaned.Content) != 1 {
+		t.Fatalf("expected 1 block (placeholder), got %d", len(cleaned.Content))
+	}
+	text, ok := cleaned.Content[0].(ai.TextContent)
+	if !ok || !strings.Contains(text.Text, "compacted") {
+		t.Errorf("expected placeholder, got %v", cleaned.Content[0])
 	}
 }

--- a/internal/memory/lcm/lcm_helpers_test.go
+++ b/internal/memory/lcm/lcm_helpers_test.go
@@ -669,8 +669,9 @@ func TestSanitizeToolPairs_OrphanCallInNonFinal(t *testing.T) {
 	}
 }
 
-func TestSanitizeToolPairs_InProgressCall(t *testing.T) {
-	// The final assistant message may have an in-progress tool_call — preserve it.
+func TestSanitizeToolPairs_FinalOrphanCallStripped(t *testing.T) {
+	// Assembled memory history is followed by the next live user message, so even
+	// the final assistant message must not keep a stale tool_call without a result.
 	tc := ai.ToolCall{ID: "call1", Name: "bash"}
 	asst := ai.AssistantMessage{Content: []ai.ContentBlock{tc}}
 	msgs := []ai.Message{ai.UserMessage{Content: "do something"}, asst}
@@ -683,10 +684,11 @@ func TestSanitizeToolPairs_InProgressCall(t *testing.T) {
 		t.Fatalf("expected AssistantMessage at 1, got %T", got[1])
 	}
 	if len(finalAsst.Content) != 1 {
-		t.Fatalf("expected 1 block preserved, got %d", len(finalAsst.Content))
+		t.Fatalf("expected 1 block (placeholder), got %d", len(finalAsst.Content))
 	}
-	if _, ok := finalAsst.Content[0].(ai.ToolCall); !ok {
-		t.Error("in-progress tool_call on final assistant message should be preserved")
+	text, ok := finalAsst.Content[0].(ai.TextContent)
+	if !ok || !strings.Contains(text.Text, "compacted") {
+		t.Errorf("expected placeholder, got %v", finalAsst.Content[0])
 	}
 }
 

--- a/internal/memory/lcm/lcm_helpers_test.go
+++ b/internal/memory/lcm/lcm_helpers_test.go
@@ -3,6 +3,7 @@ package lcm
 import (
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -406,4 +407,324 @@ func TestCompactOversizedTailResults(t *testing.T) {
 		t.Errorf("expected 0 compacted when user is first element, got %d", n)
 	}
 	_ = got
+}
+
+// --- Tool pair integrity tests ---
+
+func makeCtxItem(ord int64, itemType, eventType string) sqlc.CtxItem {
+	return sqlc.CtxItem{
+		ConversationID: "conv1",
+		Ordinal:        ord,
+		ItemType:       itemType,
+		EventType:      eventType,
+		MessageID:      sql.NullString{String: "msg" + fmt.Sprintf("%d", ord), Valid: itemType == itemTypeMessage},
+	}
+}
+
+func TestSplitFreshTail_ToolPairIntegrity(t *testing.T) {
+	// Items: user(1), asst-text(2), asst-tool_call(3), tool_result(4), user(5), asst-text(6)
+	// With freshTail=2, naive split would put items 5,6 in tail, leaving
+	// tool_call(3) in older and tool_result(4) in tail — broken pair.
+	items := []sqlc.CtxItem{
+		makeCtxItem(1, itemTypeMessage, eventTypeText),
+		makeCtxItem(2, itemTypeMessage, eventTypeText),
+		makeCtxItem(3, itemTypeMessage, eventTypeToolCall),
+		makeCtxItem(4, itemTypeMessage, eventTypeToolResult),
+		makeCtxItem(5, itemTypeMessage, eventTypeText),
+		makeCtxItem(6, itemTypeMessage, eventTypeText),
+	}
+	tail, older := splitFreshTail(items, 2)
+
+	// tool_call(3) and tool_result(4) must be in the same partition.
+	tailOrdinals := make(map[int64]bool)
+	for _, item := range tail {
+		tailOrdinals[item.Ordinal] = true
+	}
+	olderOrdinals := make(map[int64]bool)
+	for _, item := range older {
+		olderOrdinals[item.Ordinal] = true
+	}
+	// Both 3 and 4 should be in tail (pulled in to preserve the pair).
+	if olderOrdinals[3] && tailOrdinals[4] {
+		t.Error("splitFreshTail split tool_call(3) into older and tool_result(4) into tail")
+	}
+	if olderOrdinals[4] && tailOrdinals[3] {
+		t.Error("splitFreshTail split tool_result(4) into older and tool_call(3) into tail")
+	}
+	// Verify they ended up together.
+	if tailOrdinals[3] != tailOrdinals[4] {
+		t.Errorf("tool_call and tool_result not in same partition: tail has 3=%v 4=%v", tailOrdinals[3], tailOrdinals[4])
+	}
+}
+
+func TestSplitFreshTail_MultipleToolCalls(t *testing.T) {
+	// Items: user(1), asst-tc1(2), asst-tc2(3), result1(4), result2(5), user(6)
+	// freshTail=2 would naively land on item 5, splitting the tool pairs.
+	items := []sqlc.CtxItem{
+		makeCtxItem(1, itemTypeMessage, eventTypeText),
+		makeCtxItem(2, itemTypeMessage, eventTypeToolCall),
+		makeCtxItem(3, itemTypeMessage, eventTypeToolCall),
+		makeCtxItem(4, itemTypeMessage, eventTypeToolResult),
+		makeCtxItem(5, itemTypeMessage, eventTypeToolResult),
+		makeCtxItem(6, itemTypeMessage, eventTypeText),
+	}
+	tail, older := splitFreshTail(items, 2)
+
+	tailOrdinals := make(map[int64]bool)
+	for _, item := range tail {
+		tailOrdinals[item.Ordinal] = true
+	}
+	// All tool calls and results should be in the same partition.
+	for _, ord := range []int64{2, 3, 4, 5} {
+		if !tailOrdinals[ord] {
+			t.Errorf("expected ordinal %d in tail, but it's in older", ord)
+		}
+	}
+	_ = older
+}
+
+func TestTrimOrphanedToolPairs(t *testing.T) {
+	tests := []struct {
+		name     string
+		items    []sqlc.CtxItem
+		wantLen  int
+		wantOrds []int64
+	}{
+		{
+			name:     "empty",
+			items:    nil,
+			wantLen:  0,
+			wantOrds: nil,
+		},
+		{
+			name: "no orphans",
+			items: []sqlc.CtxItem{
+				makeCtxItem(1, itemTypeMessage, eventTypeText),
+				makeCtxItem(2, itemTypeMessage, eventTypeToolCall),
+				makeCtxItem(3, itemTypeMessage, eventTypeToolResult),
+			},
+			wantLen:  3,
+			wantOrds: []int64{1, 2, 3},
+		},
+		{
+			name: "leading orphan tool_result",
+			items: []sqlc.CtxItem{
+				makeCtxItem(1, itemTypeMessage, eventTypeToolResult),
+				makeCtxItem(2, itemTypeMessage, eventTypeText),
+				makeCtxItem(3, itemTypeMessage, eventTypeToolCall),
+				makeCtxItem(4, itemTypeMessage, eventTypeToolResult),
+			},
+			wantLen:  3,
+			wantOrds: []int64{2, 3, 4},
+		},
+		{
+			name: "trailing orphan tool_call",
+			items: []sqlc.CtxItem{
+				makeCtxItem(1, itemTypeMessage, eventTypeText),
+				makeCtxItem(2, itemTypeMessage, eventTypeToolCall),
+				makeCtxItem(3, itemTypeMessage, eventTypeToolResult),
+				makeCtxItem(4, itemTypeMessage, eventTypeToolCall),
+			},
+			wantLen:  3,
+			wantOrds: []int64{1, 2, 3},
+		},
+		{
+			name: "both ends orphaned",
+			items: []sqlc.CtxItem{
+				makeCtxItem(1, itemTypeMessage, eventTypeToolResult),
+				makeCtxItem(2, itemTypeMessage, eventTypeToolResult),
+				makeCtxItem(3, itemTypeMessage, eventTypeText),
+				makeCtxItem(4, itemTypeMessage, eventTypeToolCall),
+				makeCtxItem(5, itemTypeMessage, eventTypeToolCall),
+			},
+			wantLen:  1,
+			wantOrds: []int64{3},
+		},
+		{
+			name: "all orphans",
+			items: []sqlc.CtxItem{
+				makeCtxItem(1, itemTypeMessage, eventTypeToolResult),
+				makeCtxItem(2, itemTypeMessage, eventTypeToolCall),
+			},
+			wantLen:  0,
+			wantOrds: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := trimOrphanedToolPairs(tc.items)
+			if len(got) != tc.wantLen {
+				t.Fatalf("len = %d, want %d", len(got), tc.wantLen)
+			}
+			for i, want := range tc.wantOrds {
+				if got[i].Ordinal != want {
+					t.Errorf("got[%d].Ordinal = %d, want %d", i, got[i].Ordinal, want)
+				}
+			}
+		})
+	}
+}
+
+func TestFindMessageRuns_ToolPairBoundary(t *testing.T) {
+	// Items: [msg, msg, ..., tool_call, summary, tool_result, msg, msg, ...]
+	// The summary breaks the run. The first run should not end with orphan tool_call,
+	// and the second run should not start with orphan tool_result.
+	var items []sqlc.CtxItem
+	for i := int64(1); i <= 10; i++ {
+		items = append(items, makeCtxItem(i, itemTypeMessage, eventTypeText))
+	}
+	items[8].EventType = eventTypeToolCall // item at ordinal 9
+	// Insert a summary between ordinals 9 and 10.
+	items = append(items[:9], append([]sqlc.CtxItem{
+		{ConversationID: "conv1", Ordinal: 10, ItemType: itemTypeSummary, SummaryID: sql.NullString{String: "sum1", Valid: true}},
+	}, sqlc.CtxItem{ConversationID: "conv1", Ordinal: 11, ItemType: itemTypeMessage, EventType: eventTypeToolResult, MessageID: sql.NullString{String: "msg11", Valid: true}})...)
+	for i := int64(12); i <= 20; i++ {
+		items = append(items, makeCtxItem(i, itemTypeMessage, eventTypeText))
+	}
+
+	runs := findMessageRuns(items, 3)
+	for _, run := range runs {
+		first := run.items[0]
+		last := run.items[len(run.items)-1]
+		if first.EventType == eventTypeToolResult {
+			t.Errorf("run starting at ordinal %d begins with orphan tool_result", run.startOrd)
+		}
+		if last.EventType == eventTypeToolCall {
+			t.Errorf("run ending at ordinal %d ends with orphan tool_call", run.endOrd)
+		}
+	}
+}
+
+func TestStripTrailingOrphanResults(t *testing.T) {
+	tc1 := ai.ToolCall{ID: "call1", Name: "bash", Arguments: nil}
+	tc2 := ai.ToolCall{ID: "call2", Name: "read", Arguments: nil}
+	asst := ai.AssistantMessage{Content: []ai.ContentBlock{ai.TextContent{Text: "thinking"}, tc1}}
+	tr1 := ai.ToolResultMessage{ToolCallID: "call1", ToolName: "bash", Content: []ai.ContentBlock{ai.TextContent{Text: "ok"}}}
+	tr2 := ai.ToolResultMessage{ToolCallID: "call2", ToolName: "read", Content: []ai.ContentBlock{ai.TextContent{Text: "data"}}}
+
+	// tr2 is orphan (call2 not in any assistant message).
+	msgs := []ai.Message{asst, tr1, tr2}
+	got := stripTrailingOrphanResults(msgs)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 messages after strip, got %d", len(got))
+	}
+
+	// Both have matching calls — nothing stripped.
+	asst2 := ai.AssistantMessage{Content: []ai.ContentBlock{tc1, tc2}}
+	msgs = []ai.Message{asst2, tr1, tr2}
+	got = stripTrailingOrphanResults(msgs)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 messages (no orphans), got %d", len(got))
+	}
+
+	// Empty input.
+	got = stripTrailingOrphanResults(nil)
+	if len(got) != 0 {
+		t.Fatalf("expected 0 for nil input, got %d", len(got))
+	}
+}
+
+func TestSanitizeToolPairs_OrphanResult(t *testing.T) {
+	// A tool_result with no matching tool_call should become a UserMessage.
+	msgs := []ai.Message{
+		ai.UserMessage{Content: "hello"},
+		ai.ToolResultMessage{
+			ToolCallID: "orphan_call",
+			ToolName:   "bash",
+			Content:    []ai.ContentBlock{ai.TextContent{Text: "some output"}},
+		},
+	}
+	got := sanitizeToolPairs(msgs)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(got))
+	}
+	um, ok := got[1].(ai.UserMessage)
+	if !ok {
+		t.Fatalf("expected UserMessage, got %T", got[1])
+	}
+	content, _ := um.Content.(string)
+	if !strings.Contains(content, "bash") || !strings.Contains(content, "some output") {
+		t.Errorf("converted UserMessage should mention tool name and content, got %q", content)
+	}
+}
+
+func TestSanitizeToolPairs_OrphanCallInNonFinal(t *testing.T) {
+	tc := ai.ToolCall{ID: "call1", Name: "bash"}
+	asst1 := ai.AssistantMessage{Content: []ai.ContentBlock{tc}}
+	asst2 := ai.AssistantMessage{Content: []ai.ContentBlock{ai.TextContent{Text: "final"}}}
+
+	// asst1 has a tool_call with no result, and it's not the final assistant message.
+	msgs := []ai.Message{asst1, ai.UserMessage{Content: "next"}, asst2}
+	got := sanitizeToolPairs(msgs)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(got))
+	}
+	// The orphan call in asst1 should be stripped, replaced with placeholder.
+	cleaned, ok := got[0].(ai.AssistantMessage)
+	if !ok {
+		t.Fatalf("expected AssistantMessage at 0, got %T", got[0])
+	}
+	if len(cleaned.Content) != 1 {
+		t.Fatalf("expected 1 block (placeholder), got %d", len(cleaned.Content))
+	}
+	text, ok := cleaned.Content[0].(ai.TextContent)
+	if !ok || !strings.Contains(text.Text, "compacted") {
+		t.Errorf("expected placeholder text, got %v", cleaned.Content[0])
+	}
+}
+
+func TestSanitizeToolPairs_InProgressCall(t *testing.T) {
+	// The final assistant message may have an in-progress tool_call — preserve it.
+	tc := ai.ToolCall{ID: "call1", Name: "bash"}
+	asst := ai.AssistantMessage{Content: []ai.ContentBlock{tc}}
+	msgs := []ai.Message{ai.UserMessage{Content: "do something"}, asst}
+	got := sanitizeToolPairs(msgs)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(got))
+	}
+	finalAsst, ok := got[1].(ai.AssistantMessage)
+	if !ok {
+		t.Fatalf("expected AssistantMessage at 1, got %T", got[1])
+	}
+	if len(finalAsst.Content) != 1 {
+		t.Fatalf("expected 1 block preserved, got %d", len(finalAsst.Content))
+	}
+	if _, ok := finalAsst.Content[0].(ai.ToolCall); !ok {
+		t.Error("in-progress tool_call on final assistant message should be preserved")
+	}
+}
+
+func TestSanitizeToolPairs_NoOrphans(t *testing.T) {
+	tc := ai.ToolCall{ID: "call1", Name: "bash"}
+	asst := ai.AssistantMessage{Content: []ai.ContentBlock{ai.TextContent{Text: "let me check"}, tc}}
+	tr := ai.ToolResultMessage{ToolCallID: "call1", ToolName: "bash", Content: []ai.ContentBlock{ai.TextContent{Text: "ok"}}}
+	asst2 := ai.AssistantMessage{Content: []ai.ContentBlock{ai.TextContent{Text: "done"}}}
+
+	msgs := []ai.Message{ai.UserMessage{Content: "hi"}, asst, tr, asst2}
+	got := sanitizeToolPairs(msgs)
+	if len(got) != 4 {
+		t.Fatalf("expected 4 messages unchanged, got %d", len(got))
+	}
+	// Verify types preserved.
+	if _, ok := got[1].(ai.AssistantMessage); !ok {
+		t.Error("message 1 should remain AssistantMessage")
+	}
+	if _, ok := got[2].(ai.ToolResultMessage); !ok {
+		t.Error("message 2 should remain ToolResultMessage")
+	}
+}
+
+func TestSanitizeToolPairs_EmptyOrphanResultDropped(t *testing.T) {
+	msgs := []ai.Message{
+		ai.ToolResultMessage{
+			ToolCallID: "orphan",
+			ToolName:   "bash",
+			Content:    []ai.ContentBlock{ai.TextContent{Text: ""}},
+		},
+	}
+	got := sanitizeToolPairs(msgs)
+	if len(got) != 0 {
+		t.Fatalf("expected empty orphan result to be dropped, got %d messages", len(got))
+	}
 }

--- a/internal/memory/lcm/provider.go
+++ b/internal/memory/lcm/provider.go
@@ -140,6 +140,7 @@ func (p *Provider) Append(ctx context.Context, session memory.Session, msgs ...a
 					Ordinal:        ordinal,
 					ItemType:       itemTypeMessage,
 					MessageID:      sql.NullString{String: dbMsg.ID, Valid: true},
+					EventType:      row.eventType,
 				})
 				if err != nil {
 					return fmt.Errorf("append context item: %w", err)

--- a/pkg/db/sqlc/ctx_item.sql.go
+++ b/pkg/db/sqlc/ctx_item.sql.go
@@ -11,8 +11,8 @@ import (
 )
 
 const appendContextItem = `-- name: AppendContextItem :exec
-INSERT INTO ctx_item (conversation_id, ordinal, item_type, message_id, summary_id)
-VALUES (?, ?, ?, ?, ?)
+INSERT INTO ctx_item (conversation_id, ordinal, item_type, message_id, summary_id, event_type)
+VALUES (?, ?, ?, ?, ?, ?)
 `
 
 type AppendContextItemParams struct {
@@ -21,6 +21,7 @@ type AppendContextItemParams struct {
 	ItemType       string         `json:"item_type"`
 	MessageID      sql.NullString `json:"message_id"`
 	SummaryID      sql.NullString `json:"summary_id"`
+	EventType      string         `json:"event_type"`
 }
 
 func (q *Queries) AppendContextItem(ctx context.Context, arg AppendContextItemParams) error {
@@ -30,6 +31,7 @@ func (q *Queries) AppendContextItem(ctx context.Context, arg AppendContextItemPa
 		arg.ItemType,
 		arg.MessageID,
 		arg.SummaryID,
+		arg.EventType,
 	)
 	return err
 }
@@ -71,7 +73,7 @@ func (q *Queries) GetContextItemCount(ctx context.Context, conversationID string
 }
 
 const getContextItems = `-- name: GetContextItems :many
-SELECT conversation_id, ordinal, item_type, message_id, summary_id, created_at FROM ctx_item
+SELECT conversation_id, ordinal, item_type, message_id, summary_id, event_type, created_at FROM ctx_item
 WHERE conversation_id = ?
 ORDER BY ordinal ASC
 `
@@ -91,6 +93,7 @@ func (q *Queries) GetContextItems(ctx context.Context, conversationID string) ([
 			&i.ItemType,
 			&i.MessageID,
 			&i.SummaryID,
+			&i.EventType,
 			&i.CreatedAt,
 		); err != nil {
 			return nil, err
@@ -107,7 +110,7 @@ func (q *Queries) GetContextItems(ctx context.Context, conversationID string) ([
 }
 
 const getContextMessageItems = `-- name: GetContextMessageItems :many
-SELECT ci.conversation_id, ci.ordinal, ci.item_type, ci.message_id, ci.summary_id, ci.created_at, m.token_count as msg_token_count
+SELECT ci.conversation_id, ci.ordinal, ci.item_type, ci.message_id, ci.summary_id, ci.event_type, ci.created_at, m.token_count as msg_token_count
 FROM ctx_item ci
 JOIN ctx_message m ON ci.message_id = m.id
 WHERE ci.conversation_id = ? AND ci.item_type = 'message'
@@ -120,6 +123,7 @@ type GetContextMessageItemsRow struct {
 	ItemType       string         `json:"item_type"`
 	MessageID      sql.NullString `json:"message_id"`
 	SummaryID      sql.NullString `json:"summary_id"`
+	EventType      string         `json:"event_type"`
 	CreatedAt      string         `json:"created_at"`
 	MsgTokenCount  int64          `json:"msg_token_count"`
 }
@@ -139,6 +143,7 @@ func (q *Queries) GetContextMessageItems(ctx context.Context, conversationID str
 			&i.ItemType,
 			&i.MessageID,
 			&i.SummaryID,
+			&i.EventType,
 			&i.CreatedAt,
 			&i.MsgTokenCount,
 		); err != nil {

--- a/pkg/db/sqlc/models.go
+++ b/pkg/db/sqlc/models.go
@@ -448,6 +448,7 @@ type CtxItem struct {
 	ItemType       string         `json:"item_type"`
 	MessageID      sql.NullString `json:"message_id"`
 	SummaryID      sql.NullString `json:"summary_id"`
+	EventType      string         `json:"event_type"`
 	CreatedAt      string         `json:"created_at"`
 }
 


### PR DESCRIPTION
## What

Fix LCM compaction splitting tool_call/tool_result pairs, which causes the LLM API to reject requests with `400: No tool call found for function call output with call_id ...`.

## Why

Tool calls (assistant role) and tool results (tool role) are linked by `call_id`. The API requires every tool_result to have a matching tool_call in a preceding assistant message. Three code paths can break this invariant:

1. **`splitFreshTail`** — the count-based split can land between a tool_call and its result
2. **`findMessageRuns`** — run boundaries can cut between paired messages
3. **`resolveOlderWithinBudget`** — budget exhaustion can include a result but not its call

## How

### Schema change
- Add `event_type` column to `ctx_item` table (with backfill migration) so boundary logic can see message types without extra DB queries

### Boundary fixes
- **`splitFreshTail`**: adjust split point to keep tool_call/tool_result pairs in the same partition
- **`findMessageRuns`**: trim orphan tool_results from run start and orphan tool_calls from run end via new `trimOrphanedToolPairs` helper
- **`resolveOlderWithinBudget`**: strip trailing orphan results when budget is exhausted via new `stripTrailingOrphanResults` helper

### Defense-in-depth
- **`sanitizeToolPairs`**: final pass in `assemble()` output that converts orphan tool_results → UserMessages and strips orphan tool_calls from non-final assistant messages

### Tests
- 13 new unit tests covering all helpers and edge cases (multiple tool calls per turn, both-ends orphaned, empty orphans, in-progress calls on final assistant message)
- All existing tests pass (including group assembler, conformance, provider_extra)

## Refs

- Closes #341