### PR TITLE
✨ feat(sandbox): layered per-user mise — shared system base + per-user writable installs

### DIFF
--- a/internal/agent/sandbox/backend_test.go
+++ b/internal/agent/sandbox/backend_test.go
@@ -183,7 +183,7 @@ func TestRunnerFilesystemPolicyUsesUserScopedTmp(t *testing.T) {
 	if resolved, err := filepath.EvalSymlinks(base); err == nil {
 		base = resolved
 	}
-	want := filepath.Join(base, "42")
+	want := filepath.Join(base, "user-42")
 	if policy.TempDirHost != want {
 		t.Fatalf("TempDirHost = %q, want %q", policy.TempDirHost, want)
 	}

--- a/internal/agent/sandbox/env.go
+++ b/internal/agent/sandbox/env.go
@@ -18,16 +18,25 @@ import (
 )
 
 func runnerFilesystemPolicy(paths Paths, cfg Config) pkgsandbox.FilesystemPolicy {
-	tempID := cfg.UserID
-	if cfg.GroupID != "" {
-		tempID = "group-" + cfg.GroupID
-	}
+	key := miseUserKey(cfg)
 	return pkgsandbox.FilesystemPolicy{
 		WorkspaceRoot:       paths.UserRoot,
 		WorkingDir:          paths.WorkDir,
 		ExtraReadOnlyMounts: skillMountsForSandbox(paths),
-		TempDirHost:         userTempDir(tempID),
+		TempDirHost:         userTempDir(key),
+		MiseUserDirHost:     pkgsandbox.MiseUserToolsDir(paths.StellaHome, key),
 	}
+}
+
+// miseUserKey returns the key for this session's per-user temp and mise trees:
+// the group key for group sessions, otherwise the user ID. Empty when neither
+// is set, which makes callers fall back to a session-local temp dir and the
+// shared read-only system mise tree.
+func miseUserKey(cfg Config) string {
+	if cfg.GroupID != "" {
+		return "group-" + cfg.GroupID
+	}
+	return cfg.UserID
 }
 
 var validUserTempDirID = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
@@ -150,7 +159,8 @@ func buildSandboxEnv(ctx context.Context, cfg Config, paths Paths) (map[string]s
 	// PATH, so they need the mise env pointed at the org's config. Docker carries
 	// its own in-image mise tree and PATH, so host-side paths must not leak in.
 	if resolveBackendName(ctx, cfg) != config.SandboxBackendDocker {
-		maps.Copy(env, manifestplugins.RuntimeMiseEnv(paths.StellaHome))
+		userDataDir := pkgsandbox.MiseUserToolsDir(paths.StellaHome, miseUserKey(cfg))
+		maps.Copy(env, manifestplugins.RuntimeMiseEnv(paths.StellaHome, userDataDir, paths.UserRoot))
 	}
 
 	return env, nil

--- a/internal/agent/sandbox/env.go
+++ b/internal/agent/sandbox/env.go
@@ -19,12 +19,25 @@ import (
 
 func runnerFilesystemPolicy(paths Paths, cfg Config) pkgsandbox.FilesystemPolicy {
 	key := miseUserKey(cfg)
+	miseDir := pkgsandbox.MiseUserToolsDir(paths.StellaHome, key)
+	// A non-empty key that yields no dir means the user/group ID failed the
+	// safe-path-component check. Don't fail the session (we fall back to the
+	// shared read-only system tree and a session-local temp dir), but surface the
+	// silent downgrade so a malformed ID is diagnosable instead of mysterious.
+	if key != "" && miseDir == "" {
+		slog.Warn("per-user mise tree disabled: unsafe key, using shared read-only system tree",
+			"component", "runner_sandbox",
+			"user_id", cfg.UserID,
+			"group_id", cfg.GroupID,
+			"key", key,
+		)
+	}
 	return pkgsandbox.FilesystemPolicy{
 		WorkspaceRoot:       paths.UserRoot,
 		WorkingDir:          paths.WorkDir,
 		ExtraReadOnlyMounts: skillMountsForSandbox(paths),
 		TempDirHost:         userTempDir(key),
-		MiseUserDirHost:     pkgsandbox.MiseUserToolsDir(paths.StellaHome, key),
+		MiseUserDirHost:     miseDir,
 	}
 }
 

--- a/internal/agent/sandbox/env.go
+++ b/internal/agent/sandbox/env.go
@@ -28,15 +28,20 @@ func runnerFilesystemPolicy(paths Paths, cfg Config) pkgsandbox.FilesystemPolicy
 	}
 }
 
-// miseUserKey returns the key for this session's per-user temp and mise trees:
-// the group key for group sessions, otherwise the user ID. Empty when neither
-// is set, which makes callers fall back to a session-local temp dir and the
-// shared read-only system mise tree.
+// miseUserKey returns the key for this session's per-user temp and mise trees.
+// User and group keys carry disjoint prefixes ("user-"/"group-") so the two
+// principal namespaces can never collide into one shared writable tree, even if a
+// user ID ever takes the literal form "group-<n>". Empty when neither is set,
+// which makes callers fall back to a session-local temp dir and the shared
+// read-only system mise tree.
 func miseUserKey(cfg Config) string {
 	if cfg.GroupID != "" {
 		return "group-" + cfg.GroupID
 	}
-	return cfg.UserID
+	if cfg.UserID == "" {
+		return ""
+	}
+	return "user-" + cfg.UserID
 }
 
 var validUserTempDirID = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)

--- a/internal/agent/sandbox/session.go
+++ b/internal/agent/sandbox/session.go
@@ -129,6 +129,16 @@ func buildBasePolicy(ctx context.Context, cfg Config) (Paths, pkgsandbox.Policy,
 			return Paths{}, pkgsandbox.Policy{}, fmt.Errorf("ensure user temp dir: %w", err)
 		}
 	}
+	// Docker carries its own in-image mise tree; the per-user host tree only
+	// applies to host-execution backends (local, none).
+	if resolveBackendName(ctx, cfg) == config.SandboxBackendDocker {
+		fs.MiseUserDirHost = ""
+	}
+	if fs.MiseUserDirHost != "" {
+		if err := pkgsandbox.EnsureUserMiseHome(paths.StellaHome, fs.MiseUserDirHost); err != nil {
+			return Paths{}, pkgsandbox.Policy{}, fmt.Errorf("ensure per-user mise home: %w", err)
+		}
+	}
 
 	policy := pkgsandbox.Policy{
 		Filesystem: fs,

--- a/internal/manifestplugins/mise_config.go
+++ b/internal/manifestplugins/mise_config.go
@@ -21,21 +21,32 @@ const builtinScope = "_builtin"
 // parallel or they clobber each other's shims.
 var miseInstallMu sync.Mutex
 
-// miseBaseEnv returns the mise env entries shared by every Stella mise
-// invocation — the isolated data-dir layout plus the non-interactive flags.
-// Both the install side (isolatedMiseEnv) and the runtime side (RuntimeMiseEnv)
-// build on this, so the directories they must agree on cannot silently drift.
-func miseBaseEnv(stellaHome string) map[string]string {
-	dataDir := miseToolsDir(stellaHome)
+// sandboxWorkspaceDir is the path the agent workspace is mounted at inside the
+// Linux (bwrap) sandbox. It is trusted for mise config so a project's mise.toml
+// participates in version resolution. Mirrors the mount point in
+// plugins/sandbox/local/session_linux.go.
+const sandboxWorkspaceDir = "/workspace"
+
+// miseDirEnv returns the DATA/CONFIG/CACHE/STATE layout rooted at dataDir. The
+// install side roots it at the shared system tree; the runtime side roots it at
+// the per-user writable tree so both agree on the layout without drifting.
+func miseDirEnv(dataDir string) map[string]string {
 	return map[string]string{
-		"MISE_DATA_DIR":     dataDir,
-		"MISE_CONFIG_DIR":   filepath.Join(dataDir, "config"),
-		"MISE_CACHE_DIR":    filepath.Join(dataDir, "cache"),
-		"MISE_STATE_DIR":    filepath.Join(dataDir, "state"),
-		"MISE_YES":          "1",
-		"MISE_NO_ANALYTICS": "1",
-		"MISE_EXPERIMENTAL": "1",
+		"MISE_DATA_DIR":   dataDir,
+		"MISE_CONFIG_DIR": filepath.Join(dataDir, "config"),
+		"MISE_CACHE_DIR":  filepath.Join(dataDir, "cache"),
+		"MISE_STATE_DIR":  filepath.Join(dataDir, "state"),
 	}
+}
+
+// miseBaseEnv returns the mise env entries shared by every Stella mise
+// invocation — the system data-dir layout plus the non-interactive flags.
+func miseBaseEnv(stellaHome string) map[string]string {
+	env := miseDirEnv(miseToolsDir(stellaHome))
+	env["MISE_YES"] = "1"
+	env["MISE_NO_ANALYTICS"] = "1"
+	env["MISE_EXPERIMENTAL"] = "1"
+	return env
 }
 
 // runtimeScopeConfigPath returns the mise config the sandbox resolves against.
@@ -43,19 +54,48 @@ func runtimeScopeConfigPath(stellaHome string) string {
 	return ScopeConfigPath(stellaHome, builtinScope)
 }
 
-// RuntimeMiseEnv returns the mise environment variables a sandbox needs so its
-// shims resolve tool versions from the persisted config against the shared
-// install dir. HOME/XDG are intentionally left untouched — the sandbox owns
-// those. Auto-install is disabled so runtime never reaches the network.
-func RuntimeMiseEnv(stellaHome string) map[string]string {
-	env := miseBaseEnv(stellaHome)
+// RuntimeMiseEnv returns the mise environment for a sandbox session, layered
+// like a real machine: the shared system installs supply the builtin tools and
+// the _builtin config supplies their default versions, while the per-user
+// writable tree (userDataDir) holds anything the agent installs itself. HOME/XDG
+// are left untouched — the sandbox owns those.
+//
+// When userDataDir is set the per-user tree is writable, so DATA/CACHE/STATE live
+// there and auto-install is enabled (network defaults to allow_all); a user's own
+// tool versions win because the per-user shims sort ahead on PATH. workspaceDir
+// (the host workspace root) is trusted alongside the bwrap "/workspace" mount so a
+// project's mise.toml participates in resolution regardless of backend.
+//
+// When userDataDir is empty (no user/group) it falls back to the read-only system
+// tree with auto-install disabled and state redirected to a writable temp dir,
+// matching the historical behavior.
+func RuntimeMiseEnv(stellaHome, userDataDir, workspaceDir string) map[string]string {
+	dataDir := userDataDir
+	if dataDir == "" {
+		dataDir = miseToolsDir(stellaHome)
+	}
+	env := miseDirEnv(dataDir)
+	env["MISE_YES"] = "1"
+	env["MISE_NO_ANALYTICS"] = "1"
+	env["MISE_EXPERIMENTAL"] = "1"
+
 	configPath := runtimeScopeConfigPath(stellaHome)
 	env["MISE_GLOBAL_CONFIG_FILE"] = configPath
-	env["MISE_TRUSTED_CONFIG_PATHS"] = configPath
-	env["MISE_NOT_FOUND_AUTO_INSTALL"] = "false"
-	// Sandbox mounts .mise-tools read-only, so redirect state (config
-	// tracking, etc.) to a writable temp location.
-	env["MISE_STATE_DIR"] = "/tmp/mise-state"
+
+	trusted := []string{configPath, sandboxWorkspaceDir}
+	if workspaceDir != "" && workspaceDir != sandboxWorkspaceDir {
+		trusted = append(trusted, workspaceDir)
+	}
+	env["MISE_TRUSTED_CONFIG_PATHS"] = strings.Join(trusted, string(filepath.ListSeparator))
+
+	if userDataDir == "" {
+		// No writable per-user tree: keep runtime off the network and redirect
+		// state off the read-only system tree, as before.
+		env["MISE_NOT_FOUND_AUTO_INSTALL"] = "false"
+		env["MISE_STATE_DIR"] = "/tmp/mise-state"
+	} else {
+		env["MISE_NOT_FOUND_AUTO_INSTALL"] = "true"
+	}
 	return env
 }
 

--- a/internal/manifestplugins/mise_config.go
+++ b/internal/manifestplugins/mise_config.go
@@ -61,10 +61,12 @@ func runtimeScopeConfigPath(stellaHome string) string {
 // are left untouched — the sandbox owns those.
 //
 // When userDataDir is set the per-user tree is writable, so DATA/CACHE/STATE live
-// there and auto-install is enabled (network defaults to allow_all); a user's own
-// tool versions win because the per-user shims sort ahead on PATH. workspaceDir
-// (the host workspace root) is trusted alongside the bwrap "/workspace" mount so a
-// project's mise.toml participates in resolution regardless of backend.
+// there and auto-install is enabled; a user's own tool versions win because the
+// per-user shims sort ahead on PATH. (Auto-install still only reaches the network
+// when the session's NetworkPolicy permits egress — mise doesn't widen it.)
+// workspaceDir (the host workspace root) is trusted alongside the bwrap
+// "/workspace" mount so a project's mise.toml participates in resolution regardless
+// of backend.
 //
 // When userDataDir is empty (no user/group) it falls back to the read-only system
 // tree with auto-install disabled and state redirected to a writable temp dir,
@@ -82,6 +84,10 @@ func RuntimeMiseEnv(stellaHome, userDataDir, workspaceDir string) map[string]str
 	configPath := runtimeScopeConfigPath(stellaHome)
 	env["MISE_GLOBAL_CONFIG_FILE"] = configPath
 
+	// Trust a superset so the project mise.toml resolves on every backend: the
+	// literal "/workspace" is the bind-mount path (load-bearing on Linux/bwrap),
+	// the host workspaceDir is load-bearing on none/macOS where there is no remap.
+	// The entry irrelevant to a given backend is inert, so neither may be dropped.
 	trusted := []string{configPath, sandboxWorkspaceDir}
 	if workspaceDir != "" && workspaceDir != sandboxWorkspaceDir {
 		trusted = append(trusted, workspaceDir)

--- a/internal/manifestplugins/mise_runtime_test.go
+++ b/internal/manifestplugins/mise_runtime_test.go
@@ -30,8 +30,8 @@ func TestRuntimeMiseEnv_PerUser(t *testing.T) {
 	if env["MISE_NOT_FOUND_AUTO_INSTALL"] != "true" {
 		t.Fatalf("auto-install should be enabled for a writable per-user tree, got %q", env["MISE_NOT_FOUND_AUTO_INSTALL"])
 	}
-	if strings.Contains(env["MISE_STATE_DIR"], "/tmp/") {
-		t.Fatalf("state should live in the per-user tree, not /tmp, got %q", env["MISE_STATE_DIR"])
+	if env["MISE_STATE_DIR"] == "/tmp/mise-state" {
+		t.Fatalf("state should live in the per-user tree, not the read-only fallback, got %q", env["MISE_STATE_DIR"])
 	}
 
 	// Global config stays the shared system _builtin layer.

--- a/internal/manifestplugins/mise_runtime_test.go
+++ b/internal/manifestplugins/mise_runtime_test.go
@@ -1,0 +1,68 @@
+package manifestplugins
+
+import (
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestRuntimeMiseEnv_PerUser(t *testing.T) {
+	stellaHome := t.TempDir()
+	userDataDir := filepath.Join(stellaHome, "users", "u1", ".mise-tools")
+	workspace := "/home/agent/workspace"
+
+	env := RuntimeMiseEnv(stellaHome, userDataDir, workspace)
+
+	if got := env["MISE_DATA_DIR"]; got != userDataDir {
+		t.Fatalf("MISE_DATA_DIR = %q, want per-user dir %q", got, userDataDir)
+	}
+	for key, sub := range map[string]string{
+		"MISE_CACHE_DIR":  "cache",
+		"MISE_STATE_DIR":  "state",
+		"MISE_CONFIG_DIR": "config",
+	} {
+		want := filepath.Join(userDataDir, sub)
+		if env[key] != want {
+			t.Fatalf("%s = %q, want %q (under per-user tree)", key, env[key], want)
+		}
+	}
+	if env["MISE_NOT_FOUND_AUTO_INSTALL"] != "true" {
+		t.Fatalf("auto-install should be enabled for a writable per-user tree, got %q", env["MISE_NOT_FOUND_AUTO_INSTALL"])
+	}
+	if strings.Contains(env["MISE_STATE_DIR"], "/tmp/") {
+		t.Fatalf("state should live in the per-user tree, not /tmp, got %q", env["MISE_STATE_DIR"])
+	}
+
+	// Global config stays the shared system _builtin layer.
+	wantGlobal := ScopeConfigPath(stellaHome, builtinScope)
+	if env["MISE_GLOBAL_CONFIG_FILE"] != wantGlobal {
+		t.Fatalf("MISE_GLOBAL_CONFIG_FILE = %q, want _builtin %q", env["MISE_GLOBAL_CONFIG_FILE"], wantGlobal)
+	}
+
+	// The project workspace is trusted (both the bwrap /workspace mount and the
+	// host path, so it resolves regardless of backend).
+	trusted := strings.Split(env["MISE_TRUSTED_CONFIG_PATHS"], string(filepath.ListSeparator))
+	for _, want := range []string{wantGlobal, sandboxWorkspaceDir, workspace} {
+		if !slices.Contains(trusted, want) {
+			t.Fatalf("trusted paths %v missing %q", trusted, want)
+		}
+	}
+}
+
+func TestRuntimeMiseEnv_FallbackWhenNoUser(t *testing.T) {
+	stellaHome := t.TempDir()
+
+	env := RuntimeMiseEnv(stellaHome, "", "")
+
+	wantData := filepath.Join(stellaHome, ".mise-tools")
+	if env["MISE_DATA_DIR"] != wantData {
+		t.Fatalf("MISE_DATA_DIR = %q, want system tree %q", env["MISE_DATA_DIR"], wantData)
+	}
+	if env["MISE_NOT_FOUND_AUTO_INSTALL"] != "false" {
+		t.Fatalf("auto-install must stay off without a writable tree, got %q", env["MISE_NOT_FOUND_AUTO_INSTALL"])
+	}
+	if env["MISE_STATE_DIR"] != "/tmp/mise-state" {
+		t.Fatalf("state should redirect to /tmp without a writable tree, got %q", env["MISE_STATE_DIR"])
+	}
+}

--- a/pkg/sandbox/hostenv.go
+++ b/pkg/sandbox/hostenv.go
@@ -3,6 +3,7 @@ package sandbox
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 )
@@ -35,19 +36,44 @@ func MiseShimsDir(stellaHome string) string {
 	return filepath.Join(MiseToolsDir(stellaHome), "shims")
 }
 
+// miseUserKeyPattern restricts a per-user mise directory name to a single safe
+// path component. Anything else falls back to the shared (read-only) system tree.
+var miseUserKeyPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+
+// MiseUserToolsDir returns the per-user writable MISE_DATA_DIR. It mirrors a
+// real machine's per-user mise home: each user (or group) gets one tree shared
+// by all their agents, layered above the shared read-only system installs.
+// The path is keyed purely by userKey — never by agent — so the planned
+// user-directory refactor (user-scoped dirs, agents as apps) needs no change here.
+// An empty or unsafe key yields "" so callers fall back to the system tree.
+func MiseUserToolsDir(stellaHome, userKey string) string {
+	if !miseUserKeyPattern.MatchString(userKey) {
+		return ""
+	}
+	return filepath.Join(stellaHome, "users", userKey, ".mise-tools")
+}
+
+// MiseUserShimsDir returns the per-user mise shims directory. It is prepended to
+// PATH ahead of the system shims so a user's own tool versions win.
+func MiseUserShimsDir(userToolsDir string) string {
+	return filepath.Join(userToolsDir, "shims")
+}
+
 // HostEnvBuildPath returns a sanitized PATH suitable for host-execution sandbox
-// backends (local, none). It prepends the mise shims and stella bin directories
-// and filters host PATH entries to a safe allowlist on Linux.
-func HostEnvBuildPath(stellaHome string) string {
+// backends (local, none). It prepends the per-user mise shims (so a user's own
+// tool versions win), then the system mise shims and stella bin directories, and
+// filters host PATH entries to a safe allowlist on Linux. An empty userShimsDir
+// is dropped, so callers without a per-user tree pass "".
+func HostEnvBuildPath(stellaHome, userShimsDir string) string {
 	stellaBin := filepath.Join(stellaHome, "bin")
 	shimsDir := MiseShimsDir(stellaHome)
 	if runtime.GOOS != "linux" {
 		return strings.Join(hostEnvDedupeEntries([]string{
-			shimsDir, stellaBin, os.Getenv("PATH"),
+			userShimsDir, shimsDir, stellaBin, os.Getenv("PATH"),
 		}), string(os.PathListSeparator))
 	}
 
-	entries := []string{shimsDir, stellaBin}
+	entries := []string{userShimsDir, shimsDir, stellaBin}
 	for entry := range strings.SplitSeq(os.Getenv("PATH"), string(os.PathListSeparator)) {
 		if hostEnvPathAllowed(entry, stellaBin) {
 			entries = append(entries, entry)

--- a/pkg/sandbox/miseuser.go
+++ b/pkg/sandbox/miseuser.go
@@ -14,16 +14,56 @@ import (
 // tools (via the seeded symlinks) and can install its own tools/versions
 // alongside, layered above the read-only system installs. Idempotent and safe to
 // call before every session; a no-op when userToolsDir is empty.
+//
+// The tree is created 0700 (like the sibling per-user temp dir) so other host
+// users can't read one tenant's installed tools, and every structural directory
+// is verified to be a real directory — never a symlink. The tree is mounted
+// writable into the sandbox and persists across sessions, so a prior session's
+// agent could replace a structural dir with a symlink; since this runs unsandboxed
+// with server privileges, following such a link would let seeding escape the tree.
+//
+// The "shims" dir is seeded empty on purpose: builtin tools resolve through the
+// system shims (kept on PATH behind the per-user shims by HostEnvBuildPath), and
+// the per-user shims fill in only as the agent installs its own tools.
 func EnsureUserMiseHome(stellaHome, userToolsDir string) error {
 	if userToolsDir == "" {
 		return nil
 	}
+	if err := ensureRealDir(userToolsDir); err != nil {
+		return err
+	}
 	for _, sub := range []string{"installs", "shims", "cache", "state", "config"} {
-		if err := os.MkdirAll(filepath.Join(userToolsDir, sub), 0o755); err != nil {
-			return fmt.Errorf("sandbox: create per-user mise dir: %w", err)
+		if err := ensureRealDir(filepath.Join(userToolsDir, sub)); err != nil {
+			return err
 		}
 	}
 	return seedSystemInstalls(MiseToolsDir(stellaHome), userToolsDir)
+}
+
+// ensureRealDir creates dir (0700) if missing, or verifies an existing entry is a
+// real directory. A symlink left in the writable, persisted per-user tree is
+// removed (os.Remove targets the link, not what it points at) and replaced with a
+// real dir, so later MkdirAll/Symlink can't write through it to escape the tree.
+func ensureRealDir(dir string) error {
+	fi, err := os.Lstat(dir)
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return fmt.Errorf("sandbox: create per-user mise dir: %w", err)
+		}
+	case err != nil:
+		return fmt.Errorf("sandbox: stat per-user mise dir: %w", err)
+	case fi.Mode()&os.ModeSymlink != 0:
+		if err := os.Remove(dir); err != nil {
+			return fmt.Errorf("sandbox: remove symlinked per-user mise dir %q: %w", dir, err)
+		}
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return fmt.Errorf("sandbox: recreate per-user mise dir: %w", err)
+		}
+	case !fi.IsDir():
+		return fmt.Errorf("sandbox: per-user mise path %q is not a directory", dir)
+	}
+	return nil
 }
 
 // seedSystemInstalls mirrors each system installs/<tool>/<version> into the
@@ -47,6 +87,12 @@ func seedSystemInstalls(systemToolsDir, userToolsDir string) error {
 			continue
 		}
 		versions, err := os.ReadDir(filepath.Join(sysInstalls, tool.Name()))
+		if errors.Is(err, fs.ErrNotExist) {
+			// The shared system tree is mutated concurrently by the manifest/org
+			// reconciler; a tool dir can vanish between the outer and inner read.
+			// A transient race must not fail an unrelated user's session start.
+			continue
+		}
 		if err != nil {
 			return fmt.Errorf("sandbox: read system installs for %s: %w", tool.Name(), err)
 		}
@@ -56,8 +102,8 @@ func seedSystemInstalls(systemToolsDir, userToolsDir string) error {
 			if _, err := os.Lstat(link); err == nil {
 				continue // already seeded, or shadowed by a real user install
 			}
-			if err := os.MkdirAll(userToolDir, 0o755); err != nil {
-				return fmt.Errorf("sandbox: create per-user tool dir: %w", err)
+			if err := ensureRealDir(userToolDir); err != nil {
+				return err
 			}
 			target, err := filepath.Rel(userToolDir, filepath.Join(sysInstalls, tool.Name(), v.Name()))
 			if err != nil {

--- a/pkg/sandbox/miseuser.go
+++ b/pkg/sandbox/miseuser.go
@@ -24,7 +24,9 @@ import (
 //
 // The "shims" dir is seeded empty on purpose: builtin tools resolve through the
 // system shims (kept on PATH behind the per-user shims by HostEnvBuildPath), and
-// the per-user shims fill in only as the agent installs its own tools.
+// the per-user shims fill in only as the agent installs its own tools. Any shims
+// the agent did create are relinked to a relative target so a persisted tree stays
+// usable if the same user later runs under a different backend.
 func EnsureUserMiseHome(stellaHome, userToolsDir string) error {
 	if userToolsDir == "" {
 		return nil
@@ -37,7 +39,90 @@ func EnsureUserMiseHome(stellaHome, userToolsDir string) error {
 			return err
 		}
 	}
-	return seedSystemInstalls(MiseToolsDir(stellaHome), userToolsDir)
+	if err := pruneDanglingSeedLinks(filepath.Join(userToolsDir, "installs")); err != nil {
+		return err
+	}
+	if err := seedSystemInstalls(MiseToolsDir(stellaHome), userToolsDir); err != nil {
+		return err
+	}
+	return relinkUserShims(stellaHome, userToolsDir)
+}
+
+// pruneDanglingSeedLinks removes per-user install symlinks whose target no longer
+// resolves — e.g. a system version pruned or upgraded after it was seeded. Only
+// broken symlinks are touched; real user installs (directories) and still-valid
+// seed links are left alone, so the next seed pass heals the tree without
+// clobbering anything the agent installed.
+func pruneDanglingSeedLinks(userInstalls string) error {
+	tools, err := os.ReadDir(userInstalls)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("sandbox: read per-user installs: %w", err)
+	}
+	for _, tool := range tools {
+		toolDir := filepath.Join(userInstalls, tool.Name())
+		versions, err := os.ReadDir(toolDir)
+		if err != nil {
+			continue
+		}
+		for _, v := range versions {
+			if v.Type()&os.ModeSymlink == 0 {
+				continue // real user install, not a seed link
+			}
+			link := filepath.Join(toolDir, v.Name())
+			if _, err := os.Stat(link); err != nil {
+				_ = os.Remove(link) // target gone: drop the dangling link
+			}
+		}
+	}
+	return nil
+}
+
+// relinkUserShims rewrites every per-user shim to a relative target so it resolves
+// under whatever root the active backend remaps STELLA_HOME to. mise reshim (run
+// by the agent inside the sandbox) writes each shim with the absolute in-sandbox
+// mise path, which is backend-specific (bwrap's /home/stella/.stella vs a host
+// path); a relative target keeps a persisted tree portable across backends.
+// Mirrors relinkShims for the system tree, but computes the depth-correct target.
+func relinkUserShims(stellaHome, userToolsDir string) error {
+	miseBin := filepath.Join(stellaHome, "bin", "mise")
+	if _, err := os.Stat(miseBin); err != nil {
+		return nil //nolint:nilerr // no local mise binary to point at → leave shims untouched
+	}
+	shimsDir := filepath.Join(userToolsDir, "shims")
+	entries, err := os.ReadDir(shimsDir)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("sandbox: read per-user shims: %w", err)
+	}
+	relTarget, err := filepath.Rel(shimsDir, miseBin)
+	if err != nil {
+		return fmt.Errorf("sandbox: relative shim target: %w", err)
+	}
+	for _, e := range entries {
+		if e.Type()&os.ModeSymlink == 0 {
+			continue
+		}
+		shimPath := filepath.Join(shimsDir, e.Name())
+		if target, err := os.Readlink(shimPath); err != nil || target == relTarget {
+			continue
+		}
+		// Atomic replace: create a temp symlink, then rename over the old one.
+		tmp := shimPath + ".tmp"
+		_ = os.Remove(tmp)
+		if err := os.Symlink(relTarget, tmp); err != nil {
+			return fmt.Errorf("sandbox: relink per-user shim %s: %w", e.Name(), err)
+		}
+		if err := os.Rename(tmp, shimPath); err != nil {
+			_ = os.Remove(tmp)
+			return fmt.Errorf("sandbox: relink per-user shim %s: %w", e.Name(), err)
+		}
+	}
+	return nil
 }
 
 // ensureRealDir creates dir (0700) if missing, or verifies an existing entry is a

--- a/pkg/sandbox/miseuser.go
+++ b/pkg/sandbox/miseuser.go
@@ -1,0 +1,72 @@
+package sandbox
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// EnsureUserMiseHome creates the per-user mise tree at userToolsDir and seeds it
+// with the shared system installs. Pointing a session's MISE_DATA_DIR at this
+// tree gives the agent a real, writable mise home — it resolves the builtin
+// tools (via the seeded symlinks) and can install its own tools/versions
+// alongside, layered above the read-only system installs. Idempotent and safe to
+// call before every session; a no-op when userToolsDir is empty.
+func EnsureUserMiseHome(stellaHome, userToolsDir string) error {
+	if userToolsDir == "" {
+		return nil
+	}
+	for _, sub := range []string{"installs", "shims", "cache", "state", "config"} {
+		if err := os.MkdirAll(filepath.Join(userToolsDir, sub), 0o755); err != nil {
+			return fmt.Errorf("sandbox: create per-user mise dir: %w", err)
+		}
+	}
+	return seedSystemInstalls(MiseToolsDir(stellaHome), userToolsDir)
+}
+
+// seedSystemInstalls mirrors each system installs/<tool>/<version> into the
+// per-user installs dir as a relative symlink. Relative targets resolve
+// identically on the host and inside the sandbox — both trees are remapped under
+// the same root — the same trick mise shims use (see relinkShims). Existing
+// entries are left untouched, so a real user install of the same tool/version
+// shadows the system one and re-seeding never clobbers user state.
+func seedSystemInstalls(systemToolsDir, userToolsDir string) error {
+	sysInstalls := filepath.Join(systemToolsDir, "installs")
+	tools, err := os.ReadDir(sysInstalls)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("sandbox: read system installs: %w", err)
+	}
+	userInstalls := filepath.Join(userToolsDir, "installs")
+	for _, tool := range tools {
+		if !tool.IsDir() {
+			continue
+		}
+		versions, err := os.ReadDir(filepath.Join(sysInstalls, tool.Name()))
+		if err != nil {
+			return fmt.Errorf("sandbox: read system installs for %s: %w", tool.Name(), err)
+		}
+		userToolDir := filepath.Join(userInstalls, tool.Name())
+		for _, v := range versions {
+			link := filepath.Join(userToolDir, v.Name())
+			if _, err := os.Lstat(link); err == nil {
+				continue // already seeded, or shadowed by a real user install
+			}
+			if err := os.MkdirAll(userToolDir, 0o755); err != nil {
+				return fmt.Errorf("sandbox: create per-user tool dir: %w", err)
+			}
+			target, err := filepath.Rel(userToolDir, filepath.Join(sysInstalls, tool.Name(), v.Name()))
+			if err != nil {
+				return fmt.Errorf("sandbox: relative seed target: %w", err)
+			}
+			if err := os.Symlink(target, link); err != nil && !errors.Is(err, fs.ErrExist) {
+				return fmt.Errorf("sandbox: seed install symlink: %w", err)
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/sandbox/miseuser_test.go
+++ b/pkg/sandbox/miseuser_test.go
@@ -43,6 +43,11 @@ func TestEnsureUserMiseHome_SeedsSystemInstallsAsRelativeSymlinks(t *testing.T) 
 		}
 	}
 
+	// The tree is private (0700) so other host users can't read a tenant's tools.
+	if fi, err := os.Stat(userDir); err != nil || fi.Mode().Perm()&0o077 != 0 {
+		t.Fatalf("per-user mise tree must not be group/other-accessible, mode=%v err=%v", fi.Mode().Perm(), err)
+	}
+
 	link := filepath.Join(userDir, "installs", "go", "1.21.0")
 	target, err := os.Readlink(link)
 	if err != nil {
@@ -79,6 +84,37 @@ func TestEnsureUserMiseHome_IdempotentAndDoesNotShadowUserInstall(t *testing.T) 
 	// The user's own version is left as a real dir, never replaced by a symlink.
 	if fi, err := os.Lstat(userNode22); err != nil || fi.Mode()&os.ModeSymlink != 0 {
 		t.Fatalf("user node@22 must stay a real dir, lstat=%v err=%v", fi, err)
+	}
+}
+
+func TestEnsureUserMiseHome_DoesNotSeedThroughPlantedSymlink(t *testing.T) {
+	stellaHome := t.TempDir()
+	mustMkdirAll(t, filepath.Join(MiseToolsDir(stellaHome), "installs", "node", "20.0.0"))
+
+	userDir := MiseUserToolsDir(stellaHome, "u1")
+	mustMkdirAll(t, userDir)
+	// A prior session's agent planted a symlink where "installs" belongs, aimed at
+	// an outside dir it wants the (unsandboxed) seeding step to write into.
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(userDir, "installs")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureUserMiseHome(stellaHome, userDir); err != nil {
+		t.Fatalf("EnsureUserMiseHome: %v", err)
+	}
+
+	// The planted symlink is gone — "installs" is a real dir now.
+	if fi, err := os.Lstat(filepath.Join(userDir, "installs")); err != nil || fi.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("installs must be a real dir after seeding, lstat=%v err=%v", fi, err)
+	}
+	// Seeding did not escape through the link into the outside dir.
+	if entries, _ := os.ReadDir(outside); len(entries) != 0 {
+		t.Fatalf("seeding escaped the per-user tree into the symlink target: %v", entries)
+	}
+	// Seeding still landed in the real tree.
+	if _, err := os.Lstat(filepath.Join(userDir, "installs", "node", "20.0.0")); err != nil {
+		t.Fatalf("system node@20 should be seeded into the real tree: %v", err)
 	}
 }
 

--- a/pkg/sandbox/miseuser_test.go
+++ b/pkg/sandbox/miseuser_test.go
@@ -1,0 +1,97 @@
+package sandbox
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMiseUserToolsDir(t *testing.T) {
+	home := "/srv/.stella"
+	cases := map[string]string{
+		"u1":          filepath.Join(home, "users", "u1", ".mise-tools"),
+		"group-42":    filepath.Join(home, "users", "group-42", ".mise-tools"),
+		"":            "", // no user → fall back to the system tree
+		"a/b":         "", // path traversal rejected
+		"..":          "",
+		"bad name":    "",
+		"weird;rm-rf": "",
+	}
+	for key, want := range cases {
+		if got := MiseUserToolsDir(home, key); got != want {
+			t.Errorf("MiseUserToolsDir(%q) = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestEnsureUserMiseHome_SeedsSystemInstallsAsRelativeSymlinks(t *testing.T) {
+	stellaHome := t.TempDir()
+	// A builtin tool already installed in the shared system tree.
+	sysGo := filepath.Join(MiseToolsDir(stellaHome), "installs", "go", "1.21.0", "bin")
+	mustMkdirAll(t, sysGo)
+	mustWriteFile(t, filepath.Join(sysGo, "go"), "binary")
+
+	userDir := MiseUserToolsDir(stellaHome, "u1")
+	if err := EnsureUserMiseHome(stellaHome, userDir); err != nil {
+		t.Fatalf("EnsureUserMiseHome: %v", err)
+	}
+
+	// Standard subdirs exist.
+	for _, sub := range []string{"installs", "shims", "cache", "state", "config"} {
+		if _, err := os.Stat(filepath.Join(userDir, sub)); err != nil {
+			t.Fatalf("missing per-user subdir %s: %v", sub, err)
+		}
+	}
+
+	link := filepath.Join(userDir, "installs", "go", "1.21.0")
+	target, err := os.Readlink(link)
+	if err != nil {
+		t.Fatalf("seeded install should be a symlink: %v", err)
+	}
+	if filepath.IsAbs(target) {
+		t.Fatalf("seed target must be relative (sandbox-valid), got %q", target)
+	}
+	// It resolves to the system binary through the relative link.
+	if _, err := os.Stat(filepath.Join(link, "bin", "go")); err != nil {
+		t.Fatalf("relative seed symlink does not resolve to system install: %v", err)
+	}
+}
+
+func TestEnsureUserMiseHome_IdempotentAndDoesNotShadowUserInstall(t *testing.T) {
+	stellaHome := t.TempDir()
+	mustMkdirAll(t, filepath.Join(MiseToolsDir(stellaHome), "installs", "node", "20.0.0"))
+
+	userDir := MiseUserToolsDir(stellaHome, "u1")
+	// A real user-installed version sits alongside the (to-be-seeded) system one.
+	userNode22 := filepath.Join(userDir, "installs", "node", "22.0.0")
+	mustMkdirAll(t, userNode22)
+
+	for i := range 2 {
+		if err := EnsureUserMiseHome(stellaHome, userDir); err != nil {
+			t.Fatalf("EnsureUserMiseHome call %d: %v", i, err)
+		}
+	}
+
+	// System version seeded as a symlink.
+	if fi, err := os.Lstat(filepath.Join(userDir, "installs", "node", "20.0.0")); err != nil || fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("system node@20 should be a seeded symlink, lstat=%v err=%v", fi, err)
+	}
+	// The user's own version is left as a real dir, never replaced by a symlink.
+	if fi, err := os.Lstat(userNode22); err != nil || fi.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("user node@22 must stay a real dir, lstat=%v err=%v", fi, err)
+	}
+}
+
+func mustMkdirAll(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/sandbox/miseuser_test.go
+++ b/pkg/sandbox/miseuser_test.go
@@ -118,6 +118,62 @@ func TestEnsureUserMiseHome_DoesNotSeedThroughPlantedSymlink(t *testing.T) {
 	}
 }
 
+func TestEnsureUserMiseHome_RelinksPerUserShimsToRelative(t *testing.T) {
+	stellaHome := t.TempDir()
+	mustMkdirAll(t, filepath.Join(stellaHome, "bin"))
+	mustWriteFile(t, filepath.Join(stellaHome, "bin", "mise"), "binary")
+
+	userDir := MiseUserToolsDir(stellaHome, "u1")
+	mustMkdirAll(t, filepath.Join(userDir, "shims"))
+	// A shim mise wrote inside a different backend's sandbox: an absolute,
+	// backend-specific target that wouldn't resolve under another backend.
+	shim := filepath.Join(userDir, "shims", "node")
+	if err := os.Symlink("/home/stella/.stella/bin/mise", shim); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureUserMiseHome(stellaHome, userDir); err != nil {
+		t.Fatalf("EnsureUserMiseHome: %v", err)
+	}
+
+	target, err := os.Readlink(shim)
+	if err != nil {
+		t.Fatalf("shim should remain a symlink: %v", err)
+	}
+	if filepath.IsAbs(target) {
+		t.Fatalf("per-user shim must be relinked to a relative target, got %q", target)
+	}
+	// The relative target resolves to the local mise binary.
+	if _, err := os.Stat(shim); err != nil {
+		t.Fatalf("relinked shim does not resolve to bin/mise: %v", err)
+	}
+}
+
+func TestEnsureUserMiseHome_PrunesDanglingSeedLinks(t *testing.T) {
+	stellaHome := t.TempDir()
+	userDir := MiseUserToolsDir(stellaHome, "u1")
+	mustMkdirAll(t, filepath.Join(userDir, "installs", "node"))
+	// A seed link whose system target was pruned/upgraded away.
+	dangling := filepath.Join(userDir, "installs", "node", "18.0.0")
+	if err := os.Symlink("/no/such/system/install/node/18.0.0", dangling); err != nil {
+		t.Fatal(err)
+	}
+	// A real user install alongside it must survive.
+	realDir := filepath.Join(userDir, "installs", "node", "22.0.0")
+	mustMkdirAll(t, realDir)
+
+	if err := EnsureUserMiseHome(stellaHome, userDir); err != nil {
+		t.Fatalf("EnsureUserMiseHome: %v", err)
+	}
+
+	if _, err := os.Lstat(dangling); !os.IsNotExist(err) {
+		t.Fatalf("dangling seed link should be pruned, lstat err=%v", err)
+	}
+	if _, err := os.Stat(realDir); err != nil {
+		t.Fatalf("real user install must survive prune: %v", err)
+	}
+}
+
 func mustMkdirAll(t *testing.T, dir string) {
 	t.Helper()
 	if err := os.MkdirAll(dir, 0o755); err != nil {

--- a/pkg/sandbox/policy.go
+++ b/pkg/sandbox/policy.go
@@ -54,6 +54,14 @@ type FilesystemPolicy struct {
 	// directories are guaranteed to exist with 0700 permissions before the
 	// backend sees the policy; they may be shared across sessions.
 	TempDirHost string
+
+	// MiseUserDirHost is the host path of the per-user writable MISE_DATA_DIR
+	// (see pkgsandbox.MiseUserToolsDir). When set, host-execution backends bind
+	// it writable so agents can install their own mise tools, layered above the
+	// shared read-only system installs. Empty means no per-user tree — the
+	// session uses the read-only system tree only. The directory is guaranteed
+	// to exist (and be seeded with system installs) before the backend sees it.
+	MiseUserDirHost string
 }
 
 // NetworkPolicy defines network constraints for a sandbox session.

--- a/plugins/sandbox/local/session.go
+++ b/plugins/sandbox/local/session.go
@@ -105,22 +105,8 @@ func (f *Factory) adjustPolicy(policy sandboxpkg.Policy) sandboxpkg.Policy {
 		env = make(map[string]string)
 	}
 	sandboxSH := adjustStellaHome(f.cfg.StellaHome)
-	// remap rewrites a host STELLA_HOME path to its sandbox-adjusted form, leaving
-	// paths outside STELLA_HOME (e.g. /workspace) untouched. bwrap remaps
-	// STELLA_HOME to /home/stella/.stella; on macOS the two are equal and this is
-	// a no-op.
 	hostSH := f.cfg.StellaHome
-	hostPrefix := hostSH + string(filepath.Separator)
-	remap := func(p string) string {
-		switch {
-		case p == hostSH:
-			return sandboxSH
-		case strings.HasPrefix(p, hostPrefix):
-			return sandboxSH + p[len(hostSH):]
-		default:
-			return p
-		}
-	}
+	remap := func(p string) string { return remapStellaHomePath(p, hostSH, sandboxSH) }
 	userShims := ""
 	if dir := policy.Filesystem.MiseUserDirHost; dir != "" {
 		userShims = sandboxpkg.MiseUserShimsDir(remap(dir))
@@ -155,6 +141,22 @@ func (f *Factory) adjustPolicy(policy sandboxpkg.Policy) sandboxpkg.Policy {
 	policy.Env = env
 	policy.InheritEnv = false
 	return policy
+}
+
+// remapStellaHomePath rewrites a host path under hostSH to its sandbox-adjusted
+// location under sandboxSH, leaving paths outside hostSH (e.g. /workspace)
+// untouched. When hostSH == sandboxSH (macOS, no remap) it is a no-op. Shared by
+// the env rewrite in adjustPolicy and the bwrap mount path in session_linux.go so
+// the two can't drift.
+func remapStellaHomePath(p, hostSH, sandboxSH string) string {
+	switch {
+	case p == hostSH:
+		return sandboxSH
+	case strings.HasPrefix(p, hostSH+string(filepath.Separator)):
+		return sandboxSH + p[len(hostSH):]
+	default:
+		return p
+	}
 }
 
 // ─────────────────────────── localSession ─────────────────────────────

--- a/plugins/sandbox/local/session.go
+++ b/plugins/sandbox/local/session.go
@@ -130,19 +130,25 @@ func (f *Factory) adjustPolicy(policy sandboxpkg.Policy) sandboxpkg.Policy {
 	env["STELLA_HOME"] = sandboxSH
 	// Rewrite MISE_* path-valued env vars from host STELLA_HOME to the
 	// sandbox-adjusted path so mise resolves tools and configs correctly inside
-	// bwrap. Values are treated as PathListSeparator-joined lists so multi-path
-	// vars (MISE_TRUSTED_CONFIG_PATHS) remap each element independently and
-	// already-sandbox paths like /workspace survive untouched.
+	// bwrap. All but MISE_TRUSTED_CONFIG_PATHS are single scalar paths, and ':'
+	// is a legal character in a POSIX path, so they must be remapped whole — only
+	// the genuinely list-valued var is split on the path-list separator (each
+	// element remapped independently; already-sandbox paths like /workspace
+	// survive untouched).
 	if hostSH != sandboxSH {
 		for k, v := range env {
 			if !strings.HasPrefix(k, "MISE_") {
 				continue
 			}
-			parts := strings.Split(v, string(filepath.ListSeparator))
-			for i, p := range parts {
-				parts[i] = remap(p)
+			if k == "MISE_TRUSTED_CONFIG_PATHS" {
+				parts := strings.Split(v, string(filepath.ListSeparator))
+				for i, p := range parts {
+					parts[i] = remap(p)
+				}
+				env[k] = strings.Join(parts, string(filepath.ListSeparator))
+				continue
 			}
-			env[k] = strings.Join(parts, string(filepath.ListSeparator))
+			env[k] = remap(v)
 		}
 	}
 	sandboxpkg.HostEnvCopy(env)

--- a/plugins/sandbox/local/session.go
+++ b/plugins/sandbox/local/session.go
@@ -105,23 +105,44 @@ func (f *Factory) adjustPolicy(policy sandboxpkg.Policy) sandboxpkg.Policy {
 		env = make(map[string]string)
 	}
 	sandboxSH := adjustStellaHome(f.cfg.StellaHome)
-	env["PATH"] = sandboxpkg.HostEnvBuildPath(sandboxSH)
+	// remap rewrites a host STELLA_HOME path to its sandbox-adjusted form, leaving
+	// paths outside STELLA_HOME (e.g. /workspace) untouched. bwrap remaps
+	// STELLA_HOME to /home/stella/.stella; on macOS the two are equal and this is
+	// a no-op.
+	hostSH := f.cfg.StellaHome
+	hostPrefix := hostSH + string(filepath.Separator)
+	remap := func(p string) string {
+		switch {
+		case p == hostSH:
+			return sandboxSH
+		case strings.HasPrefix(p, hostPrefix):
+			return sandboxSH + p[len(hostSH):]
+		default:
+			return p
+		}
+	}
+	userShims := ""
+	if dir := policy.Filesystem.MiseUserDirHost; dir != "" {
+		userShims = sandboxpkg.MiseUserShimsDir(remap(dir))
+	}
+	env["PATH"] = sandboxpkg.HostEnvBuildPath(sandboxSH, userShims)
 	env["HOME"] = adjustHome(policy.Filesystem.WorkingDir)
 	env["STELLA_HOME"] = sandboxSH
 	// Rewrite MISE_* path-valued env vars from host STELLA_HOME to the
-	// sandbox-adjusted path so mise shims resolve tools correctly inside
-	// bwrap (where STELLA_HOME is remapped to /home/stella/.stella).
-	if hostSH := f.cfg.StellaHome; hostSH != sandboxSH {
-		hostPrefix := hostSH + string(filepath.Separator)
+	// sandbox-adjusted path so mise resolves tools and configs correctly inside
+	// bwrap. Values are treated as PathListSeparator-joined lists so multi-path
+	// vars (MISE_TRUSTED_CONFIG_PATHS) remap each element independently and
+	// already-sandbox paths like /workspace survive untouched.
+	if hostSH != sandboxSH {
 		for k, v := range env {
 			if !strings.HasPrefix(k, "MISE_") {
 				continue
 			}
-			if v == hostSH {
-				env[k] = sandboxSH
-			} else if strings.HasPrefix(v, hostPrefix) {
-				env[k] = sandboxSH + v[len(hostSH):]
+			parts := strings.Split(v, string(filepath.ListSeparator))
+			for i, p := range parts {
+				parts[i] = remap(p)
 			}
+			env[k] = strings.Join(parts, string(filepath.ListSeparator))
 		}
 	}
 	sandboxpkg.HostEnvCopy(env)

--- a/plugins/sandbox/local/session_darwin.go
+++ b/plugins/sandbox/local/session_darwin.go
@@ -127,9 +127,15 @@ func buildSeatbeltProfile(policy sandboxpkg.Policy) string {
 	// Dev nodes: required for stdout/stderr, pseudo-terminals, /dev/null, etc.
 	sb.WriteString("(allow file-write* (subpath \"/dev\"))\n")
 
-	// Mise runtime shims are read-only, but mise still refreshes metadata caches.
-	// Keep that write hole narrow instead of allowing the entire STELLA_HOME.
-	appendSeatbeltWritableEnvDirs(&sb, policy.Env)
+	// Mise: with a per-user tree, carve out the whole writable mise home so the
+	// agent can install tools (installs/cache/state all live under it). Without
+	// one, the system installs stay read-only and only the narrow cache/state
+	// metadata holes mise needs are opened.
+	if dir := policy.Filesystem.MiseUserDirHost; dir != "" {
+		fmt.Fprintf(&sb, "(allow file-write* (subpath %q))\n", filepath.Clean(dir))
+	} else {
+		appendSeatbeltWritableEnvDirs(&sb, policy.Env)
+	}
 
 	// Workspace root: the only user-controlled path that is fully writable.
 	fmt.Fprintf(&sb, "(allow file-write* (subpath %q))\n", workspace)

--- a/plugins/sandbox/local/session_linux.go
+++ b/plugins/sandbox/local/session_linux.go
@@ -226,6 +226,28 @@ func appendRoBindIfExists(args []string, hostPath, sandboxPath string) []string 
 	return append(args, "--ro-bind", hostPath, sandboxPath)
 }
 
+// appendWritableBind binds a host directory read-write into the sandbox,
+// creating the sandbox-side parent directories first. Used for the per-user
+// mise tree, the one STELLA_HOME subtree an agent may write to.
+func appendWritableBind(args []string, hostPath, sandboxPath string) []string {
+	args = appendDirParents(args, sandboxPath)
+	args = append(args, "--dir", filepath.Clean(sandboxPath))
+	return append(args, "--bind", hostPath, sandboxPath)
+}
+
+// remapToSandboxStellaHome rewrites a host path under STELLA_HOME to its
+// sandbox-view location (STELLA_HOME is remapped to /home/stella/.stella).
+// Paths outside STELLA_HOME are returned unchanged.
+func remapToSandboxStellaHome(hostPath, stellaHomeHost string) string {
+	if hostPath == stellaHomeHost {
+		return sandboxStellaHome
+	}
+	if prefix := stellaHomeHost + string(filepath.Separator); strings.HasPrefix(hostPath, prefix) {
+		return sandboxStellaHome + hostPath[len(stellaHomeHost):]
+	}
+	return hostPath
+}
+
 func appendDirParents(args []string, path string) []string {
 	parent := filepath.Clean(filepath.Dir(path))
 	if parent == "." || parent == string(filepath.Separator) {
@@ -276,6 +298,11 @@ func wrapCommand(policy sandboxpkg.Policy, sandboxCwd string, tmpMounts []tmpMou
 	}
 	bwrapArgs = appendLinuxRuntimeMounts(bwrapArgs)
 	bwrapArgs = appendStellaHomeMounts(bwrapArgs, stellaHomeHost)
+	// Per-user mise tree: the agent's writable mise home, layered above the
+	// read-only system installs mounted by appendStellaHomeMounts.
+	if userDir := policy.Filesystem.MiseUserDirHost; userDir != "" {
+		bwrapArgs = appendWritableBind(bwrapArgs, userDir, remapToSandboxStellaHome(userDir, stellaHomeHost))
+	}
 	for _, extraPath := range policy.Filesystem.ExtraReadOnlyMounts {
 		bwrapArgs = appendRoBindIfExists(bwrapArgs, extraPath, extraPath)
 	}

--- a/plugins/sandbox/local/session_linux.go
+++ b/plugins/sandbox/local/session_linux.go
@@ -239,13 +239,7 @@ func appendWritableBind(args []string, hostPath, sandboxPath string) []string {
 // sandbox-view location (STELLA_HOME is remapped to /home/stella/.stella).
 // Paths outside STELLA_HOME are returned unchanged.
 func remapToSandboxStellaHome(hostPath, stellaHomeHost string) string {
-	if hostPath == stellaHomeHost {
-		return sandboxStellaHome
-	}
-	if prefix := stellaHomeHost + string(filepath.Separator); strings.HasPrefix(hostPath, prefix) {
-		return sandboxStellaHome + hostPath[len(stellaHomeHost):]
-	}
-	return hostPath
+	return remapStellaHomePath(hostPath, stellaHomeHost, sandboxStellaHome)
 }
 
 func appendDirParents(args []string, path string) []string {

--- a/plugins/sandbox/local/session_linux_test.go
+++ b/plugins/sandbox/local/session_linux_test.go
@@ -234,3 +234,51 @@ func TestWrapCommand_linux_bwrapWorkspaceRemap(t *testing.T) {
 		t.Errorf("expected hostCwd %q, got %q", root, hostCwd)
 	}
 }
+
+// TestWrapCommand_linux_perUserMiseWritableBind verifies the per-user mise tree
+// is bound writable (--bind, not --ro-bind) at its STELLA_HOME-remapped path so
+// agents can install their own tools, while the rest of STELLA_HOME stays read-only.
+func TestWrapCommand_linux_perUserMiseWritableBind(t *testing.T) {
+	if _, err := exec.LookPath("bwrap"); err != nil {
+		t.Skip("bwrap not installed")
+	}
+	if !bwrapFunctional() {
+		t.Skip("bwrap not functional (namespace creation blocked)")
+	}
+
+	stellaHome := t.TempDir()
+	userDir := filepath.Join(stellaHome, "users", "u1", ".mise-tools")
+	if err := os.MkdirAll(userDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sandboxUserDir := filepath.Join(sandboxStellaHome, "users", "u1", ".mise-tools")
+
+	policy := sandboxpkg.Policy{
+		Filesystem: sandboxpkg.FilesystemPolicy{
+			WorkspaceRoot:   "/tmp/test-workspace",
+			WorkingDir:      "/workspace",
+			MiseUserDirHost: userDir,
+		},
+		Network: sandboxpkg.NetworkPolicy{Mode: sandboxpkg.NetworkAllowAll},
+	}
+
+	_, args, _, err := wrapCommand(policy, "/workspace", nil, stellaHome, "sh", []string{"-c", "echo hi"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	hasFlagPair := func(flag, first, second string) bool {
+		for i, a := range args {
+			if a == flag && i+2 < len(args) && args[i+1] == first && args[i+2] == second {
+				return true
+			}
+		}
+		return false
+	}
+	if !hasFlagPair("--bind", userDir, sandboxUserDir) {
+		t.Errorf("expected writable --bind %s %s for the per-user mise tree, got %v", userDir, sandboxUserDir, args)
+	}
+	if hasFlagPair("--ro-bind", userDir, sandboxUserDir) {
+		t.Errorf("per-user mise tree must be writable, not --ro-bind, got %v", args)
+	}
+}

--- a/plugins/sandbox/none/session.go
+++ b/plugins/sandbox/none/session.go
@@ -73,7 +73,11 @@ func (f *Factory) adjustPolicy(policy sandboxpkg.Policy) sandboxpkg.Policy {
 	if env == nil {
 		env = make(map[string]string)
 	}
-	env["PATH"] = sandboxpkg.HostEnvBuildPath(f.cfg.StellaHome)
+	userShims := ""
+	if dir := policy.Filesystem.MiseUserDirHost; dir != "" {
+		userShims = sandboxpkg.MiseUserShimsDir(dir)
+	}
+	env["PATH"] = sandboxpkg.HostEnvBuildPath(f.cfg.StellaHome, userShims)
 	policy.Env = env
 	return policy
 }


### PR DESCRIPTION
## What

Give each user a **writable mise home** so agents can install their own
tools at runtime, while keeping **one shared read-only copy** of the
builtin system tools. Isolation comes from mise's native config hierarchy
(system → user → project), **not** read-only mounts.

```
system (one read-only builtin copy) ──seed relative symlinks──▶ users/<userKey>/.mise-tools (writable)
                                                                  ├ installs/  (symlinked system + real self-installed)
                                                                  ├ shims/ cache/ state/ config/
project (workspace mise.toml, highest precedence)
```

Wired for the **local** (bwrap + Seatbelt) and **none** backends. Docker
keeps its in-image mise and is tracked separately in #436.

## Why

#424 — bwrap mounted the single `MISE_DATA_DIR` read-only, so any runtime
`mise install`/reshim failed. Repointing `MISE_DATA_DIR` per agent would
duplicate every builtin tool and re-introduce the path brittleness #424 is
trying to kill. The layered model fixes the write failure without
duplicating tools, and isolates users through mise config precedence
instead of fragile mount layouts.

## How

- **`pkg/sandbox/miseuser.go`** — `EnsureUserMiseHome` seeds the per-user
  tree by mirroring system `installs/<tool>/<version>` as **relative**
  symlinks, so they resolve identically on host and inside the sandbox;
  one physical copy, idempotent, never shadows a real user install.
- Per-user tree keyed by **userID** (`group-<id>` for groups), so the
  planned shared-user-directory refactor needs no change here.
- **`RuntimeMiseEnv`** points DATA/CACHE/STATE/CONFIG at the per-user tree,
  keeps `MISE_GLOBAL_CONFIG_FILE` on the shared `_builtin` layer, trusts
  the workspace (both `/workspace` and host path so it works on any
  backend), enables auto-install; falls back to the read-only system tree
  when no user key is safe.
- **Backends mount it writable**: Linux `--bind` at the remapped path,
  macOS Seatbelt opens `file-write*` on the subpath, none uses the real
  host path. Per-user shims are prepended ahead of system shims on `PATH`.
- **docker** keeps its in-image mise; per-user wiring is skipped there
  (`MiseUserDirHost` cleared, `RuntimeMiseEnv` not applied). Parity → #436.
- **Concurrency**: rely on idempotent seeding + mise's own install lock
  instead of a Stella-side file lock.

## Verification

- `mise run format && build && test` — all green; Windows + Linux
  cross-compile OK.
- **Real-mise end-to-end** (v2026.6.3): reproduced the in-sandbox layout —
  `mise which node` (`MISE_DATA_DIR`=per-user) resolved through the
  per-user relative symlink → system install → real binary (`v24.14.1`);
  `mise reshim` wrote per-user shims that executed correctly. Proves the
  per-user tree is writable, shims generate, and seeded system tools run
  through the symlink chain.
- New tests: `pkg/sandbox/miseuser_test.go` (seeding + key validation +
  idempotency), `internal/manifestplugins/mise_runtime_test.go` (env), and
  a Linux writable-bind assertion in `session_linux_test.go`.

## Refs

- Closes #424
- Follow-up: #436 (docker backend parity)