### PR TITLE
✨ feat(deploy): add Helm chart for production Kubernetes deployment

### DIFF
--- a/deploy/helm/stella/.helmignore
+++ b/deploy/helm/stella/.helmignore
@@ -1,0 +1,8 @@
+.DS_Store
+.git
+.gitignore
+*.tmproj
+*.bak
+*.orig
+.vscode/
+.idea/

--- a/deploy/helm/stella/Chart.yaml
+++ b/deploy/helm/stella/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: stella
+description: |
+  Stella — a multi-tenant, multi-user, multi-agent AI assistant platform.
+  This chart runs a single stellad server backed by SQLite on a persistent
+  volume. It is a single-replica StatefulSet by design: SQLite is a
+  single-writer database, so horizontal scaling (HPA, replicas > 1) is not
+  supported until the PostgreSQL backend lands (see issue #477).
+type: application
+home: https://github.com/CherryHQ/stella
+sources:
+  - https://github.com/CherryHQ/stella
+maintainers:
+  - name: CherryHQ
+    url: https://github.com/CherryHQ
+keywords:
+  - ai
+  - agent
+  - assistant
+  - llm
+# Chart version. Bump on every chart change (SemVer).
+version: 0.1.0
+# Tracks the Stella application release this chart was validated against.
+appVersion: "0.49.2"

--- a/deploy/helm/stella/README.md
+++ b/deploy/helm/stella/README.md
@@ -1,0 +1,103 @@
+# Stella Helm Chart
+
+Deploys [Stella](https://github.com/CherryHQ/stella) on Kubernetes as a
+single-replica `StatefulSet` backed by SQLite on a persistent volume.
+
+> **Single-writer by design.** Stella currently stores all state in one SQLite
+> database. This chart runs exactly one replica. Do not raise `replicaCount` or
+> enable autoscaling — concurrent writers corrupt SQLite. Horizontal scaling
+> arrives with the PostgreSQL backend ([#477](https://github.com/CherryHQ/stella/issues/477)).
+
+## Prerequisites
+
+- Kubernetes 1.25+
+- Helm 3.8+
+- A default StorageClass that provides `ReadWriteOnce` volumes (avoid NFS —
+  SQLite WAL is unreliable over NFS)
+- A vault key: `stella vault keygen`
+
+## Install
+
+```bash
+# Required: the age vault key. Prefer --set-file or an existing Secret over
+# putting the key in a values file.
+helm install stella ./deploy/helm/stella \
+  --namespace stella --create-namespace \
+  --set-file secret.vaultKey=/dev/stdin <<<"$(stella vault keygen)" \
+  --set secret.apiKeys.ANTHROPIC_API_KEY=sk-ant-...
+```
+
+Or with a values file:
+
+```bash
+helm install stella ./deploy/helm/stella -n stella --create-namespace -f my-values.yaml
+```
+
+Verify:
+
+```bash
+kubectl -n stella rollout status statefulset/stella
+helm test stella -n stella
+```
+
+## Configuration
+
+| Key                         | Default                   | Description                                               |
+| --------------------------- | ------------------------- | --------------------------------------------------------- |
+| `replicaCount`              | `1`                       | Keep at 1 (SQLite).                                       |
+| `image.repository`          | `ghcr.io/cherryhq/stella` | Image repo.                                               |
+| `image.tag`                 | `""` (chart appVersion)   | Image tag.                                                |
+| `service.port`              | `25678`                   | stellad listen port.                                      |
+| `sandbox.backend`           | `local`                   | `local`, `none`, or `docker`.                             |
+| `persistence.enabled`       | `true`                    | Provision a PVC for `STELLA_HOME`.                        |
+| `persistence.size`          | `10Gi`                    | Volume size.                                              |
+| `persistence.storageClass`  | `""`                      | StorageClass (cluster default if empty).                  |
+| `persistence.existingClaim` | `""`                      | Use an existing PVC.                                      |
+| `secret.create`             | `true`                    | Create the Secret from `secret.*`.                        |
+| `secret.vaultKey`           | `""`                      | **Required.** age key from `stella vault keygen`.         |
+| `secret.existingSecret`     | `""`                      | Use an existing Secret (must hold `STELLA_VAULT_KEY`).    |
+| `secret.apiKeys`            | `{}`                      | Provider keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, …). |
+| `extraEnv`                  | `{}`                      | Extra non-secret env (e.g. `STELLA_BASE_URL`, `OTEL_*`).  |
+| `ingress.enabled`           | `false`                   | Create an Ingress.                                        |
+| `resources`                 | 250m/512Mi → 2/2Gi        | Requests/limits.                                          |
+| `autoscaling.enabled`       | `false`                   | **Unsupported on SQLite.** Example only.                  |
+
+See [`values.yaml`](./values.yaml) for the full set with inline docs.
+
+### Sandbox backend
+
+The `local` backend (bubblewrap) needs `unshare(2)`, which the default
+`RuntimeDefault` seccomp profile blocks — the chart sets the container
+`seccompProfile` to `Unconfined` (mirroring the Docker
+`--security-opt seccomp=unconfined`). If your policy forbids that, set
+`sandbox.backend=none` and restore a stricter `securityContext.seccompProfile`,
+but note agent tools then run without isolation. The `docker` backend needs a
+host Docker socket and is not wired by this chart.
+
+### Health probes
+
+Liveness, readiness, and startup probes hit `GET /api/status` (unauthenticated,
+returns 200 when the server is up). The startup probe absorbs slow first-boot DB
+migration before liveness begins.
+
+### Upgrade & rollback
+
+```bash
+helm upgrade stella ./deploy/helm/stella -n stella -f my-values.yaml
+helm rollback stella -n stella          # to previous revision
+```
+
+The StatefulSet uses `RollingUpdate`; with one replica the pod is recreated in
+place. Back up the volume before upgrades:
+
+```bash
+kubectl -n stella exec statefulset/stella -- \
+  sqlite3 /home/stella/.stella/stella.db ".backup /home/stella/.stella/backup.db"
+```
+
+## PostgreSQL & S3
+
+Not yet supported by Stella — these backends are tracked in
+[#477](https://github.com/CherryHQ/stella/issues/477). When they land, this
+chart will gain `database.*` and `storage.*` values and multi-replica/HPA
+support.

--- a/deploy/helm/stella/templates/NOTES.txt
+++ b/deploy/helm/stella/templates/NOTES.txt
@@ -1,0 +1,30 @@
+Stella is deploying. Release: {{ .Release.Name }} (namespace {{ .Release.Namespace }}).
+
+1. Wait for the pod to become ready:
+
+   kubectl -n {{ .Release.Namespace }} rollout status statefulset/{{ include "stella.fullname" . }}
+
+2. Reach the Web UI:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
+{{- end }}
+{{- else }}
+   kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "stella.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+   Then open http://localhost:{{ .Values.service.port }}
+{{- end }}
+
+   Configure providers, channels, and agents from the Web UI on first run.
+
+{{- if not (or .Values.secret.vaultKey .Values.secret.existingSecret) }}
+
+WARNING: no vault key configured. Secrets, OAuth, and plugin keys will fail.
+Generate one with `stella vault keygen` and set secret.vaultKey or secret.existingSecret.
+{{- end }}
+
+Notes:
+- This is a single-replica SQLite deployment. Do NOT scale replicas or enable
+  autoscaling — it will corrupt the database. Multi-replica needs the future
+  PostgreSQL backend (#477).
+- Back up the persistent volume (STELLA_HOME): {{ .Values.persistence.mountPath }}.
+- Sandbox backend: {{ .Values.sandbox.backend }}.

--- a/deploy/helm/stella/templates/_helpers.tpl
+++ b/deploy/helm/stella/templates/_helpers.tpl
@@ -1,0 +1,78 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "stella.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "stella.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Chart name and version label.
+*/}}
+{{- define "stella.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "stella.labels" -}}
+helm.sh/chart: {{ include "stella.chart" . }}
+{{ include "stella.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "stella.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "stella.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+ServiceAccount name.
+*/}}
+{{- define "stella.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "stella.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Name of the Secret holding the vault key and provider keys.
+*/}}
+{{- define "stella.secretName" -}}
+{{- if .Values.secret.existingSecret }}
+{{- .Values.secret.existingSecret }}
+{{- else }}
+{{- include "stella.fullname" . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Image reference (repository:tag).
+*/}}
+{{- define "stella.image" -}}
+{{- printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) }}
+{{- end }}

--- a/deploy/helm/stella/templates/configmap.yaml
+++ b/deploy/helm/stella/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "stella.fullname" . }}-env
+  labels:
+    {{- include "stella.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.extraEnv }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}

--- a/deploy/helm/stella/templates/hpa.yaml
+++ b/deploy/helm/stella/templates/hpa.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.autoscaling.enabled }}
+{{- if not .Values.autoscaling.acknowledgeSqliteUnsupported }}
+{{- fail "autoscaling scales past one replica, which corrupts the SQLite database. It is unsupported until the PostgreSQL backend lands (#477). If you have migrated off SQLite and understand the risk, set autoscaling.acknowledgeSqliteUnsupported=true." }}
+{{- end }}
+# WARNING: example only. See the note above and in values.yaml — multi-replica
+# is unsafe on the current SQLite backend.
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "stella.fullname" . }}
+  labels:
+    {{- include "stella.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: {{ include "stella.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/stella/templates/ingress.yaml
+++ b/deploy/helm/stella/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "stella.fullname" . }}
+  labels:
+    {{- include "stella.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "stella.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/stella/templates/secret.yaml
+++ b/deploy/helm/stella/templates/secret.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.secret.create }}
+{{- if not (or .Values.secret.vaultKey .Values.secret.existingSecret) }}
+{{- fail "secret.vaultKey is required (generate with `stella vault keygen`), or set secret.existingSecret / secret.create=false" }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "stella.fullname" . }}
+  labels:
+    {{- include "stella.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  STELLA_VAULT_KEY: {{ .Values.secret.vaultKey | quote }}
+  {{- range $key, $value := .Values.secret.apiKeys }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/stella/templates/service.yaml
+++ b/deploy/helm/stella/templates/service.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "stella.fullname" . }}
+  labels:
+    {{- include "stella.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "stella.selectorLabels" . | nindent 4 }}
+---
+# Headless service required by the StatefulSet for stable network identity.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "stella.fullname" . }}-headless
+  labels:
+    {{- include "stella.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "stella.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/stella/templates/serviceaccount.yaml
+++ b/deploy/helm/stella/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "stella.serviceAccountName" . }}
+  labels:
+    {{- include "stella.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/stella/templates/statefulset.yaml
+++ b/deploy/helm/stella/templates/statefulset.yaml
@@ -1,0 +1,133 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "stella.fullname" . }}
+  labels:
+    {{- include "stella.labels" . | nindent 4 }}
+spec:
+  # SQLite is single-writer: never scale beyond 1 replica on this backend.
+  replicas: {{ .Values.replicaCount }}
+  serviceName: {{ include "stella.fullname" . }}-headless
+  updateStrategy:
+    {{- toYaml .Values.updateStrategy | nindent 4 }}
+  selector:
+    matchLabels:
+      {{- include "stella.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.secret.create }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "stella.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "stella.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: stella
+          image: {{ include "stella.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["stellad", "server"]
+          args:
+            - --host
+            - 0.0.0.0
+            - --port
+            - {{ .Values.service.port | quote }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          env:
+            - name: STELLA_HOME
+              value: {{ .Values.persistence.mountPath | quote }}
+            - name: STELLA_SANDBOX_BACKEND
+              value: {{ .Values.sandbox.backend | quote }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "stella.fullname" . }}-env
+            - secretRef:
+                name: {{ include "stella.secretName" . }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: /api/status
+              port: http
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /api/status
+              port: http
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /api/status
+              port: http
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if and .Values.persistence.enabled .Values.persistence.existingClaim }}
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim }}
+      {{- else if not .Values.persistence.enabled }}
+      volumes:
+        - name: data
+          emptyDir: {}
+      {{- end }}
+  {{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          {{- toYaml .Values.persistence.accessModes | nindent 10 }}
+        {{- if .Values.persistence.storageClass }}
+        storageClassName: {{ .Values.persistence.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size | quote }}
+  {{- end }}

--- a/deploy/helm/stella/templates/tests/test-connection.yaml
+++ b/deploy/helm/stella/templates/tests/test-connection.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "stella.fullname" . }}-test-connection
+  labels:
+    {{- include "stella.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+    - name: status
+      image: curlimages/curl:8.11.0
+      command:
+        - curl
+        - --fail
+        - --silent
+        - --show-error
+        - http://{{ include "stella.fullname" . }}:{{ .Values.service.port }}/api/status

--- a/deploy/helm/stella/values.yaml
+++ b/deploy/helm/stella/values.yaml
@@ -1,0 +1,176 @@
+# Default values for the Stella Helm chart.
+# See deploy/helm/stella/README.md and the production deployment doc:
+# https://github.com/CherryHQ/stella/blob/main/web/content/docs/start-here/kubernetes.md
+
+# -- Number of stellad replicas.
+# Keep this at 1. Stella stores all state in a single SQLite database on a
+# ReadWriteOnce volume; running more than one replica corrupts that database.
+# Multi-replica scaling requires the (not-yet-available) PostgreSQL backend.
+replicaCount: 1
+
+image:
+  repository: ghcr.io/cherryhq/stella
+  # -- Overrides the image tag. Defaults to the chart's appVersion.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+# -- Image pull secrets for private registries.
+imagePullSecrets: []
+# -- Override the chart name used in resource names.
+nameOverride: ""
+# -- Override the fully qualified app name used in resource names.
+fullnameOverride: ""
+
+serviceAccount:
+  # -- Create a dedicated ServiceAccount.
+  create: true
+  # -- Annotations to add to the ServiceAccount (e.g. cloud IAM role bindings).
+  annotations: {}
+  # -- ServiceAccount name. Generated from the release name when empty.
+  name: ""
+
+# -- Extra annotations for the stellad pod.
+podAnnotations: {}
+# -- Extra labels for the stellad pod.
+podLabels: {}
+
+# Pod-level security context.
+# fsGroup makes the persistent volume writable by the non-root `stella` user
+# (uid/gid 1000 in the published image).
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+
+# Container-level security context.
+# The `local` sandbox backend (bubblewrap) calls unshare(2), which the default
+# RuntimeDefault seccomp profile blocks — hence Unconfined. This mirrors the
+# `--security-opt seccomp=unconfined` used by the Docker deployment. Switch
+# sandbox.backend to "none" if you require RuntimeDefault seccomp and trust the
+# workload (agent tools then run without isolation).
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: Unconfined
+
+sandbox:
+  # -- Agent tool sandbox backend: "local" (bubblewrap isolation, no host
+  # Docker socket needed), "none" (no isolation; trusted workloads only), or
+  # "docker" (Docker-out-of-Docker; needs a host socket — not configured by
+  # this chart). Locking the backend via env makes the UI control read-only.
+  backend: local
+
+service:
+  type: ClusterIP
+  port: 25678
+  annotations: {}
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  # annotations:
+  #   nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+  hosts:
+    - host: stella.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+  #  - secretName: stella-tls
+  #    hosts:
+  #      - stella.example.com
+
+# Persistent volume backing STELLA_HOME (SQLite db, vault, skills, user data).
+# Must be ReadWriteOnce. Avoid NFS — SQLite WAL is unreliable over NFS.
+persistence:
+  enabled: true
+  # -- Use an existing PVC instead of the StatefulSet volumeClaimTemplate.
+  existingClaim: ""
+  storageClass: ""
+  accessModes:
+    - ReadWriteOnce
+  size: 10Gi
+  # -- Mount path inside the container (also set as STELLA_HOME).
+  mountPath: /home/stella/.stella
+
+# Secret holding STELLA_VAULT_KEY and provider API keys.
+secret:
+  # -- Create the Secret from the values below. Set false to use existingSecret.
+  create: true
+  # -- Reference an existing Secret instead of creating one. Must contain
+  # STELLA_VAULT_KEY and any provider keys you need.
+  existingSecret: ""
+  # -- age secret key for the vault. REQUIRED. Generate with `stella vault keygen`.
+  # Prefer --set-file / existingSecret over committing this to values.
+  vaultKey: ""
+  # -- Provider API keys injected as env vars. At least one is needed for agents
+  # to run (keys can also be set later via the Web UI).
+  apiKeys: {}
+  #   ANTHROPIC_API_KEY: sk-ant-...
+  #   OPENAI_API_KEY: sk-...
+
+# -- Extra non-secret environment variables (e.g. STELLA_BASE_URL, OTEL_*).
+# Rendered into a ConfigMap.
+extraEnv: {}
+#   STELLA_BASE_URL: https://stella.example.com
+#   OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
+
+# Probes hit GET /api/status (unauthenticated, 200 when the server is up).
+# startupProbe covers slow first-boot DB migration before liveness kicks in.
+startupProbe:
+  enabled: true
+  failureThreshold: 30
+  periodSeconds: 5
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 0
+  periodSeconds: 15
+  timeoutSeconds: 3
+  failureThreshold: 3
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: "2"
+    memory: 2Gi
+
+# Horizontal Pod Autoscaler.
+# DISABLED and unsupported with the current SQLite backend: scaling past one
+# replica corrupts the database. This block is a ready-to-use example for when
+# the PostgreSQL backend (issue #477) makes multi-replica safe. Do NOT enable
+# it on SQLite.
+autoscaling:
+  enabled: false
+  # -- Safety gate. Enabling autoscaling without setting this to true fails the
+  # render, because >1 replica corrupts SQLite. Only set true after migrating
+  # to a shared multi-writer database.
+  acknowledgeSqliteUnsupported: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# -- Node selector for pod scheduling.
+nodeSelector: {}
+# -- Tolerations for pod scheduling.
+tolerations: []
+# -- Affinity rules for pod scheduling.
+affinity: {}
+
+# -- Update strategy for the StatefulSet.
+updateStrategy:
+  type: RollingUpdate

--- a/dprint.json
+++ b/dprint.json
@@ -5,7 +5,7 @@
   "dockerfile": {},
   "markup": {},
   "yaml": {},
-  "excludes": ["**/*-lock.json", "web/**"],
+  "excludes": ["**/*-lock.json", "web/**", "deploy/helm/*/templates/**"],
   "plugins": [
     "https://plugins.dprint.dev/json-0.21.3.wasm",
     "https://plugins.dprint.dev/markdown-0.21.1.wasm",

--- a/web/content/docs/start-here/deployment.md
+++ b/web/content/docs/start-here/deployment.md
@@ -197,6 +197,10 @@ docker build -t stella .
 docker buildx build --platform linux/amd64,linux/arm64 -t stella .
 ```
 
+## Kubernetes
+
+For production Kubernetes deployments, use the official Helm chart — it covers health probes, resource limits, persistent storage, and ingress. See the [Kubernetes guide](/docs/start-here/kubernetes).
+
 ## Sandbox Backends
 
 Running Stella inside a Docker container (described above) is separate from using Docker as a sandbox backend for agent tool execution. Stella supports three sandbox backends: `docker`, `local`, and `none`. See the [Sandbox guide](/docs/guides/sandbox) for how to choose a backend, configure Docker sandbox modes, and troubleshoot common issues.

--- a/web/content/docs/start-here/deployment.zh.md
+++ b/web/content/docs/start-here/deployment.zh.md
@@ -197,6 +197,10 @@ docker build -t stella .
 docker buildx build --platform linux/amd64,linux/arm64 -t stella .
 ```
 
+## Kubernetes
+
+生产环境的 Kubernetes 部署请使用官方 Helm Chart——它涵盖健康探针、资源限制、持久化存储和 Ingress。参阅 [Kubernetes 指南](/docs/start-here/kubernetes)。
+
 ## 沙箱后端
 
 将 Stella 运行在 Docker 容器中（见上文）与使用 Docker 作为 agent 工具执行的沙箱后端是两件独立的事。Stella 支持三种沙箱后端：`docker`、`local` 和 `none`。请参阅[沙箱指南](/docs/guides/sandbox)了解如何选择后端、配置 Docker 沙箱模式和排查常见问题。

--- a/web/content/docs/start-here/kubernetes.md
+++ b/web/content/docs/start-here/kubernetes.md
@@ -1,0 +1,171 @@
+---
+title: Kubernetes
+---
+
+Deploy Stella on Kubernetes for production using the official Helm chart in
+[`deploy/helm/stella`](https://github.com/CherryHQ/stella/tree/main/deploy/helm/stella).
+The chart runs `stellad` as a single-replica StatefulSet backed by SQLite on a
+persistent volume, with health probes, resource limits, and ingress wiring.
+
+## Before you start
+
+Stella keeps all state in one SQLite database. This deployment runs **exactly
+one replica** — running more than one corrupts the database. Horizontal scaling
+(multiple replicas, autoscaling) and external PostgreSQL / S3 storage are not
+available yet; they are tracked in [issue #477](https://github.com/CherryHQ/stella/issues/477).
+For most teams a single well-resourced replica is plenty.
+
+You need:
+
+- A Kubernetes cluster (1.25+) and `kubectl` access.
+- [Helm](https://helm.sh/) 3.8+.
+- A StorageClass that provides `ReadWriteOnce` volumes. Avoid NFS — Stella's
+  database is unreliable on it.
+- A vault key, generated with `stella vault keygen`. Without it, secrets, OAuth,
+  and plugin credentials won't work.
+
+## Install
+
+Clone the repository (or copy the `deploy/helm/stella` directory), then install:
+
+```bash
+helm install stella ./deploy/helm/stella \
+  --namespace stella --create-namespace \
+  --set-file secret.vaultKey=/dev/stdin <<<"$(stella vault keygen)" \
+  --set secret.apiKeys.ANTHROPIC_API_KEY=sk-ant-...
+```
+
+`--set-file secret.vaultKey=/dev/stdin` reads the key from the piped
+`stella vault keygen` output so it never lands in your shell history or a file.
+At least one provider key (for example `ANTHROPIC_API_KEY` or `OPENAI_API_KEY`)
+lets agents run immediately; you can also add keys later from the Web UI.
+
+Wait for the pod and run the bundled smoke test:
+
+```bash
+kubectl -n stella rollout status statefulset/stella
+helm test stella -n stella
+```
+
+## Reach the Web UI
+
+Port-forward for a quick check:
+
+```bash
+kubectl -n stella port-forward svc/stella 25678:25678
+```
+
+Then open `http://localhost:25678` to configure providers, channels, and agents.
+
+For permanent external access, enable the ingress in a values file:
+
+```yaml
+# values.yaml
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: stella.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: stella-tls
+      hosts:
+        - stella.example.com
+
+# Tell Stella its public URL so Web UI links and OAuth callbacks are correct.
+extraEnv:
+  STELLA_BASE_URL: https://stella.example.com
+```
+
+Apply it with `helm upgrade stella ./deploy/helm/stella -n stella -f values.yaml`.
+
+## Configure
+
+All settings live in [`values.yaml`](https://github.com/CherryHQ/stella/blob/main/deploy/helm/stella/values.yaml)
+with inline documentation. The ones you'll touch most:
+
+| Setting                                         | Purpose                                                          |
+| ----------------------------------------------- | ---------------------------------------------------------------- |
+| `secret.vaultKey`                               | The vault key (required).                                        |
+| `secret.apiKeys`                                | Provider API keys injected as environment variables.             |
+| `secret.existingSecret`                         | Use a Secret you manage instead of letting the chart create one. |
+| `persistence.size` / `persistence.storageClass` | Size and class of the data volume.                               |
+| `resources`                                     | CPU/memory requests and limits.                                  |
+| `sandbox.backend`                               | How agent tools are isolated — `local` or `none`.                |
+| `extraEnv`                                      | Extra environment variables such as `STELLA_BASE_URL`.           |
+
+### Health probes
+
+Liveness, readiness, and startup probes all call `GET /api/status`, which
+returns 200 once the server is up. The startup probe gives the server time to
+run its first-boot database migration before the liveness probe takes over. Tune
+the thresholds under `startupProbe`, `livenessProbe`, and `readinessProbe`.
+
+### Resource limits
+
+Defaults request 250m CPU / 512Mi memory and cap at 2 CPU / 2Gi. Adjust
+`resources` to match your workload — agents running tools are the main driver.
+
+### Sandbox isolation
+
+The default `local` backend isolates agent tool execution and needs a relaxed
+seccomp profile to do so; the chart sets this for you. If your cluster policy
+forbids relaxed seccomp, set `sandbox.backend: none` — agent tools then run
+without isolation, so use it only for trusted workloads.
+
+### Using an externally managed secret
+
+To manage the vault key and provider keys yourself, create a Secret containing
+`STELLA_VAULT_KEY` (and any provider keys), then point the chart at it:
+
+```bash
+kubectl -n stella create secret generic stella-secrets \
+  --from-literal=STELLA_VAULT_KEY="$(stella vault keygen)" \
+  --from-literal=ANTHROPIC_API_KEY=sk-ant-...
+
+helm install stella ./deploy/helm/stella -n stella \
+  --set secret.create=false --set secret.existingSecret=stella-secrets
+```
+
+## Back up your data
+
+The data volume holds your database, secrets, skills, and user files — back it up
+before upgrades:
+
+```bash
+kubectl -n stella exec statefulset/stella -- \
+  sqlite3 /home/stella/.stella/stella.db ".backup /home/stella/.stella/backup.db"
+kubectl -n stella cp stella-0:/home/stella/.stella/backup.db ./stella-backup.db
+```
+
+## Upgrade and roll back
+
+```bash
+helm upgrade stella ./deploy/helm/stella -n stella -f values.yaml
+helm rollback stella -n stella          # revert to the previous release
+```
+
+With a single replica the pod is recreated in place during an upgrade, so expect
+a short downtime window. Changes to configuration or secrets automatically roll
+the pod.
+
+## Troubleshooting
+
+- **Pod stuck `Pending`.** No volume could be bound — check that your cluster has
+  a default StorageClass offering `ReadWriteOnce` (`kubectl get storageclass`).
+- **Pod crash-loops at startup.** Usually a missing or malformed vault key.
+  Confirm the Secret has `STELLA_VAULT_KEY`: `kubectl -n stella get secret stella -o yaml`.
+- **Readiness never passes.** Check logs with `kubectl -n stella logs statefulset/stella`.
+  The first boot runs migrations; if it takes longer than the startup probe
+  allows, raise `startupProbe.failureThreshold`.
+- **Agent tools fail to run.** If your cluster blocks the relaxed seccomp profile
+  the `local` sandbox needs, switch to `sandbox.backend: none` for trusted
+  workloads.
+
+## Don't scale this
+
+Do not raise `replicaCount` or set `autoscaling.enabled=true` on SQLite — the
+chart guards against the latter, but both lead to a corrupted database. Wait for
+the PostgreSQL backend before scaling horizontally.

--- a/web/content/docs/start-here/kubernetes.zh.md
+++ b/web/content/docs/start-here/kubernetes.zh.md
@@ -1,0 +1,139 @@
+---
+title: Kubernetes
+---
+
+使用官方 Helm Chart（位于 [`deploy/helm/stella`](https://github.com/CherryHQ/stella/tree/main/deploy/helm/stella)）在 Kubernetes 上以生产方式部署 Stella。该 Chart 以单副本 StatefulSet 运行 `stellad`，由持久卷上的 SQLite 提供存储，并配置了健康探针、资源限制和 Ingress。
+
+## 开始之前
+
+Stella 将全部状态保存在单个 SQLite 数据库中。本部署**只运行一个副本**——运行多个副本会损坏数据库。横向扩缩（多副本、自动扩缩）以及外部 PostgreSQL / S3 存储尚不可用，相关进展见 [issue #477](https://github.com/CherryHQ/stella/issues/477)。对大多数团队来说，一个资源充足的副本已足够。
+
+你需要：
+
+- 一个 Kubernetes 集群（1.25+）以及 `kubectl` 访问权限。
+- [Helm](https://helm.sh/) 3.8+。
+- 提供 `ReadWriteOnce` 卷的 StorageClass。请避免使用 NFS——Stella 的数据库在其上不可靠。
+- 一个用 `stella vault keygen` 生成的密钥库密钥。没有它，密钥、OAuth 和插件凭证都无法工作。
+
+## 安装
+
+克隆仓库（或复制 `deploy/helm/stella` 目录），然后安装：
+
+```bash
+helm install stella ./deploy/helm/stella \
+  --namespace stella --create-namespace \
+  --set-file secret.vaultKey=/dev/stdin <<<"$(stella vault keygen)" \
+  --set secret.apiKeys.ANTHROPIC_API_KEY=sk-ant-...
+```
+
+`--set-file secret.vaultKey=/dev/stdin` 从管道传入的 `stella vault keygen` 输出读取密钥，因此它不会留在 shell 历史或文件中。提供至少一个模型供应商密钥（例如 `ANTHROPIC_API_KEY` 或 `OPENAI_API_KEY`）可让智能体立即运行；你也可以稍后在 Web UI 中添加密钥。
+
+等待 Pod 就绪并运行内置冒烟测试：
+
+```bash
+kubectl -n stella rollout status statefulset/stella
+helm test stella -n stella
+```
+
+## 访问 Web UI
+
+快速检查可使用端口转发：
+
+```bash
+kubectl -n stella port-forward svc/stella 25678:25678
+```
+
+然后打开 `http://localhost:25678` 配置供应商、渠道和智能体。
+
+如需持久的外部访问，在 values 文件中启用 Ingress：
+
+```yaml
+# values.yaml
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: stella.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: stella-tls
+      hosts:
+        - stella.example.com
+
+# 告知 Stella 其公开 URL，使 Web UI 链接和 OAuth 回调正确。
+extraEnv:
+  STELLA_BASE_URL: https://stella.example.com
+```
+
+用 `helm upgrade stella ./deploy/helm/stella -n stella -f values.yaml` 应用。
+
+## 配置
+
+所有配置都在 [`values.yaml`](https://github.com/CherryHQ/stella/blob/main/deploy/helm/stella/values.yaml) 中，并附有行内说明。最常用的几项：
+
+| 配置项                                          | 用途                                         |
+| ----------------------------------------------- | -------------------------------------------- |
+| `secret.vaultKey`                               | 密钥库密钥（必填）。                         |
+| `secret.apiKeys`                                | 作为环境变量注入的供应商 API 密钥。          |
+| `secret.existingSecret`                         | 使用你自行管理的 Secret，而非让 Chart 创建。 |
+| `persistence.size` / `persistence.storageClass` | 数据卷的大小与 StorageClass。                |
+| `resources`                                     | CPU/内存的请求与限制。                       |
+| `sandbox.backend`                               | 智能体工具的隔离方式——`local` 或 `none`。    |
+| `extraEnv`                                      | 额外的环境变量，例如 `STELLA_BASE_URL`。     |
+
+### 健康探针
+
+存活、就绪和启动探针都调用 `GET /api/status`，服务启动后返回 200。启动探针给服务留出首次启动迁移数据库的时间，之后再由存活探针接管。可在 `startupProbe`、`livenessProbe`、`readinessProbe` 下调整阈值。
+
+### 资源限制
+
+默认请求 250m CPU / 512Mi 内存，上限为 2 CPU / 2Gi。根据负载调整 `resources`——运行工具的智能体是主要消耗来源。
+
+### 沙箱隔离
+
+默认的 `local` 后端会隔离智能体工具执行，为此需要放宽的 seccomp 配置，Chart 已为你设置。如果集群策略禁止放宽 seccomp，可设置 `sandbox.backend: none`——此时智能体工具不再隔离，仅用于可信负载。
+
+### 使用自行管理的 Secret
+
+若想自行管理密钥库密钥与供应商密钥，先创建包含 `STELLA_VAULT_KEY`（及任意供应商密钥）的 Secret，再让 Chart 指向它：
+
+```bash
+kubectl -n stella create secret generic stella-secrets \
+  --from-literal=STELLA_VAULT_KEY="$(stella vault keygen)" \
+  --from-literal=ANTHROPIC_API_KEY=sk-ant-...
+
+helm install stella ./deploy/helm/stella -n stella \
+  --set secret.create=false --set secret.existingSecret=stella-secrets
+```
+
+## 备份数据
+
+数据卷保存着数据库、密钥、技能和用户文件——升级前请务必备份：
+
+```bash
+kubectl -n stella exec statefulset/stella -- \
+  sqlite3 /home/stella/.stella/stella.db ".backup /home/stella/.stella/backup.db"
+kubectl -n stella cp stella-0:/home/stella/.stella/backup.db ./stella-backup.db
+```
+
+## 升级与回滚
+
+```bash
+helm upgrade stella ./deploy/helm/stella -n stella -f values.yaml
+helm rollback stella -n stella          # 回退到上一个版本
+```
+
+单副本下，升级时 Pod 会原地重建，因此会有短暂的停机窗口。配置或密钥变更会自动触发 Pod 滚动更新。
+
+## 故障排查
+
+- **Pod 一直处于 `Pending`。** 没有可绑定的卷——检查集群是否有提供 `ReadWriteOnce` 的默认 StorageClass（`kubectl get storageclass`）。
+- **Pod 启动时反复崩溃。** 通常是密钥库密钥缺失或格式错误。确认 Secret 中包含 `STELLA_VAULT_KEY`：`kubectl -n stella get secret stella -o yaml`。
+- **就绪探针始终不通过。** 用 `kubectl -n stella logs statefulset/stella` 查看日志。首次启动会运行迁移；若耗时超过启动探针允许的时间，请调高 `startupProbe.failureThreshold`。
+- **智能体工具无法运行。** 如果集群禁止 `local` 沙箱所需的放宽 seccomp 配置，可对可信负载改用 `sandbox.backend: none`。
+
+## 不要扩缩
+
+在 SQLite 下不要提高 `replicaCount` 或设置 `autoscaling.enabled=true`——Chart 会拦截后者，但两者都会导致数据库损坏。请等待 PostgreSQL 后端就绪后再做横向扩缩。

--- a/web/content/docs/start-here/meta.json
+++ b/web/content/docs/start-here/meta.json
@@ -7,6 +7,7 @@
     "quickstart",
     "first-shared-agent",
     "deployment",
+    "kubernetes",
     "configuration"
   ]
 }


### PR DESCRIPTION
## What

Adds an official Helm chart (`deploy/helm/stella`) for deploying Stella on Kubernetes in production, plus a bilingual deployment guide.

- **StatefulSet**, single replica, with `volumeClaimTemplates` (RWO) backing `STELLA_HOME`.
- **Service** (ClusterIP) + headless Service for the StatefulSet.
- **ConfigMap** (non-secret env) and **Secret** (vault key + provider API keys, with `existingSecret` support).
- Optional **Ingress**, **ServiceAccount**.
- **Probes**: startup/liveness/readiness on `GET /api/status` (unauthenticated, 200 = ready). The startup probe absorbs first-boot DB migration.
- **Resource** requests/limits, configurable.
- **HPA** shipped as a *disabled example*, gated behind an explicit `autoscaling.acknowledgeSqliteUnsupported` flag so it can't be enabled on SQLite by accident.
- `helm test` smoke pod, `NOTES.txt`, chart `README.md`.
- Kubernetes how-to doc (`kubernetes.md` + `.zh.md`), registered in `start-here/meta.json` and cross-linked from `deployment.md`.
- `dprint.json`: exclude `deploy/helm/*/templates/**` (Go templating is not valid YAML).

## Why

Teams deploying Stella in production need standard, supported Kubernetes assets instead of hand-written manifests (#480).

## How

- **Single-replica by design.** Stella currently stores all state in one SQLite database (single-writer). The chart runs exactly one replica; multi-replica scaling, HPA, and external PostgreSQL/S3 are documented as future work pending #477. The HPA safety gate fails the render rather than silently corrupting the DB.
- **Sandbox.** The `local` backend (bubblewrap) needs `unshare(2)`, which `RuntimeDefault` seccomp blocks — the chart sets `seccompProfile: Unconfined` (mirrors the Docker `--security-opt seccomp=unconfined`), switchable to `none` for stricter policies on trusted workloads.

### Verification

- `helm lint` clean; `helm template` renders correctly across default / Ingress / HPA-gate / existingSecret / existingClaim scenarios (8 valid manifests).
- `mise run format` passes (no lint/type errors).
- No Go changes; no cluster available, so server-side `kubectl` validation was skipped.

## Refs

- Closes #480
- Parent: #477