### PR TITLE
Wire agent auto-review for needs_verdict judgment items

### DIFF
--- a/internal/db/queries/agent_goal.sql
+++ b/internal/db/queries/agent_goal.sql
@@ -248,6 +248,17 @@ WHERE kind = 'composite'
 ORDER BY updated_at ASC
 LIMIT $1;
 
+-- name: ListGoalsBlockedNeedsVerdict :many
+-- Goals parked blocked(needs_verdict): a required judgment item has no valid
+-- verdict. The dispatcher (scanAndReview) drives an agent reviewer for any with a
+-- pending authority=agent item (contract section 10.13); the rest await a human.
+-- Both leaf and composite goals can carry an authored judgment contract.
+SELECT * FROM agent_goal
+WHERE lifecycle = 'blocked'
+  AND block_reason = 'needs_verdict'
+ORDER BY priority DESC, created_at ASC
+LIMIT $1;
+
 -- name: CancelGoal :exec
 UPDATE agent_goal SET
     lifecycle = 'cancelled',

--- a/internal/db/queries/agent_goal_attempt.sql
+++ b/internal/db/queries/agent_goal_attempt.sql
@@ -17,6 +17,20 @@ SELECT CAST(COALESCE(MAX(attempt_no), 0) AS BIGINT)
 FROM agent_goal_attempt
 WHERE goal_id = sqlc.arg(goal_id) AND purpose = sqlc.arg(purpose);
 
+-- name: CountRanReviewAttemptsForOutput :one
+-- Review attempts spent on the CURRENT needs_verdict episode: those created after
+-- the reviewed execution attempt (a later execution attempt starts a fresh
+-- episode) that actually ran (started_at set). A queued attempt reaped before it
+-- was promoted never ran and does not charge the budget, mirroring how a queued
+-- decomposition reap is refunded. This is the agent-review budget; attempt_no is
+-- still assigned globally per purpose via GetMaxAttemptNo.
+SELECT COUNT(*)
+FROM agent_goal_attempt
+WHERE goal_id = sqlc.arg(goal_id)
+  AND purpose = 'review'
+  AND started_at IS NOT NULL
+  AND created_at > sqlc.arg(since);
+
 -- name: ListAttemptByGoal :many
 SELECT * FROM agent_goal_attempt
 WHERE goal_id = sqlc.arg(goal_id)

--- a/internal/goal/acceptance.go
+++ b/internal/goal/acceptance.go
@@ -46,6 +46,27 @@ func DeriveAcceptance(c AcceptanceContract, currentOutputHash string, events []s
 	}
 }
 
+// PendingAgentReviewItems returns the required authority=agent judgment items
+// that still have no VALID event against the current output — the items the
+// agent auto-review producer must judge (contract §10.13). It is the same
+// latest-valid-by-item fold acceptance uses, filtered to agent-authored
+// judgment: an item with a stale verdict (scope_hash moved) reads as pending and
+// is re-requested. A resolved item (valid pass OR fail) is excluded — the fold
+// already accounts for it. Pure: no DB, no clock.
+func PendingAgentReviewItems(c AcceptanceContract, currentOutputHash string, events []sqlc.AgentGoalAcceptanceEvent) []AcceptanceItem {
+	if c.IsTrivial() {
+		return nil
+	}
+	latest := latestValidByItem(currentOutputHash, events)
+	var out []AcceptanceItem
+	for _, it := range c.AgentJudgmentItems() {
+		if _, ok := latest[it.ID]; !ok {
+			out = append(out, it)
+		}
+	}
+	return out
+}
+
 // itemOutcome is the salient outcome of the latest valid event for an item.
 type itemOutcome struct {
 	kind      string // ItemDeterministic | ItemJudgment
@@ -107,10 +128,11 @@ func evalAll(c AcceptanceContract, latest map[string]itemOutcome) Projection {
 		switch {
 		case !ok:
 			p.PendingItems = append(p.PendingItems, it.ID)
-			// Any pending required judgment item gates on a verdict. Agent-authored
-			// auto-review is not yet wired, so an authority=agent item also routes to
-			// a human verdict for now — consistent with the det-then-judgment path,
-			// which already blocks for a human on any pending judgment item.
+			// Any pending required judgment item gates on a verdict. The fold parks
+			// the goal NeedsVerdict regardless of authority; the dispatcher's
+			// scanAndReview then mints an agent reviewer for authority=agent items
+			// (contract §10.13) and falls back to a human verdict when none applies
+			// or the review budget is spent.
 			if it.Kind == ItemJudgment {
 				p.NeedsVerdict = true
 			}
@@ -137,10 +159,11 @@ func evalAny(c AcceptanceContract, latest map[string]itemOutcome) Projection {
 		switch {
 		case !ok:
 			p.PendingItems = append(p.PendingItems, it.ID)
-			// Any pending required judgment item gates on a verdict. Agent-authored
-			// auto-review is not yet wired, so an authority=agent item also routes to
-			// a human verdict for now — consistent with the det-then-judgment path,
-			// which already blocks for a human on any pending judgment item.
+			// Any pending required judgment item gates on a verdict. The fold parks
+			// the goal NeedsVerdict regardless of authority; the dispatcher's
+			// scanAndReview then mints an agent reviewer for authority=agent items
+			// (contract §10.13) and falls back to a human verdict when none applies
+			// or the review budget is spent.
 			if it.Kind == ItemJudgment {
 				p.NeedsVerdict = true
 			}

--- a/internal/goal/contract.go
+++ b/internal/goal/contract.go
@@ -8,6 +8,11 @@ const (
 	defaultMaxDepth    = 4
 	// defaultMaxConcurrent bounds breadth-of-fanout per root (§5).
 	defaultMaxConcurrent = 8
+	// defaultMaxReviewAttempts bounds how many agent auto-review attempts a goal
+	// gets per needs_verdict episode before degrading to a human verdict
+	// (contract §10.13). A reviewer that cannot produce a verdict after this many
+	// tries leaves the goal blocked(needs_verdict) for a human rather than looping.
+	defaultMaxReviewAttempts = 2
 )
 
 // AcceptanceContract is the composite policy tree of deterministic + judgment
@@ -62,6 +67,20 @@ func (c AcceptanceContract) HasDeterministicItem() bool {
 		}
 	}
 	return false
+}
+
+// AgentJudgmentItems returns the required judgment items resolved by a reviewer
+// agent (authority=agent) — the items the agent auto-review producer must answer
+// with a verdict (contract §10.13). A non-required or human-authority judgment
+// item is excluded; the former is advisory, the latter awaits a human verdict.
+func (c AcceptanceContract) AgentJudgmentItems() []AcceptanceItem {
+	var out []AcceptanceItem
+	for _, it := range c.Items {
+		if it.Required && it.Kind == ItemJudgment && it.Authority == AuthorityAgent {
+			out = append(out, it)
+		}
+	}
+	return out
 }
 
 // expectExit returns the item's expected exit code (default 0).

--- a/internal/goal/contract.go
+++ b/internal/goal/contract.go
@@ -8,10 +8,12 @@ const (
 	defaultMaxDepth    = 4
 	// defaultMaxConcurrent bounds breadth-of-fanout per root (§5).
 	defaultMaxConcurrent = 8
-	// defaultMaxReviewAttempts bounds how many agent auto-review attempts a goal
-	// gets per needs_verdict episode before degrading to a human verdict
-	// (contract §10.13). A reviewer that cannot produce a verdict after this many
-	// tries leaves the goal blocked(needs_verdict) for a human rather than looping.
+	// defaultMaxReviewAttempts bounds how many agent auto-review attempts are spent
+	// per needs_verdict episode — reviews of ONE execution output — before
+	// degrading to a human verdict (contract §10.13). A reviewer that cannot
+	// produce a verdict after this many tries against the same output leaves the
+	// goal blocked(needs_verdict) for a human. A rework that yields a new execution
+	// output starts a fresh episode with full budget (see CountRanReviewAttemptsForOutput).
 	defaultMaxReviewAttempts = 2
 )
 

--- a/internal/goal/converge.go
+++ b/internal/goal/converge.go
@@ -290,10 +290,11 @@ func (s *GoalService) FailAttempt(ctx context.Context, attemptID, reason string)
 			return s.recoverDecomposition(ctx, q, d, true)
 		}
 		if att.Purpose == PurposeReview {
-			// A failed review attempt leaves the goal blocked(needs_verdict): the
-			// dispatcher re-mints within the review budget, then degrades to a human
-			// verdict. The attempt is already finalized failed above; the failed
-			// attempt_no charges the review budget so a broken reviewer cannot loop.
+			// A failed review attempt (it ran but produced no usable verdict) leaves
+			// the goal blocked(needs_verdict): the dispatcher re-mints within the
+			// per-episode review budget, then degrades to a human. It is finalized
+			// failed above with started_at set, so it charges one budget unit
+			// (CountRanReviewAttemptsForOutput) and a broken reviewer cannot loop.
 			return nil
 		}
 		return s.branchOnFailure(ctx, q, d, attemptID, Evaluation{Gaps: []Gap{{Reason: reason}}})

--- a/internal/goal/converge.go
+++ b/internal/goal/converge.go
@@ -289,6 +289,13 @@ func (s *GoalService) FailAttempt(ctx context.Context, attemptID, reason string)
 			// one plan-budget unit.
 			return s.recoverDecomposition(ctx, q, d, true)
 		}
+		if att.Purpose == PurposeReview {
+			// A failed review attempt leaves the goal blocked(needs_verdict): the
+			// dispatcher re-mints within the review budget, then degrades to a human
+			// verdict. The attempt is already finalized failed above; the failed
+			// attempt_no charges the review budget so a broken reviewer cannot loop.
+			return nil
+		}
 		return s.branchOnFailure(ctx, q, d, attemptID, Evaluation{Gaps: []Gap{{Reason: reason}}})
 	})
 }

--- a/internal/goal/dispatcher.go
+++ b/internal/goal/dispatcher.go
@@ -360,6 +360,11 @@ func (d *Dispatcher) scanAndDecompose(ctx context.Context, _ time.Time) {
 // returns ErrInvalidTransition for goals awaiting a human, with no pending agent
 // item, or out of review budget — all skipped here. A nil enqueuer (test wiring)
 // skips dispatch, the same gate scanAndClaim/scanAndDecompose use.
+//
+// Review attempts are LLM jobs like execution attempts, so they share the per-root
+// and per-user concurrency caps (§5/§10.8): a user with many blocked goals can no
+// longer burst a review job for each one past their execution budget. A goal over
+// the cap stays blocked(needs_verdict) and is retried next tick once a slot frees.
 func (d *Dispatcher) scanAndReview(ctx context.Context, _ time.Time) {
 	if d.cfg.Enqueuer == nil {
 		return
@@ -369,16 +374,33 @@ func (d *Dispatcher) scanAndReview(ctx context.Context, _ time.Time) {
 		d.cfg.Logger.Warn("dispatcher: list needs-verdict goals", "err", err)
 		return
 	}
+	// Per-tick concurrency snapshot shared across the candidates, mirroring
+	// scanAndClaim: a minted review raises the in-flight count, so cache counts per
+	// root/user and bump locally to honor the cap across a burst within one tick.
+	rootInflight := map[string]int64{}
+	userInflight := map[string]int64{}
+
 	for _, goal := range candidates {
 		if d.isStopped() {
 			return
+		}
+		ok, err := d.underConcurrencyCap(ctx, goal, rootInflight, userInflight)
+		if err != nil {
+			d.cfg.Logger.Warn("dispatcher: review concurrency count", "goal", goal.ID, "err", err)
+			continue
+		}
+		if !ok {
+			continue // over the per-root or per-user budget; retry next tick
 		}
 		if _, err := d.cfg.Service.BeginReview(ctx, goal.ID, d.enqueueAttemptTx); err != nil {
 			if errors.Is(err, ErrInvalidTransition) {
 				continue // nothing to agent-review (human-only, budget spent, or raced)
 			}
 			d.cfg.Logger.Warn("dispatcher: begin review", "goal", goal.ID, "err", err)
+			continue
 		}
+		rootInflight[goal.RootID]++
+		userInflight[goal.UserID]++
 	}
 }
 

--- a/internal/goal/dispatcher.go
+++ b/internal/goal/dispatcher.go
@@ -120,6 +120,7 @@ func (d *Dispatcher) Tick(ctx context.Context) {
 	d.propagateDepFailures(ctx, now)
 	d.rollupComposites(ctx, now)
 	d.scanAndDecompose(ctx, now)
+	d.scanAndReview(ctx, now)
 	d.scanAndClaim(ctx, now)
 }
 
@@ -352,6 +353,35 @@ func (d *Dispatcher) scanAndDecompose(ctx context.Context, _ time.Time) {
 	}
 }
 
+// scanAndReview drives agent auto-review: every goal parked blocked(needs_verdict)
+// with a pending authority=agent item gets a headless purpose=review attempt
+// minted + enqueued in one tx, leaving the goal blocked until the verdict folds
+// in (contract §10.13). BeginReview re-checks eligibility under the row lock and
+// returns ErrInvalidTransition for goals awaiting a human, with no pending agent
+// item, or out of review budget — all skipped here. A nil enqueuer (test wiring)
+// skips dispatch, the same gate scanAndClaim/scanAndDecompose use.
+func (d *Dispatcher) scanAndReview(ctx context.Context, _ time.Time) {
+	if d.cfg.Enqueuer == nil {
+		return
+	}
+	candidates, err := d.cfg.Queries.ListGoalsBlockedNeedsVerdict(ctx, int32(d.cfg.BatchLimit))
+	if err != nil {
+		d.cfg.Logger.Warn("dispatcher: list needs-verdict goals", "err", err)
+		return
+	}
+	for _, goal := range candidates {
+		if d.isStopped() {
+			return
+		}
+		if _, err := d.cfg.Service.BeginReview(ctx, goal.ID, d.enqueueAttemptTx); err != nil {
+			if errors.Is(err, ErrInvalidTransition) {
+				continue // nothing to agent-review (human-only, budget spent, or raced)
+			}
+			d.cfg.Logger.Warn("dispatcher: begin review", "goal", goal.ID, "err", err)
+		}
+	}
+}
+
 // enqueueAttemptTx inserts the durable execution job for a claimed attempt inside
 // the claim's transaction (River Phase 2c). Passed to GoalService.Claim as the
 // AttemptEnqueuer so claim+enqueue are atomic; an error here aborts the claim.
@@ -500,6 +530,13 @@ func (s *GoalService) ReapAttempt(ctx context.Context, attemptID string) error {
 		// FinalizeAttempt) — do not reorder without revisiting this.
 		if att.Purpose == PurposeDecomposition {
 			return s.recoverDecomposition(ctx, q, d, att.Status == AttemptRunning)
+		}
+		// A reaped review attempt (orphaned / never picked up) leaves the goal
+		// blocked(needs_verdict); the dispatcher re-mints within the review budget,
+		// then degrades to a human verdict. The interrupted attempt_no charges the
+		// review budget — a queued reap costs one try but never loops the goal.
+		if att.Purpose == PurposeReview {
+			return nil
 		}
 
 		// A still-'queued' reap never executed: its River job sat behind the queue's

--- a/internal/goal/dispatcher.go
+++ b/internal/goal/dispatcher.go
@@ -531,10 +531,11 @@ func (s *GoalService) ReapAttempt(ctx context.Context, attemptID string) error {
 		if att.Purpose == PurposeDecomposition {
 			return s.recoverDecomposition(ctx, q, d, att.Status == AttemptRunning)
 		}
-		// A reaped review attempt (orphaned / never picked up) leaves the goal
-		// blocked(needs_verdict); the dispatcher re-mints within the review budget,
-		// then degrades to a human verdict. The interrupted attempt_no charges the
-		// review budget — a queued reap costs one try but never loops the goal.
+		// A reaped review attempt leaves the goal blocked(needs_verdict); the
+		// dispatcher re-mints within the per-episode review budget, then degrades to
+		// a human. A running reap (started_at set) charges one budget unit; a queued
+		// reap that never ran does not (CountRanReviewAttemptsForOutput filters on
+		// started_at), mirroring the queued-decomposition refund below.
 		if att.Purpose == PurposeReview {
 			return nil
 		}

--- a/internal/goal/evidence.go
+++ b/internal/goal/evidence.go
@@ -24,6 +24,11 @@ type AttemptInput struct {
 	// goal.Depth) instead of only out-of-turn at SubmitDecomposition. Zero for
 	// non-decomposition attempts, which never decompose.
 	MaxDepth int `json:"max_depth,omitempty"`
+	// ReviewItems / ReviewOutput are frozen onto a purpose=review attempt: the
+	// agent-authority judgment items the reviewer must answer and the execution
+	// output it judges (contract §10.13). Empty for non-review attempts.
+	ReviewItems  []AcceptanceItem `json:"review_items,omitempty"`
+	ReviewOutput *AttemptOutput   `json:"review_output,omitempty"`
 }
 
 // Evaluation carries the shortfalls from one acceptance fold; it feeds the next

--- a/internal/goal/evidence.go
+++ b/internal/goal/evidence.go
@@ -24,11 +24,15 @@ type AttemptInput struct {
 	// goal.Depth) instead of only out-of-turn at SubmitDecomposition. Zero for
 	// non-decomposition attempts, which never decompose.
 	MaxDepth int `json:"max_depth,omitempty"`
-	// ReviewItems / ReviewOutput are frozen onto a purpose=review attempt: the
-	// agent-authority judgment items the reviewer must answer and the execution
-	// output it judges (contract §10.13). Empty for non-review attempts.
-	ReviewItems  []AcceptanceItem `json:"review_items,omitempty"`
-	ReviewOutput *AttemptOutput   `json:"review_output,omitempty"`
+	// ReviewItems / ReviewOutput / ReviewedAttemptID are frozen onto a
+	// purpose=review attempt: the agent-authority judgment items the reviewer must
+	// answer, the execution output it judges, and the execution attempt that
+	// produced that output (contract §10.13). The reviewed id+hash pin the episode
+	// — SubmitReview binds verdicts to this output and refuses to fold if the
+	// evaluated output has moved since mint. Empty for non-review attempts.
+	ReviewItems       []AcceptanceItem `json:"review_items,omitempty"`
+	ReviewOutput      *AttemptOutput   `json:"review_output,omitempty"`
+	ReviewedAttemptID string           `json:"reviewed_attempt_id,omitempty"`
 }
 
 // Evaluation carries the shortfalls from one acceptance fold; it feeds the next

--- a/internal/goal/executor.go
+++ b/internal/goal/executor.go
@@ -35,6 +35,7 @@ const (
 	terminalBlock     TerminalAction = "block"
 	terminalFail      TerminalAction = "fail"
 	terminalDecompose TerminalAction = "decompose"
+	terminalVerdict   TerminalAction = "verdict"
 )
 
 // Blocker carries a block action's payload. The goal model resolves
@@ -62,6 +63,7 @@ type Result struct {
 	Evidence      AttemptEvidence
 	Output        AttemptOutput
 	Decomposition *DecompositionContent // purpose=decomposition only
+	Verdicts      []ReviewVerdict       // purpose=review only
 	Blocker       *Blocker
 	Failure       *Failure
 	// RepairAttempted is set when a text-only first turn triggered one bounded
@@ -157,8 +159,14 @@ func (e *workerExecutor) run(ctx context.Context, req ExecutorRequest) (Result, 
 	}
 
 	decompose := req.Attempt.Purpose == PurposeDecomposition
+	review := req.Attempt.Purpose == PurposeReview
 	rec := &terminalRecorder{}
-	ctTool := newRecordingControlTool(rec, decompose, int(req.Goal.Depth), req.Input.MaxDepth, e.log)
+	var ctTool *recordingControlTool
+	if review {
+		ctTool = newReviewControlTool(rec, req.Input.ReviewItems, e.log)
+	} else {
+		ctTool = newRecordingControlTool(rec, decompose, int(req.Goal.Depth), req.Input.MaxDepth, e.log)
+	}
 	projectID := req.Goal.ProjectID.String
 
 	turn := func(prompt string) <-chan agent.Event {
@@ -173,8 +181,15 @@ func (e *workerExecutor) run(ctx context.Context, req ExecutorRequest) (Result, 
 		})
 	}
 
+	firstPrompt := buildAttemptPrompt(req, decompose)
+	repairPrompt := func(text string) string { return buildRepairPrompt(text, decompose) }
+	if review {
+		firstPrompt = buildReviewPrompt(req)
+		repairPrompt = buildReviewRepairPrompt
+	}
+
 	// First turn against the frozen input context.
-	text, res, done, fail := e.runTurn(ctx, turn(buildAttemptPrompt(req, decompose)), rec)
+	text, res, done, fail := e.runTurn(ctx, turn(firstPrompt), rec)
 	if fail != nil {
 		return *fail, nil
 	}
@@ -190,7 +205,7 @@ func (e *workerExecutor) run(ctx context.Context, req ExecutorRequest) (Result, 
 		return Result{Action: terminalNone}, nil
 	}
 
-	_, res, done, fail = e.runTurn(ctx, turn(buildRepairPrompt(text, decompose)), rec)
+	_, res, done, fail = e.runTurn(ctx, turn(repairPrompt(text)), rec)
 	if fail != nil {
 		return *fail, nil
 	}
@@ -251,6 +266,12 @@ func foldResult(res Result, req ExecutorRequest) ExecutorResult {
 			Evidence:      res.Evidence,
 			Output:        res.Output,
 			Decomposition: res.Decomposition,
+		}
+	case terminalVerdict:
+		return ExecutorResult{
+			Submitted: true,
+			Evidence:  res.Evidence,
+			Verdicts:  res.Verdicts,
 		}
 	case terminalFail:
 		f := res.Failure
@@ -406,6 +427,67 @@ You MUST now call goal_control exactly once with one terminal action:
 Do not answer in plain text again.`
 }
 
+// buildReviewPrompt assembles the reviewer turn for a purpose=review attempt: the
+// goal intent, the submitted output under review, and each required
+// agent-authority item's rubric. The reviewer judges the output against each
+// item and reports a verdict via goal_control. It never edits the work — a
+// failing verdict feeds the next execution attempt as a gap.
+func buildReviewPrompt(req ExecutorRequest) string {
+	in := req.Input
+	var b strings.Builder
+	b.WriteString(`You are reviewing a completed Stella goal's output against its acceptance criteria.
+
+Protocol:
+- Judge ONLY whether the output below meets each criterion. Do not redo or edit the work.
+- You may use tools to verify claims.
+- Before ending this turn, you MUST call goal_control exactly once:
+  - action="verdict" with a "verdicts" array — one {item_id, pass, rationale} per criterion below.
+  - action="fail" with reason/retryable only if the output cannot be judged at all.
+
+Goal:
+`)
+	b.WriteString(strings.TrimSpace(in.Intent))
+
+	if out := in.ReviewOutput; out != nil {
+		b.WriteString("\n\nOutput under review:\n")
+		if s := strings.TrimSpace(out.Summary); s != "" {
+			b.WriteString(s + "\n")
+		}
+		if len(out.Result) > 0 {
+			if rb, err := json.Marshal(out.Result); err == nil {
+				b.WriteString("Structured result: " + string(rb) + "\n")
+			}
+		}
+	}
+
+	b.WriteString("\nCriteria to judge (return one verdict per item_id):\n")
+	for _, it := range in.ReviewItems {
+		line := "- item_id=" + it.ID
+		if r := strings.TrimSpace(it.Rubric); r != "" {
+			line += ": " + r
+		}
+		b.WriteString(line + "\n")
+	}
+	return b.String()
+}
+
+// buildReviewRepairPrompt is the single bounded correction turn for a reviewer
+// that answered in plain text without calling goal_control.
+func buildReviewRepairPrompt(priorText string) string {
+	return `Your previous response did not call goal_control, so this review is not recorded.
+
+Your previous message was:
+"""
+` + priorText + `
+"""
+
+You MUST now call goal_control exactly once:
+  - action="verdict" with a "verdicts" array of {item_id, pass, rationale} covering every criterion.
+  - action="fail" with reason/retryable only if the output cannot be judged.
+
+Do not answer in plain text again.`
+}
+
 // ── recording control tool ──────────────────────────────────────────────────
 
 // recordingControlTool is the agent-facing goal_control tool. It is PURE
@@ -422,6 +504,11 @@ type recordingControlTool struct {
 	// in the same turn instead of failing out-of-turn and burning budget.
 	parentDepth int
 	maxDepth    int
+	// review switches the accepted action set to verdict/fail; reviewItems are the
+	// required agent-authority judgment items the verdict must cover, validated
+	// in-turn (the same coverage the SubmitReview boundary expects).
+	review      bool
+	reviewItems []AcceptanceItem
 }
 
 // newRecordingControlTool wires a recording tool for one attempt. decompose
@@ -431,7 +518,17 @@ func newRecordingControlTool(rec *terminalRecorder, decompose bool, parentDepth,
 	return &recordingControlTool{rec: rec, decompose: decompose, log: log, parentDepth: parentDepth, maxDepth: maxDepth}
 }
 
+// newReviewControlTool wires a recording tool for a purpose=review attempt: the
+// accepted action set is verdict/fail and the proposed verdicts are validated
+// in-turn against the required agent-authority items.
+func newReviewControlTool(rec *terminalRecorder, reviewItems []AcceptanceItem, log *slog.Logger) *recordingControlTool {
+	return &recordingControlTool{rec: rec, review: true, reviewItems: reviewItems, log: log}
+}
+
 func (t *recordingControlTool) Definition() tools.Definition {
+	if t.review {
+		return t.reviewDefinition()
+	}
 	if t.decompose {
 		return ai.ToolDefinition{
 			Name:        "goal_control",
@@ -566,8 +663,50 @@ func (t *recordingControlTool) Definition() tools.Definition {
 	}
 }
 
+// reviewDefinition is the goal_control schema for a purpose=review attempt: a
+// verdict array covering each required agent-authority item, or a fail.
+func (t *recordingControlTool) reviewDefinition() tools.Definition {
+	return ai.ToolDefinition{
+		Name:        "goal_control",
+		Description: "Report review outcome. Call exactly one of verdict/fail before exiting.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"action": map[string]any{
+					"type":        "string",
+					"enum":        []string{"verdict", "fail"},
+					"description": "Which terminal action to take.",
+				},
+				"summary": map[string]any{
+					"type":        "string",
+					"description": "verdict: one-line summary of the review.",
+				},
+				"verdicts": map[string]any{
+					"type":        "array",
+					"description": "verdict: one entry per required item being reviewed.",
+					"items": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"item_id":   map[string]any{"type": "string", "description": "The acceptance item id this verdict answers."},
+							"pass":      map[string]any{"type": "boolean", "description": "true if the output satisfies the item."},
+							"rationale": map[string]any{"type": "string", "description": "Why it passes or fails; a fail rationale feeds the next attempt."},
+						},
+						"required": []string{"item_id", "pass"},
+					},
+				},
+				"reason":    map[string]any{"type": "string", "description": "fail: why the output cannot be judged."},
+				"retryable": map[string]any{"type": "boolean", "description": "fail: true if a retry may succeed."},
+			},
+			"required": []string{"action"},
+		},
+	}
+}
+
 func (t *recordingControlTool) Execute(ctx context.Context, args map[string]any) (string, error) {
 	action, _ := args["action"].(string)
+	if t.review {
+		return t.executeReview(action, args)
+	}
 	if t.decompose {
 		return t.executeDecompose(action, args)
 	}
@@ -649,6 +788,41 @@ func (t *recordingControlTool) executeDecompose(action string, args map[string]a
 	}
 }
 
+// executeReview handles the purpose=review action set: a verdict covering every
+// required agent-authority item, or a fail when the output cannot be judged.
+func (t *recordingControlTool) executeReview(action string, args map[string]any) (string, error) {
+	switch action {
+	case "verdict":
+		verdicts, err := decodeVerdicts(args["verdicts"])
+		if err != nil {
+			return "", err
+		}
+		// Validate in-turn: every required agent item must get exactly one verdict
+		// and no verdict may name an unknown item, so an incomplete review is
+		// returned to the model for self-correction now rather than appending a
+		// partial ledger that strands the goal pending out-of-turn.
+		if err := ValidateReviewVerdicts(verdicts, t.reviewItems); err != nil {
+			return "", fmt.Errorf("goal_control: review rejected: %w; provide exactly one verdict "+
+				"{item_id,pass,rationale} for each required item and call goal_control again", err)
+		}
+		ev := AttemptEvidence{Summary: stringArg(args, "summary")}
+		if err := t.rec.record(Result{Action: terminalVerdict, Evidence: ev, Verdicts: verdicts}); err != nil {
+			return "", err
+		}
+		return `{"ok":true,"recorded":"verdict"}`, nil
+	case "fail":
+		if err := t.rec.record(Result{Action: terminalFail, Failure: &Failure{
+			Reason:    stringArg(args, "reason"),
+			Retryable: boolArg(args, "retryable"),
+		}}); err != nil {
+			return "", err
+		}
+		return `{"ok":true,"recorded":"fail"}`, nil
+	default:
+		return "", fmt.Errorf("goal_control: unknown action %q", action)
+	}
+}
+
 // ── arg decoders ────────────────────────────────────────────────────────────
 
 func stringArg(args map[string]any, key string) string {
@@ -706,4 +880,56 @@ func decodeDecomposition(v any) (DecompositionContent, error) {
 			"edges[].{downstream_key,upstream_key,kind,on_failure}): %w", err)
 	}
 	return c, nil
+}
+
+// decodeVerdicts round-trips the loosely-typed verdicts arg into []ReviewVerdict.
+// A strict decode rejects unknown/misnamed fields in-turn (use item_id/pass/
+// rationale) rather than silently dropping them into an incomplete review.
+func decodeVerdicts(v any) ([]ReviewVerdict, error) {
+	if v == nil {
+		return nil, fmt.Errorf("goal_control: verdict requires a verdicts array")
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("goal_control: verdicts not serialisable: %w", err)
+	}
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields()
+	var out []ReviewVerdict
+	if err := dec.Decode(&out); err != nil {
+		return nil, fmt.Errorf("goal_control: verdicts have invalid or unknown fields "+
+			"(use verdicts[].{item_id,pass,rationale}): %w", err)
+	}
+	return out, nil
+}
+
+// ValidateReviewVerdicts checks a review covers exactly the required
+// agent-authority items: every required item has one verdict, no verdict names an
+// unknown item, and no item is judged twice. It is the in-turn mirror of the
+// coverage SubmitReview relies on so an incomplete review never reaches the
+// ledger (contract §10.13).
+func ValidateReviewVerdicts(verdicts []ReviewVerdict, items []AcceptanceItem) error {
+	want := make(map[string]bool, len(items))
+	for _, it := range items {
+		want[it.ID] = true
+	}
+	seen := make(map[string]bool, len(verdicts))
+	for _, v := range verdicts {
+		if v.ItemID == "" {
+			return fmt.Errorf("a verdict is missing item_id")
+		}
+		if !want[v.ItemID] {
+			return fmt.Errorf("verdict for unknown item %q", v.ItemID)
+		}
+		if seen[v.ItemID] {
+			return fmt.Errorf("duplicate verdict for item %q", v.ItemID)
+		}
+		seen[v.ItemID] = true
+	}
+	for id := range want {
+		if !seen[id] {
+			return fmt.Errorf("missing verdict for required item %q", id)
+		}
+	}
+	return nil
 }

--- a/internal/goal/judgment.go
+++ b/internal/goal/judgment.go
@@ -59,6 +59,25 @@ func HumanVerdictEvent(v HumanVerdict, item AcceptanceItem) sqlc.AppendAcceptanc
 	})
 }
 
+// AgentVerdictEvent builds the append params for a reviewer-agent verdict
+// (authority=agent, contract §10.13). evaluatedAttemptID is the execution
+// attempt whose output the verdict judges; reviewerAttemptID is the purpose=review
+// attempt that authored it; scopeHash binds the verdict to the judged output so a
+// later output edit invalidates it (§4.2). The fold already consumes these events
+// identically to a human verdict.
+func AgentVerdictEvent(goalID, itemID, evaluatedAttemptID, reviewerAttemptID, scopeHash string, pass bool, rationale string) sqlc.AppendAcceptanceEventParams {
+	return verdictEvent(verdictRow{
+		goalID:            goalID,
+		attemptID:         evaluatedAttemptID,
+		itemID:            itemID,
+		pass:              pass,
+		authority:         AuthorityAgent,
+		rationale:         rationale,
+		scopeHash:         scopeHash,
+		reviewerAttemptID: reviewerAttemptID,
+	})
+}
+
 // verdictRow is the shared input to verdictEvent for both authorities.
 type verdictRow struct {
 	goalID            string

--- a/internal/goal/review.go
+++ b/internal/goal/review.go
@@ -136,6 +136,17 @@ func (s *GoalService) pendingReviewWork(ctx context.Context, q *sqlc.Queries, d 
 	if len(contract.AgentJudgmentItems()) == 0 {
 		return nil, "", AttemptOutput{}, false // no agent items: a human verdict path
 	}
+	// Skip if a review attempt is already in flight. The goal STAYS
+	// blocked(needs_verdict) while the reviewer runs, so scanAndReview keeps
+	// listing it every tick; without this guard each tick would mint a fresh
+	// review session and only then collide on uniq_agent_goal_active_attempt,
+	// leaking a session per tick and spamming the log. One in-flight review per
+	// goal is enough -- its verdict folds the goal out of needs_verdict.
+	if _, err := q.GetActiveAttempt(ctx, sqlc.GetActiveAttemptParams{GoalID: d.ID, Purpose: PurposeReview}); err == nil {
+		return nil, "", AttemptOutput{}, false
+	} else if !errors.Is(err, pgx.ErrNoRows) {
+		return nil, "", AttemptOutput{}, false
+	}
 	execID, execOut := s.evaluatedAttempt(ctx, q, d)
 	events, err := q.ListAcceptanceEventByGoal(ctx, d.ID)
 	if err != nil {

--- a/internal/goal/review.go
+++ b/internal/goal/review.go
@@ -41,7 +41,10 @@ func (s *GoalService) BeginReview(ctx context.Context, id string, enqueue Attemp
 	}
 	// Cheap pre-checks before minting a session: skip goals awaiting a human, with
 	// no pending agent item, or out of review budget. Re-checked under the lock.
-	_, execID, _, ok := s.pendingReviewWork(ctx, s.q, d)
+	_, execID, _, ok, err := s.pendingReviewWork(ctx, s.q, d)
+	if err != nil {
+		return sqlc.AgentGoalAttempt{}, err
+	}
 	if !ok {
 		return sqlc.AgentGoalAttempt{}, ErrInvalidTransition
 	}
@@ -73,7 +76,10 @@ func (s *GoalService) BeginReview(ctx context.Context, id string, enqueue Attemp
 		if err != nil {
 			return err
 		}
-		items, execID, execOut, ok := s.pendingReviewWork(ctx, q, cur)
+		items, execID, execOut, ok, err := s.pendingReviewWork(ctx, q, cur)
+		if err != nil {
+			return err
+		}
 		if !ok {
 			return ErrInvalidTransition
 		}
@@ -128,17 +134,21 @@ func (s *GoalService) BeginReview(ctx context.Context, id string, enqueue Attemp
 
 // pendingReviewWork reports whether a goal needs an agent verdict and, if so, the
 // pending authority=agent items, the execution attempt whose output is judged,
-// and that output. ok is false unless the goal is blocked(needs_verdict) with at
-// least one pending agent item — a human-only or already-resolved goal is left
-// for its existing path. Pure of writes; safe to call with s.q or a tx querier.
-func (s *GoalService) pendingReviewWork(ctx context.Context, q *sqlc.Queries, d sqlc.AgentGoal) ([]AcceptanceItem, string, AttemptOutput, bool) {
+// and that output. ok is false (err nil) when the goal legitimately has no agent
+// review to do — awaiting a human, no pending agent item, no output to judge, or a
+// review already in flight; the caller skips it. A non-nil err is a real DB
+// failure: it must NOT be flattened to "nothing to review" (a bad connection would
+// masquerade as a healthy skip and the goal would silently never get reviewed),
+// so it bubbles up to be logged and retried next tick. Pure of writes; safe to
+// call with s.q or a tx querier.
+func (s *GoalService) pendingReviewWork(ctx context.Context, q *sqlc.Queries, d sqlc.AgentGoal) ([]AcceptanceItem, string, AttemptOutput, bool, error) {
 	if d.Lifecycle != LifecycleBlocked || d.BlockReason != BlockNeedsVerdict {
-		return nil, "", AttemptOutput{}, false
+		return nil, "", AttemptOutput{}, false, nil
 	}
 	var contract AcceptanceContract
 	_ = unmarshalJSON(d.AcceptanceContract, &contract)
 	if len(contract.AgentJudgmentItems()) == 0 {
-		return nil, "", AttemptOutput{}, false // no agent items: a human verdict path
+		return nil, "", AttemptOutput{}, false, nil // no agent items: a human verdict path
 	}
 	// Skip if a review attempt is already in flight. The goal STAYS
 	// blocked(needs_verdict) while the reviewer runs, so scanAndReview keeps
@@ -147,26 +157,26 @@ func (s *GoalService) pendingReviewWork(ctx context.Context, q *sqlc.Queries, d 
 	// leaking a session per tick and spamming the log. One in-flight review per
 	// goal is enough -- its verdict folds the goal out of needs_verdict.
 	if _, err := q.GetActiveAttempt(ctx, sqlc.GetActiveAttemptParams{GoalID: d.ID, Purpose: PurposeReview}); err == nil {
-		return nil, "", AttemptOutput{}, false
+		return nil, "", AttemptOutput{}, false, nil
 	} else if !errors.Is(err, pgx.ErrNoRows) {
-		return nil, "", AttemptOutput{}, false
+		return nil, "", AttemptOutput{}, false, fmt.Errorf("check in-flight review: %w", err)
 	}
 	execID, execOut := s.evaluatedAttempt(ctx, q, d)
 	if execID == "" {
 		// No submitted execution output to judge (e.g. a composite carrying an
 		// agent judgment item). There is nothing for a reviewer to score against, so
 		// leave it for a human verdict.
-		return nil, "", AttemptOutput{}, false
+		return nil, "", AttemptOutput{}, false, nil
 	}
 	events, err := q.ListAcceptanceEventByGoal(ctx, d.ID)
 	if err != nil {
-		return nil, "", AttemptOutput{}, false
+		return nil, "", AttemptOutput{}, false, fmt.Errorf("list acceptance events: %w", err)
 	}
 	items := PendingAgentReviewItems(contract, execOut.Hash, events)
 	if len(items) == 0 {
-		return nil, "", AttemptOutput{}, false // every agent item already has a valid verdict
+		return nil, "", AttemptOutput{}, false, nil // every agent item already has a valid verdict
 	}
-	return items, execID, execOut, true
+	return items, execID, execOut, true, nil
 }
 
 // frozenReviewHash returns the hash of the execution output a review attempt was
@@ -176,6 +186,28 @@ func frozenReviewHash(in AttemptInput) string {
 		return ""
 	}
 	return in.ReviewOutput.Hash
+}
+
+// reviewItemsStillCurrent reports whether every frozen review item is still a
+// required authority=agent judgment item in the goal's CURRENT contract. The fold
+// resolves verdicts against the live contract by item id alone, so a goal edit
+// that retyped an item (agent->human), made it non-required, or dropped it would
+// otherwise let a stale agent verdict satisfy a gate it no longer owns. Checked
+// under the goal lock at SubmitReview so the verdict binds to the contract the
+// reviewer was actually asked about.
+func reviewItemsStillCurrent(d sqlc.AgentGoal, frozen []AcceptanceItem) bool {
+	var c AcceptanceContract
+	_ = unmarshalJSON(d.AcceptanceContract, &c)
+	cur := make(map[string]struct{})
+	for _, it := range c.AgentJudgmentItems() {
+		cur[it.ID] = struct{}{}
+	}
+	for _, it := range frozen {
+		if _, ok := cur[it.ID]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 // reviewBudgetSpent counts agent-review attempts already spent on the CURRENT
@@ -231,6 +263,13 @@ func (s *GoalService) SubmitReview(ctx context.Context, attemptID string, ev Att
 			return fmt.Errorf("review verdicts reject: %w", err)
 		}
 
+		// Lock the goal so the staleness checks below see a stable snapshot: a
+		// concurrent human verdict, rework-claim, or goal edit cannot move the goal
+		// (or its evaluated output / contract) between the reads here and the fold.
+		// Mirrors BeginReview / ApprovePlan, which also lock + re-read under the lock.
+		if err := q.LockGoalForWrite(ctx, att.GoalID); err != nil {
+			return fmt.Errorf("lock goal for review submit: %w", err)
+		}
 		d, err := getGoal(ctx, q, att.GoalID)
 		if err != nil {
 			return err
@@ -248,14 +287,26 @@ func (s *GoalService) SubmitReview(ctx context.Context, attemptID string, ev Att
 			return ErrInvalidTransition // not the running attempt (reaped / raced)
 		}
 
-		// Bind to the EXACT execution output the reviewer judged (frozen at mint),
-		// not whatever evaluatedAttempt resolves now. If the evaluated output moved
-		// since mint (a rework produced a newer execution attempt while this review
-		// ran), the verdict is stale: the attempt is finalized above, but we do NOT
-		// append it or fold. The goal stays blocked(needs_verdict) and the dispatcher
-		// mints a fresh review against the new output (a new episode, full budget).
+		// Drop the verdict (attempt already finalized above) unless the goal still
+		// awaits exactly the episode the reviewer judged:
+		//   - still blocked(needs_verdict): a concurrent verdict/rework may have woken
+		//     it; folding now could move a goal that is no longer awaiting this verdict.
+		//   - evaluated output unchanged: a rework that produced a newer execution
+		//     attempt while this review ran makes the verdict stale (bind to the EXACT
+		//     output frozen at mint, not whatever evaluatedAttempt resolves now).
+		//   - frozen items are still required authority=agent items: a goal edit that
+		//     retyped an item (agent->human), dropped it, or made it non-required must
+		//     not let a stale agent verdict satisfy a different (or human) gate.
+		// On any mismatch the goal stays blocked(needs_verdict) and the dispatcher
+		// mints a fresh review against the current output (a new episode, full budget).
+		if d.Lifecycle != LifecycleBlocked || d.BlockReason != BlockNeedsVerdict {
+			return nil
+		}
 		curID, curOut := s.evaluatedAttempt(ctx, q, d)
 		if in.ReviewedAttemptID == "" || curID != in.ReviewedAttemptID || curOut.Hash != frozenReviewHash(in) {
+			return nil
+		}
+		if !reviewItemsStillCurrent(d, in.ReviewItems) {
 			return nil
 		}
 		for _, v := range verdicts {

--- a/internal/goal/review.go
+++ b/internal/goal/review.go
@@ -1,0 +1,200 @@
+package goal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/CherryHQ/stella/pkg/db/pgnull"
+	"github.com/CherryHQ/stella/pkg/db/sqlc"
+)
+
+// review.go is the agent auto-review producer (contract §10.13). A goal parks at
+// blocked(needs_verdict) whenever a required judgment item has no valid verdict;
+// for authority=agent items the dispatcher (scanAndReview) drives a reviewer
+// agent here instead of waiting for a human. The consumer half — folding an
+// authority=agent acceptance_event — already exists (judgment.go, acceptance.go);
+// this file mints the review attempt and turns its output into those events.
+//
+// The goal STAYS blocked(needs_verdict) while the review runs: the review is a
+// background producer, not an executing episode, and keeping active_attempt_id
+// cleared lets evaluatedAttempt keep scoping verdicts to the execution output's
+// hash. A passing review wakes the goal to accept; a failing one wakes it to
+// rework with the reviewer rationale fed in as a gap; a review that cannot
+// produce a verdict (or exhausts the small review budget) leaves the goal
+// blocked(needs_verdict) for a human (the chosen degradation).
+
+// BeginReview mints a headless purpose=review attempt for a goal parked at
+// blocked(needs_verdict) with a pending authority=agent item, and enqueues its
+// durable River job in ONE tx (mirrors BeginAutoDecomposition). It does NOT move
+// the goal's lifecycle — the goal stays blocked until the verdict folds in. A
+// fresh hidden session is minted per review so the reviewer never reads the
+// executor's working context. The dispatcher (scanAndReview) is the only caller;
+// ErrInvalidTransition means "nothing to review" (no agent item pending, budget
+// spent, or a race) and is ignored by the scan.
+func (s *GoalService) BeginReview(ctx context.Context, id string, enqueue AttemptEnqueuer) (sqlc.AgentGoalAttempt, error) {
+	d, err := getGoal(ctx, s.q, id)
+	if err != nil {
+		return sqlc.AgentGoalAttempt{}, err
+	}
+	// Cheap pre-checks before minting a session: skip goals awaiting a human, with
+	// no pending agent item, or out of review budget. Re-checked under the lock.
+	if _, _, _, ok := s.pendingReviewWork(ctx, s.q, d); !ok {
+		return sqlc.AgentGoalAttempt{}, ErrInvalidTransition
+	}
+	spent, err := s.q.GetMaxAttemptNo(ctx, sqlc.GetMaxAttemptNoParams{GoalID: d.ID, Purpose: PurposeReview})
+	if err != nil {
+		return sqlc.AgentGoalAttempt{}, fmt.Errorf("max review attempt no: %w", err)
+	}
+	if int(spent) >= defaultMaxReviewAttempts {
+		return sqlc.AgentGoalAttempt{}, ErrInvalidTransition // review budget spent; degrade to human
+	}
+
+	// Mint the review session OUTSIDE the tx (it opens its own tx and would
+	// self-deadlock against the held one). Reuse the worker-session minter: the
+	// review runs as a fresh hidden task session, same as an execution attempt.
+	if s.newSession == nil {
+		return sqlc.AgentGoalAttempt{}, fmt.Errorf("goal: no worker session minter configured")
+	}
+	sessionID, err := s.newSession(ctx, d.UserID, d.AgentID, d.ProjectID.String)
+	if err != nil {
+		return sqlc.AgentGoalAttempt{}, fmt.Errorf("mint review session: %w", err)
+	}
+
+	var out sqlc.AgentGoalAttempt
+	err = s.withTxRaw(ctx, func(q *sqlc.Queries, tx pgx.Tx) error {
+		if err := q.LockGoalForWrite(ctx, d.ID); err != nil {
+			return fmt.Errorf("lock goal for review attempt: %w", err)
+		}
+		// Re-read + re-derive under the lock: a racing verdict (human or a prior
+		// review) or a new execution attempt may have moved the goal since the scan.
+		cur, err := getGoal(ctx, q, d.ID)
+		if err != nil {
+			return err
+		}
+		items, _, execOut, ok := s.pendingReviewWork(ctx, q, cur)
+		if !ok {
+			return ErrInvalidTransition
+		}
+		spent, err := q.GetMaxAttemptNo(ctx, sqlc.GetMaxAttemptNoParams{GoalID: cur.ID, Purpose: PurposeReview})
+		if err != nil {
+			return fmt.Errorf("max review attempt no: %w", err)
+		}
+		if int(spent) >= defaultMaxReviewAttempts {
+			return ErrInvalidTransition
+		}
+		attemptNo := int(spent) + 1
+		input := buildInputContext(cur, nil, nil, "", attemptNo)
+		input.ReviewItems = items
+		judged := execOut
+		input.ReviewOutput = &judged
+
+		att, err := q.CreateAttempt(ctx, sqlc.CreateAttemptParams{
+			ID:              newID(),
+			GoalID:          cur.ID,
+			UserID:          cur.UserID,
+			AgentID:         pgnull.Text(cur.AgentID),
+			ExecutorAgentID: pgnull.Text(cur.AgentID),
+			SessionID:       sessionID,
+			Purpose:         PurposeReview,
+			AttemptNo:       int64(attemptNo),
+			Status:          AttemptQueued,
+			InputContext:    marshalJSON(input),
+			// A claim-grace lease: the River worker heartbeats it forward, so an
+			// expired lease is a genuine orphan the reaper recovers (mirrors Claim).
+			// uniq_agent_goal_active_attempt (goal_id, purpose) keeps this to one
+			// in-flight review attempt per goal — a racing second mint rolls back.
+			LeaseExpiresAt: nullTime(s.nowTime().Add(claimGraceTTL)),
+		})
+		if err != nil {
+			return fmt.Errorf("create review attempt: %w", err)
+		}
+		if enqueue != nil {
+			if err := enqueue(ctx, tx, cur.ID, att.ID); err != nil {
+				return fmt.Errorf("enqueue review attempt: %w", err)
+			}
+		}
+		out = att
+		return nil
+	})
+	return out, err
+}
+
+// pendingReviewWork reports whether a goal needs an agent verdict and, if so, the
+// pending authority=agent items, the execution attempt whose output is judged,
+// and that output. ok is false unless the goal is blocked(needs_verdict) with at
+// least one pending agent item — a human-only or already-resolved goal is left
+// for its existing path. Pure of writes; safe to call with s.q or a tx querier.
+func (s *GoalService) pendingReviewWork(ctx context.Context, q *sqlc.Queries, d sqlc.AgentGoal) ([]AcceptanceItem, string, AttemptOutput, bool) {
+	if d.Lifecycle != LifecycleBlocked || d.BlockReason != BlockNeedsVerdict {
+		return nil, "", AttemptOutput{}, false
+	}
+	var contract AcceptanceContract
+	_ = unmarshalJSON(d.AcceptanceContract, &contract)
+	if len(contract.AgentJudgmentItems()) == 0 {
+		return nil, "", AttemptOutput{}, false // no agent items: a human verdict path
+	}
+	execID, execOut := s.evaluatedAttempt(ctx, q, d)
+	events, err := q.ListAcceptanceEventByGoal(ctx, d.ID)
+	if err != nil {
+		return nil, "", AttemptOutput{}, false
+	}
+	items := PendingAgentReviewItems(contract, execOut.Hash, events)
+	if len(items) == 0 {
+		return nil, "", AttemptOutput{}, false // every agent item already has a valid verdict
+	}
+	return items, execID, execOut, true
+}
+
+// SubmitReview applies a reviewer agent's verdicts: it finalizes the review
+// attempt (running->submitted), appends one authority=agent acceptance_event per
+// verdict bound to the judged execution output's hash, and re-folds the ledger —
+// all in ONE tx so the verdict-as-evidence and the resulting transition are
+// atomic. The fold wakes the goal blocked(needs_verdict)->active and then accepts
+// (all items pass) or reworks (a fail, whose rationale rides as a gap); a
+// remaining human item keeps it blocked. It is the review analogue of Submit and
+// the single durable transition the worker applies for a purpose=review attempt.
+func (s *GoalService) SubmitReview(ctx context.Context, attemptID string, ev AttemptEvidence, verdicts []ReviewVerdict) error {
+	return s.withTx(ctx, func(q *sqlc.Queries) error {
+		att, err := q.GetAttempt(ctx, attemptID)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrNotFound
+		}
+		if err != nil {
+			return err
+		}
+		if att.Purpose != PurposeReview {
+			return ErrInvalidTransition
+		}
+		d, err := getGoal(ctx, q, att.GoalID)
+		if err != nil {
+			return err
+		}
+		// The verdict judges the current evaluated execution output. active_attempt_id
+		// is cleared while blocked, so this resolves to the most recent submitted
+		// execution attempt — its hash anchors every verdict's scope (§4.2).
+		execID, execOut := s.evaluatedAttempt(ctx, q, d)
+
+		// Finalize the review attempt so the reaper never recovers it after we fold.
+		rows, err := q.SubmitAttempt(ctx, sqlc.SubmitAttemptParams{
+			Evidence: marshalJSON(ev),
+			Output:   emptyJSON,
+			ID:       attemptID,
+		})
+		if err != nil {
+			return fmt.Errorf("submit review attempt: %w", err)
+		}
+		if rows == 0 {
+			return ErrInvalidTransition // not the running attempt (reaped / raced)
+		}
+		for _, v := range verdicts {
+			params := AgentVerdictEvent(d.ID, v.ItemID, execID, attemptID, execOut.Hash, v.Pass, v.Rationale)
+			if _, err := s.appendAcceptanceEvent(ctx, q, params); err != nil {
+				return fmt.Errorf("append agent verdict %q: %w", v.ItemID, err)
+			}
+		}
+		return s.foldAndTransition(ctx, q, d.ID, execID, execOut)
+	})
+}

--- a/internal/goal/review.go
+++ b/internal/goal/review.go
@@ -41,15 +41,14 @@ func (s *GoalService) BeginReview(ctx context.Context, id string, enqueue Attemp
 	}
 	// Cheap pre-checks before minting a session: skip goals awaiting a human, with
 	// no pending agent item, or out of review budget. Re-checked under the lock.
-	if _, _, _, ok := s.pendingReviewWork(ctx, s.q, d); !ok {
+	_, execID, _, ok := s.pendingReviewWork(ctx, s.q, d)
+	if !ok {
 		return sqlc.AgentGoalAttempt{}, ErrInvalidTransition
 	}
-	spent, err := s.q.GetMaxAttemptNo(ctx, sqlc.GetMaxAttemptNoParams{GoalID: d.ID, Purpose: PurposeReview})
-	if err != nil {
-		return sqlc.AgentGoalAttempt{}, fmt.Errorf("max review attempt no: %w", err)
-	}
-	if int(spent) >= defaultMaxReviewAttempts {
-		return sqlc.AgentGoalAttempt{}, ErrInvalidTransition // review budget spent; degrade to human
+	if spent, err := s.reviewBudgetSpent(ctx, s.q, d.ID, execID); err != nil {
+		return sqlc.AgentGoalAttempt{}, err
+	} else if spent >= defaultMaxReviewAttempts {
+		return sqlc.AgentGoalAttempt{}, ErrInvalidTransition // episode budget spent; degrade to human
 	}
 
 	// Mint the review session OUTSIDE the tx (it opens its own tx and would
@@ -74,22 +73,27 @@ func (s *GoalService) BeginReview(ctx context.Context, id string, enqueue Attemp
 		if err != nil {
 			return err
 		}
-		items, _, execOut, ok := s.pendingReviewWork(ctx, q, cur)
+		items, execID, execOut, ok := s.pendingReviewWork(ctx, q, cur)
 		if !ok {
 			return ErrInvalidTransition
 		}
-		spent, err := q.GetMaxAttemptNo(ctx, sqlc.GetMaxAttemptNoParams{GoalID: cur.ID, Purpose: PurposeReview})
+		if spent, err := s.reviewBudgetSpent(ctx, q, cur.ID, execID); err != nil {
+			return err
+		} else if spent >= defaultMaxReviewAttempts {
+			return ErrInvalidTransition
+		}
+		// attempt_no stays the global per-purpose sequence (uniq_agent_goal_attempt_no
+		// is on goal+purpose+attempt_no); only the budget is per-episode.
+		maxNo, err := q.GetMaxAttemptNo(ctx, sqlc.GetMaxAttemptNoParams{GoalID: cur.ID, Purpose: PurposeReview})
 		if err != nil {
 			return fmt.Errorf("max review attempt no: %w", err)
 		}
-		if int(spent) >= defaultMaxReviewAttempts {
-			return ErrInvalidTransition
-		}
-		attemptNo := int(spent) + 1
+		attemptNo := int(maxNo) + 1
 		input := buildInputContext(cur, nil, nil, "", attemptNo)
 		input.ReviewItems = items
 		judged := execOut
 		input.ReviewOutput = &judged
+		input.ReviewedAttemptID = execID
 
 		att, err := q.CreateAttempt(ctx, sqlc.CreateAttemptParams{
 			ID:              newID(),
@@ -148,6 +152,12 @@ func (s *GoalService) pendingReviewWork(ctx context.Context, q *sqlc.Queries, d 
 		return nil, "", AttemptOutput{}, false
 	}
 	execID, execOut := s.evaluatedAttempt(ctx, q, d)
+	if execID == "" {
+		// No submitted execution output to judge (e.g. a composite carrying an
+		// agent judgment item). There is nothing for a reviewer to score against, so
+		// leave it for a human verdict.
+		return nil, "", AttemptOutput{}, false
+	}
 	events, err := q.ListAcceptanceEventByGoal(ctx, d.ID)
 	if err != nil {
 		return nil, "", AttemptOutput{}, false
@@ -157,6 +167,37 @@ func (s *GoalService) pendingReviewWork(ctx context.Context, q *sqlc.Queries, d 
 		return nil, "", AttemptOutput{}, false // every agent item already has a valid verdict
 	}
 	return items, execID, execOut, true
+}
+
+// frozenReviewHash returns the hash of the execution output a review attempt was
+// minted to judge, or "" when none was frozen.
+func frozenReviewHash(in AttemptInput) string {
+	if in.ReviewOutput == nil {
+		return ""
+	}
+	return in.ReviewOutput.Hash
+}
+
+// reviewBudgetSpent counts agent-review attempts already spent on the CURRENT
+// needs_verdict episode: reviews of execID (the execution attempt whose output is
+// being judged) that actually ran. A rework that produces a newer execution
+// output starts a fresh episode with full budget, so a healthy reviewer that
+// returns a fail (legitimate rework) never starves later episodes — only a
+// reviewer that keeps failing to produce a verdict against the SAME output is
+// bounded, then degraded to a human (contract §10.13).
+func (s *GoalService) reviewBudgetSpent(ctx context.Context, q *sqlc.Queries, goalID, execID string) (int, error) {
+	exec, err := q.GetAttempt(ctx, execID)
+	if err != nil {
+		return 0, fmt.Errorf("review budget: load reviewed attempt: %w", err)
+	}
+	n, err := q.CountRanReviewAttemptsForOutput(ctx, sqlc.CountRanReviewAttemptsForOutputParams{
+		GoalID: goalID,
+		Since:  exec.CreatedAt,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("review budget: count attempts: %w", err)
+	}
+	return int(n), nil
 }
 
 // SubmitReview applies a reviewer agent's verdicts: it finalizes the review
@@ -179,15 +220,21 @@ func (s *GoalService) SubmitReview(ctx context.Context, attemptID string, ev Att
 		if att.Purpose != PurposeReview {
 			return ErrInvalidTransition
 		}
+		// Re-derive the frozen episode the reviewer judged (mint-time input), and
+		// re-validate coverage at this durable boundary — not only in-turn. The
+		// verdicts must answer exactly the frozen required items so a non-tool
+		// executor or a stale prompt can never append an unknown, duplicate, or
+		// partial verdict set the fold would misread.
+		var in AttemptInput
+		_ = unmarshalJSON(att.InputContext, &in)
+		if err := ValidateReviewVerdicts(verdicts, in.ReviewItems); err != nil {
+			return fmt.Errorf("review verdicts reject: %w", err)
+		}
+
 		d, err := getGoal(ctx, q, att.GoalID)
 		if err != nil {
 			return err
 		}
-		// The verdict judges the current evaluated execution output. active_attempt_id
-		// is cleared while blocked, so this resolves to the most recent submitted
-		// execution attempt — its hash anchors every verdict's scope (§4.2).
-		execID, execOut := s.evaluatedAttempt(ctx, q, d)
-
 		// Finalize the review attempt so the reaper never recovers it after we fold.
 		rows, err := q.SubmitAttempt(ctx, sqlc.SubmitAttemptParams{
 			Evidence: marshalJSON(ev),
@@ -200,12 +247,23 @@ func (s *GoalService) SubmitReview(ctx context.Context, attemptID string, ev Att
 		if rows == 0 {
 			return ErrInvalidTransition // not the running attempt (reaped / raced)
 		}
+
+		// Bind to the EXACT execution output the reviewer judged (frozen at mint),
+		// not whatever evaluatedAttempt resolves now. If the evaluated output moved
+		// since mint (a rework produced a newer execution attempt while this review
+		// ran), the verdict is stale: the attempt is finalized above, but we do NOT
+		// append it or fold. The goal stays blocked(needs_verdict) and the dispatcher
+		// mints a fresh review against the new output (a new episode, full budget).
+		curID, curOut := s.evaluatedAttempt(ctx, q, d)
+		if in.ReviewedAttemptID == "" || curID != in.ReviewedAttemptID || curOut.Hash != frozenReviewHash(in) {
+			return nil
+		}
 		for _, v := range verdicts {
-			params := AgentVerdictEvent(d.ID, v.ItemID, execID, attemptID, execOut.Hash, v.Pass, v.Rationale)
+			params := AgentVerdictEvent(d.ID, v.ItemID, in.ReviewedAttemptID, attemptID, curOut.Hash, v.Pass, v.Rationale)
 			if _, err := s.appendAcceptanceEvent(ctx, q, params); err != nil {
 				return fmt.Errorf("append agent verdict %q: %w", v.ItemID, err)
 			}
 		}
-		return s.foldAndTransition(ctx, q, d.ID, execID, execOut)
+		return s.foldAndTransition(ctx, q, d.ID, in.ReviewedAttemptID, curOut)
 	})
 }

--- a/internal/goal/review_test.go
+++ b/internal/goal/review_test.go
@@ -1,0 +1,210 @@
+package goal
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// agentJudgmentContract is a single required agent-verdict item — the gate the
+// dispatcher resolves with an agent reviewer (contract §10.13) rather than a
+// human, the mirror of humanJudgmentContract.
+func agentJudgmentContract() AcceptanceContract {
+	return AcceptanceContract{
+		Policy: PolicyDetThenJudgment,
+		Items: []AcceptanceItem{
+			{ID: "review", Kind: ItemJudgment, Required: true, Authority: AuthorityAgent, Rubric: "is it good?"},
+		},
+	}
+}
+
+// reviewExec scripts the shared executor: execution attempts submit a fixed-hash
+// output; review attempts return a verdict (pass) for every item they were asked
+// to judge. A test overrides the review branch to script a fail/no-verdict.
+func reviewExec(outputHash string, review func(ExecutorRequest) (ExecutorResult, error)) func(ExecutorRequest) (ExecutorResult, error) {
+	return func(req ExecutorRequest) (ExecutorResult, error) {
+		if req.Attempt.Purpose == PurposeReview {
+			return review(req)
+		}
+		return ExecutorResult{
+			Submitted: true,
+			Evidence:  AttemptEvidence{Summary: "done"},
+			Output:    AttemptOutput{Summary: "done", Hash: outputHash},
+		}, nil
+	}
+}
+
+// reviewVerdict scripts a reviewer that returns the same pass/rationale for every
+// pending item the attempt froze into its input.
+func reviewVerdict(pass bool, rationale string) func(ExecutorRequest) (ExecutorResult, error) {
+	return func(req ExecutorRequest) (ExecutorResult, error) {
+		var vs []ReviewVerdict
+		for _, it := range req.Input.ReviewItems {
+			vs = append(vs, ReviewVerdict{ItemID: it.ID, Pass: pass, Rationale: rationale})
+		}
+		return ExecutorResult{Submitted: true, Evidence: AttemptEvidence{Summary: "reviewed"}, Verdicts: vs}, nil
+	}
+}
+
+// runReview drives one agent-review episode: BeginReview mints + the worker runs
+// the review attempt to its single SubmitReview/fail transition. Returns the
+// review attempt id.
+func (h *harness) runReview(goalID string) string {
+	h.t.Helper()
+	ctx := context.Background()
+	att, err := h.svc.BeginReview(ctx, goalID, nil)
+	if err != nil {
+		h.t.Fatalf("begin review %s: %v", goalID, err)
+	}
+	if err := h.worker.Run(ctx, goalID, att.ID, Actor{Type: ActorReviewer}); err != nil {
+		h.t.Fatalf("worker run review %s/%s: %v", goalID, att.ID, err)
+	}
+	return att.ID
+}
+
+// TestReview_AgentVerdictAccepts walks the full agent auto-review gate: a worker
+// attempt blocks the leaf on needs_verdict, the dispatcher mints a review attempt,
+// and a passing reviewer verdict (scope_hash = the evaluated output) accepts the
+// goal — no human in the loop.
+func TestReview_AgentVerdictAccepts(t *testing.T) {
+	h := newHarness(t)
+	h.exec.fn = reviewExec("H1", reviewVerdict(true, "lgtm"))
+	d := h.createRoot(KindLeaf, agentJudgmentContract())
+	h.activate(d.ID)
+	h.runLeaf(d.ID)
+
+	blocked := h.get(d.ID)
+	if blocked.Lifecycle != LifecycleBlocked || blocked.BlockReason != BlockNeedsVerdict {
+		t.Fatalf("after run lifecycle=%q reason=%q want blocked/needs_verdict", blocked.Lifecycle, blocked.BlockReason)
+	}
+
+	h.runReview(d.ID)
+
+	accepted := h.get(d.ID)
+	if accepted.Lifecycle != LifecycleAccepted {
+		t.Fatalf("after agent verdict lifecycle=%q want accepted", accepted.Lifecycle)
+	}
+	var ao AcceptedOutput
+	if !accepted.AcceptedOutput.Valid {
+		t.Fatalf("accepted_output not frozen after agent verdict")
+	}
+	if err := unmarshalNullJSON(accepted.AcceptedOutput, &ao); err != nil {
+		t.Fatalf("decode accepted_output: %v", err)
+	}
+	if ao.Hash != "H1" {
+		t.Fatalf("accepted_output.hash=%q want H1", ao.Hash)
+	}
+}
+
+// TestReview_AgentVerdictFailReworks proves a failing agent verdict reworks the
+// goal (budget left): the leaf wakes blocked->active->ready for the next attempt
+// with the reviewer rationale recorded as a gap, not parked for a human.
+func TestReview_AgentVerdictFailReworks(t *testing.T) {
+	h := newHarness(t)
+	h.exec.fn = reviewExec("H1", reviewVerdict(false, "missing tests"))
+	d := h.createRoot(KindLeaf, agentJudgmentContract())
+	h.activate(d.ID)
+	execAttempt := h.runLeaf(d.ID)
+	h.runReview(d.ID)
+
+	got := h.get(d.ID)
+	if got.Lifecycle != LifecycleReady {
+		t.Fatalf("after fail verdict lifecycle=%q want ready (rework)", got.Lifecycle)
+	}
+	// The reviewer rationale rides as a gap on the rejected execution attempt.
+	att, err := h.q.GetAttempt(context.Background(), execAttempt)
+	if err != nil {
+		t.Fatalf("get exec attempt: %v", err)
+	}
+	var ev Evaluation
+	if err := unmarshalJSON(att.Gaps, &ev); err != nil {
+		t.Fatalf("decode gaps: %v", err)
+	}
+	if len(ev.Gaps) == 0 {
+		t.Fatalf("no gaps recorded on rejected attempt after fail verdict")
+	}
+}
+
+// TestReview_BudgetDegradesToHuman proves a reviewer that cannot produce a
+// verdict is retried within the small review budget, then degrades to a human:
+// once the budget is spent BeginReview is a no-op (ErrInvalidTransition) and the
+// goal stays blocked(needs_verdict) until a human verdict accepts it.
+func TestReview_BudgetDegradesToHuman(t *testing.T) {
+	h := newHarness(t)
+	reviewerCrashes := func(_ ExecutorRequest) (ExecutorResult, error) {
+		return ExecutorResult{Failed: true, FailReason: "reviewer crashed", Retryable: true}, nil
+	}
+	h.exec.fn = reviewExec("H1", reviewerCrashes)
+	d := h.createRoot(KindLeaf, agentJudgmentContract())
+	h.activate(d.ID)
+	h.runLeaf(d.ID)
+
+	// Burn the review budget: each attempt fails and leaves the goal blocked.
+	for i := 0; i < defaultMaxReviewAttempts; i++ {
+		h.runReview(d.ID)
+		if got := h.get(d.ID); got.Lifecycle != LifecycleBlocked || got.BlockReason != BlockNeedsVerdict {
+			t.Fatalf("after failed review %d lifecycle=%q reason=%q want still blocked/needs_verdict", i, got.Lifecycle, got.BlockReason)
+		}
+	}
+
+	// Budget spent: the dispatcher no longer mints a reviewer.
+	if _, err := h.svc.BeginReview(context.Background(), d.ID, nil); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("BeginReview after budget spent err=%v want ErrInvalidTransition", err)
+	}
+
+	// A human verdict still resolves it (human authority is the final override).
+	if err := h.svc.SubmitVerdict(context.Background(), VerdictInput{
+		GoalID:         d.ID,
+		ItemID:         "review",
+		Result:         ResultPass,
+		ScopeHash:      "H1",
+		ReviewerUserID: h.userID,
+	}); err != nil {
+		t.Fatalf("human verdict after budget: %v", err)
+	}
+	if got := h.get(d.ID); got.Lifecycle != LifecycleAccepted {
+		t.Fatalf("after human verdict lifecycle=%q want accepted", got.Lifecycle)
+	}
+}
+
+// TestReview_HumanOnlyNotReviewed proves a human-authority contract is left for a
+// human: BeginReview finds no agent item and is a no-op (ErrInvalidTransition).
+func TestReview_HumanOnlyNotReviewed(t *testing.T) {
+	h := newHarness(t)
+	h.exec.fn = lcl_passOutput("H1")
+	d := h.createRoot(KindLeaf, humanJudgmentContract())
+	h.activate(d.ID)
+	h.runLeaf(d.ID)
+
+	if got := h.get(d.ID); got.Lifecycle != LifecycleBlocked || got.BlockReason != BlockNeedsVerdict {
+		t.Fatalf("after run lifecycle=%q reason=%q want blocked/needs_verdict", got.Lifecycle, got.BlockReason)
+	}
+	if _, err := h.svc.BeginReview(context.Background(), d.ID, nil); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("BeginReview on human-only contract err=%v want ErrInvalidTransition", err)
+	}
+}
+
+// TestValidateReviewVerdicts pins the in-turn coverage guard: a review must
+// answer every required item exactly once and name no unknown item.
+func TestValidateReviewVerdicts(t *testing.T) {
+	items := []AcceptanceItem{{ID: "a"}, {ID: "b"}}
+	cases := []struct {
+		name     string
+		verdicts []ReviewVerdict
+		wantErr  bool
+	}{
+		{"complete", []ReviewVerdict{{ItemID: "a"}, {ItemID: "b"}}, false},
+		{"missing", []ReviewVerdict{{ItemID: "a"}}, true},
+		{"unknown", []ReviewVerdict{{ItemID: "a"}, {ItemID: "b"}, {ItemID: "c"}}, true},
+		{"duplicate", []ReviewVerdict{{ItemID: "a"}, {ItemID: "a"}, {ItemID: "b"}}, true},
+		{"empty id", []ReviewVerdict{{ItemID: ""}, {ItemID: "b"}}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateReviewVerdicts(tc.verdicts, items)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ValidateReviewVerdicts err=%v wantErr=%v", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/goal/review_test.go
+++ b/internal/goal/review_test.go
@@ -5,6 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
 
 	"github.com/CherryHQ/stella/pkg/db/pgnull"
 	"github.com/CherryHQ/stella/pkg/db/sqlc"
@@ -376,6 +381,139 @@ func TestReview_SubmitRejectsUncoveredVerdicts(t *testing.T) {
 	}
 	if got := h.get(d.ID); got.Lifecycle != LifecycleBlocked || got.BlockReason != BlockNeedsVerdict {
 		t.Fatalf("after rejected verdict lifecycle=%q reason=%q want still blocked/needs_verdict", got.Lifecycle, got.BlockReason)
+	}
+}
+
+// TestReview_ContractRetypeDropsVerdict proves a goal edit that retypes a frozen
+// review item invalidates an in-flight agent verdict: the fold resolves verdicts
+// against the LIVE contract by item id alone, so without the under-lock recheck an
+// agent verdict could satisfy a gate the user just changed to authority=human.
+// SubmitReview finalizes the attempt but appends nothing and does not fold.
+func TestReview_ContractRetypeDropsVerdict(t *testing.T) {
+	h := newHarness(t)
+	h.exec.fn = reviewExec("H1", reviewVerdict(true, "lgtm"))
+	d := h.createRoot(KindLeaf, agentJudgmentContract())
+	h.activate(d.ID)
+	h.runLeaf(d.ID) // exec H1 -> blocked(needs_verdict)
+
+	ctx := context.Background()
+	att, err := h.svc.BeginReview(ctx, d.ID, nil) // frozen: item "review" authority=agent
+	if err != nil {
+		t.Fatalf("begin review: %v", err)
+	}
+	if _, err := h.q.PromoteAttempt(ctx, sqlc.PromoteAttemptParams{ID: att.ID}); err != nil {
+		t.Fatalf("promote review: %v", err)
+	}
+	// The user retypes the same item id to authority=human while the reviewer runs.
+	cur := h.get(d.ID)
+	retyped := AcceptanceContract{Policy: PolicyDetThenJudgment, Items: []AcceptanceItem{
+		{ID: "review", Kind: ItemJudgment, Required: true, Authority: AuthorityHuman, Prompt: "is it good?"},
+	}}
+	if err := h.q.UpdateGoalIntent(ctx, sqlc.UpdateGoalIntentParams{
+		Title:              cur.Title,
+		Intent:             cur.Intent,
+		AcceptanceContract: marshalJSON(retyped),
+		ConvergencePolicy:  cur.ConvergencePolicy,
+		ReviewPolicy:       cur.ReviewPolicy,
+		Priority:           cur.Priority,
+		ID:                 d.ID,
+	}); err != nil {
+		t.Fatalf("retype contract: %v", err)
+	}
+	// The agent verdict must not satisfy the now-human gate.
+	if err := h.svc.SubmitReview(ctx, att.ID, AttemptEvidence{Summary: "ok"},
+		[]ReviewVerdict{{ItemID: "review", Pass: true, Rationale: "lgtm"}}); err != nil {
+		t.Fatalf("submit review after retype: %v", err)
+	}
+	if got := h.get(d.ID); got.Lifecycle == LifecycleAccepted {
+		t.Fatalf("stale agent verdict satisfied a retyped human gate; want still blocked")
+	}
+}
+
+// TestReview_DropsVerdictWhenAlreadyResolved proves the under-lock lifecycle
+// recheck drops a late reviewer verdict for a goal that already left
+// blocked(needs_verdict): a human verdict accepts the goal before the reviewer
+// submits, so a (fail) verdict folded in now would wrongly rework an accepted
+// goal. SubmitReview is a clean no-op (no error), and the goal stays accepted.
+func TestReview_DropsVerdictWhenAlreadyResolved(t *testing.T) {
+	h := newHarness(t)
+	h.exec.fn = reviewExec("H1", reviewVerdict(true, "lgtm"))
+	d := h.createRoot(KindLeaf, agentJudgmentContract())
+	h.activate(d.ID)
+	h.runLeaf(d.ID)
+
+	ctx := context.Background()
+	att, err := h.svc.BeginReview(ctx, d.ID, nil)
+	if err != nil {
+		t.Fatalf("begin review: %v", err)
+	}
+	if _, err := h.q.PromoteAttempt(ctx, sqlc.PromoteAttemptParams{ID: att.ID}); err != nil {
+		t.Fatalf("promote review: %v", err)
+	}
+	// A human verdict resolves (accepts) the goal before the reviewer submits.
+	if err := h.svc.SubmitVerdict(ctx, VerdictInput{
+		GoalID: d.ID, ItemID: "review", Result: ResultPass, ScopeHash: "H1", ReviewerUserID: h.userID,
+	}); err != nil {
+		t.Fatalf("human verdict: %v", err)
+	}
+	if got := h.get(d.ID); got.Lifecycle != LifecycleAccepted {
+		t.Fatalf("precondition: human verdict should have accepted, got %q", got.Lifecycle)
+	}
+	// The late reviewer submit (a fail) must be dropped, not fold into a rework.
+	if err := h.svc.SubmitReview(ctx, att.ID, AttemptEvidence{Summary: "ok"},
+		[]ReviewVerdict{{ItemID: "review", Pass: false, Rationale: "reject"}}); err != nil {
+		t.Fatalf("submit review after resolved: %v", err)
+	}
+	if got := h.get(d.ID); got.Lifecycle != LifecycleAccepted {
+		t.Fatalf("late verdict moved a resolved goal lifecycle=%q want accepted", got.Lifecycle)
+	}
+}
+
+// fakeEnqueuer is a no-op goalEnqueuer for dispatcher scan tests: it records
+// nothing and reports a successful (non-duplicate) insert so the claim/review tx
+// commits without a real River client.
+type fakeEnqueuer struct{}
+
+func (fakeEnqueuer) InsertTx(_ context.Context, _ pgx.Tx, _ river.JobArgs, _ *river.InsertOpts) (*rivertype.JobInsertResult, error) {
+	return &rivertype.JobInsertResult{Job: &rivertype.JobRow{}}, nil
+}
+
+// TestReview_RespectsConcurrencyCap proves scanAndReview honors the per-user
+// concurrency cap: a user saturated by an inflight execution attempt gets no
+// review minted for a blocked(needs_verdict) goal until a slot frees. Review
+// attempts are LLM jobs, so they share the cap rather than bursting one per
+// blocked goal.
+func TestReview_RespectsConcurrencyCap(t *testing.T) {
+	h := newHarness(t)
+	h.exec.fn = reviewExec("H1", reviewVerdict(true, "lgtm"))
+	d := h.createRoot(KindLeaf, agentJudgmentContract())
+	h.activate(d.ID)
+	h.runLeaf(d.ID) // blocked(needs_verdict)
+
+	ctx := context.Background()
+	// Saturate the per-user cap with one inflight (queued) execution attempt on
+	// another goal of the same user — never run, so it stays inflight.
+	other := h.createRoot(KindLeaf, AcceptanceContract{})
+	h.activate(other.ID)
+	if _, err := h.svc.Claim(ctx, other.ID, "w-1", nil); err != nil {
+		t.Fatalf("claim other: %v", err)
+	}
+
+	fake := fakeEnqueuer{}
+	overCap := NewDispatcher(DispatcherConfig{
+		Service: h.svc, Queries: h.q, Enqueuer: fake, MaxConcurrentPerUser: 1, BatchLimit: 50,
+	})
+	overCap.scanAndReview(ctx, time.Time{})
+	if _, err := h.q.GetActiveAttempt(ctx, sqlc.GetActiveAttemptParams{GoalID: d.ID, Purpose: PurposeReview}); !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("review minted while over per-user cap (err=%v); want none", err)
+	}
+
+	underCap := NewDispatcher(DispatcherConfig{
+		Service: h.svc, Queries: h.q, Enqueuer: fake, MaxConcurrentPerUser: 10, BatchLimit: 50,
+	})
+	underCap.scanAndReview(ctx, time.Time{})
+	if _, err := h.q.GetActiveAttempt(ctx, sqlc.GetActiveAttemptParams{GoalID: d.ID, Purpose: PurposeReview}); err != nil {
+		t.Fatalf("review not minted under cap: %v", err)
 	}
 }
 

--- a/internal/goal/review_test.go
+++ b/internal/goal/review_test.go
@@ -140,7 +140,7 @@ func TestReview_BudgetDegradesToHuman(t *testing.T) {
 	h.runLeaf(d.ID)
 
 	// Burn the review budget: each attempt fails and leaves the goal blocked.
-	for i := 0; i < defaultMaxReviewAttempts; i++ {
+	for i := range defaultMaxReviewAttempts {
 		h.runReview(d.ID)
 		if got := h.get(d.ID); got.Lifecycle != LifecycleBlocked || got.BlockReason != BlockNeedsVerdict {
 			t.Fatalf("after failed review %d lifecycle=%q reason=%q want still blocked/needs_verdict", i, got.Lifecycle, got.BlockReason)
@@ -181,6 +181,28 @@ func TestReview_HumanOnlyNotReviewed(t *testing.T) {
 	}
 	if _, err := h.svc.BeginReview(context.Background(), d.ID, nil); !errors.Is(err, ErrInvalidTransition) {
 		t.Fatalf("BeginReview on human-only contract err=%v want ErrInvalidTransition", err)
+	}
+}
+
+// TestReview_SkipsWhenInFlight proves the dispatcher does not re-mint while a
+// review attempt is already queued/running. The goal stays blocked(needs_verdict)
+// across the review, so scanAndReview lists it every tick; without the in-flight
+// guard each tick would mint a throwaway session and collide on
+// uniq_agent_goal_active_attempt. A second BeginReview must be a no-op.
+func TestReview_SkipsWhenInFlight(t *testing.T) {
+	h := newHarness(t)
+	h.exec.fn = reviewExec("H1", reviewVerdict(true, "lgtm"))
+	d := h.createRoot(KindLeaf, agentJudgmentContract())
+	h.activate(d.ID)
+	h.runLeaf(d.ID)
+
+	// First BeginReview mints a queued review attempt (no worker run yet).
+	if _, err := h.svc.BeginReview(context.Background(), d.ID, nil); err != nil {
+		t.Fatalf("first BeginReview: %v", err)
+	}
+	// Second BeginReview sees the in-flight attempt and is a no-op.
+	if _, err := h.svc.BeginReview(context.Background(), d.ID, nil); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("second BeginReview err=%v want ErrInvalidTransition", err)
 	}
 }
 

--- a/internal/goal/review_test.go
+++ b/internal/goal/review_test.go
@@ -3,7 +3,11 @@ package goal
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
+
+	"github.com/CherryHQ/stella/pkg/db/pgnull"
+	"github.com/CherryHQ/stella/pkg/db/sqlc"
 )
 
 // agentJudgmentContract is a single required agent-verdict item — the gate the
@@ -203,6 +207,175 @@ func TestReview_SkipsWhenInFlight(t *testing.T) {
 	// Second BeginReview sees the in-flight attempt and is a no-op.
 	if _, err := h.svc.BeginReview(context.Background(), d.ID, nil); !errors.Is(err, ErrInvalidTransition) {
 		t.Fatalf("second BeginReview err=%v want ErrInvalidTransition", err)
+	}
+}
+
+// submitSyntheticExec injects a freshly-submitted execution attempt carrying the
+// given output hash, so evaluatedAttempt (most-recent submitted execution) now
+// resolves to it — simulating a rework that landed a new output while a prior
+// review was mid-flight.
+func (h *harness) submitSyntheticExec(goalID, hash string) {
+	h.t.Helper()
+	ctx := context.Background()
+	d := h.get(goalID)
+	maxNo, err := h.q.GetMaxAttemptNo(ctx, sqlc.GetMaxAttemptNoParams{GoalID: goalID, Purpose: PurposeExecution})
+	if err != nil {
+		h.t.Fatalf("max exec no: %v", err)
+	}
+	att, err := h.q.CreateAttempt(ctx, sqlc.CreateAttemptParams{
+		ID:              newID(),
+		GoalID:          goalID,
+		UserID:          d.UserID,
+		AgentID:         pgnull.Text(d.AgentID),
+		ExecutorAgentID: pgnull.Text(d.AgentID),
+		SessionID:       d.SessionID,
+		Purpose:         PurposeExecution,
+		AttemptNo:       maxNo + 1,
+		Status:          AttemptQueued,
+		InputContext:    marshalJSON(AttemptInput{}),
+	})
+	if err != nil {
+		h.t.Fatalf("create synthetic exec: %v", err)
+	}
+	if _, err := h.q.PromoteAttempt(ctx, sqlc.PromoteAttemptParams{ID: att.ID}); err != nil {
+		h.t.Fatalf("promote synthetic exec: %v", err)
+	}
+	if _, err := h.q.SubmitAttempt(ctx, sqlc.SubmitAttemptParams{
+		Evidence: emptyJSON,
+		Output:   marshalJSON(AttemptOutput{Summary: hash, Hash: hash}),
+		ID:       att.ID,
+	}); err != nil {
+		h.t.Fatalf("submit synthetic exec: %v", err)
+	}
+}
+
+// TestReview_StaleVerdictDoesNotAccept proves a verdict scoped to a now-superseded
+// execution output never accepts the goal: if the evaluated output moves between a
+// review's mint and its submit (a rework landed a new attempt while the reviewer
+// ran), SubmitReview finalizes the review but appends no verdict and does not
+// fold. The goal stays blocked(needs_verdict) for a fresh review against the new
+// output — it must not pass the new output on a verdict that judged the old one.
+func TestReview_StaleVerdictDoesNotAccept(t *testing.T) {
+	h := newHarness(t)
+	h.exec.fn = reviewExec("H1", reviewVerdict(true, "lgtm"))
+	d := h.createRoot(KindLeaf, agentJudgmentContract())
+	h.activate(d.ID)
+	h.runLeaf(d.ID) // exec H1 -> blocked(needs_verdict)
+
+	ctx := context.Background()
+	att, err := h.svc.BeginReview(ctx, d.ID, nil) // frozen on exec H1
+	if err != nil {
+		t.Fatalf("begin review: %v", err)
+	}
+	if _, err := h.q.PromoteAttempt(ctx, sqlc.PromoteAttemptParams{ID: att.ID}); err != nil {
+		t.Fatalf("promote review: %v", err)
+	}
+	// A newer execution output lands before the reviewer submits.
+	h.submitSyntheticExec(d.ID, "H2")
+
+	// The reviewer (still judging H1) returns a pass; it must be discarded.
+	if err := h.svc.SubmitReview(ctx, att.ID, AttemptEvidence{Summary: "ok"},
+		[]ReviewVerdict{{ItemID: "review", Pass: true, Rationale: "lgtm"}}); err != nil {
+		t.Fatalf("submit stale review: %v", err)
+	}
+	if got := h.get(d.ID); got.Lifecycle == LifecycleAccepted {
+		t.Fatalf("stale verdict accepted the goal against a superseded output; want still blocked")
+	}
+}
+
+// TestReview_BudgetResetsPerEpisode proves the review budget is per needs_verdict
+// episode, not per goal lifetime: a healthy reviewer that fails two outputs (each
+// reworked) must still review the third. With a cumulative budget the dispatcher
+// would refuse the third review and wrongly degrade a working reviewer to a human.
+func TestReview_BudgetResetsPerEpisode(t *testing.T) {
+	h := newHarness(t)
+	var execN int
+	h.exec.fn = func(req ExecutorRequest) (ExecutorResult, error) {
+		if req.Attempt.Purpose == PurposeReview {
+			hash := ""
+			if req.Input.ReviewOutput != nil {
+				hash = req.Input.ReviewOutput.Hash
+			}
+			pass := hash == "H3" // accept only the third episode's output
+			var vs []ReviewVerdict
+			for _, it := range req.Input.ReviewItems {
+				vs = append(vs, ReviewVerdict{ItemID: it.ID, Pass: pass, Rationale: "r"})
+			}
+			return ExecutorResult{Submitted: true, Evidence: AttemptEvidence{Summary: "reviewed"}, Verdicts: vs}, nil
+		}
+		execN++
+		return ExecutorResult{Submitted: true, Evidence: AttemptEvidence{Summary: "done"}, Output: AttemptOutput{Summary: "done", Hash: fmt.Sprintf("H%d", execN)}}, nil
+	}
+	d := h.createRoot(KindLeaf, agentJudgmentContract())
+	h.activate(d.ID)
+
+	for ep := 1; ep <= 2; ep++ {
+		h.runLeaf(d.ID) // new output Hep
+		h.runReview(d.ID)
+		if got := h.get(d.ID); got.Lifecycle != LifecycleReady {
+			t.Fatalf("episode %d lifecycle=%q want ready (fail verdict reworks)", ep, got.Lifecycle)
+		}
+	}
+	// Episode 3: a cumulative budget (the bug) would have been spent by now and
+	// BeginReview inside runReview would fail; a per-episode budget reviews freely.
+	h.runLeaf(d.ID) // H3
+	h.runReview(d.ID)
+	if got := h.get(d.ID); got.Lifecycle != LifecycleAccepted {
+		t.Fatalf("episode 3 lifecycle=%q want accepted (budget must reset per episode)", got.Lifecycle)
+	}
+}
+
+// TestReview_QueuedReapDoesNotChargeBudget proves a review attempt reaped before
+// it ever ran (queued backpressure) does not consume the episode budget — only
+// attempts that actually ran do (started_at set), mirroring the queued
+// decomposition refund. Otherwise River queue lag would degrade a goal to a human
+// without a single reviewer turn.
+func TestReview_QueuedReapDoesNotChargeBudget(t *testing.T) {
+	h := newHarness(t)
+	h.exec.fn = reviewExec("H1", reviewVerdict(true, "lgtm"))
+	d := h.createRoot(KindLeaf, agentJudgmentContract())
+	h.activate(d.ID)
+	h.runLeaf(d.ID)
+
+	ctx := context.Background()
+	for i := range defaultMaxReviewAttempts {
+		att, err := h.svc.BeginReview(ctx, d.ID, nil) // queued
+		if err != nil {
+			t.Fatalf("begin review %d: %v", i, err)
+		}
+		if err := h.svc.ReapAttempt(ctx, att.ID); err != nil { // reaped while queued
+			t.Fatalf("reap %d: %v", i, err)
+		}
+	}
+	// Budget intact: a real review still mints, runs, and accepts.
+	h.runReview(d.ID)
+	if got := h.get(d.ID); got.Lifecycle != LifecycleAccepted {
+		t.Fatalf("after %d queued reaps lifecycle=%q want accepted (queued reap must not charge)", defaultMaxReviewAttempts, got.Lifecycle)
+	}
+}
+
+// TestReview_SubmitRejectsUncoveredVerdicts proves coverage is re-validated at the
+// durable boundary, not only in the tool: SubmitReview refuses a verdict set that
+// names an unknown item / misses a required one, so no partial or bogus ledger is
+// written even if a non-tool executor bypasses the in-turn check.
+func TestReview_SubmitRejectsUncoveredVerdicts(t *testing.T) {
+	h := newHarness(t)
+	h.exec.fn = reviewExec("H1", reviewVerdict(true, "lgtm"))
+	d := h.createRoot(KindLeaf, agentJudgmentContract())
+	h.activate(d.ID)
+	h.runLeaf(d.ID)
+
+	ctx := context.Background()
+	att, err := h.svc.BeginReview(ctx, d.ID, nil)
+	if err != nil {
+		t.Fatalf("begin review: %v", err)
+	}
+	if err := h.svc.SubmitReview(ctx, att.ID, AttemptEvidence{},
+		[]ReviewVerdict{{ItemID: "bogus", Pass: true}}); err == nil {
+		t.Fatalf("SubmitReview accepted an unknown-item verdict; want rejection")
+	}
+	if got := h.get(d.ID); got.Lifecycle != LifecycleBlocked || got.BlockReason != BlockNeedsVerdict {
+		t.Fatalf("after rejected verdict lifecycle=%q reason=%q want still blocked/needs_verdict", got.Lifecycle, got.BlockReason)
 	}
 }
 

--- a/internal/goal/service.go
+++ b/internal/goal/service.go
@@ -52,9 +52,20 @@ type ExecutorResult struct {
 	Evidence      AttemptEvidence
 	Output        AttemptOutput
 	Decomposition *DecompositionContent // purpose=decomposition only
+	Verdicts      []ReviewVerdict       // purpose=review only
 	Failed        bool
 	FailReason    string
 	Retryable     bool
+}
+
+// ReviewVerdict is one agent reviewer decision for a required authority=agent
+// judgment item (contract §10.13). The worker folds each into an
+// authority=agent acceptance_event via SubmitReview; the agent never writes
+// lifecycle.
+type ReviewVerdict struct {
+	ItemID    string `json:"item_id"`
+	Pass      bool   `json:"pass"`
+	Rationale string `json:"rationale"`
 }
 
 // CheckRunner runs ONE deterministic acceptance item in the sandbox and returns

--- a/internal/goal/worker.go
+++ b/internal/goal/worker.go
@@ -151,6 +151,12 @@ func (w *Worker) applyResult(goalID string, goal sqlc.AgentGoal, att sqlc.AgentG
 		// case so a decomposition never falls through to the leaf checks.
 		return w.applyDecompositionResult(ctx, goalID, att, res)
 
+	case att.Purpose == PurposeReview:
+		// A reviewer attempt's outcome is verdicts, not an output, and runs no
+		// deterministic checks. Routed by purpose BEFORE the generic submit case so
+		// it never falls through to the leaf checks/Submit.
+		return w.applyReviewResult(ctx, goalID, att, res)
+
 	case res.Submitted:
 		// Run deterministic checks (sandbox IO, no DB tx held), append
 		// each as an acceptance_event, then apply the one submit transition.
@@ -216,6 +222,29 @@ func (w *Worker) applyDecompositionResult(ctx context.Context, goalID string, at
 	reason := res.FailReason
 	if reason == "" {
 		reason = "decomposition produced no plan"
+	}
+	w.failAttempt(goalID, att.ID, reason)
+	return nil
+}
+
+// applyReviewResult applies a reviewer attempt's outcome as the single durable
+// transition. A submitted attempt carries verdicts, which SubmitReview folds in
+// as authority=agent acceptance_events and re-derives acceptance (accept on pass,
+// rework on fail). Any non-verdict terminal (fail / no verdict / protocol miss)
+// is a failed review attempt that leaves the goal blocked(needs_verdict); the
+// dispatcher re-mints within the review budget, then degrades to a human verdict.
+// Errors are recorded as a failed attempt, not returned, so applyResult always
+// succeeds. Mirrors applyDecompositionResult.
+func (w *Worker) applyReviewResult(ctx context.Context, goalID string, att sqlc.AgentGoalAttempt, res ExecutorResult) error {
+	if res.Submitted && len(res.Verdicts) > 0 {
+		if rerr := w.svc.SubmitReview(ctx, att.ID, res.Evidence, res.Verdicts); rerr != nil {
+			w.failAttempt(goalID, att.ID, "apply review: "+rerr.Error())
+		}
+		return nil
+	}
+	reason := res.FailReason
+	if reason == "" {
+		reason = "review produced no verdict"
 	}
 	w.failAttempt(goalID, att.ID, reason)
 	return nil

--- a/pkg/db/sqlc/agent_goal.sql.go
+++ b/pkg/db/sqlc/agent_goal.sql.go
@@ -786,6 +786,76 @@ func (q *Queries) ListGoalSubtree(ctx context.Context, id string) ([]AgentGoal, 
 	return items, nil
 }
 
+const listGoalsBlockedNeedsVerdict = `-- name: ListGoalsBlockedNeedsVerdict :many
+SELECT id, user_id, agent_id, project_id, parent_id, root_id, depth, position, session_id, title, intent, kind, priority, required, acceptance_contract, convergence_policy, review_policy, lifecycle, block_reason, acceptance_state, accepted_output, acceptance_seq, active_attempt_id, attempt_count, required_total, required_accepted, required_failed, required_blocked, context, dispatch_hint, created_at, updated_at, accepted_at, cancelled_at, archived_at, plan, planned_at FROM agent_goal
+WHERE lifecycle = 'blocked'
+  AND block_reason = 'needs_verdict'
+ORDER BY priority DESC, created_at ASC
+LIMIT $1
+`
+
+// Goals parked blocked(needs_verdict): a required judgment item has no valid
+// verdict. The dispatcher (scanAndReview) drives an agent reviewer for any with a
+// pending authority=agent item (contract section 10.13); the rest await a human.
+// Both leaf and composite goals can carry an authored judgment contract.
+func (q *Queries) ListGoalsBlockedNeedsVerdict(ctx context.Context, limit int32) ([]AgentGoal, error) {
+	rows, err := q.db.Query(ctx, listGoalsBlockedNeedsVerdict, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []AgentGoal{}
+	for rows.Next() {
+		var i AgentGoal
+		if err := rows.Scan(
+			&i.ID,
+			&i.UserID,
+			&i.AgentID,
+			&i.ProjectID,
+			&i.ParentID,
+			&i.RootID,
+			&i.Depth,
+			&i.Position,
+			&i.SessionID,
+			&i.Title,
+			&i.Intent,
+			&i.Kind,
+			&i.Priority,
+			&i.Required,
+			&i.AcceptanceContract,
+			&i.ConvergencePolicy,
+			&i.ReviewPolicy,
+			&i.Lifecycle,
+			&i.BlockReason,
+			&i.AcceptanceState,
+			&i.AcceptedOutput,
+			&i.AcceptanceSeq,
+			&i.ActiveAttemptID,
+			&i.AttemptCount,
+			&i.RequiredTotal,
+			&i.RequiredAccepted,
+			&i.RequiredFailed,
+			&i.RequiredBlocked,
+			&i.Context,
+			&i.DispatchHint,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.AcceptedAt,
+			&i.CancelledAt,
+			&i.ArchivedAt,
+			&i.Plan,
+			&i.PlannedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listInboxGoals = `-- name: ListInboxGoals :many
 SELECT
     d.id,

--- a/pkg/db/sqlc/agent_goal_attempt.sql.go
+++ b/pkg/db/sqlc/agent_goal_attempt.sql.go
@@ -8,6 +8,7 @@ package sqlc
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 )
@@ -39,6 +40,33 @@ func (q *Queries) CountInflightAttemptsByUser(ctx context.Context, userID string
 	var column_1 int64
 	err := row.Scan(&column_1)
 	return column_1, err
+}
+
+const countRanReviewAttemptsForOutput = `-- name: CountRanReviewAttemptsForOutput :one
+SELECT COUNT(*)
+FROM agent_goal_attempt
+WHERE goal_id = $1
+  AND purpose = 'review'
+  AND started_at IS NOT NULL
+  AND created_at > $2
+`
+
+type CountRanReviewAttemptsForOutputParams struct {
+	GoalID string    `json:"goal_id"`
+	Since  time.Time `json:"since"`
+}
+
+// Review attempts spent on the CURRENT needs_verdict episode: those created after
+// the reviewed execution attempt (a later execution attempt starts a fresh
+// episode) that actually ran (started_at set). A queued attempt reaped before it
+// was promoted never ran and does not charge the budget, mirroring how a queued
+// decomposition reap is refunded. This is the agent-review budget; attempt_no is
+// still assigned globally per purpose via GetMaxAttemptNo.
+func (q *Queries) CountRanReviewAttemptsForOutput(ctx context.Context, arg CountRanReviewAttemptsForOutputParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countRanReviewAttemptsForOutput, arg.GoalID, arg.Since)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
 }
 
 const createAttempt = `-- name: CreateAttempt :one


### PR DESCRIPTION
## What

Wire the **producer** for agent auto-review: a required `authority=agent` judgment item is now resolved by a reviewer-agent verdict instead of parking the goal at `blocked(needs_verdict)` for a human (contract §10.13).

## Why

The acceptance fold already consumed `authority=agent` verdict events (scope_hash binding, `verdictEvent`, `DeriveAcceptance`), but nothing minted the review attempt or produced the verdict — so every judgment item, agent or human, stranded waiting for a human. This closes the gap; the point of `authority=agent` is autonomous acceptance.

## How

Mirror the decomposition producer (dispatcher scan → mint+enqueue → worker → service submit), reusing the existing River attempt channel (no new job kind):

- **Trigger** — `Dispatcher.scanAndReview` lists `blocked(needs_verdict)` goals; `BeginReview` (mirror of `BeginAutoDecomposition`) mints a fresh hidden session + a `purpose=review` attempt and enqueues it in-tx for any goal with a pending agent item, budget remaining, and no in-flight review. The goal **stays** `blocked(needs_verdict)` and `active_attempt_id` is untouched, so the fold keeps scoping verdicts to the execution output's hash. `uniq_agent_goal_active_attempt (goal_id, purpose)` enforces ≤1 in-flight review per goal.
- **Execute** — the executor gains a review mode whose `goal_control` action set is `verdict`/`fail` with strict decode + in-turn coverage validation (same pattern as #604's decomposition in-turn contract). `Worker.applyReviewResult` routes `purpose=review`.
- **Submit** — `SubmitReview` appends one `authority=agent` acceptance_event per verdict (`scope_hash` = evaluated execution output, `reviewer_attempt_id` = the review attempt), finalizes the review attempt, and re-folds: pass → accept; fail → rework with the reviewer rationale fed in as a gap.
- **Degrade** — a failed/orphaned review leaves the goal `blocked(needs_verdict)`; the dispatcher retries within a small review budget (default 2), then stops and waits for a human. Human verdict remains the final override.

Reviewer identity: same agent, fresh hidden session.

### Follow-up fix (commit 2): skip re-mint while a review is in flight

The goal intentionally stays `blocked(needs_verdict)` for the seconds the reviewer turn runs, so `scanAndReview` re-listed it every tick. Each tick re-ran `BeginReview`, which minted a fresh hidden session and only then collided on `uniq_agent_goal_active_attempt` — leaking a session per tick and spamming the log with duplicate-key WARNs until the verdict folded. `pendingReviewWork` now guards with `GetActiveAttempt(purpose=review)`: a queued/running review means there is no review work to start. The DB constraint stays as the final backstop. Found by the live e2e below.

## Tests

`review_test.go` (6 tests): agent verdict accepts; fail verdict reworks (rationale recorded as a gap); review budget exhaustion degrades to a human verdict; human-only contract is not agent-reviewed; in-turn verdict-coverage validation; in-flight guard (a second `BeginReview` is a no-op). `mise run format && build && test` all green.

**Live e2e (real LLM):** a goal flowed `execution → blocked(needs_verdict) → agent review → accepted` with no human in the loop — the reviewer agent emitted a valid verdict via `buildReviewPrompt` + the `goal_control` tool, and an `authority=agent | pass` acceptance event was recorded. Re-run after the follow-up fix: 0 duplicate-key WARNs, 0 leaked sessions.

## Known limitation (not addressed here)

An `authority=agent` judgment item placed on a **composite** judges the empty rollup output and fails; the planner correctly places agent items on **leaves**, which pass cleanly. Composite-level agent rubrics have no substantive output to judge today — supporting them would need a separate design.

## Refs

- Closes #605
- Builds on #604 (decomposition in-turn contract), now merged.
