### PR TITLE
✨ feat(recally): FTS5/BM25 article search

### DIFF
--- a/internal/db/fts.go
+++ b/internal/db/fts.go
@@ -17,6 +17,11 @@ var (
 	ctxMessageFTSSchema string
 	//go:embed schemas/tables/ctx_summary_fts.sql
 	ctxSummaryFTSSchema string
+	// RecallyArticleFTSSchema is exported so recally store tests, which
+	// assemble their schema by hand instead of running migrations, can create
+	// the index and triggers their search queries depend on.
+	//go:embed schemas/tables/recally_article_fts.sql
+	RecallyArticleFTSSchema string
 )
 
 // ensureFTS creates the FTS5 virtual tables and triggers if missing, and
@@ -31,6 +36,7 @@ func ensureFTS(db *sql.DB) error {
 	}{
 		{"ctx_message_fts", ctxMessageFTSSchema},
 		{"ctx_summary_fts", ctxSummaryFTSSchema},
+		{"recally_article_fts", RecallyArticleFTSSchema},
 	} {
 		// Check the insert trigger alongside the table: an Atlas table-rebuild
 		// migration drops the content table's triggers and shifts rowids, which
@@ -45,7 +51,7 @@ func ensureFTS(db *sql.DB) error {
 		}
 		if _, err := db.ExecContext(ctx, t.schema); err != nil {
 			if strings.Contains(err.Error(), "fts5") {
-				return fmt.Errorf("create %s: sqlite build lacks FTS5 support, required for memory search: %w", t.ftsTable, err)
+				return fmt.Errorf("create %s: sqlite build lacks FTS5 support, required for full-text search: %w", t.ftsTable, err)
 			}
 			return fmt.Errorf("create %s: %w", t.ftsTable, err)
 		}

--- a/internal/db/fts_test.go
+++ b/internal/db/fts_test.go
@@ -15,7 +15,7 @@ func TestOpenDBCreatesFTSIndexes(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = db.Close() })
 
-	for _, table := range []string{"ctx_message_fts", "ctx_summary_fts"} {
+	for _, table := range []string{"ctx_message_fts", "ctx_summary_fts", "recally_article_fts"} {
 		if !tableExists(t, db, table) {
 			t.Errorf("%s should exist after OpenDB", table)
 		}
@@ -37,12 +37,16 @@ func TestEnsureFTSBackfillsPreexistingRows(t *testing.T) {
 	for _, stmt := range []string{
 		"DROP TABLE ctx_message_fts",
 		"DROP TABLE ctx_summary_fts",
+		"DROP TABLE recally_article_fts",
 		"DROP TRIGGER IF EXISTS ctx_message_fts_ai",
 		"DROP TRIGGER IF EXISTS ctx_message_fts_ad",
 		"DROP TRIGGER IF EXISTS ctx_message_fts_au",
 		"DROP TRIGGER IF EXISTS ctx_summary_fts_ai",
 		"DROP TRIGGER IF EXISTS ctx_summary_fts_ad",
 		"DROP TRIGGER IF EXISTS ctx_summary_fts_au",
+		"DROP TRIGGER IF EXISTS recally_article_fts_ai",
+		"DROP TRIGGER IF EXISTS recally_article_fts_ad",
+		"DROP TRIGGER IF EXISTS recally_article_fts_au",
 	} {
 		if _, err := db.Exec(stmt); err != nil {
 			t.Fatalf("%s: %v", stmt, err)
@@ -59,12 +63,19 @@ func TestEnsureFTSBackfillsPreexistingRows(t *testing.T) {
 		VALUES ('sum-fts', 'conv-fts', 'leaf', 0, 'legacy aardvark summary', 5)`); err != nil {
 		t.Fatalf("insert summary: %v", err)
 	}
+	if _, err := db.Exec(`INSERT INTO auth_user (id, email) VALUES ('user-fts', 'fts@example.com')`); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO recally_article (id, user_id, url, canonical_url, title)
+		VALUES ('art-fts', 'user-fts', 'https://example.com/a', 'https://example.com/a', 'legacy aardvark article')`); err != nil {
+		t.Fatalf("insert article: %v", err)
+	}
 
 	if err := ensureFTS(db); err != nil {
 		t.Fatalf("ensureFTS: %v", err)
 	}
 
-	for _, table := range []string{"ctx_message_fts", "ctx_summary_fts"} {
+	for _, table := range []string{"ctx_message_fts", "ctx_summary_fts", "recally_article_fts"} {
 		var count int
 		if err := db.QueryRow(
 			"SELECT COUNT(*) FROM " + table + " WHERE " + table + " MATCH 'aardvark'",

--- a/internal/db/ftsquery/ftsquery.go
+++ b/internal/db/ftsquery/ftsquery.go
@@ -1,0 +1,29 @@
+// Package ftsquery builds safe FTS5 MATCH expressions from free text. It is
+// shared by every feature that queries an FTS5 index (memory search, recally
+// article search) so the escaping rules live in exactly one place.
+package ftsquery
+
+import (
+	"strings"
+	"unicode"
+)
+
+// BuildMatchQuery converts free text into an FTS5 MATCH expression. Tokens
+// (runs of letters/digits/underscore) are individually quoted so FTS5 query
+// operators in user input (*, -, :, parens) can never break the query, and
+// OR-joined for recall — BM25 still ranks multi-term hits higher. Returns ""
+// when no tokens can be extracted; callers must skip the query then.
+func BuildMatchQuery(text string) string {
+	tokens := strings.FieldsFunc(text, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_'
+	})
+	quoted := make([]string, 0, len(tokens))
+	for _, tok := range tokens {
+		tok = strings.ReplaceAll(tok, `"`, "")
+		if tok == "" {
+			continue
+		}
+		quoted = append(quoted, `"`+tok+`"`)
+	}
+	return strings.Join(quoted, " OR ")
+}

--- a/internal/db/ftsquery/ftsquery_test.go
+++ b/internal/db/ftsquery/ftsquery_test.go
@@ -1,0 +1,28 @@
+package ftsquery
+
+import "testing"
+
+func TestBuildMatchQuery(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"hello", `"hello"`},
+		{"hello world", `"hello" OR "world"`},
+		{"snake_case token2", `"snake_case" OR "token2"`},
+		{`quoted "phrase" here`, `"quoted" OR "phrase" OR "here"`},
+		{"日本語 test", `"日本語" OR "test"`},
+		// FTS5 operators and punctuation are separators, never query syntax.
+		{"a* (b) -c:d", `"a" OR "b" OR "c" OR "d"`},
+		{"", ""},
+		{`*** (") -:`, ""},
+		{"   ", ""},
+	}
+	for _, tc := range tests {
+		if got := BuildMatchQuery(tc.input); got != tc.want {
+			t.Errorf("BuildMatchQuery(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}

--- a/internal/db/queries/recally_article.sql
+++ b/internal/db/queries/recally_article.sql
@@ -42,15 +42,21 @@ RETURNING *;
 DELETE FROM recally_article WHERE id = ? AND user_id = ?;
 
 -- name: SearchArticles :many
--- Phase 1 MVP: LIKE-based search. Upgrade to FTS5 in future phase.
-SELECT * FROM recally_article
-WHERE user_id = ?
-  AND (title LIKE '%' || ? || '%'
-       OR summary LIKE '%' || ? || '%'
-       OR tags LIKE '%' || ? || '%'
-       OR author LIKE '%' || ? || '%')
-ORDER BY saved_at DESC
-LIMIT ?;
+-- FTS5/BM25 search over title/summary/tags/author. Matching against the
+-- hidden table-name column searches every indexed column (declared for sqlc
+-- in recally_article_fts_sqlc.sql); bm25 weights rank title hits highest,
+-- and snippet column -1 picks the best-matching column. More negative bm25
+-- means more relevant, hence ORDER BY score ASC.
+SELECT
+    sqlc.embed(a),
+    snippet(recally_article_fts, -1, '<<', '>>', '...', 32) AS snippet,
+    bm25(recally_article_fts, 4.0, 2.0, 2.0, 1.0) AS score
+FROM recally_article_fts
+JOIN recally_article a ON a.rowid = recally_article_fts.rowid
+WHERE recally_article_fts.recally_article_fts MATCH sqlc.arg('match')
+  AND a.user_id = sqlc.arg('user_id')
+ORDER BY score ASC
+LIMIT sqlc.arg('limit');
 
 -- name: CountArticlesByStatus :one
 SELECT COUNT(*) as count FROM recally_article WHERE user_id = ? AND status = ?;

--- a/internal/db/schemas/tables/recally_article_fts.sql
+++ b/internal/db/schemas/tables/recally_article_fts.sql
@@ -1,0 +1,33 @@
+-- Runtime-managed FTS5 index over recally_article metadata
+-- (title/summary/tags/author). Executed via go:embed at startup
+-- (internal/db/fts.go), NOT through Atlas migrations: Atlas's embedded dev
+-- SQLite lacks the fts5 module, so this file is intentionally not imported
+-- into main.sql. sqlc still reads it (schema glob) so search queries can
+-- reference the virtual table; see recally_article_fts_sqlc.sql for the
+-- sqlc-only view of fts5's hidden table-name column.
+CREATE VIRTUAL TABLE IF NOT EXISTS recally_article_fts USING fts5(
+    title,
+    summary,
+    tags,
+    author,
+    content='recally_article',
+    content_rowid='rowid',
+    tokenize='unicode61 remove_diacritics 1'
+);
+
+CREATE TRIGGER IF NOT EXISTS recally_article_fts_ai AFTER INSERT ON recally_article BEGIN
+    INSERT INTO recally_article_fts(rowid, title, summary, tags, author)
+    VALUES (new.rowid, new.title, new.summary, new.tags, new.author);
+END;
+
+CREATE TRIGGER IF NOT EXISTS recally_article_fts_ad AFTER DELETE ON recally_article BEGIN
+    INSERT INTO recally_article_fts(recally_article_fts, rowid, title, summary, tags, author)
+    VALUES ('delete', old.rowid, old.title, old.summary, old.tags, old.author);
+END;
+
+CREATE TRIGGER IF NOT EXISTS recally_article_fts_au AFTER UPDATE OF title, summary, tags, author ON recally_article BEGIN
+    INSERT INTO recally_article_fts(recally_article_fts, rowid, title, summary, tags, author)
+    VALUES ('delete', old.rowid, old.title, old.summary, old.tags, old.author);
+    INSERT INTO recally_article_fts(rowid, title, summary, tags, author)
+    VALUES (new.rowid, new.title, new.summary, new.tags, new.author);
+END;

--- a/internal/db/schemas/tables/recally_article_fts_sqlc.sql
+++ b/internal/db/schemas/tables/recally_article_fts_sqlc.sql
@@ -1,0 +1,14 @@
+-- sqlc-only schema shim — NEVER executed against a real database and NOT
+-- imported into main.sql (Atlas never sees it; internal/db/fts.go does not
+-- embed it).
+--
+-- Every FTS5 table has a hidden column named after the table itself; matching
+-- against it searches ALL indexed columns (`WHERE t.t MATCH ?`). sqlc v1.29
+-- cannot see hidden columns and rejects both the bare-table form
+-- (`WHERE recally_article_fts MATCH ?` → "column does not exist") and the
+-- `=` MATCH synonym, while qualifying a real column (`fts.title MATCH ?`)
+-- restricts the search to that column at runtime. Declaring the hidden column
+-- here teaches sqlc's catalog about it so queries/recally_article.sql can use
+-- the all-column form. fts5 itself rejects a declared column named after the
+-- table, so this cannot live in the real DDL.
+ALTER TABLE recally_article_fts ADD COLUMN recally_article_fts TEXT NOT NULL;

--- a/internal/memory/lcm/lcm_helpers_test.go
+++ b/internal/memory/lcm/lcm_helpers_test.go
@@ -175,29 +175,6 @@ func TestTruncateUTF8_UTF8(t *testing.T) {
 	}
 }
 
-func TestBuildMatchQuery(t *testing.T) {
-	tests := []struct {
-		input string
-		want  string
-	}{
-		{"hello", `"hello"`},
-		{"hello world", `"hello" OR "world"`},
-		{"snake_case token2", `"snake_case" OR "token2"`},
-		{`quoted "phrase" here`, `"quoted" OR "phrase" OR "here"`},
-		{"日本語 test", `"日本語" OR "test"`},
-		// FTS5 operators and punctuation are separators, never query syntax.
-		{"a* (b) -c:d", `"a" OR "b" OR "c" OR "d"`},
-		{"", ""},
-		{`*** (") -:`, ""},
-		{"   ", ""},
-	}
-	for _, tc := range tests {
-		if got := buildMatchQuery(tc.input); got != tc.want {
-			t.Errorf("buildMatchQuery(%q) = %q, want %q", tc.input, got, tc.want)
-		}
-	}
-}
-
 func TestBoolToInt(t *testing.T) {
 	if boolToInt(true) != 1 {
 		t.Error("expected boolToInt(true)=1")

--- a/internal/memory/lcm/retrieval.go
+++ b/internal/memory/lcm/retrieval.go
@@ -5,10 +5,9 @@ import (
 	"database/sql"
 	"fmt"
 	"sort"
-	"strings"
-	"unicode"
 	"unicode/utf8"
 
+	"github.com/CherryHQ/stella/internal/db/ftsquery"
 	"github.com/CherryHQ/stella/internal/memory"
 	"github.com/CherryHQ/stella/pkg/db/sqlc"
 )
@@ -42,32 +41,12 @@ func (p *Provider) Search(ctx context.Context, session memory.Session, query mem
 	return p.retrieval.search(ctx, conv.ID, query)
 }
 
-// buildMatchQuery converts free text into an FTS5 MATCH expression. Tokens
-// (runs of letters/digits/underscore) are individually quoted so FTS5 query
-// operators in user input (*, -, :, parens) can never break the query, and
-// OR-joined for recall — BM25 still ranks multi-term hits higher. Returns ""
-// when no tokens can be extracted; callers must skip the query then.
-func buildMatchQuery(text string) string {
-	tokens := strings.FieldsFunc(text, func(r rune) bool {
-		return !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_'
-	})
-	quoted := make([]string, 0, len(tokens))
-	for _, tok := range tokens {
-		tok = strings.ReplaceAll(tok, `"`, "")
-		if tok == "" {
-			continue
-		}
-		quoted = append(quoted, `"`+tok+`"`)
-	}
-	return strings.Join(quoted, " OR ")
-}
-
 func (r *retrievalEngine) search(ctx context.Context, convID string, query memory.SearchQuery) ([]memory.SearchResult, error) {
 	limit := query.Limit
 	if limit <= 0 {
 		limit = defaultSearchLimit
 	}
-	match := buildMatchQuery(query.Text)
+	match := ftsquery.BuildMatchQuery(query.Text)
 	if match == "" {
 		return nil, nil
 	}

--- a/internal/recally/store.go
+++ b/internal/recally/store.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/oklog/ulid/v2"
 
+	"github.com/CherryHQ/stella/internal/db/ftsquery"
 	"github.com/CherryHQ/stella/pkg/db/sqlc"
 )
 
@@ -248,19 +249,20 @@ func (s *Store) ListArticles(ctx context.Context, userID string, filter ArticleF
 	return articles, nil
 }
 
-// SearchArticles searches articles by title, summary, tags, or author.
+// SearchArticles searches articles by title, summary, tags, or author using
+// the FTS5 index, ordered by BM25 relevance (title hits rank highest).
 func (s *Store) SearchArticles(ctx context.Context, userID string, query string, limit int) ([]Article, error) {
 	if limit <= 0 {
 		limit = 50
 	}
-	needle := sql.NullString{String: query, Valid: query != ""}
+	match := ftsquery.BuildMatchQuery(query)
+	if match == "" {
+		return []Article{}, nil
+	}
 	rows, err := s.q.SearchArticles(ctx, sqlc.SearchArticlesParams{
-		UserID:  userID,
-		Column2: needle,
-		Column3: needle,
-		Column4: needle,
-		Column5: needle,
-		Limit:   int64(limit),
+		Match:  match,
+		UserID: userID,
+		Limit:  int64(limit),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("search articles: %w", err)
@@ -269,7 +271,7 @@ func (s *Store) SearchArticles(ctx context.Context, userID string, query string,
 	articles := make([]Article, 0, len(rows))
 	for _, row := range rows {
 		var article Article
-		article.FromSQLCArticle(row)
+		article.FromSQLCArticle(row.RecallyArticle)
 		articles = append(articles, article)
 	}
 	return articles, nil

--- a/internal/recally/store_test.go
+++ b/internal/recally/store_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	_ "modernc.org/sqlite"
+
+	appdb "github.com/CherryHQ/stella/internal/db"
 )
 
 func setupTestDB(t *testing.T) (*sql.DB, func()) {
@@ -112,6 +114,18 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_recally_feed_entry_feed_guid ON recally_fe
 			t.Fatalf("Failed to remove temp dir: %v", removeErr)
 		}
 		t.Fatalf("Failed to create schema: %v", err)
+	}
+
+	// Article search runs against the runtime-managed FTS5 index; apply the
+	// same DDL OpenDB would so triggers keep the index in sync.
+	if _, err := db.Exec(appdb.RecallyArticleFTSSchema); err != nil {
+		if closeErr := db.Close(); closeErr != nil {
+			t.Fatalf("Failed to close test database: %v", closeErr)
+		}
+		if removeErr := os.RemoveAll(tempDir); removeErr != nil {
+			t.Fatalf("Failed to remove temp dir: %v", removeErr)
+		}
+		t.Fatalf("Failed to create FTS schema: %v", err)
 	}
 
 	// Insert a test user
@@ -370,6 +384,141 @@ func TestStore_SearchArticles(t *testing.T) {
 	}
 	if len(results) != 1 {
 		t.Errorf("Expected 1 result for 'Python', got %d", len(results))
+	}
+}
+
+func TestStore_SearchArticles_RanksTitleAboveAuthor(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	store := NewStore(db)
+	ctx := t.Context()
+
+	// Same term in a low-weight column (author) vs the high-weight title.
+	for _, req := range []SaveRequest{
+		{URL: "https://example.com/by-quasar", Title: "Unrelated piece", Author: "Quasar Quill"},
+		{URL: "https://example.com/about-quasar", Title: "Quasar formation explained", Author: "Someone Else"},
+	} {
+		if _, _, err := store.SaveArticle(ctx, "1", req); err != nil {
+			t.Fatalf("SaveArticle failed: %v", err)
+		}
+	}
+
+	results, err := store.SearchArticles(ctx, "1", "quasar", 10)
+	if err != nil {
+		t.Fatalf("SearchArticles failed: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("Expected 2 results, got %d", len(results))
+	}
+	if results[0].Title != "Quasar formation explained" {
+		t.Errorf("Expected title match ranked first, got %q", results[0].Title)
+	}
+}
+
+func TestStore_SearchArticles_UserScoping(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	store := NewStore(db)
+	ctx := t.Context()
+
+	if _, _, err := store.SaveArticle(ctx, "1", SaveRequest{
+		URL: "https://example.com/mine", Title: "Private zeppelin notes",
+	}); err != nil {
+		t.Fatalf("SaveArticle failed: %v", err)
+	}
+
+	results, err := store.SearchArticles(ctx, "2", "zeppelin", 10)
+	if err != nil {
+		t.Fatalf("SearchArticles failed: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("Expected no results for another user, got %d", len(results))
+	}
+}
+
+func TestStore_SearchArticles_NoStaleHitsAfterDeleteAndUpdate(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	store := NewStore(db)
+	ctx := t.Context()
+
+	deleted, _, err := store.SaveArticle(ctx, "1", SaveRequest{
+		URL: "https://example.com/doomed", Title: "Obsolete walrus manual",
+	})
+	if err != nil {
+		t.Fatalf("SaveArticle failed: %v", err)
+	}
+	if err := store.DeleteArticle(ctx, "1", deleted.ID); err != nil {
+		t.Fatalf("DeleteArticle failed: %v", err)
+	}
+	results, err := store.SearchArticles(ctx, "1", "walrus", 10)
+	if err != nil {
+		t.Fatalf("SearchArticles failed: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("Expected no hits after delete, got %d", len(results))
+	}
+
+	// Updates must drop the old terms from the index and add the new ones.
+	article, _, err := store.SaveArticle(ctx, "1", SaveRequest{
+		URL: "https://example.com/renamed", Title: "Original ocelot title",
+	})
+	if err != nil {
+		t.Fatalf("SaveArticle failed: %v", err)
+	}
+	if _, err := store.UpdateArticle(ctx, "1", article.ID, map[string]any{"title": "Renamed capybara title"}); err != nil {
+		t.Fatalf("UpdateArticle failed: %v", err)
+	}
+	results, err = store.SearchArticles(ctx, "1", "ocelot", 10)
+	if err != nil {
+		t.Fatalf("SearchArticles failed: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("Expected no hits for replaced title, got %d", len(results))
+	}
+	results, err = store.SearchArticles(ctx, "1", "capybara", 10)
+	if err != nil {
+		t.Fatalf("SearchArticles failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("Expected 1 hit for new title, got %d", len(results))
+	}
+}
+
+func TestStore_SearchArticles_SpecialCharsAndEmptyQuery(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	store := NewStore(db)
+	ctx := t.Context()
+
+	if _, _, err := store.SaveArticle(ctx, "1", SaveRequest{
+		URL: "https://example.com/special", Title: "C++ versus Rust: a (biased) take",
+	}); err != nil {
+		t.Fatalf("SaveArticle failed: %v", err)
+	}
+
+	// FTS5 operators in user input must never produce a query error.
+	results, err := store.SearchArticles(ctx, "1", `rust* AND (biased) -take "c++"`, 10)
+	if err != nil {
+		t.Fatalf("SearchArticles with operators failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("Expected 1 hit, got %d", len(results))
+	}
+
+	// Queries with no extractable tokens return empty without touching FTS.
+	for _, q := range []string{"", "   ", `*** (") -:`} {
+		results, err := store.SearchArticles(ctx, "1", q, 10)
+		if err != nil {
+			t.Fatalf("SearchArticles(%q) failed: %v", q, err)
+		}
+		if len(results) != 0 {
+			t.Errorf("SearchArticles(%q): expected no results, got %d", q, len(results))
+		}
 	}
 }
 

--- a/pkg/db/sqlc/models.go
+++ b/pkg/db/sqlc/models.go
@@ -597,6 +597,14 @@ type RecallyArticle struct {
 	UpdatedAt    string         `json:"updated_at"`
 }
 
+type RecallyArticleFt struct {
+	Title             string `json:"title"`
+	Summary           string `json:"summary"`
+	Tags              string `json:"tags"`
+	Author            string `json:"author"`
+	RecallyArticleFts string `json:"recally_article_fts"`
+}
+
 type RecallyDigest struct {
 	ID                   string `json:"id"`
 	UserID               string `json:"user_id"`

--- a/pkg/db/sqlc/recally_article.sql.go
+++ b/pkg/db/sqlc/recally_article.sql.go
@@ -426,62 +426,66 @@ func (q *Queries) ListUnreadArticlesOlderThan(ctx context.Context, arg ListUnrea
 }
 
 const searchArticles = `-- name: SearchArticles :many
-SELECT id, user_id, agent_id, url, canonical_url, source_type, title, author, summary, tags, status, starred, file_path, metadata, published_at, saved_at, read_at, created_at, updated_at FROM recally_article
-WHERE user_id = ?
-  AND (title LIKE '%' || ? || '%'
-       OR summary LIKE '%' || ? || '%'
-       OR tags LIKE '%' || ? || '%'
-       OR author LIKE '%' || ? || '%')
-ORDER BY saved_at DESC
-LIMIT ?
+SELECT
+    a.id, a.user_id, a.agent_id, a.url, a.canonical_url, a.source_type, a.title, a.author, a.summary, a.tags, a.status, a.starred, a.file_path, a.metadata, a.published_at, a.saved_at, a.read_at, a.created_at, a.updated_at,
+    snippet(recally_article_fts, -1, '<<', '>>', '...', 32) AS snippet,
+    bm25(recally_article_fts, 4.0, 2.0, 2.0, 1.0) AS score
+FROM recally_article_fts
+JOIN recally_article a ON a.rowid = recally_article_fts.rowid
+WHERE recally_article_fts.recally_article_fts MATCH ?1
+  AND a.user_id = ?2
+ORDER BY score ASC
+LIMIT ?3
 `
 
 type SearchArticlesParams struct {
-	UserID  string         `json:"user_id"`
-	Column2 sql.NullString `json:"column_2"`
-	Column3 sql.NullString `json:"column_3"`
-	Column4 sql.NullString `json:"column_4"`
-	Column5 sql.NullString `json:"column_5"`
-	Limit   int64          `json:"limit"`
+	Match  string `json:"match"`
+	UserID string `json:"user_id"`
+	Limit  int64  `json:"limit"`
 }
 
-// Phase 1 MVP: LIKE-based search. Upgrade to FTS5 in future phase.
-func (q *Queries) SearchArticles(ctx context.Context, arg SearchArticlesParams) ([]RecallyArticle, error) {
-	rows, err := q.db.QueryContext(ctx, searchArticles,
-		arg.UserID,
-		arg.Column2,
-		arg.Column3,
-		arg.Column4,
-		arg.Column5,
-		arg.Limit,
-	)
+type SearchArticlesRow struct {
+	RecallyArticle RecallyArticle `json:"recally_article"`
+	Snippet        string         `json:"snippet"`
+	Score          float64        `json:"score"`
+}
+
+// FTS5/BM25 search over title/summary/tags/author. Matching against the
+// hidden table-name column searches every indexed column (declared for sqlc
+// in recally_article_fts_sqlc.sql); bm25 weights rank title hits highest,
+// and snippet column -1 picks the best-matching column. More negative bm25
+// means more relevant, hence ORDER BY score ASC.
+func (q *Queries) SearchArticles(ctx context.Context, arg SearchArticlesParams) ([]SearchArticlesRow, error) {
+	rows, err := q.db.QueryContext(ctx, searchArticles, arg.Match, arg.UserID, arg.Limit)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []RecallyArticle{}
+	items := []SearchArticlesRow{}
 	for rows.Next() {
-		var i RecallyArticle
+		var i SearchArticlesRow
 		if err := rows.Scan(
-			&i.ID,
-			&i.UserID,
-			&i.AgentID,
-			&i.Url,
-			&i.CanonicalUrl,
-			&i.SourceType,
-			&i.Title,
-			&i.Author,
-			&i.Summary,
-			&i.Tags,
-			&i.Status,
-			&i.Starred,
-			&i.FilePath,
-			&i.Metadata,
-			&i.PublishedAt,
-			&i.SavedAt,
-			&i.ReadAt,
-			&i.CreatedAt,
-			&i.UpdatedAt,
+			&i.RecallyArticle.ID,
+			&i.RecallyArticle.UserID,
+			&i.RecallyArticle.AgentID,
+			&i.RecallyArticle.Url,
+			&i.RecallyArticle.CanonicalUrl,
+			&i.RecallyArticle.SourceType,
+			&i.RecallyArticle.Title,
+			&i.RecallyArticle.Author,
+			&i.RecallyArticle.Summary,
+			&i.RecallyArticle.Tags,
+			&i.RecallyArticle.Status,
+			&i.RecallyArticle.Starred,
+			&i.RecallyArticle.FilePath,
+			&i.RecallyArticle.Metadata,
+			&i.RecallyArticle.PublishedAt,
+			&i.RecallyArticle.SavedAt,
+			&i.RecallyArticle.ReadAt,
+			&i.RecallyArticle.CreatedAt,
+			&i.RecallyArticle.UpdatedAt,
+			&i.Snippet,
+			&i.Score,
 		); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## What

Migrate recally article search (`SearchArticles`) from `LIKE '%q%'` over title/summary/tags/author to an FTS5 MATCH join ranked by BM25, with per-column weights (title 4, summary 2, tags 2, author 1) and `snippet()` on the best-matching column.

## Why

The old query was annotated "Phase 1 MVP: LIKE-based search. Upgrade to FTS5 in future phase." — no relevance ranking, full table scan. #386/#387 landed the complete FTS5 pattern (runtime-managed DDL via `ensureFTS`, external-content indexes with sync triggers, backfill + trigger-loss self-heal, safe MATCH query builder), so the upgrade became cheap and consistent with memory search.

## How

- **New index** `recally_article_fts`: external-content FTS5 over (title, summary, tags, author) with `unicode61 remove_diacritics 1`, plus insert/delete/update sync triggers, following `ctx_message_fts.sql` exactly. Registered in `ensureFTS`'s data-driven loop; applied at startup via go:embed, intentionally **not** imported into `main.sql` (Atlas's dev SQLite lacks fts5).
- **Query rewrite**: `SearchArticles` becomes a MATCH join ordered by `bm25(...) ASC` (aliased `score`, never `rank`), preserving user scoping; the store builds the match expression and returns empty for token-free queries without touching FTS.
- **Shared query builder**: `buildMatchQuery` lifted out of `internal/memory/lcm` into a new `internal/db/ftsquery` package (`BuildMatchQuery`); lcm now imports it, tests moved along — exactly one escaping implementation.
- **Tests**: relevance ranking (title outranks author), user scoping, delete/update staleness, FTS operators in input, empty-token queries, plus backfill of pre-existing articles and index creation in `internal/db/fts_test.go`.

### sqlc multi-column MATCH finding (sqlc v1.29 + modernc.org/sqlite, verified by scratch experiments)

Unlike the single-column case in #387 (`fts.content MATCH` works because restricting to the only column is a no-op), multi-column FTS tables hit a real conflict:

| Form | sqlc parse | Runtime semantics |
| --- | --- | --- |
| `WHERE recally_article_fts MATCH ?` | ❌ "column does not exist" | (all columns) |
| `WHERE recally_article_fts = ?` (FTS5 `=` synonym) | ❌ same error | (all columns) |
| `WHERE fts.title MATCH ?` | ✅ | ❌ restricts to `title`; column filters in the match string can only narrow further, never widen |
| `FROM recally_article_fts(?)` (table-valued) | ⚠️ parses | ❌ sqlc leaves the parameter unwired (literal `sqlc.arg` / unbound `?` in generated SQL) |
| `WHERE recally_article_fts.recally_article_fts MATCH ?` (hidden table-name column) | ✅ with shim | ✅ searches all columns, weighted bm25 + `snippet(..., -1, ...)` work |

Every FTS5 table has a hidden column named after the table; matching against it equals table-name MATCH. sqlc can't see hidden columns, and fts5 rejects *declaring* a column named after the table, so the hidden column is declared for sqlc only in `recally_article_fts_sqlc.sql` (`ALTER TABLE ... ADD COLUMN recally_article_fts TEXT NOT NULL`) — picked up by the sqlc schema glob, never executed at runtime, never seen by Atlas (which only reads `main.sql` imports).

### Known limitation

Same as memory search: `unicode61` does not segment CJK text (cross-ref #388); tokenizer choice stays consistent across all FTS tables so a future fix applies uniformly.

## Refs

- Closes #390
- #386 / #387 — FTS5 infrastructure and design decisions this reuses
- #388 — CJK segmentation limitation