### PR TITLE
✨ feat(settings): local embedding provider + OCR toggle in the admin UI

### DIFF
--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -798,10 +798,24 @@ components:
       description: >
         Deployment-wide semantic-search configuration. The api_key is never returned; has_api_key reports whether one is stored.
 
-      required: [enabled, model, dim, base_url, normalize, has_api_key]
+      required: [
+        enabled,
+        provider,
+        model,
+        dim,
+        base_url,
+        normalize,
+        has_api_key,
+      ]
       properties:
         enabled:
           type: boolean
+        provider:
+          type: string
+          enum: [api, local]
+          description: >
+            api = remote OpenAI-compatible endpoint; local = the built-in multilingual-e5 model in the ML sidecar (no key, no network egress).
+
         model:
           type: string
         dim:
@@ -817,10 +831,13 @@ components:
       description: >
         Update payload for the embedding settings. api_key is write-only; omit it or send an empty string to keep the existing key.
 
-      required: [enabled, model, dim, base_url, normalize]
+      required: [enabled, provider, model, dim, base_url, normalize]
       properties:
         enabled:
           type: boolean
+        provider:
+          type: string
+          enum: [api, local]
         model:
           type: string
         dim:
@@ -1614,6 +1631,24 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/CachedModel"
+    OCRSettings:
+      type: object
+      description: >
+        Deployment-wide local-OCR configuration. When enabled, the read tool falls back to the built-in PP-OCRv5 model in the ML sidecar for images it cannot otherwise turn into text. available reports whether the OCR models are installed; enabling without them is accepted but stays a no-op.
+
+      required: [enabled, available]
+      properties:
+        enabled:
+          type: boolean
+        available:
+          type: boolean
+    OCRSettingsUpdate:
+      type: object
+      description: Update payload for the local-OCR settings.
+      required: [enabled]
+      properties:
+        enabled:
+          type: boolean
     PluginView:
       type: object
       properties:

--- a/api/spec/domain/embedding/schemas.yaml
+++ b/api/spec/domain/embedding/schemas.yaml
@@ -10,9 +10,23 @@ components:
       description: >
         Deployment-wide semantic-search configuration. The api_key is never
         returned; has_api_key reports whether one is stored.
-      required: [enabled, model, dim, base_url, normalize, has_api_key]
+      required: [
+        enabled,
+        provider,
+        model,
+        dim,
+        base_url,
+        normalize,
+        has_api_key,
+      ]
       properties:
         enabled: { type: boolean }
+        provider:
+          type: string
+          enum: [api, local]
+          description: >
+            api = remote OpenAI-compatible endpoint; local = the built-in
+            multilingual-e5 model in the ML sidecar (no key, no network egress).
         model: { type: string }
         dim: { type: integer }
         base_url: { type: string }
@@ -24,9 +38,12 @@ components:
       description: >
         Update payload for the embedding settings. api_key is write-only; omit it
         or send an empty string to keep the existing key.
-      required: [enabled, model, dim, base_url, normalize]
+      required: [enabled, provider, model, dim, base_url, normalize]
       properties:
         enabled: { type: boolean }
+        provider:
+          type: string
+          enum: [api, local]
         model: { type: string }
         dim: { type: integer }
         base_url: { type: string }

--- a/api/spec/domain/ocr/paths.yaml
+++ b/api/spec/domain/ocr/paths.yaml
@@ -1,0 +1,44 @@
+paths:
+  /api/ocr-settings:
+    get:
+      tags: [ocr]
+      summary: Get local-OCR settings (admin only)
+      operationId: getOCRSettings
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: {
+                $ref: "../../components.yaml#/components/schemas/OCRSettings",
+              }
+        "401": {
+          $ref: "../../components.yaml#/components/responses/Unauthorized",
+        }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+    put:
+      tags: [ocr]
+      summary: Update local-OCR settings (admin only)
+      operationId: updateOCRSettings
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {
+              $ref: "../../components.yaml#/components/schemas/OCRSettingsUpdate",
+            }
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema: {
+                $ref: "../../components.yaml#/components/schemas/OCRSettings",
+              }
+        "400": {
+          $ref: "../../components.yaml#/components/responses/BadRequest",
+        }
+        "401": {
+          $ref: "../../components.yaml#/components/responses/Unauthorized",
+        }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }

--- a/api/spec/domain/ocr/schemas.yaml
+++ b/api/spec/domain/ocr/schemas.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.3
+info:
+  title: OCR Components
+  version: "1"
+paths: {}
+components:
+  schemas:
+    OCRSettings:
+      type: object
+      description: >
+        Deployment-wide local-OCR configuration. When enabled, the read tool
+        falls back to the built-in PP-OCRv5 model in the ML sidecar for images it
+        cannot otherwise turn into text. available reports whether the OCR models
+        are installed; enabling without them is accepted but stays a no-op.
+      required: [enabled, available]
+      properties:
+        enabled: { type: boolean }
+        available: { type: boolean }
+
+    OCRSettingsUpdate:
+      type: object
+      description: Update payload for the local-OCR settings.
+      required: [enabled]
+      properties:
+        enabled: { type: boolean }

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -44,6 +44,7 @@ tags:
   - name: weixin
   - name: providers
   - name: embedding
+  - name: ocr
   - name: sessions
   - name: shares
   - name: agents
@@ -189,6 +190,9 @@ paths:
   # ── Embedding ──────────────────────────────────────────────────────────────
   /api/embedding-settings:
     $ref: "./domain/embedding/paths.yaml#/paths/~1api~1embedding-settings"
+  # ── OCR ────────────────────────────────────────────────────────────────────
+  /api/ocr-settings:
+    $ref: "./domain/ocr/paths.yaml#/paths/~1api~1ocr-settings"
   # ── Sessions ───────────────────────────────────────────────────────────────
   /api/agents/{agentId}/sessions:
     $ref: "./domain/sessions/paths.yaml#/paths/~1api~1agents~1{agentId}~1sessions"

--- a/cmd/stellad/commands.go
+++ b/cmd/stellad/commands.go
@@ -153,7 +153,7 @@ func setup(parent context.Context, _ bool) (*setupResult, error) {
 	// Native ML sidecar (local OCR/embedding). Resolved here so its local embedder
 	// can be injected into the embedding lane; started below once the background
 	// task group exists. nil when no runtime is installed (feature stays disabled).
-	mlSupervisor, mlLocalEmbed := setupMLSidecar(config.StellaHome(), slog.With("component", "ml"))
+	mlSupervisor, mlLocalEmbed := setupMLSidecar(config.StellaHome(), store, slog.With("component", "ml"))
 
 	// Semantic-search lane (config-driven via the web settings page). Always built:
 	// it reads its config from the DB at runtime and idles when disabled. Built

--- a/cmd/stellad/setup_ml.go
+++ b/cmd/stellad/setup_ml.go
@@ -3,9 +3,9 @@ package main
 import (
 	"context"
 	"log/slog"
-	"os"
 	"path/filepath"
 
+	"github.com/CherryHQ/stella/internal/config"
 	"github.com/CherryHQ/stella/internal/document"
 	"github.com/CherryHQ/stella/internal/embedding"
 	"github.com/CherryHQ/stella/internal/ml"
@@ -18,7 +18,11 @@ import (
 // features stay disabled with no error — the same graceful-degrade contract as an
 // unconfigured lane. Start the returned supervisor on the app context after the
 // background task group exists.
-func setupMLSidecar(stellaHome string, logger *slog.Logger) (*ml.Supervisor, embedding.LocalEmbedder) {
+//
+// store backs the runtime OCR toggle: when the OCR models are installed the engine
+// is always loaded, but each OCR-eligible read re-reads config.LoadOCRSettings, so
+// an admin can flip local OCR on/off from the settings UI without a restart.
+func setupMLSidecar(stellaHome string, store config.SettingStore, logger *slog.Logger) (*ml.Supervisor, embedding.LocalEmbedder) {
 	r, found, err := mlruntime.Resolve(stellaHome)
 	if err != nil {
 		logger.Warn("ml runtime resolve failed; local ML disabled", "err", err)
@@ -38,14 +42,15 @@ func setupMLSidecar(stellaHome string, logger *slog.Logger) (*ml.Supervisor, emb
 		"-tokenizer", r.TokenizerPath,
 		"-runtime-version", r.RuntimeVersion,
 	}
-	ocrWired := false
-	if r.HasOCR() && localOCREnabled() {
+	// Load OCR whenever the models are present; the enable/disable decision is a
+	// per-request config check below, not a boot-time flag, so the toggle is live.
+	// // always-load when installed; lazy load/unload if sidecar memory matters.
+	if r.HasOCR() {
 		args = append(args,
 			"-ocr-det-model", r.OCRDetPath,
 			"-ocr-rec-model", r.OCRRecPath,
 			"-ocr-keys", r.OCRKeysPath,
 		)
-		ocrWired = true
 	}
 	sup := ml.NewSupervisor(ml.SupervisorConfig{
 		BinPath:    r.BinPath,
@@ -54,36 +59,36 @@ func setupMLSidecar(stellaHome string, logger *slog.Logger) (*ml.Supervisor, emb
 	}, logger)
 
 	// Install the document-extraction OCR fallback as a process-wide capability so
-	// every read-tool extractor picks it up. Gated by STELLA_LOCAL_OCR for the MVP;
-	// the toggle moves to deployment config + the settings UI in a later phase.
-	if ocrWired {
-		document.SetLocalOCR(mlOCR{client: sup.Client(), tenant: "ocr"})
+	// every read-tool extractor picks it up. The adapter gates each call on the
+	// stored OCR setting, so this is a no-op until an admin enables it.
+	if r.HasOCR() {
+		document.SetLocalOCR(mlOCR{client: sup.Client(), tenant: "ocr", store: store})
 	}
 
-	logger.Info("native ML sidecar resolved", "bin", r.BinPath, "runtime", r.RuntimeVersion, "model", r.ModelVersion, "ocr", ocrWired)
+	logger.Info("native ML sidecar resolved", "bin", r.BinPath, "runtime", r.RuntimeVersion, "model", r.ModelVersion, "ocr", r.HasOCR())
 	return sup, mlLocalEmbedder{client: sup.Client(), tenant: "embedding"}
 }
 
-// localOCREnabled reports whether the operator opted into local OCR. Explicit
-// opt-in keeps OCR off by default even when the models happen to be installed.
-func localOCREnabled() bool {
-	switch os.Getenv("STELLA_LOCAL_OCR") {
-	case "1", "true", "yes", "on":
-		return true
-	default:
-		return false
-	}
-}
-
-// mlOCR adapts the sidecar client to document.OCR, mapping the sidecar's extract
-// result to a document.Result and pinning a fixed fairness tenant. // fixed tenant;
-// per-account once the read tool carries account context.
+// mlOCR adapts the sidecar client to document.OCR. It maps the sidecar's extract
+// result to a document.Result and gates each call on the stored OCR toggle so the
+// fallback stays off until an admin enables it. // fixed tenant; per-account once
+// the read tool carries account context.
 type mlOCR struct {
 	client *ml.Client
 	tenant string
+	store  config.SettingStore
 }
 
 func (o mlOCR) Extract(ctx context.Context, mime string, data []byte, forceOCR bool) (*document.Result, error) {
+	s, err := config.LoadOCRSettings(ctx, o.store)
+	if err != nil {
+		return nil, err
+	}
+	if !s.Enabled {
+		// Off by config: behave as if no OCR backend is installed so the composite
+		// extractor falls through to its base result.
+		return nil, document.ErrUnavailable
+	}
 	res, err := o.client.Extract(ctx, o.tenant, mime, data, forceOCR)
 	if err != nil {
 		return nil, err

--- a/cmd/stellad/setup_ml_integration_test.go
+++ b/cmd/stellad/setup_ml_integration_test.go
@@ -9,10 +9,25 @@ import (
 	"testing"
 	"time"
 
+	"github.com/CherryHQ/stella/internal/config"
 	"github.com/CherryHQ/stella/internal/document"
 	"github.com/CherryHQ/stella/internal/embedding"
 	"github.com/CherryHQ/stella/internal/mlruntime"
 )
+
+// memSettingStore is an in-memory config.SettingStore for the integration test.
+type memSettingStore struct{ m map[string]string }
+
+func newMemSettingStore() *memSettingStore { return &memSettingStore{m: map[string]string{}} }
+
+func (s *memSettingStore) GetSetting(_ context.Context, key string) (string, error) {
+	return s.m[key], nil
+}
+
+func (s *memSettingStore) SetSetting(_ context.Context, key, value string) error {
+	s.m[key] = value
+	return nil
+}
 
 // TestSetupMLSidecarIntegration drives the full stellad-side wiring against a real
 // stella-ml binary: resolve -> supervisor -> LocalEmbedder adapter -> e5 vector.
@@ -60,14 +75,17 @@ func TestSetupMLSidecarIntegration(t *testing.T) {
 	det, rec, keys := os.Getenv("STELLA_ML_OCR_DET"), os.Getenv("STELLA_ML_OCR_REC"), os.Getenv("STELLA_ML_OCR_KEYS")
 	ocrImage := os.Getenv("STELLA_ML_OCR_IMAGE")
 	testOCR := det != "" && rec != "" && keys != "" && ocrImage != ""
+	store := newMemSettingStore()
 	if testOCR {
 		symlink(t, det, filepath.Join(mdDir, "det.onnx"))
 		symlink(t, rec, filepath.Join(mdDir, "rec.onnx"))
 		symlink(t, keys, filepath.Join(mdDir, "rec_keys.txt"))
-		t.Setenv("STELLA_LOCAL_OCR", "1")
+		if err := config.SaveOCRSettings(context.Background(), store, config.OCRSettings{Enabled: true}); err != nil {
+			t.Fatal(err)
+		}
 	}
 
-	sup, emb := setupMLSidecar(home, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	sup, emb := setupMLSidecar(home, store, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	if sup == nil || emb == nil {
 		t.Fatal("expected a resolved supervisor + embedder")
 	}

--- a/internal/config/ocr.go
+++ b/internal/config/ocr.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// OCRSettingKey is the app_setting key under which the singleton local-OCR
+// configuration JSON is stored (same key-value mechanism as embedding settings).
+const OCRSettingKey = "ocr"
+
+// OCRSettings is the deployment-wide local-OCR configuration, edited in the web
+// settings page and stored as one JSON value in app_setting. Local OCR is opt-in:
+// with Enabled false (the default) the read tool never falls back to the built-in
+// model. Whether the OCR models are actually installed is a separate, runtime
+// concern reported alongside this setting by the API, not stored here.
+type OCRSettings struct {
+	Enabled bool `json:"enabled"`
+}
+
+// LoadOCRSettings reads the singleton local-OCR config. A missing row is not an
+// error — it means "never configured", which defaults to disabled.
+func LoadOCRSettings(ctx context.Context, store SettingStore) (OCRSettings, error) {
+	raw, err := store.GetSetting(ctx, OCRSettingKey)
+	if err != nil {
+		return OCRSettings{}, err
+	}
+	var s OCRSettings
+	if strings.TrimSpace(raw) != "" {
+		if err := json.Unmarshal([]byte(raw), &s); err != nil {
+			return OCRSettings{}, fmt.Errorf("parse ocr settings: %w", err)
+		}
+	}
+	return s, nil
+}
+
+// SaveOCRSettings persists the singleton local-OCR config.
+func SaveOCRSettings(ctx context.Context, store SettingStore, s OCRSettings) error {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return fmt.Errorf("marshal ocr settings: %w", err)
+	}
+	return store.SetSetting(ctx, OCRSettingKey, string(b))
+}

--- a/internal/config/ocr_test.go
+++ b/internal/config/ocr_test.go
@@ -1,0 +1,31 @@
+package config
+
+import (
+	"context"
+	"testing"
+)
+
+func TestLoadOCRSettings_DefaultsDisabled(t *testing.T) {
+	st := &fakeSettingStore{m: map[string]string{}}
+	got, err := LoadOCRSettings(context.Background(), st)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got.Enabled {
+		t.Error("unset deployment must default to OCR disabled")
+	}
+}
+
+func TestOCRSettings_RoundTrip(t *testing.T) {
+	st := &fakeSettingStore{m: map[string]string{}}
+	if err := SaveOCRSettings(context.Background(), st, OCRSettings{Enabled: true}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, err := LoadOCRSettings(context.Background(), st)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !got.Enabled {
+		t.Errorf("round-trip lost enabled: %+v", got)
+	}
+}

--- a/internal/server/embedding.go
+++ b/internal/server/embedding.go
@@ -32,6 +32,7 @@ func (s *Server) UpdateEmbeddingSettings(w http.ResponseWriter, r *http.Request)
 	}
 	var body struct {
 		Enabled   bool    `json:"enabled"`
+		Provider  string  `json:"provider"`
 		Model     string  `json:"model"`
 		Dim       int     `json:"dim"`
 		BaseURL   string  `json:"base_url"`
@@ -40,6 +41,14 @@ func (s *Server) UpdateEmbeddingSettings(w http.ResponseWriter, r *http.Request)
 	}
 	if err := decodeJSON(r, &body); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+
+	if body.Provider == "" {
+		body.Provider = config.EmbeddingProviderAPI
+	}
+	if body.Provider != config.EmbeddingProviderAPI && body.Provider != config.EmbeddingProviderLocal {
+		writeError(w, http.StatusBadRequest, "provider must be \"api\" or \"local\"")
 		return
 	}
 
@@ -65,6 +74,7 @@ func (s *Server) UpdateEmbeddingSettings(w http.ResponseWriter, r *http.Request)
 
 	next := config.EmbeddingSettings{
 		Enabled:   body.Enabled,
+		Provider:  body.Provider,
 		Model:     body.Model,
 		Dim:       body.Dim,
 		BaseURL:   body.BaseURL,
@@ -75,10 +85,10 @@ func (s *Server) UpdateEmbeddingSettings(w http.ResponseWriter, r *http.Request)
 		next.APIKey = *body.APIKey
 	}
 
-	// Enabling the lane without a key would silently no-op (the service treats a
-	// keyless config as disabled); reject it so the operator gets clear feedback.
-	if next.Enabled && next.APIKey == "" {
-		writeError(w, http.StatusBadRequest, "api_key is required to enable embedding")
+	// The api provider needs a key to do anything (a keyless config silently
+	// no-ops); the local provider runs the in-process sidecar model and needs none.
+	if next.Enabled && next.Provider == config.EmbeddingProviderAPI && next.APIKey == "" {
+		writeError(w, http.StatusBadRequest, "api_key is required to enable the api provider")
 		return
 	}
 
@@ -92,6 +102,7 @@ func (s *Server) UpdateEmbeddingSettings(w http.ResponseWriter, r *http.Request)
 func embeddingSettingsView(c config.EmbeddingSettings) map[string]any {
 	return map[string]any{
 		"enabled":     c.Enabled,
+		"provider":    c.Provider,
 		"model":       c.Model,
 		"dim":         c.Dim,
 		"base_url":    c.BaseURL,

--- a/internal/server/ocr.go
+++ b/internal/server/ocr.go
@@ -1,0 +1,60 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/CherryHQ/stella/internal/config"
+	"github.com/CherryHQ/stella/internal/mlruntime"
+)
+
+// GetOCRSettings returns the deployment-wide local-OCR configuration, plus whether
+// the OCR models are actually installed so the UI can warn when enabling would be
+// a no-op.
+func (s *Server) GetOCRSettings(w http.ResponseWriter, r *http.Request) {
+	if requireAdmin(w, r) == nil {
+		return
+	}
+	cfg, err := config.LoadOCRSettings(r.Context(), s.store)
+	if err != nil {
+		s.writeInternalError(w, err)
+		return
+	}
+	writeData(w, http.StatusOK, ocrSettingsView(cfg))
+}
+
+// UpdateOCRSettings persists the local-OCR configuration. The change takes effect
+// at runtime: the document extractor checks this setting on its next OCR-eligible
+// read, so no restart is needed.
+func (s *Server) UpdateOCRSettings(w http.ResponseWriter, r *http.Request) {
+	if requireAdmin(w, r) == nil {
+		return
+	}
+	var body struct {
+		Enabled bool `json:"enabled"`
+	}
+	if err := decodeJSON(r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	next := config.OCRSettings{Enabled: body.Enabled}
+	if err := config.SaveOCRSettings(r.Context(), s.store, next); err != nil {
+		s.writeInternalError(w, err)
+		return
+	}
+	writeData(w, http.StatusOK, ocrSettingsView(next))
+}
+
+func ocrSettingsView(c config.OCRSettings) map[string]any {
+	return map[string]any{
+		"enabled":   c.Enabled,
+		"available": ocrModelsInstalled(),
+	}
+}
+
+// ocrModelsInstalled reports whether the sidecar OCR models resolved on this host.
+// A best-effort probe: a resolve error or a missing runtime both read as "not
+// installed", which is all the UI needs to decide whether to warn.
+func ocrModelsInstalled() bool {
+	r, found, err := mlruntime.Resolve(config.StellaHome())
+	return err == nil && found && r.HasOCR()
+}

--- a/web/src/features/embeddings/EmbeddingPage.tsx
+++ b/web/src/features/embeddings/EmbeddingPage.tsx
@@ -7,7 +7,16 @@ import { useI18n } from "@/lib/i18n";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
+import {
+  Select,
+  SelectItem,
+  SelectPopup,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { SettingsPageHeader } from "@/features/settings/SettingsPageHeader";
+
+type Provider = "api" | "local";
 
 type Toast = { message: string; type: "success" | "error" } | null;
 
@@ -34,6 +43,7 @@ export function EmbeddingPage() {
   // Form draft. The api_key is write-only: blank means "keep the stored key",
   // so we never seed it from the server (which only reports has_api_key).
   const [enabled, setEnabled] = useState(false);
+  const [provider, setProvider] = useState<Provider>("api");
   const [model, setModel] = useState("");
   const [dim, setDim] = useState("");
   const [baseURL, setBaseURL] = useState("");
@@ -46,12 +56,15 @@ export function EmbeddingPage() {
   useEffect(() => {
     if (!settings) return;
     setEnabled(settings.enabled);
+    setProvider(settings.provider);
     setModel(settings.model);
     setDim(String(settings.dim));
     setBaseURL(settings.base_url);
     setNormalize(settings.normalize);
     setApiKey("");
   }, [settings]);
+
+  const isLocal = provider === "local";
 
   const showToast = useCallback((message: string, type: "success" | "error" = "success") => {
     setToast({ message, type });
@@ -64,6 +77,7 @@ export function EmbeddingPage() {
     mutationFn: async () => {
       const body: EmbeddingSettingsUpdate = {
         enabled,
+        provider,
         model: model.trim(),
         dim: Number(dim) || 0,
         base_url: baseURL.trim(),
@@ -83,12 +97,12 @@ export function EmbeddingPage() {
   });
 
   const onSave = useCallback(() => {
-    if (enabled && !hasStoredKey && !apiKey.trim()) {
+    if (enabled && !isLocal && !hasStoredKey && !apiKey.trim()) {
       showToast(t("embedding.apiKeyRequired"), "error");
       return;
     }
     save.mutate();
-  }, [enabled, hasStoredKey, apiKey, save, showToast, t]);
+  }, [enabled, isLocal, hasStoredKey, apiKey, save, showToast, t]);
 
   return (
     <div className="h-full overflow-y-auto bg-background">
@@ -109,74 +123,101 @@ export function EmbeddingPage() {
 
           <div className="border-t border-border" />
 
-          {/* Provider credentials */}
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div className="space-y-1.5 md:col-span-2">
-              <label className="block text-xs font-medium text-muted-foreground">
-                {t("embedding.apiKey")}
-              </label>
-              <Input
-                type="password"
-                value={apiKey}
-                onChange={(e) => setApiKey(e.target.value)}
-                placeholder={hasStoredKey ? t("embedding.apiKeyStored") : "sk-..."}
-                autoComplete="off"
-                nativeInput
-              />
-              <p className="text-xs text-muted-foreground">{t("embedding.apiKeyHint")}</p>
-            </div>
-
-            <div className="space-y-1.5 md:col-span-2">
-              <label className="block text-xs font-medium text-muted-foreground">
-                {t("embedding.baseURL")}
-              </label>
-              <Input
-                value={baseURL}
-                onChange={(e) => setBaseURL(e.target.value)}
-                placeholder="https://api.openai.com/v1"
-                nativeInput
-              />
-              <p className="text-xs text-muted-foreground">{t("embedding.baseURLHint")}</p>
-            </div>
-
-            <div className="space-y-1.5">
-              <label className="block text-xs font-medium text-muted-foreground">
-                {t("embedding.model")}
-              </label>
-              <Input
-                value={model}
-                onChange={(e) => setModel(e.target.value)}
-                placeholder="text-embedding-3-small"
-                nativeInput
-              />
-            </div>
-
-            <div className="space-y-1.5">
-              <label className="block text-xs font-medium text-muted-foreground">
-                {t("embedding.dim")}
-              </label>
-              <Input
-                type="number"
-                value={dim}
-                onChange={(e) => setDim(e.target.value)}
-                placeholder="1536"
-                min={1}
-                nativeInput
-              />
-              <p className="text-xs text-muted-foreground">{t("embedding.dimHint")}</p>
-            </div>
-          </div>
-
-          {/* Normalize toggle */}
+          {/* Provider selector */}
           <div className="flex items-start justify-between gap-4">
-            <div className="space-y-1">
-              <h2 className="text-sm font-semibold text-foreground">
-                {t("embedding.normalizeTitle")}
-              </h2>
-              <p className="text-xs text-muted-foreground">{t("embedding.normalizeHint")}</p>
+            <div className="space-y-1 max-w-md">
+              <h2 className="text-sm font-semibold text-foreground">{t("embedding.provider")}</h2>
+              <p className="text-xs text-muted-foreground">{t("embedding.providerHint")}</p>
             </div>
-            <Switch checked={normalize} onCheckedChange={setNormalize} />
+            <Select value={provider} onValueChange={(v) => setProvider(v as Provider)}>
+              <SelectTrigger size="sm" className="w-40">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectPopup>
+                <SelectItem value="api">{t("embedding.providerApi")}</SelectItem>
+                <SelectItem value="local">{t("embedding.providerLocal")}</SelectItem>
+              </SelectPopup>
+            </Select>
           </div>
+
+          {isLocal ? (
+            <p className="rounded-lg border border-border bg-muted/40 px-4 py-3 text-xs text-muted-foreground">
+              {t("embedding.localNote")}
+            </p>
+          ) : null}
+
+          {/* Provider credentials (API provider only) */}
+          {!isLocal ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="space-y-1.5 md:col-span-2">
+                <label className="block text-xs font-medium text-muted-foreground">
+                  {t("embedding.apiKey")}
+                </label>
+                <Input
+                  type="password"
+                  value={apiKey}
+                  onChange={(e) => setApiKey(e.target.value)}
+                  placeholder={hasStoredKey ? t("embedding.apiKeyStored") : "sk-..."}
+                  autoComplete="off"
+                  nativeInput
+                />
+                <p className="text-xs text-muted-foreground">{t("embedding.apiKeyHint")}</p>
+              </div>
+
+              <div className="space-y-1.5 md:col-span-2">
+                <label className="block text-xs font-medium text-muted-foreground">
+                  {t("embedding.baseURL")}
+                </label>
+                <Input
+                  value={baseURL}
+                  onChange={(e) => setBaseURL(e.target.value)}
+                  placeholder="https://api.openai.com/v1"
+                  nativeInput
+                />
+                <p className="text-xs text-muted-foreground">{t("embedding.baseURLHint")}</p>
+              </div>
+
+              <div className="space-y-1.5">
+                <label className="block text-xs font-medium text-muted-foreground">
+                  {t("embedding.model")}
+                </label>
+                <Input
+                  value={model}
+                  onChange={(e) => setModel(e.target.value)}
+                  placeholder="text-embedding-3-small"
+                  nativeInput
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <label className="block text-xs font-medium text-muted-foreground">
+                  {t("embedding.dim")}
+                </label>
+                <Input
+                  type="number"
+                  value={dim}
+                  onChange={(e) => setDim(e.target.value)}
+                  placeholder="1536"
+                  min={1}
+                  nativeInput
+                />
+                <p className="text-xs text-muted-foreground">{t("embedding.dimHint")}</p>
+              </div>
+            </div>
+          ) : null}
+
+          {/* Normalize toggle (API provider only; the local model already L2-normalizes) */}
+          {!isLocal ? (
+            <div className="flex items-start justify-between gap-4">
+              <div className="space-y-1">
+                <h2 className="text-sm font-semibold text-foreground">
+                  {t("embedding.normalizeTitle")}
+                </h2>
+                <p className="text-xs text-muted-foreground">{t("embedding.normalizeHint")}</p>
+              </div>
+              <Switch checked={normalize} onCheckedChange={setNormalize} />
+            </div>
+          ) : null}
 
           <div className="flex justify-end pt-2">
             <Button size="sm" loading={save.isPending} onClick={onSave}>

--- a/web/src/features/ocr/OCRPage.tsx
+++ b/web/src/features/ocr/OCRPage.tsx
@@ -1,0 +1,90 @@
+import { useCallback, useEffect, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { updateOcrSettings } from "@/lib/api-client/sdk.gen";
+import { ocrSettingsQueryOptions } from "@/lib/queries/ocr";
+import { useI18n } from "@/lib/i18n";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { SettingsPageHeader } from "@/features/settings/SettingsPageHeader";
+
+type Toast = { message: string; type: "success" | "error" } | null;
+
+function ToastAlert({ toast }: { toast: Toast }) {
+  if (!toast) return null;
+  return (
+    <div
+      className={`fixed bottom-4 right-4 z-50 w-auto max-w-sm rounded-xl border px-4 py-3 text-sm ${
+        toast.type === "error"
+          ? "border-destructive/20 bg-destructive/10 text-destructive-foreground"
+          : "border-success/20 bg-success/10 text-success-foreground"
+      }`}
+    >
+      {toast.message}
+    </div>
+  );
+}
+
+export function OCRPage() {
+  const { t } = useI18n();
+  const queryClient = useQueryClient();
+  const { data: settings } = useQuery(ocrSettingsQueryOptions);
+
+  const [enabled, setEnabled] = useState(false);
+  const [toast, setToast] = useState<Toast>(null);
+
+  useEffect(() => {
+    if (!settings) return;
+    setEnabled(settings.enabled);
+  }, [settings]);
+
+  const showToast = useCallback((message: string, type: "success" | "error" = "success") => {
+    setToast({ message, type });
+    setTimeout(() => setToast(null), 3000);
+  }, []);
+
+  const available = settings?.available ?? false;
+
+  const save = useMutation({
+    mutationFn: async () => {
+      const { data } = await updateOcrSettings({ body: { enabled }, throwOnError: true });
+      return data;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["ocr-settings"] });
+      showToast(t("ocr.saved"));
+    },
+    onError: (e) => showToast(e instanceof Error ? e.message : t("ocr.saveFailed"), "error"),
+  });
+
+  return (
+    <div className="h-full overflow-y-auto bg-background">
+      <div className="mx-auto max-w-3xl p-6 sm:p-8 lg:p-10 space-y-8">
+        <SettingsPageHeader title={t("ocr.title")} description={t("ocr.description")} />
+
+        <section className="rounded-xl border border-border bg-card p-6 space-y-6">
+          <div className="flex items-start justify-between gap-4">
+            <div className="space-y-1">
+              <h2 className="text-sm font-semibold text-foreground">{t("ocr.enableTitle")}</h2>
+              <p className="text-xs text-muted-foreground">{t("ocr.enableHint")}</p>
+            </div>
+            <Switch checked={enabled} onCheckedChange={setEnabled} />
+          </div>
+
+          {enabled && !available ? (
+            <p className="rounded-lg border border-border bg-muted/40 px-4 py-3 text-xs text-muted-foreground">
+              {t("ocr.unavailable")}
+            </p>
+          ) : null}
+
+          <div className="flex justify-end pt-2">
+            <Button size="sm" loading={save.isPending} onClick={() => save.mutate()}>
+              {t("ocr.save")}
+            </Button>
+          </div>
+        </section>
+      </div>
+
+      <ToastAlert toast={toast} />
+    </div>
+  );
+}

--- a/web/src/features/settings/SettingsLayout.tsx
+++ b/web/src/features/settings/SettingsLayout.tsx
@@ -57,6 +57,27 @@ const settingsNav: {
         ),
       },
       {
+        id: "ocr",
+        label: "settings.nav.ocr",
+        href: "/settings/ocr",
+        adminOnly: true,
+        icon: (
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            className="w-4 h-4 shrink-0 opacity-50 group-[.active]/item:opacity-80"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M2.25 15.75l5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 0 0 1.5-1.5V6a1.5 1.5 0 0 0-1.5-1.5H3.75A1.5 1.5 0 0 0 2.25 6v12a1.5 1.5 0 0 0 1.5 1.5Zm10.5-11.25h.008v.008h-.008V8.25Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z"
+            />
+          </svg>
+        ),
+      },
+      {
         id: "agents",
         label: "settings.nav.agents",
         href: "/settings/agents",

--- a/web/src/lib/i18n/messages.ts
+++ b/web/src/lib/i18n/messages.ts
@@ -154,6 +154,13 @@ const en = {
   "embedding.enableTitle": "Enable semantic search",
   "embedding.enableHint":
     "Embed new content and fuse vector results into search. Changes take effect immediately, no restart needed.",
+  "embedding.provider": "Provider",
+  "embedding.providerHint":
+    "API uses a remote OpenAI-compatible endpoint. Local runs the built-in multilingual-e5 model in the ML sidecar — no key, no network egress (requires the local ML runtime installed).",
+  "embedding.providerApi": "API (remote)",
+  "embedding.providerLocal": "Local (built-in)",
+  "embedding.localNote":
+    "The local provider uses multilingual-e5-small (384-dim). Model, dimension, key, and base URL are managed for you.",
   "embedding.apiKey": "API key",
   "embedding.apiKeyStored": "•••••••• (stored, leave blank to keep)",
   "embedding.apiKeyHint": "Stored as-is. Leave blank to keep the existing key.",
@@ -170,7 +177,19 @@ const en = {
   "embedding.save": "Save",
   "embedding.saved": "Embedding settings saved",
   "embedding.saveFailed": "Failed to save embedding settings",
-  "embedding.apiKeyRequired": "An API key is required to enable embedding",
+  "embedding.apiKeyRequired": "An API key is required to enable the API provider",
+  "settings.nav.ocr": "Local OCR",
+  "ocr.title": "Local OCR",
+  "ocr.description":
+    "Read text from images the model can't view, using the built-in PP-OCRv5 model in the ML sidecar — fully offline, no API key.",
+  "ocr.enableTitle": "Enable local OCR",
+  "ocr.enableHint":
+    "When on, the read tool falls back to local OCR for images with no extractable text. Takes effect immediately, no restart needed.",
+  "ocr.unavailable":
+    "The OCR models are not installed on this host. Enabling has no effect until the local ML runtime with OCR models is present.",
+  "ocr.save": "Save",
+  "ocr.saved": "OCR settings saved",
+  "ocr.saveFailed": "Failed to save OCR settings",
   "settings.nav.about": "About",
 
   // About
@@ -1830,6 +1849,13 @@ const zh: Record<MessageKey, string> = {
     "配置语义搜索通道。开启后,记忆搜索会将向量相似度与关键词匹配融合;关闭时则只使用关键词搜索。",
   "embedding.enableTitle": "启用语义搜索",
   "embedding.enableHint": "为新内容生成向量并将向量结果融合进搜索。修改即时生效,无需重启。",
+  "embedding.provider": "提供方",
+  "embedding.providerHint":
+    "API 使用兼容 OpenAI 的远程接口;本地则在 ML sidecar 内运行内置的 multilingual-e5 模型 —— 无需密钥、不联网(需先安装本地 ML 运行时)。",
+  "embedding.providerApi": "API(远程)",
+  "embedding.providerLocal": "本地(内置)",
+  "embedding.localNote":
+    "本地提供方使用 multilingual-e5-small(384 维)。模型、维度、密钥与 Base URL 均由系统托管。",
   "embedding.apiKey": "API 密钥",
   "embedding.apiKeyStored": "•••••••• (已保存,留空则保留)",
   "embedding.apiKeyHint": "原样保存。留空则保留已有密钥。",
@@ -1843,7 +1869,18 @@ const zh: Record<MessageKey, string> = {
   "embedding.save": "保存",
   "embedding.saved": "嵌入设置已保存",
   "embedding.saveFailed": "保存嵌入设置失败",
-  "embedding.apiKeyRequired": "启用向量嵌入需要提供 API 密钥",
+  "embedding.apiKeyRequired": "启用 API 提供方需要提供 API 密钥",
+  "settings.nav.ocr": "本地 OCR",
+  "ocr.title": "本地 OCR",
+  "ocr.description":
+    "用 ML sidecar 内置的 PP-OCRv5 模型,从模型无法查看的图片中读取文字 —— 完全离线、无需 API 密钥。",
+  "ocr.enableTitle": "启用本地 OCR",
+  "ocr.enableHint":
+    "开启后,read 工具会对没有可提取文字的图片回退到本地 OCR。修改即时生效,无需重启。",
+  "ocr.unavailable": "本机未安装 OCR 模型。在安装带 OCR 模型的本地 ML 运行时之前,开启不会生效。",
+  "ocr.save": "保存",
+  "ocr.saved": "OCR 设置已保存",
+  "ocr.saveFailed": "保存 OCR 设置失败",
   "settings.nav.about": "关于",
 
   // About

--- a/web/src/lib/queries/ocr.ts
+++ b/web/src/lib/queries/ocr.ts
@@ -1,0 +1,10 @@
+import { queryOptions } from "@tanstack/react-query";
+import { getOcrSettings } from "@/lib/api-client/sdk.gen";
+
+export const ocrSettingsQueryOptions = queryOptions({
+  queryKey: ["ocr-settings"],
+  queryFn: async () => {
+    const { data } = await getOcrSettings({ throwOnError: true });
+    return data;
+  },
+});

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -31,6 +31,7 @@ import { Route as AppSettingsSkillsRouteImport } from './routes/_app/settings/sk
 import { Route as AppSettingsSandboxRouteImport } from './routes/_app/settings/sandbox'
 import { Route as AppSettingsProvidersRouteImport } from './routes/_app/settings/providers'
 import { Route as AppSettingsPluginsRouteImport } from './routes/_app/settings/plugins'
+import { Route as AppSettingsOcrRouteImport } from './routes/_app/settings/ocr'
 import { Route as AppSettingsEmbeddingRouteImport } from './routes/_app/settings/embedding'
 import { Route as AppSettingsCredentialsRouteImport } from './routes/_app/settings/credentials'
 import { Route as AppSettingsChannelsRouteImport } from './routes/_app/settings/channels'
@@ -185,6 +186,13 @@ const AppSettingsPluginsRoute = AppSettingsPluginsRouteImport.update({
   getParentRoute: () => AppSettingsRoute,
 } as any).lazy(() =>
   import('./routes/_app/settings/plugins.lazy').then((d) => d.Route),
+)
+const AppSettingsOcrRoute = AppSettingsOcrRouteImport.update({
+  id: '/ocr',
+  path: '/ocr',
+  getParentRoute: () => AppSettingsRoute,
+} as any).lazy(() =>
+  import('./routes/_app/settings/ocr.lazy').then((d) => d.Route),
 )
 const AppSettingsEmbeddingRoute = AppSettingsEmbeddingRouteImport.update({
   id: '/embedding',
@@ -499,6 +507,7 @@ export interface FileRoutesByFullPath {
   '/settings/channels': typeof AppSettingsChannelsRouteWithChildren
   '/settings/credentials': typeof AppSettingsCredentialsRouteWithChildren
   '/settings/embedding': typeof AppSettingsEmbeddingRoute
+  '/settings/ocr': typeof AppSettingsOcrRoute
   '/settings/plugins': typeof AppSettingsPluginsRouteWithChildren
   '/settings/providers': typeof AppSettingsProvidersRouteWithChildren
   '/settings/sandbox': typeof AppSettingsSandboxRoute
@@ -554,6 +563,7 @@ export interface FileRoutesByTo {
   '/settings/channels': typeof AppSettingsChannelsRouteWithChildren
   '/settings/credentials': typeof AppSettingsCredentialsRouteWithChildren
   '/settings/embedding': typeof AppSettingsEmbeddingRoute
+  '/settings/ocr': typeof AppSettingsOcrRoute
   '/settings/plugins': typeof AppSettingsPluginsRouteWithChildren
   '/settings/providers': typeof AppSettingsProvidersRouteWithChildren
   '/settings/sandbox': typeof AppSettingsSandboxRoute
@@ -614,6 +624,7 @@ export interface FileRoutesById {
   '/_app/settings/channels': typeof AppSettingsChannelsRouteWithChildren
   '/_app/settings/credentials': typeof AppSettingsCredentialsRouteWithChildren
   '/_app/settings/embedding': typeof AppSettingsEmbeddingRoute
+  '/_app/settings/ocr': typeof AppSettingsOcrRoute
   '/_app/settings/plugins': typeof AppSettingsPluginsRouteWithChildren
   '/_app/settings/providers': typeof AppSettingsProvidersRouteWithChildren
   '/_app/settings/sandbox': typeof AppSettingsSandboxRoute
@@ -674,6 +685,7 @@ export interface FileRouteTypes {
     | '/settings/channels'
     | '/settings/credentials'
     | '/settings/embedding'
+    | '/settings/ocr'
     | '/settings/plugins'
     | '/settings/providers'
     | '/settings/sandbox'
@@ -729,6 +741,7 @@ export interface FileRouteTypes {
     | '/settings/channels'
     | '/settings/credentials'
     | '/settings/embedding'
+    | '/settings/ocr'
     | '/settings/plugins'
     | '/settings/providers'
     | '/settings/sandbox'
@@ -788,6 +801,7 @@ export interface FileRouteTypes {
     | '/_app/settings/channels'
     | '/_app/settings/credentials'
     | '/_app/settings/embedding'
+    | '/_app/settings/ocr'
     | '/_app/settings/plugins'
     | '/_app/settings/providers'
     | '/_app/settings/sandbox'
@@ -988,6 +1002,13 @@ declare module '@tanstack/react-router' {
       path: '/plugins'
       fullPath: '/settings/plugins'
       preLoaderRoute: typeof AppSettingsPluginsRouteImport
+      parentRoute: typeof AppSettingsRoute
+    }
+    '/_app/settings/ocr': {
+      id: '/_app/settings/ocr'
+      path: '/ocr'
+      fullPath: '/settings/ocr'
+      preLoaderRoute: typeof AppSettingsOcrRouteImport
       parentRoute: typeof AppSettingsRoute
     }
     '/_app/settings/embedding': {
@@ -1421,6 +1442,7 @@ interface AppSettingsRouteChildren {
   AppSettingsChannelsRoute: typeof AppSettingsChannelsRouteWithChildren
   AppSettingsCredentialsRoute: typeof AppSettingsCredentialsRouteWithChildren
   AppSettingsEmbeddingRoute: typeof AppSettingsEmbeddingRoute
+  AppSettingsOcrRoute: typeof AppSettingsOcrRoute
   AppSettingsPluginsRoute: typeof AppSettingsPluginsRouteWithChildren
   AppSettingsProvidersRoute: typeof AppSettingsProvidersRouteWithChildren
   AppSettingsSandboxRoute: typeof AppSettingsSandboxRoute
@@ -1436,6 +1458,7 @@ const AppSettingsRouteChildren: AppSettingsRouteChildren = {
   AppSettingsChannelsRoute: AppSettingsChannelsRouteWithChildren,
   AppSettingsCredentialsRoute: AppSettingsCredentialsRouteWithChildren,
   AppSettingsEmbeddingRoute: AppSettingsEmbeddingRoute,
+  AppSettingsOcrRoute: AppSettingsOcrRoute,
   AppSettingsPluginsRoute: AppSettingsPluginsRouteWithChildren,
   AppSettingsProvidersRoute: AppSettingsProvidersRouteWithChildren,
   AppSettingsSandboxRoute: AppSettingsSandboxRoute,

--- a/web/src/routes/_app/settings/ocr.lazy.tsx
+++ b/web/src/routes/_app/settings/ocr.lazy.tsx
@@ -1,0 +1,6 @@
+import { createLazyFileRoute } from "@tanstack/react-router";
+import { OCRPage } from "@/features/ocr/OCRPage";
+
+export const Route = createLazyFileRoute("/_app/settings/ocr")({
+  component: OCRPage,
+});

--- a/web/src/routes/_app/settings/ocr.tsx
+++ b/web/src/routes/_app/settings/ocr.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { meQueryOptions } from "@/lib/queries/me";
+
+export const Route = createFileRoute("/_app/settings/ocr")({
+  beforeLoad: async ({ context: { queryClient } }) => {
+    const me = await queryClient.ensureQueryData(meQueryOptions);
+    if (!me?.is_admin) throw redirect({ to: "/settings/agents" });
+  },
+});


### PR DESCRIPTION
## What

Expose the two local-ML controls in the admin settings UI + API, so a local-only
deployment is configurable without touching the DB or env vars:

- **Embedding provider** (`api` | `local`) on the existing embedding settings page.
- **Local OCR** toggle on a new settings page, backed by `/api/ocr-settings`.

Stacked on #600 (OCR sidecar). Base retargets down the chain to `main` as the
lower PRs merge.

## Why

Phase 3/4 made local embedding + OCR work, but reaching them meant editing the
`embedding` config row by hand and setting `STELLA_LOCAL_OCR`. Neither is
discoverable. This makes the whole local-ML story usable from the UI an admin
actually sees.

## How

- **Embedding**: added `provider` to the `EmbeddingSettings`/`...Update` schemas
  (enum api|local). Handler persists it and only requires an API key for the `api`
  provider. UI adds a provider `Select`; choosing **Local** hides the
  key/base-url/model/dim fields (the built-in e5 model manages them) and the
  normalize toggle (the model already L2-normalizes).
- **OCR**: new `config.OCRSettings` singleton + `/api/ocr-settings` (admin), a
  Local OCR settings page, and a `available` flag so the UI warns when the models
  aren't installed. Wiring is now **dynamic**: the sidecar loads OCR models
  whenever they resolve, and the `mlOCR` adapter checks the stored toggle per call,
  so enabling/disabling needs no restart. The `STELLA_LOCAL_OCR` env gate is gone.

OpenAPI-first throughout (`generate:api` + `generate:ts-sdk`). EN+ZH i18n added.
Config round-trip tests; the env-gated full-stack OCR integration test now drives
the config toggle instead of the env var (verified: 124 chars extracted with the
toggle on). `format && build && test` green.

## Refs

- #597 (native stella-ml sidecar: local OCR + embedding)
- Stacked on #600 → #598
