### PR TITLE
feat(cli): manage job-template subscriptions via stella scheduler

### DIFF
--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -2051,6 +2051,10 @@ components:
           type: string
           nullable: true
           description: "ID of the current user's active subscription instance, or null if not subscribed."
+        subscribed_agent_id:
+          type: string
+          nullable: true
+          description: "Agent that owns the current user's subscription job; set when subscribed_job_id is set."
     JobTemplateList:
       type: object
       required: [job_templates]

--- a/api/spec/domain/scheduler/schemas.yaml
+++ b/api/spec/domain/scheduler/schemas.yaml
@@ -148,6 +148,11 @@ components:
           nullable: true,
           description: "ID of the current user's active subscription instance, or null if not subscribed.",
         }
+        subscribed_agent_id: {
+          type: string,
+          nullable: true,
+          description: "Agent that owns the current user's subscription job; set when subscribed_job_id is set.",
+        }
 
     JobTemplateList:
       type: object

--- a/cmd/stella/scheduler.go
+++ b/cmd/stella/scheduler.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	ucli "github.com/urfave/cli/v2"
@@ -23,6 +24,9 @@ at the specified time and can optionally notify you with the results.`,
 			schedulerAddCommand(),
 			schedulerListCommand(),
 			schedulerRemoveCommand(),
+			schedulerTemplatesCommand(),
+			schedulerSubscribeCommand(),
+			schedulerUnsubscribeCommand(),
 		},
 	}
 }
@@ -182,6 +186,187 @@ func schedulerRemoveCommand() *ucli.Command {
 			}
 			o := cli.Stdout(c)
 			o.Printf("Job %q removed.\n", id)
+			return o.Err()
+		},
+	}
+}
+
+func schedulerTemplatesCommand() *ucli.Command {
+	return &ucli.Command{
+		Name:  "templates",
+		Usage: "List available job templates",
+		Description: `Lists platform-provided job templates. Each template is a pre-configured
+scheduled task you can subscribe to. The SUBSCRIBED column shows the short
+job ID when you already have an active subscription, or "-" if not.
+
+Template prompts are platform-managed and read-only. To manage subscriptions,
+use 'stella scheduler subscribe --help' and 'stella scheduler unsubscribe --help'.`,
+		Flags: []ucli.Flag{
+			cli.JSONFlag(),
+		},
+		Action: func(c *ucli.Context) error {
+			list, err := apiclient.Call[apiclient.JobTemplateList](func(api *apiclient.Client) (*http.Response, error) {
+				return api.ListJobTemplates(c.Context)
+			})
+			if err != nil {
+				return err
+			}
+			if cli.IsJSON(c) {
+				return cli.PrintJSON(c, list)
+			}
+			o := cli.Stdout(c)
+			if len(list.JobTemplates) == 0 {
+				o.Println("No job templates available.")
+				return o.Err()
+			}
+			o.Printf("%-20s  %-25s  %-22s  %s\n", "KEY", "NAME", "DEFAULT SCHEDULE", "SUBSCRIBED")
+			for _, t := range list.JobTemplates {
+				sub := "-"
+				if t.SubscribedJobId != nil && *t.SubscribedJobId != "" {
+					sub = cli.ShortID(*t.SubscribedJobId)
+				}
+				o.Printf("%-20s  %-25s  %-22s  %s\n",
+					cli.Truncate(t.Key, 20), cli.Truncate(t.Name, 25), cli.Truncate(t.DefaultSchedule, 22), sub)
+			}
+			return o.Err()
+		},
+	}
+}
+
+func schedulerSubscribeCommand() *ucli.Command {
+	return &ucli.Command{
+		Name:      "subscribe",
+		Usage:     "Subscribe to a job template",
+		ArgsUsage: "<template-key>",
+		Description: `Creates a scheduled job from a platform-provided template. The prompt is
+managed by the platform and cannot be edited. One subscription per template
+is allowed; a second subscribe returns an "already subscribed" message.
+
+Use 'stella scheduler templates' to list available template keys.
+Use 'stella scheduler unsubscribe <template-key>' to cancel a subscription.
+
+Optional schedule override flags (--cron or --every) replace the template's
+default schedule. Omit them to use the template default.`,
+		Flags: []ucli.Flag{
+			&ucli.StringFlag{Name: "cron", Usage: "Override default schedule with a cron expression, e.g. '0 9 * * 1-5'"},
+			&ucli.StringFlag{Name: "every", Usage: "Override default schedule with a Go duration, e.g. '12h'"},
+			cli.JSONFlag(),
+		},
+		Action: func(c *ucli.Context) error {
+			key := c.Args().First()
+			if key == "" {
+				return fmt.Errorf("usage: stella scheduler subscribe <template-key>")
+			}
+			cron := c.String("cron")
+			every := c.String("every")
+			if cron != "" && every != "" {
+				return fmt.Errorf("only one of --cron or --every may be set")
+			}
+
+			agentID, err := taskAgentID(c)
+			if err != nil {
+				return err
+			}
+			enabled := true
+			body := apiclient.CreateSchedulerJobJSONRequestBody{
+				TemplateKey: apiclient.Ptr(key),
+				Enabled:     &enabled,
+			}
+			if cron != "" {
+				body.Cron = &cron
+			}
+			if every != "" {
+				body.Every = &every
+			}
+
+			job, err := apiclient.Call[apiclient.Job](func(api *apiclient.Client) (*http.Response, error) {
+				return api.CreateSchedulerJob(c.Context, agentID, body)
+			})
+			if err != nil {
+				// 409 means this user is already subscribed; surface a friendly message.
+				if strings.Contains(err.Error(), "stella server 409") {
+					return fmt.Errorf("already subscribed to template %q; use 'stella scheduler templates' to see the job ID", key)
+				}
+				return err
+			}
+			if cli.IsJSON(c) {
+				return cli.PrintJSON(c, job)
+			}
+			sched := cli.DerefStr(job.Cron)
+			if sched == "" {
+				sched = cli.DerefStr(job.Every)
+			}
+			o := cli.Stdout(c)
+			o.Printf("Subscribed: job %s created (%s, %s).\n", cli.ShortID(job.Id), job.Name, sched)
+			return o.Err()
+		},
+	}
+}
+
+func schedulerUnsubscribeCommand() *ucli.Command {
+	return &ucli.Command{
+		Name:      "unsubscribe",
+		Usage:     "Unsubscribe from a job template",
+		ArgsUsage: "<template-key>",
+		Description: `Removes your subscription to a platform-provided job template by deleting
+the corresponding scheduled job. If you are not subscribed, a message is
+printed and the command exits successfully.
+
+Use 'stella scheduler templates' to see which templates you are subscribed to.`,
+		Flags: []ucli.Flag{
+			cli.JSONFlag(),
+		},
+		Action: func(c *ucli.Context) error {
+			key := c.Args().First()
+			if key == "" {
+				return fmt.Errorf("usage: stella scheduler unsubscribe <template-key>")
+			}
+
+			// Look up the subscribed job ID from the templates list.
+			list, err := apiclient.Call[apiclient.JobTemplateList](func(api *apiclient.Client) (*http.Response, error) {
+				return api.ListJobTemplates(c.Context)
+			})
+			if err != nil {
+				return err
+			}
+			var jobID, subAgentID string
+			for _, t := range list.JobTemplates {
+				if t.Key == key {
+					if t.SubscribedJobId != nil {
+						jobID = *t.SubscribedJobId
+					}
+					if t.SubscribedAgentId != nil {
+						subAgentID = *t.SubscribedAgentId
+					}
+					break
+				}
+			}
+			if jobID == "" {
+				o := cli.Stdout(c)
+				o.Printf("Not subscribed to template %q.\n", key)
+				return o.Err()
+			}
+
+			// Use the agent that owns the subscription job; fall back to the
+			// CLI's task agent when the server doesn't supply subscribed_agent_id
+			// (old server version).
+			deleteAgentID := subAgentID
+			if deleteAgentID == "" {
+				deleteAgentID, err = taskAgentID(c)
+				if err != nil {
+					return err
+				}
+			}
+			if err := apiclient.Do(func(api *apiclient.Client) (*http.Response, error) {
+				return api.DeleteSchedulerJob(c.Context, deleteAgentID, jobID)
+			}); err != nil {
+				return err
+			}
+			if cli.IsJSON(c) {
+				return cli.PrintDeleted(c, jobID)
+			}
+			o := cli.Stdout(c)
+			o.Printf("Unsubscribed from template %q (job %s removed).\n", key, cli.ShortID(jobID))
 			return o.Err()
 		},
 	}

--- a/internal/server/scheduler.go
+++ b/internal/server/scheduler.go
@@ -38,11 +38,12 @@ func (s *Server) ListJobTemplates(w http.ResponseWriter, r *http.Request) {
 
 	templates := s.schedulerSvc.Templates()
 
-	// Build a lookup: template key → subscribed job ID for this user.
-	subscriptions := make(map[string]string)
+	// Build a lookup: template key → (subscribed job ID, agent ID) for this user.
+	type subInfo struct{ jobID, agentID string }
+	subscriptions := make(map[string]subInfo)
 	for _, job := range s.schedulerSvc.ListJobs() {
 		if job.OwnerKind == scheduler.JobOwnerUser && job.UserID == info.UserID && job.JobKey != "" {
-			subscriptions[job.JobKey] = job.ID
+			subscriptions[job.JobKey] = subInfo{jobID: job.ID, agentID: job.AgentID}
 		}
 	}
 
@@ -55,8 +56,11 @@ func (s *Server) ListJobTemplates(w http.ResponseWriter, r *http.Request) {
 			DefaultSchedule: templateDefaultSchedule(tmpl.DefaultSchedule),
 			SessionMode:     tmpl.SessionMode,
 		}
-		if jobID, ok := subscriptions[tmpl.Key]; ok {
-			t.SubscribedJobId = ptrStr(jobID)
+		if sub, ok := subscriptions[tmpl.Key]; ok {
+			t.SubscribedJobId = ptrStr(sub.jobID)
+			if sub.agentID != "" {
+				t.SubscribedAgentId = ptrStr(sub.agentID)
+			}
 		}
 		out = append(out, t)
 	}

--- a/internal/server/scheduler_test.go
+++ b/internal/server/scheduler_test.go
@@ -107,6 +107,12 @@ func TestListJobTemplates_WithSubscription(t *testing.T) {
 	if *templates[0].SubscribedJobId != created.Id {
 		t.Errorf("SubscribedJobId = %q, want %q", *templates[0].SubscribedJobId, created.Id)
 	}
+	if templates[0].SubscribedAgentId == nil {
+		t.Fatal("SubscribedAgentId is nil after subscribing")
+	}
+	if *templates[0].SubscribedAgentId != agentID {
+		t.Errorf("SubscribedAgentId = %q, want %q", *templates[0].SubscribedAgentId, agentID)
+	}
 }
 
 // TestListJobTemplates_503WhenDisabled verifies 503 when scheduler is nil.

--- a/resources/skills/system/scheduler/SKILL.md
+++ b/resources/skills/system/scheduler/SKILL.md
@@ -111,8 +111,39 @@ stella scheduler add \
     --at "2024-01-15T14:45:00+08:00"
 ```
 
+## Job Template Subscriptions
+
+Platform-provided templates are opt-in scheduled jobs with platform-managed prompts. You cannot edit the message of a subscription job; the prompt is resolved from the template registry.
+
+**List available templates** (shows subscription status per template):
+
+```bash
+stella scheduler templates --help
+stella scheduler templates --json
+```
+
+**Subscribe to a template**:
+
+```bash
+stella scheduler subscribe --help
+stella scheduler subscribe recally-rss
+stella scheduler subscribe recally-rss --every 12h   # override default schedule
+```
+
+One subscription per template is allowed. If already subscribed, a friendly message is printed and the command exits with an error.
+
+**Unsubscribe from a template**:
+
+```bash
+stella scheduler unsubscribe --help
+stella scheduler unsubscribe recally-rss
+```
+
+If not subscribed, prints a message and exits successfully. Internally looks up the subscribed job ID from the templates list, then deletes it.
+
 ## Limitations
 
 - Scheduler must be enabled on the server (`scheduler.enabled = true` in config).
 - One-time jobs (`--at`) with a past timestamp are rejected.
 - Plugin-owned jobs cannot be modified.
+- Subscription job prompts are read-only; message edits are rejected by the server.

--- a/web/content/docs/guides/scheduling.md
+++ b/web/content/docs/guides/scheduling.md
@@ -22,6 +22,24 @@ Available templates:
 
 The subscription appears in your scheduled jobs list with a template badge (for example, `Subscription · recally-rss`). The prompt is platform-managed and read-only — if you want a fully custom prompt, create a regular scheduled job instead.
 
+### Subscribe via the CLI
+
+```bash
+# List available templates and check subscription status
+stella scheduler templates
+
+# Subscribe (uses the template's default schedule)
+stella scheduler subscribe recally-rss
+
+# Subscribe with a custom schedule
+stella scheduler subscribe recally-rss --every 12h
+
+# Unsubscribe
+stella scheduler unsubscribe recally-rss
+```
+
+Run `stella scheduler subscribe --help` or `stella scheduler unsubscribe --help` for full flag details.
+
 ### Subscribe via the API
 
 ```

--- a/web/content/docs/guides/scheduling.zh.md
+++ b/web/content/docs/guides/scheduling.zh.md
@@ -22,6 +22,24 @@ title: 定时任务
 
 订阅后会出现在定时任务列表，并带有模板标识（例如 `订阅 · recally-rss`）。提示词由平台维护且只读——如需自定义提示词，请创建普通定时任务。
 
+### 通过 CLI 订阅
+
+```bash
+# 列出可用模板并查看订阅状态
+stella scheduler templates
+
+# 订阅（使用模板默认频率）
+stella scheduler subscribe recally-rss
+
+# 订阅并自定义频率
+stella scheduler subscribe recally-rss --every 12h
+
+# 取消订阅
+stella scheduler unsubscribe recally-rss
+```
+
+运行 `stella scheduler subscribe --help` 或 `stella scheduler unsubscribe --help` 查看完整参数说明。
+
 ### 通过 API 订阅
 
 ```


### PR DESCRIPTION
## What

Three new `stella scheduler` subcommands so the agent can manage job-template subscriptions conversationally:

- `templates` — list platform templates with per-user subscription status
- `subscribe <template-key>` — create a subscription via the existing create endpoint with `template_key`; optional `--cron`/`--every` schedule override; friendly message on 409
- `unsubscribe <template-key>` — resolve `subscribed_job_id` from the templates endpoint and delete it; not-subscribed is a no-op success

Also adds `subscribed_agent_id` to the `JobTemplate` API schema.

## Why

After #382, subscriptions were Web-UI/API only — the agent's scheduler tool couldn't handle "帮我订阅 RSS 轮询". (#379)

## How

- CLI follows the existing `cmd/stella/scheduler.go` patterns (apiclient.Call, `--json`, ShortID tables); no `--at` on subscribe since one-shot subscriptions make no sense.
- `subscribed_agent_id` (spec-first per `api/CLAUDE.md`, regen via `mise run generate:api`) fixes cross-agent unsubscribe: the delete endpoint 404s unless the URL agent matches the job's agent, and a subscription may have been created under a different agent in the Web UI. CLI prefers it and falls back to the current agent context.
- Scheduler SKILL.md + scheduling guide (en+zh) updated; help text is the source of truth.

**Verification**: `mise run format && build && test` green; all four `--help` outputs render; server test asserts the new field.

## Refs

- Closes #379
- #382 — template subscription foundation