### PR TITLE
♻️ refactor(river): single shared client; run goal attempts on River durable jobs

### DIFF
--- a/cmd/stellad/commands.go
+++ b/cmd/stellad/commands.go
@@ -8,7 +8,9 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
 	ucli "github.com/urfave/cli/v2"
 
 	"github.com/CherryHQ/stella/internal/agent"
@@ -68,6 +70,7 @@ type setupResult struct {
 	poolManager              *agent.PoolManager
 	schedulerSvc             *scheduler.Service
 	goalSvc                  *goal.Service
+	riverClient              *river.Client[pgx.Tx]
 	builtinTools             []pkgtools.Tool
 	notifier                 *notify.Dispatcher
 	pluginToolsBuilder       agent.PluginToolsBuilder
@@ -195,7 +198,7 @@ func setup(parent context.Context, _ bool) (*setupResult, error) {
 		return phost.SessionPluginView(ctx)
 	}
 
-	goalSvc := goal.Boot(goal.BootConfig{
+	goalSvc, err := goal.Boot(goal.BootConfig{
 		DB:       db,
 		Services: &lazyServiceManager{get: func() agent.ServiceManager { return poolMgr }},
 		Chat: func(ctx context.Context, p goal.TaskChatParams) <-chan agent.Event {
@@ -222,6 +225,9 @@ func setup(parent context.Context, _ bool) (*setupResult, error) {
 			})
 		},
 	})
+	if err != nil {
+		return nil, fmt.Errorf("boot goal service: %w", err)
+	}
 
 	poolMgr = agent.NewPoolManager(store, memProvider,
 		agent.WithCompactionPM(agent.CompactionConfig{}.WithDefaults()),
@@ -251,6 +257,14 @@ func setup(parent context.Context, _ bool) (*setupResult, error) {
 		return nil, fmt.Errorf("start pool manager: %w", err)
 	}
 
+	// Composition root for River: both the scheduler and goal subsystems are now
+	// built, so assemble the single shared working client from their queues and
+	// inject it back into each. runServer owns its Start/Stop.
+	riverClient, err := buildSharedRiverClient(db, schedulerSvc, goalSvc)
+	if err != nil {
+		return nil, err
+	}
+
 	backgroundTasks := &sync.WaitGroup{}
 	if ps.manifestToReconcile != nil {
 		reconcileManifestPluginsInBackground(parent, backgroundTasks, ps.manifestToReconcile, config.StellaHome())
@@ -267,6 +281,7 @@ func setup(parent context.Context, _ bool) (*setupResult, error) {
 		poolManager:              poolMgr,
 		schedulerSvc:             schedulerSvc,
 		goalSvc:                  goalSvc,
+		riverClient:              riverClient,
 		builtinTools:             builtinTools,
 		notifier:                 dispatcher,
 		pluginToolsBuilder:       pluginToolsBuilder,
@@ -301,12 +316,44 @@ func ensureEmbeddedAssets() error {
 }
 
 func setupScheduler(db *pgxpool.Pool, phost *pluginhost.Host) (*scheduler.Service, error) {
-	svc, err := scheduler.New(db)
+	// External-river mode: the scheduler does not build its own River client. The
+	// composition root (buildSharedRiverClient) assembles the single process-wide
+	// working client from both the scheduler and goal queues and injects it back
+	// via SetRiverClient, so there is exactly one electable River client per
+	// database (see db.NewWorkingRiverClient).
+	svc, err := scheduler.New(db, scheduler.WithExternalRiver())
 	if err != nil {
 		return nil, fmt.Errorf("create scheduler service: %w", err)
 	}
 	phost.SetSchedulerService(newSchedulerServiceAdapter(svc, phost.Runtime()))
 	return svc, nil
+}
+
+// buildSharedRiverClient is the composition root for River: it assembles the
+// single process-wide working client from every subsystem's queue + worker
+// (scheduler and goal), then injects it back into each so they enqueue and
+// register periodic jobs against the same client. There must be exactly one
+// electable River client per database (see db.NewWorkingRiverClient); this is
+// where that invariant is enforced. The caller owns the returned client's
+// Start/Stop lifecycle (runServer); the subsystems only use it.
+func buildSharedRiverClient(db *pgxpool.Pool, schedulerSvc *scheduler.Service, goalSvc *goal.Service) (*river.Client[pgx.Tx], error) {
+	workers := river.NewWorkers()
+	scheduler.RegisterRiverWorker(workers, schedulerSvc)
+	goalSvc.RegisterRiverWorker(workers)
+
+	queues := map[string]river.QueueConfig{}
+	sn, sc := scheduler.SchedulerQueueConfig()
+	queues[sn] = sc
+	gn, gc := goalSvc.GoalQueueConfig()
+	queues[gn] = gc
+
+	client, err := appdb.NewWorkingRiverClient(db, queues, workers, slog.With("component", "river"))
+	if err != nil {
+		return nil, fmt.Errorf("build shared river client: %w", err)
+	}
+	schedulerSvc.SetRiverClient(client)
+	goalSvc.SetRiverClient(client)
+	return client, nil
 }
 
 func wireSchedulerCallbacks(svc *scheduler.Service, poolMgr *agent.PoolManager, dispatcher *notify.Dispatcher) {

--- a/cmd/stellad/gateway.go
+++ b/cmd/stellad/gateway.go
@@ -297,7 +297,21 @@ func runServer(ctx context.Context, s *setupResult, listFn func() []pkgchannel.M
 	// Wire auth directory into dispatcher for per-user notification routing.
 	s.notifier.SetAuthService(s.pluginHost.Auth())
 
-	// Wire scheduler and start it.
+	// Start the single shared River client (composition root: buildSharedRiverClient
+	// assembled it from the scheduler and goal queues). It is started before the
+	// subsystems and, because defers run LIFO, its Stop runs last — after the goal
+	// tick and the scheduler have stopped — so in-flight attempt and scheduled jobs
+	// drain gracefully with no new work being enqueued.
+	if s.riverClient != nil {
+		if err := s.riverClient.Start(ctx); err != nil {
+			return fmt.Errorf("start river client: %w", err)
+		}
+		defer func() { _ = s.riverClient.Stop(context.Background()) }()
+	}
+
+	// Wire scheduler and start it. In external-river mode Start/Stop register and
+	// tear down the scheduler's periodic and one-time jobs against the shared
+	// client but do not start or stop it.
 	if s.schedulerSvc != nil {
 		adminSrv.SetSchedulerService(s.schedulerSvc)
 		wireSchedulerCallbacks(s.schedulerSvc, s.poolManager, s.notifier)
@@ -308,9 +322,12 @@ func runServer(ctx context.Context, s *setupResult, listFn func() []pkgchannel.M
 		defer func() { _ = s.schedulerSvc.Stop() }()
 	}
 
-	// Dispatcher tick (Phase 6 wiring). Registered as a recurring in-memory
-	// task on scheduler.Service — no sched_job row (D4). The dispatcher waits
-	// for in-flight workers to drain on Stop.
+	// Goal execution substrate (River Phase 2a). The dispatcher enqueues claimed
+	// attempts onto the shared client (injected via SetRiverClient); register its
+	// tick as a recurring in-memory task on scheduler.Service — no sched_job row
+	// (D4). The tick scans+claims and enqueues; the shared River client executes.
+	// Shutdown (defers run LIFO): stop the tick first so no new claims enqueue,
+	// then the scheduler, then drain in-flight jobs when the shared client stops.
 	if s.goalSvc != nil && s.schedulerSvc != nil {
 		if err := s.schedulerSvc.ScheduleEvery(ctx, "2s", func(ctx context.Context) {
 			s.goalSvc.Dispatcher.Tick(ctx)

--- a/internal/db/river.go
+++ b/internal/db/river.go
@@ -3,6 +3,8 @@ package db
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -30,15 +32,41 @@ func migrateRiver(ctx context.Context, pool *pgxpool.Pool) error {
 	return nil
 }
 
-// NewRiverClient returns an insert-only River client bound to the shared pool:
-// it can enqueue jobs but works none, because it configures neither Queues nor
-// Workers. This is the Phase 0 substrate — the durable-queue plumbing stands up
-// and its schema is migrated, but nothing drives off it yet. Phase 1 supplies
-// Queues + Workers (and Start()s the client) to actually run jobs.
-func NewRiverClient(pool *pgxpool.Pool) (*river.Client[pgx.Tx], error) {
-	client, err := river.NewClient(riverpgxv5.New(pool), &river.Config{})
+const (
+	// riverJobTimeout disables River's per-job timeout (default 1m). Both the
+	// scheduler and goal queues execute agent runs that routinely exceed a minute;
+	// graceful shutdown still cancels in-flight work via SoftStopTimeout.
+	riverJobTimeout = -1
+	// riverSoftStopTimeout bounds how long Stop waits for in-flight jobs to drain
+	// before cancelling their work contexts.
+	riverSoftStopTimeout = 30 * time.Second
+	// riverRescueStuckJobsAfter keeps River from marking a legitimately long agent
+	// run as stuck (default 1h). App-level guards (scheduler's tryStartJobRun, the
+	// goal lease/reaper) are the real backstops; this only keeps River's own job
+	// state from going misleadingly stuck/discarded under expected run durations.
+	riverRescueStuckJobsAfter = 24 * time.Hour
+)
+
+// NewWorkingRiverClient builds the single, process-wide River client that works
+// the given queues with the given workers. There must be exactly ONE working
+// (electable) client per database: River elects a single leader per database to
+// run leader-only maintenance — including the periodic-job enqueuer, which only
+// enqueues the periodic jobs registered on the LEADER client. A second electable
+// client could win leadership and silently starve another client's periodic jobs
+// (e.g. the scheduler's cron). So every subsystem that needs to work or enqueue
+// jobs shares this one client; subsystems contribute their queues + workers and
+// inject the result rather than constructing their own client.
+func NewWorkingRiverClient(pool *pgxpool.Pool, queues map[string]river.QueueConfig, workers *river.Workers, logger *slog.Logger) (*river.Client[pgx.Tx], error) {
+	client, err := river.NewClient(riverpgxv5.New(pool), &river.Config{
+		Logger:               logger,
+		Queues:               queues,
+		Workers:              workers,
+		JobTimeout:           riverJobTimeout,
+		SoftStopTimeout:      riverSoftStopTimeout,
+		RescueStuckJobsAfter: riverRescueStuckJobsAfter,
+	})
 	if err != nil {
-		return nil, fmt.Errorf("river client: %w", err)
+		return nil, fmt.Errorf("create working river client: %w", err)
 	}
 	return client, nil
 }

--- a/internal/goal/boot.go
+++ b/internal/goal/boot.go
@@ -6,8 +6,10 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
 
 	"github.com/CherryHQ/stella/internal/agent"
 	"github.com/CherryHQ/stella/pkg/db/sqlc"
@@ -19,10 +21,42 @@ import (
 // exposes the read+command surface the HTTP handlers call. Every mutating method
 // delegates to GoalService so the "lifecycle is written only through a
 // transition" invariant holds; reads go straight to the querier.
+//
+// The goal subsystem does NOT own a River client: it contributes its queue +
+// worker to the single process-wide client (RegisterRiverWorker / GoalQueueConfig)
+// and receives that client back as its dispatcher's enqueuer (SetRiverClient).
+// The client's Start/Stop lifecycle belongs to the composition root.
 type Service struct {
 	Queries    *sqlc.Queries
 	Goal       *GoalService
 	Dispatcher *Dispatcher
+
+	// runner executes one claimed attempt; it backs both the goal River worker
+	// (RegisterRiverWorker) and is shared with nothing else. queueMaxWorkers and
+	// logger are captured at Boot so the composition root can assemble the shared
+	// client's worker + queue config without re-deriving them.
+	runner          WorkerRunner
+	queueMaxWorkers int
+	logger          *slog.Logger
+}
+
+// RegisterRiverWorker registers the goal-attempt worker into a shared workers
+// bundle used to build the process-wide River client. Call before building the
+// client (composition root).
+func (s *Service) RegisterRiverWorker(workers *river.Workers) {
+	RegisterGoalWorker(workers, s.runner, s.logger.With("subcomponent", "river"))
+}
+
+// GoalQueueConfig returns the goal queue name and per-node worker config for the
+// composition root assembling the shared working client.
+func (s *Service) GoalQueueConfig() (string, river.QueueConfig) {
+	return GoalQueue, river.QueueConfig{MaxWorkers: s.queueMaxWorkers}
+}
+
+// SetRiverClient injects the shared working River client as the dispatcher's
+// enqueuer. Call after the client is built and before the dispatcher tick starts.
+func (s *Service) SetRiverClient(c *river.Client[pgx.Tx]) {
+	s.Dispatcher.SetEnqueuer(c)
 }
 
 // TaskChatParams is the worker-turn request passed to BootConfig.Chat. It mirrors
@@ -51,8 +85,9 @@ type BootConfig struct {
 	DB       *pgxpool.Pool
 	Services agent.ServiceManager // registry-backed session minting
 	Chat     TaskChatFunc         // runs persisted worker turns; nil => noop executor
-	// MaxWorkers, TickEvery, LeaseTTL override defaults; zero values use the
-	// dispatcher/service defaults.
+	// MaxWorkers caps concurrent attempt executions per node on the goal River
+	// queue (0 => defaultGoalMaxWorkers). TickEvery/LeaseTTL override the
+	// dispatcher/service defaults; zero values use them.
 	MaxWorkers int
 	TickEvery  time.Duration
 	LeaseTTL   time.Duration
@@ -70,7 +105,7 @@ type BootConfig struct {
 // fails non-retryably) plus the worker + planning session minters are registered
 // on the GoalService; one Worker drives claimed attempts and the
 // Dispatcher schedules the convergence loop over it.
-func Boot(cfg BootConfig) *Service {
+func Boot(cfg BootConfig) (*Service, error) {
 	q := sqlc.New(cfg.DB)
 	logger := cfg.Logger
 	if logger == nil {
@@ -84,17 +119,32 @@ func Boot(cfg BootConfig) *Service {
 		WithConfig(Config{LeaseTTL: cfg.LeaseTTL}),
 	)
 
+	maxWorkers := cfg.MaxWorkers
+	if maxWorkers == 0 {
+		maxWorkers = defaultGoalMaxWorkers
+	}
+	runner := workerRunner{w: NewWorker(svc, q)}
+
+	// The dispatcher's enqueuer is injected later via SetRiverClient (the shared
+	// client is built by the composition root once both subsystems have
+	// contributed their queue + worker). Until then Enqueuer is nil and the
+	// dispatcher skips dispatch — the state tests rely on (they drive Worker.Run).
 	disp := NewDispatcher(DispatcherConfig{
-		Service:    svc,
-		Queries:    q,
-		Worker:     workerRunner{w: NewWorker(svc, q)},
-		MaxWorkers: cfg.MaxWorkers,
-		TickEvery:  cfg.TickEvery,
-		LeaseTTL:   cfg.LeaseTTL,
-		Logger:     logger.With("subcomponent", "dispatcher"),
+		Service:   svc,
+		Queries:   q,
+		TickEvery: cfg.TickEvery,
+		LeaseTTL:  cfg.LeaseTTL,
+		Logger:    logger.With("subcomponent", "dispatcher"),
 	})
 
-	return &Service{Queries: q, Goal: svc, Dispatcher: disp}
+	return &Service{
+		Queries:         q,
+		Goal:            svc,
+		Dispatcher:      disp,
+		runner:          runner,
+		queueMaxWorkers: maxWorkers,
+		logger:          logger,
+	}, nil
 }
 
 // bootExecutor picks the worker executor. With a Chat callback it runs persisted

--- a/internal/goal/converge.go
+++ b/internal/goal/converge.go
@@ -126,7 +126,13 @@ func (s *GoalService) mintNextAttempt(ctx context.Context, q *sqlc.Queries, d sq
 		AttemptNo:       int64(attemptNo),
 		Status:          AttemptQueued,
 		InputContext:    marshalJSON(input),
-		LeaseExpiresAt:  nullTime(s.nowTime()),
+		// Grace lease on the queued attempt: a River worker on any node must be
+		// able to pick the job up and PromoteAttempt (extending the lease) before
+		// the dispatcher reaper reclaims it. now() would be instantly stale — that
+		// only worked under the old in-process active-map guard. The lease is now
+		// the single, multi-node liveness signal: a claim/enqueue gap or a crash
+		// before pickup recovers via the reaper once this grace window expires.
+		LeaseExpiresAt: nullTime(s.nowTime().Add(claimGraceTTL)),
 	})
 	if err != nil {
 		return sqlc.AgentGoalAttempt{}, fmt.Errorf("create attempt: %w", err)

--- a/internal/goal/dispatcher.go
+++ b/internal/goal/dispatcher.go
@@ -40,12 +40,11 @@ type SchedulerLike interface {
 type DispatcherConfig struct {
 	Service *GoalService
 	Queries *sqlc.Queries
-	Worker  WorkerRunner
+	// Enqueuer enqueues one durable River job per claimed attempt (River Phase
+	// 2a). A nil enqueuer disables dispatch (tests that drive Worker.Run directly).
+	Enqueuer goalEnqueuer
 
-	TickEvery time.Duration // 0 ⇒ defaultTickEvery
-	// MaxWorkers caps attempts this process executes concurrently (the in-process
-	// worker-pool bound; distinct from the durable per-root/per-user caps below).
-	MaxWorkers int           // 0 ⇒ defaultMaxWorkers
+	TickEvery  time.Duration // 0 ⇒ defaultTickEvery
 	LeaseTTL   time.Duration // 0 ⇒ service LeaseTTL
 	BatchLimit int           // 0 ⇒ defaultBatchLimit
 	// MaxConcurrentPerUser caps in-flight attempts per user (§5/§10.8, default
@@ -56,26 +55,19 @@ type DispatcherConfig struct {
 
 const (
 	defaultTickEvery  = 2 * time.Second
-	defaultMaxWorkers = 5
 	defaultBatchLimit = 50
 )
 
 // Dispatcher drives the convergence loop on a tick: reap stale attempts,
 // propagate dep failures, roll up composites, then scan-and-claim dispatchable
-// leaves under the concurrency budget and spawn a bounded pool of workers
-// (contract §5, §7). It is the only scheduler; every durable write still routes
-// through GoalService.
+// leaves under the concurrency caps and enqueue a durable River job per claim
+// (contract §5, §7; River Phase 2a). It is the only scheduler; every durable
+// write still routes through GoalService, and every attempt now executes as a
+// River job rather than an in-process goroutine.
 type Dispatcher struct {
 	cfg DispatcherConfig
 
-	mu sync.Mutex
-	// active is the set of attempt IDs this process is executing right now. A
-	// member must never be reaped as "lease expired": the worker is alive even if
-	// its heartbeat lost the contended SQLite writer. The DB lease is the
-	// crash/restart backstop (an empty set after restart reclaims orphans).
-	// Single-process only — multi-replica reclaim keys off per-replica liveness.
-	active  map[string]bool
-	wg      sync.WaitGroup
+	mu      sync.Mutex
 	stopCh  chan struct{}
 	stopped bool
 }
@@ -85,9 +77,6 @@ type Dispatcher struct {
 func NewDispatcher(cfg DispatcherConfig) *Dispatcher {
 	if cfg.TickEvery == 0 {
 		cfg.TickEvery = defaultTickEvery
-	}
-	if cfg.MaxWorkers == 0 {
-		cfg.MaxWorkers = defaultMaxWorkers
 	}
 	if cfg.LeaseTTL == 0 && cfg.Service != nil {
 		cfg.LeaseTTL = cfg.Service.cfg.LeaseTTL
@@ -103,9 +92,15 @@ func NewDispatcher(cfg DispatcherConfig) *Dispatcher {
 	}
 	return &Dispatcher{
 		cfg:    cfg,
-		active: map[string]bool{},
 		stopCh: make(chan struct{}),
 	}
+}
+
+// SetEnqueuer injects the River enqueuer the dispatcher uses to dispatch claimed
+// attempts. Called by the composition root after the shared client is built and
+// before the tick starts; a nil enqueuer leaves dispatch disabled.
+func (d *Dispatcher) SetEnqueuer(e goalEnqueuer) {
+	d.cfg.Enqueuer = e
 }
 
 // Start registers the tick on sched. A nil scheduler is silent: callers drive
@@ -119,17 +114,17 @@ func (d *Dispatcher) Start(ctx context.Context, sched SchedulerLike) error {
 	})
 }
 
-// Stop signals the tick to go quiet and drains in-flight workers.
+// Stop signals the tick to go quiet. In-flight attempts now run as River jobs;
+// draining them is the goal River client's responsibility (Service.StopRiver),
+// not the dispatcher's.
 func (d *Dispatcher) Stop() {
 	d.mu.Lock()
+	defer d.mu.Unlock()
 	if d.stopped {
-		d.mu.Unlock()
 		return
 	}
 	d.stopped = true
 	close(d.stopCh)
-	d.mu.Unlock()
-	d.wg.Wait()
 }
 
 // Tick runs one pass of the dispatch loop. Public so tests can drive it
@@ -153,9 +148,10 @@ func (d *Dispatcher) isStopped() bool {
 }
 
 // reapStaleAttempts finds queued/running attempts whose lease has expired and
-// (unless this process is actively executing them) finalizes them as
-// 'interrupted' through the service, which returns the goal to ready
-// within its convergence budget (contract §2.2).
+// finalizes them as 'interrupted' through the service, which returns the goal to
+// ready within its convergence budget (contract §2.2). The lease is authoritative
+// across nodes: a live attempt's River worker heartbeats it forward, so an
+// expired lease means a genuine orphan.
 func (d *Dispatcher) reapStaleAttempts(ctx context.Context, now time.Time) {
 	stale, err := d.cfg.Queries.ListStaleAttempts(ctx, sqlc.ListStaleAttemptsParams{
 		Now:   pgtype.Timestamptz{Time: now, Valid: true},
@@ -166,12 +162,10 @@ func (d *Dispatcher) reapStaleAttempts(ctx context.Context, now time.Time) {
 		return
 	}
 	for _, a := range stale {
-		// Never reap an attempt this process is actively executing: the worker is
-		// alive even if its heartbeat lost the contended writer. Only genuinely
-		// orphaned attempts (never started here, or after a crash/restart) reclaim.
-		if d.isActive(a.ID) {
-			continue
-		}
+		// The lease is the single, multi-node liveness signal: a live attempt's
+		// River worker heartbeats it forward, so a lease in the past means the job
+		// genuinely orphaned (never picked up within the claim grace, or its node
+		// crashed). No in-process guard — that was the old single-process design.
 		if err := d.cfg.Service.ReapAttempt(ctx, a.ID); err != nil && !errors.Is(err, ErrInvalidTransition) {
 			d.cfg.Logger.Warn("dispatcher: reap attempt", "attempt", a.ID, "goal", a.GoalID, "err", err)
 		}
@@ -266,8 +260,14 @@ func (d *Dispatcher) applyRollup(ctx context.Context, parent sqlc.AgentGoal, sta
 
 // scanAndClaim picks dispatchable leaves, enforces readiness + the per-root and
 // per-user concurrency caps (§5/§10.8), resolves the executor, claims through
-// the service, and spawns a bounded worker per claim.
+// the service, and enqueues a durable River job per claim (River Phase 2a).
+// Execution concurrency is bounded by the goal queue's MaxWorkers plus the
+// per-root/per-user caps enforced here, so no in-process worker-pool gate is
+// needed. A nil enqueuer (test wiring) skips dispatch.
 func (d *Dispatcher) scanAndClaim(ctx context.Context, now time.Time) {
+	if d.cfg.Enqueuer == nil {
+		return
+	}
 	candidates, err := d.cfg.Queries.ListDispatchableLeaves(ctx, int32(d.cfg.BatchLimit))
 	if err != nil {
 		d.cfg.Logger.Warn("dispatcher: list dispatchable leaves", "err", err)
@@ -282,9 +282,6 @@ func (d *Dispatcher) scanAndClaim(ctx context.Context, now time.Time) {
 	for _, goal := range candidates {
 		if d.isStopped() {
 			return
-		}
-		if !d.underWorkerCap() {
-			return // process worker pool full; try again next tick
 		}
 
 		edges, err := d.cfg.Queries.ListEdgeWithUpstreamState(ctx, goal.ID)
@@ -321,7 +318,17 @@ func (d *Dispatcher) scanAndClaim(ctx context.Context, now time.Time) {
 		}
 		rootInflight[goal.RootID]++
 		userInflight[goal.UserID]++
-		d.spawnWorker(ctx, goal.ID, attempt.ID)
+		d.enqueueAttempt(ctx, goal.ID, attempt.ID)
+	}
+}
+
+// enqueueAttempt enqueues a durable River job to execute one claimed attempt. An
+// insert failure is logged, not fatal: the attempt stays queued and the reaper
+// reopens its goal once the claim grace lease expires (mintNextAttempt), so a
+// transient enqueue gap self-heals on a later tick.
+func (d *Dispatcher) enqueueAttempt(ctx context.Context, goalID, attemptID string) {
+	if _, err := d.cfg.Enqueuer.Insert(ctx, goalAttemptArgs{GoalID: goalID, AttemptID: attemptID}, goalInsertOpts()); err != nil {
+		d.cfg.Logger.Warn("dispatcher: enqueue attempt job", "goal", goalID, "attempt", attemptID, "err", err)
 	}
 }
 
@@ -406,45 +413,6 @@ type dispatchHint struct {
 	ExecutorAgentID string `json:"executor_agent_id"`
 	ConsumedAt      string `json:"consumed_at"`
 }
-
-func (d *Dispatcher) underWorkerCap() bool {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	return len(d.active) < d.cfg.MaxWorkers
-}
-
-func (d *Dispatcher) inc(attemptID string) {
-	d.mu.Lock()
-	d.active[attemptID] = true
-	d.mu.Unlock()
-}
-
-func (d *Dispatcher) dec(attemptID string) {
-	d.mu.Lock()
-	delete(d.active, attemptID)
-	d.mu.Unlock()
-}
-
-func (d *Dispatcher) isActive(attemptID string) bool {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	return d.active[attemptID]
-}
-
-// spawnWorker runs one claimed attempt in a tracked goroutine, bounded by the
-// MaxWorkers gate the caller already checked.
-func (d *Dispatcher) spawnWorker(ctx context.Context, goalID, attemptID string) {
-	d.inc(attemptID)
-	d.wg.Go(func() {
-		defer d.dec(attemptID)
-		if err := d.cfg.Worker.Run(ctx, goalID, attemptID); err != nil {
-			d.cfg.Logger.Warn("dispatcher: worker returned error", "goal", goalID, "attempt", attemptID, "err", err)
-		}
-	})
-}
-
-// WaitIdle blocks until no workers are in flight (tests).
-func (d *Dispatcher) WaitIdle() { d.wg.Wait() }
 
 // ── Dispatcher-driven service transitions ───────────────────────────────────
 //

--- a/internal/goal/river.go
+++ b/internal/goal/river.go
@@ -1,0 +1,102 @@
+package goal
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
+)
+
+// River Phase 2a: goal attempt execution runs on durable River jobs instead of
+// the old in-process worker pool. Claiming a leaf mints an attempt and enqueues
+// ONE job here; a worker promotes and drives it to a terminal attempt state.
+// River owns durability, multi-node distribution, and graceful drain — but NOT
+// retry: MaxAttempts is 1 so the same attempt_id is never re-run. Retry is the
+// goal convergence model's job (attempt_count / reopenForRework), driven by the
+// dispatcher reaper off the lease.
+//
+// The goal queue's worker runs on the single process-wide River client
+// (db.NewWorkingRiverClient): there must be exactly one electable client per
+// database, so the goal subsystem contributes its queue + worker to that shared
+// client (RegisterGoalWorker / GoalQueueConfig) rather than building its own.
+const (
+	// GoalQueue isolates goal-attempt execution from the scheduler's queue on the
+	// shared River client.
+	GoalQueue = "stella_goal"
+	// defaultGoalMaxWorkers bounds concurrent attempt executions per node when the
+	// boot config does not override it (the durable successor to the old
+	// in-process worker-pool default of 5).
+	defaultGoalMaxWorkers = 5
+)
+
+// goalAttemptArgs is the River payload for executing one claimed attempt. The
+// goal and attempt are resolved fresh from the DB at work time (Worker.Run), so
+// the payload carries only their IDs.
+type goalAttemptArgs struct {
+	GoalID    string `json:"goal_id"`
+	AttemptID string `json:"attempt_id"`
+}
+
+// Kind implements river.JobArgs.
+func (goalAttemptArgs) Kind() string { return "stella_goal_attempt" }
+
+// goalEnqueuer is the subset of the River client the dispatcher needs to enqueue
+// attempt jobs. Declared so the dispatcher compiles against the boundary and
+// tests can drive scan-and-claim with a fake enqueuer.
+type goalEnqueuer interface {
+	Insert(ctx context.Context, args river.JobArgs, opts *river.InsertOpts) (*rivertype.JobInsertResult, error)
+}
+
+// goalAttemptWorker runs one fired attempt job by delegating to the same
+// WorkerRunner the dispatcher used to call in-process. It is the only consumer
+// of the goal queue.
+type goalAttemptWorker struct {
+	river.WorkerDefaults[goalAttemptArgs]
+	runner WorkerRunner
+	log    *slog.Logger
+}
+
+// Work implements river.Worker. A superseded attempt (reaped/cancelled before
+// this job ran, so PromoteAttempt matches zero rows) surfaces as
+// ErrInvalidTransition; that is benign — the goal already recovered — so the job
+// completes cleanly rather than erroring. Any other error is returned; with
+// MaxAttempts=1 River discards it and convergence (the reaper) owns recovery.
+func (w *goalAttemptWorker) Work(ctx context.Context, j *river.Job[goalAttemptArgs]) error {
+	err := w.runner.Run(ctx, j.Args.GoalID, j.Args.AttemptID)
+	if errors.Is(err, ErrInvalidTransition) {
+		w.log.Info("goal: river fired for superseded attempt, skipping",
+			"goal_id", j.Args.GoalID, "attempt_id", j.Args.AttemptID)
+		return nil
+	}
+	return err
+}
+
+// goalInsertOpts is the InsertOpts every attempt job is enqueued with: the goal
+// queue, no River-level retry (MaxAttempts=1), and uniqueness by args so a
+// duplicate insert for the same attempt collapses to one in-flight job.
+func goalInsertOpts() *river.InsertOpts {
+	return &river.InsertOpts{
+		Queue:       GoalQueue,
+		MaxAttempts: 1,
+		UniqueOpts: river.UniqueOpts{
+			ByArgs: true,
+			ByState: []rivertype.JobState{
+				rivertype.JobStateAvailable,
+				rivertype.JobStatePending,
+				rivertype.JobStateRunning,
+				rivertype.JobStateScheduled,
+			},
+		},
+	}
+}
+
+// RegisterGoalWorker registers the goal-attempt worker into a shared workers
+// bundle used to build the process-wide River client. maxWorkers bounds
+// concurrent attempt executions per node (the durable successor to the old
+// in-process worker-pool cap); the per-root/per-user caps enforced at claim still
+// bound total in-flight attempts cluster-wide.
+func RegisterGoalWorker(workers *river.Workers, runner WorkerRunner, log *slog.Logger) {
+	river.AddWorker(workers, &goalAttemptWorker{runner: runner, log: log})
+}

--- a/internal/goal/worker.go
+++ b/internal/goal/worker.go
@@ -21,6 +21,14 @@ const heartbeatInterval = 20 * time.Second
 // > 3 * heartbeatInterval so a single missed beat does not expire the lease.
 const leaseDuration = 90 * time.Second
 
+// claimGraceTTL is the lease a freshly claimed (still queued) attempt carries
+// until a River worker picks it up and PromoteAttempt extends it. It must exceed
+// the worst-case queue pickup latency so the dispatcher reaper never reclaims a
+// job that is legitimately still waiting in the goal queue; the per-root/per-user
+// caps keep that backlog small. If pickup never happens (insert gap, crash before
+// promote), the reaper reopens the goal once this window expires (mintNextAttempt).
+const claimGraceTTL = 2 * time.Minute
+
 // Worker runs ONE claimed execution/decomposition attempt to its single durable
 // transition. It is the only place the executor (agent IO) and the CheckRunner
 // (sandbox IO) run; both are pure with respect to durable state. The worker

--- a/internal/scheduler/river.go
+++ b/internal/scheduler/river.go
@@ -9,9 +9,10 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivertype"
 	cron "github.com/robfig/cron/v3"
+
+	appdb "github.com/CherryHQ/stella/internal/db"
 )
 
 const (
@@ -23,17 +24,6 @@ const (
 	// Re-entrancy of a single job is guarded separately by tryStartJobRun, so
 	// this only caps cross-job parallelism.
 	schedulerMaxWorkers = 10
-	// schedulerSoftStopTimeout bounds how long Stop waits for in-flight jobs to
-	// drain before River cancels their work contexts. Without it a stuck job
-	// would hang Stop forever; the worker honors this cancellation because Work
-	// dispatches on River's per-job context.
-	schedulerSoftStopTimeout = 30 * time.Second
-	// schedulerRescueStuckAfter raises River's stuck-job rescue threshold (default
-	// 1h) above any expected scheduled-run duration. With JobTimeout disabled a
-	// legitimately long agent run would otherwise be marked stuck and discarded at
-	// 1h; the app-level tryStartJobRun guard already prevents double execution, so
-	// this only keeps River's job state from going misleadingly stuck/discarded.
-	schedulerRescueStuckAfter = 24 * time.Hour
 )
 
 // schedJobArgs is the River payload for a scheduled-job firing. JobID identifies
@@ -121,31 +111,31 @@ type schedRef struct {
 	isOneTime bool
 }
 
-// newSchedulerRiverClient builds the River client that both works the scheduler
-// queue and hosts its periodic jobs. The worker closes over s so it can reach
-// the live job map at fire time; s.river is assigned by the caller once this
-// returns.
+// SchedulerQueueConfig returns the scheduler's River queue name and per-node
+// worker config. The composition root reads it to assemble the single shared
+// working client (db.NewWorkingRiverClient) when scheduler runs in external-river
+// mode alongside the goal queue.
+func SchedulerQueueConfig() (string, river.QueueConfig) {
+	return schedulerQueue, river.QueueConfig{MaxWorkers: schedulerMaxWorkers}
+}
+
+// RegisterRiverWorker registers the scheduler's job worker into a shared workers
+// bundle. The worker closes over svc so it can resolve jobs from the DB at fire
+// time. Used both by the self-contained client (newSchedulerRiverClient) and by
+// the composition root building the shared working client.
+func RegisterRiverWorker(workers *river.Workers, svc *Service) {
+	river.AddWorker(workers, &schedJobWorker{svc: svc})
+}
+
+// newSchedulerRiverClient builds a self-contained River client that both works
+// the scheduler queue and hosts its periodic jobs. Used when the Service owns its
+// River client (the default / test path); production injects a shared client via
+// SetRiverClient instead (WithExternalRiver). s.river is assigned by the caller.
 func newSchedulerRiverClient(s *Service, pool *pgxpool.Pool) (*river.Client[pgx.Tx], error) {
 	workers := river.NewWorkers()
-	river.AddWorker(workers, &schedJobWorker{svc: s})
-
-	client, err := river.NewClient(riverpgxv5.New(pool), &river.Config{
-		Logger: s.log,
-		Queues: map[string]river.QueueConfig{
-			schedulerQueue: {MaxWorkers: schedulerMaxWorkers},
-		},
-		Workers: workers,
-		// -1 disables River's per-job timeout (default 1m): scheduled jobs are
-		// agent runs that routinely exceed a minute, matching gocron's unbounded
-		// runtime. Shutdown still cancels in-flight work via SoftStopTimeout.
-		JobTimeout:           -1,
-		SoftStopTimeout:      schedulerSoftStopTimeout,
-		RescueStuckJobsAfter: schedulerRescueStuckAfter,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("create scheduler river client: %w", err)
-	}
-	return client, nil
+	RegisterRiverWorker(workers, s)
+	name, cfg := SchedulerQueueConfig()
+	return appdb.NewWorkingRiverClient(pool, map[string]river.QueueConfig{name: cfg}, workers, s.log)
 }
 
 // scheduleJob registers a job with River and records its registration in

--- a/internal/scheduler/service.go
+++ b/internal/scheduler/service.go
@@ -37,6 +37,8 @@ type TaskFunc func(ctx context.Context)
 // persistence.
 type Service struct {
 	river           *river.Client[pgx.Tx]
+	ownsRiver       bool // true when Service built its own River client (default/test); false in external-river mode
+	externalRiver   bool // set by WithExternalRiver: caller injects+owns the shared client
 	onJob           OnJobFunc
 	listeners       []OnJobFunc
 	db              *pgxpool.Pool
@@ -66,9 +68,23 @@ type Service struct {
 	started bool
 }
 
+// Option configures a Service at construction.
+type Option func(*Service)
+
+// WithExternalRiver constructs the Service WITHOUT its own River client: the
+// caller injects the single process-wide working client via SetRiverClient
+// before Start and owns its Start/Stop lifecycle. This is how the composition
+// root keeps exactly one electable River client per database while letting both
+// the scheduler and the goal subsystem work and enqueue jobs (see
+// db.NewWorkingRiverClient). Without this option the Service builds and owns a
+// self-contained client (the default / test path).
+func WithExternalRiver() Option {
+	return func(s *Service) { s.externalRiver = true }
+}
+
 // New creates a scheduler service backed by the given database.
 // Call Start to load persisted jobs and begin scheduling.
-func New(db *pgxpool.Pool) (*Service, error) {
+func New(db *pgxpool.Pool, opts ...Option) (*Service, error) {
 	s := &Service{
 		db:              db,
 		q:               sqlc.New(db),
@@ -77,12 +93,26 @@ func New(db *pgxpool.Pool) (*Service, error) {
 		log:             slog.With("component", "scheduler"),
 		userJobsEnabled: true,
 	}
-	client, err := newSchedulerRiverClient(s, db)
-	if err != nil {
-		return nil, err
+	for _, o := range opts {
+		o(s)
 	}
-	s.river = client
+	if !s.externalRiver {
+		client, err := newSchedulerRiverClient(s, db)
+		if err != nil {
+			return nil, err
+		}
+		s.river = client
+		s.ownsRiver = true
+	}
 	return s, nil
+}
+
+// SetRiverClient injects the shared working River client (external-river mode).
+// Call after New(db, WithExternalRiver()) and before Start. The Service uses it
+// to enqueue and register periodic jobs but does NOT start or stop it — the
+// composition root owns the shared client's lifecycle.
+func (s *Service) SetRiverClient(c *river.Client[pgx.Tx]) {
+	s.river = c
 }
 
 // NewFromPath creates a scheduler service that opens its own PostgreSQL
@@ -168,8 +198,13 @@ func (s *Service) start(ctx context.Context, loadPersisted bool) error {
 	}
 	s.mu.Unlock()
 
-	if err := s.river.Start(ctx); err != nil {
-		return fmt.Errorf("start river client: %w", err)
+	// Own the River lifecycle only when we built the client. In external-river
+	// mode the composition root starts/stops the single shared client; we just
+	// registered our periodic jobs and one-time inserts above against it.
+	if s.ownsRiver {
+		if err := s.river.Start(ctx); err != nil {
+			return fmt.Errorf("start river client: %w", err)
+		}
 	}
 	if loadPersisted {
 		s.log.Info("scheduler service started", "jobs", len(jobs))
@@ -189,7 +224,12 @@ func (s *Service) start(ctx context.Context, loadPersisted bool) error {
 // A background context is used so in-flight jobs drain gracefully rather than
 // being cancelled mid-run.
 func (s *Service) Stop() error {
-	err := s.river.Stop(context.Background())
+	var err error
+	// Stop the River client only when we own it; the shared client is stopped by
+	// the composition root in external-river mode.
+	if s.ownsRiver {
+		err = s.river.Stop(context.Background())
+	}
 	if s.ownsDB && s.db != nil {
 		s.db.Close()
 	}


### PR DESCRIPTION
## What

Move goal **attempt execution** off the SQLite-era in-process worker pool onto River durable jobs, and collapse all River usage onto **one process-wide client** shared by the scheduler and goal subsystems.

Closes #571 (River Phase 2a).

## Why

Two reasons, the second drove the final shape:

1. Goal `dispatcher`/`worker` were still SQLite-single-process (ephemeral goroutines + a `WaitGroup`, an in-process `active` map the reaper keyed off, an instantly-stale `now()` mint lease). Under multi-node PG that loses work on crash and the cross-node liveness signal is wrong. River gives durable job state, rescue, and graceful drain — the scheduler already relies on exactly this.

2. **One electable River client per database.** River elects a single leader per database, and the periodic-job enqueuer is leader-only — each client enqueues only its OWN in-memory periodics. A dedicated goal client (the original plan) would be a second electable client; whichever won leadership would silently starve the other's periodic jobs (goal winning => scheduler cron stops firing). So there must be exactly one working client per database.

## How

Single shared client via composition-root DI:

- `db.NewWorkingRiverClient` — the sole `river.NewClient` construction point (`JobTimeout=-1`, `SoftStopTimeout`, generous `RescueStuckJobsAfter`). Dead Phase 0 `NewRiverClient` removed.
- **goal** contributes a queue + worker (`RegisterGoalWorker`/`GoalQueueConfig`) and receives the shared client as its dispatcher enqueuer (`SetRiverClient`). In-process worker pool deleted. `MaxAttempts=1` (retry stays in the convergence model). `mintNextAttempt` lease `now()` -> `now()+claimGraceTTL` (2m) so the reaper does not reclaim an attempt still queued in River.
- **scheduler** dual-mode: `WithExternalRiver()`/`ownsRiver` guard `Start`/`Stop`; `SetRiverClient` injects the shared client. Default/test path still self-builds a client (tests untouched).
- **cmd/stellad** `buildSharedRiverClient` is the composition root: assembles one client from both subsystems' queues+workers and injects it into each; `runServer` owns its `Start`/`Stop` with LIFO drain (goal tick -> scheduler -> shared client).
- No schema/sqlc changes (River tables already migrated).

## Verification

- `mise run format && mise run build && mise run test` — all green.
- goal / scheduler / db packages pass individually.

## Refs

- #571 (this issue), #563 (River Phase 1 scheduler), #538 (reliability umbrella)
- Follow-ups: Phase 2b (single-leader dispatcher tick), Phase 2c (#564 transactional enqueue)

## Note for reviewers

`claimGraceTTL = 2m` is a hand-picked value covering the claim -> enqueue -> River-execution latency. If the goal queue regularly backs up past 2m, the reaper will misjudge a queued attempt as stuck and reopen it; revisit (larger value, or gate the reaper on River job state instead of pure time).