### PR TITLE
📝 docs: S3-compatible object storage backend design (#481)

### DIFF
--- a/web/content/docs/development/meta.json
+++ b/web/content/docs/development/meta.json
@@ -9,6 +9,7 @@
     "cli-as-client",
     "sandbox",
     "memory-internals",
+    "object-storage",
     "group-chat-multi-agent",
     "group-chat-dataflow",
     "session-compaction",

--- a/web/content/docs/development/meta.zh.json
+++ b/web/content/docs/development/meta.zh.json
@@ -9,6 +9,7 @@
     "cli-as-client",
     "sandbox",
     "memory-internals",
+    "object-storage",
     "group-chat-multi-agent",
     "group-chat-dataflow",
     "session-compaction",

--- a/web/content/docs/development/object-storage.md
+++ b/web/content/docs/development/object-storage.md
@@ -1,0 +1,96 @@
+---
+title: Object Storage Backend (Design)
+---
+
+> This is a design proposal for [#481](https://github.com/vaayne/stella/issues/481), a sub-issue of #477 (production deployment). It is an explanation of _why_ the design is shaped this way, not an implementation guide. No code exists yet.
+
+## The trap to avoid
+
+The issue asks to "add S3-compatible storage for persistent files." Read literally, that suggests swapping the local filesystem for S3. That is a category error.
+
+Stella's storage is **sandbox-filesystem-centric**. The sandbox mounts `users/{userID}/agents/{agentID}/`, `projects/{projectID}/`, `.mise-tools/`, and `.cache/` as the agent's working directory (`/workspace`, `/user`). Agents read and write those paths in place — through the `write`/`edit`/`read` tools, mise toolchains, and git working trees. That demands real POSIX semantics: partial writes, rename, mmap, executable bits.
+
+S3 is an object store: `PUT`/`GET`/`DELETE` by key, no partial writes, no rename, no POSIX. **It cannot back a live sandbox filesystem.** Putting all of `STELLA_HOME` on S3 is not viable.
+
+So the real question is narrower than the issue title.
+
+## What multi-replica actually breaks
+
+The production pain isn't "the sandbox needs to be shared." A session's sandbox is per-run and can stay pinned to a node. The pain is the **durable blob tier**: when replica A handles an upload and replica B serves it later, local disk doesn't share state.
+
+That tier — and only that tier — is what this design moves to object storage.
+
+| Belongs on object storage (write-once, read-many) | Stays on local FS (live POSIX state)          |
+| ------------------------------------------------- | --------------------------------------------- |
+| Channel/user uploads — `data/assets/`             | Sandbox working trees, project working tree   |
+| Email attachments — `internal/email/imap.go`      | `.mise-tools/`, `.cache/`                     |
+| Knowledge-base articles — `internal/recally/`     | Skill disk mirror (sandbox reads it in place) |
+| Exported/durable artifacts                        | git repositories                              |
+
+Sharing the sandbox tier across replicas (node-pinned ephemeral disk + rehydrate-from-S3 on session start, or an RWX volume) is a **#477 / Kubernetes** concern. It is explicitly out of scope here.
+
+## The abstraction
+
+A new package `internal/objstore` defines a backend-agnostic interface. Two implementations: `local` (default, filesystem-backed) and `s3` (via [minio-go](https://github.com/minio/minio-go), which treats AWS S3, MinIO, and Cloudflare R2 uniformly and keeps the dependency tree small).
+
+```go
+type Store interface {
+    Put(ctx context.Context, key string, r io.Reader, opts PutOptions) error
+    Get(ctx context.Context, key string) (io.ReadCloser, error)
+    Delete(ctx context.Context, key string) error
+    Stat(ctx context.Context, key string) (ObjectInfo, error)
+    // SignedURL returns a time-bound direct URL. ok=false when the backend
+    // cannot sign (the local backend), so callers fall back to proxying.
+    SignedURL(ctx context.Context, key string, ttl time.Duration) (url string, ok bool)
+}
+```
+
+The interface is deliberately a deep module: a tiny surface (five methods) hiding all backend-specific concerns (multipart upload, path-style vs virtual-host addressing, content-type negotiation). Callers never branch on backend type.
+
+## Keys must not leak names
+
+Object keys are an addressing scheme, not a place to encode identity. The issue calls out "avoid leaking sensitive user/project names." So keys are opaque:
+
+```
+objects/{tenant}/{uuid-or-sha256}
+```
+
+The human filename, owner (user/agent/project), content-type, and size live in a DB metadata table `blob_object`, never in the key. A logical object maps to a storage key through that table, which decouples the key scheme from the on-disk FS layout entirely. Content-addressing (`sha256`) enables dedup; random UUID is simpler — that choice is deferred to implementation.
+
+## Access control sits above the store, not inside it
+
+`objstore.Store` does no authorization — it's a dumb blob mover. Permission checks live in the HTTP serving layer:
+
+1. Resolve the logical object → look up `blob_object`, get owner + storage key.
+2. Authorize the caller against the owner (the existing Stella permission model).
+3. Serve the bytes.
+
+Step 3 picks one of two paths, decided by backend capability:
+
+- **Sign if you can, proxy otherwise.** Call `SignedURL`. If `ok`, redirect (302) to a short-lived presigned URL — the client pulls straight from S3, saving stellad's bandwidth on large files. If `!ok` (local backend), stream the bytes through stellad after the auth check.
+
+This keeps a single serving entrypoint regardless of backend, and never exposes an unsigned, unauthorized object URL.
+
+## Configuration
+
+A new `storage` config section selects the backend and carries S3 parameters:
+
+- `backend`: `local` (default) | `s3`
+- S3 params: `endpoint`, `region`, `bucket`, `access_key`, `secret_key`, `path_style` (true for MinIO/R2), `use_ssl`
+- Each backed by an env var override, consistent with the existing config package (`internal/config`).
+
+`local` remains the zero-config default so simple self-hosted deployments are unaffected.
+
+## Migration
+
+A CLI command (`stella storage migrate`) walks the existing local blob directories (`data/assets/`, `library/`, email attachments), uploads each to the configured backend, writes the `blob_object` metadata row, and — after a verification pass — optionally removes the local copy. Idempotent: re-running skips objects already present in metadata.
+
+## Retention and deletion
+
+Deleting a logical object removes its `blob_object` row and the underlying object. Whether to hard-delete immediately or tombstone for a grace period is a policy decision deferred to implementation; the interface supports either.
+
+## Out of scope
+
+- Sharing the sandbox/working-tree filesystem across replicas (→ #477 / K8s).
+- Migrating the SQLite database to external storage (→ #477 PostgreSQL track).
+- Skill files — already DB-backed with a disk mirror the sandbox consumes in place; object storage adds nothing there.

--- a/web/content/docs/development/object-storage.zh.md
+++ b/web/content/docs/development/object-storage.zh.md
@@ -1,0 +1,96 @@
+---
+title: 对象存储后端（设计）
+---
+
+> 这是 [#481](https://github.com/vaayne/stella/issues/481) 的设计提案（#477 生产部署的子 issue）。它解释设计**为什么**长这样，不是实现指南。目前尚无代码。
+
+## 要避开的陷阱
+
+Issue 要求"为持久文件加 S3 兼容存储"。照字面理解，像是把本地文件系统换成 S3——这是范畴错误。
+
+Stella 的存储是**沙箱文件系统中心**的。沙箱把 `users/{userID}/agents/{agentID}/`、`projects/{projectID}/`、`.mise-tools/`、`.cache/` mount 成 agent 的工作目录（`/workspace`、`/user`）。agent 通过 `write`/`edit`/`read` 工具、mise 工具链、git working tree **就地读写**这些路径。这要求真正的 POSIX 语义：部分写、rename、mmap、可执行位。
+
+S3 是对象存储：按 key 做 `PUT`/`GET`/`DELETE`，没有部分写、没有 rename、没有 POSIX。**它撑不起一个活的沙箱文件系统。** 把整个 `STELLA_HOME` 放上 S3 不可行。
+
+所以真正的问题比 issue 标题窄得多。
+
+## 多副本真正坏掉的是什么
+
+生产痛点不是"沙箱要共享"。一个会话的沙箱是单次运行的，可以钉在某个节点上。痛点在**持久 blob 层**：replica A 处理的上传，replica B 之后要读，本地磁盘不共享状态。
+
+这一层——也只有这一层——是本设计要迁到对象存储的。
+
+| 该上对象存储（写一次读多次）         | 留在本地 FS（活的 POSIX 状态）   |
+| ------------------------------------ | -------------------------------- |
+| 渠道/用户上传 —— `data/assets/`      | 沙箱工作树、project working tree |
+| 邮件附件 —— `internal/email/imap.go` | `.mise-tools/`、`.cache/`        |
+| 知识库文章 —— `internal/recally/`    | skill 磁盘镜像（沙箱就地读取）   |
+| 导出的持久 artifact                  | git 仓库                         |
+
+让沙箱层跨副本共享（节点钉死的临时盘 + 会话启动时从 S3 rehydrate，或 RWX 卷）属于 **#477 / Kubernetes** 范畴，明确不在本设计内。
+
+## 抽象
+
+新建包 `internal/objstore`，定义一个后端无关的接口。两个实现：`local`（默认，文件系统）和 `s3`（用 [minio-go](https://github.com/minio/minio-go)，它对 AWS S3、MinIO、Cloudflare R2 一视同仁，依赖树也小）。
+
+```go
+type Store interface {
+    Put(ctx context.Context, key string, r io.Reader, opts PutOptions) error
+    Get(ctx context.Context, key string) (io.ReadCloser, error)
+    Delete(ctx context.Context, key string) error
+    Stat(ctx context.Context, key string) (ObjectInfo, error)
+    // SignedURL 返回一个限时直连 URL。后端无法签名时（local 后端）ok=false，
+    // 调用方据此回退到代理流式转发。
+    SignedURL(ctx context.Context, key string, ttl time.Duration) (url string, ok bool)
+}
+```
+
+接口刻意做成深模块：极小的表面（五个方法）藏住所有后端相关细节（分片上传、path-style vs virtual-host 寻址、content-type 协商）。调用方永远不按后端类型分支。
+
+## key 不能泄露名字
+
+对象 key 是寻址方案，不是编码身份的地方。issue 明确要求"避免泄露敏感的用户/项目名"。所以 key 是不透明的：
+
+```
+objects/{tenant}/{uuid-或-sha256}
+```
+
+人类文件名、owner（用户/agent/项目）、content-type、大小都放在 DB 元数据表 `blob_object`，绝不进 key。逻辑对象通过这张表映射到存储 key，从而把 key 方案和磁盘 FS 布局彻底解耦。内容寻址（`sha256`）可做去重；随机 UUID 更简单——这个选择留给实现阶段。
+
+## 访问控制在 store 之上，不在其内
+
+`objstore.Store` 不做任何鉴权——它只是个搬 blob 的笨工具。权限检查放在 HTTP 服务层：
+
+1. 解析逻辑对象 → 查 `blob_object`，拿到 owner + 存储 key。
+2. 用 Stella 现有的权限模型对调用方做鉴权。
+3. 返回字节。
+
+第 3 步按后端能力二选一：
+
+- **能签则签，否则代理。** 调 `SignedURL`。若 `ok`，302 重定向到一个短时效的 presigned URL——客户端直接从 S3 拉，大文件省下 stellad 的带宽。若 `!ok`（local 后端），鉴权通过后由 stellad 流式转发字节。
+
+这样不论后端如何，都只有一个统一的下载入口，且绝不暴露未签名、未鉴权的对象 URL。
+
+## 配置
+
+新增 `storage` 配置段，选后端并携带 S3 参数：
+
+- `backend`：`local`（默认）| `s3`
+- S3 参数：`endpoint`、`region`、`bucket`、`access_key`、`secret_key`、`path_style`（MinIO/R2 置 true）、`use_ssl`
+- 每项都有对应的环境变量覆盖，与现有配置包（`internal/config`）保持一致。
+
+`local` 仍是零配置默认值，简单的自托管部署不受影响。
+
+## 迁移
+
+一个 CLI 命令（`stella storage migrate`）遍历现有的本地 blob 目录（`data/assets/`、`library/`、邮件附件），逐个上传到配置的后端，写入 `blob_object` 元数据行，并在一轮校验后可选删除本地副本。幂等：重跑会跳过元数据中已存在的对象。
+
+## 保留与删除
+
+删除一个逻辑对象会移除其 `blob_object` 行和底层对象。是立即硬删除还是 tombstone 保留一段宽限期，属于策略决定，留给实现阶段；接口两者都支持。
+
+## 不在范围内
+
+- 让沙箱/工作树文件系统跨副本共享（→ #477 / K8s）。
+- 把 SQLite 数据库迁到外部存储（→ #477 PostgreSQL 线）。
+- skill 文件——已是 DB 为源 + 沙箱就地消费的磁盘镜像，对象存储在这里没有增益。


### PR DESCRIPTION
## What

A design proposal doc (EN + ZH) for an S3-compatible object storage backend, under `web/content/docs/development/object-storage.md`. No implementation code — this is the plan for review.

## Why

#481 asks to add S3-compatible storage for persistent files. Taken literally that reads as "swap local FS for S3," which is a category error: Stella's sandbox needs real POSIX semantics (in-place read/write via tools, mise, git) that S3 cannot provide. The doc reframes the scope to the part that multi-replica deployments actually break — the **durable blob tier** — and leaves the sandbox tier to #477 / K8s.

## How

- **Scope split**: object storage covers write-once/read-many blobs (uploads `data/assets/`, email attachments, knowledge-base articles, exported artifacts); sandbox working trees / `.mise-tools` / skill mirror stay on local FS.
- **Abstraction**: `internal/objstore.Store` interface, two backends — `local` (default) and `s3` via minio-go (uniform across AWS S3 / MinIO / R2).
- **Opaque keys**: `objects/{tenant}/{uuid-or-sha256}`; filenames/owner/content-type in a `blob_object` DB table, never in the key.
- **Access control** sits in the HTTP serving layer, above the store; download is **sign-if-you-can, proxy-otherwise**.
- **Config**: new `storage` section, `local` zero-config default.
- **Migration**: `stella storage migrate` CLI, idempotent.

## Refs

- Closes part of #481
- Parent: #477