### PR TITLE
🐛 fix(scheduler): de-flake single-run and disabled-job timing tests

### DIFF
--- a/internal/scheduler/template_test.go
+++ b/internal/scheduler/template_test.go
@@ -352,7 +352,9 @@ func TestDispatchJob_MissingTemplate_ErrorRun(t *testing.T) {
 func TestExecuteSingleRun_SkipsWhenAlreadyRunning(t *testing.T) {
 	svc := testService(t)
 
-	started := make(chan struct{})
+	// Buffered so the non-blocking send below never drops the signal when the
+	// run goroutine reaches it before the test goroutine parks on <-started.
+	started := make(chan struct{}, 1)
 	unblock := make(chan struct{})
 	var callCount int32
 	svc.SetOnJob(func(_ context.Context, _ Job) error {
@@ -383,7 +385,7 @@ func TestExecuteSingleRun_SkipsWhenAlreadyRunning(t *testing.T) {
 	// Wait until the first run is actually executing.
 	select {
 	case <-started:
-	case <-time.After(3 * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatal("first run did not start")
 	}
 
@@ -473,7 +475,7 @@ func TestUpdateUserJob_DisabledJobDoesNotFire(t *testing.T) {
 	}
 
 	// Let it fire at least once to confirm it was active.
-	deadline := time.Now().Add(2 * time.Second)
+	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
 		if atomic.LoadInt32(&fired) > 0 {
 			break
@@ -497,12 +499,24 @@ func TestUpdateUserJob_DisabledJobDoesNotFire(t *testing.T) {
 		t.Error("disabled job should have no gocron entry")
 	}
 
-	// Wait a couple of intervals; the job must not fire again.
-	countBefore := atomic.LoadInt32(&fired)
-	time.Sleep(300 * time.Millisecond)
-	countAfter := atomic.LoadInt32(&fired)
-	if countAfter != countBefore {
-		t.Errorf("disabled job fired %d more times after UpdateUserJob", countAfter-countBefore)
+	// A tick dispatched by gocron just before the entry was removed may still
+	// be executing, so its fire can land after UpdateUserJob returns — a fixed
+	// post-disable window races that straggler on slow runners. Instead wait
+	// for the fire stream to stay quiet for several intervals: in-flight
+	// stragglers are absorbed, while a job still scheduled at 100ms can never
+	// go quiet for 500ms.
+	countAtDisable := atomic.LoadInt32(&fired)
+	last := countAtDisable
+	lastChange := time.Now()
+	quietDeadline := time.Now().Add(10 * time.Second)
+	for time.Since(lastChange) < 500*time.Millisecond {
+		if time.Now().After(quietDeadline) {
+			t.Fatalf("disabled job fired %d more times and never went quiet", atomic.LoadInt32(&fired)-countAtDisable)
+		}
+		time.Sleep(20 * time.Millisecond)
+		if cur := atomic.LoadInt32(&fired); cur != last {
+			last, lastChange = cur, time.Now()
+		}
 	}
 }
 


### PR DESCRIPTION
## What

Stabilize `TestExecuteSingleRun_SkipsWhenAlreadyRunning` and `TestUpdateUserJob_DisabledJobDoesNotFire` in `internal/scheduler` with deterministic synchronization. Test-only changes; no production code touched.

## Why

Both tests intermittently fail the "Test (race + coverage)" CI job on slow runners:

- main's CI failed on them after merging #385, a commit unrelated to scheduling logic.
- PR #387 (unrelated LCM FTS change) hit the same failures (run 27341705268); a plain rerun passed.
- Locally they pass with `-race` in ~3.5s; the failing CI runs took 6.49s / 4.01s — the assertions were racing wall-clock windows.

The 6.49s failure matches ~3.5s base + the 3s `started` timeout exactly, confirming the lost-signal diagnosis below.

## How

**TestExecuteSingleRun_SkipsWhenAlreadyRunning** — the onJob handler signaled "run started" with a non-blocking send (`select { case started <- struct{}{}: default: }`) on an *unbuffered* channel. If the run goroutine reached that select before the test goroutine parked on `<-started` (likely on a contended runner where the test goroutine is descheduled right after `RunJobNow` returns), the signal was dropped via `default` and the test died at the 3s timeout. Fix: buffer the channel (cap 1) so the signal can never be lost; widen the fail-safe deadline to 10s.

**TestUpdateUserJob_DisabledJobDoesNotFire** — gocron's job removal does not synchronize with a tick it already dispatched, so a run in flight at disable time can increment the fire counter after `countBefore` was read, failing the fixed 300ms "no more fires" window; slow runners widen the in-flight execution and hit it more often. Fix: replace the fixed window with a quiescence wait — the fire stream must stay quiet for 500ms (10s overall deadline). Pre-removal stragglers are absorbed; a still-scheduled 100ms job can never stay quiet for 5 intervals, so the regression the test guards against still fails loudly. Also widened the first-fire deadline from 2s to 10s.

Per the issue's guidance: channels + generous-deadline polling, no retries, no production changes, no lengthened fixed sleeps.

Verification:
- `go test ./internal/scheduler/ -race -count=20 -run '...'` — pass (47s)
- `GOMAXPROCS=1 go test ./internal/scheduler/ -race -count=20 -parallel 1 -run '...'` — pass (48s)
- `go test ./internal/scheduler/ -race -count=20 -cpu=1,2` — pass (85s)
- `mise run format && mise run build && mise run test` — pass

## Refs

Closes #389