### PR TITLE
🔒 fix(sandbox): close read-tool path bypass + harden docker/bwrap resource & isolation limits

### DIFF
--- a/internal/agent/sandbox/read_test.go
+++ b/internal/agent/sandbox/read_test.go
@@ -15,7 +15,9 @@ import (
 	"testing"
 
 	"github.com/CherryHQ/stella/pkg/ai"
+	pkgsandbox "github.com/CherryHQ/stella/pkg/sandbox"
 	pkgtools "github.com/CherryHQ/stella/pkg/tools"
+	localplugin "github.com/CherryHQ/stella/plugins/sandbox/local"
 )
 
 func writePNG(t *testing.T, path string, w, h int) {
@@ -34,7 +36,7 @@ func writePNG(t *testing.T, path string, w, h int) {
 }
 
 func newTestReadTool(projectRoot string) *hostReadTool {
-	return &hostReadTool{projectRoot: projectRoot}
+	return &hostReadTool{host: pkgsandbox.NopSession(), projectRoot: projectRoot}
 }
 
 func TestReadImageVisionReturnsImageBlock(t *testing.T) {
@@ -156,6 +158,49 @@ func TestReadTextFileReturnsTextBlock(t *testing.T) {
 	}
 	if got := ai.FlattenText(blocks); !strings.Contains(got, "line1") || !strings.Contains(got, "line2") {
 		t.Errorf("unexpected text output: %q", got)
+	}
+}
+
+func TestReadToolProjectRootAbsolutePathUsesHostBoundary(t *testing.T) {
+	rawWorkspace := t.TempDir()
+	workspace, err := filepath.EvalSymlinks(rawWorkspace)
+	if err != nil {
+		t.Fatalf("EvalSymlinks workspace: %v", err)
+	}
+	inside := filepath.Join(workspace, "inside.txt")
+	if err := os.WriteFile(inside, []byte("inside workspace\n"), 0o644); err != nil {
+		t.Fatalf("write inside: %v", err)
+	}
+	outside := filepath.Join(t.TempDir(), "secret.txt")
+	if err := os.WriteFile(outside, []byte("outside workspace\n"), 0o644); err != nil {
+		t.Fatalf("write outside: %v", err)
+	}
+
+	policy := pkgsandbox.Policy{
+		Filesystem: pkgsandbox.FilesystemPolicy{
+			WorkspaceRoot: workspace,
+			WorkingDir:    workspace,
+		},
+		Network: pkgsandbox.NetworkPolicy{Mode: pkgsandbox.NetworkAllowAll},
+	}
+	session, err := localplugin.NewFactory().CreateSession(context.Background(), policy)
+	if err != nil {
+		t.Skipf("local sandbox unavailable: %v", err)
+	}
+	defer session.Close() //nolint:errcheck
+
+	tool := newReadTool(session, workspace)
+	out, err := tool.Execute(context.Background(), map[string]any{"path": inside})
+	if err != nil {
+		t.Fatalf("read inside workspace: %v", err)
+	}
+	if !strings.Contains(out, "inside workspace") {
+		t.Fatalf("read inside output = %q", out)
+	}
+
+	out, err = tool.Execute(context.Background(), map[string]any{"path": outside})
+	if err == nil {
+		t.Fatalf("expected outside absolute path to be rejected, got output %q", out)
 	}
 }
 

--- a/internal/agent/sandbox/tools.go
+++ b/internal/agent/sandbox/tools.go
@@ -33,7 +33,11 @@ func ToolDefinitions() []pkgtools.Definition {
 
 func resolveToolPath(host pkgsandbox.Host, projectRoot, path string) (string, error) {
 	if projectRoot != "" {
-		return pkgtools.ResolveProjectPath(projectRoot, path)
+		resolved, err := pkgtools.ResolveProjectPath(projectRoot, path)
+		if err != nil {
+			return "", err
+		}
+		return host.ResolvePath(resolved)
 	}
 	return host.ResolvePath(path)
 }

--- a/pkg/sandbox/output.go
+++ b/pkg/sandbox/output.go
@@ -1,0 +1,59 @@
+package sandbox
+
+import "bytes"
+
+const (
+	// MaxExecOutputBytes caps each captured stdout/stderr stream from untrusted execs.
+	MaxExecOutputBytes = 10 << 20 // 10 MiB
+
+	execOutputTruncatedMarker = "\n[stella: output truncated, exceeded 10MiB]\n"
+)
+
+// CappedOutputBuffer stores command output up to a byte ceiling and discards the rest.
+type CappedOutputBuffer struct {
+	buf       bytes.Buffer
+	limit     int
+	truncated bool
+}
+
+// NewCappedOutputBuffer returns an io.Writer that captures at most limit bytes.
+func NewCappedOutputBuffer(limit int) *CappedOutputBuffer {
+	return &CappedOutputBuffer{limit: limit}
+}
+
+// NewExecOutputBuffer returns a capped buffer for one exec output stream.
+func NewExecOutputBuffer() *CappedOutputBuffer {
+	return NewCappedOutputBuffer(MaxExecOutputBytes)
+}
+
+func (b *CappedOutputBuffer) Write(p []byte) (int, error) {
+	remaining := b.limit - b.buf.Len()
+	if remaining > 0 {
+		if remaining > len(p) {
+			remaining = len(p)
+		}
+		_, _ = b.buf.Write(p[:remaining])
+	}
+	if remaining < len(p) {
+		b.truncated = true
+	}
+	return len(p), nil
+}
+
+func (b *CappedOutputBuffer) Bytes() []byte {
+	if !b.truncated {
+		return b.buf.Bytes()
+	}
+	out := make([]byte, 0, b.buf.Len()+len(execOutputTruncatedMarker))
+	out = append(out, b.buf.Bytes()...)
+	out = append(out, execOutputTruncatedMarker...)
+	return out
+}
+
+func (b *CappedOutputBuffer) String() string {
+	return string(b.Bytes())
+}
+
+func (b *CappedOutputBuffer) Truncated() bool {
+	return b.truncated
+}

--- a/pkg/sandbox/output_test.go
+++ b/pkg/sandbox/output_test.go
@@ -1,0 +1,38 @@
+package sandbox
+
+import "testing"
+
+func TestCappedOutputBufferBoundary(t *testing.T) {
+	buf := NewCappedOutputBuffer(5)
+	if n, err := buf.Write([]byte("hello")); err != nil || n != 5 {
+		t.Fatalf("Write = %d, %v; want 5, nil", n, err)
+	}
+	if got := buf.String(); got != "hello" {
+		t.Fatalf("String = %q, want hello", got)
+	}
+	if buf.Truncated() {
+		t.Fatal("exact-limit write should not be marked truncated")
+	}
+
+	if n, err := buf.Write([]byte("!")); err != nil || n != 1 {
+		t.Fatalf("Write overflow = %d, %v; want 1, nil", n, err)
+	}
+	want := "hello" + execOutputTruncatedMarker
+	if got := buf.String(); got != want {
+		t.Fatalf("String after overflow = %q, want %q", got, want)
+	}
+	if !buf.Truncated() {
+		t.Fatal("overflow write should be marked truncated")
+	}
+}
+
+func TestCappedOutputBufferTruncatesAcrossWrites(t *testing.T) {
+	buf := NewCappedOutputBuffer(5)
+	_, _ = buf.Write([]byte("he"))
+	_, _ = buf.Write([]byte("llo!"))
+
+	want := "hello" + execOutputTruncatedMarker
+	if got := buf.String(); got != want {
+		t.Fatalf("String = %q, want %q", got, want)
+	}
+}

--- a/plugins/sandbox/docker/dockerclient/container.go
+++ b/plugins/sandbox/docker/dockerclient/container.go
@@ -21,6 +21,14 @@ const (
 	NetworkAllowAll NetworkMode = "allow_all"
 )
 
+// Deliberate resource ceilings for untrusted agent workloads; raise if a
+// legitimate toolchain needs more.
+const (
+	sandboxMemoryLimitBytes int64 = 2 << 30       // 2 GiB
+	sandboxNanoCPUs         int64 = 2_000_000_000 // 2 CPUs
+	sandboxPidsLimit        int64 = 512
+)
+
 // MountType identifies how Docker should mount Source into the container.
 type MountType string
 
@@ -233,8 +241,17 @@ func buildContainerConfig(opts CreateOptions) *container.Config {
 }
 
 func buildHostConfig(opts CreateOptions) *container.HostConfig {
+	pidsLimit := sandboxPidsLimit
 	hc := &container.HostConfig{
 		NetworkMode: mapNetworkMode(opts),
+		Resources: container.Resources{
+			Memory:    sandboxMemoryLimitBytes,
+			NanoCPUs:  sandboxNanoCPUs,
+			PidsLimit: &pidsLimit,
+		},
+		// Drop all capabilities by default; relax narrowly if a toolchain genuinely needs one.
+		CapDrop:     []string{"ALL"},
+		SecurityOpt: []string{"no-new-privileges"},
 		Mounts:      buildMounts(opts),
 	}
 	return hc

--- a/plugins/sandbox/docker/dockerclient/container_test.go
+++ b/plugins/sandbox/docker/dockerclient/container_test.go
@@ -55,6 +55,28 @@ func TestMapNetworkMode(t *testing.T) {
 	}
 }
 
+func TestBuildHostConfigHardening(t *testing.T) {
+	hc := buildHostConfig(CreateOptions{NetworkMode: NetworkDisabled})
+	if hc.NetworkMode != container.NetworkMode("none") {
+		t.Fatalf("NetworkMode = %q, want none", hc.NetworkMode)
+	}
+	if hc.Memory != sandboxMemoryLimitBytes {
+		t.Fatalf("Memory = %d, want %d", hc.Memory, sandboxMemoryLimitBytes)
+	}
+	if hc.NanoCPUs != sandboxNanoCPUs {
+		t.Fatalf("NanoCPUs = %d, want %d", hc.NanoCPUs, sandboxNanoCPUs)
+	}
+	if hc.PidsLimit == nil || *hc.PidsLimit != sandboxPidsLimit {
+		t.Fatalf("PidsLimit = %v, want %d", hc.PidsLimit, sandboxPidsLimit)
+	}
+	if len(hc.CapDrop) != 1 || hc.CapDrop[0] != "ALL" {
+		t.Fatalf("CapDrop = %v, want [ALL]", hc.CapDrop)
+	}
+	if len(hc.SecurityOpt) != 1 || hc.SecurityOpt[0] != "no-new-privileges" {
+		t.Fatalf("SecurityOpt = %v, want [no-new-privileges]", hc.SecurityOpt)
+	}
+}
+
 func TestBuildMounts(t *testing.T) {
 	t.Run("no workspace no extras", func(t *testing.T) {
 		mounts := buildMounts(CreateOptions{})

--- a/plugins/sandbox/docker/dockerclient/exec.go
+++ b/plugins/sandbox/docker/dockerclient/exec.go
@@ -1,7 +1,6 @@
 package dockerclient
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -10,6 +9,8 @@ import (
 
 	"github.com/moby/moby/api/pkg/stdcopy"
 	mobyclient "github.com/moby/moby/client"
+
+	sandboxpkg "github.com/CherryHQ/stella/pkg/sandbox"
 )
 
 // ExecOptions configures a docker exec call.
@@ -64,8 +65,9 @@ func (c *Client) Exec(ctx context.Context, opts ExecOptions) (*ExecResult, error
 		}()
 	}
 
-	var stdoutBuf, stderrBuf bytes.Buffer
-	copyErr := demuxStreams(&stdoutBuf, &stderrBuf, attach, opts.Tty)
+	stdoutBuf := sandboxpkg.NewExecOutputBuffer()
+	stderrBuf := sandboxpkg.NewExecOutputBuffer()
+	copyErr := demuxStreams(stdoutBuf, stderrBuf, attach, opts.Tty)
 
 	if ctx.Err() != nil {
 		return &ExecResult{

--- a/plugins/sandbox/local/session.go
+++ b/plugins/sandbox/local/session.go
@@ -5,7 +5,6 @@
 package local
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -715,9 +714,10 @@ func (s *localSession) Exec(ctx context.Context, command string, opts sandboxpkg
 	cmd.Env = buildEnv(policy, opts.Env)
 	setSysProcAttr(cmd)
 
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	stdout := sandboxpkg.NewExecOutputBuffer()
+	stderr := sandboxpkg.NewExecOutputBuffer()
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 
 	if startErr := cmd.Start(); startErr != nil {
 		return sandboxpkg.ExecResult{}, fmt.Errorf("local exec: start: %w", startErr)

--- a/plugins/sandbox/local/session_linux.go
+++ b/plugins/sandbox/local/session_linux.go
@@ -283,6 +283,7 @@ func wrapCommand(policy sandboxpkg.Policy, sandboxCwd string, tmpMounts []tmpMou
 	networkMode := policy.NetworkModeOrDefault()
 
 	bwrapArgs := []string{
+		"--die-with-parent",
 		"--tmpfs", "/",
 		"--dev", "/dev",
 		"--tmpfs", "/dev/shm",

--- a/plugins/sandbox/local/session_linux_test.go
+++ b/plugins/sandbox/local/session_linux_test.go
@@ -204,6 +204,9 @@ func TestWrapCommand_linux_bwrapWorkspaceRemap(t *testing.T) {
 		return flagIndex(flag) >= 0
 	}
 
+	if !hasSingle("--die-with-parent") {
+		t.Error("expected --die-with-parent in bwrap args")
+	}
 	if !hasSingle("--dir") {
 		t.Error("expected --dir in bwrap args")
 	}


### PR DESCRIPTION
## What

One-pass sandbox hardening (the cohesive, low-risk subset of the 2026-07-07 review):

1. **[HIGH] Fix `read` tool path-boundary bypass.** `read`/`write`/`edit` run in-process (`os.ReadFile`), not inside bwrap/docker/Seatbelt — so their only isolation boundary is the backend `ResolvePath`/`ResolveWritePath` check. `resolveToolPath` skipped it whenever a `projectRoot` was set, so `read {"path":"/etc/passwd"}` escaped the workspace and read arbitrary host files (cross-tenant workspaces, vault key file). `write`/`edit` already re-checked via `host.ResolveWritePath`; the asymmetry was the tell. Fixed by making `read` anchor to `projectRoot` then always pass through `host.ResolvePath`.
2. **[MED] Docker resource + capability hardening.** `buildHostConfig` now sets Memory/CPU/pids ceilings + `CapDrop:[ALL]` + `no-new-privileges` (was: only NetworkMode + Mounts).
3. **[MED] Cap Exec output.** stdout/stderr are captured through a shared `CappedOutputBuffer` (10 MiB/stream + truncation marker) so a chatty command can't OOM stellad.
4. **[LOW] bwrap `--die-with-parent`** so sandbox processes don't orphan when stellad exits.

## Why

The file tools' in-process execution means the sandbox never saw them — the read bypass defeated multi-tenant filesystem isolation for reads. Items 2-4 are defense-in-depth / DoS guards in the same boundary.

## How

- `internal/agent/sandbox/tools.go`: `resolveToolPath` now mirrors `resolveWritableToolPath`. Regression test (`read_test.go`) proves an out-of-workspace absolute path is rejected on the local backend while in-workspace reads still work.
- `plugins/sandbox/docker/dockerclient/container.go`: named, tunable ceilings + cap drop + security-opt; asserted in `container_test.go` (no daemon needed).
- `pkg/sandbox/output.go`: shared capped writer, used by both docker `exec.go` and local `session.go`; boundary tests in `output_test.go`.
- `plugins/sandbox/local/session_linux.go`: `--die-with-parent`; asserted in `session_linux_test.go`.

Deferred (behavior-risky / large / needs Linux runtime testing): #663 (bwrap namespaces/seccomp, Seatbelt read policy, env-secret redaction), #664 (`Policy` → generic `MountPlan` + shared `PathResolver`), #665 (docker lifecycle/scalability).

## Verification

- `mise run format` clean, `mise run build` OK, `GOOS=linux GOARCH=amd64 go build ./...` OK (bwrap path compiles).
- `go test ./internal/agent/sandbox/... ./plugins/sandbox/... ./pkg/sandbox/...` all pass, including the new regression + capped-writer + hardening-assertion tests.
- Full-suite `internal/skills`/`internal/vault` failures during the run were embedded-Postgres startup contention (env), not this change — both pass in isolation.

## Refs

Closes #662. Related: #650, #653, #663, #664, #665.