### PR TITLE
🔥 refactor(vault): remove legacy /api/users/me/vault routes

### DIFF
--- a/api/spec/domain/profile/paths.yaml
+++ b/api/spec/domain/profile/paths.yaml
@@ -298,78 +298,6 @@ paths:
         }
 
   # ── Vault ───────────────────────────────────────────────────────────────────
-  /api/users/me/vault:
-    get:
-      tags: [profile]
-      summary: List vault entries for the current user
-      operationId: listVaultEntries
-      responses:
-        "200":
-          description: ok
-          content:
-            application/json:
-              schema: {
-                $ref: "../../components.yaml#/components/schemas/VaultEntryList",
-              }
-        "401": {
-          $ref: "../../components.yaml#/components/responses/Unauthorized",
-        }
-
-  /api/users/me/vault/{name}:
-    parameters:
-      - { name: name, in: path, required: true, schema: { type: string } }
-    get:
-      tags: [profile]
-      summary: Get a vault entry value
-      operationId: getVaultEntry
-      responses:
-        "200":
-          description: ok
-          content:
-            application/json:
-              schema: {
-                $ref: "../../components.yaml#/components/schemas/VaultEntryValue",
-              }
-        "401": {
-          $ref: "../../components.yaml#/components/responses/Unauthorized",
-        }
-        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
-    put:
-      tags: [profile]
-      summary: Create or update a vault entry
-      operationId: setVaultEntry
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema: {
-              $ref: "../../components.yaml#/components/schemas/SetVaultEntryRequest",
-            }
-      responses:
-        "200":
-          description: saved
-          content:
-            application/json:
-              schema: {
-                $ref: "../../components.yaml#/components/schemas/VaultEntry",
-              }
-        "400": {
-          $ref: "../../components.yaml#/components/responses/BadRequest",
-        }
-        "401": {
-          $ref: "../../components.yaml#/components/responses/Unauthorized",
-        }
-    delete:
-      tags: [profile]
-      summary: Delete a vault entry
-      operationId: deleteVaultEntry
-      responses:
-        "204":
-          description: no content
-        "401": {
-          $ref: "../../components.yaml#/components/responses/Unauthorized",
-        }
-
   /api/vault:
     get:
       tags: [profile]
@@ -410,6 +338,42 @@ paths:
   /api/vault/{name}:
     parameters:
       - { name: name, in: path, required: true, schema: { type: string } }
+    get:
+      tags: [profile]
+      summary: Get a scoped vault entry value
+      operationId: getScopedVaultEntry
+      parameters:
+        - {
+            name: scope,
+            in: query,
+            required: false,
+            schema: {
+              type: string,
+              enum: [user, user_agent, system, system_agent],
+              default: user,
+            },
+          }
+        - {
+            name: agent_id,
+            in: query,
+            required: false,
+            schema: { type: string },
+          }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: {
+                $ref: "../../components.yaml#/components/schemas/VaultEntryValue",
+              }
+        "401": {
+          $ref: "../../components.yaml#/components/responses/Unauthorized",
+        }
+        "403": {
+          $ref: "../../components.yaml#/components/responses/Forbidden",
+        }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
     put:
       tags: [profile]
       summary: Create or update a scoped vault entry

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -248,10 +248,6 @@ paths:
     $ref: "./domain/profile/paths.yaml#/paths/~1api~1users~1me~1memories~1{agentId}~1constraints~1{constraintId}"
   /api/users/me/memories/{agentId}/changelog:
     $ref: "./domain/profile/paths.yaml#/paths/~1api~1users~1me~1memories~1{agentId}~1changelog"
-  /api/users/me/vault:
-    $ref: "./domain/profile/paths.yaml#/paths/~1api~1users~1me~1vault"
-  /api/users/me/vault/{name}:
-    $ref: "./domain/profile/paths.yaml#/paths/~1api~1users~1me~1vault~1{name}"
   /api/vault:
     $ref: "./domain/profile/paths.yaml#/paths/~1api~1vault"
   /api/vault/{name}:

--- a/cmd/stella/email.go
+++ b/cmd/stella/email.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/term"
 
 	apiclient "github.com/CherryHQ/stella/api/client"
+	apitypes "github.com/CherryHQ/stella/api/types"
 	"github.com/CherryHQ/stella/internal/cli"
 	"github.com/CherryHQ/stella/internal/email"
 )
@@ -44,7 +45,8 @@ read messages, and send mail directly from the terminal.`,
 }
 
 func loadVaultEmailConfig(ctx context.Context, api *apiclient.Client) (*email.Config, error) {
-	resp, err := api.GetVaultEntry(ctx, emailConfigKey)
+	scope := apiclient.GetScopedVaultEntryParamsScopeUser
+	resp, err := api.GetScopedVaultEntry(ctx, emailConfigKey, &apiclient.GetScopedVaultEntryParams{Scope: &scope})
 	if err != nil {
 		return nil, apiclient.WrapServerErr(err)
 	}
@@ -82,8 +84,10 @@ func saveVaultEmailConfig(ctx context.Context, api *apiclient.Client, cfg *email
 	if err != nil {
 		return fmt.Errorf("marshal email config: %w", err)
 	}
-	resp, err := api.SetVaultEntry(ctx, emailConfigKey, apiclient.SetVaultEntryJSONRequestBody{
+	scope := apitypes.SetVaultEntryRequestScopeUser
+	resp, err := api.SetScopedVaultEntry(ctx, emailConfigKey, apiclient.SetScopedVaultEntryJSONRequestBody{
 		Value: string(data),
+		Scope: &scope,
 	})
 	if err != nil {
 		return apiclient.WrapServerErr(err)

--- a/cmd/stella/vault.go
+++ b/cmd/stella/vault.go
@@ -55,8 +55,9 @@ func vaultListCommand() *ucli.Command {
 			cli.JSONFlag(),
 		},
 		Action: func(c *ucli.Context) error {
+			scope := apiclient.ListScopedVaultEntriesParamsScopeUser
 			list, err := apiclient.Call[apitypes.VaultEntryList](func(api *apiclient.Client) (*http.Response, error) {
-				return api.ListVaultEntries(c.Context)
+				return api.ListScopedVaultEntries(c.Context, &apiclient.ListScopedVaultEntriesParams{Scope: &scope})
 			})
 			if err != nil {
 				return err
@@ -93,8 +94,9 @@ func vaultGetCommand() *ucli.Command {
 			if name == "" {
 				return fmt.Errorf("usage: stella vault get <name>")
 			}
+			scope := apiclient.GetScopedVaultEntryParamsScopeUser
 			entry, err := apiclient.Call[apiclient.VaultEntryValue](func(api *apiclient.Client) (*http.Response, error) {
-				return api.GetVaultEntry(c.Context, name)
+				return api.GetScopedVaultEntry(c.Context, name, &apiclient.GetScopedVaultEntryParams{Scope: &scope})
 			})
 			if err != nil {
 				return err
@@ -135,8 +137,9 @@ func vaultSetCommand() *ucli.Command {
 			case "":
 				return fmt.Errorf("usage: stella vault set <name> <value>  (use '-' to read from stdin)")
 			}
+			scope := apitypes.SetVaultEntryRequestScopeUser
 			if err := apiclient.Do(func(api *apiclient.Client) (*http.Response, error) {
-				return api.SetVaultEntry(c.Context, name, apiclient.SetVaultEntryJSONRequestBody{Value: value})
+				return api.SetScopedVaultEntry(c.Context, name, apiclient.SetScopedVaultEntryJSONRequestBody{Value: value, Scope: &scope})
 			}); err != nil {
 				return err
 			}
@@ -163,8 +166,9 @@ func vaultDeleteCommand() *ucli.Command {
 			if name == "" {
 				return fmt.Errorf("usage: stella vault delete <name>")
 			}
+			scope := apiclient.DeleteScopedVaultEntryParamsScopeUser
 			if err := apiclient.Do(func(api *apiclient.Client) (*http.Response, error) {
-				return api.DeleteVaultEntry(c.Context, name)
+				return api.DeleteScopedVaultEntry(c.Context, name, &apiclient.DeleteScopedVaultEntryParams{Scope: &scope})
 			}); err != nil {
 				return err
 			}

--- a/internal/agent/pool_manager.go
+++ b/internal/agent/pool_manager.go
@@ -609,6 +609,38 @@ func (pm *PoolManager) InvalidateUser(userID string) error {
 	return lastErr
 }
 
+// InvalidateAgent closes all live runners for one agent across every user.
+func (pm *PoolManager) InvalidateAgent(agentID string) error {
+	pm.mu.RLock()
+	svc, ok := pm.services[agentID]
+	pm.mu.RUnlock()
+	if !ok {
+		return nil
+	}
+	if err := svc.Runtime.ResetRunners(); err != nil {
+		pm.log.Error("reset runners for agent", "agent_id", agentID, "error", err)
+		return err
+	}
+	return nil
+}
+
+// InvalidateAll closes every live runner across all services.
+func (pm *PoolManager) InvalidateAll() error {
+	pm.mu.RLock()
+	services := make(map[string]*Service, len(pm.services))
+	maps.Copy(services, pm.services)
+	pm.mu.RUnlock()
+
+	var lastErr error
+	for id, svc := range services {
+		if err := svc.Runtime.ResetRunners(); err != nil {
+			pm.log.Error("reset runners for service", "agent_id", id, "error", err)
+			lastErr = err
+		}
+	}
+	return lastErr
+}
+
 // Close shuts down all services and hook plugins.
 func (pm *PoolManager) Close() error {
 	pm.mu.Lock()

--- a/internal/credentials/credentials_test.go
+++ b/internal/credentials/credentials_test.go
@@ -162,6 +162,10 @@ func (s *stubInvalidator) InvalidateUser(userID string) error {
 	return nil
 }
 
+func (s *stubInvalidator) InvalidateAgent(agentID string) error { return nil }
+
+func (s *stubInvalidator) InvalidateAll() error { return nil }
+
 func TestInvalidateUserCallsInvalidator(t *testing.T) {
 	svc := newService(t)
 	inv := &stubInvalidator{}

--- a/internal/credentials/service.go
+++ b/internal/credentials/service.go
@@ -75,6 +75,22 @@ func (s *Service) InvalidateUser(userID string) error {
 	return s.invalidator.InvalidateUser(userID)
 }
 
+// InvalidateAgent closes all live runners for one agent across every user.
+func (s *Service) InvalidateAgent(agentID string) error {
+	if s.invalidator == nil {
+		return nil
+	}
+	return s.invalidator.InvalidateAgent(agentID)
+}
+
+// InvalidateAll closes every live runner across all agents and users.
+func (s *Service) InvalidateAll() error {
+	if s.invalidator == nil {
+		return nil
+	}
+	return s.invalidator.InvalidateAll()
+}
+
 // getBroker constructs a flow broker for providerID on demand from the registry
 // config and current plugin credentials. The flowType selects which flow entry to
 // use when a provider declares multiple flows.

--- a/internal/credentials/types.go
+++ b/internal/credentials/types.go
@@ -49,7 +49,11 @@ type AddSecretInstruction struct {
 	Command string // exact /config KEY VALUE command to run
 }
 
-// RunnerInvalidator invalidates live runners for a user across all pools.
+// RunnerInvalidator closes live runners so the next session reloads vault/OAuth
+// snapshots. Scope determines reach: a single user, one agent across all users,
+// or every runner.
 type RunnerInvalidator interface {
 	InvalidateUser(userID string) error
+	InvalidateAgent(agentID string) error
+	InvalidateAll() error
 }

--- a/internal/server/scoped_auth.go
+++ b/internal/server/scoped_auth.go
@@ -65,6 +65,8 @@ func topLevelPathScope(method string, rest []string) string {
 		return readWriteScope("shares", method)
 	case "recally":
 		return readWriteScope("recally", method)
+	case "vault":
+		return readWriteScope("vault", method)
 	case "users":
 		return usersMePathScope(method, rest[1:])
 	default:
@@ -79,8 +81,6 @@ func usersMePathScope(method string, rest []string) string {
 	switch rest[1] {
 	case "oauth":
 		return readWriteScope("oauth", method)
-	case "vault":
-		return readWriteScope("vault", method)
 	default:
 		return ""
 	}

--- a/internal/server/scoped_auth_test.go
+++ b/internal/server/scoped_auth_test.go
@@ -18,8 +18,8 @@ func TestScopedTokenAllowsOnlyMatchingAgentPath(t *testing.T) {
 	if !scopedTokenAllowsRequest(claims, httptest.NewRequest("GET", "/api/status", nil)) {
 		t.Fatal("status should be allowed")
 	}
-	if !scopedTokenAllowsRequest(claims, httptest.NewRequest("GET", "/api/users/me/vault/EMAIL_CONFIG", nil)) {
-		t.Fatal("vault read should be allowed by the default sandbox scopes")
+	if !scopedTokenAllowsRequest(claims, httptest.NewRequest("GET", "/api/vault/EMAIL_CONFIG", nil)) {
+		t.Fatal("scoped vault read should be allowed by the default sandbox scopes")
 	}
 	if !scopedTokenAllowsRequest(claims, httptest.NewRequest("POST", "/api/users/me/oauth/github/start", nil)) {
 		t.Fatal("oauth connect should be allowed by the default sandbox scopes")
@@ -34,8 +34,8 @@ func TestScopedTokenRequiresMappedScope(t *testing.T) {
 	if scopedTokenAllowsRequest(claims, httptest.NewRequest("POST", "/api/tasks", nil)) {
 		t.Fatal("tasks write should be denied without tasks:write")
 	}
-	if scopedTokenAllowsRequest(claims, httptest.NewRequest("GET", "/api/users/me/vault/EMAIL_CONFIG", nil)) {
-		t.Fatal("vault read should be denied without vault:read")
+	if scopedTokenAllowsRequest(claims, httptest.NewRequest("GET", "/api/vault/EMAIL_CONFIG", nil)) {
+		t.Fatal("scoped vault read should be denied without vault:read")
 	}
 	if scopedTokenAllowsRequest(claims, httptest.NewRequest("GET", "/api/users/me", nil)) {
 		t.Fatal("unmapped users/me profile should be denied")

--- a/internal/server/vault.go
+++ b/internal/server/vault.go
@@ -228,6 +228,25 @@ func (s *Server) invalidateVaultRunners(userID, scope, agentID, name, op string)
 }
 
 func (s *Server) resolveVaultScope(w http.ResponseWriter, r *http.Request, info *AuthInfo, scope string, agentID string) (string, string, bool) {
+	// A sandbox (scoped) token is bound to exactly one agent. It may only reach
+	// its own user/user_agent secrets — never another agent's, and never the
+	// admin-managed system scopes. Without this, any agent's sandbox token could
+	// pass scope=user_agent&agent_id=<sibling> to read or overwrite a different
+	// agent's credentials under the same user.
+	if info.Scoped != nil {
+		switch scope {
+		case vault.ScopeUser:
+		case vault.ScopeUserAgent:
+			if agentID != info.Scoped.AgentID {
+				writeError(w, http.StatusForbidden, "scoped token cannot access another agent's vault")
+				return "", "", false
+			}
+		default:
+			writeError(w, http.StatusForbidden, "scoped token cannot access system vault scopes")
+			return "", "", false
+		}
+	}
+
 	userID := ""
 	switch scope {
 	case vault.ScopeUser:

--- a/internal/server/vault.go
+++ b/internal/server/vault.go
@@ -161,7 +161,7 @@ func (s *Server) SetScopedVaultEntry(w http.ResponseWriter, r *http.Request, nam
 		writeError(w, http.StatusBadRequest, "invalid request")
 		return
 	}
-	s.invalidateVaultRunners(userID, body.Scope, agentID, name, "set")
+	s.invalidateVaultRunners(body.Scope, userID, agentID, name, "set")
 	meta, err := s.vaultSvc.GetScopedMeta(r.Context(), body.Scope, userID, agentID, name)
 	if err != nil {
 		s.log.Error("get scoped vault entry meta", "user_id", info.UserID, "scope", body.Scope, "agent_id", agentID, "name", name, "error", err)
@@ -210,20 +210,30 @@ func (s *Server) DeleteScopedVaultEntry(w http.ResponseWriter, r *http.Request, 
 		writeError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
-	s.invalidateVaultRunners(userID, scope, agentID, name, "delete")
+	s.invalidateVaultRunners(scope, userID, agentID, name, "delete")
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// invalidateVaultRunners closes the affected user's live runners after a vault
-// mutation so the next session reads the new snapshot instead of the value
-// baked into the sandbox env at start. Only user-owned scopes carry a userID;
-// system-scoped writes affect every user and are left to the idle reap.
-func (s *Server) invalidateVaultRunners(userID, scope, agentID, name, op string) {
-	if userID == "" {
-		return
+// invalidateVaultRunners closes the live runners a vault mutation affects so the
+// next session reads the new snapshot instead of the value baked into the sandbox
+// env at start. Reach follows the scope: a single user for user/user_agent, one
+// agent across all users for system_agent, and every runner for system (whose
+// secrets merge into every agent's env via LoadEnvForAgent).
+func (s *Server) invalidateVaultRunners(scope, userID, agentID, name, op string) {
+	var err error
+	switch scope {
+	case vault.ScopeSystem:
+		err = s.credSvc.InvalidateAll()
+	case vault.ScopeSystemAgent:
+		err = s.credSvc.InvalidateAgent(agentID)
+	default: // user, user_agent
+		if userID == "" {
+			return
+		}
+		err = s.credSvc.InvalidateUser(userID)
 	}
-	if err := s.credSvc.InvalidateUser(userID); err != nil {
-		s.log.Warn("invalidate user runners after vault "+op, "user_id", userID, "scope", scope, "agent_id", agentID, "name", name, "error", err)
+	if err != nil {
+		s.log.Warn("invalidate runners after vault "+op, "scope", scope, "user_id", userID, "agent_id", agentID, "name", name, "error", err)
 	}
 }
 

--- a/internal/server/vault.go
+++ b/internal/server/vault.go
@@ -23,163 +23,6 @@ type vaultEntryResponse struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
-// ListVaultEntries handles GET /api/users/me/vault.
-func (s *Server) ListVaultEntries(w http.ResponseWriter, r *http.Request) {
-	if s.vaultSvc == nil {
-		writeError(w, http.StatusServiceUnavailable, "vault not configured")
-		return
-	}
-
-	info := UserFromContext(r.Context())
-	if info == nil {
-		writeError(w, http.StatusUnauthorized, "not authenticated")
-		return
-	}
-
-	entries, err := s.vaultSvc.List(r.Context(), info.UserID)
-	if err != nil {
-		s.log.Error("list vault entries", "user_id", info.UserID, "error", err)
-		writeError(w, http.StatusInternalServerError, "internal error")
-		return
-	}
-
-	resp := make([]vaultEntryResponse, len(entries))
-	for i, e := range entries {
-		resp[i] = vaultEntryResponseFromMeta(e)
-	}
-	writeData(w, http.StatusOK, map[string]any{"entries": resp})
-}
-
-// GetVaultEntry handles GET /api/users/me/vault/{name}.
-func (s *Server) GetVaultEntry(w http.ResponseWriter, r *http.Request, name string) {
-	if s.vaultSvc == nil {
-		writeError(w, http.StatusServiceUnavailable, "vault not configured")
-		return
-	}
-
-	info := UserFromContext(r.Context())
-	if info == nil {
-		writeError(w, http.StatusUnauthorized, "not authenticated")
-		return
-	}
-
-	if name == "" {
-		writeError(w, http.StatusBadRequest, "name is required")
-		return
-	}
-
-	value, err := s.vaultSvc.Get(r.Context(), info.UserID, name)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			writeError(w, http.StatusNotFound, "vault entry not found")
-			return
-		}
-		s.log.Error("get vault entry", "user_id", info.UserID, "name", name, "error", err)
-		writeError(w, http.StatusInternalServerError, "internal error")
-		return
-	}
-
-	writeData(w, http.StatusOK, map[string]string{"name": name, "value": value})
-}
-
-// SetVaultEntry handles PUT /api/users/me/vault/{name}.
-func (s *Server) SetVaultEntry(w http.ResponseWriter, r *http.Request, name string) {
-	if s.vaultSvc == nil {
-		writeError(w, http.StatusServiceUnavailable, "vault not configured")
-		return
-	}
-
-	info := UserFromContext(r.Context())
-	if info == nil {
-		writeError(w, http.StatusUnauthorized, "not authenticated")
-		return
-	}
-
-	if name == "" {
-		writeError(w, http.StatusBadRequest, "name is required")
-		return
-	}
-
-	var body struct {
-		Value string `json:"value"`
-	}
-	if err := decodeJSON(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON")
-		return
-	}
-	if body.Value == "" {
-		writeError(w, http.StatusBadRequest, "value is required")
-		return
-	}
-
-	if name == "EMAIL_CONFIG" {
-		var cfg email.Config
-		if err := json.Unmarshal([]byte(body.Value), &cfg); err != nil {
-			writeError(w, http.StatusBadRequest, "invalid EMAIL_CONFIG: malformed JSON")
-			return
-		}
-		if err := cfg.Validate(); err != nil {
-			writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid email config: %v", err))
-			return
-		}
-	}
-
-	if err := s.vaultSvc.Set(r.Context(), info.UserID, name, body.Value); err != nil {
-		s.log.Error("set vault entry", "user_id", info.UserID, "name", name, "error", err)
-		writeError(w, http.StatusBadRequest, "invalid request")
-		return
-	}
-
-	// Vault entries are baked into the sandbox env at session-creation time and
-	// cannot be injected into a running process; closing live runners forces a
-	// clean restart so the next chat turn or scheduled run reads the new value.
-	// Mirrors the OAuth token write path (see credentials.Service).
-	if err := s.credSvc.InvalidateUser(info.UserID); err != nil {
-		s.log.Warn("invalidate user runners after vault set", "user_id", info.UserID, "name", name, "error", err)
-	}
-
-	meta, err := s.vaultSvc.GetMeta(r.Context(), info.UserID, name)
-	if err != nil {
-		s.log.Error("get vault entry meta", "user_id", info.UserID, "name", name, "error", err)
-		writeError(w, http.StatusInternalServerError, "internal error")
-		return
-	}
-	writeData(w, http.StatusOK, vaultEntryResponseFromMeta(meta))
-}
-
-// DeleteVaultEntry handles DELETE /api/users/me/vault/{name}.
-func (s *Server) DeleteVaultEntry(w http.ResponseWriter, r *http.Request, name string) {
-	if s.vaultSvc == nil {
-		writeError(w, http.StatusServiceUnavailable, "vault not configured")
-		return
-	}
-
-	info := UserFromContext(r.Context())
-	if info == nil {
-		writeError(w, http.StatusUnauthorized, "not authenticated")
-		return
-	}
-
-	if name == "" {
-		writeError(w, http.StatusBadRequest, "name is required")
-		return
-	}
-
-	if err := s.vaultSvc.Delete(r.Context(), info.UserID, name); err != nil {
-		s.log.Error("delete vault entry", "user_id", info.UserID, "name", name, "error", err)
-		writeError(w, http.StatusInternalServerError, "internal error")
-		return
-	}
-
-	// See SetVaultEntry: invalidate live runners so the next session sees the
-	// updated vault snapshot instead of the cached one from sandbox start.
-	if err := s.credSvc.InvalidateUser(info.UserID); err != nil {
-		s.log.Warn("invalidate user runners after vault delete", "user_id", info.UserID, "name", name, "error", err)
-	}
-
-	w.WriteHeader(http.StatusNoContent)
-}
-
 // ListScopedVaultEntries handles GET /api/vault.
 func (s *Server) ListScopedVaultEntries(w http.ResponseWriter, r *http.Request, params apiserver.ListScopedVaultEntriesParams) {
 	if s.vaultSvc == nil {
@@ -222,6 +65,48 @@ func (s *Server) ListScopedVaultEntries(w http.ResponseWriter, r *http.Request, 
 		resp[i] = vaultEntryResponseFromMeta(e)
 	}
 	writeData(w, http.StatusOK, map[string]any{"entries": resp})
+}
+
+// GetScopedVaultEntry handles GET /api/vault/{name}.
+func (s *Server) GetScopedVaultEntry(w http.ResponseWriter, r *http.Request, name string, params apiserver.GetScopedVaultEntryParams) {
+	if s.vaultSvc == nil {
+		writeError(w, http.StatusServiceUnavailable, "vault not configured")
+		return
+	}
+	info := UserFromContext(r.Context())
+	if info == nil {
+		writeError(w, http.StatusUnauthorized, "not authenticated")
+		return
+	}
+	if name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+
+	scope := vault.ScopeUser
+	if params.Scope != nil {
+		scope = string(*params.Scope)
+	}
+	agentID := ""
+	if params.AgentId != nil {
+		agentID = *params.AgentId
+	}
+	userID, agentID, ok := s.resolveVaultScope(w, r, info, scope, agentID)
+	if !ok {
+		return
+	}
+
+	value, err := s.vaultSvc.GetScoped(r.Context(), scope, userID, agentID, name)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			writeError(w, http.StatusNotFound, "vault entry not found")
+			return
+		}
+		s.log.Error("get scoped vault entry", "user_id", info.UserID, "scope", scope, "agent_id", agentID, "name", name, "error", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	writeData(w, http.StatusOK, map[string]string{"name": name, "value": value})
 }
 
 // SetScopedVaultEntry handles PUT /api/vault/{name}.
@@ -276,6 +161,7 @@ func (s *Server) SetScopedVaultEntry(w http.ResponseWriter, r *http.Request, nam
 		writeError(w, http.StatusBadRequest, "invalid request")
 		return
 	}
+	s.invalidateVaultRunners(userID, body.Scope, agentID, name, "set")
 	meta, err := s.vaultSvc.GetScopedMeta(r.Context(), body.Scope, userID, agentID, name)
 	if err != nil {
 		s.log.Error("get scoped vault entry meta", "user_id", info.UserID, "scope", body.Scope, "agent_id", agentID, "name", name, "error", err)
@@ -324,7 +210,21 @@ func (s *Server) DeleteScopedVaultEntry(w http.ResponseWriter, r *http.Request, 
 		writeError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
+	s.invalidateVaultRunners(userID, scope, agentID, name, "delete")
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// invalidateVaultRunners closes the affected user's live runners after a vault
+// mutation so the next session reads the new snapshot instead of the value
+// baked into the sandbox env at start. Only user-owned scopes carry a userID;
+// system-scoped writes affect every user and are left to the idle reap.
+func (s *Server) invalidateVaultRunners(userID, scope, agentID, name, op string) {
+	if userID == "" {
+		return
+	}
+	if err := s.credSvc.InvalidateUser(userID); err != nil {
+		s.log.Warn("invalidate user runners after vault "+op, "user_id", userID, "scope", scope, "agent_id", agentID, "name", name, "error", err)
+	}
 }
 
 func (s *Server) resolveVaultScope(w http.ResponseWriter, r *http.Request, info *AuthInfo, scope string, agentID string) (string, string, bool) {

--- a/internal/server/vault_test.go
+++ b/internal/server/vault_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"filippo.io/age"
 
+	"github.com/CherryHQ/stella/internal/auth"
 	appdb "github.com/CherryHQ/stella/internal/db"
 	"github.com/CherryHQ/stella/internal/vault"
 	"github.com/CherryHQ/stella/pkg/db/sqlc"
@@ -313,6 +315,72 @@ func TestScopedVaultGet(t *testing.T) {
 	rr = doRequest(t, env, "GET", "/api/vault/NOPE?scope=user", nil)
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("scoped get missing status = %d, want %d (body: %s)", rr.Code, http.StatusNotFound, rr.Body.String())
+	}
+}
+
+// TestScopedTokenVaultAgentBinding is a regression guard for the secret-isolation
+// boundary: a sandbox (scoped) token bound to one agent must not reach another
+// agent's user_agent secrets nor the admin-managed system scopes, even when the
+// underlying user could otherwise access those agents (#452 / CR-001).
+func TestScopedTokenVaultAgentBinding(t *testing.T) {
+	t.Setenv("STELLA_SCOPED_TOKEN_SECRET", "test-scoped-token-secret-fixed")
+	env, svc := setupVaultEnv(t)
+	ctx := context.Background()
+	q := sqlc.New(env.db)
+
+	for _, id := range []string{"sa-agent-a", "sa-agent-b"} {
+		if _, err := q.CreateAgent(ctx, sqlc.CreateAgentParams{
+			ID: id, Name: id, Model: "test/model", Workspace: "workspace", Sandbox: "{}", EnabledBuiltinSkills: "[]", Scope: "system", Enabled: 1,
+		}); err != nil {
+			t.Fatalf("CreateAgent %s: %v", id, err)
+		}
+	}
+
+	regular, _ := createTestUserWithToken(t, env.authStore, env.oidcStore, "scoped-vault", "user")
+	pubKey, encPrivKey, err := vault.GenerateUserKeys(svc.MasterRecipient())
+	if err != nil {
+		t.Fatalf("GenerateUserKeys: %v", err)
+	}
+	if err := env.oidcStore.UpdateUserAgeKeys(ctx, regular.ID, pubKey, encPrivKey); err != nil {
+		t.Fatalf("UpdateUserAgeKeys: %v", err)
+	}
+
+	// Token bound to sa-agent-a.
+	tokenSvc := auth.NewTokenService(env.authStore, nil)
+	token, err := tokenSvc.CreateScopedToken(ctx, regular.ID, "sa-agent-a", "sess-1", "")
+	if err != nil {
+		t.Fatalf("CreateScopedToken: %v", err)
+	}
+
+	scoped := func(method, path string, body any) *httptest.ResponseRecorder {
+		return doRequestWithSession(t, env.srv, token, method, path, body)
+	}
+
+	// Cross-agent access is rejected on every verb.
+	if rr := scoped("GET", "/api/vault/X?scope=user_agent&agent_id=sa-agent-b", nil); rr.Code != http.StatusForbidden {
+		t.Fatalf("cross-agent GET = %d, want 403 (body: %s)", rr.Code, rr.Body.String())
+	}
+	if rr := scoped("PUT", "/api/vault/X?scope=user_agent&agent_id=sa-agent-b", map[string]string{"scope": "user_agent", "agent_id": "sa-agent-b", "value": "v"}); rr.Code != http.StatusForbidden {
+		t.Fatalf("cross-agent PUT = %d, want 403 (body: %s)", rr.Code, rr.Body.String())
+	}
+	if rr := scoped("DELETE", "/api/vault/X?scope=user_agent&agent_id=sa-agent-b", nil); rr.Code != http.StatusForbidden {
+		t.Fatalf("cross-agent DELETE = %d, want 403 (body: %s)", rr.Code, rr.Body.String())
+	}
+
+	// System scopes are off-limits to sandbox tokens regardless of agent_id.
+	if rr := scoped("GET", "/api/vault/X?scope=system", nil); rr.Code != http.StatusForbidden {
+		t.Fatalf("system GET = %d, want 403 (body: %s)", rr.Code, rr.Body.String())
+	}
+	if rr := scoped("PUT", "/api/vault/X", map[string]string{"scope": "system", "value": "v"}); rr.Code != http.StatusForbidden {
+		t.Fatalf("system PUT = %d, want 403 (body: %s)", rr.Code, rr.Body.String())
+	}
+
+	// The token's own agent and its own-user scope remain reachable.
+	if rr := scoped("PUT", "/api/vault/OWN", map[string]string{"scope": "user_agent", "agent_id": "sa-agent-a", "value": "v"}); rr.Code != http.StatusOK {
+		t.Fatalf("own-agent PUT = %d, want 200 (body: %s)", rr.Code, rr.Body.String())
+	}
+	if rr := scoped("GET", "/api/vault/MISSING?scope=user", nil); rr.Code != http.StatusNotFound {
+		t.Fatalf("own-user GET = %d, want 404 (body: %s)", rr.Code, rr.Body.String())
 	}
 }
 

--- a/internal/server/vault_test.go
+++ b/internal/server/vault_test.go
@@ -71,7 +71,7 @@ func setupVaultEnv(t *testing.T) (*testEnv, *vault.Service) {
 func TestVaultNotConfigured(t *testing.T) {
 	env := setupAdmin(t)
 
-	rr := doRequest(t, env, "GET", "/api/users/me/vault", nil)
+	rr := doRequest(t, env, "GET", "/api/vault", nil)
 	if rr.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusServiceUnavailable)
 	}
@@ -81,7 +81,7 @@ func TestVaultCRUD(t *testing.T) {
 	env, _ := setupVaultEnv(t)
 
 	// List — empty.
-	rr := doRequest(t, env, "GET", "/api/users/me/vault", nil)
+	rr := doRequest(t, env, "GET", "/api/vault", nil)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("list status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
 	}
@@ -98,13 +98,13 @@ func TestVaultCRUD(t *testing.T) {
 	}
 
 	// Set a secret.
-	rr = doRequest(t, env, "PUT", "/api/users/me/vault/GITHUB_TOKEN", map[string]string{"value": "ghp_test123"})
+	rr = doRequest(t, env, "PUT", "/api/vault/GITHUB_TOKEN", map[string]string{"value": "ghp_test123"})
 	if rr.Code != http.StatusOK {
 		t.Fatalf("set status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
 	}
 
 	// List — one entry.
-	rr = doRequest(t, env, "GET", "/api/users/me/vault", nil)
+	rr = doRequest(t, env, "GET", "/api/vault", nil)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("list status = %d, want %d", rr.Code, http.StatusOK)
 	}
@@ -119,13 +119,13 @@ func TestVaultCRUD(t *testing.T) {
 	}
 
 	// Delete.
-	rr = doRequest(t, env, "DELETE", "/api/users/me/vault/GITHUB_TOKEN", nil)
+	rr = doRequest(t, env, "DELETE", "/api/vault/GITHUB_TOKEN", nil)
 	if rr.Code != http.StatusNoContent {
 		t.Fatalf("delete status = %d, want %d (body: %s)", rr.Code, http.StatusNoContent, rr.Body.String())
 	}
 
 	// List — empty again.
-	rr = doRequest(t, env, "GET", "/api/users/me/vault", nil)
+	rr = doRequest(t, env, "GET", "/api/vault", nil)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("list status = %d", rr.Code)
 	}
@@ -141,7 +141,7 @@ func TestVaultCRUD(t *testing.T) {
 func TestVaultSetValidationError(t *testing.T) {
 	env, _ := setupVaultEnv(t)
 
-	rr := doRequest(t, env, "PUT", "/api/users/me/vault/invalid_name", map[string]string{"value": "test"})
+	rr := doRequest(t, env, "PUT", "/api/vault/invalid_name", map[string]string{"value": "test"})
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusBadRequest, rr.Body.String())
 	}
@@ -150,7 +150,7 @@ func TestVaultSetValidationError(t *testing.T) {
 func TestVaultNotConfiguredPUT(t *testing.T) {
 	env := setupAdmin(t)
 
-	rr := doRequest(t, env, "PUT", "/api/users/me/vault/MY_KEY", map[string]string{"value": "v"})
+	rr := doRequest(t, env, "PUT", "/api/vault/MY_KEY", map[string]string{"value": "v"})
 	if rr.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusServiceUnavailable)
 	}
@@ -159,7 +159,7 @@ func TestVaultNotConfiguredPUT(t *testing.T) {
 func TestVaultNotConfiguredDELETE(t *testing.T) {
 	env := setupAdmin(t)
 
-	rr := doRequest(t, env, "DELETE", "/api/users/me/vault/MY_KEY", nil)
+	rr := doRequest(t, env, "DELETE", "/api/vault/MY_KEY", nil)
 	if rr.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusServiceUnavailable)
 	}
@@ -168,7 +168,7 @@ func TestVaultNotConfiguredDELETE(t *testing.T) {
 func TestVaultSetEmptyValue(t *testing.T) {
 	env, _ := setupVaultEnv(t)
 
-	rr := doRequest(t, env, "PUT", "/api/users/me/vault/MY_KEY", map[string]string{"value": ""})
+	rr := doRequest(t, env, "PUT", "/api/vault/MY_KEY", map[string]string{"value": ""})
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusBadRequest, rr.Body.String())
 	}
@@ -177,7 +177,7 @@ func TestVaultSetEmptyValue(t *testing.T) {
 func TestVaultSetEmptyName(t *testing.T) {
 	env, _ := setupVaultEnv(t)
 
-	rr := doRequest(t, env, "PUT", "/api/users/me/vault/", map[string]string{"value": "v"})
+	rr := doRequest(t, env, "PUT", "/api/vault/", map[string]string{"value": "v"})
 	// Empty name in path — either 400 or 404 depending on router
 	if rr.Code == http.StatusOK {
 		t.Fatal("expected error for empty name, got 200")
@@ -187,7 +187,7 @@ func TestVaultSetEmptyName(t *testing.T) {
 func TestVaultSetInvalidJSON(t *testing.T) {
 	env, _ := setupVaultEnv(t)
 
-	rr := doRequestWithSession(t, env.srv, env.bearerToken, "PUT", "/api/users/me/vault/MY_KEY", nil)
+	rr := doRequestWithSession(t, env.srv, env.bearerToken, "PUT", "/api/vault/MY_KEY", nil)
 	// No body → JSON decode error or empty value
 	if rr.Code == http.StatusOK {
 		t.Fatal("expected error for nil body, got 200")
@@ -198,14 +198,14 @@ func TestVaultEmailConfigValidation(t *testing.T) {
 	env, _ := setupVaultEnv(t)
 
 	t.Run("rejects malformed JSON", func(t *testing.T) {
-		rr := doRequest(t, env, "PUT", "/api/users/me/vault/EMAIL_CONFIG", map[string]string{"value": "not-json"})
+		rr := doRequest(t, env, "PUT", "/api/vault/EMAIL_CONFIG", map[string]string{"value": "not-json"})
 		if rr.Code != http.StatusBadRequest {
 			t.Fatalf("status = %d, want %d (body: %s)", rr.Code, http.StatusBadRequest, rr.Body.String())
 		}
 	})
 
 	t.Run("rejects invalid config", func(t *testing.T) {
-		rr := doRequest(t, env, "PUT", "/api/users/me/vault/EMAIL_CONFIG", map[string]string{
+		rr := doRequest(t, env, "PUT", "/api/vault/EMAIL_CONFIG", map[string]string{
 			"value": `{"default":"missing","accounts":{}}`,
 		})
 		if rr.Code != http.StatusBadRequest {
@@ -214,7 +214,7 @@ func TestVaultEmailConfigValidation(t *testing.T) {
 	})
 
 	t.Run("accepts valid config", func(t *testing.T) {
-		rr := doRequest(t, env, "PUT", "/api/users/me/vault/EMAIL_CONFIG", map[string]string{
+		rr := doRequest(t, env, "PUT", "/api/vault/EMAIL_CONFIG", map[string]string{
 			"value": `{"default":"work","accounts":{"work":{"imap_host":"imap.example.com","smtp_host":"smtp.example.com","username":"u","from":"u@example.com"}}}`,
 		})
 		if rr.Code != http.StatusOK {
@@ -284,6 +284,38 @@ func TestScopedVaultPermissionsAndRuntimeResolution(t *testing.T) {
 	}
 }
 
+// TestScopedVaultGet verifies the scoped GET /api/vault/{name} endpoint returns
+// the value written through the scoped PUT, the read path CLI/web callers use
+// after the legacy /api/vault routes were removed (#452).
+func TestScopedVaultGet(t *testing.T) {
+	env, _ := setupVaultEnv(t)
+
+	// Write via the scoped endpoint (default scope=user).
+	rr := doRequest(t, env, "PUT", "/api/vault/API_KEY", map[string]string{"value": "secret-value"})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("scoped set status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
+	}
+
+	// Read back via the scoped endpoint.
+	rr = doRequest(t, env, "GET", "/api/vault/API_KEY?scope=user", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("scoped get status = %d, want %d (body: %s)", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	var got map[string]string
+	if err := json.Unmarshal(parseResponse(t, rr).Data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["name"] != "API_KEY" || got["value"] != "secret-value" {
+		t.Fatalf("got %+v, want name=API_KEY value=secret-value", got)
+	}
+
+	// Missing entry → 404.
+	rr = doRequest(t, env, "GET", "/api/vault/NOPE?scope=user", nil)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("scoped get missing status = %d, want %d (body: %s)", rr.Code, http.StatusNotFound, rr.Body.String())
+	}
+}
+
 // fakeRunnerInvalidator records InvalidateUser calls so tests can assert that
 // vault mutations propagate to the runner cache.
 type fakeRunnerInvalidator struct {
@@ -306,7 +338,7 @@ func TestVaultMutationsInvalidateUserRunners(t *testing.T) {
 	env.srv.CredentialsService().SetInvalidator(inv)
 
 	// PUT triggers invalidate.
-	rr := doRequest(t, env, "PUT", "/api/users/me/vault/MY_TOKEN", map[string]string{"value": "v1"})
+	rr := doRequest(t, env, "PUT", "/api/vault/MY_TOKEN", map[string]string{"value": "v1"})
 	if rr.Code != http.StatusOK {
 		t.Fatalf("set status = %d (body: %s)", rr.Code, rr.Body.String())
 	}
@@ -318,7 +350,7 @@ func TestVaultMutationsInvalidateUserRunners(t *testing.T) {
 	}
 
 	// PUT overwriting also triggers invalidate (covers rotate-in-place).
-	rr = doRequest(t, env, "PUT", "/api/users/me/vault/MY_TOKEN", map[string]string{"value": "v2"})
+	rr = doRequest(t, env, "PUT", "/api/vault/MY_TOKEN", map[string]string{"value": "v2"})
 	if rr.Code != http.StatusOK {
 		t.Fatalf("update status = %d (body: %s)", rr.Code, rr.Body.String())
 	}
@@ -327,7 +359,7 @@ func TestVaultMutationsInvalidateUserRunners(t *testing.T) {
 	}
 
 	// DELETE also triggers invalidate.
-	rr = doRequest(t, env, "DELETE", "/api/users/me/vault/MY_TOKEN", nil)
+	rr = doRequest(t, env, "DELETE", "/api/vault/MY_TOKEN", nil)
 	if rr.Code != http.StatusNoContent {
 		t.Fatalf("delete status = %d (body: %s)", rr.Code, rr.Body.String())
 	}
@@ -343,19 +375,19 @@ func TestVaultUpdateExisting(t *testing.T) {
 	env, _ := setupVaultEnv(t)
 
 	// Set initial value.
-	rr := doRequest(t, env, "PUT", "/api/users/me/vault/MY_SECRET", map[string]string{"value": "v1"})
+	rr := doRequest(t, env, "PUT", "/api/vault/MY_SECRET", map[string]string{"value": "v1"})
 	if rr.Code != http.StatusOK {
 		t.Fatalf("set status = %d, want %d", rr.Code, http.StatusOK)
 	}
 
 	// Update with new value.
-	rr = doRequest(t, env, "PUT", "/api/users/me/vault/MY_SECRET", map[string]string{"value": "v2"})
+	rr = doRequest(t, env, "PUT", "/api/vault/MY_SECRET", map[string]string{"value": "v2"})
 	if rr.Code != http.StatusOK {
 		t.Fatalf("update status = %d, want %d", rr.Code, http.StatusOK)
 	}
 
 	// List — still one entry.
-	rr = doRequest(t, env, "GET", "/api/users/me/vault", nil)
+	rr = doRequest(t, env, "GET", "/api/vault", nil)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("list status = %d", rr.Code)
 	}

--- a/internal/server/vault_test.go
+++ b/internal/server/vault_test.go
@@ -384,14 +384,26 @@ func TestScopedTokenVaultAgentBinding(t *testing.T) {
 	}
 }
 
-// fakeRunnerInvalidator records InvalidateUser calls so tests can assert that
-// vault mutations propagate to the runner cache.
+// fakeRunnerInvalidator records invalidation calls so tests can assert that
+// vault mutations propagate to the runner cache at the right scope.
 type fakeRunnerInvalidator struct {
-	calls []string
+	calls   []string // user IDs from InvalidateUser
+	agents  []string // agent IDs from InvalidateAgent
+	allHits int      // InvalidateAll count
 }
 
 func (f *fakeRunnerInvalidator) InvalidateUser(userID string) error {
 	f.calls = append(f.calls, userID)
+	return nil
+}
+
+func (f *fakeRunnerInvalidator) InvalidateAgent(agentID string) error {
+	f.agents = append(f.agents, agentID)
+	return nil
+}
+
+func (f *fakeRunnerInvalidator) InvalidateAll() error {
+	f.allHits++
 	return nil
 }
 
@@ -436,6 +448,48 @@ func TestVaultMutationsInvalidateUserRunners(t *testing.T) {
 	}
 	if inv.calls[2] != env.adminUser.ID {
 		t.Errorf("after DELETE: invalidated user = %q, want %q", inv.calls[2], env.adminUser.ID)
+	}
+}
+
+// TestSystemVaultMutationsInvalidateRunners verifies that admin-managed system
+// secrets, which merge into every agent's runtime env, invalidate at the right
+// reach: system → all runners, system_agent → that agent's runners (CR-002).
+func TestSystemVaultMutationsInvalidateRunners(t *testing.T) {
+	env, _ := setupVaultEnv(t)
+	if _, err := sqlc.New(env.db).CreateAgent(context.Background(), sqlc.CreateAgentParams{
+		ID: "sys-agent", Name: "Sys", Model: "test/model", Workspace: "workspace", Sandbox: "{}", EnabledBuiltinSkills: "[]", Scope: "system", Enabled: 1,
+	}); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	inv := &fakeRunnerInvalidator{}
+	env.srv.CredentialsService().SetInvalidator(inv)
+
+	// system scope → InvalidateAll on both PUT and DELETE.
+	rr := doRequest(t, env, "PUT", "/api/vault/SYS_TOKEN", map[string]string{"scope": "system", "value": "v"})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("system set status = %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	rr = doRequest(t, env, "DELETE", "/api/vault/SYS_TOKEN?scope=system", nil)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("system delete status = %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	if inv.allHits != 2 {
+		t.Fatalf("system mutations: InvalidateAll hits = %d, want 2", inv.allHits)
+	}
+
+	// system_agent scope → InvalidateAgent for that agent only.
+	rr = doRequest(t, env, "PUT", "/api/vault/SA_TOKEN", map[string]string{"scope": "system_agent", "agent_id": "sys-agent", "value": "v"})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("system_agent set status = %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	if len(inv.agents) != 1 || inv.agents[0] != "sys-agent" {
+		t.Fatalf("system_agent set: InvalidateAgent calls = %v, want [sys-agent]", inv.agents)
+	}
+
+	// System scopes must never fall back to per-user invalidation.
+	if len(inv.calls) != 0 {
+		t.Fatalf("system scopes must not InvalidateUser, got %v", inv.calls)
 	}
 }
 

--- a/web/src/features/credentials/EmailAccountsPanel.tsx
+++ b/web/src/features/credentials/EmailAccountsPanel.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useState } from "react";
 import {
-  deleteVaultEntry as deleteVaultEntryRequest,
-  getVaultEntry,
-  setVaultEntry,
+  deleteScopedVaultEntry as deleteVaultEntryRequest,
+  getScopedVaultEntry,
+  setScopedVaultEntry,
 } from "@/lib/api-client/sdk.gen";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -78,8 +78,9 @@ export function EmailAccountsPanel({
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      const { data } = await getVaultEntry({
+      const { data } = await getScopedVaultEntry({
         path: { name: "EMAIL_CONFIG" },
+        query: { scope: "user" },
         throwOnError: true,
       });
       if (data && data.value) {
@@ -99,9 +100,9 @@ export function EmailAccountsPanel({
   }, [load]);
 
   const saveConfig = async (cfg: EmailConfig) => {
-    await setVaultEntry({
+    await setScopedVaultEntry({
       path: { name: "EMAIL_CONFIG" },
-      body: { value: JSON.stringify(cfg) },
+      body: { value: JSON.stringify(cfg), scope: "user" },
       throwOnError: true,
     });
     await load();
@@ -134,7 +135,11 @@ export function EmailAccountsPanel({
     setSaving(true);
     try {
       if (Object.keys(updatedAccounts).length === 0) {
-        await deleteVaultEntryRequest({ path: { name: "EMAIL_CONFIG" }, throwOnError: true });
+        await deleteVaultEntryRequest({
+          path: { name: "EMAIL_CONFIG" },
+          query: { scope: "user" },
+          throwOnError: true,
+        });
         setConfig({ default: "", accounts: {} });
       } else {
         await saveConfig({ default: nextDefault, accounts: updatedAccounts });


### PR DESCRIPTION
## What

Remove the legacy `/api/users/me/vault` and `/api/users/me/vault/{name}` routes and migrate all remaining callers to the scoped `/api/vault` API introduced in #445. Includes two follow-up security/correctness fixes surfaced by review.

**BREAKING CHANGE:** the `/api/users/me/vault[/{name}]` endpoints are gone. Clients must use `/api/vault` with a `scope` query/body field (defaults to `user`).

## Why

#445 added the scoped `/api/vault` endpoints that supersede the current-user vault API. Per #452 the legacy routes were to be migrated off and removed. We're removing them outright now rather than keeping a one-release compatibility alias.

## How

### Route removal + caller migration
- **New endpoint:** `GET /api/vault/{name}` — the scoped API only had list/put/delete; single-entry reads are required by `vault get` and EMAIL_CONFIG loading.
- **Callers migrated** to the scoped API with `scope=user`:
  - CLI `stella vault list/get/set/delete`
  - CLI `stella email` EMAIL_CONFIG read/write
  - Web `EmailAccountsPanel.tsx` (the last legacy web caller; `CredentialsPage` was already scoped)
- **Scoped-token auth:** mapped `/api/vault` into the route→scope rules so sandbox-scoped tokens can reach it; removed the now-dead `/api/users/me/vault` mapping.
- **Removed** the legacy paths from the OpenAPI spec, their server handlers, and regenerated Go/TS clients.

### Review fixes
- **CR-001 (critical, security):** moving sandbox tokens onto `/api/vault` made `scope`/`agent_id` the real authorization boundary, but `resolveVaultScope` only ran `requireAgentAccess` — which passes whenever the underlying user can reach the target agent. A sandbox token for agent A could pass `scope=user_agent&agent_id=<sibling>` to read/overwrite/delete another agent's secrets. Now, for scoped tokens, `user_agent` requests must match the token's bound agent and `system`/`system_agent` scopes are rejected outright. Regular session/PAT callers (`Scoped == nil`) are unaffected.
- **CR-002 (medium, bug):** runner invalidation only handled user-owned scopes, so rotating a `system` / `system_agent` secret left live sandboxes on the old value until idle reap. Extended `RunnerInvalidator` with `InvalidateAgent` / `InvalidateAll` (backed by the runtime's existing `ResetRunners`) and route invalidation by scope: `system` → all runners, `system_agent` → that agent across users, `user`/`user_agent` → the owning user.

## Tests

- Scoped GET test + `/api/vault` scoped-auth cases.
- `TestScopedTokenVaultAgentBinding` — cross-agent + system-scope 403 regression (CR-001).
- `TestSystemVaultMutationsInvalidateRunners` — invalidation reach by scope (CR-002).
- Existing vault/invalidation tests migrated to the scoped routes.

Verification: `mise run format && mise run build && mise run test` all pass.

## Refs

- Closes #452
- Follow-up from #445, original feature #433