### PR TITLE
🐛 fix(oauth): reconnect lark-cli through Feishu provider

### DIFF
--- a/internal/manifestplugins/loader_test.go
+++ b/internal/manifestplugins/loader_test.go
@@ -1,6 +1,13 @@
 package manifestplugins
 
-import "testing"
+import (
+	"io/fs"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/CherryHQ/stella/resources"
+)
 
 func TestLoadBuiltin(t *testing.T) {
 	m, err := LoadBuiltin()
@@ -32,4 +39,63 @@ func TestLoadBuiltinLarkCLIOAuthProvider(t *testing.T) {
 		return
 	}
 	t.Fatal("tool/lark-cli not found")
+}
+
+func TestLarkCLIReconnectGuidanceMatchesOAuthProvider(t *testing.T) {
+	m, err := LoadBuiltin()
+	if err != nil {
+		t.Fatalf("LoadBuiltin() error: %v", err)
+	}
+
+	var larkCLI *ManifestPlugin
+	for i := range m.Plugins {
+		if m.Plugins[i].ID == "tool/lark-cli" {
+			larkCLI = &m.Plugins[i]
+			break
+		}
+	}
+	if larkCLI == nil {
+		t.Fatal("tool/lark-cli not found")
+	}
+
+	provider := larkCLI.OAuthProvider
+	if provider == "" {
+		t.Fatal("tool/lark-cli OAuthProvider is empty")
+	}
+	if !strings.Contains(larkCLI.Prompt, "stella oauth connect "+provider) {
+		t.Errorf("tool/lark-cli prompt must reconnect %q", provider)
+	}
+
+	providerParameter := regexp.MustCompile(`provider=([a-z0-9_-]+)`)
+	guidanceCount := 0
+	err = fs.WalkDir(resources.FS(), "skills/system/lark-cli", func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		contents, err := fs.ReadFile(resources.FS(), path)
+		if err != nil {
+			return err
+		}
+		for line := range strings.SplitSeq(string(contents), "\n") {
+			if !strings.Contains(line, "oauth connect") {
+				continue
+			}
+			for _, match := range providerParameter.FindAllStringSubmatch(line, -1) {
+				guidanceCount++
+				if match[1] != provider {
+					t.Errorf("%s reconnects provider %q, want manifest binding %q", path, match[1], provider)
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk bundled lark-cli guidance: %v", err)
+	}
+	if guidanceCount == 0 {
+		t.Fatal("bundled lark-cli guidance has no provider= reconnect instructions")
+	}
 }

--- a/resources/skills/system/lark-cli/SKILL.md
+++ b/resources/skills/system/lark-cli/SKILL.md
@@ -28,7 +28,7 @@ This skill aggregates Lark/Feishu CLI modules synced from `larksuite/cli` and ad
 
 **Identity** — default to `--as user` for personal resources (calendar, docs, tasks, mail). `--as bot` requires manual app configuration outside Stella and cannot see user-private resources.
 
-**Token expiry** — user access tokens expire after ~2 hours. Stella proactively refreshes them within 10 minutes of expiry. If a token expires mid-session, use the `oauth` tool (oauth status, then oauth connect with provider=lark) or go to Credentials → OAuth CLI Credentials to reconnect; Stella restarts the sandbox automatically on the next message.
+**Token expiry** — user access tokens expire after ~2 hours. Stella proactively refreshes them within 10 minutes of expiry. If a token expires mid-session, use the `oauth` tool (oauth status, then oauth connect with provider=feishu) or go to Credentials → OAuth CLI Credentials to reconnect; Stella restarts the sandbox automatically on the next message.
 
 ## Modules
 

--- a/resources/skills/system/lark-cli/references/lark-shared.md
+++ b/resources/skills/system/lark-cli/references/lark-shared.md
@@ -35,7 +35,7 @@ description: "飞书/Lark CLI 共享基础（Stella 适配版）：说明 Stella
 
 ### 未连接、过期或认证失败
 
-- 如果 `lark-cli` 提示未登录、缺少 access token、401/expired，先用 `oauth` 工具检查 Lark 连接状态（oauth status 指令）；如需重新连接，执行 oauth connect（provider=lark），或引导用户前往 Credentials → OAuth CLI Credentials 重新授权。
+- 如果 `lark-cli` 提示未登录、缺少 access token、401/expired，先用 `oauth` 工具检查 Lark 连接状态（oauth status 指令）；如需重新连接，执行 oauth connect（provider=feishu），或引导用户前往 Credentials → OAuth CLI Credentials 重新授权。
 - Lark user access token 约 2 小时过期；Stella 只在**会话启动时**刷新。已连接但中途过期时，直接开启一个新的 Stella 会话。
 - 重新开启会话后仍失败，说明 refresh token 也可能失效或授权被撤销；此时应让用户从 Credentials → OAuth CLI Credentials 断开并重新连接 Lark，而不是在会话里继续尝试 `auth login`。
 


### PR DESCRIPTION
## What
Correct lark-cli's expired-token recovery guidance to reconnect the OAuth provider actually bound to the tool.

Add a contract test that derives the expected provider from the builtin manifest and checks all bundled lark-cli reconnect instructions against it.

## Why
`tool/lark-cli` intentionally supports one provider and is bound to `feishu`. Initial Feishu authorization therefore works, but the bundled recovery guidance previously asked the agent to reconnect `lark` after refresh-token expiry. That saved a valid token under `LARK_CLI_OAUTH` while the tool continued reading `FEISHU_CLI_OAUTH`, causing repeated authorization prompts.

## How
- Change the lark-cli skill and shared reference from `provider=lark` to `provider=feishu`.
- Keep the one-tool/one-provider manifest and OAuth persistence paths unchanged.
- Scan bundled lark-cli guidance in a regression test and require reconnect providers to match `tool/lark-cli.oauth_provider`.

Verification:
- `mise run generate`
- `mise run format`
- `mise run build`
- `mise run test`

## Refs
Closes #722

Patch release: `v0.50.6`
Base: `release-0.50.5`
