### PR TITLE
💄 web: redesign landing page around a commit-graph spine

### DIFF
--- a/web/src/routes/index.css
+++ b/web/src/routes/index.css
@@ -1,7 +1,10 @@
 /* Landing page — Teal brand surface.
    Visual system: light tinted canvas, pure-white cards that lift on soft
-   teal-tinted shadow, one confident teal accent, mono pulled back to chips and
-   labels only. Boldness is spent on the floating channel thread, not on color.
+   teal-tinted shadow, one confident teal accent. Boldness is spent on the
+   commit-graph spine — a single hairline runs the full page with a node at
+   each section, framing it as a dev tool's commit log — and on the headline's
+   light-to-bold weight shift; everything else stays quiet. Mono carries the
+   spine labels, chips, and data. No gradients.
    Every value resolves to a shadcn token (see web-design.md). */
 
 .home-page {
@@ -72,22 +75,28 @@
   margin: 1.4rem 0 1.3rem;
   max-width: 18ch;
   font-size: clamp(2.4rem, 5.2vw, 4rem);
-  font-weight: 600;
-  line-height: 1.06;
-  letter-spacing: -0.025em;
+  line-height: 1.04;
+  letter-spacing: -0.028em;
   color: var(--foreground);
   text-wrap: balance;
 }
 
+/* Type as the personality: a light setup resolves into a bold teal payoff.
+   The weight jump (300 -> 600) is the whole headline treatment. */
 .home-h1 span,
 .home-h1 em {
   display: block;
+}
+
+.home-h1 span {
+  font-weight: 300;
 }
 
 .home-h1 em {
   position: relative;
   z-index: 0;
   font-style: normal;
+  font-weight: 600;
   color: var(--primary);
   width: fit-content;
 }
@@ -199,25 +208,6 @@
 
 .home-hero {
   position: relative;
-  padding: clamp(3.5rem, 6vw, 6rem) 0 var(--section-pad);
-  overflow: hidden;
-}
-
-/* A single soft teal bloom behind the thread — the only gradient on the page,
-   kept low-chroma so the canvas still reads as calm. */
-.home-hero-glow {
-  position: absolute;
-  top: -12%;
-  right: -8%;
-  width: 46rem;
-  height: 46rem;
-  z-index: 0;
-  pointer-events: none;
-  background: radial-gradient(
-    closest-side,
-    color-mix(in oklch, var(--primary) 16%, transparent),
-    transparent 72%
-  );
 }
 
 .home-hero-layout {
@@ -562,60 +552,129 @@
   animation-delay: 0.3s;
 }
 
-/* ─── Pillars ─── */
+/* ─── Editorial rail — the signature ───
+   A single hairline runs down the left margin through the three story
+   sections; mono labels hang off it like spec-sheet annotations. This is
+   where the page spends its boldness; everything else stays quiet. */
 
-.home-pillars {
-  padding: var(--section-pad) 0;
+.rail-track {
+  position: relative;
 }
 
-.home-pillars-grid {
+.rail-section {
+  /* Vertical rhythm lives on .rail-body so the hairline is continuous
+     across section boundaries (adjacent bodies' borders meet). */
+  padding: 0;
+}
+
+.rail-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1.25rem;
+  grid-template-columns: minmax(6.5rem, 9rem) minmax(0, 1fr);
+  column-gap: clamp(1.25rem, 3vw, 2.75rem);
+  align-items: start;
 }
 
-.home-pillar {
-  padding: 1.75rem;
-  transition:
-    transform 200ms var(--ease),
-    box-shadow 200ms ease;
-}
-
-.home-pillar:hover {
-  transform: translateY(-3px);
-  box-shadow: var(--shadow-lg);
-}
-
-.home-pillar-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2.6rem;
-  height: 2.6rem;
-  margin-bottom: 1.1rem;
-  border-radius: var(--radius-md);
-  background: var(--accent);
-  color: var(--accent-foreground);
-}
-
-.home-pillar-title {
-  margin: 0 0 0.5rem;
-  font-size: 1.05rem;
-  font-weight: 600;
-  color: var(--foreground);
-}
-
-.home-pillar-body {
-  margin: 0;
-  font-size: 0.9rem;
-  line-height: 1.6;
+.rail-label {
+  position: sticky;
+  top: 6rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.7rem;
+  padding-top: var(--section-pad);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  line-height: 1.4;
+  text-transform: uppercase;
   color: var(--muted-foreground);
+}
+
+.home-hero-body.rail-body {
+  padding-top: clamp(2.5rem, 5vw, 4rem);
+}
+
+/* The spine: one continuous commit line down the page, with a hollow node
+   at each section — the page reads as a dev tool's commit graph. */
+.rail-body {
+  position: relative;
+  border-left: 1px solid var(--border);
+  padding-block: var(--section-pad);
+  padding-left: clamp(1.75rem, 3.5vw, 3.25rem);
+}
+
+.rail-body::before {
+  content: "";
+  position: absolute;
+  left: calc(-0.34rem - 0.5px);
+  top: calc(var(--section-pad) + 0.12rem);
+  width: 0.68rem;
+  height: 0.68rem;
+  border-radius: 50%;
+  background: var(--background);
+  border: 2px solid var(--primary);
+}
+
+.home-hero-body.rail-body::before {
+  top: calc(clamp(2.5rem, 5vw, 4rem) + 0.12rem);
+  /* Hero node is filled — the live commit you're looking at. */
+  background: var(--primary);
+}
+
+/* The builder sits on a tinted band; its node reads hollow against it. */
+.home-builder .rail-body::before {
+  background: color-mix(in oklch, var(--accent) 24%, var(--background));
+}
+
+/* ─── Pillars — spec-sheet rows, not icon cards ─── */
+
+.pillars-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.pillar-row {
+  display: grid;
+  grid-template-columns: minmax(0, 15rem) minmax(0, 1fr);
+  gap: clamp(1rem, 4vw, 3rem);
+  padding-block: 1.65rem;
+  border-top: 1px solid var(--rule);
+}
+
+.pillar-row-head {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.pillar-row-icon {
+  flex-shrink: 0;
+  color: var(--primary);
+}
+
+.pillar-row-title {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+  color: var(--foreground);
+  text-wrap: balance;
+}
+
+.pillar-row-body {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.65;
+  color: var(--muted-foreground);
+  text-wrap: pretty;
 }
 
 /* ─── Builder (agent explorer) — the one warm teal band on the page ─── */
 
 .home-builder {
-  padding: var(--section-pad) 0;
   border-block: 1px solid var(--border);
   background: color-mix(in oklch, var(--accent) 24%, var(--background));
 }
@@ -783,7 +842,7 @@
 /* ─── Reading (Recally) ─── */
 
 .home-reading {
-  padding: var(--section-pad) 0;
+  padding: 0;
 }
 
 .reader-card {
@@ -1105,13 +1164,13 @@
   transform: translateY(0);
 }
 
-.home-pillars.is-visible .home-pillar {
+.home-pillars.is-visible .pillar-row {
   animation: fade-up 0.6s var(--ease) backwards;
 }
-.home-pillars.is-visible .home-pillar:nth-child(2) {
+.home-pillars.is-visible .pillar-row:nth-child(2) {
   animation-delay: 90ms;
 }
-.home-pillars.is-visible .home-pillar:nth-child(3) {
+.home-pillars.is-visible .pillar-row:nth-child(3) {
   animation-delay: 180ms;
 }
 
@@ -1201,8 +1260,33 @@
     gap: 2.5rem;
   }
 
-  .home-pillars-grid {
+  /* Rail folds away: the label becomes a top eyebrow, the hairline drops. */
+  .rail-grid {
     grid-template-columns: 1fr;
+    row-gap: 1.25rem;
+  }
+
+  .rail-label {
+    position: static;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.6rem;
+    padding-top: var(--section-pad);
+  }
+
+  .rail-body {
+    border-left: none;
+    padding-left: 0;
+    padding-top: 1.5rem;
+  }
+
+  .rail-body::before {
+    display: none;
+  }
+
+  .pillar-row {
+    grid-template-columns: 1fr;
+    gap: 0.55rem;
   }
 
   .builder-layout {
@@ -1261,7 +1345,7 @@
   .home-hero-copy > *,
   .home-hero-preview,
   .home-h1 em::after,
-  .home-pillars.is-visible .home-pillar,
+  .home-pillars.is-visible .pillar-row,
   .thread-row,
   .thread-typing span,
   .builder-panel {

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
+import type { ReactNode } from "react";
 import {
   ArrowRight,
   Bot,
@@ -71,6 +72,16 @@ function useScrollProgress() {
   return progress;
 }
 
+// The left rail label — a mono margin-note that names this beat of the story.
+// The continuous hairline these hang off is the page's signature.
+function RailLabel({ children }: { children: ReactNode }) {
+  return (
+    <aside className="rail-label" aria-hidden>
+      {children}
+    </aside>
+  );
+}
+
 function Home() {
   const { locale } = useI18n();
   const lang: Lang = locale === "zh" ? "zh" : "en";
@@ -85,10 +96,12 @@ function Home() {
       <div className="home-progress" style={{ transform: `scaleX(${progress})` }} />
       <SiteHeader />
       <main ref={mainRef} id="main-content" className="flex-1">
-        <HeroSection lang={lang} />
-        <PillarsSection lang={lang} />
-        <AgentExplorerSection lang={lang} />
-        <RecallySection lang={lang} />
+        <div className="rail-track">
+          <HeroSection lang={lang} />
+          <PillarsSection lang={lang} />
+          <AgentExplorerSection lang={lang} />
+          <RecallySection lang={lang} />
+        </div>
         <FooterCTA lang={lang} />
       </main>
     </div>
@@ -442,49 +455,53 @@ function HeroSection({ lang }: { lang: Lang }) {
   const tr = t(lang);
 
   return (
-    <section className="home-hero">
-      <div className="home-hero-glow" aria-hidden />
-      <div className="home-shell home-hero-layout">
-        <div className="home-hero-copy">
-          <div className="home-eyebrow">
-            {isZh ? "自部署 · 团队共享 AI 同事" : "Self-hosted · Shared AI coworkers"}
-          </div>
-          <h1 className="home-h1">
-            <span>{isZh ? "团队里重复的问题" : "Your team's repeat questions"}</span>
-            <em>{isZh ? "不必再麻烦" : "don't need"}</em>
-            <span>{isZh ? "你的专家" : "your experts."}</span>
-          </h1>
-          <p className="home-lead">
-            {isZh
-              ? "财务、HR、研究的 agent 只配一次。那个本来要私聊专家的新人，直接在群里问就行——拿到答案、活也干完，关键处还停下来等你拍板。"
-              : "Set up a finance, HR, or research agent once. The new hire who'd normally DM your expert just asks the group chat — and gets the answer, the work done, and your sign-off where it matters."}
-          </p>
-          <div className="home-actions">
-            <Link to="/docs/$" params={{ _splat: "" }} className="home-btn home-btn-primary">
-              {tr.readTheDocs}
-              <ArrowRight aria-hidden className="size-4" />
-            </Link>
-            <a
-              href="https://github.com/CherryHQ/stella"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="home-btn home-btn-ghost"
-            >
-              <svg aria-hidden viewBox="0 0 24 24" className="size-4 fill-current">
-                <path d={siGithub.path} />
-              </svg>
-              {tr.sourceOnGithub}
-            </a>
-          </div>
-          <p className="home-hero-foot">
-            {isZh
-              ? "飞书 · 微信 · Telegram · QQ · Web · 终端 — 都是同一个 AI 同事的入口"
-              : "Feishu · WeChat · Telegram · QQ · Web · CLI — every one a door to the same coworker"}
-          </p>
-        </div>
+    <section className="home-hero rail-section">
+      <div className="home-shell rail-grid">
+        <RailLabel>{isZh ? "新人开口" : "The ask"}</RailLabel>
+        <div className="rail-body home-hero-body">
+          <div className="home-hero-layout">
+            <div className="home-hero-copy">
+              <div className="home-eyebrow">
+                {isZh ? "自部署 · 团队共享 AI 同事" : "Self-hosted · Shared AI coworkers"}
+              </div>
+              <h1 className="home-h1">
+                <span>{isZh ? "团队里重复的问题" : "Your team's repeat questions"}</span>
+                <em>{isZh ? "不必再麻烦" : "don't need"}</em>
+                <span>{isZh ? "你的专家" : "your experts."}</span>
+              </h1>
+              <p className="home-lead">
+                {isZh
+                  ? "财务、HR、研究的 agent 只配一次。那个本来要私聊专家的新人，直接在群里问就行——拿到答案、活也干完，关键处还停下来等你拍板。"
+                  : "Set up a finance, HR, or research agent once. The new hire who'd normally DM your expert just asks the group chat — and gets the answer, the work done, and your sign-off where it matters."}
+              </p>
+              <div className="home-actions">
+                <Link to="/docs/$" params={{ _splat: "" }} className="home-btn home-btn-primary">
+                  {tr.readTheDocs}
+                  <ArrowRight aria-hidden className="size-4" />
+                </Link>
+                <a
+                  href="https://github.com/CherryHQ/stella"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="home-btn home-btn-ghost"
+                >
+                  <svg aria-hidden viewBox="0 0 24 24" className="size-4 fill-current">
+                    <path d={siGithub.path} />
+                  </svg>
+                  {tr.sourceOnGithub}
+                </a>
+              </div>
+              <p className="home-hero-foot">
+                {isZh
+                  ? "飞书 · 微信 · Telegram · QQ · Web · 终端 — 都是同一个 AI 同事的入口"
+                  : "Feishu · WeChat · Telegram · QQ · Web · CLI — every one a door to the same coworker"}
+              </p>
+            </div>
 
-        <div className="home-hero-preview">
-          <ChannelThread lang={lang} />
+            <div className="home-hero-preview">
+              <ChannelThread lang={lang} />
+            </div>
+          </div>
         </div>
       </div>
     </section>
@@ -531,31 +548,34 @@ const PILLARS: Pillar[] = [
 function PillarsSection({ lang }: { lang: Lang }) {
   const isZh = lang === "zh";
   return (
-    <section className="home-pillars reveal-element">
-      <div className="home-shell">
-        <div className="home-block-head">
-          <h2 className="home-h2">
-            {isZh ? "配一次，全团队都能问" : "Set it up once, the whole team just asks"}
-          </h2>
-          <p className="home-lead">
-            {isZh
-              ? "一个部门负责人把 agent 装好——挂上工具、政策和知识库。从那一刻起，组织里的每个人都能直接对话调用，零配置、零学习成本。"
-              : "A department lead sets the agent up — tools, policy, knowledge base. From then on, anyone in the org uses it by chatting. Nothing to configure, nothing to learn."}
-          </p>
-        </div>
-        <div className="home-pillars-grid">
-          {PILLARS.map((p, i) => {
-            const Icon = p.icon;
-            return (
-              <article key={i} className="home-card home-pillar">
-                <span className="home-pillar-icon">
-                  <Icon aria-hidden className="size-5" />
-                </span>
-                <h3 className="home-pillar-title">{p.title[lang]}</h3>
-                <p className="home-pillar-body">{p.body[lang]}</p>
-              </article>
-            );
-          })}
+    <section className="home-pillars rail-section reveal-element">
+      <div className="home-shell rail-grid">
+        <RailLabel>{isZh ? "为什么留得住" : "Why it sticks"}</RailLabel>
+        <div className="rail-body">
+          <div className="home-block-head">
+            <h2 className="home-h2">
+              {isZh ? "配一次，全团队都能问" : "Set it up once, the whole team just asks"}
+            </h2>
+            <p className="home-lead">
+              {isZh
+                ? "一个部门负责人把 agent 装好——挂上工具、政策和知识库。从那一刻起，组织里的每个人都能直接对话调用，零配置、零学习成本。"
+                : "A department lead sets the agent up — tools, policy, knowledge base. From then on, anyone in the org uses it by chatting. Nothing to configure, nothing to learn."}
+            </p>
+          </div>
+          <ul className="pillars-list">
+            {PILLARS.map((p, i) => {
+              const Icon = p.icon;
+              return (
+                <li key={i} className="pillar-row">
+                  <div className="pillar-row-head">
+                    <Icon aria-hidden className="size-4 pillar-row-icon" />
+                    <h3 className="pillar-row-title">{p.title[lang]}</h3>
+                  </div>
+                  <p className="pillar-row-body">{p.body[lang]}</p>
+                </li>
+              );
+            })}
+          </ul>
         </div>
       </div>
     </section>
@@ -647,70 +667,73 @@ function AgentExplorerSection({ lang }: { lang: Lang }) {
   const activeAgent = AGENTS_LIST.find((a) => a.id === activeId) || AGENTS_LIST[0];
 
   return (
-    <section className="home-builder reveal-element">
-      <div className="home-shell">
-        <div className="home-block-head">
-          <h2 className="home-h2">
-            {isZh ? "做一个，全团队共享" : "Build one expert, share it with everyone"}
-          </h2>
-          <p className="home-lead">
-            {isZh
-              ? "你来定它该做什么、能用哪些工具、什么时候必须问人。建好之后，团队对话即用——不必再有人重复回答同一个问题。"
-              : "You decide what it does, which tools it can touch, and when it must ask a human. Once it exists, the team uses it by chatting — and no one answers that same question again."}
-          </p>
-        </div>
-
-        <div className="builder-layout">
-          <div className="builder-tabs">
-            {AGENTS_LIST.map((agent) => (
-              <button
-                key={agent.id}
-                onClick={() => setActiveId(agent.id)}
-                className={`builder-tab ${activeId === agent.id ? "active" : ""}`}
-              >
-                <div className="builder-tab-text">
-                  <div className="builder-tab-name">{agent.name[lang]}</div>
-                  <div className="builder-tab-role">{agent.role[lang]}</div>
-                </div>
-                <ArrowRight aria-hidden className="size-4 builder-tab-arrow" />
-              </button>
-            ))}
+    <section className="home-builder rail-section reveal-element">
+      <div className="home-shell rail-grid">
+        <RailLabel>{isZh ? "做一个专家" : "Build one expert"}</RailLabel>
+        <div className="rail-body">
+          <div className="home-block-head">
+            <h2 className="home-h2">
+              {isZh ? "做一个，全团队共享" : "Build one expert, share it with everyone"}
+            </h2>
+            <p className="home-lead">
+              {isZh
+                ? "你来定它该做什么、能用哪些工具、什么时候必须问人。建好之后，团队对话即用——不必再有人重复回答同一个问题。"
+                : "You decide what it does, which tools it can touch, and when it must ask a human. Once it exists, the team uses it by chatting — and no one answers that same question again."}
+            </p>
           </div>
 
-          <div key={activeAgent.id} className="home-card builder-panel">
-            <div className="builder-panel-head">
-              <h3 className="builder-panel-title">{activeAgent.name[lang]}</h3>
-              <p className="builder-panel-role">{activeAgent.role[lang]}</p>
+          <div className="builder-layout">
+            <div className="builder-tabs">
+              {AGENTS_LIST.map((agent) => (
+                <button
+                  key={agent.id}
+                  onClick={() => setActiveId(agent.id)}
+                  className={`builder-tab ${activeId === agent.id ? "active" : ""}`}
+                >
+                  <div className="builder-tab-text">
+                    <div className="builder-tab-name">{agent.name[lang]}</div>
+                    <div className="builder-tab-role">{agent.role[lang]}</div>
+                  </div>
+                  <ArrowRight aria-hidden className="size-4 builder-tab-arrow" />
+                </button>
+              ))}
             </div>
 
-            <div className="builder-field">
-              <span className="builder-label">
-                {isZh ? "你告诉它做什么" : "What it's told to do"}
-              </span>
-              <div className="builder-prompt">{activeAgent.instruction[lang]}</div>
-            </div>
-
-            <div className="builder-field">
-              <span className="builder-label">{isZh ? "它能用的工具" : "Tools it can use"}</span>
-              <div className="builder-tools">
-                {activeAgent.tools.map((tool, idx) => {
-                  const ToolIcon = tool.icon;
-                  return (
-                    <span key={idx} className="builder-tool">
-                      <ToolIcon aria-hidden className="size-3.5" />
-                      {tool.name}
-                    </span>
-                  );
-                })}
+            <div key={activeAgent.id} className="home-card builder-panel">
+              <div className="builder-panel-head">
+                <h3 className="builder-panel-title">{activeAgent.name[lang]}</h3>
+                <p className="builder-panel-role">{activeAgent.role[lang]}</p>
               </div>
-            </div>
 
-            <div className="builder-review">
-              <Shield aria-hidden className="size-4" />
-              <span className="builder-review-label">
-                {isZh ? "什么时候问人：" : "When it asks a human:"}
-              </span>
-              <span className="builder-review-text">{activeAgent.review[lang]}</span>
+              <div className="builder-field">
+                <span className="builder-label">
+                  {isZh ? "你告诉它做什么" : "What it's told to do"}
+                </span>
+                <div className="builder-prompt">{activeAgent.instruction[lang]}</div>
+              </div>
+
+              <div className="builder-field">
+                <span className="builder-label">{isZh ? "它能用的工具" : "Tools it can use"}</span>
+                <div className="builder-tools">
+                  {activeAgent.tools.map((tool, idx) => {
+                    const ToolIcon = tool.icon;
+                    return (
+                      <span key={idx} className="builder-tool">
+                        <ToolIcon aria-hidden className="size-3.5" />
+                        {tool.name}
+                      </span>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div className="builder-review">
+                <Shield aria-hidden className="size-4" />
+                <span className="builder-review-label">
+                  {isZh ? "什么时候问人：" : "When it asks a human:"}
+                </span>
+                <span className="builder-review-text">{activeAgent.review[lang]}</span>
+              </div>
             </div>
           </div>
         </div>
@@ -727,104 +750,109 @@ function RecallySection({ lang }: { lang: Lang }) {
   const isZh = lang === "zh";
 
   return (
-    <section className="home-reading reveal-element">
-      <div className="home-shell">
-        <div className="home-block-head">
-          <div className="home-eyebrow">Recally</div>
-          <h2 className="home-h2">
-            {isZh ? "团队的阅读和研究，自己会整理" : "Your team's reading, kept and summarized"}
-          </h2>
-          <p className="home-lead">
-            {isZh
-              ? "保存网页和 PDF、订阅 RSS、收每日摘要，还能一边读一边问。周一站会前，研究同事已经把周末的更新理好了。"
-              : "Save pages and PDFs, subscribe to feeds, get a daily digest, and ask questions while you read. By Monday standup, the research coworker has the weekend's updates ready."}
-          </p>
-        </div>
-
-        <div className="home-card reader-card">
-          <div className="reader-chrome">
-            <div className="reader-dots" aria-hidden>
-              <span className="bg-destructive" />
-              <span className="bg-chart-4" />
-              <span className="bg-chart-3" />
-            </div>
-            <span className="reader-url">recally · {isZh ? "阅读工作台" : "reader workspace"}</span>
+    <section className="home-reading rail-section reveal-element">
+      <div className="home-shell rail-grid">
+        <RailLabel>{isZh ? "它替你读" : "It reads for you"}</RailLabel>
+        <div className="rail-body">
+          <div className="home-block-head">
+            <div className="home-eyebrow">Recally</div>
+            <h2 className="home-h2">
+              {isZh ? "团队的阅读和研究，自己会整理" : "Your team's reading, kept and summarized"}
+            </h2>
+            <p className="home-lead">
+              {isZh
+                ? "保存网页和 PDF、订阅 RSS、收每日摘要，还能一边读一边问。周一站会前，研究同事已经把周末的更新理好了。"
+                : "Save pages and PDFs, subscribe to feeds, get a daily digest, and ask questions while you read. By Monday standup, the research coworker has the weekend's updates ready."}
+            </p>
           </div>
 
-          <div className="reader-layout">
-            <div className="reader-sidebar">
-              <div className="reader-sidebar-head">{isZh ? "阅读队列" : "Reading queue"}</div>
-              <div className="reader-list">
-                <div className="reader-item active">
-                  <div className="reader-item-title">
-                    {isZh ? "自部署团队 AI：真正要紧的事" : "Self-hosting team AI: what matters"}
-                  </div>
-                  <div className="reader-item-meta">stella.sh · {isZh ? "今天" : "Today"}</div>
-                </div>
-                <div className="reader-item">
-                  <div className="reader-item-title">
-                    {isZh ? "把入职问题砍掉一半" : "Cutting onboarding questions in half"}
-                  </div>
-                  <div className="reader-item-meta">blog · {isZh ? "昨天" : "Yesterday"}</div>
-                </div>
-                <div className="reader-item">
-                  <div className="reader-item-title">
-                    {isZh ? "知识库怎么不变成垃圾场" : "Keeping a knowledge base usable"}
-                  </div>
-                  <div className="reader-item-meta">notes · {isZh ? "3 天前" : "3d ago"}</div>
-                </div>
+          <div className="home-card reader-card">
+            <div className="reader-chrome">
+              <div className="reader-dots" aria-hidden>
+                <span className="bg-destructive" />
+                <span className="bg-chart-4" />
+                <span className="bg-chart-3" />
               </div>
+              <span className="reader-url">
+                recally · {isZh ? "阅读工作台" : "reader workspace"}
+              </span>
             </div>
 
-            <div className="reader-main">
-              <h3 className="reader-article-title">
-                {isZh
-                  ? "自部署团队 AI：真正要紧的，不是模型"
-                  : "Self-hosting team AI: the model isn't the hard part"}
-              </h3>
-              <div className="reader-article-meta">
-                {isZh ? "作者 Stella 团队 · 5 分钟读完" : "Stella team · 5 min read"}
+            <div className="reader-layout">
+              <div className="reader-sidebar">
+                <div className="reader-sidebar-head">{isZh ? "阅读队列" : "Reading queue"}</div>
+                <div className="reader-list">
+                  <div className="reader-item active">
+                    <div className="reader-item-title">
+                      {isZh ? "自部署团队 AI：真正要紧的事" : "Self-hosting team AI: what matters"}
+                    </div>
+                    <div className="reader-item-meta">stella.sh · {isZh ? "今天" : "Today"}</div>
+                  </div>
+                  <div className="reader-item">
+                    <div className="reader-item-title">
+                      {isZh ? "把入职问题砍掉一半" : "Cutting onboarding questions in half"}
+                    </div>
+                    <div className="reader-item-meta">blog · {isZh ? "昨天" : "Yesterday"}</div>
+                  </div>
+                  <div className="reader-item">
+                    <div className="reader-item-title">
+                      {isZh ? "知识库怎么不变成垃圾场" : "Keeping a knowledge base usable"}
+                    </div>
+                    <div className="reader-item-meta">notes · {isZh ? "3 天前" : "3d ago"}</div>
+                  </div>
+                </div>
               </div>
-              <div className="reader-article-body">
-                <p>
-                  {isZh
-                    ? "大多数团队卡住，不是因为模型不够强，而是因为答案散落在几个人的脑子里。一旦专家请假，问题就堆起来。"
-                    : "Most teams don't stall because the model is weak. They stall because the answers live in a few people's heads — and when the expert is out, the questions pile up."}
-                </p>
-                <p className="reader-highlight">
-                  {isZh
-                    ? "把数据留在你自己的机器上，把知识装进一个团队都能问的同事里——这才是自部署真正买到的东西。"
-                    : "Keep the data on your own machine, and put the knowledge into a coworker the whole team can ask. That's what self-hosting actually buys you."}
-                </p>
-                <p>
-                  {isZh
-                    ? "每个人按各自的权限看到内容，敏感操作停下来等人确认——有用的工作，有清楚的边界。"
-                    : "Everyone sees only what their permissions allow, and sensitive moves wait for a human. Useful work, with clear edges."}
-                </p>
-              </div>
-            </div>
 
-            <div className="reader-chat">
-              <div className="reader-chat-head">
-                <MessageCircle aria-hidden className="size-3.5" />
-                {isZh ? "边读边问" : "Ask while you read"}
-              </div>
-              <div className="reader-chat-body">
-                <div className="reader-bubble user">
-                  {isZh ? "一句话讲这篇说了啥？" : "One sentence — what's the point?"}
-                </div>
-                <div className="reader-bubble bot">
+              <div className="reader-main">
+                <h3 className="reader-article-title">
                   {isZh
-                    ? "把知识从几个人脑子里搬进一个团队都能问的 AI 同事，自部署保证数据和权限都在你手里。"
-                    : "Move knowledge out of a few people's heads into a coworker the team can ask — self-hosted, so the data and permissions stay yours."}
+                    ? "自部署团队 AI：真正要紧的，不是模型"
+                    : "Self-hosting team AI: the model isn't the hard part"}
+                </h3>
+                <div className="reader-article-meta">
+                  {isZh ? "作者 Stella 团队 · 5 分钟读完" : "Stella team · 5 min read"}
+                </div>
+                <div className="reader-article-body">
+                  <p>
+                    {isZh
+                      ? "大多数团队卡住，不是因为模型不够强，而是因为答案散落在几个人的脑子里。一旦专家请假，问题就堆起来。"
+                      : "Most teams don't stall because the model is weak. They stall because the answers live in a few people's heads — and when the expert is out, the questions pile up."}
+                  </p>
+                  <p className="reader-highlight">
+                    {isZh
+                      ? "把数据留在你自己的机器上，把知识装进一个团队都能问的同事里——这才是自部署真正买到的东西。"
+                      : "Keep the data on your own machine, and put the knowledge into a coworker the whole team can ask. That's what self-hosting actually buys you."}
+                  </p>
+                  <p>
+                    {isZh
+                      ? "每个人按各自的权限看到内容，敏感操作停下来等人确认——有用的工作，有清楚的边界。"
+                      : "Everyone sees only what their permissions allow, and sensitive moves wait for a human. Useful work, with clear edges."}
+                  </p>
                 </div>
               </div>
-              <div className="reader-chat-input">
-                <input
-                  type="text"
-                  readOnly
-                  placeholder={isZh ? "再追问一句…" : "Ask a follow-up…"}
-                />
+
+              <div className="reader-chat">
+                <div className="reader-chat-head">
+                  <MessageCircle aria-hidden className="size-3.5" />
+                  {isZh ? "边读边问" : "Ask while you read"}
+                </div>
+                <div className="reader-chat-body">
+                  <div className="reader-bubble user">
+                    {isZh ? "一句话讲这篇说了啥？" : "One sentence — what's the point?"}
+                  </div>
+                  <div className="reader-bubble bot">
+                    {isZh
+                      ? "把知识从几个人脑子里搬进一个团队都能问的 AI 同事，自部署保证数据和权限都在你手里。"
+                      : "Move knowledge out of a few people's heads into a coworker the team can ask — self-hosted, so the data and permissions stay yours."}
+                  </div>
+                </div>
+                <div className="reader-chat-input">
+                  <input
+                    type="text"
+                    readOnly
+                    placeholder={isZh ? "再追问一句…" : "Ask a follow-up…"}
+                  />
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## What

Visual redesign of the marketing landing page (`web/src/routes/index.tsx` + `index.css`). No copy, tokens, or CossUI components touched.

- **A continuous commit-graph spine** runs the full page: a filled teal node at the hero, hollow nodes at each section, with mono margin-labels naming each beat of the story (`The ask` → `Why it sticks` → `Build one expert` → `It reads for you`). Frames Stella as the self-hosted dev tool it is.
- **Removed the hero radial gradient** — the generic AI-design tell. Clean negative space and the thread card's elevation carry the hero instead.
- **Rebuilt the pillars** from three icon cards (the context-free icon grid) into hairline-divided spec-sheet rows.
- **Headline type treatment**: a light-to-bold weight shift (Inter 300 → 600), so the emphasis lands on "don't need."

## Why

The previous page was competent but templated: every section repeated the same centered `h2 + lead + card` rhythm, the pillars were generic icon cards, and the most-seen screen (the hero) leaned on a purple-style gradient bloom. The page read as one of four stacked demos with no through-line. The spine turns it into a single annotated narrative with a brand-true visual identity, and concentrates the boldness in one place per design discipline.

## How

- Wrapped the hero and the three story sections in a `.rail-track` with a per-section `.rail-grid` (mono label column + bordered `.rail-body`). The continuous hairline is the `border-left` of adjacent rail bodies meeting; nodes are `::before` markers on the line.
- Spine and nodes fold away below 960px (label becomes a top eyebrow); `prefers-reduced-motion` respected.
- Every value still resolves to an existing shadcn token. The Inter 300 headline is a deliberate, landing-only deviation from `web-design.md` (Inter 600 for display) — documented inline at `.home-h1`.
- Verified: `vp check` (lint + types, 266 files) and `vp build` pass; light/dark desktop + mobile screenshotted.

## Refs

- No linked issue — opened directly per repo owner's decision.