### PR TITLE
🐛 fix(sandbox): refresh expiring STELLA_TOKEN in long-lived runners

### DIFF
--- a/internal/agent/runner_impl.go
+++ b/internal/agent/runner_impl.go
@@ -61,6 +61,7 @@ type runner struct {
 	toolLifecycle *coreagent.ToolLifecycle
 	chatTimeout   time.Duration
 	session       pkgsandbox.Session // runner-owned sandbox session lifecycle
+	sandboxCfg    sandbox.Config     // retained to re-sign the sandbox STELLA_TOKEN on long-lived runners
 
 	mu           sync.Mutex
 	lastActivity time.Time
@@ -141,6 +142,7 @@ func newRunner(ctx context.Context, cfg runnerConfig) (*runner, error) {
 		toolLifecycle: cfg.ToolLifecycle,
 		chatTimeout:   cfg.ChatTimeout,
 		session:       session,
+		sandboxCfg:    cfg.Sandbox,
 		lastActivity:  time.Now(),
 		log:           slog.With("component", "go_runner"),
 	}, nil
@@ -384,6 +386,13 @@ func (r *runner) Chat(ctx context.Context, history []ai.Message, message Message
 			}
 			return &msg
 		})
+
+		// Re-sign the sandbox STELLA_TOKEN if it is near expiry, so a long-lived
+		// cached runner (kept warm by frequent scheduler fires) never hands tools an
+		// expired token. No-op on a fresh token (#490).
+		if r.session != nil {
+			sandbox.RefreshScopedToken(ctx, r.session, r.sandboxCfg)
+		}
 
 		messages := make([]ai.Message, len(history))
 		copy(messages, history)

--- a/internal/agent/sandbox/refresh.go
+++ b/internal/agent/sandbox/refresh.go
@@ -1,0 +1,58 @@
+package sandbox
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/CherryHQ/stella/pkg/auth"
+	pkgsandbox "github.com/CherryHQ/stella/pkg/sandbox"
+)
+
+// scopedTokenRefreshThreshold is the remaining-TTL floor below which the sandbox
+// STELLA_TOKEN is re-signed. It must stay comfortably above the longest single
+// chat turn (defaultChatTimeout, 30m) so a token refreshed at turn start outlives
+// the turn, and well under the token's own 6h TTL so refreshes are rare.
+const scopedTokenRefreshThreshold = time.Hour
+
+// RefreshScopedToken re-signs the sandbox STELLA_TOKEN and updates the session
+// env in place when the current token is near expiry, so long-lived cached
+// runners never serve an expired token (#490). It is a no-op when token
+// injection is disabled, the session carries no token or can't refresh its env,
+// or the token still has ample TTL — the common case, costing one cheap HMAC
+// parse per turn. A re-sign failure is logged and left to the next turn; the
+// stale token keeps working until it actually expires.
+func RefreshScopedToken(ctx context.Context, session pkgsandbox.Session, cfg Config) {
+	if session == nil || !shouldInjectScopedToken(cfg) {
+		return
+	}
+	refresher, ok := session.(pkgsandbox.EnvRefresher)
+	if !ok {
+		return
+	}
+	current := session.Policy().Env["STELLA_TOKEN"]
+	if current == "" {
+		return
+	}
+	if claims, err := auth.ParseScopedTokenUnverified(current); err == nil {
+		if time.Until(time.Unix(claims.ExpiresAt, 0)) > scopedTokenRefreshThreshold {
+			return
+		}
+	}
+
+	tokenUserID := cfg.UserID
+	if cfg.GroupID != "" {
+		tokenUserID = "group:" + cfg.GroupID
+	}
+	tok, err := cfg.TokenEnsurer.CreateScopedToken(ctx, tokenUserID, cfg.AgentID, cfg.SessionID, cfg.ProjectID)
+	if err != nil {
+		slog.Warn("scoped token refresh skipped",
+			"component", "runner_sandbox",
+			"user_id", cfg.UserID,
+			"agent_id", cfg.AgentID,
+			"error", err,
+		)
+		return
+	}
+	refresher.RefreshEnv(map[string]string{"STELLA_TOKEN": tok})
+}

--- a/internal/agent/sandbox/refresh_test.go
+++ b/internal/agent/sandbox/refresh_test.go
@@ -2,6 +2,7 @@ package sandbox
 
 import (
 	"context"
+	"errors"
 	"maps"
 	"testing"
 	"time"
@@ -30,16 +31,23 @@ type staticSession struct {
 
 func (s *staticSession) Policy() pkgsandbox.Policy { return pkgsandbox.Policy{Env: s.env} }
 
-// recordingEnsurer records CreateScopedToken calls and returns a fixed token.
+// recordingEnsurer records CreateScopedToken calls and returns a fixed token,
+// or err when set. lastUserID captures the user id passed to the last call.
 type recordingEnsurer struct {
-	token string
-	calls int
+	token      string
+	err        error
+	calls      int
+	lastUserID string
 }
 
 func (e *recordingEnsurer) EnsureAutoToken(context.Context, string) error { return nil }
 
-func (e *recordingEnsurer) CreateScopedToken(context.Context, string, string, string, string) (string, error) {
+func (e *recordingEnsurer) CreateScopedToken(_ context.Context, userID, _, _, _ string) (string, error) {
 	e.calls++
+	e.lastUserID = userID
+	if e.err != nil {
+		return "", e.err
+	}
 	return e.token, nil
 }
 
@@ -113,5 +121,50 @@ func TestRefreshScopedTokenNoOpWithoutToken(t *testing.T) {
 
 	if ensurer.calls != 0 {
 		t.Fatalf("expected no re-sign when env carries no token, got %d", ensurer.calls)
+	}
+}
+
+func TestRefreshScopedTokenReSignsUnparseableToken(t *testing.T) {
+	// A token we can't parse is treated as near-expiry and re-signed, so a
+	// corrupt token can't pin a runner to a permanently failing credential.
+	sess := &refreshSession{Session: pkgsandbox.NopSession(), env: map[string]string{"STELLA_TOKEN": "garbage"}}
+	ensurer := &recordingEnsurer{token: "stella_scoped_new"}
+
+	RefreshScopedToken(context.Background(), sess, refreshConfig(ensurer))
+
+	if ensurer.calls != 1 {
+		t.Fatalf("expected 1 re-sign for an unparseable token, got %d", ensurer.calls)
+	}
+	if got := sess.env["STELLA_TOKEN"]; got != "stella_scoped_new" {
+		t.Fatalf("token not refreshed: %q", got)
+	}
+}
+
+func TestRefreshScopedTokenGroupPrincipal(t *testing.T) {
+	near := signTokenExpiring(t, 10*time.Minute)
+	sess := &refreshSession{Session: pkgsandbox.NopSession(), env: map[string]string{"STELLA_TOKEN": near}}
+	ensurer := &recordingEnsurer{token: "stella_scoped_new"}
+	cfg := Config{GroupID: "g1", AgentID: "a1", TokenEnsurer: ensurer}
+
+	RefreshScopedToken(context.Background(), sess, cfg)
+
+	// Group sessions sign against the synthetic "group:<id>" principal, matching
+	// buildSandboxEnv's injection.
+	if ensurer.lastUserID != "group:g1" {
+		t.Fatalf("expected group principal, got %q", ensurer.lastUserID)
+	}
+}
+
+func TestRefreshScopedTokenKeepsOldTokenOnSignFailure(t *testing.T) {
+	near := signTokenExpiring(t, 10*time.Minute)
+	sess := &refreshSession{Session: pkgsandbox.NopSession(), env: map[string]string{"STELLA_TOKEN": near}}
+	ensurer := &recordingEnsurer{err: errors.New("sign failed")}
+
+	RefreshScopedToken(context.Background(), sess, refreshConfig(ensurer))
+
+	// A re-sign failure must leave the still-valid old token in place rather than
+	// blanking it; the next turn retries.
+	if got := sess.env["STELLA_TOKEN"]; got != near {
+		t.Fatalf("old token should survive a sign failure, got %q", got)
 	}
 }

--- a/internal/agent/sandbox/refresh_test.go
+++ b/internal/agent/sandbox/refresh_test.go
@@ -1,0 +1,117 @@
+package sandbox
+
+import (
+	"context"
+	"maps"
+	"testing"
+	"time"
+
+	"github.com/CherryHQ/stella/pkg/auth"
+	pkgsandbox "github.com/CherryHQ/stella/pkg/sandbox"
+)
+
+// refreshSession is a fake session whose env can be refreshed in place.
+type refreshSession struct {
+	pkgsandbox.Session
+	env map[string]string
+}
+
+func (s *refreshSession) Policy() pkgsandbox.Policy { return pkgsandbox.Policy{Env: s.env} }
+
+func (s *refreshSession) RefreshEnv(updates map[string]string) {
+	maps.Copy(s.env, updates)
+}
+
+// staticSession is a fake session that cannot refresh its env (no EnvRefresher).
+type staticSession struct {
+	pkgsandbox.Session
+	env map[string]string
+}
+
+func (s *staticSession) Policy() pkgsandbox.Policy { return pkgsandbox.Policy{Env: s.env} }
+
+// recordingEnsurer records CreateScopedToken calls and returns a fixed token.
+type recordingEnsurer struct {
+	token string
+	calls int
+}
+
+func (e *recordingEnsurer) EnsureAutoToken(context.Context, string) error { return nil }
+
+func (e *recordingEnsurer) CreateScopedToken(context.Context, string, string, string, string) (string, error) {
+	e.calls++
+	return e.token, nil
+}
+
+func signTokenExpiring(t *testing.T, in time.Duration) string {
+	t.Helper()
+	now := time.Now().UTC()
+	tok, err := auth.SignScopedToken([]byte("test-secret"), auth.ScopedTokenClaims{
+		UserID:    "u1",
+		AgentID:   "a1",
+		ExpiresAt: now.Add(in).Unix(),
+		IssuedAt:  now.Unix(),
+	}, now)
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+	return tok
+}
+
+func refreshConfig(te TokenEnsurer) Config {
+	return Config{UserID: "u1", AgentID: "a1", TokenEnsurer: te}
+}
+
+func TestRefreshScopedTokenReSignsNearExpiry(t *testing.T) {
+	fresh := signTokenExpiring(t, 30*time.Minute) // below the 1h threshold
+	sess := &refreshSession{Session: pkgsandbox.NopSession(), env: map[string]string{"STELLA_TOKEN": fresh}}
+	ensurer := &recordingEnsurer{token: "stella_scoped_new"}
+
+	RefreshScopedToken(context.Background(), sess, refreshConfig(ensurer))
+
+	if ensurer.calls != 1 {
+		t.Fatalf("expected 1 re-sign, got %d", ensurer.calls)
+	}
+	if got := sess.env["STELLA_TOKEN"]; got != "stella_scoped_new" {
+		t.Fatalf("token not refreshed: %q", got)
+	}
+}
+
+func TestRefreshScopedTokenSkipsWhenFresh(t *testing.T) {
+	fresh := signTokenExpiring(t, 5*time.Hour) // well above the 1h threshold
+	sess := &refreshSession{Session: pkgsandbox.NopSession(), env: map[string]string{"STELLA_TOKEN": fresh}}
+	ensurer := &recordingEnsurer{token: "stella_scoped_new"}
+
+	RefreshScopedToken(context.Background(), sess, refreshConfig(ensurer))
+
+	if ensurer.calls != 0 {
+		t.Fatalf("expected no re-sign for a fresh token, got %d", ensurer.calls)
+	}
+	if got := sess.env["STELLA_TOKEN"]; got != fresh {
+		t.Fatalf("fresh token should be untouched, got %q", got)
+	}
+}
+
+func TestRefreshScopedTokenNoOpWithoutRefresher(t *testing.T) {
+	fresh := signTokenExpiring(t, 1*time.Minute)
+	sess := &staticSession{Session: pkgsandbox.NopSession(), env: map[string]string{"STELLA_TOKEN": fresh}}
+	ensurer := &recordingEnsurer{token: "stella_scoped_new"}
+
+	// Must not panic and must not re-sign a token it can't install.
+	RefreshScopedToken(context.Background(), sess, refreshConfig(ensurer))
+
+	if ensurer.calls != 0 {
+		t.Fatalf("expected no re-sign when session can't refresh env, got %d", ensurer.calls)
+	}
+}
+
+func TestRefreshScopedTokenNoOpWithoutToken(t *testing.T) {
+	sess := &refreshSession{Session: pkgsandbox.NopSession(), env: map[string]string{}}
+	ensurer := &recordingEnsurer{token: "stella_scoped_new"}
+
+	RefreshScopedToken(context.Background(), sess, refreshConfig(ensurer))
+
+	if ensurer.calls != 0 {
+		t.Fatalf("expected no re-sign when env carries no token, got %d", ensurer.calls)
+	}
+}

--- a/pkg/sandbox/resilient.go
+++ b/pkg/sandbox/resilient.go
@@ -126,6 +126,18 @@ func (r *ResilientSession) StartProcess(ctx context.Context, req ProcessRequest)
 	return s.StartProcess(ctx, req)
 }
 
+// RefreshEnv forwards an env update to the current inner session when it
+// supports refreshing. A recreated session is rebuilt with fresh env by its
+// creator, so only the live inner session needs the update.
+func (r *ResilientSession) RefreshEnv(updates map[string]string) {
+	r.mu.Lock()
+	s := r.inner
+	r.mu.Unlock()
+	if refresher, ok := s.(EnvRefresher); ok {
+		refresher.RefreshEnv(updates)
+	}
+}
+
 func (r *ResilientSession) ResolvePath(path string) (string, error) {
 	r.mu.Lock()
 	s := r.inner

--- a/pkg/sandbox/session.go
+++ b/pkg/sandbox/session.go
@@ -33,6 +33,15 @@ type Session interface {
 // New code should use Session directly.
 type Host = Session
 
+// EnvRefresher is implemented by sessions whose injected environment can be
+// updated after creation, so a caller can rotate a credential (e.g. an expiring
+// STELLA_TOKEN) without tearing down and recreating the session. Updates are
+// applied atomically and are visible to every subsequent Exec/StartProcess.
+// Sessions that don't run real processes (e.g. the no-op session) may omit it.
+type EnvRefresher interface {
+	RefreshEnv(updates map[string]string)
+}
+
 type ExecOptions struct {
 	Cwd     string
 	Env     map[string]string

--- a/plugins/sandbox/docker/session.go
+++ b/plugins/sandbox/docker/session.go
@@ -575,7 +575,29 @@ type dockerSession struct {
 	mu           sync.RWMutex
 }
 
-func (s *dockerSession) Policy() sandboxpkg.Policy { return s.policy }
+func (s *dockerSession) Policy() sandboxpkg.Policy {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.policy
+}
+
+// RefreshEnv replaces injected env entries with the given updates, swapping the
+// policy's env map under the write lock (copy-on-write) so per-exec env reads on
+// the host surface never observe a half-written map. Already-running exec
+// processes keep the env they were started with.
+func (s *dockerSession) RefreshEnv(updates map[string]string) {
+	if len(updates) == 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	env := maps.Clone(s.policy.Env)
+	if env == nil {
+		env = make(map[string]string, len(updates))
+	}
+	maps.Copy(env, updates)
+	s.policy.Env = env
+}
 
 func (s *dockerSession) Exec(ctx context.Context, command string, opts sandboxpkg.ExecOptions) (sandboxpkg.ExecResult, error) {
 	return s.host.Exec(ctx, command, opts)
@@ -877,7 +899,11 @@ func (h *dockerHost) Exec(ctx context.Context, command string, opts sandboxpkg.E
 		return sandboxpkg.ExecResult{}, fmt.Errorf("docker host exec: cwd not in any mount: %w", err)
 	}
 
-	env := injectToolPaths(translateEnvPaths(mergeEnv(h.session.policy.Env, opts.Env), h.session.mountTable, h.session.envPathMaps), h.session.toolBinPaths)
+	// Snapshot env under the lock so a concurrent RefreshEnv can't race the read.
+	h.session.mu.RLock()
+	policyEnv := h.session.policy.Env
+	h.session.mu.RUnlock()
+	env := injectToolPaths(translateEnvPaths(mergeEnv(policyEnv, opts.Env), h.session.mountTable, h.session.envPathMaps), h.session.toolBinPaths)
 
 	timeout := opts.Timeout
 	if timeout == 0 {
@@ -922,7 +948,11 @@ func (h *dockerHost) StartProcess(ctx context.Context, req sandboxpkg.ProcessReq
 		return nil, fmt.Errorf("docker host start_process: cwd not in any mount: %w", err)
 	}
 
-	env := injectToolPaths(translateEnvPaths(mergeEnv(h.session.policy.Env, req.Env), h.session.mountTable, h.session.envPathMaps), h.session.toolBinPaths)
+	// Snapshot env under the lock so a concurrent RefreshEnv can't race the read.
+	h.session.mu.RLock()
+	policyEnv := h.session.policy.Env
+	h.session.mu.RUnlock()
+	env := injectToolPaths(translateEnvPaths(mergeEnv(policyEnv, req.Env), h.session.mountTable, h.session.envPathMaps), h.session.toolBinPaths)
 
 	timeout := req.Timeout
 	if timeout == 0 {

--- a/plugins/sandbox/local/session.go
+++ b/plugins/sandbox/local/session.go
@@ -222,7 +222,28 @@ type localSession struct {
 	procs          []*localProcess
 }
 
-func (s *localSession) Policy() sandboxpkg.Policy { return s.policy }
+func (s *localSession) Policy() sandboxpkg.Policy {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.policy
+}
+
+// RefreshEnv replaces injected env entries with the given updates. It swaps the
+// policy's env map under the write lock (copy-on-write) so readers that snapshot
+// the policy under the read lock never observe a half-written map.
+func (s *localSession) RefreshEnv(updates map[string]string) {
+	if len(updates) == 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	env := maps.Clone(s.policy.Env)
+	if env == nil {
+		env = make(map[string]string, len(updates))
+	}
+	maps.Copy(env, updates)
+	s.policy.Env = env
+}
 
 func (s *localSession) WorkspaceRoot() string {
 	return s.sandboxRoot
@@ -505,9 +526,11 @@ func (s *localSession) toSandboxPath(realPath string) string {
 
 // Exec runs a shell command via sh -c on the host.
 func (s *localSession) Exec(ctx context.Context, command string, opts sandboxpkg.ExecOptions) (sandboxpkg.ExecResult, error) {
-	// Finding 5: check closed before starting.
+	// Finding 5: check closed before starting. Snapshot the policy under the same
+	// lock so a concurrent RefreshEnv can't race the per-exec env read.
 	s.mu.RLock()
 	closed := s.closed
+	policy := s.policy
 	s.mu.RUnlock()
 	if closed {
 		return sandboxpkg.ExecResult{}, fmt.Errorf("local: session is closed")
@@ -520,7 +543,7 @@ func (s *localSession) Exec(ctx context.Context, command string, opts sandboxpkg
 
 	timeout := opts.Timeout
 	if timeout == 0 {
-		timeout = s.policy.Timeout
+		timeout = policy.Timeout
 	}
 	if timeout > 0 {
 		var cancel context.CancelFunc
@@ -533,7 +556,7 @@ func (s *localSession) Exec(ctx context.Context, command string, opts sandboxpkg
 		return sandboxpkg.ExecResult{}, fmt.Errorf("local exec: resolve cwd: %w", err)
 	}
 
-	execPath, execArgs, hostCwd, err := wrapCommand(s.policy, sandboxCwd, s.tmpMounts, s.stellaHomeHost, "sh", []string{"-c", command})
+	execPath, execArgs, hostCwd, err := wrapCommand(policy, sandboxCwd, s.tmpMounts, s.stellaHomeHost, "sh", []string{"-c", command})
 	if err != nil {
 		return sandboxpkg.ExecResult{}, fmt.Errorf("local exec: wrap: %w", err)
 	}
@@ -542,7 +565,7 @@ func (s *localSession) Exec(ctx context.Context, command string, opts sandboxpkg
 	// leaving process-group children alive. We manage cancellation manually.
 	cmd := exec.Command(execPath, execArgs...)
 	cmd.Dir = hostCwd
-	cmd.Env = buildEnv(s.policy, opts.Env)
+	cmd.Env = buildEnv(policy, opts.Env)
 	setSysProcAttr(cmd)
 
 	var stdout, stderr bytes.Buffer
@@ -589,6 +612,11 @@ func (s *localSession) Exec(ctx context.Context, command string, opts sandboxpkg
 
 // StartProcess starts a long-running process on the host and returns a handle.
 func (s *localSession) StartProcess(ctx context.Context, req sandboxpkg.ProcessRequest) (sandboxpkg.ProcessHandle, error) {
+	// Snapshot the policy so a concurrent RefreshEnv can't race the env read.
+	s.mu.RLock()
+	policy := s.policy
+	s.mu.RUnlock()
+
 	sandboxCwd := req.Cwd
 	if sandboxCwd == "" {
 		sandboxCwd = s.WorkingDir()
@@ -596,7 +624,7 @@ func (s *localSession) StartProcess(ctx context.Context, req sandboxpkg.ProcessR
 
 	timeout := req.Timeout
 	if timeout == 0 {
-		timeout = s.policy.Timeout
+		timeout = policy.Timeout
 	}
 
 	var (
@@ -618,7 +646,7 @@ func (s *localSession) StartProcess(ctx context.Context, req sandboxpkg.ProcessR
 		return nil, fmt.Errorf("local start_process: resolve cwd: %w", err)
 	}
 
-	execPath, execArgs, hostCwd, err := wrapCommand(s.policy, sandboxCwd, s.tmpMounts, s.stellaHomeHost, req.Path, args)
+	execPath, execArgs, hostCwd, err := wrapCommand(policy, sandboxCwd, s.tmpMounts, s.stellaHomeHost, req.Path, args)
 	if err != nil {
 		cancel()
 		return nil, fmt.Errorf("local start_process: wrap: %w", err)
@@ -627,7 +655,7 @@ func (s *localSession) StartProcess(ctx context.Context, req sandboxpkg.ProcessR
 	// Finding 2: do NOT use exec.CommandContext — kill the process group instead.
 	cmd := exec.Command(execPath, execArgs...)
 	cmd.Dir = hostCwd
-	cmd.Env = buildEnv(s.policy, req.Env)
+	cmd.Env = buildEnv(policy, req.Env)
 	setSysProcAttr(cmd)
 
 	// Finding 7: close previously opened pipes on error.

--- a/plugins/sandbox/local/session_test.go
+++ b/plugins/sandbox/local/session_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	sandboxpkg "github.com/CherryHQ/stella/pkg/sandbox"
@@ -133,6 +135,29 @@ func newTestSession(t *testing.T) (*localSession, string) {
 		done:        make(chan struct{}),
 	}
 	return s, root
+}
+
+// TestRefreshEnv_concurrentWithExec stresses RefreshEnv against concurrent Exec
+// calls so the race detector can confirm the copy-on-write swap and the
+// snapshot-under-lock reads are free of data races on the policy env map.
+func TestRefreshEnv_concurrentWithExec(t *testing.T) {
+	skipIfBwrapNotFunctional(t)
+	s, _ := newTestSession(t)
+	defer s.Close() //nolint:errcheck
+	s.policy.Env = map[string]string{"STELLA_TOKEN": "v0"}
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Go(func() {
+			for range 20 {
+				_, _ = s.Exec(context.Background(), "true", sandboxpkg.ExecOptions{})
+			}
+		})
+	}
+	for i := range 50 {
+		s.RefreshEnv(map[string]string{"STELLA_TOKEN": "v" + strconv.Itoa(i)})
+	}
+	wg.Wait()
 }
 
 // TestResolvePath_rejectsOutsideRoot verifies that ResolvePath returns an error

--- a/plugins/sandbox/none/session.go
+++ b/plugins/sandbox/none/session.go
@@ -95,7 +95,28 @@ type noneSession struct {
 	procs    []*noneProcess
 }
 
-func (s *noneSession) Policy() sandboxpkg.Policy { return s.policy }
+func (s *noneSession) Policy() sandboxpkg.Policy {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.policy
+}
+
+// RefreshEnv replaces injected env entries with the given updates, swapping the
+// policy's env map under the write lock (copy-on-write) so readers that snapshot
+// the policy under the read lock never observe a half-written map.
+func (s *noneSession) RefreshEnv(updates map[string]string) {
+	if len(updates) == 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	env := maps.Clone(s.policy.Env)
+	if env == nil {
+		env = make(map[string]string, len(updates))
+	}
+	maps.Copy(env, updates)
+	s.policy.Env = env
+}
 
 func (s *noneSession) WorkingDir() string {
 	if s.policy.Filesystem.WorkingDir != "" {
@@ -148,6 +169,7 @@ func (s *noneSession) ResolveWritePath(path string) (string, error) {
 func (s *noneSession) Exec(ctx context.Context, command string, opts sandboxpkg.ExecOptions) (sandboxpkg.ExecResult, error) {
 	s.mu.RLock()
 	closed := s.closed
+	policy := s.policy
 	s.mu.RUnlock()
 	if closed {
 		return sandboxpkg.ExecResult{}, errors.New("none: session is closed")
@@ -160,7 +182,7 @@ func (s *noneSession) Exec(ctx context.Context, command string, opts sandboxpkg.
 
 	timeout := opts.Timeout
 	if timeout == 0 {
-		timeout = s.policy.Timeout
+		timeout = policy.Timeout
 	}
 	if timeout > 0 {
 		var cancel context.CancelFunc
@@ -171,7 +193,7 @@ func (s *noneSession) Exec(ctx context.Context, command string, opts sandboxpkg.
 	sh, shFlag := shell()
 	cmd := exec.Command(sh, shFlag, command)
 	cmd.Dir = cwd
-	cmd.Env = buildEnv(s.policy, opts.Env)
+	cmd.Env = buildEnv(policy, opts.Env)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -210,6 +232,7 @@ func (s *noneSession) Exec(ctx context.Context, command string, opts sandboxpkg.
 func (s *noneSession) StartProcess(ctx context.Context, req sandboxpkg.ProcessRequest) (sandboxpkg.ProcessHandle, error) {
 	s.mu.RLock()
 	closed := s.closed
+	policy := s.policy
 	s.mu.RUnlock()
 	if closed {
 		return nil, errors.New("none: session is closed")
@@ -222,7 +245,7 @@ func (s *noneSession) StartProcess(ctx context.Context, req sandboxpkg.ProcessRe
 
 	timeout := req.Timeout
 	if timeout == 0 {
-		timeout = s.policy.Timeout
+		timeout = policy.Timeout
 	}
 
 	var execCtx context.Context
@@ -235,7 +258,7 @@ func (s *noneSession) StartProcess(ctx context.Context, req sandboxpkg.ProcessRe
 
 	cmd := exec.Command(req.Path, req.Args...)
 	cmd.Dir = cwd
-	cmd.Env = buildEnv(s.policy, req.Env)
+	cmd.Env = buildEnv(policy, req.Env)
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {


### PR DESCRIPTION
## What

Re-sign the sandbox-scoped `STELLA_TOKEN` when it nears expiry, instead of baking a single 6h token into the session at runner creation. Adds an `EnvRefresher` capability so a live sandbox session's injected env can be updated in place.

## Why

The runner cache reuses a runner as long as it's alive and the session ID matches. For scheduler jobs with `SessionReuse` (default), the session ID is deterministic, so the same runner persists across fires and is kept warm indefinitely. The `STELLA_TOKEN` signed at creation (TTL 6h) was never refreshed, so after 6h every API-backed tool (`stella vault get`, `stella recally`, …) failed with 401 until the runner was reaped (idle > 10m) and recreated.

This explains the intermittent "sometimes the env works, sometimes not" reports: works for the first 6h, breaks until the runner is recreated.

## How

- New `RefreshScopedToken` (`internal/agent/sandbox/refresh.go`), called at the start of each chat turn: unverified-parse the current token's `exp`; when remaining TTL < 1h, re-sign via `TokenEnsurer.CreateScopedToken` and update the session env in place. Fresh tokens cost one cheap HMAC parse per turn; the re-sign only fires near expiry.
- Threshold is 1h: above the longest single chat turn (`defaultChatTimeout`, 30m) so a token refreshed at turn start outlives the turn, and well under the 6h TTL so refreshes are rare.
- New `EnvRefresher` interface (`pkg/sandbox`). The local/docker/none backends swap their policy env map under the write lock (copy-on-write); per-exec env reads now snapshot the policy under the read lock, so there's no data race on the env map. `ResilientSession` forwards the update to its live inner session — a recreated session is already rebuilt with a fresh token.

## Verification

- `mise run format && mise run build && mise run test` — all green.
- Added `TestRefreshScopedToken*` (refresh fires near expiry, skips when fresh, no-ops without a refresher or token) and `TestRefreshEnv_concurrentWithExec` (8 goroutines exec while the env is refreshed in a tight loop).
- Ran the sandbox backends + agent + auth packages under `-race`: clean.

## Refs

Fixes #490 #465 