### PR TITLE
🐛 fix(goal): archive sessions orphaned by a rolled-back mint

### DIFF
--- a/internal/goal/boot.go
+++ b/internal/goal/boot.go
@@ -170,6 +170,7 @@ func Boot(cfg BootConfig) (*Service, error) {
 		WithExecutor(bootExecutor(cfg.Chat, logger)),
 		WithSessionMinter(RegistrySessionMinter(cfg.Services)),
 		WithPlanningSessionMinter(RegistryPlanningSessionMinter(cfg.Services)),
+		WithSessionDisposer(RegistrySessionDisposer(cfg.Services)),
 		WithConfig(Config{LeaseTTL: cfg.LeaseTTL}),
 	)
 

--- a/internal/goal/converge.go
+++ b/internal/goal/converge.go
@@ -404,6 +404,9 @@ func (s *GoalService) SubmitDecomposition(ctx context.Context, attemptID string,
 		for _, ch := range content.Children {
 			sid, err := s.newSession(ctx, parent.UserID, parent.AgentID, parent.ProjectID.String)
 			if err != nil {
+				// A mid-batch mint failure orphans the children minted before it (no tx
+				// has run yet); archive them so the partial batch does not leak.
+				s.disposeOrphanSessions(ctx, parent.UserID, parent.AgentID, mapValues(childSessions)...)
 				return fmt.Errorf("mint child session %q: %w", ch.Key, err)
 			}
 			childSessions[ch.Key] = sid
@@ -462,11 +465,9 @@ func (s *GoalService) SubmitDecomposition(ctx context.Context, attemptID string,
 		}
 		return s.releaseChildren(ctx, q, parent.ID)
 	})
-	if err != nil {
-		// The tx rolled back (lost race / collision); archive the child sessions
-		// pre-minted above (none on the human-review path) so they are not orphaned.
-		s.disposeOrphanSessions(ctx, parent.UserID, parent.AgentID, mapValues(childSessions)...)
-	}
+	// On a definite rollback, archive the child sessions pre-minted above (none on
+	// the human-review path) so they are not orphaned.
+	s.disposeOnRollback(ctx, err, parent.UserID, parent.AgentID, mapValues(childSessions)...)
 	return err
 }
 
@@ -498,6 +499,9 @@ func (s *GoalService) ApprovePlan(ctx context.Context, goalID string, by Actor) 
 	for _, ch := range content.Children {
 		sid, err := s.newSession(ctx, parent.UserID, parent.AgentID, parent.ProjectID.String)
 		if err != nil {
+			// A mid-batch mint failure orphans the children minted before it (no tx
+			// has run yet); archive them so the partial batch does not leak.
+			s.disposeOrphanSessions(ctx, parent.UserID, parent.AgentID, mapValues(childSessions)...)
 			return fmt.Errorf("mint child session %q: %w", ch.Key, err)
 		}
 		childSessions[ch.Key] = sid
@@ -532,11 +536,9 @@ func (s *GoalService) ApprovePlan(ctx context.Context, goalID string, by Actor) 
 		}
 		return s.releaseChildren(ctx, q, cur.ID)
 	})
-	if err != nil {
-		// The tx rolled back (concurrent reject/approve / collision); archive the
-		// child sessions pre-minted above so they are not orphaned.
-		s.disposeOrphanSessions(ctx, parent.UserID, parent.AgentID, mapValues(childSessions)...)
-	}
+	// On a definite rollback (concurrent reject/approve / collision), archive the
+	// child sessions pre-minted above so they are not orphaned.
+	s.disposeOnRollback(ctx, err, parent.UserID, parent.AgentID, mapValues(childSessions)...)
 	return err
 }
 

--- a/internal/goal/converge.go
+++ b/internal/goal/converge.go
@@ -410,7 +410,7 @@ func (s *GoalService) SubmitDecomposition(ctx context.Context, attemptID string,
 		}
 	}
 
-	return s.withTx(ctx, func(q *sqlc.Queries) error {
+	err = s.withTx(ctx, func(q *sqlc.Queries) error {
 		if err := q.LockGoalForWrite(ctx, parent.ID); err != nil {
 			return fmt.Errorf("lock goal for decomposition submit: %w", err)
 		}
@@ -462,6 +462,12 @@ func (s *GoalService) SubmitDecomposition(ctx context.Context, attemptID string,
 		}
 		return s.releaseChildren(ctx, q, parent.ID)
 	})
+	if err != nil {
+		// The tx rolled back (lost race / collision); archive the child sessions
+		// pre-minted above (none on the human-review path) so they are not orphaned.
+		s.disposeOrphanSessions(ctx, parent.UserID, parent.AgentID, mapValues(childSessions)...)
+	}
+	return err
 }
 
 // ApprovePlan applies a human approval of a composite's proposed plan: it
@@ -497,7 +503,7 @@ func (s *GoalService) ApprovePlan(ctx context.Context, goalID string, by Actor) 
 		childSessions[ch.Key] = sid
 	}
 
-	return s.withTx(ctx, func(q *sqlc.Queries) error {
+	err = s.withTx(ctx, func(q *sqlc.Queries) error {
 		if err := q.LockGoalForWrite(ctx, parent.ID); err != nil {
 			return fmt.Errorf("lock goal for plan approval: %w", err)
 		}
@@ -526,6 +532,22 @@ func (s *GoalService) ApprovePlan(ctx context.Context, goalID string, by Actor) 
 		}
 		return s.releaseChildren(ctx, q, cur.ID)
 	})
+	if err != nil {
+		// The tx rolled back (concurrent reject/approve / collision); archive the
+		// child sessions pre-minted above so they are not orphaned.
+		s.disposeOrphanSessions(ctx, parent.UserID, parent.AgentID, mapValues(childSessions)...)
+	}
+	return err
+}
+
+// mapValues returns a map's values as a slice in unspecified order. Used to feed
+// a pre-minted child-session map to disposeOrphanSessions on a rollback.
+func mapValues(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for _, v := range m {
+		out = append(out, v)
+	}
+	return out
 }
 
 // RejectPlan applies a human rejection of a composite's proposed plan: it clears

--- a/internal/goal/decompose.go
+++ b/internal/goal/decompose.go
@@ -252,11 +252,9 @@ func (s *GoalService) BeginDecomposition(ctx context.Context, id string) (sqlc.A
 		out = att
 		return nil
 	})
-	if err != nil {
-		// The tx rolled back (lost race / collision); archive the planning session
-		// minted above so it is not orphaned.
-		s.disposeOrphanSessions(ctx, d.UserID, d.AgentID, sessionID)
-	}
+	// On a definite rollback (lost race / collision), archive the planning session
+	// minted above so it is not orphaned.
+	s.disposeOnRollback(ctx, err, d.UserID, d.AgentID, sessionID)
 	return out, err
 }
 
@@ -352,11 +350,9 @@ func (s *GoalService) BeginAutoDecomposition(ctx context.Context, id string, enq
 		out = att
 		return nil
 	})
-	if err != nil {
-		// The tx rolled back (lost race / collision); archive the planning session
-		// minted above so it is not orphaned.
-		s.disposeOrphanSessions(ctx, d.UserID, d.AgentID, sessionID)
-	}
+	// On a definite rollback (lost race / collision), archive the planning session
+	// minted above so it is not orphaned.
+	s.disposeOnRollback(ctx, err, d.UserID, d.AgentID, sessionID)
 	return out, err
 }
 

--- a/internal/goal/decompose.go
+++ b/internal/goal/decompose.go
@@ -252,6 +252,11 @@ func (s *GoalService) BeginDecomposition(ctx context.Context, id string) (sqlc.A
 		out = att
 		return nil
 	})
+	if err != nil {
+		// The tx rolled back (lost race / collision); archive the planning session
+		// minted above so it is not orphaned.
+		s.disposeOrphanSessions(ctx, d.UserID, d.AgentID, sessionID)
+	}
 	return out, err
 }
 
@@ -347,6 +352,11 @@ func (s *GoalService) BeginAutoDecomposition(ctx context.Context, id string, enq
 		out = att
 		return nil
 	})
+	if err != nil {
+		// The tx rolled back (lost race / collision); archive the planning session
+		// minted above so it is not orphaned.
+		s.disposeOrphanSessions(ctx, d.UserID, d.AgentID, sessionID)
+	}
 	return out, err
 }
 

--- a/internal/goal/review.go
+++ b/internal/goal/review.go
@@ -129,6 +129,11 @@ func (s *GoalService) BeginReview(ctx context.Context, id string, enqueue Attemp
 		out = att
 		return nil
 	})
+	if err != nil {
+		// The tx rolled back (lost race / budget / collision); archive the session
+		// minted above so it is not orphaned.
+		s.disposeOrphanSessions(ctx, d.UserID, d.AgentID, sessionID)
+	}
 	return out, err
 }
 

--- a/internal/goal/review.go
+++ b/internal/goal/review.go
@@ -129,11 +129,9 @@ func (s *GoalService) BeginReview(ctx context.Context, id string, enqueue Attemp
 		out = att
 		return nil
 	})
-	if err != nil {
-		// The tx rolled back (lost race / budget / collision); archive the session
-		// minted above so it is not orphaned.
-		s.disposeOrphanSessions(ctx, d.UserID, d.AgentID, sessionID)
-	}
+	// On a definite rollback (lost race / budget / collision), archive the session
+	// minted above so it is not orphaned.
+	s.disposeOnRollback(ctx, err, d.UserID, d.AgentID, sessionID)
 	return out, err
 }
 

--- a/internal/goal/review_test.go
+++ b/internal/goal/review_test.go
@@ -560,6 +560,49 @@ func TestReview_DisposesSessionOnRollback(t *testing.T) {
 	}
 }
 
+// TestDisposeOnRollback pins the rollback gate: a session is archived only on a
+// DEFINITE rollback. A committed flow (nil err) and an AMBIGUOUS commit failure
+// (errTxCommit — the row may be live) are both left alone, so a commit blip can
+// never archive a live session.
+func TestDisposeOnRollback(t *testing.T) {
+	var disposed []string
+	svc := &GoalService{disposeSession: func(_ context.Context, _, _, sid string) error {
+		disposed = append(disposed, sid)
+		return nil
+	}}
+	ctx := context.Background()
+	svc.disposeOnRollback(ctx, nil, "u", "a", "s1")                                 // committed: keep
+	svc.disposeOnRollback(ctx, fmt.Errorf("%w: boom", errTxCommit), "u", "a", "s2") // ambiguous: keep
+	svc.disposeOnRollback(ctx, errors.New("body boom"), "u", "a", "s3")             // rolled back: dispose
+	if len(disposed) != 1 || disposed[0] != "s3" {
+		t.Fatalf("disposed=%v want [s3] (only the definite rollback)", disposed)
+	}
+}
+
+// TestReview_SuccessfulReviewKeepsSession proves the happy path never disposes: a
+// full create -> run -> agent-review -> accept commits every tx, so no session is
+// archived. Guards against a rollback-gate regression that would archive live
+// sessions on success.
+func TestReview_SuccessfulReviewKeepsSession(t *testing.T) {
+	h := newHarness(t)
+	var disposed []string
+	h.svc.disposeSession = func(_ context.Context, _, _, sid string) error {
+		disposed = append(disposed, sid)
+		return nil
+	}
+	h.exec.fn = reviewExec("H1", reviewVerdict(true, "lgtm"))
+	d := h.createRoot(KindLeaf, agentJudgmentContract())
+	h.activate(d.ID)
+	h.runLeaf(d.ID)
+	h.runReview(d.ID)
+	if got := h.get(d.ID); got.Lifecycle != LifecycleAccepted {
+		t.Fatalf("want accepted, got %q", got.Lifecycle)
+	}
+	if len(disposed) != 0 {
+		t.Fatalf("successful flow disposed %v; want none", disposed)
+	}
+}
+
 // TestValidateReviewVerdicts pins the in-turn coverage guard: a review must
 // answer every required item exactly once and name no unknown item.
 func TestValidateReviewVerdicts(t *testing.T) {

--- a/internal/goal/review_test.go
+++ b/internal/goal/review_test.go
@@ -517,6 +517,49 @@ func TestReview_RespectsConcurrencyCap(t *testing.T) {
 	}
 }
 
+// TestReview_DisposesSessionOnRollback proves the session minted before
+// BeginReview's tx is archived when that tx rolls back, so a lost race / collision
+// does not orphan it. A failing enqueue forces the rollback deterministically
+// (mint happens outside the tx; enqueue inside it).
+func TestReview_DisposesSessionOnRollback(t *testing.T) {
+	h := newHarness(t)
+	// Record every minted session (the last one is the review session) and every
+	// disposed session, replacing the minter/disposer on the service directly.
+	base := h.sessionMinter()
+	var minted []string
+	h.svc.newSession = func(ctx context.Context, u, a, p string) (string, error) {
+		id, err := base(ctx, u, a, p)
+		if err == nil {
+			minted = append(minted, id)
+		}
+		return id, err
+	}
+	var disposed []string
+	h.svc.disposeSession = func(_ context.Context, _, _, sid string) error {
+		disposed = append(disposed, sid)
+		return nil
+	}
+
+	h.exec.fn = reviewExec("H1", reviewVerdict(true, "lgtm"))
+	d := h.createRoot(KindLeaf, agentJudgmentContract())
+	h.activate(d.ID)
+	h.runLeaf(d.ID) // blocked(needs_verdict)
+
+	ctx := context.Background()
+	boom := errors.New("enqueue boom")
+	if _, err := h.svc.BeginReview(ctx, d.ID, func(_ context.Context, _ pgx.Tx, _, _ string) error {
+		return boom
+	}); !errors.Is(err, boom) {
+		t.Fatalf("BeginReview err=%v want enqueue boom", err)
+	}
+	if len(disposed) != 1 {
+		t.Fatalf("disposed %d sessions, want 1 (the rolled-back review session)", len(disposed))
+	}
+	if want := minted[len(minted)-1]; disposed[0] != want {
+		t.Fatalf("disposed %q want the review session %q", disposed[0], want)
+	}
+}
+
 // TestValidateReviewVerdicts pins the in-turn coverage guard: a review must
 // answer every required item exactly once and name no unknown item.
 func TestValidateReviewVerdicts(t *testing.T) {

--- a/internal/goal/service.go
+++ b/internal/goal/service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/google/uuid"
@@ -23,6 +24,16 @@ import (
 // a row the outer tx holds) and pin a pooled connection. Implementations land in
 // the integration phase (session.go).
 type SessionMinter func(ctx context.Context, userID, agentID, projectID string) (string, error)
+
+// SessionDisposer archives a session that was minted OUTSIDE a tx whose durable
+// write then rolled back (a lost race re-checking eligibility under the lock, a
+// budget re-check, or a unique-attempt collision). Without it the orphaned hidden
+// session lingers forever — no attempt or goal references it, but it persists. It
+// is best effort: it runs outside the tx and a failure only logs (the leak is rare
+// — the in-flight guards reject the common re-mint before any session is minted —
+// and a future orphan sweep can backstop). A nil disposer is a no-op (tests).
+// Implementations land in session.go alongside the minters.
+type SessionDisposer func(ctx context.Context, userID, agentID, sessionID string) error
 
 // Executor owns agent interaction for one attempt and is PURE with respect to
 // durable state: Execute returns the action it wants; the WORKER applies the
@@ -102,8 +113,9 @@ const (
 type GoalService struct {
 	db                 *pgxpool.Pool
 	q                  *sqlc.Queries
-	newSession         SessionMinter // worker session (KindTask)
-	newPlanningSession SessionMinter // decomposition session (KindDelegate)
+	newSession         SessionMinter   // worker session (KindTask)
+	newPlanningSession SessionMinter   // decomposition session (KindDelegate)
+	disposeSession     SessionDisposer // archives a session orphaned by a rolled-back mint
 	checks             CheckRunner
 	exec               Executor
 	clock              func() time.Time
@@ -140,6 +152,33 @@ func WithSessionMinter(m SessionMinter) Option {
 // WithPlanningSessionMinter sets the decomposition planning-session minter.
 func WithPlanningSessionMinter(m SessionMinter) Option {
 	return func(s *GoalService) { s.newPlanningSession = m }
+}
+
+// WithSessionDisposer sets the disposer used to archive sessions orphaned when a
+// mint-then-tx flow rolls back. Optional: a nil disposer leaves the (rare) leak in
+// place rather than failing the flow.
+func WithSessionDisposer(d SessionDisposer) Option {
+	return func(s *GoalService) { s.disposeSession = d }
+}
+
+// disposeOrphanSessions archives sessions that were minted before a tx that then
+// failed, so a rolled-back mint-then-write does not orphan them. Best effort and
+// nil-safe: empty ids are skipped and a disposer error only logs (the caller's tx
+// already failed and is the real error to surface). Call ONLY on the tx-error
+// path — a committed flow owns its sessions.
+func (s *GoalService) disposeOrphanSessions(ctx context.Context, userID, agentID string, sessionIDs ...string) {
+	if s.disposeSession == nil {
+		return
+	}
+	for _, sid := range sessionIDs {
+		if sid == "" {
+			continue
+		}
+		if err := s.disposeSession(ctx, userID, agentID, sid); err != nil {
+			slog.Default().Warn("goal: dispose orphaned session failed",
+				"component", "goal/service", "session_id", sid, "err", err)
+		}
+	}
 }
 
 // WithCheckRunner sets the deterministic check runner.
@@ -388,6 +427,7 @@ func (s *GoalService) CreateGoal(ctx context.Context, in CreateInput) (sqlc.Agen
 // pre-minted child sessions). Child goals get their sessions from
 // Materialize instead, so this entry is root-only.
 func (s *GoalService) CreateRoot(ctx context.Context, in CreateInput) (sqlc.AgentGoal, error) {
+	var minted string
 	if in.SessionID == "" {
 		if s.newSession == nil {
 			return sqlc.AgentGoal{}, fmt.Errorf("goal: no session minter configured")
@@ -397,8 +437,15 @@ func (s *GoalService) CreateRoot(ctx context.Context, in CreateInput) (sqlc.Agen
 			return sqlc.AgentGoal{}, fmt.Errorf("goal: mint root session: %w", err)
 		}
 		in.SessionID = sid
+		minted = sid
 	}
-	return s.CreateGoal(ctx, in)
+	out, err := s.CreateGoal(ctx, in)
+	if err != nil && minted != "" {
+		// The insert rolled back; archive only the session we minted here (never a
+		// caller-supplied one) so it is not orphaned.
+		s.disposeOrphanSessions(ctx, in.UserID, in.AgentID, minted)
+	}
+	return out, err
 }
 
 // UpdateInput is the mutable metadata of a goal (PATCH). A nil pointer

--- a/internal/goal/service.go
+++ b/internal/goal/service.go
@@ -161,20 +161,35 @@ func WithSessionDisposer(d SessionDisposer) Option {
 	return func(s *GoalService) { s.disposeSession = d }
 }
 
-// disposeOrphanSessions archives sessions that were minted before a tx that then
-// failed, so a rolled-back mint-then-write does not orphan them. Best effort and
-// nil-safe: empty ids are skipped and a disposer error only logs (the caller's tx
-// already failed and is the real error to surface). Call ONLY on the tx-error
-// path — a committed flow owns its sessions.
+// disposeOnRollback archives pre-minted sessions when txErr indicates the tx
+// DEFINITELY rolled back, so a lost race / collision does not orphan them. A nil
+// err (committed) or an AMBIGUOUS commit failure (errTxCommit — the server may have
+// committed, so the session may now be live) is left alone: archiving a live
+// session would break the worker that resumes it. The orphan sweep is the backstop
+// for the ambiguous case. Use this at every mint-then-tx site.
+func (s *GoalService) disposeOnRollback(ctx context.Context, txErr error, userID, agentID string, sessionIDs ...string) {
+	if txErr == nil || errors.Is(txErr, errTxCommit) {
+		return
+	}
+	s.disposeOrphanSessions(ctx, userID, agentID, sessionIDs...)
+}
+
+// disposeOrphanSessions archives sessions minted before a write that did not take,
+// so they are not orphaned. Best effort and nil-safe: empty ids are skipped and a
+// disposer error only logs. It detaches from the caller's cancellation — the tx
+// often failed BECAUSE ctx was cancelled/timed out, and reusing it would fail the
+// cleanup too — keeping ctx values but bounding the cleanup with a short timeout.
 func (s *GoalService) disposeOrphanSessions(ctx context.Context, userID, agentID string, sessionIDs ...string) {
 	if s.disposeSession == nil {
 		return
 	}
+	dctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
 	for _, sid := range sessionIDs {
 		if sid == "" {
 			continue
 		}
-		if err := s.disposeSession(ctx, userID, agentID, sid); err != nil {
+		if err := s.disposeSession(dctx, userID, agentID, sid); err != nil {
 			slog.Default().Warn("goal: dispose orphaned session failed",
 				"component", "goal/service", "session_id", sid, "err", err)
 		}
@@ -251,10 +266,19 @@ func (s *GoalService) withTxRaw(ctx context.Context, fn func(*sqlc.Queries, pgx.
 		return err
 	}
 	if cerr := tx.Commit(ctx); cerr != nil {
-		err = fmt.Errorf("commit: %w", cerr)
+		// Tag commit failures so callers can tell a DEFINITE rollback (body error /
+		// begin error — nothing committed) from an AMBIGUOUS commit (the server may
+		// have committed even though the client saw an error). Compensating cleanup
+		// that assumes rollback (disposeOnRollback) must skip the ambiguous case.
+		err = fmt.Errorf("%w: %w", errTxCommit, cerr)
 	}
 	return err
 }
+
+// errTxCommit tags a withTxRaw error that originated in tx.Commit — an ambiguous
+// outcome (the row may be committed on the server). Distinct from a body/begin
+// error, which is a definite rollback. See disposeOnRollback.
+var errTxCommit = errors.New("commit")
 
 // getGoal loads a row, mapping pgx.ErrNoRows to ErrNotFound.
 func getGoal(ctx context.Context, q *sqlc.Queries, id string) (sqlc.AgentGoal, error) {
@@ -440,10 +464,10 @@ func (s *GoalService) CreateRoot(ctx context.Context, in CreateInput) (sqlc.Agen
 		minted = sid
 	}
 	out, err := s.CreateGoal(ctx, in)
-	if err != nil && minted != "" {
-		// The insert rolled back; archive only the session we minted here (never a
+	if minted != "" {
+		// On a definite rollback, archive only the session we minted here (never a
 		// caller-supplied one) so it is not orphaned.
-		s.disposeOrphanSessions(ctx, in.UserID, in.AgentID, minted)
+		s.disposeOnRollback(ctx, err, in.UserID, in.AgentID, minted)
 	}
 	return out, err
 }

--- a/internal/goal/session.go
+++ b/internal/goal/session.go
@@ -48,6 +48,21 @@ func RegistryPlanningSessionMinter(sm agent.ServiceManager) SessionMinter {
 	}
 }
 
+// RegistrySessionDisposer archives a session orphaned by a rolled-back
+// mint-then-write, through the same registry the minters use. Archiving (not
+// hard-delete) is the registry's dispose primitive: the row is flagged so it is
+// never resumed or listed, which is all an orphaned hidden session needs.
+// Satisfies SessionDisposer.
+func RegistrySessionDisposer(sm agent.ServiceManager) SessionDisposer {
+	return func(ctx context.Context, userID, agentID, sessionID string) error {
+		svc, err := resolveService(sm, userID, agentID)
+		if err != nil {
+			return err
+		}
+		return svc.Sessions.Archive(ctx, session.Scope{UserID: userID, AgentID: agentID}, sessionID)
+	}
+}
+
 // resolveService validates the owner identity and resolves the executor agent's
 // Service from the registry. A missing user/agent or unknown agent is a caller
 // error, not a panic — minting cannot proceed without an owner.


### PR DESCRIPTION
## What

Archive the hidden session a headless goal flow mints **outside** its durable tx
when that tx then rolls back, so a lost race / collision no longer orphans it.

## Why

The minter opens its own tx and would self-deadlock against a held one, so every
headless flow mints the session first, then opens the durable tx. If that tx rolls
back — a lost race re-checking eligibility under the lock, a budget re-check, or a
`uniq_agent_goal_active_attempt` collision — the minted session was orphaned: no
attempt or goal referenced it, but it persisted forever. Low severity (the
in-flight guards reject the common re-mint *before* any session is minted), but the
orphans accumulate invisibly.

## How

- Add an optional `SessionDisposer` (+ `WithSessionDisposer`, nil-safe
  `disposeOrphanSessions` helper). Implementation `RegistrySessionDisposer`
  archives through the same agent registry the minters use — archiving (not
  hard-delete) is all an orphaned hidden session needs (never resumed or listed).
- Call it on the **tx-error path** of every mint-then-tx site: `BeginReview`,
  `BeginDecomposition`, `BeginAutoDecomposition`, `SubmitDecomposition`,
  `ApprovePlan`, `CreateRoot`. (The issue named three; the other three share the
  pattern, so they are fixed for consistency.) `CreateRoot` archives only a session
  it minted itself, never a caller-supplied one.
- Best effort: a disposer error only logs; the caller's tx error is the real one to
  surface.
- Regression test: a failing enqueue forces `BeginReview`'s tx to roll back
  deterministically and asserts the minted session is disposed.

A periodic orphan sweep (to also catch a crash between mint and commit) is left as a
future backstop — the rollback-after-mint window is the common, recoverable path
this PR closes.

## Refs

- Closes #607
- Follow-up from PR #606 (agent auto-review), where the leak was first noted