### PR TITLE
🐛 fix(server): invalidate runner cache when vault entries change

### DIFF
--- a/internal/server/vault.go
+++ b/internal/server/vault.go
@@ -130,6 +130,14 @@ func (s *Server) SetVaultEntry(w http.ResponseWriter, r *http.Request, name stri
 		return
 	}
 
+	// Vault entries are baked into the sandbox env at session-creation time and
+	// cannot be injected into a running process; closing live runners forces a
+	// clean restart so the next chat turn or scheduled run reads the new value.
+	// Mirrors the OAuth token write path (see credentials.Service).
+	if err := s.credSvc.InvalidateUser(info.UserID); err != nil {
+		s.log.Warn("invalidate user runners after vault set", "user_id", info.UserID, "name", name, "error", err)
+	}
+
 	meta, err := s.vaultSvc.GetMeta(r.Context(), info.UserID, name)
 	if err != nil {
 		s.log.Error("get vault entry meta", "user_id", info.UserID, "name", name, "error", err)
@@ -161,6 +169,12 @@ func (s *Server) DeleteVaultEntry(w http.ResponseWriter, r *http.Request, name s
 		s.log.Error("delete vault entry", "user_id", info.UserID, "name", name, "error", err)
 		writeError(w, http.StatusInternalServerError, "internal error")
 		return
+	}
+
+	// See SetVaultEntry: invalidate live runners so the next session sees the
+	// updated vault snapshot instead of the cached one from sandbox start.
+	if err := s.credSvc.InvalidateUser(info.UserID); err != nil {
+		s.log.Warn("invalidate user runners after vault delete", "user_id", info.UserID, "name", name, "error", err)
 	}
 
 	w.WriteHeader(http.StatusNoContent)

--- a/internal/server/vault_test.go
+++ b/internal/server/vault_test.go
@@ -284,6 +284,61 @@ func TestScopedVaultPermissionsAndRuntimeResolution(t *testing.T) {
 	}
 }
 
+// fakeRunnerInvalidator records InvalidateUser calls so tests can assert that
+// vault mutations propagate to the runner cache.
+type fakeRunnerInvalidator struct {
+	calls []string
+}
+
+func (f *fakeRunnerInvalidator) InvalidateUser(userID string) error {
+	f.calls = append(f.calls, userID)
+	return nil
+}
+
+// TestVaultMutationsInvalidateUserRunners verifies that PUT and DELETE on a
+// vault entry both close the user's live runners, so the next session reads
+// the new secret instead of the snapshot baked into the previous sandbox env.
+// Regression guard for stale secrets in scheduled jobs after key rotation.
+func TestVaultMutationsInvalidateUserRunners(t *testing.T) {
+	env, _ := setupVaultEnv(t)
+
+	inv := &fakeRunnerInvalidator{}
+	env.srv.CredentialsService().SetInvalidator(inv)
+
+	// PUT triggers invalidate.
+	rr := doRequest(t, env, "PUT", "/api/users/me/vault/MY_TOKEN", map[string]string{"value": "v1"})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("set status = %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	if len(inv.calls) != 1 {
+		t.Fatalf("after PUT: expected 1 invalidate call, got %d", len(inv.calls))
+	}
+	if inv.calls[0] != env.adminUser.ID {
+		t.Errorf("after PUT: invalidated user = %q, want %q", inv.calls[0], env.adminUser.ID)
+	}
+
+	// PUT overwriting also triggers invalidate (covers rotate-in-place).
+	rr = doRequest(t, env, "PUT", "/api/users/me/vault/MY_TOKEN", map[string]string{"value": "v2"})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("update status = %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	if len(inv.calls) != 2 {
+		t.Fatalf("after overwrite PUT: expected 2 invalidate calls, got %d", len(inv.calls))
+	}
+
+	// DELETE also triggers invalidate.
+	rr = doRequest(t, env, "DELETE", "/api/users/me/vault/MY_TOKEN", nil)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("delete status = %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	if len(inv.calls) != 3 {
+		t.Fatalf("after DELETE: expected 3 invalidate calls, got %d", len(inv.calls))
+	}
+	if inv.calls[2] != env.adminUser.ID {
+		t.Errorf("after DELETE: invalidated user = %q, want %q", inv.calls[2], env.adminUser.ID)
+	}
+}
+
 func TestVaultUpdateExisting(t *testing.T) {
 	env, _ := setupVaultEnv(t)
 


### PR DESCRIPTION
## What

`PUT` / `DELETE` on `/api/users/me/vault/{name}` now call `credSvc.InvalidateUser(userID)` after the DB write succeeds, mirroring the existing OAuth token write path. Live runners owned by that user get closed, so the next chat turn or scheduled-job tick rebuilds the sandbox with the fresh vault snapshot instead of the cached one.

## Why

Vault values are decrypted into the sandbox env at session-creation time (`buildSandboxEnv` → `LoadEnv`) and pinned for the lifetime of the runner. The OAuth path already invalidates on token writes; plain vault entries used the same env-injection path but lacked the matching invalidate, so rotating a key (e.g. `DEEPSEEK_API_KEY` for a scheduled balance check) didn't take effect until idle reap or `stellad` restart. Concrete bug report: scheduled DeepSeek balance check kept returning 401 after the user rotated the key via the Web UI.

## How

- `SetVaultEntry`: after `vaultSvc.Set` succeeds, call `s.credSvc.InvalidateUser`. Error is logged at warn level and swallowed — the DB row is already updated and the idle reaper provides eventual consistency, so failing the HTTP response on a best-effort cache poke would be a regression in its own right.
- `DeleteVaultEntry`: same pattern after `vaultSvc.Delete`.
- `InvalidateUser` is already nil-safe when no `RunnerInvalidator` is wired, so test environments and bare-bones deployments don't need new wiring.
- New `TestVaultMutationsInvalidateUserRunners`: injects a fake invalidator via `srv.CredentialsService().SetInvalidator(...)` and asserts call counts after PUT, overwriting PUT, and DELETE.

Out of scope (suggested follow-up, also noted in #465): Web UI's `CredentialsPage.tsx` only exposes "Add Secret" — adding an inline ✏️ Edit row action would remove the delete-then-recreate dance that motivated this report.

## Refs

- Closes #465
- Pattern source: `internal/credentials/service.go:592` (OAuth token write)
- Cache mechanics: `internal/agent/sandbox/env.go:104`, `internal/agent/runtime/runner_cache.go:72`

## Test plan

- [x] `go test ./internal/server/ ./internal/vault/ ./internal/credentials/` passes locally
- [x] `TestVaultMutationsInvalidateUserRunners` passes individually
- [x] `golangci-lint run --fix ./...` clean
- [ ] Manual: rotate a vault entry via Web UI, confirm the next scheduled-job run uses the new value without toggling the job

🤖 Generated with [Claude Code](https://claude.com/claude-code)