### PR TITLE
Fix goal listing and recoverable rollup

### DIFF
--- a/api/spec/domain/goals/paths.yaml
+++ b/api/spec/domain/goals/paths.yaml
@@ -6,6 +6,12 @@ paths:
       operationId: listGoals
       parameters:
         - {
+            name: agent_id,
+            in: query,
+            required: false,
+            schema: { type: string },
+          }
+        - {
             name: page_size,
             in: query,
             schema: { type: integer, minimum: 1, maximum: 500, default: 20 },

--- a/internal/db/queries/agent_goal.sql
+++ b/internal/db/queries/agent_goal.sql
@@ -11,8 +11,13 @@ RETURNING *;
 -- name: GetAgentGoal :one
 SELECT * FROM agent_goal WHERE id = ?;
 
+-- Dispatcher rollup scan. Skip quiescent goals (done/cancelled) so the bounded
+-- window is spent only on goals rollup can still act on (running/blocked/failed
+-- and pre-run states). failed is intentionally included - it is recoverable.
 -- name: ListAgentGoals :many
-SELECT * FROM agent_goal ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?;
+SELECT * FROM agent_goal
+WHERE status NOT IN ('done', 'cancelled')
+ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?;
 
 -- name: ListAgentGoalsByUser :many
 SELECT * FROM agent_goal WHERE user_id = ? ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?;

--- a/internal/server/goals.go
+++ b/internal/server/goals.go
@@ -35,7 +35,7 @@ func (s *Server) loadGoal(ctx context.Context, w http.ResponseWriter, userID, go
 	return g, true
 }
 
-// ListGoals returns all goals.
+// ListGoals returns goals owned by the current user, optionally filtered by agent.
 func (s *Server) ListGoals(w http.ResponseWriter, r *http.Request, params apiserver.ListGoalsParams) {
 	if !s.tasksReady() {
 		writeError(w, http.StatusServiceUnavailable, "task_service_unavailable")
@@ -50,9 +50,20 @@ func (s *Server) ListGoals(w http.ResponseWriter, r *http.Request, params apiser
 		writeError(w, http.StatusBadRequest, "invalid pagination parameters")
 		return
 	}
-	var rows []sqlc.AgentGoal
+	agentID := ""
+	if params.AgentId != nil {
+		agentID = *params.AgentId
+	}
 	if info.Scoped != nil {
-		rows, err = s.tasksSvc.Facade.ListGoalsByAgent(r.Context(), info.UserID, info.Scoped.AgentID, int64(limit+1), int64(offset))
+		if agentID != "" && agentID != info.Scoped.AgentID {
+			writeError(w, http.StatusForbidden, "permission denied")
+			return
+		}
+		agentID = info.Scoped.AgentID
+	}
+	var rows []sqlc.AgentGoal
+	if agentID != "" {
+		rows, err = s.tasksSvc.Facade.ListGoalsByAgent(r.Context(), info.UserID, agentID, int64(limit+1), int64(offset))
 	} else {
 		rows, err = s.tasksSvc.Facade.ListGoals(r.Context(), info.UserID, int64(limit+1), int64(offset))
 	}

--- a/internal/server/tasks_test.go
+++ b/internal/server/tasks_test.go
@@ -8,6 +8,7 @@ import (
 
 	apitypes "github.com/CherryHQ/stella/api/types"
 	"github.com/CherryHQ/stella/internal/auth"
+	"github.com/CherryHQ/stella/internal/config"
 	"github.com/CherryHQ/stella/internal/tasks"
 )
 
@@ -367,6 +368,45 @@ func TestGoals_CreateGetRoundTrip(t *testing.T) {
 	rr = doRequest(t, env, http.MethodGet, "/api/goals/"+goal.Id, nil)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("get: %d %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestGoals_ListFiltersByAgentID(t *testing.T) {
+	env := setupAdmin(t)
+	withTasks(t, env)
+
+	firstAgentID := taskTestAgentID(t, env)
+	secondAgentID := createTestAgent(t, env, config.Agent{Name: "goals-second-agent"})
+
+	createGoal := func(title, agentID string) apitypes.Goal {
+		t.Helper()
+		body := apitypes.CreateGoalRequest{Title: title, AgentId: agentID}
+		rr := doRequest(t, env, http.MethodPost, "/api/goals", body)
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("create %s: status=%d body=%s", title, rr.Code, rr.Body.String())
+		}
+		var goal apitypes.Goal
+		if err := json.Unmarshal(rr.Body.Bytes(), &goal); err != nil {
+			t.Fatalf("decode goal: %v", err)
+		}
+		return goal
+	}
+	first := createGoal("first-agent-goal", firstAgentID)
+	second := createGoal("second-agent-goal", secondAgentID)
+
+	rr := doRequest(t, env, http.MethodGet, "/api/goals?agent_id="+secondAgentID, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("list: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var list apitypes.GoalList
+	if err := json.Unmarshal(rr.Body.Bytes(), &list); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(list.Goals) != 1 || list.Goals[0].Id != second.Id {
+		t.Fatalf("filtered goals=%+v want only %s", list.Goals, second.Id)
+	}
+	if list.Goals[0].Id == first.Id {
+		t.Fatalf("agent filter leaked first agent goal %s", first.Id)
 	}
 }
 

--- a/internal/tasks/dispatcher_goals.go
+++ b/internal/tasks/dispatcher_goals.go
@@ -19,7 +19,7 @@ func (d *Dispatcher) rollupGoals(ctx context.Context, _ time.Time) {
 		return
 	}
 	for _, g := range goals {
-		if g.Status == GoalStatusDone || g.Status == GoalStatusCancelled {
+		if isQuiescentGoalStatus(g.Status) {
 			continue
 		}
 		d.rollupOneGoal(ctx, g)

--- a/internal/tasks/dispatcher_goals.go
+++ b/internal/tasks/dispatcher_goals.go
@@ -8,7 +8,7 @@ import (
 	"github.com/CherryHQ/stella/pkg/db/sqlc"
 )
 
-// rollupGoals iterates non-terminal goals and applies RollupGoal's verdict.
+// rollupGoals iterates active or recoverable goals and applies RollupGoal's verdict.
 // Driven from the dispatcher tick.
 func (d *Dispatcher) rollupGoals(ctx context.Context, _ time.Time) {
 	goals, err := d.cfg.Queries.ListAgentGoals(ctx, sqlc.ListAgentGoalsParams{
@@ -19,7 +19,7 @@ func (d *Dispatcher) rollupGoals(ctx context.Context, _ time.Time) {
 		return
 	}
 	for _, g := range goals {
-		if isTerminalGoalStatus(g.Status) {
+		if g.Status == GoalStatusDone || g.Status == GoalStatusCancelled {
 			continue
 		}
 		d.rollupOneGoal(ctx, g)
@@ -44,7 +44,8 @@ func (d *Dispatcher) rollupOneGoal(ctx context.Context, g sqlc.AgentGoal) {
 	case GoalStatusBlocked:
 		_ = d.cfg.Service.BlockGoal(ctx, g.ID, next.Reason, SystemActor())
 	case GoalStatusRunning:
-		// Recovery: a blocked goal whose children unblocked returns to running.
+		// Recovery: a blocked or failed goal whose children no longer justify the
+		// blocked/failed state returns to running.
 		_ = d.cfg.Service.UnblockGoal(ctx, g.ID, next.Reason, SystemActor())
 	}
 	// D8: SpawnSynthesizer stays dormant in this slice. RollupGoal still

--- a/internal/tasks/dispatcher_goals_test.go
+++ b/internal/tasks/dispatcher_goals_test.go
@@ -17,6 +17,38 @@ func TestDispatcher_RollupGoals_CompletesWhenAllChildrenDoneNoPolicy(t *testing.
 	}
 }
 
+func TestDispatcher_RollupGoals_FailedGoalRecoversWhenChildCompletes(t *testing.T) {
+	h, d := newDispatcherHarness(t, nil)
+	gid := h.createGoal(t, GoalStatusFailed, ReviewPolicyNone)
+	child := h.createChildTask(t, gid, StatusFailed)
+
+	goalStatus := func() string {
+		g, _ := h.q.GetAgentGoal(context.Background(), gid)
+		return g.Status
+	}
+
+	// A still-failed required child keeps the goal failed.
+	d.Tick(context.Background())
+	d.WaitIdle()
+	if got := goalStatus(); got != GoalStatusFailed {
+		t.Fatalf("with failed child: goal=%q want failed", got)
+	}
+
+	// Operational failure was reconciled elsewhere: the child is now complete.
+	if _, err := h.db.ExecContext(context.Background(),
+		`UPDATE agent_task SET status = 'done' WHERE id = ?`, child); err != nil {
+		t.Fatalf("complete child: %v", err)
+	}
+
+	// The next rollup should recover the parent all the way to done instead of
+	// leaving it permanently stuck in failed.
+	d.Tick(context.Background())
+	d.WaitIdle()
+	if got := goalStatus(); got != GoalStatusDone {
+		t.Fatalf("after child completion: goal=%q want done", got)
+	}
+}
+
 // A goal blocked by a required child recovers once that child's blocker is
 // resolved (child returns to ready). Rollup unblocks the goal on the next
 // tick and the goal completes after the child finishes.

--- a/internal/tasks/dispatcher_goals_test.go
+++ b/internal/tasks/dispatcher_goals_test.go
@@ -49,6 +49,66 @@ func TestDispatcher_RollupGoals_FailedGoalRecoversWhenChildCompletes(t *testing.
 	}
 }
 
+// The realistic #425 recovery path: a failed required child is reopened (back
+// to ready/pending), not completed in place. Rollup must take the failed goal
+// through running (UnblockGoal) before it can complete on a later tick.
+func TestDispatcher_RollupGoals_FailedGoalRecoversToRunningWhenChildReopens(t *testing.T) {
+	h, d := newDispatcherHarness(t, submitExec())
+	gid := h.createGoal(t, GoalStatusFailed, ReviewPolicyNone)
+	child := h.createChildTask(t, gid, StatusFailed)
+
+	goalStatus := func() string {
+		g, _ := h.q.GetAgentGoal(context.Background(), gid)
+		return g.Status
+	}
+
+	// Tick 1: a still-failed required child keeps the goal failed.
+	d.Tick(context.Background())
+	d.WaitIdle()
+	if got := goalStatus(); got != GoalStatusFailed {
+		t.Fatalf("with failed child: goal=%q want failed", got)
+	}
+
+	// The failed child is reopened and returns to ready (pending), not done.
+	if _, err := h.db.ExecContext(context.Background(),
+		`UPDATE agent_task SET status = 'ready' WHERE id = ?`, child); err != nil {
+		t.Fatalf("reopen child: %v", err)
+	}
+
+	// Tick 2: rollup runs before dispatch, sees a pending required child, and
+	// recovers the goal to running via UnblockGoal (failed -> running). The
+	// child is then dispatched and submits.
+	d.Tick(context.Background())
+	d.WaitIdle()
+	if got := goalStatus(); got != GoalStatusRunning {
+		t.Fatalf("after reopen: goal=%q want running", got)
+	}
+
+	// Tick 3: the recovered child is done -> goal completes.
+	d.Tick(context.Background())
+	d.WaitIdle()
+	if got := goalStatus(); got != GoalStatusDone {
+		t.Fatalf("after completion tick: goal=%q want done", got)
+	}
+}
+
+// A cancelled required child can never be reopened, so a goal whose remaining
+// required children are {done, cancelled} must fail rather than silently
+// reporting success.
+func TestDispatcher_RollupGoals_CancelledRequiredChildFailsGoal(t *testing.T) {
+	h, d := newDispatcherHarness(t, nil)
+	gid := h.createGoal(t, GoalStatusRunning, ReviewPolicyNone)
+	h.createChildTask(t, gid, StatusDone)
+	h.createChildTask(t, gid, StatusCancelled)
+
+	d.Tick(context.Background())
+	d.WaitIdle()
+	goal, _ := h.q.GetAgentGoal(context.Background(), gid)
+	if goal.Status != GoalStatusFailed {
+		t.Fatalf("goal with a cancelled required child: status=%q want failed", goal.Status)
+	}
+}
+
 // A goal blocked by a required child recovers once that child's blocker is
 // resolved (child returns to ready). Rollup unblocks the goal on the next
 // tick and the goal completes after the child finishes.

--- a/internal/tasks/goal_rollup.go
+++ b/internal/tasks/goal_rollup.go
@@ -37,15 +37,16 @@ type GoalNextState struct {
 // run is already in flight). Caller (dispatcher.rollupGoals) translates the
 // outcome into a transition call.
 func RollupGoal(goal sqlc.AgentGoal, counts sqlc.GoalChildCountsRow, hasOpenSynth bool) GoalNextState {
-	// Terminal / quiescent states are not rolled. 'blocked' is intentionally
-	// NOT quiescent: a blocked goal must keep rolling so it recovers once its
-	// children unblock. The caller skips no-op transitions (target == current).
+	// Terminal / quiescent states are not rolled. 'blocked' and 'failed' are
+	// intentionally NOT quiescent: a blocked goal must recover once children
+	// unblock, and a failed goal must recover when a failed required child is
+	// later reopened, retried, or completed.
 	switch goal.Status {
-	case GoalStatusDone, GoalStatusFailed, GoalStatusCancelled,
+	case GoalStatusDone, GoalStatusCancelled,
 		GoalStatusReviewing, GoalStatusDraft, GoalStatusPlanning:
 		return GoalNextState{}
 	}
-	// goal.Status is running or blocked from here on.
+	// goal.Status is running, blocked, or failed from here on.
 
 	done := nullFloatToInt(counts.RequiredDone)
 	failed := nullFloatToInt(counts.RequiredFailed)

--- a/internal/tasks/goal_rollup.go
+++ b/internal/tasks/goal_rollup.go
@@ -65,6 +65,14 @@ func RollupGoal(goal sqlc.AgentGoal, counts sqlc.GoalChildCountsRow, hasOpenSynt
 	if failed > 0 {
 		return GoalNextState{NextStatus: GoalStatusFailed, Reason: "required_child_failed"}
 	}
+	if cancelled > 0 {
+		// A cancelled required child can never be reopened (D10), so the
+		// requirement is permanently unmet. Fail the goal rather than letting it
+		// fall through to "all required done" and vacuously complete when the
+		// only non-done required children were abandoned. Explicit CompleteGoal
+		// stays available to override.
+		return GoalNextState{NextStatus: GoalStatusFailed, Reason: "required_child_cancelled"}
+	}
 	if blocked > 0 {
 		return GoalNextState{NextStatus: GoalStatusBlocked, Reason: "required_child_blocked"}
 	}

--- a/internal/tasks/goal_rollup_test.go
+++ b/internal/tasks/goal_rollup_test.go
@@ -62,3 +62,41 @@ func TestRollupGoal(t *testing.T) {
 		})
 	}
 }
+
+// A cancelled required child can never be reopened, so it must not let a goal
+// vacuously complete: the goal fails instead of falling through to "all done".
+func TestRollupGoal_CancelledRequiredChild(t *testing.T) {
+	f := func(v int) sql.NullFloat64 { return sql.NullFloat64{Float64: float64(v), Valid: true} }
+	row := func(done, failed, cancelled, blocked, pending int) sqlc.GoalChildCountsRow {
+		return sqlc.GoalChildCountsRow{
+			RequiredDone: f(done), RequiredFailed: f(failed), RequiredCancelled: f(cancelled),
+			RequiredBlocked: f(blocked), RequiredPending: f(pending),
+		}
+	}
+	tests := []struct {
+		name       string
+		goalStatus string
+		counts     sqlc.GoalChildCountsRow
+		wantNext   string
+		wantReason string
+	}{
+		{"running-done-plus-cancelled", GoalStatusRunning, row(1, 0, 1, 0, 0), GoalStatusFailed, "required_child_cancelled"},
+		{"running-only-cancelled", GoalStatusRunning, row(0, 0, 1, 0, 0), GoalStatusFailed, "required_child_cancelled"},
+		{"failed-done-plus-cancelled-stays-failed", GoalStatusFailed, row(1, 0, 1, 0, 0), GoalStatusFailed, "required_child_cancelled"},
+		{"failed-beats-cancelled", GoalStatusRunning, row(0, 1, 1, 0, 0), GoalStatusFailed, "required_child_failed"},
+		{"cancelled-beats-blocked", GoalStatusRunning, row(0, 0, 1, 1, 0), GoalStatusFailed, "required_child_cancelled"},
+		{"cancelled-beats-pending", GoalStatusRunning, row(0, 0, 1, 0, 1), GoalStatusFailed, "required_child_cancelled"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			goal := sqlc.AgentGoal{Status: tc.goalStatus, ReviewPolicy: ReviewPolicyNone}
+			got := RollupGoal(goal, tc.counts, false)
+			if got.NextStatus != tc.wantNext {
+				t.Errorf("NextStatus=%q want %q", got.NextStatus, tc.wantNext)
+			}
+			if got.Reason != tc.wantReason {
+				t.Errorf("Reason=%q want %q", got.Reason, tc.wantReason)
+			}
+		})
+	}
+}

--- a/internal/tasks/goal_transitions.go
+++ b/internal/tasks/goal_transitions.go
@@ -79,7 +79,7 @@ func (s *TransitionService) CompleteGoal(ctx context.Context, goalID, output str
 		if err != nil {
 			return err
 		}
-		if isTerminalGoalStatus(goal.Status) {
+		if goal.Status == GoalStatusDone || goal.Status == GoalStatusCancelled {
 			return ErrInvalidTransition
 		}
 		now := s.now()
@@ -235,22 +235,23 @@ func (s *TransitionService) BlockGoal(ctx context.Context, goalID, reason string
 	})
 }
 
-// UnblockGoal recovers a goal from blocked back to running once no required
-// child is blocked or failed. Mirror of BlockGoal; driven by rollup when a
-// child blocker is resolved or the failed dependency is waived. The goal then
-// resumes normal rollup (completing or re-blocking) on subsequent ticks.
+// UnblockGoal recovers a goal from blocked or failed back to running once no
+// required child is blocked or failed. Mirror of BlockGoal; driven by rollup
+// when a child blocker is resolved, a failed child is reopened/completed, or a
+// failed dependency is waived. The goal then resumes normal rollup (completing
+// or re-blocking) on subsequent ticks.
 func (s *TransitionService) UnblockGoal(ctx context.Context, goalID, reason string, actor Actor) error {
 	return s.withTx(ctx, func(q *sqlc.Queries) error {
 		goal, err := getGoalForUpdate(ctx, q, goalID)
 		if err != nil {
 			return err
 		}
-		if goal.Status != GoalStatusBlocked {
+		if goal.Status != GoalStatusBlocked && goal.Status != GoalStatusFailed {
 			return ErrInvalidTransition
 		}
 		now := s.now()
 		n, err := q.TransitionAgentGoalStatus(ctx, sqlc.TransitionAgentGoalStatusParams{
-			Status: GoalStatusRunning, UpdatedAt: now, ID: goalID, Status_2: GoalStatusBlocked,
+			Status: GoalStatusRunning, UpdatedAt: now, ID: goalID, Status_2: goal.Status,
 		})
 		if err != nil {
 			return err
@@ -258,7 +259,7 @@ func (s *TransitionService) UnblockGoal(ctx context.Context, goalID, reason stri
 		if n == 0 {
 			return ErrInvalidTransition
 		}
-		return s.appendGoalEvent(ctx, q, goalID, "goal_unblock", GoalStatusBlocked, GoalStatusRunning, actor,
+		return s.appendGoalEvent(ctx, q, goalID, "goal_unblock", goal.Status, GoalStatusRunning, actor,
 			map[string]any{"reason": reason})
 	})
 }

--- a/internal/tasks/goal_transitions.go
+++ b/internal/tasks/goal_transitions.go
@@ -79,7 +79,7 @@ func (s *TransitionService) CompleteGoal(ctx context.Context, goalID, output str
 		if err != nil {
 			return err
 		}
-		if goal.Status == GoalStatusDone || goal.Status == GoalStatusCancelled {
+		if isQuiescentGoalStatus(goal.Status) {
 			return ErrInvalidTransition
 		}
 		now := s.now()
@@ -273,7 +273,7 @@ func (s *TransitionService) CompleteGoalTx(ctx context.Context, q *sqlc.Queries,
 	if err != nil {
 		return err
 	}
-	if isTerminalGoalStatus(goal.Status) {
+	if isQuiescentGoalStatus(goal.Status) {
 		return ErrInvalidTransition
 	}
 	n, err := q.TransitionAgentGoalStatus(ctx, sqlc.TransitionAgentGoalStatusParams{
@@ -318,8 +318,18 @@ func getGoalForUpdate(ctx context.Context, q *sqlc.Queries, goalID string) (sqlc
 	return g, nil
 }
 
-// isTerminalGoalStatus reports whether a goal status forbids further
-// transitions.
+// isQuiescentGoalStatus reports whether rollup and completion leave a goal
+// untouched. Only done and cancelled are final for these purposes; failed is
+// recoverable — a reopened or completed required child rolls a failed goal
+// back to running or done (see RollupGoal and UnblockGoal).
+func isQuiescentGoalStatus(s string) bool {
+	return s == GoalStatusDone || s == GoalStatusCancelled
+}
+
+// isTerminalGoalStatus reports whether a goal has reached an outcome that the
+// fail/cancel/new-task-context guards refuse to act on. Unlike
+// isQuiescentGoalStatus this includes failed: those guards still treat a failed
+// goal as finished even though rollup can recover it.
 func isTerminalGoalStatus(s string) bool {
 	switch s {
 	case GoalStatusDone, GoalStatusFailed, GoalStatusCancelled:

--- a/internal/tasks/service_facade.go
+++ b/internal/tasks/service_facade.go
@@ -170,6 +170,11 @@ func (f *ServiceFacade) resolveTaskContext(ctx context.Context, in CreateTaskInp
 		if goal.UserID != in.UserID {
 			return "", "", ErrGoalNotFound
 		}
+		// A failed goal is recoverable by rollup, but only by reopening or
+		// completing its existing children — not by attaching new work. Keep it
+		// terminal for task creation so a goal cannot sit failed while accepting
+		// fresh tasks; reopen a failed child (which recovers the goal to running)
+		// before adding more. See isTerminalGoalStatus vs isQuiescentGoalStatus.
 		if isTerminalGoalStatus(goal.Status) {
 			return "", "", fmt.Errorf("%w: goal is %s and accepts no new tasks", ErrInvalidTaskContext, goal.Status)
 		}

--- a/pkg/db/sqlc/agent_goal.sql.go
+++ b/pkg/db/sqlc/agent_goal.sql.go
@@ -140,7 +140,9 @@ func (q *Queries) GoalChildCounts(ctx context.Context, goalID sql.NullString) (G
 }
 
 const listAgentGoals = `-- name: ListAgentGoals :many
-SELECT id, user_id, agent_id, project_id, title, description, status, priority, review_policy, active_review_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_goal ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?
+SELECT id, user_id, agent_id, project_id, title, description, status, priority, review_policy, active_review_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_goal
+WHERE status NOT IN ('done', 'cancelled')
+ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?
 `
 
 type ListAgentGoalsParams struct {
@@ -148,6 +150,9 @@ type ListAgentGoalsParams struct {
 	Offset int64 `json:"offset"`
 }
 
+// Dispatcher rollup scan. Skip quiescent goals (done/cancelled) so the bounded
+// window is spent only on goals rollup can still act on (running/blocked/failed
+// and pre-run states). failed is intentionally included - it is recoverable.
 func (q *Queries) ListAgentGoals(ctx context.Context, arg ListAgentGoalsParams) ([]AgentGoal, error) {
 	rows, err := q.db.QueryContext(ctx, listAgentGoals, arg.Limit, arg.Offset)
 	if err != nil {

--- a/web/content/docs/development/goal-system.md
+++ b/web/content/docs/development/goal-system.md
@@ -45,6 +45,8 @@ stateDiagram-v2
     running --> failed: required child failed
     running --> blocked: required child blocked
     blocked --> running: child unblocks (UnblockGoal)
+    failed --> running: required child reopened (UnblockGoal)
+    failed --> done: required child completed (CompleteGoal)
     draft --> cancelled: CancelGoal
     running --> cancelled: CancelGoal
     blocked --> cancelled: CancelGoal
@@ -65,24 +67,25 @@ RollupGoal(goal, childCounts, hasOpenSynth) GoalNextState
 
 For supported `review_policy=none` goals:
 
-| Child state                                  | Verdict                                                                          |
-| -------------------------------------------- | -------------------------------------------------------------------------------- |
-| Any required child failed                    | Goal → `failed` with reason `required_child_failed`.                             |
-| Any required child blocked                   | Goal → `blocked` with reason `required_child_blocked`.                           |
-| Any required child pending/running/reviewing | Goal → `running` (no-op for an already-running goal; recovers a `blocked` goal). |
-| All required children done                   | Goal → `done`.                                                                   |
+| Child state                                  | Verdict                                                                                                                                 |
+| -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Any required child failed                    | Goal → `failed` with reason `required_child_failed`.                                                                                    |
+| Any required child cancelled                 | Goal → `failed` with reason `required_child_cancelled` (a cancelled child cannot be reopened, so the requirement is permanently unmet). |
+| Any required child blocked                   | Goal → `blocked` with reason `required_child_blocked`.                                                                                  |
+| Any required child pending/running/reviewing | Goal → `running` (no-op for an already-running goal; recovers a `blocked` or `failed` goal).                                            |
+| All required children done                   | Goal → `done`.                                                                                                                          |
 
-A `blocked` goal keeps rolling up, so resolving a child blocker (or waiving its failed dependency) returns the goal to `running` on the next tick via `UnblockGoal` — there is no separate goal-unblock action. The dispatcher skips no-op transitions where the rolled-up target equals the current status.
+A `blocked` or `failed` goal keeps rolling up, so it can recover: clearing a child blocker, or reopening/completing a failed required child, returns the goal to `running` via `UnblockGoal` (or straight to `done` via `CompleteGoal` when every required child is already done) on a later tick — there is no separate goal-unblock action. The dispatcher skips no-op transitions where the rolled-up target equals the current status, so a goal that stays failed produces no churn. A `cancelled` required child does not recover the goal: it re-asserts `failed`, since cancelled tasks cannot be reopened. A failed goal accepts no new child tasks — recovery is reopen-based, so reopen an existing failed child (which returns the goal to `running`) before attaching more work.
 
 For `review_policy=auto`, `agent`, or `human`, the API rejects goal creation/activation in this release. Final synthesis and goal review require a future synthesizer runtime.
 
 ## Dispatcher behavior
 
-The supported dispatcher goal behavior is rollup only:
+The supported dispatcher goal behavior is rollup only. Within one tick:
 
-1. Task-side dispatcher steps run first: stale-run interruption, dependency failure propagation, worker task dispatch.
-2. `rollupGoals` evaluates non-terminal goals.
-3. Rollup applies goal complete/fail/block transitions when child task state requires it.
+1. Stale-run interruption and dependency-failure propagation run first.
+2. `rollupGoals` evaluates active or recoverable goals (everything except `done`/`cancelled`) and applies goal complete/fail/block/unblock transitions when child task state requires it.
+3. Worker task dispatch runs last, so a goal recovered to `running` in step 2 has its newly-ready children dispatched in the same tick.
 
 Planner, synthesizer, and agent-reviewer dispatch scan paths are removed rather than left as noop failure paths. Unsupported goal modes are stopped at API validation.
 

--- a/web/content/docs/development/goal-system.zh.md
+++ b/web/content/docs/development/goal-system.zh.md
@@ -45,6 +45,8 @@ stateDiagram-v2
     running --> failed: required child 失败
     running --> blocked: required child 被阻塞
     blocked --> running: child 解除阻塞 (UnblockGoal)
+    failed --> running: required child 被重开 (UnblockGoal)
+    failed --> done: required child 完成 (CompleteGoal)
     draft --> cancelled: CancelGoal
     running --> cancelled: CancelGoal
     blocked --> cancelled: CancelGoal
@@ -65,24 +67,25 @@ RollupGoal(goal, childCounts, hasOpenSynth) GoalNextState
 
 对支持的 `review_policy=none` goals：
 
-| 子任务状态                               | 结论                                                                          |
-| ---------------------------------------- | ----------------------------------------------------------------------------- |
-| 任一必需子任务 failed                    | Goal → `failed`，reason 为 `required_child_failed`。                          |
-| 任一必需子任务 blocked                   | Goal → `blocked`，reason 为 `required_child_blocked`。                        |
-| 任一必需子任务 pending/running/reviewing | Goal → `running`（对已 running 的 goal 是 no-op；可让 `blocked` goal 恢复）。 |
-| 所有必需子任务 done                      | Goal → `done`。                                                               |
+| 子任务状态                               | 结论                                                                                                  |
+| ---------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| 任一必需子任务 failed                    | Goal → `failed`，reason 为 `required_child_failed`。                                                  |
+| 任一必需子任务 cancelled                 | Goal → `failed`，reason 为 `required_child_cancelled`（cancelled 子任务无法重开，要求永久无法满足）。 |
+| 任一必需子任务 blocked                   | Goal → `blocked`，reason 为 `required_child_blocked`。                                                |
+| 任一必需子任务 pending/running/reviewing | Goal → `running`（对已 running 的 goal 是 no-op；可让 `blocked` 或 `failed` goal 恢复）。             |
+| 所有必需子任务 done                      | Goal → `done`。                                                                                       |
 
-`blocked` goal 会持续 rollup，因此解决子任务的 blocker（或 waive 其失败依赖）会在下一个 tick 通过 `UnblockGoal` 让 goal 回到 `running`——不需要单独的 goal-unblock 操作。当 rollup 算出的目标状态与当前状态相同时，dispatcher 会跳过这个 no-op transition。
+`blocked` 或 `failed` goal 会持续 rollup，因此可以恢复：清除子任务的 blocker，或重开/完成一个失败的必需子任务，会在后续 tick 通过 `UnblockGoal` 让 goal 回到 `running`（当所有必需子任务都已 done 时，则通过 `CompleteGoal` 直接到 `done`）——不需要单独的 goal-unblock 操作。当 rollup 算出的目标状态与当前状态相同时，dispatcher 会跳过这个 no-op transition，因此停留在 failed 的 goal 不会产生抖动。被 cancelled 的必需子任务不会让 goal 恢复：它会重新判定为 `failed`，因为 cancelled 任务无法重开。failed goal 不接受新增 child task——恢复是基于 reopen 的，所以请先重开一个已失败的子任务（让 goal 回到 `running`）再附加新工作。
 
 对 `review_policy=auto`、`agent` 或 `human`，本版本 API 会拒绝 goal 创建/激活。最终 synthesis 和 goal review 需要未来的 synthesizer runtime。
 
 ## Dispatcher 行为
 
-当前支持的 dispatcher goal 行为只有 rollup：
+当前支持的 dispatcher goal 行为只有 rollup。单个 tick 内：
 
-1. 先运行 task 侧 dispatcher 步骤：stale-run interruption、dependency failure propagation、worker task dispatch。
-2. `rollupGoals` 评估非终止 goals。
-3. Rollup 根据 child task 状态应用 goal complete/fail/block transitions。
+1. 先运行 stale-run interruption 与 dependency failure propagation。
+2. `rollupGoals` 评估活跃或可恢复的 goals（除 `done`/`cancelled` 外的全部），并在 child task 状态要求时应用 goal complete/fail/block/unblock transitions。
+3. 最后运行 worker task dispatch，因此第 2 步中恢复到 `running` 的 goal，其新就绪的子任务会在同一个 tick 内被派发。
 
 Planner、synthesizer 和 agent-reviewer dispatch scan paths 已删除，不再保留为 noop failure paths。Unsupported goal modes 通过 API validation 拦截。
 

--- a/web/src/lib/paginated.ts
+++ b/web/src/lib/paginated.ts
@@ -37,12 +37,12 @@ export async function fetchAllTasks(
   return all;
 }
 
-export async function fetchAllGoals(): Promise<ComponentsGoal[]> {
+export async function fetchAllGoals(agentId?: string): Promise<ComponentsGoal[]> {
   const all: ComponentsGoal[] = [];
   let pageToken: string | undefined;
   do {
     const { data } = await listGoals({
-      query: { page_size: 500, page_token: pageToken },
+      query: { agent_id: agentId, page_size: 500, page_token: pageToken },
       throwOnError: true,
     });
     all.push(...(data?.goals ?? []));

--- a/web/src/lib/queries/goals.ts
+++ b/web/src/lib/queries/goals.ts
@@ -13,10 +13,7 @@ import {
 export function goalsOptions(agentId: string) {
   return queryOptions({
     queryKey: ["goals", agentId],
-    queryFn: async () => {
-      const items = await fetchAllGoals();
-      return items.filter((g) => !agentId || g.agent_id === agentId);
-    },
+    queryFn: async () => fetchAllGoals(agentId),
     enabled: !!agentId,
   });
 }


### PR DESCRIPTION
## What

- Add explicit `agent_id` filtering to `GET /api/goals` and pass the selected agent from the Web UI goals query.
- Make goal rollup recover failed goals when required children are later reconciled, reopened, or completed.
- Fail a goal whose required child was **cancelled** instead of silently completing it (review-driven correctness fix).
- Unify the goal-quiescence predicate so "failed is recoverable" has one source of truth, and skip terminal goals in the dispatcher rollup scan.
- Add regression coverage for agent-filtered goal listing, recoverable failed-goal rollup (incl. the `failed → running` reopen path), and the cancelled-child case.
- Document the failed-goal recovery model in `goal-system.md` / `.zh.md`.

## Why

Goals could disappear from the selected agent page because the UI fetched all goals and filtered in the browser while the API only supported implicit scoped-agent behavior. That made visibility depend on request context instead of an explicit list filter.

Goal rollup also treated `failed` as permanently terminal. If a required child failed because of an operational worker/protocol issue and was later completed elsewhere, the parent goal stayed failed forever even though the objective was done.

A multi-perspective review of the recoverable-rollup change surfaced a latent correctness gap: `RollupGoal` computed `required_cancelled` but never branched on it, so a goal whose only non-done required children were **cancelled** fell through to "all required done" and was silently marked `done` with a success output. Making failed goals re-enter rollup widened the reachability of that path. A cancelled task can never be reopened (D10), so the requirement is permanently unmet — the goal must fail. The review also flagged that "done/cancelled are final" was open-coded in several spots while `isTerminalGoalStatus` still counted `failed`, leaving two unnamed, drift-prone definitions of "terminal".

## How

- Extend the goals OpenAPI path with an optional `agent_id` query parameter.
- Update `ListGoals` to apply explicit agent filtering, while still enforcing scoped-auth agent permissions.
- Update `fetchAllGoals(agentId)` and `goalsOptions(agentId)` to request the selected agent server-side instead of filtering client-side.
- Let rollup evaluate failed goals as recoverable state; allow `UnblockGoal` to recover from both `blocked` and `failed`, and rollup completion to transition a reconciled failed goal to `done`.
- Add a `required_child_cancelled` rollup branch so a cancelled required child fails the goal rather than vacuously completing it.
- Extract `isQuiescentGoalStatus` (`{done, cancelled}`) for the rollup/completion guards (dispatcher loop, `CompleteGoal`, `CompleteGoalTx` — which had diverged and still rejected `failed`); keep `isTerminalGoalStatus` (`{done, failed, cancelled}`) for the fail/cancel/new-task guards and correct its doc.
- Skip `done`/`cancelled` goals in the dispatcher rollup scan query so the bounded window isn't spent on terminal goals.
- Document the recovery model (state-diagram edges, cancelled-child row, reopen-only recovery, intra-tick rollup-before-dispatch order) in both doc locales.

## Refs

- Fixes #425
- Refs #416
- Follow-up: #432 — rollup scan can starve old non-terminal goals under high volume (deferred review finding CR-005).