### PR TITLE
✨ feat(lcm): FTS5/BM25 search for memory retrieval

### DIFF
--- a/internal/db/database.go
+++ b/internal/db/database.go
@@ -52,6 +52,11 @@ func OpenDB(dbPath string) (*sql.DB, error) {
 		return nil, fmt.Errorf("db: migrate: %w", err)
 	}
 
+	if err := ensureFTS(db); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("db: fts: %w", err)
+	}
+
 	return db, nil
 }
 

--- a/internal/db/fts.go
+++ b/internal/db/fts.go
@@ -1,0 +1,62 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	_ "embed"
+	"fmt"
+	"strings"
+)
+
+// FTS5 indexes live outside the Atlas migration pipeline because Atlas's
+// embedded dev SQLite lacks the fts5 module. The DDL (virtual tables +
+// sync triggers) is kept in the sqlc schema dir so generated queries can
+// reference the virtual tables, and is applied here at startup instead.
+var (
+	//go:embed schemas/tables/ctx_message_fts.sql
+	ctxMessageFTSSchema string
+	//go:embed schemas/tables/ctx_summary_fts.sql
+	ctxSummaryFTSSchema string
+)
+
+// ensureFTS creates the FTS5 virtual tables and triggers if missing, and
+// backfills the index from existing rows on first creation so pre-existing
+// history becomes searchable. Called from OpenDB after migrations succeed;
+// OpenSerialConn skips it because its caller must run OpenDB first.
+func ensureFTS(db *sql.DB) error {
+	ctx := context.Background()
+	for _, t := range []struct {
+		ftsTable string
+		schema   string
+	}{
+		{"ctx_message_fts", ctxMessageFTSSchema},
+		{"ctx_summary_fts", ctxSummaryFTSSchema},
+	} {
+		// Check the insert trigger alongside the table: an Atlas table-rebuild
+		// migration drops the content table's triggers and shifts rowids, which
+		// silently stales the index. A missing trigger with the index present is
+		// exactly that signature, so it must also force a rebuild.
+		var existing int
+		if err := db.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM sqlite_master WHERE name IN (?, ?)",
+			t.ftsTable, t.ftsTable+"_ai",
+		).Scan(&existing); err != nil {
+			return fmt.Errorf("check %s: %w", t.ftsTable, err)
+		}
+		if _, err := db.ExecContext(ctx, t.schema); err != nil {
+			if strings.Contains(err.Error(), "fts5") {
+				return fmt.Errorf("create %s: sqlite build lacks FTS5 support, required for memory search: %w", t.ftsTable, err)
+			}
+			return fmt.Errorf("create %s: %w", t.ftsTable, err)
+		}
+		// External-content tables start empty; rebuild scans the content table
+		// so rows inserted before the triggers existed become searchable.
+		if existing < 2 {
+			rebuild := fmt.Sprintf("INSERT INTO %s(%s) VALUES('rebuild')", t.ftsTable, t.ftsTable)
+			if _, err := db.ExecContext(ctx, rebuild); err != nil {
+				return fmt.Errorf("backfill %s: %w", t.ftsTable, err)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/db/fts_test.go
+++ b/internal/db/fts_test.go
@@ -1,0 +1,123 @@
+package db
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestOpenDBCreatesFTSIndexes(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "fts.db")
+	db, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	for _, table := range []string{"ctx_message_fts", "ctx_summary_fts"} {
+		if !tableExists(t, db, table) {
+			t.Errorf("%s should exist after OpenDB", table)
+		}
+	}
+}
+
+func TestEnsureFTSBackfillsPreexistingRows(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "fts-backfill.db")
+	db, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	// Simulate a database created before FTS support existed: no index, no
+	// triggers, but rows already present in the content tables.
+	for _, stmt := range []string{
+		"DROP TABLE ctx_message_fts",
+		"DROP TABLE ctx_summary_fts",
+		"DROP TRIGGER IF EXISTS ctx_message_fts_ai",
+		"DROP TRIGGER IF EXISTS ctx_message_fts_ad",
+		"DROP TRIGGER IF EXISTS ctx_message_fts_au",
+		"DROP TRIGGER IF EXISTS ctx_summary_fts_ai",
+		"DROP TRIGGER IF EXISTS ctx_summary_fts_ad",
+		"DROP TRIGGER IF EXISTS ctx_summary_fts_au",
+	} {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("%s: %v", stmt, err)
+		}
+	}
+	if _, err := db.Exec(`INSERT INTO ctx_conversation (id, session_id) VALUES ('conv-fts', 'sess-fts')`); err != nil {
+		t.Fatalf("insert conversation: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO ctx_message (id, conversation_id, seq, role, content, token_count)
+		VALUES ('msg-fts', 'conv-fts', 1, 'user', 'legacy aardvark message', 5)`); err != nil {
+		t.Fatalf("insert message: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO ctx_summary (id, conversation_id, kind, depth, content, token_count)
+		VALUES ('sum-fts', 'conv-fts', 'leaf', 0, 'legacy aardvark summary', 5)`); err != nil {
+		t.Fatalf("insert summary: %v", err)
+	}
+
+	if err := ensureFTS(db); err != nil {
+		t.Fatalf("ensureFTS: %v", err)
+	}
+
+	for _, table := range []string{"ctx_message_fts", "ctx_summary_fts"} {
+		var count int
+		if err := db.QueryRow(
+			"SELECT COUNT(*) FROM " + table + " WHERE " + table + " MATCH 'aardvark'",
+		).Scan(&count); err != nil {
+			t.Fatalf("match on %s: %v", table, err)
+		}
+		if count != 1 {
+			t.Errorf("%s: expected 1 backfilled hit, got %d", table, count)
+		}
+	}
+}
+
+func TestEnsureFTSRebuildsAfterTriggerLoss(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "fts-triggerloss.db")
+	db, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	// Simulate an Atlas table-rebuild migration: the FTS index survives but the
+	// content table's triggers are gone, so rows written afterwards are missing
+	// from the index until ensureFTS detects the loss and rebuilds.
+	for _, stmt := range []string{
+		"DROP TRIGGER ctx_message_fts_ai",
+		"DROP TRIGGER ctx_message_fts_ad",
+		"DROP TRIGGER ctx_message_fts_au",
+	} {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("%s: %v", stmt, err)
+		}
+	}
+	if _, err := db.Exec(`INSERT INTO ctx_conversation (id, session_id) VALUES ('conv-tl', 'sess-tl')`); err != nil {
+		t.Fatalf("insert conversation: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO ctx_message (id, conversation_id, seq, role, content, token_count)
+		VALUES ('msg-tl', 'conv-tl', 1, 'user', 'orphaned pangolin message', 5)`); err != nil {
+		t.Fatalf("insert message: %v", err)
+	}
+
+	if err := ensureFTS(db); err != nil {
+		t.Fatalf("ensureFTS: %v", err)
+	}
+
+	var count int
+	if err := db.QueryRow(
+		"SELECT COUNT(*) FROM ctx_message_fts WHERE ctx_message_fts MATCH 'pangolin'",
+	).Scan(&count); err != nil {
+		t.Fatalf("match: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected rebuilt index to find the orphaned row, got %d hits", count)
+	}
+}

--- a/internal/db/queries/ctx_message.sql
+++ b/internal/db/queries/ctx_message.sql
@@ -64,10 +64,16 @@ SELECT * FROM ctx_message_part WHERE message_id = ? ORDER BY ordinal ASC;
 SELECT * FROM ctx_message_part WHERE message_id IN (sqlc.slice('message_ids')) ORDER BY message_id, ordinal ASC;
 
 -- name: SearchMessages :many
-SELECT * FROM ctx_message
-WHERE conversation_id = ? AND content LIKE ?
-ORDER BY seq ASC
-LIMIT ?;
+SELECT
+    m.*,
+    snippet(ctx_message_fts, 0, '<<', '>>', '...', 32) AS snippet,
+    bm25(ctx_message_fts) AS score
+FROM ctx_message_fts
+JOIN ctx_message m ON m.rowid = ctx_message_fts.rowid
+WHERE ctx_message_fts.content MATCH sqlc.arg('match')
+  AND m.conversation_id = sqlc.arg('conversation_id')
+ORDER BY score ASC
+LIMIT sqlc.arg('limit');
 
 -- name: GetMessagesSince :many
 SELECT * FROM ctx_message

--- a/internal/db/queries/ctx_summary.sql
+++ b/internal/db/queries/ctx_summary.sql
@@ -54,7 +54,13 @@ WHERE sp.parent_summary_id = ?
 ORDER BY sp.ordinal ASC;
 
 -- name: SearchSummaries :many
-SELECT * FROM ctx_summary
-WHERE conversation_id = ? AND content LIKE ?
-ORDER BY created_at ASC
-LIMIT ?;
+SELECT
+    s.*,
+    snippet(ctx_summary_fts, 0, '<<', '>>', '...', 32) AS snippet,
+    bm25(ctx_summary_fts) AS score
+FROM ctx_summary_fts
+JOIN ctx_summary s ON s.rowid = ctx_summary_fts.rowid
+WHERE ctx_summary_fts.content MATCH sqlc.arg('match')
+  AND s.conversation_id = sqlc.arg('conversation_id')
+ORDER BY score ASC
+LIMIT sqlc.arg('limit');

--- a/internal/db/schemas/tables/ctx_message_fts.sql
+++ b/internal/db/schemas/tables/ctx_message_fts.sql
@@ -1,0 +1,26 @@
+-- Runtime-managed FTS5 index over ctx_message.content.
+-- Executed via go:embed at startup (internal/db/fts.go), NOT through Atlas
+-- migrations: Atlas's embedded dev SQLite lacks the fts5 module, so this file
+-- is intentionally not imported into main.sql. sqlc still reads it (schema
+-- glob) so search queries can reference the virtual table.
+CREATE VIRTUAL TABLE IF NOT EXISTS ctx_message_fts USING fts5(
+    content,
+    content='ctx_message',
+    content_rowid='rowid',
+    tokenize='unicode61 remove_diacritics 1'
+);
+
+CREATE TRIGGER IF NOT EXISTS ctx_message_fts_ai AFTER INSERT ON ctx_message BEGIN
+    INSERT INTO ctx_message_fts(rowid, content) VALUES (new.rowid, new.content);
+END;
+
+CREATE TRIGGER IF NOT EXISTS ctx_message_fts_ad AFTER DELETE ON ctx_message BEGIN
+    INSERT INTO ctx_message_fts(ctx_message_fts, rowid, content)
+    VALUES ('delete', old.rowid, old.content);
+END;
+
+CREATE TRIGGER IF NOT EXISTS ctx_message_fts_au AFTER UPDATE OF content ON ctx_message BEGIN
+    INSERT INTO ctx_message_fts(ctx_message_fts, rowid, content)
+    VALUES ('delete', old.rowid, old.content);
+    INSERT INTO ctx_message_fts(rowid, content) VALUES (new.rowid, new.content);
+END;

--- a/internal/db/schemas/tables/ctx_summary_fts.sql
+++ b/internal/db/schemas/tables/ctx_summary_fts.sql
@@ -1,0 +1,26 @@
+-- Runtime-managed FTS5 index over ctx_summary.content.
+-- Executed via go:embed at startup (internal/db/fts.go), NOT through Atlas
+-- migrations: Atlas's embedded dev SQLite lacks the fts5 module, so this file
+-- is intentionally not imported into main.sql. sqlc still reads it (schema
+-- glob) so search queries can reference the virtual table.
+CREATE VIRTUAL TABLE IF NOT EXISTS ctx_summary_fts USING fts5(
+    content,
+    content='ctx_summary',
+    content_rowid='rowid',
+    tokenize='unicode61 remove_diacritics 1'
+);
+
+CREATE TRIGGER IF NOT EXISTS ctx_summary_fts_ai AFTER INSERT ON ctx_summary BEGIN
+    INSERT INTO ctx_summary_fts(rowid, content) VALUES (new.rowid, new.content);
+END;
+
+CREATE TRIGGER IF NOT EXISTS ctx_summary_fts_ad AFTER DELETE ON ctx_summary BEGIN
+    INSERT INTO ctx_summary_fts(ctx_summary_fts, rowid, content)
+    VALUES ('delete', old.rowid, old.content);
+END;
+
+CREATE TRIGGER IF NOT EXISTS ctx_summary_fts_au AFTER UPDATE OF content ON ctx_summary BEGIN
+    INSERT INTO ctx_summary_fts(ctx_summary_fts, rowid, content)
+    VALUES ('delete', old.rowid, old.content);
+    INSERT INTO ctx_summary_fts(rowid, content) VALUES (new.rowid, new.content);
+END;

--- a/internal/memory/lcm/lcm_helpers_test.go
+++ b/internal/memory/lcm/lcm_helpers_test.go
@@ -175,6 +175,29 @@ func TestTruncateUTF8_UTF8(t *testing.T) {
 	}
 }
 
+func TestBuildMatchQuery(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"hello", `"hello"`},
+		{"hello world", `"hello" OR "world"`},
+		{"snake_case token2", `"snake_case" OR "token2"`},
+		{`quoted "phrase" here`, `"quoted" OR "phrase" OR "here"`},
+		{"日本語 test", `"日本語" OR "test"`},
+		// FTS5 operators and punctuation are separators, never query syntax.
+		{"a* (b) -c:d", `"a" OR "b" OR "c" OR "d"`},
+		{"", ""},
+		{`*** (") -:`, ""},
+		{"   ", ""},
+	}
+	for _, tc := range tests {
+		if got := buildMatchQuery(tc.input); got != tc.want {
+			t.Errorf("buildMatchQuery(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
 func TestBoolToInt(t *testing.T) {
 	if boolToInt(true) != 1 {
 		t.Error("expected boolToInt(true)=1")

--- a/internal/memory/lcm/retrieval.go
+++ b/internal/memory/lcm/retrieval.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"sort"
+	"strings"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/CherryHQ/stella/internal/memory"
@@ -39,12 +42,35 @@ func (p *Provider) Search(ctx context.Context, session memory.Session, query mem
 	return p.retrieval.search(ctx, conv.ID, query)
 }
 
+// buildMatchQuery converts free text into an FTS5 MATCH expression. Tokens
+// (runs of letters/digits/underscore) are individually quoted so FTS5 query
+// operators in user input (*, -, :, parens) can never break the query, and
+// OR-joined for recall — BM25 still ranks multi-term hits higher. Returns ""
+// when no tokens can be extracted; callers must skip the query then.
+func buildMatchQuery(text string) string {
+	tokens := strings.FieldsFunc(text, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_'
+	})
+	quoted := make([]string, 0, len(tokens))
+	for _, tok := range tokens {
+		tok = strings.ReplaceAll(tok, `"`, "")
+		if tok == "" {
+			continue
+		}
+		quoted = append(quoted, `"`+tok+`"`)
+	}
+	return strings.Join(quoted, " OR ")
+}
+
 func (r *retrievalEngine) search(ctx context.Context, convID string, query memory.SearchQuery) ([]memory.SearchResult, error) {
 	limit := query.Limit
 	if limit <= 0 {
 		limit = defaultSearchLimit
 	}
-	likePattern := "%" + query.Text + "%"
+	match := buildMatchQuery(query.Text)
+	if match == "" {
+		return nil, nil
+	}
 
 	scope := scopeBoth
 	switch query.Scope {
@@ -59,7 +85,7 @@ func (r *retrievalEngine) search(ctx context.Context, convID string, query memor
 	if scope == scopeMessages || scope == scopeBoth {
 		msgs, err := r.q.SearchMessages(ctx, sqlc.SearchMessagesParams{
 			ConversationID: convID,
-			Content:        likePattern,
+			Match:          match,
 			Limit:          int64(limit),
 		})
 		if err != nil {
@@ -69,21 +95,18 @@ func (r *retrievalEngine) search(ctx context.Context, convID string, query memor
 			results = append(results, memory.SearchResult{
 				SourceType: itemTypeMessage,
 				SourceID:   fmt.Sprint(msg.ID),
-				Content:    truncateUTF8(msg.Content, maxContentSnippet),
+				Content:    searchSnippet(msg.Snippet, msg.Content),
+				Score:      -msg.Score,
 				Timestamp:  parseTime(msg.CreatedAt),
 			})
 		}
 	}
 
 	if scope == scopeSummaries || scope == scopeBoth {
-		remaining := limit - len(results)
-		if remaining <= 0 {
-			remaining = limit // summaries-only: use full limit
-		}
 		sums, err := r.q.SearchSummaries(ctx, sqlc.SearchSummariesParams{
 			ConversationID: convID,
-			Content:        likePattern,
-			Limit:          int64(remaining),
+			Match:          match,
+			Limit:          int64(limit),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("search summaries: %w", err)
@@ -92,13 +115,36 @@ func (r *retrievalEngine) search(ctx context.Context, convID string, query memor
 			results = append(results, memory.SearchResult{
 				SourceType: itemTypeSummary,
 				SourceID:   s.ID,
-				Content:    truncateUTF8(s.Content, maxContentSnippet),
+				Content:    searchSnippet(s.Snippet, s.Content),
+				Score:      -s.Score,
 				Timestamp:  parseTime(s.CreatedAt),
 			})
 		}
 	}
 
+	// Both-scope queries each table with the full limit, then keep the global
+	// top N so a strong summary hit can outrank a weak message hit. BM25 from
+	// the two indexes shares the same corpus statistics family closely enough
+	// for cross-source ordering.
+	sort.SliceStable(results, func(i, j int) bool {
+		if results[i].Score != results[j].Score {
+			return results[i].Score > results[j].Score
+		}
+		return results[i].Timestamp.After(results[j].Timestamp)
+	})
+	if len(results) > limit {
+		results = results[:limit]
+	}
 	return results, nil
+}
+
+// searchSnippet prefers the FTS5 snippet (match context with <<>> highlights)
+// and falls back to a plain truncation for degenerate empty snippets.
+func searchSnippet(snippet, content string) string {
+	if snippet != "" {
+		return snippet
+	}
+	return truncateUTF8(content, maxContentSnippet)
 }
 
 func (p *Provider) getScopedSummary(ctx context.Context, summaryID string) (sqlc.CtxSummary, error) {

--- a/internal/memory/lcm/search_test.go
+++ b/internal/memory/lcm/search_test.go
@@ -1,0 +1,231 @@
+package lcm_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/CherryHQ/stella/internal/memory"
+	"github.com/CherryHQ/stella/internal/memory/lcm"
+	"github.com/CherryHQ/stella/pkg/ai"
+)
+
+// newSearchTestEnv builds a provider on a raw db handle so tests can both use
+// the public Append path and reach behind it (insert summaries, delete rows).
+func newSearchTestEnv(t *testing.T, suffix string) (*sql.DB, memory.Provider, memory.Session) {
+	t.Helper()
+	db := newLCMTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	p, err := lcm.New(db, nil, nil)
+	if err != nil {
+		t.Fatalf("new provider: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Close() })
+
+	sess := newLCMTestSession(suffix)
+	if err := p.Bootstrap(context.Background(), sess); err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	return db, p, sess
+}
+
+func conversationID(t *testing.T, db *sql.DB, sessionID string) string {
+	t.Helper()
+	var id string
+	if err := db.QueryRow(`SELECT id FROM ctx_conversation WHERE session_id = ?`, sessionID).Scan(&id); err != nil {
+		t.Fatalf("conversation id: %v", err)
+	}
+	return id
+}
+
+func insertSummary(t *testing.T, db *sql.DB, convID, id, content string) {
+	t.Helper()
+	_, err := db.Exec(`INSERT INTO ctx_summary (id, conversation_id, kind, depth, content, token_count)
+		VALUES (?, ?, 'leaf', 0, ?, 10)`, id, convID, content)
+	if err != nil {
+		t.Fatalf("insert summary: %v", err)
+	}
+}
+
+func appendUser(t *testing.T, p memory.Provider, sess memory.Session, contents ...string) {
+	t.Helper()
+	for _, c := range contents {
+		if err := p.Append(context.Background(), sess, ai.UserMessage{Content: c}); err != nil {
+			t.Fatalf("append %q: %v", c, err)
+		}
+	}
+}
+
+func runSearch(t *testing.T, p memory.Provider, sess memory.Session, q memory.SearchQuery) []memory.SearchResult {
+	t.Helper()
+	results, err := p.(memory.Searcher).Search(context.Background(), sess, q)
+	if err != nil {
+		t.Fatalf("search %q: %v", q.Text, err)
+	}
+	return results
+}
+
+func TestSearch_MessagesRankedByBM25(t *testing.T) {
+	_, p, sess := newSearchTestEnv(t, "fts-rank")
+	appendUser(t, p, sess,
+		"alpha beaver alpha beaver strongdoc",
+		"alpha weakdoc and unrelated padding words here",
+		"completely irrelevant content",
+	)
+
+	results := runSearch(t, p, sess, memory.SearchQuery{Text: "alpha beaver", Scope: memory.SearchScopeMessages})
+	if len(results) != 2 {
+		t.Fatalf("expected 2 hits, got %d: %+v", len(results), results)
+	}
+	if !strings.Contains(results[0].Content, "strongdoc") {
+		t.Errorf("expected strong doc ranked first, got %q", results[0].Content)
+	}
+	if results[0].Score <= results[1].Score {
+		t.Errorf("expected descending scores, got %v then %v", results[0].Score, results[1].Score)
+	}
+	// FTS snippet highlights matched terms.
+	if !strings.Contains(results[0].Content, "<<alpha>>") {
+		t.Errorf("expected snippet highlighting, got %q", results[0].Content)
+	}
+}
+
+func TestSearch_SummariesReturnHits(t *testing.T) {
+	db, p, sess := newSearchTestEnv(t, "fts-sum")
+	convID := conversationID(t, db, sess.ID)
+	insertSummary(t, db, convID, "sum-fts-1", "quarterly zebra report discussed in detail")
+
+	results := runSearch(t, p, sess, memory.SearchQuery{Text: "zebra", Scope: memory.SearchScopeSummaries})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 hit, got %d", len(results))
+	}
+	if results[0].SourceType != "summary" || results[0].SourceID != "sum-fts-1" {
+		t.Errorf("unexpected hit: %+v", results[0])
+	}
+}
+
+func TestSearch_ScopeIsolation(t *testing.T) {
+	db, p, sess := newSearchTestEnv(t, "fts-scope")
+	convID := conversationID(t, db, sess.ID)
+	appendUser(t, p, sess, "gamma in a message")
+	insertSummary(t, db, convID, "sum-fts-2", "gamma in a summary")
+
+	msgs := runSearch(t, p, sess, memory.SearchQuery{Text: "gamma", Scope: memory.SearchScopeMessages})
+	for _, r := range msgs {
+		if r.SourceType != "message" {
+			t.Errorf("messages scope returned %q hit", r.SourceType)
+		}
+	}
+	if len(msgs) != 1 {
+		t.Errorf("messages scope: expected 1 hit, got %d", len(msgs))
+	}
+
+	sums := runSearch(t, p, sess, memory.SearchQuery{Text: "gamma", Scope: memory.SearchScopeSummaries})
+	for _, r := range sums {
+		if r.SourceType != "summary" {
+			t.Errorf("summaries scope returned %q hit", r.SourceType)
+		}
+	}
+	if len(sums) != 1 {
+		t.Errorf("summaries scope: expected 1 hit, got %d", len(sums))
+	}
+}
+
+func TestSearch_BothMergesAndRanks(t *testing.T) {
+	db, p, sess := newSearchTestEnv(t, "fts-both")
+	convID := conversationID(t, db, sess.ID)
+	appendUser(t, p, sess, "delta mentioned once among many other unrelated padding words in this message")
+	insertSummary(t, db, convID, "sum-fts-3", "delta delta delta focused summary")
+
+	results := runSearch(t, p, sess, memory.SearchQuery{Text: "delta", Scope: memory.SearchScopeBoth})
+	if len(results) != 2 {
+		t.Fatalf("expected 2 hits across sources, got %d", len(results))
+	}
+	if results[0].SourceType != "summary" {
+		t.Errorf("expected strong summary hit ranked above weak message hit, got %+v", results)
+	}
+	if results[1].SourceType != "message" {
+		t.Errorf("expected message hit second, got %+v", results[1])
+	}
+}
+
+func TestSearch_BothRespectsLimit(t *testing.T) {
+	db, p, sess := newSearchTestEnv(t, "fts-limit")
+	convID := conversationID(t, db, sess.ID)
+	for i := range 3 {
+		appendUser(t, p, sess, fmt.Sprintf("epsilon message number %d", i))
+		insertSummary(t, db, convID, fmt.Sprintf("sum-fts-lim-%d", i), fmt.Sprintf("epsilon summary number %d", i))
+	}
+
+	results := runSearch(t, p, sess, memory.SearchQuery{Text: "epsilon", Scope: memory.SearchScopeBoth, Limit: 4})
+	if len(results) != 4 {
+		t.Fatalf("expected merged results capped at limit 4, got %d", len(results))
+	}
+}
+
+func TestSearch_DeleteRemovesFTSHits(t *testing.T) {
+	db, p, sess := newSearchTestEnv(t, "fts-del")
+	appendUser(t, p, sess, "ephemeral xylophone note")
+
+	if got := runSearch(t, p, sess, memory.SearchQuery{Text: "xylophone"}); len(got) != 1 {
+		t.Fatalf("expected 1 hit before delete, got %d", len(got))
+	}
+
+	convID := conversationID(t, db, sess.ID)
+	// ctx_item restricts message deletes, so clear the pointer first.
+	if _, err := db.Exec(`DELETE FROM ctx_item WHERE conversation_id = ?`, convID); err != nil {
+		t.Fatalf("delete items: %v", err)
+	}
+	if _, err := db.Exec(`DELETE FROM ctx_message WHERE conversation_id = ?`, convID); err != nil {
+		t.Fatalf("delete messages: %v", err)
+	}
+
+	if got := runSearch(t, p, sess, memory.SearchQuery{Text: "xylophone"}); len(got) != 0 {
+		t.Fatalf("expected 0 hits after delete, got %d: %+v", len(got), got)
+	}
+}
+
+func TestSearch_ConversationIsolation(t *testing.T) {
+	_, p, sess := newSearchTestEnv(t, "fts-iso-a")
+	appendUser(t, p, sess, "shared quokka keyword in conversation A")
+
+	other := newLCMTestSession("fts-iso-b")
+	if err := p.Bootstrap(context.Background(), other); err != nil {
+		t.Fatalf("bootstrap other: %v", err)
+	}
+	appendUser(t, p, other, "shared quokka keyword in conversation B")
+
+	results := runSearch(t, p, sess, memory.SearchQuery{Text: "quokka"})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 hit scoped to conversation A, got %d", len(results))
+	}
+	if !strings.Contains(results[0].Content, "conversation A") {
+		t.Errorf("hit leaked from another conversation: %q", results[0].Content)
+	}
+}
+
+func TestSearch_SpecialCharactersDoNotError(t *testing.T) {
+	_, p, sess := newSearchTestEnv(t, "fts-special")
+	appendUser(t, p, sess, "function parse_config returns errors")
+
+	for _, q := range []string{
+		`parse_config*`,
+		`"parse_config"`,
+		`(parse_config) -errors`,
+		`parse_config: NOT errors`,
+	} {
+		results := runSearch(t, p, sess, memory.SearchQuery{Text: q})
+		if len(results) == 0 {
+			t.Errorf("query %q: expected hits, got none", q)
+		}
+	}
+
+	// No extractable tokens: empty results, no error.
+	for _, q := range []string{"", `***`, `"(" - :`} {
+		if got := runSearch(t, p, sess, memory.SearchQuery{Text: q}); len(got) != 0 {
+			t.Errorf("query %q: expected empty results, got %d", q, len(got))
+		}
+	}
+}

--- a/internal/memory/provider.go
+++ b/internal/memory/provider.go
@@ -142,7 +142,7 @@ type SearchResult struct {
 	SourceType string    // "message" or "summary"
 	SourceID   string    // message ID or summary ID
 	Content    string    // snippet of the matching content (truncated at ~500 chars)
-	Score      float64   // relevance score: 0 for keyword match, 0.0-1.0 for semantic
+	Score      float64   // normalized BM25 relevance (-bm25), higher is better
 	Timestamp  time.Time // when the source was created
 }
 

--- a/internal/memory/tool.go
+++ b/internal/memory/tool.go
@@ -215,7 +215,7 @@ func (t *memoryTool) buildInputSchema() map[string]any {
 	if t.hasAction(actionSearch) {
 		properties["pattern"] = map[string]any{
 			"type":        "string",
-			"description": "Text pattern to search for (required for search, case-insensitive substring match)",
+			"description": "Keywords to search for (required for search, full-text match ranked by relevance)",
 		}
 		properties["scope"] = map[string]any{
 			"type":        "string",

--- a/pkg/db/sqlc/ctx_message.sql.go
+++ b/pkg/db/sqlc/ctx_message.sql.go
@@ -482,27 +482,46 @@ func (q *Queries) ListMessagesByLogicalPage(ctx context.Context, arg ListMessage
 }
 
 const searchMessages = `-- name: SearchMessages :many
-SELECT id, conversation_id, seq, role, event_type, content, token_count, created_at FROM ctx_message
-WHERE conversation_id = ? AND content LIKE ?
-ORDER BY seq ASC
-LIMIT ?
+SELECT
+    m.id, m.conversation_id, m.seq, m.role, m.event_type, m.content, m.token_count, m.created_at,
+    snippet(ctx_message_fts, 0, '<<', '>>', '...', 32) AS snippet,
+    bm25(ctx_message_fts) AS score
+FROM ctx_message_fts
+JOIN ctx_message m ON m.rowid = ctx_message_fts.rowid
+WHERE ctx_message_fts.content MATCH ?1
+  AND m.conversation_id = ?2
+ORDER BY score ASC
+LIMIT ?3
 `
 
 type SearchMessagesParams struct {
+	Match          string `json:"match"`
 	ConversationID string `json:"conversation_id"`
-	Content        string `json:"content"`
 	Limit          int64  `json:"limit"`
 }
 
-func (q *Queries) SearchMessages(ctx context.Context, arg SearchMessagesParams) ([]CtxMessage, error) {
-	rows, err := q.db.QueryContext(ctx, searchMessages, arg.ConversationID, arg.Content, arg.Limit)
+type SearchMessagesRow struct {
+	ID             string  `json:"id"`
+	ConversationID string  `json:"conversation_id"`
+	Seq            int64   `json:"seq"`
+	Role           string  `json:"role"`
+	EventType      string  `json:"event_type"`
+	Content        string  `json:"content"`
+	TokenCount     int64   `json:"token_count"`
+	CreatedAt      string  `json:"created_at"`
+	Snippet        string  `json:"snippet"`
+	Score          float64 `json:"score"`
+}
+
+func (q *Queries) SearchMessages(ctx context.Context, arg SearchMessagesParams) ([]SearchMessagesRow, error) {
+	rows, err := q.db.QueryContext(ctx, searchMessages, arg.Match, arg.ConversationID, arg.Limit)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []CtxMessage{}
+	items := []SearchMessagesRow{}
 	for rows.Next() {
-		var i CtxMessage
+		var i SearchMessagesRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.ConversationID,
@@ -512,6 +531,8 @@ func (q *Queries) SearchMessages(ctx context.Context, arg SearchMessagesParams) 
 			&i.Content,
 			&i.TokenCount,
 			&i.CreatedAt,
+			&i.Snippet,
+			&i.Score,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/db/sqlc/ctx_summary.sql.go
+++ b/pkg/db/sqlc/ctx_summary.sql.go
@@ -422,27 +422,50 @@ func (q *Queries) ListSummariesByIDs(ctx context.Context, arg ListSummariesByIDs
 }
 
 const searchSummaries = `-- name: SearchSummaries :many
-SELECT id, conversation_id, kind, depth, content, token_count, earliest_at, latest_at, descendant_count, descendant_token_count, source_message_token_count, created_at FROM ctx_summary
-WHERE conversation_id = ? AND content LIKE ?
-ORDER BY created_at ASC
-LIMIT ?
+SELECT
+    s.id, s.conversation_id, s.kind, s.depth, s.content, s.token_count, s.earliest_at, s.latest_at, s.descendant_count, s.descendant_token_count, s.source_message_token_count, s.created_at,
+    snippet(ctx_summary_fts, 0, '<<', '>>', '...', 32) AS snippet,
+    bm25(ctx_summary_fts) AS score
+FROM ctx_summary_fts
+JOIN ctx_summary s ON s.rowid = ctx_summary_fts.rowid
+WHERE ctx_summary_fts.content MATCH ?1
+  AND s.conversation_id = ?2
+ORDER BY score ASC
+LIMIT ?3
 `
 
 type SearchSummariesParams struct {
+	Match          string `json:"match"`
 	ConversationID string `json:"conversation_id"`
-	Content        string `json:"content"`
 	Limit          int64  `json:"limit"`
 }
 
-func (q *Queries) SearchSummaries(ctx context.Context, arg SearchSummariesParams) ([]CtxSummary, error) {
-	rows, err := q.db.QueryContext(ctx, searchSummaries, arg.ConversationID, arg.Content, arg.Limit)
+type SearchSummariesRow struct {
+	ID                      string         `json:"id"`
+	ConversationID          string         `json:"conversation_id"`
+	Kind                    string         `json:"kind"`
+	Depth                   int64          `json:"depth"`
+	Content                 string         `json:"content"`
+	TokenCount              int64          `json:"token_count"`
+	EarliestAt              sql.NullString `json:"earliest_at"`
+	LatestAt                sql.NullString `json:"latest_at"`
+	DescendantCount         int64          `json:"descendant_count"`
+	DescendantTokenCount    int64          `json:"descendant_token_count"`
+	SourceMessageTokenCount int64          `json:"source_message_token_count"`
+	CreatedAt               string         `json:"created_at"`
+	Snippet                 string         `json:"snippet"`
+	Score                   float64        `json:"score"`
+}
+
+func (q *Queries) SearchSummaries(ctx context.Context, arg SearchSummariesParams) ([]SearchSummariesRow, error) {
+	rows, err := q.db.QueryContext(ctx, searchSummaries, arg.Match, arg.ConversationID, arg.Limit)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []CtxSummary{}
+	items := []SearchSummariesRow{}
 	for rows.Next() {
-		var i CtxSummary
+		var i SearchSummariesRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.ConversationID,
@@ -456,6 +479,8 @@ func (q *Queries) SearchSummaries(ctx context.Context, arg SearchSummariesParams
 			&i.DescendantTokenCount,
 			&i.SourceMessageTokenCount,
 			&i.CreatedAt,
+			&i.Snippet,
+			&i.Score,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/db/sqlc/models.go
+++ b/pkg/db/sqlc/models.go
@@ -466,6 +466,10 @@ type CtxMessage struct {
 	CreatedAt      string `json:"created_at"`
 }
 
+type CtxMessageFt struct {
+	Content string `json:"content"`
+}
+
 type CtxMessagePart struct {
 	ID          string         `json:"id"`
 	MessageID   string         `json:"message_id"`
@@ -492,6 +496,10 @@ type CtxSummary struct {
 	DescendantTokenCount    int64          `json:"descendant_token_count"`
 	SourceMessageTokenCount int64          `json:"source_message_token_count"`
 	CreatedAt               string         `json:"created_at"`
+}
+
+type CtxSummaryFt struct {
+	Content string `json:"content"`
 }
 
 type CtxSummaryMessage struct {

--- a/web/content/docs/development/memory-internals.md
+++ b/web/content/docs/development/memory-internals.md
@@ -204,6 +204,15 @@ Summarization escalates from normal mode, to aggressive durable-facts mode, to d
 
 Every assembly emits a structured log entry (`lcm tail telemetry`) with `tail_items`, `tail_messages`, `user_turns`, `items_per_turn`, and `tool_results_before/after` for observability-driven tuning.
 
+### Search
+
+Search runs on SQLite FTS5 with BM25 ranking. Two external-content virtual tables — `ctx_message_fts` and `ctx_summary_fts` — index `content` and are kept in sync by insert/update/delete triggers on the base tables.
+
+- Query text is tokenized into letter/digit/underscore runs, each quoted and OR-joined into a `MATCH` expression, so FTS5 operators in user input never break the query. Queries with no extractable tokens return empty results.
+- Results carry an FTS snippet (`<<term>>` highlights) and a normalized score (`-bm25`, higher is better).
+- `both` scope queries messages and summaries separately with the full limit, then merges by score and keeps the top N — a strong summary hit can outrank a weak message hit. Summary hits drill down via `describe`/`expand`.
+- The FTS schema lives in `internal/db/schemas/tables/ctx_*_fts.sql` but is applied at **runtime** (`internal/db/fts.go`), not through Atlas migrations — Atlas's dev SQLite lacks the fts5 module. The index is rebuilt from existing rows on first creation (so pre-FTS history is searchable) and whenever the sync triggers are found missing — the signature of an Atlas table-rebuild migration, which drops triggers and shifts rowids. If the SQLite build lacks FTS5, startup fails with an explicit error.
+
 ## Simple Plugin
 
 The Simple plugin uses a sliding-window approach:

--- a/web/content/docs/development/memory-internals.zh.md
+++ b/web/content/docs/development/memory-internals.zh.md
@@ -204,6 +204,15 @@ ai.Message (user/assistant/tool_result)
 
 每次组装都会输出一条结构化日志（`lcm tail telemetry`），包含 `tail_items`、`tail_messages`、`user_turns`、`items_per_turn` 和 `tool_results_before/after`，用于数据驱动的参数调优。
 
+### 搜索
+
+搜索基于 SQLite FTS5 和 BM25 排序。两张外部内容（external-content）虚拟表 — `ctx_message_fts` 和 `ctx_summary_fts` — 为 `content` 建立索引，并通过基础表上的 insert/update/delete 触发器保持同步。
+
+- 查询文本按字母/数字/下划线切分为 token，逐个加引号并以 OR 连接成 `MATCH` 表达式，用户输入中的 FTS5 操作符不会破坏查询。无法提取 token 的查询返回空结果。
+- 结果包含 FTS 片段（`<<term>>` 高亮）和归一化分数（`-bm25`，越大越相关）。
+- `both` 范围分别以完整 limit 查询消息和摘要，再按分数合并取前 N — 强摘要命中可以排在弱消息命中之前。摘要命中可通过 `describe`/`expand` 下钻。
+- FTS schema 位于 `internal/db/schemas/tables/ctx_*_fts.sql`，但在**运行时**（`internal/db/fts.go`）创建，而非通过 Atlas 迁移 — Atlas 的 dev SQLite 缺少 fts5 模块。索引会在首次创建时从已有行重建（因此 FTS 之前的历史也可搜索）；当检测到同步触发器丢失时也会重建 — 这是 Atlas 表重建迁移的特征，它会删除触发器并改变 rowid。若 SQLite 构建缺少 FTS5，启动会以明确错误失败。
+
 ## Simple 插件
 
 Simple 插件使用滑动窗口方式：


### PR DESCRIPTION
## What

Replaces the LIKE-based substring search in LCM memory retrieval with SQLite FTS5 full-text search ranked by BM25, covering both raw messages (`ctx_message`) and compacted summaries (`ctx_summary`).

- External-content FTS5 tables `ctx_message_fts` / `ctx_summary_fts`, kept in sync by insert/update/delete triggers (using the FTS5 `'delete'` command form so no stale tokens remain).
- `SearchMessages` / `SearchSummaries` rewritten as conversation-scoped `MATCH` queries with `bm25()` ranking and `snippet()` highlights (`<<term>>`).
- Safe MATCH builder: query text is tokenized into letter/digit/underscore runs, each quoted and OR-joined — FTS5 operators in user input can never break the query; no extractable tokens → empty results.
- `both` scope queries each table with the full limit, normalizes relevance as `-bm25` (higher is better, exposed via `SearchResult.Score`), merges, and keeps the top N — cross-source ranking instead of fill-messages-first.
- Summary hits keep `SourceType`/`SourceID` semantics, so `describe`/`expand` drill-down works unchanged.

## Why

LIKE substring matching has poor recall for multi-token queries, no relevance ranking, no snippets, and cannot compare messages against summaries. LCM is otherwise well-positioned for retrieval — summaries already preserve lineage via `describe`/`expand` — so BM25 search becomes the entry point and summary expansion the drill-down path. See #386 for the full rationale.

## How

**FTS5 cannot go through Atlas** — its embedded dev SQLite lacks the fts5 module (verified: `db:diff` fails with "no such module: fts5", and any fts5 DDL in the migrations dir would break every future diff replay). Instead:

- The FTS DDL lives in `internal/db/schemas/tables/ctx_*_fts.sql`, visible to sqlc via its schema glob but intentionally **not** imported into `main.sql`, so Atlas never sees it (`db:validate` / `db:diff` confirmed clean).
- `internal/db/fts.go` embeds those same files via `go:embed` (single source of truth) and applies them in `OpenDB` after migrations. The index is rebuilt from existing rows on first creation (backfills pre-FTS history) and whenever the sync triggers are found missing — the signature of an Atlas table-rebuild migration, which drops triggers and shifts rowids. A SQLite build without FTS5 fails loudly at startup; there is no LIKE fallback (modernc.org/sqlite bundles FTS5 unconditionally, verified at v1.46.1).
- sqlc quirks worked around: `rank` is a reserved word (alias is `score`), and bare `table MATCH ?` doesn't parse (column-qualified `ctx_message_fts.content MATCH` used instead).

**Tests** (11 new): BM25 ranking order, per-scope filtering, both-scope cross-source merge, limit capping, delete leaves no stale hits, conversation/session isolation, special-character queries, MATCH-builder tokenization, runtime index creation, legacy-row backfill, and trigger-loss self-heal.

**Known limitation**: unicode61 has no CJK segmentation — contiguous Chinese text indexes as a single token, limiting Chinese recall. The trigram tokenizer would fix substring recall at the cost of BM25 quality; worth a separate issue.

Verification: `mise run format && mise run build && mise run test` all green; `mise run db:validate` and a no-op `db:diff` confirm the Atlas pipeline is unaffected.

## Refs

- Closes #386