### PR TITLE
🗄️ db: Verify PostgreSQL extension capabilities

### DIFF
--- a/internal/db/database.go
+++ b/internal/db/database.go
@@ -25,7 +25,7 @@ import (
 const migrateLockKey int64 = 0x73_74_65_6C_6C_61
 
 // OpenDB opens the PostgreSQL database at dsn, sizes the connection pool, ensures
-// the pg_trgm extension and the schema are present, and returns a handle safe for
+// required PostgreSQL extensions and the schema are present, and returns a handle safe for
 // concurrent use. dsn is a libpq/pgx connection string (e.g.
 // "postgres://user:pass@host:5432/db?sslmode=disable").
 //
@@ -217,10 +217,10 @@ func migrate(db *sql.DB) error {
 	}()
 
 	// The baseline's trigram indexes (gin_trgm_ops) depend on pg_trgm, which
-	// Atlas (OSS) can't manage declaratively, so create it before applying any
-	// migration. Requires a role with CREATE privilege on the database.
-	if _, err := conn.ExecContext(ctx, "CREATE EXTENSION IF NOT EXISTS pg_trgm"); err != nil {
-		return fmt.Errorf("ensure pg_trgm extension: %w", err)
+	// Atlas (OSS) can't manage declaratively, so create required extensions before
+	// applying any migration. Requires a role with CREATE privilege on the database.
+	if err := ensureExtensions(ctx, conn); err != nil {
+		return err
 	}
 
 	const createTable = `CREATE TABLE IF NOT EXISTS schema_migrations (

--- a/internal/db/extensions.go
+++ b/internal/db/extensions.go
@@ -1,0 +1,131 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+)
+
+type ExtensionRequirement struct {
+	Name            string
+	Required        bool
+	MinVersion      string
+	RequiresPreload bool
+}
+
+var postgresExtensions = []ExtensionRequirement{
+	{Name: "pg_trgm", Required: true},
+	{Name: "vector"},
+	{Name: "pg_search", RequiresPreload: true},
+}
+
+func ensureExtensions(ctx context.Context, conn *sql.Conn) error {
+	return ensureExtensionRequirements(ctx, conn, postgresExtensions)
+}
+
+func ensureExtensionRequirements(ctx context.Context, conn *sql.Conn, requirements []ExtensionRequirement) error {
+	for _, req := range requirements {
+		if !req.Required {
+			continue
+		}
+		if err := checkExtensionAvailable(ctx, conn, req); err != nil {
+			return err
+		}
+		if req.RequiresPreload {
+			if err := checkExtensionPreloaded(ctx, conn, req.Name); err != nil {
+				return err
+			}
+		}
+		if _, err := conn.ExecContext(ctx, "CREATE EXTENSION IF NOT EXISTS "+pgx.Identifier{req.Name}.Sanitize()); err != nil {
+			return fmt.Errorf("create PostgreSQL extension %q: %w", req.Name, err)
+		}
+	}
+	return nil
+}
+
+func checkExtensionAvailable(ctx context.Context, conn *sql.Conn, req ExtensionRequirement) error {
+	var defaultVersion string
+	err := conn.QueryRowContext(ctx, "SELECT default_version FROM pg_available_extensions WHERE name = $1", req.Name).Scan(&defaultVersion)
+	if errors.Is(err, sql.ErrNoRows) {
+		return missingExtensionError(req.Name)
+	}
+	if err != nil {
+		return fmt.Errorf("check PostgreSQL extension %q availability: %w", req.Name, err)
+	}
+	if req.MinVersion != "" && compareExtensionVersion(defaultVersion, req.MinVersion) < 0 {
+		return fmt.Errorf("PostgreSQL extension %q default version %s is below required version %s", req.Name, defaultVersion, req.MinVersion)
+	}
+	return nil
+}
+
+func checkExtensionPreloaded(ctx context.Context, conn *sql.Conn, name string) error {
+	var preload string
+	if err := conn.QueryRowContext(ctx, "SHOW shared_preload_libraries").Scan(&preload); err != nil {
+		return fmt.Errorf("check PostgreSQL shared_preload_libraries for %q: %w", name, err)
+	}
+	if !preloadContains(preload, name) {
+		return fmt.Errorf("external PostgreSQL is missing %s preload: install %s and set shared_preload_libraries='%s', then restart PostgreSQL", name, name, name)
+	}
+	return nil
+}
+
+func missingExtensionError(name string) error {
+	switch name {
+	case "pg_search":
+		return fmt.Errorf("stella embedded PostgreSQL runtime is missing extension %q. Expected bundle: %s. External PostgreSQL must install pg_search and set shared_preload_libraries='pg_search', then restart PostgreSQL", name, postgresBundleID)
+	case "vector":
+		return fmt.Errorf("stella embedded PostgreSQL runtime is missing extension %q. Expected bundle: %s. External PostgreSQL must install pgvector before Stella starts", name, postgresBundleID)
+	default:
+		return fmt.Errorf("PostgreSQL extension %q is not available; install the extension files before starting Stella", name)
+	}
+}
+
+func preloadContains(value, name string) bool {
+	for part := range strings.SplitSeq(value, ",") {
+		if strings.TrimSpace(part) == name {
+			return true
+		}
+	}
+	return false
+}
+
+func compareExtensionVersion(have, want string) int {
+	h := splitVersion(have)
+	w := splitVersion(want)
+	for i := 0; i < len(h) || i < len(w); i++ {
+		var hv, wv int
+		if i < len(h) {
+			hv = h[i]
+		}
+		if i < len(w) {
+			wv = w[i]
+		}
+		if hv < wv {
+			return -1
+		}
+		if hv > wv {
+			return 1
+		}
+	}
+	return 0
+}
+
+func splitVersion(version string) []int {
+	parts := strings.FieldsFunc(version, func(r rune) bool {
+		return r < '0' || r > '9'
+	})
+	out := make([]int, 0, len(parts))
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		var n int
+		_, _ = fmt.Sscanf(part, "%d", &n)
+		out = append(out, n)
+	}
+	return out
+}

--- a/internal/db/extensions_test.go
+++ b/internal/db/extensions_test.go
@@ -114,6 +114,25 @@ func TestPreloadContains(t *testing.T) {
 	}
 }
 
+func TestCompareExtensionVersion(t *testing.T) {
+	tests := []struct {
+		have string
+		want string
+		cmp  int
+	}{
+		{have: "1.6", want: "1.5", cmp: 1},
+		{have: "1.5.0", want: "1.5", cmp: 0},
+		{have: "0.7.4", want: "0.8.0", cmp: -1},
+		{have: "0.24.1-beta1", want: "0.24.1", cmp: 1},
+	}
+	for _, tt := range tests {
+		got := compareExtensionVersion(tt.have, tt.want)
+		if got != tt.cmp {
+			t.Fatalf("compareExtensionVersion(%q, %q) = %d, want %d", tt.have, tt.want, got, tt.cmp)
+		}
+	}
+}
+
 func startExtensionTestPostgres(t *testing.T) *Embedded {
 	t.Helper()
 	e, err := StartEmbedded("", 0)

--- a/internal/db/extensions_test.go
+++ b/internal/db/extensions_test.go
@@ -1,0 +1,134 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+)
+
+func TestEnsureExtensionRequirementsCreatesPGTrgm(t *testing.T) {
+	e := startExtensionTestPostgres(t)
+	db := openExtensionTestDB(t, e.DSN())
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("Conn: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	reqs := []ExtensionRequirement{{Name: "pg_trgm", Required: true}}
+	if err := ensureExtensionRequirements(ctx, conn, reqs); err != nil {
+		t.Fatalf("ensureExtensionRequirements: %v", err)
+	}
+
+	var exists bool
+	if err := conn.QueryRowContext(ctx, "SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_trgm')").Scan(&exists); err != nil {
+		t.Fatalf("query pg_extension: %v", err)
+	}
+	if !exists {
+		t.Fatal("pg_trgm was not created")
+	}
+}
+
+func TestCheckExtensionAvailableReportsMissingExtension(t *testing.T) {
+	e := startExtensionTestPostgres(t)
+	db := openExtensionTestDB(t, e.DSN())
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("Conn: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	err = checkExtensionAvailable(ctx, conn, ExtensionRequirement{Name: "definitely_missing_stella_ext", Required: true})
+	if err == nil {
+		t.Fatal("checkExtensionAvailable succeeded, want error")
+	}
+	if !strings.Contains(err.Error(), `"definitely_missing_stella_ext" is not available`) {
+		t.Fatalf("missing extension error = %q", err)
+	}
+}
+
+func TestCheckExtensionPreloadedReportsMissingPGSearch(t *testing.T) {
+	e := startExtensionTestPostgres(t)
+	db := openExtensionTestDB(t, e.DSN())
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("Conn: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	err = checkExtensionPreloaded(ctx, conn, "pg_search")
+	if err == nil {
+		t.Fatal("checkExtensionPreloaded succeeded, want error")
+	}
+	for _, want := range []string{"shared_preload_libraries='pg_search'", "restart PostgreSQL"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("preload error %q does not contain %q", err, want)
+		}
+	}
+}
+
+func TestOptionalExtensionRequirementIsSkipped(t *testing.T) {
+	e := startExtensionTestPostgres(t)
+	db := openExtensionTestDB(t, e.DSN())
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("Conn: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	reqs := []ExtensionRequirement{{Name: "definitely_missing_stella_ext"}}
+	if err := ensureExtensionRequirements(ctx, conn, reqs); err != nil {
+		t.Fatalf("ensureExtensionRequirements optional missing ext: %v", err)
+	}
+}
+
+func TestPreloadContains(t *testing.T) {
+	tests := []struct {
+		value string
+		name  string
+		want  bool
+	}{
+		{value: "pg_search", name: "pg_search", want: true},
+		{value: "pg_stat_statements, pg_search", name: "pg_search", want: true},
+		{value: "pg_stat_statements,pg_search", name: "pg_search", want: true},
+		{value: "pg_search_extra", name: "pg_search", want: false},
+		{value: "", name: "pg_search", want: false},
+	}
+	for _, tt := range tests {
+		if got := preloadContains(tt.value, tt.name); got != tt.want {
+			t.Fatalf("preloadContains(%q, %q) = %v, want %v", tt.value, tt.name, got, tt.want)
+		}
+	}
+}
+
+func startExtensionTestPostgres(t *testing.T) *Embedded {
+	t.Helper()
+	e, err := StartEmbedded("", 0)
+	if err != nil {
+		t.Fatalf("StartEmbedded: %v", err)
+	}
+	t.Cleanup(func() { _ = e.Stop() })
+	return e
+}
+
+func openExtensionTestDB(t *testing.T, dsn string) *sql.DB {
+	t.Helper()
+	db, err := openTracedPG(dsn)
+	if err != nil {
+		t.Fatalf("openTracedPG: %v", err)
+	}
+	return db
+}


### PR DESCRIPTION
## What

Add a PostgreSQL extension capability layer before schema migrations.

## Why

Stella needs explicit extension checks before migrations depend on extension-owned operators or types. Today only `pg_trgm` is required, but vector and pg_search need a safe capability model before search work lands.

## How

- Add `ExtensionRequirement` and `ensureExtensions`.
- Check `pg_available_extensions` before creating required extensions.
- Check `shared_preload_libraries` for preload-required extensions.
- Keep `vector` and `pg_search` modeled but optional so vanilla embedded PostgreSQL remains supported.
- Replace the inline `CREATE EXTENSION pg_trgm` migration setup with the capability layer.

## Refs

Refs #553
Stacked on #557
Parent #549

Verification:
- `go test ./internal/db -run 'TestEnsureExtension|TestCheckExtension|TestOptionalExtension|TestPreload|TestEmbeddedSmoke'`
- `mise run format && mise run build && mise run test`
