### PR TITLE
✨ feat(api): ClawHub discover endpoint for skills marketplace

### DIFF
--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -493,6 +493,40 @@ components:
           type: string
         baseurl:
           type: string
+    ClawhubSkill:
+      type: object
+      required: [slug, name]
+      properties:
+        slug:
+          type: string
+        name:
+          type: string
+        summary:
+          type: string
+        version:
+          type: string
+        downloads:
+          type: integer
+        installs:
+          type: integer
+        updated_at:
+          type: string
+          format: date-time
+        author_handle:
+          type: string
+        author_image:
+          type: string
+    ClawhubSkillList:
+      type: object
+      required: [skills]
+      properties:
+        skills:
+          type: array
+          items:
+            $ref: "#/components/schemas/ClawhubSkill"
+        next_page_token:
+          type: string
+          nullable: true
     EmailFolderList:
       type: object
       required: [folders]

--- a/api/spec/domain/clawhub/paths.yaml
+++ b/api/spec/domain/clawhub/paths.yaml
@@ -1,0 +1,33 @@
+paths:
+  /api/clawhub/skills:
+    get:
+      tags: [clawhub]
+      summary: List or search ClawHub marketplace skills (any authenticated user)
+      operationId: listClawhubSkills
+      parameters:
+        - name: q
+          in: query
+          required: false
+          schema: { type: string }
+        - name: page_size
+          in: query
+          required: false
+          schema: { type: integer, default: 20 }
+        - name: page_token
+          in: query
+          required: false
+          schema: { type: string }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: {
+                $ref: "../../components.yaml#/components/schemas/ClawhubSkillList",
+              }
+        "400": {
+          $ref: "../../components.yaml#/components/responses/BadRequest",
+        }
+        "401": {
+          $ref: "../../components.yaml#/components/responses/Unauthorized",
+        }

--- a/api/spec/domain/clawhub/schemas.yaml
+++ b/api/spec/domain/clawhub/schemas.yaml
@@ -1,0 +1,31 @@
+openapi: 3.0.3
+info:
+  title: ClawHub Components
+  version: "1"
+paths: {}
+components:
+  schemas:
+    ClawhubSkill:
+      type: object
+      required: [slug, name]
+      properties:
+        slug: { type: string }
+        name: { type: string }
+        summary: { type: string }
+        version: { type: string }
+        downloads: { type: integer }
+        installs: { type: integer }
+        updated_at: { type: string, format: date-time }
+        author_handle: { type: string }
+        author_image: { type: string }
+
+    ClawhubSkillList:
+      type: object
+      required: [skills]
+      properties:
+        skills:
+          type: array
+          items: { $ref: "#/components/schemas/ClawhubSkill" }
+        next_page_token:
+          type: string
+          nullable: true

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -47,6 +47,7 @@ tags:
   - name: shares
   - name: agents
   - name: skills
+  - name: clawhub
   - name: users
   - name: auth-users
   - name: profile
@@ -105,6 +106,9 @@ paths:
   # ── Skills ─────────────────────────────────────────────────────────────────
   /api/skills/search:
     $ref: "./domain/skills/paths.yaml#/paths/~1api~1skills~1search"
+  # ── ClawHub ────────────────────────────────────────────────────────────────
+  /api/clawhub/skills:
+    $ref: "./domain/clawhub/paths.yaml#/paths/~1api~1clawhub~1skills"
   # ── Recally ────────────────────────────────────────────────────────────────
   /api/recally/articles:
     $ref: "./domain/recally/paths.yaml#/paths/~1api~1recally~1articles"

--- a/internal/server/clawhub.go
+++ b/internal/server/clawhub.go
@@ -1,0 +1,84 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	apiserver "github.com/CherryHQ/stella/api/server"
+	clawhubskills "github.com/CherryHQ/stella/internal/tools/skills"
+)
+
+// clawhubSkillView is the JSON representation of a single ClawHub marketplace skill.
+type clawhubSkillView struct {
+	Slug         string `json:"slug"`
+	Name         string `json:"name"`
+	Summary      string `json:"summary,omitempty"`
+	Version      string `json:"version,omitempty"`
+	Downloads    *int   `json:"downloads,omitempty"`
+	Installs     *int   `json:"installs,omitempty"`
+	UpdatedAt    string `json:"updated_at,omitempty"`
+	AuthorHandle string `json:"author_handle,omitempty"`
+	AuthorImage  string `json:"author_image,omitempty"`
+}
+
+// ListClawhubSkills handles GET /api/clawhub/skills.
+// When q is absent it browses popular skills (paginated); when q is set it searches.
+func (s *Server) ListClawhubSkills(w http.ResponseWriter, r *http.Request, params apiserver.ListClawhubSkillsParams) {
+	limit := 20
+	if params.PageSize != nil {
+		limit = *params.PageSize
+	}
+	if limit < 1 {
+		limit = 1
+	}
+	if limit > 50 {
+		limit = 50
+	}
+
+	var q string
+	if params.Q != nil {
+		q = *params.Q
+	}
+	var pageToken string
+	if params.PageToken != nil {
+		pageToken = *params.PageToken
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	catalog, nextCursor, err := clawhubskills.BrowseCatalog(ctx, q, limit, pageToken)
+	if err != nil {
+		s.writeBadGatewayError(w, err)
+		return
+	}
+
+	views := make([]clawhubSkillView, 0, len(catalog))
+	for _, sk := range catalog {
+		v := clawhubSkillView{
+			Slug:         sk.Slug,
+			Name:         sk.Name,
+			Summary:      sk.Summary,
+			Version:      sk.Version,
+			Downloads:    sk.Downloads,
+			Installs:     sk.Installs,
+			AuthorHandle: sk.AuthorHandle,
+			AuthorImage:  sk.AuthorImage,
+		}
+		if !sk.UpdatedAt.IsZero() {
+			v.UpdatedAt = sk.UpdatedAt.UTC().Format(time.RFC3339)
+		}
+		views = append(views, v)
+	}
+
+	var nextPageToken *string
+	if nextCursor != "" {
+		nextPageToken = &nextCursor
+	}
+
+	writeData(w, http.StatusOK, map[string]any{
+		"skills":          views,
+		"next_page_token": nextPageToken,
+	})
+}

--- a/internal/tools/skills/clawhub.go
+++ b/internal/tools/skills/clawhub.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/go-resty/resty/v2"
 
@@ -28,6 +29,45 @@ type clawhubSearchResult struct {
 	Summary     string  `json:"summary,omitempty"`
 	Version     *string `json:"version,omitempty"`
 	UpdatedAt   int64   `json:"updatedAt,omitempty"`
+	OwnerHandle string  `json:"ownerHandle,omitempty"`
+	Owner       *struct {
+		Handle      string `json:"handle"`
+		DisplayName string `json:"displayName"`
+		Image       string `json:"image"`
+	} `json:"owner,omitempty"`
+}
+
+// clawhubListItem is one row from GET /api/v1/skills (browse/popular endpoint).
+type clawhubListItem struct {
+	Slug        string `json:"slug"`
+	DisplayName string `json:"displayName"`
+	Summary     string `json:"summary,omitempty"`
+	Tags        struct {
+		Latest string `json:"latest"`
+	} `json:"tags"`
+	Stats struct {
+		Downloads       int `json:"downloads"`
+		InstallsCurrent int `json:"installsCurrent"`
+		InstallsAllTime int `json:"installsAllTime"`
+		Stars           int `json:"stars"`
+	} `json:"stats"`
+	UpdatedAt     int64 `json:"updatedAt,omitempty"`
+	LatestVersion struct {
+		Version string `json:"version"`
+	} `json:"latestVersion"`
+}
+
+// CatalogSkill is one marketplace row from the ClawHub registry.
+type CatalogSkill struct {
+	Slug         string
+	Name         string
+	Summary      string
+	Version      string    // empty when unknown
+	Downloads    *int      // nil in search mode (upstream search has no stats)
+	Installs     *int      // nil in search mode
+	UpdatedAt    time.Time // zero when unknown
+	AuthorHandle string    // empty in browse mode (upstream list has no owner)
+	AuthorImage  string
 }
 
 type clawhubSkillDetail struct {
@@ -94,6 +134,115 @@ func clawhubWithFallback(fn func(base string) (is429 bool, err error)) error {
 		return fmt.Errorf("%s", clawhubRateLimitMsg)
 	}
 	return fmt.Errorf("clawhub: all endpoints unavailable")
+}
+
+// clawhubListSkills fetches popular skills from GET /api/v1/skills sorted by downloads.
+// cursor is passed through as-is; an empty string omits the query parameter.
+// Returns the items, the opaque next cursor (empty on last page), and any error.
+func clawhubListSkills(ctx context.Context, limit int, cursor string) ([]clawhubListItem, string, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	client := newClawhubClient()
+	var result struct {
+		Items      []clawhubListItem `json:"items"`
+		NextCursor string            `json:"nextCursor"`
+	}
+	err := clawhubWithFallback(func(base string) (bool, error) {
+		req := client.R().
+			SetContext(ctx).
+			SetQueryParam("sort", "downloads").
+			SetQueryParam("limit", fmt.Sprintf("%d", limit)).
+			SetResult(&result)
+		if cursor != "" {
+			req = req.SetQueryParam("cursor", cursor)
+		}
+		resp, err := req.Get(base + "/api/v1/skills")
+		if err != nil {
+			return false, err
+		}
+		if resp.StatusCode() == 429 {
+			return true, nil
+		}
+		if resp.IsError() {
+			return false, fmt.Errorf("clawhub list returned HTTP %d", resp.StatusCode())
+		}
+		return false, nil
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	return result.Items, result.NextCursor, nil
+}
+
+// BrowseCatalog returns popular skills when q is empty (paginated via the
+// opaque pageToken) and search results when q is set (no pagination).
+func BrowseCatalog(ctx context.Context, q string, limit int, pageToken string) (items []CatalogSkill, nextPageToken string, err error) {
+	if q != "" {
+		// Search mode: use clawhubSearch, no pagination.
+		results, searchErr := clawhubSearch(ctx, q, limit)
+		if searchErr != nil {
+			return nil, "", searchErr
+		}
+		items = make([]CatalogSkill, 0, len(results))
+		for _, r := range results {
+			var version string
+			if r.Version != nil {
+				version = *r.Version
+			}
+			var updatedAt time.Time
+			if r.UpdatedAt > 0 {
+				updatedAt = time.UnixMilli(r.UpdatedAt).UTC()
+			}
+			authorHandle := r.OwnerHandle
+			var authorImage string
+			if r.Owner != nil {
+				if authorHandle == "" {
+					authorHandle = r.Owner.Handle
+				}
+				authorImage = r.Owner.Image
+			}
+			items = append(items, CatalogSkill{
+				Slug:         r.Slug,
+				Name:         r.DisplayName,
+				Summary:      r.Summary,
+				Version:      version,
+				UpdatedAt:    updatedAt,
+				AuthorHandle: authorHandle,
+				AuthorImage:  authorImage,
+			})
+		}
+		return items, "", nil
+	}
+
+	// Browse mode: use clawhubListSkills with cursor passthrough.
+	listItems, nextCursor, listErr := clawhubListSkills(ctx, limit, pageToken)
+	if listErr != nil {
+		return nil, "", listErr
+	}
+	items = make([]CatalogSkill, 0, len(listItems))
+	for _, li := range listItems {
+		version := li.Tags.Latest
+		if version == "" {
+			version = li.LatestVersion.Version
+		}
+		var updatedAt time.Time
+		if li.UpdatedAt > 0 {
+			updatedAt = time.UnixMilli(li.UpdatedAt).UTC()
+		}
+		downloads := li.Stats.Downloads
+		installs := li.Stats.InstallsCurrent
+		items = append(items, CatalogSkill{
+			Slug:      li.Slug,
+			Name:      li.DisplayName,
+			Summary:   li.Summary,
+			Version:   version,
+			Downloads: &downloads,
+			Installs:  &installs,
+			UpdatedAt: updatedAt,
+		})
+	}
+	return items, nextCursor, nil
 }
 
 func clawhubSearch(ctx context.Context, query string, limit int) ([]clawhubSearchResult, error) {

--- a/internal/tools/skills/clawhub_test.go
+++ b/internal/tools/skills/clawhub_test.go
@@ -1,0 +1,214 @@
+package skills
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// fakeListResponse is the shape returned by the upstream /api/v1/skills endpoint.
+type fakeListResponse struct {
+	Items      []map[string]any `json:"items"`
+	NextCursor string           `json:"nextCursor,omitempty"`
+}
+
+// fakeSearchResponse is the shape returned by the upstream /api/v1/search endpoint.
+type fakeSearchResponse struct {
+	Results []map[string]any `json:"results"`
+}
+
+func newFakeClawhubServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/api/v1/skills", func(w http.ResponseWriter, r *http.Request) {
+		cursor := r.URL.Query().Get("cursor")
+		var resp fakeListResponse
+		if cursor == "" {
+			resp = fakeListResponse{
+				Items: []map[string]any{
+					{
+						"slug":        "awesome-skill",
+						"displayName": "Awesome Skill",
+						"summary":     "Does awesome things",
+						"tags":        map[string]any{"latest": "1.2.3"},
+						"stats": map[string]any{
+							"downloads":       42000,
+							"installsCurrent": 500,
+							"installsAllTime": 600,
+							"stars":           100,
+						},
+						"updatedAt":     int64(1780785432794),
+						"latestVersion": map[string]any{"version": "1.2.3"},
+					},
+				},
+				NextCursor: "cursor-page2",
+			}
+		} else {
+			// Second page — no next cursor.
+			resp = fakeListResponse{
+				Items: []map[string]any{
+					{
+						"slug":        "second-skill",
+						"displayName": "Second Skill",
+						"summary":     "Page 2 skill",
+						"tags":        map[string]any{"latest": "0.1.0"},
+						"stats": map[string]any{
+							"downloads":       100,
+							"installsCurrent": 10,
+							"installsAllTime": 20,
+							"stars":           5,
+						},
+						"updatedAt":     int64(1767632598365),
+						"latestVersion": map[string]any{"version": "0.1.0"},
+					},
+				},
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	mux.HandleFunc("/api/v1/search", func(w http.ResponseWriter, r *http.Request) {
+		resp := fakeSearchResponse{
+			Results: []map[string]any{
+				{
+					"score":       2.5,
+					"slug":        "found-skill",
+					"displayName": "Found Skill",
+					"summary":     "A searched skill",
+					"version":     nil,
+					"updatedAt":   int64(1778988067226),
+					"ownerHandle": "brennerspear",
+					"owner": map[string]any{
+						"handle":      "brennerspear",
+						"displayName": "Brenner Spear",
+						"image":       "https://example.com/avatar.png",
+					},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestBrowseCatalog_Browse_MapsStatsAndCursor(t *testing.T) {
+	srv := newFakeClawhubServer(t)
+	t.Setenv("CLAWHUB_URL", srv.URL)
+
+	items, nextToken, err := BrowseCatalog(context.Background(), "", 10, "")
+	if err != nil {
+		t.Fatalf("BrowseCatalog browse: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	sk := items[0]
+	if sk.Slug != "awesome-skill" {
+		t.Errorf("Slug = %q, want %q", sk.Slug, "awesome-skill")
+	}
+	if sk.Name != "Awesome Skill" {
+		t.Errorf("Name = %q, want %q", sk.Name, "Awesome Skill")
+	}
+	if sk.Version != "1.2.3" {
+		t.Errorf("Version = %q, want %q", sk.Version, "1.2.3")
+	}
+	if sk.Downloads == nil || *sk.Downloads != 42000 {
+		t.Errorf("Downloads = %v, want 42000", sk.Downloads)
+	}
+	if sk.Installs == nil || *sk.Installs != 500 {
+		t.Errorf("Installs = %v, want 500", sk.Installs)
+	}
+	if sk.UpdatedAt.IsZero() {
+		t.Error("UpdatedAt should not be zero")
+	}
+	if sk.AuthorHandle != "" {
+		t.Errorf("AuthorHandle should be empty in browse mode, got %q", sk.AuthorHandle)
+	}
+	if nextToken != "cursor-page2" {
+		t.Errorf("nextPageToken = %q, want %q", nextToken, "cursor-page2")
+	}
+}
+
+func TestBrowseCatalog_Browse_PageTokenPassthrough(t *testing.T) {
+	var capturedCursor string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/skills", func(w http.ResponseWriter, r *http.Request) {
+		capturedCursor = r.URL.Query().Get("cursor")
+		resp := fakeListResponse{Items: []map[string]any{}}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	t.Setenv("CLAWHUB_URL", srv.URL)
+
+	_, _, err := BrowseCatalog(context.Background(), "", 5, "my-opaque-cursor")
+	if err != nil {
+		t.Fatalf("BrowseCatalog: %v", err)
+	}
+	if capturedCursor != "my-opaque-cursor" {
+		t.Errorf("cursor in upstream request = %q, want %q", capturedCursor, "my-opaque-cursor")
+	}
+}
+
+func TestBrowseCatalog_Search_MapsOwnerAndEmptyNextToken(t *testing.T) {
+	srv := newFakeClawhubServer(t)
+	t.Setenv("CLAWHUB_URL", srv.URL)
+
+	items, nextToken, err := BrowseCatalog(context.Background(), "something", 10, "")
+	if err != nil {
+		t.Fatalf("BrowseCatalog search: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	sk := items[0]
+	if sk.Slug != "found-skill" {
+		t.Errorf("Slug = %q, want %q", sk.Slug, "found-skill")
+	}
+	if sk.AuthorHandle != "brennerspear" {
+		t.Errorf("AuthorHandle = %q, want %q", sk.AuthorHandle, "brennerspear")
+	}
+	if sk.AuthorImage != "https://example.com/avatar.png" {
+		t.Errorf("AuthorImage = %q, want %q", sk.AuthorImage, "https://example.com/avatar.png")
+	}
+	if sk.Downloads != nil {
+		t.Errorf("Downloads should be nil in search mode, got %v", sk.Downloads)
+	}
+	if sk.Installs != nil {
+		t.Errorf("Installs should be nil in search mode, got %v", sk.Installs)
+	}
+	if sk.UpdatedAt.IsZero() {
+		t.Error("UpdatedAt should not be zero")
+	}
+	if nextToken != "" {
+		t.Errorf("nextPageToken should be empty in search mode, got %q", nextToken)
+	}
+}
+
+func TestBrowseCatalog_Browse_SecondPageNoNextToken(t *testing.T) {
+	srv := newFakeClawhubServer(t)
+	t.Setenv("CLAWHUB_URL", srv.URL)
+
+	items, nextToken, err := BrowseCatalog(context.Background(), "", 10, "cursor-page2")
+	if err != nil {
+		t.Fatalf("BrowseCatalog page 2: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item on page 2, got %d", len(items))
+	}
+	if items[0].Slug != "second-skill" {
+		t.Errorf("Slug = %q, want %q", items[0].Slug, "second-skill")
+	}
+	if nextToken != "" {
+		t.Errorf("nextToken on last page = %q, want empty", nextToken)
+	}
+}


### PR DESCRIPTION
## What

New `GET /api/clawhub/skills` endpoint — a read-only List over the ClawHub registry, feeding the skills Discover tab (#412 / #413) with real marketplace data.

## Why

The redesigned skills page ships its Discover tab on a mock catalog (`skill-mock-discover.ts`, marked `TODO(discover)`). ClawHub already exposes everything needed; nothing in our API passed it through. The existing `GET /api/skills/search` (skills.sh via mcphub, used by the install dialog) is untouched.

## How

- Modeled as a standard List per `api-design.md` (room for `GET /api/clawhub/skills/{slug}` later).
- No `q`: proxy ClawHub `GET /api/v1/skills?sort=downloads`; upstream `nextCursor` passes through as opaque `next_page_token`.
- `q` set: proxy `GET /api/v1/search`; upstream search has no stats and no cursor, so `downloads`/`installs` are omitted and `next_page_token` is null.
- Row: `slug, name, summary, version?, downloads?, installs?, updated_at (RFC3339), author_handle?, author_image?` — browse mode has no owner upstream, search mode has no stats; all optional fields verified against the live API.
- No per-row detail enrichment: N+1 against ClawHub's anonymous quota is a 429 trap.
- Spec-first: new domain `api/spec/domain/clawhub/`; handler `internal/server/clawhub.go` mirrors `SearchSkills` (10s timeout, 502 on upstream failure); client logic in `internal/tools/skills/clawhub.go` reuses the existing `clawhubWithFallback` mirror/429 handling; exported via `BrowseCatalog`.
- Tests: `clawhub_test.go` stubs upstream via `CLAWHUB_URL` + `httptest` — browse stat/cursor mapping, search owner mapping, page-token passthrough, last page.
- Follow-up (separate PR after this and #413 merge): swap the frontend mock for the generated `listClawhubSkills` SDK call.

## Refs

Closes #414. Related: #412, #413.