### PR TITLE
✨ feat(tasks): improve goal scale and archive flow

### DIFF
--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -859,6 +859,17 @@ components:
         cancelled_at:
           type: string
           format: date-time
+        archived_at:
+          type: string
+          format: date-time
+          description: Set when the goal is hidden from default lists.
+    CompleteGoalRequest:
+      type: object
+      properties:
+        output:
+          type: object
+          additionalProperties: {}
+          description: Final goal output/summary recorded when manually marking achieved.
     GoalList:
       type: object
       required: [goals]
@@ -2885,6 +2896,10 @@ components:
         cancelled_at:
           type: string
           format: date-time
+        archived_at:
+          type: string
+          format: date-time
+          description: Set when the task is hidden from default lists.
     TaskList:
       type: object
       required: [tasks]

--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -882,6 +882,9 @@ components:
           type: string
           nullable: true
           description: Opaque pagination token; null when no further pages.
+        total:
+          type: integer
+          description: Total goals matching the filter, ignoring pagination. Drives numbered pages and count badges.
     CreateGoalRequest:
       type: object
       required: [title, agent_id]

--- a/api/spec/domain/goals/paths.yaml
+++ b/api/spec/domain/goals/paths.yaml
@@ -18,6 +18,11 @@ paths:
             required: false,
             schema: { type: string },
           }
+        - name: archived
+          in: query
+          required: false
+          description: When true returns only archived goals (the history/restore view) instead of the default active set.
+          schema: { type: boolean }
         - {
             name: page_size,
             in: query,
@@ -81,6 +86,26 @@ paths:
       operationId: deleteGoal
       responses:
         "204": { description: archived }
+        "401":
+          { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+        "409":
+          { $ref: "../../components.yaml#/components/responses/Conflict" }
+
+  /api/goals/{goalId}/unarchive:
+    parameters:
+      - { name: goalId, in: path, required: true, schema: { type: string } }
+    post:
+      tags: [goals]
+      summary: Restore an archived goal (and its archived children) to default lists
+      operationId: unarchiveGoal
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                { $ref: "../../components.yaml#/components/schemas/Goal" }
         "401":
           { $ref: "../../components.yaml#/components/responses/Unauthorized" }
         "404": { $ref: "../../components.yaml#/components/responses/NotFound" }

--- a/api/spec/domain/goals/paths.yaml
+++ b/api/spec/domain/goals/paths.yaml
@@ -11,6 +11,13 @@ paths:
             required: false,
             schema: { type: string },
           }
+        - { name: status, in: query, required: false, schema: { type: string } }
+        - {
+            name: project_id,
+            in: query,
+            required: false,
+            schema: { type: string },
+          }
         - {
             name: page_size,
             in: query,
@@ -67,6 +74,18 @@ paths:
         "401":
           { $ref: "../../components.yaml#/components/responses/Unauthorized" }
         "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+    delete:
+      tags: [goals]
+      summary: Archive a goal
+      description: Audit-safe delete; hides terminal/draft goals from default lists without removing history.
+      operationId: deleteGoal
+      responses:
+        "204": { description: archived }
+        "401":
+          { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+        "409":
+          { $ref: "../../components.yaml#/components/responses/Conflict" }
 
   /api/goals/{goalId}/activate:
     parameters:
@@ -75,6 +94,34 @@ paths:
       tags: [goals]
       summary: Activate a goal (draft → running, promotes draft children to ready)
       operationId: activateGoal
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                { $ref: "../../components.yaml#/components/schemas/Goal" }
+        "401":
+          { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+        "409":
+          { $ref: "../../components.yaml#/components/responses/Conflict" }
+
+  /api/goals/{goalId}/complete:
+    parameters:
+      - { name: goalId, in: path, required: true, schema: { type: string } }
+    post:
+      tags: [goals]
+      summary: Mark a goal achieved
+      operationId: completeGoal
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              {
+                $ref: "../../components.yaml#/components/schemas/CompleteGoalRequest",
+              }
       responses:
         "200":
           description: ok

--- a/api/spec/domain/goals/paths.yaml
+++ b/api/spec/domain/goals/paths.yaml
@@ -23,6 +23,16 @@ paths:
           required: false
           description: When true returns only archived goals (the history/restore view) instead of the default active set.
           schema: { type: boolean }
+        - name: terminal
+          in: query
+          required: false
+          description: When false returns only non-terminal (active) goals; when true only terminal (done/failed/cancelled) goals. Omit for any. Ignored when archived=true.
+          schema: { type: boolean }
+        - name: q
+          in: query
+          required: false
+          description: Case-insensitive substring match against goal title and description.
+          schema: { type: string }
         - {
             name: page_size,
             in: query,

--- a/api/spec/domain/goals/schemas.yaml
+++ b/api/spec/domain/goals/schemas.yaml
@@ -84,6 +84,9 @@ components:
           type: string
           nullable: true
           description: Opaque pagination token; null when no further pages.
+        total:
+          type: integer
+          description: Total goals matching the filter, ignoring pagination. Drives numbered pages and count badges.
 
     CreateGoalRequest:
       type: object

--- a/api/spec/domain/goals/schemas.yaml
+++ b/api/spec/domain/goals/schemas.yaml
@@ -60,6 +60,18 @@ components:
         updated_at: { type: string, format: date-time }
         completed_at: { type: string, format: date-time }
         cancelled_at: { type: string, format: date-time }
+        archived_at:
+          type: string
+          format: date-time
+          description: Set when the goal is hidden from default lists.
+
+    CompleteGoalRequest:
+      type: object
+      properties:
+        output:
+          type: object
+          additionalProperties: {}
+          description: Final goal output/summary recorded when manually marking achieved.
 
     GoalList:
       type: object

--- a/api/spec/domain/tasks/paths.yaml
+++ b/api/spec/domain/tasks/paths.yaml
@@ -18,6 +18,11 @@ paths:
             required: false,
             schema: { type: string },
           }
+        - name: archived
+          in: query
+          required: false
+          description: When true returns only archived tasks (the history/restore view) instead of the default active set.
+          schema: { type: boolean }
         - {
             name: page_size,
             in: query,
@@ -90,6 +95,26 @@ paths:
       operationId: deleteTask
       responses:
         "204": { description: archived }
+        "401":
+          { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+        "409":
+          { $ref: "../../components.yaml#/components/responses/Conflict" }
+
+  /api/tasks/{taskId}/unarchive:
+    parameters:
+      - { name: taskId, in: path, required: true, schema: { type: string } }
+    post:
+      tags: [tasks]
+      summary: Restore an archived task to default lists
+      operationId: unarchiveTask
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                { $ref: "../../components.yaml#/components/schemas/Task" }
         "401":
           { $ref: "../../components.yaml#/components/responses/Unauthorized" }
         "404": { $ref: "../../components.yaml#/components/responses/NotFound" }

--- a/api/spec/domain/tasks/paths.yaml
+++ b/api/spec/domain/tasks/paths.yaml
@@ -83,6 +83,19 @@ paths:
           { $ref: "../../components.yaml#/components/responses/Unauthorized" }
         "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
 
+    delete:
+      tags: [tasks]
+      summary: Archive a task
+      description: Audit-safe delete; hides terminal/draft tasks from default lists without removing history.
+      operationId: deleteTask
+      responses:
+        "204": { description: archived }
+        "401":
+          { $ref: "../../components.yaml#/components/responses/Unauthorized" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+        "409":
+          { $ref: "../../components.yaml#/components/responses/Conflict" }
+
   /api/tasks/{taskId}/cancel:
     parameters:
       - { name: taskId, in: path, required: true, schema: { type: string } }

--- a/api/spec/domain/tasks/schemas.yaml
+++ b/api/spec/domain/tasks/schemas.yaml
@@ -70,6 +70,10 @@ components:
         updated_at: { type: string, format: date-time }
         completed_at: { type: string, format: date-time }
         cancelled_at: { type: string, format: date-time }
+        archived_at:
+          type: string
+          format: date-time
+          description: Set when the task is hidden from default lists.
 
     TaskList:
       type: object

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -310,6 +310,8 @@ paths:
     $ref: "./domain/tasks/paths.yaml#/paths/~1api~1tasks"
   /api/tasks/{taskId}:
     $ref: "./domain/tasks/paths.yaml#/paths/~1api~1tasks~1{taskId}"
+  /api/tasks/{taskId}/unarchive:
+    $ref: "./domain/tasks/paths.yaml#/paths/~1api~1tasks~1{taskId}~1unarchive"
   /api/tasks/{taskId}/cancel:
     $ref: "./domain/tasks/paths.yaml#/paths/~1api~1tasks~1{taskId}~1cancel"
   /api/tasks/{taskId}/reopen:

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -345,6 +345,8 @@ paths:
     $ref: "./domain/goals/paths.yaml#/paths/~1api~1goals~1{goalId}"
   /api/goals/{goalId}/activate:
     $ref: "./domain/goals/paths.yaml#/paths/~1api~1goals~1{goalId}~1activate"
+  /api/goals/{goalId}/complete:
+    $ref: "./domain/goals/paths.yaml#/paths/~1api~1goals~1{goalId}~1complete"
   /api/goals/{goalId}/cancel:
     $ref: "./domain/goals/paths.yaml#/paths/~1api~1goals~1{goalId}~1cancel"
   /api/goals/{goalId}/tasks:
@@ -662,6 +664,9 @@ components:
     }
     Goal: { $ref: "./components.yaml#/components/schemas/Goal" }
     GoalList: { $ref: "./components.yaml#/components/schemas/GoalList" }
+    CompleteGoalRequest: {
+      $ref: "./components.yaml#/components/schemas/CompleteGoalRequest",
+    }
     CreateGoalRequest: {
       $ref: "./components.yaml#/components/schemas/CreateGoalRequest",
     }

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -343,6 +343,8 @@ paths:
     $ref: "./domain/goals/paths.yaml#/paths/~1api~1goals"
   /api/goals/{goalId}:
     $ref: "./domain/goals/paths.yaml#/paths/~1api~1goals~1{goalId}"
+  /api/goals/{goalId}/unarchive:
+    $ref: "./domain/goals/paths.yaml#/paths/~1api~1goals~1{goalId}~1unarchive"
   /api/goals/{goalId}/activate:
     $ref: "./domain/goals/paths.yaml#/paths/~1api~1goals~1{goalId}~1activate"
   /api/goals/{goalId}/complete:

--- a/internal/db/migrations/20260617170000_add_task_goal_archive.sql
+++ b/internal/db/migrations/20260617170000_add_task_goal_archive.sql
@@ -1,0 +1,7 @@
+ALTER TABLE `agent_task` ADD COLUMN `archived_at` text;
+ALTER TABLE `agent_goal` ADD COLUMN `archived_at` text;
+
+CREATE INDEX `idx_agent_task_user_archived_created`
+    ON `agent_task` (`user_id`, `archived_at`, `created_at` DESC, `id` DESC);
+CREATE INDEX `idx_agent_goal_user_archived_created`
+    ON `agent_goal` (`user_id`, `archived_at`, `created_at` DESC, `id` DESC);

--- a/internal/db/migrations/atlas.sum
+++ b/internal/db/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:L/DrpBHs+JWXSXnyM5gV3nve9feT2HvCp3ThLMfVhYQ=
+h1:2uTWkSoxk4vBMchgxt1aSD1eF+Gs3/cQlMMteppPqow=
 20260531120105_initial.sql h1:yFv08NKwCabgVkvWoSNzba6WMXjbXrI9xHctaJBir/8=
 20260601060943_add_config_to_plugin_override.sql h1:q2MIJRzEYGDQyjnLeFUrQ0zbnvdgxBh/MRANwRmPFn4=
 20260602031701_add-channel-name.sql h1:1ZGYJvwMOOShxLGIN9SJihmcfQtFRpTPXHhOWDv29fc=
@@ -22,3 +22,4 @@ h1:L/DrpBHs+JWXSXnyM5gV3nve9feT2HvCp3ThLMfVhYQ=
 20260612043053_add_group_dispatch_result_message_id.sql h1:5G6rlXvNYLAIW7UE/gkUAdWG7wD6mnZbNtDktaSA+oY=
 20260615040329_scoped_vault_entries.sql h1:Bk0KnvCHo3h854gTkH0h/ieShXfe3FYG0/hFfoCYzMQ=
 20260615140513_scoped_skills.sql h1:mS1wbB+WjyAyTbb8uRJOgykNy1rgLwWncoFkjTdzNU0=
+20260617170000_add_task_goal_archive.sql h1:bvj2IDkJSBoeUTmwKnl9Yd16iUaGiN56dizeqb5Y/hU=

--- a/internal/db/queries/agent_goal.sql
+++ b/internal/db/queries/agent_goal.sql
@@ -20,10 +20,17 @@ WHERE status NOT IN ('done', 'cancelled')
 ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?;
 
 -- name: ListAgentGoalsByUser :many
-SELECT * FROM agent_goal WHERE user_id = ? ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?;
+SELECT * FROM agent_goal
+WHERE user_id = sqlc.arg('user_id')
+  AND archived_at IS NULL
+  AND (sqlc.narg('agent_id') IS NULL OR agent_id = sqlc.narg('agent_id'))
+  AND (sqlc.narg('status') IS NULL OR status = sqlc.narg('status'))
+  AND (sqlc.narg('project_id') IS NULL OR project_id = sqlc.narg('project_id'))
+ORDER BY created_at DESC, id DESC
+LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');
 
--- name: ListAgentGoalsByUserAndAgent :many
-SELECT * FROM agent_goal WHERE user_id = ? AND agent_id = ? ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?;
+-- name: ArchiveAgentGoal :execrows
+UPDATE agent_goal SET archived_at = ?, updated_at = ? WHERE id = ? AND archived_at IS NULL;
 
 -- name: TransitionAgentGoalStatus :execrows
 UPDATE agent_goal

--- a/internal/db/queries/agent_goal.sql
+++ b/internal/db/queries/agent_goal.sql
@@ -14,15 +14,24 @@ SELECT * FROM agent_goal WHERE id = ?;
 -- Dispatcher rollup scan. Skip quiescent goals (done/cancelled) so the bounded
 -- window is spent only on goals rollup can still act on (running/blocked/failed
 -- and pre-run states). failed is intentionally included - it is recoverable.
+-- Archived goals are inert: excluding them stops rollup from silently recovering
+-- an archived failed goal back to running while it stays hidden from default lists.
 -- name: ListAgentGoals :many
 SELECT * FROM agent_goal
 WHERE status NOT IN ('done', 'cancelled')
+  AND archived_at IS NULL
 ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?;
 
 -- name: ListAgentGoalsByUser :many
+-- archived narg: NULL/false yields only active rows (archived_at IS NULL, the
+-- default); true yields only archived rows (the history/restore view).
 SELECT * FROM agent_goal
 WHERE user_id = sqlc.arg('user_id')
-  AND archived_at IS NULL
+  AND (
+    (sqlc.narg('archived') = 1 AND archived_at IS NOT NULL)
+    OR (sqlc.narg('archived') IS NULL AND archived_at IS NULL)
+    OR (sqlc.narg('archived') = 0 AND archived_at IS NULL)
+  )
   AND (sqlc.narg('agent_id') IS NULL OR agent_id = sqlc.narg('agent_id'))
   AND (sqlc.narg('status') IS NULL OR status = sqlc.narg('status'))
   AND (sqlc.narg('project_id') IS NULL OR project_id = sqlc.narg('project_id'))
@@ -31,6 +40,9 @@ LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');
 
 -- name: ArchiveAgentGoal :execrows
 UPDATE agent_goal SET archived_at = ?, updated_at = ? WHERE id = ? AND archived_at IS NULL;
+
+-- name: UnarchiveAgentGoal :execrows
+UPDATE agent_goal SET archived_at = NULL, updated_at = ? WHERE id = ? AND archived_at IS NOT NULL;
 
 -- name: TransitionAgentGoalStatus :execrows
 UPDATE agent_goal

--- a/internal/db/queries/agent_goal.sql
+++ b/internal/db/queries/agent_goal.sql
@@ -25,6 +25,10 @@ ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?;
 -- name: ListAgentGoalsByUser :many
 -- archived narg: NULL/false yields only active rows (archived_at IS NULL, the
 -- default); true yields only archived rows (the history/restore view).
+-- terminal narg: NULL matches any status; 1 keeps only terminal goals
+-- (done/failed/cancelled, the history view); 0 keeps only non-terminal goals
+-- (the active view). search narg is a case-insensitive substring matched against
+-- title and description (NULL matches all).
 SELECT * FROM agent_goal
 WHERE user_id = sqlc.arg('user_id')
   AND (
@@ -35,8 +39,43 @@ WHERE user_id = sqlc.arg('user_id')
   AND (sqlc.narg('agent_id') IS NULL OR agent_id = sqlc.narg('agent_id'))
   AND (sqlc.narg('status') IS NULL OR status = sqlc.narg('status'))
   AND (sqlc.narg('project_id') IS NULL OR project_id = sqlc.narg('project_id'))
+  AND (
+    sqlc.narg('terminal') IS NULL
+    OR (sqlc.narg('terminal') = 1 AND status IN ('done', 'failed', 'cancelled'))
+    OR (sqlc.narg('terminal') = 0 AND status NOT IN ('done', 'failed', 'cancelled'))
+  )
+  AND (
+    sqlc.narg('search') IS NULL
+    OR instr(lower(title), lower(sqlc.narg('search'))) > 0
+    OR instr(lower(description), lower(sqlc.narg('search'))) > 0
+  )
 ORDER BY created_at DESC, id DESC
 LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');
+
+-- CountAgentGoalsByUser returns the total rows matching the same filters as
+-- ListAgentGoalsByUser (ignoring pagination), so the UI can render numbered
+-- pages and per-mode count badges from server-side state.
+-- name: CountAgentGoalsByUser :one
+SELECT COUNT(*) FROM agent_goal
+WHERE user_id = sqlc.arg('user_id')
+  AND (
+    (sqlc.narg('archived') = 1 AND archived_at IS NOT NULL)
+    OR (sqlc.narg('archived') IS NULL AND archived_at IS NULL)
+    OR (sqlc.narg('archived') = 0 AND archived_at IS NULL)
+  )
+  AND (sqlc.narg('agent_id') IS NULL OR agent_id = sqlc.narg('agent_id'))
+  AND (sqlc.narg('status') IS NULL OR status = sqlc.narg('status'))
+  AND (sqlc.narg('project_id') IS NULL OR project_id = sqlc.narg('project_id'))
+  AND (
+    sqlc.narg('terminal') IS NULL
+    OR (sqlc.narg('terminal') = 1 AND status IN ('done', 'failed', 'cancelled'))
+    OR (sqlc.narg('terminal') = 0 AND status NOT IN ('done', 'failed', 'cancelled'))
+  )
+  AND (
+    sqlc.narg('search') IS NULL
+    OR instr(lower(title), lower(sqlc.narg('search'))) > 0
+    OR instr(lower(description), lower(sqlc.narg('search'))) > 0
+  );
 
 -- name: ArchiveAgentGoal :execrows
 UPDATE agent_goal SET archived_at = ?, updated_at = ? WHERE id = ? AND archived_at IS NULL;

--- a/internal/db/queries/agent_task.sql
+++ b/internal/db/queries/agent_task.sql
@@ -174,3 +174,6 @@ WHERE id = ?;
 
 -- name: ArchiveAgentTask :execrows
 UPDATE agent_task SET archived_at = ?, updated_at = ? WHERE id = ? AND archived_at IS NULL;
+
+-- name: UnarchiveAgentTask :execrows
+UPDATE agent_task SET archived_at = NULL, updated_at = ? WHERE id = ? AND archived_at IS NOT NULL;

--- a/internal/db/queries/agent_task.sql
+++ b/internal/db/queries/agent_task.sql
@@ -21,6 +21,7 @@ SELECT * FROM agent_task ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?;
 -- name: ListAgentTasksByUser :many
 SELECT * FROM agent_task
 WHERE user_id = sqlc.arg('user_id')
+  AND archived_at IS NULL
   AND (sqlc.narg('agent_id') IS NULL OR agent_id = sqlc.narg('agent_id'))
   AND (sqlc.narg('status') IS NULL OR status = sqlc.narg('status'))
   AND (sqlc.narg('project_id') IS NULL OR project_id = sqlc.narg('project_id'))
@@ -171,5 +172,5 @@ UPDATE agent_task
 SET cancelled_at = ?, updated_at = ?
 WHERE id = ?;
 
--- name: DeleteAgentTask :exec
-DELETE FROM agent_task WHERE id = ?;
+-- name: ArchiveAgentTask :execrows
+UPDATE agent_task SET archived_at = ?, updated_at = ? WHERE id = ? AND archived_at IS NULL;

--- a/internal/db/queries/agent_task.sql
+++ b/internal/db/queries/agent_task.sql
@@ -18,10 +18,17 @@ SELECT * FROM agent_task WHERE id = ?;
 -- name: ListAgentTasks :many
 SELECT * FROM agent_task ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?;
 
+-- archived narg mirrors ListAgentGoalsByUser: NULL/false yields only active rows
+-- (archived_at IS NULL, the default); true yields only archived rows (the
+-- history/restore view).
 -- name: ListAgentTasksByUser :many
 SELECT * FROM agent_task
 WHERE user_id = sqlc.arg('user_id')
-  AND archived_at IS NULL
+  AND (
+    (sqlc.narg('archived') = 1 AND archived_at IS NOT NULL)
+    OR (sqlc.narg('archived') IS NULL AND archived_at IS NULL)
+    OR (sqlc.narg('archived') = 0 AND archived_at IS NULL)
+  )
   AND (sqlc.narg('agent_id') IS NULL OR agent_id = sqlc.narg('agent_id'))
   AND (sqlc.narg('status') IS NULL OR status = sqlc.narg('status'))
   AND (sqlc.narg('project_id') IS NULL OR project_id = sqlc.narg('project_id'))

--- a/internal/db/queries/agent_task_event.sql
+++ b/internal/db/queries/agent_task_event.sql
@@ -16,3 +16,13 @@ SELECT * FROM agent_task_event WHERE goal_id = ? ORDER BY created_at ASC;
 
 -- name: ListAgentTaskEventsByRun :many
 SELECT * FROM agent_task_event WHERE run_id = ? ORDER BY created_at ASC;
+
+-- GetLatestGoalArchiveDetail returns the detail JSON of a goal's most recent
+-- goal_archive event. UnarchiveGoal reads the archived_task_ids it recorded so it
+-- restores exactly the children that cascade-archived, not ones the user hid on
+-- their own. Returns ErrNoRows for goals archived before that detail was recorded.
+-- name: GetLatestGoalArchiveDetail :one
+SELECT detail FROM agent_task_event
+WHERE goal_id = ? AND event_type = 'goal_archive'
+ORDER BY created_at DESC, id DESC
+LIMIT 1;

--- a/internal/db/schemas/tables/agent_goal.sql
+++ b/internal/db/schemas/tables/agent_goal.sql
@@ -19,7 +19,8 @@ CREATE TABLE agent_goal (
     created_at      TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at      TEXT NOT NULL DEFAULT (datetime('now')),
     completed_at    TEXT,
-    cancelled_at    TEXT
+    cancelled_at    TEXT,
+    archived_at     TEXT
 );
 
 CREATE INDEX idx_agent_goal_agent_project ON agent_goal(agent_id, project_id);

--- a/internal/db/schemas/tables/agent_goal.sql
+++ b/internal/db/schemas/tables/agent_goal.sql
@@ -26,6 +26,7 @@ CREATE TABLE agent_goal (
 CREATE INDEX idx_agent_goal_agent_project ON agent_goal(agent_id, project_id);
 CREATE INDEX idx_agent_goal_project       ON agent_goal(project_id);
 CREATE INDEX idx_agent_goal_user_created  ON agent_goal(user_id, created_at DESC, id DESC);
+CREATE INDEX idx_agent_goal_user_archived_created ON agent_goal(user_id, archived_at, created_at DESC, id DESC);
 CREATE INDEX idx_agent_goal_planning_candidates
     ON agent_goal(priority DESC, created_at ASC)
     WHERE status = 'draft';

--- a/internal/db/schemas/tables/agent_task.sql
+++ b/internal/db/schemas/tables/agent_task.sql
@@ -27,7 +27,8 @@ CREATE TABLE agent_task (
     created_at          TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at          TEXT NOT NULL DEFAULT (datetime('now')),
     completed_at        TEXT,
-    cancelled_at        TEXT
+    cancelled_at        TEXT,
+    archived_at         TEXT
 );
 
 CREATE UNIQUE INDEX uniq_agent_task_session ON agent_task(session_id);

--- a/internal/db/schemas/tables/agent_task.sql
+++ b/internal/db/schemas/tables/agent_task.sql
@@ -35,6 +35,7 @@ CREATE UNIQUE INDEX uniq_agent_task_session ON agent_task(session_id);
 CREATE INDEX idx_agent_task_agent_status_not_before ON agent_task(agent_id, status, not_before);
 CREATE INDEX idx_agent_task_user_agent        ON agent_task(user_id, agent_id);
 CREATE INDEX idx_agent_task_user_created      ON agent_task(user_id, created_at DESC, id DESC);
+CREATE INDEX idx_agent_task_user_archived_created ON agent_task(user_id, archived_at, created_at DESC, id DESC);
 CREATE INDEX idx_agent_task_user_agent_status_created ON agent_task(user_id, agent_id, status, created_at DESC, id DESC);
 CREATE INDEX idx_agent_task_user_agent_project_created ON agent_task(user_id, agent_id, project_id, created_at DESC, id DESC);
 CREATE INDEX idx_agent_task_ready_candidates

--- a/internal/server/archive_mapping_test.go
+++ b/internal/server/archive_mapping_test.go
@@ -1,0 +1,44 @@
+package server
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/CherryHQ/stella/pkg/db/sqlc"
+)
+
+// CR-021: the API schema declares archived_at on Goal/Task, so the mappers must
+// serialize it — otherwise clients can never show when a row was archived.
+func TestGoalToAPI_SerializesArchivedAt(t *testing.T) {
+	g := sqlc.AgentGoal{
+		ID: "g1", UserID: "u1", AgentID: "a1", Title: "g",
+		Status: "done", Priority: "routine", ReviewPolicy: "none",
+		Context: "{}", Output: "{}",
+		CreatedAt: "2026-06-18T00:00:00Z", UpdatedAt: "2026-06-18T00:00:00Z",
+		ArchivedAt: sql.NullString{String: "2026-06-18T01:02:03Z", Valid: true},
+	}
+	if goalToAPI(g).ArchivedAt == nil {
+		t.Fatal("goalToAPI dropped archived_at")
+	}
+	g.ArchivedAt = sql.NullString{}
+	if goalToAPI(g).ArchivedAt != nil {
+		t.Fatal("goalToAPI invented archived_at for a non-archived goal")
+	}
+}
+
+func TestTaskToAPI_SerializesArchivedAt(t *testing.T) {
+	tk := sqlc.AgentTask{
+		ID: "t1", UserID: "u1", AgentID: "a1", Title: "t",
+		Status: "done", Priority: "routine", ReviewPolicy: "none",
+		Context: "{}", Output: "{}",
+		CreatedAt: "2026-06-18T00:00:00Z", UpdatedAt: "2026-06-18T00:00:00Z",
+		ArchivedAt: sql.NullString{String: "2026-06-18T01:02:03Z", Valid: true},
+	}
+	if taskToAPI(tk).ArchivedAt == nil {
+		t.Fatal("taskToAPI dropped archived_at")
+	}
+	tk.ArchivedAt = sql.NullString{}
+	if taskToAPI(tk).ArchivedAt != nil {
+		t.Fatal("taskToAPI invented archived_at for a non-archived task")
+	}
+}

--- a/internal/server/goals.go
+++ b/internal/server/goals.go
@@ -61,12 +61,15 @@ func (s *Server) ListGoals(w http.ResponseWriter, r *http.Request, params apiser
 		}
 		agentID = info.Scoped.AgentID
 	}
-	var rows []sqlc.AgentGoal
-	if agentID != "" {
-		rows, err = s.tasksSvc.Facade.ListGoalsByAgent(r.Context(), info.UserID, agentID, int64(limit+1), int64(offset))
-	} else {
-		rows, err = s.tasksSvc.Facade.ListGoals(r.Context(), info.UserID, int64(limit+1), int64(offset))
+	projectID := ""
+	if params.ProjectId != nil {
+		projectID = *params.ProjectId
 	}
+	status := ""
+	if params.Status != nil {
+		status = *params.Status
+	}
+	rows, err := s.tasksSvc.Facade.ListGoals(r.Context(), info.UserID, agentID, projectID, status, int64(limit+1), int64(offset))
 	if err != nil {
 		s.taskError(w, err)
 		return
@@ -149,6 +152,56 @@ func (s *Server) GetGoal(w http.ResponseWriter, r *http.Request, goalID string) 
 		return
 	}
 	writeData(w, http.StatusOK, goalToAPI(g))
+}
+
+func (s *Server) DeleteGoal(w http.ResponseWriter, r *http.Request, goalID string) {
+	if !s.tasksReady() {
+		writeError(w, http.StatusServiceUnavailable, "task_service_unavailable")
+		return
+	}
+	info := requireAuth(w, r)
+	if info == nil {
+		return
+	}
+	if _, ok := s.loadGoal(r.Context(), w, info.UserID, goalID); !ok {
+		return
+	}
+	if err := s.tasksSvc.Facade.ArchiveGoal(r.Context(), goalID, authActor(r)); err != nil {
+		s.taskError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) CompleteGoal(w http.ResponseWriter, r *http.Request, goalID string) {
+	if !s.tasksReady() {
+		writeError(w, http.StatusServiceUnavailable, "task_service_unavailable")
+		return
+	}
+	info := requireAuth(w, r)
+	if info == nil {
+		return
+	}
+	g, ok := s.loadGoal(r.Context(), w, info.UserID, goalID)
+	if !ok {
+		return
+	}
+	var req apitypes.CompleteGoalRequest
+	_ = decodeJSON(r, &req)
+	output := ""
+	if req.Output != nil {
+		output = marshalContext(req.Output)
+	}
+	if err := s.tasksSvc.Facade.CompleteGoal(r.Context(), g.ID, output, authActor(r)); err != nil {
+		s.taskError(w, err)
+		return
+	}
+	fresh, err := s.tasksSvc.Facade.GetGoal(r.Context(), g.ID)
+	if err != nil {
+		s.taskError(w, err)
+		return
+	}
+	writeData(w, http.StatusOK, goalToAPI(fresh))
 }
 
 func (s *Server) ActivateGoal(w http.ResponseWriter, r *http.Request, goalID string) {

--- a/internal/server/goals.go
+++ b/internal/server/goals.go
@@ -61,15 +61,17 @@ func (s *Server) ListGoals(w http.ResponseWriter, r *http.Request, params apiser
 		}
 		agentID = info.Scoped.AgentID
 	}
-	projectID := ""
+	filter := tasks.GoalFilter{AgentID: agentID}
 	if params.ProjectId != nil {
-		projectID = *params.ProjectId
+		filter.ProjectID = *params.ProjectId
 	}
-	status := ""
 	if params.Status != nil {
-		status = *params.Status
+		filter.Status = *params.Status
 	}
-	rows, err := s.tasksSvc.Facade.ListGoals(r.Context(), info.UserID, agentID, projectID, status, int64(limit+1), int64(offset))
+	if params.Archived != nil {
+		filter.Archived = *params.Archived
+	}
+	rows, err := s.tasksSvc.Facade.ListGoals(r.Context(), info.UserID, filter, int64(limit+1), int64(offset))
 	if err != nil {
 		s.taskError(w, err)
 		return
@@ -171,6 +173,31 @@ func (s *Server) DeleteGoal(w http.ResponseWriter, r *http.Request, goalID strin
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) UnarchiveGoal(w http.ResponseWriter, r *http.Request, goalID string) {
+	if !s.tasksReady() {
+		writeError(w, http.StatusServiceUnavailable, "task_service_unavailable")
+		return
+	}
+	info := requireAuth(w, r)
+	if info == nil {
+		return
+	}
+	g, ok := s.loadGoal(r.Context(), w, info.UserID, goalID)
+	if !ok {
+		return
+	}
+	if err := s.tasksSvc.Facade.UnarchiveGoal(r.Context(), g.ID, authActor(r)); err != nil {
+		s.taskError(w, err)
+		return
+	}
+	fresh, err := s.tasksSvc.Facade.GetGoal(r.Context(), g.ID)
+	if err != nil {
+		s.taskError(w, err)
+		return
+	}
+	writeData(w, http.StatusOK, goalToAPI(fresh))
 }
 
 func (s *Server) CompleteGoal(w http.ResponseWriter, r *http.Request, goalID string) {

--- a/internal/server/goals.go
+++ b/internal/server/goals.go
@@ -71,7 +71,18 @@ func (s *Server) ListGoals(w http.ResponseWriter, r *http.Request, params apiser
 	if params.Archived != nil {
 		filter.Archived = *params.Archived
 	}
+	if params.Terminal != nil {
+		filter.Terminal = params.Terminal
+	}
+	if params.Q != nil {
+		filter.Search = *params.Q
+	}
 	rows, err := s.tasksSvc.Facade.ListGoals(r.Context(), info.UserID, filter, int64(limit+1), int64(offset))
+	if err != nil {
+		s.taskError(w, err)
+		return
+	}
+	total, err := s.tasksSvc.Facade.CountGoals(r.Context(), info.UserID, filter)
 	if err != nil {
 		s.taskError(w, err)
 		return
@@ -81,7 +92,8 @@ func (s *Server) ListGoals(w http.ResponseWriter, r *http.Request, params apiser
 	for _, g := range rows {
 		out = append(out, goalToAPI(g))
 	}
-	list := apitypes.GoalList{Goals: out}
+	totalInt := int(total)
+	list := apitypes.GoalList{Goals: out, Total: &totalInt}
 	if nextToken != "" {
 		list.NextPageToken = &nextToken
 	}

--- a/internal/server/goals.go
+++ b/internal/server/goals.go
@@ -480,6 +480,10 @@ func goalToAPI(g sqlc.AgentGoal) apitypes.Goal {
 		v := parseTS(g.CancelledAt.String)
 		out.CancelledAt = &v
 	}
+	if g.ArchivedAt.Valid {
+		v := parseTS(g.ArchivedAt.String)
+		out.ArchivedAt = &v
+	}
 	if m := jsonObject(g.Context); m != nil {
 		out.Context = m
 	}

--- a/internal/server/tasks.go
+++ b/internal/server/tasks.go
@@ -805,6 +805,10 @@ func taskToAPI(t sqlc.AgentTask) apitypes.Task {
 		v := parseTS(t.CancelledAt.String)
 		out.CancelledAt = &v
 	}
+	if t.ArchivedAt.Valid {
+		v := parseTS(t.ArchivedAt.String)
+		out.ArchivedAt = &v
+	}
 	if m := jsonObject(t.Context); m != nil {
 		out.Context = m
 	}

--- a/internal/server/tasks.go
+++ b/internal/server/tasks.go
@@ -245,6 +245,25 @@ func (s *Server) GetTask(w http.ResponseWriter, r *http.Request, taskID string) 
 	writeData(w, http.StatusOK, taskToAPI(t))
 }
 
+func (s *Server) DeleteTask(w http.ResponseWriter, r *http.Request, taskID string) {
+	if !s.tasksReady() {
+		writeError(w, http.StatusServiceUnavailable, "task_service_unavailable")
+		return
+	}
+	if requireAuth(w, r) == nil {
+		return
+	}
+	t, ok := s.loadTask(r.Context(), w, taskID)
+	if !ok {
+		return
+	}
+	if err := s.tasksSvc.Facade.ArchiveTask(r.Context(), t.ID, authActor(r)); err != nil {
+		s.taskError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // ---------------------------------------------------------------------------
 // Cancel / reopen
 // ---------------------------------------------------------------------------

--- a/internal/server/tasks.go
+++ b/internal/server/tasks.go
@@ -134,7 +134,11 @@ func (s *Server) ListTasks(w http.ResponseWriter, r *http.Request, params apiser
 	if params.Status != nil {
 		status = *params.Status
 	}
-	rows, err := s.tasksSvc.Facade.ListTasksByUser(r.Context(), info.UserID, agentID, projectID, status, int64(limit+1), int64(offset))
+	archived := false
+	if params.Archived != nil {
+		archived = *params.Archived
+	}
+	rows, err := s.tasksSvc.Facade.ListTasksByUser(r.Context(), info.UserID, agentID, projectID, status, archived, int64(limit+1), int64(offset))
 	if err != nil {
 		s.taskError(w, err)
 		return
@@ -262,6 +266,30 @@ func (s *Server) DeleteTask(w http.ResponseWriter, r *http.Request, taskID strin
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) UnarchiveTask(w http.ResponseWriter, r *http.Request, taskID string) {
+	if !s.tasksReady() {
+		writeError(w, http.StatusServiceUnavailable, "task_service_unavailable")
+		return
+	}
+	if requireAuth(w, r) == nil {
+		return
+	}
+	t, ok := s.loadTask(r.Context(), w, taskID)
+	if !ok {
+		return
+	}
+	if err := s.tasksSvc.Facade.UnarchiveTask(r.Context(), t.ID, authActor(r)); err != nil {
+		s.taskError(w, err)
+		return
+	}
+	fresh, err := s.tasksSvc.Facade.GetTask(r.Context(), t.ID)
+	if err != nil {
+		s.taskError(w, err)
+		return
+	}
+	writeData(w, http.StatusOK, taskToAPI(fresh))
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/server/tasks.go
+++ b/internal/server/tasks.go
@@ -138,7 +138,12 @@ func (s *Server) ListTasks(w http.ResponseWriter, r *http.Request, params apiser
 	if params.Archived != nil {
 		archived = *params.Archived
 	}
-	rows, err := s.tasksSvc.Facade.ListTasksByUser(r.Context(), info.UserID, agentID, projectID, status, archived, int64(limit+1), int64(offset))
+	rows, err := s.tasksSvc.Facade.ListTasksByUser(r.Context(), info.UserID, tasks.TaskFilter{
+		AgentID:   agentID,
+		ProjectID: projectID,
+		Status:    status,
+		Archived:  archived,
+	}, int64(limit+1), int64(offset))
 	if err != nil {
 		s.taskError(w, err)
 		return

--- a/internal/tasks/goal_transitions.go
+++ b/internal/tasks/goal_transitions.go
@@ -84,6 +84,9 @@ func (s *TransitionService) CompleteGoal(ctx context.Context, goalID, output str
 		if err != nil {
 			return err
 		}
+		if goal.ArchivedAt.Valid {
+			return ErrInvalidTransition
+		}
 		if isQuiescentGoalStatus(goal.Status) {
 			return ErrInvalidTransition
 		}
@@ -121,6 +124,9 @@ func (s *TransitionService) FailGoal(ctx context.Context, goalID, reason string,
 		if err != nil {
 			return err
 		}
+		if goal.ArchivedAt.Valid {
+			return ErrInvalidTransition
+		}
 		if isTerminalGoalStatus(goal.Status) {
 			return ErrInvalidTransition
 		}
@@ -152,6 +158,9 @@ func (s *TransitionService) CancelGoal(ctx context.Context, goalID, reason strin
 		goal, err := getGoalForUpdate(ctx, q, goalID)
 		if err != nil {
 			return err
+		}
+		if goal.ArchivedAt.Valid {
+			return ErrInvalidTransition
 		}
 		if isTerminalGoalStatus(goal.Status) {
 			return ErrInvalidTransition
@@ -222,6 +231,9 @@ func (s *TransitionService) BlockGoal(ctx context.Context, goalID, reason string
 		if err != nil {
 			return err
 		}
+		if goal.ArchivedAt.Valid {
+			return ErrInvalidTransition
+		}
 		if goal.Status != GoalStatusRunning {
 			return ErrInvalidTransition
 		}
@@ -251,6 +263,9 @@ func (s *TransitionService) UnblockGoal(ctx context.Context, goalID, reason stri
 		if err != nil {
 			return err
 		}
+		if goal.ArchivedAt.Valid {
+			return ErrInvalidTransition
+		}
 		if goal.Status != GoalStatusBlocked && goal.Status != GoalStatusFailed {
 			return ErrInvalidTransition
 		}
@@ -277,6 +292,9 @@ func (s *TransitionService) CompleteGoalTx(ctx context.Context, q *sqlc.Queries,
 	goal, err := getGoalForUpdate(ctx, q, goalID)
 	if err != nil {
 		return err
+	}
+	if goal.ArchivedAt.Valid {
+		return ErrInvalidTransition
 	}
 	if isQuiescentGoalStatus(goal.Status) {
 		return ErrInvalidTransition

--- a/internal/tasks/goal_transitions.go
+++ b/internal/tasks/goal_transitions.go
@@ -24,6 +24,11 @@ func (s *TransitionService) ActivateGoal(ctx context.Context, goalID string, act
 		if goal.Status != GoalStatusDraft {
 			return ErrInvalidTransition
 		}
+		// Archived goals are inert; reactivating one would resurrect work that is
+		// hidden from default lists (D-archive invariant).
+		if goal.ArchivedAt.Valid {
+			return ErrInvalidTransition
+		}
 		// Defense in depth against rows that predate goal review gating: a goal
 		// whose review_policy needs the unwired synthesizer/review runtime must
 		// not activate. CreateGoal already rejects non-none at creation.
@@ -45,7 +50,7 @@ func (s *TransitionService) ActivateGoal(ctx context.Context, goalID string, act
 			return fmt.Errorf("list children: %w", err)
 		}
 		for _, c := range children {
-			if c.Status != StatusDraft {
+			if c.Status != StatusDraft || c.ArchivedAt.Valid {
 				continue
 			}
 			if _, err := q.TransitionAgentTaskStatus(ctx, sqlc.TransitionAgentTaskStatusParams{

--- a/internal/tasks/goal_transitions_test.go
+++ b/internal/tasks/goal_transitions_test.go
@@ -142,7 +142,7 @@ func TestArchiveGoal_TerminalHidesGoalAndChildren(t *testing.T) {
 			t.Fatalf("archived goal returned in default list")
 		}
 	}
-	tasks, err := f.ListTasksByUser(context.Background(), h.userID, h.agentID, "", "", 10, 0)
+	tasks, err := f.ListTasksByUser(context.Background(), h.userID, h.agentID, "", "", false, 10, 0)
 	if err != nil {
 		t.Fatalf("ListTasksByUser: %v", err)
 	}
@@ -355,6 +355,163 @@ func TestBlockGoal_RunningToBlocked(t *testing.T) {
 	goal, _ := h.q.GetAgentGoal(context.Background(), gid)
 	if goal.Status != GoalStatusBlocked {
 		t.Errorf("status=%q want blocked", goal.Status)
+	}
+}
+
+// CR-013: a child the user archived on their own must NOT be resurrected when a
+// parent goal is later archived and then unarchived. Only children that the goal
+// archive cascade actually hid are restored.
+func TestUnarchiveGoal_SkipsIndependentlyArchivedChild(t *testing.T) {
+	h := newHarness(t)
+	f := NewServiceFacade(h.db, h.q, h.svc, testSessionMinter)
+	gid := h.createGoal(t, GoalStatusDone, ReviewPolicyNone)
+	solo := h.createChildTask(t, gid, StatusDone)    // user archives this one first
+	cascade := h.createChildTask(t, gid, StatusDone) // hidden by the goal archive
+	if err := f.ArchiveTask(context.Background(), solo, SystemActor()); err != nil {
+		t.Fatalf("ArchiveTask(solo): %v", err)
+	}
+	if err := f.ArchiveGoal(context.Background(), gid, SystemActor()); err != nil {
+		t.Fatalf("ArchiveGoal: %v", err)
+	}
+	if err := f.UnarchiveGoal(context.Background(), gid, SystemActor()); err != nil {
+		t.Fatalf("UnarchiveGoal: %v", err)
+	}
+	if !h.getTask(t, solo).ArchivedAt.Valid {
+		t.Errorf("independently archived child was wrongly restored")
+	}
+	if h.getTask(t, cascade).ArchivedAt.Valid {
+		t.Errorf("cascade-archived child not restored")
+	}
+}
+
+// CR-015: an archived goal is inert — lifecycle transitions must not mutate it.
+func TestArchivedGoal_RejectsLifecycleTransitions(t *testing.T) {
+	h := newHarness(t)
+	f := NewServiceFacade(h.db, h.q, h.svc, testSessionMinter)
+	archiveDraft := func(t *testing.T) string {
+		gid := h.createGoal(t, GoalStatusDraft, ReviewPolicyNone)
+		if err := f.ArchiveGoal(context.Background(), gid, SystemActor()); err != nil {
+			t.Fatalf("ArchiveGoal: %v", err)
+		}
+		return gid
+	}
+	t.Run("complete", func(t *testing.T) {
+		if err := h.svc.CompleteGoal(context.Background(), archiveDraft(t), "{}", SystemActor()); !errors.Is(err, ErrInvalidTransition) {
+			t.Fatalf("got %v want ErrInvalidTransition", err)
+		}
+	})
+	t.Run("fail", func(t *testing.T) {
+		if err := h.svc.FailGoal(context.Background(), archiveDraft(t), "boom", SystemActor()); !errors.Is(err, ErrInvalidTransition) {
+			t.Fatalf("got %v want ErrInvalidTransition", err)
+		}
+	})
+	t.Run("cancel", func(t *testing.T) {
+		if err := h.svc.CancelGoal(context.Background(), archiveDraft(t), "x", SystemActor()); !errors.Is(err, ErrInvalidTransition) {
+			t.Fatalf("got %v want ErrInvalidTransition", err)
+		}
+	})
+	t.Run("unblock", func(t *testing.T) {
+		// failed is archivable and the rollup unblock path; an archived failed
+		// goal must not be revived to running.
+		gid := h.createGoal(t, GoalStatusFailed, ReviewPolicyNone)
+		if err := f.ArchiveGoal(context.Background(), gid, SystemActor()); err != nil {
+			t.Fatalf("ArchiveGoal: %v", err)
+		}
+		if err := h.svc.UnblockGoal(context.Background(), gid, "child recovered", SystemActor()); !errors.Is(err, ErrInvalidTransition) {
+			t.Fatalf("got %v want ErrInvalidTransition", err)
+		}
+	})
+}
+
+// CR-016: a standalone archived task is discoverable via the archived filter and
+// restorable via UnarchiveTask, mirroring goals.
+func TestUnarchiveTask_RestoresStandaloneTask(t *testing.T) {
+	h := newHarness(t)
+	f := NewServiceFacade(h.db, h.q, h.svc, testSessionMinter)
+	gid := h.createGoal(t, GoalStatusDone, ReviewPolicyNone)
+	tid := h.createChildTask(t, gid, StatusDone)
+	if err := f.ArchiveTask(context.Background(), tid, SystemActor()); err != nil {
+		t.Fatalf("ArchiveTask: %v", err)
+	}
+	archived, err := f.ListTasksByUser(context.Background(), h.userID, h.agentID, "", "", true, 10, 0)
+	if err != nil {
+		t.Fatalf("ListTasksByUser(archived): %v", err)
+	}
+	if len(archived) != 1 || archived[0].ID != tid {
+		t.Fatalf("archived filter did not surface the task: %+v", archived)
+	}
+	if active, _ := f.ListTasksByUser(context.Background(), h.userID, h.agentID, "", "", false, 10, 0); len(active) != 0 {
+		t.Fatalf("archived task leaked into active list: %+v", active)
+	}
+	if err := f.UnarchiveTask(context.Background(), tid, SystemActor()); err != nil {
+		t.Fatalf("UnarchiveTask: %v", err)
+	}
+	if h.getTask(t, tid).ArchivedAt.Valid {
+		t.Fatalf("task still archived after unarchive")
+	}
+	active, err := f.ListTasksByUser(context.Background(), h.userID, h.agentID, "", "", false, 10, 0)
+	if err != nil {
+		t.Fatalf("ListTasksByUser(active): %v", err)
+	}
+	if len(active) != 1 || active[0].ID != tid {
+		t.Fatalf("restored task not in default list: %+v", active)
+	}
+}
+
+func TestUnarchiveTask_NotArchived_NoOp(t *testing.T) {
+	h := newHarness(t)
+	f := NewServiceFacade(h.db, h.q, h.svc, testSessionMinter)
+	gid := h.createGoal(t, GoalStatusDone, ReviewPolicyNone)
+	tid := h.createChildTask(t, gid, StatusDone)
+	if err := f.UnarchiveTask(context.Background(), tid, SystemActor()); err != nil {
+		t.Fatalf("UnarchiveTask on non-archived task should be a no-op, got %v", err)
+	}
+}
+
+// CR-014: the Goals page drives filtering/search server-side. Exercise the
+// terminal-group filter, the case-insensitive search, and the matching count.
+func TestListGoals_ServerSideFilterSearchAndCount(t *testing.T) {
+	h := newHarness(t)
+	f := NewServiceFacade(h.db, h.q, h.svc, testSessionMinter)
+	// Two active (non-terminal) and one terminal goal; titles drive the search.
+	h.createGoal(t, GoalStatusRunning, ReviewPolicyNone)
+	h.createGoal(t, GoalStatusDraft, ReviewPolicyNone)
+	done := h.createGoal(t, GoalStatusDone, ReviewPolicyNone)
+	// Lowercase title vs uppercase query proves the match is case-insensitive.
+	if _, err := h.db.ExecContext(context.Background(),
+		`UPDATE agent_goal SET title = ? WHERE id = ?`, "find the needle", done); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	active := false
+	terminal := true
+	cases := []struct {
+		name   string
+		filter GoalFilter
+		want   int
+	}{
+		{"active-only", GoalFilter{AgentID: h.agentID, Terminal: &active}, 2},
+		{"terminal-only", GoalFilter{AgentID: h.agentID, Terminal: &terminal}, 1},
+		{"search-hit", GoalFilter{AgentID: h.agentID, Search: "NEEDLE"}, 1},
+		{"search-miss", GoalFilter{AgentID: h.agentID, Search: "no-such-goal"}, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rows, err := f.ListGoals(context.Background(), h.userID, tc.filter, 50, 0)
+			if err != nil {
+				t.Fatalf("ListGoals: %v", err)
+			}
+			if len(rows) != tc.want {
+				t.Errorf("ListGoals len=%d want %d", len(rows), tc.want)
+			}
+			n, err := f.CountGoals(context.Background(), h.userID, tc.filter)
+			if err != nil {
+				t.Fatalf("CountGoals: %v", err)
+			}
+			if int(n) != tc.want {
+				t.Errorf("CountGoals=%d want %d", n, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/tasks/goal_transitions_test.go
+++ b/internal/tasks/goal_transitions_test.go
@@ -114,6 +114,56 @@ func TestCreateGoal_NonePolicy_OK(t *testing.T) {
 	}
 }
 
+func TestArchiveGoal_TerminalHidesGoalAndChildren(t *testing.T) {
+	h := newHarness(t)
+	f := NewServiceFacade(h.db, h.q, h.svc, testSessionMinter)
+	gid := h.createGoal(t, GoalStatusDone, ReviewPolicyNone)
+	childID := h.createChildTask(t, gid, StatusDone)
+	if err := f.ArchiveGoal(context.Background(), gid, SystemActor()); err != nil {
+		t.Fatalf("ArchiveGoal: %v", err)
+	}
+	goal, err := h.q.GetAgentGoal(context.Background(), gid)
+	if err != nil {
+		t.Fatalf("GetAgentGoal: %v", err)
+	}
+	if !goal.ArchivedAt.Valid {
+		t.Fatalf("goal archived_at not set")
+	}
+	child := h.getTask(t, childID)
+	if !child.ArchivedAt.Valid {
+		t.Fatalf("child archived_at not set")
+	}
+	goals, err := f.ListGoals(context.Background(), h.userID, h.agentID, "", "", 10, 0)
+	if err != nil {
+		t.Fatalf("ListGoals: %v", err)
+	}
+	for _, g := range goals {
+		if g.ID == gid {
+			t.Fatalf("archived goal returned in default list")
+		}
+	}
+	tasks, err := f.ListTasksByUser(context.Background(), h.userID, h.agentID, "", "", 10, 0)
+	if err != nil {
+		t.Fatalf("ListTasksByUser: %v", err)
+	}
+	for _, task := range tasks {
+		if task.ID == childID {
+			t.Fatalf("archived child returned in default task list")
+		}
+	}
+}
+
+func TestArchiveGoal_RunningChildRejected(t *testing.T) {
+	h := newHarness(t)
+	f := NewServiceFacade(h.db, h.q, h.svc, testSessionMinter)
+	gid := h.createGoal(t, GoalStatusDone, ReviewPolicyNone)
+	h.createChildTask(t, gid, StatusRunning)
+	err := f.ArchiveGoal(context.Background(), gid, SystemActor())
+	if !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("got %v want ErrInvalidTransition", err)
+	}
+}
+
 func TestCompleteGoal_RunningToDone_StampsCompletedAt(t *testing.T) {
 	h := newHarness(t)
 	gid := h.createGoal(t, GoalStatusRunning, ReviewPolicyNone)

--- a/internal/tasks/goal_transitions_test.go
+++ b/internal/tasks/goal_transitions_test.go
@@ -142,7 +142,7 @@ func TestArchiveGoal_TerminalHidesGoalAndChildren(t *testing.T) {
 			t.Fatalf("archived goal returned in default list")
 		}
 	}
-	tasks, err := f.ListTasksByUser(context.Background(), h.userID, h.agentID, "", "", false, 10, 0)
+	tasks, err := f.ListTasksByUser(context.Background(), h.userID, TaskFilter{AgentID: h.agentID}, 10, 0)
 	if err != nil {
 		t.Fatalf("ListTasksByUser: %v", err)
 	}
@@ -433,14 +433,14 @@ func TestUnarchiveTask_RestoresStandaloneTask(t *testing.T) {
 	if err := f.ArchiveTask(context.Background(), tid, SystemActor()); err != nil {
 		t.Fatalf("ArchiveTask: %v", err)
 	}
-	archived, err := f.ListTasksByUser(context.Background(), h.userID, h.agentID, "", "", true, 10, 0)
+	archived, err := f.ListTasksByUser(context.Background(), h.userID, TaskFilter{AgentID: h.agentID, Archived: true}, 10, 0)
 	if err != nil {
 		t.Fatalf("ListTasksByUser(archived): %v", err)
 	}
 	if len(archived) != 1 || archived[0].ID != tid {
 		t.Fatalf("archived filter did not surface the task: %+v", archived)
 	}
-	if active, _ := f.ListTasksByUser(context.Background(), h.userID, h.agentID, "", "", false, 10, 0); len(active) != 0 {
+	if active, _ := f.ListTasksByUser(context.Background(), h.userID, TaskFilter{AgentID: h.agentID}, 10, 0); len(active) != 0 {
 		t.Fatalf("archived task leaked into active list: %+v", active)
 	}
 	if err := f.UnarchiveTask(context.Background(), tid, SystemActor()); err != nil {
@@ -449,7 +449,7 @@ func TestUnarchiveTask_RestoresStandaloneTask(t *testing.T) {
 	if h.getTask(t, tid).ArchivedAt.Valid {
 		t.Fatalf("task still archived after unarchive")
 	}
-	active, err := f.ListTasksByUser(context.Background(), h.userID, h.agentID, "", "", false, 10, 0)
+	active, err := f.ListTasksByUser(context.Background(), h.userID, TaskFilter{AgentID: h.agentID}, 10, 0)
 	if err != nil {
 		t.Fatalf("ListTasksByUser(active): %v", err)
 	}

--- a/internal/tasks/goal_transitions_test.go
+++ b/internal/tasks/goal_transitions_test.go
@@ -530,3 +530,45 @@ func TestGoalEvents_RecordTransitions(t *testing.T) {
 		t.Fatalf("no goal events recorded")
 	}
 }
+
+// CR-017: an archived (draft) goal must not accept new child tasks, or the task
+// would be dispatchable while the goal stays hidden.
+func TestCreateTask_ArchivedGoal_Rejects(t *testing.T) {
+	h := newHarness(t)
+	f := NewServiceFacade(h.db, h.q, h.svc, testSessionMinter)
+	gid := h.createGoal(t, GoalStatusDraft, ReviewPolicyNone)
+	if err := f.ArchiveGoal(context.Background(), gid, SystemActor()); err != nil {
+		t.Fatalf("ArchiveGoal: %v", err)
+	}
+	_, err := f.CreateTask(context.Background(), CreateTaskInput{
+		UserID: h.userID, AgentID: h.agentID, GoalID: gid, Title: "new work",
+	})
+	if !errors.Is(err, ErrInvalidTaskContext) {
+		t.Fatalf("CreateTask under archived goal: want ErrInvalidTaskContext, got %v", err)
+	}
+}
+
+// CR-018: restoring a child directly must not resurrect it under a still-archived
+// parent goal; unarchiving the goal is the supported restore path.
+func TestUnarchiveTask_ParentGoalArchived_Rejects(t *testing.T) {
+	h := newHarness(t)
+	f := NewServiceFacade(h.db, h.q, h.svc, testSessionMinter)
+	gid := h.createGoal(t, GoalStatusDone, ReviewPolicyNone)
+	tid := h.createChildTask(t, gid, StatusDone)
+	if err := f.ArchiveGoal(context.Background(), gid, SystemActor()); err != nil {
+		t.Fatalf("ArchiveGoal: %v", err)
+	}
+	if err := f.UnarchiveTask(context.Background(), tid, SystemActor()); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("UnarchiveTask under archived goal: want ErrInvalidTransition, got %v", err)
+	}
+	if !h.getTask(t, tid).ArchivedAt.Valid {
+		t.Fatalf("child was unarchived despite archived parent")
+	}
+	// The supported path restores both.
+	if err := f.UnarchiveGoal(context.Background(), gid, SystemActor()); err != nil {
+		t.Fatalf("UnarchiveGoal: %v", err)
+	}
+	if h.getTask(t, tid).ArchivedAt.Valid {
+		t.Fatalf("child not restored by goal unarchive")
+	}
+}

--- a/internal/tasks/goal_transitions_test.go
+++ b/internal/tasks/goal_transitions_test.go
@@ -133,7 +133,7 @@ func TestArchiveGoal_TerminalHidesGoalAndChildren(t *testing.T) {
 	if !child.ArchivedAt.Valid {
 		t.Fatalf("child archived_at not set")
 	}
-	goals, err := f.ListGoals(context.Background(), h.userID, h.agentID, "", "", 10, 0)
+	goals, err := f.ListGoals(context.Background(), h.userID, GoalFilter{AgentID: h.agentID}, 10, 0)
 	if err != nil {
 		t.Fatalf("ListGoals: %v", err)
 	}
@@ -161,6 +161,132 @@ func TestArchiveGoal_RunningChildRejected(t *testing.T) {
 	err := f.ArchiveGoal(context.Background(), gid, SystemActor())
 	if !errors.Is(err, ErrInvalidTransition) {
 		t.Fatalf("got %v want ErrInvalidTransition", err)
+	}
+}
+
+// Re-archiving is idempotent: a second DELETE must not surface a spurious
+// not-found just because archived_at is already set.
+func TestArchiveGoal_Idempotent(t *testing.T) {
+	h := newHarness(t)
+	f := NewServiceFacade(h.db, h.q, h.svc, testSessionMinter)
+	gid := h.createGoal(t, GoalStatusDone, ReviewPolicyNone)
+	if err := f.ArchiveGoal(context.Background(), gid, SystemActor()); err != nil {
+		t.Fatalf("first ArchiveGoal: %v", err)
+	}
+	if err := f.ArchiveGoal(context.Background(), gid, SystemActor()); err != nil {
+		t.Fatalf("second ArchiveGoal should be a no-op, got %v", err)
+	}
+}
+
+func TestArchiveTask_Idempotent(t *testing.T) {
+	h := newHarness(t)
+	f := NewServiceFacade(h.db, h.q, h.svc, testSessionMinter)
+	gid := h.createGoal(t, GoalStatusDone, ReviewPolicyNone)
+	tid := h.createChildTask(t, gid, StatusDone)
+	if err := f.ArchiveTask(context.Background(), tid, SystemActor()); err != nil {
+		t.Fatalf("first ArchiveTask: %v", err)
+	}
+	if err := f.ArchiveTask(context.Background(), tid, SystemActor()); err != nil {
+		t.Fatalf("second ArchiveTask should be a no-op, got %v", err)
+	}
+}
+
+// UnarchiveGoal restores the goal and its archived children, and the archived
+// filter surfaces the goal for the history/restore view.
+func TestUnarchiveGoal_RestoresGoalAndChildren(t *testing.T) {
+	h := newHarness(t)
+	f := NewServiceFacade(h.db, h.q, h.svc, testSessionMinter)
+	gid := h.createGoal(t, GoalStatusDone, ReviewPolicyNone)
+	childID := h.createChildTask(t, gid, StatusDone)
+	if err := f.ArchiveGoal(context.Background(), gid, SystemActor()); err != nil {
+		t.Fatalf("ArchiveGoal: %v", err)
+	}
+	// Archived filter must surface it; default filter must not.
+	archived, err := f.ListGoals(context.Background(), h.userID, GoalFilter{AgentID: h.agentID, Archived: true}, 10, 0)
+	if err != nil {
+		t.Fatalf("ListGoals(archived): %v", err)
+	}
+	if len(archived) != 1 || archived[0].ID != gid {
+		t.Fatalf("archived filter did not return the archived goal: %+v", archived)
+	}
+	if err := f.UnarchiveGoal(context.Background(), gid, SystemActor()); err != nil {
+		t.Fatalf("UnarchiveGoal: %v", err)
+	}
+	goal, _ := h.q.GetAgentGoal(context.Background(), gid)
+	if goal.ArchivedAt.Valid {
+		t.Fatalf("goal still archived after unarchive")
+	}
+	if h.getTask(t, childID).ArchivedAt.Valid {
+		t.Fatalf("child still archived after unarchive")
+	}
+	active, err := f.ListGoals(context.Background(), h.userID, GoalFilter{AgentID: h.agentID}, 10, 0)
+	if err != nil {
+		t.Fatalf("ListGoals(active): %v", err)
+	}
+	if len(active) != 1 || active[0].ID != gid {
+		t.Fatalf("restored goal not in default list: %+v", active)
+	}
+}
+
+func TestUnarchiveGoal_NotArchived_NoOp(t *testing.T) {
+	h := newHarness(t)
+	f := NewServiceFacade(h.db, h.q, h.svc, testSessionMinter)
+	gid := h.createGoal(t, GoalStatusDone, ReviewPolicyNone)
+	if err := f.UnarchiveGoal(context.Background(), gid, SystemActor()); err != nil {
+		t.Fatalf("UnarchiveGoal on non-archived goal should be a no-op, got %v", err)
+	}
+}
+
+// An archived goal must stay inert: reactivation may not resurrect work that is
+// hidden from default lists.
+func TestActivateGoal_Archived_Rejects(t *testing.T) {
+	h := newHarness(t)
+	f := NewServiceFacade(h.db, h.q, h.svc, testSessionMinter)
+	gid := h.createGoal(t, GoalStatusDraft, ReviewPolicyNone)
+	if err := f.ArchiveGoal(context.Background(), gid, SystemActor()); err != nil {
+		t.Fatalf("ArchiveGoal: %v", err)
+	}
+	err := h.svc.ActivateGoal(context.Background(), gid, SystemActor())
+	if !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("got %v want ErrInvalidTransition", err)
+	}
+	goal, _ := h.q.GetAgentGoal(context.Background(), gid)
+	if goal.Status != GoalStatusDraft {
+		t.Errorf("goal status=%q want draft (activation rejected)", goal.Status)
+	}
+}
+
+func TestReopenTask_Archived_Rejects(t *testing.T) {
+	h := newHarness(t)
+	f := NewServiceFacade(h.db, h.q, h.svc, testSessionMinter)
+	gid := h.createGoal(t, GoalStatusDone, ReviewPolicyNone)
+	tid := h.createChildTask(t, gid, StatusDone)
+	if err := f.ArchiveTask(context.Background(), tid, SystemActor()); err != nil {
+		t.Fatalf("ArchiveTask: %v", err)
+	}
+	err := h.svc.ReopenTask(context.Background(), tid, false, SystemActor())
+	if !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("got %v want ErrInvalidTransition", err)
+	}
+}
+
+// The dispatcher rollup scan must skip archived goals so an archived (but
+// recoverable) failed goal is never silently revived to running.
+func TestListAgentGoals_ExcludesArchived(t *testing.T) {
+	h := newHarness(t)
+	f := NewServiceFacade(h.db, h.q, h.svc, testSessionMinter)
+	gid := h.createGoal(t, GoalStatusFailed, ReviewPolicyNone)
+	if err := f.ArchiveGoal(context.Background(), gid, SystemActor()); err != nil {
+		t.Fatalf("ArchiveGoal: %v", err)
+	}
+	goals, err := h.q.ListAgentGoals(context.Background(), sqlc.ListAgentGoalsParams{Limit: 100, Offset: 0})
+	if err != nil {
+		t.Fatalf("ListAgentGoals: %v", err)
+	}
+	for _, g := range goals {
+		if g.ID == gid {
+			t.Fatalf("archived failed goal returned in rollup scan")
+		}
 	}
 }
 

--- a/internal/tasks/goal_transitions_test.go
+++ b/internal/tasks/goal_transitions_test.go
@@ -572,3 +572,32 @@ func TestUnarchiveTask_ParentGoalArchived_Rejects(t *testing.T) {
 		t.Fatalf("child not restored by goal unarchive")
 	}
 }
+
+// CR-023: a draft child still counts as required_pending in the rollup, so
+// individually archiving one under a live goal would wedge the goal forever.
+func TestArchiveTask_DraftChildOfRunningGoal_Rejected(t *testing.T) {
+	h := newHarness(t)
+	f := NewServiceFacade(h.db, h.q, h.svc, testSessionMinter)
+	gid := h.createGoal(t, GoalStatusRunning, ReviewPolicyNone)
+	cid := h.createChildTask(t, gid, StatusDraft)
+	if err := f.ArchiveTask(context.Background(), cid, SystemActor()); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("archive draft child of running goal: want ErrInvalidTransition, got %v", err)
+	}
+	if h.getTask(t, cid).ArchivedAt.Valid {
+		t.Fatalf("child archived despite live parent goal")
+	}
+}
+
+// A child of a terminal goal carries no rollup risk and stays individually archivable.
+func TestArchiveTask_ChildOfTerminalGoal_Allowed(t *testing.T) {
+	h := newHarness(t)
+	f := NewServiceFacade(h.db, h.q, h.svc, testSessionMinter)
+	gid := h.createGoal(t, GoalStatusDone, ReviewPolicyNone)
+	cid := h.createChildTask(t, gid, StatusDone)
+	if err := f.ArchiveTask(context.Background(), cid, SystemActor()); err != nil {
+		t.Fatalf("archive child of terminal goal: %v", err)
+	}
+	if !h.getTask(t, cid).ArchivedAt.Valid {
+		t.Fatalf("child not archived")
+	}
+}

--- a/internal/tasks/reopen.go
+++ b/internal/tasks/reopen.go
@@ -53,6 +53,11 @@ func (s *TransitionService) ReopenTask(ctx context.Context, taskID string, casca
 		default:
 			return ErrInvalidTransition
 		}
+		// Archived tasks are inert; reopening one would resurrect work that is
+		// hidden from default lists (D-archive invariant).
+		if task.ArchivedAt.Valid {
+			return ErrInvalidTransition
+		}
 
 		downstream, err := q.ListReachableDownstream(ctx, taskID)
 		if err != nil {

--- a/internal/tasks/reopen.go
+++ b/internal/tasks/reopen.go
@@ -68,6 +68,11 @@ func (s *TransitionService) ReopenTask(ctx context.Context, taskID string, casca
 		if !cascade {
 			var conflicts []string
 			for _, d := range downstream {
+				if d.ArchivedAt.Valid {
+					// Archived downstream is hidden and inert; it neither
+					// blocks the reopen nor would be reset by a cascade.
+					continue
+				}
 				switch d.Status {
 				case StatusCancelled:
 					// cancellation is a deliberate stop; doesn't block reopen
@@ -108,6 +113,11 @@ func (s *TransitionService) ReopenTask(ctx context.Context, taskID string, casca
 
 		// Cascade: reset each downstream per ownership rule.
 		for _, d := range downstream {
+			if d.ArchivedAt.Valid {
+				// Resetting an archived task would resurrect work that is
+				// hidden from default lists (D-archive invariant).
+				continue
+			}
 			target := StatusReady
 			if d.GoalID.Valid {
 				// Goal-owned: depends on goal status.

--- a/internal/tasks/reopen_test.go
+++ b/internal/tasks/reopen_test.go
@@ -62,6 +62,56 @@ func TestReopen_Cascade_Standalone_DownstreamToReady(t *testing.T) {
 	}
 }
 
+func TestReopen_Cascade_SkipsArchivedDownstream(t *testing.T) {
+	h := newHarness(t)
+	f := NewServiceFacade(h.db, h.q, h.svc, testSessionMinter)
+	a := h.createTask(t, StatusReady)
+	b := h.createTask(t, StatusReady)
+	_ = h.svc.AddDep(context.Background(), b, a, DepKindHard, OnFailureBlock)
+	completeTask(t, h, a)
+	completeTask(t, h, b)
+	if err := f.ArchiveTask(context.Background(), b, SystemActor()); err != nil {
+		t.Fatalf("ArchiveTask: %v", err)
+	}
+	if err := h.svc.ReopenTask(context.Background(), a, true, SystemActor()); err != nil {
+		t.Fatalf("ReopenTask cascade: %v", err)
+	}
+	if got := h.getTask(t, a).Status; got != StatusReady {
+		t.Errorf("a status=%q want ready", got)
+	}
+	// Archived downstream stays inert: not reset, still archived (CR-022).
+	bt := h.getTask(t, b)
+	if !bt.ArchivedAt.Valid {
+		t.Errorf("archived downstream lost archived_at")
+	}
+	if bt.Status != StatusDone {
+		t.Errorf("archived downstream status=%q want done (not resurrected)", bt.Status)
+	}
+}
+
+func TestReopen_NoCascade_ArchivedDownstream_NoConflict(t *testing.T) {
+	h := newHarness(t)
+	f := NewServiceFacade(h.db, h.q, h.svc, testSessionMinter)
+	a := h.createTask(t, StatusReady)
+	b := h.createTask(t, StatusReady)
+	_ = h.svc.AddDep(context.Background(), b, a, DepKindHard, OnFailureBlock)
+	completeTask(t, h, a)
+	completeTask(t, h, b)
+	if err := f.ArchiveTask(context.Background(), b, SystemActor()); err != nil {
+		t.Fatalf("ArchiveTask: %v", err)
+	}
+	// b is hidden; a done archived downstream must not block the reopen (CR-022).
+	if err := h.svc.ReopenTask(context.Background(), a, false, SystemActor()); err != nil {
+		t.Fatalf("ReopenTask: archived downstream should not conflict, got %v", err)
+	}
+	if got := h.getTask(t, a).Status; got != StatusReady {
+		t.Errorf("a status=%q want ready", got)
+	}
+	if !h.getTask(t, b).ArchivedAt.Valid {
+		t.Errorf("archived downstream lost archived_at")
+	}
+}
+
 func TestReopen_CancelledTask_Rejected(t *testing.T) {
 	h := newHarness(t)
 	id := h.createTask(t, StatusReady)

--- a/internal/tasks/service_facade.go
+++ b/internal/tasks/service_facade.go
@@ -231,24 +231,33 @@ func (f *ServiceFacade) GetTask(ctx context.Context, taskID string) (sqlc.AgentT
 	return t, nil
 }
 
-// ListTasksByUser returns paginated tasks owned by the given user, optionally
-// filtered by agent, project, and status. Empty filter strings match all rows.
-// archived=false lists active tasks (the default); archived=true lists the
-// archived history/restore set.
-func (f *ServiceFacade) ListTasksByUser(ctx context.Context, userID, agentID, projectID, status string, archived bool, limit, offset int64) ([]sqlc.AgentTask, error) {
+// TaskFilter narrows a task list. Named fields avoid the transposition footgun
+// of several adjacent string parameters (mirrors GoalFilter); the zero value
+// lists active tasks.
+type TaskFilter struct {
+	AgentID   string
+	ProjectID string
+	Status    string
+	Archived  bool // true lists the archived (history/restore) set instead of active tasks
+}
+
+// ListTasksByUser returns paginated tasks owned by the given user, narrowed by
+// filter. The zero filter lists active tasks; Archived=true lists the archived
+// history/restore set. Empty filter strings match all rows.
+func (f *ServiceFacade) ListTasksByUser(ctx context.Context, userID string, filter TaskFilter, limit, offset int64) ([]sqlc.AgentTask, error) {
 	if limit <= 0 {
 		limit = 50
 	}
 	var arch any
-	if archived {
+	if filter.Archived {
 		arch = int64(1)
 	}
 	return f.q.ListAgentTasksByUser(ctx, sqlc.ListAgentTasksByUserParams{
 		UserID:    userID,
 		Archived:  arch,
-		AgentID:   nilIfEmpty(agentID),
-		ProjectID: nilIfEmpty(projectID),
-		Status:    nilIfEmpty(status),
+		AgentID:   nilIfEmpty(filter.AgentID),
+		ProjectID: nilIfEmpty(filter.ProjectID),
+		Status:    nilIfEmpty(filter.Status),
 		Limit:     limit,
 		Offset:    offset,
 	})

--- a/internal/tasks/service_facade.go
+++ b/internal/tasks/service_facade.go
@@ -325,35 +325,51 @@ func (f *ServiceFacade) WaiveDep(ctx context.Context, taskID, depTaskID, userID,
 }
 
 // ArchiveTask hides a terminal/draft task from default lists while preserving audit data.
+// Re-archiving an already-archived task is a no-op (idempotent), matching HTTP DELETE semantics.
 func (f *ServiceFacade) ArchiveTask(ctx context.Context, taskID string, actor Actor) error {
-	t, err := f.q.GetAgentTask(ctx, taskID)
+	return f.svc.WithTx(ctx, func(q *sqlc.Queries) error {
+		_, err := f.archiveTaskTx(ctx, q, taskID, "", `{"mode":"archive"}`, actor)
+		return err
+	})
+}
+
+// archiveTaskTx archives one task inside an open tx. The status fetch and check
+// happen in-tx so a concurrent transition (e.g. draft→ready) that committed
+// before this write is respected instead of being silently overwritten. Returns
+// whether a row was archived; an already-archived task is a no-op (false, nil),
+// while a non-archivable status aborts with ErrInvalidTransition (the caller's
+// signal to abort an enclosing goal archive).
+func (f *ServiceFacade) archiveTaskTx(ctx context.Context, q *sqlc.Queries, taskID, goalID, detail string, actor Actor) (bool, error) {
+	t, err := q.GetAgentTask(ctx, taskID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return ErrTaskNotFound
+			return false, ErrTaskNotFound
 		}
-		return err
+		return false, err
+	}
+	if t.ArchivedAt.Valid {
+		return false, nil
 	}
 	if !isArchivableTaskStatus(t.Status) {
-		return ErrInvalidTransition
+		return false, ErrInvalidTransition
 	}
 	now := time.Now().UTC().Format(time.RFC3339Nano)
-	return f.svc.WithTx(ctx, func(q *sqlc.Queries) error {
-		n, err := q.ArchiveAgentTask(ctx, sqlc.ArchiveAgentTaskParams{ArchivedAt: sql.NullString{String: now, Valid: true}, UpdatedAt: now, ID: taskID})
-		if err != nil {
-			return err
-		}
-		if n == 0 {
-			return ErrTaskNotFound
-		}
-		return f.svc.appendEvent(ctx, q, sqlc.InsertAgentTaskEventParams{
-			TaskID:     nullable(taskID),
-			EventType:  "task_archive",
-			FromStatus: nullable(t.Status),
-			ToStatus:   nullable(t.Status),
-			ActorType:  actor.Type,
-			ActorID:    nullable(actor.ID),
-			Detail:     `{"mode":"archive"}`,
-		})
+	n, err := q.ArchiveAgentTask(ctx, sqlc.ArchiveAgentTaskParams{ArchivedAt: sql.NullString{String: now, Valid: true}, UpdatedAt: now, ID: taskID})
+	if err != nil {
+		return false, err
+	}
+	if n == 0 {
+		return false, nil
+	}
+	return true, f.svc.appendEvent(ctx, q, sqlc.InsertAgentTaskEventParams{
+		TaskID:     nullable(taskID),
+		GoalID:     nullable(goalID),
+		EventType:  "task_archive",
+		FromStatus: nullable(t.Status),
+		ToStatus:   nullable(t.Status),
+		ActorType:  actor.Type,
+		ActorID:    nullable(actor.ID),
+		Detail:     detail,
 	})
 }
 
@@ -498,73 +514,73 @@ func (f *ServiceFacade) GetGoal(ctx context.Context, goalID string) (sqlc.AgentG
 	return g, nil
 }
 
+// GoalFilter narrows a goal list. Named fields avoid the transposition footgun
+// of several adjacent string parameters; the zero value lists active goals.
+type GoalFilter struct {
+	AgentID   string
+	ProjectID string
+	Status    string
+	Archived  bool // true lists the archived (history/restore) set instead of active goals
+}
+
 // ListGoals returns goals owned by the given user, newest first.
-func (f *ServiceFacade) ListGoals(ctx context.Context, userID, agentID, projectID, status string, limit, offset int64) ([]sqlc.AgentGoal, error) {
+func (f *ServiceFacade) ListGoals(ctx context.Context, userID string, filter GoalFilter, limit, offset int64) ([]sqlc.AgentGoal, error) {
 	if limit <= 0 {
 		limit = 50
 	}
+	var archived any
+	if filter.Archived {
+		archived = int64(1)
+	}
 	return f.q.ListAgentGoalsByUser(ctx, sqlc.ListAgentGoalsByUserParams{
 		UserID:    userID,
-		AgentID:   nilIfEmpty(agentID),
-		ProjectID: nilIfEmpty(projectID),
-		Status:    nilIfEmpty(status),
+		Archived:  archived,
+		AgentID:   nilIfEmpty(filter.AgentID),
+		ProjectID: nilIfEmpty(filter.ProjectID),
+		Status:    nilIfEmpty(filter.Status),
 		Limit:     limit,
 		Offset:    offset,
 	})
 }
 
 // ArchiveGoal hides a terminal/draft goal and its terminal/draft children from default lists while preserving audit data.
+// All status fetches and checks run inside the tx so a concurrent transition is
+// respected; re-archiving an already-archived goal is a no-op (idempotent).
 func (f *ServiceFacade) ArchiveGoal(ctx context.Context, goalID string, actor Actor) error {
-	g, err := f.q.GetAgentGoal(ctx, goalID)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return ErrGoalNotFound
+	return f.svc.WithTx(ctx, func(q *sqlc.Queries) error {
+		g, err := getGoalForUpdate(ctx, q, goalID)
+		if err != nil {
+			return err
 		}
-		return err
-	}
-	if !isArchivableGoalStatus(g.Status) {
-		return ErrInvalidTransition
-	}
-	children, err := f.q.ListChildrenByGoal(ctx, nullable(goalID))
-	if err != nil {
-		return err
-	}
-	for _, child := range children {
-		if !isArchivableTaskStatus(child.Status) {
+		if g.ArchivedAt.Valid {
+			return nil
+		}
+		if !isArchivableGoalStatus(g.Status) {
 			return ErrInvalidTransition
 		}
-	}
-	now := time.Now().UTC().Format(time.RFC3339Nano)
-	return f.svc.WithTx(ctx, func(q *sqlc.Queries) error {
+		children, err := q.ListChildrenByGoal(ctx, nullable(goalID))
+		if err != nil {
+			return err
+		}
+		// Validate every child up front so an active child aborts the whole
+		// operation before any row is archived (all-or-nothing).
 		for _, child := range children {
-			if child.ArchivedAt.Valid {
-				continue
-			}
-			n, err := q.ArchiveAgentTask(ctx, sqlc.ArchiveAgentTaskParams{ArchivedAt: sql.NullString{String: now, Valid: true}, UpdatedAt: now, ID: child.ID})
-			if err != nil {
-				return err
-			}
-			if n > 0 {
-				if err := f.svc.appendEvent(ctx, q, sqlc.InsertAgentTaskEventParams{
-					TaskID:     nullable(child.ID),
-					GoalID:     nullable(goalID),
-					EventType:  "task_archive",
-					FromStatus: nullable(child.Status),
-					ToStatus:   nullable(child.Status),
-					ActorType:  actor.Type,
-					ActorID:    nullable(actor.ID),
-					Detail:     `{"mode":"archive","parent_goal_archived":true}`,
-				}); err != nil {
-					return err
-				}
+			if !child.ArchivedAt.Valid && !isArchivableTaskStatus(child.Status) {
+				return ErrInvalidTransition
 			}
 		}
+		for _, child := range children {
+			if _, err := f.archiveTaskTx(ctx, q, child.ID, goalID, `{"mode":"archive","parent_goal_archived":true}`, actor); err != nil {
+				return err
+			}
+		}
+		now := time.Now().UTC().Format(time.RFC3339Nano)
 		n, err := q.ArchiveAgentGoal(ctx, sqlc.ArchiveAgentGoalParams{ArchivedAt: sql.NullString{String: now, Valid: true}, UpdatedAt: now, ID: goalID})
 		if err != nil {
 			return err
 		}
 		if n == 0 {
-			return ErrGoalNotFound
+			return nil
 		}
 		return f.svc.appendEvent(ctx, q, sqlc.InsertAgentTaskEventParams{
 			GoalID:     nullable(goalID),
@@ -574,6 +590,65 @@ func (f *ServiceFacade) ArchiveGoal(ctx context.Context, goalID string, actor Ac
 			ActorType:  actor.Type,
 			ActorID:    nullable(actor.ID),
 			Detail:     `{"mode":"archive"}`,
+		})
+	})
+}
+
+// UnarchiveGoal restores an archived goal and its archived children to default
+// lists, reversing ArchiveGoal. Restoring an already-active goal is a no-op.
+func (f *ServiceFacade) UnarchiveGoal(ctx context.Context, goalID string, actor Actor) error {
+	return f.svc.WithTx(ctx, func(q *sqlc.Queries) error {
+		g, err := getGoalForUpdate(ctx, q, goalID)
+		if err != nil {
+			return err
+		}
+		if !g.ArchivedAt.Valid {
+			return nil
+		}
+		now := time.Now().UTC().Format(time.RFC3339Nano)
+		children, err := q.ListChildrenByGoal(ctx, nullable(goalID))
+		if err != nil {
+			return err
+		}
+		for _, child := range children {
+			if !child.ArchivedAt.Valid {
+				continue
+			}
+			n, err := q.UnarchiveAgentTask(ctx, sqlc.UnarchiveAgentTaskParams{UpdatedAt: now, ID: child.ID})
+			if err != nil {
+				return err
+			}
+			if n == 0 {
+				continue
+			}
+			if err := f.svc.appendEvent(ctx, q, sqlc.InsertAgentTaskEventParams{
+				TaskID:     nullable(child.ID),
+				GoalID:     nullable(goalID),
+				EventType:  "task_unarchive",
+				FromStatus: nullable(child.Status),
+				ToStatus:   nullable(child.Status),
+				ActorType:  actor.Type,
+				ActorID:    nullable(actor.ID),
+				Detail:     `{"mode":"unarchive","parent_goal_unarchived":true}`,
+			}); err != nil {
+				return err
+			}
+		}
+		n, err := q.UnarchiveAgentGoal(ctx, sqlc.UnarchiveAgentGoalParams{UpdatedAt: now, ID: goalID})
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return nil
+		}
+		return f.svc.appendEvent(ctx, q, sqlc.InsertAgentTaskEventParams{
+			GoalID:     nullable(goalID),
+			EventType:  "goal_unarchive",
+			FromStatus: nullable(g.Status),
+			ToStatus:   nullable(g.Status),
+			ActorType:  actor.Type,
+			ActorID:    nullable(actor.ID),
+			Detail:     `{"mode":"unarchive"}`,
 		})
 	})
 }

--- a/internal/tasks/service_facade.go
+++ b/internal/tasks/service_facade.go
@@ -324,6 +324,39 @@ func (f *ServiceFacade) WaiveDep(ctx context.Context, taskID, depTaskID, userID,
 	return f.svc.WaiveDep(ctx, taskID, depTaskID, userID, reason, actor)
 }
 
+// ArchiveTask hides a terminal/draft task from default lists while preserving audit data.
+func (f *ServiceFacade) ArchiveTask(ctx context.Context, taskID string, actor Actor) error {
+	t, err := f.q.GetAgentTask(ctx, taskID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrTaskNotFound
+		}
+		return err
+	}
+	if !isArchivableTaskStatus(t.Status) {
+		return ErrInvalidTransition
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	return f.svc.WithTx(ctx, func(q *sqlc.Queries) error {
+		n, err := q.ArchiveAgentTask(ctx, sqlc.ArchiveAgentTaskParams{ArchivedAt: sql.NullString{String: now, Valid: true}, UpdatedAt: now, ID: taskID})
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return ErrTaskNotFound
+		}
+		return f.svc.appendEvent(ctx, q, sqlc.InsertAgentTaskEventParams{
+			TaskID:     nullable(taskID),
+			EventType:  "task_archive",
+			FromStatus: nullable(t.Status),
+			ToStatus:   nullable(t.Status),
+			ActorType:  actor.Type,
+			ActorID:    nullable(actor.ID),
+			Detail:     `{"mode":"archive"}`,
+		})
+	})
+}
+
 // ReopenTask exposes TransitionService.ReopenTask. Cascade applies the
 // downstream reset rules in D10.
 func (f *ServiceFacade) ReopenTask(ctx context.Context, taskID string, cascade bool, actor Actor) error {
@@ -466,19 +499,105 @@ func (f *ServiceFacade) GetGoal(ctx context.Context, goalID string) (sqlc.AgentG
 }
 
 // ListGoals returns goals owned by the given user, newest first.
-func (f *ServiceFacade) ListGoals(ctx context.Context, userID string, limit, offset int64) ([]sqlc.AgentGoal, error) {
+func (f *ServiceFacade) ListGoals(ctx context.Context, userID, agentID, projectID, status string, limit, offset int64) ([]sqlc.AgentGoal, error) {
 	if limit <= 0 {
 		limit = 50
 	}
-	return f.q.ListAgentGoalsByUser(ctx, sqlc.ListAgentGoalsByUserParams{UserID: userID, Limit: limit, Offset: offset})
+	return f.q.ListAgentGoalsByUser(ctx, sqlc.ListAgentGoalsByUserParams{
+		UserID:    userID,
+		AgentID:   nilIfEmpty(agentID),
+		ProjectID: nilIfEmpty(projectID),
+		Status:    nilIfEmpty(status),
+		Limit:     limit,
+		Offset:    offset,
+	})
 }
 
-// ListGoalsByAgent returns goals owned by the given user and agent, newest first.
-func (f *ServiceFacade) ListGoalsByAgent(ctx context.Context, userID string, agentID string, limit, offset int64) ([]sqlc.AgentGoal, error) {
-	if limit <= 0 {
-		limit = 50
+// ArchiveGoal hides a terminal/draft goal and its terminal/draft children from default lists while preserving audit data.
+func (f *ServiceFacade) ArchiveGoal(ctx context.Context, goalID string, actor Actor) error {
+	g, err := f.q.GetAgentGoal(ctx, goalID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrGoalNotFound
+		}
+		return err
 	}
-	return f.q.ListAgentGoalsByUserAndAgent(ctx, sqlc.ListAgentGoalsByUserAndAgentParams{UserID: userID, AgentID: agentID, Limit: limit, Offset: offset})
+	if !isArchivableGoalStatus(g.Status) {
+		return ErrInvalidTransition
+	}
+	children, err := f.q.ListChildrenByGoal(ctx, nullable(goalID))
+	if err != nil {
+		return err
+	}
+	for _, child := range children {
+		if !isArchivableTaskStatus(child.Status) {
+			return ErrInvalidTransition
+		}
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	return f.svc.WithTx(ctx, func(q *sqlc.Queries) error {
+		for _, child := range children {
+			if child.ArchivedAt.Valid {
+				continue
+			}
+			n, err := q.ArchiveAgentTask(ctx, sqlc.ArchiveAgentTaskParams{ArchivedAt: sql.NullString{String: now, Valid: true}, UpdatedAt: now, ID: child.ID})
+			if err != nil {
+				return err
+			}
+			if n > 0 {
+				if err := f.svc.appendEvent(ctx, q, sqlc.InsertAgentTaskEventParams{
+					TaskID:     nullable(child.ID),
+					GoalID:     nullable(goalID),
+					EventType:  "task_archive",
+					FromStatus: nullable(child.Status),
+					ToStatus:   nullable(child.Status),
+					ActorType:  actor.Type,
+					ActorID:    nullable(actor.ID),
+					Detail:     `{"mode":"archive","parent_goal_archived":true}`,
+				}); err != nil {
+					return err
+				}
+			}
+		}
+		n, err := q.ArchiveAgentGoal(ctx, sqlc.ArchiveAgentGoalParams{ArchivedAt: sql.NullString{String: now, Valid: true}, UpdatedAt: now, ID: goalID})
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return ErrGoalNotFound
+		}
+		return f.svc.appendEvent(ctx, q, sqlc.InsertAgentTaskEventParams{
+			GoalID:     nullable(goalID),
+			EventType:  "goal_archive",
+			FromStatus: nullable(g.Status),
+			ToStatus:   nullable(g.Status),
+			ActorType:  actor.Type,
+			ActorID:    nullable(actor.ID),
+			Detail:     `{"mode":"archive"}`,
+		})
+	})
+}
+
+func (f *ServiceFacade) CompleteGoal(ctx context.Context, goalID, output string, actor Actor) error {
+	return f.svc.CompleteGoal(ctx, goalID, output, actor)
+}
+
+func isArchivableGoalStatus(status string) bool {
+	switch status {
+	case GoalStatusDraft, GoalStatusDone, GoalStatusFailed, GoalStatusCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+func isArchivableTaskStatus(status string) bool {
+	switch status {
+	case StatusDraft, StatusDone, StatusFailed, StatusCancelled:
+		return true
+	default:
+		return false
+	}
 }
 
 // ActivateGoal / CancelGoal are thin shims over TransitionService.

--- a/internal/tasks/service_facade.go
+++ b/internal/tasks/service_facade.go
@@ -342,7 +342,31 @@ func (f *ServiceFacade) WaiveDep(ctx context.Context, taskID, depTaskID, userID,
 // Re-archiving an already-archived task is a no-op (idempotent), matching HTTP DELETE semantics.
 func (f *ServiceFacade) ArchiveTask(ctx context.Context, taskID string, actor Actor) error {
 	return f.svc.WithTx(ctx, func(q *sqlc.Queries) error {
-		_, err := f.archiveTaskTx(ctx, q, taskID, "", `{"mode":"archive"}`, actor)
+		t, err := q.GetAgentTask(ctx, taskID)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrTaskNotFound
+			}
+			return err
+		}
+		if t.ArchivedAt.Valid {
+			return nil
+		}
+		// Individually archiving a goal child while its parent goal is still live
+		// would strand the goal: a draft child stays counted as required_pending
+		// in the rollup (GoalChildCounts ignores archived_at), so hiding it wedges
+		// the goal in 'running' with an invisible blocker. Children are cleared by
+		// archiving the whole goal (which cascades) once it is terminal/archived.
+		if t.GoalID.Valid {
+			goal, err := q.GetAgentGoal(ctx, t.GoalID.String)
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
+				return err
+			}
+			if err == nil && !goal.ArchivedAt.Valid && !isTerminalGoalStatus(goal.Status) {
+				return ErrInvalidTransition
+			}
+		}
+		_, err = f.archiveTaskTx(ctx, q, taskID, "", `{"mode":"archive"}`, actor)
 		return err
 	})
 }

--- a/internal/tasks/service_facade.go
+++ b/internal/tasks/service_facade.go
@@ -407,24 +407,8 @@ func (f *ServiceFacade) UnarchiveTask(ctx context.Context, taskID string, actor 
 				return ErrInvalidTransition
 			}
 		}
-		now := time.Now().UTC().Format(time.RFC3339Nano)
-		n, err := q.UnarchiveAgentTask(ctx, sqlc.UnarchiveAgentTaskParams{UpdatedAt: now, ID: taskID})
-		if err != nil {
-			return err
-		}
-		if n == 0 {
-			return nil
-		}
-		return f.svc.appendEvent(ctx, q, sqlc.InsertAgentTaskEventParams{
-			TaskID:     nullable(taskID),
-			GoalID:     t.GoalID,
-			EventType:  "task_unarchive",
-			FromStatus: nullable(t.Status),
-			ToStatus:   nullable(t.Status),
-			ActorType:  actor.Type,
-			ActorID:    nullable(actor.ID),
-			Detail:     `{"mode":"unarchive"}`,
-		})
+		_, err = f.unarchiveTaskTx(ctx, q, taskID, t.GoalID.String, `{"mode":"unarchive"}`, actor)
+		return err
 	})
 }
 
@@ -460,6 +444,40 @@ func (f *ServiceFacade) archiveTaskTx(ctx context.Context, q *sqlc.Queries, task
 		TaskID:     nullable(taskID),
 		GoalID:     nullable(goalID),
 		EventType:  "task_archive",
+		FromStatus: nullable(t.Status),
+		ToStatus:   nullable(t.Status),
+		ActorType:  actor.Type,
+		ActorID:    nullable(actor.ID),
+		Detail:     detail,
+	})
+}
+
+// unarchiveTaskTx clears archived_at on one task inside an open tx and records a
+// task_unarchive event. Returns whether a row changed; an already-active task is
+// a no-op (false, nil). Mirrors archiveTaskTx.
+func (f *ServiceFacade) unarchiveTaskTx(ctx context.Context, q *sqlc.Queries, taskID, goalID, detail string, actor Actor) (bool, error) {
+	t, err := q.GetAgentTask(ctx, taskID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, ErrTaskNotFound
+		}
+		return false, err
+	}
+	if !t.ArchivedAt.Valid {
+		return false, nil
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	n, err := q.UnarchiveAgentTask(ctx, sqlc.UnarchiveAgentTaskParams{UpdatedAt: now, ID: taskID})
+	if err != nil {
+		return false, err
+	}
+	if n == 0 {
+		return false, nil
+	}
+	return true, f.svc.appendEvent(ctx, q, sqlc.InsertAgentTaskEventParams{
+		TaskID:     nullable(taskID),
+		GoalID:     nullable(goalID),
+		EventType:  "task_unarchive",
 		FromStatus: nullable(t.Status),
 		ToStatus:   nullable(t.Status),
 		ActorType:  actor.Type,
@@ -754,23 +772,7 @@ func (f *ServiceFacade) UnarchiveGoal(ctx context.Context, goalID string, actor 
 			if !child.ArchivedAt.Valid || !restore[child.ID] {
 				continue
 			}
-			n, err := q.UnarchiveAgentTask(ctx, sqlc.UnarchiveAgentTaskParams{UpdatedAt: now, ID: child.ID})
-			if err != nil {
-				return err
-			}
-			if n == 0 {
-				continue
-			}
-			if err := f.svc.appendEvent(ctx, q, sqlc.InsertAgentTaskEventParams{
-				TaskID:     nullable(child.ID),
-				GoalID:     nullable(goalID),
-				EventType:  "task_unarchive",
-				FromStatus: nullable(child.Status),
-				ToStatus:   nullable(child.Status),
-				ActorType:  actor.Type,
-				ActorID:    nullable(actor.ID),
-				Detail:     `{"mode":"unarchive","parent_goal_unarchived":true}`,
-			}); err != nil {
+			if _, err := f.unarchiveTaskTx(ctx, q, child.ID, goalID, `{"mode":"unarchive","parent_goal_unarchived":true}`, actor); err != nil {
 				return err
 			}
 		}

--- a/internal/tasks/service_facade.go
+++ b/internal/tasks/service_facade.go
@@ -171,6 +171,12 @@ func (f *ServiceFacade) resolveTaskContext(ctx context.Context, in CreateTaskInp
 		if goal.UserID != in.UserID {
 			return "", "", ErrGoalNotFound
 		}
+		// An archived goal is inert: it must not accept new child tasks, or a
+		// task created under it would be dispatchable while the goal stays
+		// hidden — reviving archived work. Unarchive the goal first (CR-017).
+		if goal.ArchivedAt.Valid {
+			return "", "", fmt.Errorf("%w: goal is archived and accepts no new tasks", ErrInvalidTaskContext)
+		}
 		// A failed goal is recoverable by rollup, but only by reopening or
 		// completing its existing children — not by attaching new work. Keep it
 		// terminal for task creation so a goal cannot sit failed while accepting
@@ -354,6 +360,19 @@ func (f *ServiceFacade) UnarchiveTask(ctx context.Context, taskID string, actor 
 		}
 		if !t.ArchivedAt.Valid {
 			return nil
+		}
+		// Restoring a child while its goal is still archived would resurrect the
+		// task under a hidden parent — an inert goal must stay fully inert. Make
+		// the user unarchive the goal first, which cascades the child back
+		// (CR-018).
+		if t.GoalID.Valid {
+			goal, err := q.GetAgentGoal(ctx, t.GoalID.String)
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
+				return err
+			}
+			if err == nil && goal.ArchivedAt.Valid {
+				return ErrInvalidTransition
+			}
 		}
 		now := time.Now().UTC().Format(time.RFC3339Nano)
 		n, err := q.UnarchiveAgentTask(ctx, sqlc.UnarchiveAgentTaskParams{UpdatedAt: now, ID: taskID})

--- a/internal/tasks/service_facade.go
+++ b/internal/tasks/service_facade.go
@@ -3,6 +3,7 @@ package tasks
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -226,12 +227,19 @@ func (f *ServiceFacade) GetTask(ctx context.Context, taskID string) (sqlc.AgentT
 
 // ListTasksByUser returns paginated tasks owned by the given user, optionally
 // filtered by agent, project, and status. Empty filter strings match all rows.
-func (f *ServiceFacade) ListTasksByUser(ctx context.Context, userID, agentID, projectID, status string, limit, offset int64) ([]sqlc.AgentTask, error) {
+// archived=false lists active tasks (the default); archived=true lists the
+// archived history/restore set.
+func (f *ServiceFacade) ListTasksByUser(ctx context.Context, userID, agentID, projectID, status string, archived bool, limit, offset int64) ([]sqlc.AgentTask, error) {
 	if limit <= 0 {
 		limit = 50
 	}
+	var arch any
+	if archived {
+		arch = int64(1)
+	}
 	return f.q.ListAgentTasksByUser(ctx, sqlc.ListAgentTasksByUserParams{
 		UserID:    userID,
+		Archived:  arch,
 		AgentID:   nilIfEmpty(agentID),
 		ProjectID: nilIfEmpty(projectID),
 		Status:    nilIfEmpty(status),
@@ -330,6 +338,41 @@ func (f *ServiceFacade) ArchiveTask(ctx context.Context, taskID string, actor Ac
 	return f.svc.WithTx(ctx, func(q *sqlc.Queries) error {
 		_, err := f.archiveTaskTx(ctx, q, taskID, "", `{"mode":"archive"}`, actor)
 		return err
+	})
+}
+
+// UnarchiveTask restores a standalone archived task to default lists, reversing
+// ArchiveTask. Restoring a non-archived task is a no-op (idempotent).
+func (f *ServiceFacade) UnarchiveTask(ctx context.Context, taskID string, actor Actor) error {
+	return f.svc.WithTx(ctx, func(q *sqlc.Queries) error {
+		t, err := q.GetAgentTask(ctx, taskID)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrTaskNotFound
+			}
+			return err
+		}
+		if !t.ArchivedAt.Valid {
+			return nil
+		}
+		now := time.Now().UTC().Format(time.RFC3339Nano)
+		n, err := q.UnarchiveAgentTask(ctx, sqlc.UnarchiveAgentTaskParams{UpdatedAt: now, ID: taskID})
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return nil
+		}
+		return f.svc.appendEvent(ctx, q, sqlc.InsertAgentTaskEventParams{
+			TaskID:     nullable(taskID),
+			GoalID:     t.GoalID,
+			EventType:  "task_unarchive",
+			FromStatus: nullable(t.Status),
+			ToStatus:   nullable(t.Status),
+			ActorType:  actor.Type,
+			ActorID:    nullable(actor.ID),
+			Detail:     `{"mode":"unarchive"}`,
+		})
 	})
 }
 
@@ -520,7 +563,38 @@ type GoalFilter struct {
 	AgentID   string
 	ProjectID string
 	Status    string
-	Archived  bool // true lists the archived (history/restore) set instead of active goals
+	Archived  bool   // true lists the archived (history/restore) set instead of active goals
+	Terminal  *bool  // nil any; false non-terminal (active); true terminal (history). Ignored when Archived.
+	Search    string // case-insensitive substring on title/description; empty matches all
+}
+
+func (filter GoalFilter) params(userID string, limit, offset int64) sqlc.ListAgentGoalsByUserParams {
+	var archived, terminal any
+	if filter.Archived {
+		archived = int64(1)
+	} else if filter.Terminal != nil {
+		// Terminal only narrows the active set; archived rows are listed whole.
+		if *filter.Terminal {
+			terminal = int64(1)
+		} else {
+			terminal = int64(0)
+		}
+	}
+	var search any
+	if filter.Search != "" {
+		search = filter.Search
+	}
+	return sqlc.ListAgentGoalsByUserParams{
+		UserID:    userID,
+		Archived:  archived,
+		AgentID:   nilIfEmpty(filter.AgentID),
+		ProjectID: nilIfEmpty(filter.ProjectID),
+		Status:    nilIfEmpty(filter.Status),
+		Terminal:  terminal,
+		Search:    search,
+		Limit:     limit,
+		Offset:    offset,
+	}
 }
 
 // ListGoals returns goals owned by the given user, newest first.
@@ -528,18 +602,20 @@ func (f *ServiceFacade) ListGoals(ctx context.Context, userID string, filter Goa
 	if limit <= 0 {
 		limit = 50
 	}
-	var archived any
-	if filter.Archived {
-		archived = int64(1)
-	}
-	return f.q.ListAgentGoalsByUser(ctx, sqlc.ListAgentGoalsByUserParams{
-		UserID:    userID,
-		Archived:  archived,
-		AgentID:   nilIfEmpty(filter.AgentID),
-		ProjectID: nilIfEmpty(filter.ProjectID),
-		Status:    nilIfEmpty(filter.Status),
-		Limit:     limit,
-		Offset:    offset,
+	return f.q.ListAgentGoalsByUser(ctx, filter.params(userID, limit, offset))
+}
+
+// CountGoals returns the total goals matching the filter, ignoring pagination.
+func (f *ServiceFacade) CountGoals(ctx context.Context, userID string, filter GoalFilter) (int64, error) {
+	p := filter.params(userID, 0, 0)
+	return f.q.CountAgentGoalsByUser(ctx, sqlc.CountAgentGoalsByUserParams{
+		UserID:    p.UserID,
+		Archived:  p.Archived,
+		AgentID:   p.AgentID,
+		ProjectID: p.ProjectID,
+		Status:    p.Status,
+		Terminal:  p.Terminal,
+		Search:    p.Search,
 	})
 }
 
@@ -569,9 +645,17 @@ func (f *ServiceFacade) ArchiveGoal(ctx context.Context, goalID string, actor Ac
 				return ErrInvalidTransition
 			}
 		}
+		// Record which children THIS cascade actually archived (archiveTaskTx is a
+		// no-op for already-archived ones). UnarchiveGoal restores exactly this
+		// set, so children the user archived independently stay hidden.
+		archivedChildIDs := make([]string, 0, len(children))
 		for _, child := range children {
-			if _, err := f.archiveTaskTx(ctx, q, child.ID, goalID, `{"mode":"archive","parent_goal_archived":true}`, actor); err != nil {
+			archived, err := f.archiveTaskTx(ctx, q, child.ID, goalID, `{"mode":"archive","parent_goal_archived":true}`, actor)
+			if err != nil {
 				return err
+			}
+			if archived {
+				archivedChildIDs = append(archivedChildIDs, child.ID)
 			}
 		}
 		now := time.Now().UTC().Format(time.RFC3339Nano)
@@ -589,7 +673,7 @@ func (f *ServiceFacade) ArchiveGoal(ctx context.Context, goalID string, actor Ac
 			ToStatus:   nullable(g.Status),
 			ActorType:  actor.Type,
 			ActorID:    nullable(actor.ID),
-			Detail:     `{"mode":"archive"}`,
+			Detail:     archiveGoalDetail(archivedChildIDs),
 		})
 	})
 }
@@ -610,8 +694,12 @@ func (f *ServiceFacade) UnarchiveGoal(ctx context.Context, goalID string, actor 
 		if err != nil {
 			return err
 		}
+		restore, err := f.childrenArchivedByGoal(ctx, q, goalID)
+		if err != nil {
+			return err
+		}
 		for _, child := range children {
-			if !child.ArchivedAt.Valid {
+			if !child.ArchivedAt.Valid || !restore[child.ID] {
 				continue
 			}
 			n, err := q.UnarchiveAgentTask(ctx, sqlc.UnarchiveAgentTaskParams{UpdatedAt: now, ID: child.ID})
@@ -651,6 +739,47 @@ func (f *ServiceFacade) UnarchiveGoal(ctx context.Context, goalID string, actor 
 			Detail:     `{"mode":"unarchive"}`,
 		})
 	})
+}
+
+// goalArchiveDetail is the shape of a goal_archive event's detail JSON. The
+// recorded child IDs let UnarchiveGoal reverse exactly this cascade.
+type goalArchiveDetail struct {
+	Mode            string   `json:"mode"`
+	ArchivedTaskIDs []string `json:"archived_task_ids"`
+}
+
+func archiveGoalDetail(archivedChildIDs []string) string {
+	b, err := json.Marshal(goalArchiveDetail{Mode: "archive", ArchivedTaskIDs: archivedChildIDs})
+	if err != nil {
+		// archivedChildIDs is plain strings; marshaling cannot fail.
+		return `{"mode":"archive"}`
+	}
+	return string(b)
+}
+
+// childrenArchivedByGoal returns the set of child task IDs the goal's latest
+// archive cascade hid. Goals archived before this detail was recorded yield an
+// empty set, so their children stay archived on unarchive (safe: never restores
+// a task the user did not expect).
+func (f *ServiceFacade) childrenArchivedByGoal(ctx context.Context, q *sqlc.Queries, goalID string) (map[string]bool, error) {
+	detail, err := q.GetLatestGoalArchiveDetail(ctx, nullable(goalID))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return map[string]bool{}, nil
+		}
+		return nil, err
+	}
+	set := map[string]bool{}
+	if detail != "" {
+		var d goalArchiveDetail
+		if err := json.Unmarshal([]byte(detail), &d); err != nil {
+			return nil, err
+		}
+		for _, id := range d.ArchivedTaskIDs {
+			set[id] = true
+		}
+	}
+	return set, nil
 }
 
 func (f *ServiceFacade) CompleteGoal(ctx context.Context, goalID, output string, actor Actor) error {

--- a/pkg/db/sqlc/agent_goal.sql.go
+++ b/pkg/db/sqlc/agent_goal.sql.go
@@ -162,6 +162,7 @@ func (q *Queries) GoalChildCounts(ctx context.Context, goalID sql.NullString) (G
 const listAgentGoals = `-- name: ListAgentGoals :many
 SELECT id, user_id, agent_id, project_id, title, description, status, priority, review_policy, active_review_id, context, output, created_at, updated_at, completed_at, cancelled_at, archived_at FROM agent_goal
 WHERE status NOT IN ('done', 'cancelled')
+  AND archived_at IS NULL
 ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?
 `
 
@@ -173,6 +174,8 @@ type ListAgentGoalsParams struct {
 // Dispatcher rollup scan. Skip quiescent goals (done/cancelled) so the bounded
 // window is spent only on goals rollup can still act on (running/blocked/failed
 // and pre-run states). failed is intentionally included - it is recoverable.
+// Archived goals are inert: excluding them stops rollup from silently recovering
+// an archived failed goal back to running while it stays hidden from default lists.
 func (q *Queries) ListAgentGoals(ctx context.Context, arg ListAgentGoalsParams) ([]AgentGoal, error) {
 	rows, err := q.db.QueryContext(ctx, listAgentGoals, arg.Limit, arg.Offset)
 	if err != nil {
@@ -217,16 +220,21 @@ func (q *Queries) ListAgentGoals(ctx context.Context, arg ListAgentGoalsParams) 
 const listAgentGoalsByUser = `-- name: ListAgentGoalsByUser :many
 SELECT id, user_id, agent_id, project_id, title, description, status, priority, review_policy, active_review_id, context, output, created_at, updated_at, completed_at, cancelled_at, archived_at FROM agent_goal
 WHERE user_id = ?1
-  AND archived_at IS NULL
-  AND (?2 IS NULL OR agent_id = ?2)
-  AND (?3 IS NULL OR status = ?3)
-  AND (?4 IS NULL OR project_id = ?4)
+  AND (
+    (?2 = 1 AND archived_at IS NOT NULL)
+    OR (?2 IS NULL AND archived_at IS NULL)
+    OR (?2 = 0 AND archived_at IS NULL)
+  )
+  AND (?3 IS NULL OR agent_id = ?3)
+  AND (?4 IS NULL OR status = ?4)
+  AND (?5 IS NULL OR project_id = ?5)
 ORDER BY created_at DESC, id DESC
-LIMIT ?6 OFFSET ?5
+LIMIT ?7 OFFSET ?6
 `
 
 type ListAgentGoalsByUserParams struct {
 	UserID    string      `json:"user_id"`
+	Archived  interface{} `json:"archived"`
 	AgentID   interface{} `json:"agent_id"`
 	Status    interface{} `json:"status"`
 	ProjectID interface{} `json:"project_id"`
@@ -234,9 +242,12 @@ type ListAgentGoalsByUserParams struct {
 	Limit     int64       `json:"limit"`
 }
 
+// archived narg: NULL/false yields only active rows (archived_at IS NULL, the
+// default); true yields only archived rows (the history/restore view).
 func (q *Queries) ListAgentGoalsByUser(ctx context.Context, arg ListAgentGoalsByUserParams) ([]AgentGoal, error) {
 	rows, err := q.db.QueryContext(ctx, listAgentGoalsByUser,
 		arg.UserID,
+		arg.Archived,
 		arg.AgentID,
 		arg.Status,
 		arg.ProjectID,
@@ -548,6 +559,23 @@ func (q *Queries) TransitionAgentGoalStatus(ctx context.Context, arg TransitionA
 		arg.ID,
 		arg.Status_2,
 	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const unarchiveAgentGoal = `-- name: UnarchiveAgentGoal :execrows
+UPDATE agent_goal SET archived_at = NULL, updated_at = ? WHERE id = ? AND archived_at IS NOT NULL
+`
+
+type UnarchiveAgentGoalParams struct {
+	UpdatedAt string `json:"updated_at"`
+	ID        string `json:"id"`
+}
+
+func (q *Queries) UnarchiveAgentGoal(ctx context.Context, arg UnarchiveAgentGoalParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, unarchiveAgentGoal, arg.UpdatedAt, arg.ID)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/db/sqlc/agent_goal.sql.go
+++ b/pkg/db/sqlc/agent_goal.sql.go
@@ -10,6 +10,24 @@ import (
 	"database/sql"
 )
 
+const archiveAgentGoal = `-- name: ArchiveAgentGoal :execrows
+UPDATE agent_goal SET archived_at = ?, updated_at = ? WHERE id = ? AND archived_at IS NULL
+`
+
+type ArchiveAgentGoalParams struct {
+	ArchivedAt sql.NullString `json:"archived_at"`
+	UpdatedAt  string         `json:"updated_at"`
+	ID         string         `json:"id"`
+}
+
+func (q *Queries) ArchiveAgentGoal(ctx context.Context, arg ArchiveAgentGoalParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, archiveAgentGoal, arg.ArchivedAt, arg.UpdatedAt, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const createAgentGoal = `-- name: CreateAgentGoal :one
 
 INSERT INTO agent_goal (
@@ -17,7 +35,7 @@ INSERT INTO agent_goal (
     review_policy, context, output, created_at, updated_at
 )
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-RETURNING id, user_id, agent_id, project_id, title, description, status, priority, review_policy, active_review_id, context, output, created_at, updated_at, completed_at, cancelled_at
+RETURNING id, user_id, agent_id, project_id, title, description, status, priority, review_policy, active_review_id, context, output, created_at, updated_at, completed_at, cancelled_at, archived_at
 `
 
 type CreateAgentGoalParams struct {
@@ -71,12 +89,13 @@ func (q *Queries) CreateAgentGoal(ctx context.Context, arg CreateAgentGoalParams
 		&i.UpdatedAt,
 		&i.CompletedAt,
 		&i.CancelledAt,
+		&i.ArchivedAt,
 	)
 	return i, err
 }
 
 const getAgentGoal = `-- name: GetAgentGoal :one
-SELECT id, user_id, agent_id, project_id, title, description, status, priority, review_policy, active_review_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_goal WHERE id = ?
+SELECT id, user_id, agent_id, project_id, title, description, status, priority, review_policy, active_review_id, context, output, created_at, updated_at, completed_at, cancelled_at, archived_at FROM agent_goal WHERE id = ?
 `
 
 func (q *Queries) GetAgentGoal(ctx context.Context, id string) (AgentGoal, error) {
@@ -99,6 +118,7 @@ func (q *Queries) GetAgentGoal(ctx context.Context, id string) (AgentGoal, error
 		&i.UpdatedAt,
 		&i.CompletedAt,
 		&i.CancelledAt,
+		&i.ArchivedAt,
 	)
 	return i, err
 }
@@ -140,7 +160,7 @@ func (q *Queries) GoalChildCounts(ctx context.Context, goalID sql.NullString) (G
 }
 
 const listAgentGoals = `-- name: ListAgentGoals :many
-SELECT id, user_id, agent_id, project_id, title, description, status, priority, review_policy, active_review_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_goal
+SELECT id, user_id, agent_id, project_id, title, description, status, priority, review_policy, active_review_id, context, output, created_at, updated_at, completed_at, cancelled_at, archived_at FROM agent_goal
 WHERE status NOT IN ('done', 'cancelled')
 ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?
 `
@@ -179,6 +199,7 @@ func (q *Queries) ListAgentGoals(ctx context.Context, arg ListAgentGoalsParams) 
 			&i.UpdatedAt,
 			&i.CompletedAt,
 			&i.CancelledAt,
+			&i.ArchivedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -194,72 +215,33 @@ func (q *Queries) ListAgentGoals(ctx context.Context, arg ListAgentGoalsParams) 
 }
 
 const listAgentGoalsByUser = `-- name: ListAgentGoalsByUser :many
-SELECT id, user_id, agent_id, project_id, title, description, status, priority, review_policy, active_review_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_goal WHERE user_id = ? ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?
+SELECT id, user_id, agent_id, project_id, title, description, status, priority, review_policy, active_review_id, context, output, created_at, updated_at, completed_at, cancelled_at, archived_at FROM agent_goal
+WHERE user_id = ?1
+  AND archived_at IS NULL
+  AND (?2 IS NULL OR agent_id = ?2)
+  AND (?3 IS NULL OR status = ?3)
+  AND (?4 IS NULL OR project_id = ?4)
+ORDER BY created_at DESC, id DESC
+LIMIT ?6 OFFSET ?5
 `
 
 type ListAgentGoalsByUserParams struct {
-	UserID string `json:"user_id"`
-	Limit  int64  `json:"limit"`
-	Offset int64  `json:"offset"`
+	UserID    string      `json:"user_id"`
+	AgentID   interface{} `json:"agent_id"`
+	Status    interface{} `json:"status"`
+	ProjectID interface{} `json:"project_id"`
+	Offset    int64       `json:"offset"`
+	Limit     int64       `json:"limit"`
 }
 
 func (q *Queries) ListAgentGoalsByUser(ctx context.Context, arg ListAgentGoalsByUserParams) ([]AgentGoal, error) {
-	rows, err := q.db.QueryContext(ctx, listAgentGoalsByUser, arg.UserID, arg.Limit, arg.Offset)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []AgentGoal{}
-	for rows.Next() {
-		var i AgentGoal
-		if err := rows.Scan(
-			&i.ID,
-			&i.UserID,
-			&i.AgentID,
-			&i.ProjectID,
-			&i.Title,
-			&i.Description,
-			&i.Status,
-			&i.Priority,
-			&i.ReviewPolicy,
-			&i.ActiveReviewID,
-			&i.Context,
-			&i.Output,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.CompletedAt,
-			&i.CancelledAt,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listAgentGoalsByUserAndAgent = `-- name: ListAgentGoalsByUserAndAgent :many
-SELECT id, user_id, agent_id, project_id, title, description, status, priority, review_policy, active_review_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_goal WHERE user_id = ? AND agent_id = ? ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?
-`
-
-type ListAgentGoalsByUserAndAgentParams struct {
-	UserID  string `json:"user_id"`
-	AgentID string `json:"agent_id"`
-	Limit   int64  `json:"limit"`
-	Offset  int64  `json:"offset"`
-}
-
-func (q *Queries) ListAgentGoalsByUserAndAgent(ctx context.Context, arg ListAgentGoalsByUserAndAgentParams) ([]AgentGoal, error) {
-	rows, err := q.db.QueryContext(ctx, listAgentGoalsByUserAndAgent,
+	rows, err := q.db.QueryContext(ctx, listAgentGoalsByUser,
 		arg.UserID,
 		arg.AgentID,
-		arg.Limit,
+		arg.Status,
+		arg.ProjectID,
 		arg.Offset,
+		arg.Limit,
 	)
 	if err != nil {
 		return nil, err
@@ -285,6 +267,7 @@ func (q *Queries) ListAgentGoalsByUserAndAgent(ctx context.Context, arg ListAgen
 			&i.UpdatedAt,
 			&i.CompletedAt,
 			&i.CancelledAt,
+			&i.ArchivedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -300,7 +283,7 @@ func (q *Queries) ListAgentGoalsByUserAndAgent(ctx context.Context, arg ListAgen
 }
 
 const listChildrenByGoal = `-- name: ListChildrenByGoal :many
-SELECT id, user_id, agent_id, session_id, goal_id, project_id, title, description, status, priority, review_policy, active_review_id, required, retry_count, max_retries, not_before, deadline_at, active_run_id, active_blocker_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_task WHERE goal_id = ? ORDER BY created_at ASC
+SELECT id, user_id, agent_id, session_id, goal_id, project_id, title, description, status, priority, review_policy, active_review_id, required, retry_count, max_retries, not_before, deadline_at, active_run_id, active_blocker_id, context, output, created_at, updated_at, completed_at, cancelled_at, archived_at FROM agent_task WHERE goal_id = ? ORDER BY created_at ASC
 `
 
 func (q *Queries) ListChildrenByGoal(ctx context.Context, goalID sql.NullString) ([]AgentTask, error) {
@@ -338,6 +321,7 @@ func (q *Queries) ListChildrenByGoal(ctx context.Context, goalID sql.NullString)
 			&i.UpdatedAt,
 			&i.CompletedAt,
 			&i.CancelledAt,
+			&i.ArchivedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -353,7 +337,7 @@ func (q *Queries) ListChildrenByGoal(ctx context.Context, goalID sql.NullString)
 }
 
 const listChildrenByGoalPaged = `-- name: ListChildrenByGoalPaged :many
-SELECT id, user_id, agent_id, session_id, goal_id, project_id, title, description, status, priority, review_policy, active_review_id, required, retry_count, max_retries, not_before, deadline_at, active_run_id, active_blocker_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_task WHERE goal_id = ? ORDER BY created_at ASC, id ASC LIMIT ? OFFSET ?
+SELECT id, user_id, agent_id, session_id, goal_id, project_id, title, description, status, priority, review_policy, active_review_id, required, retry_count, max_retries, not_before, deadline_at, active_run_id, active_blocker_id, context, output, created_at, updated_at, completed_at, cancelled_at, archived_at FROM agent_task WHERE goal_id = ? ORDER BY created_at ASC, id ASC LIMIT ? OFFSET ?
 `
 
 type ListChildrenByGoalPagedParams struct {
@@ -397,6 +381,7 @@ func (q *Queries) ListChildrenByGoalPaged(ctx context.Context, arg ListChildrenB
 			&i.UpdatedAt,
 			&i.CompletedAt,
 			&i.CancelledAt,
+			&i.ArchivedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -412,7 +397,7 @@ func (q *Queries) ListChildrenByGoalPaged(ctx context.Context, arg ListChildrenB
 }
 
 const listGoalPlanningCandidates = `-- name: ListGoalPlanningCandidates :many
-SELECT id, user_id, agent_id, project_id, title, description, status, priority, review_policy, active_review_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_goal
+SELECT id, user_id, agent_id, project_id, title, description, status, priority, review_policy, active_review_id, context, output, created_at, updated_at, completed_at, cancelled_at, archived_at FROM agent_goal
 WHERE status = 'draft'
 ORDER BY priority DESC, created_at ASC
 LIMIT ?
@@ -444,6 +429,7 @@ func (q *Queries) ListGoalPlanningCandidates(ctx context.Context, limit int64) (
 			&i.UpdatedAt,
 			&i.CompletedAt,
 			&i.CancelledAt,
+			&i.ArchivedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -459,7 +445,7 @@ func (q *Queries) ListGoalPlanningCandidates(ctx context.Context, limit int64) (
 }
 
 const listGoalSynthesisCandidates = `-- name: ListGoalSynthesisCandidates :many
-SELECT id, user_id, agent_id, project_id, title, description, status, priority, review_policy, active_review_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_goal
+SELECT id, user_id, agent_id, project_id, title, description, status, priority, review_policy, active_review_id, context, output, created_at, updated_at, completed_at, cancelled_at, archived_at FROM agent_goal
 WHERE status = 'running' AND review_policy != 'none'
 ORDER BY priority DESC, updated_at ASC
 LIMIT ?
@@ -491,6 +477,7 @@ func (q *Queries) ListGoalSynthesisCandidates(ctx context.Context, limit int64) 
 			&i.UpdatedAt,
 			&i.CompletedAt,
 			&i.CancelledAt,
+			&i.ArchivedAt,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/db/sqlc/agent_goal.sql.go
+++ b/pkg/db/sqlc/agent_goal.sql.go
@@ -28,6 +28,57 @@ func (q *Queries) ArchiveAgentGoal(ctx context.Context, arg ArchiveAgentGoalPara
 	return result.RowsAffected()
 }
 
+const countAgentGoalsByUser = `-- name: CountAgentGoalsByUser :one
+SELECT COUNT(*) FROM agent_goal
+WHERE user_id = ?1
+  AND (
+    (?2 = 1 AND archived_at IS NOT NULL)
+    OR (?2 IS NULL AND archived_at IS NULL)
+    OR (?2 = 0 AND archived_at IS NULL)
+  )
+  AND (?3 IS NULL OR agent_id = ?3)
+  AND (?4 IS NULL OR status = ?4)
+  AND (?5 IS NULL OR project_id = ?5)
+  AND (
+    ?6 IS NULL
+    OR (?6 = 1 AND status IN ('done', 'failed', 'cancelled'))
+    OR (?6 = 0 AND status NOT IN ('done', 'failed', 'cancelled'))
+  )
+  AND (
+    ?7 IS NULL
+    OR instr(lower(title), lower(?7)) > 0
+    OR instr(lower(description), lower(?7)) > 0
+  )
+`
+
+type CountAgentGoalsByUserParams struct {
+	UserID    string      `json:"user_id"`
+	Archived  interface{} `json:"archived"`
+	AgentID   interface{} `json:"agent_id"`
+	Status    interface{} `json:"status"`
+	ProjectID interface{} `json:"project_id"`
+	Terminal  interface{} `json:"terminal"`
+	Search    interface{} `json:"search"`
+}
+
+// CountAgentGoalsByUser returns the total rows matching the same filters as
+// ListAgentGoalsByUser (ignoring pagination), so the UI can render numbered
+// pages and per-mode count badges from server-side state.
+func (q *Queries) CountAgentGoalsByUser(ctx context.Context, arg CountAgentGoalsByUserParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countAgentGoalsByUser,
+		arg.UserID,
+		arg.Archived,
+		arg.AgentID,
+		arg.Status,
+		arg.ProjectID,
+		arg.Terminal,
+		arg.Search,
+	)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const createAgentGoal = `-- name: CreateAgentGoal :one
 
 INSERT INTO agent_goal (
@@ -228,8 +279,18 @@ WHERE user_id = ?1
   AND (?3 IS NULL OR agent_id = ?3)
   AND (?4 IS NULL OR status = ?4)
   AND (?5 IS NULL OR project_id = ?5)
+  AND (
+    ?6 IS NULL
+    OR (?6 = 1 AND status IN ('done', 'failed', 'cancelled'))
+    OR (?6 = 0 AND status NOT IN ('done', 'failed', 'cancelled'))
+  )
+  AND (
+    ?7 IS NULL
+    OR instr(lower(title), lower(?7)) > 0
+    OR instr(lower(description), lower(?7)) > 0
+  )
 ORDER BY created_at DESC, id DESC
-LIMIT ?7 OFFSET ?6
+LIMIT ?9 OFFSET ?8
 `
 
 type ListAgentGoalsByUserParams struct {
@@ -238,12 +299,18 @@ type ListAgentGoalsByUserParams struct {
 	AgentID   interface{} `json:"agent_id"`
 	Status    interface{} `json:"status"`
 	ProjectID interface{} `json:"project_id"`
+	Terminal  interface{} `json:"terminal"`
+	Search    interface{} `json:"search"`
 	Offset    int64       `json:"offset"`
 	Limit     int64       `json:"limit"`
 }
 
 // archived narg: NULL/false yields only active rows (archived_at IS NULL, the
 // default); true yields only archived rows (the history/restore view).
+// terminal narg: NULL matches any status; 1 keeps only terminal goals
+// (done/failed/cancelled, the history view); 0 keeps only non-terminal goals
+// (the active view). search narg is a case-insensitive substring matched against
+// title and description (NULL matches all).
 func (q *Queries) ListAgentGoalsByUser(ctx context.Context, arg ListAgentGoalsByUserParams) ([]AgentGoal, error) {
 	rows, err := q.db.QueryContext(ctx, listAgentGoalsByUser,
 		arg.UserID,
@@ -251,6 +318,8 @@ func (q *Queries) ListAgentGoalsByUser(ctx context.Context, arg ListAgentGoalsBy
 		arg.AgentID,
 		arg.Status,
 		arg.ProjectID,
+		arg.Terminal,
+		arg.Search,
 		arg.Offset,
 		arg.Limit,
 	)

--- a/pkg/db/sqlc/agent_task.sql.go
+++ b/pkg/db/sqlc/agent_task.sql.go
@@ -271,16 +271,21 @@ func (q *Queries) ListAgentTasks(ctx context.Context, arg ListAgentTasksParams) 
 const listAgentTasksByUser = `-- name: ListAgentTasksByUser :many
 SELECT id, user_id, agent_id, session_id, goal_id, project_id, title, description, status, priority, review_policy, active_review_id, required, retry_count, max_retries, not_before, deadline_at, active_run_id, active_blocker_id, context, output, created_at, updated_at, completed_at, cancelled_at, archived_at FROM agent_task
 WHERE user_id = ?1
-  AND archived_at IS NULL
-  AND (?2 IS NULL OR agent_id = ?2)
-  AND (?3 IS NULL OR status = ?3)
-  AND (?4 IS NULL OR project_id = ?4)
+  AND (
+    (?2 = 1 AND archived_at IS NOT NULL)
+    OR (?2 IS NULL AND archived_at IS NULL)
+    OR (?2 = 0 AND archived_at IS NULL)
+  )
+  AND (?3 IS NULL OR agent_id = ?3)
+  AND (?4 IS NULL OR status = ?4)
+  AND (?5 IS NULL OR project_id = ?5)
 ORDER BY created_at DESC, id DESC
-LIMIT ?6 OFFSET ?5
+LIMIT ?7 OFFSET ?6
 `
 
 type ListAgentTasksByUserParams struct {
 	UserID    string      `json:"user_id"`
+	Archived  interface{} `json:"archived"`
 	AgentID   interface{} `json:"agent_id"`
 	Status    interface{} `json:"status"`
 	ProjectID interface{} `json:"project_id"`
@@ -288,9 +293,13 @@ type ListAgentTasksByUserParams struct {
 	Limit     int64       `json:"limit"`
 }
 
+// archived narg mirrors ListAgentGoalsByUser: NULL/false yields only active rows
+// (archived_at IS NULL, the default); true yields only archived rows (the
+// history/restore view).
 func (q *Queries) ListAgentTasksByUser(ctx context.Context, arg ListAgentTasksByUserParams) ([]AgentTask, error) {
 	rows, err := q.db.QueryContext(ctx, listAgentTasksByUser,
 		arg.UserID,
+		arg.Archived,
 		arg.AgentID,
 		arg.Status,
 		arg.ProjectID,

--- a/pkg/db/sqlc/agent_task.sql.go
+++ b/pkg/db/sqlc/agent_task.sql.go
@@ -714,6 +714,23 @@ func (q *Queries) TransitionAgentTaskStatus(ctx context.Context, arg TransitionA
 	return result.RowsAffected()
 }
 
+const unarchiveAgentTask = `-- name: UnarchiveAgentTask :execrows
+UPDATE agent_task SET archived_at = NULL, updated_at = ? WHERE id = ? AND archived_at IS NOT NULL
+`
+
+type UnarchiveAgentTaskParams struct {
+	UpdatedAt string `json:"updated_at"`
+	ID        string `json:"id"`
+}
+
+func (q *Queries) UnarchiveAgentTask(ctx context.Context, arg UnarchiveAgentTaskParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, unarchiveAgentTask, arg.UpdatedAt, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const updateAgentTaskMeta = `-- name: UpdateAgentTaskMeta :exec
 UPDATE agent_task
 SET title = ?, description = ?, priority = ?, not_before = ?, deadline_at = ?,

--- a/pkg/db/sqlc/agent_task.sql.go
+++ b/pkg/db/sqlc/agent_task.sql.go
@@ -10,6 +10,24 @@ import (
 	"database/sql"
 )
 
+const archiveAgentTask = `-- name: ArchiveAgentTask :execrows
+UPDATE agent_task SET archived_at = ?, updated_at = ? WHERE id = ? AND archived_at IS NULL
+`
+
+type ArchiveAgentTaskParams struct {
+	ArchivedAt sql.NullString `json:"archived_at"`
+	UpdatedAt  string         `json:"updated_at"`
+	ID         string         `json:"id"`
+}
+
+func (q *Queries) ArchiveAgentTask(ctx context.Context, arg ArchiveAgentTaskParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, archiveAgentTask, arg.ArchivedAt, arg.UpdatedAt, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const claimAgentTask = `-- name: ClaimAgentTask :execrows
 UPDATE agent_task
 SET status = 'running',
@@ -54,7 +72,7 @@ INSERT INTO agent_task (
     context, output, created_at, updated_at
 )
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-RETURNING id, user_id, agent_id, session_id, goal_id, project_id, title, description, status, priority, review_policy, active_review_id, required, retry_count, max_retries, not_before, deadline_at, active_run_id, active_blocker_id, context, output, created_at, updated_at, completed_at, cancelled_at
+RETURNING id, user_id, agent_id, session_id, goal_id, project_id, title, description, status, priority, review_policy, active_review_id, required, retry_count, max_retries, not_before, deadline_at, active_run_id, active_blocker_id, context, output, created_at, updated_at, completed_at, cancelled_at, archived_at
 `
 
 type CreateAgentTaskParams struct {
@@ -132,21 +150,13 @@ func (q *Queries) CreateAgentTask(ctx context.Context, arg CreateAgentTaskParams
 		&i.UpdatedAt,
 		&i.CompletedAt,
 		&i.CancelledAt,
+		&i.ArchivedAt,
 	)
 	return i, err
 }
 
-const deleteAgentTask = `-- name: DeleteAgentTask :exec
-DELETE FROM agent_task WHERE id = ?
-`
-
-func (q *Queries) DeleteAgentTask(ctx context.Context, id string) error {
-	_, err := q.db.ExecContext(ctx, deleteAgentTask, id)
-	return err
-}
-
 const getAgentTask = `-- name: GetAgentTask :one
-SELECT id, user_id, agent_id, session_id, goal_id, project_id, title, description, status, priority, review_policy, active_review_id, required, retry_count, max_retries, not_before, deadline_at, active_run_id, active_blocker_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_task WHERE id = ?
+SELECT id, user_id, agent_id, session_id, goal_id, project_id, title, description, status, priority, review_policy, active_review_id, required, retry_count, max_retries, not_before, deadline_at, active_run_id, active_blocker_id, context, output, created_at, updated_at, completed_at, cancelled_at, archived_at FROM agent_task WHERE id = ?
 `
 
 func (q *Queries) GetAgentTask(ctx context.Context, id string) (AgentTask, error) {
@@ -178,6 +188,7 @@ func (q *Queries) GetAgentTask(ctx context.Context, id string) (AgentTask, error
 		&i.UpdatedAt,
 		&i.CompletedAt,
 		&i.CancelledAt,
+		&i.ArchivedAt,
 	)
 	return i, err
 }
@@ -199,7 +210,7 @@ func (q *Queries) IncrementAgentTaskRetry(ctx context.Context, arg IncrementAgen
 }
 
 const listAgentTasks = `-- name: ListAgentTasks :many
-SELECT id, user_id, agent_id, session_id, goal_id, project_id, title, description, status, priority, review_policy, active_review_id, required, retry_count, max_retries, not_before, deadline_at, active_run_id, active_blocker_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_task ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?
+SELECT id, user_id, agent_id, session_id, goal_id, project_id, title, description, status, priority, review_policy, active_review_id, required, retry_count, max_retries, not_before, deadline_at, active_run_id, active_blocker_id, context, output, created_at, updated_at, completed_at, cancelled_at, archived_at FROM agent_task ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?
 `
 
 type ListAgentTasksParams struct {
@@ -242,6 +253,7 @@ func (q *Queries) ListAgentTasks(ctx context.Context, arg ListAgentTasksParams) 
 			&i.UpdatedAt,
 			&i.CompletedAt,
 			&i.CancelledAt,
+			&i.ArchivedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -257,8 +269,9 @@ func (q *Queries) ListAgentTasks(ctx context.Context, arg ListAgentTasksParams) 
 }
 
 const listAgentTasksByUser = `-- name: ListAgentTasksByUser :many
-SELECT id, user_id, agent_id, session_id, goal_id, project_id, title, description, status, priority, review_policy, active_review_id, required, retry_count, max_retries, not_before, deadline_at, active_run_id, active_blocker_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_task
+SELECT id, user_id, agent_id, session_id, goal_id, project_id, title, description, status, priority, review_policy, active_review_id, required, retry_count, max_retries, not_before, deadline_at, active_run_id, active_blocker_id, context, output, created_at, updated_at, completed_at, cancelled_at, archived_at FROM agent_task
 WHERE user_id = ?1
+  AND archived_at IS NULL
   AND (?2 IS NULL OR agent_id = ?2)
   AND (?3 IS NULL OR status = ?3)
   AND (?4 IS NULL OR project_id = ?4)
@@ -317,6 +330,7 @@ func (q *Queries) ListAgentTasksByUser(ctx context.Context, arg ListAgentTasksBy
 			&i.UpdatedAt,
 			&i.CompletedAt,
 			&i.CancelledAt,
+			&i.ArchivedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -409,7 +423,7 @@ func (q *Queries) ListBlockedInboxTasks(ctx context.Context, arg ListBlockedInbo
 }
 
 const listReadyCandidates = `-- name: ListReadyCandidates :many
-SELECT id, user_id, agent_id, session_id, goal_id, project_id, title, description, status, priority, review_policy, active_review_id, required, retry_count, max_retries, not_before, deadline_at, active_run_id, active_blocker_id, context, output, created_at, updated_at, completed_at, cancelled_at FROM agent_task
+SELECT id, user_id, agent_id, session_id, goal_id, project_id, title, description, status, priority, review_policy, active_review_id, required, retry_count, max_retries, not_before, deadline_at, active_run_id, active_blocker_id, context, output, created_at, updated_at, completed_at, cancelled_at, archived_at FROM agent_task
 WHERE status = 'ready'
   AND active_run_id IS NULL
   AND (not_before IS NULL OR not_before <= ?)
@@ -459,6 +473,7 @@ func (q *Queries) ListReadyCandidates(ctx context.Context, arg ListReadyCandidat
 			&i.UpdatedAt,
 			&i.CompletedAt,
 			&i.CancelledAt,
+			&i.ArchivedAt,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/db/sqlc/agent_task_dep.sql.go
+++ b/pkg/db/sqlc/agent_task_dep.sql.go
@@ -306,7 +306,7 @@ WITH RECURSIVE downstream(id, depth) AS (
     JOIN downstream ds ON atd.dep_task_id = ds.id
     WHERE ds.depth < 1000
 )
-SELECT t.id, t.user_id, t.agent_id, t.session_id, t.goal_id, t.project_id, t.title, t.description, t.status, t.priority, t.review_policy, t.active_review_id, t.required, t.retry_count, t.max_retries, t.not_before, t.deadline_at, t.active_run_id, t.active_blocker_id, t.context, t.output, t.created_at, t.updated_at, t.completed_at, t.cancelled_at FROM agent_task t JOIN downstream ds ON t.id = ds.id
+SELECT t.id, t.user_id, t.agent_id, t.session_id, t.goal_id, t.project_id, t.title, t.description, t.status, t.priority, t.review_policy, t.active_review_id, t.required, t.retry_count, t.max_retries, t.not_before, t.deadline_at, t.active_run_id, t.active_blocker_id, t.context, t.output, t.created_at, t.updated_at, t.completed_at, t.cancelled_at, t.archived_at FROM agent_task t JOIN downstream ds ON t.id = ds.id
 `
 
 // Reachable downstream tasks of a given task (Slice 4 reopen cascade).
@@ -348,6 +348,7 @@ func (q *Queries) ListReachableDownstream(ctx context.Context, depTaskID string)
 			&i.UpdatedAt,
 			&i.CompletedAt,
 			&i.CancelledAt,
+			&i.ArchivedAt,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/db/sqlc/agent_task_event.sql.go
+++ b/pkg/db/sqlc/agent_task_event.sql.go
@@ -10,6 +10,24 @@ import (
 	"database/sql"
 )
 
+const getLatestGoalArchiveDetail = `-- name: GetLatestGoalArchiveDetail :one
+SELECT detail FROM agent_task_event
+WHERE goal_id = ? AND event_type = 'goal_archive'
+ORDER BY created_at DESC, id DESC
+LIMIT 1
+`
+
+// GetLatestGoalArchiveDetail returns the detail JSON of a goal's most recent
+// goal_archive event. UnarchiveGoal reads the archived_task_ids it recorded so it
+// restores exactly the children that cascade-archived, not ones the user hid on
+// their own. Returns ErrNoRows for goals archived before that detail was recorded.
+func (q *Queries) GetLatestGoalArchiveDetail(ctx context.Context, goalID sql.NullString) (string, error) {
+	row := q.db.QueryRowContext(ctx, getLatestGoalArchiveDetail, goalID)
+	var detail string
+	err := row.Scan(&detail)
+	return detail, err
+}
+
 const insertAgentTaskEvent = `-- name: InsertAgentTaskEvent :one
 
 INSERT INTO agent_task_event (

--- a/pkg/db/sqlc/models.go
+++ b/pkg/db/sqlc/models.go
@@ -46,6 +46,7 @@ type AgentGoal struct {
 	UpdatedAt      string         `json:"updated_at"`
 	CompletedAt    sql.NullString `json:"completed_at"`
 	CancelledAt    sql.NullString `json:"cancelled_at"`
+	ArchivedAt     sql.NullString `json:"archived_at"`
 }
 
 type AgentReview struct {
@@ -100,6 +101,7 @@ type AgentTask struct {
 	UpdatedAt       string         `json:"updated_at"`
 	CompletedAt     sql.NullString `json:"completed_at"`
 	CancelledAt     sql.NullString `json:"cancelled_at"`
+	ArchivedAt      sql.NullString `json:"archived_at"`
 }
 
 type AgentTaskBlocker struct {

--- a/web/content/docs/development/goal-system.md
+++ b/web/content/docs/development/goal-system.md
@@ -116,18 +116,28 @@ Use human task reviews when child task output needs approval. Goal-level synthes
 
 ## HTTP surface
 
-| Method | Path                                                                              | Purpose                                                                                      |
-| ------ | --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| `POST` | `/api/goals`                                                                      | Create a goal. Use `review_policy=none` in the supported runtime.                            |
-| `GET`  | `/api/goals`                                                                      | List goals.                                                                                  |
-| `GET`  | `/api/goals/{id}`                                                                 | Fetch one goal.                                                                              |
-| `POST` | `/api/goals/{id}/activate`                                                        | Draft → running; promotes draft children to ready.                                           |
-| `POST` | `/api/goals/{id}/cancel`                                                          | Cascade-cancel non-terminal children.                                                        |
-| `GET`  | `/api/goals/{id}/tasks`                                                           | List child tasks.                                                                            |
-| `GET`  | `/api/goals/{id}/reviews`                                                         | Schema-supported, but this release gates the goal review runtime off through API validation. |
-| `POST` | `/api/goals/{id}/reviews/{reviewID}/approve` (+reject, request-changes, escalate) | Review decision endpoints exist, but this release does not create a new goal review runtime. |
+| Method   | Path                                                                              | Purpose                                                                                                                                                                                                         |
+| -------- | --------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `POST`   | `/api/goals`                                                                      | Create a goal. Use `review_policy=none` in the supported runtime.                                                                                                                                               |
+| `GET`    | `/api/goals`                                                                      | List goals. Filters: `status`, `terminal` (true=done/failed/cancelled, false=active), `archived=true` (restore view), `q` (title/description substring). `total` in the response counts all matches for paging. |
+| `GET`    | `/api/goals/{id}`                                                                 | Fetch one goal.                                                                                                                                                                                                 |
+| `POST`   | `/api/goals/{id}/activate`                                                        | Draft → running; promotes draft children to ready.                                                                                                                                                              |
+| `POST`   | `/api/goals/{id}/cancel`                                                          | Cascade-cancel non-terminal children.                                                                                                                                                                           |
+| `DELETE` | `/api/goals/{id}`                                                                 | Archive a terminal/draft goal and its terminal/draft children (audit-safe; hides from default lists).                                                                                                           |
+| `POST`   | `/api/goals/{id}/unarchive`                                                       | Restore an archived goal and the children that archive hid, back to default lists.                                                                                                                              |
+| `GET`    | `/api/goals/{id}/tasks`                                                           | List child tasks.                                                                                                                                                                                               |
+| `GET`    | `/api/goals/{id}/reviews`                                                         | Schema-supported, but this release gates the goal review runtime off through API validation.                                                                                                                    |
+| `POST`   | `/api/goals/{id}/reviews/{reviewID}/approve` (+reject, request-changes, escalate) | Review decision endpoints exist, but this release does not create a new goal review runtime.                                                                                                                    |
 
 Any change that rejects unsupported goal review policies must be done spec-first.
+
+## Archiving and restore
+
+Archiving is an audit-safe soft delete: `DELETE /api/goals/{id}` stamps `archived_at` and hides the goal (and its terminal/draft children) from default lists without deleting history. It is only allowed from a terminal or draft status, and is idempotent — re-archiving an already-archived goal is a no-op.
+
+An archived goal is **inert**: every lifecycle transition (activate, complete, fail, cancel, block, unblock) and the dispatcher rollup scan reject or skip it, so hidden work is never silently revived. Unarchive first if you need to act on it again.
+
+`POST /api/goals/{id}/unarchive` reverses the archive. It restores only the children that _this_ goal's archive cascade hid — recorded in the `goal_archive` event — so a task the user archived independently beforehand stays hidden. Restoring a non-archived goal is a no-op. Standalone tasks have the mirror surface: `DELETE /api/tasks/{id}` archives, `GET /api/tasks?archived=true` lists, `POST /api/tasks/{id}/unarchive` restores.
 
 ## Future work
 

--- a/web/content/docs/development/goal-system.zh.md
+++ b/web/content/docs/development/goal-system.zh.md
@@ -116,18 +116,28 @@ Task-level review 仍然支持这些 policy：
 
 ## HTTP surface
 
-| Method | Path                                                                                   | Purpose                                                                  |
-| ------ | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `POST` | `/api/goals`                                                                           | 创建 goal。支持 runtime 中请使用 `review_policy=none`。                  |
-| `GET`  | `/api/goals`                                                                           | 列出 goals。                                                             |
-| `GET`  | `/api/goals/{id}`                                                                      | 获取单个 goal。                                                          |
-| `POST` | `/api/goals/{id}/activate`                                                             | Draft → running；把 draft children 提升到 ready。                        |
-| `POST` | `/api/goals/{id}/cancel`                                                               | 级联取消非终止 children。                                                |
-| `GET`  | `/api/goals/{id}/tasks`                                                                | 列出 child tasks。                                                       |
-| `GET`  | `/api/goals/{id}/reviews`                                                              | Schema 支持，但本版本通过 API validation gate off goal review runtime。  |
-| `POST` | `/api/goals/{id}/reviews/{reviewID}/approve`（以及 reject、request-changes、escalate） | Review decision endpoints 存在，但本版本不创建新的 goal review runtime。 |
+| Method   | Path                                                                                   | Purpose                                                                                                                                                                        |
+| -------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `POST`   | `/api/goals`                                                                           | 创建 goal。支持 runtime 中请使用 `review_policy=none`。                                                                                                                        |
+| `GET`    | `/api/goals`                                                                           | 列出 goals。过滤参数：`status`、`terminal`（true=done/failed/cancelled，false=活跃）、`archived=true`（恢复视图）、`q`（标题/描述子串）。响应含 `total` 统计全部匹配用于分页。 |
+| `GET`    | `/api/goals/{id}`                                                                      | 获取单个 goal。                                                                                                                                                                |
+| `POST`   | `/api/goals/{id}/activate`                                                             | Draft → running；把 draft children 提升到 ready。                                                                                                                              |
+| `POST`   | `/api/goals/{id}/cancel`                                                               | 级联取消非终止 children。                                                                                                                                                      |
+| `DELETE` | `/api/goals/{id}`                                                                      | 归档终止/draft goal 及其终止/draft children（审计安全，从默认列表隐藏）。                                                                                                      |
+| `POST`   | `/api/goals/{id}/unarchive`                                                            | 恢复已归档 goal 及随其归档的 children 回到默认列表。                                                                                                                           |
+| `GET`    | `/api/goals/{id}/tasks`                                                                | 列出 child tasks。                                                                                                                                                             |
+| `GET`    | `/api/goals/{id}/reviews`                                                              | Schema 支持，但本版本通过 API validation gate off goal review runtime。                                                                                                        |
+| `POST`   | `/api/goals/{id}/reviews/{reviewID}/approve`（以及 reject、request-changes、escalate） | Review decision endpoints 存在，但本版本不创建新的 goal review runtime。                                                                                                       |
 
 任何拒绝 unsupported goal review policy 的行为变化都必须 spec-first。
+
+## 归档与恢复
+
+归档是审计安全的软删除：`DELETE /api/goals/{id}` 写入 `archived_at`，把 goal（及其终止/draft children）从默认列表隐藏，但不删除历史。仅允许从终止或 draft 状态归档，且幂等——重复归档已归档 goal 为 no-op。
+
+已归档 goal 是**惰性**的：所有生命周期转换（activate、complete、fail、cancel、block、unblock）以及 dispatcher rollup 扫描都会拒绝或跳过它，因此隐藏的工作绝不会被悄悄复活。需要再操作时请先 unarchive。
+
+`POST /api/goals/{id}/unarchive` 反向归档，只恢复**本次** goal 归档级联隐藏的 children（记录在 `goal_archive` 事件里），用户此前单独归档的 task 保持隐藏。恢复未归档 goal 为 no-op。独立 task 有对称接口：`DELETE /api/tasks/{id}` 归档、`GET /api/tasks?archived=true` 列出、`POST /api/tasks/{id}/unarchive` 恢复。
 
 ## 后续工作
 

--- a/web/content/docs/development/task-system.md
+++ b/web/content/docs/development/task-system.md
@@ -209,10 +209,12 @@ Task routes are flat under `/api/tasks` and scoped by authenticated user context
 | Method         | Path                                                 | Purpose                                                                                                           |
 | -------------- | ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `POST`         | `/api/tasks`                                         | Create a task.                                                                                                    |
-| `GET`          | `/api/tasks`                                         | List tasks, optionally filtered by agent/status.                                                                  |
+| `GET`          | `/api/tasks`                                         | List tasks, optionally filtered by agent/status/project. `archived=true` returns the archived (restore) view.     |
 | `GET`          | `/api/tasks/{id}`                                    | Fetch a task.                                                                                                     |
+| `DELETE`       | `/api/tasks/{id}`                                    | Archive a terminal/draft task (audit-safe soft delete; hidden from default lists). Idempotent.                    |
+| `POST`         | `/api/tasks/{id}/unarchive`                          | Restore an archived task to default lists.                                                                        |
 | `POST`         | `/api/tasks/{id}/cancel`                             | Cancel a task.                                                                                                    |
-| `POST`         | `/api/tasks/{id}/reopen`                             | Reopen done/failed task.                                                                                          |
+| `POST`         | `/api/tasks/{id}/reopen`                             | Reopen done/failed task. Rejected for archived tasks — unarchive first.                                           |
 | `GET`          | `/api/tasks/{id}/readiness`                          | Explain dispatchability.                                                                                          |
 | `GET`          | `/api/tasks/{id}/events`                             | Audit events.                                                                                                     |
 | `GET`          | `/api/tasks/{id}/runs`                               | Run attempts.                                                                                                     |

--- a/web/content/docs/development/task-system.zh.md
+++ b/web/content/docs/development/task-system.zh.md
@@ -209,10 +209,12 @@ Task routes 扁平挂在 `/api/tasks` 下，并通过认证用户上下文限制
 | Method         | Path                                                 | Purpose                                                                                  |
 | -------------- | ---------------------------------------------------- | ---------------------------------------------------------------------------------------- |
 | `POST`         | `/api/tasks`                                         | 创建 task。                                                                              |
-| `GET`          | `/api/tasks`                                         | 列出 tasks，可按 agent/status 过滤。                                                     |
+| `GET`          | `/api/tasks`                                         | 列出 tasks，可按 agent/status/project 过滤。`archived=true` 返回已归档（恢复）视图。     |
 | `GET`          | `/api/tasks/{id}`                                    | 获取 task。                                                                              |
+| `DELETE`       | `/api/tasks/{id}`                                    | 归档终止/draft task（审计安全软删除，从默认列表隐藏）。幂等。                            |
+| `POST`         | `/api/tasks/{id}/unarchive`                          | 恢复已归档 task 回到默认列表。                                                           |
 | `POST`         | `/api/tasks/{id}/cancel`                             | 取消 task。                                                                              |
-| `POST`         | `/api/tasks/{id}/reopen`                             | 重新打开 done/failed task。                                                              |
+| `POST`         | `/api/tasks/{id}/reopen`                             | 重新打开 done/failed task。已归档 task 会被拒绝——请先 unarchive。                        |
 | `GET`          | `/api/tasks/{id}/readiness`                          | 解释可派发性。                                                                           |
 | `GET`          | `/api/tasks/{id}/events`                             | 审计事件。                                                                               |
 | `GET`          | `/api/tasks/{id}/runs`                               | 执行尝试。                                                                               |

--- a/web/src/features/tasks/GoalsPage.tsx
+++ b/web/src/features/tasks/GoalsPage.tsx
@@ -120,8 +120,11 @@ export function GoalsPage() {
   // Clamp the page after a bulk action (or a filter change) shrinks the result
   // set so the pager never points past the last page (CR-010).
   useEffect(() => {
-    if (page > totalPages) patch({ page: totalPages }, true);
-  }, [page, totalPages, patch]);
+    // Only clamp once a real total is loaded; clamping while isLoading would
+    // bounce a cold deep-link to ?page=N back to page 1 before its data arrives
+    // (CR-019).
+    if (!isLoading && page > totalPages) patch({ page: totalPages }, true);
+  }, [isLoading, page, totalPages, patch]);
 
   const runBulk = useCallback(async () => {
     const ids = selectedActionable.map((g) => g.id);

--- a/web/src/features/tasks/GoalsPage.tsx
+++ b/web/src/features/tasks/GoalsPage.tsx
@@ -1,5 +1,11 @@
-import { useCallback, useEffect } from "react";
-import { Columns3, Inbox, Table as TableIcon } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Archive,
+  Columns3,
+  Inbox,
+  Search,
+  Table as TableIcon,
+} from "lucide-react";
 import type { TFunction } from "i18next";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
@@ -11,9 +17,27 @@ import { formatTime } from "@/lib/time";
 import { cn } from "@/lib/utils";
 import { useAppShell } from "@/layouts/AppShell";
 import { Button } from "@/components/ui/button";
-import { StatusDot, StatusPill, avatarInitials, goalNeedsYou, statusLabel } from "./lib";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectItem,
+  SelectPopup,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  StatusDot,
+  StatusPill,
+  avatarInitials,
+  goalNeedsYou,
+  statusLabel,
+} from "./lib";
 
 export type GoalsView = "triage" | "board" | "table";
+type GoalsMode = "active" | "history";
+type GoalStatusFilter = "all" | ComponentsGoal["status"];
+
 const VIEWS: GoalsView[] = ["triage", "board", "table"];
 const VIEW_LABEL: Record<GoalsView, MessageKey> = {
   triage: "goals.viewTriage",
@@ -25,31 +49,131 @@ const VIEW_ICON: Record<GoalsView, typeof Inbox> = {
   board: Columns3,
   table: TableIcon,
 };
+const TERMINAL_STATUSES: ComponentsGoal["status"][] = [
+  "done",
+  "failed",
+  "cancelled",
+];
+const ACTIVE_STATUSES: ComponentsGoal["status"][] = [
+  "blocked",
+  "reviewing",
+  "running",
+  "planning",
+  "draft",
+];
+const PAGE_SIZE = 24;
 
 export function GoalsPage() {
   const { t } = useI18n();
   const { agentId } = useParams({ strict: false }) as { agentId: string };
   const search = useSearch({ strict: false });
-  const view = (search as Record<string, unknown>).view as string | undefined;
+  const rawSearch = search as Record<string, unknown>;
+  const view = rawSearch.view as string | undefined;
+  const modeParam = rawSearch.mode as string | undefined;
   const navigate = useNavigate();
   const { setHeaderTitle, setHeaderActions } = useAppShell();
   const { data: goals = [], isLoading } = useQuery(goalsOptions(agentId));
+  const [query, setQuery] = useState("");
+  const [status, setStatus] = useState<GoalStatusFilter>("all");
+  const [page, setPage] = useState(1);
+  const [selected, setSelected] = useState<Set<string>>(() => new Set());
+  const [hiddenIds, setHiddenIds] = useState<Set<string>>(() =>
+    readHiddenGoals(agentId),
+  );
 
-  const cur: GoalsView = VIEWS.includes(view as GoalsView) ? (view as GoalsView) : "triage";
+  const cur: GoalsView = VIEWS.includes(view as GoalsView)
+    ? (view as GoalsView)
+    : "triage";
+  const mode: GoalsMode = modeParam === "history" ? "history" : "active";
   const setView = useCallback(
     (v: GoalsView) =>
       void navigate({
         to: "/agents/$agentId/tasks/goals",
         params: { agentId },
-        search: { view: v } as Record<string, unknown>,
+        search: { ...rawSearch, view: v } as Record<string, unknown>,
       }),
-    [agentId, navigate],
+    [agentId, navigate, rawSearch],
+  );
+  const setMode = useCallback(
+    (m: GoalsMode) =>
+      void navigate({
+        to: "/agents/$agentId/tasks/goals",
+        params: { agentId },
+        search: { ...rawSearch, mode: m } as Record<string, unknown>,
+      }),
+    [agentId, navigate, rawSearch],
   );
   const openGoal = (g: ComponentsGoal) =>
     void navigate({
       to: "/agents/$agentId/tasks/goals/$goalId",
       params: { agentId, goalId: g.id },
     });
+
+  const visibleGoals = useMemo(
+    () => goals.filter((g) => !hiddenIds.has(g.id)),
+    [goals, hiddenIds],
+  );
+  const counts = useMemo(() => {
+    const active = visibleGoals.filter(
+      (g) => !TERMINAL_STATUSES.includes(g.status),
+    ).length;
+    const history = visibleGoals.length - active;
+    const needs = visibleGoals.filter(goalNeedsYou).length;
+    return { active, history, needs, hidden: hiddenIds.size };
+  }, [hiddenIds.size, visibleGoals]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return visibleGoals
+      .filter((g) =>
+        mode === "active"
+          ? !TERMINAL_STATUSES.includes(g.status)
+          : TERMINAL_STATUSES.includes(g.status),
+      )
+      .filter((g) => status === "all" || g.status === status)
+      .filter((g) => {
+        if (!q) return true;
+        return [g.title, g.description, g.agent_id, g.project_id]
+          .filter(Boolean)
+          .some((part) => String(part).toLowerCase().includes(q));
+      })
+      .sort(byUpdatedDesc);
+  }, [mode, query, status, visibleGoals]);
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const pageGoals = useMemo(() => {
+    const safePage = Math.min(page, totalPages);
+    const start = (safePage - 1) * PAGE_SIZE;
+    return filtered.slice(start, start + PAGE_SIZE);
+  }, [filtered, page, totalPages]);
+  const selectedTerminalCount = useMemo(
+    () =>
+      filtered.filter(
+        (g) => selected.has(g.id) && TERMINAL_STATUSES.includes(g.status),
+      ).length,
+    [filtered, selected],
+  );
+
+  useEffect(() => setPage(1), [mode, query, status, hiddenIds]);
+  useEffect(() => setSelected(new Set()), [mode, query, status]);
+  useEffect(() => setHiddenIds(readHiddenGoals(agentId)), [agentId]);
+
+  const hideSelectedTerminal = useCallback(() => {
+    const next = new Set(hiddenIds);
+    for (const g of filtered) {
+      if (selected.has(g.id) && TERMINAL_STATUSES.includes(g.status))
+        next.add(g.id);
+    }
+    setHiddenIds(next);
+    writeHiddenGoals(agentId, next);
+    setSelected(new Set());
+  }, [agentId, filtered, hiddenIds, selected]);
+
+  const restoreHidden = useCallback(() => {
+    const next = new Set<string>();
+    setHiddenIds(next);
+    writeHiddenGoals(agentId, next);
+  }, [agentId]);
 
   useEffect(() => {
     setHeaderTitle(
@@ -64,6 +188,29 @@ export function GoalsPage() {
     );
     setHeaderActions(
       <div className="flex items-center gap-1">
+        <Button
+          size="sm"
+          variant={mode === "active" ? "secondary" : "outline"}
+          aria-pressed={mode === "active"}
+          onClick={() => setMode("active")}
+        >
+          {t("goals.modeActive")}
+          <span className="font-mono text-xs text-muted-foreground">
+            {counts.active}
+          </span>
+        </Button>
+        <Button
+          size="sm"
+          variant={mode === "history" ? "secondary" : "outline"}
+          aria-pressed={mode === "history"}
+          onClick={() => setMode("history")}
+        >
+          <Archive />
+          <span className="max-sm:hidden">{t("goals.modeHistory")}</span>
+          <span className="font-mono text-xs text-muted-foreground">
+            {counts.history}
+          </span>
+        </Button>
         {VIEWS.map((v) => {
           const Icon = VIEW_ICON[v];
           return (
@@ -79,16 +226,23 @@ export function GoalsPage() {
             </Button>
           );
         })}
-        <span className="font-mono text-xs text-muted-foreground max-sm:hidden">
-          {t("goals.unit", { count: goals.length })}
-        </span>
       </div>,
     );
     return () => {
       setHeaderTitle(null);
       setHeaderActions(null);
     };
-  }, [cur, goals.length, setHeaderActions, setHeaderTitle, setView, t]);
+  }, [
+    counts.active,
+    counts.history,
+    cur,
+    mode,
+    setHeaderActions,
+    setHeaderTitle,
+    setMode,
+    setView,
+    t,
+  ]);
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-background">
@@ -101,10 +255,130 @@ export function GoalsPage() {
           <Empty />
         ) : (
           <div className="mx-auto max-w-[1140px] px-6 py-6">
-            {cur === "triage" && <Triage goals={goals} onOpen={openGoal} />}
-            {cur === "board" && <Board goals={goals} onOpen={openGoal} />}
-            {cur === "table" && <Table goals={goals} onOpen={openGoal} />}
+            <Toolbar
+              query={query}
+              status={status}
+              mode={mode}
+              total={filtered.length}
+              hiddenCount={counts.hidden}
+              selectedTerminalCount={selectedTerminalCount}
+              onQueryChange={setQuery}
+              onStatusChange={setStatus}
+              onHideSelected={hideSelectedTerminal}
+              onRestoreHidden={restoreHidden}
+            />
+            {filtered.length === 0 ? (
+              <FilteredEmpty />
+            ) : (
+              <>
+                {cur === "triage" && (
+                  <Triage
+                    goals={pageGoals}
+                    onOpen={openGoal}
+                    selected={selected}
+                    onSelect={setSelected}
+                  />
+                )}
+                {cur === "board" && (
+                  <Board
+                    goals={pageGoals}
+                    onOpen={openGoal}
+                    selected={selected}
+                    onSelect={setSelected}
+                  />
+                )}
+                {cur === "table" && (
+                  <Table
+                    goals={pageGoals}
+                    onOpen={openGoal}
+                    selected={selected}
+                    onSelect={setSelected}
+                  />
+                )}
+                <Pager
+                  page={page}
+                  totalPages={totalPages}
+                  total={filtered.length}
+                  onPage={setPage}
+                />
+              </>
+            )}
           </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Toolbar({
+  query,
+  status,
+  mode,
+  total,
+  hiddenCount,
+  selectedTerminalCount,
+  onQueryChange,
+  onStatusChange,
+  onHideSelected,
+  onRestoreHidden,
+}: {
+  query: string;
+  status: GoalStatusFilter;
+  mode: GoalsMode;
+  total: number;
+  hiddenCount: number;
+  selectedTerminalCount: number;
+  onQueryChange: (value: string) => void;
+  onStatusChange: (value: GoalStatusFilter) => void;
+  onHideSelected: () => void;
+  onRestoreHidden: () => void;
+}) {
+  const { t } = useI18n();
+  const statusOptions = mode === "active" ? ACTIVE_STATUSES : TERMINAL_STATUSES;
+  return (
+    <div className="mb-5 flex flex-col gap-3 rounded-2xl border border-border bg-card p-3 sm:flex-row sm:items-center">
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        <Search className="size-4 shrink-0 text-muted-foreground" />
+        <Input
+          value={query}
+          onChange={(e) => onQueryChange(e.target.value)}
+          placeholder={t("goals.searchPlaceholder")}
+          type="search"
+          size="sm"
+        />
+      </div>
+      <Select
+        value={status}
+        onValueChange={(value) => onStatusChange(value as GoalStatusFilter)}
+      >
+        <SelectTrigger size="sm" className="w-full sm:w-44">
+          <SelectValue placeholder={t("goals.statusAll")} />
+        </SelectTrigger>
+        <SelectPopup>
+          <SelectItem value="all">{t("goals.statusAll")}</SelectItem>
+          {statusOptions.map((s) => (
+            <SelectItem key={s} value={s}>
+              {statusLabel(t, s)}
+            </SelectItem>
+          ))}
+        </SelectPopup>
+      </Select>
+      <div className="flex items-center gap-2 sm:ml-auto">
+        <span className="font-mono text-xs text-muted-foreground">
+          {t("goals.filteredCount", { count: total })}
+        </span>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={selectedTerminalCount === 0}
+          onClick={onHideSelected}
+        >
+          {t("goals.hideSelected", { count: selectedTerminalCount })}
+        </Button>
+        {hiddenCount > 0 && (
+          <Button variant="ghost" size="sm" onClick={onRestoreHidden}>
+            {t("goals.restoreHidden", { count: hiddenCount })}
+          </Button>
         )}
       </div>
     </div>
@@ -115,8 +389,26 @@ function Empty() {
   const { t } = useI18n();
   return (
     <div className="flex flex-col items-center justify-center py-24 text-center">
-      <p className="text-sm font-medium text-muted-foreground">{t("goals.empty")}</p>
-      <p className="mt-1 max-w-xs text-xs text-muted-foreground">{t("goals.emptyDesc")}</p>
+      <p className="text-sm font-medium text-muted-foreground">
+        {t("goals.empty")}
+      </p>
+      <p className="mt-1 max-w-xs text-xs text-muted-foreground">
+        {t("goals.emptyDesc")}
+      </p>
+    </div>
+  );
+}
+
+function FilteredEmpty() {
+  const { t } = useI18n();
+  return (
+    <div className="flex flex-col items-center justify-center rounded-2xl border border-border py-16 text-center">
+      <p className="text-sm font-medium text-muted-foreground">
+        {t("goals.noMatches")}
+      </p>
+      <p className="mt-1 max-w-sm text-xs text-muted-foreground">
+        {t("goals.noMatchesDesc")}
+      </p>
     </div>
   );
 }
@@ -124,6 +416,12 @@ function Empty() {
 function hookText(t: TFunction, g: ComponentsGoal): string | null {
   if (g.status === "blocked") return t("goals.hookBlocked");
   if (g.status === "reviewing") return t("goals.hookReviewing");
+  if (g.status === "done")
+    return t("goals.hookAchieved", {
+      time: formatTime(g.completed_at ?? g.updated_at),
+    });
+  if (g.status === "failed") return t("goals.hookFailed");
+  if (g.status === "cancelled") return t("goals.hookCancelled");
   return null;
 }
 
@@ -133,23 +431,51 @@ const byUpdatedDesc = (a: ComponentsGoal, b: ComponentsGoal) =>
 interface ViewProps {
   goals: ComponentsGoal[];
   onOpen: (g: ComponentsGoal) => void;
+  selected: Set<string>;
+  onSelect: (next: Set<string>) => void;
 }
 
-function Triage({ goals, onOpen }: ViewProps) {
+function toggleSelected(
+  selected: Set<string>,
+  id: string,
+  onSelect: (next: Set<string>) => void,
+) {
+  const next = new Set(selected);
+  if (next.has(id)) next.delete(id);
+  else next.add(id);
+  onSelect(next);
+}
+
+function Triage({ goals, onOpen, selected, onSelect }: ViewProps) {
   const { t } = useI18n();
   const needs = goals.filter(goalNeedsYou).sort(byUpdatedDesc);
   const prog = goals
-    .filter((g) => g.status === "running" || g.status === "planning")
+    .filter(
+      (g) =>
+        g.status === "running" ||
+        g.status === "planning" ||
+        g.status === "draft",
+    )
     .sort(byUpdatedDesc);
   const closed = goals
-    .filter((g) => ["done", "failed", "cancelled", "draft"].includes(g.status))
+    .filter((g) => TERMINAL_STATUSES.includes(g.status))
     .sort(byUpdatedDesc);
 
-  const Section = ({ label, arr, dim }: { label: string; arr: ComponentsGoal[]; dim?: boolean }) =>
+  const Section = ({
+    label,
+    arr,
+    dim,
+  }: {
+    label: string;
+    arr: ComponentsGoal[];
+    dim?: boolean;
+  }) =>
     arr.length ? (
       <section className="mb-7">
         <div className="mb-3 flex items-center gap-2.5">
-          <span className="font-mono text-xs font-semibold text-muted-foreground">{label}</span>
+          <span className="font-mono text-xs font-semibold text-muted-foreground">
+            {label}
+          </span>
           <span className="rounded-full bg-muted px-2 py-0.5 font-mono text-xs text-muted-foreground">
             {arr.length}
           </span>
@@ -157,7 +483,14 @@ function Triage({ goals, onOpen }: ViewProps) {
         </div>
         <div className="space-y-2">
           {arr.map((g) => (
-            <Row key={g.id} g={g} onOpen={onOpen} dim={dim} />
+            <Row
+              key={g.id}
+              g={g}
+              onOpen={onOpen}
+              selected={selected.has(g.id)}
+              onSelect={() => toggleSelected(selected, g.id, onSelect)}
+              dim={dim}
+            />
           ))}
         </div>
       </section>
@@ -175,48 +508,68 @@ function Triage({ goals, onOpen }: ViewProps) {
 function Row({
   g,
   onOpen,
+  selected,
+  onSelect,
   dim,
 }: {
   g: ComponentsGoal;
   onOpen: (g: ComponentsGoal) => void;
+  selected: boolean;
+  onSelect: () => void;
   dim?: boolean;
 }) {
   const { t } = useI18n();
   const hook = hookText(t, g);
   const needs = goalNeedsYou(g);
   return (
-    <button
-      type="button"
-      onClick={() => onOpen(g)}
+    <div
       className={cn(
         "flex w-full items-center gap-3.5 rounded-2xl border bg-card px-4 py-3 text-left transition-shadow hover:shadow-md",
         needs ? "border-primary/30" : "border-border",
         dim && "opacity-65 hover:opacity-100",
       )}
     >
-      <StatusPill status={g.status} label={statusLabel(t, g.status)} />
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <span className="truncate font-serif text-[15px] font-semibold">{g.title}</span>
-          {g.priority === "urgent" && (
-            <span className="rounded-md border border-chart-4/25 bg-chart-4/10 px-1.5 py-0.5 font-mono text-xs font-medium text-chart-4">
-              urgent
+      <Checkbox
+        checked={selected}
+        onCheckedChange={onSelect}
+        aria-label={t("goals.selectGoal")}
+      />
+      <button
+        type="button"
+        onClick={() => onOpen(g)}
+        className="flex min-w-0 flex-1 items-center gap-3.5 text-left"
+      >
+        <StatusPill status={g.status} label={statusLabel(t, g.status)} />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="truncate font-serif text-[15px] font-semibold">
+              {g.title}
             </span>
-          )}
+            {g.status === "done" && (
+              <span className="rounded-md border border-chart-3/25 bg-chart-3/10 px-1.5 py-0.5 font-mono text-xs font-medium text-chart-3">
+                {t("goals.achieved")}
+              </span>
+            )}
+            {g.priority === "urgent" && (
+              <span className="rounded-md border border-chart-4/25 bg-chart-4/10 px-1.5 py-0.5 font-mono text-xs font-medium text-chart-4">
+                urgent
+              </span>
+            )}
+          </div>
+          <div
+            className={cn(
+              "mt-1 truncate text-[12.5px]",
+              hook ? "font-medium text-primary/90" : "text-muted-foreground",
+            )}
+          >
+            {hook ?? g.description ?? t("goals.progressHint")}
+          </div>
         </div>
-        <div
-          className={cn(
-            "mt-1 truncate text-[12.5px]",
-            hook ? "font-medium text-primary/90" : "text-muted-foreground",
-          )}
-        >
-          {hook ?? g.description ?? ""}
-        </div>
-      </div>
-      <span className="shrink-0 font-mono text-xs text-muted-foreground">
-        {formatTime(g.updated_at)}
-      </span>
-    </button>
+        <span className="shrink-0 font-mono text-xs text-muted-foreground">
+          {formatTime(g.updated_at)}
+        </span>
+      </button>
+    </div>
   );
 }
 
@@ -239,53 +592,81 @@ const BOARD_COLS: {
   {
     labelKey: "goals.colClosed",
     status: "done",
-    match: (g) => ["done", "failed", "cancelled"].includes(g.status),
+    match: (g) => TERMINAL_STATUSES.includes(g.status),
   },
 ];
 
-function Board({ goals, onOpen }: ViewProps) {
+function Board({ goals, onOpen, selected, onSelect }: ViewProps) {
   const { t } = useI18n();
   return (
     <div className="grid grid-cols-1 items-start gap-3.5 sm:grid-cols-2 lg:grid-cols-4">
       {BOARD_COLS.map((col) => {
         const items = goals.filter(col.match).sort(byUpdatedDesc);
         return (
-          <div key={col.labelKey} className="min-h-[180px] rounded-2xl bg-muted p-2.5">
+          <div
+            key={col.labelKey}
+            className="min-h-[180px] rounded-2xl bg-muted p-2.5"
+          >
             <div className="flex items-center gap-2 px-1.5 pb-2.5 pt-1">
               <StatusDot status={col.status} />
-              <span className="font-mono text-xs font-semibold">{t(col.labelKey)}</span>
+              <span className="font-mono text-xs font-semibold">
+                {t(col.labelKey)}
+              </span>
               <span className="ml-auto font-mono text-xs text-muted-foreground">
                 {items.length}
               </span>
             </div>
             <div className="space-y-2">
               {items.map((g) => (
-                <button
+                <div
                   key={g.id}
-                  type="button"
-                  onClick={() => onOpen(g)}
-                  className="block w-full rounded-xl border border-border bg-card px-3 py-2.5 text-left transition-shadow hover:shadow-md"
+                  className="rounded-xl border border-border bg-card px-3 py-2.5 transition-shadow hover:shadow-md"
                 >
-                  <div className="font-serif text-[13.5px] font-semibold leading-snug">
-                    {g.title}
+                  <div className="mb-2 flex items-center gap-2">
+                    <Checkbox
+                      checked={selected.has(g.id)}
+                      onCheckedChange={() =>
+                        toggleSelected(selected, g.id, onSelect)
+                      }
+                      aria-label={t("goals.selectGoal")}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => onOpen(g)}
+                      className="min-w-0 flex-1 text-left"
+                    >
+                      <div className="truncate font-serif text-[13.5px] font-semibold leading-snug">
+                        {g.title}
+                      </div>
+                    </button>
                   </div>
-                  <div className="mt-2 flex flex-wrap items-center gap-1.5">
-                    <StatusPill status={g.status} label={statusLabel(t, g.status)} />
+                  <div className="flex flex-wrap items-center gap-1.5">
+                    <StatusPill
+                      status={g.status}
+                      label={statusLabel(t, g.status)}
+                    />
+                    {g.status === "done" && (
+                      <span className="rounded-md border border-chart-3/25 bg-chart-3/10 px-1.5 py-0.5 font-mono text-xs font-medium text-chart-3">
+                        {t("goals.achieved")}
+                      </span>
+                    )}
                     {g.priority === "urgent" && (
                       <span className="rounded-md border border-chart-4/25 bg-chart-4/10 px-1.5 py-0.5 font-mono text-xs font-medium text-chart-4">
                         urgent
                       </span>
                     )}
                   </div>
-                  {goalNeedsYou(g) && (
+                  {hookText(t, g) && (
                     <div className="mt-1.5 text-[11.5px] font-medium text-primary/90">
                       {hookText(t, g)}
                     </div>
                   )}
-                </button>
+                </div>
               ))}
               {!items.length && (
-                <div className="py-5 text-center text-xs text-muted-foreground">—</div>
+                <div className="py-5 text-center text-xs text-muted-foreground">
+                  —
+                </div>
               )}
             </div>
           </div>
@@ -306,7 +687,7 @@ const TABLE_ORDER = [
   "cancelled",
 ];
 
-function Table({ goals, onOpen }: ViewProps) {
+function Table({ goals, onOpen, selected, onSelect }: ViewProps) {
   const { t } = useI18n();
   const rows = [...goals].sort(
     (a, b) => TABLE_ORDER.indexOf(a.status) - TABLE_ORDER.indexOf(b.status),
@@ -316,24 +697,52 @@ function Table({ goals, onOpen }: ViewProps) {
       <table className="w-full border-collapse">
         <thead>
           <tr className="border-b border-border bg-muted/50 text-left font-mono text-[10.5px] text-muted-foreground">
-            <th className="w-[120px] px-3.5 py-2.5 font-semibold">{t("goals.colStatus")}</th>
-            <th className="px-3.5 py-2.5 font-semibold">{t("goals.colGoal")}</th>
-            <th className="w-[120px] px-3.5 py-2.5 font-semibold">{t("goals.colAttention")}</th>
-            <th className="w-[150px] px-3.5 py-2.5 font-semibold">{t("goals.colAgent")}</th>
-            <th className="w-[90px] px-3.5 py-2.5 font-semibold">{t("goals.colUpdated")}</th>
+            <th className="w-[42px] px-3.5 py-2.5 font-semibold" />
+            <th className="w-[120px] px-3.5 py-2.5 font-semibold">
+              {t("goals.colStatus")}
+            </th>
+            <th className="px-3.5 py-2.5 font-semibold">
+              {t("goals.colGoal")}
+            </th>
+            <th className="w-[120px] px-3.5 py-2.5 font-semibold">
+              {t("goals.colAttention")}
+            </th>
+            <th className="w-[150px] px-3.5 py-2.5 font-semibold">
+              {t("goals.colAgent")}
+            </th>
+            <th className="w-[90px] px-3.5 py-2.5 font-semibold">
+              {t("goals.colUpdated")}
+            </th>
           </tr>
         </thead>
         <tbody>
           {rows.map((g) => (
             <tr
               key={g.id}
-              onClick={() => onOpen(g)}
-              className="cursor-pointer border-b border-border last:border-0 hover:bg-accent/40"
+              className="border-b border-border last:border-0 hover:bg-accent/40"
             >
               <td className="px-3.5 py-3">
-                <StatusPill status={g.status} label={statusLabel(t, g.status)} />
+                <Checkbox
+                  checked={selected.has(g.id)}
+                  onCheckedChange={() =>
+                    toggleSelected(selected, g.id, onSelect)
+                  }
+                  aria-label={t("goals.selectGoal")}
+                />
               </td>
-              <td className="px-3.5 py-3">
+              <td
+                className="cursor-pointer px-3.5 py-3"
+                onClick={() => onOpen(g)}
+              >
+                <StatusPill
+                  status={g.status}
+                  label={statusLabel(t, g.status)}
+                />
+              </td>
+              <td
+                className="cursor-pointer px-3.5 py-3"
+                onClick={() => onOpen(g)}
+              >
                 <div className="font-medium">{g.title}</div>
                 {g.description && (
                   <div className="mt-0.5 truncate text-[11.5px] text-muted-foreground">
@@ -344,14 +753,22 @@ function Table({ goals, onOpen }: ViewProps) {
               <td className="px-3.5 py-3">
                 {goalNeedsYou(g) ? (
                   <span className="rounded-md border border-primary/25 bg-primary/10 px-2 py-0.5 font-mono text-xs font-medium text-primary">
-                    {g.status === "blocked" ? t("goals.actUnblock") : t("goals.actReview")}
+                    {g.status === "blocked"
+                      ? t("goals.actUnblock")
+                      : t("goals.actReview")}
+                  </span>
+                ) : g.status === "done" ? (
+                  <span className="rounded-md border border-chart-3/25 bg-chart-3/10 px-2 py-0.5 font-mono text-xs font-medium text-chart-3">
+                    {t("goals.achieved")}
                   </span>
                 ) : g.priority === "urgent" ? (
                   <span className="rounded-md border border-chart-4/25 bg-chart-4/10 px-2 py-0.5 font-mono text-xs font-medium text-chart-4">
                     urgent
                   </span>
                 ) : (
-                  <span className="font-mono text-xs text-muted-foreground">—</span>
+                  <span className="font-mono text-xs text-muted-foreground">
+                    —
+                  </span>
                 )}
               </td>
               <td className="px-3.5 py-3">
@@ -362,7 +779,9 @@ function Table({ goals, onOpen }: ViewProps) {
                     </span>
                   </span>
                 ) : (
-                  <span className="font-mono text-xs text-muted-foreground">—</span>
+                  <span className="font-mono text-xs text-muted-foreground">
+                    —
+                  </span>
                 )}
               </td>
               <td className="px-3.5 py-3">
@@ -375,5 +794,70 @@ function Table({ goals, onOpen }: ViewProps) {
         </tbody>
       </table>
     </div>
+  );
+}
+
+function Pager({
+  page,
+  totalPages,
+  total,
+  onPage,
+}: {
+  page: number;
+  totalPages: number;
+  total: number;
+  onPage: (page: number) => void;
+}) {
+  const { t } = useI18n();
+  if (totalPages <= 1) return null;
+  return (
+    <div className="mt-5 flex items-center justify-between gap-3">
+      <span className="font-mono text-xs text-muted-foreground">
+        {t("goals.pageStatus", { page, totalPages, total })}
+      </span>
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={page <= 1}
+          onClick={() => onPage(page - 1)}
+        >
+          {t("common.back")}
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={page >= totalPages}
+          onClick={() => onPage(page + 1)}
+        >
+          {t("common.next")}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function hiddenStorageKey(agentId: string): string {
+  return `stella:hidden-goals:${agentId}`;
+}
+
+function readHiddenGoals(agentId: string): Set<string> {
+  if (typeof window === "undefined") return new Set();
+  try {
+    const raw = window.localStorage.getItem(hiddenStorageKey(agentId));
+    const parsed = raw ? (JSON.parse(raw) as string[]) : [];
+    return new Set(
+      Array.isArray(parsed) ? parsed.filter((x) => typeof x === "string") : [],
+    );
+  } catch {
+    return new Set();
+  }
+}
+
+function writeHiddenGoals(agentId: string, ids: Set<string>) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(
+    hiddenStorageKey(agentId),
+    JSON.stringify([...ids]),
   );
 }

--- a/web/src/features/tasks/GoalsPage.tsx
+++ b/web/src/features/tasks/GoalsPage.tsx
@@ -5,7 +5,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { deleteGoal, unarchiveGoal } from "@/lib/api-client";
 import type { ComponentsGoal } from "@/lib/api-client/types.gen";
-import { goalsOptions } from "@/lib/queries/goals";
+import { GOALS_PAGE_SIZE, goalCountsOptions, goalsPageOptions } from "@/lib/queries/goals";
 import { useI18n } from "@/lib/i18n";
 import type { MessageKey } from "@/lib/i18n/messages";
 import { formatTime } from "@/lib/time";
@@ -46,7 +46,6 @@ const ACTIVE_STATUSES: ComponentsGoal["status"][] = [
   "planning",
   "draft",
 ];
-const PAGE_SIZE = 24;
 
 export function GoalsPage() {
   const { t } = useI18n();
@@ -58,87 +57,71 @@ export function GoalsPage() {
   const navigate = useNavigate();
   const qc = useQueryClient();
   const { setHeaderTitle, setHeaderActions } = useAppShell();
-  const { data: activeGoals = [], isLoading } = useQuery(goalsOptions(agentId));
-  const { data: archivedGoals = [] } = useQuery(goalsOptions(agentId, true));
-  const [query, setQuery] = useState("");
-  const [status, setStatus] = useState<GoalStatusFilter>("all");
-  const [page, setPage] = useState(1);
-  const [selected, setSelected] = useState<Set<string>>(() => new Set());
-  const [acting, setActing] = useState(false);
 
+  // URL params are the source of truth for mode, status, search, and page so the
+  // view is shareable and survives refresh/back-forward.
   const cur: GoalsView = VIEWS.includes(view as GoalsView) ? (view as GoalsView) : "triage";
   const mode: GoalsMode =
     modeParam === "history" ? "history" : modeParam === "archived" ? "archived" : "active";
-  const source = mode === "archived" ? archivedGoals : activeGoals;
-  const setView = useCallback(
-    (v: GoalsView) =>
+  const status = ((rawSearch.status as string) || "all") as GoalStatusFilter;
+  const query = (rawSearch.q as string) || "";
+  const page = Math.max(1, Number(rawSearch.page) || 1);
+  const [selected, setSelected] = useState<Set<string>>(() => new Set());
+  const [acting, setActing] = useState(false);
+
+  // Mode maps to the server's archived/terminal filters: active = non-terminal &
+  // not archived, history = terminal & not archived, archived = archived rows.
+  const archived = mode === "archived";
+  const terminal = mode === "active" ? false : mode === "history" ? true : undefined;
+
+  const { data: counts } = useQuery(goalCountsOptions(agentId));
+  const c = counts ?? { active: 0, history: 0, archived: 0 };
+  const { data: pageData, isLoading } = useQuery(
+    goalsPageOptions({
+      agentId,
+      archived,
+      terminal,
+      status: status === "all" ? undefined : status,
+      q: query || undefined,
+      page,
+    }),
+  );
+  const goals = pageData?.goals ?? [];
+  const total = pageData?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / GOALS_PAGE_SIZE));
+
+  const patch = useCallback(
+    (next: Record<string, unknown>, replace = false) =>
       void navigate({
         to: "/agents/$agentId/tasks/goals",
         params: { agentId },
-        search: { ...rawSearch, view: v } as Record<string, unknown>,
+        search: { ...rawSearch, ...next } as Record<string, unknown>,
+        replace,
       }),
     [agentId, navigate, rawSearch],
   );
-  const setMode = useCallback(
-    (m: GoalsMode) =>
-      void navigate({
-        to: "/agents/$agentId/tasks/goals",
-        params: { agentId },
-        search: { ...rawSearch, mode: m } as Record<string, unknown>,
-      }),
-    [agentId, navigate, rawSearch],
-  );
+  const setView = useCallback((v: GoalsView) => patch({ view: v }), [patch]);
+  const setMode = useCallback((m: GoalsMode) => patch({ mode: m, page: 1 }), [patch]);
   const openGoal = (g: ComponentsGoal) =>
     void navigate({
       to: "/agents/$agentId/tasks/goals/$goalId",
       params: { agentId, goalId: g.id },
     });
 
-  const counts = useMemo(() => {
-    const active = activeGoals.filter((g) => !TERMINAL_STATUSES.includes(g.status)).length;
-    const history = activeGoals.length - active;
-    const needs = activeGoals.filter(goalNeedsYou).length;
-    return { active, history, needs, archived: archivedGoals.length };
-  }, [activeGoals, archivedGoals.length]);
-
-  const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    return source
-      .filter((g) => {
-        if (mode === "active") return !TERMINAL_STATUSES.includes(g.status);
-        if (mode === "history") return TERMINAL_STATUSES.includes(g.status);
-        return true; // archived mode: the server already scoped to archived rows
-      })
-      .filter((g) => status === "all" || g.status === status)
-      .filter((g) => {
-        if (!q) return true;
-        return [g.title, g.description, g.agent_id, g.project_id]
-          .filter(Boolean)
-          .some((part) => String(part).toLowerCase().includes(q));
-      })
-      .sort(byUpdatedDesc);
-  }, [mode, query, status, source]);
-
-  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
-  const pageGoals = useMemo(() => {
-    const safePage = Math.min(page, totalPages);
-    const start = (safePage - 1) * PAGE_SIZE;
-    return filtered.slice(start, start + PAGE_SIZE);
-  }, [filtered, page, totalPages]);
-
   // History archives the selected terminal goals; the archived view restores them.
-  // Active goals are never bulk-actionable (they are not yet finished).
-  const selectedActionable = useMemo(() => {
-    if (mode === "history")
-      return filtered.filter((g) => selected.has(g.id) && TERMINAL_STATUSES.includes(g.status));
-    if (mode === "archived") return filtered.filter((g) => selected.has(g.id));
-    return [];
-  }, [filtered, selected, mode]);
+  // The server already scopes each mode, so every selected row on the page is
+  // actionable. Active goals are never bulk-actionable (they are not yet finished).
+  const selectedActionable = useMemo(
+    () => (mode === "active" ? [] : goals.filter((g) => selected.has(g.id))),
+    [goals, selected, mode],
+  );
 
-  useEffect(() => setPage(1), [mode, query, status]);
-  useEffect(() => setSelected(new Set()), [mode, query, status]);
-  // Keep the page in range after a bulk action shrinks the result set (CR-010).
-  useEffect(() => setPage((p) => Math.min(Math.max(1, p), totalPages)), [totalPages]);
+  useEffect(() => setSelected(new Set()), [mode, query, status, page]);
+  // Clamp the page after a bulk action (or a filter change) shrinks the result
+  // set so the pager never points past the last page (CR-010).
+  useEffect(() => {
+    if (page > totalPages) patch({ page: totalPages }, true);
+  }, [page, totalPages, patch]);
 
   const runBulk = useCallback(async () => {
     const ids = selectedActionable.map((g) => g.id);
@@ -152,7 +135,11 @@ export function GoalsPage() {
             : deleteGoal({ path: { goalId }, throwOnError: true }),
         ),
       );
-      await qc.invalidateQueries({ queryKey: ["goals"] });
+      await Promise.all([
+        qc.invalidateQueries({ queryKey: ["goals-page"] }),
+        qc.invalidateQueries({ queryKey: ["goals-counts"] }),
+        qc.invalidateQueries({ queryKey: ["goals"] }),
+      ]);
       setSelected(new Set());
     } finally {
       setActing(false);
@@ -179,7 +166,7 @@ export function GoalsPage() {
           onClick={() => setMode("active")}
         >
           {t("goals.modeActive")}
-          <span className="font-mono text-xs text-muted-foreground">{counts.active}</span>
+          <span className="font-mono text-xs text-muted-foreground">{c.active}</span>
         </Button>
         <Button
           size="sm"
@@ -189,7 +176,7 @@ export function GoalsPage() {
         >
           <History />
           <span className="max-sm:hidden">{t("goals.modeHistory")}</span>
-          <span className="font-mono text-xs text-muted-foreground">{counts.history}</span>
+          <span className="font-mono text-xs text-muted-foreground">{c.history}</span>
         </Button>
         <Button
           size="sm"
@@ -199,7 +186,7 @@ export function GoalsPage() {
         >
           <Archive />
           <span className="max-sm:hidden">{t("goals.modeArchived")}</span>
-          <span className="font-mono text-xs text-muted-foreground">{counts.archived}</span>
+          <span className="font-mono text-xs text-muted-foreground">{c.archived}</span>
         </Button>
         {VIEWS.map((v) => {
           const Icon = VIEW_ICON[v];
@@ -223,9 +210,9 @@ export function GoalsPage() {
       setHeaderActions(null);
     };
   }, [
-    counts.active,
-    counts.history,
-    counts.archived,
+    c.active,
+    c.history,
+    c.archived,
     cur,
     mode,
     setHeaderActions,
@@ -242,7 +229,7 @@ export function GoalsPage() {
           <div className="flex items-center justify-center py-20">
             <div className="size-4 animate-spin rounded-full border-2 border-muted-foreground/30 border-t-muted-foreground" />
           </div>
-        ) : activeGoals.length === 0 && archivedGoals.length === 0 ? (
+        ) : counts && c.active + c.history + c.archived === 0 ? (
           <Empty />
         ) : (
           <div className="mx-auto max-w-[1140px] px-6 py-6">
@@ -250,20 +237,22 @@ export function GoalsPage() {
               query={query}
               status={status}
               mode={mode}
-              total={filtered.length}
+              total={total}
               selectedActionableCount={selectedActionable.length}
               acting={acting}
-              onQueryChange={setQuery}
-              onStatusChange={setStatus}
+              onQueryChange={(value) => patch({ q: value || undefined, page: 1 }, true)}
+              onStatusChange={(value) =>
+                patch({ status: value === "all" ? undefined : value, page: 1 }, true)
+              }
               onBulkAction={runBulk}
             />
-            {filtered.length === 0 ? (
+            {goals.length === 0 ? (
               <FilteredEmpty />
             ) : (
               <>
                 {cur === "triage" && (
                   <Triage
-                    goals={pageGoals}
+                    goals={goals}
                     onOpen={openGoal}
                     selected={selected}
                     onSelect={setSelected}
@@ -271,7 +260,7 @@ export function GoalsPage() {
                 )}
                 {cur === "board" && (
                   <Board
-                    goals={pageGoals}
+                    goals={goals}
                     onOpen={openGoal}
                     selected={selected}
                     onSelect={setSelected}
@@ -279,7 +268,7 @@ export function GoalsPage() {
                 )}
                 {cur === "table" && (
                   <Table
-                    goals={pageGoals}
+                    goals={goals}
                     onOpen={openGoal}
                     selected={selected}
                     onSelect={setSelected}
@@ -288,8 +277,8 @@ export function GoalsPage() {
                 <Pager
                   page={page}
                   totalPages={totalPages}
-                  total={filtered.length}
-                  onPage={setPage}
+                  total={total}
+                  onPage={(p) => patch({ page: p })}
                 />
               </>
             )}

--- a/web/src/features/tasks/GoalsPage.tsx
+++ b/web/src/features/tasks/GoalsPage.tsx
@@ -101,7 +101,13 @@ export function GoalsPage() {
     [agentId, navigate, rawSearch],
   );
   const setView = useCallback((v: GoalsView) => patch({ view: v }), [patch]);
-  const setMode = useCallback((m: GoalsMode) => patch({ mode: m, page: 1 }), [patch]);
+  // Each mode exposes a different status set (active vs terminal), so a status
+  // carried over from the previous mode would filter against values the new
+  // mode can never contain — a fake-empty list. Clear it on switch (CR-020).
+  const setMode = useCallback(
+    (m: GoalsMode) => patch({ mode: m, page: 1, status: undefined }),
+    [patch],
+  );
   const openGoal = (g: ComponentsGoal) =>
     void navigate({
       to: "/agents/$agentId/tasks/goals/$goalId",

--- a/web/src/features/tasks/GoalsPage.tsx
+++ b/web/src/features/tasks/GoalsPage.tsx
@@ -1,14 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import {
-  Archive,
-  Columns3,
-  Inbox,
-  Search,
-  Table as TableIcon,
-} from "lucide-react";
+import { Archive, Columns3, History, Inbox, Search, Table as TableIcon } from "lucide-react";
 import type { TFunction } from "i18next";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
+import { deleteGoal, unarchiveGoal } from "@/lib/api-client";
 import type { ComponentsGoal } from "@/lib/api-client/types.gen";
 import { goalsOptions } from "@/lib/queries/goals";
 import { useI18n } from "@/lib/i18n";
@@ -26,16 +21,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  StatusDot,
-  StatusPill,
-  avatarInitials,
-  goalNeedsYou,
-  statusLabel,
-} from "./lib";
+import { StatusDot, StatusPill, avatarInitials, goalNeedsYou, statusLabel } from "./lib";
 
 export type GoalsView = "triage" | "board" | "table";
-type GoalsMode = "active" | "history";
+type GoalsMode = "active" | "history" | "archived";
 type GoalStatusFilter = "all" | ComponentsGoal["status"];
 
 const VIEWS: GoalsView[] = ["triage", "board", "table"];
@@ -49,11 +38,7 @@ const VIEW_ICON: Record<GoalsView, typeof Inbox> = {
   board: Columns3,
   table: TableIcon,
 };
-const TERMINAL_STATUSES: ComponentsGoal["status"][] = [
-  "done",
-  "failed",
-  "cancelled",
-];
+const TERMINAL_STATUSES: ComponentsGoal["status"][] = ["done", "failed", "cancelled"];
 const ACTIVE_STATUSES: ComponentsGoal["status"][] = [
   "blocked",
   "reviewing",
@@ -71,20 +56,20 @@ export function GoalsPage() {
   const view = rawSearch.view as string | undefined;
   const modeParam = rawSearch.mode as string | undefined;
   const navigate = useNavigate();
+  const qc = useQueryClient();
   const { setHeaderTitle, setHeaderActions } = useAppShell();
-  const { data: goals = [], isLoading } = useQuery(goalsOptions(agentId));
+  const { data: activeGoals = [], isLoading } = useQuery(goalsOptions(agentId));
+  const { data: archivedGoals = [] } = useQuery(goalsOptions(agentId, true));
   const [query, setQuery] = useState("");
   const [status, setStatus] = useState<GoalStatusFilter>("all");
   const [page, setPage] = useState(1);
   const [selected, setSelected] = useState<Set<string>>(() => new Set());
-  const [hiddenIds, setHiddenIds] = useState<Set<string>>(() =>
-    readHiddenGoals(agentId),
-  );
+  const [acting, setActing] = useState(false);
 
-  const cur: GoalsView = VIEWS.includes(view as GoalsView)
-    ? (view as GoalsView)
-    : "triage";
-  const mode: GoalsMode = modeParam === "history" ? "history" : "active";
+  const cur: GoalsView = VIEWS.includes(view as GoalsView) ? (view as GoalsView) : "triage";
+  const mode: GoalsMode =
+    modeParam === "history" ? "history" : modeParam === "archived" ? "archived" : "active";
+  const source = mode === "archived" ? archivedGoals : activeGoals;
   const setView = useCallback(
     (v: GoalsView) =>
       void navigate({
@@ -109,27 +94,21 @@ export function GoalsPage() {
       params: { agentId, goalId: g.id },
     });
 
-  const visibleGoals = useMemo(
-    () => goals.filter((g) => !hiddenIds.has(g.id)),
-    [goals, hiddenIds],
-  );
   const counts = useMemo(() => {
-    const active = visibleGoals.filter(
-      (g) => !TERMINAL_STATUSES.includes(g.status),
-    ).length;
-    const history = visibleGoals.length - active;
-    const needs = visibleGoals.filter(goalNeedsYou).length;
-    return { active, history, needs, hidden: hiddenIds.size };
-  }, [hiddenIds.size, visibleGoals]);
+    const active = activeGoals.filter((g) => !TERMINAL_STATUSES.includes(g.status)).length;
+    const history = activeGoals.length - active;
+    const needs = activeGoals.filter(goalNeedsYou).length;
+    return { active, history, needs, archived: archivedGoals.length };
+  }, [activeGoals, archivedGoals.length]);
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
-    return visibleGoals
-      .filter((g) =>
-        mode === "active"
-          ? !TERMINAL_STATUSES.includes(g.status)
-          : TERMINAL_STATUSES.includes(g.status),
-      )
+    return source
+      .filter((g) => {
+        if (mode === "active") return !TERMINAL_STATUSES.includes(g.status);
+        if (mode === "history") return TERMINAL_STATUSES.includes(g.status);
+        return true; // archived mode: the server already scoped to archived rows
+      })
       .filter((g) => status === "all" || g.status === status)
       .filter((g) => {
         if (!q) return true;
@@ -138,7 +117,7 @@ export function GoalsPage() {
           .some((part) => String(part).toLowerCase().includes(q));
       })
       .sort(byUpdatedDesc);
-  }, [mode, query, status, visibleGoals]);
+  }, [mode, query, status, source]);
 
   const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
   const pageGoals = useMemo(() => {
@@ -146,34 +125,39 @@ export function GoalsPage() {
     const start = (safePage - 1) * PAGE_SIZE;
     return filtered.slice(start, start + PAGE_SIZE);
   }, [filtered, page, totalPages]);
-  const selectedTerminalCount = useMemo(
-    () =>
-      filtered.filter(
-        (g) => selected.has(g.id) && TERMINAL_STATUSES.includes(g.status),
-      ).length,
-    [filtered, selected],
-  );
 
-  useEffect(() => setPage(1), [mode, query, status, hiddenIds]);
+  // History archives the selected terminal goals; the archived view restores them.
+  // Active goals are never bulk-actionable (they are not yet finished).
+  const selectedActionable = useMemo(() => {
+    if (mode === "history")
+      return filtered.filter((g) => selected.has(g.id) && TERMINAL_STATUSES.includes(g.status));
+    if (mode === "archived") return filtered.filter((g) => selected.has(g.id));
+    return [];
+  }, [filtered, selected, mode]);
+
+  useEffect(() => setPage(1), [mode, query, status]);
   useEffect(() => setSelected(new Set()), [mode, query, status]);
-  useEffect(() => setHiddenIds(readHiddenGoals(agentId)), [agentId]);
+  // Keep the page in range after a bulk action shrinks the result set (CR-010).
+  useEffect(() => setPage((p) => Math.min(Math.max(1, p), totalPages)), [totalPages]);
 
-  const hideSelectedTerminal = useCallback(() => {
-    const next = new Set(hiddenIds);
-    for (const g of filtered) {
-      if (selected.has(g.id) && TERMINAL_STATUSES.includes(g.status))
-        next.add(g.id);
+  const runBulk = useCallback(async () => {
+    const ids = selectedActionable.map((g) => g.id);
+    if (!ids.length) return;
+    setActing(true);
+    try {
+      await Promise.all(
+        ids.map((goalId) =>
+          mode === "archived"
+            ? unarchiveGoal({ path: { goalId }, throwOnError: true })
+            : deleteGoal({ path: { goalId }, throwOnError: true }),
+        ),
+      );
+      await qc.invalidateQueries({ queryKey: ["goals"] });
+      setSelected(new Set());
+    } finally {
+      setActing(false);
     }
-    setHiddenIds(next);
-    writeHiddenGoals(agentId, next);
-    setSelected(new Set());
-  }, [agentId, filtered, hiddenIds, selected]);
-
-  const restoreHidden = useCallback(() => {
-    const next = new Set<string>();
-    setHiddenIds(next);
-    writeHiddenGoals(agentId, next);
-  }, [agentId]);
+  }, [mode, qc, selectedActionable]);
 
   useEffect(() => {
     setHeaderTitle(
@@ -195,9 +179,7 @@ export function GoalsPage() {
           onClick={() => setMode("active")}
         >
           {t("goals.modeActive")}
-          <span className="font-mono text-xs text-muted-foreground">
-            {counts.active}
-          </span>
+          <span className="font-mono text-xs text-muted-foreground">{counts.active}</span>
         </Button>
         <Button
           size="sm"
@@ -205,11 +187,19 @@ export function GoalsPage() {
           aria-pressed={mode === "history"}
           onClick={() => setMode("history")}
         >
-          <Archive />
+          <History />
           <span className="max-sm:hidden">{t("goals.modeHistory")}</span>
-          <span className="font-mono text-xs text-muted-foreground">
-            {counts.history}
-          </span>
+          <span className="font-mono text-xs text-muted-foreground">{counts.history}</span>
+        </Button>
+        <Button
+          size="sm"
+          variant={mode === "archived" ? "secondary" : "outline"}
+          aria-pressed={mode === "archived"}
+          onClick={() => setMode("archived")}
+        >
+          <Archive />
+          <span className="max-sm:hidden">{t("goals.modeArchived")}</span>
+          <span className="font-mono text-xs text-muted-foreground">{counts.archived}</span>
         </Button>
         {VIEWS.map((v) => {
           const Icon = VIEW_ICON[v];
@@ -235,6 +225,7 @@ export function GoalsPage() {
   }, [
     counts.active,
     counts.history,
+    counts.archived,
     cur,
     mode,
     setHeaderActions,
@@ -251,7 +242,7 @@ export function GoalsPage() {
           <div className="flex items-center justify-center py-20">
             <div className="size-4 animate-spin rounded-full border-2 border-muted-foreground/30 border-t-muted-foreground" />
           </div>
-        ) : goals.length === 0 ? (
+        ) : activeGoals.length === 0 && archivedGoals.length === 0 ? (
           <Empty />
         ) : (
           <div className="mx-auto max-w-[1140px] px-6 py-6">
@@ -260,12 +251,11 @@ export function GoalsPage() {
               status={status}
               mode={mode}
               total={filtered.length}
-              hiddenCount={counts.hidden}
-              selectedTerminalCount={selectedTerminalCount}
+              selectedActionableCount={selectedActionable.length}
+              acting={acting}
               onQueryChange={setQuery}
               onStatusChange={setStatus}
-              onHideSelected={hideSelectedTerminal}
-              onRestoreHidden={restoreHidden}
+              onBulkAction={runBulk}
             />
             {filtered.length === 0 ? (
               <FilteredEmpty />
@@ -315,26 +305,29 @@ function Toolbar({
   status,
   mode,
   total,
-  hiddenCount,
-  selectedTerminalCount,
+  selectedActionableCount,
+  acting,
   onQueryChange,
   onStatusChange,
-  onHideSelected,
-  onRestoreHidden,
+  onBulkAction,
 }: {
   query: string;
   status: GoalStatusFilter;
   mode: GoalsMode;
   total: number;
-  hiddenCount: number;
-  selectedTerminalCount: number;
+  selectedActionableCount: number;
+  acting: boolean;
   onQueryChange: (value: string) => void;
   onStatusChange: (value: GoalStatusFilter) => void;
-  onHideSelected: () => void;
-  onRestoreHidden: () => void;
+  onBulkAction: () => void;
 }) {
   const { t } = useI18n();
-  const statusOptions = mode === "active" ? ACTIVE_STATUSES : TERMINAL_STATUSES;
+  const statusOptions =
+    mode === "active"
+      ? ACTIVE_STATUSES
+      : mode === "history"
+        ? TERMINAL_STATUSES
+        : ([...TERMINAL_STATUSES, "draft"] as ComponentsGoal["status"][]);
   return (
     <div className="mb-5 flex flex-col gap-3 rounded-2xl border border-border bg-card p-3 sm:flex-row sm:items-center">
       <div className="flex min-w-0 flex-1 items-center gap-2">
@@ -347,10 +340,7 @@ function Toolbar({
           size="sm"
         />
       </div>
-      <Select
-        value={status}
-        onValueChange={(value) => onStatusChange(value as GoalStatusFilter)}
-      >
+      <Select value={status} onValueChange={(value) => onStatusChange(value as GoalStatusFilter)}>
         <SelectTrigger size="sm" className="w-full sm:w-44">
           <SelectValue placeholder={t("goals.statusAll")} />
         </SelectTrigger>
@@ -367,17 +357,17 @@ function Toolbar({
         <span className="font-mono text-xs text-muted-foreground">
           {t("goals.filteredCount", { count: total })}
         </span>
-        <Button
-          variant="outline"
-          size="sm"
-          disabled={selectedTerminalCount === 0}
-          onClick={onHideSelected}
-        >
-          {t("goals.hideSelected", { count: selectedTerminalCount })}
-        </Button>
-        {hiddenCount > 0 && (
-          <Button variant="ghost" size="sm" onClick={onRestoreHidden}>
-            {t("goals.restoreHidden", { count: hiddenCount })}
+        {mode !== "active" && (
+          <Button
+            variant="outline"
+            size="sm"
+            loading={acting}
+            disabled={selectedActionableCount === 0}
+            onClick={onBulkAction}
+          >
+            {mode === "archived"
+              ? t("goals.restoreSelected", { count: selectedActionableCount })
+              : t("goals.archiveSelected", { count: selectedActionableCount })}
           </Button>
         )}
       </div>
@@ -389,12 +379,8 @@ function Empty() {
   const { t } = useI18n();
   return (
     <div className="flex flex-col items-center justify-center py-24 text-center">
-      <p className="text-sm font-medium text-muted-foreground">
-        {t("goals.empty")}
-      </p>
-      <p className="mt-1 max-w-xs text-xs text-muted-foreground">
-        {t("goals.emptyDesc")}
-      </p>
+      <p className="text-sm font-medium text-muted-foreground">{t("goals.empty")}</p>
+      <p className="mt-1 max-w-xs text-xs text-muted-foreground">{t("goals.emptyDesc")}</p>
     </div>
   );
 }
@@ -403,12 +389,8 @@ function FilteredEmpty() {
   const { t } = useI18n();
   return (
     <div className="flex flex-col items-center justify-center rounded-2xl border border-border py-16 text-center">
-      <p className="text-sm font-medium text-muted-foreground">
-        {t("goals.noMatches")}
-      </p>
-      <p className="mt-1 max-w-sm text-xs text-muted-foreground">
-        {t("goals.noMatchesDesc")}
-      </p>
+      <p className="text-sm font-medium text-muted-foreground">{t("goals.noMatches")}</p>
+      <p className="mt-1 max-w-sm text-xs text-muted-foreground">{t("goals.noMatchesDesc")}</p>
     </div>
   );
 }
@@ -435,11 +417,7 @@ interface ViewProps {
   onSelect: (next: Set<string>) => void;
 }
 
-function toggleSelected(
-  selected: Set<string>,
-  id: string,
-  onSelect: (next: Set<string>) => void,
-) {
+function toggleSelected(selected: Set<string>, id: string, onSelect: (next: Set<string>) => void) {
   const next = new Set(selected);
   if (next.has(id)) next.delete(id);
   else next.add(id);
@@ -450,32 +428,15 @@ function Triage({ goals, onOpen, selected, onSelect }: ViewProps) {
   const { t } = useI18n();
   const needs = goals.filter(goalNeedsYou).sort(byUpdatedDesc);
   const prog = goals
-    .filter(
-      (g) =>
-        g.status === "running" ||
-        g.status === "planning" ||
-        g.status === "draft",
-    )
+    .filter((g) => g.status === "running" || g.status === "planning" || g.status === "draft")
     .sort(byUpdatedDesc);
-  const closed = goals
-    .filter((g) => TERMINAL_STATUSES.includes(g.status))
-    .sort(byUpdatedDesc);
+  const closed = goals.filter((g) => TERMINAL_STATUSES.includes(g.status)).sort(byUpdatedDesc);
 
-  const Section = ({
-    label,
-    arr,
-    dim,
-  }: {
-    label: string;
-    arr: ComponentsGoal[];
-    dim?: boolean;
-  }) =>
+  const Section = ({ label, arr, dim }: { label: string; arr: ComponentsGoal[]; dim?: boolean }) =>
     arr.length ? (
       <section className="mb-7">
         <div className="mb-3 flex items-center gap-2.5">
-          <span className="font-mono text-xs font-semibold text-muted-foreground">
-            {label}
-          </span>
+          <span className="font-mono text-xs font-semibold text-muted-foreground">{label}</span>
           <span className="rounded-full bg-muted px-2 py-0.5 font-mono text-xs text-muted-foreground">
             {arr.length}
           </span>
@@ -529,11 +490,7 @@ function Row({
         dim && "opacity-65 hover:opacity-100",
       )}
     >
-      <Checkbox
-        checked={selected}
-        onCheckedChange={onSelect}
-        aria-label={t("goals.selectGoal")}
-      />
+      <Checkbox checked={selected} onCheckedChange={onSelect} aria-label={t("goals.selectGoal")} />
       <button
         type="button"
         onClick={() => onOpen(g)}
@@ -542,9 +499,7 @@ function Row({
         <StatusPill status={g.status} label={statusLabel(t, g.status)} />
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
-            <span className="truncate font-serif text-[15px] font-semibold">
-              {g.title}
-            </span>
+            <span className="truncate font-serif text-[15px] font-semibold">{g.title}</span>
             {g.status === "done" && (
               <span className="rounded-md border border-chart-3/25 bg-chart-3/10 px-1.5 py-0.5 font-mono text-xs font-medium text-chart-3">
                 {t("goals.achieved")}
@@ -603,15 +558,10 @@ function Board({ goals, onOpen, selected, onSelect }: ViewProps) {
       {BOARD_COLS.map((col) => {
         const items = goals.filter(col.match).sort(byUpdatedDesc);
         return (
-          <div
-            key={col.labelKey}
-            className="min-h-[180px] rounded-2xl bg-muted p-2.5"
-          >
+          <div key={col.labelKey} className="min-h-[180px] rounded-2xl bg-muted p-2.5">
             <div className="flex items-center gap-2 px-1.5 pb-2.5 pt-1">
               <StatusDot status={col.status} />
-              <span className="font-mono text-xs font-semibold">
-                {t(col.labelKey)}
-              </span>
+              <span className="font-mono text-xs font-semibold">{t(col.labelKey)}</span>
               <span className="ml-auto font-mono text-xs text-muted-foreground">
                 {items.length}
               </span>
@@ -625,9 +575,7 @@ function Board({ goals, onOpen, selected, onSelect }: ViewProps) {
                   <div className="mb-2 flex items-center gap-2">
                     <Checkbox
                       checked={selected.has(g.id)}
-                      onCheckedChange={() =>
-                        toggleSelected(selected, g.id, onSelect)
-                      }
+                      onCheckedChange={() => toggleSelected(selected, g.id, onSelect)}
                       aria-label={t("goals.selectGoal")}
                     />
                     <button
@@ -641,10 +589,7 @@ function Board({ goals, onOpen, selected, onSelect }: ViewProps) {
                     </button>
                   </div>
                   <div className="flex flex-wrap items-center gap-1.5">
-                    <StatusPill
-                      status={g.status}
-                      label={statusLabel(t, g.status)}
-                    />
+                    <StatusPill status={g.status} label={statusLabel(t, g.status)} />
                     {g.status === "done" && (
                       <span className="rounded-md border border-chart-3/25 bg-chart-3/10 px-1.5 py-0.5 font-mono text-xs font-medium text-chart-3">
                         {t("goals.achieved")}
@@ -664,9 +609,7 @@ function Board({ goals, onOpen, selected, onSelect }: ViewProps) {
                 </div>
               ))}
               {!items.length && (
-                <div className="py-5 text-center text-xs text-muted-foreground">
-                  —
-                </div>
+                <div className="py-5 text-center text-xs text-muted-foreground">—</div>
               )}
             </div>
           </div>
@@ -698,51 +641,27 @@ function Table({ goals, onOpen, selected, onSelect }: ViewProps) {
         <thead>
           <tr className="border-b border-border bg-muted/50 text-left font-mono text-[10.5px] text-muted-foreground">
             <th className="w-[42px] px-3.5 py-2.5 font-semibold" />
-            <th className="w-[120px] px-3.5 py-2.5 font-semibold">
-              {t("goals.colStatus")}
-            </th>
-            <th className="px-3.5 py-2.5 font-semibold">
-              {t("goals.colGoal")}
-            </th>
-            <th className="w-[120px] px-3.5 py-2.5 font-semibold">
-              {t("goals.colAttention")}
-            </th>
-            <th className="w-[150px] px-3.5 py-2.5 font-semibold">
-              {t("goals.colAgent")}
-            </th>
-            <th className="w-[90px] px-3.5 py-2.5 font-semibold">
-              {t("goals.colUpdated")}
-            </th>
+            <th className="w-[120px] px-3.5 py-2.5 font-semibold">{t("goals.colStatus")}</th>
+            <th className="px-3.5 py-2.5 font-semibold">{t("goals.colGoal")}</th>
+            <th className="w-[120px] px-3.5 py-2.5 font-semibold">{t("goals.colAttention")}</th>
+            <th className="w-[150px] px-3.5 py-2.5 font-semibold">{t("goals.colAgent")}</th>
+            <th className="w-[90px] px-3.5 py-2.5 font-semibold">{t("goals.colUpdated")}</th>
           </tr>
         </thead>
         <tbody>
           {rows.map((g) => (
-            <tr
-              key={g.id}
-              className="border-b border-border last:border-0 hover:bg-accent/40"
-            >
+            <tr key={g.id} className="border-b border-border last:border-0 hover:bg-accent/40">
               <td className="px-3.5 py-3">
                 <Checkbox
                   checked={selected.has(g.id)}
-                  onCheckedChange={() =>
-                    toggleSelected(selected, g.id, onSelect)
-                  }
+                  onCheckedChange={() => toggleSelected(selected, g.id, onSelect)}
                   aria-label={t("goals.selectGoal")}
                 />
               </td>
-              <td
-                className="cursor-pointer px-3.5 py-3"
-                onClick={() => onOpen(g)}
-              >
-                <StatusPill
-                  status={g.status}
-                  label={statusLabel(t, g.status)}
-                />
+              <td className="cursor-pointer px-3.5 py-3" onClick={() => onOpen(g)}>
+                <StatusPill status={g.status} label={statusLabel(t, g.status)} />
               </td>
-              <td
-                className="cursor-pointer px-3.5 py-3"
-                onClick={() => onOpen(g)}
-              >
+              <td className="cursor-pointer px-3.5 py-3" onClick={() => onOpen(g)}>
                 <div className="font-medium">{g.title}</div>
                 {g.description && (
                   <div className="mt-0.5 truncate text-[11.5px] text-muted-foreground">
@@ -753,9 +672,7 @@ function Table({ goals, onOpen, selected, onSelect }: ViewProps) {
               <td className="px-3.5 py-3">
                 {goalNeedsYou(g) ? (
                   <span className="rounded-md border border-primary/25 bg-primary/10 px-2 py-0.5 font-mono text-xs font-medium text-primary">
-                    {g.status === "blocked"
-                      ? t("goals.actUnblock")
-                      : t("goals.actReview")}
+                    {g.status === "blocked" ? t("goals.actUnblock") : t("goals.actReview")}
                   </span>
                 ) : g.status === "done" ? (
                   <span className="rounded-md border border-chart-3/25 bg-chart-3/10 px-2 py-0.5 font-mono text-xs font-medium text-chart-3">
@@ -766,9 +683,7 @@ function Table({ goals, onOpen, selected, onSelect }: ViewProps) {
                     urgent
                   </span>
                 ) : (
-                  <span className="font-mono text-xs text-muted-foreground">
-                    —
-                  </span>
+                  <span className="font-mono text-xs text-muted-foreground">—</span>
                 )}
               </td>
               <td className="px-3.5 py-3">
@@ -779,9 +694,7 @@ function Table({ goals, onOpen, selected, onSelect }: ViewProps) {
                     </span>
                   </span>
                 ) : (
-                  <span className="font-mono text-xs text-muted-foreground">
-                    —
-                  </span>
+                  <span className="font-mono text-xs text-muted-foreground">—</span>
                 )}
               </td>
               <td className="px-3.5 py-3">
@@ -816,12 +729,7 @@ function Pager({
         {t("goals.pageStatus", { page, totalPages, total })}
       </span>
       <div className="flex items-center gap-2">
-        <Button
-          variant="outline"
-          size="sm"
-          disabled={page <= 1}
-          onClick={() => onPage(page - 1)}
-        >
+        <Button variant="outline" size="sm" disabled={page <= 1} onClick={() => onPage(page - 1)}>
           {t("common.back")}
         </Button>
         <Button
@@ -834,30 +742,5 @@ function Pager({
         </Button>
       </div>
     </div>
-  );
-}
-
-function hiddenStorageKey(agentId: string): string {
-  return `stella:hidden-goals:${agentId}`;
-}
-
-function readHiddenGoals(agentId: string): Set<string> {
-  if (typeof window === "undefined") return new Set();
-  try {
-    const raw = window.localStorage.getItem(hiddenStorageKey(agentId));
-    const parsed = raw ? (JSON.parse(raw) as string[]) : [];
-    return new Set(
-      Array.isArray(parsed) ? parsed.filter((x) => typeof x === "string") : [],
-    );
-  } catch {
-    return new Set();
-  }
-}
-
-function writeHiddenGoals(agentId: string, ids: Set<string>) {
-  if (typeof window === "undefined") return;
-  window.localStorage.setItem(
-    hiddenStorageKey(agentId),
-    JSON.stringify([...ids]),
   );
 }

--- a/web/src/features/tasks/OverviewPage.tsx
+++ b/web/src/features/tasks/OverviewPage.tsx
@@ -1,18 +1,8 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-  type ReactNode,
-} from "react";
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
 import { useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate, useParams } from "@tanstack/react-router";
 import { reopenTask, updateSchedulerJob } from "@/lib/api-client";
-import type {
-  ComponentsGoal,
-  ComponentsTask,
-  JobRun,
-} from "@/lib/api-client/types.gen";
+import type { ComponentsGoal, ComponentsTask, JobRun } from "@/lib/api-client/types.gen";
 import type { SchedulerJob } from "@/lib/types";
 import { goalsOptions, goalGraphOptions } from "@/lib/queries/goals";
 import { agentSchedulerJobsOptions } from "@/lib/queries/agents";
@@ -32,10 +22,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import {
-  standaloneTasksOptions,
-  schedulerJobRecentRunsOptions,
-} from "./queries";
+import { standaloneTasksOptions, schedulerJobRecentRunsOptions } from "./queries";
 import { jobNextRunAt } from "./types";
 import {
   ProgressBar,
@@ -57,9 +44,7 @@ export function OverviewPage() {
 
   const { data: goals = [] } = useQuery(goalsOptions(agentId));
   const { data: jobs = [] } = useQuery(agentSchedulerJobsOptions(agentId));
-  const { data: tasks = [] } = useQuery(
-    standaloneTasksOptions(agentId, projectId),
-  );
+  const { data: tasks = [] } = useQuery(standaloneTasksOptions(agentId, projectId));
 
   useEffect(() => {
     setHeaderActions(
@@ -88,28 +73,20 @@ export function OverviewPage() {
   const needsYou = useMemo(() => {
     const items: NeedsYouItem[] = [];
     for (const g of goals) {
-      if (g.status === "blocked" || g.status === "reviewing")
-        items.push({ kind: "goal", goal: g });
+      if (g.status === "blocked" || g.status === "reviewing") items.push({ kind: "goal", goal: g });
     }
     for (const task of tasks) {
-      if (
-        task.status === "blocked" ||
-        task.status === "reviewing" ||
-        task.status === "failed"
-      )
+      if (task.status === "blocked" || task.status === "reviewing" || task.status === "failed")
         items.push({ kind: "task", task });
     }
-    items.sort(
-      (a, b) =>
-        new Date(itemUpdated(b)).getTime() - new Date(itemUpdated(a)).getTime(),
-    );
+    items.sort((a, b) => new Date(itemUpdated(b)).getTime() - new Date(itemUpdated(a)).getTime());
     return items;
   }, [goals, tasks]);
 
   const runningCount = useMemo(
     () =>
-      goals.filter((g) => g.status === "running" || g.status === "planning")
-        .length + tasks.filter((task) => task.status === "running").length,
+      goals.filter((g) => g.status === "running" || g.status === "planning").length +
+      tasks.filter((task) => task.status === "running").length,
     [goals, tasks],
   );
 
@@ -118,8 +95,7 @@ export function OverviewPage() {
     const fresh = (s: string) => new Date(s).getTime() >= cutoff;
     return (
       goals.filter((g) => g.status === "done" && fresh(g.updated_at)).length +
-      tasks.filter((task) => task.status === "done" && fresh(task.updated_at))
-        .length
+      tasks.filter((task) => task.status === "done" && fresh(task.updated_at)).length
     );
   }, [goals, tasks]);
 
@@ -143,17 +119,13 @@ export function OverviewPage() {
   const sortedGoals = useMemo(
     () =>
       [...goals].sort(
-        (a, b) =>
-          new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
+        (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
       ),
     [goals],
   );
 
   const activeGoals = useMemo(
-    () =>
-      sortedGoals.filter(
-        (g) => !["done", "failed", "cancelled"].includes(g.status),
-      ),
+    () => sortedGoals.filter((g) => !["done", "failed", "cancelled"].includes(g.status)),
     [sortedGoals],
   );
   const historyGoalsCount = sortedGoals.length - activeGoals.length;
@@ -161,14 +133,9 @@ export function OverviewPage() {
 
   const recentDone = useMemo(() => {
     const items: NeedsYouItem[] = [];
-    for (const g of goals)
-      if (g.status === "done") items.push({ kind: "goal", goal: g });
-    for (const task of tasks)
-      if (task.status === "done") items.push({ kind: "task", task });
-    items.sort(
-      (a, b) =>
-        new Date(itemUpdated(b)).getTime() - new Date(itemUpdated(a)).getTime(),
-    );
+    for (const g of goals) if (g.status === "done") items.push({ kind: "goal", goal: g });
+    for (const task of tasks) if (task.status === "done") items.push({ kind: "task", task });
+    items.sort((a, b) => new Date(itemUpdated(b)).getTime() - new Date(itemUpdated(a)).getTime());
     return items.slice(0, 5);
   }, [goals, tasks]);
 
@@ -198,11 +165,7 @@ export function OverviewPage() {
             label={t("hub.secNeedsYou")}
             tone={needsYou.length > 0 ? "attn" : undefined}
           />
-          <StatCard
-            num={runningCount}
-            label={t("hub.statRunning")}
-            tone="live"
-          />
+          <StatCard num={runningCount} label={t("hub.statRunning")} tone="live" />
           <StatCard
             num={sortedJobs.filter((j) => j.enabled).length}
             label={
@@ -219,18 +182,12 @@ export function OverviewPage() {
           <SectionHead title={t("hub.secNeedsYou")} count={needsYou.length} />
           {needsYou.length === 0 ? (
             <div className="rounded-xl border border-border px-4 py-3.5">
-              <p className="text-sm font-medium text-muted-foreground">
-                {t("hub.noNeedsYou")}
-              </p>
-              <p className="mt-1 text-[12.5px] text-muted-foreground">
-                {t("hub.noNeedsYouDesc")}
-              </p>
+              <p className="text-sm font-medium text-muted-foreground">{t("hub.noNeedsYou")}</p>
+              <p className="mt-1 text-[12.5px] text-muted-foreground">{t("hub.noNeedsYouDesc")}</p>
             </div>
           ) : (
             <>
-              <p className="mb-3 text-[12.5px] text-muted-foreground">
-                {t("hub.needsYouHint")}
-              </p>
+              <p className="mb-3 text-[12.5px] text-muted-foreground">{t("hub.needsYouHint")}</p>
               <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
                 {needsYou.map((item) => (
                   <NeedsYouCard
@@ -247,14 +204,9 @@ export function OverviewPage() {
 
         {/* Schedules */}
         <section className="mt-8">
-          <SectionHead
-            title={t("hub.secSchedules")}
-            count={sortedJobs.length}
-          />
+          <SectionHead title={t("hub.secSchedules")} count={sortedJobs.length} />
           {sortedJobs.length === 0 ? (
-            <p className="text-sm text-muted-foreground">
-              {t("hub.noSchedules")}
-            </p>
+            <p className="text-sm text-muted-foreground">{t("hub.noSchedules")}</p>
           ) : (
             <SchedulesTable jobs={sortedJobs} agentId={agentId} />
           )}
@@ -299,17 +251,11 @@ export function OverviewPage() {
             }
           />
           {activeGoals.length === 0 ? (
-            <p className="text-sm text-muted-foreground">
-              {t("hub.noActiveGoals")}
-            </p>
+            <p className="text-sm text-muted-foreground">{t("hub.noActiveGoals")}</p>
           ) : (
             <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
               {previewGoals.map((g) => (
-                <GoalCard
-                  key={g.id}
-                  goal={g}
-                  onOpen={() => openItem({ kind: "goal", goal: g })}
-                />
+                <GoalCard key={g.id} goal={g} onOpen={() => openItem({ kind: "goal", goal: g })} />
               ))}
             </div>
           )}
@@ -322,8 +268,7 @@ export function OverviewPage() {
             <div className="overflow-hidden rounded-xl border border-border">
               {recentDone.map((item) => {
                 const id = item.kind === "goal" ? item.goal.id : item.task.id;
-                const title =
-                  item.kind === "goal" ? item.goal.title : item.task.title;
+                const title = item.kind === "goal" ? item.goal.title : item.task.title;
                 return (
                   <button
                     key={`${item.kind}:${id}`}
@@ -331,9 +276,7 @@ export function OverviewPage() {
                     onClick={() => openItem(item)}
                     className="flex w-full items-center gap-3 border-b border-border px-3.5 py-2.5 text-left text-[13px] last:border-b-0 hover:bg-muted/50"
                   >
-                    <span className="min-w-0 flex-1 truncate font-medium">
-                      {title}
-                    </span>
+                    <span className="min-w-0 flex-1 truncate font-medium">{title}</span>
                     <span className="shrink-0 font-mono text-xs text-chart-3">
                       {statusLabel(t, "done")}
                     </span>
@@ -351,23 +294,13 @@ export function OverviewPage() {
   );
 }
 
-type NeedsYouItem =
-  | { kind: "goal"; goal: ComponentsGoal }
-  | { kind: "task"; task: ComponentsTask };
+type NeedsYouItem = { kind: "goal"; goal: ComponentsGoal } | { kind: "task"; task: ComponentsTask };
 
 function itemUpdated(item: NeedsYouItem): string {
   return item.kind === "goal" ? item.goal.updated_at : item.task.updated_at;
 }
 
-function StatCard({
-  num,
-  label,
-  tone,
-}: {
-  num: number;
-  label: string;
-  tone?: "attn" | "live";
-}) {
+function StatCard({ num, label, tone }: { num: number; label: string; tone?: "attn" | "live" }) {
   return (
     <div
       className={cn(
@@ -384,10 +317,7 @@ function StatCard({
       >
         {num}
       </div>
-      <div
-        className="mt-0.5 truncate text-xs text-muted-foreground"
-        title={label}
-      >
+      <div className="mt-0.5 truncate text-xs text-muted-foreground" title={label}>
         {label}
       </div>
     </div>
@@ -432,11 +362,9 @@ function NeedsYouCard({
 
   const status = item.kind === "goal" ? item.goal.status : item.task.status;
   const isFail = status === "failed";
-  const kindLabel =
-    item.kind === "goal" ? t("hub.kindGoal") : t("hub.kindTask");
+  const kindLabel = item.kind === "goal" ? t("hub.kindGoal") : t("hub.kindTask");
   const title = item.kind === "goal" ? item.goal.title : item.task.title;
-  const desc =
-    item.kind === "goal" ? item.goal.description : item.task.description;
+  const desc = item.kind === "goal" ? item.goal.description : item.task.description;
 
   const handleRetry = async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -498,21 +426,13 @@ function NeedsYouCard({
   );
 }
 
-function SchedulesTable({
-  jobs,
-  agentId,
-}: {
-  jobs: SchedulerJob[];
-  agentId: string;
-}) {
+function SchedulesTable({ jobs, agentId }: { jobs: SchedulerJob[]; agentId: string }) {
   const { t } = useI18n();
   const navigate = useNavigate();
   const qc = useQueryClient();
 
   const runQueries = useQueries({
-    queries: jobs.map((j) =>
-      schedulerJobRecentRunsOptions(j.agent_id || agentId, j.id),
-    ),
+    queries: jobs.map((j) => schedulerJobRecentRunsOptions(j.agent_id || agentId, j.id)),
   });
 
   const toggleJob = async (job: SchedulerJob, enabled: boolean) => {
@@ -576,14 +496,9 @@ function SchedulesTable({
               <TableCell>
                 <RunSparkline runs={runQueries[i]?.data ?? []} />
               </TableCell>
-              <TableCell className="text-[12.5px]">
-                {next ? formatUntil(t, next) : "—"}
-              </TableCell>
+              <TableCell className="text-[12.5px]">{next ? formatUntil(t, next) : "—"}</TableCell>
               <TableCell onClick={(e) => e.stopPropagation()}>
-                <Switch
-                  checked={job.enabled}
-                  onCheckedChange={(v) => void toggleJob(job, v)}
-                />
+                <Switch checked={job.enabled} onCheckedChange={(v) => void toggleJob(job, v)} />
               </TableCell>
             </TableRow>
           );
@@ -596,8 +511,7 @@ function SchedulesTable({
 /** Last runs as colored dots, oldest → newest. */
 function RunSparkline({ runs }: { runs: JobRun[] }) {
   const ordered = [...runs].reverse().slice(-10);
-  if (!ordered.length)
-    return <span className="text-xs text-muted-foreground">—</span>;
+  if (!ordered.length) return <span className="text-xs text-muted-foreground">—</span>;
   return (
     <span className="inline-flex items-center gap-[3px]">
       {ordered.map((run) => (
@@ -618,13 +532,7 @@ function RunSparkline({ runs }: { runs: JobRun[] }) {
   );
 }
 
-function GoalCard({
-  goal,
-  onOpen,
-}: {
-  goal: ComponentsGoal;
-  onOpen: () => void;
-}) {
+function GoalCard({ goal, onOpen }: { goal: ComponentsGoal; onOpen: () => void }) {
   const { t } = useI18n();
   const { data: graph } = useQuery(goalGraphOptions(goal.id));
   const r = rollup(graph?.tasks ?? []);
@@ -638,15 +546,8 @@ function GoalCard({
       className="cursor-pointer rounded-xl border border-border px-4 py-3.5 hover:bg-muted/40"
     >
       <div className="flex items-center gap-2">
-        <span
-          className={cn(
-            "size-1.5 shrink-0 rounded-full",
-            statusMeta(goal.status).dot,
-          )}
-        />
-        <span className="min-w-0 flex-1 truncate text-sm font-semibold">
-          {goal.title}
-        </span>
+        <span className={cn("size-1.5 shrink-0 rounded-full", statusMeta(goal.status).dot)} />
+        <span className="min-w-0 flex-1 truncate text-sm font-semibold">{goal.title}</span>
         <span className="shrink-0 font-mono text-xs text-muted-foreground">
           {statusLabel(t, goal.status)}
         </span>
@@ -666,13 +567,9 @@ function GoalCard({
         </div>
       ) : null}
       <div className="mt-2 flex flex-wrap gap-x-3.5 font-mono text-xs text-muted-foreground">
-        {r.total > 0 && (
-          <span>{t("hub.goalDone", { done: r.done, total: r.total })}</span>
-        )}
+        {r.total > 0 && <span>{t("hub.goalDone", { done: r.done, total: r.total })}</span>}
         {r.blocked > 0 && (
-          <span className="text-chart-4">
-            {t("hub.goalBlocked", { n: r.blocked })}
-          </span>
+          <span className="text-chart-4">{t("hub.goalBlocked", { n: r.blocked })}</span>
         )}
         {r.running > 0 && <span>{t("hub.goalRunning", { n: r.running })}</span>}
         <span>{t("hub.updatedAt", { time: formatTime(goal.updated_at) })}</span>

--- a/web/src/features/tasks/OverviewPage.tsx
+++ b/web/src/features/tasks/OverviewPage.tsx
@@ -1,8 +1,18 @@
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
 import { useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate, useParams } from "@tanstack/react-router";
 import { reopenTask, updateSchedulerJob } from "@/lib/api-client";
-import type { ComponentsGoal, ComponentsTask, JobRun } from "@/lib/api-client/types.gen";
+import type {
+  ComponentsGoal,
+  ComponentsTask,
+  JobRun,
+} from "@/lib/api-client/types.gen";
 import type { SchedulerJob } from "@/lib/types";
 import { goalsOptions, goalGraphOptions } from "@/lib/queries/goals";
 import { agentSchedulerJobsOptions } from "@/lib/queries/agents";
@@ -22,7 +32,10 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { standaloneTasksOptions, schedulerJobRecentRunsOptions } from "./queries";
+import {
+  standaloneTasksOptions,
+  schedulerJobRecentRunsOptions,
+} from "./queries";
 import { jobNextRunAt } from "./types";
 import {
   ProgressBar,
@@ -44,7 +57,9 @@ export function OverviewPage() {
 
   const { data: goals = [] } = useQuery(goalsOptions(agentId));
   const { data: jobs = [] } = useQuery(agentSchedulerJobsOptions(agentId));
-  const { data: tasks = [] } = useQuery(standaloneTasksOptions(agentId, projectId));
+  const { data: tasks = [] } = useQuery(
+    standaloneTasksOptions(agentId, projectId),
+  );
 
   useEffect(() => {
     setHeaderActions(
@@ -73,20 +88,28 @@ export function OverviewPage() {
   const needsYou = useMemo(() => {
     const items: NeedsYouItem[] = [];
     for (const g of goals) {
-      if (g.status === "blocked" || g.status === "reviewing") items.push({ kind: "goal", goal: g });
+      if (g.status === "blocked" || g.status === "reviewing")
+        items.push({ kind: "goal", goal: g });
     }
     for (const task of tasks) {
-      if (task.status === "blocked" || task.status === "reviewing" || task.status === "failed")
+      if (
+        task.status === "blocked" ||
+        task.status === "reviewing" ||
+        task.status === "failed"
+      )
         items.push({ kind: "task", task });
     }
-    items.sort((a, b) => new Date(itemUpdated(b)).getTime() - new Date(itemUpdated(a)).getTime());
+    items.sort(
+      (a, b) =>
+        new Date(itemUpdated(b)).getTime() - new Date(itemUpdated(a)).getTime(),
+    );
     return items;
   }, [goals, tasks]);
 
   const runningCount = useMemo(
     () =>
-      goals.filter((g) => g.status === "running" || g.status === "planning").length +
-      tasks.filter((task) => task.status === "running").length,
+      goals.filter((g) => g.status === "running" || g.status === "planning")
+        .length + tasks.filter((task) => task.status === "running").length,
     [goals, tasks],
   );
 
@@ -95,7 +118,8 @@ export function OverviewPage() {
     const fresh = (s: string) => new Date(s).getTime() >= cutoff;
     return (
       goals.filter((g) => g.status === "done" && fresh(g.updated_at)).length +
-      tasks.filter((task) => task.status === "done" && fresh(task.updated_at)).length
+      tasks.filter((task) => task.status === "done" && fresh(task.updated_at))
+        .length
     );
   }, [goals, tasks]);
 
@@ -119,18 +143,32 @@ export function OverviewPage() {
   const sortedGoals = useMemo(
     () =>
       [...goals].sort(
-        (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
+        (a, b) =>
+          new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
       ),
     [goals],
   );
 
-  const previewGoals = useMemo(() => sortedGoals.slice(0, 6), [sortedGoals]);
+  const activeGoals = useMemo(
+    () =>
+      sortedGoals.filter(
+        (g) => !["done", "failed", "cancelled"].includes(g.status),
+      ),
+    [sortedGoals],
+  );
+  const historyGoalsCount = sortedGoals.length - activeGoals.length;
+  const previewGoals = useMemo(() => activeGoals.slice(0, 6), [activeGoals]);
 
   const recentDone = useMemo(() => {
     const items: NeedsYouItem[] = [];
-    for (const g of goals) if (g.status === "done") items.push({ kind: "goal", goal: g });
-    for (const task of tasks) if (task.status === "done") items.push({ kind: "task", task });
-    items.sort((a, b) => new Date(itemUpdated(b)).getTime() - new Date(itemUpdated(a)).getTime());
+    for (const g of goals)
+      if (g.status === "done") items.push({ kind: "goal", goal: g });
+    for (const task of tasks)
+      if (task.status === "done") items.push({ kind: "task", task });
+    items.sort(
+      (a, b) =>
+        new Date(itemUpdated(b)).getTime() - new Date(itemUpdated(a)).getTime(),
+    );
     return items.slice(0, 5);
   }, [goals, tasks]);
 
@@ -160,7 +198,11 @@ export function OverviewPage() {
             label={t("hub.secNeedsYou")}
             tone={needsYou.length > 0 ? "attn" : undefined}
           />
-          <StatCard num={runningCount} label={t("hub.statRunning")} tone="live" />
+          <StatCard
+            num={runningCount}
+            label={t("hub.statRunning")}
+            tone="live"
+          />
           <StatCard
             num={sortedJobs.filter((j) => j.enabled).length}
             label={
@@ -176,54 +218,102 @@ export function OverviewPage() {
         <section className="mt-8">
           <SectionHead title={t("hub.secNeedsYou")} count={needsYou.length} />
           {needsYou.length === 0 ? (
-            <p className="text-sm text-muted-foreground">{t("hub.noNeedsYou")}</p>
-          ) : (
-            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-              {needsYou.map((item) => (
-                <NeedsYouCard
-                  key={item.kind === "goal" ? item.goal.id : item.task.id}
-                  item={item}
-                  agentId={agentId}
-                  onOpen={() => openItem(item)}
-                />
-              ))}
+            <div className="rounded-xl border border-border px-4 py-3.5">
+              <p className="text-sm font-medium text-muted-foreground">
+                {t("hub.noNeedsYou")}
+              </p>
+              <p className="mt-1 text-[12.5px] text-muted-foreground">
+                {t("hub.noNeedsYouDesc")}
+              </p>
             </div>
+          ) : (
+            <>
+              <p className="mb-3 text-[12.5px] text-muted-foreground">
+                {t("hub.needsYouHint")}
+              </p>
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                {needsYou.map((item) => (
+                  <NeedsYouCard
+                    key={item.kind === "goal" ? item.goal.id : item.task.id}
+                    item={item}
+                    agentId={agentId}
+                    onOpen={() => openItem(item)}
+                  />
+                ))}
+              </div>
+            </>
           )}
         </section>
 
         {/* Schedules */}
         <section className="mt-8">
-          <SectionHead title={t("hub.secSchedules")} count={sortedJobs.length} />
+          <SectionHead
+            title={t("hub.secSchedules")}
+            count={sortedJobs.length}
+          />
           {sortedJobs.length === 0 ? (
-            <p className="text-sm text-muted-foreground">{t("hub.noSchedules")}</p>
+            <p className="text-sm text-muted-foreground">
+              {t("hub.noSchedules")}
+            </p>
           ) : (
             <SchedulesTable jobs={sortedJobs} agentId={agentId} />
           )}
         </section>
 
         {/* Goals */}
-        {sortedGoals.length > 0 && (
-          <section className="mt-8">
-            <SectionHead
-              title={t("hub.secGoals")}
-              count={sortedGoals.length}
-              action={
+        <section className="mt-8">
+          <SectionHead
+            title={t("hub.activeWork")}
+            count={activeGoals.length}
+            action={
+              <div className="flex items-center gap-2">
+                {historyGoalsCount > 0 && (
+                  <Button
+                    render={
+                      <Link
+                        to="/agents/$agentId/tasks/goals"
+                        params={{ agentId }}
+                        search={{ mode: "history" }}
+                      />
+                    }
+                    variant="ghost"
+                    size="xs"
+                  >
+                    {t("hub.openHistory")}
+                  </Button>
+                )}
                 <Button
-                  render={<Link to="/agents/$agentId/tasks/goals" params={{ agentId }} />}
+                  render={
+                    <Link
+                      to="/agents/$agentId/tasks/goals"
+                      params={{ agentId }}
+                      search={{ mode: "active" }}
+                    />
+                  }
                   variant="outline"
                   size="xs"
                 >
-                  {t("hub.viewAll")}
+                  {t("hub.openActiveGoals")}
                 </Button>
-              }
-            />
+              </div>
+            }
+          />
+          {activeGoals.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              {t("hub.noActiveGoals")}
+            </p>
+          ) : (
             <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
               {previewGoals.map((g) => (
-                <GoalCard key={g.id} goal={g} onOpen={() => openItem({ kind: "goal", goal: g })} />
+                <GoalCard
+                  key={g.id}
+                  goal={g}
+                  onOpen={() => openItem({ kind: "goal", goal: g })}
+                />
               ))}
             </div>
-          </section>
-        )}
+          )}
+        </section>
 
         {/* Recently completed */}
         {recentDone.length > 0 && (
@@ -232,7 +322,8 @@ export function OverviewPage() {
             <div className="overflow-hidden rounded-xl border border-border">
               {recentDone.map((item) => {
                 const id = item.kind === "goal" ? item.goal.id : item.task.id;
-                const title = item.kind === "goal" ? item.goal.title : item.task.title;
+                const title =
+                  item.kind === "goal" ? item.goal.title : item.task.title;
                 return (
                   <button
                     key={`${item.kind}:${id}`}
@@ -240,7 +331,9 @@ export function OverviewPage() {
                     onClick={() => openItem(item)}
                     className="flex w-full items-center gap-3 border-b border-border px-3.5 py-2.5 text-left text-[13px] last:border-b-0 hover:bg-muted/50"
                   >
-                    <span className="min-w-0 flex-1 truncate font-medium">{title}</span>
+                    <span className="min-w-0 flex-1 truncate font-medium">
+                      {title}
+                    </span>
                     <span className="shrink-0 font-mono text-xs text-chart-3">
                       {statusLabel(t, "done")}
                     </span>
@@ -258,13 +351,23 @@ export function OverviewPage() {
   );
 }
 
-type NeedsYouItem = { kind: "goal"; goal: ComponentsGoal } | { kind: "task"; task: ComponentsTask };
+type NeedsYouItem =
+  | { kind: "goal"; goal: ComponentsGoal }
+  | { kind: "task"; task: ComponentsTask };
 
 function itemUpdated(item: NeedsYouItem): string {
   return item.kind === "goal" ? item.goal.updated_at : item.task.updated_at;
 }
 
-function StatCard({ num, label, tone }: { num: number; label: string; tone?: "attn" | "live" }) {
+function StatCard({
+  num,
+  label,
+  tone,
+}: {
+  num: number;
+  label: string;
+  tone?: "attn" | "live";
+}) {
   return (
     <div
       className={cn(
@@ -281,7 +384,10 @@ function StatCard({ num, label, tone }: { num: number; label: string; tone?: "at
       >
         {num}
       </div>
-      <div className="mt-0.5 truncate text-xs text-muted-foreground" title={label}>
+      <div
+        className="mt-0.5 truncate text-xs text-muted-foreground"
+        title={label}
+      >
         {label}
       </div>
     </div>
@@ -326,9 +432,11 @@ function NeedsYouCard({
 
   const status = item.kind === "goal" ? item.goal.status : item.task.status;
   const isFail = status === "failed";
-  const kindLabel = item.kind === "goal" ? t("hub.kindGoal") : t("hub.kindTask");
+  const kindLabel =
+    item.kind === "goal" ? t("hub.kindGoal") : t("hub.kindTask");
   const title = item.kind === "goal" ? item.goal.title : item.task.title;
-  const desc = item.kind === "goal" ? item.goal.description : item.task.description;
+  const desc =
+    item.kind === "goal" ? item.goal.description : item.task.description;
 
   const handleRetry = async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -390,13 +498,21 @@ function NeedsYouCard({
   );
 }
 
-function SchedulesTable({ jobs, agentId }: { jobs: SchedulerJob[]; agentId: string }) {
+function SchedulesTable({
+  jobs,
+  agentId,
+}: {
+  jobs: SchedulerJob[];
+  agentId: string;
+}) {
   const { t } = useI18n();
   const navigate = useNavigate();
   const qc = useQueryClient();
 
   const runQueries = useQueries({
-    queries: jobs.map((j) => schedulerJobRecentRunsOptions(j.agent_id || agentId, j.id)),
+    queries: jobs.map((j) =>
+      schedulerJobRecentRunsOptions(j.agent_id || agentId, j.id),
+    ),
   });
 
   const toggleJob = async (job: SchedulerJob, enabled: boolean) => {
@@ -447,7 +563,9 @@ function SchedulesTable({ jobs, agentId }: { jobs: SchedulerJob[]; agentId: stri
                   {job.name}
                   {job.template_key && (
                     <Badge size="sm" variant="secondary">
-                      {t("automations.subscriptionBadge", { key: job.template_key })}
+                      {t("automations.subscriptionBadge", {
+                        key: job.template_key,
+                      })}
                     </Badge>
                   )}
                 </span>
@@ -458,9 +576,14 @@ function SchedulesTable({ jobs, agentId }: { jobs: SchedulerJob[]; agentId: stri
               <TableCell>
                 <RunSparkline runs={runQueries[i]?.data ?? []} />
               </TableCell>
-              <TableCell className="text-[12.5px]">{next ? formatUntil(t, next) : "—"}</TableCell>
+              <TableCell className="text-[12.5px]">
+                {next ? formatUntil(t, next) : "—"}
+              </TableCell>
               <TableCell onClick={(e) => e.stopPropagation()}>
-                <Switch checked={job.enabled} onCheckedChange={(v) => void toggleJob(job, v)} />
+                <Switch
+                  checked={job.enabled}
+                  onCheckedChange={(v) => void toggleJob(job, v)}
+                />
               </TableCell>
             </TableRow>
           );
@@ -473,7 +596,8 @@ function SchedulesTable({ jobs, agentId }: { jobs: SchedulerJob[]; agentId: stri
 /** Last runs as colored dots, oldest → newest. */
 function RunSparkline({ runs }: { runs: JobRun[] }) {
   const ordered = [...runs].reverse().slice(-10);
-  if (!ordered.length) return <span className="text-xs text-muted-foreground">—</span>;
+  if (!ordered.length)
+    return <span className="text-xs text-muted-foreground">—</span>;
   return (
     <span className="inline-flex items-center gap-[3px]">
       {ordered.map((run) => (
@@ -494,7 +618,13 @@ function RunSparkline({ runs }: { runs: JobRun[] }) {
   );
 }
 
-function GoalCard({ goal, onOpen }: { goal: ComponentsGoal; onOpen: () => void }) {
+function GoalCard({
+  goal,
+  onOpen,
+}: {
+  goal: ComponentsGoal;
+  onOpen: () => void;
+}) {
   const { t } = useI18n();
   const { data: graph } = useQuery(goalGraphOptions(goal.id));
   const r = rollup(graph?.tasks ?? []);
@@ -508,8 +638,15 @@ function GoalCard({ goal, onOpen }: { goal: ComponentsGoal; onOpen: () => void }
       className="cursor-pointer rounded-xl border border-border px-4 py-3.5 hover:bg-muted/40"
     >
       <div className="flex items-center gap-2">
-        <span className={cn("size-1.5 shrink-0 rounded-full", statusMeta(goal.status).dot)} />
-        <span className="min-w-0 flex-1 truncate text-sm font-semibold">{goal.title}</span>
+        <span
+          className={cn(
+            "size-1.5 shrink-0 rounded-full",
+            statusMeta(goal.status).dot,
+          )}
+        />
+        <span className="min-w-0 flex-1 truncate text-sm font-semibold">
+          {goal.title}
+        </span>
         <span className="shrink-0 font-mono text-xs text-muted-foreground">
           {statusLabel(t, goal.status)}
         </span>
@@ -519,11 +656,23 @@ function GoalCard({ goal, onOpen }: { goal: ComponentsGoal; onOpen: () => void }
           {goal.description}
         </div>
       )}
-      {r.total > 0 && <ProgressBar r={r} className="mt-3" />}
+      {r.total > 0 ? (
+        <ProgressBar r={r} className="mt-3" />
+      ) : goal.status === "done" ? (
+        <div className="mt-3 rounded-lg border border-chart-3/25 bg-chart-3/10 px-3 py-2 font-mono text-xs text-chart-3">
+          {t("hub.achievedAt", {
+            time: formatTime(goal.completed_at ?? goal.updated_at),
+          })}
+        </div>
+      ) : null}
       <div className="mt-2 flex flex-wrap gap-x-3.5 font-mono text-xs text-muted-foreground">
-        <span>{t("hub.goalDone", { done: r.done, total: r.total })}</span>
+        {r.total > 0 && (
+          <span>{t("hub.goalDone", { done: r.done, total: r.total })}</span>
+        )}
         {r.blocked > 0 && (
-          <span className="text-chart-4">{t("hub.goalBlocked", { n: r.blocked })}</span>
+          <span className="text-chart-4">
+            {t("hub.goalBlocked", { n: r.blocked })}
+          </span>
         )}
         {r.running > 0 && <span>{t("hub.goalRunning", { n: r.running })}</span>}
         <span>{t("hub.updatedAt", { time: formatTime(goal.updated_at) })}</span>

--- a/web/src/lib/i18n/messages.ts
+++ b/web/src/lib/i18n/messages.ts
@@ -113,16 +113,13 @@ const en = {
   "login.hasAccount": "Already have an account?",
   "login.signUpLink": "Sign up",
   "login.signInLink": "Sign in",
-  "login.noProviders":
-    "No login providers configured. Contact your administrator.",
-  "login.providersUnavailable":
-    "Authentication providers are unavailable. Try again later.",
+  "login.noProviders": "No login providers configured. Contact your administrator.",
+  "login.providersUnavailable": "Authentication providers are unavailable. Try again later.",
   "login.orContinueWith": "Or continue with",
   "login.signupSubtitle": "Create an account to get started",
   "login.noLocalRegistration":
     "Local registration is not available. Please contact your administrator.",
-  "login.registrationDisabled":
-    "Registration is currently disabled on this instance.",
+  "login.registrationDisabled": "Registration is currently disabled on this instance.",
   "login.passwordTooShort": "Password must be at least 8 characters long",
   "login.passwordMismatch": "Passwords do not match",
 
@@ -158,8 +155,7 @@ const en = {
 
   // About
   "about.title": "About",
-  "about.description":
-    "Version and runtime information for this Stella instance.",
+  "about.description": "Version and runtime information for this Stella instance.",
   "about.status": "Status",
   "about.version": "Version",
   "about.commit": "Commit",
@@ -180,8 +176,7 @@ const en = {
   "agents.noAgents": "No agents yet",
   "agents.noAgentsDesc": "Create your first agent to get started.",
   "agents.deleteConfirm": "Delete agent?",
-  "agents.deleteConfirmDesc":
-    "This will permanently delete {{name}} and all associated data.",
+  "agents.deleteConfirmDesc": "This will permanently delete {{name}} and all associated data.",
   "agents.deleted": "Agent deleted",
   "agents.deleteFailed": "Failed to delete agent",
   "agents.created": "Agent created",
@@ -241,14 +236,12 @@ const en = {
   "agents.form.enabled": "Enabled",
   "agents.form.soulPreset": "Soul preset",
   "agents.form.soul": "Soul",
-  "agents.form.soulDesc":
-    "Default personality for all users. Each user can override their own.",
+  "agents.form.soulDesc": "Default personality for all users. Each user can override their own.",
   "agents.form.soulPlaceholder": "Personality and behavior tone…",
   "agents.form.networkPolicy": "Network policy",
   "agents.form.networkMode": "Network mode",
   "agents.form.allowlist": "Allowlist",
-  "agents.form.allowlistHint":
-    "Runtime whitelist support depends on your sandbox backend version.",
+  "agents.form.allowlistHint": "Runtime whitelist support depends on your sandbox backend version.",
   "agents.users.desc": "Manage user access for restricted-scope agents.",
   "agents.users.selectUser": "Select user…",
   "agents.skills.searchPlaceholder": "Search skills…",
@@ -276,24 +269,21 @@ const en = {
   "agents.skills.userScope": "Installed for you in this agent.",
   "agents.skills.agentScope": "Installed for this agent.",
   "agents.skills.addSkill": "Add a skill",
-  "agents.skills.addSkillDesc":
-    "Install from the catalog or upload your own skill bundle.",
+  "agents.skills.addSkillDesc": "Install from the catalog or upload your own skill bundle.",
   "agents.skills.installTarget": "Install target",
   "agents.skills.onlyThisAgent": "Only this agent",
   "agents.skills.myProfile": "My profile",
   "agents.skills.agentOnlyHint":
     "Agent-only install is available after the agent is saved, and only for admins.",
   "agents.skills.browseCatalog": "Browse catalog",
-  "agents.skills.browseCatalogDesc":
-    "Search public skills and install in one click.",
+  "agents.skills.browseCatalogDesc": "Search public skills and install in one click.",
   "agents.skills.noSkillsFound": "No skills found for that search.",
   "agents.skills.startTyping": "Start typing to search the catalog.",
   "agents.skills.installFromSource": "Or install from source",
   "agents.skills.uploadZip": "Upload zip",
   "agents.skills.uploadDesc": "Import a skill you already have on disk.",
   "agents.skills.chooseZip": "Choose a .zip file",
-  "agents.skills.zipRequirement":
-    "Must contain exactly one skill folder with SKILL.md.",
+  "agents.skills.zipRequirement": "Must contain exactly one skill folder with SKILL.md.",
   "agents.skills.browseFiles": "Browse files",
   "agents.skills.uploadSkill": "Upload skill",
   "agents.template.startFrom": "Start from a template",
@@ -312,8 +302,7 @@ const en = {
   "channels.title": "Channels",
   "channels.new": "New Channel",
   "channels.noChannels": "No channels configured",
-  "channels.noChannelsDesc":
-    "Add a channel to connect stella to messaging platforms.",
+  "channels.noChannelsDesc": "Add a channel to connect stella to messaging platforms.",
   "channels.type": "Type",
   "channels.enabled": "Enabled",
   "channels.disabled": "Disabled",
@@ -324,15 +313,13 @@ const en = {
   "channels.updated": "Channel updated",
   "channels.updateFailed": "Failed to update channel",
   "channels.deleteConfirm": "Delete channel?",
-  "channels.deleteConfirmDesc":
-    "This will permanently delete the channel {{name}}.",
+  "channels.deleteConfirmDesc": "This will permanently delete the channel {{name}}.",
 
   // Credentials
   "credentials.title": "Credentials",
   "credentials.new": "New Credential",
   "credentials.noCredentials": "No credentials stored",
-  "credentials.noCredentialsDesc":
-    "Add credentials to authenticate with external services.",
+  "credentials.noCredentialsDesc": "Add credentials to authenticate with external services.",
   "credentials.key": "Key",
   "credentials.value": "Value",
   "credentials.deleted": "Credential deleted",
@@ -342,8 +329,7 @@ const en = {
   "credentials.updated": "Credential updated",
   "credentials.updateFailed": "Failed to update credential",
   "credentials.deleteConfirm": "Delete credential?",
-  "credentials.deleteConfirmDesc":
-    "This will permanently delete the credential {{key}}.",
+  "credentials.deleteConfirmDesc": "This will permanently delete the credential {{key}}.",
 
   // Plugins
   "plugins.title": "Plugins",
@@ -388,8 +374,7 @@ const en = {
   "providers.updated": "Provider updated",
   "providers.updateFailed": "Failed to update provider",
   "providers.deleteConfirm": "Delete provider?",
-  "providers.deleteConfirmDesc":
-    "This will permanently delete the provider {{name}}.",
+  "providers.deleteConfirmDesc": "This will permanently delete the provider {{name}}.",
   "providers.enabled": "Enabled",
   "providers.updateModel": "Update model",
   "providers.addModel": "Add model",
@@ -407,16 +392,14 @@ const en = {
   "providers.maxTokens": "Max tokens",
   "providers.reasoning": "Reasoning",
   "providers.reasoningDesc": "Stores the provider-facing reasoning flag.",
-  "providers.enabledDesc":
-    "Persist model availability on this provider instance.",
+  "providers.enabledDesc": "Persist model availability on this provider instance.",
   "providers.costInput": "Cost input",
   "providers.costOutput": "Cost output",
   "providers.costCacheRead": "Cost cache read",
   "providers.costCacheWrite": "Cost cache write",
   "providers.modelsHint":
     "Toggle models on or off, then save. Custom models can be edited with the form or in the advanced JSON editor.",
-  "providers.noModels":
-    "No models yet. Fetch from the provider or add custom models above.",
+  "providers.noModels": "No models yet. Fetch from the provider or add custom models above.",
   "providers.fetchModels": "Fetch models",
   "providers.fetching": "Fetching...",
   "providers.modelsAvailable": "{{count}} models available",
@@ -440,8 +423,7 @@ const en = {
   "scheduler.title": "Scheduler",
   "scheduler.new": "New Task",
   "scheduler.noTasks": "No scheduled tasks",
-  "scheduler.noTasksDesc":
-    "Create a scheduled task to automate recurring work.",
+  "scheduler.noTasksDesc": "Create a scheduled task to automate recurring work.",
   "scheduler.cron": "Cron Expression",
   "scheduler.nextRun": "Next Run",
   "scheduler.lastRun": "Last Run",
@@ -452,8 +434,7 @@ const en = {
   "scheduler.createFailed": "Failed to create task",
   "scheduler.updated": "Task updated",
   "scheduler.updateFailed": "Failed to update task",
-  "scheduler.deleteConfirmDesc":
-    "This will permanently delete the task {{name}}.",
+  "scheduler.deleteConfirmDesc": "This will permanently delete the task {{name}}.",
   "scheduler.running": "Running…",
 
   // Users
@@ -470,11 +451,9 @@ const en = {
   "users.updated": "User updated",
   "users.updateFailed": "Failed to update user",
   "users.deleteConfirm": "Delete user?",
-  "users.deleteConfirmDesc":
-    "This will permanently delete the user {{username}}.",
+  "users.deleteConfirmDesc": "This will permanently delete the user {{username}}.",
   "users.resetPassword": "Reset Password",
-  "users.desc":
-    "Manage authentication, roles, linked accounts, and memory databases.",
+  "users.desc": "Manage authentication, roles, linked accounts, and memory databases.",
   "users.admins": "Admins",
   "users.users": "Users",
   "users.active": "Active",
@@ -490,13 +469,11 @@ const en = {
   "users.unlinkIdentity": "Unlink {{platform}} identity?",
   "users.identityUnlinked": "Identity unlinked",
   "users.notifyChannel": "Notify channel",
-  "users.notifyChannelDesc":
-    "Which channel receives scheduler and tool notifications.",
+  "users.notifyChannelDesc": "Which channel receives scheduler and tool notifications.",
   "users.autoFirst": "Auto (first linked)",
   "users.notifyUpdated": "Notify channel updated",
   "users.agentAssignments": "Agent assignments",
-  "users.noAgentAssignments":
-    "No agent assignments (has access to all system-scope agents).",
+  "users.noAgentAssignments": "No agent assignments (has access to all system-scope agents).",
   "users.agentAssigned": "Agent assigned",
   "users.agentRemoved": "Agent removed",
   "users.selectAgent": "Select agent...",
@@ -519,8 +496,7 @@ const en = {
   "sessions.deleted": "Session deleted",
   "sessions.deleteFailed": "Failed to delete session",
   "sessions.deleteConfirm": "Delete session?",
-  "sessions.deleteConfirmDesc":
-    "This will permanently delete this session and all its messages.",
+  "sessions.deleteConfirmDesc": "This will permanently delete this session and all its messages.",
   "sessions.search": "Search sessions…",
   "sessions.composer.placeholder": "Message…",
   "sessions.composer.send": "Send",
@@ -675,17 +651,13 @@ const en = {
   "automations.tab.log": "Log",
   "automations.now.title": "Tasks",
   "automations.tasks.title": "Tasks",
-  "automations.now.description":
-    "Tasks Stella is doing or waiting for you to review.",
-  "automations.tasks.description":
-    "Tasks Stella is doing or waiting for you to review.",
+  "automations.now.description": "Tasks Stella is doing or waiting for you to review.",
+  "automations.tasks.description": "Tasks Stella is doing or waiting for you to review.",
   "automations.scheduler.title": "Scheduler",
-  "automations.scheduler.description":
-    "Things Stella should start later or repeat automatically.",
+  "automations.scheduler.description": "Things Stella should start later or repeat automatically.",
   "automations.scheduler.empty": "No schedules yet.",
   "automations.log.title": "Log",
-  "automations.log.description":
-    "What ran, when it ran, and whether it succeeded.",
+  "automations.log.description": "What ran, when it ran, and whether it succeeded.",
   "automations.log.empty": "No recent automation history yet.",
   "automations.refreshing": "Refreshing…",
   "automations.newWork": "New task",
@@ -707,8 +679,7 @@ const en = {
   "automations.empty.failures": "No failed tasks.",
   "automations.detail.task": "Task detail",
   "automations.select.title": "Select an item",
-  "automations.select.description":
-    "Pick a task, scheduler item, or log entry to inspect it here.",
+  "automations.select.description": "Pick a task, scheduler item, or log entry to inspect it here.",
   "automations.confirm.deleteTask": "Delete this task?",
   "automations.confirm.deleteSchedule": "Delete this schedule?",
 
@@ -724,8 +695,7 @@ const en = {
   "sessions.sidebar.renameRequired": "Thread name is required.",
   "sessions.sidebar.renameFailed": "Failed to rename thread",
   "sessions.sidebar.deleteThreadConfirm": "Delete this thread?",
-  "sessions.sidebar.deleteProjectConfirm":
-    "Delete this project? Sessions will be kept.",
+  "sessions.sidebar.deleteProjectConfirm": "Delete this project? Sessions will be kept.",
 
   // Sessions panel — automation
 
@@ -746,8 +716,7 @@ const en = {
 
   // Sessions panel — memory
   "sessions.memory.title": "User Profile",
-  "sessions.memory.context":
-    "Persistent context this agent will remember across conversations.",
+  "sessions.memory.context": "Persistent context this agent will remember across conversations.",
   "sessions.memory.empty": "No memory yet.",
   "sessions.memory.placeholder":
     "What should this agent remember? Use natural language or bullet points.",
@@ -755,30 +724,24 @@ const en = {
 
   // Sessions panel — soul
   "sessions.soul.title": "Agent Soul",
-  "sessions.soul.subtitle":
-    "Default personality and behavior tone for this agent.",
+  "sessions.soul.subtitle": "Default personality and behavior tone for this agent.",
   "sessions.soul.empty": "No soul configured.",
-  "sessions.soul.placeholder":
-    "Describe the agent's personality, tone, and behavior…",
+  "sessions.soul.placeholder": "Describe the agent's personality, tone, and behavior…",
   "sessions.soul.saving": "Saving…",
 
   // Memories
   "memories.title": "Memories",
   "memories.soul.title": "Agent Soul",
-  "memories.soul.description":
-    "The agent's personality, tone, and default behavior.",
+  "memories.soul.description": "The agent's personality, tone, and default behavior.",
   "memories.soul.empty": "No soul configured yet.",
-  "memories.soul.placeholder":
-    "Describe the agent's personality, tone, and behavior…",
+  "memories.soul.placeholder": "Describe the agent's personality, tone, and behavior…",
   "memories.profile.title": "User Profile",
-  "memories.profile.description":
-    "Persistent context this agent remembers about you.",
+  "memories.profile.description": "Persistent context this agent remembers about you.",
   "memories.profile.empty": "No profile memory yet.",
   "memories.profile.placeholder":
     "What should this agent remember? Use natural language or bullet points.",
   "memories.constraints.title": "Constraints",
-  "memories.constraints.description":
-    "Hard rules the agent must always follow.",
+  "memories.constraints.description": "Hard rules the agent must always follow.",
   "memories.constraints.empty":
     "No constraints set. Constraints are hard rules the agent must always follow.",
   "memories.constraints.error": "Failed to load constraints.",
@@ -794,8 +757,7 @@ const en = {
   "sessions.task.subtitle": "The agent will work on this task asynchronously.",
   "sessions.task.creating": "Creating…",
   "sessions.task.createBtn": "Create task",
-  "sessions.task.descPlaceholder":
-    "Additional context, constraints, or acceptance criteria…",
+  "sessions.task.descPlaceholder": "Additional context, constraints, or acceptance criteria…",
   "sessions.task.priorityRoutineDesc": "Routine — handle when possible",
   "sessions.task.priorityUrgentDesc": "Urgent — prioritize immediately",
 
@@ -853,14 +815,14 @@ const en = {
   "goals.noEvents": "No events yet.",
   "goals.modeActive": "Active",
   "goals.modeHistory": "History",
+  "goals.modeArchived": "Archived",
   "goals.searchPlaceholder": "Search goals…",
   "goals.statusAll": "All statuses",
   "goals.filteredCount": "{{count}} shown",
-  "goals.hideSelected": "Hide {{count}} closed",
-  "goals.restoreHidden": "Restore {{count}} hidden",
+  "goals.archiveSelected": "Archive {{count}} selected",
+  "goals.restoreSelected": "Restore {{count}} selected",
   "goals.noMatches": "No matching goals",
-  "goals.noMatchesDesc":
-    "Try a different search, status, or active/history view.",
+  "goals.noMatchesDesc": "Try a different search, status, or active/history view.",
   "goals.selectGoal": "Select goal",
   "goals.achieved": "Achieved",
   "goals.hookAchieved": "Achieved {{time}}",
@@ -874,10 +836,8 @@ const en = {
     "Start here: blocked goals, reviews, and failed tasks are the only things demanding action.",
   "hub.openActiveGoals": "Open active goals",
   "hub.openHistory": "Open history",
-  "hub.noNeedsYouDesc":
-    "Active work is still running; nothing is blocked or waiting on review.",
-  "hub.noActiveGoals":
-    "No active goals. History stays one click away when you need receipts.",
+  "hub.noNeedsYouDesc": "Active work is still running; nothing is blocked or waiting on review.",
+  "hub.noActiveGoals": "No active goals. History stays one click away when you need receipts.",
   "hub.achievedAt": "Achieved {{time}}",
 
   // Automations hub (unified page)
@@ -971,8 +931,7 @@ const en = {
   "hub.blockerKindToolError": "Tool error",
   "hub.blockerKindPolicyHold": "Policy hold",
   "hub.blockerKindDepFailure": "Upstream dependency failed",
-  "hub.blockerAnswerPlaceholder":
-    "Write your answer; the agent resumes with it…",
+  "hub.blockerAnswerPlaceholder": "Write your answer; the agent resumes with it…",
   "hub.resolveBlocker": "Resolve & resume",
   "hub.failedDeps": "Failed dependencies",
   "hub.waiveDep": "Waive",
@@ -1056,11 +1015,9 @@ const en = {
   "credentials.scope.userAgent.desc":
     "Injected only when you use the selected agent. Highest priority.",
   "credentials.scope.system.label": "Global · all agents",
-  "credentials.scope.system.desc":
-    "Shared by all users. Lowest priority. Admin only.",
+  "credentials.scope.system.desc": "Shared by all users. Lowest priority. Admin only.",
   "credentials.scope.systemAgent.label": "Global · specific agent",
-  "credentials.scope.systemAgent.desc":
-    "Shared by all users of the selected agent. Admin only.",
+  "credentials.scope.systemAgent.desc": "Shared by all users of the selected agent. Admin only.",
   "credentials.scope.reserved": "Managed by stella · read-only",
   "credentials.scope.agentMissing": "Select an agent for this scope.",
   "credentials.scope.priorityTitle": "Priority — higher overrides lower",
@@ -1105,15 +1062,13 @@ const en = {
   "credentials.oauth.clientIdRequired": "Client ID is required",
   "credentials.oauth.error": "OAuth error",
   "credentials.oauth.connectedSuccess": "{{provider}} connected successfully",
-  "credentials.oauth.authorizationState":
-    "{{provider}} authorization {{state}}",
+  "credentials.oauth.authorizationState": "{{provider}} authorization {{state}}",
   "credentials.oauth.disconnectConfirm": "Disconnect {{provider}} credentials?",
   "credentials.oauth.disconnected": "{{provider}} disconnected",
   "credentials.oauth.disconnectFailed": "Failed to disconnect",
   "credentials.oauth.configSaved": "{{provider}} credentials saved",
   "credentials.oauth.configSaveFailed": "Failed to save config",
-  "credentials.oauth.resetConfirm":
-    "Reset {{provider}} credentials to defaults?",
+  "credentials.oauth.resetConfirm": "Reset {{provider}} credentials to defaults?",
   "credentials.oauth.configReset": "{{provider}} credentials reset to defaults",
   "credentials.oauth.configResetFailed": "Failed to reset config",
   "credentials.email.default": "Default",
@@ -1188,19 +1143,15 @@ const en = {
   "skills.scope.current": "current",
   "skills.scope.agentMissing": "Select an agent for this scope.",
   "skills.scope.user.label": "Mine · all agents",
-  "skills.scope.user.desc":
-    "Skills you added — available across all of your agents.",
+  "skills.scope.user.desc": "Skills you added — available across all of your agents.",
   "skills.scope.userAgent.label": "Mine · this agent",
-  "skills.scope.userAgent.desc":
-    "Skills you added — active only in this agent. Highest priority.",
+  "skills.scope.userAgent.desc": "Skills you added — active only in this agent. Highest priority.",
   "skills.scope.system.label": "System · all agents",
-  "skills.scope.system.desc":
-    "Preset skills — available in every agent. Lowest priority.",
+  "skills.scope.system.desc": "Preset skills — available in every agent. Lowest priority.",
   "skills.scope.systemAgent.label": "System · this agent",
   "skills.scope.systemAgent.desc": "Preset skills — active only in this agent.",
   "skills.scope.project.label": "Project",
-  "skills.scope.project.desc":
-    "Managed in the project's filesystem. Read-only here.",
+  "skills.scope.project.desc": "Managed in the project's filesystem. Read-only here.",
 
   // Login (additions)
   "login.email": "Email",
@@ -1226,13 +1177,11 @@ const en = {
   "sessions.inspector.tools": "Tools",
   "sessions.inspector.prompt": "Prompt",
   "sessions.inspector.inspector": "Inspector",
-  "sessions.inspector.sessionWorkspace":
-    "Session workspace, work queue, and context",
+  "sessions.inspector.sessionWorkspace": "Session workspace, work queue, and context",
   "sessions.skill.installSkill": "Install a skill",
   "sessions.skill.catalog": "Catalog",
   "sessions.skill.searchSkills": "Search skills...",
-  "sessions.skill.searchPublic":
-    "Search public skills and install one into the selected target.",
+  "sessions.skill.searchPublic": "Search public skills and install one into the selected target.",
   "sessions.skill.noSkillsFound": "No skills found for that search.",
   "sessions.skill.searchCatalog": "Search the catalog",
   "sessions.skill.resultsAppear": "Results appear here as you type.",
@@ -1245,8 +1194,7 @@ const en = {
   "sessions.skill.myProfile": "My profile",
   "sessions.skill.thisAgent": "This agent",
   "sessions.skill.adminOnly": "Agent installs are available to admins.",
-  "sessions.skill.catalogDesc":
-    "Search the catalog or import a zip bundle into Stella.",
+  "sessions.skill.catalogDesc": "Search the catalog or import a zip bundle into Stella.",
   "sessions.sidebar.newProject": "New Project",
   "sessions.sidebar.projectName": "Project name",
   "sessions.sidebar.selectFolder": "Select a workspace folder for this agent.",
@@ -1271,11 +1219,9 @@ const en = {
   "sessions.skillsList.project": "Project",
   "sessions.skillsList.userDesc": "Your personal skills, visible only to you",
   "sessions.skillsList.user_agentDesc": "Your skills for this agent only",
-  "sessions.skillsList.system_agentDesc":
-    "Shared with everyone who uses this agent",
+  "sessions.skillsList.system_agentDesc": "Shared with everyone who uses this agent",
   "sessions.skillsList.systemDesc": "Built into Stella, read-only",
-  "sessions.skillsList.projectDesc":
-    "Loaded from the project directory, managed via files",
+  "sessions.skillsList.projectDesc": "Loaded from the project directory, managed via files",
   "sessions.skillsList.noAgentSkills": "No agent-level skills installed.",
   "sessions.skillsList.noSystemSkills": "No system skills.",
   "sessions.skillsList.noProjectSkills": "No skills in the project directory.",
@@ -1293,10 +1239,8 @@ const en = {
   "sessions.skillsList.githubSkill": "Skill",
   "sessions.skillsList.githubSkillPlaceholder": "skill name within the repo",
   "sessions.skillsList.githubVersion": "Version (optional)",
-  "sessions.skillsList.githubVersionPlaceholder":
-    "tag or branch — blank uses the default branch",
-  "sessions.skillsList.githubHint":
-    "Private repos require a connected GitHub account.",
+  "sessions.skillsList.githubVersionPlaceholder": "tag or branch — blank uses the default branch",
+  "sessions.skillsList.githubHint": "Private repos require a connected GitHub account.",
   "sessions.skillsList.upgradeCheck": "Check for updates",
   "sessions.skillsList.upgradeDone": "Updated to {version}",
   "sessions.skillsList.upgradeUpToDate": "Already up to date",
@@ -1310,16 +1254,14 @@ const en = {
   "sessions.skillsList.scope": "Scope",
   "sessions.skillsList.status": "Status",
   "sessions.skillsList.versionLabel": "Version",
-  "sessions.skillsList.versionHint":
-    "Recorded tag, branch, or commit. Cleared if left blank.",
+  "sessions.skillsList.versionHint": "Recorded tag, branch, or commit. Cleared if left blank.",
   "sessions.skillsList.modelInvocation": "Model invocation",
   "sessions.skillsList.fileCount": "Files",
   "sessions.skillsList.readonlyNote": "This skill is read-only at this scope.",
   "sessions.skillsList.statusActive": "Active",
   "sessions.skillsList.statusDraft": "Draft",
   "sessions.skillsList.statusDeprecated": "Deprecated",
-  "sessions.skillsList.modelInvocationHint":
-    "Allow the model to call this skill automatically.",
+  "sessions.skillsList.modelInvocationHint": "Allow the model to call this skill automatically.",
   "sessions.skillsList.deleteSkill": "Delete skill",
   "sessions.skillsList.deleteConfirm": "Delete this skill?",
   "sessions.skillsList.deleteConfirmDesc":
@@ -1358,8 +1300,7 @@ const en = {
     "Search the mise registry by name, or type a mise key (e.g. github:owner/repo). Stella installs it and keeps it in sync.",
   "plugins.searchRegistry": "Search a tool name or mise key…",
   "plugins.searchingRegistry": "Searching…",
-  "plugins.noRegistryMatches":
-    "No matches. You can still add a mise key directly.",
+  "plugins.noRegistryMatches": "No matches. You can still add a mise key directly.",
   "plugins.useDirectKey": 'Use "{{key}}" as a mise key',
   "plugins.miseKey": "mise key",
   "plugins.cliToolName": "Name",
@@ -1505,8 +1446,7 @@ const en = {
   "plugins.displayName": "Display name",
   "plugins.binaries": "Binaries",
   "plugins.addBinary": "+ Add binary",
-  "plugins.noBinaries":
-    "No binaries declared. Add one to install a CLI from a GitHub release.",
+  "plugins.noBinaries": "No binaries declared. Add one to install a CLI from a GitHub release.",
   "plugins.binaryN": "Binary {{n}}",
   "plugins.githubRepoLabel": "GitHub repo (owner/repo)",
   "plugins.binPath": "Bin path",
@@ -1519,8 +1459,7 @@ const en = {
   "plugins.sourceLabel": "Source",
   "plugins.valueStaticOnly": "Value (static only)",
   "plugins.oauthProvider": "OAuth provider",
-  "plugins.overrideDesc":
-    "Override the manifest definition. Binaries sync on save.",
+  "plugins.overrideDesc": "Override the manifest definition. Binaries sync on save.",
   "plugins.exeOverride": "Exe override",
   "plugins.nameLabel": "Name",
   "plugins.descriptionLabel": "Description",
@@ -1545,14 +1484,12 @@ const en = {
   "channels.channelIdPlaceholder": "e.g. feishu-coder",
   "channels.channelIdDesc":
     'Must not match the platform ID (e.g. not "telegram" for a Telegram channel).',
-  "channels.weixinChannelIdDesc":
-    'WeChat is singleton-only; the channel ID is fixed to "weixin".',
+  "channels.weixinChannelIdDesc": 'WeChat is singleton-only; the channel ID is fixed to "weixin".',
   "channels.configuration": "Configuration",
   "channels.boundAgent": "Bound agent",
   "channels.boundAgentDesc":
     "Messages received by this bot are routed to this agent. Each agent can only have one channel per platform.",
-  "channels.noAvailableAgents":
-    "No enabled agents are available for this platform.",
+  "channels.noAvailableAgents": "No enabled agents are available for this platform.",
   "channels.selectAgent": "Select agent...",
   "channels.manualFeishuSetup": "I already have a Feishu app",
   "channels.manualWeixinSetup": "I already have WeChat iLink credentials",
@@ -1567,13 +1504,11 @@ const en = {
     "Scan with the Feishu mobile app, then confirm the app creation request.",
   "channels.scanFeishuQrAlt": "Feishu bot registration QR code",
   "channels.scanWeixinTitle": "Create WeChat bot",
-  "channels.scanWeixinDesc":
-    "Scan with the WeChat mobile app, then confirm bot creation.",
+  "channels.scanWeixinDesc": "Scan with the WeChat mobile app, then confirm bot creation.",
   "channels.scanWeixinQrAlt": "WeChat bot registration QR code",
   "channels.scanNeedsName": "Enter a name before starting QR setup.",
   "channels.scanNeedsId": "Enter a channel ID before starting QR setup.",
-  "channels.scanNeedsAgent":
-    "Bind this channel to an agent before starting QR setup.",
+  "channels.scanNeedsAgent": "Bind this channel to an agent before starting QR setup.",
   "channels.scanExpired": "QR code expired. Try again.",
   "channels.waiting": "Waiting",
 
@@ -1635,8 +1570,7 @@ const en = {
 
   // Workspace share dialog
   "sessions.workspace.shareArtifact": "Share artifact",
-  "sessions.workspace.shareDesc":
-    "Create a public, read-only snapshot link for {{file}}.",
+  "sessions.workspace.shareDesc": "Create a public, read-only snapshot link for {{file}}.",
   "sessions.workspace.thisFile": "this file",
   "sessions.workspace.expiration": "Expiration",
   "sessions.workspace.1hour": "1 hour",
@@ -1929,8 +1863,7 @@ const zh: Record<MessageKey, string> = {
   "agents.skills.deleteFile": "删除文件",
   "agents.skills.disableModelInvocation": "禁用模型调用",
   "agents.skills.noMatch": "没有技能匹配此筛选条件。",
-  "agents.skills.saveFirst":
-    "如果要添加或自定义智能体专用技能，请先保存智能体。",
+  "agents.skills.saveFirst": "如果要添加或自定义智能体专用技能，请先保存智能体。",
   "agents.skills.noDescription": "暂无描述。",
   "agents.skills.noContent": "暂无内容。",
   "agents.skills.systemScope": "系统技能，此处只读。",
@@ -1954,8 +1887,7 @@ const zh: Record<MessageKey, string> = {
   "agents.skills.browseFiles": "浏览文件",
   "agents.skills.uploadSkill": "上传技能",
   "agents.template.startFrom": "从模板开始",
-  "agents.template.templateDesc":
-    "模板会预填系统提示词、技能和模型。保存前可以编辑所有内容。",
+  "agents.template.templateDesc": "模板会预填系统提示词、技能和模型。保存前可以编辑所有内容。",
   "agents.template.blank": "空白",
   "agents.template.blankSlate": "空白模板",
   "agents.template.blankDesc": "从零开始自行配置所有内容。",
@@ -2064,8 +1996,7 @@ const zh: Record<MessageKey, string> = {
   "providers.costOutput": "输出成本",
   "providers.costCacheRead": "缓存读取成本",
   "providers.costCacheWrite": "缓存写入成本",
-  "providers.modelsHint":
-    "开关模型后点击保存。自定义模型可通过表单或高级 JSON 编辑器编辑。",
+  "providers.modelsHint": "开关模型后点击保存。自定义模型可通过表单或高级 JSON 编辑器编辑。",
   "providers.noModels": "暂无模型。从提供商获取或添加自定义模型。",
   "providers.fetchModels": "获取模型",
   "providers.fetching": "获取中...",
@@ -2385,8 +2316,7 @@ const zh: Record<MessageKey, string> = {
   "sessions.memory.title": "用户档案",
   "sessions.memory.context": "此 agent 在所有对话中都会记住的持久上下文。",
   "sessions.memory.empty": "暂无记忆。",
-  "sessions.memory.placeholder":
-    "该 agent 应该记住什么？用自然语言或要点列表。",
+  "sessions.memory.placeholder": "该 agent 应该记住什么？用自然语言或要点列表。",
   "sessions.memory.saving": "保存中…",
 
   // Sessions panel — soul
@@ -2405,8 +2335,7 @@ const zh: Record<MessageKey, string> = {
   "memories.profile.title": "用户档案",
   "memories.profile.description": "该 agent 会持续记住的你的上下文。",
   "memories.profile.empty": "还没有用户档案记忆。",
-  "memories.profile.placeholder":
-    "该 agent 应该记住什么？用自然语言或要点列表。",
+  "memories.profile.placeholder": "该 agent 应该记住什么？用自然语言或要点列表。",
   "memories.constraints.title": "约束",
   "memories.constraints.description": "Agent 必须始终遵守的硬规则。",
   "memories.constraints.empty": "暂无约束。约束是 agent 必须始终遵守的硬规则。",
@@ -2481,11 +2410,12 @@ const zh: Record<MessageKey, string> = {
   "goals.noEvents": "暂无事件。",
   "goals.modeActive": "活跃",
   "goals.modeHistory": "历史",
+  "goals.modeArchived": "已归档",
   "goals.searchPlaceholder": "搜索目标…",
   "goals.statusAll": "全部状态",
   "goals.filteredCount": "显示 {{count}} 个",
-  "goals.hideSelected": "隐藏 {{count}} 个已关闭",
-  "goals.restoreHidden": "恢复 {{count}} 个隐藏项",
+  "goals.archiveSelected": "归档选中 {{count}} 个",
+  "goals.restoreSelected": "恢复选中 {{count}} 个",
   "goals.noMatches": "没有匹配的目标",
   "goals.noMatchesDesc": "换个搜索词、状态，或切换活跃/历史视图。",
   "goals.selectGoal": "选择目标",
@@ -2497,8 +2427,7 @@ const zh: Record<MessageKey, string> = {
   "goals.pageStatus": "第 {{page}}/{{totalPages}} 页 · 共 {{total}} 个",
   "hub.activeWork": "活跃工作",
   "hub.historyArchive": "历史归档",
-  "hub.needsYouHint":
-    "先看这里：阻塞目标、审批和失败任务才是真正需要你处理的事项。",
+  "hub.needsYouHint": "先看这里：阻塞目标、审批和失败任务才是真正需要你处理的事项。",
   "hub.openActiveGoals": "打开活跃目标",
   "hub.openHistory": "打开历史",
   "hub.noNeedsYouDesc": "活跃工作仍在运行；目前没有阻塞或等待审批。",
@@ -2677,13 +2606,11 @@ const zh: Record<MessageKey, string> = {
   "credentials.scope.user.label": "我的 · 所有 Agent",
   "credentials.scope.user.desc": "注入到你所有 agent 的会话中。",
   "credentials.scope.userAgent.label": "我的 · 指定 Agent",
-  "credentials.scope.userAgent.desc":
-    "仅在你使用所选 agent 时注入，优先级最高。",
+  "credentials.scope.userAgent.desc": "仅在你使用所选 agent 时注入，优先级最高。",
   "credentials.scope.system.label": "全局 · 所有 Agent",
   "credentials.scope.system.desc": "所有用户共享，优先级最低。仅管理员。",
   "credentials.scope.systemAgent.label": "全局 · 指定 Agent",
-  "credentials.scope.systemAgent.desc":
-    "所有用户使用所选 agent 时共享。仅管理员。",
+  "credentials.scope.systemAgent.desc": "所有用户使用所选 agent 时共享。仅管理员。",
   "credentials.scope.reserved": "由 stella 托管 · 只读",
   "credentials.scope.agentMissing": "请为该范围选择一个 agent。",
   "credentials.scope.priorityTitle": "优先级 — 上覆盖下",
@@ -2811,8 +2738,7 @@ const zh: Record<MessageKey, string> = {
   "skills.scope.user.label": "我的 · 全部智能体",
   "skills.scope.user.desc": "你添加的技能，在你的每个智能体中都可用。",
   "skills.scope.userAgent.label": "我的 · 仅此智能体",
-  "skills.scope.userAgent.desc":
-    "你添加的技能，只在当前这个智能体中生效。优先级最高。",
+  "skills.scope.userAgent.desc": "你添加的技能，只在当前这个智能体中生效。优先级最高。",
   "skills.scope.system.label": "系统 · 全部智能体",
   "skills.scope.system.desc": "系统预设技能，所有智能体通用。优先级最低。",
   "skills.scope.systemAgent.label": "系统 · 仅此智能体",
@@ -2901,8 +2827,7 @@ const zh: Record<MessageKey, string> = {
   "sessions.skillsList.githubSkill": "技能",
   "sessions.skillsList.githubSkillPlaceholder": "仓库内的技能名",
   "sessions.skillsList.githubVersion": "版本（可选）",
-  "sessions.skillsList.githubVersionPlaceholder":
-    "tag 或 branch — 留空用默认分支",
+  "sessions.skillsList.githubVersionPlaceholder": "tag 或 branch — 留空用默认分支",
   "sessions.skillsList.githubHint": "私有仓库需要已连接 GitHub 账号。",
   "sessions.skillsList.upgradeCheck": "检查更新",
   "sessions.skillsList.upgradeDone": "已更新到 {version}",
@@ -2913,8 +2838,7 @@ const zh: Record<MessageKey, string> = {
   "sessions.skillsList.scopeFilter": "范围",
   "sessions.skillsList.uploadZip": "上传 ZIP",
   "sessions.skillsList.searchPlaceholder": "搜索技能…",
-  "sessions.skillsList.stats":
-    "{{total}} 项技能 · {{callable}} 项可自动调用 · {{readonly}} 项只读",
+  "sessions.skillsList.stats": "{{total}} 项技能 · {{callable}} 项可自动调用 · {{readonly}} 项只读",
   "sessions.skillsList.readonly": "只读",
   "sessions.skillsList.manual": "手动",
   "sessions.skillsList.auto": "自动",
@@ -2922,8 +2846,7 @@ const zh: Record<MessageKey, string> = {
   "sessions.skillsList.scope": "作用域",
   "sessions.skillsList.status": "状态",
   "sessions.skillsList.versionLabel": "版本",
-  "sessions.skillsList.versionHint":
-    "记录的 tag、branch 或 commit。留空则清除。",
+  "sessions.skillsList.versionHint": "记录的 tag、branch 或 commit。留空则清除。",
   "sessions.skillsList.modelInvocation": "模型调用",
   "sessions.skillsList.fileCount": "文件数",
   "sessions.skillsList.readonlyNote": "此作用域的技能为只读。",
@@ -2933,8 +2856,7 @@ const zh: Record<MessageKey, string> = {
   "sessions.skillsList.modelInvocationHint": "允许模型自动调用此技能。",
   "sessions.skillsList.deleteSkill": "删除技能",
   "sessions.skillsList.deleteConfirm": "删除此技能？",
-  "sessions.skillsList.deleteConfirmDesc":
-    "将永久删除 {{name}} 及其文件，此操作无法撤销。",
+  "sessions.skillsList.deleteConfirmDesc": "将永久删除 {{name}} 及其文件，此操作无法撤销。",
   "sessions.skillsList.saved": "设置已保存",
   "sessions.skillsList.emptyFile": "此文件为空。",
   "sessions.skillsList.name": "名称",
@@ -2963,8 +2885,7 @@ const zh: Record<MessageKey, string> = {
 
   // Plugins (additions)
   "plugins.addTool": "添加工具",
-  "plugins.addToolDesc":
-    "声明 GitHub 发布二进制文件。Stella 将其写入 plugins.yaml 并自动同步。",
+  "plugins.addToolDesc": "声明 GitHub 发布二进制文件。Stella 将其写入 plugins.yaml 并自动同步。",
   "plugins.addCliToolDesc":
     "按名称搜索 mise 注册表，或直接输入 mise 标识（如 github:owner/repo）。Stella 会自动安装并保持同步。",
   "plugins.searchRegistry": "搜索工具名称或 mise 标识…",
@@ -3149,8 +3070,7 @@ const zh: Record<MessageKey, string> = {
   "channels.namePlaceholder": "例如：飞书编码助手",
   "channels.channelId": "频道 ID",
   "channels.channelIdPlaceholder": "例如：feishu-coder",
-  "channels.channelIdDesc":
-    '不能和平台 ID 相同（例如 Telegram 频道不能填写 "telegram"）。',
+  "channels.channelIdDesc": '不能和平台 ID 相同（例如 Telegram 频道不能填写 "telegram"）。',
   "channels.weixinChannelIdDesc": '微信是单例频道；频道 ID 固定为 "weixin"。',
   "channels.configuration": "配置",
   "channels.boundAgent": "绑定 Agent",

--- a/web/src/lib/i18n/messages.ts
+++ b/web/src/lib/i18n/messages.ts
@@ -113,13 +113,16 @@ const en = {
   "login.hasAccount": "Already have an account?",
   "login.signUpLink": "Sign up",
   "login.signInLink": "Sign in",
-  "login.noProviders": "No login providers configured. Contact your administrator.",
-  "login.providersUnavailable": "Authentication providers are unavailable. Try again later.",
+  "login.noProviders":
+    "No login providers configured. Contact your administrator.",
+  "login.providersUnavailable":
+    "Authentication providers are unavailable. Try again later.",
   "login.orContinueWith": "Or continue with",
   "login.signupSubtitle": "Create an account to get started",
   "login.noLocalRegistration":
     "Local registration is not available. Please contact your administrator.",
-  "login.registrationDisabled": "Registration is currently disabled on this instance.",
+  "login.registrationDisabled":
+    "Registration is currently disabled on this instance.",
   "login.passwordTooShort": "Password must be at least 8 characters long",
   "login.passwordMismatch": "Passwords do not match",
 
@@ -155,7 +158,8 @@ const en = {
 
   // About
   "about.title": "About",
-  "about.description": "Version and runtime information for this Stella instance.",
+  "about.description":
+    "Version and runtime information for this Stella instance.",
   "about.status": "Status",
   "about.version": "Version",
   "about.commit": "Commit",
@@ -176,7 +180,8 @@ const en = {
   "agents.noAgents": "No agents yet",
   "agents.noAgentsDesc": "Create your first agent to get started.",
   "agents.deleteConfirm": "Delete agent?",
-  "agents.deleteConfirmDesc": "This will permanently delete {{name}} and all associated data.",
+  "agents.deleteConfirmDesc":
+    "This will permanently delete {{name}} and all associated data.",
   "agents.deleted": "Agent deleted",
   "agents.deleteFailed": "Failed to delete agent",
   "agents.created": "Agent created",
@@ -236,12 +241,14 @@ const en = {
   "agents.form.enabled": "Enabled",
   "agents.form.soulPreset": "Soul preset",
   "agents.form.soul": "Soul",
-  "agents.form.soulDesc": "Default personality for all users. Each user can override their own.",
+  "agents.form.soulDesc":
+    "Default personality for all users. Each user can override their own.",
   "agents.form.soulPlaceholder": "Personality and behavior tone…",
   "agents.form.networkPolicy": "Network policy",
   "agents.form.networkMode": "Network mode",
   "agents.form.allowlist": "Allowlist",
-  "agents.form.allowlistHint": "Runtime whitelist support depends on your sandbox backend version.",
+  "agents.form.allowlistHint":
+    "Runtime whitelist support depends on your sandbox backend version.",
   "agents.users.desc": "Manage user access for restricted-scope agents.",
   "agents.users.selectUser": "Select user…",
   "agents.skills.searchPlaceholder": "Search skills…",
@@ -269,21 +276,24 @@ const en = {
   "agents.skills.userScope": "Installed for you in this agent.",
   "agents.skills.agentScope": "Installed for this agent.",
   "agents.skills.addSkill": "Add a skill",
-  "agents.skills.addSkillDesc": "Install from the catalog or upload your own skill bundle.",
+  "agents.skills.addSkillDesc":
+    "Install from the catalog or upload your own skill bundle.",
   "agents.skills.installTarget": "Install target",
   "agents.skills.onlyThisAgent": "Only this agent",
   "agents.skills.myProfile": "My profile",
   "agents.skills.agentOnlyHint":
     "Agent-only install is available after the agent is saved, and only for admins.",
   "agents.skills.browseCatalog": "Browse catalog",
-  "agents.skills.browseCatalogDesc": "Search public skills and install in one click.",
+  "agents.skills.browseCatalogDesc":
+    "Search public skills and install in one click.",
   "agents.skills.noSkillsFound": "No skills found for that search.",
   "agents.skills.startTyping": "Start typing to search the catalog.",
   "agents.skills.installFromSource": "Or install from source",
   "agents.skills.uploadZip": "Upload zip",
   "agents.skills.uploadDesc": "Import a skill you already have on disk.",
   "agents.skills.chooseZip": "Choose a .zip file",
-  "agents.skills.zipRequirement": "Must contain exactly one skill folder with SKILL.md.",
+  "agents.skills.zipRequirement":
+    "Must contain exactly one skill folder with SKILL.md.",
   "agents.skills.browseFiles": "Browse files",
   "agents.skills.uploadSkill": "Upload skill",
   "agents.template.startFrom": "Start from a template",
@@ -302,7 +312,8 @@ const en = {
   "channels.title": "Channels",
   "channels.new": "New Channel",
   "channels.noChannels": "No channels configured",
-  "channels.noChannelsDesc": "Add a channel to connect stella to messaging platforms.",
+  "channels.noChannelsDesc":
+    "Add a channel to connect stella to messaging platforms.",
   "channels.type": "Type",
   "channels.enabled": "Enabled",
   "channels.disabled": "Disabled",
@@ -313,13 +324,15 @@ const en = {
   "channels.updated": "Channel updated",
   "channels.updateFailed": "Failed to update channel",
   "channels.deleteConfirm": "Delete channel?",
-  "channels.deleteConfirmDesc": "This will permanently delete the channel {{name}}.",
+  "channels.deleteConfirmDesc":
+    "This will permanently delete the channel {{name}}.",
 
   // Credentials
   "credentials.title": "Credentials",
   "credentials.new": "New Credential",
   "credentials.noCredentials": "No credentials stored",
-  "credentials.noCredentialsDesc": "Add credentials to authenticate with external services.",
+  "credentials.noCredentialsDesc":
+    "Add credentials to authenticate with external services.",
   "credentials.key": "Key",
   "credentials.value": "Value",
   "credentials.deleted": "Credential deleted",
@@ -329,7 +342,8 @@ const en = {
   "credentials.updated": "Credential updated",
   "credentials.updateFailed": "Failed to update credential",
   "credentials.deleteConfirm": "Delete credential?",
-  "credentials.deleteConfirmDesc": "This will permanently delete the credential {{key}}.",
+  "credentials.deleteConfirmDesc":
+    "This will permanently delete the credential {{key}}.",
 
   // Plugins
   "plugins.title": "Plugins",
@@ -374,7 +388,8 @@ const en = {
   "providers.updated": "Provider updated",
   "providers.updateFailed": "Failed to update provider",
   "providers.deleteConfirm": "Delete provider?",
-  "providers.deleteConfirmDesc": "This will permanently delete the provider {{name}}.",
+  "providers.deleteConfirmDesc":
+    "This will permanently delete the provider {{name}}.",
   "providers.enabled": "Enabled",
   "providers.updateModel": "Update model",
   "providers.addModel": "Add model",
@@ -392,14 +407,16 @@ const en = {
   "providers.maxTokens": "Max tokens",
   "providers.reasoning": "Reasoning",
   "providers.reasoningDesc": "Stores the provider-facing reasoning flag.",
-  "providers.enabledDesc": "Persist model availability on this provider instance.",
+  "providers.enabledDesc":
+    "Persist model availability on this provider instance.",
   "providers.costInput": "Cost input",
   "providers.costOutput": "Cost output",
   "providers.costCacheRead": "Cost cache read",
   "providers.costCacheWrite": "Cost cache write",
   "providers.modelsHint":
     "Toggle models on or off, then save. Custom models can be edited with the form or in the advanced JSON editor.",
-  "providers.noModels": "No models yet. Fetch from the provider or add custom models above.",
+  "providers.noModels":
+    "No models yet. Fetch from the provider or add custom models above.",
   "providers.fetchModels": "Fetch models",
   "providers.fetching": "Fetching...",
   "providers.modelsAvailable": "{{count}} models available",
@@ -423,7 +440,8 @@ const en = {
   "scheduler.title": "Scheduler",
   "scheduler.new": "New Task",
   "scheduler.noTasks": "No scheduled tasks",
-  "scheduler.noTasksDesc": "Create a scheduled task to automate recurring work.",
+  "scheduler.noTasksDesc":
+    "Create a scheduled task to automate recurring work.",
   "scheduler.cron": "Cron Expression",
   "scheduler.nextRun": "Next Run",
   "scheduler.lastRun": "Last Run",
@@ -434,7 +452,8 @@ const en = {
   "scheduler.createFailed": "Failed to create task",
   "scheduler.updated": "Task updated",
   "scheduler.updateFailed": "Failed to update task",
-  "scheduler.deleteConfirmDesc": "This will permanently delete the task {{name}}.",
+  "scheduler.deleteConfirmDesc":
+    "This will permanently delete the task {{name}}.",
   "scheduler.running": "Running…",
 
   // Users
@@ -451,9 +470,11 @@ const en = {
   "users.updated": "User updated",
   "users.updateFailed": "Failed to update user",
   "users.deleteConfirm": "Delete user?",
-  "users.deleteConfirmDesc": "This will permanently delete the user {{username}}.",
+  "users.deleteConfirmDesc":
+    "This will permanently delete the user {{username}}.",
   "users.resetPassword": "Reset Password",
-  "users.desc": "Manage authentication, roles, linked accounts, and memory databases.",
+  "users.desc":
+    "Manage authentication, roles, linked accounts, and memory databases.",
   "users.admins": "Admins",
   "users.users": "Users",
   "users.active": "Active",
@@ -469,11 +490,13 @@ const en = {
   "users.unlinkIdentity": "Unlink {{platform}} identity?",
   "users.identityUnlinked": "Identity unlinked",
   "users.notifyChannel": "Notify channel",
-  "users.notifyChannelDesc": "Which channel receives scheduler and tool notifications.",
+  "users.notifyChannelDesc":
+    "Which channel receives scheduler and tool notifications.",
   "users.autoFirst": "Auto (first linked)",
   "users.notifyUpdated": "Notify channel updated",
   "users.agentAssignments": "Agent assignments",
-  "users.noAgentAssignments": "No agent assignments (has access to all system-scope agents).",
+  "users.noAgentAssignments":
+    "No agent assignments (has access to all system-scope agents).",
   "users.agentAssigned": "Agent assigned",
   "users.agentRemoved": "Agent removed",
   "users.selectAgent": "Select agent...",
@@ -496,7 +519,8 @@ const en = {
   "sessions.deleted": "Session deleted",
   "sessions.deleteFailed": "Failed to delete session",
   "sessions.deleteConfirm": "Delete session?",
-  "sessions.deleteConfirmDesc": "This will permanently delete this session and all its messages.",
+  "sessions.deleteConfirmDesc":
+    "This will permanently delete this session and all its messages.",
   "sessions.search": "Search sessions…",
   "sessions.composer.placeholder": "Message…",
   "sessions.composer.send": "Send",
@@ -651,13 +675,17 @@ const en = {
   "automations.tab.log": "Log",
   "automations.now.title": "Tasks",
   "automations.tasks.title": "Tasks",
-  "automations.now.description": "Tasks Stella is doing or waiting for you to review.",
-  "automations.tasks.description": "Tasks Stella is doing or waiting for you to review.",
+  "automations.now.description":
+    "Tasks Stella is doing or waiting for you to review.",
+  "automations.tasks.description":
+    "Tasks Stella is doing or waiting for you to review.",
   "automations.scheduler.title": "Scheduler",
-  "automations.scheduler.description": "Things Stella should start later or repeat automatically.",
+  "automations.scheduler.description":
+    "Things Stella should start later or repeat automatically.",
   "automations.scheduler.empty": "No schedules yet.",
   "automations.log.title": "Log",
-  "automations.log.description": "What ran, when it ran, and whether it succeeded.",
+  "automations.log.description":
+    "What ran, when it ran, and whether it succeeded.",
   "automations.log.empty": "No recent automation history yet.",
   "automations.refreshing": "Refreshing…",
   "automations.newWork": "New task",
@@ -679,7 +707,8 @@ const en = {
   "automations.empty.failures": "No failed tasks.",
   "automations.detail.task": "Task detail",
   "automations.select.title": "Select an item",
-  "automations.select.description": "Pick a task, scheduler item, or log entry to inspect it here.",
+  "automations.select.description":
+    "Pick a task, scheduler item, or log entry to inspect it here.",
   "automations.confirm.deleteTask": "Delete this task?",
   "automations.confirm.deleteSchedule": "Delete this schedule?",
 
@@ -695,7 +724,8 @@ const en = {
   "sessions.sidebar.renameRequired": "Thread name is required.",
   "sessions.sidebar.renameFailed": "Failed to rename thread",
   "sessions.sidebar.deleteThreadConfirm": "Delete this thread?",
-  "sessions.sidebar.deleteProjectConfirm": "Delete this project? Sessions will be kept.",
+  "sessions.sidebar.deleteProjectConfirm":
+    "Delete this project? Sessions will be kept.",
 
   // Sessions panel — automation
 
@@ -716,7 +746,8 @@ const en = {
 
   // Sessions panel — memory
   "sessions.memory.title": "User Profile",
-  "sessions.memory.context": "Persistent context this agent will remember across conversations.",
+  "sessions.memory.context":
+    "Persistent context this agent will remember across conversations.",
   "sessions.memory.empty": "No memory yet.",
   "sessions.memory.placeholder":
     "What should this agent remember? Use natural language or bullet points.",
@@ -724,24 +755,30 @@ const en = {
 
   // Sessions panel — soul
   "sessions.soul.title": "Agent Soul",
-  "sessions.soul.subtitle": "Default personality and behavior tone for this agent.",
+  "sessions.soul.subtitle":
+    "Default personality and behavior tone for this agent.",
   "sessions.soul.empty": "No soul configured.",
-  "sessions.soul.placeholder": "Describe the agent's personality, tone, and behavior…",
+  "sessions.soul.placeholder":
+    "Describe the agent's personality, tone, and behavior…",
   "sessions.soul.saving": "Saving…",
 
   // Memories
   "memories.title": "Memories",
   "memories.soul.title": "Agent Soul",
-  "memories.soul.description": "The agent's personality, tone, and default behavior.",
+  "memories.soul.description":
+    "The agent's personality, tone, and default behavior.",
   "memories.soul.empty": "No soul configured yet.",
-  "memories.soul.placeholder": "Describe the agent's personality, tone, and behavior…",
+  "memories.soul.placeholder":
+    "Describe the agent's personality, tone, and behavior…",
   "memories.profile.title": "User Profile",
-  "memories.profile.description": "Persistent context this agent remembers about you.",
+  "memories.profile.description":
+    "Persistent context this agent remembers about you.",
   "memories.profile.empty": "No profile memory yet.",
   "memories.profile.placeholder":
     "What should this agent remember? Use natural language or bullet points.",
   "memories.constraints.title": "Constraints",
-  "memories.constraints.description": "Hard rules the agent must always follow.",
+  "memories.constraints.description":
+    "Hard rules the agent must always follow.",
   "memories.constraints.empty":
     "No constraints set. Constraints are hard rules the agent must always follow.",
   "memories.constraints.error": "Failed to load constraints.",
@@ -757,7 +794,8 @@ const en = {
   "sessions.task.subtitle": "The agent will work on this task asynchronously.",
   "sessions.task.creating": "Creating…",
   "sessions.task.createBtn": "Create task",
-  "sessions.task.descPlaceholder": "Additional context, constraints, or acceptance criteria…",
+  "sessions.task.descPlaceholder":
+    "Additional context, constraints, or acceptance criteria…",
   "sessions.task.priorityRoutineDesc": "Routine — handle when possible",
   "sessions.task.priorityUrgentDesc": "Urgent — prioritize immediately",
 
@@ -813,6 +851,34 @@ const en = {
   "goals.actUnblock": "Unblock",
   "goals.respond": "Respond & resolve",
   "goals.noEvents": "No events yet.",
+  "goals.modeActive": "Active",
+  "goals.modeHistory": "History",
+  "goals.searchPlaceholder": "Search goals…",
+  "goals.statusAll": "All statuses",
+  "goals.filteredCount": "{{count}} shown",
+  "goals.hideSelected": "Hide {{count}} closed",
+  "goals.restoreHidden": "Restore {{count}} hidden",
+  "goals.noMatches": "No matching goals",
+  "goals.noMatchesDesc":
+    "Try a different search, status, or active/history view.",
+  "goals.selectGoal": "Select goal",
+  "goals.achieved": "Achieved",
+  "goals.hookAchieved": "Achieved {{time}}",
+  "goals.hookFailed": "Failed — in history",
+  "goals.hookCancelled": "Cancelled — in history",
+  "goals.progressHint": "Open to inspect progress and child tasks.",
+  "goals.pageStatus": "Page {{page}}/{{totalPages}} · {{total}} total",
+  "hub.activeWork": "Active work",
+  "hub.historyArchive": "History archive",
+  "hub.needsYouHint":
+    "Start here: blocked goals, reviews, and failed tasks are the only things demanding action.",
+  "hub.openActiveGoals": "Open active goals",
+  "hub.openHistory": "Open history",
+  "hub.noNeedsYouDesc":
+    "Active work is still running; nothing is blocked or waiting on review.",
+  "hub.noActiveGoals":
+    "No active goals. History stays one click away when you need receipts.",
+  "hub.achievedAt": "Achieved {{time}}",
 
   // Automations hub (unified page)
   "hub.title": "Tasks",
@@ -905,7 +971,8 @@ const en = {
   "hub.blockerKindToolError": "Tool error",
   "hub.blockerKindPolicyHold": "Policy hold",
   "hub.blockerKindDepFailure": "Upstream dependency failed",
-  "hub.blockerAnswerPlaceholder": "Write your answer; the agent resumes with it…",
+  "hub.blockerAnswerPlaceholder":
+    "Write your answer; the agent resumes with it…",
   "hub.resolveBlocker": "Resolve & resume",
   "hub.failedDeps": "Failed dependencies",
   "hub.waiveDep": "Waive",
@@ -989,9 +1056,11 @@ const en = {
   "credentials.scope.userAgent.desc":
     "Injected only when you use the selected agent. Highest priority.",
   "credentials.scope.system.label": "Global · all agents",
-  "credentials.scope.system.desc": "Shared by all users. Lowest priority. Admin only.",
+  "credentials.scope.system.desc":
+    "Shared by all users. Lowest priority. Admin only.",
   "credentials.scope.systemAgent.label": "Global · specific agent",
-  "credentials.scope.systemAgent.desc": "Shared by all users of the selected agent. Admin only.",
+  "credentials.scope.systemAgent.desc":
+    "Shared by all users of the selected agent. Admin only.",
   "credentials.scope.reserved": "Managed by stella · read-only",
   "credentials.scope.agentMissing": "Select an agent for this scope.",
   "credentials.scope.priorityTitle": "Priority — higher overrides lower",
@@ -1036,13 +1105,15 @@ const en = {
   "credentials.oauth.clientIdRequired": "Client ID is required",
   "credentials.oauth.error": "OAuth error",
   "credentials.oauth.connectedSuccess": "{{provider}} connected successfully",
-  "credentials.oauth.authorizationState": "{{provider}} authorization {{state}}",
+  "credentials.oauth.authorizationState":
+    "{{provider}} authorization {{state}}",
   "credentials.oauth.disconnectConfirm": "Disconnect {{provider}} credentials?",
   "credentials.oauth.disconnected": "{{provider}} disconnected",
   "credentials.oauth.disconnectFailed": "Failed to disconnect",
   "credentials.oauth.configSaved": "{{provider}} credentials saved",
   "credentials.oauth.configSaveFailed": "Failed to save config",
-  "credentials.oauth.resetConfirm": "Reset {{provider}} credentials to defaults?",
+  "credentials.oauth.resetConfirm":
+    "Reset {{provider}} credentials to defaults?",
   "credentials.oauth.configReset": "{{provider}} credentials reset to defaults",
   "credentials.oauth.configResetFailed": "Failed to reset config",
   "credentials.email.default": "Default",
@@ -1117,15 +1188,19 @@ const en = {
   "skills.scope.current": "current",
   "skills.scope.agentMissing": "Select an agent for this scope.",
   "skills.scope.user.label": "Mine · all agents",
-  "skills.scope.user.desc": "Skills you added — available across all of your agents.",
+  "skills.scope.user.desc":
+    "Skills you added — available across all of your agents.",
   "skills.scope.userAgent.label": "Mine · this agent",
-  "skills.scope.userAgent.desc": "Skills you added — active only in this agent. Highest priority.",
+  "skills.scope.userAgent.desc":
+    "Skills you added — active only in this agent. Highest priority.",
   "skills.scope.system.label": "System · all agents",
-  "skills.scope.system.desc": "Preset skills — available in every agent. Lowest priority.",
+  "skills.scope.system.desc":
+    "Preset skills — available in every agent. Lowest priority.",
   "skills.scope.systemAgent.label": "System · this agent",
   "skills.scope.systemAgent.desc": "Preset skills — active only in this agent.",
   "skills.scope.project.label": "Project",
-  "skills.scope.project.desc": "Managed in the project's filesystem. Read-only here.",
+  "skills.scope.project.desc":
+    "Managed in the project's filesystem. Read-only here.",
 
   // Login (additions)
   "login.email": "Email",
@@ -1151,11 +1226,13 @@ const en = {
   "sessions.inspector.tools": "Tools",
   "sessions.inspector.prompt": "Prompt",
   "sessions.inspector.inspector": "Inspector",
-  "sessions.inspector.sessionWorkspace": "Session workspace, work queue, and context",
+  "sessions.inspector.sessionWorkspace":
+    "Session workspace, work queue, and context",
   "sessions.skill.installSkill": "Install a skill",
   "sessions.skill.catalog": "Catalog",
   "sessions.skill.searchSkills": "Search skills...",
-  "sessions.skill.searchPublic": "Search public skills and install one into the selected target.",
+  "sessions.skill.searchPublic":
+    "Search public skills and install one into the selected target.",
   "sessions.skill.noSkillsFound": "No skills found for that search.",
   "sessions.skill.searchCatalog": "Search the catalog",
   "sessions.skill.resultsAppear": "Results appear here as you type.",
@@ -1168,7 +1245,8 @@ const en = {
   "sessions.skill.myProfile": "My profile",
   "sessions.skill.thisAgent": "This agent",
   "sessions.skill.adminOnly": "Agent installs are available to admins.",
-  "sessions.skill.catalogDesc": "Search the catalog or import a zip bundle into Stella.",
+  "sessions.skill.catalogDesc":
+    "Search the catalog or import a zip bundle into Stella.",
   "sessions.sidebar.newProject": "New Project",
   "sessions.sidebar.projectName": "Project name",
   "sessions.sidebar.selectFolder": "Select a workspace folder for this agent.",
@@ -1193,9 +1271,11 @@ const en = {
   "sessions.skillsList.project": "Project",
   "sessions.skillsList.userDesc": "Your personal skills, visible only to you",
   "sessions.skillsList.user_agentDesc": "Your skills for this agent only",
-  "sessions.skillsList.system_agentDesc": "Shared with everyone who uses this agent",
+  "sessions.skillsList.system_agentDesc":
+    "Shared with everyone who uses this agent",
   "sessions.skillsList.systemDesc": "Built into Stella, read-only",
-  "sessions.skillsList.projectDesc": "Loaded from the project directory, managed via files",
+  "sessions.skillsList.projectDesc":
+    "Loaded from the project directory, managed via files",
   "sessions.skillsList.noAgentSkills": "No agent-level skills installed.",
   "sessions.skillsList.noSystemSkills": "No system skills.",
   "sessions.skillsList.noProjectSkills": "No skills in the project directory.",
@@ -1213,8 +1293,10 @@ const en = {
   "sessions.skillsList.githubSkill": "Skill",
   "sessions.skillsList.githubSkillPlaceholder": "skill name within the repo",
   "sessions.skillsList.githubVersion": "Version (optional)",
-  "sessions.skillsList.githubVersionPlaceholder": "tag or branch — blank uses the default branch",
-  "sessions.skillsList.githubHint": "Private repos require a connected GitHub account.",
+  "sessions.skillsList.githubVersionPlaceholder":
+    "tag or branch — blank uses the default branch",
+  "sessions.skillsList.githubHint":
+    "Private repos require a connected GitHub account.",
   "sessions.skillsList.upgradeCheck": "Check for updates",
   "sessions.skillsList.upgradeDone": "Updated to {version}",
   "sessions.skillsList.upgradeUpToDate": "Already up to date",
@@ -1228,14 +1310,16 @@ const en = {
   "sessions.skillsList.scope": "Scope",
   "sessions.skillsList.status": "Status",
   "sessions.skillsList.versionLabel": "Version",
-  "sessions.skillsList.versionHint": "Recorded tag, branch, or commit. Cleared if left blank.",
+  "sessions.skillsList.versionHint":
+    "Recorded tag, branch, or commit. Cleared if left blank.",
   "sessions.skillsList.modelInvocation": "Model invocation",
   "sessions.skillsList.fileCount": "Files",
   "sessions.skillsList.readonlyNote": "This skill is read-only at this scope.",
   "sessions.skillsList.statusActive": "Active",
   "sessions.skillsList.statusDraft": "Draft",
   "sessions.skillsList.statusDeprecated": "Deprecated",
-  "sessions.skillsList.modelInvocationHint": "Allow the model to call this skill automatically.",
+  "sessions.skillsList.modelInvocationHint":
+    "Allow the model to call this skill automatically.",
   "sessions.skillsList.deleteSkill": "Delete skill",
   "sessions.skillsList.deleteConfirm": "Delete this skill?",
   "sessions.skillsList.deleteConfirmDesc":
@@ -1274,7 +1358,8 @@ const en = {
     "Search the mise registry by name, or type a mise key (e.g. github:owner/repo). Stella installs it and keeps it in sync.",
   "plugins.searchRegistry": "Search a tool name or mise key…",
   "plugins.searchingRegistry": "Searching…",
-  "plugins.noRegistryMatches": "No matches. You can still add a mise key directly.",
+  "plugins.noRegistryMatches":
+    "No matches. You can still add a mise key directly.",
   "plugins.useDirectKey": 'Use "{{key}}" as a mise key',
   "plugins.miseKey": "mise key",
   "plugins.cliToolName": "Name",
@@ -1420,7 +1505,8 @@ const en = {
   "plugins.displayName": "Display name",
   "plugins.binaries": "Binaries",
   "plugins.addBinary": "+ Add binary",
-  "plugins.noBinaries": "No binaries declared. Add one to install a CLI from a GitHub release.",
+  "plugins.noBinaries":
+    "No binaries declared. Add one to install a CLI from a GitHub release.",
   "plugins.binaryN": "Binary {{n}}",
   "plugins.githubRepoLabel": "GitHub repo (owner/repo)",
   "plugins.binPath": "Bin path",
@@ -1433,7 +1519,8 @@ const en = {
   "plugins.sourceLabel": "Source",
   "plugins.valueStaticOnly": "Value (static only)",
   "plugins.oauthProvider": "OAuth provider",
-  "plugins.overrideDesc": "Override the manifest definition. Binaries sync on save.",
+  "plugins.overrideDesc":
+    "Override the manifest definition. Binaries sync on save.",
   "plugins.exeOverride": "Exe override",
   "plugins.nameLabel": "Name",
   "plugins.descriptionLabel": "Description",
@@ -1458,12 +1545,14 @@ const en = {
   "channels.channelIdPlaceholder": "e.g. feishu-coder",
   "channels.channelIdDesc":
     'Must not match the platform ID (e.g. not "telegram" for a Telegram channel).',
-  "channels.weixinChannelIdDesc": 'WeChat is singleton-only; the channel ID is fixed to "weixin".',
+  "channels.weixinChannelIdDesc":
+    'WeChat is singleton-only; the channel ID is fixed to "weixin".',
   "channels.configuration": "Configuration",
   "channels.boundAgent": "Bound agent",
   "channels.boundAgentDesc":
     "Messages received by this bot are routed to this agent. Each agent can only have one channel per platform.",
-  "channels.noAvailableAgents": "No enabled agents are available for this platform.",
+  "channels.noAvailableAgents":
+    "No enabled agents are available for this platform.",
   "channels.selectAgent": "Select agent...",
   "channels.manualFeishuSetup": "I already have a Feishu app",
   "channels.manualWeixinSetup": "I already have WeChat iLink credentials",
@@ -1478,11 +1567,13 @@ const en = {
     "Scan with the Feishu mobile app, then confirm the app creation request.",
   "channels.scanFeishuQrAlt": "Feishu bot registration QR code",
   "channels.scanWeixinTitle": "Create WeChat bot",
-  "channels.scanWeixinDesc": "Scan with the WeChat mobile app, then confirm bot creation.",
+  "channels.scanWeixinDesc":
+    "Scan with the WeChat mobile app, then confirm bot creation.",
   "channels.scanWeixinQrAlt": "WeChat bot registration QR code",
   "channels.scanNeedsName": "Enter a name before starting QR setup.",
   "channels.scanNeedsId": "Enter a channel ID before starting QR setup.",
-  "channels.scanNeedsAgent": "Bind this channel to an agent before starting QR setup.",
+  "channels.scanNeedsAgent":
+    "Bind this channel to an agent before starting QR setup.",
   "channels.scanExpired": "QR code expired. Try again.",
   "channels.waiting": "Waiting",
 
@@ -1544,7 +1635,8 @@ const en = {
 
   // Workspace share dialog
   "sessions.workspace.shareArtifact": "Share artifact",
-  "sessions.workspace.shareDesc": "Create a public, read-only snapshot link for {{file}}.",
+  "sessions.workspace.shareDesc":
+    "Create a public, read-only snapshot link for {{file}}.",
   "sessions.workspace.thisFile": "this file",
   "sessions.workspace.expiration": "Expiration",
   "sessions.workspace.1hour": "1 hour",
@@ -1837,7 +1929,8 @@ const zh: Record<MessageKey, string> = {
   "agents.skills.deleteFile": "删除文件",
   "agents.skills.disableModelInvocation": "禁用模型调用",
   "agents.skills.noMatch": "没有技能匹配此筛选条件。",
-  "agents.skills.saveFirst": "如果要添加或自定义智能体专用技能，请先保存智能体。",
+  "agents.skills.saveFirst":
+    "如果要添加或自定义智能体专用技能，请先保存智能体。",
   "agents.skills.noDescription": "暂无描述。",
   "agents.skills.noContent": "暂无内容。",
   "agents.skills.systemScope": "系统技能，此处只读。",
@@ -1861,7 +1954,8 @@ const zh: Record<MessageKey, string> = {
   "agents.skills.browseFiles": "浏览文件",
   "agents.skills.uploadSkill": "上传技能",
   "agents.template.startFrom": "从模板开始",
-  "agents.template.templateDesc": "模板会预填系统提示词、技能和模型。保存前可以编辑所有内容。",
+  "agents.template.templateDesc":
+    "模板会预填系统提示词、技能和模型。保存前可以编辑所有内容。",
   "agents.template.blank": "空白",
   "agents.template.blankSlate": "空白模板",
   "agents.template.blankDesc": "从零开始自行配置所有内容。",
@@ -1970,7 +2064,8 @@ const zh: Record<MessageKey, string> = {
   "providers.costOutput": "输出成本",
   "providers.costCacheRead": "缓存读取成本",
   "providers.costCacheWrite": "缓存写入成本",
-  "providers.modelsHint": "开关模型后点击保存。自定义模型可通过表单或高级 JSON 编辑器编辑。",
+  "providers.modelsHint":
+    "开关模型后点击保存。自定义模型可通过表单或高级 JSON 编辑器编辑。",
   "providers.noModels": "暂无模型。从提供商获取或添加自定义模型。",
   "providers.fetchModels": "获取模型",
   "providers.fetching": "获取中...",
@@ -2290,7 +2385,8 @@ const zh: Record<MessageKey, string> = {
   "sessions.memory.title": "用户档案",
   "sessions.memory.context": "此 agent 在所有对话中都会记住的持久上下文。",
   "sessions.memory.empty": "暂无记忆。",
-  "sessions.memory.placeholder": "该 agent 应该记住什么？用自然语言或要点列表。",
+  "sessions.memory.placeholder":
+    "该 agent 应该记住什么？用自然语言或要点列表。",
   "sessions.memory.saving": "保存中…",
 
   // Sessions panel — soul
@@ -2309,7 +2405,8 @@ const zh: Record<MessageKey, string> = {
   "memories.profile.title": "用户档案",
   "memories.profile.description": "该 agent 会持续记住的你的上下文。",
   "memories.profile.empty": "还没有用户档案记忆。",
-  "memories.profile.placeholder": "该 agent 应该记住什么？用自然语言或要点列表。",
+  "memories.profile.placeholder":
+    "该 agent 应该记住什么？用自然语言或要点列表。",
   "memories.constraints.title": "约束",
   "memories.constraints.description": "Agent 必须始终遵守的硬规则。",
   "memories.constraints.empty": "暂无约束。约束是 agent 必须始终遵守的硬规则。",
@@ -2382,6 +2479,31 @@ const zh: Record<MessageKey, string> = {
   "goals.actUnblock": "解除阻塞",
   "goals.respond": "回应并解除",
   "goals.noEvents": "暂无事件。",
+  "goals.modeActive": "活跃",
+  "goals.modeHistory": "历史",
+  "goals.searchPlaceholder": "搜索目标…",
+  "goals.statusAll": "全部状态",
+  "goals.filteredCount": "显示 {{count}} 个",
+  "goals.hideSelected": "隐藏 {{count}} 个已关闭",
+  "goals.restoreHidden": "恢复 {{count}} 个隐藏项",
+  "goals.noMatches": "没有匹配的目标",
+  "goals.noMatchesDesc": "换个搜索词、状态，或切换活跃/历史视图。",
+  "goals.selectGoal": "选择目标",
+  "goals.achieved": "已达成",
+  "goals.hookAchieved": "已于 {{time}} 达成",
+  "goals.hookFailed": "失败 — 已归入历史",
+  "goals.hookCancelled": "已取消 — 已归入历史",
+  "goals.progressHint": "打开查看进度和子任务。",
+  "goals.pageStatus": "第 {{page}}/{{totalPages}} 页 · 共 {{total}} 个",
+  "hub.activeWork": "活跃工作",
+  "hub.historyArchive": "历史归档",
+  "hub.needsYouHint":
+    "先看这里：阻塞目标、审批和失败任务才是真正需要你处理的事项。",
+  "hub.openActiveGoals": "打开活跃目标",
+  "hub.openHistory": "打开历史",
+  "hub.noNeedsYouDesc": "活跃工作仍在运行；目前没有阻塞或等待审批。",
+  "hub.noActiveGoals": "暂无活跃目标。需要追溯时，历史记录仍可一键查看。",
+  "hub.achievedAt": "已于 {{time}} 达成",
 
   // Automations hub (unified page)
   "hub.title": "任务",
@@ -2555,11 +2677,13 @@ const zh: Record<MessageKey, string> = {
   "credentials.scope.user.label": "我的 · 所有 Agent",
   "credentials.scope.user.desc": "注入到你所有 agent 的会话中。",
   "credentials.scope.userAgent.label": "我的 · 指定 Agent",
-  "credentials.scope.userAgent.desc": "仅在你使用所选 agent 时注入，优先级最高。",
+  "credentials.scope.userAgent.desc":
+    "仅在你使用所选 agent 时注入，优先级最高。",
   "credentials.scope.system.label": "全局 · 所有 Agent",
   "credentials.scope.system.desc": "所有用户共享，优先级最低。仅管理员。",
   "credentials.scope.systemAgent.label": "全局 · 指定 Agent",
-  "credentials.scope.systemAgent.desc": "所有用户使用所选 agent 时共享。仅管理员。",
+  "credentials.scope.systemAgent.desc":
+    "所有用户使用所选 agent 时共享。仅管理员。",
   "credentials.scope.reserved": "由 stella 托管 · 只读",
   "credentials.scope.agentMissing": "请为该范围选择一个 agent。",
   "credentials.scope.priorityTitle": "优先级 — 上覆盖下",
@@ -2687,7 +2811,8 @@ const zh: Record<MessageKey, string> = {
   "skills.scope.user.label": "我的 · 全部智能体",
   "skills.scope.user.desc": "你添加的技能，在你的每个智能体中都可用。",
   "skills.scope.userAgent.label": "我的 · 仅此智能体",
-  "skills.scope.userAgent.desc": "你添加的技能，只在当前这个智能体中生效。优先级最高。",
+  "skills.scope.userAgent.desc":
+    "你添加的技能，只在当前这个智能体中生效。优先级最高。",
   "skills.scope.system.label": "系统 · 全部智能体",
   "skills.scope.system.desc": "系统预设技能，所有智能体通用。优先级最低。",
   "skills.scope.systemAgent.label": "系统 · 仅此智能体",
@@ -2776,7 +2901,8 @@ const zh: Record<MessageKey, string> = {
   "sessions.skillsList.githubSkill": "技能",
   "sessions.skillsList.githubSkillPlaceholder": "仓库内的技能名",
   "sessions.skillsList.githubVersion": "版本（可选）",
-  "sessions.skillsList.githubVersionPlaceholder": "tag 或 branch — 留空用默认分支",
+  "sessions.skillsList.githubVersionPlaceholder":
+    "tag 或 branch — 留空用默认分支",
   "sessions.skillsList.githubHint": "私有仓库需要已连接 GitHub 账号。",
   "sessions.skillsList.upgradeCheck": "检查更新",
   "sessions.skillsList.upgradeDone": "已更新到 {version}",
@@ -2787,7 +2913,8 @@ const zh: Record<MessageKey, string> = {
   "sessions.skillsList.scopeFilter": "范围",
   "sessions.skillsList.uploadZip": "上传 ZIP",
   "sessions.skillsList.searchPlaceholder": "搜索技能…",
-  "sessions.skillsList.stats": "{{total}} 项技能 · {{callable}} 项可自动调用 · {{readonly}} 项只读",
+  "sessions.skillsList.stats":
+    "{{total}} 项技能 · {{callable}} 项可自动调用 · {{readonly}} 项只读",
   "sessions.skillsList.readonly": "只读",
   "sessions.skillsList.manual": "手动",
   "sessions.skillsList.auto": "自动",
@@ -2795,7 +2922,8 @@ const zh: Record<MessageKey, string> = {
   "sessions.skillsList.scope": "作用域",
   "sessions.skillsList.status": "状态",
   "sessions.skillsList.versionLabel": "版本",
-  "sessions.skillsList.versionHint": "记录的 tag、branch 或 commit。留空则清除。",
+  "sessions.skillsList.versionHint":
+    "记录的 tag、branch 或 commit。留空则清除。",
   "sessions.skillsList.modelInvocation": "模型调用",
   "sessions.skillsList.fileCount": "文件数",
   "sessions.skillsList.readonlyNote": "此作用域的技能为只读。",
@@ -2805,7 +2933,8 @@ const zh: Record<MessageKey, string> = {
   "sessions.skillsList.modelInvocationHint": "允许模型自动调用此技能。",
   "sessions.skillsList.deleteSkill": "删除技能",
   "sessions.skillsList.deleteConfirm": "删除此技能？",
-  "sessions.skillsList.deleteConfirmDesc": "将永久删除 {{name}} 及其文件，此操作无法撤销。",
+  "sessions.skillsList.deleteConfirmDesc":
+    "将永久删除 {{name}} 及其文件，此操作无法撤销。",
   "sessions.skillsList.saved": "设置已保存",
   "sessions.skillsList.emptyFile": "此文件为空。",
   "sessions.skillsList.name": "名称",
@@ -2834,7 +2963,8 @@ const zh: Record<MessageKey, string> = {
 
   // Plugins (additions)
   "plugins.addTool": "添加工具",
-  "plugins.addToolDesc": "声明 GitHub 发布二进制文件。Stella 将其写入 plugins.yaml 并自动同步。",
+  "plugins.addToolDesc":
+    "声明 GitHub 发布二进制文件。Stella 将其写入 plugins.yaml 并自动同步。",
   "plugins.addCliToolDesc":
     "按名称搜索 mise 注册表，或直接输入 mise 标识（如 github:owner/repo）。Stella 会自动安装并保持同步。",
   "plugins.searchRegistry": "搜索工具名称或 mise 标识…",
@@ -3019,7 +3149,8 @@ const zh: Record<MessageKey, string> = {
   "channels.namePlaceholder": "例如：飞书编码助手",
   "channels.channelId": "频道 ID",
   "channels.channelIdPlaceholder": "例如：feishu-coder",
-  "channels.channelIdDesc": '不能和平台 ID 相同（例如 Telegram 频道不能填写 "telegram"）。',
+  "channels.channelIdDesc":
+    '不能和平台 ID 相同（例如 Telegram 频道不能填写 "telegram"）。',
   "channels.weixinChannelIdDesc": '微信是单例频道；频道 ID 固定为 "weixin"。',
   "channels.configuration": "配置",
   "channels.boundAgent": "绑定 Agent",

--- a/web/src/lib/paginated.ts
+++ b/web/src/lib/paginated.ts
@@ -37,12 +37,15 @@ export async function fetchAllTasks(
   return all;
 }
 
-export async function fetchAllGoals(agentId?: string): Promise<ComponentsGoal[]> {
+export async function fetchAllGoals(
+  agentId?: string,
+  archived?: boolean,
+): Promise<ComponentsGoal[]> {
   const all: ComponentsGoal[] = [];
   let pageToken: string | undefined;
   do {
     const { data } = await listGoals({
-      query: { agent_id: agentId, page_size: 500, page_token: pageToken },
+      query: { agent_id: agentId, archived, page_size: 500, page_token: pageToken },
       throwOnError: true,
     });
     all.push(...(data?.goals ?? []));

--- a/web/src/lib/paginated.ts
+++ b/web/src/lib/paginated.ts
@@ -20,6 +20,15 @@ import type {
 } from "@/lib/api-client/types.gen";
 import type { Message } from "@/lib/types";
 
+// offsetPageToken mirrors the server's AIP-158 offset token (encodeOffsetToken
+// in internal/server/response.go: base64url of the decimal row offset). It lets
+// a numbered pager jump straight to any page without walking cursor tokens.
+// Offset 0 returns "" so the caller omits page_token and starts at the first page.
+export function offsetPageToken(offset: number): string {
+  if (offset <= 0) return "";
+  return btoa(String(offset)).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
 export async function fetchAllTasks(
   agentId?: string,
   projectId?: string,

--- a/web/src/lib/queries/goals.ts
+++ b/web/src/lib/queries/goals.ts
@@ -1,4 +1,4 @@
-import { queryOptions } from "@tanstack/react-query";
+import { keepPreviousData, queryOptions } from "@tanstack/react-query";
 import { getGoal, getTaskReadiness, listGoals } from "@/lib/api-client";
 import type { ComponentsDep, ComponentsGoal, ComponentsTask } from "@/lib/api-client/types.gen";
 import {
@@ -73,6 +73,10 @@ export function goalsPageOptions(p: GoalsPageParams) {
       return { goals: data?.goals ?? [], total: data?.total ?? 0 };
     },
     enabled: !!p.agentId,
+    // Keep the previous page's data (and its total) on screen while the next
+    // page loads, so the pager's total never transiently drops to 0 and bounces
+    // the user back to page 1 (CR-019).
+    placeholderData: keepPreviousData,
   });
 }
 

--- a/web/src/lib/queries/goals.ts
+++ b/web/src/lib/queries/goals.ts
@@ -1,5 +1,5 @@
 import { queryOptions } from "@tanstack/react-query";
-import { getGoal, getTaskReadiness } from "@/lib/api-client";
+import { getGoal, getTaskReadiness, listGoals } from "@/lib/api-client";
 import type { ComponentsDep, ComponentsGoal, ComponentsTask } from "@/lib/api-client/types.gen";
 import {
   fetchAllGoalTasks,
@@ -8,12 +8,95 @@ import {
   fetchAllTaskEvents,
   fetchAllTaskReviews,
   fetchAllTaskRuns,
+  offsetPageToken,
 } from "@/lib/paginated";
 
+// goalsOptions fetches every goal (all pages) for callers that aggregate over
+// the whole set (e.g. the overview dashboard). The Goals page itself uses the
+// server-paginated goalsPageOptions instead.
 export function goalsOptions(agentId: string, archived = false) {
   return queryOptions({
     queryKey: ["goals", agentId, archived ? "archived" : "active"],
     queryFn: async () => fetchAllGoals(agentId, archived),
+    enabled: !!agentId,
+  });
+}
+
+export const GOALS_PAGE_SIZE = 24;
+
+export interface GoalsPageParams {
+  agentId: string;
+  archived?: boolean;
+  /** undefined = any; false = active (non-terminal); true = terminal (history). */
+  terminal?: boolean;
+  /** exact status; undefined = all statuses in scope. */
+  status?: string;
+  /** case-insensitive substring on title/description; server-side. */
+  q?: string;
+  /** 1-based page. */
+  page?: number;
+}
+
+export interface GoalsPage {
+  goals: ComponentsGoal[];
+  total: number;
+}
+
+// goalsPageOptions drives the Goals page from one server page: filtering,
+// search, and pagination all run in the DB so the first paint no longer waits
+// for every goal to download.
+export function goalsPageOptions(p: GoalsPageParams) {
+  const page = Math.max(1, p.page ?? 1);
+  return queryOptions({
+    queryKey: [
+      "goals-page",
+      p.agentId,
+      p.archived ?? false,
+      p.terminal ?? null,
+      p.status ?? "",
+      p.q ?? "",
+      page,
+    ],
+    queryFn: async (): Promise<GoalsPage> => {
+      const { data } = await listGoals({
+        query: {
+          agent_id: p.agentId,
+          archived: p.archived || undefined,
+          terminal: p.terminal,
+          status: p.status || undefined,
+          q: p.q || undefined,
+          page_size: GOALS_PAGE_SIZE,
+          page_token: offsetPageToken((page - 1) * GOALS_PAGE_SIZE),
+        },
+        throwOnError: true,
+      });
+      return { goals: data?.goals ?? [], total: data?.total ?? 0 };
+    },
+    enabled: !!p.agentId,
+  });
+}
+
+async function goalsCount(agentId: string, q: { archived?: boolean; terminal?: boolean }) {
+  const { data } = await listGoals({
+    query: { agent_id: agentId, ...q, page_size: 1 },
+    throwOnError: true,
+  });
+  return data?.total ?? 0;
+}
+
+// goalCountsOptions powers the active/history/archived header badges with cheap
+// server-side counts, independent of the current page or filters.
+export function goalCountsOptions(agentId: string) {
+  return queryOptions({
+    queryKey: ["goals-counts", agentId],
+    queryFn: async () => {
+      const [active, history, archived] = await Promise.all([
+        goalsCount(agentId, { terminal: false }),
+        goalsCount(agentId, { terminal: true }),
+        goalsCount(agentId, { archived: true }),
+      ]);
+      return { active, history, archived };
+    },
     enabled: !!agentId,
   });
 }

--- a/web/src/lib/queries/goals.ts
+++ b/web/src/lib/queries/goals.ts
@@ -10,10 +10,10 @@ import {
   fetchAllTaskRuns,
 } from "@/lib/paginated";
 
-export function goalsOptions(agentId: string) {
+export function goalsOptions(agentId: string, archived = false) {
   return queryOptions({
-    queryKey: ["goals", agentId],
-    queryFn: async () => fetchAllGoals(agentId),
+    queryKey: ["goals", agentId, archived ? "archived" : "active"],
+    queryFn: async () => fetchAllGoals(agentId, archived),
     enabled: !!agentId,
   });
 }

--- a/web/src/routes/_app/agents.$agentId/tasks/goals.tsx
+++ b/web/src/routes/_app/agents.$agentId/tasks/goals.tsx
@@ -2,10 +2,12 @@ import { createFileRoute } from "@tanstack/react-router";
 
 interface GoalsSearch {
   view?: string;
+  mode?: string;
 }
 
 export const Route = createFileRoute("/_app/agents/$agentId/tasks/goals")({
   validateSearch: (search: Record<string, unknown>): GoalsSearch => ({
     view: typeof search.view === "string" ? search.view : undefined,
+    mode: typeof search.mode === "string" ? search.mode : undefined,
   }),
 });


### PR DESCRIPTION
## What

Implements the first production slice of #521 — goal/task archive semantics, explicit goal completion, and a scaled Goals UI — plus the follow-up fixes from the multi-perspective review (CR-013/014/015/016).

- Audit-safe archive via `DELETE /api/goals/{goalId}` and `DELETE /api/tasks/{taskId}`, with matching `POST .../unarchive` restore endpoints.
- `POST /api/goals/{goalId}/complete` for explicit “mark achieved” semantics.
- Server-side goal list: `status`, `terminal`, `archived`, and `q` (title/description) filters, plus `total` for numbered paging.
- Archived goals/tasks are fully **inert** — every lifecycle transition and the dispatcher rollup scan reject or skip them.
- Goals page is fully server-driven (active/history/archived modes, search, status filter, numbered pagination, hide/restore); the overview prioritizes “Needs you” and active work.

## Why

#521 identified three product gaps: goals had unclear achievement semantics, the UI loaded/rendered unbounded goal lists, and closed/test goals could not be cleared from normal work views. This PR makes the default experience focus on active work while preserving audit history. The review then surfaced four correctness/scale gaps in that first cut — silent revival of archived work, a full-fetch Goals page that wouldn’t scale, asymmetric task archiving, and over-eager child restore — all fixed here.

## How

- Adds `archived_at` to `agent_task` and `agent_goal` (Atlas migration/hash + sqlc regen). Default list queries exclude archived rows.
- Archive stays audit-safe: only draft/terminal goals/tasks archive; archiving a goal cascades to its draft/terminal children and rejects active ones.
- **CR-013** selective restore: `ArchiveGoal` records the child IDs its cascade archived (in the `goal_archive` event); `UnarchiveGoal` restores only those, so independently-archived tasks stay hidden.
- **CR-014** server-side scale: `ListAgentGoalsByUser` gains terminal/search filters with a `CountAgentGoalsByUser` companion; `GoalList.total` lets the web pager jump pages via offset tokens. OverviewPage still full-fetches for aggregates only.
- **CR-015** inertness: archived goals reject complete/fail/cancel/block/unblock at every entry point, including rollup paths.
- **CR-016** task parity: `listTasks` gains an `archived` filter and a `POST /api/tasks/{taskId}/unarchive` endpoint mirroring goals.
- Wires the new OpenAPI routes, regenerated Go/TS, HTTP handlers, archive events, and internal tests; documents the archive/restore surface (EN + ZH).

Validation:

- `mise run format` ✅ · `mise run build` ✅ · `mise run test` ✅
- `go test ./internal/tasks ./internal/server` ✅ · `mise run db:diff` synced (no schema drift this round)

Review: multi-perspective adversarial pass — 13 findings fixed, 3 open low-risk (CR-007 medium, CR-008/CR-012 low). Verdict: ship-it.

## Refs

- Closes #521
