### PR TITLE
✨ feat(sessions): stream live turns + allow human messages on internal sessions

### DIFF
--- a/api/spec/domain/sessions/paths.yaml
+++ b/api/spec/domain/sessions/paths.yaml
@@ -199,6 +199,33 @@ paths:
         }
         "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
 
+  /api/agents/{agentId}/sessions/{sessionId}/events:
+    parameters:
+      - { name: agentId, in: path, required: true, schema: { type: string } }
+      - { name: sessionId, in: path, required: true, schema: { type: string } }
+    get:
+      tags: [sessions]
+      summary: Stream a session's live turn events (read-only SSE)
+      description: >
+        Subscribe to the events of an in-flight turn on this session without
+        initiating one. Used by the web UI to watch server-driven turns
+        (scheduler, task, delegate) or a turn started in another tab in real
+        time. The stream emits the same Vercel AI-SDK UI message frames as the
+        message-send endpoint and ends when the turn finishes.
+      operationId: streamSessionEvents
+      responses:
+        "200":
+          description: SSE stream of session events
+          content:
+            text/event-stream:
+              schema: { type: string }
+        "204": { description: No turn currently in flight on this session }
+        "401": {
+          $ref: "../../components.yaml#/components/responses/Unauthorized",
+        }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+
   /api/agents/{agentId}/sessions/{sessionId}/context-items:
     parameters:
       - { name: agentId, in: path, required: true, schema: { type: string } }

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -192,6 +192,8 @@ paths:
     $ref: "./domain/sessions/paths.yaml#/paths/~1api~1agents~1{agentId}~1sessions~1{sessionId}"
   /api/agents/{agentId}/sessions/{sessionId}/messages:
     $ref: "./domain/sessions/paths.yaml#/paths/~1api~1agents~1{agentId}~1sessions~1{sessionId}~1messages"
+  /api/agents/{agentId}/sessions/{sessionId}/events:
+    $ref: "./domain/sessions/paths.yaml#/paths/~1api~1agents~1{agentId}~1sessions~1{sessionId}~1events"
   /api/agents/{agentId}/sessions/{sessionId}/context-items:
     $ref: "./domain/sessions/paths.yaml#/paths/~1api~1agents~1{agentId}~1sessions~1{sessionId}~1context-items"
   /api/agents/{agentId}/sessions/{sessionId}/summaries/{summaryId}:

--- a/internal/agent/runtime/hub.go
+++ b/internal/agent/runtime/hub.go
@@ -10,6 +10,15 @@ import "sync"
 // Publishing never blocks the turn: a slow subscriber drops events rather than
 // stalling the agent. Subscribers reconcile final state by reloading persisted
 // history, so dropped deltas are cosmetic.
+//
+// Placement invariant: the hub lives on the Runtime that executes a session's
+// turns, and the SSE handler subscribes via the Service of `session.AgentID`.
+// This is correct only because every turn for a session — chat, scheduler,
+// task, and delegate — runs on that agent's Runtime. If a turn ever runs on a
+// different Runtime (e.g. a cross-agent delegate, or a standalone task runner),
+// it would publish to a hub the watcher never subscribes to and the live
+// stream would silently fall back to 204. Such a change must hoist the hub to a
+// single per-pool instance keyed by session ID.
 type SessionHub struct {
 	mu   sync.Mutex
 	subs map[string]map[chan Event]struct{}

--- a/internal/agent/runtime/hub.go
+++ b/internal/agent/runtime/hub.go
@@ -1,0 +1,106 @@
+package runtime
+
+import "sync"
+
+// SessionHub fans out a session's live turn events to any number of read-only
+// subscribers. The runtime publishes every event of an in-flight turn; HTTP SSE
+// handlers subscribe to watch a turn they did not initiate — a scheduler/task
+// turn driven server-side, or a turn started from another browser tab.
+//
+// Publishing never blocks the turn: a slow subscriber drops events rather than
+// stalling the agent. Subscribers reconcile final state by reloading persisted
+// history, so dropped deltas are cosmetic.
+type SessionHub struct {
+	mu   sync.Mutex
+	subs map[string]map[chan Event]struct{}
+	live map[string]int // session ID → in-flight turn count
+}
+
+// subBuffer bounds per-subscriber buffering before events are dropped.
+const subBuffer = 256
+
+// NewSessionHub returns an empty hub.
+func NewSessionHub() *SessionHub {
+	return &SessionHub{
+		subs: make(map[string]map[chan Event]struct{}),
+		live: make(map[string]int),
+	}
+}
+
+// Subscribe registers a listener for a session's live events. The returned
+// channel delivers events until the turn ends (then it is closed) or the caller
+// invokes cancel. Callers must always invoke cancel to avoid leaking the
+// subscription.
+func (h *SessionHub) Subscribe(sessionID string) (<-chan Event, func()) {
+	ch := make(chan Event, subBuffer)
+	h.mu.Lock()
+	set := h.subs[sessionID]
+	if set == nil {
+		set = make(map[chan Event]struct{})
+		h.subs[sessionID] = set
+	}
+	set[ch] = struct{}{}
+	h.mu.Unlock()
+
+	var once sync.Once
+	cancel := func() {
+		once.Do(func() {
+			h.mu.Lock()
+			if set := h.subs[sessionID]; set != nil {
+				if _, ok := set[ch]; ok {
+					delete(set, ch)
+					close(ch)
+				}
+				if len(set) == 0 {
+					delete(h.subs, sessionID)
+				}
+			}
+			h.mu.Unlock()
+		})
+	}
+	return ch, cancel
+}
+
+// IsLive reports whether a turn is currently in flight on the session.
+func (h *SessionHub) IsLive(sessionID string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.live[sessionID] > 0
+}
+
+// begin marks a turn as in flight.
+func (h *SessionHub) begin(sessionID string) {
+	h.mu.Lock()
+	h.live[sessionID]++
+	h.mu.Unlock()
+}
+
+// end clears a turn. When the last turn on a session finishes, all of its
+// subscriber channels are closed so SSE handlers can finish their streams.
+func (h *SessionHub) end(sessionID string) {
+	h.mu.Lock()
+	if h.live[sessionID] > 0 {
+		h.live[sessionID]--
+	}
+	if h.live[sessionID] == 0 {
+		delete(h.live, sessionID)
+		for ch := range h.subs[sessionID] {
+			close(ch)
+		}
+		delete(h.subs, sessionID)
+	}
+	h.mu.Unlock()
+}
+
+// publish delivers an event to every current subscriber, dropping it for any
+// subscriber whose buffer is full.
+func (h *SessionHub) publish(sessionID string, ev Event) {
+	h.mu.Lock()
+	for ch := range h.subs[sessionID] {
+		select {
+		case ch <- ev:
+		default:
+		}
+	}
+	h.mu.Unlock()
+}

--- a/internal/agent/runtime/hub_test.go
+++ b/internal/agent/runtime/hub_test.go
@@ -1,0 +1,60 @@
+package runtime
+
+import "testing"
+
+func TestSessionHubFanOutAndClose(t *testing.T) {
+	h := NewSessionHub()
+	if h.IsLive("s1") {
+		t.Fatal("session should not be live before a turn begins")
+	}
+
+	ch, cancel := h.Subscribe("s1")
+	defer cancel()
+
+	h.begin("s1")
+	if !h.IsLive("s1") {
+		t.Fatal("session should be live after begin")
+	}
+
+	h.publish("s1", Event{Text: "hello"})
+	if ev := <-ch; ev.Text != "hello" {
+		t.Fatalf("got %q, want %q", ev.Text, "hello")
+	}
+
+	h.end("s1")
+	if h.IsLive("s1") {
+		t.Fatal("session should not be live after end")
+	}
+	if _, open := <-ch; open {
+		t.Fatal("subscriber channel should be closed when the turn ends")
+	}
+}
+
+func TestSessionHubCancelUnsubscribes(t *testing.T) {
+	h := NewSessionHub()
+	ch, cancel := h.Subscribe("s1")
+
+	cancel()
+	if _, open := <-ch; open {
+		t.Fatal("cancel should close the channel")
+	}
+
+	// Publishing after cancel must not panic or deliver.
+	h.begin("s1")
+	h.publish("s1", Event{Text: "dropped"})
+	h.end("s1")
+
+	// Double cancel is a no-op.
+	cancel()
+}
+
+func TestSessionHubPublishNeverBlocks(t *testing.T) {
+	h := NewSessionHub()
+	_, cancel := h.Subscribe("s1") // never drained
+	defer cancel()
+
+	// More events than the buffer; excess is dropped rather than blocking.
+	for range subBuffer + 10 {
+		h.publish("s1", Event{Text: "x"})
+	}
+}

--- a/internal/agent/runtime/panic_recover_test.go
+++ b/internal/agent/runtime/panic_recover_test.go
@@ -1,0 +1,44 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/CherryHQ/stella/internal/agent/session"
+	"github.com/CherryHQ/stella/pkg/ai"
+)
+
+type panicRunner struct{}
+
+func (panicRunner) Chat(_ context.Context, _ []ai.Message, _ MessageContent) <-chan Event {
+	panic("boom")
+}
+func (panicRunner) Alive() bool             { return true }
+func (panicRunner) Busy() bool              { return false }
+func (panicRunner) LastActivity() time.Time { return time.Now() }
+func (panicRunner) SystemPrompt() string    { return "" }
+func (panicRunner) Close() error            { return nil }
+
+// A panic inside the turn must not wedge the session: the caller's channel
+// still closes, the busy guard clears, and the hub stops reporting the session
+// as live (otherwise SSE watchers would poll a never-closing stream forever).
+func TestChat_PanicRecovers_FreesSessionAndHub(t *testing.T) {
+	mem := &recordingMemory{}
+	rt, _ := New(Config{
+		NewRunner: func(_ context.Context, _ RunnerParams) (Runner, error) {
+			return panicRunner{}, nil
+		},
+		Memory: mem,
+	})
+
+	info := session.Info{ID: "sess-1", UserID: "u1", AgentID: "a1"}
+	ch := rt.Chat(context.Background(), info, "hi")
+	for range ch { //nolint:revive // drain until the forwarder closes out
+	}
+
+	waitSessionFree(t, rt, info.ID)
+	if rt.SessionLive(info.ID) {
+		t.Fatal("session stuck live after a panicking turn")
+	}
+}

--- a/internal/agent/runtime/panic_recover_test.go
+++ b/internal/agent/runtime/panic_recover_test.go
@@ -2,10 +2,12 @@ package runtime
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/CherryHQ/stella/internal/agent/session"
+	"github.com/CherryHQ/stella/internal/memory"
 	"github.com/CherryHQ/stella/pkg/ai"
 )
 
@@ -40,5 +42,51 @@ func TestChat_PanicRecovers_FreesSessionAndHub(t *testing.T) {
 	waitSessionFree(t, rt, info.ID)
 	if rt.SessionLive(info.ID) {
 		t.Fatal("session stuck live after a panicking turn")
+	}
+}
+
+// panicOnNthAppendMemory panics on the nth Append call. Used to drive a panic
+// from inside streamEvents (which persists the assistant message) rather than
+// before it — the user message is appended first, in rt.chat.
+type panicOnNthAppendMemory struct {
+	recordingMemory
+	n     int
+	mu    sync.Mutex
+	count int
+}
+
+func (m *panicOnNthAppendMemory) Append(_ context.Context, _ memory.Session, _ ...ai.Message) error {
+	m.mu.Lock()
+	m.count++
+	c := m.count
+	m.mu.Unlock()
+	if c == m.n {
+		panic("append boom")
+	}
+	return nil
+}
+
+// A panic raised inside streamEvents unwinds through its defer, which closes
+// inner. The Chat wrapper's recover must NOT blindly close inner again — a
+// second close of the same channel panics in a goroutine and crashes the
+// process. This guards that the recovery path tolerates an already-closed
+// channel while still freeing the session and hub.
+func TestChat_PanicInStreamEvents_NoDoubleClose(t *testing.T) {
+	mem := &panicOnNthAppendMemory{n: 2} // 1: user message in rt.chat; 2: assistant flush in streamEvents
+	rt, _ := New(Config{
+		Memory: mem,
+		NewRunner: func(_ context.Context, _ RunnerParams) (Runner, error) {
+			return chatFakeRunner{events: []Event{{Text: "hi"}}}, nil
+		},
+	})
+
+	info := session.Info{ID: "sess-1", UserID: "u1", AgentID: "a1"}
+	ch := rt.Chat(context.Background(), info, "hi")
+	for range ch { //nolint:revive // drain until the forwarder closes out
+	}
+
+	waitSessionFree(t, rt, info.ID)
+	if rt.SessionLive(info.ID) {
+		t.Fatal("session stuck live after a panic inside streamEvents")
 	}
 }

--- a/internal/agent/runtime/runtime.go
+++ b/internal/agent/runtime/runtime.go
@@ -26,6 +26,7 @@ type Runtime struct {
 	beforeRun      BeforeRunFunc
 	snapshotPrompt SnapshotPromptFunc
 	active         sync.Map // session ID → struct{}, tracks in-flight turns
+	hub            *SessionHub
 }
 
 // CompactionConfig controls automatic compaction thresholds.
@@ -84,7 +85,20 @@ func New(cfg Config) (*Runtime, error) {
 		compact:        cfg.Compaction.WithDefaults(),
 		beforeRun:      cfg.BeforeRun,
 		snapshotPrompt: cfg.SnapshotPrompt,
+		hub:            NewSessionHub(),
 	}, nil
+}
+
+// Subscribe registers a read-only listener for a session's live turn events.
+// The channel is closed when the in-flight turn ends; callers must invoke the
+// returned cancel func when they stop reading. See SessionHub.
+func (rt *Runtime) Subscribe(sessionID string) (<-chan Event, func()) {
+	return rt.hub.Subscribe(sessionID)
+}
+
+// SessionLive reports whether a turn is currently in flight on the session.
+func (rt *Runtime) SessionLive(sessionID string) bool {
+	return rt.hub.IsLive(sessionID)
 }
 
 // SetNewRunner replaces the runner builder. Existing runners are not affected
@@ -200,9 +214,34 @@ func (rt *Runtime) Chat(ctx context.Context, info session.Info, msg MessageConte
 		o(&co)
 	}
 	ctx = memory.WithSessionID(ctx, info.ID)
+
+	// Tee: chat writes to inner; the forwarder fans every event out to the hub
+	// (for read-only subscribers — SSE watchers of scheduler/task/delegate turns
+	// or other tabs) and to the caller's channel. The hub is fed even if the
+	// initiating caller disconnects, so a server-driven turn still streams to
+	// watching UIs.
+	inner := make(chan Event, 100)
+	rt.hub.begin(info.ID)
 	go func() {
 		defer rt.active.Delete(info.ID)
-		rt.chat(ctx, out, info, msg, co)
+		rt.chat(ctx, inner, info, msg, co)
+	}()
+	go func() {
+		defer close(out)
+		defer rt.hub.end(info.ID)
+		for ev := range inner {
+			rt.hub.publish(info.ID, ev)
+			select {
+			case out <- ev:
+			case <-ctx.Done():
+				// Caller gone: keep draining so the turn completes and hub
+				// subscribers keep receiving, but stop writing to out.
+				for ev := range inner {
+					rt.hub.publish(info.ID, ev)
+				}
+				return
+			}
+		}
 	}()
 	return out
 }

--- a/internal/agent/runtime/runtime.go
+++ b/internal/agent/runtime/runtime.go
@@ -200,6 +200,13 @@ var ErrSessionBusy = agenterr.ErrSessionBusy
 //
 // Only one active turn per session is allowed. A second concurrent Chat on the
 // same session returns ErrSessionBusy immediately.
+// safeClose closes ch, tolerating an already-closed channel. The panic-recovery
+// path in Chat cannot know whether rt.chat closed inner before unwinding.
+func safeClose(ch chan Event) {
+	defer func() { _ = recover() }()
+	close(ch)
+}
+
 func (rt *Runtime) Chat(ctx context.Context, info session.Info, msg MessageContent, opts ...Option) <-chan Event {
 	out := make(chan Event, 100)
 
@@ -230,11 +237,13 @@ func (rt *Runtime) Chat(ctx context.Context, info session.Info, msg MessageConte
 		defer rt.active.Delete(info.ID)
 		defer func() {
 			if p := recover(); p != nil {
-				// rt.chat panicked before closing inner. Close it so the
-				// forwarder drains and rt.hub.end runs; otherwise the session
-				// wedges — stuck busy and permanently "live" to SSE watchers.
+				// rt.chat panicked. Close inner so the forwarder drains and
+				// rt.hub.end runs; otherwise the session wedges — stuck busy
+				// and permanently "live" to SSE watchers. The panic may have
+				// unwound through a defer in rt.chat/streamEvents that already
+				// closed inner, so tolerate an already-closed channel.
 				rt.log.Error("chat turn panicked", "session_id", info.ID, "panic", p)
-				close(inner)
+				safeClose(inner)
 			}
 		}()
 		rt.chat(ctx, inner, info, msg, co)

--- a/internal/agent/runtime/runtime.go
+++ b/internal/agent/runtime/runtime.go
@@ -216,14 +216,27 @@ func (rt *Runtime) Chat(ctx context.Context, info session.Info, msg MessageConte
 	ctx = memory.WithSessionID(ctx, info.ID)
 
 	// Tee: chat writes to inner; the forwarder fans every event out to the hub
-	// (for read-only subscribers — SSE watchers of scheduler/task/delegate turns
-	// or other tabs) and to the caller's channel. The hub is fed even if the
-	// initiating caller disconnects, so a server-driven turn still streams to
-	// watching UIs.
+	// (read-only subscribers — SSE watchers of scheduler/task/delegate turns, or
+	// another tab) as well as to the caller's channel.
+	//
+	// A server-driven turn (scheduler/task) runs under its own context, so
+	// watchers can attach and detach without affecting it. A user-initiated turn
+	// runs under the caller's request context and ends when that caller
+	// disconnects; the ctx.Done branch below only flushes already-buffered
+	// events rather than blocking on a reader that is gone.
 	inner := make(chan Event, 100)
 	rt.hub.begin(info.ID)
 	go func() {
 		defer rt.active.Delete(info.ID)
+		defer func() {
+			if p := recover(); p != nil {
+				// rt.chat panicked before closing inner. Close it so the
+				// forwarder drains and rt.hub.end runs; otherwise the session
+				// wedges — stuck busy and permanently "live" to SSE watchers.
+				rt.log.Error("chat turn panicked", "session_id", info.ID, "panic", p)
+				close(inner)
+			}
+		}()
 		rt.chat(ctx, inner, info, msg, co)
 	}()
 	go func() {
@@ -234,8 +247,8 @@ func (rt *Runtime) Chat(ctx context.Context, info session.Info, msg MessageConte
 			select {
 			case out <- ev:
 			case <-ctx.Done():
-				// Caller gone: keep draining so the turn completes and hub
-				// subscribers keep receiving, but stop writing to out.
+				// Caller gone: keep draining inner so the turn finishes cleanly
+				// and hub subscribers still receive, but stop writing to out.
 				for ev := range inner {
 					rt.hub.publish(info.ID, ev)
 				}

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -96,7 +96,8 @@ func (s *Service) Chat(ctx context.Context, req ChatRequest) <-chan Event {
 		Channel:   req.Channel,
 	}
 	if req.SessionID != "" {
-		// Resume: accept main or chat sessions; reject internal kinds.
+		// Resume: enforce the caller-declared kind matches the stored session
+		// (any kind, including internal delegate/task/scheduler sessions).
 		if req.Kind != "" {
 			ensureReq.RequireKind = kind
 		}
@@ -122,6 +123,18 @@ func (s *Service) Chat(ctx context.Context, req ChatRequest) <-chan Event {
 		opts = append(opts, agentruntime.WithCurrentSpeaker(req.CurrentSpeaker))
 	}
 	return s.Runtime.Chat(ctx, info, req.Message, opts...)
+}
+
+// SubscribeSession registers a read-only listener for a session's live turn
+// events, regardless of who initiated the turn. Used by the SSE endpoint to let
+// the web UI watch scheduler/task/delegate turns in real time.
+func (s *Service) SubscribeSession(sessionID string) (<-chan Event, func()) {
+	return s.Runtime.Subscribe(sessionID)
+}
+
+// SessionLive reports whether a turn is currently in flight on the session.
+func (s *Service) SessionLive(sessionID string) bool {
+	return s.Runtime.SessionLive(sessionID)
 }
 
 // ChannelChatRequest describes a chat turn on a non-private channel/group session

--- a/internal/server/sessions.go
+++ b/internal/server/sessions.go
@@ -145,11 +145,10 @@ func (s *Server) SendSessionMessage(w http.ResponseWriter, r *http.Request, agen
 	// Convert AI SDK parts to internal MessageContent.
 	msgContent := partsToMessageContent(body.Parts)
 
+	// Humans may join any session kind (chat/main and internal delegate/task/
+	// scheduler sessions alike). The runtime's chat loop is kind-agnostic, so a
+	// manual message simply resumes the agent on that session's context.
 	siKind := session.Kind(si.Kind)
-	if siKind != session.KindMain && siKind != session.KindChat {
-		writeError(w, http.StatusBadRequest, "cannot send messages to internal sessions")
-		return
-	}
 
 	// Intercept slash commands before hitting the LLM.
 	if text, ok := msgContent.(string); ok {
@@ -159,6 +158,23 @@ func (s *Server) SendSessionMessage(w http.ResponseWriter, r *http.Request, agen
 		}
 	}
 
+	ch := svc.Chat(ctx, agent.ChatRequest{
+		SessionID: sessionID,
+		UserID:    si.UserID,
+		AgentID:   si.AgentID,
+		Kind:      siKind,
+		Channel:   session.Channel(si.Channel),
+		Message:   msgContent,
+	})
+	streamAgentEvents(r.Context(), w, flusher, agentID, sessionID, ch)
+}
+
+// streamAgentEvents encodes a live turn's events to w as a Vercel AI-SDK UI
+// message stream (SSE). Shared by SendSessionMessage (the turn it initiated) and
+// StreamSessionEvents (a read-only subscription to a turn started elsewhere), so
+// both emit the exact wire format the web chat parser expects. The stream ends
+// when ch closes (turn finished) or ctx is cancelled (client disconnected).
+func streamAgentEvents(ctx context.Context, w http.ResponseWriter, flusher http.Flusher, agentID, sessionID string, ch <-chan agent.Event) {
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("X-Accel-Buffering", "no")
@@ -200,17 +216,9 @@ func (s *Server) SendSessionMessage(w http.ResponseWriter, r *http.Request, agen
 		}
 	}
 
-	ch := svc.Chat(ctx, agent.ChatRequest{
-		SessionID: sessionID,
-		UserID:    si.UserID,
-		AgentID:   si.AgentID,
-		Kind:      siKind,
-		Channel:   session.Channel(si.Channel),
-		Message:   msgContent,
-	})
 	for {
 		select {
-		case <-r.Context().Done():
+		case <-ctx.Done():
 			closeText()
 			closeReasoning()
 			if stepOpen {
@@ -370,6 +378,72 @@ func (s *Server) SendSessionMessage(w http.ResponseWriter, r *http.Request, agen
 			}
 		}
 	}
+}
+
+// StreamSessionEvents subscribes to a session's in-flight turn and streams its
+// events read-only, regardless of who initiated the turn. This lets the web UI
+// watch server-driven turns (scheduler/task/delegate) or a turn started in
+// another tab in real time, since those turns carry no HTTP request of their own.
+func (s *Server) StreamSessionEvents(w http.ResponseWriter, r *http.Request, agentID string, sessionID string) {
+	if sessionID == "" {
+		writeError(w, http.StatusBadRequest, "missing session ID")
+		return
+	}
+
+	authInfo := UserFromContext(r.Context())
+	if authInfo == nil {
+		writeError(w, http.StatusUnauthorized, "authentication required")
+		return
+	}
+
+	sm, ok := s.mem.(memory.SessionManager)
+	if !ok {
+		writeError(w, http.StatusNotFound, "memory provider does not support sessions")
+		return
+	}
+
+	ctx := memoryContext(r, agentID)
+	si, err := sm.LoadInfo(ctx, sessionID)
+	if err != nil {
+		writeError(w, http.StatusNotFound, "not found")
+		return
+	}
+
+	// Ownership is strict: only the session owner may watch its events.
+	if authInfo.UserID != si.UserID {
+		writeError(w, http.StatusForbidden, "access denied")
+		return
+	}
+
+	var svc *agent.Service
+	if si.AgentID != "" {
+		svc = s.poolManager.GetService(si.AgentID)
+	} else {
+		svc = s.poolManager.Default()
+	}
+	if svc == nil {
+		writeError(w, http.StatusBadRequest, "no service available for this session")
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeError(w, http.StatusInternalServerError, "streaming not supported")
+		return
+	}
+
+	ch, cancel := svc.SubscribeSession(sessionID)
+	defer cancel()
+
+	// No turn in flight: 204 tells the AI-SDK resume client there is nothing to
+	// reconnect to, so it stays on the static transcript instead of holding the
+	// connection open.
+	if !svc.SessionLive(sessionID) {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	streamAgentEvents(r.Context(), w, flusher, agentID, sessionID, ch)
 }
 
 // partsToMessageContent converts API MessageParts to internal MessageContent.

--- a/internal/server/sessions.go
+++ b/internal/server/sessions.go
@@ -90,12 +90,6 @@ func (s *Server) SendSessionMessage(w http.ResponseWriter, r *http.Request, agen
 		return
 	}
 
-	authInfo := UserFromContext(r.Context())
-	if authInfo == nil {
-		writeError(w, http.StatusUnauthorized, "authentication required")
-		return
-	}
-
 	var body apiserver.SendSessionMessageJSONRequestBody
 	if err := decodeJSON(r, &body); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request")
@@ -103,6 +97,13 @@ func (s *Server) SendSessionMessage(w http.ResponseWriter, r *http.Request, agen
 	}
 	if len(body.Parts) == 0 {
 		writeError(w, http.StatusBadRequest, "parts is required")
+		return
+	}
+
+	// Authorize through the single chokepoint: ownership, agent/path match, and
+	// the scoped-token session pin. A scoped (e.g. sandbox) token must not reach
+	// a session other than the one it is pinned to.
+	if err := s.checkSessionAccess(w, r, agentID, sessionID); err != nil {
 		return
 	}
 
@@ -116,12 +117,6 @@ func (s *Server) SendSessionMessage(w http.ResponseWriter, r *http.Request, agen
 	si, err := sm.LoadInfo(ctx, sessionID)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "not found")
-		return
-	}
-
-	// Ownership is strict: only the session owner may send messages.
-	if authInfo.UserID != si.UserID {
-		writeError(w, http.StatusForbidden, "access denied")
 		return
 	}
 
@@ -390,9 +385,10 @@ func (s *Server) StreamSessionEvents(w http.ResponseWriter, r *http.Request, age
 		return
 	}
 
-	authInfo := UserFromContext(r.Context())
-	if authInfo == nil {
-		writeError(w, http.StatusUnauthorized, "authentication required")
+	// Same authorization chokepoint as message-send: ownership, agent/path
+	// match, and scoped-token session pin. The live event stream is at least as
+	// sensitive as the transcript, so it must not be reachable cross-session.
+	if err := s.checkSessionAccess(w, r, agentID, sessionID); err != nil {
 		return
 	}
 
@@ -406,12 +402,6 @@ func (s *Server) StreamSessionEvents(w http.ResponseWriter, r *http.Request, age
 	si, err := sm.LoadInfo(ctx, sessionID)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "not found")
-		return
-	}
-
-	// Ownership is strict: only the session owner may watch its events.
-	if authInfo.UserID != si.UserID {
-		writeError(w, http.StatusForbidden, "access denied")
 		return
 	}
 

--- a/web/content/docs/development/agent-architecture.md
+++ b/web/content/docs/development/agent-architecture.md
@@ -156,6 +156,8 @@ Session kind describes why the session exists. Channel describes where it origin
 
 Typed resume must validate kind. A scheduler run must not resume a delegate session even if the ID matches. A channel session must require `KindChat` even though channel keys are trusted.
 
+Human messages are accepted on every kind. The web UI may send a message to a `delegate`, `task`, or `scheduler` session just like a `chat` session — the runtime turn loop is kind-agnostic. A send during an in-flight turn fails closed with `ErrSessionBusy` (see Concurrency), so manual messages never race a server-driven turn.
+
 ## ID trust model
 
 Not all session IDs are equal.
@@ -206,6 +208,16 @@ This matters for delegate and scheduler callers because they treat any stream er
 ### Concurrency
 
 Runtime allows at most one active turn per session. It rejects a second same-session turn with `ErrSessionBusy`. It does not queue. Queueing requires product-level semantics for cancellation, ordering, and backpressure; rejection is simple and safe.
+
+### Live event fan-out
+
+Server-driven turns (`scheduler`, `task`, `delegate`) carry no HTTP request of their own, so their events would otherwise be invisible to the web UI. Runtime tees every turn's events through a per-runtime `SessionHub`:
+
+- `Runtime.Chat` publishes each event to the hub in addition to the caller's channel. The hub is fed even if the initiating caller disconnects, so a turn started by the scheduler still streams to a watching browser.
+- Publishing never blocks the turn: a slow subscriber drops events rather than stalling the agent. Subscribers reconcile final state by reloading persisted history, so dropped deltas are cosmetic.
+- When the turn ends, the hub closes its subscriber channels.
+
+`GET /api/agents/{agentId}/sessions/{sessionId}/events` subscribes a read-only SSE stream that reuses the same AI-SDK UI message encoding as the message-send endpoint, and returns `204` when no turn is in flight. The web UI calls the AI-SDK `resumeStream()` against this endpoint for internal-kind sessions so the transcript renders live.
 
 ## Caller flows
 

--- a/web/content/docs/development/agent-architecture.zh.md
+++ b/web/content/docs/development/agent-architecture.zh.md
@@ -156,6 +156,8 @@ Session kind 描述 session 为什么存在。Channel 描述 session 从哪里�
 
 Typed resume 必须验证 kind。即使 ID 一样，scheduler run 也不能恢复 delegate session。Channel session 虽然 key 是 trusted，也必须要求 `KindChat`。
 
+所有 kind 都接受人工消息。Web UI 可以像给 `chat` session 发消息一样,给 `delegate`、`task`、`scheduler` session 发消息——runtime 的 turn 循环与 kind 无关。turn 进行中发送会以 `ErrSessionBusy` 失败关闭(见并发),因此人工消息不会与服务端驱动的 turn 竞争。
+
 ## ID trust model
 
 不是所有 session ID 都一样。
@@ -206,6 +208,16 @@ Chat timeout 是可恢复停止，不是硬失败。Runtime 会持久化并 stre
 ### Concurrency
 
 Runtime 对每个 session 最多允许一个 active turn。第二个 same-session turn 会被 `ErrSessionBusy` 拒绝。Runtime 不排队。排队需要产品层定义 cancellation、ordering 和 backpressure；拒绝更简单也更安全。
+
+### 实时事件扇出
+
+服务端驱动的 turn(`scheduler`、`task`、`delegate`)没有自己的 HTTP 请求,因此其事件对 Web UI 本来是不可见的。Runtime 把每个 turn 的事件经由每个 runtime 一份的 `SessionHub` tee 出去:
+
+- `Runtime.Chat` 除了写给调用方的 channel,还把每个事件发布到 hub。即使发起的调用方断开,hub 仍被持续喂入,所以由 scheduler 发起的 turn 照样能流式推给正在观看的浏览器。
+- 发布永不阻塞 turn:慢订阅者丢弃事件而非拖住 agent。订阅者通过重新加载已持久化的历史来对齐最终状态,因此丢掉的增量只是视觉上的。
+- turn 结束时,hub 关闭其订阅 channel。
+
+`GET /api/agents/{agentId}/sessions/{sessionId}/events` 订阅一个只读 SSE 流,复用与发消息端点相同的 AI-SDK UI message 编码;没有进行中的 turn 时返回 `204`。Web UI 对内部 kind 的 session 用 AI-SDK 的 `resumeStream()` 连到该端点,使 transcript 实时渲染。
 
 ## Caller flows
 

--- a/web/src/features/sessions/SessionDetail.tsx
+++ b/web/src/features/sessions/SessionDetail.tsx
@@ -139,11 +139,19 @@ export function SessionDetail({
     session?.kind === "scheduler" || session?.kind === "task" || session?.kind === "delegate";
   const chatStatusRef = useRef(chatStatus);
   chatStatusRef.current = chatStatus;
+  // resumeStream() is async and status only flips to "streaming" once the SSE
+  // connection parses its first frame; guard with an in-flight ref so a tick
+  // firing inside that window can't open a second concurrent stream.
+  const resumingRef = useRef(false);
   useEffect(() => {
     if (!session || !isInternalKind) return;
     let cancelled = false;
     const tick = () => {
-      if (!cancelled && chatStatusRef.current === "ready") void chatResume();
+      if (cancelled || resumingRef.current || chatStatusRef.current !== "ready") return;
+      resumingRef.current = true;
+      void chatResume().finally(() => {
+        resumingRef.current = false;
+      });
     };
     tick();
     const timer = setInterval(tick, 3000);

--- a/web/src/features/sessions/SessionDetail.tsx
+++ b/web/src/features/sessions/SessionDetail.tsx
@@ -121,12 +121,37 @@ export function SessionDetail({
     setMessages: setChatMessages,
     status: chatStatus,
     stop: chatStop,
+    resumeStream: chatResume,
   } = useChat({
     id: session?.id ?? "empty",
     transport,
   });
 
   const isStreaming = chatStatus === "streaming" || chatStatus === "submitted";
+
+  // Server-driven sessions (scheduler/task/delegate) run turns that carry no
+  // HTTP request of their own, so the normal send-stream never sees them. Poll
+  // the read-only events stream to watch such a turn live: resumeStream()
+  // attaches when one is in flight and no-ops (204) otherwise. Fire it only
+  // while idle so we never double-connect, and read status via a ref to keep
+  // the interval stable.
+  const isInternalKind =
+    session?.kind === "scheduler" || session?.kind === "task" || session?.kind === "delegate";
+  const chatStatusRef = useRef(chatStatus);
+  chatStatusRef.current = chatStatus;
+  useEffect(() => {
+    if (!session || !isInternalKind) return;
+    let cancelled = false;
+    const tick = () => {
+      if (!cancelled && chatStatusRef.current === "ready") void chatResume();
+    };
+    tick();
+    const timer = setInterval(tick, 3000);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [session?.id, isInternalKind, chatResume]);
 
   const messagesQuery = useInfiniteQuery({
     queryKey: ["session-messages", session?.id],

--- a/web/src/lib/chat-transport.ts
+++ b/web/src/lib/chat-transport.ts
@@ -4,8 +4,9 @@ import type { GroupMessage } from "@/lib/api-client/types.gen";
 import type { Message, RenderableReference } from "./types";
 
 export function createSessionTransport(agentId: string, sessionId: string) {
+  const base = `/api/agents/${encodeURIComponent(agentId)}/sessions/${encodeURIComponent(sessionId)}`;
   return new DefaultChatTransport({
-    api: `/api/agents/${encodeURIComponent(agentId)}/sessions/${encodeURIComponent(sessionId)}/messages`,
+    api: `${base}/messages`,
     prepareSendMessagesRequest: ({ messages }) => {
       const last = messages[messages.length - 1];
       const parts = last.parts
@@ -16,6 +17,11 @@ export function createSessionTransport(agentId: string, sessionId: string) {
         .filter(Boolean);
       return { body: { parts } };
     },
+    // Read-only resume: watch a turn started elsewhere (server-driven
+    // scheduler/task/delegate turns, or another tab) via the events SSE
+    // endpoint. It answers 204 when no turn is in flight, which the SDK treats
+    // as "nothing to resume".
+    prepareReconnectToStreamRequest: () => ({ api: `${base}/events` }),
   });
 }
 


### PR DESCRIPTION
## What

Closes the two halves of #467:

1. **Allow human messages on any session kind.** Dropped the `main`/`chat`-only guard in `SendSessionMessage`; the web composer can now message `delegate`, `task`, and `scheduler` sessions.
2. **Stream server-driven turns live.** A per-runtime `SessionHub` fans every turn's events to read-only subscribers, exposed via a new SSE endpoint `GET /api/agents/{agentId}/sessions/{sessionId}/events`. The web UI watches internal-kind sessions in real time.

## Why

`scheduler` / `task` / `delegate` sessions were a black box: the send endpoint returned `400 cannot send messages to internal sessions`, and server-driven turns produced no live updates until a manual page refresh (#467). Users read that as "stuck".

The #467 author flagged "allow sending" (option C) as *not recommended*. We're taking it anyway per product decision — interjecting on a running internal session is now a first-class flow — **and** layering on real streaming (the author's option B), so the issue closes fully rather than landing the read-only-fallback (option A).

## How

- `internal/agent/runtime/hub.go` — `SessionHub`: non-blocking fan-out (drops on slow subscribers, never stalls the turn), closes subscriber channels when the turn ends. Unit-tested incl. `-race`.
- `Runtime.Chat` tees each event to the hub in addition to the caller's channel, and keeps feeding the hub even if the initiating caller disconnects, so a scheduler-driven turn still streams to a watching browser.
- `StreamSessionEvents` subscribes and reuses the shared `streamAgentEvents` AI-SDK UI message encoder (extracted from `SendSessionMessage` so both speak one wire format). Returns `204` when no turn is in flight.
- Concurrency is already serialized by `Runtime.active` (`ErrSessionBusy`), so a human send during a live turn fails gracefully instead of racing.
- Frontend: `createSessionTransport` adds `prepareReconnectToStreamRequest` → `/events`; `SessionDetail` polls `resumeStream()` while idle for internal-kind sessions.
- Docs: `agent-architecture.md` / `.zh.md` updated (session-kind messaging + live event fan-out).

### Verification

- `mise run format && mise run build && mise run test` — green.
- `SessionHub` tested under `-race`.
- ⚠️ Not yet exercised end-to-end in a browser; logic reviewed but live SSE rendering unverified.

## Refs

- #467