### PR TITLE
✨ feat(chat): rich cards for agent-created goals, tasks & articles

### DIFF
--- a/cmd/stella/recally_articles.go
+++ b/cmd/stella/recally_articles.go
@@ -101,10 +101,16 @@ Options must be placed before the URL. Trailing options are rejected.`,
 				message = "Article saved successfully"
 			}
 			// Best-effort: a failed sentinel write must never fail the save.
+			// `save` is upsert — only call it "created" when the article is new,
+			// otherwise the card would claim a creation that didn't happen.
+			saveIntent := "referenced"
+			if created {
+				saveIntent = "created"
+			}
 			_ = renderrefs.Emit(c.App.ErrWriter, renderrefs.Reference{
 				Type:    "recally_article",
 				ID:      article.Id,
-				Intent:  "created",
+				Intent:  saveIntent,
 				Preview: &renderrefs.Preview{Title: article.Title, Status: string(article.Status)},
 			})
 			if cli.IsJSON(c) {

--- a/cmd/stella/recally_articles.go
+++ b/cmd/stella/recally_articles.go
@@ -12,6 +12,7 @@ import (
 
 	apiclient "github.com/CherryHQ/stella/api/client"
 	"github.com/CherryHQ/stella/internal/cli"
+	"github.com/CherryHQ/stella/internal/renderrefs"
 )
 
 func recallySaveCommand() *ucli.Command {
@@ -99,6 +100,13 @@ Options must be placed before the URL. Trailing options are rejected.`,
 			if created {
 				message = "Article saved successfully"
 			}
+			// Best-effort: a failed sentinel write must never fail the save.
+			_ = renderrefs.Emit(c.App.ErrWriter, renderrefs.Reference{
+				Type:    "recally_article",
+				ID:      article.Id,
+				Intent:  "created",
+				Preview: &renderrefs.Preview{Title: article.Title, Status: string(article.Status)},
+			})
 			if cli.IsJSON(c) {
 				return cli.PrintJSON(c, article)
 			}

--- a/cmd/stella/task.go
+++ b/cmd/stella/task.go
@@ -10,6 +10,7 @@ import (
 	apiclient "github.com/CherryHQ/stella/api/client"
 	apitypes "github.com/CherryHQ/stella/api/types"
 	"github.com/CherryHQ/stella/internal/cli"
+	"github.com/CherryHQ/stella/internal/renderrefs"
 )
 
 func taskAgentID(_ *ucli.Context) (string, error) {
@@ -174,6 +175,13 @@ func taskCreateCmd() *ucli.Command {
 			if err != nil {
 				return fmt.Errorf("create task: %w", err)
 			}
+			// Best-effort: a failed sentinel write must never fail task creation.
+			_ = renderrefs.Emit(c.App.ErrWriter, renderrefs.Reference{
+				Type:    "task",
+				ID:      task.Id,
+				Intent:  "created",
+				Preview: &renderrefs.Preview{Title: task.Title, Status: string(task.Status)},
+			})
 			return printTask(c, task)
 		},
 	}

--- a/cmd/stella/task_goal.go
+++ b/cmd/stella/task_goal.go
@@ -9,6 +9,7 @@ import (
 	apiclient "github.com/CherryHQ/stella/api/client"
 	apitypes "github.com/CherryHQ/stella/api/types"
 	"github.com/CherryHQ/stella/internal/cli"
+	"github.com/CherryHQ/stella/internal/renderrefs"
 )
 
 func goalCommand() *ucli.Command {
@@ -158,6 +159,13 @@ func goalCreateCmd() *ucli.Command {
 					return fmt.Errorf("activate goal: %w", err)
 				}
 			}
+			// Best-effort: a failed sentinel write must never fail goal creation.
+			_ = renderrefs.Emit(c.App.ErrWriter, renderrefs.Reference{
+				Type:    "goal",
+				ID:      goal.Id,
+				Intent:  "created",
+				Preview: &renderrefs.Preview{Title: goal.Title, Status: string(goal.Status)},
+			})
 			return printGoal(c, goal)
 		},
 	}

--- a/internal/memory/lcm/engine.go
+++ b/internal/memory/lcm/engine.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/CherryHQ/stella/internal/memory"
+	"github.com/CherryHQ/stella/internal/renderrefs"
 	"github.com/CherryHQ/stella/pkg/ai"
 	"github.com/CherryHQ/stella/pkg/db/sqlc"
 )
@@ -106,11 +107,12 @@ type toolCallEnvelope struct {
 // and the provider's prompt cache stays valid. Result remains the flattened text
 // for backward compatibility and token estimation.
 type toolResultEnvelope struct {
-	ID     string             `json:"id"`
-	Tool   string             `json:"tool"`
-	Result json.RawMessage    `json:"result"`
-	Error  string             `json:"error,omitempty"`
-	Blocks []contentBlockJSON `json:"blocks,omitempty"`
+	ID         string                 `json:"id"`
+	Tool       string                 `json:"tool"`
+	Result     json.RawMessage        `json:"result"`
+	Error      string                 `json:"error,omitempty"`
+	Blocks     []contentBlockJSON     `json:"blocks,omitempty"`
+	References []renderrefs.Reference `json:"references,omitempty"`
 }
 
 // storageRow is a single DB row to be written for an ai.Message.
@@ -179,16 +181,21 @@ func assistantMessageToRows(m ai.AssistantMessage) []storageRow {
 
 func toolResultToRows(m ai.ToolResultMessage) []storageRow {
 	text := ai.FlattenText(m.Content)
+	// Lift any renderable-reference sentinels out of the tool output once, at
+	// ingest: the cleaned text is what the model and user see; the references
+	// ride along on the envelope so the chat can render cards by entity id.
+	text, refs := renderrefs.Extract(text)
 	resultJSON, _ := json.Marshal(text)
 	var errStr string
 	if m.IsError {
 		errStr = text
 	}
 	envelope := toolResultEnvelope{
-		ID:     m.ToolCallID,
-		Tool:   m.ToolName,
-		Result: resultJSON,
-		Error:  errStr,
+		ID:         m.ToolCallID,
+		Tool:       m.ToolName,
+		Result:     resultJSON,
+		Error:      errStr,
+		References: refs,
 	}
 	if ai.HasImage(m.Content) {
 		envelope.Blocks = contentBlocksToJSON(m.Content)

--- a/internal/renderrefs/renderrefs.go
+++ b/internal/renderrefs/renderrefs.go
@@ -1,0 +1,94 @@
+// Package renderrefs defines the sideband protocol that lets agent CLI commands
+// announce a freshly created (or referenced) Stella entity — a task, goal, or
+// recally article — so the chat UI can render a rich card instead of a raw UUID.
+//
+// The producer (a CLI command, gated by [Enabled]) writes one sentinel line per
+// reference to its stderr via [Emit]. The consumer (the tool-result ingest path)
+// runs [Extract] over the combined tool output to lift the references out and
+// strip the sentinel lines, so the text shown to the model and the user stays
+// clean. References are derived data: nothing is stored that a GET on the entity
+// could not re-derive, so there is no migration and stale previews never lie —
+// the frontend always hydrates by id.
+package renderrefs
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// marker prefixes every sentinel line. The version is in the marker (not just
+// the payload) so a future incompatible format can be introduced without the
+// old extractor mis-parsing it.
+const marker = "::stella-ref/v1::"
+
+// envVar gates emission. The bash tool sets it so the CLI only emits sentinels
+// when run by an agent, never when a human runs the same command in a terminal.
+const envVar = "STELLA_RENDERABLE_REFS"
+
+// Preview is a best-effort snapshot used only as a loading placeholder. It is
+// never trusted: the frontend hydrates the live entity by id, so a forged or
+// stale preview cannot grant access or misrepresent state past first paint.
+type Preview struct {
+	Title  string `json:"title,omitempty"`
+	Status string `json:"status,omitempty"`
+}
+
+// Reference is one renderable entity reference. Type and ID are the only load-
+// bearing fields; everything else is a hint.
+type Reference struct {
+	V       int      `json:"v"`
+	Type    string   `json:"type"`             // "task" | "goal" | "recally_article" | future
+	ID      string   `json:"id"`               // entity UUID
+	Intent  string   `json:"intent,omitempty"` // "created" (default emitted) | "referenced"
+	Preview *Preview `json:"preview,omitempty"`
+}
+
+// Enabled reports whether the current process should emit sentinels.
+func Enabled() bool { return os.Getenv(envVar) == "1" }
+
+// Emit writes one sentinel line for ref to w (typically a command's stderr).
+// It is a no-op returning nil when ref carries no id, so callers can emit
+// unconditionally without guarding on partial data.
+func Emit(w io.Writer, ref Reference) error {
+	if ref.ID == "" || ref.Type == "" {
+		return nil
+	}
+	if ref.V == 0 {
+		ref.V = 1
+	}
+	payload, err := json.Marshal(ref)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(w, "%s%s\n", marker, payload)
+	return err
+}
+
+// Extract pulls every sentinel reference out of text and returns the text with
+// those lines removed. Lines are matched anchored at their start (after leading
+// whitespace), so a sentinel survives stdout/stderr interleaving and tail
+// truncation as long as the line itself is intact. Malformed sentinel lines are
+// dropped silently rather than surfaced as garbage to the user.
+func Extract(text string) (clean string, refs []Reference) {
+	if !strings.Contains(text, marker) {
+		return text, nil
+	}
+	lines := strings.Split(text, "\n")
+	kept := lines[:0]
+	for _, line := range lines {
+		// Only treat the marker as a sentinel when nothing but whitespace
+		// precedes it; this avoids eating a line that merely mentions it.
+		if before, payload, found := strings.Cut(line, marker); found && strings.TrimSpace(before) == "" {
+			var ref Reference
+			if err := json.Unmarshal([]byte(payload), &ref); err == nil && ref.ID != "" && ref.Type != "" {
+				refs = append(refs, ref)
+				continue
+			}
+		}
+		kept = append(kept, line)
+	}
+	return strings.Join(kept, "\n"), refs
+}

--- a/internal/renderrefs/renderrefs.go
+++ b/internal/renderrefs/renderrefs.go
@@ -50,9 +50,14 @@ type Reference struct {
 func Enabled() bool { return os.Getenv(envVar) == "1" }
 
 // Emit writes one sentinel line for ref to w (typically a command's stderr).
-// It is a no-op returning nil when ref carries no id, so callers can emit
-// unconditionally without guarding on partial data.
+// It is a no-op (returning nil) unless emission is [Enabled], so a human running
+// the same CLI in a terminal never sees the marker — only agent runs, where the
+// bash tool sets the env, do. It is also a no-op when ref carries no id/type, so
+// callers can emit unconditionally without guarding on partial data.
 func Emit(w io.Writer, ref Reference) error {
+	if !Enabled() {
+		return nil
+	}
 	if ref.ID == "" || ref.Type == "" {
 		return nil
 	}

--- a/internal/renderrefs/renderrefs_test.go
+++ b/internal/renderrefs/renderrefs_test.go
@@ -1,0 +1,76 @@
+package renderrefs
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEmitExtractRoundTrip(t *testing.T) {
+	var b strings.Builder
+	ref := Reference{Type: "task", ID: "abc", Intent: "created", Preview: &Preview{Title: "Fix login", Status: "draft"}}
+	if err := Emit(&b, ref); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	// Sentinel interleaved with ordinary tool output and a tail marker.
+	text := "creating task...\n" + b.String() + "ok\n[exit:0 | 12ms]"
+
+	clean, refs := Extract(text)
+	if len(refs) != 1 {
+		t.Fatalf("want 1 ref, got %d", len(refs))
+	}
+	got := refs[0]
+	if got.V != 1 || got.Type != "task" || got.ID != "abc" || got.Intent != "created" {
+		t.Fatalf("ref mismatch: %+v", got)
+	}
+	if got.Preview == nil || got.Preview.Title != "Fix login" || got.Preview.Status != "draft" {
+		t.Fatalf("preview mismatch: %+v", got.Preview)
+	}
+	if strings.Contains(clean, marker) {
+		t.Fatalf("sentinel not stripped: %q", clean)
+	}
+	if !strings.Contains(clean, "creating task...") || !strings.Contains(clean, "[exit:0 | 12ms]") {
+		t.Fatalf("real output lost: %q", clean)
+	}
+}
+
+func TestEmitSkipsIncomplete(t *testing.T) {
+	var b strings.Builder
+	if err := Emit(&b, Reference{Type: "task"}); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if b.Len() != 0 {
+		t.Fatalf("expected no output for id-less ref, got %q", b.String())
+	}
+}
+
+func TestExtractNoMarker(t *testing.T) {
+	clean, refs := Extract("plain output\nno sentinel here")
+	if refs != nil {
+		t.Fatalf("expected no refs, got %+v", refs)
+	}
+	if clean != "plain output\nno sentinel here" {
+		t.Fatalf("text mutated: %q", clean)
+	}
+}
+
+func TestExtractIgnoresMidLineMention(t *testing.T) {
+	// A line that merely mentions the marker mid-text is not a sentinel.
+	text := "the protocol uses " + marker + "{...} as a prefix"
+	clean, refs := Extract(text)
+	if len(refs) != 0 {
+		t.Fatalf("expected no refs, got %+v", refs)
+	}
+	if clean != text {
+		t.Fatalf("text mutated: %q", clean)
+	}
+}
+
+func TestExtractMultiple(t *testing.T) {
+	var b strings.Builder
+	_ = Emit(&b, Reference{Type: "task", ID: "t1"})
+	_ = Emit(&b, Reference{Type: "goal", ID: "g1"})
+	_, refs := Extract("head\n" + b.String() + "tail")
+	if len(refs) != 2 || refs[0].ID != "t1" || refs[1].ID != "g1" {
+		t.Fatalf("want [t1 g1], got %+v", refs)
+	}
+}

--- a/internal/renderrefs/renderrefs_test.go
+++ b/internal/renderrefs/renderrefs_test.go
@@ -5,7 +5,19 @@ import (
 	"testing"
 )
 
+func TestEmitDisabledByDefault(t *testing.T) {
+	// Without the env gate (a human in a terminal), Emit writes nothing.
+	var b strings.Builder
+	if err := Emit(&b, Reference{Type: "task", ID: "abc"}); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if b.Len() != 0 {
+		t.Fatalf("expected no output when disabled, got %q", b.String())
+	}
+}
+
 func TestEmitExtractRoundTrip(t *testing.T) {
+	t.Setenv(envVar, "1")
 	var b strings.Builder
 	ref := Reference{Type: "task", ID: "abc", Intent: "created", Preview: &Preview{Title: "Fix login", Status: "draft"}}
 	if err := Emit(&b, ref); err != nil {
@@ -34,6 +46,7 @@ func TestEmitExtractRoundTrip(t *testing.T) {
 }
 
 func TestEmitSkipsIncomplete(t *testing.T) {
+	t.Setenv(envVar, "1")
 	var b strings.Builder
 	if err := Emit(&b, Reference{Type: "task"}); err != nil {
 		t.Fatalf("emit: %v", err)
@@ -66,6 +79,7 @@ func TestExtractIgnoresMidLineMention(t *testing.T) {
 }
 
 func TestExtractMultiple(t *testing.T) {
+	t.Setenv(envVar, "1")
 	var b strings.Builder
 	_ = Emit(&b, Reference{Type: "task", ID: "t1"})
 	_ = Emit(&b, Reference{Type: "goal", ID: "g1"})

--- a/internal/server/sessions.go
+++ b/internal/server/sessions.go
@@ -314,10 +314,24 @@ func (s *Server) SendSessionMessage(w http.ResponseWriter, r *http.Request, agen
 						"input":      args,
 					})
 				case "done":
+					// Lift renderable-reference sentinels out of the live output so
+					// the chat can show a card the moment the tool finishes, without
+					// waiting for a reload to hydrate them from storage. Extraction
+					// also runs at LCM ingest for the persisted copy; the two are
+					// independent.
+					output := tu.Content
+					if clean, refs := renderrefs.Extract(output); len(refs) > 0 {
+						output = clean
+						writeData(map[string]any{
+							"type": "data-tool-references",
+							"id":   tu.ID,
+							"data": map[string]any{"toolCallId": tu.ID, "references": refs},
+						})
+					}
 					writeData(map[string]any{
 						"type":       "tool-output-available",
 						"toolCallId": tu.ID,
-						"output":     tu.Content,
+						"output":     output,
 					})
 				case "error":
 					writeData(map[string]any{

--- a/internal/server/sessions.go
+++ b/internal/server/sessions.go
@@ -1638,7 +1638,7 @@ func serializeUserRow(row sqlc.CtxMessage) map[string]any {
 	return map[string]any{
 		"id":          row.ID,
 		"role":        "user",
-		"timestamp":   row.CreatedAt,
+		"timestamp":   parseTime(row.CreatedAt),
 		"content":     row.Content,
 		"token_count": row.TokenCount,
 	}
@@ -1674,7 +1674,7 @@ func serializeAssistantRows(rows []sqlc.CtxMessage, start int) (map[string]any, 
 		"id":          rows[start].ID,
 		"role":        "assistant",
 		"blocks":      blocks,
-		"timestamp":   rows[start].CreatedAt,
+		"timestamp":   parseTime(rows[start].CreatedAt),
 		"token_count": totalTokens,
 	}, consumed
 }
@@ -1697,7 +1697,7 @@ func serializeToolRow(row sqlc.CtxMessage) map[string]any {
 	m := map[string]any{
 		"id":          row.ID,
 		"role":        "tool",
-		"timestamp":   row.CreatedAt,
+		"timestamp":   parseTime(row.CreatedAt),
 		"token_count": row.TokenCount,
 	}
 	var env struct {

--- a/internal/server/sessions.go
+++ b/internal/server/sessions.go
@@ -25,6 +25,7 @@ import (
 	"github.com/CherryHQ/stella/internal/config"
 	"github.com/CherryHQ/stella/internal/memory"
 	"github.com/CherryHQ/stella/internal/pluginhost"
+	"github.com/CherryHQ/stella/internal/renderrefs"
 	skillstool "github.com/CherryHQ/stella/internal/tools/skills"
 	"github.com/CherryHQ/stella/pkg/ai"
 	"github.com/CherryHQ/stella/pkg/db/sqlc"
@@ -1700,10 +1701,11 @@ func serializeToolRow(row sqlc.CtxMessage) map[string]any {
 		"token_count": row.TokenCount,
 	}
 	var env struct {
-		ID     string          `json:"id"`
-		Tool   string          `json:"tool"`
-		Result json.RawMessage `json:"result"`
-		Error  string          `json:"error,omitempty"`
+		ID         string                 `json:"id"`
+		Tool       string                 `json:"tool"`
+		Result     json.RawMessage        `json:"result"`
+		Error      string                 `json:"error,omitempty"`
+		References []renderrefs.Reference `json:"references,omitempty"`
 	}
 	if err := json.Unmarshal([]byte(row.Content), &env); err != nil {
 		// Malformed envelope: best-effort — show raw content, no ID to match.
@@ -1721,6 +1723,9 @@ func serializeToolRow(row sqlc.CtxMessage) map[string]any {
 	m["tool_name"] = env.Tool
 	m["content"] = text
 	m["is_error"] = env.Error != ""
+	if len(env.References) > 0 {
+		m["references"] = env.References
+	}
 	return m
 }
 

--- a/internal/tools/bash.go
+++ b/internal/tools/bash.go
@@ -50,6 +50,10 @@ func (t *hostBashTool) Execute(ctx context.Context, args map[string]any) (string
 	if t.toolsBinDir != "" {
 		env["PATH"] = t.toolsBinDir + string(os.PathListSeparator) + os.Getenv("PATH")
 	}
+	// Opt the CLI into emitting renderable-reference sentinels: when the agent
+	// runs `stella task/goal/recally create`, the command announces the new
+	// entity on stderr so the chat can render a rich card instead of a UUID.
+	env["STELLA_RENDERABLE_REFS"] = "1"
 	execOpts := sandbox.ExecOptions{Timeout: time.Duration(timeoutSeconds) * time.Second, Env: env}
 	if t.projectRoot != "" {
 		execOpts.Cwd = t.projectRoot

--- a/resources/skills/system/recally/references/save-workflow.md
+++ b/resources/skills/system/recally/references/save-workflow.md
@@ -107,6 +107,6 @@ Required values for this workflow:
 - source type (`web`, `twitter`, `youtube`, `github`, `rss`, or `pdf`)
 - `worth_reading` metadata value: `Top pick`, `Good read`, or `Skim` — no emoji
 
-**Output** (`--json`): the saved article resource, including `id`, `file_path`, `url`, `title`, `status`, `source_type`, and `saved_at`. The CLI also prints a sideband marker on stderr that the chat renders as a clickable article card — run `stella recally save` plainly and do not discard stderr (no `2>/dev/null`), or the user sees a bare ID instead.
+**Output** (`--json`): the saved article resource, including `id`, `file_path`, `url`, `title`, `status`, `source_type`, and `saved_at`. The CLI also prints a sideband marker on stderr that the chat renders as a clickable article card — run `stella recally save` plainly and do not discard stderr (no `2>/dev/null`), or the user sees a bare ID instead. The card shows the title and a link, so do not echo the raw ID/title back into your reply text.
 
 To re-fetch and refresh an existing article: recompute `$f` from the URL hash, re-fetch, read `stella recally save --help`, then save again with the refreshed content file.

--- a/resources/skills/system/recally/references/save-workflow.md
+++ b/resources/skills/system/recally/references/save-workflow.md
@@ -107,6 +107,6 @@ Required values for this workflow:
 - source type (`web`, `twitter`, `youtube`, `github`, `rss`, or `pdf`)
 - `worth_reading` metadata value: `Top pick`, `Good read`, or `Skim` — no emoji
 
-**Output** (`--json`): the saved article resource, including `id`, `file_path`, `url`, `title`, `status`, `source_type`, and `saved_at`.
+**Output** (`--json`): the saved article resource, including `id`, `file_path`, `url`, `title`, `status`, `source_type`, and `saved_at`. The CLI also prints a sideband marker on stderr that the chat renders as a clickable article card — run `stella recally save` plainly and do not discard stderr (no `2>/dev/null`), or the user sees a bare ID instead.
 
 To re-fetch and refresh an existing article: recompute `$f` from the URL hash, re-fetch, read `stella recally save --help`, then save again with the refreshed content file.

--- a/resources/skills/system/stella/references/tasks.md
+++ b/resources/skills/system/stella/references/tasks.md
@@ -79,7 +79,7 @@ All commands are `stella task ...` or `stella task goal ...`.
 
 **Create one background task.** Use `stella task create ... --activate`. Add `--project-id <project-id>` for project-scoped work. Without `--activate`, the task stays `draft` and never runs.
 
-**Let the chat render created entities.** When you create a task or goal, the CLI prints a sideband marker on stderr that the chat turns into a rich, clickable card. Run `stella task create` / `stella task goal create` plainly — do not redirect or discard stderr (no `2>/dev/null`), or the user sees a bare ID instead of a card.
+**Let the chat render created entities.** When you create a task or goal, the CLI prints a sideband marker on stderr that the chat turns into a rich, clickable card. Run `stella task create` / `stella task goal create` plainly — do not redirect or discard stderr (no `2>/dev/null`), or the user sees a bare ID instead of a card. The card already shows the title, status, and a link, so do **not** echo the raw ID/title back into your reply text — just say what you did and let the card speak.
 
 **Build a goal.** Create the goal first, optionally with `--project-id`, then create child tasks with `stella task create --goal-id <goal-id> ...`. A task created without `--goal-id` is standalone and will not appear under `stella task goal tasks <goal-id>` or the Web UI goal detail page.
 

--- a/resources/skills/system/stella/references/tasks.md
+++ b/resources/skills/system/stella/references/tasks.md
@@ -79,6 +79,8 @@ All commands are `stella task ...` or `stella task goal ...`.
 
 **Create one background task.** Use `stella task create ... --activate`. Add `--project-id <project-id>` for project-scoped work. Without `--activate`, the task stays `draft` and never runs.
 
+**Let the chat render created entities.** When you create a task or goal, the CLI prints a sideband marker on stderr that the chat turns into a rich, clickable card. Run `stella task create` / `stella task goal create` plainly — do not redirect or discard stderr (no `2>/dev/null`), or the user sees a bare ID instead of a card.
+
 **Build a goal.** Create the goal first, optionally with `--project-id`, then create child tasks with `stella task create --goal-id <goal-id> ...`. A task created without `--goal-id` is standalone and will not appear under `stella task goal tasks <goal-id>` or the Web UI goal detail page.
 
 **Build a dependency graph.** Create upstream tasks first, note their IDs, then create downstream tasks with `--dep <upstream-id>` or add edges later with `stella task dep add`. Default dependency behavior is `hard` + `block`: downstream waits for upstream success.

--- a/web/src/components/chat/AssistantMessage.tsx
+++ b/web/src/components/chat/AssistantMessage.tsx
@@ -23,6 +23,7 @@ import {
 import { getAgentColor } from "@/lib/agent-colors";
 import { CollapsibleThinking } from "./CollapsibleThinking";
 import { CopyButton, REVEAL_ON_HOVER } from "./CopyButton";
+import { RenderableReferenceList } from "./references";
 import { SessionTrace } from "./SessionTrace";
 
 export interface AssistantMessageProps {
@@ -233,27 +234,37 @@ function StepsGroup({ blocks, active }: { blocks: ContentBlock[]; active: boolea
     labelText = t("sessions.transcript.worked");
   }
 
+  // Renderable references the agent emitted while creating entities in this
+  // step group. Surfaced as cards OUTSIDE the collapsible — the raw tool output
+  // defaults to collapsed, so a card buried inside would read as "not done".
+  const references = blocks.flatMap((b) =>
+    b.type === "tool_call" ? (b.result?.references ?? []) : [],
+  );
+
   return (
-    <CollapsibleThinking labelText={labelText} expanded={expanded} onToggle={setExpanded}>
-      <div className="space-y-3">
-        {blocks.map((block, idx) => {
-          if (block.type === "thinking" && block.thinking) {
-            return (
-              <div
-                key={idx}
-                className="py-0.5 text-xs text-muted-foreground/80 leading-relaxed whitespace-pre-wrap break-words overflow-hidden border-l border-border/60 pl-3 font-sans min-w-0"
-              >
-                {block.thinking}
-              </div>
-            );
-          }
-          if (block.type === "tool_call") {
-            return <ToolStepRow key={idx} block={block} />;
-          }
-          return null;
-        })}
-      </div>
-    </CollapsibleThinking>
+    <div className="space-y-3">
+      <CollapsibleThinking labelText={labelText} expanded={expanded} onToggle={setExpanded}>
+        <div className="space-y-3">
+          {blocks.map((block, idx) => {
+            if (block.type === "thinking" && block.thinking) {
+              return (
+                <div
+                  key={idx}
+                  className="py-0.5 text-xs text-muted-foreground/80 leading-relaxed whitespace-pre-wrap break-words overflow-hidden border-l border-border/60 pl-3 font-sans min-w-0"
+                >
+                  {block.thinking}
+                </div>
+              );
+            }
+            if (block.type === "tool_call") {
+              return <ToolStepRow key={idx} block={block} />;
+            }
+            return null;
+          })}
+        </div>
+      </CollapsibleThinking>
+      {references.length > 0 && <RenderableReferenceList references={references} />}
+    </div>
   );
 }
 

--- a/web/src/components/chat/references/ArticleReferenceCard.tsx
+++ b/web/src/components/chat/references/ArticleReferenceCard.tsx
@@ -1,0 +1,57 @@
+import { queryOptions, useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { ArrowUpRight, BookOpen } from "lucide-react";
+import { getArticle } from "@/lib/api-client";
+import type { Article } from "@/lib/api-client/types.gen";
+import { useI18n } from "@/lib/i18n";
+import type { RenderableReference } from "@/lib/types";
+import { StatusBadge } from "@/features/recally/components/StatusBadge";
+import { ReferenceCardShell } from "./ReferenceCardShell";
+
+function articleOptions(id: string) {
+  return queryOptions({
+    queryKey: ["recally", "article", id],
+    queryFn: async () => {
+      const { data } = await getArticle({ path: { id }, throwOnError: true });
+      return data as Article;
+    },
+    enabled: !!id,
+  });
+}
+
+export function ArticleReferenceCard({ reference }: { reference: RenderableReference }) {
+  const { t } = useI18n();
+  const { data: article, isError } = useQuery(articleOptions(reference.id));
+
+  const title = article?.title ?? reference.preview?.title ?? reference.id;
+
+  if (isError) {
+    return (
+      <ReferenceCardShell
+        icon={BookOpen}
+        kind={t("references.article")}
+        title={t("references.deleted")}
+        muted
+      />
+    );
+  }
+
+  return (
+    <ReferenceCardShell
+      icon={BookOpen}
+      kind={t("references.article")}
+      title={title}
+      status={article ? <StatusBadge status={article.status} t={t} /> : undefined}
+      action={
+        <Link
+          to="/recally"
+          search={{ article: reference.id }}
+          className="inline-flex shrink-0 items-center gap-1 rounded-lg px-2 py-1 font-mono text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+        >
+          {t("references.open")}
+          <ArrowUpRight className="size-3.5" />
+        </Link>
+      }
+    />
+  );
+}

--- a/web/src/components/chat/references/GenericReferenceCard.tsx
+++ b/web/src/components/chat/references/GenericReferenceCard.tsx
@@ -1,0 +1,19 @@
+import { FileQuestion } from "lucide-react";
+import type { RenderableReference } from "@/lib/types";
+import { ReferenceCardShell } from "./ReferenceCardShell";
+
+/**
+ * Fallback for reference types this client build doesn't know how to render
+ * (e.g. a newer backend emitting a type the UI predates). Shows what we have —
+ * type + preview title + short id — and offers no Open target.
+ */
+export function GenericReferenceCard({ reference }: { reference: RenderableReference }) {
+  return (
+    <ReferenceCardShell
+      icon={FileQuestion}
+      kind={reference.type}
+      title={reference.preview?.title ?? reference.id.slice(0, 8)}
+      muted
+    />
+  );
+}

--- a/web/src/components/chat/references/GoalReferenceCard.tsx
+++ b/web/src/components/chat/references/GoalReferenceCard.tsx
@@ -5,11 +5,16 @@ import { goalGraphOptions, goalOptions } from "@/lib/queries/goals";
 import { useI18n } from "@/lib/i18n";
 import type { RenderableReference } from "@/lib/types";
 import { StatusPill, statusLabel, statusMeta } from "@/features/tasks/lib";
+import { pollWhileActive } from "./poll";
 import { ReferenceCardShell } from "./ReferenceCardShell";
 
 export function GoalReferenceCard({ reference }: { reference: RenderableReference }) {
   const { t } = useI18n();
-  const { data: goal, isError } = useQuery(goalOptions(reference.id));
+  // Poll only while the goal is active; the shared goalOptions stays unpolled.
+  const { data: goal, isError } = useQuery({
+    ...goalOptions(reference.id),
+    refetchInterval: pollWhileActive,
+  });
   const { data: graph } = useQuery(goalGraphOptions(reference.id));
 
   const title = goal?.title ?? reference.preview?.title ?? reference.id;

--- a/web/src/components/chat/references/GoalReferenceCard.tsx
+++ b/web/src/components/chat/references/GoalReferenceCard.tsx
@@ -57,19 +57,25 @@ export function GoalReferenceCard({ reference }: { reference: RenderableReferenc
         }
       />
       {tasks.length > 0 && (
-        <div className="flex items-center gap-3 pl-12 font-mono text-[11px] text-muted-foreground/70">
+        <div className="flex items-center gap-2 pl-12 text-[11px] text-muted-foreground/70">
           <span>{t("references.goalTasks", { count: tasks.length })}</span>
           {done > 0 && (
-            <span className="inline-flex items-center gap-1">
-              <span className={`size-1.5 rounded-full ${statusMeta("done").dot}`} />
-              {done}
-            </span>
+            <>
+              <span aria-hidden>·</span>
+              <span className="inline-flex items-center gap-1">
+                <span className={`size-1.5 rounded-full ${statusMeta("done").dot}`} />
+                {t("references.goalDone", { count: done })}
+              </span>
+            </>
           )}
           {running > 0 && (
-            <span className="inline-flex items-center gap-1">
-              <span className={`size-1.5 rounded-full ${statusMeta("running").dot}`} />
-              {running}
-            </span>
+            <>
+              <span aria-hidden>·</span>
+              <span className="inline-flex items-center gap-1">
+                <span className={`size-1.5 rounded-full ${statusMeta("running").dot}`} />
+                {t("references.goalRunning", { count: running })}
+              </span>
+            </>
           )}
         </div>
       )}

--- a/web/src/components/chat/references/GoalReferenceCard.tsx
+++ b/web/src/components/chat/references/GoalReferenceCard.tsx
@@ -1,0 +1,73 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { ArrowUpRight, Target } from "lucide-react";
+import { goalGraphOptions, goalOptions } from "@/lib/queries/goals";
+import { useI18n } from "@/lib/i18n";
+import type { RenderableReference } from "@/lib/types";
+import { StatusPill, statusLabel, statusMeta } from "@/features/tasks/lib";
+import { ReferenceCardShell } from "./ReferenceCardShell";
+
+export function GoalReferenceCard({ reference }: { reference: RenderableReference }) {
+  const { t } = useI18n();
+  const { data: goal, isError } = useQuery(goalOptions(reference.id));
+  const { data: graph } = useQuery(goalGraphOptions(reference.id));
+
+  const title = goal?.title ?? reference.preview?.title ?? reference.id;
+  const status = goal?.status ?? reference.preview?.status;
+
+  if (isError) {
+    return (
+      <ReferenceCardShell
+        icon={Target}
+        kind={t("references.goal")}
+        title={t("references.deleted")}
+        muted
+      />
+    );
+  }
+
+  // Subtask rollup — a single summary line, not the full DAG (design V2).
+  const tasks = graph?.tasks ?? [];
+  const done = tasks.filter((tk) => tk.status === "done").length;
+  const running = tasks.filter((tk) => tk.status === "running").length;
+
+  return (
+    <div className="flex flex-col gap-1">
+      <ReferenceCardShell
+        icon={Target}
+        kind={t("references.goal")}
+        title={title}
+        status={status ? <StatusPill status={status} label={statusLabel(t, status)} /> : undefined}
+        action={
+          goal?.agent_id ? (
+            <Link
+              to="/agents/$agentId/tasks/goals/$goalId"
+              params={{ agentId: goal.agent_id, goalId: reference.id }}
+              className="inline-flex shrink-0 items-center gap-1 rounded-lg px-2 py-1 font-mono text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              {t("references.open")}
+              <ArrowUpRight className="size-3.5" />
+            </Link>
+          ) : undefined
+        }
+      />
+      {tasks.length > 0 && (
+        <div className="flex items-center gap-3 pl-12 font-mono text-[11px] text-muted-foreground/70">
+          <span>{t("references.goalTasks", { count: tasks.length })}</span>
+          {done > 0 && (
+            <span className="inline-flex items-center gap-1">
+              <span className={`size-1.5 rounded-full ${statusMeta("done").dot}`} />
+              {done}
+            </span>
+          )}
+          {running > 0 && (
+            <span className="inline-flex items-center gap-1">
+              <span className={`size-1.5 rounded-full ${statusMeta("running").dot}`} />
+              {running}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/chat/references/ReferenceCardShell.tsx
+++ b/web/src/components/chat/references/ReferenceCardShell.tsx
@@ -1,0 +1,48 @@
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Shared layout for every renderable-reference card. Cards differ only in their
+ * icon, kind label, status node, and Open target; this shell owns the common
+ * frame so task / goal / article cards stay visually identical (design V2).
+ */
+export function ReferenceCardShell({
+  icon: Icon,
+  kind,
+  title,
+  status,
+  action,
+  muted,
+}: {
+  icon: LucideIcon;
+  kind: string;
+  title: ReactNode;
+  status?: ReactNode;
+  action?: ReactNode;
+  /** Dim the frame for tombstone / unknown states. */
+  muted?: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 rounded-xl border border-border bg-card px-3 py-2.5 text-sm",
+        muted && "opacity-70",
+      )}
+    >
+      <span className="grid size-7 shrink-0 place-items-center rounded-lg bg-muted text-muted-foreground">
+        <Icon className="size-4" />
+      </span>
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/70">
+            {kind}
+          </span>
+          {status}
+        </div>
+        <span className="truncate font-medium text-foreground">{title}</span>
+      </div>
+      {action}
+    </div>
+  );
+}

--- a/web/src/components/chat/references/TaskReferenceCard.tsx
+++ b/web/src/components/chat/references/TaskReferenceCard.tsx
@@ -6,6 +6,7 @@ import type { ComponentsTask } from "@/lib/api-client/types.gen";
 import { useI18n } from "@/lib/i18n";
 import type { RenderableReference } from "@/lib/types";
 import { StatusPill, statusLabel } from "@/features/tasks/lib";
+import { pollWhileActive } from "./poll";
 import { ReferenceCardShell } from "./ReferenceCardShell";
 
 function taskOptions(taskId: string) {
@@ -16,6 +17,7 @@ function taskOptions(taskId: string) {
       return data as ComponentsTask;
     },
     enabled: !!taskId,
+    refetchInterval: pollWhileActive,
   });
 }
 

--- a/web/src/components/chat/references/TaskReferenceCard.tsx
+++ b/web/src/components/chat/references/TaskReferenceCard.tsx
@@ -1,0 +1,62 @@
+import { queryOptions, useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { ArrowUpRight, ListTodo } from "lucide-react";
+import { getTask } from "@/lib/api-client";
+import type { ComponentsTask } from "@/lib/api-client/types.gen";
+import { useI18n } from "@/lib/i18n";
+import type { RenderableReference } from "@/lib/types";
+import { StatusPill, statusLabel } from "@/features/tasks/lib";
+import { ReferenceCardShell } from "./ReferenceCardShell";
+
+function taskOptions(taskId: string) {
+  return queryOptions({
+    queryKey: ["task", taskId],
+    queryFn: async () => {
+      const { data } = await getTask({ path: { taskId }, throwOnError: true });
+      return data as ComponentsTask;
+    },
+    enabled: !!taskId,
+  });
+}
+
+export function TaskReferenceCard({ reference }: { reference: RenderableReference }) {
+  const { t } = useI18n();
+  const { data: task, isError } = useQuery(taskOptions(reference.id));
+
+  // Live entity wins; preview is only a first-paint placeholder and is never
+  // trusted for routing or existence.
+  const title = task?.title ?? reference.preview?.title ?? reference.id;
+  const status = task?.status ?? reference.preview?.status;
+
+  if (isError) {
+    return (
+      <ReferenceCardShell
+        icon={ListTodo}
+        kind={t("references.task")}
+        title={t("references.deleted")}
+        muted
+      />
+    );
+  }
+
+  return (
+    <ReferenceCardShell
+      icon={ListTodo}
+      kind={t("references.task")}
+      title={title}
+      status={status ? <StatusPill status={status} label={statusLabel(t, status)} /> : undefined}
+      action={
+        task?.agent_id ? (
+          <Link
+            to="/agents/$agentId/tasks/$taskId"
+            params={{ agentId: task.agent_id, taskId: reference.id }}
+            className="inline-flex shrink-0 items-center gap-1 rounded-lg px-2 py-1 font-mono text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            {t("references.open")}
+            <ArrowUpRight className="size-3.5" />
+          </Link>
+        ) : undefined
+      }
+    />
+  );
+}

--- a/web/src/components/chat/references/index.tsx
+++ b/web/src/components/chat/references/index.tsx
@@ -18,8 +18,9 @@ const registry: Record<string, React.ComponentType<{ reference: RenderableRefere
 /**
  * Renders the renderable-reference cards an agent emitted in a tool step. Placed
  * by {@link StepsGroup} outside the collapsible so cards are always visible, not
- * buried in the (default-collapsed) raw tool output. Dedupes by type+id so a
- * reference echoed across steps shows once.
+ * buried in the (default-collapsed) raw tool output. Dedupes by type+id within
+ * this list (one StepsGroup); the same entity surfacing in a different step
+ * group still renders once per group.
  */
 export function RenderableReferenceList({ references }: { references: RenderableReference[] }) {
   const seen = new Set<string>();

--- a/web/src/components/chat/references/index.tsx
+++ b/web/src/components/chat/references/index.tsx
@@ -1,0 +1,38 @@
+import type { RenderableReference } from "@/lib/types";
+import { GenericReferenceCard } from "./GenericReferenceCard";
+import { TaskReferenceCard } from "./TaskReferenceCard";
+
+/**
+ * Per-type card registry. Each renderer owns its own hydration and Open target;
+ * the registry only maps a reference `type` to its card. Unknown types fall back
+ * to {@link GenericReferenceCard}. Add goal / article renderers here in P2.
+ */
+const registry: Record<string, React.ComponentType<{ reference: RenderableReference }>> = {
+  task: TaskReferenceCard,
+};
+
+/**
+ * Renders the renderable-reference cards an agent emitted in a tool step. Placed
+ * by {@link StepsGroup} outside the collapsible so cards are always visible, not
+ * buried in the (default-collapsed) raw tool output. Dedupes by type+id so a
+ * reference echoed across steps shows once.
+ */
+export function RenderableReferenceList({ references }: { references: RenderableReference[] }) {
+  const seen = new Set<string>();
+  const unique = references.filter((r) => {
+    const key = `${r.type}:${r.id}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+  if (unique.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-2">
+      {unique.map((reference) => {
+        const Card = registry[reference.type] ?? GenericReferenceCard;
+        return <Card key={`${reference.type}:${reference.id}`} reference={reference} />;
+      })}
+    </div>
+  );
+}

--- a/web/src/components/chat/references/index.tsx
+++ b/web/src/components/chat/references/index.tsx
@@ -33,7 +33,7 @@ export function RenderableReferenceList({ references }: { references: Renderable
   if (unique.length === 0) return null;
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex max-w-xl flex-col gap-2">
       {unique.map((reference) => {
         const Card = registry[reference.type] ?? GenericReferenceCard;
         return <Card key={`${reference.type}:${reference.id}`} reference={reference} />;

--- a/web/src/components/chat/references/index.tsx
+++ b/web/src/components/chat/references/index.tsx
@@ -1,14 +1,18 @@
 import type { RenderableReference } from "@/lib/types";
+import { ArticleReferenceCard } from "./ArticleReferenceCard";
 import { GenericReferenceCard } from "./GenericReferenceCard";
+import { GoalReferenceCard } from "./GoalReferenceCard";
 import { TaskReferenceCard } from "./TaskReferenceCard";
 
 /**
  * Per-type card registry. Each renderer owns its own hydration and Open target;
  * the registry only maps a reference `type` to its card. Unknown types fall back
- * to {@link GenericReferenceCard}. Add goal / article renderers here in P2.
+ * to {@link GenericReferenceCard}.
  */
 const registry: Record<string, React.ComponentType<{ reference: RenderableReference }>> = {
   task: TaskReferenceCard,
+  goal: GoalReferenceCard,
+  recally_article: ArticleReferenceCard,
 };
 
 /**

--- a/web/src/components/chat/references/poll.ts
+++ b/web/src/components/chat/references/poll.ts
@@ -1,0 +1,16 @@
+/** Statuses a goal or task can no longer move out of. */
+const TERMINAL = new Set(["done", "failed", "cancelled"]);
+
+const POLL_MS = 15_000;
+
+/**
+ * `refetchInterval` for an entity card: poll every 15s while the entity is in a
+ * non-terminal status, stop once it settles. Polling is inherently scoped to a
+ * mounted card — TanStack pauses it when the last observer unmounts — so closed
+ * conversations cost nothing. Typed structurally to stay agnostic of each
+ * query's key/data generics.
+ */
+export function pollWhileActive(query: { state: { data?: { status?: string } } }): number | false {
+  const status = query.state.data?.status;
+  return status && TERMINAL.has(status) ? false : POLL_MS;
+}

--- a/web/src/features/recally/RecallyPage.tsx
+++ b/web/src/features/recally/RecallyPage.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
+import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useI18n } from "@/lib/i18n";
 import { X } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -15,7 +16,20 @@ import { ToastAlert } from "./components/ToastAlert";
 
 export function RecallyPage() {
   const { t } = useI18n();
-  const [selectedId, setSelectedId] = useState<string | null>(null);
+  // Selected article lives in the URL (`?article=`) so it survives refresh and
+  // back/forward, and so reference cards can deep-link straight to a reader.
+  const navigate = useNavigate();
+  const { article } = useSearch({ from: "/_app/recally" });
+  const selectedId = article ?? null;
+  const setSelectedId = useCallback(
+    (id: string | null) => {
+      void navigate({
+        to: "/recally",
+        search: (prev) => ({ ...prev, article: id ?? undefined }),
+      });
+    },
+    [navigate],
+  );
   const [chatOpen, setChatOpen] = useState(false);
 
   const filters = useRecallyFilters();

--- a/web/src/lib/chat-transport.ts
+++ b/web/src/lib/chat-transport.ts
@@ -1,7 +1,7 @@
 import { DefaultChatTransport } from "ai";
 import type { UIMessage } from "ai";
 import type { GroupMessage } from "@/lib/api-client/types.gen";
-import type { Message } from "./types";
+import type { Message, RenderableReference } from "./types";
 
 export function createSessionTransport(agentId: string, sessionId: string) {
   return new DefaultChatTransport({
@@ -254,6 +254,20 @@ export function uiMessageToMessage(m: UIMessage): Message {
   const blocks: Message["blocks"] = [];
   let content = "";
 
+  // Renderable references arrive as out-of-band `data-tool-references` parts
+  // (the live counterpart of the stored `references[]`); collect them up front
+  // and attach to the matching tool block so cards show mid-stream.
+  const refsByTool = new Map<string, RenderableReference[]>();
+  for (const part of m.parts) {
+    if (part.type === "data-tool-references") {
+      const data = (part as unknown as { data?: { toolCallId?: string; references?: unknown } })
+        .data;
+      if (data?.toolCallId && Array.isArray(data.references)) {
+        refsByTool.set(data.toolCallId, data.references as RenderableReference[]);
+      }
+    }
+  }
+
   for (const part of m.parts) {
     switch (part.type) {
       case "text":
@@ -273,6 +287,7 @@ export function uiMessageToMessage(m: UIMessage): Message {
                 ? part.output
                 : JSON.stringify(part.output)
             : undefined;
+          const references = refsByTool.get(part.toolCallId);
           blocks.push({
             type: "tool_call",
             id: part.toolCallId,
@@ -285,6 +300,7 @@ export function uiMessageToMessage(m: UIMessage): Message {
                     tool_call_id: part.toolCallId,
                     content: outputContent!,
                     is_error: part.state === "output-error",
+                    ...(references && references.length > 0 ? { references } : {}),
                   },
                 }
               : {}),

--- a/web/src/lib/chat-transport.ts
+++ b/web/src/lib/chat-transport.ts
@@ -195,7 +195,7 @@ export function messageToUIMessage(m: Message): UIMessage {
             parts.push({ type: "reasoning", text: block.thinking, providerMetadata: {} });
           }
           break;
-        case "tool_call":
+        case "tool_call": {
           parts.push({
             type: "dynamic-tool",
             toolName: block.name,
@@ -209,7 +209,19 @@ export function messageToUIMessage(m: Message): UIMessage {
             ...(block.result && !block.result.is_error ? { output: block.result.content } : {}),
             ...(block.result?.is_error ? { errorText: block.result.content } : {}),
           } as UIMessage["parts"][number]);
+          // Re-emit references as a data part so history rehydration feeds the
+          // exact same channel as the live SSE stream — uiMessageToMessage reads
+          // `data-tool-references` for both, so there is one rendering path.
+          const refs = block.result?.references;
+          if (refs && refs.length > 0) {
+            parts.push({
+              type: "data-tool-references",
+              id: block.id,
+              data: { toolCallId: block.id, references: refs },
+            } as unknown as UIMessage["parts"][number]);
+          }
           break;
+        }
       }
     }
   } else if (m.content) {

--- a/web/src/lib/chat-transport.ts
+++ b/web/src/lib/chat-transport.ts
@@ -154,6 +154,7 @@ export function mergeToolResults(messages: Message[]): Message[] {
                 tool_call_id: m.tool_call_id!,
                 content: m.content ?? "",
                 is_error: false,
+                ...(m.references && m.references.length > 0 ? { references: m.references } : {}),
               },
             };
           }

--- a/web/src/lib/i18n/messages.ts
+++ b/web/src/lib/i18n/messages.ts
@@ -23,6 +23,8 @@ const en = {
   "references.open": "Open",
   "references.deleted": "No longer available",
   "references.goalTasks": "{{count}} tasks",
+  "references.goalDone": "{{count}} done",
+  "references.goalRunning": "{{count}} running",
 
   // Agent IA
   "inbox.needsYou": "Needs you",
@@ -1599,6 +1601,8 @@ const zh: Record<MessageKey, string> = {
   "references.open": "打开",
   "references.deleted": "已不存在",
   "references.goalTasks": "{{count}} 个任务",
+  "references.goalDone": "{{count}} 完成",
+  "references.goalRunning": "{{count}} 进行",
 
   // Agent IA
   "inbox.needsYou": "需要你",

--- a/web/src/lib/i18n/messages.ts
+++ b/web/src/lib/i18n/messages.ts
@@ -16,6 +16,13 @@ const en = {
   "nav.docs": "Docs",
   "nav.apiReferences": "API References",
 
+  // Renderable reference cards (agent-created entities in chat)
+  "references.task": "Task",
+  "references.goal": "Goal",
+  "references.article": "Article",
+  "references.open": "Open",
+  "references.deleted": "No longer available",
+
   // Agent IA
   "inbox.needsYou": "Needs you",
   "inbox.title": "Inbox",
@@ -1583,6 +1590,13 @@ const zh: Record<MessageKey, string> = {
   "nav.recally.desc": "阅读队列、订阅源与记忆",
   "nav.docs": "文档",
   "nav.apiReferences": "API 文档",
+
+  // Renderable reference cards (agent-created entities in chat)
+  "references.task": "任务",
+  "references.goal": "目标",
+  "references.article": "文章",
+  "references.open": "打开",
+  "references.deleted": "已不存在",
 
   // Agent IA
   "inbox.needsYou": "需要你",

--- a/web/src/lib/i18n/messages.ts
+++ b/web/src/lib/i18n/messages.ts
@@ -22,6 +22,7 @@ const en = {
   "references.article": "Article",
   "references.open": "Open",
   "references.deleted": "No longer available",
+  "references.goalTasks": "{{count}} tasks",
 
   // Agent IA
   "inbox.needsYou": "Needs you",
@@ -1597,6 +1598,7 @@ const zh: Record<MessageKey, string> = {
   "references.article": "文章",
   "references.open": "打开",
   "references.deleted": "已不存在",
+  "references.goalTasks": "{{count}} 个任务",
 
   // Agent IA
   "inbox.needsYou": "需要你",

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -115,10 +115,25 @@ export interface ThinkingBlock {
 
 export type ContentBlock = TextBlock | ThinkingBlock | ToolBlock;
 
+/**
+ * A renderable reference an agent emitted when it created (or referenced) a
+ * Stella entity via a CLI tool. `type` + `id` are load-bearing; `preview` is a
+ * loading placeholder only — cards hydrate the live entity by id and never
+ * trust it past first paint.
+ */
+export interface RenderableReference {
+  v: 1;
+  type: "task" | "goal" | "recally_article" | (string & {});
+  id: string;
+  intent?: "created" | "referenced";
+  preview?: { title?: string; status?: string };
+}
+
 export interface ToolResult {
   tool_call_id: string;
   content: string;
   is_error: boolean;
+  references?: RenderableReference[];
 }
 
 export interface Message {
@@ -127,6 +142,7 @@ export interface Message {
   content?: string;
   blocks?: ContentBlock[];
   tool_call_id?: string;
+  references?: RenderableReference[];
   timestamp: string;
   token_count?: number;
   model?: string;

--- a/web/src/routes/_app/recally.tsx
+++ b/web/src/routes/_app/recally.tsx
@@ -1,3 +1,12 @@
 import { createFileRoute } from "@tanstack/react-router";
 
-export const Route = createFileRoute("/_app/recally")({});
+interface RecallySearch {
+  // Deep-link to a specific article (e.g. from an agent-created reference card).
+  article?: string;
+}
+
+export const Route = createFileRoute("/_app/recally")({
+  validateSearch: (search: Record<string, unknown>): RecallySearch => ({
+    article: typeof search.article === "string" ? search.article : undefined,
+  }),
+});


### PR DESCRIPTION
## What

Render agent-created entities (goal / task / recally article) in chat as rich, hydrating cards instead of the raw UUID the CLI prints. Closes #438.

A new sideband protocol lets the `stella ... create` commands announce what they created; the chat renders a compact card with title, type, live status, and an Open link. One mechanism covers all current types and is open for future ones.

## Why

When an agent creates a goal/task/article via the `bash` tool, the conversation only showed the bare identifier — technically correct, useless to a human. Users couldn't tell what was created, its status, or how to open it. See #438 for the full motivation.

## How

**Sideband protocol (`internal/renderrefs`)**
- On success, `stella task/goal create` and `stella recally save` write a sentinel line to **stderr**: `::stella-ref/v1::{"type":"task","id":"…","intent":"created","preview":{…}}`. stdout stays a clean `--json` entity.
- The `bash` tool injects `STELLA_RENDERABLE_REFS=1` so only agent runs emit — a human running the same command in a terminal sees nothing.
- At ingest (`toolResultToRows`), the engine lifts references out of the tool output once, strips the sentinel from the stored text, and persists them on the tool-result envelope. No DB column, no migration — references are derived data.
- `serializeToolRow` emits `references[]` on the message; the frontend carries them through to the UI.

**Frontend rendering**
- `StepsGroup` collects references from a step's tool results and renders cards **outside** the collapsed tool step (a card buried in collapsed output reads as "not done").
- Per-type registry → `TaskReferenceCard`, `GoalReferenceCard`, `ArticleReferenceCard`, with a generic fallback for unknown types and a tombstone card on 404.
- Cards hydrate the live entity by id (preview is a first-paint placeholder only, never trusted for routing/existence). Goal card adds a one-line subtask rollup.
- Filled the Recally deep-link gap: `?article=` search param + `RecallyPage` now derives the selected article from the URL (was `useState`), so cards can open a reader and selection survives refresh / back-forward.

**Phasing:** P1 = protocol + backend + task card (end-to-end one type). P2 = goal/article cards + recally deep-link. P3 (next) = non-terminal `refetchInterval`, prompt/skill guidance to not redirect stderr.

## Refs

- Closes #438
