### PR TITLE
📝 docs(skills): GitHub issue reporting workflow in stella skill

### DIFF
--- a/resources/skills/system/stella/SKILL.md
+++ b/resources/skills/system/stella/SKILL.md
@@ -8,6 +8,8 @@ description: >
   self-update, multi-agent, multi-user, or general "how does stella work" / "help me get started" questions.
   Also triggers on "change my model", "set up telegram", "set up wechat", "configure provider", "update stella",
   "what can you do", "how do I install skills", "stella onboard", "switch agent".
+  Also triggers when the user wants to report a bug or file a GitHub issue about stella:
+  "report this bug", "create an issue for this", "报告这个 issue", "帮我建个 issue".
 ---
 
 # Stella Self-Knowledge
@@ -56,6 +58,7 @@ Read the relevant reference file for detailed guidance:
 | Channels      | [references/channels.md](references/channels.md)           | Telegram/QQ/Feishu/WeChat bot setup, groups, access control                                           |
 | Update        | [references/update.md](references/update.md)               | How to update stella to the latest version                                                            |
 | Tasks & goals | [references/tasks.md](references/tasks.md)                 | Goal/task system: manager CLI vs worker `task_control`, lifecycle, deps, readiness, reviews, blockers |
+| Report issue  | [references/report-issue.md](references/report-issue.md)   | User asks to report a bug / file a GitHub issue about stella                                          |
 
 ## In-chat commands
 

--- a/resources/skills/system/stella/references/report-issue.md
+++ b/resources/skills/system/stella/references/report-issue.md
@@ -14,16 +14,22 @@ Never create an issue without explicit confirmation, and never run the flow with
    stella oauth status github --json
    ```
    If `connected` is `false`, run the OAuth flow (next section) before continuing. Do not ask the user to authenticate `gh` manually.
-5. **Create the issue** once approved and authenticated:
+5. **Create the issue** once approved and authenticated. Use a heredoc for the body — a literal `\n` inside a double-quoted `--body` is written verbatim, not as a newline. Add a `bug` label (or `docs`/`enhancement` if it fits better):
    ```bash
-   gh issue create --repo CherryHQ/stella --title "<title>" --body "<body>"
+   gh issue create --repo CherryHQ/stella --label bug \
+     --title "<title>" \
+     --body "$(cat <<'EOF'
+   ## What
+   ...
+   EOF
+   )"
    ```
 6. **Return the created issue URL** to the user.
 7. **Offer to star the repo.** Check whether it is already starred (`gh api /user/starred/CherryHQ/stella` returns 204 if starred, 404 if not). If not starred, offer to add a star — `gh api -X PUT /user/starred/CherryHQ/stella` — only with the user's consent.
 
 ## Issue structure
 
-Follow the project's standard four-section format:
+Follow the project's standard four-section format (the What/Why/How/Refs convention from the repo's issue template). A user-reported bug only needs the issue itself with a label — skip the milestone and project-board steps the full tracker workflow uses.
 
 ```markdown
 ## What

--- a/resources/skills/system/stella/references/report-issue.md
+++ b/resources/skills/system/stella/references/report-issue.md
@@ -1,0 +1,67 @@
+# Reporting a GitHub issue
+
+When the user reports that you (stella) hit an error or behaved incorrectly and asks to file it — e.g. "报告这个 issue", "帮我建个 issue", "report this bug", "create an issue for this" — help them open a GitHub issue against the stella repo (`CherryHQ/stella`).
+
+Never create an issue without explicit confirmation, and never run the flow without checking GitHub is linked first.
+
+## Workflow
+
+1. **Confirm intent and target repo.** Default repo is `CherryHQ/stella`. If the user means a different repo, ask before proceeding.
+2. **Draft the issue.** Summarize the problem from the conversation and recent errors. Ask clarifying questions only when required context is missing. Use the standard structure below.
+3. **Get explicit confirmation.** Show the user the drafted title and body. Do not create the issue until they approve.
+4. **Check GitHub link status:**
+   ```bash
+   stella oauth status github --json
+   ```
+   If `connected` is `false`, run the OAuth flow (next section) before continuing. Do not ask the user to authenticate `gh` manually.
+5. **Create the issue** once approved and authenticated:
+   ```bash
+   gh issue create --repo CherryHQ/stella --title "<title>" --body "<body>"
+   ```
+6. **Return the created issue URL** to the user.
+
+## Issue structure
+
+Follow the project's standard four-section format:
+
+```markdown
+## What
+
+<one-line summary of the problem>
+
+## Why
+
+<impact — what the user couldn't do, or what broke>
+
+## How
+
+**Expected:** <what should have happened>
+**Actual:** <what actually happened>
+**Steps/context:** <how to reproduce or what triggered it>
+**Logs/errors:** <relevant error output, redacted>
+
+## Refs
+
+<session/environment context if useful and safe; related issues>
+```
+
+## Linking GitHub via OAuth
+
+If GitHub is not connected, initiate the device flow yourself — do not tell the user to run CLI commands:
+
+```bash
+stella oauth connect github --json
+```
+
+This prints a verification URL and a user code. Relay them to the user:
+
+1. Give them the `verification_uri` and `user_code`.
+2. Ask them to open the URL, enter the code, and authorize.
+3. After they report back, confirm with `stella oauth status github --json`.
+4. Once `connected` is `true`, `gh` works directly in `bash` — proceed to create the issue.
+
+## Privacy and safety
+
+- Never include secrets, tokens, credentials, API keys, or private user data in the issue body.
+- Redact sensitive values from any logs you attach (replace with `<redacted>`).
+- Include environment/session context only when it helps and is safe to publish — issues are public.

--- a/resources/skills/system/stella/references/report-issue.md
+++ b/resources/skills/system/stella/references/report-issue.md
@@ -19,6 +19,7 @@ Never create an issue without explicit confirmation, and never run the flow with
    gh issue create --repo CherryHQ/stella --title "<title>" --body "<body>"
    ```
 6. **Return the created issue URL** to the user.
+7. **Offer to star the repo.** Check whether it is already starred (`gh api /user/starred/CherryHQ/stella` returns 204 if starred, 404 if not). If not starred, offer to add a star — `gh api -X PUT /user/starred/CherryHQ/stella` — only with the user's consent.
 
 ## Issue structure
 


### PR DESCRIPTION
## What

Add a "report a GitHub issue" workflow to the built-in stella skill so stella can help users file an issue when they report a bug during usage.

- New reference `resources/skills/system/stella/references/report-issue.md` documenting the end-to-end flow.
- `SKILL.md`: Topics table row pointing to the reference + frontmatter triggers (`report this bug`, `建个 issue`, etc.).

## Why

When stella errors or misbehaves, the feedback loop should be fast — users shouldn't hand-copy logs/context into GitHub. A skill-level workflow makes the behavior consistent across agents and sessions.

## How

The documented workflow:

1. Detect intent and confirm target repo (default `CherryHQ/stella`; ask if ambiguous).
2. Draft a standard four-section issue (What / Why / How / Refs).
3. Require explicit user confirmation before creating.
4. Verify link status via `stella oauth status github`.
5. If unlinked, stella initiates the device flow (`stella oauth connect github`), relays URL + code, and confirms — no manual `gh auth`.
6. Create with `gh issue create` and return the issue URL.

Privacy: never include secrets/credentials; redact logs; issues are public.

Verified with `mise run format && mise run build` (skill is an embedded resource). Docs-only change, no tests run.

## Refs

Closes #492