### PR TITLE
✨ feat(fts): trigram tokenizer for CJK recall with short-query LIKE fallback

### DIFF
--- a/internal/db/fts.go
+++ b/internal/db/fts.go
@@ -33,15 +33,29 @@ func ensureFTS(db *sql.DB) error {
 	for _, t := range []struct {
 		ftsTable string
 		schema   string
+		tokenize string
 	}{
-		{"ctx_message_fts", ctxMessageFTSSchema},
-		{"ctx_summary_fts", ctxSummaryFTSSchema},
-		{"recally_article_fts", RecallyArticleFTSSchema},
+		{"ctx_message_fts", ctxMessageFTSSchema, "trigram"},
+		{"ctx_summary_fts", ctxSummaryFTSSchema, "trigram"},
+		{"recally_article_fts", RecallyArticleFTSSchema, "trigram"},
 	} {
+		// A table created with an older tokenizer (unicode61) would survive the
+		// CREATE IF NOT EXISTS below with a stale, incompatible index. Drop it
+		// so the embedded DDL recreates it and the rebuild path backfills it.
+		var ddl sql.NullString
+		_ = db.QueryRowContext(ctx,
+			`SELECT sql FROM sqlite_master WHERE type='table' AND name = ?`, t.ftsTable,
+		).Scan(&ddl) // ErrNoRows means no table yet; the create below handles it
+		if ddl.Valid && !strings.Contains(ddl.String, "tokenize='"+t.tokenize+"'") {
+			if _, err := db.ExecContext(ctx, `DROP TABLE `+t.ftsTable); err != nil {
+				return fmt.Errorf("drop stale %s: %w", t.ftsTable, err)
+			}
+		}
 		// Check the insert trigger alongside the table: an Atlas table-rebuild
 		// migration drops the content table's triggers and shifts rowids, which
 		// silently stales the index. A missing trigger with the index present is
-		// exactly that signature, so it must also force a rebuild.
+		// exactly that signature, so it must also force a rebuild. A tokenizer
+		// drop above also lands here (table missing → existing < 2 → rebuild).
 		var existing int
 		if err := db.QueryRowContext(ctx,
 			"SELECT COUNT(*) FROM sqlite_master WHERE name IN (?, ?)",

--- a/internal/db/fts_test.go
+++ b/internal/db/fts_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -130,5 +131,67 @@ func TestEnsureFTSRebuildsAfterTriggerLoss(t *testing.T) {
 	}
 	if count != 1 {
 		t.Errorf("expected rebuilt index to find the orphaned row, got %d hits", count)
+	}
+}
+
+func TestEnsureFTSRebuildsOnTokenizerDrift(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "fts-tokenizer-drift.db")
+	db, err := OpenDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	// Simulate a database from before the trigram switch: same table and
+	// triggers, but built with the old unicode61 tokenizer. CREATE IF NOT
+	// EXISTS alone would leave it stale, so ensureFTS must detect the
+	// tokenizer mismatch, drop, recreate, and rebuild.
+	for _, stmt := range []string{
+		"DROP TABLE ctx_message_fts",
+		`CREATE VIRTUAL TABLE ctx_message_fts USING fts5(
+			content,
+			content='ctx_message',
+			content_rowid='rowid',
+			tokenize='unicode61 remove_diacritics 1'
+		)`,
+	} {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("%s: %v", stmt, err)
+		}
+	}
+	if _, err := db.Exec(`INSERT INTO ctx_conversation (id, session_id) VALUES ('conv-tok', 'sess-tok')`); err != nil {
+		t.Fatalf("insert conversation: %v", err)
+	}
+	// The surviving insert trigger indexes this row with unicode61, where a
+	// CJK substring query cannot match it.
+	if _, err := db.Exec(`INSERT INTO ctx_message (id, conversation_id, seq, role, content, token_count)
+		VALUES ('msg-tok', 'conv-tok', 1, 'user', '今天讨论了部署方案', 5)`); err != nil {
+		t.Fatalf("insert message: %v", err)
+	}
+
+	if err := ensureFTS(db); err != nil {
+		t.Fatalf("ensureFTS: %v", err)
+	}
+
+	var ddl string
+	if err := db.QueryRow(
+		`SELECT sql FROM sqlite_master WHERE type='table' AND name='ctx_message_fts'`,
+	).Scan(&ddl); err != nil {
+		t.Fatalf("read DDL: %v", err)
+	}
+	if !strings.Contains(ddl, "tokenize='trigram'") {
+		t.Fatalf("expected trigram table after ensureFTS, got DDL: %s", ddl)
+	}
+
+	var count int
+	if err := db.QueryRow(
+		"SELECT COUNT(*) FROM ctx_message_fts WHERE ctx_message_fts MATCH '部署方案'",
+	).Scan(&count); err != nil {
+		t.Fatalf("match: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected CJK substring hit after tokenizer rebuild, got %d", count)
 	}
 }

--- a/internal/db/ftsquery/ftsquery.go
+++ b/internal/db/ftsquery/ftsquery.go
@@ -6,13 +6,17 @@ package ftsquery
 import (
 	"strings"
 	"unicode"
+	"unicode/utf8"
 )
 
-// BuildMatchQuery converts free text into an FTS5 MATCH expression. Tokens
-// (runs of letters/digits/underscore) are individually quoted so FTS5 query
-// operators in user input (*, -, :, parens) can never break the query, and
-// OR-joined for recall — BM25 still ranks multi-term hits higher. Returns ""
-// when no tokens can be extracted; callers must skip the query then.
+// BuildMatchQuery converts free text into an FTS5 MATCH expression for a
+// trigram-tokenized index. Tokens (runs of letters/digits/underscore) are
+// individually quoted so FTS5 query operators in user input (*, -, :, parens)
+// can never break the query, and OR-joined for recall — BM25 still ranks
+// multi-term hits higher. Tokens shorter than 3 runes are dropped: the
+// trigram tokenizer silently matches nothing for them, so they contribute
+// zero recall. Returns "" when no usable token remains; callers must skip
+// MATCH then (and may fall back to a LIKE scan, see EscapeLike).
 func BuildMatchQuery(text string) string {
 	tokens := strings.FieldsFunc(text, func(r rune) bool {
 		return !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_'
@@ -20,10 +24,18 @@ func BuildMatchQuery(text string) string {
 	quoted := make([]string, 0, len(tokens))
 	for _, tok := range tokens {
 		tok = strings.ReplaceAll(tok, `"`, "")
-		if tok == "" {
+		if utf8.RuneCountInString(tok) < 3 {
 			continue
 		}
 		quoted = append(quoted, `"`+tok+`"`)
 	}
 	return strings.Join(quoted, " OR ")
+}
+
+// EscapeLike escapes LIKE wildcards (%, _) and the escape character itself so
+// user text can be embedded in a `LIKE ? ESCAPE '\'` pattern as a literal
+// substring.
+func EscapeLike(s string) string {
+	r := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+	return r.Replace(s)
 }

--- a/internal/db/ftsquery/ftsquery_test.go
+++ b/internal/db/ftsquery/ftsquery_test.go
@@ -15,14 +15,43 @@ func TestBuildMatchQuery(t *testing.T) {
 		{`quoted "phrase" here`, `"quoted" OR "phrase" OR "here"`},
 		{"日本語 test", `"日本語" OR "test"`},
 		// FTS5 operators and punctuation are separators, never query syntax.
-		{"a* (b) -c:d", `"a" OR "b" OR "c" OR "d"`},
+		{"a* (b) -c:d", ""},
 		{"", ""},
 		{`*** (") -:`, ""},
 		{"   ", ""},
+		// Tokens under 3 runes match nothing on a trigram index, so they are
+		// dropped entirely; mixed queries keep only the usable tokens.
+		{"部署", ""},
+		{"go", ""},
+		{"ai 部署", ""},
+		{"部署方案", `"部署方案"`},
+		{"go 部署 deployment", `"deployment"`},
+		{"部署 部署方案", `"部署方案"`},
 	}
 	for _, tc := range tests {
 		if got := BuildMatchQuery(tc.input); got != tc.want {
 			t.Errorf("BuildMatchQuery(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestEscapeLike(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"plain", "plain"},
+		{"50%", `50\%`},
+		{"a_b", `a\_b`},
+		{`back\slash`, `back\\slash`},
+		{`%_\`, `\%\_\\`},
+		{"部署", "部署"},
+	}
+	for _, tc := range tests {
+		if got := EscapeLike(tc.input); got != tc.want {
+			t.Errorf("EscapeLike(%q) = %q, want %q", tc.input, got, tc.want)
 		}
 	}
 }

--- a/internal/db/queries/ctx_message.sql
+++ b/internal/db/queries/ctx_message.sql
@@ -75,6 +75,20 @@ WHERE ctx_message_fts.content MATCH sqlc.arg('match')
 ORDER BY score ASC
 LIMIT sqlc.arg('limit');
 
+-- name: SearchMessagesLike :many
+-- Fallback for queries with no token of 3+ runes, which trigram MATCH would
+-- silently never hit. Scans the content table directly (faster there than on
+-- the FTS table, which pays external-content read-back), recency-ordered, no
+-- BM25. Pattern must be a full '%text%' built with ftsquery.EscapeLike; sqlc
+-- cannot parse || concatenation here, so the caller wraps it, and the parens
+-- around LIKE...ESCAPE are also required by sqlc's grammar. Keep these doc
+-- comments ASCII: multibyte chars corrupt sqlc's query rewriter offsets.
+SELECT * FROM ctx_message
+WHERE conversation_id = sqlc.arg('conversation_id')
+  AND (content LIKE sqlc.arg('pattern') ESCAPE '\')
+ORDER BY created_at DESC
+LIMIT sqlc.arg('limit');
+
 -- name: GetMessagesSince :many
 SELECT * FROM ctx_message
 WHERE conversation_id = ? AND created_at > ?

--- a/internal/db/queries/ctx_summary.sql
+++ b/internal/db/queries/ctx_summary.sql
@@ -64,3 +64,11 @@ WHERE ctx_summary_fts.content MATCH sqlc.arg('match')
   AND s.conversation_id = sqlc.arg('conversation_id')
 ORDER BY score ASC
 LIMIT sqlc.arg('limit');
+
+-- name: SearchSummariesLike :many
+-- Fallback for queries with no token of 3+ runes (see SearchMessagesLike).
+SELECT * FROM ctx_summary
+WHERE conversation_id = sqlc.arg('conversation_id')
+  AND (content LIKE sqlc.arg('pattern') ESCAPE '\')
+ORDER BY created_at DESC
+LIMIT sqlc.arg('limit');

--- a/internal/db/queries/recally_article.sql
+++ b/internal/db/queries/recally_article.sql
@@ -58,6 +58,20 @@ WHERE recally_article_fts.recally_article_fts MATCH sqlc.arg('match')
 ORDER BY score ASC
 LIMIT sqlc.arg('limit');
 
+-- name: SearchArticlesLike :many
+-- Fallback for queries with no token of 3+ runes, which trigram MATCH would
+-- silently never hit. Scans the content table directly, recency-ordered, no
+-- BM25. Pattern must be a full '%text%' built with ftsquery.EscapeLike; see
+-- SearchMessagesLike for the sqlc constraints shaping this query.
+SELECT * FROM recally_article
+WHERE user_id = sqlc.arg('user_id')
+  AND ((title LIKE sqlc.arg('pattern') ESCAPE '\')
+    OR (summary LIKE sqlc.arg('pattern') ESCAPE '\')
+    OR (tags LIKE sqlc.arg('pattern') ESCAPE '\')
+    OR (author LIKE sqlc.arg('pattern') ESCAPE '\'))
+ORDER BY created_at DESC
+LIMIT sqlc.arg('limit');
+
 -- name: CountArticlesByStatus :one
 SELECT COUNT(*) as count FROM recally_article WHERE user_id = ? AND status = ?;
 

--- a/internal/db/schemas/tables/ctx_message_fts.sql
+++ b/internal/db/schemas/tables/ctx_message_fts.sql
@@ -3,11 +3,17 @@
 -- migrations: Atlas's embedded dev SQLite lacks the fts5 module, so this file
 -- is intentionally not imported into main.sql. sqlc still reads it (schema
 -- glob) so search queries can reference the virtual table.
+-- trigram tokenizer: unicode61 indexed contiguous CJK runs as single tokens,
+-- so 部署 never matched 今天讨论了部署方案. Trigram gives CJK (and English)
+-- substring recall with BM25 + snippets; queries under 3 runes silently match
+-- nothing, so callers fall back to LIKE on the content table.
+-- internal/db/fts.go drops and rebuilds the index when an existing table
+-- still carries a different tokenizer.
 CREATE VIRTUAL TABLE IF NOT EXISTS ctx_message_fts USING fts5(
     content,
     content='ctx_message',
     content_rowid='rowid',
-    tokenize='unicode61 remove_diacritics 1'
+    tokenize='trigram'
 );
 
 CREATE TRIGGER IF NOT EXISTS ctx_message_fts_ai AFTER INSERT ON ctx_message BEGIN

--- a/internal/db/schemas/tables/ctx_summary_fts.sql
+++ b/internal/db/schemas/tables/ctx_summary_fts.sql
@@ -3,11 +3,14 @@
 -- migrations: Atlas's embedded dev SQLite lacks the fts5 module, so this file
 -- is intentionally not imported into main.sql. sqlc still reads it (schema
 -- glob) so search queries can reference the virtual table.
+-- trigram tokenizer for CJK substring recall (rationale in
+-- ctx_message_fts.sql); internal/db/fts.go rebuilds the index when an
+-- existing table still carries a different tokenizer.
 CREATE VIRTUAL TABLE IF NOT EXISTS ctx_summary_fts USING fts5(
     content,
     content='ctx_summary',
     content_rowid='rowid',
-    tokenize='unicode61 remove_diacritics 1'
+    tokenize='trigram'
 );
 
 CREATE TRIGGER IF NOT EXISTS ctx_summary_fts_ai AFTER INSERT ON ctx_summary BEGIN

--- a/internal/db/schemas/tables/recally_article_fts.sql
+++ b/internal/db/schemas/tables/recally_article_fts.sql
@@ -5,6 +5,9 @@
 -- into main.sql. sqlc still reads it (schema glob) so search queries can
 -- reference the virtual table; see recally_article_fts_sqlc.sql for the
 -- sqlc-only view of fts5's hidden table-name column.
+-- trigram tokenizer for CJK substring recall (rationale in
+-- ctx_message_fts.sql); internal/db/fts.go rebuilds the index when an
+-- existing table still carries a different tokenizer.
 CREATE VIRTUAL TABLE IF NOT EXISTS recally_article_fts USING fts5(
     title,
     summary,
@@ -12,7 +15,7 @@ CREATE VIRTUAL TABLE IF NOT EXISTS recally_article_fts USING fts5(
     author,
     content='recally_article',
     content_rowid='rowid',
-    tokenize='unicode61 remove_diacritics 1'
+    tokenize='trigram'
 );
 
 CREATE TRIGGER IF NOT EXISTS recally_article_fts_ai AFTER INSERT ON recally_article BEGIN

--- a/internal/memory/lcm/retrieval.go
+++ b/internal/memory/lcm/retrieval.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"sort"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/CherryHQ/stella/internal/db/ftsquery"
@@ -46,17 +47,22 @@ func (r *retrievalEngine) search(ctx context.Context, convID string, query memor
 	if limit <= 0 {
 		limit = defaultSearchLimit
 	}
-	match := ftsquery.BuildMatchQuery(query.Text)
-	if match == "" {
-		return nil, nil
-	}
-
 	scope := scopeBoth
 	switch query.Scope {
 	case memory.SearchScopeMessages:
 		scope = scopeMessages
 	case memory.SearchScopeSummaries:
 		scope = scopeSummaries
+	}
+
+	match := ftsquery.BuildMatchQuery(query.Text)
+	if match == "" {
+		// All tokens are below the trigram minimum (e.g. 部署, "go"), which
+		// MATCH would silently never hit — fall back to a substring scan.
+		if text := strings.TrimSpace(query.Text); text != "" {
+			return r.searchLike(ctx, convID, text, scope, limit)
+		}
+		return nil, nil
 	}
 
 	var results []memory.SearchResult
@@ -109,6 +115,60 @@ func (r *retrievalEngine) search(ctx context.Context, convID string, query memor
 		if results[i].Score != results[j].Score {
 			return results[i].Score > results[j].Score
 		}
+		return results[i].Timestamp.After(results[j].Timestamp)
+	})
+	if len(results) > limit {
+		results = results[:limit]
+	}
+	return results, nil
+}
+
+// searchLike is the recall path for short queries: a plain substring scan of
+// the content tables, recency-ordered. Honest limitation: no BM25 ranking and
+// no snippet highlighting here, so hits carry Score 0 and truncated content.
+func (r *retrievalEngine) searchLike(ctx context.Context, convID, text, scope string, limit int) ([]memory.SearchResult, error) {
+	pattern := "%" + ftsquery.EscapeLike(text) + "%"
+	var results []memory.SearchResult
+
+	if scope == scopeMessages || scope == scopeBoth {
+		msgs, err := r.q.SearchMessagesLike(ctx, sqlc.SearchMessagesLikeParams{
+			ConversationID: convID,
+			Pattern:        pattern,
+			Limit:          int64(limit),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("search messages like: %w", err)
+		}
+		for _, msg := range msgs {
+			results = append(results, memory.SearchResult{
+				SourceType: itemTypeMessage,
+				SourceID:   fmt.Sprint(msg.ID),
+				Content:    truncateUTF8(msg.Content, maxContentSnippet),
+				Timestamp:  parseTime(msg.CreatedAt),
+			})
+		}
+	}
+
+	if scope == scopeSummaries || scope == scopeBoth {
+		sums, err := r.q.SearchSummariesLike(ctx, sqlc.SearchSummariesLikeParams{
+			ConversationID: convID,
+			Pattern:        pattern,
+			Limit:          int64(limit),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("search summaries like: %w", err)
+		}
+		for _, s := range sums {
+			results = append(results, memory.SearchResult{
+				SourceType: itemTypeSummary,
+				SourceID:   s.ID,
+				Content:    truncateUTF8(s.Content, maxContentSnippet),
+				Timestamp:  parseTime(s.CreatedAt),
+			})
+		}
+	}
+
+	sort.SliceStable(results, func(i, j int) bool {
 		return results[i].Timestamp.After(results[j].Timestamp)
 	})
 	if len(results) > limit {

--- a/internal/memory/lcm/search_test.go
+++ b/internal/memory/lcm/search_test.go
@@ -69,10 +69,12 @@ func runSearch(t *testing.T, p memory.Provider, sess memory.Session, q memory.Se
 }
 
 func TestSearch_MessagesRankedByBM25(t *testing.T) {
+	// Contents kept short: the snippet window is 32 tokens, which under the
+	// trigram tokenizer is only ~34 characters.
 	_, p, sess := newSearchTestEnv(t, "fts-rank")
 	appendUser(t, p, sess,
-		"alpha beaver alpha beaver strongdoc",
-		"alpha weakdoc and unrelated padding words here",
+		"alpha beaver alpha strongdoc",
+		"alpha weakdoc padding words",
 		"completely irrelevant content",
 	)
 
@@ -188,20 +190,21 @@ func TestSearch_DeleteRemovesFTSHits(t *testing.T) {
 }
 
 func TestSearch_ConversationIsolation(t *testing.T) {
+	// Marker fits the ~34-char trigram snippet window.
 	_, p, sess := newSearchTestEnv(t, "fts-iso-a")
-	appendUser(t, p, sess, "shared quokka keyword in conversation A")
+	appendUser(t, p, sess, "shared quokka keyword in convA")
 
 	other := newLCMTestSession("fts-iso-b")
 	if err := p.Bootstrap(context.Background(), other); err != nil {
 		t.Fatalf("bootstrap other: %v", err)
 	}
-	appendUser(t, p, other, "shared quokka keyword in conversation B")
+	appendUser(t, p, other, "shared quokka keyword in convB")
 
 	results := runSearch(t, p, sess, memory.SearchQuery{Text: "quokka"})
 	if len(results) != 1 {
 		t.Fatalf("expected 1 hit scoped to conversation A, got %d", len(results))
 	}
-	if !strings.Contains(results[0].Content, "conversation A") {
+	if !strings.Contains(results[0].Content, "convA") {
 		t.Errorf("hit leaked from another conversation: %q", results[0].Content)
 	}
 }
@@ -227,5 +230,81 @@ func TestSearch_SpecialCharactersDoNotError(t *testing.T) {
 		if got := runSearch(t, p, sess, memory.SearchQuery{Text: q}); len(got) != 0 {
 			t.Errorf("query %q: expected empty results, got %d", q, len(got))
 		}
+	}
+}
+
+func TestSearch_CJKSubstringMatch(t *testing.T) {
+	_, p, sess := newSearchTestEnv(t, "fts-cjk")
+	appendUser(t, p, sess, "今天讨论了部署方案的细节和时间表")
+
+	// 3+ rune CJK query goes through trigram MATCH with snippet highlights.
+	results := runSearch(t, p, sess, memory.SearchQuery{Text: "部署方案", Scope: memory.SearchScopeMessages})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 hit for 部署方案, got %d", len(results))
+	}
+	if !strings.Contains(results[0].Content, "<<") {
+		t.Errorf("expected snippet highlighting in MATCH path, got %q", results[0].Content)
+	}
+}
+
+func TestSearch_ShortQueryFallsBackToLike(t *testing.T) {
+	db, p, sess := newSearchTestEnv(t, "fts-short")
+	convID := conversationID(t, db, sess.ID)
+	appendUser(t, p, sess, "今天讨论了部署方案的细节")
+	insertSummary(t, db, convID, "sum-fts-short", "总结：部署流程已经确定")
+
+	// 2-char CJK queries match nothing via trigram MATCH; the LIKE fallback
+	// must still find them, in both scopes, with Score 0 (no BM25 here).
+	results := runSearch(t, p, sess, memory.SearchQuery{Text: "部署", Scope: memory.SearchScopeBoth})
+	if len(results) != 2 {
+		t.Fatalf("expected 2 fallback hits for 部署, got %d: %+v", len(results), results)
+	}
+	for _, r := range results {
+		if r.Score != 0 {
+			t.Errorf("fallback hit should carry Score 0, got %v", r.Score)
+		}
+	}
+
+	msgs := runSearch(t, p, sess, memory.SearchQuery{Text: "部署", Scope: memory.SearchScopeMessages})
+	if len(msgs) != 1 || msgs[0].SourceType != "message" {
+		t.Errorf("messages scope fallback: expected 1 message hit, got %+v", msgs)
+	}
+}
+
+func TestSearch_LikeFallbackConversationIsolation(t *testing.T) {
+	_, p, sess := newSearchTestEnv(t, "fts-like-iso-a")
+	appendUser(t, p, sess, "会话A的部署记录")
+
+	other := newLCMTestSession("fts-like-iso-b")
+	if err := p.Bootstrap(context.Background(), other); err != nil {
+		t.Fatalf("bootstrap other: %v", err)
+	}
+	appendUser(t, p, other, "会话B的部署记录")
+
+	results := runSearch(t, p, sess, memory.SearchQuery{Text: "部署"})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 hit scoped to conversation A, got %d", len(results))
+	}
+	if !strings.Contains(results[0].Content, "会话A") {
+		t.Errorf("fallback hit leaked from another conversation: %q", results[0].Content)
+	}
+}
+
+func TestSearch_LikeFallbackEscapesWildcards(t *testing.T) {
+	_, p, sess := newSearchTestEnv(t, "fts-like-esc")
+	appendUser(t, p, sess,
+		"discount is 50% off",
+		"discount is 500 off",
+		"see a_b here",
+		"see axb here",
+	)
+
+	// Both queries tokenize below the trigram minimum, so they hit the LIKE
+	// fallback; % and _ must match literally, not as wildcards.
+	if got := runSearch(t, p, sess, memory.SearchQuery{Text: "50%"}); len(got) != 1 {
+		t.Errorf("query 50%%: expected 1 literal hit, got %d: %+v", len(got), got)
+	}
+	if got := runSearch(t, p, sess, memory.SearchQuery{Text: "_b"}); len(got) != 1 {
+		t.Errorf("query _b: expected 1 literal hit, got %d: %+v", len(got), got)
 	}
 }

--- a/internal/recally/store.go
+++ b/internal/recally/store.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/oklog/ulid/v2"
@@ -251,13 +252,35 @@ func (s *Store) ListArticles(ctx context.Context, userID string, filter ArticleF
 
 // SearchArticles searches articles by title, summary, tags, or author using
 // the FTS5 index, ordered by BM25 relevance (title hits rank highest).
+// Queries with no token of 3+ runes use an unranked LIKE fallback instead.
 func (s *Store) SearchArticles(ctx context.Context, userID string, query string, limit int) ([]Article, error) {
 	if limit <= 0 {
 		limit = 50
 	}
 	match := ftsquery.BuildMatchQuery(query)
 	if match == "" {
-		return []Article{}, nil
+		// All tokens are below the trigram minimum (e.g. 部署, "go"), which
+		// MATCH would silently never hit — fall back to a substring scan,
+		// recency-ordered, without BM25 ranking.
+		text := strings.TrimSpace(query)
+		if text == "" {
+			return []Article{}, nil
+		}
+		rows, err := s.q.SearchArticlesLike(ctx, sqlc.SearchArticlesLikeParams{
+			UserID:  userID,
+			Pattern: "%" + ftsquery.EscapeLike(text) + "%",
+			Limit:   int64(limit),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("search articles like: %w", err)
+		}
+		articles := make([]Article, 0, len(rows))
+		for _, row := range rows {
+			var article Article
+			article.FromSQLCArticle(row)
+			articles = append(articles, article)
+		}
+		return articles, nil
 	}
 	rows, err := s.q.SearchArticles(ctx, sqlc.SearchArticlesParams{
 		Match:  match,

--- a/internal/recally/store_test.go
+++ b/internal/recally/store_test.go
@@ -438,6 +438,46 @@ func TestStore_SearchArticles_UserScoping(t *testing.T) {
 	}
 }
 
+func TestStore_SearchArticles_CJKAndShortQueryFallback(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	store := NewStore(db)
+	ctx := t.Context()
+
+	if _, _, err := store.SaveArticle(ctx, "1", SaveRequest{
+		URL: "https://example.com/deploy", Title: "今天讨论了部署方案", Summary: "K8s 上线计划",
+	}); err != nil {
+		t.Fatalf("SaveArticle failed: %v", err)
+	}
+
+	// 3+ rune CJK query hits the trigram MATCH path.
+	results, err := store.SearchArticles(ctx, "1", "部署方案", 10)
+	if err != nil {
+		t.Fatalf("SearchArticles failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("Expected 1 MATCH hit for 部署方案, got %d", len(results))
+	}
+
+	// 2-char query matches nothing via trigram MATCH; the LIKE fallback must
+	// still find it, and must stay user-scoped.
+	results, err = store.SearchArticles(ctx, "1", "部署", 10)
+	if err != nil {
+		t.Fatalf("SearchArticles failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("Expected 1 fallback hit for 部署, got %d", len(results))
+	}
+	results, err = store.SearchArticles(ctx, "2", "部署", 10)
+	if err != nil {
+		t.Fatalf("SearchArticles failed: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("Expected fallback to stay user-scoped, got %d hits", len(results))
+	}
+}
+
 func TestStore_SearchArticles_NoStaleHitsAfterDeleteAndUpdate(t *testing.T) {
 	db, cleanup := setupTestDB(t)
 	defer cleanup()

--- a/pkg/db/sqlc/ctx_message.sql.go
+++ b/pkg/db/sqlc/ctx_message.sql.go
@@ -546,3 +546,56 @@ func (q *Queries) SearchMessages(ctx context.Context, arg SearchMessagesParams) 
 	}
 	return items, nil
 }
+
+const searchMessagesLike = `-- name: SearchMessagesLike :many
+SELECT id, conversation_id, seq, role, event_type, content, token_count, created_at FROM ctx_message
+WHERE conversation_id = ?1
+  AND (content LIKE ?2 ESCAPE '\')
+ORDER BY created_at DESC
+LIMIT ?3
+`
+
+type SearchMessagesLikeParams struct {
+	ConversationID string `json:"conversation_id"`
+	Pattern        string `json:"pattern"`
+	Limit          int64  `json:"limit"`
+}
+
+// Fallback for queries with no token of 3+ runes, which trigram MATCH would
+// silently never hit. Scans the content table directly (faster there than on
+// the FTS table, which pays external-content read-back), recency-ordered, no
+// BM25. Pattern must be a full '%text%' built with ftsquery.EscapeLike; sqlc
+// cannot parse || concatenation here, so the caller wraps it, and the parens
+// around LIKE...ESCAPE are also required by sqlc's grammar. Keep these doc
+// comments ASCII: multibyte chars corrupt sqlc's query rewriter offsets.
+func (q *Queries) SearchMessagesLike(ctx context.Context, arg SearchMessagesLikeParams) ([]CtxMessage, error) {
+	rows, err := q.db.QueryContext(ctx, searchMessagesLike, arg.ConversationID, arg.Pattern, arg.Limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []CtxMessage{}
+	for rows.Next() {
+		var i CtxMessage
+		if err := rows.Scan(
+			&i.ID,
+			&i.ConversationID,
+			&i.Seq,
+			&i.Role,
+			&i.EventType,
+			&i.Content,
+			&i.TokenCount,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}

--- a/pkg/db/sqlc/ctx_summary.sql.go
+++ b/pkg/db/sqlc/ctx_summary.sql.go
@@ -494,3 +494,54 @@ func (q *Queries) SearchSummaries(ctx context.Context, arg SearchSummariesParams
 	}
 	return items, nil
 }
+
+const searchSummariesLike = `-- name: SearchSummariesLike :many
+SELECT id, conversation_id, kind, depth, content, token_count, earliest_at, latest_at, descendant_count, descendant_token_count, source_message_token_count, created_at FROM ctx_summary
+WHERE conversation_id = ?1
+  AND (content LIKE ?2 ESCAPE '\')
+ORDER BY created_at DESC
+LIMIT ?3
+`
+
+type SearchSummariesLikeParams struct {
+	ConversationID string `json:"conversation_id"`
+	Pattern        string `json:"pattern"`
+	Limit          int64  `json:"limit"`
+}
+
+// Fallback for queries with no token of 3+ runes (see SearchMessagesLike).
+func (q *Queries) SearchSummariesLike(ctx context.Context, arg SearchSummariesLikeParams) ([]CtxSummary, error) {
+	rows, err := q.db.QueryContext(ctx, searchSummariesLike, arg.ConversationID, arg.Pattern, arg.Limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []CtxSummary{}
+	for rows.Next() {
+		var i CtxSummary
+		if err := rows.Scan(
+			&i.ID,
+			&i.ConversationID,
+			&i.Kind,
+			&i.Depth,
+			&i.Content,
+			&i.TokenCount,
+			&i.EarliestAt,
+			&i.LatestAt,
+			&i.DescendantCount,
+			&i.DescendantTokenCount,
+			&i.SourceMessageTokenCount,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}

--- a/pkg/db/sqlc/recally_article.sql.go
+++ b/pkg/db/sqlc/recally_article.sql.go
@@ -500,6 +500,70 @@ func (q *Queries) SearchArticles(ctx context.Context, arg SearchArticlesParams) 
 	return items, nil
 }
 
+const searchArticlesLike = `-- name: SearchArticlesLike :many
+SELECT id, user_id, agent_id, url, canonical_url, source_type, title, author, summary, tags, status, starred, file_path, metadata, published_at, saved_at, read_at, created_at, updated_at FROM recally_article
+WHERE user_id = ?1
+  AND ((title LIKE ?2 ESCAPE '\')
+    OR (summary LIKE ?2 ESCAPE '\')
+    OR (tags LIKE ?2 ESCAPE '\')
+    OR (author LIKE ?2 ESCAPE '\'))
+ORDER BY created_at DESC
+LIMIT ?3
+`
+
+type SearchArticlesLikeParams struct {
+	UserID  string `json:"user_id"`
+	Pattern string `json:"pattern"`
+	Limit   int64  `json:"limit"`
+}
+
+// Fallback for queries with no token of 3+ runes, which trigram MATCH would
+// silently never hit. Scans the content table directly, recency-ordered, no
+// BM25. Pattern must be a full '%text%' built with ftsquery.EscapeLike; see
+// SearchMessagesLike for the sqlc constraints shaping this query.
+func (q *Queries) SearchArticlesLike(ctx context.Context, arg SearchArticlesLikeParams) ([]RecallyArticle, error) {
+	rows, err := q.db.QueryContext(ctx, searchArticlesLike, arg.UserID, arg.Pattern, arg.Limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []RecallyArticle{}
+	for rows.Next() {
+		var i RecallyArticle
+		if err := rows.Scan(
+			&i.ID,
+			&i.UserID,
+			&i.AgentID,
+			&i.Url,
+			&i.CanonicalUrl,
+			&i.SourceType,
+			&i.Title,
+			&i.Author,
+			&i.Summary,
+			&i.Tags,
+			&i.Status,
+			&i.Starred,
+			&i.FilePath,
+			&i.Metadata,
+			&i.PublishedAt,
+			&i.SavedAt,
+			&i.ReadAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const updateArticle = `-- name: UpdateArticle :one
 UPDATE recally_article
 SET title       = ?1,

--- a/web/content/docs/development/memory-internals.md
+++ b/web/content/docs/development/memory-internals.md
@@ -206,12 +206,13 @@ Every assembly emits a structured log entry (`lcm tail telemetry`) with `tail_it
 
 ### Search
 
-Search runs on SQLite FTS5 with BM25 ranking. Two external-content virtual tables — `ctx_message_fts` and `ctx_summary_fts` — index `content` and are kept in sync by insert/update/delete triggers on the base tables.
+Search runs on SQLite FTS5 with BM25 ranking. Two external-content virtual tables — `ctx_message_fts` and `ctx_summary_fts` — index `content` with the `trigram` tokenizer and are kept in sync by insert/update/delete triggers on the base tables. Trigram gives substring recall — 部署方案 matches inside a longer CJK sentence, and English queries also match substrings ("ploy" hits "deployment").
 
-- Query text is tokenized into letter/digit/underscore runs, each quoted and OR-joined into a `MATCH` expression, so FTS5 operators in user input never break the query. Queries with no extractable tokens return empty results.
-- Results carry an FTS snippet (`<<term>>` highlights) and a normalized score (`-bm25`, higher is better).
+- Query text is tokenized into letter/digit/underscore runs, each quoted and OR-joined into a `MATCH` expression, so FTS5 operators in user input never break the query. Tokens shorter than 3 characters are dropped — trigram `MATCH` silently returns nothing for them.
+- Queries whose tokens are all shorter than 3 characters (部署, "go") fall back to an unranked, recency-ordered `LIKE` scan of the content tables: no BM25 score, no snippet highlights.
+- `MATCH` results carry an FTS snippet (`<<term>>` highlights) and a normalized score (`-bm25`, higher is better).
 - `both` scope queries messages and summaries separately with the full limit, then merges by score and keeps the top N — a strong summary hit can outrank a weak message hit. Summary hits drill down via `describe`/`expand`.
-- The FTS schema lives in `internal/db/schemas/tables/ctx_*_fts.sql` but is applied at **runtime** (`internal/db/fts.go`), not through Atlas migrations — Atlas's dev SQLite lacks the fts5 module. The index is rebuilt from existing rows on first creation (so pre-FTS history is searchable) and whenever the sync triggers are found missing — the signature of an Atlas table-rebuild migration, which drops triggers and shifts rowids. If the SQLite build lacks FTS5, startup fails with an explicit error.
+- The FTS schema lives in `internal/db/schemas/tables/ctx_*_fts.sql` but is applied at **runtime** (`internal/db/fts.go`), not through Atlas migrations — Atlas's dev SQLite lacks the fts5 module. The index is rebuilt from existing rows on first creation (so pre-FTS history is searchable), whenever the sync triggers are found missing — the signature of an Atlas table-rebuild migration, which drops triggers and shifts rowids — and when an existing table carries a different tokenizer (the unicode61 → trigram migration). If the SQLite build lacks FTS5, startup fails with an explicit error.
 
 ## Simple Plugin
 

--- a/web/content/docs/development/memory-internals.zh.md
+++ b/web/content/docs/development/memory-internals.zh.md
@@ -206,12 +206,13 @@ ai.Message (user/assistant/tool_result)
 
 ### 搜索
 
-搜索基于 SQLite FTS5 和 BM25 排序。两张外部内容（external-content）虚拟表 — `ctx_message_fts` 和 `ctx_summary_fts` — 为 `content` 建立索引，并通过基础表上的 insert/update/delete 触发器保持同步。
+搜索基于 SQLite FTS5 和 BM25 排序。两张外部内容（external-content）虚拟表 — `ctx_message_fts` 和 `ctx_summary_fts` — 使用 `trigram` 分词器为 `content` 建立索引，并通过基础表上的 insert/update/delete 触发器保持同步。trigram 提供子串召回 — 部署方案 可以命中更长的中文句子，英文查询也获得子串语义（"ploy" 命中 "deployment"）。
 
-- 查询文本按字母/数字/下划线切分为 token，逐个加引号并以 OR 连接成 `MATCH` 表达式，用户输入中的 FTS5 操作符不会破坏查询。无法提取 token 的查询返回空结果。
-- 结果包含 FTS 片段（`<<term>>` 高亮）和归一化分数（`-bm25`，越大越相关）。
+- 查询文本按字母/数字/下划线切分为 token，逐个加引号并以 OR 连接成 `MATCH` 表达式，用户输入中的 FTS5 操作符不会破坏查询。短于 3 个字符的 token 会被丢弃 — trigram `MATCH` 对它们静默返回零命中。
+- 当所有 token 都短于 3 个字符时（部署、"go"），回退到对内容表的 `LIKE` 扫描：按时间倒序、无 BM25 分数、无片段高亮。
+- `MATCH` 结果包含 FTS 片段（`<<term>>` 高亮）和归一化分数（`-bm25`，越大越相关）。
 - `both` 范围分别以完整 limit 查询消息和摘要，再按分数合并取前 N — 强摘要命中可以排在弱消息命中之前。摘要命中可通过 `describe`/`expand` 下钻。
-- FTS schema 位于 `internal/db/schemas/tables/ctx_*_fts.sql`，但在**运行时**（`internal/db/fts.go`）创建，而非通过 Atlas 迁移 — Atlas 的 dev SQLite 缺少 fts5 模块。索引会在首次创建时从已有行重建（因此 FTS 之前的历史也可搜索）；当检测到同步触发器丢失时也会重建 — 这是 Atlas 表重建迁移的特征，它会删除触发器并改变 rowid。若 SQLite 构建缺少 FTS5，启动会以明确错误失败。
+- FTS schema 位于 `internal/db/schemas/tables/ctx_*_fts.sql`，但在**运行时**（`internal/db/fts.go`）创建，而非通过 Atlas 迁移 — Atlas 的 dev SQLite 缺少 fts5 模块。索引会在首次创建时从已有行重建（因此 FTS 之前的历史也可搜索）；当检测到同步触发器丢失时也会重建 — 这是 Atlas 表重建迁移的特征，它会删除触发器并改变 rowid；当现有表使用不同分词器时同样会重建（unicode61 → trigram 迁移）。若 SQLite 构建缺少 FTS5，启动会以明确错误失败。
 
 ## Simple 插件
 


### PR DESCRIPTION
> **Stacked PR**: based on #392 (`feat/recally-fts5-search`) and must merge after it — or be retargeted to `main` once #392 merges. Only the last commit is new here.

## What

Switch all three FTS5 indexes (`ctx_message_fts`, `ctx_summary_fts`, `recally_article_fts`) from `unicode61` to the `trigram` tokenizer, and add an unranked `LIKE` fallback for queries whose tokens are all shorter than 3 runes. Existing databases are migrated automatically: `ensureFTS` detects a tokenizer mismatch in the table DDL, drops the stale virtual table, and rebuilds the index from the content tables.

## Why

unicode61 has no CJK segmentation: it indexes a contiguous CJK run as a single token, so 部署 never matched 今天讨论了部署方案 — partial-phrase recall for Chinese memory/article search was effectively zero, and Stella's content is heavily Chinese.

Trigram gives CJK substring recall with BM25 ranking and snippet highlights intact (verified with modernc.org/sqlite v1.46.1 / SQLite 3.51.2). The catch: trigram `MATCH` **silently returns zero hits** for any term under 3 chars (部署, `go`, `ai`) — no error — which is why short queries need an explicit fallback instead of just being passed through.

## How

- **Tokenizer**: `tokenize='trigram'` (default `case_sensitive 0`; `case_sensitive=1` would lose LIKE acceleration and break uppercase queries) in the three runtime-managed FTS schema files. Triggers, external-content structure, `'delete'` command form, and `'rebuild'` are unchanged.
- **Drift rebuild** (`internal/db/fts.go`): the table list now carries an expected-tokenizer marker; if `sqlite_master` DDL doesn't contain it, the virtual table is dropped before the existing `CREATE IF NOT EXISTS` + `existing < 2` rebuild logic runs — the drop makes the table count as missing, so the established backfill path handles the rest (~62ms for 50k rows).
- **`ftsquery.BuildMatchQuery`**: drops tokens under 3 runes (they contribute zero recall under trigram); returns `""` when nothing usable remains. New `ftsquery.EscapeLike` escapes `%`/`_`/`\` for `LIKE ... ESCAPE '\'`.
- **LIKE fallback**: when the match expression is empty but the trimmed query isn't, LCM search and recally article search run new sqlc queries (`SearchMessagesLike`, `SearchSummariesLike`, `SearchArticlesLike`) against the **content tables** — short LIKE patterns are not trigram-accelerated on the FTS tables and are actually slower there. Fallback hits are recency-ordered with Score 0 and truncated content; documented honestly as unranked.
- **Tests**: tokenizer-drift rebuild (unicode61 table recreated, ensureFTS converts it to trigram and the CJK row becomes searchable), 2-char CJK fallback + 4-char CJK MATCH with highlights, fallback conversation/user isolation, `%`/`_` wildcard escaping, token-dropping and EscapeLike unit tests. Two pre-existing snippet assertions were adjusted because the 32-token snippet window is ~34 chars under trigram.
- **Docs**: `memory-internals.md` / `.zh.md` Search sections updated (trigram semantics, short-query fallback, English substring matching).

Notable sqlc findings: its SQLite grammar rejects `||` concatenation and unparenthesized `LIKE ... ESCAPE` after `AND`, and multibyte characters in query doc comments corrupt its rewriter offsets — the LIKE queries are shaped accordingly (parenthesized, full pattern bound from Go, ASCII comments).

Verification: `mise run format && mise run build && mise run test` all green; focused new tests pass with `-count=1`.

## Refs

- Closes #388
- Stacked on #392 (recally FTS5 search + shared `ftsquery` package)
- #386 (FTS5/BM25 search design, where the CJK limitation was called out), #387 (LCM FTS implementation), #390 (recally search issue)