### PR TITLE
feat(recally): nudge feed adders toward the recally-rss subscription

### DIFF
--- a/cmd/stella/recally_feeds.go
+++ b/cmd/stella/recally_feeds.go
@@ -71,6 +71,19 @@ Options must be placed before the feed URL. Trailing options are rejected.`,
 			o.Printf("  Kind: %s\n", feed.Kind)
 			o.Printf("  Title: %s\n", feed.Title)
 			o.Printf("  URL: %s\n", feed.Url)
+			// Best-effort: nudge the user to subscribe to the recally-rss job template
+			// if they have not done so. Any error (503 scheduler-disabled, network, etc.)
+			// is silently ignored — the feed was already added successfully.
+			if tpl, err := apiclient.Call[apiclient.JobTemplateList](func(api *apiclient.Client) (*http.Response, error) {
+				return api.ListJobTemplates(c.Context)
+			}); err == nil {
+				for _, t := range tpl.JobTemplates {
+					if t.Key == "recally-rss" && (t.SubscribedJobId == nil || *t.SubscribedJobId == "") {
+						o.Printf("\nNote: RSS polling is opt-in — subscribe with 'stella scheduler subscribe recally-rss' or via the Web UI scheduler page.\n")
+						break
+					}
+				}
+			}
 			return o.Err()
 		},
 	}

--- a/resources/skills/system/recally/SKILL.md
+++ b/resources/skills/system/recally/SKILL.md
@@ -67,6 +67,18 @@ stella recally feed mark --help
 `twitter`, everything else defaults to `rss`. Pass `--kind rss|twitter|website` to
 force it. Use `--kind website` for a page that lists items but has no RSS.
 
+**RSS polling subscription**: RSS feeds are only polled when the user has subscribed
+to the `recally-rss` job template. After adding a feed, check whether the user is
+already subscribed (the CLI prints a hint when they are not). If they are not
+subscribed and confirm they want automatic polling, run:
+
+```bash
+stella scheduler subscribe recally-rss
+```
+
+See `stella scheduler subscribe --help` for schedule overrides. Ask before
+subscribing — do not subscribe automatically.
+
 - **rss** feeds: poll server-side, then process pending entries — see [references/rss-workflow.md](references/rss-workflow.md).
 - **twitter** feeds: discover entries via the skill — see [references/twitter-workflow.md](references/twitter-workflow.md).
 - **website** feeds: scrape item links from a no-RSS page — see [references/website-workflow.md](references/website-workflow.md).


### PR DESCRIPTION
## What

After a successful `stella recally feed add`, print a one-line hint when the user has no `recally-rss` template subscription, and teach the recally skill to offer subscribing (with user confirmation, never automatically).

## Why

After #382, RSS polling is opt-in — users who add feeds without subscribing get silent no-op behavior. (#380)

## How

- Best-effort check against `GET /api/scheduler/job-templates` after the feed-add success output; any error (503 scheduler-disabled, network, missing template) silently skips the hint and never affects the feed-add result. Skipped in `--json` mode to keep output clean.
- Hint points to `stella scheduler subscribe recally-rss` (added in #383) and the Web UI scheduler page.
- recally SKILL.md gains an "RSS polling subscription" note; docs already carry the opt-in callout from #382, untouched.

**Verification**: `mise run format && build && test` green.

## Refs

- Closes #380
- #383 — provides the `stella scheduler subscribe` command the hint references