### PR TITLE
🔊 fix(logging): cap River noise, default INFO, add HTTP access log

### DIFF
--- a/cmd/stellad/commands.go
+++ b/cmd/stellad/commands.go
@@ -24,6 +24,7 @@ import (
 	sessionaccess "github.com/CherryHQ/stella/internal/agent/session/access"
 	"github.com/CherryHQ/stella/internal/asset"
 	"github.com/CherryHQ/stella/internal/blob"
+	"github.com/CherryHQ/stella/internal/cli"
 	"github.com/CherryHQ/stella/internal/config"
 	"github.com/CherryHQ/stella/internal/connections"
 	oauth "github.com/CherryHQ/stella/internal/connections/oauth"
@@ -471,7 +472,7 @@ func setup(parent context.Context, cfg config.ServerConfig, baseURL string) (*se
 	// Composition root for River: both the scheduler and goal subsystems are now
 	// built, so assemble the single shared working client from their queues and
 	// inject it back into each. runServer owns its Start/Stop.
-	riverClient, err := buildSharedRiverClient(db, schedulerSvc, goalSvc, embeddingSvc, cfg.Lifecycle.RiverSoftStopTimeout)
+	riverClient, err := buildSharedRiverClient(db, schedulerSvc, goalSvc, embeddingSvc, cfg.Lifecycle.RiverSoftStopTimeout, cfg.Observability.RiverLogLevel)
 	if err != nil {
 		return nil, err
 	}
@@ -575,7 +576,7 @@ func setupScheduler(db *pgxpool.Pool, phost *pluginhost.Host, agentAccess *agent
 // electable River client per database (see db.NewWorkingRiverClient); this is
 // where that invariant is enforced. The caller owns the returned client's
 // Start/Stop lifecycle (runServer); the subsystems only use it.
-func buildSharedRiverClient(db *pgxpool.Pool, schedulerSvc *scheduler.Service, goalSvc *goal.Service, embeddingSvc *embedding.Service, softStopTimeout time.Duration) (*river.Client[pgx.Tx], error) {
+func buildSharedRiverClient(db *pgxpool.Pool, schedulerSvc *scheduler.Service, goalSvc *goal.Service, embeddingSvc *embedding.Service, softStopTimeout time.Duration, riverLogLevel string) (*river.Client[pgx.Tx], error) {
 	workers := river.NewWorkers()
 	scheduler.RegisterRiverWorker(workers, schedulerSvc)
 	goalSvc.RegisterRiverWorker(workers)
@@ -596,7 +597,15 @@ func buildSharedRiverClient(db *pgxpool.Pool, schedulerSvc *scheduler.Service, g
 		queues[en] = ec
 	}
 
-	client, err := appdb.NewWorkingRiverClient(db, queues, workers, slog.With("component", "river"), softStopTimeout)
+	// River heartbeats at DEBUG/INFO every few seconds (producer batches, job
+	// stats, leader reelection), which drowns application logs. Cap its logger
+	// at WARN unless LOG_LEVEL_RIVER explicitly opens it up for queue debugging.
+	riverLevel := slog.LevelWarn
+	if riverLogLevel != "" {
+		riverLevel = cli.ParseLogLevel(riverLogLevel)
+	}
+	riverLog := slog.New(cli.NewMinLevelHandler(riverLevel, slog.Default().Handler())).With("component", "river")
+	client, err := appdb.NewWorkingRiverClient(db, queues, workers, riverLog, softStopTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("build shared river client: %w", err)
 	}

--- a/cmd/stellad/main.go
+++ b/cmd/stellad/main.go
@@ -6,14 +6,19 @@ import (
 	"os"
 
 	"github.com/CherryHQ/stella/internal/cli"
+	"github.com/CherryHQ/stella/internal/observability"
 )
 
 func main() {
 	cli.LoadDotEnv()
 
-	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
-		Level: cli.ParseLogLevel(os.Getenv("LOG_LEVEL")),
-	})))
+	// The trace-context wrapper stamps trace_id/span_id onto records logged
+	// with a span-carrying context, so stderr lines correlate with exported
+	// traces. It is inert (a map lookup) when tracing is off.
+	slog.SetDefault(slog.New(observability.NewTraceContextHandler(
+		slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+			Level: cli.ParseLogLevel(os.Getenv("LOG_LEVEL")),
+		}))))
 
 	app := newApp()
 

--- a/go.mod
+++ b/go.mod
@@ -44,10 +44,13 @@ require (
 	go.opentelemetry.io/contrib/bridges/otelslog v0.18.0
 	go.opentelemetry.io/contrib/exporters/autoexport v0.67.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0
+	go.opentelemetry.io/contrib/instrumentation/runtime v0.68.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/log v0.19.0
+	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/log v0.19.0
+	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/crypto v0.50.0
 	golang.org/x/image v0.41.0
@@ -176,8 +179,6 @@ require (
 	go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.18.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.42.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.42.0 // indirect
-	go.opentelemetry.io/otel/metric v1.43.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/goleak v1.3.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -754,6 +754,8 @@ go.opentelemetry.io/contrib/exporters/autoexport v0.67.0 h1:4fnRcNpc6YFtG3zsFw9a
 go.opentelemetry.io/contrib/exporters/autoexport v0.67.0/go.mod h1:qTvIHMFKoxW7HXg02gm6/Wofhq5p3Ib/A/NNt1EoBSQ=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0 h1:CqXxU8VOmDefoh0+ztfGaymYbhdB/tT3zs79QaZTNGY=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0/go.mod h1:BuhAPThV8PBHBvg8ZzZ/Ok3idOdhWIodywz2xEcRbJo=
+go.opentelemetry.io/contrib/instrumentation/runtime v0.68.0 h1:jhVIQEprwUTV+KfzzliLidclhoTOoHTgdz96kAyR8mU=
+go.opentelemetry.io/contrib/instrumentation/runtime v0.68.0/go.mod h1:4HsdbLUbernaTnA8CNaNE+1g026SciXb3juRYe3l8EY=
 go.opentelemetry.io/otel v1.43.0 h1:mYIM03dnh5zfN7HautFE4ieIig9amkNANT+xcVxAj9I=
 go.opentelemetry.io/otel v1.43.0/go.mod h1:JuG+u74mvjvcm8vj8pI5XiHy1zDeoCS2LB1spIq7Ay0=
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.18.0 h1:deI9UQMoGFgrg5iLPgzueqFPHevDl+28YKfSpPTI6rY=

--- a/internal/cli/loglevel.go
+++ b/internal/cli/loglevel.go
@@ -1,28 +1,58 @@
 package cli
 
 import (
+	"context"
 	"log/slog"
 	"strings"
 )
 
 // ParseLogLevel maps a LOG_LEVEL value to slog.Level.
 // Supported values: TRACE, DEBUG, INFO, WARN, ERROR (case-insensitive).
-// Defaults to DEBUG if empty or unrecognized. It is a pure function of its
+// Defaults to INFO if empty or unrecognized. It is a pure function of its
 // argument: logging is configured before the server config is parsed, so the
 // caller (main) passes the raw environment value.
 func ParseLogLevel(raw string) slog.Level {
 	switch strings.ToUpper(raw) {
 	case "TRACE":
 		return slog.Level(-8)
-	case "DEBUG", "":
+	case "DEBUG":
 		return slog.LevelDebug
-	case "INFO":
+	case "INFO", "":
 		return slog.LevelInfo
 	case "WARN":
 		return slog.LevelWarn
 	case "ERROR":
 		return slog.LevelError
 	default:
-		return slog.LevelDebug
+		return slog.LevelInfo
 	}
+}
+
+// NewMinLevelHandler wraps next and drops records below min, regardless of
+// what next would accept. It exists so chatty subsystem loggers (e.g. the
+// River job queue, which heartbeats at DEBUG/INFO every few seconds) can be
+// capped independently of the process-wide LOG_LEVEL.
+func NewMinLevelHandler(min slog.Level, next slog.Handler) slog.Handler {
+	return minLevelHandler{min: min, next: next}
+}
+
+type minLevelHandler struct {
+	min  slog.Level
+	next slog.Handler
+}
+
+func (h minLevelHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return level >= h.min && h.next.Enabled(ctx, level)
+}
+
+func (h minLevelHandler) Handle(ctx context.Context, record slog.Record) error {
+	return h.next.Handle(ctx, record)
+}
+
+func (h minLevelHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return minLevelHandler{min: h.min, next: h.next.WithAttrs(attrs)}
+}
+
+func (h minLevelHandler) WithGroup(name string) slog.Handler {
+	return minLevelHandler{min: h.min, next: h.next.WithGroup(name)}
 }

--- a/internal/cli/loglevel_test.go
+++ b/internal/cli/loglevel_test.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+)
+
+func TestParseLogLevel(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want slog.Level
+	}{
+		{"TRACE", slog.Level(-8)},
+		{"trace", slog.Level(-8)},
+		{"DEBUG", slog.LevelDebug},
+		{"info", slog.LevelInfo},
+		{"WARN", slog.LevelWarn},
+		{"error", slog.LevelError},
+		// Empty and unrecognized values default to INFO.
+		{"", slog.LevelInfo},
+		{"bogus", slog.LevelInfo},
+	}
+	for _, tc := range cases {
+		if got := ParseLogLevel(tc.raw); got != tc.want {
+			t.Errorf("ParseLogLevel(%q) = %v, want %v", tc.raw, got, tc.want)
+		}
+	}
+}
+
+func TestMinLevelHandlerDropsBelowMin(t *testing.T) {
+	var buf bytes.Buffer
+	// Inner handler accepts everything down to DEBUG; the wrapper caps at WARN.
+	inner := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	log := slog.New(NewMinLevelHandler(slog.LevelWarn, inner)).With("component", "river")
+
+	log.Debug("dropped debug")
+	log.Info("dropped info")
+	log.Warn("kept warn")
+	log.Error("kept error")
+
+	out := buf.String()
+	if bytes.Contains(buf.Bytes(), []byte("dropped")) {
+		t.Errorf("records below min leaked through: %q", out)
+	}
+	for _, want := range []string{"kept warn", "kept error", "component=river"} {
+		if !bytes.Contains(buf.Bytes(), []byte(want)) {
+			t.Errorf("output missing %q: %q", want, out)
+		}
+	}
+}

--- a/internal/config/server_config.go
+++ b/internal/config/server_config.go
@@ -31,6 +31,10 @@ const (
 	vaultKeyEnv     = "STELLA_VAULT_KEY"
 	pprofAddrEnv    = "STELLA_PPROF_ADDR"
 	recordToolIOEnv = "OTEL_STELLA_RECORD_TOOL_IO"
+	// riverLogLevelEnv is the companion of LOG_LEVEL (read pre-config in main)
+	// for the River job queue only; internal/cli.ParseLogLevel owns the dialect,
+	// so the value passes through raw.
+	riverLogLevelEnv = "LOG_LEVEL_RIVER"
 
 	reflectIntervalEnv    = "STELLA_REFLECT_INTERVAL"
 	reflectCuratorModeEnv = "STELLA_REFLECT_CURATOR_MODE"
@@ -151,12 +155,16 @@ type DiagnosticsConfig struct {
 	PprofAddr string
 }
 
-// ObservabilityConfig holds tracing toggles this server owns.
+// ObservabilityConfig holds tracing and logging toggles this server owns.
 type ObservabilityConfig struct {
 	// RecordToolIO records tool input/output payloads on spans
 	// (OTEL_STELLA_RECORD_TOOL_IO). Preserves the exact ==\"true\" opt-in: any
 	// other value, including unset, leaves it off.
 	RecordToolIO bool
+	// RiverLogLevel is the raw LOG_LEVEL_RIVER value ("" for unset). The River
+	// job queue heartbeats at DEBUG/INFO, so its logger is capped at WARN unless
+	// this opens it up; internal/cli.ParseLogLevel owns the level dialect.
+	RiverLogLevel string
 }
 
 // DatabaseConfig holds the two variables that jointly decide, at startup,
@@ -273,6 +281,7 @@ func LoadServerConfig(lookup func(string) (string, bool)) (ServerConfig, error) 
 	}
 	cfg.Diagnostics.PprofAddr = get(pprofAddrEnv)
 	cfg.Observability.RecordToolIO = get(recordToolIOEnv) == "true"
+	cfg.Observability.RiverLogLevel = get(riverLogLevelEnv)
 	return cfg, nil
 }
 

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -21,14 +21,19 @@ import (
 
 	"go.opentelemetry.io/contrib/bridges/otelslog"
 	"go.opentelemetry.io/contrib/exporters/autoexport"
+	"go.opentelemetry.io/contrib/instrumentation/runtime"
 	"go.opentelemetry.io/otel"
 	otellog "go.opentelemetry.io/otel/log"
 	otellogglobal "go.opentelemetry.io/otel/log/global"
+	otelmetric "go.opentelemetry.io/otel/metric"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/CherryHQ/stella/internal/version"
 )
 
 // Config holds OTel settings derived from standard environment variables.
@@ -73,9 +78,11 @@ func signalEnabled(exporterKey, endpointKey string) bool {
 type Provider struct {
 	tp *sdktrace.TracerProvider // nil when trace export is disabled
 	lp *sdklog.LoggerProvider   // nil when log export is disabled
+	mp *sdkmetric.MeterProvider // nil when metric export is disabled
 
 	previousTracerProvider trace.TracerProvider
 	previousLoggerProvider otellog.LoggerProvider
+	previousMeterProvider  otelmetric.MeterProvider
 	previousSlog           *slog.Logger
 }
 
@@ -86,7 +93,8 @@ type Provider struct {
 func Init(ctx context.Context) (*Provider, error) {
 	cfg := LoadConfig()
 	logsEnabled := signalEnabled("OTEL_LOGS_EXPORTER", "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT")
-	if !cfg.Enabled && !logsEnabled {
+	metricsEnabled := signalEnabled("OTEL_METRICS_EXPORTER", "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT")
+	if !cfg.Enabled && !logsEnabled && !metricsEnabled {
 		return &Provider{}, nil
 	}
 
@@ -105,9 +113,14 @@ func Init(ctx context.Context) (*Provider, error) {
 	if logsEnabled {
 		p.lp, err = newLoggerProvider(ctx, res)
 		if err != nil {
-			if p.tp != nil {
-				_ = p.tp.Shutdown(ctx)
-			}
+			_ = p.shutdownProviders(ctx)
+			return nil, err
+		}
+	}
+	if metricsEnabled {
+		p.mp, err = newMeterProvider(ctx, res)
+		if err != nil {
+			_ = p.shutdownProviders(ctx)
 			return nil, err
 		}
 	}
@@ -128,6 +141,20 @@ func Init(ctx context.Context) (*Provider, error) {
 			"endpoint", os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"),
 			"service", cfg.ServiceName)
 	}
+	if p.mp != nil {
+		p.previousMeterProvider = otel.GetMeterProvider()
+		otel.SetMeterProvider(p.mp)
+		// Go runtime metrics (memory, GC, goroutines). otelhttp picks up the
+		// global meter provider by itself, so HTTP server metrics need no start
+		// call. A runtime.Start failure only loses one instrument set; the
+		// provider is already installed, so warn rather than fail startup.
+		if err := runtime.Start(runtime.WithMeterProvider(p.mp)); err != nil {
+			slog.Warn("otel runtime metrics failed to start", "error", err)
+		}
+		slog.Info("otel metrics enabled",
+			"endpoint", os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"),
+			"service", cfg.ServiceName)
+	}
 	if os.Getenv("OTEL_EXPORTER_OTLP_INSECURE") == "true" {
 		slog.Warn("otel exporter transport is insecure; telemetry is sent without TLS")
 	}
@@ -135,10 +162,17 @@ func Init(ctx context.Context) (*Provider, error) {
 }
 
 func newResource(ctx context.Context, cfg Config) (*resource.Resource, error) {
+	// WithFromEnv is last so OTEL_RESOURCE_ATTRIBUTES (and OTEL_SERVICE_NAME)
+	// override the in-code defaults; without it those variables are silently
+	// dropped, since resource.New has no default detectors.
 	res, err := resource.New(ctx,
-		resource.WithAttributes(semconv.ServiceName(cfg.ServiceName)),
+		resource.WithAttributes(
+			semconv.ServiceName(cfg.ServiceName),
+			semconv.ServiceVersion(version.DisplayVersion()),
+		),
 		resource.WithProcessRuntimeDescription(),
 		resource.WithHost(),
+		resource.WithFromEnv(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("otel: create resource: %w", err)
@@ -156,6 +190,18 @@ func newTracerProvider(ctx context.Context, res *resource.Resource) (*sdktrace.T
 	return sdktrace.NewTracerProvider(
 		sdktrace.WithBatcher(exporter),
 		sdktrace.WithResource(res),
+	), nil
+}
+
+func newMeterProvider(ctx context.Context, res *resource.Resource) (*sdkmetric.MeterProvider, error) {
+	reader, err := autoexport.NewMetricReader(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("otel: create metric reader: %w", err)
+	}
+
+	return sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(reader),
+		sdkmetric.WithResource(res),
 	), nil
 }
 
@@ -210,7 +256,6 @@ func (p *Provider) Shutdown(ctx context.Context) error {
 	if p == nil {
 		return nil
 	}
-	var err error
 	if p.lp != nil {
 		if p.previousSlog != nil {
 			slog.SetDefault(p.previousSlog)
@@ -218,12 +263,28 @@ func (p *Provider) Shutdown(ctx context.Context) error {
 		if p.previousLoggerProvider != nil {
 			otellogglobal.SetLoggerProvider(p.previousLoggerProvider)
 		}
+	}
+	if p.mp != nil && p.previousMeterProvider != nil {
+		otel.SetMeterProvider(p.previousMeterProvider)
+	}
+	if p.tp != nil && p.previousTracerProvider != nil {
+		otel.SetTracerProvider(p.previousTracerProvider)
+	}
+	return p.shutdownProviders(ctx)
+}
+
+// shutdownProviders stops whichever providers were built, without touching the
+// global registrations. Init uses it directly to unwind a partial build before
+// any global was installed.
+func (p *Provider) shutdownProviders(ctx context.Context) error {
+	var err error
+	if p.lp != nil {
 		err = errors.Join(err, p.lp.Shutdown(ctx))
 	}
+	if p.mp != nil {
+		err = errors.Join(err, p.mp.Shutdown(ctx))
+	}
 	if p.tp != nil {
-		if p.previousTracerProvider != nil {
-			otel.SetTracerProvider(p.previousTracerProvider)
-		}
 		err = errors.Join(err, p.tp.Shutdown(ctx))
 	}
 	return err

--- a/internal/observability/observability_test.go
+++ b/internal/observability/observability_test.go
@@ -21,6 +21,9 @@ func clearOTelEnv(t *testing.T) {
 		"OTEL_EXPORTER_OTLP_LOGS_PROTOCOL",
 		"OTEL_TRACES_EXPORTER",
 		"OTEL_LOGS_EXPORTER",
+		"OTEL_METRICS_EXPORTER",
+		"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+		"OTEL_RESOURCE_ATTRIBUTES",
 	} {
 		t.Setenv(key, "")
 	}
@@ -169,6 +172,7 @@ func TestInitEnabledInstallsAndShutsDown(t *testing.T) {
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
 	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
 	t.Setenv("OTEL_LOGS_EXPORTER", "none")
+	t.Setenv("OTEL_METRICS_EXPORTER", "none")
 
 	p, err := Init(context.Background())
 	if err != nil {
@@ -242,5 +246,61 @@ func TestShutdownNilProvider(t *testing.T) {
 	var p *Provider
 	if err := p.Shutdown(context.Background()); err != nil {
 		t.Errorf("nil Provider Shutdown() = %v, want nil", err)
+	}
+}
+
+func TestInitMetricsOnlyInstallsAndShutsDown(t *testing.T) {
+	clearOTelEnv(t)
+	t.Setenv("OTEL_METRICS_EXPORTER", "console")
+
+	beforeTracer := otel.GetTracerProvider()
+	beforeMeter := otel.GetMeterProvider()
+	p, err := Init(context.Background())
+	if err != nil {
+		t.Fatalf("Init() error = %v, want nil", err)
+	}
+	if p.tp != nil {
+		t.Fatal("Init() installed a tracer provider when only metrics are enabled")
+	}
+	if p.mp == nil {
+		t.Fatal("Init() returned a no-op meter provider while metrics are enabled")
+	}
+	if otel.GetMeterProvider() != p.mp {
+		t.Error("Init() did not install the meter provider as global")
+	}
+	if otel.GetTracerProvider() != beforeTracer {
+		t.Error("Init() replaced the global tracer provider when only metrics are enabled")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := p.Shutdown(ctx); err != nil {
+		t.Errorf("Shutdown() error = %v, want nil", err)
+	}
+	if otel.GetMeterProvider() != beforeMeter {
+		t.Error("Shutdown() did not restore the previous meter provider")
+	}
+}
+
+func TestNewResourceIncludesEnvAndVersion(t *testing.T) {
+	clearOTelEnv(t)
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=dev")
+
+	res, err := newResource(context.Background(), Config{ServiceName: "stella"})
+	if err != nil {
+		t.Fatalf("newResource() error = %v, want nil", err)
+	}
+	got := map[string]string{}
+	for _, attr := range res.Attributes() {
+		got[string(attr.Key)] = attr.Value.Emit()
+	}
+	if got["deployment.environment"] != "dev" {
+		t.Errorf("resource dropped OTEL_RESOURCE_ATTRIBUTES: %v", got)
+	}
+	if got["service.version"] == "" {
+		t.Errorf("resource missing service.version: %v", got)
+	}
+	if got["service.name"] != "stella" {
+		t.Errorf("service.name = %q, want stella", got["service.name"])
 	}
 }

--- a/internal/observability/slog.go
+++ b/internal/observability/slog.go
@@ -6,7 +6,46 @@ import (
 	"log/slog"
 	"os"
 	"reflect"
+
+	"go.opentelemetry.io/otel/trace"
 )
+
+// NewTraceContextHandler wraps next so records logged with a span-carrying
+// context (the slog *Context variants) gain trace_id/span_id attributes. The
+// OTLP log bridge extracts trace context natively; this wrapper gives the
+// console output the same correlation, so an operator can jump from a stderr
+// line to the trace in their backend. Records logged without a context pass
+// through unchanged.
+func NewTraceContextHandler(next slog.Handler) slog.Handler {
+	return traceContextHandler{next: next}
+}
+
+type traceContextHandler struct {
+	next slog.Handler
+}
+
+func (h traceContextHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.next.Enabled(ctx, level)
+}
+
+func (h traceContextHandler) Handle(ctx context.Context, record slog.Record) error {
+	if sc := trace.SpanContextFromContext(ctx); sc.HasTraceID() {
+		record = record.Clone()
+		record.AddAttrs(
+			slog.String("trace_id", sc.TraceID().String()),
+			slog.String("span_id", sc.SpanID().String()),
+		)
+	}
+	return h.next.Handle(ctx, record)
+}
+
+func (h traceContextHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return traceContextHandler{next: h.next.WithAttrs(attrs)}
+}
+
+func (h traceContextHandler) WithGroup(name string) slog.Handler {
+	return traceContextHandler{next: h.next.WithGroup(name)}
+}
 
 type teeHandler struct {
 	handlers []slog.Handler

--- a/internal/observability/slog_test.go
+++ b/internal/observability/slog_test.go
@@ -1,0 +1,37 @@
+package observability
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestTraceContextHandlerAddsIDs(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(NewTraceContextHandler(slog.NewTextHandler(&buf, nil)))
+
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: trace.TraceID{0x01, 0x02},
+		SpanID:  trace.SpanID{0x03, 0x04},
+	})
+	ctx := trace.ContextWithSpanContext(context.Background(), sc)
+
+	log.InfoContext(ctx, "with span")
+	log.Info("without span")
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("want 2 log lines, got %d: %q", len(lines), buf.String())
+	}
+	if !strings.Contains(lines[0], "trace_id="+sc.TraceID().String()) ||
+		!strings.Contains(lines[0], "span_id="+sc.SpanID().String()) {
+		t.Errorf("span-carrying record missing trace/span ids: %q", lines[0])
+	}
+	if strings.Contains(lines[1], "trace_id") {
+		t.Errorf("context-free record must not carry a trace_id: %q", lines[1])
+	}
+}

--- a/internal/observability/tracehook/agent.go
+++ b/internal/observability/tracehook/agent.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (h *Hook) OnPreAgentCall(ctx context.Context, hctx *hooks.PreAgentCallContext) {
-	h.log.Info("pre_agent_call",
+	h.log.InfoContext(ctx, "pre_agent_call",
 		"session_id", hctx.SessionID,
 		"agent_id", hctx.AgentID,
 		"user_id", hctx.UserID,
@@ -35,7 +35,7 @@ func (h *Hook) OnPreAgentCall(ctx context.Context, hctx *hooks.PreAgentCallConte
 	}
 }
 
-func (h *Hook) OnPostAgentCall(_ context.Context, hctx *hooks.PostAgentCallContext) {
+func (h *Hook) OnPostAgentCall(ctx context.Context, hctx *hooks.PostAgentCallContext) {
 	attrs := []any{
 		"session_id", hctx.SessionID,
 		"agent_id", hctx.AgentID,
@@ -45,7 +45,7 @@ func (h *Hook) OnPostAgentCall(_ context.Context, hctx *hooks.PostAgentCallConte
 	if hctx.Error != nil {
 		attrs = append(attrs, "error", hctx.Error)
 	}
-	h.log.Info("post_agent_call", attrs...)
+	h.log.InfoContext(ctx, "post_agent_call", attrs...)
 
 	if !h.otelEnabled() {
 		return

--- a/internal/observability/tracehook/llm.go
+++ b/internal/observability/tracehook/llm.go
@@ -16,7 +16,7 @@ func (h *Hook) OnPreLLMCall(ctx context.Context, hctx *hooks.PreLLMCallContext) 
 	for i, t := range hctx.ToolDefinitions {
 		tools[i] = t.Name
 	}
-	h.log.Info("pre_llm_call",
+	h.log.InfoContext(ctx, "pre_llm_call",
 		"model", hctx.Model,
 		"messages", hctx.MessageCount,
 		"tools", len(tools),
@@ -93,7 +93,7 @@ func (h *Hook) OnPreLLMCall(ctx context.Context, hctx *hooks.PreLLMCallContext) 
 	return hooks.PreLLMCallResult{}, nil
 }
 
-func (h *Hook) OnPostLLMCall(_ context.Context, hctx *hooks.PostLLMCallContext) {
+func (h *Hook) OnPostLLMCall(ctx context.Context, hctx *hooks.PostLLMCallContext) {
 	attrs := []any{
 		"provider", hctx.Provider,
 		"model", hctx.Model,
@@ -115,7 +115,7 @@ func (h *Hook) OnPostLLMCall(_ context.Context, hctx *hooks.PostLLMCallContext) 
 	if hctx.Error != nil {
 		attrs = append(attrs, "error", hctx.Error)
 	}
-	h.log.Info("post_llm_call", attrs...)
+	h.log.InfoContext(ctx, "post_llm_call", attrs...)
 
 	if !h.otelEnabled() {
 		return

--- a/internal/observability/tracehook/memory.go
+++ b/internal/observability/tracehook/memory.go
@@ -112,7 +112,7 @@ func (h *Hook) OnPostMemoryCall(ctx context.Context, hctx *hooks.PostMemoryCallC
 	if hctx.Detail != "" && h.log.Enabled(context.Background(), levelTrace) {
 		attrs = append(attrs, "detail", hctx.Detail)
 	}
-	h.log.Info("post_memory_call", attrs...)
+	h.log.InfoContext(ctx, "post_memory_call", attrs...)
 
 	if !h.otelEnabled() {
 		return

--- a/internal/observability/tracehook/tool.go
+++ b/internal/observability/tracehook/tool.go
@@ -60,9 +60,9 @@ func recordSpanError(span trace.Span, err error) {
 	span.SetAttributes(attribute.String("error.type", fmt.Sprintf("%T", err)))
 }
 
-func (h *Hook) OnPreToolCall(_ context.Context, hctx *hooks.PreToolCallContext) (hooks.PreToolCallResult, error) {
+func (h *Hook) OnPreToolCall(ctx context.Context, hctx *hooks.PreToolCallContext) (hooks.PreToolCallResult, error) {
 	input := redactSecrets(summarizeArgs(hctx.ToolName, hctx.Arguments))
-	h.log.Info("pre_tool_call",
+	h.log.InfoContext(ctx, "pre_tool_call",
 		"tool", hctx.ToolName,
 		"call_id", hctx.ToolCallID,
 		"input", input,
@@ -115,12 +115,12 @@ func (h *Hook) OnPreToolCall(_ context.Context, hctx *hooks.PreToolCallContext) 
 	return hooks.PreToolCallResult{}, nil
 }
 
-func (h *Hook) OnPostToolCall(_ context.Context, hctx *hooks.PostToolCallContext) {
+func (h *Hook) OnPostToolCall(ctx context.Context, hctx *hooks.PostToolCallContext) {
 	resultSnippet := redactSecrets(hctx.Result)
 	if len(resultSnippet) > 200 {
 		resultSnippet = resultSnippet[:200] + "..."
 	}
-	h.log.Info("post_tool_call",
+	h.log.InfoContext(ctx, "post_tool_call",
 		"tool", hctx.ToolName,
 		"call_id", hctx.ToolCallID,
 		"is_error", hctx.IsError,

--- a/internal/server/access_log_test.go
+++ b/internal/server/access_log_test.go
@@ -1,0 +1,90 @@
+package server
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newAccessLogServer(buf *bytes.Buffer) *Server {
+	handler := slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	return &Server{log: slog.New(handler)}
+}
+
+func TestAccessLogMiddlewareLogsRequest(t *testing.T) {
+	var buf bytes.Buffer
+	s := newAccessLogServer(&buf)
+
+	h := s.accessLogMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte("hello"))
+	}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/agents", nil))
+
+	out := buf.String()
+	for _, want := range []string{"level=INFO", `msg="http request"`, "method=POST", "path=/api/agents", "status=201", "bytes=5"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("access log missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestAccessLogMiddlewareLevels(t *testing.T) {
+	cases := []struct {
+		name      string
+		path      string
+		status    int
+		wantLevel string
+	}{
+		{"server error is ERROR", "/api/agents", http.StatusInternalServerError, "level=ERROR"},
+		{"client error is INFO", "/api/agents", http.StatusUnauthorized, "level=INFO"},
+		{"health probe is DEBUG", "/healthz", http.StatusOK, "level=DEBUG"},
+		{"static asset is DEBUG", "/assets/app.js", http.StatusOK, "level=DEBUG"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			s := newAccessLogServer(&buf)
+			h := s.accessLogMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+			}))
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, tc.path, nil))
+
+			if out := buf.String(); !strings.Contains(out, tc.wantLevel) {
+				t.Errorf("want %s in access log, got: %q", tc.wantLevel, out)
+			}
+		})
+	}
+}
+
+// TestAccessLogMiddlewarePreservesFlusher guards SSE streaming: session and
+// group chat handlers assert w.(http.Flusher) and refuse to stream without it.
+func TestAccessLogMiddlewarePreservesFlusher(t *testing.T) {
+	var buf bytes.Buffer
+	s := newAccessLogServer(&buf)
+
+	flushed := false
+	h := s.accessLogMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("response writer lost http.Flusher")
+		}
+		_, _ = w.Write([]byte("data: hi\n\n"))
+		f.Flush()
+	}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/sessions/1/events", nil))
+	flushed = rec.Flushed
+
+	if !flushed {
+		t.Error("Flush was not forwarded to the underlying writer")
+	}
+	if !strings.Contains(buf.String(), "status=200") {
+		t.Errorf("default status should be 200: %q", buf.String())
+	}
+}

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -28,14 +28,15 @@ func (s *Server) redirectRoot(w http.ResponseWriter, r *http.Request) {
 // session authMiddleware. It stays in internal/server, with its Server-field
 // dependencies, because it is transport code — not a plugin implementation.
 func (s *Server) WebhookIngressHandler() http.Handler {
-	return http.HandlerFunc(s.handleWebhookIngress)
+	return s.accessLogMiddleware(http.HandlerFunc(s.handleWebhookIngress))
 }
 
 // Handler returns the HTTP handler with OTel instrumentation wrapping the
-// CORS, JSON, and auth middleware chain. The OTel wrap is unconditional: it is
-// a no-op when tracing is disabled.
+// access-log, CORS, JSON, and auth middleware chain. The OTel wrap is
+// unconditional: it is a no-op when tracing is disabled. The access log sits
+// directly inside it so log lines can carry the request's trace_id.
 func (s *Server) Handler() http.Handler {
-	return observability.Handler(s.corsMiddleware(s.authMiddleware(s.jsonMiddleware(s.mux))))
+	return observability.Handler(s.accessLogMiddleware(s.corsMiddleware(s.authMiddleware(s.jsonMiddleware(s.mux)))))
 }
 
 // corsMiddleware handles CORS headers. Origin is read from settings at startup.

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -2,9 +2,13 @@ package server
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"slices"
 	"strings"
+	"time"
+
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/CherryHQ/stella/internal/auth"
 	"github.com/CherryHQ/stella/internal/credential"
@@ -231,4 +235,79 @@ func (s *Server) denyAccess(w http.ResponseWriter, r *http.Request) {
 // isAPIRoute returns true if the path starts with /api/.
 func isAPIRoute(path string) bool {
 	return strings.HasPrefix(path, "/api/")
+}
+
+// accessLogMiddleware emits one log line per completed request. It sits inside
+// the OTel wrap — the request context carries a live span, so lines get a
+// trace_id when tracing is enabled — and outside authMiddleware so denied
+// requests (401/redirect) are logged too. That placement means the
+// authenticated user is not available here; correlate by trace_id instead.
+func (s *Server) accessLogMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(rec, r)
+
+		level := slog.LevelInfo
+		switch {
+		case rec.status >= 500:
+			level = slog.LevelError
+		case isQuietPath(r.URL.Path):
+			level = slog.LevelDebug
+		}
+
+		attrs := []slog.Attr{
+			slog.String("method", r.Method),
+			slog.String("path", r.URL.Path),
+			slog.Int("status", rec.status),
+			slog.Duration("duration", time.Since(start)),
+			slog.Int64("bytes", rec.bytes),
+		}
+		if sc := trace.SpanContextFromContext(r.Context()); sc.HasTraceID() {
+			attrs = append(attrs, slog.String("trace_id", sc.TraceID().String()))
+		}
+		s.log.LogAttrs(r.Context(), level, "http request", attrs...)
+	})
+}
+
+// isQuietPath returns true for high-frequency, low-signal requests
+// (orchestrator probes and static assets) that log at DEBUG instead of INFO.
+func isQuietPath(path string) bool {
+	return path == "/healthz" || path == "/readyz" ||
+		strings.HasPrefix(path, "/assets/") || strings.HasPrefix(path, "/static/")
+}
+
+// statusRecorder captures the response status and body size for the access
+// log. Flush is forwarded so SSE handlers, which assert w.(http.Flusher),
+// keep streaming; Unwrap supports http.ResponseController.
+type statusRecorder struct {
+	http.ResponseWriter
+	status      int
+	bytes       int64
+	wroteHeader bool
+}
+
+func (r *statusRecorder) WriteHeader(code int) {
+	if !r.wroteHeader {
+		r.status = code
+		r.wroteHeader = true
+	}
+	r.ResponseWriter.WriteHeader(code)
+}
+
+func (r *statusRecorder) Write(b []byte) (int, error) {
+	r.wroteHeader = true
+	n, err := r.ResponseWriter.Write(b)
+	r.bytes += int64(n)
+	return n, err
+}
+
+func (r *statusRecorder) Flush() {
+	if f, ok := r.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func (r *statusRecorder) Unwrap() http.ResponseWriter {
+	return r.ResponseWriter
 }

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"go.opentelemetry.io/otel/trace"
-
 	"github.com/CherryHQ/stella/internal/auth"
 	"github.com/CherryHQ/stella/internal/credential"
 )
@@ -65,7 +63,7 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 		// fall through to the cookie session or any full-access path.
 		info, err := s.authInfoFromBearer(ctx, r.Header.Get("Authorization"))
 		if err != nil {
-			s.log.Warn("bearer credential rejected", "error", err, "path", path)
+			s.log.WarnContext(ctx, "bearer credential rejected", "error", err, "path", path)
 			s.denyAccess(w, r)
 			return
 		}
@@ -256,17 +254,15 @@ func (s *Server) accessLogMiddleware(next http.Handler) http.Handler {
 			level = slog.LevelDebug
 		}
 
-		attrs := []slog.Attr{
+		// trace_id/span_id come from the trace-context slog handler (main installs
+		// it), which reads them off the request context passed here.
+		s.log.LogAttrs(r.Context(), level, "http request",
 			slog.String("method", r.Method),
 			slog.String("path", r.URL.Path),
 			slog.Int("status", rec.status),
 			slog.Duration("duration", time.Since(start)),
 			slog.Int64("bytes", rec.bytes),
-		}
-		if sc := trace.SpanContextFromContext(r.Context()); sc.HasTraceID() {
-			attrs = append(attrs, slog.String("trace_id", sc.TraceID().String()))
-		}
-		s.log.LogAttrs(r.Context(), level, "http request", attrs...)
+		)
 	})
 }
 

--- a/mise.toml
+++ b/mise.toml
@@ -19,7 +19,8 @@ node = "24.14.1"
 
 [env]
 BINARY_D = "./dist/bin/stellad"
-LOG_LEVEL = "trace"
+# Dev default; raise to "trace" for memory-detail fields, LOG_LEVEL_RIVER for queue internals.
+LOG_LEVEL = "debug"
 DEV_ADMIN_USER = "admin"
 DEV_ADMIN_PASS = "i-am-admin"
 DEV_USER = "user"

--- a/web/content/docs/development/rules/cli-design.md
+++ b/web/content/docs/development/rules/cli-design.md
@@ -272,7 +272,8 @@ variables include:
 | `STELLA_HOME`         | Stella home directory                      |
 | `STELLA_DATABASE_URL` | External PostgreSQL connection URL         |
 | `STELLA_VAULT_KEY`    | age secret key for daemon vault encryption |
-| `LOG_LEVEL`           | CLI logging verbosity                      |
+| `LOG_LEVEL`           | CLI logging verbosity (default `INFO`)     |
+| `LOG_LEVEL_RIVER`     | River job-queue logging (default `WARN`)   |
 
 Never print secrets except for explicit generation commands such as
 `stellad vault keygen`, where the secret value is the requested output.

--- a/web/content/docs/development/rules/cli-design.zh.md
+++ b/web/content/docs/development/rules/cli-design.zh.md
@@ -224,12 +224,13 @@ flag > environment variable > persisted config > default
 
 环境变量影响行为时，在 help 文本中说明。常见变量包括：
 
-| 变量                  | 用途                            |
-| --------------------- | ------------------------------- |
-| `STELLA_HOME`         | Stella 主目录                   |
-| `STELLA_DATABASE_URL` | 外部 PostgreSQL 连接 URL        |
-| `STELLA_VAULT_KEY`    | 守护进程保险库加密用的 age 私钥 |
-| `LOG_LEVEL`           | CLI 日志详细程度                |
+| 变量                  | 用途                              |
+| --------------------- | --------------------------------- |
+| `STELLA_HOME`         | Stella 主目录                     |
+| `STELLA_DATABASE_URL` | 外部 PostgreSQL 连接 URL          |
+| `STELLA_VAULT_KEY`    | 守护进程保险库加密用的 age 私钥   |
+| `LOG_LEVEL`           | CLI 日志详细程度（默认 `INFO`）   |
+| `LOG_LEVEL_RIVER`     | River 任务队列日志（默认 `WARN`） |
 
 除了 `stellad vault keygen` 这类明确生成 secret、且 secret 就是请求输出的命令，不要打印 secret。
 

--- a/web/content/docs/guides/observability.md
+++ b/web/content/docs/guides/observability.md
@@ -39,6 +39,14 @@ level=INFO msg=post_tool_call hook=trace tool=bash call_id=call_01 is_error=fals
 level=INFO msg=post_memory_call hook=trace op=compact duration=200ms token_count=8000 token_delta=-4500
 ```
 
+Every HTTP request also logs one INFO line (`msg="http request"` with method, path, status, duration, response size, and — when tracing is enabled — the request's `trace_id`, so you can jump from a log line to its trace). Requests that fail with a server error log at ERROR; health probes and static assets log at DEBUG.
+
+The internal job queue that drives scheduled and background work logs only warnings and errors by default, so it does not drown the signals above. Set `LOG_LEVEL_RIVER` (same values as `LOG_LEVEL`) to open it up when debugging scheduled work:
+
+```bash
+LOG_LEVEL_RIVER=DEBUG stellad server
+```
+
 ### OpenTelemetry Mode
 
 Set `OTEL_EXPORTER_OTLP_ENDPOINT` to enable traces and logs together, or use signal-specific exporter variables to enable only one signal. If the backend does not support the logs service (e.g. Jaeger), Stella detects the first failure and silently disables log export. Stella delegates exporter configuration to the OpenTelemetry SDK, so standard OTel environment variables are supported:

--- a/web/content/docs/guides/observability.md
+++ b/web/content/docs/guides/observability.md
@@ -49,7 +49,7 @@ LOG_LEVEL_RIVER=DEBUG stellad server
 
 ### OpenTelemetry Mode
 
-Set `OTEL_EXPORTER_OTLP_ENDPOINT` to enable traces and logs together, or use signal-specific exporter variables to enable only one signal. If the backend does not support the logs service (e.g. Jaeger), Stella detects the first failure and silently disables log export. Stella delegates exporter configuration to the OpenTelemetry SDK, so standard OTel environment variables are supported:
+Set `OTEL_EXPORTER_OTLP_ENDPOINT` to enable traces, logs, and metrics together, or use signal-specific exporter variables to enable only some signals. Metrics cover the HTTP server (request counts, durations) and the Go runtime (memory, GC, goroutines). If the backend does not support the logs service (e.g. Jaeger), Stella detects the first failure and silently disables log export. Stella delegates exporter configuration to the OpenTelemetry SDK, so standard OTel environment variables are supported:
 
 | Environment Variable                 | Default                    | Description                                                                                                                                                                                               |
 | ------------------------------------ | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -62,11 +62,13 @@ Set `OTEL_EXPORTER_OTLP_ENDPOINT` to enable traces and logs together, or use sig
 | `OTEL_EXPORTER_OTLP_LOGS_HEADERS`    | _(empty)_                  | Comma-separated headers applied to logs only. Overrides generic OTLP headers for logs.                                                                                                                    |
 | `OTEL_TRACES_EXPORTER`               | SDK default                | Trace exporter. Set to `none` to disable trace export while keeping other OTel signals available.                                                                                                         |
 | `OTEL_LOGS_EXPORTER`                 | SDK default                | Log exporter. Set to `none` to disable log export while keeping traces available.                                                                                                                         |
+| `OTEL_METRICS_EXPORTER`              | SDK default                | Metric exporter. Set to `none` to disable metric export while keeping other OTel signals available.                                                                                                       |
 | `OTEL_SERVICE_NAME`                  | `stella`                   | Service name shown in your observability backend.                                                                                                                                                         |
+| `OTEL_RESOURCE_ATTRIBUTES`           | _(empty)_                  | Extra resource attributes attached to every signal, for example `deployment.environment=prod`.                                                                                                            |
 | `OTEL_EXPORTER_OTLP_INSECURE`        | SDK default                | Set to `false` to require TLS. Use `false` for HTTPS or secure gRPC endpoints.                                                                                                                            |
 | `OTEL_STELLA_RECORD_TOOL_IO`         | `false`                    | Set to `true` to record tool input (e.g. bash commands) and result text on spans. Off by default so this content is never exported; spans always carry tool name, argument count, and result length.      |
 
-When OTel is enabled, both modes run simultaneously -- you get stderr log lines plus exported traces and logs.
+When OTel is enabled, both modes run simultaneously -- you get stderr log lines plus exported traces, logs, and metrics. Log lines written on a traced path (LLM calls, tool calls, HTTP requests) carry `trace_id` and `span_id`, so you can jump from a stderr line straight to the trace in your backend.
 
 ### Common Pitfalls
 
@@ -279,4 +281,4 @@ Sandbox lifecycle spans use these Stella-specific attributes:
 
 ## Turning It Off
 
-There is no plugin to disable. Log mode follows `LOG_LEVEL`; set it to `WARN` or `ERROR` to quiet the per-call INFO lines. OTel export is off unless `OTEL_EXPORTER_OTLP_ENDPOINT` or a signal-specific exporter is set, so leaving those variables empty disables distributed telemetry entirely. Set `OTEL_TRACES_EXPORTER=none` or `OTEL_LOGS_EXPORTER=none` to disable only one signal.
+There is no plugin to disable. Log mode follows `LOG_LEVEL`; set it to `WARN` or `ERROR` to quiet the per-call INFO lines. OTel export is off unless `OTEL_EXPORTER_OTLP_ENDPOINT` or a signal-specific exporter is set, so leaving those variables empty disables distributed telemetry entirely. Set `OTEL_TRACES_EXPORTER=none`, `OTEL_LOGS_EXPORTER=none`, or `OTEL_METRICS_EXPORTER=none` to disable individual signals.

--- a/web/content/docs/guides/observability.zh.md
+++ b/web/content/docs/guides/observability.zh.md
@@ -49,7 +49,7 @@ LOG_LEVEL_RIVER=DEBUG stellad server
 
 ### OpenTelemetry 模式
 
-设置 `OTEL_EXPORTER_OTLP_ENDPOINT` 会同时启用追踪和日志；也可以用信号专用导出器变量只启用其中一种信号。如果后端不支持日志服务（如 Jaeger），Stella 会在首次失败后自动禁用日志导出。Stella 将导出器配置交给 OpenTelemetry SDK，因此支持标准的 OTel 环境变量：
+设置 `OTEL_EXPORTER_OTLP_ENDPOINT` 会同时启用追踪、日志和指标；也可以用信号专用导出器变量只启用部分信号。指标覆盖 HTTP 服务器（请求数、耗时）和 Go 运行时（内存、GC、goroutine）。如果后端不支持日志服务（如 Jaeger），Stella 会在首次失败后自动禁用日志导出。Stella 将导出器配置交给 OpenTelemetry SDK，因此支持标准的 OTel 环境变量：
 
 | 环境变量                             | 默认值              | 说明                                                                                                                                                                            |
 | ------------------------------------ | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -62,11 +62,13 @@ LOG_LEVEL_RIVER=DEBUG stellad server
 | `OTEL_EXPORTER_OTLP_LOGS_HEADERS`    | _(空)_              | 仅应用于 logs 的逗号分隔请求头。会覆盖针对 logs 的通用 OTLP 请求头。                                                                                                            |
 | `OTEL_TRACES_EXPORTER`               | SDK 默认            | Trace 导出器。设为 `none` 可只关闭 trace 导出，保留其他 OTel 信号。                                                                                                             |
 | `OTEL_LOGS_EXPORTER`                 | SDK 默认            | Log 导出器。设为 `none` 可只关闭 log 导出，保留 trace。                                                                                                                         |
+| `OTEL_METRICS_EXPORTER`              | SDK 默认            | 指标导出器。设为 `none` 可只关闭指标导出，保留其他 OTel 信号。                                                                                                                  |
 | `OTEL_SERVICE_NAME`                  | `stella`            | 在可观测性后端显示的服务名。                                                                                                                                                    |
+| `OTEL_RESOURCE_ATTRIBUTES`           | _(空)_              | 附加到所有信号的资源属性，例如 `deployment.environment=prod`。                                                                                                                  |
 | `OTEL_EXPORTER_OTLP_INSECURE`        | SDK 默认            | 设为 `false` 以要求 TLS。HTTPS 或安全 gRPC 端点请使用 `false`。                                                                                                                 |
 | `OTEL_STELLA_RECORD_TOOL_IO`         | `false`             | 设为 `true` 才会把工具输入(如 bash 命令)和结果文本记录到 span。默认关闭,因此这些内容永不导出;span 始终携带工具名、参数数量与结果长度。                                          |
 
-启用 OTel 后，两种模式会同时运行——你既能看到 stderr 日志行，也能导出追踪和日志。
+启用 OTel 后，两种模式会同时运行——你既能看到 stderr 日志行，也能导出追踪、日志和指标。处于追踪路径上的日志行（LLM 调用、工具调用、HTTP 请求）会携带 `trace_id` 和 `span_id`，可以直接从 stderr 行跳到后端里对应的 trace。
 
 ### 常见陷阱
 
@@ -279,4 +281,4 @@ LLM 与工具 span 遵循 [OpenTelemetry GenAI 语义约定](https://opentelemet
 
 ## 如何关闭
 
-没有可禁用的插件。日志模式跟随 `LOG_LEVEL`，设为 `WARN` 或 `ERROR` 即可静默每次调用的 INFO 行。除非设置了 `OTEL_EXPORTER_OTLP_ENDPOINT` 或信号专用导出器，否则 OTel 导出默认关闭；留空这些变量即可完全停用分布式遥测。设 `OTEL_TRACES_EXPORTER=none` 或 `OTEL_LOGS_EXPORTER=none` 可以只关闭其中一种信号。
+没有可禁用的插件。日志模式跟随 `LOG_LEVEL`，设为 `WARN` 或 `ERROR` 即可静默每次调用的 INFO 行。除非设置了 `OTEL_EXPORTER_OTLP_ENDPOINT` 或信号专用导出器，否则 OTel 导出默认关闭；留空这些变量即可完全停用分布式遥测。设 `OTEL_TRACES_EXPORTER=none`、`OTEL_LOGS_EXPORTER=none` 或 `OTEL_METRICS_EXPORTER=none` 可以按信号单独关闭。

--- a/web/content/docs/guides/observability.zh.md
+++ b/web/content/docs/guides/observability.zh.md
@@ -39,6 +39,14 @@ level=INFO msg=post_tool_call hook=trace tool=bash call_id=call_01 is_error=fals
 level=INFO msg=post_memory_call hook=trace op=compact duration=200ms token_count=8000 token_delta=-4500
 ```
 
+每个 HTTP 请求还会记录一条 INFO 日志（`msg="http request"`，包含方法、路径、状态码、耗时、响应大小，启用追踪时还带 `trace_id`，方便从日志跳到对应 trace）。返回服务端错误的请求记为 ERROR；健康检查和静态资源记为 DEBUG。
+
+驱动定时和后台工作的内部任务队列默认只记录警告和错误，避免淹没上面的信号。调试定时任务时，可设置 `LOG_LEVEL_RIVER`（取值与 `LOG_LEVEL` 相同）打开它：
+
+```bash
+LOG_LEVEL_RIVER=DEBUG stellad server
+```
+
 ### OpenTelemetry 模式
 
 设置 `OTEL_EXPORTER_OTLP_ENDPOINT` 会同时启用追踪和日志；也可以用信号专用导出器变量只启用其中一种信号。如果后端不支持日志服务（如 Jaeger），Stella 会在首次失败后自动禁用日志导出。Stella 将导出器配置交给 OpenTelemetry SDK，因此支持标准的 OTel 环境变量：


### PR DESCRIPTION
Closes #745

## What

The full #745 audit in two commits: logging signal-to-noise fixes, then the OTel gaps.

**Commit 1 — logging:**

1. **River logger capped at WARN** — a min-level slog handler wraps the logger passed to the shared River client. `LOG_LEVEL_RIVER` (new, routed through `ServerConfig.Observability`) opens it up for queue debugging.
2. **Sane default levels** — `ParseLogLevel` falls back to INFO instead of DEBUG (the observability guide already documented INFO as the default; code now matches). `mise.toml` dev env drops from `trace` to `debug`.
3. **HTTP access log middleware** — one line per request: method, path, status, duration, bytes. Applied to the main handler chain and the webhook ingress. 5xx logs at ERROR; `/healthz`, `/readyz`, and static assets at DEBUG.

**Commit 2 — OTel:**

4. **Metrics signal** — `OTEL_METRICS_EXPORTER` / the generic OTLP endpoint now build a MeterProvider via autoexport; otelhttp emits HTTP server metrics on its own, and contrib runtime instrumentation adds memory/GC/goroutine metrics. New dependency: `go.opentelemetry.io/contrib/instrumentation/runtime`.
5. **Resource fix** — `resource.New` has no default detectors, so `OTEL_RESOURCE_ATTRIBUTES` was silently dropped. Added `resource.WithFromEnv()` (last, so env wins) and `service.version` from `internal/version`.
6. **Log↔trace correlation** — a trace-context slog handler (installed in `main`) stamps `trace_id`/`span_id` onto any record logged with a span-carrying context. Tracehook LLM/tool/agent/memory lines, the access log, and the auth-reject warn now use the `*Context` variants, so stderr lines link straight to exported traces.

## Why

On main, 90 seconds of `dist/logs/dev.log` is 233 lines with 198 of them `component=river` heartbeats from the 2-second goal tick — and hitting the API (even a 401) produces zero log output. OTel had no metrics provider, dropped `OTEL_RESOURCE_ATTRIBUTES`, and almost no log line carried trace context. See #745 for the full audit.

## Verification

- `mise run format && mise run build && mise run test` green after each commit; `mise run system-test` green.
- New unit tests: `ParseLogLevel` defaults, min-level handler, access-log levels/attrs, SSE Flusher preservation, trace-context handler, metrics-only Init/Shutdown, resource env-attrs + service.version.
- Live smoke (`mise run dev` against a local OTLP collector): river lines dropped from 198/90s to **0**; all three "otel … enabled" startup lines present; runtime metrics started clean, no export errors over a full periodic-reader cycle; access log now reads
  `level=INFO msg="http request" method=GET path=/api/agents status=401 duration=16µs bytes=86 trace_id=4f18a5de… span_id=b9984807…`.
- Side effect worth noting: with River quiet, a real pre-existing WARN (`dispatcher: zombie goal`) is now visible in dev logs.
- Known flake: the goal-journey system test failed once (model-request ordering) and passed on 4 subsequent runs including targeted reruns; unrelated to these changes.

## Compatibility note

Setting only `OTEL_EXPORTER_OTLP_ENDPOINT` now enables metrics in addition to traces and logs (standard OTel semantics). Opt out per signal with `OTEL_METRICS_EXPORTER=none`.