### PR TITLE
🐛 fix: pin @redocly/cli to 2.39.0 in generate:api

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -74,7 +74,9 @@ dprint fmt api/spec/components.yaml
 go tool oapi-codegen --config api/codegen/types.yaml   api/spec/components.yaml
 go tool oapi-codegen --config api/codegen/server.yaml  api/spec/openapi.yaml
 go run ./internal/goal/cmd/gengoalcontrolschema
-pnpm --package=@redocly/cli dlx redocly bundle api/spec/openapi.yaml -o internal/server/docs_spec.yaml
+# Pin: redocly 2.40.0 tightened YAML parsing and rejects openapi.yaml's flow
+# mappings (issue #769). Bump deliberately after verifying the spec still bundles.
+pnpm --package=@redocly/cli@2.39.0 dlx redocly bundle api/spec/openapi.yaml -o internal/server/docs_spec.yaml
 go run ./internal/cmd/toolgen
 """
 


### PR DESCRIPTION
## What

Pin `@redocly/cli` to `2.39.0` in the `generate:api` mise task (was unpinned `pnpm dlx`).

## Why

redocly `2.40.0` (released ~2026-07-21) tightened YAML parsing and rejects the committed `api/spec/openapi.yaml`:

```
deficient indentation in api/spec/openapi.yaml (437:5)
```

This silently broke `mise run generate:api` / `release:validate` and blocked the v0.60.1 release gate. The spec is byte-identical to the `v0.60.0` tag and `oapi-codegen` still parses it — only redocly ≥ 2.40.0 fails. Verified: `2.39.0`, `1.34.5`, `1.25.15` all bundle cleanly.

## How

`pnpm --package=@redocly/cli@2.39.0 dlx redocly bundle ...`

Verified `generate:api` passes and regenerates `docs_spec.yaml` byte-identical (no drift). Follow-up (non-blocking): normalize openapi.yaml flow mappings to block style so future redocly majors don't re-break.

## Refs

Closes #769