### PR TITLE
🐛 fix(goal): executor 同步排干 terminal turn，消除 active-turn 重试竞态

### DIFF
--- a/internal/goal/executor.go
+++ b/internal/goal/executor.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/CherryHQ/stella/internal/agent"
 	"github.com/CherryHQ/stella/pkg/ai"
@@ -76,6 +77,16 @@ type Result struct {
 // TaskChatParams / TaskChatFunc — the persisted-worker-turn callback — are
 // declared in boot.go (BootConfig.Chat is a TaskChatFunc). This file consumes
 // them; it does not re-declare them.
+
+const (
+	terminalTurnDrainGrace  = 10 * time.Second
+	terminalTurnCancelGrace = 10 * time.Second
+)
+
+type executorTurn struct {
+	events <-chan agent.Event
+	cancel context.CancelFunc
+}
 
 // terminalRecorder captures the first terminal action declared during an attempt.
 // Later terminal declarations are rejected so a stray second tool call cannot
@@ -169,16 +180,20 @@ func (e *workerExecutor) run(ctx context.Context, req ExecutorRequest) (Result, 
 	}
 	projectID := req.Goal.ProjectID.String
 
-	turn := func(prompt string) <-chan agent.Event {
-		return e.chat(ctx, TaskChatParams{
-			AgentID:    agentID,
-			UserID:     req.Attempt.UserID,
-			SessionID:  req.Attempt.SessionID,
-			ProjectID:  projectID,
-			Prompt:     prompt,
-			Decompose:  decompose,
-			ExtraTools: []tools.Tool{ctTool},
-		})
+	turn := func(prompt string) executorTurn {
+		turnCtx, cancel := context.WithCancel(ctx)
+		return executorTurn{
+			events: e.chat(turnCtx, TaskChatParams{
+				AgentID:    agentID,
+				UserID:     req.Attempt.UserID,
+				SessionID:  req.Attempt.SessionID,
+				ProjectID:  projectID,
+				Prompt:     prompt,
+				Decompose:  decompose,
+				ExtraTools: []tools.Tool{ctTool},
+			}),
+			cancel: cancel,
+		}
 	}
 
 	firstPrompt := buildAttemptPrompt(req, decompose)
@@ -219,13 +234,18 @@ func (e *workerExecutor) run(ctx context.Context, req ExecutorRequest) (Result, 
 // channel closes. It returns the assistant text emitted during the turn, the
 // recorded Result (when done), whether a terminal action fired, and a non-nil
 // fail Result if the stream errored before any terminal action.
-func (e *workerExecutor) runTurn(ctx context.Context, events <-chan agent.Event, rec *terminalRecorder) (text string, res Result, done bool, fail *Result) {
+func (e *workerExecutor) runTurn(ctx context.Context, turn executorTurn, rec *terminalRecorder) (text string, res Result, done bool, fail *Result) {
+	defer turn.cancel()
+
 	var buf strings.Builder
-	for ev := range events {
+	for ev := range turn.events {
 		if ev.Err != nil {
 			if rec.isDone() {
-				go drainEvents(events)
 				r, _ := rec.snapshot()
+				if err := e.drainTerminalTurn(ctx, turn); err != nil {
+					f := failResult(fmt.Sprintf("runner cleanup error: %v", err), true)
+					return buf.String(), Result{}, false, &f
+				}
 				return buf.String(), r, true, nil
 			}
 			e.log.Warn("goal executor stream error", "err", ev.Err)
@@ -236,8 +256,11 @@ func (e *workerExecutor) runTurn(ctx context.Context, events <-chan agent.Event,
 			buf.WriteString(ev.Text)
 		}
 		if rec.isDone() {
-			go drainEvents(events)
 			r, _ := rec.snapshot()
+			if err := e.drainTerminalTurn(ctx, turn); err != nil {
+				f := failResult(fmt.Sprintf("runner cleanup error: %v", err), true)
+				return buf.String(), Result{}, false, &f
+			}
 			return buf.String(), r, true, nil
 		}
 	}
@@ -246,6 +269,53 @@ func (e *workerExecutor) runTurn(ctx context.Context, events <-chan agent.Event,
 		return buf.String(), r, true, nil
 	}
 	return buf.String(), Result{}, false, nil
+}
+
+// drainTerminalTurn waits for the runtime turn to release the session busy guard
+// before the worker finalizes the attempt and convergence can dispatch a retry.
+// Most turns close immediately after goal_control; the timeout path cancels the
+// turn and gives runtime cleanup a bounded grace period instead of spinning.
+func (e *workerExecutor) drainTerminalTurn(ctx context.Context, turn executorTurn) error {
+	if turn.events == nil {
+		return nil
+	}
+
+	grace := time.NewTimer(terminalTurnDrainGrace)
+	defer grace.Stop()
+
+	for {
+		select {
+		case _, ok := <-turn.events:
+			if !ok {
+				return nil
+			}
+		case <-ctx.Done():
+			turn.cancel()
+			return ctx.Err()
+		case <-grace.C:
+			e.log.Warn("goal executor terminal turn still active after drain grace; cancelling turn")
+			turn.cancel()
+			return e.drainCancelledTurn(ctx, turn.events)
+		}
+	}
+}
+
+func (e *workerExecutor) drainCancelledTurn(ctx context.Context, events <-chan agent.Event) error {
+	cleanup := time.NewTimer(terminalTurnCancelGrace)
+	defer cleanup.Stop()
+
+	for {
+		select {
+		case _, ok := <-events:
+			if !ok {
+				return nil
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-cleanup.C:
+			return fmt.Errorf("terminal turn did not stop within %s after cancellation", terminalTurnCancelGrace)
+		}
+	}
 }
 
 // foldResult maps the rich internal Result onto the frozen ExecutorResult the
@@ -305,13 +375,6 @@ func blockReason(b *Blocker) string {
 // failResult is a constructor for a non-agent failure outcome.
 func failResult(reason string, retryable bool) Result {
 	return Result{Action: terminalFail, Failure: &Failure{Reason: reason, Retryable: retryable}}
-}
-
-// drainEvents consumes remaining events so the runner can close cleanly after a
-// terminal action has been recorded.
-func drainEvents(ch <-chan agent.Event) {
-	for range ch { //nolint:revive // intentional drain
-	}
 }
 
 // ── prompt assembly ─────────────────────────────────────────────────────────

--- a/internal/goal/executor_routing_test.go
+++ b/internal/goal/executor_routing_test.go
@@ -3,12 +3,78 @@ package goal
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/CherryHQ/stella/internal/agent"
 	"github.com/CherryHQ/stella/pkg/db/sqlc"
 )
+
+// TestExecutorWaitsForTerminalTurnDrain pins the retry race: once goal_control
+// records a terminal action, Execute must still wait for the chat stream to close
+// before returning so the runtime has released the session busy guard.
+func TestExecutorWaitsForTerminalTurnDrain(t *testing.T) {
+	eventConsumed := make(chan struct{})
+	release := make(chan struct{})
+	returned := make(chan error, 1)
+
+	chat := func(ctx context.Context, p TaskChatParams) <-chan agent.Event {
+		ch := make(chan agent.Event)
+		go func() {
+			defer close(ch)
+			if _, err := p.ExtraTools[0].Execute(ctx, map[string]any{"action": "submit", "summary": "done"}); err != nil {
+				ch <- agent.Event{Err: err}
+				return
+			}
+			ch <- agent.Event{Text: "terminal recorded"}
+			close(eventConsumed)
+			select {
+			case <-release:
+			case <-ctx.Done():
+			}
+		}()
+		return ch
+	}
+
+	ex := newWorkerExecutor(chat, nil)
+	go func() {
+		_, err := ex.Execute(context.Background(), ExecutorRequest{
+			Attempt: sqlc.AgentGoalAttempt{
+				Purpose:         PurposeExecution,
+				UserID:          "u",
+				SessionID:       "s",
+				ExecutorAgentID: pgtype.Text{String: "a", Valid: true},
+			},
+			Input: AttemptInput{Intent: "do the thing"},
+		})
+		returned <- err
+	}()
+
+	select {
+	case <-eventConsumed:
+	case err := <-returned:
+		t.Fatalf("Execute returned before terminal event was consumed: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("terminal event was not consumed")
+	}
+
+	select {
+	case err := <-returned:
+		t.Fatalf("Execute returned before the terminal turn drained: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+	select {
+	case err := <-returned:
+		if err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Execute did not return after the terminal turn drained")
+	}
+}
 
 // TestExecutorRoutesDecomposeFlag pins the executor->chat contract the
 // session-kind routing depends on: a purpose=decomposition attempt MUST set


### PR DESCRIPTION
## What

修 #625 问题 1：goal 子目标失败重试时撞上同一 session 未回收的上一 turn（`session has an active turn`），假失败烧光业务预算杀死整棵 goal 树。

## Why

因果链（文件:行号级）：terminal action 后老代码 `go drainEvents(events)` **异步**排水并立即返回 → worker `FailAttempt` 落库 → convergence 放行重试 → dispatcher 派发新 attempt 复用同一 session → runtime 的 turn busy 守卫还没释放 → 假失败。实测三并发子目标场景 6/9 attempt 中招（#625 有完整复现记录）。

## How

最小侵入修复（`internal/goal/executor.go`）：terminal action 后**同步**等待 chat stream 关闭再返回——10s drain grace 超时则 cancel turn 再给 10s cleanup grace，无轮询、有界等待，超时走 retryable fail。刻意不做的两个方向：dispatcher 查 session busy（runtime 进程内状态泄给 durable 多节点模型，更脆）、显式终止旧 session（lifecycle API 侵入面大）。不动 convergence 预算语义（#627 的事）。

验证：
- 确定性回归测试 `TestExecutorWaitsForTerminalTurnDrain`：修复前红（报告存档）、修复后绿
- `mise run format && build && test` 全绿（作者与验收方独立复跑）
- dev e2e 同配方对照：修复前 6/9 竞态假死 → 修复后 **0/9**，全部失败均为真实原因；附带覆盖 Phase 1 repair 循环的同 session 重跑路径

## Refs

- Fixes #625 问题 1（问题 2 transient 预算模型保持开放，等 #627 数据）
- 复现记录与实测数据：#625 comments