### PR TITLE
🐛 fix(sandbox): auto-wire docker sandbox to reach stellad in DooD

### DIFF
--- a/plugins/sandbox/docker/config.go
+++ b/plugins/sandbox/docker/config.go
@@ -48,6 +48,22 @@ type Config struct {
 	// Normally auto-derived from STELLA_HOME_VOLUME by NewFactory.
 	StellaHomeVolume string
 
+	// SandboxNetwork, when set, attaches sandbox containers to this Docker
+	// network instead of the daemon default bridge. Required in DooD setups
+	// where stellad and the sandbox are separate containers: without a shared
+	// network the sandbox cannot reach stellad, so server-backed CLI commands
+	// (stella task/goal, recally) fail with connection refused. Set via
+	// STELLA_SANDBOX_NETWORK, otherwise auto-detected by NewFactory from the
+	// network stellad's own container is on.
+	SandboxNetwork string
+
+	// ServerURL, when set, is injected into the sandbox as STELLA_SERVER_URL so
+	// CLI commands inside the sandbox reach stellad over SandboxNetwork instead
+	// of the default 127.0.0.1 loopback (which, inside a separate sandbox
+	// container, points at nothing). Set via STELLA_SANDBOX_SERVER_URL, otherwise
+	// auto-detected by NewFactory as stellad's address on SandboxNetwork.
+	ServerURL string
+
 	// UserToolBinaries are manifest-declared, user-configured CLIs that are not
 	// baked into the versioned sandbox image. They are installed in a Linux
 	// helper container and exposed to sessions through a Docker-managed tool

--- a/plugins/sandbox/docker/dockerclient/container.go
+++ b/plugins/sandbox/docker/dockerclient/container.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sort"
+	"strings"
 
 	"github.com/containerd/errdefs"
 	"github.com/moby/moby/api/types/container"
@@ -49,6 +50,7 @@ type CreateOptions struct {
 	WorkspaceMount string      // absolute in-container path (e.g. "/workspace")
 	ExtraMounts    []Mount     // additional host -> container mounts; ReadOnly is honored per mount
 	NetworkMode    NetworkMode // disabled | allow_all
+	Network        string      // optional Docker network to join (e.g. to reach stellad in DooD); ignored when NetworkMode is disabled
 	Env            map[string]string
 	User           string            // optional container user override
 	Labels         map[string]string // must include LabelSessionID + LabelStellaHome + LabelCreatedAt
@@ -151,6 +153,60 @@ func (c *Client) InspectContainerState(ctx context.Context, containerRef string)
 	}, nil
 }
 
+// SelfNetwork is one network the current container is attached to.
+type SelfNetwork struct {
+	Name string
+	IP   string // this container's IP on the network, empty if unset
+}
+
+// SelfContainer describes the container the current process runs in, so a
+// sibling sandbox can be wired to reach it. Networks holds the user-defined
+// networks (DNS-capable; a sandbox can reach this container by Name on them),
+// sorted by name. BridgeIP is the address on the default bridge, used as a
+// last resort when there is no user-defined network (the bridge has no embedded
+// DNS, so only its IP is reachable).
+type SelfContainer struct {
+	ID       string
+	Name     string // without the leading slash docker prepends
+	Networks []SelfNetwork
+	BridgeIP string
+}
+
+// InspectSelf inspects the container referenced by ref — typically os.Hostname(),
+// which Docker defaults to the short container ID — and reports its networks so
+// a sibling sandbox can be attached and pointed back at this process. Returns
+// (nil, nil) when ref is not a known container (e.g. stellad runs on the host),
+// so callers fall back to explicit configuration or loopback.
+func (c *Client) InspectSelf(ctx context.Context, ref string) (*SelfContainer, error) {
+	res, err := c.api.ContainerInspect(ctx, ref, mobyclient.ContainerInspectOptions{})
+	if err != nil {
+		if errdefs.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("dockerclient: inspect self %s: %w", ref, err)
+	}
+	self := &SelfContainer{ID: res.Container.ID, Name: strings.TrimPrefix(res.Container.Name, "/")}
+	if res.Container.NetworkSettings == nil {
+		return self, nil
+	}
+	for name, ep := range res.Container.NetworkSettings.Networks {
+		ip := ""
+		if ep != nil && ep.IPAddress.IsValid() {
+			ip = ep.IPAddress.String()
+		}
+		switch name {
+		case "host", "none":
+			continue
+		case "bridge":
+			self.BridgeIP = ip
+		default:
+			self.Networks = append(self.Networks, SelfNetwork{Name: name, IP: ip})
+		}
+	}
+	sort.Slice(self.Networks, func(i, j int) bool { return self.Networks[i].Name < self.Networks[j].Name })
+	return self, nil
+}
+
 // buildContainerCreateOptions translates CreateOptions into the SDK request.
 // Pure function so tests can assert the wiring without a daemon.
 func buildContainerCreateOptions(opts CreateOptions) mobyclient.ContainerCreateOptions {
@@ -178,19 +234,24 @@ func buildContainerConfig(opts CreateOptions) *container.Config {
 
 func buildHostConfig(opts CreateOptions) *container.HostConfig {
 	hc := &container.HostConfig{
-		NetworkMode: mapNetworkMode(opts.NetworkMode),
+		NetworkMode: mapNetworkMode(opts),
 		Mounts:      buildMounts(opts),
 	}
 	return hc
 }
 
-func mapNetworkMode(m NetworkMode) container.NetworkMode {
-	switch m {
-	case NetworkDisabled:
+// mapNetworkMode picks the container network. A disabled policy always wins
+// (fully isolated). Otherwise an explicit Network joins that user-defined
+// network — required so DooD sandboxes can reach stellad by service name —
+// falling back to the daemon default bridge.
+func mapNetworkMode(opts CreateOptions) container.NetworkMode {
+	if opts.NetworkMode == NetworkDisabled {
 		return container.NetworkMode("none")
-	default:
-		return container.NetworkMode("")
 	}
+	if opts.Network != "" {
+		return container.NetworkMode(opts.Network)
+	}
+	return container.NetworkMode("")
 }
 
 func buildMounts(opts CreateOptions) []mount.Mount {

--- a/plugins/sandbox/docker/dockerclient/container_test.go
+++ b/plugins/sandbox/docker/dockerclient/container_test.go
@@ -37,17 +37,20 @@ func TestEnvSlice(t *testing.T) {
 
 func TestMapNetworkMode(t *testing.T) {
 	cases := []struct {
-		in   NetworkMode
+		name string
+		in   CreateOptions
 		want container.NetworkMode
 	}{
-		{NetworkDisabled, container.NetworkMode("none")},
-		{NetworkAllowAll, container.NetworkMode("")},
-		{"unknown", container.NetworkMode("")},
+		{"disabled", CreateOptions{NetworkMode: NetworkDisabled}, container.NetworkMode("none")},
+		{"allow all default bridge", CreateOptions{NetworkMode: NetworkAllowAll}, container.NetworkMode("")},
+		{"unknown mode default bridge", CreateOptions{NetworkMode: "unknown"}, container.NetworkMode("")},
+		{"explicit network", CreateOptions{NetworkMode: NetworkAllowAll, Network: "stella-net"}, container.NetworkMode("stella-net")},
+		{"disabled wins over network", CreateOptions{NetworkMode: NetworkDisabled, Network: "stella-net"}, container.NetworkMode("none")},
 	}
 	for _, c := range cases {
 		got := mapNetworkMode(c.in)
 		if got != c.want {
-			t.Fatalf("mapNetworkMode(%q) = %q, want %q", c.in, got, c.want)
+			t.Fatalf("%s: mapNetworkMode = %q, want %q", c.name, got, c.want)
 		}
 	}
 }

--- a/plugins/sandbox/docker/dockerclient/self_test.go
+++ b/plugins/sandbox/docker/dockerclient/self_test.go
@@ -1,0 +1,99 @@
+package dockerclient
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+
+	"github.com/containerd/errdefs"
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
+	mobyclient "github.com/moby/moby/client"
+)
+
+// inspectAPI overrides only ContainerInspect; other methods are never called by
+// InspectSelf, so the embedded nil interface is fine.
+type inspectAPI struct {
+	API
+	res mobyclient.ContainerInspectResult
+	err error
+}
+
+func (f inspectAPI) ContainerInspect(context.Context, string, mobyclient.ContainerInspectOptions) (mobyclient.ContainerInspectResult, error) {
+	return f.res, f.err
+}
+
+func inspectResult(name string, nets map[string]string) mobyclient.ContainerInspectResult {
+	networks := make(map[string]*network.EndpointSettings, len(nets))
+	for n, ip := range nets {
+		ep := &network.EndpointSettings{}
+		if ip != "" {
+			ep.IPAddress = netip.MustParseAddr(ip)
+		}
+		networks[n] = ep
+	}
+	return mobyclient.ContainerInspectResult{Container: container.InspectResponse{
+		ID:              "abc123def456",
+		Name:            name,
+		NetworkSettings: &container.NetworkSettings{Networks: networks},
+	}}
+}
+
+func TestInspectSelf(t *testing.T) {
+	t.Run("collects user networks sorted, bridge separate", func(t *testing.T) {
+		c := NewWithAPI(inspectAPI{res: inspectResult("/anna-stella-1", map[string]string{
+			"bridge":       "172.17.0.2",
+			"anna_default": "192.168.97.3",
+		})})
+		self, err := c.InspectSelf(context.Background(), "abc123")
+		if err != nil {
+			t.Fatalf("InspectSelf: %v", err)
+		}
+		if self.Name != "anna-stella-1" {
+			t.Fatalf("Name = %q, want anna-stella-1 (leading slash trimmed)", self.Name)
+		}
+		if len(self.Networks) != 1 || self.Networks[0].Name != "anna_default" || self.Networks[0].IP != "192.168.97.3" {
+			t.Fatalf("Networks = %+v, want [anna_default 192.168.97.3]", self.Networks)
+		}
+		if self.BridgeIP != "172.17.0.2" {
+			t.Fatalf("BridgeIP = %q, want 172.17.0.2", self.BridgeIP)
+		}
+	})
+
+	t.Run("user networks sorted by name", func(t *testing.T) {
+		c := NewWithAPI(inspectAPI{res: inspectResult("/s", map[string]string{
+			"net-b": "10.0.2.2",
+			"net-a": "10.0.1.2",
+		})})
+		self, _ := c.InspectSelf(context.Background(), "s")
+		if len(self.Networks) != 2 || self.Networks[0].Name != "net-a" || self.Networks[1].Name != "net-b" {
+			t.Fatalf("Networks = %+v, want sorted net-a, net-b", self.Networks)
+		}
+	})
+
+	t.Run("only default networks yields no user network but keeps bridge", func(t *testing.T) {
+		c := NewWithAPI(inspectAPI{res: inspectResult("/s", map[string]string{
+			"bridge": "172.17.0.2",
+			"host":   "",
+			"none":   "",
+		})})
+		self, _ := c.InspectSelf(context.Background(), "s")
+		if len(self.Networks) != 0 {
+			t.Fatalf("expected no user network, got %+v", self.Networks)
+		}
+		if self.BridgeIP != "172.17.0.2" {
+			t.Fatalf("BridgeIP = %q, want 172.17.0.2", self.BridgeIP)
+		}
+		if self.ID != "abc123def456" {
+			t.Fatalf("ID = %q, want abc123def456", self.ID)
+		}
+	})
+
+	t.Run("not found returns nil", func(t *testing.T) {
+		c := NewWithAPI(inspectAPI{err: errdefs.ErrNotFound})
+		self, err := c.InspectSelf(context.Background(), "ghost")
+		if err != nil || self != nil {
+			t.Fatalf("got self=%v err=%v, want nil,nil for not-found", self, err)
+		}
+	})
+}

--- a/plugins/sandbox/docker/dood.go
+++ b/plugins/sandbox/docker/dood.go
@@ -1,13 +1,25 @@
 package docker
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
 	"strings"
+
+	"github.com/CherryHQ/stella/plugins/sandbox/docker/dockerclient"
 )
 
 const dockerSandboxModeEnv = "STELLA_DOCKER_SANDBOX_MODE"
+
+// defaultSandboxServerPort is stellad's default admin/API port (see cmd/stellad
+// gateway). Auto-detected sandbox URLs target it; override the whole URL with
+// STELLA_SANDBOX_SERVER_URL when stellad listens elsewhere.
+const defaultSandboxServerPort = 25678
+
+// lookupHostname reports the current hostname, which Docker defaults to the
+// short container ID. Overridden in tests.
+var lookupHostname = os.Hostname
 
 // lookupDockerSandboxMode reads STELLA_DOCKER_SANDBOX_MODE. Overridden in tests.
 var lookupDockerSandboxMode = func() string {
@@ -22,6 +34,123 @@ var lookupStellaHomeHost = func() string {
 // lookupStellaHomeVolume reads the STELLA_HOME_VOLUME env. Overridden in tests.
 var lookupStellaHomeVolume = func() string {
 	return strings.TrimSpace(os.Getenv("STELLA_HOME_VOLUME"))
+}
+
+// lookupSandboxNetwork reads the STELLA_SANDBOX_NETWORK env. Overridden in tests.
+var lookupSandboxNetwork = func() string {
+	return strings.TrimSpace(os.Getenv("STELLA_SANDBOX_NETWORK"))
+}
+
+// lookupSandboxServerURL reads the STELLA_SANDBOX_SERVER_URL env. Overridden in tests.
+var lookupSandboxServerURL = func() string {
+	return strings.TrimSpace(os.Getenv("STELLA_SANDBOX_SERVER_URL"))
+}
+
+// autodetectServerReachability fills SandboxNetwork/ServerURL by inspecting the
+// container stellad runs in, so DooD sandboxes reach stellad with zero extra
+// configuration: they join the same Docker network and target stellad's address
+// on it instead of their own empty 127.0.0.1 loopback. Best-effort — running on
+// the host, no user-defined network, or a daemon hiccup leaves cfg untouched and
+// the caller falls back to loopback. Explicit env values always win.
+func autodetectServerReachability(ctx context.Context, cfg Config) Config {
+	if cfg.RuntimeMode == DockerSandboxModeHost {
+		// stellad runs on the host, so there is no own-container to inspect.
+		// Reaching the host from a sandbox container needs a host-gateway address
+		// (e.g. host.docker.internal) which is deployment-specific — out of scope
+		// here; set STELLA_SANDBOX_SERVER_URL explicitly if sandboxes need it.
+		return cfg
+	}
+	if cfg.SandboxNetwork != "" && cfg.ServerURL != "" {
+		return cfg // fully configured by env
+	}
+	host, err := lookupHostname()
+	if err != nil {
+		return cfg
+	}
+	client, err := getSharedClient()
+	if err != nil {
+		return cfg
+	}
+	self, err := client.InspectSelf(ctx, host)
+	if err != nil || self == nil {
+		// Silent failure here would surface only as connection-refused inside the
+		// sandbox, which is miserable to debug — point the operator at the override.
+		slog.Warn("docker backend: could not identify stellad's own container for sandbox networking; set STELLA_SANDBOX_NETWORK and STELLA_SANDBOX_SERVER_URL if sandboxes cannot reach stellad",
+			"component", "runner_sandbox", "ref", host, "err", err)
+		return cfg
+	}
+	return applyReachability(cfg, self)
+}
+
+// applyReachability merges a detected self-container into cfg, filling only the
+// fields env did not already set. Pure, so the selection logic is tested without
+// a daemon. Selection: an explicit SandboxNetwork wins (URL host taken from that
+// same network so the two never disagree); otherwise the sole/compose-default
+// user network; otherwise the default bridge by IP as a last resort.
+func applyReachability(cfg Config, self *dockerclient.SelfContainer) Config {
+	if self == nil {
+		return cfg
+	}
+
+	network, host := "", ""
+	switch {
+	case cfg.SandboxNetwork != "":
+		// Honor the operator's network; only fabricate a URL if stellad is
+		// actually on it (else the sandbox would join a network stellad can't be
+		// reached on — a misconfiguration we must not paper over).
+		network = cfg.SandboxNetwork
+		if on := findNetwork(self.Networks, cfg.SandboxNetwork); on != nil {
+			host = self.Name // user-defined network: reach by DNS name (stable)
+		} else if cfg.ServerURL == "" {
+			slog.Warn("docker backend: STELLA_SANDBOX_NETWORK is not a network stellad is on; set STELLA_SANDBOX_SERVER_URL explicitly",
+				"component", "runner_sandbox", "network", cfg.SandboxNetwork)
+		}
+	case len(self.Networks) > 0:
+		chosen := pickUserNetwork(self.Networks)
+		if len(self.Networks) > 1 {
+			slog.Warn("docker backend: stellad is on multiple networks; using one for sandboxes — set STELLA_SANDBOX_NETWORK to override",
+				"component", "runner_sandbox", "network", chosen.Name)
+		}
+		network, host = chosen.Name, self.Name
+	case self.BridgeIP != "":
+		// Bridge-only: keep the sandbox on the default bridge (network stays
+		// empty) and reach stellad by its bridge IP — the bridge has no DNS.
+		host = self.BridgeIP
+	}
+
+	if cfg.SandboxNetwork == "" {
+		cfg.SandboxNetwork = network
+	}
+	if cfg.ServerURL == "" && host != "" {
+		cfg.ServerURL = fmt.Sprintf("http://%s:%d", host, defaultSandboxServerPort)
+	}
+	slog.Info("docker backend: auto-detected sandbox reachability",
+		"component", "runner_sandbox",
+		"network", cfg.SandboxNetwork,
+		"server_url", cfg.ServerURL,
+	)
+	return cfg
+}
+
+// pickUserNetwork prefers the compose project default ("*_default") so sandboxes
+// land on the app network rather than an isolated/internal one; Networks is
+// already sorted, so the first entry is the deterministic fallback.
+func pickUserNetwork(nets []dockerclient.SelfNetwork) dockerclient.SelfNetwork {
+	for _, n := range nets {
+		if strings.HasSuffix(n.Name, "_default") {
+			return n
+		}
+	}
+	return nets[0]
+}
+
+func findNetwork(nets []dockerclient.SelfNetwork, name string) *dockerclient.SelfNetwork {
+	for i := range nets {
+		if nets[i].Name == name {
+			return &nets[i]
+		}
+	}
+	return nil
 }
 
 // applyDockerMode fills and validates the explicit docker sandbox runtime mode.
@@ -40,6 +169,12 @@ func applyDockerMode(cfg Config, stellaHome string) (Config, error) {
 	}
 	if cfg.StellaHomeVolume == "" {
 		cfg.StellaHomeVolume = lookupStellaHomeVolume()
+	}
+	if cfg.SandboxNetwork == "" {
+		cfg.SandboxNetwork = lookupSandboxNetwork()
+	}
+	if cfg.ServerURL == "" {
+		cfg.ServerURL = lookupSandboxServerURL()
 	}
 	if cfg.ContainerPathPrefix == "" && cfg.HostPathPrefix == "" {
 		if hostPath := lookupStellaHomeHost(); hostPath != "" {

--- a/plugins/sandbox/docker/reachability_test.go
+++ b/plugins/sandbox/docker/reachability_test.go
@@ -1,0 +1,88 @@
+package docker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/CherryHQ/stella/plugins/sandbox/docker/dockerclient"
+)
+
+func TestApplyReachability(t *testing.T) {
+	composeSelf := &dockerclient.SelfContainer{
+		Name:     "anna-stella-1",
+		Networks: []dockerclient.SelfNetwork{{Name: "anna_default", IP: "192.168.97.3"}},
+		BridgeIP: "172.17.0.2",
+	}
+
+	t.Run("auto: joins user network, URL by container name (DNS)", func(t *testing.T) {
+		got := applyReachability(Config{}, composeSelf)
+		if got.SandboxNetwork != "anna_default" {
+			t.Fatalf("network = %q", got.SandboxNetwork)
+		}
+		if got.ServerURL != "http://anna-stella-1:25678" {
+			t.Fatalf("url = %q, want name-based", got.ServerURL)
+		}
+	})
+
+	t.Run("prefers *_default network when several", func(t *testing.T) {
+		self := &dockerclient.SelfContainer{Name: "s", Networks: []dockerclient.SelfNetwork{
+			{Name: "anna_backend", IP: "10.0.1.2"},
+			{Name: "anna_default", IP: "10.0.2.2"},
+		}}
+		got := applyReachability(Config{}, self)
+		if got.SandboxNetwork != "anna_default" {
+			t.Fatalf("network = %q, want anna_default preferred", got.SandboxNetwork)
+		}
+	})
+
+	t.Run("bridge-only: keep default bridge, URL by bridge IP", func(t *testing.T) {
+		self := &dockerclient.SelfContainer{Name: "s", BridgeIP: "172.17.0.2"}
+		got := applyReachability(Config{}, self)
+		if got.SandboxNetwork != "" {
+			t.Fatalf("network = %q, want empty (default bridge)", got.SandboxNetwork)
+		}
+		if got.ServerURL != "http://172.17.0.2:25678" {
+			t.Fatalf("url = %q, want bridge IP", got.ServerURL)
+		}
+	})
+
+	t.Run("explicit network present on self: URL host from that network by name", func(t *testing.T) {
+		got := applyReachability(Config{SandboxNetwork: "anna_default"}, composeSelf)
+		if got.SandboxNetwork != "anna_default" || got.ServerURL != "http://anna-stella-1:25678" {
+			t.Fatalf("got %+v", got)
+		}
+	})
+
+	t.Run("explicit network absent on self: do not fabricate URL", func(t *testing.T) {
+		got := applyReachability(Config{SandboxNetwork: "custom-net"}, composeSelf)
+		if got.SandboxNetwork != "custom-net" {
+			t.Fatalf("network = %q", got.SandboxNetwork)
+		}
+		if got.ServerURL != "" {
+			t.Fatalf("url = %q, want empty (stellad not on custom-net)", got.ServerURL)
+		}
+	})
+
+	t.Run("explicit URL always wins", func(t *testing.T) {
+		got := applyReachability(Config{ServerURL: "http://stella:9000"}, composeSelf)
+		if got.ServerURL != "http://stella:9000" {
+			t.Fatalf("url overridden: %q", got.ServerURL)
+		}
+	})
+}
+
+func TestAutodetectServerReachabilityShortCircuits(t *testing.T) {
+	t.Run("host mode skips detection", func(t *testing.T) {
+		got := autodetectServerReachability(context.Background(), Config{RuntimeMode: DockerSandboxModeHost})
+		if got.SandboxNetwork != "" || got.ServerURL != "" {
+			t.Fatalf("host mode mutated cfg: %+v", got)
+		}
+	})
+
+	t.Run("fully configured by env skips detection", func(t *testing.T) {
+		got := autodetectServerReachability(context.Background(), Config{RuntimeMode: DockerSandboxModeVolume, SandboxNetwork: "n", ServerURL: "u"})
+		if got.SandboxNetwork != "n" || got.ServerURL != "u" {
+			t.Fatalf("configured cfg mutated: %+v", got)
+		}
+	})
+}

--- a/plugins/sandbox/docker/session.go
+++ b/plugins/sandbox/docker/session.go
@@ -69,6 +69,9 @@ func NewFactory(cfg Config) (sandboxpkg.Factory, error) {
 		if err != nil {
 			return nil, err
 		}
+		detectCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		cfg = autodetectServerReachability(detectCtx, cfg)
+		cancel()
 		if len(cfg.UserToolBinaries) == 0 {
 			tools, err := resolveUserToolBinaries(cfg.StellaHome)
 			if err != nil {
@@ -184,6 +187,7 @@ func (f *dockerFactory) CreateSession(ctx context.Context, policy sandboxpkg.Pol
 		WorkspaceHost:  workspaceHost,
 		WorkspaceMount: workspaceMount,
 		NetworkMode:    networkMode,
+		Network:        f.cfg.SandboxNetwork,
 		Env:            mergeEnv(policy.Env, nil),
 		Labels: map[string]string{
 			dockerclient.LabelSessionID:  sessionID,
@@ -220,6 +224,14 @@ func (f *dockerFactory) CreateSession(ctx context.Context, policy sandboxpkg.Pol
 		env["STELLA_USER_DIR"] = mountedUserDataHost
 		policy.Env = env
 	}
+
+	// Point the in-sandbox CLI at stellad over the shared network. Without this
+	// the CLI falls back to 127.0.0.1:25678 — the sandbox container's own
+	// loopback, where nothing listens — so server-backed commands fail. Injecting
+	// into policy.Env covers both the container's create-time env and every later
+	// exec, which both derive from it. Set only when configured (DooD); the
+	// local/host backend reaches stellad on loopback.
+	policy.Env = withServerURL(policy.Env, f.cfg.ServerURL)
 
 	// Build the mount table and env prefix maps before creating the container so
 	// the create-time env can be translated to the container view too — otherwise
@@ -708,6 +720,21 @@ func buildMountTable(opts mountTableOptions) []dockerclient.Mount {
 
 // mergeEnv merges policy environment and per-call overrides into a map.
 // NEVER inherits host environment — that is a host-process concept, not a container concept.
+// withServerURL returns env with STELLA_SERVER_URL set to url, cloning so the
+// caller's map is untouched. A blank url returns env unchanged (local/host
+// backends keep the 127.0.0.1 default).
+func withServerURL(env map[string]string, url string) map[string]string {
+	if url == "" {
+		return env
+	}
+	out := maps.Clone(env)
+	if out == nil {
+		out = make(map[string]string, 1)
+	}
+	out["STELLA_SERVER_URL"] = url
+	return out
+}
+
 func mergeEnv(policyEnv, optsEnv map[string]string) map[string]string {
 	out := make(map[string]string, len(policyEnv)+len(optsEnv))
 	maps.Copy(out, policyEnv)

--- a/plugins/sandbox/docker/session_pure_test.go
+++ b/plugins/sandbox/docker/session_pure_test.go
@@ -37,6 +37,32 @@ func TestMergeEnv(t *testing.T) {
 	})
 }
 
+func TestWithServerURL(t *testing.T) {
+	t.Run("blank url leaves env untouched", func(t *testing.T) {
+		in := map[string]string{"A": "1"}
+		got := withServerURL(in, "")
+		if _, ok := got["STELLA_SERVER_URL"]; ok {
+			t.Fatalf("did not expect STELLA_SERVER_URL: %v", got)
+		}
+	})
+	t.Run("sets url and does not mutate input", func(t *testing.T) {
+		in := map[string]string{"A": "1"}
+		got := withServerURL(in, "http://stella:25678")
+		if got["STELLA_SERVER_URL"] != "http://stella:25678" || got["A"] != "1" {
+			t.Fatalf("unexpected: %v", got)
+		}
+		if _, ok := in["STELLA_SERVER_URL"]; ok {
+			t.Fatalf("input map was mutated: %v", in)
+		}
+	})
+	t.Run("nil env", func(t *testing.T) {
+		got := withServerURL(nil, "http://stella:25678")
+		if got["STELLA_SERVER_URL"] != "http://stella:25678" {
+			t.Fatalf("unexpected: %v", got)
+		}
+	})
+}
+
 func TestBuildMountTable(t *testing.T) {
 	stellaHome := t.TempDir()
 	for _, name := range []string{"bin", ".mise-tools", filepath.Join(".agents", "skills")} {


### PR DESCRIPTION
## What

Fix the Docker sandbox backend (DooD) so server-backed CLI commands run by the agent inside its sandbox — `stella task`, `stella task goal`, `recally` — can reach `stellad` instead of failing with `connection refused`.

Closes #517.

## Why

`stellad` runs in one container (on the Compose user network); the sandbox is a separate container created via the host Docker socket, on the default `bridge`. Inside the sandbox the CLI falls back to `http://127.0.0.1:25678` (`internal/config/paths.go` `ServerURL`) — the sandbox's own empty loopback — and the two containers aren't on the same network. So agent goal/task flows (and the #438/#439 reference cards that depend on them) are broken under `mise run dev:docker`.

## How

Self-wired, zero-config — no Compose changes:

- `dockerclient.InspectSelf` inspects `stellad`'s own container and reports its networks (+ IPs) and the bridge IP.
- `applyReachability` (pure, fully unit-tested) selects the network and the URL host: prefers an explicit `STELLA_SANDBOX_NETWORK`, else the Compose default (`*_default`), else the sole user network, else the bridge. The URL host comes from the **same** network that was selected (container DNS name on a user network; bridge IP only as last resort), so the joined network and the URL never disagree.
- Sandbox containers join the selected network (`CreateOptions.Network`); `STELLA_SERVER_URL` is injected into the sandbox env (`withServerURL`), covering both create-time and exec-time env.
- Warnings on the ambiguous/failed paths (multiple networks, explicit network not found, can't identify own container) so failures aren't silent.
- Overrides: `STELLA_SANDBOX_NETWORK` / `STELLA_SANDBOX_SERVER_URL`. `host` mode (stellad on the host) is out of scope — it needs a deployment-specific host-gateway address; set `STELLA_SANDBOX_SERVER_URL` if required.

Reviewed by a delegated agent; addressed bridge-only reachability, env/URL network consistency, multi-network selection, and silent self-identification failure.

## Refs

- #517 (issue)
- Unblocks #439 / #438 reference cards under the Docker sandbox dev stack.

## Verification

- `mise run format && mise run build && mise run test` — all green.
- `GOOS=windows GOARCH=amd64 go build ./cmd/stella` — passes.
- New tests: `InspectSelf` (multi-network / bridge / not-found), `applyReachability` (6 selection branches), `withServerURL`, extended `mapNetworkMode`.
