### PR TITLE
♻️ fix(skills): unify skill disk-path authority; fix system-scope skill_dir

### DIFF
--- a/cmd/stellad/setup_skills.go
+++ b/cmd/stellad/setup_skills.go
@@ -25,32 +25,11 @@ type skillStores struct {
 
 func setupSkillStores(db *sql.DB) skillStores {
 	raw := skills.New(db)
+	// The per-scope on-disk layout is owned by agent.WriterSkillDiskLayout (the
+	// single authority the skills tool reads back through); this resolver just
+	// selects the base dir for the skill's scope.
 	diskSync := skills.NewDiskSyncStore(raw, func(scope, agentID string, userID string) string {
-		base := config.StellaHome()
-		switch scope {
-		case "system_agent":
-			if agentID == "" {
-				return ""
-			}
-			return agent.UserSkillsDir(agent.AgentWorkspaceDir(base, agentID))
-		case "user":
-			// User skills are shared across all of a user's agents (#442) and live
-			// under the user-data root (mounted as /user), so the path no longer
-			// depends on agentID.
-			if userID == "" {
-				return ""
-			}
-			return agent.UserSkillsDir(agent.UserDataDir(agent.UserHomeDir(base, userID)))
-		case "user_agent":
-			if agentID == "" || userID == "" {
-				return ""
-			}
-			return agent.UserSkillsDir(agent.UserAgentDir(base, userID, agentID))
-		default:
-			// system (global) skills are not tied to a workspace, so they are not
-			// mirrored to disk here; their SKILL.md resolves from the DB.
-			return ""
-		}
+		return agent.WriterSkillDiskLayout(config.StellaHome(), userID, agentID).BaseDir(scope)
 	})
 
 	return skillStores{raw: raw, diskSync: diskSync}

--- a/internal/agent/runner_builder.go
+++ b/internal/agent/runner_builder.go
@@ -194,37 +194,36 @@ func newRunnerFunc(cfg runnerBuilderConfig) NewRunnerFunc {
 			// then, omit every skill_dir (Isolated, no roots) rather than risk emitting a
 			// host path the model could leak or fail to resolve.
 			stellaHome := config.StellaHome()
-			toolAgentRoot := cfg.Snap.Workspace
 			toolProjectRoot := projectRoot
-			userSkillsDir := UserSkillsDir(UserDataDir(userRoot))
-			userAgentSkillsDir := ""
+			// layout is rooted at the canonicalized sandbox paths so the host→view
+			// remap below matches; until ResolvePaths succeeds, fall back to the raw
+			// user home (the sandbox session fails downstream anyway).
+			layout := skillDiskLayout(SystemDBSkillsDir(stellaHome), cfg.Snap.Workspace, UserDataDir(userRoot), userRoot)
 			view := skillstool.SkillDirView{Isolated: true}
 			if resolved, err := sandbox.ResolvePaths(sandboxCfg); err == nil {
 				stellaHome = resolved.StellaHome
-				toolAgentRoot = resolved.AgentRoot
 				toolProjectRoot = resolved.ProjectRoot
-				userSkillsDir = UserSkillsDir(resolved.UserDataDir)
-				userAgentSkillsDir = UserSkillsDir(resolved.WorkspaceRoot)
+				layout = skillDiskLayout(SystemDBSkillsDir(resolved.StellaHome), resolved.AgentRoot, resolved.UserDataDir, resolved.WorkspaceRoot)
 				sv := sandbox.ResolveSkillView(ctx, sandboxCfg, resolved)
 				view = skillstool.SkillDirView{
-					Isolated:         sv.Isolated,
-					SystemSkillsHost: sv.SystemSkillsHost,
-					SystemSkillsView: sv.SystemSkillsView,
-					AgentSkillsHost:  sv.AgentSkillsHost,
-					AgentSkillsView:  sv.AgentSkillsView,
-					UserDataHost:     sv.UserDataHost,
-					UserDataView:     sv.UserDataView,
-					WorkspaceHost:    sv.WorkspaceHost,
-					WorkspaceView:    sv.WorkspaceView,
+					Isolated:           sv.Isolated,
+					SystemSkillsHost:   sv.SystemSkillsHost,
+					SystemSkillsView:   sv.SystemSkillsView,
+					AgentSkillsHost:    sv.AgentSkillsHost,
+					AgentSkillsView:    sv.AgentSkillsView,
+					SystemDBSkillsHost: sv.SystemDBSkillsHost,
+					SystemDBSkillsView: sv.SystemDBSkillsView,
+					UserDataHost:       sv.UserDataHost,
+					UserDataView:       sv.UserDataView,
+					WorkspaceHost:      sv.WorkspaceHost,
+					WorkspaceView:      sv.WorkspaceView,
 				}
 			}
 			runnerTools = append(runnerTools, skillstool.NewTool(
 				cfg.SkillStore,
 				stellaHome,
-				toolAgentRoot,
 				toolProjectRoot,
-				userSkillsDir,
-			).WithUserAgentSkillsDir(userAgentSkillsDir).WithSkillDirView(view))
+			).WithSkillDiskLayout(layout).WithSkillDirView(view))
 		}
 
 		return newRunner(ctx, runnerConfig{

--- a/internal/agent/runner_builder.go
+++ b/internal/agent/runner_builder.go
@@ -11,6 +11,7 @@ import (
 	"github.com/CherryHQ/stella/internal/config"
 	oauth "github.com/CherryHQ/stella/internal/credentials/oauth"
 	"github.com/CherryHQ/stella/internal/memory"
+	"github.com/CherryHQ/stella/internal/skills"
 	skillstool "github.com/CherryHQ/stella/internal/tools/skills"
 	coreagent "github.com/CherryHQ/stella/pkg/agent"
 	"github.com/CherryHQ/stella/pkg/hooks"
@@ -195,10 +196,10 @@ func newRunnerFunc(cfg runnerBuilderConfig) NewRunnerFunc {
 			// host path the model could leak or fail to resolve.
 			stellaHome := config.StellaHome()
 			toolProjectRoot := projectRoot
-			// layout is rooted at the canonicalized sandbox paths so the host→view
-			// remap below matches; until ResolvePaths succeeds, fall back to the raw
-			// user home (the sandbox session fails downstream anyway).
-			layout := skillDiskLayout(SystemDBSkillsDir(stellaHome), cfg.Snap.Workspace, UserDataDir(userRoot), userRoot)
+			// Until ResolvePaths succeeds the view has no roots (Isolated drops every
+			// skill_dir), so the layout is inert; keep it empty to match that intent
+			// rather than emit dirs that would never be remapped.
+			layout := skills.SkillDiskLayout{}
 			view := skillstool.SkillDirView{Isolated: true}
 			if resolved, err := sandbox.ResolvePaths(sandboxCfg); err == nil {
 				stellaHome = resolved.StellaHome

--- a/internal/agent/sandbox/env.go
+++ b/internal/agent/sandbox/env.go
@@ -20,12 +20,23 @@ import (
 func runnerFilesystemPolicy(paths Paths, cfg Config) pkgsandbox.FilesystemPolicy {
 	principalDir, id := misePrincipal(cfg)
 	return pkgsandbox.FilesystemPolicy{
-		WorkspaceRoot:  paths.WorkspaceRoot,
-		WorkingDir:     paths.WorkDir,
-		UserDataDir:    userDataDirHost(paths, cfg),
-		AgentSkillsDir: agentSkillsDirHost(paths),
-		TempDirHost:    userTempDir(principalDir, id),
+		WorkspaceRoot:     paths.WorkspaceRoot,
+		WorkingDir:        paths.WorkDir,
+		UserDataDir:       userDataDirHost(paths, cfg),
+		AgentSkillsDir:    agentSkillsDirHost(paths),
+		SystemDBSkillsDir: systemDBSkillsDirHost(paths),
+		TempDirHost:       userTempDir(principalDir, id),
 	}
+}
+
+// systemDBSkillsDirHost returns the host path of the DB-installed system-scope
+// skills dir, STELLA_HOME/.agents/db-skills (a sibling of the shipped built-ins).
+// Isolating backends mount it read-only at /opt/stella/db-skills.
+func systemDBSkillsDirHost(paths Paths) string {
+	if paths.StellaHome == "" {
+		return ""
+	}
+	return filepath.Join(paths.StellaHome, ".agents", "db-skills")
 }
 
 // agentSkillsDirHost returns the host path of the admin-managed, agent-bound

--- a/internal/agent/sandbox/skill_view.go
+++ b/internal/agent/sandbox/skill_view.go
@@ -30,10 +30,16 @@ type SkillView struct {
 	// mapping onto /workspace.
 	AgentSkillsHost string
 	AgentSkillsView string
-	UserDataHost    string
-	UserDataView    string
-	WorkspaceHost   string
-	WorkspaceView   string
+	// SystemDBSkillsHost/View map the DB-installed system skills dir
+	// (STELLA_HOME/.agents/db-skills), a sibling of the shipped built-ins. It gets
+	// its own fixed /opt/stella/db-skills mount rather than mixing into the
+	// built-in system skills view.
+	SystemDBSkillsHost string
+	SystemDBSkillsView string
+	UserDataHost       string
+	UserDataView       string
+	WorkspaceHost      string
+	WorkspaceView      string
 }
 
 // ResolveSkillView returns the skill-root remapping for cfg's active backend:
@@ -46,20 +52,24 @@ func ResolveSkillView(ctx context.Context, cfg Config, paths Paths) SkillView {
 	backend := resolveBackendName(ctx, cfg)
 	systemSkillsHost := filepath.Join(paths.StellaHome, ".agents", "skills")
 	agentSkillsHost := agentSkillsDirHost(paths)
+	systemDBSkillsHost := systemDBSkillsDirHost(paths)
 	v := SkillView{
-		SystemSkillsHost: systemSkillsHost,
-		SystemSkillsView: systemSkillsHost,
-		AgentSkillsHost:  agentSkillsHost,
-		AgentSkillsView:  agentSkillsHost,
-		UserDataHost:     paths.UserDataDir,
-		UserDataView:     paths.UserDataDir,
-		WorkspaceHost:    paths.WorkspaceRoot,
-		WorkspaceView:    paths.WorkspaceRoot,
+		SystemSkillsHost:   systemSkillsHost,
+		SystemSkillsView:   systemSkillsHost,
+		AgentSkillsHost:    agentSkillsHost,
+		AgentSkillsView:    agentSkillsHost,
+		SystemDBSkillsHost: systemDBSkillsHost,
+		SystemDBSkillsView: systemDBSkillsHost,
+		UserDataHost:       paths.UserDataDir,
+		UserDataView:       paths.UserDataDir,
+		WorkspaceHost:      paths.WorkspaceRoot,
+		WorkspaceView:      paths.WorkspaceRoot,
 	}
 	if isolatingBackend(backend) {
 		v.Isolated = true
 		v.SystemSkillsView = filepath.Join(pkgsandbox.MountStellaHome, ".agents", "skills")
 		v.AgentSkillsView = pkgsandbox.MountAgentSkills
+		v.SystemDBSkillsView = pkgsandbox.MountSystemDBSkills
 		v.UserDataView = pkgsandbox.MountUserData
 		v.WorkspaceView = pkgsandbox.MountWorkspace
 	}

--- a/internal/agent/workspace.go
+++ b/internal/agent/workspace.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/CherryHQ/stella/internal/skills"
 )
 
 // The on-disk layout is user-first (#442): a principal — a user, or a channel
@@ -137,6 +139,49 @@ func UserAssetsDir(userHome string) string {
 // UserSkillsDir returns the user-level skills directory within a user home.
 func UserSkillsDir(userHome string) string {
 	return filepath.Join(userHome, ".agents", "skills")
+}
+
+// SystemDBSkillsDir returns the directory holding DB-installed system-scope
+// skills, a sibling of the shipped built-in skills dir (UserSkillsDir(base),
+// read by ListSystemSkills). Keeping them apart is load-bearing: SyncAllToDisk
+// deletes disk files absent from the DB, so mirroring DB system skills into the
+// built-in dir would wipe the built-ins (they are not DB rows). Isolating
+// backends mount it read-only.
+func SystemDBSkillsDir(base string) string {
+	return filepath.Join(base, ".agents", "db-skills")
+}
+
+// skillDiskLayout assembles the per-scope skill layout under the given roots.
+// An empty root zeroes its scope so SkillDiskLayout.BaseDir returns "" there.
+func skillDiskLayout(systemDB, agentRoot, userDataDir, userAgentRoot string) skills.SkillDiskLayout {
+	l := skills.SkillDiskLayout{SystemDB: systemDB}
+	if agentRoot != "" {
+		l.Agent = UserSkillsDir(agentRoot)
+	}
+	if userDataDir != "" {
+		l.User = UserSkillsDir(userDataDir)
+	}
+	if userAgentRoot != "" {
+		l.UserAgent = UserSkillsDir(userAgentRoot)
+	}
+	return l
+}
+
+// WriterSkillDiskLayout builds the layout the disk-mirroring writer uses, rooted
+// at base (config.StellaHome()). An empty userID/agentID drops the scopes that
+// need it, so those skills are not mirrored to disk.
+func WriterSkillDiskLayout(base, userID, agentID string) skills.SkillDiskLayout {
+	var agentRoot, userDataDir, userAgentRoot string
+	if agentID != "" {
+		agentRoot = AgentWorkspaceDir(base, agentID)
+	}
+	if userID != "" {
+		userDataDir = UserDataDir(UserHomeDir(base, userID))
+	}
+	if userID != "" && agentID != "" {
+		userAgentRoot = UserAgentDir(base, userID, agentID)
+	}
+	return skillDiskLayout(SystemDBSkillsDir(base), agentRoot, userDataDir, userAgentRoot)
 }
 
 // SaveAsset writes data to assetsDir with a timestamp-prefixed filename to avoid

--- a/internal/reflect/conversation_review.go
+++ b/internal/reflect/conversation_review.go
@@ -95,7 +95,7 @@ func (s *Service) newConversationReviewer(ctx context.Context, snap *config.Snap
 	return newReviewer(reviewerConfig{
 		Stream:         stream,
 		Model:          model,
-		SkillsTool:     skillstool.NewTool(s.skillStore, "", snap.Workspace, "", userSkillsDir(snap.Workspace, userID)),
+		SkillsTool:     skillstool.NewTool(s.skillStore, "", "").WithSkillDiskLayout(agent.WriterSkillDiskLayout(snap.Workspace, userID, snap.AgentID)),
 		MemoryTool:     memory.BuildTool(s.memory, memory.WithActionsOnly("profile_get", "profile_update")),
 		ExistingSkills: loadExistingSkillSummaries(context.Background(), s.skillStore, userID),
 		CurrentProfile: profile,
@@ -120,11 +120,6 @@ func loadExistingSkillSummaries(ctx context.Context, store pkgplugins.SkillStore
 		}
 	}
 	return entries
-}
-
-func userSkillsDir(workspace string, userID string) string {
-	// User skills live under the shared user-data root (data/, mounted as /user).
-	return agent.UserSkillsDir(agent.UserDataDir(agent.UserHomeDir(workspace, userID)))
 }
 
 func (s *Service) notifyReviewResult(ctx context.Context, userID string, result reviewResult) {

--- a/internal/reflect/conversation_review.go
+++ b/internal/reflect/conversation_review.go
@@ -11,6 +11,7 @@ import (
 	"github.com/CherryHQ/stella/internal/agent"
 	"github.com/CherryHQ/stella/internal/config"
 	"github.com/CherryHQ/stella/internal/memory"
+	coreskills "github.com/CherryHQ/stella/internal/skills"
 	skillstool "github.com/CherryHQ/stella/internal/tools/skills"
 	"github.com/CherryHQ/stella/pkg/ai"
 	pkgchannel "github.com/CherryHQ/stella/pkg/channel"
@@ -95,11 +96,25 @@ func (s *Service) newConversationReviewer(ctx context.Context, snap *config.Snap
 	return newReviewer(reviewerConfig{
 		Stream:         stream,
 		Model:          model,
-		SkillsTool:     skillstool.NewTool(s.skillStore, "", "").WithSkillDiskLayout(agent.WriterSkillDiskLayout(snap.Workspace, userID, snap.AgentID)),
+		SkillsTool:     skillstool.NewTool(s.skillStore, "", "").WithSkillDiskLayout(reviewSkillLayout(snap.Workspace, userID)),
 		MemoryTool:     memory.BuildTool(s.memory, memory.WithActionsOnly("profile_get", "profile_update")),
 		ExistingSkills: loadExistingSkillSummaries(context.Background(), s.skillStore, userID),
 		CurrentProfile: profile,
 	})
+}
+
+// reviewSkillLayout reproduces the pre-refactor skill_dir mapping for the
+// host-identity reflect tool, where workspace is the agent workspace root (not
+// STELLA_HOME). Skill content is served from the DB; these dirs only label the
+// host-side <skill_dir>. system / DB-system are intentionally absent (the old
+// tool emitted none), and user_agent mirrors user as the old fallback did.
+func reviewSkillLayout(workspace, userID string) coreskills.SkillDiskLayout {
+	userDir := agent.UserSkillsDir(agent.UserDataDir(agent.UserHomeDir(workspace, userID)))
+	return coreskills.SkillDiskLayout{
+		Agent:     agent.UserSkillsDir(workspace),
+		User:      userDir,
+		UserAgent: userDir,
+	}
 }
 
 func loadExistingSkillSummaries(ctx context.Context, store pkgplugins.SkillStore, userID string) []string {

--- a/internal/reflect/conversation_review.go
+++ b/internal/reflect/conversation_review.go
@@ -8,10 +8,8 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
-	"github.com/CherryHQ/stella/internal/agent"
 	"github.com/CherryHQ/stella/internal/config"
 	"github.com/CherryHQ/stella/internal/memory"
-	coreskills "github.com/CherryHQ/stella/internal/skills"
 	skillstool "github.com/CherryHQ/stella/internal/tools/skills"
 	"github.com/CherryHQ/stella/pkg/ai"
 	pkgchannel "github.com/CherryHQ/stella/pkg/channel"
@@ -94,27 +92,16 @@ func (s *Service) newConversationReviewer(ctx context.Context, snap *config.Snap
 		profile, _ = ps.GetProfile(ctx, userID, snap.AgentID)
 	}
 	return newReviewer(reviewerConfig{
-		Stream:         stream,
-		Model:          model,
-		SkillsTool:     skillstool.NewTool(s.skillStore, "", "").WithSkillDiskLayout(reviewSkillLayout(snap.Workspace, userID)),
+		Stream: stream,
+		Model:  model,
+		// No skill-disk layout: reflect runs host-identity and only reads skill
+		// content (from the DB) and writes back through the store, which mirrors to
+		// disk itself. The tool needs no skill-path knowledge here.
+		SkillsTool:     skillstool.NewTool(s.skillStore, "", ""),
 		MemoryTool:     memory.BuildTool(s.memory, memory.WithActionsOnly("profile_get", "profile_update")),
 		ExistingSkills: loadExistingSkillSummaries(context.Background(), s.skillStore, userID),
 		CurrentProfile: profile,
 	})
-}
-
-// reviewSkillLayout reproduces the pre-refactor skill_dir mapping for the
-// host-identity reflect tool, where workspace is the agent workspace root (not
-// STELLA_HOME). Skill content is served from the DB; these dirs only label the
-// host-side <skill_dir>. system / DB-system are intentionally absent (the old
-// tool emitted none), and user_agent mirrors user as the old fallback did.
-func reviewSkillLayout(workspace, userID string) coreskills.SkillDiskLayout {
-	userDir := agent.UserSkillsDir(agent.UserDataDir(agent.UserHomeDir(workspace, userID)))
-	return coreskills.SkillDiskLayout{
-		Agent:     agent.UserSkillsDir(workspace),
-		User:      userDir,
-		UserAgent: userDir,
-	}
 }
 
 func loadExistingSkillSummaries(ctx context.Context, store pkgplugins.SkillStore, userID string) []string {

--- a/internal/skills/skill_layout.go
+++ b/internal/skills/skill_layout.go
@@ -1,0 +1,54 @@
+package skills
+
+import "path/filepath"
+
+// SkillDiskLayout is the single authority for where a DB-backed skill's files
+// live on disk, keyed by scope. The write side (DiskSyncStore mirrors every DB
+// skill to these dirs) and the read side (the skills tool emits the matching
+// <skill_dir>) both resolve through it, so a skill can never materialize at one
+// path while its skill_dir points at another.
+//
+// Roots are supplied by the caller because they legitimately differ: the writer
+// roots from config.StellaHome(); the runner from the sandbox's canonicalized
+// (symlink-evaluated) paths, so the later host→sandbox view match holds. Only
+// the per-scope mapping — which root, and the layout under it — lives here.
+type SkillDiskLayout struct {
+	// SystemDB holds DB-installed system-scope skills. It is deliberately NOT the
+	// shipped built-in dir (those resolve from the filesystem via ResolvedSkill.Dir):
+	// SyncAllToDisk deletes disk files absent from the DB, so mirroring DB system
+	// skills into the built-in dir would wipe the built-ins.
+	SystemDB string
+	// Agent holds system_agent (admin-managed, agent-bound) skills.
+	Agent string
+	// User holds user-level skills, shared across the user's agents.
+	User string
+	// UserAgent holds per-(user, agent) skills.
+	UserAgent string
+}
+
+// BaseDir returns the directory under which scope's skills live (each in a
+// {name}/ subdir), or "" when the scope has no managed disk location.
+func (l SkillDiskLayout) BaseDir(scope string) string {
+	switch scope {
+	case "system":
+		return l.SystemDB
+	case "system_agent":
+		return l.Agent
+	case "user":
+		return l.User
+	case "user_agent":
+		return l.UserAgent
+	default:
+		return ""
+	}
+}
+
+// Dir returns the absolute directory holding skillName's files for scope, or ""
+// when the scope has no managed disk location.
+func (l SkillDiskLayout) Dir(scope, skillName string) string {
+	base := l.BaseDir(scope)
+	if base == "" || skillName == "" {
+		return ""
+	}
+	return filepath.Join(base, skillName)
+}

--- a/internal/skills/skill_layout_test.go
+++ b/internal/skills/skill_layout_test.go
@@ -1,0 +1,40 @@
+package skills
+
+import "testing"
+
+func TestSkillDiskLayout_BaseDirByScope(t *testing.T) {
+	l := SkillDiskLayout{
+		SystemDB:  "/base/.agents/db-skills",
+		Agent:     "/base/agents/a1/.agents/skills",
+		User:      "/base/users/u1/data/.agents/skills",
+		UserAgent: "/base/users/u1/agents/a1/.agents/skills",
+	}
+	cases := map[string]string{
+		"system":       l.SystemDB,
+		"system_agent": l.Agent,
+		"user":         l.User,
+		"user_agent":   l.UserAgent,
+		"project":      "", // not a disk-managed scope
+		"":             "",
+	}
+	for scope, want := range cases {
+		if got := l.BaseDir(scope); got != want {
+			t.Errorf("BaseDir(%q) = %q, want %q", scope, got, want)
+		}
+	}
+}
+
+func TestSkillDiskLayout_Dir(t *testing.T) {
+	l := SkillDiskLayout{User: "/base/users/u1/data/.agents/skills"}
+
+	if got, want := l.Dir("user", "demo"), "/base/users/u1/data/.agents/skills/demo"; got != want {
+		t.Errorf("Dir(user, demo) = %q, want %q", got, want)
+	}
+	// Unmapped scope and empty name both yield "" — no false path is emitted.
+	if got := l.Dir("system", "demo"); got != "" {
+		t.Errorf("Dir(system, demo) = %q, want \"\" (zero-value scope)", got)
+	}
+	if got := l.Dir("user", ""); got != "" {
+		t.Errorf("Dir(user, \"\") = %q, want \"\"", got)
+	}
+}

--- a/internal/tools/skills/skilldirview_test.go
+++ b/internal/tools/skills/skilldirview_test.go
@@ -9,15 +9,17 @@ import (
 // isolatingView mirrors what runner_builder builds for the bwrap backend.
 func isolatingView() SkillDirView {
 	return SkillDirView{
-		Isolated:         true,
-		SystemSkillsHost: "/srv/.stella/.agents/skills",
-		SystemSkillsView: "/opt/stella/.agents/skills",
-		AgentSkillsHost:  "/srv/.stella/agents/a1/.agents/skills",
-		AgentSkillsView:  "/opt/stella/agent-skills",
-		UserDataHost:     "/srv/.stella/users/u1/data",
-		UserDataView:     "/user",
-		WorkspaceHost:    "/srv/.stella/users/u1/agents/a1",
-		WorkspaceView:    "/workspace",
+		Isolated:           true,
+		SystemSkillsHost:   "/srv/.stella/.agents/skills",
+		SystemSkillsView:   "/opt/stella/.agents/skills",
+		AgentSkillsHost:    "/srv/.stella/agents/a1/.agents/skills",
+		AgentSkillsView:    "/opt/stella/agent-skills",
+		SystemDBSkillsHost: "/srv/.stella/.agents/db-skills",
+		SystemDBSkillsView: "/opt/stella/db-skills",
+		UserDataHost:       "/srv/.stella/users/u1/data",
+		UserDataView:       "/user",
+		WorkspaceHost:      "/srv/.stella/users/u1/agents/a1",
+		WorkspaceView:      "/workspace",
 	}
 }
 
@@ -33,6 +35,7 @@ func TestSkillDirView_remapsReachableTiers(t *testing.T) {
 		{"project", "/srv/.stella/users/u1/agents/a1/projects/p1/.agents/skills/baz", "/workspace/projects/p1/.agents/skills/baz"},
 		{"workspace-root", "/srv/.stella/users/u1/agents/a1/.agents/skills/qux", "/workspace/.agents/skills/qux"},
 		{"agent", "/srv/.stella/agents/a1/.agents/skills/agentlevel", "/opt/stella/agent-skills/agentlevel"},
+		{"system-db", "/srv/.stella/.agents/db-skills/installed", "/opt/stella/db-skills/installed"},
 	}
 	for _, c := range cases {
 		if got := v.apply(c.host); got != c.want {

--- a/internal/tools/skills/tool.go
+++ b/internal/tools/skills/tool.go
@@ -205,8 +205,19 @@ func (t *Tool) targetScope(ctx context.Context, rawScope string) (string, error)
 	}
 	switch scope {
 	case skillScopeUser:
-		if t.layout.BaseDir(skillScopeUser) == "" {
-			return "", fmt.Errorf("user skill scope is unavailable")
+		// User-scope skills are owned by the requesting user; without a user in
+		// context there is no owner to attribute them to. Where they materialize on
+		// disk is the store's concern (DiskSyncStore), not the tool's — the tool
+		// carries no skill-path knowledge for writes.
+		//
+		// Group sessions deliberately leave the user unset (D9: runtime identity
+		// stays the group, see runtime/chat.go), so user-scope writes are refused
+		// here. That is intentional: the old layout-based gate let them through but
+		// create() then stamped an empty owner — which fails late on the user_id
+		// foreign key under normal enforcement, or (without it) leaves a dead row the
+		// store never resolves and DiskSyncStore never materializes. This fails fast.
+		if memory.UserIDFromContext(ctx) == "" {
+			return "", fmt.Errorf("user skill scope is unavailable without a user context")
 		}
 		return scope, nil
 	case skillScopeAgent:

--- a/internal/tools/skills/tool.go
+++ b/internal/tools/skills/tool.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/CherryHQ/stella/internal/memory"
+	coreskills "github.com/CherryHQ/stella/internal/skills"
 	pkgplugins "github.com/CherryHQ/stella/pkg/plugins"
 	"github.com/CherryHQ/stella/pkg/tools"
 )
@@ -74,28 +75,31 @@ var skillsInputSchema = func() map[string]any {
 }()
 
 type Tool struct {
-	svc           *Service
-	store         pkgplugins.SkillStore
-	stellaHome    string
-	agentRoot     string
-	projectRoot   string
-	userSkillsDir string
-	// userAgentSkillsDir is the per-(user, agent) skills dir (the agent workspace,
-	// mounted as /workspace). user_agent skills live here, not under the shared
-	// userSkillsDir. Empty falls back to userSkillsDir (non-sandbox callers).
-	userAgentSkillsDir string
-	view               SkillDirView
+	svc         *Service
+	store       pkgplugins.SkillStore
+	stellaHome  string
+	projectRoot string
+	// layout is the single authority for where a DB-backed skill's files live on
+	// disk, by scope; it must agree with the write side that materialized them.
+	layout coreskills.SkillDiskLayout
+	view   SkillDirView
 }
 
-func NewTool(store pkgplugins.SkillStore, stellaHome, agentRoot, projectRoot, userSkillsDir string) *Tool {
+func NewTool(store pkgplugins.SkillStore, stellaHome, projectRoot string) *Tool {
 	return &Tool{
-		svc:           NewService(store, stellaHome),
-		store:         store,
-		stellaHome:    stellaHome,
-		agentRoot:     agentRoot,
-		projectRoot:   projectRoot,
-		userSkillsDir: userSkillsDir,
+		svc:         NewService(store, stellaHome),
+		store:       store,
+		stellaHome:  stellaHome,
+		projectRoot: projectRoot,
 	}
+}
+
+// WithSkillDiskLayout sets where DB-backed skills live on disk, by scope. The
+// emitted <skill_dir> for a DB skill comes from here, so it must match the dirs
+// the disk-mirroring writer used. The zero value emits no dir for DB skills.
+func (t *Tool) WithSkillDiskLayout(l coreskills.SkillDiskLayout) *Tool {
+	t.layout = l
+	return t
 }
 
 // WithSkillDirView sets how host skill directories are remapped to the
@@ -103,14 +107,6 @@ func NewTool(store pkgplugins.SkillStore, stellaHome, agentRoot, projectRoot, us
 // emits host paths, which is correct for host-execution and non-sandbox callers.
 func (t *Tool) WithSkillDirView(v SkillDirView) *Tool {
 	t.view = v
-	return t
-}
-
-// WithUserAgentSkillsDir sets the host dir for user_agent-scoped skills (the
-// agent workspace, mounted as /workspace), distinct from the shared user skills
-// dir. Without it, user_agent skill_dir falls back to the user skills dir.
-func (t *Tool) WithUserAgentSkillsDir(dir string) *Tool {
-	t.userAgentSkillsDir = dir
 	return t
 }
 
@@ -131,6 +127,11 @@ type SkillDirView struct {
 	// in the user-independent agent definition tree, outside the two roots.
 	AgentSkillsHost string
 	AgentSkillsView string
+	// SystemDBSkillsHost/View map the DB-installed system skills dir (a sibling of
+	// the shipped built-ins under STELLA_HOME), mounted at its own fixed path
+	// (/opt/stella/db-skills); the built-ins map via SystemSkillsHost/View.
+	SystemDBSkillsHost string
+	SystemDBSkillsView string
 	// UserData and Workspace are full binds, so their whole root maps (this lets
 	// project skills under <workspace>/projects/<id>/.agents/skills map too).
 	UserDataHost  string
@@ -152,6 +153,7 @@ func (v SkillDirView) apply(hostDir string) string {
 		{v.UserDataHost, v.UserDataView},
 		{v.SystemSkillsHost, v.SystemSkillsView},
 		{v.AgentSkillsHost, v.AgentSkillsView},
+		{v.SystemDBSkillsHost, v.SystemDBSkillsView},
 	} {
 		if m[0] == "" {
 			continue
@@ -179,42 +181,6 @@ const (
 	skillScopeAgent = "user_agent"
 )
 
-// skillDirForScope returns the absolute host path to the skill's directory so
-// agents can execute scripts directly. Returns empty string if the path cannot
-// be determined.
-func (t *Tool) skillDirForScope(scope, agentID string, userID string, skillName string) string {
-	switch scope {
-	case "system":
-		if t.stellaHome == "" {
-			return ""
-		}
-		return filepath.Join(t.stellaHome, ".agents", "skills", skillName)
-	case "system_agent":
-		if t.agentRoot == "" {
-			return ""
-		}
-		return filepath.Join(t.agentRoot, ".agents", "skills", skillName)
-	case "user":
-		if t.userSkillsDir == "" {
-			return ""
-		}
-		return filepath.Join(t.userSkillsDir, skillName)
-	case "user_agent":
-		// user_agent skills live in the agent workspace (/workspace), not the
-		// shared user dir; fall back to the user dir for non-sandbox callers.
-		dir := t.userAgentSkillsDir
-		if dir == "" {
-			dir = t.userSkillsDir
-		}
-		if dir == "" {
-			return ""
-		}
-		return filepath.Join(dir, skillName)
-	default:
-		return ""
-	}
-}
-
 // errProjectScopeWriteRejected is the error returned when a write action is attempted on project scope.
 const errProjectScopeMsg = "scope=project is not supported for write operations — project skills live in {PROJECT_ROOT}/.agents/skills and come with the repo; edit the files directly in git"
 
@@ -239,7 +205,7 @@ func (t *Tool) targetScope(ctx context.Context, rawScope string) (string, error)
 	}
 	switch scope {
 	case skillScopeUser:
-		if t.userSkillsDir == "" {
+		if t.layout.BaseDir(skillScopeUser) == "" {
 			return "", fmt.Errorf("user skill scope is unavailable")
 		}
 		return scope, nil
@@ -247,23 +213,6 @@ func (t *Tool) targetScope(ctx context.Context, rawScope string) (string, error)
 		return scope, nil
 	default:
 		return "", fmt.Errorf("unsupported scope %q", scope)
-	}
-}
-
-// targetSkillsDir returns the scope and skill directory for a writable scope.
-// Kept for backward compatibility; most callers only need the scope now.
-func (t *Tool) targetSkillsDir(ctx context.Context, rawScope string) (string, string, error) {
-	scope, err := t.targetScope(ctx, rawScope)
-	if err != nil {
-		return "", "", err
-	}
-	switch scope {
-	case skillScopeUser:
-		return scope, t.userSkillsDir, nil
-	case skillScopeAgent:
-		return scope, filepath.Join(t.agentRoot, ".agents", "skills"), nil
-	default:
-		return "", "", fmt.Errorf("unsupported scope %q", scope)
 	}
 }
 
@@ -330,11 +279,12 @@ func (t *Tool) load(ctx context.Context, args map[string]any) (string, error) {
 		path = pkgplugins.SkillMainFile
 	}
 
-	// For DB skills without a dir from the service, try to resolve the disk path.
+	// For DB skills without a dir from the service, resolve the disk path the
+	// writer materialized them to (the layout is the shared authority).
 	if skillDir == "" {
 		rs, _ := t.svc.Resolve(ctx, name, vc, projectRoot)
 		if rs != nil {
-			skillDir = t.skillDirForScope(rs.Scope, rs.AgentID, rs.UserID, rs.Name)
+			skillDir = t.layout.Dir(rs.Scope, rs.Name)
 		}
 	}
 

--- a/internal/tools/skills/tool_test.go
+++ b/internal/tools/skills/tool_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/CherryHQ/stella/internal/config"
 	appdb "github.com/CherryHQ/stella/internal/db"
 	"github.com/CherryHQ/stella/internal/memory"
-	coreskills "github.com/CherryHQ/stella/internal/skills"
 	"github.com/CherryHQ/stella/internal/store"
 	"github.com/CherryHQ/stella/pkg/db/sqlc"
 	pkgplugins "github.com/CherryHQ/stella/pkg/plugins"
@@ -349,9 +348,8 @@ func TestRemoveInvalidName(t *testing.T) {
 func TestTargetScopeDefaultsToUser(t *testing.T) {
 	store, _, _ := newTestSkillStore(t)
 
-	tool := NewTool(store, "/tmp/stella", "").
-		WithSkillDiskLayout(coreskills.SkillDiskLayout{User: t.TempDir()})
-	scope, err := tool.targetScope(context.Background(), "")
+	tool := NewTool(store, "/tmp/stella", "")
+	scope, err := tool.targetScope(ctxWithUser("7", "agent-1"), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -360,10 +358,24 @@ func TestTargetScopeDefaultsToUser(t *testing.T) {
 	}
 }
 
-func TestTargetScopeUserUnavailableWithoutLayout(t *testing.T) {
+func TestTargetScopeRequiresUserContext(t *testing.T) {
 	tool := NewTool(nil, "/tmp/stella", "")
 	if _, err := tool.targetScope(context.Background(), ""); err == nil {
-		t.Fatal("expected error when user scope has no disk location")
+		t.Fatal("expected error for user scope without a user in context")
+	}
+}
+
+// A group turn carries an agent but no user (D9 keeps identity as the group):
+// user-scope writes are refused (no owner), while the agent scope still works.
+func TestTargetScopeGroupContext(t *testing.T) {
+	tool := NewTool(nil, "/tmp/stella", "")
+	groupCtx := memory.WithAgentID(context.Background(), "agent-1")
+
+	if _, err := tool.targetScope(groupCtx, "user"); err == nil {
+		t.Fatal("expected user scope to be refused in a group (no user) context")
+	}
+	if scope, err := tool.targetScope(groupCtx, "agent"); err != nil || scope != skillScopeAgent {
+		t.Fatalf("agent scope in group context = (%q, %v), want (%q, nil)", scope, err, skillScopeAgent)
 	}
 }
 
@@ -755,8 +767,7 @@ func TestInstallFromLocalDirViaStore(t *testing.T) {
 	store, userID, agentID := newTestSkillStore(t)
 	ctx := ctxWithUser(userID, agentID)
 
-	userSkillsDir := t.TempDir()
-	tool := NewTool(store, "", "").WithSkillDiskLayout(coreskills.SkillDiskLayout{User: userSkillsDir})
+	tool := NewTool(store, "", "")
 	result, err := tool.install(ctx, map[string]any{"source": srcDir})
 	if err != nil {
 		t.Fatalf("install error: %v", err)

--- a/internal/tools/skills/tool_test.go
+++ b/internal/tools/skills/tool_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/CherryHQ/stella/internal/config"
 	appdb "github.com/CherryHQ/stella/internal/db"
 	"github.com/CherryHQ/stella/internal/memory"
+	coreskills "github.com/CherryHQ/stella/internal/skills"
 	"github.com/CherryHQ/stella/internal/store"
 	"github.com/CherryHQ/stella/pkg/db/sqlc"
 	pkgplugins "github.com/CherryHQ/stella/pkg/plugins"
@@ -275,7 +276,7 @@ func ctxWithUser(userID string, agentID string) context.Context {
 }
 
 func TestDefinition(t *testing.T) {
-	tool := NewTool(nil, "/tmp/stella", "/tmp/agents", "", "")
+	tool := NewTool(nil, "/tmp/stella", "")
 	def := tool.Definition()
 
 	if def.Name != "skills" {
@@ -290,7 +291,7 @@ func TestDefinition(t *testing.T) {
 }
 
 func TestExecuteUnknownAction(t *testing.T) {
-	tool := NewTool(nil, "/tmp/stella", "/tmp/agents", "", "")
+	tool := NewTool(nil, "/tmp/stella", "")
 	_, err := tool.Execute(context.Background(), map[string]any{"action": "bogus"})
 	if err == nil {
 		t.Error("expected error for unknown action")
@@ -298,7 +299,7 @@ func TestExecuteUnknownAction(t *testing.T) {
 }
 
 func TestExecuteDispatch(t *testing.T) {
-	tool := NewTool(nil, "/tmp/stella", "/tmp/agents", "", "")
+	tool := NewTool(nil, "/tmp/stella", "")
 	_, err := tool.Execute(context.Background(), map[string]any{"action": "search"})
 	if err == nil {
 		t.Error("expected error for search without query")
@@ -314,7 +315,7 @@ func TestExecuteDispatch(t *testing.T) {
 }
 
 func TestSearchMissingQuery(t *testing.T) {
-	tool := NewTool(nil, "/tmp/stella", "/tmp/agents", "", "")
+	tool := NewTool(nil, "/tmp/stella", "")
 	_, err := tool.search(context.Background(), map[string]any{})
 	if err == nil {
 		t.Error("expected error for missing query")
@@ -322,7 +323,7 @@ func TestSearchMissingQuery(t *testing.T) {
 }
 
 func TestInstallMissingSource(t *testing.T) {
-	tool := NewTool(nil, "/tmp/stella", "/tmp/agents", "", "")
+	tool := NewTool(nil, "/tmp/stella", "")
 	_, err := tool.install(context.Background(), map[string]any{})
 	if err == nil {
 		t.Error("expected error for missing source")
@@ -330,7 +331,7 @@ func TestInstallMissingSource(t *testing.T) {
 }
 
 func TestRemoveMissingName(t *testing.T) {
-	tool := NewTool(nil, "/tmp/stella", "/tmp/agents", "", "")
+	tool := NewTool(nil, "/tmp/stella", "")
 	_, err := tool.remove(context.Background(), map[string]any{})
 	if err == nil {
 		t.Error("expected error for missing name")
@@ -338,55 +339,38 @@ func TestRemoveMissingName(t *testing.T) {
 }
 
 func TestRemoveInvalidName(t *testing.T) {
-	tool := NewTool(nil, "/tmp/stella", "/tmp/agents", "", "")
+	tool := NewTool(nil, "/tmp/stella", "")
 	_, err := tool.remove(context.Background(), map[string]any{"name": "../../../etc"})
 	if err == nil {
 		t.Error("expected error for path traversal name")
 	}
 }
 
-func TestTargetSkillsDirDefaultsToUserScope(t *testing.T) {
-	base := t.TempDir()
-	agentWS := filepath.Join(base, "agents", "agent-1")
-	userSkillsDir := filepath.Join(base, "users", "7", ".agents", "skills")
+func TestTargetScopeDefaultsToUser(t *testing.T) {
+	store, _, _ := newTestSkillStore(t)
 
-	tool := NewTool(nil, "/tmp/stella", agentWS, filepath.Join(base, "project"), userSkillsDir)
-	scope, got, err := tool.targetSkillsDir(context.Background(), "")
+	tool := NewTool(store, "/tmp/stella", "").
+		WithSkillDiskLayout(coreskills.SkillDiskLayout{User: t.TempDir()})
+	scope, err := tool.targetScope(context.Background(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if scope != skillScopeUser {
 		t.Fatalf("scope = %q, want %q", scope, skillScopeUser)
 	}
-	if got != userSkillsDir {
-		t.Errorf("targetSkillsDir() = %q, want %q", got, userSkillsDir)
-	}
 }
 
-func TestTargetSkillsDirAgentScope(t *testing.T) {
-	base := t.TempDir()
-	agentWS := filepath.Join(base, "agents", "agent-1")
-	userSkillsDir := filepath.Join(base, "users", "7", ".agents", "skills")
-
-	tool := NewTool(nil, "/tmp/stella", agentWS, filepath.Join(base, "project"), userSkillsDir)
-	scope, got, err := tool.targetSkillsDir(context.Background(), "agent")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if scope != skillScopeAgent {
-		t.Fatalf("scope = %q, want %q", scope, skillScopeAgent)
-	}
-	want := filepath.Join(agentWS, ".agents", "skills")
-	if got != want {
-		t.Errorf("targetSkillsDir() = %q, want %q", got, want)
+func TestTargetScopeUserUnavailableWithoutLayout(t *testing.T) {
+	tool := NewTool(nil, "/tmp/stella", "")
+	if _, err := tool.targetScope(context.Background(), ""); err == nil {
+		t.Fatal("expected error when user scope has no disk location")
 	}
 }
 
 func TestInstallProjectScopeIsRejected(t *testing.T) {
 	store, _, _ := newTestSkillStore(t)
-	userSkillsDir := t.TempDir()
 
-	tool := NewTool(store, "/tmp/stella", t.TempDir(), t.TempDir(), userSkillsDir)
+	tool := NewTool(store, "/tmp/stella", t.TempDir())
 	_, err := tool.install(context.Background(), map[string]any{
 		"source": t.TempDir(),
 		"scope":  "project",
@@ -401,7 +385,7 @@ func TestInstallProjectScopeIsRejected(t *testing.T) {
 
 func TestInstallRejectsNonStringScope(t *testing.T) {
 	// scope parse happens before store check
-	tool := NewTool(nil, "/tmp/stella", t.TempDir(), t.TempDir(), t.TempDir())
+	tool := NewTool(nil, "/tmp/stella", t.TempDir())
 	_, err := tool.install(context.Background(), map[string]any{
 		"source": t.TempDir(),
 		"scope":  1,
@@ -434,7 +418,7 @@ func TestLoadViaStore(t *testing.T) {
 		t.Fatalf("create skill: %v", err)
 	}
 
-	tool := NewTool(store, "", "", "", "")
+	tool := NewTool(store, "", "")
 
 	t.Run("loads existing skill default path", func(t *testing.T) {
 		result, err := tool.load(ctx, map[string]any{"name": "test-skill"})
@@ -489,7 +473,7 @@ func TestLoadWithPath(t *testing.T) {
 		t.Fatalf("upsert file: %v", err)
 	}
 
-	tool := NewTool(store, "", "", "", "")
+	tool := NewTool(store, "", "")
 	result, err := tool.load(ctx, map[string]any{"name": "multi-file", "path": "references/api.md"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -518,7 +502,7 @@ func TestListViaStore(t *testing.T) {
 		t.Fatalf("create skill: %v", err)
 	}
 
-	tool := NewTool(store, "", "", "", "")
+	tool := NewTool(store, "", "")
 	result, err := tool.list(ctx)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -565,7 +549,7 @@ func TestRemoveViaStore(t *testing.T) {
 		t.Fatalf("create skill: %v", err)
 	}
 
-	tool := NewTool(store, "", "", "", "")
+	tool := NewTool(store, "", "")
 	result, err := tool.remove(ctx, map[string]any{"name": "removable-skill"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -600,7 +584,7 @@ func TestRemoveRespectsScope(t *testing.T) {
 		t.Fatalf("create user_agent skill: %v", err)
 	}
 
-	tool := NewTool(store, "", "", "", "")
+	tool := NewTool(store, "", "")
 
 	// scope=agent must delete the per-agent (user_agent) row, leaving user alive.
 	if _, err := tool.remove(ctx, map[string]any{"name": "dup", "scope": "agent"}); err != nil {
@@ -642,7 +626,7 @@ func TestRemoveScopeNotFound(t *testing.T) {
 		t.Fatalf("create: %v", err)
 	}
 
-	tool := NewTool(store, "", "", "", "")
+	tool := NewTool(store, "", "")
 	_, err := tool.remove(ctx, map[string]any{"name": "only-user", "scope": "agent"})
 	if err == nil {
 		t.Fatal("expected error when scope has no match")
@@ -664,7 +648,7 @@ func TestRemoveRejectsAdminScope(t *testing.T) {
 		t.Fatalf("create system_agent skill: %v", err)
 	}
 
-	tool := NewTool(store, "", "", "", "")
+	tool := NewTool(store, "", "")
 	if _, err := tool.remove(ctx, map[string]any{"name": "shared"}); err == nil {
 		t.Fatal("expected error removing a system_agent skill via the tool")
 	}
@@ -687,7 +671,7 @@ func TestPatchRespectsScope(t *testing.T) {
 		t.Fatalf("create user_agent skill: %v", err)
 	}
 
-	tool := NewTool(store, "", "", "", "")
+	tool := NewTool(store, "", "")
 	if _, err := tool.patch(ctx, map[string]any{"name": "dup", "scope": "user", "status": "deprecated"}); err != nil {
 		t.Fatalf("patch user scope: %v", err)
 	}
@@ -730,7 +714,7 @@ func TestPatchDefaultScopeIsUser(t *testing.T) {
 		t.Fatalf("create disabled user skill: %v", err)
 	}
 
-	tool := NewTool(store, "", "", "", "")
+	tool := NewTool(store, "", "")
 	if _, err := tool.patch(ctx, map[string]any{"name": "dup", "status": "deprecated"}); err != nil {
 		t.Fatalf("patch default scope: %v", err)
 	}
@@ -772,7 +756,7 @@ func TestInstallFromLocalDirViaStore(t *testing.T) {
 	ctx := ctxWithUser(userID, agentID)
 
 	userSkillsDir := t.TempDir()
-	tool := NewTool(store, "", "", "", userSkillsDir)
+	tool := NewTool(store, "", "").WithSkillDiskLayout(coreskills.SkillDiskLayout{User: userSkillsDir})
 	result, err := tool.install(ctx, map[string]any{"source": srcDir})
 	if err != nil {
 		t.Fatalf("install error: %v", err)
@@ -836,7 +820,7 @@ func TestListMergesProjectSkills(t *testing.T) {
 	// Create a project skill with same name as a DB skill to test shadowing.
 	makeProjectSkill(t, projectRoot, "db-skill", "Project override of db-skill")
 
-	tool := NewTool(store, "", "", projectRoot, "")
+	tool := NewTool(store, "", projectRoot)
 	result, err := tool.list(WithProjectRoot(ctx, projectRoot))
 	if err != nil {
 		t.Fatalf("list error: %v", err)
@@ -895,7 +879,7 @@ func TestLoadPrefersProjectSkill(t *testing.T) {
 	// Create a project skill with the same name.
 	makeProjectSkill(t, projectRoot, "shared", "Project version")
 
-	tool := NewTool(store, "", "", projectRoot, "")
+	tool := NewTool(store, "", projectRoot)
 	result, err := tool.load(WithProjectRoot(ctx, projectRoot), map[string]any{"name": "shared"})
 	if err != nil {
 		t.Fatalf("load error: %v", err)
@@ -919,8 +903,7 @@ func TestInstallAgentScope(t *testing.T) {
 	store, userID, agentID := newTestSkillStore(t)
 	ctx := ctxWithUser(userID, agentID)
 
-	userSkillsDir := t.TempDir()
-	tool := NewTool(store, "", t.TempDir(), "", userSkillsDir)
+	tool := NewTool(store, "", "")
 	result, err := tool.install(ctx, map[string]any{"source": srcDir, "scope": "agent"})
 	if err != nil {
 		t.Fatalf("install error: %v", err)

--- a/pkg/sandbox/policy.go
+++ b/pkg/sandbox/policy.go
@@ -34,6 +34,10 @@ const (
 	// dir is the user-independent agent definition tree, not the per-agent
 	// workspace), so it gets its own fixed mount instead of mapping onto /workspace.
 	MountAgentSkills = "/opt/stella/agent-skills"
+	// MountSystemDBSkills is the read-only mount of DB-installed system-scope
+	// skills. They live in a dedicated dir (a sibling of the shipped built-ins
+	// under STELLA_HOME, not mixed into it), so they get their own fixed mount.
+	MountSystemDBSkills = "/opt/stella/db-skills"
 )
 
 // Policy is an immutable, backend-agnostic session policy describing requested limits
@@ -112,6 +116,13 @@ type FilesystemPolicy struct {
 	// leaking. Empty for a session with no agent definition root, and ignored by
 	// the none backend (host paths are valid in-sandbox there).
 	AgentSkillsDir string
+
+	// SystemDBSkillsDir is the host path of the DB-installed system-scope skills
+	// dir (STELLA_HOME/.agents/db-skills). Isolating backends mount it read-only
+	// at MountSystemDBSkills (/opt/stella/db-skills) so a system skill installed
+	// via Settings can still load and run its files without the host path leaking.
+	// Ignored by the none backend (host paths are valid in-sandbox there).
+	SystemDBSkillsDir string
 
 	// AgentPrivateDir is a legacy sibling-hiding hint, left empty in the two-root
 	// layout: the agent workspace IS the per-agent dir (WorkspaceRoot), so siblings

--- a/plugins/sandbox/docker/session.go
+++ b/plugins/sandbox/docker/session.go
@@ -359,6 +359,21 @@ func (f *dockerFactory) configureVolumeMounts(opts *dockerclient.CreateOptions, 
 			logSkippedSandboxMount(DockerSandboxModeVolume, as, "agent skills dir is outside STELLA_HOME and cannot be mounted from the named volume")
 		}
 	}
+	// DB-installed system skills → /opt/stella/db-skills (RO). Also under
+	// STELLA_HOME, so it comes from the same named volume at its subpath.
+	if sd := policy.Filesystem.SystemDBSkillsDir; sd != "" && dirExists(sd) {
+		if subpath, ok := relativePathWithin(f.cfg.StellaHome, sd); ok && subpath != "." {
+			opts.ExtraMounts = append(opts.ExtraMounts, dockerclient.Mount{
+				HostPath:      f.cfg.StellaHomeVolume,
+				ContainerPath: sandboxpkg.MountSystemDBSkills,
+				ReadOnly:      true,
+				Type:          dockerclient.MountTypeVolume,
+				VolumeSubpath: filepath.ToSlash(subpath),
+			})
+		} else {
+			logSkippedSandboxMount(DockerSandboxModeVolume, sd, "system DB skills dir is outside STELLA_HOME and cannot be mounted from the named volume")
+		}
+	}
 	mountedExtraReadOnly := []string{}
 	for _, hostPath := range policy.Filesystem.ExtraReadOnlyMounts {
 		subpath, ok := relativePathWithin(f.cfg.StellaHome, hostPath)
@@ -413,6 +428,18 @@ func (f *dockerFactory) configureBindMounts(opts *dockerclient.CreateOptions, po
 			})
 		} else {
 			logSkippedSandboxMount(f.cfg.RuntimeMode, as, "agent skills dir is not visible to the Docker daemon")
+		}
+	}
+	// DB-installed system skills → /opt/stella/db-skills (RO).
+	if sd := policy.Filesystem.SystemDBSkillsDir; sd != "" && dirExists(sd) {
+		if daemonPath, ok := f.cfg.daemonPath(sd); ok {
+			opts.ExtraMounts = append(opts.ExtraMounts, dockerclient.Mount{
+				HostPath:      daemonPath,
+				ContainerPath: sandboxpkg.MountSystemDBSkills,
+				ReadOnly:      true,
+			})
+		} else {
+			logSkippedSandboxMount(f.cfg.RuntimeMode, sd, "system DB skills dir is not visible to the Docker daemon")
 		}
 	}
 	stellaHome := f.cfg.StellaHome

--- a/plugins/sandbox/local/session.go
+++ b/plugins/sandbox/local/session.go
@@ -87,17 +87,18 @@ func (f *Factory) CreateSession(_ context.Context, policy sandboxpkg.Policy) (sa
 		return nil, fmt.Errorf("local: create session tmp: %w", err)
 	}
 	s := &localSession{
-		id:                sessionID,
-		policy:            policy,
-		realRoot:          realRoot,
-		sandboxRoot:       sandboxRoot,
-		userDataReal:      userDataReal,
-		userDataSandbox:   userDataSandbox,
-		agentSkillsReal:   policy.Filesystem.AgentSkillsDir,
-		stellaHomeHost:    hostStellaHome,
-		stellaHomeSandbox: adjustStellaHome(hostStellaHome),
-		tmpMounts:         tmpMounts,
-		done:              make(chan struct{}),
+		id:                 sessionID,
+		policy:             policy,
+		realRoot:           realRoot,
+		sandboxRoot:        sandboxRoot,
+		userDataReal:       userDataReal,
+		userDataSandbox:    userDataSandbox,
+		agentSkillsReal:    policy.Filesystem.AgentSkillsDir,
+		systemDBSkillsReal: policy.Filesystem.SystemDBSkillsDir,
+		stellaHomeHost:     hostStellaHome,
+		stellaHomeSandbox:  adjustStellaHome(hostStellaHome),
+		tmpMounts:          tmpMounts,
+		done:               make(chan struct{}),
 	}
 	sandboxpkg.LogSessionCreated(sessionID, "local", policy)
 	return s, nil
@@ -249,21 +250,22 @@ func remapStellaHomePath(p, hostSH, sandboxSH string) string {
 // localSession implements sandboxpkg.Session by running commands directly on
 // the host OS with no container isolation.
 type localSession struct {
-	id                string
-	policy            sandboxpkg.Policy
-	realRoot          string     // actual host path (e.g. /home/stella/.stella-dev/...)
-	sandboxRoot       string     // path the agent sees (/workspace on Linux+bwrap, else = realRoot)
-	userDataReal      string     // host path of the shared user-data root, "" when none
-	userDataSandbox   string     // path the agent sees for it (/user on Linux+bwrap, else = userDataReal)
-	agentSkillsReal   string     // host path of the agent-bound (system_agent) skills dir, "" when none
-	stellaHomeHost    string     // host-side STELLA_HOME for bwrap mounts
-	stellaHomeSandbox string     // agent's view of STELLA_HOME (/opt/stella on Linux+bwrap, else = host)
-	tmpMounts         []tmpMount // sandbox temp paths mapped to real host dirs (/tmp, /var/tmp)
-	done              chan struct{}
-	doneOnce          sync.Once
-	mu                sync.RWMutex
-	closed            bool
-	procs             []*localProcess
+	id                 string
+	policy             sandboxpkg.Policy
+	realRoot           string     // actual host path (e.g. /home/stella/.stella-dev/...)
+	sandboxRoot        string     // path the agent sees (/workspace on Linux+bwrap, else = realRoot)
+	userDataReal       string     // host path of the shared user-data root, "" when none
+	userDataSandbox    string     // path the agent sees for it (/user on Linux+bwrap, else = userDataReal)
+	agentSkillsReal    string     // host path of the agent-bound (system_agent) skills dir, "" when none
+	systemDBSkillsReal string     // host path of the DB-installed system skills dir, "" when none
+	stellaHomeHost     string     // host-side STELLA_HOME for bwrap mounts
+	stellaHomeSandbox  string     // agent's view of STELLA_HOME (/opt/stella on Linux+bwrap, else = host)
+	tmpMounts          []tmpMount // sandbox temp paths mapped to real host dirs (/tmp, /var/tmp)
+	done               chan struct{}
+	doneOnce           sync.Once
+	mu                 sync.RWMutex
+	closed             bool
+	procs              []*localProcess
 }
 
 func (s *localSession) Policy() sandboxpkg.Policy {
@@ -524,6 +526,11 @@ func (s *localSession) stellaHomeSubdirs() [][2]string {
 	// subtrees above). Mapped here so the file tools can read it and reject writes.
 	if s.agentSkillsReal != "" {
 		out = append(out, [2]string{sandboxpkg.MountAgentSkills, filepath.Clean(s.agentSkillsReal)})
+	}
+	// DB-installed system skills: same treatment — a read-only subtree at its own
+	// fixed path, kept separate from the shipped built-ins under STELLA_HOME.
+	if s.systemDBSkillsReal != "" {
+		out = append(out, [2]string{sandboxpkg.MountSystemDBSkills, filepath.Clean(s.systemDBSkillsReal)})
 	}
 	return out
 }

--- a/plugins/sandbox/local/session_linux.go
+++ b/plugins/sandbox/local/session_linux.go
@@ -304,6 +304,11 @@ func wrapCommand(policy sandboxpkg.Policy, sandboxCwd string, tmpMounts []tmpMou
 	if as := policy.Filesystem.AgentSkillsDir; as != "" {
 		bwrapArgs = appendRoBindIfExists(bwrapArgs, as, sandboxpkg.MountAgentSkills)
 	}
+	// DB-installed system skills: read-only at a fixed path, kept separate from the
+	// shipped built-ins so a system skill installed via Settings stays loadable.
+	if sd := policy.Filesystem.SystemDBSkillsDir; sd != "" {
+		bwrapArgs = appendRoBindIfExists(bwrapArgs, sd, sandboxpkg.MountSystemDBSkills)
+	}
 	// Extra writable mounts (e.g. an out-of-workspace per-principal cache), layered
 	// above the read-only system installs mounted by appendStellaHomeMounts: bind
 	// each at its STELLA_HOME-remapped sandbox path so writes land in the host tree.

--- a/plugins/sandbox/local/session_test.go
+++ b/plugins/sandbox/local/session_test.go
@@ -488,6 +488,51 @@ func TestAgentSkills_readableButNotWritable(t *testing.T) {
 	}
 }
 
+// TestSystemDBSkills_readableButNotWritable verifies that the DB-installed
+// system skills dir, mounted read-only at /opt/stella/db-skills on an isolating
+// backend, is resolvable for reads and rejected for writes — and stays distinct
+// from the shipped built-in system skills dir under STELLA_HOME.
+func TestSystemDBSkills_readableButNotWritable(t *testing.T) {
+	root := t.TempDir()
+	root, _ = filepath.EvalSymlinks(root)
+	hostSH := t.TempDir()
+	hostSH, _ = filepath.EvalSymlinks(hostSH)
+
+	dbSkills := filepath.Join(hostSH, ".agents", "db-skills")
+	if err := os.MkdirAll(filepath.Join(dbSkills, "demo"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dbSkills, "demo", "SKILL.md"), []byte("# skill"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	s := &localSession{
+		id:                 "test",
+		policy:             sandboxpkg.Policy{Filesystem: sandboxpkg.FilesystemPolicy{WorkspaceRoot: root, WorkingDir: root, SystemDBSkillsDir: dbSkills}},
+		realRoot:           root,
+		sandboxRoot:        root,
+		systemDBSkillsReal: dbSkills,
+		stellaHomeHost:     hostSH,
+		stellaHomeSandbox:  "/opt/stella",
+		done:               make(chan struct{}),
+	}
+
+	sandboxPath := sandboxpkg.MountSystemDBSkills + "/demo/SKILL.md"
+	real, _, err := s.resolvePath(sandboxPath)
+	if err != nil {
+		t.Fatalf("resolvePath rejected system-db-skills read: %v", err)
+	}
+	if want := filepath.Join(dbSkills, "demo", "SKILL.md"); real != want {
+		t.Errorf("resolvePath real = %q, want %q", real, want)
+	}
+	if got := s.toSandboxPath(filepath.Join(dbSkills, "demo")); got != sandboxpkg.MountSystemDBSkills+"/demo" {
+		t.Errorf("toSandboxPath = %q, want %q", got, sandboxpkg.MountSystemDBSkills+"/demo")
+	}
+	if _, err := s.ResolveWritePath(sandboxPath); err == nil {
+		t.Fatal("expected ResolveWritePath to reject system-db-skills path, got nil")
+	}
+}
+
 // TestResolveWritePath_acceptsWorkspace verifies that ResolveWritePath allows
 // paths within the writable workspace root.
 func TestResolveWritePath_acceptsWorkspace(t *testing.T) {


### PR DESCRIPTION
## What

Collapse the per-scope skill on-disk layout into a single `SkillDiskLayout` authority, and fix the concrete `<skill_dir>` mismatch for DB-installed `system`-scope skills.

## Why

`(scope, userID, agentID) → host skill dir` was computed in **three independent places** that had to agree byte-for-byte by hand: the write side (`DiskSyncStore` resolver in `setup_skills.go`), the read side (`runner_builder.go`), and the tool (`skillDirForScope`). Change one and a skill silently materializes at dir A while its `skill_dir` points at dir B.

`system`-scope DB skills were already broken this way: the resolver returned `""` (never materialized), but the tool still emitted `STELLA_HOME/.agents/skills/{name}` — the **shipped built-in dir**, which lacks the DB skill's files and, on a same-name collision, points at the wrong skill entirely.

## How

1. **One authority.** New `internal/skills.SkillDiskLayout` (`BaseDir`/`Dir`) owns the scope→dir mapping. The writer (`agent.WriterSkillDiskLayout`), the runner, and the tool all resolve through it; the three can no longer drift. Roots are still supplied per-caller (writer from `config.StellaHome()`, runner from canonicalized sandbox paths) so the host→sandbox view match keeps working.
2. **Tool stops encoding layout.** `NewTool` drops the four loose dir args for `WithSkillDiskLayout`; `skillDirForScope`/`targetSkillsDir` deleted.
3. **Fix `system` with a dedicated dir.** DB system skills materialize to `STELLA_HOME/.agents/db-skills` (sibling of the built-ins, never mixed in — `SyncAllToDisk`'s orphan deletion would otherwise wipe the built-ins), RO-mounted at `/opt/stella/db-skills` on isolating backends (bwrap + docker volume/bind), and the tool emits the matching `skill_dir`.

Verified: `mise run format && build && test` all green; windows + linux cross-builds clean. Added `SkillDiskLayout` unit tests, a `system-db` view-remap case, and a `SystemDBSkills_readableButNotWritable` session test.

## Refs

- Closes #499
- Parent: #495 · builds on the `system_agent` mount from #496