### PR TITLE
perf(lcm): parallelize compaction LLM summarization calls

### DIFF
--- a/internal/memory/lcm/compaction.go
+++ b/internal/memory/lcm/compaction.go
@@ -10,9 +10,13 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/CherryHQ/stella/internal/memory"
 	"github.com/CherryHQ/stella/pkg/db/sqlc"
 )
+
+const summarizeConcurrency = 4
 
 // compactionEngine runs leaf and condensed compaction passes.
 type compactionEngine struct {
@@ -104,8 +108,28 @@ func (c *compactionEngine) leafPass(ctx context.Context, convID string, items []
 		return nil
 	}
 
-	for _, run := range runs {
-		if err := c.compactMessageRun(ctx, convID, run, result); err != nil {
+	prepared := make([]messageRunSummary, len(runs))
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.SetLimit(summarizeConcurrency)
+	for i, run := range runs {
+		group.Go(func() error {
+			summary, err := c.summarizeMessageRun(groupCtx, convID, run)
+			if err != nil {
+				return err
+			}
+			prepared[i] = summary
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return err
+	}
+
+	// Summaries in a pass are written only after every LLM call succeeds. This
+	// intentionally makes each pass all-or-nothing; older sequential code could
+	// leave earlier runs committed when a later summarization failed.
+	for _, summary := range prepared {
+		if err := c.writeMessageRunSummary(ctx, convID, summary, result); err != nil {
 			return err
 		}
 	}
@@ -204,8 +228,17 @@ func formatMessageForSummarizer(msg sqlc.CtxMessage) string {
 	}
 }
 
-// compactMessageRun creates a leaf summary from a message run.
-func (c *compactionEngine) compactMessageRun(ctx context.Context, convID string, run messageRun, result *memory.CompactionResult) error {
+type messageRunSummary struct {
+	run         messageRun
+	messages    []sqlc.CtxMessage
+	content     string
+	totalTokens int64
+	earliestAt  string
+	latestAt    string
+}
+
+// summarizeMessageRun creates a leaf summary candidate from a message run without writing it.
+func (c *compactionEngine) summarizeMessageRun(ctx context.Context, convID string, run messageRun) (messageRunSummary, error) {
 	// Load source messages before opening a transaction. The summarizer may call
 	// back into the database to resolve model/provider settings, and Stella's SQLite
 	// handle intentionally uses a single connection. Holding a transaction while
@@ -224,7 +257,7 @@ func (c *compactionEngine) compactMessageRun(ctx context.Context, convID string,
 	}
 	loadedMessages, err := c.q.ListMessagesByIDs(ctx, sqlc.ListMessagesByIDsParams{ConversationID: convID, MessageIds: messageIDs})
 	if err != nil {
-		return fmt.Errorf("list messages: %w", err)
+		return messageRunSummary{}, fmt.Errorf("list messages: %w", err)
 	}
 	messagesByID := make(map[string]sqlc.CtxMessage, len(loadedMessages))
 	for _, msg := range loadedMessages {
@@ -236,7 +269,7 @@ func (c *compactionEngine) compactMessageRun(ctx context.Context, convID string,
 		}
 		msg, ok := messagesByID[item.MessageID.String]
 		if !ok {
-			return fmt.Errorf("get message %s: %w", item.MessageID.String, sql.ErrNoRows)
+			return messageRunSummary{}, fmt.Errorf("get message %s: %w", item.MessageID.String, sql.ErrNoRows)
 		}
 		messages = append(messages, msg)
 		textParts = append(textParts, formatMessageForSummarizer(msg))
@@ -251,7 +284,7 @@ func (c *compactionEngine) compactMessageRun(ctx context.Context, convID string,
 	}
 
 	if len(messages) == 0 {
-		return nil
+		return messageRunSummary{run: run}, nil
 	}
 
 	// Generate summary outside the write transaction. The provider-level
@@ -263,7 +296,22 @@ func (c *compactionEngine) compactMessageRun(ctx context.Context, convID string,
 		TargetTokens: targetTokens,
 	})
 	if err != nil {
-		return fmt.Errorf("summarize: %w", err)
+		return messageRunSummary{}, fmt.Errorf("summarize: %w", err)
+	}
+
+	return messageRunSummary{
+		run:         run,
+		messages:    messages,
+		content:     summary,
+		totalTokens: totalTokens,
+		earliestAt:  earliestAt,
+		latestAt:    latestAt,
+	}, nil
+}
+
+func (c *compactionEngine) writeMessageRunSummary(ctx context.Context, convID string, summary messageRunSummary, result *memory.CompactionResult) error {
+	if len(summary.messages) == 0 {
+		return nil
 	}
 
 	tx, err := c.db.BeginTx(ctx, nil)
@@ -280,20 +328,20 @@ func (c *compactionEngine) compactMessageRun(ctx context.Context, convID string,
 		ConversationID:          convID,
 		Kind:                    kindLeaf,
 		Depth:                   0,
-		Content:                 summary,
-		TokenCount:              int64(memory.EstimateTokens(summary)),
-		EarliestAt:              sql.NullString{String: earliestAt, Valid: earliestAt != ""},
-		LatestAt:                sql.NullString{String: latestAt, Valid: latestAt != ""},
-		DescendantCount:         int64(len(messages)),
-		DescendantTokenCount:    totalTokens,
-		SourceMessageTokenCount: totalTokens,
+		Content:                 summary.content,
+		TokenCount:              int64(memory.EstimateTokens(summary.content)),
+		EarliestAt:              sql.NullString{String: summary.earliestAt, Valid: summary.earliestAt != ""},
+		LatestAt:                sql.NullString{String: summary.latestAt, Valid: summary.latestAt != ""},
+		DescendantCount:         int64(len(summary.messages)),
+		DescendantTokenCount:    summary.totalTokens,
+		SourceMessageTokenCount: summary.totalTokens,
 	})
 	if err != nil {
 		return fmt.Errorf("create summary: %w", err)
 	}
 
 	// Link summary to source messages.
-	for i, msg := range messages {
+	for i, msg := range summary.messages {
 		err = qtx.LinkSummaryToMessage(ctx, sqlc.LinkSummaryToMessageParams{
 			SummaryID: sumID,
 			MessageID: msg.ID,
@@ -307,8 +355,8 @@ func (c *compactionEngine) compactMessageRun(ctx context.Context, convID string,
 	// Replace message context items with summary item.
 	err = qtx.DeleteContextItemsInRange(ctx, sqlc.DeleteContextItemsInRangeParams{
 		ConversationID: convID,
-		Ordinal:        run.startOrd,
-		Ordinal_2:      run.endOrd,
+		Ordinal:        summary.run.startOrd,
+		Ordinal_2:      summary.run.endOrd,
 	})
 	if err != nil {
 		return fmt.Errorf("delete context range: %w", err)
@@ -316,7 +364,7 @@ func (c *compactionEngine) compactMessageRun(ctx context.Context, convID string,
 
 	err = qtx.AppendContextItem(ctx, sqlc.AppendContextItemParams{
 		ConversationID: convID,
-		Ordinal:        run.startOrd, // reuse start ordinal
+		Ordinal:        summary.run.startOrd, // reuse start ordinal
 		ItemType:       itemTypeSummary,
 		SummaryID:      sql.NullString{String: sumID, Valid: true},
 		Role:           "",
@@ -330,7 +378,7 @@ func (c *compactionEngine) compactMessageRun(ctx context.Context, convID string,
 	}
 
 	result.LeafSummariesCreated++
-	result.MessagesCompacted += len(messages)
+	result.MessagesCompacted += len(summary.messages)
 
 	return nil
 }
@@ -353,8 +401,26 @@ func (c *compactionEngine) condensedPass(ctx context.Context, convID string, ite
 		return nil
 	}
 
-	for _, run := range runs {
-		if err := c.condenseSummaryRun(ctx, convID, run, sumCache, result); err != nil {
+	prepared := make([]condensedRunSummary, len(runs))
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.SetLimit(summarizeConcurrency)
+	for i, run := range runs {
+		group.Go(func() error {
+			summary, err := c.summarizeCondensedRun(groupCtx, run, sumCache)
+			if err != nil {
+				return err
+			}
+			prepared[i] = summary
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return err
+	}
+
+	// See leafPass: writes stay serial and happen only after all summaries succeed.
+	for _, summary := range prepared {
+		if err := c.writeCondensedRunSummary(ctx, convID, summary, result); err != nil {
 			return err
 		}
 	}
@@ -441,10 +507,22 @@ func findSummaryRuns(items []sqlc.CtxItem, minSize int, depthOf map[string]int64
 	return runs
 }
 
-// condenseSummaryRun creates a condensed summary from a run of summary context items.
-func (c *compactionEngine) condenseSummaryRun(ctx context.Context, convID string, run summaryRun, sumCache map[string]sqlc.CtxSummary, result *memory.CompactionResult) error {
+type condensedRunSummary struct {
+	run              summaryRun
+	summaries        []sqlc.CtxSummary
+	content          string
+	newDepth         int64
+	totalTokens      int64
+	totalDescendants int64
+	totalDescTokens  int64
+	earliestAt       string
+	latestAt         string
+}
+
+// summarizeCondensedRun creates a condensed summary candidate from summary items without writing it.
+func (c *compactionEngine) summarizeCondensedRun(ctx context.Context, run summaryRun, sumCache map[string]sqlc.CtxSummary) (condensedRunSummary, error) {
 	// Load summaries from cache before opening a transaction; see
-	// compactMessageRun for why LLM work must not happen while holding Stella's
+	// summarizeMessageRun for why LLM work must not happen while holding Stella's
 	// single SQLite connection in a transaction.
 	var summaries []sqlc.CtxSummary
 	var textParts []string
@@ -460,7 +538,7 @@ func (c *compactionEngine) condenseSummaryRun(ctx context.Context, convID string
 		}
 		sum, ok := sumCache[item.SummaryID.String]
 		if !ok {
-			return fmt.Errorf("summary %s not in cache", item.SummaryID.String)
+			return condensedRunSummary{}, fmt.Errorf("summary %s not in cache", item.SummaryID.String)
 		}
 		summaries = append(summaries, sum)
 		textParts = append(textParts, sum.Content)
@@ -479,7 +557,7 @@ func (c *compactionEngine) condenseSummaryRun(ctx context.Context, convID string
 	}
 
 	if len(summaries) < 2 {
-		return nil
+		return condensedRunSummary{run: run}, nil
 	}
 
 	// Generate condensed summary.
@@ -495,7 +573,25 @@ func (c *compactionEngine) condenseSummaryRun(ctx context.Context, convID string
 		TargetTokens: targetTokens,
 	})
 	if err != nil {
-		return fmt.Errorf("summarize condensed: %w", err)
+		return condensedRunSummary{}, fmt.Errorf("summarize condensed: %w", err)
+	}
+
+	return condensedRunSummary{
+		run:              run,
+		summaries:        summaries,
+		content:          content,
+		newDepth:         newDepth,
+		totalTokens:      totalTokens,
+		totalDescendants: totalDescendants,
+		totalDescTokens:  totalDescTokens,
+		earliestAt:       earliestAt,
+		latestAt:         latestAt,
+	}, nil
+}
+
+func (c *compactionEngine) writeCondensedRunSummary(ctx context.Context, convID string, summary condensedRunSummary, result *memory.CompactionResult) error {
+	if len(summary.summaries) < 2 {
+		return nil
 	}
 
 	tx, err := c.db.BeginTx(ctx, nil)
@@ -511,13 +607,13 @@ func (c *compactionEngine) condenseSummaryRun(ctx context.Context, convID string
 		ID:                      sumID,
 		ConversationID:          convID,
 		Kind:                    kindCondensed,
-		Depth:                   newDepth,
-		Content:                 content,
-		TokenCount:              int64(memory.EstimateTokens(content)),
-		EarliestAt:              sql.NullString{String: earliestAt, Valid: earliestAt != ""},
-		LatestAt:                sql.NullString{String: latestAt, Valid: latestAt != ""},
-		DescendantCount:         totalDescendants + int64(len(summaries)),
-		DescendantTokenCount:    totalDescTokens + totalTokens,
+		Depth:                   summary.newDepth,
+		Content:                 summary.content,
+		TokenCount:              int64(memory.EstimateTokens(summary.content)),
+		EarliestAt:              sql.NullString{String: summary.earliestAt, Valid: summary.earliestAt != ""},
+		LatestAt:                sql.NullString{String: summary.latestAt, Valid: summary.latestAt != ""},
+		DescendantCount:         summary.totalDescendants + int64(len(summary.summaries)),
+		DescendantTokenCount:    summary.totalDescTokens + summary.totalTokens,
 		SourceMessageTokenCount: 0,
 	})
 	if err != nil {
@@ -525,7 +621,7 @@ func (c *compactionEngine) condenseSummaryRun(ctx context.Context, convID string
 	}
 
 	// Link to parent summaries.
-	for i, sum := range summaries {
+	for i, sum := range summary.summaries {
 		err = qtx.LinkSummaryToParent(ctx, sqlc.LinkSummaryToParentParams{
 			SummaryID:       sumID,
 			ParentSummaryID: sum.ID,
@@ -539,8 +635,8 @@ func (c *compactionEngine) condenseSummaryRun(ctx context.Context, convID string
 	// Replace summary context items with condensed item.
 	err = qtx.DeleteContextItemsInRange(ctx, sqlc.DeleteContextItemsInRangeParams{
 		ConversationID: convID,
-		Ordinal:        run.startOrd,
-		Ordinal_2:      run.endOrd,
+		Ordinal:        summary.run.startOrd,
+		Ordinal_2:      summary.run.endOrd,
 	})
 	if err != nil {
 		return fmt.Errorf("delete context range: %w", err)
@@ -548,7 +644,7 @@ func (c *compactionEngine) condenseSummaryRun(ctx context.Context, convID string
 
 	err = qtx.AppendContextItem(ctx, sqlc.AppendContextItemParams{
 		ConversationID: convID,
-		Ordinal:        run.startOrd,
+		Ordinal:        summary.run.startOrd,
 		ItemType:       itemTypeSummary,
 		SummaryID:      sql.NullString{String: sumID, Valid: true},
 		Role:           "",

--- a/internal/memory/lcm/compaction_parallel_test.go
+++ b/internal/memory/lcm/compaction_parallel_test.go
@@ -1,0 +1,244 @@
+package lcm
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/CherryHQ/stella/internal/memory"
+	"github.com/CherryHQ/stella/pkg/db/sqlc"
+)
+
+type trackingSummarizer struct {
+	delay  time.Duration
+	failAt int64
+
+	calls    atomic.Int64
+	inFlight atomic.Int64
+	maxSeen  atomic.Int64
+}
+
+func (s *trackingSummarizer) Summarize(ctx context.Context, text string, opts memory.SummarizeOptions) (string, error) {
+	call := s.calls.Add(1)
+	current := s.inFlight.Add(1)
+	defer s.inFlight.Add(-1)
+	for {
+		maxSeen := s.maxSeen.Load()
+		if current <= maxSeen || s.maxSeen.CompareAndSwap(maxSeen, current) {
+			break
+		}
+	}
+	if s.delay > 0 {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(s.delay):
+		}
+	}
+	if s.failAt == call {
+		return "", errors.New("boom")
+	}
+	return fmt.Sprintf("summary:%s", firstLine(text)), nil
+}
+
+func firstLine(text string) string {
+	if before, _, ok := strings.Cut(text, "\n"); ok {
+		return before
+	}
+	return text
+}
+
+func TestLeafPassSummarizesRunsConcurrently(t *testing.T) {
+	db := newAssemblerTestDB(t)
+	defer func() { _ = db.Close() }()
+	ctx := context.Background()
+	q := sqlc.New(db)
+	convID, items := seedLeafRuns(t, ctx, q, 4, defaultLeafChunkSize)
+
+	summarizer := &trackingSummarizer{delay: 25 * time.Millisecond}
+	engine := newCompactionEngine(db, q, summarizer, 0)
+	result := &memory.CompactionResult{}
+	if err := engine.leafPass(ctx, convID, items, result); err != nil {
+		t.Fatalf("leafPass: %v", err)
+	}
+	if maxSeen := summarizer.maxSeen.Load(); maxSeen <= 1 || maxSeen > summarizeConcurrency {
+		t.Fatalf("max in-flight = %d, want >1 and <=%d", maxSeen, summarizeConcurrency)
+	}
+	if result.LeafSummariesCreated != 4 || result.MessagesCompacted != 4*defaultLeafChunkSize {
+		t.Fatalf("result = %+v", result)
+	}
+
+	summaries := listSummariesByOrdinal(t, ctx, q, convID)
+	if len(summaries) != 8 {
+		t.Fatalf("summary context items = %d, want 8 including separators", len(summaries))
+	}
+	for i := range 4 {
+		got := summaries[i*2]
+		want := fmt.Sprintf("summary:[user] run-%d-message-0", i)
+		if got.content != want {
+			t.Fatalf("summary %d content = %q, want %q", i, got.content, want)
+		}
+	}
+}
+
+func TestLeafPassSummarizeFailureWritesNothing(t *testing.T) {
+	db := newAssemblerTestDB(t)
+	defer func() { _ = db.Close() }()
+	ctx := context.Background()
+	q := sqlc.New(db)
+	convID, items := seedLeafRuns(t, ctx, q, 3, defaultLeafChunkSize)
+
+	before := countSummaries(t, ctx, db, convID, kindLeaf)
+	summarizer := &trackingSummarizer{delay: 10 * time.Millisecond, failAt: 2}
+	engine := newCompactionEngine(db, q, summarizer, 0)
+	result := &memory.CompactionResult{}
+	if err := engine.leafPass(ctx, convID, items, result); err == nil {
+		t.Fatal("leafPass succeeded, want summarize error")
+	}
+	if result.LeafSummariesCreated != 0 || result.MessagesCompacted != 0 {
+		t.Fatalf("result mutated despite failed pass: %+v", result)
+	}
+	if count := countSummaries(t, ctx, db, convID, kindLeaf); count != before {
+		t.Fatalf("leaf summaries written = %d, want unchanged %d", count, before)
+	}
+}
+
+func TestLeafPassWritesSummariesInRunOrder(t *testing.T) {
+	db := newAssemblerTestDB(t)
+	defer func() { _ = db.Close() }()
+	ctx := context.Background()
+	q := sqlc.New(db)
+	convID, items := seedLeafRuns(t, ctx, q, 3, defaultLeafChunkSize)
+
+	summarizer := &trackingSummarizer{delay: 5 * time.Millisecond}
+	engine := newCompactionEngine(db, q, summarizer, 0)
+	if err := engine.leafPass(ctx, convID, items, &memory.CompactionResult{}); err != nil {
+		t.Fatalf("leafPass: %v", err)
+	}
+
+	summaries := listSummariesByOrdinal(t, ctx, q, convID)
+	for i := range 3 {
+		got := summaries[i*2]
+		if got.ordinal != int64(i*(defaultLeafChunkSize+1)+1) {
+			t.Fatalf("summary %d ordinal = %d", i, got.ordinal)
+		}
+		want := fmt.Sprintf("run-%d-message-0", i)
+		if !strings.Contains(got.content, want) {
+			t.Fatalf("summary %d content = %q, want %q", i, got.content, want)
+		}
+	}
+}
+
+func seedLeafRuns(t *testing.T, ctx context.Context, q *sqlc.Queries, runs, runSize int) (string, []sqlc.CtxItem) {
+	t.Helper()
+	convID := fmt.Sprintf("conv-parallel-%d", time.Now().UnixNano())
+	if _, err := q.CreateConversation(ctx, sqlc.CreateConversationParams{ID: convID, SessionID: convID, Channel: "test", Kind: "chat"}); err != nil {
+		t.Fatalf("create conversation: %v", err)
+	}
+	ordinal := int64(0)
+	seq := int64(0)
+	appendMessage := func(id, content string) {
+		t.Helper()
+		seq++
+		ordinal++
+		if _, err := q.CreateMessage(ctx, sqlc.CreateMessageParams{
+			ID:             id,
+			ConversationID: convID,
+			Seq:            seq,
+			Role:           roleUser,
+			EventType:      eventTypeText,
+			Content:        content,
+			TokenCount:     int64(memory.EstimateTokens(content)),
+		}); err != nil {
+			t.Fatalf("create message: %v", err)
+		}
+		if err := q.AppendContextItem(ctx, sqlc.AppendContextItemParams{
+			ConversationID: convID,
+			Ordinal:        ordinal,
+			ItemType:       itemTypeMessage,
+			MessageID:      sql.NullString{String: id, Valid: true},
+			EventType:      eventTypeText,
+			Role:           roleUser,
+		}); err != nil {
+			t.Fatalf("append message item: %v", err)
+		}
+	}
+	for run := range runs {
+		for i := range runSize {
+			appendMessage(fmt.Sprintf("msg-%d-%d", run, i), fmt.Sprintf("run-%d-message-%d", run, i))
+		}
+		ordinal++
+		separatorID := fmt.Sprintf("separator-%d", run)
+		if err := q.CreateSummary(ctx, sqlc.CreateSummaryParams{
+			ID:                      separatorID,
+			ConversationID:          convID,
+			Kind:                    kindLeaf,
+			Depth:                   0,
+			Content:                 "separator",
+			TokenCount:              1,
+			DescendantCount:         1,
+			DescendantTokenCount:    1,
+			SourceMessageTokenCount: 1,
+		}); err != nil {
+			t.Fatalf("create separator summary: %v", err)
+		}
+		if err := q.AppendContextItem(ctx, sqlc.AppendContextItemParams{
+			ConversationID: convID,
+			Ordinal:        ordinal,
+			ItemType:       itemTypeSummary,
+			SummaryID:      sql.NullString{String: separatorID, Valid: true},
+			Role:           "",
+		}); err != nil {
+			t.Fatalf("append separator item: %v", err)
+		}
+	}
+	for i := range defaultFreshTail {
+		appendMessage(fmt.Sprintf("tail-%d", i), fmt.Sprintf("tail-message-%d", i))
+	}
+	items, err := q.GetContextItems(ctx, convID)
+	if err != nil {
+		t.Fatalf("get context items: %v", err)
+	}
+	return convID, items
+}
+
+type ordinalSummary struct {
+	ordinal int64
+	content string
+}
+
+func listSummariesByOrdinal(t *testing.T, ctx context.Context, q *sqlc.Queries, convID string) []ordinalSummary {
+	t.Helper()
+	items, err := q.GetContextItems(ctx, convID)
+	if err != nil {
+		t.Fatalf("get context items: %v", err)
+	}
+	out := make([]ordinalSummary, 0)
+	for _, item := range items {
+		if item.ItemType != itemTypeSummary || !item.SummaryID.Valid {
+			continue
+		}
+		sum, err := q.GetSummary(ctx, sqlc.GetSummaryParams{ConversationID: convID, ID: item.SummaryID.String})
+		if err != nil {
+			t.Fatalf("get summary %s: %v", item.SummaryID.String, err)
+		}
+		out = append(out, ordinalSummary{ordinal: item.Ordinal, content: sum.Content})
+	}
+	return out
+}
+
+func countSummaries(t *testing.T, ctx context.Context, db *sql.DB, convID, kind string) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM ctx_summary WHERE conversation_id = ? AND kind = ?`, convID, kind).Scan(&count); err != nil {
+		t.Fatalf("count summaries: %v", err)
+	}
+	return count
+}
+
+var _ memory.Summarizer = (*trackingSummarizer)(nil)


### PR DESCRIPTION
## What
Compaction's per-run `Summarize` calls (leaf and condensed passes) now run concurrently (errgroup, limit 4); DB writes stay serial in run order and only happen after every summary in the pass succeeds.

## Why
Auto-compaction blocks the user request path (2-minute timeout); 5 runs × 3s of sequential LLM latency is user-visible. Issue #399.

## How
`compactMessageRun`/`condenseSummaryRun` split into pure summarize stages and write stages. The single-SQLite-connection constraint only ever applied to writes (LLM calls were already kept outside transactions). Deliberate behavior change, documented in-code: a failing summarization now fails the whole pass with zero writes, instead of leaving earlier runs committed. Tests cover max in-flight concurrency, failure-writes-nothing, and run-order determinism; lcm suite run twice to shake out flakes.

**Stacked on #407** (base: `lcm/context-window-loader`). Merge order: #395 → #405 → #406 → #407 → this.

## Refs
Closes #399