### PR TITLE
🐛 fix(release): embed Linux PostgreSQL runtimes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
           set -euo pipefail
           GOOS=darwin GOARCH=arm64 STELLA_PG_RUNTIME_SOURCE=postgresapp scripts/fetch-pg-runtime.sh
           for arch in amd64 arm64; do
-            for source in bookworm noble trixie; do
+            for source in bookworm jammy noble resolute trixie; do
               GOOS=linux GOARCH="$arch" STELLA_PG_RUNTIME_SOURCE="$source" scripts/fetch-pg-runtime.sh
             done
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
+      - name: Fetch embedded PostgreSQL runtimes
+        run: |
+          set -euo pipefail
+          GOOS=darwin GOARCH=arm64 STELLA_PG_RUNTIME_SOURCE=postgresapp scripts/fetch-pg-runtime.sh
+          for arch in amd64 arm64; do
+            for source in bookworm noble trixie; do
+              GOOS=linux GOARCH="$arch" STELLA_PG_RUNTIME_SOURCE="$source" scripts/fetch-pg-runtime.sh
+            done
+          done
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
           set -euo pipefail
           GOOS=darwin GOARCH=arm64 STELLA_PG_RUNTIME_SOURCE=postgresapp scripts/fetch-pg-runtime.sh
           for arch in amd64 arm64; do
-            for source in bookworm jammy noble resolute trixie; do
+            for source in bookworm noble trixie; do
               GOOS=linux GOARCH="$arch" STELLA_PG_RUNTIME_SOURCE="$source" scripts/fetch-pg-runtime.sh
             done
           done

--- a/internal/db/pgruntime.go
+++ b/internal/db/pgruntime.go
@@ -62,10 +62,8 @@ func newPostgresRuntimeInfo(dataDir, tmpDir string) (postgresRuntimeInfo, error)
 			// bundle, anything else must point at an external PostgreSQL that already
 			// has the extensions.
 			return postgresRuntimeInfo{}, fmt.Errorf(
-				"db: no embedded PostgreSQL runtime bundle for %s/%s (expected %s). "+
-					"Run scripts/fetch-pg-runtime.sh on a supported platform to embed it, "+
-					"or set STELLA_DATABASE_URL to an external PostgreSQL with pg_search and pgvector installed",
-				runtime.GOOS, runtime.GOARCH, postgresBundleID)
+				"db: no embedded PostgreSQL runtime bundle for %s/%s (expected %s). %s",
+				runtime.GOOS, runtime.GOARCH, postgresBundleID, pgbundle.MissingBundleHint())
 		} else {
 			bundleRoot = root
 		}

--- a/resources/pgbundle/runtime.go
+++ b/resources/pgbundle/runtime.go
@@ -140,7 +140,7 @@ func linuxRuntimeSourceFromOSRelease(data string) (string, bool) {
 	// Runtime bundles are built from distro packages; do not guess across distro
 	// families because glibc and extension ABI mismatches fail later and uglier.
 	switch codename {
-	case "bookworm", "noble", "trixie":
+	case "bookworm", "jammy", "noble", "resolute", "trixie":
 		return codename, true
 	default:
 		return "", false

--- a/resources/pgbundle/runtime.go
+++ b/resources/pgbundle/runtime.go
@@ -11,6 +11,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/klauspost/compress/zstd"
@@ -31,15 +32,19 @@ func EnsureBundle(cacheRoot string) (root string, ok bool, err error) {
 	if err := os.MkdirAll(cacheRoot, 0o755); err != nil {
 		return "", false, fmt.Errorf("create PostgreSQL runtime cache: %w", err)
 	}
-	archive, err := bundleFS.ReadFile(bundleDir + "/" + archiveName)
-	if errors.Is(err, fs.ErrNotExist) {
+	archivePath, checksumPath, ok, err := selectBundlePaths()
+	if err != nil {
+		return "", false, err
+	}
+	if !ok {
 		return "", false, nil
 	}
+	archive, err := bundleFS.ReadFile(archivePath)
 	if err != nil {
 		return "", false, fmt.Errorf("read embedded PostgreSQL runtime: %w", err)
 	}
 
-	checksum, err := bundleChecksum(archive)
+	checksum, err := bundleChecksum(archive, checksumPath)
 	if err != nil {
 		return "", false, err
 	}
@@ -71,16 +76,79 @@ func EnsureBundle(cacheRoot string) (root string, ok bool, err error) {
 }
 
 func VerifyBundlePresent() error {
-	if _, err := bundleFS.Open(bundleDir + "/" + archiveName); errors.Is(err, fs.ErrNotExist) {
+	archivePath, _, ok, err := selectBundlePaths()
+	if err != nil {
+		return err
+	}
+	if !ok {
 		return fmt.Errorf("embedded PostgreSQL runtime bundle missing for this platform: %s/%s", bundleDir, archiveName)
-	} else if err != nil {
+	}
+	if _, err := bundleFS.Open(archivePath); err != nil {
 		return fmt.Errorf("open embedded PostgreSQL runtime bundle: %w", err)
 	}
 	return nil
 }
 
-func bundleChecksum(archive []byte) (string, error) {
-	if data, err := bundleFS.ReadFile(bundleDir + "/" + checksumName); err == nil {
+func selectBundlePaths() (archivePath, checksumPath string, ok bool, err error) {
+	archivePath = bundleDir + "/" + archiveName
+	checksumPath = bundleDir + "/" + checksumName
+	if _, err := bundleFS.Open(archivePath); err == nil {
+		return archivePath, checksumPath, true, nil
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return "", "", false, fmt.Errorf("open embedded PostgreSQL runtime bundle: %w", err)
+	}
+
+	if runtime.GOOS != "linux" {
+		return "", "", false, nil
+	}
+	source, ok := linuxRuntimeSource()
+	if !ok {
+		return "", "", false, nil
+	}
+	archivePath = bundleDir + "/" + source + "/" + archiveName
+	checksumPath = bundleDir + "/" + source + "/" + checksumName
+	if _, err := bundleFS.Open(archivePath); errors.Is(err, fs.ErrNotExist) {
+		return "", "", false, nil
+	} else if err != nil {
+		return "", "", false, fmt.Errorf("open embedded PostgreSQL runtime bundle: %w", err)
+	}
+	return archivePath, checksumPath, true, nil
+}
+
+func linuxRuntimeSource() (string, bool) {
+	data, err := os.ReadFile("/etc/os-release")
+	if err != nil {
+		return "", false
+	}
+	return linuxRuntimeSourceFromOSRelease(string(data))
+}
+
+func linuxRuntimeSourceFromOSRelease(data string) (string, bool) {
+	values := map[string]string{}
+	for line := range strings.SplitSeq(data, "\n") {
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		value = strings.Trim(value, "\"'")
+		values[key] = value
+	}
+	codename := values["VERSION_CODENAME"]
+	if codename == "" {
+		codename = values["UBUNTU_CODENAME"]
+	}
+	// Runtime bundles are built from distro packages; do not guess across distro
+	// families because glibc and extension ABI mismatches fail later and uglier.
+	switch codename {
+	case "bookworm", "noble", "trixie":
+		return codename, true
+	default:
+		return "", false
+	}
+}
+
+func bundleChecksum(archive []byte, checksumPath string) (string, error) {
+	if data, err := bundleFS.ReadFile(checksumPath); err == nil {
 		fields := strings.Fields(string(data))
 		if len(fields) > 0 {
 			return fields[0], nil

--- a/resources/pgbundle/runtime.go
+++ b/resources/pgbundle/runtime.go
@@ -22,7 +22,7 @@ const (
 	checksumName    = "pg-runtime.sha256"
 	versionFileName = ".pg-runtime-sha256"
 
-	supportedLinuxRuntimeSources = "bookworm, jammy, noble, resolute, trixie"
+	supportedLinuxRuntimeSources = "bookworm, noble, trixie"
 	stellaIssueURL               = "https://github.com/CherryHQ/stella/issues/new"
 )
 
@@ -133,9 +133,12 @@ func MissingBundleHint() string {
 		if _, ok := supportedLinuxRuntimeSource(codename); !ok {
 			return fmt.Sprintf("Detected Linux runtime source %q, but Stella only embeds PostgreSQL runtimes for: %s. Set STELLA_DATABASE_URL to an external PostgreSQL with pg_search and pgvector, or file an issue requesting this distro: %s", codename, supportedLinuxRuntimeSources, stellaIssueURL)
 		}
-		return fmt.Sprintf("Detected supported Linux runtime source %q, but this binary does not contain its PostgreSQL runtime bundle. If this is an official Stella release, file a packaging bug: %s", codename, stellaIssueURL)
+		return fmt.Sprintf("Detected supported Linux runtime source %q, but this binary does not contain its PostgreSQL runtime bundle. Set STELLA_DATABASE_URL to an external PostgreSQL with pg_search and pgvector; if this is an official Stella release, file a packaging bug: %s", codename, stellaIssueURL)
 	case "darwin":
-		return fmt.Sprintf("Embedded PostgreSQL release bundles are currently published for darwin/arm64 and linux/amd64|arm64 (%s). Set STELLA_DATABASE_URL to an external PostgreSQL with pg_search and pgvector, or file an issue for this platform: %s", supportedLinuxRuntimeSources, stellaIssueURL)
+		if runtime.GOARCH == "arm64" {
+			return fmt.Sprintf("This darwin/arm64 binary does not contain its PostgreSQL runtime bundle. Set STELLA_DATABASE_URL to an external PostgreSQL with pg_search and pgvector; if this is an official Stella release, file a packaging bug: %s", stellaIssueURL)
+		}
+		return fmt.Sprintf("Embedded PostgreSQL release bundles are not published for darwin/%s. Set STELLA_DATABASE_URL to an external PostgreSQL with pg_search and pgvector, or file an issue for this platform: %s", runtime.GOARCH, stellaIssueURL)
 	default:
 		return fmt.Sprintf("Embedded PostgreSQL release bundles are currently published for linux/amd64|arm64 (%s) and darwin/arm64. Set STELLA_DATABASE_URL to an external PostgreSQL with pg_search and pgvector, or file an issue for this platform: %s", supportedLinuxRuntimeSources, stellaIssueURL)
 	}
@@ -173,7 +176,7 @@ func supportedLinuxRuntimeSource(codename string) (string, bool) {
 	// Runtime bundles are built from distro packages; do not guess across distro
 	// families because glibc and extension ABI mismatches fail later and uglier.
 	switch codename {
-	case "bookworm", "jammy", "noble", "resolute", "trixie":
+	case "bookworm", "noble", "trixie":
 		return codename, true
 	default:
 		return "", false

--- a/resources/pgbundle/runtime.go
+++ b/resources/pgbundle/runtime.go
@@ -21,6 +21,9 @@ const (
 	archiveName     = "pg-runtime.tar.zst"
 	checksumName    = "pg-runtime.sha256"
 	versionFileName = ".pg-runtime-sha256"
+
+	supportedLinuxRuntimeSources = "bookworm, jammy, noble, resolute, trixie"
+	stellaIssueURL               = "https://github.com/CherryHQ/stella/issues/new"
 )
 
 // EnsureBundle extracts the embedded PostgreSQL runtime bundle into cacheRoot and
@@ -81,7 +84,7 @@ func VerifyBundlePresent() error {
 		return err
 	}
 	if !ok {
-		return fmt.Errorf("embedded PostgreSQL runtime bundle missing for this platform: %s/%s", bundleDir, archiveName)
+		return fmt.Errorf("embedded PostgreSQL runtime bundle missing for this platform: %s/%s. %s", bundleDir, archiveName, MissingBundleHint())
 	}
 	if _, err := bundleFS.Open(archivePath); err != nil {
 		return fmt.Errorf("open embedded PostgreSQL runtime bundle: %w", err)
@@ -115,6 +118,29 @@ func selectBundlePaths() (archivePath, checksumPath string, ok bool, err error) 
 	return archivePath, checksumPath, true, nil
 }
 
+// MissingBundleHint explains why automatic embedded PostgreSQL selection failed.
+func MissingBundleHint() string {
+	switch runtime.GOOS {
+	case "linux":
+		data, err := os.ReadFile("/etc/os-release")
+		if err != nil {
+			return fmt.Sprintf("Could not read /etc/os-release to select a Linux runtime bundle. Supported Linux runtime sources: %s. Set STELLA_DATABASE_URL to an external PostgreSQL with pg_search and pgvector, or file an issue with your OS details: %s", supportedLinuxRuntimeSources, stellaIssueURL)
+		}
+		codename := linuxRuntimeCodenameFromOSRelease(string(data))
+		if codename == "" {
+			return fmt.Sprintf("Could not detect VERSION_CODENAME or UBUNTU_CODENAME from /etc/os-release. Supported Linux runtime sources: %s. Set STELLA_DATABASE_URL to an external PostgreSQL with pg_search and pgvector, or file an issue with your /etc/os-release: %s", supportedLinuxRuntimeSources, stellaIssueURL)
+		}
+		if _, ok := supportedLinuxRuntimeSource(codename); !ok {
+			return fmt.Sprintf("Detected Linux runtime source %q, but Stella only embeds PostgreSQL runtimes for: %s. Set STELLA_DATABASE_URL to an external PostgreSQL with pg_search and pgvector, or file an issue requesting this distro: %s", codename, supportedLinuxRuntimeSources, stellaIssueURL)
+		}
+		return fmt.Sprintf("Detected supported Linux runtime source %q, but this binary does not contain its PostgreSQL runtime bundle. If this is an official Stella release, file a packaging bug: %s", codename, stellaIssueURL)
+	case "darwin":
+		return fmt.Sprintf("Embedded PostgreSQL release bundles are currently published for darwin/arm64 and linux/amd64|arm64 (%s). Set STELLA_DATABASE_URL to an external PostgreSQL with pg_search and pgvector, or file an issue for this platform: %s", supportedLinuxRuntimeSources, stellaIssueURL)
+	default:
+		return fmt.Sprintf("Embedded PostgreSQL release bundles are currently published for linux/amd64|arm64 (%s) and darwin/arm64. Set STELLA_DATABASE_URL to an external PostgreSQL with pg_search and pgvector, or file an issue for this platform: %s", supportedLinuxRuntimeSources, stellaIssueURL)
+	}
+}
+
 func linuxRuntimeSource() (string, bool) {
 	data, err := os.ReadFile("/etc/os-release")
 	if err != nil {
@@ -124,6 +150,10 @@ func linuxRuntimeSource() (string, bool) {
 }
 
 func linuxRuntimeSourceFromOSRelease(data string) (string, bool) {
+	return supportedLinuxRuntimeSource(linuxRuntimeCodenameFromOSRelease(data))
+}
+
+func linuxRuntimeCodenameFromOSRelease(data string) string {
 	values := map[string]string{}
 	for line := range strings.SplitSeq(data, "\n") {
 		key, value, ok := strings.Cut(line, "=")
@@ -133,10 +163,13 @@ func linuxRuntimeSourceFromOSRelease(data string) (string, bool) {
 		value = strings.Trim(value, "\"'")
 		values[key] = value
 	}
-	codename := values["VERSION_CODENAME"]
-	if codename == "" {
-		codename = values["UBUNTU_CODENAME"]
+	if codename := values["VERSION_CODENAME"]; codename != "" {
+		return codename
 	}
+	return values["UBUNTU_CODENAME"]
+}
+
+func supportedLinuxRuntimeSource(codename string) (string, bool) {
 	// Runtime bundles are built from distro packages; do not guess across distro
 	// families because glibc and extension ABI mismatches fail later and uglier.
 	switch codename {

--- a/resources/pgbundle/runtime_test.go
+++ b/resources/pgbundle/runtime_test.go
@@ -1,0 +1,38 @@
+package pgbundle
+
+import "testing"
+
+func TestLinuxRuntimeSourceFromOSRelease(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want string
+		ok   bool
+	}{
+		{
+			name: "debian trixie",
+			data: "PRETTY_NAME=\"Debian GNU/Linux 13 (trixie)\"\nVERSION_CODENAME=trixie\n",
+			want: "trixie",
+			ok:   true,
+		},
+		{
+			name: "ubuntu noble fallback",
+			data: "NAME=Ubuntu\nUBUNTU_CODENAME=noble\n",
+			want: "noble",
+			ok:   true,
+		},
+		{
+			name: "unsupported",
+			data: "VERSION_CODENAME=forky\n",
+			ok:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := linuxRuntimeSourceFromOSRelease(tt.data)
+			if got != tt.want || ok != tt.ok {
+				t.Fatalf("linuxRuntimeSourceFromOSRelease() = %q, %v; want %q, %v", got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}

--- a/resources/pgbundle/runtime_test.go
+++ b/resources/pgbundle/runtime_test.go
@@ -16,21 +16,9 @@ func TestLinuxRuntimeSourceFromOSRelease(t *testing.T) {
 			ok:   true,
 		},
 		{
-			name: "ubuntu jammy fallback",
-			data: "NAME=Ubuntu\nUBUNTU_CODENAME=jammy\n",
-			want: "jammy",
-			ok:   true,
-		},
-		{
 			name: "ubuntu noble fallback",
 			data: "NAME=Ubuntu\nUBUNTU_CODENAME=noble\n",
 			want: "noble",
-			ok:   true,
-		},
-		{
-			name: "ubuntu resolute fallback",
-			data: "NAME=Ubuntu\nUBUNTU_CODENAME=resolute\n",
-			want: "resolute",
 			ok:   true,
 		},
 		{

--- a/resources/pgbundle/runtime_test.go
+++ b/resources/pgbundle/runtime_test.go
@@ -16,9 +16,21 @@ func TestLinuxRuntimeSourceFromOSRelease(t *testing.T) {
 			ok:   true,
 		},
 		{
+			name: "ubuntu jammy fallback",
+			data: "NAME=Ubuntu\nUBUNTU_CODENAME=jammy\n",
+			want: "jammy",
+			ok:   true,
+		},
+		{
 			name: "ubuntu noble fallback",
 			data: "NAME=Ubuntu\nUBUNTU_CODENAME=noble\n",
 			want: "noble",
+			ok:   true,
+		},
+		{
+			name: "ubuntu resolute fallback",
+			data: "NAME=Ubuntu\nUBUNTU_CODENAME=resolute\n",
+			want: "resolute",
 			ok:   true,
 		},
 		{

--- a/scripts/fetch-pg-runtime.sh
+++ b/scripts/fetch-pg-runtime.sh
@@ -39,6 +39,9 @@ fi
 ASSET="stella-pg-runtime-$VERSION-$GOOS_VALUE-$GOARCH_VALUE-$SOURCE.tar.zst"
 TAG="$VERSION"
 DEST_DIR="resources/pgbundle/bundles/$GOOS_VALUE-$GOARCH_VALUE"
+if [[ "$GOOS_VALUE" == "linux" ]]; then
+  DEST_DIR="$DEST_DIR/$SOURCE"
+fi
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 

--- a/scripts/fetch-pg-runtime.sh
+++ b/scripts/fetch-pg-runtime.sh
@@ -13,7 +13,7 @@ linux_source() {
     codename="$(. /etc/os-release && printf '%s' "${VERSION_CODENAME:-${UBUNTU_CODENAME:-}}")"
   fi
   case "$codename" in
-    bookworm|jammy|noble|resolute|trixie) printf '%s' "$codename" ;;
+    bookworm|noble|trixie) printf '%s' "$codename" ;;
     *) return 1 ;;
   esac
 }
@@ -24,7 +24,7 @@ if [[ -z "$SOURCE" ]]; then
     linux-amd64|linux-arm64)
       if ! SOURCE="$(linux_source)"; then
         echo "no default PostgreSQL runtime source for $GOOS_VALUE-$GOARCH_VALUE on this Linux distro" >&2
-        echo "set STELLA_PG_RUNTIME_SOURCE to one of: bookworm, jammy, noble, resolute, trixie" >&2
+        echo "set STELLA_PG_RUNTIME_SOURCE to one of: bookworm, noble, trixie" >&2
         exit 1
       fi
       ;;


### PR DESCRIPTION
## What
Embed PostgreSQL runtime bundles into release builds for the supported Linux runtime sources, select the matching Linux bundle at startup from `/etc/os-release`, and return actionable errors when no bundle can be selected.

Supported Linux assets:
- linux-amd64-bookworm / linux-arm64-bookworm
- linux-amd64-noble / linux-arm64-noble
- linux-amd64-trixie / linux-arm64-trixie

## Why
The release workflow built Linux binaries without fetching PG runtime bundles first, so zero-config startup could fail with a missing embedded PostgreSQL runtime on supported hosts like Debian 13/trixie. Unsupported distros should get a precise message, not a vague embedded PG failure.

## How
- Fetch darwin-arm64 plus linux amd64/arm64 bookworm, noble, and trixie runtime bundles before GoReleaser runs.
- Store Linux bundles under `bundles/<goos>-<goarch>/<source>/` so one Linux binary can carry multiple distro-specific runtimes.
- Select `bookworm`, `noble`, or `trixie` from `VERSION_CODENAME` / `UBUNTU_CODENAME` at runtime.
- Explain whether startup failed because `/etc/os-release` could not be read, no codename was found, the codename is unsupported, or an official binary is missing an expected bundle.
- Add unit coverage for distro source selection.

## Refs
Refs #580

Verification:
- `go test ./resources/pgbundle`
- `go test ./resources/pgbundle ./internal/db`
- `bash -n scripts/fetch-pg-runtime.sh`
- `GOOS=linux GOARCH=amd64 go test -c -o /tmp/pgbundle-linux-amd64.test ./resources/pgbundle`
- `mise run release:check`
- `mise run format && mise run build && mise run test`