### PR TITLE
✨ feat(recally): store article bodies in PostgreSQL

### DIFF
--- a/internal/db/migrations/20260707040522_add_recally_article_content.sql
+++ b/internal/db/migrations/20260707040522_add_recally_article_content.sql
@@ -1,8 +1,9 @@
 -- +goose Up
 CREATE TABLE recally_article_content (
-    article_id TEXT PRIMARY KEY REFERENCES recally_article(id) ON DELETE CASCADE,
-    content    TEXT NOT NULL,
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    article_id  TEXT PRIMARY KEY REFERENCES recally_article(id) ON DELETE CASCADE,
+    content     TEXT NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
 -- +goose Down

--- a/internal/db/migrations/20260707040522_add_recally_article_content.sql
+++ b/internal/db/migrations/20260707040522_add_recally_article_content.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+CREATE TABLE recally_article_content (
+    article_id TEXT PRIMARY KEY REFERENCES recally_article(id) ON DELETE CASCADE,
+    content    TEXT NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- +goose Down
+DROP TABLE recally_article_content;

--- a/internal/db/queries/recally_article.sql
+++ b/internal/db/queries/recally_article.sql
@@ -13,6 +13,16 @@ SELECT * FROM recally_article WHERE id = $1 AND user_id = $2;
 -- name: GetArticleByCanonicalURL :one
 SELECT * FROM recally_article WHERE user_id = $1 AND canonical_url = $2;
 
+-- name: GetArticleContent :one
+SELECT content FROM recally_article_content WHERE article_id = $1;
+
+-- name: UpsertArticleContent :exec
+INSERT INTO recally_article_content (article_id, content)
+VALUES (sqlc.arg('article_id'), sqlc.arg('content'))
+ON CONFLICT (article_id) DO UPDATE
+SET content = EXCLUDED.content,
+    updated_at = now();
+
 -- name: ListArticles :many
 SELECT * FROM recally_article
 WHERE user_id = sqlc.arg('user_id')

--- a/internal/db/queries/recally_article.sql
+++ b/internal/db/queries/recally_article.sql
@@ -23,6 +23,11 @@ ON CONFLICT (article_id) DO UPDATE
 SET content = EXCLUDED.content,
     updated_at = now();
 
+-- name: InsertArticleContentIfAbsent :exec
+INSERT INTO recally_article_content (article_id, content)
+VALUES (sqlc.arg('article_id'), sqlc.arg('content'))
+ON CONFLICT (article_id) DO NOTHING;
+
 -- name: ListArticles :many
 SELECT * FROM recally_article
 WHERE user_id = sqlc.arg('user_id')

--- a/internal/recally/service.go
+++ b/internal/recally/service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -89,18 +90,13 @@ func (s *Service) saveWithFile(ctx context.Context, userID string, req SaveReque
 	if content == "" && lookupErr != nil {
 		return nil, false, fmt.Errorf("content is required for new articles")
 	}
-	article, isNew, err := s.store.SaveArticle(ctx, userID, req)
-	if err != nil {
-		return nil, false, err
-	}
 	var filePath string
-	switch {
-	case isNew:
-		filePath = s.files.ArticlePath(userID, article.ID, article.Title, article.SavedAt)
-	case existing != nil && existing.FilePath != "":
-		filePath = existing.FilePath
-		if !filepath.IsAbs(filePath) {
-			filePath = filepath.Join(s.stellaHome, filePath)
+	if existing != nil {
+		if existing.FilePath != "" {
+			filePath = existing.FilePath
+			if !filepath.IsAbs(filePath) {
+				filePath = filepath.Join(s.stellaHome, filePath)
+			}
 		}
 		if content == "" {
 			if body, ok, err := s.store.GetArticleContent(ctx, existing.ID); err != nil {
@@ -109,23 +105,26 @@ func (s *Service) saveWithFile(ctx context.Context, userID string, req SaveReque
 				content = body
 			}
 		}
-		if content == "" {
+		if content == "" && filePath != "" {
 			if body, readErr := s.files.ReadArticle(filePath); readErr == nil {
 				content = body
 			}
 		}
-	default:
+	}
+	article, isNew, err := s.store.SaveArticleWithContent(ctx, userID, req, content)
+	if err != nil {
+		return nil, false, err
+	}
+	if filePath == "" {
 		filePath = s.files.ArticlePath(userID, article.ID, article.Title, article.SavedAt)
 	}
-	if content == "" {
-		if body, ok, err := s.store.GetArticleContent(ctx, article.ID); err != nil {
+	if !isNew && content != "" {
+		if err := s.store.UpsertArticleContent(ctx, article.ID, content); err != nil {
 			return nil, false, err
-		} else if ok {
-			content = body
 		}
 	}
-	if err := s.store.UpsertArticleContent(ctx, article.ID, content); err != nil {
-		return nil, false, err
+	if content == "" {
+		return article, isNew, nil
 	}
 	if err := s.files.WriteArticle(filePath, article, content); err != nil {
 		slog.Warn("failed to mirror recally article body to disk", "article_id", article.ID, "path", filePath, "error", err)
@@ -171,10 +170,13 @@ func (s *Service) ReadArticleBody(ctx context.Context, article *Article) (string
 	}
 	body, err := s.files.ReadArticle(path)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", nil
+		}
 		return "", err
 	}
 	if body != "" {
-		if err := s.store.UpsertArticleContent(ctx, article.ID, body); err != nil {
+		if err := s.store.InsertArticleContentIfAbsent(ctx, article.ID, body); err != nil {
 			slog.Warn("failed to backfill recally article content from disk", "article_id", article.ID, "error", err)
 		}
 	}

--- a/internal/recally/service.go
+++ b/internal/recally/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"path/filepath"
 	"strings"
 	"time"
@@ -102,6 +103,13 @@ func (s *Service) saveWithFile(ctx context.Context, userID string, req SaveReque
 			filePath = filepath.Join(s.stellaHome, filePath)
 		}
 		if content == "" {
+			if body, ok, err := s.store.GetArticleContent(ctx, existing.ID); err != nil {
+				return nil, false, err
+			} else if ok {
+				content = body
+			}
+		}
+		if content == "" {
 			if body, readErr := s.files.ReadArticle(filePath); readErr == nil {
 				content = body
 			}
@@ -109,12 +117,24 @@ func (s *Service) saveWithFile(ctx context.Context, userID string, req SaveReque
 	default:
 		filePath = s.files.ArticlePath(userID, article.ID, article.Title, article.SavedAt)
 	}
-	if err := s.files.WriteArticle(filePath, article, content); err != nil {
+	if content == "" {
+		if body, ok, err := s.store.GetArticleContent(ctx, article.ID); err != nil {
+			return nil, false, err
+		} else if ok {
+			content = body
+		}
+	}
+	if err := s.store.UpsertArticleContent(ctx, article.ID, content); err != nil {
 		return nil, false, err
+	}
+	if err := s.files.WriteArticle(filePath, article, content); err != nil {
+		slog.Warn("failed to mirror recally article body to disk", "article_id", article.ID, "path", filePath, "error", err)
+		return article, isNew, nil
 	}
 	relPath := s.files.RelativePath(filePath)
 	if err := s.store.UpdateArticleFilePath(ctx, userID, article.ID, relPath); err != nil {
-		return nil, false, err
+		slog.Warn("failed to update recally article mirror path", "article_id", article.ID, "path", relPath, "error", err)
+		return article, isNew, nil
 	}
 	article.FilePath = relPath
 	return article, isNew, nil
@@ -133,15 +153,32 @@ func (s Authorized) GetArticle(ctx context.Context, id string) (*Article, error)
 	return article, nil
 }
 
-func (s *Service) ReadArticleBody(article *Article) (string, error) {
-	if article == nil || article.FilePath == "" {
+func (s *Service) ReadArticleBody(ctx context.Context, article *Article) (string, error) {
+	if article == nil {
+		return "", nil
+	}
+	if body, ok, err := s.store.GetArticleContent(ctx, article.ID); err != nil {
+		return "", err
+	} else if ok && body != "" {
+		return body, nil
+	}
+	if article.FilePath == "" {
 		return "", nil
 	}
 	path := article.FilePath
 	if !filepath.IsAbs(path) {
 		path = filepath.Join(s.stellaHome, path)
 	}
-	return s.files.ReadArticle(path)
+	body, err := s.files.ReadArticle(path)
+	if err != nil {
+		return "", err
+	}
+	if body != "" {
+		if err := s.store.UpsertArticleContent(ctx, article.ID, body); err != nil {
+			slog.Warn("failed to backfill recally article content from disk", "article_id", article.ID, "error", err)
+		}
+	}
+	return body, nil
 }
 
 func (s Authorized) ListArticles(ctx context.Context, filter ArticleFilter) ([]Article, error) {

--- a/internal/recally/service_test.go
+++ b/internal/recally/service_test.go
@@ -61,6 +61,55 @@ func TestServiceReadArticleBodyUsesDatabaseWhenMirrorIsMissing(t *testing.T) {
 	}
 }
 
+func TestStoreArticleContentInsertIfAbsentDoesNotOverwrite(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+	store := NewStore(db)
+
+	article, _, err := store.SaveArticle(t.Context(), testUserID, SaveRequest{URL: "https://example.com/content-race", Title: "Content Race", Content: "ignored"})
+	if err != nil {
+		t.Fatalf("SaveArticle: %v", err)
+	}
+	if err := store.UpsertArticleContent(t.Context(), article.ID, "current body"); err != nil {
+		t.Fatalf("UpsertArticleContent seed: %v", err)
+	}
+	if err := store.InsertArticleContentIfAbsent(t.Context(), article.ID, "legacy body"); err != nil {
+		t.Fatalf("InsertArticleContentIfAbsent: %v", err)
+	}
+	body, ok, err := store.GetArticleContent(t.Context(), article.ID)
+	if err != nil || !ok || body != "current body" {
+		t.Fatalf("GetArticleContent after insert-if-absent body=%q ok=%v err=%v, want current body", body, ok, err)
+	}
+	if err := store.UpsertArticleContent(t.Context(), article.ID, "new body"); err != nil {
+		t.Fatalf("UpsertArticleContent overwrite: %v", err)
+	}
+	body, ok, err = store.GetArticleContent(t.Context(), article.ID)
+	if err != nil || !ok || body != "new body" {
+		t.Fatalf("GetArticleContent after upsert body=%q ok=%v err=%v, want new body", body, ok, err)
+	}
+}
+
+func TestServiceReadArticleBodyMissingMirrorReturnsNoContent(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+	home := t.TempDir()
+	store := NewStore(db)
+	svc := NewService(store, NewFileManager(home), home)
+
+	article, _, err := store.SaveArticle(t.Context(), testUserID, SaveRequest{URL: "https://example.com/missing-mirror", Title: "Missing Mirror", Content: "ignored"})
+	if err != nil {
+		t.Fatalf("SaveArticle: %v", err)
+	}
+	article.FilePath = "library/missing.md"
+	if err := store.UpdateArticleFilePath(t.Context(), testUserID, article.ID, article.FilePath); err != nil {
+		t.Fatalf("UpdateArticleFilePath: %v", err)
+	}
+	body, err := svc.ReadArticleBody(t.Context(), article)
+	if err != nil || body != "" {
+		t.Fatalf("ReadArticleBody missing mirror body=%q err=%v, want no content and no error", body, err)
+	}
+}
+
 func TestServiceReadArticleBodyBackfillsLegacyFile(t *testing.T) {
 	db, cleanup := setupTestDB(t)
 	defer cleanup()

--- a/internal/recally/service_test.go
+++ b/internal/recally/service_test.go
@@ -2,6 +2,8 @@ package recally
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -22,7 +24,7 @@ func TestServiceSaveWritesFilesAndDedups(t *testing.T) {
 	if !first.Created || first.Article.FilePath == "" {
 		t.Fatalf("first=%+v, want created with file", first)
 	}
-	body, err := svc.ReadArticleBody(first.Article)
+	body, err := svc.ReadArticleBody(t.Context(), first.Article)
 	if err != nil || body != "first" {
 		t.Fatalf("ReadArticleBody body=%q err=%v", body, err)
 	}
@@ -37,6 +39,90 @@ func TestServiceSaveWritesFilesAndDedups(t *testing.T) {
 	if err != nil || len(articles) != 1 {
 		t.Fatalf("ListArticles len=%d err=%v", len(articles), err)
 	}
+}
+
+func TestServiceReadArticleBodyUsesDatabaseWhenMirrorIsMissing(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+	home := t.TempDir()
+	svc := NewService(NewStore(db), NewFileManager(home), home)
+	ident := authz.Identity{UserID: testUserID}
+
+	saved, err := svc.As(ident).Save(t.Context(), SaveRequest{URL: "https://example.com/db-body", Title: "DB Body", Content: "from database"})
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := os.Remove(articleAbsPath(home, saved.Article)); err != nil {
+		t.Fatalf("remove mirror: %v", err)
+	}
+	body, err := svc.ReadArticleBody(t.Context(), saved.Article)
+	if err != nil || body != "from database" {
+		t.Fatalf("ReadArticleBody body=%q err=%v, want database body", body, err)
+	}
+}
+
+func TestServiceReadArticleBodyBackfillsLegacyFile(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+	home := t.TempDir()
+	store := NewStore(db)
+	files := NewFileManager(home)
+	svc := NewService(store, files, home)
+
+	article, _, err := store.SaveArticle(t.Context(), testUserID, SaveRequest{URL: "https://example.com/legacy", Title: "Legacy", Content: "ignored"})
+	if err != nil {
+		t.Fatalf("SaveArticle: %v", err)
+	}
+	path := files.ArticlePath(testUserID, article.ID, article.Title, article.SavedAt)
+	if err := files.WriteArticle(path, article, "legacy body"); err != nil {
+		t.Fatalf("WriteArticle: %v", err)
+	}
+	relPath := files.RelativePath(path)
+	if err := store.UpdateArticleFilePath(t.Context(), testUserID, article.ID, relPath); err != nil {
+		t.Fatalf("UpdateArticleFilePath: %v", err)
+	}
+	article.FilePath = relPath
+
+	body, err := svc.ReadArticleBody(t.Context(), article)
+	if err != nil || body != "legacy body" {
+		t.Fatalf("ReadArticleBody legacy body=%q err=%v", body, err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove mirror: %v", err)
+	}
+	body, err = svc.ReadArticleBody(t.Context(), article)
+	if err != nil || body != "legacy body" {
+		t.Fatalf("ReadArticleBody backfilled body=%q err=%v", body, err)
+	}
+}
+
+func TestServiceDeleteArticleCascadesContent(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+	store := NewStore(db)
+	svc := NewService(store, NewFileManager(t.TempDir()), t.TempDir())
+	ident := authz.Identity{UserID: testUserID}
+
+	saved, err := svc.As(ident).Save(t.Context(), SaveRequest{URL: "https://example.com/delete", Title: "Delete", Content: "delete me"})
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if _, ok, err := store.GetArticleContent(t.Context(), saved.Article.ID); err != nil || !ok {
+		t.Fatalf("GetArticleContent before delete ok=%v err=%v", ok, err)
+	}
+	if err := store.DeleteArticle(t.Context(), testUserID, saved.Article.ID); err != nil {
+		t.Fatalf("DeleteArticle: %v", err)
+	}
+	if _, ok, err := store.GetArticleContent(t.Context(), saved.Article.ID); err != nil || ok {
+		t.Fatalf("GetArticleContent after delete ok=%v err=%v, want missing", ok, err)
+	}
+}
+
+func articleAbsPath(home string, article *Article) string {
+	if filepath.IsAbs(article.FilePath) {
+		return article.FilePath
+	}
+	return filepath.Join(home, article.FilePath)
 }
 
 func TestServiceAuthorizedIdentityAndMissingMapping(t *testing.T) {

--- a/internal/recally/store.go
+++ b/internal/recally/store.go
@@ -540,6 +540,24 @@ func (s *Store) UpdateArticleFilePath(ctx context.Context, userID, articleID, fi
 	return nil
 }
 
+func (s *Store) UpsertArticleContent(ctx context.Context, articleID, content string) error {
+	if err := s.q.UpsertArticleContent(ctx, sqlc.UpsertArticleContentParams{ArticleID: articleID, Content: content}); err != nil {
+		return fmt.Errorf("upsert article content: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) GetArticleContent(ctx context.Context, articleID string) (string, bool, error) {
+	content, err := s.q.GetArticleContent(ctx, articleID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("get article content: %w", err)
+	}
+	return content, true, nil
+}
+
 // GetDigest generates a daily reading digest for a user.
 func (s *Store) GetDigest(ctx context.Context, userID string) (*Digest, error) {
 	digest := &Digest{

--- a/internal/recally/store.go
+++ b/internal/recally/store.go
@@ -36,6 +36,17 @@ func generateID() string {
 
 // SaveArticle saves or updates an article by canonical URL.
 func (s *Store) SaveArticle(ctx context.Context, userID string, req SaveRequest) (*Article, bool, error) {
+	return s.saveArticle(ctx, userID, req, "", false)
+}
+
+// SaveArticleWithContent saves or updates an article by canonical URL. New
+// articles and their body content are inserted in one transaction so a crash
+// cannot leave an article row without its source body.
+func (s *Store) SaveArticleWithContent(ctx context.Context, userID string, req SaveRequest, content string) (*Article, bool, error) {
+	return s.saveArticle(ctx, userID, req, content, true)
+}
+
+func (s *Store) saveArticle(ctx context.Context, userID string, req SaveRequest, content string, insertContent bool) (*Article, bool, error) {
 	if req.SourceType == "" {
 		req.SourceType = SourceTypeWeb
 	}
@@ -75,7 +86,7 @@ func (s *Store) SaveArticle(ctx context.Context, userID string, req SaveRequest)
 		return nil, false, fmt.Errorf("lookup article by canonical url: %w", err)
 	}
 
-	created, err := s.q.CreateArticle(ctx, sqlc.CreateArticleParams{
+	params := sqlc.CreateArticleParams{
 		ID:           generateID(),
 		UserID:       userID,
 		AgentID:      toNullString(req.AgentID),
@@ -93,9 +104,32 @@ func (s *Store) SaveArticle(ctx context.Context, userID string, req SaveRequest)
 		PublishedAt:  toNullTime(req.PublishedAt),
 		SavedAt:      time.Now().UTC(),
 		ReadAt:       pgtype.Timestamptz{},
-	})
-	if err != nil {
-		return nil, false, fmt.Errorf("create article: %w", err)
+	}
+
+	var created sqlc.RecallyArticle
+	if insertContent {
+		tx, err := s.db.Begin(ctx)
+		if err != nil {
+			return nil, false, fmt.Errorf("begin article transaction: %w", err)
+		}
+		defer func() { _ = tx.Rollback(ctx) }()
+
+		qtx := s.q.WithTx(tx)
+		created, err = qtx.CreateArticle(ctx, params)
+		if err != nil {
+			return nil, false, fmt.Errorf("create article: %w", err)
+		}
+		if err := qtx.UpsertArticleContent(ctx, sqlc.UpsertArticleContentParams{ArticleID: created.ID, Content: content}); err != nil {
+			return nil, false, fmt.Errorf("upsert article content: %w", err)
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return nil, false, fmt.Errorf("commit article transaction: %w", err)
+		}
+	} else {
+		created, err = s.q.CreateArticle(ctx, params)
+		if err != nil {
+			return nil, false, fmt.Errorf("create article: %w", err)
+		}
 	}
 
 	var article Article
@@ -543,6 +577,13 @@ func (s *Store) UpdateArticleFilePath(ctx context.Context, userID, articleID, fi
 func (s *Store) UpsertArticleContent(ctx context.Context, articleID, content string) error {
 	if err := s.q.UpsertArticleContent(ctx, sqlc.UpsertArticleContentParams{ArticleID: articleID, Content: content}); err != nil {
 		return fmt.Errorf("upsert article content: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) InsertArticleContentIfAbsent(ctx context.Context, articleID, content string) error {
+	if err := s.q.InsertArticleContentIfAbsent(ctx, sqlc.InsertArticleContentIfAbsentParams{ArticleID: articleID, Content: content}); err != nil {
+		return fmt.Errorf("insert article content if absent: %w", err)
 	}
 	return nil
 }

--- a/internal/recally/tool.go
+++ b/internal/recally/tool.go
@@ -106,7 +106,7 @@ func (h recallyHandler) GetArticle(ctx context.Context, in GetArticleInput) (any
 	if err != nil {
 		return nil, err
 	}
-	content, err := h.svc.ReadArticleBody(article)
+	content, err := h.svc.ReadArticleBody(ctx, article)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/recally_handlers.go
+++ b/internal/server/recally_handlers.go
@@ -2,11 +2,9 @@ package server
 
 import (
 	"context"
-	"errors"
 	"log/slog"
 	"maps"
 	"net/http"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -219,7 +217,7 @@ func (h *recallyHandlers) GetArticle(w http.ResponseWriter, r *http.Request, id 
 		include = *params.Include
 	}
 	if includesContent(include) {
-		body, _ := h.readArticleBody(article)
+		body, _ := h.readArticleBody(r.Context(), article)
 		writeData(w, http.StatusOK, toAPIArticle(article, body))
 		return
 	}
@@ -281,7 +279,7 @@ func (h *recallyHandlers) UpdateArticle(w http.ResponseWriter, r *http.Request, 
 	}
 
 	if body.Content != nil || len(updates) > 0 {
-		if err := h.rewriteArticleFile(updated, strDeref(body.Content)); err != nil {
+		if err := h.rewriteArticleFile(r.Context(), updated, body.Content); err != nil {
 			h.writeInternalError(w, err)
 			return
 		}
@@ -744,18 +742,27 @@ func includesContent(include string) bool {
 	return false
 }
 
-func (h *recallyHandlers) readArticleBody(article *recally.Article) (string, error) {
-	if article.FilePath == "" {
-		return "", errors.New("article has no file")
-	}
-	path := article.FilePath
-	if !filepath.IsAbs(path) {
-		path = filepath.Join(config.StellaHome(), path)
-	}
-	return h.files.ReadArticle(path)
+func (h *recallyHandlers) readArticleBody(ctx context.Context, article *recally.Article) (string, error) {
+	return h.svc.ReadArticleBody(ctx, article)
 }
 
-func (h *recallyHandlers) rewriteArticleFile(article *recally.Article, newContent string) error {
+func (h *recallyHandlers) rewriteArticleFile(ctx context.Context, article *recally.Article, newContent *string) error {
+	body := ""
+	if newContent != nil {
+		body = *newContent
+	} else {
+		existing, err := h.svc.ReadArticleBody(ctx, article)
+		if err != nil {
+			// Legacy rows can point at a mirror file this replica never had; a
+			// metadata-only update must not fail on the missing body.
+			h.log.Warn("skipping recally article body rewrite; body unavailable", "article_id", article.ID, "error", err)
+			return nil
+		}
+		body = existing
+	}
+	if err := h.store.UpsertArticleContent(ctx, article.ID, body); err != nil {
+		return err
+	}
 	if article.FilePath == "" {
 		return nil
 	}
@@ -763,18 +770,10 @@ func (h *recallyHandlers) rewriteArticleFile(article *recally.Article, newConten
 	if !filepath.IsAbs(path) {
 		path = filepath.Join(config.StellaHome(), path)
 	}
-	body := newContent
-	if body == "" {
-		existing, err := h.files.ReadArticle(path)
-		if errors.Is(err, os.ErrNotExist) {
-			return nil
-		}
-		if err != nil {
-			return err
-		}
-		body = existing
+	if err := h.files.WriteArticle(path, article, body); err != nil {
+		h.log.Warn("failed to mirror recally article body to disk", "article_id", article.ID, "path", path, "error", err)
 	}
-	return h.files.WriteArticle(path, article, body)
+	return nil
 }
 
 func strDeref(p *string) string {

--- a/internal/server/recally_handlers.go
+++ b/internal/server/recally_handlers.go
@@ -217,7 +217,11 @@ func (h *recallyHandlers) GetArticle(w http.ResponseWriter, r *http.Request, id 
 		include = *params.Include
 	}
 	if includesContent(include) {
-		body, _ := h.readArticleBody(r.Context(), article)
+		body, err := h.readArticleBody(r.Context(), article)
+		if err != nil {
+			h.writeInternalError(w, err)
+			return
+		}
 		writeData(w, http.StatusOK, toAPIArticle(article, body))
 		return
 	}
@@ -759,6 +763,9 @@ func (h *recallyHandlers) rewriteArticleFile(ctx context.Context, article *recal
 			return nil
 		}
 		body = existing
+	}
+	if newContent == nil && body == "" {
+		return nil
 	}
 	if err := h.store.UpsertArticleContent(ctx, article.ID, body); err != nil {
 		return err

--- a/internal/share/service.go
+++ b/internal/share/service.go
@@ -51,6 +51,7 @@ type Service struct {
 	mem        memory.Provider
 	store      *recally.Store
 	files      *recally.FileManager
+	recallySvc *recally.Service
 	stellaHome string
 	baseURL    string
 }
@@ -67,7 +68,7 @@ type ListResult struct {
 }
 
 func NewService(q *sqlc.Queries, mem memory.Provider, store *recally.Store, files *recally.FileManager, stellaHome, baseURL string) *Service {
-	return &Service{q: q, mem: mem, store: store, files: files, stellaHome: stellaHome, baseURL: strings.TrimRight(baseURL, "/")}
+	return &Service{q: q, mem: mem, store: store, files: files, recallySvc: recally.NewService(store, files, stellaHome), stellaHome: stellaHome, baseURL: strings.TrimRight(baseURL, "/")}
 }
 
 func (s *Service) SetBaseURL(baseURL string) {
@@ -148,16 +149,12 @@ func (s Authorized) ShareArticle(ctx context.Context, articleID, expiresIn strin
 	if article.UserID != ident.UserID {
 		return Created{}, authz.ErrForbidden
 	}
-	if article.FilePath == "" {
-		return Created{}, ErrNoContent
-	}
-	filePath := article.FilePath
-	if !filepath.IsAbs(filePath) {
-		filePath = filepath.Join(s.stellaHome, filePath)
-	}
-	md, err := s.files.ReadArticle(filePath)
+	md, err := s.recallySvc.ReadArticleBody(ctx, article)
 	if err != nil {
 		return Created{}, err
+	}
+	if md == "" {
+		return Created{}, ErrNoContent
 	}
 	rendered, err := RenderMarkdownPage(RenderMarkdownOpts{Title: article.Title, Author: article.Author, SourceURL: article.URL, Summary: article.Summary, Tags: article.Tags}, []byte(md))
 	if err != nil {

--- a/internal/share/service_test.go
+++ b/internal/share/service_test.go
@@ -53,6 +53,41 @@ func TestAuthorizedMethodsEnforceShareOwnership(t *testing.T) {
 	}
 }
 
+func TestShareArticleUsesDatabaseBodyWhenMirrorIsMissing(t *testing.T) {
+	ctx := context.Background()
+	db := dbtest.New(t)
+	q := sqlc.New(db)
+	mem := memorytest.New()
+	home := t.TempDir()
+	store := recally.NewStore(db)
+	files := recally.NewFileManager(home)
+	svc := sharepkg.NewService(q, mem, store, files, home, "http://stella.test")
+	userID := uuid.NewString()
+	if _, err := db.Exec(ctx, `INSERT INTO auth_user (id, email) VALUES ($1, $2)`, userID, userID+"@example.com"); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	recallySvc := recally.NewService(store, files, home)
+	saved, err := recallySvc.As(authz.Identity{UserID: userID}).Save(ctx, recally.SaveRequest{URL: "https://example.com/share", Title: "Share", Content: "share body"})
+	if err != nil {
+		t.Fatalf("Save article: %v", err)
+	}
+	path := saved.Article.FilePath
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(home, path)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove mirror: %v", err)
+	}
+
+	created, err := svc.As(ident(userID, "agent")).ShareArticle(ctx, saved.Article.ID, "7d")
+	if err != nil {
+		t.Fatalf("ShareArticle: %v", err)
+	}
+	if !strings.Contains(string(created.Share.Content), "share body") {
+		t.Fatalf("shared content %q, want article body", string(created.Share.Content))
+	}
+}
+
 func TestShareArtifactRejectsUnsafeAndInvalidFiles(t *testing.T) {
 	ctx := context.Background()
 	db := dbtest.New(t)

--- a/pkg/db/sqlc/models.go
+++ b/pkg/db/sqlc/models.go
@@ -723,6 +723,12 @@ type RecallyArticle struct {
 	UpdatedAt    time.Time          `json:"updated_at"`
 }
 
+type RecallyArticleContent struct {
+	ArticleID string    `json:"article_id"`
+	Content   string    `json:"content"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
 type RecallyArticleEmbedding struct {
 	ArticleID   string             `json:"article_id"`
 	Model       string             `json:"model"`

--- a/pkg/db/sqlc/models.go
+++ b/pkg/db/sqlc/models.go
@@ -726,6 +726,7 @@ type RecallyArticle struct {
 type RecallyArticleContent struct {
 	ArticleID string    `json:"article_id"`
 	Content   string    `json:"content"`
+	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 }
 

--- a/pkg/db/sqlc/recally_article.sql.go
+++ b/pkg/db/sqlc/recally_article.sql.go
@@ -202,6 +202,17 @@ func (q *Queries) GetArticleByCanonicalURL(ctx context.Context, arg GetArticleBy
 	return i, err
 }
 
+const getArticleContent = `-- name: GetArticleContent :one
+SELECT content FROM recally_article_content WHERE article_id = $1
+`
+
+func (q *Queries) GetArticleContent(ctx context.Context, articleID string) (string, error) {
+	row := q.db.QueryRow(ctx, getArticleContent, articleID)
+	var content string
+	err := row.Scan(&content)
+	return content, err
+}
+
 const getArticlesSavedThisWeek = `-- name: GetArticlesSavedThisWeek :many
 SELECT id, user_id, agent_id, url, canonical_url, source_type, title, author, summary, tags, status, starred, file_path, metadata, published_at, saved_at, read_at, created_at, updated_at FROM recally_article
 WHERE user_id = $1
@@ -693,6 +704,24 @@ func (q *Queries) UpdateArticle(ctx context.Context, arg UpdateArticleParams) (R
 		&i.UpdatedAt,
 	)
 	return i, err
+}
+
+const upsertArticleContent = `-- name: UpsertArticleContent :exec
+INSERT INTO recally_article_content (article_id, content)
+VALUES ($1, $2)
+ON CONFLICT (article_id) DO UPDATE
+SET content = EXCLUDED.content,
+    updated_at = now()
+`
+
+type UpsertArticleContentParams struct {
+	ArticleID string `json:"article_id"`
+	Content   string `json:"content"`
+}
+
+func (q *Queries) UpsertArticleContent(ctx context.Context, arg UpsertArticleContentParams) error {
+	_, err := q.db.Exec(ctx, upsertArticleContent, arg.ArticleID, arg.Content)
+	return err
 }
 
 const upsertArticleEmbedding = `-- name: UpsertArticleEmbedding :exec

--- a/pkg/db/sqlc/recally_article.sql.go
+++ b/pkg/db/sqlc/recally_article.sql.go
@@ -260,6 +260,22 @@ func (q *Queries) GetArticlesSavedThisWeek(ctx context.Context, userID string) (
 	return items, nil
 }
 
+const insertArticleContentIfAbsent = `-- name: InsertArticleContentIfAbsent :exec
+INSERT INTO recally_article_content (article_id, content)
+VALUES ($1, $2)
+ON CONFLICT (article_id) DO NOTHING
+`
+
+type InsertArticleContentIfAbsentParams struct {
+	ArticleID string `json:"article_id"`
+	Content   string `json:"content"`
+}
+
+func (q *Queries) InsertArticleContentIfAbsent(ctx context.Context, arg InsertArticleContentIfAbsentParams) error {
+	_, err := q.db.Exec(ctx, insertArticleContentIfAbsent, arg.ArticleID, arg.Content)
+	return err
+}
+
 const listArticles = `-- name: ListArticles :many
 SELECT id, user_id, agent_id, url, canonical_url, source_type, title, author, summary, tags, status, starred, file_path, metadata, published_at, saved_at, read_at, created_at, updated_at FROM recally_article
 WHERE user_id = $1


### PR DESCRIPTION
## What

Move recally article bodies into PostgreSQL (`recally_article_content`, 1:1 with `recally_article`, `ON DELETE CASCADE`); demote the markdown file under `$STELLA_HOME/library/` to a best-effort mirror.

## Why

The body existed only on the pod that saved it while the DB stored metadata plus a `file_path` pointer. With multiple replicas or an ephemeral pod disk the row survives and the body vanishes: `GET ?include=content`, agent reads, and `ShareArticle` all fail cross-replica. This is finding A3 in `docs/design/research/filesystem-k8s-audit.md`.

## How

- New table instead of a column: every existing `recally_article` query is `SELECT *`, so a `content` column would drag bodies into list/search. `UpsertArticleContent` / `GetArticleContent` are the only new queries; delete rides the CASCADE.
- Save/update: DB write is the source of truth (failure = error); the file mirror and `file_path` update are best-effort (failure = warn).
- Read (`ReadArticleBody`, handlers, share): DB first, file fallback for legacy rows with lazy backfill on success.
- Metadata-only updates no longer fail when a legacy row points at a mirror file this replica never had (matches the old `os.ErrNotExist` tolerance).
- Tests: DB-only read with mirror deleted, legacy fallback + backfill, CASCADE on delete, share with mirror absent.

## Refs

- #649 (phase 2 of 3), umbrella #637
- Audit: `docs/design/research/filesystem-k8s-audit.md`