### PR TITLE
Support Ubuntu LTS PostgreSQL runtime sources

### DIFF
--- a/scripts/fetch-pg-runtime.sh
+++ b/scripts/fetch-pg-runtime.sh
@@ -13,7 +13,7 @@ linux_source() {
     codename="$(. /etc/os-release && printf '%s' "${VERSION_CODENAME:-${UBUNTU_CODENAME:-}}")"
   fi
   case "$codename" in
-    bookworm|noble|trixie) printf '%s' "$codename" ;;
+    bookworm|jammy|noble|resolute|trixie) printf '%s' "$codename" ;;
     *) return 1 ;;
   esac
 }
@@ -24,7 +24,7 @@ if [[ -z "$SOURCE" ]]; then
     linux-amd64|linux-arm64)
       if ! SOURCE="$(linux_source)"; then
         echo "no default PostgreSQL runtime source for $GOOS_VALUE-$GOARCH_VALUE on this Linux distro" >&2
-        echo "set STELLA_PG_RUNTIME_SOURCE to one of: bookworm, noble, trixie" >&2
+        echo "set STELLA_PG_RUNTIME_SOURCE to one of: bookworm, jammy, noble, resolute, trixie" >&2
         exit 1
       fi
       ;;


### PR DESCRIPTION
## What
Teach the PostgreSQL runtime fetch script to auto-detect Ubuntu LTS runtime sources.

## Why
Once Ubuntu LTS runtime assets are published, Stella should select the matching bundle automatically on Ubuntu 22.04 jammy, 24.04 noble, and 26.04 resolute hosts instead of asking users to override STELLA_PG_RUNTIME_SOURCE.

## How
- Add jammy and resolute to the Linux source allowlist while keeping noble.
- Include jammy and resolute in the manual override hint.

## Test Plan
- bash -n scripts/fetch-pg-runtime.sh
- git diff --check

## Refs
- CherryHQ/stella#580
- CherryHQ/stella-pg-runtime#2