### PR TITLE
🐛 fix(web): surface session run errors in the chat UI

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -228,9 +228,9 @@ func streamAssistant(ctx context.Context, messages []ai.Message, cfg loopConfig,
 		case ai.EventStop:
 			msg.StopReason = e.Reason
 		case ai.EventError:
+			msg.StopReason = ai.StopReasonError
 			if e.Err != nil {
 				msg.ErrorMessage = e.Err.Error()
-				msg.StopReason = ai.StopReasonError
 			}
 		}
 
@@ -258,8 +258,12 @@ func streamAssistant(ctx context.Context, messages []ai.Message, cfg loopConfig,
 	// Surface provider-level errors that were delivered as EventError events
 	// rather than as a stream-level Wait() error. Without this, the error
 	// is silently swallowed: StopReason=Error causes runLoop to return nil,
-	// and the caller never learns what went wrong.
-	if msg.StopReason == ai.StopReasonError && msg.ErrorMessage != "" {
+	// and the caller never learns what went wrong. Providers may signal
+	// StopReason=Error without any error detail; that is still a failure.
+	if msg.StopReason == ai.StopReasonError {
+		if msg.ErrorMessage == "" {
+			msg.ErrorMessage = "stream ended with error stop reason"
+		}
 		return streamResult{Message: msg, TimeToFirstToken: ttft}, fmt.Errorf("provider: %s", msg.ErrorMessage)
 	}
 

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -192,7 +193,9 @@ func TestRunMultiTurnLoop(t *testing.T) {
 	}
 }
 
-func TestRunStopsOnErrorStopReason(t *testing.T) {
+func TestRunErrorStopReasonSurfacesError(t *testing.T) {
+	// A provider may signal StopReason=Error without any EventError detail;
+	// the loop must still fail loudly instead of finishing cleanly.
 	stream := func(_ context.Context, _ ai.Model, _ ai.Context, _ ai.StreamOptions) (providers.AssistantEventStream, error) {
 		out := providers.NewChannelEventStream(8)
 		go func() {
@@ -204,12 +207,18 @@ func TestRunStopsOnErrorStopReason(t *testing.T) {
 	}
 
 	runner := newTestRunner(stream)
-	history, _, err := collectEvents(runner, []ai.Message{ai.UserMessage{Content: "go"}})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	history, events, err := collectEvents(runner, []ai.Message{ai.UserMessage{Content: "go"}})
+	if err == nil {
+		t.Fatal("expected error for StopReason=Error with no detail, got nil")
 	}
-	if len(history) != 2 {
-		t.Fatalf("expected history len 2, got %d", len(history))
+	if !strings.Contains(err.Error(), "provider:") {
+		t.Fatalf("expected provider error, got %v", err)
+	}
+	if len(history) != 1 {
+		t.Fatalf("expected history len 1 (failed turn not appended), got %d", len(history))
+	}
+	if countEvents[AgentErrored](events) != 1 {
+		t.Fatalf("expected 1 AgentErrored, got %d", countEvents[AgentErrored](events))
 	}
 }
 

--- a/web/src/components/chat/ChatErrorNotice.tsx
+++ b/web/src/components/chat/ChatErrorNotice.tsx
@@ -1,0 +1,32 @@
+import { AlertCircle } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { useI18n } from "@/lib/i18n";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  /** The `error` from `useChat`. When undefined, nothing renders. */
+  error: Error | undefined;
+  /** Layout-only overrides (spacing, width) for the wrapper. */
+  className?: string;
+}
+
+/**
+ * Inline run-level failure notice for chat surfaces. Renders the SDK error at
+ * the bottom of the transcript so a failed turn is visible where the user is
+ * looking. Sending the next message clears `useChat`'s error, which unmounts
+ * this automatically — no dismiss control needed.
+ */
+export function ChatErrorNotice({ error, className }: Props) {
+  const { t } = useI18n();
+  if (!error) return null;
+  const detail = error.message?.trim();
+  return (
+    <div className={cn("mx-auto w-full max-w-3xl px-4 pb-3 sm:px-8", className)}>
+      <Alert variant="error">
+        <AlertCircle />
+        <AlertTitle>{t("chat.error.title")}</AlertTitle>
+        <AlertDescription>{detail || t("chat.error.generic")}</AlertDescription>
+      </Alert>
+    </div>
+  );
+}

--- a/web/src/components/chat/ChatPane.tsx
+++ b/web/src/components/chat/ChatPane.tsx
@@ -4,13 +4,16 @@ interface Props {
   transcript: ReactNode;
   composer?: ReactNode;
   banner?: ReactNode;
+  /** Rendered between the transcript and composer (e.g. run-level error notice). */
+  notice?: ReactNode;
 }
 
-export function ChatPane({ transcript, composer, banner }: Props) {
+export function ChatPane({ transcript, composer, banner, notice }: Props) {
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-background">
       {banner}
       {transcript}
+      {notice}
       {composer}
     </div>
   );

--- a/web/src/features/groups/GroupChat.tsx
+++ b/web/src/features/groups/GroupChat.tsx
@@ -9,6 +9,7 @@ import { groupMembersQueryOptions } from "@/lib/queries/groups";
 import { agentSkillsOptions } from "@/lib/queries/agents";
 import { createGroupTransport, groupMessagesToUIMessages } from "@/lib/chat-transport";
 import { ChatPane } from "@/components/chat/ChatPane";
+import { ChatErrorNotice } from "@/components/chat/ChatErrorNotice";
 import { BUILTIN_COMMANDS, ChatComposer } from "@/features/sessions/ChatComposer";
 import { useFileAttachments } from "@/features/sessions/useFileAttachments";
 import { GroupInspector } from "./GroupInspector";
@@ -90,6 +91,7 @@ export function GroupChat({ groupId }: Props) {
     setMessages: setChatMessages,
     status: chatStatus,
     stop: chatStop,
+    error: chatError,
   } = useChat({
     id: `group-${groupId}`,
     transport,
@@ -97,6 +99,7 @@ export function GroupChat({ groupId }: Props) {
       void loadMessages();
       void queryClient.invalidateQueries({ queryKey: ["groups"] });
     },
+    onError: (err) => console.error("[group chat]", err),
   });
 
   const isStreaming = chatStatus === "streaming" || chatStatus === "submitted";
@@ -263,6 +266,7 @@ export function GroupChat({ groupId }: Props) {
             uploadSessionId={uploadContext?.sessionId}
           />
         }
+        notice={<ChatErrorNotice error={chatError} />}
         composer={
           <ChatComposer
             value={userInput}

--- a/web/src/features/recally/components/RecallyChat.tsx
+++ b/web/src/features/recally/components/RecallyChat.tsx
@@ -9,6 +9,7 @@ import { agentsQueryOptions } from "@/lib/queries/agents";
 import type { Message } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { MarkdownPreview } from "@/components/MarkdownPreview";
+import { ChatErrorNotice } from "@/components/chat/ChatErrorNotice";
 import { Button } from "@/components/ui/button";
 import {
   createSessionTransport,
@@ -123,9 +124,11 @@ export function RecallyChat({ articleId, onClose }: Props) {
     sendMessage: chatSendMessage,
     setMessages: setChatMessages,
     status: chatStatus,
+    error: chatError,
   } = useChat({
     id: activeSessionId ?? "recally-chat-empty",
     transport,
+    onError: (err) => console.error("[recally chat]", err),
   });
 
   const isStreaming = chatStatus === "streaming" || chatStatus === "submitted";
@@ -282,6 +285,8 @@ export function RecallyChat({ articleId, onClose }: Props) {
         )}
         <div ref={messagesEndRef} />
       </div>
+
+      <ChatErrorNotice error={chatError} className="max-w-full px-4 pb-2 sm:px-4" />
 
       {/* Input Form */}
       <div className="shrink-0 border-t border-border bg-card p-3">

--- a/web/src/features/sessions/SessionConversation.tsx
+++ b/web/src/features/sessions/SessionConversation.tsx
@@ -18,6 +18,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Transcript } from "./Transcript";
+import { ChatErrorNotice } from "@/components/chat/ChatErrorNotice";
 import { useI18n } from "@/lib/i18n";
 
 interface Props {
@@ -54,9 +55,11 @@ export function SessionConversation({
     setMessages: setChatMessages,
     status: chatStatus,
     stop: chatStop,
+    error: chatError,
   } = useChat({
     id: `conv-${sessionId}`,
     transport,
+    onError: (err) => console.error("[session conversation chat]", err),
   });
 
   const isStreaming = chatStatus === "streaming" || chatStatus === "submitted";
@@ -150,6 +153,7 @@ export function SessionConversation({
         sessionId={sessionId}
         activeStreaming={isStreaming}
       />
+      <ChatErrorNotice error={chatError} />
       <div className="flex flex-col gap-2 border-t border-border p-2 sm:flex-row sm:p-3">
         <input
           value={userInput}

--- a/web/src/features/sessions/SessionDetail.tsx
+++ b/web/src/features/sessions/SessionDetail.tsx
@@ -17,6 +17,7 @@ import { sessionContextItemsOptions } from "@/lib/queries/session-context";
 import { fetchAllSessionMessages } from "@/lib/paginated";
 import type { Message, Session } from "@/lib/types";
 import { ChatPane } from "@/components/chat/ChatPane";
+import { ChatErrorNotice } from "@/components/chat/ChatErrorNotice";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -122,9 +123,11 @@ export function SessionDetail({
     status: chatStatus,
     stop: chatStop,
     resumeStream: chatResume,
+    error: chatError,
   } = useChat({
     id: session?.id ?? "empty",
     transport,
+    onError: (err) => console.error("[session chat]", err),
   });
 
   const isStreaming = chatStatus === "streaming" || chatStatus === "submitted";
@@ -559,6 +562,7 @@ export function SessionDetail({
             activeStreaming={isStreaming}
           />
         }
+        notice={<ChatErrorNotice error={chatError} />}
         composer={
           session.user_id === currentUserID ? (
             <ChatComposer

--- a/web/src/lib/i18n/messages.ts
+++ b/web/src/lib/i18n/messages.ts
@@ -1261,6 +1261,8 @@ const en = {
   "chat.executionTrace": "Execution trace",
   "chat.noExecutionDetails": "No execution details found.",
   "chat.you": "You",
+  "chat.error.title": "Response failed",
+  "chat.error.generic": "The response could not be completed.",
 
   // Groups
   "groups.title": "Groups",
@@ -3168,6 +3170,8 @@ const zh: Record<MessageKey, string> = {
   "chat.executionTrace": "执行追踪",
   "chat.noExecutionDetails": "未找到执行细节。",
   "chat.you": "你",
+  "chat.error.title": "响应失败",
+  "chat.error.generic": "响应未能完成。",
 
   // Groups
   "groups.title": "群组",


### PR DESCRIPTION
## What

When a session turn fails (LLM/provider API error), the chat UI now shows an inline "Response failed" notice with the provider's error text, instead of showing nothing. Also fixes a backend path where a provider error with no detail was silently treated as a clean finish.

Fixes #783

## Why

The backend already emitted `{"type":"error","errorText":...}` SSE frames on failure, but all four `useChat` consumers ignored the AI SDK's `error` state — the typing indicator just vanished and the user had no idea the run failed or what to do.

## How

**Web**
- New shared `ChatErrorNotice` (`web/src/components/chat/ChatErrorNotice.tsx`): CossUI `Alert` `error` variant, i18n en+zh, renders `error.message` with a generic fallback. Layout classes only; dark mode via semantic tokens.
- `ChatPane` gains a `notice` slot between transcript and composer; wired `error` + a minimal `onError` console log into `SessionDetail`, `SessionConversation`, `GroupChat`, and `RecallyChat`.
- Clearing: verified in `ai@6` that `sendMessage`/`resumeStream` reset `error` at request start, so the notice unmounts on the next send — no dismiss control needed.

**Backend**
- `pkg/agent/loop.go`: `streamAssistant` now fails on `StopReason=Error` even when the provider supplied no error message (fallback text), and `EventError` unconditionally sets the error stop reason. Previously that case returned a clean finish and the caller never learned the turn died.
- Rewrote `TestRunStopsOnErrorStopReason` (which codified the swallow) as `TestRunErrorStopReasonSurfacesError`: asserts an error is returned, `AgentErrored` is emitted, and the failed turn is not appended to history.

## Verification

- `mise run format && mise run build && mise run test` — all pass, no FAIL lines.
- `vp check --fix` — clean on 284 files. No frontend component-test infra exists (no vitest test files / jsdom), so no component test was added.

## Out of scope (follow-up)

Errors are never persisted (`ctx_conversation`/`ctx_message` have no status/error columns), so a refresh or reconnect still loses the failure; and the SSE frame contract is typed as a bare `string` in OpenAPI. Both need schema/spec work and are noted in #783.