### PR TITLE
🔒 fix: gate unsafe host sandbox execution

### DIFF
--- a/cmd/stellad/commands.go
+++ b/cmd/stellad/commands.go
@@ -409,6 +409,7 @@ func setup(parent context.Context, cfg config.ServerConfig, baseURL string) (*se
 	poolMgr = agent.NewPoolManager(store, memProvider,
 		agent.WithCompactionPM(agent.CompactionConfig{}.WithDefaults()),
 		agent.WithAssetStorePM(assetStore),
+		agent.WithUnsafeHostExecution(cfg.Sandbox.AllowUnsafeHostExecution),
 		agent.WithBuiltinTools(builtinTools),
 		agent.WithPluginToolsBuilder(pluginToolsBuilder),
 		agent.WithPluginHooksBuilder(pluginHooksBuilder),

--- a/deploy/helm/check.sh
+++ b/deploy/helm/check.sh
@@ -95,11 +95,6 @@ expect_ok "image digest pins over tag" "${BASE[@]}" --set sandbox.backend=local 
   --set image.digest=sha256:0123456789abcdef
 assert_contains "image pinned by digest"     "ghcr.io/cherryhq/stella@sha256:0123456789abcdef"
 
-expect_ok "sandbox=none with confirmation" "${BASE[@]}" \
-  --set sandbox.backend=none --set sandbox.allowUnsafeHostExecution=true
-assert_contains "none drops escalation"      "allowPrivilegeEscalation: false"
-assert_contains "none drops capabilities"    'drop: ["ALL"]'
-
 expect_ok "ephemeral storage with confirmation" "${BASE[@]}" \
   --set sandbox.backend=local --set persistence.enabled=false \
   --set persistence.allowEphemeralDataLoss=true
@@ -142,8 +137,10 @@ expect_fail "missing existingSecret" "existingSecret" \
 expect_fail "replicaCount=2" "replica" \
   "${BASE[@]}" --set sandbox.backend=local --set replicaCount=2
 expect_fail "sandbox backend missing" "sandbox.backend" "${BASE[@]}"
-expect_fail "sandbox=none without confirmation" "allowUnsafeHostExecution" \
+expect_fail "sandbox=none is unsupported" 'sandbox.backend must be one of the following: "", "local"' \
   "${BASE[@]}" --set sandbox.backend=none
+expect_fail "sandbox=none escape hatch is unsupported" 'sandbox.backend must be one of the following: "", "local"' \
+  "${BASE[@]}" --set sandbox.backend=none --set sandbox.allowUnsafeHostExecution=true
 expect_fail "grace period too small" "terminationGracePeriodSeconds" \
   "${BASE[@]}" --set sandbox.backend=local \
   --set shutdown.terminationGracePeriodSeconds=50
@@ -172,9 +169,6 @@ expect_fail "podLabels overrides selector" "podLabels must not set" \
   --set 'podLabels.app\.kubernetes\.io/name=evil'
 expect_fail "invalid seccompProfile rejected" "seccompProfile" \
   "${BASE[@]}" --set sandbox.backend=local --set sandbox.seccompProfile=Wide
-expect_fail "none must not weaken seccomp" "seccompProfile=RuntimeDefault" \
-  "${BASE[@]}" --set sandbox.backend=none --set sandbox.allowUnsafeHostExecution=true \
-  --set sandbox.seccompProfile=Unconfined
 expect_fail "ingress enabled without hosts" "ingress.hosts" \
   "${BASE[@]}" --set sandbox.backend=local --set ingress.enabled=true --set 'ingress.hosts=null'
 

--- a/deploy/helm/stella/templates/NOTES.txt
+++ b/deploy/helm/stella/templates/NOTES.txt
@@ -38,15 +38,9 @@ Updating the Secret does NOT restart the pod. Roll it after a secret change:
 Sandbox
 -------
 sandbox.backend = {{ .Values.sandbox.backend }}
-{{- if eq (trim .Values.sandbox.backend) "none" }}
-  backend=none runs agent tools directly inside the Stella pod WITHOUT sandbox
-  isolation. It does not disable agent tools.
-{{- else }}
   backend=local (bubblewrap) is experimental and requires a cluster that permits
-  unprivileged user namespaces. If tools fail with bwrap/unshare errors, switch
-  to backend=none (and set sandbox.allowUnsafeHostExecution=true) or adjust the
-  cluster.
-{{- end }}
+  unprivileged user namespaces. If tools fail with bwrap/unshare errors, adjust
+  the cluster; this chart intentionally does not support host execution.
 
 Storage
 -------

--- a/deploy/helm/stella/templates/_helpers.tpl
+++ b/deploy/helm/stella/templates/_helpers.tpl
@@ -114,19 +114,10 @@ actionable message. Kept in one place so every template shares the same checks.
 
 {{- $backend := trim $v.sandbox.backend -}}
 {{- if not $backend -}}
-{{- fail "stella: sandbox.backend is required — set it to 'local' (bubblewrap, experimental) or 'none' (no isolation). The 'docker' backend is not supported by this chart." -}}
+{{- fail "stella: sandbox.backend is required — set it to 'local' (bubblewrap, experimental). Host execution (none) and the docker backend are not supported by this chart." -}}
 {{- end -}}
-{{- if not (has $backend (list "local" "none")) -}}
-{{- fail (printf "stella: sandbox.backend must be 'local' or 'none' (got %q). The 'docker' backend is not supported by this chart." $backend) -}}
-{{- end -}}
-{{- if and (eq $backend "none") (not $v.sandbox.allowUnsafeHostExecution) -}}
-{{- fail "stella: sandbox.backend=none runs agent tools directly inside the Stella pod with no isolation. Set sandbox.allowUnsafeHostExecution=true to acknowledge this, or choose sandbox.backend=local." -}}
-{{- end -}}
-{{- /* Unconfined seccomp only exists to unblock the local (bubblewrap) backend;
-       none never needs it, and keeping it (e.g. carried over by --reuse-values
-       when switching from local) would drop defence-in-depth for no reason. */ -}}
-{{- if and (eq $backend "none") (ne (trim $v.sandbox.seccompProfile) "RuntimeDefault") -}}
-{{- fail "stella: sandbox.backend=none requires sandbox.seccompProfile=RuntimeDefault; Unconfined is only an escape hatch for the local bubblewrap backend." -}}
+{{- if ne $backend "local" -}}
+{{- fail (printf "stella: sandbox.backend must be 'local' (got %q). Host execution (none) and the docker backend are not supported by this chart." $backend) -}}
 {{- end -}}
 
 {{- $s := $v.shutdown -}}

--- a/deploy/helm/stella/templates/deployment.yaml
+++ b/deploy/helm/stella/templates/deployment.yaml
@@ -51,15 +51,6 @@ spec:
         - name: stella
           image: {{ include "stella.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if eq (trim .Values.sandbox.backend) "none" }}
-          # With no sandbox there is no reason to keep escalation paths open.
-          # The local (bubblewrap) backend omits this: bwrap needs user
-          # namespaces and, on setuid installs, privilege escalation.
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: ["ALL"]
-          {{- end }}
           ports:
             - name: http
               containerPort: 25678

--- a/deploy/helm/stella/values.schema.json
+++ b/deploy/helm/stella/values.schema.json
@@ -56,10 +56,9 @@
       "properties": {
         "backend": {
           "type": "string",
-          "enum": ["", "local", "none"],
-          "description": "docker is intentionally unsupported by this chart."
+          "enum": ["", "local"],
+          "description": "host execution (none) and docker are intentionally unsupported by this chart."
         },
-        "allowUnsafeHostExecution": { "type": "boolean" },
         "seccompProfile": {
           "type": "string",
           "enum": ["RuntimeDefault", "Unconfined"]

--- a/deploy/helm/stella/values.yaml
+++ b/deploy/helm/stella/values.yaml
@@ -47,20 +47,11 @@ secrets:
     databaseURL: STELLA_DATABASE_URL
 
 sandbox:
-  # Which sandbox backend agent tools use. Required, no default. One of:
-  #   local — bubblewrap isolation. EXPERIMENTAL: needs a cluster that permits
-  #           unprivileged user namespaces. The chart adds no privileges and
-  #           mounts no docker socket.
-  #   none  — no sandbox isolation. Agent tools run directly inside the Stella
-  #           pod. This does NOT disable agent tools; it removes their isolation.
-  # The `docker` backend is intentionally unsupported here (no docker socket).
+  # Required local bubblewrap backend. The chart adds no privileges and mounts
+  # no Docker socket; host execution (backend=none) is intentionally unsupported.
   backend: ""
-  # Must be true when backend is "none" to acknowledge that agent tools execute
-  # unsandboxed inside the pod. Ignored for other backends.
-  allowUnsafeHostExecution: false
   # Pod seccomp profile. RuntimeDefault is the hardened default. If backend=local
-  # (bubblewrap) fails with seccomp/namespace errors on your cluster, set this to
-  # Unconfined; backend=none never needs it.
+  # fails with seccomp/namespace errors on your cluster, set this to Unconfined.
   seccompProfile: RuntimeDefault
 
 # Two-phase graceful-shutdown budget, in whole seconds. See the deployment docs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,8 @@ services:
       - GITHUB_TOKEN=${GITHUB_TOKEN:-}
       # External PostgreSQL DSN -> use the postgres service instead of the managed embedded server
       - STELLA_DATABASE_URL=postgres://postgres:postgres@postgres:5432/stella?sslmode=disable
-      # Lock sandbox backend via env (docker | local | none); UI becomes read-only
+      # Lock sandbox backend via env (docker | local | none); none also requires
+      # STELLA_ALLOW_UNSAFE_HOST_EXECUTION=true. UI becomes read-only.
       - STELLA_SANDBOX_BACKEND=docker
       # Explicit Docker sandbox mode: host | bind | volume
       - STELLA_DOCKER_SANDBOX_MODE=volume

--- a/internal/agent/pool_manager.go
+++ b/internal/agent/pool_manager.go
@@ -133,6 +133,12 @@ func WithAssetStorePM(a *asset.Store) PoolManagerOption {
 	return func(pm *PoolManager) { pm.assets = a }
 }
 
+// WithUnsafeHostExecution permits the explicitly unsafe none sandbox backend.
+// The boot-time setting is passed only to the session-selection boundary.
+func WithUnsafeHostExecution(allow bool) PoolManagerOption {
+	return func(pm *PoolManager) { pm.allowUnsafeHostExecution = allow }
+}
+
 // PoolManager manages one Service per enabled agent. It reads enabled agents
 // from the config Store and creates a Service (session.Registry + runtime.Runtime)
 // per agent.
@@ -167,6 +173,7 @@ type PoolManager struct {
 	tokenManager             *oauth.TokenManager
 	oauthRegistry            *oauth.ProviderRegistry
 	assets                   *asset.Store
+	allowUnsafeHostExecution bool
 	sessionAccess            SessionAccessService
 	log                      *slog.Logger
 }
@@ -685,6 +692,7 @@ func (pm *PoolManager) buildRunnerFunc(_ context.Context, snap *config.Snapshot)
 		ToolOverrideFetcher:      pm.toolOverrideFetcher,
 		ToolLifecycle:            pm.toolLifecycle,
 		SandboxBackendFn:         sandboxBackendFn,
+		AllowUnsafeHostExecution: pm.allowUnsafeHostExecution,
 		VaultEnvLoader:           pm.vaultEnvLoader,
 		TokenManager:             pm.tokenManager,
 		ProjectResolver:          pm.projectResolver,

--- a/internal/agent/runner_builder.go
+++ b/internal/agent/runner_builder.go
@@ -51,6 +51,7 @@ type runnerBuilderConfig struct {
 	ToolOverrideFetcher      ToolOverrideFetcher
 	ToolLifecycle            *coreagent.ToolLifecycle
 	SandboxBackendFn         func(ctx context.Context) string
+	AllowUnsafeHostExecution bool
 	VaultEnvLoader           sandbox.VaultEnvLoader
 	TokenManager             *oauth.TokenManager
 	ProjectResolver          ProjectResolverFunc
@@ -202,8 +203,9 @@ func newRunnerFunc(cfg runnerBuilderConfig) NewRunnerFunc {
 
 		sessionSecretValues := sandbox.NewSessionSecretValues()
 		sandboxCfg := sandbox.Config{
-			SandboxConfig:    cfg.Snap.Sandbox,
-			SandboxBackendFn: cfg.SandboxBackendFn,
+			SandboxConfig:            cfg.Snap.Sandbox,
+			SandboxBackendFn:         cfg.SandboxBackendFn,
+			AllowUnsafeHostExecution: cfg.AllowUnsafeHostExecution,
 			Paths: sandbox.Paths{
 				StellaHome:  config.StellaHome(),
 				AgentRoot:   cfg.Snap.Workspace,

--- a/internal/agent/runner_builder_test.go
+++ b/internal/agent/runner_builder_test.go
@@ -52,7 +52,8 @@ func TestNewRunnerFuncPassesProjectRootToSystemPrompt(t *testing.T) {
 		ProviderStreamBuilder: func(api, apiKey, baseURL string) (providers.StreamFunc, error) {
 			return providers.AdapterStreamFunc(fakeStreamProvider{}), nil
 		},
-		SandboxBackendFn: func(context.Context) string { return config.SandboxBackendNone },
+		SandboxBackendFn:         func(context.Context) string { return config.SandboxBackendNone },
+		AllowUnsafeHostExecution: true,
 		ProjectResolver: func(ctx context.Context, projectID, userID string) (string, error) {
 			if projectID != "project-1" || userID != "user-1" {
 				t.Fatalf("ProjectResolver called with projectID=%q userID=%q", projectID, userID)

--- a/internal/agent/sandbox/backend_test.go
+++ b/internal/agent/sandbox/backend_test.go
@@ -85,6 +85,61 @@ func TestResolveSessionRequiresUserRoot(t *testing.T) {
 	}
 }
 
+func TestResolveSessionRejectsNoneWithoutUnsafeHostExecution(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		setup func(t *testing.T) func(context.Context) string
+	}{
+		{
+			name: "environment override",
+			setup: func(t *testing.T) func(context.Context) string {
+				t.Setenv("STELLA_SANDBOX_BACKEND", config.SandboxBackendNone)
+				return func(context.Context) string { return config.ActiveSandboxBackend(nil) }
+			},
+		},
+		{
+			name: "enabled database plugin",
+			setup: func(_ *testing.T) func(context.Context) string {
+				plugins := []config.Plugin{{
+					Kind:    config.PluginKindSandbox,
+					Name:    config.SandboxBackendNone,
+					Enabled: true,
+				}}
+				return func(context.Context) string { return config.ActiveSandboxBackend(plugins) }
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ResolveSession(context.Background(), Config{SandboxBackendFn: tc.setup(t)})
+			if err == nil {
+				t.Fatal("ResolveSession() error = nil, want unsafe host execution rejection")
+			}
+			if got := err.Error(); got != unsafeHostExecutionError {
+				t.Errorf("ResolveSession() error = %q, want %q", got, unsafeHostExecutionError)
+			}
+		})
+	}
+}
+
+func TestResolveSessionAllowsNoneWithUnsafeHostExecution(t *testing.T) {
+	root := t.TempDir()
+	session, err := ResolveSession(context.Background(), Config{
+		AllowUnsafeHostExecution: true,
+		SandboxBackendFn:         func(context.Context) string { return config.SandboxBackendNone },
+		Paths: Paths{
+			StellaHome: root,
+			AgentRoot:  filepath.Join(root, "agent"),
+			UserRoot:   filepath.Join(root, "user"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("ResolveSession() error = %v", err)
+	}
+	if err := session.Close(); err != nil {
+		t.Errorf("Close() error = %v", err)
+	}
+}
+
 func TestSandboxProcessEnvLeavesHomeUnsetForDocker(t *testing.T) {
 	cfg := Config{
 		Paths: Paths{

--- a/internal/agent/sandbox/config.go
+++ b/internal/agent/sandbox/config.go
@@ -24,18 +24,19 @@ type VaultEnvLoader interface {
 // Config is passed to sandbox operations.
 // It is constructed from the runner config in the parent agent package.
 type Config struct {
-	SandboxConfig       config.SandboxConfig
-	SandboxBackendFn    func(ctx context.Context) string
-	Paths               Paths
-	UserID              string
-	GroupID             string // non-empty for group sessions; vault/env use group principal
-	AgentID             string
-	SessionID           string
-	ProjectID           string
-	SessionEnvSpecs     []pkgplugins.SessionEnvSpec
-	VaultEnvLoader      VaultEnvLoader
-	SessionSecretValues *SessionSecretValues
-	TokenManager        *oauth.TokenManager
+	SandboxConfig            config.SandboxConfig
+	SandboxBackendFn         func(ctx context.Context) string
+	AllowUnsafeHostExecution bool
+	Paths                    Paths
+	UserID                   string
+	GroupID                  string // non-empty for group sessions; vault/env use group principal
+	AgentID                  string
+	SessionID                string
+	ProjectID                string
+	SessionEnvSpecs          []pkgplugins.SessionEnvSpec
+	VaultEnvLoader           VaultEnvLoader
+	SessionSecretValues      *SessionSecretValues
+	TokenManager             *oauth.TokenManager
 	// OAuthEnvBindings records which sandbox env vars were injected from an OAuth
 	// bundle at session creation, so a later live refresh reloads only those and
 	// never overwrites an explicit vault override of the same name. Shared by

--- a/internal/agent/sandbox/session.go
+++ b/internal/agent/sandbox/session.go
@@ -165,10 +165,22 @@ func resolveBackendName(ctx context.Context, cfg Config) string {
 	return name
 }
 
+const unsafeHostExecutionError = "sandbox backend \"none\" requires STELLA_ALLOW_UNSAFE_HOST_EXECUTION=true"
+
+func validateBackendSelection(name string, allowUnsafeHostExecution bool) error {
+	if name == config.SandboxBackendNone && !allowUnsafeHostExecution {
+		return fmt.Errorf("%s", unsafeHostExecutionError)
+	}
+	return nil
+}
+
 // ResolveSession creates a sandbox session from configuration.
 // The active backend is determined by SandboxBackendFn, defaulting to local.
 func ResolveSession(ctx context.Context, cfg Config) (pkgsandbox.Session, error) {
 	name := resolveBackendName(ctx, cfg)
+	if err := validateBackendSelection(name, cfg.AllowUnsafeHostExecution); err != nil {
+		return nil, err
+	}
 
 	ctx, span := sandboxTracer.Start(ctx, "sandbox.create_session",
 		trace.WithAttributes(
@@ -187,7 +199,11 @@ func ResolveSession(ctx context.Context, cfg Config) (pkgsandbox.Session, error)
 	}
 
 	return pkgsandbox.NewResilientSession(session, func(ctx context.Context) (pkgsandbox.Session, error) {
-		return createSessionForBackend(ctx, cfg, resolveBackendName(ctx, cfg))
+		name := resolveBackendName(ctx, cfg)
+		if err := validateBackendSelection(name, cfg.AllowUnsafeHostExecution); err != nil {
+			return nil, err
+		}
+		return createSessionForBackend(ctx, cfg, name)
 	}), nil
 }
 

--- a/internal/config/server_config.go
+++ b/internal/config/server_config.go
@@ -14,9 +14,10 @@ import (
 // source of truth for the normalized-environment key set and the parse-error
 // messages.
 const (
-	requireExternalDBEnv    = "STELLA_REQUIRE_EXTERNAL_DB"
-	httpShutdownTimeoutEnv  = "STELLA_HTTP_SHUTDOWN_TIMEOUT"
-	riverSoftStopTimeoutEnv = "STELLA_RIVER_SOFT_STOP_TIMEOUT"
+	requireExternalDBEnv        = "STELLA_REQUIRE_EXTERNAL_DB"
+	httpShutdownTimeoutEnv      = "STELLA_HTTP_SHUTDOWN_TIMEOUT"
+	riverSoftStopTimeoutEnv     = "STELLA_RIVER_SOFT_STOP_TIMEOUT"
+	allowUnsafeHostExecutionEnv = "STELLA_ALLOW_UNSAFE_HOST_EXECUTION"
 
 	// Raw passthrough vars: read with os.Getenv semantics (value or "" for
 	// unset/empty; no trim, no default). Their group-level validation stays with
@@ -104,6 +105,8 @@ type ServerConfig struct {
 	// Observability holds tracing/telemetry toggles owned by this server (the
 	// standard OTEL SDK variables stay with the SDK and are not mirrored here).
 	Observability ObservabilityConfig
+	// Sandbox controls server-wide safety gates for sandbox backend selection.
+	Sandbox SandboxRuntimeConfig
 }
 
 // VaultConfig carries the vault master key (STELLA_VAULT_KEY). The key is a
@@ -147,6 +150,13 @@ type ReflectConfig struct {
 	Interval    string
 	Mode        string
 	CuratorMode string
+}
+
+// SandboxRuntimeConfig holds server-wide sandbox safety settings.
+type SandboxRuntimeConfig struct {
+	// AllowUnsafeHostExecution permits the explicitly unsafe none backend. When
+	// false, agent sessions reject that backend before creating a host process.
+	AllowUnsafeHostExecution bool
 }
 
 // DiagnosticsConfig holds optional local debug-server settings.
@@ -199,9 +209,10 @@ const defaultServerURL = "http://127.0.0.1:25678"
 // with the Go field name and cannot enforce the ">0" bound — so we parse those
 // after the struct is populated to preserve the existing actionable messages.
 type rawServerConfig struct {
-	RequireExternalDB    string `env:"STELLA_REQUIRE_EXTERNAL_DB"`
-	HTTPShutdownTimeout  string `env:"STELLA_HTTP_SHUTDOWN_TIMEOUT"`
-	RiverSoftStopTimeout string `env:"STELLA_RIVER_SOFT_STOP_TIMEOUT"`
+	RequireExternalDB        string `env:"STELLA_REQUIRE_EXTERNAL_DB"`
+	AllowUnsafeHostExecution string `env:"STELLA_ALLOW_UNSAFE_HOST_EXECUTION"`
+	HTTPShutdownTimeout      string `env:"STELLA_HTTP_SHUTDOWN_TIMEOUT"`
+	RiverSoftStopTimeout     string `env:"STELLA_RIVER_SOFT_STOP_TIMEOUT"`
 }
 
 // serverConfigKeys is the closed set of normalized (trimmed, empty=default)
@@ -210,6 +221,7 @@ type rawServerConfig struct {
 // unrelated variable can never leak into the parse.
 var serverConfigKeys = []string{
 	requireExternalDBEnv,
+	allowUnsafeHostExecutionEnv,
 	httpShutdownTimeoutEnv,
 	riverSoftStopTimeoutEnv,
 }
@@ -297,6 +309,10 @@ func (raw rawServerConfig) convert() (ServerConfig, error) {
 	if err != nil {
 		errs = append(errs, err)
 	}
+	allowUnsafeHostExecution, err := parseServerBool(allowUnsafeHostExecutionEnv, raw.AllowUnsafeHostExecution)
+	if err != nil {
+		errs = append(errs, err)
+	}
 	httpTimeout, err := parseServerDuration(httpShutdownTimeoutEnv, raw.HTTPShutdownTimeout, defaultHTTPShutdownTimeout)
 	if err != nil {
 		errs = append(errs, err)
@@ -316,6 +332,9 @@ func (raw rawServerConfig) convert() (ServerConfig, error) {
 		Lifecycle: Lifecycle{
 			HTTPShutdownTimeout:  httpTimeout,
 			RiverSoftStopTimeout: riverTimeout,
+		},
+		Sandbox: SandboxRuntimeConfig{
+			AllowUnsafeHostExecution: allowUnsafeHostExecution,
 		},
 	}, nil
 }

--- a/internal/config/server_config_test.go
+++ b/internal/config/server_config_test.go
@@ -33,6 +33,9 @@ func TestLoadServerConfigDefaults(t *testing.T) {
 	if cfg.Database.RequireExternalDB {
 		t.Errorf("RequireExternalDB = true, want false")
 	}
+	if cfg.Sandbox.AllowUnsafeHostExecution {
+		t.Errorf("AllowUnsafeHostExecution = true, want false")
+	}
 	if cfg.Database.URL != "" {
 		t.Errorf("Database.URL = %q, want empty", cfg.Database.URL)
 	}
@@ -152,6 +155,42 @@ func TestLoadServerConfigBoolQuadrants(t *testing.T) {
 	}
 }
 
+func TestLoadServerConfigUnsafeHostExecutionBool(t *testing.T) {
+	cases := []struct {
+		name    string
+		value   string
+		want    bool
+		wantErr bool
+	}{
+		{name: "unset is false", want: false},
+		{name: "whitespace is false", value: "  ", want: false},
+		{name: "true permits none", value: "true", want: true},
+		{name: "one permits none", value: "1", want: true},
+		{name: "invalid is rejected", value: "unsafe", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := map[string]string{}
+			if tc.value != "" {
+				env[allowUnsafeHostExecutionEnv] = tc.value
+			}
+			cfg, err := LoadServerConfig(lookupFrom(env))
+			if tc.wantErr {
+				if err == nil || !strings.Contains(err.Error(), allowUnsafeHostExecutionEnv) {
+					t.Fatalf("LoadServerConfig() error = %v, want %s parse error", err, allowUnsafeHostExecutionEnv)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("LoadServerConfig() unexpected error: %v", err)
+			}
+			if cfg.Sandbox.AllowUnsafeHostExecution != tc.want {
+				t.Errorf("AllowUnsafeHostExecution = %v, want %v", cfg.Sandbox.AllowUnsafeHostExecution, tc.want)
+			}
+		})
+	}
+}
+
 func TestLoadServerConfigDurationMessage(t *testing.T) {
 	_, err := LoadServerConfig(lookupFrom(map[string]string{httpShutdownTimeoutEnv: "nope"}))
 	if err == nil {
@@ -178,9 +217,10 @@ func TestLoadServerConfigBoolMessage(t *testing.T) {
 // once (via env.AggregateError), not one per restart.
 func TestLoadServerConfigAggregatesErrors(t *testing.T) {
 	_, err := LoadServerConfig(lookupFrom(map[string]string{
-		requireExternalDBEnv:    "maybe",
-		httpShutdownTimeoutEnv:  "nope",
-		riverSoftStopTimeoutEnv: "later",
+		requireExternalDBEnv:        "maybe",
+		httpShutdownTimeoutEnv:      "nope",
+		riverSoftStopTimeoutEnv:     "later",
+		allowUnsafeHostExecutionEnv: "unsafe",
 	}))
 	if err == nil {
 		t.Fatal("expected error")
@@ -189,10 +229,10 @@ func TestLoadServerConfigAggregatesErrors(t *testing.T) {
 	if !errors.As(err, &agg) {
 		t.Fatalf("error is not env.AggregateError: %T", err)
 	}
-	if len(agg.Errors) != 3 {
-		t.Fatalf("aggregate has %d errors, want 3: %v", len(agg.Errors), agg.Errors)
+	if len(agg.Errors) != 4 {
+		t.Fatalf("aggregate has %d errors, want 4: %v", len(agg.Errors), agg.Errors)
 	}
-	for _, name := range []string{requireExternalDBEnv, httpShutdownTimeoutEnv, riverSoftStopTimeoutEnv} {
+	for _, name := range []string{requireExternalDBEnv, allowUnsafeHostExecutionEnv, httpShutdownTimeoutEnv, riverSoftStopTimeoutEnv} {
 		if !strings.Contains(err.Error(), name) {
 			t.Errorf("aggregated error %q missing field %q", err.Error(), name)
 		}

--- a/web/content/docs/admin/kubernetes.md
+++ b/web/content/docs/admin/kubernetes.md
@@ -56,9 +56,8 @@ helm install stella ./deploy/helm/stella \
   --set sandbox.backend=local
 ```
 
-`sandbox.backend=local` is the recommended choice — it isolates agent-run tools with
-bubblewrap. Only fall back to `none` after reading [Sandbox backend](#sandbox-backend);
-`none` runs agent code with no isolation and exposes deployment secrets to it.
+`sandbox.backend=local` is the only supported choice. It isolates agent-run tools with
+bubblewrap; this chart intentionally rejects unsafe host execution (`none`).
 
 `baseURL`, `secrets.existingSecret`, and `sandbox.backend` are required — the chart
 refuses to render without them. `baseURL` must be the externally reachable URL
@@ -90,36 +89,35 @@ install with `-f values.yaml`.
 
 ## Values reference
 
-| Key                                      | Default                         | Description                                                        |
-| ---------------------------------------- | ------------------------------- | ------------------------------------------------------------------ |
-| `replicaCount`                           | `1`                             | Must be `1`. Any other value is rejected.                          |
-| `image.repository`                       | `ghcr.io/cherryhq/stella`       | Container image.                                                   |
-| `image.tag`                              | `""`                            | Defaults to `latest`; pin a version tag or digest for production.  |
-| `image.digest`                           | `""`                            | `sha256:…` digest; pins the image and overrides `tag`.             |
-| `image.pullPolicy`                       | `IfNotPresent`                  |                                                                    |
-| `imagePullSecrets`                       | `[]`                            | For a private registry.                                            |
-| `baseURL`                                | `""`                            | **Required.** Public URL (`STELLA_BASE_URL`).                      |
-| `secrets.existingSecret`                 | `""`                            | **Required.** Name of the Secret with the vault key and DSN.       |
-| `secrets.keys.vaultKey`                  | `STELLA_VAULT_KEY`              | Key in the Secret holding the vault key.                           |
-| `secrets.keys.databaseURL`               | `STELLA_DATABASE_URL`           | Key in the Secret holding the DSN.                                 |
-| `sandbox.backend`                        | `""`                            | **Required.** `local` or `none` (see [Sandbox](#sandbox-backend)). |
-| `sandbox.allowUnsafeHostExecution`       | `false`                         | Must be `true` when `backend=none`.                                |
-| `sandbox.seccompProfile`                 | `RuntimeDefault`                | Pod seccomp profile. `Unconfined` if `local` needs it.             |
-| `shutdown.preStopSeconds`                | `10`                            | preStop sleep, for endpoint propagation.                           |
-| `shutdown.httpSeconds`                   | `60`                            | `STELLA_HTTP_SHUTDOWN_TIMEOUT`.                                    |
-| `shutdown.riverSoftStopSeconds`          | `120`                           | `STELLA_RIVER_SOFT_STOP_TIMEOUT`.                                  |
-| `shutdown.terminationGracePeriodSeconds` | `200`                           | Pod grace period (see [formula](#graceful-shutdown)).              |
-| `persistence.enabled`                    | `true`                          | Mount a PVC at `/home/stella/.stella`.                             |
-| `persistence.allowEphemeralDataLoss`     | `false`                         | Must be `true` to disable persistence (emptyDir loses user data).  |
-| `persistence.size`                       | `10Gi`                          | Requested volume size.                                             |
-| `persistence.accessMode`                 | `ReadWriteOnce`                 |                                                                    |
-| `persistence.storageClass`               | `""`                            | Empty = cluster default; `-` disables dynamic provisioning.        |
-| `persistence.existingClaim`              | `""`                            | Reuse a PVC you manage instead of creating one.                    |
-| `service.type` / `service.port`          | `ClusterIP` / `25678`           |                                                                    |
-| `ingress.*`                              | disabled                        | `className`, `annotations`, `hosts`, `tls`.                        |
-| `resources`                              | 500m/1Gi requests, 2/4Gi limits |                                                                    |
-| `extraEnv`                               | `[]`                            | Passthrough plain env vars (S3, OIDC, provider keys).              |
-| `serviceAccount.*`                       | `create: true`                  | Token automount is always off.                                     |
+| Key                                      | Default                         | Description                                                       |
+| ---------------------------------------- | ------------------------------- | ----------------------------------------------------------------- |
+| `replicaCount`                           | `1`                             | Must be `1`. Any other value is rejected.                         |
+| `image.repository`                       | `ghcr.io/cherryhq/stella`       | Container image.                                                  |
+| `image.tag`                              | `""`                            | Defaults to `latest`; pin a version tag or digest for production. |
+| `image.digest`                           | `""`                            | `sha256:…` digest; pins the image and overrides `tag`.            |
+| `image.pullPolicy`                       | `IfNotPresent`                  |                                                                   |
+| `imagePullSecrets`                       | `[]`                            | For a private registry.                                           |
+| `baseURL`                                | `""`                            | **Required.** Public URL (`STELLA_BASE_URL`).                     |
+| `secrets.existingSecret`                 | `""`                            | **Required.** Name of the Secret with the vault key and DSN.      |
+| `secrets.keys.vaultKey`                  | `STELLA_VAULT_KEY`              | Key in the Secret holding the vault key.                          |
+| `secrets.keys.databaseURL`               | `STELLA_DATABASE_URL`           | Key in the Secret holding the DSN.                                |
+| `sandbox.backend`                        | `""`                            | **Required.** `local` only (see [Sandbox](#sandbox-backend)).     |
+| `sandbox.seccompProfile`                 | `RuntimeDefault`                | Pod seccomp profile. `Unconfined` if `local` needs it.            |
+| `shutdown.preStopSeconds`                | `10`                            | preStop sleep, for endpoint propagation.                          |
+| `shutdown.httpSeconds`                   | `60`                            | `STELLA_HTTP_SHUTDOWN_TIMEOUT`.                                   |
+| `shutdown.riverSoftStopSeconds`          | `120`                           | `STELLA_RIVER_SOFT_STOP_TIMEOUT`.                                 |
+| `shutdown.terminationGracePeriodSeconds` | `200`                           | Pod grace period (see [formula](#graceful-shutdown)).             |
+| `persistence.enabled`                    | `true`                          | Mount a PVC at `/home/stella/.stella`.                            |
+| `persistence.allowEphemeralDataLoss`     | `false`                         | Must be `true` to disable persistence (emptyDir loses user data). |
+| `persistence.size`                       | `10Gi`                          | Requested volume size.                                            |
+| `persistence.accessMode`                 | `ReadWriteOnce`                 |                                                                   |
+| `persistence.storageClass`               | `""`                            | Empty = cluster default; `-` disables dynamic provisioning.       |
+| `persistence.existingClaim`              | `""`                            | Reuse a PVC you manage instead of creating one.                   |
+| `service.type` / `service.port`          | `ClusterIP` / `25678`           |                                                                   |
+| `ingress.*`                              | disabled                        | `className`, `annotations`, `hosts`, `tls`.                       |
+| `resources`                              | 500m/1Gi requests, 2/4Gi limits |                                                                   |
+| `extraEnv`                               | `[]`                            | Passthrough plain env vars (S3, OIDC, provider keys).             |
+| `serviceAccount.*`                       | `create: true`                  | Token automount is always off.                                    |
 
 ### Optional integrations via `extraEnv`
 
@@ -149,38 +147,20 @@ defaults, so its contract holds for any `image.repository` you substitute.
 
 ## Sandbox backend
 
-`sandbox.backend` is required and has no default. It decides how the tools an agent
-runs (`bash`, file edits) are isolated from the Stella process. This chart supports
-two backends; the `docker` backend is intentionally unsupported (it would need a
-mounted Docker socket).
+`sandbox.backend` is required and has no default. This chart supports only
+**`local`** (bubblewrap) isolation; it intentionally rejects both `none` host
+execution and the `docker` backend (which would require a mounted Docker socket).
 
-- **`local`** (recommended) — bubblewrap isolation. Tool processes run in their own
-  user, PID, and mount namespaces with the Stella process's environment scrubbed, so
-  they cannot read its secrets. **Experimental on Kubernetes:** it depends on the
-  cluster allowing _unprivileged user namespaces_ (bubblewrap calls `unshare(2)`).
-  The chart adds no privileged securityContext and mounts no Docker socket, and
-  defaults the pod's seccomp profile to `RuntimeDefault`. If tools fail with `bwrap:`
-  / `unshare` / "Operation not permitted" errors, first set
-  `sandbox.seccompProfile=Unconfined` (some clusters' default profile blocks
-  bubblewrap's namespace syscalls); if that is not enough, reconfigure the
-  cluster/node to permit unprivileged user namespaces — do not reach for `none` to
-  work around it on a multi-user deployment.
-- **`none`** — no isolation. `none` does not disable agent tools; it runs them
-  directly inside the Stella pod as the same user and in the same process namespace.
-
-  > **`none` exposes deployment secrets to agent code.** With no process isolation,
-  > a tool can read the Stella process's environment (e.g. `/proc/1/environ`) and
-  > recover `STELLA_VAULT_KEY` — the master key that decrypts **every user's**
-  > secrets and tokens — and `STELLA_DATABASE_URL`. `secretKeyRef` and the `extraEnv`
-  > guard do not protect against this. Only choose `none` when every user who can
-  > drive an agent is fully trusted (e.g. a single-operator install), never for a
-  > multi-user or public deployment. Hardening the `none` backend itself is
-  > tracked in [#705](https://github.com/CherryHQ/stella/issues/705).
-
-  Because of that, `none` also requires `sandbox.allowUnsafeHostExecution=true` to
-  render. The chart still drops all Linux capabilities and disallows privilege
-  escalation for the container in this mode, but that does not restore the process
-  isolation the secret exposure depends on.
+Tool processes run in their own user, PID, and mount namespaces with the Stella
+process's environment scrubbed. **Experimental on Kubernetes:** it depends on the
+cluster allowing _unprivileged user namespaces_ (bubblewrap calls `unshare(2)`). The
+chart adds no privileged securityContext and mounts no Docker socket, and defaults
+the pod's seccomp profile to `RuntimeDefault`. If tools fail with `bwrap:` /
+`unshare` / "Operation not permitted" errors, first set
+`sandbox.seccompProfile=Unconfined` (some clusters' default profile blocks
+bubblewrap's namespace syscalls); if that is not enough, reconfigure the
+cluster/node to permit unprivileged user namespaces. Do not disable isolation to
+work around the cluster configuration.
 
 ## Why only one replica?
 
@@ -290,9 +270,8 @@ Stella needs outbound access to:
 If your cluster restricts egress, allow these destinations. The chart does not ship
 a NetworkPolicy.
 
-**Restrict egress when you run untrusted agents.** Agent tools reach the network
-with the pod's full access — and with `sandbox.backend=none` they do so as arbitrary
-model-driven code. At minimum, block the cloud metadata endpoint
+**Restrict egress when you run untrusted agents.** Agent tools can reach the network
+with the pod's configured access. At minimum, block the cloud metadata endpoint
 (`169.254.169.254`), which on IMDSv1 clusters can hand out node IAM credentials, and
 deny east-west traffic you do not need. A starting NetworkPolicy:
 
@@ -334,8 +313,6 @@ spec:
   StorageClass whose driver honors `fsGroup`.
 - **Agent tools fail with `bwrap` / `unshare` errors.** You are on
   `sandbox.backend=local` in a cluster that blocks unprivileged user namespaces.
-  Reconfigure the node to allow them. Switching to `sandbox.backend=none` also makes
-  the error go away, but on a multi-user deployment that trades an isolation error
-  for a secret-exposure problem — see [Sandbox backend](#sandbox-backend) first.
+  Reconfigure the node to allow them; this chart intentionally rejects host execution.
 - **OAuth/channel links point at localhost.** `baseURL` is wrong or unset upstream —
   set it to the public ingress URL.

--- a/web/content/docs/admin/kubernetes.zh.md
+++ b/web/content/docs/admin/kubernetes.zh.md
@@ -50,9 +50,8 @@ helm install stella ./deploy/helm/stella \
   --set sandbox.backend=local
 ```
 
-`sandbox.backend=local` 是推荐选项 —— 它用 bubblewrap 隔离 agent 运行的工具。只有在
-读过 [沙箱后端](#sandbox-backend) 之后才考虑退回 `none`；`none` 让 agent 代码无隔离
-运行，并会把部署密钥暴露给它。
+`sandbox.backend=local` 是唯一支持的选项。它用 bubblewrap 隔离 agent 运行的工具；此 chart
+刻意拒绝不安全的宿主机执行（`none`）。
 
 `baseURL`、`secrets.existingSecret`、`sandbox.backend` 为必填 —— 缺任意一个 chart 都
 拒绝渲染。`baseURL` 必须是外部可达的 URL（ingress 地址），绝不能是 loopback：它是
@@ -82,36 +81,35 @@ kubectl -n stella port-forward svc/stella 25678:25678
 
 ## Values 参考
 
-| 键                                       | 默认值                          | 说明                                                          |
-| ---------------------------------------- | ------------------------------- | ------------------------------------------------------------- |
-| `replicaCount`                           | `1`                             | 必须为 `1`，其他值一律拒绝。                                  |
-| `image.repository`                       | `ghcr.io/cherryhq/stella`       | 容器镜像。                                                    |
-| `image.tag`                              | `""`                            | 为空时用 `latest`；生产建议固定版本 tag 或 digest。           |
-| `image.digest`                           | `""`                            | `sha256:…` 摘要；固定镜像并覆盖 `tag`。                       |
-| `image.pullPolicy`                       | `IfNotPresent`                  |                                                               |
-| `imagePullSecrets`                       | `[]`                            | 私有 registry 用。                                            |
-| `baseURL`                                | `""`                            | **必填。** 公网 URL（`STELLA_BASE_URL`）。                    |
-| `secrets.existingSecret`                 | `""`                            | **必填。** 含 vault key 与 DSN 的 Secret 名。                 |
-| `secrets.keys.vaultKey`                  | `STELLA_VAULT_KEY`              | Secret 中存 vault key 的键名。                                |
-| `secrets.keys.databaseURL`               | `STELLA_DATABASE_URL`           | Secret 中存 DSN 的键名。                                      |
-| `sandbox.backend`                        | `""`                            | **必填。** `local` 或 `none`（见 [沙箱](#sandbox-backend)）。 |
-| `sandbox.allowUnsafeHostExecution`       | `false`                         | `backend=none` 时必须为 `true`。                              |
-| `sandbox.seccompProfile`                 | `RuntimeDefault`                | Pod seccomp profile。`local` 需要时设 `Unconfined`。          |
-| `shutdown.preStopSeconds`                | `10`                            | preStop sleep，等待 endpoint 摘除传播。                       |
-| `shutdown.httpSeconds`                   | `60`                            | `STELLA_HTTP_SHUTDOWN_TIMEOUT`。                              |
-| `shutdown.riverSoftStopSeconds`          | `120`                           | `STELLA_RIVER_SOFT_STOP_TIMEOUT`。                            |
-| `shutdown.terminationGracePeriodSeconds` | `200`                           | Pod grace period（见 [公式](#graceful-shutdown)）。           |
-| `persistence.enabled`                    | `true`                          | 在 `/home/stella/.stella` 挂 PVC。                            |
-| `persistence.allowEphemeralDataLoss`     | `false`                         | 关闭持久化时必须为 `true`（emptyDir 会丢用户数据）。          |
-| `persistence.size`                       | `10Gi`                          | 申请卷大小。                                                  |
-| `persistence.accessMode`                 | `ReadWriteOnce`                 |                                                               |
-| `persistence.storageClass`               | `""`                            | 空 = 集群默认；`-` 关闭动态供给。                             |
-| `persistence.existingClaim`              | `""`                            | 复用你自己管理的 PVC，不由 chart 创建。                       |
-| `service.type` / `service.port`          | `ClusterIP` / `25678`           |                                                               |
-| `ingress.*`                              | 关闭                            | `className`、`annotations`、`hosts`、`tls`。                  |
-| `resources`                              | requests 500m/1Gi，limits 2/4Gi |                                                               |
-| `extraEnv`                               | `[]`                            | 透传普通环境变量（S3、OIDC、provider key）。                  |
-| `serviceAccount.*`                       | `create: true`                  | token automount 始终关闭。                                    |
+| 键                                       | 默认值                          | 说明                                                   |
+| ---------------------------------------- | ------------------------------- | ------------------------------------------------------ |
+| `replicaCount`                           | `1`                             | 必须为 `1`，其他值一律拒绝。                           |
+| `image.repository`                       | `ghcr.io/cherryhq/stella`       | 容器镜像。                                             |
+| `image.tag`                              | `""`                            | 为空时用 `latest`；生产建议固定版本 tag 或 digest。    |
+| `image.digest`                           | `""`                            | `sha256:…` 摘要；固定镜像并覆盖 `tag`。                |
+| `image.pullPolicy`                       | `IfNotPresent`                  |                                                        |
+| `imagePullSecrets`                       | `[]`                            | 私有 registry 用。                                     |
+| `baseURL`                                | `""`                            | **必填。** 公网 URL（`STELLA_BASE_URL`）。             |
+| `secrets.existingSecret`                 | `""`                            | **必填。** 含 vault key 与 DSN 的 Secret 名。          |
+| `secrets.keys.vaultKey`                  | `STELLA_VAULT_KEY`              | Secret 中存 vault key 的键名。                         |
+| `secrets.keys.databaseURL`               | `STELLA_DATABASE_URL`           | Secret 中存 DSN 的键名。                               |
+| `sandbox.backend`                        | `""`                            | **必填。** 仅 `local`（见 [沙箱](#sandbox-backend)）。 |
+| `sandbox.seccompProfile`                 | `RuntimeDefault`                | Pod seccomp profile。`local` 需要时设 `Unconfined`。   |
+| `shutdown.preStopSeconds`                | `10`                            | preStop sleep，等待 endpoint 摘除传播。                |
+| `shutdown.httpSeconds`                   | `60`                            | `STELLA_HTTP_SHUTDOWN_TIMEOUT`。                       |
+| `shutdown.riverSoftStopSeconds`          | `120`                           | `STELLA_RIVER_SOFT_STOP_TIMEOUT`。                     |
+| `shutdown.terminationGracePeriodSeconds` | `200`                           | Pod grace period（见 [公式](#graceful-shutdown)）。    |
+| `persistence.enabled`                    | `true`                          | 在 `/home/stella/.stella` 挂 PVC。                     |
+| `persistence.allowEphemeralDataLoss`     | `false`                         | 关闭持久化时必须为 `true`（emptyDir 会丢用户数据）。   |
+| `persistence.size`                       | `10Gi`                          | 申请卷大小。                                           |
+| `persistence.accessMode`                 | `ReadWriteOnce`                 |                                                        |
+| `persistence.storageClass`               | `""`                            | 空 = 集群默认；`-` 关闭动态供给。                      |
+| `persistence.existingClaim`              | `""`                            | 复用你自己管理的 PVC，不由 chart 创建。                |
+| `service.type` / `service.port`          | `ClusterIP` / `25678`           |                                                        |
+| `ingress.*`                              | 关闭                            | `className`、`annotations`、`hosts`、`tls`。           |
+| `resources`                              | requests 500m/1Gi，limits 2/4Gi |                                                        |
+| `extraEnv`                               | `[]`                            | 透传普通环境变量（S3、OIDC、provider key）。           |
+| `serviceAccount.*`                       | `create: true`                  | token automount 始终关闭。                             |
 
 ### 通过 `extraEnv` 接入可选集成
 
@@ -139,31 +137,16 @@ chart 通过 typed values 管理的变量在 `extraEnv` 里会被**拒绝**（`S
 
 ## 沙箱后端 {#sandbox-backend}
 
-`sandbox.backend` 必填且无默认值。它决定 agent 运行的工具（`bash`、文件编辑）如何与
-Stella 进程隔离。本 chart 支持两种后端；`docker` 后端刻意不支持（它需要挂载 Docker
-socket）。
+`sandbox.backend` 必填且无默认值。本 chart 只支持 **`local`**（bubblewrap）隔离；它刻意
+拒绝 `none` 宿主机执行和 `docker` 后端（后者需要挂载 Docker socket）。
 
-- **`local`**（推荐）—— bubblewrap 隔离。工具进程运行在自己独立的 user、PID、mount
-  namespace 里，且 Stella 进程的环境变量被擦除，因此读不到它的密钥。**在 Kubernetes
-  上属实验性：** 依赖集群允许 _非特权 user namespace_（bubblewrap 会调用
-  `unshare(2)`）。chart 不加任何特权 securityContext，也不挂 Docker socket，并把 pod
-  的 seccomp profile 默认设为 `RuntimeDefault`。若工具报 `bwrap:` / `unshare` /
-  “Operation not permitted” 错误，先设 `sandbox.seccompProfile=Unconfined`（某些集群
-  的默认 profile 会拦掉 bubblewrap 的 namespace 系统调用）；若还不够，再把集群/节点改成
-  允许非特权 user namespace —— 在多用户部署上不要用切到 `none` 来绕过。
-- **`none`** —— 无隔离。`none` 不会禁用 agent 工具；它让工具以同一用户、同一进程
-  namespace 直接在 Stella pod 内运行。
-
-  > **`none` 会把部署密钥暴露给 agent 代码。** 没有进程隔离，工具可以读取 Stella
-  > 进程的环境变量（如 `/proc/1/environ`），拿到 `STELLA_VAULT_KEY`——解密**每一个
-  > 用户**密钥与 token 的主密钥——以及 `STELLA_DATABASE_URL`。`secretKeyRef` 和
-  > `extraEnv` 防护都挡不住这条路径。只有当每个能驱动 agent 的用户都完全可信时
-  > （例如单运维者的私有部署）才用 `none`，绝不要用于多用户或公开部署。加固 `none`
-  > 后端本身的工作追踪在 [#705](https://github.com/CherryHQ/stella/issues/705)。
-
-  正因如此，`none` 还要求 `sandbox.allowUnsafeHostExecution=true` 才能渲染。这种模式
-  下 chart 仍会为容器 drop 所有 Linux capability 并禁止提权，但这并不能恢复密钥暴露
-  所依赖的那层进程隔离。
+工具进程运行在自己独立的 user、PID、mount namespace 里，且 Stella 进程的环境变量被擦除。
+**在 Kubernetes 上属实验性：** 依赖集群允许 _非特权 user namespace_（bubblewrap 会调用
+`unshare(2)`）。chart 不加任何特权 securityContext，也不挂 Docker socket，并把 pod 的
+seccomp profile 默认设为 `RuntimeDefault`。若工具报 `bwrap:` / `unshare` /
+“Operation not permitted” 错误，先设 `sandbox.seccompProfile=Unconfined`（某些集群的默认
+profile 会拦掉 bubblewrap 的 namespace 系统调用）；若还不够，再把集群/节点改成允许非特权
+user namespace。不要为了绕过集群配置而关闭隔离。
 
 ## 为什么只能单副本？ {#why-only-one-replica}
 
@@ -257,8 +240,7 @@ Stella 需要出站访问：
 
 若集群限制出站，请放行这些目标。chart 不提供 NetworkPolicy。
 
-**运行不受信任的 agent 时请限制出站。** agent 工具以 pod 的完整网络权限访问外部——
-在 `sandbox.backend=none` 下更是以任意模型驱动的代码身份访问。至少要阻断云元数据端点
+**运行不受信任的 agent 时请限制出站。** agent 工具可用 pod 配置的网络权限访问外部。至少要阻断云元数据端点
 （`169.254.169.254`），它在 IMDSv1 集群上可能交出节点 IAM 凭据；并拒绝不需要的东西向
 流量。一个起步的 NetworkPolicy：
 
@@ -297,8 +279,6 @@ spec:
   chart 设了 `fsGroup: 1000`；若你的 CSI 驱动忽略 `fsGroup`（有些会），请在外部给卷
   设好属主，或选一个驱动尊重 `fsGroup` 的 StorageClass。
 - **agent 工具报 `bwrap` / `unshare` 错误。** 你在一个禁止非特权 user namespace 的
-  集群上用 `sandbox.backend=local`。把节点改成允许它们。切到 `sandbox.backend=none`
-  也能让错误消失，但在多用户部署上这是用一个隔离错误换来一个密钥暴露问题 —— 请先看
-  [沙箱后端](#sandbox-backend)。
+  集群上用 `sandbox.backend=local`。把节点改成允许它们；此 chart 刻意拒绝宿主机执行。
 - **OAuth/通道链接指向 localhost。** 上游的 `baseURL` 错了或没设 —— 把它设成公网
   ingress URL。

--- a/web/content/docs/guides/sandbox.md
+++ b/web/content/docs/guides/sandbox.md
@@ -104,13 +104,14 @@ volumes:
 
 ### Environment Variables
 
-| Variable                     | Description                                                               |
-| ---------------------------- | ------------------------------------------------------------------------- |
-| `STELLA_DOCKER_SANDBOX_MODE` | Required for the `docker` sandbox backend: `host`, `bind`, or `volume`    |
-| `STELLA_HOME_HOST`           | Host-side path backing `STELLA_HOME`; required only in `bind` mode        |
-| `STELLA_HOME_VOLUME`         | Docker named volume backing `STELLA_HOME`; required only in `volume` mode |
+| Variable                             | Description                                                               |
+| ------------------------------------ | ------------------------------------------------------------------------- |
+| `STELLA_DOCKER_SANDBOX_MODE`         | Required for the `docker` sandbox backend: `host`, `bind`, or `volume`    |
+| `STELLA_HOME_HOST`                   | Host-side path backing `STELLA_HOME`; required only in `bind` mode        |
+| `STELLA_HOME_VOLUME`                 | Docker named volume backing `STELLA_HOME`; required only in `volume` mode |
+| `STELLA_ALLOW_UNSAFE_HOST_EXECUTION` | Required as `true` to select the unsafe `none` backend                    |
 
-If agents use `local` or `none`, none of these variables are needed.
+If agents use `local`, none of these variables are needed.
 
 ## Local Backend
 
@@ -164,6 +165,8 @@ The docker backend bakes its mise toolchain under absolute `/opt/stella` — the
 ## None Backend
 
 The `none` backend runs the agent directly on the host with the current user's permissions. No isolation of any kind — no filesystem confinement, no network restrictions, no process group kill, no resource limits.
+
+It is disabled by default. To select it, set `STELLA_ALLOW_UNSAFE_HOST_EXECUTION=true` before starting stellad. This is an explicit acceptance that agent code can access the stellad process, its files, and its environment (including secrets reachable through `/proc`); environment scrubbing does not create isolation.
 
 **Use only for fully trusted agents in single-user local deployments.** Not safe for untrusted agents or multi-user environments.
 

--- a/web/content/docs/guides/sandbox.zh.md
+++ b/web/content/docs/guides/sandbox.zh.md
@@ -104,13 +104,14 @@ volumes:
 
 ### 环境变量
 
-| 变量                         | 描述                                                                |
-| ---------------------------- | ------------------------------------------------------------------- |
-| `STELLA_DOCKER_SANDBOX_MODE` | `docker` 沙箱后端必须设置：`host`、`bind` 或 `volume`               |
-| `STELLA_HOME_HOST`           | `STELLA_HOME` 的宿主机侧路径；仅 `bind` 模式需要                    |
-| `STELLA_HOME_VOLUME`         | `STELLA_HOME` 对应的 Docker named volume 名称；仅 `volume` 模式需要 |
+| 变量                                 | 描述                                                                |
+| ------------------------------------ | ------------------------------------------------------------------- |
+| `STELLA_DOCKER_SANDBOX_MODE`         | `docker` 沙箱后端必须设置：`host`、`bind` 或 `volume`               |
+| `STELLA_HOME_HOST`                   | `STELLA_HOME` 的宿主机侧路径；仅 `bind` 模式需要                    |
+| `STELLA_HOME_VOLUME`                 | `STELLA_HOME` 对应的 Docker named volume 名称；仅 `volume` 模式需要 |
+| `STELLA_ALLOW_UNSAFE_HOST_EXECUTION` | 必须为 `true` 才能选择不安全的 `none` 后端                          |
 
-agent 使用 `local` 或 `none` 时，这些变量都不需要。
+agent 使用 `local` 时，这些变量都不需要。
 
 ## 本地后端
 
@@ -164,6 +165,8 @@ Docker 后端把 mise 工具链烤在绝对 `/opt/stella` 下——与 Linux `lo
 ## None 后端
 
 `none` 后端以当前用户权限直接在宿主机上运行 agent，不提供任何隔离——无文件系统限制、无网络限制、无进程组终止，也无资源限制。
+
+它默认禁用。要选择它，请在启动 stellad 前设置 `STELLA_ALLOW_UNSAFE_HOST_EXECUTION=true`。这明确表示运营者接受 agent 代码能访问 stellad 进程、其文件和环境变量（包括经由 `/proc` 可读取的密钥）；清理环境变量并不能形成隔离。
 
 **仅在单用户本地部署中对完全受信任的 agent 使用。** 不适用于不受信任的 agent 或多用户环境。
 

--- a/web/content/docs/start-here/configuration.md
+++ b/web/content/docs/start-here/configuration.md
@@ -76,26 +76,27 @@ All data lives under `~/.stella` (configurable via `STELLA_HOME`):
 
 Only a small set of environment variables is recognized:
 
-| Variable                      | Description                                                                                                       |
-| ----------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `STELLA_HOME`                 | Override the home directory (default `~/.stella`)                                                                 |
-| `STELLA_DATABASE_URL`         | Use an external PostgreSQL database instead of the embedded cluster                                               |
-| `STELLA_BLOB_S3_ENDPOINT`     | Optional S3-compatible endpoint for the durable user-asset mirror                                                 |
-| `STELLA_BLOB_S3_BUCKET`       | Bucket for mirrored user-uploaded assets; set with endpoint/access/secret or leave all unset                      |
-| `STELLA_BLOB_S3_ACCESS_KEY`   | Access key for the asset mirror                                                                                   |
-| `STELLA_BLOB_S3_SECRET_KEY`   | Secret key for the asset mirror                                                                                   |
-| `STELLA_BLOB_S3_REGION`       | Optional S3 region                                                                                                |
-| `STELLA_BLOB_S3_USE_SSL`      | Use HTTPS for S3-compatible storage; defaults to `true`                                                           |
-| `ANTHROPIC_API_KEY`           | Fallback API key for Anthropic                                                                                    |
-| `OPENAI_API_KEY`              | Fallback API key for OpenAI                                                                                       |
-| `STELLA_VAULT_KEY`            | Master key for the [secret vault](/docs/guides/secrets-and-keys) — required for secrets, OAuth, and bearer tokens |
-| `STELLA_DOCKER_SANDBOX_MODE`  | Required only for the `docker` sandbox backend: `host`, `bind`, or `volume`                                       |
-| `STELLA_HOME_HOST`            | Host-side path for `STELLA_HOME`; required only when `STELLA_DOCKER_SANDBOX_MODE=bind`                            |
-| `STELLA_HOME_VOLUME`          | Docker named volume for `STELLA_HOME`; required only when `STELLA_DOCKER_SANDBOX_MODE=volume`                     |
-| `STELLA_REFLECT_MODE`         | Reflect writer: `legacy` (default and rollback target) or `structured`                                            |
-| `STELLA_REFLECT_CURATOR_MODE` | Lifecycle curator: `shadow` (default and rollback target) or `armed`                                              |
+| Variable                             | Description                                                                                                                                 |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `STELLA_HOME`                        | Override the home directory (default `~/.stella`)                                                                                           |
+| `STELLA_DATABASE_URL`                | Use an external PostgreSQL database instead of the embedded cluster                                                                         |
+| `STELLA_BLOB_S3_ENDPOINT`            | Optional S3-compatible endpoint for the durable user-asset mirror                                                                           |
+| `STELLA_BLOB_S3_BUCKET`              | Bucket for mirrored user-uploaded assets; set with endpoint/access/secret or leave all unset                                                |
+| `STELLA_BLOB_S3_ACCESS_KEY`          | Access key for the asset mirror                                                                                                             |
+| `STELLA_BLOB_S3_SECRET_KEY`          | Secret key for the asset mirror                                                                                                             |
+| `STELLA_BLOB_S3_REGION`              | Optional S3 region                                                                                                                          |
+| `STELLA_BLOB_S3_USE_SSL`             | Use HTTPS for S3-compatible storage; defaults to `true`                                                                                     |
+| `ANTHROPIC_API_KEY`                  | Fallback API key for Anthropic                                                                                                              |
+| `OPENAI_API_KEY`                     | Fallback API key for OpenAI                                                                                                                 |
+| `STELLA_VAULT_KEY`                   | Master key for the [secret vault](/docs/guides/secrets-and-keys) — required for secrets, OAuth, and bearer tokens                           |
+| `STELLA_DOCKER_SANDBOX_MODE`         | Required only for the `docker` sandbox backend: `host`, `bind`, or `volume`                                                                 |
+| `STELLA_HOME_HOST`                   | Host-side path for `STELLA_HOME`; required only when `STELLA_DOCKER_SANDBOX_MODE=bind`                                                      |
+| `STELLA_HOME_VOLUME`                 | Docker named volume for `STELLA_HOME`; required only when `STELLA_DOCKER_SANDBOX_MODE=volume`                                               |
+| `STELLA_ALLOW_UNSAFE_HOST_EXECUTION` | Set to `true` only to permit the explicitly unsafe `none` sandbox backend; it grants agent code access to stellad process/files/environment |
+| `STELLA_REFLECT_MODE`                | Reflect writer: `legacy` (default and rollback target) or `structured`                                                                      |
+| `STELLA_REFLECT_CURATOR_MODE`        | Lifecycle curator: `shadow` (default and rollback target) or `armed`                                                                        |
 
-The Reflect mode variables are read at server startup, so restart Stella after changing them. Invalid writer or curator modes stop startup. See [Deployment](/docs/start-here/deployment#roll-out-structured-reflect) for the activation and rollback procedure and [Memory internals](/docs/development/memory-internals#structured-reflect-and-curator-rollout) for the detailed mechanism.
+The Reflect mode variables and `STELLA_ALLOW_UNSAFE_HOST_EXECUTION` are read at server startup, so restart Stella after changing them. Invalid writer or curator modes stop startup. See [Deployment](/docs/start-here/deployment#roll-out-structured-reflect) for the activation and rollback procedure and [Memory internals](/docs/development/memory-internals#structured-reflect-and-curator-rollout) for the detailed mechanism.
 
 See the [Sandbox guide](/docs/guides/sandbox) for how to choose a sandbox backend and configure Docker sandbox modes.
 

--- a/web/content/docs/start-here/configuration.zh.md
+++ b/web/content/docs/start-here/configuration.zh.md
@@ -76,26 +76,27 @@ Runner 控制代理如何处理消息。你可以在Web UI的 **设置** 页面�
 
 仅识别少量环境变量：
 
-| 变量                          | 描述                                                                                     |
-| ----------------------------- | ---------------------------------------------------------------------------------------- |
-| `STELLA_HOME`                 | 覆盖主目录（默认 `~/.stella`）                                                           |
-| `STELLA_DATABASE_URL`         | 使用外部 PostgreSQL 数据库，而不是内嵌集群                                               |
-| `STELLA_BLOB_S3_ENDPOINT`     | 可选的 S3 兼容 endpoint，用于持久化用户资产镜像                                          |
-| `STELLA_BLOB_S3_BUCKET`       | 镜像用户上传资产的 bucket；需与 endpoint/access/secret 同时设置，或全部不设置            |
-| `STELLA_BLOB_S3_ACCESS_KEY`   | 资产镜像使用的 access key                                                                |
-| `STELLA_BLOB_S3_SECRET_KEY`   | 资产镜像使用的 secret key                                                                |
-| `STELLA_BLOB_S3_REGION`       | 可选 S3 region                                                                           |
-| `STELLA_BLOB_S3_USE_SSL`      | S3 兼容存储是否使用 HTTPS；默认 `true`                                                   |
-| `ANTHROPIC_API_KEY`           | Anthropic 的备用 API 密钥                                                                |
-| `OPENAI_API_KEY`              | OpenAI 的备用 API 密钥                                                                   |
-| `STELLA_VAULT_KEY`            | [密钥库](/docs/guides/secrets-and-keys)的主密钥 — 密钥管理、OAuth 和 Bearer Token 所必需 |
-| `STELLA_DOCKER_SANDBOX_MODE`  | 仅 `docker` 沙箱后端需要：`host`、`bind` 或 `volume`                                     |
-| `STELLA_HOME_HOST`            | `STELLA_HOME` 的宿主机侧路径；仅 `STELLA_DOCKER_SANDBOX_MODE=bind` 时需要                |
-| `STELLA_HOME_VOLUME`          | `STELLA_HOME` 的 Docker named volume 名称；仅 `STELLA_DOCKER_SANDBOX_MODE=volume` 时需要 |
-| `STELLA_REFLECT_MODE`         | Reflect 写入模式：`legacy`（默认值和回滚目标）或 `structured`                            |
-| `STELLA_REFLECT_CURATOR_MODE` | 生命周期 curator：`shadow`（默认值和回滚目标）或 `armed`                                 |
+| 变量                                 | 描述                                                                                              |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| `STELLA_HOME`                        | 覆盖主目录（默认 `~/.stella`）                                                                    |
+| `STELLA_DATABASE_URL`                | 使用外部 PostgreSQL 数据库，而不是内嵌集群                                                        |
+| `STELLA_BLOB_S3_ENDPOINT`            | 可选的 S3 兼容 endpoint，用于持久化用户资产镜像                                                   |
+| `STELLA_BLOB_S3_BUCKET`              | 镜像用户上传资产的 bucket；需与 endpoint/access/secret 同时设置，或全部不设置                     |
+| `STELLA_BLOB_S3_ACCESS_KEY`          | 资产镜像使用的 access key                                                                         |
+| `STELLA_BLOB_S3_SECRET_KEY`          | 资产镜像使用的 secret key                                                                         |
+| `STELLA_BLOB_S3_REGION`              | 可选 S3 region                                                                                    |
+| `STELLA_BLOB_S3_USE_SSL`             | S3 兼容存储是否使用 HTTPS；默认 `true`                                                            |
+| `ANTHROPIC_API_KEY`                  | Anthropic 的备用 API 密钥                                                                         |
+| `OPENAI_API_KEY`                     | OpenAI 的备用 API 密钥                                                                            |
+| `STELLA_VAULT_KEY`                   | [密钥库](/docs/guides/secrets-and-keys)的主密钥 — 密钥管理、OAuth 和 Bearer Token 所必需          |
+| `STELLA_DOCKER_SANDBOX_MODE`         | 仅 `docker` 沙箱后端需要：`host`、`bind` 或 `volume`                                              |
+| `STELLA_HOME_HOST`                   | `STELLA_HOME` 的宿主机侧路径；仅 `STELLA_DOCKER_SANDBOX_MODE=bind` 时需要                         |
+| `STELLA_HOME_VOLUME`                 | `STELLA_HOME` 的 Docker named volume 名称；仅 `STELLA_DOCKER_SANDBOX_MODE=volume` 时需要          |
+| `STELLA_ALLOW_UNSAFE_HOST_EXECUTION` | 仅在允许明确不安全的 `none` 沙箱后端时设为 `true`；会授权 agent 代码访问 stellad 进程、文件和环境 |
+| `STELLA_REFLECT_MODE`                | Reflect 写入模式：`legacy`（默认值和回滚目标）或 `structured`                                     |
+| `STELLA_REFLECT_CURATOR_MODE`        | 生命周期 curator：`shadow`（默认值和回滚目标）或 `armed`                                          |
 
-Reflect 模式变量在服务启动时读取，修改后需要重启 Stella。无效的写入或 curator 模式会阻止启动。启用和回滚步骤见[部署](/docs/start-here/deployment#启用-structured-reflect)，详细机制见[记忆系统内部原理](/docs/development/memory-internals#structured-reflect-与-curator-上线机制)。
+Reflect 模式变量和 `STELLA_ALLOW_UNSAFE_HOST_EXECUTION` 都在服务启动时读取，修改后需要重启 Stella。无效的写入或 curator 模式会阻止启动。启用和回滚步骤见[部署](/docs/start-here/deployment#启用-structured-reflect)，详细机制见[记忆系统内部原理](/docs/development/memory-internals#structured-reflect-与-curator-上线机制)。
 
 有关如何选择沙箱后端和配置 Docker 沙箱模式，请参阅[沙箱指南](/docs/guides/sandbox)。
 


### PR DESCRIPTION
## What

Disable the unisolated `none` sandbox backend by default, require an explicit application-level unsafe opt-in for local development, and reject it unconditionally in the Kubernetes Helm chart.

## Why

`none` executes agent commands beside `stellad`; on Linux it can read `/proc/<pid>/environ` and recover the vault master key and database credentials. Environment scrubbing cannot repair a missing process boundary.

## How

- Parse `STELLA_ALLOW_UNSAFE_HOST_EXECUTION` once at startup and enforce it at the central session-resolution boundary, including resilient session recreation.
- Preserve `none` only as an explicitly unsafe host-execution mode; do not duplicate the existing `local` isolation backend.
- Restrict the Helm chart to `local` and remove its former acknowledgement escape hatch.
- Update English and Chinese configuration, sandbox, and Kubernetes docs.

## Verification

- `deploy/helm/check.sh`
- `mise run format`
- `mise run build`
- `mise run test`

## Refs

Closes #705