### PR TITLE
✨ feat(channels): add Feishu QR bot setup

### DIFF
--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -475,6 +475,89 @@ components:
         config:
           type: string
           description: "JSON string of the channel config"
+    FeishuRegistrationInitRequest:
+      type: object
+      properties:
+        brand:
+          type: string
+          enum: [feishu, lark]
+          default: feishu
+    FeishuRegistrationInit:
+      type: object
+      required: [supported_auth_methods]
+      properties:
+        supported_auth_methods:
+          type: array
+          items:
+            type: string
+    FeishuRegistrationBeginRequest:
+      type: object
+      properties:
+        brand:
+          type: string
+          enum: [feishu, lark]
+          default: feishu
+    FeishuRegistrationBegin:
+      type: object
+      required: [
+        device_code,
+        verification_uri_complete,
+        qr_url,
+        interval,
+        expires_in,
+      ]
+      properties:
+        device_code:
+          type: string
+        user_code:
+          type: string
+        verification_uri:
+          type: string
+        verification_uri_complete:
+          type: string
+        qr_url:
+          type: string
+        interval:
+          type: integer
+        expires_in:
+          type: integer
+    FeishuRegistrationPollRequest:
+      type: object
+      required: [device_code, channel_id, agent_id]
+      properties:
+        device_code:
+          type: string
+        channel_id:
+          type: string
+        agent_id:
+          type: string
+        name:
+          type: string
+        brand:
+          type: string
+          enum: [feishu, lark]
+          default: feishu
+        enabled:
+          type: boolean
+          default: true
+        config:
+          type: object
+          additionalProperties: true
+    FeishuRegistrationPoll:
+      type: object
+      required: [status]
+      properties:
+        status:
+          type: string
+          enum: [pending, slow_down, created]
+        interval:
+          type: integer
+        tenant_brand:
+          type: string
+        channel:
+          nullable: true
+          allOf:
+            - $ref: "#/components/schemas/Channel"
     WeixinQRCode:
       type: object
       properties:

--- a/api/spec/domain/channels/paths.yaml
+++ b/api/spec/domain/channels/paths.yaml
@@ -120,6 +120,111 @@ paths:
         "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
         "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
 
+  /api/channels/feishu/register/init:
+    post:
+      tags: [channels]
+      summary: Initialize Feishu PersonalAgent registration (admin only)
+      operationId: initFeishuRegistration
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema: {
+              $ref: "../../components.yaml#/components/schemas/FeishuRegistrationInitRequest",
+            }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: {
+                $ref: "../../components.yaml#/components/schemas/FeishuRegistrationInit",
+              }
+        "400": {
+          $ref: "../../components.yaml#/components/responses/BadRequest",
+        }
+        "401": {
+          $ref: "../../components.yaml#/components/responses/Unauthorized",
+        }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "502":
+          description: upstream error from Feishu registration API
+          content:
+            application/json:
+              schema: {
+                $ref: "../../components.yaml#/components/schemas/Error",
+              }
+
+  /api/channels/feishu/register/begin:
+    post:
+      tags: [channels]
+      summary: Begin Feishu PersonalAgent registration (admin only)
+      operationId: beginFeishuRegistration
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema: {
+              $ref: "../../components.yaml#/components/schemas/FeishuRegistrationBeginRequest",
+            }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: {
+                $ref: "../../components.yaml#/components/schemas/FeishuRegistrationBegin",
+              }
+        "400": {
+          $ref: "../../components.yaml#/components/responses/BadRequest",
+        }
+        "401": {
+          $ref: "../../components.yaml#/components/responses/Unauthorized",
+        }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "502":
+          description: upstream error from Feishu registration API
+          content:
+            application/json:
+              schema: {
+                $ref: "../../components.yaml#/components/schemas/Error",
+              }
+
+  /api/channels/feishu/register/poll:
+    post:
+      tags: [channels]
+      summary: Poll Feishu PersonalAgent registration and create a channel (admin only)
+      operationId: pollFeishuRegistration
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {
+              $ref: "../../components.yaml#/components/schemas/FeishuRegistrationPollRequest",
+            }
+      responses:
+        "200":
+          description: pending or created
+          content:
+            application/json:
+              schema: {
+                $ref: "../../components.yaml#/components/schemas/FeishuRegistrationPoll",
+              }
+        "400": {
+          $ref: "../../components.yaml#/components/responses/BadRequest",
+        }
+        "401": {
+          $ref: "../../components.yaml#/components/responses/Unauthorized",
+        }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "502":
+          description: upstream error from Feishu registration API
+          content:
+            application/json:
+              schema: {
+                $ref: "../../components.yaml#/components/schemas/Error",
+              }
+
   /api/channels/weixin/qr:
     post:
       tags: [weixin]

--- a/api/spec/domain/channels/schemas.yaml
+++ b/api/spec/domain/channels/schemas.yaml
@@ -60,6 +60,81 @@ components:
           description: "JSON string of the channel config",
         }
 
+    FeishuRegistrationInitRequest:
+      type: object
+      properties:
+        brand:
+          type: string
+          enum: [feishu, lark]
+          default: feishu
+
+    FeishuRegistrationInit:
+      type: object
+      required: [supported_auth_methods]
+      properties:
+        supported_auth_methods:
+          type: array
+          items: { type: string }
+
+    FeishuRegistrationBeginRequest:
+      type: object
+      properties:
+        brand:
+          type: string
+          enum: [feishu, lark]
+          default: feishu
+
+    FeishuRegistrationBegin:
+      type: object
+      required: [
+        device_code,
+        verification_uri_complete,
+        qr_url,
+        interval,
+        expires_in,
+      ]
+      properties:
+        device_code: { type: string }
+        user_code: { type: string }
+        verification_uri: { type: string }
+        verification_uri_complete: { type: string }
+        qr_url: { type: string }
+        interval: { type: integer }
+        expires_in: { type: integer }
+
+    FeishuRegistrationPollRequest:
+      type: object
+      required: [device_code, channel_id, agent_id]
+      properties:
+        device_code: { type: string }
+        channel_id: { type: string }
+        agent_id: { type: string }
+        name: { type: string }
+        brand:
+          type: string
+          enum: [feishu, lark]
+          default: feishu
+        enabled:
+          type: boolean
+          default: true
+        config:
+          type: object
+          additionalProperties: true
+
+    FeishuRegistrationPoll:
+      type: object
+      required: [status]
+      properties:
+        status:
+          type: string
+          enum: [pending, slow_down, created]
+        interval: { type: integer }
+        tenant_brand: { type: string }
+        channel:
+          nullable: true
+          allOf:
+            - $ref: "#/components/schemas/Channel"
+
     WeixinQRCode:
       type: object
       properties:

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -150,6 +150,12 @@ paths:
     $ref: "./domain/channels/paths.yaml#/paths/~1api~1channels"
   /api/channels/{id}:
     $ref: "./domain/channels/paths.yaml#/paths/~1api~1channels~1{id}"
+  /api/channels/feishu/register/init:
+    $ref: "./domain/channels/paths.yaml#/paths/~1api~1channels~1feishu~1register~1init"
+  /api/channels/feishu/register/begin:
+    $ref: "./domain/channels/paths.yaml#/paths/~1api~1channels~1feishu~1register~1begin"
+  /api/channels/feishu/register/poll:
+    $ref: "./domain/channels/paths.yaml#/paths/~1api~1channels~1feishu~1register~1poll"
   /api/channels/weixin/qr:
     $ref: "./domain/channels/paths.yaml#/paths/~1api~1channels~1weixin~1qr"
   /api/channels/weixin/qr/status:

--- a/internal/server/channels.go
+++ b/internal/server/channels.go
@@ -318,6 +318,13 @@ func (s *Server) channelFromWriteRequest(r *http.Request, req channelWriteReques
 }
 
 func (s *Server) saveChannel(w http.ResponseWriter, r *http.Request, ch config.Channel, cfgMap map[string]any, status int) bool {
+	if conflict, err := s.channelAgentPlatformBindingConflict(r.Context(), ch); err != nil {
+		s.writeInternalError(w, err)
+		return false
+	} else if conflict != "" {
+		writeError(w, http.StatusBadRequest, conflict)
+		return false
+	}
 	pluginID := config.PluginID(config.PluginKindChannel, ch.Type)
 	if err := s.pluginHost.ValidateConfig(pluginID, cfgMap); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request")
@@ -347,6 +354,25 @@ func (s *Server) saveChannel(w http.ResponseWriter, r *http.Request, ch config.C
 	}
 	writeData(w, status, channelToView(saved))
 	return true
+}
+
+func (s *Server) channelAgentPlatformBindingConflict(ctx context.Context, ch config.Channel) (string, error) {
+	if ch.AgentID == "" || ch.Type == "" {
+		return "", nil
+	}
+	channels, err := s.store.ListChannels(ctx)
+	if err != nil {
+		return "", err
+	}
+	for _, existing := range channels {
+		if existing.ID == ch.ID {
+			continue
+		}
+		if effectiveChannelType(existing) == ch.Type && existing.AgentID == ch.AgentID {
+			return "agent is already bound to " + ch.Type + " channel " + existing.ID, nil
+		}
+	}
+	return "", nil
 }
 
 func (s *Server) ensureChannelPluginEnabled(ctx context.Context, channelType string) error {

--- a/internal/server/feishu_registration.go
+++ b/internal/server/feishu_registration.go
@@ -1,0 +1,347 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/CherryHQ/stella/internal/config"
+	pkgchannel "github.com/CherryHQ/stella/pkg/channel"
+)
+
+const feishuRegistrationPath = "/oauth/v1/app/registration"
+
+var (
+	feishuRegistrationHTTPClient = &http.Client{Timeout: 20 * time.Second}
+	feishuRegistrationAccounts   = map[string]string{
+		"feishu": "https://accounts.feishu.cn",
+		"lark":   "https://accounts.larksuite.com",
+	}
+)
+
+func SetFeishuRegistrationEndpointForTesting(endpoint string) func() {
+	previousClient := feishuRegistrationHTTPClient
+	previousAccounts := feishuRegistrationAccounts
+	feishuRegistrationHTTPClient = &http.Client{Timeout: 20 * time.Second}
+	feishuRegistrationAccounts = map[string]string{"feishu": endpoint, "lark": endpoint}
+	return func() {
+		feishuRegistrationHTTPClient = previousClient
+		feishuRegistrationAccounts = previousAccounts
+	}
+}
+
+type feishuRegistrationBrandRequest struct {
+	Brand string `json:"brand"`
+}
+
+type feishuRegistrationPollRequest struct {
+	DeviceCode string         `json:"device_code"`
+	ChannelID  string         `json:"channel_id"`
+	AgentID    string         `json:"agent_id"`
+	Name       string         `json:"name"`
+	Brand      string         `json:"brand"`
+	Enabled    *bool          `json:"enabled"`
+	Config     map[string]any `json:"config"`
+}
+
+type feishuRegistrationUserInfo struct {
+	OpenID      string `json:"open_id"`
+	TenantBrand string `json:"tenant_brand"`
+}
+
+type feishuRegistrationUpstream struct {
+	SupportedAuthMethods    []string                    `json:"supported_auth_methods"`
+	DeviceCode              string                      `json:"device_code"`
+	UserCode                string                      `json:"user_code"`
+	VerificationURI         string                      `json:"verification_uri"`
+	VerificationURIComplete string                      `json:"verification_uri_complete"`
+	Interval                int                         `json:"interval"`
+	ExpiresIn               int                         `json:"expires_in"`
+	ClientID                string                      `json:"client_id"`
+	ClientSecret            string                      `json:"client_secret"`
+	UserInfo                *feishuRegistrationUserInfo `json:"user_info"`
+	Error                   string                      `json:"error"`
+	ErrorDescription        string                      `json:"error_description"`
+}
+
+func (s *Server) InitFeishuRegistration(w http.ResponseWriter, r *http.Request) {
+	if requireAdmin(w, r) == nil {
+		return
+	}
+	var req feishuRegistrationBrandRequest
+	if err := decodeOptionalJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	upstream, err := postFeishuRegistration(r, registrationBrand(req.Brand), url.Values{"action": {"init"}})
+	if err != nil {
+		writeFeishuRegistrationError(w, err)
+		return
+	}
+	writeData(w, http.StatusOK, map[string]any{"supported_auth_methods": upstream.SupportedAuthMethods})
+}
+
+func (s *Server) BeginFeishuRegistration(w http.ResponseWriter, r *http.Request) {
+	if requireAdmin(w, r) == nil {
+		return
+	}
+	var req feishuRegistrationBrandRequest
+	if err := decodeOptionalJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	form := url.Values{
+		"action":            {"begin"},
+		"archetype":         {"PersonalAgent"},
+		"auth_method":       {"client_secret"},
+		"request_user_info": {"open_id tenant_brand"},
+	}
+	upstream, err := postFeishuRegistration(r, registrationBrand(req.Brand), form)
+	if err != nil {
+		writeFeishuRegistrationError(w, err)
+		return
+	}
+	verificationURL := upstream.VerificationURIComplete
+	if verificationURL == "" {
+		verificationURL = upstream.VerificationURI
+	}
+	qrURL := appendQueryParam(verificationURL, "from", "stella")
+	writeData(w, http.StatusOK, map[string]any{
+		"device_code":               upstream.DeviceCode,
+		"user_code":                 upstream.UserCode,
+		"verification_uri":          upstream.VerificationURI,
+		"verification_uri_complete": verificationURL,
+		"qr_url":                    qrURL,
+		"interval":                  defaultInt(upstream.Interval, 5),
+		"expires_in":                defaultInt(upstream.ExpiresIn, 300),
+	})
+}
+
+func (s *Server) PollFeishuRegistration(w http.ResponseWriter, r *http.Request) {
+	if requireAdmin(w, r) == nil {
+		return
+	}
+	var req feishuRegistrationPollRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	req.DeviceCode = strings.TrimSpace(req.DeviceCode)
+	req.ChannelID = strings.TrimSpace(req.ChannelID)
+	req.AgentID = strings.TrimSpace(req.AgentID)
+	if req.DeviceCode == "" || req.ChannelID == "" {
+		writeError(w, http.StatusBadRequest, "device_code and channel_id are required")
+		return
+	}
+	if req.AgentID == "" {
+		writeError(w, http.StatusBadRequest, "agent_id is required; bind this Feishu channel to an agent")
+		return
+	}
+	agent, err := s.store.GetAgent(r.Context(), req.AgentID)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "agent_id must reference an existing agent")
+		return
+	}
+	if !agent.Enabled {
+		writeError(w, http.StatusBadRequest, "agent_id must reference an enabled agent")
+		return
+	}
+	if conflict, err := s.channelAgentPlatformBindingConflict(r.Context(), config.Channel{ID: req.ChannelID, Type: pkgchannel.PlatformFeishu, AgentID: req.AgentID}); err != nil {
+		s.writeInternalError(w, err)
+		return
+	} else if conflict != "" {
+		writeError(w, http.StatusBadRequest, conflict)
+		return
+	}
+	brand := registrationBrand(req.Brand)
+	upstream, err := pollFeishuRegistrationUpstream(r, brand, req.DeviceCode)
+	if err != nil {
+		var pending feishuRegistrationPendingError
+		if errors.As(err, &pending) {
+			writeData(w, http.StatusOK, map[string]any{"status": pending.Status, "interval": pending.Interval})
+			return
+		}
+		writeFeishuRegistrationError(w, err)
+		return
+	}
+	if upstream.ClientSecret == "" && upstream.UserInfo != nil && upstream.UserInfo.TenantBrand == "lark" && brand != "lark" {
+		upstream, err = pollFeishuRegistrationUpstream(r, "lark", req.DeviceCode)
+		if err != nil {
+			writeFeishuRegistrationError(w, err)
+			return
+		}
+	}
+	if upstream.ClientID == "" || upstream.ClientSecret == "" {
+		writeError(w, http.StatusBadGateway, "Feishu registration did not return app credentials")
+		return
+	}
+
+	cfg := req.Config
+	if cfg == nil {
+		cfg = map[string]any{}
+	}
+	cfg["app_id"] = upstream.ClientID
+	cfg["app_secret"] = upstream.ClientSecret
+	enabled := true
+	if req.Enabled != nil {
+		enabled = *req.Enabled
+	}
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		name = "Feishu"
+	}
+	ch := config.Channel{ID: req.ChannelID, Name: name, Type: pkgchannel.PlatformFeishu, AgentID: req.AgentID, Enabled: enabled}
+	pluginID := config.PluginID(config.PluginKindChannel, ch.Type)
+	if err := s.pluginHost.ValidateConfig(pluginID, cfg); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request")
+		return
+	}
+	saved, err := s.saveFeishuRegistrationChannel(r, ch, cfg)
+	if err != nil {
+		s.writeInternalError(w, err)
+		return
+	}
+	writeData(w, http.StatusOK, map[string]any{
+		"status":       "created",
+		"tenant_brand": tenantBrand(upstream),
+		"channel":      channelToView(saved),
+	})
+}
+
+func (s *Server) saveFeishuRegistrationChannel(r *http.Request, ch config.Channel, cfgMap map[string]any) (config.Channel, error) {
+	cfgJSON, err := json.Marshal(cfgMap)
+	if err != nil {
+		return config.Channel{}, err
+	}
+	ch.Config = string(cfgJSON)
+	if err := s.store.UpsertChannel(r.Context(), ch); err != nil {
+		return config.Channel{}, err
+	}
+	if err := s.ensureChannelPluginEnabled(r.Context(), ch.Type); err != nil {
+		return config.Channel{}, err
+	}
+	if err := s.pluginHost.ApplyChannel(r.Context(), ch); err != nil {
+		s.log.Error("failed to apply channel runtime", "channel_id", ch.ID, "channel_type", ch.Type, "error", err)
+	}
+	return s.store.GetChannel(r.Context(), ch.ID)
+}
+
+func tenantBrand(upstream feishuRegistrationUpstream) string {
+	if upstream.UserInfo == nil {
+		return ""
+	}
+	return upstream.UserInfo.TenantBrand
+}
+
+func pollFeishuRegistrationUpstream(r *http.Request, brand, deviceCode string) (feishuRegistrationUpstream, error) {
+	return postFeishuRegistration(r, brand, url.Values{"action": {"poll"}, "device_code": {deviceCode}})
+}
+
+type feishuRegistrationPendingError struct {
+	Status   string
+	Interval int
+}
+
+func (e feishuRegistrationPendingError) Error() string { return e.Status }
+
+type feishuRegistrationUpstreamError struct {
+	Message string
+}
+
+func (e feishuRegistrationUpstreamError) Error() string { return e.Message }
+
+func postFeishuRegistration(r *http.Request, brand string, form url.Values) (feishuRegistrationUpstream, error) {
+	endpoint := feishuRegistrationAccounts[brand] + feishuRegistrationPath
+	httpReq, err := http.NewRequestWithContext(r.Context(), http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return feishuRegistrationUpstream{}, err
+	}
+	httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := feishuRegistrationHTTPClient.Do(httpReq)
+	if err != nil {
+		return feishuRegistrationUpstream{}, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return feishuRegistrationUpstream{}, err
+	}
+	var data feishuRegistrationUpstream
+	if err := json.Unmarshal(body, &data); err != nil {
+		return feishuRegistrationUpstream{}, fmt.Errorf("decode Feishu registration response: %w", err)
+	}
+	if data.Error != "" {
+		switch data.Error {
+		case "authorization_pending":
+			return feishuRegistrationUpstream{}, feishuRegistrationPendingError{Status: "pending", Interval: defaultInt(data.Interval, 5)}
+		case "slow_down":
+			return feishuRegistrationUpstream{}, feishuRegistrationPendingError{Status: "slow_down", Interval: defaultInt(data.Interval, 10)}
+		}
+		message := data.ErrorDescription
+		if message == "" {
+			message = data.Error
+		}
+		return feishuRegistrationUpstream{}, feishuRegistrationUpstreamError{Message: message}
+	}
+	if resp.StatusCode >= 400 {
+		return feishuRegistrationUpstream{}, feishuRegistrationUpstreamError{Message: fmt.Sprintf("Feishu registration API returned HTTP %d", resp.StatusCode)}
+	}
+	return data, nil
+}
+
+func writeFeishuRegistrationError(w http.ResponseWriter, err error) {
+	var upstreamErr feishuRegistrationUpstreamError
+	if errors.As(err, &upstreamErr) {
+		writeError(w, http.StatusBadGateway, upstreamErr.Message)
+		return
+	}
+	writeError(w, http.StatusBadGateway, "upstream service error")
+}
+
+func decodeOptionalJSON(r *http.Request, dst any) error {
+	if r.Body == nil {
+		return nil
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+	if len(bytes.TrimSpace(body)) == 0 {
+		return nil
+	}
+	return json.Unmarshal(body, dst)
+}
+
+func registrationBrand(brand string) string {
+	if brand == "lark" {
+		return "lark"
+	}
+	return "feishu"
+}
+
+func appendQueryParam(rawURL, key, value string) string {
+	if rawURL == "" {
+		return ""
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	q := u.Query()
+	q.Set(key, value)
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+func defaultInt(value, fallback int) int {
+	if value > 0 {
+		return value
+	}
+	return fallback
+}

--- a/internal/server/feishu_registration_test.go
+++ b/internal/server/feishu_registration_test.go
@@ -1,0 +1,197 @@
+package server_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/CherryHQ/stella/internal/config"
+	"github.com/CherryHQ/stella/internal/server"
+)
+
+func TestBeginFeishuRegistrationProxiesDeviceFlow(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/oauth/v1/app/registration" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		assertForm(t, r.Form, "action", "begin")
+		assertForm(t, r.Form, "archetype", "PersonalAgent")
+		assertForm(t, r.Form, "auth_method", "client_secret")
+		assertForm(t, r.Form, "request_user_info", "open_id tenant_brand")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"device_code":               "device-1",
+			"user_code":                 "user-1",
+			"verification_uri":          "https://open.feishu.cn/page/cli",
+			"verification_uri_complete": "https://open.feishu.cn/page/cli?user_code=user-1",
+			"interval":                  2,
+			"expires_in":                300,
+		})
+	}))
+	defer upstream.Close()
+	defer server.SetFeishuRegistrationEndpointForTesting(upstream.URL)()
+
+	env := setupAdmin(t)
+	rr := doRequest(t, env, "POST", "/api/channels/feishu/register/begin", map[string]any{})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	var got struct {
+		DeviceCode string `json:"device_code"`
+		QrURL      string `json:"qr_url"`
+		Interval   int    `json:"interval"`
+	}
+	if err := json.Unmarshal(parseResponse(t, rr).Data, &got); err != nil {
+		t.Fatalf("unmarshal begin: %v", err)
+	}
+	if got.DeviceCode != "device-1" || got.Interval != 2 {
+		t.Fatalf("begin response = %#v", got)
+	}
+	qr, err := url.Parse(got.QrURL)
+	if err != nil {
+		t.Fatalf("parse qr_url: %v", err)
+	}
+	if qr.Query().Get("from") != "stella" || qr.Query().Get("user_code") != "user-1" {
+		t.Fatalf("qr_url query = %v", qr.Query())
+	}
+}
+
+func TestPollFeishuRegistrationCreatesChannel(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		assertForm(t, r.Form, "action", "poll")
+		assertForm(t, r.Form, "device_code", "device-1")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"client_id":     "cli_a",
+			"client_secret": "sec_b",
+			"user_info": map[string]any{
+				"open_id":      "ou_x",
+				"tenant_brand": "feishu",
+			},
+		})
+	}))
+	defer upstream.Close()
+	defer server.SetFeishuRegistrationEndpointForTesting(upstream.URL)()
+
+	env := setupAdmin(t)
+	agentID := findStellaID(t, env)
+	rr := doRequest(t, env, "POST", "/api/channels/feishu/register/poll", map[string]any{
+		"device_code": "device-1",
+		"channel_id":  "feishu-auto",
+		"agent_id":    agentID,
+		"name":        "Feishu Auto",
+		"config": map[string]any{
+			"group_mode":     "mention",
+			"auto_provision": true,
+		},
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	var got struct {
+		Status      string `json:"status"`
+		TenantBrand string `json:"tenant_brand"`
+		Channel     struct {
+			ID      string `json:"id"`
+			Type    string `json:"type"`
+			AgentID string `json:"agent_id"`
+			Config  string `json:"config"`
+		} `json:"channel"`
+	}
+	if err := json.Unmarshal(parseResponse(t, rr).Data, &got); err != nil {
+		t.Fatalf("unmarshal poll: %v", err)
+	}
+	if got.Status != "created" || got.TenantBrand != "feishu" || got.Channel.ID != "feishu-auto" || got.Channel.Type != "feishu" || got.Channel.AgentID != agentID {
+		t.Fatalf("poll response = %#v", got)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal([]byte(got.Channel.Config), &cfg); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+	if cfg["app_id"] != "cli_a" || cfg["app_secret"] != "sec_b" || cfg["group_mode"] != "mention" || cfg["auto_provision"] != true {
+		t.Fatalf("config = %#v", cfg)
+	}
+}
+
+func TestPollFeishuRegistrationRequiresAgent(t *testing.T) {
+	env := setupAdmin(t)
+	rr := doRequest(t, env, "POST", "/api/channels/feishu/register/poll", map[string]any{
+		"device_code": "device-1",
+		"channel_id":  "feishu-auto",
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusBadRequest, rr.Body.String())
+	}
+	if got := parseResponse(t, rr).Error; got != "agent_id is required; bind this Feishu channel to an agent" {
+		t.Fatalf("error = %q", got)
+	}
+}
+
+func TestPollFeishuRegistrationRejectsSamePlatformAgentBinding(t *testing.T) {
+	env := setupAdmin(t)
+	agentID := findStellaID(t, env)
+	if err := env.store.UpsertChannel(context.Background(), config.Channel{
+		ID:      "feishu-existing",
+		Name:    "Existing Feishu",
+		Type:    "feishu",
+		AgentID: agentID,
+		Enabled: true,
+		Config:  `{"app_id":"existing","app_secret":"secret"}`,
+	}); err != nil {
+		t.Fatalf("UpsertChannel: %v", err)
+	}
+
+	rr := doRequest(t, env, "POST", "/api/channels/feishu/register/poll", map[string]any{
+		"device_code": "device-1",
+		"channel_id":  "feishu-auto",
+		"agent_id":    agentID,
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusBadRequest, rr.Body.String())
+	}
+	if got := parseResponse(t, rr).Error; got != "agent is already bound to feishu channel feishu-existing" {
+		t.Fatalf("error = %q", got)
+	}
+}
+
+func TestPollFeishuRegistrationPendingDoesNotCreateChannel(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"error": "authorization_pending", "interval": 4})
+	}))
+	defer upstream.Close()
+	defer server.SetFeishuRegistrationEndpointForTesting(upstream.URL)()
+
+	env := setupAdmin(t)
+	rr := doRequest(t, env, "POST", "/api/channels/feishu/register/poll", map[string]any{
+		"device_code": "device-1",
+		"channel_id":  "feishu-auto",
+		"agent_id":    findStellaID(t, env),
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	var got struct {
+		Status   string `json:"status"`
+		Interval int    `json:"interval"`
+	}
+	if err := json.Unmarshal(parseResponse(t, rr).Data, &got); err != nil {
+		t.Fatalf("unmarshal pending: %v", err)
+	}
+	if got.Status != "pending" || got.Interval != 4 {
+		t.Fatalf("pending response = %#v", got)
+	}
+}
+
+func assertForm(t *testing.T, form url.Values, key, want string) {
+	t.Helper()
+	if got := form.Get(key); got != want {
+		t.Fatalf("form[%s] = %q, want %q", key, got, want)
+	}
+}

--- a/web/content/docs/channels/feishu.md
+++ b/web/content/docs/channels/feishu.md
@@ -10,9 +10,29 @@ Before you start, make sure you have:
 
 - A running Stella server (`stellad server`)
 - At least one AI provider configured in the Web UI (e.g. Anthropic, OpenAI)
-- A Feishu app created at [Feishu Open Platform](https://open.feishu.cn/) with the **Bot** capability enabled
+- The Feishu mobile app, signed in as a tenant user who can create internal apps
 
 ## Setup
+
+1. Start your Stella server if it is not already running:
+
+   ```bash
+   stellad server
+   ```
+
+2. Open the Web UI at `http://localhost:25678`.
+3. Go to **Channels** and add a new Feishu channel instance.
+4. Enter a channel ID and name.
+5. Select the agent this bot should represent.
+6. Click **Scan to create Feishu bot**.
+7. Scan the QR code with the Feishu mobile app and confirm the app creation request.
+8. Stella saves the returned App ID and App Secret on the channel and starts the bot.
+
+You can create multiple Feishu channel instances in the Web UI. Each instance gets its own Feishu PersonalAgent app and can optionally be bound to a dedicated agent.
+
+### Manual setup (advanced)
+
+If you already have a Feishu app, you can still enter credentials manually:
 
 1. Create a Feishu app at [Feishu Open Platform](https://open.feishu.cn/).
 2. Enable the **Bot** capability in your app settings.
@@ -20,18 +40,9 @@ Before you start, make sure you have:
    - `im.message.receive_v1`
    - `im.message.reaction.created_v1` (optional, for reaction events)
 4. Copy your App ID, App Secret, Encrypt Key, and Verification Token.
-5. Start your Stella server if it is not already running:
-
-   ```bash
-   stellad server
-   ```
-
-6. Open the Web UI at `http://localhost:25678`.
-7. Go to the **Channels** page and add a new Feishu channel instance.
-8. Enter your credentials and save.
-9. Restart `stellad server` to activate the new channel.
-
-You can create multiple Feishu channel instances in the Web UI. Each instance can use its own Feishu app credentials and can optionally be bound to a dedicated agent.
+5. Add a Feishu channel instance in the Web UI.
+6. Select the agent this bot should represent.
+7. Expand the manual fields, enter your credentials, and save.
 
 ## Lark Workspace Automation
 

--- a/web/content/docs/channels/feishu.zh.md
+++ b/web/content/docs/channels/feishu.zh.md
@@ -10,9 +10,29 @@ Stella 内置了通过 WebSocket 连接的飞书（Lark）机器人，因此不�
 
 - 一个正在运行的 Stella 服务器（`stellad server`）
 - 至少在Web UI中配置了一个 AI 提供商（如 Anthropic、OpenAI）
-- 在 [飞书开放平台](https://open.feishu.cn/) 创建的应用，并启用了 **Bot** 能力
+- 已登录飞书手机端，并且当前租户允许你创建内部应用
 
 ## 设置
+
+1. 如果尚未启动，先启动 Stella 服务器：
+
+   ```bash
+   stellad server
+   ```
+
+2. 打开 Web UI：`http://localhost:25678`。
+3. 进入 **Channels**，添加新的飞书频道实例。
+4. 填写频道 ID 和名称。
+5. 选择这个机器人代表的 Agent。
+6. 点击 **扫码创建飞书机器人**。
+7. 用飞书手机端扫码，并确认创建应用。
+8. Stella 会把返回的 App ID 和 App Secret 保存到频道，并启动机器人。
+
+你可以在 Web UI 中创建多个飞书频道实例。每个实例都会获得独立的飞书 PersonalAgent 应用，也可以选择绑定专用 agent。
+
+### 手动设置（高级）
+
+如果你已经有飞书应用，仍然可以手动填写凭据：
 
 1. 在 [飞书开放平台](https://open.feishu.cn/) 创建应用。
 2. 在应用设置中启用 **Bot** 能力。
@@ -20,18 +40,9 @@ Stella 内置了通过 WebSocket 连接的飞书（Lark）机器人，因此不�
    - `im.message.receive_v1`
    - `im.message.reaction.created_v1`（可选，用于表情事件）
 4. 复制你的 App ID、App Secret、Encrypt Key 和 Verification Token。
-5. 如果尚未启动，先启动 Stella 服务器：
-
-   ```bash
-   stellad server
-   ```
-
-6. 打开Web UI `http://localhost:25678`。
-7. 进入 **Channels** 页面，添加一个新的飞书频道实例。
-8. 输入你的凭据并保存。
-9. 重启 `stellad server` 以激活新频道。
-
-你可以在Web UI中创建多个飞书频道实例。每个实例可以使用不同的飞书应用凭据，并可选择绑定专用 agent。
+5. 在 Web UI 中添加飞书频道实例。
+6. 选择这个机器人代表的 Agent。
+7. 展开手动字段，输入凭据并保存。
 
 ## Lark 工作区自动化
 

--- a/web/src/features/channels/ChannelsPage.tsx
+++ b/web/src/features/channels/ChannelsPage.tsx
@@ -4,24 +4,37 @@ import { useQuery } from "@tanstack/react-query";
 import { meQueryOptions } from "@/lib/queries/me";
 import QRCode from "qrcode";
 import {
+  beginFeishuRegistration,
   createChannel as createChannelRequest,
   deleteChannel,
   generateLinkCode,
+  listAgents,
   listChannels,
   listProfileIdentities,
   listPublicChannels,
+  pollFeishuRegistration,
   pollWeixinQrStatus,
   startWeixinQr,
   unlinkProfileIdentity,
   updateChannel,
 } from "@/lib/api-client/sdk.gen";
 import type { ComponentsPublicChannel } from "@/lib/api-client/types.gen";
-import type { Channel, Identity } from "@/lib/types";
+import type { Agent, Channel, Identity } from "@/lib/types";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Switch } from "@/components/ui/switch";
 import { Spinner } from "@/components/ui/spinner";
+import {
+  Dialog,
+  DialogClose,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogPanel,
+  DialogPopup,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { useI18n } from "@/lib/i18n";
 import { useToast, ToastContainer } from "@/hooks/use-toast";
 import {
@@ -67,7 +80,10 @@ const platformMeta: Record<string, { label: string; defaults: PlatformDefaults; 
   weixin: { label: "Weixin", defaults: {} },
 };
 
-const channelTypes = Object.entries(platformMeta).map(([id, meta]) => ({ id, label: meta.label }));
+const channelTypes = Object.entries(platformMeta).map(([id, meta]) => ({
+  id,
+  label: meta.label,
+}));
 const defaultChannelType = channelTypes[0]?.id || "";
 
 const PLATFORM_ICON_PATHS: Record<string, string> = {
@@ -467,15 +483,47 @@ function ChannelDetail({
 
 interface NewChannelFormProps {
   fallbackChannelType: string;
+  agents: Agent[];
+  channels: NormalizedChannel[];
   onAdd: (channel: Record<string, unknown>) => Promise<void>;
+  onRegistered: (channel: NormalizedChannel) => Promise<void>;
   onCancel: () => void;
   creating: boolean;
 }
 
-function NewChannelForm({ fallbackChannelType, onAdd, onCancel, creating }: NewChannelFormProps) {
+function NewChannelForm({
+  fallbackChannelType,
+  agents,
+  channels,
+  onAdd,
+  onRegistered,
+  onCancel,
+  creating,
+}: NewChannelFormProps) {
   const { t } = useI18n();
   const [draft, setDraft] = useState<Record<string, unknown>>(
     newInstanceDraft(fallbackChannelType, ""),
+  );
+  const [scanOpen, setScanOpen] = useState(false);
+  const [scanQrUrl, setScanQrUrl] = useState("");
+  const [scanStatus, setScanStatus] = useState("");
+  const [scanError, setScanError] = useState("");
+  const [scanning, setScanning] = useState(false);
+  const scanIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const stopScanPolling = useCallback(() => {
+    if (scanIntervalRef.current) {
+      clearInterval(scanIntervalRef.current);
+      scanIntervalRef.current = null;
+    }
+    setScanning(false);
+  }, []);
+
+  useEffect(
+    () => () => {
+      if (scanIntervalRef.current) clearInterval(scanIntervalRef.current);
+    },
+    [],
   );
 
   const updateField = (key: string, value: unknown) => {
@@ -485,6 +533,99 @@ function NewChannelForm({ fallbackChannelType, onAdd, onCancel, creating }: NewC
       setDraft((prev) => ({ ...prev, [key]: value }));
     }
   };
+
+  const pollFeishuScan = useCallback(
+    async (deviceCode: string, intervalSeconds: number) => {
+      const channelId = ((draft.id as string) || "").trim();
+      const agentId = ((draft.agent_id as string) || "").trim();
+      if (!deviceCode || !channelId || !agentId) return;
+      try {
+        const { data: result } = await pollFeishuRegistration({
+          body: {
+            device_code: deviceCode,
+            channel_id: channelId,
+            agent_id: agentId,
+            name: (draft.name as string) || "Feishu",
+            enabled: true,
+            config: serializePlatformConfig("feishu", draft),
+          },
+          throwOnError: true,
+        });
+        setScanStatus(result.status);
+        if (result.status === "slow_down") {
+          stopScanPolling();
+          scanIntervalRef.current = setInterval(
+            () => void pollFeishuScan(deviceCode, result.interval || intervalSeconds + 5),
+            (result.interval || intervalSeconds + 5) * 1000,
+          );
+          setScanning(true);
+        }
+        if (result.status === "created" && result.channel) {
+          stopScanPolling();
+          setScanOpen(false);
+          await onRegistered(normalizeChannel(result.channel as Channel));
+        }
+      } catch (e) {
+        stopScanPolling();
+        setScanError((e as Error).message);
+      }
+    },
+    [draft, onRegistered, stopScanPolling],
+  );
+
+  const startFeishuScan = async () => {
+    const channelName = ((draft.name as string) || "").trim();
+    const channelId = ((draft.id as string) || "").trim();
+    if (!channelName) {
+      setScanError(t("channels.scanNeedsName"));
+      setScanOpen(true);
+      return;
+    }
+    if (!channelId) {
+      setScanError(t("channels.scanNeedsId"));
+      setScanOpen(true);
+      return;
+    }
+    if (!draft.agent_id) {
+      setScanError(t("channels.scanNeedsAgent"));
+      setScanOpen(true);
+      return;
+    }
+    setScanOpen(true);
+    setScanQrUrl("");
+    setScanStatus("waiting");
+    setScanError("");
+    stopScanPolling();
+    setScanning(true);
+    try {
+      const { data: result } = await beginFeishuRegistration({
+        body: {},
+        throwOnError: true,
+      });
+      setScanQrUrl(await QRCode.toDataURL(result.qr_url, { width: 256, margin: 2 }));
+      const intervalSeconds = result.interval || 5;
+      scanIntervalRef.current = setInterval(
+        () => void pollFeishuScan(result.device_code, intervalSeconds),
+        intervalSeconds * 1000,
+      );
+      setScanning(true);
+    } catch (e) {
+      setScanError((e as Error).message);
+      setScanning(false);
+    }
+  };
+
+  const availableAgents = agents.filter(
+    (agent) =>
+      agent.enabled !== false &&
+      !channels.some((channel) => channel.type === draft.type && channel.agent_id === agent.id),
+  );
+
+  const canStartFeishuScan = Boolean(
+    ((draft.name as string) || "").trim() &&
+    ((draft.id as string) || "").trim() &&
+    ((draft.agent_id as string) || "").trim(),
+  );
 
   const canSubmit = !creating && !!draft.id && !!draft.type;
 
@@ -523,39 +664,121 @@ function NewChannelForm({ fallbackChannelType, onAdd, onCancel, creating }: NewC
         </div>
 
         <div className="w-full space-y-1.5">
-          <label className="text-sm font-medium">Name</label>
+          <label className="text-sm font-medium">{t("common.name")}</label>
           <Input
             nativeInput
             type="text"
             value={(draft.name as string) || ""}
             onChange={(e) => updateField("name", e.target.value)}
-            placeholder="e.g. Feishu Coder"
+            placeholder={t("channels.namePlaceholder")}
             className="w-full text-sm"
           />
         </div>
 
         <div className="w-full space-y-1.5">
-          <label className="text-sm font-medium font-mono">Channel ID</label>
+          <label className="text-sm font-medium font-mono">{t("channels.channelId")}</label>
           <Input
             nativeInput
             type="text"
             value={(draft.id as string) || ""}
             onChange={(e) => updateField("id", e.target.value)}
-            placeholder="e.g. feishu-coder"
+            placeholder={t("channels.channelIdPlaceholder")}
             className="w-full text-sm font-mono"
           />
-          <p className="text-xs text-muted-foreground">
-            Must not match the platform ID (e.g. not &quot;telegram&quot; for a Telegram channel).
-          </p>
+          <p className="text-xs text-muted-foreground">{t("channels.channelIdDesc")}</p>
         </div>
+
+        {draft.type === "feishu" && (
+          <div className="w-full space-y-1.5">
+            <label className="text-sm font-medium">{t("channels.boundAgent")}</label>
+            <select
+              value={(draft.agent_id as string) || ""}
+              onChange={(e) => updateField("agent_id", e.target.value)}
+              className={selectClassName}
+            >
+              <option value="">{t("channels.selectAgent")}</option>
+              {availableAgents.map((agent) => (
+                <option key={agent.id} value={agent.id}>
+                  {agent.name || agent.id}
+                </option>
+              ))}
+            </select>
+            <p className="text-xs text-muted-foreground">{t("channels.boundAgentDesc")}</p>
+            {availableAgents.length === 0 && (
+              <p className="text-xs text-muted-foreground">{t("channels.noAvailableAgents")}</p>
+            )}
+          </div>
+        )}
 
         {!!draft.type && (
           <div className="space-y-4">
-            <FormSectionTitle>Configuration</FormSectionTitle>
-            <InstanceFields ch={draft} onChange={updateField} />
+            <FormSectionTitle>{t("channels.configuration")}</FormSectionTitle>
+            {draft.type === "feishu" && (
+              <div className="space-y-2">
+                <Button
+                  type="button"
+                  onClick={startFeishuScan}
+                  loading={scanning}
+                  disabled={scanning || !canStartFeishuScan}
+                  size="sm"
+                >
+                  {t("channels.scanCreateFeishu")}
+                </Button>
+                <p className="text-xs text-muted-foreground">
+                  {t("channels.scanCreateFeishuDesc")}
+                </p>
+              </div>
+            )}
+            {draft.type === "feishu" ? (
+              <details className="space-y-4">
+                <summary className="cursor-pointer text-sm font-medium">
+                  {t("channels.manualFeishuSetup")}
+                </summary>
+                <div className="pt-4">
+                  <InstanceFields ch={draft} onChange={updateField} />
+                </div>
+              </details>
+            ) : (
+              <InstanceFields ch={draft} onChange={updateField} />
+            )}
           </div>
         )}
       </div>
+
+      <Dialog open={scanOpen} onOpenChange={setScanOpen}>
+        <DialogPopup>
+          <DialogHeader>
+            <DialogTitle>{t("channels.scanFeishuTitle")}</DialogTitle>
+            <DialogDescription>{t("channels.scanFeishuDesc")}</DialogDescription>
+          </DialogHeader>
+          <DialogPanel>
+            <div className="flex flex-col items-center gap-4 text-center">
+              {scanQrUrl && (
+                <img
+                  src={scanQrUrl}
+                  alt={t("channels.scanFeishuQrAlt")}
+                  className="size-48 max-w-full"
+                />
+              )}
+              {!scanQrUrl && !scanError && <Spinner className="size-4" />}
+              <Badge
+                size="sm"
+                variant={scanError ? "error" : scanStatus === "created" ? "success" : "warning"}
+                className="max-w-full whitespace-normal"
+              >
+                {scanError || scanStatus || t("channels.waiting")}
+              </Badge>
+            </div>
+          </DialogPanel>
+          <DialogFooter>
+            <DialogClose
+              render={<Button type="button" variant="ghost" onClick={stopScanPolling} />}
+            >
+              {t("common.cancel")}
+            </DialogClose>
+          </DialogFooter>
+        </DialogPopup>
+      </Dialog>
     </DetailPanel>
   );
 }
@@ -703,6 +926,7 @@ export function ChannelsPage() {
   const [publicChannels, setPublicChannels] = useState<ComponentsPublicChannel[]>([]);
   const [linkedIdentities, setLinkedIdentities] = useState<Identity[]>([]);
   const [instances, setInstances] = useState<NormalizedChannel[]>([]);
+  const [agents, setAgents] = useState<Agent[]>([]);
   const [loadingInstances, setLoadingInstances] = useState(false);
 
   const [linkCode, setLinkCode] = useState("");
@@ -766,6 +990,18 @@ export function ChannelsPage() {
     }
   }, [showToast]);
 
+  const loadAgents = useCallback(async () => {
+    try {
+      const { data } = await listAgents({
+        query: { include_all: true },
+        throwOnError: true,
+      });
+      setAgents((data?.agents as Agent[]) ?? []);
+    } catch (e) {
+      showToast((e as Error).message, "error");
+    }
+  }, [showToast]);
+
   const loadInstances = useCallback(async () => {
     setLoadingInstances(true);
     try {
@@ -790,14 +1026,14 @@ export function ChannelsPage() {
 
   useEffect(() => {
     if (isAdmin) {
-      void Promise.all([loadPublicChannels(), loadIdentities(), loadInstances()]);
+      void Promise.all([loadPublicChannels(), loadIdentities(), loadInstances(), loadAgents()]);
     } else {
       void Promise.all([loadPublicChannels(), loadIdentities()]);
     }
     return () => {
       if (wxQrIntervalRef.current) clearInterval(wxQrIntervalRef.current);
     };
-  }, [isAdmin, loadPublicChannels, loadIdentities, loadInstances]);
+  }, [isAdmin, loadPublicChannels, loadIdentities, loadInstances, loadAgents]);
 
   // ── link code ──
 
@@ -873,7 +1109,10 @@ export function ChannelsPage() {
       wxQrCodeRef.current = qrCode;
       const imgContent = result.qrcode_img_content || "";
       if (imgContent) {
-        const dataUrl = await QRCode.toDataURL(imgContent, { width: 256, margin: 2 });
+        const dataUrl = await QRCode.toDataURL(imgContent, {
+          width: 256,
+          margin: 2,
+        });
         setWxQrUrl(dataUrl);
       }
       setWxQrStatus("waiting");
@@ -889,7 +1128,10 @@ export function ChannelsPage() {
   const unlinkIdentity = async (id: string | undefined) => {
     if (!id || !confirm("Unlink this identity?")) return;
     try {
-      await unlinkProfileIdentity({ path: { id: String(id) }, throwOnError: true });
+      await unlinkProfileIdentity({
+        path: { id: String(id) },
+        throwOnError: true,
+      });
       showToast("Identity unlinked");
       await loadIdentities();
     } catch (e) {
@@ -940,6 +1182,15 @@ export function ChannelsPage() {
     }
   };
 
+  const finishRegisteredChannel = async (channel: NormalizedChannel) => {
+    await loadInstances();
+    void navigate({
+      to: "/settings/channels/$channelId",
+      params: { channelId: channel.id },
+    });
+    showToast(channel.id + " created");
+  };
+
   const createNewChannel = async (draft: Record<string, unknown>) => {
     const id = ((draft.id as string) || "").trim();
     if (!id || !draft.type) {
@@ -950,6 +1201,10 @@ export function ChannelsPage() {
       showToast("Dedicated instance ID must not match the platform ID", "error");
       return;
     }
+    if (draft.type === "feishu" && !draft.agent_id) {
+      showToast(t("channels.scanNeedsAgent"), "error");
+      return;
+    }
     setCreatingInstance(true);
     try {
       const { data: saved } = await createChannelRequest({
@@ -957,7 +1212,7 @@ export function ChannelsPage() {
           id,
           name: (draft.name as string) || "",
           type: draft.type as string,
-          agent_id: "",
+          agent_id: (draft.agent_id as string) || "",
           config: channelConfig(draft),
         },
         throwOnError: true,
@@ -998,7 +1253,10 @@ export function ChannelsPage() {
       detail = (
         <NewChannelForm
           fallbackChannelType={defaultChannelType}
+          agents={agents}
+          channels={instances}
           onAdd={createNewChannel}
+          onRegistered={finishRegisteredChannel}
           onCancel={() => void navigate({ to: "/settings/channels" })}
           creating={creatingInstance}
         />

--- a/web/src/lib/i18n/messages.ts
+++ b/web/src/lib/i18n/messages.ts
@@ -1306,6 +1306,29 @@ const en = {
   "channels.selectPlatform": "Select platform...",
   "channels.addChannel": "Add Channel",
   "channels.adding": "Adding...",
+  "channels.namePlaceholder": "e.g. Feishu Coder",
+  "channels.channelId": "Channel ID",
+  "channels.channelIdPlaceholder": "e.g. feishu-coder",
+  "channels.channelIdDesc":
+    'Must not match the platform ID (e.g. not "telegram" for a Telegram channel).',
+  "channels.configuration": "Configuration",
+  "channels.boundAgent": "Bound agent",
+  "channels.boundAgentDesc":
+    "Messages received by this bot are routed to this agent. Each agent can only have one channel per platform.",
+  "channels.noAvailableAgents": "No enabled agents are available for this platform.",
+  "channels.selectAgent": "Select agent...",
+  "channels.manualFeishuSetup": "I already have a Feishu app",
+  "channels.scanCreateFeishu": "Scan to create Feishu bot",
+  "channels.scanCreateFeishuDesc":
+    "Stella creates a PersonalAgent app in your Feishu tenant and stores the returned credentials on this channel.",
+  "channels.scanFeishuTitle": "Create Feishu bot",
+  "channels.scanFeishuDesc":
+    "Scan with the Feishu mobile app, then confirm the app creation request.",
+  "channels.scanFeishuQrAlt": "Feishu bot registration QR code",
+  "channels.scanNeedsName": "Enter a name before starting QR setup.",
+  "channels.scanNeedsId": "Enter a channel ID before starting QR setup.",
+  "channels.scanNeedsAgent": "Bind this Feishu channel to an agent before starting QR setup.",
+  "channels.waiting": "Waiting",
 
   // Automations schedule detail
   "automations.scheduleField": "Schedule",
@@ -2649,6 +2672,27 @@ const zh: Record<MessageKey, string> = {
   "channels.selectPlatform": "选择平台...",
   "channels.addChannel": "添加频道",
   "channels.adding": "添加中...",
+  "channels.namePlaceholder": "例如：飞书编码助手",
+  "channels.channelId": "频道 ID",
+  "channels.channelIdPlaceholder": "例如：feishu-coder",
+  "channels.channelIdDesc": '不能和平台 ID 相同（例如 Telegram 频道不能填写 "telegram"）。',
+  "channels.configuration": "配置",
+  "channels.boundAgent": "绑定 Agent",
+  "channels.boundAgentDesc":
+    "这个机器人收到的消息会路由到该 Agent。每个 Agent 在同一平台只能绑定一个频道。",
+  "channels.noAvailableAgents": "这个平台没有可用的已启用 Agent。",
+  "channels.selectAgent": "选择 Agent...",
+  "channels.manualFeishuSetup": "我已有飞书应用",
+  "channels.scanCreateFeishu": "扫码创建飞书机器人",
+  "channels.scanCreateFeishuDesc":
+    "Stella 会在你的飞书租户中创建 PersonalAgent 应用，并把返回的凭据保存到这个频道。",
+  "channels.scanFeishuTitle": "创建飞书机器人",
+  "channels.scanFeishuDesc": "用飞书手机端扫码，然后确认创建应用。",
+  "channels.scanFeishuQrAlt": "飞书机器人注册二维码",
+  "channels.scanNeedsName": "先填写名称，再开始扫码配置。",
+  "channels.scanNeedsId": "先填写频道 ID，再开始扫码配置。",
+  "channels.scanNeedsAgent": "先把这个飞书频道绑定到 Agent，再开始扫码配置。",
+  "channels.waiting": "等待中",
 
   // Automations schedule detail
   "automations.scheduleField": "计划",


### PR DESCRIPTION
## What

Add scan-QR Feishu bot creation for channel setup.

- Add `POST /api/channels/feishu/register/{init,begin,poll}`.
- Proxy Feishu PersonalAgent registration and append `from=stella` to the QR URL.
- Create/update the Feishu channel with returned `app_id` / `app_secret` on successful poll.
- Add the Web UI scan dialog for new Feishu channel instances.
- Keep manual `app_id` / `app_secret` setup as the fallback.
- Update English and Chinese Feishu channel docs.


## Why

Manual Feishu setup is too much yak shaving: users had to create an app, enable bot capability, configure events/scopes, and copy credentials by hand. The QR flow matches Feishu's official tooling pattern and removes the worst onboarding step while keeping manual setup available if the upstream registration endpoint changes.

## How

- OpenAPI-first: added channel registration schemas/paths and regenerated API artifacts.
- Backend: added a thin registration proxy with pending/slow_down handling, Lark tenant fallback, channel config validation, plugin enablement, and runtime apply.
- Frontend: uses the generated SDK, renders a Coss dialog with a generated QR image, polls at Feishu's requested interval, then navigates to the created channel.
- Tests: added server tests for begin, successful poll/channel creation, and pending poll.

Verification:

```bash
mise run format && mise run build && mise run test
```

## Refs

- Closes #449
