### PR TITLE
⚡ perf: inject group speaker per turn

### DIFF
--- a/internal/agent/pool_manager.go
+++ b/internal/agent/pool_manager.go
@@ -366,38 +366,8 @@ func (pm *PoolManager) buildSnapshotPromptFunc(snap *config.Snapshot) agentrunti
 	}
 }
 
-// buildGroupSystemPrompt renders a per-turn group system prompt with the current
-// speaker. It is never cached on the runner, so one speaker's addressing context
-// can't leak into another speaker's turn. The prompt UserID stays empty and
-// group memory flows from GroupID; private speaker profile text is deliberately
-// not auto-injected into public group prompts.
-func (pm *PoolManager) buildGroupSystemPrompt(ctx context.Context, snap *config.Snapshot, info session.Info, speaker memory.CurrentSpeaker) string {
-	userRoot, _, groupID := pm.promptScope(snap.AgentID, info)
-	sections := pm.promptSections(ctx, snap, info, userRoot)
-
-	return prompt.BuildSystemPromptFromDB(ctx, prompt.DBPromptParams{
-		SystemPrompt:      snap.SystemPrompt,
-		AgentSoul:         snap.Soul,
-		Memory:            pm.mem,
-		UserID:            "",
-		AgentID:           info.AgentID,
-		GroupID:           groupID,
-		StellaHome:        config.StellaHome(),
-		AgentRoot:         snap.Workspace,
-		UserRoot:          userRoot,
-		Sections:          sections,
-		CurrentSpeaker:    speaker,
-		HasCurrentSpeaker: true,
-	})
-}
-
 func (pm *PoolManager) runtimeBeforeRunFunc(snap *config.Snapshot) agentruntime.BeforeRunFunc {
 	return func(ctx context.Context, info session.Info, model, msgText, system string, history []ai.Message) (string, error) {
-		if info.GroupID != "" {
-			if speaker, ok := memory.CurrentSpeakerFromContext(ctx); ok {
-				system = pm.buildGroupSystemPrompt(ctx, snap, info, speaker)
-			}
-		}
 		if pm.beforeRunBuilder == nil {
 			return system, nil
 		}

--- a/internal/agent/prompt/prompt.go
+++ b/internal/agent/prompt/prompt.go
@@ -68,10 +68,7 @@ type promptData struct {
 	// Group session rendering. IsGroup switches the template from the per-user
 	// "## User Profile" section to "## Group Memory" (+ optional current speaker),
 	// driven by session kind, not by whether group memory text is non-empty.
-	IsGroup              bool
-	HasCurrentSpeaker    bool // a current-speaker section should render this turn
-	CurrentSpeakerName   string
-	CurrentSpeakerLinked bool // resolved to a Stella user; private profile is not auto-injected in groups
+	IsGroup bool
 }
 
 // DBPromptParams holds the parameters for building a system prompt from DB-backed config.
@@ -93,11 +90,10 @@ type DBPromptParams struct {
 	SnapshotVersion   int64     // frozen memory version for this session; 0 means current
 	SnapshotUpdatedAt time.Time // wall-clock time of the last snapshot advance; used to filter knowledge
 
-	// CurrentSpeaker renders a group-only "## Current Speaker" section when
-	// HasCurrentSpeaker is true. It is a personalization target only: its UserID
-	// must never be passed as the prompt UserID (which stays empty/group-scoped for
-	// group sessions). Group prompts expose only speaker presence/linked status;
-	// private profile text is not auto-injected into a public room.
+	// CurrentSpeaker is retained for compatibility with callers/tests that still
+	// populate it, but it is intentionally not rendered into the system prompt.
+	// Runtime injects speaker metadata as per-turn message context so reused group
+	// runners keep a stable system prefix for prompt caching.
 	CurrentSpeaker    memory.CurrentSpeaker
 	HasCurrentSpeaker bool
 }
@@ -185,23 +181,9 @@ func BuildSystemPromptFromDB(ctx context.Context, p DBPromptParams) string {
 		}
 	}
 
-	// Current speaker (D9): a per-turn personalization axis for group turns.
-	// Public group prompts expose only who is speaking and whether they are
-	// linked. Private profile text/entries, soul, and constraints are intentionally
-	// NOT auto-injected; a public room is not the place to disclose one member's
-	// private memory to the whole group.
-	// Render the section only when the caller resolved a real speaker. Unlinked
-	// platform senders can still render (name/platform set); fail-closed dispatch
-	// leaves HasCurrentSpeaker false so no phantom "Unknown speaker" appears.
-	if p.HasCurrentSpeaker && p.CurrentSpeaker != (memory.CurrentSpeaker{}) {
-		data.HasCurrentSpeaker = true
-		data.CurrentSpeakerName = p.CurrentSpeaker.DisplayName
-		if data.CurrentSpeakerName == "" {
-			data.CurrentSpeakerName = "Unknown"
-		}
-		data.CurrentSpeakerLinked = p.CurrentSpeaker.UserID != ""
-	}
-
+	// Current speaker (D9): intentionally not rendered into the system prompt.
+	// Runtime injects it as per-turn message context instead, preserving the group
+	// system prompt prefix across speakers for provider prompt caches.
 	// Knowledge: active fact/context entries injected as ## Knowledge section.
 	// When a session snapshot is active, filter out entries that became active
 	// after the snapshot was last advanced so that background knowledge changes

--- a/internal/agent/prompt/prompt_current_speaker_test.go
+++ b/internal/agent/prompt/prompt_current_speaker_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/CherryHQ/stella/internal/memory/memorytest"
 )
 
-func TestCurrentSpeakerLinkedRendersWithGroupMemory(t *testing.T) {
+func TestCurrentSpeakerNotRenderedInGroupSystemPrompt(t *testing.T) {
 	fake := memorytest.New()
 	ctx := context.Background()
 
@@ -32,96 +32,15 @@ func TestCurrentSpeakerLinkedRendersWithGroupMemory(t *testing.T) {
 		HasCurrentSpeaker: true,
 	})
 
-	for _, want := range []string{"## Group Memory", "## Current Speaker", "Alice", "Linked Stella user: yes"} {
+	for _, want := range []string{"## Group Memory", "This group talks about Go."} {
 		if !strings.Contains(p, want) {
 			t.Errorf("expected prompt to contain %q\n---\n%s", want, p)
 		}
 	}
-	for _, forbidden := range []string{"## User Profile", "Alice likes tea", "Based in Berlin", "OTHER MEMBER SECRET", "<speaker_profile>"} {
+	for _, forbidden := range []string{"## Current Speaker", "Linked Stella user", "Alice likes tea", "Based in Berlin", "OTHER MEMBER SECRET", "<speaker_profile>"} {
 		if strings.Contains(p, forbidden) {
-			t.Errorf("group turn must not auto-inject private profile content %q", forbidden)
+			t.Errorf("group system prompt must not include per-turn/private speaker content %q", forbidden)
 		}
-	}
-}
-
-func TestCurrentSpeakerUnlinkedRendersNameOnly(t *testing.T) {
-	fake := memorytest.New()
-	ctx := context.Background()
-
-	// An unlinked sender that happens to share a platform id with a real user's
-	// profile must NOT pull that profile — only UserID drives the lookup.
-	_ = fake.SetProfile(ctx, "tg-stranger", "a1", "WRONG PROFILE")
-
-	p := prompt.BuildSystemPromptFromDB(ctx, prompt.DBPromptParams{
-		SystemPrompt:      "You are Stella.",
-		Memory:            fake,
-		AgentID:           "a1",
-		GroupID:           "grp-1",
-		CurrentSpeaker:    memory.CurrentSpeaker{Platform: "telegram", PlatformUserID: "tg-stranger", DisplayName: "Stranger"},
-		HasCurrentSpeaker: true,
-	})
-
-	if !strings.Contains(p, "## Current Speaker") {
-		t.Error("expected Current Speaker section for unlinked sender")
-	}
-	if !strings.Contains(p, "Stranger") {
-		t.Error("expected unlinked sender display name")
-	}
-	if !strings.Contains(p, "Linked Stella user: no") {
-		t.Error("expected unlinked marker")
-	}
-	if strings.Contains(p, "WRONG PROFILE") {
-		t.Error("unlinked sender must not resolve any profile")
-	}
-}
-
-func TestCurrentSpeakerPrivateMemoryNotInjected(t *testing.T) {
-	fake := memorytest.New()
-	ctx := context.Background()
-
-	_ = fake.SetAgentSoul(ctx, "speaker1", "a1", "SPEAKER SECRET SOUL")
-	if _, err := fake.AddConstraint(ctx, "speaker1", "a1", "SPEAKER SECRET CONSTRAINT"); err != nil {
-		t.Fatal(err)
-	}
-	_ = fake.SetProfile(ctx, "speaker1", "a1", "Alice profile")
-
-	p := prompt.BuildSystemPromptFromDB(ctx, prompt.DBPromptParams{
-		SystemPrompt:      "You are Stella.",
-		Memory:            fake,
-		AgentID:           "a1",
-		GroupID:           "grp-1",
-		CurrentSpeaker:    memory.CurrentSpeaker{DisplayName: "Alice", UserID: "speaker1"},
-		HasCurrentSpeaker: true,
-	})
-
-	for _, forbidden := range []string{"Alice profile", "SPEAKER SECRET SOUL", "SPEAKER SECRET CONSTRAINT"} {
-		if strings.Contains(p, forbidden) {
-			t.Errorf("speaker private memory must not be injected into a group prompt: %q", forbidden)
-		}
-	}
-}
-
-func TestCurrentSpeakerZeroValueRendersNoSection(t *testing.T) {
-	fake := memorytest.New()
-	ctx := context.Background()
-	fake.SetGroupMemory("grp-1", "Group about Go.")
-
-	// Fail-closed dispatch (e.g. non-human Web trigger) can defensively pass a
-	// zero speaker; the section must not render a phantom "Unknown" speaker.
-	p := prompt.BuildSystemPromptFromDB(ctx, prompt.DBPromptParams{
-		SystemPrompt:      "You are Stella.",
-		Memory:            fake,
-		AgentID:           "a1",
-		GroupID:           "grp-1",
-		CurrentSpeaker:    memory.CurrentSpeaker{},
-		HasCurrentSpeaker: true,
-	})
-
-	if strings.Contains(p, "## Current Speaker") {
-		t.Error("zero-value speaker must not render a Current Speaker section")
-	}
-	if !strings.Contains(p, "## Group Memory") {
-		t.Error("group memory should still render for the group turn")
 	}
 }
 

--- a/internal/agent/prompt/template/system_prompt.tmpl
+++ b/internal/agent/prompt/template/system_prompt.tmpl
@@ -87,19 +87,7 @@ Shared knowledge about this group conversation.
 <group_memory>
 {{ .GroupMemory }}
 </group_memory>
-{{ if .HasCurrentSpeaker }}
-## Current Speaker
-
-The human speaking in this turn. This section is for addressing and tone only.
-Private profile facts are not injected into public group prompts. Do not call
-`memory.profile_get` or disclose profile details in a group unless this speaker
-explicitly asks you to read or use their profile in this conversation.
-
-<current_speaker>
-Name: {{ .CurrentSpeakerName }}
-{{ if .CurrentSpeakerLinked }}Linked Stella user: yes (profile available only by explicit request){{ else }}Linked Stella user: no{{ end }}
-</current_speaker>
-{{ end }}{{ else }}## User Profile
+{{ else }}## User Profile
 
 What you know about this user. Edit via the memory tool (profile_get / profile_update).
 

--- a/internal/agent/runtime/chat.go
+++ b/internal/agent/runtime/chat.go
@@ -180,6 +180,10 @@ func (rt *Runtime) chat(ctx context.Context, out chan<- Event, info session.Info
 	// failed durable dispatch retry would leave the same trigger in history and
 	// duplicate it on the next attempt.
 	userMsg := ai.UserMessage{Content: msg, Timestamp: time.Now()}
+	modelMsg := userMsg
+	if memSess.GroupID != "" && co.hasSpeaker {
+		modelMsg.Content = withCurrentSpeakerContext(msg, co.currentSpeaker)
+	}
 	var storePrefix []ai.Message
 	if memSess.GroupID != "" {
 		storePrefix = []ai.Message{userMsg}
@@ -187,7 +191,7 @@ func (rt *Runtime) chat(ctx context.Context, out chan<- Event, info session.Info
 		rt.log.Warn("memory append user message failed", "session_id", info.ID, "error", err)
 	}
 
-	stream := r.Chat(ctx, history, userMsg)
+	stream := r.Chat(ctx, history, modelMsg)
 	chatErr := rt.streamEvents(ctx, info.ID, memSess, stream, out, hs, hookMeta, chatStart, storePrefix...)
 	if chatErr == nil && assembledOK && ctx.Err() == nil && memSess.GroupID != "" {
 		if committer, ok := rt.mem.(memory.GroupCursorCommitter); ok {

--- a/internal/agent/runtime/chat_group_speaker_test.go
+++ b/internal/agent/runtime/chat_group_speaker_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/CherryHQ/stella/internal/agent/session"
@@ -56,5 +57,55 @@ func TestRuntimeChatGroupSpeakerContextNoUserPromotion(t *testing.T) {
 		if uid != "" {
 			t.Errorf("turn %d: memory.UserIDFromContext = %q, want empty (group D9)", i, uid)
 		}
+	}
+}
+
+func TestRuntimeChatGroupSpeakerContextInjectedIntoModelMessageOnly(t *testing.T) {
+	mem := &recordingMemory{}
+	var modelMessages []MessageContent
+
+	rt, err := New(Config{
+		Memory: mem,
+		NewRunner: func(context.Context, RunnerParams) (Runner, error) {
+			return chatFakeRunner{events: []Event{{Text: "ok"}}, messages: &modelMessages}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+
+	info := session.Info{ID: "sess-1", UserID: "group-1", AgentID: "agent-1", GroupID: "group-1"}
+	out := make(chan Event, 10)
+	rt.chat(
+		memory.WithGroupSeq(context.Background(), 1),
+		out, info, "hi Stella",
+		chatOptions{currentSpeaker: memory.CurrentSpeaker{UserID: "alice", DisplayName: "Alice"}, hasSpeaker: true},
+	)
+	for range out { //nolint:revive // drain
+	}
+
+	if len(modelMessages) != 1 {
+		t.Fatalf("model messages = %d, want 1", len(modelMessages))
+	}
+	modelMsg, ok := modelMessages[0].(ai.UserMessage)
+	if !ok {
+		t.Fatalf("model message type = %T, want ai.UserMessage", modelMessages[0])
+	}
+	modelText := flattenRuntimeUserMessage(modelMsg)
+	for _, want := range []string{"<current_speaker>", "Name: Alice", "Linked Stella user: yes", "hi Stella"} {
+		if !strings.Contains(modelText, want) {
+			t.Fatalf("model message missing %q:\n%s", want, modelText)
+		}
+	}
+
+	if len(mem.messages) != 2 {
+		t.Fatalf("stored messages = %d, want user + assistant", len(mem.messages))
+	}
+	storedUser, ok := mem.messages[0].(ai.UserMessage)
+	if !ok {
+		t.Fatalf("stored first message = %T, want ai.UserMessage", mem.messages[0])
+	}
+	if storedUser.Content != "hi Stella" {
+		t.Fatalf("stored user content = %#v, want original message", storedUser.Content)
 	}
 }

--- a/internal/agent/runtime/chat_test.go
+++ b/internal/agent/runtime/chat_test.go
@@ -55,10 +55,15 @@ func (m *recordingMemory) CommitGroupCursor(_ context.Context, _ memory.Session,
 }
 
 type chatFakeRunner struct {
-	events []Event
+	events   []Event
+	system   string
+	messages *[]MessageContent
 }
 
-func (r chatFakeRunner) Chat(context.Context, []ai.Message, MessageContent) <-chan Event {
+func (r chatFakeRunner) Chat(_ context.Context, _ []ai.Message, msg MessageContent) <-chan Event {
+	if r.messages != nil {
+		*r.messages = append(*r.messages, msg)
+	}
 	ch := make(chan Event, len(r.events))
 	for _, evt := range r.events {
 		ch <- evt
@@ -70,7 +75,7 @@ func (r chatFakeRunner) Chat(context.Context, []ai.Message, MessageContent) <-ch
 func (r chatFakeRunner) Alive() bool             { return true }
 func (r chatFakeRunner) Busy() bool              { return false }
 func (r chatFakeRunner) LastActivity() time.Time { return time.Now() }
-func (r chatFakeRunner) SystemPrompt() string    { return "" }
+func (r chatFakeRunner) SystemPrompt() string    { return r.system }
 func (r chatFakeRunner) Close() error            { return nil }
 
 func TestRuntimeChatCommitsGroupCursorAfterSuccessfulGroupTurn(t *testing.T) {

--- a/internal/agent/runtime/current_speaker.go
+++ b/internal/agent/runtime/current_speaker.go
@@ -1,0 +1,41 @@
+package runtime
+
+import (
+	"fmt"
+
+	"github.com/CherryHQ/stella/internal/memory"
+	"github.com/CherryHQ/stella/pkg/ai"
+)
+
+const currentSpeakerInstruction = "The human speaking in this group turn. Use this only for addressing and tone. Private profile facts are not injected into public group prompts. Do not call `memory.profile_get` or disclose profile details in a group unless this speaker explicitly asks you to read or use their profile in this conversation."
+
+func withCurrentSpeakerContext(msg MessageContent, speaker memory.CurrentSpeaker) MessageContent {
+	if speaker == (memory.CurrentSpeaker{}) {
+		return msg
+	}
+
+	prefix := currentSpeakerContextText(speaker)
+	switch m := msg.(type) {
+	case string:
+		return prefix + "\n\n" + m
+	case []ai.ContentBlock:
+		out := make([]ai.ContentBlock, 0, len(m)+1)
+		out = append(out, ai.TextContent{Text: prefix})
+		out = append(out, m...)
+		return out
+	default:
+		return prefix + "\n\n" + fmt.Sprintf("%v", m)
+	}
+}
+
+func currentSpeakerContextText(speaker memory.CurrentSpeaker) string {
+	name := speaker.DisplayName
+	if name == "" {
+		name = "Unknown"
+	}
+	linked := "no"
+	if speaker.UserID != "" {
+		linked = "yes (profile available only by explicit request)"
+	}
+	return fmt.Sprintf("<current_speaker>\n%s\n\nName: %s\nLinked Stella user: %s\n</current_speaker>", currentSpeakerInstruction, name, linked)
+}

--- a/internal/agent/runtime/current_speaker_test.go
+++ b/internal/agent/runtime/current_speaker_test.go
@@ -1,0 +1,105 @@
+package runtime
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/CherryHQ/stella/internal/agent/session"
+	"github.com/CherryHQ/stella/internal/memory"
+	"github.com/CherryHQ/stella/pkg/ai"
+)
+
+type recordingChatRunner struct {
+	system  string
+	events  []Event
+	history []ai.Message
+	message MessageContent
+}
+
+func (r *recordingChatRunner) Chat(_ context.Context, history []ai.Message, message MessageContent) <-chan Event {
+	r.history = append([]ai.Message(nil), history...)
+	r.message = message
+	ch := make(chan Event, len(r.events))
+	for _, evt := range r.events {
+		ch <- evt
+	}
+	close(ch)
+	return ch
+}
+
+func (r *recordingChatRunner) Alive() bool             { return true }
+func (r *recordingChatRunner) Busy() bool              { return false }
+func (r *recordingChatRunner) LastActivity() time.Time { return time.Now() }
+func (r *recordingChatRunner) SystemPrompt() string    { return r.system }
+func (r *recordingChatRunner) Close() error            { return nil }
+
+func TestRuntimeChatInjectsCurrentSpeakerIntoGroupTurnMessage(t *testing.T) {
+	mem := &recordingMemory{}
+	runner := &recordingChatRunner{system: "stable group system", events: []Event{{Text: "ok"}}}
+	var beforeRunSystems []string
+
+	rt, err := New(Config{
+		Memory: mem,
+		NewRunner: func(context.Context, RunnerParams) (Runner, error) {
+			return runner, nil
+		},
+		BeforeRun: func(_ context.Context, _ session.Info, _, _, system string, _ []ai.Message) (string, error) {
+			beforeRunSystems = append(beforeRunSystems, system)
+			return system, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+
+	info := session.Info{ID: "sess-1", UserID: "group-1", AgentID: "agent-1", GroupID: "group-1"}
+	out := make(chan Event, 10)
+	rt.chat(
+		memory.WithGroupSeq(context.Background(), 7),
+		out,
+		info,
+		"hello everyone",
+		chatOptions{currentSpeaker: memory.CurrentSpeaker{DisplayName: "Alice", UserID: "alice-user"}, hasSpeaker: true},
+	)
+	for range out { // drain
+	}
+
+	if len(beforeRunSystems) != 1 || beforeRunSystems[0] != "stable group system" {
+		t.Fatalf("before-run systems = %q, want stable base system", beforeRunSystems)
+	}
+	got := flattenRuntimeUserMessage(runner.message.(ai.UserMessage))
+	for _, want := range []string{"<current_speaker>", "Name: Alice", "Linked Stella user: yes", "hello everyone"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("model message missing %q:\n%s", want, got)
+		}
+	}
+	if len(mem.messages) == 0 {
+		t.Fatal("expected persisted group user message")
+	}
+	if persisted := flattenRuntimeUserMessage(mem.messages[0]); persisted != "hello everyone" {
+		t.Fatalf("persisted group user message = %q, want original user text only", persisted)
+	}
+}
+
+func TestWithCurrentSpeakerContextSupportsMultimodalContent(t *testing.T) {
+	msg := []ai.ContentBlock{
+		ai.ImageContent{Data: "abc", MimeType: "image/png"},
+		ai.TextContent{Text: "what is this?"},
+	}
+	got, ok := withCurrentSpeakerContext(msg, memory.CurrentSpeaker{DisplayName: "Bob"}).([]ai.ContentBlock)
+	if !ok {
+		t.Fatalf("speaker context content = %T, want []ai.ContentBlock", got)
+	}
+	if len(got) != 3 {
+		t.Fatalf("blocks = %d, want speaker prefix + original 2 blocks", len(got))
+	}
+	prefix, ok := got[0].(ai.TextContent)
+	if !ok || !strings.Contains(prefix.Text, "Name: Bob") || !strings.Contains(prefix.Text, "Linked Stella user: no") {
+		t.Fatalf("prefix block = %#v", got[0])
+	}
+	if got[1] != msg[0] || got[2] != msg[1] {
+		t.Fatalf("original blocks not preserved: %#v", got)
+	}
+}


### PR DESCRIPTION
## What

Move group `Current Speaker` context out of the system prompt rebuild path and inject it into each group turn message sent to the model.

## Why

Group chat currently rebuilds the full system prompt every turn only because the speaker changes. That makes the system prefix unstable, defeats prompt caching, and repeats expensive prompt/context work.

## How

- Remove the `## Current Speaker` section from the system prompt template.
- Stop `runtimeBeforeRunFunc` from rebuilding group system prompts just to add speaker context.
- Inject speaker context into the per-turn model message for group turns only.
- Keep persisted user messages clean: stored history does not include injected speaker metadata.
- Add regression tests for stable group system prompts, model-only speaker injection, and multimodal content preservation.

## Refs

Fixes #420
