### PR TITLE
fix(reflect): backfill legacy Reflect fact provenance

### DIFF
--- a/internal/db/database_test.go
+++ b/internal/db/database_test.go
@@ -222,7 +222,9 @@ func TestReflectProvenanceBackfillMarksOnlyLegacyReflectFacts(t *testing.T) {
 	agentReflect := "reflect-backfill-agent"
 	agentManualLatest := "manual-latest-agent"
 	agentAmbiguous := "ambiguous-agent"
-	for _, agentID := range []string{agentReflect, agentManualLatest, agentAmbiguous} {
+	agentContentMismatch := "content-mismatch-agent"
+	agentDeprecated := "deprecated-agent"
+	for _, agentID := range []string{agentReflect, agentManualLatest, agentAmbiguous, agentContentMismatch, agentDeprecated} {
 		if _, err := db.Exec(ctx, `INSERT INTO agent (id, name, workspace) VALUES ($1, $1, '/tmp')`, agentID); err != nil {
 			t.Fatalf("seed agent %s: %v", agentID, err)
 		}
@@ -235,12 +237,14 @@ func TestReflectProvenanceBackfillMarksOnlyLegacyReflectFacts(t *testing.T) {
 	reflectSoulFactID := uuid.NewString()
 	manualLatestFactID := uuid.NewString()
 	ambiguousFactID := uuid.NewString()
-	seedMigratedFact := func(id, agentID, subject, content string) {
+	contentMismatchFactID := uuid.NewString()
+	deprecatedFactID := uuid.NewString()
+	seedMigratedFact := func(id, agentID, subject, status, content string) {
 		t.Helper()
 		if _, err := db.Exec(ctx, `
 			INSERT INTO facts (id, subject, scope, user_id, agent_id, content, status, metadata, version, source, created_at, updated_at)
-			VALUES ($1, $2, 'user_agent', $3, $4, $5, 'active', '{"migration":"20260625090000_add_facts_memory"}', 1, 'manual', now(), now())`,
-			id, subject, userID, agentID, content); err != nil {
+			VALUES ($1, $2, 'user_agent', $3, $4, $5, $6, '{"migration":"20260625090000_add_facts_memory"}', 1, 'manual', now(), now())`,
+			id, subject, userID, agentID, content, status); err != nil {
 			t.Fatalf("seed fact %s: %v", id, err)
 		}
 		if _, err := db.Exec(ctx, `
@@ -252,21 +256,23 @@ func TestReflectProvenanceBackfillMarksOnlyLegacyReflectFacts(t *testing.T) {
 				'user_id', $2::uuid::text,
 				'agent_id', $3::text,
 				'content', $6::text,
-				'status', 'active',
+				'status', $7::text,
 				'metadata', jsonb_build_object('migration', '20260625090000_add_facts_memory'),
 				'version', 1,
 				'source', 'manual',
 				'created_at', now(),
 				'updated_at', now()
 			)::text, '{"migration":"20260625090000_add_facts_memory"}')`,
-			uuid.NewString(), userID, agentID, id, subject, content); err != nil {
+			uuid.NewString(), userID, agentID, id, subject, content, status); err != nil {
 			t.Fatalf("seed fact changelog %s: %v", id, err)
 		}
 	}
-	seedMigratedFact(reflectProfileFactID, agentReflect, "user", "reflect generated profile")
-	seedMigratedFact(reflectSoulFactID, agentReflect, "agent", "reflect generated soul")
-	seedMigratedFact(manualLatestFactID, agentManualLatest, "user", "manual latest profile")
-	seedMigratedFact(ambiguousFactID, agentAmbiguous, "user", "ambiguous profile")
+	seedMigratedFact(reflectProfileFactID, agentReflect, "user", "active", "reflect generated profile")
+	seedMigratedFact(reflectSoulFactID, agentReflect, "agent", "active", "reflect generated soul")
+	seedMigratedFact(manualLatestFactID, agentManualLatest, "user", "active", "manual latest profile")
+	seedMigratedFact(ambiguousFactID, agentAmbiguous, "user", "active", "ambiguous profile")
+	seedMigratedFact(contentMismatchFactID, agentContentMismatch, "user", "active", "locally edited profile")
+	seedMigratedFact(deprecatedFactID, agentDeprecated, "user", "deprecated", "deprecated reflect profile")
 
 	seedLegacyIdentityChangelog := func(agentID, scope, source string, version int, after string) {
 		t.Helper()
@@ -282,13 +288,8 @@ func TestReflectProvenanceBackfillMarksOnlyLegacyReflectFacts(t *testing.T) {
 	seedLegacyIdentityChangelog(agentReflect, "soul", "reflect", 2, "reflect generated soul")
 	seedLegacyIdentityChangelog(agentManualLatest, "profile", "reflect", 1, "manual latest profile")
 	seedLegacyIdentityChangelog(agentManualLatest, "profile", "manual", 2, "manual latest profile")
-
-	if _, err := db.Exec(ctx, `
-		INSERT INTO skill (id, scope, user_id, agent_id, name, description, status, metadata)
-		VALUES ('ambiguous-skill', 'user_agent', $1, $2, 'ambiguous-skill', 'not proven reflect', 'active', '{"created-at":"2026-07-01T00:00:00Z"}')`,
-		userID, agentReflect); err != nil {
-		t.Fatalf("seed ambiguous skill: %v", err)
-	}
+	seedLegacyIdentityChangelog(agentContentMismatch, "profile", "reflect", 1, "legacy reflect profile")
+	seedLegacyIdentityChangelog(agentDeprecated, "profile", "reflect", 1, "deprecated reflect profile")
 
 	if _, err := provider.UpTo(ctx, 20260708090000); err != nil {
 		t.Fatalf("goose up reflect provenance backfill: %v", err)
@@ -308,6 +309,8 @@ func TestReflectProvenanceBackfillMarksOnlyLegacyReflectFacts(t *testing.T) {
 	assertFactSource(reflectSoulFactID, "reflect")
 	assertFactSource(manualLatestFactID, "manual")
 	assertFactSource(ambiguousFactID, "manual")
+	assertFactSource(contentMismatchFactID, "manual")
+	assertFactSource(deprecatedFactID, "manual")
 
 	var changelogSource, payloadSource string
 	if err := db.QueryRow(ctx, `
@@ -319,14 +322,6 @@ func TestReflectProvenanceBackfillMarksOnlyLegacyReflectFacts(t *testing.T) {
 	}
 	if changelogSource != "reflect" || payloadSource != "reflect" {
 		t.Fatalf("migrated fact changelog source = %q payload=%q, want reflect/reflect", changelogSource, payloadSource)
-	}
-
-	var skillCreatedBy *string
-	if err := db.QueryRow(ctx, `SELECT metadata->>'created_by' FROM skill WHERE id = 'ambiguous-skill'`).Scan(&skillCreatedBy); err != nil {
-		t.Fatalf("read ambiguous skill metadata: %v", err)
-	}
-	if skillCreatedBy != nil {
-		t.Fatalf("ambiguous skill created_by = %q, want null", *skillCreatedBy)
 	}
 }
 

--- a/internal/db/database_test.go
+++ b/internal/db/database_test.go
@@ -197,6 +197,139 @@ func TestFactsMigrationDownFlushesActiveIdentityFacts(t *testing.T) {
 	}
 }
 
+func TestReflectProvenanceBackfillMarksOnlyLegacyReflectFacts(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	sub, err := fs.Sub(MigrationsFS, "migrations")
+	if err != nil {
+		t.Fatalf("open migrations fs: %v", err)
+	}
+	sqlDB := stdlib.OpenDBFromPool(db)
+	defer func() { _ = sqlDB.Close() }()
+	provider, err := goose.NewProvider(goose.DialectPostgres, sqlDB, sub)
+	if err != nil {
+		t.Fatalf("create migration provider: %v", err)
+	}
+	if _, err := provider.DownTo(ctx, 20260707092307); err != nil {
+		t.Fatalf("goose down to before reflect provenance backfill: %v", err)
+	}
+
+	userID := uuid.NewString()
+	if _, err := db.Exec(ctx, `INSERT INTO auth_user (id, email) VALUES ($1, 'reflect-backfill@test.local')`, userID); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	agentReflect := "reflect-backfill-agent"
+	agentManualLatest := "manual-latest-agent"
+	agentAmbiguous := "ambiguous-agent"
+	for _, agentID := range []string{agentReflect, agentManualLatest, agentAmbiguous} {
+		if _, err := db.Exec(ctx, `INSERT INTO agent (id, name, workspace) VALUES ($1, $1, '/tmp')`, agentID); err != nil {
+			t.Fatalf("seed agent %s: %v", agentID, err)
+		}
+		if _, err := db.Exec(ctx, `INSERT INTO ctx_agent_memory (user_id, agent_id, version) VALUES ($1, $2, 3)`, userID, agentID); err != nil {
+			t.Fatalf("seed memory row %s: %v", agentID, err)
+		}
+	}
+
+	reflectProfileFactID := uuid.NewString()
+	reflectSoulFactID := uuid.NewString()
+	manualLatestFactID := uuid.NewString()
+	ambiguousFactID := uuid.NewString()
+	seedMigratedFact := func(id, agentID, subject, content string) {
+		t.Helper()
+		if _, err := db.Exec(ctx, `
+			INSERT INTO facts (id, subject, scope, user_id, agent_id, content, status, metadata, version, source, created_at, updated_at)
+			VALUES ($1, $2, 'user_agent', $3, $4, $5, 'active', '{"migration":"20260625090000_add_facts_memory"}', 1, 'manual', now(), now())`,
+			id, subject, userID, agentID, content); err != nil {
+			t.Fatalf("seed fact %s: %v", id, err)
+		}
+		if _, err := db.Exec(ctx, `
+			INSERT INTO ctx_agent_memory_changelog (id, user_id, agent_id, entity_id, scope, action, source, memory_version_after, after_text, metadata)
+			VALUES ($1, $2, $3, $4, 'fact', 'create', 'manual', 3, jsonb_build_object(
+				'id', $4::text,
+				'subject', $5::text,
+				'scope', 'user_agent',
+				'user_id', $2::uuid::text,
+				'agent_id', $3::text,
+				'content', $6::text,
+				'status', 'active',
+				'metadata', jsonb_build_object('migration', '20260625090000_add_facts_memory'),
+				'version', 1,
+				'source', 'manual',
+				'created_at', now(),
+				'updated_at', now()
+			)::text, '{"migration":"20260625090000_add_facts_memory"}')`,
+			uuid.NewString(), userID, agentID, id, subject, content); err != nil {
+			t.Fatalf("seed fact changelog %s: %v", id, err)
+		}
+	}
+	seedMigratedFact(reflectProfileFactID, agentReflect, "user", "reflect generated profile")
+	seedMigratedFact(reflectSoulFactID, agentReflect, "agent", "reflect generated soul")
+	seedMigratedFact(manualLatestFactID, agentManualLatest, "user", "manual latest profile")
+	seedMigratedFact(ambiguousFactID, agentAmbiguous, "user", "ambiguous profile")
+
+	seedLegacyIdentityChangelog := func(agentID, scope, source string, version int, after string) {
+		t.Helper()
+		if _, err := db.Exec(ctx, `
+			INSERT INTO ctx_agent_memory_changelog (id, user_id, agent_id, scope, action, source, memory_version_after, after_text)
+			VALUES ($1, $2, $3, $4, 'update', $5, $6, $7)`,
+			uuid.NewString(), userID, agentID, scope, source, version, after); err != nil {
+			t.Fatalf("seed legacy %s changelog for %s: %v", scope, agentID, err)
+		}
+	}
+	seedLegacyIdentityChangelog(agentReflect, "profile", "manual", 1, "old manual profile")
+	seedLegacyIdentityChangelog(agentReflect, "profile", "reflect", 2, "reflect generated profile")
+	seedLegacyIdentityChangelog(agentReflect, "soul", "reflect", 2, "reflect generated soul")
+	seedLegacyIdentityChangelog(agentManualLatest, "profile", "reflect", 1, "manual latest profile")
+	seedLegacyIdentityChangelog(agentManualLatest, "profile", "manual", 2, "manual latest profile")
+
+	if _, err := db.Exec(ctx, `
+		INSERT INTO skill (id, scope, user_id, agent_id, name, description, status, metadata)
+		VALUES ('ambiguous-skill', 'user_agent', $1, $2, 'ambiguous-skill', 'not proven reflect', 'active', '{"created-at":"2026-07-01T00:00:00Z"}')`,
+		userID, agentReflect); err != nil {
+		t.Fatalf("seed ambiguous skill: %v", err)
+	}
+
+	if _, err := provider.UpTo(ctx, 20260708090000); err != nil {
+		t.Fatalf("goose up reflect provenance backfill: %v", err)
+	}
+
+	assertFactSource := func(id, want string) {
+		t.Helper()
+		var got string
+		if err := db.QueryRow(ctx, `SELECT source FROM facts WHERE id = $1`, id).Scan(&got); err != nil {
+			t.Fatalf("read fact source %s: %v", id, err)
+		}
+		if got != want {
+			t.Fatalf("fact %s source = %q, want %q", id, got, want)
+		}
+	}
+	assertFactSource(reflectProfileFactID, "reflect")
+	assertFactSource(reflectSoulFactID, "reflect")
+	assertFactSource(manualLatestFactID, "manual")
+	assertFactSource(ambiguousFactID, "manual")
+
+	var changelogSource, payloadSource string
+	if err := db.QueryRow(ctx, `
+		SELECT source, after_text::jsonb->>'source'
+		FROM ctx_agent_memory_changelog
+		WHERE scope = 'fact' AND entity_id = $1`,
+		reflectProfileFactID).Scan(&changelogSource, &payloadSource); err != nil {
+		t.Fatalf("read migrated fact changelog source: %v", err)
+	}
+	if changelogSource != "reflect" || payloadSource != "reflect" {
+		t.Fatalf("migrated fact changelog source = %q payload=%q, want reflect/reflect", changelogSource, payloadSource)
+	}
+
+	var skillCreatedBy *string
+	if err := db.QueryRow(ctx, `SELECT metadata->>'created_by' FROM skill WHERE id = 'ambiguous-skill'`).Scan(&skillCreatedBy); err != nil {
+		t.Fatalf("read ambiguous skill metadata: %v", err)
+	}
+	if skillCreatedBy != nil {
+		t.Fatalf("ambiguous skill created_by = %q, want null", *skillCreatedBy)
+	}
+}
+
 func tableExists(t *testing.T, db *pgxpool.Pool, name string) bool {
 	t.Helper()
 

--- a/internal/db/migrations/20260708090000_backfill_reflect_owned_legacy_memory.sql
+++ b/internal/db/migrations/20260708090000_backfill_reflect_owned_legacy_memory.sql
@@ -31,6 +31,7 @@ eligible_facts AS (
      OR (f."subject" = 'agent' AND l."scope" = 'soul')
    )
   WHERE f."source" = 'manual'
+    AND f."status" = 'active'
     AND l."source" = 'reflect'
     AND l."after_text" = f."content"
     AND EXISTS (
@@ -68,18 +69,23 @@ WHERE c."scope" = 'fact'
   AND (c."metadata"::jsonb)->>'migration' = '20260625090000_add_facts_memory';
 
 -- +goose Down
-WITH marked_facts AS (
+-- Roll back only rows that are still active. If Reflect or a manual migration
+-- later superseded/deprecated a backfilled row, keep that later audit history
+-- intact instead of rewriting provenance on an obsolete fact.
+WITH marked_active_facts AS (
   SELECT c."entity_id"
   FROM "ctx_agent_memory_changelog" c
+  JOIN "facts" f ON f."id"::text = c."entity_id"
   WHERE c."scope" = 'fact'
     AND c."metadata" IS NOT NULL
     AND (c."metadata"::jsonb)->>'reflect_provenance_backfill' = '20260708090000_backfill_reflect_owned_legacy_memory'
+    AND f."status" = 'active'
 ),
 reverted_facts AS (
   UPDATE "facts" f
   SET "source" = 'manual',
       "updated_at" = now()
-  FROM marked_facts m
+  FROM marked_active_facts m
   WHERE f."id"::text = m."entity_id"
     AND f."source" = 'reflect'
   RETURNING f."id"

--- a/internal/db/migrations/20260708090000_backfill_reflect_owned_legacy_memory.sql
+++ b/internal/db/migrations/20260708090000_backfill_reflect_owned_legacy_memory.sql
@@ -1,0 +1,97 @@
+-- +goose Up
+-- Backfill only facts that were created by the facts migration from legacy
+-- profile/soul blobs and whose latest legacy identity changelog proves Reflect
+-- was the writer. Migration metadata alone is not provenance.
+WITH latest_legacy_identity AS (
+  SELECT DISTINCT ON ("user_id", "agent_id", "scope")
+    "user_id",
+    "agent_id",
+    "scope",
+    "source",
+    "after_text"
+  FROM "ctx_agent_memory_changelog"
+  WHERE "scope" IN ('profile', 'soul')
+    AND "memory_version_after" IS NOT NULL
+  ORDER BY
+    "user_id",
+    "agent_id",
+    "scope",
+    "memory_version_after" DESC NULLS LAST,
+    "created_at" DESC,
+    "id" DESC
+),
+eligible_facts AS (
+  SELECT f."id"
+  FROM "facts" f
+  JOIN latest_legacy_identity l
+    ON l."user_id" = f."user_id"
+   AND l."agent_id" = f."agent_id"
+   AND (
+     (f."subject" = 'user' AND l."scope" = 'profile')
+     OR (f."subject" = 'agent' AND l."scope" = 'soul')
+   )
+  WHERE f."source" = 'manual'
+    AND l."source" = 'reflect'
+    AND l."after_text" = f."content"
+    AND EXISTS (
+      SELECT 1
+      FROM "ctx_agent_memory_changelog" c
+      WHERE c."scope" = 'fact'
+        AND c."entity_id" = f."id"::text
+        AND c."metadata" IS NOT NULL
+        AND (c."metadata"::jsonb)->>'migration' = '20260625090000_add_facts_memory'
+    )
+),
+updated_facts AS (
+  UPDATE "facts" f
+  SET "source" = 'reflect',
+      "updated_at" = now()
+  FROM eligible_facts e
+  WHERE f."id" = e."id"
+  RETURNING f."id"
+)
+UPDATE "ctx_agent_memory_changelog" c
+SET "source" = 'reflect',
+    "after_text" = CASE
+      WHEN c."after_text" IS NULL THEN NULL
+      ELSE jsonb_set(c."after_text"::jsonb, '{source}', '"reflect"'::jsonb, true)::text
+    END,
+    "metadata" = jsonb_set(
+      COALESCE(c."metadata"::jsonb, '{}'::jsonb),
+      '{reflect_provenance_backfill}',
+      '"20260708090000_backfill_reflect_owned_legacy_memory"'::jsonb,
+      true
+    )::text
+WHERE c."scope" = 'fact'
+  AND c."entity_id" IN (SELECT "id"::text FROM updated_facts)
+  AND c."metadata" IS NOT NULL
+  AND (c."metadata"::jsonb)->>'migration' = '20260625090000_add_facts_memory';
+
+-- +goose Down
+WITH marked_facts AS (
+  SELECT c."entity_id"
+  FROM "ctx_agent_memory_changelog" c
+  WHERE c."scope" = 'fact'
+    AND c."metadata" IS NOT NULL
+    AND (c."metadata"::jsonb)->>'reflect_provenance_backfill' = '20260708090000_backfill_reflect_owned_legacy_memory'
+),
+reverted_facts AS (
+  UPDATE "facts" f
+  SET "source" = 'manual',
+      "updated_at" = now()
+  FROM marked_facts m
+  WHERE f."id"::text = m."entity_id"
+    AND f."source" = 'reflect'
+  RETURNING f."id"
+)
+UPDATE "ctx_agent_memory_changelog" c
+SET "source" = 'manual',
+    "after_text" = CASE
+      WHEN c."after_text" IS NULL THEN NULL
+      ELSE jsonb_set(c."after_text"::jsonb, '{source}', '"manual"'::jsonb, true)::text
+    END,
+    "metadata" = (c."metadata"::jsonb - 'reflect_provenance_backfill')::text
+WHERE c."scope" = 'fact'
+  AND c."entity_id" IN (SELECT "id"::text FROM reverted_facts)
+  AND c."metadata" IS NOT NULL
+  AND (c."metadata"::jsonb)->>'reflect_provenance_backfill' = '20260708090000_backfill_reflect_owned_legacy_memory';


### PR DESCRIPTION
## What
Backfill proven legacy Reflect-owned profile/soul facts so old Reflect-produced singleton facts carry the new source=reflect ownership marker.

## Why
The goal is not to loosen the new Reflect safety boundary. New Reflect should only maintain old records when existing data proves old Reflect produced them.

This PR covers the subset with strong provenance: migrated profile/soul facts whose latest legacy profile/soul changelog row has source=reflect and whose after_text still matches the active migrated fact content. It does not claim to solve world/knowledge facts or legacy skills, because those rows do not currently have enough durable provenance to safely auto-mark as Reflect-owned.

## How
- Add a conservative goose migration for active profile/soul facts created by the facts migration.
- Require latest legacy profile/soul changelog source=reflect.
- Require legacy after_text to exactly match the migrated fact content.
- Require the migrated fact to still be active, so deprecated/superseded audit rows are not relabeled.
- Update the matching migration-created fact changelog row and JSON payload source so audit history stays aligned.
- Leave ambiguous, manual-latest, content-mismatched, deprecated, world/knowledge, and skill rows unchanged.
- The migration is embedded with the normal DB migrations. No one-off manual command is required in normal operation; Stella applies pending migrations when the service opens the database during startup/deploy.
- Add DB migration tests covering Reflect-owned, manual-latest, no-evidence, content-mismatch, and deprecated cases.

## Test Plan
- mise exec -- go test ./internal/db -run TestReflectProvenanceBackfillMarksOnlyLegacyReflectFacts -count=1
- mise run format
- mise exec -- go test ./internal/db -count=1
- mise run db:validate
- git diff --check

## Refs
Refs #679