### PR TITLE
✨ feat(ml): built-in local OCR via the stella-ml sidecar

### DIFF
--- a/cmd/stella-ml/README.md
+++ b/cmd/stella-ml/README.md
@@ -11,15 +11,20 @@ parent's `go build ./...` skips this nested module automatically.
 
 ## Endpoints (protocol v1)
 
-| Method + path      | Body in                  | Body out                                                             |
-| ------------------ | ------------------------ | -------------------------------------------------------------------- |
-| `GET /healthz`     | —                        | JSON: runtime/protocol version, model-manifest digest, loaded models |
-| `POST /v1/embed`   | JSON `{texts[], mode}`   | `application/octet-stream`: little-endian f32, `count*dim`           |
-| `POST /v1/extract` | raw bytes (octet-stream) | JSON `{content, mime_type}` — **501 until Phase 4a**                 |
+| Method + path      | Body in                                      | Body out                                                             |
+| ------------------ | -------------------------------------------- | -------------------------------------------------------------------- |
+| `GET /healthz`     | —                                            | JSON: runtime/protocol version, model-manifest digest, loaded models |
+| `POST /v1/embed`   | JSON `{texts[], mode}`                       | `application/octet-stream`: little-endian f32, `count*dim`           |
+| `POST /v1/extract` | image bytes (octet-stream) + `X-Stella-Mime` | JSON `{content, mime_type}` — PP-OCRv5 OCR                           |
 
 Every request carries `X-Stella-Tenant`, `X-Stella-Request-Id`, and an optional
 `X-Stella-Deadline-Unix-Ms`. Per-endpoint lanes + a per-tenant in-flight cap keep a
 shared sidecar fair; request caps bound batch size and body bytes.
+
+The embedding and OCR engines are independently optional: pass `-embed-model`
+without the `-ocr-*` flags for an embedding-only sidecar (extract then reports
+503), or vice versa. `/v1/extract` is image-only (JPEG/PNG/GIF/WebP/BMP/TIFF);
+detection uses axis-aligned bounding rects (rotated-crop is a follow-up).
 
 ## Build (local dev, darwin/arm64)
 
@@ -44,8 +49,17 @@ Release builds resolve `libtokenizers.a` + `libonnxruntime` from the
   -socket /tmp/sml/ml.sock \
   -runtime-lib ../../poc/e5-embedding-onnx/runtime/onnxruntime-osx-arm64-1.27.0/lib \
   -embed-model ../../poc/e5-embedding-onnx/model/model_int8.onnx \
-  -tokenizer  ../../poc/e5-embedding-onnx/model/tokenizer.json
+  -tokenizer  ../../poc/e5-embedding-onnx/model/tokenizer.json \
+  -ocr-det-model ../../poc/paddleocr-onnx/models/det.onnx \
+  -ocr-rec-model ../../poc/paddleocr-onnx/models/rec.onnx \
+  -ocr-keys      ../../poc/paddleocr-onnx/models/rec_keys.txt
 ```
 
-Then `curl --unix-socket /tmp/sml/ml.sock http://x/healthz`. Keep the socket path
-short — macOS caps unix socket paths at ~104 bytes.
+Then `curl --unix-socket /tmp/sml/ml.sock http://x/healthz`, or OCR an image:
+
+```sh
+curl --unix-socket /tmp/sml/ml.sock -X POST http://x/v1/extract \
+  -H 'X-Stella-Mime: image/png' --data-binary @page.png
+```
+
+Keep the socket path short — macOS caps unix socket paths at ~104 bytes.

--- a/cmd/stella-ml/engine_ocr.go
+++ b/cmd/stella-ml/engine_ocr.go
@@ -1,0 +1,428 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"image"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+
+	ort "github.com/yalue/onnxruntime_go"
+)
+
+// ocrModelID is the logical model name reported on /healthz.
+const ocrModelID = "PaddlePaddle/PP-OCRv5_mobile"
+
+// DB detection postprocess params, read from the PP-OCRv5 det inference.yml (not
+// guesses). Rec geometry comes from the rec inference.yml.
+const (
+	detLongSide    = 960
+	detThresh      = 0.3 // probability-map binarization
+	detBoxThresh   = 0.6 // min mean score to keep a box
+	detUnclipRatio = 1.5 // box dilation
+	detMinSize     = 3   // drop boxes smaller than this (resized px)
+
+	recHeight = 48
+	recWidth  = 320 // fixed batch width; PP-OCRv5 pads to 320
+)
+
+// ocrEngine holds the long-lived detection + recognition sessions and the CTC
+// charset. PP-OCRv5 mobile det finds text boxes; rec reads each crop. Both ORT
+// sessions are reused across requests.
+//
+// onnxruntime sessions are not guaranteed safe for concurrent Run calls when the
+// graph is shared, so a single mutex serializes inference. The server's extract
+// lane already bounds concurrency; OCR is CPU-bound and this keeps it simple and
+// correct. // single lock; per-session pool if extract throughput matters.
+type ocrEngine struct {
+	mu      sync.Mutex
+	det     *ort.DynamicAdvancedSession
+	rec     *ort.DynamicAdvancedSession
+	detOpts *ort.SessionOptions
+	recOpts *ort.SessionOptions
+	charset []string
+}
+
+func newOCREngine(detPath, recPath, keysPath string, intraOp, interOp int) (*ocrEngine, error) {
+	cs, err := loadCharset(keysPath)
+	if err != nil {
+		return nil, fmt.Errorf("load ocr charset: %w", err)
+	}
+	detOpts, err := newSessionOptions(intraOp, interOp)
+	if err != nil {
+		return nil, err
+	}
+	det, err := ort.NewDynamicAdvancedSession(detPath, []string{"x"}, []string{"fetch_name_0"}, detOpts)
+	if err != nil {
+		detOpts.Destroy()
+		return nil, fmt.Errorf("det session: %w", err)
+	}
+	recOpts, err := newSessionOptions(intraOp, interOp)
+	if err != nil {
+		det.Destroy()
+		detOpts.Destroy()
+		return nil, err
+	}
+	rec, err := ort.NewDynamicAdvancedSession(recPath, []string{"x"}, []string{"fetch_name_0"}, recOpts)
+	if err != nil {
+		det.Destroy()
+		detOpts.Destroy()
+		recOpts.Destroy()
+		return nil, fmt.Errorf("rec session: %w", err)
+	}
+	return &ocrEngine{det: det, rec: rec, detOpts: detOpts, recOpts: recOpts, charset: cs}, nil
+}
+
+func (e *ocrEngine) close() {
+	if e.det != nil {
+		_ = e.det.Destroy()
+	}
+	if e.rec != nil {
+		_ = e.rec.Destroy()
+	}
+	if e.detOpts != nil {
+		e.detOpts.Destroy()
+	}
+	if e.recOpts != nil {
+		e.recOpts.Destroy()
+	}
+}
+
+// Recognize runs the full detect -> crop -> recognize pipeline and returns the
+// page text, one detected line per output line, ordered top-to-bottom then
+// left-to-right. Empty result means no text was found (not an error).
+func (e *ocrEngine) Recognize(img image.Image) (string, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	rgba := toRGBA(img)
+	data, rw, rh, sx, sy := preprocessDet(rgba)
+	prob, shape, err := runSingle(e.det, ort.NewShape(1, 3, int64(rh), int64(rw)), data)
+	if err != nil {
+		return "", fmt.Errorf("det run: %w", err)
+	}
+	if len(shape) != 4 {
+		return "", fmt.Errorf("unexpected det output rank %v", shape)
+	}
+	ph, pw := int(shape[2]), int(shape[3])
+	boxes := dbPostProcess(prob, pw, ph)
+
+	ow, oh := rgba.Bounds().Dx(), rgba.Bounds().Dy()
+	for i := range boxes {
+		boxes[i].minX = clampI(int(float64(boxes[i].minX)*sx), 0, ow-1)
+		boxes[i].maxX = clampI(int(float64(boxes[i].maxX)*sx), 0, ow)
+		boxes[i].minY = clampI(int(float64(boxes[i].minY)*sy), 0, oh-1)
+		boxes[i].maxY = clampI(int(float64(boxes[i].maxY)*sy), 0, oh)
+	}
+	sortBoxes(boxes)
+
+	var lines []string
+	for _, b := range boxes {
+		text, _, err := e.recognize(cropRGBA(rgba, b))
+		if err != nil {
+			return "", fmt.Errorf("rec run: %w", err)
+		}
+		if t := strings.TrimSpace(text); t != "" {
+			lines = append(lines, t)
+		}
+	}
+	return strings.Join(lines, "\n"), nil
+}
+
+type box struct {
+	minX, minY, maxX, maxY int
+	score                  float32
+}
+
+// preprocessDet resizes so the longer side is detLongSide, snaps both dims to
+// multiples of 32 (DBNet requirement), normalizes with ImageNet mean/std applied
+// in BGR channel order (a training quirk), and returns a CHW BGR buffer plus the
+// resized dims and the original/resized scale factors.
+func preprocessDet(src *image.RGBA) (buf []float32, rw, rh int, sx, sy float64) {
+	ow, oh := src.Bounds().Dx(), src.Bounds().Dy()
+	ratio := float64(detLongSide) / float64(max(ow, oh))
+	rw = round32(float64(ow) * ratio)
+	rh = round32(float64(oh) * ratio)
+	resized := bilinearResize(src, rw, rh)
+	sx = float64(ow) / float64(rw)
+	sy = float64(oh) / float64(rh)
+
+	mean := [3]float32{0.485, 0.456, 0.406}
+	std := [3]float32{0.229, 0.224, 0.225}
+	buf = make([]float32, 3*rh*rw)
+	plane := rh * rw
+	for y := 0; y < rh; y++ {
+		for x := 0; x < rw; x++ {
+			off := y*resized.Stride + x*4
+			r := float32(resized.Pix[off+0]) / 255
+			g := float32(resized.Pix[off+1]) / 255
+			b := float32(resized.Pix[off+2]) / 255
+			buf[0*plane+y*rw+x] = (b - mean[0]) / std[0]
+			buf[1*plane+y*rw+x] = (g - mean[1]) / std[1]
+			buf[2*plane+y*rw+x] = (r - mean[2]) / std[2]
+		}
+	}
+	return buf, rw, rh, sx, sy
+}
+
+func round32(v float64) int {
+	n := int((v + 16) / 32)
+	if n < 1 {
+		n = 1
+	}
+	return n * 32
+}
+
+// dbPostProcess thresholds the probability map and extracts axis-aligned boxes via
+// connected components, scoring each by mean probability and dilating by the
+// unclip ratio. Simplified vs PaddleOCR (no contour/minAreaRect/polygon): rotated
+// or skewed text is cropped as its bounding box. // bounding-rect MVP; rotated
+// crop (minAreaRect + perspective warp) is Phase 4b.
+func dbPostProcess(prob []float32, w, h int) []box {
+	bin := make([]bool, w*h)
+	for i, p := range prob {
+		if p > detThresh {
+			bin[i] = true
+		}
+	}
+
+	visited := make([]bool, w*h)
+	var boxes []box
+	stack := make([]int, 0, 1024)
+	for start := 0; start < w*h; start++ {
+		if !bin[start] || visited[start] {
+			continue
+		}
+		minX, minY, maxX, maxY := w, h, -1, -1
+		stack = stack[:0]
+		stack = append(stack, start)
+		visited[start] = true
+		for len(stack) > 0 {
+			idx := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			cx, cy := idx%w, idx/w
+			if cx < minX {
+				minX = cx
+			}
+			if cx > maxX {
+				maxX = cx
+			}
+			if cy < minY {
+				minY = cy
+			}
+			if cy > maxY {
+				maxY = cy
+			}
+			if cx > 0 && bin[idx-1] && !visited[idx-1] {
+				visited[idx-1] = true
+				stack = append(stack, idx-1)
+			}
+			if cx < w-1 && bin[idx+1] && !visited[idx+1] {
+				visited[idx+1] = true
+				stack = append(stack, idx+1)
+			}
+			if cy > 0 && bin[idx-w] && !visited[idx-w] {
+				visited[idx-w] = true
+				stack = append(stack, idx-w)
+			}
+			if cy < h-1 && bin[idx+w] && !visited[idx+w] {
+				visited[idx+w] = true
+				stack = append(stack, idx+w)
+			}
+		}
+		if maxX-minX < detMinSize || maxY-minY < detMinSize {
+			continue
+		}
+		var sum float32
+		var n int
+		for y := minY; y <= maxY; y++ {
+			for x := minX; x <= maxX; x++ {
+				sum += prob[y*w+x]
+				n++
+			}
+		}
+		score := sum / float32(n)
+		if score < detBoxThresh {
+			continue
+		}
+		bw, bh := float64(maxX-minX), float64(maxY-minY)
+		dist := bw * bh * detUnclipRatio / (2 * (bw + bh))
+		d := int(dist + 0.5)
+		boxes = append(boxes, box{
+			minX: clampI(minX-d, 0, w-1), minY: clampI(minY-d, 0, h-1),
+			maxX: clampI(maxX+d, 0, w-1), maxY: clampI(maxY+d, 0, h-1),
+			score: score,
+		})
+	}
+	return boxes
+}
+
+// sortBoxes orders boxes top-to-bottom, then left-to-right, grouping lines that
+// overlap vertically by more than half a box height.
+func sortBoxes(b []box) {
+	sort.Slice(b, func(i, j int) bool {
+		hi := b[i].maxY - b[i].minY
+		if absInt(b[i].minY-b[j].minY) > hi/2 {
+			return b[i].minY < b[j].minY
+		}
+		return b[i].minX < b[j].minX
+	})
+}
+
+func cropRGBA(src *image.RGBA, b box) *image.RGBA {
+	w, h := b.maxX-b.minX, b.maxY-b.minY
+	if w < 1 {
+		w = 1
+	}
+	if h < 1 {
+		h = 1
+	}
+	dst := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			so := (b.minY+y)*src.Stride + (b.minX+x)*4
+			do := y*dst.Stride + x*4
+			copy(dst.Pix[do:do+4], src.Pix[so:so+4])
+		}
+	}
+	return dst
+}
+
+// recognize runs a single cropped text-line image and returns text + mean score.
+func (e *ocrEngine) recognize(img image.Image) (string, float32, error) {
+	data := preprocessRec(toRGBA(img))
+	out, outShape, err := runSingle(e.rec, ort.NewShape(1, 3, recHeight, recWidth), data)
+	if err != nil {
+		return "", 0, err
+	}
+	if len(outShape) != 3 {
+		return "", 0, fmt.Errorf("unexpected rec output rank %v", outShape)
+	}
+	return e.ctcDecode(out, int(outShape[1]), int(outShape[2]))
+}
+
+// preprocessRec resizes to height 48 keeping aspect ratio (capped at width 320),
+// normalizes BGR to [-1,1] via (x/255-0.5)/0.5, and writes a zero-padded CHW
+// float32 buffer of shape [3,48,320].
+func preprocessRec(src *image.RGBA) []float32 {
+	sb := src.Bounds()
+	sw, sh := sb.Dx(), sb.Dy()
+	ratio := float64(sw) / float64(sh)
+	w := int(float64(recHeight)*ratio + 0.5)
+	if w > recWidth {
+		w = recWidth
+	}
+	if w < 1 {
+		w = 1
+	}
+	resized := bilinearResize(src, w, recHeight)
+
+	buf := make([]float32, 3*recHeight*recWidth)
+	plane := recHeight * recWidth
+	for y := 0; y < recHeight; y++ {
+		for x := 0; x < w; x++ {
+			off := y*resized.Stride + x*4
+			r := float32(resized.Pix[off+0])
+			g := float32(resized.Pix[off+1])
+			b := float32(resized.Pix[off+2])
+			buf[0*plane+y*recWidth+x] = (b/255 - 0.5) / 0.5
+			buf[1*plane+y*recWidth+x] = (g/255 - 0.5) / 0.5
+			buf[2*plane+y*recWidth+x] = (r/255 - 0.5) / 0.5
+		}
+	}
+	return buf
+}
+
+// ctcDecode performs greedy CTC decoding: argmax per timestep, collapse repeats,
+// drop the blank (index 0). Returns the string and mean confidence of kept steps.
+func (e *ocrEngine) ctcDecode(logits []float32, steps, classes int) (string, float32, error) {
+	var sb strings.Builder
+	var sum float32
+	var n int
+	last := -1
+	for t := 0; t < steps; t++ {
+		off := t * classes
+		best := 0
+		bestV := logits[off]
+		for c := 1; c < classes; c++ {
+			if v := logits[off+c]; v > bestV {
+				bestV = v
+				best = c
+			}
+		}
+		if best != 0 && best != last {
+			if best < len(e.charset) {
+				sb.WriteString(e.charset[best])
+				sum += bestV
+				n++
+			}
+		}
+		last = best
+	}
+	var score float32
+	if n > 0 {
+		score = sum / float32(n)
+	}
+	return sb.String(), score, nil
+}
+
+// loadCharset reads the PP-OCR character dictionary (one entry per line) and
+// builds the CTC index->string table: index 0 is the blank, 1..N map to dict
+// lines 0..N-1, and the final index is the space character.
+func loadCharset(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	var dict []string
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 1024*1024), 1024*1024)
+	for sc.Scan() {
+		dict = append(dict, sc.Text())
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	if len(dict) == 0 {
+		return nil, fmt.Errorf("empty charset %s", path)
+	}
+
+	table := make([]string, 0, len(dict)+2)
+	table = append(table, "")      // 0: blank
+	table = append(table, dict...) // 1..N
+	table = append(table, " ")     // N+1: space
+	return table, nil
+}
+
+// runSingle feeds one NCHW float32 input through a dynamic single-input/output
+// session and returns the output data and shape. PP-OCR det and rec both have one
+// input and one output.
+func runSingle(sess *ort.DynamicAdvancedSession, shape ort.Shape, data []float32) ([]float32, []int64, error) {
+	in, err := ort.NewTensor(shape, data)
+	if err != nil {
+		return nil, nil, fmt.Errorf("new input tensor: %w", err)
+	}
+	defer in.Destroy()
+
+	outputs := []ort.Value{nil}
+	if err := sess.Run([]ort.Value{in}, outputs); err != nil {
+		return nil, nil, fmt.Errorf("run: %w", err)
+	}
+	out, ok := outputs[0].(*ort.Tensor[float32])
+	if !ok {
+		return nil, nil, fmt.Errorf("unexpected output type %T", outputs[0])
+	}
+	defer out.Destroy()
+	return out.GetData(), out.GetShape(), nil
+}
+
+func absInt(v int) int {
+	if v < 0 {
+		return -v
+	}
+	return v
+}

--- a/cmd/stella-ml/go.mod
+++ b/cmd/stella-ml/go.mod
@@ -11,3 +11,5 @@ require (
 	github.com/daulet/tokenizers v1.27.0
 	github.com/yalue/onnxruntime_go v1.31.0
 )
+
+require golang.org/x/image v0.43.0

--- a/cmd/stella-ml/go.sum
+++ b/cmd/stella-ml/go.sum
@@ -8,5 +8,7 @@ github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/yalue/onnxruntime_go v1.31.0 h1:1ln4YW1SFOFfGJZXe3jNOb2JUSt+l2pEneZfV8HdtFA=
 github.com/yalue/onnxruntime_go v1.31.0/go.mod h1:b4X26A8pekNb1ACJ58wAXgNKeUCGEAQ9dmACut9Sm/4=
+golang.org/x/image v0.43.0 h1:FLxcP4ec2350nTfOC8ysKtqYSIFbk/QGjw1ZHNP4tsY=
+golang.org/x/image v0.43.0/go.mod h1:rrpelvGFt+kLPAjPM4HeWPgrl0FtafueU//e5N0qk/Q=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/cmd/stella-ml/main.go
+++ b/cmd/stella-ml/main.go
@@ -17,12 +17,35 @@ import (
 	"time"
 )
 
+// config holds the resolved flags. The embedding model is required; OCR is
+// optional (its three paths are all-or-nothing) so an embedding-only bundle still
+// boots and /v1/extract reports 503 until OCR models are installed.
+type config struct {
+	socketPath  string
+	runtimeLib  string
+	embedModel  string
+	tokenizer   string
+	ocrDet      string
+	ocrRec      string
+	ocrKeys     string
+	runtimeVer  string
+	modelDigest string
+	intraOp     int
+	interOp     int
+	embedConc   int
+	extractConc int
+}
+
 func main() {
 	var (
+		cfg         config
 		socketPath  = flag.String("socket", "", "unix socket path to listen on (required)")
 		runtimeLib  = flag.String("runtime-lib", "", "path to libonnxruntime (dir or file) (required)")
 		modelPath   = flag.String("embed-model", "", "path to the e5 embedding model.onnx (required)")
 		tokenizer   = flag.String("tokenizer", "", "path to tokenizer.json (required)")
+		ocrDet      = flag.String("ocr-det-model", "", "path to the PP-OCR detection model.onnx (optional; enables /v1/extract)")
+		ocrRec      = flag.String("ocr-rec-model", "", "path to the PP-OCR recognition model.onnx (optional)")
+		ocrKeys     = flag.String("ocr-keys", "", "path to the PP-OCR rec character dictionary (optional)")
 		runtimeVer  = flag.String("runtime-version", "dev", "runtime version reported on /healthz")
 		modelDigest = flag.String("model-digest", "", "model-manifest digest reported on /healthz")
 		intraOp     = flag.Int("intra-op-threads", 1, "onnxruntime intra-op thread count (pinned)")
@@ -39,32 +62,49 @@ func main() {
 		os.Exit(2)
 	}
 
-	if err := run(log, *socketPath, *runtimeLib, *modelPath, *tokenizer, *runtimeVer, *modelDigest, *intraOp, *interOp, *embedConc, *extractConc); err != nil {
+	cfg = config{
+		socketPath: *socketPath, runtimeLib: *runtimeLib, embedModel: *modelPath, tokenizer: *tokenizer,
+		ocrDet: *ocrDet, ocrRec: *ocrRec, ocrKeys: *ocrKeys,
+		runtimeVer: *runtimeVer, modelDigest: *modelDigest,
+		intraOp: *intraOp, interOp: *interOp, embedConc: *embedConc, extractConc: *extractConc,
+	}
+	if err := run(log, cfg); err != nil {
 		log.Error("stella-ml exited", "err", err)
 		os.Exit(1)
 	}
 }
 
-func run(log *slog.Logger, socketPath, runtimeLib, modelPath, tokenizer, runtimeVer, modelDigest string, intraOp, interOp, embedConc, extractConc int) error {
-	if err := initORT(runtimeLib); err != nil {
+func run(log *slog.Logger, cfg config) error {
+	if err := initORT(cfg.runtimeLib); err != nil {
 		return err
 	}
 	defer shutdownORT()
 
-	embed, err := newE5Engine(modelPath, tokenizer, intraOp, interOp)
+	embed, err := newE5Engine(cfg.embedModel, cfg.tokenizer, cfg.intraOp, cfg.interOp)
 	if err != nil {
 		return err
 	}
 	defer embed.close()
 	log.Info("embed engine loaded", "model", embedModelID)
 
-	ln, err := listenUnix(socketPath)
+	// OCR is optional and all-or-nothing across its three assets.
+	var ocr *ocrEngine
+	if cfg.ocrDet != "" && cfg.ocrRec != "" && cfg.ocrKeys != "" {
+		ocr, err = newOCREngine(cfg.ocrDet, cfg.ocrRec, cfg.ocrKeys, cfg.intraOp, cfg.interOp)
+		if err != nil {
+			return err
+		}
+		defer ocr.close()
+		log.Info("ocr engine loaded", "model", ocrModelID)
+	}
+
+	ln, err := listenUnix(cfg.socketPath)
 	if err != nil {
 		return err
 	}
-	defer func() { _ = os.Remove(socketPath) }()
+	defer func() { _ = os.Remove(cfg.socketPath) }()
 
-	srv := newServer(embed, runtimeVer, modelDigest, defaultLimits(), embedConc, extractConc, log)
+	srv := newServer(embed, ocr, cfg.runtimeVer, cfg.modelDigest, defaultLimits(), cfg.embedConc, cfg.extractConc, log)
 	httpSrv := &http.Server{
 		Handler:           srv.handler(),
 		ReadHeaderTimeout: 10 * time.Second,
@@ -83,7 +123,7 @@ func run(log *slog.Logger, socketPath, runtimeLib, modelPath, tokenizer, runtime
 		_ = httpSrv.Shutdown(shCtx)
 	}()
 
-	log.Info("listening", "socket", socketPath, "runtime_version", runtimeVer)
+	log.Info("listening", "socket", cfg.socketPath, "runtime_version", cfg.runtimeVer)
 	if err := httpSrv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return err
 	}

--- a/cmd/stella-ml/ocr_decode.go
+++ b/cmd/stella-ml/ocr_decode.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+
+	// Register the decoders image.Decode dispatches to. JPEG/PNG/GIF are stdlib;
+	// WebP/BMP/TIFF come from golang.org/x/image. All are pure Go.
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
+
+	_ "golang.org/x/image/bmp"
+	_ "golang.org/x/image/tiff"
+	_ "golang.org/x/image/webp"
+)
+
+// decodeImage decodes raw image bytes. It relies on image.Decode sniffing the
+// format from the magic bytes; the mime hint is only used to improve the error
+// message, since callers occasionally send a mislabeled or empty mime.
+func decodeImage(data []byte, mime string) (image.Image, error) {
+	img, _, err := image.Decode(bytes.NewReader(data))
+	if err != nil {
+		if mime != "" {
+			return nil, fmt.Errorf("%w (mime %q)", err, mime)
+		}
+		return nil, err
+	}
+	return img, nil
+}

--- a/cmd/stella-ml/ocr_image.go
+++ b/cmd/stella-ml/ocr_image.go
@@ -1,0 +1,68 @@
+package main
+
+import "image"
+
+// toRGBA copies any image into an *image.RGBA for fast, stride-addressed pixel
+// access during OCR preprocessing.
+func toRGBA(src image.Image) *image.RGBA {
+	if r, ok := src.(*image.RGBA); ok {
+		return r
+	}
+	b := src.Bounds()
+	dst := image.NewRGBA(image.Rect(0, 0, b.Dx(), b.Dy()))
+	for y := 0; y < b.Dy(); y++ {
+		for x := 0; x < b.Dx(); x++ {
+			dst.Set(x, y, src.At(b.Min.X+x, b.Min.Y+y))
+		}
+	}
+	return dst
+}
+
+// bilinearResize resizes an RGBA image to dstW x dstH using bilinear sampling.
+// Good enough for OCR preprocessing and avoids pulling in an image-scaling library.
+func bilinearResize(src *image.RGBA, dstW, dstH int) *image.RGBA {
+	sb := src.Bounds()
+	srcW, srcH := sb.Dx(), sb.Dy()
+	dst := image.NewRGBA(image.Rect(0, 0, dstW, dstH))
+	if srcW == 0 || srcH == 0 {
+		return dst
+	}
+	sx := float64(srcW) / float64(dstW)
+	sy := float64(srcH) / float64(dstH)
+	for y := 0; y < dstH; y++ {
+		fy := (float64(y)+0.5)*sy - 0.5
+		y0 := int(fy)
+		dy := fy - float64(y0)
+		y1 := y0 + 1
+		y0 = clampI(y0, 0, srcH-1)
+		y1 = clampI(y1, 0, srcH-1)
+		for x := 0; x < dstW; x++ {
+			fx := (float64(x)+0.5)*sx - 0.5
+			x0 := int(fx)
+			dx := fx - float64(x0)
+			x1 := x0 + 1
+			x0 = clampI(x0, 0, srcW-1)
+			x1 = clampI(x1, 0, srcW-1)
+			for c := 0; c < 4; c++ {
+				p00 := float64(src.Pix[(y0)*src.Stride+x0*4+c])
+				p01 := float64(src.Pix[(y0)*src.Stride+x1*4+c])
+				p10 := float64(src.Pix[(y1)*src.Stride+x0*4+c])
+				p11 := float64(src.Pix[(y1)*src.Stride+x1*4+c])
+				top := p00 + (p01-p00)*dx
+				bot := p10 + (p11-p10)*dx
+				dst.Pix[y*dst.Stride+x*4+c] = uint8(top + (bot-top)*dy + 0.5)
+			}
+		}
+	}
+	return dst
+}
+
+func clampI(v, lo, hi int) int {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}

--- a/cmd/stella-ml/server.go
+++ b/cmd/stella-ml/server.go
@@ -13,10 +13,12 @@ import (
 	"time"
 )
 
-// server hosts the ML engines behind the UDS HTTP contract. extract is nil until
-// the OCR engine lands (Phase 4a); its endpoint returns 501 until then.
+// server hosts the ML engines behind the UDS HTTP contract. Either engine may be
+// nil — an embedding-only or OCR-only deployment is valid; the matching endpoint
+// returns 503 when its engine is not loaded.
 type server struct {
 	embed   *e5Engine
+	ocr     *ocrEngine
 	lim     limits
 	embedLn *lane
 	extLn   *lane
@@ -26,9 +28,10 @@ type server struct {
 	log            *slog.Logger
 }
 
-func newServer(embed *e5Engine, runtimeVersion, modelDigest string, lim limits, embedSlots, extractSlots int, log *slog.Logger) *server {
+func newServer(embed *e5Engine, ocr *ocrEngine, runtimeVersion, modelDigest string, lim limits, embedSlots, extractSlots int, log *slog.Logger) *server {
 	return &server{
 		embed:          embed,
+		ocr:            ocr,
 		lim:            lim,
 		embedLn:        newLane(embedSlots, lim.perTenantInflight),
 		extLn:          newLane(extractSlots, lim.perTenantInflight),
@@ -77,6 +80,10 @@ func (s *server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
 	if s.embed != nil {
 		status = "ok"
 		models["embed"] = embedModelID
+	}
+	if s.ocr != nil {
+		status = "ok"
+		models["ocr"] = ocrModelID
 	}
 	writeJSON(w, http.StatusOK, healthResponse{
 		Status:              status,
@@ -145,12 +152,55 @@ func (s *server) handleEmbed(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// handleExtract runs OCR over the raw image bytes in the request body. The MVP
+// path is image-only: the text-layer fast path (PDF/native text) lives on the
+// stellad side, which calls extract only when it needs pixels read. X-Stella-Mime
+// hints the decoder; X-Stella-Force-Ocr is accepted for protocol completeness but
+// is a no-op here since this endpoint always OCRs.
 func (s *server) handleExtract(w http.ResponseWriter, r *http.Request) {
-	_, rc, cancel := s.withContext(r)
+	r, rc, cancel := s.withContext(r)
 	defer cancel()
-	// OCR engine lands in Phase 4a; the endpoint exists now so the protocol and
-	// supervisor contract can be exercised end-to-end.
-	s.fail(w, rc, http.StatusNotImplemented, errors.New("extract not implemented yet"))
+
+	if s.ocr == nil {
+		s.fail(w, rc, http.StatusServiceUnavailable, errors.New("ocr engine not loaded"))
+		return
+	}
+
+	data, err := io.ReadAll(io.LimitReader(r.Body, s.lim.maxExtractBody))
+	if err != nil {
+		s.fail(w, rc, http.StatusBadRequest, errwrap("read extract body", err))
+		return
+	}
+	if len(data) == 0 {
+		s.fail(w, rc, http.StatusBadRequest, errors.New("empty extract body"))
+		return
+	}
+
+	mime := r.Header.Get(headerExtMime)
+	img, err := decodeImage(data, mime)
+	if err != nil {
+		s.fail(w, rc, http.StatusUnsupportedMediaType, errwrap("decode image", err))
+		return
+	}
+
+	release, err := s.extLn.acquire(r.Context(), rc.tenant)
+	if err != nil {
+		s.failAdmission(w, rc, err)
+		return
+	}
+	defer release()
+
+	text, err := s.ocr.Recognize(img)
+	if err != nil {
+		s.fail(w, rc, http.StatusInternalServerError, errwrap("ocr", err))
+		return
+	}
+
+	outMime := mime
+	if outMime == "" {
+		outMime = "text/plain"
+	}
+	writeJSON(w, http.StatusOK, extractResponse{Content: text, MimeType: outMime})
 }
 
 // writeVectors streams vectors as little-endian float32, count*dim contiguous.

--- a/cmd/stellad/setup_ml.go
+++ b/cmd/stellad/setup_ml.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"log/slog"
+	"os"
 	"path/filepath"
 
+	"github.com/CherryHQ/stella/internal/document"
 	"github.com/CherryHQ/stella/internal/embedding"
 	"github.com/CherryHQ/stella/internal/ml"
 	"github.com/CherryHQ/stella/internal/mlruntime"
@@ -30,18 +32,63 @@ func setupMLSidecar(stellaHome string, logger *slog.Logger) (*ml.Supervisor, emb
 	// socket paths are capped near 104 bytes and the sidecar errors clearly if the
 	// resolved path is too long.
 	sockPath := filepath.Join(stellaHome, "run", "stella-ml.sock")
+	args := []string{
+		"-runtime-lib", r.LibDir,
+		"-embed-model", r.EmbedModelPath,
+		"-tokenizer", r.TokenizerPath,
+		"-runtime-version", r.RuntimeVersion,
+	}
+	ocrWired := false
+	if r.HasOCR() && localOCREnabled() {
+		args = append(args,
+			"-ocr-det-model", r.OCRDetPath,
+			"-ocr-rec-model", r.OCRRecPath,
+			"-ocr-keys", r.OCRKeysPath,
+		)
+		ocrWired = true
+	}
 	sup := ml.NewSupervisor(ml.SupervisorConfig{
 		BinPath:    r.BinPath,
 		SocketPath: sockPath,
-		Args: []string{
-			"-runtime-lib", r.LibDir,
-			"-embed-model", r.EmbedModelPath,
-			"-tokenizer", r.TokenizerPath,
-			"-runtime-version", r.RuntimeVersion,
-		},
+		Args:       args,
 	}, logger)
-	logger.Info("native ML sidecar resolved", "bin", r.BinPath, "runtime", r.RuntimeVersion, "model", r.ModelVersion)
+
+	// Install the document-extraction OCR fallback as a process-wide capability so
+	// every read-tool extractor picks it up. Gated by STELLA_LOCAL_OCR for the MVP;
+	// the toggle moves to deployment config + the settings UI in a later phase.
+	if ocrWired {
+		document.SetLocalOCR(mlOCR{client: sup.Client(), tenant: "ocr"})
+	}
+
+	logger.Info("native ML sidecar resolved", "bin", r.BinPath, "runtime", r.RuntimeVersion, "model", r.ModelVersion, "ocr", ocrWired)
 	return sup, mlLocalEmbedder{client: sup.Client(), tenant: "embedding"}
+}
+
+// localOCREnabled reports whether the operator opted into local OCR. Explicit
+// opt-in keeps OCR off by default even when the models happen to be installed.
+func localOCREnabled() bool {
+	switch os.Getenv("STELLA_LOCAL_OCR") {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+// mlOCR adapts the sidecar client to document.OCR, mapping the sidecar's extract
+// result to a document.Result and pinning a fixed fairness tenant. // fixed tenant;
+// per-account once the read tool carries account context.
+type mlOCR struct {
+	client *ml.Client
+	tenant string
+}
+
+func (o mlOCR) Extract(ctx context.Context, mime string, data []byte, forceOCR bool) (*document.Result, error) {
+	res, err := o.client.Extract(ctx, o.tenant, mime, data, forceOCR)
+	if err != nil {
+		return nil, err
+	}
+	return &document.Result{Content: res.Content, MimeType: res.MimeType}, nil
 }
 
 // mlLocalEmbedder adapts the sidecar client to embedding.LocalEmbedder, mapping

--- a/cmd/stellad/setup_ml_integration_test.go
+++ b/cmd/stellad/setup_ml_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/CherryHQ/stella/internal/document"
 	"github.com/CherryHQ/stella/internal/embedding"
 	"github.com/CherryHQ/stella/internal/mlruntime"
 )
@@ -54,6 +55,18 @@ func TestSetupMLSidecarIntegration(t *testing.T) {
 	t.Setenv(mlruntime.EnvRuntimeDir, rtDir)
 	t.Setenv(mlruntime.EnvModelDir, mdDir)
 
+	// OCR is optional: only exercised when its three models + a test image are
+	// provided via STELLA_ML_OCR_{DET,REC,KEYS} and STELLA_ML_OCR_IMAGE.
+	det, rec, keys := os.Getenv("STELLA_ML_OCR_DET"), os.Getenv("STELLA_ML_OCR_REC"), os.Getenv("STELLA_ML_OCR_KEYS")
+	ocrImage := os.Getenv("STELLA_ML_OCR_IMAGE")
+	testOCR := det != "" && rec != "" && keys != "" && ocrImage != ""
+	if testOCR {
+		symlink(t, det, filepath.Join(mdDir, "det.onnx"))
+		symlink(t, rec, filepath.Join(mdDir, "rec.onnx"))
+		symlink(t, keys, filepath.Join(mdDir, "rec_keys.txt"))
+		t.Setenv("STELLA_LOCAL_OCR", "1")
+	}
+
 	sup, emb := setupMLSidecar(home, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if sup == nil || emb == nil {
 		t.Fatal("expected a resolved supervisor + embedder")
@@ -76,6 +89,23 @@ func TestSetupMLSidecarIntegration(t *testing.T) {
 	}
 	if len(vecs) != 1 || len(vecs[0]) != 384 {
 		t.Fatalf("vector shape = %dx%d, want 1x384", len(vecs), len(vecs[0]))
+	}
+
+	if testOCR {
+		// setupMLSidecar installed the OCR fallback globally; drive it through the
+		// real document extractor to prove the full read-tool path OCRs an image.
+		img, rerr := os.ReadFile(ocrImage)
+		if rerr != nil {
+			t.Fatal(rerr)
+		}
+		res, oerr := document.NewExtractor().ExtractBytes(ctx, img, "image/png", document.Options{Timeout: 30 * time.Second})
+		if oerr != nil {
+			t.Fatalf("OCR ExtractBytes: %v", oerr)
+		}
+		if len(res.Content) == 0 {
+			t.Fatal("OCR returned empty content")
+		}
+		t.Logf("OCR extracted %d chars", len(res.Content))
 	}
 }
 

--- a/internal/document/default.go
+++ b/internal/document/default.go
@@ -2,6 +2,6 @@
 
 package document
 
-func NewExtractor() Extractor {
+func newBaseExtractor() Extractor {
 	return cliExtractor{}
 }

--- a/internal/document/sidecar.go
+++ b/internal/document/sidecar.go
@@ -1,0 +1,142 @@
+package document
+
+import (
+	"context"
+	gomime "mime"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+)
+
+// OCR is the local image-OCR capability the composite extractor falls back to —
+// satisfied by an adapter over the ML sidecar client. It is defined here, in terms
+// of document types, so this package keeps no dependency on internal/ml.
+type OCR interface {
+	// Extract runs OCR over raw image bytes. forceOCR is a hint to skip any
+	// text-layer fast path; the sidecar's image endpoint always OCRs regardless.
+	Extract(ctx context.Context, mime string, data []byte, forceOCR bool) (*Result, error)
+}
+
+// localOCR holds the process-wide OCR backend, installed once at boot via
+// SetLocalOCR before any tool is built. It is a global because NewExtractor is the
+// single extractor factory and is called from many tool-construction sites that do
+// not thread a client through; an atomic pointer keeps the read race-free.
+// global injection point; per-call wiring if a request ever needs its own backend.
+var localOCR atomic.Pointer[ocrHolder]
+
+type ocrHolder struct{ ocr OCR }
+
+// SetLocalOCR enables sidecar OCR fallback for every subsequently built extractor.
+// Passing nil disables it again. Safe to call before or after extractors exist;
+// existing extractors read the global per request.
+func SetLocalOCR(o OCR) {
+	if o == nil {
+		localOCR.Store(nil)
+		return
+	}
+	localOCR.Store(&ocrHolder{ocr: o})
+}
+
+func currentOCR() OCR {
+	if h := localOCR.Load(); h != nil {
+		return h.ocr
+	}
+	return nil
+}
+
+// NewExtractor returns the platform base extractor, transparently wrapped with
+// sidecar OCR fallback when one has been installed via SetLocalOCR. The wrapper
+// reads the global per call, so enabling OCR after construction still takes effect.
+func NewExtractor() Extractor {
+	return compositeExtractor{base: newBaseExtractor()}
+}
+
+// compositeExtractor tries the base (text-layer) extractor first and falls back to
+// local OCR for image inputs the base could not turn into text. The fallback only
+// fires for images: text documents that legitimately extract to empty are not
+// re-run through OCR.
+type compositeExtractor struct {
+	base Extractor
+}
+
+func (c compositeExtractor) ExtractFile(ctx context.Context, path string, opts Options) (*Result, error) {
+	res, err := c.base.ExtractFile(ctx, path, opts)
+	if ocrSatisfied(res, err) {
+		return res, err
+	}
+	ocr := currentOCR()
+	if ocr == nil {
+		return res, err
+	}
+	data, mime, readErr := readForOCR(path)
+	if readErr != nil || !isImageMime(mime) {
+		return res, err
+	}
+	return runOCR(ctx, ocr, data, mime, res, err)
+}
+
+func (c compositeExtractor) ExtractBytes(ctx context.Context, data []byte, mime string, opts Options) (*Result, error) {
+	res, err := c.base.ExtractBytes(ctx, data, mime, opts)
+	if ocrSatisfied(res, err) {
+		return res, err
+	}
+	ocr := currentOCR()
+	if ocr == nil {
+		return res, err
+	}
+	effMime := mime
+	if !isImageMime(effMime) {
+		effMime = http.DetectContentType(data)
+	}
+	if !isImageMime(effMime) {
+		return res, err
+	}
+	return runOCR(ctx, ocr, data, effMime, res, err)
+}
+
+// ocrSatisfied reports whether the base extractor already produced usable text, in
+// which case OCR is skipped.
+func ocrSatisfied(res *Result, err error) bool {
+	return err == nil && res != nil && strings.TrimSpace(res.Content) != ""
+}
+
+// runOCR invokes the OCR backend and normalizes the result, preferring the base
+// extractor's error over the OCR error when both fail so the original failure
+// reason is not masked.
+func runOCR(ctx context.Context, ocr OCR, data []byte, mime string, baseRes *Result, baseErr error) (*Result, error) {
+	ores, oerr := ocr.Extract(ctx, mime, data, false)
+	if oerr != nil {
+		if baseErr != nil {
+			return baseRes, baseErr
+		}
+		return nil, oerr
+	}
+	return NormalizeResult(ores)
+}
+
+func isImageMime(mime string) bool {
+	return strings.HasPrefix(mime, "image/")
+}
+
+// readForOCR reads a file and resolves its mime: extension first (authoritative
+// for the file's intent), content sniffing as a fallback. It does not error on an
+// unknown mime — the caller's isImageMime gate decides whether OCR applies.
+func readForOCR(path string) (data []byte, mime string, err error) {
+	data, err = os.ReadFile(path)
+	if err != nil {
+		return nil, "", err
+	}
+	if ext := filepath.Ext(path); ext != "" {
+		mime = gomime.TypeByExtension(ext)
+	}
+	if mime == "" {
+		mime = http.DetectContentType(data)
+	}
+	// TypeByExtension may append "; charset=..."; keep just the media type.
+	if i := strings.IndexByte(mime, ';'); i >= 0 {
+		mime = strings.TrimSpace(mime[:i])
+	}
+	return data, mime, nil
+}

--- a/internal/document/sidecar_test.go
+++ b/internal/document/sidecar_test.go
@@ -1,0 +1,135 @@
+package document
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// fakeBase is a base extractor with scripted output for both methods.
+type fakeBase struct {
+	res *Result
+	err error
+}
+
+func (f fakeBase) ExtractFile(context.Context, string, Options) (*Result, error) {
+	return f.res, f.err
+}
+
+func (f fakeBase) ExtractBytes(context.Context, []byte, string, Options) (*Result, error) {
+	return f.res, f.err
+}
+
+// fakeOCR records its calls and returns scripted text.
+type fakeOCR struct {
+	called bool
+	text   string
+	err    error
+}
+
+func (o *fakeOCR) Extract(_ context.Context, _ string, _ []byte, _ bool) (*Result, error) {
+	o.called = true
+	if o.err != nil {
+		return nil, o.err
+	}
+	return &Result{Content: o.text}, nil
+}
+
+func TestCompositeSkipsOCRWhenBaseHasText(t *testing.T) {
+	t.Cleanup(func() { SetLocalOCR(nil) })
+	ocr := &fakeOCR{text: "ocr text"}
+	SetLocalOCR(ocr)
+
+	c := compositeExtractor{base: fakeBase{res: &Result{Content: "real text"}}}
+	res, err := c.ExtractBytes(context.Background(), pngBytes(), "image/png", Options{})
+	if err != nil {
+		t.Fatalf("ExtractBytes: %v", err)
+	}
+	if res.Content != "real text" {
+		t.Fatalf("content = %q, want base text", res.Content)
+	}
+	if ocr.called {
+		t.Fatal("OCR ran even though the base produced text")
+	}
+}
+
+func TestCompositeFallsBackToOCRForImage(t *testing.T) {
+	t.Cleanup(func() { SetLocalOCR(nil) })
+	ocr := &fakeOCR{text: "scanned words"}
+	SetLocalOCR(ocr)
+
+	// Base returns empty for an image (no text layer) -> OCR should run.
+	c := compositeExtractor{base: fakeBase{res: &Result{Content: "  "}}}
+	res, err := c.ExtractBytes(context.Background(), pngBytes(), "image/png", Options{})
+	if err != nil {
+		t.Fatalf("ExtractBytes: %v", err)
+	}
+	if !ocr.called {
+		t.Fatal("OCR did not run for an empty-text image")
+	}
+	if res.Content != "scanned words" {
+		t.Fatalf("content = %q, want OCR text", res.Content)
+	}
+}
+
+func TestCompositeDoesNotOCRNonImage(t *testing.T) {
+	t.Cleanup(func() { SetLocalOCR(nil) })
+	ocr := &fakeOCR{text: "should not appear"}
+	SetLocalOCR(ocr)
+
+	// A text document that extracts to empty must not be re-run through OCR.
+	c := compositeExtractor{base: fakeBase{res: nil, err: ErrEmptyContent}}
+	_, err := c.ExtractBytes(context.Background(), []byte("plain text, not an image"), "text/plain", Options{})
+	if !errors.Is(err, ErrEmptyContent) {
+		t.Fatalf("err = %v, want ErrEmptyContent passthrough", err)
+	}
+	if ocr.called {
+		t.Fatal("OCR ran for a non-image input")
+	}
+}
+
+func TestCompositeNoOCRInstalled(t *testing.T) {
+	SetLocalOCR(nil) // explicit: nothing installed
+	c := compositeExtractor{base: fakeBase{res: nil, err: ErrUnavailable}}
+	_, err := c.ExtractBytes(context.Background(), pngBytes(), "image/png", Options{})
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("err = %v, want base error passthrough when no OCR", err)
+	}
+}
+
+func TestCompositeExtractFileOCR(t *testing.T) {
+	t.Cleanup(func() { SetLocalOCR(nil) })
+	ocr := &fakeOCR{text: "from file"}
+	SetLocalOCR(ocr)
+
+	path := filepath.Join(t.TempDir(), "scan.png")
+	if err := os.WriteFile(path, pngBytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c := compositeExtractor{base: fakeBase{res: &Result{Content: ""}}}
+	res, err := c.ExtractFile(context.Background(), path, Options{})
+	if err != nil {
+		t.Fatalf("ExtractFile: %v", err)
+	}
+	if !ocr.called || res.Content != "from file" {
+		t.Fatalf("OCR fallback failed: called=%v content=%q", ocr.called, res.Content)
+	}
+}
+
+// pngBytes returns a minimal valid 1x1 PNG so http.DetectContentType and the
+// image/* mime gate treat the payload as an image.
+func pngBytes() []byte {
+	return []byte{
+		0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, // PNG signature
+		0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52, // IHDR
+		0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+		0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+		0x89, 0x00, 0x00, 0x00, 0x0a, 0x49, 0x44, 0x41,
+		0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00,
+		0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00,
+		0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+		0x42, 0x60, 0x82,
+	}
+}

--- a/internal/document/xberg.go
+++ b/internal/document/xberg.go
@@ -11,7 +11,7 @@ import (
 
 type xbergExtractor struct{}
 
-func NewExtractor() Extractor {
+func newBaseExtractor() Extractor {
 	return xbergExtractor{}
 }
 

--- a/internal/mlruntime/runtime.go
+++ b/internal/mlruntime/runtime.go
@@ -34,16 +34,30 @@ const (
 	embedModelFile = "model_int8.onnx"
 	tokenizerFile  = "tokenizer.json"
 	binFile        = "stella-ml"
+
+	ocrDetFile  = "det.onnx"
+	ocrRecFile  = "rec.onnx"
+	ocrKeysFile = "rec_keys.txt"
 )
 
-// Resolved is the set of paths a supervisor needs to launch the sidecar.
+// Resolved is the set of paths a supervisor needs to launch the sidecar. The OCR
+// paths are empty when the OCR models are not installed; embedding and OCR are
+// independently optional.
 type Resolved struct {
 	BinPath        string // stella-ml executable
 	LibDir         string // directory holding libonnxruntime.{dylib,so}
 	EmbedModelPath string // e5 embedding model
 	TokenizerPath  string // tokenizer.json
+	OCRDetPath     string // PP-OCR detection model (optional)
+	OCRRecPath     string // PP-OCR recognition model (optional)
+	OCRKeysPath    string // PP-OCR rec character dictionary (optional)
 	RuntimeVersion string
 	ModelVersion   string
+}
+
+// HasOCR reports whether all three OCR assets resolved.
+func (r Resolved) HasOCR() bool {
+	return r.OCRDetPath != "" && r.OCRRecPath != "" && r.OCRKeysPath != ""
 }
 
 // Supported reports whether the current platform can run the sidecar at all.
@@ -102,6 +116,15 @@ func Resolve(stellaHome string) (Resolved, bool, error) {
 		if !fileExists(p) {
 			return Resolved{}, false, nil
 		}
+	}
+
+	// OCR is optional: fill its paths only when the full det+rec+keys set is present
+	// so a partial install never half-enables the extract endpoint.
+	det := filepath.Join(modelDir, ocrDetFile)
+	rec := filepath.Join(modelDir, ocrRecFile)
+	keys := filepath.Join(modelDir, ocrKeysFile)
+	if fileExists(det) && fileExists(rec) && fileExists(keys) {
+		r.OCRDetPath, r.OCRRecPath, r.OCRKeysPath = det, rec, keys
 	}
 	return r, true, nil
 }

--- a/internal/mlruntime/runtime_test.go
+++ b/internal/mlruntime/runtime_test.go
@@ -54,6 +54,49 @@ func TestResolveDevOverride(t *testing.T) {
 	}
 }
 
+func TestResolveOCROptional(t *testing.T) {
+	if !Supported() {
+		t.Skip("unsupported platform")
+	}
+	rt := t.TempDir()
+	md := t.TempDir()
+	mustWrite(t, filepath.Join(rt, binFile), "#!/bin/true\n")
+	if err := os.MkdirAll(filepath.Join(rt, "lib"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(md, embedModelFile), "x")
+	mustWrite(t, filepath.Join(md, tokenizerFile), "{}")
+	t.Setenv(EnvRuntimeDir, rt)
+	t.Setenv(EnvModelDir, md)
+
+	// Without OCR assets, embedding still resolves and HasOCR is false.
+	got, found, err := Resolve("/unused")
+	if err != nil || !found {
+		t.Fatalf("resolve embed-only: found=%v err=%v", found, err)
+	}
+	if got.HasOCR() {
+		t.Fatal("HasOCR true with no OCR models present")
+	}
+
+	// A partial OCR install (det only) must not half-enable OCR.
+	mustWrite(t, filepath.Join(md, ocrDetFile), "d")
+	got, _, _ = Resolve("/unused")
+	if got.HasOCR() {
+		t.Fatal("HasOCR true with a partial OCR install")
+	}
+
+	// Full det+rec+keys set enables OCR.
+	mustWrite(t, filepath.Join(md, ocrRecFile), "r")
+	mustWrite(t, filepath.Join(md, ocrKeysFile), "k")
+	got, _, _ = Resolve("/unused")
+	if !got.HasOCR() {
+		t.Fatal("HasOCR false with a full OCR install")
+	}
+	if got.OCRDetPath != filepath.Join(md, ocrDetFile) {
+		t.Errorf("det path = %q", got.OCRDetPath)
+	}
+}
+
 func mustWrite(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {


### PR DESCRIPTION
## What

Built-in local OCR on the document-extraction seam, served by the `stella-ml`
sidecar. Promotes the `paddleocr-onnx` POC (PP-OCRv5 mobile det+rec, ONNX) into
the sidecar and wires a real `POST /v1/extract`, then plugs it into
`internal/document.Extractor` as an image fallback.

Stacked on #598 (the embedding half). Base will retarget to `main` once #598 merges.

## Why

`stellad` is `CGO_ENABLED=0` and can't host onnxruntime, but the sidecar already
exists for embeddings. OCR rides the same process: offline, no API key, no network
egress. The read tool can now turn an unreadable image into text for non-vision
models without a remote OCR dependency.

## How

- **Sidecar** (`cmd/stella-ml`): long-lived `ocrEngine` (det+rec sessions reused),
  real `/v1/extract` — octet-stream image body + `X-Stella-Mime` → JSON
  `{content, mime_type}`. Image decode covers JPEG/PNG/GIF/WebP/BMP/TIFF. OCR is
  optional and all-or-nothing across det/rec/keys, so embedding-only bundles still
  boot (extract → 503).
- **Resolver** (`internal/mlruntime`): resolves `det.onnx`/`rec.onnx`/`rec_keys.txt`
  independently from the embed model; `Resolved.HasOCR()`.
- **Seam** (`internal/document`): single `NewExtractor()` wraps the build-tagged
  base extractor in a composite that falls back to sidecar OCR for image inputs the
  text layer can't read. Backend injected process-wide via `SetLocalOCR` (one
  factory, many construction sites). Adapter + `STELLA_LOCAL_OCR` toggle live in
  `setupMLSidecar`.

Verified end-to-end (darwin/arm64): composition root → `SetLocalOCR` →
`NewExtractor()` → sidecar OCR extracts a zh/en/digit page (124 chars). Unit tests
cover the composite (skip-when-text, image-fallback, non-image-skip, no-OCR
passthrough) and optional/partial OCR resolution. `format && build && test` green.

### Known MVP simplifications (→ Phase 4b)
- Axis-aligned bounding-rect detection; rotated/skewed crop (minAreaRect +
  perspective warp) deferred.
- No angle classifier (180°-flipped lines).
- Image-only; PDF rasterization is a separate adapter.
- Toggle is an env var; moves to deployment config + settings UI in a later phase.

## Refs

- #597 (native stella-ml sidecar: local OCR + embedding)
- Stacked on #598
