### PR TITLE
fix(sandbox): keep per-user mise tree in the STELLA_HOME frame (#505)

### DIFF
--- a/internal/agent/group_session_test.go
+++ b/internal/agent/group_session_test.go
@@ -45,7 +45,7 @@ func TestSetupGroupWorkspace(t *testing.T) {
 		t.Fatalf("dir = %q, want %q", dir, want)
 	}
 	// Verify the shared user-data subtree exists.
-	for _, sub := range []string{"data/.agents/skills", "data/.agents/delegates", "data/.mise-tools", "data/assets"} {
+	for _, sub := range []string{"data/.agents/skills", "data/.agents/delegates", "data/assets"} {
 		p := filepath.Join(dir, sub)
 		if _, err := os.Stat(p); os.IsNotExist(err) {
 			t.Fatalf("expected directory %q to exist", p)

--- a/internal/agent/sandbox/backend_test.go
+++ b/internal/agent/sandbox/backend_test.go
@@ -209,9 +209,11 @@ func TestRunnerFilesystemPolicyGroupUsesGroupSubtree(t *testing.T) {
 	}
 	cfg := Config{GroupID: "g7", UserID: "g7", AgentID: "a1"}
 
-	// The mise tree relocates under the group's data root; the group-keying still
-	// gates validity (a real user with the same raw ID can't share it).
-	if want := filepath.Join(userData, ".mise-tools"); miseUserDirHost(paths, cfg) != want {
+	// The mise tree lives under the group's home in the STELLA_HOME frame (a
+	// sibling of data, not inside it), so it shares the system tree's sandbox root
+	// once STELLA_HOME is remapped. The group-keying still gates validity (a real
+	// user with the same raw ID can't share it).
+	if want := filepath.Join("/stella", "users", "group-g7", ".mise-tools"); miseUserDirHost(paths, cfg) != want {
 		t.Fatalf("miseUserDirHost = %q, want %q", miseUserDirHost(paths, cfg), want)
 	}
 	base := os.TempDir()

--- a/internal/agent/sandbox/env.go
+++ b/internal/agent/sandbox/env.go
@@ -62,14 +62,22 @@ func userDataDirHost(paths Paths, cfg Config) string {
 }
 
 // miseUserDirHost returns the host path of this session's writable per-user mise
-// home — now under the shared user-data root (UserDataDir/.mise-tools), so the
-// /user mount makes it writable without a dedicated bind. Returns "" when there
-// is no per-user tree: no principal, or an ID that fails the safe-path-component
-// check (the session then falls back to the shared read-only system tree). A
-// downgrade from an unsafe ID is logged so a malformed ID is diagnosable.
+// home, under the STELLA_HOME frame ($STELLA_HOME/users/{id}/.mise-tools), a
+// sibling of the user-data root rather than inside it. This keeps the per-user
+// tree under the same root as the shared system tree once a backend remaps
+// STELLA_HOME (bwrap's /opt/stella), so the relative seed/shim symlinks that
+// bridge per-user tree -> system tree resolve identically on host and in the
+// sandbox. Putting it under the /user-mounted user-data root instead would split
+// the two trees across separate sandbox roots (/user vs /opt/stella) and dangle
+// those symlinks (#505). The cost is one dedicated writable bind, wired via
+// ExtraWritableMounts. Returns "" when there is no per-user tree: no principal, or
+// an ID that fails the safe-path-component check (the session then falls back to
+// the shared read-only system tree). A downgrade from an unsafe ID is logged so a
+// malformed ID is diagnosable.
 func miseUserDirHost(paths Paths, cfg Config) string {
 	principalDir, id := misePrincipal(cfg)
-	if pkgsandbox.MiseUserToolsDir(paths.StellaHome, principalDir, id) == "" {
+	dir := pkgsandbox.MiseUserToolsDir(paths.StellaHome, principalDir, id)
+	if dir == "" {
 		if id != "" {
 			slog.Warn("per-user mise tree disabled: unsafe id, using shared read-only system tree",
 				"component", "runner_sandbox",
@@ -80,7 +88,7 @@ func miseUserDirHost(paths Paths, cfg Config) string {
 		}
 		return ""
 	}
-	return filepath.Join(paths.UserDataDir, ".mise-tools")
+	return dir
 }
 
 // misePrincipal returns the home subtree and ID for this session's per-principal
@@ -213,8 +221,9 @@ func buildSandboxEnv(ctx context.Context, cfg Config, paths Paths) (map[string]s
 	// PATH, so they need the mise env pointed at the org's config. Docker carries
 	// its own in-image mise tree and PATH, so host-side paths must not leak in.
 	if resolveBackendName(ctx, cfg) != config.SandboxBackendDocker {
-		// MISE_DATA_DIR points at the relocated per-user tree (UserDataDir/.mise-tools);
-		// the workspace dir trusted for project mise.toml is the agent workspace.
+		// MISE_DATA_DIR points at the per-user tree in the STELLA_HOME frame
+		// ($STELLA_HOME/users/{id}/.mise-tools); the workspace dir trusted for a
+		// project mise.toml is the agent workspace.
 		maps.Copy(env, manifestplugins.RuntimeMiseEnv(paths.StellaHome, miseUserDirHost(paths, cfg), paths.WorkspaceRoot))
 	}
 

--- a/internal/agent/sandbox/session.go
+++ b/internal/agent/sandbox/session.go
@@ -129,16 +129,21 @@ func buildBasePolicy(ctx context.Context, cfg Config) (Paths, pkgsandbox.Policy,
 			return Paths{}, pkgsandbox.Policy{}, fmt.Errorf("ensure user temp dir: %w", err)
 		}
 	}
-	// Per-user mise tree: host-execution backends (local, none) get a writable
-	// per-user mise home, seeded with relative symlinks to the read-only system
-	// installs and mounted writable so the agent can install its own tools.
-	// Docker carries its own in-image mise tree, so it is skipped here (bringing
-	// docker to parity is tracked in #436).
+	// Mise shims for host-execution backends (local, none). EnsureMiseShims
+	// relinks the shared system-tree shims to relative targets so they resolve
+	// after STELLA_HOME is remapped (bwrap's /opt/stella) — otherwise the system
+	// shims are only relinked at reconcile, so a session started before the next
+	// reconcile inherits stale absolute host-path shims that dangle in the sandbox
+	// (#505). When a per-user tree exists it is also seeded (relative symlinks to
+	// the read-only system installs) and mounted writable so the agent can install
+	// its own tools. Docker carries its own in-image mise tree, so it is skipped
+	// here (bringing docker to parity is tracked in #436).
 	if resolveBackendName(ctx, cfg) != config.SandboxBackendDocker {
-		if miseDir := miseUserDirHost(paths, cfg); miseDir != "" {
-			if err := pkgsandbox.EnsureUserMiseHome(paths.StellaHome, miseDir); err != nil {
-				return Paths{}, pkgsandbox.Policy{}, fmt.Errorf("ensure per-user mise home: %w", err)
-			}
+		miseDir := miseUserDirHost(paths, cfg)
+		if err := pkgsandbox.EnsureMiseShims(paths.StellaHome, miseDir); err != nil {
+			return Paths{}, pkgsandbox.Policy{}, fmt.Errorf("ensure mise shims: %w", err)
+		}
+		if miseDir != "" {
 			fs.ExtraWritableMounts = append(fs.ExtraWritableMounts, miseDir)
 		}
 	}

--- a/internal/agent/workspace.go
+++ b/internal/agent/workspace.go
@@ -98,11 +98,11 @@ func setupHome(home, agentDir, agentID string) (string, error) {
 		return "", fmt.Errorf("agent ID must not be empty")
 	}
 	// data/ is the shared user-data root mounted as /user. Its subtree holds the
-	// per-user toolchain, cache, user-level skills/delegates, and uploads — all
-	// shared across the user's agents.
+	// per-user cache, user-level skills/delegates, and uploads — all shared across
+	// the user's agents. The per-user mise tree is a sibling of data/ (under the
+	// STELLA_HOME frame, created on demand by EnsureUserMiseHome), not here.
 	for _, sub := range [][]string{
 		{"data"},
-		{"data", ".mise-tools"},
 		{"data", ".cache"},
 		{"data", ".agents", "skills"},
 		{"data", ".agents", "delegates"},

--- a/internal/agent/workspace_test.go
+++ b/internal/agent/workspace_test.go
@@ -89,7 +89,6 @@ func TestSetupUserWorkspace(t *testing.T) {
 	for _, sub := range []string{
 		filepath.Join(userDir, "data", ".agents", "skills"),
 		filepath.Join(userDir, "data", ".agents", "delegates"),
-		filepath.Join(userDir, "data", ".mise-tools"),
 		filepath.Join(userDir, "data", "assets"),
 		filepath.Join(userDir, "agents", "agent-1"),
 	} {

--- a/internal/manifestplugins/mise_installer.go
+++ b/internal/manifestplugins/mise_installer.go
@@ -119,54 +119,13 @@ func runtimeBinaryName(name string) string {
 	return name
 }
 
-// relinkShims rewrites mise shim symlinks to use relative paths so they
-// resolve correctly inside bwrap sandboxes where STELLA_HOME is remapped.
-//
-// mise reshim creates symlinks pointing to the absolute host path of the mise
-// binary (e.g. /home/user/.local/bin/mise). Inside bwrap, that path doesn't
-// exist. By rewriting shims to relative symlinks (../../bin/mise), they work
-// on both the host and inside the sandbox — the relative traversal from
-// .mise-tools/shims/ to bin/ resolves identically regardless of the mount root.
+// relinkShims rewrites the system-tree mise shims to relative paths so they
+// resolve inside bwrap sandboxes where STELLA_HOME is remapped. The relink logic
+// lives in pkg/sandbox alongside the per-user variant; this delegates so the
+// install/reconcile path and the session path stay in lockstep. The second
+// parameter is retained for the existing call sites and tests.
 func relinkShims(stellaHome, _ string) error {
-	// Only relink if $STELLA_HOME/bin/mise exists. We never copy an
-	// arbitrary PATH-resolved mise into a trusted location.
-	localBin := filepath.Join(stellaHome, "bin", runtimeBinaryName("mise"))
-	if _, err := os.Stat(localBin); err != nil {
-		return nil //nolint:nilerr // no local mise binary → nothing to relink
-	}
-
-	shimsDir := filepath.Join(miseToolsDir(stellaHome), "shims")
-	entries, err := os.ReadDir(shimsDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("read shims dir: %w", err)
-	}
-
-	relTarget := filepath.Join("..", "..", "bin", runtimeBinaryName("mise"))
-
-	for _, e := range entries {
-		if e.Type()&os.ModeSymlink == 0 {
-			continue
-		}
-		shimPath := filepath.Join(shimsDir, e.Name())
-		target, err := os.Readlink(shimPath)
-		if err != nil || target == relTarget {
-			continue
-		}
-		// Atomic replace: create temp symlink then rename over the old one.
-		tmp := shimPath + ".tmp"
-		_ = os.Remove(tmp)
-		if err := os.Symlink(relTarget, tmp); err != nil {
-			return fmt.Errorf("relink shim %s: %w", e.Name(), err)
-		}
-		if err := os.Rename(tmp, shimPath); err != nil {
-			_ = os.Remove(tmp)
-			return fmt.Errorf("relink shim %s: %w", e.Name(), err)
-		}
-	}
-	return nil
+	return pkgsandbox.RelinkSystemMiseShims(stellaHome)
 }
 
 // stringOption returns a non-empty string tool option value.

--- a/pkg/sandbox/miseuser.go
+++ b/pkg/sandbox/miseuser.go
@@ -6,6 +6,8 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
+	"sync"
 )
 
 // EnsureUserMiseHome creates the per-user mise tree at userToolsDir and seeds it
@@ -80,28 +82,75 @@ func pruneDanglingSeedLinks(userInstalls string) error {
 	return nil
 }
 
-// relinkUserShims rewrites every per-user shim to a relative target so it resolves
-// under whatever root the active backend remaps STELLA_HOME to. mise reshim (run
-// by the agent inside the sandbox) writes each shim with the absolute in-sandbox
-// mise path, which is backend-specific (bwrap's /opt/stella vs a host
-// path); a relative target keeps a persisted tree portable across backends.
-// Mirrors relinkShims for the system tree, but computes the depth-correct target.
-func relinkUserShims(stellaHome, userToolsDir string) error {
-	miseBin := filepath.Join(stellaHome, "bin", "mise")
-	if _, err := os.Stat(miseBin); err != nil {
-		return nil //nolint:nilerr // no local mise binary to point at → leave shims untouched
+// EnsureMiseShims prepares the mise shims a sandbox session resolves against,
+// before the session's PATH is used. It relinks the shared system-tree shims
+// (always) and, when userToolsDir is set, seeds and relinks the per-user tree via
+// EnsureUserMiseHome. Splitting the two trees keeps each concern separate while a
+// single call site guarantees both resolve under the active backend's remap.
+// Docker carries its own in-image mise tree and must not call this.
+func EnsureMiseShims(stellaHome, userToolsDir string) error {
+	if err := RelinkSystemMiseShims(stellaHome); err != nil {
+		return err
 	}
-	shimsDir := filepath.Join(userToolsDir, "shims")
+	if userToolsDir == "" {
+		return nil
+	}
+	return EnsureUserMiseHome(stellaHome, userToolsDir)
+}
+
+// shimRelinkMu serializes shim relinking. The system shims dir is shared by every
+// session, so concurrent session starts would otherwise race on the per-shim temp
+// symlink. Relinking is fast (one readlink per shim once already relative), so a
+// single lock across all trees is cheap.
+var shimRelinkMu sync.Mutex
+
+// miseBinName is the mise binary file name for the current platform.
+func miseBinName() string {
+	if runtime.GOOS == "windows" {
+		return "mise.exe"
+	}
+	return "mise"
+}
+
+// RelinkSystemMiseShims rewrites the shared system-tree shims to relative targets.
+// Idempotent and safe to call before every session; see relinkShimsToLocalMise.
+func RelinkSystemMiseShims(stellaHome string) error {
+	return relinkShimsToLocalMise(stellaHome, MiseShimsDir(stellaHome))
+}
+
+// relinkUserShims rewrites the per-user shims (those the agent created with mise
+// reshim inside a sandbox) to relative targets. Mirrors RelinkSystemMiseShims for
+// the per-user tree.
+func relinkUserShims(stellaHome, userToolsDir string) error {
+	return relinkShimsToLocalMise(stellaHome, MiseUserShimsDir(userToolsDir))
+}
+
+// relinkShimsToLocalMise rewrites every symlink shim in shimsDir to a relative
+// path targeting $STELLA_HOME/bin/mise. mise reshim writes each shim with the
+// absolute path of whichever mise ran it — a host path that does not exist once a
+// backend remaps STELLA_HOME (bwrap's /opt/stella), which is the #505 failure:
+// the shim resolves on the host but dangles in the sandbox. A relative target
+// resolves identically on the host and under any remap. A no-op when
+// $STELLA_HOME/bin/mise is absent: we never point a shim at an arbitrary host mise.
+func relinkShimsToLocalMise(stellaHome, shimsDir string) error {
+	miseBin := filepath.Join(stellaHome, "bin", miseBinName())
+	if _, err := os.Stat(miseBin); err != nil {
+		return nil
+	}
+	relTarget, err := filepath.Rel(shimsDir, miseBin)
+	if err != nil {
+		return fmt.Errorf("sandbox: relative shim target: %w", err)
+	}
+
+	shimRelinkMu.Lock()
+	defer shimRelinkMu.Unlock()
+
 	entries, err := os.ReadDir(shimsDir)
 	if errors.Is(err, fs.ErrNotExist) {
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf("sandbox: read per-user shims: %w", err)
-	}
-	relTarget, err := filepath.Rel(shimsDir, miseBin)
-	if err != nil {
-		return fmt.Errorf("sandbox: relative shim target: %w", err)
+		return fmt.Errorf("sandbox: read shims dir: %w", err)
 	}
 	for _, e := range entries {
 		if e.Type()&os.ModeSymlink == 0 {
@@ -115,11 +164,11 @@ func relinkUserShims(stellaHome, userToolsDir string) error {
 		tmp := shimPath + ".tmp"
 		_ = os.Remove(tmp)
 		if err := os.Symlink(relTarget, tmp); err != nil {
-			return fmt.Errorf("sandbox: relink per-user shim %s: %w", e.Name(), err)
+			return fmt.Errorf("sandbox: relink shim %s: %w", e.Name(), err)
 		}
 		if err := os.Rename(tmp, shimPath); err != nil {
 			_ = os.Remove(tmp)
-			return fmt.Errorf("sandbox: relink per-user shim %s: %w", e.Name(), err)
+			return fmt.Errorf("sandbox: relink shim %s: %w", e.Name(), err)
 		}
 	}
 	return nil

--- a/pkg/sandbox/miseuser_test.go
+++ b/pkg/sandbox/miseuser_test.go
@@ -195,6 +195,41 @@ func TestEnsureUserMiseHome_PrunesDanglingSeedLinks(t *testing.T) {
 	}
 }
 
+// TestEnsureMiseShims_RelinksSystemShimsWithoutUserTree locks in the #505 fix:
+// the system-tree shims must be relinked at session start even when there is no
+// per-user tree, so a session started before the next reconcile never inherits a
+// stale absolute host-path shim that dangles once STELLA_HOME is remapped.
+func TestEnsureMiseShims_RelinksSystemShimsWithoutUserTree(t *testing.T) {
+	stellaHome := t.TempDir()
+	mustMkdirAll(t, filepath.Join(stellaHome, "bin"))
+	mustWriteFile(t, filepath.Join(stellaHome, "bin", "mise"), "binary")
+	mustMkdirAll(t, MiseShimsDir(stellaHome))
+
+	// A shim mise reshim wrote with the absolute path of the host mise that ran
+	// the install — valid on the host, dangling under a bwrap remap.
+	shim := filepath.Join(MiseShimsDir(stellaHome), "gh")
+	if err := os.Symlink("/Users/dev/.local/bin/mise", shim); err != nil {
+		t.Fatal(err)
+	}
+
+	// No per-user tree (user-less job).
+	if err := EnsureMiseShims(stellaHome, ""); err != nil {
+		t.Fatalf("EnsureMiseShims: %v", err)
+	}
+
+	target, err := os.Readlink(shim)
+	if err != nil {
+		t.Fatalf("shim should remain a symlink: %v", err)
+	}
+	if filepath.IsAbs(target) {
+		t.Fatalf("system shim must be relinked to a relative target, got %q", target)
+	}
+	// The relative target resolves to the local mise binary.
+	if _, err := os.Stat(shim); err != nil {
+		t.Fatalf("relinked shim does not resolve to bin/mise: %v", err)
+	}
+}
+
 func mustMkdirAll(t *testing.T, dir string) {
 	t.Helper()
 	if err := os.MkdirAll(dir, 0o755); err != nil {

--- a/plugins/sandbox/local/session.go
+++ b/plugins/sandbox/local/session.go
@@ -120,12 +120,13 @@ func (f *Factory) adjustPolicy(policy sandboxpkg.Policy, sandboxRoot, realRoot, 
 	sandboxSH := adjustStellaHome(f.cfg.StellaHome)
 	hostSH := f.cfg.StellaHome
 	// remapMise rewrites a mise path to the agent's view. The per-user mise tree
-	// now lives under the shared user-data root (UserDataDir/.mise-tools), so map
-	// that frame to /user first; the agent sees its toolchain at /user/.mise-tools
-	// and never learns the on-disk users/{id} layout. A project-local or system
-	// tree falls through to the workspace (/workspace) then STELLA_HOME (/opt/stella)
-	// remaps. Composing is safe — once a path lands under one sandbox root it is no
-	// longer under the next frame's host prefix, so later steps leave it untouched.
+	// lives under the STELLA_HOME frame ($STELLA_HOME/users/{id}/.mise-tools), so it
+	// falls through the user-data (/user) and workspace (/workspace) frames and
+	// lands under STELLA_HOME (/opt/stella/users/{id}/.mise-tools) — the same root
+	// as the system tree, so the relative seed/shim symlinks resolve (#505). A
+	// project-local tree maps to /workspace. Composing is safe — once a path lands
+	// under one sandbox root it is no longer under the next frame's host prefix, so
+	// later steps leave it untouched.
 	remapMise := func(p string) string {
 		p = remapToSandboxRoot(p, userDataReal, userDataSandbox)
 		p = remapToSandboxRoot(p, realRoot, sandboxRoot)
@@ -149,9 +150,10 @@ func (f *Factory) adjustPolicy(policy sandboxpkg.Policy, sandboxRoot, realRoot, 
 		env["STELLA_USER_DIR"] = userDataSandbox
 	}
 	env["STELLA_HOME"] = sandboxSH
-	// Rewrite MISE_* path-valued env vars to the agent's view (see remapMise): the
-	// per-user tree lands under /user, the system tree under the sandbox
-	// STELLA_HOME. All but MISE_TRUSTED_CONFIG_PATHS are single scalar paths, and
+	// Rewrite MISE_* path-valued env vars to the agent's view (see remapMise): both
+	// the per-user tree and the system tree land under the sandbox STELLA_HOME, so
+	// their host-relative seed/shim symlinks resolve identically in the sandbox.
+	// All but MISE_TRUSTED_CONFIG_PATHS are single scalar paths, and
 	// ':' is a legal character in a POSIX path, so they are remapped whole — only
 	// the genuinely list-valued var is split on the path-list separator (each
 	// element remapped independently; already-sandbox paths like /workspace

--- a/plugins/sandbox/local/session_linux.go
+++ b/plugins/sandbox/local/session_linux.go
@@ -322,7 +322,7 @@ func wrapCommand(policy sandboxpkg.Policy, sandboxCwd string, tmpMounts []tmpMou
 			continue // under /workspace
 		}
 		if userDataReal != "" && remapToSandboxRoot(writable, userDataReal, "/user") != writable {
-			continue // under /user (e.g. the relocated per-user mise tree)
+			continue // under /user (an extra writable mount inside the user-data root)
 		}
 		bwrapArgs = appendWritableBind(bwrapArgs, writable, remapToSandboxStellaHome(writable, stellaHomeHost))
 	}

--- a/plugins/sandbox/local/session_linux_test.go
+++ b/plugins/sandbox/local/session_linux_test.go
@@ -329,10 +329,10 @@ func TestWrapCommand_linux_inWorkspaceWritableMountSkipped(t *testing.T) {
 	}
 }
 
-// TestWrapCommand_linux_inUserDataWritableMountSkipped verifies the runtime case
-// for the relocated per-user mise tree: a writable mount under the user-data root
-// is NOT bound again under the STELLA_HOME tree, because the /user bind already
-// makes it writable. A second bind would re-expose the host path.
+// TestWrapCommand_linux_inUserDataWritableMountSkipped verifies that an extra
+// writable mount that already sits under the user-data root is NOT bound again
+// under the STELLA_HOME tree: the /user bind already makes it writable, and a
+// second bind would re-expose the host path to the agent.
 func TestWrapCommand_linux_inUserDataWritableMountSkipped(t *testing.T) {
 	if _, err := exec.LookPath("bwrap"); err != nil {
 		t.Skip("bwrap not installed")
@@ -344,8 +344,8 @@ func TestWrapCommand_linux_inUserDataWritableMountSkipped(t *testing.T) {
 	stellaHome := t.TempDir()
 	agentDir := filepath.Join(stellaHome, "users", "u1", "agents", "a1")
 	userData := filepath.Join(stellaHome, "users", "u1", "data")
-	miseDir := filepath.Join(userData, ".mise-tools")
-	if err := os.MkdirAll(miseDir, 0o755); err != nil {
+	writableDir := filepath.Join(userData, "scratch")
+	if err := os.MkdirAll(writableDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -354,7 +354,7 @@ func TestWrapCommand_linux_inUserDataWritableMountSkipped(t *testing.T) {
 			WorkspaceRoot:       agentDir,
 			WorkingDir:          "/workspace",
 			UserDataDir:         userData,
-			ExtraWritableMounts: []string{miseDir},
+			ExtraWritableMounts: []string{writableDir},
 		},
 		Network: sandboxpkg.NetworkPolicy{Mode: sandboxpkg.NetworkAllowAll},
 	}
@@ -365,12 +365,12 @@ func TestWrapCommand_linux_inUserDataWritableMountSkipped(t *testing.T) {
 	}
 
 	joined := strings.Join(args, " ")
-	sandboxMiseDir := filepath.Join(sandboxStellaHome, "users", "u1", "data", ".mise-tools")
-	if strings.Contains(joined, sandboxMiseDir) {
+	sandboxWritableDir := filepath.Join(sandboxStellaHome, "users", "u1", "data", "scratch")
+	if strings.Contains(joined, sandboxWritableDir) {
 		t.Errorf("under-/user writable mount must not be re-bound under %s: %v", sandboxStellaHome, args)
 	}
 	if !strings.Contains(joined, "--bind "+userData+" /user") {
-		t.Errorf("expected --bind %s /user covering the relocated mise tree, got %v", userData, args)
+		t.Errorf("expected --bind %s /user covering the writable mount, got %v", userData, args)
 	}
 }
 

--- a/plugins/sandbox/local/session_test.go
+++ b/plugins/sandbox/local/session_test.go
@@ -689,22 +689,25 @@ func TestAdjustPolicy_perUserMiseShimsOnPath(t *testing.T) {
 	}
 }
 
-// TestAdjustPolicy_perUserMiseInUserDataFrame verifies that the per-user mise
-// tree — now under the shared user-data root (UserDataDir/.mise-tools) — is
-// expressed in the /user frame, not the host STELLA_HOME tree: the agent sees its
-// toolchain at /user/.mise-tools and never learns the on-disk users/{id} layout.
-// The system config path stays under the sandbox STELLA_HOME, and the host
-// workspace trusted entry collapses onto /workspace.
-func TestAdjustPolicy_perUserMiseInUserDataFrame(t *testing.T) {
+// TestAdjustPolicy_perUserMiseInStellaHomeFrame verifies that the per-user mise
+// tree — under the STELLA_HOME frame ($STELLA_HOME/users/{id}/.mise-tools, a
+// sibling of the user-data root) — is expressed under the sandbox STELLA_HOME
+// (/opt/stella/users/{id}/.mise-tools), sharing the system tree's root so the
+// relative seed/shim symlinks resolve. The system config path also stays under
+// the sandbox STELLA_HOME, and the host workspace trusted entry collapses onto
+// /workspace. This is the production layout (#505): the tree must NOT land in the
+// /user frame, which would split it from the system tree across sandbox roots.
+func TestAdjustPolicy_perUserMiseInStellaHomeFrame(t *testing.T) {
 	hostSH := "/home/user/.stella"
 	userHome := hostSH + "/users/u1"
 	agentDir := userHome + "/agents/a1"
 	userData := userHome + "/data"
+	miseHome := userHome + "/.mise-tools" // sibling of data, under STELLA_HOME
 	policy := sandboxpkg.Policy{
 		Filesystem: sandboxpkg.FilesystemPolicy{WorkspaceRoot: agentDir, UserDataDir: userData},
 		Env: map[string]string{
-			"MISE_DATA_DIR":             userData + "/.mise-tools",
-			"MISE_CACHE_DIR":            userData + "/.mise-tools/cache",
+			"MISE_DATA_DIR":             miseHome,
+			"MISE_CACHE_DIR":            miseHome + "/cache",
 			"MISE_GLOBAL_CONFIG_FILE":   hostSH + "/.mise-tools/configs/_builtin.toml",
 			"MISE_TRUSTED_CONFIG_PATHS": hostSH + "/.mise-tools/configs/_builtin.toml:/workspace:" + agentDir,
 		},
@@ -718,8 +721,8 @@ func TestAdjustPolicy_perUserMiseInUserDataFrame(t *testing.T) {
 	adjusted := f.adjustPolicy(policy, sandboxRoot, realRoot, userDataSandbox, userDataReal)
 
 	for _, tc := range []struct{ key, want string }{
-		{"MISE_DATA_DIR", "/user/.mise-tools"},
-		{"MISE_CACHE_DIR", "/user/.mise-tools/cache"},
+		{"MISE_DATA_DIR", sandboxSH + "/users/u1/.mise-tools"},
+		{"MISE_CACHE_DIR", sandboxSH + "/users/u1/.mise-tools/cache"},
 		{"MISE_GLOBAL_CONFIG_FILE", sandboxSH + "/.mise-tools/configs/_builtin.toml"},
 		{"MISE_TRUSTED_CONFIG_PATHS", sandboxSH + "/.mise-tools/configs/_builtin.toml:/workspace"},
 	} {
@@ -727,10 +730,10 @@ func TestAdjustPolicy_perUserMiseInUserDataFrame(t *testing.T) {
 			t.Errorf("env[%s] = %q, want %q", tc.key, got, tc.want)
 		}
 	}
-	if wantShims := "/user/.mise-tools/shims"; !strings.Contains(adjusted.Env["PATH"], wantShims) {
-		t.Errorf("PATH must include /user-frame shims %q, got %q", wantShims, adjusted.Env["PATH"])
+	if wantShims := sandboxSH + "/users/u1/.mise-tools/shims"; !strings.Contains(adjusted.Env["PATH"], wantShims) {
+		t.Errorf("PATH must include STELLA_HOME-frame shims %q, got %q", wantShims, adjusted.Env["PATH"])
 	}
-	if strings.Contains(adjusted.Env["PATH"], userData) {
+	if strings.Contains(adjusted.Env["PATH"], userData+"/") {
 		t.Errorf("PATH must not leak the host user-data path %q: %q", userData, adjusted.Env["PATH"])
 	}
 }

--- a/web/content/docs/changelog.mdx
+++ b/web/content/docs/changelog.mdx
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🐛 Bug Fixes
+
+- Sandbox: fix broken `mise` shims (e.g. `gh`, `lark-cli`) in the agent runtime by keeping the per-user toolchain in the `STELLA_HOME` frame so its symlinks resolve under the sandbox. Tools manually installed under v0.49.0 must be reinstalled once. ([#507](https://github.com/CherryHQ/stella/pull/507))
+
 ## [0.49.0] - 2026-06-16
 
 ### ✨ Features

--- a/web/content/docs/changelog.zh.mdx
+++ b/web/content/docs/changelog.zh.mdx
@@ -11,6 +11,10 @@ icon: History
 
 ## [Unreleased]
 
+### 🐛 修复
+
+- Sandbox：修复 agent 运行时中损坏的 `mise` shim（如 `gh`、`lark-cli`）——将 per-user 工具链保留在 `STELLA_HOME` 框架下，使其软链在沙箱内可正确解析。在 v0.49.0 下手动安装的工具需重新安装一次。([#507](https://github.com/CherryHQ/stella/pull/507))
+
 ## [0.49.0] - 2026-06-16
 
 ### ✨ 功能


### PR DESCRIPTION
## What

Fix broken `mise` shims (`gh`, `lark-cli`, …) in the agent runtime. Move the **per-user mise tree** back into the `STELLA_HOME` frame so its symlinks resolve inside the sandbox. Plus a smaller hardening: relink the **system-tree** shims at session start, not only at reconcile.

Fixes #505.

## Why

**Root cause (the real one).** The #496 two-root layout relocated the per-user mise tree to `UserDataDir/.mise-tools`, which mounts at `/user` — a **separate bwrap root** from `/opt/stella`, where the system tree and `bin/mise` live. The host-relative symlinks that bridge the two trees (seeded installs → system installs; per-user shims → `bin/mise`) dangle across the `/user` ↔ `/opt/stella` split:

```
$ mise which gh
mise ERROR gh is not a mise bin. Perhaps you need to install it first.
```

mise runs fine — it just can't follow the install link across the root boundary. This shipped in v0.49.0.

**Secondary gap.** `mise reshim` writes each **system** shim as a symlink to the absolute path of whichever mise ran the install (e.g. a host `~/.local/bin/mise`), which dangles once `STELLA_HOME` is remapped to `/opt/stella`. `relinkShims` rewrites these to relative `../../bin/mise`, but only ran at reconcile — a session started before the next reconcile inherited stale absolute shims.

## How

- **Per-user tree relocation** (the #505 fix): `miseUserDirHost` now returns `$STELLA_HOME/users/{id}/.mise-tools` (a sibling of `data/`, via `MiseUserToolsDir`) instead of `UserDataDir/.mise-tools`. bwrap binds it writable at `/opt/stella/users/{id}/.mise-tools` and remaps `MISE_*` there, so per-user and system trees share `/opt/stella` and the existing **host-relative** seed/shim symlinks resolve identically on host and in-sandbox. Zero changes to the symlink-writing logic. Reverts the #496 "save one bind" choice that caused the split.
- **System-shim relink at session start**: `EnsureMiseShims(stellaHome, userToolsDir)` — single non-docker entry: relinks the system tree always, seeds + relinks the per-user tree when present. `relinkShimsToLocalMise` is the shared loop (relative target via `filepath.Rel`); `manifestplugins` reconcile now delegates to it. A package mutex serializes concurrent relinks.
- Docker is unaffected (ships its own in-image mise tree, skips this path). Darwin/seatbelt and `none` use host paths — no remap, symlinks resolve as before.
- Stale `data/.mise-tools` comments/tests from the #496 framing cleaned up.

## Refs

- Issue #505
- Reviewed read-only by a second agent (Pi): traced the symlink resolution in both host and `/opt/stella` views, confirmed the mixed-backend and host-follow-symlink concerns are eliminated. Verdict: ship.
- v0.49.0 users who manually installed tools must reinstall once (old `data/.mise-tools` is orphaned). Noted in CHANGELOG.
- Tests: `TestAdjustPolicy_perUserMiseInStellaHomeFrame`, `TestEnsureMiseShims_RelinksSystemShimsWithoutUserTree`. Full Go `build`/`test` green (web format step blocked by an unrelated local vite native-binding issue).