### PR TITLE
🐛 fix(anthropic): tool schema drops oneOf + required; over-eager goal skill read

### DIFF
--- a/internal/cmd/toolgen/main.go
+++ b/internal/cmd/toolgen/main.go
@@ -502,22 +502,107 @@ func renderTool(tool, packageName string, actions []toolAction) ([]byte, error) 
 func toolSchema(actions []toolAction) map[string]any {
 	enum := make([]any, 0, len(actions))
 	oneOf := make([]any, 0, len(actions))
+	branches := make([]map[string]any, 0, len(actions))
 	for _, action := range actions {
 		enum = append(enum, action.Action)
 		branch := cloneMap(action.Schema)
 		props := branch["properties"].(map[string]any)
 		props["action"] = map[string]any{"type": "string", "const": action.Action}
 		addRequired(branch, "action")
+		branches = append(branches, branch)
 		oneOf = append(oneOf, branch)
 	}
+	// Hoist the union of every branch's fields into the top-level `properties` so
+	// a model sees all possible parameters up front instead of having to reason
+	// through oneOf. The oneOf branches still carry the exact per-action
+	// requiredness and constraints; top-level `required` stays [action] only.
+	properties := hoistProperties(branches)
+	properties["action"] = map[string]any{"type": "string", "enum": enum}
 	return map[string]any{
-		"type":     "object",
-		"required": []any{"action"},
-		"properties": map[string]any{
-			"action": map[string]any{"type": "string", "enum": enum},
-		},
-		"oneOf": oneOf,
+		"type":       "object",
+		"required":   []any{"action"},
+		"properties": properties,
+		"oneOf":      oneOf,
 	}
+}
+
+// hoistProperties merges the field schemas across every action branch (excluding
+// `action`, handled separately). When branches agree on a field's schema it is
+// copied verbatim; when they disagree the hoisted copy is loosened to type +
+// description only, so the top-level descriptor can never contradict the branch a
+// given action must satisfy.
+func hoistProperties(branches []map[string]any) map[string]any {
+	variants := map[string][]map[string]any{}
+	var order []string
+	for _, branch := range branches {
+		props, _ := branch["properties"].(map[string]any)
+		for name, raw := range props {
+			if name == "action" {
+				continue
+			}
+			ps, _ := raw.(map[string]any)
+			if _, seen := variants[name]; !seen {
+				order = append(order, name)
+			}
+			variants[name] = append(variants[name], ps)
+		}
+	}
+	sort.Strings(order)
+	out := map[string]any{}
+	for _, name := range order {
+		vs := variants[name]
+		identical := true
+		for _, v := range vs[1:] {
+			if !schemaEqual(vs[0], v) {
+				identical = false
+				break
+			}
+		}
+		if identical {
+			out[name] = cloneMap(vs[0])
+		} else {
+			out[name] = loosenProperty(vs)
+		}
+	}
+	return out
+}
+
+// loosenProperty reduces a set of divergent field schemas to a conflict-free
+// descriptor. `type` is kept only when every variant agrees on it — otherwise it
+// is dropped so the hoisted copy can never contradict a branch (e.g. `inputs` is
+// an object for one action and an array for another). Enum/const/format and other
+// per-action constraints are dropped here but preserved in the matching oneOf
+// branch, which is what actually gates a call.
+func loosenProperty(vs []map[string]any) map[string]any {
+	out := map[string]any{}
+	if sharedType, ok := vs[0]["type"]; ok {
+		unanimous := true
+		for _, v := range vs[1:] {
+			if t, has := v["type"]; !has || t != sharedType {
+				unanimous = false
+				break
+			}
+		}
+		if unanimous {
+			out["type"] = sharedType
+		}
+	}
+	for _, v := range vs {
+		if d, ok := v["description"]; ok {
+			out["description"] = d
+			break
+		}
+	}
+	return out
+}
+
+func schemaEqual(a, b map[string]any) bool {
+	ab, err1 := json.Marshal(a)
+	bb, err2 := json.Marshal(b)
+	if err1 != nil || err2 != nil {
+		return false
+	}
+	return bytes.Equal(ab, bb)
 }
 
 func goType(schema any, required bool) string {

--- a/internal/cmd/toolgen/main_test.go
+++ b/internal/cmd/toolgen/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"slices"
 	"strings"
 	"testing"
 )
@@ -72,6 +73,61 @@ func TestToolSchemaUsesActionEnumAndOneOf(t *testing.T) {
 	if branchProps["action"].(map[string]any)["const"] == "" {
 		t.Fatal("oneOf branch missing action const")
 	}
+}
+
+func TestToolSchemaHoistsBranchPropertiesToTopLevel(t *testing.T) {
+	schema := toolSchema([]toolAction{
+		{Action: "create", Schema: objectSchema(map[string]any{"title": map[string]any{"type": "string"}}, []string{"title"})},
+		{Action: "list", Schema: objectSchema(map[string]any{"q": map[string]any{"type": "string"}}, nil)},
+	})
+	props := schema["properties"].(map[string]any)
+	// Every branch field is visible at the top level, but only `action` is required.
+	for _, want := range []string{"action", "title", "q"} {
+		if _, ok := props[want]; !ok {
+			t.Errorf("top-level properties missing %q: %#v", want, props)
+		}
+	}
+	if req := schema["required"].([]any); len(req) != 1 || req[0] != "action" {
+		t.Fatalf("top-level required=%#v, want [action]", req)
+	}
+	// The per-action requiredness stays in the matching oneOf branch.
+	for _, raw := range schema["oneOf"].([]any) {
+		branch := raw.(map[string]any)
+		if branch["properties"].(map[string]any)["action"].(map[string]any)["const"] == "create" {
+			if req := stringSlice(branch["required"]); !contains(req, "title") {
+				t.Errorf("create branch required=%#v, want title", req)
+			}
+		}
+	}
+}
+
+func TestToolSchemaLoosensConflictingBranchTypes(t *testing.T) {
+	// `inputs` is an object for one action and an array for another; the hoisted
+	// top-level copy must not commit to either type, or it would contradict a branch.
+	schema := toolSchema([]toolAction{
+		{Action: "run", Schema: objectSchema(map[string]any{"inputs": map[string]any{"type": "object"}}, nil)},
+		{Action: "save", Schema: objectSchema(map[string]any{"inputs": map[string]any{"type": "array"}}, nil)},
+	})
+	inputs := schema["properties"].(map[string]any)["inputs"].(map[string]any)
+	if _, ok := inputs["type"]; ok {
+		t.Fatalf("top-level inputs kept a conflicting type: %#v", inputs)
+	}
+	// A field all branches agree on keeps its type.
+	schema2 := toolSchema([]toolAction{
+		{Action: "a", Schema: objectSchema(map[string]any{"name": map[string]any{"type": "string"}}, nil)},
+		{Action: "b", Schema: objectSchema(map[string]any{"name": map[string]any{"type": "string", "minLength": 1}}, nil)},
+	})
+	name := schema2["properties"].(map[string]any)["name"].(map[string]any)
+	if name["type"] != "string" {
+		t.Errorf("agreed type dropped: %#v", name)
+	}
+	if _, ok := name["minLength"]; ok {
+		t.Errorf("per-branch constraint leaked to top level: %#v", name)
+	}
+}
+
+func contains(s []string, v string) bool {
+	return slices.Contains(s, v)
 }
 
 func TestRestrictAnnotationNarrowsPropertyEnum(t *testing.T) {

--- a/internal/connections/tool_gen.go
+++ b/internal/connections/tool_gen.go
@@ -91,6 +91,12 @@ const InputSchemaJSON = `{
         "status"
       ],
       "type": "string"
+    },
+    "flow_id": {
+      "type": "string"
+    },
+    "provider": {
+      "type": "string"
     }
   },
   "required": [

--- a/internal/email/tool_gen.go
+++ b/internal/email/tool_gen.go
@@ -163,6 +163,9 @@ const InputSchemaJSON = `{
     }
   ],
   "properties": {
+    "account": {
+      "type": "string"
+    },
     "action": {
       "enum": [
         "accounts",
@@ -171,6 +174,77 @@ const InputSchemaJSON = `{
         "send"
       ],
       "type": "string"
+    },
+    "bcc": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "before": {
+      "format": "date",
+      "type": "string"
+    },
+    "body": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "cc": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "folder": {
+      "default": "INBOX",
+      "type": "string"
+    },
+    "from": {
+      "type": "string"
+    },
+    "html": {
+      "type": "boolean"
+    },
+    "idempotency_key": {
+      "description": "Optional for HTTP clients; required by the native email tool to suppress duplicate sends.",
+      "type": "string"
+    },
+    "in_reply_to": {
+      "type": "string"
+    },
+    "limit": {
+      "default": 20,
+      "maximum": 500,
+      "minimum": 1,
+      "type": "integer"
+    },
+    "reply_to": {
+      "type": "string"
+    },
+    "since": {
+      "format": "date",
+      "type": "string"
+    },
+    "subject": {
+      "type": "string"
+    },
+    "to": {
+      "items": {
+        "minLength": 1,
+        "type": "string"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "uid": {
+      "maximum": 4294967295,
+      "minimum": 1,
+      "type": "integer"
+    },
+    "unread": {
+      "type": "boolean"
     }
   },
   "required": [

--- a/internal/goal/tool_gen.go
+++ b/internal/goal/tool_gen.go
@@ -246,6 +246,70 @@ const InputSchemaJSON = `{
     }
   ],
   "properties": {
+    "acceptance_contract": {
+      "description": "Optional acceptance gate; omit for trivial auto-accept.",
+      "properties": {
+        "items": {
+          "items": {
+            "properties": {
+              "authority": {
+                "description": "Who renders a judgment verdict.",
+                "enum": [
+                  "agent",
+                  "human"
+                ],
+                "type": "string"
+              },
+              "command": {
+                "description": "Deterministic check command (run in the sandbox).",
+                "type": "string"
+              },
+              "expect_exit": {
+                "description": "Expected exit code for a deterministic check (default 0).",
+                "type": "integer"
+              },
+              "id": {
+                "type": "string"
+              },
+              "kind": {
+                "enum": [
+                  "deterministic",
+                  "judgment"
+                ],
+                "type": "string"
+              },
+              "prompt": {
+                "description": "Human verdict prompt.",
+                "type": "string"
+              },
+              "required": {
+                "description": "A non-required item is advisory and does not gate acceptance.",
+                "type": "boolean"
+              },
+              "rubric": {
+                "description": "Agent reviewer prompt.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "kind"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "policy": {
+          "enum": [
+            "deterministic_then_judgment",
+            "all",
+            "any"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "action": {
       "enum": [
         "cancel",
@@ -253,6 +317,112 @@ const InputSchemaJSON = `{
         "get",
         "list"
       ],
+      "type": "string"
+    },
+    "activate": {
+      "description": "When true the new goal is activated immediately after create (direct run). Only a leaf with a satisfied plan gate can activate; a composite must be planned first, so 'activate' is ignored for it.",
+      "type": "boolean"
+    },
+    "archived": {
+      "type": "boolean"
+    },
+    "convergence_policy": {
+      "description": "Bounds the rework loop and recursion depth.",
+      "properties": {
+        "escalation": {
+          "enum": [
+            "block",
+            "abandon"
+          ],
+          "type": "string"
+        },
+        "max_attempts": {
+          "description": "Rework budget; exhaustion ⇒ blocked(budget_exhausted). Default 3.",
+          "type": "integer"
+        },
+        "max_concurrent": {
+          "description": "Per-root breadth-of-fanout cap. Default 8.",
+          "type": "integer"
+        },
+        "max_depth": {
+          "description": "Recursion ceiling. Default 4.",
+          "type": "integer"
+        },
+        "planner_repair_max": {
+          "description": "Structural planning repair turns in the same session. Default 2.",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "id": {
+      "type": "string"
+    },
+    "idempotency_key": {
+      "description": "Optional key; repeated creates by the same user with the same key return the existing goal.",
+      "type": "string"
+    },
+    "intent": {
+      "description": "What \"done\" means for this goal.",
+      "type": "string"
+    },
+    "kind": {
+      "description": "'leaf' (default) is a directly-executed goal; 'composite' is decomposed into children (the plan is materialized) before it can activate.",
+      "enum": [
+        "leaf",
+        "composite"
+      ],
+      "type": "string"
+    },
+    "lifecycle": {
+      "type": "string"
+    },
+    "page_size": {
+      "default": 20,
+      "maximum": 500,
+      "minimum": 1,
+      "type": "integer"
+    },
+    "page_token": {
+      "type": "string"
+    },
+    "parent": {
+      "type": "string"
+    },
+    "priority": {
+      "enum": [
+        "routine",
+        "urgent"
+      ],
+      "type": "string"
+    },
+    "project_id": {
+      "description": "Optional project/workspace context. Must belong to the caller and agent.",
+      "type": "string"
+    },
+    "q": {
+      "type": "string"
+    },
+    "reason": {
+      "type": "string"
+    },
+    "review_policy": {
+      "enum": [
+        "none",
+        "human"
+      ],
+      "type": "string"
+    },
+    "root": {
+      "type": "string"
+    },
+    "terminal": {
+      "type": "boolean"
+    },
+    "title": {
+      "type": "string"
+    },
+    "workflow_id": {
       "type": "string"
     }
   },

--- a/internal/recally/tool_gen.go
+++ b/internal/recally/tool_gen.go
@@ -394,6 +394,145 @@ const InputSchemaJSON = `{
         "save"
       ],
       "type": "string"
+    },
+    "article_id": {
+      "nullable": true,
+      "type": "string"
+    },
+    "articles": {
+      "items": {
+        "properties": {
+          "author": {
+            "type": "string"
+          },
+          "canonical_url": {
+            "type": "string"
+          },
+          "content": {
+            "description": "Markdown body. If empty and the article exists, only metadata is updated; if empty and the article is new, the request fails 400.",
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "published_at": {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "source_type": {
+            "enum": [
+              "web",
+              "twitter",
+              "youtube",
+              "github",
+              "rss",
+              "pdf"
+            ],
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url": {
+            "format": "uri",
+            "type": "string"
+          }
+        },
+        "required": [
+          "url"
+        ],
+        "type": "object"
+      },
+      "maxItems": 20,
+      "minItems": 1,
+      "type": "array"
+    },
+    "canonical_url": {
+      "type": "string"
+    },
+    "date": {
+      "description": "YYYY-MM-DD; defaults to today if omitted",
+      "type": "string"
+    },
+    "error_msg": {
+      "type": "string"
+    },
+    "feed_id": {
+      "type": "string"
+    },
+    "guid": {
+      "description": "Stable per-source item id; the dedup key (unique per feed)",
+      "type": "string"
+    },
+    "id": {
+      "type": "string"
+    },
+    "kind": {
+      "description": "Escape hatch to force the feed kind. Omit to let the server sniff it from the URL (x.com/twitter.com → twitter, otherwise rss).",
+      "enum": [
+        "rss",
+        "twitter",
+        "website"
+      ],
+      "type": "string"
+    },
+    "limit": {
+      "default": 20,
+      "maximum": 500,
+      "minimum": 1,
+      "type": "integer"
+    },
+    "narrative": {
+      "type": "string"
+    },
+    "page_size": {
+      "default": 20,
+      "maximum": 500,
+      "minimum": 1,
+      "type": "integer"
+    },
+    "page_token": {
+      "type": "string"
+    },
+    "q": {
+      "type": "string"
+    },
+    "source_type": {
+      "enum": [
+        "web",
+        "twitter",
+        "youtube",
+        "github",
+        "rss",
+        "pdf"
+      ],
+      "type": "string"
+    },
+    "starred": {
+      "type": "boolean"
+    },
+    "status": {
+      "type": "string"
+    },
+    "title": {
+      "description": "Optional override; server fetches feed metadata if omitted (rss only)",
+      "type": "string"
+    },
+    "url": {
+      "type": "string"
     }
   },
   "required": [

--- a/internal/scheduler/tool_gen.go
+++ b/internal/scheduler/tool_gen.go
@@ -242,6 +242,63 @@ const InputSchemaJSON = `{
         "update"
       ],
       "type": "string"
+    },
+    "allow_replan": {
+      "description": "Allow scheduling a partially frozen workflow.",
+      "type": "boolean"
+    },
+    "at": {
+      "type": "string"
+    },
+    "cron": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "dispatch_kind": {
+      "enum": [
+        "chat",
+        "workflow"
+      ],
+      "type": "string"
+    },
+    "enabled": {
+      "type": "boolean"
+    },
+    "every": {
+      "type": "string"
+    },
+    "id": {
+      "type": "string"
+    },
+    "idempotency_key": {
+      "description": "Optional key; repeated creates by the same user with the same key return the existing job.",
+      "type": "string"
+    },
+    "inputs": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Workflow input values.",
+      "type": "object"
+    },
+    "message": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "session_mode": {
+      "type": "string"
+    },
+    "template_key": {
+      "description": "Optional. When set, create a subscription instance for this template. name/message are filled from the template; schedule fields may override defaults.",
+      "type": "string"
+    },
+    "workflow_id": {
+      "description": "Exact workflow version row to instantiate when dispatch_kind is workflow.",
+      "type": "string"
     }
   },
   "required": [

--- a/internal/share/tool_gen.go
+++ b/internal/share/tool_gen.go
@@ -120,6 +120,40 @@ const InputSchemaJSON = `{
         "revoke"
       ],
       "type": "string"
+    },
+    "article_id": {
+      "type": "string"
+    },
+    "expires_in": {
+      "default": "7d",
+      "enum": [
+        "1h",
+        "1d",
+        "7d",
+        "never"
+      ],
+      "type": "string"
+    },
+    "id": {
+      "type": "string"
+    },
+    "page_size": {
+      "type": "integer"
+    },
+    "page_token": {
+      "type": "string"
+    },
+    "path": {
+      "type": "string"
+    },
+    "scope": {
+      "default": "agent",
+      "description": "Which root to operate on: agent — the per-agent home (sandbox /workspace), private to this agent; user — the shared user-data root (sandbox /user), shared across all of the user's agents.",
+      "enum": [
+        "agent",
+        "user"
+      ],
+      "type": "string"
     }
   },
   "required": [

--- a/internal/vault/tool_gen.go
+++ b/internal/vault/tool_gen.go
@@ -98,6 +98,20 @@ const InputSchemaJSON = `{
         "set"
       ],
       "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "scope": {
+      "default": "user",
+      "enum": [
+        "user",
+        "user_agent"
+      ],
+      "type": "string"
+    },
+    "value": {
+      "type": "string"
     }
   },
   "required": [

--- a/internal/workflow/tool_gen.go
+++ b/internal/workflow/tool_gen.go
@@ -127,6 +127,17 @@ const InputSchemaJSON = `{
         "save"
       ],
       "type": "string"
+    },
+    "id": {
+      "type": "string"
+    },
+    "idempotency_key": {
+      "description": "Optional idempotency key. When omitted, the server generates a UUID, so retries must provide their own key to be idempotent.",
+      "type": "string"
+    },
+    "inputs": {},
+    "name": {
+      "type": "string"
     }
   },
   "required": [

--- a/plugins/providers/anthropic/options.go
+++ b/plugins/providers/anthropic/options.go
@@ -42,18 +42,53 @@ func buildParams(model ai.Model, ctx ai.Context, opts ai.StreamOptions) sdk.Mess
 func convertTools(tools []ai.ToolDefinition) []sdk.ToolUnionParam {
 	out := make([]sdk.ToolUnionParam, 0, len(tools))
 	for _, t := range tools {
-		schema := sdk.ToolInputSchemaParam{
-			Properties: t.InputSchema["properties"],
-		}
-		if req, ok := t.InputSchema["required"].([]string); ok {
-			schema.Required = req
-		}
 		tp := sdk.ToolParam{
 			Name:        t.Name,
-			InputSchema: schema,
+			InputSchema: toolSchema(t.InputSchema),
 			Description: param.NewOpt(t.Description),
 		}
 		out = append(out, sdk.ToolUnionParam{OfTool: &tp})
 	}
 	return out
+}
+
+// toolSchema carries the full JSON Schema to Anthropic. The SDK's typed struct
+// only models `properties`, `required`, and `type`, so every other top-level key
+// (oneOf/anyOf/$defs, used by multi-action tool schemas to hold per-action
+// parameters) must ride along in ExtraFields or it is silently dropped.
+func toolSchema(in map[string]any) sdk.ToolInputSchemaParam {
+	schema := sdk.ToolInputSchemaParam{Properties: in["properties"]}
+	schema.Required = stringSlice(in["required"])
+	var extras map[string]any
+	for k, v := range in {
+		switch k {
+		case "type", "properties", "required":
+			continue
+		}
+		if extras == nil {
+			extras = map[string]any{}
+		}
+		extras[k] = v
+	}
+	schema.ExtraFields = extras
+	return schema
+}
+
+// stringSlice coerces a JSON-decoded array (which is []any after unmarshalling
+// into map[string]any) into []string, tolerating an already-typed []string.
+func stringSlice(v any) []string {
+	switch req := v.(type) {
+	case []string:
+		return req
+	case []any:
+		out := make([]string, 0, len(req))
+		for _, item := range req {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
 }

--- a/plugins/providers/anthropic/options_test.go
+++ b/plugins/providers/anthropic/options_test.go
@@ -1,6 +1,8 @@
 package anthropic
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/CherryHQ/stella/pkg/ai"
@@ -146,6 +148,51 @@ func TestConvertToolsWithRequired(t *testing.T) {
 	}
 	if len(out[0].OfTool.InputSchema.Required) != 1 {
 		t.Errorf("expected 1 required field, got %d", len(out[0].OfTool.InputSchema.Required))
+	}
+}
+
+// Multi-action tools describe per-action parameters inside a oneOf. The SDK's
+// typed schema only models properties/required/type, so oneOf must survive via
+// ExtraFields or Claude sees a tool with no usable parameters.
+func TestConvertToolsPreservesOneOf(t *testing.T) {
+	// Mirror a toolgen schema decoded via json.Unmarshal: arrays are []any.
+	tools := []ai.ToolDefinition{
+		{
+			Name: "goal",
+			InputSchema: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{"action": map[string]any{"enum": []any{"create", "list"}}},
+				"required":   []any{"action"},
+				"oneOf": []any{
+					map[string]any{
+						"properties": map[string]any{
+							"action": map[string]any{"const": "create"},
+							"title":  map[string]any{"type": "string"},
+						},
+						"required": []any{"action", "title"},
+					},
+				},
+			},
+		},
+	}
+	out := convertTools(tools)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(out))
+	}
+	// Top-level required must survive the []any coercion.
+	if got := out[0].OfTool.InputSchema.Required; len(got) != 1 || got[0] != "action" {
+		t.Errorf("required = %v, want [action]", got)
+	}
+	// oneOf (with the create branch's title) must reach the wire.
+	data, err := json.Marshal(out[0].OfTool.InputSchema)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"oneOf"`) {
+		t.Errorf("serialized schema dropped oneOf: %s", data)
+	}
+	if !strings.Contains(string(data), `"title"`) {
+		t.Errorf("serialized schema dropped per-action title: %s", data)
 	}
 }
 

--- a/resources/skills/system/stella/SKILL.md
+++ b/resources/skills/system/stella/SKILL.md
@@ -10,12 +10,10 @@ description: >
   "what can you do", "how do I install skills", "stella onboard", "switch agent".
   Also triggers when the user wants to report a bug or file a GitHub issue about stella:
   "report this bug", "create an issue for this", "报告这个 issue", "帮我建个 issue".
-  Read references/goals.md BEFORE diagnosing, steering, or working an existing goal —
-  "what's the status of this goal", "why is this blocked", "decompose this",
-  "review/accept this", "拆解成子目标", "为什么卡住了", "验收", or when you are dispatched as a
-  goal worker: it explains how a goal converges through its acceptance contract and your
-  worker contract. Simply creating a goal ("run this in the background", "后台跑") needs no
-  read — write a clear intent and call the goal tool.
+  Also triggers on goal-model work — goal status, "why is this blocked", "decompose this",
+  "review/accept this", "为什么卡住了", "拆解成子目标", "验收", or being dispatched as a goal
+  worker: read references/goals.md. Merely creating a goal does not — write a clear intent
+  and call the goal tool.
 ---
 
 # Stella Self-Knowledge

--- a/resources/skills/system/stella/SKILL.md
+++ b/resources/skills/system/stella/SKILL.md
@@ -10,11 +10,12 @@ description: >
   "what can you do", "how do I install skills", "stella onboard", "switch agent".
   Also triggers when the user wants to report a bug or file a GitHub issue about stella:
   "report this bug", "create an issue for this", "报告这个 issue", "帮我建个 issue".
-  Read this BEFORE working on any goal — not only when asked how stella works, but
-  whenever you are about to act on one: "run this in the background", "what's the status of
-  this goal", "why is this blocked", "decompose this", "review/accept this",
-  "后台跑", "拆解成子目标", "为什么卡住了", "验收". Read references/goals.md for how a
-  goal converges through its acceptance contract and what your worker contract is.
+  Read references/goals.md BEFORE diagnosing, steering, or working an existing goal —
+  "what's the status of this goal", "why is this blocked", "decompose this",
+  "review/accept this", "拆解成子目标", "为什么卡住了", "验收", or when you are dispatched as a
+  goal worker: it explains how a goal converges through its acceptance contract and your
+  worker contract. Simply creating a goal ("run this in the background", "后台跑") needs no
+  read — write a clear intent and call the goal tool.
 ---
 
 # Stella Self-Knowledge


### PR DESCRIPTION
## What

Fix the diagnosed chain behind "creating a simple goal takes 18s, two skill reads, and a failed first tool call". Four changes across three surfaces:

1. **anthropic provider** — carry the full tool input schema (was dropping `oneOf` and mis-typing `required`).
2. **stella skill** — stop forcing a `references/goals.md` read for the trivial goal-authoring path, then trim the goal block to a lean pre-load trigger.
3. **toolgen** — hoist per-action fields into top-level `properties` so models see all parameters without reasoning through `oneOf`.

## Why

Every toolgen-generated tool (goal, scheduler, workflow, share, vault, oauth, recally, email) uses a `oneOf`-per-action schema where required fields (e.g. `title` for `goal create`) live inside a branch.

- The Anthropic adapter rebuilt each schema from only top-level `properties`, dropping `oneOf` entirely, and read `required` via `.([]string)` on a value that is `[]any` after JSON decode — so Claude saw the `goal` tool as having a single `action` param and nothing else. First call `{"action":"create"}` failed server-side with `missing required field "title"` the model was never shown.
- The `stella` skill description told the model to read `references/goals.md` before working on **any** goal, including plain authoring — producing two `skills load` roundtrips before the goal tool even ran. Authoring is already covered by the system prompt's Goals section. The description is injected verbatim into every session's system prompt, so the goal block had also grown to *explain* goal convergence and the worker contract — content that belongs in `goals.md`, which the model reads once triggered.
- Even with `oneOf` reaching the model, per-action params lived only inside branches (top-level `properties` = `{action}`), forcing the model to reason through `oneOf` to find required fields.

OpenAI and OpenAI-Response adapters were unaffected: they pass the whole schema map through (`shared.FunctionParameters(t.InputSchema)` / `Parameters: t.InputSchema`). Only the Anthropic adapter hand-rebuilt the schema field-by-field, because its SDK's `ToolInputSchemaParam` is a typed struct rather than a map — which is why the drop bug was Anthropic-only.

## How

- `plugins/providers/anthropic/options.go`: `toolSchema` keeps `properties`/`required` and routes every other top-level key (`oneOf`, `$defs`, …) through `ToolInputSchemaParam.ExtraFields`; `stringSlice` coerces `required` from `[]any`.
- `resources/skills/system/stella/SKILL.md`: narrow the goals.md trigger to diagnosing/steering/working an existing goal (exclude authoring), then compress the goal block to pre-load trigger phrases + the goals.md pointer + the authoring carve-out, dropping the explanatory tail.
- `internal/cmd/toolgen/main.go`: `hoistProperties` unions branch fields into top-level `properties` (top-level `required` stays `[action]`); `loosenProperty` drops `type` when branches disagree (e.g. `workflow inputs`: object vs array) so the hoisted copy never contradicts a oneOf branch. Regenerated all 8 `tool_gen.go`.
- Regression tests: anthropic oneOf survival + `[]any` required; toolgen hoist + conflict-loosening.

Verification: `mise run format && mise run build && mise run test` all pass. Reviewed by codex (openai-codex/gpt-5.5, read-only): no blocker / should-fix / nit.

## Refs

Fixes #680