### PR TITLE
✨ feat(goal): 契约闭环——structural 修复同 session 回灌 + 独立预算 + failure_class

### DIFF
--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -917,7 +917,14 @@ components:
           ]
         block_reason:
           type: string
-          enum: ["", budget_exhausted, needs_plan_approval, needs_verdict, dep]
+          enum: [
+            "",
+            budget_exhausted,
+            needs_plan_approval,
+            planning_invalid,
+            needs_verdict,
+            dep,
+          ]
           description: Meaningful only when lifecycle=blocked.
         acceptance_state:
           type: string
@@ -1112,6 +1119,9 @@ components:
         max_depth:
           type: integer
           description: Recursion ceiling. Default 4.
+        planner_repair_max:
+          type: integer
+          description: Structural planning repair turns in the same session. Default 2.
         max_concurrent:
           type: integer
           description: Per-root breadth-of-fanout cap. Default 8.
@@ -1165,6 +1175,10 @@ components:
           additionalProperties: {}
         error:
           type: string
+        failure_class:
+          type: string
+          enum: ["", structural, semantic, transient]
+          description: Class for failed or interrupted attempts.
         worker_id:
           type: string
         heartbeat_at:

--- a/api/spec/domain/goals/schemas.yaml
+++ b/api/spec/domain/goals/schemas.yaml
@@ -90,7 +90,15 @@ components:
             ]
         block_reason:
           type: string
-          enum: ["", budget_exhausted, needs_plan_approval, needs_verdict, dep]
+          enum:
+            [
+              "",
+              budget_exhausted,
+              needs_plan_approval,
+              planning_invalid,
+              needs_verdict,
+              dep,
+            ]
           description: Meaningful only when lifecycle=blocked.
         acceptance_state:
           type: string
@@ -271,6 +279,9 @@ components:
         max_depth:
           type: integer
           description: Recursion ceiling. Default 4.
+        planner_repair_max:
+          type: integer
+          description: Structural planning repair turns in the same session. Default 2.
         max_concurrent:
           type: integer
           description: Per-root breadth-of-fanout cap. Default 8.
@@ -316,6 +327,10 @@ components:
           type: object
           additionalProperties: {}
         error: { type: string }
+        failure_class:
+          type: string
+          enum: ["", structural, semantic, transient]
+          description: Class for failed or interrupted attempts.
         worker_id: { type: string }
         heartbeat_at: { type: string, format: date-time, nullable: true }
         lease_expires_at: { type: string, format: date-time, nullable: true }

--- a/internal/agent/prompt/template/system_prompt.tmpl
+++ b/internal/agent/prompt/template/system_prompt.tmpl
@@ -40,7 +40,7 @@ When you are **dispatched as a worker**, the goal's intent and acceptance criter
 - `submit` — provide `evidence` (summary + optional artifacts) and `output` when the work meets the acceptance criteria.
 - `block` — pause with `kind`/`question` when you need input or an external dependency.
 - `fail` — report `reason`/`retryable` when the work cannot be completed.
-- `decompose` — when dispatched to plan a goal: return a `decomposition` `{children, edges}` (each child has key, title, intent, kind, required, acceptance_contract; edges declare hard/soft deps). Otherwise use `fail`.
+- `decompose` — when dispatched to plan a goal: return a `decomposition` `{children, edges}` (each child has key, title, intent, kind, required, acceptance_contract; edges declare hard/soft deps). If the prompt includes `prior_errors`, fix those structural errors in the next `decompose` call. Otherwise use `fail`.
 
 A final text response without `goal_control` is a protocol failure. Your `submit` does not make the goal done — the acceptance contract decides; if it falls short you'll be dispatched again with the gaps to repair.
 

--- a/internal/db/migrations/20260702085628_add_goal_attempt_failure_class.sql
+++ b/internal/db/migrations/20260702085628_add_goal_attempt_failure_class.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE agent_goal_attempt
+    ADD COLUMN failure_class text NOT NULL DEFAULT '';
+
+-- +goose Down
+ALTER TABLE agent_goal_attempt
+    DROP COLUMN failure_class;

--- a/internal/db/queries/agent_goal_attempt.sql
+++ b/internal/db/queries/agent_goal_attempt.sql
@@ -82,6 +82,7 @@ WHERE id = sqlc.arg(id);
 UPDATE agent_goal_attempt
 SET status = sqlc.arg(to_status),
     error = sqlc.arg(error),
+    failure_class = sqlc.arg(failure_class),
     finished_at = now(),
     updated_at = now()
 WHERE id = sqlc.arg(id) AND status IN ('queued', 'running');

--- a/internal/goal/boot.go
+++ b/internal/goal/boot.go
@@ -376,7 +376,7 @@ func (s *Service) Abandon(ctx context.Context, id, reason string, by Actor) erro
 	return s.Goal.Abandon(ctx, id, reason, by)
 }
 
-// Reattempt raises the budget on a blocked(budget_exhausted) goal.
+// Reattempt resumes a recoverably blocked goal, raising budget only for budget_exhausted.
 func (s *Service) Reattempt(ctx context.Context, id string, by Actor) error {
 	return s.Goal.Reattempt(ctx, id, by)
 }

--- a/internal/goal/composite_rollup_test.go
+++ b/internal/goal/composite_rollup_test.go
@@ -554,7 +554,7 @@ func TestCompositeRollup_ReattemptComposite(t *testing.T) {
 		if err != nil {
 			t.Fatalf("BeginDecomposition #%d: %v", i+1, err)
 		}
-		if err := h.svc.FailAttempt(ctx, att.ID, "planner boom"); err != nil {
+		if err := h.svc.FailAttempt(ctx, att.ID, "planner boom", FailureClassSemantic); err != nil {
 			t.Fatalf("FailAttempt #%d: %v", i+1, err)
 		}
 	}
@@ -621,8 +621,10 @@ func TestCompositeRollup_RedecomposeAfterInterrupt(t *testing.T) {
 	// Simulate an interrupted decomposition (worker crash / restart): finalize the
 	// attempt out of queued/running and reset the goal active->draft for a re-plan.
 	if _, err := h.q.FinalizeAttempt(ctx, sqlc.FinalizeAttemptParams{
-		ToStatus: AttemptInterrupted,
-		ID:       att1.ID,
+		ToStatus:     AttemptInterrupted,
+		Error:        "interrupted in test",
+		FailureClass: FailureClassTransient,
+		ID:           att1.ID,
 	}); err != nil {
 		t.Fatalf("FinalizeAttempt: %v", err)
 	}

--- a/internal/goal/contract.go
+++ b/internal/goal/contract.go
@@ -15,6 +15,9 @@ const (
 	// goal blocked(needs_verdict) for a human. A rework that yields a new execution
 	// output starts a fresh episode with full budget (see CountRanReviewAttemptsForOutput).
 	defaultMaxReviewAttempts = 2
+	// defaultPlannerRepairMax bounds structural decomposition repair turns inside
+	// the same planning session before the composite blocks as planning_invalid.
+	defaultPlannerRepairMax = 2
 )
 
 // AcceptanceContract is the composite policy tree of deterministic + judgment
@@ -47,6 +50,9 @@ type ConvergencePolicy struct {
 	MaxAttempts int    `json:"max_attempts"`        // default 3; exhaustion → blocked(budget_exhausted)
 	Escalation  string `json:"escalation"`          // block (default) | abandon
 	MaxDepth    int    `json:"max_depth,omitempty"` // recursion ceiling; default 4
+	// PlannerRepairMax bounds structural decomposition repair turns inside one
+	// planning session; these do not consume MaxAttempts plan budget.
+	PlannerRepairMax int `json:"planner_repair_max,omitempty"`
 	// MaxConcurrent bounds breadth-of-fanout per root (§5, default 8). Read from
 	// the root's policy by the dispatcher; 0 ⇒ default.
 	MaxConcurrent int `json:"max_concurrent,omitempty"`
@@ -133,14 +139,15 @@ func (i AcceptanceItem) Valid() bool {
 // Valid reports whether the convergence policy is well-formed. A zero-value
 // policy is valid; Normalized fills the defaults.
 func (p ConvergencePolicy) Valid() bool {
-	if p.MaxAttempts < 0 || p.MaxDepth < 0 || p.MaxConcurrent < 0 {
+	if p.MaxAttempts < 0 || p.MaxDepth < 0 || p.PlannerRepairMax < 0 || p.MaxConcurrent < 0 {
 		return false
 	}
 	return p.Escalation == "" || ValidEscalation(p.Escalation)
 }
 
 // Normalized returns the policy with defaults applied (MaxAttempts 3,
-// Escalation block, MaxDepth 4, MaxConcurrent 8). It never mutates the receiver.
+// Escalation block, MaxDepth 4, PlannerRepairMax 2, MaxConcurrent 8). It never
+// mutates the receiver.
 func (p ConvergencePolicy) Normalized() ConvergencePolicy {
 	if p.MaxAttempts <= 0 {
 		p.MaxAttempts = defaultMaxAttempts
@@ -150,6 +157,9 @@ func (p ConvergencePolicy) Normalized() ConvergencePolicy {
 	}
 	if p.MaxDepth <= 0 {
 		p.MaxDepth = defaultMaxDepth
+	}
+	if p.PlannerRepairMax <= 0 {
+		p.PlannerRepairMax = defaultPlannerRepairMax
 	}
 	if p.MaxConcurrent <= 0 {
 		p.MaxConcurrent = defaultMaxConcurrent

--- a/internal/goal/converge.go
+++ b/internal/goal/converge.go
@@ -29,7 +29,9 @@ func buildInputContext(d sqlc.AgentGoal, upstream []AcceptedOutput, priorGaps *E
 	var c AcceptanceContract
 	_ = unmarshalJSON(d.AcceptanceContract, &c)
 	return AttemptInput{
+		Title:           d.Title,
 		Intent:          d.Intent,
+		Context:         d.Context,
 		UpstreamOutputs: upstream,
 		PriorGaps:       priorGaps,
 		Contract:        c,
@@ -260,7 +262,10 @@ func (s *GoalService) Submit(ctx context.Context, attemptID string, ev AttemptEv
 // A 0-row FinalizeAttempt means the attempt is no longer queued/running (already
 // reaped/raced); the tx rolls back and the caller treats ErrInvalidTransition as a
 // no-op (the goal already recovered).
-func (s *GoalService) FailAttempt(ctx context.Context, attemptID, reason string) error {
+func (s *GoalService) FailAttempt(ctx context.Context, attemptID, reason, failureClass string) error {
+	if !ValidFailureClass(failureClass) || failureClass == "" {
+		return ErrInvalidTransition
+	}
 	return s.withTx(ctx, func(q *sqlc.Queries) error {
 		att, err := q.GetAttempt(ctx, attemptID)
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -270,9 +275,10 @@ func (s *GoalService) FailAttempt(ctx context.Context, attemptID, reason string)
 			return err
 		}
 		rows, err := q.FinalizeAttempt(ctx, sqlc.FinalizeAttemptParams{
-			ToStatus: AttemptFailed,
-			Error:    reason,
-			ID:       attemptID,
+			ToStatus:     AttemptFailed,
+			Error:        reason,
+			FailureClass: failureClass,
+			ID:           attemptID,
 		})
 		if err != nil {
 			return fmt.Errorf("finalize failed attempt: %w", err)
@@ -285,8 +291,14 @@ func (s *GoalService) FailAttempt(ctx context.Context, attemptID, reason string)
 			return err
 		}
 		if att.Purpose == PurposeDecomposition {
-			// A reported decomposition failure always ran the planner, so it charges
-			// one plan-budget unit.
+			// Structural planner failures are repaired inside the same planning session.
+			// If the repair loop gives up, park the composite on a distinct block reason
+			// without charging the semantic/transient plan budget.
+			if failureClass == FailureClassStructural {
+				return s.blockPlanningInvalid(ctx, q, d)
+			}
+			// A reported semantic/transient decomposition failure ran the planner, so it
+			// charges one plan-budget unit as before.
 			return s.recoverDecomposition(ctx, q, d, true)
 		}
 		if att.Purpose == PurposeReview {
@@ -913,6 +925,28 @@ func (s *GoalService) blockBudget(ctx context.Context, q *sqlc.Queries, d sqlc.A
 	})
 	if err != nil {
 		return fmt.Errorf("block budget: %w", err)
+	}
+	if rows == 0 {
+		return ErrInvalidTransition
+	}
+	return nil
+}
+
+// blockPlanningInvalid parks a composite whose planner exhausted structural
+// repairs. This is not convergence-budget exhaustion, so Reattempt does not use
+// the semantic/transient plan budget path.
+func (s *GoalService) blockPlanningInvalid(ctx context.Context, q *sqlc.Queries, d sqlc.AgentGoal) error {
+	if err := q.ClearGoalActiveAttempt(ctx, d.ID); err != nil {
+		return fmt.Errorf("clear active attempt: %w", err)
+	}
+	rows, err := q.TransitionGoalLifecycle(ctx, sqlc.TransitionGoalLifecycleParams{
+		ToLifecycle:   LifecycleBlocked,
+		BlockReason:   BlockPlanningInvalid,
+		ID:            d.ID,
+		FromLifecycle: LifecycleActive,
+	})
+	if err != nil {
+		return fmt.Errorf("block planning invalid: %w", err)
 	}
 	if rows == 0 {
 		return ErrInvalidTransition

--- a/internal/goal/create_defaults_test.go
+++ b/internal/goal/create_defaults_test.go
@@ -5,9 +5,9 @@ import "testing"
 // TestCreateRoot_NormalizesConvergencePolicy pins that a goal created without an
 // explicit convergence policy persists the effective defaults, not a bare zero
 // policy. The create response then shows real values (max_attempts 3, block,
-// depth 4, concurrent 8) instead of a confusing max_attempts:0, and the goal's
-// budget is frozen at create rather than depending on every runtime caller to
-// Normalize.
+// depth 4, planner repair 2, concurrent 8) instead of a confusing
+// max_attempts:0, and the goal's budget is frozen at create rather than depending
+// on every runtime caller to Normalize.
 func TestCreateRoot_NormalizesConvergencePolicy(t *testing.T) {
 	h := newHarness(t)
 	root := h.createRoot(KindLeaf, AcceptanceContract{})
@@ -17,10 +17,11 @@ func TestCreateRoot_NormalizesConvergencePolicy(t *testing.T) {
 		t.Fatalf("decode convergence_policy: %v", err)
 	}
 	want := ConvergencePolicy{
-		MaxAttempts:   defaultMaxAttempts,
-		Escalation:    EscalationBlock,
-		MaxDepth:      defaultMaxDepth,
-		MaxConcurrent: defaultMaxConcurrent,
+		MaxAttempts:      defaultMaxAttempts,
+		Escalation:       EscalationBlock,
+		MaxDepth:         defaultMaxDepth,
+		PlannerRepairMax: defaultPlannerRepairMax,
+		MaxConcurrent:    defaultMaxConcurrent,
 	}
 	if pol != want {
 		t.Fatalf("convergence_policy = %+v, want defaults %+v applied at create", pol, want)

--- a/internal/goal/decompose.go
+++ b/internal/goal/decompose.go
@@ -60,74 +60,7 @@ const maxDecompositionBreadth = 64
 //
 // parentDepth is the composite's own depth; a child sits at parentDepth+1.
 func ValidateDecomposition(c DecompositionContent, parentDepth, maxDepth int) error {
-	if len(c.Children) > maxDecompositionBreadth {
-		return ErrInvalidDecomposition
-	}
-	keys := make(map[string]ProposedChild, len(c.Children))
-	requiredCount := 0
-	for _, ch := range c.Children {
-		if ch.Key == "" {
-			return ErrInvalidDecomposition
-		}
-		if _, dup := keys[ch.Key]; dup {
-			return ErrInvalidDecomposition
-		}
-		if ch.Kind != "" && !ValidKind(ch.Kind) {
-			return ErrInvalidDecomposition
-		}
-		if !ch.AcceptanceContract.Valid() || !ch.ConvergencePolicy.Valid() {
-			return ErrInvalidContract
-		}
-		if ch.Kind == KindComposite {
-			// A composite child can never satisfy a deterministic item and must have
-			// room to decompose its own children at parentDepth+2.
-			if ch.AcceptanceContract.HasDeterministicItem() {
-				return ErrCompositeDeterministicContract
-			}
-			if parentDepth+2 > maxDepth {
-				return ErrDepthExceeded
-			}
-		}
-		if ch.ReviewPolicy != "" && !ValidReviewPolicy(ch.ReviewPolicy) {
-			return ErrInvalidDecomposition
-		}
-		if ch.Required {
-			requiredCount++
-		}
-		keys[ch.Key] = ch
-	}
-	if requiredCount < 1 {
-		return ErrInvalidDecomposition // a decomposition must commit to ≥1 required child
-	}
-	if parentDepth+1 > maxDepth {
-		return ErrDepthExceeded
-	}
-
-	// Edges: keys resolve, kinds/policies known.
-	adj := make(map[string][]string, len(c.Children))
-	for _, e := range c.Edges {
-		if _, ok := keys[e.DownstreamKey]; !ok {
-			return ErrInvalidDecomposition
-		}
-		if _, ok := keys[e.UpstreamKey]; !ok {
-			return ErrInvalidDecomposition
-		}
-		if e.DownstreamKey == e.UpstreamKey {
-			return ErrCycle
-		}
-		if e.Kind != "" && !ValidEdgeKind(e.Kind) {
-			return ErrInvalidDecomposition
-		}
-		if e.OnFailure != "" && !ValidOnFailure(e.OnFailure) {
-			return ErrInvalidDecomposition
-		}
-		// Edge downstream depends on upstream: upstream → downstream in the DAG.
-		adj[e.UpstreamKey] = append(adj[e.UpstreamKey], e.DownstreamKey)
-	}
-	if hasCycleDFS(keys, adj) {
-		return ErrCycle
-	}
-	return nil
+	return validateDecompositionError(c, parentDepth, maxDepth)
 }
 
 // hasCycleDFS reports whether the key dependency graph contains a cycle, via a

--- a/internal/goal/decomposition_budget_test.go
+++ b/internal/goal/decomposition_budget_test.go
@@ -116,7 +116,7 @@ func TestDecompositionBudgetExhausted_ParentBlocks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BeginDecomposition(child): %v", err)
 	}
-	if err := h.svc.FailAttempt(ctx, att.ID, "planner produced no valid decomposition"); err != nil {
+	if err := h.svc.FailAttempt(ctx, att.ID, "planner produced no valid decomposition", FailureClassSemantic); err != nil {
 		t.Fatalf("FailAttempt: %v", err)
 	}
 	blocked := h.get(childA)

--- a/internal/goal/decomposition_errors.go
+++ b/internal/goal/decomposition_errors.go
@@ -1,0 +1,179 @@
+package goal
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ValidationError is a structured planner-contract violation that can be fed
+// back to the same planning session without asking the model to infer from prose.
+type ValidationError struct {
+	Path     string `json:"path"`
+	Code     string `json:"code"`
+	Message  string `json:"message"`
+	Expected string `json:"expected,omitempty"`
+	Actual   string `json:"actual,omitempty"`
+	Hint     string `json:"hint,omitempty"`
+}
+
+func RenderErrorsJSON(errs []ValidationError) string {
+	b, err := json.MarshalIndent(errs, "", "  ")
+	if err != nil {
+		return "[]"
+	}
+	return string(b)
+}
+
+func RenderErrorsText(errs []ValidationError) string {
+	if len(errs) == 0 {
+		return "valid"
+	}
+	var b strings.Builder
+	for _, e := range errs {
+		fmt.Fprintf(&b, "- %s at %s: %s", e.Code, e.Path, e.Message)
+		if e.Expected != "" {
+			fmt.Fprintf(&b, " (expected: %s)", e.Expected)
+		}
+		if e.Actual != "" {
+			fmt.Fprintf(&b, " (actual: %s)", e.Actual)
+		}
+		if e.Hint != "" {
+			fmt.Fprintf(&b, " hint: %s", e.Hint)
+		}
+		b.WriteByte('\n')
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func validateDecompositionDetailed(c DecompositionContent, parentDepth, maxDepth int) []ValidationError {
+	var errs []ValidationError
+	add := func(path, code, message, expected, actual, hint string) {
+		errs = append(errs, ValidationError{Path: path, Code: code, Message: message, Expected: expected, Actual: actual, Hint: hint})
+	}
+
+	if len(c.Children) > maxDecompositionBreadth {
+		add("/children", "too_many_children", "decomposition has too many children", fmt.Sprintf("at most %d", maxDecompositionBreadth), fmt.Sprintf("%d", len(c.Children)), "merge or stage lower-priority child goals")
+	}
+	if parentDepth+1 > maxDepth {
+		add("/children", "depth_exceeded", "child depth would exceed max_depth", fmt.Sprintf("parent_depth+1 <= %d", maxDepth), fmt.Sprintf("%d", parentDepth+1), "make this goal a leaf or raise max_depth before planning")
+	}
+
+	keys := make(map[string]ProposedChild, len(c.Children))
+	requiredCount := 0
+	for i, ch := range c.Children {
+		base := fmt.Sprintf("/children/%d", i)
+		if ch.Key == "" {
+			add(base+"/key", "missing_child_key", "child key must be non-empty", "stable non-empty key", "", "generate a short slug and use it in edges")
+		} else if _, dup := keys[ch.Key]; dup {
+			add(base+"/key", "duplicate_child_key", fmt.Sprintf("duplicate child key %q", ch.Key), "unique child keys", ch.Key, "rename this child and update any edges")
+		}
+		if ch.Kind != "" && !ValidKind(ch.Kind) {
+			add(base+"/kind", "invalid_child_kind", "child kind is not supported", "leaf or composite", ch.Kind, "choose leaf unless the child needs its own decomposition")
+		}
+		if !ch.AcceptanceContract.Valid() {
+			add(base+"/acceptance_contract", "invalid_acceptance_contract", "acceptance contract is invalid", "valid Stella acceptance contract", string(marshalJSON(ch.AcceptanceContract)), "fix policy/items or use an empty object for trivial acceptance")
+		}
+		if !ch.ConvergencePolicy.Valid() {
+			add(base+"/convergence_policy", "invalid_convergence_policy", "convergence policy is invalid", "non-negative bounds and known escalation", string(marshalJSON(ch.ConvergencePolicy)), "remove negative values and use escalation block or abandon")
+		}
+		if ch.Kind == KindComposite {
+			if ch.AcceptanceContract.HasDeterministicItem() {
+				add(base+"/acceptance_contract", "composite_deterministic_contract", "composite children cannot carry deterministic acceptance items", "judgment-only or trivial composite contract", string(marshalJSON(ch.AcceptanceContract)), "put deterministic checks on leaf children")
+			}
+			if parentDepth+2 > maxDepth {
+				add(base+"/kind", "depth_exceeded", "composite child would have no depth headroom for its own children", fmt.Sprintf("parent_depth+2 <= %d", maxDepth), fmt.Sprintf("%d", parentDepth+2), "make this child a leaf or reduce nesting")
+			}
+		}
+		if ch.ReviewPolicy != "" && !ValidReviewPolicy(ch.ReviewPolicy) {
+			add(base+"/review_policy", "invalid_review_policy", "review policy is not supported", "none or human", ch.ReviewPolicy, "omit review_policy or set it to human")
+		}
+		if ch.Required {
+			requiredCount++
+		}
+		if ch.Key != "" {
+			keys[ch.Key] = ch
+		}
+	}
+	if requiredCount < 1 {
+		add("/children", "no_required_child", "decomposition must include at least one required child", "at least one child with required=true", "0", "mark the child that completes the goal as required")
+	}
+
+	adj := make(map[string][]string, len(c.Children))
+	for i, e := range c.Edges {
+		base := fmt.Sprintf("/edges/%d", i)
+		if _, ok := keys[e.DownstreamKey]; !ok {
+			add(base+"/downstream_key", "unknown_edge_downstream", fmt.Sprintf("downstream key %q does not match any child", e.DownstreamKey), oneOfChildKeys(keys), e.DownstreamKey, "use an existing children[].key")
+		}
+		if _, ok := keys[e.UpstreamKey]; !ok {
+			add(base+"/upstream_key", "unknown_edge_upstream", fmt.Sprintf("upstream key %q does not match any child", e.UpstreamKey), oneOfChildKeys(keys), e.UpstreamKey, "use an existing children[].key")
+		}
+		if e.DownstreamKey != "" && e.DownstreamKey == e.UpstreamKey {
+			add(base, "self_dependency", "edge cannot point a child at itself", "different upstream and downstream keys", e.DownstreamKey, "remove the edge or choose a different upstream")
+		}
+		if e.Kind != "" && !ValidEdgeKind(e.Kind) {
+			add(base+"/kind", "invalid_edge_kind", "edge kind is not supported", "hard or soft", e.Kind, "use hard for blocking dependencies or soft for advisory ordering")
+		}
+		if e.OnFailure != "" && !ValidOnFailure(e.OnFailure) {
+			add(base+"/on_failure", "invalid_edge_on_failure", "edge on_failure policy is not supported", "block, fail, or ignore", e.OnFailure, "choose how downstream should react if upstream fails")
+		}
+		if _, ok := keys[e.DownstreamKey]; ok {
+			if _, ok := keys[e.UpstreamKey]; ok && e.DownstreamKey != e.UpstreamKey {
+				adj[e.UpstreamKey] = append(adj[e.UpstreamKey], e.DownstreamKey)
+			}
+		}
+	}
+	if len(errs) == 0 && hasCycleDFS(keys, adj) {
+		add("/edges", "cycle_detected", "dependency edges contain a cycle", "DAG", "cycle", "remove an edge or split the loop into a child goal")
+	}
+	return errs
+}
+
+func validateDecompositionError(c DecompositionContent, parentDepth, maxDepth int) error {
+	errs := validateDecompositionDetailed(c, parentDepth, maxDepth)
+	if len(errs) == 0 {
+		return nil
+	}
+	return validationErrorClass(errs[0])
+}
+
+func validationErrorClass(e ValidationError) error {
+	switch e.Code {
+	case "invalid_acceptance_contract", "invalid_convergence_policy":
+		return ErrInvalidContract
+	case "composite_deterministic_contract":
+		return ErrCompositeDeterministicContract
+	case "depth_exceeded":
+		return ErrDepthExceeded
+	case "self_dependency", "cycle_detected":
+		return ErrCycle
+	default:
+		return ErrInvalidDecomposition
+	}
+}
+
+func structuralValidationErrors(err error) []ValidationError {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, ErrInvalidDecomposition) || errors.Is(err, ErrInvalidContract) ||
+		errors.Is(err, ErrCompositeDeterministicContract) || errors.Is(err, ErrDepthExceeded) ||
+		errors.Is(err, ErrCycle) {
+		return []ValidationError{{Path: "/", Code: "structural_error", Message: err.Error(), Hint: "fix the decomposition and call goal_control again"}}
+	}
+	return nil
+}
+
+func oneOfChildKeys(keys map[string]ProposedChild) string {
+	if len(keys) == 0 {
+		return "no child keys available"
+	}
+	out := make([]string, 0, len(keys))
+	for k := range keys {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return strings.Join(out, ", ")
+}

--- a/internal/goal/decomposition_repair_test.go
+++ b/internal/goal/decomposition_repair_test.go
@@ -1,0 +1,207 @@
+package goal
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/CherryHQ/stella/pkg/db/pgnull"
+	"github.com/CherryHQ/stella/pkg/db/sqlc"
+)
+
+func TestDecompositionRepairLoop_ReusesPlanningSessionAndMaterializes(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	root := h.createRoot(KindComposite, AcceptanceContract{})
+	var firstSession string
+	calls := 0
+	h.exec.fn = func(req ExecutorRequest) (ExecutorResult, error) {
+		calls++
+		if req.Input.Title != "root" {
+			t.Fatalf("planner input title=%q want root", req.Input.Title)
+		}
+		if firstSession == "" {
+			firstSession = req.Attempt.SessionID
+		} else if req.Attempt.SessionID != firstSession {
+			t.Fatalf("repair session=%q want first session %q", req.Attempt.SessionID, firstSession)
+		}
+		switch calls {
+		case 1:
+			if len(req.Input.PriorErrors) != 0 {
+				t.Fatalf("first call prior_errors=%d want 0", len(req.Input.PriorErrors))
+			}
+			return ExecutorResult{Submitted: true, Evidence: AttemptEvidence{Summary: "bad"}, Decomposition: &DecompositionContent{
+				Children: []ProposedChild{cmp_child("a", false)},
+			}}, nil
+		case 2:
+			if len(req.Input.PriorErrors) == 0 {
+				t.Fatalf("repair call got no prior_errors")
+			}
+			if got := RenderErrorsJSON(req.Input.PriorErrors); got == "[]" {
+				t.Fatalf("prior_errors JSON rendered empty")
+			}
+			return ExecutorResult{Submitted: true, Evidence: AttemptEvidence{Summary: "fixed"}, Decomposition: &DecompositionContent{
+				Children: []ProposedChild{cmp_child("a", true)},
+			}}, nil
+		default:
+			t.Fatalf("unexpected planner call %d", calls)
+			return ExecutorResult{}, nil
+		}
+	}
+
+	att, err := h.svc.BeginAutoDecomposition(ctx, root.ID, nil)
+	if err != nil {
+		t.Fatalf("BeginAutoDecomposition: %v", err)
+	}
+	if err := h.worker.Run(ctx, root.ID, att.ID, Actor{Type: ActorWorker}); err != nil {
+		t.Fatalf("worker Run: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("planner calls=%d want 2", calls)
+	}
+	got := h.get(root.ID)
+	if !got.PlannedAt.Valid || got.Lifecycle != LifecycleActive {
+		t.Fatalf("root planned=%v lifecycle=%q want planned active", got.PlannedAt.Valid, got.Lifecycle)
+	}
+	if child := h.get(childID(root.ID, "a")); child.Lifecycle != LifecycleReady {
+		t.Fatalf("materialized child lifecycle=%q want ready", child.Lifecycle)
+	}
+	attempts, err := h.q.ListAttemptByGoal(ctx, sqlc.ListAttemptByGoalParams{GoalID: root.ID, Purpose: pgnull.Text(PurposeDecomposition)})
+	if err != nil {
+		t.Fatalf("ListAttemptByGoal: %v", err)
+	}
+	if len(attempts) != 1 || attempts[0].Status != AttemptSubmitted || attempts[0].FailureClass != "" {
+		t.Fatalf("attempts=%+v want one submitted attempt without failure_class", attempts)
+	}
+}
+
+func TestDecompositionRepairLoop_ExhaustionBlocksPlanningInvalid(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	root := h.createRoot(KindComposite, AcceptanceContract{})
+	calls := 0
+	h.exec.fn = func(req ExecutorRequest) (ExecutorResult, error) {
+		calls++
+		if calls > 1 && len(req.Input.PriorErrors) == 0 {
+			t.Fatalf("repair call %d got no prior_errors", calls)
+		}
+		return ExecutorResult{Submitted: true, Evidence: AttemptEvidence{Summary: "bad"}, Decomposition: &DecompositionContent{
+			Children: []ProposedChild{cmp_child("a", false)},
+		}}, nil
+	}
+
+	att, err := h.svc.BeginAutoDecomposition(ctx, root.ID, nil)
+	if err != nil {
+		t.Fatalf("BeginAutoDecomposition: %v", err)
+	}
+	if err := h.worker.Run(ctx, root.ID, att.ID, Actor{Type: ActorWorker}); err != nil {
+		t.Fatalf("worker Run: %v", err)
+	}
+	if calls != defaultPlannerRepairMax+1 {
+		t.Fatalf("planner calls=%d want %d", calls, defaultPlannerRepairMax+1)
+	}
+	blocked := h.get(root.ID)
+	if blocked.Lifecycle != LifecycleBlocked || blocked.BlockReason != BlockPlanningInvalid {
+		t.Fatalf("root lifecycle=%q reason=%q want blocked/planning_invalid", blocked.Lifecycle, blocked.BlockReason)
+	}
+	if blocked.AttemptCount != 0 {
+		t.Fatalf("attempt_count=%d want 0; structural repairs must not consume execution budget", blocked.AttemptCount)
+	}
+	var pol ConvergencePolicy
+	if err := unmarshalJSON(blocked.ConvergencePolicy, &pol); err != nil {
+		t.Fatalf("decode convergence_policy: %v", err)
+	}
+	if pol.MaxAttempts != defaultMaxAttempts {
+		t.Fatalf("max_attempts=%d want %d; structural repairs must not mutate business plan budget", pol.MaxAttempts, defaultMaxAttempts)
+	}
+	attempts, err := h.q.ListAttemptByGoal(ctx, sqlc.ListAttemptByGoalParams{GoalID: root.ID, Purpose: pgnull.Text(PurposeDecomposition)})
+	if err != nil {
+		t.Fatalf("ListAttemptByGoal: %v", err)
+	}
+	if len(attempts) != 1 || attempts[0].Status != AttemptFailed || attempts[0].FailureClass != FailureClassStructural {
+		t.Fatalf("attempts=%+v want one failed structural attempt", attempts)
+	}
+}
+
+func TestDecompositionFailureClass_PersistsSemanticAndTransient(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	cases := []struct {
+		name          string
+		finalize      func(string) error
+		wantClass     string
+		wantLifecycle string
+	}{
+		{
+			name: "semantic",
+			finalize: func(attemptID string) error {
+				return h.svc.FailAttempt(ctx, attemptID, "planner cannot decompose", FailureClassSemantic)
+			},
+			wantClass:     FailureClassSemantic,
+			wantLifecycle: LifecycleDraft,
+		},
+		{
+			name: "transient",
+			finalize: func(attemptID string) error {
+				return h.svc.ReapAttempt(ctx, attemptID)
+			},
+			wantClass:     FailureClassTransient,
+			wantLifecycle: LifecycleDraft,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := h.createRoot(KindComposite, AcceptanceContract{})
+			att, err := h.svc.BeginAutoDecomposition(ctx, root.ID, AttemptEnqueuer(func(context.Context, pgx.Tx, string, string) error { return nil }))
+			if err != nil {
+				t.Fatalf("BeginAutoDecomposition: %v", err)
+			}
+			if err := tc.finalize(att.ID); err != nil {
+				t.Fatalf("finalize: %v", err)
+			}
+			stored, err := h.q.GetAttempt(ctx, att.ID)
+			if err != nil {
+				t.Fatalf("GetAttempt: %v", err)
+			}
+			if stored.FailureClass != tc.wantClass {
+				t.Fatalf("failure_class=%q want %q", stored.FailureClass, tc.wantClass)
+			}
+			if got := h.get(root.ID).Lifecycle; got != tc.wantLifecycle {
+				t.Fatalf("lifecycle=%q want %q", got, tc.wantLifecycle)
+			}
+		})
+	}
+}
+
+func TestAttemptInputCarriesGoalContext(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	contextJSON := json.RawMessage(`{"note":"keep this"}`)
+	root, err := h.svc.CreateRoot(ctx, CreateInput{
+		UserID: h.userID, AgentID: h.agentID, Title: "context title", Intent: "context intent",
+		Kind: KindComposite, Required: true, Contract: AcceptanceContract{}, Context: contextJSON,
+	})
+	if err != nil {
+		t.Fatalf("CreateRoot: %v", err)
+	}
+	att, err := h.svc.BeginAutoDecomposition(ctx, root.ID, nil)
+	if err != nil {
+		t.Fatalf("BeginAutoDecomposition: %v", err)
+	}
+	var input AttemptInput
+	if err := unmarshalJSON(att.InputContext, &input); err != nil {
+		t.Fatalf("decode input_context: %v", err)
+	}
+	var gotContext, wantContext map[string]string
+	if err := json.Unmarshal(input.Context, &gotContext); err != nil {
+		t.Fatalf("decode input context: %v", err)
+	}
+	if err := json.Unmarshal(contextJSON, &wantContext); err != nil {
+		t.Fatalf("decode want context: %v", err)
+	}
+	if input.Title != "context title" || input.Intent != "context intent" || gotContext["note"] != wantContext["note"] {
+		t.Fatalf("input envelope title=%q intent=%q context=%s", input.Title, input.Intent, input.Context)
+	}
+}

--- a/internal/goal/dispatcher.go
+++ b/internal/goal/dispatcher.go
@@ -529,9 +529,10 @@ func (s *GoalService) ReapAttempt(ctx context.Context, attemptID string) error {
 		// longer queued/running (already finalized/raced) — idempotent no-op the
 		// dispatcher ignores as ErrInvalidTransition.
 		rows, err := q.FinalizeAttempt(ctx, sqlc.FinalizeAttemptParams{
-			ToStatus: AttemptInterrupted,
-			Error:    "lease expired; reaped by dispatcher",
-			ID:       attemptID,
+			ToStatus:     AttemptInterrupted,
+			Error:        "lease expired; reaped by dispatcher",
+			FailureClass: FailureClassTransient,
+			ID:           attemptID,
 		})
 		if err != nil {
 			return fmt.Errorf("finalize stale attempt: %w", err)

--- a/internal/goal/evidence.go
+++ b/internal/goal/evidence.go
@@ -13,9 +13,12 @@ import (
 // (contract §3.3). Marshaled to the attempt's input_context column. Frozen
 // means an in-flight edit to intent/contract never mutates a running attempt.
 type AttemptInput struct {
+	Title           string             `json:"title,omitempty"`
 	Intent          string             `json:"intent"`
+	Context         json.RawMessage    `json:"context,omitempty"`
 	UpstreamOutputs []AcceptedOutput   `json:"upstream_outputs"`           // ONLY accepted upstream outputs
 	PriorGaps       *Evaluation        `json:"prior_gaps,omitempty"`       // Evaluation[i-1].gaps; nil on attempt 1
+	PriorErrors     []ValidationError  `json:"prior_errors,omitempty"`     // structural planner errors from the previous repair turn
 	Contract        AcceptanceContract `json:"contract"`                   // the bar the attempt must clear
 	ResolvedVerdict string             `json:"resolved_verdict,omitempty"` // a human answer that unblocked needs_verdict
 	AttemptNo       int                `json:"attempt_no"`

--- a/internal/goal/executor.go
+++ b/internal/goal/executor.go
@@ -353,7 +353,25 @@ Goal:
 `)
 	}
 
+	if title := strings.TrimSpace(in.Title); title != "" {
+		b.WriteString("Title: " + title + "\n")
+	}
 	b.WriteString(strings.TrimSpace(in.Intent))
+
+	if len(in.Context) > 0 && string(in.Context) != "{}" {
+		b.WriteString("\n\nGoal context:\n")
+		b.WriteString(string(in.Context))
+		b.WriteString("\n")
+	}
+
+	if len(in.PriorErrors) > 0 {
+		b.WriteString("\nYour previous decomposition was structurally invalid. Fix these errors and call goal_control again.\n")
+		b.WriteString("prior_errors JSON:\n")
+		b.WriteString(RenderErrorsJSON(in.PriorErrors))
+		b.WriteString("\n\nprior_errors text:\n")
+		b.WriteString(RenderErrorsText(in.PriorErrors))
+		b.WriteString("\n")
+	}
 
 	if c := in.Contract; len(c.Items) > 0 {
 		b.WriteString("\n\nAcceptance criteria (your work is accepted only when these are met):\n")
@@ -446,7 +464,16 @@ Protocol:
 
 Goal:
 `)
+	if title := strings.TrimSpace(in.Title); title != "" {
+		b.WriteString("Title: " + title + "\n")
+	}
 	b.WriteString(strings.TrimSpace(in.Intent))
+
+	if len(in.Context) > 0 && string(in.Context) != "{}" {
+		b.WriteString("\n\nGoal context:\n")
+		b.WriteString(string(in.Context))
+		b.WriteString("\n")
+	}
 
 	if out := in.ReviewOutput; out != nil {
 		b.WriteString("\n\nOutput under review:\n")
@@ -765,10 +792,8 @@ func (t *recordingControlTool) executeDecompose(action string, args map[string]a
 		if maxDepth <= 0 { // unset on an attempt minted before MaxDepth was frozen
 			maxDepth = defaultMaxDepth
 		}
-		if err := ValidateDecomposition(content, t.parentDepth, maxDepth); err != nil {
-			return "", fmt.Errorf("goal_control: decomposition rejected: %w; fix the plan and call goal_control again "+
-				"(need >=1 child with required=true, every edge key must match a child key, no cycles, "+
-				"composites need depth headroom and no deterministic acceptance items)", err)
+		if errs := validateDecompositionDetailed(content, t.parentDepth, maxDepth); len(errs) > 0 {
+			return "", fmt.Errorf("goal_control: decomposition rejected:\n%s\nprior_errors JSON:\n%s", RenderErrorsText(errs), RenderErrorsJSON(errs))
 		}
 		ev := AttemptEvidence{Summary: stringArg(args, "summary")}
 		if err := t.rec.record(Result{Action: terminalDecompose, Evidence: ev, Decomposition: &content}); err != nil {

--- a/internal/goal/service.go
+++ b/internal/goal/service.go
@@ -678,15 +678,32 @@ func (s *GoalService) Unblock(ctx context.Context, id string, by Actor) error {
 // Reattempt raises the budget on a blocked(budget_exhausted) goal so the next
 // tick mints a fresh attempt. A leaf returns to ready (the dispatcher claims it);
 // a composite, whose budget meters DECOMPOSITION attempts, returns to draft so
-// scanAndDecompose re-plans it (contract §2.1, see recoveryLifecycle).
+// scanAndDecompose re-plans it (contract §2.1, see recoveryLifecycle). For
+// blocked(planning_invalid), Reattempt restarts planning without raising the
+// semantic/transient budget because structural repairs are metered separately.
 func (s *GoalService) Reattempt(ctx context.Context, id string, by Actor) error {
 	return s.withTx(ctx, func(q *sqlc.Queries) error {
 		d, err := getGoal(ctx, q, id)
 		if err != nil {
 			return err
 		}
-		if d.Lifecycle != LifecycleBlocked || d.BlockReason != BlockBudgetExhausted {
+		if d.Lifecycle != LifecycleBlocked || (d.BlockReason != BlockBudgetExhausted && d.BlockReason != BlockPlanningInvalid) {
 			return ErrInvalidTransition
+		}
+		if d.BlockReason == BlockPlanningInvalid {
+			rows, err := q.TransitionGoalLifecycle(ctx, sqlc.TransitionGoalLifecycleParams{
+				ToLifecycle:   recoveryLifecycle(d),
+				BlockReason:   "",
+				ID:            id,
+				FromLifecycle: LifecycleBlocked,
+			})
+			if err != nil {
+				return fmt.Errorf("reattempt planning invalid: %w", err)
+			}
+			if rows == 0 {
+				return ErrInvalidTransition
+			}
+			return nil
 		}
 		// Raise the budget by one attempt past what is already spent so the next tick
 		// runs one more. A leaf meters convergence by attempt_count; a composite
@@ -763,9 +780,10 @@ func (s *GoalService) Cancel(ctx context.Context, id, reason string, by Actor) e
 			// Cancel any in-flight attempt for this descendant before flipping it.
 			if d.ActiveAttemptID.Valid && d.ActiveAttemptID.String != "" {
 				if _, err := q.FinalizeAttempt(ctx, sqlc.FinalizeAttemptParams{
-					ToStatus: AttemptCancelled,
-					Error:    reason,
-					ID:       d.ActiveAttemptID.String,
+					ToStatus:     AttemptCancelled,
+					Error:        reason,
+					FailureClass: "",
+					ID:           d.ActiveAttemptID.String,
 				}); err != nil {
 					return fmt.Errorf("cancel in-flight attempt: %w", err)
 				}

--- a/internal/goal/types.go
+++ b/internal/goal/types.go
@@ -33,6 +33,7 @@ const (
 const (
 	BlockBudgetExhausted   = "budget_exhausted"
 	BlockNeedsPlanApproval = "needs_plan_approval"
+	BlockPlanningInvalid   = "planning_invalid"
 	BlockNeedsVerdict      = "needs_verdict"
 	BlockDep               = "dep"
 )
@@ -59,6 +60,14 @@ const (
 	PurposeExecution     = "execution"
 	PurposeDecomposition = "decomposition"
 	PurposeReview        = "review"
+)
+
+// Failure class records why a failed/interrupted attempt did not produce a
+// usable terminal result.
+const (
+	FailureClassStructural = "structural"
+	FailureClassSemantic   = "semantic"
+	FailureClassTransient  = "transient"
 )
 
 // Goal kind.
@@ -137,7 +146,7 @@ func ValidLifecycle(s string) bool {
 // ValidBlockReason reports whether s is a known block reason.
 func ValidBlockReason(s string) bool {
 	switch s {
-	case BlockBudgetExhausted, BlockNeedsPlanApproval, BlockNeedsVerdict, BlockDep:
+	case BlockBudgetExhausted, BlockNeedsPlanApproval, BlockPlanningInvalid, BlockNeedsVerdict, BlockDep:
 		return true
 	}
 	return false
@@ -166,6 +175,16 @@ func ValidAttemptStatus(s string) bool {
 func ValidPurpose(s string) bool {
 	switch s {
 	case PurposeExecution, PurposeDecomposition, PurposeReview:
+		return true
+	}
+	return false
+}
+
+// ValidFailureClass reports whether s is a known failure class. Empty is valid
+// for non-failure final states such as cancelled attempts.
+func ValidFailureClass(s string) bool {
+	switch s {
+	case "", FailureClassStructural, FailureClassSemantic, FailureClassTransient:
 		return true
 	}
 	return false

--- a/internal/goal/worker.go
+++ b/internal/goal/worker.go
@@ -118,7 +118,7 @@ func (w *Worker) Run(ctx context.Context, goalID, attemptID string, actor Actor)
 		hbWG.Wait()
 		if r := recover(); r != nil {
 			w.log.Error("worker executor panicked", "goal_id", goalID, "attempt_id", attemptID, "panic", r)
-			w.failAttempt(goalID, attemptID, fmt.Sprintf("executor panic: %v", r))
+			w.failAttempt(goalID, attemptID, fmt.Sprintf("executor panic: %v", r), FailureClassTransient)
 			err = fmt.Errorf("executor panic: %v", r)
 		}
 	}()
@@ -149,7 +149,7 @@ func (w *Worker) applyResult(goalID string, goal sqlc.AgentGoal, att sqlc.AgentG
 		// and never runs deterministic checks, so it is handled wholly apart from
 		// the execution/review fold. Routed by purpose BEFORE the generic submit
 		// case so a decomposition never falls through to the leaf checks.
-		return w.applyDecompositionResult(ctx, goalID, att, res)
+		return w.applyDecompositionResult(ctx, goal, att, res)
 
 	case att.Purpose == PurposeReview:
 		// A reviewer attempt's outcome is verdicts, not an output, and runs no
@@ -167,7 +167,7 @@ func (w *Worker) applyResult(goalID string, goal sqlc.AgentGoal, att sqlc.AgentG
 			// goal 'active' on a pending item with no future event source
 			// (issue #543); fail the attempt so convergence retries within budget
 			// and ultimately blocks for a human if it persists.
-			w.failAttempt(goalID, att.ID, "deterministic check could not be evaluated: "+cerr.Error())
+			w.failAttempt(goalID, att.ID, "deterministic check could not be evaluated: "+cerr.Error(), FailureClassTransient)
 			return nil //nolint:nilerr // failAttempt records the failure transition; applyResult succeeded
 		}
 		err := w.svc.Submit(ctx, att.ID, res.Evidence, res.Output)
@@ -176,7 +176,7 @@ func (w *Worker) applyResult(goalID string, goal sqlc.AgentGoal, att sqlc.AgentG
 			// a goal failure: finalize this attempt as a retryable failure
 			// so convergence re-mints with the same budget.
 			reason := "submitted without a handoff summary"
-			w.failAttempt(goalID, att.ID, reason)
+			w.failAttempt(goalID, att.ID, reason, FailureClassSemantic)
 			return nil
 		}
 		return err
@@ -191,7 +191,7 @@ func (w *Worker) applyResult(goalID string, goal sqlc.AgentGoal, att sqlc.AgentG
 		if reason == "" {
 			reason = "unspecified executor failure"
 		}
-		w.failAttempt(goalID, att.ID, reason)
+		w.failAttempt(goalID, att.ID, reason, failureClassForResult(res))
 		return nil
 
 	default:
@@ -199,32 +199,68 @@ func (w *Worker) applyResult(goalID string, goal sqlc.AgentGoal, att sqlc.AgentG
 		// / silent exit). Treat as a failed attempt so the goal never
 		// strands with a live attempt that produced nothing.
 		w.log.Warn("worker: executor produced no action", "goal_id", goalID, "attempt_id", att.ID)
-		w.failAttempt(goalID, att.ID, "agent exited without submitting or failing")
+		w.failAttempt(goalID, att.ID, "agent exited without submitting or failing", FailureClassSemantic)
 		return nil
 	}
 }
 
 // applyDecompositionResult applies a planner attempt's outcome as the single
-// durable transition. A successful attempt carries the produced plan, which
-// SubmitDecomposition stores inline on the goal and (review_policy=none)
-// materializes + releases children in one tx, or (human) parks it
-// blocked(needs_plan_approval). Any non-submit terminal (fail / no decomposition /
-// protocol miss) is a failed plan attempt that convergence recovers within the
-// plan budget (recoverDecomposition). Errors are recorded as a failed attempt,
-// not returned, so applyResult itself always succeeds.
-func (w *Worker) applyDecompositionResult(ctx context.Context, goalID string, att sqlc.AgentGoalAttempt, res ExecutorResult) error {
-	if res.Submitted && res.Decomposition != nil {
-		if derr := w.svc.SubmitDecomposition(ctx, att.ID, res.Evidence, *res.Decomposition); derr != nil {
-			w.failAttempt(goalID, att.ID, "apply decomposition: "+derr.Error())
+// durable transition. Structural plan errors are fed back to the same planning
+// session for a bounded repair loop; semantic/transient failures keep the old
+// recoverDecomposition budget path.
+func (w *Worker) applyDecompositionResult(ctx context.Context, goal sqlc.AgentGoal, att sqlc.AgentGoalAttempt, res ExecutorResult) error {
+	input := w.attemptInput(att)
+	repairMax := plannerRepairMax(goal)
+	for repairs := 0; ; {
+		if res.Submitted && res.Decomposition != nil {
+			if derr := w.svc.SubmitDecomposition(ctx, att.ID, res.Evidence, *res.Decomposition); derr != nil {
+				errs := decompositionSubmitErrors(goal, input.MaxDepth, *res.Decomposition, derr)
+				if len(errs) > 0 {
+					if repairs < repairMax {
+						repairs++
+						input.PriorErrors = errs
+						next, eerr := w.exec.Execute(ctx, ExecutorRequest{Goal: goal, Attempt: att, Input: input})
+						if eerr != nil {
+							w.log.Warn("worker: planner repair executor returned error", "goal_id", goal.ID, "attempt_id", att.ID, "err", eerr)
+							res = ExecutorResult{Failed: true, FailReason: fmt.Sprintf("executor error: %v", eerr), Retryable: true}
+						} else {
+							res = next
+						}
+						continue
+					}
+					w.failAttempt(goal.ID, att.ID, "planning invalid:\n"+RenderErrorsText(errs), FailureClassStructural)
+					return nil
+				}
+				w.failAttempt(goal.ID, att.ID, "apply decomposition: "+derr.Error(), FailureClassTransient)
+			}
+			return nil
 		}
+		reason := res.FailReason
+		if reason == "" {
+			reason = "decomposition produced no plan"
+		}
+		w.failAttempt(goal.ID, att.ID, reason, failureClassForResult(res))
 		return nil
 	}
-	reason := res.FailReason
-	if reason == "" {
-		reason = "decomposition produced no plan"
+}
+
+func plannerRepairMax(goal sqlc.AgentGoal) int {
+	var pol ConvergencePolicy
+	_ = unmarshalJSON(goal.ConvergencePolicy, &pol)
+	return pol.Normalized().PlannerRepairMax
+}
+
+func decompositionSubmitErrors(goal sqlc.AgentGoal, maxDepth int, content DecompositionContent, err error) []ValidationError {
+	if len(structuralValidationErrors(err)) == 0 {
+		return nil
 	}
-	w.failAttempt(goalID, att.ID, reason)
-	return nil
+	if maxDepth <= 0 {
+		maxDepth = defaultMaxDepth
+	}
+	if errs := validateDecompositionDetailed(content, int(goal.Depth), maxDepth); len(errs) > 0 {
+		return errs
+	}
+	return structuralValidationErrors(err)
 }
 
 // applyReviewResult applies a reviewer attempt's outcome as the single durable
@@ -238,7 +274,7 @@ func (w *Worker) applyDecompositionResult(ctx context.Context, goalID string, at
 func (w *Worker) applyReviewResult(ctx context.Context, goalID string, att sqlc.AgentGoalAttempt, res ExecutorResult) error {
 	if res.Submitted && len(res.Verdicts) > 0 {
 		if rerr := w.svc.SubmitReview(ctx, att.ID, res.Evidence, res.Verdicts); rerr != nil {
-			w.failAttempt(goalID, att.ID, "apply review: "+rerr.Error())
+			w.failAttempt(goalID, att.ID, "apply review: "+rerr.Error(), FailureClassTransient)
 		}
 		return nil
 	}
@@ -246,7 +282,7 @@ func (w *Worker) applyReviewResult(ctx context.Context, goalID string, att sqlc.
 	if reason == "" {
 		reason = "review produced no verdict"
 	}
-	w.failAttempt(goalID, att.ID, reason)
+	w.failAttempt(goalID, att.ID, reason, failureClassForResult(res))
 	return nil
 }
 
@@ -376,11 +412,18 @@ func (w *Worker) attemptInput(att sqlc.AgentGoalAttempt) AttemptInput {
 // goal never strands 'active' with no live attempt (issue #543). Uses a
 // fresh context so a cancelled dispatch still records the outcome. ErrInvalidTransition
 // is benign — the attempt was already reaped/raced and the goal recovered.
-func (w *Worker) failAttempt(goalID, attemptID, reason string) {
+func (w *Worker) failAttempt(goalID, attemptID, reason, failureClass string) {
 	ctx := context.Background()
-	if err := w.svc.FailAttempt(ctx, attemptID, reason); err != nil && !errors.Is(err, ErrInvalidTransition) {
+	if err := w.svc.FailAttempt(ctx, attemptID, reason, failureClass); err != nil && !errors.Is(err, ErrInvalidTransition) {
 		w.log.Warn("worker: finalize failed attempt failed", "goal_id", goalID, "attempt_id", attemptID, "err", err)
 	}
+}
+
+func failureClassForResult(res ExecutorResult) string {
+	if res.Retryable {
+		return FailureClassTransient
+	}
+	return FailureClassSemantic
 }
 
 // truncStdout caps captured stdout before it touches event detail. Zero/absent

--- a/internal/server/goals.go
+++ b/internal/server/goals.go
@@ -775,7 +775,7 @@ func goalToAPI(d sqlc.AgentGoal) apitypes.Goal {
 }
 
 func attemptToAPI(a sqlc.AgentGoalAttempt) apitypes.Attempt {
-	return apitypes.Attempt{
+	out := apitypes.Attempt{
 		Id:              a.ID,
 		GoalId:          a.GoalID,
 		SessionId:       a.SessionID,
@@ -798,6 +798,11 @@ func attemptToAPI(a sqlc.AgentGoalAttempt) apitypes.Attempt {
 		StartedAt:       parseTimePtr(a.StartedAt),
 		FinishedAt:      parseTimePtr(a.FinishedAt),
 	}
+	if a.FailureClass != "" {
+		fc := apitypes.AttemptFailureClass(a.FailureClass)
+		out.FailureClass = &fc
+	}
+	return out
 }
 
 func acceptanceEventListAPI(rows []sqlc.AgentGoalAcceptanceEvent) apitypes.AcceptanceEventList {

--- a/pkg/db/sqlc/agent_goal_attempt.sql.go
+++ b/pkg/db/sqlc/agent_goal_attempt.sql.go
@@ -75,7 +75,7 @@ INSERT INTO agent_goal_attempt (
     purpose, attempt_no, status, input_context, lease_expires_at
 )
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-RETURNING id, goal_id, user_id, agent_id, executor_agent_id, session_id, purpose, attempt_no, status, input_context, evidence, output, gaps, error, heartbeat_at, lease_expires_at, worker_id, started_at, finished_at, created_at, updated_at
+RETURNING id, goal_id, user_id, agent_id, executor_agent_id, session_id, purpose, attempt_no, status, input_context, evidence, output, gaps, error, heartbeat_at, lease_expires_at, worker_id, started_at, finished_at, created_at, updated_at, failure_class
 `
 
 type CreateAttemptParams struct {
@@ -129,6 +129,7 @@ func (q *Queries) CreateAttempt(ctx context.Context, arg CreateAttemptParams) (A
 		&i.FinishedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.FailureClass,
 	)
 	return i, err
 }
@@ -137,19 +138,26 @@ const finalizeAttempt = `-- name: FinalizeAttempt :execrows
 UPDATE agent_goal_attempt
 SET status = $1,
     error = $2,
+    failure_class = $3,
     finished_at = now(),
     updated_at = now()
-WHERE id = $3 AND status IN ('queued', 'running')
+WHERE id = $4 AND status IN ('queued', 'running')
 `
 
 type FinalizeAttemptParams struct {
-	ToStatus string `json:"to_status"`
-	Error    string `json:"error"`
-	ID       string `json:"id"`
+	ToStatus     string `json:"to_status"`
+	Error        string `json:"error"`
+	FailureClass string `json:"failure_class"`
+	ID           string `json:"id"`
 }
 
 func (q *Queries) FinalizeAttempt(ctx context.Context, arg FinalizeAttemptParams) (int64, error) {
-	result, err := q.db.Exec(ctx, finalizeAttempt, arg.ToStatus, arg.Error, arg.ID)
+	result, err := q.db.Exec(ctx, finalizeAttempt,
+		arg.ToStatus,
+		arg.Error,
+		arg.FailureClass,
+		arg.ID,
+	)
 	if err != nil {
 		return 0, err
 	}
@@ -157,7 +165,7 @@ func (q *Queries) FinalizeAttempt(ctx context.Context, arg FinalizeAttemptParams
 }
 
 const getActiveAttempt = `-- name: GetActiveAttempt :one
-SELECT id, goal_id, user_id, agent_id, executor_agent_id, session_id, purpose, attempt_no, status, input_context, evidence, output, gaps, error, heartbeat_at, lease_expires_at, worker_id, started_at, finished_at, created_at, updated_at FROM agent_goal_attempt
+SELECT id, goal_id, user_id, agent_id, executor_agent_id, session_id, purpose, attempt_no, status, input_context, evidence, output, gaps, error, heartbeat_at, lease_expires_at, worker_id, started_at, finished_at, created_at, updated_at, failure_class FROM agent_goal_attempt
 WHERE goal_id = $1
   AND purpose = $2
   AND status IN ('queued', 'running')
@@ -193,12 +201,13 @@ func (q *Queries) GetActiveAttempt(ctx context.Context, arg GetActiveAttemptPara
 		&i.FinishedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.FailureClass,
 	)
 	return i, err
 }
 
 const getAttempt = `-- name: GetAttempt :one
-SELECT id, goal_id, user_id, agent_id, executor_agent_id, session_id, purpose, attempt_no, status, input_context, evidence, output, gaps, error, heartbeat_at, lease_expires_at, worker_id, started_at, finished_at, created_at, updated_at FROM agent_goal_attempt WHERE id = $1
+SELECT id, goal_id, user_id, agent_id, executor_agent_id, session_id, purpose, attempt_no, status, input_context, evidence, output, gaps, error, heartbeat_at, lease_expires_at, worker_id, started_at, finished_at, created_at, updated_at, failure_class FROM agent_goal_attempt WHERE id = $1
 `
 
 func (q *Queries) GetAttempt(ctx context.Context, id string) (AgentGoalAttempt, error) {
@@ -226,6 +235,7 @@ func (q *Queries) GetAttempt(ctx context.Context, id string) (AgentGoalAttempt, 
 		&i.FinishedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.FailureClass,
 	)
 	return i, err
 }
@@ -273,7 +283,7 @@ func (q *Queries) HeartbeatAttempt(ctx context.Context, arg HeartbeatAttemptPara
 }
 
 const listAttemptByGoal = `-- name: ListAttemptByGoal :many
-SELECT id, goal_id, user_id, agent_id, executor_agent_id, session_id, purpose, attempt_no, status, input_context, evidence, output, gaps, error, heartbeat_at, lease_expires_at, worker_id, started_at, finished_at, created_at, updated_at FROM agent_goal_attempt
+SELECT id, goal_id, user_id, agent_id, executor_agent_id, session_id, purpose, attempt_no, status, input_context, evidence, output, gaps, error, heartbeat_at, lease_expires_at, worker_id, started_at, finished_at, created_at, updated_at, failure_class FROM agent_goal_attempt
 WHERE goal_id = $1
   AND ($2::text IS NULL OR purpose = $2::text)
 ORDER BY attempt_no DESC
@@ -315,6 +325,7 @@ func (q *Queries) ListAttemptByGoal(ctx context.Context, arg ListAttemptByGoalPa
 			&i.FinishedAt,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.FailureClass,
 		); err != nil {
 			return nil, err
 		}
@@ -327,7 +338,7 @@ func (q *Queries) ListAttemptByGoal(ctx context.Context, arg ListAttemptByGoalPa
 }
 
 const listStaleAttempts = `-- name: ListStaleAttempts :many
-SELECT id, goal_id, user_id, agent_id, executor_agent_id, session_id, purpose, attempt_no, status, input_context, evidence, output, gaps, error, heartbeat_at, lease_expires_at, worker_id, started_at, finished_at, created_at, updated_at FROM agent_goal_attempt
+SELECT id, goal_id, user_id, agent_id, executor_agent_id, session_id, purpose, attempt_no, status, input_context, evidence, output, gaps, error, heartbeat_at, lease_expires_at, worker_id, started_at, finished_at, created_at, updated_at, failure_class FROM agent_goal_attempt
 WHERE status IN ('queued', 'running')
   AND lease_expires_at IS NOT NULL
   AND lease_expires_at < $1
@@ -377,6 +388,7 @@ func (q *Queries) ListStaleAttempts(ctx context.Context, arg ListStaleAttemptsPa
 			&i.FinishedAt,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.FailureClass,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/db/sqlc/models.go
+++ b/pkg/db/sqlc/models.go
@@ -116,6 +116,7 @@ type AgentGoalAttempt struct {
 	FinishedAt      pgtype.Timestamptz `json:"finished_at"`
 	CreatedAt       time.Time          `json:"created_at"`
 	UpdatedAt       time.Time          `json:"updated_at"`
+	FailureClass    string             `json:"failure_class"`
 }
 
 type AgentGoalEdge struct {

--- a/resources/skills/system/stella/references/tasks.md
+++ b/resources/skills/system/stella/references/tasks.md
@@ -37,7 +37,7 @@ draft ──activate──▶ ready ──claim──▶ active ──submit─�
 - `accepted` — terminal-good; the accepted output is frozen.
 - `rejected_final` — a verdict said no with no rework path left.
 - `abandoned` — convergence budget exhausted and the policy gave up.
-- `blocked` is **recoverable**, not terminal. Block reasons: `budget_exhausted` > `needs_verdict` > `dep`.
+- `blocked` is **recoverable**, not terminal. Block reasons: `budget_exhausted` > `needs_plan_approval` > `planning_invalid` > `needs_verdict` > `dep`.
 
 Acceptance is a separate projection from lifecycle: `pending | passed | failed`. A goal reaches `accepted` only when its contract's acceptance fold passes.
 
@@ -50,7 +50,7 @@ A composite holds child goals produced by a **decomposition** (the only way chil
 - a required child blocked → parent blocks
 - a blocked parent recovers when the blocking child clears
 
-Decomposition is automatic: `stella goal create` produces a composite whose planning runs on its own, materializing children and activating them so the dispatcher runs them — no manual steps. When a goal needs a human approval gate (`review_policy=human`), the dispatcher still plans automatically but parks the composite at `blocked(needs_plan_approval)` with the proposed `{children, edges}` stored on the goal; `stella goal get <id>` shows the pending plan, `stella goal approve <id>` materializes it (children become ready), and `stella goal reject <id>` returns it to draft for re-decomposition. See each subcommand's `--help` for the JSON shape and flags.
+Decomposition is automatic: `stella goal create` produces a composite whose planning runs on its own, materializing children and activating them so the dispatcher runs them — no manual steps. Structural planning errors are repaired in the same planning session with `prior_errors`; if those repairs are exhausted, the goal parks at `blocked(planning_invalid)`. When a goal needs a human approval gate (`review_policy=human`), the dispatcher still plans automatically but parks the composite at `blocked(needs_plan_approval)` with the proposed `{children, edges}` stored on the goal; `stella goal get <id>` shows the pending plan, `stella goal approve <id>` materializes it (children become ready), and `stella goal reject <id>` returns it to draft for re-decomposition. See each subcommand's `--help` for the JSON shape and flags.
 
 ## Worker: the `goal_control` contract
 
@@ -59,7 +59,7 @@ If you see a `goal_control` tool in your toolset, you are a worker. The goal's i
 - `submit` — provide `evidence` (summary + optional artifacts) and `output` when the work meets the acceptance criteria.
 - `block` — pause with `kind`/`question` when you need input or an external dependency.
 - `fail` — report `reason`/`retryable` when the work cannot be completed.
-- `decompose` — **when dispatched to plan a goal** — return a `decomposition` `{children, edges}`. Each child needs `key`, `title`, `intent`, `kind` (`leaf|composite`), `required`, and `acceptance_contract`; edges declare hard/soft deps by child key. If the goal cannot be decomposed, use `fail` instead.
+- `decompose` — **when dispatched to plan a goal** — return a `decomposition` `{children, edges}`. Each child needs `key`, `title`, `intent`, `kind` (`leaf|composite`), `required`, and `acceptance_contract`; edges declare hard/soft deps by child key. If the prompt includes `prior_errors`, fix those structural errors in the next `decompose` call. If the goal cannot be decomposed, use `fail` instead.
 
 Rules:
 

--- a/web/content/docs/development/goal-model.md
+++ b/web/content/docs/development/goal-model.md
@@ -153,8 +153,10 @@ produced X, acceptance rejected with gaps Y, attempt 2 produced Z, accepted.
 A composite goal produces a **decomposition** as the output of an attempt, stored inline on
 `goal.plan`, gated by a review policy (`none` materializes immediately; `human` parks the
 composite at `blocked(needs_plan_approval)` until a human approves — the plan-review gate).
-Once materialized, child goals and their edges exist and each child runs its own convergence
-loop.
+Structural decomposition errors are repaired inside the same planning session with
+`prior_errors`; exhausting `planner_repair_max` parks the composite at
+`blocked(planning_invalid)` without spending the semantic/transient plan budget. Once
+materialized, child goals and their edges exist and each child runs its own convergence loop.
 
 When all required children are accepted, the parent runs **its own** acceptance evaluation.
 That step _is_ the root-level final acceptance / synthesizer — not a special, separate

--- a/web/content/docs/development/goal-model.zh.md
+++ b/web/content/docs/development/goal-model.zh.md
@@ -131,8 +131,9 @@ evidence 都保留，审计链清晰：attempt 1 产出 X，验收以 gaps Y 拒
 ## 递归白送分解与终审
 
 复合 goal 由一次 attempt 产出一个 **decomposition**，由 review policy 把关（`none` 自动接
-受；`human` 等待批准——plan-review 闸，归到 decomposition）。一旦接受，子 goal 及其边被物
-化，每个子项跑自己的收敛循环。
+受；`human` 等待批准——plan-review 闸，归到 decomposition）。结构性 decomposition 错误会带着
+`prior_errors` 回灌到同一个 planning session 里修；耗尽 `planner_repair_max` 后，复合 goal 进入
+`blocked(planning_invalid)`，不消耗语义/瞬态规划预算。一旦接受，子 goal 及其边被物化，每个子项跑自己的收敛循环。
 
 当所有必需子项都 accepted，父项跑**它自己的**验收评估。这一步*就是*根级终审 / synthesizer
 ——不是一个特殊、单独的特性，而是每个叶子都有的同一个验收闸，应用在根上。synthesizer 从递归里


### PR DESCRIPTION
## What

goal 分解的契约闭环生产落地（#623 Phase 1）：

- **同 session 修复循环**：decomposition 写边界 structural 失败不再新 session 空重试，结构化错误（path/code/expected/hint）以 `prior_errors` 回灌同一 planning session，最多 `planner_repair_max`（默认 2）轮
- **预算分离**：structural 修复不消耗业务 attempt/plan 预算；耗尽 → `blocked(planning_invalid)`（新 block reason，`Reattempt` 可解）
- **`failure_class` 落库**：`agent_goal_attempt.failure_class ∈ {structural, semantic, transient}`，哨兵判类（`errors.Is`），不解析 error string；`recoverDecomposition` 按 class 分流，semantic/transient 路径零变化
- **envelope 增强**：planner prompt 透传 goal 的 title + context
- 错误目录 `validateDecompositionDetailed` 统一供给 in-turn 校验与写边界（结构化 ValidationError + did-you-mean hint）
- API spec-first：`Attempt.failure_class` / `block_reason` / `convergence_policy.planner_repair_max` 入 OpenAPI 并重新生成；EN/ZH 文档同步

## Why

Spike #622（225 runs + 73 对盲评）证明契约闭环在现有 schema 上是纯收益：首轮合法 97.3% → 收敛 100%，成本 +7% token。生产现状四个机制性缺陷（重试无反馈、structural 烧业务预算、planner 看不到 title/context、failure 不分类）本 PR 修前三个 + 落分类。

## How

- 修复循环在 `worker.applyDecompositionResult` 内实现（同一 attempt、同一 session、心跳存续期间），写边界守卫（`FinalizeAttempt` 的 `status IN (queued,running)`）保证竞态安全
- 验收测试：
  - `TestDecompositionRepairLoop_ReusesPlanningSessionAndMaterializes`——非法计划 → prior_errors 回灌 → 第 2 轮修复落库，断言 session 复用
  - `TestDecompositionRepairLoop_ExhaustionBlocksPlanningInvalid`——断言 `attempt_count=0`、`max_attempts` 不变、`failure_class=structural`
  - `TestDecompositionFailureClass_PersistsSemanticAndTransient`——旧路径零回归
- goose 迁移 up/down 可重放；`mise run format && build && test` 全绿（作者与验收方各自独立复跑）

已知非阻塞注记：repair 循环跑在 background ctx 上，极端停机时序下可能浪费一次 LLM 调用（写边界守卫兜底正确性），记档不修。

## Refs

- Closes #623 的 Phase 1 部分（issue 保持开放跟踪 Phase 2 schema 单源化）
- Spike 数据与终判：#622