### PR TITLE
🐛 fix(recally): clarify save UX for URL-only invocations

### DIFF
--- a/cmd/stella/recally_args.go
+++ b/cmd/stella/recally_args.go
@@ -2,16 +2,24 @@ package main
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	ucli "github.com/urfave/cli/v2"
 )
 
 func rejectFlagsAfterArgs(c *ucli.Context, usage string) error {
+	var misplaced []string
 	for _, arg := range c.Args().Slice() {
 		if strings.HasPrefix(arg, "-") {
-			return fmt.Errorf("flags must be placed before positional arguments; usage: %s", usage)
+			misplaced = append(misplaced, strconv.Quote(arg))
 		}
 	}
-	return nil
+	if len(misplaced) == 0 {
+		return nil
+	}
+	// Show the misplaced option(s) and the correct order so the caller can
+	// retry without guessing — the usage string already lists options first.
+	return fmt.Errorf("options must be placed before positional arguments; found %s after them; usage: %s",
+		strings.Join(misplaced, " "), usage)
 }

--- a/cmd/stella/recally_articles.go
+++ b/cmd/stella/recally_articles.go
@@ -18,11 +18,27 @@ import (
 func recallySaveCommand() *ucli.Command {
 	return &ucli.Command{
 		Name:      "save",
-		Usage:     "Save an article to your library",
+		Usage:     "Save already-fetched content as an article in your library",
 		ArgsUsage: "<url>",
-		Description: `Examples:
-  stella recally save --title "Article Title" --summary "Brief summary" --tags go --tags concurrency "https://example.com/article"
-  stella recally save --json --content-file article.md --source-type twitter --title "Tweet title" "https://x.com/user/status/123"
+		Description: `Saves content you have ALREADY fetched — it does not fetch the URL for you.
+
+Fetching web pages is error-prone (paywalls, JS-rendered pages, bot walls), so
+that step is left to the caller (e.g. an agent using tap fetch). For a NEW
+article the content is required via --content-file (or piped on stdin); without
+it the server rejects the save with "content is required for new articles".
+
+Typical workflow:
+  1. Fetch the page to a file:   tap fetch "https://example.com/article" > article.md
+  2. Derive title/summary/tags from that content.
+  3. Save it:                    stella recally save --content-file article.md --title "..." "https://example.com/article"
+
+Re-saving a URL that already exists WITHOUT --content-file refreshes its
+metadata only (title, summary, tags) and keeps the stored content.
+
+Examples:
+  stella recally save --content-file article.md --title "Article Title" --summary "Brief summary" --tags go --tags concurrency "https://example.com/article"
+  stella recally save --json --content-file tweet.md --source-type twitter --title "Tweet title" "https://x.com/user/status/123"
+  cat article.md | stella recally save --title "Piped article" "https://example.com/article"
 
 Options must be placed before the URL. Trailing options are rejected.`,
 		Flags: []ucli.Flag{
@@ -93,6 +109,19 @@ Options must be placed before the URL. Trailing options are rejected.`,
 			defer resp.Body.Close() //nolint:errcheck
 			var article apiclient.Article
 			if err := apiclient.DecodeJSON(resp, &article); err != nil {
+				// A new article with no content is the one confusing failure: the
+				// command does not fetch URLs, so turn the server's terse 400 into
+				// the exact fetch-then-save commands. Refreshing an existing article
+				// without content succeeds (200), so it never reaches here.
+				if resp.StatusCode == http.StatusBadRequest && content == "" {
+					return fmt.Errorf("%q is not saved yet and no content was provided.\n\n"+
+						"This command saves content you have already fetched — it does not fetch the URL.\n"+
+						"Fetch the page first, then save:\n"+
+						"  tap fetch %q > article.md\n"+
+						"  stella recally save --content-file article.md --title \"...\" %q\n\n"+
+						"Or pipe content on stdin:\n"+
+						"  cat article.md | stella recally save --title \"...\" %q", url, url, url, url)
+				}
 				return err
 			}
 			created := resp.StatusCode == http.StatusCreated

--- a/cmd/stella/recally_test.go
+++ b/cmd/stella/recally_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	ucli "github.com/urfave/cli/v2"
@@ -69,6 +70,32 @@ func TestRecallySaveUsesPositionalURL(t *testing.T) {
 	}
 }
 
+func TestRecallySaveNewWithoutContentGivesActionableError(t *testing.T) {
+	t.Setenv("STELLA_TOKEN", "test-token")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"code":"bad_request","message":"content is required for new articles","status":400}}`))
+	}))
+	defer server.Close()
+	t.Setenv("STELLA_SERVER_URL", server.URL)
+	config.ResetStellaHome()
+	t.Cleanup(config.ResetStellaHome)
+
+	app := ucli.NewApp()
+	app.Commands = []*ucli.Command{recallyCommand()}
+	err := app.Run([]string{"stella", "recally", "save", "https://example.com/article"})
+	if err == nil {
+		t.Fatal("expected error for new article without content")
+	}
+	got := err.Error()
+	for _, want := range []string{"is not saved yet", "tap fetch", "--content-file", "https://example.com/article"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("error %q missing %q", got, want)
+		}
+	}
+}
+
 func TestRecallySaveRequiresURL(t *testing.T) {
 	app := ucli.NewApp()
 	app.Commands = []*ucli.Command{recallyCommand()}
@@ -84,7 +111,7 @@ func TestRecallySaveRejectsFlagsAfterURL(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for flags after url")
 	}
-	if got := err.Error(); got != "flags must be placed before positional arguments; usage: stella recally save [options] <url>" {
+	if got := err.Error(); got != `options must be placed before positional arguments; found "--title" after them; usage: stella recally save [options] <url>` {
 		t.Fatalf("error = %q", got)
 	}
 }
@@ -96,7 +123,7 @@ func TestRecallyFeedMarkRejectsFlagsAfterArgs(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for flags after feed entry args")
 	}
-	if got := err.Error(); got != "flags must be placed before positional arguments; usage: stella recally feed mark [options] <feed-id> <entry-id>" {
+	if got := err.Error(); got != `options must be placed before positional arguments; found "--status" after them; usage: stella recally feed mark [options] <feed-id> <entry-id>` {
 		t.Fatalf("error = %q", got)
 	}
 }

--- a/resources/skills/system/recally/references/save-workflow.md
+++ b/resources/skills/system/recally/references/save-workflow.md
@@ -88,6 +88,10 @@ Potential biases, assumptions, strengths, or weaknesses. Any limitations or area
 
 ## 3. Save
 
+`save` never fetches the URL itself — that is why steps 1-2 exist. Content is
+required for a new article (`--content-file` or stdin); saving an already-saved
+URL without content refreshes its metadata only.
+
 Before saving, read the command help:
 
 ```bash


### PR DESCRIPTION
## What

Make `stella recally save <url>` self-explanatory when content is omitted, without adding auto-fetch.

- Rewrite `save` usage/description to state the command saves **already-fetched** content (it does not fetch URLs) and show the fetch → save and stdin workflows with runnable examples.
- Turn the server's terse `400 content is required for new articles` into an actionable CLI error that prints the exact `tap fetch` and `save --content-file` commands with the real URL.
- Improve the flag-order error to name the misplaced option(s) and show the correct order.
- Note the no-fetch contract in the recally `save-workflow.md` skill doc.

## Why

A bare `save <url>` failed with a confusing generic 400, implying the command should have fetched the page. Per the maintainer's design intent, fetching is intentionally the **agent's** job (paywalls, JS, bot walls) — so the fix is clarity and ergonomics, not auto-fetch.

## How

CLI-side error wrapping plus help/skill text only. No server or API changes.

- The actionable error only triggers on a `400` **with empty local content**, so refreshing an existing article (which returns `200`) is unaffected — avoids the false-positive of a blind pre-flight check that can't tell new from existing.
- stdin piping (`cat article.md | stella recally save ...`) already worked and is now documented.

Verified with `mise run format && mise run build && mise run test` (0 failures); added a CLI test asserting the actionable error and updated the flag-order assertions.

## Refs

Closes #514