### PR TITLE
♻️ refactor(sandbox): flip on-disk layout to user-first (#442)

### DIFF
--- a/cmd/stellad/commands_test.go
+++ b/cmd/stellad/commands_test.go
@@ -164,7 +164,7 @@ func TestCLIUserSkillsDirUsesUserScope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cliUserSkillsDir: %v", err)
 	}
-	want := filepath.Join(config.StellaHome(), "workspaces", snap.AgentID, "users", "1", ".agents", "skills")
+	want := filepath.Join(config.StellaHome(), "users", "1", ".agents", "skills")
 	if dir != want {
 		t.Fatalf("cliUserSkillsDir() = %q, want %q", dir, want)
 	}

--- a/cmd/stellad/setup_pool.go
+++ b/cmd/stellad/setup_pool.go
@@ -95,16 +95,18 @@ func buildProjectEnsurer(db *sql.DB, store config.Store) agent.ProjectEnsurerFun
 		if ag, err := store.GetAgent(ctx, agentID); err == nil && ag.Name != "" {
 			agentName = ag.Name
 		}
-		userRoot, err := agent.SetupUserWorkspace(agentID, config.StellaHome(), userID)
-		if err != nil {
+		if _, err := agent.SetupUserWorkspace(config.StellaHome(), userID, agentID); err != nil {
 			return "", err
 		}
+		// The default project's working tree is the agent's private area under the
+		// user home (a project is owned by the agent, #442).
+		baseDir := agent.UserAgentDir(config.StellaHome(), userID, agentID)
 		p, err := q.CreateProject(ctx, sqlc.CreateProjectParams{
 			ID:      uuid.NewString(),
 			AgentID: agentID,
 			UserID:  userID,
 			Name:    agentName,
-			BaseDir: userRoot,
+			BaseDir: baseDir,
 		})
 		if err != nil {
 			if existing, err2 := q.ListProjects(ctx, sqlc.ListProjectsParams{AgentID: agentID, UserID: userID}); err2 == nil && len(existing) > 0 {

--- a/cmd/stellad/setup_skills.go
+++ b/cmd/stellad/setup_skills.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"database/sql"
-	"path/filepath"
 
 	"github.com/CherryHQ/stella/internal/agent"
 	"github.com/CherryHQ/stella/internal/config"
@@ -12,7 +11,7 @@ import (
 const cliSkillsUserID = "1"
 
 func cliUserSkillsDir(snap *config.Snapshot) (string, error) {
-	userDir, err := agent.SetupUserWorkspace(snap.AgentID, config.StellaHome(), cliSkillsUserID)
+	userDir, err := agent.SetupUserWorkspace(config.StellaHome(), cliSkillsUserID, snap.AgentID)
 	if err != nil {
 		return "", err
 	}
@@ -33,16 +32,22 @@ func setupSkillStores(db *sql.DB) skillStores {
 			if agentID == "" {
 				return ""
 			}
-			return filepath.Join(base, "workspaces", agentID, ".agents", "skills")
+			return agent.UserSkillsDir(agent.AgentWorkspaceDir(base, agentID))
+		case "user":
+			// User skills are shared across all of a user's agents (#442), so the
+			// path no longer depends on agentID.
+			if userID == "" {
+				return ""
+			}
+			return agent.UserSkillsDir(agent.UserHomeDir(base, userID))
 		case "user_agent":
 			if agentID == "" || userID == "" {
 				return ""
 			}
-			return filepath.Join(base, "workspaces", agentID, "users", userID, ".agents", "skills")
+			return agent.UserSkillsDir(agent.UserAgentDir(base, userID, agentID))
 		default:
-			// user (global) and system (global) skills are not tied to a single
-			// agent workspace, so they are not mirrored to disk here; their
-			// SKILL.md resolves from the DB.
+			// system (global) skills are not tied to a workspace, so they are not
+			// mirrored to disk here; their SKILL.md resolves from the DB.
 			return ""
 		}
 	})

--- a/internal/agent/group_session_test.go
+++ b/internal/agent/group_session_test.go
@@ -34,11 +34,13 @@ func TestTwoSendersShareGroupSessionKey(t *testing.T) {
 
 func TestSetupGroupWorkspace(t *testing.T) {
 	base := t.TempDir()
-	dir, err := SetupGroupWorkspace("agent1", base, "group-abc-123")
+	dir, err := SetupGroupWorkspace(base, "abc-123", "agent1")
 	if err != nil {
 		t.Fatalf("SetupGroupWorkspace: %v", err)
 	}
-	want := filepath.Join(base, "workspaces", "agent1", "groups", "group-abc-123")
+	// A channel group is a principal in the users tree, keyed under a "group-"
+	// prefix so it can't collide with a real user home of the same raw ID (#442).
+	want := filepath.Join(base, "users", "group-abc-123")
 	if dir != want {
 		t.Fatalf("dir = %q, want %q", dir, want)
 	}
@@ -51,14 +53,24 @@ func TestSetupGroupWorkspace(t *testing.T) {
 	}
 }
 
-func TestGroupWorkspaceNotUnderUsers(t *testing.T) {
+func TestGroupWorkspaceDisjointFromUserOfSameID(t *testing.T) {
 	base := t.TempDir()
-	dir, err := SetupGroupWorkspace("agent1", base, "group-abc-123")
+	id := "abc-123"
+	groupDir, err := SetupGroupWorkspace(base, id, "agent1")
 	if err != nil {
 		t.Fatalf("SetupGroupWorkspace: %v", err)
 	}
-	if strings.Contains(dir, "/users/") {
-		t.Fatalf("group workspace must not be under users/, got %q", dir)
+	userDir, err := SetupUserWorkspace(base, id, "agent1")
+	if err != nil {
+		t.Fatalf("SetupUserWorkspace: %v", err)
+	}
+	// Both live under users/, but the "group-" prefix keeps a group and a real
+	// user of the same raw ID from sharing one home.
+	if filepath.Dir(groupDir) != filepath.Join(base, "users") {
+		t.Fatalf("group workspace must sit directly under users/, got %q", groupDir)
+	}
+	if groupDir == userDir {
+		t.Fatalf("group and user home for the same raw ID must differ, both %q", groupDir)
 	}
 }
 

--- a/internal/agent/pool_manager.go
+++ b/internal/agent/pool_manager.go
@@ -304,13 +304,13 @@ func (pm *PoolManager) buildService(ctx context.Context, agentID string, factory
 // the session's UserID (the group id) so they match the cached group runner.
 func (pm *PoolManager) promptScope(agentID string, info session.Info) (userRoot, promptUserID, groupID string) {
 	if info.GroupID != "" {
-		if dir, err := SetupGroupWorkspace(agentID, config.StellaHome(), info.GroupID); err == nil {
+		if dir, err := SetupGroupWorkspace(config.StellaHome(), info.GroupID, agentID); err == nil {
 			userRoot = dir
 		}
 		return userRoot, "", info.GroupID
 	}
 	if info.UserID != "" {
-		if dir, err := SetupUserWorkspace(agentID, config.StellaHome(), info.UserID); err == nil {
+		if dir, err := SetupUserWorkspace(config.StellaHome(), info.UserID, agentID); err == nil {
 			userRoot = dir
 		}
 	}
@@ -535,7 +535,7 @@ func (pm *PoolManager) removeAgent(agentID string) error {
 }
 
 func (pm *PoolManager) loadAgentSnapshot(ctx context.Context, agentID string) (*config.Snapshot, string, error) {
-	workspace, err := SetupWorkspace(agentID, config.StellaHome())
+	workspace, err := SetupAgentWorkspace(config.StellaHome(), agentID)
 	if err != nil {
 		return nil, "", fmt.Errorf("setup workspace for agent %q: %w", agentID, err)
 	}

--- a/internal/agent/runner_builder.go
+++ b/internal/agent/runner_builder.go
@@ -62,17 +62,27 @@ func newRunnerFunc(cfg runnerBuilderConfig) NewRunnerFunc {
 			apiName = provID
 		}
 
+		stellaHome := config.StellaHome()
 		var (
 			userDir string
-			err     error
+			// projectValidateRoot is the per-(principal, agent) dir a project must
+			// live under: a project is owned by the agent (see #442), so it stays
+			// scoped to the agent's subdir of the shared user/group home.
+			projectValidateRoot string
+			err                 error
 		)
 		switch {
 		case params.GroupID != "":
-			userDir, err = SetupGroupWorkspace(cfg.Snap.AgentID, config.StellaHome(), params.GroupID)
+			userDir, err = SetupGroupWorkspace(stellaHome, params.GroupID, cfg.Snap.AgentID)
+			projectValidateRoot = GroupAgentDir(stellaHome, params.GroupID, cfg.Snap.AgentID)
 		case params.UserID != "":
-			userDir, err = SetupUserWorkspace(cfg.Snap.AgentID, config.StellaHome(), params.UserID)
+			userDir, err = SetupUserWorkspace(stellaHome, params.UserID, cfg.Snap.AgentID)
+			projectValidateRoot = UserAgentDir(stellaHome, params.UserID, cfg.Snap.AgentID)
 		default:
-			userDir, err = SetupSystemWorkspace(cfg.Snap.AgentID, config.StellaHome())
+			// A user-less agent job (e.g. a builtin scheduled job) has no
+			// principal home; it runs in the agent's own pool workspace (#442).
+			userDir = cfg.Snap.Workspace
+			projectValidateRoot = userDir
 		}
 		if err != nil {
 			return nil, fmt.Errorf("setup workspace: %w", err)
@@ -86,7 +96,7 @@ func newRunnerFunc(cfg runnerBuilderConfig) NewRunnerFunc {
 			if err != nil {
 				slog.Warn("project resolution failed", "project_id", params.ProjectID, "error", err)
 			} else if dir != "" {
-				if err := ValidateProjectDir(dir, userRoot); err != nil {
+				if err := ValidateProjectDir(dir, projectValidateRoot); err != nil {
 					slog.Warn("project dir validation failed", "project_id", params.ProjectID, "base_dir", dir, "error", err)
 				} else {
 					projectRoot = dir

--- a/internal/agent/runner_builder_test.go
+++ b/internal/agent/runner_builder_test.go
@@ -36,8 +36,10 @@ func TestNewRunnerFuncPassesProjectRootToSystemPrompt(t *testing.T) {
 	}
 	snap.Workspace = t.TempDir()
 
-	userRoot := filepath.Join(stellaHome, "workspaces", snap.AgentID, "users", "user-1")
-	projectRoot := filepath.Join(userRoot, "projects", "app")
+	// A project is owned by the agent, so it lives under the agent's private subdir
+	// of the user home (#442).
+	userAgentDir := filepath.Join(stellaHome, "users", "user-1", "agents", snap.AgentID)
+	projectRoot := filepath.Join(userAgentDir, "projects", "app")
 	if err := os.MkdirAll(projectRoot, 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}

--- a/internal/agent/sandbox/backend_test.go
+++ b/internal/agent/sandbox/backend_test.go
@@ -195,20 +195,21 @@ func TestRunnerFilesystemPolicyUsesUserScopedTmp(t *testing.T) {
 }
 
 // A group session carries both a GroupID and a synthetic UserID equal to it. It
-// must key off the group subtree so a real user whose ID equals the group ID can
-// never share the group's writable mise/temp trees.
+// must key off the group under the "group-" prefix in the users tree, so a real
+// user whose ID equals the group ID can never share the group's writable
+// mise/temp trees (#442).
 func TestRunnerFilesystemPolicyGroupUsesGroupSubtree(t *testing.T) {
 	paths := Paths{StellaHome: "/stella", UserRoot: "/workspace", WorkDir: "/workspace"}
 	cfg := Config{GroupID: "g7", UserID: "g7"}
 
-	if want := filepath.Join("/stella", "groups", "g7", ".mise-tools"); miseUserDirHost(paths, cfg) != want {
+	if want := filepath.Join("/stella", "users", "group-g7", ".mise-tools"); miseUserDirHost(paths, cfg) != want {
 		t.Fatalf("miseUserDirHost = %q, want %q", miseUserDirHost(paths, cfg), want)
 	}
 	base := os.TempDir()
 	if resolved, err := filepath.EvalSymlinks(base); err == nil {
 		base = resolved
 	}
-	if want := filepath.Join(base, "groups", "g7"); runnerFilesystemPolicy(paths, cfg).TempDirHost != want {
+	if want := filepath.Join(base, "users", "group-g7"); runnerFilesystemPolicy(paths, cfg).TempDirHost != want {
 		t.Fatalf("TempDirHost = %q, want %q", runnerFilesystemPolicy(paths, cfg).TempDirHost, want)
 	}
 }

--- a/internal/agent/sandbox/env.go
+++ b/internal/agent/sandbox/env.go
@@ -48,17 +48,17 @@ func miseUserDirHost(paths Paths, cfg Config) string {
 	return dir
 }
 
-// misePrincipal returns the home subtree and raw ID for this session's per-user
-// temp and mise trees. Users and groups resolve to disjoint top-level subtrees
-// ("users"/"groups") keyed by the raw ID, so the two principal namespaces live in
-// separate trees and equal IDs across them can never collide into one shared
-// writable tree — without a name prefix. Empty dir when neither is set, which
-// makes callers fall back to a session-local temp dir and the shared read-only
-// system mise tree. Groups take precedence: a group session carries both a
-// GroupID and a synthetic UserID and must key off the group.
+// misePrincipal returns the home subtree and ID for this session's per-principal
+// temp and mise trees. Every principal lives in the single "users" subtree (the
+// only top-level isolation boundary, #442): a real user keys off its raw ID, a
+// channel group off the group ID under a "group-" prefix so a group can never
+// collide with a user of the same raw ID into one shared writable tree. Empty dir
+// when neither is set, which makes callers fall back to a session-local temp dir
+// and the shared read-only system mise tree. Groups take precedence: a group
+// session carries both a GroupID and a synthetic UserID and must key off the group.
 func misePrincipal(cfg Config) (principalDir, id string) {
 	if cfg.GroupID != "" {
-		return "groups", cfg.GroupID
+		return "users", "group-" + cfg.GroupID
 	}
 	if cfg.UserID == "" {
 		return "", ""
@@ -69,8 +69,8 @@ func misePrincipal(cfg Config) (principalDir, id string) {
 var validUserTempDirID = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
 
 // userTempDir returns the per-principal scratch dir mounted as /tmp. principalDir
-// ("users"/"groups") keeps the user and group namespaces in separate subtrees so
-// equal IDs across them can't share a temp dir. Empty for an empty or unsafe id.
+// is always "users"; a channel group's "group-" ID prefix keeps user and group
+// scratch dirs from colliding. Empty for an empty or unsafe id.
 func userTempDir(principalDir, id string) string {
 	if principalDir == "" || !validUserTempDirID.MatchString(id) {
 		return ""

--- a/internal/agent/workspace.go
+++ b/internal/agent/workspace.go
@@ -7,99 +7,116 @@ import (
 	"time"
 )
 
-// SetupWorkspace ensures the per-agent workspace directory exists.
-// Creates: basePath/workspaces/{agentID}/.agents/skills/
-// Returns the absolute path to the agent's workspace directory.
-func SetupWorkspace(agentID, basePath string) (string, error) {
+// The on-disk layout is user-first (#442): a principal — a user, or a channel
+// group treated as a synthetic user — has one home shared by all of its agents,
+// the "real PC" model where the principal has a home and an agent is an app run
+// under it. Toolchains, skills, caches, and uploads live at the principal level
+// and are shared across its agents; a project's working tree stays scoped to the
+// agent that owns it, under that agent's subdir of the home.
+//
+//	{base}/agents/{agentID}/                  agent definition + agent-level skills (user-independent)
+//	{base}/users/{userID}/                    THE user home (sandbox $HOME)
+//	  .mise-tools/                            per-user toolchain, shared by all agents (#424)
+//	  .agents/skills/                         user-level skills, shared
+//	  data/  assets/                          user data + uploads, shared
+//	  agents/{agentID}/projects/{projectID}/  project working tree = sandbox cwd, owned by the agent
+//	{base}/users/group-{groupID}/             a channel group's home — same shape, a shared "account"
+//
+// The users tree is the only top-level isolation boundary. A channel group is its
+// own principal (one home for the whole group), keyed by the group ID under a
+// "group-" prefix so a group home can never collide with a user home of the same
+// raw ID. User-less agent jobs (e.g. builtin scheduled jobs) have no principal
+// home and run in the agent's own workspace, {base}/agents/{agentID}/.
+
+// AgentWorkspaceDir returns the user-independent agent directory that holds the
+// agent definition and agent-level skills.
+func AgentWorkspaceDir(base, agentID string) string {
+	return filepath.Join(base, "agents", agentID)
+}
+
+// UserHomeDir returns the home directory for a user, shared by all the user's agents.
+func UserHomeDir(base, userID string) string {
+	return filepath.Join(base, "users", userID)
+}
+
+// GroupHomeDir returns the home directory for a channel group — a principal in
+// the users tree, shared by all the group's agents. The "group-" prefix keeps a
+// group home from colliding with a user home of the same raw ID.
+func GroupHomeDir(base, groupID string) string {
+	return filepath.Join(base, "users", "group-"+groupID)
+}
+
+// UserAgentDir returns the per-(user, agent) private area under a user home.
+// Projects owned by the agent live under this directory.
+func UserAgentDir(base, userID, agentID string) string {
+	return filepath.Join(UserHomeDir(base, userID), "agents", agentID)
+}
+
+// GroupAgentDir returns the per-(group, agent) private area under a group home.
+func GroupAgentDir(base, groupID, agentID string) string {
+	return filepath.Join(GroupHomeDir(base, groupID), "agents", agentID)
+}
+
+// SetupAgentWorkspace ensures the user-independent agent directory exists.
+// Creates {base}/agents/{agentID}/.agents/skills/ and returns the agent directory.
+func SetupAgentWorkspace(base, agentID string) (string, error) {
 	if agentID == "" {
 		return "", fmt.Errorf("agent ID must not be empty")
 	}
-	dir := filepath.Join(basePath, "workspaces", agentID)
+	dir := AgentWorkspaceDir(base, agentID)
 	if err := os.MkdirAll(filepath.Join(dir, ".agents", "skills"), 0o755); err != nil {
-		return "", fmt.Errorf("create workspace for agent %q: %w", agentID, err)
+		return "", fmt.Errorf("create agent workspace for agent %q: %w", agentID, err)
 	}
 	return dir, nil
 }
 
-// SetupUserWorkspace ensures per-user directories exist within an agent workspace.
-// Creates:
-//   - basePath/workspaces/{agentID}/users/{userID}/.agents/skills/
-//   - basePath/workspaces/{agentID}/users/{userID}/data/
-//   - basePath/workspaces/{agentID}/users/{userID}/assets/
-//
-// Returns the absolute path to the user's workspace directory
-// (basePath/workspaces/{agentID}/users/{userID}/).
-func SetupUserWorkspace(agentID, basePath string, userID string) (string, error) {
-	if agentID == "" {
-		return "", fmt.Errorf("agent ID must not be empty")
-	}
+// SetupUserWorkspace ensures a user home and the per-(user, agent) area exist.
+// Creates the user home (.agents/skills, data, assets — shared by all the user's
+// agents) and the agent's private subdir (where its projects live). Returns the
+// user home directory, which is the sandbox workspace root and HOME.
+func SetupUserWorkspace(base, userID, agentID string) (string, error) {
 	if userID == "" {
 		return "", fmt.Errorf("user ID must not be empty")
 	}
-	userDir := filepath.Join(basePath, "workspaces", agentID, "users", userID)
-	if err := os.MkdirAll(filepath.Join(userDir, ".agents", "skills"), 0o755); err != nil {
-		return "", fmt.Errorf("create user workspace for agent %q user %s: %w", agentID, userID, err)
-	}
-	if err := os.MkdirAll(filepath.Join(userDir, "data"), 0o755); err != nil {
-		return "", fmt.Errorf("create user data dir for agent %q user %s: %w", agentID, userID, err)
-	}
-	if err := os.MkdirAll(filepath.Join(userDir, "assets"), 0o755); err != nil {
-		return "", fmt.Errorf("create user assets dir for agent %q user %s: %w", agentID, userID, err)
-	}
-	return userDir, nil
+	return setupHome(UserHomeDir(base, userID), UserAgentDir(base, userID, agentID), agentID)
 }
 
-// SetupGroupWorkspace ensures per-group directories exist within an agent workspace.
-// Returns the path basePath/workspaces/{agentID}/groups/{groupID}/.
-func SetupGroupWorkspace(agentID, basePath, groupID string) (string, error) {
-	if agentID == "" {
-		return "", fmt.Errorf("agent ID must not be empty")
-	}
+// SetupGroupWorkspace mirrors SetupUserWorkspace for a group account.
+func SetupGroupWorkspace(base, groupID, agentID string) (string, error) {
 	if groupID == "" {
 		return "", fmt.Errorf("group ID must not be empty")
 	}
-	dir := filepath.Join(basePath, "workspaces", agentID, "groups", groupID)
-	if err := os.MkdirAll(filepath.Join(dir, ".agents", "skills"), 0o755); err != nil {
-		return "", fmt.Errorf("create group workspace for agent %q group %s: %w", agentID, groupID, err)
-	}
-	if err := os.MkdirAll(filepath.Join(dir, "data"), 0o755); err != nil {
-		return "", fmt.Errorf("create group data dir for agent %q group %s: %w", agentID, groupID, err)
-	}
-	if err := os.MkdirAll(filepath.Join(dir, "assets"), 0o755); err != nil {
-		return "", fmt.Errorf("create group assets dir for agent %q group %s: %w", agentID, groupID, err)
-	}
-	return dir, nil
+	return setupHome(GroupHomeDir(base, groupID), GroupAgentDir(base, groupID, agentID), agentID)
 }
 
-// SetupSystemWorkspace creates the shared system workspace for agent jobs that
-// run without a user context (e.g. builtin scheduled jobs).
-// Returns the path basePath/workspaces/{agentID}/system/.
-func SetupSystemWorkspace(agentID, basePath string) (string, error) {
+// setupHome creates the shared home directories and, when agentDir is non-empty,
+// the agent's private subdir under the home.
+func setupHome(home, agentDir, agentID string) (string, error) {
 	if agentID == "" {
 		return "", fmt.Errorf("agent ID must not be empty")
 	}
-	dir := filepath.Join(basePath, "workspaces", agentID, "system")
-	if err := os.MkdirAll(filepath.Join(dir, ".agents", "skills"), 0o755); err != nil {
-		return "", fmt.Errorf("create system workspace for agent %q: %w", agentID, err)
+	for _, sub := range [][]string{{".agents", "skills"}, {"data"}, {"assets"}} {
+		if err := os.MkdirAll(filepath.Join(home, filepath.Join(sub...)), 0o755); err != nil {
+			return "", fmt.Errorf("create home dir %q: %w", home, err)
+		}
 	}
-	if err := os.MkdirAll(filepath.Join(dir, "data"), 0o755); err != nil {
-		return "", fmt.Errorf("create system data dir for agent %q: %w", agentID, err)
+	if agentDir != "" {
+		if err := os.MkdirAll(agentDir, 0o755); err != nil {
+			return "", fmt.Errorf("create per-agent area %q: %w", agentDir, err)
+		}
 	}
-	if err := os.MkdirAll(filepath.Join(dir, "assets"), 0o755); err != nil {
-		return "", fmt.Errorf("create system assets dir for agent %q: %w", agentID, err)
-	}
-	return dir, nil
+	return home, nil
 }
 
-// UserAssetsDir returns the per-user assets directory within a user root.
-// Uploaded files from all channels are stored here.
-func UserAssetsDir(userRoot string) string {
-	return filepath.Join(userRoot, "assets")
+// UserAssetsDir returns the per-user assets directory within a user home.
+// Uploaded files from all channels are stored here, shared across the user's agents.
+func UserAssetsDir(userHome string) string {
+	return filepath.Join(userHome, "assets")
 }
 
-// UserSkillsDir returns the per-user skills directory path within a user workspace.
-func UserSkillsDir(userWorkspace string) string {
-	return filepath.Join(userWorkspace, ".agents", "skills")
+// UserSkillsDir returns the user-level skills directory within a user home.
+func UserSkillsDir(userHome string) string {
+	return filepath.Join(userHome, ".agents", "skills")
 }
 
 // SaveAsset writes data to assetsDir with a timestamp-prefixed filename to avoid

--- a/internal/agent/workspace_test.go
+++ b/internal/agent/workspace_test.go
@@ -6,15 +6,15 @@ import (
 	"testing"
 )
 
-func TestSetupWorkspace(t *testing.T) {
+func TestSetupAgentWorkspace(t *testing.T) {
 	base := t.TempDir()
 
-	dir, err := SetupWorkspace("stella", base)
+	dir, err := SetupAgentWorkspace(base, "stella")
 	if err != nil {
-		t.Fatalf("SetupWorkspace: %v", err)
+		t.Fatalf("SetupAgentWorkspace: %v", err)
 	}
 
-	want := filepath.Join(base, "workspaces", "stella")
+	want := filepath.Join(base, "agents", "stella")
 	if dir != want {
 		t.Errorf("dir = %q, want %q", dir, want)
 	}
@@ -30,15 +30,15 @@ func TestSetupWorkspace(t *testing.T) {
 	}
 }
 
-func TestSetupWorkspaceIdempotent(t *testing.T) {
+func TestSetupAgentWorkspaceIdempotent(t *testing.T) {
 	base := t.TempDir()
 
-	dir1, err := SetupWorkspace("stella", base)
+	dir1, err := SetupAgentWorkspace(base, "stella")
 	if err != nil {
 		t.Fatalf("first call: %v", err)
 	}
 
-	dir2, err := SetupWorkspace("stella", base)
+	dir2, err := SetupAgentWorkspace(base, "stella")
 	if err != nil {
 		t.Fatalf("second call: %v", err)
 	}
@@ -48,8 +48,8 @@ func TestSetupWorkspaceIdempotent(t *testing.T) {
 	}
 }
 
-func TestSetupWorkspaceEmptyID(t *testing.T) {
-	_, err := SetupWorkspace("", t.TempDir())
+func TestSetupAgentWorkspaceEmptyID(t *testing.T) {
+	_, err := SetupAgentWorkspace(t.TempDir(), "")
 	if err == nil {
 		t.Error("expected error for empty agent ID")
 	}
@@ -57,20 +57,22 @@ func TestSetupWorkspaceEmptyID(t *testing.T) {
 
 func TestSetupUserWorkspace(t *testing.T) {
 	base := t.TempDir()
-	userDir, err := SetupUserWorkspace("agent-1", base, "42")
+	userDir, err := SetupUserWorkspace(base, "42", "agent-1")
 	if err != nil {
 		t.Fatalf("SetupUserWorkspace: %v", err)
 	}
 
-	want := filepath.Join(base, "workspaces", "agent-1", "users", "42")
+	want := filepath.Join(base, "users", "42")
 	if userDir != want {
 		t.Errorf("dir = %q, want %q", userDir, want)
 	}
 
-	// Verify subdirectories.
+	// Verify the shared user-home subdirectories and the per-agent private area.
 	for _, sub := range []string{
 		filepath.Join(userDir, ".agents", "skills"),
 		filepath.Join(userDir, "data"),
+		filepath.Join(userDir, "assets"),
+		filepath.Join(userDir, "agents", "agent-1"),
 	} {
 		info, err := os.Stat(sub)
 		if err != nil {
@@ -84,14 +86,14 @@ func TestSetupUserWorkspace(t *testing.T) {
 }
 
 func TestSetupUserWorkspaceEmptyAgent(t *testing.T) {
-	_, err := SetupUserWorkspace("", t.TempDir(), "1")
+	_, err := SetupUserWorkspace(t.TempDir(), "1", "")
 	if err == nil {
 		t.Error("expected error for empty agent ID")
 	}
 }
 
 func TestSetupUserWorkspaceInvalidUser(t *testing.T) {
-	_, err := SetupUserWorkspace("agent-1", t.TempDir(), "")
+	_, err := SetupUserWorkspace(t.TempDir(), "", "agent-1")
 	if err == nil {
 		t.Error("expected error for empty user ID")
 	}
@@ -99,7 +101,7 @@ func TestSetupUserWorkspaceInvalidUser(t *testing.T) {
 
 func TestSetupUserWorkspaceIdempotent(t *testing.T) {
 	base := t.TempDir()
-	d1, err := SetupUserWorkspace("agent-1", base, "42")
+	d1, err := SetupUserWorkspace(base, "42", "agent-1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,7 +111,7 @@ func TestSetupUserWorkspaceIdempotent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	d2, err := SetupUserWorkspace("agent-1", base, "42")
+	d2, err := SetupUserWorkspace(base, "42", "agent-1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,13 +123,35 @@ func TestSetupUserWorkspaceIdempotent(t *testing.T) {
 	}
 }
 
-func TestSetupUserWorkspaceIsolation(t *testing.T) {
+// TestSetupUserWorkspaceSharedAcrossAgents verifies the user home is the same
+// directory regardless of which agent set it up — toolchains, skills, and uploads
+// are shared across a user's agents (#442).
+func TestSetupUserWorkspaceSharedAcrossAgents(t *testing.T) {
 	base := t.TempDir()
-	d1, err := SetupUserWorkspace("agent-1", base, "1")
+	d1, err := SetupUserWorkspace(base, "42", "agent-1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	d2, err := SetupUserWorkspace("agent-1", base, "2")
+	d2, err := SetupUserWorkspace(base, "42", "agent-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d1 != d2 {
+		t.Errorf("same user under different agents should share one home: %q vs %q", d1, d2)
+	}
+	// Each agent still gets its own private subdir for projects.
+	if a1, a2 := UserAgentDir(base, "42", "agent-1"), UserAgentDir(base, "42", "agent-2"); a1 == a2 {
+		t.Error("different agents should have distinct private areas under the user home")
+	}
+}
+
+func TestSetupUserWorkspaceIsolation(t *testing.T) {
+	base := t.TempDir()
+	d1, err := SetupUserWorkspace(base, "1", "agent-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	d2, err := SetupUserWorkspace(base, "2", "agent-1")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/channel/coordinator.go
+++ b/internal/channel/coordinator.go
@@ -539,13 +539,13 @@ func (c *Coordinator) ResolveUserRoot(ctx context.Context, msg pkgchannel.Incomi
 		return "", fmt.Errorf("resolve user root: %w", err)
 	}
 	if rc.GroupID != "" {
-		dir, err := agent.SetupGroupWorkspace(rc.AgentID, config.StellaHome(), rc.GroupID)
+		dir, err := agent.SetupGroupWorkspace(config.StellaHome(), rc.GroupID, rc.AgentID)
 		if err != nil {
 			return "", fmt.Errorf("setup group workspace: %w", err)
 		}
 		return dir, nil
 	}
-	userDir, err := agent.SetupUserWorkspace(rc.AgentID, config.StellaHome(), rc.User.ID)
+	userDir, err := agent.SetupUserWorkspace(config.StellaHome(), rc.User.ID, rc.AgentID)
 	if err != nil {
 		return "", fmt.Errorf("setup user workspace: %w", err)
 	}

--- a/internal/server/projects.go
+++ b/internal/server/projects.go
@@ -15,12 +15,14 @@ import (
 )
 
 func validateBaseDir(w http.ResponseWriter, agentID, userID, baseDir string) bool {
-	userRoot, err := agent.SetupUserWorkspace(agentID, config.StellaHome(), userID)
-	if err != nil {
+	if _, err := agent.SetupUserWorkspace(config.StellaHome(), userID, agentID); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to resolve workspace")
 		return false
 	}
-	if err := agent.ValidateProjectDir(baseDir, userRoot); err != nil {
+	// A project is owned by the agent (#442), so it must live under the agent's
+	// subdir of the user home.
+	projectRoot := agent.UserAgentDir(config.StellaHome(), userID, agentID)
+	if err := agent.ValidateProjectDir(baseDir, projectRoot); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid base_dir")
 		return false
 	}

--- a/internal/server/sessions.go
+++ b/internal/server/sessions.go
@@ -941,7 +941,7 @@ func (s *Server) GetSessionWorkspace(w http.ResponseWriter, r *http.Request, age
 		writeData(w, http.StatusOK, workspaceDiskInfo{Root: "", Paths: []string{}})
 		return
 	}
-	userDir, err := agent.SetupUserWorkspace(info.AgentID, config.StellaHome(), info.UserID)
+	userDir, err := agent.SetupUserWorkspace(config.StellaHome(), info.UserID, info.AgentID)
 	if err != nil {
 		s.writeInternalError(w, err)
 		return
@@ -1059,7 +1059,7 @@ func (s *Server) sessionWorkspaceRoot(w http.ResponseWriter, r *http.Request, ag
 		writeError(w, http.StatusNotFound, "session has no workspace")
 		return "", fmt.Errorf("no workspace")
 	}
-	userDir, err := agent.SetupUserWorkspace(info.AgentID, config.StellaHome(), info.UserID)
+	userDir, err := agent.SetupUserWorkspace(config.StellaHome(), info.UserID, info.AgentID)
 	if err != nil {
 		s.writeInternalError(w, err)
 		return "", err
@@ -1396,7 +1396,7 @@ func (s *Server) GetSessionSystemPrompt(w http.ResponseWriter, r *http.Request, 
 	}
 	var userRoot string
 	if info.UserID != "" && info.AgentID != "" {
-		if userDir, err := agent.SetupUserWorkspace(info.AgentID, config.StellaHome(), info.UserID); err == nil {
+		if userDir, err := agent.SetupUserWorkspace(config.StellaHome(), info.UserID, info.AgentID); err == nil {
 			userRoot = userDir
 		}
 	}

--- a/internal/store/dbstore.go
+++ b/internal/store/dbstore.go
@@ -697,7 +697,7 @@ func (s *DBStore) Seed(ctx context.Context) error {
 	if len(agents) > 0 {
 		return nil
 	}
-	workspace := filepath.Join(config.StellaHome(), "workspaces", "stella")
+	workspace := filepath.Join(config.StellaHome(), "agents", "stella")
 	sandboxJSON, err := marshalSandboxConfig(config.SandboxConfig{})
 	if err != nil {
 		return fmt.Errorf("seed: marshal stella sandbox config: %w", err)

--- a/internal/tools/delegate/preset_loader.go
+++ b/internal/tools/delegate/preset_loader.go
@@ -14,8 +14,8 @@ import (
 // LoadDelegatePresetsConfig configures the delegate preset discovery paths.
 type LoadDelegatePresetsConfig struct {
 	StellaHome  string // stella home dir (e.g. ~/.stella)
-	AgentRoot   string // agent root dir (e.g. ~/.stella/workspaces/{agentID})
-	UserRoot    string // user root dir (e.g. ~/.stella/workspaces/{agentID}/users/{userID})
+	AgentRoot   string // agent root dir (e.g. ~/.stella/agents/{agentID})
+	UserRoot    string // user home dir (e.g. ~/.stella/users/{userID})
 	ProjectRoot string // optional project root for local/project-attached runs
 }
 

--- a/internal/tools/skills/tool_test.go
+++ b/internal/tools/skills/tool_test.go
@@ -347,8 +347,8 @@ func TestRemoveInvalidName(t *testing.T) {
 
 func TestTargetSkillsDirDefaultsToUserScope(t *testing.T) {
 	base := t.TempDir()
-	agentWS := filepath.Join(base, "workspaces", "agent-1")
-	userSkillsDir := filepath.Join(agentWS, "users", "7", ".agents", "skills")
+	agentWS := filepath.Join(base, "agents", "agent-1")
+	userSkillsDir := filepath.Join(base, "users", "7", ".agents", "skills")
 
 	tool := NewTool(nil, "/tmp/stella", agentWS, filepath.Join(base, "project"), userSkillsDir)
 	scope, got, err := tool.targetSkillsDir(context.Background(), "")
@@ -365,8 +365,8 @@ func TestTargetSkillsDirDefaultsToUserScope(t *testing.T) {
 
 func TestTargetSkillsDirAgentScope(t *testing.T) {
 	base := t.TempDir()
-	agentWS := filepath.Join(base, "workspaces", "agent-1")
-	userSkillsDir := filepath.Join(agentWS, "users", "7", ".agents", "skills")
+	agentWS := filepath.Join(base, "agents", "agent-1")
+	userSkillsDir := filepath.Join(base, "users", "7", ".agents", "skills")
 
 	tool := NewTool(nil, "/tmp/stella", agentWS, filepath.Join(base, "project"), userSkillsDir)
 	scope, got, err := tool.targetSkillsDir(context.Background(), "agent")

--- a/pkg/sandbox/hostenv.go
+++ b/pkg/sandbox/hostenv.go
@@ -41,16 +41,16 @@ func MiseShimsDir(stellaHome string) string {
 var miseUserKeyPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
 
 // MiseUserToolsDir returns the per-principal writable MISE_DATA_DIR. It mirrors a
-// real machine's per-user mise home: each user or group gets one tree shared by
-// all their agents, layered above the shared read-only system installs.
-// principalDir is the top-level home subtree ("users" or "groups") and id is the
-// raw user/group ID. Keying as {stellaHome}/{principalDir}/{id}/.mise-tools puts
-// the two principal namespaces in disjoint top-level trees, so equal IDs across
-// them can't collide — no name prefix needed. The path never depends on the
-// agent, so all of a principal's agents share one tree. An empty or unsafe
+// real machine's per-user mise home: each principal gets one tree shared by all
+// their agents, layered above the shared read-only system installs. principalDir
+// is the home subtree — always "users", the only top-level isolation boundary
+// (#442) — and id is the principal's key: a raw user ID, or a channel group's ID
+// under a "group-" prefix so equal raw IDs across users and groups can never
+// collide. Keying as {stellaHome}/{principalDir}/{id}/.mise-tools never depends on
+// the agent, so all of a principal's agents share one tree. An empty or unsafe
 // argument yields "" so callers fall back to the system tree.
 func MiseUserToolsDir(stellaHome, principalDir, id string) string {
-	if principalDir != "users" && principalDir != "groups" {
+	if principalDir != "users" {
 		return ""
 	}
 	if !miseUserKeyPattern.MatchString(id) {

--- a/pkg/sandbox/miseuser_test.go
+++ b/pkg/sandbox/miseuser_test.go
@@ -11,11 +11,12 @@ func TestMiseUserToolsDir(t *testing.T) {
 	type in struct{ dir, id string }
 	cases := map[in]string{
 		{"users", "u1"}:          filepath.Join(home, "users", "u1", ".mise-tools"),
-		{"groups", "42"}:         filepath.Join(home, "groups", "42", ".mise-tools"),
-		{"users", ""}:            "", // no id → fall back to the system tree
-		{"", "u1"}:               "", // no principal subtree
-		{"vault", "u1"}:          "", // unknown subtree rejected
-		{"users", "a/b"}:         "", // path traversal rejected
+		{"users", "group-42"}:    filepath.Join(home, "users", "group-42", ".mise-tools"), // a channel group, prefixed
+		{"users", ""}:            "",                                                      // no id → fall back to the system tree
+		{"", "u1"}:               "",                                                      // no principal subtree
+		{"groups", "42"}:         "",                                                      // groups no longer a top-level subtree (#442)
+		{"vault", "u1"}:          "",                                                      // unknown subtree rejected
+		{"users", "a/b"}:         "",                                                      // path traversal rejected
 		{"users", ".."}:          "",
 		{"users", "bad name"}:    "",
 		{"users", "weird;rm-rf"}: "",

--- a/plugins/sandbox/docker/session_pure_test.go
+++ b/plugins/sandbox/docker/session_pure_test.go
@@ -221,7 +221,7 @@ func TestConfigureSessionMounts_BindModeTranslatesSources(t *testing.T) {
 	if err != nil {
 		t.Fatalf("configureSessionMounts: %v", err)
 	}
-	if opts.WorkspaceHost != "/daemon/stella/workspaces/agent/users/user" {
+	if opts.WorkspaceHost != "/daemon/stella/users/user" {
 		t.Fatalf("WorkspaceHost = %q", opts.WorkspaceHost)
 	}
 	if mountedTmp != "" {
@@ -231,8 +231,8 @@ func TestConfigureSessionMounts_BindModeTranslatesSources(t *testing.T) {
 		t.Fatalf("mounted extra = %v, want [%q]", mountedExtra, extra)
 	}
 	assertMount(t, opts.ExtraMounts, "/daemon/stella/bin", filepath.Join(stellaHomeMount, "bin"), true, dockerclient.MountType(""), "")
-	assertMount(t, opts.ExtraMounts, "/daemon/stella/workspaces/agent/users/user/skills", extra, true, dockerclient.MountType(""), "")
-	assertMount(t, opts.ExtraMounts, "/daemon/stella/workspaces/agent/users/user/skills", filepath.Join(workspaceMount, "skills"), true, dockerclient.MountTypeBind, "")
+	assertMount(t, opts.ExtraMounts, "/daemon/stella/users/user/skills", extra, true, dockerclient.MountType(""), "")
+	assertMount(t, opts.ExtraMounts, "/daemon/stella/users/user/skills", filepath.Join(workspaceMount, "skills"), true, dockerclient.MountTypeBind, "")
 }
 
 func TestConfigureSessionMounts_VolumeModeUsesSubpaths(t *testing.T) {
@@ -255,10 +255,10 @@ func TestConfigureSessionMounts_VolumeModeUsesSubpaths(t *testing.T) {
 	if len(mountedExtra) != 1 || mountedExtra[0] != extra {
 		t.Fatalf("mounted extra = %v, want only [%q]", mountedExtra, extra)
 	}
-	assertMount(t, opts.ExtraMounts, "stella-data", workspaceMount, false, dockerclient.MountTypeVolume, "workspaces/agent/users/user")
+	assertMount(t, opts.ExtraMounts, "stella-data", workspaceMount, false, dockerclient.MountTypeVolume, "users/user")
 	assertMount(t, opts.ExtraMounts, "stella-data", filepath.Join(stellaHomeMount, "bin"), true, dockerclient.MountTypeVolume, "bin")
-	assertMount(t, opts.ExtraMounts, "stella-data", extra, true, dockerclient.MountTypeVolume, "workspaces/agent/users/user/skills")
-	assertMount(t, opts.ExtraMounts, "stella-data", filepath.Join(workspaceMount, "skills"), true, dockerclient.MountTypeVolume, "workspaces/agent/users/user/skills")
+	assertMount(t, opts.ExtraMounts, "stella-data", extra, true, dockerclient.MountTypeVolume, "users/user/skills")
+	assertMount(t, opts.ExtraMounts, "stella-data", filepath.Join(workspaceMount, "skills"), true, dockerclient.MountTypeVolume, "users/user/skills")
 }
 
 func TestConfigureSessionMounts_VolumeModeRejectsStellaHomeAsWorkspace(t *testing.T) {
@@ -290,7 +290,7 @@ func TestConfigureSessionMounts_BindModeUsesConfigStellaHome(t *testing.T) {
 func dockerModeTestDirs(t *testing.T) (stellaHome, workspace, extra, tmp string) {
 	t.Helper()
 	stellaHome = t.TempDir()
-	workspace = filepath.Join(stellaHome, "workspaces", "agent", "users", "user")
+	workspace = filepath.Join(stellaHome, "users", "user")
 	extra = filepath.Join(workspace, "skills")
 	tmp = t.TempDir()
 	for _, dir := range []string{filepath.Join(stellaHome, "bin"), workspace, extra} {

--- a/resources/skills/system/stella/SKILL.md
+++ b/resources/skills/system/stella/SKILL.md
@@ -22,7 +22,7 @@ Run mode:
 
 - **Server**: `stellad server` (Telegram, QQ, Feishu, WeChat bots + scheduler + Web UI)
 
-Setup: run `stellad server` and open `http://localhost:25678` to configure everything via the Web UI. All configuration is stored in a SQLite database (`$STELLA_HOME/stella.db`). Data: `$STELLA_HOME/workspaces/{agent_id}/`.
+Setup: run `stellad server` and open `http://localhost:25678` to configure everything via the Web UI. All configuration is stored in a SQLite database (`$STELLA_HOME/stella.db`). Data: `$STELLA_HOME/agents/{agent_id}/`.
 
 ## Architecture
 

--- a/resources/skills/system/stella/references/configuration.md
+++ b/resources/skills/system/stella/references/configuration.md
@@ -33,7 +33,7 @@ Each agent has:
 
 - A provider + model configuration
 - A system prompt (personality/identity)
-- An isolated workspace at `$STELLA_HOME/workspaces/{agent_id}/`
+- An isolated workspace at `$STELLA_HOME/agents/{agent_id}/`
 - Its own skills directory
 
 Create agents via the Web UI or directly in the database.
@@ -90,13 +90,13 @@ Global settings are stored in the `settings` table as JSON values:
 
 All paths are relative to `$STELLA_HOME` (`~/.stella` by default).
 
-| Path                                    | Purpose                                     |
-| --------------------------------------- | ------------------------------------------- |
-| `stella.db`                             | SQLite database (all config + runtime data) |
-| `cache/models.json`                     | Cached model list (safe to delete)          |
-| `workspaces/{agent_id}/`                | Per-agent workspace                         |
-| `workspaces/{agent_id}/.agents/skills/` | Per-agent installed skills                  |
-| `workspaces/{agent_id}/stella.log`      | Per-agent log                               |
+| Path                                | Purpose                                     |
+| ----------------------------------- | ------------------------------------------- |
+| `stella.db`                         | SQLite database (all config + runtime data) |
+| `cache/models.json`                 | Cached model list (safe to delete)          |
+| `agents/{agent_id}/`                | Per-agent workspace                         |
+| `agents/{agent_id}/.agents/skills/` | Per-agent installed skills                  |
+| `agents/{agent_id}/stella.log`      | Per-agent log                               |
 
 ## Environment variables
 

--- a/web/content/docs/development/group-chat-multi-agent.md
+++ b/web/content/docs/development/group-chat-multi-agent.md
@@ -208,12 +208,12 @@ So the group session stores `group_id` in `ctx_conversation.user_id` as a **look
 
 The critical constraint: that `group_id` must **never flow into the runtime identity surfaces.** The runtime detects "this is a group session" in one place and reroutes all four surfaces:
 
-| Surface                 | Code                                                              | Group-session behavior                                                   |
-| ----------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| memory / prompt profile | `runtime/chat.go` (`memory.WithUserID`), `prompt/prompt.go`       | inject no human; read the group drawer, never a member's private profile |
-| workspace               | `runner_builder.go`, `workspace.go`                               | path `workspaces/{agentID}/groups/{group_id}`, not `users/{userID}`      |
-| vault                   | `sandbox/env.go`                                                  | resolve only agent/group-scoped secrets, never a member's private vault  |
-| scoped token            | `auth/token_service.go`, `auth/scoped_token.go`, `sandbox/env.go` | subject = group principal `group:{group_id}`, not a human userID         |
+| Surface                 | Code                                                              | Group-session behavior                                                                             |
+| ----------------------- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| memory / prompt profile | `runtime/chat.go` (`memory.WithUserID`), `prompt/prompt.go`       | inject no human; read the group drawer, never a member's private profile                           |
+| workspace               | `runner_builder.go`, `workspace.go`                               | path `users/group-{group_id}/` — the group is its own principal, never a member's `users/{userID}` |
+| vault                   | `sandbox/env.go`                                                  | resolve only agent/group-scoped secrets, never a member's private vault                            |
+| scoped token            | `auth/token_service.go`, `auth/scoped_token.go`, `sandbox/env.go` | subject = group principal `group:{group_id}`, not a human userID                                   |
 
 `SignScopedToken` currently hard-requires `claims.UserID != ""`. That must be relaxed to accept a group principal, or gain a `Scope=group` dimension — **never stuff a real human userID in.** No synthetic `auth_user` is created: the group principal is a token subject / execution scope, not a row in `auth_user`.
 

--- a/web/content/docs/development/group-chat-multi-agent.zh.md
+++ b/web/content/docs/development/group-chat-multi-agent.zh.md
@@ -208,12 +208,12 @@ CREATE TABLE ctx_group_memory (
 
 关键约束:这个 `group_id` **绝不能流进运行时身份面**。runtime 在一处识别「这是群 session」,把四个面统一改道:
 
-| 面                      | 代码                                                              | 群 session 行为                                                     |
-| ----------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
-| memory / prompt profile | `runtime/chat.go`(`memory.WithUserID`)、`prompt/prompt.go`        | 不注入任何 human;读群抽屉,绝不读成员私有 profile                    |
-| workspace               | `runner_builder.go`、`workspace.go`                               | 路径 `workspaces/{agentID}/groups/{group_id}`,不是 `users/{userID}` |
-| vault                   | `sandbox/env.go`                                                  | 只解 agent/群作用域密钥,绝不解成员私有 vault                        |
-| scoped token            | `auth/token_service.go`、`auth/scoped_token.go`、`sandbox/env.go` | 主体 = 群 principal `group:{group_id}`,不是 human userID            |
+| 面                      | 代码                                                              | 群 session 行为                                                                  |
+| ----------------------- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| memory / prompt profile | `runtime/chat.go`(`memory.WithUserID`)、`prompt/prompt.go`        | 不注入任何 human;读群抽屉,绝不读成员私有 profile                                 |
+| workspace               | `runner_builder.go`、`workspace.go`                               | 路径 `users/group-{group_id}/`——群是独立 principal,绝不是成员的 `users/{userID}` |
+| vault                   | `sandbox/env.go`                                                  | 只解 agent/群作用域密钥,绝不解成员私有 vault                                     |
+| scoped token            | `auth/token_service.go`、`auth/scoped_token.go`、`sandbox/env.go` | 主体 = 群 principal `group:{group_id}`,不是 human userID                         |
 
 `SignScopedToken` 现硬要求 `claims.UserID != ""`。需放宽成接受群 principal,或加 `Scope=group` 维度——**绝不塞真 human userID**。不造 synthetic `auth_user`:群 principal 是 token 主体 / 执行作用域,不是 `auth_user` 表里的行。
 

--- a/web/content/docs/development/memory-internals.md
+++ b/web/content/docs/development/memory-internals.md
@@ -257,4 +257,4 @@ This is suitable for short-lived conversations or resource-constrained environme
 
 ## Agent Workspaces
 
-Each agent has its own workspace at `$STELLA_HOME/workspaces/{agent_id}/` for file overrides, skills, and per-agent data.
+Each agent has its own workspace at `$STELLA_HOME/agents/{agent_id}/` for file overrides, skills, and per-agent data.

--- a/web/content/docs/development/memory-internals.zh.md
+++ b/web/content/docs/development/memory-internals.zh.md
@@ -257,4 +257,4 @@ Simple 插件使用滑动窗口方式：
 
 ## Agent 工作区
 
-每个 agent 在 `$STELLA_HOME/workspaces/{agent_id}/` 有自己的工作区，用于文件覆盖、技能和每 agent 数据。
+每个 agent 在 `$STELLA_HOME/agents/{agent_id}/` 有自己的工作区，用于文件覆盖、技能和每 agent 数据。

--- a/web/content/docs/start-here/configuration.md
+++ b/web/content/docs/start-here/configuration.md
@@ -23,7 +23,7 @@ Open the **Agents** page to create and configure agents. Each agent has:
 - **System prompt** — custom personality and instructions
 - **Sandbox settings** — network access policy for agent code execution
 
-You can also override the system prompt by placing a `SOUL.md` file in the agent's workspace at `~/.stella/workspaces/{agent-id}/`.
+You can also override the system prompt by placing a `SOUL.md` file in the agent's workspace at `~/.stella/agents/{agent-id}/`.
 
 ## Channels
 
@@ -63,13 +63,13 @@ The runner controls how the agent processes messages. You can configure these fr
 
 All data lives under `~/.stella` (configurable via `STELLA_HOME`):
 
-| Path                                        | Purpose                                             |
-| ------------------------------------------- | --------------------------------------------------- |
-| `~/.stella/stella.db`                       | Database (config, memory, scheduler) — back this up |
-| `~/.stella/workspaces/{agent-id}/`          | Per-agent workspace, skills, and overrides          |
-| `~/.stella/workspaces/{agent-id}/SOUL.md`   | Optional agent personality override                 |
-| `~/.stella/workspaces/{agent-id}/SYSTEM.md` | Optional system prompt override                     |
-| `~/.stella/cache/`                          | Model cache (safe to delete)                        |
+| Path                                    | Purpose                                             |
+| --------------------------------------- | --------------------------------------------------- |
+| `~/.stella/stella.db`                   | Database (config, memory, scheduler) — back this up |
+| `~/.stella/agents/{agent-id}/`          | Per-agent workspace, skills, and overrides          |
+| `~/.stella/agents/{agent-id}/SOUL.md`   | Optional agent personality override                 |
+| `~/.stella/agents/{agent-id}/SYSTEM.md` | Optional system prompt override                     |
+| `~/.stella/cache/`                      | Model cache (safe to delete)                        |
 
 ## Environment Variables
 

--- a/web/content/docs/start-here/configuration.zh.md
+++ b/web/content/docs/start-here/configuration.zh.md
@@ -23,7 +23,7 @@ title: 配置
 - **系统提示** — 自定义人格和指令
 - **沙箱设置** — 代理代码执行的网络访问策略
 
-你也可以在代理工作空间 `~/.stella/workspaces/{agent-id}/` 中放置 `SOUL.md` 文件来覆盖系统提示。
+你也可以在代理工作空间 `~/.stella/agents/{agent-id}/` 中放置 `SOUL.md` 文件来覆盖系统提示。
 
 ## 渠道
 
@@ -63,13 +63,13 @@ Runner 控制代理如何处理消息。你可以在Web UI的 **设置** 页面�
 
 所有数据存储在 `~/.stella` 下（可通过 `STELLA_HOME` 配置）：
 
-| 路径                                        | 用途                                       |
-| ------------------------------------------- | ------------------------------------------ |
-| `~/.stella/stella.db`                       | 数据库（配置、记忆、调度器）— 请备份此文件 |
-| `~/.stella/workspaces/{agent-id}/`          | 每个代理的工作空间、技能和覆盖文件         |
-| `~/.stella/workspaces/{agent-id}/SOUL.md`   | 可选的代理人格覆盖                         |
-| `~/.stella/workspaces/{agent-id}/SYSTEM.md` | 可选的系统提示覆盖                         |
-| `~/.stella/cache/`                          | 模型缓存（可安全删除）                     |
+| 路径                                    | 用途                                       |
+| --------------------------------------- | ------------------------------------------ |
+| `~/.stella/stella.db`                   | 数据库（配置、记忆、调度器）— 请备份此文件 |
+| `~/.stella/agents/{agent-id}/`          | 每个代理的工作空间、技能和覆盖文件         |
+| `~/.stella/agents/{agent-id}/SOUL.md`   | 可选的代理人格覆盖                         |
+| `~/.stella/agents/{agent-id}/SYSTEM.md` | 可选的系统提示覆盖                         |
+| `~/.stella/cache/`                      | 模型缓存（可安全删除）                     |
 
 ## 环境变量
 

--- a/web/content/docs/start-here/deployment.md
+++ b/web/content/docs/start-here/deployment.md
@@ -205,12 +205,12 @@ Running Stella inside a Docker container (described above) is separate from usin
 
 All data lives under the stella home directory (`~/.stella` by default, configurable via `STELLA_HOME`).
 
-| Path                                      | Purpose                                     |
-| ----------------------------------------- | ------------------------------------------- |
-| `~/.stella/stella.db`                     | Single database (config, memory, scheduler) |
-| `~/.stella/workspaces/{agent-id}/skills/` | Per-agent installed skills                  |
-| `~/.stella/workspaces/{agent-id}/SOUL.md` | Optional per-agent soul/identity override   |
-| `~/.stella/cache/`                        | Model cache (regenerable, safe to delete)   |
+| Path                                  | Purpose                                     |
+| ------------------------------------- | ------------------------------------------- |
+| `~/.stella/stella.db`                 | Single database (config, memory, scheduler) |
+| `~/.stella/agents/{agent-id}/skills/` | Per-agent installed skills                  |
+| `~/.stella/agents/{agent-id}/SOUL.md` | Optional per-agent soul/identity override   |
+| `~/.stella/cache/`                    | Model cache (regenerable, safe to delete)   |
 
 The `stella.db` file is the only critical data to back up. It contains all configuration, message history, summaries, and scheduler jobs.
 

--- a/web/content/docs/start-here/deployment.zh.md
+++ b/web/content/docs/start-here/deployment.zh.md
@@ -205,12 +205,12 @@ docker buildx build --platform linux/amd64,linux/arm64 -t stella .
 
 所有数据都存储在 stella 主目录下（默认为 `~/.stella`，可通过 `STELLA_HOME` 配置）。
 
-| 路径                                      | 用途                             |
-| ----------------------------------------- | -------------------------------- |
-| `~/.stella/stella.db`                     | 单一数据库（配置、记忆、调度器） |
-| `~/.stella/workspaces/{agent-id}/skills/` | 每个 agent 安装的技能            |
-| `~/.stella/workspaces/{agent-id}/SOUL.md` | 可选的每个 agent 的灵魂/身份覆盖 |
-| `~/.stella/cache/`                        | 模型缓存（可重新生成，安全删除） |
+| 路径                                  | 用途                             |
+| ------------------------------------- | -------------------------------- |
+| `~/.stella/stella.db`                 | 单一数据库（配置、记忆、调度器） |
+| `~/.stella/agents/{agent-id}/skills/` | 每个 agent 安装的技能            |
+| `~/.stella/agents/{agent-id}/SOUL.md` | 可选的每个 agent 的灵魂/身份覆盖 |
+| `~/.stella/cache/`                    | 模型缓存（可重新生成，安全删除） |
 
 `stella.db` 文件是唯一需要备份的关键数据。它包含所有配置、消息历史、摘要和调度器任务。
 


### PR DESCRIPTION
## What

Flip the on-disk sandbox layout from agent-first to **user-first**: the `users/` tree is the only top-level isolation boundary. A principal — a real user, or a channel group treated as a synthetic user — has one home shared by all of its agents; an agent is an app run under that home.

```
~/.stella/
  agents/{agentID}/              # user-independent agent workspace (skills, log);
                                 # a user-less job (builtin scheduled) runs here
  users/
    {userID}/                    # user home (sandbox $HOME), shared by the user's agents
      .mise-tools/ .agents/skills/ data/ assets/
      agents/{agentID}/projects/{projectID}/   # per-agent area; the agent owns its projects
    group-{groupID}/             # channel group home — its own principal in the users tree
      .mise-tools/ .agents/skills/ agents/{agentID}/...
```

Drops the separate top-level `groups/` and `system/` trees, and renames the per-agent workspace from `workspaces/{id}` to `agents/{id}`.

## Why

Issue #442: model the layout like a real PC — a principal has a home, agents are apps under it. Toolchains, skills, caches, and uploads belong to the principal and are shared across its agents; a project's working tree stays scoped to the owning agent.

Two boundary cases drove the shape:
- **Channel groups** (Feishu/Telegram/QQ) carry a synthetic `UserID == GroupID` and have no owning human user (`OwnerUserID == ""`), so a group can't nest under a person — it is its own principal. The `group-` prefix keeps a group home from colliding with a real user home of the same raw ID, preserving #443's "equal IDs never share a writable tree" invariant now that both live in one tree.
- **User-less jobs** (builtin scheduled) have no principal home, so they run in the agent's own user-independent workspace `agents/{agentID}/` — no `system/` tree needed.

## How

- `internal/agent/workspace.go` — `GroupHomeDir` → `users/group-{id}/`; remove `SystemWorkspaceDir`/`SetupSystemWorkspace`; rewrite the layout doc comment.
- `internal/agent/runner_builder.go` — user-less branch runs in `cfg.Snap.Workspace` (AgentRoot) instead of building a `system/` dir.
- `internal/agent/sandbox/env.go` — `misePrincipal` routes groups to `("users", "group-"+id)` so a group's `.mise-tools`/temp sit inside its home and stay collision-safe.
- `pkg/sandbox/hostenv.go` — `MiseUserToolsDir` whitelist tightened to `"users"` only, blocking any revival of a top-level `groups/`.
- Tests: update path assertions across `backend_test`/`group_session_test`/`miseuser_test`/`docker session_pure_test`; flip the old "group not under users/" test into "group and same-raw-ID user homes stay disjoint via prefix".
- Docs/skill: `group-chat-multi-agent`(EN/ZH) group workspace path corrected; `workspaces/{id}` → `agents/{id}` across configuration/deployment/memory-internals docs and the stella system skill.

Verification: `mise run build` + `mise run test` green; `gofmt` clean; cross-compiled `windows/amd64` and `linux/amd64`. (`mise run format`'s web step fails on a missing local vite native binding — environmental, unrelated to these Go+markdown changes.)

Scope note: this is the layout flip only ("本期只搬家"). PR2 will set `HOME` to the user home + XDG writable mounts and drop the now-redundant `MISE_*_DIR` overrides.

## Refs

Refs #442