### PR TITLE
🐛 fix: materialize DB skills on load

### DIFF
--- a/cmd/stellad/commands.go
+++ b/cmd/stellad/commands.go
@@ -100,6 +100,9 @@ func setup(parent context.Context, _ bool) (*setupResult, error) {
 	}
 
 	ss := setupSkillStores(db)
+	if err := ss.diskSync.SyncAllToDisk(parent); err != nil {
+		return nil, fmt.Errorf("sync DB skills to disk: %w", err)
+	}
 
 	dispatcher := notify.NewDispatcher()
 	dispatcher.SetChannelStore(store)

--- a/internal/tools/skills/tool.go
+++ b/internal/tools/skills/tool.go
@@ -1,10 +1,14 @@
 package skills
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"log/slog"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -291,11 +295,20 @@ func (t *Tool) load(ctx context.Context, args map[string]any) (string, error) {
 	}
 
 	// For DB skills without a dir from the service, resolve the disk path the
-	// writer materialized them to (the layout is the shared authority).
+	// writer materialized them to (the layout is the shared authority). Materialize
+	// on load as a repair path for existing rows that predate disk mirroring or were
+	// created through a non-syncing store; <skill_dir> must be executable, not a
+	// theoretical address.
 	if skillDir == "" {
 		rs, _ := t.svc.Resolve(ctx, name, vc, projectRoot)
 		if rs != nil {
 			skillDir = t.layout.Dir(rs.Scope, rs.Name)
+			if skillDir != "" && !dbSkillDirReady(skillDir) {
+				if err := t.materializeDBSkill(ctx, rs.ID, skillDir); err != nil {
+					slog.WarnContext(ctx, "skills load: failed to materialize DB skill", "skill", rs.Name, "dir", skillDir, "err", err)
+					skillDir = ""
+				}
+			}
 		}
 	}
 
@@ -318,6 +331,85 @@ type installedSkill struct {
 	Status      string `json:"status"`
 	Scope       string `json:"scope"`
 	Removable   bool   `json:"removable"`
+}
+
+func (t *Tool) materializeDBSkill(ctx context.Context, skillID, skillDir string) error {
+	if t.store == nil || skillID == "" || skillDir == "" {
+		return nil
+	}
+	paths, err := t.store.ListFiles(ctx, skillID)
+	if err != nil {
+		return fmt.Errorf("materialize skill files: %w", err)
+	}
+	seen := make(map[string]struct{}, len(paths))
+	for _, p := range paths {
+		content, err := t.store.LoadFile(ctx, skillID, p)
+		if err != nil {
+			return fmt.Errorf("materialize skill file %q: %w", p, err)
+		}
+		diskPath, err := safeSkillDiskPath(skillDir, filepath.FromSlash(p))
+		if err != nil {
+			return fmt.Errorf("materialize skill file %q: %w", p, err)
+		}
+		if err := os.MkdirAll(filepath.Dir(diskPath), 0o755); err != nil {
+			return fmt.Errorf("materialize skill file %q: %w", p, err)
+		}
+		data := []byte(content)
+		if existing, err := readDiskFile(diskPath); err == nil && bytes.Equal(existing, data) {
+			// Already current.
+		} else if err := os.WriteFile(diskPath, data, 0o644); err != nil {
+			return fmt.Errorf("materialize skill file %q: %w", p, err)
+		}
+		rel, err := filepath.Rel(skillDir, diskPath)
+		if err != nil {
+			return fmt.Errorf("materialize skill file %q: %w", p, err)
+		}
+		seen[filepath.ToSlash(rel)] = struct{}{}
+	}
+	if err := filepath.WalkDir(skillDir, func(p string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil || d.IsDir() {
+			return walkErr
+		}
+		rel, err := filepath.Rel(skillDir, p)
+		if err != nil {
+			return err
+		}
+		if _, ok := seen[filepath.ToSlash(rel)]; !ok {
+			_ = os.Remove(p)
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("materialize skill files: prune stale files: %w", err)
+	}
+	return nil
+}
+
+func dbSkillDirReady(skillDir string) bool {
+	f, err := os.Open(filepath.Join(skillDir, pkgplugins.SkillMainFile))
+	if err != nil {
+		return false
+	}
+	_ = f.Close()
+	return true
+}
+
+func readDiskFile(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close() //nolint:errcheck
+	return io.ReadAll(f)
+}
+
+func safeSkillDiskPath(base string, parts ...string) (string, error) {
+	joined := filepath.Join(append([]string{base}, parts...)...)
+	cleaned := filepath.Clean(joined)
+	base = filepath.Clean(base)
+	if cleaned != base && !strings.HasPrefix(cleaned, base+string(filepath.Separator)) {
+		return "", fmt.Errorf("path %q escapes base %q", cleaned, base)
+	}
+	return cleaned, nil
 }
 
 func (t *Tool) list(ctx context.Context) (string, error) {

--- a/internal/tools/skills/tool_test.go
+++ b/internal/tools/skills/tool_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/CherryHQ/stella/internal/config"
 	appdb "github.com/CherryHQ/stella/internal/db"
 	"github.com/CherryHQ/stella/internal/memory"
+	coreskills "github.com/CherryHQ/stella/internal/skills"
 	"github.com/CherryHQ/stella/internal/store"
 	"github.com/CherryHQ/stella/pkg/db/sqlc"
 	pkgplugins "github.com/CherryHQ/stella/pkg/plugins"
@@ -495,6 +496,87 @@ func TestLoadWithPath(t *testing.T) {
 	}
 	if !strings.Contains(result, "# API Reference") {
 		t.Errorf("expected file content in result, got %q", result)
+	}
+}
+
+func TestLoadMaterializesDBSkillDir(t *testing.T) {
+	store, userID, agentID := newTestSkillStore(t)
+	ctx := ctxWithUser(userID, agentID)
+
+	skillID, err := store.Create(ctx, pkgplugins.Skill{
+		Scope:       "system_agent",
+		AgentID:     agentID,
+		Name:        "agent-db-skill",
+		Description: "DB-backed agent skill",
+		Status:      "active",
+	}, map[string]string{
+		pkgplugins.SkillMainFile: "# Agent DB Skill",
+		"scripts/run.sh":         "#!/bin/sh\necho ok\n",
+	})
+	if err != nil {
+		t.Fatalf("create skill: %v", err)
+	}
+
+	agentBase := t.TempDir()
+	tool := NewTool(store, "", "").WithSkillDiskLayout(coreskills.SkillDiskLayout{Agent: agentBase})
+	result, err := tool.load(ctx, map[string]any{"name": "agent-db-skill"})
+	if err != nil {
+		t.Fatalf("load skill: %v", err)
+	}
+	wantDir := filepath.Join(agentBase, "agent-db-skill")
+	if !strings.Contains(result, "<skill_dir>"+wantDir+"</skill_dir>") {
+		t.Fatalf("skill_dir not emitted for materialized dir: %q", result)
+	}
+	if got, err := os.ReadFile(filepath.Join(wantDir, "scripts", "run.sh")); err != nil || string(got) != "#!/bin/sh\necho ok\n" {
+		t.Fatalf("materialized script = %q, %v", got, err)
+	}
+
+	stale := filepath.Join(wantDir, "stale.md")
+	if err := os.WriteFile(stale, []byte("old"), 0o644); err != nil {
+		t.Fatalf("write stale file: %v", err)
+	}
+	if err := tool.materializeDBSkill(ctx, "", ""); err != nil {
+		t.Fatalf("empty materialize should be a no-op: %v", err)
+	}
+	if err := tool.materializeDBSkill(ctx, skillID, wantDir); err != nil {
+		t.Fatalf("materialize skill: %v", err)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Fatalf("stale file exists after materialize: %v", err)
+	}
+}
+
+func TestLoadOmitsSkillDirWhenMaterializeFails(t *testing.T) {
+	store, userID, agentID := newTestSkillStore(t)
+	ctx := ctxWithUser(userID, agentID)
+
+	_, err := store.Create(ctx, pkgplugins.Skill{
+		Scope:       "system_agent",
+		AgentID:     agentID,
+		Name:        "unwritable-skill",
+		Description: "DB-backed agent skill",
+		Status:      "active",
+	}, map[string]string{pkgplugins.SkillMainFile: "# Still Loads"})
+	if err != nil {
+		t.Fatalf("create skill: %v", err)
+	}
+
+	agentBase := t.TempDir()
+	blockingFile := filepath.Join(agentBase, "unwritable-skill")
+	if err := os.WriteFile(blockingFile, []byte("not a dir"), 0o644); err != nil {
+		t.Fatalf("write blocking file: %v", err)
+	}
+
+	tool := NewTool(store, "", "").WithSkillDiskLayout(coreskills.SkillDiskLayout{Agent: agentBase})
+	result, err := tool.load(ctx, map[string]any{"name": "unwritable-skill"})
+	if err != nil {
+		t.Fatalf("load should return DB content when materialization fails: %v", err)
+	}
+	if strings.Contains(result, "<skill_dir>") {
+		t.Fatalf("unexpected skill_dir when materialization fails: %q", result)
+	}
+	if !strings.Contains(result, "# Still Loads") {
+		t.Fatalf("missing DB skill content: %q", result)
 	}
 }
 


### PR DESCRIPTION
## What
Materialize DB-backed skill files during `skills.load` before emitting `<skill_dir>`.

## Why
A DB-backed agent skill can be loadable from the skill store while its advertised sandbox directory does not exist, breaking shell execution of skill scripts.

## How
- Resolve the DB skill's disk layout during load.
- Copy all stored skill files to that directory and remove stale files.
- Keep materialized writes constrained under the skill directory.
- Add a regression test for a `system_agent` DB skill.

## Refs
Fixes #536
