### PR TITLE
perf(lcm): push session list filters and writes into SQL

### DIFF
--- a/internal/db/queries/ctx_conversation.sql
+++ b/internal/db/queries/ctx_conversation.sql
@@ -40,6 +40,25 @@ WHERE session_id = sqlc.arg(session_id) AND user_id = sqlc.arg(user_id) AND agen
 UPDATE ctx_conversation SET title = sqlc.arg(title), updated_at = datetime('now')
 WHERE session_id = sqlc.arg(session_id) AND user_id = sqlc.arg(user_id) AND agent_id IS sqlc.narg(agent_id);
 
+-- name: UpdateConversationInfoBySessionID :exec
+UPDATE ctx_conversation
+SET
+  title = CASE
+    WHEN sqlc.narg(title) IS NOT NULL AND (title IS NULL OR title != sqlc.narg(title)) THEN sqlc.narg(title)
+    ELSE title
+  END,
+  archived = CASE WHEN archived != sqlc.arg(archived) THEN sqlc.arg(archived) ELSE archived END,
+  kind = CASE WHEN sqlc.narg(kind) IS NOT NULL AND kind != sqlc.narg(kind) THEN sqlc.narg(kind) ELSE kind END,
+  project_id = CASE
+    WHEN sqlc.narg(project_id) IS NOT NULL AND (project_id IS NULL OR project_id != sqlc.narg(project_id)) THEN sqlc.narg(project_id)
+    ELSE project_id
+  END,
+  last_active = datetime('now'),
+  updated_at = datetime('now')
+WHERE session_id = sqlc.arg(session_id)
+  AND user_id = sqlc.arg(user_id)
+  AND agent_id IS sqlc.narg(agent_id);
+
 -- name: ListConversations :many
 SELECT * FROM ctx_conversation
 WHERE user_id = sqlc.arg(user_id)
@@ -52,6 +71,16 @@ SELECT * FROM ctx_conversation
 WHERE user_id = sqlc.arg(user_id)
   AND (sqlc.narg(agent_id) IS NULL OR agent_id = sqlc.narg(agent_id))
 ORDER BY last_active DESC;
+
+-- name: ListConversationsFiltered :many
+SELECT * FROM ctx_conversation
+WHERE user_id = sqlc.arg(user_id)
+  AND agent_id IS sqlc.narg(agent_id)
+  AND (sqlc.arg(include_archived) != 0 OR archived = 0)
+  AND (sqlc.narg(kind) IS NULL OR kind = sqlc.narg(kind))
+  AND (sqlc.narg(project_id) IS NULL OR project_id = sqlc.narg(project_id))
+ORDER BY last_active DESC
+LIMIT sqlc.arg(limit) OFFSET sqlc.arg(offset);
 
 -- name: ListAgentConversationLastActive :many
 SELECT agent_id, MAX(last_active) AS last_active
@@ -66,6 +95,15 @@ SELECT * FROM ctx_conversation
 WHERE agent_id = sqlc.arg(agent_id)
   AND archived = 0
 ORDER BY last_active DESC;
+
+-- name: ListConversationsForReviewFiltered :many
+SELECT * FROM ctx_conversation
+WHERE agent_id = sqlc.arg(agent_id)
+  AND archived = 0
+  AND (sqlc.narg(kind) IS NULL OR kind = sqlc.narg(kind))
+  AND (sqlc.narg(project_id) IS NULL OR project_id = sqlc.narg(project_id))
+ORDER BY last_active DESC
+LIMIT sqlc.arg(limit) OFFSET sqlc.arg(offset);
 
 -- name: ListConversationsByKind :many
 SELECT * FROM ctx_conversation WHERE agent_id = ? AND user_id = ? AND kind = ? AND archived = 0 ORDER BY last_active DESC;

--- a/internal/memory/lcm/provider_extra_test.go
+++ b/internal/memory/lcm/provider_extra_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -51,6 +52,14 @@ func newLCMTestProvider(t *testing.T) (memory.Provider, func()) {
 		_ = p.Close()
 		_ = db.Close()
 	}
+}
+
+func sessionIDs(infos []memory.SessionInfo) []string {
+	ids := make([]string, 0, len(infos))
+	for _, info := range infos {
+		ids = append(ids, info.ID)
+	}
+	return ids
 }
 
 func newLCMTestSession(suffix string) memory.Session {
@@ -448,6 +457,135 @@ func TestLCMProvider_LoadHistory(t *testing.T) {
 	}
 	if len(history) < 2 {
 		t.Errorf("expected at least 2 messages in history, got %d", len(history))
+	}
+}
+
+func TestLCMProvider_ListInfoFiltersInSQL(t *testing.T) {
+	db := newLCMTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	p, err := lcm.New(db, nil, nil)
+	if err != nil {
+		t.Fatalf("new provider: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	ctx := memory.WithAgentID(memory.WithUserID(context.Background(), "1"), "test")
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	fixtures := []memory.SessionInfo{
+		{ID: "list-1", AgentID: "test", UserID: "1", Channel: "web", Kind: "chat", ProjectID: "p1", LastActive: base.Add(1 * time.Minute)},
+		{ID: "list-2", AgentID: "test", UserID: "1", Channel: "web", Kind: "task", ProjectID: "p1", LastActive: base.Add(2 * time.Minute)},
+		{ID: "list-3", AgentID: "test", UserID: "1", Channel: "web", Kind: "chat", ProjectID: "p2", LastActive: base.Add(3 * time.Minute)},
+		{ID: "list-4", AgentID: "test", UserID: "1", Channel: "web", Kind: "chat", ProjectID: "p1", LastActive: base.Add(4 * time.Minute)},
+		{ID: "list-5", AgentID: "test", UserID: "1", Channel: "web", Kind: "chat", ProjectID: "p1", LastActive: base.Add(5 * time.Minute), Archived: true},
+		{ID: "list-6", AgentID: "test", UserID: "1", Channel: "web", Kind: "chat", ProjectID: "p1", LastActive: base.Add(6 * time.Minute)},
+	}
+	for _, info := range fixtures {
+		if err := p.SaveInfo(ctx, info); err != nil {
+			t.Fatalf("SaveInfo %s: %v", info.ID, err)
+		}
+	}
+
+	infos, err := p.ListInfo(ctx, memory.ListOptions{Kind: "chat", ProjectID: "p1", Offset: 1, Limit: 2})
+	if err != nil {
+		t.Fatalf("ListInfo filtered: %v", err)
+	}
+	if got, want := sessionIDs(infos), []string{"list-4", "list-1"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("filtered IDs = %v, want %v", got, want)
+	}
+
+	infos, err = p.ListInfo(ctx, memory.ListOptions{Kind: "chat", ProjectID: "p1", IncludeArchived: true, Limit: 3})
+	if err != nil {
+		t.Fatalf("ListInfo include archived: %v", err)
+	}
+	if got, want := sessionIDs(infos), []string{"list-6", "list-5", "list-4"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("include archived IDs = %v, want %v", got, want)
+	}
+}
+
+func TestLCMProvider_SaveInfoSingleUpdateSemantics(t *testing.T) {
+	db := newLCMTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	p, err := lcm.New(db, nil, nil)
+	if err != nil {
+		t.Fatalf("new provider: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	ctx := memory.WithAgentID(memory.WithUserID(context.Background(), "1"), "test")
+	initial := memory.SessionInfo{ID: "save-info", AgentID: "test", UserID: "1", Channel: "web", Kind: "chat", ProjectID: "p1", Title: "Original", LastActive: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+	if err := p.SaveInfo(ctx, initial); err != nil {
+		t.Fatalf("SaveInfo initial: %v", err)
+	}
+	if err := p.SaveInfo(ctx, memory.SessionInfo{ID: "save-info", AgentID: "test", UserID: "1", Archived: true}); err != nil {
+		t.Fatalf("SaveInfo partial: %v", err)
+	}
+	info, err := p.LoadInfo(ctx, "save-info")
+	if err != nil {
+		t.Fatalf("LoadInfo partial: %v", err)
+	}
+	if info.Title != "Original" || !info.Archived || info.Kind != "chat" || info.ProjectID != "p1" {
+		t.Fatalf("partial update clobbered fields: %+v", info)
+	}
+
+	if err := p.SaveInfo(ctx, memory.SessionInfo{ID: "save-info", AgentID: "test", UserID: "1", Title: "Renamed", Kind: "task", ProjectID: "p2"}); err != nil {
+		t.Fatalf("SaveInfo full: %v", err)
+	}
+	info, err = p.LoadInfo(ctx, "save-info")
+	if err != nil {
+		t.Fatalf("LoadInfo full: %v", err)
+	}
+	if info.Title != "Renamed" || info.Archived || info.Kind != "task" || info.ProjectID != "p2" {
+		t.Fatalf("full update = %+v", info)
+	}
+
+	if err := p.SaveInfo(ctx, memory.SessionInfo{ID: "save-info", AgentID: "test", UserID: "1", Title: ""}); err != nil {
+		t.Fatalf("SaveInfo empty title/project: %v", err)
+	}
+	info, err = p.LoadInfo(ctx, "save-info")
+	if err != nil {
+		t.Fatalf("LoadInfo final: %v", err)
+	}
+	if info.Title != "Renamed" || info.ProjectID != "p2" {
+		t.Fatalf("empty title/project should preserve existing values: %+v", info)
+	}
+}
+
+func TestLCMProvider_ListInfoForReviewFiltersInSQL(t *testing.T) {
+	db := newLCMTestDB(t)
+	defer func() { _ = db.Close() }()
+	if _, err := db.Exec(`INSERT INTO auth_user (id, email) VALUES ('2', 'user-2@test.local')`); err != nil {
+		t.Fatalf("seed second user: %v", err)
+	}
+
+	p, err := lcm.New(db, nil, nil)
+	if err != nil {
+		t.Fatalf("new provider: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	fixtures := []memory.SessionInfo{
+		{ID: "review-1", AgentID: "test", UserID: "1", Channel: "web", Kind: "chat", ProjectID: "p1", LastActive: base.Add(1 * time.Minute)},
+		{ID: "review-2", AgentID: "test", UserID: "2", Channel: "web", Kind: "task", ProjectID: "p1", LastActive: base.Add(2 * time.Minute)},
+		{ID: "review-3", AgentID: "test", UserID: "1", Channel: "web", Kind: "chat", ProjectID: "p2", LastActive: base.Add(3 * time.Minute)},
+		{ID: "review-4", AgentID: "test", UserID: "2", Channel: "web", Kind: "chat", ProjectID: "p1", LastActive: base.Add(4 * time.Minute)},
+		{ID: "review-5", AgentID: "test", UserID: "1", Channel: "web", Kind: "chat", ProjectID: "p1", LastActive: base.Add(5 * time.Minute), Archived: true},
+		{ID: "review-6", AgentID: "test", UserID: "2", Channel: "web", Kind: "chat", ProjectID: "p1", LastActive: base.Add(6 * time.Minute)},
+	}
+	for _, info := range fixtures {
+		if err := p.SaveInfo(context.Background(), info); err != nil {
+			t.Fatalf("SaveInfo %s: %v", info.ID, err)
+		}
+	}
+
+	infos, err := p.ListInfoForReview(context.Background(), memory.ListOptions{AgentID: "test", Kind: "chat", ProjectID: "p1", Offset: 1, Limit: 2})
+	if err != nil {
+		t.Fatalf("ListInfoForReview filtered: %v", err)
+	}
+	if got, want := sessionIDs(infos), []string{"review-4", "review-1"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("review filtered IDs = %v, want %v", got, want)
 	}
 }
 

--- a/internal/memory/lcm/review.go
+++ b/internal/memory/lcm/review.go
@@ -31,14 +31,10 @@ func (p *Provider) BuildReviewContext(ctx context.Context, session memory.Sessio
 	var b strings.Builder
 
 	if !since.IsZero() {
+		remainingBudget := maxReviewTokens
 		summaries, err := p.q.GetSummariesByConversation(ctx, conv.ID)
 		if err == nil && len(summaries) > 0 {
-			b.WriteString("<prior_context>\n")
-			for _, s := range summaries {
-				b.WriteString(FormatSummaryXML(s, nil))
-				b.WriteString("\n")
-			}
-			b.WriteString("</prior_context>\n\n")
+			remainingBudget = appendReviewSummaries(&b, summaries, remainingBudget)
 		}
 
 		msgs, err := p.q.GetMessagesSince(ctx, sqlc.GetMessagesSinceParams{
@@ -48,7 +44,7 @@ func (p *Provider) BuildReviewContext(ctx context.Context, session memory.Sessio
 		if err != nil {
 			return "", fmt.Errorf("get messages since: %w", err)
 		}
-		appendReviewMessages(&b, msgs)
+		appendReviewMessagesWithBudget(&b, msgs, remainingBudget)
 	} else {
 		msgs, err := p.q.GetMessagesByConversation(ctx, conv.ID)
 		if err != nil {
@@ -60,7 +56,44 @@ func (p *Provider) BuildReviewContext(ctx context.Context, session memory.Sessio
 	return b.String(), nil
 }
 
+func appendReviewSummaries(b *strings.Builder, summaries []sqlc.CtxSummary, budget int) int {
+	if budget <= 0 {
+		return 0
+	}
+	xmlByIndex := make([]string, len(summaries))
+	selected := make([]int, 0, len(summaries))
+	remaining := budget
+	for i := len(summaries) - 1; i >= 0; i-- {
+		xml := FormatSummaryXML(summaries[i], nil)
+		cost := memory.EstimateTokens(xml) + 4
+		if remaining-cost < 0 {
+			break
+		}
+		xmlByIndex[i] = xml
+		selected = append(selected, i)
+		remaining -= cost
+	}
+	if len(selected) == 0 {
+		return budget
+	}
+
+	b.WriteString("<prior_context>\n")
+	for i := len(selected) - 1; i >= 0; i-- {
+		b.WriteString(xmlByIndex[selected[i]])
+		b.WriteString("\n")
+	}
+	b.WriteString("</prior_context>\n\n")
+	return remaining
+}
+
 func appendReviewMessages(b *strings.Builder, msgs []sqlc.CtxMessage) {
+	appendReviewMessagesWithBudget(b, msgs, maxReviewTokens)
+}
+
+func appendReviewMessagesWithBudget(b *strings.Builder, msgs []sqlc.CtxMessage, budget int) {
+	if budget <= 0 {
+		return
+	}
 	// Filter out tool results — they're large and useless for the reviewer.
 	filtered := make([]sqlc.CtxMessage, 0, len(msgs))
 	for _, m := range msgs {
@@ -73,7 +106,6 @@ func appendReviewMessages(b *strings.Builder, msgs []sqlc.CtxMessage) {
 	}
 
 	// Take the tail that fits within the token budget.
-	budget := maxReviewTokens
 	start := len(filtered)
 	for i := len(filtered) - 1; i >= 0; i-- {
 		cost := memory.EstimateTokens(filtered[i].Content) + memory.EstimateTokens(filtered[i].Role) + 4

--- a/internal/memory/lcm/review_test.go
+++ b/internal/memory/lcm/review_test.go
@@ -1,11 +1,63 @@
 package lcm
 
 import (
+	"context"
+	"fmt"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/CherryHQ/stella/internal/memory"
 	"github.com/CherryHQ/stella/pkg/db/sqlc"
 )
+
+func TestBuildReviewContext_BudgetsSummariesBeforeMessages(t *testing.T) {
+	db := newAssemblerTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	p, err := New(db, nil, nil)
+	if err != nil {
+		t.Fatalf("new provider: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	ctx := context.Background()
+	convID := "review-budget-conv"
+	sess := memory.Session{ID: "review-budget-session", UserID: "user-1", AgentID: "agent-1", Channel: "test"}
+	if _, err := db.ExecContext(ctx, `INSERT INTO ctx_conversation (id, session_id, channel, kind, agent_id, user_id) VALUES (?, ?, 'test', 'chat', ?, ?)`, convID, sess.ID, sess.AgentID, sess.UserID); err != nil {
+		t.Fatalf("insert conversation: %v", err)
+	}
+
+	large := strings.Repeat("s", 240_000)
+	for i := 1; i <= 3; i++ {
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO ctx_summary (id, conversation_id, kind, depth, content, token_count, created_at)
+			VALUES (?, ?, ?, 0, ?, 60000, ?)
+		`, fmt.Sprintf("summary-%d", i), convID, kindLeaf, fmt.Sprintf("summary %d %s", i, large), fmt.Sprintf("2026-01-01 00:00:0%d", i)); err != nil {
+			t.Fatalf("insert summary %d: %v", i, err)
+		}
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO ctx_message (id, conversation_id, seq, role, event_type, content, token_count, created_at)
+		VALUES ('msg-review', ?, 1, 'user', 'text', 'recent review message', 5, '2026-01-02 00:00:00')
+	`, convID); err != nil {
+		t.Fatalf("insert message: %v", err)
+	}
+
+	got, err := p.BuildReviewContext(ctx, sess, time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("BuildReviewContext: %v", err)
+	}
+	if strings.Contains(got, `id="summary-1"`) || strings.Contains(got, `id="summary-2"`) {
+		t.Fatalf("older summaries should be truncated by budget")
+	}
+	if !strings.Contains(got, `id="summary-3"`) {
+		t.Fatalf("newest summary should be kept")
+	}
+	if !strings.Contains(got, "recent review message") {
+		t.Fatalf("messages should use remaining budget, got length %d", len(got))
+	}
+}
 
 func TestAppendReviewMessages_FiltersToolResults(t *testing.T) {
 	msgs := []sqlc.CtxMessage{

--- a/internal/memory/lcm/sessions.go
+++ b/internal/memory/lcm/sessions.go
@@ -62,7 +62,7 @@ func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error 
 	info.UserID = userID
 	info.AgentID = agentIDValue
 
-	conv, err := p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: info.ID, UserID: sql.NullString{String: info.UserID, Valid: true}, AgentID: nullAgent(info.AgentID)})
+	_, err = p.q.GetConversationBySessionID(ctx, sqlc.GetConversationBySessionIDParams{SessionID: info.ID, UserID: sql.NullString{String: info.UserID, Valid: true}, AgentID: nullAgent(info.AgentID)})
 	if errors.Is(err, sql.ErrNoRows) {
 		lastActive := info.LastActive
 		if lastActive.IsZero() {
@@ -93,51 +93,16 @@ func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error 
 		return fmt.Errorf("get conversation: %w", err)
 	}
 
-	agentID := nullAgent(info.AgentID)
-
-	// Update existing conversation fields.
-	if info.Title != "" {
-		if err := p.q.UpdateConversationTitleBySessionID(ctx, sqlc.UpdateConversationTitleBySessionIDParams{
-			Title:     sql.NullString{String: info.Title, Valid: true},
-			SessionID: info.ID,
-			UserID:    sql.NullString{String: info.UserID, Valid: true},
-			AgentID:   agentID,
-		}); err != nil {
-			return fmt.Errorf("update title: %w", err)
-		}
-	}
-	if boolToInt(info.Archived) != conv.Archived {
-		if err := p.q.UpdateConversationArchived(ctx, sqlc.UpdateConversationArchivedParams{
-			Archived:  boolToInt(info.Archived),
-			SessionID: info.ID,
-			UserID:    sql.NullString{String: info.UserID, Valid: true},
-			AgentID:   agentID,
-		}); err != nil {
-			return fmt.Errorf("update archived: %w", err)
-		}
-	}
-	if (info.Kind != "" && info.Kind != conv.Kind) || (info.ProjectID != "" && (!conv.ProjectID.Valid || info.ProjectID != conv.ProjectID.String)) {
-		kind := info.Kind
-		if kind == "" {
-			kind = conv.Kind
-		}
-		projectID := sql.NullString{String: info.ProjectID, Valid: info.ProjectID != ""}
-		if info.ProjectID == "" && conv.ProjectID.Valid {
-			projectID = conv.ProjectID
-		}
-		if err := p.q.UpdateConversationKindProject(ctx, sqlc.UpdateConversationKindProjectParams{
-			Kind:      kind,
-			ProjectID: projectID,
-			SessionID: info.ID,
-			UserID:    sql.NullString{String: info.UserID, Valid: true},
-			AgentID:   agentID,
-		}); err != nil {
-			return fmt.Errorf("update kind/project: %w", err)
-		}
-	}
-
-	if err := p.q.UpdateConversationLastActive(ctx, sqlc.UpdateConversationLastActiveParams{SessionID: info.ID, UserID: sql.NullString{String: info.UserID, Valid: true}, AgentID: agentID}); err != nil {
-		return fmt.Errorf("update last_active: %w", err)
+	if err := p.q.UpdateConversationInfoBySessionID(ctx, sqlc.UpdateConversationInfoBySessionIDParams{
+		Title:     optionalString(info.Title),
+		Archived:  boolToInt(info.Archived),
+		Kind:      optionalString(info.Kind),
+		ProjectID: optionalString(info.ProjectID),
+		SessionID: info.ID,
+		UserID:    sql.NullString{String: info.UserID, Valid: true},
+		AgentID:   nullAgent(info.AgentID),
+	}); err != nil {
+		return fmt.Errorf("update conversation info: %w", err)
 	}
 	return nil
 }
@@ -161,49 +126,23 @@ func (p *Provider) LoadInfo(ctx context.Context, sessionID string) (memory.Sessi
 
 // ListInfo implements memory.SessionManager.
 func (p *Provider) ListInfo(ctx context.Context, opts memory.ListOptions) ([]memory.SessionInfo, error) {
-	var convs []sqlc.CtxConversation
-	var err error
 	userID, agentIDValue, err := requireSessionScope(ctx, opts.UserID, opts.AgentID)
 	if err != nil {
 		return nil, err
 	}
-	agentID := sql.NullString{String: agentIDValue, Valid: true}
-	if opts.IncludeArchived {
-		convs, err = p.q.ListConversationsAll(ctx, sqlc.ListConversationsAllParams{UserID: sql.NullString{String: userID, Valid: true}, AgentID: agentID})
-	} else {
-		convs, err = p.q.ListConversations(ctx, sqlc.ListConversationsParams{UserID: sql.NullString{String: userID, Valid: true}, AgentID: agentID})
-	}
+	convs, err := p.q.ListConversationsFiltered(ctx, sqlc.ListConversationsFilteredParams{
+		UserID:          sql.NullString{String: userID, Valid: true},
+		AgentID:         nullAgent(agentIDValue),
+		IncludeArchived: boolToInt(opts.IncludeArchived),
+		Kind:            optionalString(opts.Kind),
+		ProjectID:       optionalString(opts.ProjectID),
+		Offset:          nonNegativeOffset(opts.Offset),
+		Limit:           listLimit(opts.Limit),
+	})
 	if err != nil {
 		return nil, fmt.Errorf("list conversations: %w", err)
 	}
-
-	var result []memory.SessionInfo
-	skipped := 0
-	for _, c := range convs {
-		info := convToSessionInfo(c)
-		// Apply filters.
-		if opts.AgentID != "" && info.AgentID != opts.AgentID {
-			continue
-		}
-		if opts.UserID != "" && info.UserID != opts.UserID {
-			continue
-		}
-		if opts.Kind != "" && info.Kind != opts.Kind {
-			continue
-		}
-		if opts.ProjectID != "" && info.ProjectID != opts.ProjectID {
-			continue
-		}
-		if skipped < opts.Offset {
-			skipped++
-			continue
-		}
-		result = append(result, info)
-		if opts.Limit > 0 && len(result) >= opts.Limit {
-			break
-		}
-	}
-	return result, nil
+	return convsToSessionInfo(convs), nil
 }
 
 // ListInfoForReview lists review candidates across users for one agent.
@@ -211,31 +150,17 @@ func (p *Provider) ListInfoForReview(ctx context.Context, opts memory.ListOption
 	if opts.AgentID == "" {
 		return nil, fmt.Errorf("missing agent context")
 	}
-	convs, err := p.q.ListConversationsForReviewByAgent(ctx, nullAgent(opts.AgentID))
+	convs, err := p.q.ListConversationsForReviewFiltered(ctx, sqlc.ListConversationsForReviewFilteredParams{
+		AgentID:   nullAgent(opts.AgentID),
+		Kind:      optionalString(opts.Kind),
+		ProjectID: optionalString(opts.ProjectID),
+		Offset:    nonNegativeOffset(opts.Offset),
+		Limit:     listLimit(opts.Limit),
+	})
 	if err != nil {
 		return nil, fmt.Errorf("list review conversations: %w", err)
 	}
-
-	result := make([]memory.SessionInfo, 0, len(convs))
-	skipped := 0
-	for _, c := range convs {
-		info := convToSessionInfo(c)
-		if opts.Kind != "" && info.Kind != opts.Kind {
-			continue
-		}
-		if opts.ProjectID != "" && info.ProjectID != opts.ProjectID {
-			continue
-		}
-		if skipped < opts.Offset {
-			skipped++
-			continue
-		}
-		result = append(result, info)
-		if opts.Limit > 0 && len(result) >= opts.Limit {
-			break
-		}
-	}
-	return result, nil
+	return convsToSessionInfo(convs), nil
 }
 
 // LoadHistory implements memory.SessionManager.
@@ -262,6 +187,35 @@ func (p *Provider) LoadHistory(ctx context.Context, sessionID string) ([]ai.Mess
 	}
 
 	return rowsToMessages(msgs), nil
+}
+
+func convsToSessionInfo(convs []sqlc.CtxConversation) []memory.SessionInfo {
+	result := make([]memory.SessionInfo, 0, len(convs))
+	for _, conv := range convs {
+		result = append(result, convToSessionInfo(conv))
+	}
+	return result
+}
+
+func optionalString(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+func listLimit(limit int) int64 {
+	if limit <= 0 {
+		return -1
+	}
+	return int64(limit)
+}
+
+func nonNegativeOffset(offset int) int64 {
+	if offset <= 0 {
+		return 0
+	}
+	return int64(offset)
 }
 
 func convToSessionInfo(conv sqlc.CtxConversation) memory.SessionInfo {

--- a/pkg/db/sqlc/ctx_conversation.sql.go
+++ b/pkg/db/sqlc/ctx_conversation.sql.go
@@ -365,6 +365,72 @@ func (q *Queries) ListConversationsByKind(ctx context.Context, arg ListConversat
 	return items, nil
 }
 
+const listConversationsFiltered = `-- name: ListConversationsFiltered :many
+SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at FROM ctx_conversation
+WHERE user_id = ?1
+  AND agent_id IS ?2
+  AND (?3 != 0 OR archived = 0)
+  AND (?4 IS NULL OR kind = ?4)
+  AND (?5 IS NULL OR project_id = ?5)
+ORDER BY last_active DESC
+LIMIT ?7 OFFSET ?6
+`
+
+type ListConversationsFilteredParams struct {
+	UserID          sql.NullString `json:"user_id"`
+	AgentID         sql.NullString `json:"agent_id"`
+	IncludeArchived interface{}    `json:"include_archived"`
+	Kind            interface{}    `json:"kind"`
+	ProjectID       interface{}    `json:"project_id"`
+	Offset          int64          `json:"offset"`
+	Limit           int64          `json:"limit"`
+}
+
+func (q *Queries) ListConversationsFiltered(ctx context.Context, arg ListConversationsFilteredParams) ([]CtxConversation, error) {
+	rows, err := q.db.QueryContext(ctx, listConversationsFiltered,
+		arg.UserID,
+		arg.AgentID,
+		arg.IncludeArchived,
+		arg.Kind,
+		arg.ProjectID,
+		arg.Offset,
+		arg.Limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []CtxConversation{}
+	for rows.Next() {
+		var i CtxConversation
+		if err := rows.Scan(
+			&i.ID,
+			&i.SessionID,
+			&i.Title,
+			&i.Channel,
+			&i.Kind,
+			&i.ProjectID,
+			&i.Archived,
+			&i.LastActive,
+			&i.BootstrappedAt,
+			&i.AgentID,
+			&i.UserID,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listConversationsForReviewByAgent = `-- name: ListConversationsForReviewByAgent :many
 SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at FROM ctx_conversation
 WHERE agent_id = ?1
@@ -374,6 +440,67 @@ ORDER BY last_active DESC
 
 func (q *Queries) ListConversationsForReviewByAgent(ctx context.Context, agentID sql.NullString) ([]CtxConversation, error) {
 	rows, err := q.db.QueryContext(ctx, listConversationsForReviewByAgent, agentID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []CtxConversation{}
+	for rows.Next() {
+		var i CtxConversation
+		if err := rows.Scan(
+			&i.ID,
+			&i.SessionID,
+			&i.Title,
+			&i.Channel,
+			&i.Kind,
+			&i.ProjectID,
+			&i.Archived,
+			&i.LastActive,
+			&i.BootstrappedAt,
+			&i.AgentID,
+			&i.UserID,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listConversationsForReviewFiltered = `-- name: ListConversationsForReviewFiltered :many
+SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at FROM ctx_conversation
+WHERE agent_id = ?1
+  AND archived = 0
+  AND (?2 IS NULL OR kind = ?2)
+  AND (?3 IS NULL OR project_id = ?3)
+ORDER BY last_active DESC
+LIMIT ?5 OFFSET ?4
+`
+
+type ListConversationsForReviewFilteredParams struct {
+	AgentID   sql.NullString `json:"agent_id"`
+	Kind      interface{}    `json:"kind"`
+	ProjectID interface{}    `json:"project_id"`
+	Offset    int64          `json:"offset"`
+	Limit     int64          `json:"limit"`
+}
+
+func (q *Queries) ListConversationsForReviewFiltered(ctx context.Context, arg ListConversationsForReviewFilteredParams) ([]CtxConversation, error) {
+	rows, err := q.db.QueryContext(ctx, listConversationsForReviewFiltered,
+		arg.AgentID,
+		arg.Kind,
+		arg.ProjectID,
+		arg.Offset,
+		arg.Limit,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -444,6 +571,49 @@ type UpdateConversationBootstrappedParams struct {
 
 func (q *Queries) UpdateConversationBootstrapped(ctx context.Context, arg UpdateConversationBootstrappedParams) error {
 	_, err := q.db.ExecContext(ctx, updateConversationBootstrapped, arg.ID, arg.UserID, arg.AgentID)
+	return err
+}
+
+const updateConversationInfoBySessionID = `-- name: UpdateConversationInfoBySessionID :exec
+UPDATE ctx_conversation
+SET
+  title = CASE
+    WHEN ?1 IS NOT NULL AND (title IS NULL OR title != ?1) THEN ?1
+    ELSE title
+  END,
+  archived = CASE WHEN archived != ?2 THEN ?2 ELSE archived END,
+  kind = CASE WHEN ?3 IS NOT NULL AND kind != ?3 THEN ?3 ELSE kind END,
+  project_id = CASE
+    WHEN ?4 IS NOT NULL AND (project_id IS NULL OR project_id != ?4) THEN ?4
+    ELSE project_id
+  END,
+  last_active = datetime('now'),
+  updated_at = datetime('now')
+WHERE session_id = ?5
+  AND user_id = ?6
+  AND agent_id IS ?7
+`
+
+type UpdateConversationInfoBySessionIDParams struct {
+	Title     interface{}    `json:"title"`
+	Archived  int64          `json:"archived"`
+	Kind      interface{}    `json:"kind"`
+	ProjectID interface{}    `json:"project_id"`
+	SessionID string         `json:"session_id"`
+	UserID    sql.NullString `json:"user_id"`
+	AgentID   sql.NullString `json:"agent_id"`
+}
+
+func (q *Queries) UpdateConversationInfoBySessionID(ctx context.Context, arg UpdateConversationInfoBySessionIDParams) error {
+	_, err := q.db.ExecContext(ctx, updateConversationInfoBySessionID,
+		arg.Title,
+		arg.Archived,
+		arg.Kind,
+		arg.ProjectID,
+		arg.SessionID,
+		arg.UserID,
+		arg.AgentID,
+	)
 	return err
 }
 


### PR DESCRIPTION
## What
SQL pushdown for LCM session listing (Kind/ProjectID/Offset/Limit now in dedicated queries), SaveInfo collapsed to a single conditional UPDATE, and BuildReviewContext now budgets summaries (newest-first) within maxReviewTokens before budgeting messages.

## Why
Verified review findings: unbounded loads plus in-process pagination over indexed columns, four write round-trips per SaveInfo, and review contexts that could exceed their token budget on summaries alone.

## How
`ListConversationsFiltered` / `ListConversationsForReviewFiltered` with optional-param WHERE clauses (LIMIT -1 = unbounded); `UpdateConversationInfoBySessionID` encodes keep-vs-set in CASE expressions; review budget threads through `appendReviewSummaries` → `appendReviewMessagesWithBudget`. New tests cover filter parity with the old Go filtering, SaveInfo conditional semantics, and summary truncation.

**Stacked on #395** — merge that first; this PR's base is `perf/lcm-optimizations`.

## Refs
Closes #396