### PR TITLE
🐛 fix: Accept root-level skill ZIP uploads

### DIFF
--- a/internal/server/skills_upload.go
+++ b/internal/server/skills_upload.go
@@ -95,7 +95,7 @@ func parseUploadedSkill(r *http.Request) (*uploadedSkill, int, string, error) {
 	defer func() { _ = file.Close() }()
 	up, err := readUploadedSkillArchive(file, header)
 	if err != nil {
-		return nil, http.StatusBadRequest, "invalid skill archive", err
+		return nil, http.StatusBadRequest, "invalid skill archive: " + err.Error(), err
 	}
 	return up, 0, "", nil
 }
@@ -132,28 +132,34 @@ func readUploadedSkillArchive(file multipart.File, header *multipart.FileHeader)
 		}
 	}
 	if len(roots) == 0 {
-		return nil, fmt.Errorf("archive must contain exactly one skill folder with SKILL.md")
+		return nil, fmt.Errorf("archive must contain SKILL.md")
 	}
 	if len(roots) > 1 {
-		return nil, fmt.Errorf("archive must contain exactly one skill folder with SKILL.md")
+		return nil, fmt.Errorf("archive must contain exactly one SKILL.md")
 	}
 
 	var root string
 	for candidate := range roots {
 		root = candidate
 	}
-	if root == "." || root == "" {
-		return nil, fmt.Errorf("archive must contain a skill folder with SKILL.md")
+	if root == "." {
+		root = ""
 	}
 
 	files := make(map[string]string, len(entries))
-	prefix := root + "/"
+	prefix := ""
+	if root != "" {
+		prefix = root + "/"
+	}
 	var expanded int64
 	for name, entry := range entries {
-		if !strings.HasPrefix(name, prefix) {
+		if prefix != "" && !strings.HasPrefix(name, prefix) {
 			return nil, fmt.Errorf("archive must contain only one skill folder")
 		}
-		rel := strings.TrimPrefix(name, prefix)
+		rel := name
+		if prefix != "" {
+			rel = strings.TrimPrefix(name, prefix)
+		}
 		if rel == "" || strings.Contains(rel, "../") || strings.HasPrefix(rel, "/") {
 			return nil, fmt.Errorf("invalid archive path %q", name)
 		}
@@ -178,9 +184,16 @@ func readUploadedSkillArchive(file multipart.File, header *multipart.FileHeader)
 	}
 	name := strings.TrimSpace(fm.Name)
 	if name == "" {
+		if root == "" {
+			return nil, fmt.Errorf("SKILL.md name is required when it is at the archive root")
+		}
 		name = path.Base(root)
 	}
-	if errs := skills.ValidateSkillName(name, path.Base(root)); len(errs) > 0 {
+	parentDirName := name
+	if root != "" {
+		parentDirName = path.Base(root)
+	}
+	if errs := skills.ValidateSkillName(name, parentDirName); len(errs) > 0 {
 		return nil, fmt.Errorf("invalid skill name %q: %s", name, strings.Join(errs, "; "))
 	}
 	createdAt := strings.TrimSpace(fm.CreatedAt)

--- a/internal/server/skills_upload_test.go
+++ b/internal/server/skills_upload_test.go
@@ -1,6 +1,88 @@
 package server
 
-import "testing"
+import (
+	"archive/zip"
+	"bytes"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type uploadArchiveFile struct {
+	*bytes.Reader
+}
+
+func (uploadArchiveFile) Close() error { return nil }
+
+func TestReadUploadedSkillArchiveAcceptsSkillAtArchiveRoot(t *testing.T) {
+	archive := makeUploadArchive(t, map[string]string{
+		"SKILL.md":          "---\nname: root-skill\ndescription: Root-level user skill\n---\n# Root Skill\n",
+		"references/api.md": "notes",
+	})
+
+	up, err := readUploadedSkillArchive(
+		uploadArchiveFile{Reader: bytes.NewReader(archive)},
+		&multipart.FileHeader{Filename: "root-skill.zip"},
+	)
+	if err != nil {
+		t.Fatalf("read root-level skill archive: %v", err)
+	}
+	if up.name != "root-skill" {
+		t.Fatalf("skill name = %q, want root-skill", up.name)
+	}
+	if up.files["SKILL.md"] == "" || up.files["references/api.md"] != "notes" {
+		t.Fatalf("uploaded files = %#v, want root-relative skill files", up.files)
+	}
+}
+
+func TestParseUploadedSkillReturnsActionableArchiveError(t *testing.T) {
+	archive := makeUploadArchive(t, map[string]string{
+		"references/api.md": "notes",
+	})
+	var body bytes.Buffer
+	w := multipart.NewWriter(&body)
+	part, err := w.CreateFormFile("file", "missing-skill-md.zip")
+	if err != nil {
+		t.Fatalf("create form file: %v", err)
+	}
+	if _, err := part.Write(archive); err != nil {
+		t.Fatalf("write archive: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close multipart body: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/skills/upload", &body)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	_, code, msg, parseErr := parseUploadedSkill(req)
+	if code != http.StatusBadRequest || parseErr == nil {
+		t.Fatalf("parse result = code %d, err %v; want 400 with error", code, parseErr)
+	}
+	if !strings.Contains(msg, "archive must contain SKILL.md") {
+		t.Fatalf("client message = %q, want actionable missing SKILL.md reason", msg)
+	}
+}
+
+func makeUploadArchive(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for name, content := range files {
+		entry, err := zw.Create(name)
+		if err != nil {
+			t.Fatalf("create zip entry %q: %v", name, err)
+		}
+		if _, err := entry.Write([]byte(content)); err != nil {
+			t.Fatalf("write zip entry %q: %v", name, err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+	return buf.Bytes()
+}
 
 func TestNormalizeUploadedSkillPathSkipsHiddenDirectories(t *testing.T) {
 	paths := []string{


### PR DESCRIPTION
## What

- Accept skill ZIPs with `SKILL.md` at the archive root.
- Preserve support for a single nested skill directory.
- Return actionable archive validation reasons in structured 400 responses.
- Add focused parser tests that do not require PostgreSQL.

## Why

Manual uploads rejected a common skill package layout that Stella's ClawHub reader already accepts. The generic error response also made valid packaging mistakes difficult to diagnose.

## How

The upload parser now treats `.` as an empty archive prefix and stores root-level files with their original relative paths. A root-level skill must declare its frontmatter `name`; nested archives retain the directory-name fallback and name-match validation.

## Test plan

- `go test ./internal/server -run 'Test(NormalizeUploadedSkillPath|ReadUploadedSkillArchive|ParseUploadedSkill)' -count=1`
- `golangci-lint run --new-from-rev=HEAD ./internal/server/...`
- `go build -o dist/bin/stellad.exe ./cmd/stellad`

Full database-backed tests cannot run on this Windows host because Stella does not publish an embedded PostgreSQL runtime for `windows/amd64`; CI will run the repository's Linux test gate.

Closes #755
