### PR TITLE
✨ feat(sessions): expose epoch transcript context

### DIFF
--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -2208,6 +2208,130 @@ components:
           items:
             type: object
             additionalProperties: {}
+    SessionContextMeta:
+      type: object
+      required: [
+        message_count,
+        source_token_count,
+        active_token_count,
+        summary_depth,
+      ]
+      properties:
+        message_count:
+          type: integer
+        source_token_count:
+          type: integer
+        active_token_count:
+          type: integer
+        summary_depth:
+          type: integer
+    SessionContextMessage:
+      type: object
+      required: [id, seq, role, timestamp, token_count]
+      properties:
+        id:
+          type: string
+        seq:
+          type: integer
+        role:
+          type: string
+        event_type:
+          type: string
+        content:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+        token_count:
+          type: integer
+        data:
+          type: object
+          additionalProperties: {}
+    SessionContextSummary:
+      type: object
+      required: [
+        id,
+        kind,
+        depth,
+        content,
+        token_count,
+        descendant_count,
+        descendant_token_count,
+        source_message_token_count,
+        created_at,
+      ]
+      properties:
+        id:
+          type: string
+        kind:
+          type: string
+        depth:
+          type: integer
+        content:
+          type: string
+        token_count:
+          type: integer
+        earliest_at:
+          type: string
+          format: date-time
+          nullable: true
+        latest_at:
+          type: string
+          format: date-time
+          nullable: true
+        descendant_count:
+          type: integer
+        descendant_token_count:
+          type: integer
+        source_message_token_count:
+          type: integer
+        created_at:
+          type: string
+          format: date-time
+    SessionContextItem:
+      type: object
+      required: [ordinal, type]
+      properties:
+        ordinal:
+          type: integer
+        type:
+          type: string
+          enum: [message, summary]
+        event_type:
+          type: string
+        message:
+          $ref: "#/components/schemas/SessionContextMessage"
+        summary:
+          $ref: "#/components/schemas/SessionContextSummary"
+    SessionContextItemList:
+      type: object
+      required: [items, meta]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/SessionContextItem"
+        meta:
+          $ref: "#/components/schemas/SessionContextMeta"
+        next_page_token:
+          type: string
+          nullable: true
+    SessionSummaryDetail:
+      type: object
+      required: [summary, children]
+      properties:
+        summary:
+          $ref: "#/components/schemas/SessionContextSummary"
+        children:
+          type: array
+          items:
+            $ref: "#/components/schemas/SessionContextSummary"
+        message_seq_from:
+          type: integer
+          nullable: true
+        message_seq_to:
+          type: integer
+          nullable: true
     Share:
       type: object
       required: [id, url, title, media_type, created_at]

--- a/api/spec/domain/sessions/paths.yaml
+++ b/api/spec/domain/sessions/paths.yaml
@@ -113,11 +113,16 @@ paths:
         - name: seq_from
           in: query
           schema: { type: integer, minimum: 1 }
-          description: Only return messages with seq greater than or equal to this value
+          description: >-
+            Only return messages with seq greater than or equal to this value.
+            Must be provided together with seq_to; when set, the seq range
+            takes precedence over limit/skip/after/before.
         - name: seq_to
           in: query
           schema: { type: integer, minimum: 1 }
-          description: Only return messages with seq less than or equal to this value
+          description: >-
+            Only return messages with seq less than or equal to this value.
+            Must be provided together with seq_from.
       responses:
         "200":
           description: ok

--- a/api/spec/domain/sessions/paths.yaml
+++ b/api/spec/domain/sessions/paths.yaml
@@ -110,6 +110,14 @@ paths:
           in: query
           schema: { type: string }
           description: Only return messages created at or before this timestamp
+        - name: seq_from
+          in: query
+          schema: { type: integer, minimum: 1 }
+          description: Only return messages with seq greater than or equal to this value
+        - name: seq_to
+          in: query
+          schema: { type: integer, minimum: 1 }
+          description: Only return messages with seq less than or equal to this value
       responses:
         "200":
           description: ok
@@ -147,6 +155,58 @@ paths:
           $ref: "../../components.yaml#/components/responses/Unauthorized",
         }
         "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+
+  /api/agents/{agentId}/sessions/{sessionId}/context-items:
+    parameters:
+      - { name: agentId, in: path, required: true, schema: { type: string } }
+      - { name: sessionId, in: path, required: true, schema: { type: string } }
+    get:
+      tags: [sessions]
+      summary: List compacted context items for a session
+      operationId: getSessionContextItems
+      parameters:
+        - name: page_size
+          in: query
+          schema: { type: integer, default: 100, minimum: 1, maximum: 500 }
+        - name: page_token
+          in: query
+          schema: { type: string }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: {
+                $ref: "../../components.yaml#/components/schemas/SessionContextItemList",
+              }
+        "401": {
+          $ref: "../../components.yaml#/components/responses/Unauthorized",
+        }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+
+  /api/agents/{agentId}/sessions/{sessionId}/summaries/{summaryId}:
+    parameters:
+      - { name: agentId, in: path, required: true, schema: { type: string } }
+      - { name: sessionId, in: path, required: true, schema: { type: string } }
+      - { name: summaryId, in: path, required: true, schema: { type: string } }
+    get:
+      tags: [sessions]
+      summary: Get compacted summary detail for a session
+      operationId: getSessionSummary
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: {
+                $ref: "../../components.yaml#/components/schemas/SessionSummaryDetail",
+              }
+        "401": {
+          $ref: "../../components.yaml#/components/responses/Unauthorized",
+        }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
 
   /api/agents/{agentId}/sessions/{sessionId}/workspace:
     parameters:

--- a/api/spec/domain/sessions/schemas.yaml
+++ b/api/spec/domain/sessions/schemas.yaml
@@ -191,3 +191,93 @@ components:
           items:
             type: object
             additionalProperties: {}
+
+    SessionContextMeta:
+      type: object
+      required:
+        [
+          message_count,
+          source_token_count,
+          active_token_count,
+          summary_depth,
+        ]
+      properties:
+        message_count: { type: integer }
+        source_token_count: { type: integer }
+        active_token_count: { type: integer }
+        summary_depth: { type: integer }
+
+    SessionContextMessage:
+      type: object
+      required: [id, seq, role, timestamp, token_count]
+      properties:
+        id: { type: string }
+        seq: { type: integer }
+        role: { type: string }
+        event_type: { type: string }
+        content: { type: string }
+        timestamp: { type: string, format: date-time }
+        token_count: { type: integer }
+        data:
+          type: object
+          additionalProperties: {}
+
+    SessionContextSummary:
+      type: object
+      required:
+        [
+          id,
+          kind,
+          depth,
+          content,
+          token_count,
+          descendant_count,
+          descendant_token_count,
+          source_message_token_count,
+          created_at,
+        ]
+      properties:
+        id: { type: string }
+        kind: { type: string }
+        depth: { type: integer }
+        content: { type: string }
+        token_count: { type: integer }
+        earliest_at: { type: string, format: date-time, nullable: true }
+        latest_at: { type: string, format: date-time, nullable: true }
+        descendant_count: { type: integer }
+        descendant_token_count: { type: integer }
+        source_message_token_count: { type: integer }
+        created_at: { type: string, format: date-time }
+
+    SessionContextItem:
+      type: object
+      required: [ordinal, type]
+      properties:
+        ordinal: { type: integer }
+        type:
+          type: string
+          enum: [message, summary]
+        event_type: { type: string }
+        message: { $ref: "#/components/schemas/SessionContextMessage" }
+        summary: { $ref: "#/components/schemas/SessionContextSummary" }
+
+    SessionContextItemList:
+      type: object
+      required: [items, meta]
+      properties:
+        items:
+          type: array
+          items: { $ref: "#/components/schemas/SessionContextItem" }
+        meta: { $ref: "#/components/schemas/SessionContextMeta" }
+        next_page_token: { type: string, nullable: true }
+
+    SessionSummaryDetail:
+      type: object
+      required: [summary, children]
+      properties:
+        summary: { $ref: "#/components/schemas/SessionContextSummary" }
+        children:
+          type: array
+          items: { $ref: "#/components/schemas/SessionContextSummary" }
+        message_seq_from: { type: integer, nullable: true }
+        message_seq_to: { type: integer, nullable: true }

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -164,6 +164,10 @@ paths:
     $ref: "./domain/sessions/paths.yaml#/paths/~1api~1agents~1{agentId}~1sessions~1{sessionId}"
   /api/agents/{agentId}/sessions/{sessionId}/messages:
     $ref: "./domain/sessions/paths.yaml#/paths/~1api~1agents~1{agentId}~1sessions~1{sessionId}~1messages"
+  /api/agents/{agentId}/sessions/{sessionId}/context-items:
+    $ref: "./domain/sessions/paths.yaml#/paths/~1api~1agents~1{agentId}~1sessions~1{sessionId}~1context-items"
+  /api/agents/{agentId}/sessions/{sessionId}/summaries/{summaryId}:
+    $ref: "./domain/sessions/paths.yaml#/paths/~1api~1agents~1{agentId}~1sessions~1{sessionId}~1summaries~1{summaryId}"
   /api/agents/{agentId}/sessions/{sessionId}/workspace:
     $ref: "./domain/sessions/paths.yaml#/paths/~1api~1agents~1{agentId}~1sessions~1{sessionId}~1workspace"
   /api/agents/{agentId}/sessions/{sessionId}/workspace/files:

--- a/internal/db/queries/ctx_item.sql
+++ b/internal/db/queries/ctx_item.sql
@@ -7,6 +7,36 @@ SELECT * FROM ctx_item
 WHERE conversation_id = ?
 ORDER BY ordinal ASC;
 
+-- name: ListContextItemsPage :many
+SELECT
+  ci.ordinal,
+  ci.item_type,
+  ci.event_type,
+  m.id AS message_id,
+  m.seq AS message_seq,
+  m.role AS message_role,
+  m.event_type AS message_event_type,
+  m.content AS message_content,
+  m.token_count AS message_token_count,
+  m.created_at AS message_created_at,
+  s.id AS summary_id,
+  s.kind AS summary_kind,
+  s.depth AS summary_depth,
+  s.content AS summary_content,
+  s.token_count AS summary_token_count,
+  s.earliest_at AS summary_earliest_at,
+  s.latest_at AS summary_latest_at,
+  s.descendant_count AS summary_descendant_count,
+  s.descendant_token_count AS summary_descendant_token_count,
+  s.source_message_token_count AS summary_source_message_token_count,
+  s.created_at AS summary_created_at
+FROM ctx_item ci
+LEFT JOIN ctx_message m ON m.id = ci.message_id
+LEFT JOIN ctx_summary s ON s.id = ci.summary_id
+WHERE ci.conversation_id = sqlc.arg('conversation_id')
+ORDER BY ci.ordinal ASC
+LIMIT sqlc.arg(limit_count) OFFSET sqlc.arg(offset_count);
+
 -- name: GetContextItemCount :one
 SELECT COUNT(*) FROM ctx_item WHERE conversation_id = ?;
 
@@ -31,6 +61,23 @@ FROM ctx_item ci
 LEFT JOIN ctx_message m ON ci.message_id = m.id
 LEFT JOIN ctx_summary s ON ci.summary_id = s.id
 WHERE ci.conversation_id = ?;
+
+-- name: GetContextStats :one
+SELECT
+  (SELECT COUNT(*) FROM ctx_message cm WHERE cm.conversation_id = sqlc.arg('conversation_id')) AS message_count,
+  (SELECT CAST(COALESCE(SUM(cm.token_count), 0) AS INTEGER) FROM ctx_message cm WHERE cm.conversation_id = sqlc.arg('conversation_id')) AS source_token_count,
+  (SELECT CAST(COALESCE(SUM(
+        CASE
+            WHEN ci.item_type = 'message' THEN m.token_count
+            WHEN ci.item_type = 'summary' THEN s.token_count
+            ELSE 0
+        END
+    ), 0) AS INTEGER)
+   FROM ctx_item ci
+   LEFT JOIN ctx_message m ON ci.message_id = m.id
+   LEFT JOIN ctx_summary s ON ci.summary_id = s.id
+   WHERE ci.conversation_id = sqlc.arg('conversation_id')) AS active_token_count,
+  (SELECT CAST(COALESCE(MAX(cs.depth), 0) AS INTEGER) FROM ctx_summary cs WHERE cs.conversation_id = sqlc.arg('conversation_id')) AS summary_depth;
 
 -- name: GetContextMessageItems :many
 SELECT ci.*, m.token_count as msg_token_count

--- a/internal/db/queries/ctx_summary.sql
+++ b/internal/db/queries/ctx_summary.sql
@@ -33,6 +33,14 @@ JOIN ctx_summary_message sm ON sm.message_id = m.id
 WHERE sm.summary_id = ?
 ORDER BY sm.ordinal ASC;
 
+-- name: GetSummaryMessageSeqRange :one
+SELECT
+  CAST(COALESCE(MIN(m.seq), 0) AS INTEGER) AS message_seq_from,
+  CAST(COALESCE(MAX(m.seq), 0) AS INTEGER) AS message_seq_to
+FROM ctx_summary_message sm
+JOIN ctx_message m ON sm.message_id = m.id
+WHERE sm.summary_id = ?;
+
 -- name: GetSummaryParents :many
 SELECT s.* FROM ctx_summary s
 JOIN ctx_summary_parent sp ON sp.parent_summary_id = s.id

--- a/internal/server/context_items_test.go
+++ b/internal/server/context_items_test.go
@@ -2,14 +2,22 @@ package server_test
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"testing"
 	"time"
 
 	apitypes "github.com/CherryHQ/stella/api/types"
+	"github.com/CherryHQ/stella/internal/auth"
 	"github.com/CherryHQ/stella/internal/memory"
 )
+
+// offsetToken mirrors the server's opaque page-token encoding.
+func offsetToken(offset int) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(strconv.Itoa(offset)))
+}
 
 func TestSessionContextItemsAndSummaryEndpoints(t *testing.T) {
 	env := setupAdmin(t)
@@ -139,6 +147,158 @@ func TestSessionContextItemsFallbackUsesMessagePaging(t *testing.T) {
 	}
 	if len(second.Items) != 1 || second.Items[0].Message == nil || second.Items[0].Message.Id != "fallback-msg-2" {
 		t.Fatalf("second page = %+v", second.Items)
+	}
+}
+
+func TestSessionSummaryCondensedAggregatesChildren(t *testing.T) {
+	env := setupAdmin(t)
+	agentID := findStellaID(t, env)
+	sessionID := "context-condensed-session"
+	now := time.Date(2026, 6, 10, 3, 0, 0, 0, time.UTC)
+	sm := env.mem.(memory.SessionManager)
+	if err := sm.SaveInfo(context.Background(), memory.SessionInfo{
+		ID:         sessionID,
+		AgentID:    agentID,
+		UserID:     env.adminUser.ID,
+		Channel:    "web",
+		Kind:       "chat",
+		Title:      "Condensed",
+		CreatedAt:  now,
+		LastActive: now,
+	}); err != nil {
+		t.Fatalf("SaveInfo: %v", err)
+	}
+	var conversationID string
+	if err := env.db.QueryRow(`SELECT id FROM ctx_conversation WHERE session_id = ?`, sessionID).Scan(&conversationID); err != nil {
+		t.Fatalf("load conversation: %v", err)
+	}
+	mustExec := func(query string, args ...any) {
+		t.Helper()
+		if _, err := env.db.Exec(query, args...); err != nil {
+			t.Fatalf("exec seed: %v\n%s", err, query)
+		}
+	}
+	mustExec(`
+		INSERT INTO ctx_message (id, conversation_id, seq, role, event_type, content, token_count, created_at)
+		VALUES
+		('cm-1', ?, 1, 'user', 'text', 'one', 10, '2026-06-10 03:00:00'),
+		('cm-2', ?, 2, 'assistant', 'text', 'two', 10, '2026-06-10 03:01:00'),
+		('cm-3', ?, 3, 'user', 'text', 'three', 10, '2026-06-10 03:02:00'),
+		('cm-4', ?, 4, 'assistant', 'text', 'four', 10, '2026-06-10 03:03:00')
+	`, conversationID, conversationID, conversationID, conversationID)
+	mustExec(`
+		INSERT INTO ctx_summary (
+			id, conversation_id, kind, depth, content, token_count, earliest_at, latest_at,
+			descendant_count, descendant_token_count, source_message_token_count, created_at
+		)
+		VALUES
+		('leaf-a', ?, 'epoch', 1, 'leaf a', 10, '2026-06-10 03:00:00', '2026-06-10 03:01:00', 2, 20, 20, '2026-06-10 03:04:00'),
+		('leaf-b', ?, 'epoch', 1, 'leaf b', 10, '2026-06-10 03:02:00', '2026-06-10 03:03:00', 2, 20, 20, '2026-06-10 03:05:00'),
+		('cond-1', ?, 'epoch', 2, 'condensed', 12, '2026-06-10 03:00:00', '2026-06-10 03:03:00', 4, 40, 40, '2026-06-10 03:06:00')
+	`, conversationID, conversationID, conversationID)
+	mustExec(`
+		INSERT INTO ctx_summary_message (summary_id, message_id, ordinal)
+		VALUES ('leaf-a', 'cm-1', 1), ('leaf-a', 'cm-2', 2), ('leaf-b', 'cm-3', 1), ('leaf-b', 'cm-4', 2)
+	`)
+	// Rows are (summary_id=condensed, parent_summary_id=constituent), matching
+	// the write path in compaction.
+	mustExec(`
+		INSERT INTO ctx_summary_parent (summary_id, parent_summary_id, ordinal)
+		VALUES ('cond-1', 'leaf-a', 1), ('cond-1', 'leaf-b', 2)
+	`)
+
+	rr := doRequest(t, env, http.MethodGet, "/api/agents/"+agentID+"/sessions/"+sessionID+"/summaries/cond-1", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("condensed summary: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var detail apitypes.SessionSummaryDetail
+	if err := json.Unmarshal(rr.Body.Bytes(), &detail); err != nil {
+		t.Fatalf("decode condensed summary: %v", err)
+	}
+	if len(detail.Children) != 2 || detail.Children[0].Id != "leaf-a" || detail.Children[1].Id != "leaf-b" {
+		t.Fatalf("children = %+v, want [leaf-a leaf-b]", detail.Children)
+	}
+	if detail.MessageSeqFrom == nil || *detail.MessageSeqFrom != 1 || detail.MessageSeqTo == nil || *detail.MessageSeqTo != 4 {
+		t.Fatalf("seq range = %v..%v, want 1..4", detail.MessageSeqFrom, detail.MessageSeqTo)
+	}
+}
+
+func TestSessionContextItemsPageTokenEdgeCases(t *testing.T) {
+	env := setupAdmin(t)
+	agentID := findStellaID(t, env)
+	sessionID := "context-token-session"
+	now := time.Date(2026, 6, 10, 4, 0, 0, 0, time.UTC)
+	sm := env.mem.(memory.SessionManager)
+	if err := sm.SaveInfo(context.Background(), memory.SessionInfo{
+		ID:         sessionID,
+		AgentID:    agentID,
+		UserID:     env.adminUser.ID,
+		Channel:    "web",
+		Kind:       "chat",
+		Title:      "Token edges",
+		CreatedAt:  now,
+		LastActive: now,
+	}); err != nil {
+		t.Fatalf("SaveInfo: %v", err)
+	}
+	var conversationID string
+	if err := env.db.QueryRow(`SELECT id FROM ctx_conversation WHERE session_id = ?`, sessionID).Scan(&conversationID); err != nil {
+		t.Fatalf("load conversation: %v", err)
+	}
+	seedContextItems(t, env, conversationID)
+
+	rr := doRequest(t, env, http.MethodGet, "/api/agents/"+agentID+"/sessions/"+sessionID+"/context-items?page_token=not-a-token", nil)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("invalid token: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+
+	// An out-of-range offset on a session that has ctx_item rows must return
+	// an empty page, not fall back to raw message paging.
+	rr = doRequest(t, env, http.MethodGet, "/api/agents/"+agentID+"/sessions/"+sessionID+"/context-items?page_size=10&page_token="+offsetToken(1000), nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("out-of-range token: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var list apitypes.SessionContextItemList
+	if err := json.Unmarshal(rr.Body.Bytes(), &list); err != nil {
+		t.Fatalf("decode out-of-range page: %v", err)
+	}
+	if len(list.Items) != 0 {
+		t.Fatalf("out-of-range items = %+v, want empty", list.Items)
+	}
+	if list.NextPageToken != nil {
+		t.Fatalf("out-of-range next token = %v, want nil", *list.NextPageToken)
+	}
+}
+
+func TestSessionContextItemsTenantIsolation(t *testing.T) {
+	env := setupAdmin(t)
+	agentID := findStellaID(t, env)
+	sessionID := "context-isolation-session"
+	now := time.Date(2026, 6, 10, 5, 0, 0, 0, time.UTC)
+	sm := env.mem.(memory.SessionManager)
+	if err := sm.SaveInfo(context.Background(), memory.SessionInfo{
+		ID:         sessionID,
+		AgentID:    agentID,
+		UserID:     env.adminUser.ID,
+		Channel:    "web",
+		Kind:       "chat",
+		Title:      "Isolation",
+		CreatedAt:  now,
+		LastActive: now,
+	}); err != nil {
+		t.Fatalf("SaveInfo: %v", err)
+	}
+
+	// Another user's session lookup misses entirely, so the API answers 404
+	// rather than 403 — existence is not leaked across tenants.
+	_, otherToken := createTestUserWithToken(t, env.authStore, env.oidcStore, "context-other", auth.RoleUser)
+	rr := doRequestWithSession(t, env.srv, otherToken, http.MethodGet, "/api/agents/"+agentID+"/sessions/"+sessionID+"/context-items", nil)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("other user context items: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	rr = doRequestWithSession(t, env.srv, otherToken, http.MethodGet, "/api/agents/"+agentID+"/sessions/"+sessionID+"/summaries/sum-1", nil)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("other user summary: status=%d body=%s", rr.Code, rr.Body.String())
 	}
 }
 

--- a/internal/server/context_items_test.go
+++ b/internal/server/context_items_test.go
@@ -1,0 +1,178 @@
+package server_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	apitypes "github.com/CherryHQ/stella/api/types"
+	"github.com/CherryHQ/stella/internal/memory"
+)
+
+func TestSessionContextItemsAndSummaryEndpoints(t *testing.T) {
+	env := setupAdmin(t)
+	agentID := findStellaID(t, env)
+	sessionID := "context-items-session"
+	now := time.Date(2026, 6, 10, 1, 0, 0, 0, time.UTC)
+	sm := env.mem.(memory.SessionManager)
+	if err := sm.SaveInfo(context.Background(), memory.SessionInfo{
+		ID:         sessionID,
+		AgentID:    agentID,
+		UserID:     env.adminUser.ID,
+		Channel:    "web",
+		Kind:       "chat",
+		Title:      "Context items",
+		CreatedAt:  now,
+		LastActive: now,
+	}); err != nil {
+		t.Fatalf("SaveInfo: %v", err)
+	}
+
+	var conversationID string
+	if err := env.db.QueryRow(`SELECT id FROM ctx_conversation WHERE session_id = ?`, sessionID).Scan(&conversationID); err != nil {
+		t.Fatalf("load conversation: %v", err)
+	}
+	seedContextItems(t, env, conversationID)
+
+	rr := doRequest(t, env, http.MethodGet, "/api/agents/"+agentID+"/sessions/"+sessionID+"/context-items?page_size=10", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("context items: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var list apitypes.SessionContextItemList
+	if err := json.Unmarshal(rr.Body.Bytes(), &list); err != nil {
+		t.Fatalf("decode context items: %v", err)
+	}
+	if len(list.Items) != 3 {
+		t.Fatalf("items len = %d, want 3: %+v", len(list.Items), list.Items)
+	}
+	if list.Items[0].Type != apitypes.Message || list.Items[1].Type != apitypes.Summary {
+		t.Fatalf("item ordering/types = %+v", list.Items)
+	}
+	if list.Meta.MessageCount != 3 || list.Meta.SourceTokenCount != 60 || list.Meta.ActiveTokenCount != 65 || list.Meta.SummaryDepth != 1 {
+		t.Fatalf("meta = %+v", list.Meta)
+	}
+
+	rr = doRequest(t, env, http.MethodGet, "/api/agents/"+agentID+"/sessions/"+sessionID+"/summaries/sum-1", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("summary: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var detail apitypes.SessionSummaryDetail
+	if err := json.Unmarshal(rr.Body.Bytes(), &detail); err != nil {
+		t.Fatalf("decode summary: %v", err)
+	}
+	if detail.MessageSeqFrom == nil || *detail.MessageSeqFrom != 2 || detail.MessageSeqTo == nil || *detail.MessageSeqTo != 3 {
+		t.Fatalf("seq range = %v..%v, want 2..3", detail.MessageSeqFrom, detail.MessageSeqTo)
+	}
+
+	rr = doRequest(t, env, http.MethodGet, "/api/agents/"+agentID+"/sessions/"+sessionID+"/messages?seq_from=2&seq_to=3", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("messages seq range: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var messages apitypes.SessionMessageList
+	if err := json.Unmarshal(rr.Body.Bytes(), &messages); err != nil {
+		t.Fatalf("decode messages: %v", err)
+	}
+	if len(messages.Messages) != 1 || messages.Messages[0]["role"] != "assistant" {
+		t.Fatalf("messages = %+v, want merged assistant range", messages.Messages)
+	}
+}
+
+func TestSessionContextItemsFallbackUsesMessagePaging(t *testing.T) {
+	env := setupAdmin(t)
+	agentID := findStellaID(t, env)
+	sessionID := "context-items-fallback-session"
+	now := time.Date(2026, 6, 10, 2, 0, 0, 0, time.UTC)
+	sm := env.mem.(memory.SessionManager)
+	if err := sm.SaveInfo(context.Background(), memory.SessionInfo{
+		ID:         sessionID,
+		AgentID:    agentID,
+		UserID:     env.adminUser.ID,
+		Channel:    "web",
+		Kind:       "chat",
+		Title:      "Context fallback",
+		CreatedAt:  now,
+		LastActive: now,
+	}); err != nil {
+		t.Fatalf("SaveInfo: %v", err)
+	}
+
+	var conversationID string
+	if err := env.db.QueryRow(`SELECT id FROM ctx_conversation WHERE session_id = ?`, sessionID).Scan(&conversationID); err != nil {
+		t.Fatalf("load conversation: %v", err)
+	}
+	if _, err := env.db.Exec(`
+		INSERT INTO ctx_message (id, conversation_id, seq, role, event_type, content, token_count, created_at)
+		VALUES
+		('fallback-msg-1', ?, 1, 'user', 'text', 'first', 10, '2026-06-10 02:00:00'),
+		('fallback-msg-2', ?, 2, 'assistant', 'text', 'second', 20, '2026-06-10 02:01:00')
+	`, conversationID, conversationID); err != nil {
+		t.Fatalf("seed fallback messages: %v", err)
+	}
+
+	rr := doRequest(t, env, http.MethodGet, "/api/agents/"+agentID+"/sessions/"+sessionID+"/context-items?page_size=1", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("context fallback: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var first apitypes.SessionContextItemList
+	if err := json.Unmarshal(rr.Body.Bytes(), &first); err != nil {
+		t.Fatalf("decode first page: %v", err)
+	}
+	if len(first.Items) != 1 || first.Items[0].Message == nil || first.Items[0].Message.Id != "fallback-msg-1" {
+		t.Fatalf("first page = %+v", first.Items)
+	}
+	if first.Meta.SourceTokenCount != 30 || first.Meta.ActiveTokenCount != 30 {
+		t.Fatalf("fallback meta = %+v", first.Meta)
+	}
+	if first.NextPageToken == nil {
+		t.Fatal("missing next page token")
+	}
+
+	rr = doRequest(t, env, http.MethodGet, "/api/agents/"+agentID+"/sessions/"+sessionID+"/context-items?page_size=1&page_token="+*first.NextPageToken, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("context fallback second page: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var second apitypes.SessionContextItemList
+	if err := json.Unmarshal(rr.Body.Bytes(), &second); err != nil {
+		t.Fatalf("decode second page: %v", err)
+	}
+	if len(second.Items) != 1 || second.Items[0].Message == nil || second.Items[0].Message.Id != "fallback-msg-2" {
+		t.Fatalf("second page = %+v", second.Items)
+	}
+}
+
+func seedContextItems(t *testing.T, env *testEnv, conversationID string) {
+	t.Helper()
+	mustExec := func(query string, args ...any) {
+		t.Helper()
+		if _, err := env.db.Exec(query, args...); err != nil {
+			t.Fatalf("exec seed: %v\n%s", err, query)
+		}
+	}
+	mustExec(`
+		INSERT INTO ctx_message (id, conversation_id, seq, role, event_type, content, token_count, created_at)
+		VALUES
+		('msg-1', ?, 1, 'user', 'text', 'hello', 10, '2026-06-10 01:00:00'),
+		('msg-2', ?, 2, 'assistant', 'text', 'first', 20, '2026-06-10 01:01:00'),
+		('msg-3', ?, 3, 'assistant', 'text', 'second', 30, '2026-06-10 01:02:00')
+	`, conversationID, conversationID, conversationID)
+	mustExec(`
+		INSERT INTO ctx_summary (
+			id, conversation_id, kind, depth, content, token_count, earliest_at, latest_at,
+			descendant_count, descendant_token_count, source_message_token_count, created_at
+		)
+		VALUES ('sum-1', ?, 'epoch', 1, 'assistant summary', 25, '2026-06-10 01:01:00', '2026-06-10 01:02:00', 2, 50, 50, '2026-06-10 01:03:00')
+	`, conversationID)
+	mustExec(`
+		INSERT INTO ctx_summary_message (summary_id, message_id, ordinal)
+		VALUES ('sum-1', 'msg-2', 1), ('sum-1', 'msg-3', 2)
+	`)
+	mustExec(`
+		INSERT INTO ctx_item (conversation_id, ordinal, item_type, message_id, summary_id, event_type)
+		VALUES
+		(?, 1, 'message', 'msg-1', NULL, 'text'),
+		(?, 2, 'summary', NULL, 'sum-1', 'summary'),
+		(?, 3, 'message', 'msg-3', NULL, 'text')
+	`, conversationID, conversationID, conversationID)
+}

--- a/internal/server/sessions.go
+++ b/internal/server/sessions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -586,7 +587,22 @@ func (s *Server) GetSessionMessages(w http.ResponseWriter, r *http.Request, agen
 		return
 	}
 	var rows []sqlc.CtxMessage
-	if limit > 0 {
+	switch {
+	case params.SeqFrom != nil || params.SeqTo != nil:
+		if params.SeqFrom == nil || params.SeqTo == nil || *params.SeqFrom <= 0 || *params.SeqTo < *params.SeqFrom {
+			writeError(w, http.StatusBadRequest, "invalid seq range")
+			return
+		}
+		rows, err = s.q.GetMessagesByConversationRange(r.Context(), sqlc.GetMessagesByConversationRangeParams{
+			ConversationID: conv.ID,
+			Seq:            int64(*params.SeqFrom),
+			Seq_2:          int64(*params.SeqTo),
+		})
+		if err != nil {
+			s.writeInternalError(w, err)
+			return
+		}
+	case limit > 0:
 		pageRows, err := s.q.ListMessagesByLogicalPage(r.Context(), sqlc.ListMessagesByLogicalPageParams{
 			ConversationID: conv.ID,
 			After:          nilIfStringPtr(params.After),
@@ -599,7 +615,7 @@ func (s *Server) GetSessionMessages(w http.ResponseWriter, r *http.Request, agen
 			return
 		}
 		rows = logicalPageRowsToMessages(pageRows)
-	} else {
+	default:
 		var err error
 		rows, err = s.q.GetMessagesByConversation(r.Context(), conv.ID)
 		if err != nil {
@@ -610,6 +626,140 @@ func (s *Server) GetSessionMessages(w http.ResponseWriter, r *http.Request, agen
 	}
 
 	writeData(w, http.StatusOK, map[string]any{"messages": serializeDBMessages(rows)})
+}
+
+func (s *Server) GetSessionContextItems(w http.ResponseWriter, r *http.Request, agentID string, sessionID string, params apiserver.GetSessionContextItemsParams) {
+	conv, ok := s.requireSessionConversation(w, r, agentID, sessionID)
+	if !ok {
+		return
+	}
+	pageSize := 100
+	if params.PageSize != nil && *params.PageSize > 0 {
+		pageSize = *params.PageSize
+	}
+	if pageSize > 500 {
+		pageSize = 500
+	}
+	offset, err := decodeOffsetToken(derefStr(params.PageToken))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid page token")
+		return
+	}
+	rows, err := s.q.ListContextItemsPage(r.Context(), sqlc.ListContextItemsPageParams{
+		ConversationID: conv.ID,
+		LimitCount:     int64(pageSize + 1),
+		OffsetCount:    int64(offset),
+	})
+	if err != nil {
+		s.writeInternalError(w, err)
+		return
+	}
+	usingMessageFallback := false
+	if len(rows) == 0 {
+		messages, err := s.q.GetMessagesByConversation(r.Context(), conv.ID)
+		if err != nil {
+			s.writeInternalError(w, err)
+			return
+		}
+		rows = contextRowsFromMessages(messages)
+		if offset < len(rows) {
+			rows = rows[offset:]
+		} else {
+			rows = nil
+		}
+		usingMessageFallback = true
+	}
+	stats, err := s.q.GetContextStats(r.Context(), conv.ID)
+	if err != nil {
+		s.writeInternalError(w, err)
+		return
+	}
+	var nextPageToken *string
+	if len(rows) > pageSize {
+		rows = rows[:pageSize]
+		tok := encodeOffsetToken(offset + pageSize)
+		nextPageToken = &tok
+	}
+	items := make([]apitypes.SessionContextItem, 0, len(rows))
+	for _, row := range rows {
+		if item, ok := contextItemFromRow(row); ok {
+			items = append(items, item)
+		}
+	}
+	activeTokenCount := int(stats.ActiveTokenCount)
+	if usingMessageFallback {
+		activeTokenCount = int(stats.SourceTokenCount)
+	}
+	writeData(w, http.StatusOK, apitypes.SessionContextItemList{
+		Items: items,
+		Meta: apitypes.SessionContextMeta{
+			MessageCount:     int(stats.MessageCount),
+			SourceTokenCount: int(stats.SourceTokenCount),
+			ActiveTokenCount: activeTokenCount,
+			SummaryDepth:     int(stats.SummaryDepth),
+		},
+		NextPageToken: nextPageToken,
+	})
+}
+
+func (s *Server) GetSessionSummary(w http.ResponseWriter, r *http.Request, agentID string, sessionID string, summaryID string) {
+	conv, ok := s.requireSessionConversation(w, r, agentID, sessionID)
+	if !ok {
+		return
+	}
+	summary, err := s.q.GetSummary(r.Context(), sqlc.GetSummaryParams{ID: summaryID, ConversationID: conv.ID})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			writeError(w, http.StatusNotFound, "summary not found")
+		} else {
+			s.writeInternalError(w, err)
+		}
+		return
+	}
+	children, err := s.q.GetSummaryChildren(r.Context(), summaryID)
+	if err != nil {
+		s.writeInternalError(w, err)
+		return
+	}
+	seqRange, err := s.q.GetSummaryMessageSeqRange(r.Context(), summaryID)
+	if err != nil {
+		s.writeInternalError(w, err)
+		return
+	}
+	resp := apitypes.SessionSummaryDetail{
+		Summary:  summaryToAPI(summary),
+		Children: make([]apitypes.SessionContextSummary, 0, len(children)),
+	}
+	for _, child := range children {
+		resp.Children = append(resp.Children, summaryToAPI(child))
+	}
+	if seqRange.MessageSeqFrom > 0 && seqRange.MessageSeqTo > 0 {
+		from := int(seqRange.MessageSeqFrom)
+		to := int(seqRange.MessageSeqTo)
+		resp.MessageSeqFrom = &from
+		resp.MessageSeqTo = &to
+	}
+	writeData(w, http.StatusOK, resp)
+}
+
+func (s *Server) requireSessionConversation(w http.ResponseWriter, r *http.Request, agentID, sessionID string) (sqlc.CtxConversation, bool) {
+	if sessionID == "" {
+		writeError(w, http.StatusBadRequest, "missing session ID")
+		return sqlc.CtxConversation{}, false
+	}
+	if err := s.checkSessionAccess(w, r, agentID, sessionID); err != nil {
+		return sqlc.CtxConversation{}, false
+	}
+	userID := ""
+	if info := UserFromContext(r.Context()); info != nil {
+		userID = info.UserID
+	}
+	conv, err := s.q.GetConversationBySessionID(memoryContext(r, agentID), sqlc.GetConversationBySessionIDParams{SessionID: sessionID, UserID: sql.NullString{String: userID, Valid: true}, AgentID: sql.NullString{String: agentID, Valid: agentID != ""}})
+	if err != nil {
+		writeError(w, http.StatusNotFound, "session not found")
+		return sqlc.CtxConversation{}, false
+	}
+	return conv, true
 }
 
 // checkSessionAccess verifies the current user has access to the session.
@@ -1204,6 +1354,88 @@ func filterMessageRowsByTime(rows []sqlc.CtxMessage, after, before *string) []sq
 		filtered = append(filtered, row)
 	}
 	return filtered
+}
+
+func contextRowsFromMessages(messages []sqlc.CtxMessage) []sqlc.ListContextItemsPageRow {
+	rows := make([]sqlc.ListContextItemsPageRow, 0, len(messages))
+	for i, msg := range messages {
+		rows = append(rows, sqlc.ListContextItemsPageRow{
+			Ordinal:           int64(i + 1),
+			ItemType:          "message",
+			EventType:         msg.EventType,
+			MessageID:         sql.NullString{String: msg.ID, Valid: true},
+			MessageSeq:        sql.NullInt64{Int64: msg.Seq, Valid: true},
+			MessageRole:       sql.NullString{String: msg.Role, Valid: true},
+			MessageEventType:  sql.NullString{String: msg.EventType, Valid: true},
+			MessageContent:    sql.NullString{String: msg.Content, Valid: true},
+			MessageTokenCount: sql.NullInt64{Int64: msg.TokenCount, Valid: true},
+			MessageCreatedAt:  sql.NullString{String: msg.CreatedAt, Valid: true},
+		})
+	}
+	return rows
+}
+
+func contextItemFromRow(row sqlc.ListContextItemsPageRow) (apitypes.SessionContextItem, bool) {
+	item := apitypes.SessionContextItem{
+		Ordinal:   int(row.Ordinal),
+		EventType: nullableStringPtr(sql.NullString{String: row.EventType, Valid: row.EventType != ""}),
+	}
+	switch row.ItemType {
+	case "message":
+		if !row.MessageID.Valid || !row.MessageSeq.Valid || !row.MessageRole.Valid {
+			return item, false
+		}
+		content := nullableStringPtr(row.MessageContent)
+		eventType := nullableStringPtr(row.MessageEventType)
+		item.Type = apitypes.Message
+		item.Message = &apitypes.SessionContextMessage{
+			Id:         row.MessageID.String,
+			Seq:        int(row.MessageSeq.Int64),
+			Role:       row.MessageRole.String,
+			EventType:  eventType,
+			Content:    content,
+			Timestamp:  parseTime(row.MessageCreatedAt.String),
+			TokenCount: int(row.MessageTokenCount.Int64),
+		}
+		return item, true
+	case "summary":
+		if !row.SummaryID.Valid {
+			return item, false
+		}
+		item.Type = apitypes.Summary
+		item.Summary = &apitypes.SessionContextSummary{
+			Id:                      row.SummaryID.String,
+			Kind:                    row.SummaryKind.String,
+			Depth:                   int(row.SummaryDepth.Int64),
+			Content:                 row.SummaryContent.String,
+			TokenCount:              int(row.SummaryTokenCount.Int64),
+			EarliestAt:              parseTimePtr(row.SummaryEarliestAt),
+			LatestAt:                parseTimePtr(row.SummaryLatestAt),
+			DescendantCount:         int(row.SummaryDescendantCount.Int64),
+			DescendantTokenCount:    int(row.SummaryDescendantTokenCount.Int64),
+			SourceMessageTokenCount: int(row.SummarySourceMessageTokenCount.Int64),
+			CreatedAt:               parseTime(row.SummaryCreatedAt.String),
+		}
+		return item, true
+	default:
+		return item, false
+	}
+}
+
+func summaryToAPI(s sqlc.CtxSummary) apitypes.SessionContextSummary {
+	return apitypes.SessionContextSummary{
+		Id:                      s.ID,
+		Kind:                    s.Kind,
+		Depth:                   int(s.Depth),
+		Content:                 s.Content,
+		TokenCount:              int(s.TokenCount),
+		EarliestAt:              parseTimePtr(s.EarliestAt),
+		LatestAt:                parseTimePtr(s.LatestAt),
+		DescendantCount:         int(s.DescendantCount),
+		DescendantTokenCount:    int(s.DescendantTokenCount),
+		SourceMessageTokenCount: int(s.SourceMessageTokenCount),
+		CreatedAt:               parseTime(s.CreatedAt),
+	}
 }
 
 // serializeDBMessages converts raw DB message rows to JSON-friendly maps,

--- a/internal/server/sessions.go
+++ b/internal/server/sessions.go
@@ -656,18 +656,27 @@ func (s *Server) GetSessionContextItems(w http.ResponseWriter, r *http.Request, 
 	}
 	usingMessageFallback := false
 	if len(rows) == 0 {
-		messages, err := s.q.GetMessagesByConversation(r.Context(), conv.ID)
+		// Distinguish "conversation predates ctx_item" from an out-of-range
+		// page token: only fall back to raw messages when no items exist.
+		count, err := s.q.GetContextItemCount(r.Context(), conv.ID)
 		if err != nil {
 			s.writeInternalError(w, err)
 			return
 		}
-		rows = contextRowsFromMessages(messages)
-		if offset < len(rows) {
-			rows = rows[offset:]
-		} else {
-			rows = nil
+		if count == 0 {
+			messages, err := s.q.GetMessagesByConversation(r.Context(), conv.ID)
+			if err != nil {
+				s.writeInternalError(w, err)
+				return
+			}
+			rows = contextRowsFromMessages(messages)
+			if offset < len(rows) {
+				rows = rows[offset:]
+			} else {
+				rows = nil
+			}
+			usingMessageFallback = true
 		}
-		usingMessageFallback = true
 	}
 	stats, err := s.q.GetContextStats(r.Context(), conv.ID)
 	if err != nil {
@@ -716,12 +725,15 @@ func (s *Server) GetSessionSummary(w http.ResponseWriter, r *http.Request, agent
 		}
 		return
 	}
-	children, err := s.q.GetSummaryChildren(r.Context(), summaryID)
+	// ctx_summary_parent rows are written as (summary_id=condensed,
+	// parent_summary_id=constituent), so "parents" is the downward direction:
+	// GetSummaryParents returns the sub-summaries a condensed node was built from.
+	children, err := s.q.GetSummaryParents(r.Context(), summaryID)
 	if err != nil {
 		s.writeInternalError(w, err)
 		return
 	}
-	seqRange, err := s.q.GetSummaryMessageSeqRange(r.Context(), summaryID)
+	from, to, err := s.summaryMessageSeqRange(r.Context(), summaryID)
 	if err != nil {
 		s.writeInternalError(w, err)
 		return
@@ -733,13 +745,48 @@ func (s *Server) GetSessionSummary(w http.ResponseWriter, r *http.Request, agent
 	for _, child := range children {
 		resp.Children = append(resp.Children, summaryToAPI(child))
 	}
-	if seqRange.MessageSeqFrom > 0 && seqRange.MessageSeqTo > 0 {
-		from := int(seqRange.MessageSeqFrom)
-		to := int(seqRange.MessageSeqTo)
+	if from > 0 && to > 0 {
 		resp.MessageSeqFrom = &from
 		resp.MessageSeqTo = &to
 	}
 	writeData(w, http.StatusOK, resp)
+}
+
+// summaryMessageSeqRange aggregates the covered message seq range across the
+// summary hierarchy: only leaf summaries carry ctx_summary_message links, so
+// condensed nodes walk down through their constituents.
+func (s *Server) summaryMessageSeqRange(ctx context.Context, summaryID string) (int, int, error) {
+	from, to := 0, 0
+	queue := []string{summaryID}
+	seen := map[string]bool{}
+	for len(queue) > 0 {
+		id := queue[0]
+		queue = queue[1:]
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		r, err := s.q.GetSummaryMessageSeqRange(ctx, id)
+		if err != nil {
+			return 0, 0, err
+		}
+		if r.MessageSeqFrom > 0 {
+			if from == 0 || int(r.MessageSeqFrom) < from {
+				from = int(r.MessageSeqFrom)
+			}
+			if int(r.MessageSeqTo) > to {
+				to = int(r.MessageSeqTo)
+			}
+		}
+		kids, err := s.q.GetSummaryParents(ctx, id)
+		if err != nil {
+			return 0, 0, err
+		}
+		for _, k := range kids {
+			queue = append(queue, k.ID)
+		}
+	}
+	return from, to, nil
 }
 
 func (s *Server) requireSessionConversation(w http.ResponseWriter, r *http.Request, agentID, sessionID string) (sqlc.CtxConversation, bool) {

--- a/pkg/db/sqlc/ctx_item.sql.go
+++ b/pkg/db/sqlc/ctx_item.sql.go
@@ -160,6 +160,43 @@ func (q *Queries) GetContextMessageItems(ctx context.Context, conversationID str
 	return items, nil
 }
 
+const getContextStats = `-- name: GetContextStats :one
+SELECT
+  (SELECT COUNT(*) FROM ctx_message cm WHERE cm.conversation_id = ?1) AS message_count,
+  (SELECT CAST(COALESCE(SUM(cm.token_count), 0) AS INTEGER) FROM ctx_message cm WHERE cm.conversation_id = ?1) AS source_token_count,
+  (SELECT CAST(COALESCE(SUM(
+        CASE
+            WHEN ci.item_type = 'message' THEN m.token_count
+            WHEN ci.item_type = 'summary' THEN s.token_count
+            ELSE 0
+        END
+    ), 0) AS INTEGER)
+   FROM ctx_item ci
+   LEFT JOIN ctx_message m ON ci.message_id = m.id
+   LEFT JOIN ctx_summary s ON ci.summary_id = s.id
+   WHERE ci.conversation_id = ?1) AS active_token_count,
+  (SELECT CAST(COALESCE(MAX(cs.depth), 0) AS INTEGER) FROM ctx_summary cs WHERE cs.conversation_id = ?1) AS summary_depth
+`
+
+type GetContextStatsRow struct {
+	MessageCount     int64 `json:"message_count"`
+	SourceTokenCount int64 `json:"source_token_count"`
+	ActiveTokenCount int64 `json:"active_token_count"`
+	SummaryDepth     int64 `json:"summary_depth"`
+}
+
+func (q *Queries) GetContextStats(ctx context.Context, conversationID string) (GetContextStatsRow, error) {
+	row := q.db.QueryRowContext(ctx, getContextStats, conversationID)
+	var i GetContextStatsRow
+	err := row.Scan(
+		&i.MessageCount,
+		&i.SourceTokenCount,
+		&i.ActiveTokenCount,
+		&i.SummaryDepth,
+	)
+	return i, err
+}
+
 const getContextTokenCount = `-- name: GetContextTokenCount :one
 SELECT CAST(
     COALESCE(SUM(
@@ -227,4 +264,110 @@ func (q *Queries) GetMaxContextOrdinal(ctx context.Context, conversationID strin
 	var column_1 int64
 	err := row.Scan(&column_1)
 	return column_1, err
+}
+
+const listContextItemsPage = `-- name: ListContextItemsPage :many
+SELECT
+  ci.ordinal,
+  ci.item_type,
+  ci.event_type,
+  m.id AS message_id,
+  m.seq AS message_seq,
+  m.role AS message_role,
+  m.event_type AS message_event_type,
+  m.content AS message_content,
+  m.token_count AS message_token_count,
+  m.created_at AS message_created_at,
+  s.id AS summary_id,
+  s.kind AS summary_kind,
+  s.depth AS summary_depth,
+  s.content AS summary_content,
+  s.token_count AS summary_token_count,
+  s.earliest_at AS summary_earliest_at,
+  s.latest_at AS summary_latest_at,
+  s.descendant_count AS summary_descendant_count,
+  s.descendant_token_count AS summary_descendant_token_count,
+  s.source_message_token_count AS summary_source_message_token_count,
+  s.created_at AS summary_created_at
+FROM ctx_item ci
+LEFT JOIN ctx_message m ON m.id = ci.message_id
+LEFT JOIN ctx_summary s ON s.id = ci.summary_id
+WHERE ci.conversation_id = ?1
+ORDER BY ci.ordinal ASC
+LIMIT ?3 OFFSET ?2
+`
+
+type ListContextItemsPageParams struct {
+	ConversationID string `json:"conversation_id"`
+	OffsetCount    int64  `json:"offset_count"`
+	LimitCount     int64  `json:"limit_count"`
+}
+
+type ListContextItemsPageRow struct {
+	Ordinal                        int64          `json:"ordinal"`
+	ItemType                       string         `json:"item_type"`
+	EventType                      string         `json:"event_type"`
+	MessageID                      sql.NullString `json:"message_id"`
+	MessageSeq                     sql.NullInt64  `json:"message_seq"`
+	MessageRole                    sql.NullString `json:"message_role"`
+	MessageEventType               sql.NullString `json:"message_event_type"`
+	MessageContent                 sql.NullString `json:"message_content"`
+	MessageTokenCount              sql.NullInt64  `json:"message_token_count"`
+	MessageCreatedAt               sql.NullString `json:"message_created_at"`
+	SummaryID                      sql.NullString `json:"summary_id"`
+	SummaryKind                    sql.NullString `json:"summary_kind"`
+	SummaryDepth                   sql.NullInt64  `json:"summary_depth"`
+	SummaryContent                 sql.NullString `json:"summary_content"`
+	SummaryTokenCount              sql.NullInt64  `json:"summary_token_count"`
+	SummaryEarliestAt              sql.NullString `json:"summary_earliest_at"`
+	SummaryLatestAt                sql.NullString `json:"summary_latest_at"`
+	SummaryDescendantCount         sql.NullInt64  `json:"summary_descendant_count"`
+	SummaryDescendantTokenCount    sql.NullInt64  `json:"summary_descendant_token_count"`
+	SummarySourceMessageTokenCount sql.NullInt64  `json:"summary_source_message_token_count"`
+	SummaryCreatedAt               sql.NullString `json:"summary_created_at"`
+}
+
+func (q *Queries) ListContextItemsPage(ctx context.Context, arg ListContextItemsPageParams) ([]ListContextItemsPageRow, error) {
+	rows, err := q.db.QueryContext(ctx, listContextItemsPage, arg.ConversationID, arg.OffsetCount, arg.LimitCount)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListContextItemsPageRow{}
+	for rows.Next() {
+		var i ListContextItemsPageRow
+		if err := rows.Scan(
+			&i.Ordinal,
+			&i.ItemType,
+			&i.EventType,
+			&i.MessageID,
+			&i.MessageSeq,
+			&i.MessageRole,
+			&i.MessageEventType,
+			&i.MessageContent,
+			&i.MessageTokenCount,
+			&i.MessageCreatedAt,
+			&i.SummaryID,
+			&i.SummaryKind,
+			&i.SummaryDepth,
+			&i.SummaryContent,
+			&i.SummaryTokenCount,
+			&i.SummaryEarliestAt,
+			&i.SummaryLatestAt,
+			&i.SummaryDescendantCount,
+			&i.SummaryDescendantTokenCount,
+			&i.SummarySourceMessageTokenCount,
+			&i.SummaryCreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }

--- a/pkg/db/sqlc/ctx_summary.sql.go
+++ b/pkg/db/sqlc/ctx_summary.sql.go
@@ -230,6 +230,27 @@ func (q *Queries) GetSummaryChildren(ctx context.Context, parentSummaryID string
 	return items, nil
 }
 
+const getSummaryMessageSeqRange = `-- name: GetSummaryMessageSeqRange :one
+SELECT
+  CAST(COALESCE(MIN(m.seq), 0) AS INTEGER) AS message_seq_from,
+  CAST(COALESCE(MAX(m.seq), 0) AS INTEGER) AS message_seq_to
+FROM ctx_summary_message sm
+JOIN ctx_message m ON sm.message_id = m.id
+WHERE sm.summary_id = ?
+`
+
+type GetSummaryMessageSeqRangeRow struct {
+	MessageSeqFrom int64 `json:"message_seq_from"`
+	MessageSeqTo   int64 `json:"message_seq_to"`
+}
+
+func (q *Queries) GetSummaryMessageSeqRange(ctx context.Context, summaryID string) (GetSummaryMessageSeqRangeRow, error) {
+	row := q.db.QueryRowContext(ctx, getSummaryMessageSeqRange, summaryID)
+	var i GetSummaryMessageSeqRangeRow
+	err := row.Scan(&i.MessageSeqFrom, &i.MessageSeqTo)
+	return i, err
+}
+
 const getSummaryMessages = `-- name: GetSummaryMessages :many
 SELECT m.id, m.conversation_id, m.seq, m.role, m.event_type, m.content, m.token_count, m.created_at FROM ctx_message m
 JOIN ctx_summary_message sm ON sm.message_id = m.id

--- a/web/src/components/chat/ChatTranscript.tsx
+++ b/web/src/components/chat/ChatTranscript.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useMemo } from "react";
+import { forwardRef, useMemo, type ReactNode } from "react";
 import { useI18n } from "@/lib/i18n";
 import type { ContentBlock } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -26,6 +26,8 @@ interface Props {
   fileAgentId?: string;
   fileSessionId?: string;
   agentNames?: Map<string, string>;
+  /* Rendered inside the scroll container above the messages (e.g. epoch summaries). */
+  header?: ReactNode;
 }
 
 interface Annotated extends TranscriptMessage {
@@ -43,7 +45,7 @@ function annotate(messages: TranscriptMessage[]): Annotated[] {
 }
 
 export const ChatTranscript = forwardRef<HTMLDivElement, Props>(function ChatTranscript(
-  { messages, loading, onScroll, fileAgentId, fileSessionId, agentNames },
+  { messages, loading, onScroll, fileAgentId, fileSessionId, agentNames, header },
   ref,
 ) {
   const { t } = useI18n();
@@ -63,7 +65,8 @@ export const ChatTranscript = forwardRef<HTMLDivElement, Props>(function ChatTra
           </span>
         </div>
       )}
-      {messages.length === 0 && !loading && (
+      {header}
+      {messages.length === 0 && !loading && !header && (
         <div className="py-20 text-center">
           <p className="font-mono text-xs text-muted-foreground/60">
             {t("sessions.transcript.empty")}

--- a/web/src/features/sessions/InspectorPanel.tsx
+++ b/web/src/features/sessions/InspectorPanel.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ChevronDown, FileText, Wrench } from "lucide-react";
-import { getSessionMessages, getSessionSystemPrompt, listTools } from "@/lib/api-client";
-import type { Message, Session, Tool, Workspace } from "@/lib/types";
+import { useQuery } from "@tanstack/react-query";
+import { getSessionSystemPrompt, listTools } from "@/lib/api-client";
+import type { Session, Tool, Workspace } from "@/lib/types";
+import { sessionContextItemsOptions } from "@/lib/queries/session-context";
 import { cn } from "@/lib/utils";
 import { useI18n } from "@/lib/i18n";
 import { WorkspacePanel } from "./WorkspacePanel";
@@ -109,38 +111,22 @@ function ContextMonitor({ session }: { agentID: string; session: Session | null 
     tools: false,
     prompt: false,
   });
-  const [messages, setMessages] = useState<Message[]>([]);
-  const [messagesLoading, setMessagesLoading] = useState(false);
   const [systemPrompt, setSystemPrompt] = useState("");
   const [promptLoading, setPromptLoading] = useState(false);
   const [tools, setTools] = useState<Tool[]>([]);
   const [toolsLoading, setToolsLoading] = useState(false);
 
+  const contextQuery = useQuery(
+    sessionContextItemsOptions(session?.agent_id ?? "", session?.id ?? ""),
+  );
+
   useEffect(() => {
     if (!session) {
-      setMessages([]);
       setSystemPrompt("");
       return;
     }
 
     let cancelled = false;
-    setMessagesLoading(true);
-    getSessionMessages({
-      path: { agentId: session.agent_id, sessionId: session.id },
-      query: { limit: 1000 },
-      throwOnError: true,
-    })
-      .then(({ data }) => {
-        if (!cancelled) setMessages((data?.messages as unknown as Message[] | undefined) ?? []);
-      })
-      .catch((e) => {
-        console.error(e);
-        if (!cancelled) setMessages([]);
-      })
-      .finally(() => {
-        if (!cancelled) setMessagesLoading(false);
-      });
-
     setPromptLoading(true);
     getSessionSystemPrompt({
       path: { agentId: session.agent_id, sessionId: session.id },
@@ -228,8 +214,8 @@ function ContextMonitor({ session }: { agentID: string; session: Session | null 
           {session && (
             <SessionContextCard
               session={session}
-              messages={messages}
-              messagesLoading={messagesLoading}
+              meta={contextQuery.data?.meta}
+              metaLoading={contextQuery.isLoading}
             />
           )}
         </ContextSectionCard>
@@ -287,18 +273,22 @@ function ContextSectionCard({
 
 function SessionContextCard({
   session,
-  messages,
-  messagesLoading,
+  meta,
+  metaLoading,
 }: {
   session: Session;
-  messages: Message[];
-  messagesLoading: boolean;
+  meta?: {
+    message_count: number;
+    source_token_count: number;
+    active_token_count: number;
+    summary_depth: number;
+  };
+  metaLoading: boolean;
 }) {
   const { t } = useI18n();
   const copyID = useCallback(() => {
     navigator.clipboard.writeText(session.id).catch(console.error);
   }, [session.id]);
-  const sessionTotalTokens = messages.reduce((sum, message) => sum + (message.token_count ?? 0), 0);
   const agentName = (session as Session & { agent_name?: string }).agent_name || session.agent_id;
 
   return (
@@ -326,13 +316,23 @@ function SessionContextCard({
           {t("sessions.inspector.messages")}
         </dt>
         <dd className="truncate text-foreground font-medium">
-          {messagesLoading ? "..." : messages.length.toLocaleString()}
+          {metaLoading ? "..." : (meta?.message_count ?? 0).toLocaleString()}
         </dd>
         <dt className="text-muted-foreground font-semibold text-[10px]">
           {t("sessions.inspector.tokens")}
         </dt>
         <dd className="truncate text-foreground font-medium">
-          {messagesLoading ? "..." : sessionTotalTokens.toLocaleString()}
+          {metaLoading
+            ? "..."
+            : `${(meta?.active_token_count ?? 0).toLocaleString()} / ${(meta?.source_token_count ?? 0).toLocaleString()}`}
+        </dd>
+        <dt className="text-muted-foreground font-semibold text-[10px]">
+          {t("sessions.inspector.longTerm")}
+        </dt>
+        <dd className="truncate text-foreground font-medium">
+          {metaLoading
+            ? "..."
+            : t("sessions.inspector.summaryDepth", { count: meta?.summary_depth ?? 0 })}
         </dd>
         <dt className="text-muted-foreground font-semibold text-[10px]">
           {t("sessions.inspector.sessionId")}

--- a/web/src/features/sessions/SessionDetail.tsx
+++ b/web/src/features/sessions/SessionDetail.tsx
@@ -7,6 +7,7 @@ import { useI18n } from "@/lib/i18n";
 import { getSessionMessages, uploadWorkspaceFile } from "@/lib/api-client/sdk.gen";
 import { agentSkillsOptions } from "@/lib/queries/agents";
 import { inboxQueryOptions } from "@/lib/queries/inbox";
+import { sessionContextItemsOptions } from "@/lib/queries/session-context";
 import type { Message, Session } from "@/lib/types";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "@/components/ui/tooltip";
@@ -75,6 +76,9 @@ export function SessionDetail({
 
   const { data: skills = [] } = useQuery(agentSkillsOptions(agentId));
   const { data: inbox } = useQuery(inboxQueryOptions(agentId, 5));
+  const contextItemsQuery = useQuery(sessionContextItemsOptions(agentId, sessionId));
+  const hasContextSummaries =
+    contextItemsQuery.data?.items.some((item) => item.type === "summary") ?? false;
   const attentionItems = inbox?.items ?? [];
   const composerSkills = useMemo(
     () => [
@@ -104,7 +108,7 @@ export function SessionDetail({
 
   const messagesQuery = useInfiniteQuery({
     queryKey: ["session-messages", session?.id],
-    enabled: !!session,
+    enabled: !!session && contextItemsQuery.isSuccess && !hasContextSummaries,
     initialPageParam: 0,
     queryFn: async ({ pageParam }) => {
       const { data } = await getSessionMessages({
@@ -330,6 +334,8 @@ export function SessionDetail({
             ref={transcriptRef}
             messages={messages}
             messagesLoading={messagesQuery.isLoading || messagesQuery.isFetchingNextPage}
+            contextItems={contextItemsQuery.data?.items}
+            contextLoading={contextItemsQuery.isLoading}
             onScroll={handleTranscriptScroll}
             agentId={agentId}
             sessionId={sessionId}

--- a/web/src/features/sessions/SessionDetail.tsx
+++ b/web/src/features/sessions/SessionDetail.tsx
@@ -108,7 +108,12 @@ export function SessionDetail({
 
   const messagesQuery = useInfiniteQuery({
     queryKey: ["session-messages", session?.id],
-    enabled: !!session && contextItemsQuery.isSuccess && !hasContextSummaries,
+    // Paged history is only for uncompacted sessions; compacted ones load
+    // their tail via the seq-range query below. If the context-items request
+    // fails we fall back to plain paging rather than showing nothing.
+    enabled:
+      !!session &&
+      (contextItemsQuery.isError || (contextItemsQuery.isSuccess && !hasContextSummaries)),
     initialPageParam: 0,
     queryFn: async ({ pageParam }) => {
       const { data } = await getSessionMessages({
@@ -122,11 +127,43 @@ export function SessionDetail({
       lastPage.length === 20 ? allPages.reduce((sum, page) => sum + page.length, 0) : undefined,
   });
 
+  // In a compacted session the live tail is the message-type context items;
+  // fetch them as full messages so they render through the normal chat
+  // pipeline instead of as raw context blobs.
+  const tailSeqRange = useMemo(() => {
+    const items = contextItemsQuery.data?.items;
+    if (!items) return null;
+    const seqs = items
+      .filter((item) => item.type === "message" && item.message)
+      .map((item) => item.message!.seq);
+    if (seqs.length === 0) return null;
+    return { from: Math.min(...seqs), to: Math.max(...seqs) };
+  }, [contextItemsQuery.data]);
+
+  const tailQuery = useQuery({
+    queryKey: ["session-tail-messages", session?.id, tailSeqRange?.from, tailSeqRange?.to],
+    enabled: !!session && hasContextSummaries && !!tailSeqRange,
+    queryFn: async () => {
+      const { data } = await getSessionMessages({
+        path: { agentId, sessionId },
+        query: { seq_from: tailSeqRange!.from, seq_to: tailSeqRange!.to },
+        throwOnError: true,
+      });
+      return (data?.messages as unknown as Message[] | undefined) ?? [];
+    },
+  });
+
+  const historyMessages = useMemo(() => {
+    if (hasContextSummaries) return tailQuery.data ?? null;
+    if (!messagesQuery.data) return null;
+    return [...messagesQuery.data.pages].reverse().flat();
+  }, [hasContextSummaries, tailQuery.data, messagesQuery.data]);
+
   const historicalIDsRef = useRef(new Set<string>());
 
   useEffect(() => {
-    if (!messagesQuery.data) return;
-    const merged = mergeToolResults([...messagesQuery.data.pages].reverse().flat());
+    if (!historyMessages) return;
+    const merged = mergeToolResults(historyMessages);
     if (merged.length === 0) return;
     const uiMessages = merged.map(messageToUIMessage);
     const newIDs = new Set(uiMessages.map((m) => m.id));
@@ -135,7 +172,7 @@ export function SessionDetail({
       const liveSlice = prev.filter((m) => !newIDs.has(m.id));
       return [...uiMessages, ...liveSlice];
     });
-  }, [messagesQuery.data, setChatMessages]);
+  }, [historyMessages, setChatMessages]);
 
   const messages = useMemo(() => chatMessages.map(uiMessageToMessage), [chatMessages]);
 
@@ -150,16 +187,19 @@ export function SessionDetail({
     shouldAutoScrollRef.current = true;
   }, [session?.id]);
 
+  const historyReady = hasContextSummaries
+    ? !tailSeqRange || tailQuery.isSuccess
+    : messagesQuery.isSuccess;
+
   useEffect(() => {
-    if (!session || !messagesQuery.isSuccess || initialScrollSessionRef.current === session.id)
-      return;
+    if (!session || !historyReady || initialScrollSessionRef.current === session.id) return;
     initialScrollSessionRef.current = session.id;
     shouldAutoScrollRef.current = true;
     setTimeout(() => {
       if (transcriptRef.current)
         transcriptRef.current.scrollTop = transcriptRef.current.scrollHeight;
     }, 0);
-  }, [session, messagesQuery.isSuccess]);
+  }, [session, historyReady]);
 
   // Auto-scroll to bottom as new messages stream in (if the user is already near the bottom)
   useEffect(() => {
@@ -173,8 +213,11 @@ export function SessionDetail({
   }, [messages]);
 
   const loadOlderMessages = useCallback(async () => {
+    // Compacted sessions have no older pages to load: everything before the
+    // tail is folded into the epoch summaries shown above the transcript.
     if (
       !session ||
+      hasContextSummaries ||
       !transcriptRef.current ||
       !messagesQuery.hasNextPage ||
       messagesQuery.isFetching
@@ -187,7 +230,7 @@ export function SessionDetail({
     setTimeout(() => {
       if (el) el.scrollTop = el.scrollHeight - prevHeight;
     }, 0);
-  }, [session, messagesQuery]);
+  }, [session, hasContextSummaries, messagesQuery]);
 
   const handleTranscriptScroll = useCallback(() => {
     void loadOlderMessages();
@@ -333,7 +376,11 @@ export function SessionDetail({
           <Transcript
             ref={transcriptRef}
             messages={messages}
-            messagesLoading={messagesQuery.isLoading || messagesQuery.isFetchingNextPage}
+            messagesLoading={
+              hasContextSummaries
+                ? tailQuery.isLoading
+                : messagesQuery.isLoading || messagesQuery.isFetchingNextPage
+            }
             contextItems={contextItemsQuery.data?.items}
             contextLoading={contextItemsQuery.isLoading}
             onScroll={handleTranscriptScroll}

--- a/web/src/features/sessions/Transcript.tsx
+++ b/web/src/features/sessions/Transcript.tsx
@@ -5,7 +5,7 @@ import { Archive, ChevronDown, MessageSquareText } from "lucide-react";
 import { agentsQueryOptions } from "@/lib/queries/agents";
 import { sessionSummaryOptions } from "@/lib/queries/session-context";
 import { getSessionMessages } from "@/lib/api-client/sdk.gen";
-import type { SessionContextItem, SessionContextMessage } from "@/lib/api-client/types.gen";
+import type { SessionContextItem } from "@/lib/api-client/types.gen";
 import { ChatTranscript, type TranscriptMessage } from "@/components/chat/ChatTranscript";
 import { Button } from "@/components/ui/button";
 import { useI18n } from "@/lib/i18n";
@@ -59,34 +59,23 @@ export const Transcript = forwardRef<HTMLDivElement, Props>(function Transcript(
     }));
   }, [messages, agentName, agentId, activeStreaming]);
 
-  if (hasSummaries) {
-    return (
-      <div
-        ref={ref}
-        onScroll={onScroll}
-        className="min-h-0 flex-1 overflow-y-auto bg-background px-4 py-4"
-      >
-        <div className="mx-auto flex w-full max-w-3xl flex-col gap-3">
-          {contextItems.map((item) =>
-            item.type === "summary" && item.summary ? (
-              <SummaryCard
-                key={`summary:${item.summary.id}`}
-                agentId={agentId}
-                sessionId={sessionId}
-                item={item}
-              />
-            ) : item.message ? (
-              <ContextMessageBubble
-                key={`message:${item.message.id}`}
-                message={item.message}
-                agentName={agentName}
-              />
-            ) : null,
-          )}
-        </div>
-      </div>
-    );
-  }
+  // Compacted epochs render as summary cards above the live tail; the tail
+  // messages themselves flow through the regular chat pipeline so tool calls,
+  // markdown, and streaming render identically to an uncompacted session.
+  const epochHeader = hasSummaries ? (
+    <div className="mx-auto mb-8 flex w-full max-w-3xl flex-col gap-3">
+      {contextItems.map((item) =>
+        item.type === "summary" && item.summary ? (
+          <SummaryCard
+            key={`summary:${item.summary.id}`}
+            agentId={agentId}
+            sessionId={sessionId}
+            item={item}
+          />
+        ) : null,
+      )}
+    </div>
+  ) : undefined;
 
   return (
     <ChatTranscript
@@ -96,6 +85,7 @@ export const Transcript = forwardRef<HTMLDivElement, Props>(function Transcript(
       onScroll={onScroll}
       fileAgentId={agentId}
       fileSessionId={sessionId}
+      header={epochHeader}
     />
   );
 });
@@ -153,7 +143,7 @@ function SummaryCard({
             {summary.content}
           </span>
           <span className="mt-2 block font-mono text-[10px] text-muted-foreground">
-            {summary.descendant_count} {t("sessions.epoch.messages")} ·{" "}
+            {t("sessions.epoch.messageCount", { count: summary.descendant_count })} ·{" "}
             {formatNumber(summary.source_message_token_count)} → {formatNumber(summary.token_count)}
           </span>
         </span>
@@ -166,6 +156,17 @@ function SummaryCard({
           <p className="whitespace-pre-wrap text-xs leading-relaxed text-foreground">
             {summaryQuery.data?.summary.content ?? summary.content}
           </p>
+          {(summaryQuery.data?.children.length ?? 0) > 0 && (
+            <div className="mt-3 space-y-2">
+              {summaryQuery.data?.children.map((child) => (
+                <div key={child.id} className="rounded-md border border-border bg-background p-2">
+                  <p className="line-clamp-3 whitespace-pre-wrap text-xs leading-relaxed text-muted-foreground">
+                    {child.content}
+                  </p>
+                </div>
+              ))}
+            </div>
+          )}
           <div className="mt-3 flex items-center gap-2">
             <Button variant="outline" size="xs" onClick={() => setShowMessages((value) => !value)}>
               <MessageSquareText className="size-3.5" />
@@ -194,38 +195,26 @@ function SummaryCard({
   );
 }
 
-function ContextMessageBubble({
-  message,
-  agentName,
-}: {
-  message: SessionContextMessage;
-  agentName: string;
-}) {
-  const isUser = message.role === "user";
-  return (
-    <div className={cn("flex", isUser ? "justify-end" : "justify-start")}>
-      <div
-        className={cn(
-          "max-w-[78%] rounded-lg border px-3 py-2 text-sm leading-relaxed",
-          isUser ? "border-primary/20 bg-primary text-primary-foreground" : "border-border bg-card",
-        )}
-      >
-        {!isUser && (
-          <div className="mb-1 text-[10px] font-medium text-muted-foreground">{agentName}</div>
-        )}
-        <div className="whitespace-pre-wrap">{message.content}</div>
-      </div>
-    </div>
-  );
-}
-
 function formatNumber(value: number): string {
   if (value >= 1000) return `${(value / 1000).toFixed(1)}k`;
   return String(value);
 }
 
 function formatRawMessage(message: Record<string, unknown>): string {
-  if (typeof message.content === "string") return message.content;
+  if (typeof message.content === "string" && message.content.trim()) return message.content;
+  if (Array.isArray(message.blocks)) {
+    const parts = (message.blocks as Array<Record<string, unknown>>)
+      .map((block) => {
+        if (block.type === "text" && typeof block.text === "string") return block.text;
+        if (block.type === "tool_call") {
+          const name = typeof block.name === "string" ? block.name : "unknown";
+          return `[tool: ${name}]`;
+        }
+        return null;
+      })
+      .filter(Boolean);
+    if (parts.length > 0) return parts.join("\n");
+  }
   return JSON.stringify(message.blocks ?? message, null, 2);
 }
 

--- a/web/src/features/sessions/Transcript.tsx
+++ b/web/src/features/sessions/Transcript.tsx
@@ -1,8 +1,15 @@
-import { forwardRef, useMemo } from "react";
+import { forwardRef, useMemo, useState } from "react";
 import type { Message } from "@/lib/types";
 import { useQuery } from "@tanstack/react-query";
+import { Archive, ChevronDown, MessageSquareText } from "lucide-react";
 import { agentsQueryOptions } from "@/lib/queries/agents";
+import { sessionSummaryOptions } from "@/lib/queries/session-context";
+import { getSessionMessages } from "@/lib/api-client/sdk.gen";
+import type { SessionContextItem, SessionContextMessage } from "@/lib/api-client/types.gen";
 import { ChatTranscript, type TranscriptMessage } from "@/components/chat/ChatTranscript";
+import { Button } from "@/components/ui/button";
+import { useI18n } from "@/lib/i18n";
+import { cn } from "@/lib/utils";
 
 interface Props {
   messages: Message[];
@@ -11,14 +18,26 @@ interface Props {
   agentId: string;
   sessionId: string;
   activeStreaming?: boolean;
+  contextItems?: SessionContextItem[];
+  contextLoading?: boolean;
 }
 
 export const Transcript = forwardRef<HTMLDivElement, Props>(function Transcript(
-  { messages, messagesLoading, onScroll, agentId, sessionId, activeStreaming },
+  {
+    messages,
+    messagesLoading,
+    onScroll,
+    agentId,
+    sessionId,
+    activeStreaming,
+    contextItems = [],
+    contextLoading = false,
+  },
   ref,
 ) {
   const { data: agents = [] } = useQuery(agentsQueryOptions);
   const agentName = agents.find((a) => a.id === agentId)?.name ?? "Agent";
+  const hasSummaries = contextItems.some((item) => item.type === "summary");
 
   const transcriptMessages = useMemo((): TranscriptMessage[] => {
     const filtered = messages.filter((m) => m.role !== "tool");
@@ -40,17 +59,175 @@ export const Transcript = forwardRef<HTMLDivElement, Props>(function Transcript(
     }));
   }, [messages, agentName, agentId, activeStreaming]);
 
+  if (hasSummaries) {
+    return (
+      <div
+        ref={ref}
+        onScroll={onScroll}
+        className="min-h-0 flex-1 overflow-y-auto bg-background px-4 py-4"
+      >
+        <div className="mx-auto flex w-full max-w-3xl flex-col gap-3">
+          {contextItems.map((item) =>
+            item.type === "summary" && item.summary ? (
+              <SummaryCard
+                key={`summary:${item.summary.id}`}
+                agentId={agentId}
+                sessionId={sessionId}
+                item={item}
+              />
+            ) : item.message ? (
+              <ContextMessageBubble
+                key={`message:${item.message.id}`}
+                message={item.message}
+                agentName={agentName}
+              />
+            ) : null,
+          )}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <ChatTranscript
       ref={ref}
       messages={transcriptMessages}
-      loading={messagesLoading}
+      loading={messagesLoading || contextLoading}
       onScroll={onScroll}
       fileAgentId={agentId}
       fileSessionId={sessionId}
     />
   );
 });
+
+function SummaryCard({
+  agentId,
+  sessionId,
+  item,
+}: {
+  agentId: string;
+  sessionId: string;
+  item: SessionContextItem;
+}) {
+  const { t } = useI18n();
+  const [open, setOpen] = useState(false);
+  const [showMessages, setShowMessages] = useState(false);
+  const summary = item.summary;
+  const summaryQuery = useQuery({
+    ...sessionSummaryOptions(agentId, sessionId, summary?.id ?? ""),
+    enabled: open && !!summary?.id,
+  });
+  const from = summaryQuery.data?.message_seq_from;
+  const to = summaryQuery.data?.message_seq_to;
+  const rangeReady = typeof from === "number" && typeof to === "number";
+  const messagesQuery = useQuery({
+    queryKey: ["session-summary-messages", agentId, sessionId, from, to],
+    queryFn: async () => {
+      const { data } = await getSessionMessages({
+        path: { agentId, sessionId },
+        query: { seq_from: from as number, seq_to: to as number },
+        throwOnError: true,
+      });
+      return data.messages;
+    },
+    enabled: showMessages && rangeReady,
+  });
+
+  if (!summary) return null;
+
+  return (
+    <section className="rounded-lg border border-border bg-muted/20">
+      <button
+        type="button"
+        className="flex w-full items-start gap-3 px-4 py-3 text-left"
+        onClick={() => setOpen((value) => !value)}
+      >
+        <span className="grid size-8 shrink-0 place-items-center rounded-md border border-border bg-background text-muted-foreground">
+          <Archive className="size-4" />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block text-xs font-semibold text-foreground">
+            {t("sessions.epoch.summary")}
+          </span>
+          <span className="mt-1 block line-clamp-2 text-xs leading-relaxed text-muted-foreground">
+            {summary.content}
+          </span>
+          <span className="mt-2 block font-mono text-[10px] text-muted-foreground">
+            {summary.descendant_count} {t("sessions.epoch.messages")} ·{" "}
+            {formatNumber(summary.source_message_token_count)} → {formatNumber(summary.token_count)}
+          </span>
+        </span>
+        <ChevronDown
+          className={cn("mt-1 size-4 shrink-0 transition-transform", open && "rotate-180")}
+        />
+      </button>
+      {open && (
+        <div className="border-t border-border px-4 py-3">
+          <p className="whitespace-pre-wrap text-xs leading-relaxed text-foreground">
+            {summaryQuery.data?.summary.content ?? summary.content}
+          </p>
+          <div className="mt-3 flex items-center gap-2">
+            <Button variant="outline" size="xs" onClick={() => setShowMessages((value) => !value)}>
+              <MessageSquareText className="size-3.5" />
+              {t("sessions.epoch.originalMessages")}
+            </Button>
+          </div>
+          {showMessages && (
+            <div className="mt-3 space-y-2">
+              {messagesQuery.isLoading ? (
+                <p className="text-xs text-muted-foreground">{t("common.loading")}</p>
+              ) : (
+                messagesQuery.data?.map((message, index) => (
+                  <pre
+                    key={index}
+                    className="whitespace-pre-wrap rounded-md border border-border bg-background p-2 text-xs text-muted-foreground"
+                  >
+                    {formatRawMessage(message)}
+                  </pre>
+                ))
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function ContextMessageBubble({
+  message,
+  agentName,
+}: {
+  message: SessionContextMessage;
+  agentName: string;
+}) {
+  const isUser = message.role === "user";
+  return (
+    <div className={cn("flex", isUser ? "justify-end" : "justify-start")}>
+      <div
+        className={cn(
+          "max-w-[78%] rounded-lg border px-3 py-2 text-sm leading-relaxed",
+          isUser ? "border-primary/20 bg-primary text-primary-foreground" : "border-border bg-card",
+        )}
+      >
+        {!isUser && (
+          <div className="mb-1 text-[10px] font-medium text-muted-foreground">{agentName}</div>
+        )}
+        <div className="whitespace-pre-wrap">{message.content}</div>
+      </div>
+    </div>
+  );
+}
+
+function formatNumber(value: number): string {
+  if (value >= 1000) return `${(value / 1000).toFixed(1)}k`;
+  return String(value);
+}
+
+function formatRawMessage(message: Record<string, unknown>): string {
+  if (typeof message.content === "string") return message.content;
+  return JSON.stringify(message.blocks ?? message, null, 2);
+}
 
 function mergeConsecutiveMessages(messages: Message[]): Message[] {
   const result: Message[] = [];

--- a/web/src/lib/i18n/messages.ts
+++ b/web/src/lib/i18n/messages.ts
@@ -1112,6 +1112,11 @@ const en = {
   "sessions.inspector.available": "{{count}} available",
   "sessions.inspector.loading": "Loading",
   "sessions.inspector.files": "Files",
+  "sessions.inspector.longTerm": "Long-term",
+  "sessions.inspector.summaryDepth": "{{count}} layers",
+  "sessions.epoch.summary": "Compacted epoch",
+  "sessions.epoch.messages": "messages",
+  "sessions.epoch.originalMessages": "Original messages",
 
   // Sidebar (additions)
   "sessions.sidebar.projects": "Projects",
@@ -2348,6 +2353,11 @@ const zh: Record<MessageKey, string> = {
   "sessions.inspector.available": "{{count}} 个可用",
   "sessions.inspector.loading": "加载中",
   "sessions.inspector.files": "文件",
+  "sessions.inspector.longTerm": "长期层",
+  "sessions.inspector.summaryDepth": "{{count}} 层",
+  "sessions.epoch.summary": "折叠片段",
+  "sessions.epoch.messages": "条消息",
+  "sessions.epoch.originalMessages": "原始消息",
 
   // Sidebar (additions)
   "sessions.sidebar.projects": "项目",

--- a/web/src/lib/i18n/messages.ts
+++ b/web/src/lib/i18n/messages.ts
@@ -1115,7 +1115,7 @@ const en = {
   "sessions.inspector.longTerm": "Long-term",
   "sessions.inspector.summaryDepth": "{{count}} layers",
   "sessions.epoch.summary": "Compacted epoch",
-  "sessions.epoch.messages": "messages",
+  "sessions.epoch.messageCount": "{{count}} messages",
   "sessions.epoch.originalMessages": "Original messages",
 
   // Sidebar (additions)
@@ -2356,7 +2356,7 @@ const zh: Record<MessageKey, string> = {
   "sessions.inspector.longTerm": "长期层",
   "sessions.inspector.summaryDepth": "{{count}} 层",
   "sessions.epoch.summary": "折叠片段",
-  "sessions.epoch.messages": "条消息",
+  "sessions.epoch.messageCount": "{{count}} 条消息",
   "sessions.epoch.originalMessages": "原始消息",
 
   // Sidebar (additions)

--- a/web/src/lib/queries/session-context.ts
+++ b/web/src/lib/queries/session-context.ts
@@ -1,0 +1,31 @@
+import { queryOptions } from "@tanstack/react-query";
+import { getSessionContextItems, getSessionSummary } from "@/lib/api-client/sdk.gen";
+
+export function sessionContextItemsOptions(agentId: string, sessionId: string) {
+  return queryOptions({
+    queryKey: ["session-context-items", agentId, sessionId],
+    queryFn: async () => {
+      const { data } = await getSessionContextItems({
+        path: { agentId, sessionId },
+        query: { page_size: 200 },
+        throwOnError: true,
+      });
+      return data;
+    },
+    enabled: !!agentId && !!sessionId,
+  });
+}
+
+export function sessionSummaryOptions(agentId: string, sessionId: string, summaryId: string) {
+  return queryOptions({
+    queryKey: ["session-summary", agentId, sessionId, summaryId],
+    queryFn: async () => {
+      const { data } = await getSessionSummary({
+        path: { agentId, sessionId, summaryId },
+        throwOnError: true,
+      });
+      return data;
+    },
+    enabled: !!agentId && !!sessionId && !!summaryId,
+  });
+}

--- a/web/src/lib/queries/session-context.ts
+++ b/web/src/lib/queries/session-context.ts
@@ -1,16 +1,29 @@
 import { queryOptions } from "@tanstack/react-query";
 import { getSessionContextItems, getSessionSummary } from "@/lib/api-client/sdk.gen";
+import type { SessionContextItem, SessionContextMeta } from "@/lib/api-client/types.gen";
 
 export function sessionContextItemsOptions(agentId: string, sessionId: string) {
   return queryOptions({
     queryKey: ["session-context-items", agentId, sessionId],
-    queryFn: async () => {
-      const { data } = await getSessionContextItems({
-        path: { agentId, sessionId },
-        query: { page_size: 200 },
-        throwOnError: true,
-      });
-      return data;
+    queryFn: async (): Promise<{ items: SessionContextItem[]; meta?: SessionContextMeta }> => {
+      // Compaction keeps the active window bounded, so the full ordinal
+      // sequence is small; drain all pages instead of truncating the newest
+      // items. The loop cap is a runaway guard.
+      const items: SessionContextItem[] = [];
+      let meta: SessionContextMeta | undefined;
+      let pageToken: string | undefined;
+      for (let page = 0; page < 20; page++) {
+        const { data } = await getSessionContextItems({
+          path: { agentId, sessionId },
+          query: { page_size: 200, page_token: pageToken },
+          throwOnError: true,
+        });
+        items.push(...(data.items ?? []));
+        meta = data.meta;
+        pageToken = data.next_page_token ?? undefined;
+        if (!pageToken) break;
+      }
+      return { items, meta };
     },
     enabled: !!agentId && !!sessionId,
   });


### PR DESCRIPTION
## What

Expose compacted session context to the web UI and render compressed epochs in the transcript.

## Why

Long-lived agent sessions cannot stay navigable if the UI only shows a flat message list. The backend already stores `ctx_item`/`ctx_summary`; this PR gives the web app a read-only surface for that structure and avoids fetching the full message history on compressed sessions.

## How

- Add OpenAPI endpoints for session `context-items` and summary detail, plus optional `seq_from`/`seq_to` message filters.
- Add sqlc queries and server handlers for context item paging, context meta, summary detail, and covered-message seq ranges.
- Add server tests for item ordering, summary seq references, seq range messages, no-`ctx_item` fallback paging, and fallback token stats.
- Render summary epoch cards in `Transcript`, lazily loading summary detail and original messages only when expanded.
- Update the inspector long-term layer to use context meta instead of pulling 1000 messages.

`next scheduled trigger` is intentionally not implemented here: current scheduler APIs do not expose a per-session computed next-run concept. Better to define that in scheduler scope than fake it in the transcript UI.

## Refs

Refs #352
Stacked on #359