### PR TITLE
♻️ refactor(sandbox): generalize MiseUserDirHost into ExtraWritableMounts (CR-004)

### DIFF
--- a/internal/agent/sandbox/backend_test.go
+++ b/internal/agent/sandbox/backend_test.go
@@ -199,17 +199,17 @@ func TestRunnerFilesystemPolicyUsesUserScopedTmp(t *testing.T) {
 // never share the group's writable mise/temp trees.
 func TestRunnerFilesystemPolicyGroupUsesGroupSubtree(t *testing.T) {
 	paths := Paths{StellaHome: "/stella", UserRoot: "/workspace", WorkDir: "/workspace"}
-	policy := runnerFilesystemPolicy(paths, Config{GroupID: "g7", UserID: "g7"})
+	cfg := Config{GroupID: "g7", UserID: "g7"}
 
-	if want := filepath.Join("/stella", "groups", "g7", ".mise-tools"); policy.MiseUserDirHost != want {
-		t.Fatalf("MiseUserDirHost = %q, want %q", policy.MiseUserDirHost, want)
+	if want := filepath.Join("/stella", "groups", "g7", ".mise-tools"); miseUserDirHost(paths, cfg) != want {
+		t.Fatalf("miseUserDirHost = %q, want %q", miseUserDirHost(paths, cfg), want)
 	}
 	base := os.TempDir()
 	if resolved, err := filepath.EvalSymlinks(base); err == nil {
 		base = resolved
 	}
-	if want := filepath.Join(base, "groups", "g7"); policy.TempDirHost != want {
-		t.Fatalf("TempDirHost = %q, want %q", policy.TempDirHost, want)
+	if want := filepath.Join(base, "groups", "g7"); runnerFilesystemPolicy(paths, cfg).TempDirHost != want {
+		t.Fatalf("TempDirHost = %q, want %q", runnerFilesystemPolicy(paths, cfg).TempDirHost, want)
 	}
 }
 

--- a/internal/agent/sandbox/env.go
+++ b/internal/agent/sandbox/env.go
@@ -19,12 +19,25 @@ import (
 
 func runnerFilesystemPolicy(paths Paths, cfg Config) pkgsandbox.FilesystemPolicy {
 	principalDir, id := misePrincipal(cfg)
-	miseDir := pkgsandbox.MiseUserToolsDir(paths.StellaHome, principalDir, id)
-	// A set principal that yields no dir means the user/group ID failed the
-	// safe-path-component check. Don't fail the session (we fall back to the
-	// shared read-only system tree and a session-local temp dir), but surface the
-	// silent downgrade so a malformed ID is diagnosable instead of mysterious.
-	if id != "" && miseDir == "" {
+	return pkgsandbox.FilesystemPolicy{
+		WorkspaceRoot:       paths.UserRoot,
+		WorkingDir:          paths.WorkDir,
+		ExtraReadOnlyMounts: skillMountsForSandbox(paths),
+		TempDirHost:         userTempDir(principalDir, id),
+	}
+}
+
+// miseUserDirHost returns the host path of this session's writable per-user mise
+// home, or "" when there is no per-user tree: no principal, or an ID that fails
+// the safe-path-component check (the session then falls back to the shared
+// read-only system tree). A downgrade from an unsafe ID is logged so a malformed
+// ID is diagnosable instead of mysterious. The caller seeds the tree and adds it
+// to the policy's writable mounts; keeping that mise-specific wiring here leaves
+// the FilesystemPolicy mise-agnostic.
+func miseUserDirHost(paths Paths, cfg Config) string {
+	principalDir, id := misePrincipal(cfg)
+	dir := pkgsandbox.MiseUserToolsDir(paths.StellaHome, principalDir, id)
+	if id != "" && dir == "" {
 		slog.Warn("per-user mise tree disabled: unsafe id, using shared read-only system tree",
 			"component", "runner_sandbox",
 			"user_id", cfg.UserID,
@@ -32,13 +45,7 @@ func runnerFilesystemPolicy(paths Paths, cfg Config) pkgsandbox.FilesystemPolicy
 			"principal_dir", principalDir,
 		)
 	}
-	return pkgsandbox.FilesystemPolicy{
-		WorkspaceRoot:       paths.UserRoot,
-		WorkingDir:          paths.WorkDir,
-		ExtraReadOnlyMounts: skillMountsForSandbox(paths),
-		TempDirHost:         userTempDir(principalDir, id),
-		MiseUserDirHost:     miseDir,
-	}
+	return dir
 }
 
 // misePrincipal returns the home subtree and raw ID for this session's per-user

--- a/internal/agent/sandbox/session.go
+++ b/internal/agent/sandbox/session.go
@@ -129,14 +129,17 @@ func buildBasePolicy(ctx context.Context, cfg Config) (Paths, pkgsandbox.Policy,
 			return Paths{}, pkgsandbox.Policy{}, fmt.Errorf("ensure user temp dir: %w", err)
 		}
 	}
-	// Docker carries its own in-image mise tree; the per-user host tree only
-	// applies to host-execution backends (local, none).
-	if resolveBackendName(ctx, cfg) == config.SandboxBackendDocker {
-		fs.MiseUserDirHost = ""
-	}
-	if fs.MiseUserDirHost != "" {
-		if err := pkgsandbox.EnsureUserMiseHome(paths.StellaHome, fs.MiseUserDirHost); err != nil {
-			return Paths{}, pkgsandbox.Policy{}, fmt.Errorf("ensure per-user mise home: %w", err)
+	// Per-user mise tree: host-execution backends (local, none) get a writable
+	// per-user mise home, seeded with relative symlinks to the read-only system
+	// installs and mounted writable so the agent can install its own tools.
+	// Docker carries its own in-image mise tree, so it is skipped here (bringing
+	// docker to parity is tracked in #436).
+	if resolveBackendName(ctx, cfg) != config.SandboxBackendDocker {
+		if miseDir := miseUserDirHost(paths, cfg); miseDir != "" {
+			if err := pkgsandbox.EnsureUserMiseHome(paths.StellaHome, miseDir); err != nil {
+				return Paths{}, pkgsandbox.Policy{}, fmt.Errorf("ensure per-user mise home: %w", err)
+			}
+			fs.ExtraWritableMounts = append(fs.ExtraWritableMounts, miseDir)
 		}
 	}
 

--- a/internal/manifestplugins/mise_config.go
+++ b/internal/manifestplugins/mise_config.go
@@ -71,6 +71,11 @@ func runtimeScopeConfigPath(stellaHome string) string {
 // When userDataDir is empty (no user/group) it falls back to the read-only system
 // tree with auto-install disabled and state redirected to a writable temp dir,
 // matching the historical behavior.
+//
+// MISE_DATA_DIR is load-bearing beyond mise itself: the sandbox host backends
+// recover the per-user mise home from it via pkgsandbox.PerUserMiseDataDir to put
+// the per-user shims on PATH, so the FilesystemPolicy carries no mise-specific
+// field. Keep DATA_DIR pointing at userDataDir (or the system tree when empty).
 func RuntimeMiseEnv(stellaHome, userDataDir, workspaceDir string) map[string]string {
 	dataDir := userDataDir
 	if dataDir == "" {

--- a/pkg/sandbox/hostenv.go
+++ b/pkg/sandbox/hostenv.go
@@ -72,6 +72,11 @@ func MiseUserShimsDir(userToolsDir string) string {
 // mise-specific field. stellaHome is the host STELLA_HOME used to recognize the
 // system tree; the returned path is whatever scope the env holds (host path here,
 // the backend remaps it as needed).
+//
+// Precondition: env's MISE_DATA_DIR and stellaHome must be in the same scope
+// (both host paths, or both sandbox paths). Callers that remap MISE_* env vars
+// must read this before remapping (see adjustPolicy), since after remap the
+// data dir no longer matches the host system tree this compares against.
 func PerUserMiseDataDir(env map[string]string, stellaHome string) string {
 	dir := env["MISE_DATA_DIR"]
 	if dir == "" || dir == MiseToolsDir(stellaHome) {

--- a/pkg/sandbox/hostenv.go
+++ b/pkg/sandbox/hostenv.go
@@ -65,6 +65,21 @@ func MiseUserShimsDir(userToolsDir string) string {
 	return filepath.Join(userToolsDir, "shims")
 }
 
+// PerUserMiseDataDir returns the per-user MISE_DATA_DIR carried in a session's
+// env, or "" when it points at the shared read-only system tree (or is unset).
+// It lets a host backend recover the per-user mise home — to derive the shims
+// dir for PATH — from the env it already remaps, so the FilesystemPolicy needs no
+// mise-specific field. stellaHome is the host STELLA_HOME used to recognize the
+// system tree; the returned path is whatever scope the env holds (host path here,
+// the backend remaps it as needed).
+func PerUserMiseDataDir(env map[string]string, stellaHome string) string {
+	dir := env["MISE_DATA_DIR"]
+	if dir == "" || dir == MiseToolsDir(stellaHome) {
+		return ""
+	}
+	return dir
+}
+
 // HostEnvBuildPath returns a sanitized PATH suitable for host-execution sandbox
 // backends (local, none). It prepends the per-user mise shims (so a user's own
 // tool versions win), then the system mise shims and stella bin directories, and

--- a/pkg/sandbox/miseuser_test.go
+++ b/pkg/sandbox/miseuser_test.go
@@ -27,6 +27,23 @@ func TestMiseUserToolsDir(t *testing.T) {
 	}
 }
 
+func TestPerUserMiseDataDir(t *testing.T) {
+	home := "/srv/.stella"
+	cases := map[string]struct {
+		env  map[string]string
+		want string
+	}{
+		"per-user tree": {map[string]string{"MISE_DATA_DIR": home + "/users/u1/.mise-tools"}, home + "/users/u1/.mise-tools"},
+		"system tree":   {map[string]string{"MISE_DATA_DIR": MiseToolsDir(home)}, ""},
+		"unset":         {map[string]string{}, ""},
+	}
+	for name, tc := range cases {
+		if got := PerUserMiseDataDir(tc.env, home); got != tc.want {
+			t.Errorf("%s: PerUserMiseDataDir = %q, want %q", name, got, tc.want)
+		}
+	}
+}
+
 func TestEnsureUserMiseHome_SeedsSystemInstallsAsRelativeSymlinks(t *testing.T) {
 	stellaHome := t.TempDir()
 	// A builtin tool already installed in the shared system tree.

--- a/pkg/sandbox/policy.go
+++ b/pkg/sandbox/policy.go
@@ -55,13 +55,17 @@ type FilesystemPolicy struct {
 	// backend sees the policy; they may be shared across sessions.
 	TempDirHost string
 
-	// MiseUserDirHost is the host path of the per-user writable MISE_DATA_DIR
-	// (see pkgsandbox.MiseUserToolsDir). When set, host-execution backends bind
-	// it writable so agents can install their own mise tools, layered above the
-	// shared read-only system installs. Empty means no per-user tree — the
-	// session uses the read-only system tree only. The directory is guaranteed
-	// to exist (and be seeded with system installs) before the backend sees it.
-	MiseUserDirHost string
+	// ExtraWritableMounts is a list of host paths to mount writable inside the
+	// sandbox at their STELLA_HOME-remapped path. Symmetric with
+	// ExtraReadOnlyMounts: the isolating backends bind each writable (bwrap
+	// --bind, Seatbelt allow file-write*); the host-passthrough backends
+	// (none/local) need no mount since they share the host filesystem. Used for
+	// per-user subtrees an agent must write through — today the writable per-user
+	// mise home (see pkgsandbox.MiseUserToolsDir), with more to follow. Each path
+	// is guaranteed to exist (the mise tree also seeded with system installs)
+	// before the backend sees the policy. The policy stays mise-agnostic: it only
+	// learns "these host dirs are writable", not why.
+	ExtraWritableMounts []string
 }
 
 // NetworkPolicy defines network constraints for a sandbox session.

--- a/pkg/sandbox/policy.go
+++ b/pkg/sandbox/policy.go
@@ -56,15 +56,25 @@ type FilesystemPolicy struct {
 	TempDirHost string
 
 	// ExtraWritableMounts is a list of host paths to mount writable inside the
-	// sandbox at their STELLA_HOME-remapped path. Symmetric with
-	// ExtraReadOnlyMounts: the isolating backends bind each writable (bwrap
-	// --bind, Seatbelt allow file-write*); the host-passthrough backends
-	// (none/local) need no mount since they share the host filesystem. Used for
-	// per-user subtrees an agent must write through — today the writable per-user
-	// mise home (see pkgsandbox.MiseUserToolsDir), with more to follow. Each path
-	// is guaranteed to exist (the mise tree also seeded with system installs)
-	// before the backend sees the policy. The policy stays mise-agnostic: it only
-	// learns "these host dirs are writable", not why.
+	// sandbox at their STELLA_HOME-remapped path. Each path must live under the
+	// host STELLA_HOME: the isolating backends mount it at its remapped location
+	// (bwrap remaps STELLA_HOME -> /home/stella/.stella; Seatbelt uses the host
+	// path unchanged), so a path outside STELLA_HOME would bind at an unintended
+	// target. This differs from ExtraReadOnlyMounts, which mounts at the exact
+	// host path (same-path strategy).
+	//
+	// The isolating backends bind each writable (bwrap --bind, Seatbelt allow
+	// file-write*); the none backend needs no mount since it shares the host
+	// filesystem. The docker backend is the exception: it ships its own in-image
+	// mise and never reads this field, so the caller skips populating it for
+	// docker (see the backend guard in buildBasePolicy). Reaching docker with a
+	// non-empty list would silently no-op — backend parity is tracked in #442.
+	//
+	// Used for per-user subtrees an agent must write through — today the writable
+	// per-user mise home (see pkgsandbox.MiseUserToolsDir), with more to follow.
+	// Each path is guaranteed to exist (the mise tree also seeded with system
+	// installs) before the backend sees the policy. The policy stays mise-agnostic:
+	// it only learns "these host dirs are writable", not why.
 	ExtraWritableMounts []string
 }
 

--- a/plugins/sandbox/local/session.go
+++ b/plugins/sandbox/local/session.go
@@ -107,8 +107,10 @@ func (f *Factory) adjustPolicy(policy sandboxpkg.Policy) sandboxpkg.Policy {
 	sandboxSH := adjustStellaHome(f.cfg.StellaHome)
 	hostSH := f.cfg.StellaHome
 	remap := func(p string) string { return remapStellaHomePath(p, hostSH, sandboxSH) }
+	// Recover the per-user mise home from the runtime env (MISE_DATA_DIR, still a
+	// host path here) and remap it to the sandbox tree to put its shims on PATH.
 	userShims := ""
-	if dir := policy.Filesystem.MiseUserDirHost; dir != "" {
+	if dir := sandboxpkg.PerUserMiseDataDir(env, hostSH); dir != "" {
 		userShims = sandboxpkg.MiseUserShimsDir(remap(dir))
 	}
 	env["PATH"] = sandboxpkg.HostEnvBuildPath(sandboxSH, userShims)

--- a/plugins/sandbox/local/session_darwin.go
+++ b/plugins/sandbox/local/session_darwin.go
@@ -104,7 +104,10 @@ func checkSandboxRequirements() error {
 // the policy requests NetworkDisabled.
 //
 // SBPL evaluates rules in order and the last match wins.
-func buildSeatbeltProfile(policy sandboxpkg.Policy) string {
+//
+// stellaHomeHost is the host STELLA_HOME, used to recognize whether the policy
+// carries a writable per-user mise tree (see the cache/state fallback below).
+func buildSeatbeltProfile(policy sandboxpkg.Policy, stellaHomeHost string) string {
 	workspace := policy.WorkspaceRootOrDefault()
 	networkMode := policy.NetworkModeOrDefault()
 
@@ -129,12 +132,16 @@ func buildSeatbeltProfile(policy sandboxpkg.Policy) string {
 
 	// Extra writable mounts (e.g. the per-user mise home): carve out each subtree
 	// so the agent can write through it — for mise that's installs/cache/state,
-	// all under the tree. With no writable per-user tree, the system installs stay
-	// read-only and only the narrow cache/state metadata holes mise needs open.
+	// all under the tree.
 	for _, dir := range policy.Filesystem.ExtraWritableMounts {
 		fmt.Fprintf(&sb, "(allow file-write* (subpath %q))\n", filepath.Clean(dir))
 	}
-	if len(policy.Filesystem.ExtraWritableMounts) == 0 {
+	// With no writable per-user mise tree, the shared system installs stay
+	// read-only; mise still needs its cache/state metadata holes open. Key off the
+	// per-user mise data dir recovered from the env — not len(ExtraWritableMounts)
+	// — so an unrelated writable mount cannot suppress these holes. This mirrors
+	// how the none/linux backends recover the per-user mise home from the env.
+	if sandboxpkg.PerUserMiseDataDir(policy.Env, stellaHomeHost) == "" {
 		appendSeatbeltWritableEnvDirs(&sb, policy.Env)
 	}
 
@@ -162,7 +169,7 @@ func appendSeatbeltWritableEnvDirs(sb *strings.Builder, env map[string]string) {
 // wrapCommand wraps name+args with sandbox-exec for macOS Seatbelt isolation.
 // tmpMounts is accepted for signature compatibility with the Linux backend but
 // is not used here — macOS bash and file tools share the same host filesystem.
-func wrapCommand(policy sandboxpkg.Policy, sandboxCwd string, _ []tmpMount, _ string, name string, args []string) (execPath string, execArgs []string, hostCwd string, err error) {
+func wrapCommand(policy sandboxpkg.Policy, sandboxCwd string, _ []tmpMount, stellaHomeHost string, name string, args []string) (execPath string, execArgs []string, hostCwd string, err error) {
 	if !seatbeltFunctional() {
 		return "", nil, "", fmt.Errorf(
 			"local sandbox: sandbox-exec (macOS Seatbelt) is required but not available",
@@ -174,7 +181,7 @@ func wrapCommand(policy sandboxpkg.Policy, sandboxCwd string, _ []tmpMount, _ st
 		return "", nil, "", fmt.Errorf("local exec: look up %q: %w", name, lookErr)
 	}
 
-	profile := buildSeatbeltProfile(policy)
+	profile := buildSeatbeltProfile(policy, stellaHomeHost)
 	seatbeltArgs := []string{"-p", profile, resolved}
 	seatbeltArgs = append(seatbeltArgs, args...)
 	return seatbeltExecPath, seatbeltArgs, sandboxCwd, nil

--- a/plugins/sandbox/local/session_darwin.go
+++ b/plugins/sandbox/local/session_darwin.go
@@ -127,13 +127,14 @@ func buildSeatbeltProfile(policy sandboxpkg.Policy) string {
 	// Dev nodes: required for stdout/stderr, pseudo-terminals, /dev/null, etc.
 	sb.WriteString("(allow file-write* (subpath \"/dev\"))\n")
 
-	// Mise: with a per-user tree, carve out the whole writable mise home so the
-	// agent can install tools (installs/cache/state all live under it). Without
-	// one, the system installs stay read-only and only the narrow cache/state
-	// metadata holes mise needs are opened.
-	if dir := policy.Filesystem.MiseUserDirHost; dir != "" {
+	// Extra writable mounts (e.g. the per-user mise home): carve out each subtree
+	// so the agent can write through it — for mise that's installs/cache/state,
+	// all under the tree. With no writable per-user tree, the system installs stay
+	// read-only and only the narrow cache/state metadata holes mise needs open.
+	for _, dir := range policy.Filesystem.ExtraWritableMounts {
 		fmt.Fprintf(&sb, "(allow file-write* (subpath %q))\n", filepath.Clean(dir))
-	} else {
+	}
+	if len(policy.Filesystem.ExtraWritableMounts) == 0 {
 		appendSeatbeltWritableEnvDirs(&sb, policy.Env)
 	}
 

--- a/plugins/sandbox/local/session_darwin_test.go
+++ b/plugins/sandbox/local/session_darwin_test.go
@@ -43,7 +43,7 @@ func TestWrapCommand_darwin_usesSeatbelt(t *testing.T) {
 
 func TestBuildSeatbeltProfile_structure(t *testing.T) {
 	policy := makePolicy("/tmp/ws", sandboxpkg.NetworkDisabled)
-	profile := buildSeatbeltProfile(policy)
+	profile := buildSeatbeltProfile(policy, "")
 
 	for _, want := range []string{
 		"(allow default)",
@@ -68,7 +68,7 @@ func TestBuildSeatbeltProfile_allowsMiseRuntimeWriteDirs(t *testing.T) {
 		"MISE_CACHE_DIR": filepath.Join(stellaHome, ".mise-tools", "cache"),
 		"MISE_STATE_DIR": "/tmp/mise-state",
 	}
-	profile := buildSeatbeltProfile(policy)
+	profile := buildSeatbeltProfile(policy, "")
 
 	for _, want := range []string{
 		`(allow file-write* (subpath "` + filepath.Join(stellaHome, ".mise-tools", "cache") + `"))`,
@@ -86,7 +86,7 @@ func TestBuildSeatbeltProfile_ignoresUnsafeMiseRuntimeWriteDirs(t *testing.T) {
 		"MISE_CACHE_DIR": "/",
 		"MISE_STATE_DIR": "relative/state",
 	}
-	profile := buildSeatbeltProfile(policy)
+	profile := buildSeatbeltProfile(policy, "")
 
 	for _, forbidden := range []string{
 		`(allow file-write* (subpath "/"))`,
@@ -98,9 +98,44 @@ func TestBuildSeatbeltProfile_ignoresUnsafeMiseRuntimeWriteDirs(t *testing.T) {
 	}
 }
 
+// TestBuildSeatbeltProfile_miseHolesKeyedOnPerUserTree verifies the cache/state
+// fallback holes are keyed on the per-user mise tree recovered from the env, not
+// on len(ExtraWritableMounts): an unrelated writable mount must not suppress them
+// (the #442 scenario), and a real per-user mise tree must.
+func TestBuildSeatbeltProfile_miseHolesKeyedOnPerUserTree(t *testing.T) {
+	stellaHome := t.TempDir()
+	cacheDir := filepath.Join(stellaHome, ".mise-tools", "cache")
+
+	t.Run("unrelated writable mount still emits cache holes", func(t *testing.T) {
+		policy := makePolicy("/tmp/ws", sandboxpkg.NetworkDisabled)
+		policy.Env = map[string]string{"MISE_CACHE_DIR": cacheDir}
+		policy.Filesystem.ExtraWritableMounts = []string{"/tmp/unrelated"}
+		profile := buildSeatbeltProfile(policy, stellaHome)
+
+		if !strings.Contains(profile, `(allow file-write* (subpath "`+cacheDir+`"))`) {
+			t.Errorf("an unrelated writable mount must not suppress mise cache holes:\n%s", profile)
+		}
+	})
+
+	t.Run("per-user mise tree skips cache fallback", func(t *testing.T) {
+		userDir := filepath.Join(stellaHome, "users", "u1", ".mise-tools")
+		policy := makePolicy("/tmp/ws", sandboxpkg.NetworkDisabled)
+		policy.Env = map[string]string{
+			"MISE_DATA_DIR":  userDir,
+			"MISE_CACHE_DIR": "/tmp/mise-cache",
+		}
+		policy.Filesystem.ExtraWritableMounts = []string{userDir}
+		profile := buildSeatbeltProfile(policy, stellaHome)
+
+		if strings.Contains(profile, `(allow file-write* (subpath "/tmp/mise-cache"))`) {
+			t.Errorf("a writable per-user mise tree should skip the cache fallback holes:\n%s", profile)
+		}
+	})
+}
+
 func TestBuildSeatbeltProfile_networkAllowAll(t *testing.T) {
 	policy := makePolicy("/tmp/ws", sandboxpkg.NetworkAllowAll)
-	profile := buildSeatbeltProfile(policy)
+	profile := buildSeatbeltProfile(policy, "")
 
 	if strings.Contains(profile, "(deny network*)") {
 		t.Error("profile must not deny network when mode is allow_all")

--- a/plugins/sandbox/local/session_linux.go
+++ b/plugins/sandbox/local/session_linux.go
@@ -292,10 +292,11 @@ func wrapCommand(policy sandboxpkg.Policy, sandboxCwd string, tmpMounts []tmpMou
 	}
 	bwrapArgs = appendLinuxRuntimeMounts(bwrapArgs)
 	bwrapArgs = appendStellaHomeMounts(bwrapArgs, stellaHomeHost)
-	// Per-user mise tree: the agent's writable mise home, layered above the
-	// read-only system installs mounted by appendStellaHomeMounts.
-	if userDir := policy.Filesystem.MiseUserDirHost; userDir != "" {
-		bwrapArgs = appendWritableBind(bwrapArgs, userDir, remapToSandboxStellaHome(userDir, stellaHomeHost))
+	// Extra writable mounts (e.g. the per-user mise home, layered above the
+	// read-only system installs mounted by appendStellaHomeMounts): bind each at
+	// its STELLA_HOME-remapped sandbox path so writes land in the host tree.
+	for _, writable := range policy.Filesystem.ExtraWritableMounts {
+		bwrapArgs = appendWritableBind(bwrapArgs, writable, remapToSandboxStellaHome(writable, stellaHomeHost))
 	}
 	for _, extraPath := range policy.Filesystem.ExtraReadOnlyMounts {
 		bwrapArgs = appendRoBindIfExists(bwrapArgs, extraPath, extraPath)

--- a/plugins/sandbox/local/session_linux_test.go
+++ b/plugins/sandbox/local/session_linux_test.go
@@ -255,9 +255,9 @@ func TestWrapCommand_linux_perUserMiseWritableBind(t *testing.T) {
 
 	policy := sandboxpkg.Policy{
 		Filesystem: sandboxpkg.FilesystemPolicy{
-			WorkspaceRoot:   "/tmp/test-workspace",
-			WorkingDir:      "/workspace",
-			MiseUserDirHost: userDir,
+			WorkspaceRoot:       "/tmp/test-workspace",
+			WorkingDir:          "/workspace",
+			ExtraWritableMounts: []string{userDir},
 		},
 		Network: sandboxpkg.NetworkPolicy{Mode: sandboxpkg.NetworkAllowAll},
 	}

--- a/plugins/sandbox/local/session_test.go
+++ b/plugins/sandbox/local/session_test.go
@@ -496,6 +496,29 @@ func TestAdjustPolicy_rewritesMiseEnvPaths(t *testing.T) {
 	}
 }
 
+// TestAdjustPolicy_perUserMiseShimsOnPath verifies that when the runtime env
+// points MISE_DATA_DIR at a per-user tree, adjustPolicy prepends that tree's
+// shims (remapped into the sandbox) onto PATH. The per-user shims are derived
+// from the env, not a mise-specific policy field — exercising PerUserMiseDataDir.
+func TestAdjustPolicy_perUserMiseShimsOnPath(t *testing.T) {
+	hostSH := "/home/user/.stella"
+	sandboxSH := adjustStellaHome(hostSH)
+	if hostSH == sandboxSH {
+		t.Skip("no path remapping on this platform")
+	}
+
+	policy := sandboxpkg.Policy{
+		Env: map[string]string{"MISE_DATA_DIR": hostSH + "/users/u1/.mise-tools"},
+	}
+	f := &Factory{cfg: Config{StellaHome: hostSH}}
+	adjusted := f.adjustPolicy(policy)
+
+	wantShims := sandboxSH + "/users/u1/.mise-tools/shims"
+	if !strings.Contains(adjusted.Env["PATH"], wantShims) {
+		t.Fatalf("PATH must include per-user shims %q, got %q", wantShims, adjusted.Env["PATH"])
+	}
+}
+
 // TestBuildEnv_denyListFiltersVaultKey verifies that STELLA_VAULT_KEY is never
 // copied from the host environment into the sandbox env, even when InheritEnv
 // is true, while other env vars (e.g. PATH) remain present.

--- a/plugins/sandbox/none/session.go
+++ b/plugins/sandbox/none/session.go
@@ -73,8 +73,10 @@ func (f *Factory) adjustPolicy(policy sandboxpkg.Policy) sandboxpkg.Policy {
 	if env == nil {
 		env = make(map[string]string)
 	}
+	// Recover the per-user mise home from the runtime env (MISE_DATA_DIR) to put
+	// its shims on PATH; no remap here since none shares the host filesystem.
 	userShims := ""
-	if dir := policy.Filesystem.MiseUserDirHost; dir != "" {
+	if dir := sandboxpkg.PerUserMiseDataDir(env, f.cfg.StellaHome); dir != "" {
 		userShims = sandboxpkg.MiseUserShimsDir(dir)
 	}
 	env["PATH"] = sandboxpkg.HostEnvBuildPath(f.cfg.StellaHome, userShims)


### PR DESCRIPTION
> #443 merged; this branch is rebased onto `main` and the base is retargeted. Single-commit diff.

## What

Implements the `ExtraWritableMounts` generalization from #436 (review finding
CR-004): replace the mise-specific `FilesystemPolicy.MiseUserDirHost` with a
backend-neutral `ExtraWritableMounts []string`, symmetric with the existing
`ExtraReadOnlyMounts`. The generic policy no longer names mise.

This is the **plumbing** half of #436. The docker per-user mise parity (actually
wiring docker's writable tree, env, and system-installs sharing) is the
remaining half and stays a follow-up.

## Why

`MiseUserDirHost` leaked mise's storage model into the generic, backend-agnostic
`FilesystemPolicy`: every backend special-cased mise by name (bwrap binds,
Seatbelt write-allows, none/local derive shims, docker nulled it). #442 needs to
mount *several* writable per-user subtrees (`.cache`, `projects/{id}`, agent
data), which would mean threading more typed fields through every backend. A
generic list collapses all of that into one loop per backend and unblocks #442.

## How

- **Policy**: `MiseUserDirHost string` → `ExtraWritableMounts []string`. The
  isolating backends loop it — bwrap `--bind` each at its STELLA_HOME-remapped
  path, Seatbelt `allow file-write*` each; the host-passthrough backends
  (none/local) share the host fs and need no mount.
- **Mise wiring stays in `internal/agent/sandbox`**: `buildBasePolicy` seeds the
  per-user tree (`EnsureUserMiseHome`) and appends it to `ExtraWritableMounts`
  for non-docker backends. The mise-dir computation + unsafe-ID warn moved into a
  `miseUserDirHost` helper. The policy only learns "these dirs are writable".
- **PATH/shims**: none/local recover the per-user mise home from the runtime env
  (`MISE_DATA_DIR`) via the new `pkg/sandbox.PerUserMiseDataDir`, instead of the
  dropped policy field — so mise PATH knowledge also stays out of the generic
  policy. The system-tree value yields `""` (no per-user shims), preserving today's
  fallback.
- **Docker** unchanged: `buildSandboxEnv` still skips `RuntimeMiseEnv` for docker
  and nothing is added to its `ExtraWritableMounts`, so behavior is identical (the
  `if backend==docker { MiseUserDirHost = "" }` special-case is simply gone).

Behavior-preserving refactor. Tests: `TestPerUserMiseDataDir` (system-tree
guard), `TestAdjustPolicy_perUserMiseShimsOnPath` (env-derived shims on PATH,
linux), updated linux writable-bind test, updated group-subtree test.

Verification: `go test ./...` (darwin) green; `GOOS=linux` build+vet and
`GOOS=windows` build green. (`mise run format`'s web step is broken locally on a
vite native-binding issue unrelated to this Go-only change; `gofmt` clean.)

## Refs

- #436 (this is its CR-004 / `ExtraWritableMounts` half; docker parity remains)
- #442 (consumes `ExtraWritableMounts` to mount more per-user subtrees)
- #443 (stacked under this — per-principal subtree keying)