### PR TITLE
✨ feat(deploy): require external PostgreSQL in containers + deployment URL hardening

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,4 +59,9 @@ COPY --from=builder /go/src/app/dist/bin/stellad /usr/local/bin/stellad
 # an explicit --host so a manifest that overrides `command:` does not silently
 # drop the bind, and lets users override HOST without fighting the flag.
 ENV HOST=0.0.0.0
+# In a container the embedded PostgreSQL cluster would land on an ephemeral
+# filesystem (and split state across replicas), so the image requires an
+# external STELLA_DATABASE_URL by default. Override with =0 to deliberately run
+# embedded PostgreSQL on a persistent volume.
+ENV STELLA_REQUIRE_EXTERNAL_DB=1
 CMD ["stellad", "server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,4 +54,9 @@ WORKDIR /home/stella
 USER stella
 COPY --from=builder /go/src/app/dist/bin/stellad /usr/local/bin/stellad
 
-CMD ["stellad", "server", "--host", "0.0.0.0"]
+# Containers must bind all interfaces to be reachable; the --host flag binds to
+# HOST, so set it via env instead of a hardcoded flag. This keeps the CMD free of
+# an explicit --host so a manifest that overrides `command:` does not silently
+# drop the bind, and lets users override HOST without fighting the flag.
+ENV HOST=0.0.0.0
+CMD ["stellad", "server"]

--- a/cmd/stellad/commands.go
+++ b/cmd/stellad/commands.go
@@ -100,18 +100,19 @@ type setupResult struct {
 }
 
 func setup(parent context.Context, _ bool) (*setupResult, error) {
-	strict, err := config.StrictDeployment()
+	requireExternalDB, err := config.RequireExternalDB()
 	if err != nil {
 		return nil, err
 	}
 	dsn := config.DatabaseURL()
 	var embedded *appdb.Embedded
 	if dsn == "" {
-		if strict {
-			// Managed deployment (k8s etc.): the embedded PostgreSQL cluster is a
-			// single-node local convenience with no HA, backups, or shared state
-			// across replicas, so refuse it rather than silently starting one.
-			return nil, errors.New("STELLA_STRICT_DEPLOYMENT=1 requires STELLA_DATABASE_URL: embedded PostgreSQL is for single-node local use; point STELLA_DATABASE_URL at an external PostgreSQL with pgvector + pg_search")
+		if requireExternalDB {
+			// Set by the Docker image (and k8s manifests): in a container the
+			// embedded cluster lands on an ephemeral filesystem, and with multiple
+			// replicas each process would create its own database — refuse it
+			// rather than silently starting one.
+			return nil, errors.New("STELLA_REQUIRE_EXTERNAL_DB=1 but STELLA_DATABASE_URL is not set: embedded PostgreSQL is for single-node local use; point STELLA_DATABASE_URL at an external PostgreSQL with pgvector + pg_search (or set STELLA_REQUIRE_EXTERNAL_DB=0 to deliberately run embedded PostgreSQL on a persistent volume)")
 		}
 		// Zero-config default: no external DSN, so run a managed PostgreSQL whose
 		// cluster lives under the stella home and persists across restarts.

--- a/cmd/stellad/commands.go
+++ b/cmd/stellad/commands.go
@@ -100,9 +100,19 @@ type setupResult struct {
 }
 
 func setup(parent context.Context, _ bool) (*setupResult, error) {
+	strict, err := config.StrictDeployment()
+	if err != nil {
+		return nil, err
+	}
 	dsn := config.DatabaseURL()
 	var embedded *appdb.Embedded
 	if dsn == "" {
+		if strict {
+			// Managed deployment (k8s etc.): the embedded PostgreSQL cluster is a
+			// single-node local convenience with no HA, backups, or shared state
+			// across replicas, so refuse it rather than silently starting one.
+			return nil, errors.New("STELLA_STRICT_DEPLOYMENT=1 requires STELLA_DATABASE_URL: embedded PostgreSQL is for single-node local use; point STELLA_DATABASE_URL at an external PostgreSQL with pgvector + pg_search")
+		}
 		// Zero-config default: no external DSN, so run a managed PostgreSQL whose
 		// cluster lives under the stella home and persists across restarts.
 		emb, err := appdb.StartEmbedded(filepath.Join(config.StellaHome(), "postgres"), 0)

--- a/cmd/stellad/gateway.go
+++ b/cmd/stellad/gateway.go
@@ -136,9 +136,7 @@ func serverAction(c *ucli.Context) error {
 func runServer(ctx context.Context, s *setupResult, listFn func() []pkgchannel.ModelOption, switchFn func(string, string) error, adminHost string, adminPort int) error {
 	g, gctx := errgroup.WithContext(ctx)
 
-	if err := checkDeploymentBaseURL(resolveBaseURL(adminHost, adminPort)); err != nil {
-		return err
-	}
+	warnDeploymentBaseURL(resolveBaseURL(adminHost, adminPort))
 
 	// Seed default data (channels, providers, default agent) if absent.
 	if err := s.store.Seed(gctx); err != nil {
@@ -416,35 +414,23 @@ func resolveBaseURL(adminHost string, adminPort int) string {
 	return adminBaseURL(adminHost, adminPort)
 }
 
-// checkDeploymentBaseURL guards the canonical base URL used for OAuth callbacks
-// and channel deep links. When STELLA_BASE_URL is unset the URL is derived from
-// the bind host, so a default (loopback) bind yields a base URL that points back
-// at this pod and is useless off-box. In strict deployment mode that is a hard
-// failure unless STELLA_ALLOW_UNSAFE_BASE_URL overrides it; outside strict mode
-// it is only a warning, and only when a link-dependent feature is configured.
-func checkDeploymentBaseURL(baseURL string) error {
+// warnDeploymentBaseURL warns when the canonical base URL used for OAuth
+// callbacks and channel deep links cannot work off-box. When STELLA_BASE_URL is
+// unset the URL is derived from the bind host, so a default (loopback) bind
+// yields a base URL that points back at this machine. That is legitimate in
+// every deployment shape (local browser, docker port publish, kubectl
+// port-forward) and its failure mode is immediately visible in the login
+// redirect — so this warns loudly instead of failing, and only when a feature
+// that emits such links is actually configured. Kubernetes charts enforce
+// STELLA_BASE_URL as a required value at the layer that knows it is behind an
+// ingress.
+func warnDeploymentBaseURL(baseURL string) {
 	if !baseURLUnsafe(baseURL) {
-		return nil
-	}
-	strict, err := config.StrictDeployment()
-	if err != nil {
-		return err
-	}
-	if strict {
-		allow, err := config.AllowUnsafeBaseURL()
-		if err != nil {
-			return err
-		}
-		if !allow {
-			return fmt.Errorf("STELLA_STRICT_DEPLOYMENT=1 requires a public STELLA_BASE_URL: %q is loopback/unspecified, so OAuth callbacks and channel links would point back at this pod; set STELLA_BASE_URL to the public URL clients use (or STELLA_ALLOW_UNSAFE_BASE_URL=1 to override)", baseURL)
-		}
-		slog.Warn("STELLA_BASE_URL is loopback/unspecified but STELLA_ALLOW_UNSAFE_BASE_URL=1 is set; OAuth callbacks and channel deep links will point back at this pod and fail off-box", "base_url", baseURL)
-		return nil
+		return
 	}
 	if linkDependentFeaturesConfigured() {
 		slog.Warn("STELLA_BASE_URL is loopback/unspecified; OAuth callbacks and channel deep links will point back at this host and fail off-box. Set STELLA_BASE_URL to the public URL clients use", "base_url", baseURL)
 	}
-	return nil
 }
 
 // baseURLUnsafe reports whether a base URL cannot serve as a public canonical

--- a/cmd/stellad/gateway.go
+++ b/cmd/stellad/gateway.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"strings"
@@ -134,6 +135,10 @@ func serverAction(c *ucli.Context) error {
 
 func runServer(ctx context.Context, s *setupResult, listFn func() []pkgchannel.ModelOption, switchFn func(string, string) error, adminHost string, adminPort int) error {
 	g, gctx := errgroup.WithContext(ctx)
+
+	if err := checkDeploymentBaseURL(resolveBaseURL(adminHost, adminPort)); err != nil {
+		return err
+	}
 
 	// Seed default data (channels, providers, default agent) if absent.
 	if err := s.store.Seed(gctx); err != nil {
@@ -409,6 +414,69 @@ func resolveBaseURL(adminHost string, adminPort int) string {
 		return strings.TrimRight(v, "/")
 	}
 	return adminBaseURL(adminHost, adminPort)
+}
+
+// checkDeploymentBaseURL guards the canonical base URL used for OAuth callbacks
+// and channel deep links. When STELLA_BASE_URL is unset the URL is derived from
+// the bind host, so a default (loopback) bind yields a base URL that points back
+// at this pod and is useless off-box. In strict deployment mode that is a hard
+// failure unless STELLA_ALLOW_UNSAFE_BASE_URL overrides it; outside strict mode
+// it is only a warning, and only when a link-dependent feature is configured.
+func checkDeploymentBaseURL(baseURL string) error {
+	if !baseURLUnsafe(baseURL) {
+		return nil
+	}
+	strict, err := config.StrictDeployment()
+	if err != nil {
+		return err
+	}
+	if strict {
+		allow, err := config.AllowUnsafeBaseURL()
+		if err != nil {
+			return err
+		}
+		if !allow {
+			return fmt.Errorf("STELLA_STRICT_DEPLOYMENT=1 requires a public STELLA_BASE_URL: %q is loopback/unspecified, so OAuth callbacks and channel links would point back at this pod; set STELLA_BASE_URL to the public URL clients use (or STELLA_ALLOW_UNSAFE_BASE_URL=1 to override)", baseURL)
+		}
+		slog.Warn("STELLA_BASE_URL is loopback/unspecified but STELLA_ALLOW_UNSAFE_BASE_URL=1 is set; OAuth callbacks and channel deep links will point back at this pod and fail off-box", "base_url", baseURL)
+		return nil
+	}
+	if linkDependentFeaturesConfigured() {
+		slog.Warn("STELLA_BASE_URL is loopback/unspecified; OAuth callbacks and channel deep links will point back at this host and fail off-box. Set STELLA_BASE_URL to the public URL clients use", "base_url", baseURL)
+	}
+	return nil
+}
+
+// baseURLUnsafe reports whether a base URL cannot serve as a public canonical
+// address: it fails to parse, is not http(s), or resolves to a loopback,
+// unspecified, or localhost host.
+func baseURLUnsafe(raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return true
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return true
+	}
+	host := u.Hostname()
+	if host == "" {
+		return true
+	}
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback() || ip.IsUnspecified()
+	}
+	return false
+}
+
+// linkDependentFeaturesConfigured reports whether a feature that emits absolute
+// links back to this server (external OIDC or an OAuth login provider) is
+// configured, reusing the auth package's existing env probes rather than
+// enumerating channels from the database.
+func linkDependentFeaturesConfigured() bool {
+	return os.Getenv("OIDC_ISSUER_URL") != "" || oidc.OAuthConfiguredFromEnv()
 }
 
 func adminURLForDisplay(host string, port int, fallbackAddr string) string {

--- a/cmd/stellad/gateway_test.go
+++ b/cmd/stellad/gateway_test.go
@@ -30,33 +30,3 @@ func TestBaseURLUnsafe(t *testing.T) {
 		})
 	}
 }
-
-func TestCheckDeploymentBaseURL(t *testing.T) {
-	cases := []struct {
-		name    string
-		url     string
-		strict  string
-		allow   string
-		wantErr bool
-	}{
-		{"safe url passes regardless", "https://stella.example.com", "1", "", false},
-		{"unsafe non-strict warns only", "http://127.0.0.1:25678", "", "", false},
-		{"unsafe strict fails", "http://127.0.0.1:25678", "1", "", true},
-		{"unsafe strict with override passes", "http://127.0.0.1:25678", "1", "1", false},
-		{"strict parse error surfaces", "http://127.0.0.1:25678", "maybe", "", true},
-		{"override parse error surfaces", "http://127.0.0.1:25678", "1", "maybe", true},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("STELLA_STRICT_DEPLOYMENT", tc.strict)
-			t.Setenv("STELLA_ALLOW_UNSAFE_BASE_URL", tc.allow)
-			err := checkDeploymentBaseURL(tc.url)
-			if tc.wantErr && err == nil {
-				t.Fatalf("checkDeploymentBaseURL(%q) = nil, want error", tc.url)
-			}
-			if !tc.wantErr && err != nil {
-				t.Fatalf("checkDeploymentBaseURL(%q) unexpected error: %v", tc.url, err)
-			}
-		})
-	}
-}

--- a/cmd/stellad/gateway_test.go
+++ b/cmd/stellad/gateway_test.go
@@ -1,0 +1,62 @@
+package main
+
+import "testing"
+
+func TestBaseURLUnsafe(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{"public https", "https://stella.example.com", false},
+		{"public http with port", "http://stella.example.com:8080", false},
+		{"public ip", "http://203.0.113.7:25678", false},
+		{"loopback ipv4", "http://127.0.0.1:25678", true},
+		{"loopback ipv4 range", "http://127.0.0.53:25678", true},
+		{"loopback ipv6", "http://[::1]:25678", true},
+		{"localhost", "http://localhost:25678", true},
+		{"localhost uppercase", "http://LOCALHOST:25678", true},
+		{"unspecified ipv4", "http://0.0.0.0:25678", true},
+		{"unspecified ipv6", "http://[::]:25678", true},
+		{"non-http scheme", "ftp://stella.example.com", true},
+		{"missing scheme", "stella.example.com", true},
+		{"empty", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := baseURLUnsafe(tc.url); got != tc.want {
+				t.Errorf("baseURLUnsafe(%q) = %v, want %v", tc.url, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCheckDeploymentBaseURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		url     string
+		strict  string
+		allow   string
+		wantErr bool
+	}{
+		{"safe url passes regardless", "https://stella.example.com", "1", "", false},
+		{"unsafe non-strict warns only", "http://127.0.0.1:25678", "", "", false},
+		{"unsafe strict fails", "http://127.0.0.1:25678", "1", "", true},
+		{"unsafe strict with override passes", "http://127.0.0.1:25678", "1", "1", false},
+		{"strict parse error surfaces", "http://127.0.0.1:25678", "maybe", "", true},
+		{"override parse error surfaces", "http://127.0.0.1:25678", "1", "maybe", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("STELLA_STRICT_DEPLOYMENT", tc.strict)
+			t.Setenv("STELLA_ALLOW_UNSAFE_BASE_URL", tc.allow)
+			err := checkDeploymentBaseURL(tc.url)
+			if tc.wantErr && err == nil {
+				t.Fatalf("checkDeploymentBaseURL(%q) = nil, want error", tc.url)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("checkDeploymentBaseURL(%q) unexpected error: %v", tc.url, err)
+			}
+		})
+	}
+}

--- a/internal/config/deployment.go
+++ b/internal/config/deployment.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// strictDeploymentEnv marks a managed deployment (Kubernetes and similar
+// orchestrators) where the single-node local conveniences are unsafe. When set
+// to a truthy value the server refuses fallbacks meant for local use: it
+// requires an external PostgreSQL via STELLA_DATABASE_URL instead of the
+// embedded cluster, and it requires an explicit, non-loopback STELLA_BASE_URL
+// so OAuth callbacks and channel deep links point at a reachable address.
+const strictDeploymentEnv = "STELLA_STRICT_DEPLOYMENT"
+
+// allowUnsafeBaseURLEnv opts out of the strict base-URL check: it lets a managed
+// deployment start with a loopback or otherwise unsafe STELLA_BASE_URL,
+// downgrading the hard failure to a loud warning. Use it only when link-out
+// features (OAuth callbacks, channel deep links) are known to be unused.
+const allowUnsafeBaseURLEnv = "STELLA_ALLOW_UNSAFE_BASE_URL"
+
+// StrictDeployment reports whether STELLA_STRICT_DEPLOYMENT requests managed
+// deployment mode. Unset or empty is false. Any other value is parsed as a
+// boolean; an unparseable value returns an actionable error instead of being
+// silently ignored, so a typo fails fast rather than quietly disabling the
+// guard.
+func StrictDeployment() (bool, error) {
+	return parseBoolEnv(strictDeploymentEnv)
+}
+
+// AllowUnsafeBaseURL reports whether STELLA_ALLOW_UNSAFE_BASE_URL permits an
+// unsafe base URL in strict deployment mode. Same parsing rules as
+// StrictDeployment.
+func AllowUnsafeBaseURL() (bool, error) {
+	return parseBoolEnv(allowUnsafeBaseURLEnv)
+}
+
+func parseBoolEnv(name string) (bool, error) {
+	v := strings.TrimSpace(os.Getenv(name))
+	if v == "" {
+		return false, nil
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return false, fmt.Errorf("%s=%q is not a boolean: set it to 1/true or 0/false", name, v)
+	}
+	return b, nil
+}

--- a/internal/config/deployment.go
+++ b/internal/config/deployment.go
@@ -7,34 +7,22 @@ import (
 	"strings"
 )
 
-// strictDeploymentEnv marks a managed deployment (Kubernetes and similar
-// orchestrators) where the single-node local conveniences are unsafe. When set
-// to a truthy value the server refuses fallbacks meant for local use: it
-// requires an external PostgreSQL via STELLA_DATABASE_URL instead of the
-// embedded cluster, and it requires an explicit, non-loopback STELLA_BASE_URL
-// so OAuth callbacks and channel deep links point at a reachable address.
-const strictDeploymentEnv = "STELLA_STRICT_DEPLOYMENT"
+// requireExternalDBEnv makes an empty STELLA_DATABASE_URL a startup error
+// instead of silently starting the embedded PostgreSQL cluster. The embedded
+// cluster is a single-node local convenience: in a container it lands on an
+// ephemeral filesystem, and with multiple replicas each process would create
+// its own database. The Docker image sets this by default; set it to 0 to
+// deliberately run embedded PostgreSQL inside a container (e.g. a single
+// container with a persistent volume).
+const requireExternalDBEnv = "STELLA_REQUIRE_EXTERNAL_DB"
 
-// allowUnsafeBaseURLEnv opts out of the strict base-URL check: it lets a managed
-// deployment start with a loopback or otherwise unsafe STELLA_BASE_URL,
-// downgrading the hard failure to a loud warning. Use it only when link-out
-// features (OAuth callbacks, channel deep links) are known to be unused.
-const allowUnsafeBaseURLEnv = "STELLA_ALLOW_UNSAFE_BASE_URL"
-
-// StrictDeployment reports whether STELLA_STRICT_DEPLOYMENT requests managed
-// deployment mode. Unset or empty is false. Any other value is parsed as a
-// boolean; an unparseable value returns an actionable error instead of being
-// silently ignored, so a typo fails fast rather than quietly disabling the
-// guard.
-func StrictDeployment() (bool, error) {
-	return parseBoolEnv(strictDeploymentEnv)
-}
-
-// AllowUnsafeBaseURL reports whether STELLA_ALLOW_UNSAFE_BASE_URL permits an
-// unsafe base URL in strict deployment mode. Same parsing rules as
-// StrictDeployment.
-func AllowUnsafeBaseURL() (bool, error) {
-	return parseBoolEnv(allowUnsafeBaseURLEnv)
+// RequireExternalDB reports whether STELLA_REQUIRE_EXTERNAL_DB forbids the
+// embedded-PostgreSQL fallback. Unset or empty is false. Any other value is
+// parsed as a boolean; an unparseable value returns an actionable error instead
+// of being silently ignored, so a typo fails fast rather than quietly disabling
+// the guard.
+func RequireExternalDB() (bool, error) {
+	return parseBoolEnv(requireExternalDBEnv)
 }
 
 func parseBoolEnv(name string) (bool, error) {

--- a/internal/config/deployment_test.go
+++ b/internal/config/deployment_test.go
@@ -1,0 +1,83 @@
+package config
+
+import "testing"
+
+func TestStrictDeployment(t *testing.T) {
+	cases := []struct {
+		name    string
+		value   string
+		set     bool
+		want    bool
+		wantErr bool
+	}{
+		{name: "unset", set: false, want: false},
+		{name: "empty", value: "", set: true, want: false},
+		{name: "one", value: "1", set: true, want: true},
+		{name: "true", value: "true", set: true, want: true},
+		{name: "zero", value: "0", set: true, want: false},
+		{name: "false", value: "false", set: true, want: false},
+		{name: "garbage", value: "yes", set: true, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv("STELLA_STRICT_DEPLOYMENT", tc.value)
+			} else {
+				t.Setenv("STELLA_STRICT_DEPLOYMENT", "")
+			}
+			got, err := StrictDeployment()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("StrictDeployment() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("StrictDeployment() unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("StrictDeployment() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAllowUnsafeBaseURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		value   string
+		set     bool
+		want    bool
+		wantErr bool
+	}{
+		{name: "unset", set: false, want: false},
+		{name: "empty", value: "", set: true, want: false},
+		{name: "one", value: "1", set: true, want: true},
+		{name: "true", value: "true", set: true, want: true},
+		{name: "zero", value: "0", set: true, want: false},
+		{name: "false", value: "false", set: true, want: false},
+		{name: "garbage", value: "nope", set: true, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv("STELLA_ALLOW_UNSAFE_BASE_URL", tc.value)
+			} else {
+				t.Setenv("STELLA_ALLOW_UNSAFE_BASE_URL", "")
+			}
+			got, err := AllowUnsafeBaseURL()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("AllowUnsafeBaseURL() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("AllowUnsafeBaseURL() unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("AllowUnsafeBaseURL() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/config/deployment_test.go
+++ b/internal/config/deployment_test.go
@@ -2,7 +2,7 @@ package config
 
 import "testing"
 
-func TestStrictDeployment(t *testing.T) {
+func TestRequireExternalDB(t *testing.T) {
 	cases := []struct {
 		name    string
 		value   string
@@ -21,62 +21,22 @@ func TestStrictDeployment(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.set {
-				t.Setenv("STELLA_STRICT_DEPLOYMENT", tc.value)
+				t.Setenv("STELLA_REQUIRE_EXTERNAL_DB", tc.value)
 			} else {
-				t.Setenv("STELLA_STRICT_DEPLOYMENT", "")
+				t.Setenv("STELLA_REQUIRE_EXTERNAL_DB", "")
 			}
-			got, err := StrictDeployment()
+			got, err := RequireExternalDB()
 			if tc.wantErr {
 				if err == nil {
-					t.Fatalf("StrictDeployment() error = nil, want error")
+					t.Fatalf("RequireExternalDB() error = nil, want error")
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("StrictDeployment() unexpected error: %v", err)
+				t.Fatalf("RequireExternalDB() unexpected error: %v", err)
 			}
 			if got != tc.want {
-				t.Errorf("StrictDeployment() = %v, want %v", got, tc.want)
-			}
-		})
-	}
-}
-
-func TestAllowUnsafeBaseURL(t *testing.T) {
-	cases := []struct {
-		name    string
-		value   string
-		set     bool
-		want    bool
-		wantErr bool
-	}{
-		{name: "unset", set: false, want: false},
-		{name: "empty", value: "", set: true, want: false},
-		{name: "one", value: "1", set: true, want: true},
-		{name: "true", value: "true", set: true, want: true},
-		{name: "zero", value: "0", set: true, want: false},
-		{name: "false", value: "false", set: true, want: false},
-		{name: "garbage", value: "nope", set: true, wantErr: true},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if tc.set {
-				t.Setenv("STELLA_ALLOW_UNSAFE_BASE_URL", tc.value)
-			} else {
-				t.Setenv("STELLA_ALLOW_UNSAFE_BASE_URL", "")
-			}
-			got, err := AllowUnsafeBaseURL()
-			if tc.wantErr {
-				if err == nil {
-					t.Fatalf("AllowUnsafeBaseURL() error = nil, want error")
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("AllowUnsafeBaseURL() unexpected error: %v", err)
-			}
-			if got != tc.want {
-				t.Errorf("AllowUnsafeBaseURL() = %v, want %v", got, tc.want)
+				t.Errorf("RequireExternalDB() = %v, want %v", got, tc.want)
 			}
 		})
 	}

--- a/web/content/docs/start-here/deployment.md
+++ b/web/content/docs/start-here/deployment.md
@@ -208,7 +208,7 @@ docker buildx build --platform linux/amd64,linux/arm64 -t stella .
 
 ## Managed Deployment
 
-When you run Stella under an orchestrator (Kubernetes and similar), two things that are convenient locally become traps: the embedded single-node database and a base URL that points back at the pod. Set `STELLA_STRICT_DEPLOYMENT=1` to turn those traps into fast, actionable startup errors.
+When you run Stella under an orchestrator (Kubernetes and similar), two things that are convenient locally become traps: the embedded single-node database and a base URL that points back at the pod. The Docker image refuses the first by default (`STELLA_REQUIRE_EXTERNAL_DB=1`), and Stella warns loudly about the second.
 
 ### The three URL roles
 
@@ -222,23 +222,20 @@ Stella uses three distinct addresses. Keep them separate:
 
 Binding to `0.0.0.0` (`HOST`) does **not** give you a public URL: with `STELLA_BASE_URL` unset, the base URL is derived from the bind host and still resolves to loopback. Always set `STELLA_BASE_URL` explicitly in a managed deployment.
 
-### Strict deployment mode
+### External database requirement
 
-`STELLA_STRICT_DEPLOYMENT=1` refuses local-only fallbacks:
+The Docker image sets `STELLA_REQUIRE_EXTERNAL_DB=1`: startup fails with an actionable error when `STELLA_DATABASE_URL` is unset, instead of silently starting the embedded PostgreSQL cluster on the container's ephemeral filesystem — with multiple replicas, each pod would even create its own database. Point `STELLA_DATABASE_URL` at an external PostgreSQL with `pgvector` and `pg_search`. To deliberately run embedded PostgreSQL in a single container backed by a persistent volume, set `STELLA_REQUIRE_EXTERNAL_DB=0`.
 
-- The server will not start its embedded PostgreSQL. You must set `STELLA_DATABASE_URL` to an external PostgreSQL with `pgvector` and `pg_search`.
-- The server will not start with a loopback or unspecified `STELLA_BASE_URL`. Set it to the public URL clients use.
-
-If you have deliberately configured a deployment with no link-out features (no OAuth login, no channel deep links) and accept a loopback base URL, set `STELLA_ALLOW_UNSAFE_BASE_URL=1` to downgrade the base-URL failure to a warning. Outside strict mode Stella only warns about a loopback base URL when a link-dependent feature is configured.
+A loopback base URL is never a startup error — it is legitimate when you reach Stella via `localhost` or `kubectl port-forward` — but Stella logs a loud warning when OAuth/OIDC login is configured against one, because login redirects would point back at the pod. Deployment charts should make `STELLA_BASE_URL` a required value; that layer knows it sits behind an ingress.
 
 ### Required environment for a managed deployment
 
-| Variable                   | Value                                                                |
-| -------------------------- | -------------------------------------------------------------------- |
-| `STELLA_DATABASE_URL`      | External PostgreSQL DSN with `pgvector` + `pg_search`                |
-| `STELLA_VAULT_KEY`         | age secret key for the vault (generate with `stellad vault keygen`)  |
-| `STELLA_BASE_URL`          | Public canonical URL clients use (e.g. `https://stella.example.com`) |
-| `STELLA_STRICT_DEPLOYMENT` | `1` — fail fast if a local-only fallback would otherwise be used     |
+| Variable                     | Value                                                                                    |
+| ---------------------------- | ---------------------------------------------------------------------------------------- |
+| `STELLA_DATABASE_URL`        | External PostgreSQL DSN with `pgvector` + `pg_search`                                    |
+| `STELLA_VAULT_KEY`           | age secret key for the vault (generate with `stellad vault keygen`)                      |
+| `STELLA_BASE_URL`            | Public canonical URL clients use (e.g. `https://stella.example.com`)                     |
+| `STELLA_REQUIRE_EXTERNAL_DB` | `1` — already set by the Docker image; fail fast instead of starting embedded PostgreSQL |
 
 A full Kubernetes manifest walkthrough is out of scope here.
 
@@ -266,25 +263,24 @@ For a full breakdown of which directories are durable data, derived cache, or sc
 
 Configuration is managed through the Web UI (default `http://localhost:25678`; use `--port` to change). `HOST` and `PORT` are supported for binding the server, and only a small set of other environment variables is supported:
 
-| Variable                       | Required                  | Description                                                                                                                         |
-| ------------------------------ | ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `STELLA_HOME`                  | No                        | Stella home directory (default `~/.stella`)                                                                                         |
-| `STELLA_DATABASE_URL`          | Docker: yes; otherwise no | External PostgreSQL connection URL; unset uses the embedded cluster under `STELLA_HOME` outside Docker                              |
-| `STELLA_BASE_URL`              | No¶                       | Public canonical URL for OAuth callbacks and channel deep links; unset derives from the bind host (loopback)                        |
-| `STELLA_STRICT_DEPLOYMENT`     | No                        | Set `1` for managed deployments: requires `STELLA_DATABASE_URL` and a non-loopback `STELLA_BASE_URL`, refusing local-only fallbacks |
-| `STELLA_ALLOW_UNSAFE_BASE_URL` | No                        | Set `1` to allow a loopback `STELLA_BASE_URL` under `STELLA_STRICT_DEPLOYMENT` (downgrades the failure to a warning)                |
-| `STELLA_BLOB_S3_ENDPOINT`      | No§                       | S3-compatible endpoint for the durable user-asset mirror                                                                            |
-| `STELLA_BLOB_S3_BUCKET`        | No§                       | Bucket for mirrored user-uploaded assets                                                                                            |
-| `STELLA_BLOB_S3_ACCESS_KEY`    | No§                       | Access key for the asset mirror                                                                                                     |
-| `STELLA_BLOB_S3_SECRET_KEY`    | No§                       | Secret key for the asset mirror                                                                                                     |
-| `STELLA_BLOB_S3_REGION`        | No                        | Optional S3 region                                                                                                                  |
-| `STELLA_BLOB_S3_USE_SSL`       | No                        | Use HTTPS for S3-compatible storage; defaults to `true`                                                                             |
-| `ANTHROPIC_API_KEY`            | Yes\*                     | Anthropic provider key                                                                                                              |
-| `OPENAI_API_KEY`               | Yes\*                     | OpenAI provider key                                                                                                                 |
-| `STELLA_VAULT_KEY`             | Yes†                      | age secret key for the vault — required for secrets, OAuth, and bearer tokens                                                       |
-| `STELLA_DOCKER_SANDBOX_MODE`   | No‡                       | Required only for the `docker` sandbox backend: `host`, `bind`, or `volume`                                                         |
-| `STELLA_HOME_HOST`             | No‡                       | Host-side path backing `STELLA_HOME` — required only when `STELLA_DOCKER_SANDBOX_MODE=bind`                                         |
-| `STELLA_HOME_VOLUME`           | No‡                       | Docker named volume backing `STELLA_HOME` — required only when `STELLA_DOCKER_SANDBOX_MODE=volume`                                  |
+| Variable                     | Required                  | Description                                                                                                                                                                   |
+| ---------------------------- | ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `STELLA_HOME`                | No                        | Stella home directory (default `~/.stella`)                                                                                                                                   |
+| `STELLA_DATABASE_URL`        | Docker: yes; otherwise no | External PostgreSQL connection URL; unset uses the embedded cluster under `STELLA_HOME` outside Docker                                                                        |
+| `STELLA_BASE_URL`            | No¶                       | Public canonical URL for OAuth callbacks and channel deep links; unset derives from the bind host (loopback)                                                                  |
+| `STELLA_REQUIRE_EXTERNAL_DB` | No                        | Fail startup when `STELLA_DATABASE_URL` is unset instead of starting embedded PostgreSQL; the Docker image sets `1`, override with `0` for embedded PG on a persistent volume |
+| `STELLA_BLOB_S3_ENDPOINT`    | No§                       | S3-compatible endpoint for the durable user-asset mirror                                                                                                                      |
+| `STELLA_BLOB_S3_BUCKET`      | No§                       | Bucket for mirrored user-uploaded assets                                                                                                                                      |
+| `STELLA_BLOB_S3_ACCESS_KEY`  | No§                       | Access key for the asset mirror                                                                                                                                               |
+| `STELLA_BLOB_S3_SECRET_KEY`  | No§                       | Secret key for the asset mirror                                                                                                                                               |
+| `STELLA_BLOB_S3_REGION`      | No                        | Optional S3 region                                                                                                                                                            |
+| `STELLA_BLOB_S3_USE_SSL`     | No                        | Use HTTPS for S3-compatible storage; defaults to `true`                                                                                                                       |
+| `ANTHROPIC_API_KEY`          | Yes\*                     | Anthropic provider key                                                                                                                                                        |
+| `OPENAI_API_KEY`             | Yes\*                     | OpenAI provider key                                                                                                                                                           |
+| `STELLA_VAULT_KEY`           | Yes†                      | age secret key for the vault — required for secrets, OAuth, and bearer tokens                                                                                                 |
+| `STELLA_DOCKER_SANDBOX_MODE` | No‡                       | Required only for the `docker` sandbox backend: `host`, `bind`, or `volume`                                                                                                   |
+| `STELLA_HOME_HOST`           | No‡                       | Host-side path backing `STELLA_HOME` — required only when `STELLA_DOCKER_SANDBOX_MODE=bind`                                                                                   |
+| `STELLA_HOME_VOLUME`         | No‡                       | Docker named volume backing `STELLA_HOME` — required only when `STELLA_DOCKER_SANDBOX_MODE=volume`                                                                            |
 
 \* At least one provider key is required. API keys can also be configured via the Web UI.
 

--- a/web/content/docs/start-here/deployment.md
+++ b/web/content/docs/start-here/deployment.md
@@ -206,6 +206,42 @@ docker build -t stella .
 docker buildx build --platform linux/amd64,linux/arm64 -t stella .
 ```
 
+## Managed Deployment
+
+When you run Stella under an orchestrator (Kubernetes and similar), two things that are convenient locally become traps: the embedded single-node database and a base URL that points back at the pod. Set `STELLA_STRICT_DEPLOYMENT=1` to turn those traps into fast, actionable startup errors.
+
+### The three URL roles
+
+Stella uses three distinct addresses. Keep them separate:
+
+| Variable            | Role                                                                                                                                                                     |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `HOST`              | The interface the server binds to. Use `0.0.0.0` in a container so the pod is reachable; defaults to `127.0.0.1`.                                                        |
+| `STELLA_SERVER_URL` | The address the CLI and in-process callers use to reach the local server. Pod-local; defaults to `http://127.0.0.1:25678`.                                               |
+| `STELLA_BASE_URL`   | The public, canonical URL clients see. It is the source for OAuth callback URLs and channel deep links, so it must be the externally reachable address — not a loopback. |
+
+Binding to `0.0.0.0` (`HOST`) does **not** give you a public URL: with `STELLA_BASE_URL` unset, the base URL is derived from the bind host and still resolves to loopback. Always set `STELLA_BASE_URL` explicitly in a managed deployment.
+
+### Strict deployment mode
+
+`STELLA_STRICT_DEPLOYMENT=1` refuses local-only fallbacks:
+
+- The server will not start its embedded PostgreSQL. You must set `STELLA_DATABASE_URL` to an external PostgreSQL with `pgvector` and `pg_search`.
+- The server will not start with a loopback or unspecified `STELLA_BASE_URL`. Set it to the public URL clients use.
+
+If you have deliberately configured a deployment with no link-out features (no OAuth login, no channel deep links) and accept a loopback base URL, set `STELLA_ALLOW_UNSAFE_BASE_URL=1` to downgrade the base-URL failure to a warning. Outside strict mode Stella only warns about a loopback base URL when a link-dependent feature is configured.
+
+### Required environment for a managed deployment
+
+| Variable                   | Value                                                                |
+| -------------------------- | -------------------------------------------------------------------- |
+| `STELLA_DATABASE_URL`      | External PostgreSQL DSN with `pgvector` + `pg_search`                |
+| `STELLA_VAULT_KEY`         | age secret key for the vault (generate with `stellad vault keygen`)  |
+| `STELLA_BASE_URL`          | Public canonical URL clients use (e.g. `https://stella.example.com`) |
+| `STELLA_STRICT_DEPLOYMENT` | `1` — fail fast if a local-only fallback would otherwise be used     |
+
+A full Kubernetes manifest walkthrough is out of scope here.
+
 ## Sandbox Backends
 
 Running Stella inside a Docker container (described above) is separate from using Docker as a sandbox backend for agent tool execution. Stella supports three sandbox backends: `docker`, `local`, and `none`. See the [Sandbox guide](/docs/guides/sandbox) for how to choose a backend, configure Docker sandbox modes, and troubleshoot common issues.
@@ -230,22 +266,25 @@ For a full breakdown of which directories are durable data, derived cache, or sc
 
 Configuration is managed through the Web UI (default `http://localhost:25678`; use `--port` to change). `HOST` and `PORT` are supported for binding the server, and only a small set of other environment variables is supported:
 
-| Variable                     | Required                  | Description                                                                                            |
-| ---------------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `STELLA_HOME`                | No                        | Stella home directory (default `~/.stella`)                                                            |
-| `STELLA_DATABASE_URL`        | Docker: yes; otherwise no | External PostgreSQL connection URL; unset uses the embedded cluster under `STELLA_HOME` outside Docker |
-| `STELLA_BLOB_S3_ENDPOINT`    | No§                       | S3-compatible endpoint for the durable user-asset mirror                                               |
-| `STELLA_BLOB_S3_BUCKET`      | No§                       | Bucket for mirrored user-uploaded assets                                                               |
-| `STELLA_BLOB_S3_ACCESS_KEY`  | No§                       | Access key for the asset mirror                                                                        |
-| `STELLA_BLOB_S3_SECRET_KEY`  | No§                       | Secret key for the asset mirror                                                                        |
-| `STELLA_BLOB_S3_REGION`      | No                        | Optional S3 region                                                                                     |
-| `STELLA_BLOB_S3_USE_SSL`     | No                        | Use HTTPS for S3-compatible storage; defaults to `true`                                                |
-| `ANTHROPIC_API_KEY`          | Yes\*                     | Anthropic provider key                                                                                 |
-| `OPENAI_API_KEY`             | Yes\*                     | OpenAI provider key                                                                                    |
-| `STELLA_VAULT_KEY`           | Yes†                      | age secret key for the vault — required for secrets, OAuth, and bearer tokens                          |
-| `STELLA_DOCKER_SANDBOX_MODE` | No‡                       | Required only for the `docker` sandbox backend: `host`, `bind`, or `volume`                            |
-| `STELLA_HOME_HOST`           | No‡                       | Host-side path backing `STELLA_HOME` — required only when `STELLA_DOCKER_SANDBOX_MODE=bind`            |
-| `STELLA_HOME_VOLUME`         | No‡                       | Docker named volume backing `STELLA_HOME` — required only when `STELLA_DOCKER_SANDBOX_MODE=volume`     |
+| Variable                       | Required                  | Description                                                                                                                         |
+| ------------------------------ | ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `STELLA_HOME`                  | No                        | Stella home directory (default `~/.stella`)                                                                                         |
+| `STELLA_DATABASE_URL`          | Docker: yes; otherwise no | External PostgreSQL connection URL; unset uses the embedded cluster under `STELLA_HOME` outside Docker                              |
+| `STELLA_BASE_URL`              | No¶                       | Public canonical URL for OAuth callbacks and channel deep links; unset derives from the bind host (loopback)                        |
+| `STELLA_STRICT_DEPLOYMENT`     | No                        | Set `1` for managed deployments: requires `STELLA_DATABASE_URL` and a non-loopback `STELLA_BASE_URL`, refusing local-only fallbacks |
+| `STELLA_ALLOW_UNSAFE_BASE_URL` | No                        | Set `1` to allow a loopback `STELLA_BASE_URL` under `STELLA_STRICT_DEPLOYMENT` (downgrades the failure to a warning)                |
+| `STELLA_BLOB_S3_ENDPOINT`      | No§                       | S3-compatible endpoint for the durable user-asset mirror                                                                            |
+| `STELLA_BLOB_S3_BUCKET`        | No§                       | Bucket for mirrored user-uploaded assets                                                                                            |
+| `STELLA_BLOB_S3_ACCESS_KEY`    | No§                       | Access key for the asset mirror                                                                                                     |
+| `STELLA_BLOB_S3_SECRET_KEY`    | No§                       | Secret key for the asset mirror                                                                                                     |
+| `STELLA_BLOB_S3_REGION`        | No                        | Optional S3 region                                                                                                                  |
+| `STELLA_BLOB_S3_USE_SSL`       | No                        | Use HTTPS for S3-compatible storage; defaults to `true`                                                                             |
+| `ANTHROPIC_API_KEY`            | Yes\*                     | Anthropic provider key                                                                                                              |
+| `OPENAI_API_KEY`               | Yes\*                     | OpenAI provider key                                                                                                                 |
+| `STELLA_VAULT_KEY`             | Yes†                      | age secret key for the vault — required for secrets, OAuth, and bearer tokens                                                       |
+| `STELLA_DOCKER_SANDBOX_MODE`   | No‡                       | Required only for the `docker` sandbox backend: `host`, `bind`, or `volume`                                                         |
+| `STELLA_HOME_HOST`             | No‡                       | Host-side path backing `STELLA_HOME` — required only when `STELLA_DOCKER_SANDBOX_MODE=bind`                                         |
+| `STELLA_HOME_VOLUME`           | No‡                       | Docker named volume backing `STELLA_HOME` — required only when `STELLA_DOCKER_SANDBOX_MODE=volume`                                  |
 
 \* At least one provider key is required. API keys can also be configured via the Web UI.
 
@@ -254,6 +293,8 @@ Configuration is managed through the Web UI (default `http://localhost:25678`; u
 ‡ Required only when agents use the `docker` sandbox backend. Use `host` when stellad runs on the host, `bind` when stellad runs in Docker with a host bind mount, and `volume` when stellad runs in Docker with a named volume.
 
 § Set all four required S3 mirror variables together, or leave all unset. Partial blob-store configuration fails startup.
+
+¶ Required for managed deployments, and whenever OAuth login or channel deep links are used. See [Managed Deployment](#managed-deployment).
 
 ## Health Check
 

--- a/web/content/docs/start-here/deployment.zh.md
+++ b/web/content/docs/start-here/deployment.zh.md
@@ -206,6 +206,42 @@ docker build -t stella .
 docker buildx build --platform linux/amd64,linux/arm64 -t stella .
 ```
 
+## 受管部署
+
+当你在编排系统（Kubernetes 等）下运行 Stella 时，两个本地环境下的便利做法会变成陷阱：内嵌的单节点数据库，以及指向 pod 自身的 base URL。设置 `STELLA_STRICT_DEPLOYMENT=1` 可将这些陷阱转化为快速、可操作的启动错误。
+
+### 三种 URL 角色
+
+Stella 使用三个不同的地址，务必区分：
+
+| 变量                | 角色                                                                                                         |
+| ------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `HOST`              | 服务绑定的网卡地址。容器内使用 `0.0.0.0` 让 pod 可达；默认 `127.0.0.1`。                                     |
+| `STELLA_SERVER_URL` | CLI 与进程内调用方访问本地服务所用的地址。pod 内部使用；默认 `http://127.0.0.1:25678`。                      |
+| `STELLA_BASE_URL`   | 客户端看到的公网 canonical URL。它是 OAuth 回调地址与频道外链的来源，因此必须是外部可达地址，而非 loopback。 |
+
+绑定到 `0.0.0.0`（`HOST`）**并不会**给你一个公网 URL：`STELLA_BASE_URL` 未设置时，base URL 由绑定地址推导，仍然解析为 loopback。受管部署中请始终显式设置 `STELLA_BASE_URL`。
+
+### 严格部署模式
+
+`STELLA_STRICT_DEPLOYMENT=1` 会拒绝仅供本地使用的 fallback：
+
+- 服务不会启动内嵌 PostgreSQL。你必须将 `STELLA_DATABASE_URL` 指向已安装 `pgvector` 与 `pg_search` 的外部 PostgreSQL。
+- 服务不会在 `STELLA_BASE_URL` 为 loopback 或未指定地址时启动。请将其设为客户端使用的公网 URL。
+
+如果你有意配置了一个不使用任何外链功能（无 OAuth 登录、无频道外链）的部署，并接受 loopback base URL，可设置 `STELLA_ALLOW_UNSAFE_BASE_URL=1` 将 base URL 的启动失败降级为警告。在非严格模式下，仅当配置了依赖外链的功能时，Stella 才会对 loopback base URL 发出警告。
+
+### 受管部署所需的环境变量
+
+| 变量                       | 值                                                                |
+| -------------------------- | ----------------------------------------------------------------- |
+| `STELLA_DATABASE_URL`      | 含 `pgvector` + `pg_search` 的外部 PostgreSQL DSN                 |
+| `STELLA_VAULT_KEY`         | 密钥库的 age 私钥（用 `stellad vault keygen` 生成）               |
+| `STELLA_BASE_URL`          | 客户端使用的公网 canonical URL（如 `https://stella.example.com`） |
+| `STELLA_STRICT_DEPLOYMENT` | `1` —— 若将回退到仅本地 fallback 则快速失败                       |
+
+完整的 Kubernetes manifest 演示不在本页范围内。
+
 ## 沙箱后端
 
 将 Stella 运行在 Docker 容器中（见上文）与使用 Docker 作为 agent 工具执行的沙箱后端是两件独立的事。Stella 支持三种沙箱后端：`docker`、`local` 和 `none`。请参阅[沙箱指南](/docs/guides/sandbox)了解如何选择后端、配置 Docker 沙箱模式和排查常见问题。
@@ -230,22 +266,25 @@ PostgreSQL 数据是唯一需要备份的关键数据。它包含所有配置、
 
 配置通过Web UI管理（默认 `http://localhost:25678`；使用 `--port` 自定义端口）。还支持使用 `HOST` 和 `PORT` 绑定服务，其余仅支持少量环境变量：
 
-| 变量                         | 必需                      | 描述                                                                                     |
-| ---------------------------- | ------------------------- | ---------------------------------------------------------------------------------------- |
-| `STELLA_HOME`                | 否                        | Stella 主目录（默认 `~/.stella`）                                                        |
-| `STELLA_DATABASE_URL`        | Docker 中必需；其他环境否 | 外部 PostgreSQL 连接 URL；Docker 之外不设置时使用 `STELLA_HOME` 下的内嵌集群             |
-| `STELLA_BLOB_S3_ENDPOINT`    | 否§                       | 持久化用户资产镜像使用的 S3 兼容 endpoint                                                |
-| `STELLA_BLOB_S3_BUCKET`      | 否§                       | 镜像用户上传资产的 bucket                                                                |
-| `STELLA_BLOB_S3_ACCESS_KEY`  | 否§                       | 资产镜像使用的 access key                                                                |
-| `STELLA_BLOB_S3_SECRET_KEY`  | 否§                       | 资产镜像使用的 secret key                                                                |
-| `STELLA_BLOB_S3_REGION`      | 否                        | 可选 S3 region                                                                           |
-| `STELLA_BLOB_S3_USE_SSL`     | 否                        | S3 兼容存储是否使用 HTTPS；默认 `true`                                                   |
-| `ANTHROPIC_API_KEY`          | 是\*                      | Anthropic 提供商密钥                                                                     |
-| `OPENAI_API_KEY`             | 是\*                      | OpenAI 提供商密钥                                                                        |
-| `STELLA_VAULT_KEY`           | 是†                       | 密钥库使用的 age 私钥 —— 密钥管理、OAuth 和 Bearer Token 所必需                          |
-| `STELLA_DOCKER_SANDBOX_MODE` | 否‡                       | 仅 `docker` 沙箱后端需要：`host`、`bind` 或 `volume`                                     |
-| `STELLA_HOME_HOST`           | 否‡                       | `STELLA_HOME` 的宿主机侧路径；仅 `STELLA_DOCKER_SANDBOX_MODE=bind` 时需要                |
-| `STELLA_HOME_VOLUME`         | 否‡                       | `STELLA_HOME` 的 Docker named volume 名称；仅 `STELLA_DOCKER_SANDBOX_MODE=volume` 时需要 |
+| 变量                           | 必需                      | 描述                                                                                                    |
+| ------------------------------ | ------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `STELLA_HOME`                  | 否                        | Stella 主目录（默认 `~/.stella`）                                                                       |
+| `STELLA_DATABASE_URL`          | Docker 中必需；其他环境否 | 外部 PostgreSQL 连接 URL；Docker 之外不设置时使用 `STELLA_HOME` 下的内嵌集群                            |
+| `STELLA_BASE_URL`              | 否¶                       | OAuth 回调与频道外链使用的公网 canonical URL；未设置时由绑定地址推导（loopback）                        |
+| `STELLA_STRICT_DEPLOYMENT`     | 否                        | 受管部署设为 `1`：要求 `STELLA_DATABASE_URL` 与非 loopback 的 `STELLA_BASE_URL`，拒绝仅本地 fallback    |
+| `STELLA_ALLOW_UNSAFE_BASE_URL` | 否                        | 设为 `1` 时，允许在 `STELLA_STRICT_DEPLOYMENT` 下使用 loopback 的 `STELLA_BASE_URL`（将失败降级为警告） |
+| `STELLA_BLOB_S3_ENDPOINT`      | 否§                       | 持久化用户资产镜像使用的 S3 兼容 endpoint                                                               |
+| `STELLA_BLOB_S3_BUCKET`        | 否§                       | 镜像用户上传资产的 bucket                                                                               |
+| `STELLA_BLOB_S3_ACCESS_KEY`    | 否§                       | 资产镜像使用的 access key                                                                               |
+| `STELLA_BLOB_S3_SECRET_KEY`    | 否§                       | 资产镜像使用的 secret key                                                                               |
+| `STELLA_BLOB_S3_REGION`        | 否                        | 可选 S3 region                                                                                          |
+| `STELLA_BLOB_S3_USE_SSL`       | 否                        | S3 兼容存储是否使用 HTTPS；默认 `true`                                                                  |
+| `ANTHROPIC_API_KEY`            | 是\*                      | Anthropic 提供商密钥                                                                                    |
+| `OPENAI_API_KEY`               | 是\*                      | OpenAI 提供商密钥                                                                                       |
+| `STELLA_VAULT_KEY`             | 是†                       | 密钥库使用的 age 私钥 —— 密钥管理、OAuth 和 Bearer Token 所必需                                         |
+| `STELLA_DOCKER_SANDBOX_MODE`   | 否‡                       | 仅 `docker` 沙箱后端需要：`host`、`bind` 或 `volume`                                                    |
+| `STELLA_HOME_HOST`             | 否‡                       | `STELLA_HOME` 的宿主机侧路径；仅 `STELLA_DOCKER_SANDBOX_MODE=bind` 时需要                               |
+| `STELLA_HOME_VOLUME`           | 否‡                       | `STELLA_HOME` 的 Docker named volume 名称；仅 `STELLA_DOCKER_SANDBOX_MODE=volume` 时需要                |
 
 \* 至少需要一个提供商密钥。API 密钥也可以通过Web UI配置。
 
@@ -254,6 +293,8 @@ PostgreSQL 数据是唯一需要备份的关键数据。它包含所有配置、
 ‡ 仅当 agent 使用 `docker` 沙箱后端时需要。stellad 在宿主机上运行用 `host`；stellad 在 Docker 内且使用 host bind mount 用 `bind`；stellad 在 Docker 内且使用 named volume 用 `volume`。
 
 § 四个必需的 S3 镜像变量必须同时设置，或全部不设置。部分设置会导致启动失败。
+
+¶ 受管部署所必需，以及在使用 OAuth 登录或频道外链时必需。参见[受管部署](#受管部署)。
 
 ## 健康检查
 

--- a/web/content/docs/start-here/deployment.zh.md
+++ b/web/content/docs/start-here/deployment.zh.md
@@ -208,7 +208,7 @@ docker buildx build --platform linux/amd64,linux/arm64 -t stella .
 
 ## 受管部署
 
-当你在编排系统（Kubernetes 等）下运行 Stella 时，两个本地环境下的便利做法会变成陷阱：内嵌的单节点数据库，以及指向 pod 自身的 base URL。设置 `STELLA_STRICT_DEPLOYMENT=1` 可将这些陷阱转化为快速、可操作的启动错误。
+当你在编排系统（Kubernetes 等）下运行 Stella 时，两个本地环境下的便利做法会变成陷阱：内嵌的单节点数据库，以及指向 pod 自身的 base URL。Docker 镜像默认拒绝前者（`STELLA_REQUIRE_EXTERNAL_DB=1`），对后者 Stella 会发出响亮的警告。
 
 ### 三种 URL 角色
 
@@ -222,23 +222,20 @@ Stella 使用三个不同的地址，务必区分：
 
 绑定到 `0.0.0.0`（`HOST`）**并不会**给你一个公网 URL：`STELLA_BASE_URL` 未设置时，base URL 由绑定地址推导，仍然解析为 loopback。受管部署中请始终显式设置 `STELLA_BASE_URL`。
 
-### 严格部署模式
+### 外部数据库要求
 
-`STELLA_STRICT_DEPLOYMENT=1` 会拒绝仅供本地使用的 fallback：
+Docker 镜像设置了 `STELLA_REQUIRE_EXTERNAL_DB=1`：当 `STELLA_DATABASE_URL` 未设置时，启动会以可操作的错误快速失败，而不是在容器的临时文件系统上静默启动内嵌 PostgreSQL 集群——多副本时每个 pod 甚至会各建一套数据库。请将 `STELLA_DATABASE_URL` 指向带 `pgvector` 与 `pg_search` 的外部 PostgreSQL。若要有意在挂载持久卷的单容器中运行内嵌 PostgreSQL，设置 `STELLA_REQUIRE_EXTERNAL_DB=0`。
 
-- 服务不会启动内嵌 PostgreSQL。你必须将 `STELLA_DATABASE_URL` 指向已安装 `pgvector` 与 `pg_search` 的外部 PostgreSQL。
-- 服务不会在 `STELLA_BASE_URL` 为 loopback 或未指定地址时启动。请将其设为客户端使用的公网 URL。
-
-如果你有意配置了一个不使用任何外链功能（无 OAuth 登录、无频道外链）的部署，并接受 loopback base URL，可设置 `STELLA_ALLOW_UNSAFE_BASE_URL=1` 将 base URL 的启动失败降级为警告。在非严格模式下，仅当配置了依赖外链的功能时，Stella 才会对 loopback base URL 发出警告。
+loopback base URL 永远不是启动错误——通过 `localhost` 或 `kubectl port-forward` 访问 Stella 时它是合法的——但当配置了 OAuth/OIDC 登录时 Stella 会发出响亮警告，因为登录跳转会指回 pod 自身。部署 chart 应将 `STELLA_BASE_URL` 作为必填值：那一层才知道自己位于 ingress 之后。
 
 ### 受管部署所需的环境变量
 
-| 变量                       | 值                                                                |
-| -------------------------- | ----------------------------------------------------------------- |
-| `STELLA_DATABASE_URL`      | 含 `pgvector` + `pg_search` 的外部 PostgreSQL DSN                 |
-| `STELLA_VAULT_KEY`         | 密钥库的 age 私钥（用 `stellad vault keygen` 生成）               |
-| `STELLA_BASE_URL`          | 客户端使用的公网 canonical URL（如 `https://stella.example.com`） |
-| `STELLA_STRICT_DEPLOYMENT` | `1` —— 若将回退到仅本地 fallback 则快速失败                       |
+| 变量                         | 值                                                                            |
+| ---------------------------- | ----------------------------------------------------------------------------- |
+| `STELLA_DATABASE_URL`        | 含 `pgvector` + `pg_search` 的外部 PostgreSQL DSN                             |
+| `STELLA_VAULT_KEY`           | 密钥库的 age 私钥（用 `stellad vault keygen` 生成）                           |
+| `STELLA_BASE_URL`            | 客户端使用的公网 canonical URL（如 `https://stella.example.com`）             |
+| `STELLA_REQUIRE_EXTERNAL_DB` | `1` —— Docker 镜像已默认设置；未配外部数据库时快速失败而非启动内嵌 PostgreSQL |
 
 完整的 Kubernetes manifest 演示不在本页范围内。
 
@@ -266,25 +263,24 @@ PostgreSQL 数据是唯一需要备份的关键数据。它包含所有配置、
 
 配置通过Web UI管理（默认 `http://localhost:25678`；使用 `--port` 自定义端口）。还支持使用 `HOST` 和 `PORT` 绑定服务，其余仅支持少量环境变量：
 
-| 变量                           | 必需                      | 描述                                                                                                    |
-| ------------------------------ | ------------------------- | ------------------------------------------------------------------------------------------------------- |
-| `STELLA_HOME`                  | 否                        | Stella 主目录（默认 `~/.stella`）                                                                       |
-| `STELLA_DATABASE_URL`          | Docker 中必需；其他环境否 | 外部 PostgreSQL 连接 URL；Docker 之外不设置时使用 `STELLA_HOME` 下的内嵌集群                            |
-| `STELLA_BASE_URL`              | 否¶                       | OAuth 回调与频道外链使用的公网 canonical URL；未设置时由绑定地址推导（loopback）                        |
-| `STELLA_STRICT_DEPLOYMENT`     | 否                        | 受管部署设为 `1`：要求 `STELLA_DATABASE_URL` 与非 loopback 的 `STELLA_BASE_URL`，拒绝仅本地 fallback    |
-| `STELLA_ALLOW_UNSAFE_BASE_URL` | 否                        | 设为 `1` 时，允许在 `STELLA_STRICT_DEPLOYMENT` 下使用 loopback 的 `STELLA_BASE_URL`（将失败降级为警告） |
-| `STELLA_BLOB_S3_ENDPOINT`      | 否§                       | 持久化用户资产镜像使用的 S3 兼容 endpoint                                                               |
-| `STELLA_BLOB_S3_BUCKET`        | 否§                       | 镜像用户上传资产的 bucket                                                                               |
-| `STELLA_BLOB_S3_ACCESS_KEY`    | 否§                       | 资产镜像使用的 access key                                                                               |
-| `STELLA_BLOB_S3_SECRET_KEY`    | 否§                       | 资产镜像使用的 secret key                                                                               |
-| `STELLA_BLOB_S3_REGION`        | 否                        | 可选 S3 region                                                                                          |
-| `STELLA_BLOB_S3_USE_SSL`       | 否                        | S3 兼容存储是否使用 HTTPS；默认 `true`                                                                  |
-| `ANTHROPIC_API_KEY`            | 是\*                      | Anthropic 提供商密钥                                                                                    |
-| `OPENAI_API_KEY`               | 是\*                      | OpenAI 提供商密钥                                                                                       |
-| `STELLA_VAULT_KEY`             | 是†                       | 密钥库使用的 age 私钥 —— 密钥管理、OAuth 和 Bearer Token 所必需                                         |
-| `STELLA_DOCKER_SANDBOX_MODE`   | 否‡                       | 仅 `docker` 沙箱后端需要：`host`、`bind` 或 `volume`                                                    |
-| `STELLA_HOME_HOST`             | 否‡                       | `STELLA_HOME` 的宿主机侧路径；仅 `STELLA_DOCKER_SANDBOX_MODE=bind` 时需要                               |
-| `STELLA_HOME_VOLUME`           | 否‡                       | `STELLA_HOME` 的 Docker named volume 名称；仅 `STELLA_DOCKER_SANDBOX_MODE=volume` 时需要                |
+| 变量                         | 必需                      | 描述                                                                                                                   |
+| ---------------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `STELLA_HOME`                | 否                        | Stella 主目录（默认 `~/.stella`）                                                                                      |
+| `STELLA_DATABASE_URL`        | Docker 中必需；其他环境否 | 外部 PostgreSQL 连接 URL；Docker 之外不设置时使用 `STELLA_HOME` 下的内嵌集群                                           |
+| `STELLA_BASE_URL`            | 否¶                       | OAuth 回调与频道外链使用的公网 canonical URL；未设置时由绑定地址推导（loopback）                                       |
+| `STELLA_REQUIRE_EXTERNAL_DB` | 否                        | `STELLA_DATABASE_URL` 未设置时快速失败而非启动内嵌 PostgreSQL；Docker 镜像默认设为 `1`，设 `0` 可在持久卷上运行内嵌 PG |
+| `STELLA_BLOB_S3_ENDPOINT`    | 否§                       | 持久化用户资产镜像使用的 S3 兼容 endpoint                                                                              |
+| `STELLA_BLOB_S3_BUCKET`      | 否§                       | 镜像用户上传资产的 bucket                                                                                              |
+| `STELLA_BLOB_S3_ACCESS_KEY`  | 否§                       | 资产镜像使用的 access key                                                                                              |
+| `STELLA_BLOB_S3_SECRET_KEY`  | 否§                       | 资产镜像使用的 secret key                                                                                              |
+| `STELLA_BLOB_S3_REGION`      | 否                        | 可选 S3 region                                                                                                         |
+| `STELLA_BLOB_S3_USE_SSL`     | 否                        | S3 兼容存储是否使用 HTTPS；默认 `true`                                                                                 |
+| `ANTHROPIC_API_KEY`          | 是\*                      | Anthropic 提供商密钥                                                                                                   |
+| `OPENAI_API_KEY`             | 是\*                      | OpenAI 提供商密钥                                                                                                      |
+| `STELLA_VAULT_KEY`           | 是†                       | 密钥库使用的 age 私钥 —— 密钥管理、OAuth 和 Bearer Token 所必需                                                        |
+| `STELLA_DOCKER_SANDBOX_MODE` | 否‡                       | 仅 `docker` 沙箱后端需要：`host`、`bind` 或 `volume`                                                                   |
+| `STELLA_HOME_HOST`           | 否‡                       | `STELLA_HOME` 的宿主机侧路径；仅 `STELLA_DOCKER_SANDBOX_MODE=bind` 时需要                                              |
+| `STELLA_HOME_VOLUME`         | 否‡                       | `STELLA_HOME` 的 Docker named volume 名称；仅 `STELLA_DOCKER_SANDBOX_MODE=volume` 时需要                               |
 
 \* 至少需要一个提供商密钥。API 密钥也可以通过Web UI配置。
 


### PR DESCRIPTION
Closes #638
Closes #641

Phase 0 PR 1/2 of the k8s deployment milestone (tracking: #637). Plan was reviewed against the 2026-07-04 readiness audit before implementation, then **simplified after review feedback** (V): the original `STELLA_STRICT_DEPLOYMENT` mode + `STELLA_ALLOW_UNSAFE_BASE_URL` escape hatch collapsed to one narrow switch and a warning.

## What

- **#638** — `STELLA_REQUIRE_EXTERNAL_DB=1` makes an empty `STELLA_DATABASE_URL` a fast, actionable startup error instead of silently starting the embedded PostgreSQL cluster. **Baked into the Docker image via `ENV`**, so every container (compose, k8s) gets the guard with zero operator action; `=0` deliberately opts back in for a single container on a persistent volume. Strict bool parsing: a typo fails startup instead of silently disabling the guard. The check runs before `StartEmbedded`, so no pg-runtime path is ever reached.
- **#641** — a loopback/unspecified base URL logs a **loud warning** when OAuth/OIDC login is configured (login redirects would point back at the pod). It is never a startup failure: loopback is legitimate in every deployment shape (localhost browsing, docker port publish, `kubectl port-forward`) and the failure mode is immediately visible. Charts (#480) enforce `STELLA_BASE_URL` as a required value — the layer that actually knows it sits behind an ingress.
- Docker image binds via `ENV HOST=0.0.0.0` + `CMD ["stellad", "server"]` instead of an explicit `--host` flag, so a manifest overriding `command:` doesn't silently lose the bind and `HOST` stays user-overridable. The binary keeps its local-safe `127.0.0.1` default.
- Docs (EN + ZH): *Managed Deployment* section separating the three URL roles (`HOST` bind / `STELLA_SERVER_URL` pod-local / `STELLA_BASE_URL` public canonical), the external-DB requirement, and the required env set.

No existing local deployment changes behavior on upgrade; the host binary without the env is untouched.

## Verification

- `mise run format && mise run build && mise run test` green.
- Unit tests: `internal/config/deployment_test.go` (bool parsing), `cmd/stellad/gateway_test.go` (`baseURLUnsafe` classification incl. IPv6/unspecified).
- Binary smoke: `STELLA_REQUIRE_EXTERNAL_DB=1` without DB URL → exact actionable error (including the `=0` opt-out hint), exit 1; garbage value → parse error naming the variable.