### PR TITLE
fix(oauth): request Feishu permission-setting scopes for v0.50.7

### DIFF
--- a/resources/oauth.yaml
+++ b/resources/oauth.yaml
@@ -269,6 +269,8 @@ oauth_providers:
       - docs:document:export
       - docs:document:import
       - docs:event:subscribe
+      - docs:permission.setting:read
+      - docs:permission.setting:write_only
       - docs:permission.member:auth
       - docs:permission.member:create
       - docs:permission.member:transfer


### PR DESCRIPTION
## What

Backport the Feishu OAuth permission-setting scopes onto the hotfix line based exactly on `v0.50.6`:

- `docs:permission.setting:read`
- `docs:permission.setting:write_only`

## Why

The expense reimbursement setup flow closes and verifies Base public sharing. Stella must request these scopes before the `v0.50.7` hotfix tag is cut.

## Release shape

`release-0.50.7` points at `v0.50.6`; after this PR is merged, `v0.50.7` can be tagged from the resulting release-branch head.

## Verification

- Parsed `resources/oauth.yaml` and asserted both scopes exist only in the `feishu` provider with no duplicates
- `git diff --check`
- `mise run generate`
- `mise run format`
- `mise run build`
- `mise run test`

Refs #736