### PR TITLE
chore: move reflect 531 eval reports out of gitignored dist/

### DIFF
--- a/docs/test-reports/reflect/issue-531/2026-07-08-e2e-eval.zh.md
+++ b/docs/test-reports/reflect/issue-531/2026-07-08-e2e-eval.zh.md
@@ -55,11 +55,12 @@
    - content include / exclude
    - expected count
 10. 跑 LLM judge，评分维度为：
-   - `action_fit`
-   - `related_usefulness`
-   - `write_accuracy`
-   - `content_completeness`
-   - `no_unrelated_content`
+
+- `action_fit`
+- `related_usefulness`
+- `write_accuracy`
+- `content_completeness`
+- `no_unrelated_content`
 
 Judge 通过标准：`verdict=pass` 且每项分数 >= 3。
 
@@ -80,25 +81,25 @@ env OPENAI_BASE_URL=... OPENAI_API_KEY=... \
 
 最终 expanded e2e 数据集共 8 个 case：
 
-| 分组 | case | 覆盖点 |
-|---|---|---|
-| `e2e_fact_single` | `e2e_fact_soul_create_concise_chinese` | 用户明确要求未来回复风格，生成 agent/soul fact，并在无 current singleton 时 `create_singleton` |
-| `e2e_fact_single` | `e2e_fact_world_replace_endpoint` | world fact 替换旧 endpoint fact，走 related discovery + `replace_many` |
-| `e2e_fact_single` | `e2e_fact_negative_no_durable_write` | 无 durable fact，fact line 应 no-write |
-| `e2e_skill_single` | `e2e_skill_create_verified_provider_workflow` | 显式保存 provider stream debugging workflow，skill create |
-| `e2e_skill_single` | `e2e_skill_negative_simple_advice_no_write` | 一次性建议，不应生成 skill |
-| `e2e_mixed_verified` | `e2e_mixed_fact_replace_skill_patch_verified` | 同一 review window 中 fact replace + skill patch |
-| `e2e_mixed_verified` | `e2e_mixed_wsl_fact_and_skill_delta` | 同一 review window 中 WSL world fact create + existing WSL skill patch |
-| `e2e_stress` | `e2e_stress_multi_signal_large_catalog` | 多 fact、多 skill、大 catalog、fact replace_many、skill patch/create |
+| 分组                 | case                                          | 覆盖点                                                                                         |
+| -------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `e2e_fact_single`    | `e2e_fact_soul_create_concise_chinese`        | 用户明确要求未来回复风格，生成 agent/soul fact，并在无 current singleton 时 `create_singleton` |
+| `e2e_fact_single`    | `e2e_fact_world_replace_endpoint`             | world fact 替换旧 endpoint fact，走 related discovery + `replace_many`                         |
+| `e2e_fact_single`    | `e2e_fact_negative_no_durable_write`          | 无 durable fact，fact line 应 no-write                                                         |
+| `e2e_skill_single`   | `e2e_skill_create_verified_provider_workflow` | 显式保存 provider stream debugging workflow，skill create                                      |
+| `e2e_skill_single`   | `e2e_skill_negative_simple_advice_no_write`   | 一次性建议，不应生成 skill                                                                     |
+| `e2e_mixed_verified` | `e2e_mixed_fact_replace_skill_patch_verified` | 同一 review window 中 fact replace + skill patch                                               |
+| `e2e_mixed_verified` | `e2e_mixed_wsl_fact_and_skill_delta`          | 同一 review window 中 WSL world fact create + existing WSL skill patch                         |
+| `e2e_stress`         | `e2e_stress_multi_signal_large_catalog`       | 多 fact、多 skill、大 catalog、fact replace_many、skill patch/create                           |
 
 Stress case 规模：
 
-| 类型 | 数量 | 内容 |
-|---|---:|---|
-| prior facts | 10 | enterprise endpoint、audit output、provider stream、WSL proxy、PR template、OpenAPI、sqlc、browser canvas 等 |
-| prior skills | 5 | WSL proxy、provider stream、PR writing、OpenAPI、browser network |
-| fresh fact signals | 2 | enterprise admin endpoint 统一、audit report 输出目录 |
-| fresh skill signals | 2 | WSL package-download debugging workflow、browser visual verification workflow |
+| 类型                | 数量 | 内容                                                                                                         |
+| ------------------- | ---: | ------------------------------------------------------------------------------------------------------------ |
+| prior facts         |   10 | enterprise endpoint、audit output、provider stream、WSL proxy、PR template、OpenAPI、sqlc、browser canvas 等 |
+| prior skills        |    5 | WSL proxy、provider stream、PR writing、OpenAPI、browser network                                             |
+| fresh fact signals  |    2 | enterprise admin endpoint 统一、audit report 输出目录                                                        |
+| fresh skill signals |    2 | WSL package-download debugging workflow、browser visual verification workflow                                |
 
 ## 4. 主全量 run 结果
 
@@ -111,16 +112,16 @@ Stress case 规模：
 - 8/8 LLM judge verdict=pass。
 - 全量耗时约 481 秒。
 
-| case | deterministic | judge | fact 结果 | skill 结果 |
-|---|---|---|---|---|
-| `e2e_fact_soul_create_concise_chinese` | pass | pass | 1 accepted，`set_singleton agent` | 无 |
-| `e2e_fact_world_replace_endpoint` | pass | pass | 1 accepted，related=1，`replace_many fact-old-endpoint` | 无 |
-| `e2e_fact_negative_no_durable_write` | pass | pass | 0 candidates，0 writes | 无 |
-| `e2e_skill_create_verified_provider_workflow` | pass | pass | 无 | 1 accepted，`create_skill` |
-| `e2e_skill_negative_simple_advice_no_write` | pass | pass | 无 | 0 candidates，0 writes |
-| `e2e_mixed_fact_replace_skill_patch_verified` | pass | pass | 1 accepted，`replace_many fact-old-endpoint` | 1 accepted，related=1，patch `skill-provider-debug` |
-| `e2e_mixed_wsl_fact_and_skill_delta` | pass | pass | 2 generated / 1 accepted，`create world` | 1 accepted，patch `skill-stella-wsl` |
-| `e2e_stress_multi_signal_large_catalog` | fail | pass | 2 accepted，但输出为 `create + deprecate_many` | 2 accepted，create 1 + patch 1 |
+| case                                          | deterministic | judge | fact 结果                                               | skill 结果                                          |
+| --------------------------------------------- | ------------- | ----- | ------------------------------------------------------- | --------------------------------------------------- |
+| `e2e_fact_soul_create_concise_chinese`        | pass          | pass  | 1 accepted，`set_singleton agent`                       | 无                                                  |
+| `e2e_fact_world_replace_endpoint`             | pass          | pass  | 1 accepted，related=1，`replace_many fact-old-endpoint` | 无                                                  |
+| `e2e_fact_negative_no_durable_write`          | pass          | pass  | 0 candidates，0 writes                                  | 无                                                  |
+| `e2e_skill_create_verified_provider_workflow` | pass          | pass  | 无                                                      | 1 accepted，`create_skill`                          |
+| `e2e_skill_negative_simple_advice_no_write`   | pass          | pass  | 无                                                      | 0 candidates，0 writes                              |
+| `e2e_mixed_fact_replace_skill_patch_verified` | pass          | pass  | 1 accepted，`replace_many fact-old-endpoint`            | 1 accepted，related=1，patch `skill-provider-debug` |
+| `e2e_mixed_wsl_fact_and_skill_delta`          | pass          | pass  | 2 generated / 1 accepted，`create world`                | 1 accepted，patch `skill-stella-wsl`                |
+| `e2e_stress_multi_signal_large_catalog`       | fail          | pass  | 2 accepted，但输出为 `create + deprecate_many`          | 2 accepted，create 1 + patch 1                      |
 
 主全量 run 中唯一 deterministic fail：
 
@@ -141,35 +142,35 @@ Stress 单 case 复验：`dist/reflect-evals/531-532/20260708T095504Z`
 
 Stress 复验写入摘要：
 
-| line | 输出 |
-|---|---|
-| fact | `replace_many` old enterprise endpoint facts -> `express-ent-admin.cherryin.ai` |
-| fact | `replace_many` old audit root fact -> `dist/enterprise-audit-reports` |
-| skill | create `debug-blank-screenshots` |
-| skill | patch `skill-wsl-proxy` |
+| line  | 输出                                                                            |
+| ----- | ------------------------------------------------------------------------------- |
+| fact  | `replace_many` old enterprise endpoint facts -> `express-ent-admin.cherryin.ai` |
+| fact  | `replace_many` old audit root fact -> `dist/enterprise-audit-reports`           |
+| skill | create `debug-blank-screenshots`                                                |
+| skill | patch `skill-wsl-proxy`                                                         |
 
 分阶段关键 run：
 
-| 目录 | 范围 | 结果 |
-|---|---|---|
-| `dist/reflect-evals/531-532/20260708T082525Z` | skill-only | 2/2 pass |
-| `dist/reflect-evals/531-532/20260708T084022Z` | mixed | judge 2/2 pass；其中一个 deterministic check 之后被判定为过窄 |
-| `dist/reflect-evals/531-532/20260708T095504Z` | stress final | 1/1 pass |
+| 目录                                          | 范围         | 结果                                                          |
+| --------------------------------------------- | ------------ | ------------------------------------------------------------- |
+| `dist/reflect-evals/531-532/20260708T082525Z` | skill-only   | 2/2 pass                                                      |
+| `dist/reflect-evals/531-532/20260708T084022Z` | mixed        | judge 2/2 pass；其中一个 deterministic check 之后被判定为过窄 |
+| `dist/reflect-evals/531-532/20260708T095504Z` | stress final | 1/1 pass                                                      |
 
 ## 6. Judge 分数
 
 主全量 run + stress final 的 judge 分数：
 
-| case | action_fit | related_usefulness | write_accuracy | content_completeness | no_unrelated_content |
-|---|---:|---:|---:|---:|---:|
-| `e2e_fact_soul_create_concise_chinese` | 4 | 4 | 4 | 4 | 4 |
-| `e2e_fact_world_replace_endpoint` | 4 | 4 | 4 | 3 | 4 |
-| `e2e_fact_negative_no_durable_write` | 4 | 4 | 4 | 4 | 4 |
-| `e2e_skill_create_verified_provider_workflow` | 4 | 4 | 4 | 4 | 4 |
-| `e2e_skill_negative_simple_advice_no_write` | 4 | 4 | 4 | 4 | 4 |
-| `e2e_mixed_fact_replace_skill_patch_verified` | 4 | 4 | 4 | 4 | 4 |
-| `e2e_mixed_wsl_fact_and_skill_delta` | 4 | 4 | 4 | 4 | 4 |
-| `e2e_stress_multi_signal_large_catalog` | 4 | 4 | 4 | 4 | 4 |
+| case                                          | action_fit | related_usefulness | write_accuracy | content_completeness | no_unrelated_content |
+| --------------------------------------------- | ---------: | -----------------: | -------------: | -------------------: | -------------------: |
+| `e2e_fact_soul_create_concise_chinese`        |          4 |                  4 |              4 |                    4 |                    4 |
+| `e2e_fact_world_replace_endpoint`             |          4 |                  4 |              4 |                    3 |                    4 |
+| `e2e_fact_negative_no_durable_write`          |          4 |                  4 |              4 |                    4 |                    4 |
+| `e2e_skill_create_verified_provider_workflow` |          4 |                  4 |              4 |                    4 |                    4 |
+| `e2e_skill_negative_simple_advice_no_write`   |          4 |                  4 |              4 |                    4 |                    4 |
+| `e2e_mixed_fact_replace_skill_patch_verified` |          4 |                  4 |              4 |                    4 |                    4 |
+| `e2e_mixed_wsl_fact_and_skill_delta`          |          4 |                  4 |              4 |                    4 |                    4 |
+| `e2e_stress_multi_signal_large_catalog`       |          4 |                  4 |              4 |                    4 |                    4 |
 
 `e2e_fact_world_replace_endpoint` 的 `content_completeness=3` 是因为 judge 希望事实写入包含更完整上下文；但该 case 的 fact write 已包含关键 endpoint 替换信息，deterministic checks 通过。
 

--- a/docs/test-reports/reflect/issue-531/2026-07-08-focused-eval.zh.md
+++ b/docs/test-reports/reflect/issue-531/2026-07-08-focused-eval.zh.md
@@ -32,25 +32,25 @@ Judge 阈值：每项 >= 3 且 verdict=pass。
 
 最终全量 run 共 33 个 case：
 
-| 分组 | case 数 | 覆盖点 |
-|---|---:|---|
-| `531_fact_focused` | 3 | knowledge replace/noop/create |
-| `531_fact_operation_focused` | 7 | profile/soul singleton create/replace/noop，knowledge deprecate/replace_many |
-| `531_related_discovery_focused` | 12 | fact/skill relation kind 与噪声排除 |
-| `531_skill_focused` | 3 | skill patch/create/noop |
-| `531_skill_relation_focused` | 1 | stale predecessor |
-| `531_mixed_focused` | 1 | fact + skill 同轮 |
-| `531_scale_focused` | 2 | 20 facts、15 skills 级别 catalog，多候选 |
-| `531_stress_focused` | 4 | 更大 catalog、多候选、多操作、混合线 |
+| 分组                            | case 数 | 覆盖点                                                                       |
+| ------------------------------- | ------: | ---------------------------------------------------------------------------- |
+| `531_fact_focused`              |       3 | knowledge replace/noop/create                                                |
+| `531_fact_operation_focused`    |       7 | profile/soul singleton create/replace/noop，knowledge deprecate/replace_many |
+| `531_related_discovery_focused` |      12 | fact/skill relation kind 与噪声排除                                          |
+| `531_skill_focused`             |       3 | skill patch/create/noop                                                      |
+| `531_skill_relation_focused`    |       1 | stale predecessor                                                            |
+| `531_mixed_focused`             |       1 | fact + skill 同轮                                                            |
+| `531_scale_focused`             |       2 | 20 facts、15 skills 级别 catalog，多候选                                     |
+| `531_stress_focused`            |       4 | 更大 catalog、多候选、多操作、混合线                                         |
 
 新增 stress case：
 
-| case | prior facts | prior skills | candidates | 重点 |
-|---|---:|---:|---:|---|
-| `stress_fact_large_catalog_multi_relation` | 33 | 0 | 3 fact | 多 endpoint/header/audit 事实同时 replace_many，排除 provider/WSL/PR 噪声 |
-| `stress_fact_retired_dependency_and_manual_exclusion` | 28 | 0 | 2 fact | retired fact + dependency fact，排除 manual/inactive/distractor |
-| `stress_skill_large_catalog_mixed_patch_create` | 0 | 20 | 3 skill | WSL patch、provider patch/create/noop 边界、browser create |
-| `stress_mixed_large_catalog_dual_line` | 14 | 7 | 1 fact + 1 skill | fact/skill 双线同轮，OpenAPI + web fixture + browser smoke |
+| case                                                  | prior facts | prior skills |       candidates | 重点                                                                      |
+| ----------------------------------------------------- | ----------: | -----------: | ---------------: | ------------------------------------------------------------------------- |
+| `stress_fact_large_catalog_multi_relation`            |          33 |            0 |           3 fact | 多 endpoint/header/audit 事实同时 replace_many，排除 provider/WSL/PR 噪声 |
+| `stress_fact_retired_dependency_and_manual_exclusion` |          28 |            0 |           2 fact | retired fact + dependency fact，排除 manual/inactive/distractor           |
+| `stress_skill_large_catalog_mixed_patch_create`       |           0 |           20 |          3 skill | WSL patch、provider patch/create/noop 边界、browser create                |
+| `stress_mixed_large_catalog_dual_line`                |          14 |            7 | 1 fact + 1 skill | fact/skill 双线同轮，OpenAPI + web fixture + browser smoke                |
 
 ## 4. 最终主 run 结果
 
@@ -77,14 +77,14 @@ env OPENAI_BASE_URL=... OPENAI_API_KEY=... \
 
 LLM judge 分数：
 
-| case | action_fit | related_usefulness | write_accuracy | content_completeness | no_unrelated_content |
-|---|---:|---:|---:|---:|---:|
-| `scale_fact_many_active_records_multi_candidate` | 4 | 4 | 4 | 4 | 4 |
-| `scale_skill_many_active_records_multi_candidate` | 4 | 4 | 4 | 3 | 4 |
-| `stress_fact_large_catalog_multi_relation` | 4 | 4 | 4 | 3 | 4 |
-| `stress_fact_retired_dependency_and_manual_exclusion` | 4 | 4 | 4 | 4 | 4 |
-| `stress_mixed_large_catalog_dual_line` | 4 | 4 | 4 | 4 | 4 |
-| `stress_skill_large_catalog_mixed_patch_create` | 4 | 4 | 4 | 4 | 4 |
+| case                                                  | action_fit | related_usefulness | write_accuracy | content_completeness | no_unrelated_content |
+| ----------------------------------------------------- | ---------: | -----------------: | -------------: | -------------------: | -------------------: |
+| `scale_fact_many_active_records_multi_candidate`      |          4 |                  4 |              4 |                    4 |                    4 |
+| `scale_skill_many_active_records_multi_candidate`     |          4 |                  4 |              4 |                    3 |                    4 |
+| `stress_fact_large_catalog_multi_relation`            |          4 |                  4 |              4 |                    3 |                    4 |
+| `stress_fact_retired_dependency_and_manual_exclusion` |          4 |                  4 |              4 |                    4 |                    4 |
+| `stress_mixed_large_catalog_dual_line`                |          4 |                  4 |              4 |                    4 |                    4 |
+| `stress_skill_large_catalog_mixed_patch_create`       |          4 |                  4 |              4 |                    4 |                    4 |
 
 ## 5. 质量观察
 

--- a/docs/test-reports/reflect/issue-531/README.md
+++ b/docs/test-reports/reflect/issue-531/README.md
@@ -1,0 +1,9 @@
+# Reflect #531 Test Reports
+
+This directory stores human-readable evaluation reports for the Reflect #531
+related-discovery and reconciliation work.
+
+The committed reports summarize curated local eval runs. Raw per-case artifacts
+and generated harness outputs are intentionally kept under ignored
+`dist/reflect-evals/` paths (`goreleaser --clean` wipes `dist/`, so nothing
+tracked may live there — see #740).


### PR DESCRIPTION
Closes #740

`git mv` plus dprint reformatting only — no content changes. The two #687 eval reports were force-tracked under the gitignored `/dist/`, and `goreleaser --clean` (inside `mise run release:snapshot` / `release:validate`) deletes them on every run. They now live in `docs/test-reports/reflect/issue-531/` with dated filenames plus a README, mirroring the existing `issue-532` convention (committed human-readable reports in docs/test-reports; raw artifacts intentionally under the ignored `dist/reflect-evals/`).

The in-report references to `dist/reflect-evals/...` raw output directories are left as-is — those point at intentionally ignored artifact paths, same as the issue-532 report does.

Verified: `git ls-files dist/` is now empty; `mise run release:snapshot` can no longer delete tracked files.