### PR TITLE
✨ feat(sandbox): user-home $HOME + per-agent credential isolation (#442)

### DIFF
--- a/internal/agent/sandbox/env.go
+++ b/internal/agent/sandbox/env.go
@@ -24,7 +24,23 @@ func runnerFilesystemPolicy(paths Paths, cfg Config) pkgsandbox.FilesystemPolicy
 		WorkingDir:          paths.WorkDir,
 		ExtraReadOnlyMounts: skillMountsForSandbox(paths),
 		TempDirHost:         userTempDir(principalDir, id),
+		AgentPrivateDir:     agentPrivateDir(paths, cfg),
 	}
+}
+
+// agentPrivateDir returns the host path of the running agent's private subdir of
+// the user home, users/{id}/agents/{agentID} — the area the isolating backends
+// keep private to this agent (XDG config/data/state) while hiding its siblings.
+// It mirrors the agent's project area (UserRoot/agents/{agentID}/projects/...,
+// see internal/agent/workspace.go), kept here as a literal join to avoid a cycle
+// back into the agent package. Empty for a user-less job: with no principal home
+// the agent is its own principal under paths.UserRoot and has no siblings, so
+// there is nothing to isolate.
+func agentPrivateDir(paths Paths, cfg Config) string {
+	if cfg.AgentID == "" || (cfg.UserID == "" && cfg.GroupID == "") {
+		return ""
+	}
+	return filepath.Join(paths.UserRoot, "agents", cfg.AgentID)
 }
 
 // miseUserDirHost returns the host path of this session's writable per-user mise

--- a/pkg/sandbox/hostenv.go
+++ b/pkg/sandbox/hostenv.go
@@ -117,16 +117,6 @@ func HostEnvBuildPath(stellaHome, userShimsDir string) string {
 	return strings.Join(hostEnvDedupeEntries(entries), string(os.PathListSeparator))
 }
 
-// HostEnvBuildHome returns the HOME value for host-execution sandbox backends.
-// On Linux (with bwrap), HOME is remapped to /workspace; elsewhere it
-// mirrors the working directory.
-func HostEnvBuildHome(workDir string) string {
-	if runtime.GOOS == "linux" {
-		return "/workspace"
-	}
-	return workDir
-}
-
 // HostEnvCopy copies a fixed allowlist of host environment variables into env.
 // Only locale, terminal, and proxy variables are included.
 func HostEnvCopy(env map[string]string) {

--- a/pkg/sandbox/policy.go
+++ b/pkg/sandbox/policy.go
@@ -76,6 +76,18 @@ type FilesystemPolicy struct {
 	// installs) before the backend sees the policy. The policy stays mise-agnostic:
 	// it only learns "these host dirs are writable", not why.
 	ExtraWritableMounts []string
+
+	// AgentPrivateDir is the host path of the running agent's private subdir of
+	// the user home (users/{id}/agents/{agentID}), which must live under
+	// WorkspaceRoot. The isolating backends redirect the agent's XDG
+	// config/data/state here and hide its siblings' subdirs, so one agent cannot
+	// read or tamper with another's cached credentials and bypass the per-agent
+	// scoped-token isolation (#442). Caches and toolchains stay shared at the
+	// user-home level; only this subtree is private. Empty when the session has
+	// no sibling agents to isolate from — a user-less job, where the agent is its
+	// own principal — and ignored by backends that don't enforce isolation (none,
+	// and docker until #436).
+	AgentPrivateDir string
 }
 
 // NetworkPolicy defines network constraints for a sandbox session.

--- a/plugins/sandbox/local/session.go
+++ b/plugins/sandbox/local/session.go
@@ -75,9 +75,12 @@ func (f *Factory) CreateSession(_ context.Context, policy sandboxpkg.Policy) (sa
 	}
 
 	hostStellaHome := f.cfg.StellaHome
-	policy = f.adjustPolicy(policy)
-
+	// Resolve the sandbox-space root first: adjustPolicy needs it to point HOME
+	// and the XDG dirs at the user home as the agent sees it. resolveSandboxRoot
+	// reads only WorkspaceRoot, which adjustPolicy leaves untouched.
 	sandboxRoot, realRoot := resolveSandboxRoot(policy)
+	policy = f.adjustPolicy(policy, sandboxRoot, realRoot)
+
 	tmpMounts, err := createSessionTmpMounts(policy)
 	if err != nil {
 		return nil, fmt.Errorf("local: create session tmp: %w", err)
@@ -96,7 +99,10 @@ func (f *Factory) CreateSession(_ context.Context, policy sandboxpkg.Policy) (sa
 }
 
 // adjustPolicy applies local-backend-specific environment adjustments.
-func (f *Factory) adjustPolicy(policy sandboxpkg.Policy) sandboxpkg.Policy {
+// sandboxRoot/realRoot are the sandbox-space and host views of the workspace
+// root (the user home); HOME and the XDG dirs are anchored to the sandbox-space
+// view so the agent sees a real per-user home.
+func (f *Factory) adjustPolicy(policy sandboxpkg.Policy, sandboxRoot, realRoot string) sandboxpkg.Policy {
 	if f.cfg.StellaHome == "" {
 		return policy
 	}
@@ -114,7 +120,11 @@ func (f *Factory) adjustPolicy(policy sandboxpkg.Policy) sandboxpkg.Policy {
 		userShims = sandboxpkg.MiseUserShimsDir(remap(dir))
 	}
 	env["PATH"] = sandboxpkg.HostEnvBuildPath(sandboxSH, userShims)
-	env["HOME"] = adjustHome(policy.Filesystem.WorkingDir)
+	// HOME is the user home (the workspace root as the agent sees it), so XDG
+	// defaults — caches, tool config — land under it and are shared per-user. The
+	// project dir stays the cwd; only HOME differs (#442).
+	env["HOME"] = sandboxRoot
+	setXDGDirs(env, sandboxRoot, remapToSandboxRoot(policy.Filesystem.AgentPrivateDir, realRoot, sandboxRoot))
 	env["STELLA_HOME"] = sandboxSH
 	// Rewrite MISE_* path-valued env vars from host STELLA_HOME to the
 	// sandbox-adjusted path so mise resolves tools and configs correctly inside
@@ -143,6 +153,39 @@ func (f *Factory) adjustPolicy(policy sandboxpkg.Policy) sandboxpkg.Policy {
 	policy.Env = env
 	policy.InheritEnv = false
 	return policy
+}
+
+// setXDGDirs points the per-agent XDG dirs at the agent's private subdir so each
+// agent's credentials and state (e.g. ~/.config/gh) stay private to it, while the
+// cache stays at the shared user-home default. agentPrivate is the sandbox-space
+// agent-private dir, or "" for a user-less session with no siblings — then XDG is
+// left to its $HOME defaults (everything shared under the one home).
+func setXDGDirs(env map[string]string, home, agentPrivate string) {
+	env["XDG_CACHE_HOME"] = filepath.Join(home, ".cache")
+	if agentPrivate == "" {
+		return
+	}
+	env["XDG_CONFIG_HOME"] = filepath.Join(agentPrivate, ".config")
+	env["XDG_DATA_HOME"] = filepath.Join(agentPrivate, ".local", "share")
+	env["XDG_STATE_HOME"] = filepath.Join(agentPrivate, ".local", "state")
+}
+
+// remapToSandboxRoot rewrites a host path under realRoot to its sandbox-space
+// location under sandboxRoot, leaving paths outside realRoot (and the macOS case
+// realRoot == sandboxRoot) untouched. It mirrors localSession.toSandboxPath for
+// the workspace root, but runs at policy-build time before a session exists.
+func remapToSandboxRoot(hostPath, realRoot, sandboxRoot string) string {
+	if hostPath == "" || realRoot == sandboxRoot {
+		return hostPath
+	}
+	rel, err := filepath.Rel(realRoot, filepath.Clean(hostPath))
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return hostPath
+	}
+	if rel == "." {
+		return sandboxRoot
+	}
+	return filepath.Join(sandboxRoot, rel)
 }
 
 // remapStellaHomePath rewrites a host path under hostSH to its sandbox-adjusted

--- a/plugins/sandbox/local/session_darwin.go
+++ b/plugins/sandbox/local/session_darwin.go
@@ -76,10 +76,6 @@ func createSessionTmpMounts(policy sandboxpkg.Policy) ([]tmpMount, error) {
 	}, nil
 }
 
-// adjustHome returns the sandbox-view HOME directory.
-// On macOS (Seatbelt), no path remapping; uses the working directory.
-func adjustHome(workDir string) string { return sandboxpkg.HostEnvBuildHome(workDir) }
-
 // adjustStellaHome returns the sandbox-view STELLA_HOME directory.
 // On macOS (Seatbelt), no path remapping; uses the real host path.
 func adjustStellaHome(stellaHome string) string { return stellaHome }
@@ -147,6 +143,17 @@ func buildSeatbeltProfile(policy sandboxpkg.Policy, stellaHomeHost string) strin
 
 	// Workspace root: the only user-controlled path that is fully writable.
 	fmt.Fprintf(&sb, "(allow file-write* (subpath %q))\n", workspace)
+
+	// Hide sibling agents: deny read+write across the agents/ subtree, then
+	// re-allow this agent's own dir, so it can neither read nor write another
+	// agent's credentials/state (#442). Placed after the workspace allow above so
+	// it wins (last-match-wins) for the agents subtree, while the rest of the home
+	// — caches, toolchains — stays shared. Reads outside the home remain governed
+	// by (allow default): seatbelt's read-permissive base is unchanged here.
+	if ap := filepath.Clean(policy.Filesystem.AgentPrivateDir); filepath.IsAbs(ap) && ap != workspace {
+		fmt.Fprintf(&sb, "(deny file-read* file-write* (subpath %q))\n", filepath.Dir(ap))
+		fmt.Fprintf(&sb, "(allow file-read* file-write* (subpath %q))\n", ap)
+	}
 
 	// Network: deny unless the policy explicitly requests unrestricted access.
 	if networkMode != sandboxpkg.NetworkAllowAll {

--- a/plugins/sandbox/local/session_darwin_test.go
+++ b/plugins/sandbox/local/session_darwin_test.go
@@ -133,6 +133,39 @@ func TestBuildSeatbeltProfile_miseHolesKeyedOnPerUserTree(t *testing.T) {
 	})
 }
 
+// TestBuildSeatbeltProfile_hidesSiblingAgents verifies the per-agent isolation
+// rules (#442): the agents/ subtree is denied read+write and only this agent's
+// own dir is re-allowed, and the ordering wins under last-match-wins (the rules
+// must follow the workspace allow, and the own re-allow must follow the deny).
+func TestBuildSeatbeltProfile_hidesSiblingAgents(t *testing.T) {
+	root := "/private/tmp/ws"
+	policy := makePolicy(root, sandboxpkg.NetworkDisabled)
+	policy.Filesystem.AgentPrivateDir = root + "/agents/a1"
+	profile := buildSeatbeltProfile(policy, "")
+
+	wsAllow := `(allow file-write* (subpath "` + root + `"))`
+	siblingDeny := `(deny file-read* file-write* (subpath "` + root + `/agents"))`
+	ownAllow := `(allow file-read* file-write* (subpath "` + root + `/agents/a1"))`
+	for _, want := range []string{wsAllow, siblingDeny, ownAllow} {
+		if !strings.Contains(profile, want) {
+			t.Errorf("profile missing %s:\n%s", want, profile)
+		}
+	}
+	wsAt, denyAt, ownAt := strings.Index(profile, wsAllow), strings.Index(profile, siblingDeny), strings.Index(profile, ownAllow)
+	if wsAt >= denyAt || denyAt >= ownAt {
+		t.Errorf("rule order must be workspace-allow < sibling-deny < own-allow:\n%s", profile)
+	}
+}
+
+// TestBuildSeatbeltProfile_noSiblingRulesWithoutAgentPrivateDir verifies a
+// user-less session (no agent-private dir) emits no per-agent deny/allow rules.
+func TestBuildSeatbeltProfile_noSiblingRulesWithoutAgentPrivateDir(t *testing.T) {
+	profile := buildSeatbeltProfile(makePolicy("/private/tmp/ws", sandboxpkg.NetworkDisabled), "")
+	if strings.Contains(profile, "(deny file-read* file-write*") {
+		t.Errorf("no sibling-hiding rules expected without AgentPrivateDir:\n%s", profile)
+	}
+}
+
 func TestBuildSeatbeltProfile_networkAllowAll(t *testing.T) {
 	policy := makePolicy("/tmp/ws", sandboxpkg.NetworkAllowAll)
 	profile := buildSeatbeltProfile(policy, "")

--- a/plugins/sandbox/local/session_linux.go
+++ b/plugins/sandbox/local/session_linux.go
@@ -16,13 +16,10 @@ import (
 	sandboxpkg "github.com/CherryHQ/stella/pkg/sandbox"
 )
 
-const (
-	// sandboxHome is the virtual HOME inside the bwrap sandbox, matching the
-	// docker backend's /home/stella layout for a realistic Linux user directory.
-	sandboxHome = "/home/stella"
-	// sandboxStellaHome is the virtual STELLA_HOME inside the bwrap sandbox.
-	sandboxStellaHome = "/home/stella/.stella"
-)
+// sandboxStellaHome is the virtual STELLA_HOME inside the bwrap sandbox. HOME is
+// not a fixed path: it is the workspace root (the user home) at /workspace, set
+// in adjustPolicy, so XDG defaults land in the per-user home (#442).
+const sandboxStellaHome = "/home/stella/.stella"
 
 // setSysProcAttr places the child in its own process group so that
 // killProcessGroup can terminate the entire subtree.
@@ -182,10 +179,6 @@ func appendLinuxRuntimeMounts(args []string) []string {
 	return args
 }
 
-// adjustHome returns the sandbox-view HOME directory.
-// On Linux (bwrap), HOME is remapped to /home/stella for a realistic layout.
-func adjustHome(_ string) string { return sandboxHome }
-
 // adjustStellaHome returns the sandbox-view STELLA_HOME directory.
 // On Linux (bwrap), it is remapped to /home/stella/.stella.
 func adjustStellaHome(_ string) string { return sandboxStellaHome }
@@ -306,6 +299,19 @@ func wrapCommand(policy sandboxpkg.Policy, sandboxCwd string, tmpMounts []tmpMou
 		"--bind", realRoot, "/workspace",
 		"--chdir", sandboxCwd,
 	)
+	// Hide sibling agents: the realRoot bind exposes every users/{id}/agents/* at
+	// /workspace/agents/*, so cover that subtree with an empty tmpfs and bind back
+	// only this agent's own dir. One agent then can neither read nor write
+	// another's credentials/state, enforcing the per-agent boundary (#442). Must
+	// follow the realRoot bind (which it overlays) and precede the read-only
+	// re-mounts (the agent's own project skill dirs live under it).
+	if sandboxAP := remapToSandboxRoot(policy.Filesystem.AgentPrivateDir, realRoot, "/workspace"); sandboxAP != "" && sandboxAP != "/workspace" {
+		bwrapArgs = append(bwrapArgs,
+			"--tmpfs", filepath.Dir(sandboxAP),
+			"--dir", sandboxAP,
+			"--bind", policy.Filesystem.AgentPrivateDir, sandboxAP,
+		)
+	}
 	// Re-mount workspace-contained extra paths read-only at their /workspace/...
 	// equivalent. This overrides the writable workspace bind for those subdirectories
 	// so bash cannot write to them via /workspace.

--- a/plugins/sandbox/local/session_linux_test.go
+++ b/plugins/sandbox/local/session_linux_test.go
@@ -282,3 +282,62 @@ func TestWrapCommand_linux_perUserMiseWritableBind(t *testing.T) {
 		t.Errorf("per-user mise tree must be writable, not --ro-bind, got %v", args)
 	}
 }
+
+// TestWrapCommand_linux_hidesSiblingAgents verifies the per-agent isolation
+// mounts (#442): the agents/ subtree under /workspace is covered by an empty
+// tmpfs (hiding siblings) and only this agent's own dir is bound back, after the
+// realRoot bind it overlays.
+func TestWrapCommand_linux_hidesSiblingAgents(t *testing.T) {
+	if _, err := exec.LookPath("bwrap"); err != nil {
+		t.Skip("bwrap not installed")
+	}
+	if !bwrapFunctional() {
+		t.Skip("bwrap not functional (namespace creation blocked)")
+	}
+
+	root := "/tmp/test-workspace"
+	agentPriv := root + "/agents/a1"
+	policy := sandboxpkg.Policy{
+		Filesystem: sandboxpkg.FilesystemPolicy{
+			WorkspaceRoot:   root,
+			WorkingDir:      agentPriv + "/projects/p",
+			AgentPrivateDir: agentPriv,
+		},
+		Network: sandboxpkg.NetworkPolicy{Mode: sandboxpkg.NetworkAllowAll},
+	}
+
+	_, args, _, err := wrapCommand(policy, "/workspace/agents/a1/projects/p", nil, "", "sh", []string{"-c", "echo hi"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	flagIndex := func(flag, val string) int {
+		for i, a := range args {
+			if a == flag && i+1 < len(args) && args[i+1] == val {
+				return i
+			}
+		}
+		return -1
+	}
+	hasFlagPair := func(flag, first, second string) bool {
+		for i, a := range args {
+			if a == flag && i+2 < len(args) && args[i+1] == first && args[i+2] == second {
+				return true
+			}
+		}
+		return false
+	}
+
+	tmpfsAt := flagIndex("--tmpfs", "/workspace/agents")
+	if tmpfsAt < 0 {
+		t.Errorf("expected --tmpfs /workspace/agents to hide siblings, got %v", args)
+	}
+	if !hasFlagPair("--bind", agentPriv, "/workspace/agents/a1") {
+		t.Errorf("expected own agent dir bound back at /workspace/agents/a1, got %v", args)
+	}
+	// The tmpfs must come after the realRoot bind it overlays, else the bind would
+	// re-expose the siblings the tmpfs is meant to hide.
+	if rootBind := flagIndex("--bind", root); rootBind < 0 || rootBind > tmpfsAt {
+		t.Errorf("--tmpfs /workspace/agents must follow --bind %s /workspace, got %v", root, args)
+	}
+}

--- a/plugins/sandbox/local/session_other.go
+++ b/plugins/sandbox/local/session_other.go
@@ -16,9 +16,6 @@ func resolveSandboxRoot(policy sandboxpkg.Policy) (sandboxRoot, realRoot string)
 // createSessionTmpMounts returns no temp mounts on platforms other than Linux and macOS.
 func createSessionTmpMounts(sandboxpkg.Policy) ([]tmpMount, error) { return nil, nil }
 
-// adjustHome returns the sandbox-view HOME directory. No remapping on this platform.
-func adjustHome(workDir string) string { return workDir }
-
 // adjustStellaHome returns the sandbox-view STELLA_HOME. No remapping on this platform.
 func adjustStellaHome(stellaHome string) string { return stellaHome }
 

--- a/plugins/sandbox/local/session_test.go
+++ b/plugins/sandbox/local/session_test.go
@@ -465,7 +465,8 @@ func TestAdjustPolicy_rewritesMiseEnvPaths(t *testing.T) {
 	}
 
 	f := &Factory{cfg: Config{StellaHome: hostSH}}
-	adjusted := f.adjustPolicy(policy)
+	sandboxRoot, realRoot := resolveSandboxRoot(policy)
+	adjusted := f.adjustPolicy(policy, sandboxRoot, realRoot)
 
 	if hostSH == sandboxSH {
 		t.Skip("no path remapping on this platform")
@@ -511,11 +512,66 @@ func TestAdjustPolicy_perUserMiseShimsOnPath(t *testing.T) {
 		Env: map[string]string{"MISE_DATA_DIR": hostSH + "/users/u1/.mise-tools"},
 	}
 	f := &Factory{cfg: Config{StellaHome: hostSH}}
-	adjusted := f.adjustPolicy(policy)
+	sandboxRoot, realRoot := resolveSandboxRoot(policy)
+	adjusted := f.adjustPolicy(policy, sandboxRoot, realRoot)
 
 	wantShims := sandboxSH + "/users/u1/.mise-tools/shims"
 	if !strings.Contains(adjusted.Env["PATH"], wantShims) {
 		t.Fatalf("PATH must include per-user shims %q, got %q", wantShims, adjusted.Env["PATH"])
+	}
+}
+
+// TestAdjustPolicy_homeAndXDG verifies HOME is the user home (the sandbox-space
+// workspace root) and the XDG dirs split shared-vs-private: cache stays at the
+// shared home while config/data/state redirect into the agent's private subdir
+// (#442). On Linux the agent-private path is also remapped into /workspace.
+func TestAdjustPolicy_homeAndXDG(t *testing.T) {
+	root := t.TempDir()
+	agentPriv := filepath.Join(root, "agents", "a1")
+	policy := sandboxpkg.Policy{
+		Filesystem: sandboxpkg.FilesystemPolicy{
+			WorkspaceRoot:   root,
+			WorkingDir:      filepath.Join(agentPriv, "projects", "p"),
+			AgentPrivateDir: agentPriv,
+		},
+	}
+	f := &Factory{cfg: Config{StellaHome: t.TempDir()}}
+	sandboxRoot, realRoot := resolveSandboxRoot(policy)
+	env := f.adjustPolicy(policy, sandboxRoot, realRoot).Env
+
+	apSandbox := remapToSandboxRoot(agentPriv, realRoot, sandboxRoot)
+	for _, tc := range []struct{ key, want string }{
+		{"HOME", sandboxRoot},
+		{"XDG_CACHE_HOME", filepath.Join(sandboxRoot, ".cache")},
+		{"XDG_CONFIG_HOME", filepath.Join(apSandbox, ".config")},
+		{"XDG_DATA_HOME", filepath.Join(apSandbox, ".local", "share")},
+		{"XDG_STATE_HOME", filepath.Join(apSandbox, ".local", "state")},
+	} {
+		if env[tc.key] != tc.want {
+			t.Errorf("env[%s] = %q, want %q", tc.key, env[tc.key], tc.want)
+		}
+	}
+}
+
+// TestAdjustPolicy_noAgentPrivateDir_sharesXDG verifies a user-less session (no
+// agent-private dir, no siblings) keeps config/data/state at their $HOME
+// defaults — only the cache is set, so everything lives under the one home.
+func TestAdjustPolicy_noAgentPrivateDir_sharesXDG(t *testing.T) {
+	root := t.TempDir()
+	policy := sandboxpkg.Policy{
+		Filesystem: sandboxpkg.FilesystemPolicy{WorkspaceRoot: root, WorkingDir: root},
+	}
+	f := &Factory{cfg: Config{StellaHome: t.TempDir()}}
+	sandboxRoot, realRoot := resolveSandboxRoot(policy)
+	env := f.adjustPolicy(policy, sandboxRoot, realRoot).Env
+
+	if env["XDG_CACHE_HOME"] != filepath.Join(sandboxRoot, ".cache") {
+		t.Errorf("XDG_CACHE_HOME = %q, want shared cache", env["XDG_CACHE_HOME"])
+	}
+	for _, k := range []string{"XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_STATE_HOME"} {
+		if v, ok := env[k]; ok {
+			t.Errorf("%s should be unset (left to $HOME default), got %q", k, v)
+		}
 	}
 }
 

--- a/web/content/docs/guides/sandbox.md
+++ b/web/content/docs/guides/sandbox.md
@@ -143,6 +143,10 @@ bubblewrap must be functional, not just installed. Inside Docker containers with
 
 On Linux the agent always sees its workspace at `/workspace` regardless of the real host path (bubblewrap bind-mounts it). Docker and Linux local sessions mount the host `/tmp/{user_id}` directory as sandbox `/tmp`, so temporary files work inside the sandbox while remaining scoped per user. On macOS the agent sees the real host path.
 
+### Home directory
+
+Inside the sandbox, `$HOME` is the per-user home, shared by all of that user's agents — so tool caches and toolchains (`~/.cache`, the mise tree) are shared per user instead of duplicated per agent. Each agent's credential and state directories — the XDG dirs `~/.config`, `~/.local/share`, `~/.local/state` (e.g. `~/.config/gh`) — live under that agent's own private subdir of the home, so one agent's cached credentials stay separate from another's. The project tree remains the working directory.
+
 ## None Backend
 
 The `none` backend runs the agent directly on the host with the current user's permissions. No isolation of any kind — no filesystem confinement, no network restrictions, no process group kill, no resource limits.

--- a/web/content/docs/guides/sandbox.zh.md
+++ b/web/content/docs/guides/sandbox.zh.md
@@ -143,6 +143,10 @@ bubblewrap 必须实际可用，仅安装不够。在未启用 `--privileged` �
 
 在 Linux 上，无论真实宿主机路径如何，agent 始终将工作区看作 `/workspace`（bubblewrap 负责绑定挂载）。Docker 和 Linux 本地会话会把宿主机 `/tmp/{user_id}` 挂载为沙箱内 `/tmp`，因此沙箱内可以正常使用临时文件路径，同时仍按用户隔离。在 macOS 上，agent 看到的是真实宿主机路径。
 
+### 主目录
+
+在沙箱内，`$HOME` 是按用户划分的主目录，由该用户的所有 agent 共享——因此工具缓存与工具链（`~/.cache`、mise 工具树）按用户共享，而非按 agent 重复。每个 agent 的凭证与状态目录——XDG 目录 `~/.config`、`~/.local/share`、`~/.local/state`（例如 `~/.config/gh`）——位于该 agent 在主目录下的私有子目录中，因此各 agent 缓存的凭证彼此隔离。项目目录仍作为工作目录。
+
 ## None 后端
 
 `none` 后端以当前用户权限直接在宿主机上运行 agent，不提供任何隔离——无文件系统限制、无网络限制、无进程组终止，也无资源限制。


### PR DESCRIPTION
## What

PR2 of #442 (stacked on #455). Make the sandbox `$HOME` the per-user home and keep each agent's credential/state directories private from its siblings — completing the "real PC" model on the local backend.

- **`$HOME` = the user home** (the workspace root the agent sees): `/workspace` on Linux (bwrap), the real user-home path on macOS. Previously HOME was the project dir (macOS) or a fixed `/home/stella` (Linux). The project dir stays the working directory.
- **XDG split (shared vs private):** `XDG_CACHE_HOME` stays at the shared `$HOME/.cache`; `XDG_CONFIG_HOME` / `XDG_DATA_HOME` / `XDG_STATE_HOME` redirect into the agent's private subdir `users/{id}/agents/{agentID}` (e.g. `~/.config/gh`).
- **Sibling agents hidden:** Linux covers `/workspace/agents` with an empty tmpfs and binds back only the running agent's dir; macOS denies read+write across the `agents/` subtree and re-allows only the own dir (placed after the workspace allow so it wins under SBPL last-match-wins). Verified empirically with `sandbox-exec` on macOS.

## Why

Toolchains and caches should be **shared per user** (the point of the user-first layout in #455), but credential/identity state must stay **per agent** — otherwise one agent could read another's cached tokens (`~/.config/gh`) and bypass the per-agent scoped-token isolation (D9).

## How

- New `FilesystemPolicy.AgentPrivateDir` carries the host path of the agent's private subdir. The runner sets it for principal (user/group) sessions and leaves it empty for user-less jobs (no siblings to isolate).
- HOME/XDG are anchored to the sandbox-space workspace root; `adjustPolicy` now receives `sandboxRoot`/`realRoot`. The now-uniform `adjustHome` and `HostEnvBuildHome` are removed.
- `MISE_DATA_DIR` is kept pointing at `.mise-tools` (per the layered per-user mise design); mise sets its own DATA/CONFIG/CACHE/STATE explicitly, so the XDG change does not affect it.
- **Scope:** local backend (Linux bwrap + macOS Seatbelt). `none` keeps host env (zero isolation by design); docker parity is tracked in #436.

### Tests

- `adjustPolicy` sets `HOME` = sandbox workspace root and the XDG split (shared cache, private config/data/state); user-less sessions leave config/data/state at `$HOME` defaults.
- Linux `wrapCommand` emits `--tmpfs /workspace/agents` + the own-dir rebind, after the realRoot bind.
- macOS `buildSeatbeltProfile` emits the sibling deny + own re-allow in the correct order.

### Known limitation

The macOS local backend keeps Seatbelt's read-permissive `(allow default)` base, so reads **outside** the user home (e.g. the operator's own files) are unchanged; only the cross-agent boundary is enforced. The strong, full-tree isolation path is Linux/bwrap and (future) docker. Separately, `docs/guides/sandbox.md` still labels the macOS local backend "no additional sandboxing" — a pre-existing inaccuracy (it does use Seatbelt) left untouched here.

## Refs

- #442 (epic), #455 (PR1: user-first layout — base of this PR), #436 (docker `ExtraWritableMounts` + parity)