### PR TITLE
🐛 fix(goal): enforce decomposition contract in-turn; render output as markdown

### DIFF
--- a/internal/goal/decompose.go
+++ b/internal/goal/decompose.go
@@ -215,6 +215,7 @@ func (s *GoalService) BeginDecomposition(ctx context.Context, id string) (sqlc.A
 		}
 		attemptNo := int(maxNo) + 1
 		input := buildInputContext(d, nil, nil, "", attemptNo)
+		input.MaxDepth = rootMaxDepth(ctx, q, d.RootID)
 		att, err := q.CreateAttempt(ctx, sqlc.CreateAttemptParams{
 			ID:              newID(),
 			GoalID:          d.ID,
@@ -307,6 +308,7 @@ func (s *GoalService) BeginAutoDecomposition(ctx context.Context, id string, enq
 		}
 		attemptNo := int(maxNo) + 1
 		input := buildInputContext(cur, nil, nil, "", attemptNo)
+		input.MaxDepth = rootMaxDepth(ctx, q, cur.RootID)
 		att, err := q.CreateAttempt(ctx, sqlc.CreateAttemptParams{
 			ID:              newID(),
 			GoalID:          cur.ID,
@@ -353,12 +355,20 @@ func (s *GoalService) BeginAutoDecomposition(ctx context.Context, id string, enq
 // SubmitDecomposition and ApprovePlan so a malformed plan is rejected at the
 // write boundary, not at materialize.
 func (s *GoalService) validateContent(ctx context.Context, d sqlc.AgentGoal, content DecompositionContent) error {
+	return ValidateDecomposition(content, int(d.Depth), rootMaxDepth(ctx, s.q, d.RootID))
+}
+
+// rootMaxDepth resolves the recursion ceiling from the root's convergence
+// policy, falling back to the default if the root or its policy is unreadable.
+// Shared by validateContent (the write-boundary guard) and the decomposition
+// mint sites (which freeze it into AttemptInput for in-turn validation).
+func rootMaxDepth(ctx context.Context, q *sqlc.Queries, rootID string) int {
 	maxDepth := defaultMaxDepth
-	if root, err := s.q.GetGoal(ctx, d.RootID); err == nil {
+	if root, err := q.GetGoal(ctx, rootID); err == nil {
 		var rp ConvergencePolicy
 		if err := unmarshalJSON(root.ConvergencePolicy, &rp); err == nil {
 			maxDepth = rp.Normalized().MaxDepth
 		}
 	}
-	return ValidateDecomposition(content, int(d.Depth), maxDepth)
+	return maxDepth
 }

--- a/internal/goal/evidence.go
+++ b/internal/goal/evidence.go
@@ -19,6 +19,11 @@ type AttemptInput struct {
 	Contract        AcceptanceContract `json:"contract"`                   // the bar the attempt must clear
 	ResolvedVerdict string             `json:"resolved_verdict,omitempty"` // a human answer that unblocked needs_verdict
 	AttemptNo       int                `json:"attempt_no"`
+	// MaxDepth is the root's recursion ceiling, frozen here so a decomposition
+	// attempt can validate its proposed plan in-turn (against parentDepth =
+	// goal.Depth) instead of only out-of-turn at SubmitDecomposition. Zero for
+	// non-decomposition attempts, which never decompose.
+	MaxDepth int `json:"max_depth,omitempty"`
 }
 
 // Evaluation carries the shortfalls from one acceptance fold; it feeds the next

--- a/internal/goal/executor.go
+++ b/internal/goal/executor.go
@@ -1,6 +1,7 @@
 package goal
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -157,7 +158,7 @@ func (e *workerExecutor) run(ctx context.Context, req ExecutorRequest) (Result, 
 
 	decompose := req.Attempt.Purpose == PurposeDecomposition
 	rec := &terminalRecorder{}
-	ctTool := newRecordingControlTool(rec, decompose, e.log)
+	ctTool := newRecordingControlTool(rec, decompose, int(req.Goal.Depth), req.Input.MaxDepth, e.log)
 	projectID := req.Goal.ProjectID.String
 
 	turn := func(prompt string) <-chan agent.Event {
@@ -415,12 +416,19 @@ type recordingControlTool struct {
 	rec       *terminalRecorder
 	decompose bool
 	log       *slog.Logger
+	// parentDepth/maxDepth let a decomposition action validate its proposed plan
+	// in-turn (the same ValidateDecomposition the write boundary runs), so a
+	// structurally-doomed plan is rejected back to the model for self-correction
+	// in the same turn instead of failing out-of-turn and burning budget.
+	parentDepth int
+	maxDepth    int
 }
 
 // newRecordingControlTool wires a recording tool for one attempt. decompose
-// switches the accepted action set to decomposition.
-func newRecordingControlTool(rec *terminalRecorder, decompose bool, log *slog.Logger) *recordingControlTool {
-	return &recordingControlTool{rec: rec, decompose: decompose, log: log}
+// switches the accepted action set to decomposition; parentDepth/maxDepth feed
+// in-turn decomposition validation (ignored for non-decomposition attempts).
+func newRecordingControlTool(rec *terminalRecorder, decompose bool, parentDepth, maxDepth int, log *slog.Logger) *recordingControlTool {
+	return &recordingControlTool{rec: rec, decompose: decompose, log: log, parentDepth: parentDepth, maxDepth: maxDepth}
 }
 
 func (t *recordingControlTool) Definition() tools.Definition {
@@ -442,7 +450,70 @@ func (t *recordingControlTool) Definition() tools.Definition {
 					},
 					"decomposition": map[string]any{
 						"type":        "object",
-						"description": "decompose: {children:[...], edges:[...]} per the decomposition schema.",
+						"description": "decompose: the proposed plan as children + sibling edges.",
+						"properties": map[string]any{
+							"children": map[string]any{
+								"type":        "array",
+								"description": "Child goals; at least one must have required=true.",
+								"items": map[string]any{
+									"type": "object",
+									"properties": map[string]any{
+										"key":      map[string]any{"type": "string", "description": "Stable unique id of this child within the plan; edges reference it."},
+										"title":    map[string]any{"type": "string"},
+										"intent":   map[string]any{"type": "string", "description": "What this child must accomplish."},
+										"kind":     map[string]any{"type": "string", "enum": []string{"leaf", "composite"}},
+										"required": map[string]any{"type": "boolean"},
+										"acceptance_contract": map[string]any{
+											"type":        "object",
+											"description": "How this child's output is judged.",
+											"properties": map[string]any{
+												"policy": map[string]any{"type": "string", "enum": []string{"deterministic_then_judgment", "all", "any"}},
+												"items": map[string]any{
+													"type": "array",
+													"items": map[string]any{
+														"type": "object",
+														"properties": map[string]any{
+															"id":        map[string]any{"type": "string"},
+															"kind":      map[string]any{"type": "string", "enum": []string{"deterministic", "judgment"}},
+															"required":  map[string]any{"type": "boolean"},
+															"command":   map[string]any{"type": "string", "description": "deterministic: shell check."},
+															"authority": map[string]any{"type": "string", "enum": []string{"agent", "human"}},
+															"rubric":    map[string]any{"type": "string", "description": "judgment: agent reviewer prompt."},
+															"prompt":    map[string]any{"type": "string", "description": "judgment: human verdict prompt."},
+														},
+													},
+												},
+											},
+										},
+										"convergence_policy": map[string]any{
+											"type": "object",
+											"properties": map[string]any{
+												"max_attempts": map[string]any{"type": "integer"},
+												"escalation":   map[string]any{"type": "string", "enum": []string{"block", "abandon"}},
+												"max_depth":    map[string]any{"type": "integer"},
+											},
+										},
+										"review_policy": map[string]any{"type": "string"},
+									},
+									"required": []string{"key", "title"},
+								},
+							},
+							"edges": map[string]any{
+								"type":        "array",
+								"description": "Sibling dependencies by child key: downstream depends on upstream.",
+								"items": map[string]any{
+									"type": "object",
+									"properties": map[string]any{
+										"downstream_key": map[string]any{"type": "string", "description": "Child key that depends on the upstream."},
+										"upstream_key":   map[string]any{"type": "string", "description": "Child key that must finish first."},
+										"kind":           map[string]any{"type": "string", "enum": []string{"hard", "soft"}},
+										"on_failure":     map[string]any{"type": "string", "enum": []string{"block", "fail", "ignore"}},
+									},
+									"required": []string{"downstream_key", "upstream_key"},
+								},
+							},
+						},
+						"required": []string{"children"},
 					},
 					"reason":    map[string]any{"type": "string", "description": "fail: error message."},
 					"retryable": map[string]any{"type": "boolean", "description": "fail: true if a retry may succeed."},
@@ -548,6 +619,18 @@ func (t *recordingControlTool) executeDecompose(action string, args map[string]a
 		if err != nil {
 			return "", err
 		}
+		// Validate in-turn against the same structural guards the write boundary
+		// runs (ValidateDecomposition), so a doomed plan is returned to the model
+		// for self-correction now rather than recorded ok and rejected out-of-turn.
+		maxDepth := t.maxDepth
+		if maxDepth <= 0 { // unset on an attempt minted before MaxDepth was frozen
+			maxDepth = defaultMaxDepth
+		}
+		if err := ValidateDecomposition(content, t.parentDepth, maxDepth); err != nil {
+			return "", fmt.Errorf("goal_control: decomposition rejected: %w; fix the plan and call goal_control again "+
+				"(need >=1 child with required=true, every edge key must match a child key, no cycles, "+
+				"composites need depth headroom and no deterministic acceptance items)", err)
+		}
 		ev := AttemptEvidence{Summary: stringArg(args, "summary")}
 		if err := t.rec.record(Result{Action: terminalDecompose, Evidence: ev, Decomposition: &content}); err != nil {
 			return "", err
@@ -610,9 +693,17 @@ func decodeDecomposition(v any) (DecompositionContent, error) {
 	if err != nil {
 		return DecompositionContent{}, fmt.Errorf("goal_control: decomposition not serialisable: %w", err)
 	}
+	// Strict decode: an unknown or misnamed field (e.g. edges using from/to/type
+	// instead of downstream_key/upstream_key/kind) is rejected in-turn with an
+	// actionable message rather than silently dropped — a dropped field used to
+	// produce empty edge keys that failed validation out-of-turn and burned budget.
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields()
 	var c DecompositionContent
-	if err := json.Unmarshal(b, &c); err != nil {
-		return DecompositionContent{}, fmt.Errorf("goal_control: decomposition not valid: %w", err)
+	if err := dec.Decode(&c); err != nil {
+		return DecompositionContent{}, fmt.Errorf("goal_control: decomposition has invalid or unknown fields "+
+			"(use children[].{key,title,intent,kind,required,acceptance_contract,convergence_policy} and "+
+			"edges[].{downstream_key,upstream_key,kind,on_failure}): %w", err)
 	}
 	return c, nil
 }

--- a/internal/goal/executor_routing_test.go
+++ b/internal/goal/executor_routing_test.go
@@ -36,7 +36,14 @@ func TestExecutorRoutesDecomposeFlag(t *testing.T) {
 				// the attempt resolves without a real agent runtime.
 				args := map[string]any{"action": tc.action}
 				if tc.action == "decompose" {
-					args["decomposition"] = map[string]any{"children": []any{}, "edges": []any{}}
+					// A minimal plan that clears in-turn ValidateDecomposition (>=1
+					// required child); this test only pins the Decompose routing flag.
+					args["decomposition"] = map[string]any{
+						"children": []any{map[string]any{
+							"key": "c1", "title": "t", "kind": "leaf", "required": true,
+						}},
+						"edges": []any{},
+					}
 				}
 				if _, err := p.ExtraTools[0].Execute(context.Background(), args); err != nil {
 					t.Errorf("control tool execute: %v", err)

--- a/web/src/features/goals/GoalPage.tsx
+++ b/web/src/features/goals/GoalPage.tsx
@@ -1219,9 +1219,29 @@ function AcceptedOutputView({ output }: { output: Record<string, unknown> }) {
   );
 }
 
-// Payload keys are agent-authored data fields (`test_items`, `name`), not UI
-// strings, so they can't go through i18n. Humanize them for display:
-// snake/kebab-case to spaced, first letter capitalized.
+// Payload keys are agent-authored data fields. Common deliverable field names
+// get a localized label; everything else humanizes the raw key (snake/kebab to
+// spaced, capitalized) since arbitrary agent keys can't all go through i18n.
+const FIELD_LABEL_KEY: Record<string, MessageKey> = {
+  report: "goals.fieldReport",
+  material: "goals.fieldMaterial",
+  materials: "goals.fieldMaterial",
+  result: "goals.fieldResult",
+  results: "goals.fieldResult",
+  summary: "goals.fieldSummary",
+  analysis: "goals.fieldAnalysis",
+  conclusion: "goals.fieldConclusion",
+  conclusions: "goals.fieldConclusion",
+  recommendation: "goals.fieldRecommendation",
+  recommendations: "goals.fieldRecommendation",
+  findings: "goals.fieldFindings",
+  content: "goals.fieldContent",
+  notes: "goals.fieldNotes",
+  plan: "goals.fieldPlan",
+  data: "goals.fieldData",
+  details: "goals.fieldDetails",
+};
+
 function humanizeKey(key: string) {
   const s = key.replace(/[_-]+/g, " ").trim();
   return s.charAt(0).toUpperCase() + s.slice(1);
@@ -1230,6 +1250,7 @@ function humanizeKey(key: string) {
 // JsonView renders arbitrary JSON as readable structure: objects as labelled
 // rows, arrays as stacked cards, primitives as plain text — no raw dump.
 function JsonView({ value }: { value: unknown }) {
+  const { t } = useI18n();
   if (value === null || value === undefined) {
     return <span className="text-muted-foreground">—</span>;
   }
@@ -1253,7 +1274,9 @@ function JsonView({ value }: { value: unknown }) {
         {entries.map(([k, v]) => (
           <div key={k} className="flex flex-col gap-0.5 sm:flex-row sm:gap-3">
             <dt className="shrink-0 text-[11.5px] font-medium text-muted-foreground sm:w-36">
-              {humanizeKey(k)}
+              {FIELD_LABEL_KEY[k.toLowerCase()]
+                ? t(FIELD_LABEL_KEY[k.toLowerCase()])
+                : humanizeKey(k)}
             </dt>
             <dd className="min-w-0 flex-1 text-[12.5px] text-foreground">
               <JsonView value={v} />
@@ -1263,11 +1286,16 @@ function JsonView({ value }: { value: unknown }) {
       </dl>
     );
   }
-  return (
-    <span className="break-words text-[12.5px] text-foreground">
-      {typeof value === "string" ? value : JSON.stringify(value)}
-    </span>
-  );
+  if (typeof value === "string") {
+    // Agent prose (reports, analyses) arrives as one string with newlines and
+    // markdown; render it as markdown so headings/tables/lists are readable
+    // instead of a raw wall of text. Short single-line values stay plain.
+    if (value.includes("\n")) {
+      return <MarkdownPreview content={value} className="text-[12.5px]" />;
+    }
+    return <span className="break-words text-[12.5px] text-foreground">{value}</span>;
+  }
+  return <span className="break-words text-[12.5px] text-foreground">{JSON.stringify(value)}</span>;
 }
 
 // ── Shared ───────────────────────────────────────────────────────────

--- a/web/src/lib/i18n/messages.ts
+++ b/web/src/lib/i18n/messages.ts
@@ -897,6 +897,21 @@ const en = {
   "goals.outputResult": "Result",
   "goals.outputArtifacts": "Artifacts",
 
+  // Goals — common agent-authored output field labels (humanized fallback for unknown keys)
+  "goals.fieldReport": "Report",
+  "goals.fieldMaterial": "Material",
+  "goals.fieldResult": "Result",
+  "goals.fieldSummary": "Summary",
+  "goals.fieldAnalysis": "Analysis",
+  "goals.fieldConclusion": "Conclusion",
+  "goals.fieldRecommendation": "Recommendation",
+  "goals.fieldFindings": "Findings",
+  "goals.fieldContent": "Content",
+  "goals.fieldNotes": "Notes",
+  "goals.fieldPlan": "Plan",
+  "goals.fieldData": "Data",
+  "goals.fieldDetails": "Details",
+
   // Goals — new (create form)
   "goals.new": "New goal",
   "goals.newTitle": "Title",
@@ -2560,6 +2575,21 @@ const zh: Record<MessageKey, string> = {
   "goals.outputHash": "哈希",
   "goals.outputResult": "结果",
   "goals.outputArtifacts": "产物文件",
+
+  // Goals — common agent-authored output field labels (humanized fallback for unknown keys)
+  "goals.fieldReport": "报告",
+  "goals.fieldMaterial": "材料",
+  "goals.fieldResult": "结果",
+  "goals.fieldSummary": "摘要",
+  "goals.fieldAnalysis": "分析",
+  "goals.fieldConclusion": "结论",
+  "goals.fieldRecommendation": "建议",
+  "goals.fieldFindings": "发现",
+  "goals.fieldContent": "内容",
+  "goals.fieldNotes": "备注",
+  "goals.fieldPlan": "计划",
+  "goals.fieldData": "数据",
+  "goals.fieldDetails": "详情",
 
   // Goals — new (create form)
   "goals.new": "新建目标",


### PR DESCRIPTION
## What
Fix composite goals getting stuck pending because decomposition deterministically fails and burns budget, and make accepted goal output readable in the UI.

Closes #603.

## Why
The planner LLM's decomposition was validated *out-of-turn* (`SubmitDecomposition`), so the model never saw why a plan was rejected. With a loose `goal_control` tool schema and a lossy decode that silently dropped misnamed fields (`from/to/type` → empty `downstream_key/upstream_key`), a non-deterministic producer error turned into a deterministic failure that exhausted the decomposition budget and parked the goal forever. Separately, completed deliverables rendered as an unreadable raw-text blob with English field labels.

## How
**Backend (`internal/goal/`)** — move the producer contract into the turn:
- Tighten the decompose tool schema with full nested `children`/`edges`/`acceptance_contract` so field names and enums are constrained at the source.
- Strict-decode the decomposition (`DisallowUnknownFields`): a misnamed field is now an in-turn, actionable error instead of a silent drop.
- Run `ValidateDecomposition` in-turn so a structurally doomed plan is returned to the planner for self-correction in the same turn rather than failing out-of-turn and consuming budget. `MaxDepth` is frozen into `AttemptInput` at mint so the in-turn check matches the authoritative write-boundary guard.

**Web (`web/src/features/goals/`)**:
- `JsonView` renders multi-line string values as markdown via `MarkdownPreview` (reports/analyses show structure instead of a wall of text); short single-line values stay plain.
- Common agent-authored deliverable field names (report, material, result, summary, …) get localized labels, falling back to the humanized key.

## Verification
- `mise run format && mise run build && mise run test` — all green.
- `vp check` — 270 files clean.
- Live e2e (real LLM): composite goal ran `plan(decompose, first-call clean, zero retries) → subtasks(research → report, hard edge respected) → execute → verify(needs_verdict) → accepted (2/2)`. UI confirmed: report renders as markdown (headings/tables), field label shows localized "报告".

## Refs
- Root-cause analysis and the follow-up (agent auto-review for `needs_verdict`) tracked separately.