### PR TITLE
✨ feat(deploy): production Helm chart for Kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ stellad server
 
 You can also install with `go install github.com/CherryHQ/stella/cmd/stellad@latest` or download binaries from [Releases](https://github.com/CherryHQ/stella/releases).
 
-See the [full quickstart guide](web/content/docs/getting-started/quickstart.md) for detailed steps.
+See the [full quickstart guide](web/content/docs/getting-started/quickstart.md) for detailed steps. To run Stella on Kubernetes, use the production [Helm chart](web/content/docs/admin/kubernetes.md).
 
 ## Connect your channels
 
@@ -72,6 +72,7 @@ Skills are reusable playbooks that teach Stella how to perform specific tasks. S
 | Getting Started | Install, deploy, configure                  | [Quick Start](/docs/getting-started/quickstart) |
 | Guides          | Memory, scheduling, skills, notifications   | [Guides](/docs/guides/memory)                   |
 | Channels        | Telegram, QQ, Feishu, WeChat, Webhook setup | [Channels](/docs/channels/telegram)             |
+| Admin           | Kubernetes / Helm deployment                | [Kubernetes](/docs/admin/kubernetes)            |
 | Development     | Architecture, plugins, contributing         | [Development](/docs/development/architecture)   |
 
 ## CLI reference

--- a/README.zh.md
+++ b/README.zh.md
@@ -44,7 +44,7 @@ stellad server
 
 你也可以使用 `go install github.com/CherryHQ/stella/cmd/stellad@latest` 安装，或从 [Releases](https://github.com/CherryHQ/stella/releases) 下载二进制文件。
 
-详见[完整快速开始指南](web/content/docs/getting-started/quickstart.zh.md)。
+详见[完整快速开始指南](web/content/docs/getting-started/quickstart.zh.md)。要在 Kubernetes 上运行 Stella，请使用生产级 [Helm chart](web/content/docs/admin/kubernetes.zh.md)。
 
 ## 连接聊天渠道
 
@@ -72,6 +72,7 @@ stellad server
 | 入门 | 安装、部署、配置                       | [快速开始](/docs/getting-started/quickstart) |
 | 指南 | 记忆、定时任务、技能、通知             | [指南](/docs/guides/memory)                  |
 | 渠道 | Telegram、QQ、飞书、微信、Webhook 配置 | [渠道](/docs/channels/telegram)              |
+| 管理 | Kubernetes / Helm 部署                 | [Kubernetes](/docs/admin/kubernetes)         |
 | 开发 | 架构、插件、贡献                       | [开发](/docs/development/architecture)       |
 
 ## CLI 参考

--- a/deploy/helm/check.sh
+++ b/deploy/helm/check.sh
@@ -111,6 +111,15 @@ expect_ok "storageClass '-' disables provisioning" "${BASE[@]}" \
   --set sandbox.backend=local --set 'persistence.storageClass=-'
 assert_contains "empty storageClassName"     'storageClassName: ""'
 
+expect_ok "seccomp Unconfined override for local" "${BASE[@]}" \
+  --set sandbox.backend=local --set sandbox.seccompProfile=Unconfined
+assert_contains "seccomp unconfined rendered"  "type: Unconfined"
+
+expect_ok "custom podLabels render" "${BASE[@]}" --set sandbox.backend=local \
+  --set 'podLabels.team=platform'
+assert_contains "custom pod label"           "team: platform"
+assert_contains "selector label kept"        "app.kubernetes.io/name:"
+
 expect_ok "ingress + tls" "${BASE[@]}" --set sandbox.backend=local \
   --set ingress.enabled=true \
   --set 'ingress.className=nginx' \
@@ -152,6 +161,14 @@ expect_fail "baseURL without scheme" "scheme" \
 expect_fail "baseURL loopback host" "loopback" \
   --set baseURL=http://localhost:25678 --set secrets.existingSecret=stella-secrets \
   --set sandbox.backend=local
+expect_fail "baseURL IPv6 loopback" "loopback" \
+  --set 'baseURL=https://[::1]:8443' --set secrets.existingSecret=stella-secrets \
+  --set sandbox.backend=local
+expect_fail "podLabels overrides selector" "podLabels must not set" \
+  "${BASE[@]}" --set sandbox.backend=local \
+  --set 'podLabels.app\.kubernetes\.io/name=evil'
+expect_fail "invalid seccompProfile rejected" "seccompProfile" \
+  "${BASE[@]}" --set sandbox.backend=local --set sandbox.seccompProfile=Wide
 expect_fail "ingress enabled without hosts" "ingress.hosts" \
   "${BASE[@]}" --set sandbox.backend=local --set ingress.enabled=true --set 'ingress.hosts=null'
 

--- a/deploy/helm/check.sh
+++ b/deploy/helm/check.sh
@@ -79,9 +79,9 @@ assert_contains "vault key secretKeyRef"     'key: "STELLA_VAULT_KEY"'
 assert_contains "database secretKeyRef"      'key: "STELLA_DATABASE_URL"'
 assert_contains "pvc kept on uninstall"      "helm.sh/resource-policy: keep"
 assert_contains "image repo"                 "ghcr.io/cherryhq/stella"
-# Default tag comes from Chart.appVersion; published image tags carry a leading
-# "v", so the default MUST render "…:v…" or the out-of-box pull 404s.
-assert_contains "default tag has v prefix"   "ghcr.io/cherryhq/stella:v"
+# Empty image.tag defaults to "latest" so a fresh install tracks the newest
+# published release (a pinned appVersion could point at an incompatible image).
+assert_contains "default tag is latest"      "ghcr.io/cherryhq/stella:latest"
 assert_contains "explicit bind all"          'value: "0.0.0.0"'
 assert_contains "explicit external db"       "STELLA_REQUIRE_EXTERNAL_DB"
 assert_contains "readiness probe timeout"    "timeoutSeconds: 3"

--- a/deploy/helm/check.sh
+++ b/deploy/helm/check.sh
@@ -79,6 +79,9 @@ assert_contains "vault key secretKeyRef"     'key: "STELLA_VAULT_KEY"'
 assert_contains "database secretKeyRef"      'key: "STELLA_DATABASE_URL"'
 assert_contains "pvc kept on uninstall"      "helm.sh/resource-policy: keep"
 assert_contains "image repo"                 "ghcr.io/cherryhq/stella"
+# Default tag comes from Chart.appVersion; published image tags carry a leading
+# "v", so the default MUST render "…:v…" or the out-of-box pull 404s.
+assert_contains "default tag has v prefix"   "ghcr.io/cherryhq/stella:v"
 assert_contains "explicit bind all"          'value: "0.0.0.0"'
 assert_contains "explicit external db"       "STELLA_REQUIRE_EXTERNAL_DB"
 assert_contains "readiness probe timeout"    "timeoutSeconds: 3"

--- a/deploy/helm/check.sh
+++ b/deploy/helm/check.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Lint and render-assert the Stella Helm chart. All secret material here is fake.
+set -euo pipefail
+
+CHART_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/stella" && pwd)"
+ERR="$(mktemp)"
+OUT="$(mktemp)"
+trap 'rm -f "$ERR" "$OUT"' EXIT
+
+rc=0
+
+# Minimal valid values reused by success cases (all fake).
+BASE=(
+  --set baseURL=https://stella.example.com
+  --set secrets.existingSecret=stella-secrets
+)
+
+render() { helm template stella "$CHART_DIR" "$@"; }
+
+expect_ok() {
+  local name="$1"; shift
+  if render "$@" >"$OUT" 2>"$ERR"; then
+    echo "ok   - $name"
+  else
+    echo "FAIL - $name (expected render to succeed)"
+    sed 's/^/       /' "$ERR"
+    rc=1
+  fi
+}
+
+expect_fail() {
+  local name="$1" keyword="$2"; shift 2
+  if render "$@" >"$OUT" 2>"$ERR"; then
+    echo "FAIL - $name (expected render to fail, but it succeeded)"
+    rc=1
+  elif grep -qi -- "$keyword" "$ERR"; then
+    echo "ok   - $name (rejected, matched '$keyword')"
+  else
+    echo "FAIL - $name (failed, but message missing '$keyword')"
+    sed 's/^/       /' "$ERR"
+    rc=1
+  fi
+}
+
+# assert the last successful render's output contains / omits a string.
+assert_contains() {
+  if grep -qF -- "$2" "$OUT"; then echo "ok   - render contains: $1"
+  else echo "FAIL - render missing: $1 ($2)"; rc=1; fi
+}
+assert_absent() {
+  if grep -qF -- "$2" "$OUT"; then echo "FAIL - render should omit: $1 ($2)"; rc=1
+  else echo "ok   - render omits: $1"; fi
+}
+
+echo "== helm lint =="
+if helm lint "$CHART_DIR" --set baseURL=https://stella.example.com \
+  --set secrets.existingSecret=stella-secrets --set sandbox.backend=local; then
+  echo "ok   - helm lint"
+else
+  echo "FAIL - helm lint"; rc=1
+fi
+
+echo
+echo "== success cases =="
+expect_ok "minimal (sandbox=local)" "${BASE[@]}" --set sandbox.backend=local
+# Assertions run against the last render ($OUT), i.e. the minimal-local case.
+assert_contains "Recreate strategy"          "type: Recreate"
+assert_contains "single replica"             "replicas: 1"
+assert_contains "http shutdown timeout 60s"  'value: "60s"'
+assert_contains "river soft-stop 120s"       'value: "120s"'
+assert_contains "preStop sleep 10"           '"/bin/sleep", "10"'
+assert_contains "grace period 200"           "terminationGracePeriodSeconds: 200"
+assert_contains "no api token"               "automountServiceAccountToken: false"
+assert_contains "runAsNonRoot"               "runAsNonRoot: true"
+assert_contains "fsGroupChangePolicy"        "fsGroupChangePolicy: OnRootMismatch"
+assert_contains "startup failureThreshold"   "failureThreshold: 60"
+assert_contains "mount STELLA_HOME"          "mountPath: /home/stella/.stella"
+assert_contains "vault key secretKeyRef"     'key: "STELLA_VAULT_KEY"'
+assert_contains "database secretKeyRef"      'key: "STELLA_DATABASE_URL"'
+assert_contains "pvc kept on uninstall"      "helm.sh/resource-policy: keep"
+assert_contains "image repo"                 "ghcr.io/cherryhq/stella"
+assert_absent   "no plaintext secret env"    "AGE-SECRET-KEY"
+
+expect_ok "sandbox=none with confirmation" "${BASE[@]}" \
+  --set sandbox.backend=none --set sandbox.allowUnsafeHostExecution=true
+
+expect_ok "existingClaim reuses PVC" "${BASE[@]}" --set sandbox.backend=local \
+  --set persistence.existingClaim=my-stella-data
+assert_absent "no chart-created PVC with existingClaim" "kind: PersistentVolumeClaim"
+
+expect_ok "ingress + tls" "${BASE[@]}" --set sandbox.backend=local \
+  --set ingress.enabled=true \
+  --set 'ingress.className=nginx' \
+  --set 'ingress.hosts[0].host=stella.example.com' \
+  --set 'ingress.hosts[0].paths[0].path=/' \
+  --set 'ingress.hosts[0].paths[0].pathType=Prefix' \
+  --set 'ingress.tls[0].secretName=stella-tls' \
+  --set 'ingress.tls[0].hosts[0]=stella.example.com'
+assert_contains "ingress rendered" "kind: Ingress"
+
+echo
+echo "== must-fail cases =="
+expect_fail "missing baseURL" "baseURL" \
+  --set secrets.existingSecret=stella-secrets --set sandbox.backend=local
+expect_fail "missing existingSecret" "existingSecret" \
+  --set baseURL=https://stella.example.com --set sandbox.backend=local
+expect_fail "replicaCount=2" "replica" \
+  "${BASE[@]}" --set sandbox.backend=local --set replicaCount=2
+expect_fail "sandbox backend missing" "sandbox.backend" "${BASE[@]}"
+expect_fail "sandbox=none without confirmation" "allowUnsafeHostExecution" \
+  "${BASE[@]}" --set sandbox.backend=none
+expect_fail "grace period too small" "terminationGracePeriodSeconds" \
+  "${BASE[@]}" --set sandbox.backend=local \
+  --set shutdown.terminationGracePeriodSeconds=50
+
+echo
+if [ "$rc" -eq 0 ]; then echo "All Helm checks passed."; else echo "Helm checks FAILED."; fi
+exit "$rc"

--- a/deploy/helm/check.sh
+++ b/deploy/helm/check.sh
@@ -81,10 +81,16 @@ assert_contains "pvc kept on uninstall"      "helm.sh/resource-policy: keep"
 assert_contains "image repo"                 "ghcr.io/cherryhq/stella"
 assert_contains "explicit bind all"          'value: "0.0.0.0"'
 assert_contains "explicit external db"       "STELLA_REQUIRE_EXTERNAL_DB"
+assert_contains "readiness probe timeout"    "timeoutSeconds: 3"
+assert_contains "seccomp runtime default"    "type: RuntimeDefault"
 assert_absent   "no plaintext secret env"    "AGE-SECRET-KEY"
 # local backend must not get the restrictive container securityContext that
 # would break bubblewrap.
 assert_absent   "no privilege drop on local" "allowPrivilegeEscalation"
+
+expect_ok "image digest pins over tag" "${BASE[@]}" --set sandbox.backend=local \
+  --set image.digest=sha256:0123456789abcdef
+assert_contains "image pinned by digest"     "ghcr.io/cherryhq/stella@sha256:0123456789abcdef"
 
 expect_ok "sandbox=none with confirmation" "${BASE[@]}" \
   --set sandbox.backend=none --set sandbox.allowUnsafeHostExecution=true
@@ -99,6 +105,11 @@ assert_contains "emptyDir when unpersisted"  "emptyDir: {}"
 expect_ok "existingClaim reuses PVC" "${BASE[@]}" --set sandbox.backend=local \
   --set persistence.existingClaim=my-stella-data
 assert_absent "no chart-created PVC with existingClaim" "kind: PersistentVolumeClaim"
+assert_contains "mounts the existing claim"  "claimName: my-stella-data"
+
+expect_ok "storageClass '-' disables provisioning" "${BASE[@]}" \
+  --set sandbox.backend=local --set 'persistence.storageClass=-'
+assert_contains "empty storageClassName"     'storageClassName: ""'
 
 expect_ok "ingress + tls" "${BASE[@]}" --set sandbox.backend=local \
   --set ingress.enabled=true \
@@ -135,6 +146,14 @@ expect_fail "extraEnv injects vault key" "extraEnv must not set STELLA_VAULT_KEY
 expect_fail "extraEnv overrides HOST" "extraEnv must not set HOST" \
   "${BASE[@]}" --set sandbox.backend=local \
   --set 'extraEnv[0].name=HOST' --set 'extraEnv[0].value=127.0.0.1'
+expect_fail "baseURL without scheme" "scheme" \
+  --set baseURL=stella.example.com --set secrets.existingSecret=stella-secrets \
+  --set sandbox.backend=local
+expect_fail "baseURL loopback host" "loopback" \
+  --set baseURL=http://localhost:25678 --set secrets.existingSecret=stella-secrets \
+  --set sandbox.backend=local
+expect_fail "ingress enabled without hosts" "ingress.hosts" \
+  "${BASE[@]}" --set sandbox.backend=local --set ingress.enabled=true --set 'ingress.hosts=null'
 
 echo
 if [ "$rc" -eq 0 ]; then echo "All Helm checks passed."; else echo "Helm checks FAILED."; fi

--- a/deploy/helm/check.sh
+++ b/deploy/helm/check.sh
@@ -169,6 +169,9 @@ expect_fail "podLabels overrides selector" "podLabels must not set" \
   --set 'podLabels.app\.kubernetes\.io/name=evil'
 expect_fail "invalid seccompProfile rejected" "seccompProfile" \
   "${BASE[@]}" --set sandbox.backend=local --set sandbox.seccompProfile=Wide
+expect_fail "none must not weaken seccomp" "seccompProfile=RuntimeDefault" \
+  "${BASE[@]}" --set sandbox.backend=none --set sandbox.allowUnsafeHostExecution=true \
+  --set sandbox.seccompProfile=Unconfined
 expect_fail "ingress enabled without hosts" "ingress.hosts" \
   "${BASE[@]}" --set sandbox.backend=local --set ingress.enabled=true --set 'ingress.hosts=null'
 

--- a/deploy/helm/check.sh
+++ b/deploy/helm/check.sh
@@ -79,10 +79,22 @@ assert_contains "vault key secretKeyRef"     'key: "STELLA_VAULT_KEY"'
 assert_contains "database secretKeyRef"      'key: "STELLA_DATABASE_URL"'
 assert_contains "pvc kept on uninstall"      "helm.sh/resource-policy: keep"
 assert_contains "image repo"                 "ghcr.io/cherryhq/stella"
+assert_contains "explicit bind all"          'value: "0.0.0.0"'
+assert_contains "explicit external db"       "STELLA_REQUIRE_EXTERNAL_DB"
 assert_absent   "no plaintext secret env"    "AGE-SECRET-KEY"
+# local backend must not get the restrictive container securityContext that
+# would break bubblewrap.
+assert_absent   "no privilege drop on local" "allowPrivilegeEscalation"
 
 expect_ok "sandbox=none with confirmation" "${BASE[@]}" \
   --set sandbox.backend=none --set sandbox.allowUnsafeHostExecution=true
+assert_contains "none drops escalation"      "allowPrivilegeEscalation: false"
+assert_contains "none drops capabilities"    'drop: ["ALL"]'
+
+expect_ok "ephemeral storage with confirmation" "${BASE[@]}" \
+  --set sandbox.backend=local --set persistence.enabled=false \
+  --set persistence.allowEphemeralDataLoss=true
+assert_contains "emptyDir when unpersisted"  "emptyDir: {}"
 
 expect_ok "existingClaim reuses PVC" "${BASE[@]}" --set sandbox.backend=local \
   --set persistence.existingClaim=my-stella-data
@@ -112,6 +124,17 @@ expect_fail "sandbox=none without confirmation" "allowUnsafeHostExecution" \
 expect_fail "grace period too small" "terminationGracePeriodSeconds" \
   "${BASE[@]}" --set sandbox.backend=local \
   --set shutdown.terminationGracePeriodSeconds=50
+expect_fail "persistence off without confirmation" "allowEphemeralDataLoss" \
+  "${BASE[@]}" --set sandbox.backend=local --set persistence.enabled=false
+expect_fail "extraEnv overrides sandbox" "extraEnv must not set STELLA_SANDBOX_BACKEND" \
+  "${BASE[@]}" --set sandbox.backend=local \
+  --set 'extraEnv[0].name=STELLA_SANDBOX_BACKEND' --set 'extraEnv[0].value=none'
+expect_fail "extraEnv injects vault key" "extraEnv must not set STELLA_VAULT_KEY" \
+  "${BASE[@]}" --set sandbox.backend=local \
+  --set 'extraEnv[0].name=STELLA_VAULT_KEY' --set 'extraEnv[0].value=fake'
+expect_fail "extraEnv overrides HOST" "extraEnv must not set HOST" \
+  "${BASE[@]}" --set sandbox.backend=local \
+  --set 'extraEnv[0].name=HOST' --set 'extraEnv[0].value=127.0.0.1'
 
 echo
 if [ "$rc" -eq 0 ]; then echo "All Helm checks passed."; else echo "Helm checks FAILED."; fi

--- a/deploy/helm/stella/Chart.yaml
+++ b/deploy/helm/stella/Chart.yaml
@@ -5,8 +5,11 @@ type: application
 # Chart version — bump on chart changes, independent of the app version.
 version: 0.1.0
 # appVersion tracks the Stella release the chart is validated against; it is the
-# default image tag. Update it in lockstep with the published container image.
-appVersion: "0.50.4"
+# default image tag (see stella.image). It MUST match a published container image
+# tag, and those carry a leading "v" (git release tags are v0.50.5, etc.), so this
+# value must include the "v" too — without it the default pull 404s. Update it in
+# lockstep with the published image.
+appVersion: "v0.50.5"
 home: https://stella.cherryin.com
 sources:
   - https://github.com/CherryHQ/stella

--- a/deploy/helm/stella/Chart.yaml
+++ b/deploy/helm/stella/Chart.yaml
@@ -4,11 +4,10 @@ description: Stella — a multi-tenant, multi-user, multi-agent AI assistant pla
 type: application
 # Chart version — bump on chart changes, independent of the app version.
 version: 0.1.0
-# appVersion tracks the Stella release the chart is validated against; it is the
-# default image tag (see stella.image). It MUST match a published container image
-# tag, and those carry a leading "v" (git release tags are v0.50.5, etc.), so this
-# value must include the "v" too — without it the default pull 404s. Update it in
-# lockstep with the published image.
+# appVersion is metadata noting the Stella release this chart was developed
+# against. It is NOT the default image tag: the chart defaults image.tag to
+# "latest" (see stella.image / values.yaml) so a fresh install tracks the newest
+# published release. Pin image.tag or image.digest for reproducible deploys.
 appVersion: "v0.50.5"
 home: https://stella.cherryin.com
 sources:

--- a/deploy/helm/stella/Chart.yaml
+++ b/deploy/helm/stella/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: stella
+description: Stella — a multi-tenant, multi-user, multi-agent AI assistant platform. Single-replica production chart.
+type: application
+# Chart version — bump on chart changes, independent of the app version.
+version: 0.1.0
+# appVersion tracks the Stella release the chart is validated against; it is the
+# default image tag. Update it in lockstep with the published container image.
+appVersion: "0.50.4"
+home: https://stella.cherryin.com
+sources:
+  - https://github.com/CherryHQ/stella
+keywords:
+  - ai
+  - assistant
+  - agent
+  - self-hosted
+maintainers:
+  - name: CherryHQ
+    email: hello@cherryin.com

--- a/deploy/helm/stella/templates/NOTES.txt
+++ b/deploy/helm/stella/templates/NOTES.txt
@@ -1,0 +1,71 @@
+Stella has been deployed as release "{{ .Release.Name }}" in namespace "{{ .Release.Namespace }}".
+
+Single replica only (strategy: Recreate). Upgrades and restarts have a brief
+downtime window; this is by design — see "Why only one replica?" in the docs.
+
+Access
+------
+{{- if .Values.ingress.enabled }}
+Ingress is enabled. Reach Stella at:
+{{- range .Values.ingress.hosts }}
+  - http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
+{{- end }}
+{{- else }}
+No ingress configured. Port-forward to reach the Web UI locally:
+
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "stella.fullname" . }} 25678:{{ int .Values.service.port }}
+
+Then open http://localhost:25678
+{{- end }}
+
+Make sure baseURL ({{ .Values.baseURL }}) matches the address users actually reach.
+
+Secret
+------
+Stella reads its vault key and database DSN from the Secret named
+"{{ .Values.secrets.existingSecret }}" (keys: {{ .Values.secrets.keys.vaultKey }},
+{{ .Values.secrets.keys.databaseURL }}). If that Secret does not exist yet, create it,
+for example (replace the placeholder values):
+
+  kubectl -n {{ .Release.Namespace }} create secret generic {{ .Values.secrets.existingSecret }} \
+    --from-literal={{ .Values.secrets.keys.vaultKey }}='AGE-SECRET-KEY-REPLACE-ME' \
+    --from-literal={{ .Values.secrets.keys.databaseURL }}='postgres://user:pass@postgres.example.com:5432/stella?sslmode=require'
+
+Updating the Secret does NOT restart the pod. Roll it after a secret change:
+
+  kubectl -n {{ .Release.Namespace }} rollout restart deployment/{{ include "stella.fullname" . }}
+
+Sandbox
+-------
+sandbox.backend = {{ .Values.sandbox.backend }}
+{{- if eq (trim .Values.sandbox.backend) "none" }}
+  backend=none runs agent tools directly inside the Stella pod WITHOUT sandbox
+  isolation. It does not disable agent tools.
+{{- else }}
+  backend=local (bubblewrap) is experimental and requires a cluster that permits
+  unprivileged user namespaces. If tools fail with bwrap/unshare errors, switch
+  to backend=none (and set sandbox.allowUnsafeHostExecution=true) or adjust the
+  cluster.
+{{- end }}
+
+Storage
+-------
+{{- if .Values.persistence.enabled }}
+{{- if .Values.persistence.existingClaim }}
+Using your existing PVC "{{ .Values.persistence.existingClaim }}" for STELLA_HOME.
+{{- else }}
+STELLA_HOME is backed by PVC "{{ include "stella.pvcName" . }}" ({{ .Values.persistence.size }}).
+It carries annotation helm.sh/resource-policy: keep, so "helm uninstall" leaves it
+(and your data) in place. To delete it deliberately:
+
+  kubectl -n {{ .Release.Namespace }} delete pvc {{ include "stella.pvcName" . }}
+{{- end }}
+{{- else }}
+Persistence is DISABLED — STELLA_HOME uses an emptyDir and is lost when the pod
+restarts. Enable persistence for any real deployment.
+{{- end }}
+
+Health
+------
+  kubectl -n {{ .Release.Namespace }} get pods -l app.kubernetes.io/instance={{ .Release.Name }}
+  # Liveness /healthz, readiness /readyz on port 25678.

--- a/deploy/helm/stella/templates/_helpers.tpl
+++ b/deploy/helm/stella/templates/_helpers.tpl
@@ -98,9 +98,12 @@ actionable message. Kept in one place so every template shares the same checks.
 {{- if not (or (hasPrefix "http://" $baseURL) (hasPrefix "https://" $baseURL)) -}}
 {{- fail (printf "stella: baseURL must include an http:// or https:// scheme (got %q). It is the public address clients reach, used for OAuth callbacks and channel deep links." $baseURL) -}}
 {{- end -}}
-{{- $host := regexReplaceAll "^https?://([^/:]+).*$" $baseURL "${1}" -}}
-{{- if or (eq $host "localhost") (hasPrefix "127." $host) (eq $host "0.0.0.0") (eq $host "::1") -}}
-{{- fail (printf "stella: baseURL host %q is a loopback/bind address, but it must be the externally reachable URL clients use (the ingress address), or OAuth callbacks and channel links break." $host) -}}
+{{- $authority := regexReplaceAll "^https?://" $baseURL "" -}}
+{{- $host := regexReplaceAll "^([^/:]+).*$" $authority "${1}" -}}
+{{- /* IPv6 hosts are bracketed ([::1], [::1]:8443); the host regex above cannot
+       capture them, so match the bracketed loopback on the raw authority. */ -}}
+{{- if or (eq $host "localhost") (hasPrefix "127." $host) (eq $host "0.0.0.0") (hasPrefix "[::1]" $authority) (hasPrefix "[0:0:0:0:0:0:0:1]" $authority) -}}
+{{- fail (printf "stella: baseURL %q points at a loopback/bind address, but it must be the externally reachable URL clients use (the ingress address), or OAuth callbacks and channel links break." $baseURL) -}}
 {{- end -}}
 
 {{- if not (trim $v.secrets.existingSecret) -}}
@@ -131,6 +134,12 @@ actionable message. Kept in one place so every template shares the same checks.
 {{- range $v.extraEnv -}}
 {{- if has .name (list "STELLA_BASE_URL" "STELLA_SANDBOX_BACKEND" "STELLA_HTTP_SHUTDOWN_TIMEOUT" "STELLA_RIVER_SOFT_STOP_TIMEOUT" "STELLA_VAULT_KEY" "STELLA_DATABASE_URL" "HOST" "PORT" "STELLA_REQUIRE_EXTERNAL_DB") -}}
 {{- fail (printf "stella: extraEnv must not set %s — it is managed by the chart's typed values (baseURL, secrets.*, sandbox.*, shutdown.*), which enforce this chart's safety contract. Setting it twice would make the effective value ambiguous." .name) -}}
+{{- end -}}
+{{- end -}}
+
+{{- range $k, $val := $v.podLabels -}}
+{{- if has $k (list "app.kubernetes.io/name" "app.kubernetes.io/instance") -}}
+{{- fail (printf "stella: podLabels must not set %s — it is the Deployment's immutable selector label. Overriding it would leave the Deployment unable to find its own pods." $k) -}}
 {{- end -}}
 {{- end -}}
 

--- a/deploy/helm/stella/templates/_helpers.tpl
+++ b/deploy/helm/stella/templates/_helpers.tpl
@@ -98,10 +98,12 @@ actionable message. Kept in one place so every template shares the same checks.
 {{- if not (or (hasPrefix "http://" $baseURL) (hasPrefix "https://" $baseURL)) -}}
 {{- fail (printf "stella: baseURL must include an http:// or https:// scheme (got %q). It is the public address clients reach, used for OAuth callbacks and channel deep links." $baseURL) -}}
 {{- end -}}
-{{- $authority := regexReplaceAll "^https?://" $baseURL "" -}}
+{{- $authority := lower (regexReplaceAll "^https?://" $baseURL "") -}}
 {{- $host := regexReplaceAll "^([^/:]+).*$" $authority "${1}" -}}
-{{- /* IPv6 hosts are bracketed ([::1], [::1]:8443); the host regex above cannot
-       capture them, so match the bracketed loopback on the raw authority. */ -}}
+{{- /* Best-effort rejection of common loopback/bind forms, not full URL/IP
+       validation. IPv6 hosts are bracketed ([::1], [::1]:8443); the host regex
+       above cannot capture them, so match the bracketed loopback on the raw
+       authority. */ -}}
 {{- if or (eq $host "localhost") (hasPrefix "127." $host) (eq $host "0.0.0.0") (hasPrefix "[::1]" $authority) (hasPrefix "[0:0:0:0:0:0:0:1]" $authority) -}}
 {{- fail (printf "stella: baseURL %q points at a loopback/bind address, but it must be the externally reachable URL clients use (the ingress address), or OAuth callbacks and channel links break." $baseURL) -}}
 {{- end -}}
@@ -119,6 +121,12 @@ actionable message. Kept in one place so every template shares the same checks.
 {{- end -}}
 {{- if and (eq $backend "none") (not $v.sandbox.allowUnsafeHostExecution) -}}
 {{- fail "stella: sandbox.backend=none runs agent tools directly inside the Stella pod with no isolation. Set sandbox.allowUnsafeHostExecution=true to acknowledge this, or choose sandbox.backend=local." -}}
+{{- end -}}
+{{- /* Unconfined seccomp only exists to unblock the local (bubblewrap) backend;
+       none never needs it, and keeping it (e.g. carried over by --reuse-values
+       when switching from local) would drop defence-in-depth for no reason. */ -}}
+{{- if and (eq $backend "none") (ne (trim $v.sandbox.seccompProfile) "RuntimeDefault") -}}
+{{- fail "stella: sandbox.backend=none requires sandbox.seccompProfile=RuntimeDefault; Unconfined is only an escape hatch for the local bubblewrap backend." -}}
 {{- end -}}
 
 {{- $s := $v.shutdown -}}

--- a/deploy/helm/stella/templates/_helpers.tpl
+++ b/deploy/helm/stella/templates/_helpers.tpl
@@ -57,11 +57,16 @@ ServiceAccount name.
 {{- end -}}
 
 {{/*
-Image reference (repository:tag, tag defaults to appVersion).
+Image reference. A digest pins the image immutably and wins over any tag;
+otherwise repository:tag, with tag defaulting to the chart's appVersion.
 */}}
 {{- define "stella.image" -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}
+{{- else -}}
 {{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
 {{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
 {{- end -}}
 
 {{/*
@@ -86,8 +91,16 @@ actionable message. Kept in one place so every template shares the same checks.
 {{- fail (printf "stella: replicaCount must be 1 (got %v). Stella does not support multiple replicas; see the 'Why only one replica?' section of the Kubernetes deployment docs. The Deployment strategy is fixed to Recreate." $v.replicaCount) -}}
 {{- end -}}
 
-{{- if not (trim $v.baseURL) -}}
+{{- $baseURL := trim $v.baseURL -}}
+{{- if not $baseURL -}}
 {{- fail "stella: baseURL is required — set it to the externally reachable URL clients use (STELLA_BASE_URL), e.g. --set baseURL=https://stella.example.com" -}}
+{{- end -}}
+{{- if not (or (hasPrefix "http://" $baseURL) (hasPrefix "https://" $baseURL)) -}}
+{{- fail (printf "stella: baseURL must include an http:// or https:// scheme (got %q). It is the public address clients reach, used for OAuth callbacks and channel deep links." $baseURL) -}}
+{{- end -}}
+{{- $host := regexReplaceAll "^https?://([^/:]+).*$" $baseURL "${1}" -}}
+{{- if or (eq $host "localhost") (hasPrefix "127." $host) (eq $host "0.0.0.0") (eq $host "::1") -}}
+{{- fail (printf "stella: baseURL host %q is a loopback/bind address, but it must be the externally reachable URL clients use (the ingress address), or OAuth callbacks and channel links break." $host) -}}
 {{- end -}}
 
 {{- if not (trim $v.secrets.existingSecret) -}}
@@ -118,6 +131,17 @@ actionable message. Kept in one place so every template shares the same checks.
 {{- range $v.extraEnv -}}
 {{- if has .name (list "STELLA_BASE_URL" "STELLA_SANDBOX_BACKEND" "STELLA_HTTP_SHUTDOWN_TIMEOUT" "STELLA_RIVER_SOFT_STOP_TIMEOUT" "STELLA_VAULT_KEY" "STELLA_DATABASE_URL" "HOST" "PORT" "STELLA_REQUIRE_EXTERNAL_DB") -}}
 {{- fail (printf "stella: extraEnv must not set %s — it is managed by the chart's typed values (baseURL, secrets.*, sandbox.*, shutdown.*), which enforce this chart's safety contract. Setting it twice would make the effective value ambiguous." .name) -}}
+{{- end -}}
+{{- end -}}
+
+{{- if $v.ingress.enabled -}}
+{{- if not $v.ingress.hosts -}}
+{{- fail "stella: ingress.enabled=true requires at least one entry under ingress.hosts (each with a host and one or more paths), or the rendered Ingress is rejected by the API server." -}}
+{{- end -}}
+{{- range $v.ingress.hosts -}}
+{{- if or (not .host) (not .paths) -}}
+{{- fail "stella: every ingress.hosts entry needs a non-empty host and at least one path." -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/deploy/helm/stella/templates/_helpers.tpl
+++ b/deploy/helm/stella/templates/_helpers.tpl
@@ -110,4 +110,14 @@ actionable message. Kept in one place so every template shares the same checks.
 {{- if lt (int $s.terminationGracePeriodSeconds) $minGrace -}}
 {{- fail (printf "stella: shutdown.terminationGracePeriodSeconds (%d) is too small. It must be >= preStopSeconds + httpSeconds + riverSoftStopSeconds + 10 (cleanup margin) = %d + %d + %d + 10 = %d, or the kubelet SIGKILLs the pod mid-drain." (int $s.terminationGracePeriodSeconds) (int $s.preStopSeconds) (int $s.httpSeconds) (int $s.riverSoftStopSeconds) $minGrace) -}}
 {{- end -}}
+
+{{- if and (not $v.persistence.enabled) (not $v.persistence.allowEphemeralDataLoss) -}}
+{{- fail "stella: persistence.enabled=false stores STELLA_HOME (user workspaces, attachments, article files) in an emptyDir that is lost on every pod restart. Set persistence.allowEphemeralDataLoss=true to acknowledge this, or keep persistence enabled." -}}
+{{- end -}}
+
+{{- range $v.extraEnv -}}
+{{- if has .name (list "STELLA_BASE_URL" "STELLA_SANDBOX_BACKEND" "STELLA_HTTP_SHUTDOWN_TIMEOUT" "STELLA_RIVER_SOFT_STOP_TIMEOUT" "STELLA_VAULT_KEY" "STELLA_DATABASE_URL" "HOST" "PORT" "STELLA_REQUIRE_EXTERNAL_DB") -}}
+{{- fail (printf "stella: extraEnv must not set %s — it is managed by the chart's typed values (baseURL, secrets.*, sandbox.*, shutdown.*), which enforce this chart's safety contract. Setting it twice would make the effective value ambiguous." .name) -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}

--- a/deploy/helm/stella/templates/_helpers.tpl
+++ b/deploy/helm/stella/templates/_helpers.tpl
@@ -1,0 +1,113 @@
+{{/*
+Chart name, optionally overridden.
+*/}}
+{{- define "stella.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Fully qualified app name.
+*/}}
+{{- define "stella.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "stella.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels.
+*/}}
+{{- define "stella.labels" -}}
+helm.sh/chart: {{ include "stella.chart" . }}
+{{ include "stella.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "stella.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "stella.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+ServiceAccount name.
+*/}}
+{{- define "stella.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "stella.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Image reference (repository:tag, tag defaults to appVersion).
+*/}}
+{{- define "stella.image" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
+
+{{/*
+Name of the PVC backing STELLA_HOME.
+*/}}
+{{- define "stella.pvcName" -}}
+{{- if .Values.persistence.existingClaim -}}
+{{- .Values.persistence.existingClaim -}}
+{{- else -}}
+{{- printf "%s-data" (include "stella.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+validate — hard configuration gates. Each rule fails rendering with an
+actionable message. Kept in one place so every template shares the same checks.
+*/}}
+{{- define "stella.validate" -}}
+{{- $v := .Values -}}
+
+{{- if ne (int $v.replicaCount) 1 -}}
+{{- fail (printf "stella: replicaCount must be 1 (got %v). Stella does not support multiple replicas; see the 'Why only one replica?' section of the Kubernetes deployment docs. The Deployment strategy is fixed to Recreate." $v.replicaCount) -}}
+{{- end -}}
+
+{{- if not (trim $v.baseURL) -}}
+{{- fail "stella: baseURL is required — set it to the externally reachable URL clients use (STELLA_BASE_URL), e.g. --set baseURL=https://stella.example.com" -}}
+{{- end -}}
+
+{{- if not (trim $v.secrets.existingSecret) -}}
+{{- fail "stella: secrets.existingSecret is required — create a Secret with STELLA_VAULT_KEY and STELLA_DATABASE_URL, then set secrets.existingSecret to its name. This chart does not create the Secret." -}}
+{{- end -}}
+
+{{- $backend := trim $v.sandbox.backend -}}
+{{- if not $backend -}}
+{{- fail "stella: sandbox.backend is required — set it to 'local' (bubblewrap, experimental) or 'none' (no isolation). The 'docker' backend is not supported by this chart." -}}
+{{- end -}}
+{{- if not (has $backend (list "local" "none")) -}}
+{{- fail (printf "stella: sandbox.backend must be 'local' or 'none' (got %q). The 'docker' backend is not supported by this chart." $backend) -}}
+{{- end -}}
+{{- if and (eq $backend "none") (not $v.sandbox.allowUnsafeHostExecution) -}}
+{{- fail "stella: sandbox.backend=none runs agent tools directly inside the Stella pod with no isolation. Set sandbox.allowUnsafeHostExecution=true to acknowledge this, or choose sandbox.backend=local." -}}
+{{- end -}}
+
+{{- $s := $v.shutdown -}}
+{{- $minGrace := add (int $s.preStopSeconds) (int $s.httpSeconds) (int $s.riverSoftStopSeconds) 10 -}}
+{{- if lt (int $s.terminationGracePeriodSeconds) $minGrace -}}
+{{- fail (printf "stella: shutdown.terminationGracePeriodSeconds (%d) is too small. It must be >= preStopSeconds + httpSeconds + riverSoftStopSeconds + 10 (cleanup margin) = %d + %d + %d + 10 = %d, or the kubelet SIGKILLs the pod mid-drain." (int $s.terminationGracePeriodSeconds) (int $s.preStopSeconds) (int $s.httpSeconds) (int $s.riverSoftStopSeconds) $minGrace) -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/stella/templates/_helpers.tpl
+++ b/deploy/helm/stella/templates/_helpers.tpl
@@ -64,7 +64,7 @@ otherwise repository:tag, with tag defaulting to the chart's appVersion.
 {{- if .Values.image.digest -}}
 {{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}
 {{- else -}}
-{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- $tag := .Values.image.tag | default "latest" -}}
 {{- printf "%s:%s" .Values.image.repository $tag -}}
 {{- end -}}
 {{- end -}}

--- a/deploy/helm/stella/templates/deployment.yaml
+++ b/deploy/helm/stella/templates/deployment.yaml
@@ -18,12 +18,12 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "stella.selectorLabels" . | nindent 8 }}
+        {{- /* podLabels cannot collide with the selector labels: stella.validate
+               rejects the two selector keys, so no duplicate YAML keys render. */}}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- /* Selector labels render last so podLabels can never shadow them
-               and leave the Deployment unable to find its own pods. */}}
-        {{- include "stella.selectorLabels" . | nindent 8 }}
       {{- with .Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
@@ -42,7 +42,10 @@ spec:
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
-          type: RuntimeDefault
+          # RuntimeDefault by default. bubblewrap (sandbox.backend=local) may need
+          # Unconfined on clusters whose default profile blocks its namespace
+          # syscalls; that is why this is a lever, not a hardcoded value.
+          type: {{ .Values.sandbox.seccompProfile }}
       terminationGracePeriodSeconds: {{ int .Values.shutdown.terminationGracePeriodSeconds }}
       containers:
         - name: stella

--- a/deploy/helm/stella/templates/deployment.yaml
+++ b/deploy/helm/stella/templates/deployment.yaml
@@ -1,0 +1,123 @@
+{{- include "stella.validate" . -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "stella.fullname" . }}
+  labels:
+    {{- include "stella.labels" . | nindent 4 }}
+spec:
+  # Single replica only; enforced by stella.validate. Recreate avoids two pods
+  # ever running at once (they would fight over the RWO volume, the IM channel
+  # ingress, and in-process session state).
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "stella.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "stella.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "stella.serviceAccountName" . }}
+      automountServiceAccountToken: false
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+      terminationGracePeriodSeconds: {{ int .Values.shutdown.terminationGracePeriodSeconds }}
+      containers:
+        - name: stella
+          image: {{ include "stella.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 25678
+              protocol: TCP
+          env:
+            - name: STELLA_BASE_URL
+              value: {{ .Values.baseURL | quote }}
+            - name: STELLA_SANDBOX_BACKEND
+              value: {{ .Values.sandbox.backend | quote }}
+            - name: STELLA_HTTP_SHUTDOWN_TIMEOUT
+              value: {{ printf "%ds" (int .Values.shutdown.httpSeconds) | quote }}
+            - name: STELLA_RIVER_SOFT_STOP_TIMEOUT
+              value: {{ printf "%ds" (int .Values.shutdown.riverSoftStopSeconds) | quote }}
+            - name: STELLA_VAULT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.existingSecret | quote }}
+                  key: {{ .Values.secrets.keys.vaultKey | quote }}
+            - name: STELLA_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.existingSecret | quote }}
+                  key: {{ .Values.secrets.keys.databaseURL | quote }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /home/stella/.stella
+          lifecycle:
+            preStop:
+              exec:
+                # The app has not received SIGTERM yet during preStop; this sleep
+                # only gives endpoint removal time to propagate so the load
+                # balancer stops routing new traffic before the drain begins.
+                command: ["/bin/sleep", {{ int .Values.shutdown.preStopSeconds | quote }}]
+          # startupProbe gates liveness/readiness until the process is serving,
+          # covering migrations, seed, and plugin reconcile (5s * 60 = 5 min).
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 5
+            failureThreshold: 60
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            periodSeconds: 5
+            failureThreshold: 2
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: data
+        {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "stella.pvcName" . }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/stella/templates/deployment.yaml
+++ b/deploy/helm/stella/templates/deployment.yaml
@@ -18,10 +18,12 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "stella.selectorLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- /* Selector labels render last so podLabels can never shadow them
+               and leave the Deployment unable to find its own pods. */}}
+        {{- include "stella.selectorLabels" . | nindent 8 }}
       {{- with .Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
@@ -39,6 +41,8 @@ spec:
         runAsGroup: 1000
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
       terminationGracePeriodSeconds: {{ int .Values.shutdown.terminationGracePeriodSeconds }}
       containers:
         - name: stella
@@ -114,6 +118,9 @@ spec:
               path: /readyz
               port: http
             periodSeconds: 5
+            # /readyz pings the database with a 2s budget; a 1s probe timeout
+            # (the kubelet default) would flap the pod NotReady under DB latency.
+            timeoutSeconds: 3
             failureThreshold: 2
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/deploy/helm/stella/templates/deployment.yaml
+++ b/deploy/helm/stella/templates/deployment.yaml
@@ -44,11 +44,27 @@ spec:
         - name: stella
           image: {{ include "stella.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if eq (trim .Values.sandbox.backend) "none" }}
+          # With no sandbox there is no reason to keep escalation paths open.
+          # The local (bubblewrap) backend omits this: bwrap needs user
+          # namespaces and, on setuid installs, privilege escalation.
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          {{- end }}
           ports:
             - name: http
               containerPort: 25678
               protocol: TCP
           env:
+            # Set explicitly rather than trusting the image's ENV defaults: the
+            # chart's contract (reachable probes, no embedded PostgreSQL) must
+            # hold for any image.repository/tag the user substitutes.
+            - name: HOST
+              value: "0.0.0.0"
+            - name: STELLA_REQUIRE_EXTERNAL_DB
+              value: "1"
             - name: STELLA_BASE_URL
               value: {{ .Values.baseURL | quote }}
             - name: STELLA_SANDBOX_BACKEND

--- a/deploy/helm/stella/templates/ingress.yaml
+++ b/deploy/helm/stella/templates/ingress.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "stella.fullname" . -}}
+{{- $svcPort := int .Values.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "stella.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/stella/templates/pvc.yaml
+++ b/deploy/helm/stella/templates/pvc.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "stella.pvcName" . }}
+  labels:
+    {{- include "stella.labels" . | nindent 4 }}
+  annotations:
+    # Keep the claim (and its data) when the release is uninstalled. Delete it
+    # manually if you really mean to discard STELLA_HOME.
+    helm.sh/resource-policy: keep
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  {{- if eq "-" .Values.persistence.storageClass }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/stella/templates/service.yaml
+++ b/deploy/helm/stella/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "stella.fullname" . }}
+  labels:
+    {{- include "stella.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "stella.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ int .Values.service.port }}
+      targetPort: http
+      protocol: TCP

--- a/deploy/helm/stella/templates/serviceaccount.yaml
+++ b/deploy/helm/stella/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "stella.serviceAccountName" . }}
+  labels:
+    {{- include "stella.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+# Stella does not call the Kubernetes API; never mount a token into the pod.
+automountServiceAccountToken: false
+{{- end }}

--- a/deploy/helm/stella/values.schema.json
+++ b/deploy/helm/stella/values.schema.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Stella Helm values",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "replicaCount",
+    "image",
+    "baseURL",
+    "secrets",
+    "sandbox",
+    "shutdown",
+    "persistence",
+    "service"
+  ],
+  "properties": {
+    "replicaCount": {
+      "type": "integer",
+      "description": "Must be 1; multi-replica is unsupported."
+    },
+    "image": {
+      "type": "object",
+      "required": ["repository", "pullPolicy"],
+      "properties": {
+        "repository": { "type": "string", "minLength": 1 },
+        "tag": { "type": "string" },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        }
+      }
+    },
+    "imagePullSecrets": { "type": "array" },
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "baseURL": { "type": "string" },
+    "secrets": {
+      "type": "object",
+      "required": ["existingSecret", "keys"],
+      "properties": {
+        "existingSecret": { "type": "string" },
+        "keys": {
+          "type": "object",
+          "required": ["vaultKey", "databaseURL"],
+          "properties": {
+            "vaultKey": { "type": "string", "minLength": 1 },
+            "databaseURL": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
+    },
+    "sandbox": {
+      "type": "object",
+      "required": ["backend"],
+      "properties": {
+        "backend": {
+          "type": "string",
+          "enum": ["", "local", "none"],
+          "description": "docker is intentionally unsupported by this chart."
+        },
+        "allowUnsafeHostExecution": { "type": "boolean" }
+      }
+    },
+    "shutdown": {
+      "type": "object",
+      "required": [
+        "preStopSeconds",
+        "httpSeconds",
+        "riverSoftStopSeconds",
+        "terminationGracePeriodSeconds"
+      ],
+      "properties": {
+        "preStopSeconds": { "type": "integer", "minimum": 0 },
+        "httpSeconds": { "type": "integer", "minimum": 1 },
+        "riverSoftStopSeconds": { "type": "integer", "minimum": 1 },
+        "terminationGracePeriodSeconds": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "required": ["enabled"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "size": { "type": "string" },
+        "accessMode": {
+          "type": "string",
+          "enum": ["ReadWriteOnce", "ReadWriteOncePod"]
+        },
+        "storageClass": { "type": "string" },
+        "existingClaim": { "type": "string" }
+      }
+    },
+    "service": {
+      "type": "object",
+      "required": ["type", "port"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
+        },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "className": { "type": "string" },
+        "annotations": { "type": "object" },
+        "hosts": { "type": "array" },
+        "tls": { "type": "array" }
+      }
+    },
+    "resources": { "type": "object" },
+    "extraEnv": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean" },
+        "name": { "type": "string" },
+        "annotations": { "type": "object" }
+      }
+    },
+    "podAnnotations": { "type": "object" },
+    "podLabels": { "type": "object" },
+    "nodeSelector": { "type": "object" },
+    "tolerations": { "type": "array" },
+    "affinity": { "type": "object" }
+  }
+}

--- a/deploy/helm/stella/values.schema.json
+++ b/deploy/helm/stella/values.schema.json
@@ -24,6 +24,7 @@
       "properties": {
         "repository": { "type": "string", "minLength": 1 },
         "tag": { "type": "string" },
+        "digest": { "type": "string" },
         "pullPolicy": {
           "type": "string",
           "enum": ["Always", "IfNotPresent", "Never"]

--- a/deploy/helm/stella/values.schema.json
+++ b/deploy/helm/stella/values.schema.json
@@ -59,7 +59,11 @@
           "enum": ["", "local", "none"],
           "description": "docker is intentionally unsupported by this chart."
         },
-        "allowUnsafeHostExecution": { "type": "boolean" }
+        "allowUnsafeHostExecution": { "type": "boolean" },
+        "seccompProfile": {
+          "type": "string",
+          "enum": ["RuntimeDefault", "Unconfined"]
+        }
       }
     },
     "shutdown": {

--- a/deploy/helm/stella/values.schema.json
+++ b/deploy/helm/stella/values.schema.json
@@ -81,6 +81,7 @@
       "required": ["enabled"],
       "properties": {
         "enabled": { "type": "boolean" },
+        "allowEphemeralDataLoss": { "type": "boolean" },
         "size": { "type": "string" },
         "accessMode": {
           "type": "string",

--- a/deploy/helm/stella/values.yaml
+++ b/deploy/helm/stella/values.yaml
@@ -1,0 +1,122 @@
+# Default values for the Stella chart.
+# Stella runs as a single replica (see the "Why only one replica?" section of
+# the Kubernetes deployment docs). Values that have no safe default are left
+# empty and rejected at render time with an actionable message.
+
+# Stella does not support multiple replicas. This must be 1; any other value
+# fails rendering. The Deployment strategy is hard-wired to Recreate and is not
+# configurable.
+replicaCount: 1
+
+image:
+  repository: ghcr.io/cherryhq/stella
+  # Empty tag defaults to the chart's appVersion.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+# Names of image pull secrets (for a private registry).
+imagePullSecrets: []
+# - name: my-registry-creds
+
+nameOverride: ""
+fullnameOverride: ""
+
+# Public, externally reachable URL clients see (STELLA_BASE_URL). Used for OAuth
+# callback URLs and channel deep links, so it must be the ingress address, never
+# a loopback. Required.
+baseURL: ""
+
+# Stella's required secrets are read from a Secret you create out-of-band. The
+# chart only references it; it never creates or templates secret material.
+# Deliberate ceiling: no in-chart secret creation until a demo path needs it.
+secrets:
+  # Name of a pre-existing Secret holding STELLA_VAULT_KEY and STELLA_DATABASE_URL.
+  # Required.
+  existingSecret: ""
+  # Keys within that Secret. Defaults match the environment variable names, so a
+  # `kubectl create secret generic ... --from-literal=STELLA_VAULT_KEY=...` works
+  # without further configuration.
+  keys:
+    vaultKey: STELLA_VAULT_KEY
+    databaseURL: STELLA_DATABASE_URL
+
+sandbox:
+  # Which sandbox backend agent tools use. Required, no default. One of:
+  #   local — bubblewrap isolation. EXPERIMENTAL: needs a cluster that permits
+  #           unprivileged user namespaces. The chart adds no privileges and
+  #           mounts no docker socket.
+  #   none  — no sandbox isolation. Agent tools run directly inside the Stella
+  #           pod. This does NOT disable agent tools; it removes their isolation.
+  # The `docker` backend is intentionally unsupported here (no docker socket).
+  backend: ""
+  # Must be true when backend is "none" to acknowledge that agent tools execute
+  # unsandboxed inside the pod. Ignored for other backends.
+  allowUnsafeHostExecution: false
+
+# Two-phase graceful-shutdown budget, in whole seconds. See the deployment docs
+# for how these combine. Rendering fails when the termination grace period is
+# too small to cover the full drain.
+shutdown:
+  # preStop sleep: buys time for endpoint removal to propagate before SIGTERM.
+  preStopSeconds: 10
+  # STELLA_HTTP_SHUTDOWN_TIMEOUT: in-flight HTTP drain budget.
+  httpSeconds: 60
+  # STELLA_RIVER_SOFT_STOP_TIMEOUT: in-flight background-job drain budget.
+  riverSoftStopSeconds: 120
+  # Pod terminationGracePeriodSeconds. Must be >= preStop + http + river + 10.
+  terminationGracePeriodSeconds: 200
+
+# Persistent storage for STELLA_HOME (/home/stella/.stella).
+persistence:
+  enabled: true
+  size: 10Gi
+  accessMode: ReadWriteOnce
+  # Empty uses the cluster default StorageClass; "-" disables dynamic provisioning.
+  storageClass: ""
+  # Reuse a PVC you manage yourself instead of one created by the chart.
+  existingClaim: ""
+
+service:
+  type: ClusterIP
+  port: 25678
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: stella.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  # tls:
+  #   - secretName: stella-tls
+  #     hosts:
+  #       - stella.example.com
+  tls: []
+
+resources:
+  requests:
+    cpu: 500m
+    memory: 1Gi
+  limits:
+    cpu: "2"
+    memory: 4Gi
+
+# Extra plain environment variables passed through verbatim. Use this for
+# optional integrations (S3 asset mirror STELLA_BLOB_S3_*, OIDC_*, provider API
+# keys). Keep secret values in the Secret referenced above, not here.
+extraEnv: []
+# - name: STELLA_BLOB_S3_ENDPOINT
+#   value: https://s3.example.com
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+podAnnotations: {}
+podLabels: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/deploy/helm/stella/values.yaml
+++ b/deploy/helm/stella/values.yaml
@@ -12,6 +12,9 @@ image:
   repository: ghcr.io/cherryhq/stella
   # Empty tag defaults to the chart's appVersion.
   tag: ""
+  # Immutable digest (e.g. "sha256:abc..."). When set it pins the image and
+  # takes precedence over tag; recommended for production.
+  digest: ""
   pullPolicy: IfNotPresent
 
 # Names of image pull secrets (for a private registry).

--- a/deploy/helm/stella/values.yaml
+++ b/deploy/helm/stella/values.yaml
@@ -10,11 +10,14 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/cherryhq/stella
-  # Empty tag defaults to the chart's appVersion.
+  # Empty tag defaults to "latest" (tracks the newest published release). For
+  # reproducible/production deploys pin a version tag (e.g. v0.50.5) or a digest.
   tag: ""
   # Immutable digest (e.g. "sha256:abc..."). When set it pins the image and
   # takes precedence over tag; recommended for production.
   digest: ""
+  # With tag "latest" + IfNotPresent a node reuses its cached image; set Always
+  # (or pin a digest) if a restart must pull the newest "latest".
   pullPolicy: IfNotPresent
 
 # Names of image pull secrets (for a private registry).

--- a/deploy/helm/stella/values.yaml
+++ b/deploy/helm/stella/values.yaml
@@ -69,6 +69,10 @@ shutdown:
 # Persistent storage for STELLA_HOME (/home/stella/.stella).
 persistence:
   enabled: true
+  # STELLA_HOME holds durable user data (workspaces, attachments, article
+  # files). Disabling persistence puts it in an emptyDir that vanishes on every
+  # pod restart, so enabled=false additionally requires this acknowledgement.
+  allowEphemeralDataLoss: false
   size: 10Gi
   accessMode: ReadWriteOnce
   # Empty uses the cluster default StorageClass; "-" disables dynamic provisioning.
@@ -106,6 +110,10 @@ resources:
 # Extra plain environment variables passed through verbatim. Use this for
 # optional integrations (S3 asset mirror STELLA_BLOB_S3_*, OIDC_*, provider API
 # keys). Keep secret values in the Secret referenced above, not here.
+# Variables the chart manages through typed values (STELLA_BASE_URL,
+# STELLA_SANDBOX_BACKEND, the shutdown timeouts, the two secret refs, HOST,
+# PORT, STELLA_REQUIRE_EXTERNAL_DB) are rejected here — overriding them would
+# bypass the chart's validation contract.
 extraEnv: []
 # - name: STELLA_BLOB_S3_ENDPOINT
 #   value: https://s3.example.com

--- a/deploy/helm/stella/values.yaml
+++ b/deploy/helm/stella/values.yaml
@@ -55,6 +55,10 @@ sandbox:
   # Must be true when backend is "none" to acknowledge that agent tools execute
   # unsandboxed inside the pod. Ignored for other backends.
   allowUnsafeHostExecution: false
+  # Pod seccomp profile. RuntimeDefault is the hardened default. If backend=local
+  # (bubblewrap) fails with seccomp/namespace errors on your cluster, set this to
+  # Unconfined; backend=none never needs it.
+  seccompProfile: RuntimeDefault
 
 # Two-phase graceful-shutdown budget, in whole seconds. See the deployment docs
 # for how these combine. Rendering fails when the termination grace period is

--- a/dprint.json
+++ b/dprint.json
@@ -5,7 +5,7 @@
   "dockerfile": {},
   "markup": {},
   "yaml": {},
-  "excludes": ["**/*-lock.json", "web/**"],
+  "excludes": ["**/*-lock.json", "web/**", "deploy/helm/stella/templates/**"],
   "plugins": [
     "https://plugins.dprint.dev/json-0.21.3.wasm",
     "https://plugins.dprint.dev/markdown-0.21.1.wasm",

--- a/internal/server/AGENTS.md
+++ b/internal/server/AGENTS.md
@@ -22,7 +22,7 @@ GET /api/*      → apiserver.HandlerFromMux       (all API routes from OpenAPI 
 GET /{path...}  → web.SPAHandler()              (serves dist files or index.html fallback)
 ```
 
-`authMiddleware` (global, wraps the entire mux) exempts `/login`, `/static/`, `/s/`, `GET /api/shares/public/*`, and auth endpoints. All other page routes require a valid session; unauthenticated requests are redirected to `/login`.
+`authMiddleware` (global, wraps the entire mux) exempts `/login`, `/healthz`, `/readyz` (infrastructure probes — no user session), `/static/`, `/s/`, `GET /api/shares/public/*`, and auth endpoints. All other page routes require a valid session; unauthenticated requests are redirected to `/login`. See `isAuthExempt` in `middleware.go` for the authoritative list.
 
 ### Directory Structure
 

--- a/mise.toml
+++ b/mise.toml
@@ -5,6 +5,7 @@ dprint = "0.54.0"
 jq = "1.8.1"
 yq = "4.49.2"
 act = "0.2.88"
+helm = "3.16.4"
 # Go
 "github:pressly/goose" = "3.27.1"
 go = "1.25.9"
@@ -242,6 +243,14 @@ if ! tar tzf "$archive" 2>/dev/null | grep -Eq "(^|/)${bin}$" && ! unzip -l "$ar
 fi
 echo "OK: archive $archive contains stellad"
 """
+
+# ============================================================================
+# Deploy
+# ============================================================================
+
+[tasks."deploy:helm:check"]
+description = "Lint and render-assert the Kubernetes Helm chart"
+run = "bash deploy/helm/check.sh"
 
 # ============================================================================
 # Docker

--- a/web/content/docs/admin/kubernetes.md
+++ b/web/content/docs/admin/kubernetes.md
@@ -94,7 +94,7 @@ install with `-f values.yaml`.
 | ---------------------------------------- | ------------------------------- | ------------------------------------------------------------------ |
 | `replicaCount`                           | `1`                             | Must be `1`. Any other value is rejected.                          |
 | `image.repository`                       | `ghcr.io/cherryhq/stella`       | Container image.                                                   |
-| `image.tag`                              | `""`                            | Defaults to the chart's `appVersion`.                              |
+| `image.tag`                              | `""`                            | Defaults to `latest`; pin a version tag or digest for production.  |
 | `image.digest`                           | `""`                            | `sha256:…` digest; pins the image and overrides `tag`.             |
 | `image.pullPolicy`                       | `IfNotPresent`                  |                                                                    |
 | `imagePullSecrets`                       | `[]`                            | For a private registry.                                            |

--- a/web/content/docs/admin/kubernetes.md
+++ b/web/content/docs/admin/kubernetes.md
@@ -26,10 +26,12 @@ two-phase graceful drain. Multiple replicas are not supported — see
 ### Create the Secret
 
 The chart never creates or templates secret material; it only references a Secret
-you create yourself. Create it with your real values:
+you create yourself. Create the namespace and the Secret in it (the same namespace
+you install the release into):
 
 ```bash
-kubectl create secret generic stella-secrets \
+kubectl create namespace stella
+kubectl -n stella create secret generic stella-secrets \
   --from-literal=STELLA_VAULT_KEY='AGE-SECRET-KEY-REPLACE-ME' \
   --from-literal=STELLA_DATABASE_URL='postgres://user:pass@postgres.example.com:5432/stella?sslmode=require'
 ```
@@ -40,7 +42,7 @@ you must use different key names, set `secrets.keys.vaultKey` and
 `secrets.keys.databaseURL`.
 
 > Updating this Secret does **not** restart the pod. After you change it, roll the
-> deployment: `kubectl rollout restart deployment/stella`.
+> deployment: `kubectl -n stella rollout restart deployment/stella`.
 
 ## Install
 
@@ -48,12 +50,15 @@ From a checkout of the repository:
 
 ```bash
 helm install stella ./deploy/helm/stella \
-  --namespace stella --create-namespace \
+  --namespace stella \
   --set baseURL=https://stella.example.com \
   --set secrets.existingSecret=stella-secrets \
-  --set sandbox.backend=none \
-  --set sandbox.allowUnsafeHostExecution=true
+  --set sandbox.backend=local
 ```
+
+`sandbox.backend=local` is the recommended choice — it isolates agent-run tools with
+bubblewrap. Only fall back to `none` after reading [Sandbox backend](#sandbox-backend);
+`none` runs agent code with no isolation and exposes deployment secrets to it.
 
 `baseURL`, `secrets.existingSecret`, and `sandbox.backend` are required — the chart
 refuses to render without them. `baseURL` must be the externally reachable URL
@@ -90,6 +95,7 @@ install with `-f values.yaml`.
 | `replicaCount`                           | `1`                             | Must be `1`. Any other value is rejected.                          |
 | `image.repository`                       | `ghcr.io/cherryhq/stella`       | Container image.                                                   |
 | `image.tag`                              | `""`                            | Defaults to the chart's `appVersion`.                              |
+| `image.digest`                           | `""`                            | `sha256:…` digest; pins the image and overrides `tag`.             |
 | `image.pullPolicy`                       | `IfNotPresent`                  |                                                                    |
 | `imagePullSecrets`                       | `[]`                            | For a private registry.                                            |
 | `baseURL`                                | `""`                            | **Required.** Public URL (`STELLA_BASE_URL`).                      |
@@ -142,21 +148,34 @@ defaults, so its contract holds for any `image.repository` you substitute.
 
 ## Sandbox backend
 
-`sandbox.backend` is required and has no default. This chart supports two backends;
-the `docker` backend is intentionally unsupported (it would need a mounted Docker
-socket).
+`sandbox.backend` is required and has no default. It decides how the tools an agent
+runs (`bash`, file edits) are isolated from the Stella process. This chart supports
+two backends; the `docker` backend is intentionally unsupported (it would need a
+mounted Docker socket).
 
-- **`none`** — `none` does not disable agent tools — it runs them directly inside
-  the Stella pod without sandbox isolation. Because there is no isolation host,
-  you must also set `sandbox.allowUnsafeHostExecution=true` to acknowledge it, or
-  rendering fails. This is the simplest, most reliable backend on Kubernetes.
-- **`local`** — bubblewrap isolation. **Experimental on Kubernetes.** It depends on
-  the cluster allowing _unprivileged user namespaces_ (bubblewrap calls
-  `unshare(2)`). The chart adds no privileged securityContext and mounts no Docker
-  socket. If tools fail with `bwrap:` / `unshare` / "Operation not permitted"
-  errors, either switch to `none` (and confirm `allowUnsafeHostExecution=true`) or
-  reconfigure the cluster/node to permit unprivileged user namespaces and an
-  unrestricted seccomp profile.
+- **`local`** (recommended) — bubblewrap isolation. Tool processes run in their own
+  user, PID, and mount namespaces with the Stella process's environment scrubbed, so
+  they cannot read its secrets. **Experimental on Kubernetes:** it depends on the
+  cluster allowing _unprivileged user namespaces_ (bubblewrap calls `unshare(2)`).
+  The chart adds no privileged securityContext and mounts no Docker socket. If tools
+  fail with `bwrap:` / `unshare` / "Operation not permitted" errors, reconfigure the
+  cluster/node to permit unprivileged user namespaces and an unrestricted seccomp
+  profile — do not reach for `none` to work around it on a multi-tenant deployment.
+- **`none`** — no isolation. `none` does not disable agent tools; it runs them
+  directly inside the Stella pod as the same user and in the same process namespace.
+
+  > **`none` exposes deployment secrets to agent code.** With no process isolation,
+  > a tool can read the Stella process's environment (e.g. `/proc/1/environ`) and
+  > recover `STELLA_VAULT_KEY` — the master key that decrypts **every tenant's**
+  > secrets and tokens — and `STELLA_DATABASE_URL`. `secretKeyRef` and the `extraEnv`
+  > guard do not protect against this. Only choose `none` when every user who can
+  > drive an agent is fully trusted (e.g. a single-operator install), never for a
+  > multi-tenant or public deployment.
+
+  Because of that, `none` also requires `sandbox.allowUnsafeHostExecution=true` to
+  render. The chart still drops all Linux capabilities and disallows privilege
+  escalation for the container in this mode, but that does not restore the process
+  isolation the secret exposure depends on.
 
 ## Why only one replica?
 
@@ -178,9 +197,21 @@ the moment a second pod runs.
   `STELLA_HOME` files (the database stores only relative paths). A second pod with
   its own volume would not see them.
 
-`Recreate` guarantees the old pod is fully gone before the new one starts, so these
-never overlap. The chart does not ship HPA, PodDisruptionBudget, or NetworkPolicy
-resources — they only make sense for a stateless, multi-replica workload.
+`Recreate` guarantees a clean rollout: the old pod is fully gone before the new one
+starts, so these never overlap during an upgrade. (An involuntary disruption — a node
+failure or eviction — can still briefly overlap two pods; see [Storage](#storage) for
+the `ReadWriteOncePod` fencing option.)
+
+The chart ships no HPA (autoscaling a stateful single replica is unsafe) and no
+PodDisruptionBudget. A single-replica PDB is a deliberate omission, not an oversight:
+`minAvailable: 1` on one replica blocks every voluntary eviction, including node
+drains for maintenance. If your operations require gating voluntary disruptions,
+add one yourself and accept that it will hold up node drains until the pod is
+manually moved.
+
+Because the Deployment strategy is `Recreate`, an HPA or a second replica can never
+be reached through values — but a raw manifest edit could. Do not add either; the
+"Why only one replica?" reasons above are correctness constraints, not tuning.
 
 ## Graceful shutdown
 
@@ -232,6 +263,16 @@ The pod runs as UID/GID `1000` with `fsGroup: 1000` and
 `fsGroupChangePolicy: OnRootMismatch`, so the volume is group-owned correctly on
 first mount.
 
+The chart-created PVC name is derived from the release/chart name. Do not change
+`nameOverride`/`fullnameOverride` after install — the pod would bind a new, empty
+PVC and the old one (with your data) would be left behind by the `keep` policy. Use
+`persistence.existingClaim` to pin a volume you manage yourself.
+
+To keep a node failure from ever running two pods against the volume at once, set
+`persistence.accessMode: ReadWriteOncePod` on a cluster that supports it (Kubernetes
+1.29+). With plain `ReadWriteOnce`, `Recreate` prevents overlap on rollout but not
+during an involuntary disruption.
+
 ## Network egress
 
 Stella needs outbound access to:
@@ -243,6 +284,37 @@ Stella needs outbound access to:
 
 If your cluster restricts egress, allow these destinations. The chart does not ship
 a NetworkPolicy.
+
+**Restrict egress when you run untrusted agents.** Agent tools reach the network
+with the pod's full access — and with `sandbox.backend=none` they do so as arbitrary
+model-driven code. At minimum, block the cloud metadata endpoint
+(`169.254.169.254`), which on IMDSv1 clusters can hand out node IAM credentials, and
+deny east-west traffic you do not need. A starting NetworkPolicy:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: stella-egress
+  namespace: stella
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: stella
+  policyTypes: [Egress]
+  egress:
+    # DNS
+    - to: []
+      ports:
+        - { protocol: UDP, port: 53 }
+        - { protocol: TCP, port: 53 }
+    # Everything except link-local (blocks 169.254.169.254). Tighten to your
+    # PostgreSQL, provider, IM, and S3 CIDRs for a real deployment.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except: ["169.254.0.0/16"]
+```
 
 ## Troubleshooting
 
@@ -257,7 +329,8 @@ a NetworkPolicy.
   StorageClass whose driver honors `fsGroup`.
 - **Agent tools fail with `bwrap` / `unshare` errors.** You are on
   `sandbox.backend=local` in a cluster that blocks unprivileged user namespaces.
-  Switch to `sandbox.backend=none` (with `sandbox.allowUnsafeHostExecution=true`) or
-  reconfigure the node to allow them.
+  Reconfigure the node to allow them. Switching to `sandbox.backend=none` also makes
+  the error go away, but on a multi-tenant deployment that trades an isolation error
+  for a secret-exposure problem — see [Sandbox backend](#sandbox-backend) first.
 - **OAuth/channel links point at localhost.** `baseURL` is wrong or unset upstream —
   set it to the public ingress URL.

--- a/web/content/docs/admin/kubernetes.md
+++ b/web/content/docs/admin/kubernetes.md
@@ -104,6 +104,7 @@ install with `-f values.yaml`.
 | `secrets.keys.databaseURL`               | `STELLA_DATABASE_URL`           | Key in the Secret holding the DSN.                                 |
 | `sandbox.backend`                        | `""`                            | **Required.** `local` or `none` (see [Sandbox](#sandbox-backend)). |
 | `sandbox.allowUnsafeHostExecution`       | `false`                         | Must be `true` when `backend=none`.                                |
+| `sandbox.seccompProfile`                 | `RuntimeDefault`                | Pod seccomp profile. `Unconfined` if `local` needs it.             |
 | `shutdown.preStopSeconds`                | `10`                            | preStop sleep, for endpoint propagation.                           |
 | `shutdown.httpSeconds`                   | `60`                            | `STELLA_HTTP_SHUTDOWN_TIMEOUT`.                                    |
 | `shutdown.riverSoftStopSeconds`          | `120`                           | `STELLA_RIVER_SOFT_STOP_TIMEOUT`.                                  |
@@ -157,10 +158,13 @@ mounted Docker socket).
   user, PID, and mount namespaces with the Stella process's environment scrubbed, so
   they cannot read its secrets. **Experimental on Kubernetes:** it depends on the
   cluster allowing _unprivileged user namespaces_ (bubblewrap calls `unshare(2)`).
-  The chart adds no privileged securityContext and mounts no Docker socket. If tools
-  fail with `bwrap:` / `unshare` / "Operation not permitted" errors, reconfigure the
-  cluster/node to permit unprivileged user namespaces and an unrestricted seccomp
-  profile — do not reach for `none` to work around it on a multi-tenant deployment.
+  The chart adds no privileged securityContext and mounts no Docker socket, and
+  defaults the pod's seccomp profile to `RuntimeDefault`. If tools fail with `bwrap:`
+  / `unshare` / "Operation not permitted" errors, first set
+  `sandbox.seccompProfile=Unconfined` (some clusters' default profile blocks
+  bubblewrap's namespace syscalls); if that is not enough, reconfigure the
+  cluster/node to permit unprivileged user namespaces — do not reach for `none` to
+  work around it on a multi-tenant deployment.
 - **`none`** — no isolation. `none` does not disable agent tools; it runs them
   directly inside the Stella pod as the same user and in the same process namespace.
 
@@ -170,7 +174,8 @@ mounted Docker socket).
   > secrets and tokens — and `STELLA_DATABASE_URL`. `secretKeyRef` and the `extraEnv`
   > guard do not protect against this. Only choose `none` when every user who can
   > drive an agent is fully trusted (e.g. a single-operator install), never for a
-  > multi-tenant or public deployment.
+  > multi-tenant or public deployment. Hardening the `none` backend itself is
+  > tracked in [#705](https://github.com/CherryHQ/stella/issues/705).
 
   Because of that, `none` also requires `sandbox.allowUnsafeHostExecution=true` to
   render. The chart still drops all Linux capabilities and disallows privilege

--- a/web/content/docs/admin/kubernetes.md
+++ b/web/content/docs/admin/kubernetes.md
@@ -125,7 +125,7 @@ extraEnv:
     value: https://s3.example.com
   - name: STELLA_BLOB_S3_BUCKET
     value: stella-assets
-  - name: OIDC_ISSUER
+  - name: OIDC_ISSUER_URL
     value: https://id.example.com
 ```
 

--- a/web/content/docs/admin/kubernetes.md
+++ b/web/content/docs/admin/kubernetes.md
@@ -103,6 +103,7 @@ install with `-f values.yaml`.
 | `shutdown.riverSoftStopSeconds`          | `120`                           | `STELLA_RIVER_SOFT_STOP_TIMEOUT`.                                  |
 | `shutdown.terminationGracePeriodSeconds` | `200`                           | Pod grace period (see [formula](#graceful-shutdown)).              |
 | `persistence.enabled`                    | `true`                          | Mount a PVC at `/home/stella/.stella`.                             |
+| `persistence.allowEphemeralDataLoss`     | `false`                         | Must be `true` to disable persistence (emptyDir loses user data).  |
 | `persistence.size`                       | `10Gi`                          | Requested volume size.                                             |
 | `persistence.accessMode`                 | `ReadWriteOnce`                 |                                                                    |
 | `persistence.storageClass`               | `""`                            | Empty = cluster default; `-` disables dynamic provisioning.        |
@@ -131,6 +132,13 @@ extraEnv:
 
 Keep credentials (S3 secret key, OIDC client secret) out of `extraEnv` values that
 sit in your `values.yaml` — put them in the Secret and reference them there.
+
+Variables the chart manages through typed values are **rejected** in `extraEnv`
+(`STELLA_BASE_URL`, `STELLA_SANDBOX_BACKEND`, the shutdown timeouts, the vault key
+and DSN, `HOST`, `PORT`, `STELLA_REQUIRE_EXTERNAL_DB`): setting them there would
+silently bypass the chart's validation. The chart also sets `HOST=0.0.0.0` and
+`STELLA_REQUIRE_EXTERNAL_DB=1` explicitly rather than relying on the image's ENV
+defaults, so its contract holds for any `image.repository` you substitute.
 
 ## Sandbox backend
 

--- a/web/content/docs/admin/kubernetes.md
+++ b/web/content/docs/admin/kubernetes.md
@@ -1,0 +1,255 @@
+---
+title: Kubernetes
+description: Deploy Stella on Kubernetes with the production Helm chart.
+---
+
+Stella ships a Helm chart at `deploy/helm/stella` for running a single, production
+Stella instance on Kubernetes. It is deliberately opinionated: one replica, an
+external PostgreSQL, a persistent volume for `STELLA_HOME`, health probes, and a
+two-phase graceful drain. Multiple replicas are not supported — see
+[Why only one replica?](#why-only-one-replica).
+
+## Prerequisites
+
+- A Kubernetes cluster (1.23+) and `helm` 3.
+- **External PostgreSQL.** Stella refuses the embedded database in a container.
+  You need a reachable PostgreSQL server with the `pgvector` and `pg_search`
+  extensions, and a connection URL (DSN).
+- **A vault key.** Generate one with `stellad vault keygen` (or `age-keygen`). It
+  encrypts secrets, OAuth tokens, and bearer tokens; every restart must use the
+  same key.
+- **An ingress** (or another way to expose the Service) and the public URL clients
+  will use.
+- Optional: an S3-compatible bucket for the durable user-asset mirror, and an
+  OIDC provider for login. Both are passed through `extraEnv` (see below).
+
+### Create the Secret
+
+The chart never creates or templates secret material; it only references a Secret
+you create yourself. Create it with your real values:
+
+```bash
+kubectl create secret generic stella-secrets \
+  --from-literal=STELLA_VAULT_KEY='AGE-SECRET-KEY-REPLACE-ME' \
+  --from-literal=STELLA_DATABASE_URL='postgres://user:pass@postgres.example.com:5432/stella?sslmode=require'
+```
+
+The default key names inside the Secret (`STELLA_VAULT_KEY`, `STELLA_DATABASE_URL`)
+match the environment variables Stella reads, so no further mapping is needed. If
+you must use different key names, set `secrets.keys.vaultKey` and
+`secrets.keys.databaseURL`.
+
+> Updating this Secret does **not** restart the pod. After you change it, roll the
+> deployment: `kubectl rollout restart deployment/stella`.
+
+## Install
+
+From a checkout of the repository:
+
+```bash
+helm install stella ./deploy/helm/stella \
+  --namespace stella --create-namespace \
+  --set baseURL=https://stella.example.com \
+  --set secrets.existingSecret=stella-secrets \
+  --set sandbox.backend=none \
+  --set sandbox.allowUnsafeHostExecution=true
+```
+
+`baseURL`, `secrets.existingSecret`, and `sandbox.backend` are required — the chart
+refuses to render without them. `baseURL` must be the externally reachable URL
+(the ingress address), never a loopback: it is the source for OAuth callback URLs
+and channel deep links.
+
+Expose the Service with an ingress:
+
+```bash
+helm upgrade stella ./deploy/helm/stella --namespace stella --reuse-values \
+  --set ingress.enabled=true \
+  --set ingress.className=nginx \
+  --set 'ingress.hosts[0].host=stella.example.com' \
+  --set 'ingress.hosts[0].paths[0].path=/' \
+  --set 'ingress.hosts[0].paths[0].pathType=Prefix' \
+  --set 'ingress.tls[0].secretName=stella-tls' \
+  --set 'ingress.tls[0].hosts[0]=stella.example.com'
+```
+
+Without an ingress, reach the Web UI with a port-forward:
+
+```bash
+kubectl -n stella port-forward svc/stella 25678:25678
+# then open http://localhost:25678
+```
+
+For anything beyond a couple of flags, put your settings in a `values.yaml` and
+install with `-f values.yaml`.
+
+## Values reference
+
+| Key                                      | Default                         | Description                                                        |
+| ---------------------------------------- | ------------------------------- | ------------------------------------------------------------------ |
+| `replicaCount`                           | `1`                             | Must be `1`. Any other value is rejected.                          |
+| `image.repository`                       | `ghcr.io/cherryhq/stella`       | Container image.                                                   |
+| `image.tag`                              | `""`                            | Defaults to the chart's `appVersion`.                              |
+| `image.pullPolicy`                       | `IfNotPresent`                  |                                                                    |
+| `imagePullSecrets`                       | `[]`                            | For a private registry.                                            |
+| `baseURL`                                | `""`                            | **Required.** Public URL (`STELLA_BASE_URL`).                      |
+| `secrets.existingSecret`                 | `""`                            | **Required.** Name of the Secret with the vault key and DSN.       |
+| `secrets.keys.vaultKey`                  | `STELLA_VAULT_KEY`              | Key in the Secret holding the vault key.                           |
+| `secrets.keys.databaseURL`               | `STELLA_DATABASE_URL`           | Key in the Secret holding the DSN.                                 |
+| `sandbox.backend`                        | `""`                            | **Required.** `local` or `none` (see [Sandbox](#sandbox-backend)). |
+| `sandbox.allowUnsafeHostExecution`       | `false`                         | Must be `true` when `backend=none`.                                |
+| `shutdown.preStopSeconds`                | `10`                            | preStop sleep, for endpoint propagation.                           |
+| `shutdown.httpSeconds`                   | `60`                            | `STELLA_HTTP_SHUTDOWN_TIMEOUT`.                                    |
+| `shutdown.riverSoftStopSeconds`          | `120`                           | `STELLA_RIVER_SOFT_STOP_TIMEOUT`.                                  |
+| `shutdown.terminationGracePeriodSeconds` | `200`                           | Pod grace period (see [formula](#graceful-shutdown)).              |
+| `persistence.enabled`                    | `true`                          | Mount a PVC at `/home/stella/.stella`.                             |
+| `persistence.size`                       | `10Gi`                          | Requested volume size.                                             |
+| `persistence.accessMode`                 | `ReadWriteOnce`                 |                                                                    |
+| `persistence.storageClass`               | `""`                            | Empty = cluster default; `-` disables dynamic provisioning.        |
+| `persistence.existingClaim`              | `""`                            | Reuse a PVC you manage instead of creating one.                    |
+| `service.type` / `service.port`          | `ClusterIP` / `25678`           |                                                                    |
+| `ingress.*`                              | disabled                        | `className`, `annotations`, `hosts`, `tls`.                        |
+| `resources`                              | 500m/1Gi requests, 2/4Gi limits |                                                                    |
+| `extraEnv`                               | `[]`                            | Passthrough plain env vars (S3, OIDC, provider keys).              |
+| `serviceAccount.*`                       | `create: true`                  | Token automount is always off.                                     |
+
+### Optional integrations via `extraEnv`
+
+The chart keeps its values surface small; optional integrations go through
+`extraEnv` (a list of `name`/`value` entries) and, for secret values, the Secret
+you reference. For example, the S3 asset mirror and OIDC login:
+
+```yaml
+extraEnv:
+  - name: STELLA_BLOB_S3_ENDPOINT
+    value: https://s3.example.com
+  - name: STELLA_BLOB_S3_BUCKET
+    value: stella-assets
+  - name: OIDC_ISSUER
+    value: https://id.example.com
+```
+
+Keep credentials (S3 secret key, OIDC client secret) out of `extraEnv` values that
+sit in your `values.yaml` — put them in the Secret and reference them there.
+
+## Sandbox backend
+
+`sandbox.backend` is required and has no default. This chart supports two backends;
+the `docker` backend is intentionally unsupported (it would need a mounted Docker
+socket).
+
+- **`none`** — `none` does not disable agent tools — it runs them directly inside
+  the Stella pod without sandbox isolation. Because there is no isolation host,
+  you must also set `sandbox.allowUnsafeHostExecution=true` to acknowledge it, or
+  rendering fails. This is the simplest, most reliable backend on Kubernetes.
+- **`local`** — bubblewrap isolation. **Experimental on Kubernetes.** It depends on
+  the cluster allowing _unprivileged user namespaces_ (bubblewrap calls
+  `unshare(2)`). The chart adds no privileged securityContext and mounts no Docker
+  socket. If tools fail with `bwrap:` / `unshare` / "Operation not permitted"
+  errors, either switch to `none` (and confirm `allowUnsafeHostExecution=true`) or
+  reconfigure the cluster/node to permit unprivileged user namespaces and an
+  unrestricted seccomp profile.
+
+## Why only one replica?
+
+The chart hard-codes `replicaCount: 1` and `strategy: Recreate`. Stella is not
+stateless: a multi-replica readiness audit found three classes of state that break
+the moment a second pod runs.
+
+- **IM channels start in full on every replica.** Each pod independently starts
+  every configured Telegram/QQ/Feishu/WeChat connection. Two pods means two long-poll
+  or WebSocket sessions on the same bot token — platforms respond with conflicts
+  (e.g. Telegram `409`) or deliver each message twice.
+- **Live streaming and per-session serialization are in-process.** The guarantee
+  that a session has only one in-flight turn, and the SSE hub that streams turn
+  output to the browser, live in the memory of the pod running the turn. A second
+  pod would run concurrent turns for the same session and could not stream a turn
+  it isn't running.
+- **`STELLA_HOME` is treated as durable, pod-local data.** User workspaces,
+  uploaded and channel attachments, and Recally article bodies are written to
+  `STELLA_HOME` files (the database stores only relative paths). A second pod with
+  its own volume would not see them.
+
+`Recreate` guarantees the old pod is fully gone before the new one starts, so these
+never overlap. The chart does not ship HPA, PodDisruptionBudget, or NetworkPolicy
+resources — they only make sense for a stateless, multi-replica workload.
+
+## Graceful shutdown
+
+On `SIGTERM` Stella runs a two-phase drain: `/readyz` flips to `503`, in-flight HTTP
+requests drain within `STELLA_HTTP_SHUTDOWN_TIMEOUT`, then background jobs drain
+within `STELLA_RIVER_SOFT_STOP_TIMEOUT`. The chart wires these from the `shutdown.*`
+values and validates the grace period covers the whole drain:
+
+```
+terminationGracePeriodSeconds >=
+    preStopSeconds            (endpoint propagation)
+  + httpSeconds               (STELLA_HTTP_SHUTDOWN_TIMEOUT)
+  + riverSoftStopSeconds      (STELLA_RIVER_SOFT_STOP_TIMEOUT)
+  + 10                        (cleanup margin)
+```
+
+At the defaults that is `10 + 60 + 120 + 10 = 200`. A smaller grace period is
+rejected at render time — otherwise the kubelet would `SIGKILL` the pod mid-drain.
+
+The `preStop` step is a plain `sleep`. During `preStop` the application has **not**
+received `SIGTERM` yet; traffic is shed because the kubelet removes the pod from the
+Service endpoints when termination begins, and the sleep gives that removal time to
+propagate. It does not depend on `/readyz` flipping to `503`.
+
+## Upgrades
+
+Because of `strategy: Recreate`, every upgrade has a brief **downtime** window while
+the old pod stops and the new one starts and passes its startup probe.
+
+- **Back up first.** Snapshot your PostgreSQL database (`pg_dump`) and the
+  `STELLA_HOME` PVC before upgrading. Stella applies pending database migrations
+  automatically on startup.
+- **`helm rollback` only reverts the workload, not the database.** Rolling the chart
+  back to an older image does not undo migrations that the newer version already
+  applied. If you must roll back across a migration, restore the database from your
+  backup as well.
+
+## Storage
+
+`STELLA_HOME` (`/home/stella/.stella`) is backed by a PVC. When the chart creates
+it, the PVC carries `helm.sh/resource-policy: keep`, so `helm uninstall` leaves the
+volume — and your data — in place. Delete it deliberately when you mean to:
+
+```bash
+kubectl -n stella delete pvc stella-data
+```
+
+The pod runs as UID/GID `1000` with `fsGroup: 1000` and
+`fsGroupChangePolicy: OnRootMismatch`, so the volume is group-owned correctly on
+first mount.
+
+## Network egress
+
+Stella needs outbound access to:
+
+- **PostgreSQL** — your external database (usually `5432`).
+- **LLM provider APIs** — Anthropic, OpenAI, or whichever providers you configure.
+- **IM platform APIs** — Telegram, QQ, Feishu, WeChat, for any channels you enable.
+- **S3 / object storage** — only if you configure the `STELLA_BLOB_S3_*` asset mirror.
+
+If your cluster restricts egress, allow these destinations. The chart does not ship
+a NetworkPolicy.
+
+## Troubleshooting
+
+- **Pod never becomes ready / `/readyz` returns `503`.** `/readyz` is `503` while
+  startup is incomplete, during shutdown, or when the database ping fails. Check the
+  pod logs and confirm `STELLA_DATABASE_URL` points at a reachable PostgreSQL with
+  `pgvector` and `pg_search`. The startup probe allows up to five minutes for
+  migrations, seed, and plugin reconcile before liveness/readiness begin.
+- **`permission denied` writing under `/home/stella/.stella`.** The volume was not
+  group-owned for GID `1000`. The chart sets `fsGroup: 1000`; if your CSI driver
+  ignores `fsGroup` (some do), set ownership on the volume out-of-band or choose a
+  StorageClass whose driver honors `fsGroup`.
+- **Agent tools fail with `bwrap` / `unshare` errors.** You are on
+  `sandbox.backend=local` in a cluster that blocks unprivileged user namespaces.
+  Switch to `sandbox.backend=none` (with `sandbox.allowUnsafeHostExecution=true`) or
+  reconfigure the node to allow them.
+- **OAuth/channel links point at localhost.** `baseURL` is wrong or unset upstream —
+  set it to the public ingress URL.

--- a/web/content/docs/admin/kubernetes.zh.md
+++ b/web/content/docs/admin/kubernetes.zh.md
@@ -96,6 +96,7 @@ kubectl -n stella port-forward svc/stella 25678:25678
 | `secrets.keys.databaseURL`               | `STELLA_DATABASE_URL`           | Secret 中存 DSN 的键名。                                      |
 | `sandbox.backend`                        | `""`                            | **必填。** `local` 或 `none`（见 [沙箱](#sandbox-backend)）。 |
 | `sandbox.allowUnsafeHostExecution`       | `false`                         | `backend=none` 时必须为 `true`。                              |
+| `sandbox.seccompProfile`                 | `RuntimeDefault`                | Pod seccomp profile。`local` 需要时设 `Unconfined`。          |
 | `shutdown.preStopSeconds`                | `10`                            | preStop sleep，等待 endpoint 摘除传播。                       |
 | `shutdown.httpSeconds`                   | `60`                            | `STELLA_HTTP_SHUTDOWN_TIMEOUT`。                              |
 | `shutdown.riverSoftStopSeconds`          | `120`                           | `STELLA_RIVER_SOFT_STOP_TIMEOUT`。                            |
@@ -145,9 +146,11 @@ socket）。
 - **`local`**（推荐）—— bubblewrap 隔离。工具进程运行在自己独立的 user、PID、mount
   namespace 里，且 Stella 进程的环境变量被擦除，因此读不到它的密钥。**在 Kubernetes
   上属实验性：** 依赖集群允许 _非特权 user namespace_（bubblewrap 会调用
-  `unshare(2)`）。chart 不加任何特权 securityContext，也不挂 Docker socket。若工具报
-  `bwrap:` / `unshare` / “Operation not permitted” 错误，请把集群/节点改成允许非特权
-  user namespace 和不受限的 seccomp profile —— 在多租户部署上不要用切到 `none` 来绕过。
+  `unshare(2)`）。chart 不加任何特权 securityContext，也不挂 Docker socket，并把 pod
+  的 seccomp profile 默认设为 `RuntimeDefault`。若工具报 `bwrap:` / `unshare` /
+  “Operation not permitted” 错误，先设 `sandbox.seccompProfile=Unconfined`（某些集群
+  的默认 profile 会拦掉 bubblewrap 的 namespace 系统调用）；若还不够，再把集群/节点改成
+  允许非特权 user namespace —— 在多租户部署上不要用切到 `none` 来绕过。
 - **`none`** —— 无隔离。`none` 不会禁用 agent 工具；它让工具以同一用户、同一进程
   namespace 直接在 Stella pod 内运行。
 
@@ -155,7 +158,8 @@ socket）。
   > 进程的环境变量（如 `/proc/1/environ`），拿到 `STELLA_VAULT_KEY`——解密**每一个
   > 租户**密钥与 token 的主密钥——以及 `STELLA_DATABASE_URL`。`secretKeyRef` 和
   > `extraEnv` 防护都挡不住这条路径。只有当每个能驱动 agent 的用户都完全可信时
-  > （例如单运维者的私有部署）才用 `none`，绝不要用于多租户或公开部署。
+  > （例如单运维者的私有部署）才用 `none`，绝不要用于多租户或公开部署。加固 `none`
+  > 后端本身的工作追踪在 [#705](https://github.com/CherryHQ/stella/issues/705)。
 
   正因如此，`none` 还要求 `sandbox.allowUnsafeHostExecution=true` 才能渲染。这种模式
   下 chart 仍会为容器 drop 所有 Linux capability 并禁止提权，但这并不能恢复密钥暴露

--- a/web/content/docs/admin/kubernetes.zh.md
+++ b/web/content/docs/admin/kubernetes.zh.md
@@ -1,0 +1,230 @@
+---
+title: Kubernetes
+description: 使用生产级 Helm chart 在 Kubernetes 上部署 Stella。
+---
+
+Stella 在 `deploy/helm/stella` 提供了一个 Helm chart，用于在 Kubernetes 上运行单个
+生产实例。它刻意做了强约束：单副本、外部 PostgreSQL、给 `STELLA_HOME` 挂持久卷、
+健康探针，以及两阶段优雅摘流。**不支持多副本** —— 参见
+[为什么只能单副本？](#why-only-one-replica)。
+
+## 前置条件
+
+- 一个 Kubernetes 集群（1.23+）和 `helm` 3。
+- **外部 PostgreSQL。** 容器内 Stella 拒绝使用内嵌数据库。你需要一台可达的
+  PostgreSQL，装有 `pgvector` 与 `pg_search` 扩展，并拿到连接串（DSN）。
+- **一个 vault key。** 用 `stellad vault keygen`（或 `age-keygen`）生成。它加密密钥、
+  OAuth token 和 bearer token；每次重启都必须使用同一个 key。
+- **一个 ingress**（或其他暴露 Service 的方式）以及客户端将访问的公网 URL。
+- 可选：一个 S3 兼容存储桶用于持久化用户附件镜像，以及一个用于登录的 OIDC provider。
+  两者都通过 `extraEnv` 传入（见下文）。
+
+### 创建 Secret
+
+chart 从不创建或渲染任何密钥内容，只引用你自己创建的 Secret。用你的真实值创建它：
+
+```bash
+kubectl create secret generic stella-secrets \
+  --from-literal=STELLA_VAULT_KEY='AGE-SECRET-KEY-REPLACE-ME' \
+  --from-literal=STELLA_DATABASE_URL='postgres://user:pass@postgres.example.com:5432/stella?sslmode=require'
+```
+
+Secret 里默认的 key 名（`STELLA_VAULT_KEY`、`STELLA_DATABASE_URL`）与 Stella 读取的
+环境变量一致，无需额外映射。若必须用不同的 key 名，设置 `secrets.keys.vaultKey`
+和 `secrets.keys.databaseURL`。
+
+> 更新这个 Secret **不会**自动重启 Pod。改完之后需手动滚动：
+> `kubectl rollout restart deployment/stella`。
+
+## 安装
+
+在仓库检出目录下：
+
+```bash
+helm install stella ./deploy/helm/stella \
+  --namespace stella --create-namespace \
+  --set baseURL=https://stella.example.com \
+  --set secrets.existingSecret=stella-secrets \
+  --set sandbox.backend=none \
+  --set sandbox.allowUnsafeHostExecution=true
+```
+
+`baseURL`、`secrets.existingSecret`、`sandbox.backend` 为必填 —— 缺任意一个 chart 都
+拒绝渲染。`baseURL` 必须是外部可达的 URL（ingress 地址），绝不能是 loopback：它是
+OAuth 回调 URL 和通道 deep link 的来源。
+
+用 ingress 暴露 Service：
+
+```bash
+helm upgrade stella ./deploy/helm/stella --namespace stella --reuse-values \
+  --set ingress.enabled=true \
+  --set ingress.className=nginx \
+  --set 'ingress.hosts[0].host=stella.example.com' \
+  --set 'ingress.hosts[0].paths[0].path=/' \
+  --set 'ingress.hosts[0].paths[0].pathType=Prefix' \
+  --set 'ingress.tls[0].secretName=stella-tls' \
+  --set 'ingress.tls[0].hosts[0]=stella.example.com'
+```
+
+不用 ingress 时，用 port-forward 访问 Web UI：
+
+```bash
+kubectl -n stella port-forward svc/stella 25678:25678
+# 然后打开 http://localhost:25678
+```
+
+超过几个 flag 的配置，建议写进 `values.yaml`，用 `-f values.yaml` 安装。
+
+## Values 参考
+
+| 键                                       | 默认值                          | 说明                                                          |
+| ---------------------------------------- | ------------------------------- | ------------------------------------------------------------- |
+| `replicaCount`                           | `1`                             | 必须为 `1`，其他值一律拒绝。                                  |
+| `image.repository`                       | `ghcr.io/cherryhq/stella`       | 容器镜像。                                                    |
+| `image.tag`                              | `""`                            | 为空时用 chart 的 `appVersion`。                              |
+| `image.pullPolicy`                       | `IfNotPresent`                  |                                                               |
+| `imagePullSecrets`                       | `[]`                            | 私有 registry 用。                                            |
+| `baseURL`                                | `""`                            | **必填。** 公网 URL（`STELLA_BASE_URL`）。                    |
+| `secrets.existingSecret`                 | `""`                            | **必填。** 含 vault key 与 DSN 的 Secret 名。                 |
+| `secrets.keys.vaultKey`                  | `STELLA_VAULT_KEY`              | Secret 中存 vault key 的键名。                                |
+| `secrets.keys.databaseURL`               | `STELLA_DATABASE_URL`           | Secret 中存 DSN 的键名。                                      |
+| `sandbox.backend`                        | `""`                            | **必填。** `local` 或 `none`（见 [沙箱](#sandbox-backend)）。 |
+| `sandbox.allowUnsafeHostExecution`       | `false`                         | `backend=none` 时必须为 `true`。                              |
+| `shutdown.preStopSeconds`                | `10`                            | preStop sleep，等待 endpoint 摘除传播。                       |
+| `shutdown.httpSeconds`                   | `60`                            | `STELLA_HTTP_SHUTDOWN_TIMEOUT`。                              |
+| `shutdown.riverSoftStopSeconds`          | `120`                           | `STELLA_RIVER_SOFT_STOP_TIMEOUT`。                            |
+| `shutdown.terminationGracePeriodSeconds` | `200`                           | Pod grace period（见 [公式](#graceful-shutdown)）。           |
+| `persistence.enabled`                    | `true`                          | 在 `/home/stella/.stella` 挂 PVC。                            |
+| `persistence.size`                       | `10Gi`                          | 申请卷大小。                                                  |
+| `persistence.accessMode`                 | `ReadWriteOnce`                 |                                                               |
+| `persistence.storageClass`               | `""`                            | 空 = 集群默认；`-` 关闭动态供给。                             |
+| `persistence.existingClaim`              | `""`                            | 复用你自己管理的 PVC，不由 chart 创建。                       |
+| `service.type` / `service.port`          | `ClusterIP` / `25678`           |                                                               |
+| `ingress.*`                              | 关闭                            | `className`、`annotations`、`hosts`、`tls`。                  |
+| `resources`                              | requests 500m/1Gi，limits 2/4Gi |                                                               |
+| `extraEnv`                               | `[]`                            | 透传普通环境变量（S3、OIDC、provider key）。                  |
+| `serviceAccount.*`                       | `create: true`                  | token automount 始终关闭。                                    |
+
+### 通过 `extraEnv` 接入可选集成
+
+chart 刻意保持 values 面最小；可选集成走 `extraEnv`（`name`/`value` 列表），密钥类
+值放进你引用的 Secret。例如 S3 附件镜像和 OIDC 登录：
+
+```yaml
+extraEnv:
+  - name: STELLA_BLOB_S3_ENDPOINT
+    value: https://s3.example.com
+  - name: STELLA_BLOB_S3_BUCKET
+    value: stella-assets
+  - name: OIDC_ISSUER
+    value: https://id.example.com
+```
+
+凭据（S3 secret key、OIDC client secret）不要写进落在 `values.yaml` 里的 `extraEnv`
+值 —— 放进 Secret 并在那里引用。
+
+## 沙箱后端 {#sandbox-backend}
+
+`sandbox.backend` 必填且无默认值。本 chart 支持两种后端；`docker` 后端刻意不支持
+（它需要挂载 Docker socket）。
+
+- **`none`** —— `none does not disable agent tools — it runs them directly inside
+the Stella pod without sandbox isolation.`（none 不会禁用 agent 工具，而是让它们
+  直接在 Stella pod 内、无沙箱隔离地运行。）因为没有隔离宿主，你必须同时设置
+  `sandbox.allowUnsafeHostExecution=true` 来确认，否则渲染失败。这是 Kubernetes 上
+  最简单、最可靠的后端。
+- **`local`** —— bubblewrap 隔离。**在 Kubernetes 上属实验性。** 它依赖集群允许
+  _非特权 user namespace_（bubblewrap 会调用 `unshare(2)`）。chart 不加任何特权
+  securityContext，也不挂 Docker socket。若工具报 `bwrap:` / `unshare` /
+  “Operation not permitted” 错误，要么切到 `none`（并确认
+  `allowUnsafeHostExecution=true`），要么把集群/节点改成允许非特权 user namespace
+  和不受限的 seccomp profile。
+
+## 为什么只能单副本？ {#why-only-one-replica}
+
+chart 写死了 `replicaCount: 1` 与 `strategy: Recreate`。Stella 不是无状态的：一次
+多副本就绪度审计发现三类状态，一旦跑起第二个 pod 立刻出错。
+
+- **IM 通道在每个副本上全量启动。** 每个 pod 各自启动所有已配置的
+  Telegram/QQ/Feishu/微信连接。两个 pod 就是同一个 bot token 上两条 long-poll 或
+  WebSocket 会话 —— 平台会返回冲突（如 Telegram `409`）或把每条消息投递两次。
+- **实时推送与 per-session 串行化是进程内存态。** “同一 session 只有一个进行中
+  turn” 的保证，以及把 turn 输出推给浏览器的 SSE hub，都只存在于跑该 turn 的那个
+  pod 的内存里。第二个 pod 会对同一 session 并发跑 turn，且无法推送它没在跑的 turn。
+- **`STELLA_HOME` 被当作持久的、pod 本地的数据。** 用户工作区、上传与通道附件、
+  Recally 文章正文都写在 `STELLA_HOME` 文件里（数据库只存相对路径）。带独立卷的
+  第二个 pod 看不到这些文件。
+
+`Recreate` 保证新 pod 启动前旧 pod 已完全消失，所以这些永不重叠。chart 不提供
+HPA、PodDisruptionBudget 或 NetworkPolicy 资源 —— 它们只对无状态多副本负载才有意义。
+
+## 优雅停机 {#graceful-shutdown}
+
+收到 `SIGTERM` 后 Stella 走两阶段摘流：`/readyz` 翻成 `503`，在
+`STELLA_HTTP_SHUTDOWN_TIMEOUT` 内排空在途 HTTP 请求，再在
+`STELLA_RIVER_SOFT_STOP_TIMEOUT` 内排空后台任务。chart 从 `shutdown.*` values
+渲染这些值，并校验 grace period 覆盖整个摘流：
+
+```
+terminationGracePeriodSeconds >=
+    preStopSeconds            (endpoint 摘除传播)
+  + httpSeconds               (STELLA_HTTP_SHUTDOWN_TIMEOUT)
+  + riverSoftStopSeconds      (STELLA_RIVER_SOFT_STOP_TIMEOUT)
+  + 10                        (清理余量)
+```
+
+按默认值即 `10 + 60 + 120 + 10 = 200`。更小的 grace period 会在渲染期被拒 ——
+否则 kubelet 会在摘流中途 `SIGKILL` 掉 pod。
+
+`preStop` 步骤就是一个普通 `sleep`。preStop 期间应用**还没**收到 `SIGTERM`；流量
+之所以被摘掉，是因为终止开始时 kubelet 会把 pod 从 Service endpoints 里移除，sleep
+给这个移除留出传播时间。它**不**依赖 `/readyz` 翻成 `503`。
+
+## 升级
+
+由于 `strategy: Recreate`，每次升级都有一小段**停机**窗口 —— 旧 pod 停止、新 pod
+启动并通过 startup probe 期间。
+
+- **先备份。** 升级前对 PostgreSQL 做快照（`pg_dump`）并备份 `STELLA_HOME` 的 PVC。
+  Stella 启动时会自动应用待执行的数据库迁移。
+- **`helm rollback` 只回滚 workload，不回滚数据库。** 把 chart 回滚到旧镜像不会撤销
+  新版本已经应用的迁移。若必须跨迁移回滚，请一并从备份恢复数据库。
+
+## 存储
+
+`STELLA_HOME`（`/home/stella/.stella`）由 PVC 支撑。chart 创建它时会带上
+`helm.sh/resource-policy: keep`，所以 `helm uninstall` 会保留卷 —— 以及你的数据。
+确实要删时手动删：
+
+```bash
+kubectl -n stella delete pvc stella-data
+```
+
+Pod 以 UID/GID `1000` 运行，配 `fsGroup: 1000` 和
+`fsGroupChangePolicy: OnRootMismatch`，首次挂载时卷会被正确地按组授权。
+
+## 网络出站
+
+Stella 需要出站访问：
+
+- **PostgreSQL** —— 你的外部数据库（通常 `5432`）。
+- **LLM provider API** —— Anthropic、OpenAI，或你配置的任意 provider。
+- **IM 平台 API** —— 你启用的通道对应的 Telegram、QQ、Feishu、微信。
+- **S3 / 对象存储** —— 仅当你配置了 `STELLA_BLOB_S3_*` 附件镜像时。
+
+若集群限制出站，请放行这些目标。chart 不提供 NetworkPolicy。
+
+## 排障
+
+- **Pod 一直不 ready / `/readyz` 返回 `503`。** 启动未完成、正在停机、或数据库 ping
+  失败时 `/readyz` 都是 `503`。查 pod 日志，确认 `STELLA_DATABASE_URL` 指向一台
+  可达、装有 `pgvector` 与 `pg_search` 的 PostgreSQL。startup probe 给迁移、seed、
+  插件 reconcile 最多五分钟，之后 liveness/readiness 才开始。
+- **写 `/home/stella/.stella` 时 `permission denied`。** 卷没有按 GID `1000` 授组。
+  chart 设了 `fsGroup: 1000`；若你的 CSI 驱动忽略 `fsGroup`（有些会），请在外部给卷
+  设好属主，或选一个驱动尊重 `fsGroup` 的 StorageClass。
+- **agent 工具报 `bwrap` / `unshare` 错误。** 你在一个禁止非特权 user namespace 的
+  集群上用 `sandbox.backend=local`。切到 `sandbox.backend=none`（并设
+  `sandbox.allowUnsafeHostExecution=true`），或把节点改成允许它们。
+- **OAuth/通道链接指向 localhost。** 上游的 `baseURL` 错了或没设 —— 把它设成公网
+  ingress URL。

--- a/web/content/docs/admin/kubernetes.zh.md
+++ b/web/content/docs/admin/kubernetes.zh.md
@@ -21,10 +21,12 @@ Stella 在 `deploy/helm/stella` 提供了一个 Helm chart，用于在 Kubernete
 
 ### 创建 Secret
 
-chart 从不创建或渲染任何密钥内容，只引用你自己创建的 Secret。用你的真实值创建它：
+chart 从不创建或渲染任何密钥内容，只引用你自己创建的 Secret。先创建 namespace，
+再在同一个 namespace（你安装 release 的那个）里用真实值创建它：
 
 ```bash
-kubectl create secret generic stella-secrets \
+kubectl create namespace stella
+kubectl -n stella create secret generic stella-secrets \
   --from-literal=STELLA_VAULT_KEY='AGE-SECRET-KEY-REPLACE-ME' \
   --from-literal=STELLA_DATABASE_URL='postgres://user:pass@postgres.example.com:5432/stella?sslmode=require'
 ```
@@ -34,7 +36,7 @@ Secret 里默认的 key 名（`STELLA_VAULT_KEY`、`STELLA_DATABASE_URL`）与 S
 和 `secrets.keys.databaseURL`。
 
 > 更新这个 Secret **不会**自动重启 Pod。改完之后需手动滚动：
-> `kubectl rollout restart deployment/stella`。
+> `kubectl -n stella rollout restart deployment/stella`。
 
 ## 安装
 
@@ -42,12 +44,15 @@ Secret 里默认的 key 名（`STELLA_VAULT_KEY`、`STELLA_DATABASE_URL`）与 S
 
 ```bash
 helm install stella ./deploy/helm/stella \
-  --namespace stella --create-namespace \
+  --namespace stella \
   --set baseURL=https://stella.example.com \
   --set secrets.existingSecret=stella-secrets \
-  --set sandbox.backend=none \
-  --set sandbox.allowUnsafeHostExecution=true
+  --set sandbox.backend=local
 ```
+
+`sandbox.backend=local` 是推荐选项 —— 它用 bubblewrap 隔离 agent 运行的工具。只有在
+读过 [沙箱后端](#sandbox-backend) 之后才考虑退回 `none`；`none` 让 agent 代码无隔离
+运行，并会把部署密钥暴露给它。
 
 `baseURL`、`secrets.existingSecret`、`sandbox.backend` 为必填 —— 缺任意一个 chart 都
 拒绝渲染。`baseURL` 必须是外部可达的 URL（ingress 地址），绝不能是 loopback：它是
@@ -82,6 +87,7 @@ kubectl -n stella port-forward svc/stella 25678:25678
 | `replicaCount`                           | `1`                             | 必须为 `1`，其他值一律拒绝。                                  |
 | `image.repository`                       | `ghcr.io/cherryhq/stella`       | 容器镜像。                                                    |
 | `image.tag`                              | `""`                            | 为空时用 chart 的 `appVersion`。                              |
+| `image.digest`                           | `""`                            | `sha256:…` 摘要；固定镜像并覆盖 `tag`。                       |
 | `image.pullPolicy`                       | `IfNotPresent`                  |                                                               |
 | `imagePullSecrets`                       | `[]`                            | 私有 registry 用。                                            |
 | `baseURL`                                | `""`                            | **必填。** 公网 URL（`STELLA_BASE_URL`）。                    |
@@ -132,20 +138,28 @@ chart 通过 typed values 管理的变量在 `extraEnv` 里会被**拒绝**（`S
 
 ## 沙箱后端 {#sandbox-backend}
 
-`sandbox.backend` 必填且无默认值。本 chart 支持两种后端；`docker` 后端刻意不支持
-（它需要挂载 Docker socket）。
+`sandbox.backend` 必填且无默认值。它决定 agent 运行的工具（`bash`、文件编辑）如何与
+Stella 进程隔离。本 chart 支持两种后端；`docker` 后端刻意不支持（它需要挂载 Docker
+socket）。
 
-- **`none`** —— `none` 不会禁用 agent 工具：它让工具直接在 Stella pod 内、无沙箱
-  隔离地运行（none does not disable agent tools — it runs them directly inside
-  the Stella pod without sandbox isolation）。因为没有隔离层，你必须同时设置
-  `sandbox.allowUnsafeHostExecution=true` 来确认，否则渲染失败。这是 Kubernetes 上
-  最简单、最可靠的后端。
-- **`local`** —— bubblewrap 隔离。**在 Kubernetes 上属实验性。** 它依赖集群允许
-  _非特权 user namespace_（bubblewrap 会调用 `unshare(2)`）。chart 不加任何特权
-  securityContext，也不挂 Docker socket。若工具报 `bwrap:` / `unshare` /
-  “Operation not permitted” 错误，要么切到 `none`（并确认
-  `allowUnsafeHostExecution=true`），要么把集群/节点改成允许非特权 user namespace
-  和不受限的 seccomp profile。
+- **`local`**（推荐）—— bubblewrap 隔离。工具进程运行在自己独立的 user、PID、mount
+  namespace 里，且 Stella 进程的环境变量被擦除，因此读不到它的密钥。**在 Kubernetes
+  上属实验性：** 依赖集群允许 _非特权 user namespace_（bubblewrap 会调用
+  `unshare(2)`）。chart 不加任何特权 securityContext，也不挂 Docker socket。若工具报
+  `bwrap:` / `unshare` / “Operation not permitted” 错误，请把集群/节点改成允许非特权
+  user namespace 和不受限的 seccomp profile —— 在多租户部署上不要用切到 `none` 来绕过。
+- **`none`** —— 无隔离。`none` 不会禁用 agent 工具；它让工具以同一用户、同一进程
+  namespace 直接在 Stella pod 内运行。
+
+  > **`none` 会把部署密钥暴露给 agent 代码。** 没有进程隔离，工具可以读取 Stella
+  > 进程的环境变量（如 `/proc/1/environ`），拿到 `STELLA_VAULT_KEY`——解密**每一个
+  > 租户**密钥与 token 的主密钥——以及 `STELLA_DATABASE_URL`。`secretKeyRef` 和
+  > `extraEnv` 防护都挡不住这条路径。只有当每个能驱动 agent 的用户都完全可信时
+  > （例如单运维者的私有部署）才用 `none`，绝不要用于多租户或公开部署。
+
+  正因如此，`none` 还要求 `sandbox.allowUnsafeHostExecution=true` 才能渲染。这种模式
+  下 chart 仍会为容器 drop 所有 Linux capability 并禁止提权，但这并不能恢复密钥暴露
+  所依赖的那层进程隔离。
 
 ## 为什么只能单副本？ {#why-only-one-replica}
 
@@ -162,8 +176,18 @@ chart 写死了 `replicaCount: 1` 与 `strategy: Recreate`。Stella 不是无状
   Recally 文章正文都写在 `STELLA_HOME` 文件里（数据库只存相对路径）。带独立卷的
   第二个 pod 看不到这些文件。
 
-`Recreate` 保证新 pod 启动前旧 pod 已完全消失，所以这些永不重叠。chart 不提供
-HPA、PodDisruptionBudget 或 NetworkPolicy 资源 —— 它们只对无状态多副本负载才有意义。
+`Recreate` 保证干净滚动：新 pod 启动前旧 pod 已完全消失，所以升级期间永不重叠。
+（节点故障或驱逐这类**非自愿中断**仍可能短暂让两个 pod 重叠；见 [存储](#存储) 的
+`ReadWriteOncePod` fencing 选项。）
+
+chart 不提供 HPA（对有状态单副本自动扩缩不安全），也不提供 PodDisruptionBudget。
+单副本不发 PDB 是刻意的，不是疏漏：单副本上 `minAvailable: 1` 会阻断一切自愿驱逐，
+包括节点维护时的 drain。若你的运维确实需要门控自愿中断，请自己加一个，并接受它会
+一直挡住节点 drain，直到手动迁移该 pod。
+
+由于 Deployment 策略是 `Recreate`，通过 values 永远无法得到 HPA 或第二个副本 —— 但
+手改裸 manifest 可以。不要那样做；上面“为什么只能单副本”的三条是正确性约束，不是
+可调参数。
 
 ## 优雅停机 {#graceful-shutdown}
 
@@ -210,6 +234,14 @@ kubectl -n stella delete pvc stella-data
 Pod 以 UID/GID `1000` 运行，配 `fsGroup: 1000` 和
 `fsGroupChangePolicy: OnRootMismatch`，首次挂载时卷会被正确地按组授权。
 
+chart 创建的 PVC 名字派生自 release/chart 名。安装后不要改
+`nameOverride`/`fullnameOverride` —— 否则 pod 会挂上一个新的空 PVC，而旧的（带你数据的）
+会因 `keep` 策略被留下。要固定你自己管理的卷，用 `persistence.existingClaim`。
+
+要让节点故障永远不会同时让两个 pod 用同一个卷，在支持的集群（Kubernetes 1.29+）上把
+`persistence.accessMode` 设为 `ReadWriteOncePod`。用普通 `ReadWriteOnce` 时，`Recreate`
+只保证滚动升级不重叠，不覆盖非自愿中断。
+
 ## 网络出站
 
 Stella 需要出站访问：
@@ -221,6 +253,36 @@ Stella 需要出站访问：
 
 若集群限制出站，请放行这些目标。chart 不提供 NetworkPolicy。
 
+**运行不受信任的 agent 时请限制出站。** agent 工具以 pod 的完整网络权限访问外部——
+在 `sandbox.backend=none` 下更是以任意模型驱动的代码身份访问。至少要阻断云元数据端点
+（`169.254.169.254`），它在 IMDSv1 集群上可能交出节点 IAM 凭据；并拒绝不需要的东西向
+流量。一个起步的 NetworkPolicy：
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: stella-egress
+  namespace: stella
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: stella
+  policyTypes: [Egress]
+  egress:
+    # DNS
+    - to: []
+      ports:
+        - { protocol: UDP, port: 53 }
+        - { protocol: TCP, port: 53 }
+    # 除 link-local 外全部放行（阻断 169.254.169.254）。生产环境请收紧到你的
+    # PostgreSQL、provider、IM、S3 的 CIDR。
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except: ["169.254.0.0/16"]
+```
+
 ## 排障
 
 - **Pod 一直不 ready / `/readyz` 返回 `503`。** 启动未完成、正在停机、或数据库 ping
@@ -231,7 +293,8 @@ Stella 需要出站访问：
   chart 设了 `fsGroup: 1000`；若你的 CSI 驱动忽略 `fsGroup`（有些会），请在外部给卷
   设好属主，或选一个驱动尊重 `fsGroup` 的 StorageClass。
 - **agent 工具报 `bwrap` / `unshare` 错误。** 你在一个禁止非特权 user namespace 的
-  集群上用 `sandbox.backend=local`。切到 `sandbox.backend=none`（并设
-  `sandbox.allowUnsafeHostExecution=true`），或把节点改成允许它们。
+  集群上用 `sandbox.backend=local`。把节点改成允许它们。切到 `sandbox.backend=none`
+  也能让错误消失，但在多租户部署上这是用一个隔离错误换来一个密钥暴露问题 —— 请先看
+  [沙箱后端](#sandbox-backend)。
 - **OAuth/通道链接指向 localhost。** 上游的 `baseURL` 错了或没设 —— 把它设成公网
   ingress URL。

--- a/web/content/docs/admin/kubernetes.zh.md
+++ b/web/content/docs/admin/kubernetes.zh.md
@@ -116,7 +116,7 @@ extraEnv:
     value: https://s3.example.com
   - name: STELLA_BLOB_S3_BUCKET
     value: stella-assets
-  - name: OIDC_ISSUER
+  - name: OIDC_ISSUER_URL
     value: https://id.example.com
 ```
 

--- a/web/content/docs/admin/kubernetes.zh.md
+++ b/web/content/docs/admin/kubernetes.zh.md
@@ -95,6 +95,7 @@ kubectl -n stella port-forward svc/stella 25678:25678
 | `shutdown.riverSoftStopSeconds`          | `120`                           | `STELLA_RIVER_SOFT_STOP_TIMEOUT`。                            |
 | `shutdown.terminationGracePeriodSeconds` | `200`                           | Pod grace period（见 [公式](#graceful-shutdown)）。           |
 | `persistence.enabled`                    | `true`                          | 在 `/home/stella/.stella` 挂 PVC。                            |
+| `persistence.allowEphemeralDataLoss`     | `false`                         | 关闭持久化时必须为 `true`（emptyDir 会丢用户数据）。          |
 | `persistence.size`                       | `10Gi`                          | 申请卷大小。                                                  |
 | `persistence.accessMode`                 | `ReadWriteOnce`                 |                                                               |
 | `persistence.storageClass`               | `""`                            | 空 = 集群默认；`-` 关闭动态供给。                             |
@@ -123,14 +124,20 @@ extraEnv:
 凭据（S3 secret key、OIDC client secret）不要写进落在 `values.yaml` 里的 `extraEnv`
 值 —— 放进 Secret 并在那里引用。
 
+chart 通过 typed values 管理的变量在 `extraEnv` 里会被**拒绝**（`STELLA_BASE_URL`、
+`STELLA_SANDBOX_BACKEND`、两个停机超时、vault key 与 DSN、`HOST`、`PORT`、
+`STELLA_REQUIRE_EXTERNAL_DB`）：在这里设置它们会静默绕过 chart 的校验。chart 也
+显式设置 `HOST=0.0.0.0` 和 `STELLA_REQUIRE_EXTERNAL_DB=1`，不依赖镜像的 ENV 默认
+值，所以换用自定义 `image.repository` 时合同依然成立。
+
 ## 沙箱后端 {#sandbox-backend}
 
 `sandbox.backend` 必填且无默认值。本 chart 支持两种后端；`docker` 后端刻意不支持
 （它需要挂载 Docker socket）。
 
-- **`none`** —— `none does not disable agent tools — it runs them directly inside
-the Stella pod without sandbox isolation.`（none 不会禁用 agent 工具，而是让它们
-  直接在 Stella pod 内、无沙箱隔离地运行。）因为没有隔离宿主，你必须同时设置
+- **`none`** —— `none` 不会禁用 agent 工具：它让工具直接在 Stella pod 内、无沙箱
+  隔离地运行（none does not disable agent tools — it runs them directly inside
+  the Stella pod without sandbox isolation）。因为没有隔离层，你必须同时设置
   `sandbox.allowUnsafeHostExecution=true` 来确认，否则渲染失败。这是 Kubernetes 上
   最简单、最可靠的后端。
 - **`local`** —— bubblewrap 隔离。**在 Kubernetes 上属实验性。** 它依赖集群允许

--- a/web/content/docs/admin/kubernetes.zh.md
+++ b/web/content/docs/admin/kubernetes.zh.md
@@ -86,7 +86,7 @@ kubectl -n stella port-forward svc/stella 25678:25678
 | ---------------------------------------- | ------------------------------- | ------------------------------------------------------------- |
 | `replicaCount`                           | `1`                             | 必须为 `1`，其他值一律拒绝。                                  |
 | `image.repository`                       | `ghcr.io/cherryhq/stella`       | 容器镜像。                                                    |
-| `image.tag`                              | `""`                            | 为空时用 chart 的 `appVersion`。                              |
+| `image.tag`                              | `""`                            | 为空时用 `latest`；生产建议固定版本 tag 或 digest。           |
 | `image.digest`                           | `""`                            | `sha256:…` 摘要；固定镜像并覆盖 `tag`。                       |
 | `image.pullPolicy`                       | `IfNotPresent`                  |                                                               |
 | `imagePullSecrets`                       | `[]`                            | 私有 registry 用。                                            |

--- a/web/content/docs/admin/meta.json
+++ b/web/content/docs/admin/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Admin",
-  "pages": ["index"]
+  "pages": ["index", "kubernetes"]
 }

--- a/web/content/docs/admin/meta.zh.json
+++ b/web/content/docs/admin/meta.zh.json
@@ -1,4 +1,4 @@
 {
   "title": "管理",
-  "pages": ["index"]
+  "pages": ["index", "kubernetes"]
 }

--- a/web/content/docs/development/rules/release.md
+++ b/web/content/docs/development/rules/release.md
@@ -18,20 +18,27 @@ GoReleaser auto-detects pre-release suffixes (`-rc.1`, `-beta.1`).
    jq --arg version "$VERSION" '.version = $version' web/package.json > "$tmp" && mv "$tmp" web/package.json
    test "$(jq -r '.version' web/package.json)" = "$VERSION"
    ```
-3. Update `web/content/docs/changelog.mdx` and `web/content/docs/changelog.zh.mdx` (see below).
-4. Commit: `📝 docs: Update CHANGELOG for vX.Y.Z` including both changelogs and `web/package.json`.
-5. Verify the commit succeeded and the working tree is clean:
+3. Update the Helm chart metadata in `deploy/helm/stella/Chart.yaml`:
+   - Set `appVersion: "vX.Y.Z"` so the chart records the release it ships alongside.
+     The default `image.tag` is `latest` (CI publishes it for every stable release,
+     see Artifacts), so a fresh install already tracks this version; `appVersion`
+     just keeps the metadata honest.
+   - Bump the chart's own `version` (its SemVer, independent of `appVersion`)
+     whenever the chart changed since the last release.
+4. Update `web/content/docs/changelog.mdx` and `web/content/docs/changelog.zh.mdx` (see below).
+5. Commit: `📝 docs: Update CHANGELOG for vX.Y.Z` including both changelogs, `web/package.json`, and `deploy/helm/stella/Chart.yaml`.
+6. Verify the commit succeeded and the working tree is clean:
    ```bash
    git status --short
    git log --oneline -1
    ```
    Stop if the release commit is not `HEAD`; never tag before the commit exists.
-6. Tag the release commit and verify the tag points at `HEAD`:
+7. Tag the release commit and verify the tag points at `HEAD`:
    ```bash
    git tag vX.Y.Z
    test "$(git rev-parse vX.Y.Z)" = "$(git rev-parse HEAD)"
    ```
-7. Tag release issues with the release label so they are traceable on the GitHub Project board:
+8. Tag release issues with the release label so they are traceable on the GitHub Project board:
 
    ```bash
    # warn about any issue still open in the milestone before tagging
@@ -45,8 +52,8 @@ GoReleaser auto-detects pre-release suffixes (`-rc.1`, `-beta.1`).
 
    Filter the project board by the `release:vX.Y.Z` label to confirm the release scope.
 
-8. Push the branch and new release tag explicitly: `git push origin main vX.Y.Z`.
-9. CI triggers `.github/workflows/release.yml` → GoReleaser binaries + Docker images.
+9. Push the branch and new release tag explicitly: `git push origin main vX.Y.Z`.
+10. CI triggers `.github/workflows/release.yml` → GoReleaser binaries + Docker images.
 
 ## Update Changelog
 

--- a/web/content/docs/start-here/deployment.md
+++ b/web/content/docs/start-here/deployment.md
@@ -210,6 +210,8 @@ docker buildx build --platform linux/amd64,linux/arm64 -t stella .
 
 When you run Stella under an orchestrator (Kubernetes and similar), two things that are convenient locally become traps: the embedded single-node database and a base URL that points back at the pod. The Docker image refuses the first by default (`STELLA_REQUIRE_EXTERNAL_DB=1`), and Stella warns loudly about the second.
 
+For Kubernetes, use the production Helm chart and its walkthrough in the [Kubernetes deployment guide](/docs/admin/kubernetes); the rest of this section explains the concepts the chart configures for you.
+
 ### The three URL roles
 
 Stella uses three distinct addresses. Keep them separate:

--- a/web/content/docs/start-here/deployment.zh.md
+++ b/web/content/docs/start-here/deployment.zh.md
@@ -210,6 +210,8 @@ docker buildx build --platform linux/amd64,linux/arm64 -t stella .
 
 当你在编排系统（Kubernetes 等）下运行 Stella 时，两个本地环境下的便利做法会变成陷阱：内嵌的单节点数据库，以及指向 pod 自身的 base URL。Docker 镜像默认拒绝前者（`STELLA_REQUIRE_EXTERNAL_DB=1`），对后者 Stella 会发出响亮的警告。
 
+在 Kubernetes 上部署请使用生产级 Helm chart，完整步骤见 [Kubernetes 部署指南](/docs/admin/kubernetes)；本节其余内容解释 chart 已为你配置好的那些概念。
+
 ### 三种 URL 角色
 
 Stella 使用三个不同的地址，务必区分：


### PR DESCRIPTION
Closes #480

## What

A production Helm chart at `deploy/helm/stella/` for running a single Stella instance on Kubernetes, plus a render-assertion check (`mise run deploy:helm:check`) and a bilingual deployment walkthrough (`docs/admin/kubernetes`).

## Why

Teams deploying Stella in production need supported Kubernetes assets instead of hand-written manifests. #699/#700/#702 landed the runtime prerequisites (external-DB enforcement, `/healthz`+`/readyz`, configurable two-phase drain, unified env contract); this PR ships the deployment surface that uses them.

## How

**Opinionated single-replica chart** — per the multi-replica readiness audit, >1 replica is unsafe today (IM channels start in full per pod, session/SSE state is in-process, `STELLA_HOME` has file affinity). The chart renders `replicas: 1` + `strategy: Recreate` and **fails rendering** on `replicaCount != 1`. No HPA/PDB/NetworkPolicy resources. Multi-replica work is tracked in the k8s milestone Phase 1/2 issues.

**Hard render-time gates** (all in `stella.validate`, with actionable messages):
- `baseURL` required (`STELLA_BASE_URL`, plain env).
- `secrets.existingSecret` required — the chart never creates or templates secret material; vault key + DSN come from a Secret you create (`secretKeyRef`). Deliberate ceiling: no in-chart secret creation until a demo path needs it.
- `sandbox.backend` required, enum `local|none`, no default. `none` means agent tools run **unsandboxed inside the pod**, so it additionally requires `sandbox.allowUnsafeHostExecution=true`. `local` (bubblewrap) is experimental — needs unprivileged user namespaces; no privileged securityContext, no docker socket. `docker`/DooD is unsupported.
- Shutdown budget in whole seconds (`shutdown.*`), rendered into `STELLA_HTTP_SHUTDOWN_TIMEOUT`/`STELLA_RIVER_SOFT_STOP_TIMEOUT` + preStop sleep; rendering fails when `terminationGracePeriodSeconds < preStop + http + river + 10`.

**Data safety** — PVC at `/home/stella/.stella` (workspaces, attachments, Recally files) carries `helm.sh/resource-policy: keep` so `helm uninstall` never deletes data; `persistence.existingClaim` supported.

**Probes** — `startupProbe` (5m budget for migrations/seed/plugin reconcile) gates liveness `/healthz` and readiness `/readyz`.

**Hardening** — `runAsNonRoot` 1000 + `fsGroupChangePolicy: OnRootMismatch`, `automountServiceAccountToken: false`, values.schema.json, NOTES prints no secret values.

**Verification** — `deploy/helm/check.sh` (wired as `mise run deploy:helm:check`, helm pinned in mise): helm lint, 5 success renders with 17 output assertions, 6 must-fail cases asserting non-zero exit + message keywords. All fake secret values. No live-cluster e2e was run (no local cluster); remaining risk is confined to cluster-specific behavior (CSI `fsGroup` handling, userns policy for `local`), both covered in troubleshooting docs.

**Docs** — `web/content/docs/admin/kubernetes.md` + `.zh.md`: prerequisites, Secret creation, install/ingress walkthrough, values reference, sandbox semantics ("`none` does not disable agent tools"), "Why only one replica?", shutdown formula (including why preStop ≠ SIGTERM), upgrade/rollback caveats (Recreate downtime; `helm rollback` does not undo migrations — back up PostgreSQL and the PVC first), egress list, troubleshooting. Linked from README (EN/ZH) and the existing Managed Deployment section.

Issue #480's acceptance was rescoped to single-replica (HPA moved to Phase 1/2) before implementation; plan and result reviewed by architecture review.

## Refs

- Closes #480 (parent: #477)
- Audit: docs/design/research/2026-07-04-k8s-multi-replica-readiness.md
- Runtime prerequisites: #699, #700, #702
- Follow-up security issue (app-layer `none` sandbox hardening): #705