### PR TITLE
🐛 fix: make Docker sandbox ownership namespace-safe

### DIFF
--- a/plugins/sandbox/docker/dockerclient/labels.go
+++ b/plugins/sandbox/docker/dockerclient/labels.go
@@ -6,5 +6,25 @@ const (
 	// path for bind mounts, or "volume:<name>" for named-volume mode.
 	LabelStellaHome = "stella.sandbox.stella_home"
 	LabelCreatedAt  = "stella.sandbox.created_at" // RFC3339
-	LabelOwnerPID   = "stella.sandbox.owner_pid"  // PID of the creating stella process
+
+	// LabelOwnerKind and LabelOwnerID identify the stellad instance that created
+	// a sandbox. New containers always write these as a pair.
+	LabelOwnerKind = "stella.sandbox.owner_kind"
+	LabelOwnerID   = "stella.sandbox.owner_id"
+
+	// LabelOwnerPID is retained only to read containers created before owner
+	// identities were introduced. Never write this label on new containers.
+	LabelOwnerPID = "stella.sandbox.owner_pid"
 )
+
+const (
+	OwnerKindProcess   = "process"
+	OwnerKindContainer = "container"
+)
+
+// Owner identifies the current stellad instance for orphan cleanup. It is
+// constructed by the docker backend once at factory construction.
+type Owner struct {
+	Kind string
+	ID   string
+}

--- a/plugins/sandbox/docker/dockerclient/orphan.go
+++ b/plugins/sandbox/docker/dockerclient/orphan.go
@@ -13,17 +13,19 @@ import (
 	mobyclient "github.com/moby/moby/client"
 )
 
-// CleanupOrphanedContainers force-removes stella-labeled containers whose owning
-// process is clearly gone:
-//   - dead-state containers (exited, dead, created) are always removed
-//   - running / paused containers are removed only when their owner_pid label
-//     points to a process that no longer exists on this host — this keeps
-//     peer stella processes with live sessions safe from another stella startup
-//   - transitional states (restarting, …) fall back to an age cutoff so
-//     truly-hung containers eventually clear
+// CleanupOrphanedContainers force-removes Stella-labelled containers whose owner
+// is conclusively gone. Dead-state containers are always removed; running and
+// paused containers are removed only when their recorded owner is gone. Unknown
+// owner state and Docker inspection errors fail closed. Transitional states keep
+// the existing age cutoff so genuinely hung containers eventually clear.
+//
+// current identifies this factory's cached owner. A sandbox marked with the
+// current container ID predates this process: cleanup runs before it creates
+// sessions, so it is removed even if Docker has reused that container ID after a
+// restart.
 //
 // Best-effort: errors are logged, not returned.
-func CleanupOrphanedContainers(ctx context.Context, c *Client, stellaHome string) {
+func CleanupOrphanedContainers(ctx context.Context, c *Client, stellaHome string, current Owner) {
 	filters := mobyclient.Filters{}.Add("label", LabelStellaHome+"="+stellaHome)
 
 	list, err := c.api.ContainerList(ctx, mobyclient.ContainerListOptions{
@@ -36,11 +38,11 @@ func CleanupOrphanedContainers(ctx context.Context, c *Client, stellaHome string
 	}
 
 	for _, cs := range list.Items {
-		cleanupContainer(ctx, c, cs.ID)
+		cleanupContainer(ctx, c, cs.ID, current)
 	}
 }
 
-func cleanupContainer(ctx context.Context, c *Client, id string) {
+func cleanupContainer(ctx context.Context, c *Client, id string, current Owner) {
 	res, err := c.api.ContainerInspect(ctx, id, mobyclient.ContainerInspectOptions{})
 	if err != nil {
 		if errdefs.IsNotFound(err) {
@@ -59,7 +61,9 @@ func cleanupContainer(ctx context.Context, c *Client, id string) {
 		labels = res.Container.Config.Labels
 	}
 
-	if !isContainerStale(status, labels[LabelOwnerPID], labels[LabelCreatedAt]) {
+	if !isContainerStale(status, labels, current, func() bool {
+		return sandboxOwnerGone(ctx, c, labels, current)
+	}) {
 		return
 	}
 
@@ -74,19 +78,20 @@ func cleanupContainer(ctx context.Context, c *Client, id string) {
 }
 
 // isContainerStale reports whether a labelled container should be force-removed
-// during startup cleanup. Age alone never triggers removal of a running or
-// paused container — that would race with peer stella processes — so live states
-// are gated on whether the recorded owner PID is still a live process.
-func isContainerStale(status, ownerPID, createdAt string) bool {
+// during startup cleanup. ownerGone is evaluated for live and created states so
+// a concurrent peer cannot lose a newly-created session before it starts. Dead
+// and transitional state handling remains independent of owner lookup failures.
+func isContainerStale(status string, labels map[string]string, current Owner, ownerGone func() bool) bool {
 	switch status {
-	case "exited", "dead", "created":
+	case "exited", "dead":
 		return true
-	case "running", "paused":
-		return ownerProcessGone(ownerPID)
+	case "created", "running", "paused":
+		return ownerGone()
 	}
 	// restarting, removing, or unknown: fall back to age so truly-hung
-	// transitional containers eventually clear. Peer stella processes that
-	// are actively running sit in "running" above, not here.
+	// transitional containers eventually clear. Peer Stella processes that are
+	// actively running sit in "running" above, not here.
+	createdAt := labels[LabelCreatedAt]
 	if createdAt == "" {
 		return false
 	}
@@ -95,6 +100,39 @@ func isContainerStale(status, ownerPID, createdAt string) bool {
 		return false
 	}
 	return time.Since(t) > time.Hour
+}
+
+// sandboxOwnerGone determines liveness from the labels' declared ownership
+// scheme. Container owners are checked through the Docker daemon, never through
+// the stellad container's PID namespace. Legacy owner_pid is safe to probe only
+// in native host mode; in DooD it is deliberately preserved.
+func sandboxOwnerGone(ctx context.Context, c *Client, labels map[string]string, current Owner) bool {
+	switch labels[LabelOwnerKind] {
+	case OwnerKindProcess:
+		ownerID := labels[LabelOwnerID]
+		if current.Kind != OwnerKindProcess || ownerID == "" {
+			return false
+		}
+		// Cleanup precedes this process's first session, so a matching PID is a
+		// prior-process leftover whose PID the OS has reused.
+		return ownerID == current.ID || ownerProcessGone(ownerID)
+	case OwnerKindContainer:
+		ownerID := labels[LabelOwnerID]
+		if ownerID == "" {
+			return false
+		}
+		if current.Kind == OwnerKindContainer && ownerID == current.ID {
+			return true
+		}
+		state, err := c.InspectContainerState(ctx, ownerID)
+		return err == nil && (state == nil || !state.Running)
+	default:
+		if current.Kind != OwnerKindProcess {
+			return false
+		}
+		legacyPID := labels[LabelOwnerPID]
+		return legacyPID != "" && (legacyPID == current.ID || ownerProcessGone(legacyPID))
+	}
 }
 
 // ownerProcessGone reports whether the PID label refers to a process that no

--- a/plugins/sandbox/docker/dockerclient/orphan_test.go
+++ b/plugins/sandbox/docker/dockerclient/orphan_test.go
@@ -1,66 +1,245 @@
 package dockerclient
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
+	"strconv"
 	"testing"
 	"time"
+
+	"github.com/containerd/errdefs"
+	"github.com/moby/moby/api/types/container"
+	mobyclient "github.com/moby/moby/client"
 )
 
 func TestIsContainerStale(t *testing.T) {
+	old := time.Now().Add(-2 * time.Hour).Format(time.RFC3339)
 	cases := []struct {
 		name      string
 		status    string
-		ownerPID  string
-		createdAt string
+		labels    map[string]string
+		ownerGone bool
 		want      bool
 	}{
-		{"exited is stale", "exited", "", "", true},
-		{"dead is stale", "dead", "", "", true},
-		{"created is stale", "created", "", "", true},
-		{"running no pid not stale", "running", "", "", false},
-		{"running bad pid not stale", "running", "notapid", "", false},
-		{"paused no pid not stale", "paused", "", "", false},
-		{"unknown no createdAt", "unknown", "", "", false},
-		{"unknown old createdAt stale", "unknown", "", time.Now().Add(-2 * time.Hour).Format(time.RFC3339), true},
-		{"unknown recent createdAt not stale", "unknown", "", time.Now().Add(-30 * time.Minute).Format(time.RFC3339), false},
-		{"unknown bad createdAt not stale", "unknown", "", "bad-date", false},
+		{"exited is stale", "exited", nil, false, true},
+		{"dead is stale", "dead", nil, false, true},
+		{"created with live owner is preserved", "created", nil, false, false},
+		{"created with dead owner is stale", "created", nil, true, true},
+		{"running live owner is preserved", "running", nil, false, false},
+		{"running dead owner is stale", "running", nil, true, true},
+		{"paused dead owner is stale", "paused", nil, true, true},
+		{"unknown no createdAt", "unknown", nil, true, false},
+		{"unknown old createdAt stale", "unknown", map[string]string{LabelCreatedAt: old}, false, true},
+		{"unknown bad createdAt not stale", "unknown", map[string]string{LabelCreatedAt: "bad-date"}, false, false},
 	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			got := isContainerStale(c.status, c.ownerPID, c.createdAt)
-			if got != c.want {
-				t.Fatalf("isContainerStale(%q, %q, %q) = %v, want %v", c.status, c.ownerPID, c.createdAt, got, c.want)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			called := false
+			got := isContainerStale(tc.status, tc.labels, Owner{}, func() bool {
+				called = true
+				return tc.ownerGone
+			})
+			if got != tc.want {
+				t.Fatalf("isContainerStale() = %v, want %v", got, tc.want)
+			}
+			if called != (tc.status == "created" || tc.status == "running" || tc.status == "paused") {
+				t.Fatalf("owner check called = %v for %q", called, tc.status)
 			}
 		})
 	}
 }
 
+type orphanAPI struct {
+	API
+	inspect map[string]inspectResponse
+	removed []string
+}
+
+type inspectResponse struct {
+	result mobyclient.ContainerInspectResult
+	err    error
+}
+
+func (f *orphanAPI) ContainerInspect(_ context.Context, id string, _ mobyclient.ContainerInspectOptions) (mobyclient.ContainerInspectResult, error) {
+	res, ok := f.inspect[id]
+	if !ok {
+		return mobyclient.ContainerInspectResult{}, errdefs.ErrNotFound
+	}
+	return res.result, res.err
+}
+
+func (f *orphanAPI) ContainerRemove(_ context.Context, id string, _ mobyclient.ContainerRemoveOptions) (mobyclient.ContainerRemoveResult, error) {
+	f.removed = append(f.removed, id)
+	return mobyclient.ContainerRemoveResult{}, nil
+}
+
+func sandboxInspect(status string, labels map[string]string) mobyclient.ContainerInspectResult {
+	return mobyclient.ContainerInspectResult{Container: container.InspectResponse{
+		Config: &container.Config{Labels: labels},
+		State:  &container.State{Status: container.ContainerState(status)},
+	}}
+}
+
+func ownerInspect(running bool) mobyclient.ContainerInspectResult {
+	return mobyclient.ContainerInspectResult{Container: container.InspectResponse{
+		State: &container.State{Running: running},
+	}}
+}
+
+func TestCleanupContainerContainerOwnerLiveness(t *testing.T) {
+	const sandboxID = "sandbox"
+	cases := []struct {
+		name    string
+		current Owner
+		ownerID string
+		owner   inspectResponse
+		want    bool
+	}{
+		{
+			name:    "same container ID is a prior process leftover",
+			current: Owner{Kind: OwnerKindContainer, ID: "self"},
+			ownerID: "self",
+			want:    true,
+		},
+		{
+			name:    "live foreign owner is preserved",
+			current: Owner{Kind: OwnerKindContainer, ID: "self"},
+			ownerID: "peer",
+			owner:   inspectResponse{result: ownerInspect(true)},
+			want:    false,
+		},
+		{
+			name:    "missing foreign owner is removed",
+			current: Owner{Kind: OwnerKindContainer, ID: "self"},
+			ownerID: "gone",
+			owner:   inspectResponse{err: errdefs.ErrNotFound},
+			want:    true,
+		},
+		{
+			name:    "stopped foreign owner is removed",
+			current: Owner{Kind: OwnerKindContainer, ID: "self"},
+			ownerID: "stopped",
+			owner:   inspectResponse{result: ownerInspect(false)},
+			want:    true,
+		},
+		{
+			name:    "owner inspect error fails closed",
+			current: Owner{Kind: OwnerKindContainer, ID: "self"},
+			ownerID: "unavailable",
+			owner:   inspectResponse{err: errors.New("daemon unavailable")},
+			want:    false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			api := &orphanAPI{inspect: map[string]inspectResponse{
+				sandboxID:  {result: sandboxInspect("running", map[string]string{LabelOwnerKind: OwnerKindContainer, LabelOwnerID: tc.ownerID})},
+				tc.ownerID: tc.owner,
+			}}
+			cleanupContainer(context.Background(), NewWithAPI(api), sandboxID, tc.current)
+			if got := len(api.removed) == 1; got != tc.want {
+				t.Fatalf("removed = %v, want %v", api.removed, tc.want)
+			}
+		})
+	}
+}
+
+func TestCleanupContainerCreatedForeignOwnerIsPreserved(t *testing.T) {
+	api := &orphanAPI{inspect: map[string]inspectResponse{
+		"sandbox":   {result: sandboxInspect("created", map[string]string{LabelOwnerKind: OwnerKindContainer, LabelOwnerID: "live-peer"})},
+		"live-peer": {result: ownerInspect(true)},
+	}}
+	cleanupContainer(context.Background(), NewWithAPI(api), "sandbox", Owner{Kind: OwnerKindContainer, ID: "self"})
+	if len(api.removed) != 0 {
+		t.Fatalf("created sandbox with a live foreign owner removed: %v", api.removed)
+	}
+}
+
+func TestCleanupContainerPIDOwnershipIsHostOnly(t *testing.T) {
+	// Use a real, reaped child PID: unlike a guessed out-of-range value this has
+	// consistent Signal(0) semantics across Unix kernels.
+	cmd := exec.Command(os.Args[0], "-test.run=^$")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("run short-lived process: %v", err)
+	}
+	deadPID := strconv.Itoa(cmd.ProcessState.Pid())
+	cases := []struct {
+		name    string
+		labels  map[string]string
+		current Owner
+		want    bool
+	}{
+		{
+			name:    "DooD preserves process owner",
+			labels:  map[string]string{LabelOwnerKind: OwnerKindProcess, LabelOwnerID: deadPID},
+			current: Owner{Kind: OwnerKindContainer, ID: "self"},
+			want:    false,
+		},
+		{
+			name:    "host removes same PID left by prior process",
+			labels:  map[string]string{LabelOwnerKind: OwnerKindProcess, LabelOwnerID: strconv.Itoa(os.Getpid())},
+			current: Owner{Kind: OwnerKindProcess, ID: strconv.Itoa(os.Getpid())},
+			want:    true,
+		},
+		{
+			name:    "host removes dead process owner",
+			labels:  map[string]string{LabelOwnerKind: OwnerKindProcess, LabelOwnerID: deadPID},
+			current: Owner{Kind: OwnerKindProcess, ID: "self"},
+			want:    true,
+		},
+		{
+			name:    "DooD preserves legacy PID owner",
+			labels:  map[string]string{LabelOwnerPID: deadPID},
+			current: Owner{Kind: OwnerKindContainer, ID: "self"},
+			want:    false,
+		},
+		{
+			name:    "host removes legacy same PID left by prior process",
+			labels:  map[string]string{LabelOwnerPID: strconv.Itoa(os.Getpid())},
+			current: Owner{Kind: OwnerKindProcess, ID: strconv.Itoa(os.Getpid())},
+			want:    true,
+		},
+		{
+			name:    "host removes legacy dead PID owner",
+			labels:  map[string]string{LabelOwnerPID: deadPID},
+			current: Owner{Kind: OwnerKindProcess, ID: "self"},
+			want:    true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			api := &orphanAPI{inspect: map[string]inspectResponse{
+				"sandbox": {result: sandboxInspect("running", tc.labels)},
+			}}
+			cleanupContainer(context.Background(), NewWithAPI(api), "sandbox", tc.current)
+			if got := len(api.removed) == 1; got != tc.want {
+				t.Fatalf("removed = %v, want removal %v", api.removed, tc.want)
+			}
+		})
+	}
+}
+
+func TestCleanupContainerDeadStateAlwaysRemoves(t *testing.T) {
+	api := &orphanAPI{inspect: map[string]inspectResponse{
+		"sandbox":   {result: sandboxInspect("exited", map[string]string{LabelOwnerKind: OwnerKindContainer, LabelOwnerID: "live-peer"})},
+		"live-peer": {result: ownerInspect(true)},
+	}}
+	cleanupContainer(context.Background(), NewWithAPI(api), "sandbox", Owner{Kind: OwnerKindContainer, ID: "self"})
+	if fmt.Sprint(api.removed) != "[sandbox]" {
+		t.Fatalf("removed = %v, want [sandbox]", api.removed)
+	}
+}
+
 func TestOwnerProcessGone(t *testing.T) {
-	t.Run("empty pid", func(t *testing.T) {
-		if ownerProcessGone("") {
-			t.Fatal("empty pid should return false")
+	for _, pid := range []string{"", "0", "-1", "abc"} {
+		if ownerProcessGone(pid) {
+			t.Fatalf("ownerProcessGone(%q) = true, want false", pid)
 		}
-	})
-	t.Run("zero pid", func(t *testing.T) {
-		if ownerProcessGone("0") {
-			t.Fatal("pid=0 should return false")
-		}
-	})
-	t.Run("negative pid", func(t *testing.T) {
-		if ownerProcessGone("-1") {
-			t.Fatal("negative pid should return false")
-		}
-	})
-	t.Run("non-numeric", func(t *testing.T) {
-		if ownerProcessGone("abc") {
-			t.Fatal("non-numeric pid should return false")
-		}
-	})
-	t.Run("current process is alive", func(t *testing.T) {
-		pidStr := fmt.Sprintf("%d", os.Getpid())
-		if ownerProcessGone(pidStr) {
-			t.Fatal("current process should not be gone")
-		}
-	})
+	}
+	if ownerProcessGone(fmt.Sprintf("%d", os.Getpid())) {
+		t.Fatal("current process should not be gone")
+	}
 }

--- a/plugins/sandbox/docker/dood.go
+++ b/plugins/sandbox/docker/dood.go
@@ -46,40 +46,30 @@ var lookupSandboxServerURL = func() string {
 	return strings.TrimSpace(os.Getenv("STELLA_SANDBOX_SERVER_URL"))
 }
 
-// autodetectServerReachability fills SandboxNetwork/ServerURL by inspecting the
-// container stellad runs in, so DooD sandboxes reach stellad with zero extra
-// configuration: they join the same Docker network and target stellad's address
-// on it instead of their own empty 127.0.0.1 loopback. Best-effort — running on
-// the host, no user-defined network, or a daemon hiccup leaves cfg untouched and
-// the caller falls back to loopback. Explicit env values always win.
-func autodetectServerReachability(ctx context.Context, cfg Config) Config {
-	if cfg.RuntimeMode == DockerSandboxModeHost {
-		// stellad runs on the host, so there is no own-container to inspect.
-		// Reaching the host from a sandbox container needs a host-gateway address
-		// (e.g. host.docker.internal) which is deployment-specific — out of scope
-		// here; set STELLA_SANDBOX_SERVER_URL explicitly if sandboxes need it.
-		return cfg
-	}
-	if cfg.SandboxNetwork != "" && cfg.ServerURL != "" {
-		return cfg // fully configured by env
-	}
+// identifySelf resolves stellad's daemon-visible container identity. DooD owner
+// labels depend on this identity, so unlike reachability detection it fails
+// closed when the daemon cannot identify the current container.
+func identifySelf(ctx context.Context) (*dockerclient.SelfContainer, error) {
 	host, err := lookupHostname()
 	if err != nil {
-		return cfg
+		return nil, fmt.Errorf("docker backend: determine container hostname: %w", err)
 	}
 	client, err := getSharedClient()
 	if err != nil {
-		return cfg
+		return nil, fmt.Errorf("docker backend: create client to identify own container: %w", err)
 	}
+	return identifySelfWithClient(ctx, client, host)
+}
+
+func identifySelfWithClient(ctx context.Context, client *dockerclient.Client, host string) (*dockerclient.SelfContainer, error) {
 	self, err := client.InspectSelf(ctx, host)
-	if err != nil || self == nil {
-		// Silent failure here would surface only as connection-refused inside the
-		// sandbox, which is miserable to debug — point the operator at the override.
-		slog.Warn("docker backend: could not identify stellad's own container for sandbox networking; set STELLA_SANDBOX_NETWORK and STELLA_SANDBOX_SERVER_URL if sandboxes cannot reach stellad",
-			"component", "runner_sandbox", "ref", host, "err", err)
-		return cfg
+	if err != nil {
+		return nil, fmt.Errorf("docker backend: inspect own container %q: %w", host, err)
 	}
-	return applyReachability(cfg, self)
+	if self == nil || self.ID == "" {
+		return nil, fmt.Errorf("docker backend: could not identify own container; docker bind and volume modes require stellad to run in a daemon-visible container")
+	}
+	return self, nil
 }
 
 // applyReachability merges a detected self-container into cfg, filling only the

--- a/plugins/sandbox/docker/dood_test.go
+++ b/plugins/sandbox/docker/dood_test.go
@@ -1,8 +1,15 @@
 package docker
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"testing"
+
+	"github.com/moby/moby/api/types/container"
+	mobyclient "github.com/moby/moby/client"
+
+	"github.com/CherryHQ/stella/plugins/sandbox/docker/dockerclient"
 )
 
 func withDockerModeEnv(t *testing.T, mode, stellaHomeHost, stellaHomeVolume string) {
@@ -165,6 +172,45 @@ func TestApplyDockerMode_MissingModeErrors(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), dockerSandboxModeEnv) {
 		t.Errorf("error should mention %s, got: %v", dockerSandboxModeEnv, err)
+	}
+}
+
+type selfIdentityAPI struct {
+	noopAPI
+	result mobyclient.ContainerInspectResult
+	err    error
+}
+
+func (f selfIdentityAPI) ContainerInspect(context.Context, string, mobyclient.ContainerInspectOptions) (mobyclient.ContainerInspectResult, error) {
+	return f.result, f.err
+}
+
+func TestIdentifySelfWithClientFailsClosed(t *testing.T) {
+	cases := []struct {
+		name string
+		api  selfIdentityAPI
+		want string
+	}{
+		{"not a container", selfIdentityAPI{}, "could not identify"},
+		{"inspect error", selfIdentityAPI{err: errors.New("daemon down")}, "inspect own container"},
+		{"empty ID", selfIdentityAPI{result: mobyclient.ContainerInspectResult{Container: container.InspectResponse{}}}, "could not identify"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := identifySelfWithClient(context.Background(), dockerclient.NewWithAPI(tc.api), "self")
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestIdentifySelfWithClientCachesDaemonVisibleID(t *testing.T) {
+	self, err := identifySelfWithClient(context.Background(), dockerclient.NewWithAPI(selfIdentityAPI{
+		result: mobyclient.ContainerInspectResult{Container: container.InspectResponse{ID: "daemon-visible-id"}},
+	}), "self")
+	if err != nil || self.ID != "daemon-visible-id" {
+		t.Fatalf("self, err = %+v, %v", self, err)
 	}
 }
 

--- a/plugins/sandbox/docker/reachability_test.go
+++ b/plugins/sandbox/docker/reachability_test.go
@@ -1,7 +1,6 @@
 package docker
 
 import (
-	"context"
 	"testing"
 
 	"github.com/CherryHQ/stella/plugins/sandbox/docker/dockerclient"
@@ -67,22 +66,6 @@ func TestApplyReachability(t *testing.T) {
 		got := applyReachability(Config{ServerURL: "http://stella:9000"}, composeSelf)
 		if got.ServerURL != "http://stella:9000" {
 			t.Fatalf("url overridden: %q", got.ServerURL)
-		}
-	})
-}
-
-func TestAutodetectServerReachabilityShortCircuits(t *testing.T) {
-	t.Run("host mode skips detection", func(t *testing.T) {
-		got := autodetectServerReachability(context.Background(), Config{RuntimeMode: DockerSandboxModeHost})
-		if got.SandboxNetwork != "" || got.ServerURL != "" {
-			t.Fatalf("host mode mutated cfg: %+v", got)
-		}
-	})
-
-	t.Run("fully configured by env skips detection", func(t *testing.T) {
-		got := autodetectServerReachability(context.Background(), Config{RuntimeMode: DockerSandboxModeVolume, SandboxNetwork: "n", ServerURL: "u"})
-		if got.SandboxNetwork != "n" || got.ServerURL != "u" {
-			t.Fatalf("configured cfg mutated: %+v", got)
 		}
 	})
 }

--- a/plugins/sandbox/docker/session.go
+++ b/plugins/sandbox/docker/session.go
@@ -48,6 +48,7 @@ func logSessionClosed(sessionID, backend, reason string) {
 // dockerFactory creates docker-backed sandbox sessions.
 type dockerFactory struct {
 	cfg                Config
+	owner              dockerclient.Owner
 	cleanupOrphansOnce sync.Once
 	toolCacheGCOnce    sync.Once
 }
@@ -58,21 +59,31 @@ type dockerFactory struct {
 //   - Runtime mode resolution: reads $STELLA_DOCKER_SANDBOX_MODE and the
 //     matching mode-specific env ($STELLA_HOME_HOST or $STELLA_HOME_VOLUME).
 //     No container runtime auto-detection is used.
+//   - DooD owner identity: inspects the daemon-visible current container once;
+//     bind and volume modes fail closed when that identity cannot be resolved.
 //   - User tool resolution: loads the builtin and user plugin manifests
 //     ($STELLA_HOME/plugins.yaml) to populate UserToolBinaries.
 //
-// Both steps are skipped when StellaHome is empty (e.g. unit tests), making
+// These steps are skipped when StellaHome is empty (e.g. unit tests), making
 // construction cheap and infallible in that case.
 func NewFactory(cfg Config) (sandboxpkg.Factory, error) {
+	owner := dockerclient.Owner{Kind: dockerclient.OwnerKindProcess, ID: strconv.Itoa(os.Getpid())}
 	if cfg.StellaHome != "" {
 		var err error
 		cfg, err = applyDockerMode(cfg, cfg.StellaHome)
 		if err != nil {
 			return nil, err
 		}
-		detectCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-		cfg = autodetectServerReachability(detectCtx, cfg)
-		cancel()
+		if cfg.RuntimeMode != DockerSandboxModeHost {
+			detectCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			self, err := identifySelf(detectCtx)
+			cancel()
+			if err != nil {
+				return nil, err
+			}
+			cfg = applyReachability(cfg, self)
+			owner = dockerclient.Owner{Kind: dockerclient.OwnerKindContainer, ID: self.ID}
+		}
 		if len(cfg.UserToolBinaries) == 0 {
 			tools, err := resolveUserToolBinaries(cfg.StellaHome)
 			if err != nil {
@@ -81,7 +92,7 @@ func NewFactory(cfg Config) (sandboxpkg.Factory, error) {
 			cfg.UserToolBinaries = tools
 		}
 	}
-	return &dockerFactory{cfg: cfg}, nil
+	return &dockerFactory{cfg: cfg, owner: owner}, nil
 }
 
 func (f *dockerFactory) Name() string { return "docker" }
@@ -129,7 +140,7 @@ func (f *dockerFactory) EnsureReady(ctx context.Context) error {
 		if err != nil {
 			return
 		}
-		dockerclient.CleanupOrphanedContainers(ctx, client, scope)
+		dockerclient.CleanupOrphanedContainers(ctx, client, scope, f.owner)
 	})
 	f.toolCacheGCOnce.Do(func() {
 		client, err := getSharedClient()
@@ -197,13 +208,8 @@ func (f *dockerFactory) CreateSession(ctx context.Context, policy sandboxpkg.Pol
 		NetworkMode:    networkMode,
 		Network:        f.cfg.SandboxNetwork,
 		Env:            mergeEnv(policy.Env, nil),
-		Labels: map[string]string{
-			dockerclient.LabelSessionID:  sessionID,
-			dockerclient.LabelStellaHome: cleanupScope,
-			dockerclient.LabelCreatedAt:  time.Now().UTC().Format(time.RFC3339),
-			dockerclient.LabelOwnerPID:   strconv.Itoa(os.Getpid()),
-		},
-		Name: "stella-sandbox-" + sessionID,
+		Labels:         f.sessionLabels(sessionID, cleanupScope, time.Now().UTC()),
+		Name:           "stella-sandbox-" + sessionID,
 	}
 
 	mountedPolicyMounts, mountedTempDirHost, mountedUserDataHost, err := f.configureSessionMounts(&opts, policy, workspaceHost, userDataHost)
@@ -346,6 +352,16 @@ func (f *dockerFactory) CreateSession(ctx context.Context, policy sandboxpkg.Pol
 // returns the mounted process-view mounts, the mounted temp-dir host, and the
 // mounted user-data host ("" when /user could not be mounted, so callers don't
 // wire a /user that isn't really there).
+func (f *dockerFactory) sessionLabels(sessionID, cleanupScope string, createdAt time.Time) map[string]string {
+	return map[string]string{
+		dockerclient.LabelSessionID:  sessionID,
+		dockerclient.LabelStellaHome: cleanupScope,
+		dockerclient.LabelCreatedAt:  createdAt.UTC().Format(time.RFC3339),
+		dockerclient.LabelOwnerKind:  f.owner.Kind,
+		dockerclient.LabelOwnerID:    f.owner.ID,
+	}
+}
+
 func (f *dockerFactory) configureSessionMounts(opts *dockerclient.CreateOptions, policy sandboxpkg.Policy, workspaceHost, userDataHost string) ([]sandboxpkg.Mount, string, string, error) {
 	if len(policy.Filesystem.Mounts) == 0 {
 		policy.Filesystem.Mounts = append(policy.Filesystem.Mounts, sandboxpkg.Mount{HostPath: workspaceHost, SandboxPath: workspaceMount, Access: sandboxpkg.MountReadWrite})

--- a/plugins/sandbox/docker/session_pure_test.go
+++ b/plugins/sandbox/docker/session_pure_test.go
@@ -5,10 +5,33 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	sandboxpkg "github.com/CherryHQ/stella/pkg/sandbox"
 	"github.com/CherryHQ/stella/plugins/sandbox/docker/dockerclient"
 )
+
+func TestSessionLabelsUseCachedOwnerIdentity(t *testing.T) {
+	createdAt := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name  string
+		owner dockerclient.Owner
+	}{
+		{"host process", dockerclient.Owner{Kind: dockerclient.OwnerKindProcess, ID: "1234"}},
+		{"DooD container", dockerclient.Owner{Kind: dockerclient.OwnerKindContainer, ID: "daemon-visible-container-id"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			labels := (&dockerFactory{owner: tc.owner}).sessionLabels("session", "/stella", createdAt)
+			if labels[dockerclient.LabelOwnerKind] != tc.owner.Kind || labels[dockerclient.LabelOwnerID] != tc.owner.ID {
+				t.Fatalf("owner labels = %q/%q, want %q/%q", labels[dockerclient.LabelOwnerKind], labels[dockerclient.LabelOwnerID], tc.owner.Kind, tc.owner.ID)
+			}
+			if _, legacy := labels[dockerclient.LabelOwnerPID]; legacy {
+				t.Fatalf("new labels must not write %s: %v", dockerclient.LabelOwnerPID, labels)
+			}
+		})
+	}
+}
 
 func TestMergeEnv(t *testing.T) {
 	t.Run("nil inputs", func(t *testing.T) {

--- a/web/content/docs/admin/kubernetes.md
+++ b/web/content/docs/admin/kubernetes.md
@@ -147,9 +147,15 @@ defaults, so its contract holds for any `image.repository` you substitute.
 
 ## Sandbox backend
 
+| Deployment                      | Supported sandbox backends                                                                                 |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Helm on Kubernetes              | `local` only                                                                                               |
+| Docker Compose or a native host | `docker`, `local`, or explicitly enabled `none` as documented in the [sandbox guide](/docs/guides/sandbox) |
+
 `sandbox.backend` is required and has no default. This chart supports only
 **`local`** (bubblewrap) isolation; it intentionally rejects both `none` host
-execution and the `docker` backend (which would require a mounted Docker socket).
+execution and the `docker` backend. Docker is unsupported on Kubernetes: the
+chart never mounts a Docker socket and offers no values or escape hatch to add one.
 
 Tool processes run in their own user, PID, and mount namespaces with the Stella
 process's environment scrubbed. **Experimental on Kubernetes:** it depends on the
@@ -233,6 +239,12 @@ the old pod stops and the new one starts and passes its startup probe.
   back to an older image does not undo migrations that the newer version already
   applied. If you must roll back across a migration, restore the database from your
   backup as well.
+- **Docker sandbox upgrades are outside Helm.** If you previously ran Docker-outside-
+  of-Docker (DooD), running sandbox containers with the legacy `owner_pid` label are
+  preserved on the first upgrade because a container PID is not safely meaningful to
+  the Docker daemon. End those old sessions deliberately, or remove their stopped
+  containers after confirming they are not in use. New DooD sessions use daemon-
+  visible container ownership and are cleaned up safely after restarts.
 
 ## Storage
 

--- a/web/content/docs/admin/kubernetes.zh.md
+++ b/web/content/docs/admin/kubernetes.zh.md
@@ -137,8 +137,14 @@ chart 通过 typed values 管理的变量在 `extraEnv` 里会被**拒绝**（`S
 
 ## 沙箱后端 {#sandbox-backend}
 
+| 部署方式                    | 支持的沙箱后端                                                                  |
+| --------------------------- | ------------------------------------------------------------------------------- |
+| Kubernetes 上的 Helm        | 仅 `local`                                                                      |
+| Docker Compose 或原生宿主机 | 按[沙箱指南](/docs/guides/sandbox)配置的 `docker`、`local`，或显式启用的 `none` |
+
 `sandbox.backend` 必填且无默认值。本 chart 只支持 **`local`**（bubblewrap）隔离；它刻意
-拒绝 `none` 宿主机执行和 `docker` 后端（后者需要挂载 Docker socket）。
+拒绝 `none` 宿主机执行和 `docker` 后端。Kubernetes 上不支持 Docker：chart 绝不挂载 Docker
+socket，也没有通过 values 添加它的逃生口。
 
 工具进程运行在自己独立的 user、PID、mount namespace 里，且 Stella 进程的环境变量被擦除。
 **在 Kubernetes 上属实验性：** 依赖集群允许 _非特权 user namespace_（bubblewrap 会调用
@@ -207,6 +213,10 @@ terminationGracePeriodSeconds >=
   Stella 启动时会自动应用待执行的数据库迁移。
 - **`helm rollback` 只回滚 workload，不回滚数据库。** 把 chart 回滚到旧镜像不会撤销
   新版本已经应用的迁移。若必须跨迁移回滚，请一并从备份恢复数据库。
+- **Docker 沙箱升级不属于 Helm 范围。** 若你之前运行的是 Docker-outside-of-Docker（DooD），
+  带旧 `owner_pid` 标签且仍在运行的沙箱容器会在首次升级时被保留：容器内 PID 对 Docker daemon
+  没有可安全解释的含义。请在确认不再使用后结束这些旧 session，或删除已停止的容器。新的 DooD
+  session 会记录 daemon 可见的容器归属，重启后可被安全清理。
 
 ## 存储
 

--- a/web/content/docs/guides/sandbox.md
+++ b/web/content/docs/guides/sandbox.md
@@ -21,6 +21,13 @@ Change the active sandbox backend from the **Plugins** page in the Web UI. Only 
 
 Docker provides full container-level process, filesystem, and network isolation. The Docker daemon must be running and reachable. All platforms (Linux, macOS, Windows) are supported.
 
+| Deployment                            | Docker sandbox support                       |
+| ------------------------------------- | -------------------------------------------- |
+| Native host or Docker Compose         | Supported (`host`, `bind`, or `volume` mode) |
+| Kubernetes with the Stella Helm chart | Unsupported — use `local` only               |
+
+The Helm chart never mounts a Docker socket and has no socket-mount escape hatch. Do not add one: it would give agent-controlled containers access to the node's Docker daemon.
+
 ### When to Use
 
 - You need strong isolation between the agent and the host.
@@ -47,6 +54,14 @@ When stellad itself runs inside a Docker container and agents use the `docker` s
 Each mode rejects env vars that belong to other modes. For example, `bind` mode with `STELLA_HOME_VOLUME` set is an error.
 
 Volume mode requires Docker Engine 25+ for volume subpath mounts.
+
+### Upgrading DooD ownership
+
+Existing DooD sandbox containers labelled only with `stella.sandbox.owner_pid` are
+preserved while running after upgrading: that PID belongs to a container namespace
+and cannot safely establish daemon-side liveness. End those sessions deliberately,
+or remove their stopped containers after verifying they are unused. New sessions use
+the daemon-visible owning container ID and are cleaned up safely after a restart.
 
 ### Docker Compose Examples
 

--- a/web/content/docs/guides/sandbox.zh.md
+++ b/web/content/docs/guides/sandbox.zh.md
@@ -21,6 +21,13 @@ Stella 在沙箱内运行 agent 代码。你可以为每个 agent 选择沙箱�
 
 Docker 提供完整的容器级进程、文件系统和网络隔离。Docker 守护进程必须正在运行且可访问。支持所有平台（Linux、macOS、Windows）。
 
+| 部署方式                        | Docker 沙箱支持                         |
+| ------------------------------- | --------------------------------------- |
+| 原生宿主机或 Docker Compose     | 支持（`host`、`bind` 或 `volume` 模式） |
+| Stella Helm chart 的 Kubernetes | 不支持——仅使用 `local`                  |
+
+Helm chart 绝不挂载 Docker socket，也没有挂载 socket 的逃生口。不要自行添加：这会让 agent 控制的容器获得节点 Docker daemon 的访问权。
+
 ### 何时使用
 
 - 需要 agent 与宿主机之间的强隔离。
@@ -47,6 +54,12 @@ Docker 提供完整的容器级进程、文件系统和网络隔离。Docker 守
 每种模式都会拒绝属于其他模式的环境变量。例如，`bind` 模式下设置 `STELLA_HOME_VOLUME` 会报错。
 
 Volume 模式需要 Docker Engine 25+ 以支持 volume subpath 挂载。
+
+### 升级 DooD 归属
+
+升级时，仍在运行且只带 `stella.sandbox.owner_pid` 标签的旧 DooD 沙箱容器会被保留：该 PID
+属于容器 namespace，无法安全地用于 daemon 侧存活判断。请有意结束这些 session，或在确认未使用后
+删除已停止的容器。新 session 使用 daemon 可见的所属容器 ID，重启后可被安全清理。
 
 ### Docker Compose 示例
 


### PR DESCRIPTION
## What

Replace Docker sandbox `owner_pid` labels with daemon-verifiable owner identities and document the supported Kubernetes sandbox matrix.

## Why

A PID recorded inside the `stellad` container is meaningless to the host Docker daemon. Startup cleanup could therefore delete a live peer's sandbox or preserve dead sandboxes indefinitely under Docker-outside-of-Docker.

## How

- Native-host mode records a host-process owner; bind/volume modes resolve the daemon-visible `stellad` container ID and fail closed if it cannot be identified.
- Startup cleanup removes dead owners and prior-process leftovers, preserves live foreign owners and transient inspect failures, and never interprets legacy container-namespace PIDs in DooD mode.
- Same-container and same-PID restart reuse is handled because cleanup runs before the new process creates sessions.
- Kubernetes docs explicitly keep the Helm chart on `local` only; no Docker socket or Kubernetes lease subsystem is introduced.

## Verification

- `go test ./plugins/sandbox/docker/...`
- `deploy/helm/check.sh`
- `mise run format`
- `mise run build`
- `mise run test`

## Dependency

Stacked on #764; retarget to `main` after #764 merges.

## Refs

Closes #650
