### PR TITLE
🐛 fix(web): align user chat message typography with agent output

### DIFF
--- a/web/src/components/chat/UserMessage.tsx
+++ b/web/src/components/chat/UserMessage.tsx
@@ -52,7 +52,7 @@ export function UserMessage({
       )}
       <div className="pl-7 w-full min-w-0 flex flex-col items-start gap-3">
         {text && (
-          <div className="min-w-0 break-words text-lg font-medium leading-normal tracking-tight whitespace-pre-wrap text-foreground/90 sm:text-xl">
+          <div className="min-w-0 break-words text-[15px] leading-relaxed whitespace-pre-wrap text-foreground/90 font-sans">
             {renderMentionedText(text, agentNames)}
           </div>
         )}


### PR DESCRIPTION
## What
Align user-authored chat message typography with agent output so the conversation reads consistently.

## Why
User messages rendered at `text-lg`/`sm:text-xl` with `font-medium`, making them noticeably larger and bolder than agent responses (`text-[15px]`, normal weight). The mismatch left the chat UI unbalanced and harder to read.

## How
- `web/src/components/chat/UserMessage.tsx`: change the user message text classes from `text-lg font-medium leading-normal tracking-tight ... sm:text-xl` to match the agent `BlockRenderer`: `text-[15px] leading-relaxed text-foreground/90 font-sans`.
- Keeps the shared `text-foreground/90` theme token, so light/dark are unaffected; no CossUI/theme overrides introduced.

## Refs
Closes #454