### PR TITLE
🐛 fix(oauth): refresh credentials in long-lived sessions

### DIFF
--- a/internal/agent/runner_builder.go
+++ b/internal/agent/runner_builder.go
@@ -219,6 +219,7 @@ func newRunnerFunc(cfg runnerBuilderConfig) NewRunnerFunc {
 			VaultEnvLoader:      cfg.VaultEnvLoader,
 			SessionSecretValues: sessionSecretValues,
 			TokenManager:        cfg.TokenManager,
+			OAuthEnvBindings:    sandbox.NewOAuthEnvBindings(),
 		}
 
 		builtinTools := append([]BuiltinTool(nil), cfg.BuiltinTools...)

--- a/internal/agent/runner_impl.go
+++ b/internal/agent/runner_impl.go
@@ -71,6 +71,7 @@ type runner struct {
 	toolLifecycle *coreagent.ToolLifecycle
 	chatTimeout   time.Duration
 	session       pkgsandbox.Session // runner-owned sandbox session lifecycle
+	sandboxCfg    sandbox.Config     // retained to refresh OAuth-derived env on long-lived runners
 
 	mu           sync.Mutex
 	lastActivity time.Time
@@ -88,6 +89,11 @@ func newRunner(ctx context.Context, cfg runnerConfig) (*runner, error) {
 	systemPrompt := cfg.System
 
 	model := ai.Model{API: cfg.Provider.API, Name: cfg.Provider.Model, Provider: cfg.Provider.API, BaseURL: cfg.Provider.BaseURL}
+
+	// Propagate the turn budget into the sandbox config so both initial OAuth env
+	// injection and per-turn refresh size their min-validity to the actual chat
+	// timeout (#722). cfg is a value copy, so this stays local to this runner.
+	cfg.Sandbox.ChatTimeout = cfg.ChatTimeout
 
 	session, err := sandbox.ResolveSession(ctx, cfg.Sandbox)
 	if err != nil {
@@ -137,6 +143,7 @@ func newRunner(ctx context.Context, cfg runnerConfig) (*runner, error) {
 		toolLifecycle: cfg.ToolLifecycle,
 		chatTimeout:   cfg.ChatTimeout,
 		session:       session,
+		sandboxCfg:    cfg.Sandbox,
 		lastActivity:  time.Now(),
 		log:           slog.With("component", "go_runner"),
 	}, nil
@@ -452,6 +459,14 @@ func (r *runner) Chat(ctx context.Context, history []ai.Message, message Message
 			}
 			return &msg
 		})
+
+		// Reload the OAuth-derived session env before each turn so a long-lived
+		// cached runner (kept warm by frequent scheduler fires) never hands tools
+		// an expired OAuth token. A no-op on a fresh credential, on group
+		// sessions, and on sessions without OAuth-sourced env (#722).
+		if r.session != nil {
+			sandbox.RefreshSessionEnv(ctx, r.session, r.sandboxCfg)
+		}
 
 		messages := make([]ai.Message, len(history))
 		copy(messages, history)

--- a/internal/agent/sandbox/backend_test.go
+++ b/internal/agent/sandbox/backend_test.go
@@ -491,9 +491,10 @@ func TestBuildSandboxEnv_TokenInjectionErrorsAreSkipped(t *testing.T) {
 	if _, ok := env["GH_TOKEN"]; ok {
 		t.Fatal("GH_TOKEN should be skipped when access token is empty")
 	}
-	// Lark token is loaded by GetOAuthToken regardless of expiry (no refresh check).
-	if got := env["LARKSUITE_CLI_USER_ACCESS_TOKEN"]; got != "token" {
-		t.Fatalf("LARKSUITE_CLI_USER_ACCESS_TOKEN = %q, want %q", got, "token")
+	// The lark bundle is expired with an expired refresh token, so it cannot be
+	// renewed; it must be skipped rather than injected as a dead credential (#722).
+	if got, ok := env["LARKSUITE_CLI_USER_ACCESS_TOKEN"]; ok {
+		t.Fatalf("expired lark token must be skipped, got LARKSUITE_CLI_USER_ACCESS_TOKEN = %q", got)
 	}
 	if _, ok := env[oauth.VaultKeyGitHub]; ok {
 		t.Fatal("GH_OAUTH must still be stripped when token injection fails")

--- a/internal/agent/sandbox/config.go
+++ b/internal/agent/sandbox/config.go
@@ -4,6 +4,7 @@ package sandbox
 
 import (
 	"context"
+	"time"
 
 	"github.com/CherryHQ/stella/internal/config"
 	oauth "github.com/CherryHQ/stella/internal/connections/oauth"
@@ -35,4 +36,15 @@ type Config struct {
 	VaultEnvLoader      VaultEnvLoader
 	SessionSecretValues *SessionSecretValues
 	TokenManager        *oauth.TokenManager
+	// OAuthEnvBindings records which sandbox env vars were injected from an OAuth
+	// bundle at session creation, so a later live refresh reloads only those and
+	// never overwrites an explicit vault override of the same name. Shared by
+	// pointer with the retained runner config so RefreshSessionEnv sees what
+	// buildSandboxEnv recorded.
+	OAuthEnvBindings *OAuthEnvBindings
+	// ChatTimeout is the wall-clock budget for one chat turn. OAuth-derived env
+	// is refreshed to stay valid for at least this long plus a safety margin so a
+	// token injected at turn start outlives the turn (#722). Zero uses the
+	// runner's default turn budget.
+	ChatTimeout time.Duration
 }

--- a/internal/agent/sandbox/env.go
+++ b/internal/agent/sandbox/env.go
@@ -251,6 +251,10 @@ func recordSessionSecretValues(target *SessionSecretValues, env map[string]strin
 func injectSessionEnv(ctx context.Context, cfg Config, env map[string]string, vaultEnv map[string]string, secretEnv map[string]string) error {
 	// oauthBundles caches loaded bundles per provider to avoid redundant vault hits.
 	oauthBundles := make(map[string]*oauth.OAuthBundle)
+	// oauthBoundVars records the env vars actually injected from OAuth so a later
+	// live refresh rotates exactly those and never an explicit vault override.
+	var oauthBoundVars []string
+	defer func() { cfg.OAuthEnvBindings.Set(oauthBoundVars) }()
 	for _, spec := range cfg.SessionEnvSpecs {
 		src := string(spec.Source)
 		if spec.Source == pkgplugins.SessionEnvSourceStatic {
@@ -283,7 +287,7 @@ func injectSessionEnv(ctx context.Context, cfg Config, env map[string]string, va
 		bundle, ok := oauthBundles[providerID]
 		if !ok {
 			var err error
-			bundle, err = cfg.TokenManager.GetOAuthToken(ctx, providerID, cfg.UserID)
+			bundle, err = cfg.TokenManager.GetOAuthToken(ctx, providerID, cfg.UserID, oauthMinValidity(cfg))
 			if err != nil {
 				slog.Debug("session env injection skipped",
 					"component", "runner_sandbox",
@@ -312,17 +316,8 @@ func injectSessionEnv(ctx context.Context, cfg Config, env map[string]string, va
 			continue
 		}
 		field := strings.TrimPrefix(src, "oauth.")
-		var value string
-		switch field {
-		case "access_token":
-			value = bundle.AccessToken
-		case "client_id":
-			value = bundle.ClientID
-		case "brand":
-			value = bundle.Brand
-		case "refresh_token":
-			value = bundle.RefreshToken
-		default:
+		value, known := oauthBundleField(bundle, field)
+		if !known {
 			if spec.Required {
 				return fmt.Errorf("required session env %q (source %q) for plugin %q: unknown oauth field %q", spec.EnvVar, spec.Source, spec.PluginID, field)
 			}
@@ -330,6 +325,7 @@ func injectSessionEnv(ctx context.Context, cfg Config, env map[string]string, va
 		}
 		if value != "" {
 			env[spec.EnvVar] = value
+			oauthBoundVars = append(oauthBoundVars, spec.EnvVar)
 			if oauthSessionEnvFieldSecret(field) {
 				secretEnv[spec.EnvVar] = value
 			}
@@ -338,6 +334,25 @@ func injectSessionEnv(ctx context.Context, cfg Config, env map[string]string, va
 		}
 	}
 	return nil
+}
+
+// oauthBundleField maps an oauth.<field> source suffix to the corresponding
+// value on a resolved bundle; known is false for an unrecognized field. It is
+// the single mapping shared by initial env injection (injectSessionEnv) and live
+// refresh (RefreshSessionEnv) so the two never drift (#722).
+func oauthBundleField(bundle *oauth.OAuthBundle, field string) (value string, known bool) {
+	switch field {
+	case "access_token":
+		return bundle.AccessToken, true
+	case "client_id":
+		return bundle.ClientID, true
+	case "brand":
+		return bundle.Brand, true
+	case "refresh_token":
+		return bundle.RefreshToken, true
+	default:
+		return "", false
+	}
 }
 
 func oauthSessionEnvFieldSecret(field string) bool {

--- a/internal/agent/sandbox/env_test.go
+++ b/internal/agent/sandbox/env_test.go
@@ -105,6 +105,7 @@ func TestBuildSandboxEnvVaultSecretOverridesOAuthSessionEnv(t *testing.T) {
 		name          string
 		vaultSecret   bool
 		wantToken     string
+		wantOAuthBind bool
 		wantRedacted  []string
 		absentSecrets []string
 	}{
@@ -118,6 +119,7 @@ func TestBuildSandboxEnvVaultSecretOverridesOAuthSessionEnv(t *testing.T) {
 		{
 			name:          "oauth injects without vault collision",
 			wantToken:     "oauth_access_token",
+			wantOAuthBind: true,
 			wantRedacted:  []string{"oauth_access_token"},
 			absentSecrets: []string{"vault_pat"},
 		},
@@ -143,12 +145,14 @@ func TestBuildSandboxEnvVaultSecretOverridesOAuthSessionEnv(t *testing.T) {
 				}
 			}
 			secretValues := NewSessionSecretValues()
+			oauthBindings := NewOAuthEnvBindings()
 			env, err := buildSandboxEnv(ctx, Config{
 				UserID:              userID,
 				AgentID:             "agent-1",
 				VaultEnvLoader:      store,
 				SessionSecretValues: secretValues,
 				TokenManager:        tm,
+				OAuthEnvBindings:    oauthBindings,
 				SessionEnvSpecs: []pkgplugins.SessionEnvSpec{
 					{EnvVar: "GH_TOKEN", Source: pkgplugins.SessionEnvSource("oauth.access_token"), OAuthProviderID: "github"},
 				},
@@ -161,6 +165,9 @@ func TestBuildSandboxEnvVaultSecretOverridesOAuthSessionEnv(t *testing.T) {
 			}
 			if _, ok := env[oauth.VaultKeyGitHub]; ok {
 				t.Fatalf("%s must not appear in sandbox env", oauth.VaultKeyGitHub)
+			}
+			if got := oauthBindings.Has("GH_TOKEN"); got != tt.wantOAuthBind {
+				t.Fatalf("OAuth binding recorded = %v, want %v", got, tt.wantOAuthBind)
 			}
 			requireSessionSecretValues(t, secretValues.Values(), tt.wantRedacted, tt.absentSecrets)
 		})

--- a/internal/agent/sandbox/oauth_env_bindings.go
+++ b/internal/agent/sandbox/oauth_env_bindings.go
@@ -1,0 +1,51 @@
+package sandbox
+
+import "sync"
+
+// OAuthEnvBindings records, for one session, the set of sandbox env var names
+// that were injected from an OAuth bundle at session creation. It is the origin
+// state that lets RefreshSessionEnv rotate exactly those vars while leaving an
+// explicit vault override of the same name untouched (injectSessionEnv skips
+// OAuth injection when the vault already provides the var, so an overridden var
+// is never recorded here). It is reset on each (re)build so a recreated session
+// rebinds cleanly, and is concurrency-safe because refresh reads it while a
+// session recreation may be writing it.
+type OAuthEnvBindings struct {
+	mu    sync.RWMutex
+	names map[string]struct{}
+}
+
+// NewOAuthEnvBindings returns an empty binding set.
+func NewOAuthEnvBindings() *OAuthEnvBindings {
+	return &OAuthEnvBindings{}
+}
+
+// Set replaces the recorded env var names with names. A nil holder is a no-op so
+// callers that never wired one degrade to "nothing is refreshable".
+func (b *OAuthEnvBindings) Set(names []string) {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(names) == 0 {
+		b.names = nil
+		return
+	}
+	b.names = make(map[string]struct{}, len(names))
+	for _, n := range names {
+		b.names[n] = struct{}{}
+	}
+}
+
+// Has reports whether envVar was recorded as OAuth-injected. A nil holder or an
+// unrecorded var returns false, so refresh skips it.
+func (b *OAuthEnvBindings) Has(envVar string) bool {
+	if b == nil {
+		return false
+	}
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	_, ok := b.names[envVar]
+	return ok
+}

--- a/internal/agent/sandbox/refresh.go
+++ b/internal/agent/sandbox/refresh.go
@@ -1,0 +1,116 @@
+package sandbox
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+
+	oauth "github.com/CherryHQ/stella/internal/connections/oauth"
+	pkgsandbox "github.com/CherryHQ/stella/pkg/sandbox"
+)
+
+// defaultChatTurnTimeout mirrors the runner's own defaultChatTimeout. It is the
+// fallback turn budget when Config.ChatTimeout is unset, so OAuth min-validity
+// still covers a full-length turn.
+const defaultChatTurnTimeout = 30 * time.Minute
+
+// oauthValiditySafetyMargin pads the OAuth min-validity above the turn budget so
+// a token refreshed at turn start comfortably outlives the turn plus the trailing
+// egress/tool calls, absorbing clock skew across replicas.
+const oauthValiditySafetyMargin = 5 * time.Minute
+
+// oauthMinValidity is the remaining lifetime an OAuth access token must have at
+// turn start to be trusted for the whole turn: the configured chat timeout plus
+// a safety margin (#722). It replaces the old fixed 10-minute window, which
+// could not guarantee a token outlived a 30-minute turn.
+func oauthMinValidity(cfg Config) time.Duration {
+	timeout := cfg.ChatTimeout
+	if timeout <= 0 {
+		timeout = defaultChatTurnTimeout
+	}
+	return timeout + oauthValiditySafetyMargin
+}
+
+// RefreshSessionEnv reloads the OAuth bundles behind the session's env specs and
+// atomically updates the derived sandbox env in place, so a long-lived cached
+// runner keeps serving valid OAuth-derived tool credentials as access tokens
+// rotate (#722). Each provider bundle is reloaded through the TokenManager,
+// which refreshes a token below the min-validity floor (chat timeout + margin)
+// and persists it, or consumes one a concurrent replica just wrote.
+//
+// It refreshes only env vars actually injected from OAuth at session creation
+// (recorded in cfg.OAuthEnvBindings), so an explicit vault override of the same
+// name — which injectSessionEnv leaves untouched — is never clobbered. It is a
+// no-op for group sessions (which must never touch the human OAuth vault, D9),
+// sessions whose env cannot be refreshed, or a config without a TokenManager or
+// oauth-sourced bindings. A reload/refresh failure for a provider is logged and
+// leaves that env var at its previous value — which keeps working until it
+// actually expires — rather than clearing it.
+func RefreshSessionEnv(ctx context.Context, session pkgsandbox.Session, cfg Config) {
+	if session == nil || cfg.GroupID != "" || cfg.TokenManager == nil {
+		return
+	}
+	refresher, ok := session.(pkgsandbox.EnvRefresher)
+	if !ok {
+		return
+	}
+
+	minValidity := oauthMinValidity(cfg)
+	// bundles caches one resolution per provider so multiple env vars sourced
+	// from the same provider trigger a single reload/refresh. A nil entry records
+	// a resolution that failed, so we don't retry it within one turn.
+	bundles := make(map[string]*oauth.OAuthBundle)
+	updates := make(map[string]string)
+	var rotatedSecrets []string
+	for _, spec := range cfg.SessionEnvSpecs {
+		src := string(spec.Source)
+		if !strings.HasPrefix(src, "oauth.") {
+			continue
+		}
+		// Only vars injected from OAuth at creation are refreshable; anything the
+		// vault explicitly provided (or that was never connected) is left alone.
+		if !cfg.OAuthEnvBindings.Has(spec.EnvVar) {
+			continue
+		}
+		providerID := spec.OAuthProviderID
+		if providerID == "" {
+			continue
+		}
+		bundle, seen := bundles[providerID]
+		if !seen {
+			var err error
+			bundle, err = cfg.TokenManager.GetOAuthToken(ctx, providerID, cfg.UserID, minValidity)
+			if err != nil {
+				// Preserve the old env: log and skip rather than clear a value
+				// that may still work until it truly expires.
+				slog.Warn("session env refresh skipped: oauth token unavailable",
+					"component", "runner_sandbox",
+					"user_id", cfg.UserID,
+					"provider", providerID,
+					"env_var", spec.EnvVar,
+					"error", err,
+				)
+				bundle = nil
+			}
+			bundles[providerID] = bundle
+		}
+		if bundle == nil {
+			continue
+		}
+		field := strings.TrimPrefix(src, "oauth.")
+		value, known := oauthBundleField(bundle, field)
+		if known && value != "" {
+			updates[spec.EnvVar] = value
+			if oauthSessionEnvFieldSecret(field) {
+				rotatedSecrets = append(rotatedSecrets, value)
+			}
+		}
+	}
+	if len(updates) > 0 {
+		// Register rotated values before making them executable so an overlapping
+		// turn cannot observe a live token before output redaction knows it.
+		cfg.SessionSecretValues.Add(rotatedSecrets...)
+		refresher.RefreshEnv(updates)
+	}
+}

--- a/internal/agent/sandbox/refresh_session_env_test.go
+++ b/internal/agent/sandbox/refresh_session_env_test.go
@@ -1,0 +1,285 @@
+package sandbox
+
+import (
+	"context"
+	"encoding/json"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	oauth "github.com/CherryHQ/stella/internal/connections/oauth"
+	pkgplugins "github.com/CherryHQ/stella/pkg/plugins"
+	pkgsandbox "github.com/CherryHQ/stella/pkg/sandbox"
+)
+
+// refreshSession is a fake session whose env can be refreshed in place.
+type refreshSession struct {
+	pkgsandbox.Session
+	env       map[string]string
+	onRefresh func()
+}
+
+func (s *refreshSession) Policy() pkgsandbox.Policy { return pkgsandbox.Policy{Env: s.env} }
+
+func (s *refreshSession) RefreshEnv(updates map[string]string) {
+	if s.onRefresh != nil {
+		s.onRefresh()
+	}
+	maps.Copy(s.env, updates)
+}
+
+// staticSession is a fake session that cannot refresh its env (no EnvRefresher).
+type staticSession struct {
+	pkgsandbox.Session
+	env map[string]string
+}
+
+func (s *staticSession) Policy() pkgsandbox.Policy { return pkgsandbox.Policy{Env: s.env} }
+
+// larkSpecs is the standard set of oauth-sourced env specs for the lark provider.
+func larkSpecs() []pkgplugins.SessionEnvSpec {
+	return []pkgplugins.SessionEnvSpec{
+		{EnvVar: "LARK_TOKEN", Source: pkgplugins.SessionEnvSource("oauth.access_token"), OAuthProviderID: "lark"},
+	}
+}
+
+// oauthRefreshConfig wires a TokenManager over store with a single lark provider
+// whose token endpoint is tokenURL (empty when refresh is not expected). By
+// default it binds every oauth-sourced spec as if it had been injected from
+// OAuth at session creation; tests that need an unbound (vault-overridden) var
+// clear the binding afterwards.
+func oauthRefreshConfig(t *testing.T, store oauth.VaultStore, tokenURL string, specs []pkgplugins.SessionEnvSpec) Config {
+	t.Helper()
+	registry := oauth.NewProviderRegistry()
+	pc := oauth.ProviderConfig{ID: "lark", VaultKey: oauth.VaultKeyLark}
+	if tokenURL != "" {
+		pc.Flows = []oauth.ProviderFlowConfig{{Type: "authorization_code", TokenURL: tokenURL}}
+	}
+	registry.Register(pc)
+	tm := oauth.NewTokenManager(store)
+	tm.SetRegistry(registry)
+
+	bindings := NewOAuthEnvBindings()
+	names := make([]string, 0, len(specs))
+	for _, s := range specs {
+		if strings.HasPrefix(string(s.Source), "oauth.") {
+			names = append(names, s.EnvVar)
+		}
+	}
+	bindings.Set(names)
+
+	return Config{
+		UserID:           "u1",
+		AgentID:          "a1",
+		TokenManager:     tm,
+		SessionEnvSpecs:  specs,
+		OAuthEnvBindings: bindings,
+	}
+}
+
+// TestRefreshSessionEnvLiveRefresh drives the full live path: a near-expiry
+// bundle is refreshed through the TokenManager and the new access token lands in
+// the sandbox env in place of the stale one.
+func TestRefreshSessionEnvLiveRefresh(t *testing.T) {
+	ctx := context.Background()
+	store := newStubOAuthVaultStore()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "rotated_access_token",
+			"token_type":    "Bearer",
+			"expires_in":    7200,
+			"refresh_token": "next_refresh",
+		})
+	}))
+	defer srv.Close()
+
+	if err := oauth.SaveOAuthBundle(ctx, store, "u1", oauth.VaultKeyLark, oauth.OAuthBundle{
+		Version:         1,
+		ClientID:        "app",
+		ClientSecret:    "secret",
+		AccessToken:     "about_to_expire",
+		RefreshToken:    "shared_refresh",
+		AccessExpiresAt: time.Now().Add(10 * time.Minute), // below the 35m turn floor
+	}); err != nil {
+		t.Fatalf("SaveOAuthBundle: %v", err)
+	}
+
+	sess := &refreshSession{Session: pkgsandbox.NopSession(), env: map[string]string{"LARK_TOKEN": "about_to_expire"}}
+	cfg := oauthRefreshConfig(t, store, srv.URL+"/token", larkSpecs())
+
+	RefreshSessionEnv(ctx, sess, cfg)
+
+	if got := sess.env["LARK_TOKEN"]; got != "rotated_access_token" {
+		t.Fatalf("LARK_TOKEN = %q, want rotated_access_token", got)
+	}
+}
+
+// TestRefreshSessionEnvUpdatesRedaction asserts a rotated secret value is added
+// to SessionSecretValues while the value captured at session start is retained,
+// so tool output redaction covers both the old and new access token.
+func TestRefreshSessionEnvUpdatesRedaction(t *testing.T) {
+	ctx := context.Background()
+	store := newStubOAuthVaultStore()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "rotated_access_token",
+			"token_type":    "Bearer",
+			"expires_in":    7200,
+			"refresh_token": "next_refresh",
+		})
+	}))
+	defer srv.Close()
+
+	if err := oauth.SaveOAuthBundle(ctx, store, "u1", oauth.VaultKeyLark, oauth.OAuthBundle{
+		Version:         1,
+		ClientID:        "app",
+		ClientSecret:    "secret",
+		AccessToken:     "about_to_expire",
+		RefreshToken:    "shared_refresh",
+		AccessExpiresAt: time.Now().Add(10 * time.Minute),
+	}); err != nil {
+		t.Fatalf("SaveOAuthBundle: %v", err)
+	}
+
+	secrets := NewSessionSecretValues()
+	secrets.Set([]string{"about_to_expire"}) // captured at session start
+
+	sess := &refreshSession{Session: pkgsandbox.NopSession(), env: map[string]string{"LARK_TOKEN": "about_to_expire"}}
+	sess.onRefresh = func() {
+		if !slices.Contains(secrets.Values(), "rotated_access_token") {
+			t.Fatal("rotated token became executable before redaction was updated")
+		}
+	}
+	cfg := oauthRefreshConfig(t, store, srv.URL+"/token", larkSpecs())
+	cfg.SessionSecretValues = secrets
+
+	RefreshSessionEnv(ctx, sess, cfg)
+
+	values := secrets.Values()
+	if !slices.Contains(values, "about_to_expire") {
+		t.Errorf("redaction must retain the original secret; values = %v", values)
+	}
+	if !slices.Contains(values, "rotated_access_token") {
+		t.Errorf("redaction must add the rotated secret; values = %v", values)
+	}
+}
+
+// TestRefreshSessionEnvSkipsUnboundVar asserts a var that was NOT injected from
+// OAuth at creation (e.g. an explicit vault override of the same name) is left
+// untouched even though a fresh bundle exists — only recorded OAuth-origin vars
+// are live-refreshed.
+func TestRefreshSessionEnvSkipsUnboundVar(t *testing.T) {
+	ctx := context.Background()
+	store := newStubOAuthVaultStore()
+
+	if err := oauth.SaveOAuthBundle(ctx, store, "u1", oauth.VaultKeyLark, oauth.OAuthBundle{
+		Version:         1,
+		AccessToken:     "vault_oauth_token",
+		AccessExpiresAt: time.Now().Add(2 * time.Hour),
+	}); err != nil {
+		t.Fatalf("SaveOAuthBundle: %v", err)
+	}
+
+	sess := &refreshSession{Session: pkgsandbox.NopSession(), env: map[string]string{"LARK_TOKEN": "explicit_override"}}
+	cfg := oauthRefreshConfig(t, store, "", larkSpecs())
+	// Simulate injectSessionEnv skipping OAuth because the vault explicitly
+	// provided LARK_TOKEN: the var is never recorded as an OAuth binding.
+	cfg.OAuthEnvBindings.Set(nil)
+
+	RefreshSessionEnv(ctx, sess, cfg)
+
+	if got := sess.env["LARK_TOKEN"]; got != "explicit_override" {
+		t.Fatalf("unbound (vault-overridden) var must not be refreshed; LARK_TOKEN = %q", got)
+	}
+}
+
+// TestRefreshSessionEnvGroupNoOp asserts a group session never touches the human
+// OAuth vault: the env is left untouched even though a fresh bundle exists.
+func TestRefreshSessionEnvGroupNoOp(t *testing.T) {
+	ctx := context.Background()
+	store := newStubOAuthVaultStore()
+
+	if err := oauth.SaveOAuthBundle(ctx, store, "u1", oauth.VaultKeyLark, oauth.OAuthBundle{
+		Version:         1,
+		AccessToken:     "vault_token",
+		AccessExpiresAt: time.Now().Add(2 * time.Hour),
+	}); err != nil {
+		t.Fatalf("SaveOAuthBundle: %v", err)
+	}
+
+	sess := &refreshSession{Session: pkgsandbox.NopSession(), env: map[string]string{"LARK_TOKEN": "stale"}}
+	cfg := oauthRefreshConfig(t, store, "", larkSpecs())
+	cfg.GroupID = "g1"
+
+	RefreshSessionEnv(ctx, sess, cfg)
+
+	if got := sess.env["LARK_TOKEN"]; got != "stale" {
+		t.Fatalf("group session must not load the human vault; LARK_TOKEN = %q, want stale", got)
+	}
+}
+
+// TestRefreshSessionEnvPreservesOldEnvOnFailure asserts a resolution failure
+// (provider not connected) leaves the previous env value intact rather than
+// clearing it.
+func TestRefreshSessionEnvPreservesOldEnvOnFailure(t *testing.T) {
+	ctx := context.Background()
+	store := newStubOAuthVaultStore() // no bundle saved -> "has not connected"
+
+	sess := &refreshSession{Session: pkgsandbox.NopSession(), env: map[string]string{"LARK_TOKEN": "still_working"}}
+	cfg := oauthRefreshConfig(t, store, "", larkSpecs())
+
+	RefreshSessionEnv(ctx, sess, cfg)
+
+	if got := sess.env["LARK_TOKEN"]; got != "still_working" {
+		t.Fatalf("failed refresh must preserve old env; LARK_TOKEN = %q, want still_working", got)
+	}
+}
+
+// TestRefreshSessionEnvNoOpWithoutRefresher asserts a session that cannot refresh
+// its env is a safe no-op (no panic).
+func TestRefreshSessionEnvNoOpWithoutRefresher(t *testing.T) {
+	ctx := context.Background()
+	store := newStubOAuthVaultStore()
+	if err := oauth.SaveOAuthBundle(ctx, store, "u1", oauth.VaultKeyLark, oauth.OAuthBundle{
+		Version:         1,
+		AccessToken:     "vault_token",
+		AccessExpiresAt: time.Now().Add(2 * time.Hour),
+	}); err != nil {
+		t.Fatalf("SaveOAuthBundle: %v", err)
+	}
+
+	sess := &staticSession{Session: pkgsandbox.NopSession(), env: map[string]string{"LARK_TOKEN": "stale"}}
+	cfg := oauthRefreshConfig(t, store, "", larkSpecs())
+
+	RefreshSessionEnv(ctx, sess, cfg) // must not panic
+
+	if got := sess.env["LARK_TOKEN"]; got != "stale" {
+		t.Fatalf("static session env must be untouched; LARK_TOKEN = %q", got)
+	}
+}
+
+// TestRefreshSessionEnvNoOpWithoutOAuthSpecs asserts static-only specs never
+// trigger an env update.
+func TestRefreshSessionEnvNoOpWithoutOAuthSpecs(t *testing.T) {
+	ctx := context.Background()
+	store := newStubOAuthVaultStore()
+
+	sess := &refreshSession{Session: pkgsandbox.NopSession(), env: map[string]string{"FOO": "bar"}}
+	cfg := oauthRefreshConfig(t, store, "", []pkgplugins.SessionEnvSpec{
+		{EnvVar: "FOO", Source: pkgplugins.SessionEnvSourceStatic, Value: "changed"},
+	})
+
+	RefreshSessionEnv(ctx, sess, cfg)
+
+	if got := sess.env["FOO"]; got != "bar" {
+		t.Fatalf("static specs must not be refreshed; FOO = %q, want bar", got)
+	}
+}

--- a/internal/agent/sandbox/session_secret_values.go
+++ b/internal/agent/sandbox/session_secret_values.go
@@ -22,6 +22,32 @@ func (s *SessionSecretValues) Set(values []string) {
 	s.values = append([]string(nil), values...)
 }
 
+// Add appends values to the recorded set, retaining the existing ones and
+// skipping empties and duplicates. Live refresh uses it to register rotated
+// OAuth secret values (access/refresh tokens, client id) for redaction without
+// dropping the values captured at session start.
+func (s *SessionSecretValues) Add(values ...string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	seen := make(map[string]struct{}, len(s.values))
+	for _, v := range s.values {
+		seen[v] = struct{}{}
+	}
+	for _, v := range values {
+		if v == "" {
+			continue
+		}
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		s.values = append(s.values, v)
+	}
+}
+
 func (s *SessionSecretValues) Values() []string {
 	if s == nil {
 		return nil

--- a/internal/connections/oauth/registry.go
+++ b/internal/connections/oauth/registry.go
@@ -11,7 +11,15 @@ import (
 	"golang.org/x/oauth2"
 )
 
-const tokenRefreshWindow = 10 * time.Minute
+// defaultMinValidity is the remaining-lifetime floor a caller gets when it does
+// not request one explicitly: refresh (or reject) a token with less than this
+// left. Session-scoped callers pass a larger value derived from the chat timeout
+// (#722); short-lived callers (e.g. a one-shot GitHub API call) rely on this.
+const (
+	defaultMinValidity       = 10 * time.Minute
+	concurrentReloadAttempts = 5
+	concurrentReloadBaseWait = 25 * time.Millisecond
+)
 
 // ProviderFlowConfig holds the static configuration for one OAuth flow type
 // (authorization_code or device_code) read from manifest YAML.
@@ -102,12 +110,14 @@ func (r *ProviderRegistry) IDs() []string {
 	return ids
 }
 
-// GetToken loads the OAuthBundle for userID from vault. If the access token
-// expires within tokenRefreshWindow and a refresh token is available, it
-// proactively refreshes and persists the new bundle before returning. On
-// refresh failure the existing bundle is returned so callers can decide what
-// to do with a soon-to-expire or already-expired token.
-func (r *ProviderRegistry) GetToken(ctx context.Context, vs VaultStore, providerID string, userID string) (*OAuthBundle, error) {
+// GetToken loads the OAuthBundle for userID from vault and returns a token that
+// remains valid for at least minValidity (0 uses defaultMinValidity). If the
+// access token would fall below that floor and a refresh token is available it
+// proactively refreshes and persists the new bundle. On refresh failure it
+// briefly reloads the vault to consume a bundle another replica may have just
+// persisted, and never returns an expired or below-floor token — see
+// resolveToken.
+func (r *ProviderRegistry) GetToken(ctx context.Context, vs VaultStore, providerID string, userID string, minValidity time.Duration) (*OAuthBundle, error) {
 	cfg, ok := r.providerConfig(providerID)
 	if !ok {
 		return nil, fmt.Errorf("oauth: unknown provider: %s", providerID)
@@ -116,7 +126,7 @@ func (r *ProviderRegistry) GetToken(ctx context.Context, vs VaultStore, provider
 	if err != nil {
 		return nil, fmt.Errorf("oauth: get token for provider %s: %w", providerID, err)
 	}
-	return r.resolveToken(ctx, vs, cfg, providerID, userID, bundle)
+	return r.resolveToken(ctx, vs, cfg, providerID, userID, bundle, minValidity)
 }
 
 func (r *ProviderRegistry) providerConfig(providerID string) (ProviderConfig, bool) {
@@ -126,9 +136,17 @@ func (r *ProviderRegistry) providerConfig(providerID string) (ProviderConfig, bo
 	return cfg, ok
 }
 
-// resolveToken validates a loaded bundle and proactively refreshes it when the
-// access token is near expiry, persisting the refreshed bundle through vs.
-func (r *ProviderRegistry) resolveToken(ctx context.Context, vs VaultStore, cfg ProviderConfig, providerID string, userID string, bundle *OAuthBundle) (*OAuthBundle, error) {
+// resolveToken returns a token good for at least minValidity (0 uses
+// defaultMinValidity). It refreshes a bundle whose access token would fall below
+// that floor and persists the result through vs. If the refresh fails it reloads
+// the vault once to consume a bundle a concurrent replica may have just written,
+// rather than coordinating through a lock. It never returns an expired or
+// below-floor token: a still-valid bundle that clears the floor is returned,
+// otherwise an actionable error tells the caller to reconnect.
+func (r *ProviderRegistry) resolveToken(ctx context.Context, vs VaultStore, cfg ProviderConfig, providerID string, userID string, bundle *OAuthBundle, minValidity time.Duration) (*OAuthBundle, error) {
+	if minValidity <= 0 {
+		minValidity = defaultMinValidity
+	}
 	if bundle == nil {
 		return nil, fmt.Errorf("oauth: user %s has not connected %s", userID, providerID)
 	}
@@ -136,22 +154,37 @@ func (r *ProviderRegistry) resolveToken(ctx context.Context, vs VaultStore, cfg 
 		return nil, fmt.Errorf("oauth: empty access token in vault for user %s provider %s", userID, providerID)
 	}
 
-	if needsRefresh(bundle) {
+	if needsRefresh(bundle, minValidity) {
 		refreshed, err := r.tryRefresh(ctx, vs, cfg, userID, bundle)
-		if err != nil {
-			slog.Warn("oauth: token refresh failed, using existing token",
-				"provider", providerID, "user_id", userID, "error", err)
-		} else {
-			return refreshed, nil
+		if err == nil {
+			if meetsMinValidity(refreshed, minValidity) {
+				return refreshed, nil
+			}
+			err = fmt.Errorf("provider returned a token below the required %s validity", minValidity)
+		}
+		// A concurrent replica sharing this user's vault may have rotated the
+		// refresh token and be about to persist a fresh bundle, which makes our
+		// reused refresh token fail. Briefly poll the vault for that winner's
+		// bundle instead of introducing a distributed lock.
+		slog.Warn("oauth: token refresh failed, checking vault for a concurrently refreshed bundle",
+			"provider", providerID, "user_id", userID, "error", err)
+		if reloaded := r.reloadUsable(ctx, vs, cfg, userID, minValidity); reloaded != nil {
+			return reloaded, nil
 		}
 	}
 
-	return bundle, nil
+	// Never hand back a token that can't cover minValidity — that includes an
+	// already-expired one. A still-valid token that clears the floor (e.g. one
+	// with no known expiry, or refreshed by another path) is fine to serve.
+	if meetsMinValidity(bundle, minValidity) {
+		return bundle, nil
+	}
+	return nil, fmt.Errorf("oauth: provider %s token for user %s is expired or below the required %s validity and could not be refreshed; reconnect the provider", providerID, userID, minValidity)
 }
 
-// needsRefresh returns true when the access token expires within
-// tokenRefreshWindow and the bundle has a usable refresh token.
-func needsRefresh(bundle *OAuthBundle) bool {
+// needsRefresh returns true when the access token would drop below minValidity
+// and the bundle has a usable refresh token to trade for a new one.
+func needsRefresh(bundle *OAuthBundle, minValidity time.Duration) bool {
 	if bundle.RefreshToken == "" {
 		return false
 	}
@@ -161,7 +194,43 @@ func needsRefresh(bundle *OAuthBundle) bool {
 	if !bundle.RefreshExpiresAt.IsZero() && bundle.RefreshExpiresAt.Before(time.Now()) {
 		return false // refresh token itself has expired
 	}
-	return time.Until(bundle.AccessExpiresAt) < tokenRefreshWindow
+	return time.Until(bundle.AccessExpiresAt) < minValidity
+}
+
+// meetsMinValidity reports whether the bundle's access token stays valid for at
+// least minValidity. A bundle with no known expiry (AccessExpiresAt zero) is
+// treated as long-lived — e.g. a GitHub OAuth-app token — and always qualifies.
+func meetsMinValidity(bundle *OAuthBundle, minValidity time.Duration) bool {
+	if bundle.AccessExpiresAt.IsZero() {
+		return true
+	}
+	return time.Until(bundle.AccessExpiresAt) >= minValidity
+}
+
+// reloadUsable briefly polls the vault and returns only a bundle that clears
+// minValidity. A refresh loser can receive invalid_grant just before the winning
+// replica commits its rotated bundle, so one immediate read is racy. The bounded
+// exponential wait keeps that convergence path lock-free and honors ctx.
+func (r *ProviderRegistry) reloadUsable(ctx context.Context, vs VaultStore, cfg ProviderConfig, userID string, minValidity time.Duration) *OAuthBundle {
+	for attempt := range concurrentReloadAttempts {
+		reloaded, err := LoadOAuthBundle(ctx, vs, userID, cfg.VaultKey)
+		if err == nil && reloaded != nil && reloaded.AccessToken != "" && meetsMinValidity(reloaded, minValidity) {
+			return reloaded
+		}
+		if attempt == concurrentReloadAttempts-1 {
+			break
+		}
+
+		wait := concurrentReloadBaseWait << attempt
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil
+		case <-timer.C:
+		}
+	}
+	return nil
 }
 
 // tryRefresh exchanges the bundle's refresh token for a new access token,

--- a/internal/connections/oauth/registry_test.go
+++ b/internal/connections/oauth/registry_test.go
@@ -115,7 +115,7 @@ func TestNeedsRefresh(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := needsRefresh(&tt.bundle)
+			got := needsRefresh(&tt.bundle, defaultMinValidity)
 			if got != tt.want {
 				t.Errorf("needsRefresh() = %v, want %v", got, tt.want)
 			}
@@ -161,7 +161,7 @@ func TestGetToken_RefreshesNearExpiry(t *testing.T) {
 		t.Fatalf("SaveOAuthBundle: %v", err)
 	}
 
-	got, err := reg.GetToken(ctx, vs, "testprovider", userID)
+	got, err := reg.GetToken(ctx, vs, "testprovider", userID, 0)
 	if err != nil {
 		t.Fatalf("GetToken: %v", err)
 	}
@@ -216,7 +216,7 @@ func TestGetToken_SkipsRefreshWhenFreshToken(t *testing.T) {
 		t.Fatalf("SaveOAuthBundle: %v", err)
 	}
 
-	got, err := reg.GetToken(ctx, vs, "freshprovider", userID)
+	got, err := reg.GetToken(ctx, vs, "freshprovider", userID, 0)
 	if err != nil {
 		t.Fatalf("GetToken: %v", err)
 	}
@@ -228,7 +228,10 @@ func TestGetToken_SkipsRefreshWhenFreshToken(t *testing.T) {
 	}
 }
 
-func TestGetToken_RefreshFailureFallsBackToExisting(t *testing.T) {
+func TestGetToken_RefreshFailureBelowMinValidityErrors(t *testing.T) {
+	// A refresh that fails must not fall back to a token that can no longer cover
+	// the caller's minimum validity — the tool would get a credential that dies
+	// mid-turn. The caller gets an actionable error instead (#722).
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "bad_refresh_token", http.StatusBadRequest)
 	}))
@@ -253,19 +256,200 @@ func TestGetToken_RefreshFailureFallsBackToExisting(t *testing.T) {
 		ClientSecret:    "csecret",
 		AccessToken:     "expiring_token",
 		RefreshToken:    "bad_refresh",
-		AccessExpiresAt: time.Now().Add(2 * time.Minute), // inside window
+		AccessExpiresAt: time.Now().Add(2 * time.Minute), // below the 10-min floor
 	}
 	if err := SaveOAuthBundle(ctx, vs, userID, "FAIL_OAUTH", bundle); err != nil {
 		t.Fatalf("SaveOAuthBundle: %v", err)
 	}
 
-	got, err := reg.GetToken(ctx, vs, "failprovider", userID)
-	if err != nil {
-		t.Fatalf("GetToken should not error on refresh failure: %v", err)
+	got, err := reg.GetToken(ctx, vs, "failprovider", userID, 0)
+	if err == nil {
+		t.Fatalf("GetToken should error when refresh fails and the token is below min-validity; got %+v", got)
 	}
-	// Falls back to original token.
-	if got.AccessToken != "expiring_token" {
-		t.Errorf("AccessToken = %q, want expiring_token", got.AccessToken)
+}
+
+func TestGetToken_ExpiredTokenNeverReturned(t *testing.T) {
+	// An already-expired token with no way to refresh must surface as an error,
+	// never be returned as a usable credential (#722).
+	vs := newMockVaultStore()
+	ctx := context.Background()
+	userID := "9"
+
+	reg := NewProviderRegistry()
+	reg.Register(ProviderConfig{ID: "expprovider", VaultKey: "EXP_OAUTH"})
+
+	bundle := OAuthBundle{
+		Version:         1,
+		AccessToken:     "dead_token",
+		AccessExpiresAt: time.Now().Add(-1 * time.Minute), // already expired
+		// No refresh token: nothing to trade for a new access token.
+	}
+	if err := SaveOAuthBundle(ctx, vs, userID, "EXP_OAUTH", bundle); err != nil {
+		t.Fatalf("SaveOAuthBundle: %v", err)
+	}
+
+	got, err := reg.GetToken(ctx, vs, "expprovider", userID, 0)
+	if err == nil {
+		t.Fatalf("GetToken should error for an expired token; got %+v", got)
+	}
+}
+
+func TestGetToken_ConcurrentReplicaReloadWins(t *testing.T) {
+	// When a refresh fails because another replica already rotated the refresh
+	// token, GetToken must consume the fresh bundle that replica persisted rather
+	// than error or serve the stale token (#722). The token endpoint stands in for
+	// the concurrent winner: it persists a fresh bundle to the shared vault, then
+	// rejects our reused refresh token.
+	vs := newMockVaultStore()
+	ctx := context.Background()
+	userID := "7"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Return the loser's invalid_grant before the winner persists, matching the
+		// real ordering that makes a single immediate reload insufficient.
+		go func() {
+			time.Sleep(40 * time.Millisecond)
+			winner := OAuthBundle{
+				Version:         1,
+				ClientID:        "cid",
+				ClientSecret:    "csecret",
+				AccessToken:     "winner_access_token",
+				RefreshToken:    "rotated_refresh",
+				AccessExpiresAt: time.Now().Add(2 * time.Hour),
+			}
+			_ = SaveOAuthBundle(ctx, vs, userID, "RACE_OAUTH", winner)
+		}()
+		http.Error(w, "refresh_token_reused", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	reg := NewProviderRegistry()
+	reg.Register(ProviderConfig{
+		ID:       "raceprovider",
+		VaultKey: "RACE_OAUTH",
+		Flows: []ProviderFlowConfig{
+			{Type: "authorization_code", TokenURL: srv.URL + "/token"},
+		},
+	})
+
+	stale := OAuthBundle{
+		Version:         1,
+		ClientID:        "cid",
+		ClientSecret:    "csecret",
+		AccessToken:     "stale_access_token",
+		RefreshToken:    "shared_refresh",
+		AccessExpiresAt: time.Now().Add(1 * time.Minute), // below floor -> triggers refresh
+	}
+	if err := SaveOAuthBundle(ctx, vs, userID, "RACE_OAUTH", stale); err != nil {
+		t.Fatalf("SaveOAuthBundle: %v", err)
+	}
+
+	got, err := reg.GetToken(ctx, vs, "raceprovider", userID, 0)
+	if err != nil {
+		t.Fatalf("GetToken should consume the concurrently-refreshed bundle: %v", err)
+	}
+	if got.AccessToken != "winner_access_token" {
+		t.Errorf("AccessToken = %q, want winner_access_token (reloaded from vault)", got.AccessToken)
+	}
+}
+
+func TestGetToken_MinValidityCoversChatTimeout(t *testing.T) {
+	// A token comfortably outside the fixed 10-min window must still be refreshed
+	// when the caller demands a longer validity than a single chat turn (#722):
+	// the old fixed window could not guarantee a token outlived the turn.
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "renewed_for_turn",
+			"token_type":    "Bearer",
+			"expires_in":    7200,
+			"refresh_token": "next_refresh",
+		})
+	}))
+	defer srv.Close()
+
+	vs := newMockVaultStore()
+	ctx := context.Background()
+	userID := "8"
+
+	reg := NewProviderRegistry()
+	reg.Register(ProviderConfig{
+		ID:       "turnprovider",
+		VaultKey: "TURN_OAUTH",
+		Flows: []ProviderFlowConfig{
+			{Type: "authorization_code", TokenURL: srv.URL + "/token", AuthStyle: oauth2.AuthStyleInParams},
+		},
+	})
+
+	bundle := OAuthBundle{
+		Version:         1,
+		ClientID:        "cid",
+		ClientSecret:    "csecret",
+		AccessToken:     "valid_for_20m",
+		RefreshToken:    "ref",
+		AccessExpiresAt: time.Now().Add(20 * time.Minute), // outside 10m, inside a 35m turn floor
+	}
+	if err := SaveOAuthBundle(ctx, vs, userID, "TURN_OAUTH", bundle); err != nil {
+		t.Fatalf("SaveOAuthBundle: %v", err)
+	}
+
+	// 10-min default leaves the 20-min token untouched.
+	got, err := reg.GetToken(ctx, vs, "turnprovider", userID, 0)
+	if err != nil {
+		t.Fatalf("GetToken (default validity): %v", err)
+	}
+	if called || got.AccessToken != "valid_for_20m" {
+		t.Fatalf("default validity should not refresh a 20-min token; called=%v token=%q", called, got.AccessToken)
+	}
+
+	// A 35-min floor (30m turn + 5m margin) forces a refresh.
+	got, err = reg.GetToken(ctx, vs, "turnprovider", userID, 35*time.Minute)
+	if err != nil {
+		t.Fatalf("GetToken (turn validity): %v", err)
+	}
+	if !called || got.AccessToken != "renewed_for_turn" {
+		t.Fatalf("turn validity should refresh; called=%v token=%q", called, got.AccessToken)
+	}
+}
+
+func TestGetToken_RejectsRefreshedTokenBelowMinValidity(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "still_too_short",
+			"token_type":    "Bearer",
+			"expires_in":    300,
+			"refresh_token": "next_refresh",
+		})
+	}))
+	defer srv.Close()
+
+	vs := newMockVaultStore()
+	ctx := context.Background()
+	userID := "10"
+	reg := NewProviderRegistry()
+	reg.Register(ProviderConfig{
+		ID:       "shortprovider",
+		VaultKey: "SHORT_OAUTH",
+		Flows: []ProviderFlowConfig{{
+			Type: "authorization_code", TokenURL: srv.URL + "/token", AuthStyle: oauth2.AuthStyleInParams,
+		}},
+	})
+	if err := SaveOAuthBundle(ctx, vs, userID, "SHORT_OAUTH", OAuthBundle{
+		Version:         1,
+		ClientID:        "cid",
+		ClientSecret:    "secret",
+		AccessToken:     "expiring",
+		RefreshToken:    "refresh",
+		AccessExpiresAt: time.Now().Add(time.Minute),
+	}); err != nil {
+		t.Fatalf("SaveOAuthBundle: %v", err)
+	}
+
+	if got, err := reg.GetToken(ctx, vs, "shortprovider", userID, 35*time.Minute); err == nil {
+		t.Fatalf("GetToken should reject a refreshed token below min-validity; got %+v", got)
 	}
 }
 
@@ -300,7 +484,7 @@ func TestGetToken_NoRefreshForTokenWithoutExpiry(t *testing.T) {
 		t.Fatalf("SaveOAuthBundle: %v", err)
 	}
 
-	got, err := reg.GetToken(ctx, vs, "github", userID)
+	got, err := reg.GetToken(ctx, vs, "github", userID, 0)
 	if err != nil {
 		t.Fatalf("GetToken: %v", err)
 	}

--- a/internal/connections/oauth/token_manager.go
+++ b/internal/connections/oauth/token_manager.go
@@ -3,6 +3,7 @@ package oauth
 import (
 	"context"
 	"fmt"
+	"time"
 )
 
 // TokenManager provides host-side token validation and reads from/writes to
@@ -22,11 +23,12 @@ func (m *TokenManager) SetRegistry(r *ProviderRegistry) {
 	m.registry = r
 }
 
-// GetOAuthToken returns the generic OAuthBundle for providerID and userID.
-// It delegates to the ProviderRegistry to load the bundle from vault.
-func (m *TokenManager) GetOAuthToken(ctx context.Context, providerID string, userID string) (*OAuthBundle, error) {
+// GetOAuthToken returns the generic OAuthBundle for providerID and userID,
+// guaranteed valid for at least minValidity (0 uses the registry default). It
+// delegates to the ProviderRegistry to load, refresh, and validate the bundle.
+func (m *TokenManager) GetOAuthToken(ctx context.Context, providerID string, userID string, minValidity time.Duration) (*OAuthBundle, error) {
 	if m.registry == nil {
 		return nil, fmt.Errorf("oauth: provider registry not set")
 	}
-	return m.registry.GetToken(ctx, m.vs, providerID, userID)
+	return m.registry.GetToken(ctx, m.vs, providerID, userID, minValidity)
 }

--- a/internal/connections/oauth/token_manager_test.go
+++ b/internal/connections/oauth/token_manager_test.go
@@ -35,7 +35,7 @@ func TestGetOAuthToken_Success(t *testing.T) {
 		t.Fatalf("SaveOAuthBundle: %v", err)
 	}
 
-	got, err := tm.GetOAuthToken(ctx, "github", userID)
+	got, err := tm.GetOAuthToken(ctx, "github", userID, 0)
 	if err != nil {
 		t.Fatalf("GetOAuthToken: %v", err)
 	}
@@ -54,7 +54,7 @@ func TestGetOAuthToken_NoBundle(t *testing.T) {
 	tm := NewTokenManager(vs)
 	tm.SetRegistry(registry)
 
-	_, err := tm.GetOAuthToken(ctx, "github", userID)
+	_, err := tm.GetOAuthToken(ctx, "github", userID, 0)
 	if err == nil {
 		t.Fatal("GetOAuthToken expected error for missing bundle")
 	}
@@ -81,7 +81,7 @@ func TestGetOAuthToken_EmptyToken(t *testing.T) {
 		t.Fatalf("SaveOAuthBundle: %v", err)
 	}
 
-	_, err := tm.GetOAuthToken(ctx, "github", userID)
+	_, err := tm.GetOAuthToken(ctx, "github", userID, 0)
 	if err == nil {
 		t.Fatal("GetOAuthToken expected error for empty token")
 	}
@@ -94,7 +94,7 @@ func TestGetOAuthToken_NoRegistry(t *testing.T) {
 	vs := newMockVaultStore()
 	ctx := context.Background()
 
-	_, err := NewTokenManager(vs).GetOAuthToken(ctx, "github", "1")
+	_, err := NewTokenManager(vs).GetOAuthToken(ctx, "github", "1", 0)
 	if err == nil {
 		t.Fatal("GetOAuthToken expected error when registry not set")
 	}

--- a/internal/connections/oauth/vault_test.go
+++ b/internal/connections/oauth/vault_test.go
@@ -2,12 +2,16 @@ package oauth
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 )
 
-// mockVaultStore is a simple in-memory VaultStore for testing.
+// mockVaultStore is a simple in-memory VaultStore for testing. Its mutex lets the
+// concurrent-reload test write a winning bundle from one goroutine while GetToken
+// reloads from another.
 type mockVaultStore struct {
+	mu   sync.RWMutex
 	data map[string]string // keyed by "userID:name"
 }
 
@@ -20,16 +24,22 @@ func (m *mockVaultStore) key(userID string, name string) string {
 }
 
 func (m *mockVaultStore) Set(_ context.Context, userID string, name string, plaintext string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.data[m.key(userID, name)] = plaintext
 	return nil
 }
 
 func (m *mockVaultStore) Delete(_ context.Context, userID string, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	delete(m.data, m.key(userID, name))
 	return nil
 }
 
 func (m *mockVaultStore) Lookup(_ context.Context, userID string, name string) (string, bool, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	value, ok := m.data[m.key(userID, name)]
 	return value, ok, nil
 }

--- a/internal/connections/service.go
+++ b/internal/connections/service.go
@@ -384,7 +384,7 @@ func (s *Service) GitHubAccessToken(ctx context.Context, userID string) string {
 	if s.registry == nil || s.vaultSvc == nil {
 		return ""
 	}
-	bundle, err := s.registry.GetToken(ctx, s.vaultSvc, string(oauth.ProviderGitHub), userID)
+	bundle, err := s.registry.GetToken(ctx, s.vaultSvc, string(oauth.ProviderGitHub), userID, 0)
 	if err != nil {
 		// Not-connected surfaces here as an error too; log at debug so a genuine
 		// vault/refresh failure leaves a breadcrumb without spamming on the common

--- a/pkg/sandbox/resilient.go
+++ b/pkg/sandbox/resilient.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
 	"sync"
 )
 
@@ -16,11 +17,12 @@ type SessionCreator func(ctx context.Context) (Session, error)
 // sandbox process crashed). Explicit Close calls are permanent — no recreation
 // after that.
 type ResilientSession struct {
-	create SessionCreator
-	mu     sync.Mutex
-	inner  Session
-	closed bool
-	log    *slog.Logger
+	create     SessionCreator
+	mu         sync.Mutex
+	inner      Session
+	envUpdates map[string]string
+	closed     bool
+	log        *slog.Logger
 }
 
 // NewResilientSession wraps an existing session with auto-recreation support.
@@ -53,17 +55,24 @@ func (r *ResilientSession) ensureAlive(ctx context.Context) (Session, error) {
 	}
 
 	r.inner = session
+	// The creator rebuilds the session from current credential state. Discard
+	// overlays applied to the dead inner session so stale values cannot override
+	// that newly built environment.
+	r.envUpdates = nil
 	return session, nil
 }
 
 func (r *ResilientSession) Policy() Policy {
 	r.mu.Lock()
 	s := r.inner
+	updates := maps.Clone(r.envUpdates)
 	r.mu.Unlock()
 	if s == nil {
 		return Policy{}
 	}
-	return s.Policy()
+	policy := s.Policy()
+	policy.Env = mergeEnvUpdates(policy.Env, updates)
+	return policy
 }
 
 func (r *ResilientSession) WorkingDir() string {
@@ -115,6 +124,10 @@ func (r *ResilientSession) Exec(ctx context.Context, command string, opts ExecOp
 	if err != nil {
 		return ExecResult{}, err
 	}
+	r.mu.Lock()
+	updates := maps.Clone(r.envUpdates)
+	r.mu.Unlock()
+	opts.Env = mergeEnvUpdates(updates, opts.Env)
 	return s.Exec(ctx, command, opts)
 }
 
@@ -123,7 +136,36 @@ func (r *ResilientSession) StartProcess(ctx context.Context, req ProcessRequest)
 	if err != nil {
 		return nil, err
 	}
+	r.mu.Lock()
+	updates := maps.Clone(r.envUpdates)
+	r.mu.Unlock()
+	req.Env = mergeEnvUpdates(updates, req.Env)
 	return s.StartProcess(ctx, req)
+}
+
+// RefreshEnv overlays injected env entries for subsequent Exec and StartProcess
+// calls. Keeping the overlay at this wrapper boundary makes credential rotation
+// backend-independent. A recreated inner session is built from current state and
+// clears the overlay in ensureAlive.
+func (r *ResilientSession) RefreshEnv(updates map[string]string) {
+	if len(updates) == 0 {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.envUpdates = mergeEnvUpdates(r.envUpdates, updates)
+}
+
+func mergeEnvUpdates(base, overrides map[string]string) map[string]string {
+	if len(base) == 0 && len(overrides) == 0 {
+		return nil
+	}
+	merged := maps.Clone(base)
+	if merged == nil {
+		merged = make(map[string]string, len(overrides))
+	}
+	maps.Copy(merged, overrides)
+	return merged
 }
 
 func (r *ResilientSession) ResolvePath(path string) (string, error) {

--- a/pkg/sandbox/resilient_test.go
+++ b/pkg/sandbox/resilient_test.go
@@ -3,6 +3,7 @@ package sandbox
 import (
 	"context"
 	"errors"
+	"maps"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -10,11 +11,13 @@ import (
 
 // mockSession is a controllable Session for testing ResilientSession.
 type mockSession struct {
-	mu        sync.Mutex
-	alive     bool
-	closed    bool
-	execCount int
-	done      chan struct{}
+	mu             sync.Mutex
+	alive          bool
+	closed         bool
+	execCount      int
+	lastExecEnv    map[string]string
+	lastProcessEnv map[string]string
+	done           chan struct{}
 }
 
 func newMockSession() *mockSession {
@@ -39,14 +42,18 @@ func (m *mockSession) Close() error {
 	return nil
 }
 
-func (m *mockSession) Exec(_ context.Context, _ string, _ ExecOptions) (ExecResult, error) {
+func (m *mockSession) Exec(_ context.Context, _ string, opts ExecOptions) (ExecResult, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.execCount++
+	m.lastExecEnv = maps.Clone(opts.Env)
 	return ExecResult{Stdout: "ok"}, nil
 }
 
-func (m *mockSession) StartProcess(_ context.Context, _ ProcessRequest) (ProcessHandle, error) {
+func (m *mockSession) StartProcess(_ context.Context, req ProcessRequest) (ProcessHandle, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.lastProcessEnv = maps.Clone(req.Env)
 	return nil, nil
 }
 
@@ -69,6 +76,32 @@ func TestResilientSession_ExecUsesExistingSession(t *testing.T) {
 	}
 }
 
+func TestResilientSessionRefreshEnvOverlaysSubsequentProcesses(t *testing.T) {
+	inner := newMockSession()
+	rs := NewResilientSession(inner, nil)
+	rs.RefreshEnv(map[string]string{"TOKEN": "new", "CALLER": "overlay"})
+
+	if _, err := rs.Exec(context.Background(), "true", ExecOptions{Env: map[string]string{"CALLER": "exec"}}); err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if got := inner.lastExecEnv["TOKEN"]; got != "new" {
+		t.Fatalf("Exec TOKEN = %q, want new", got)
+	}
+	if got := inner.lastExecEnv["CALLER"]; got != "exec" {
+		t.Fatalf("per-exec env must win; CALLER = %q", got)
+	}
+
+	if _, err := rs.StartProcess(context.Background(), ProcessRequest{}); err != nil {
+		t.Fatalf("StartProcess: %v", err)
+	}
+	if got := inner.lastProcessEnv["TOKEN"]; got != "new" {
+		t.Fatalf("StartProcess TOKEN = %q, want new", got)
+	}
+	if got := rs.Policy().Env["TOKEN"]; got != "new" {
+		t.Fatalf("Policy TOKEN = %q, want new", got)
+	}
+}
+
 func TestResilientSession_RecreatesAfterClose(t *testing.T) {
 	first := newMockSession()
 	second := newMockSession()
@@ -78,8 +111,10 @@ func TestResilientSession_RecreatesAfterClose(t *testing.T) {
 		createCount.Add(1)
 		return second, nil
 	})
+	rs.RefreshEnv(map[string]string{"TOKEN": "old-overlay"})
 
-	// Close the underlying session (simulates reaper).
+	// Close the underlying session (simulates reaper). The recreated session is
+	// built from current state, so the dead session's overlay must be discarded.
 	_ = first.Close()
 
 	result, err := rs.Exec(context.Background(), "echo hi", ExecOptions{})
@@ -91,6 +126,9 @@ func TestResilientSession_RecreatesAfterClose(t *testing.T) {
 	}
 	if createCount.Load() != 1 {
 		t.Errorf("create called %d times, want 1", createCount.Load())
+	}
+	if _, ok := second.lastExecEnv["TOKEN"]; ok {
+		t.Fatal("recreated session inherited a stale env overlay")
 	}
 
 	// Second exec should reuse the recreated session.

--- a/pkg/sandbox/session.go
+++ b/pkg/sandbox/session.go
@@ -33,6 +33,15 @@ type Session interface {
 // New code should use Session directly.
 type Host = Session
 
+// EnvRefresher is implemented by sessions whose injected environment can be
+// updated after creation, so a caller can rotate a credential (e.g. an expiring
+// OAuth access token) without tearing down and recreating the session. Updates
+// are applied atomically and are visible to every subsequent Exec/StartProcess.
+// Sessions that don't run real processes (e.g. the no-op session) may omit it.
+type EnvRefresher interface {
+	RefreshEnv(updates map[string]string)
+}
+
 type ExecOptions struct {
 	Cwd     string
 	Env     map[string]string


### PR DESCRIPTION
## What
Port the long-lived OAuth session refresh fix from the v0.50.6 patch line to `main`.

## Why
Cached agent sessions retain OAuth-derived environment snapshots. Without the patch, a token can expire while the runner remains alive and subsequent tool processes continue receiving the stale value.

## How
- Require OAuth tokens to cover the configured chat timeout plus a safety margin and refresh them before each turn.
- Use a backend-independent environment overlay in `ResilientSession` for subsequent `Exec` and `StartProcess` calls; discard overlays when a dead inner session is recreated from current state.
- Record which env vars were actually injected from OAuth so live refresh never overwrites explicit vault overrides.
- Register rotated secrets for output redaction before making them executable.
- Preserve the bounded, lock-free multi-replica convergence path from #730: refresh losers poll briefly for the winner's persisted bundle and never return expired tokens.
- Preserve group-session isolation and add regression coverage for env origin, redaction, overlay precedence/recreation, timeout-derived validity, and concurrent refresh.

## Refs
- Issue: #722
- Patch PR: #730
- Released in: v0.50.6
- Verification: `mise run format && mise run build && mise run test`
- Cross-platform: `GOOS=windows GOARCH=amd64 go build -o dist/bin/stellad-windows-amd64.exe ./cmd/stellad`
