### PR TITLE
🐛 fix: group chat dispatch correctness — mention routing, ordering, web disconnect, at-least-once

### DIFF
--- a/internal/channel/arbiter.go
+++ b/internal/channel/arbiter.go
@@ -86,8 +86,10 @@ func (a *Arbiter) Decide(_ context.Context, groupID string, mentions []pkgchanne
 		}
 	}
 
+	mentionResponding := len(responding) > 0
+
 	// Explicit @mention always responds — skip debounce entirely.
-	if len(responding) == 0 {
+	if !mentionResponding {
 		// No fallback agent → check AllMembersFallback or skip (CR-012).
 		if channelAgentID == "" {
 			if !opt.AllMembersFallback {
@@ -116,7 +118,9 @@ func (a *Arbiter) Decide(_ context.Context, groupID string, mentions []pkgchanne
 		}
 	}
 
-	responding = capResponders(responding, a.cfg.MaxRepliesPerTrigger)
+	if !mentionResponding {
+		responding = capResponders(responding, a.cfg.MaxRepliesPerTrigger)
+	}
 
 	// Evict expired debounce entries on all paths (not just fallback).
 	if a.cfg.DebounceWindow > 0 {

--- a/internal/channel/arbiter_test.go
+++ b/internal/channel/arbiter_test.go
@@ -39,7 +39,7 @@ func TestArbiterNoMentionFallback(t *testing.T) {
 	}
 }
 
-func TestArbiterMaxReplies(t *testing.T) {
+func TestArbiterMentionedAgentsBypassMaxReplies(t *testing.T) {
 	a := NewArbiter(ArbiterConfig{MaxRepliesPerTrigger: 1})
 	ctx := context.Background()
 
@@ -53,8 +53,22 @@ func TestArbiterMaxReplies(t *testing.T) {
 	}
 
 	d := a.Decide(ctx, "g1", mentions, members, "")
-	if len(d.RespondingAgents) != 1 {
-		t.Fatalf("expected max 1 response, got %d: %v", len(d.RespondingAgents), d.RespondingAgents)
+	if len(d.RespondingAgents) != 2 || d.RespondingAgents[0] != "agent-1" || d.RespondingAgents[1] != "agent-2" {
+		t.Fatalf("expected both mentioned agents, got %v", d.RespondingAgents)
+	}
+}
+
+func TestArbiterFallbackMaxReplies(t *testing.T) {
+	a := NewArbiter(ArbiterConfig{MaxRepliesPerTrigger: 1})
+	ctx := context.Background()
+	members := []GroupMember{
+		{AgentID: "agent-1"},
+		{AgentID: "agent-2"},
+	}
+
+	d := a.Decide(ctx, "g1", nil, members, "", DecideOptions{AllMembersFallback: true})
+	if len(d.RespondingAgents) != 1 || d.RespondingAgents[0] != "agent-1" {
+		t.Fatalf("expected capped fallback [agent-1], got %v", d.RespondingAgents)
 	}
 }
 

--- a/internal/channel/group_dispatcher.go
+++ b/internal/channel/group_dispatcher.go
@@ -472,6 +472,9 @@ func (d *GroupDispatcher) ExecuteDispatch(ctx context.Context, row sqlc.CtxGroup
 	if !ok {
 		return nil
 	}
+	if claimed.ResultMessageID != "" {
+		return d.completeDispatch(ctx, claimed)
+	}
 	ownedCtx, cancelOwned := context.WithCancel(ctx)
 	defer cancelOwned()
 	stopHeartbeat := d.startHeartbeat(ownedCtx, "dispatch", claimed.ID, func(ctx context.Context, until time.Time) (int64, error) {
@@ -498,6 +501,7 @@ func (d *GroupDispatcher) ExecuteDispatch(ctx context.Context, row sqlc.CtxGroup
 	if err != nil {
 		return d.failDispatch(ctx, claimed, err)
 	}
+	stream, responseC := d.wrapGroupResponseStream(ownedCtx, stream)
 	if err := publisher.Publish(ownedCtx, GroupPublishRequest{
 		GroupID:          claimed.GroupID,
 		AgentID:          claimed.AgentID,
@@ -511,14 +515,13 @@ func (d *GroupDispatcher) ExecuteDispatch(ctx context.Context, row sqlc.CtxGroup
 	}); err != nil {
 		return d.failDispatch(ctx, claimed, fmt.Errorf("publish: %w", err))
 	}
-	rows, err := d.q.MarkGroupDispatchCompleted(ctx, sqlc.MarkGroupDispatchCompletedParams{ID: claimed.ID, AttemptCount: claimed.AttemptCount})
-	if err != nil {
-		return fmt.Errorf("mark dispatch completed: %w", err)
+	response := <-responseC
+	if response.complete && response.text != "" {
+		if err := d.recordDispatchResult(ctx, claimed, response); err != nil {
+			return d.failDispatch(ctx, claimed, err)
+		}
 	}
-	if rows == 0 {
-		return nil
-	}
-	return nil
+	return d.completeDispatch(ctx, claimed)
 }
 
 func (d *GroupDispatcher) claimDispatch(ctx context.Context, row sqlc.CtxGroupDispatch) (sqlc.CtxGroupDispatch, bool, error) {
@@ -541,6 +544,63 @@ func (d *GroupDispatcher) claimDispatch(ctx context.Context, row sqlc.CtxGroupDi
 	default:
 		return sqlc.CtxGroupDispatch{}, false, nil
 	}
+}
+
+func (d *GroupDispatcher) completeDispatch(ctx context.Context, row sqlc.CtxGroupDispatch) error {
+	rows, err := d.q.MarkGroupDispatchCompleted(ctx, sqlc.MarkGroupDispatchCompletedParams{ID: row.ID, AttemptCount: row.AttemptCount})
+	if err != nil {
+		return fmt.Errorf("mark dispatch completed: %w", err)
+	}
+	if rows == 0 {
+		return nil
+	}
+	return nil
+}
+
+func (d *GroupDispatcher) recordDispatchResult(ctx context.Context, row sqlc.CtxGroupDispatch, response groupResponse) error {
+	if d.db == nil {
+		return errors.New("dispatcher db not configured")
+	}
+	conn, err := d.db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("record dispatch result: acquire conn: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return fmt.Errorf("record dispatch result: begin immediate: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(ctx, "ROLLBACK")
+		}
+	}()
+	q := sqlc.New(conn)
+	result, err := eventlog.AppendToGroupWithQueries(ctx, q, row.GroupID, eventlog.GroupMessage{
+		ActorType:      eventlog.ActorAgent,
+		ActorID:        row.AgentID,
+		Content:        response.text,
+		AgentSessionID: response.sessionID,
+	})
+	if err != nil {
+		return err
+	}
+	updated, err := q.SetGroupDispatchResultMessage(ctx, sqlc.SetGroupDispatchResultMessageParams{
+		ID:              row.ID,
+		AttemptCount:    row.AttemptCount,
+		ResultMessageID: result.Message.ID,
+	})
+	if err != nil {
+		return fmt.Errorf("set dispatch result message: %w", err)
+	}
+	if updated == 0 {
+		return errors.New("set dispatch result message: lost dispatch ownership")
+	}
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return fmt.Errorf("record dispatch result: commit: %w", err)
+	}
+	committed = true
+	return nil
 }
 
 func (d *GroupDispatcher) publisherFor(state sqlc.CtxGroupState, row sqlc.CtxGroupDispatch, override GroupPublisher) (GroupPublisher, error) {
@@ -700,7 +760,7 @@ func (d *GroupDispatcher) chatDispatchUnqueued(ctx context.Context, row sqlc.Ctx
 	if err != nil {
 		return nil, err
 	}
-	return d.wrapGroupResponseStream(ctx, row.GroupID, row.AgentID, stream), nil
+	return stream, nil
 }
 
 func (d *GroupDispatcher) chatWeb(ctx context.Context, row sqlc.CtxGroupDispatch, message sqlc.CtxGroupMessage) (*pkgchannel.ChatStream, error) {
@@ -765,8 +825,15 @@ func webGroupSpeaker(message sqlc.CtxGroupMessage) memory.CurrentSpeaker {
 	}
 }
 
-func (d *GroupDispatcher) wrapGroupResponseStream(ctx context.Context, groupID, agentID string, stream *pkgchannel.ChatStream) *pkgchannel.ChatStream {
+type groupResponse struct {
+	text      string
+	sessionID string
+	complete  bool
+}
+
+func (d *GroupDispatcher) wrapGroupResponseStream(ctx context.Context, stream *pkgchannel.ChatStream) (*pkgchannel.ChatStream, <-chan groupResponse) {
 	out := make(chan pkgchannel.Event, 100)
+	responseC := make(chan groupResponse, 1)
 	go func() {
 		defer close(out)
 		var textBuf strings.Builder
@@ -789,20 +856,10 @@ func (d *GroupDispatcher) wrapGroupResponseStream(ctx context.Context, groupID, 
 		if ctx.Err() != nil {
 			sawErr = true
 		}
-		if !sawErr && textBuf.Len() > 0 && d.coord != nil && d.coord.eventLog != nil {
-			writeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
-			defer cancel()
-			if _, err := d.coord.eventLog.AppendToGroup(writeCtx, groupID, eventlog.GroupMessage{
-				ActorType:      eventlog.ActorAgent,
-				ActorID:        agentID,
-				Content:        textBuf.String(),
-				AgentSessionID: stream.SessionID,
-			}); err != nil {
-				d.log.Warn("failed to write group response", "group_id", groupID, "agent_id", agentID, "error", err)
-			}
-		}
+		responseC <- groupResponse{text: textBuf.String(), sessionID: stream.SessionID, complete: !sawErr}
+		close(responseC)
 	}()
-	return &pkgchannel.ChatStream{Events: out, SessionID: stream.SessionID}
+	return &pkgchannel.ChatStream{Events: out, SessionID: stream.SessionID}, responseC
 }
 
 func fallbackGroupDecision(mentions []pkgchannel.Mention, members []GroupMember, allMembersFallback bool) ArbiterDecision {

--- a/internal/channel/group_dispatcher.go
+++ b/internal/channel/group_dispatcher.go
@@ -199,6 +199,12 @@ func (d *GroupDispatcher) reapExpired(ctx context.Context) error {
 		return fmt.Errorf("list expired dispatch: %w", err)
 	}
 	for _, row := range dispatchRows {
+		if row.ResultMessageID != "" {
+			if _, err := d.q.MarkGroupDispatchCompleted(ctx, sqlc.MarkGroupDispatchCompletedParams{ID: row.ID, AttemptCount: row.AttemptCount}); err != nil {
+				return fmt.Errorf("complete expired dispatch with result marker: %w", err)
+			}
+			continue
+		}
 		if row.AttemptCount >= d.maxAttempts {
 			if _, err := d.q.MarkGroupDispatchFailed(ctx, sqlc.MarkGroupDispatchFailedParams{ID: row.ID, AttemptCount: row.AttemptCount, LastError: "lease expired"}); err != nil {
 				return fmt.Errorf("fail expired dispatch: %w", err)
@@ -457,20 +463,39 @@ func (d *GroupDispatcher) recentGroupContext(ctx context.Context, q *sqlc.Querie
 }
 
 func (d *GroupDispatcher) executeDispatchesByMessage(ctx context.Context, groupMessageID string, publisherOverride GroupPublisher) error {
-	rows, err := d.q.ListPendingGroupDispatchByMessage(ctx, sqlc.ListPendingGroupDispatchByMessageParams{
-		GroupMessageID: groupMessageID,
-		Now:            nullTime(time.Now().UTC()),
-	})
-	if err != nil {
-		return fmt.Errorf("list dispatch rows: %w", err)
-	}
-	var errs []error
-	for _, row := range rows {
-		if err := d.ExecuteDispatch(ctx, row, publisherOverride); err != nil {
-			errs = append(errs, err)
+	for {
+		rows, err := d.q.ListPendingGroupDispatchByMessage(ctx, sqlc.ListPendingGroupDispatchByMessageParams{
+			GroupMessageID: groupMessageID,
+			Now:            nullTime(time.Now().UTC()),
+		})
+		if err != nil {
+			return fmt.Errorf("list dispatch rows: %w", err)
+		}
+		var errs []error
+		for _, row := range rows {
+			if err := d.ExecuteDispatch(ctx, row, publisherOverride); err != nil {
+				errs = append(errs, err)
+			}
+		}
+		if err := errors.Join(errs...); err != nil {
+			return err
+		}
+		if publisherOverride == nil {
+			return nil
+		}
+		remaining, err := d.q.CountNonTerminalGroupDispatchByMessage(ctx, groupMessageID)
+		if err != nil {
+			return fmt.Errorf("count remaining dispatch rows: %w", err)
+		}
+		if remaining == 0 {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(250 * time.Millisecond):
 		}
 	}
-	return errors.Join(errs...)
 }
 
 func (d *GroupDispatcher) ExecuteDispatch(ctx context.Context, row sqlc.CtxGroupDispatch, publisherOverride GroupPublisher) error {

--- a/internal/channel/group_dispatcher.go
+++ b/internal/channel/group_dispatcher.go
@@ -660,6 +660,10 @@ func (d *GroupDispatcher) chatDispatch(ctx context.Context, row sqlc.CtxGroupDis
 			select {
 			case out <- evt:
 			case <-ctx.Done():
+				out <- pkgchannel.Event{Err: ctx.Err()}
+				for range stream.Events {
+				}
+				return
 			}
 		}
 	}()
@@ -735,6 +739,10 @@ func (d *GroupDispatcher) chatWeb(ctx context.Context, row sqlc.CtxGroupDispatch
 			select {
 			case out <- convertEvent(evt):
 			case <-ctx.Done():
+				out <- pkgchannel.Event{Err: ctx.Err()}
+				for range events {
+				}
+				return
 			}
 		}
 	}()
@@ -762,7 +770,11 @@ func (d *GroupDispatcher) wrapGroupResponseStream(ctx context.Context, groupID, 
 	go func() {
 		defer close(out)
 		var textBuf strings.Builder
+		sawErr := false
 		for evt := range stream.Events {
+			if evt.Err != nil {
+				sawErr = true
+			}
 			if evt.Text != "" {
 				textBuf.WriteString(evt.Text)
 			}
@@ -771,7 +783,13 @@ func (d *GroupDispatcher) wrapGroupResponseStream(ctx context.Context, groupID, 
 			case <-ctx.Done():
 			}
 		}
-		if textBuf.Len() > 0 && d.coord != nil && d.coord.eventLog != nil {
+		// The forwarding select can win the race against ctx.Done, so
+		// cancellation must be re-checked deterministically before treating the
+		// buffered text as a complete reply.
+		if ctx.Err() != nil {
+			sawErr = true
+		}
+		if !sawErr && textBuf.Len() > 0 && d.coord != nil && d.coord.eventLog != nil {
 			writeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 			defer cancel()
 			if _, err := d.coord.eventLog.AppendToGroup(writeCtx, groupID, eventlog.GroupMessage{

--- a/internal/channel/group_dispatcher.go
+++ b/internal/channel/group_dispatcher.go
@@ -358,8 +358,7 @@ func (d *GroupDispatcher) createDispatchRows(ctx context.Context, q *sqlc.Querie
 
 // decideResponders selects which agents respond. Explicit mentions always take
 // the deterministic rule path. A no-mention message uses the semantic arbiter
-// when one is configured; otherwise it falls back to existing platform behavior
-// (web/always broadcast, mention-mode silence).
+// when one is configured; otherwise it falls back to platform group-mode policy.
 func (d *GroupDispatcher) decideResponders(ctx context.Context, q *sqlc.Queries, outbox sqlc.CtxGroupOutbox, message sqlc.CtxGroupMessage, state sqlc.CtxGroupState, envelope GroupOutboxEnvelope, groupMembers []GroupMember) []string {
 	if len(envelope.Mentions) > 0 {
 		if d.coord != nil && d.coord.arbiter != nil {
@@ -373,7 +372,17 @@ func (d *GroupDispatcher) decideResponders(ctx context.Context, q *sqlc.Queries,
 	if d.coord != nil && d.coord.semanticGroupArbiter != nil {
 		return d.semanticResponders(ctx, q, outbox.GroupID, message, state, groupMembers)
 	}
-	allMembersFallback := state.Platform == "web" || effectivePlatformGroupMode(ctx, q, groupMembers, state) == "always"
+	groupMode := effectivePlatformGroupMode(ctx, q, groupMembers, state)
+	if state.Platform == "web" && groupMode == "mention" {
+		if len(groupMembers) == 1 {
+			return []string{groupMembers[0].AgentID}
+		}
+		if len(groupMembers) > 1 {
+			d.log.Warn("web group has multiple members and no semantic arbiter; configure semantic arbiter", "group_id", outbox.GroupID, "member_count", len(groupMembers))
+		}
+		return nil
+	}
+	allMembersFallback := groupMode == "always"
 	if d.coord != nil && d.coord.arbiter != nil {
 		return d.coord.arbiter.Decide(ctx, outbox.GroupID, envelope.Mentions, groupMembers, "", DecideOptions{
 			AllMembersFallback: allMembersFallback,

--- a/internal/channel/group_dispatcher.go
+++ b/internal/channel/group_dispatcher.go
@@ -317,6 +317,9 @@ func (d *GroupDispatcher) prepareDispatchResponders(ctx context.Context, q *sqlc
 	for i, m := range members {
 		groupMembers[i] = GroupMember{AgentID: m.AgentID, ReplyChannelID: m.ReplyChannelID}
 	}
+	if d.coord != nil {
+		d.coord.resolveMentionAgentsWithMembers(ctx, outbox.GroupID, state.Platform, envelope.Mentions, groupMembers)
+	}
 	return d.decideResponders(ctx, q, outbox, message, state, envelope, groupMembers), nil
 }
 

--- a/internal/channel/group_dispatcher_semantic_test.go
+++ b/internal/channel/group_dispatcher_semantic_test.go
@@ -73,6 +73,26 @@ func TestSemanticDispatchMentionBypassesArbiter(t *testing.T) {
 	}
 }
 
+func TestSemanticDispatchPlatformUnresolvedMentionBypassesArbiter(t *testing.T) {
+	envelope, err := EncodeGroupOutboxEnvelope([]pkgchannel.Mention{{PlatformID: "other-bot"}})
+	if err != nil {
+		t.Fatalf("encode envelope: %v", err)
+	}
+	fx := newDispatcherFixture(t, "telegram", envelope)
+	stub := &stubSemanticArbiter{decision: SemanticGroupDecision{ShouldReply: true, RespondingAgents: []string{"agent-1"}}}
+	fx.d.coord.semanticGroupArbiter = stub
+
+	if err := fx.d.ProcessOutbox(context.Background(), fx.outbox); err != nil {
+		t.Fatalf("process outbox: %v", err)
+	}
+	if stub.called {
+		t.Fatal("semantic arbiter must not be called for unresolved platform mentions")
+	}
+	if count, _ := fx.q.CountGroupDispatchByMessage(context.Background(), fx.message.ID); count != 0 {
+		t.Fatalf("dispatch rows = %d, want 0 (unresolved platform mention)", count)
+	}
+}
+
 func TestSemanticDispatchUnresolvedMentionBypassesArbiter(t *testing.T) {
 	envelope, err := EncodeGroupOutboxEnvelope([]pkgchannel.Mention{{PlatformID: "other-bot"}})
 	if err != nil {
@@ -90,6 +110,29 @@ func TestSemanticDispatchUnresolvedMentionBypassesArbiter(t *testing.T) {
 	}
 	if count, _ := fx.q.CountGroupDispatchByMessage(context.Background(), fx.message.ID); count != 0 {
 		t.Fatalf("dispatch rows = %d, want 0 (unresolved mention)", count)
+	}
+}
+
+func TestSemanticDispatchWebNonMemberMentionTextUsesArbiter(t *testing.T) {
+	fx := newDispatcherFixture(t, "web", `{}`)
+	if _, err := fx.db.ExecContext(context.Background(), `UPDATE ctx_group_message SET content = '@non-member hello' WHERE id = ?`, fx.message.ID); err != nil {
+		t.Fatalf("set message content: %v", err)
+	}
+	stub := &stubSemanticArbiter{decision: SemanticGroupDecision{ShouldReply: true, RespondingAgents: []string{"agent-1"}}}
+	fx.d.coord.semanticGroupArbiter = stub
+	fx.d.publishers.Register("ch-1", &recordingGroupPublisher{})
+
+	if err := fx.d.ProcessOutbox(context.Background(), fx.outbox); err != nil {
+		t.Fatalf("process outbox: %v", err)
+	}
+	if !stub.called {
+		t.Fatal("semantic arbiter must be called when web @text produced no envelope mention")
+	}
+	if stub.gotReq.Message != "@non-member hello" {
+		t.Fatalf("semantic message = %q, want @non-member hello", stub.gotReq.Message)
+	}
+	if count, _ := fx.q.CountGroupDispatchByMessage(context.Background(), fx.message.ID); count != 1 {
+		t.Fatalf("dispatch rows = %d, want 1 (semantic fallback)", count)
 	}
 }
 

--- a/internal/channel/group_dispatcher_test.go
+++ b/internal/channel/group_dispatcher_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	appdb "github.com/CherryHQ/stella/internal/db"
-	"github.com/CherryHQ/stella/internal/eventlog"
 	cfgstore "github.com/CherryHQ/stella/internal/store"
 	pkgchannel "github.com/CherryHQ/stella/pkg/channel"
 	"github.com/CherryHQ/stella/pkg/db/sqlc"
@@ -117,6 +116,7 @@ func newDispatcherFixture(t *testing.T, platform, envelope string) dispatcherFix
 	if err != nil {
 		t.Fatalf("create group message: %v", err)
 	}
+	setGroupNextSeq(t, db, state.ID, message.Seq)
 	outbox, err := q.CreateGroupOutbox(ctx, sqlc.CreateGroupOutboxParams{
 		ID:             "outbox-1",
 		GroupMessageID: message.ID,
@@ -461,6 +461,191 @@ func TestGroupDispatcherExistingDispatchSkipsEnvelopeDecode(t *testing.T) {
 	}
 }
 
+func TestGroupDispatcherPublishFailureLeavesResultEmptyAndRequeues(t *testing.T) {
+	fx := newDispatcherFixture(t, "web", `{}`)
+	boom := errors.New("boom")
+	publisher := &recordingGroupPublisher{err: boom}
+	fx.d.publishers.Register("ch-1", publisher)
+	if err := fx.q.CreateGroupDispatch(context.Background(), sqlc.CreateGroupDispatchParams{
+		ID:             "dispatch-1",
+		GroupMessageID: fx.message.ID,
+		GroupID:        "group-1",
+		AgentID:        "agent-1",
+		ReplyChannelID: "ch-1",
+		Status:         "pending",
+		LastError:      "",
+	}); err != nil {
+		t.Fatalf("create dispatch: %v", err)
+	}
+	dispatch, err := fx.q.GetGroupDispatch(context.Background(), "dispatch-1")
+	if err != nil {
+		t.Fatalf("get dispatch: %v", err)
+	}
+	if err := fx.d.ExecuteDispatch(context.Background(), dispatch, nil); err == nil {
+		t.Fatal("expected publisher error")
+	}
+	dispatch, err = fx.q.GetGroupDispatch(context.Background(), "dispatch-1")
+	if err != nil {
+		t.Fatalf("get dispatch after failure: %v", err)
+	}
+	if dispatch.Status != "pending" || dispatch.ResultMessageID != "" {
+		t.Fatalf("dispatch status/result = %q/%q, want pending empty result", dispatch.Status, dispatch.ResultMessageID)
+	}
+	if got := countAgentGroupMessages(t, fx.db); got != 0 {
+		t.Fatalf("agent messages = %d, want 0", got)
+	}
+
+	publisher.err = nil
+	if _, err := fx.db.ExecContext(context.Background(), `UPDATE ctx_group_dispatch SET next_attempt_at = NULL WHERE id = 'dispatch-1'`); err != nil {
+		t.Fatalf("make dispatch due: %v", err)
+	}
+	dispatch, err = fx.q.GetGroupDispatch(context.Background(), "dispatch-1")
+	if err != nil {
+		t.Fatalf("get dispatch before retry: %v", err)
+	}
+	if err := fx.d.ExecuteDispatch(context.Background(), dispatch, nil); err != nil {
+		t.Fatalf("retry dispatch: %v", err)
+	}
+	if publisher.calls != 2 {
+		t.Fatalf("publisher calls = %d, want retry to republish", publisher.calls)
+	}
+}
+
+func TestGroupDispatcherWritebackFailureLeavesResultEmptyAndRequeues(t *testing.T) {
+	fx := newDispatcherFixture(t, "web", `{}`)
+	publisher := &recordingGroupPublisher{}
+	fx.d.publishers.Register("ch-1", publisher)
+	chatCalls := 0
+	fx.d.chat = func(context.Context, sqlc.CtxGroupDispatch, sqlc.CtxGroupMessage, sqlc.CtxGroupState) (*pkgchannel.ChatStream, error) {
+		chatCalls++
+		return textStream("ok"), nil
+	}
+	if err := fx.q.CreateGroupDispatch(context.Background(), sqlc.CreateGroupDispatchParams{
+		ID:             "dispatch-1",
+		GroupMessageID: fx.message.ID,
+		GroupID:        "group-1",
+		AgentID:        "agent-1",
+		ReplyChannelID: "ch-1",
+		Status:         "pending",
+		LastError:      "",
+	}); err != nil {
+		t.Fatalf("create dispatch: %v", err)
+	}
+	if _, err := fx.db.ExecContext(context.Background(), `CREATE TRIGGER fail_agent_writeback BEFORE INSERT ON ctx_group_message WHEN NEW.actor_type = 'agent' BEGIN SELECT RAISE(FAIL, 'fail agent writeback'); END;`); err != nil {
+		t.Fatalf("create trigger: %v", err)
+	}
+	dispatch, err := fx.q.GetGroupDispatch(context.Background(), "dispatch-1")
+	if err != nil {
+		t.Fatalf("get dispatch: %v", err)
+	}
+	if err := fx.d.ExecuteDispatch(context.Background(), dispatch, nil); err == nil {
+		t.Fatal("expected writeback error")
+	}
+	dispatch, err = fx.q.GetGroupDispatch(context.Background(), "dispatch-1")
+	if err != nil {
+		t.Fatalf("get dispatch after failure: %v", err)
+	}
+	if dispatch.Status != "pending" || dispatch.ResultMessageID != "" {
+		t.Fatalf("dispatch status/result = %q/%q, want pending empty result", dispatch.Status, dispatch.ResultMessageID)
+	}
+	if got := countAgentGroupMessages(t, fx.db); got != 0 {
+		t.Fatalf("agent messages = %d, want failed transaction to append none", got)
+	}
+	if _, err := fx.db.ExecContext(context.Background(), `DROP TRIGGER fail_agent_writeback`); err != nil {
+		t.Fatalf("drop trigger: %v", err)
+	}
+	if _, err := fx.db.ExecContext(context.Background(), `UPDATE ctx_group_dispatch SET next_attempt_at = NULL WHERE id = 'dispatch-1'`); err != nil {
+		t.Fatalf("make dispatch due: %v", err)
+	}
+	dispatch, err = fx.q.GetGroupDispatch(context.Background(), "dispatch-1")
+	if err != nil {
+		t.Fatalf("get dispatch before retry: %v", err)
+	}
+	if err := fx.d.ExecuteDispatch(context.Background(), dispatch, nil); err != nil {
+		t.Fatalf("retry dispatch: %v", err)
+	}
+	if chatCalls != 2 {
+		t.Fatalf("chat calls = %d, want retry to rerun chat", chatCalls)
+	}
+	if got := countAgentGroupMessages(t, fx.db); got != 1 {
+		t.Fatalf("agent messages = %d, want one successful retry append", got)
+	}
+}
+
+func TestGroupDispatcherResultMessageSkipsChatPublishAndAppend(t *testing.T) {
+	fx := newDispatcherFixture(t, "web", `{}`)
+	publisher := &recordingGroupPublisher{}
+	fx.d.publishers.Register("ch-1", publisher)
+	chatCalls := 0
+	fx.d.chat = func(context.Context, sqlc.CtxGroupDispatch, sqlc.CtxGroupMessage, sqlc.CtxGroupState) (*pkgchannel.ChatStream, error) {
+		chatCalls++
+		return textStream("ok"), nil
+	}
+	if err := fx.q.CreateGroupDispatch(context.Background(), sqlc.CreateGroupDispatchParams{
+		ID:             "dispatch-1",
+		GroupMessageID: fx.message.ID,
+		GroupID:        "group-1",
+		AgentID:        "agent-1",
+		ReplyChannelID: "ch-1",
+		Status:         "running",
+		AttemptCount:   1,
+		LastError:      "",
+	}); err != nil {
+		t.Fatalf("create dispatch: %v", err)
+	}
+	if _, err := fx.db.ExecContext(context.Background(), `UPDATE ctx_group_dispatch SET result_message_id = 'result-1' WHERE id = 'dispatch-1'`); err != nil {
+		t.Fatalf("set result marker: %v", err)
+	}
+	dispatch, err := fx.q.GetGroupDispatch(context.Background(), "dispatch-1")
+	if err != nil {
+		t.Fatalf("get dispatch: %v", err)
+	}
+	if err := fx.d.ExecuteDispatch(context.Background(), dispatch, nil); err != nil {
+		t.Fatalf("execute dispatch: %v", err)
+	}
+	dispatch, err = fx.q.GetGroupDispatch(context.Background(), "dispatch-1")
+	if err != nil {
+		t.Fatalf("get dispatch after execute: %v", err)
+	}
+	if dispatch.Status != "completed" || chatCalls != 0 || publisher.calls != 0 {
+		t.Fatalf("status/chat/publish = %q/%d/%d, want completed/0/0", dispatch.Status, chatCalls, publisher.calls)
+	}
+	if got := countAgentGroupMessages(t, fx.db); got != 0 {
+		t.Fatalf("agent messages = %d, want 0", got)
+	}
+}
+
+func TestGroupDispatcherWebWriteErrorStillRecordsResult(t *testing.T) {
+	fx := newDispatcherFixture(t, "web", `{}`)
+	publisher := &recordingGroupPublisher{}
+	fx.d.publishers.Register("ch-1", publisher)
+	if err := fx.q.CreateGroupDispatch(context.Background(), sqlc.CreateGroupDispatchParams{
+		ID:             "dispatch-1",
+		GroupMessageID: fx.message.ID,
+		GroupID:        "group-1",
+		AgentID:        "agent-1",
+		ReplyChannelID: "ch-1",
+		Status:         "pending",
+		LastError:      "",
+	}); err != nil {
+		t.Fatalf("create dispatch: %v", err)
+	}
+	dispatch, err := fx.q.GetGroupDispatch(context.Background(), "dispatch-1")
+	if err != nil {
+		t.Fatalf("get dispatch: %v", err)
+	}
+	if err := fx.d.ExecuteDispatch(context.Background(), dispatch, nil); err != nil {
+		t.Fatalf("execute dispatch: %v", err)
+	}
+	dispatch, err = fx.q.GetGroupDispatch(context.Background(), "dispatch-1")
+	if err != nil {
+		t.Fatalf("get dispatch after execute: %v", err)
+	}
+	if dispatch.ResultMessageID == "" || dispatch.Status != "completed" {
+		t.Fatalf("dispatch status/result = %q/%q, want completed result", dispatch.Status, dispatch.ResultMessageID)
+	}
+}
+
 func TestGroupDispatcherPublisherFailureMarksFailedAtMaxAttempts(t *testing.T) {
 	fx := newDispatcherFixture(t, "web", `{}`)
 	fx.d.maxAttempts = 1
@@ -723,28 +908,37 @@ func dispatchStatusByMessage(t *testing.T, db *sql.DB, messageID string) string 
 	return status
 }
 
+func countAgentGroupMessages(t *testing.T, db *sql.DB) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM ctx_group_message WHERE actor_type = 'agent'`).Scan(&count); err != nil {
+		t.Fatalf("count agent messages: %v", err)
+	}
+	return count
+}
+
 func TestWrapGroupResponseStreamSkipsWritebackOnErrEvent(t *testing.T) {
 	fx := newDispatcherFixture(t, "web", `{}`)
-	fx.d.coord.eventLog = eventlog.NewStore(fx.db)
-	setGroupNextSeq(t, fx.db, fx.message.GroupID, 1)
 	stream := make(chan pkgchannel.Event, 2)
 	stream <- pkgchannel.Event{Text: "partial"}
 	stream <- pkgchannel.Event{Err: errors.New("boom")}
 	close(stream)
 
-	wrapped := fx.d.wrapGroupResponseStream(context.Background(), fx.message.GroupID, "agent-1", &pkgchannel.ChatStream{Events: stream, SessionID: "session-1"})
+	wrapped, responseC := fx.d.wrapGroupResponseStream(context.Background(), &pkgchannel.ChatStream{Events: stream, SessionID: "session-1"})
 	for range wrapped.Events {
+	}
+	response := <-responseC
+	if response.complete {
+		t.Fatalf("response.complete = true, want false")
 	}
 	assertNoAgentGroupMessages(t, fx.db)
 }
 
 func TestWrapGroupResponseStreamSkipsWritebackAfterCancel(t *testing.T) {
 	fx := newDispatcherFixture(t, "web", `{}`)
-	fx.d.coord.eventLog = eventlog.NewStore(fx.db)
-	setGroupNextSeq(t, fx.db, fx.message.GroupID, 1)
 	ctx, cancel := context.WithCancel(context.Background())
 	stream := make(chan pkgchannel.Event)
-	wrapped := fx.d.wrapGroupResponseStream(ctx, fx.message.GroupID, "agent-1", &pkgchannel.ChatStream{Events: stream, SessionID: "session-1"})
+	wrapped, responseC := fx.d.wrapGroupResponseStream(ctx, &pkgchannel.ChatStream{Events: stream, SessionID: "session-1"})
 
 	stream <- pkgchannel.Event{Text: "partial"}
 	cancel()
@@ -752,39 +946,27 @@ func TestWrapGroupResponseStreamSkipsWritebackAfterCancel(t *testing.T) {
 	close(stream)
 	for range wrapped.Events {
 	}
+	response := <-responseC
+	if response.complete {
+		t.Fatalf("response.complete = true, want false")
+	}
 	assertNoAgentGroupMessages(t, fx.db)
 }
 
-func TestWrapGroupResponseStreamWritesBackCompleteStream(t *testing.T) {
+func TestWrapGroupResponseStreamBuffersCompleteStream(t *testing.T) {
 	fx := newDispatcherFixture(t, "web", `{}`)
-	fx.d.coord.eventLog = eventlog.NewStore(fx.db)
-	setGroupNextSeq(t, fx.db, fx.message.GroupID, 1)
 	stream := make(chan pkgchannel.Event, 2)
 	stream <- pkgchannel.Event{Text: "complete"}
 	close(stream)
 
-	wrapped := fx.d.wrapGroupResponseStream(context.Background(), fx.message.GroupID, "agent-1", &pkgchannel.ChatStream{Events: stream, SessionID: "session-1"})
+	wrapped, responseC := fx.d.wrapGroupResponseStream(context.Background(), &pkgchannel.ChatStream{Events: stream, SessionID: "session-1"})
 	for range wrapped.Events {
 	}
-	rows, err := fx.db.QueryContext(context.Background(), `SELECT content FROM ctx_group_message WHERE actor_type = 'agent'`)
-	if err != nil {
-		t.Fatalf("query agent messages: %v", err)
+	response := <-responseC
+	if !response.complete || response.text != "complete" || response.sessionID != "session-1" {
+		t.Fatalf("response = %+v, want complete buffered response", response)
 	}
-	defer func() { _ = rows.Close() }()
-	var got []string
-	for rows.Next() {
-		var content string
-		if err := rows.Scan(&content); err != nil {
-			t.Fatalf("scan content: %v", err)
-		}
-		got = append(got, content)
-	}
-	if err := rows.Err(); err != nil {
-		t.Fatalf("rows: %v", err)
-	}
-	if !slices.Equal(got, []string{"complete"}) {
-		t.Fatalf("agent messages = %v, want complete", got)
-	}
+	assertNoAgentGroupMessages(t, fx.db)
 }
 
 func setGroupNextSeq(t *testing.T, db *sql.DB, groupID string, seq int64) {

--- a/internal/channel/group_dispatcher_test.go
+++ b/internal/channel/group_dispatcher_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -139,6 +141,138 @@ func textStream(text string) *pkgchannel.ChatStream {
 	ch <- pkgchannel.Event{Text: text}
 	close(ch)
 	return &pkgchannel.ChatStream{Events: ch, SessionID: "session-1"}
+}
+
+func createDispatchForGroupMessage(t *testing.T, q *sqlc.Queries, msg sqlc.CtxGroupMessage, id, agentID, groupID string, status string, leaseUntil sql.NullString) {
+	t.Helper()
+	if err := q.CreateGroupDispatch(context.Background(), sqlc.CreateGroupDispatchParams{
+		ID:             id,
+		GroupMessageID: msg.ID,
+		GroupID:        groupID,
+		AgentID:        agentID,
+		ReplyChannelID: "ch-1",
+		Status:         status,
+		LeaseUntil:     leaseUntil,
+		LastError:      "",
+	}); err != nil {
+		t.Fatalf("create dispatch %s: %v", id, err)
+	}
+}
+
+func createGroupMessageWithSeq(t *testing.T, q *sqlc.Queries, groupID, id string, seq int64) sqlc.CtxGroupMessage {
+	t.Helper()
+	msg, err := q.CreateGroupMessage(context.Background(), sqlc.CreateGroupMessageParams{
+		ID:        id,
+		GroupID:   groupID,
+		Seq:       seq,
+		ActorType: "human",
+		ActorID:   "user-1",
+		Content:   "hello",
+	})
+	if err != nil {
+		t.Fatalf("create message %s: %v", id, err)
+	}
+	return msg
+}
+
+func listPendingDispatchIDs(t *testing.T, q *sqlc.Queries, now time.Time, limit int64) []string {
+	t.Helper()
+	rows, err := q.ListPendingGroupDispatch(context.Background(), sqlc.ListPendingGroupDispatchParams{
+		Now:        nullTime(now),
+		LimitCount: limit,
+	})
+	if err != nil {
+		t.Fatalf("list pending dispatch: %v", err)
+	}
+	ids := make([]string, 0, len(rows))
+	for _, row := range rows {
+		ids = append(ids, row.ID)
+	}
+	return ids
+}
+
+func TestListPendingGroupDispatchBlocksLaterSameAgentSeq(t *testing.T) {
+	fx := newDispatcherFixture(t, "web", `{}`)
+	now := time.Now().UTC()
+	earlier := fx.message
+	later := createGroupMessageWithSeq(t, fx.q, fx.message.GroupID, "msg-2", 2)
+	createDispatchForGroupMessage(t, fx.q, earlier, "dispatch-1", "agent-1", fx.message.GroupID, "pending", sql.NullString{})
+	createDispatchForGroupMessage(t, fx.q, later, "dispatch-2", "agent-1", fx.message.GroupID, "pending", sql.NullString{})
+
+	ids := listPendingDispatchIDs(t, fx.q, now, 25)
+	if !containsString(ids, "dispatch-1") || containsString(ids, "dispatch-2") {
+		t.Fatalf("pending ids = %v, want earlier only", ids)
+	}
+	if _, err := fx.db.ExecContext(context.Background(), `UPDATE ctx_group_dispatch SET status = 'completed' WHERE id = 'dispatch-1'`); err != nil {
+		t.Fatalf("complete earlier: %v", err)
+	}
+	ids = listPendingDispatchIDs(t, fx.q, now, 25)
+	if !containsString(ids, "dispatch-2") {
+		t.Fatalf("pending ids = %v, want later after terminal earlier", ids)
+	}
+}
+
+func TestListPendingGroupDispatchExpiredRunningDoesNotBlockLater(t *testing.T) {
+	fx := newDispatcherFixture(t, "web", `{}`)
+	now := time.Now().UTC()
+	later := createGroupMessageWithSeq(t, fx.q, fx.message.GroupID, "msg-2", 2)
+	createDispatchForGroupMessage(t, fx.q, fx.message, "dispatch-1", "agent-1", fx.message.GroupID, "running", nullTime(now.Add(-time.Minute)))
+	createDispatchForGroupMessage(t, fx.q, later, "dispatch-2", "agent-1", fx.message.GroupID, "pending", sql.NullString{})
+
+	ids := listPendingDispatchIDs(t, fx.q, now, 25)
+	if !containsString(ids, "dispatch-2") {
+		t.Fatalf("pending ids = %v, want expired running not to block later", ids)
+	}
+}
+
+func TestListPendingGroupDispatchBlockedRowsDoNotConsumeLimit(t *testing.T) {
+	fx := newDispatcherFixture(t, "web", `{}`)
+	now := time.Now().UTC()
+	createDispatchForGroupMessage(t, fx.q, fx.message, "dispatch-1", "agent-1", fx.message.GroupID, "pending", sql.NullString{})
+	for i := range 30 {
+		msg := createGroupMessageWithSeq(t, fx.q, fx.message.GroupID, fmt.Sprintf("msg-blocked-%02d", i), int64(i+2))
+		createDispatchForGroupMessage(t, fx.q, msg, fmt.Sprintf("dispatch-blocked-%02d", i), "agent-1", fx.message.GroupID, "pending", sql.NullString{})
+	}
+	otherGroup, err := fx.q.CreateGroupState(context.Background(), sqlc.CreateGroupStateParams{ID: "group-2", Platform: "web", PlatformGroupID: "physical-group-2", GroupName: "Group Two"})
+	if err != nil {
+		t.Fatalf("create group-2: %v", err)
+	}
+	otherMsg := createGroupMessageWithSeq(t, fx.q, otherGroup.ID, "msg-other", 1)
+	createDispatchForGroupMessage(t, fx.q, otherMsg, "dispatch-other", "agent-1", otherGroup.ID, "pending", sql.NullString{})
+
+	ids := listPendingDispatchIDs(t, fx.q, now, 25)
+	if !containsString(ids, "dispatch-other") {
+		t.Fatalf("pending ids = %v, want other group despite 30 blocked rows", ids)
+	}
+}
+
+func TestListPendingGroupDispatchGateIsPerGroupAgent(t *testing.T) {
+	fx := newDispatcherFixture(t, "web", `{}`)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if _, err := fx.q.CreateAgent(ctx, sqlc.CreateAgentParams{ID: "agent-2", Name: "Agent Two", Workspace: t.TempDir(), Sandbox: "{}", EnabledBuiltinSkills: "[]", Scope: "system", Enabled: 1}); err != nil {
+		t.Fatalf("create agent-2: %v", err)
+	}
+	state2, err := fx.q.CreateGroupState(ctx, sqlc.CreateGroupStateParams{ID: "group-2", Platform: "web", PlatformGroupID: "physical-group-2", GroupName: "Group Two"})
+	if err != nil {
+		t.Fatalf("create group-2: %v", err)
+	}
+	laterSameAgent := createGroupMessageWithSeq(t, fx.q, fx.message.GroupID, "msg-2", 2)
+	laterOtherAgent := createGroupMessageWithSeq(t, fx.q, fx.message.GroupID, "msg-3", 3)
+	otherGroup := createGroupMessageWithSeq(t, fx.q, state2.ID, "msg-4", 2)
+	createDispatchForGroupMessage(t, fx.q, fx.message, "dispatch-1", "agent-1", fx.message.GroupID, "pending", sql.NullString{})
+	createDispatchForGroupMessage(t, fx.q, laterSameAgent, "dispatch-2", "agent-1", fx.message.GroupID, "pending", sql.NullString{})
+	createDispatchForGroupMessage(t, fx.q, laterOtherAgent, "dispatch-3", "agent-2", fx.message.GroupID, "pending", sql.NullString{})
+	createDispatchForGroupMessage(t, fx.q, otherGroup, "dispatch-4", "agent-1", state2.ID, "pending", sql.NullString{})
+
+	ids := listPendingDispatchIDs(t, fx.q, now, 25)
+	if containsString(ids, "dispatch-2") || !containsString(ids, "dispatch-3") || !containsString(ids, "dispatch-4") {
+		t.Fatalf("pending ids = %v, want same-agent blocked only", ids)
+	}
+}
+
+func containsString(xs []string, want string) bool {
+	return slices.Contains(xs, want)
 }
 
 func TestGroupDispatcherProcessOutboxHappyPath(t *testing.T) {

--- a/internal/channel/group_dispatcher_test.go
+++ b/internal/channel/group_dispatcher_test.go
@@ -194,6 +194,9 @@ func listPendingDispatchIDs(t *testing.T, q *sqlc.Queries, now time.Time, limit 
 
 func TestListPendingGroupDispatchBlocksLaterSameAgentSeq(t *testing.T) {
 	fx := newDispatcherFixture(t, "web", `{}`)
+	if _, err := fx.db.ExecContext(context.Background(), `UPDATE ctx_group_outbox SET status = 'completed' WHERE id = 'outbox-1'`); err != nil {
+		t.Fatalf("complete outbox: %v", err)
+	}
 	now := time.Now().UTC()
 	earlier := fx.message
 	later := createGroupMessageWithSeq(t, fx.q, fx.message.GroupID, "msg-2", 2)
@@ -215,6 +218,9 @@ func TestListPendingGroupDispatchBlocksLaterSameAgentSeq(t *testing.T) {
 
 func TestListPendingGroupDispatchExpiredRunningDoesNotBlockLater(t *testing.T) {
 	fx := newDispatcherFixture(t, "web", `{}`)
+	if _, err := fx.db.ExecContext(context.Background(), `UPDATE ctx_group_outbox SET status = 'completed' WHERE id = 'outbox-1'`); err != nil {
+		t.Fatalf("complete outbox: %v", err)
+	}
 	now := time.Now().UTC()
 	later := createGroupMessageWithSeq(t, fx.q, fx.message.GroupID, "msg-2", 2)
 	createDispatchForGroupMessage(t, fx.q, fx.message, "dispatch-1", "agent-1", fx.message.GroupID, "running", nullTime(now.Add(-time.Minute)))
@@ -226,8 +232,30 @@ func TestListPendingGroupDispatchExpiredRunningDoesNotBlockLater(t *testing.T) {
 	}
 }
 
+func TestListPendingGroupDispatchBlocksLaterWhenEarlierOutboxNotTerminal(t *testing.T) {
+	fx := newDispatcherFixture(t, "web", `{}`)
+	now := time.Now().UTC()
+	later := createGroupMessageWithSeq(t, fx.q, fx.message.GroupID, "msg-2", 2)
+	createDispatchForGroupMessage(t, fx.q, later, "dispatch-2", "agent-1", fx.message.GroupID, "pending", sql.NullString{})
+
+	ids := listPendingDispatchIDs(t, fx.q, now, 25)
+	if containsString(ids, "dispatch-2") {
+		t.Fatalf("pending ids = %v, want later blocked by earlier outbox", ids)
+	}
+	if _, err := fx.db.ExecContext(context.Background(), `UPDATE ctx_group_outbox SET status = 'completed' WHERE id = 'outbox-1'`); err != nil {
+		t.Fatalf("complete earlier outbox: %v", err)
+	}
+	ids = listPendingDispatchIDs(t, fx.q, now, 25)
+	if !containsString(ids, "dispatch-2") {
+		t.Fatalf("pending ids = %v, want later after terminal earlier outbox", ids)
+	}
+}
+
 func TestListPendingGroupDispatchBlockedRowsDoNotConsumeLimit(t *testing.T) {
 	fx := newDispatcherFixture(t, "web", `{}`)
+	if _, err := fx.db.ExecContext(context.Background(), `UPDATE ctx_group_outbox SET status = 'completed' WHERE id = 'outbox-1'`); err != nil {
+		t.Fatalf("complete outbox: %v", err)
+	}
 	now := time.Now().UTC()
 	createDispatchForGroupMessage(t, fx.q, fx.message, "dispatch-1", "agent-1", fx.message.GroupID, "pending", sql.NullString{})
 	for i := range 30 {
@@ -250,6 +278,9 @@ func TestListPendingGroupDispatchBlockedRowsDoNotConsumeLimit(t *testing.T) {
 func TestListPendingGroupDispatchGateIsPerGroupAgent(t *testing.T) {
 	fx := newDispatcherFixture(t, "web", `{}`)
 	ctx := context.Background()
+	if _, err := fx.db.ExecContext(ctx, `UPDATE ctx_group_outbox SET status = 'completed' WHERE id = 'outbox-1'`); err != nil {
+		t.Fatalf("complete outbox: %v", err)
+	}
 	now := time.Now().UTC()
 	if _, err := fx.q.CreateAgent(ctx, sqlc.CreateAgentParams{ID: "agent-2", Name: "Agent Two", Workspace: t.TempDir(), Sandbox: "{}", EnabledBuiltinSkills: "[]", Scope: "system", Enabled: 1}); err != nil {
 		t.Fatalf("create agent-2: %v", err)
@@ -274,6 +305,38 @@ func TestListPendingGroupDispatchGateIsPerGroupAgent(t *testing.T) {
 
 func containsString(xs []string, want string) bool {
 	return slices.Contains(xs, want)
+}
+
+func TestGroupDispatcherReapExpiredCompletesDispatchWithResultMarker(t *testing.T) {
+	fx := newDispatcherFixture(t, "web", `{}`)
+	past := time.Now().UTC().Add(-time.Minute)
+	if err := fx.q.CreateGroupDispatch(context.Background(), sqlc.CreateGroupDispatchParams{
+		ID:             "dispatch-marker",
+		GroupMessageID: fx.message.ID,
+		GroupID:        fx.message.GroupID,
+		AgentID:        "agent-1",
+		ReplyChannelID: "ch-1",
+		Status:         "running",
+		AttemptCount:   fx.d.maxAttempts,
+		LeaseUntil:     nullTime(past),
+		LastError:      "",
+	}); err != nil {
+		t.Fatalf("create dispatch: %v", err)
+	}
+	if _, err := fx.db.ExecContext(context.Background(), `UPDATE ctx_group_dispatch SET result_message_id = 'result-1' WHERE id = 'dispatch-marker'`); err != nil {
+		t.Fatalf("set marker: %v", err)
+	}
+
+	if err := fx.d.reapExpired(context.Background()); err != nil {
+		t.Fatalf("reap expired: %v", err)
+	}
+	dispatch, err := fx.q.GetGroupDispatch(context.Background(), "dispatch-marker")
+	if err != nil {
+		t.Fatalf("get dispatch: %v", err)
+	}
+	if dispatch.Status != "completed" {
+		t.Fatalf("dispatch status = %q, want completed", dispatch.Status)
+	}
 }
 
 func TestGroupDispatcherProcessOutboxHappyPath(t *testing.T) {
@@ -712,6 +775,32 @@ func TestGroupDispatcherDispatchSyncUsesPublisherOverride(t *testing.T) {
 	publisher := &recordingGroupPublisher{}
 
 	if err := fx.d.DispatchSync(context.Background(), fx.outbox, publisher); err != nil {
+		t.Fatalf("dispatch sync: %v", err)
+	}
+	if publisher.calls != 1 {
+		t.Fatalf("publisher calls = %d, want 1", publisher.calls)
+	}
+}
+
+func TestGroupDispatcherDispatchSyncWaitsForBlockedDispatch(t *testing.T) {
+	fx := newDispatcherFixture(t, "web", `{}`)
+	ctx := context.Background()
+	if _, err := fx.db.ExecContext(ctx, `UPDATE ctx_group_outbox SET status = 'completed' WHERE id = 'outbox-1'`); err != nil {
+		t.Fatalf("complete earlier outbox: %v", err)
+	}
+	createDispatchForGroupMessage(t, fx.q, fx.message, "dispatch-1", "agent-1", fx.message.GroupID, "pending", sql.NullString{})
+	later := createGroupMessageWithSeq(t, fx.q, fx.message.GroupID, "msg-2", 2)
+	setGroupNextSeq(t, fx.db, fx.message.GroupID, later.Seq)
+	laterOutbox, err := fx.q.CreateGroupOutbox(ctx, sqlc.CreateGroupOutboxParams{ID: "outbox-2", GroupMessageID: later.ID, GroupID: fx.message.GroupID, Envelope: `{}`, Status: "pending", LastError: ""})
+	if err != nil {
+		t.Fatalf("create later outbox: %v", err)
+	}
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		_, _ = fx.db.ExecContext(context.Background(), `UPDATE ctx_group_dispatch SET status = 'completed' WHERE id = 'dispatch-1'`)
+	}()
+	publisher := &recordingGroupPublisher{}
+	if err := fx.d.DispatchSync(ctx, laterOutbox, publisher); err != nil {
 		t.Fatalf("dispatch sync: %v", err)
 	}
 	if publisher.calls != 1 {

--- a/internal/channel/group_dispatcher_test.go
+++ b/internal/channel/group_dispatcher_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	appdb "github.com/CherryHQ/stella/internal/db"
+	"github.com/CherryHQ/stella/internal/eventlog"
 	cfgstore "github.com/CherryHQ/stella/internal/store"
 	pkgchannel "github.com/CherryHQ/stella/pkg/channel"
 	"github.com/CherryHQ/stella/pkg/db/sqlc"
@@ -720,4 +721,86 @@ func dispatchStatusByMessage(t *testing.T, db *sql.DB, messageID string) string 
 		t.Fatalf("query dispatch status: %v", err)
 	}
 	return status
+}
+
+func TestWrapGroupResponseStreamSkipsWritebackOnErrEvent(t *testing.T) {
+	fx := newDispatcherFixture(t, "web", `{}`)
+	fx.d.coord.eventLog = eventlog.NewStore(fx.db)
+	setGroupNextSeq(t, fx.db, fx.message.GroupID, 1)
+	stream := make(chan pkgchannel.Event, 2)
+	stream <- pkgchannel.Event{Text: "partial"}
+	stream <- pkgchannel.Event{Err: errors.New("boom")}
+	close(stream)
+
+	wrapped := fx.d.wrapGroupResponseStream(context.Background(), fx.message.GroupID, "agent-1", &pkgchannel.ChatStream{Events: stream, SessionID: "session-1"})
+	for range wrapped.Events {
+	}
+	assertNoAgentGroupMessages(t, fx.db)
+}
+
+func TestWrapGroupResponseStreamSkipsWritebackAfterCancel(t *testing.T) {
+	fx := newDispatcherFixture(t, "web", `{}`)
+	fx.d.coord.eventLog = eventlog.NewStore(fx.db)
+	setGroupNextSeq(t, fx.db, fx.message.GroupID, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	stream := make(chan pkgchannel.Event)
+	wrapped := fx.d.wrapGroupResponseStream(ctx, fx.message.GroupID, "agent-1", &pkgchannel.ChatStream{Events: stream, SessionID: "session-1"})
+
+	stream <- pkgchannel.Event{Text: "partial"}
+	cancel()
+	stream <- pkgchannel.Event{Text: " ignored"}
+	close(stream)
+	for range wrapped.Events {
+	}
+	assertNoAgentGroupMessages(t, fx.db)
+}
+
+func TestWrapGroupResponseStreamWritesBackCompleteStream(t *testing.T) {
+	fx := newDispatcherFixture(t, "web", `{}`)
+	fx.d.coord.eventLog = eventlog.NewStore(fx.db)
+	setGroupNextSeq(t, fx.db, fx.message.GroupID, 1)
+	stream := make(chan pkgchannel.Event, 2)
+	stream <- pkgchannel.Event{Text: "complete"}
+	close(stream)
+
+	wrapped := fx.d.wrapGroupResponseStream(context.Background(), fx.message.GroupID, "agent-1", &pkgchannel.ChatStream{Events: stream, SessionID: "session-1"})
+	for range wrapped.Events {
+	}
+	rows, err := fx.db.QueryContext(context.Background(), `SELECT content FROM ctx_group_message WHERE actor_type = 'agent'`)
+	if err != nil {
+		t.Fatalf("query agent messages: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var got []string
+	for rows.Next() {
+		var content string
+		if err := rows.Scan(&content); err != nil {
+			t.Fatalf("scan content: %v", err)
+		}
+		got = append(got, content)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+	if !slices.Equal(got, []string{"complete"}) {
+		t.Fatalf("agent messages = %v, want complete", got)
+	}
+}
+
+func setGroupNextSeq(t *testing.T, db *sql.DB, groupID string, seq int64) {
+	t.Helper()
+	if _, err := db.ExecContext(context.Background(), `UPDATE ctx_group_state SET next_seq = ? WHERE id = ?`, seq, groupID); err != nil {
+		t.Fatalf("set group next seq: %v", err)
+	}
+}
+
+func assertNoAgentGroupMessages(t *testing.T, db *sql.DB) {
+	t.Helper()
+	var count int
+	if err := db.QueryRowContext(context.Background(), `SELECT count(*) FROM ctx_group_message WHERE actor_type = 'agent'`).Scan(&count); err != nil {
+		t.Fatalf("count agent messages: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("agent group messages = %d, want 0", count)
+	}
 }

--- a/internal/channel/group_dispatcher_test.go
+++ b/internal/channel/group_dispatcher_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	appdb "github.com/CherryHQ/stella/internal/db"
+	cfgstore "github.com/CherryHQ/stella/internal/store"
 	pkgchannel "github.com/CherryHQ/stella/pkg/channel"
 	"github.com/CherryHQ/stella/pkg/db/sqlc"
 )
@@ -124,7 +125,7 @@ func newDispatcherFixture(t *testing.T, platform, envelope string) dispatcherFix
 	if err != nil {
 		t.Fatalf("create outbox: %v", err)
 	}
-	coord := &Coordinator{arbiter: NewArbiter(ArbiterConfig{MaxRepliesPerTrigger: 3})}
+	coord := &Coordinator{store: cfgstore.NewDBStore(db), arbiter: NewArbiter(ArbiterConfig{MaxRepliesPerTrigger: 3})}
 	d := NewGroupDispatcher(db, coord, NewPublisherRegistry())
 	d.leaseDuration = 0
 	d.chat = func(context.Context, sqlc.CtxGroupDispatch, sqlc.CtxGroupMessage, sqlc.CtxGroupState) (*pkgchannel.ChatStream, error) {
@@ -252,6 +253,48 @@ func TestGroupDispatcherPlatformAlwaysModeUsesMemberFallback(t *testing.T) {
 	}
 	if firstPublisher.calls != 1 {
 		t.Fatalf("first publisher calls = %d, want 1", firstPublisher.calls)
+	}
+}
+
+func TestGroupDispatcherResolvesEnvelopeMentionAtDispatch(t *testing.T) {
+	envelope, err := EncodeGroupOutboxEnvelope([]pkgchannel.Mention{{Raw: "@bot1", PlatformID: "bot1"}})
+	if err != nil {
+		t.Fatalf("encode envelope: %v", err)
+	}
+	fx := newDispatcherFixture(t, "telegram", envelope)
+	reg := NewBotIdentityRegistry()
+	reg.Register("telegram", "bot1", "ch-1")
+	fx.d.coord.botRegistry = reg
+	fx.d.publishers.Register("ch-1", &recordingGroupPublisher{})
+
+	if err := fx.d.ProcessOutbox(context.Background(), fx.outbox); err != nil {
+		t.Fatalf("process outbox: %v", err)
+	}
+	if got := dispatchAgentsByMessage(t, fx.db, fx.message.ID); len(got) != 1 || got[0] != "agent-1" {
+		t.Fatalf("dispatch agents = %v, want [agent-1]", got)
+	}
+}
+
+func TestGroupDispatcherDispatchesAllMentionedMembers(t *testing.T) {
+	envelope, err := EncodeGroupOutboxEnvelope([]pkgchannel.Mention{{AgentID: "agent-1"}, {AgentID: "agent-2"}})
+	if err != nil {
+		t.Fatalf("encode envelope: %v", err)
+	}
+	fx := newDispatcherFixture(t, "telegram", envelope)
+	addSecondMember(t, fx)
+	firstPublisher := &recordingGroupPublisher{}
+	secondPublisher := &recordingGroupPublisher{}
+	fx.d.publishers.Register("ch-1", firstPublisher)
+	fx.d.publishers.Register("ch-2", secondPublisher)
+
+	if err := fx.d.ProcessOutbox(context.Background(), fx.outbox); err != nil {
+		t.Fatalf("process outbox: %v", err)
+	}
+	if got := dispatchAgentsByMessage(t, fx.db, fx.message.ID); len(got) != 2 || got[0] != "agent-1" || got[1] != "agent-2" {
+		t.Fatalf("dispatch agents = %v, want [agent-1 agent-2]", got)
+	}
+	if firstPublisher.calls != 1 || secondPublisher.calls != 1 {
+		t.Fatalf("publisher calls = %d/%d, want 1/1", firstPublisher.calls, secondPublisher.calls)
 	}
 }
 
@@ -509,6 +552,31 @@ func TestGroupDispatcherExtendsDispatchLeaseWhilePublishing(t *testing.T) {
 			}
 		}
 	}
+}
+
+func dispatchAgentsByMessage(t *testing.T, db *sql.DB, messageID string) []string {
+	t.Helper()
+	rows, err := db.QueryContext(context.Background(), `SELECT agent_id FROM ctx_group_dispatch WHERE group_message_id = ? ORDER BY agent_id`, messageID)
+	if err != nil {
+		t.Fatalf("query dispatch agents: %v", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			t.Fatalf("close dispatch agent rows: %v", err)
+		}
+	}()
+	var agents []string
+	for rows.Next() {
+		var agentID string
+		if err := rows.Scan(&agentID); err != nil {
+			t.Fatalf("scan dispatch agent: %v", err)
+		}
+		agents = append(agents, agentID)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate dispatch agents: %v", err)
+	}
+	return agents
 }
 
 func dispatchStatusByMessage(t *testing.T, db *sql.DB, messageID string) string {

--- a/internal/channel/group_dispatcher_test.go
+++ b/internal/channel/group_dispatcher_test.go
@@ -300,6 +300,34 @@ func TestGroupDispatcherProcessOutboxHappyPath(t *testing.T) {
 	}
 }
 
+func TestGroupDispatcherWebNoMentionSingleMemberFallbackCreatesOneDispatch(t *testing.T) {
+	fx := newDispatcherFixture(t, "web", `{}`)
+	fx.d.publishers.Register("ch-1", &recordingGroupPublisher{})
+
+	if err := fx.d.ProcessOutbox(context.Background(), fx.outbox); err != nil {
+		t.Fatalf("process outbox: %v", err)
+	}
+	if got := dispatchAgentsByMessage(t, fx.db, fx.message.ID); len(got) != 1 || got[0] != "agent-1" {
+		t.Fatalf("dispatch agents = %v, want [agent-1]", got)
+	}
+}
+
+func TestGroupDispatcherWebNoMentionMultiMemberStaysSilent(t *testing.T) {
+	fx := newDispatcherFixture(t, "web", `{}`)
+	addSecondMember(t, fx)
+
+	if err := fx.d.ProcessOutbox(context.Background(), fx.outbox); err != nil {
+		t.Fatalf("process outbox: %v", err)
+	}
+	count, err := fx.q.CountGroupDispatchByMessage(context.Background(), fx.message.ID)
+	if err != nil {
+		t.Fatalf("count dispatch: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("dispatch rows = %d, want 0", count)
+	}
+}
+
 func TestGroupDispatcherZeroRespondersCompletesOutbox(t *testing.T) {
 	fx := newDispatcherFixture(t, "telegram", `{}`)
 

--- a/internal/channel/publisher.go
+++ b/internal/channel/publisher.go
@@ -9,7 +9,10 @@ import (
 
 // GroupPublisher renders and sends an agent response stream to one concrete
 // group egress. It must not resolve sessions, call agents, or write event-log
-// rows; the dispatcher owns those cross-platform concerns.
+// rows; the dispatcher owns those cross-platform concerns. Returning nil means
+// the platform API confirmed delivery for platform publishers, or the stream was
+// fully consumed for Web publishers (client write errors do not make Web publish
+// fail; the event log is the durable delivery channel).
 type GroupPublisher interface {
 	Publish(ctx context.Context, req GroupPublishRequest) error
 }

--- a/internal/db/migrations/20260612043053_add_group_dispatch_result_message_id.sql
+++ b/internal/db/migrations/20260612043053_add_group_dispatch_result_message_id.sql
@@ -1,0 +1,2 @@
+-- Add column "result_message_id" to table: "ctx_group_dispatch"
+ALTER TABLE `ctx_group_dispatch` ADD COLUMN `result_message_id` text NOT NULL DEFAULT '';

--- a/internal/db/migrations/atlas.sum
+++ b/internal/db/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:BKwUcbeEcaA/phcRanmlznUnOsa634WbqiS1X+pXEI8=
+h1:LSQGT0UUxBQ2QsSm0kpwbW5hS9J7iLK0Iq+p/DLnhXI=
 20260531120105_initial.sql h1:yFv08NKwCabgVkvWoSNzba6WMXjbXrI9xHctaJBir/8=
 20260601060943_add_config_to_plugin_override.sql h1:q2MIJRzEYGDQyjnLeFUrQ0zbnvdgxBh/MRANwRmPFn4=
 20260602031701_add-channel-name.sql h1:1ZGYJvwMOOShxLGIN9SJihmcfQtFRpTPXHhOWDv29fc=
@@ -19,3 +19,4 @@ h1:BKwUcbeEcaA/phcRanmlznUnOsa634WbqiS1X+pXEI8=
 20260610014557_add_agent_thinking_levels.sql h1:zsr59uHERtdAhgsGA/NomtUKAaWyxHrajHYsU8/U8h4=
 20260611023502_sched_job_run_output.sql h1:zNoa428mqc9RwW6uevQCKYYE6Ury2HfWcH62BIlIEq4=
 20260611161743_add_ctx_item_role_and_summary_parent_index.sql h1:O9zmwanPi/44mfHncJsypyeZKKzBMKtUcyh+6JNMVxU=
+20260612043053_add_group_dispatch_result_message_id.sql h1:5G6rlXvNYLAIW7UE/gkUAdWG7wD6mnZbNtDktaSA+oY=

--- a/internal/db/queries/ctx_group_dispatch.sql
+++ b/internal/db/queries/ctx_group_dispatch.sql
@@ -11,6 +11,11 @@ SELECT * FROM ctx_group_dispatch WHERE id = ?;
 SELECT CAST(COUNT(*) AS INTEGER) FROM ctx_group_dispatch
 WHERE group_message_id = ?;
 
+-- name: CountNonTerminalGroupDispatchByMessage :one
+SELECT CAST(COUNT(*) AS INTEGER) FROM ctx_group_dispatch
+WHERE group_message_id = ?
+  AND status IN ('pending', 'running');
+
 -- name: ListPendingGroupDispatchByMessage :many
 SELECT * FROM ctx_group_dispatch gd
 WHERE gd.group_message_id = sqlc.arg(group_message_id)
@@ -27,6 +32,18 @@ WHERE gd.group_message_id = sqlc.arg(group_message_id)
       AND (
         earlier.status = 'pending'
         OR (earlier.status = 'running' AND earlier.lease_until IS NOT NULL AND earlier.lease_until >= ?2)
+      )
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM ctx_group_outbox earlier_outbox
+    JOIN ctx_group_message earlier_msg ON earlier_msg.id = earlier_outbox.group_message_id
+    JOIN ctx_group_message current_msg ON current_msg.id = gd.group_message_id
+    WHERE earlier_outbox.group_id = gd.group_id
+      AND earlier_msg.seq < current_msg.seq
+      AND (
+        earlier_outbox.status = 'pending'
+        OR (earlier_outbox.status = 'running' AND earlier_outbox.lease_until IS NOT NULL AND earlier_outbox.lease_until >= ?2)
       )
   )
 ORDER BY gd.created_at ASC;
@@ -46,6 +63,18 @@ WHERE gd.status = 'pending'
       AND (
         earlier.status = 'pending'
         OR (earlier.status = 'running' AND earlier.lease_until IS NOT NULL AND earlier.lease_until >= ?1)
+      )
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM ctx_group_outbox earlier_outbox
+    JOIN ctx_group_message earlier_msg ON earlier_msg.id = earlier_outbox.group_message_id
+    JOIN ctx_group_message current_msg ON current_msg.id = gd.group_message_id
+    WHERE earlier_outbox.group_id = gd.group_id
+      AND earlier_msg.seq < current_msg.seq
+      AND (
+        earlier_outbox.status = 'pending'
+        OR (earlier_outbox.status = 'running' AND earlier_outbox.lease_until IS NOT NULL AND earlier_outbox.lease_until >= ?1)
       )
   )
 ORDER BY gd.created_at ASC

--- a/internal/db/queries/ctx_group_dispatch.sql
+++ b/internal/db/queries/ctx_group_dispatch.sql
@@ -12,24 +12,49 @@ SELECT CAST(COUNT(*) AS INTEGER) FROM ctx_group_dispatch
 WHERE group_message_id = ?;
 
 -- name: ListPendingGroupDispatchByMessage :many
-SELECT * FROM ctx_group_dispatch
-WHERE group_message_id = sqlc.arg(group_message_id)
-  AND status = 'pending'
-  AND (next_attempt_at IS NULL OR next_attempt_at <= sqlc.arg(now))
-ORDER BY created_at ASC;
+SELECT * FROM ctx_group_dispatch gd
+WHERE gd.group_message_id = sqlc.arg(group_message_id)
+  AND gd.status = 'pending'
+  AND (gd.next_attempt_at IS NULL OR gd.next_attempt_at <= sqlc.arg('now'))
+  AND NOT EXISTS (
+    SELECT 1
+    FROM ctx_group_dispatch earlier
+    JOIN ctx_group_message earlier_msg ON earlier_msg.id = earlier.group_message_id
+    JOIN ctx_group_message current_msg ON current_msg.id = gd.group_message_id
+    WHERE earlier.group_id = gd.group_id
+      AND earlier.agent_id = gd.agent_id
+      AND earlier_msg.seq < current_msg.seq
+      AND (
+        earlier.status = 'pending'
+        OR (earlier.status = 'running' AND earlier.lease_until IS NOT NULL AND earlier.lease_until >= ?2)
+      )
+  )
+ORDER BY gd.created_at ASC;
 
 -- name: ListPendingGroupDispatch :many
-SELECT * FROM ctx_group_dispatch
-WHERE status = 'pending'
-  AND (next_attempt_at IS NULL OR next_attempt_at <= sqlc.arg(now))
-ORDER BY created_at ASC
+SELECT * FROM ctx_group_dispatch gd
+WHERE gd.status = 'pending'
+  AND (gd.next_attempt_at IS NULL OR gd.next_attempt_at <= sqlc.arg('now'))
+  AND NOT EXISTS (
+    SELECT 1
+    FROM ctx_group_dispatch earlier
+    JOIN ctx_group_message earlier_msg ON earlier_msg.id = earlier.group_message_id
+    JOIN ctx_group_message current_msg ON current_msg.id = gd.group_message_id
+    WHERE earlier.group_id = gd.group_id
+      AND earlier.agent_id = gd.agent_id
+      AND earlier_msg.seq < current_msg.seq
+      AND (
+        earlier.status = 'pending'
+        OR (earlier.status = 'running' AND earlier.lease_until IS NOT NULL AND earlier.lease_until >= ?1)
+      )
+  )
+ORDER BY gd.created_at ASC
 LIMIT sqlc.arg(limit_count);
-
 -- name: ListExpiredRunningGroupDispatch :many
 SELECT * FROM ctx_group_dispatch
 WHERE status = 'running'
   AND lease_until IS NOT NULL
-  AND lease_until <= sqlc.arg(now)
+  AND lease_until <= sqlc.arg('now')
 ORDER BY lease_until ASC
 LIMIT sqlc.arg(limit_count);
 
@@ -43,7 +68,7 @@ SET status = 'running',
     updated_at = datetime('now')
 WHERE id = sqlc.arg(id)
   AND status = 'pending'
-  AND (next_attempt_at IS NULL OR next_attempt_at <= sqlc.arg(now))
+  AND (next_attempt_at IS NULL OR next_attempt_at <= sqlc.arg('now'))
 RETURNING *;
 
 -- name: ClaimExpiredGroupDispatch :one
@@ -57,7 +82,7 @@ SET status = 'running',
 WHERE id = sqlc.arg(id)
   AND status = 'running'
   AND lease_until IS NOT NULL
-  AND lease_until <= sqlc.arg(now)
+  AND lease_until <= sqlc.arg('now')
 RETURNING *;
 
 -- name: ExtendRunningGroupDispatchLease :execrows

--- a/internal/db/queries/ctx_group_dispatch.sql
+++ b/internal/db/queries/ctx_group_dispatch.sql
@@ -93,6 +93,14 @@ WHERE id = sqlc.arg(id)
   AND status = 'running'
   AND attempt_count = sqlc.arg(attempt_count);
 
+-- name: SetGroupDispatchResultMessage :execrows
+UPDATE ctx_group_dispatch
+SET result_message_id = sqlc.arg(result_message_id),
+    updated_at = datetime('now')
+WHERE id = sqlc.arg(id)
+  AND status = 'running'
+  AND attempt_count = sqlc.arg(attempt_count);
+
 -- name: MarkGroupDispatchCompleted :execrows
 UPDATE ctx_group_dispatch
 SET status = 'completed',

--- a/internal/db/queries/ctx_message.sql
+++ b/internal/db/queries/ctx_message.sql
@@ -98,3 +98,10 @@ LIMIT sqlc.arg('limit');
 SELECT * FROM ctx_message
 WHERE conversation_id = ? AND created_at > ?
 ORDER BY seq ASC;
+
+-- name: ListExistingUserMessageContent :many
+SELECT content FROM ctx_message
+WHERE conversation_id = sqlc.arg('conversation_id')
+  AND role = 'user'
+  AND content IN (sqlc.slice('contents'))
+ORDER BY seq ASC;

--- a/internal/db/schemas/tables/ctx_group_dispatch.sql
+++ b/internal/db/schemas/tables/ctx_group_dispatch.sql
@@ -12,6 +12,7 @@ CREATE TABLE ctx_group_dispatch (
     lease_until      TEXT,
     next_attempt_at  TEXT,
     last_error       TEXT NOT NULL DEFAULT '',
+    result_message_id TEXT NOT NULL DEFAULT '',
     created_at       TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at       TEXT NOT NULL DEFAULT (datetime('now')),
     UNIQUE (group_message_id, agent_id)

--- a/internal/eventlog/eventlog.go
+++ b/internal/eventlog/eventlog.go
@@ -179,14 +179,8 @@ func (s *Store) AppendGroupMessage(ctx context.Context, msg Message, opts ...App
 // triple-based group resolution). Used for agent response writeback where the
 // groupID is already known from the dispatch flow.
 func (s *Store) AppendToGroup(ctx context.Context, groupID string, msg GroupMessage) (AppendResult, error) {
-	if groupID == "" {
-		return AppendResult{}, errors.New("eventlog: group_id is required")
-	}
-	if msg.ActorType != ActorHuman && msg.ActorType != ActorAgent {
-		return AppendResult{}, fmt.Errorf("eventlog: invalid actor_type %q", msg.ActorType)
-	}
-	if msg.ActorID == "" {
-		return AppendResult{}, errors.New("eventlog: actor_id is required")
+	if err := validateGroupAppend(groupID, msg); err != nil {
+		return AppendResult{}, err
 	}
 
 	conn, err := s.db.Conn(ctx)
@@ -206,11 +200,29 @@ func (s *Store) AppendToGroup(ctx context.Context, groupID string, msg GroupMess
 	}()
 
 	q := sqlc.New(conn)
+	result, err := AppendToGroupWithQueries(ctx, q, groupID, msg)
+	if err != nil {
+		return AppendResult{}, err
+	}
+
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return AppendResult{}, fmt.Errorf("eventlog: commit: %w", err)
+	}
+	committed = true
+	return result, nil
+}
+
+// AppendToGroupWithQueries appends to a pre-resolved group using the caller's
+// query handle. The caller owns the surrounding transaction; this helper lets
+// dispatch result markers commit atomically with agent response writeback.
+func AppendToGroupWithQueries(ctx context.Context, q *sqlc.Queries, groupID string, msg GroupMessage) (AppendResult, error) {
+	if err := validateGroupAppend(groupID, msg); err != nil {
+		return AppendResult{}, err
+	}
 	seq, err := q.BumpGroupSeq(ctx, groupID)
 	if err != nil {
 		return AppendResult{}, fmt.Errorf("eventlog: bump seq: %w", err)
 	}
-
 	row, err := q.CreateGroupMessage(ctx, sqlc.CreateGroupMessageParams{
 		ID:             uuid.NewString(),
 		GroupID:        groupID,
@@ -224,12 +236,20 @@ func (s *Store) AppendToGroup(ctx context.Context, groupID string, msg GroupMess
 	if err != nil {
 		return AppendResult{}, fmt.Errorf("eventlog: create message: %w", err)
 	}
-
-	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
-		return AppendResult{}, fmt.Errorf("eventlog: commit: %w", err)
-	}
-	committed = true
 	return AppendResult{GroupID: groupID, Seq: seq, Inserted: true, Message: row}, nil
+}
+
+func validateGroupAppend(groupID string, msg GroupMessage) error {
+	if groupID == "" {
+		return errors.New("eventlog: group_id is required")
+	}
+	if msg.ActorType != ActorHuman && msg.ActorType != ActorAgent {
+		return fmt.Errorf("eventlog: invalid actor_type %q", msg.ActorType)
+	}
+	if msg.ActorID == "" {
+		return errors.New("eventlog: actor_id is required")
+	}
+	return nil
 }
 
 // GroupMessage is a simplified message for direct group append (pre-resolved groupID).

--- a/internal/memory/lcm/group_assembler.go
+++ b/internal/memory/lcm/group_assembler.go
@@ -124,16 +124,19 @@ func (p *Provider) filterAlreadyPersistedInjected(ctx context.Context, convID st
 	if len(contents) == 0 {
 		return injected, nil
 	}
-	existingRows, err := p.q.ListExistingUserMessageContent(ctx, sqlc.ListExistingUserMessageContentParams{
-		ConversationID: convID,
-		Contents:       contents,
-	})
-	if err != nil {
-		return nil, err
-	}
-	seen := make(map[string]struct{}, len(existingRows))
-	for _, content := range existingRows {
-		seen[content] = struct{}{}
+	seen := make(map[string]struct{})
+	for start := 0; start < len(contents); start += 500 {
+		end := min(start+500, len(contents))
+		existingRows, err := p.q.ListExistingUserMessageContent(ctx, sqlc.ListExistingUserMessageContentParams{
+			ConversationID: convID,
+			Contents:       contents[start:end],
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, content := range existingRows {
+			seen[content] = struct{}{}
+		}
 	}
 	out := injected[:0]
 	for _, msg := range injected {

--- a/internal/memory/lcm/group_assembler.go
+++ b/internal/memory/lcm/group_assembler.go
@@ -64,7 +64,10 @@ func (p *Provider) assembleGroup(ctx context.Context, session memory.Session, bu
 	// 3.5. Persist injected messages before the live user turn so future
 	// assemblies preserve event-log chronology. Cursor movement is intentionally
 	// deferred to CommitGroupCursor after the chat succeeds.
-	injected = filterAlreadyPersistedInjected(injected, agentHistory)
+	injected, err = p.filterAlreadyPersistedInjected(ctx, convID, injected)
+	if err != nil {
+		return nil, fmt.Errorf("filter persisted injected messages: %w", err)
+	}
 	if len(injected) > 0 {
 		if err := p.Append(ctx, session, injected...); err != nil {
 			return nil, fmt.Errorf("persist between-turn messages: %w", err)
@@ -106,17 +109,31 @@ func (p *Provider) CommitGroupCursor(ctx context.Context, session memory.Session
 	return nil
 }
 
-func filterAlreadyPersistedInjected(injected, history []ai.Message) []ai.Message {
-	if len(injected) == 0 || len(history) == 0 {
-		return injected
+func (p *Provider) filterAlreadyPersistedInjected(ctx context.Context, convID string, injected []ai.Message) ([]ai.Message, error) {
+	if len(injected) == 0 {
+		return injected, nil
 	}
-	seen := make(map[string]struct{}, len(history))
-	for _, msg := range history {
+	contents := make([]string, 0, len(injected))
+	for _, msg := range injected {
 		um, ok := msg.(ai.UserMessage)
 		if !ok {
 			continue
 		}
-		seen[flattenUserContent(um)] = struct{}{}
+		contents = append(contents, flattenUserContent(um))
+	}
+	if len(contents) == 0 {
+		return injected, nil
+	}
+	existingRows, err := p.q.ListExistingUserMessageContent(ctx, sqlc.ListExistingUserMessageContentParams{
+		ConversationID: convID,
+		Contents:       contents,
+	})
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]struct{}, len(existingRows))
+	for _, content := range existingRows {
+		seen[content] = struct{}{}
 	}
 	out := injected[:0]
 	for _, msg := range injected {
@@ -130,7 +147,7 @@ func filterAlreadyPersistedInjected(injected, history []ai.Message) []ai.Message
 		}
 		out = append(out, msg)
 	}
-	return out
+	return out, nil
 }
 
 func flattenUserContent(msg ai.UserMessage) string {
@@ -176,11 +193,7 @@ func groupRowsToMessages(rows []sqlc.CtxGroupMessage, selfAgentID string) []ai.M
 		if row.ActorType == string(eventlog.ActorAgent) {
 			label = "agent:" + row.ActorID
 		}
-		msgs = append(msgs, ai.UserMessage{
-			Content: []ai.ContentBlock{ai.TextContent{
-				Text: fmt.Sprintf("[seq:%d %s]: %s", row.Seq, label, row.Content),
-			}},
-		})
+		msgs = append(msgs, ai.UserMessage{Content: fmt.Sprintf("[seq:%d %s]: %s", row.Seq, label, row.Content)})
 	}
 	return msgs
 }

--- a/internal/memory/lcm/group_assembler_test.go
+++ b/internal/memory/lcm/group_assembler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/CherryHQ/stella/internal/eventlog"
 	"github.com/CherryHQ/stella/internal/memory"
 	"github.com/CherryHQ/stella/pkg/ai"
+	"github.com/CherryHQ/stella/pkg/db/sqlc"
 )
 
 func openTestDB(t *testing.T) *sql.DB {
@@ -265,6 +266,45 @@ func TestGroupAssemble_DedupsPersistedInjectedOutsideBudget(t *testing.T) {
 	}
 	if count != 1 {
 		t.Fatalf("persisted injected count = %d, want 1", count)
+	}
+}
+
+func TestFilterAlreadyPersistedInjectedBatchesLargeCandidateSet(t *testing.T) {
+	db := openTestDB(t)
+	p, err := New(db, nil, map[string]any{})
+	if err != nil {
+		t.Fatalf("new provider: %v", err)
+	}
+	q := sqlc.New(db)
+	ctx := context.Background()
+	if _, err := q.CreateConversation(ctx, sqlc.CreateConversationParams{ID: "conv-large", SessionID: "session-large", Channel: "test", Kind: "chat", LastActive: "2026-06-12T00:00:00Z"}); err != nil {
+		t.Fatalf("create conversation: %v", err)
+	}
+	for i, content := range []string{"candidate-0000", "candidate-0500", "candidate-1001"} {
+		if _, err := q.CreateMessage(ctx, sqlc.CreateMessageParams{ID: "msg-" + content, ConversationID: "conv-large", Seq: int64(i + 1), Role: "user", EventType: "text", Content: content}); err != nil {
+			t.Fatalf("create message %s: %v", content, err)
+		}
+	}
+	injected := make([]ai.Message, 0, 1005)
+	for i := range 1005 {
+		injected = append(injected, ai.UserMessage{Content: fmt.Sprintf("candidate-%04d", i)})
+	}
+
+	filtered, err := p.filterAlreadyPersistedInjected(ctx, "conv-large", injected)
+	if err != nil {
+		t.Fatalf("filter injected: %v", err)
+	}
+	if len(filtered) != 1002 {
+		t.Fatalf("filtered len = %d, want 1002", len(filtered))
+	}
+	for _, msg := range filtered {
+		content := msg.(ai.UserMessage).Content.(string)
+		if content == "candidate-0000" || content == "candidate-0500" || content == "candidate-1001" {
+			t.Fatalf("persisted content %q was not filtered", content)
+		}
+	}
+	if got := filtered[0].(ai.UserMessage).Content.(string); got != "candidate-0001" {
+		t.Fatalf("first filtered content = %q, want order preserved", got)
 	}
 }
 

--- a/internal/memory/lcm/group_assembler_test.go
+++ b/internal/memory/lcm/group_assembler_test.go
@@ -229,6 +229,45 @@ func TestGroupAssemble_OtherAgentInjected(t *testing.T) {
 	}
 }
 
+func TestGroupAssemble_DedupsPersistedInjectedOutsideBudget(t *testing.T) {
+	db := openTestDB(t)
+	el := eventlog.NewStore(db)
+	ctx := context.Background()
+	res1, err := el.AppendGroupMessage(ctx, eventlog.Message{Platform: "test", PlatformGroupID: "g-dedup", ActorType: eventlog.ActorHuman, ActorID: "user1", Content: "already persisted", PlatformMessageID: "d1"})
+	if err != nil {
+		t.Fatalf("seed seq1: %v", err)
+	}
+	gid := res1.GroupID
+	res2, err := el.AppendGroupMessage(ctx, eventlog.Message{Platform: "test", PlatformGroupID: "g-dedup", ActorType: eventlog.ActorHuman, ActorID: "user2", Content: "trigger", PlatformMessageID: "d2"})
+	if err != nil {
+		t.Fatalf("seed trigger: %v", err)
+	}
+	p, err := New(db, nil, nil)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	sess := groupSess("agent-a", gid)
+	assembleCtx := groupCtx(res2.Seq)
+	if _, err := p.Assemble(assembleCtx, sess, 100_000, 20); err != nil {
+		t.Fatalf("first assemble: %v", err)
+	}
+	for i := range 20 {
+		if err := p.Append(ctx, sess, ai.UserMessage{Content: fmt.Sprintf("large retry filler %02d %s", i, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")}); err != nil {
+			t.Fatalf("append filler %d: %v", i, err)
+		}
+	}
+	if _, err := p.Assemble(assembleCtx, sess, 20, 20); err != nil {
+		t.Fatalf("retry assemble: %v", err)
+	}
+	var count int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM ctx_message WHERE role = 'user' AND content = ?`, "[seq:1 user1]: already persisted").Scan(&count); err != nil {
+		t.Fatalf("count persisted injected: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("persisted injected count = %d, want 1", count)
+	}
+}
+
 func TestGroupAssemble_TokenBudget(t *testing.T) {
 	db := openTestDB(t)
 	el := eventlog.NewStore(db)

--- a/internal/server/group_publisher.go
+++ b/internal/server/group_publisher.go
@@ -14,8 +14,9 @@ import (
 )
 
 type webGroupPublisher struct {
-	w       http.ResponseWriter
-	flusher http.Flusher
+	w          http.ResponseWriter
+	flusher    http.Flusher
+	clientGone bool
 }
 
 func streamEmptyGroupReply(w http.ResponseWriter, flusher http.Flusher) {
@@ -32,8 +33,14 @@ func streamEmptyGroupReply(w http.ResponseWriter, flusher http.Flusher) {
 }
 
 func (p *webGroupPublisher) writeSSE(v any) {
+	if p.clientGone {
+		return
+	}
 	data, _ := json.Marshal(v)
-	_, _ = fmt.Fprintf(p.w, "data: %s\n\n", data)
+	if _, err := fmt.Fprintf(p.w, "data: %s\n\n", data); err != nil {
+		p.clientGone = true
+		return
+	}
 	p.flusher.Flush()
 }
 
@@ -73,17 +80,17 @@ func (p *webGroupPublisher) Publish(ctx context.Context, req channel.GroupPublis
 		closeReasoning()
 	}
 
-	var firstErr error
+	var streamErr error
 	for {
 		select {
 		case evt, ok := <-req.Stream.Events:
 			if !ok {
 				closeOpenParts()
-				return firstErr
+				return streamErr
 			}
 			if evt.Err != nil {
-				if firstErr == nil {
-					firstErr = evt.Err
+				if streamErr == nil {
+					streamErr = evt.Err
 				}
 				closeOpenParts()
 				p.writeSSE(map[string]string{"type": "error", "errorText": evt.Err.Error()})

--- a/internal/server/group_publisher_test.go
+++ b/internal/server/group_publisher_test.go
@@ -1,0 +1,60 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/CherryHQ/stella/internal/channel"
+	pkgchannel "github.com/CherryHQ/stella/pkg/channel"
+)
+
+type failingStreamWriter struct {
+	headers http.Header
+	writes  int
+}
+
+func (w *failingStreamWriter) Header() http.Header {
+	if w.headers == nil {
+		w.headers = make(http.Header)
+	}
+	return w.headers
+}
+
+func (w *failingStreamWriter) Write([]byte) (int, error) {
+	w.writes++
+	return 0, errors.New("client gone")
+}
+
+func (w *failingStreamWriter) WriteHeader(int) {}
+func (w *failingStreamWriter) Flush()          {}
+
+func TestWebGroupPublisherWriteFailureDrainsStream(t *testing.T) {
+	events := make(chan pkgchannel.Event)
+	drained := make(chan struct{})
+	go func() {
+		defer close(drained)
+		events <- pkgchannel.Event{Text: "one"}
+		events <- pkgchannel.Event{Text: "two"}
+		close(events)
+	}()
+
+	w := &failingStreamWriter{}
+	publisher := &webGroupPublisher{w: w, flusher: w}
+	err := publisher.Publish(context.Background(), channel.GroupPublishRequest{
+		AgentID:   "agent-1",
+		AgentName: "Agent One",
+		Stream:    &pkgchannel.ChatStream{Events: events, SessionID: "session-1"},
+	})
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	<-drained
+	if !publisher.clientGone {
+		t.Fatal("clientGone = false, want true")
+	}
+	if w.writes != 1 {
+		t.Fatalf("writes = %d, want exactly first failed write", w.writes)
+	}
+}

--- a/internal/server/groups.go
+++ b/internal/server/groups.go
@@ -518,7 +518,9 @@ func (s *Server) SendGroupMessage(w http.ResponseWriter, r *http.Request, groupI
 
 	publisher := &webGroupPublisher{w: w, flusher: flusher}
 	publisher.writeSSE(map[string]string{"type": "start", "messageId": uuid.NewString()})
-	if err := s.groupDispatcher.DispatchSync(ctx, outbox, publisher); err != nil {
+	dispatchCtx, cancelDispatch := context.WithTimeout(s.runtimeCtx, groupOutboxLeaseDuration)
+	defer cancelDispatch()
+	if err := s.groupDispatcher.DispatchSync(dispatchCtx, outbox, publisher); err != nil {
 		publisher.writeSSE(map[string]string{"type": "error", "errorText": err.Error()})
 	}
 	publisher.writeSSE(map[string]string{"type": "finish"})

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -75,12 +75,18 @@ type Server struct {
 	arbiter *channel.Arbiter
 	// groupDispatcher runs the shared durable group dispatch flow for Web sends.
 	groupDispatcher *channel.GroupDispatcher
+	// runtimeCtx is canceled by the process/service lifecycle; request handlers
+	// derive long-running work from it instead of client connections.
+	runtimeCtx context.Context
 }
 
 // New creates an admin server with all API routes mounted.
 // The linkCodes store is shared with channel bots so codes generated in the
 // Web UI can be consumed by channel handlers.
 func New(ctx context.Context, store config.Store, authStore auth.AuthStore, engine *auth.PolicyEngine, mem memory.Provider, db *sql.DB, linkCodes *auth.LinkCodeStore, poolManager *agent.PoolManager, pluginHost *pluginhost.Host) *Server {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if pluginHost == nil {
 		panic("admin: plugin host is required")
 	}
@@ -107,6 +113,7 @@ func New(ctx context.Context, store config.Store, authStore auth.AuthStore, engi
 		credSvc:     credSvc,
 		recally:     newRecallyHandlers(recally.NewStore(db), recally.NewFileManager(config.StellaHome()), log),
 		startedAt:   time.Now(),
+		runtimeCtx:  ctx,
 	}
 
 	s.registerRoutes()

--- a/pkg/db/sqlc/ctx_group_dispatch.sql.go
+++ b/pkg/db/sqlc/ctx_group_dispatch.sql.go
@@ -237,10 +237,23 @@ func (q *Queries) ListExpiredRunningGroupDispatch(ctx context.Context, arg ListE
 }
 
 const listPendingGroupDispatch = `-- name: ListPendingGroupDispatch :many
-SELECT id, group_message_id, group_id, agent_id, reply_channel_id, status, attempt_count, lease_until, next_attempt_at, last_error, created_at, updated_at FROM ctx_group_dispatch
-WHERE status = 'pending'
-  AND (next_attempt_at IS NULL OR next_attempt_at <= ?1)
-ORDER BY created_at ASC
+SELECT id, group_message_id, group_id, agent_id, reply_channel_id, status, attempt_count, lease_until, next_attempt_at, last_error, created_at, updated_at FROM ctx_group_dispatch gd
+WHERE gd.status = 'pending'
+  AND (gd.next_attempt_at IS NULL OR gd.next_attempt_at <= ?1)
+  AND NOT EXISTS (
+    SELECT 1
+    FROM ctx_group_dispatch earlier
+    JOIN ctx_group_message earlier_msg ON earlier_msg.id = earlier.group_message_id
+    JOIN ctx_group_message current_msg ON current_msg.id = gd.group_message_id
+    WHERE earlier.group_id = gd.group_id
+      AND earlier.agent_id = gd.agent_id
+      AND earlier_msg.seq < current_msg.seq
+      AND (
+        earlier.status = 'pending'
+        OR (earlier.status = 'running' AND earlier.lease_until IS NOT NULL AND earlier.lease_until >= ?1)
+      )
+  )
+ORDER BY gd.created_at ASC
 LIMIT ?2
 `
 
@@ -286,11 +299,24 @@ func (q *Queries) ListPendingGroupDispatch(ctx context.Context, arg ListPendingG
 }
 
 const listPendingGroupDispatchByMessage = `-- name: ListPendingGroupDispatchByMessage :many
-SELECT id, group_message_id, group_id, agent_id, reply_channel_id, status, attempt_count, lease_until, next_attempt_at, last_error, created_at, updated_at FROM ctx_group_dispatch
-WHERE group_message_id = ?1
-  AND status = 'pending'
-  AND (next_attempt_at IS NULL OR next_attempt_at <= ?2)
-ORDER BY created_at ASC
+SELECT id, group_message_id, group_id, agent_id, reply_channel_id, status, attempt_count, lease_until, next_attempt_at, last_error, created_at, updated_at FROM ctx_group_dispatch gd
+WHERE gd.group_message_id = ?1
+  AND gd.status = 'pending'
+  AND (gd.next_attempt_at IS NULL OR gd.next_attempt_at <= ?2)
+  AND NOT EXISTS (
+    SELECT 1
+    FROM ctx_group_dispatch earlier
+    JOIN ctx_group_message earlier_msg ON earlier_msg.id = earlier.group_message_id
+    JOIN ctx_group_message current_msg ON current_msg.id = gd.group_message_id
+    WHERE earlier.group_id = gd.group_id
+      AND earlier.agent_id = gd.agent_id
+      AND earlier_msg.seq < current_msg.seq
+      AND (
+        earlier.status = 'pending'
+        OR (earlier.status = 'running' AND earlier.lease_until IS NOT NULL AND earlier.lease_until >= ?2)
+      )
+  )
+ORDER BY gd.created_at ASC
 `
 
 type ListPendingGroupDispatchByMessageParams struct {

--- a/pkg/db/sqlc/ctx_group_dispatch.sql.go
+++ b/pkg/db/sqlc/ctx_group_dispatch.sql.go
@@ -22,7 +22,7 @@ WHERE id = ?2
   AND status = 'running'
   AND lease_until IS NOT NULL
   AND lease_until <= ?3
-RETURNING id, group_message_id, group_id, agent_id, reply_channel_id, status, attempt_count, lease_until, next_attempt_at, last_error, created_at, updated_at
+RETURNING id, group_message_id, group_id, agent_id, reply_channel_id, status, attempt_count, lease_until, next_attempt_at, last_error, result_message_id, created_at, updated_at
 `
 
 type ClaimExpiredGroupDispatchParams struct {
@@ -45,6 +45,7 @@ func (q *Queries) ClaimExpiredGroupDispatch(ctx context.Context, arg ClaimExpire
 		&i.LeaseUntil,
 		&i.NextAttemptAt,
 		&i.LastError,
+		&i.ResultMessageID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -62,7 +63,7 @@ SET status = 'running',
 WHERE id = ?2
   AND status = 'pending'
   AND (next_attempt_at IS NULL OR next_attempt_at <= ?3)
-RETURNING id, group_message_id, group_id, agent_id, reply_channel_id, status, attempt_count, lease_until, next_attempt_at, last_error, created_at, updated_at
+RETURNING id, group_message_id, group_id, agent_id, reply_channel_id, status, attempt_count, lease_until, next_attempt_at, last_error, result_message_id, created_at, updated_at
 `
 
 type ClaimPendingGroupDispatchParams struct {
@@ -85,6 +86,7 @@ func (q *Queries) ClaimPendingGroupDispatch(ctx context.Context, arg ClaimPendin
 		&i.LeaseUntil,
 		&i.NextAttemptAt,
 		&i.LastError,
+		&i.ResultMessageID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -163,7 +165,7 @@ func (q *Queries) ExtendRunningGroupDispatchLease(ctx context.Context, arg Exten
 }
 
 const getGroupDispatch = `-- name: GetGroupDispatch :one
-SELECT id, group_message_id, group_id, agent_id, reply_channel_id, status, attempt_count, lease_until, next_attempt_at, last_error, created_at, updated_at FROM ctx_group_dispatch WHERE id = ?
+SELECT id, group_message_id, group_id, agent_id, reply_channel_id, status, attempt_count, lease_until, next_attempt_at, last_error, result_message_id, created_at, updated_at FROM ctx_group_dispatch WHERE id = ?
 `
 
 func (q *Queries) GetGroupDispatch(ctx context.Context, id string) (CtxGroupDispatch, error) {
@@ -180,6 +182,7 @@ func (q *Queries) GetGroupDispatch(ctx context.Context, id string) (CtxGroupDisp
 		&i.LeaseUntil,
 		&i.NextAttemptAt,
 		&i.LastError,
+		&i.ResultMessageID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -187,7 +190,7 @@ func (q *Queries) GetGroupDispatch(ctx context.Context, id string) (CtxGroupDisp
 }
 
 const listExpiredRunningGroupDispatch = `-- name: ListExpiredRunningGroupDispatch :many
-SELECT id, group_message_id, group_id, agent_id, reply_channel_id, status, attempt_count, lease_until, next_attempt_at, last_error, created_at, updated_at FROM ctx_group_dispatch
+SELECT id, group_message_id, group_id, agent_id, reply_channel_id, status, attempt_count, lease_until, next_attempt_at, last_error, result_message_id, created_at, updated_at FROM ctx_group_dispatch
 WHERE status = 'running'
   AND lease_until IS NOT NULL
   AND lease_until <= ?1
@@ -220,6 +223,7 @@ func (q *Queries) ListExpiredRunningGroupDispatch(ctx context.Context, arg ListE
 			&i.LeaseUntil,
 			&i.NextAttemptAt,
 			&i.LastError,
+			&i.ResultMessageID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {
@@ -237,7 +241,7 @@ func (q *Queries) ListExpiredRunningGroupDispatch(ctx context.Context, arg ListE
 }
 
 const listPendingGroupDispatch = `-- name: ListPendingGroupDispatch :many
-SELECT id, group_message_id, group_id, agent_id, reply_channel_id, status, attempt_count, lease_until, next_attempt_at, last_error, created_at, updated_at FROM ctx_group_dispatch gd
+SELECT id, group_message_id, group_id, agent_id, reply_channel_id, status, attempt_count, lease_until, next_attempt_at, last_error, result_message_id, created_at, updated_at FROM ctx_group_dispatch gd
 WHERE gd.status = 'pending'
   AND (gd.next_attempt_at IS NULL OR gd.next_attempt_at <= ?1)
   AND NOT EXISTS (
@@ -282,6 +286,7 @@ func (q *Queries) ListPendingGroupDispatch(ctx context.Context, arg ListPendingG
 			&i.LeaseUntil,
 			&i.NextAttemptAt,
 			&i.LastError,
+			&i.ResultMessageID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {
@@ -299,7 +304,7 @@ func (q *Queries) ListPendingGroupDispatch(ctx context.Context, arg ListPendingG
 }
 
 const listPendingGroupDispatchByMessage = `-- name: ListPendingGroupDispatchByMessage :many
-SELECT id, group_message_id, group_id, agent_id, reply_channel_id, status, attempt_count, lease_until, next_attempt_at, last_error, created_at, updated_at FROM ctx_group_dispatch gd
+SELECT id, group_message_id, group_id, agent_id, reply_channel_id, status, attempt_count, lease_until, next_attempt_at, last_error, result_message_id, created_at, updated_at FROM ctx_group_dispatch gd
 WHERE gd.group_message_id = ?1
   AND gd.status = 'pending'
   AND (gd.next_attempt_at IS NULL OR gd.next_attempt_at <= ?2)
@@ -344,6 +349,7 @@ func (q *Queries) ListPendingGroupDispatchByMessage(ctx context.Context, arg Lis
 			&i.LeaseUntil,
 			&i.NextAttemptAt,
 			&i.LastError,
+			&i.ResultMessageID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {
@@ -436,6 +442,29 @@ func (q *Queries) RequeueGroupDispatch(ctx context.Context, arg RequeueGroupDisp
 		arg.ID,
 		arg.AttemptCount,
 	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const setGroupDispatchResultMessage = `-- name: SetGroupDispatchResultMessage :execrows
+UPDATE ctx_group_dispatch
+SET result_message_id = ?1,
+    updated_at = datetime('now')
+WHERE id = ?2
+  AND status = 'running'
+  AND attempt_count = ?3
+`
+
+type SetGroupDispatchResultMessageParams struct {
+	ResultMessageID string `json:"result_message_id"`
+	ID              string `json:"id"`
+	AttemptCount    int64  `json:"attempt_count"`
+}
+
+func (q *Queries) SetGroupDispatchResultMessage(ctx context.Context, arg SetGroupDispatchResultMessageParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, setGroupDispatchResultMessage, arg.ResultMessageID, arg.ID, arg.AttemptCount)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/db/sqlc/ctx_group_dispatch.sql.go
+++ b/pkg/db/sqlc/ctx_group_dispatch.sql.go
@@ -105,6 +105,19 @@ func (q *Queries) CountGroupDispatchByMessage(ctx context.Context, groupMessageI
 	return column_1, err
 }
 
+const countNonTerminalGroupDispatchByMessage = `-- name: CountNonTerminalGroupDispatchByMessage :one
+SELECT CAST(COUNT(*) AS INTEGER) FROM ctx_group_dispatch
+WHERE group_message_id = ?
+  AND status IN ('pending', 'running')
+`
+
+func (q *Queries) CountNonTerminalGroupDispatchByMessage(ctx context.Context, groupMessageID string) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countNonTerminalGroupDispatchByMessage, groupMessageID)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
 const createGroupDispatch = `-- name: CreateGroupDispatch :exec
 INSERT OR IGNORE INTO ctx_group_dispatch (
   id, group_message_id, group_id, agent_id, reply_channel_id, status, attempt_count, lease_until, next_attempt_at, last_error
@@ -257,6 +270,18 @@ WHERE gd.status = 'pending'
         OR (earlier.status = 'running' AND earlier.lease_until IS NOT NULL AND earlier.lease_until >= ?1)
       )
   )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM ctx_group_outbox earlier_outbox
+    JOIN ctx_group_message earlier_msg ON earlier_msg.id = earlier_outbox.group_message_id
+    JOIN ctx_group_message current_msg ON current_msg.id = gd.group_message_id
+    WHERE earlier_outbox.group_id = gd.group_id
+      AND earlier_msg.seq < current_msg.seq
+      AND (
+        earlier_outbox.status = 'pending'
+        OR (earlier_outbox.status = 'running' AND earlier_outbox.lease_until IS NOT NULL AND earlier_outbox.lease_until >= ?1)
+      )
+  )
 ORDER BY gd.created_at ASC
 LIMIT ?2
 `
@@ -319,6 +344,18 @@ WHERE gd.group_message_id = ?1
       AND (
         earlier.status = 'pending'
         OR (earlier.status = 'running' AND earlier.lease_until IS NOT NULL AND earlier.lease_until >= ?2)
+      )
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM ctx_group_outbox earlier_outbox
+    JOIN ctx_group_message earlier_msg ON earlier_msg.id = earlier_outbox.group_message_id
+    JOIN ctx_group_message current_msg ON current_msg.id = gd.group_message_id
+    WHERE earlier_outbox.group_id = gd.group_id
+      AND earlier_msg.seq < current_msg.seq
+      AND (
+        earlier_outbox.status = 'pending'
+        OR (earlier_outbox.status = 'running' AND earlier_outbox.lease_until IS NOT NULL AND earlier_outbox.lease_until >= ?2)
       )
   )
 ORDER BY gd.created_at ASC

--- a/pkg/db/sqlc/ctx_message.sql.go
+++ b/pkg/db/sqlc/ctx_message.sql.go
@@ -359,6 +359,53 @@ func (q *Queries) GetMessagesSince(ctx context.Context, arg GetMessagesSincePara
 	return items, nil
 }
 
+const listExistingUserMessageContent = `-- name: ListExistingUserMessageContent :many
+SELECT content FROM ctx_message
+WHERE conversation_id = ?1
+  AND role = 'user'
+  AND content IN (/*SLICE:contents*/?)
+ORDER BY seq ASC
+`
+
+type ListExistingUserMessageContentParams struct {
+	ConversationID string   `json:"conversation_id"`
+	Contents       []string `json:"contents"`
+}
+
+func (q *Queries) ListExistingUserMessageContent(ctx context.Context, arg ListExistingUserMessageContentParams) ([]string, error) {
+	query := listExistingUserMessageContent
+	var queryParams []interface{}
+	queryParams = append(queryParams, arg.ConversationID)
+	if len(arg.Contents) > 0 {
+		for _, v := range arg.Contents {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:contents*/?", strings.Repeat(",?", len(arg.Contents))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:contents*/?", "NULL", 1)
+	}
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var content string
+		if err := rows.Scan(&content); err != nil {
+			return nil, err
+		}
+		items = append(items, content)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listMessagesByIDs = `-- name: ListMessagesByIDs :many
 SELECT id, conversation_id, seq, role, event_type, content, token_count, created_at FROM ctx_message WHERE conversation_id = ? AND id IN (/*SLICE:message_ids*/?) ORDER BY seq ASC
 `

--- a/pkg/db/sqlc/models.go
+++ b/pkg/db/sqlc/models.go
@@ -364,18 +364,19 @@ type CtxConversation struct {
 }
 
 type CtxGroupDispatch struct {
-	ID             string         `json:"id"`
-	GroupMessageID string         `json:"group_message_id"`
-	GroupID        string         `json:"group_id"`
-	AgentID        string         `json:"agent_id"`
-	ReplyChannelID string         `json:"reply_channel_id"`
-	Status         string         `json:"status"`
-	AttemptCount   int64          `json:"attempt_count"`
-	LeaseUntil     sql.NullString `json:"lease_until"`
-	NextAttemptAt  sql.NullString `json:"next_attempt_at"`
-	LastError      string         `json:"last_error"`
-	CreatedAt      string         `json:"created_at"`
-	UpdatedAt      string         `json:"updated_at"`
+	ID              string         `json:"id"`
+	GroupMessageID  string         `json:"group_message_id"`
+	GroupID         string         `json:"group_id"`
+	AgentID         string         `json:"agent_id"`
+	ReplyChannelID  string         `json:"reply_channel_id"`
+	Status          string         `json:"status"`
+	AttemptCount    int64          `json:"attempt_count"`
+	LeaseUntil      sql.NullString `json:"lease_until"`
+	NextAttemptAt   sql.NullString `json:"next_attempt_at"`
+	LastError       string         `json:"last_error"`
+	ResultMessageID string         `json:"result_message_id"`
+	CreatedAt       string         `json:"created_at"`
+	UpdatedAt       string         `json:"updated_at"`
 }
 
 type CtxGroupIngestCursor struct {

--- a/web/content/docs/development/group-chat-multi-agent.md
+++ b/web/content/docs/development/group-chat-multi-agent.md
@@ -119,7 +119,7 @@ type Mention struct {
 }
 ```
 
-Adapters fill `Raw` and `PlatformID` (they know the platform id). The **dispatcher resolves `AgentID`** by looking up membership. @-routing honors only `Mention.AgentID != ""` — no component guesses usernames or open_ids on its own.
+Adapters fill `Raw` and `PlatformID` (they know the platform id). Ingest resolves `AgentID` best-effort and stores the result in the outbox envelope; the dispatcher re-resolves any still-empty `AgentID` before routing. @-routing honors only `Mention.AgentID != ""` — no component guesses usernames or open_ids on its own.
 
 ## Memory: subject axis (D4)
 
@@ -176,13 +176,22 @@ group message (delivered by any bot)
       → for each selected agent: runtime → publisher (through reply_channel_id)
 ```
 
-- Any `@mention` signal stays on the L0 rule path. If a platform mention cannot be resolved to a Stella group member, the dispatcher does not treat it as a no-mention semantic request; it stays silent rather than replying to a message aimed elsewhere.
-- No-mention messages use L1 semantic routing when the semantic arbiter is configured. The classifier can return silence, one agent, or a capped multi-agent broadcast. Failures, timeouts, invalid JSON, or no eligible routing model collapse to silence.
+- Any `@mention` signal stays on the L0 rule path. Resolved mentions bypass `MaxRepliesPerTrigger`: if a user mentions multiple group agents, every mentioned member replies. If a platform mention cannot be resolved to a Stella group member, the dispatcher does not treat it as a no-mention semantic request; it stays silent rather than replying to a message aimed elsewhere. Web text mentions that do not resolve remain ordinary text and can use the no-mention path.
+- No-mention messages use L1 semantic routing when the semantic arbiter is configured. The classifier can return silence, one agent, or a capped multi-agent broadcast. Failures, timeouts, invalid JSON, or no eligible routing model collapse to silence. Without semantic routing, Web single-member groups route directly to that one member; Web multi-member groups stay silent and log a WARN to configure the semantic arbiter. Platform `always` still uses member fallback; platform `mention` stays silent.
 - The L1 routing model is selected by ownership, not by arbitrary member order. Web groups prefer the group owner's own agent, then system-scope agents. Platform groups allow system-scope agents only, so private agents' credentials are not used for shared routing decisions.
-- L1 sees only bounded public routing metadata: agent ID/name, `soul` summary, and bounded prior group context with `seq < currentSeq`. It never receives agent `system_prompt`, and delayed outbox retries never see future messages as prior context.
+- L1 sees only bounded public routing metadata: agent ID/name, member summary (the first 180 characters of `system_prompt`, intentionally sent for correct routing), and bounded prior group context with `seq < currentSeq`. Delayed outbox retries never see future messages as prior context.
 - decide and generate are separate; **decide emits intent only, not a draft** (saves tokens).
 - A hard cap of N public replies per human trigger prevents runaway flooding.
 - An agent's own message is logged (passively readable) but **does not wake other agents' arbiters by default.** The exception is an explicit `@otherAgent`, which is handled by a separate handoff dispatcher — the normal arbiter only reacts to `actor_type=human`, so the two paths don't conflict.
+
+### Durable dispatch correctness
+
+- Platform ingest creates a pending outbox row in the same transaction as the event-log message. Web synchronous ingest creates the outbox as `running` with a lease in that same transaction, so the background worker cannot steal the request while the SSE path is executing. If the process crashes or the lease expires, the worker recovers it with `NoopGroupPublisher`; Web's durable delivery source is the event log, not the open SSE socket.
+- Web disconnects do not cancel generation. The server uses a service-lifecycle context with a bounded timeout, drains the stream, and writes back only complete successful responses. Partial streams caused by cancellation or errors are not appended.
+- Dispatch retries use linear backoff: `1s * attempts`, capped at 60s. Rows that exceed the retry budget are marked `failed`; there is no fallback that lets another channel impersonate the agent.
+- Dispatch is ordered per `(group_id, agent_id)`: SQL only claims a row when no earlier `seq` for the same agent is pending or running with a live lease. Expired running rows are reclaimed instead of blocking forever.
+- Reply publishing is at-least-once. The normal tail is publish → one DB transaction that appends the group reply and writes `result_message_id` → mark completed. A retry that sees `result_message_id` skips chat and publish, then completes. The remaining duplicate window is publish succeeded but the writeback+marker transaction did not commit.
+- Group context injection deduplicates already-persisted injected messages with an exact SQL content lookup across the conversation, not a token-budget window.
 
 ## Reply egress: group only (D8)
 

--- a/web/content/docs/development/group-chat-multi-agent.zh.md
+++ b/web/content/docs/development/group-chat-multi-agent.zh.md
@@ -119,7 +119,7 @@ type Mention struct {
 }
 ```
 
-适配器填 `Raw` 和 `PlatformID`(它知道平台 id)。**dispatcher 反查 membership 解析 `AgentID`**。@路由只认 `Mention.AgentID != ""`——任何组件不在各处猜 username/open_id。
+适配器填 `Raw` 和 `PlatformID`(它知道平台 id)。ingest best-effort 解析 `AgentID` 并存入 outbox envelope；dispatcher 在路由前对仍为空的 `AgentID` 再补解析一次。@路由只认 `Mention.AgentID != ""`——任何组件不在各处猜 username/open_id。
 
 ## 记忆:subject 轴(D4)
 
@@ -176,13 +176,22 @@ CREATE TABLE ctx_group_memory (
       → 对选中的 agent 逐个:runtime → publisher(通过 reply_channel_id)
 ```
 
-- 任何 `@mention` 信号都留在 L0 规则路径。如果平台 mention 无法解析到 Stella 群成员,dispatcher 不会把它当成无 mention 语义请求;它会静默,避免回复本来发给别人的消息。
-- 无 mention 消息在配置了语义仲裁时走 L1 语义路由。分类器可以返回静默、单 agent 或受上限保护的多 agent 广播。失败、超时、无效 JSON 或无合格路由模型都折叠为静默。
+- 任何 `@mention` 信号都留在 L0 规则路径。已解析的 mention 绕过 `MaxRepliesPerTrigger`:用户一条消息 @ 多个群成员时,所有被 @ 的成员都会回复。如果平台 mention 无法解析到 Stella 群成员,dispatcher 不会把它当成无 mention 语义请求;它会静默,避免回复本来发给别人的消息。Web 文本 mention 解析不出成员时仍按普通文本进入无 mention 路径。
+- 无 mention 消息在配置了语义仲裁时走 L1 语义路由。分类器可以返回静默、单 agent 或受上限保护的多 agent 广播。失败、超时、无效 JSON 或无合格路由模型都折叠为静默。未配置语义路由时,Web 单成员群直接路由到唯一成员;Web 多成员群静默并写 WARN,提示配置语义仲裁。Platform `always` 仍使用成员 fallback;platform `mention` 保持静默。
 - L1 路由模型按归属选择,不是随便取第一个成员。Web 群优先群 owner 自己的 agent,再退到 system-scope agent。Platform 群只允许 system-scope agent,避免把私有 agent 的凭据用于共享路由决策。
-- L1 只接收有界的公开路由元数据:agent ID/name、`soul` 摘要,以及 `seq < currentSeq` 的有界历史群上下文。它不会收到 agent `system_prompt`,延迟 outbox 重试也不会把未来消息当成历史上下文。
+- L1 只接收有界的公开路由元数据:agent ID/name、成员摘要(`system_prompt` 前 180 字符,有意发送以便正确路由),以及 `seq < currentSeq` 的有界历史群上下文。延迟 outbox 重试不会把未来消息当成历史上下文。
 - decide 与 generate 分离,**decide 只出意图、不出草稿**(省 token)。
 - 每次人类触发硬上限 N 条公开回复,防失控刷屏。
 - agent 自己的发言写进 log(可被动读),但**默认不唤醒其他 agent 的 arbiter**。例外是显式 `@另一个 agent`,由独立 handoff dispatcher 处理——普通 arbiter 只对 `actor_type=human` 反应,两条路径互不冲突。
+
+### Durable dispatch 正确性
+
+- Platform ingest 在 event-log 消息同一事务内创建 pending outbox。Web 同步 ingest 在同一事务内以 `running` + lease 创建 outbox,避免后台 worker 在 SSE 路径执行时抢单。进程崩溃或租约过期后,worker 用 `NoopGroupPublisher` 恢复;Web 的持久交付来源是 event log,不是打开的 SSE socket。
+- Web 断连不会取消生成。服务端使用带上限的服务生命周期 context,继续 drain stream,且只写回完整成功响应。取消或错误导致的 partial stream 不会 append。
+- Dispatch 重试使用线性退避:`1s * attempts`,封顶 60s。超过重试预算后置为 `failed`;不会 fallback 到其它 channel 冒名该 agent。
+- Dispatch 按 `(group_id, agent_id)` 保持顺序:SQL 只在同 agent 没有更小 `seq` 的 pending 或未过期 running 行时 claim。过期 running 行会被回收,不会永久阻塞。
+- 回复发布是 at-least-once。正常收尾为 publish → 一个 DB 事务 append 群回复并写 `result_message_id` → mark completed。重试看到 `result_message_id` 会跳过 chat 和 publish,直接 completed。剩余重复窗口是 publish 成功但 writeback+marker 事务尚未提交。
+- 群上下文 injected 去重用 SQL 在整个 conversation 内做完整 content 精确查重,不依赖 token budget 窗口。
 
 ## 回复出口:只发到群(D8)
 

--- a/web/public/docs/group-chat-dataflow.html
+++ b/web/public/docs/group-chat-dataflow.html
@@ -744,9 +744,11 @@
           </div>
           <div class="stage-desc">
             目标态下，所有入口都调用同一个 ingest 原语。适配器只负责收消息并写入事实：resolve
-            group_id → dedup check → bump seq + insert message → insert dispatch
-            outbox，全部在同一个
-            <code>BEGIN IMMEDIATE</code> 事务里完成。adapter 不再直接负责回复。
+            group_id → dedup check → bump seq + insert message → best-effort 解析 mention → insert
+            dispatch outbox，全部在同一个
+            <code>BEGIN IMMEDIATE</code> 事务里完成。Web 同步路径在同一事务内直接以
+            <code>running</code> + lease 创建 outbox，避免后台 worker 抢单；adapter
+            不再直接负责回复。
           </div>
           <div class="stage-body">
             <div class="data-card">
@@ -793,8 +795,10 @@ VALUES ('uuid-new', 'grp_9f3a', <span class="num">42</span>, 'human', 'uid_88',
   'tg_msg_9001', '@weather-bot 北京今天天气怎么样？', ...);
 
 <span class="cm">-- Step 3: same transaction outbox — “这条事实需要被调度”</span>
-INSERT INTO ctx_group_outbox (id, group_message_id, group_id, envelope, status)
-VALUES ('outbox-uuid-1', 'uuid-new', 'grp_9f3a', '{"mentions":[{"agent_id":"weather-bot"}]}', 'pending');</pre>
+<span class="cm">-- ingest best-effort 解析 mention；未解析项保留 raw/platform id，dispatch 时补解析</span>
+INSERT INTO ctx_group_outbox (id, group_message_id, group_id, envelope, status, lease_until)
+VALUES ('outbox-uuid-1', 'uuid-new', 'grp_9f3a', '{"mentions":[{"agent_id":"weather-bot"}]}', 'pending', NULL);
+<span class="cm">-- Web 同步路径：status='running', lease_until=now+5m，由当前请求协程持有</span></pre>
             </div>
 
             <div class="info-callout">
@@ -817,8 +821,10 @@ VALUES ('outbox-uuid-1', 'uuid-new', 'grp_9f3a', '{"mentions":[{"agent_id":"weat
               <div class="design-callout-label">Dispatch gate</div>
               <p>
                 只有首次插入的 human message 才创建 outbox。幂等重投返回 existing seq 后必须停在
-                ingest 层：不 bump seq、不创建 outbox、不重复 arbiter、不重复回复。调度是否完成由
-                outbox / dispatch ledger 记录，不靠接收 adapter 的调用栈。
+                ingest 层：不 bump seq、不创建 outbox、不重复 arbiter、不重复回复。平台入口创建
+                pending outbox 交给 worker；Web 同步入口创建 running+lease outbox 并立即执行，后台
+                worker 只在租约过期后用 NoopGroupPublisher 做 crash recovery。调度是否完成由 outbox
+                / dispatch ledger 记录，不靠接收 adapter 的调用栈。
               </p>
             </div>
 
@@ -888,7 +894,7 @@ VALUES ('outbox-uuid-1', 'uuid-new', 'grp_9f3a', '{"mentions":[{"agent_id":"weat
     id               TEXT NOT NULL PRIMARY KEY,
     group_message_id TEXT NOT NULL REFERENCES ctx_group_message(id) ON DELETE CASCADE,
     group_id         TEXT NOT NULL REFERENCES ctx_group_state(id) ON DELETE CASCADE,
-    envelope         TEXT NOT NULL DEFAULT '{}',        <span class="cm">-- resolved mentions JSON</span>
+    envelope         TEXT NOT NULL DEFAULT '{}',        <span class="cm">-- best-effort resolved mentions JSON; unresolved resolved at dispatch</span>
     status           TEXT NOT NULL DEFAULT 'pending',  <span class="cm">-- Go-enforced: pending/running/completed/failed</span>
     attempt_count    INTEGER NOT NULL DEFAULT 0,
     lease_until      TEXT,
@@ -918,9 +924,9 @@ CREATE INDEX idx_ctx_group_outbox_running_lease
             <span class="stage-file">dispatcher worker (target)</span>
           </div>
           <div class="stage-desc">
-            独立 dispatcher worker 从 outbox claim 待处理消息，再将平台级 mention（bot 的
-            platform_id）映射为 agent_id。接收消息的 adapter 已经退出路径；后续调度不依赖
-            observerChannelID。
+            独立 dispatcher worker 从 outbox claim 待处理消息，复用 ingest 已解析的 mention，并对
+            envelope 里仍未解析的 mention（bot 的 platform_id）补映射为 agent_id。接收消息的 adapter
+            已经退出路径；后续调度不依赖 observerChannelID。
           </div>
           <div class="stage-body">
             <div class="data-card">
@@ -984,8 +990,9 @@ mentions = [{PlatformID: "bot_777", AgentID: <span class="ok">"weather-bot"</spa
                 <span class="decision-condition">有任意 @mention?</span>
                 <div class="decision-result">
                   <strong style="color: var(--accent-green)">→ L0 规则路径</strong><br />
-                  已解析到 Stella 群成员的 mention 直达对应 agent(s)，跳过 debounce，并受
-                  <code>MaxRepliesPerTrigger</code> 上限。无法解析的 mention 不会被当成无 mention
+                  已解析到 Stella 群成员的 mention 直达对应 agent(s)，跳过 debounce，并绕过
+                  <code>MaxRepliesPerTrigger</code>：一条消息 @ 多个成员时所有被 @ 的成员都会回复。
+                  无法解析的 platform mention 不会被当成无 mention
                   语义请求；默认静默，避免回复本来发给别人的消息。<br />
                   <span
                     style="
@@ -1010,8 +1017,8 @@ mentions = [{PlatformID: "bot_777", AgentID: <span class="ok">"weather-bot"</spa
                   system-scope。所选 agent 用其 fast tier 分类，若未配置
                   <code>model_fast</code> 则自动回退到该 agent
                   的默认模型（不会因为没配快模型就静默）。私有 agent
-                  的凭据不会被用于共享路由决策；agent 的
-                  <code>system_prompt</code> 也不会暴露给路由模型。<br />
+                  的凭据不会被用于共享路由决策；成员摘要（<code>system_prompt</code> 前 180
+                  字符）有意发给路由模型，用于正确路由。<br />
                   分类调用有
                   <strong>8s</strong> 预算（覆盖首 token + 一小段
                   JSON）。失败均降级为静默，并按级别记日志：每条消息的 prompt / 原始响应 / 决策走
@@ -1023,10 +1030,9 @@ mentions = [{PlatformID: "bot_777", AgentID: <span class="ok">"weather-bot"</spa
               <div class="decision-branch">
                 <span class="decision-condition">无 mention + 未配置语义仲裁（回退）</span>
                 <div class="decision-result">
-                  → <code>AllMembersFallback=true</code>（Web / platform
-                  <code>always</code>）：所有成员响应（受 MaxReplies 上限）。<br />
-                  → <code>AllMembersFallback=false</code>（platform
-                  <code>mention</code>）：不响应（静默跳过）。
+                  → Web：单成员群直接让唯一成员回复；多成员群静默并写 WARN，提示配置语义仲裁。<br />
+                  → Platform <code>always</code>：所有成员响应（受 MaxReplies 上限）。<br />
+                  → Platform <code>mention</code>：不响应（静默跳过）。
                 </div>
               </div>
             </div>
@@ -1135,6 +1141,7 @@ semantic response parse failed<span class="cm">// 模型返回非法 JSON</span>
     attempt_count    INTEGER NOT NULL DEFAULT 0,
     lease_until      TEXT,
     next_attempt_at  TEXT,
+    result_message_id TEXT NOT NULL DEFAULT '',
     last_error       TEXT NOT NULL DEFAULT '',
     created_at       TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at       TEXT NOT NULL DEFAULT (datetime('now')),
@@ -1196,8 +1203,8 @@ publisher.PublishGroupResponse(ctx, GroupDispatchRequest{
     TriggerSeq:     groupMessage.Seq,
 })
 
-<span class="cm">// publisher 内部：session resolve → Chat() → platform API → AppendToGroup writeback</span>
-<span class="cm">// 成功：status=completed；失败：attempt_count++，按 backoff 设置 next_attempt_at；超过上限 status=failed</span></pre>
+<span class="cm">// publisher 内部：session resolve → Chat() → platform API → 同事务 AppendToGroup + result_message_id</span>
+<span class="cm">// 成功：status=completed；失败：attempt_count++，按线性 backoff 设置 next_attempt_at；超过上限 status=failed</span></pre>
             </div>
 
             <div class="design-callout" style="margin-top: 8px">
@@ -1209,8 +1216,23 @@ publisher.PublishGroupResponse(ctx, GroupDispatchRequest{
                 >，以及
                 <code>status='running' AND lease_until &lt; now</code> 的过期租约回收。执行期初始
                 lease 默认 5 分钟，长工具调用可 heartbeat 延长。失败时递增
-                <code>attempt_count</code> 并指数退避；超过 <code>MaxDispatchAttempts</code> 后标记
-                <code>failed</code>，写 log/metric，平台侧不冒名 fallback。
+                <code>attempt_count</code> 并线性退避（1s × attempts，封顶 60s）；超过
+                <code>MaxDispatchAttempts</code> 后标记 <code>failed</code>，写
+                log/metric，平台侧不冒名 fallback。 同一 agent 在同一 group 内按 seq
+                顺序领取：若存在更小 seq 的 pending 或未过期 running
+                dispatch，后序行不会被查出，避免乱序执行。
+              </p>
+            </div>
+
+            <div class="design-callout" style="margin-top: 8px">
+              <div class="design-callout-label">At-least-once 收敛</div>
+              <p>
+                发布语义是 at-least-once。正常收尾顺序是：Publish 成功 → 同一个 DB 事务内
+                <code>AppendToGroup</code> writeback + 写 <code>result_message_id</code> marker →
+                标记 completed。重试若看到 marker 已存在，会跳过 Chat 和 Publish，直接 completed。
+                因此 writeback 已提交后的崩溃不会重发；唯一残余重复窗口是平台 Publish 已成功、但
+                writeback+marker 事务尚未提交前进程崩溃。Web 的主交付通道是 event log，客户端断线后
+                服务端继续跑完；NoopGroupPublisher 用于重启后的恢复，不向客户端推 SSE。
               </p>
             </div>
           </div>


### PR DESCRIPTION
## What

Six-phase fix for group chat dispatch correctness, implemented per the reviewed spec-dev plan:

1. **Mention routing** (`eaadcc58`) — mentions frozen at ingest are re-resolved at dispatch time, so a startup race no longer silences a message forever; explicit mentions bypass `MaxRepliesPerTrigger` so every mentioned agent replies.
2. **Ordering + dedup** (`0216cdbb`) — per-`(group_id, agent_id)` seq ordering gate as a SQL `NOT EXISTS` (expired leases don't block); injected group-context dedup moved from the token-budget window to an exact SQL content lookup over the whole conversation.
3. **Web disconnect** (`15c49258`) — web sync dispatch runs on a service-lifecycle context with a lease-duration timeout instead of `r.Context()`; cancelled/errored streams inject an `Err` event and partial replies are never written back; the web publisher keeps draining after the client is gone.
4. **At-least-once convergence** (`b60e5b23`) — new `ctx_group_dispatch.result_message_id` column (Atlas migration); publish → event-log writeback + result marker in one `BEGIN IMMEDIATE` transaction → mark completed; a retry that sees the marker skips chat/publish entirely.
5. **Web no-mention fallback** (`1a9146f8`) — single-member web groups reply directly; multi-member groups stay silent with a WARN to configure the semantic arbiter (replaces the accidental "first member replies" behavior).
6. **Docs sync** (`1b78bdfc`) — `group-chat-dataflow.html` and `group-chat-multi-agent.md`/`.zh.md` updated to match implemented behavior (routing summary intentionally sent, linear backoff, anti-steal web outbox, the new fallback rules, at-least-once semantics).

## Why

A design-vs-code review of `group-chat-dataflow.html` found real defects: permanently silenced mentions, truncated multi-mentions, partial+duplicate replies on web disconnect, out-of-order same-agent dispatch causing duplicate context injection, unbounded duplicate publishing after crashes, a self-contradictory web fallback, and documentation that misstated privacy and retry behavior.

## How

Plan with design decisions D1–D9, inline review threads (12, all resolved), and per-phase handoffs lives at `~/.agents/sessions/anna/2026-06-12-group-chat-dispatch-fixes/plan.md`. Each phase was implemented by Pi, line-by-line reviewed, and verified with `mise run format && build && test` plus targeted tests (fault injection for the transaction paths, `-count=30/50` runs for the cancellation race). One real bug was caught in review: a `select`-based cancellation check that wrote back partial replies ~50% of the time; fixed with a deterministic `ctx.Err()` re-check.

Accepted tradeoffs (documented in the plan): remaining at-least-once window (publish succeeded but writeback tx uncommitted), empty replies don't set the result marker, one-shot upgrade-compat window for old multimodal-JSON injected rows.

## Refs

Closes #409