### PR TITLE
🐛 fix(sandbox): resolve local command cwd on host

### DIFF
--- a/plugins/sandbox/local/session.go
+++ b/plugins/sandbox/local/session.go
@@ -494,12 +494,12 @@ func (s *localSession) Exec(ctx context.Context, command string, opts sandboxpkg
 		defer cancel()
 	}
 
-	sandboxCwd, _, err := s.resolveCwd(sandboxCwd)
+	sandboxCwd, realCwd, err := s.resolveCwd(sandboxCwd)
 	if err != nil {
 		return sandboxpkg.ExecResult{}, fmt.Errorf("local exec: resolve cwd: %w", err)
 	}
 
-	execPath, execArgs, hostCwd, err := wrapCommand(policy, sandboxCwd, s.tmpMounts, s.stellaHomeHost, "sh", []string{"-c", command})
+	execPath, execArgs, err := wrapCommand(policy, sandboxCwd, s.tmpMounts, s.stellaHomeHost, "sh", []string{"-c", command})
 	if err != nil {
 		return sandboxpkg.ExecResult{}, fmt.Errorf("local exec: wrap: %w", err)
 	}
@@ -507,7 +507,7 @@ func (s *localSession) Exec(ctx context.Context, command string, opts sandboxpkg
 	// Finding 2: do NOT use exec.CommandContext — it only kills the leader PID,
 	// leaving process-group children alive. We manage cancellation manually.
 	cmd := exec.Command(execPath, execArgs...)
-	cmd.Dir = hostCwd
+	cmd.Dir = realCwd
 	cmd.Env = buildEnv(policy, opts.Env)
 	setSysProcAttr(cmd)
 
@@ -584,13 +584,13 @@ func (s *localSession) StartProcess(ctx context.Context, req sandboxpkg.ProcessR
 	args := make([]string, 0, len(req.Args))
 	args = append(args, req.Args...)
 
-	sandboxCwd, _, err := s.resolveCwd(sandboxCwd)
+	sandboxCwd, realCwd, err := s.resolveCwd(sandboxCwd)
 	if err != nil {
 		cancel()
 		return nil, fmt.Errorf("local start_process: resolve cwd: %w", err)
 	}
 
-	execPath, execArgs, hostCwd, err := wrapCommand(policy, sandboxCwd, s.tmpMounts, s.stellaHomeHost, req.Path, args)
+	execPath, execArgs, err := wrapCommand(policy, sandboxCwd, s.tmpMounts, s.stellaHomeHost, req.Path, args)
 	if err != nil {
 		cancel()
 		return nil, fmt.Errorf("local start_process: wrap: %w", err)
@@ -598,7 +598,7 @@ func (s *localSession) StartProcess(ctx context.Context, req sandboxpkg.ProcessR
 
 	// Finding 2: do NOT use exec.CommandContext — kill the process group instead.
 	cmd := exec.Command(execPath, execArgs...)
-	cmd.Dir = hostCwd
+	cmd.Dir = realCwd
 	cmd.Env = buildEnv(policy, req.Env)
 	setSysProcAttr(cmd)
 

--- a/plugins/sandbox/local/session_darwin.go
+++ b/plugins/sandbox/local/session_darwin.go
@@ -175,20 +175,20 @@ func appendSeatbeltWritableEnvDirs(sb *strings.Builder, env map[string]string) {
 // wrapCommand wraps name+args with sandbox-exec for macOS Seatbelt isolation.
 // tmpMounts is accepted for signature compatibility with the Linux backend but
 // is not used here — macOS bash and file tools share the same host filesystem.
-func wrapCommand(policy sandboxpkg.Policy, sandboxCwd string, _ []tmpMount, stellaHomeHost string, name string, args []string) (execPath string, execArgs []string, hostCwd string, err error) {
+func wrapCommand(policy sandboxpkg.Policy, _ string, _ []tmpMount, stellaHomeHost string, name string, args []string) (execPath string, execArgs []string, err error) {
 	if !seatbeltFunctional() {
-		return "", nil, "", fmt.Errorf(
+		return "", nil, fmt.Errorf(
 			"local sandbox: sandbox-exec (macOS Seatbelt) is required but not available",
 		)
 	}
 
 	resolved, lookErr := exec.LookPath(name)
 	if lookErr != nil {
-		return "", nil, "", fmt.Errorf("local exec: look up %q: %w", name, lookErr)
+		return "", nil, fmt.Errorf("local exec: look up %q: %w", name, lookErr)
 	}
 
 	profile := buildSeatbeltProfile(policy, stellaHomeHost)
 	seatbeltArgs := []string{"-p", profile, resolved}
 	seatbeltArgs = append(seatbeltArgs, args...)
-	return seatbeltExecPath, seatbeltArgs, sandboxCwd, nil
+	return seatbeltExecPath, seatbeltArgs, nil
 }

--- a/plugins/sandbox/local/session_darwin_test.go
+++ b/plugins/sandbox/local/session_darwin_test.go
@@ -1,6 +1,9 @@
 package local
 
 import (
+	"context"
+	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -25,7 +28,7 @@ func TestWrapCommand_darwin_usesSeatbelt(t *testing.T) {
 	root := t.TempDir()
 	policy := makePolicy(root, sandboxpkg.NetworkDisabled)
 
-	execPath, args, hostCwd, err := wrapCommand(policy, root, nil, "", "sh", []string{"-c", "echo hi"})
+	execPath, args, err := wrapCommand(policy, root, nil, "", "sh", []string{"-c", "echo hi"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -36,9 +39,83 @@ func TestWrapCommand_darwin_usesSeatbelt(t *testing.T) {
 	if len(args) < 3 || args[0] != "-p" {
 		t.Fatalf("expected -p <profile> <cmd> ..., got %v", args)
 	}
-	if hostCwd != root {
-		t.Fatalf("hostCwd = %q, want %q", hostCwd, root)
+}
+
+// TestLocalSession_darwinProductionMountUsesHostCwd verifies that direct
+// Seatbelt execution starts in the host path for a production-style /workspace
+// mount. sandbox-exec does not remap paths, unlike bwrap.
+func TestLocalSession_darwinProductionMountUsesHostCwd(t *testing.T) {
+	if !seatbeltFunctional() {
+		t.Skip("sandbox-exec not available")
 	}
+
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	realCwd := filepath.Join(root, "sub")
+	if err := os.Mkdir(realCwd, 0o755); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+	sandboxCwd := filepath.Join(sandboxpkg.MountWorkspace, "sub")
+	policy := sandboxpkg.Policy{
+		Filesystem: sandboxpkg.FilesystemPolicy{
+			WorkspaceRoot: root,
+			WorkingDir:    sandboxpkg.MountWorkspace,
+			Mounts: []sandboxpkg.Mount{{
+				HostPath:    root,
+				SandboxPath: sandboxpkg.MountWorkspace,
+				Access:      sandboxpkg.MountReadWrite,
+			}},
+		},
+		Network:    sandboxpkg.NetworkPolicy{Mode: sandboxpkg.NetworkAllowAll},
+		InheritEnv: true,
+	}
+	s := &localSession{
+		id:          "test",
+		policy:      policy,
+		realRoot:    root,
+		sandboxRoot: sandboxpkg.MountWorkspace,
+		done:        make(chan struct{}),
+	}
+	want := realCwd + "\n"
+
+	t.Run("Exec", func(t *testing.T) {
+		result, err := s.Exec(context.Background(), "pwd", sandboxpkg.ExecOptions{Cwd: sandboxCwd})
+		if err != nil {
+			t.Fatalf("Exec: %v", err)
+		}
+		if result.ExitCode != 0 {
+			t.Fatalf("Exec exit code = %d, stderr = %q", result.ExitCode, result.Stderr)
+		}
+		if result.Stdout != want {
+			t.Errorf("Exec stdout = %q, want %q", result.Stdout, want)
+		}
+	})
+
+	t.Run("StartProcess", func(t *testing.T) {
+		process, err := s.StartProcess(context.Background(), sandboxpkg.ProcessRequest{
+			Path: "/bin/pwd",
+			Cwd:  sandboxCwd,
+		})
+		if err != nil {
+			t.Fatalf("StartProcess: %v", err)
+		}
+		stdout, err := io.ReadAll(process.Stdout())
+		if err != nil {
+			t.Fatalf("read stdout: %v", err)
+		}
+		result, err := process.Wait(context.Background())
+		if err != nil {
+			t.Fatalf("Wait: %v", err)
+		}
+		if result.ExitCode != 0 {
+			t.Fatalf("StartProcess exit code = %d", result.ExitCode)
+		}
+		if string(stdout) != want {
+			t.Errorf("StartProcess stdout = %q, want %q", stdout, want)
+		}
+	})
 }
 
 func TestBuildSeatbeltProfile_structure(t *testing.T) {
@@ -157,11 +234,11 @@ func TestBuildSeatbeltProfile_networkDisabledVsAllowAll(t *testing.T) {
 	}
 	root := t.TempDir()
 
-	_, disabledArgs, _, err := wrapCommand(makePolicy(root, sandboxpkg.NetworkDisabled), root, nil, "", "sh", []string{"-c", "echo"})
+	_, disabledArgs, err := wrapCommand(makePolicy(root, sandboxpkg.NetworkDisabled), root, nil, "", "sh", []string{"-c", "echo"})
 	if err != nil {
 		t.Fatalf("disabled wrapCommand error: %v", err)
 	}
-	_, allowArgs, _, err := wrapCommand(makePolicy(root, sandboxpkg.NetworkAllowAll), root, nil, "", "sh", []string{"-c", "echo"})
+	_, allowArgs, err := wrapCommand(makePolicy(root, sandboxpkg.NetworkAllowAll), root, nil, "", "sh", []string{"-c", "echo"})
 	if err != nil {
 		t.Fatalf("allow_all wrapCommand error: %v", err)
 	}

--- a/plugins/sandbox/local/session_linux.go
+++ b/plugins/sandbox/local/session_linux.go
@@ -288,10 +288,9 @@ func isCoveredByWritableMount(hostPath string, mounts []sandboxpkg.Mount) bool {
 // isolation on Linux. bwrap is mandatory — returns an error if not functional.
 //
 //   - sandboxCwd: working directory in sandbox space (e.g. /workspace/sub).
-//   - hostCwd returned: real host path (bwrap uses --chdir internally).
-func wrapCommand(policy sandboxpkg.Policy, sandboxCwd string, tmpMounts []tmpMount, stellaHomeHost string, name string, args []string) (execPath string, execArgs []string, hostCwd string, err error) {
+func wrapCommand(policy sandboxpkg.Policy, sandboxCwd string, tmpMounts []tmpMount, stellaHomeHost string, name string, args []string) (execPath string, execArgs []string, err error) {
 	if !bwrapFunctional() {
-		return "", nil, "", fmt.Errorf(
+		return "", nil, fmt.Errorf(
 			"local sandbox: bwrap (bubblewrap) is required on Linux but is not available or not functional; " +
 				"install it (apt install bubblewrap / dnf install bubblewrap / pacman -S bubblewrap) " +
 				"or use the docker backend",
@@ -365,5 +364,5 @@ func wrapCommand(policy sandboxpkg.Policy, sandboxCwd string, tmpMounts []tmpMou
 	}
 	bwrapArgs = append(bwrapArgs, "--", name)
 	bwrapArgs = append(bwrapArgs, args...)
-	return bwrapPath, bwrapArgs, realRoot, nil
+	return bwrapPath, bwrapArgs, nil
 }

--- a/plugins/sandbox/local/session_linux_test.go
+++ b/plugins/sandbox/local/session_linux_test.go
@@ -26,7 +26,7 @@ func TestWrapCommand_linux_networkDisabled(t *testing.T) {
 		Network: sandboxpkg.NetworkPolicy{Mode: sandboxpkg.NetworkDisabled},
 	}
 
-	path, args, _, err := wrapCommand(policy, sandboxCwd, nil, "", "sh", []string{"-c", "echo hi"})
+	path, args, err := wrapCommand(policy, sandboxCwd, nil, "", "sh", []string{"-c", "echo hi"})
 
 	if !bwrapFunctional() {
 		if err == nil {
@@ -66,7 +66,7 @@ func TestWrapCommand_linux_allowAllNoWrap(t *testing.T) {
 		Network: sandboxpkg.NetworkPolicy{Mode: sandboxpkg.NetworkAllowAll},
 	}
 
-	_, args, _, err := wrapCommand(policy, sandboxCwd, nil, "", "sh", []string{"-c", "echo hi"})
+	_, args, err := wrapCommand(policy, sandboxCwd, nil, "", "sh", []string{"-c", "echo hi"})
 	if err != nil {
 		t.Fatalf("unexpected error for allow_all network: %v", err)
 	}
@@ -168,7 +168,7 @@ func TestWrapCommand_linux_bwrapWorkspaceRemap(t *testing.T) {
 		Network: sandboxpkg.NetworkPolicy{Mode: sandboxpkg.NetworkAllowAll},
 	}
 
-	execPath, args, hostCwd, err := wrapCommand(policy, sandboxCwd, nil, "", "sh", []string{"-c", "echo hi"})
+	execPath, args, err := wrapCommand(policy, sandboxCwd, nil, "", "sh", []string{"-c", "echo hi"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -235,9 +235,6 @@ func TestWrapCommand_linux_bwrapWorkspaceRemap(t *testing.T) {
 	if !hasFlag("--chdir", sandboxCwd) {
 		t.Errorf("expected --chdir %s in bwrap args, got %v", sandboxCwd, args)
 	}
-	if hostCwd != root {
-		t.Errorf("expected hostCwd %q, got %q", root, hostCwd)
-	}
 }
 
 // TestWrapCommand_linux_outOfRootWritableBind verifies a writable mount that
@@ -270,7 +267,7 @@ func TestWrapCommand_linux_outOfRootWritableBind(t *testing.T) {
 		Network: sandboxpkg.NetworkPolicy{Mode: sandboxpkg.NetworkAllowAll},
 	}
 
-	_, args, _, err := wrapCommand(policy, "/workspace", nil, stellaHome, "sh", []string{"-c", "echo hi"})
+	_, args, err := wrapCommand(policy, "/workspace", nil, stellaHome, "sh", []string{"-c", "echo hi"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -320,7 +317,7 @@ func TestWrapCommand_linux_inWorkspaceWritableMountSkipped(t *testing.T) {
 		Network: sandboxpkg.NetworkPolicy{Mode: sandboxpkg.NetworkAllowAll},
 	}
 
-	_, args, _, err := wrapCommand(policy, "/workspace", nil, stellaHome, "sh", []string{"-c", "echo hi"})
+	_, args, err := wrapCommand(policy, "/workspace", nil, stellaHome, "sh", []string{"-c", "echo hi"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -363,7 +360,7 @@ func TestWrapCommand_linux_inUserDataWritableMountSkipped(t *testing.T) {
 		Network: sandboxpkg.NetworkPolicy{Mode: sandboxpkg.NetworkAllowAll},
 	}
 
-	_, args, _, err := wrapCommand(policy, "/workspace", nil, stellaHome, "sh", []string{"-c", "echo hi"})
+	_, args, err := wrapCommand(policy, "/workspace", nil, stellaHome, "sh", []string{"-c", "echo hi"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -401,7 +398,7 @@ func TestWrapCommand_linux_twoRoots(t *testing.T) {
 		Network: sandboxpkg.NetworkPolicy{Mode: sandboxpkg.NetworkAllowAll},
 	}
 
-	_, args, _, err := wrapCommand(policy, "/workspace/projects/p", nil, "", "sh", []string{"-c", "echo hi"})
+	_, args, err := wrapCommand(policy, "/workspace/projects/p", nil, "", "sh", []string{"-c", "echo hi"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/plugins/sandbox/local/session_other.go
+++ b/plugins/sandbox/local/session_other.go
@@ -33,6 +33,6 @@ func checkSandboxRequirements() error { return nil }
 
 // wrapCommand is a no-op on platforms other than Linux and macOS.
 // Commands run unwrapped on the host OS.
-func wrapCommand(_ sandboxpkg.Policy, sandboxCwd string, _ []tmpMount, _ string, name string, args []string) (string, []string, string, error) {
-	return name, args, sandboxCwd, nil
+func wrapCommand(_ sandboxpkg.Policy, _ string, _ []tmpMount, _ string, name string, args []string) (string, []string, error) {
+	return name, args, nil
 }


### PR DESCRIPTION
## What

Fix local sandbox command execution on macOS when the production mount plan maps the host workspace to `/workspace`.

- Launch wrapped commands from the validated host cwd.
- Keep backend wrappers responsible only for Seatbelt/bwrap command construction.
- Cover both `Exec` and `StartProcess` with a real Darwin Seatbelt regression test using the production mount layout.

## Why

After #671, `resolveCwd` produced both sandbox and host paths, but the host path was discarded. Darwin then used `/workspace` as `cmd.Dir`; because that directory does not exist on the host, Go returned the misleading error:

```text
fork/exec /usr/bin/sandbox-exec: no such file or directory
```

`/usr/bin/sandbox-exec` was present and functional—the missing path was the cwd.

## How

`Exec` and `StartProcess` now use `realCwd` for `cmd.Dir` while still passing `sandboxCwd` into backend wrappers. Linux bwrap therefore retains `--chdir /workspace/...`, while macOS starts Seatbelt from the actual host directory.

## Verification

- `mise run format`
- `mise run build`
- `mise run test`
- Linux amd64 test binary cross-compilation
- Windows amd64 test binary cross-compilation
- Independent sandbox boundary review: no high-confidence findings

## Refs

Closes #728
Regression from #671