### PR TITLE
🏗️ refactor: establish architecture migration foundation

### DIFF
--- a/cmd/stellad/architecture_boundary_test.go
+++ b/cmd/stellad/architecture_boundary_test.go
@@ -1,0 +1,120 @@
+package main
+
+// Architecture boundary tripwire for issue #706 (stack 1 of #703).
+//
+// cmd/stellad is the composition root: it wires services, but must not grow new
+// application/business logic. The clearest structural signal is a direct reach
+// into the raw sqlc query layer (pkg/db/sqlc). Pure wiring closures that carry no
+// query are out of structural scope by design — a test cannot prove "wiring vs
+// business" for an arbitrary closure, so this guard does not claim to.
+//
+// This freezes the EXACT number of sqlc package references per allowlisted file
+// (resolved through each file's own import name, so an aliased import cannot
+// evade the guard). Adding another query reference to commands.go/gateway.go —
+// or introducing sqlc in a new file — fails, forcing the query behind a service
+// the root merely wires.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const sqlcImportPath = "github.com/CherryHQ/stella/pkg/db/sqlc"
+
+// cmdSQLCRefCounts is the exact count of sqlc.<Symbol> references per file today.
+// Every entry is existing debt to be relocated behind a service; counts may only
+// go down (pay off debt, then lower the number), never up.
+var cmdSQLCRefCounts = map[string]int{
+	"commands.go":       11,
+	"gateway.go":        2,
+	"setup_pool.go":     4,
+	"tool_overrides.go": 2,
+}
+
+// localImportName returns the identifier a file uses for importPath, honoring an
+// explicit alias; "" if the file does not import it. This defeats trivial alias
+// evasion (import foo "…/sqlc" is still counted).
+func localImportName(f *ast.File, importPath string) string {
+	for _, imp := range f.Imports {
+		if strings.Trim(imp.Path.Value, "`\"") != importPath {
+			continue
+		}
+		if imp.Name != nil {
+			return imp.Name.Name // explicit alias (including "." / "_")
+		}
+		seg := importPath[strings.LastIndex(importPath, "/")+1:]
+		return seg
+	}
+	return ""
+}
+
+// countSelectorRefs counts SelectorExpr nodes whose receiver identifier is local
+// (e.g. sqlc.New, sqlc.GetProjectParams) — every reference to the package.
+func countSelectorRefs(f *ast.File, local string) int {
+	n := 0
+	ast.Inspect(f, func(node ast.Node) bool {
+		sel, ok := node.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if id, ok := sel.X.(*ast.Ident); ok && id.Name == local {
+			n++
+		}
+		return true
+	})
+	return n
+}
+
+func TestNoNewCmdApplicationQueries(t *testing.T) {
+	dir, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatalf("resolve package dir: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+	seen := map[string]int{}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		fset := token.NewFileSet()
+		f, err := parser.ParseFile(fset, filepath.Join(dir, name), nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		local := localImportName(f, sqlcImportPath)
+		if local == "" {
+			continue
+		}
+		seen[name] = countSelectorRefs(f, local)
+	}
+
+	for name, got := range seen {
+		want, ok := cmdSQLCRefCounts[name]
+		if !ok {
+			t.Errorf("%s: cmd/stellad reaches the raw sqlc query layer (%d ref(s)); move this query behind a service the composition root wires, or add a justified allowlist entry", name, got)
+			continue
+		}
+		if got > want {
+			t.Errorf("%s: %d sqlc references, allowlist permits %d; do not add new raw queries to the composition root — relocate them behind a service", name, got, want)
+		}
+	}
+	for name, want := range cmdSQLCRefCounts {
+		got, ok := seen[name]
+		if !ok {
+			t.Errorf("stale cmd sqlc allowlist entry %q no longer imports sqlc; remove it", name)
+			continue
+		}
+		if got < want {
+			t.Errorf("%s: only %d sqlc references remain (allowlist expects %d); lower the count so regressions are caught", name, got, want)
+		}
+	}
+}

--- a/internal/agent/compact_session_test.go
+++ b/internal/agent/compact_session_test.go
@@ -1,0 +1,63 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	agentruntime "github.com/CherryHQ/stella/internal/agent/runtime"
+	"github.com/CherryHQ/stella/internal/agent/session"
+	"github.com/CherryHQ/stella/internal/memory"
+	"github.com/CherryHQ/stella/internal/memory/memorytest"
+)
+
+// compactSpy wraps the fake memory provider and counts Compact invocations so a
+// test can assert whether the compactor was reached.
+type compactSpy struct {
+	*memorytest.Fake
+	calls int
+}
+
+func (s *compactSpy) Compact(context.Context, memory.Session, memory.CompactionMode) (*memory.CompactionResult, error) {
+	s.calls++
+	return &memory.CompactionResult{}, nil
+}
+
+func newCompactService(t *testing.T, mem memory.Provider) *Service {
+	t.Helper()
+	rt, err := agentruntime.New(agentruntime.Config{
+		Memory:    mem,
+		NewRunner: func(context.Context, agentruntime.RunnerParams) (agentruntime.Runner, error) { return nil, nil },
+	})
+	if err != nil {
+		t.Fatalf("runtime.New: %v", err)
+	}
+	return &Service{Runtime: rt}
+}
+
+// TestCompactSession_GroupRejectedBeforeCompactor proves a group session is
+// rejected with ErrGroupCompactionUnsupported and never reaches the compactor;
+// a private session is the control that proves the spy would have recorded a call.
+func TestCompactSession_GroupRejectedBeforeCompactor(t *testing.T) {
+	spy := &compactSpy{Fake: memorytest.New()}
+	svc := newCompactService(t, spy)
+
+	const groupID = "11111111-1111-4111-8111-111111111111"
+	group := session.Info{ID: "a:group:" + groupID, AgentID: "a", UserID: groupID, GroupID: groupID, Kind: string(session.KindChat)}
+
+	_, err := svc.CompactSession(context.Background(), group)
+	if !errors.Is(err, ErrGroupCompactionUnsupported) {
+		t.Fatalf("group CompactSession err = %v, want ErrGroupCompactionUnsupported", err)
+	}
+	if spy.calls != 0 {
+		t.Fatalf("compactor invoked %d times for a group session; want 0", spy.calls)
+	}
+
+	private := session.Info{ID: "s-priv", AgentID: "a", UserID: "user-1", Kind: string(session.KindChat)}
+	if _, err := svc.CompactSession(context.Background(), private); err != nil {
+		t.Fatalf("private CompactSession: %v", err)
+	}
+	if spy.calls != 1 {
+		t.Fatalf("compactor calls = %d for a private session; want 1", spy.calls)
+	}
+}

--- a/internal/agent/runtime/chat.go
+++ b/internal/agent/runtime/chat.go
@@ -57,16 +57,11 @@ func (rt *Runtime) chat(ctx context.Context, out chan<- Event, info session.Info
 		ctx = withChannel(ctx, info.Channel)
 	}
 
-	memUserID := info.UserID
-	if info.GroupID != "" {
-		memUserID = info.GroupID
-	}
-	memSess := memory.Session{
-		ID:      info.ID,
-		AgentID: info.AgentID,
-		UserID:  memUserID,
-		Channel: info.Channel,
-		GroupID: info.GroupID,
+	memSess, err := info.MemoryScope()
+	if err != nil {
+		out <- Event{Err: fmt.Errorf("session scope: %w", err)}
+		close(out)
+		return
 	}
 
 	msgText := MessageText(msg)
@@ -117,7 +112,9 @@ func (rt *Runtime) chat(ctx context.Context, out chan<- Event, info session.Info
 		}
 		saveCtx := authz.WithUserID(ctx, info.UserID)
 		saveCtx = authz.WithAgentID(saveCtx, info.AgentID)
-		if err := sm.SaveInfo(saveCtx, updated); err != nil {
+		if rec, err := updated.Record(); err != nil {
+			rt.log.Warn("skip saving invalid session info", "session_id", info.ID, "error", err)
+		} else if err := sm.SaveInfo(saveCtx, rec); err != nil {
 			rt.log.Warn("failed to save session info", "session_id", info.ID, "error", err)
 		}
 	}

--- a/internal/agent/runtime/chat_group_speaker_test.go
+++ b/internal/agent/runtime/chat_group_speaker_test.go
@@ -37,7 +37,7 @@ func TestRuntimeChatGroupSpeakerContextNoUserPromotion(t *testing.T) {
 		t.Fatalf("new runtime: %v", err)
 	}
 
-	info := session.Info{ID: "sess-1", UserID: "group-1", AgentID: "agent-1", GroupID: "group-1"}
+	info := session.Info{ID: "sess-1", UserID: "11111111-1111-4111-8111-111111111111", AgentID: "agent-1", GroupID: "11111111-1111-4111-8111-111111111111"}
 	for _, speaker := range []string{"alice", "bob"} {
 		out := make(chan Event, 10)
 		rt.chat(
@@ -75,7 +75,7 @@ func TestRuntimeChatGroupSpeakerContextInjectedIntoModelMessageOnly(t *testing.T
 		t.Fatalf("new runtime: %v", err)
 	}
 
-	info := session.Info{ID: "sess-1", UserID: "group-1", AgentID: "agent-1", GroupID: "group-1"}
+	info := session.Info{ID: "sess-1", UserID: "11111111-1111-4111-8111-111111111111", AgentID: "agent-1", GroupID: "11111111-1111-4111-8111-111111111111"}
 	out := make(chan Event, 10)
 	rt.chat(
 		memory.WithGroupSeq(context.Background(), 1),

--- a/internal/agent/runtime/chat_test.go
+++ b/internal/agent/runtime/chat_test.go
@@ -91,7 +91,7 @@ func TestRuntimeChatCommitsGroupCursorAfterSuccessfulGroupTurn(t *testing.T) {
 	}
 	ctx := memory.WithGroupSeq(context.Background(), 42)
 	out := make(chan Event, 10)
-	rt.chat(ctx, out, session.Info{ID: "sess-1", UserID: "group-1", AgentID: "agent-1", GroupID: "group-1"}, "hello", chatOptions{})
+	rt.chat(ctx, out, session.Info{ID: "sess-1", UserID: "11111111-1111-4111-8111-111111111111", AgentID: "agent-1", GroupID: "11111111-1111-4111-8111-111111111111"}, "hello", chatOptions{})
 	for range out {
 	}
 	if len(mem.commits) != 1 || mem.commits[0] != 42 {
@@ -122,7 +122,7 @@ func TestRuntimeChatDoesNotCommitGroupCursorOnChatError(t *testing.T) {
 	}
 	ctx := memory.WithGroupSeq(context.Background(), 42)
 	out := make(chan Event, 10)
-	rt.chat(ctx, out, session.Info{ID: "sess-1", UserID: "group-1", AgentID: "agent-1", GroupID: "group-1"}, "hello", chatOptions{})
+	rt.chat(ctx, out, session.Info{ID: "sess-1", UserID: "11111111-1111-4111-8111-111111111111", AgentID: "agent-1", GroupID: "11111111-1111-4111-8111-111111111111"}, "hello", chatOptions{})
 	for range out {
 	}
 	if len(mem.commits) != 0 {
@@ -147,7 +147,7 @@ func TestRuntimeChatDoesNotCommitGroupCursorWhenContextCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(memory.WithGroupSeq(context.Background(), 42))
 	cancel()
 	out := make(chan Event, 10)
-	rt.chat(ctx, out, session.Info{ID: "sess-1", UserID: "group-1", AgentID: "agent-1", GroupID: "group-1"}, "hello", chatOptions{})
+	rt.chat(ctx, out, session.Info{ID: "sess-1", UserID: "11111111-1111-4111-8111-111111111111", AgentID: "agent-1", GroupID: "11111111-1111-4111-8111-111111111111"}, "hello", chatOptions{})
 	for range out {
 	}
 	if len(mem.commits) != 0 {
@@ -168,7 +168,7 @@ func TestRuntimeChatDoesNotPersistGroupPartialOnTimeout(t *testing.T) {
 	}
 	ctx := memory.WithGroupSeq(context.Background(), 42)
 	out := make(chan Event, 10)
-	rt.chat(ctx, out, session.Info{ID: "sess-1", UserID: "group-1", AgentID: "agent-1", GroupID: "group-1"}, "hello", chatOptions{})
+	rt.chat(ctx, out, session.Info{ID: "sess-1", UserID: "11111111-1111-4111-8111-111111111111", AgentID: "agent-1", GroupID: "11111111-1111-4111-8111-111111111111"}, "hello", chatOptions{})
 	for range out {
 	}
 	if len(mem.commits) != 0 {
@@ -193,7 +193,7 @@ func TestRuntimeChatDoesNotPersistGroupStoreBeforeLaterError(t *testing.T) {
 	}
 	ctx := memory.WithGroupSeq(context.Background(), 42)
 	out := make(chan Event, 10)
-	rt.chat(ctx, out, session.Info{ID: "sess-1", UserID: "group-1", AgentID: "agent-1", GroupID: "group-1"}, "hello", chatOptions{})
+	rt.chat(ctx, out, session.Info{ID: "sess-1", UserID: "11111111-1111-4111-8111-111111111111", AgentID: "agent-1", GroupID: "11111111-1111-4111-8111-111111111111"}, "hello", chatOptions{})
 	for range out {
 	}
 	if len(mem.commits) != 0 {
@@ -217,7 +217,7 @@ func TestRuntimeChatDoesNotCommitGroupCursorWhenStoreFails(t *testing.T) {
 	}
 	ctx := memory.WithGroupSeq(context.Background(), 42)
 	out := make(chan Event, 10)
-	rt.chat(ctx, out, session.Info{ID: "sess-1", UserID: "group-1", AgentID: "agent-1", GroupID: "group-1"}, "hello", chatOptions{})
+	rt.chat(ctx, out, session.Info{ID: "sess-1", UserID: "11111111-1111-4111-8111-111111111111", AgentID: "agent-1", GroupID: "11111111-1111-4111-8111-111111111111"}, "hello", chatOptions{})
 	for range out {
 	}
 	if len(mem.commits) != 0 {
@@ -239,7 +239,7 @@ func TestRuntimeChatDoesNotCommitGroupCursorWhenAssembleFails(t *testing.T) {
 	}
 	ctx := memory.WithGroupSeq(context.Background(), 42)
 	out := make(chan Event, 10)
-	rt.chat(ctx, out, session.Info{ID: "sess-1", UserID: "group-1", AgentID: "agent-1", GroupID: "group-1"}, "hello", chatOptions{})
+	rt.chat(ctx, out, session.Info{ID: "sess-1", UserID: "11111111-1111-4111-8111-111111111111", AgentID: "agent-1", GroupID: "11111111-1111-4111-8111-111111111111"}, "hello", chatOptions{})
 	var gotErr bool
 	for evt := range out {
 		if errors.Is(evt.Err, assembleErr) {

--- a/internal/agent/runtime/current_speaker_test.go
+++ b/internal/agent/runtime/current_speaker_test.go
@@ -54,7 +54,7 @@ func TestRuntimeChatInjectsCurrentSpeakerIntoGroupTurnMessage(t *testing.T) {
 		t.Fatalf("new runtime: %v", err)
 	}
 
-	info := session.Info{ID: "sess-1", UserID: "group-1", AgentID: "agent-1", GroupID: "group-1"}
+	info := session.Info{ID: "sess-1", UserID: "11111111-1111-4111-8111-111111111111", AgentID: "agent-1", GroupID: "11111111-1111-4111-8111-111111111111"}
 	out := make(chan Event, 10)
 	rt.chat(
 		memory.WithGroupSeq(context.Background(), 7),

--- a/internal/agent/runtime/runner_cache.go
+++ b/internal/agent/runtime/runner_cache.go
@@ -60,14 +60,12 @@ func newRunnerCache(
 // Passing extraTools always builds a fresh runner (per-call tools defeat the
 // cache); the caller is expected to evict it afterwards via CloseSession.
 func (c *runnerCache) getOrCreate(ctx context.Context, info session.Info, model string, thinking ai.ThinkingLevel, extraTools ...tools.Tool) (*cachedSession, Runner, error) {
-	if info.ID == "" {
-		return nil, nil, fmt.Errorf("session.Info.ID is required")
-	}
-	if info.UserID == "" {
-		return nil, nil, fmt.Errorf("session.Info.UserID is required")
-	}
-	if info.AgentID == "" {
-		return nil, nil, fmt.Errorf("session.Info.AgentID is required")
+	// Validate the session and derive its memory scope before any cache lookup or
+	// runner creation. An invalid session (missing owner, malformed group id) must
+	// fail closed here so a runner is never installed over an unusable scope.
+	memSess, err := info.MemoryScope()
+	if err != nil {
+		return nil, nil, fmt.Errorf("session scope: %w", err)
 	}
 
 	c.mu.Lock()
@@ -165,18 +163,7 @@ func (c *runnerCache) getOrCreate(ctx context.Context, info session.Info, model 
 	cs.thinking = effectiveThinking
 	c.mu.Unlock()
 
-	// Bootstrap memory for this session.
-	memUserID := info.UserID
-	if info.GroupID != "" {
-		memUserID = info.GroupID
-	}
-	memSess := memory.Session{
-		ID:      info.ID,
-		AgentID: info.AgentID,
-		UserID:  memUserID,
-		Channel: info.Channel,
-		GroupID: info.GroupID,
-	}
+	// Bootstrap memory for this session using the scope derived up front.
 	if err := c.mem.Bootstrap(ctx, memSess); err != nil {
 		c.log.Warn("memory bootstrap failed", "session_id", info.ID, "error", err)
 	}

--- a/internal/agent/runtime/runner_cache_test.go
+++ b/internal/agent/runtime/runner_cache_test.go
@@ -247,3 +247,30 @@ func TestRuntimeChat_BeforeRunOverride(t *testing.T) {
 		t.Fatalf("runner system = %q, want hook override", runner.chatSystem)
 	}
 }
+
+// TestRunnerCache_InvalidGroupSessionFailsClosedWithoutRunner proves an invalid
+// group session (non-canonical group id) fails closed before any runner is built
+// or cached — the runner factory is never called.
+func TestRunnerCache_InvalidGroupSessionFailsClosedWithoutRunner(t *testing.T) {
+	var calls int
+	factory := func(context.Context, RunnerParams) (Runner, error) {
+		calls++
+		return newFakeRunner(), nil
+	}
+	cache := newRunnerCache(factory, fakeMemory{}, 10*time.Minute, slog.Default())
+
+	bad := session.Info{ID: "s1", AgentID: "a1", UserID: "not-a-uuid", GroupID: "not-a-uuid"}
+	cs, r, err := cache.getOrCreate(context.Background(), bad, "", "")
+	if err == nil {
+		t.Fatal("expected a fail-closed error for an invalid group session")
+	}
+	if cs != nil || r != nil {
+		t.Fatal("no cached session or runner should be returned on failure")
+	}
+	if calls != 0 {
+		t.Fatalf("runner factory called %d times; want 0", calls)
+	}
+	if _, ok := cache.sessions["s1"]; ok {
+		t.Fatal("no session entry should be installed for an invalid session")
+	}
+}

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -14,6 +15,12 @@ import (
 	"github.com/CherryHQ/stella/pkg/sandbox"
 	"github.com/CherryHQ/stella/pkg/tools"
 )
+
+// ErrGroupCompactionUnsupported is returned by CompactSession for a group
+// session. Group history lives in the group event log, not the LCM conversation,
+// so LCM compaction does not apply; callers surface this as a user-facing notice
+// rather than silently compacting an event-log conversation.
+var ErrGroupCompactionUnsupported = errors.New("compaction is not supported for group sessions")
 
 // Service is a thin composition facade over session.Registry and runtime.Runtime.
 // It provides ergonomic entry points for common use cases without hiding the
@@ -93,6 +100,7 @@ func (s *Service) Chat(ctx context.Context, req ChatRequest) <-chan Event {
 		ID:        req.SessionID,
 		UserID:    req.UserID,
 		AgentID:   req.AgentID,
+		GroupID:   req.GroupID,
 		ProjectID: req.ProjectID,
 		Kind:      kind,
 		Channel:   req.Channel,
@@ -113,9 +121,8 @@ func (s *Service) Chat(ctx context.Context, req ChatRequest) <-chan Event {
 		close(out)
 		return out
 	}
-	if req.GroupID != "" {
-		info.GroupID = req.GroupID
-	}
+	// GroupID is threaded through the Request and owned by the Registry (create
+	// persists it; resume overlays it), so info.GroupID is already set here.
 
 	opts := req.RuntimeOpts
 	if req.Model != "" {
@@ -302,14 +309,33 @@ func (s *Service) chatOnSession(ctx context.Context, sreq session.Request, req T
 	return out
 }
 
-// ResolveChannelSession resolves or creates a channel/group chat session using a
-// trusted system-derived session key. This is the session-only variant of
-// ChatForChannel — it returns the Info without executing a chat turn.
-func (s *Service) ResolveChannelSession(ctx context.Context, sessionKey, userID, agentID string, channel session.Channel) (session.Info, error) {
+// ResolvePrivateChannelSession resolves or creates a private channel chat session
+// using a trusted system-derived session key. It is the session-only variant of
+// ChatForChannel for a per-user channel; it returns the Info without executing a
+// chat turn. Private callers do not know about groups.
+func (s *Service) ResolvePrivateChannelSession(ctx context.Context, sessionKey, userID, agentID string, channel session.Channel) (session.Info, error) {
 	return s.Sessions.Ensure(ctx, session.Request{
 		ID:                 sessionKey,
 		UserID:             userID,
 		AgentID:            agentID,
+		Kind:               session.KindChat,
+		Channel:            channel,
+		CreateIfMissing:    true,
+		AllowExactIDCreate: true,
+		RequireKind:        session.KindChat,
+	})
+}
+
+// ResolveGroupChannelSession resolves or creates a group chat session owned by
+// the group. The caller passes the canonical group id once; the group-ownership
+// invariant (a group session is owned by its group, so UserID == GroupID) is
+// established here in one place rather than by callers repeating the id.
+func (s *Service) ResolveGroupChannelSession(ctx context.Context, sessionKey, groupID, agentID string, channel session.Channel) (session.Info, error) {
+	return s.Sessions.Ensure(ctx, session.Request{
+		ID:                 sessionKey,
+		UserID:             groupID,
+		AgentID:            agentID,
+		GroupID:            groupID,
 		Kind:               session.KindChat,
 		Channel:            channel,
 		CreateIfMissing:    true,
@@ -437,7 +463,16 @@ func (s *Service) ResolveMainSession(ctx context.Context, userID, agentID string
 
 // CompactSession runs full compaction on the session identified by sessionID.
 // This is a best-effort operation: it returns the compaction summary or an error.
+//
+// Group sessions are unsupported: their history is assembled from the group event
+// log, not the LCM conversation, and NeedsCompaction already declines them. The
+// manual path rejects a group session up front (before touching the compactor)
+// with ErrGroupCompactionUnsupported rather than run a private-style compaction
+// over an event-log conversation.
 func (s *Service) CompactSession(ctx context.Context, info session.Info) (string, error) {
+	if info.GroupID != "" {
+		return "", ErrGroupCompactionUnsupported
+	}
 	mem := s.Runtime.Memory()
 	if mem == nil {
 		return "", fmt.Errorf("no memory provider")
@@ -448,7 +483,10 @@ func (s *Service) CompactSession(ctx context.Context, info session.Info) (string
 	if !ok {
 		return "", fmt.Errorf("memory provider does not support compaction")
 	}
-	memSess := s.Sessions.MemoryScope(info)
+	memSess, err := s.Sessions.MemoryScope(info)
+	if err != nil {
+		return "", err
+	}
 	result, err := c.Compact(ctx, memSess, memory.CompactionFull)
 	if err != nil {
 		return "", fmt.Errorf("compact: %w", err)

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -146,45 +146,6 @@ func (s *Service) SessionLive(sessionID string) bool {
 	return s.Runtime.SessionLive(sessionID)
 }
 
-// ChannelChatRequest describes a chat turn on a non-private channel/group session
-// identified by a Stella-derived session key.
-type ChannelChatRequest struct {
-	SessionKey string // system-derived session key (e.g. "agent:telegram:group:123")
-	UserID     string
-	AgentID    string
-	Channel    session.Channel
-	Message    MessageContent
-	Model      string
-}
-
-// ChatForChannel resolves or creates a channel/group chat session using a
-// trusted system-derived session key. Unlike Chat, this method allows exact-ID
-// creation because the key is derived by Stella, not by user/model input.
-func (s *Service) ChatForChannel(ctx context.Context, req ChannelChatRequest) <-chan Event {
-	info, err := s.Sessions.Ensure(ctx, session.Request{
-		ID:                 req.SessionKey,
-		UserID:             req.UserID,
-		AgentID:            req.AgentID,
-		Kind:               session.KindChat,
-		Channel:            req.Channel,
-		CreateIfMissing:    true,
-		AllowExactIDCreate: true,
-		RequireKind:        session.KindChat,
-	})
-	if err != nil {
-		out := make(chan Event, 1)
-		out <- Event{Err: fmt.Errorf("resolve channel session: %w", err)}
-		close(out)
-		return out
-	}
-
-	var opts []agentruntime.Option
-	if req.Model != "" {
-		opts = append(opts, agentruntime.WithModel(req.Model))
-	}
-	return s.Runtime.Chat(ctx, info, req.Message, opts...)
-}
-
 // SchedulerChatRequest describes a scheduler-initiated chat turn.
 type SchedulerChatRequest struct {
 	SessionID string // scheduler-derived session ID
@@ -310,9 +271,8 @@ func (s *Service) chatOnSession(ctx context.Context, sreq session.Request, req T
 }
 
 // ResolvePrivateChannelSession resolves or creates a private channel chat session
-// using a trusted system-derived session key. It is the session-only variant of
-// ChatForChannel for a per-user channel; it returns the Info without executing a
-// chat turn. Private callers do not know about groups.
+// using a trusted system-derived session key. It returns the Info without
+// executing a chat turn. Private callers do not know about groups.
 func (s *Service) ResolvePrivateChannelSession(ctx context.Context, sessionKey, userID, agentID string, channel session.Channel) (session.Info, error) {
 	return s.Sessions.Ensure(ctx, session.Request{
 		ID:                 sessionKey,

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -1,9 +1,5 @@
 package agent
 
-import (
-	"github.com/CherryHQ/stella/internal/memory"
-)
-
 // CompactionConfig controls automatic session compaction.
 type CompactionConfig struct {
 	// MaxTokens triggers compaction when the estimated token count exceeds this.
@@ -47,6 +43,3 @@ func BuildUserSessionKey(agentID string, authUserID string, channelContext strin
 func BuildGroupSessionKey(agentID, groupID string) string {
 	return agentID + ":group:" + groupID
 }
-
-// SessionInfo is an alias for memory.SessionInfo.
-type SessionInfo = memory.SessionInfo

--- a/internal/agent/session/info.go
+++ b/internal/agent/session/info.go
@@ -4,13 +4,19 @@
 // policy, main-session resolution, review candidate selection, and the
 // conversion from a validated session record to a memory operation scope.
 //
-// Production code outside this package and runtime should obtain memory.Session
-// via Registry.MemoryScope. The runtime is allowed to construct it directly
-// from validated Info because its inputs always come through the Registry.
+// Info is a session-domain type, not an alias to memory.SessionInfo. Every use
+// boundary fails closed: the persistence mapping (Record / InfoFromRecord) and
+// the memory-scope conversion (MemoryScope) validate the session invariant and
+// return an error rather than emit an unchecked value. The memory scope is
+// produced only by MemoryScope; production code must not hand-build
+// memory.Session values.
 package session
 
 import (
+	"fmt"
 	"time"
+
+	"github.com/google/uuid"
 
 	"github.com/CherryHQ/stella/internal/memory"
 )
@@ -39,10 +45,29 @@ const (
 	ChannelWebhook   Channel = "webhook"
 )
 
-// Info holds metadata about an agent session.
-// It wraps memory.SessionInfo so callers interact with a session-domain type
-// while the underlying storage stays in the memory layer.
-type Info = memory.SessionInfo
+// Info holds validated metadata about an agent session. It is a session-domain
+// value distinct from the memory-layer persistence type memory.SessionInfo;
+// callers cross the persistence boundary through Record and InfoFromRecord.
+//
+// GroupID identifies the group a group session belongs to. It is now durable
+// (ctx_conversation.group_id) and load/save round-trip it. The durable invariant
+// is that a group session is owned by the group itself: UserID equals GroupID,
+// and GroupID is the canonical ctx_group_state UUID. That equality is what makes
+// group read, write, and compaction resolve one memory partition; it is enforced
+// by Validate at every use boundary rather than left as an undeclared convention.
+type Info struct {
+	ID         string
+	AgentID    string
+	UserID     string
+	GroupID    string
+	Channel    string
+	Kind       string
+	ProjectID  string
+	Title      string
+	CreatedAt  time.Time
+	LastActive time.Time
+	Archived   bool
+}
 
 // NewInfo constructs a fresh Info with the required fields set.
 func NewInfo(id, agentID, userID, channel string, kind Kind, projectID string, now time.Time) Info {
@@ -56,4 +81,142 @@ func NewInfo(id, agentID, userID, channel string, kind Kind, projectID string, n
 		CreatedAt:  now,
 		LastActive: now,
 	}
+}
+
+// Validate enforces the durable session-scope invariant. Every session needs an
+// ID, an agent, and a user owner. A group session is owned by its group: UserID
+// must equal GroupID and GroupID must be a canonical ctx_group_state UUID. This
+// is the single fail-closed gate the persistence and memory-scope boundaries run.
+func (i Info) Validate() error {
+	if i.ID == "" {
+		return fmt.Errorf("session info: missing ID")
+	}
+	if i.AgentID == "" {
+		return fmt.Errorf("session info %q: missing AgentID", i.ID)
+	}
+	if i.UserID == "" {
+		return fmt.Errorf("session info %q: missing UserID", i.ID)
+	}
+	if i.GroupID != "" {
+		if i.UserID != i.GroupID {
+			return fmt.Errorf("session info %q: group session UserID %q must equal GroupID %q", i.ID, i.UserID, i.GroupID)
+		}
+		// Require the exact canonical lowercase-hyphenated UUID form. uuid.Parse
+		// also accepts braces/urn/uppercase/hyphenless variants, but the durable
+		// group id is a canonical ctx_group_state UUID, so anything that does not
+		// round-trip through uuid.String() is rejected.
+		parsed, err := uuid.Parse(i.GroupID)
+		if err != nil {
+			return fmt.Errorf("session info %q: GroupID %q is not a valid group id: %w", i.ID, i.GroupID, err)
+		}
+		if parsed.String() != i.GroupID {
+			return fmt.Errorf("session info %q: GroupID %q is not in canonical UUID form", i.ID, i.GroupID)
+		}
+	}
+	return nil
+}
+
+// MemoryScope is the single canonical conversion from a validated session Info
+// to a memory.Session operation scope. It fails closed: an Info that violates the
+// session invariant yields an error, never a half-formed scope.
+//
+// For a private session, read (Assemble), write (Append/Bootstrap), and
+// compaction all derive their scope here and land on the same partition. A group
+// session shares one durable canonical scope for read and write (partition keyed
+// on session/user/agent, with GroupID selecting the group assembly/isolation
+// path); group compaction is a separate matter and is unsupported (rejected by
+// agent.Service.CompactSession), because group history is assembled from the
+// group event log rather than the LCM conversation.
+func (i Info) MemoryScope() (memory.Session, error) {
+	if err := i.Validate(); err != nil {
+		return memory.Session{}, err
+	}
+	return memory.Session{
+		ID:      i.ID,
+		AgentID: i.AgentID,
+		UserID:  i.UserID,
+		Channel: i.Channel,
+		GroupID: i.GroupID,
+	}, nil
+}
+
+// Record maps a validated session-domain Info onto the memory-layer persistence
+// type. It is the domain→persistence half of the session store boundary and
+// fails closed on an invalid Info.
+func (i Info) Record() (memory.SessionInfo, error) {
+	if err := i.Validate(); err != nil {
+		return memory.SessionInfo{}, err
+	}
+	return memory.SessionInfo{
+		ID:         i.ID,
+		AgentID:    i.AgentID,
+		UserID:     i.UserID,
+		GroupID:    i.GroupID,
+		Channel:    i.Channel,
+		Kind:       i.Kind,
+		ProjectID:  i.ProjectID,
+		Title:      i.Title,
+		CreatedAt:  i.CreatedAt,
+		LastActive: i.LastActive,
+		Archived:   i.Archived,
+	}, nil
+}
+
+// InfoFromRecord maps a memory-layer persistence record back to a session-domain
+// Info. It is the persistence→domain half of the session store boundary and the
+// only sanctioned way to turn an unvalidated memory.SessionInfo into an Info; it
+// validates the resulting Info and fails closed on a record that violates the
+// session invariant.
+func InfoFromRecord(r memory.SessionInfo) (Info, error) {
+	info := Info{
+		ID:         r.ID,
+		AgentID:    r.AgentID,
+		UserID:     r.UserID,
+		GroupID:    r.GroupID,
+		Channel:    r.Channel,
+		Kind:       r.Kind,
+		ProjectID:  r.ProjectID,
+		Title:      r.Title,
+		CreatedAt:  r.CreatedAt,
+		LastActive: r.LastActive,
+		Archived:   r.Archived,
+	}
+	if err := info.Validate(); err != nil {
+		return Info{}, err
+	}
+	return info, nil
+}
+
+// infosFromRecords maps a slice of persistence records to validated domain Info
+// values, failing closed if any record violates the session invariant.
+func infosFromRecords(rs []memory.SessionInfo) ([]Info, error) {
+	out := make([]Info, len(rs))
+	for i, r := range rs {
+		info, err := InfoFromRecord(r)
+		if err != nil {
+			return nil, fmt.Errorf("session record %d: %w", i, err)
+		}
+		out[i] = info
+	}
+	return out, nil
+}
+
+// infosFromReviewRecords maps review-listing records to validated Info values.
+// Unlike infosFromRecords it skips a legacy ownerless row (empty UserID) instead
+// of failing: such rows were historically excluded from review, so one must not
+// fail an agent's entire review list forever. Any non-empty malformed record
+// (group mismatch, non-canonical id) still fails closed.
+func infosFromReviewRecords(rs []memory.SessionInfo) ([]Info, error) {
+	out := make([]Info, 0, len(rs))
+	for i, r := range rs {
+		if r.UserID == "" {
+			continue
+		}
+		info, err := InfoFromRecord(r)
+		if err != nil {
+			return nil, fmt.Errorf("session record %d: %w", i, err)
+		}
+		out = append(out, info)
+	}
+	return out, nil
 }

--- a/internal/agent/session/info_test.go
+++ b/internal/agent/session/info_test.go
@@ -1,0 +1,199 @@
+package session
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/CherryHQ/stella/internal/memory"
+)
+
+// a canonical (parseable) group id used across the group-scope tests.
+const testGroupID = "11111111-1111-4111-8111-111111111111"
+
+// TestInfoIsNotMemoryAlias guards the architecture invariant that session.Info
+// is a distinct session-domain type, not an alias to the memory persistence
+// type. If Info were reintroduced as `type Info = memory.SessionInfo`, the two
+// reflect types would be identical (and Info.MemoryScope/Record could not be
+// declared on it at all).
+func TestInfoIsNotMemoryAlias(t *testing.T) {
+	if reflect.TypeFor[Info]() == reflect.TypeFor[memory.SessionInfo]() {
+		t.Fatal("session.Info must not be an alias of memory.SessionInfo")
+	}
+}
+
+// TestMemoryScope_Kinds covers every known session kind and scope so read,
+// write, and compaction always derive one partition per session from the single
+// canonical conversion.
+//
+// Note on group scope: production group sessions are owned by the group, so
+// UserID == GroupID and the conversation partition (keyed on session/user/agent)
+// already lands on the group id. There is no reachable double-partition bug in
+// the current tree; the value of a single conversion plus a durable, validated
+// GroupID is that the invariant is enforced rather than left implicit.
+func TestMemoryScope_Kinds(t *testing.T) {
+	const (
+		agentID = "agent"
+		userID  = "user-1"
+	)
+	cases := []struct {
+		name string
+		info Info
+		want memory.Session
+	}{
+		{
+			name: "main private",
+			info: Info{ID: "agent:user:user-1:private", AgentID: agentID, UserID: userID, Channel: "web", Kind: string(KindMain)},
+			want: memory.Session{ID: "agent:user:user-1:private", AgentID: agentID, UserID: userID, Channel: "web"},
+		},
+		{
+			name: "chat private",
+			info: Info{ID: "s-chat", AgentID: agentID, UserID: userID, Channel: string(ChannelWeb), Kind: string(KindChat)},
+			want: memory.Session{ID: "s-chat", AgentID: agentID, UserID: userID, Channel: "web"},
+		},
+		{
+			name: "task",
+			info: Info{ID: "s-task", AgentID: agentID, UserID: userID, Channel: string(ChannelTask), Kind: string(KindTask)},
+			want: memory.Session{ID: "s-task", AgentID: agentID, UserID: userID, Channel: "task"},
+		},
+		{
+			name: "delegate",
+			info: Info{ID: "s-del", AgentID: agentID, UserID: userID, Channel: string(ChannelDelegate), Kind: string(KindDelegate)},
+			want: memory.Session{ID: "s-del", AgentID: agentID, UserID: userID, Channel: "delegate"},
+		},
+		{
+			name: "scheduler",
+			info: Info{ID: "s-sch", AgentID: agentID, UserID: userID, Channel: string(ChannelScheduler), Kind: string(KindScheduler)},
+			want: memory.Session{ID: "s-sch", AgentID: agentID, UserID: userID, Channel: "scheduler"},
+		},
+		{
+			name: "project scoped",
+			info: Info{ID: "s-proj", AgentID: agentID, UserID: userID, Channel: string(ChannelWeb), Kind: string(KindChat), ProjectID: "proj-1"},
+			// ProjectID scopes memory via context, not the partition key.
+			want: memory.Session{ID: "s-proj", AgentID: agentID, UserID: userID, Channel: "web"},
+		},
+		{
+			name: "channel telegram",
+			info: Info{ID: "s-tg", AgentID: agentID, UserID: userID, Channel: string(ChannelTelegram), Kind: string(KindChat)},
+			want: memory.Session{ID: "s-tg", AgentID: agentID, UserID: userID, Channel: "telegram"},
+		},
+		{
+			name: "group (owned by the group: UserID == GroupID)",
+			info: Info{ID: "agent:group:" + testGroupID, AgentID: agentID, UserID: testGroupID, GroupID: testGroupID, Channel: "group:" + testGroupID, Kind: string(KindChat)},
+			want: memory.Session{ID: "agent:group:" + testGroupID, AgentID: agentID, UserID: testGroupID, Channel: "group:" + testGroupID, GroupID: testGroupID},
+		},
+	}
+
+	reg := &Registry{}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.info.MemoryScope()
+			if err != nil {
+				t.Fatalf("Info.MemoryScope: unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("Info.MemoryScope:\n got  %+v\n want %+v", got, tc.want)
+			}
+			// Registry.MemoryScope must not diverge from the canonical conversion.
+			regGot, err := reg.MemoryScope(tc.info)
+			if err != nil {
+				t.Fatalf("Registry.MemoryScope: unexpected error: %v", err)
+			}
+			if regGot != tc.want {
+				t.Fatalf("Registry.MemoryScope:\n got  %+v\n want %+v", regGot, tc.want)
+			}
+		})
+	}
+}
+
+// TestMemoryScope_FailsClosed proves the scope conversion refuses an Info that
+// violates the session invariant rather than emit a half-formed scope.
+func TestMemoryScope_FailsClosed(t *testing.T) {
+	bad := Info{ID: "s", AgentID: "a", UserID: "u", GroupID: testGroupID} // UserID != GroupID
+	if _, err := bad.MemoryScope(); err == nil {
+		t.Fatal("MemoryScope must fail closed on an invalid group Info")
+	}
+}
+
+// TestInfoValidate exercises the durable session-scope invariant: UserID is
+// always required, and a group session must be owned by its group (UserID ==
+// GroupID) with a canonical group id.
+func TestInfoValidate(t *testing.T) {
+	cases := []struct {
+		name    string
+		info    Info
+		wantErr bool
+	}{
+		{name: "valid private", info: Info{ID: "s", AgentID: "a", UserID: "u"}},
+		{name: "valid group", info: Info{ID: "s", AgentID: "a", UserID: testGroupID, GroupID: testGroupID}},
+		{name: "missing id", info: Info{AgentID: "a", UserID: "u"}, wantErr: true},
+		{name: "missing agent", info: Info{ID: "s", UserID: "u"}, wantErr: true},
+		{name: "missing user", info: Info{ID: "s", AgentID: "a"}, wantErr: true},
+		{name: "group user must equal group", info: Info{ID: "s", AgentID: "a", UserID: "u", GroupID: testGroupID}, wantErr: true},
+		{name: "group id not a uuid", info: Info{ID: "s", AgentID: "a", UserID: "not-a-uuid", GroupID: "not-a-uuid"}, wantErr: true},
+		// uuid.Parse accepts these non-canonical forms, but the durable group id
+		// must be the exact canonical lowercase-hyphenated UUID.
+		{name: "group id uppercase", info: Info{ID: "s", AgentID: "a", UserID: "11111111-1111-4111-8111-111111111111", GroupID: "11111111-1111-4111-8111-111111111111"}, wantErr: false},
+		{name: "group id uppercased rejected", info: Info{ID: "s", AgentID: "a", UserID: "11111111-1111-4111-8111-11111111111A", GroupID: "11111111-1111-4111-8111-11111111111A"}, wantErr: true},
+		{name: "group id braces rejected", info: Info{ID: "s", AgentID: "a", UserID: "{11111111-1111-4111-8111-111111111111}", GroupID: "{11111111-1111-4111-8111-111111111111}"}, wantErr: true},
+		{name: "group id hyphenless rejected", info: Info{ID: "s", AgentID: "a", UserID: "11111111111141118111111111111111", GroupID: "11111111111141118111111111111111"}, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.info.Validate(); (err != nil) != tc.wantErr {
+				t.Fatalf("Validate() err = %v, wantErr = %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestInfoRecordRoundTrip verifies the persistence boundary mapping is lossless
+// for both private and group sessions.
+func TestInfoRecordRoundTrip(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	cases := []Info{
+		{ID: "s-1", AgentID: "agent", UserID: "user-1", Channel: "web", Kind: string(KindChat), ProjectID: "proj-1", Title: "hello", CreatedAt: now, LastActive: now, Archived: true},
+		{ID: "agent:group:" + testGroupID, AgentID: "agent", UserID: testGroupID, GroupID: testGroupID, Channel: "group:" + testGroupID, Kind: string(KindChat), CreatedAt: now, LastActive: now},
+	}
+	for _, info := range cases {
+		rec, err := info.Record()
+		if err != nil {
+			t.Fatalf("Record(%q): %v", info.ID, err)
+		}
+		got, err := InfoFromRecord(rec)
+		if err != nil {
+			t.Fatalf("InfoFromRecord(%q): %v", info.ID, err)
+		}
+		if got != info {
+			t.Fatalf("round trip mismatch:\n got  %+v\n want %+v", got, info)
+		}
+	}
+}
+
+// TestInfoFromRecord_FailsClosed proves the persistence→domain boundary rejects
+// a record that violates the session invariant.
+func TestInfoFromRecord_FailsClosed(t *testing.T) {
+	cases := []struct {
+		name string
+		rec  memory.SessionInfo
+	}{
+		{name: "missing user", rec: memory.SessionInfo{ID: "s", AgentID: "a"}},
+		{name: "group user mismatch", rec: memory.SessionInfo{ID: "s", AgentID: "a", UserID: "u", GroupID: testGroupID}},
+		{name: "group id not canonical", rec: memory.SessionInfo{ID: "s", AgentID: "a", UserID: "g", GroupID: "g"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := InfoFromRecord(tc.rec); err == nil {
+				t.Fatalf("InfoFromRecord must fail closed on %s", tc.name)
+			}
+		})
+	}
+}
+
+// TestRecord_FailsClosed proves the domain→persistence boundary rejects an
+// invalid Info instead of persisting it.
+func TestRecord_FailsClosed(t *testing.T) {
+	if _, err := (Info{ID: "s", AgentID: "a"}).Record(); err == nil {
+		t.Fatal("Record must fail closed on an Info missing a user owner")
+	}
+}

--- a/internal/agent/session/memory_adapter.go
+++ b/internal/agent/session/memory_adapter.go
@@ -18,15 +18,23 @@ func newMemoryAdapter(sm memory.SessionManager) *memoryAdapter {
 }
 
 func (a *memoryAdapter) save(ctx context.Context, info Info) error {
+	rec, err := info.Record()
+	if err != nil {
+		return err
+	}
 	ctx = authz.WithUserID(ctx, info.UserID)
 	ctx = authz.WithAgentID(ctx, info.AgentID)
-	return a.sm.SaveInfo(ctx, info)
+	return a.sm.SaveInfo(ctx, rec)
 }
 
 func (a *memoryAdapter) load(ctx context.Context, sessionID, userID, agentID string) (Info, error) {
 	ctx = authz.WithUserID(ctx, userID)
 	ctx = authz.WithAgentID(ctx, agentID)
-	info, err := a.sm.LoadInfo(ctx, sessionID)
+	rec, err := a.sm.LoadInfo(ctx, sessionID)
+	if err != nil {
+		return Info{}, fmt.Errorf("load session %q: %w", sessionID, err)
+	}
+	info, err := InfoFromRecord(rec)
 	if err != nil {
 		return Info{}, fmt.Errorf("load session %q: %w", sessionID, err)
 	}
@@ -38,7 +46,11 @@ func (a *memoryAdapter) list(ctx context.Context, userID, agentID string, opts m
 	opts.AgentID = agentID
 	ctx = authz.WithUserID(ctx, userID)
 	ctx = authz.WithAgentID(ctx, agentID)
-	return a.sm.ListInfo(ctx, opts)
+	recs, err := a.sm.ListInfo(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	return infosFromRecords(recs)
 }
 
 func (a *memoryAdapter) listForReview(ctx context.Context, agentID string, opts memory.ListOptions) ([]Info, error) {
@@ -46,8 +58,16 @@ func (a *memoryAdapter) listForReview(ctx context.Context, agentID string, opts 
 	if lister, ok := a.sm.(interface {
 		ListInfoForReview(ctx context.Context, opts memory.ListOptions) ([]memory.SessionInfo, error)
 	}); ok {
-		return lister.ListInfoForReview(ctx, opts)
+		recs, err := lister.ListInfoForReview(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
+		return infosFromReviewRecords(recs)
 	}
 	ctx = authz.WithAgentID(ctx, agentID)
-	return a.sm.ListInfo(ctx, opts)
+	recs, err := a.sm.ListInfo(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	return infosFromReviewRecords(recs)
 }

--- a/internal/agent/session/memory_adapter_test.go
+++ b/internal/agent/session/memory_adapter_test.go
@@ -1,0 +1,122 @@
+package session
+
+import (
+	"context"
+	"testing"
+
+	"github.com/CherryHQ/stella/internal/memory"
+	"github.com/CherryHQ/stella/pkg/ai"
+)
+
+// fakeSessionManager returns caller-supplied records so the adapter's fail-closed
+// behaviour on corrupt persisted rows can be exercised without a database.
+type fakeSessionManager struct {
+	rec  memory.SessionInfo
+	recs []memory.SessionInfo
+}
+
+func (f *fakeSessionManager) SaveInfo(context.Context, memory.SessionInfo) error { return nil }
+func (f *fakeSessionManager) LoadInfo(context.Context, string) (memory.SessionInfo, error) {
+	return f.rec, nil
+}
+
+func (f *fakeSessionManager) ListInfo(context.Context, memory.ListOptions) ([]memory.SessionInfo, error) {
+	return f.recs, nil
+}
+
+func (f *fakeSessionManager) LoadHistory(context.Context, string) ([]ai.Message, error) {
+	return nil, nil
+}
+
+// A record whose group_id is set but whose user_id is not the group id violates
+// the durable invariant; the persistence boundary must not hand it back as a
+// validated Info.
+var corruptGroupRecord = memory.SessionInfo{
+	ID:      "a:group:11111111-1111-4111-8111-111111111111",
+	AgentID: "a",
+	UserID:  "some-user", // != GroupID
+	GroupID: "11111111-1111-4111-8111-111111111111",
+	Kind:    "chat",
+}
+
+func TestMemoryAdapter_LoadFailsClosedOnCorruptRecord(t *testing.T) {
+	a := newMemoryAdapter(&fakeSessionManager{rec: corruptGroupRecord})
+	if _, err := a.load(context.Background(), corruptGroupRecord.ID, corruptGroupRecord.UserID, corruptGroupRecord.AgentID); err == nil {
+		t.Fatal("load must fail closed on a record that violates the session invariant")
+	}
+}
+
+func TestMemoryAdapter_ListFailsClosedOnCorruptRecord(t *testing.T) {
+	valid := memory.SessionInfo{ID: "s-priv", AgentID: "a", UserID: "u", Kind: "chat"}
+	a := newMemoryAdapter(&fakeSessionManager{recs: []memory.SessionInfo{valid, corruptGroupRecord}})
+	if _, err := a.list(context.Background(), "u", "a", memory.ListOptions{}); err == nil {
+		t.Fatal("list must fail closed when any record violates the session invariant")
+	}
+}
+
+// fakeReviewSessionManager also implements ListInfoForReview so the adapter's
+// primary (LCM-style) review branch is exercised.
+type fakeReviewSessionManager struct {
+	fakeSessionManager
+	reviewRecs []memory.SessionInfo
+}
+
+func (f *fakeReviewSessionManager) ListInfoForReview(context.Context, memory.ListOptions) ([]memory.SessionInfo, error) {
+	return f.reviewRecs, nil
+}
+
+var (
+	ownerlessLegacyRecord = memory.SessionInfo{ID: "s-ownerless", AgentID: "a", UserID: "", Kind: "chat"}
+	validReviewRecordA    = memory.SessionInfo{ID: "s-a", AgentID: "a", UserID: "u1", Kind: "chat"}
+	validReviewRecordB    = memory.SessionInfo{ID: "s-b", AgentID: "a", UserID: "u2", Kind: "chat"}
+)
+
+// TestMemoryAdapter_ListForReviewSkipsOwnerlessKeepsValid proves the review path
+// skips a legacy ownerless row (so one such row cannot fail the whole list) while
+// returning every valid owned row. Covers both the ListInfoForReview branch and
+// the ListInfo fallback used by non-LCM/fake providers.
+func TestMemoryAdapter_ListForReviewSkipsOwnerlessKeepsValid(t *testing.T) {
+	recs := []memory.SessionInfo{validReviewRecordA, ownerlessLegacyRecord, validReviewRecordB}
+
+	assertKeepsValid := func(t *testing.T, a *memoryAdapter) {
+		t.Helper()
+		got, err := a.listForReview(context.Background(), "a", memory.ListOptions{})
+		if err != nil {
+			t.Fatalf("listForReview: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("got %d infos, want 2 (ownerless skipped)", len(got))
+		}
+		for _, info := range got {
+			if info.ID == ownerlessLegacyRecord.ID {
+				t.Fatal("ownerless legacy row must be skipped from review")
+			}
+		}
+	}
+
+	t.Run("ListInfoForReview branch", func(t *testing.T) {
+		assertKeepsValid(t, newMemoryAdapter(&fakeReviewSessionManager{reviewRecs: recs}))
+	})
+	t.Run("ListInfo fallback branch", func(t *testing.T) {
+		assertKeepsValid(t, newMemoryAdapter(&fakeSessionManager{recs: recs}))
+	})
+}
+
+// TestMemoryAdapter_ListForReviewFailsClosedOnMalformedOwned proves a non-empty
+// malformed record (group mismatch) still fails the review list closed.
+func TestMemoryAdapter_ListForReviewFailsClosedOnMalformedOwned(t *testing.T) {
+	recs := []memory.SessionInfo{validReviewRecordA, corruptGroupRecord}
+
+	t.Run("ListInfoForReview branch", func(t *testing.T) {
+		a := newMemoryAdapter(&fakeReviewSessionManager{reviewRecs: recs})
+		if _, err := a.listForReview(context.Background(), "a", memory.ListOptions{}); err == nil {
+			t.Fatal("review list must fail closed on a non-empty malformed record")
+		}
+	})
+	t.Run("ListInfo fallback branch", func(t *testing.T) {
+		a := newMemoryAdapter(&fakeSessionManager{recs: recs})
+		if _, err := a.listForReview(context.Background(), "a", memory.ListOptions{}); err == nil {
+			t.Fatal("review list must fail closed on a non-empty malformed record")
+		}
+	})
+}

--- a/internal/agent/session/registry.go
+++ b/internal/agent/session/registry.go
@@ -245,14 +245,13 @@ func (r *Registry) ListForReview(ctx context.Context, req ReviewRequest) ([]Info
 }
 
 // MemoryScope converts a validated session Info into a memory.Session scope.
-// This is the ONLY authorised way to produce memory.Session for production agent sessions.
-func (r *Registry) MemoryScope(info Info) memory.Session {
-	return memory.Session{
-		ID:      info.ID,
-		AgentID: info.AgentID,
-		UserID:  info.UserID,
-		Channel: info.Channel,
-	}
+// This is the ONLY authorised way to produce memory.Session for production agent
+// sessions; it delegates to the canonical Info.MemoryScope conversion. Private
+// read, write, and compaction resolve one partition; group read and write share
+// the durable canonical group scope (group compaction is unsupported, so
+// MemoryScope makes no claim about it). It fails closed on an invalid Info.
+func (r *Registry) MemoryScope(info Info) (memory.Session, error) {
+	return info.MemoryScope()
 }
 
 // --- internal helpers -------------------------------------------------------
@@ -300,6 +299,25 @@ func (r *Registry) validateResume(info Info, req Request) (Info, error) {
 	if !req.Channel.isZero() && info.Channel == "" {
 		info.Channel = string(req.Channel)
 	}
+	// Reconcile the requested group identity with the durable one.
+	if req.GroupID != "" {
+		switch {
+		case info.GroupID == req.GroupID:
+			// Durable group_id already matches; nothing to do.
+		case info.GroupID != "":
+			// A different durable group owns this session: reject rather than rebind.
+			return Info{}, fmt.Errorf("%w: session %s belongs to group %q, not %q", ErrForbidden, info.ID, info.GroupID, req.GroupID)
+		case info.UserID == req.GroupID:
+			// Legacy row with a NULL group_id whose owner is this group: reattach.
+			info.GroupID = req.GroupID
+		default:
+			return Info{}, fmt.Errorf("%w: group %q does not own session %s", ErrForbidden, req.GroupID, info.ID)
+		}
+	}
+	// Fail closed: never hand back a resumed Info that violates the invariant.
+	if err := info.Validate(); err != nil {
+		return Info{}, err
+	}
 	return info, nil
 }
 
@@ -308,6 +326,7 @@ func (r *Registry) createNew(ctx context.Context, req Request, agentID string) (
 	id := uuid.Must(uuid.NewV7()).String()
 	channel := defaultChannel(req.Channel, req.Kind)
 	info := NewInfo(id, agentID, req.UserID, channel, req.Kind, req.ProjectID, now)
+	info.GroupID = req.GroupID
 	info.Title = req.Title
 	if req.Kind == "" {
 		info.Kind = string(KindChat)
@@ -322,6 +341,7 @@ func (r *Registry) createWithID(ctx context.Context, id string, req Request, age
 	now := time.Now().UTC()
 	channel := defaultChannel(req.Channel, req.Kind)
 	info := NewInfo(id, agentID, req.UserID, channel, req.Kind, req.ProjectID, now)
+	info.GroupID = req.GroupID
 	info.Title = req.Title
 	if req.Kind == "" {
 		info.Kind = string(KindChat)

--- a/internal/agent/session/registry_test.go
+++ b/internal/agent/session/registry_test.go
@@ -300,7 +300,10 @@ func TestMemoryScope(t *testing.T) {
 	now := time.Now().UTC()
 	info := NewInfo("s1", "agent1", "u1", "web", KindChat, "", now)
 
-	scope := r.MemoryScope(info)
+	scope, err := r.MemoryScope(info)
+	if err != nil {
+		t.Fatalf("MemoryScope: %v", err)
+	}
 	if scope.ID != "s1" || scope.AgentID != "agent1" || scope.UserID != "u1" {
 		t.Errorf("unexpected scope: %+v", scope)
 	}
@@ -389,4 +392,63 @@ func TestResolveMain_CreatesAgentMainWhenOnlyProjectMainExists(t *testing.T) {
 	if !strings.Contains(info.Channel, ":user:u1:") {
 		t.Errorf("Channel = %q, want private user channel", info.Channel)
 	}
+}
+
+// TestEnsure_ResumeGroupReconciliation covers validateResume's handling of a
+// requested GroupID against the durable one.
+func TestEnsure_ResumeGroupReconciliation(t *testing.T) {
+	const (
+		gid1 = "11111111-1111-4111-8111-111111111111"
+		gid2 = "22222222-2222-4222-8222-222222222222"
+	)
+	now := time.Now().UTC()
+
+	seedGroup := func(s *fakeStore, id, userID, groupID string) {
+		s.sessions[id] = Info{
+			ID: id, AgentID: "agent1", UserID: userID, GroupID: groupID,
+			Channel: "group:" + userID, Kind: string(KindChat), CreatedAt: now, LastActive: now,
+		}
+	}
+
+	t.Run("durable group matches", func(t *testing.T) {
+		r, s := newTestRegistry(t)
+		seedGroup(s, "g", gid1, gid1)
+		info, err := r.Ensure(context.Background(), Request{ID: "g", UserID: gid1, GroupID: gid1})
+		if err != nil {
+			t.Fatalf("Ensure: %v", err)
+		}
+		if info.GroupID != gid1 {
+			t.Fatalf("GroupID = %q, want %q", info.GroupID, gid1)
+		}
+	})
+
+	t.Run("conflicting durable group rejected", func(t *testing.T) {
+		r, s := newTestRegistry(t)
+		seedGroup(s, "g", gid1, gid1)
+		_, err := r.Ensure(context.Background(), Request{ID: "g", UserID: gid1, GroupID: gid2})
+		if !errors.Is(err, ErrForbidden) {
+			t.Fatalf("err = %v, want ErrForbidden", err)
+		}
+	})
+
+	t.Run("legacy null row reattaches for matching owner", func(t *testing.T) {
+		r, s := newTestRegistry(t)
+		seedGroup(s, "g", gid1, "") // durable group_id is NULL, owner is the group
+		info, err := r.Ensure(context.Background(), Request{ID: "g", UserID: gid1, GroupID: gid1})
+		if err != nil {
+			t.Fatalf("Ensure: %v", err)
+		}
+		if info.GroupID != gid1 {
+			t.Fatalf("GroupID after reattach = %q, want %q", info.GroupID, gid1)
+		}
+	})
+
+	t.Run("legacy null row rejects non-owner", func(t *testing.T) {
+		r, s := newTestRegistry(t)
+		seedGroup(s, "g", "some-user", "") // owner is not the requested group
+		_, err := r.Ensure(context.Background(), Request{ID: "g", UserID: "some-user", GroupID: gid1})
+		if !errors.Is(err, ErrForbidden) {
+			t.Fatalf("err = %v, want ErrForbidden", err)
+		}
+	})
 }

--- a/internal/agent/session/request.go
+++ b/internal/agent/session/request.go
@@ -7,6 +7,10 @@ type Request struct {
 	// UserID and AgentID are required for user-scoped operations.
 	UserID  string
 	AgentID string
+	// GroupID marks this as a group session owned by the group. When set it is
+	// the canonical ctx_group_state UUID and must equal UserID; it is persisted
+	// so the group identity survives reload. Empty for private sessions.
+	GroupID string
 	// ProjectID scopes the session to a project when non-empty.
 	ProjectID string
 	// Kind is the session kind to use when creating a new session.

--- a/internal/blob/default_boundary_test.go
+++ b/internal/blob/default_boundary_test.go
@@ -1,0 +1,141 @@
+package blob_test
+
+// Architecture boundary tripwire for issue #706 (stack 1 of #703).
+//
+// blob.Default()/blob.SetDefault() are the process-global raw blob store. The
+// target architecture injects raw blob storage only into a single asset/workspace
+// persistence service; transports and plugins receive narrow ports instead.
+// Removing the global is a later stack, so this guard freezes the CURRENT set of
+// production call sites by (file -> call count) and fails on any new call — even
+// inside an already-listed file, since the count is exact.
+//
+// This walks the whole module (call sites live outside internal/blob) and matches
+// blob.Default / blob.SetDefault by the "blob" import identifier (an aliased
+// import would evade it — an accepted limit shared with env_scan_test).
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// blobDefaultCallAllowlist records the exact number of blob.Default/SetDefault
+// production call sites per module-relative file. These are existing debt to be
+// replaced by an injected asset/workspace persistence service; the counts may
+// only go down (pay off debt, then lower the number), never up.
+var blobDefaultCallAllowlist = map[string]int{
+	"cmd/stellad/commands.go":     1, // SetDefault: installs the process-global store at boot
+	"internal/server/sessions.go": 5, // asset upload/download/list/delete handlers
+	"internal/agent/hydrate.go":   1, // cold-pod workspace hydration
+	"internal/agent/workspace.go": 1, // workspace materialization
+	"internal/share/service.go":   1, // shared-asset read
+}
+
+const blobImportPath = "github.com/CherryHQ/stella/internal/blob"
+
+// blobLocalName returns the identifier a file uses for the internal/blob import
+// (honoring an explicit alias), or "" if it does not import it. Resolving the
+// local name means an aliased import cannot evade the call counter.
+func blobLocalName(f *ast.File) string {
+	for _, imp := range f.Imports {
+		if strings.Trim(imp.Path.Value, "`\"") != blobImportPath {
+			continue
+		}
+		if imp.Name != nil {
+			return imp.Name.Name
+		}
+		return "blob"
+	}
+	return ""
+}
+
+func isBlobDefaultCall(call *ast.CallExpr, local string) bool {
+	if local == "" {
+		return false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	id, ok := sel.X.(*ast.Ident)
+	if !ok || id.Name != local {
+		return false
+	}
+	return sel.Sel.Name == "Default" || sel.Sel.Name == "SetDefault"
+}
+
+func TestNoNewBlobDefaultCallers(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("resolve module root: %v", err)
+	}
+	counts := map[string]int{}
+	skipDirs := map[string]bool{
+		".git": true, "node_modules": true, "dist": true, ".agents": true,
+	}
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if skipDirs[d.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		src := string(raw)
+		if strings.Contains(src, "//go:build ignore") || strings.Contains(src, "// Code generated") {
+			return nil
+		}
+		fset := token.NewFileSet()
+		f, err := parser.ParseFile(fset, path, src, 0)
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		local := blobLocalName(f)
+		ast.Inspect(f, func(n ast.Node) bool {
+			if call, ok := n.(*ast.CallExpr); ok && isBlobDefaultCall(call, local) {
+				counts[rel]++
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk module: %v", err)
+	}
+
+	for file, got := range counts {
+		want, ok := blobDefaultCallAllowlist[file]
+		if !ok {
+			t.Errorf("%s: new production blob.Default/SetDefault caller (%d call(s)); inject an asset/workspace persistence port instead of the process-global store", file, got)
+			continue
+		}
+		if got > want {
+			t.Errorf("%s: %d blob.Default/SetDefault call(s), allowlist permits %d; do not add new callers of the process-global blob store", file, got, want)
+		}
+	}
+	for file, want := range blobDefaultCallAllowlist {
+		got := counts[file]
+		if got < want {
+			t.Errorf("%s: only %d blob.Default/SetDefault call(s) remain (allowlist expects %d); lower the allowlist so regressions are caught", file, got, want)
+		}
+	}
+}

--- a/internal/channel/commands.go
+++ b/internal/channel/commands.go
@@ -2,9 +2,11 @@ package channel
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/CherryHQ/stella/internal/agent"
 	pkgchannel "github.com/CherryHQ/stella/pkg/channel"
 )
 
@@ -22,6 +24,9 @@ func HandleCommand(ctx context.Context, rc *ResolvedChat, text, senderID string)
 		return pkgchannel.WelcomeMessage, true
 	case "/new", "/compact":
 		if _, err := rc.CompactSession(ctx); err != nil {
+			if errors.Is(err, agent.ErrGroupCompactionUnsupported) {
+				return pkgchannel.GroupCompactUnsupportedMessage, true
+			}
 			return fmt.Sprintf("Compaction failed: %v", err), true
 		}
 		return "Session compacted.", true

--- a/internal/channel/commands_test.go
+++ b/internal/channel/commands_test.go
@@ -5,6 +5,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/CherryHQ/stella/internal/agent"
+	agentruntime "github.com/CherryHQ/stella/internal/agent/runtime"
+	"github.com/CherryHQ/stella/internal/agent/session"
+	"github.com/CherryHQ/stella/internal/auth"
+	"github.com/CherryHQ/stella/internal/memory/memorytest"
 	pkgchannel "github.com/CherryHQ/stella/pkg/channel"
 )
 
@@ -81,5 +86,68 @@ func TestWelcomeMessageIncludesNaturalLanguagePhrases(t *testing.T) {
 	}
 	if !strings.Contains(pkgchannel.WelcomeMessage, "If a short phrase is unclear") {
 		t.Error("WelcomeMessage should explain the fallback behavior for unclear phrases")
+	}
+}
+
+// --- /compact group vs private mapping --------------------------------------
+
+func newCompactTestChat(t *testing.T, groupID string, user auth.User) *ResolvedChat {
+	t.Helper()
+	const agentID = "cmd-agent"
+	fake := memorytest.New()
+	reg, err := session.NewRegistry(fake, agentID)
+	if err != nil {
+		t.Fatalf("new registry: %v", err)
+	}
+	rt, err := agentruntime.New(agentruntime.Config{
+		Memory:    fake,
+		NewRunner: func(context.Context, agentruntime.RunnerParams) (agentruntime.Runner, error) { return nil, nil },
+	})
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+	svc := &agent.Service{Sessions: reg, Runtime: rt, AgentID: agentID}
+
+	rc := &ResolvedChat{Service: svc, AgentID: agentID, User: user, GroupID: groupID}
+	if groupID != "" {
+		rc.SessionKey = agent.BuildGroupSessionKey(agentID, groupID)
+		rc.Channel = session.Channel("group:" + groupID)
+	} else {
+		rc.SessionKey = agent.BuildSessionKey(agentID, "telegram", user.ID, "private")
+		rc.Channel = session.Channel("telegram")
+	}
+	return rc
+}
+
+// TestHandleCommandCompactGroupUsesGroupMemoryMessage proves a group /compact maps
+// agent.ErrGroupCompactionUnsupported to the shared clear message, not the generic
+// "Compaction failed".
+func TestHandleCommandCompactGroupUsesGroupMemoryMessage(t *testing.T) {
+	const groupID = "11111111-1111-4111-8111-111111111111"
+	rc := newCompactTestChat(t, groupID, auth.User{})
+
+	resp, ok := HandleCommand(context.Background(), rc, "/compact", "sender-1")
+	if !ok {
+		t.Fatal("expected /compact to be handled")
+	}
+	if resp != pkgchannel.GroupCompactUnsupportedMessage {
+		t.Fatalf("response = %q, want the shared group-memory message", resp)
+	}
+	if strings.Contains(resp, "Compaction failed") {
+		t.Fatal("group /compact must not surface the generic failure message")
+	}
+}
+
+// TestHandleCommandCompactPrivateStillCompacts confirms the private /compact path
+// is unchanged (the fake provider compacts successfully).
+func TestHandleCommandCompactPrivateStillCompacts(t *testing.T) {
+	rc := newCompactTestChat(t, "", auth.User{ID: "user-1"})
+
+	resp, ok := HandleCommand(context.Background(), rc, "/compact", "user-1")
+	if !ok {
+		t.Fatal("expected /compact to be handled")
+	}
+	if resp != "Session compacted." {
+		t.Fatalf("response = %q, want %q", resp, "Session compacted.")
 	}
 }

--- a/internal/channel/group_dispatcher.go
+++ b/internal/channel/group_dispatcher.go
@@ -781,7 +781,7 @@ func (d *GroupDispatcher) chatWeb(ctx context.Context, row sqlc.CtxGroupDispatch
 	}
 	sessionKey := agent.BuildGroupSessionKey(row.AgentID, row.GroupID)
 	channelStr := "group:" + row.GroupID
-	info, err := svc.ResolveChannelSession(ctx, sessionKey, row.GroupID, row.AgentID, session.Channel(channelStr))
+	info, err := svc.ResolveGroupChannelSession(ctx, sessionKey, row.GroupID, row.AgentID, session.Channel(channelStr))
 	if err != nil {
 		return nil, fmt.Errorf("resolve session: %w", err)
 	}

--- a/internal/channel/resolved_chat.go
+++ b/internal/channel/resolved_chat.go
@@ -43,18 +43,14 @@ func (rc *ResolvedChat) sessionUserID() string {
 	return rc.User.ID
 }
 
-func (rc *ResolvedChat) ResolveSession(ctx context.Context) (agent.SessionInfo, error) {
+func (rc *ResolvedChat) ResolveSession(ctx context.Context) (session.Info, error) {
 	if rc.User.ID != "" && strings.Contains(string(rc.Channel), ":user:") {
 		return rc.Service.ResolveMainSession(ctx, rc.User.ID, rc.AgentID)
 	}
-	info, err := rc.Service.ResolveChannelSession(ctx, rc.SessionKey, rc.sessionUserID(), rc.AgentID, rc.Channel)
-	if err != nil {
-		return info, err
-	}
 	if rc.GroupID != "" {
-		info.GroupID = rc.GroupID
+		return rc.Service.ResolveGroupChannelSession(ctx, rc.SessionKey, rc.GroupID, rc.AgentID, rc.Channel)
 	}
-	return info, nil
+	return rc.Service.ResolvePrivateChannelSession(ctx, rc.SessionKey, rc.sessionUserID(), rc.AgentID, rc.Channel)
 }
 
 func (rc *ResolvedChat) CompactSession(ctx context.Context) (string, error) {

--- a/internal/db/database_test.go
+++ b/internal/db/database_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/pressly/goose/v3"
@@ -470,5 +471,83 @@ func TestSpanName(t *testing.T) {
 		if got := spanName(c.query); got != c.want {
 			t.Errorf("spanName(%q) = %q, want %q", c.query, got, c.want)
 		}
+	}
+}
+
+// TestCtxConversationGroupIDBackfillMigration seeds canonical group and private
+// rows before the group_id migration, applies the real migration, and asserts the
+// backfill populates only the canonical group conversation while leaving private
+// and non-canonical rows NULL. It uses the repository's DownTo/seed/UpTo pattern.
+func TestCtxConversationGroupIDBackfillMigration(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	sub, err := fs.Sub(MigrationsFS, "migrations")
+	if err != nil {
+		t.Fatalf("open migrations fs: %v", err)
+	}
+	sqlDB := stdlib.OpenDBFromPool(db)
+	defer func() { _ = sqlDB.Close() }()
+	provider, err := goose.NewProvider(goose.DialectPostgres, sqlDB, sub)
+	if err != nil {
+		t.Fatalf("create migration provider: %v", err)
+	}
+
+	// Roll back to just before the group_id migration.
+	if _, err := provider.DownTo(ctx, 20260709120000); err != nil {
+		t.Fatalf("goose down to before group_id migration: %v", err)
+	}
+	if columnExists(t, db, "ctx_conversation", "group_id") {
+		t.Fatal("group_id should not exist before the migration")
+	}
+
+	const agentID = "agent-a"
+	gid := uuid.NewString()
+	if _, err := db.Exec(ctx, `INSERT INTO ctx_group_state (id, platform, platform_group_id) VALUES ($1, 'test', $2)`, gid, "grp-"+gid); err != nil {
+		t.Fatalf("seed group state: %v", err)
+	}
+
+	// Canonical group conversation: user_id == group uuid and the derived key.
+	groupSessionID := agentID + ":group:" + gid
+	if _, err := db.Exec(ctx, `INSERT INTO ctx_conversation (id, session_id, channel, kind, agent_id, user_id) VALUES ($1, $2, $3, 'chat', $4, $5)`,
+		uuid.NewString(), groupSessionID, "group:"+gid, agentID, gid); err != nil {
+		t.Fatalf("seed canonical group conversation: %v", err)
+	}
+	// Private conversation: real user, should never be backfilled.
+	privateSessionID := agentID + ":user:user-1:private"
+	if _, err := db.Exec(ctx, `INSERT INTO ctx_conversation (id, session_id, channel, kind, agent_id, user_id) VALUES ($1, $2, 'web', 'chat', $3, 'user-1')`,
+		uuid.NewString(), privateSessionID, agentID); err != nil {
+		t.Fatalf("seed private conversation: %v", err)
+	}
+	// Non-canonical row: user_id == group uuid but session_id does not match the
+	// derived group key, so the predicate must leave it NULL.
+	noncanonSessionID := "arbitrary-key"
+	if _, err := db.Exec(ctx, `INSERT INTO ctx_conversation (id, session_id, channel, kind, agent_id, user_id) VALUES ($1, $2, 'web', 'chat', $3, $4)`,
+		uuid.NewString(), noncanonSessionID, agentID, gid); err != nil {
+		t.Fatalf("seed non-canonical conversation: %v", err)
+	}
+
+	// Apply the real migration (adds column, FK, CHECK, index, and backfills).
+	if _, err := provider.UpTo(ctx, 20260711134243); err != nil {
+		t.Fatalf("goose up group_id migration: %v", err)
+	}
+
+	groupIDOf := func(sessionID string) (string, bool) {
+		t.Helper()
+		var g pgtype.Text
+		if err := db.QueryRow(ctx, `SELECT group_id::text FROM ctx_conversation WHERE session_id = $1`, sessionID).Scan(&g); err != nil {
+			t.Fatalf("read group_id for %s: %v", sessionID, err)
+		}
+		return g.String, g.Valid
+	}
+
+	if got, ok := groupIDOf(groupSessionID); !ok || got != gid {
+		t.Fatalf("canonical group conversation group_id = (%q, valid=%v), want %q", got, ok, gid)
+	}
+	if _, ok := groupIDOf(privateSessionID); ok {
+		t.Fatal("private conversation group_id must stay NULL")
+	}
+	if _, ok := groupIDOf(noncanonSessionID); ok {
+		t.Fatal("non-canonical conversation group_id must stay NULL")
 	}
 }

--- a/internal/db/migrations/20260711134243_add_ctx_conversation_group_id.sql
+++ b/internal/db/migrations/20260711134243_add_ctx_conversation_group_id.sql
@@ -1,0 +1,51 @@
+-- +goose Up
+-- Make a group session's group identity durable on its LCM conversation row.
+-- Until now group_id lived only on the in-flight runtime Info and was never
+-- persisted, so a reloaded group conversation was indistinguishable from a
+-- private one (reflect misclassified it; scope relied on the undeclared
+-- user_id == group_id convention). Add an explicit, FK-backed column.
+--
+-- ON DELETE CASCADE matches every sibling group_id FK into ctx_group_state
+-- (channel_group_member, ctx_group_dispatch, ctx_group_ingest_cursor/error,
+-- ctx_group_memory, ctx_group_message, ctx_group_outbox): ctx_group_state is the
+-- durable identity anchor for a group and its deletion already cascades all
+-- group-derived state. The LCM conversation shell is likewise group-derived;
+-- SET NULL would leave a corrupt "private" conversation still owned by a dead
+-- group UUID (user_id), and RESTRICT would block group deletion on a subordinate
+-- table. CASCADE also cleans the conversation's ctx_message/ctx_item rows, which
+-- already cascade from ctx_conversation.
+ALTER TABLE "ctx_conversation" ADD COLUMN "group_id" uuid NULL;
+ALTER TABLE "ctx_conversation"
+  ADD CONSTRAINT "ctx_conversation_group_id_fkey"
+  FOREIGN KEY ("group_id") REFERENCES "ctx_group_state" ("id")
+  ON UPDATE NO ACTION ON DELETE CASCADE;
+-- Structural ownership invariant (a coupling rule between columns, not an enum):
+-- a group conversation is owned by its group, so when group_id is set the row's
+-- user_id must equal it. This is the DB-level twin of session.Info.Validate and
+-- keeps a mismatched (user_id, group_id) pair unrepresentable at the boundary.
+ALTER TABLE "ctx_conversation"
+  ADD CONSTRAINT "ctx_conversation_group_owner_check"
+  CHECK ("group_id" IS NULL OR ("user_id" IS NOT NULL AND "user_id" = "group_id"::text));
+CREATE INDEX "idx_ctx_conversation_group_id" ON "ctx_conversation" ("group_id")
+  WHERE ("group_id" IS NOT NULL);
+
+-- Backfill only canonical group rows: user_id holds the group UUID (compared as
+-- text to avoid an invalid-uuid cast on legacy non-uuid user_ids) and the
+-- session_id is the derived group key agent_id || ':group:' || group UUID. Both
+-- conditions must hold, so private conversations and any malformed row are left
+-- untouched (group_id stays NULL).
+UPDATE "ctx_conversation" AS c
+SET "group_id" = gs."id",
+    "updated_at" = now()
+FROM "ctx_group_state" AS gs
+WHERE c."group_id" IS NULL
+  AND c."user_id" IS NOT NULL
+  AND c."agent_id" IS NOT NULL
+  AND gs."id"::text = c."user_id"
+  AND c."session_id" = c."agent_id" || ':group:' || c."user_id";
+
+-- +goose Down
+ALTER TABLE "ctx_conversation" DROP CONSTRAINT IF EXISTS "ctx_conversation_group_owner_check";
+ALTER TABLE "ctx_conversation" DROP CONSTRAINT IF EXISTS "ctx_conversation_group_id_fkey";
+DROP INDEX IF EXISTS "idx_ctx_conversation_group_id";
+ALTER TABLE "ctx_conversation" DROP COLUMN IF EXISTS "group_id";

--- a/internal/db/queries/ctx_conversation.sql
+++ b/internal/db/queries/ctx_conversation.sql
@@ -1,6 +1,6 @@
 -- name: CreateConversation :one
-INSERT INTO ctx_conversation (id, session_id, title, channel, kind, project_id, archived, last_active, agent_id, user_id)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+INSERT INTO ctx_conversation (id, session_id, title, channel, kind, project_id, archived, last_active, agent_id, user_id, group_id)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, sqlc.narg(group_id))
 RETURNING *;
 
 -- name: GetConversation :one
@@ -53,6 +53,12 @@ SET
     WHEN sqlc.narg(project_id)::text IS NOT NULL AND (project_id IS NULL OR project_id != sqlc.narg(project_id)) THEN sqlc.narg(project_id)
     ELSE project_id
   END,
+  -- Make a legacy canonical group row durable: adopt the supplied group_id only
+  -- when the stored value is NULL. Never overwrite or clear an existing group_id.
+  group_id = CASE
+    WHEN group_id IS NULL AND sqlc.narg(group_id)::uuid IS NOT NULL THEN sqlc.narg(group_id)
+    ELSE group_id
+  END,
   last_active = now(),
   updated_at = now()
 WHERE session_id = sqlc.arg(session_id)
@@ -93,15 +99,21 @@ WHERE user_id = sqlc.arg(user_id)
 GROUP BY agent_id;
 
 -- name: ListConversationsForReviewByAgent :many
+-- Ownerless legacy rows (NULL/empty user_id) are excluded: review is user-scoped
+-- and such rows were never review candidates.
 SELECT * FROM ctx_conversation
 WHERE agent_id = sqlc.arg(agent_id)
   AND archived = false
+  AND user_id IS NOT NULL AND user_id <> ''
 ORDER BY last_active DESC;
 
 -- name: ListConversationsForReviewFiltered :many
+-- Ownerless legacy rows (NULL/empty user_id) are excluded: review is user-scoped
+-- and such rows were never review candidates.
 SELECT * FROM ctx_conversation
 WHERE agent_id = sqlc.arg(agent_id)
   AND archived = false
+  AND user_id IS NOT NULL AND user_id <> ''
   AND (sqlc.narg(kind)::text IS NULL OR kind = sqlc.narg(kind))
   AND (sqlc.arg(project_id_is_null) = 0 OR project_id IS NULL)
   AND (sqlc.narg(project_id)::text IS NULL OR project_id = sqlc.narg(project_id))

--- a/internal/memory/lcm/engine.go
+++ b/internal/memory/lcm/engine.go
@@ -91,6 +91,7 @@ func (p *Provider) getOrCreateConversation(ctx context.Context, session memory.S
 		Kind:       "chat",
 		AgentID:    pgnull.Text(session.AgentID),
 		UserID:     pgtype.Text{String: session.UserID, Valid: true},
+		GroupID:    pgnull.Text(session.GroupID),
 		LastActive: now,
 	})
 	if err == nil {

--- a/internal/memory/lcm/group_assembler_test.go
+++ b/internal/memory/lcm/group_assembler_test.go
@@ -364,7 +364,16 @@ func TestGroupAssemble_EmptyGroup(t *testing.T) {
 		t.Fatalf("new: %v", err)
 	}
 
-	sess := groupSess("agent-a", "nonexistent")
+	// A group session's conversation now carries an FK-backed group_id, so the
+	// group must exist even when it has no messages. Create an empty group state.
+	gid := uuid.Must(uuid.NewV7()).String()
+	if _, err := p.q.CreateGroupState(context.Background(), sqlc.CreateGroupStateParams{
+		ID: gid, Platform: "test", PlatformGroupID: "empty-" + gid,
+	}); err != nil {
+		t.Fatalf("create group state: %v", err)
+	}
+
+	sess := groupSess("agent-a", gid)
 	assembleCtx := groupCtx(1)
 	msgs, err := p.Assemble(assembleCtx, sess, 100_000, 20)
 	if err != nil {

--- a/internal/memory/lcm/group_id_persistence_test.go
+++ b/internal/memory/lcm/group_id_persistence_test.go
@@ -1,0 +1,191 @@
+package lcm
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/CherryHQ/stella/internal/authz"
+	"github.com/CherryHQ/stella/internal/memory"
+	"github.com/CherryHQ/stella/pkg/db/pgnull"
+	"github.com/CherryHQ/stella/pkg/db/sqlc"
+)
+
+// newEmptyGroupState creates an FK-valid ctx_group_state row and returns its id.
+func newEmptyGroupState(t *testing.T, p *Provider) string {
+	t.Helper()
+	gid := uuid.Must(uuid.NewV7()).String()
+	if _, err := p.q.CreateGroupState(context.Background(), sqlc.CreateGroupStateParams{
+		ID: gid, Platform: "test", PlatformGroupID: "grp-" + gid,
+	}); err != nil {
+		t.Fatalf("create group state: %v", err)
+	}
+	return gid
+}
+
+// TestGroupID_DurableAcrossReload proves the group identity is now persisted on
+// ctx_conversation.group_id and survives both a re-read and a fresh Provider
+// (restart-style), rather than living only on the in-flight runtime Info.
+func TestGroupID_DurableAcrossReload(t *testing.T) {
+	db := openTestDB(t)
+	p, err := New(db, nil, nil)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+
+	const agentID = "agent-a"
+	gid := newEmptyGroupState(t, p)
+	ctx := authz.WithAgentID(authz.WithUserID(context.Background(), gid), agentID)
+
+	info := memory.SessionInfo{
+		ID:      agentID + ":group:" + gid,
+		AgentID: agentID,
+		UserID:  gid, // group session owned by the group
+		GroupID: gid,
+		Channel: "group:" + gid,
+		Kind:    "chat",
+	}
+	if err := p.SaveInfo(ctx, info); err != nil {
+		t.Fatalf("SaveInfo: %v", err)
+	}
+
+	got, err := p.LoadInfo(ctx, info.ID)
+	if err != nil {
+		t.Fatalf("LoadInfo: %v", err)
+	}
+	if got.GroupID != gid {
+		t.Fatalf("GroupID after reload = %q, want %q", got.GroupID, gid)
+	}
+
+	// Restart-style: a fresh Provider over the same pool still sees the durable id.
+	p2, err := New(db, nil, nil)
+	if err != nil {
+		t.Fatalf("new (restart): %v", err)
+	}
+	got2, err := p2.LoadInfo(ctx, info.ID)
+	if err != nil {
+		t.Fatalf("LoadInfo (restart): %v", err)
+	}
+	if got2.GroupID != gid {
+		t.Fatalf("GroupID after restart = %q, want %q", got2.GroupID, gid)
+	}
+}
+
+// TestGroupID_SaveMakesLegacyNullRowDurable proves that a legacy canonical group
+// conversation whose group_id is still NULL adopts the supplied group_id on the
+// next SaveInfo update, without a migration backfill.
+func TestGroupID_SaveMakesLegacyNullRowDurable(t *testing.T) {
+	db := openTestDB(t)
+	p, err := New(db, nil, nil)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+
+	const agentID = "agent-a"
+	gid := newEmptyGroupState(t, p)
+	sessionID := agentID + ":group:" + gid
+
+	// Legacy shape: a group conversation persisted with group_id NULL.
+	if _, err := p.q.CreateConversation(context.Background(), sqlc.CreateConversationParams{
+		ID:        uuid.Must(uuid.NewV7()).String(),
+		SessionID: sessionID,
+		Channel:   "group:" + gid,
+		Kind:      "chat",
+		AgentID:   pgnull.Text(agentID),
+		UserID:    pgtype.Text{String: gid, Valid: true},
+		GroupID:   pgtype.Text{}, // NULL
+	}); err != nil {
+		t.Fatalf("seed legacy group conversation: %v", err)
+	}
+
+	ctx := authz.WithAgentID(authz.WithUserID(context.Background(), gid), agentID)
+	// An ordinary SaveInfo update (existing row) carrying the group id.
+	if err := p.SaveInfo(ctx, memory.SessionInfo{
+		ID: sessionID, AgentID: agentID, UserID: gid, GroupID: gid, Kind: "chat",
+	}); err != nil {
+		t.Fatalf("SaveInfo update: %v", err)
+	}
+
+	got, err := p.LoadInfo(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("LoadInfo: %v", err)
+	}
+	if got.GroupID != gid {
+		t.Fatalf("legacy row group_id after save = %q, want %q", got.GroupID, gid)
+	}
+}
+
+// TestGroupID_CheckRejectsUserGroupMismatch proves the DB CHECK constraint
+// refuses a row whose group_id is set but whose user_id is not the group id.
+func TestGroupID_CheckRejectsUserGroupMismatch(t *testing.T) {
+	db := openTestDB(t)
+	p, err := New(db, nil, nil)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+
+	const agentID = "agent-a"
+	gid := newEmptyGroupState(t, p)
+
+	_, err = p.q.CreateConversation(context.Background(), sqlc.CreateConversationParams{
+		ID:        uuid.Must(uuid.NewV7()).String(),
+		SessionID: agentID + ":group:" + gid,
+		Channel:   "group:" + gid,
+		Kind:      "chat",
+		AgentID:   pgnull.Text(agentID),
+		UserID:    pgtype.Text{String: "some-other-user", Valid: true}, // != group id
+		GroupID:   pgnull.Text(gid),
+	})
+	if err == nil {
+		t.Fatal("expected the group-owner CHECK to reject a mismatched user_id/group_id")
+	}
+	if !strings.Contains(err.Error(), "ctx_conversation_group_owner_check") {
+		t.Fatalf("error should mention the group-owner check, got: %v", err)
+	}
+}
+
+// TestListInfoForReview_ExcludesOwnerlessRows proves the production review SQL
+// skips legacy rows with a NULL/empty user_id (review is user-scoped) while
+// returning owned rows for the agent.
+func TestListInfoForReview_ExcludesOwnerlessRows(t *testing.T) {
+	db := openTestDB(t)
+	p, err := New(db, nil, nil)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	ctx := context.Background()
+	const agentID = "review-agent"
+
+	if _, err := p.q.CreateConversation(ctx, sqlc.CreateConversationParams{
+		ID:        uuid.Must(uuid.NewV7()).String(),
+		SessionID: "s-owned",
+		Channel:   "web",
+		Kind:      "chat",
+		AgentID:   pgnull.Text(agentID),
+		UserID:    pgtype.Text{String: "user-1", Valid: true},
+	}); err != nil {
+		t.Fatalf("seed owned conversation: %v", err)
+	}
+	// Legacy ownerless row: user_id NULL.
+	if _, err := p.q.CreateConversation(ctx, sqlc.CreateConversationParams{
+		ID:        uuid.Must(uuid.NewV7()).String(),
+		SessionID: "s-ownerless",
+		Channel:   "web",
+		Kind:      "chat",
+		AgentID:   pgnull.Text(agentID),
+		UserID:    pgtype.Text{}, // NULL
+	}); err != nil {
+		t.Fatalf("seed ownerless conversation: %v", err)
+	}
+
+	recs, err := p.ListInfoForReview(ctx, memory.ListOptions{AgentID: agentID})
+	if err != nil {
+		t.Fatalf("ListInfoForReview: %v", err)
+	}
+	if len(recs) != 1 || recs[0].ID != "s-owned" {
+		t.Fatalf("expected only the owned row, got %+v", recs)
+	}
+}

--- a/internal/memory/lcm/sessions.go
+++ b/internal/memory/lcm/sessions.go
@@ -82,6 +82,7 @@ func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error 
 			LastActive: lastActive.UTC(),
 			AgentID:    pgnull.Text(info.AgentID),
 			UserID:     pgtype.Text{String: info.UserID, Valid: true},
+			GroupID:    pgnull.Text(info.GroupID),
 		})
 		if err != nil {
 			return fmt.Errorf("create conversation: %w", err)
@@ -97,6 +98,7 @@ func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error 
 		Archived:  info.Archived,
 		Kind:      pgnull.Text(info.Kind),
 		ProjectID: pgnull.Text(info.ProjectID),
+		GroupID:   pgnull.Text(info.GroupID),
 		SessionID: info.ID,
 		UserID:    pgtype.Text{String: info.UserID, Valid: true},
 		AgentID:   pgnull.Text(info.AgentID),
@@ -254,6 +256,9 @@ func convToSessionInfo(conv sqlc.CtxConversation) memory.SessionInfo {
 	}
 	if conv.UserID.Valid {
 		info.UserID = conv.UserID.String
+	}
+	if conv.GroupID.Valid {
+		info.GroupID = conv.GroupID.String
 	}
 	if conv.ProjectID.Valid {
 		info.ProjectID = conv.ProjectID.String

--- a/internal/reflect/conversation_review.go
+++ b/internal/reflect/conversation_review.go
@@ -19,6 +19,14 @@ import (
 )
 
 func (s *Service) reviewConversation(ctx context.Context, snap *config.Snapshot, target reviewTarget) error {
+	// The production reviewer predates the candidate pipeline, whose
+	// buildReviewUnit also enforces this boundary. Keep the live path fail-closed:
+	// group history is assembled from the shared event log and must not be mined
+	// as a private one-to-one conversation.
+	if !target.privateOneToOne {
+		return nil
+	}
+
 	ctx, span := startConversationSpan(ctx, target)
 	defer span.End()
 

--- a/internal/reflect/conversation_review_test.go
+++ b/internal/reflect/conversation_review_test.go
@@ -57,6 +57,35 @@ func TestReviewConversationUsesLegacyCombinedPrompt(t *testing.T) {
 	}
 }
 
+func TestReviewConversationSkipsGroupTarget(t *testing.T) {
+	wm := newFakeWatermarks()
+	svc := &Service{
+		memory: memorytest.New(),
+		wm:     wm,
+		log:    testLogger(),
+		providers: func(string, string, string) (providers.StreamFunc, error) {
+			t.Fatal("group target must not construct a production reviewer")
+			return nil, nil
+		},
+	}
+	target := reviewTarget{
+		session: memory.Session{
+			ID:      "group-session",
+			AgentID: "agent-1",
+			UserID:  "01980f2d-e91d-7f99-ac5f-d36098e0c800",
+			GroupID: "01980f2d-e91d-7f99-ac5f-d36098e0c800",
+		},
+		privateOneToOne: false,
+	}
+
+	if err := svc.reviewConversation(context.Background(), testSnapshot(), target); err != nil {
+		t.Fatalf("review group target: %v", err)
+	}
+	if !wm.marks[target.session.ID].IsZero() {
+		t.Fatal("skipped group target must not advance the private review watermark")
+	}
+}
+
 func TestReviewConversationCandidatesEntryPointUsesCandidateRunners(t *testing.T) {
 	svc, target, wm, freshAt := newCandidatePipelineTestService(t)
 	stream := sequentialCaptureStream(t,

--- a/internal/reflect/group_review_target_test.go
+++ b/internal/reflect/group_review_target_test.go
@@ -1,0 +1,73 @@
+package reflect
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/CherryHQ/stella/internal/memory"
+)
+
+// TestUnreviewedTarget_GroupSessionNotPrivate proves that now GroupID is durable
+// (loaded from ctx_conversation.group_id), a group session is classified as
+// not-private-one-to-one and is therefore skipped by buildReviewUnit rather than
+// reviewed as a personal 1:1 conversation.
+func TestUnreviewedTarget_GroupSessionNotPrivate(t *testing.T) {
+	svc := &Service{wm: newFakeWatermarks(), log: testLogger()}
+	const groupID = "11111111-1111-4111-8111-111111111111"
+	rec := memory.SessionInfo{
+		ID:         "a:group:" + groupID,
+		AgentID:    "a",
+		UserID:     groupID, // group sessions are owned by the group
+		GroupID:    groupID,
+		Channel:    "group:" + groupID,
+		Kind:       "chat",
+		LastActive: time.Date(2026, 7, 2, 10, 0, 0, 0, time.UTC),
+	}
+
+	target, ok := svc.unreviewedTarget(context.Background(), rec)
+	if !ok {
+		t.Fatal("expected a review target for a fresh group session")
+	}
+	if target.privateOneToOne {
+		t.Fatal("group session must not be classified as private one-to-one")
+	}
+	if target.sourceGroupID != groupID {
+		t.Fatalf("sourceGroupID = %q, want %q", target.sourceGroupID, groupID)
+	}
+
+	unit, err := svc.buildReviewUnit(context.Background(), target, reviewWatermark{}, 1000)
+	if err != nil {
+		t.Fatalf("buildReviewUnit: %v", err)
+	}
+	if unit.PrivateOneToOne {
+		t.Fatal("review unit for a group session must not be private one-to-one")
+	}
+	if len(unit.Skipped) != 1 || unit.Skipped[0].Reason != reviewSkipNotPrivateOneToOne {
+		t.Fatalf("expected a single not-private-one-to-one skip, got %+v", unit.Skipped)
+	}
+}
+
+// TestUnreviewedTarget_PrivateSessionStaysPrivate is the control: a private
+// session (no GroupID) is still classified private one-to-one.
+func TestUnreviewedTarget_PrivateSessionStaysPrivate(t *testing.T) {
+	svc := &Service{wm: newFakeWatermarks(), log: testLogger()}
+	rec := memory.SessionInfo{
+		ID:         "s-priv",
+		AgentID:    "a",
+		UserID:     "user-1",
+		Channel:    "web",
+		Kind:       "chat",
+		LastActive: time.Date(2026, 7, 2, 10, 0, 0, 0, time.UTC),
+	}
+	target, ok := svc.unreviewedTarget(context.Background(), rec)
+	if !ok {
+		t.Fatal("expected a review target for a fresh private session")
+	}
+	if !target.privateOneToOne {
+		t.Fatal("private session must be classified as private one-to-one")
+	}
+	if target.sourceGroupID != "" {
+		t.Fatalf("sourceGroupID = %q, want empty", target.sourceGroupID)
+	}
+}

--- a/internal/reflect/group_review_target_test.go
+++ b/internal/reflect/group_review_target_test.go
@@ -8,11 +8,10 @@ import (
 	"github.com/CherryHQ/stella/internal/memory"
 )
 
-// TestUnreviewedTarget_GroupSessionNotPrivate proves that now GroupID is durable
-// (loaded from ctx_conversation.group_id), a group session is classified as
-// not-private-one-to-one and is therefore skipped by buildReviewUnit rather than
-// reviewed as a personal 1:1 conversation.
-func TestUnreviewedTarget_GroupSessionNotPrivate(t *testing.T) {
+// TestUnreviewedTarget_GroupSessionExcluded proves that a durable GroupID keeps
+// a group session out of the private Reflect queue entirely. Filtering before
+// target limiting prevents old group sessions from starving private reviews.
+func TestUnreviewedTarget_GroupSessionExcluded(t *testing.T) {
 	svc := &Service{wm: newFakeWatermarks(), log: testLogger()}
 	const groupID = "11111111-1111-4111-8111-111111111111"
 	rec := memory.SessionInfo{
@@ -25,26 +24,8 @@ func TestUnreviewedTarget_GroupSessionNotPrivate(t *testing.T) {
 		LastActive: time.Date(2026, 7, 2, 10, 0, 0, 0, time.UTC),
 	}
 
-	target, ok := svc.unreviewedTarget(context.Background(), rec)
-	if !ok {
-		t.Fatal("expected a review target for a fresh group session")
-	}
-	if target.privateOneToOne {
-		t.Fatal("group session must not be classified as private one-to-one")
-	}
-	if target.sourceGroupID != groupID {
-		t.Fatalf("sourceGroupID = %q, want %q", target.sourceGroupID, groupID)
-	}
-
-	unit, err := svc.buildReviewUnit(context.Background(), target, reviewWatermark{}, 1000)
-	if err != nil {
-		t.Fatalf("buildReviewUnit: %v", err)
-	}
-	if unit.PrivateOneToOne {
-		t.Fatal("review unit for a group session must not be private one-to-one")
-	}
-	if len(unit.Skipped) != 1 || unit.Skipped[0].Reason != reviewSkipNotPrivateOneToOne {
-		t.Fatalf("expected a single not-private-one-to-one skip, got %+v", unit.Skipped)
+	if _, ok := svc.unreviewedTarget(context.Background(), rec); ok {
+		t.Fatal("group session must be excluded before entering the private review queue")
 	}
 }
 
@@ -66,8 +47,5 @@ func TestUnreviewedTarget_PrivateSessionStaysPrivate(t *testing.T) {
 	}
 	if !target.privateOneToOne {
 		t.Fatal("private session must be classified as private one-to-one")
-	}
-	if target.sourceGroupID != "" {
-		t.Fatalf("sourceGroupID = %q, want empty", target.sourceGroupID)
 	}
 }

--- a/internal/reflect/review_targets.go
+++ b/internal/reflect/review_targets.go
@@ -15,7 +15,6 @@ type reviewTarget struct {
 	session         memory.Session
 	lastActive      time.Time // from SessionInfo — used as tiebreaker
 	lastReview      time.Time // zero if never reviewed
-	sourceGroupID   string
 	privateOneToOne bool
 }
 
@@ -85,7 +84,10 @@ func listSessionInfoForReview(ctx context.Context, sm memory.SessionManager, age
 }
 
 func (s *Service) unreviewedTargetFromRegistry(ctx context.Context, reg *session.Registry, info session.Info) (reviewTarget, bool) {
-	if info.UserID == "" {
+	// Reflect currently mines private one-to-one history only. Exclude groups
+	// before watermark lookup and target limiting so skipped group sessions cannot
+	// permanently occupy the oldest-review slots and starve private sessions.
+	if info.UserID == "" || info.GroupID != "" {
 		return reviewTarget{}, false
 	}
 
@@ -103,20 +105,16 @@ func (s *Service) unreviewedTargetFromRegistry(ctx context.Context, reg *session
 		s.log.Warn("reflect: invalid session scope, skipping session", "session", info.ID, "error", err)
 		return reviewTarget{}, false
 	}
-	// GroupID is durable now, so a group session (GroupID set) is correctly
-	// classified as not private-one-to-one and skipped by buildReviewUnit rather
-	// than reviewed as a personal 1:1 conversation.
 	return reviewTarget{
 		session:         scope,
 		lastActive:      info.LastActive,
 		lastReview:      wm,
-		sourceGroupID:   info.GroupID,
-		privateOneToOne: info.GroupID == "" && info.UserID != "",
+		privateOneToOne: true,
 	}, true
 }
 
 func (s *Service) unreviewedTarget(ctx context.Context, sess memory.SessionInfo) (reviewTarget, bool) {
-	if sess.UserID == "" {
+	if sess.UserID == "" || sess.GroupID != "" {
 		return reviewTarget{}, false
 	}
 
@@ -143,8 +141,7 @@ func (s *Service) unreviewedTarget(ctx context.Context, sess memory.SessionInfo)
 		session:         scope,
 		lastActive:      info.LastActive,
 		lastReview:      wm,
-		sourceGroupID:   info.GroupID,
-		privateOneToOne: info.GroupID == "" && info.UserID != "",
+		privateOneToOne: true,
 	}, true
 }
 

--- a/internal/reflect/review_targets.go
+++ b/internal/reflect/review_targets.go
@@ -98,8 +98,16 @@ func (s *Service) unreviewedTargetFromRegistry(ctx context.Context, reg *session
 		return reviewTarget{}, false
 	}
 
+	scope, err := reg.MemoryScope(info)
+	if err != nil {
+		s.log.Warn("reflect: invalid session scope, skipping session", "session", info.ID, "error", err)
+		return reviewTarget{}, false
+	}
+	// GroupID is durable now, so a group session (GroupID set) is correctly
+	// classified as not private-one-to-one and skipped by buildReviewUnit rather
+	// than reviewed as a personal 1:1 conversation.
 	return reviewTarget{
-		session:         reg.MemoryScope(info),
+		session:         scope,
 		lastActive:      info.LastActive,
 		lastReview:      wm,
 		sourceGroupID:   info.GroupID,
@@ -121,18 +129,22 @@ func (s *Service) unreviewedTarget(ctx context.Context, sess memory.SessionInfo)
 		return reviewTarget{}, false
 	}
 
+	info, err := session.InfoFromRecord(sess)
+	if err != nil {
+		s.log.Warn("reflect: invalid session record, skipping session", "session", sess.ID, "error", err)
+		return reviewTarget{}, false
+	}
+	scope, err := info.MemoryScope()
+	if err != nil {
+		s.log.Warn("reflect: invalid session scope, skipping session", "session", sess.ID, "error", err)
+		return reviewTarget{}, false
+	}
 	return reviewTarget{
-		session: memory.Session{
-			ID:      sess.ID,
-			AgentID: sess.AgentID,
-			UserID:  sess.UserID,
-			Channel: sess.Channel,
-			GroupID: sess.GroupID,
-		},
-		lastActive:      sess.LastActive,
+		session:         scope,
+		lastActive:      info.LastActive,
 		lastReview:      wm,
-		sourceGroupID:   sess.GroupID,
-		privateOneToOne: sess.GroupID == "" && sess.UserID != "",
+		sourceGroupID:   info.GroupID,
+		privateOneToOne: info.GroupID == "" && info.UserID != "",
 	}, true
 }
 

--- a/internal/server/architecture_boundary_test.go
+++ b/internal/server/architecture_boundary_test.go
@@ -1,0 +1,487 @@
+package server_test
+
+// Architecture boundary tripwires for issue #706 (stack 1 of #703).
+//
+// These tests freeze the CURRENT transport-boundary debt of internal/server as
+// exact allowlists and fail on any NEW instance. They are structural: they parse
+// the package's own source with go/ast and match declarations/imports/selectors.
+// They deliberately prove only what source structure can prove — they do not
+// assert that any given check is semantically "correct authorization", only that
+// no new symbol of a guarded shape appears outside its recorded allowlist.
+//
+// When a test fails it names the new forbidden symbol/file and the fix: route the
+// capability through the composition root / a narrow port, or (if genuinely
+// unavoidable) add a justified allowlist entry. Allowlists carry an unused-entry
+// guard so they cannot rot once debt is paid down.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// serverFile is one parsed non-test .go file of the internal/server package.
+type serverFile struct {
+	rel  string
+	file *ast.File
+	fset *token.FileSet
+}
+
+// parseServerPackage parses every non-test .go file in the internal/server
+// package directory (the test's working directory). Generated and build-ignored
+// files are skipped.
+func parseServerPackage(t *testing.T) []serverFile {
+	t.Helper()
+	dir, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatalf("resolve package dir: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+	var out []serverFile
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		src := string(raw)
+		if strings.Contains(src, "//go:build ignore") || strings.Contains(src, "// Code generated") {
+			continue
+		}
+		fset := token.NewFileSet()
+		f, err := parser.ParseFile(fset, path, src, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		out = append(out, serverFile{rel: name, file: f, fset: fset})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].rel < out[j].rel })
+	return out
+}
+
+// isSelector reports whether e is the selector pkg.Name matched by the receiver
+// identifier text. Used only for stdlib selectors (http.ResponseWriter,
+// authz.Identity) whose package name is fixed by convention; internal-package
+// selectors are matched via resolved local import names (see localImportName).
+func isSelector(e ast.Expr, pkg, name string) bool {
+	sel, ok := e.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != name {
+		return false
+	}
+	id, ok := sel.X.(*ast.Ident)
+	return ok && id.Name == pkg
+}
+
+// localImportName returns the identifier a file uses for importPath, honoring an
+// explicit alias; "" if the file does not import it. This defeats trivial alias
+// evasion where a package is imported under a different name.
+func localImportName(f *ast.File, importPath string) string {
+	for _, imp := range f.Imports {
+		if strings.Trim(imp.Path.Value, "`\"") != importPath {
+			continue
+		}
+		if imp.Name != nil {
+			return imp.Name.Name
+		}
+		return importPath[strings.LastIndex(importPath, "/")+1:]
+	}
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// Tripwire 1: no new Server wiring setters.
+//
+// Mutable-topology setters on *Server (Set*/Init* methods that are NOT OpenAPI
+// operation handlers, i.e. take no http.ResponseWriter) are composition-time
+// wiring. The target architecture replaces this post-construction mutation with
+// constructor injection, so the set may only shrink. A new one fails here.
+//
+// Scope: *Server is the transport composition root and the unambiguous guarded
+// type. pluginhost.Host has an adjacent service-injection setter surface
+// (service_extensions.go), but that surface is governed by the separate
+// plugin-capability contract phase of #703, not the transport boundary, so it is
+// intentionally out of scope here rather than folded in with weaker signals.
+// ---------------------------------------------------------------------------
+
+var serverWiringSetterAllowlist = map[string]bool{
+	// internal/server/server.go
+	"SetVaultRecipient":       true,
+	"SetVaultService":         true,
+	"SetMCPService":           true,
+	"SetBuiltinTools":         true,
+	"InitCredentialFrontDoor": true,
+	"SetSchedulerService":     true,
+	"SetEventLogStore":        true,
+	"SetArbiter":              true,
+	"SetGroupDispatcher":      true,
+	"SetBaseURL":              true,
+	"SetLoginIdentityStore":   true,
+	"SetUserStore":            true,
+	"SetSessionStore":         true,
+	"SetCredentialStore":      true,
+	"SetOIDCAuth":             true,
+	"SetCredentialsService":   true,
+	"SetShareService":         true,
+	"SetRecallyService":       true,
+	// internal/server/goals.go, workflows.go
+	"SetGoalService":     true,
+	"SetWorkflowService": true,
+}
+
+func hasHTTPResponseWriterParam(ft *ast.FuncType) bool {
+	if ft.Params == nil {
+		return false
+	}
+	for _, p := range ft.Params.List {
+		if isSelector(p.Type, "http", "ResponseWriter") {
+			return true
+		}
+	}
+	return false
+}
+
+func isServerReceiver(fd *ast.FuncDecl) bool {
+	if fd.Recv == nil || len(fd.Recv.List) != 1 {
+		return false
+	}
+	star, ok := fd.Recv.List[0].Type.(*ast.StarExpr)
+	if !ok {
+		return false
+	}
+	id, ok := star.X.(*ast.Ident)
+	return ok && id.Name == "Server"
+}
+
+func TestNoNewServerWiringSetters(t *testing.T) {
+	unused := map[string]bool{}
+	for k := range serverWiringSetterAllowlist {
+		unused[k] = true
+	}
+	for _, sf := range parseServerPackage(t) {
+		for _, decl := range sf.file.Decls {
+			fd, ok := decl.(*ast.FuncDecl)
+			if !ok || !isServerReceiver(fd) {
+				continue
+			}
+			name := fd.Name.Name
+			if !strings.HasPrefix(name, "Set") && !strings.HasPrefix(name, "Init") {
+				continue
+			}
+			if hasHTTPResponseWriterParam(fd.Type) {
+				continue // OpenAPI operation handler, not a wiring setter
+			}
+			if serverWiringSetterAllowlist[name] {
+				delete(unused, name)
+				continue
+			}
+			pos := sf.fset.Position(fd.Pos())
+			t.Errorf("%s:%d: new *Server wiring setter %q; inject it through server.New instead of a post-construction setter, or add a justified allowlist entry", sf.rel, pos.Line, name)
+		}
+	}
+	for k := range unused {
+		t.Errorf("stale wiring-setter allowlist entry %q is no longer present; remove it", k)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tripwire 2: no new broad persistence capabilities in internal/server.
+//
+// Transports must reach persistence through narrow ports, not raw stores. Each
+// file's set of broad-capability tokens (raw sqlc, raw pgxpool, config.Store,
+// memory.SessionManager, raw auth stores, raw blob.Store) is frozen. A new
+// (file, capability) pair fails.
+// ---------------------------------------------------------------------------
+
+const (
+	capSQLC           = "sqlc"                  // import pkg/db/sqlc (raw query layer)
+	capPgxpool        = "pgxpool"               // import pgx/v5/pgxpool (raw pool)
+	capConfigStore    = "config.Store"          // raw config store handle
+	capSessionManager = "memory.SessionManager" // raw memory session manager
+	capAuthStore      = "auth.store"            // raw auth persistence stores
+	capBlobStore      = "blob.Store"            // raw blob store handle
+)
+
+// serverPersistenceAllowlist records, per file, the broad persistence
+// capabilities that file is permitted to reach directly today. server.go is the
+// composition root that injects these into the Server struct; sessions.go and
+// skills_scoped.go type-assert the memory session manager for session APIs.
+var serverPersistenceAllowlist = map[string]map[string]bool{
+	"server.go":          {capSQLC: true, capPgxpool: true, capConfigStore: true, capAuthStore: true},
+	"sessions.go":        {capSQLC: true, capSessionManager: true},
+	"skills_scoped.go":   {capSQLC: true, capSessionManager: true},
+	"agent_tools.go":     {capSQLC: true},
+	"credential_wire.go": {capSQLC: true},
+	"goals.go":           {capSQLC: true},
+	"inbox.go":           {capSQLC: true},
+	"groups.go":          {capSQLC: true},
+	"oauth_wire.go":      {capSQLC: true},
+	"projects.go":        {capSQLC: true},
+	"profile.go":         {capSQLC: true},
+	"shares.go":          {capSQLC: true},
+	"scheduler.go":       {capSQLC: true},
+	"workflows.go":       {capSQLC: true},
+}
+
+var authStoreTypes = map[string]bool{
+	"AuthStore": true, "SessionStore": true, "CredentialStore": true,
+	"UserStore": true, "LoginIdentityStore": true, "ChannelIdentityStore": true,
+	"LinkCodeStore": true,
+}
+
+func fileCapabilities(sf serverFile) map[string]bool {
+	caps := map[string]bool{}
+	for _, imp := range sf.file.Imports {
+		path := strings.Trim(imp.Path.Value, "`\"")
+		switch path {
+		case "github.com/CherryHQ/stella/pkg/db/sqlc":
+			caps[capSQLC] = true
+		case "github.com/jackc/pgx/v5/pgxpool":
+			caps[capPgxpool] = true
+		}
+	}
+	// Resolve local import names so an aliased import (e.g. cfg "…/internal/config")
+	// cannot evade the selector match.
+	configName := localImportName(sf.file, "github.com/CherryHQ/stella/internal/config")
+	memoryName := localImportName(sf.file, "github.com/CherryHQ/stella/internal/memory")
+	blobName := localImportName(sf.file, "github.com/CherryHQ/stella/internal/blob")
+	authName := localImportName(sf.file, "github.com/CherryHQ/stella/internal/auth")
+	ast.Inspect(sf.file, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		id, ok := sel.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		switch {
+		case configName != "" && id.Name == configName && sel.Sel.Name == "Store":
+			caps[capConfigStore] = true
+		case memoryName != "" && id.Name == memoryName && sel.Sel.Name == "SessionManager":
+			caps[capSessionManager] = true
+		case blobName != "" && id.Name == blobName && sel.Sel.Name == "Store":
+			caps[capBlobStore] = true
+		case authName != "" && id.Name == authName && authStoreTypes[sel.Sel.Name]:
+			caps[capAuthStore] = true
+		}
+		return true
+	})
+	return caps
+}
+
+func TestNoNewServerPersistenceCapabilities(t *testing.T) {
+	unused := map[string]map[string]bool{}
+	for f, caps := range serverPersistenceAllowlist {
+		unused[f] = map[string]bool{}
+		for c := range caps {
+			unused[f][c] = true
+		}
+	}
+	for _, sf := range parseServerPackage(t) {
+		for c := range fileCapabilities(sf) {
+			if serverPersistenceAllowlist[sf.rel][c] {
+				delete(unused[sf.rel], c)
+				continue
+			}
+			t.Errorf("%s: new broad persistence capability %q in internal/server; use a narrow port or the composition root, or add a justified allowlist entry", sf.rel, c)
+		}
+	}
+	for f, caps := range unused {
+		for c := range caps {
+			t.Errorf("stale persistence allowlist entry: %s no longer uses %q; remove it", f, c)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tripwire 3: no new internal/server imports of platform plugin implementations.
+//
+// The transport layer must depend on plugin ports (pkg/plugins, pluginhost), not
+// concrete plugins/* implementations. The current channel-registration debt is
+// frozen per (file, plugin import path).
+// ---------------------------------------------------------------------------
+
+const pluginImplPrefix = "github.com/CherryHQ/stella/plugins/"
+
+var serverPluginImportAllowlist = map[string]map[string]bool{
+	"webhook_ingress.go":     {"github.com/CherryHQ/stella/plugins/channels/webhook": true},
+	"weixin_qr.go":           {"github.com/CherryHQ/stella/plugins/channels/weixin": true},
+	"weixin_registration.go": {"github.com/CherryHQ/stella/plugins/channels/weixin": true},
+}
+
+func TestNoServerPlatformPluginImports(t *testing.T) {
+	unused := map[string]map[string]bool{}
+	for f, paths := range serverPluginImportAllowlist {
+		unused[f] = map[string]bool{}
+		for p := range paths {
+			unused[f][p] = true
+		}
+	}
+	for _, sf := range parseServerPackage(t) {
+		for _, imp := range sf.file.Imports {
+			path := strings.Trim(imp.Path.Value, "`\"")
+			if !strings.HasPrefix(path, pluginImplPrefix) {
+				continue
+			}
+			if serverPluginImportAllowlist[sf.rel][path] {
+				delete(unused[sf.rel], path)
+				continue
+			}
+			pos := sf.fset.Position(imp.Pos())
+			t.Errorf("%s:%d: internal/server imports platform plugin %q; depend on the plugin port (pkg/plugins / pluginhost), or add a justified allowlist entry", sf.rel, pos.Line, path)
+		}
+	}
+	for f, paths := range unused {
+		for p := range paths {
+			t.Errorf("stale plugin-import allowlist entry: %s no longer imports %q; remove it", f, p)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tripwire 4: no new scattered resource-authorization identity constructors.
+//
+// The target authorization core centralizes request->authz.Identity mapping. The
+// hand-rolled per-domain constructors (functions whose result type includes
+// authz.Identity) are frozen. This proves only the structural "constructs an
+// authz.Identity" shape, not that any check is semantically complete.
+// ---------------------------------------------------------------------------
+
+var authIdentityConstructorAllowlist = map[string]bool{
+	"emailIdentity": true, // internal/server/email.go
+	"goalAuth":      true, // internal/server/goals.go
+	"shareIdentity": true, // internal/server/shares.go
+	"toolIdentity":  true, // internal/server/tool_identity.go
+}
+
+func resultHasAuthzIdentity(ft *ast.FuncType) bool {
+	if ft.Results == nil {
+		return false
+	}
+	for _, r := range ft.Results.List {
+		if isSelector(r.Type, "authz", "Identity") {
+			return true
+		}
+	}
+	return false
+}
+
+func TestNoNewResourceAuthIdentityConstructors(t *testing.T) {
+	unused := map[string]bool{}
+	for k := range authIdentityConstructorAllowlist {
+		unused[k] = true
+	}
+	for _, sf := range parseServerPackage(t) {
+		for _, decl := range sf.file.Decls {
+			fd, ok := decl.(*ast.FuncDecl)
+			if !ok || !resultHasAuthzIdentity(fd.Type) {
+				continue
+			}
+			name := fd.Name.Name
+			if authIdentityConstructorAllowlist[name] {
+				delete(unused, name)
+				continue
+			}
+			pos := sf.fset.Position(fd.Pos())
+			t.Errorf("%s:%d: new resource-authorization identity constructor %q returning authz.Identity; route authorization through the shared authorization core, or add a justified allowlist entry", sf.rel, pos.Line, name)
+		}
+	}
+	for k := range unused {
+		t.Errorf("stale authz-identity-constructor allowlist entry %q is no longer present; remove it", k)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tripwire 5: no new scattered resource-authorization helpers.
+//
+// The target authorization core centralizes access decisions. The current
+// scattered helpers are gate/ownership functions whose names follow the
+// require*/authorize*/canAccess*/check*Access shapes. This freezes that exact set
+// and fails on a new one (e.g. a `checkGoalAccess`). It complements — does not
+// replace — the identity-constructor guard above, which catches a distinct shape
+// (functions that build an authz.Identity, none of which match these name
+// prefixes).
+//
+// Only UNEXPORTED helpers are considered: generated OpenAPI ServerInterface
+// methods are exported (PascalCase) and so are excluded by construction, which is
+// the explicit evidence for that exclusion. require*/authorize*/canAccess* names
+// are resource/auth gates by convention; the one authentication-only helper
+// (requireAuth) is kept in the allowlist rather than excluded, since freezing it
+// is harmless and a new authn helper still warrants review.
+// ---------------------------------------------------------------------------
+
+// resourceAuthHelperAllowlist is the exact current set of scattered
+// resource-authorization / gate helpers in internal/server. A new helper of the
+// same shape must be added here (with justification) or, preferably, routed
+// through the shared authorization core.
+var resourceAuthHelperAllowlist = map[string]bool{
+	"canAccessAgent":             true, // agent_access.go — agent read via PolicyEngine
+	"requireGroupOwner":          true, // groups.go — group ownership gate
+	"requireAuth":                true, // middleware.go — authentication (not resource authz)
+	"requireAdmin":               true, // middleware.go — admin gate
+	"requireUser":                true, // recally_handlers.go — recally user gate
+	"authorizeSkillManage":       true, // skills_manage.go — skill manage authorization
+	"requireAgentAccess":         true, // skills_scoped.go — agent access gate
+	"requireAgentManage":         true, // skills_scoped.go — agent manage gate
+	"requireSkillScope":          true, // skills_scoped.go — skill scope gate
+	"requireAgentSkillWrite":     true, // skills_scoped.go — agent skill write gate
+	"requireSessionConversation": true, // sessions.go — session ownership gate
+	"checkSessionAccess":         true, // sessions.go — session access check
+	"requireUserTarget":          true, // users.go — target-user admin gate
+}
+
+// isResourceAuthHelperName reports whether an unexported function name has one of
+// the scattered-auth-helper shapes.
+func isResourceAuthHelperName(name string) bool {
+	if name == "" || name[0] < 'a' || name[0] > 'z' {
+		return false // exported (generated OpenAPI methods) or non-identifier
+	}
+	switch {
+	case strings.HasPrefix(name, "require"):
+		return true
+	case strings.HasPrefix(name, "authorize"):
+		return true
+	case strings.HasPrefix(name, "canAccess"):
+		return true
+	case strings.HasPrefix(name, "check") && strings.HasSuffix(name, "Access"):
+		return true
+	}
+	return false
+}
+
+func TestNoNewResourceAuthHelpers(t *testing.T) {
+	unused := map[string]bool{}
+	for k := range resourceAuthHelperAllowlist {
+		unused[k] = true
+	}
+	for _, sf := range parseServerPackage(t) {
+		for _, decl := range sf.file.Decls {
+			fd, ok := decl.(*ast.FuncDecl)
+			if !ok || !isResourceAuthHelperName(fd.Name.Name) {
+				continue
+			}
+			name := fd.Name.Name
+			if resourceAuthHelperAllowlist[name] {
+				delete(unused, name)
+				continue
+			}
+			pos := sf.fset.Position(fd.Pos())
+			t.Errorf("%s:%d: new scattered resource-authorization helper %q; route the decision through the shared authorization core, or add a justified allowlist entry", sf.rel, pos.Line, name)
+		}
+	}
+	for k := range unused {
+		t.Errorf("stale resource-auth-helper allowlist entry %q is no longer present; remove it", k)
+	}
+}

--- a/internal/server/authorization_coverage_test.go
+++ b/internal/server/authorization_coverage_test.go
@@ -1,0 +1,405 @@
+package server
+
+// Authorization-entry coverage gate for issue #706 (stack 1 of #703).
+//
+// TestAuthorizationEntryCoverage mechanically enumerates every generated /api
+// route (via the same recordingMux the credential-scope test uses) and requires
+// each one to be classified by a deep, rule-based classifier into BOTH its
+// current entry gate AND its target authorization shape (Authority actor class,
+// typed action, resource, visibility, owning stack). A newly generated route the
+// classifier does not recognise fails unclassified — the same fail-closed
+// discipline as credential.RequiredScope, but for resource authorization rather
+// than PAT scope.
+//
+// PAT scope != resource authorization. credential.RequiredScope answers "may this
+// token reach the route at all"; this classifier answers "who is the target
+// Authority and what action/resource/visibility does the route govern". The two
+// are cross-referenced (patReachable column) but never conflated.
+//
+// Honesty ceiling: CurrentGate and the target fields are RULE-derived per family
+// (grounded in the requireAdmin/owner-helper/exempt evidence surveyed in
+// foundation-baseline.md §2), not a per-route semantic proof. The executable
+// guarantees are: every live route is classified, every classification field is
+// populated, the route set is non-empty, and a new/renamed route or sub-resource
+// fails until someone classifies it.
+
+import (
+	"net/http"
+	"slices"
+	"strings"
+	"testing"
+
+	apiserver "github.com/CherryHQ/stella/api/server"
+	"github.com/CherryHQ/stella/internal/credential"
+)
+
+// routeClass is the full classification every /api route must carry.
+type routeClass struct {
+	CurrentGate string // current entry gate/check category (as it exists today)
+	Actor       string // target Authority actor class
+	Action      string // typed action
+	Resource    string // target resource
+	Visibility  string // public | private | admin
+	Stack       string // owning migration stack
+}
+
+func (c routeClass) complete() bool {
+	return c.CurrentGate != "" && c.Actor != "" && c.Action != "" &&
+		c.Resource != "" && c.Visibility != "" && c.Stack != ""
+}
+
+// action verbs: a POST whose path contains one of these is an execute/command,
+// not a create.
+var actionVerbs = map[string]bool{
+	"run": true, "activate": true, "cancel": true, "abandon": true,
+	"reattempt": true, "unarchive": true, "verdict": true, "approve": true,
+	"reject": true, "waive": true, "poll": true, "sync": true, "start": true,
+	"instantiate": true, "mark": true, "send": true, "login": true,
+	"logout": true, "register": true, "begin": true, "init": true,
+	"upload": true, "install": true, "upgrade": true, "rotate-secret": true,
+	"link-code": true, "qr": true, "connected": true, "callback": true,
+}
+
+func actionFor(method string, segs []string) string {
+	switch method {
+	case http.MethodGet:
+		return "read"
+	case http.MethodDelete:
+		return "delete"
+	case http.MethodPut, http.MethodPatch:
+		return "write"
+	case http.MethodPost:
+		for _, s := range segs {
+			if actionVerbs[s] {
+				return "execute"
+			}
+		}
+		return "create"
+	default:
+		return ""
+	}
+}
+
+// apiPathSegments returns the path segments after "/api/".
+func apiPathSegments(path string) []string {
+	rest := strings.TrimPrefix(path, "/api/")
+	if rest == path {
+		return nil
+	}
+	return strings.Split(strings.Trim(rest, "/"), "/")
+}
+
+const (
+	stackAuthz     = "authz-core"
+	stackAsset     = "asset-workspace"
+	stackPlugin    = "plugin-capability"
+	stackTransport = "transports"
+)
+
+// classifyAPIRoute is the rule-based classifier. It returns ok=false for any
+// route family / sub-resource it does not explicitly recognise, so a newly
+// generated route fails the coverage test until classified.
+func classifyAPIRoute(method, path string) (routeClass, bool) {
+	segs := apiPathSegments(path)
+	if len(segs) == 0 {
+		return routeClass{}, false
+	}
+	act := actionFor(method, segs)
+	if act == "" {
+		return routeClass{}, false
+	}
+	family := segs[0]
+
+	// user-facing owner-scoped resources with a uniform target shape.
+	ownerResource := func(resource string) (routeClass, bool) {
+		return routeClass{
+			CurrentGate: "owner (inline owner_id / domain auth helper)",
+			Actor:       "UserActor", Action: act, Resource: resource,
+			Visibility: "private", Stack: stackAuthz,
+		}, true
+	}
+	adminResource := func(resource, stack string) (routeClass, bool) {
+		return routeClass{
+			CurrentGate: "admin (requireAdmin)",
+			Actor:       "UserActor(admin)", Action: act, Resource: resource,
+			Visibility: "admin", Stack: stack,
+		}, true
+	}
+	authenticated := func(resource string) (routeClass, bool) {
+		return routeClass{
+			CurrentGate: "authenticated (session/bearer, no per-object check)",
+			Actor:       "UserActor", Action: act, Resource: resource,
+			Visibility: "private", Stack: stackAuthz,
+		}, true
+	}
+
+	switch family {
+	case "agents":
+		return classifyAgents(method, act, segs)
+	case "users":
+		return classifyUsers(act, segs)
+	case "auth":
+		return classifyAuth(act, segs)
+	case "channels":
+		return classifyChannels(act, segs)
+	case "groups":
+		// group message send is a group-ingress turn; other ops are owner/admin.
+		if len(segs) >= 3 && segs[2] == "messages" && method == http.MethodPost {
+			return routeClass{
+				CurrentGate: "group-owner/member (requireGroupOwner + membership)",
+				Actor:       "GroupIngressActor", Action: "execute", Resource: "group_turn",
+				Visibility: "private", Stack: stackAuthz,
+			}, true
+		}
+		return routeClass{
+			CurrentGate: "owner-or-admin (requireGroupOwner / IsAdmin)",
+			Actor:       "UserActor", Action: act, Resource: "group",
+			Visibility: "private", Stack: stackAuthz,
+		}, true
+	case "goals":
+		return ownerResource("goal")
+	case "workflows":
+		return ownerResource("workflow")
+	case "skills":
+		return ownerResource("skill")
+	case "recally":
+		return ownerResource("recally")
+	case "email":
+		return ownerResource("email")
+	case "vault":
+		return ownerResource("vault")
+	case "mcp":
+		return ownerResource("mcp")
+	case "inbox":
+		return ownerResource("inbox")
+	case "shares":
+		if len(segs) >= 2 && segs[1] == "public" {
+			return routeClass{
+				CurrentGate: "public (auth-exempt share token)",
+				Actor:       "Anonymous", Action: act, Resource: "share",
+				Visibility: "public", Stack: stackAuthz,
+			}, true
+		}
+		return ownerResource("share")
+	case "scheduler":
+		// only /api/scheduler/job-templates (read-only catalog).
+		return authenticated("scheduler")
+	case "builtin":
+		return authenticated("builtin")
+	case "clawhub":
+		return authenticated("skill_registry")
+	case "models":
+		return authenticated("model")
+	case "token-scopes":
+		return authenticated("token")
+	case "status":
+		return authenticated("status")
+	case "provider-types", "providers":
+		return adminResource("provider", stackAuthz)
+	case "plugins", "manifest-plugins":
+		return adminResource("plugin", stackPlugin)
+	case "cli-tools":
+		return adminResource("cli", stackAuthz)
+	case "embedding-settings":
+		return adminResource("embedding", stackAuthz)
+	case "admin":
+		return adminResource("oauth_provider_config", stackAuthz)
+	}
+	return routeClass{}, false
+}
+
+func classifyAgents(method, act string, segs []string) (routeClass, bool) {
+	// segs = [agents, {id}, <sub>?, ...]; sub-resource is segs[2] when present.
+	if len(segs) <= 2 {
+		// collection or single agent.
+		if method == http.MethodGet {
+			return routeClass{
+				CurrentGate: "agent-policy (canAccessAgent -> PolicyEngine.Can)",
+				Actor:       "UserActor", Action: act, Resource: "agent",
+				Visibility: "private", Stack: stackAuthz,
+			}, true
+		}
+		return routeClass{
+			CurrentGate: "agent-admin (info.IsAdmin)",
+			Actor:       "UserActor(admin)", Action: act, Resource: "agent",
+			Visibility: "admin", Stack: stackAuthz,
+		}, true
+	}
+	sub := segs[2]
+	agentScoped := func(resource, stack string) (routeClass, bool) {
+		return routeClass{
+			CurrentGate: "agent-scoped owner (requireAgentAccess/checkSessionAccess)",
+			Actor:       "UserActor", Action: act, Resource: resource,
+			Visibility: "private", Stack: stack,
+		}, true
+	}
+	switch sub {
+	case "sessions":
+		// workspace sub-tree is asset/workspace state, not just session metadata.
+		if slices.Contains(segs, "workspace") {
+			return agentScoped("workspace_asset", stackAsset)
+		}
+		return agentScoped("session", stackAuthz)
+	case "projects":
+		return agentScoped("project", stackAsset)
+	case "scheduler":
+		return agentScoped("scheduler", stackAuthz)
+	case "skills":
+		return agentScoped("skill", stackAuthz)
+	case "tools":
+		return agentScoped("agent_tool", stackAuthz)
+	case "users":
+		return routeClass{
+			CurrentGate: "admin (requireAdmin)",
+			Actor:       "UserActor(admin)", Action: act, Resource: "agent_membership",
+			Visibility: "admin", Stack: stackAuthz,
+		}, true
+	}
+	return routeClass{}, false
+}
+
+func classifyUsers(act string, segs []string) (routeClass, bool) {
+	// segs = [users, ...].
+	if len(segs) == 1 {
+		return routeClass{
+			CurrentGate: "admin (requireAdmin)",
+			Actor:       "UserActor(admin)", Action: act, Resource: "user",
+			Visibility: "admin", Stack: stackAuthz,
+		}, true
+	}
+	if segs[1] == "me" {
+		resource := "user_data"
+		if len(segs) >= 3 {
+			switch segs[2] {
+			case "oauth", "oauth-clients", "oauth-client-scopes", "authorized-apps":
+				resource = "oauth"
+			case "tokens":
+				resource = "token"
+			case "memories", "soul", "password", "identities", "link-code":
+				resource = "user_data"
+			}
+		}
+		return routeClass{
+			CurrentGate: "self (subject == authenticated user)",
+			Actor:       "UserActor", Action: act, Resource: resource,
+			Visibility: "private", Stack: stackAuthz,
+		}, true
+	}
+	// /api/users/{id}/... -> admin-managed target user.
+	return routeClass{
+		CurrentGate: "admin (requireAdmin / requireUserTarget)",
+		Actor:       "UserActor(admin)", Action: act, Resource: "user",
+		Visibility: "admin", Stack: stackAuthz,
+	}, true
+}
+
+func classifyAuth(act string, segs []string) (routeClass, bool) {
+	if len(segs) < 2 {
+		return routeClass{}, false
+	}
+	switch segs[1] {
+	case "me":
+		return routeClass{
+			CurrentGate: "self (OIDC session)",
+			Actor:       "UserActor", Action: act, Resource: "user",
+			Visibility: "private", Stack: stackAuthz,
+		}, true
+	case "providers":
+		return routeClass{
+			CurrentGate: "public (login options, auth-exempt)",
+			Actor:       "Anonymous", Action: act, Resource: "auth_provider",
+			Visibility: "public", Stack: stackAuthz,
+		}, true
+	case "sessions":
+		return routeClass{
+			CurrentGate: "self (own OIDC sessions)",
+			Actor:       "UserActor", Action: act, Resource: "auth_session",
+			Visibility: "private", Stack: stackAuthz,
+		}, true
+	case "logout":
+		return routeClass{
+			CurrentGate: "authenticated (session)",
+			Actor:       "UserActor", Action: act, Resource: "auth",
+			Visibility: "private", Stack: stackAuthz,
+		}, true
+	case "local":
+		return routeClass{
+			CurrentGate: "public (auth-exempt login/register)",
+			Actor:       "Anonymous", Action: act, Resource: "auth",
+			Visibility: "public", Stack: stackAuthz,
+		}, true
+	case "oauth", "profile":
+		return routeClass{
+			CurrentGate: "public (auth-exempt OAuth callback)",
+			Actor:       "Anonymous", Action: act, Resource: "oauth",
+			Visibility: "public", Stack: stackAuthz,
+		}, true
+	}
+	return routeClass{}, false
+}
+
+func classifyChannels(act string, segs []string) (routeClass, bool) {
+	// /api/channels/public is an authenticated agent-visibility listing;
+	// registration + admin ops require admin.
+	if len(segs) >= 2 && segs[1] == "public" {
+		return routeClass{
+			CurrentGate: "authenticated (public-channel listing)",
+			Actor:       "UserActor", Action: act, Resource: "channel",
+			Visibility: "private", Stack: stackTransport,
+		}, true
+	}
+	return routeClass{
+		CurrentGate: "admin (requireAdmin)",
+		Actor:       "UserActor(admin)", Action: act, Resource: "channel",
+		Visibility: "admin", Stack: stackTransport,
+	}, true
+}
+
+func TestAuthorizationEntryCoverage(t *testing.T) {
+	rm := &recordingMux{}
+	apiserver.HandlerFromMux(&Server{}, rm)
+
+	count := 0
+	for _, p := range rm.patterns {
+		method, path, ok := strings.Cut(p, " ")
+		if !ok || !strings.HasPrefix(path, "/api/") {
+			continue
+		}
+		count++
+		class, classified := classifyAPIRoute(method, path)
+		if !classified {
+			t.Errorf("route %s %s is unclassified for resource authorization; add a rule to classifyAPIRoute (current gate + target Authority/action/resource/visibility/stack)", method, path)
+			continue
+		}
+		if !class.complete() {
+			t.Errorf("route %s %s classification has an empty field: %+v", method, path, class)
+		}
+		// Cross-reference PAT scope WITHOUT conflating it with authorization: a
+		// route the classifier marks private/admin must be scope-registered too.
+		if _, registered := credential.RequiredScope(method, path); !registered && class.Visibility != "public" {
+			t.Errorf("route %s %s classified %q but credential.RequiredScope does not register it; PAT-reachability and resource authorization must both be defined", method, path, class.Visibility)
+		}
+	}
+	if count == 0 {
+		t.Fatal("no /api routes were enumerated; the classifier is not exercising the router")
+	}
+	t.Logf("classified %d /api routes for resource authorization", count)
+}
+
+// TestAuthorizationClassifierFailsClosed locks the fail-closed property: a newly
+// generated route family or agent sub-resource the classifier does not recognise
+// must return ok=false (so TestAuthorizationEntryCoverage fails until it is
+// classified), rather than silently inheriting a neighbouring rule.
+func TestAuthorizationClassifierFailsClosed(t *testing.T) {
+	unknown := []struct{ method, path string }{
+		{http.MethodGet, "/api/newresource"},
+		{http.MethodPost, "/api/agents/{id}/newsubresource"},
+		{http.MethodGet, "/api/auth/newthing"},
+		{http.MethodDelete, "/api/newresource/{id}"},
+	}
+	for _, u := range unknown {
+		if _, ok := classifyAPIRoute(u.method, u.path); ok {
+			t.Errorf("classifyAPIRoute(%s %s) returned classified=true; unknown routes must fail closed", u.method, u.path)
+		}
+	}
+}

--- a/internal/server/entry_inventory_test.go
+++ b/internal/server/entry_inventory_test.go
@@ -1,0 +1,328 @@
+package server_test
+
+// Non-OpenAPI authorization-entry inventory for issue #706 (stack 1 of #703).
+//
+// The /api surface is enumerable via the router (authorization_coverage_test.go).
+// The remaining entry families are not all exposed through one registry, so this
+// test uses two disciplines:
+//
+//   - ENUMERABLE registries (River durable workers, the builtin-tool list) are
+//     mechanically walked; the live set must equal a frozen inventory, so a newly
+//     registered worker/tool fails until classified.
+//   - NON-ENUMERABLE grant points (the inbound webhook route; the channel
+//     DM/group/dedicated grant decisions, which are plugin-fed and have no single
+//     registry) are frozen as concrete (file, symbol) rows and AST-checked to
+//     still exist; a rename/move fails so the inventory cannot silently rot.
+//
+// Every row carries the same target classification as the /api matrix (actor,
+// action, resource, visibility, stack). Discovery ceiling: channel entries are
+// enumerated by frozen source symbol, NOT by live registry, because concrete
+// channels are provided by out-of-tree plugins and their per-message grant is
+// decided in code, not a table.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"testing"
+)
+
+type entryRow struct {
+	Actor, Action, Resource, Visibility, Stack, Gate string
+}
+
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("resolve module root: %v", err)
+	}
+	return root
+}
+
+func parseGoFile(t *testing.T, path string) (*ast.File, *token.FileSet) {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return f, fset
+}
+
+// funcDeclNames returns the set of declared function/method names in a file
+// (methods keyed by "Recv.Name").
+func funcDeclNames(f *ast.File) map[string]bool {
+	names := map[string]bool{}
+	for _, decl := range f.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		name := fd.Name.Name
+		if fd.Recv != nil && len(fd.Recv.List) == 1 {
+			t := fd.Recv.List[0].Type
+			if star, ok := t.(*ast.StarExpr); ok {
+				t = star.X
+			}
+			if id, ok := t.(*ast.Ident); ok {
+				name = id.Name + "." + name
+			}
+		}
+		names[name] = true
+	}
+	return names
+}
+
+// ---------------------------------------------------------------------------
+// 1. Inbound webhook (POST /webhooks/{id}) — single hand-registered route.
+// ---------------------------------------------------------------------------
+
+var webhookEntry = entryRow{
+	Actor: "SystemActor(webhook-ingress)", Action: "execute", Resource: "webhook_trigger",
+	Visibility: "private(secret-authenticated)", Stack: "transports",
+	Gate: "webhook id/secret + per-instance rate limit (not session/PAT)",
+}
+
+func TestWebhookEntryRegistered(t *testing.T) {
+	path := filepath.Join(moduleRoot(t), "internal/server/routes.go")
+	f, _ := parseGoFile(t, path)
+	found := false
+	ast.Inspect(f, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok || len(call.Args) < 1 {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "HandleFunc" {
+			return true
+		}
+		if lit, ok := call.Args[0].(*ast.BasicLit); ok {
+			if v := lit.Value; len(v) >= 2 && v[1:len(v)-1] == "POST /webhooks/{id}" {
+				found = true
+			}
+		}
+		return true
+	})
+	if !found {
+		t.Errorf("webhook ingress route \"POST /webhooks/{id}\" is no longer registered in routes.go; the non-HTTP entry inventory is stale — re-classify (%+v)", webhookEntry)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 2. River durable workers — ENUMERABLE registry.
+// ---------------------------------------------------------------------------
+
+var riverWorkerFiles = []string{
+	"internal/embedding/river.go",
+	"internal/scheduler/river.go",
+	"internal/goal/river.go",
+}
+
+// riverWorkerInventory freezes every durable worker entry family and its target
+// classification. A new river.AddWorker(...) not listed here fails.
+var riverWorkerInventory = map[string]entryRow{
+	"backfillWorker":    {Actor: "SystemActor(embedding-backfill)", Action: "execute", Resource: "embedding_job", Visibility: "private", Stack: "authz-core", Gate: "River queue insert authority (no per-request auth)"},
+	"schedJobWorker":    {Actor: "AgentActor(scheduled)", Action: "execute", Resource: "scheduler_job", Visibility: "private", Stack: "authz-core", Gate: "reconstruct owner AgentActor from persisted job row"},
+	"goalAttemptWorker": {Actor: "AgentActor(goal)", Action: "execute", Resource: "goal_attempt", Visibility: "private", Stack: "authz-core", Gate: "reconstruct owner/executor from persisted goal"},
+	"goalTickWorker":    {Actor: "SystemActor(goal-tick)", Action: "execute", Resource: "goal_tick", Visibility: "private", Stack: "authz-core", Gate: "River queue insert authority (no per-request auth)"},
+}
+
+func collectRiverWorkers(t *testing.T) map[string]bool {
+	got := map[string]bool{}
+	for _, rel := range riverWorkerFiles {
+		f, _ := parseGoFile(t, filepath.Join(moduleRoot(t), rel))
+		ast.Inspect(f, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "AddWorker" {
+				return true
+			}
+			if pkg, ok := sel.X.(*ast.Ident); !ok || pkg.Name != "river" {
+				return true
+			}
+			if len(call.Args) < 2 {
+				return true
+			}
+			arg := call.Args[1]
+			if u, ok := arg.(*ast.UnaryExpr); ok {
+				arg = u.X
+			}
+			if clit, ok := arg.(*ast.CompositeLit); ok {
+				if id, ok := clit.Type.(*ast.Ident); ok {
+					got[id.Name] = true
+				}
+			}
+			return true
+		})
+	}
+	return got
+}
+
+func TestDurableWorkerInventory(t *testing.T) {
+	got := collectRiverWorkers(t)
+	if len(got) == 0 {
+		t.Fatal("no river.AddWorker registrations found; the worker enumerator is not working")
+	}
+	for name := range got {
+		if _, ok := riverWorkerInventory[name]; !ok {
+			t.Errorf("new durable worker %q registered via river.AddWorker; classify it (target Actor/action/resource/visibility/stack) in riverWorkerInventory", name)
+		}
+	}
+	for name := range riverWorkerInventory {
+		if !got[name] {
+			t.Errorf("stale worker-inventory entry %q no longer registered; remove it", name)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 3. Builtin agent tools — ENUMERABLE list in the composition root.
+//
+// Ceiling: this covers the static builtin-tool list wired in commands.go. Tools
+// injected at runtime via PoolManager.AddBuiltinTool (the plugin-tool path) are a
+// separate entry family governed by the plugin-capability contract and are NOT
+// enumerated here — documented, not hidden.
+// ---------------------------------------------------------------------------
+
+// builtinToolInventory freezes every agent builtin-tool entry family (keyed by
+// its constructor descriptor: "pkg.Func" for a call, or the local ident for a
+// pre-built tool). A new tool added to the list fails until classified.
+var builtinToolInventory = map[string]entryRow{
+	"memory.BuildTool":    {Actor: "AgentActor", Action: "write", Resource: "memory", Visibility: "private", Stack: "authz-core", Gate: "runtime authz.Identity (session-scoped writes)"},
+	"notifyTool":          {Actor: "AgentActor", Action: "execute", Resource: "notify", Visibility: "private", Stack: "authz-core", Gate: "runtime authz.Identity"},
+	"goal.NewTool":        {Actor: "AgentActor", Action: "execute", Resource: "goal", Visibility: "private", Stack: "authz-core", Gate: "runtime authz.Identity"},
+	"scheduler.NewTool":   {Actor: "AgentActor", Action: "execute", Resource: "scheduler", Visibility: "private", Stack: "authz-core", Gate: "runtime authz.Identity"},
+	"workflowpkg.NewTool": {Actor: "AgentActor", Action: "execute", Resource: "workflow", Visibility: "private", Stack: "authz-core", Gate: "runtime authz.Identity"},
+	"connections.NewTool": {Actor: "AgentActor", Action: "execute", Resource: "connections", Visibility: "private", Stack: "authz-core", Gate: "oauthToolAvailable gate"},
+	"email.NewTool":       {Actor: "AgentActor", Action: "execute", Resource: "email", Visibility: "private", Stack: "authz-core", Gate: "emailToolAvailable gate"},
+	"sharepkg.NewTool":    {Actor: "AgentActor", Action: "execute", Resource: "share", Visibility: "private", Stack: "authz-core", Gate: "runtime authz.Identity"},
+	"recally.NewTool":     {Actor: "AgentActor", Action: "execute", Resource: "recally", Visibility: "private", Stack: "authz-core", Gate: "runtime authz.Identity"},
+	"vault.NewTool":       {Actor: "AgentActor", Action: "execute", Resource: "vault", Visibility: "private", Stack: "authz-core", Gate: "runtime authz.Identity (vault capability resolver)"},
+}
+
+// toolValueDescriptor returns the frozen-inventory key for a BuiltinTool "Tool:"
+// value: "pkg.Func" for a constructor call, or the ident name for a prebuilt var.
+func toolValueDescriptor(v ast.Expr) string {
+	if call, ok := v.(*ast.CallExpr); ok {
+		v = call.Fun
+	}
+	switch e := v.(type) {
+	case *ast.SelectorExpr:
+		if id, ok := e.X.(*ast.Ident); ok {
+			return id.Name + "." + e.Sel.Name
+		}
+	case *ast.Ident:
+		return e.Name
+	}
+	return ""
+}
+
+func toolDescriptorsFromLit(clit *ast.CompositeLit, out map[string]bool) {
+	for _, elt := range clit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		if key, ok := kv.Key.(*ast.Ident); !ok || key.Name != "Tool" {
+			continue
+		}
+		if d := toolValueDescriptor(kv.Value); d != "" {
+			out[d] = true
+		}
+	}
+}
+
+func isBuiltinToolType(e ast.Expr) bool {
+	sel, ok := e.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	id, ok := sel.X.(*ast.Ident)
+	return ok && id.Name == "agent" && sel.Sel.Name == "BuiltinTool"
+}
+
+func TestBuiltinToolInventory(t *testing.T) {
+	path := filepath.Join(moduleRoot(t), "cmd/stellad/commands.go")
+	f, _ := parseGoFile(t, path)
+	got := map[string]bool{}
+	ast.Inspect(f, func(n ast.Node) bool {
+		clit, ok := n.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		switch typ := clit.Type.(type) {
+		case *ast.SelectorExpr: // agent.BuiltinTool{Tool: ...}
+			if isBuiltinToolType(typ) {
+				toolDescriptorsFromLit(clit, got)
+			}
+		case *ast.ArrayType: // []agent.BuiltinTool{ {Tool: ...}, ... }
+			if isBuiltinToolType(typ.Elt) {
+				for _, elt := range clit.Elts {
+					if inner, ok := elt.(*ast.CompositeLit); ok {
+						toolDescriptorsFromLit(inner, got)
+					}
+				}
+			}
+		}
+		return true
+	})
+	if len(got) == 0 {
+		t.Fatal("no agent.BuiltinTool literals found; the builtin-tool enumerator is not working")
+	}
+	for d := range got {
+		if _, ok := builtinToolInventory[d]; !ok {
+			t.Errorf("new builtin agent tool %q registered in commands.go; classify it (target Actor/action/resource/visibility/stack) in builtinToolInventory", d)
+		}
+	}
+	for d := range builtinToolInventory {
+		if !got[d] {
+			t.Errorf("stale builtin-tool inventory entry %q no longer registered; remove it", d)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 4. Channel DM/group/dedicated grant — frozen source symbols (no live registry).
+// ---------------------------------------------------------------------------
+
+type channelSymbol struct {
+	file, symbol string
+	class        entryRow
+}
+
+var channelGrantInventory = []channelSymbol{
+	{"internal/channel/coordinator.go", "Coordinator.handleResolvedIncoming", entryRow{
+		Actor: "UserActor(channel-DM)/AgentActor", Action: "execute", Resource: "channel_dm_turn",
+		Visibility: "private", Stack: "authz-core", Gate: "resolved chat identity + channel binding",
+	}},
+	{"internal/channel/agent_switch.go", "filterDedicatedAgents", entryRow{
+		Actor: "UserActor", Action: "execute", Resource: "channel_dedicated_grant",
+		Visibility: "private", Stack: "authz-core", Gate: "dedicated-channel/agent binding enforcement",
+	}},
+	{"internal/channel/agent_switch.go", "agentDedicatedToOtherChannel", entryRow{
+		Actor: "UserActor", Action: "execute", Resource: "channel_dedicated_grant",
+		Visibility: "private", Stack: "authz-core", Gate: "dedicated-channel/agent binding enforcement",
+	}},
+	{"internal/channel/group_dispatcher.go", "GroupDispatcher.Run", entryRow{
+		Actor: "GroupIngressActor", Action: "execute", Resource: "group_turn",
+		Visibility: "private", Stack: "authz-core", Gate: "durable group outbox lease + membership",
+	}},
+}
+
+func TestChannelGrantInventory(t *testing.T) {
+	byFile := map[string]map[string]bool{}
+	for _, sym := range channelGrantInventory {
+		if _, ok := byFile[sym.file]; !ok {
+			f, _ := parseGoFile(t, filepath.Join(moduleRoot(t), sym.file))
+			byFile[sym.file] = funcDeclNames(f)
+		}
+		if !byFile[sym.file][sym.symbol] {
+			t.Errorf("channel grant symbol %s in %s no longer exists; the frozen channel-entry inventory is stale — re-locate and re-classify (%+v)", sym.symbol, sym.file, sym.class)
+		}
+	}
+}

--- a/internal/server/groups.go
+++ b/internal/server/groups.go
@@ -12,9 +12,6 @@ import (
 
 	apiserver "github.com/CherryHQ/stella/api/server"
 	apitypes "github.com/CherryHQ/stella/api/types"
-	"github.com/CherryHQ/stella/internal/agent"
-	"github.com/CherryHQ/stella/internal/agent/session"
-	"github.com/CherryHQ/stella/internal/authz"
 	"github.com/CherryHQ/stella/internal/channel"
 	"github.com/CherryHQ/stella/internal/eventlog"
 	pkgchannel "github.com/CherryHQ/stella/pkg/channel"
@@ -559,32 +556,11 @@ func (s *Server) handleGroupCommand(ctx context.Context, groupID, content string
 	case "/config":
 		return "⚠️ /config is not available in group chats. Please use it in a direct message.", true
 	case "/compact":
-		var results []string
-		for _, m := range members {
-			svc := s.poolManager.GetService(m.AgentID)
-			if svc == nil {
-				continue
-			}
-			agentCtx := authz.WithAgentID(ctx, m.AgentID)
-			sessionKey := agent.BuildGroupSessionKey(m.AgentID, groupID)
-			channelStr := "group:" + groupID
-			info, err := svc.ResolveChannelSession(agentCtx, sessionKey, groupID, m.AgentID, session.Channel(channelStr))
-			if err != nil {
-				results = append(results, fmt.Sprintf("%s: failed to resolve session: %v", m.AgentID, err))
-				continue
-			}
-			info.GroupID = groupID
-			summary, err := svc.CompactSession(agentCtx, info)
-			if err != nil {
-				results = append(results, fmt.Sprintf("%s: compaction failed: %v", m.AgentID, err))
-				continue
-			}
-			results = append(results, fmt.Sprintf("%s: %s", m.AgentID, summary))
-		}
-		if len(results) == 0 {
-			return "No agents to compact.", true
-		}
-		return strings.Join(results, "\n"), true
+		// Group history is assembled from the group event log, not per-agent LCM
+		// conversations, so compaction does not apply here (see
+		// agent.ErrGroupCompactionUnsupported). Report it plainly instead of
+		// running a private-style compaction over an event-log conversation.
+		return pkgchannel.GroupCompactUnsupportedMessage, true
 	default:
 		return "", false
 	}

--- a/internal/server/sessions.go
+++ b/internal/server/sessions.go
@@ -84,7 +84,7 @@ func (s *Server) CreateSession(w http.ResponseWriter, r *http.Request, agentID s
 		return
 	}
 
-	writeData(w, http.StatusCreated, toSessionResponse(info))
+	writeData(w, http.StatusCreated, sessionResponseFromInfo(info))
 }
 
 func (s *Server) SendSessionMessage(w http.ResponseWriter, r *http.Request, agentID string, sessionID string) {
@@ -514,6 +514,23 @@ type sessionDetailResponse struct {
 }
 
 func toSessionResponse(info memory.SessionInfo) sessionResponse {
+	return sessionResponse{
+		ID:         info.ID,
+		Channel:    info.Channel,
+		Kind:       info.Kind,
+		ProjectID:  info.ProjectID,
+		Title:      info.Title,
+		AgentID:    info.AgentID,
+		UserID:     info.UserID,
+		CreatedAt:  info.CreatedAt.UTC(),
+		LastActive: info.LastActive.UTC(),
+		Archived:   info.Archived,
+	}
+}
+
+// sessionResponseFromInfo renders a session-domain Info directly, without
+// round-tripping through the memory persistence record just to build a DTO.
+func sessionResponseFromInfo(info session.Info) sessionResponse {
 	return sessionResponse{
 		ID:         info.ID,
 		Channel:    info.Channel,
@@ -1975,7 +1992,11 @@ func handleSessionCommand(ctx context.Context, svc *agent.Service, si memory.Ses
 	}
 	switch cmd {
 	case "/compact":
-		summary, err := svc.CompactSession(ctx, si)
+		info, err := session.InfoFromRecord(si)
+		if err != nil {
+			return fmt.Sprintf("Compaction failed: %v", err), true
+		}
+		summary, err := svc.CompactSession(ctx, info)
 		if err != nil {
 			return fmt.Sprintf("Compaction failed: %v", err), true
 		}

--- a/internal/server/webhook_ingress.go
+++ b/internal/server/webhook_ingress.go
@@ -148,7 +148,7 @@ func (s *Server) handleWebhookIngress(w http.ResponseWriter, r *http.Request) {
 	var info session.Info
 	if cfg.Persistent() {
 		key := agent.BuildUserSessionKey(ch.AgentID, principal.UserID, "webhook:"+id)
-		info, err = svc.ResolveChannelSession(ctx, key, principal.UserID, ch.AgentID, session.ChannelWebhook)
+		info, err = svc.ResolvePrivateChannelSession(ctx, key, principal.UserID, ch.AgentID, session.ChannelWebhook)
 	} else {
 		info, err = svc.NewSession(ctx, principal.UserID, ch.AgentID, "", session.KindChat, session.ChannelWebhook)
 	}

--- a/pkg/channel/util.go
+++ b/pkg/channel/util.go
@@ -37,6 +37,12 @@ Other commands
 If a short phrase is unclear, Stella treats it as a normal chat message.
 Just send a message to get started.`
 
+// GroupCompactUnsupportedMessage is the shared reply when a user asks to compact
+// a group chat. Group memory is assembled from the shared event log rather than a
+// per-agent LCM conversation, so manual compaction does not apply. Both the web
+// group endpoint and the shared channel command handler use this text.
+const GroupCompactUnsupportedMessage = "⚠️ Group memory is managed automatically from the shared event log, so manual compaction is not available in group chats."
+
 // SplitMessage splits text into chunks that fit within maxLen.
 // It tries to split at newline boundaries and avoids cutting multi-byte
 // UTF-8 characters.

--- a/pkg/db/sqlc/ctx_conversation.sql.go
+++ b/pkg/db/sqlc/ctx_conversation.sql.go
@@ -13,9 +13,9 @@ import (
 )
 
 const createConversation = `-- name: CreateConversation :one
-INSERT INTO ctx_conversation (id, session_id, title, channel, kind, project_id, archived, last_active, agent_id, user_id)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-RETURNING id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at
+INSERT INTO ctx_conversation (id, session_id, title, channel, kind, project_id, archived, last_active, agent_id, user_id, group_id)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+RETURNING id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at, group_id
 `
 
 type CreateConversationParams struct {
@@ -29,6 +29,7 @@ type CreateConversationParams struct {
 	LastActive time.Time   `json:"last_active"`
 	AgentID    pgtype.Text `json:"agent_id"`
 	UserID     pgtype.Text `json:"user_id"`
+	GroupID    pgtype.Text `json:"group_id"`
 }
 
 func (q *Queries) CreateConversation(ctx context.Context, arg CreateConversationParams) (CtxConversation, error) {
@@ -43,6 +44,7 @@ func (q *Queries) CreateConversation(ctx context.Context, arg CreateConversation
 		arg.LastActive,
 		arg.AgentID,
 		arg.UserID,
+		arg.GroupID,
 	)
 	var i CtxConversation
 	err := row.Scan(
@@ -59,12 +61,13 @@ func (q *Queries) CreateConversation(ctx context.Context, arg CreateConversation
 		&i.UserID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.GroupID,
 	)
 	return i, err
 }
 
 const getConversation = `-- name: GetConversation :one
-SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at FROM ctx_conversation
+SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at, group_id FROM ctx_conversation
 WHERE id = $1
   AND user_id = $2
   AND agent_id IS NOT DISTINCT FROM $3
@@ -93,6 +96,7 @@ func (q *Queries) GetConversation(ctx context.Context, arg GetConversationParams
 		&i.UserID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.GroupID,
 	)
 	return i, err
 }
@@ -116,7 +120,7 @@ func (q *Queries) GetConversationAgentBySessionID(ctx context.Context, arg GetCo
 }
 
 const getConversationBySessionID = `-- name: GetConversationBySessionID :one
-SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at FROM ctx_conversation
+SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at, group_id FROM ctx_conversation
 WHERE session_id = $1
   AND user_id = $2
   AND agent_id IS NOT DISTINCT FROM $3
@@ -145,12 +149,13 @@ func (q *Queries) GetConversationBySessionID(ctx context.Context, arg GetConvers
 		&i.UserID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.GroupID,
 	)
 	return i, err
 }
 
 const getMainConversationByProject = `-- name: GetMainConversationByProject :one
-SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at FROM ctx_conversation
+SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at, group_id FROM ctx_conversation
 WHERE project_id = $1
   AND user_id = $2
   AND agent_id IS NOT DISTINCT FROM $3
@@ -180,6 +185,7 @@ func (q *Queries) GetMainConversationByProject(ctx context.Context, arg GetMainC
 		&i.UserID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.GroupID,
 	)
 	return i, err
 }
@@ -219,7 +225,7 @@ func (q *Queries) ListAgentConversationLastActive(ctx context.Context, userID pg
 }
 
 const listConversations = `-- name: ListConversations :many
-SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at FROM ctx_conversation
+SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at, group_id FROM ctx_conversation
 WHERE user_id = $1
   AND ($2::text IS NULL OR agent_id = $2)
   AND archived = false
@@ -254,6 +260,7 @@ func (q *Queries) ListConversations(ctx context.Context, arg ListConversationsPa
 			&i.UserID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.GroupID,
 		); err != nil {
 			return nil, err
 		}
@@ -266,7 +273,7 @@ func (q *Queries) ListConversations(ctx context.Context, arg ListConversationsPa
 }
 
 const listConversationsAll = `-- name: ListConversationsAll :many
-SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at FROM ctx_conversation
+SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at, group_id FROM ctx_conversation
 WHERE user_id = $1
   AND ($2::text IS NULL OR agent_id = $2)
 ORDER BY last_active DESC
@@ -300,6 +307,7 @@ func (q *Queries) ListConversationsAll(ctx context.Context, arg ListConversation
 			&i.UserID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.GroupID,
 		); err != nil {
 			return nil, err
 		}
@@ -312,7 +320,7 @@ func (q *Queries) ListConversationsAll(ctx context.Context, arg ListConversation
 }
 
 const listConversationsByKind = `-- name: ListConversationsByKind :many
-SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at FROM ctx_conversation WHERE agent_id = $1 AND user_id = $2 AND kind = $3 AND archived = false ORDER BY last_active DESC
+SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at, group_id FROM ctx_conversation WHERE agent_id = $1 AND user_id = $2 AND kind = $3 AND archived = false ORDER BY last_active DESC
 `
 
 type ListConversationsByKindParams struct {
@@ -344,6 +352,7 @@ func (q *Queries) ListConversationsByKind(ctx context.Context, arg ListConversat
 			&i.UserID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.GroupID,
 		); err != nil {
 			return nil, err
 		}
@@ -356,7 +365,7 @@ func (q *Queries) ListConversationsByKind(ctx context.Context, arg ListConversat
 }
 
 const listConversationsFiltered = `-- name: ListConversationsFiltered :many
-SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at FROM ctx_conversation
+SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at, group_id FROM ctx_conversation
 WHERE user_id = $1
   AND agent_id IS NOT DISTINCT FROM $2
   AND ($3 != 0 OR archived = false)
@@ -413,6 +422,7 @@ func (q *Queries) ListConversationsFiltered(ctx context.Context, arg ListConvers
 			&i.UserID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.GroupID,
 		); err != nil {
 			return nil, err
 		}
@@ -425,12 +435,15 @@ func (q *Queries) ListConversationsFiltered(ctx context.Context, arg ListConvers
 }
 
 const listConversationsForReviewByAgent = `-- name: ListConversationsForReviewByAgent :many
-SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at FROM ctx_conversation
+SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at, group_id FROM ctx_conversation
 WHERE agent_id = $1
   AND archived = false
+  AND user_id IS NOT NULL AND user_id <> ''
 ORDER BY last_active DESC
 `
 
+// Ownerless legacy rows (NULL/empty user_id) are excluded: review is user-scoped
+// and such rows were never review candidates.
 func (q *Queries) ListConversationsForReviewByAgent(ctx context.Context, agentID pgtype.Text) ([]CtxConversation, error) {
 	rows, err := q.db.Query(ctx, listConversationsForReviewByAgent, agentID)
 	if err != nil {
@@ -454,6 +467,7 @@ func (q *Queries) ListConversationsForReviewByAgent(ctx context.Context, agentID
 			&i.UserID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.GroupID,
 		); err != nil {
 			return nil, err
 		}
@@ -466,9 +480,10 @@ func (q *Queries) ListConversationsForReviewByAgent(ctx context.Context, agentID
 }
 
 const listConversationsForReviewFiltered = `-- name: ListConversationsForReviewFiltered :many
-SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at FROM ctx_conversation
+SELECT id, session_id, title, channel, kind, project_id, archived, last_active, bootstrapped_at, agent_id, user_id, created_at, updated_at, group_id FROM ctx_conversation
 WHERE agent_id = $1
   AND archived = false
+  AND user_id IS NOT NULL AND user_id <> ''
   AND ($2::text IS NULL OR kind = $2)
   AND ($3 = 0 OR project_id IS NULL)
   AND ($4::text IS NULL OR project_id = $4)
@@ -485,6 +500,8 @@ type ListConversationsForReviewFilteredParams struct {
 	Limit           interface{} `json:"limit"`
 }
 
+// Ownerless legacy rows (NULL/empty user_id) are excluded: review is user-scoped
+// and such rows were never review candidates.
 func (q *Queries) ListConversationsForReviewFiltered(ctx context.Context, arg ListConversationsForReviewFilteredParams) ([]CtxConversation, error) {
 	rows, err := q.db.Query(ctx, listConversationsForReviewFiltered,
 		arg.AgentID,
@@ -515,6 +532,7 @@ func (q *Queries) ListConversationsForReviewFiltered(ctx context.Context, arg Li
 			&i.UserID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.GroupID,
 		); err != nil {
 			return nil, err
 		}
@@ -593,11 +611,17 @@ SET
     WHEN $4::text IS NOT NULL AND (project_id IS NULL OR project_id != $4) THEN $4
     ELSE project_id
   END,
+  -- Make a legacy canonical group row durable: adopt the supplied group_id only
+  -- when the stored value is NULL. Never overwrite or clear an existing group_id.
+  group_id = CASE
+    WHEN group_id IS NULL AND $5::uuid IS NOT NULL THEN $5
+    ELSE group_id
+  END,
   last_active = now(),
   updated_at = now()
-WHERE session_id = $5
-  AND user_id = $6
-  AND agent_id IS NOT DISTINCT FROM $7
+WHERE session_id = $6
+  AND user_id = $7
+  AND agent_id IS NOT DISTINCT FROM $8
 `
 
 type UpdateConversationInfoBySessionIDParams struct {
@@ -605,6 +629,7 @@ type UpdateConversationInfoBySessionIDParams struct {
 	Archived  bool        `json:"archived"`
 	Kind      pgtype.Text `json:"kind"`
 	ProjectID pgtype.Text `json:"project_id"`
+	GroupID   pgtype.Text `json:"group_id"`
 	SessionID string      `json:"session_id"`
 	UserID    pgtype.Text `json:"user_id"`
 	AgentID   pgtype.Text `json:"agent_id"`
@@ -616,6 +641,7 @@ func (q *Queries) UpdateConversationInfoBySessionID(ctx context.Context, arg Upd
 		arg.Archived,
 		arg.Kind,
 		arg.ProjectID,
+		arg.GroupID,
 		arg.SessionID,
 		arg.UserID,
 		arg.AgentID,

--- a/pkg/db/sqlc/models.go
+++ b/pkg/db/sqlc/models.go
@@ -354,6 +354,7 @@ type CtxConversation struct {
 	UserID         pgtype.Text        `json:"user_id"`
 	CreatedAt      time.Time          `json:"created_at"`
 	UpdatedAt      time.Time          `json:"updated_at"`
+	GroupID        pgtype.Text        `json:"group_id"`
 }
 
 type CtxGroupDispatch struct {

--- a/web/content/docs/development/agent-architecture.md
+++ b/web/content/docs/development/agent-architecture.md
@@ -44,7 +44,6 @@ Current important methods:
 | Method                                                        | Purpose                                                           | ID trust model                                                          |
 | ------------------------------------------------------------- | ----------------------------------------------------------------- | ----------------------------------------------------------------------- |
 | `Chat`                                                        | Foreground chat for an existing or newly generated session        | caller-supplied `SessionID` is resume-only                              |
-| `ChatForChannel`                                              | Non-private channel/group chat                                    | exact-create allowed because Stella derives `SessionKey`                |
 | `ChatForScheduler`                                            | Scheduler-initiated run                                           | exact-create allowed because scheduler derives `SessionID`              |
 | `ResolvePrivateChannelSession` / `ResolveGroupChannelSession` | Resolve a private or group channel session without running a turn | trusted channel key, requires `KindChat`; group id owns a group session |
 | `NewSession`                                                  | HTTP/Web UI create session                                        | generated ID only                                                       |
@@ -147,13 +146,13 @@ scope, err := svc.Sessions.MemoryScope(validatedInfo)
 
 Session kind describes why the session exists. Channel describes where it originated.
 
-| Kind        | Owner                          | Visible to users?  | Creation path                          |
-| ----------- | ------------------------------ | ------------------ | -------------------------------------- |
-| `main`      | private user chat              | yes                | `ResolveMainSession`                   |
-| `chat`      | normal foreground/channel chat | yes                | `Chat`, `ChatForChannel`, `NewSession` |
-| `delegate`  | child agent work               | usually hidden     | `Delegate`                             |
-| `task`      | async task worker run          | hidden by default  | `MintTaskSession`                      |
-| `scheduler` | scheduled job run              | hidden or filtered | `ChatForScheduler`                     |
+| Kind        | Owner                          | Visible to users?  | Creation path                           |
+| ----------- | ------------------------------ | ------------------ | --------------------------------------- |
+| `main`      | private user chat              | yes                | `ResolveMainSession`                    |
+| `chat`      | normal foreground/channel chat | yes                | channel resolvers, `Chat`, `NewSession` |
+| `delegate`  | child agent work               | usually hidden     | `Delegate`                              |
+| `task`      | async task worker run          | hidden by default  | `MintTaskSession`                       |
+| `scheduler` | scheduled job run              | hidden or filtered | `ChatForScheduler`                      |
 
 Typed resume must validate kind. A scheduler run must not resume a delegate session even if the ID matches. A channel session must require `KindChat` even though channel keys are trusted.
 
@@ -257,9 +256,10 @@ Private user channels converge on the main session.
 ### Group or shared channel message
 
 ```text
-channel derives SessionKey
-    -> Service.ChatForChannel(SessionKey, KindChat, Channel)
+channel derives SessionKey and resolves the canonical GroupID
+    -> Service.ResolveGroupChannelSession(SessionKey, GroupID, AgentID, Channel)
     -> Registry exact-creates only because the key is Stella-derived
+    -> Service.Chat(validated group session)
     -> Runtime.Chat
 ```
 

--- a/web/content/docs/development/agent-architecture.md
+++ b/web/content/docs/development/agent-architecture.md
@@ -41,16 +41,16 @@ The old `Pool` shape mixed these responsibilities. New code should not add behav
 
 Current important methods:
 
-| Method                  | Purpose                                                    | ID trust model                                             |
-| ----------------------- | ---------------------------------------------------------- | ---------------------------------------------------------- |
-| `Chat`                  | Foreground chat for an existing or newly generated session | caller-supplied `SessionID` is resume-only                 |
-| `ChatForChannel`        | Non-private channel/group chat                             | exact-create allowed because Stella derives `SessionKey`   |
-| `ChatForScheduler`      | Scheduler-initiated run                                    | exact-create allowed because scheduler derives `SessionID` |
-| `ResolveChannelSession` | Resolve channel session without running a turn             | trusted channel key, requires `KindChat`                   |
-| `NewSession`            | HTTP/Web UI create session                                 | generated ID only                                          |
-| `MintTaskSession`       | Task system creates a worker session                       | generated ID under resolved executor agent                 |
-| `Delegate`              | Run/resume delegate child session                          | caller/model supplied `SessionID` is resume-only           |
-| `ResolveMainSession`    | Resolve or create private main session                     | generated or promoted main session                         |
+| Method                                                        | Purpose                                                           | ID trust model                                                          |
+| ------------------------------------------------------------- | ----------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `Chat`                                                        | Foreground chat for an existing or newly generated session        | caller-supplied `SessionID` is resume-only                              |
+| `ChatForChannel`                                              | Non-private channel/group chat                                    | exact-create allowed because Stella derives `SessionKey`                |
+| `ChatForScheduler`                                            | Scheduler-initiated run                                           | exact-create allowed because scheduler derives `SessionID`              |
+| `ResolvePrivateChannelSession` / `ResolveGroupChannelSession` | Resolve a private or group channel session without running a turn | trusted channel key, requires `KindChat`; group id owns a group session |
+| `NewSession`                                                  | HTTP/Web UI create session                                        | generated ID only                                                       |
+| `MintTaskSession`                                             | Task system creates a worker session                              | generated ID under resolved executor agent                              |
+| `Delegate`                                                    | Run/resume delegate child session                                 | caller/model supplied `SessionID` is resume-only                        |
+| `ResolveMainSession`                                          | Resolve or create private main session                            | generated or promoted main session                                      |
 
 ### `session.Registry`
 
@@ -136,11 +136,12 @@ Memory owns:
 Hard rule:
 
 ```go
-// Production code should not hand-build memory.Session.
-scope := svc.Sessions.MemoryScope(validatedInfo)
+// Production code derives memory scope only from a validated session.Info.
+// MemoryScope validates the session invariant and fails closed on a bad Info.
+scope, err := svc.Sessions.MemoryScope(validatedInfo)
 ```
 
-Low-level memory tests are the exception. Production code should obtain `memory.Session` from a validated `session.Info` so ownership and kind policy cannot be bypassed.
+`session.Info` is a distinct, validated session-domain type — not an alias of `memory.SessionInfo`. All production code, including `runtime.Runtime`, obtains `memory.Session` only through `MemoryScope`; there is no runtime direct-construction exception. A group session carries a durable, validated `GroupID` (persisted on `ctx_conversation.group_id`, with `UserID == GroupID`). For a private session, read, write, and compaction resolve the same partition. A group session shares one durable canonical scope for read and write; group compaction is unsupported — `CompactSession` rejects it with `ErrGroupCompactionUnsupported` because group history is assembled from the group event log, not the LCM conversation. Low-level memory tests may still build a `memory.Session` directly.
 
 ## Session kinds and channels
 
@@ -370,8 +371,8 @@ ID: req.SessionID,
 ```
 
 ```go
-// Runtime called with session info that did not come from Registry.
-rt.Chat(ctx, memory.SessionInfo{ID: id}, msg)
+// Runtime called with a session.Info that did not come from Registry.
+rt.Chat(ctx, session.Info{ID: id}, msg)
 ```
 
 ```go

--- a/web/content/docs/development/agent-architecture.zh.md
+++ b/web/content/docs/development/agent-architecture.zh.md
@@ -44,7 +44,6 @@ internal/agent.Service        业务意图 seam
 | Method                                                        | 用途                                                      | ID trust model                                                    |
 | ------------------------------------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------- |
 | `Chat`                                                        | 前台 chat，使用已有 session 或生成新 session              | caller-supplied `SessionID` 是 resume-only                        |
-| `ChatForChannel`                                              | 非私有 channel/group chat                                 | 允许 exact-create，因为 `SessionKey` 由 Stella 派生               |
 | `ChatForScheduler`                                            | scheduler 发起的 run                                      | 允许 exact-create，因为 `SessionID` 由 scheduler 派生             |
 | `ResolvePrivateChannelSession` / `ResolveGroupChannelSession` | 只解析 private 或 group channel session，不执行 chat turn | trusted channel key，要求 `KindChat`；group id 拥有 group session |
 | `NewSession`                                                  | HTTP/Web UI 创建 session                                  | 只能生成 ID                                                       |
@@ -150,7 +149,7 @@ Session kind 描述 session 为什么存在。Channel 描述 session 从哪里�
 | Kind        | Owner                 | 用户可见？ | 创建路径                               |
 | ----------- | --------------------- | ---------- | -------------------------------------- |
 | `main`      | private user chat     | 是         | `ResolveMainSession`                   |
-| `chat`      | 普通前台/channel chat | 是         | `Chat`、`ChatForChannel`、`NewSession` |
+| `chat`      | 普通前台/channel chat | 是         | channel resolver、`Chat`、`NewSession` |
 | `delegate`  | child agent work      | 通常隐藏   | `Delegate`                             |
 | `task`      | async task worker run | 默认隐藏   | `MintTaskSession`                      |
 | `scheduler` | scheduled job run     | 隐藏或过滤 | `ChatForScheduler`                     |
@@ -257,9 +256,10 @@ Private user channels 收敛到 main session。
 ### Group 或 shared channel message
 
 ```text
-channel derives SessionKey
-    -> Service.ChatForChannel(SessionKey, KindChat, Channel)
+channel 派生 SessionKey 并解析 canonical GroupID
+    -> Service.ResolveGroupChannelSession(SessionKey, GroupID, AgentID, Channel)
     -> Registry exact-create，因为 key 由 Stella 派生
+    -> Service.Chat(validated group session)
     -> Runtime.Chat
 ```
 

--- a/web/content/docs/development/agent-architecture.zh.md
+++ b/web/content/docs/development/agent-architecture.zh.md
@@ -41,16 +41,16 @@ internal/agent.Service        业务意图 seam
 
 当前重要方法：
 
-| Method                  | 用途                                         | ID trust model                                        |
-| ----------------------- | -------------------------------------------- | ----------------------------------------------------- |
-| `Chat`                  | 前台 chat，使用已有 session 或生成新 session | caller-supplied `SessionID` 是 resume-only            |
-| `ChatForChannel`        | 非私有 channel/group chat                    | 允许 exact-create，因为 `SessionKey` 由 Stella 派生   |
-| `ChatForScheduler`      | scheduler 发起的 run                         | 允许 exact-create，因为 `SessionID` 由 scheduler 派生 |
-| `ResolveChannelSession` | 只解析 channel session，不执行 chat turn     | trusted channel key，要求 `KindChat`                  |
-| `NewSession`            | HTTP/Web UI 创建 session                     | 只能生成 ID                                           |
-| `MintTaskSession`       | task system 创建 worker session              | 在 resolved executor agent 名下生成 ID                |
-| `Delegate`              | 运行/恢复 delegate child session             | caller/model supplied `SessionID` 是 resume-only      |
-| `ResolveMainSession`    | 解析或创建 private main session              | 生成或提升 main session                               |
+| Method                                                        | 用途                                                      | ID trust model                                                    |
+| ------------------------------------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------- |
+| `Chat`                                                        | 前台 chat，使用已有 session 或生成新 session              | caller-supplied `SessionID` 是 resume-only                        |
+| `ChatForChannel`                                              | 非私有 channel/group chat                                 | 允许 exact-create，因为 `SessionKey` 由 Stella 派生               |
+| `ChatForScheduler`                                            | scheduler 发起的 run                                      | 允许 exact-create，因为 `SessionID` 由 scheduler 派生             |
+| `ResolvePrivateChannelSession` / `ResolveGroupChannelSession` | 只解析 private 或 group channel session，不执行 chat turn | trusted channel key，要求 `KindChat`；group id 拥有 group session |
+| `NewSession`                                                  | HTTP/Web UI 创建 session                                  | 只能生成 ID                                                       |
+| `MintTaskSession`                                             | task system 创建 worker session                           | 在 resolved executor agent 名下生成 ID                            |
+| `Delegate`                                                    | 运行/恢复 delegate child session                          | caller/model supplied `SessionID` 是 resume-only                  |
+| `ResolveMainSession`                                          | 解析或创建 private main session                           | 生成或提升 main session                                           |
 
 ### `session.Registry`
 
@@ -136,11 +136,12 @@ Memory 拥有：
 硬规则：
 
 ```go
-// 生产代码不应该手搓 memory.Session。
-scope := svc.Sessions.MemoryScope(validatedInfo)
+// 生产代码只从验证过的 session.Info 派生 memory scope。
+// MemoryScope 会校验 session invariant，遇到非法 Info 时 fail closed 返回错误。
+scope, err := svc.Sessions.MemoryScope(validatedInfo)
 ```
 
-低层 memory 测试是例外。生产代码应该从验证过的 `session.Info` 获取 `memory.Session`，这样 ownership 和 kind policy 不会被绕过。
+`session.Info` 是独立的、经过验证的 session-domain 类型，不是 `memory.SessionInfo` 的别名。所有生产代码（包括 `runtime.Runtime`）都只通过 `MemoryScope` 获取 `memory.Session`，不存在 runtime 直接构造的例外。group session 带有持久且经过验证的 `GroupID`（持久化在 `ctx_conversation.group_id`，且 `UserID == GroupID`）。对 private session，read、write、compaction 落在同一个 partition。group session 的 read 和 write 共享同一个持久 canonical scope；group compaction 不被支持——`CompactSession` 会用 `ErrGroupCompactionUnsupported` 拒绝它，因为 group history 来自 group event log，而不是 LCM conversation。低层 memory 测试仍可以直接构造 `memory.Session`。
 
 ## Session kinds 和 channels
 
@@ -370,8 +371,8 @@ ID: req.SessionID,
 ```
 
 ```go
-// Runtime 使用未经过 Registry 验证的 session info。
-rt.Chat(ctx, memory.SessionInfo{ID: id}, msg)
+// Runtime 使用未经过 Registry 验证的 session.Info。
+rt.Chat(ctx, session.Info{ID: id}, msg)
 ```
 
 ```go


### PR DESCRIPTION
## What

Establishes the architecture-migration foundation for #703:

- persists canonical group identity on `ctx_conversation` with safe backfill, FK/CHECK constraints, and restart coverage;
- makes `session.Info` a validated domain type with one fail-closed memory-scope conversion;
- rejects unsupported group compaction and prevents reflect from treating group sessions as private conversations;
- adds executable architecture debt tripwires and complete authorization-entry coverage for generated API routes plus webhook/channel/tool/worker surfaces;
- records lifecycle, authorization, policy reachability, ambient capability, boot-config, and multi-replica baselines outside the repository.

## Why

Group semantics previously depended on an undeclared `UserID == GroupID` convention while `GroupID` itself disappeared after persistence reload. Later authorization and composition work also needed executable guardrails so existing ambient authority can only shrink.

## Verification

- `mise run db:validate`
- deterministic `mise run generate`
- `mise run format`
- `mise run build`
- `mise run test`
- `go vet ./...`
- temporary failing counterexamples for every architecture tripwire
- Fable final gate: `SHIP`

## Stack

- Stack 1 / 7 under #703
- Base: `main`
- Next: #707

Closes #706
