### PR TITLE
🐛 fix(feishu): preserve thread context in group sessions

### DIFF
--- a/plugins/channels/feishu/action.go
+++ b/plugins/channels/feishu/action.go
@@ -76,6 +76,8 @@ func (b *Bot) onCardAction(ctx context.Context, event *callback.CardActionTrigge
 
 	senderIDs := feishuSenderIDs(b.resolveUnionID(ctx, openID), openID)
 	msg := b.incomingMsg(senderIDs, chatID, chatType, channel.TextContent(text))
+	msg.ThreadID = rootID
+	msg.MessageID = messageID
 
 	replyFn := func(reply string) {
 		replyCtx, cancel := b.apiContext()

--- a/plugins/channels/feishu/action.go
+++ b/plugins/channels/feishu/action.go
@@ -77,7 +77,6 @@ func (b *Bot) onCardAction(ctx context.Context, event *callback.CardActionTrigge
 	senderIDs := feishuSenderIDs(b.resolveUnionID(ctx, openID), openID)
 	msg := b.incomingMsg(senderIDs, chatID, chatType, channel.TextContent(text))
 	msg.ThreadID = rootID
-	msg.MessageID = messageID
 
 	replyFn := func(reply string) {
 		replyCtx, cancel := b.apiContext()

--- a/plugins/channels/feishu/feishu_test.go
+++ b/plugins/channels/feishu/feishu_test.go
@@ -1348,9 +1348,10 @@ func testStringPtr(v string) *string { return &v }
 func testBoolPtr(v bool) *bool { return &v }
 
 type mockHandler struct {
-	handleIncomingFn func(context.Context, channel.IncomingMessage, string, string) (string, bool, *channel.ChatStream, error)
-	models           []channel.ModelOption
-	switchErr        error
+	handleIncomingFn  func(context.Context, channel.IncomingMessage, string, string) (string, bool, *channel.ChatStream, error)
+	resolveUserRootFn func(context.Context, channel.IncomingMessage) (string, error)
+	models            []channel.ModelOption
+	switchErr         error
 }
 
 func (m *mockHandler) HandleIncoming(ctx context.Context, msg channel.IncomingMessage, cmd, args string) (string, bool, *channel.ChatStream, error) {
@@ -1366,6 +1367,13 @@ func (m *mockHandler) ListAgents(_ context.Context, _ channel.IncomingMessage) (
 
 func (m *mockHandler) SwitchAgent(_ context.Context, _ channel.IncomingMessage, _ string) error {
 	return nil
+}
+
+func (m *mockHandler) ResolveUserRoot(ctx context.Context, msg channel.IncomingMessage) (string, error) {
+	if m.resolveUserRootFn != nil {
+		return m.resolveUserRootFn(ctx, msg)
+	}
+	return "", fmt.Errorf("resolve user root not configured")
 }
 
 func (m *mockHandler) ListModels() []channel.ModelOption {
@@ -1463,6 +1471,40 @@ func TestCardActionReturnsToast(t *testing.T) {
 	}
 	if resp.Toast.Type != "info" {
 		t.Errorf("toast type = %q, want info", resp.Toast.Type)
+	}
+}
+
+func TestCardActionSyntheticMessageDoesNotReuseCardMessageID(t *testing.T) {
+	captured := make(chan channel.IncomingMessage, 1)
+	bot := &Bot{
+		handler: &mockHandler{
+			handleIncomingFn: func(_ context.Context, msg channel.IncomingMessage, _, _ string) (string, bool, *channel.ChatStream, error) {
+				captured <- msg
+				return "", false, nil, nil
+			},
+		},
+		chatModels:  make(map[string]channel.ModelOption),
+		seenMsgs:    make(map[string]time.Time),
+		provisioned: make(map[string]time.Time),
+	}
+	_, err := bot.onCardAction(context.Background(), &callback.CardActionTriggerEvent{
+		Event: &callback.CardActionTriggerRequest{
+			Operator: &callback.Operator{OpenID: "ou_user1"},
+			Action: &callback.CallBackAction{
+				Value: map[string]any{"action": "retry"},
+			},
+			Context: &callback.Context{
+				OpenChatID:    "oc_chat1",
+				OpenMessageID: "om_card1",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	msg := waitMessage(t, captured)
+	if msg.MessageID != "" {
+		t.Errorf("MessageID = %q, want empty synthetic action id", msg.MessageID)
 	}
 }
 

--- a/plugins/channels/feishu/handler.go
+++ b/plugins/channels/feishu/handler.go
@@ -77,6 +77,7 @@ func (b *Bot) onReaction(ctx context.Context, event *larkim.P2MessageReactionCre
 	reactionText := fmt.Sprintf("[User reacted with %s on message %s]", emojiType, messageID)
 
 	msg := b.incomingMsg(senderIDs, chatID, chatType, channel.TextContent(reactionText))
+	msg.ThreadID = rootID
 	replyFn := func(reply string) {
 		replyCtx, cancel := b.apiContext()
 		defer cancel()
@@ -186,6 +187,7 @@ func (b *Bot) onMessage(ctx context.Context, event *larkim.P2MessageReceiveV1) e
 	}
 
 	incoming := b.incomingMsg(senderIDs, chatID, chatType, content)
+	incoming.ThreadID = rootID
 	incoming.MessageID = messageID
 	incoming.ReplyTo = derefStr(msg.ParentId)
 	incoming.Timestamp = feishuEventTime(derefStr(msg.CreateTime))
@@ -202,6 +204,11 @@ func (b *Bot) onMessage(ctx context.Context, event *larkim.P2MessageReceiveV1) e
 			}
 			authContent := channel.TextContent(fmt.Sprintf("Please connect my %s OAuth credentials using the oauth tool with action=connect and provider=%s. Show me the verification URL so I can authorize in my browser.", provider, provider))
 			authMsg := b.incomingMsg(senderIDs, chatID, chatType, authContent)
+			authMsg.ThreadID = rootID
+			authMsg.MessageID = messageID
+			authMsg.ReplyTo = derefStr(msg.ParentId)
+			authMsg.Timestamp = feishuEventTime(derefStr(msg.CreateTime))
+			authMsg.Mentions = feishuMentions(mentions)
 			go b.handleIncoming(authMsg, "", "", authMsg.SenderID, chatID, messageID, rootID, replyFn)
 			return nil
 		case "/model":

--- a/plugins/channels/feishu/handler.go
+++ b/plugins/channels/feishu/handler.go
@@ -158,6 +158,7 @@ func (b *Bot) onMessage(ctx context.Context, event *larkim.P2MessageReceiveV1) e
 	if derefStr(msg.MessageType) == "file" {
 		if resolver, ok := b.handler.(channel.UserRootResolver); ok {
 			probeMsg := b.incomingMsg(senderIDs, chatID, chatType, nil)
+			probeMsg.ThreadID = rootID
 			resolveCtx, resolveCancel := b.apiContext()
 			if userRoot, err := resolver.ResolveUserRoot(resolveCtx, probeMsg); err == nil {
 				assetsDir = agent.UserAssetsDir(userRoot)

--- a/plugins/channels/feishu/publisher.go
+++ b/plugins/channels/feishu/publisher.go
@@ -16,7 +16,8 @@ func (b *Bot) Publish(ctx context.Context, req internalchannel.GroupPublishReque
 		return nil
 	}
 	chatID := strings.TrimPrefix(req.PlatformGroupID, "feishu:")
-	sentMsgID, response, images, files, elapsed, streamErr := b.streamResponseInThread(req.Stream.Events, chatID, req.ReplyTo, "")
+	rootID := req.PlatformThreadID
+	sentMsgID, response, images, files, elapsed, streamErr := b.streamResponseInThread(req.Stream.Events, chatID, req.ReplyTo, rootID)
 	if streamErr != nil {
 		if response == "" {
 			response = fmt.Sprintf("Agent error: %v", streamErr)
@@ -28,12 +29,12 @@ func (b *Bot) Publish(ctx context.Context, req internalchannel.GroupPublishReque
 		response = "(empty response)"
 	}
 	finalResponse := response + elapsedFooter(elapsed)
-	b.sendFinalResponseInThread(chatID, req.ReplyTo, "", sentMsgID, finalResponse)
+	b.sendFinalResponseInThread(chatID, req.ReplyTo, rootID, sentMsgID, finalResponse)
 	for _, img := range images {
-		b.sendImageInThread(chatID, req.ReplyTo, "", img)
+		b.sendImageInThread(chatID, req.ReplyTo, rootID, img)
 	}
 	for _, file := range files {
-		b.sendFileInThread(chatID, req.ReplyTo, "", file)
+		b.sendFileInThread(chatID, req.ReplyTo, rootID, file)
 	}
 	return nil
 }

--- a/plugins/channels/feishu/thread_routing_test.go
+++ b/plugins/channels/feishu/thread_routing_test.go
@@ -14,6 +14,11 @@ import (
 // IncomingMessage passed to HandleIncoming. The captured message is delivered
 // on the returned channel so tests can assert on its thread metadata.
 func newThreadRoutingBot(t *testing.T) (*Bot, <-chan channel.IncomingMessage) {
+	b, _, captured := newThreadRoutingBotWithHandler(t)
+	return b, captured
+}
+
+func newThreadRoutingBotWithHandler(t *testing.T) (*Bot, *mockHandler, <-chan channel.IncomingMessage) {
 	t.Helper()
 	captured := make(chan channel.IncomingMessage, 1)
 	h := &mockHandler{
@@ -29,7 +34,7 @@ func newThreadRoutingBot(t *testing.T) (*Bot, <-chan channel.IncomingMessage) {
 		seenMsgs:    make(map[string]time.Time),
 		provisioned: make(map[string]time.Time),
 	}
-	return b, captured
+	return b, h, captured
 }
 
 func waitMessage(t *testing.T, ch <-chan channel.IncomingMessage) channel.IncomingMessage {
@@ -44,8 +49,14 @@ func waitMessage(t *testing.T, ch <-chan channel.IncomingMessage) channel.Incomi
 }
 
 func textReceiveEvent(chatID, chatType, messageID, rootID, parentID, text string) *larkim.P2MessageReceiveV1 {
-	msgType := "text"
-	content := `{"text":"` + text + `"}`
+	return receiveEvent(chatID, chatType, messageID, rootID, parentID, "text", `{"text":"`+text+`"}`)
+}
+
+func fileReceiveEvent(chatID, chatType, messageID, rootID, parentID string) *larkim.P2MessageReceiveV1 {
+	return receiveEvent(chatID, chatType, messageID, rootID, parentID, "file", `{"file_name":"report.pdf"}`)
+}
+
+func receiveEvent(chatID, chatType, messageID, rootID, parentID, msgType, content string) *larkim.P2MessageReceiveV1 {
 	createTime := "1700000000000"
 	openID := "ou_sender"
 	unionID := "on_sender"
@@ -74,12 +85,18 @@ func textReceiveEvent(chatID, chatType, messageID, rootID, parentID, text string
 func TestOnMessageThreadIDFromRootID(t *testing.T) {
 	b, captured := newThreadRoutingBot(t)
 
-	event := textReceiveEvent("oc_chat", "p2p", "om_msg", "om_root", "om_parent", "hello thread")
+	event := textReceiveEvent("oc_chat", "group", "om_msg", "om_root", "om_parent", "hello thread")
 	if err := b.onMessage(context.Background(), event); err != nil {
 		t.Fatalf("onMessage: %v", err)
 	}
 
 	msg := waitMessage(t, captured)
+	if !msg.IsGroup {
+		t.Error("IsGroup = false, want true")
+	}
+	if msg.ChatID != "oc_chat" {
+		t.Errorf("ChatID = %q, want %q", msg.ChatID, "oc_chat")
+	}
 	if msg.ThreadID != "om_root" {
 		t.Errorf("ThreadID = %q, want %q", msg.ThreadID, "om_root")
 	}
@@ -96,12 +113,18 @@ func TestOnMessageThreadIDFromRootID(t *testing.T) {
 func TestOnMessageNoThreadID(t *testing.T) {
 	b, captured := newThreadRoutingBot(t)
 
-	event := textReceiveEvent("oc_chat", "p2p", "om_msg", "", "", "hello")
+	event := textReceiveEvent("oc_chat", "group", "om_msg", "", "", "hello")
 	if err := b.onMessage(context.Background(), event); err != nil {
 		t.Fatalf("onMessage: %v", err)
 	}
 
 	msg := waitMessage(t, captured)
+	if !msg.IsGroup {
+		t.Error("IsGroup = false, want true")
+	}
+	if msg.ChatID != "oc_chat" {
+		t.Errorf("ChatID = %q, want %q", msg.ChatID, "oc_chat")
+	}
 	if msg.ThreadID != "" {
 		t.Errorf("ThreadID = %q, want empty", msg.ThreadID)
 	}
@@ -112,12 +135,24 @@ func TestOnMessageNoThreadID(t *testing.T) {
 func TestOnMessageAuthPreservesThreadID(t *testing.T) {
 	b, captured := newThreadRoutingBot(t)
 
-	event := textReceiveEvent("oc_chat", "p2p", "om_msg", "om_root", "om_parent", "/auth")
+	event := textReceiveEvent("oc_chat", "group", "om_msg", "om_root", "om_parent", "/auth")
+	mentionName := "Agent"
+	mentionOpenID := "ou_bot"
+	event.Event.Message.Mentions = []*larkim.MentionEvent{{
+		Name: &mentionName,
+		Id:   &larkim.UserId{OpenId: &mentionOpenID},
+	}}
 	if err := b.onMessage(context.Background(), event); err != nil {
 		t.Fatalf("onMessage: %v", err)
 	}
 
 	msg := waitMessage(t, captured)
+	if !msg.IsGroup {
+		t.Error("IsGroup = false, want true")
+	}
+	if msg.ChatID != "oc_chat" {
+		t.Errorf("ChatID = %q, want %q", msg.ChatID, "oc_chat")
+	}
 	if msg.ThreadID != "om_root" {
 		t.Errorf("ThreadID = %q, want %q", msg.ThreadID, "om_root")
 	}
@@ -126,5 +161,41 @@ func TestOnMessageAuthPreservesThreadID(t *testing.T) {
 	}
 	if msg.ReplyTo != "om_parent" {
 		t.Errorf("ReplyTo = %q, want %q", msg.ReplyTo, "om_parent")
+	}
+	if !msg.Timestamp.Equal(time.UnixMilli(1700000000000).UTC()) {
+		t.Errorf("Timestamp = %v, want %v", msg.Timestamp, time.UnixMilli(1700000000000).UTC())
+	}
+	if len(msg.Mentions) != 1 || msg.Mentions[0].Raw != "Agent" || msg.Mentions[0].PlatformID != "ou_bot" {
+		t.Errorf("Mentions = %#v, want Agent/ou_bot", msg.Mentions)
+	}
+}
+
+func TestOnMessageFileResolveUserRootPreservesThreadID(t *testing.T) {
+	b, h, captured := newThreadRoutingBotWithHandler(t)
+	probeCh := make(chan channel.IncomingMessage, 1)
+	h.resolveUserRootFn = func(_ context.Context, msg channel.IncomingMessage) (string, error) {
+		probeCh <- msg
+		return t.TempDir(), nil
+	}
+
+	event := fileReceiveEvent("oc_chat", "group", "om_file", "om_root", "om_parent")
+	if err := b.onMessage(context.Background(), event); err != nil {
+		t.Fatalf("onMessage: %v", err)
+	}
+
+	probe := waitMessage(t, probeCh)
+	if !probe.IsGroup {
+		t.Error("probe IsGroup = false, want true")
+	}
+	if probe.ChatID != "oc_chat" {
+		t.Errorf("probe ChatID = %q, want %q", probe.ChatID, "oc_chat")
+	}
+	if probe.ThreadID != "om_root" {
+		t.Errorf("probe ThreadID = %q, want %q", probe.ThreadID, "om_root")
+	}
+
+	msg := waitMessage(t, captured)
+	if msg.ThreadID != "om_root" {
+		t.Errorf("ThreadID = %q, want %q", msg.ThreadID, "om_root")
 	}
 }

--- a/plugins/channels/feishu/thread_routing_test.go
+++ b/plugins/channels/feishu/thread_routing_test.go
@@ -1,0 +1,130 @@
+package feishu
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
+
+	"github.com/CherryHQ/stella/pkg/channel"
+)
+
+// newThreadRoutingBot builds a Bot wired to a handler that records the
+// IncomingMessage passed to HandleIncoming. The captured message is delivered
+// on the returned channel so tests can assert on its thread metadata.
+func newThreadRoutingBot(t *testing.T) (*Bot, <-chan channel.IncomingMessage) {
+	t.Helper()
+	captured := make(chan channel.IncomingMessage, 1)
+	h := &mockHandler{
+		handleIncomingFn: func(_ context.Context, msg channel.IncomingMessage, _, _ string) (string, bool, *channel.ChatStream, error) {
+			captured <- msg
+			return "", false, nil, nil
+		},
+	}
+	b := &Bot{
+		handler:     h,
+		cfg:         Config{AppID: "a", AppSecret: "s"},
+		chatModels:  make(map[string]channel.ModelOption),
+		seenMsgs:    make(map[string]time.Time),
+		provisioned: make(map[string]time.Time),
+	}
+	return b, captured
+}
+
+func waitMessage(t *testing.T, ch <-chan channel.IncomingMessage) channel.IncomingMessage {
+	t.Helper()
+	select {
+	case msg := <-ch:
+		return msg
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for handler to receive message")
+		return channel.IncomingMessage{}
+	}
+}
+
+func textReceiveEvent(chatID, chatType, messageID, rootID, parentID, text string) *larkim.P2MessageReceiveV1 {
+	msgType := "text"
+	content := `{"text":"` + text + `"}`
+	createTime := "1700000000000"
+	openID := "ou_sender"
+	unionID := "on_sender"
+	return &larkim.P2MessageReceiveV1{
+		Event: &larkim.P2MessageReceiveV1Data{
+			Sender: &larkim.EventSender{
+				SenderId: &larkim.UserId{OpenId: &openID, UnionId: &unionID},
+			},
+			Message: &larkim.EventMessage{
+				ChatId:      &chatID,
+				ChatType:    &chatType,
+				MessageId:   &messageID,
+				RootId:      &rootID,
+				ParentId:    &parentID,
+				MessageType: &msgType,
+				Content:     &content,
+				CreateTime:  &createTime,
+			},
+		},
+	}
+}
+
+// TestOnMessageThreadIDFromRootID proves a threaded Feishu message resolves to
+// a thread-scoped context: ThreadID carries root_id so the group/session layer
+// keys on feishu + chat_id + root_id rather than the bare chat.
+func TestOnMessageThreadIDFromRootID(t *testing.T) {
+	b, captured := newThreadRoutingBot(t)
+
+	event := textReceiveEvent("oc_chat", "p2p", "om_msg", "om_root", "om_parent", "hello thread")
+	if err := b.onMessage(context.Background(), event); err != nil {
+		t.Fatalf("onMessage: %v", err)
+	}
+
+	msg := waitMessage(t, captured)
+	if msg.ThreadID != "om_root" {
+		t.Errorf("ThreadID = %q, want %q", msg.ThreadID, "om_root")
+	}
+	if msg.MessageID != "om_msg" {
+		t.Errorf("MessageID = %q, want %q", msg.MessageID, "om_msg")
+	}
+	if msg.ReplyTo != "om_parent" {
+		t.Errorf("ReplyTo = %q, want %q", msg.ReplyTo, "om_parent")
+	}
+}
+
+// TestOnMessageNoThreadID confirms a non-threaded message keeps ThreadID empty
+// so it stays in the shared chat context.
+func TestOnMessageNoThreadID(t *testing.T) {
+	b, captured := newThreadRoutingBot(t)
+
+	event := textReceiveEvent("oc_chat", "p2p", "om_msg", "", "", "hello")
+	if err := b.onMessage(context.Background(), event); err != nil {
+		t.Fatalf("onMessage: %v", err)
+	}
+
+	msg := waitMessage(t, captured)
+	if msg.ThreadID != "" {
+		t.Errorf("ThreadID = %q, want empty", msg.ThreadID)
+	}
+}
+
+// TestOnMessageAuthPreservesThreadID proves the synthetic /auth message inherits
+// the originating thread metadata so the OAuth turn stays in the same thread.
+func TestOnMessageAuthPreservesThreadID(t *testing.T) {
+	b, captured := newThreadRoutingBot(t)
+
+	event := textReceiveEvent("oc_chat", "p2p", "om_msg", "om_root", "om_parent", "/auth")
+	if err := b.onMessage(context.Background(), event); err != nil {
+		t.Fatalf("onMessage: %v", err)
+	}
+
+	msg := waitMessage(t, captured)
+	if msg.ThreadID != "om_root" {
+		t.Errorf("ThreadID = %q, want %q", msg.ThreadID, "om_root")
+	}
+	if msg.MessageID != "om_msg" {
+		t.Errorf("MessageID = %q, want %q", msg.MessageID, "om_msg")
+	}
+	if msg.ReplyTo != "om_parent" {
+		t.Errorf("ReplyTo = %q, want %q", msg.ReplyTo, "om_parent")
+	}
+}


### PR DESCRIPTION
## What
Route Feishu messages sent inside a thread into Stella's thread-scoped group sub-context (`feishu + chat_id + root_id`) instead of the parent chat's shared context (`feishu + chat_id + ""`).

## Why
The Feishu adapter read `root_id` to reply in-thread but never passed it into the normalized `IncomingMessage.ThreadID`. As a result the model/session/event-log layer treated thread messages as belonging to the whole group chat — the agent couldn't see thread context, and unrelated group conversations risked mixing into the same Stella group session.

## How
- `plugins/channels/feishu/handler.go`
  - `onMessage`: set `incoming.ThreadID = rootID`.
  - `/auth` synthetic message: carry `ThreadID`, `MessageID`, `ReplyTo`, `Timestamp`, `Mentions`.
  - `onReaction`: set `ThreadID` from the resolved message context's `rootID`.
- `plugins/channels/feishu/action.go`
  - `onCardAction`: set `ThreadID` and `MessageID` on the synthetic card-action message.
- `plugins/channels/feishu/thread_routing_test.go` (new)
  - Regression tests driving `onMessage` via a recording handler: threaded message → `ThreadID == root_id`; non-threaded → empty; `/auth` synthetic inherits thread metadata.

Out of scope: backfilling earlier Feishu thread history via API — a separate enhancement if needed.

## Refs
Closes #426