### PR TITLE
♻️ refactor(sandbox): key per-principal mise/temp trees by subtree, drop name prefix

### DIFF
--- a/internal/agent/sandbox/backend_test.go
+++ b/internal/agent/sandbox/backend_test.go
@@ -183,7 +183,7 @@ func TestRunnerFilesystemPolicyUsesUserScopedTmp(t *testing.T) {
 	if resolved, err := filepath.EvalSymlinks(base); err == nil {
 		base = resolved
 	}
-	want := filepath.Join(base, "user-42")
+	want := filepath.Join(base, "users", "42")
 	if policy.TempDirHost != want {
 		t.Fatalf("TempDirHost = %q, want %q", policy.TempDirHost, want)
 	}
@@ -191,6 +191,25 @@ func TestRunnerFilesystemPolicyUsesUserScopedTmp(t *testing.T) {
 		if got := runnerFilesystemPolicy(paths, Config{UserID: unsafeID}).TempDirHost; got != "" {
 			t.Fatalf("unsafe user id %q should not produce temp dir, got %q", unsafeID, got)
 		}
+	}
+}
+
+// A group session carries both a GroupID and a synthetic UserID equal to it. It
+// must key off the group subtree so a real user whose ID equals the group ID can
+// never share the group's writable mise/temp trees.
+func TestRunnerFilesystemPolicyGroupUsesGroupSubtree(t *testing.T) {
+	paths := Paths{StellaHome: "/stella", UserRoot: "/workspace", WorkDir: "/workspace"}
+	policy := runnerFilesystemPolicy(paths, Config{GroupID: "g7", UserID: "g7"})
+
+	if want := filepath.Join("/stella", "groups", "g7", ".mise-tools"); policy.MiseUserDirHost != want {
+		t.Fatalf("MiseUserDirHost = %q, want %q", policy.MiseUserDirHost, want)
+	}
+	base := os.TempDir()
+	if resolved, err := filepath.EvalSymlinks(base); err == nil {
+		base = resolved
+	}
+	if want := filepath.Join(base, "groups", "g7"); policy.TempDirHost != want {
+		t.Fatalf("TempDirHost = %q, want %q", policy.TempDirHost, want)
 	}
 }
 

--- a/internal/agent/sandbox/env.go
+++ b/internal/agent/sandbox/env.go
@@ -18,49 +18,54 @@ import (
 )
 
 func runnerFilesystemPolicy(paths Paths, cfg Config) pkgsandbox.FilesystemPolicy {
-	key := miseUserKey(cfg)
-	miseDir := pkgsandbox.MiseUserToolsDir(paths.StellaHome, key)
-	// A non-empty key that yields no dir means the user/group ID failed the
+	principalDir, id := misePrincipal(cfg)
+	miseDir := pkgsandbox.MiseUserToolsDir(paths.StellaHome, principalDir, id)
+	// A set principal that yields no dir means the user/group ID failed the
 	// safe-path-component check. Don't fail the session (we fall back to the
 	// shared read-only system tree and a session-local temp dir), but surface the
 	// silent downgrade so a malformed ID is diagnosable instead of mysterious.
-	if key != "" && miseDir == "" {
-		slog.Warn("per-user mise tree disabled: unsafe key, using shared read-only system tree",
+	if id != "" && miseDir == "" {
+		slog.Warn("per-user mise tree disabled: unsafe id, using shared read-only system tree",
 			"component", "runner_sandbox",
 			"user_id", cfg.UserID,
 			"group_id", cfg.GroupID,
-			"key", key,
+			"principal_dir", principalDir,
 		)
 	}
 	return pkgsandbox.FilesystemPolicy{
 		WorkspaceRoot:       paths.UserRoot,
 		WorkingDir:          paths.WorkDir,
 		ExtraReadOnlyMounts: skillMountsForSandbox(paths),
-		TempDirHost:         userTempDir(key),
+		TempDirHost:         userTempDir(principalDir, id),
 		MiseUserDirHost:     miseDir,
 	}
 }
 
-// miseUserKey returns the key for this session's per-user temp and mise trees.
-// User and group keys carry disjoint prefixes ("user-"/"group-") so the two
-// principal namespaces can never collide into one shared writable tree, even if a
-// user ID ever takes the literal form "group-<n>". Empty when neither is set,
-// which makes callers fall back to a session-local temp dir and the shared
-// read-only system mise tree.
-func miseUserKey(cfg Config) string {
+// misePrincipal returns the home subtree and raw ID for this session's per-user
+// temp and mise trees. Users and groups resolve to disjoint top-level subtrees
+// ("users"/"groups") keyed by the raw ID, so the two principal namespaces live in
+// separate trees and equal IDs across them can never collide into one shared
+// writable tree — without a name prefix. Empty dir when neither is set, which
+// makes callers fall back to a session-local temp dir and the shared read-only
+// system mise tree. Groups take precedence: a group session carries both a
+// GroupID and a synthetic UserID and must key off the group.
+func misePrincipal(cfg Config) (principalDir, id string) {
 	if cfg.GroupID != "" {
-		return "group-" + cfg.GroupID
+		return "groups", cfg.GroupID
 	}
 	if cfg.UserID == "" {
-		return ""
+		return "", ""
 	}
-	return "user-" + cfg.UserID
+	return "users", cfg.UserID
 }
 
 var validUserTempDirID = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
 
-func userTempDir(userID string) string {
-	if !validUserTempDirID.MatchString(userID) {
+// userTempDir returns the per-principal scratch dir mounted as /tmp. principalDir
+// ("users"/"groups") keeps the user and group namespaces in separate subtrees so
+// equal IDs across them can't share a temp dir. Empty for an empty or unsafe id.
+func userTempDir(principalDir, id string) string {
+	if principalDir == "" || !validUserTempDirID.MatchString(id) {
 		return ""
 	}
 	// Resolve symlinks in the base temp dir so that pathWithinRoot checks
@@ -69,7 +74,7 @@ func userTempDir(userID string) string {
 	if resolved, err := filepath.EvalSymlinks(base); err == nil {
 		base = resolved
 	}
-	return filepath.Join(base, userID)
+	return filepath.Join(base, principalDir, id)
 }
 
 // skillMountsForSandbox returns host paths for all skill directories that must
@@ -177,7 +182,8 @@ func buildSandboxEnv(ctx context.Context, cfg Config, paths Paths) (map[string]s
 	// PATH, so they need the mise env pointed at the org's config. Docker carries
 	// its own in-image mise tree and PATH, so host-side paths must not leak in.
 	if resolveBackendName(ctx, cfg) != config.SandboxBackendDocker {
-		userDataDir := pkgsandbox.MiseUserToolsDir(paths.StellaHome, miseUserKey(cfg))
+		principalDir, id := misePrincipal(cfg)
+		userDataDir := pkgsandbox.MiseUserToolsDir(paths.StellaHome, principalDir, id)
 		maps.Copy(env, manifestplugins.RuntimeMiseEnv(paths.StellaHome, userDataDir, paths.UserRoot))
 	}
 

--- a/pkg/sandbox/hostenv.go
+++ b/pkg/sandbox/hostenv.go
@@ -40,17 +40,23 @@ func MiseShimsDir(stellaHome string) string {
 // path component. Anything else falls back to the shared (read-only) system tree.
 var miseUserKeyPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
 
-// MiseUserToolsDir returns the per-user writable MISE_DATA_DIR. It mirrors a
-// real machine's per-user mise home: each user (or group) gets one tree shared
-// by all their agents, layered above the shared read-only system installs.
-// The path is keyed purely by userKey — never by agent — so the planned
-// user-directory refactor (user-scoped dirs, agents as apps) needs no change here.
-// An empty or unsafe key yields "" so callers fall back to the system tree.
-func MiseUserToolsDir(stellaHome, userKey string) string {
-	if !miseUserKeyPattern.MatchString(userKey) {
+// MiseUserToolsDir returns the per-principal writable MISE_DATA_DIR. It mirrors a
+// real machine's per-user mise home: each user or group gets one tree shared by
+// all their agents, layered above the shared read-only system installs.
+// principalDir is the top-level home subtree ("users" or "groups") and id is the
+// raw user/group ID. Keying as {stellaHome}/{principalDir}/{id}/.mise-tools puts
+// the two principal namespaces in disjoint top-level trees, so equal IDs across
+// them can't collide — no name prefix needed. The path never depends on the
+// agent, so all of a principal's agents share one tree. An empty or unsafe
+// argument yields "" so callers fall back to the system tree.
+func MiseUserToolsDir(stellaHome, principalDir, id string) string {
+	if principalDir != "users" && principalDir != "groups" {
 		return ""
 	}
-	return filepath.Join(stellaHome, "users", userKey, ".mise-tools")
+	if !miseUserKeyPattern.MatchString(id) {
+		return ""
+	}
+	return filepath.Join(stellaHome, principalDir, id, ".mise-tools")
 }
 
 // MiseUserShimsDir returns the per-user mise shims directory. It is prepended to

--- a/pkg/sandbox/miseuser_test.go
+++ b/pkg/sandbox/miseuser_test.go
@@ -8,18 +8,21 @@ import (
 
 func TestMiseUserToolsDir(t *testing.T) {
 	home := "/srv/.stella"
-	cases := map[string]string{
-		"u1":          filepath.Join(home, "users", "u1", ".mise-tools"),
-		"group-42":    filepath.Join(home, "users", "group-42", ".mise-tools"),
-		"":            "", // no user → fall back to the system tree
-		"a/b":         "", // path traversal rejected
-		"..":          "",
-		"bad name":    "",
-		"weird;rm-rf": "",
+	type in struct{ dir, id string }
+	cases := map[in]string{
+		{"users", "u1"}:          filepath.Join(home, "users", "u1", ".mise-tools"),
+		{"groups", "42"}:         filepath.Join(home, "groups", "42", ".mise-tools"),
+		{"users", ""}:            "", // no id → fall back to the system tree
+		{"", "u1"}:               "", // no principal subtree
+		{"vault", "u1"}:          "", // unknown subtree rejected
+		{"users", "a/b"}:         "", // path traversal rejected
+		{"users", ".."}:          "",
+		{"users", "bad name"}:    "",
+		{"users", "weird;rm-rf"}: "",
 	}
-	for key, want := range cases {
-		if got := MiseUserToolsDir(home, key); got != want {
-			t.Errorf("MiseUserToolsDir(%q) = %q, want %q", key, got, want)
+	for k, want := range cases {
+		if got := MiseUserToolsDir(home, k.dir, k.id); got != want {
+			t.Errorf("MiseUserToolsDir(%q, %q) = %q, want %q", k.dir, k.id, got, want)
 		}
 	}
 }
@@ -31,7 +34,7 @@ func TestEnsureUserMiseHome_SeedsSystemInstallsAsRelativeSymlinks(t *testing.T) 
 	mustMkdirAll(t, sysGo)
 	mustWriteFile(t, filepath.Join(sysGo, "go"), "binary")
 
-	userDir := MiseUserToolsDir(stellaHome, "u1")
+	userDir := MiseUserToolsDir(stellaHome, "users", "u1")
 	if err := EnsureUserMiseHome(stellaHome, userDir); err != nil {
 		t.Fatalf("EnsureUserMiseHome: %v", err)
 	}
@@ -66,7 +69,7 @@ func TestEnsureUserMiseHome_IdempotentAndDoesNotShadowUserInstall(t *testing.T) 
 	stellaHome := t.TempDir()
 	mustMkdirAll(t, filepath.Join(MiseToolsDir(stellaHome), "installs", "node", "20.0.0"))
 
-	userDir := MiseUserToolsDir(stellaHome, "u1")
+	userDir := MiseUserToolsDir(stellaHome, "users", "u1")
 	// A real user-installed version sits alongside the (to-be-seeded) system one.
 	userNode22 := filepath.Join(userDir, "installs", "node", "22.0.0")
 	mustMkdirAll(t, userNode22)
@@ -91,7 +94,7 @@ func TestEnsureUserMiseHome_DoesNotSeedThroughPlantedSymlink(t *testing.T) {
 	stellaHome := t.TempDir()
 	mustMkdirAll(t, filepath.Join(MiseToolsDir(stellaHome), "installs", "node", "20.0.0"))
 
-	userDir := MiseUserToolsDir(stellaHome, "u1")
+	userDir := MiseUserToolsDir(stellaHome, "users", "u1")
 	mustMkdirAll(t, userDir)
 	// A prior session's agent planted a symlink where "installs" belongs, aimed at
 	// an outside dir it wants the (unsandboxed) seeding step to write into.
@@ -123,7 +126,7 @@ func TestEnsureUserMiseHome_RelinksPerUserShimsToRelative(t *testing.T) {
 	mustMkdirAll(t, filepath.Join(stellaHome, "bin"))
 	mustWriteFile(t, filepath.Join(stellaHome, "bin", "mise"), "binary")
 
-	userDir := MiseUserToolsDir(stellaHome, "u1")
+	userDir := MiseUserToolsDir(stellaHome, "users", "u1")
 	mustMkdirAll(t, filepath.Join(userDir, "shims"))
 	// A shim mise wrote inside a different backend's sandbox: an absolute,
 	// backend-specific target that wouldn't resolve under another backend.
@@ -151,7 +154,7 @@ func TestEnsureUserMiseHome_RelinksPerUserShimsToRelative(t *testing.T) {
 
 func TestEnsureUserMiseHome_PrunesDanglingSeedLinks(t *testing.T) {
 	stellaHome := t.TempDir()
-	userDir := MiseUserToolsDir(stellaHome, "u1")
+	userDir := MiseUserToolsDir(stellaHome, "users", "u1")
 	mustMkdirAll(t, filepath.Join(userDir, "installs", "node"))
 	// A seed link whose system target was pruned/upgraded away.
 	dangling := filepath.Join(userDir, "installs", "node", "18.0.0")


### PR DESCRIPTION
## What

First step of the user-home-centric layout (#442): route a user's writable mise
tree and scratch temp dir to `users/{id}` and a group's to `groups/{id}` — raw
IDs in disjoint top-level subtrees — instead of one shared `users/` namespace
disambiguated by a `user-`/`group-` name prefix. The on-disk path is now the raw
ID:

```
✅ {STELLA_HOME}/users/7e942981-…/.mise-tools/shims/pnpm
❌ {STELLA_HOME}/users/user-7e942981-…/.mise-tools/shims/pnpm
```

## Why

The `user-`/`group-` prefix was added (review finding CR-008 on #424) only to keep
the two principal namespaces from colliding inside one shared `users/` tree — e.g.
a real user whose ID is literally `group-1` vs the group `1`. Splitting users and
groups into separate top-level subtrees makes that collision structurally
impossible, so the prefix is dead weight and the directory can be the bare ID.
This is exactly the keying shape the unified layout (#442) targets, so doing it now
keeps the mise/temp trees from being migrated twice.

## How

- `MiseUserToolsDir(stellaHome, principalDir, id)` now takes the home subtree
  (`"users"`/`"groups"`) and raw ID, joining `{stellaHome}/{principalDir}/{id}/.mise-tools`.
  Unknown subtrees and unsafe IDs still yield `""` (fall back to the shared
  read-only system tree).
- `miseUserKey` (prefix builder) → `misePrincipal(cfg) (principalDir, id)`. Groups
  still take precedence over the synthetic per-group UserID.
- `userTempDir(principalDir, id)` mounts `/tmp` from `{tmp}/{principalDir}/{id}`,
  keeping user/group scratch dirs in separate subtrees too.
- Tests: `TestMiseUserToolsDir` covers both subtrees + rejection cases; new
  `TestRunnerFilesystemPolicyGroupUsesGroupSubtree` locks in that a group session
  (UserID == GroupID) keys off `groups/{id}`, the CR-008 regression guard under the
  new structure.

No migration code: #424 (#437) has not shipped, so `users/user-*` / `users/group-*`
trees exist only in dev and repopulate lazily at the new path on next session.

Verification: `go build ./...`, `go test ./...`, Windows + Linux cross-builds all
pass. (`mise run format`'s web step is broken locally on a vite native-binding
issue unrelated to this Go-only change; `gofmt` is clean.)

## Refs

- #442 (user-home-centric layout — this is its first step)
- #424 / #437 (layered per-user mise; introduced the prefix as CR-008)