### PR TITLE
♻️ refactor(sandbox): generic MountPlan + single shared PathResolver

### DIFF
--- a/internal/agent/sandbox/env.go
+++ b/internal/agent/sandbox/env.go
@@ -18,14 +18,48 @@ import (
 
 func runnerFilesystemPolicy(paths Paths, cfg Config) pkgsandbox.FilesystemPolicy {
 	principalDir, id := misePrincipal(cfg)
-	return pkgsandbox.FilesystemPolicy{
-		WorkspaceRoot:     paths.WorkspaceRoot,
-		WorkingDir:        paths.WorkDir,
-		UserDataDir:       userDataDirHost(paths, cfg),
-		AgentSkillsDir:    agentSkillsDirHost(paths),
-		SystemDBSkillsDir: systemDBSkillsDirHost(paths),
-		TempDirHost:       userTempDir(principalDir, id),
+	mounts := []pkgsandbox.Mount{
+		{HostPath: paths.WorkspaceRoot, SandboxPath: pkgsandbox.MountWorkspace, Access: pkgsandbox.MountReadWrite},
 	}
+	if userData := userDataDirHost(paths, cfg); userData != "" {
+		mounts = append(mounts, pkgsandbox.Mount{HostPath: userData, SandboxPath: pkgsandbox.MountUserData, Access: pkgsandbox.MountReadWrite})
+	}
+	for _, name := range pkgsandbox.StellaHomeSandboxDirs() {
+		mounts = append(mounts, pkgsandbox.Mount{
+			HostPath:    filepath.Join(paths.StellaHome, name),
+			SandboxPath: filepath.Join(pkgsandbox.MountStellaHome, name),
+			Access:      pkgsandbox.MountReadOnly,
+		})
+	}
+	if agentSkills := agentSkillsDirHost(paths); agentSkills != "" {
+		mounts = append(mounts, pkgsandbox.Mount{HostPath: agentSkills, SandboxPath: pkgsandbox.MountAgentSkills, Access: pkgsandbox.MountReadOnly})
+	}
+	if systemSkills := systemDBSkillsDirHost(paths); systemSkills != "" {
+		mounts = append(mounts, pkgsandbox.Mount{HostPath: systemSkills, SandboxPath: pkgsandbox.MountSystemDBSkills, Access: pkgsandbox.MountReadOnly})
+	}
+	if miseDir := miseUserDirHost(paths, cfg); miseDir != "" {
+		mounts = append(mounts, pkgsandbox.Mount{
+			HostPath:    miseDir,
+			SandboxPath: remapStellaHomePolicyPath(miseDir, paths.StellaHome),
+			Access:      pkgsandbox.MountReadWrite,
+		})
+	}
+	return pkgsandbox.FilesystemPolicy{
+		WorkspaceRoot: paths.WorkspaceRoot,
+		WorkingDir:    paths.WorkDir,
+		Mounts:        mounts,
+		TempDirHost:   userTempDir(principalDir, id),
+	}
+}
+
+func remapStellaHomePolicyPath(hostPath, stellaHome string) string {
+	if hostPath == stellaHome {
+		return pkgsandbox.MountStellaHome
+	}
+	if strings.HasPrefix(hostPath, stellaHome+string(filepath.Separator)) {
+		return pkgsandbox.MountStellaHome + hostPath[len(stellaHome):]
+	}
+	return hostPath
 }
 
 // systemDBSkillsDirHost returns the host path of the DB-installed system-scope
@@ -68,11 +102,11 @@ func userDataDirHost(paths Paths, cfg Config) string {
 // bridge per-user tree -> system tree resolve identically on host and in the
 // sandbox. Putting it under the /user-mounted user-data root instead would split
 // the two trees across separate sandbox roots (/user vs /opt/stella) and dangle
-// those symlinks (#505). The cost is one dedicated writable bind, wired via
-// ExtraWritableMounts. Returns "" when there is no per-user tree: no principal, or
-// an ID that fails the safe-path-component check (the session then falls back to
-// the shared read-only system tree). A downgrade from an unsafe ID is logged so a
-// malformed ID is diagnosable.
+// those symlinks (#505). The policy builder emits it as one dedicated writable
+// Mount. Returns "" when there is no per-user tree: no principal, or an ID that
+// fails the safe-path-component check (the session then falls back to the shared
+// read-only system tree). A downgrade from an unsafe ID is logged so a malformed
+// ID is diagnosable.
 func miseUserDirHost(paths Paths, cfg Config) string {
 	principalDir, id := misePrincipal(cfg)
 	dir := pkgsandbox.MiseUserToolsDir(paths.StellaHome, principalDir, id)

--- a/internal/agent/sandbox/session.go
+++ b/internal/agent/sandbox/session.go
@@ -142,9 +142,6 @@ func buildBasePolicy(ctx context.Context, cfg Config) (Paths, pkgsandbox.Policy,
 	if err := pkgsandbox.EnsureMiseShims(paths.StellaHome, miseDir); err != nil {
 		return Paths{}, pkgsandbox.Policy{}, fmt.Errorf("ensure mise shims: %w", err)
 	}
-	if miseDir != "" {
-		fs.ExtraWritableMounts = append(fs.ExtraWritableMounts, miseDir)
-	}
 
 	policy := pkgsandbox.Policy{
 		Filesystem: fs,

--- a/pkg/sandbox/path_resolver.go
+++ b/pkg/sandbox/path_resolver.go
@@ -1,0 +1,238 @@
+package sandbox
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// PathResolver is the shared host-side filesystem boundary for in-process tools.
+// It translates agent-visible paths to host paths only when the result stays
+// inside a declared mount, and it rejects symlink traversal below mount roots.
+type PathResolver struct {
+	workingDir string
+	mounts     []Mount
+}
+
+// PathResolverConfig describes the mount view used by PathResolver.
+type PathResolverConfig struct {
+	WorkspaceRoot string
+	WorkingDir    string
+	Mounts        []Mount
+	TempDirHost   string
+}
+
+// ResolvedPath is a path resolved through a mount.
+type ResolvedPath struct {
+	HostPath    string
+	SandboxPath string
+	Mount       Mount
+}
+
+// NewPathResolver returns a resolver for the supplied filesystem view. The
+// workspace mount is added as a compatibility default when Mounts omits it.
+func NewPathResolver(cfg PathResolverConfig) *PathResolver {
+	mounts := normalizeMounts(cfg.Mounts)
+	workspace := cfg.WorkspaceRoot
+	if workspace == "" {
+		workspace = cfg.WorkingDir
+	}
+	if workspace != "" && !hasSandboxMount(mounts, MountWorkspace) && !hasHostMount(mounts, workspace) {
+		mounts = append(mounts, Mount{HostPath: workspace, SandboxPath: workspace, Access: MountReadWrite})
+	}
+	if cfg.TempDirHost != "" && !hasSandboxMount(mounts, "/tmp") {
+		mounts = append(mounts, Mount{HostPath: cfg.TempDirHost, SandboxPath: "/tmp", Access: MountReadWrite})
+	}
+	return &PathResolver{workingDir: cfg.WorkingDir, mounts: mounts}
+}
+
+// Mounts returns a copy of the normalized mount table.
+func (r *PathResolver) Mounts() []Mount {
+	out := make([]Mount, len(r.mounts))
+	copy(out, r.mounts)
+	return out
+}
+
+// ResolvePath resolves an agent path for reading.
+func (r *PathResolver) ResolvePath(agentPath string) (ResolvedPath, error) {
+	return r.resolve(agentPath, false)
+}
+
+// ResolveWritePath resolves an agent path for writing and rejects read-only mounts.
+func (r *PathResolver) ResolveWritePath(agentPath string) (ResolvedPath, error) {
+	return r.resolve(agentPath, true)
+}
+
+// ToHostPath maps a sandbox-space path to its host path using the deepest mount.
+func (r *PathResolver) ToHostPath(sandboxPath string) (string, bool) {
+	m, rel, ok := deepestSandboxMount(r.mounts, filepath.Clean(sandboxPath))
+	if !ok {
+		return "", false
+	}
+	return joinMountRel(m.HostPath, rel), true
+}
+
+// ToSandboxPath maps a host path to its sandbox-space path using the deepest mount.
+func (r *PathResolver) ToSandboxPath(hostPath string) (string, bool) {
+	m, rel, ok := deepestHostMount(r.mounts, filepath.Clean(hostPath))
+	if !ok {
+		return "", false
+	}
+	return joinMountRel(m.SandboxPath, rel), true
+}
+
+func (r *PathResolver) resolve(agentPath string, write bool) (ResolvedPath, error) {
+	if len(r.mounts) == 0 {
+		return ResolvedPath{}, fmt.Errorf("sandbox: path %q is outside workspace root: no mounts configured", agentPath)
+	}
+
+	candidateSandbox := agentPath
+	if !filepath.IsAbs(candidateSandbox) {
+		candidateSandbox = filepath.Join(r.sandboxWorkingDir(), agentPath)
+	}
+	candidateSandbox = filepath.Clean(candidateSandbox)
+
+	candidateHost, ok := r.ToHostPath(candidateSandbox)
+	if !ok {
+		// Backwards compatibility and host-absolute inputs: treat an absolute path
+		// under a host mount as already in host space.
+		candidateHost = filepath.Clean(candidateSandbox)
+	}
+
+	resolved, err := filepath.EvalSymlinks(candidateHost)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return ResolvedPath{}, fmt.Errorf("sandbox: resolve path %q: %w", agentPath, err)
+		}
+		resolved = candidateHost
+	}
+	resolved = filepath.Clean(resolved)
+
+	mount, _, ok := deepestHostMount(r.mounts, resolved)
+	if !ok {
+		mount, _, ok = deepestHostMount(r.mounts, candidateHost)
+	}
+	if !ok {
+		return ResolvedPath{}, fmt.Errorf("sandbox: path %q resolves to %q which is outside workspace root/mount set", agentPath, resolved)
+	}
+	if write && mount.Access == MountReadOnly {
+		return ResolvedPath{}, fmt.Errorf("sandbox: path %q is in a read-only mount", agentPath)
+	}
+	if err := rejectMountSymlinkTraversal(mount.HostPath, candidateHost); err != nil {
+		return ResolvedPath{}, fmt.Errorf("sandbox: %w", err)
+	}
+	sandboxPath, _ := r.ToSandboxPath(candidateHost)
+	return ResolvedPath{HostPath: candidateHost, SandboxPath: sandboxPath, Mount: mount}, nil
+}
+
+func (r *PathResolver) sandboxWorkingDir() string {
+	wd := r.workingDir
+	if wd == "" {
+		if len(r.mounts) == 0 {
+			return ""
+		}
+		return r.mounts[0].SandboxPath
+	}
+	if sandboxPath, ok := r.ToSandboxPath(wd); ok {
+		return sandboxPath
+	}
+	return wd
+}
+
+func normalizeMounts(mounts []Mount) []Mount {
+	out := make([]Mount, 0, len(mounts))
+	for _, m := range mounts {
+		if m.HostPath == "" || m.SandboxPath == "" {
+			continue
+		}
+		m.HostPath = filepath.Clean(m.HostPath)
+		m.SandboxPath = filepath.Clean(m.SandboxPath)
+		out = append(out, m)
+	}
+	return out
+}
+
+func hasSandboxMount(mounts []Mount, sandboxPath string) bool {
+	clean := filepath.Clean(sandboxPath)
+	for _, m := range mounts {
+		if m.SandboxPath == clean {
+			return true
+		}
+	}
+	return false
+}
+
+func hasHostMount(mounts []Mount, hostPath string) bool {
+	clean := filepath.Clean(hostPath)
+	for _, m := range mounts {
+		if m.HostPath == clean {
+			return true
+		}
+	}
+	return false
+}
+
+func deepestSandboxMount(mounts []Mount, path string) (Mount, string, bool) {
+	return deepestMountBy(path, mounts, func(m Mount) string { return m.SandboxPath })
+}
+
+func deepestHostMount(mounts []Mount, path string) (Mount, string, bool) {
+	return deepestMountBy(path, mounts, func(m Mount) string { return m.HostPath })
+}
+
+func deepestMountBy(path string, mounts []Mount, rootOf func(Mount) string) (Mount, string, bool) {
+	var best Mount
+	bestRel := ""
+	found := false
+	for _, m := range mounts {
+		root := rootOf(m)
+		rel, err := filepath.Rel(root, path)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			continue
+		}
+		if !found || len(root) > len(rootOf(best)) {
+			best = m
+			bestRel = rel
+			found = true
+		}
+	}
+	return best, bestRel, found
+}
+
+func joinMountRel(root, rel string) string {
+	if rel == "." || rel == "" {
+		return root
+	}
+	return filepath.Join(root, rel)
+}
+
+func rejectMountSymlinkTraversal(root, path string) error {
+	root = filepath.Clean(root)
+	path = filepath.Clean(path)
+	rel, err := filepath.Rel(root, path)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("path %q is outside mount root %q", path, root)
+	}
+	if rel == "." {
+		return nil
+	}
+	current := root
+	for part := range strings.SplitSeq(rel, string(filepath.Separator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		current = filepath.Join(current, part)
+		info, err := os.Lstat(current)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return fmt.Errorf("lstat %q: %w", current, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("path %q traverses symlink at %q", path, current)
+		}
+	}
+	return nil
+}

--- a/pkg/sandbox/policy.go
+++ b/pkg/sandbox/policy.go
@@ -59,76 +59,43 @@ type Policy struct {
 	Timeout time.Duration
 }
 
+// MountAccess is the access mode a sandbox mount grants inside the sandbox.
+type MountAccess uint8
+
+const (
+	// MountReadOnly allows reads but rejects writes through host-side tools and
+	// asks isolating backends for a read-only bind when the platform supports it.
+	MountReadOnly MountAccess = iota
+	// MountReadWrite allows reads and writes.
+	MountReadWrite
+)
+
+// Mount maps a host path into the sandbox view.
+type Mount struct {
+	HostPath    string
+	SandboxPath string
+	Access      MountAccess
+}
+
 // FilesystemPolicy defines filesystem constraints for a sandbox session.
 type FilesystemPolicy struct {
-	// WorkspaceRoot is the host path mounted as the sandbox root. When empty,
-	// WorkingDir is used for backwards compatibility.
+	// WorkspaceRoot is the host workspace root. When empty, WorkingDir is used for
+	// backwards compatibility and for relative-path anchoring in non-isolating code.
 	WorkspaceRoot string
 
-	// WorkingDir is the logical working directory inside the sandbox root.
+	// WorkingDir is the requested working directory. Producers may provide either
+	// a host path under WorkspaceRoot or the corresponding sandbox path; backends
+	// normalize it through Mounts before execution.
 	WorkingDir string
 
-	// UserDataDir is the host path of the shared user-data root, mounted as a
-	// second top-level root (/user) in the two-root layout. Holds toolchains,
-	// caches, user-level skills/delegates, and uploads shared across the user's
-	// agents. Empty during the migration / for backends that don't yet implement
-	// the second root; not consumed until a later phase wires the mount and the
-	// host-side path resolver.
-	UserDataDir string
-
-	// ExtraReadOnlyMounts is a list of host paths to mount read-only inside the
-	// sandbox at their exact host path (same-path strategy). Used for skill dirs
-	// that live outside the workspace root but must be accessible for script execution.
-	ExtraReadOnlyMounts []string
+	// Mounts is the complete host→sandbox mount plan for isolating backends.
+	Mounts []Mount
 
 	// TempDirHost is the host directory mounted as /tmp inside the sandbox.
 	// Empty means the backend chooses a session-local temp directory. Non-empty
 	// directories are guaranteed to exist with 0700 permissions before the
 	// backend sees the policy; they may be shared across sessions.
 	TempDirHost string
-
-	// ExtraWritableMounts is a list of host paths to mount writable inside the
-	// sandbox at their STELLA_HOME-remapped path. Each path must live under the
-	// host STELLA_HOME: the isolating backends mount it at its remapped location
-	// (bwrap remaps STELLA_HOME -> /opt/stella; Seatbelt uses the host
-	// path unchanged), so a path outside STELLA_HOME would bind at an unintended
-	// target. This differs from ExtraReadOnlyMounts, which mounts at the exact
-	// host path (same-path strategy).
-	//
-	// The isolating backends bind each writable (bwrap --bind, Seatbelt allow
-	// file-write*); the none backend needs no mount since it shares the host
-	// filesystem. The docker backend is the exception: it ships its own in-image
-	// mise and never reads this field, so the caller skips populating it for
-	// docker (see the backend guard in buildBasePolicy). Reaching docker with a
-	// non-empty list would silently no-op — backend parity is tracked in #442.
-	//
-	// Used for per-user subtrees an agent must write through — today the writable
-	// per-user mise home (see pkgsandbox.MiseUserToolsDir), with more to follow.
-	// Each path is guaranteed to exist (the mise tree also seeded with system
-	// installs) before the backend sees the policy. The policy stays mise-agnostic:
-	// it only learns "these host dirs are writable", not why.
-	ExtraWritableMounts []string
-
-	// AgentSkillsDir is the host path of the admin-managed, agent-bound
-	// (system_agent scope) skills dir — AgentRoot/.agents/skills. Isolating
-	// backends mount it read-only at MountAgentSkills (/opt/stella/agent-skills)
-	// so an agent can still load and run those skills without the host path
-	// leaking. Empty for a session with no agent definition root, and ignored by
-	// the none backend (host paths are valid in-sandbox there).
-	AgentSkillsDir string
-
-	// SystemDBSkillsDir is the host path of the DB-installed system-scope skills
-	// dir (STELLA_HOME/.agents/db-skills). Isolating backends mount it read-only
-	// at MountSystemDBSkills (/opt/stella/db-skills) so a system skill installed
-	// via Settings can still load and run its files without the host path leaking.
-	// Ignored by the none backend (host paths are valid in-sandbox there).
-	SystemDBSkillsDir string
-
-	// AgentPrivateDir is a legacy sibling-hiding hint, left empty in the two-root
-	// layout: the agent workspace IS the per-agent dir (WorkspaceRoot), so siblings
-	// are never mounted and there is nothing to hide. Still read by the macOS
-	// Seatbelt profile (a deny/allow carve-out), where it stays inert while empty.
-	AgentPrivateDir string
 }
 
 // NetworkPolicy defines network constraints for a sandbox session.

--- a/pkg/sandbox/session.go
+++ b/pkg/sandbox/session.go
@@ -24,7 +24,7 @@ type Session interface {
 	// ResolvePath validates read access; use ResolveWritePath for write operations.
 	ResolvePath(path string) (string, error)
 	// ResolveWritePath is like ResolvePath but additionally rejects paths in
-	// read-only mounts (e.g. ExtraReadOnlyMounts / skill directories).
+	// read-only mounts.
 	ResolveWritePath(path string) (string, error)
 	WorkingDir() string
 }

--- a/plugins/sandbox/docker/session.go
+++ b/plugins/sandbox/docker/session.go
@@ -167,7 +167,7 @@ func (f *dockerFactory) CreateSession(ctx context.Context, policy sandboxpkg.Pol
 	// Shared user-data root (mounted as /user). Empty for a user-less job, which
 	// has no principal home — then no /user mount and STELLA_USER_DIR stays unset.
 	userDataHost := ""
-	if ud := policy.Filesystem.UserDataDir; ud != "" {
+	if ud := hostPathForSandboxMount(policy.Filesystem.Mounts, userDataMount); ud != "" {
 		if abs, absErr := filepath.Abs(ud); absErr == nil {
 			userDataHost = abs
 		}
@@ -206,18 +206,16 @@ func (f *dockerFactory) CreateSession(ctx context.Context, policy sandboxpkg.Pol
 		Name: "stella-sandbox-" + sessionID,
 	}
 
-	mountedExtraReadOnly, mountedTempDirHost, mountedUserDataHost, err := f.configureSessionMounts(&opts, policy, workspaceHost, userDataHost)
+	mountedPolicyMounts, mountedTempDirHost, mountedUserDataHost, err := f.configureSessionMounts(&opts, policy, workspaceHost, userDataHost)
 	if err != nil {
 		recordError(span, err)
 		span.End()
 		return nil, err
 	}
 
-	// Per-user mise tree(s): mounted writable at the /opt/stella-remapped path so
-	// the agent can persist its own `mise install`s, mirroring bwrap. The image
-	// supplies the shared read-only base at /opt/stella/.mise-tools; these overlay
-	// the writable per-user layer on top.
-	perUserTrees := f.mountPerUserToolTrees(&opts, policy)
+	// Per-user mise tree(s) are generic writable mounts; keep their mounted pairs
+	// so PATH can point at their shims.
+	perUserTrees := writableToolTrees(mountedPolicyMounts)
 
 	// Expose the user-data root as STELLA_USER_DIR — but only when /user was
 	// actually mounted, keyed off the host path the mount really used. The value
@@ -246,14 +244,10 @@ func (f *dockerFactory) CreateSession(ctx context.Context, policy sandboxpkg.Pol
 	// PID 1's environment carries host paths the agent can read via
 	// /proc/1/environ, defeating the isolation (Pi critical).
 	mountTable := buildMountTable(mountTableOptions{
-		WorkspaceHost:       workspaceHost,
-		WorkspaceMount:      workspaceMount,
-		UserDataHost:        mountedUserDataHost,
-		UserDataMount:       userDataMount,
-		StellaHomeHost:      policy.Env["STELLA_HOME"],
-		StellaHomeContainer: stellaHomeMount,
-		ExtraReadOnlyMounts: mountedExtraReadOnly,
-		TempDirHost:         mountedTempDirHost,
+		WorkspaceHost:  workspaceHost,
+		WorkspaceMount: workspaceMount,
+		Mounts:         mountedPolicyMounts,
+		TempDirHost:    mountedTempDirHost,
 	})
 
 	// The per-user trees are writable and resolve via the process view too.
@@ -275,9 +269,8 @@ func (f *dockerFactory) CreateSession(ctx context.Context, policy sandboxpkg.Pol
 
 	// Per-user mise shims go on PATH ahead of the image's system shims so a user's
 	// own tool versions win (mirrors HostEnvBuildPath on the host backends). Only
-	// the mise tree gets a shims/ entry: ExtraWritableMounts is a generic policy
-	// field, so guard against a future non-mise writable mount contributing a
-	// bogus PATH dir.
+	// the mise tree gets a shims/ entry, so guard against a future non-mise writable
+	// mount contributing a bogus PATH dir.
 	var toolBinPaths []string
 	for _, tree := range perUserTrees {
 		if filepath.Base(tree.Container) == ".mise-tools" {
@@ -349,19 +342,25 @@ func (f *dockerFactory) CreateSession(ctx context.Context, policy sandboxpkg.Pol
 	return session, nil
 }
 
-// configureSessionMounts wires the container mounts for the active mode and
-// returns the extra read-only mounts, the mounted temp-dir host, and the mounted
-// user-data host ("" when /user could not be mounted, so callers don't wire a
-// /user that isn't really there).
-func (f *dockerFactory) configureSessionMounts(opts *dockerclient.CreateOptions, policy sandboxpkg.Policy, workspaceHost, userDataHost string) ([]string, string, string, error) {
+// configureSessionMounts wires the generic mount plan for the active mode and
+// returns the mounted process-view mounts, the mounted temp-dir host, and the
+// mounted user-data host ("" when /user could not be mounted, so callers don't
+// wire a /user that isn't really there).
+func (f *dockerFactory) configureSessionMounts(opts *dockerclient.CreateOptions, policy sandboxpkg.Policy, workspaceHost, userDataHost string) ([]sandboxpkg.Mount, string, string, error) {
+	if len(policy.Filesystem.Mounts) == 0 {
+		policy.Filesystem.Mounts = append(policy.Filesystem.Mounts, sandboxpkg.Mount{HostPath: workspaceHost, SandboxPath: workspaceMount, Access: sandboxpkg.MountReadWrite})
+	}
+	if userDataHost != "" && hostPathForSandboxMount(policy.Filesystem.Mounts, userDataMount) == "" {
+		policy.Filesystem.Mounts = append(policy.Filesystem.Mounts, sandboxpkg.Mount{HostPath: userDataHost, SandboxPath: userDataMount, Access: sandboxpkg.MountReadWrite})
+	}
 	if f.cfg.RuntimeMode == DockerSandboxModeVolume {
-		mountedExtraReadOnly, mountedUserDataHost, err := f.configureVolumeMounts(opts, policy, workspaceHost, userDataHost)
-		return mountedExtraReadOnly, "", mountedUserDataHost, err
+		mounted, mountedUserDataHost, err := f.configureVolumeMounts(opts, policy, workspaceHost, userDataHost)
+		return mounted, "", mountedUserDataHost, err
 	}
 	return f.configureBindMounts(opts, policy, workspaceHost, userDataHost)
 }
 
-func (f *dockerFactory) configureVolumeMounts(opts *dockerclient.CreateOptions, policy sandboxpkg.Policy, workspaceHost, userDataHost string) ([]string, string, error) {
+func (f *dockerFactory) configureVolumeMounts(opts *dockerclient.CreateOptions, policy sandboxpkg.Policy, workspaceHost, userDataHost string) ([]sandboxpkg.Mount, string, error) {
 	workspaceSubpath, ok := relativePathWithin(f.cfg.StellaHome, workspaceHost)
 	if !ok {
 		return nil, "", fmt.Errorf("docker session: workspace %q is not inside STELLA_HOME %q; cannot use volume mode", workspaceHost, f.cfg.StellaHome)
@@ -376,151 +375,64 @@ func (f *dockerFactory) configureVolumeMounts(opts *dockerclient.CreateOptions, 
 		Type:          dockerclient.MountTypeVolume,
 		VolumeSubpath: filepath.ToSlash(workspaceSubpath),
 	})
-	// Shared user-data root → /user (RW). Lives under STELLA_HOME, so it comes
-	// from the same named volume at its subpath.
+	mounted := []sandboxpkg.Mount{{HostPath: workspaceHost, SandboxPath: workspaceMount, Access: sandboxpkg.MountReadWrite}}
 	mountedUserDataHost := ""
-	if userDataHost != "" {
-		if subpath, ok := relativePathWithin(f.cfg.StellaHome, userDataHost); ok && subpath != "." {
-			opts.ExtraMounts = append(opts.ExtraMounts, dockerclient.Mount{
-				HostPath:      f.cfg.StellaHomeVolume,
-				ContainerPath: userDataMount,
-				ReadOnly:      false,
-				Type:          dockerclient.MountTypeVolume,
-				VolumeSubpath: filepath.ToSlash(subpath),
-			})
-			mountedUserDataHost = userDataHost
-		} else {
-			logSkippedSandboxMount(DockerSandboxModeVolume, userDataHost, "user-data root is outside STELLA_HOME and cannot be mounted from the named volume")
+	for _, m := range nonWorkspacePolicyMounts(policy.Filesystem.Mounts) {
+		if m.Access == sandboxpkg.MountReadOnly && !dirExists(m.HostPath) {
+			continue
 		}
-	}
-	for _, name := range dockerHostStellaDirs() {
-		hostPath := filepath.Join(f.cfg.StellaHome, name)
-		if _, err := os.Stat(hostPath); err != nil {
+		subpath, ok := relativePathWithin(f.cfg.StellaHome, m.HostPath)
+		if !ok || subpath == "." {
+			logSkippedSandboxMount(DockerSandboxModeVolume, m.HostPath, "path is outside STELLA_HOME and cannot be mounted from the named volume")
 			continue
 		}
 		opts.ExtraMounts = append(opts.ExtraMounts, dockerclient.Mount{
 			HostPath:      f.cfg.StellaHomeVolume,
-			ContainerPath: filepath.Join(stellaHomeMount, name),
-			ReadOnly:      true,
-			Type:          dockerclient.MountTypeVolume,
-			VolumeSubpath: filepath.ToSlash(name),
-		})
-	}
-	// Agent-bound (system_agent) skills → /opt/stella/agent-skills (RO). Lives
-	// under STELLA_HOME, so it comes from the same named volume at its subpath.
-	// Skipped when not installed for this agent (the dir is absent).
-	if as := policy.Filesystem.AgentSkillsDir; as != "" && dirExists(as) {
-		if subpath, ok := relativePathWithin(f.cfg.StellaHome, as); ok && subpath != "." {
-			opts.ExtraMounts = append(opts.ExtraMounts, dockerclient.Mount{
-				HostPath:      f.cfg.StellaHomeVolume,
-				ContainerPath: sandboxpkg.MountAgentSkills,
-				ReadOnly:      true,
-				Type:          dockerclient.MountTypeVolume,
-				VolumeSubpath: filepath.ToSlash(subpath),
-			})
-		} else {
-			logSkippedSandboxMount(DockerSandboxModeVolume, as, "agent skills dir is outside STELLA_HOME and cannot be mounted from the named volume")
-		}
-	}
-	// DB-installed system skills → /opt/stella/db-skills (RO). Also under
-	// STELLA_HOME, so it comes from the same named volume at its subpath.
-	if sd := policy.Filesystem.SystemDBSkillsDir; sd != "" && dirExists(sd) {
-		if subpath, ok := relativePathWithin(f.cfg.StellaHome, sd); ok && subpath != "." {
-			opts.ExtraMounts = append(opts.ExtraMounts, dockerclient.Mount{
-				HostPath:      f.cfg.StellaHomeVolume,
-				ContainerPath: sandboxpkg.MountSystemDBSkills,
-				ReadOnly:      true,
-				Type:          dockerclient.MountTypeVolume,
-				VolumeSubpath: filepath.ToSlash(subpath),
-			})
-		} else {
-			logSkippedSandboxMount(DockerSandboxModeVolume, sd, "system DB skills dir is outside STELLA_HOME and cannot be mounted from the named volume")
-		}
-	}
-	mountedExtraReadOnly := []string{}
-	for _, hostPath := range policy.Filesystem.ExtraReadOnlyMounts {
-		subpath, ok := relativePathWithin(f.cfg.StellaHome, hostPath)
-		if !ok {
-			logSkippedSandboxMount(DockerSandboxModeVolume, hostPath, "path is outside STELLA_HOME and cannot be mounted from the named volume")
-			continue
-		}
-		opts.ExtraMounts = append(opts.ExtraMounts, dockerclient.Mount{
-			HostPath:      f.cfg.StellaHomeVolume,
-			ContainerPath: hostPath,
-			ReadOnly:      true,
+			ContainerPath: m.SandboxPath,
+			ReadOnly:      m.Access == sandboxpkg.MountReadOnly,
 			Type:          dockerclient.MountTypeVolume,
 			VolumeSubpath: filepath.ToSlash(subpath),
 		})
-		mountedExtraReadOnly = append(mountedExtraReadOnly, hostPath)
-		appendWorkspaceRelativeReadOnlyMount(opts, f.cfg.StellaHomeVolume, hostPath, workspaceHost, subpath, dockerclient.MountTypeVolume)
+		mounted = append(mounted, m)
+		if m.SandboxPath == userDataMount {
+			mountedUserDataHost = m.HostPath
+		}
+		if m.Access == sandboxpkg.MountReadOnly {
+			appendWorkspaceRelativeReadOnlyMount(opts, f.cfg.StellaHomeVolume, m.HostPath, workspaceHost, subpath, dockerclient.MountTypeVolume)
+		}
 	}
-	// Workspace is handled by the volume mount above; clear WorkspaceHost so the
-	// docker client skips the default bind mount. TempDirHost lives outside
-	// STELLA_HOME and is intentionally unavailable in volume mode.
 	opts.WorkspaceHost = ""
-	return mountedExtraReadOnly, mountedUserDataHost, nil
+	return mounted, mountedUserDataHost, nil
 }
 
-func (f *dockerFactory) configureBindMounts(opts *dockerclient.CreateOptions, policy sandboxpkg.Policy, workspaceHost, userDataHost string) ([]string, string, string, error) {
+func (f *dockerFactory) configureBindMounts(opts *dockerclient.CreateOptions, policy sandboxpkg.Policy, workspaceHost, userDataHost string) ([]sandboxpkg.Mount, string, string, error) {
 	daemonWorkspaceHost, ok := f.cfg.daemonPath(workspaceHost)
 	if !ok {
 		return nil, "", "", fmt.Errorf("docker session: workspace %q is not under STELLA_HOME %q; cannot use bind-mount mode", workspaceHost, f.cfg.StellaHome)
 	}
 	opts.WorkspaceHost = daemonWorkspaceHost
-	// Shared user-data root → /user (RW).
+	mounted := []sandboxpkg.Mount{{HostPath: workspaceHost, SandboxPath: workspaceMount, Access: sandboxpkg.MountReadWrite}}
 	mountedUserDataHost := ""
-	if userDataHost != "" {
-		if daemonPath, ok := f.cfg.daemonPath(userDataHost); ok {
-			opts.ExtraMounts = append(opts.ExtraMounts, dockerclient.Mount{
-				HostPath:      daemonPath,
-				ContainerPath: userDataMount,
-			})
-			mountedUserDataHost = userDataHost
-		} else {
-			logSkippedSandboxMount(f.cfg.RuntimeMode, userDataHost, "user-data root is not visible to the Docker daemon")
+	for _, m := range nonWorkspacePolicyMounts(policy.Filesystem.Mounts) {
+		if m.Access == sandboxpkg.MountReadOnly && !dirExists(m.HostPath) {
+			continue
 		}
-	}
-	// Agent-bound (system_agent) skills → /opt/stella/agent-skills (RO). Skipped
-	// when not installed for this agent (the dir is absent).
-	if as := policy.Filesystem.AgentSkillsDir; as != "" && dirExists(as) {
-		if daemonPath, ok := f.cfg.daemonPath(as); ok {
-			opts.ExtraMounts = append(opts.ExtraMounts, dockerclient.Mount{
-				HostPath:      daemonPath,
-				ContainerPath: sandboxpkg.MountAgentSkills,
-				ReadOnly:      true,
-			})
-		} else {
-			logSkippedSandboxMount(f.cfg.RuntimeMode, as, "agent skills dir is not visible to the Docker daemon")
+		daemonPath, ok := f.cfg.daemonPath(m.HostPath)
+		if !ok {
+			logSkippedSandboxMount(f.cfg.RuntimeMode, m.HostPath, "path is not visible to the Docker daemon")
+			continue
 		}
-	}
-	// DB-installed system skills → /opt/stella/db-skills (RO).
-	if sd := policy.Filesystem.SystemDBSkillsDir; sd != "" && dirExists(sd) {
-		if daemonPath, ok := f.cfg.daemonPath(sd); ok {
-			opts.ExtraMounts = append(opts.ExtraMounts, dockerclient.Mount{
-				HostPath:      daemonPath,
-				ContainerPath: sandboxpkg.MountSystemDBSkills,
-				ReadOnly:      true,
-			})
-		} else {
-			logSkippedSandboxMount(f.cfg.RuntimeMode, sd, "system DB skills dir is not visible to the Docker daemon")
+		opts.ExtraMounts = append(opts.ExtraMounts, dockerclient.Mount{
+			HostPath:      daemonPath,
+			ContainerPath: m.SandboxPath,
+			ReadOnly:      m.Access == sandboxpkg.MountReadOnly,
+		})
+		mounted = append(mounted, m)
+		if m.SandboxPath == userDataMount {
+			mountedUserDataHost = m.HostPath
 		}
-	}
-	stellaHome := f.cfg.StellaHome
-	if stellaHome != "" {
-		for _, name := range dockerHostStellaDirs() {
-			hostPath := filepath.Join(stellaHome, name)
-			if _, err := os.Stat(hostPath); err != nil {
-				continue
-			}
-			daemonPath, ok := f.cfg.daemonPath(hostPath)
-			if !ok {
-				continue
-			}
-			opts.ExtraMounts = append(opts.ExtraMounts, dockerclient.Mount{
-				HostPath:      daemonPath,
-				ContainerPath: filepath.Join(stellaHomeMount, name),
-				ReadOnly:      true,
-			})
+		if m.Access == sandboxpkg.MountReadOnly {
+			appendWorkspaceRelativeReadOnlyMount(opts, daemonPath, m.HostPath, workspaceHost, "", dockerclient.MountTypeBind)
 		}
 	}
 	mountedTempDirHost := ""
@@ -535,22 +447,7 @@ func (f *dockerFactory) configureBindMounts(opts *dockerclient.CreateOptions, po
 			logSkippedSandboxMount(f.cfg.RuntimeMode, policy.Filesystem.TempDirHost, "path is not visible to the Docker daemon")
 		}
 	}
-	mountedExtraReadOnly := []string{}
-	for _, hostPath := range policy.Filesystem.ExtraReadOnlyMounts {
-		daemonPath, ok := f.cfg.daemonPath(hostPath)
-		if !ok {
-			logSkippedSandboxMount(f.cfg.RuntimeMode, hostPath, "path is not visible to the Docker daemon")
-			continue
-		}
-		opts.ExtraMounts = append(opts.ExtraMounts, dockerclient.Mount{
-			HostPath:      daemonPath,
-			ContainerPath: hostPath,
-			ReadOnly:      true,
-		})
-		mountedExtraReadOnly = append(mountedExtraReadOnly, hostPath)
-		appendWorkspaceRelativeReadOnlyMount(opts, daemonPath, hostPath, workspaceHost, "", dockerclient.MountTypeBind)
-	}
-	return mountedExtraReadOnly, mountedTempDirHost, mountedUserDataHost, nil
+	return mounted, mountedTempDirHost, mountedUserDataHost, nil
 }
 
 func logSkippedSandboxMount(mode DockerSandboxMode, path, reason string) {
@@ -577,6 +474,39 @@ func relativePathWithin(root, path string) (string, bool) {
 	return rel, true
 }
 
+func hostPathForSandboxMount(mounts []sandboxpkg.Mount, sandboxPath string) string {
+	clean := filepath.Clean(sandboxPath)
+	for _, m := range mounts {
+		if filepath.Clean(m.SandboxPath) == clean {
+			return m.HostPath
+		}
+	}
+	return ""
+}
+
+func dockerMountProvidedByImage(m sandboxpkg.Mount) bool {
+	if !strings.HasPrefix(filepath.Clean(m.SandboxPath), stellaHomeMount+string(filepath.Separator)) {
+		return false
+	}
+	rel, err := filepath.Rel(stellaHomeMount, m.SandboxPath)
+	if err != nil {
+		return false
+	}
+	_, ok := dockerImageProvidedStellaDirs[rel]
+	return ok
+}
+
+func nonWorkspacePolicyMounts(mounts []sandboxpkg.Mount) []sandboxpkg.Mount {
+	out := make([]sandboxpkg.Mount, 0, len(mounts))
+	for _, m := range mounts {
+		if filepath.Clean(m.SandboxPath) == workspaceMount || dockerMountProvidedByImage(m) {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
 func appendWorkspaceRelativeReadOnlyMount(opts *dockerclient.CreateOptions, source, hostPath, workspaceHost, volumeSubpath string, mountType dockerclient.MountType) {
 	rel, ok := relativePathWithin(workspaceHost, hostPath)
 	if !ok || rel == "." {
@@ -601,20 +531,6 @@ var dockerImageProvidedStellaDirs = map[string]struct{}{
 	".mise-tools": {},
 }
 
-// dockerHostStellaDirs returns the STELLA_HOME subdirs docker mounts from the
-// host — the shared set minus the image-provided ones.
-func dockerHostStellaDirs() []string {
-	all := sandboxpkg.StellaHomeSandboxDirs()
-	dirs := make([]string, 0, len(all))
-	for _, name := range all {
-		if _, skip := dockerImageProvidedStellaDirs[name]; skip {
-			continue
-		}
-		dirs = append(dirs, name)
-	}
-	return dirs
-}
-
 // writableMount is a per-user writable tree mounted into the container, recording
 // both ends so the caller can register it in the mount table and derive PATH.
 type writableMount struct {
@@ -628,34 +544,36 @@ type writableMount struct {
 // otherwise. Mounts outside STELLA_HOME are skipped (the remap can't place them).
 func (f *dockerFactory) mountPerUserToolTrees(opts *dockerclient.CreateOptions, policy sandboxpkg.Policy) []writableMount {
 	var mounted []writableMount
-	for _, hostPath := range policy.Filesystem.ExtraWritableMounts {
-		sub, ok := relativePathWithin(f.cfg.StellaHome, hostPath)
-		if !ok || sub == "." {
-			logSkippedSandboxMount(f.cfg.RuntimeMode, hostPath, "writable mount is outside STELLA_HOME and cannot be remapped")
+	for _, m := range policy.Filesystem.Mounts {
+		if m.Access != sandboxpkg.MountReadWrite || m.SandboxPath == workspaceMount || m.SandboxPath == userDataMount {
 			continue
 		}
-		containerPath := filepath.Join(stellaHomeMount, sub)
-		if f.cfg.RuntimeMode == DockerSandboxModeVolume {
-			opts.ExtraMounts = append(opts.ExtraMounts, dockerclient.Mount{
-				HostPath:      f.cfg.StellaHomeVolume,
-				ContainerPath: containerPath,
-				Type:          dockerclient.MountTypeVolume,
-				VolumeSubpath: filepath.ToSlash(sub),
-			})
-		} else {
-			daemonPath, ok := f.cfg.daemonPath(hostPath)
-			if !ok {
-				logSkippedSandboxMount(f.cfg.RuntimeMode, hostPath, "writable mount is not visible to the Docker daemon")
-				continue
-			}
-			opts.ExtraMounts = append(opts.ExtraMounts, dockerclient.Mount{
-				HostPath:      daemonPath,
-				ContainerPath: containerPath,
-			})
+		sub, ok := relativePathWithin(f.cfg.StellaHome, m.HostPath)
+		if !ok || sub == "." {
+			logSkippedSandboxMount(f.cfg.RuntimeMode, m.HostPath, "writable mount is outside STELLA_HOME and cannot be remapped")
+			continue
 		}
-		mounted = append(mounted, writableMount{Host: hostPath, Container: containerPath})
+		if f.cfg.RuntimeMode == DockerSandboxModeVolume {
+			opts.ExtraMounts = append(opts.ExtraMounts, dockerclient.Mount{HostPath: f.cfg.StellaHomeVolume, ContainerPath: m.SandboxPath, Type: dockerclient.MountTypeVolume, VolumeSubpath: filepath.ToSlash(sub)})
+		} else if daemonPath, ok := f.cfg.daemonPath(m.HostPath); ok {
+			opts.ExtraMounts = append(opts.ExtraMounts, dockerclient.Mount{HostPath: daemonPath, ContainerPath: m.SandboxPath})
+		} else {
+			logSkippedSandboxMount(f.cfg.RuntimeMode, m.HostPath, "writable mount is not visible to the Docker daemon")
+			continue
+		}
+		mounted = append(mounted, writableMount{Host: m.HostPath, Container: m.SandboxPath})
 	}
 	return mounted
+}
+
+func writableToolTrees(mounts []sandboxpkg.Mount) []writableMount {
+	out := []writableMount{}
+	for _, m := range mounts {
+		if m.Access == sandboxpkg.MountReadWrite && m.SandboxPath != workspaceMount && m.SandboxPath != userDataMount {
+			out = append(out, writableMount{Host: m.HostPath, Container: m.SandboxPath})
+		}
+	}
+	return out
 }
 
 // mapNetworkMode translates sandbox policy network mode to the dockerclient type.
@@ -669,59 +587,30 @@ func mapNetworkMode(policy sandboxpkg.Policy) dockerclient.NetworkMode {
 }
 
 type mountTableOptions struct {
-	WorkspaceHost       string
-	WorkspaceMount      string
-	UserDataHost        string
-	UserDataMount       string
-	StellaHomeHost      string
-	StellaHomeContainer string
-	ExtraReadOnlyMounts []string
-	TempDirHost         string
+	WorkspaceHost  string
+	WorkspaceMount string
+	Mounts         []sandboxpkg.Mount
+	TempDirHost    string
 }
 
 // buildMountTable returns the process-view bind mount set that path resolution
 // should consult. Host paths here are intentionally not daemon-translated: file
 // tools run in the Stella process namespace, not the Docker daemon namespace.
 func buildMountTable(opts mountTableOptions) []dockerclient.Mount {
-	mounts := []dockerclient.Mount{
-		{
-			HostPath:      opts.WorkspaceHost,
-			ContainerPath: opts.WorkspaceMount,
-			ReadOnly:      false,
-		},
-	}
-	if opts.UserDataHost != "" && opts.UserDataMount != "" {
-		mounts = append(mounts, dockerclient.Mount{
-			HostPath:      opts.UserDataHost,
-			ContainerPath: opts.UserDataMount,
-			ReadOnly:      false,
-		})
-	}
-	if opts.StellaHomeHost != "" && opts.StellaHomeContainer != "" {
-		for _, name := range dockerHostStellaDirs() {
-			hostPath := filepath.Join(opts.StellaHomeHost, name)
-			if _, err := os.Stat(hostPath); err != nil {
-				continue
-			}
+	mounts := make([]dockerclient.Mount, 0, len(opts.Mounts)+1)
+	if len(opts.Mounts) == 0 {
+		mounts = append(mounts, dockerclient.Mount{HostPath: opts.WorkspaceHost, ContainerPath: opts.WorkspaceMount})
+	} else {
+		for _, m := range opts.Mounts {
 			mounts = append(mounts, dockerclient.Mount{
-				HostPath:      hostPath,
-				ContainerPath: filepath.Join(opts.StellaHomeContainer, name),
-				ReadOnly:      true,
+				HostPath:      m.HostPath,
+				ContainerPath: m.SandboxPath,
+				ReadOnly:      m.Access == sandboxpkg.MountReadOnly,
 			})
 		}
 	}
-	for _, hostPath := range opts.ExtraReadOnlyMounts {
-		mounts = append(mounts, dockerclient.Mount{
-			HostPath:      hostPath,
-			ContainerPath: hostPath,
-			ReadOnly:      true,
-		})
-	}
 	if opts.TempDirHost != "" {
-		mounts = append(mounts, dockerclient.Mount{
-			HostPath:      opts.TempDirHost,
-			ContainerPath: "/tmp",
-		})
+		mounts = append(mounts, dockerclient.Mount{HostPath: opts.TempDirHost, ContainerPath: "/tmp"})
 	}
 	return mounts
 }
@@ -1124,20 +1013,11 @@ func (h *dockerHost) WorkingDir() string {
 // workspace, so any are agent-planted and following them would let an
 // agent escape the mount via a file that passes the string-based check.
 func (h *dockerHost) ResolvePath(path string) (string, error) {
-	resolved := path
-	if !filepath.IsAbs(resolved) {
-		workingDir := h.session.policy.Filesystem.WorkingDir
-		resolved = filepath.Join(workingDir, path)
-	} else if hostPath, ok := toHostPath(h.session.mountTable, resolved); ok {
-		resolved = hostPath
-	}
-	if _, err := toContainerPath(h.session.mountTable, resolved); err != nil {
-		return "", fmt.Errorf("docker host: path %q is outside the session mount set: %w", path, err)
-	}
-	if err := rejectSymlinkTraversal(h.session.mountTable, resolved); err != nil {
+	resolved, err := h.pathResolver().ResolvePath(path)
+	if err != nil {
 		return "", fmt.Errorf("docker host: %w", err)
 	}
-	return resolved, nil
+	return resolved.HostPath, nil
 }
 
 // toHostPath maps a container absolute path to its equivalent host path when
@@ -1172,86 +1052,38 @@ func toHostPath(mounts []dockerclient.Mount, containerPath string) (string, bool
 // agent-controllable, so they are not checked. Components at or below the
 // mount root are agent-writable and any symlink there is either
 // agent-planted or unexpected — both are rejected.
-func rejectSymlinkTraversal(mounts []dockerclient.Mount, path string) error {
-	root := deepestMountRoot(mounts, path)
-	if root == "" {
-		return fmt.Errorf("path %q has no matching mount", path)
-	}
-	rel, err := filepath.Rel(root, path)
-	if err != nil {
-		return fmt.Errorf("rel %q from %q: %w", path, root, err)
-	}
-	if rel == "." {
-		return nil
-	}
-	current := root
-	for part := range strings.SplitSeq(rel, string(filepath.Separator)) {
-		current = filepath.Join(current, part)
-		info, err := os.Lstat(current)
-		if err != nil {
-			if os.IsNotExist(err) {
-				return nil
-			}
-			return fmt.Errorf("lstat %q: %w", current, err)
-		}
-		if info.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("path %q traverses symlink at %q", path, current)
-		}
-	}
-	return nil
-}
 
 // deepestMountRoot returns the longest-prefix mount HostPath that contains
 // `path`, or "" if no mount covers it. Mirrors the selection rule in
 // toContainerPath so both agree on which mount owns a given path.
-func deepestMountRoot(mounts []dockerclient.Mount, path string) string {
-	best := ""
-	for _, m := range mounts {
-		rel, err := filepath.Rel(m.HostPath, path)
-		if err != nil {
-			continue
-		}
-		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-			continue
-		}
-		if len(m.HostPath) > len(best) {
-			best = m.HostPath
-		}
-	}
-	return best
-}
 
 // deepestMount returns the mount with the longest HostPath prefix containing
 // path, or nil if no mount covers it.
-func deepestMount(mounts []dockerclient.Mount, path string) *dockerclient.Mount {
-	var best *dockerclient.Mount
-	for i := range mounts {
-		m := &mounts[i]
-		rel, err := filepath.Rel(m.HostPath, path)
-		if err != nil {
-			continue
-		}
-		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-			continue
-		}
-		if best == nil || len(m.HostPath) > len(best.HostPath) {
-			best = m
-		}
-	}
-	return best
-}
 
 // ResolveWritePath is like ResolvePath but additionally rejects paths that
 // fall within a read-only mount.
 func (h *dockerHost) ResolveWritePath(path string) (string, error) {
-	resolved, err := h.ResolvePath(path)
+	resolved, err := h.pathResolver().ResolveWritePath(path)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("docker host: %w", err)
 	}
-	if m := deepestMount(h.session.mountTable, resolved); m != nil && m.ReadOnly {
-		return "", fmt.Errorf("docker host: path %q is in a read-only mount", path)
+	return resolved.HostPath, nil
+}
+
+func (h *dockerHost) pathResolver() *sandboxpkg.PathResolver {
+	mounts := make([]sandboxpkg.Mount, 0, len(h.session.mountTable))
+	for _, m := range h.session.mountTable {
+		access := sandboxpkg.MountReadWrite
+		if m.ReadOnly {
+			access = sandboxpkg.MountReadOnly
+		}
+		mounts = append(mounts, sandboxpkg.Mount{HostPath: m.HostPath, SandboxPath: m.ContainerPath, Access: access})
 	}
-	return resolved, nil
+	return sandboxpkg.NewPathResolver(sandboxpkg.PathResolverConfig{
+		WorkspaceRoot: h.session.policy.WorkspaceRootOrDefault(),
+		WorkingDir:    h.session.policy.Filesystem.WorkingDir,
+		Mounts:        mounts,
+	})
 }
 
 func (h *dockerHost) Exec(ctx context.Context, command string, opts sandboxpkg.ExecOptions) (sandboxpkg.ExecResult, error) {

--- a/plugins/sandbox/docker/session_pure_test.go
+++ b/plugins/sandbox/docker/session_pure_test.go
@@ -64,83 +64,30 @@ func TestWithServerURL(t *testing.T) {
 }
 
 func TestBuildMountTable(t *testing.T) {
-	stellaHome := t.TempDir()
-	for _, name := range []string{"bin", ".mise-tools", filepath.Join(".agents", "skills")} {
-		if err := os.MkdirAll(filepath.Join(stellaHome, name), 0o755); err != nil {
-			t.Fatal(err)
-		}
-	}
-
 	table := buildMountTable(mountTableOptions{
-		WorkspaceHost:       "/host/ws",
-		WorkspaceMount:      "/container/ws",
-		StellaHomeHost:      stellaHome,
-		StellaHomeContainer: "/home/stella/.stella",
-	})
-	// bin and .mise-tools are image-provided (linux), never host-mounted, so the
-	// process view carries only the workspace and the host-supplied skills.
-	if len(table) != 2 {
-		t.Fatalf("expected 2 entries, got %d: %+v", len(table), table)
-	}
-	if table[0].HostPath != "/host/ws" || table[0].ContainerPath != "/container/ws" {
-		t.Fatalf("unexpected workspace mount: %+v", table[0])
-	}
-	if table[0].ReadOnly {
-		t.Fatal("workspace should be read-write")
-	}
-	if table[1].HostPath != filepath.Join(stellaHome, ".agents/skills") || table[1].ContainerPath != "/home/stella/.stella/.agents/skills" || !table[1].ReadOnly {
-		t.Fatalf("unexpected stella skills mount: %+v", table[1])
-	}
-	for _, m := range table {
-		if strings.HasSuffix(m.ContainerPath, "/bin") || strings.HasSuffix(m.ContainerPath, "/.mise-tools") {
-			t.Fatalf("image-provided dir must not be host-mounted: %+v", m)
-		}
-	}
-	// Verify that missing subdirs are skipped — a home with only bin (image-provided)
-	// yields just the workspace.
-	partialHome := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(partialHome, "bin"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	tablePartial := buildMountTable(mountTableOptions{
-		WorkspaceHost:       "/host/ws",
-		WorkspaceMount:      "/container/ws",
-		StellaHomeHost:      partialHome,
-		StellaHomeContainer: "/home/stella/.stella",
-	})
-	// workspace only (bin is image-provided, no .agents/skills)
-	if len(tablePartial) != 1 {
-		t.Fatalf("expected 1 entry for partial stella home, got %d", len(tablePartial))
-	}
-
-	// With a user-data root, /user appears RW right after the workspace.
-	tableUser := buildMountTable(mountTableOptions{
 		WorkspaceHost:  "/host/ws",
 		WorkspaceMount: "/container/ws",
-		UserDataHost:   "/host/data",
-		UserDataMount:  "/user",
+		Mounts: []sandboxpkg.Mount{
+			{HostPath: "/host/ws", SandboxPath: "/container/ws", Access: sandboxpkg.MountReadWrite},
+			{HostPath: "/host/data", SandboxPath: "/user", Access: sandboxpkg.MountReadWrite},
+			{HostPath: "/extra/path", SandboxPath: "/extra/path", Access: sandboxpkg.MountReadOnly},
+		},
+		TempDirHost: "/tmp/user-1",
 	})
-	if len(tableUser) != 2 {
-		t.Fatalf("expected workspace + user entries, got %d", len(tableUser))
+	if len(table) != 4 {
+		t.Fatalf("expected 4 entries, got %d: %+v", len(table), table)
 	}
-	if tableUser[1].HostPath != "/host/data" || tableUser[1].ContainerPath != "/user" || tableUser[1].ReadOnly {
-		t.Fatalf("unexpected user-data mount: %+v", tableUser[1])
+	if table[0].HostPath != "/host/ws" || table[0].ContainerPath != "/container/ws" || table[0].ReadOnly {
+		t.Fatalf("unexpected workspace mount: %+v", table[0])
 	}
-
-	tableExtra := buildMountTable(mountTableOptions{
-		WorkspaceHost:       "/host/ws",
-		WorkspaceMount:      "/container/ws",
-		ExtraReadOnlyMounts: []string{"/extra/path"},
-		TempDirHost:         "/tmp/user-1",
-	})
-	if len(tableExtra) != 3 {
-		t.Fatalf("expected 3 entries with extra and tmp, got %d", len(tableExtra))
+	if table[1].HostPath != "/host/data" || table[1].ContainerPath != "/user" || table[1].ReadOnly {
+		t.Fatalf("unexpected user-data mount: %+v", table[1])
 	}
-	if tableExtra[1].HostPath != "/extra/path" || tableExtra[1].ContainerPath != "/extra/path" || !tableExtra[1].ReadOnly {
-		t.Fatalf("unexpected extra mount: %+v", tableExtra[1])
+	if table[2].HostPath != "/extra/path" || table[2].ContainerPath != "/extra/path" || !table[2].ReadOnly {
+		t.Fatalf("unexpected extra mount: %+v", table[2])
 	}
-	if tableExtra[2].HostPath != "/tmp/user-1" || tableExtra[2].ContainerPath != "/tmp" || tableExtra[2].ReadOnly {
-		t.Fatalf("unexpected tmp mount: %+v", tableExtra[2])
+	if table[3].HostPath != "/tmp/user-1" || table[3].ContainerPath != "/tmp" || table[3].ReadOnly {
+		t.Fatalf("unexpected tmp mount: %+v", table[3])
 	}
 }
 
@@ -241,7 +188,7 @@ func TestConfigureSessionMounts_HostMode(t *testing.T) {
 	if mountedTmp != tmp {
 		t.Fatalf("mounted tmp = %q, want %q", mountedTmp, tmp)
 	}
-	if len(mountedExtra) != 1 || mountedExtra[0] != extra {
+	if len(mountedExtra) < 2 || mountedExtra[1].HostPath != extra {
 		t.Fatalf("mounted extra = %v, want [%q]", mountedExtra, extra)
 	}
 	assertNoMountTo(t, opts.ExtraMounts, filepath.Join(stellaHomeMount, "bin"))
@@ -269,7 +216,7 @@ func TestConfigureSessionMounts_BindModeTranslatesSources(t *testing.T) {
 	if mountedTmp != "" {
 		t.Fatalf("tmp outside STELLA_HOME should be skipped in bind mode, got %q", mountedTmp)
 	}
-	if len(mountedExtra) != 1 || mountedExtra[0] != extra {
+	if len(mountedExtra) < 2 || mountedExtra[1].HostPath != extra {
 		t.Fatalf("mounted extra = %v, want [%q]", mountedExtra, extra)
 	}
 	assertNoMountTo(t, opts.ExtraMounts, filepath.Join(stellaHomeMount, "bin"))
@@ -283,7 +230,7 @@ func TestConfigureSessionMounts_VolumeModeUsesSubpaths(t *testing.T) {
 	f := &dockerFactory{cfg: Config{RuntimeMode: DockerSandboxModeVolume, StellaHome: stellaHome, StellaHomeVolume: "stella-data"}}
 	opts := dockerModeCreateOptions(workspace)
 	policy := dockerModePolicy(stellaHome, workspace, extra, tmp)
-	policy.Filesystem.ExtraReadOnlyMounts = append(policy.Filesystem.ExtraReadOnlyMounts, outsideExtra)
+	policy.Filesystem.Mounts = append(policy.Filesystem.Mounts, sandboxpkg.Mount{HostPath: outsideExtra, SandboxPath: outsideExtra, Access: sandboxpkg.MountReadOnly})
 	mountedExtra, mountedTmp, _, err := f.configureSessionMounts(&opts, policy, workspace, "")
 	if err != nil {
 		t.Fatalf("configureSessionMounts: %v", err)
@@ -294,7 +241,7 @@ func TestConfigureSessionMounts_VolumeModeUsesSubpaths(t *testing.T) {
 	if mountedTmp != "" {
 		t.Fatalf("volume mode should not mount process-view tmp, got %q", mountedTmp)
 	}
-	if len(mountedExtra) != 1 || mountedExtra[0] != extra {
+	if len(mountedExtra) < 2 || mountedExtra[1].HostPath != extra {
 		t.Fatalf("mounted extra = %v, want only [%q]", mountedExtra, extra)
 	}
 	assertMount(t, opts.ExtraMounts, "stella-data", workspaceMount, false, dockerclient.MountTypeVolume, "users/user")
@@ -377,7 +324,7 @@ func TestMountPerUserToolTrees(t *testing.T) {
 	stellaHome := t.TempDir()
 	miseDir := filepath.Join(stellaHome, "users", "u1", ".mise-tools")
 	want := filepath.Join(stellaHomeMount, "users", "u1", ".mise-tools")
-	policy := sandboxpkg.Policy{Filesystem: sandboxpkg.FilesystemPolicy{ExtraWritableMounts: []string{miseDir}}}
+	policy := sandboxpkg.Policy{Filesystem: sandboxpkg.FilesystemPolicy{Mounts: []sandboxpkg.Mount{{HostPath: miseDir, SandboxPath: filepath.Join(stellaHomeMount, "users", "u1", ".mise-tools"), Access: sandboxpkg.MountReadWrite}}}}
 
 	t.Run("host", func(t *testing.T) {
 		f := &dockerFactory{cfg: Config{RuntimeMode: DockerSandboxModeHost, StellaHome: stellaHome}}
@@ -402,7 +349,7 @@ func TestMountPerUserToolTrees(t *testing.T) {
 	t.Run("outside STELLA_HOME skipped", func(t *testing.T) {
 		f := &dockerFactory{cfg: Config{RuntimeMode: DockerSandboxModeHost, StellaHome: stellaHome}}
 		opts := &dockerclient.CreateOptions{}
-		outside := sandboxpkg.Policy{Filesystem: sandboxpkg.FilesystemPolicy{ExtraWritableMounts: []string{t.TempDir()}}}
+		outside := sandboxpkg.Policy{Filesystem: sandboxpkg.FilesystemPolicy{Mounts: []sandboxpkg.Mount{{HostPath: t.TempDir(), SandboxPath: "/outside", Access: sandboxpkg.MountReadWrite}}}}
 		if mounted := f.mountPerUserToolTrees(opts, outside); len(mounted) != 0 {
 			t.Fatalf("expected outside-STELLA_HOME mount to be skipped, got %+v", mounted)
 		}
@@ -458,10 +405,10 @@ func dockerModePolicy(stellaHome, workspace, extra, tmp string) sandboxpkg.Polic
 	return sandboxpkg.Policy{
 		Env: map[string]string{"STELLA_HOME": stellaHome},
 		Filesystem: sandboxpkg.FilesystemPolicy{
-			WorkspaceRoot:       workspace,
-			WorkingDir:          workspace,
-			ExtraReadOnlyMounts: []string{extra},
-			TempDirHost:         tmp,
+			WorkspaceRoot: workspace,
+			WorkingDir:    workspace,
+			Mounts:        []sandboxpkg.Mount{{HostPath: workspace, SandboxPath: workspaceMount, Access: sandboxpkg.MountReadWrite}, {HostPath: extra, SandboxPath: extra, Access: sandboxpkg.MountReadOnly}, {HostPath: filepath.Join(stellaHome, ".agents", "skills"), SandboxPath: filepath.Join(stellaHomeMount, ".agents", "skills"), Access: sandboxpkg.MountReadOnly}},
+			TempDirHost:   tmp,
 		},
 	}
 }

--- a/plugins/sandbox/local/session.go
+++ b/plugins/sandbox/local/session.go
@@ -86,18 +86,16 @@ func (f *Factory) CreateSession(_ context.Context, policy sandboxpkg.Policy) (sa
 		return nil, fmt.Errorf("local: create session tmp: %w", err)
 	}
 	s := &localSession{
-		id:                 sessionID,
-		policy:             policy,
-		realRoot:           realRoot,
-		sandboxRoot:        sandboxRoot,
-		userDataReal:       userDataReal,
-		userDataSandbox:    userDataSandbox,
-		agentSkillsReal:    policy.Filesystem.AgentSkillsDir,
-		systemDBSkillsReal: policy.Filesystem.SystemDBSkillsDir,
-		stellaHomeHost:     hostStellaHome,
-		stellaHomeSandbox:  adjustStellaHome(hostStellaHome),
-		tmpMounts:          tmpMounts,
-		done:               make(chan struct{}),
+		id:                sessionID,
+		policy:            policy,
+		realRoot:          realRoot,
+		sandboxRoot:       sandboxRoot,
+		userDataReal:      userDataReal,
+		userDataSandbox:   userDataSandbox,
+		stellaHomeHost:    hostStellaHome,
+		stellaHomeSandbox: adjustStellaHome(hostStellaHome),
+		tmpMounts:         tmpMounts,
+		done:              make(chan struct{}),
 	}
 	sandboxpkg.LogSessionCreated(sessionID, "local", policy)
 	return s, nil
@@ -246,27 +244,35 @@ func remapStellaHomePath(p, hostSH, sandboxSH string) string {
 	}
 }
 
+func mountBySandboxPath(mounts []sandboxpkg.Mount, sandboxPath string) (sandboxpkg.Mount, bool) {
+	clean := filepath.Clean(sandboxPath)
+	for _, m := range mounts {
+		if filepath.Clean(m.SandboxPath) == clean {
+			return m, true
+		}
+	}
+	return sandboxpkg.Mount{}, false
+}
+
 // ─────────────────────────── localSession ─────────────────────────────
 
 // localSession implements sandboxpkg.Session by running commands directly on
 // the host OS with no container isolation.
 type localSession struct {
-	id                 string
-	policy             sandboxpkg.Policy
-	realRoot           string     // actual host path (e.g. /home/stella/.stella-dev/...)
-	sandboxRoot        string     // path the agent sees (/workspace on Linux+bwrap, else = realRoot)
-	userDataReal       string     // host path of the shared user-data root, "" when none
-	userDataSandbox    string     // path the agent sees for it (/user on Linux+bwrap, else = userDataReal)
-	agentSkillsReal    string     // host path of the agent-bound (system_agent) skills dir, "" when none
-	systemDBSkillsReal string     // host path of the DB-installed system skills dir, "" when none
-	stellaHomeHost     string     // host-side STELLA_HOME for bwrap mounts
-	stellaHomeSandbox  string     // agent's view of STELLA_HOME (/opt/stella on Linux+bwrap, else = host)
-	tmpMounts          []tmpMount // sandbox temp paths mapped to real host dirs (/tmp, /var/tmp)
-	done               chan struct{}
-	doneOnce           sync.Once
-	mu                 sync.RWMutex
-	closed             bool
-	procs              []*localProcess
+	id                string
+	policy            sandboxpkg.Policy
+	realRoot          string     // actual host path (e.g. /home/stella/.stella-dev/...)
+	sandboxRoot       string     // path the agent sees (/workspace on Linux+bwrap, else = realRoot)
+	userDataReal      string     // host path of the shared user-data root, "" when none
+	userDataSandbox   string     // path the agent sees for it (/user on Linux+bwrap, else = userDataReal)
+	stellaHomeHost    string     // host-side STELLA_HOME for bwrap mounts
+	stellaHomeSandbox string     // agent's view of STELLA_HOME (/opt/stella on Linux+bwrap, else = host)
+	tmpMounts         []tmpMount // sandbox temp paths mapped to real host dirs (/tmp, /var/tmp)
+	done              chan struct{}
+	doneOnce          sync.Once
+	mu                sync.RWMutex
+	closed            bool
+	procs             []*localProcess
 }
 
 func (s *localSession) Policy() sandboxpkg.Policy {
@@ -369,24 +375,14 @@ func (s *localSession) ResolvePath(agentPath string) (string, error) {
 	return resolved, err
 }
 
-// ResolveWritePath is like ResolvePath but additionally rejects paths that
-// fall within ExtraReadOnlyMounts.
+// ResolveWritePath is like ResolvePath but additionally rejects paths that fall
+// within read-only mounts.
 func (s *localSession) ResolveWritePath(agentPath string) (string, error) {
-	resolved, _, err := s.resolvePath(agentPath)
+	resolved, err := s.pathResolver().ResolveWritePath(agentPath)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("local: %w", err)
 	}
-	if matchingExtraMount(s.policy.Filesystem.ExtraReadOnlyMounts, resolved) != "" {
-		return "", fmt.Errorf("local: path %q is in a read-only mount", agentPath)
-	}
-	// The system install subtrees (/opt/stella/*) are read-only — reject writes
-	// even though resolvePath allows reads of them.
-	for _, pair := range s.stellaHomeSubdirs() {
-		if pathWithinRoot(filepath.Clean(pair[1]), resolved) {
-			return "", fmt.Errorf("local: path %q is in the read-only system tree", agentPath)
-		}
-	}
-	return resolved, nil
+	return resolved.HostPath, nil
 }
 
 // resolveCwd validates a requested working directory, then returns both its
@@ -407,102 +403,40 @@ func (s *localSession) resolveCwd(cwd string) (sandboxCwd, realCwd string, err e
 // sandbox-space path. Existing symlink components under the workspace are
 // rejected, including symlinked parents of non-existent creation targets.
 func (s *localSession) resolvePath(agentPath string) (realPath, sandboxPath string, err error) {
-	abs := agentPath
-	if !filepath.IsAbs(abs) {
-		abs = filepath.Join(s.WorkingDir(), agentPath)
-	}
-	sandboxPath = filepath.Clean(abs)
-	real := filepath.Clean(s.toRealPath(sandboxPath))
-
-	resolved, err := filepath.EvalSymlinks(real)
+	resolved, err := s.pathResolver().ResolvePath(agentPath)
 	if err != nil {
-		if !os.IsNotExist(err) {
-			return "", "", fmt.Errorf("local: resolve path %q: %w", agentPath, err)
-		}
-		resolved = real
+		return "", "", fmt.Errorf("local: %w", err)
 	}
-	resolved = filepath.Clean(resolved)
-
-	cleanRoot := filepath.Clean(s.realRoot)
-	if pathWithinRoot(cleanRoot, resolved) {
-		if err := rejectLocalSymlinkTraversal(cleanRoot, real); err != nil {
-			return "", "", fmt.Errorf("local: %w", err)
-		}
-		return resolved, s.toSandboxPath(resolved), nil
-	}
-
-	// Also allow the shared user-data root (/user): a second writable top-level
-	// root, disjoint from the workspace. Without this the file tools reject /user
-	// even though bash inside the sandbox can reach it via the bind mount.
-	if s.userDataReal != "" {
-		cleanUserData := filepath.Clean(s.userDataReal)
-		if pathWithinRoot(cleanUserData, resolved) {
-			if err := rejectLocalSymlinkTraversal(cleanUserData, real); err != nil {
-				return "", "", fmt.Errorf("local: %w", err)
-			}
-			return resolved, s.toSandboxPath(resolved), nil
-		}
-	}
-
-	// Also allow read of the RO system install subtrees (/opt/stella/{bin,
-	// .mise-tools,.agents/skills}) — e.g. system skill bundles the model addresses
-	// via skill_dir. Scoped to the mounted subtrees only, never the whole host
-	// STELLA_HOME, so the sibling users/ and agents/ trees stay invisible. Writes
-	// are rejected separately in ResolveWritePath.
-	for _, pair := range s.stellaHomeSubdirs() {
-		if pathWithinRoot(filepath.Clean(pair[1]), resolved) {
-			return resolved, s.toSandboxPath(resolved), nil
-		}
-	}
-
-	// Also allow access to extra read-only mounts (e.g. agent-level skill dirs).
-	if mountRoot := matchingExtraMount(s.policy.Filesystem.ExtraReadOnlyMounts, resolved); mountRoot != "" {
-		if err := rejectLocalSymlinkTraversal(mountRoot, real); err != nil {
-			return "", "", fmt.Errorf("local: %w", err)
-		}
-		return resolved, s.toSandboxPath(resolved), nil
-	}
-
-	// Allow access to session temp directories (/tmp, /var/tmp).
-	for _, m := range s.tmpMounts {
-		if pathWithinRoot(m.realPath, resolved) {
-			if err := rejectLocalSymlinkTraversal(m.realPath, real); err != nil {
-				return "", "", fmt.Errorf("local: %w", err)
-			}
-			return resolved, s.toSandboxPath(resolved), nil
-		}
-	}
-
-	return "", "", fmt.Errorf("local: path %q resolves to %q which is outside workspace root %q", agentPath, resolved, s.realRoot)
+	return resolved.HostPath, resolved.SandboxPath, nil
 }
 
 // matchingTmpMount returns the tmpMount with the longest sandboxPath that
 // contains sandboxPath, or nil if none match.
-func (s *localSession) matchingTmpMount(sandboxPath string) *tmpMount {
-	clean := filepath.Clean(sandboxPath)
-	var best *tmpMount
-	for i := range s.tmpMounts {
-		m := &s.tmpMounts[i]
-		if clean == m.sandboxPath || strings.HasPrefix(clean, m.sandboxPath+string(filepath.Separator)) {
-			if best == nil || len(m.sandboxPath) > len(best.sandboxPath) {
-				best = m
-			}
-		}
-	}
-	return best
-}
 
 // matchingExtraMount returns the longest extra read-only mount that contains
 // resolved, or "" if none match.
-func matchingExtraMount(mounts []string, resolved string) string {
-	best := ""
-	for _, m := range mounts {
-		clean := filepath.Clean(m)
-		if pathWithinRoot(clean, resolved) && len(clean) > len(best) {
-			best = clean
+
+func (s *localSession) pathResolver() *sandboxpkg.PathResolver {
+	mounts := append([]sandboxpkg.Mount(nil), s.policy.Filesystem.Mounts...)
+	if len(mounts) == 0 {
+		if s.realRoot != "" && s.sandboxRoot != "" {
+			mounts = append(mounts, sandboxpkg.Mount{HostPath: s.realRoot, SandboxPath: s.sandboxRoot, Access: sandboxpkg.MountReadWrite})
+		}
+		if s.userDataReal != "" && s.userDataSandbox != "" {
+			mounts = append(mounts, sandboxpkg.Mount{HostPath: s.userDataReal, SandboxPath: s.userDataSandbox, Access: sandboxpkg.MountReadWrite})
+		}
+		for _, pair := range s.stellaHomeSubdirs() {
+			mounts = append(mounts, sandboxpkg.Mount{HostPath: pair[1], SandboxPath: pair[0], Access: sandboxpkg.MountReadOnly})
 		}
 	}
-	return best
+	for _, m := range s.tmpMounts {
+		mounts = append(mounts, sandboxpkg.Mount{HostPath: m.realPath, SandboxPath: m.sandboxPath, Access: sandboxpkg.MountReadWrite})
+	}
+	return sandboxpkg.NewPathResolver(sandboxpkg.PathResolverConfig{
+		WorkspaceRoot: s.realRoot,
+		WorkingDir:    s.WorkingDir(),
+		Mounts:        mounts,
+	})
 }
 
 // stellaHomeSubdirs returns the {sandboxRoot, hostRoot} pairs for each subtree of
@@ -514,160 +448,40 @@ func (s *localSession) stellaHomeSubdirs() [][2]string {
 	if s.stellaHomeHost == "" || s.stellaHomeSandbox == s.stellaHomeHost {
 		return nil
 	}
-	names := sandboxpkg.StellaHomeSandboxDirs()
-	out := make([][2]string, 0, len(names)+1)
-	for _, name := range names {
+	out := make([][2]string, 0, len(sandboxpkg.StellaHomeSandboxDirs()))
+	for _, name := range sandboxpkg.StellaHomeSandboxDirs() {
 		out = append(out, [2]string{
 			filepath.Join(s.stellaHomeSandbox, name),
 			filepath.Join(s.stellaHomeHost, name),
 		})
 	}
-	// Agent-bound (system_agent) skills: a read-only subtree mounted at its own
-	// fixed path (it lives in the agent definition tree, not under the STELLA_HOME
-	// subtrees above). Mapped here so the file tools can read it and reject writes.
-	if s.agentSkillsReal != "" {
-		out = append(out, [2]string{sandboxpkg.MountAgentSkills, filepath.Clean(s.agentSkillsReal)})
-	}
-	// DB-installed system skills: same treatment — a read-only subtree at its own
-	// fixed path, kept separate from the shipped built-ins under STELLA_HOME.
-	if s.systemDBSkillsReal != "" {
-		out = append(out, [2]string{sandboxpkg.MountSystemDBSkills, filepath.Clean(s.systemDBSkillsReal)})
-	}
 	return out
 }
 
 // pathWithinRoot reports whether path is the root itself or is contained under it.
-func pathWithinRoot(root, path string) bool {
-	return path == root || strings.HasPrefix(path, root+string(filepath.Separator))
-}
 
 // rejectLocalSymlinkTraversal rejects any symlink component at or below the
 // workspace root. For non-existent targets, checking stops at the first missing
 // component so creating new files still works unless an existing parent is a
 // symlink.
-func rejectLocalSymlinkTraversal(root, path string) error {
-	if !pathWithinRoot(root, path) {
-		return fmt.Errorf("path %q is outside workspace root %q", path, root)
-	}
-	rel, err := filepath.Rel(root, path)
-	if err != nil {
-		return fmt.Errorf("rel %q from %q: %w", path, root, err)
-	}
-	if rel == "." {
-		return nil
-	}
-	current := root
-	for part := range strings.SplitSeq(rel, string(filepath.Separator)) {
-		if part == "" || part == "." {
-			continue
-		}
-		current = filepath.Join(current, part)
-		info, err := os.Lstat(current)
-		if err != nil {
-			if os.IsNotExist(err) {
-				return nil
-			}
-			return fmt.Errorf("lstat %q: %w", current, err)
-		}
-		if info.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("path %q traverses symlink at %q", path, current)
-		}
-	}
-	return nil
-}
 
 // toRealPath translates a sandbox-space absolute path to the real host path.
 // When sandboxRoot == realRoot (no remapping), it is a no-op.
 // Temp paths (/tmp, /var/tmp) are checked first against tmpMounts.
 func (s *localSession) toRealPath(sandboxPath string) string {
-	if m := s.matchingTmpMount(sandboxPath); m != nil {
-		rel, _ := filepath.Rel(m.sandboxPath, filepath.Clean(sandboxPath))
-		if rel == "." {
-			return m.realPath
-		}
-		return filepath.Join(m.realPath, rel)
+	if hostPath, ok := s.pathResolver().ToHostPath(sandboxPath); ok {
+		return hostPath
 	}
-	// Shared user-data root: /user/... maps to its host path. Disjoint from the
-	// workspace remap below; identity on macOS (sandbox == real).
-	if s.userDataSandbox != "" && s.userDataSandbox != s.userDataReal {
-		if rel, err := filepath.Rel(s.userDataSandbox, filepath.Clean(sandboxPath)); err == nil &&
-			rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-			return filepath.Join(s.userDataReal, rel)
-		}
-	}
-	// RO system install subtrees: /opt/stella/{bin,.mise-tools,.agents/skills}/...
-	// map back to the matching host STELLA_HOME subtree (only the mounted ones).
-	for _, pair := range s.stellaHomeSubdirs() {
-		if rel, err := filepath.Rel(pair[0], filepath.Clean(sandboxPath)); err == nil &&
-			rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-			return filepath.Join(pair[1], rel)
-		}
-	}
-	if s.sandboxRoot == s.realRoot {
-		return sandboxPath
-	}
-	rel, err := filepath.Rel(s.sandboxRoot, filepath.Clean(sandboxPath))
-	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return sandboxPath
-	}
-	return filepath.Join(s.realRoot, rel)
+	return sandboxPath
 }
 
 // toSandboxPath translates a real host path back into sandbox space.
 // Temp mount real paths are checked first against tmpMounts.
 func (s *localSession) toSandboxPath(realPath string) string {
-	clean := filepath.Clean(realPath)
-	// Use longest matching tmpMount (e.g. /var/tmp before /tmp if both match).
-	var best *tmpMount
-	for i := range s.tmpMounts {
-		m := &s.tmpMounts[i]
-		rel, err := filepath.Rel(m.realPath, clean)
-		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-			continue
-		}
-		if best == nil || len(m.realPath) > len(best.realPath) {
-			best = m
-		}
+	if sandboxPath, ok := s.pathResolver().ToSandboxPath(realPath); ok {
+		return sandboxPath
 	}
-	if best != nil {
-		rel, _ := filepath.Rel(best.realPath, clean)
-		if rel == "." {
-			return best.sandboxPath
-		}
-		return filepath.Join(best.sandboxPath, rel)
-	}
-	// Shared user-data root: host paths under it map back to /user/...
-	if s.userDataReal != "" && s.userDataReal != s.userDataSandbox {
-		if rel, err := filepath.Rel(s.userDataReal, clean); err == nil &&
-			rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-			if rel == "." {
-				return s.userDataSandbox
-			}
-			return filepath.Join(s.userDataSandbox, rel)
-		}
-	}
-	// RO system install subtrees: host STELLA_HOME subtrees map back to
-	// /opt/stella/{bin,.mise-tools,.agents/skills}/... (only the mounted ones).
-	for _, pair := range s.stellaHomeSubdirs() {
-		if rel, err := filepath.Rel(pair[1], clean); err == nil &&
-			rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-			if rel == "." {
-				return pair[0]
-			}
-			return filepath.Join(pair[0], rel)
-		}
-	}
-	if s.sandboxRoot == s.realRoot {
-		return realPath
-	}
-	rel, err := filepath.Rel(s.realRoot, clean)
-	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return realPath
-	}
-	if rel == "." {
-		return s.sandboxRoot
-	}
-	return filepath.Join(s.sandboxRoot, rel)
+	return realPath
 }
 
 // Exec runs a shell command via sh -c on the host.

--- a/plugins/sandbox/local/session_darwin.go
+++ b/plugins/sandbox/local/session_darwin.go
@@ -54,8 +54,10 @@ func resolveSandboxRoot(policy sandboxpkg.Policy) (sandboxRoot, realRoot string)
 // resolveUserDataRoot returns the shared user-data root. macOS does no path
 // remapping, so the sandbox-space and host paths are identical (no /user alias).
 func resolveUserDataRoot(policy sandboxpkg.Policy) (sandboxRoot, realRoot string) {
-	real := policy.Filesystem.UserDataDir
-	return real, real
+	if m, ok := mountBySandboxPath(policy.Filesystem.Mounts, sandboxpkg.MountUserData); ok {
+		return m.HostPath, m.HostPath
+	}
+	return "", ""
 }
 
 // createSessionTmpMounts returns tmpMount pairs for macOS temp paths.
@@ -133,40 +135,24 @@ func buildSeatbeltProfile(policy sandboxpkg.Policy, stellaHomeHost string) strin
 	// Dev nodes: required for stdout/stderr, pseudo-terminals, /dev/null, etc.
 	sb.WriteString("(allow file-write* (subpath \"/dev\"))\n")
 
-	// Extra writable mounts (e.g. the per-user mise home): carve out each subtree
-	// so the agent can write through it — for mise that's installs/cache/state,
-	// all under the tree.
-	for _, dir := range policy.Filesystem.ExtraWritableMounts {
-		fmt.Fprintf(&sb, "(allow file-write* (subpath %q))\n", filepath.Clean(dir))
+	// Writable mounts (e.g. the per-user mise home): carve out each subtree so the
+	// agent can write through it — for mise that's installs/cache/state.
+	for _, m := range policy.Filesystem.Mounts {
+		if m.Access == sandboxpkg.MountReadWrite {
+			fmt.Fprintf(&sb, "(allow file-write* (subpath %q))\n", filepath.Clean(m.HostPath))
+		}
 	}
 	// With no writable per-user mise tree, the shared system installs stay
 	// read-only; mise still needs its cache/state metadata holes open. Key off the
-	// per-user mise data dir recovered from the env — not len(ExtraWritableMounts)
-	// — so an unrelated writable mount cannot suppress these holes. This mirrors
-	// how the none/linux backends recover the per-user mise home from the env.
+	// per-user mise data dir recovered from the env — not the mount count — so an
+	// unrelated writable mount cannot suppress these holes. This mirrors how the
+	// none/linux backends recover the per-user mise home from the env.
 	if sandboxpkg.PerUserMiseDataDir(policy.Env, stellaHomeHost) == "" {
 		appendSeatbeltWritableEnvDirs(&sb, policy.Env)
 	}
 
 	// Workspace root: the agent's fully writable working tree.
 	fmt.Fprintf(&sb, "(allow file-write* (subpath %q))\n", workspace)
-
-	// Shared user-data root (/user equivalent): writable, shared across the user's
-	// agents. macOS does no remap, so this is the host UserDataDir path.
-	if ud := filepath.Clean(policy.Filesystem.UserDataDir); filepath.IsAbs(ud) {
-		fmt.Fprintf(&sb, "(allow file-write* (subpath %q))\n", ud)
-	}
-
-	// Hide sibling agents: deny read+write across the agents/ subtree, then
-	// re-allow this agent's own dir, so it can neither read nor write another
-	// agent's credentials/state (#442). Placed after the workspace allow above so
-	// it wins (last-match-wins) for the agents subtree, while the rest of the home
-	// — caches, toolchains — stays shared. Reads outside the home remain governed
-	// by (allow default): seatbelt's read-permissive base is unchanged here.
-	if ap := filepath.Clean(policy.Filesystem.AgentPrivateDir); filepath.IsAbs(ap) && ap != workspace {
-		fmt.Fprintf(&sb, "(deny file-read* file-write* (subpath %q))\n", filepath.Dir(ap))
-		fmt.Fprintf(&sb, "(allow file-read* file-write* (subpath %q))\n", ap)
-	}
 
 	// Network: deny unless the policy explicitly requests unrestricted access.
 	if networkMode != sandboxpkg.NetworkAllowAll {

--- a/plugins/sandbox/local/session_darwin_test.go
+++ b/plugins/sandbox/local/session_darwin_test.go
@@ -109,7 +109,7 @@ func TestBuildSeatbeltProfile_miseHolesKeyedOnPerUserTree(t *testing.T) {
 	t.Run("unrelated writable mount still emits cache holes", func(t *testing.T) {
 		policy := makePolicy("/tmp/ws", sandboxpkg.NetworkDisabled)
 		policy.Env = map[string]string{"MISE_CACHE_DIR": cacheDir}
-		policy.Filesystem.ExtraWritableMounts = []string{"/tmp/unrelated"}
+		policy.Filesystem.Mounts = append(policy.Filesystem.Mounts, sandboxpkg.Mount{HostPath: "/tmp/unrelated", SandboxPath: "/tmp/unrelated", Access: sandboxpkg.MountReadWrite})
 		profile := buildSeatbeltProfile(policy, stellaHome)
 
 		if !strings.Contains(profile, `(allow file-write* (subpath "`+cacheDir+`"))`) {
@@ -124,7 +124,7 @@ func TestBuildSeatbeltProfile_miseHolesKeyedOnPerUserTree(t *testing.T) {
 			"MISE_DATA_DIR":  userDir,
 			"MISE_CACHE_DIR": "/tmp/mise-cache",
 		}
-		policy.Filesystem.ExtraWritableMounts = []string{userDir}
+		policy.Filesystem.Mounts = append(policy.Filesystem.Mounts, sandboxpkg.Mount{HostPath: userDir, SandboxPath: userDir, Access: sandboxpkg.MountReadWrite})
 		profile := buildSeatbeltProfile(policy, stellaHome)
 
 		if strings.Contains(profile, `(allow file-write* (subpath "/tmp/mise-cache"))`) {
@@ -133,36 +133,12 @@ func TestBuildSeatbeltProfile_miseHolesKeyedOnPerUserTree(t *testing.T) {
 	})
 }
 
-// TestBuildSeatbeltProfile_hidesSiblingAgents verifies the per-agent isolation
-// rules (#442): the agents/ subtree is denied read+write and only this agent's
-// own dir is re-allowed, and the ordering wins under last-match-wins (the rules
-// must follow the workspace allow, and the own re-allow must follow the deny).
-func TestBuildSeatbeltProfile_hidesSiblingAgents(t *testing.T) {
-	root := "/private/tmp/ws"
-	policy := makePolicy(root, sandboxpkg.NetworkDisabled)
-	policy.Filesystem.AgentPrivateDir = root + "/agents/a1"
-	profile := buildSeatbeltProfile(policy, "")
-
-	wsAllow := `(allow file-write* (subpath "` + root + `"))`
-	siblingDeny := `(deny file-read* file-write* (subpath "` + root + `/agents"))`
-	ownAllow := `(allow file-read* file-write* (subpath "` + root + `/agents/a1"))`
-	for _, want := range []string{wsAllow, siblingDeny, ownAllow} {
-		if !strings.Contains(profile, want) {
-			t.Errorf("profile missing %s:\n%s", want, profile)
-		}
-	}
-	wsAt, denyAt, ownAt := strings.Index(profile, wsAllow), strings.Index(profile, siblingDeny), strings.Index(profile, ownAllow)
-	if wsAt >= denyAt || denyAt >= ownAt {
-		t.Errorf("rule order must be workspace-allow < sibling-deny < own-allow:\n%s", profile)
-	}
-}
-
-// TestBuildSeatbeltProfile_noSiblingRulesWithoutAgentPrivateDir verifies a
-// user-less session (no agent-private dir) emits no per-agent deny/allow rules.
-func TestBuildSeatbeltProfile_noSiblingRulesWithoutAgentPrivateDir(t *testing.T) {
+// TestBuildSeatbeltProfile_noSiblingRules verifies generic mount policy emits no
+// legacy per-agent deny/allow rules.
+func TestBuildSeatbeltProfile_noSiblingRules(t *testing.T) {
 	profile := buildSeatbeltProfile(makePolicy("/private/tmp/ws", sandboxpkg.NetworkDisabled), "")
 	if strings.Contains(profile, "(deny file-read* file-write*") {
-		t.Errorf("no sibling-hiding rules expected without AgentPrivateDir:\n%s", profile)
+		t.Errorf("no sibling-hiding rules expected without generic mounts:\n%s", profile)
 	}
 }
 

--- a/plugins/sandbox/local/session_linux.go
+++ b/plugins/sandbox/local/session_linux.go
@@ -200,18 +200,6 @@ func appendLinuxRuntimeMounts(args []string) []string {
 // On Linux (bwrap), it is remapped to /opt/stella.
 func adjustStellaHome(_ string) string { return sandboxStellaHome }
 
-func appendStellaHomeMounts(args []string, stellaHome string) []string {
-	if stellaHome == "" {
-		return args
-	}
-	for _, name := range sandboxpkg.StellaHomeSandboxDirs() {
-		hostPath := filepath.Join(stellaHome, name)
-		sandboxPath := filepath.Join(sandboxStellaHome, name)
-		args = appendRoBindIfExists(args, hostPath, sandboxPath)
-	}
-	return args
-}
-
 func appendResolvedFileMount(args []string, path string) []string {
 	resolved, err := filepath.EvalSymlinks(path)
 	if err != nil || resolved == path {
@@ -243,13 +231,6 @@ func appendWritableBind(args []string, hostPath, sandboxPath string) []string {
 	args = appendDirParents(args, sandboxPath)
 	args = append(args, "--dir", filepath.Clean(sandboxPath))
 	return append(args, "--bind", hostPath, sandboxPath)
-}
-
-// remapToSandboxStellaHome rewrites a host path under STELLA_HOME to its
-// sandbox-view location (STELLA_HOME is remapped to /opt/stella).
-// Paths outside STELLA_HOME are returned unchanged.
-func remapToSandboxStellaHome(hostPath, stellaHomeHost string) string {
-	return remapStellaHomePath(hostPath, stellaHomeHost, sandboxStellaHome)
 }
 
 func appendDirParents(args []string, path string) []string {

--- a/plugins/sandbox/local/session_linux.go
+++ b/plugins/sandbox/local/session_linux.go
@@ -99,11 +99,10 @@ func resolveSandboxRoot(policy sandboxpkg.Policy) (sandboxRoot, realRoot string)
 // user-data root. On Linux it is bind-mounted at the fixed path /user; "" host
 // path (a user-less job) yields no second root.
 func resolveUserDataRoot(policy sandboxpkg.Policy) (sandboxRoot, realRoot string) {
-	realRoot = policy.Filesystem.UserDataDir
-	if realRoot == "" {
-		return "", ""
+	if m, ok := mountBySandboxPath(policy.Filesystem.Mounts, sandboxpkg.MountUserData); ok {
+		return sandboxpkg.MountUserData, m.HostPath
 	}
-	return sandboxpkg.MountUserData, realRoot
+	return "", ""
 }
 
 // createSessionTmpMounts returns host directories for each sandbox temp path.
@@ -269,6 +268,41 @@ func appendDirParents(args []string, path string) []string {
 	return args
 }
 
+func linuxPolicyMounts(policy sandboxpkg.Policy, stellaHomeHost string) []sandboxpkg.Mount {
+	mounts := append([]sandboxpkg.Mount(nil), policy.Filesystem.Mounts...)
+	if len(mounts) != 0 {
+		return mounts
+	}
+	mounts = append(mounts, sandboxpkg.Mount{
+		HostPath:    policy.WorkspaceRootOrDefault(),
+		SandboxPath: sandboxpkg.MountWorkspace,
+		Access:      sandboxpkg.MountReadWrite,
+	})
+	if stellaHomeHost != "" {
+		for _, name := range sandboxpkg.StellaHomeSandboxDirs() {
+			mounts = append(mounts, sandboxpkg.Mount{
+				HostPath:    filepath.Join(stellaHomeHost, name),
+				SandboxPath: filepath.Join(sandboxStellaHome, name),
+				Access:      sandboxpkg.MountReadOnly,
+			})
+		}
+	}
+	return mounts
+}
+
+func isCoveredByWritableMount(hostPath string, mounts []sandboxpkg.Mount) bool {
+	for _, m := range mounts {
+		if m.Access != sandboxpkg.MountReadWrite || filepath.Clean(m.HostPath) == filepath.Clean(hostPath) {
+			continue
+		}
+		rel, err := filepath.Rel(m.HostPath, hostPath)
+		if err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
 // wrapCommand wraps name+args with bwrap for filesystem and optional network
 // isolation on Linux. bwrap is mandatory — returns an error if not functional.
 //
@@ -284,8 +318,8 @@ func wrapCommand(policy sandboxpkg.Policy, sandboxCwd string, tmpMounts []tmpMou
 	}
 
 	realRoot := policy.WorkspaceRootOrDefault()
-	_, userDataReal := resolveUserDataRoot(policy)
 	networkMode := policy.NetworkModeOrDefault()
+	mounts := linuxPolicyMounts(policy, stellaHomeHost)
 
 	bwrapArgs := []string{
 		"--die-with-parent",
@@ -308,59 +342,42 @@ func wrapCommand(policy sandboxpkg.Policy, sandboxCwd string, tmpMounts []tmpMou
 		bwrapArgs = append(bwrapArgs, "--dir", m.sandboxPath, "--bind", m.realPath, m.sandboxPath)
 	}
 	bwrapArgs = appendLinuxRuntimeMounts(bwrapArgs)
-	bwrapArgs = appendStellaHomeMounts(bwrapArgs, stellaHomeHost)
-	// Agent-bound (system_agent) skills: read-only at a fixed path, so admin-managed
-	// skills bound to this agent stay loadable without leaking the host path.
-	if as := policy.Filesystem.AgentSkillsDir; as != "" {
-		bwrapArgs = appendRoBindIfExists(bwrapArgs, as, sandboxpkg.MountAgentSkills)
-	}
-	// DB-installed system skills: read-only at a fixed path, kept separate from the
-	// shipped built-ins so a system skill installed via Settings stays loadable.
-	if sd := policy.Filesystem.SystemDBSkillsDir; sd != "" {
-		bwrapArgs = appendRoBindIfExists(bwrapArgs, sd, sandboxpkg.MountSystemDBSkills)
-	}
-	// Extra writable mounts (e.g. an out-of-workspace per-principal cache), layered
-	// above the read-only system installs mounted by appendStellaHomeMounts: bind
-	// each at its STELLA_HOME-remapped sandbox path so writes land in the host tree.
-	// A mount inside the workspace is skipped — it is already writable through the
-	// realRoot -> /workspace bind below, and binding it again under the STELLA_HOME
-	// tree would only re-expose the host path to the agent (#442).
-	for _, writable := range policy.Filesystem.ExtraWritableMounts {
-		// Already writable through a top-level bind — skip the separate
-		// STELLA_HOME-style bind, which would re-expose the host path to the agent.
-		if remapToSandboxRoot(writable, realRoot, "/workspace") != writable {
-			continue // under /workspace
+	for _, m := range mounts {
+		if m.SandboxPath == sandboxpkg.MountWorkspace || m.SandboxPath == sandboxpkg.MountUserData {
+			continue
 		}
-		if userDataReal != "" && remapToSandboxRoot(writable, userDataReal, "/user") != writable {
-			continue // under /user (an extra writable mount inside the user-data root)
+		if m.Access == sandboxpkg.MountReadWrite && isCoveredByWritableMount(m.HostPath, mounts) {
+			continue
 		}
-		bwrapArgs = appendWritableBind(bwrapArgs, writable, remapToSandboxStellaHome(writable, stellaHomeHost))
+		if m.Access == sandboxpkg.MountReadOnly {
+			bwrapArgs = appendRoBindIfExists(bwrapArgs, m.HostPath, m.SandboxPath)
+			continue
+		}
+		bwrapArgs = appendWritableBind(bwrapArgs, m.HostPath, m.SandboxPath)
 	}
-	for _, extraPath := range policy.Filesystem.ExtraReadOnlyMounts {
-		bwrapArgs = appendRoBindIfExists(bwrapArgs, extraPath, extraPath)
+	workspaceMount, _ := mountBySandboxPath(mounts, sandboxpkg.MountWorkspace)
+	if workspaceMount.HostPath == "" {
+		workspaceMount = sandboxpkg.Mount{HostPath: realRoot, SandboxPath: sandboxpkg.MountWorkspace, Access: sandboxpkg.MountReadWrite}
 	}
 	bwrapArgs = append(bwrapArgs,
-		"--dir", "/workspace",
-		"--bind", realRoot, "/workspace",
+		"--dir", workspaceMount.SandboxPath,
+		"--bind", workspaceMount.HostPath, workspaceMount.SandboxPath,
 		"--chdir", sandboxCwd,
 	)
-	// Shared user-data root: bind the host UserDataDir writable at /user. Isolation
-	// is by non-mounting — realRoot is the per-agent dir, so sibling agents are
-	// never exposed and no tmpfs cover-up is needed (the #442 sibling-hiding hack
-	// is gone). /user is a deliberate shared writable root for all of the user's
-	// agents (caches, toolchain, uploads), not an isolation boundary.
-	if userDataReal != "" {
-		bwrapArgs = appendWritableBind(bwrapArgs, userDataReal, "/user")
+	if userMount, ok := mountBySandboxPath(mounts, sandboxpkg.MountUserData); ok {
+		bwrapArgs = appendWritableBind(bwrapArgs, userMount.HostPath, userMount.SandboxPath)
 	}
-	// Re-mount workspace-contained extra paths read-only at their /workspace/...
-	// equivalent. This overrides the writable workspace bind for those subdirectories
-	// so bash cannot write to them via /workspace.
-	for _, extraPath := range policy.Filesystem.ExtraReadOnlyMounts {
-		rel, relErr := filepath.Rel(realRoot, filepath.Clean(extraPath))
+	// Re-mount workspace-contained read-only paths at their /workspace/... equivalent.
+	// This overrides the writable workspace bind for those subdirectories.
+	for _, m := range mounts {
+		if m.Access != sandboxpkg.MountReadOnly {
+			continue
+		}
+		rel, relErr := filepath.Rel(workspaceMount.HostPath, filepath.Clean(m.HostPath))
 		if relErr != nil || strings.HasPrefix(rel, "..") || rel == "." {
 			continue
 		}
-		bwrapArgs = appendRoBindIfExists(bwrapArgs, extraPath, filepath.Join("/workspace", rel))
+		bwrapArgs = appendRoBindIfExists(bwrapArgs, m.HostPath, filepath.Join(workspaceMount.SandboxPath, rel))
 	}
 	if networkMode != sandboxpkg.NetworkAllowAll {
 		bwrapArgs = append(bwrapArgs, "--unshare-net")

--- a/plugins/sandbox/local/session_linux_test.go
+++ b/plugins/sandbox/local/session_linux_test.go
@@ -263,9 +263,9 @@ func TestWrapCommand_linux_outOfRootWritableBind(t *testing.T) {
 
 	policy := sandboxpkg.Policy{
 		Filesystem: sandboxpkg.FilesystemPolicy{
-			WorkspaceRoot:       "/tmp/test-workspace",
-			WorkingDir:          "/workspace",
-			ExtraWritableMounts: []string{userDir},
+			WorkspaceRoot: "/tmp/test-workspace",
+			WorkingDir:    "/workspace",
+			Mounts:        []sandboxpkg.Mount{{HostPath: "/tmp/test-workspace", SandboxPath: "/workspace", Access: sandboxpkg.MountReadWrite}, {HostPath: userDir, SandboxPath: sandboxUserDir, Access: sandboxpkg.MountReadWrite}},
 		},
 		Network: sandboxpkg.NetworkPolicy{Mode: sandboxpkg.NetworkAllowAll},
 	}
@@ -313,9 +313,9 @@ func TestWrapCommand_linux_inWorkspaceWritableMountSkipped(t *testing.T) {
 
 	policy := sandboxpkg.Policy{
 		Filesystem: sandboxpkg.FilesystemPolicy{
-			WorkspaceRoot:       userHome,
-			WorkingDir:          "/workspace",
-			ExtraWritableMounts: []string{miseDir},
+			WorkspaceRoot: userHome,
+			WorkingDir:    "/workspace",
+			Mounts:        []sandboxpkg.Mount{{HostPath: userHome, SandboxPath: "/workspace", Access: sandboxpkg.MountReadWrite}, {HostPath: miseDir, SandboxPath: sandboxMiseDir, Access: sandboxpkg.MountReadWrite}},
 		},
 		Network: sandboxpkg.NetworkPolicy{Mode: sandboxpkg.NetworkAllowAll},
 	}
@@ -356,10 +356,9 @@ func TestWrapCommand_linux_inUserDataWritableMountSkipped(t *testing.T) {
 
 	policy := sandboxpkg.Policy{
 		Filesystem: sandboxpkg.FilesystemPolicy{
-			WorkspaceRoot:       agentDir,
-			WorkingDir:          "/workspace",
-			UserDataDir:         userData,
-			ExtraWritableMounts: []string{writableDir},
+			WorkspaceRoot: agentDir,
+			WorkingDir:    "/workspace",
+			Mounts:        []sandboxpkg.Mount{{HostPath: agentDir, SandboxPath: "/workspace", Access: sandboxpkg.MountReadWrite}, {HostPath: userData, SandboxPath: "/user", Access: sandboxpkg.MountReadWrite}, {HostPath: writableDir, SandboxPath: filepath.Join(sandboxStellaHome, "users", "u1", "data", "scratch"), Access: sandboxpkg.MountReadWrite}},
 		},
 		Network: sandboxpkg.NetworkPolicy{Mode: sandboxpkg.NetworkAllowAll},
 	}
@@ -397,7 +396,7 @@ func TestWrapCommand_linux_twoRoots(t *testing.T) {
 		Filesystem: sandboxpkg.FilesystemPolicy{
 			WorkspaceRoot: agentDir,
 			WorkingDir:    agentDir + "/projects/p",
-			UserDataDir:   userData,
+			Mounts:        []sandboxpkg.Mount{{HostPath: agentDir, SandboxPath: "/workspace", Access: sandboxpkg.MountReadWrite}, {HostPath: userData, SandboxPath: "/user", Access: sandboxpkg.MountReadWrite}},
 		},
 		Network: sandboxpkg.NetworkPolicy{Mode: sandboxpkg.NetworkAllowAll},
 	}

--- a/plugins/sandbox/local/session_other.go
+++ b/plugins/sandbox/local/session_other.go
@@ -16,8 +16,10 @@ func resolveSandboxRoot(policy sandboxpkg.Policy) (sandboxRoot, realRoot string)
 // resolveUserDataRoot returns the shared user-data root. There is no path
 // remapping on this platform, so the sandbox-space and host paths are identical.
 func resolveUserDataRoot(policy sandboxpkg.Policy) (sandboxRoot, realRoot string) {
-	real := policy.Filesystem.UserDataDir
-	return real, real
+	if m, ok := mountBySandboxPath(policy.Filesystem.Mounts, sandboxpkg.MountUserData); ok {
+		return m.HostPath, m.HostPath
+	}
+	return "", ""
 }
 
 // createSessionTmpMounts returns no temp mounts on platforms other than Linux and macOS.

--- a/plugins/sandbox/local/session_test.go
+++ b/plugins/sandbox/local/session_test.go
@@ -326,9 +326,9 @@ func TestResolvePath_extraMountAllowed(t *testing.T) {
 
 	policy := sandboxpkg.Policy{
 		Filesystem: sandboxpkg.FilesystemPolicy{
-			WorkspaceRoot:       root,
-			WorkingDir:          root,
-			ExtraReadOnlyMounts: []string{mountDir},
+			WorkspaceRoot: root,
+			WorkingDir:    root,
+			Mounts:        []sandboxpkg.Mount{{HostPath: mountDir, SandboxPath: mountDir, Access: sandboxpkg.MountReadOnly}},
 		},
 	}
 	s := &localSession{
@@ -365,9 +365,9 @@ func TestResolveWritePath_rejectsExtraMount(t *testing.T) {
 
 	policy := sandboxpkg.Policy{
 		Filesystem: sandboxpkg.FilesystemPolicy{
-			WorkspaceRoot:       root,
-			WorkingDir:          root,
-			ExtraReadOnlyMounts: []string{mountDir},
+			WorkspaceRoot: root,
+			WorkingDir:    root,
+			Mounts:        []sandboxpkg.Mount{{HostPath: mountDir, SandboxPath: mountDir, Access: sandboxpkg.MountReadOnly}},
 		},
 	}
 	s := &localSession{
@@ -463,10 +463,9 @@ func TestAgentSkills_readableButNotWritable(t *testing.T) {
 
 	s := &localSession{
 		id:                "test",
-		policy:            sandboxpkg.Policy{Filesystem: sandboxpkg.FilesystemPolicy{WorkspaceRoot: root, WorkingDir: root, AgentSkillsDir: agentSkills}},
+		policy:            sandboxpkg.Policy{Filesystem: sandboxpkg.FilesystemPolicy{WorkspaceRoot: root, WorkingDir: root, Mounts: []sandboxpkg.Mount{{HostPath: root, SandboxPath: root, Access: sandboxpkg.MountReadWrite}, {HostPath: agentSkills, SandboxPath: sandboxpkg.MountAgentSkills, Access: sandboxpkg.MountReadOnly}}}},
 		realRoot:          root,
 		sandboxRoot:       root,
-		agentSkillsReal:   agentSkills,
 		stellaHomeHost:    hostSH,
 		stellaHomeSandbox: "/opt/stella",
 		done:              make(chan struct{}),
@@ -507,14 +506,13 @@ func TestSystemDBSkills_readableButNotWritable(t *testing.T) {
 	}
 
 	s := &localSession{
-		id:                 "test",
-		policy:             sandboxpkg.Policy{Filesystem: sandboxpkg.FilesystemPolicy{WorkspaceRoot: root, WorkingDir: root, SystemDBSkillsDir: dbSkills}},
-		realRoot:           root,
-		sandboxRoot:        root,
-		systemDBSkillsReal: dbSkills,
-		stellaHomeHost:     hostSH,
-		stellaHomeSandbox:  "/opt/stella",
-		done:               make(chan struct{}),
+		id:                "test",
+		policy:            sandboxpkg.Policy{Filesystem: sandboxpkg.FilesystemPolicy{WorkspaceRoot: root, WorkingDir: root, Mounts: []sandboxpkg.Mount{{HostPath: root, SandboxPath: root, Access: sandboxpkg.MountReadWrite}, {HostPath: dbSkills, SandboxPath: sandboxpkg.MountSystemDBSkills, Access: sandboxpkg.MountReadOnly}}}},
+		realRoot:          root,
+		sandboxRoot:       root,
+		stellaHomeHost:    hostSH,
+		stellaHomeSandbox: "/opt/stella",
+		done:              make(chan struct{}),
 	}
 
 	sandboxPath := sandboxpkg.MountSystemDBSkills + "/demo/SKILL.md"
@@ -560,9 +558,9 @@ func TestResolvePath_rejectsAdjacentToExtraMount(t *testing.T) {
 
 	policy := sandboxpkg.Policy{
 		Filesystem: sandboxpkg.FilesystemPolicy{
-			WorkspaceRoot:       root,
-			WorkingDir:          root,
-			ExtraReadOnlyMounts: []string{mountDir},
+			WorkspaceRoot: root,
+			WorkingDir:    root,
+			Mounts:        []sandboxpkg.Mount{{HostPath: mountDir, SandboxPath: mountDir, Access: sandboxpkg.MountReadOnly}},
 		},
 	}
 	s := &localSession{
@@ -704,7 +702,7 @@ func TestAdjustPolicy_perUserMiseInStellaHomeFrame(t *testing.T) {
 	userData := userHome + "/data"
 	miseHome := userHome + "/.mise-tools" // sibling of data, under STELLA_HOME
 	policy := sandboxpkg.Policy{
-		Filesystem: sandboxpkg.FilesystemPolicy{WorkspaceRoot: agentDir, UserDataDir: userData},
+		Filesystem: sandboxpkg.FilesystemPolicy{WorkspaceRoot: agentDir, Mounts: []sandboxpkg.Mount{{HostPath: agentDir, SandboxPath: "/workspace", Access: sandboxpkg.MountReadWrite}, {HostPath: userData, SandboxPath: "/user", Access: sandboxpkg.MountReadWrite}}},
 		Env: map[string]string{
 			"MISE_DATA_DIR":             miseHome,
 			"MISE_CACHE_DIR":            miseHome + "/cache",
@@ -750,7 +748,7 @@ func TestAdjustPolicy_homeAndXDG(t *testing.T) {
 		Filesystem: sandboxpkg.FilesystemPolicy{
 			WorkspaceRoot: root,
 			WorkingDir:    filepath.Join(root, "projects", "p"),
-			UserDataDir:   userData,
+			Mounts:        []sandboxpkg.Mount{{HostPath: root, SandboxPath: sandboxpkg.MountWorkspace, Access: sandboxpkg.MountReadWrite}, {HostPath: userData, SandboxPath: sandboxpkg.MountUserData, Access: sandboxpkg.MountReadWrite}},
 		},
 	}
 	f := &Factory{cfg: Config{StellaHome: t.TempDir()}}

--- a/plugins/sandbox/none/session.go
+++ b/plugins/sandbox/none/session.go
@@ -83,11 +83,21 @@ func (f *Factory) adjustPolicy(policy sandboxpkg.Policy) sandboxpkg.Policy {
 	// Host execution shares the real filesystem, so the shared user-data root is
 	// exposed at its real path (no /user remap). Keeps STELLA_USER_DIR meaningful
 	// for skills/prompt that address it regardless of backend.
-	if ud := policy.Filesystem.UserDataDir; ud != "" {
+	if ud := hostPathForSandboxMount(policy.Filesystem.Mounts, sandboxpkg.MountUserData); ud != "" {
 		env["STELLA_USER_DIR"] = ud
 	}
 	policy.Env = env
 	return policy
+}
+
+func hostPathForSandboxMount(mounts []sandboxpkg.Mount, sandboxPath string) string {
+	clean := filepath.Clean(sandboxPath)
+	for _, m := range mounts {
+		if filepath.Clean(m.SandboxPath) == clean {
+			return m.HostPath
+		}
+	}
+	return ""
 }
 
 // noneSession implements sandboxpkg.Session with zero isolation.


### PR DESCRIPTION
## What

Replace `pkg/sandbox.FilesystemPolicy`'s backend-specific fields with a generic mount plan, and centralize file-tool path resolution into one shared `PathResolver` that both local and docker delegate to. Net −183 lines.

- New `pkg/sandbox`: `MountAccess` (ReadOnly/ReadWrite), `Mount{HostPath, SandboxPath, Access}`, `PathResolver`.
- `FilesystemPolicy` reduced to generic fields: `WorkspaceRoot`, `WorkingDir`, `Mounts`, `TempDirHost`. The leaked fields (`ExtraReadOnlyMounts`/`ExtraWritableMounts`/`AgentSkillsDir`/`SystemDBSkillsDir`/`UserDataDir`/`AgentPrivateDir`) are gone.
- All Stella/mise/skills/user-data mount knowledge now lives solely in the agent-side policy builder (`internal/agent/sandbox/env.go`), which emits concrete `Mount`s (workspace RW at /workspace, user-data RW at /user, STELLA_HOME toolchain + skills RO at /opt/stella/*, per-user mise tree RW).
- bwrap / Seatbelt / docker consume the mount plan uniformly by `Access`; local + docker `ResolvePath`/`ResolveWritePath` delegate to the shared `PathResolver`.

## Why

The generic layer leaked mise/skills/STELLA_HOME/bwrap/docker semantics (change amplification), and `ResolvePath` was duplicated in local and docker — the exact divergence that let #668's read-boundary bypass exist. One resolver, one place for mount semantics.

## Boundary preserved (the important part)

This touches the security boundary, so containment was the #1 requirement:
- `PathResolver` keeps symlink-traversal rejection (Lstat per component) and read-only-mount write rejection.
- The **#668 regression test `TestReadToolProjectRootAbsolutePathUsesHostBoundary` still passes** (an absolute path outside the mounts is rejected).
- All existing sandbox tests pass unchanged: `internal/agent/sandbox/...`, `plugins/sandbox/{local,docker,none}/...`, `pkg/sandbox/...`.
- `go build ./...` and `GOOS=linux GOARCH=amd64 go build ./...` OK.

Out of scope (deferred): host-runner extraction (none/local dedup), ResilientSession backend-pinning.

## Merge order

Please merge **after #663 and #665** — this branch overlaps `internal/agent/sandbox/env.go` and `session_linux_test.go` with #663 and will need a trivial rebase. It's based on the pre-#666 main.

## Refs

Closes #664. Related: #662, #663, #665, #668.