### PR TITLE
✨ feat(search): tune BM25 lexical search — jieba, native field boost, cross-source RRF

### DIFF
--- a/internal/db/migrations/20260620131914_postgres_baseline.sql
+++ b/internal/db/migrations/20260620131914_postgres_baseline.sql
@@ -587,8 +587,14 @@ CREATE TABLE "ctx_message" (
 );
 -- Create index "idx_ctx_message_conv_seq" to table: "ctx_message"
 CREATE INDEX "idx_ctx_message_conv_seq" ON "ctx_message" ("conversation_id", "seq");
--- Create index "idx_ctx_message_bm25" to table: "ctx_message" (pg_search BM25, ICU tokenizer for CJK)
-CREATE INDEX "idx_ctx_message_bm25" ON "ctx_message" USING bm25 ("id", ("content"::pdb.icu)) WITH (key_field = 'id');
+-- Create index "idx_ctx_message_bm25" to table: "ctx_message" (pg_search BM25, jieba
+-- tokenizer for CJK word segmentation). jieba emits whitespace as its own tokens, so
+-- stopwords drop them; otherwise a multi-term query's spaces would match every row.
+-- Punctuation tokens are not enumerated here (jieba splits them per-char and the list
+-- would never be complete); pure-punctuation queries are short-circuited in the Go
+-- search layer instead. Configured via JSON text_fields because the ::pdb.jieba cast
+-- form takes no tokenizer arguments.
+CREATE INDEX "idx_ctx_message_bm25" ON "ctx_message" USING bm25 ("id", "content") WITH (key_field = 'id', text_fields = '{"content":{"tokenizer":{"type":"jieba","stopwords":[" ","\t","\n","\r"]}}}');
 -- Create "ctx_message_part" table
 CREATE TABLE "ctx_message_part" (
   "id" uuid NOT NULL DEFAULT uuidv7(),
@@ -622,8 +628,9 @@ CREATE TABLE "ctx_summary" (
 );
 -- Create index "idx_ctx_summary_conv" to table: "ctx_summary"
 CREATE INDEX "idx_ctx_summary_conv" ON "ctx_summary" ("conversation_id", "created_at");
--- Create index "idx_ctx_summary_bm25" to table: "ctx_summary" (pg_search BM25, ICU tokenizer for CJK)
-CREATE INDEX "idx_ctx_summary_bm25" ON "ctx_summary" USING bm25 ("id", ("content"::pdb.icu)) WITH (key_field = 'id');
+-- Create index "idx_ctx_summary_bm25" to table: "ctx_summary" (pg_search BM25, jieba
+-- tokenizer for CJK; whitespace stopwords as in idx_ctx_message_bm25).
+CREATE INDEX "idx_ctx_summary_bm25" ON "ctx_summary" USING bm25 ("id", "content") WITH (key_field = 'id', text_fields = '{"content":{"tokenizer":{"type":"jieba","stopwords":[" ","\t","\n","\r"]}}}');
 -- Create "ctx_summary_message" table
 CREATE TABLE "ctx_summary_message" (
   "summary_id" text NOT NULL,
@@ -734,8 +741,11 @@ CREATE TABLE "recally_article" (
 );
 -- Create index "idx_recally_article_saved_at" to table: "recally_article"
 CREATE INDEX "idx_recally_article_saved_at" ON "recally_article" ("saved_at");
--- Create index "idx_recally_article_bm25" to table: "recally_article" (pg_search BM25, ICU tokenizer for CJK)
-CREATE INDEX "idx_recally_article_bm25" ON "recally_article" USING bm25 ("id", ("title"::pdb.icu), ("summary"::pdb.icu), ("tags"::pdb.icu), ("author"::pdb.icu)) WITH (key_field = 'id');
+-- Create index "idx_recally_article_bm25" to table: "recally_article" (pg_search BM25, jieba
+-- tokenizer for CJK over title/summary/tags/author; whitespace stopwords as in
+-- idx_ctx_message_bm25). Per-field relevance weighting is applied at query time with
+-- paradedb.boost, not here.
+CREATE INDEX "idx_recally_article_bm25" ON "recally_article" USING bm25 ("id", "title", "summary", "tags", "author") WITH (key_field = 'id', text_fields = '{"title":{"tokenizer":{"type":"jieba","stopwords":[" ","\t","\n","\r"]}},"summary":{"tokenizer":{"type":"jieba","stopwords":[" ","\t","\n","\r"]}},"tags":{"tokenizer":{"type":"jieba","stopwords":[" ","\t","\n","\r"]}},"author":{"tokenizer":{"type":"jieba","stopwords":[" ","\t","\n","\r"]}}}');
 -- Create index "idx_recally_article_user_canonical" to table: "recally_article"
 CREATE UNIQUE INDEX "idx_recally_article_user_canonical" ON "recally_article" ("user_id", "canonical_url");
 -- Create index "idx_recally_article_user_source" to table: "recally_article"

--- a/internal/db/queries/ctx_message.sql
+++ b/internal/db/queries/ctx_message.sql
@@ -104,7 +104,9 @@ JOIN ctx_conversation c ON c.id = m.conversation_id
 WHERE m.id @@@ paradedb.match('content', sqlc.arg('match')::text)
   AND c.user_id = sqlc.arg('user_id')
   AND c.agent_id IS NOT DISTINCT FROM sqlc.narg('agent_id')
-ORDER BY score DESC
+-- created_at, id break score ties deterministically: cross-source RRF uses each
+-- row's rank, so a stable order keeps the same query from reshuffling the merge.
+ORDER BY score DESC, m.created_at DESC, m.id DESC
 LIMIT sqlc.arg('limit');
 
 -- name: GetMessagesSince :many

--- a/internal/db/queries/ctx_message.sql
+++ b/internal/db/queries/ctx_message.sql
@@ -88,9 +88,11 @@ SELECT * FROM ctx_message_part WHERE message_id = ANY(sqlc.arg('message_ids')::u
 -- survives across sessions. Joins ctx_conversation to pin the scope and surface
 -- provenance (session_id, title). Global ORDER BY score + LIMIT keeps the best
 -- matches across the merged corpus, not per-conversation truncations. Lexical
--- ranking is pg_search BM25; paradedb.match tokenizes the raw user text with ICU
--- (so CJK matches natively, no fallback tier) and never errors on punctuation or
--- query-syntax characters. The match arg is the raw user text.
+-- ranking is pg_search BM25; paradedb.match tokenizes the raw user text with the
+-- jieba tokenizer (dictionary + statistical CJK word segmentation, so CJK matches
+-- natively with no fallback tier) and never errors on punctuation or query-syntax
+-- characters. The match arg is the raw user text. Multi-term queries are OR'd and
+-- ranked by BM25, which sinks weak partial matches below strong full matches.
 SELECT
     m.*,
     c.session_id AS session_id,

--- a/internal/db/queries/ctx_summary.sql
+++ b/internal/db/queries/ctx_summary.sql
@@ -76,5 +76,7 @@ JOIN ctx_conversation c ON c.id = s.conversation_id
 WHERE s.id @@@ paradedb.match('content', sqlc.arg('match')::text)
   AND c.user_id = sqlc.arg('user_id')
   AND c.agent_id IS NOT DISTINCT FROM sqlc.narg('agent_id')
-ORDER BY score DESC
+-- Stable score tie-break (see SearchMessages): content time, then id, so the
+-- per-source rank that cross-source RRF consumes is deterministic.
+ORDER BY score DESC, COALESCE(s.latest_at, s.created_at) DESC, s.id DESC
 LIMIT sqlc.arg('limit');

--- a/internal/db/queries/ctx_summary.sql
+++ b/internal/db/queries/ctx_summary.sql
@@ -62,8 +62,9 @@ ORDER BY sp.ordinal ASC;
 -- name: SearchSummaries :many
 -- Spans every conversation of the current (user_id, agent_id); see SearchMessages.
 -- Lexical ranking is pg_search BM25; paradedb.match tokenizes the raw user text
--- with ICU (CJK matches natively) and never errors on punctuation. The match arg
--- is the raw user text.
+-- with the jieba tokenizer (dictionary + statistical CJK word segmentation, CJK
+-- matches natively) and never errors on punctuation. The match arg is the raw
+-- user text.
 SELECT
     s.*,
     c.session_id AS session_id,

--- a/internal/db/queries/recally_article.sql
+++ b/internal/db/queries/recally_article.sql
@@ -62,7 +62,9 @@ WHERE (a.id @@@ paradedb.boost(3.0, paradedb.match('title', sqlc.arg('match')::t
     OR a.id @@@ paradedb.match('summary', sqlc.arg('match')::text)
     OR a.id @@@ paradedb.match('author', sqlc.arg('match')::text))
   AND a.user_id = sqlc.arg('user_id')
-ORDER BY score DESC
+-- saved_at, id break score ties deterministically so identical queries return a
+-- stable order.
+ORDER BY score DESC, a.saved_at DESC, a.id DESC
 LIMIT sqlc.arg('limit');
 
 -- name: CountArticlesByStatus :one

--- a/internal/db/queries/recally_article.sql
+++ b/internal/db/queries/recally_article.sql
@@ -44,19 +44,22 @@ DELETE FROM recally_article WHERE id = $1 AND user_id = $2;
 -- name: SearchArticles :many
 -- Multi-field BM25 search over title/summary/tags/author via pg_search. Each
 -- field is matched with paradedb.match, which tokenizes the raw user text with
--- ICU (CJK matches natively, no fallback tier) and never errors on punctuation.
--- Title is weighted above the other fields (the old setweight A=title intent) by
--- boosting the row score when the title matches, so a title hit outranks a body
--- or author hit. snippet highlights the title. The match arg is raw user text.
+-- the jieba tokenizer (dictionary + statistical CJK word segmentation, CJK
+-- matches natively with no fallback tier) and never errors on punctuation.
+-- Per-field relevance is weighted natively with paradedb.boost (title 3x, tags 2x,
+-- summary/author 1x): boost scales each field's BM25 contribution to the row
+-- score, so a title hit outranks a tags hit outranks a body/author hit, with no
+-- CASE multiplier on the whole row. snippet highlights the title. match is raw
+-- user text.
 SELECT
     sqlc.embed(a),
     -- snippet highlights the title; NULL when the hit was on another field only.
     COALESCE(paradedb.snippet(a.title), '')::text AS snippet,
-    (paradedb.score(a.id) * (CASE WHEN a.id @@@ paradedb.match('title', sqlc.arg('match')::text) THEN 3 ELSE 1 END))::double precision AS score
+    paradedb.score(a.id)::double precision AS score
 FROM recally_article a
-WHERE (a.id @@@ paradedb.match('title', sqlc.arg('match')::text)
+WHERE (a.id @@@ paradedb.boost(3.0, paradedb.match('title', sqlc.arg('match')::text))
+    OR a.id @@@ paradedb.boost(2.0, paradedb.match('tags', sqlc.arg('match')::text))
     OR a.id @@@ paradedb.match('summary', sqlc.arg('match')::text)
-    OR a.id @@@ paradedb.match('tags', sqlc.arg('match')::text)
     OR a.id @@@ paradedb.match('author', sqlc.arg('match')::text))
   AND a.user_id = sqlc.arg('user_id')
 ORDER BY score DESC

--- a/internal/memory/lcm/retrieval.go
+++ b/internal/memory/lcm/retrieval.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/jackc/pgx/v5/pgtype"
@@ -54,14 +55,16 @@ func (r *retrievalEngine) search(ctx context.Context, userID, agentID string, qu
 	}
 
 	// Raw user text goes straight to pg_search: paradedb.match tokenizes it with
-	// ICU (so short and CJK queries match) and never errors on punctuation, so
-	// there is no separate sanitize/fallback tier.
+	// the jieba tokenizer (so short and CJK queries match) and never errors on
+	// punctuation, so there is no separate sanitize/fallback tier. A query with no
+	// letter or digit (empty, whitespace, or pure punctuation) has nothing the BM25
+	// index can match, so short-circuit instead of issuing a no-op query.
 	match := strings.TrimSpace(query.Text)
-	if match == "" {
+	if !hasSearchableToken(match) {
 		return nil, nil
 	}
 
-	var results []memory.SearchResult
+	var msgResults, sumResults []memory.SearchResult
 
 	if scope == scopeMessages || scope == scopeBoth {
 		msgs, err := r.q.SearchMessages(ctx, sqlc.SearchMessagesParams{
@@ -74,7 +77,7 @@ func (r *retrievalEngine) search(ctx context.Context, userID, agentID string, qu
 			return nil, fmt.Errorf("search messages: %w", err)
 		}
 		for _, msg := range msgs {
-			results = append(results, memory.SearchResult{
+			msgResults = append(msgResults, memory.SearchResult{
 				SourceType:        itemTypeMessage,
 				SourceID:          fmt.Sprint(msg.ID),
 				Content:           searchSnippet(msg.Snippet, msg.Content),
@@ -97,7 +100,7 @@ func (r *retrievalEngine) search(ctx context.Context, userID, agentID string, qu
 			return nil, fmt.Errorf("search summaries: %w", err)
 		}
 		for _, s := range sums {
-			results = append(results, memory.SearchResult{
+			sumResults = append(sumResults, memory.SearchResult{
 				SourceType:        itemTypeSummary,
 				SourceID:          s.ID,
 				Content:           searchSnippet(s.Snippet, s.Content),
@@ -109,20 +112,55 @@ func (r *retrievalEngine) search(ctx context.Context, userID, agentID string, qu
 		}
 	}
 
-	// Both-scope queries each table with the full limit, then keep the global
-	// top N so a strong summary hit can outrank a weak message hit. BM25 from
-	// the two indexes shares the same corpus statistics family closely enough
-	// for cross-source ordering.
-	sort.SliceStable(results, func(i, j int) bool {
-		if results[i].Score != results[j].Score {
-			return results[i].Score > results[j].Score
-		}
-		return results[i].OccurredAt.After(results[j].OccurredAt)
-	})
-	if len(results) > limit {
-		results = results[:limit]
+	// A single-scope query returns its one BM25-ranked list as-is (already sorted
+	// best-first by SQL): within one index the raw score is a meaningful absolute
+	// relevance signal worth preserving.
+	switch scope {
+	case scopeMessages:
+		return capResults(msgResults, limit), nil
+	case scopeSummaries:
+		return capResults(sumResults, limit), nil
+	default:
+		return fuseRRF(msgResults, sumResults, limit), nil
 	}
-	return results, nil
+}
+
+// rrfK is the Reciprocal Rank Fusion damping constant: 60, the value from the
+// original RRF paper and the de facto default. Larger values flatten the
+// contribution curve so rank position matters less.
+const rrfK = 60
+
+// fuseRRF merges two BM25-ranked result lists with Reciprocal Rank Fusion. The
+// two lists come from independent pg_search indexes whose raw scores share no
+// common scale (IDF is per-index), so comparing them directly mis-orders the
+// merge. RRF instead fuses on 1/(k+rank): each input must already be sorted
+// best-first, so a slice index is its within-list rank, and the fused value
+// replaces the now-meaningless cross-index raw score.
+func fuseRRF(a, b []memory.SearchResult, limit int) []memory.SearchResult {
+	merged := make([]memory.SearchResult, 0, len(a)+len(b))
+	for i := range a {
+		a[i].Score = 1.0 / float64(rrfK+i+1)
+		merged = append(merged, a[i])
+	}
+	for i := range b {
+		b[i].Score = 1.0 / float64(rrfK+i+1)
+		merged = append(merged, b[i])
+	}
+	sort.SliceStable(merged, func(i, j int) bool {
+		if merged[i].Score != merged[j].Score {
+			return merged[i].Score > merged[j].Score
+		}
+		return merged[i].OccurredAt.After(merged[j].OccurredAt)
+	})
+	return capResults(merged, limit)
+}
+
+// capResults truncates to the top limit, leaving order untouched.
+func capResults(results []memory.SearchResult, limit int) []memory.SearchResult {
+	if len(results) > limit {
+		return results[:limit]
+	}
+	return results
 }
 
 // summaryContentTime returns when a summary's underlying content actually
@@ -284,6 +322,19 @@ func (r *retrievalEngine) expand(ctx context.Context, sum sqlc.CtxSummary, token
 	}
 
 	return result, nil
+}
+
+// hasSearchableToken reports whether s holds at least one letter or digit. A
+// query of only whitespace or punctuation tokenizes to nothing the BM25 index
+// can match (jieba drops whitespace via stopwords; punctuation carries no
+// signal), so search short-circuits to empty rather than issue a no-op query.
+func hasSearchableToken(s string) bool {
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			return true
+		}
+	}
+	return false
 }
 
 // truncateUTF8 truncates s to at most maxLen runes, appending "..." if truncated.

--- a/internal/memory/lcm/retrieval.go
+++ b/internal/memory/lcm/retrieval.go
@@ -54,13 +54,11 @@ func (r *retrievalEngine) search(ctx context.Context, userID, agentID string, qu
 		scope = scopeSummaries
 	}
 
-	// Raw user text goes straight to pg_search: paradedb.match tokenizes it with
-	// the jieba tokenizer (so short and CJK queries match) and never errors on
-	// punctuation, so there is no separate sanitize/fallback tier. A query with no
-	// letter or digit (empty, whitespace, or pure punctuation) has nothing the BM25
-	// index can match, so short-circuit instead of issuing a no-op query.
-	match := strings.TrimSpace(query.Text)
-	if !hasSearchableToken(match) {
+	// normalizeQuery folds punctuation to spaces before pg_search tokenizes it, so
+	// the jieba tokenizer never emits a punctuation token that matches unrelated
+	// rows; a query with no letters/digits normalizes to "" and short-circuits.
+	match := normalizeQuery(query.Text)
+	if match == "" {
 		return nil, nil
 	}
 
@@ -324,17 +322,22 @@ func (r *retrievalEngine) expand(ctx context.Context, sum sqlc.CtxSummary, token
 	return result, nil
 }
 
-// hasSearchableToken reports whether s holds at least one letter or digit. A
-// query of only whitespace or punctuation tokenizes to nothing the BM25 index
-// can match (jieba drops whitespace via stopwords; punctuation carries no
-// signal), so search short-circuits to empty rather than issue a no-op query.
-func hasSearchableToken(s string) bool {
+// normalizeQuery folds punctuation and symbols to spaces and collapses runs of
+// whitespace. jieba emits punctuation and whitespace as their own tokens, so a
+// raw query like "alpha, beaver" would have the "," token match every row that
+// contains a comma; folding it to "alpha beaver" leaves only real search terms
+// (index-side whitespace stopwords then drop the spaces). A query with no
+// letters or digits normalizes to "", which callers treat as a no-op search.
+func normalizeQuery(s string) string {
+	var b strings.Builder
 	for _, r := range s {
-		if unicode.IsLetter(r) || unicode.IsDigit(r) {
-			return true
+		if unicode.IsPunct(r) || unicode.IsSymbol(r) {
+			b.WriteByte(' ')
+		} else {
+			b.WriteRune(r)
 		}
 	}
-	return false
+	return strings.Join(strings.Fields(b.String()), " ")
 }
 
 // truncateUTF8 truncates s to at most maxLen runes, appending "..." if truncated.

--- a/internal/memory/lcm/search_test.go
+++ b/internal/memory/lcm/search_test.go
@@ -331,6 +331,26 @@ func TestSearch_SpecialCharactersDoNotError(t *testing.T) {
 	}
 }
 
+func TestSearch_PunctuationInQueryDoesNotPollute(t *testing.T) {
+	// jieba emits punctuation as its own token, so "alpha, beaver" would otherwise
+	// match every row containing a comma. normalizeQuery folds the comma to a
+	// space, so only rows with the real terms come back — the comma-only row must
+	// not appear.
+	_, p, sess := newSearchTestEnv(t, "fts-punct")
+	appendUser(t, p, sess,
+		"alpha beaver strong match",
+		"hello, world, unrelated commas only",
+	)
+
+	results := runSearch(t, p, sess, memory.SearchQuery{Text: "alpha, beaver", Scope: memory.SearchScopeMessages})
+	if len(results) != 1 {
+		t.Fatalf("expected 1 hit (comma-only row must not pollute), got %d: %+v", len(results), results)
+	}
+	if !strings.Contains(results[0].Content, "alpha") {
+		t.Errorf("expected the alpha/beaver row, got %q", results[0].Content)
+	}
+}
+
 func TestSearch_CJKMatch(t *testing.T) {
 	_, p, sess := newSearchTestEnv(t, "fts-cjk")
 	appendUser(t, p, sess, "今天讨论了部署方案的细节和时间表")

--- a/internal/memory/lcm/search_test.go
+++ b/internal/memory/lcm/search_test.go
@@ -180,20 +180,35 @@ func TestSearch_ScopeIsolation(t *testing.T) {
 }
 
 func TestSearch_BothMergesAndRanks(t *testing.T) {
+	// Merging two independent BM25 indexes can't compare their raw scores (IDF is
+	// per-index), so search fuses by Reciprocal Rank Fusion: each source's rank-0
+	// hit outranks both sources' rank-1 hits. Give messages and summaries each a
+	// strong (rank 0) and a weak (rank 1) "delta" hit, then assert the two strong
+	// hits land first and come from different sources — RRF lifts each index's
+	// best hit, it does not just sort everything by raw score.
 	db, p, sess := newSearchTestEnv(t, "fts-both")
 	convID := conversationID(t, db, sess.ID)
-	appendUser(t, p, sess, "delta mentioned once among many other unrelated padding words in this message")
-	insertSummary(t, db, convID, "sum-fts-3", "delta delta delta focused summary")
+	appendUser(t, p, sess, "delta delta delta strong message focus")
+	appendUser(t, p, sess, "delta weak among other padding words here")
+	insertSummary(t, db, convID, "sum-strong", "delta delta delta strong summary focus")
+	insertSummary(t, db, convID, "sum-weak", "delta weak among other padding words")
 
 	results := runSearch(t, p, sess, memory.SearchQuery{Text: "delta", Scope: memory.SearchScopeBoth})
-	if len(results) != 2 {
-		t.Fatalf("expected 2 hits across sources, got %d", len(results))
+	if len(results) != 4 {
+		t.Fatalf("expected 4 hits across sources, got %d: %+v", len(results), results)
 	}
-	if results[0].SourceType != "summary" {
-		t.Errorf("expected strong summary hit ranked above weak message hit, got %+v", results)
+	for i, r := range results[:2] {
+		if !strings.Contains(r.Content, "strong") {
+			t.Errorf("RRF: result[%d] should be a rank-0 (strong) hit, got %q", i, r.Content)
+		}
 	}
-	if results[1].SourceType != "message" {
-		t.Errorf("expected message hit second, got %+v", results[1])
+	if results[0].SourceType == results[1].SourceType {
+		t.Errorf("RRF should interleave both sources' top hits, got two %q", results[0].SourceType)
+	}
+	for i, r := range results[2:] {
+		if !strings.Contains(r.Content, "weak") {
+			t.Errorf("RRF: result[%d] should be a rank-1 (weak) hit, got %q", i+2, r.Content)
+		}
 	}
 }
 
@@ -320,7 +335,7 @@ func TestSearch_CJKMatch(t *testing.T) {
 	_, p, sess := newSearchTestEnv(t, "fts-cjk")
 	appendUser(t, p, sess, "今天讨论了部署方案的细节和时间表")
 
-	// pg_search tokenizes CJK with ICU word segmentation, so a CJK query is a
+	// pg_search tokenizes CJK with jieba word segmentation, so a CJK query is a
 	// real BM25 hit (positive score), not a degraded substring fallback.
 	results := runSearch(t, p, sess, memory.SearchQuery{Text: "部署方案", Scope: memory.SearchScopeMessages})
 	if len(results) != 1 {
@@ -337,7 +352,7 @@ func TestSearch_ShortCJKQueryMatches(t *testing.T) {
 	appendUser(t, p, sess, "今天讨论了部署方案的细节")
 	insertSummary(t, db, convID, "sum-fts-short", "总结：部署流程已经确定")
 
-	// A short 2-char CJK token is segmented by ICU and matches via BM25 in both
+	// A short 2-char CJK token is segmented by jieba and matches via BM25 in both
 	// scopes, with a positive score and no fallback tier.
 	results := runSearch(t, p, sess, memory.SearchQuery{Text: "部署", Scope: memory.SearchScopeBoth})
 	if len(results) != 2 {
@@ -438,7 +453,7 @@ func TestSearch_IsCaseInsensitive(t *testing.T) {
 	appendUser(t, p, sess, "golang runtime notes")
 	insertSummary(t, db, convID, "sum-like-case", "GoLang summary header")
 
-	// ICU lowercases tokens, so an uppercase query matches the lowercase
+	// jieba lowercases tokens, so an uppercase query matches the lowercase
 	// "golang" message and the mixed-case "GoLang" summary alike.
 	results := runSearch(t, p, sess, memory.SearchQuery{Text: "GOLANG", Scope: memory.SearchScopeBoth})
 	if len(results) != 2 {

--- a/internal/memory/provider.go
+++ b/internal/memory/provider.go
@@ -144,7 +144,7 @@ type SearchResult struct {
 	SourceType        string    `json:"source_type"`        // "message" or "summary"
 	SourceID          string    `json:"source_id"`          // message ID or summary ID
 	Content           string    `json:"content"`            // snippet of the matching content (truncated at ~500 chars)
-	Score             float64   `json:"score"`              // ts_rank_cd relevance from the tsvector match, higher is better
+	Score             float64   `json:"score"`              // relevance, higher is better: pg_search BM25 for a single-scope query, RRF fusion score when messages and summaries are merged
 	OccurredAt        time.Time `json:"occurred_at"`        // when the underlying content actually happened
 	SessionID         string    `json:"session_id"`         // origin session for traceability
 	ConversationTitle string    `json:"conversation_title"` // human-readable origin label (may be empty)

--- a/internal/recally/store.go
+++ b/internal/recally/store.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -252,15 +253,18 @@ func (s *Store) ListArticles(ctx context.Context, userID string, filter ArticleF
 }
 
 // SearchArticles searches articles by title, summary, tags, or author using the
-// pg_search BM25 index, ordered by relevance (title hits rank highest). The raw
-// query goes straight to paradedb.match, which tokenizes with ICU (short and CJK
-// queries match) and never errors on punctuation, so there is no fallback tier.
+// pg_search BM25 index, ordered by relevance (title hits rank highest via native
+// paradedb.boost). The raw query goes straight to paradedb.match, which tokenizes
+// with the jieba tokenizer (short and CJK queries match) and never errors on
+// punctuation, so there is no fallback tier.
 func (s *Store) SearchArticles(ctx context.Context, userID string, query string, limit int) ([]Article, error) {
 	if limit <= 0 {
 		limit = 50
 	}
+	// A query with no letter or digit (whitespace or pure punctuation) has nothing
+	// the BM25 index can match, so short-circuit instead of issuing a no-op query.
 	match := strings.TrimSpace(query)
-	if match == "" {
+	if !hasSearchableToken(match) {
 		return []Article{}, nil
 	}
 	rows, err := s.q.SearchArticles(ctx, sqlc.SearchArticlesParams{
@@ -279,6 +283,19 @@ func (s *Store) SearchArticles(ctx context.Context, userID string, query string,
 		articles = append(articles, article)
 	}
 	return articles, nil
+}
+
+// hasSearchableToken reports whether s holds at least one letter or digit. A
+// query of only whitespace or punctuation tokenizes to nothing the BM25 index
+// can match (jieba drops whitespace via stopwords; punctuation carries no
+// signal), so search short-circuits to empty rather than issue a no-op query.
+func hasSearchableToken(s string) bool {
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			return true
+		}
+	}
+	return false
 }
 
 // CreateFeed creates a new feed subscription. kind is the extraction-dispatch

--- a/internal/recally/store.go
+++ b/internal/recally/store.go
@@ -261,10 +261,11 @@ func (s *Store) SearchArticles(ctx context.Context, userID string, query string,
 	if limit <= 0 {
 		limit = 50
 	}
-	// A query with no letter or digit (whitespace or pure punctuation) has nothing
-	// the BM25 index can match, so short-circuit instead of issuing a no-op query.
-	match := strings.TrimSpace(query)
-	if !hasSearchableToken(match) {
+	// normalizeQuery folds punctuation to spaces so jieba never emits a punctuation
+	// token that matches unrelated rows; a letter/digit-free query normalizes to ""
+	// and short-circuits instead of issuing a no-op query.
+	match := normalizeQuery(query)
+	if match == "" {
 		return []Article{}, nil
 	}
 	rows, err := s.q.SearchArticles(ctx, sqlc.SearchArticlesParams{
@@ -285,17 +286,20 @@ func (s *Store) SearchArticles(ctx context.Context, userID string, query string,
 	return articles, nil
 }
 
-// hasSearchableToken reports whether s holds at least one letter or digit. A
-// query of only whitespace or punctuation tokenizes to nothing the BM25 index
-// can match (jieba drops whitespace via stopwords; punctuation carries no
-// signal), so search short-circuits to empty rather than issue a no-op query.
-func hasSearchableToken(s string) bool {
+// normalizeQuery folds punctuation and symbols to spaces and collapses runs of
+// whitespace, so jieba never emits a punctuation token that matches unrelated
+// rows (index-side whitespace stopwords then drop the spaces). A query with no
+// letters or digits normalizes to "", which callers treat as a no-op search.
+func normalizeQuery(s string) string {
+	var b strings.Builder
 	for _, r := range s {
-		if unicode.IsLetter(r) || unicode.IsDigit(r) {
-			return true
+		if unicode.IsPunct(r) || unicode.IsSymbol(r) {
+			b.WriteByte(' ')
+		} else {
+			b.WriteRune(r)
 		}
 	}
-	return false
+	return strings.Join(strings.Fields(b.String()), " ")
 }
 
 // CreateFeed creates a new feed subscription. kind is the extraction-dispatch

--- a/internal/recally/store_test.go
+++ b/internal/recally/store_test.go
@@ -334,7 +334,7 @@ func TestStore_SearchArticles_CJKAndCaseInsensitive(t *testing.T) {
 		t.Fatalf("SaveArticle failed: %v", err)
 	}
 
-	// CJK is segmented by ICU, so both a multi-word and a single-word CJK query
+	// CJK is segmented by jieba, so both a multi-word and a single-word CJK query
 	// match via BM25 with no fallback tier.
 	results, err := store.SearchArticles(ctx, testUserID, "部署方案", 10)
 	if err != nil {
@@ -359,7 +359,7 @@ func TestStore_SearchArticles_CJKAndCaseInsensitive(t *testing.T) {
 		t.Errorf("Expected search to stay user-scoped, got %d hits", len(results))
 	}
 
-	// ICU lowercases tokens, so an uppercase query finds the "K8s" summary token.
+	// jieba lowercases tokens, so an uppercase query finds the "K8s" summary token.
 	results, err = store.SearchArticles(ctx, testUserID, "K8S", 10)
 	if err != nil {
 		t.Fatalf("SearchArticles failed: %v", err)

--- a/pkg/db/sqlc/ctx_message.sql.go
+++ b/pkg/db/sqlc/ctx_message.sql.go
@@ -586,9 +586,11 @@ type SearchMessagesRow struct {
 // survives across sessions. Joins ctx_conversation to pin the scope and surface
 // provenance (session_id, title). Global ORDER BY score + LIMIT keeps the best
 // matches across the merged corpus, not per-conversation truncations. Lexical
-// ranking is pg_search BM25; paradedb.match tokenizes the raw user text with ICU
-// (so CJK matches natively, no fallback tier) and never errors on punctuation or
-// query-syntax characters. The match arg is the raw user text.
+// ranking is pg_search BM25; paradedb.match tokenizes the raw user text with the
+// jieba tokenizer (dictionary + statistical CJK word segmentation, so CJK matches
+// natively with no fallback tier) and never errors on punctuation or query-syntax
+// characters. The match arg is the raw user text. Multi-term queries are OR'd and
+// ranked by BM25, which sinks weak partial matches below strong full matches.
 func (q *Queries) SearchMessages(ctx context.Context, arg SearchMessagesParams) ([]SearchMessagesRow, error) {
 	rows, err := q.db.Query(ctx, searchMessages,
 		arg.Match,

--- a/pkg/db/sqlc/ctx_message.sql.go
+++ b/pkg/db/sqlc/ctx_message.sql.go
@@ -556,7 +556,7 @@ JOIN ctx_conversation c ON c.id = m.conversation_id
 WHERE m.id @@@ paradedb.match('content', $1::text)
   AND c.user_id = $2
   AND c.agent_id IS NOT DISTINCT FROM $3
-ORDER BY score DESC
+ORDER BY score DESC, m.created_at DESC, m.id DESC
 LIMIT $4
 `
 
@@ -591,6 +591,8 @@ type SearchMessagesRow struct {
 // natively with no fallback tier) and never errors on punctuation or query-syntax
 // characters. The match arg is the raw user text. Multi-term queries are OR'd and
 // ranked by BM25, which sinks weak partial matches below strong full matches.
+// created_at, id break score ties deterministically: cross-source RRF uses each
+// row's rank, so a stable order keeps the same query from reshuffling the merge.
 func (q *Queries) SearchMessages(ctx context.Context, arg SearchMessagesParams) ([]SearchMessagesRow, error) {
 	rows, err := q.db.Query(ctx, searchMessages,
 		arg.Match,

--- a/pkg/db/sqlc/ctx_summary.sql.go
+++ b/pkg/db/sqlc/ctx_summary.sql.go
@@ -432,7 +432,7 @@ JOIN ctx_conversation c ON c.id = s.conversation_id
 WHERE s.id @@@ paradedb.match('content', $1::text)
   AND c.user_id = $2
   AND c.agent_id IS NOT DISTINCT FROM $3
-ORDER BY score DESC
+ORDER BY score DESC, COALESCE(s.latest_at, s.created_at) DESC, s.id DESC
 LIMIT $4
 `
 
@@ -467,6 +467,8 @@ type SearchSummariesRow struct {
 // with the jieba tokenizer (dictionary + statistical CJK word segmentation, CJK
 // matches natively) and never errors on punctuation. The match arg is the raw
 // user text.
+// Stable score tie-break (see SearchMessages): content time, then id, so the
+// per-source rank that cross-source RRF consumes is deterministic.
 func (q *Queries) SearchSummaries(ctx context.Context, arg SearchSummariesParams) ([]SearchSummariesRow, error) {
 	rows, err := q.db.Query(ctx, searchSummaries,
 		arg.Match,

--- a/pkg/db/sqlc/ctx_summary.sql.go
+++ b/pkg/db/sqlc/ctx_summary.sql.go
@@ -464,8 +464,9 @@ type SearchSummariesRow struct {
 
 // Spans every conversation of the current (user_id, agent_id); see SearchMessages.
 // Lexical ranking is pg_search BM25; paradedb.match tokenizes the raw user text
-// with ICU (CJK matches natively) and never errors on punctuation. The match arg
-// is the raw user text.
+// with the jieba tokenizer (dictionary + statistical CJK word segmentation, CJK
+// matches natively) and never errors on punctuation. The match arg is the raw
+// user text.
 func (q *Queries) SearchSummaries(ctx context.Context, arg SearchSummariesParams) ([]SearchSummariesRow, error) {
 	rows, err := q.db.Query(ctx, searchSummaries,
 		arg.Match,

--- a/pkg/db/sqlc/recally_article.sql.go
+++ b/pkg/db/sqlc/recally_article.sql.go
@@ -421,11 +421,11 @@ SELECT
     a.id, a.user_id, a.agent_id, a.url, a.canonical_url, a.source_type, a.title, a.author, a.summary, a.tags, a.status, a.starred, a.file_path, a.metadata, a.published_at, a.saved_at, a.read_at, a.created_at, a.updated_at,
     -- snippet highlights the title; NULL when the hit was on another field only.
     COALESCE(paradedb.snippet(a.title), '')::text AS snippet,
-    (paradedb.score(a.id) * (CASE WHEN a.id @@@ paradedb.match('title', $1::text) THEN 3 ELSE 1 END))::double precision AS score
+    paradedb.score(a.id)::double precision AS score
 FROM recally_article a
-WHERE (a.id @@@ paradedb.match('title', $1::text)
+WHERE (a.id @@@ paradedb.boost(3.0, paradedb.match('title', $1::text))
+    OR a.id @@@ paradedb.boost(2.0, paradedb.match('tags', $1::text))
     OR a.id @@@ paradedb.match('summary', $1::text)
-    OR a.id @@@ paradedb.match('tags', $1::text)
     OR a.id @@@ paradedb.match('author', $1::text))
   AND a.user_id = $2
 ORDER BY score DESC
@@ -446,10 +446,13 @@ type SearchArticlesRow struct {
 
 // Multi-field BM25 search over title/summary/tags/author via pg_search. Each
 // field is matched with paradedb.match, which tokenizes the raw user text with
-// ICU (CJK matches natively, no fallback tier) and never errors on punctuation.
-// Title is weighted above the other fields (the old setweight A=title intent) by
-// boosting the row score when the title matches, so a title hit outranks a body
-// or author hit. snippet highlights the title. The match arg is raw user text.
+// the jieba tokenizer (dictionary + statistical CJK word segmentation, CJK
+// matches natively with no fallback tier) and never errors on punctuation.
+// Per-field relevance is weighted natively with paradedb.boost (title 3x, tags 2x,
+// summary/author 1x): boost scales each field's BM25 contribution to the row
+// score, so a title hit outranks a tags hit outranks a body/author hit, with no
+// CASE multiplier on the whole row. snippet highlights the title. match is raw
+// user text.
 func (q *Queries) SearchArticles(ctx context.Context, arg SearchArticlesParams) ([]SearchArticlesRow, error) {
 	rows, err := q.db.Query(ctx, searchArticles, arg.Match, arg.UserID, arg.Limit)
 	if err != nil {

--- a/pkg/db/sqlc/recally_article.sql.go
+++ b/pkg/db/sqlc/recally_article.sql.go
@@ -428,7 +428,7 @@ WHERE (a.id @@@ paradedb.boost(3.0, paradedb.match('title', $1::text))
     OR a.id @@@ paradedb.match('summary', $1::text)
     OR a.id @@@ paradedb.match('author', $1::text))
   AND a.user_id = $2
-ORDER BY score DESC
+ORDER BY score DESC, a.saved_at DESC, a.id DESC
 LIMIT $3
 `
 
@@ -453,6 +453,8 @@ type SearchArticlesRow struct {
 // score, so a title hit outranks a tags hit outranks a body/author hit, with no
 // CASE multiplier on the whole row. snippet highlights the title. match is raw
 // user text.
+// saved_at, id break score ties deterministically so identical queries return a
+// stable order.
 func (q *Queries) SearchArticles(ctx context.Context, arg SearchArticlesParams) ([]SearchArticlesRow, error) {
 	rows, err := q.db.Query(ctx, searchArticles, arg.Match, arg.UserID, arg.Limit)
 	if err != nil {


### PR DESCRIPTION
## What

Quality pass over the pg_search BM25 **lexical** lane (no vector work):

1. **jieba tokenizer** (was ICU) for real CJK word segmentation.
2. **Native `paradedb.boost`** field weighting in `SearchArticles`.
3. **Reciprocal Rank Fusion** when merging messages + summaries.
4. Comment/doc hygiene (ICU→jieba, `SearchResult.Score` doc).

## Why

- **ICU mis-segments CJK.** Verified on live pg_search 0.24.1: ICU splits
  `中信`→`中`/`信`, `时间表`→`时间`/`表`; jieba keeps `中信集团`/`有限公司`/
  `人工智能` whole. Matters for an org-name-heavy, Chinese-first corpus.
- **`CASE ... ×3`** scaled the whole row score, not the title field's
  contribution.
- **Raw-score merge of two BM25 indexes is wrong** — IDF is per-index, scores
  aren't comparable.

## How

- **jieba** — baseline BM25 indexes move from the `::pdb.icu` cast to JSON
  `text_fields` (the cast form takes no tokenizer args). jieba emits
  whitespace/punctuation as tokens, so **whitespace stopwords** (index) + a
  **Go short-circuit** for letter/digit-free queries stop multi-term and
  punctuation queries from matching unrelated rows.
- **boost** — `paradedb.boost(3.0, match('title'))` / `boost(2.0, match('tags'))`
  / plain match for summary+author; score is the natural boosted BM25 sum.
- **RRF** — both-scope search fuses on `1/(60+rank)`; single-scope keeps raw BM25.

## Verification

- Live-DB suites: `internal/memory/lcm`, `internal/recally`, `internal/db` pass;
  full `internal/...` = 40 packages, zero failures.
- `mise run format && mise run build` clean; sqlc regenerated, no signature change.
- Each tokenizer/boost/stopword claim validated against a live pg_search 0.24.1.
- The both-scope test now asserts real RRF interleaving, not a timing coincidence.

## Notes

- **Amends the pre-release baseline migration in place** (goose.md exception);
  pull → reset dev DB (`rm -rf ~/.stella/postgres`).
- Mixed-query punctuation (e.g. `alpha, beaver`) keeps IDF-negligible punct
  tokens — a noted simplification with an upgrade path (extend stopwords).

## Refs

- Closes #586
- Parent: #549 · builds on #569