### PR TITLE
fix(oauth): request Feishu permission-setting scopes

### DIFF
--- a/resources/oauth.yaml
+++ b/resources/oauth.yaml
@@ -269,6 +269,8 @@ oauth_providers:
       - docs:document:export
       - docs:document:import
       - docs:event:subscribe
+      - docs:permission.setting:read
+      - docs:permission.setting:write_only
       - docs:permission.member:auth
       - docs:permission.member:create
       - docs:permission.member:transfer


### PR DESCRIPTION
## What

Add the Feishu OAuth scopes required to read and update document public-sharing settings:

- `docs:permission.setting:read`
- `docs:permission.setting:write_only`

## Why

The expense reimbursement setup flow closes and verifies Base public sharing. Its preflight already requires these scopes, but Stella did not request them during Feishu OAuth authorization.

## Verification

- Parsed `resources/oauth.yaml` and asserted both scopes exist only in the `feishu` provider with no duplicates
- `git diff --check`
- `mise run format`
- `mise run build`
- `mise run test`

Refs #736