### PR TITLE
🐛 fix(web): repair Recally article list display

### DIFF
--- a/web/src/features/recally/components/RecallyArticleList.tsx
+++ b/web/src/features/recally/components/RecallyArticleList.tsx
@@ -64,7 +64,7 @@ export function RecallyArticleList({
   };
 
   return (
-    <div className="flex min-h-0 w-full flex-col overflow-hidden border-r border-border bg-card/50">
+    <div className="flex min-h-0 w-full flex-1 flex-col overflow-hidden border-r border-border bg-card/50">
       {/* Search + Filter Toolbar */}
       {!digestView && (
         <div className="shrink-0 border-b border-border px-3 py-2">
@@ -81,6 +81,8 @@ export function RecallyArticleList({
             </div>
             <button
               onClick={() => setRefinementsOpen(!refinementsOpen)}
+              title={t("recally.article.filterRefinements")}
+              aria-label={t("recally.article.filterRefinements")}
               className={cn(
                 "relative p-2 rounded-md border transition-colors duration-120 cursor-pointer flex items-center justify-center shrink-0",
                 refinementsOpen || activeFiltersCount > 0
@@ -104,7 +106,7 @@ export function RecallyArticleList({
         <div className="shrink-0 border-b border-border/40 p-3 space-y-2.5">
           <div className="flex items-center gap-3">
             <span className="text-xs font-mono font-semibold text-muted-foreground w-12 shrink-0">
-              Status:
+              {t("recally.filter.status")}
             </span>
             <div className="flex flex-wrap gap-1.5">
               <FilterChip
@@ -126,7 +128,7 @@ export function RecallyArticleList({
           </div>
           <div className="flex items-center gap-3">
             <span className="text-xs font-mono font-semibold text-muted-foreground w-12 shrink-0">
-              Source:
+              {t("recally.filter.source")}
             </span>
             <div className="flex flex-wrap gap-1.5">
               <FilterChip

--- a/web/src/features/recally/components/RecallyReader.tsx
+++ b/web/src/features/recally/components/RecallyReader.tsx
@@ -104,22 +104,25 @@ export function RecallyReader({
     setShareError(null);
   }, [selectedId]);
 
-  const createArticleShare = useCallback(async (articleId: string) => {
-    setSharing(true);
-    setShareError(null);
-    try {
-      const { data } = await createShare({
-        body: { source: "article", article_id: articleId, expires_in: "7d" },
-        throwOnError: true,
-      });
-      setShareUrl(data.url);
-      await navigator.clipboard?.writeText(data.url);
-    } catch (e) {
-      setShareError(e instanceof Error ? e.message : "Failed to share");
-    } finally {
-      setSharing(false);
-    }
-  }, []);
+  const createArticleShare = useCallback(
+    async (articleId: string) => {
+      setSharing(true);
+      setShareError(null);
+      try {
+        const { data } = await createShare({
+          body: { source: "article", article_id: articleId, expires_in: "7d" },
+          throwOnError: true,
+        });
+        setShareUrl(data.url);
+        await navigator.clipboard?.writeText(data.url);
+      } catch (e) {
+        setShareError(e instanceof Error ? e.message : t("recally.reader.shareFailed"));
+      } finally {
+        setSharing(false);
+      }
+    },
+    [t],
+  );
 
   const articleQuery = useQuery({
     ...getArticleOptions({
@@ -152,8 +155,7 @@ export function RecallyReader({
             </div>
             <h3 className="text-base font-semibold text-foreground">{t("recally.reader.empty")}</h3>
             <p className="text-xs text-muted-foreground mt-1 max-w-72 mx-auto leading-relaxed">
-              Select an article or digest from the sidebar queue to start reading and chatting with
-              AI.
+              {t("recally.reader.emptyDesc")}
             </p>
           </div>
         </div>
@@ -296,7 +298,9 @@ export function RecallyReader({
               {/* Delete / Destructive actions */}
               {confirmingDeleteId === selectedArticle.id ? (
                 <div className="flex items-center gap-1 bg-destructive/5 border border-destructive/20 rounded-lg p-1">
-                  <span className="text-xs font-medium text-destructive px-1.5">Confirm?</span>
+                  <span className="text-xs font-medium text-destructive px-1.5">
+                    {t("common.confirm")}
+                  </span>
                   <button
                     onClick={() =>
                       deleteArticleMut.mutate({
@@ -346,7 +350,7 @@ export function RecallyReader({
                     <Link className="size-4 text-primary/75 shrink-0 mt-0.5" />
                     <div className="min-w-0 flex-1">
                       <span className="text-xs font-semibold text-muted-foreground block leading-none mb-1">
-                        Source URL
+                        {t("recally.reader.sourceUrl")}
                       </span>
                       <a
                         href={parsed.metadata.url}
@@ -364,7 +368,7 @@ export function RecallyReader({
                     <Calendar className="size-4 text-primary/75 shrink-0 mt-0.5" />
                     <div className="min-w-0 flex-1">
                       <span className="text-xs font-semibold text-muted-foreground block leading-none mb-1">
-                        Published Time
+                        {t("recally.reader.publishedTime")}
                       </span>
                       <span className="text-xs text-foreground block leading-tight">
                         {parsed.metadata.publishedTime}
@@ -416,11 +420,10 @@ export function RecallyReader({
                 </div>
                 <div>
                   <h4 className="text-sm font-semibold text-foreground">
-                    No article content parsed
+                    {t("recally.reader.noContentParsed")}
                   </h4>
                   <p className="text-xs text-muted-foreground max-w-96 mx-auto mt-1 leading-normal">
-                    This item has no body text. It could be a simple link, or require JavaScript to
-                    render. You can read the summary or visit the original webpage.
+                    {t("recally.reader.noContentDesc")}
                   </p>
                 </div>
               </div>

--- a/web/src/features/recally/components/RecallySourceNav.tsx
+++ b/web/src/features/recally/components/RecallySourceNav.tsx
@@ -196,7 +196,9 @@ export function RecallySourceNav({
                       {pollFeedMut.isPending && pollFeedMut.variables?.path.id === feed.id ? (
                         <RefreshCw className="size-2.5 animate-spin" />
                       ) : feedPollResults[feed.id]?.error ? (
-                        <span className="text-destructive font-semibold">Err</span>
+                        <span className="text-destructive font-semibold">
+                          {t("recally.article.err")}
+                        </span>
                       ) : feedPollResults[feed.id] ? (
                         <span className="text-primary font-semibold">
                           +{feedPollResults[feed.id].newCount}
@@ -260,7 +262,9 @@ export function RecallySourceNav({
                   )}
                 </>
               ) : (
-                <div className="px-3 py-2 text-xs font-mono text-muted-foreground/45">No tags</div>
+                <div className="px-3 py-2 text-xs font-mono text-muted-foreground/45">
+                  {t("recally.tags.empty")}
+                </div>
               )}
             </div>
           )}

--- a/web/src/lib/i18n/messages.ts
+++ b/web/src/lib/i18n/messages.ts
@@ -1165,9 +1165,20 @@ const en = {
   "recally.reader.discuss": "Discuss",
   "recally.reader.discussWithAI": "Discuss with AI",
   "recally.reader.copyShareLink": "Copy share link",
+  "recally.reader.emptyDesc":
+    "Select an article or digest from the sidebar queue to start reading and chatting with AI.",
+  "recally.reader.shareFailed": "Failed to share",
+  "recally.reader.sourceUrl": "Source URL",
+  "recally.reader.publishedTime": "Published Time",
+  "recally.reader.noContentParsed": "No article content parsed",
+  "recally.reader.noContentDesc":
+    "This item has no body text. It could be a simple link, or require JavaScript to render. You can read the summary or visit the original webpage.",
   "recally.article.err": "Err",
   "recally.article.poll": "Poll",
   "recally.article.filterRefinements": "Filter refinements",
+  "recally.filter.status": "Status:",
+  "recally.filter.source": "Source:",
+  "recally.tags.empty": "No tags",
 
   // Automations (additions)
   "hub.priority": "Priority",
@@ -2497,9 +2508,19 @@ const zh: Record<MessageKey, string> = {
   "recally.reader.discuss": "讨论",
   "recally.reader.discussWithAI": "与 AI 讨论",
   "recally.reader.copyShareLink": "复制分享链接",
+  "recally.reader.emptyDesc": "从侧边栏选择文章或摘要，开始阅读并与 AI 讨论。",
+  "recally.reader.shareFailed": "分享失败",
+  "recally.reader.sourceUrl": "来源 URL",
+  "recally.reader.publishedTime": "发布时间",
+  "recally.reader.noContentParsed": "未解析到文章正文",
+  "recally.reader.noContentDesc":
+    "此条目没有正文内容。它可能只是一个链接，或需要 JavaScript 渲染。你可以阅读摘要，或访问原网页。",
   "recally.article.err": "错误",
   "recally.article.poll": "拉取",
   "recally.article.filterRefinements": "筛选条件",
+  "recally.filter.status": "状态：",
+  "recally.filter.source": "来源：",
+  "recally.tags.empty": "暂无标签",
 
   // Automations (additions)
   "hub.priority": "优先级",


### PR DESCRIPTION
## What
- Make the Recally article list fill the available middle-column height.
- Replace remaining hardcoded English strings in the Recally article list, reader, and source nav with i18n keys.

## Why
- The empty article list stopped early, leaving a broken blank block in the Recally layout.
- The Chinese UI still showed English copy in several Recally states.

## How
- Add flex growth to the `RecallyArticleList` root so it occupies its parent column.
- Add English/Chinese translations for filter labels, empty states, metadata labels, share errors, and tag/feed status text.

## Refs
- Closes #411