### PR TITLE
🔒 fix(sandbox): bwrap namespace isolation + redact session vault secrets in bash output

### DIFF
--- a/internal/agent/exec_secrets.go
+++ b/internal/agent/exec_secrets.go
@@ -13,25 +13,26 @@ type execSecretResolver struct {
 	cfg agentsandbox.Config
 }
 
-// newExecSecretResolver returns the interface type so a session without a
-// vault loader yields a true nil: returning a nil *execSecretResolver would
-// survive the caller's interface nil check and panic on first use.
+// newExecSecretResolver returns the interface type so a session without vault
+// secrets or session-scoped redaction values yields a true nil: returning a nil
+// *execSecretResolver would survive the caller's interface nil check and panic
+// on first use.
 func newExecSecretResolver(cfg agentsandbox.Config) agentsandbox.ExecSecretResolver {
-	if cfg.VaultEnvLoader == nil {
+	if cfg.VaultEnvLoader == nil && cfg.SessionSecretValues == nil {
 		return nil
 	}
 	return &execSecretResolver{cfg: cfg}
 }
 
 func (r *execSecretResolver) SessionSecretValues(context.Context) ([]string, error) {
-	if r.cfg.GroupID != "" || r.cfg.SessionSecretValues == nil {
+	if r.cfg.SessionSecretValues == nil {
 		return nil, nil
 	}
 	return r.cfg.SessionSecretValues.Values(), nil
 }
 
 func (r *execSecretResolver) DeclarableSecretNames(ctx context.Context) ([]string, error) {
-	if r.cfg.GroupID != "" {
+	if r.cfg.GroupID != "" || r.cfg.VaultEnvLoader == nil {
 		return nil, nil
 	}
 	secrets, err := r.cfg.VaultEnvLoader.ListDeclarableForAgentProject(ctx, r.cfg.UserID, r.cfg.AgentID, r.cfg.ProjectID)
@@ -48,6 +49,9 @@ func (r *execSecretResolver) DeclarableSecretNames(ctx context.Context) ([]strin
 func (r *execSecretResolver) ResolveExecSecrets(ctx context.Context, names []string, command string) (map[string]string, []string, error) {
 	if r.cfg.GroupID != "" {
 		return nil, nil, fmt.Errorf("secrets are disabled for group sessions")
+	}
+	if r.cfg.VaultEnvLoader == nil {
+		return nil, nil, fmt.Errorf("secrets are not available in this session")
 	}
 	if r.cfg.UserID == "" || r.cfg.AgentID == "" {
 		return nil, nil, fmt.Errorf("secrets require a user and agent session")

--- a/internal/agent/exec_secrets.go
+++ b/internal/agent/exec_secrets.go
@@ -23,6 +23,13 @@ func newExecSecretResolver(cfg agentsandbox.Config) agentsandbox.ExecSecretResol
 	return &execSecretResolver{cfg: cfg}
 }
 
+func (r *execSecretResolver) SessionSecretValues(context.Context) ([]string, error) {
+	if r.cfg.GroupID != "" || r.cfg.SessionSecretValues == nil {
+		return nil, nil
+	}
+	return r.cfg.SessionSecretValues.Values(), nil
+}
+
 func (r *execSecretResolver) DeclarableSecretNames(ctx context.Context) ([]string, error) {
 	if r.cfg.GroupID != "" {
 		return nil, nil

--- a/internal/agent/exec_secrets_test.go
+++ b/internal/agent/exec_secrets_test.go
@@ -34,9 +34,48 @@ func (v *fakeExecSecretVault) RecordExecSecretUse(_ context.Context, _ string, _
 	return nil
 }
 
-func TestNewExecSecretResolverWithoutVaultLoaderIsTrueNil(t *testing.T) {
+func TestNewExecSecretResolverWithoutVaultLoaderOrSessionSecretsIsTrueNil(t *testing.T) {
 	if r := newExecSecretResolver(agentsandbox.Config{}); r != nil {
 		t.Fatalf("resolver = %#v, want nil interface", r)
+	}
+}
+
+func TestNewExecSecretResolverWithSessionSecretsOnlyRedacts(t *testing.T) {
+	secretValues := agentsandbox.NewSessionSecretValues()
+	secretValues.Set([]string{"scoped-token"})
+	resolver := newExecSecretResolver(agentsandbox.Config{SessionSecretValues: secretValues})
+	if resolver == nil {
+		t.Fatal("resolver is nil, want redaction-only resolver")
+	}
+
+	values, err := resolver.SessionSecretValues(context.Background())
+	if err != nil {
+		t.Fatalf("SessionSecretValues: %v", err)
+	}
+	if len(values) != 1 || values[0] != "scoped-token" {
+		t.Fatalf("session secret values = %#v, want scoped token", values)
+	}
+	_, _, err = resolver.ResolveExecSecrets(context.Background(), []string{"A"}, "echo ok")
+	if err == nil || !strings.Contains(err.Error(), "not available") {
+		t.Fatalf("err = %v, want graceful unavailable error", err)
+	}
+}
+
+func TestExecSecretResolverGroupSessionStillReturnsRedactionValues(t *testing.T) {
+	secretValues := agentsandbox.NewSessionSecretValues()
+	secretValues.Set([]string{"group-scoped-token"})
+	resolver := newExecSecretResolver(agentsandbox.Config{UserID: "user-1", GroupID: "group-1", AgentID: "agent-1", VaultEnvLoader: &fakeExecSecretVault{}, SessionSecretValues: secretValues})
+
+	values, err := resolver.SessionSecretValues(context.Background())
+	if err != nil {
+		t.Fatalf("SessionSecretValues: %v", err)
+	}
+	if len(values) != 1 || values[0] != "group-scoped-token" {
+		t.Fatalf("session secret values = %#v, want group scoped token", values)
+	}
+	_, _, err = resolver.ResolveExecSecrets(context.Background(), []string{"A"}, "echo ok")
+	if err == nil || !strings.Contains(err.Error(), "group sessions") {
+		t.Fatalf("err = %v, want group session rejection", err)
 	}
 }
 

--- a/internal/agent/runner_builder.go
+++ b/internal/agent/runner_builder.go
@@ -189,6 +189,7 @@ func newRunnerFunc(cfg runnerBuilderConfig) NewRunnerFunc {
 			hookPlugins = params.HooksFn()
 		}
 
+		sessionSecretValues := sandbox.NewSessionSecretValues()
 		sandboxCfg := sandbox.Config{
 			SandboxConfig:    cfg.Snap.Sandbox,
 			SandboxBackendFn: cfg.SandboxBackendFn,
@@ -198,15 +199,16 @@ func newRunnerFunc(cfg runnerBuilderConfig) NewRunnerFunc {
 				UserRoot:    userRoot,
 				ProjectRoot: projectRoot,
 			},
-			UserID:          params.UserID,
-			GroupID:         params.GroupID,
-			AgentID:         params.AgentID,
-			SessionID:       params.SessionID,
-			ProjectID:       params.ProjectID,
-			SessionEnvSpecs: append([]pkgplugins.SessionEnvSpec(nil), pluginView.SessionEnvSpecs...),
-			VaultEnvLoader:  cfg.VaultEnvLoader,
-			TokenEnsurer:    cfg.TokenEnsurer,
-			TokenManager:    cfg.TokenManager,
+			UserID:              params.UserID,
+			GroupID:             params.GroupID,
+			AgentID:             params.AgentID,
+			SessionID:           params.SessionID,
+			ProjectID:           params.ProjectID,
+			SessionEnvSpecs:     append([]pkgplugins.SessionEnvSpec(nil), pluginView.SessionEnvSpecs...),
+			VaultEnvLoader:      cfg.VaultEnvLoader,
+			SessionSecretValues: sessionSecretValues,
+			TokenEnsurer:        cfg.TokenEnsurer,
+			TokenManager:        cfg.TokenManager,
 		}
 
 		builtinTools := append([]BuiltinTool(nil), cfg.BuiltinTools...)

--- a/internal/agent/sandbox/backend_test.go
+++ b/internal/agent/sandbox/backend_test.go
@@ -378,19 +378,22 @@ func TestBuildSandboxEnv_RuntimeOAuthEnvInjected(t *testing.T) {
 		t.Fatalf("Set OTHER_SECRET: %v", err)
 	}
 
+	secretValues := NewSessionSecretValues()
 	cfg := Config{
 		Paths: Paths{
 			StellaHome: "/stella",
 			AgentRoot:  "/workspace/agent",
 			UserRoot:   "/workspace/users/1",
 		},
-		UserID:         userID,
-		AgentID:        "a1",
-		VaultEnvLoader: store,
-		TokenManager:   tm,
+		UserID:              userID,
+		AgentID:             "a1",
+		VaultEnvLoader:      store,
+		SessionSecretValues: secretValues,
+		TokenManager:        tm,
 		SessionEnvSpecs: []pkgplugins.SessionEnvSpec{
 			{EnvVar: "GH_TOKEN", Source: pkgplugins.SessionEnvSource("oauth.access_token"), OAuthProviderID: "github"},
 			{EnvVar: "LARKSUITE_CLI_USER_ACCESS_TOKEN", Source: pkgplugins.SessionEnvSource("oauth.access_token"), OAuthProviderID: "lark"},
+			{EnvVar: "LARKSUITE_CLI_REFRESH_TOKEN", Source: pkgplugins.SessionEnvSource("oauth.refresh_token"), OAuthProviderID: "lark"},
 			{EnvVar: "LARKSUITE_CLI_APP_ID", Source: pkgplugins.SessionEnvSource("oauth.client_id"), OAuthProviderID: "lark"},
 			{EnvVar: "LARKSUITE_CLI_BRAND", Source: pkgplugins.SessionEnvSource("oauth.brand"), OAuthProviderID: "lark"},
 		},
@@ -417,6 +420,9 @@ func TestBuildSandboxEnv_RuntimeOAuthEnvInjected(t *testing.T) {
 	if got := env["LARKSUITE_CLI_USER_ACCESS_TOKEN"]; got != "lark_access_token" {
 		t.Fatalf("LARKSUITE_CLI_USER_ACCESS_TOKEN = %q, want %q", got, "lark_access_token")
 	}
+	if got := env["LARKSUITE_CLI_REFRESH_TOKEN"]; got != "lark_refresh_token" {
+		t.Fatalf("LARKSUITE_CLI_REFRESH_TOKEN = %q, want %q", got, "lark_refresh_token")
+	}
 	if got := env["LARKSUITE_CLI_APP_ID"]; got != "lark_app_id" {
 		t.Fatalf("LARKSUITE_CLI_APP_ID = %q, want %q", got, "lark_app_id")
 	}
@@ -426,6 +432,10 @@ func TestBuildSandboxEnv_RuntimeOAuthEnvInjected(t *testing.T) {
 	if got := env["OTHER_SECRET"]; got != "still-present" {
 		t.Fatalf("OTHER_SECRET = %q, want %q", got, "still-present")
 	}
+	requireSessionSecretValues(t, secretValues.Values(),
+		[]string{"still-present", "ghp_runtime_token", "lark_access_token", "lark_refresh_token", "lark_app_id"},
+		[]string{"feishu", "/stella"},
+	)
 }
 
 func TestBuildSandboxEnv_TokenInjectionErrorsAreSkipped(t *testing.T) {

--- a/internal/agent/sandbox/bash.go
+++ b/internal/agent/sandbox/bash.go
@@ -76,10 +76,6 @@ func (t *hostBashTool) Execute(ctx context.Context, args map[string]any) (string
 		return "", err
 	}
 	secretEnv := map[string]string{}
-	sessionSecretValues, err := t.sessionSecretValues(ctx)
-	if err != nil {
-		return "", err
-	}
 	var valid []string
 	if len(secretNames) > 0 {
 		if t.secretResolver == nil {
@@ -91,7 +87,6 @@ func (t *hostBashTool) Execute(ctx context.Context, args map[string]any) (string
 		}
 		maps.Copy(env, secretEnv)
 	}
-	redactionEnv := buildRedactionEnv(secretEnv, sessionSecretValues)
 
 	// Opt the CLI into emitting renderable-reference sentinels: when the agent
 	// runs `stella task/goal/recally create`, the command announces the new
@@ -102,6 +97,10 @@ func (t *hostBashTool) Execute(ctx context.Context, args map[string]any) (string
 		execOpts.Cwd = t.projectRoot
 	}
 	result, err := t.host.Exec(ctx, command, execOpts)
+	redactionEnv, redactionErr := t.redactionEnv(ctx, secretEnv)
+	if redactionErr != nil {
+		return "", redactionErr
+	}
 	if err != nil {
 		norm := t.normalizer.NormalizeError(err, "bash")
 		return redactSecretValues(norm.Content, redactionEnv), fmt.Errorf("bash: %w", err)
@@ -117,6 +116,14 @@ func (t *hostBashTool) Execute(ctx context.Context, args map[string]any) (string
 		return redactSecretValues(content, redactionEnv), fmt.Errorf("bash: exit code %d", result.ExitCode)
 	}
 	return redactSecretValues(norm.Content, redactionEnv), nil
+}
+
+func (t *hostBashTool) redactionEnv(ctx context.Context, secretEnv map[string]string) (map[string]string, error) {
+	sessionSecretValues, err := t.sessionSecretValues(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return buildRedactionEnv(secretEnv, sessionSecretValues), nil
 }
 
 func (t *hostBashTool) sessionSecretValues(ctx context.Context) ([]string, error) {

--- a/internal/agent/sandbox/bash.go
+++ b/internal/agent/sandbox/bash.go
@@ -34,6 +34,7 @@ func bashDefinition() pkgtools.Definition {
 type ExecSecretResolver interface {
 	ResolveExecSecrets(ctx context.Context, names []string, command string) (map[string]string, []string, error)
 	DeclarableSecretNames(ctx context.Context) ([]string, error)
+	SessionSecretValues(ctx context.Context) ([]string, error)
 }
 
 func newBashTool(host pkgsandbox.Host, toolsBinDir, projectRoot string, secretResolver ExecSecretResolver) pkgtools.Tool {
@@ -75,6 +76,10 @@ func (t *hostBashTool) Execute(ctx context.Context, args map[string]any) (string
 		return "", err
 	}
 	secretEnv := map[string]string{}
+	sessionSecretValues, err := t.sessionSecretValues(ctx)
+	if err != nil {
+		return "", err
+	}
 	var valid []string
 	if len(secretNames) > 0 {
 		if t.secretResolver == nil {
@@ -86,6 +91,7 @@ func (t *hostBashTool) Execute(ctx context.Context, args map[string]any) (string
 		}
 		maps.Copy(env, secretEnv)
 	}
+	redactionEnv := buildRedactionEnv(secretEnv, sessionSecretValues)
 
 	// Opt the CLI into emitting renderable-reference sentinels: when the agent
 	// runs `stella task/goal/recally create`, the command announces the new
@@ -98,19 +104,30 @@ func (t *hostBashTool) Execute(ctx context.Context, args map[string]any) (string
 	result, err := t.host.Exec(ctx, command, execOpts)
 	if err != nil {
 		norm := t.normalizer.NormalizeError(err, "bash")
-		return redactSecretValues(norm.Content, secretEnv), fmt.Errorf("bash: %w", err)
+		return redactSecretValues(norm.Content, redactionEnv), fmt.Errorf("bash: %w", err)
 	}
 	if timeoutSeconds > 0 && result.ExitCode == -1 {
 		content := fmt.Sprintf("bash: command timed out after %d seconds\n[exit:124 | %s]", timeoutSeconds, formatToolDuration(time.Since(start)))
-		return redactSecretValues(content, secretEnv), fmt.Errorf("bash: command timed out after %d seconds", timeoutSeconds)
+		return redactSecretValues(content, redactionEnv), fmt.Errorf("bash: command timed out after %d seconds", timeoutSeconds)
 	}
 
 	norm := t.normalizer.NormalizeExec(result, time.Since(start))
 	if norm.IsError {
 		content := norm.Content + t.undeclaredSecretHint(ctx, command, secretNames)
-		return redactSecretValues(content, secretEnv), fmt.Errorf("bash: exit code %d", result.ExitCode)
+		return redactSecretValues(content, redactionEnv), fmt.Errorf("bash: exit code %d", result.ExitCode)
 	}
-	return redactSecretValues(norm.Content, secretEnv), nil
+	return redactSecretValues(norm.Content, redactionEnv), nil
+}
+
+func (t *hostBashTool) sessionSecretValues(ctx context.Context) ([]string, error) {
+	if t.secretResolver == nil {
+		return nil, nil
+	}
+	values, err := t.secretResolver.SessionSecretValues(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("bash: session secrets are not available: %w", err)
+	}
+	return values, nil
 }
 
 func (t *hostBashTool) undeclaredSecretHint(ctx context.Context, command string, declared []string) string {
@@ -171,6 +188,15 @@ func commandReferencesSecret(command, name string) bool {
 
 func isEnvNameChar(b byte) bool {
 	return (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9') || b == '_'
+}
+
+func buildRedactionEnv(secretEnv map[string]string, sessionSecretValues []string) map[string]string {
+	env := make(map[string]string, len(secretEnv)+len(sessionSecretValues))
+	maps.Copy(env, secretEnv)
+	for i, value := range sessionSecretValues {
+		env[fmt.Sprintf("__SESSION_SECRET_%d", i)] = value
+	}
+	return env
 }
 
 func redactSecretValues(content string, env map[string]string) string {

--- a/internal/agent/sandbox/bash.go
+++ b/internal/agent/sandbox/bash.go
@@ -200,10 +200,15 @@ func buildRedactionEnv(secretEnv map[string]string, sessionSecretValues []string
 }
 
 func redactSecretValues(content string, env map[string]string) string {
+	values := make([]string, 0, len(env))
 	for _, value := range env {
 		if value == "" {
 			continue
 		}
+		values = append(values, value)
+	}
+	sort.SliceStable(values, func(i, j int) bool { return len(values[i]) > len(values[j]) })
+	for _, value := range values {
 		content = strings.ReplaceAll(content, value, "[REDACTED_SECRET]")
 	}
 	return content

--- a/internal/agent/sandbox/bash_secret_test.go
+++ b/internal/agent/sandbox/bash_secret_test.go
@@ -80,6 +80,16 @@ func TestBashDeclaredSecretValueRedactedFromResult(t *testing.T) {
 	}
 }
 
+func TestRedactSecretValuesReplacesLongestSecretsFirst(t *testing.T) {
+	content := "token abc123 also abc"
+	for range 100 {
+		redacted := redactSecretValues(content, map[string]string{"SHORT": "abc", "LONG": "abc123"})
+		if strings.Contains(redacted, "123") || strings.Contains(redacted, "abc") {
+			t.Fatalf("redacted = %q, want no partial secret suffix", redacted)
+		}
+	}
+}
+
 func TestBashSessionVaultSecretValueRedactedFromResult(t *testing.T) {
 	session := &secretCaptureSession{Session: pkgsandbox.NopSession(), result: pkgsandbox.ExecResult{Stdout: "vault-secret-value\n", ExitCode: 0}}
 	resolver := &fakeSecretResolver{sessionValues: []string{"vault-secret-value"}}

--- a/internal/agent/sandbox/bash_secret_test.go
+++ b/internal/agent/sandbox/bash_secret_test.go
@@ -13,10 +13,18 @@ type secretCaptureSession struct {
 	pkgsandbox.Session
 	lastEnv map[string]string
 	result  pkgsandbox.ExecResult
+	execErr error
+	onExec  func()
 }
 
 func (s *secretCaptureSession) Exec(_ context.Context, _ string, opts pkgsandbox.ExecOptions) (pkgsandbox.ExecResult, error) {
 	s.lastEnv = opts.Env
+	if s.onExec != nil {
+		s.onExec()
+	}
+	if s.execErr != nil {
+		return s.result, s.execErr
+	}
 	if s.result.Stdout != "" || s.result.Stderr != "" || s.result.ExitCode != 0 {
 		return s.result, nil
 	}
@@ -101,6 +109,46 @@ func TestBashSessionVaultSecretValueRedactedFromResult(t *testing.T) {
 	}
 	if strings.Contains(content, "vault-secret-value") || !strings.Contains(content, "[REDACTED_SECRET]") {
 		t.Fatalf("content = %q, want redacted session vault secret", content)
+	}
+}
+
+func TestBashSessionSecretValueRecordedDuringExecIsRedactedFromResult(t *testing.T) {
+	resolver := &fakeSecretResolver{sessionValues: []string{"old-token"}}
+	session := &secretCaptureSession{
+		Session: pkgsandbox.NopSession(),
+		result:  pkgsandbox.ExecResult{Stdout: "new-token\n", ExitCode: 0},
+		onExec: func() {
+			resolver.sessionValues = []string{"old-token", "new-token"}
+		},
+	}
+	tool := newBashTool(session, "", "", resolver)
+
+	content, err := tool.Execute(context.Background(), map[string]any{"command": "printf $STELLA_TOKEN"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if strings.Contains(content, "new-token") || !strings.Contains(content, "[REDACTED_SECRET]") {
+		t.Fatalf("content = %q, want redacted recreated-session token", content)
+	}
+}
+
+func TestBashSessionSecretValueRecordedDuringExecIsRedactedFromExecError(t *testing.T) {
+	resolver := &fakeSecretResolver{sessionValues: []string{"old-token"}}
+	session := &secretCaptureSession{
+		Session: pkgsandbox.NopSession(),
+		execErr: errors.New("runner failed after minting new-token"),
+		onExec: func() {
+			resolver.sessionValues = []string{"old-token", "new-token"}
+		},
+	}
+	tool := newBashTool(session, "", "", resolver)
+
+	content, err := tool.Execute(context.Background(), map[string]any{"command": "printf $STELLA_TOKEN"})
+	if err == nil {
+		t.Fatal("Execute succeeded, want error")
+	}
+	if strings.Contains(content, "new-token") || !strings.Contains(content, "[REDACTED_SECRET]") {
+		t.Fatalf("content = %q, want redacted recreated-session token", content)
 	}
 }
 

--- a/internal/agent/sandbox/bash_secret_test.go
+++ b/internal/agent/sandbox/bash_secret_test.go
@@ -24,12 +24,13 @@ func (s *secretCaptureSession) Exec(_ context.Context, _ string, opts pkgsandbox
 }
 
 type fakeSecretResolver struct {
-	env        map[string]string
-	valid      []string
-	declarable []string
-	err        error
-	uses       []string
-	command    string
+	env           map[string]string
+	valid         []string
+	declarable    []string
+	sessionValues []string
+	err           error
+	uses          []string
+	command       string
 }
 
 func (r *fakeSecretResolver) ResolveExecSecrets(_ context.Context, names []string, command string) (map[string]string, []string, error) {
@@ -40,6 +41,10 @@ func (r *fakeSecretResolver) ResolveExecSecrets(_ context.Context, names []strin
 
 func (r *fakeSecretResolver) DeclarableSecretNames(context.Context) ([]string, error) {
 	return r.declarable, nil
+}
+
+func (r *fakeSecretResolver) SessionSecretValues(context.Context) ([]string, error) {
+	return r.sessionValues, nil
 }
 
 func TestBashDeclaredSecretInjectedOnlyIntoExecEnv(t *testing.T) {
@@ -72,6 +77,20 @@ func TestBashDeclaredSecretValueRedactedFromResult(t *testing.T) {
 	}
 	if strings.Contains(content, "secret-value") || !strings.Contains(content, "[REDACTED_SECRET]") {
 		t.Fatalf("content = %q, want redacted secret", content)
+	}
+}
+
+func TestBashSessionVaultSecretValueRedactedFromResult(t *testing.T) {
+	session := &secretCaptureSession{Session: pkgsandbox.NopSession(), result: pkgsandbox.ExecResult{Stdout: "vault-secret-value\n", ExitCode: 0}}
+	resolver := &fakeSecretResolver{sessionValues: []string{"vault-secret-value"}}
+	tool := newBashTool(session, "", "", resolver)
+
+	content, err := tool.Execute(context.Background(), map[string]any{"command": "printf $MY_SECRET"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if strings.Contains(content, "vault-secret-value") || !strings.Contains(content, "[REDACTED_SECRET]") {
+		t.Fatalf("content = %q, want redacted session vault secret", content)
 	}
 }
 

--- a/internal/agent/sandbox/config.go
+++ b/internal/agent/sandbox/config.go
@@ -30,16 +30,17 @@ type TokenEnsurer interface {
 // Config is passed to sandbox operations.
 // It is constructed from the runner config in the parent agent package.
 type Config struct {
-	SandboxConfig    config.SandboxConfig
-	SandboxBackendFn func(ctx context.Context) string
-	Paths            Paths
-	UserID           string
-	GroupID          string // non-empty for group sessions; vault/token use group principal
-	AgentID          string
-	SessionID        string
-	ProjectID        string
-	SessionEnvSpecs  []pkgplugins.SessionEnvSpec
-	VaultEnvLoader   VaultEnvLoader
-	TokenEnsurer     TokenEnsurer
-	TokenManager     *oauth.TokenManager
+	SandboxConfig       config.SandboxConfig
+	SandboxBackendFn    func(ctx context.Context) string
+	Paths               Paths
+	UserID              string
+	GroupID             string // non-empty for group sessions; vault/token use group principal
+	AgentID             string
+	SessionID           string
+	ProjectID           string
+	SessionEnvSpecs     []pkgplugins.SessionEnvSpec
+	VaultEnvLoader      VaultEnvLoader
+	SessionSecretValues *SessionSecretValues
+	TokenEnsurer        TokenEnsurer
+	TokenManager        *oauth.TokenManager
 }

--- a/internal/agent/sandbox/env.go
+++ b/internal/agent/sandbox/env.go
@@ -132,6 +132,7 @@ func userTempDir(principalDir, id string) string {
 func buildSandboxEnv(ctx context.Context, cfg Config, paths Paths) (map[string]string, error) {
 	env := make(map[string]string)
 	var vaultEnv map[string]string
+	sessionSecretEnv := make(map[string]string)
 	cfg.SessionSecretValues.Set(nil)
 
 	// Group sessions never load human vault secrets (D9 isolation).
@@ -158,7 +159,7 @@ func buildSandboxEnv(ctx context.Context, cfg Config, paths Paths) (map[string]s
 	delete(env, oauth.VaultKeyLark)
 	delete(env, oauth.VaultKeyFeishu)
 	if cfg.GroupID == "" {
-		if err := injectSessionEnv(ctx, cfg, env); err != nil {
+		if err := injectSessionEnv(ctx, cfg, env, sessionSecretEnv); err != nil {
 			return nil, err
 		}
 	}
@@ -173,6 +174,7 @@ func buildSandboxEnv(ctx context.Context, cfg Config, paths Paths) (map[string]s
 			return nil, err
 		}
 		env["STELLA_TOKEN"] = tok
+		sessionSecretEnv["STELLA_TOKEN"] = tok
 	} else {
 		delete(env, "STELLA_TOKEN")
 	}
@@ -187,26 +189,38 @@ func buildSandboxEnv(ctx context.Context, cfg Config, paths Paths) (map[string]s
 	// (translateEnvPaths), while local/none use them via the host PATH or bwrap
 	// remap — so an agent sees identical mise paths whichever backend runs it.
 	maps.Copy(env, manifestplugins.RuntimeMiseEnv(paths.StellaHome, miseUserDirHost(paths, cfg), paths.WorkspaceRoot))
-	recordSessionSecretValues(cfg.SessionSecretValues, env, vaultEnv)
+	recordSessionSecretValues(cfg.SessionSecretValues, env, vaultEnv, sessionSecretEnv)
 
 	return env, nil
 }
 
-func recordSessionSecretValues(target *SessionSecretValues, env map[string]string, vaultEnv map[string]string) {
+func recordSessionSecretValues(target *SessionSecretValues, env map[string]string, vaultEnv map[string]string, sessionSecretEnv map[string]string) {
 	if target == nil {
 		return
 	}
-	values := make([]string, 0, len(vaultEnv))
-	seen := make(map[string]struct{}, len(vaultEnv))
-	for key, value := range vaultEnv {
-		if value == "" || env[key] != value {
-			continue
+	values := make([]string, 0, len(vaultEnv)+len(sessionSecretEnv))
+	seen := make(map[string]struct{}, len(vaultEnv)+len(sessionSecretEnv))
+	addValue := func(value string) {
+		if value == "" {
+			return
 		}
 		if _, ok := seen[value]; ok {
-			continue
+			return
 		}
 		seen[value] = struct{}{}
 		values = append(values, value)
+	}
+	for key, value := range vaultEnv {
+		if env[key] != value {
+			continue
+		}
+		addValue(value)
+	}
+	for key, value := range sessionSecretEnv {
+		if env[key] != value {
+			continue
+		}
+		addValue(value)
 	}
 	target.Set(values)
 }
@@ -217,7 +231,7 @@ func shouldInjectScopedToken(cfg Config) bool {
 }
 
 // injectSessionEnv resolves plugin SessionEnvSpecs into env.
-func injectSessionEnv(ctx context.Context, cfg Config, env map[string]string) error {
+func injectSessionEnv(ctx context.Context, cfg Config, env map[string]string, secretEnv map[string]string) error {
 	// oauthBundles caches loaded bundles per provider to avoid redundant vault hits.
 	oauthBundles := make(map[string]*oauth.OAuthBundle)
 	for _, spec := range cfg.SessionEnvSpecs {
@@ -295,9 +309,21 @@ func injectSessionEnv(ctx context.Context, cfg Config, env map[string]string) er
 		}
 		if value != "" {
 			env[spec.EnvVar] = value
+			if oauthSessionEnvFieldSecret(field) {
+				secretEnv[spec.EnvVar] = value
+			}
 		} else if spec.Required {
 			return fmt.Errorf("required session env %q (source %q) for plugin %q could not be resolved", spec.EnvVar, spec.Source, spec.PluginID)
 		}
 	}
 	return nil
+}
+
+func oauthSessionEnvFieldSecret(field string) bool {
+	switch field {
+	case "access_token", "refresh_token", "client_id":
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/agent/sandbox/env.go
+++ b/internal/agent/sandbox/env.go
@@ -131,6 +131,8 @@ func userTempDir(principalDir, id string) string {
 // (e.g. STELLA_HOME) always take precedence over user-defined secrets.
 func buildSandboxEnv(ctx context.Context, cfg Config, paths Paths) (map[string]string, error) {
 	env := make(map[string]string)
+	var vaultEnv map[string]string
+	cfg.SessionSecretValues.Set(nil)
 
 	// Group sessions never load human vault secrets (D9 isolation).
 	if cfg.GroupID == "" && cfg.VaultEnvLoader != nil {
@@ -144,6 +146,7 @@ func buildSandboxEnv(ctx context.Context, cfg Config, paths Paths) (map[string]s
 				"error", err,
 			)
 		} else {
+			vaultEnv = ve
 			maps.Copy(env, ve)
 		}
 	}
@@ -184,8 +187,28 @@ func buildSandboxEnv(ctx context.Context, cfg Config, paths Paths) (map[string]s
 	// (translateEnvPaths), while local/none use them via the host PATH or bwrap
 	// remap — so an agent sees identical mise paths whichever backend runs it.
 	maps.Copy(env, manifestplugins.RuntimeMiseEnv(paths.StellaHome, miseUserDirHost(paths, cfg), paths.WorkspaceRoot))
+	recordSessionSecretValues(cfg.SessionSecretValues, env, vaultEnv)
 
 	return env, nil
+}
+
+func recordSessionSecretValues(target *SessionSecretValues, env map[string]string, vaultEnv map[string]string) {
+	if target == nil {
+		return
+	}
+	values := make([]string, 0, len(vaultEnv))
+	seen := make(map[string]struct{}, len(vaultEnv))
+	for key, value := range vaultEnv {
+		if value == "" || env[key] != value {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		values = append(values, value)
+	}
+	target.Set(values)
 }
 
 func shouldInjectScopedToken(cfg Config) bool {

--- a/internal/agent/sandbox/env_test.go
+++ b/internal/agent/sandbox/env_test.go
@@ -43,6 +43,27 @@ func (s staticScopedToken) CreateScopedToken(context.Context, string, string, st
 	return s.token, nil
 }
 
+func requireSessionSecretValues(t *testing.T, values []string, present []string, absent []string) {
+	t.Helper()
+	got := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		got[value] = struct{}{}
+	}
+	for _, value := range present {
+		if _, ok := got[value]; !ok {
+			t.Fatalf("session secret values = %#v, missing %q", values, value)
+		}
+	}
+	for _, value := range absent {
+		if _, ok := got[value]; ok {
+			t.Fatalf("session secret values = %#v, unexpectedly contains %q", values, value)
+		}
+	}
+	if len(values) != len(present) {
+		t.Fatalf("session secret values = %#v, want exactly %#v", values, present)
+	}
+}
+
 func TestBuildSandboxEnvUsesScopedTokenOverVaultToken(t *testing.T) {
 	env, err := buildSandboxEnv(context.Background(), Config{
 		UserID:         "user-1",
@@ -79,9 +100,10 @@ func TestBuildSandboxEnvRecordsOnlyInjectedVaultSecretValues(t *testing.T) {
 		t.Fatalf("MY_SECRET = %q, want vault-secret", got)
 	}
 	values := secretValues.Values()
-	if len(values) != 1 || values[0] != "vault-secret" {
-		t.Fatalf("session secret values = %#v, want only injected vault secret", values)
-	}
+	requireSessionSecretValues(t, values,
+		[]string{"vault-secret", "stella_scoped_session"},
+		[]string{"vault-home", "stella_legacy", "/runtime/stella"},
+	)
 }
 
 func TestBuildSandboxEnvDeletesVaultTokenWhenScopedUnavailable(t *testing.T) {

--- a/internal/agent/sandbox/env_test.go
+++ b/internal/agent/sandbox/env_test.go
@@ -62,6 +62,28 @@ func TestBuildSandboxEnvUsesScopedTokenOverVaultToken(t *testing.T) {
 	}
 }
 
+func TestBuildSandboxEnvRecordsOnlyInjectedVaultSecretValues(t *testing.T) {
+	secretValues := NewSessionSecretValues()
+	env, err := buildSandboxEnv(context.Background(), Config{
+		UserID:              "user-1",
+		AgentID:             "agent-1",
+		SessionID:           "session-1",
+		VaultEnvLoader:      staticVaultEnv{env: map[string]string{"MY_SECRET": "vault-secret", "STELLA_HOME": "vault-home", "STELLA_TOKEN": "stella_legacy"}},
+		SessionSecretValues: secretValues,
+		TokenEnsurer:        staticScopedToken{token: "stella_scoped_session"},
+	}, Paths{StellaHome: "/runtime/stella"})
+	if err != nil {
+		t.Fatalf("buildSandboxEnv: %v", err)
+	}
+	if got := env["MY_SECRET"]; got != "vault-secret" {
+		t.Fatalf("MY_SECRET = %q, want vault-secret", got)
+	}
+	values := secretValues.Values()
+	if len(values) != 1 || values[0] != "vault-secret" {
+		t.Fatalf("session secret values = %#v, want only injected vault secret", values)
+	}
+}
+
 func TestBuildSandboxEnvDeletesVaultTokenWhenScopedUnavailable(t *testing.T) {
 	env, err := buildSandboxEnv(context.Background(), Config{
 		UserID:         "user-1",

--- a/internal/agent/sandbox/refresh.go
+++ b/internal/agent/sandbox/refresh.go
@@ -55,4 +55,5 @@ func RefreshScopedToken(ctx context.Context, session pkgsandbox.Session, cfg Con
 		return
 	}
 	refresher.RefreshEnv(map[string]string{"STELLA_TOKEN": tok})
+	cfg.SessionSecretValues.Add(tok)
 }

--- a/internal/agent/sandbox/refresh_test.go
+++ b/internal/agent/sandbox/refresh_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"maps"
+	"slices"
 	"testing"
 	"time"
 
@@ -72,14 +73,22 @@ func TestRefreshScopedTokenReSignsNearExpiry(t *testing.T) {
 	fresh := signTokenExpiring(t, 30*time.Minute) // below the 1h threshold
 	sess := &refreshSession{Session: pkgsandbox.NopSession(), env: map[string]string{"STELLA_TOKEN": fresh}}
 	ensurer := &recordingEnsurer{token: "stella_scoped_new"}
+	secretValues := NewSessionSecretValues()
+	secretValues.Set([]string{fresh})
+	cfg := refreshConfig(ensurer)
+	cfg.SessionSecretValues = secretValues
 
-	RefreshScopedToken(context.Background(), sess, refreshConfig(ensurer))
+	RefreshScopedToken(context.Background(), sess, cfg)
 
 	if ensurer.calls != 1 {
 		t.Fatalf("expected 1 re-sign, got %d", ensurer.calls)
 	}
 	if got := sess.env["STELLA_TOKEN"]; got != "stella_scoped_new" {
 		t.Fatalf("token not refreshed: %q", got)
+	}
+	values := secretValues.Values()
+	if !slices.Contains(values, fresh) || !slices.Contains(values, "stella_scoped_new") {
+		t.Fatalf("session secret values = %#v, want old and refreshed tokens", values)
 	}
 }
 

--- a/internal/agent/sandbox/session_secret_values.go
+++ b/internal/agent/sandbox/session_secret_values.go
@@ -2,8 +2,8 @@ package sandbox
 
 import "sync"
 
-// SessionSecretValues carries vault-sourced env values injected at session start
-// to tool output redaction without marking benign runner env (PATH, HOME, etc.) sensitive.
+// SessionSecretValues carries secret env values injected at session start to tool
+// output redaction without marking benign runner env (PATH, HOME, etc.) sensitive.
 type SessionSecretValues struct {
 	mu     sync.RWMutex
 	values []string

--- a/internal/agent/sandbox/session_secret_values.go
+++ b/internal/agent/sandbox/session_secret_values.go
@@ -1,0 +1,32 @@
+package sandbox
+
+import "sync"
+
+// SessionSecretValues carries vault-sourced env values injected at session start
+// to tool output redaction without marking benign runner env (PATH, HOME, etc.) sensitive.
+type SessionSecretValues struct {
+	mu     sync.RWMutex
+	values []string
+}
+
+func NewSessionSecretValues() *SessionSecretValues {
+	return &SessionSecretValues{}
+}
+
+func (s *SessionSecretValues) Set(values []string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.values = append([]string(nil), values...)
+}
+
+func (s *SessionSecretValues) Values() []string {
+	if s == nil {
+		return nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return append([]string(nil), s.values...)
+}

--- a/internal/agent/sandbox/session_secret_values.go
+++ b/internal/agent/sandbox/session_secret_values.go
@@ -1,6 +1,9 @@
 package sandbox
 
-import "sync"
+import (
+	"slices"
+	"sync"
+)
 
 // SessionSecretValues carries secret env values injected at session start to tool
 // output redaction without marking benign runner env (PATH, HOME, etc.) sensitive.
@@ -20,6 +23,18 @@ func (s *SessionSecretValues) Set(values []string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.values = append([]string(nil), values...)
+}
+
+func (s *SessionSecretValues) Add(value string) {
+	if s == nil || value == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if slices.Contains(s.values, value) {
+		return
+	}
+	s.values = append(s.values, value)
 }
 
 func (s *SessionSecretValues) Values() []string {

--- a/plugins/sandbox/local/session_linux.go
+++ b/plugins/sandbox/local/session_linux.go
@@ -156,8 +156,13 @@ func bwrapFunctional() bool {
 		if err != nil {
 			return
 		}
-		// Probe with a minimal sandbox that just runs true(1).
-		if exec.Command(p, "--dev-bind", "/", "/", "--", "true").Run() == nil {
+		// Probe with a minimal sandbox that just runs true(1), including the
+		// namespace isolation flags used by real execs.
+		args := []string{
+			"--unshare-pid", "--unshare-ipc", "--unshare-uts",
+			"--dev-bind", "/", "/", "--", "true",
+		}
+		if exec.Command(p, args...).Run() == nil {
 			bwrapPath = p
 			bwrapAvailable = true
 		}

--- a/plugins/sandbox/local/session_linux.go
+++ b/plugins/sandbox/local/session_linux.go
@@ -284,6 +284,9 @@ func wrapCommand(policy sandboxpkg.Policy, sandboxCwd string, tmpMounts []tmpMou
 
 	bwrapArgs := []string{
 		"--die-with-parent",
+		"--unshare-pid",
+		"--unshare-ipc",
+		"--unshare-uts",
 		"--tmpfs", "/",
 		"--dev", "/dev",
 		"--tmpfs", "/dev/shm",
@@ -292,6 +295,7 @@ func wrapCommand(policy sandboxpkg.Policy, sandboxCwd string, tmpMounts []tmpMou
 		"--proc", "/proc",
 		"--dir", "/run",
 	}
+	// User namespace remapping and seccomp are deferred until they have real Linux coverage.
 	// Mount temp directories: bind each per-session host dir so file tools on
 	// the host share the same view as bash running inside bwrap.
 	// See createSessionTmpMounts for how to add a new temp path.

--- a/plugins/sandbox/local/session_linux_test.go
+++ b/plugins/sandbox/local/session_linux_test.go
@@ -204,8 +204,10 @@ func TestWrapCommand_linux_bwrapWorkspaceRemap(t *testing.T) {
 		return flagIndex(flag) >= 0
 	}
 
-	if !hasSingle("--die-with-parent") {
-		t.Error("expected --die-with-parent in bwrap args")
+	for _, flag := range []string{"--die-with-parent", "--unshare-pid", "--unshare-ipc", "--unshare-uts"} {
+		if !hasSingle(flag) {
+			t.Errorf("expected %s in bwrap args", flag)
+		}
 	}
 	if !hasSingle("--dir") {
 		t.Error("expected --dir in bwrap args")


### PR DESCRIPTION
## What

Two of the three isolation-hardening items from #663 (the third, macOS Seatbelt read-restriction, proved fragile and stays deferred — see below).

1. **bwrap namespace isolation (Linux).** `wrapCommand` now adds `--unshare-pid`, `--unshare-ipc`, `--unshare-uts` to the base bwrap args (on top of the existing `--die-with-parent` / `--proc /proc`). The sandboxed process no longer shares the host PID/IPC/UTS namespaces, so it can't see or signal host processes. Left `--unshare-user`/uid-remap and `--seccomp` deferred (they need a real Linux test rig — flagged in a code comment and in #663).
2. **bash redacts session vault secrets.** `redactSecretValues` previously redacted only per-call declarable `secrets`. A vault secret injected into `Policy.Env` (e.g. `MY_SECRET`) leaked via `echo $MY_SECRET`. Now `buildSandboxEnv` records the vault-sourced values actually injected, the runner/session plumb them to the bash tool via `SessionSecretValues`, and bash redacts the union of per-call + session vault values — without redacting benign runner-set values (`STELLA_HOME`, scoped-token overlays).

## Why

Both close real multi-tenant leaks: shared namespaces let a sandboxed agent observe host/other-tenant processes; unredacted `Policy.Env` secrets flowed straight into model-visible tool output.

## How / verification

- `plugins/sandbox/local/session_linux.go` (+ arg-assertion test).
- `internal/agent/sandbox/{bash.go,env.go,config.go,session_secret_values.go}`, `internal/agent/{exec_secrets.go,runner_builder.go}`; tests in `bash_secret_test.go` (asserts the session vault value is redacted) and `env_test.go`.
- `mise run format`/`build` OK; `go test ./internal/agent/sandbox/... ./plugins/sandbox/local/...` pass; `GOOS=linux GOARCH=amd64 go build ./...` OK.

## Deferred (still in #663)

macOS Seatbelt deny-by-default reads: a hands-on attempt showed `(allow default)` + trailing `(deny file-read* …)` does **not** reliably block reads under Seatbelt's last-match semantics (a real `/bin/cat` test still read the "denied" file), so the change was reverted rather than shipping a false sense of isolation. Needs a rethink (deny-first profile or a different mechanism). bwrap `--unshare-user`/seccomp also remain in #663.

## Refs

Part of #663. Related: #662, #664, #665.