### PR TITLE
fix: respect assigned agent visibility for admins

### DIFF
--- a/api/spec/domain/agents/paths.yaml
+++ b/api/spec/domain/agents/paths.yaml
@@ -2,8 +2,15 @@ paths:
   /api/agents:
     get:
       tags: [agents]
-      summary: List agents (any authenticated user; non-admin sees accessible only)
+      summary: List agents visible to the current user
       operationId: listAgents
+      parameters:
+        - {
+            name: include_all,
+            in: query,
+            required: false,
+            schema: { type: boolean, default: false },
+          }
       responses:
         "200":
           description: ok

--- a/internal/server/agents.go
+++ b/internal/server/agents.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	apiserver "github.com/CherryHQ/stella/api/server"
 	"github.com/CherryHQ/stella/internal/config"
 	"github.com/CherryHQ/stella/resources"
 )
@@ -68,16 +69,17 @@ func applyTemplate(a *config.Agent, templateID string) error {
 	return nil
 }
 
-func (s *Server) ListAgents(w http.ResponseWriter, r *http.Request) {
+func (s *Server) ListAgents(w http.ResponseWriter, r *http.Request, params apiserver.ListAgentsParams) {
 	info := requireAuth(w, r)
 	if info == nil {
 		return
 	}
 	ctx := r.Context()
 
+	includeAll := info.IsAdmin && params.IncludeAll != nil && *params.IncludeAll
 	var agents []config.Agent
 	var err error
-	if info.IsAdmin {
+	if includeAll {
 		agents, err = s.store.ListAgents(ctx)
 	} else {
 		agents, err = s.store.ListAccessibleAgents(ctx, info.UserID)

--- a/internal/server/agents_test.go
+++ b/internal/server/agents_test.go
@@ -41,6 +41,53 @@ func createTestAgent(t *testing.T, env *testEnv, a config.Agent) string {
 	return created.ID
 }
 
+func TestListAgents_AdminUsesAccessibleListUnlessIncludeAll(t *testing.T) {
+	env := setupAdmin(t)
+
+	stellaID := findStellaID(t, env)
+	restrictedID := createTestAgent(t, env, config.Agent{
+		Name:    "Admin Hidden Restricted",
+		Model:   "anthropic/claude-sonnet-4-6",
+		Scope:   config.AgentScopeRestricted,
+		Enabled: true,
+	})
+
+	decodeAgents := func(path string) []config.Agent {
+		t.Helper()
+		rr := doRequest(t, env, http.MethodGet, path, nil)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("GET %s: status=%d body=%s", path, rr.Code, rr.Body.String())
+		}
+		items := parseListItems(t, rr, "agents")
+		var agents []config.Agent
+		if err := json.Unmarshal(items, &agents); err != nil {
+			t.Fatalf("decode agents: %v", err)
+		}
+		return agents
+	}
+	contains := func(agents []config.Agent, id string) bool {
+		for _, a := range agents {
+			if a.ID == id {
+				return true
+			}
+		}
+		return false
+	}
+
+	regular := decodeAgents("/api/agents")
+	if !contains(regular, stellaID) {
+		t.Fatalf("regular agent list omitted system agent %s: %+v", stellaID, regular)
+	}
+	if contains(regular, restrictedID) {
+		t.Fatalf("regular agent list leaked unassigned restricted agent %s", restrictedID)
+	}
+
+	management := decodeAgents("/api/agents?include_all=true")
+	if !contains(management, restrictedID) {
+		t.Fatalf("management agent list omitted restricted agent %s: %+v", restrictedID, management)
+	}
+}
+
 func TestCreateAgentFromTemplate(t *testing.T) {
 	env := setupAdmin(t)
 

--- a/web/src/features/agents/AgentsPage.tsx
+++ b/web/src/features/agents/AgentsPage.tsx
@@ -144,7 +144,7 @@ export interface AgentsSettingsLoaderData {
 
 export async function loadAgentsSettingsData(agentId = ""): Promise<AgentsSettingsLoaderData> {
   const [agentsRaw, modelsRaw, me, catalog] = await Promise.all([
-    listAgents({ throwOnError: true })
+    listAgents({ query: { include_all: true }, throwOnError: true })
       .then(({ data }) => data?.agents ?? [])
       .catch(() => []),
     listModels({ throwOnError: true })
@@ -339,7 +339,7 @@ export function AgentsPage() {
   const loadAgents = useCallback(
     async (currentState?: AgentsPageState) => {
       try {
-        const { data } = await listAgents({ throwOnError: true });
+        const { data } = await listAgents({ query: { include_all: true }, throwOnError: true });
         const agents = (data?.agents ?? []).map((a) => ({
           ...a,
           sandbox: normalizeSandbox(a.sandbox),

--- a/web/src/features/users/UserDetailPanel.tsx
+++ b/web/src/features/users/UserDetailPanel.tsx
@@ -81,7 +81,7 @@ export function UserDetailPanel({ userId }: UserDetailPanelProps) {
         if (data?.id) setCurrentUserId(data.id);
       })
       .catch(() => {});
-    void listAgents({ throwOnError: true })
+    void listAgents({ query: { include_all: true }, throwOnError: true })
       .then(({ data }) => setAgents((data?.agents ?? []) as Agent[]))
       .catch(() => {});
   }, [loadUser]);


### PR DESCRIPTION
## What

Fix the regular agents settings page so admin users no longer get every workspace agent by default.

Admins now use the same effective visibility rule as normal users unless the caller explicitly asks for the management list.

## Why

The regular agents page is for using/configuring agents the current user can actually access. Showing every restricted agent to admins there mixes it up with the admin permission-management flow.

The admin user agents settings page still needs the complete list so admins can assign and revoke access.

## How

- Add an admin-only `include_all` query option to `GET /api/agents`.
- Default `GET /api/agents` to `ListAccessibleAgents` for both admin and non-admin users.
- Keep management screens calling `include_all=true` where they need the complete agent list.
- Add a regression test that verifies admin users do not see unassigned restricted agents unless `include_all=true` is set.

## Refs

Fixes #430
