### PR TITLE
fix: keep channel main session separate from project main

### DIFF
--- a/internal/agent/session/registry.go
+++ b/internal/agent/session/registry.go
@@ -161,13 +161,14 @@ func (r *Registry) ResolveMain(ctx context.Context, req MainRequest) (Info, erro
 
 	// Look for an existing main-kind session.
 	mains, err := r.store.list(ctx, req.UserID, agentID, memory.ListOptions{
-		Kind:    string(KindMain),
-		UserID:  req.UserID,
-		AgentID: agentID,
+		Kind:            string(KindMain),
+		UserID:          req.UserID,
+		AgentID:         agentID,
+		ProjectIDIsNull: true,
 	})
 	if err == nil {
 		for _, info := range mains {
-			if !info.Archived && info.ProjectID == "" {
+			if !info.Archived {
 				return info, nil
 			}
 		}

--- a/internal/agent/session/registry.go
+++ b/internal/agent/session/registry.go
@@ -168,9 +168,7 @@ func (r *Registry) ResolveMain(ctx context.Context, req MainRequest) (Info, erro
 	})
 	if err == nil {
 		for _, info := range mains {
-			if !info.Archived {
-				return info, nil
-			}
+			return info, nil
 		}
 	}
 

--- a/internal/agent/session/registry.go
+++ b/internal/agent/session/registry.go
@@ -167,7 +167,7 @@ func (r *Registry) ResolveMain(ctx context.Context, req MainRequest) (Info, erro
 	})
 	if err == nil {
 		for _, info := range mains {
-			if !info.Archived {
+			if !info.Archived && info.ProjectID == "" {
 				return info, nil
 			}
 		}

--- a/internal/agent/session/registry_test.go
+++ b/internal/agent/session/registry_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -331,5 +332,55 @@ func TestResolveMain_ReturnsExisting(t *testing.T) {
 	}
 	if info.ID != "main-1" {
 		t.Errorf("ID = %q, want main-1", info.ID)
+	}
+}
+
+func TestResolveMain_IgnoresProjectMainWhenAgentMainExists(t *testing.T) {
+	r, s := newTestRegistry(t)
+	now := time.Now().UTC()
+	projectMain := NewInfo("project-main-1", "agent1", "u1", "web", KindMain, "project-1", now.Add(time.Minute))
+	agentMain := NewInfo("agent-main-1", "agent1", "u1", "agent1:user:u1:private", KindMain, "", now)
+	s.sessions["project-main-1"] = projectMain
+	s.sessions["agent-main-1"] = agentMain
+
+	info, err := r.ResolveMain(context.Background(), MainRequest{
+		UserID:  "u1",
+		AgentID: "agent1",
+	})
+	if err != nil {
+		t.Fatalf("ResolveMain: %v", err)
+	}
+	if info.ID != "agent-main-1" {
+		t.Errorf("ID = %q, want agent-main-1", info.ID)
+	}
+	if info.ProjectID != "" {
+		t.Errorf("ProjectID = %q, want empty", info.ProjectID)
+	}
+}
+
+func TestResolveMain_CreatesAgentMainWhenOnlyProjectMainExists(t *testing.T) {
+	r, s := newTestRegistry(t)
+	now := time.Now().UTC()
+	projectMain := NewInfo("project-main-1", "agent1", "u1", "web", KindMain, "project-1", now)
+	s.sessions["project-main-1"] = projectMain
+
+	info, err := r.ResolveMain(context.Background(), MainRequest{
+		UserID:  "u1",
+		AgentID: "agent1",
+	})
+	if err != nil {
+		t.Fatalf("ResolveMain: %v", err)
+	}
+	if info.ID == "project-main-1" {
+		t.Fatal("ResolveMain reused project main as agent main")
+	}
+	if info.Kind != string(KindMain) {
+		t.Errorf("Kind = %q, want %q", info.Kind, KindMain)
+	}
+	if info.ProjectID != "" {
+		t.Errorf("ProjectID = %q, want empty", info.ProjectID)
+	}
+	if !strings.Contains(info.Channel, ":user:u1:") {
+		t.Errorf("Channel = %q, want private user channel", info.Channel)
 	}
 }

--- a/internal/agent/session/registry_test.go
+++ b/internal/agent/session/registry_test.go
@@ -47,6 +47,12 @@ func (f *fakeStore) list(_ context.Context, userID, agentID string, opts memory.
 		if opts.Kind != "" && info.Kind != opts.Kind {
 			continue
 		}
+		if opts.ProjectIDIsNull && info.ProjectID != "" {
+			continue
+		}
+		if opts.ProjectID != "" && info.ProjectID != opts.ProjectID {
+			continue
+		}
 		if !opts.IncludeArchived && info.Archived {
 			continue
 		}

--- a/internal/db/queries/ctx_conversation.sql
+++ b/internal/db/queries/ctx_conversation.sql
@@ -78,6 +78,7 @@ WHERE user_id = sqlc.arg(user_id)
   AND agent_id IS sqlc.narg(agent_id)
   AND (sqlc.arg(include_archived) != 0 OR archived = 0)
   AND (sqlc.narg(kind) IS NULL OR kind = sqlc.narg(kind))
+  AND (sqlc.arg(project_id_is_null) = 0 OR project_id IS NULL)
   AND (sqlc.narg(project_id) IS NULL OR project_id = sqlc.narg(project_id))
 ORDER BY last_active DESC
 LIMIT sqlc.arg(limit) OFFSET sqlc.arg(offset);
@@ -101,6 +102,7 @@ SELECT * FROM ctx_conversation
 WHERE agent_id = sqlc.arg(agent_id)
   AND archived = 0
   AND (sqlc.narg(kind) IS NULL OR kind = sqlc.narg(kind))
+  AND (sqlc.arg(project_id_is_null) = 0 OR project_id IS NULL)
   AND (sqlc.narg(project_id) IS NULL OR project_id = sqlc.narg(project_id))
 ORDER BY last_active DESC
 LIMIT sqlc.arg(limit) OFFSET sqlc.arg(offset);

--- a/internal/memory/lcm/provider_extra_test.go
+++ b/internal/memory/lcm/provider_extra_test.go
@@ -479,6 +479,7 @@ func TestLCMProvider_ListInfoFiltersInSQL(t *testing.T) {
 		{ID: "list-4", AgentID: "test", UserID: "1", Channel: "web", Kind: "chat", ProjectID: "p1", LastActive: base.Add(4 * time.Minute)},
 		{ID: "list-5", AgentID: "test", UserID: "1", Channel: "web", Kind: "chat", ProjectID: "p1", LastActive: base.Add(5 * time.Minute), Archived: true},
 		{ID: "list-6", AgentID: "test", UserID: "1", Channel: "web", Kind: "chat", ProjectID: "p1", LastActive: base.Add(6 * time.Minute)},
+		{ID: "list-7", AgentID: "test", UserID: "1", Channel: "web", Kind: "chat", LastActive: base.Add(7 * time.Minute)},
 	}
 	for _, info := range fixtures {
 		if err := p.SaveInfo(ctx, info); err != nil {
@@ -500,6 +501,14 @@ func TestLCMProvider_ListInfoFiltersInSQL(t *testing.T) {
 	}
 	if got, want := sessionIDs(infos), []string{"list-6", "list-5", "list-4"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("include archived IDs = %v, want %v", got, want)
+	}
+
+	infos, err = p.ListInfo(ctx, memory.ListOptions{Kind: "chat", ProjectIDIsNull: true})
+	if err != nil {
+		t.Fatalf("ListInfo project null: %v", err)
+	}
+	if got, want := sessionIDs(infos), []string{"list-7"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("project null IDs = %v, want %v", got, want)
 	}
 }
 
@@ -573,6 +582,7 @@ func TestLCMProvider_ListInfoForReviewFiltersInSQL(t *testing.T) {
 		{ID: "review-4", AgentID: "test", UserID: "2", Channel: "web", Kind: "chat", ProjectID: "p1", LastActive: base.Add(4 * time.Minute)},
 		{ID: "review-5", AgentID: "test", UserID: "1", Channel: "web", Kind: "chat", ProjectID: "p1", LastActive: base.Add(5 * time.Minute), Archived: true},
 		{ID: "review-6", AgentID: "test", UserID: "2", Channel: "web", Kind: "chat", ProjectID: "p1", LastActive: base.Add(6 * time.Minute)},
+		{ID: "review-7", AgentID: "test", UserID: "1", Channel: "web", Kind: "chat", LastActive: base.Add(7 * time.Minute)},
 	}
 	for _, info := range fixtures {
 		if err := p.SaveInfo(context.Background(), info); err != nil {
@@ -586,6 +596,14 @@ func TestLCMProvider_ListInfoForReviewFiltersInSQL(t *testing.T) {
 	}
 	if got, want := sessionIDs(infos), []string{"review-4", "review-1"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("review filtered IDs = %v, want %v", got, want)
+	}
+
+	infos, err = p.ListInfoForReview(context.Background(), memory.ListOptions{AgentID: "test", Kind: "chat", ProjectIDIsNull: true})
+	if err != nil {
+		t.Fatalf("ListInfoForReview project null: %v", err)
+	}
+	if got, want := sessionIDs(infos), []string{"review-7"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("review project null IDs = %v, want %v", got, want)
 	}
 }
 

--- a/internal/memory/lcm/sessions.go
+++ b/internal/memory/lcm/sessions.go
@@ -135,6 +135,7 @@ func (p *Provider) ListInfo(ctx context.Context, opts memory.ListOptions) ([]mem
 		AgentID:         nullAgent(agentIDValue),
 		IncludeArchived: boolToInt(opts.IncludeArchived),
 		Kind:            optionalString(opts.Kind),
+		ProjectIDIsNull: boolToInt(opts.ProjectIDIsNull),
 		ProjectID:       optionalString(opts.ProjectID),
 		Offset:          nonNegativeOffset(opts.Offset),
 		Limit:           listLimit(opts.Limit),
@@ -151,11 +152,12 @@ func (p *Provider) ListInfoForReview(ctx context.Context, opts memory.ListOption
 		return nil, fmt.Errorf("missing agent context")
 	}
 	convs, err := p.q.ListConversationsForReviewFiltered(ctx, sqlc.ListConversationsForReviewFilteredParams{
-		AgentID:   nullAgent(opts.AgentID),
-		Kind:      optionalString(opts.Kind),
-		ProjectID: optionalString(opts.ProjectID),
-		Offset:    nonNegativeOffset(opts.Offset),
-		Limit:     listLimit(opts.Limit),
+		AgentID:         nullAgent(opts.AgentID),
+		Kind:            optionalString(opts.Kind),
+		ProjectIDIsNull: boolToInt(opts.ProjectIDIsNull),
+		ProjectID:       optionalString(opts.ProjectID),
+		Offset:          nonNegativeOffset(opts.Offset),
+		Limit:           listLimit(opts.Limit),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("list review conversations: %w", err)

--- a/internal/memory/memorytest/fake.go
+++ b/internal/memory/memorytest/fake.go
@@ -421,6 +421,15 @@ func (f *Fake) ListInfo(_ context.Context, opts memory.ListOptions) ([]memory.Se
 		if opts.UserID != "" && si.info.UserID != opts.UserID {
 			continue
 		}
+		if opts.Kind != "" && si.info.Kind != opts.Kind {
+			continue
+		}
+		if opts.ProjectIDIsNull && si.info.ProjectID != "" {
+			continue
+		}
+		if opts.ProjectID != "" && si.info.ProjectID != opts.ProjectID {
+			continue
+		}
 		if !opts.IncludeArchived && si.info.Archived {
 			continue
 		}

--- a/internal/memory/types.go
+++ b/internal/memory/types.go
@@ -140,6 +140,7 @@ type ListOptions struct {
 	UserID          string // filter by user (empty = all)
 	Kind            string // filter by kind (empty = all)
 	ProjectID       string // filter by project (empty = all)
+	ProjectIDIsNull bool   // when true, require project_id IS NULL
 	IncludeArchived bool
 	Limit           int // 0 = no limit
 	Offset          int // skip first N matching results

--- a/pkg/db/sqlc/ctx_conversation.sql.go
+++ b/pkg/db/sqlc/ctx_conversation.sql.go
@@ -371,9 +371,10 @@ WHERE user_id = ?1
   AND agent_id IS ?2
   AND (?3 != 0 OR archived = 0)
   AND (?4 IS NULL OR kind = ?4)
-  AND (?5 IS NULL OR project_id = ?5)
+  AND (?5 = 0 OR project_id IS NULL)
+  AND (?6 IS NULL OR project_id = ?6)
 ORDER BY last_active DESC
-LIMIT ?7 OFFSET ?6
+LIMIT ?8 OFFSET ?7
 `
 
 type ListConversationsFilteredParams struct {
@@ -381,6 +382,7 @@ type ListConversationsFilteredParams struct {
 	AgentID         sql.NullString `json:"agent_id"`
 	IncludeArchived interface{}    `json:"include_archived"`
 	Kind            interface{}    `json:"kind"`
+	ProjectIDIsNull interface{}    `json:"project_id_is_null"`
 	ProjectID       interface{}    `json:"project_id"`
 	Offset          int64          `json:"offset"`
 	Limit           int64          `json:"limit"`
@@ -392,6 +394,7 @@ func (q *Queries) ListConversationsFiltered(ctx context.Context, arg ListConvers
 		arg.AgentID,
 		arg.IncludeArchived,
 		arg.Kind,
+		arg.ProjectIDIsNull,
 		arg.ProjectID,
 		arg.Offset,
 		arg.Limit,
@@ -480,23 +483,26 @@ SELECT id, session_id, title, channel, kind, project_id, archived, last_active, 
 WHERE agent_id = ?1
   AND archived = 0
   AND (?2 IS NULL OR kind = ?2)
-  AND (?3 IS NULL OR project_id = ?3)
+  AND (?3 = 0 OR project_id IS NULL)
+  AND (?4 IS NULL OR project_id = ?4)
 ORDER BY last_active DESC
-LIMIT ?5 OFFSET ?4
+LIMIT ?6 OFFSET ?5
 `
 
 type ListConversationsForReviewFilteredParams struct {
-	AgentID   sql.NullString `json:"agent_id"`
-	Kind      interface{}    `json:"kind"`
-	ProjectID interface{}    `json:"project_id"`
-	Offset    int64          `json:"offset"`
-	Limit     int64          `json:"limit"`
+	AgentID         sql.NullString `json:"agent_id"`
+	Kind            interface{}    `json:"kind"`
+	ProjectIDIsNull interface{}    `json:"project_id_is_null"`
+	ProjectID       interface{}    `json:"project_id"`
+	Offset          int64          `json:"offset"`
+	Limit           int64          `json:"limit"`
 }
 
 func (q *Queries) ListConversationsForReviewFiltered(ctx context.Context, arg ListConversationsForReviewFilteredParams) ([]CtxConversation, error) {
 	rows, err := q.db.QueryContext(ctx, listConversationsForReviewFiltered,
 		arg.AgentID,
 		arg.Kind,
+		arg.ProjectIDIsNull,
 		arg.ProjectID,
 		arg.Offset,
 		arg.Limit,


### PR DESCRIPTION
## What
Fix channel/private main-session resolution so it only returns the agent-level main conversation, never a project-scoped main conversation.

## Why
`ResolveMainSession` is used by private/channel entrypoints such as Feishu when a resolved channel maps to a per-user private session. The previous lookup accepted any unarchived `kind = main` row for the user and agent, including rows with `project_id IS NOT NULL`. That could attach channel chats to project context by mistake.

## How
- Require `ProjectID == ""` when selecting an existing main session in `session.Registry.ResolveMain`.
- Preserve the existing fallback behavior, which already rejects project sessions via `isMainCandidate`.
- Add regression tests for:
  - choosing the non-project agent main when a project main also exists;
  - creating a fresh non-project agent main when only a project main exists.

Targeted test run:

```text
MISE_DATA_DIR=/tmp/stella-mise-data MISE_CACHE_DIR=/tmp/stella-mise-cache mise exec -- go test ./internal/agent/session
```

Full `mise run format` was attempted but hit existing/generated-web issues and a Vite+ stdout panic unrelated to this Go-only change.

## Refs
Fixes #427
