### PR TITLE
🐛 fix(channel): persist group message image blocks through the event log

### DIFF
--- a/internal/channel/group_dispatch.go
+++ b/internal/channel/group_dispatch.go
@@ -248,13 +248,33 @@ func firstMentionedAgent(mentions []pkgchannel.Mention) string {
 	return ""
 }
 
-// contentBlocksToText extracts text from content blocks for event log storage.
+// imageContentPlaceholder is the deterministic text projection stored for a
+// group message that carries images but no text (see contentBlocksToText).
+const imageContentPlaceholder = "[image]"
+
+// contentBlocksToText projects content blocks onto the plain-text `content`
+// column that the semantic arbiter and history assembly read (rehydration for
+// dispatch goes through content_blocks instead).
+//
+// An image-only message has no text blocks, so a naive projection stores "".
+// But LLMSemanticGroupArbiter.Decide treats an empty message as "nothing to
+// route" and returns silence, so without an explicit @mention a pure-image
+// group message would never dispatch — and the content_blocks rehydration path
+// would never run. To honor that arbiter/history contract, project an
+// image-only message to a fixed "[image]" placeholder (one per message,
+// regardless of image count) so the arbiter sees a non-empty message and
+// history assembly gets a meaningful line. The placeholder lives only in this
+// text projection; groupMessageContentBlocks prefers content_blocks, so it
+// never leaks into the rehydrated image blocks the agent actually sees.
 func contentBlocksToText(blocks []ai.ContentBlock) string {
 	var parts []string
 	for _, b := range blocks {
 		if tc, ok := b.(ai.TextContent); ok && tc.Text != "" {
 			parts = append(parts, tc.Text)
 		}
+	}
+	if len(parts) == 0 && ai.HasImage(blocks) {
+		return imageContentPlaceholder
 	}
 	return strings.Join(parts, "\n")
 }

--- a/internal/channel/group_dispatch.go
+++ b/internal/channel/group_dispatch.go
@@ -73,6 +73,7 @@ func (c *Coordinator) appendGroupMessage(ctx context.Context, msg pkgchannel.Inc
 		PlatformTimestamp: msg.Timestamp,
 		ReplyTo:           msg.ReplyTo,
 		Content:           contentBlocksToText(msg.Content),
+		ContentBlocks:     marshalGroupContentBlocks(msg.Content),
 	}, eventlog.WithOnInserted(func(ctx context.Context, q *sqlc.Queries, result eventlog.AppendResult) error {
 		members, err := q.ListGroupMembers(ctx, result.GroupID)
 		if err != nil {
@@ -256,6 +257,21 @@ func contentBlocksToText(blocks []ai.ContentBlock) string {
 		}
 	}
 	return strings.Join(parts, "\n")
+}
+
+// marshalGroupContentBlocks serializes message content for event-log storage
+// when it carries more than text. Text-only messages store nothing and replay
+// from the text projection; a marshal failure degrades the same way rather
+// than dropping the message.
+func marshalGroupContentBlocks(blocks []ai.ContentBlock) []byte {
+	if !ai.HasImage(blocks) {
+		return nil
+	}
+	data, err := ai.MarshalContentBlocks(blocks)
+	if err != nil {
+		return nil
+	}
+	return data
 }
 
 // FuncGroupMemberLister adapts a function to GroupMemberLister.

--- a/internal/channel/group_dispatch_test.go
+++ b/internal/channel/group_dispatch_test.go
@@ -61,6 +61,65 @@ func TestContentBlocksToText(t *testing.T) {
 	}
 }
 
+func TestMarshalGroupContentBlocks(t *testing.T) {
+	textOnly := []ai.ContentBlock{ai.TextContent{Text: "hello"}}
+	if got := marshalGroupContentBlocks(textOnly); got != nil {
+		t.Errorf("text-only blocks = %s, want nil (replay from text projection)", got)
+	}
+
+	withImage := []ai.ContentBlock{
+		ai.TextContent{Text: "look"},
+		ai.ImageContent{Data: "aGk=", MimeType: "image/png"},
+	}
+	data := marshalGroupContentBlocks(withImage)
+	if data == nil {
+		t.Fatal("image-bearing blocks must serialize")
+	}
+	blocks, err := ai.UnmarshalContentBlocks(data)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(blocks) != 2 || !ai.HasImage(blocks) {
+		t.Fatalf("round-trip = %#v, want text+image", blocks)
+	}
+}
+
+func TestGroupMessageContentRehydration(t *testing.T) {
+	// Legacy/text-only row: empty JSON array falls back to the text projection.
+	legacy := sqlc.CtxGroupMessage{Content: "just text", ContentBlocks: []byte("[]")}
+	blocks := groupMessageContentBlocks(legacy)
+	if len(blocks) != 1 {
+		t.Fatalf("legacy blocks = %#v, want single text block", blocks)
+	}
+	if tc, ok := blocks[0].(ai.TextContent); !ok || tc.Text != "just text" {
+		t.Fatalf("legacy block = %#v, want text projection", blocks[0])
+	}
+	if got, ok := groupMessageChatContent(legacy).(string); !ok || got != "just text" {
+		t.Fatalf("legacy chat content = %#v, want plain string", groupMessageChatContent(legacy))
+	}
+
+	// Image-bearing row: structured blocks win over the text projection.
+	withImage := sqlc.CtxGroupMessage{
+		Content:       "look",
+		ContentBlocks: []byte(`[{"kind":"text","text":"look"},{"kind":"image","data":"aGk=","mime_type":"image/png"}]`),
+	}
+	blocks = groupMessageContentBlocks(withImage)
+	if len(blocks) != 2 || !ai.HasImage(blocks) {
+		t.Fatalf("rehydrated blocks = %#v, want text+image", blocks)
+	}
+	chat, ok := groupMessageChatContent(withImage).([]ai.ContentBlock)
+	if !ok || !ai.HasImage(chat) {
+		t.Fatalf("chat content = %#v, want blocks with image", chat)
+	}
+
+	// Corrupt blocks degrade to the text projection instead of dropping the message.
+	corrupt := sqlc.CtxGroupMessage{Content: "still here", ContentBlocks: []byte("{not json")}
+	blocks = groupMessageContentBlocks(corrupt)
+	if len(blocks) != 1 || ai.HasImage(blocks) {
+		t.Fatalf("corrupt blocks = %#v, want text fallback", blocks)
+	}
+}
+
 func TestFirstMentionedAgent(t *testing.T) {
 	if got := firstMentionedAgent(nil); got != "" {
 		t.Errorf("expected empty, got %q", got)

--- a/internal/channel/group_dispatch_test.go
+++ b/internal/channel/group_dispatch_test.go
@@ -50,6 +50,20 @@ func TestContentBlocksToText(t *testing.T) {
 			ai.TextContent{Text: ""},
 			ai.TextContent{Text: "world"},
 		}, "hello\nworld"},
+		// Image-only messages must project to a non-empty placeholder so the
+		// semantic arbiter does not treat them as "nothing to route" (Major 1).
+		{"image only", []ai.ContentBlock{
+			ai.ImageContent{Data: "aGk=", MimeType: "image/png"},
+		}, imageContentPlaceholder},
+		{"multiple images only", []ai.ContentBlock{
+			ai.ImageContent{Data: "aGk=", MimeType: "image/png"},
+			ai.ImageContent{Data: "Ynll", MimeType: "image/jpeg"},
+		}, imageContentPlaceholder},
+		// Real text wins over the placeholder when both are present.
+		{"text and image", []ai.ContentBlock{
+			ai.TextContent{Text: "look"},
+			ai.ImageContent{Data: "aGk=", MimeType: "image/png"},
+		}, "look"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -117,6 +131,42 @@ func TestGroupMessageContentRehydration(t *testing.T) {
 	blocks = groupMessageContentBlocks(corrupt)
 	if len(blocks) != 1 || ai.HasImage(blocks) {
 		t.Fatalf("corrupt blocks = %#v, want text fallback", blocks)
+	}
+}
+
+// TestImageOnlyMessageProjectionAndRehydration pins the Major 1 contract: an
+// image-only group message stores a non-empty "[image]" text projection (so the
+// semantic arbiter routes it instead of dropping it), yet dispatch rehydrates
+// the real image blocks — the placeholder must never leak into them.
+func TestImageOnlyMessageProjectionAndRehydration(t *testing.T) {
+	blocks := []ai.ContentBlock{ai.ImageContent{Data: "aGk=", MimeType: "image/png"}}
+
+	// Ingest-side projection: what the arbiter and history assembly see.
+	content := contentBlocksToText(blocks)
+	if content != imageContentPlaceholder {
+		t.Fatalf("image-only projection = %q, want %q", content, imageContentPlaceholder)
+	}
+	if content == "" {
+		t.Fatal("arbiter-visible projection must be non-empty for image-only messages")
+	}
+
+	// Persisted row: placeholder in content, real blocks in content_blocks.
+	stored := marshalGroupContentBlocks(blocks)
+	if stored == nil {
+		t.Fatal("image-bearing blocks must serialize to content_blocks")
+	}
+	msg := sqlc.CtxGroupMessage{Content: content, ContentBlocks: stored}
+
+	// Dispatch-side rehydration must prefer content_blocks and return the real
+	// image, with no "[image]" placeholder text block leaking through.
+	got := groupMessageContentBlocks(msg)
+	if len(got) != 1 || !ai.HasImage(got) {
+		t.Fatalf("rehydrated blocks = %#v, want a single image block", got)
+	}
+	for _, b := range got {
+		if tc, ok := b.(ai.TextContent); ok && tc.Text == imageContentPlaceholder {
+			t.Fatalf("placeholder %q leaked into rehydrated blocks", imageContentPlaceholder)
+		}
 	}
 }
 

--- a/internal/channel/group_dispatcher.go
+++ b/internal/channel/group_dispatcher.go
@@ -781,7 +781,7 @@ func (d *GroupDispatcher) chatDispatchUnqueued(ctx context.Context, row sqlc.Ctx
 		return nil, errors.New("coordinator not configured")
 	}
 	ctx = memory.WithGroupSeq(ctx, message.Seq)
-	content := []ai.ContentBlock{ai.TextContent{Text: message.Content}}
+	content := groupMessageContentBlocks(message)
 	var stream *pkgchannel.ChatStream
 	var err error
 	if state.Platform == "web" {
@@ -807,6 +807,25 @@ func (d *GroupDispatcher) chatDispatchUnqueued(ctx context.Context, row sqlc.Ctx
 		return nil, err
 	}
 	return stream, nil
+}
+
+// groupMessageContentBlocks rebuilds the structured blocks persisted for a
+// group message (images survive the event log via content_blocks), falling
+// back to the plain-text projection for text-only or legacy rows.
+func groupMessageContentBlocks(message sqlc.CtxGroupMessage) []ai.ContentBlock {
+	if blocks, err := ai.UnmarshalContentBlocks(message.ContentBlocks); err == nil && blocks != nil {
+		return blocks
+	}
+	return []ai.ContentBlock{ai.TextContent{Text: message.Content}}
+}
+
+// groupMessageChatContent is groupMessageContentBlocks for agent.ChatRequest,
+// which keeps plain strings for text-only messages.
+func groupMessageChatContent(message sqlc.CtxGroupMessage) agent.MessageContent {
+	if blocks, err := ai.UnmarshalContentBlocks(message.ContentBlocks); err == nil && blocks != nil {
+		return blocks
+	}
+	return message.Content
 }
 
 func (d *GroupDispatcher) chatWeb(ctx context.Context, row sqlc.CtxGroupDispatch, message sqlc.CtxGroupMessage) (*pkgchannel.ChatStream, error) {
@@ -848,7 +867,7 @@ func (d *GroupDispatcher) chatWeb(ctx context.Context, row sqlc.CtxGroupDispatch
 		Kind:           session.KindChat,
 		GroupID:        row.GroupID,
 		Channel:        session.Channel(channelStr),
-		Message:        message.Content,
+		Message:        groupMessageChatContent(message),
 		CurrentSpeaker: speaker,
 		Authority:      authority,
 	})

--- a/internal/db/migrations/20260724162628_add_group_message_content_blocks.sql
+++ b/internal/db/migrations/20260724162628_add_group_message_content_blocks.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+-- Structured content blocks (JSON []ai.ContentBlock: text + image) for group
+-- messages, so inbound images survive event-log storage and can be rehydrated
+-- at dispatch. "content" remains the plain-text projection consumed by the
+-- arbiter and history assembly; this column is written only when a message
+-- carries non-text blocks and stays '[]' otherwise.
+ALTER TABLE ctx_group_message ADD COLUMN content_blocks JSONB NOT NULL DEFAULT '[]';
+
+-- +goose Down
+ALTER TABLE ctx_group_message DROP COLUMN content_blocks;

--- a/internal/db/queries/ctx_group.sql
+++ b/internal/db/queries/ctx_group.sql
@@ -61,6 +61,10 @@ WHERE idempotency_key = sqlc.arg(idempotency_key);
 -- name: GetGroupMessage :one
 SELECT * FROM ctx_group_message WHERE id = $1;
 
+-- List queries SELECT * and therefore drag content_blocks (image payloads,
+-- bounded by the channel inline ceiling) for history windows; switch to an
+-- explicit column list if measured dispatch latency makes that matter.
+
 -- name: ListRecentGroupMessages :many
 SELECT * FROM ctx_group_message
 WHERE group_id = sqlc.arg(group_id)
@@ -83,7 +87,13 @@ LIMIT sqlc.arg(limit_count) OFFSET sqlc.arg(offset_count);
 -- name: CreateGroupMessage :one
 INSERT INTO ctx_group_message (
   id, group_id, seq, source_channel_id, actor_type, actor_id,
-  platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id
+  platform_message_id, reply_to, platform_timestamp, idempotency_key, content, content_blocks, reasoning, agent_session_id
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+VALUES (
+  sqlc.arg(id), sqlc.arg(group_id), sqlc.arg(seq), sqlc.arg(source_channel_id),
+  sqlc.arg(actor_type), sqlc.arg(actor_id), sqlc.arg(platform_message_id),
+  sqlc.arg(reply_to), sqlc.arg(platform_timestamp), sqlc.arg(idempotency_key),
+  sqlc.arg(content), COALESCE(sqlc.arg(content_blocks)::jsonb, '[]'::jsonb),
+  sqlc.arg(reasoning), sqlc.arg(agent_session_id)
+)
 RETURNING *;

--- a/internal/db/queries/ctx_group.sql
+++ b/internal/db/queries/ctx_group.sql
@@ -61,10 +61,18 @@ WHERE idempotency_key = sqlc.arg(idempotency_key);
 -- name: GetGroupMessage :one
 SELECT * FROM ctx_group_message WHERE id = $1;
 
--- List queries SELECT * and therefore drag content_blocks (image payloads,
--- bounded by the channel inline ceiling) for history windows; switch to an
--- explicit column list if measured dispatch latency makes that matter.
+-- content_blocks holds inbound image payloads, so a single row is bounded only
+-- by the channel inline ceiling (telegram/qq inline up to 20MB today; 5MB once
+-- #786 lands). Only the dispatch reads above (GetGroupMessage / the dedup
+-- :one lookups) rehydrate images, so they keep SELECT *. The text-only list
+-- consumers below — semantic-arbiter recent context, LCM cross-agent assembly,
+-- and web pagination — read only the projected text columns, so they select an
+-- explicit column list that EXCLUDES content_blocks and never drag image blobs
+-- across a history window.
 
+-- ListRecentGroupMessages currently has no caller; it keeps SELECT * so a future
+-- replay/dispatch consumer that needs content_blocks gets the full row. Give it
+-- an explicit lean list only if a text-only consumer adopts it.
 -- name: ListRecentGroupMessages :many
 SELECT * FROM ctx_group_message
 WHERE group_id = sqlc.arg(group_id)
@@ -72,14 +80,20 @@ ORDER BY seq DESC
 LIMIT sqlc.arg(max_count);
 
 -- name: ListRecentGroupMessagesBeforeSeq :many
-SELECT * FROM ctx_group_message
+SELECT id, group_id, seq, source_channel_id, actor_type, actor_id,
+       platform_message_id, reply_to, platform_timestamp, idempotency_key,
+       content, reasoning, agent_session_id, created_at
+FROM ctx_group_message
 WHERE group_id = sqlc.arg(group_id)
   AND seq < sqlc.arg(before_seq)
 ORDER BY seq DESC
 LIMIT sqlc.arg(max_count);
 
 -- name: ListGroupMessagesPaginated :many
-SELECT * FROM ctx_group_message
+SELECT id, group_id, seq, source_channel_id, actor_type, actor_id,
+       platform_message_id, reply_to, platform_timestamp, idempotency_key,
+       content, reasoning, agent_session_id, created_at
+FROM ctx_group_message
 WHERE group_id = sqlc.arg(group_id)
 ORDER BY seq DESC
 LIMIT sqlc.arg(limit_count) OFFSET sqlc.arg(offset_count);

--- a/internal/db/queries/ctx_group_ingest.sql
+++ b/internal/db/queries/ctx_group_ingest.sql
@@ -18,14 +18,26 @@ ON CONFLICT(group_id, pipeline, seq) DO NOTHING;
 SELECT count(*) > 0 as is_error FROM ctx_group_ingest_error
 WHERE group_id = sqlc.arg(group_id) AND pipeline = sqlc.arg(pipeline) AND seq = sqlc.arg(seq);
 
+-- Both ingest list queries feed text-only consumers (group-memory extraction and
+-- LCM cross-agent assembly); neither reads content_blocks. They select an
+-- explicit column list that EXCLUDES content_blocks so a lagging agent or a
+-- memory batch never drags inbound image payloads across the seq range —
+-- ListGroupMessagesBetweenSeqs has no LIMIT, so the interval alone bounds it.
+
 -- name: ListGroupMessagesAfterSeq :many
-SELECT * FROM ctx_group_message
+SELECT id, group_id, seq, source_channel_id, actor_type, actor_id,
+       platform_message_id, reply_to, platform_timestamp, idempotency_key,
+       content, reasoning, agent_session_id, created_at
+FROM ctx_group_message
 WHERE group_id = sqlc.arg(group_id) AND seq > sqlc.arg(min_seq)
 ORDER BY seq ASC
 LIMIT sqlc.arg(batch_limit);
 
 -- name: ListGroupMessagesBetweenSeqs :many
-SELECT * FROM ctx_group_message
+SELECT id, group_id, seq, source_channel_id, actor_type, actor_id,
+       platform_message_id, reply_to, platform_timestamp, idempotency_key,
+       content, reasoning, agent_session_id, created_at
+FROM ctx_group_message
 WHERE group_id = sqlc.arg(group_id)
   AND seq > sqlc.arg(after_seq)
   AND seq < sqlc.arg(before_seq)

--- a/internal/eventlog/eventlog.go
+++ b/internal/eventlog/eventlog.go
@@ -59,6 +59,12 @@ type Message struct {
 	PlatformTimestamp time.Time
 
 	Content string
+
+	// ContentBlocks is the optional structured projection of Content: a JSON
+	// []ai.ContentBlock (see ai.MarshalContentBlocks) carrying non-text blocks
+	// such as inbound images. Empty means text-only; eventlog stores it
+	// verbatim like Content.
+	ContentBlocks []byte
 }
 
 // AppendResult reports the outcome of an append.
@@ -152,6 +158,7 @@ func (s *Store) AppendGroupMessage(ctx context.Context, msg Message, opts ...App
 		PlatformTimestamp: nullTime(msg.PlatformTimestamp),
 		IdempotencyKey:    idemKey,
 		Content:           msg.Content,
+		ContentBlocks:     contentBlocksOrEmpty(msg.ContentBlocks),
 	})
 	if err != nil {
 		return AppendResult{}, fmt.Errorf("eventlog: create message: %w", err)
@@ -231,6 +238,7 @@ func AppendToGroupWithQueries(ctx context.Context, q *sqlc.Queries, groupID stri
 		ActorType:      string(msg.ActorType),
 		ActorID:        msg.ActorID,
 		Content:        msg.Content,
+		ContentBlocks:  contentBlocksOrEmpty(nil),
 		Reasoning:      msg.Reasoning,
 		AgentSessionID: msg.AgentSessionID,
 	})
@@ -238,6 +246,15 @@ func AppendToGroupWithQueries(ctx context.Context, q *sqlc.Queries, groupID stri
 		return AppendResult{}, fmt.Errorf("eventlog: create message: %w", err)
 	}
 	return AppendResult{GroupID: groupID, Seq: seq, Inserted: true, Message: row}, nil
+}
+
+// contentBlocksOrEmpty normalizes an absent structured projection to the empty
+// JSON array the NOT NULL content_blocks column expects.
+func contentBlocksOrEmpty(blocks []byte) []byte {
+	if len(blocks) == 0 {
+		return []byte("[]")
+	}
+	return blocks
 }
 
 func validateGroupAppend(groupID string, msg GroupMessage) error {

--- a/internal/eventlog/eventlog_test.go
+++ b/internal/eventlog/eventlog_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/CherryHQ/stella/internal/db/dbtest"
 	"github.com/CherryHQ/stella/internal/eventlog"
+	"github.com/CherryHQ/stella/pkg/ai"
 	"github.com/CherryHQ/stella/pkg/db/sqlc"
 )
 
@@ -49,6 +50,44 @@ func TestAppendInsertsFirstMessageWithSeqOne(t *testing.T) {
 	}
 	if res.GroupID == "" {
 		t.Fatal("group id should be resolved")
+	}
+}
+
+func TestAppendPersistsContentBlocks(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+
+	msg := humanMsg()
+	msg.PlatformMessageID = "m-blocks"
+	msg.ContentBlocks = []byte(`[{"kind":"text","text":"hi"},{"kind":"image","data":"aGk=","mime_type":"image/png"}]`)
+
+	res, err := s.AppendGroupMessage(ctx, msg)
+	if err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	// jsonb normalizes formatting; compare decoded blocks, not raw bytes.
+	blocks, err := ai.UnmarshalContentBlocks(res.Message.ContentBlocks)
+	if err != nil {
+		t.Fatalf("unmarshal stored blocks: %v", err)
+	}
+	if len(blocks) != 2 || !ai.HasImage(blocks) {
+		t.Fatalf("stored blocks = %#v, want text+image", blocks)
+	}
+}
+
+func TestAppendWithoutContentBlocksStoresEmptyArray(t *testing.T) {
+	s := newStore(t)
+	ctx := context.Background()
+
+	msg := humanMsg()
+	msg.PlatformMessageID = "m-noblocks"
+
+	res, err := s.AppendGroupMessage(ctx, msg)
+	if err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	if got := string(res.Message.ContentBlocks); got != "[]" {
+		t.Fatalf("content_blocks = %s, want []", got)
 	}
 }
 

--- a/internal/memory/lcm/group_assembler.go
+++ b/internal/memory/lcm/group_assembler.go
@@ -184,7 +184,7 @@ func (p *Provider) getGroupCursor(ctx context.Context, groupID, pipeline string)
 // groupRowsToMessages converts event log rows to ai.Messages.
 // The current agent's own messages are skipped (they're already in ctx_message).
 // All other messages become UserMessages with actor attribution.
-func groupRowsToMessages(rows []sqlc.CtxGroupMessage, selfAgentID string) []ai.Message {
+func groupRowsToMessages(rows []sqlc.ListGroupMessagesBetweenSeqsRow, selfAgentID string) []ai.Message {
 	msgs := make([]ai.Message, 0, len(rows))
 	for _, row := range rows {
 		if row.Content == "" {

--- a/pkg/ai/blocks_json.go
+++ b/pkg/ai/blocks_json.go
@@ -1,0 +1,66 @@
+package ai
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ContentBlockJSON is the canonical storage serialization for user-visible
+// content blocks (text and image). The wire shape matches the LCM message
+// store so serialized blocks are interchangeable across stores.
+type ContentBlockJSON struct {
+	Kind     string `json:"kind"`
+	Text     string `json:"text,omitempty"`
+	Data     string `json:"data,omitempty"`
+	MimeType string `json:"mime_type,omitempty"`
+}
+
+// MarshalContentBlocks serializes text and image blocks to the canonical JSON
+// array. Other block kinds (thinking, tool calls) are storage-internal and are
+// skipped.
+func MarshalContentBlocks(blocks []ContentBlock) ([]byte, error) {
+	out := make([]ContentBlockJSON, 0, len(blocks))
+	for _, b := range blocks {
+		switch b := b.(type) {
+		case TextContent:
+			out = append(out, ContentBlockJSON{Kind: "text", Text: b.Text})
+		case ImageContent:
+			out = append(out, ContentBlockJSON{Kind: "image", Data: b.Data, MimeType: b.MimeType})
+		}
+	}
+	data, err := json.Marshal(out)
+	if err != nil {
+		return nil, fmt.Errorf("marshal content blocks: %w", err)
+	}
+	return data, nil
+}
+
+// UnmarshalContentBlocks is the inverse of MarshalContentBlocks. It returns
+// nil for an empty array (or empty input), letting callers fall back to a
+// plain-text path. Unknown kinds are skipped so old readers tolerate newer
+// payloads.
+func UnmarshalContentBlocks(data []byte) ([]ContentBlock, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	var raw []ContentBlockJSON
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("unmarshal content blocks: %w", err)
+	}
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	blocks := make([]ContentBlock, 0, len(raw))
+	for _, b := range raw {
+		switch b.Kind {
+		case "text":
+			blocks = append(blocks, TextContent{Text: b.Text})
+		case "image":
+			blocks = append(blocks, ImageContent{Data: b.Data, MimeType: b.MimeType})
+		}
+	}
+	if len(blocks) == 0 {
+		return nil, nil
+	}
+	return blocks, nil
+}

--- a/pkg/ai/blocks_json_test.go
+++ b/pkg/ai/blocks_json_test.go
@@ -1,0 +1,57 @@
+package ai
+
+import "testing"
+
+func TestContentBlocksJSONRoundTrip(t *testing.T) {
+	in := []ContentBlock{
+		TextContent{Text: "look at this"},
+		ImageContent{Data: "aGVsbG8=", MimeType: "image/png"},
+	}
+
+	data, err := MarshalContentBlocks(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	out, err := UnmarshalContentBlocks(data)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("blocks = %d, want 2", len(out))
+	}
+	if tc, ok := out[0].(TextContent); !ok || tc.Text != "look at this" {
+		t.Errorf("block 0 = %#v, want original text", out[0])
+	}
+	if ic, ok := out[1].(ImageContent); !ok || ic.Data != "aGVsbG8=" || ic.MimeType != "image/png" {
+		t.Errorf("block 1 = %#v, want original image", out[1])
+	}
+}
+
+func TestUnmarshalContentBlocksEmptyFallsBack(t *testing.T) {
+	for _, data := range [][]byte{nil, []byte("[]")} {
+		blocks, err := UnmarshalContentBlocks(data)
+		if err != nil {
+			t.Fatalf("unmarshal %q: %v", data, err)
+		}
+		if blocks != nil {
+			t.Errorf("unmarshal %q = %#v, want nil for text fallback", data, blocks)
+		}
+	}
+}
+
+func TestMarshalContentBlocksSkipsInternalKinds(t *testing.T) {
+	data, err := MarshalContentBlocks([]ContentBlock{
+		ThinkingContent{Thinking: "secret"},
+		TextContent{Text: "visible"},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	blocks, err := UnmarshalContentBlocks(data)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(blocks) != 1 {
+		t.Fatalf("blocks = %#v, want only the text block", blocks)
+	}
+}

--- a/pkg/db/sqlc/ctx_group.sql.go
+++ b/pkg/db/sqlc/ctx_group.sql.go
@@ -7,6 +7,7 @@ package sqlc
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
@@ -29,10 +30,16 @@ func (q *Queries) BumpGroupSeq(ctx context.Context, id string) (int64, error) {
 const createGroupMessage = `-- name: CreateGroupMessage :one
 INSERT INTO ctx_group_message (
   id, group_id, seq, source_channel_id, actor_type, actor_id,
-  platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id
+  platform_message_id, reply_to, platform_timestamp, idempotency_key, content, content_blocks, reasoning, agent_session_id
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
-RETURNING id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at
+VALUES (
+  $1, $2, $3, $4,
+  $5, $6, $7,
+  $8, $9, $10,
+  $11, COALESCE($12::jsonb, '[]'::jsonb),
+  $13, $14
+)
+RETURNING id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at, content_blocks
 `
 
 type CreateGroupMessageParams struct {
@@ -47,6 +54,7 @@ type CreateGroupMessageParams struct {
 	PlatformTimestamp pgtype.Timestamptz `json:"platform_timestamp"`
 	IdempotencyKey    pgtype.Text        `json:"idempotency_key"`
 	Content           string             `json:"content"`
+	ContentBlocks     json.RawMessage    `json:"content_blocks"`
 	Reasoning         string             `json:"reasoning"`
 	AgentSessionID    string             `json:"agent_session_id"`
 }
@@ -64,6 +72,7 @@ func (q *Queries) CreateGroupMessage(ctx context.Context, arg CreateGroupMessage
 		arg.PlatformTimestamp,
 		arg.IdempotencyKey,
 		arg.Content,
+		arg.ContentBlocks,
 		arg.Reasoning,
 		arg.AgentSessionID,
 	)
@@ -83,6 +92,7 @@ func (q *Queries) CreateGroupMessage(ctx context.Context, arg CreateGroupMessage
 		&i.Reasoning,
 		&i.AgentSessionID,
 		&i.CreatedAt,
+		&i.ContentBlocks,
 	)
 	return i, err
 }
@@ -151,7 +161,7 @@ func (q *Queries) GetGroupLastActive(ctx context.Context, id string) (time.Time,
 }
 
 const getGroupMessage = `-- name: GetGroupMessage :one
-SELECT id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at FROM ctx_group_message WHERE id = $1
+SELECT id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at, content_blocks FROM ctx_group_message WHERE id = $1
 `
 
 func (q *Queries) GetGroupMessage(ctx context.Context, id string) (CtxGroupMessage, error) {
@@ -172,12 +182,13 @@ func (q *Queries) GetGroupMessage(ctx context.Context, id string) (CtxGroupMessa
 		&i.Reasoning,
 		&i.AgentSessionID,
 		&i.CreatedAt,
+		&i.ContentBlocks,
 	)
 	return i, err
 }
 
 const getGroupMessageByIdempotencyKey = `-- name: GetGroupMessageByIdempotencyKey :one
-SELECT id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at FROM ctx_group_message
+SELECT id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at, content_blocks FROM ctx_group_message
 WHERE idempotency_key = $1
 `
 
@@ -199,12 +210,13 @@ func (q *Queries) GetGroupMessageByIdempotencyKey(ctx context.Context, idempoten
 		&i.Reasoning,
 		&i.AgentSessionID,
 		&i.CreatedAt,
+		&i.ContentBlocks,
 	)
 	return i, err
 }
 
 const getGroupMessageByPlatformID = `-- name: GetGroupMessageByPlatformID :one
-SELECT id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at FROM ctx_group_message
+SELECT id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at, content_blocks FROM ctx_group_message
 WHERE group_id = $1
   AND platform_message_id = $2
 `
@@ -232,6 +244,7 @@ func (q *Queries) GetGroupMessageByPlatformID(ctx context.Context, arg GetGroupM
 		&i.Reasoning,
 		&i.AgentSessionID,
 		&i.CreatedAt,
+		&i.ContentBlocks,
 	)
 	return i, err
 }
@@ -309,7 +322,7 @@ func (q *Queries) GetGroupStateByTriple(ctx context.Context, arg GetGroupStateBy
 }
 
 const listGroupMessagesPaginated = `-- name: ListGroupMessagesPaginated :many
-SELECT id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at FROM ctx_group_message
+SELECT id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at, content_blocks FROM ctx_group_message
 WHERE group_id = $1
 ORDER BY seq DESC
 LIMIT $3 OFFSET $2
@@ -345,6 +358,7 @@ func (q *Queries) ListGroupMessagesPaginated(ctx context.Context, arg ListGroupM
 			&i.Reasoning,
 			&i.AgentSessionID,
 			&i.CreatedAt,
+			&i.ContentBlocks,
 		); err != nil {
 			return nil, err
 		}
@@ -420,7 +434,8 @@ func (q *Queries) ListGroupsByUser(ctx context.Context, arg ListGroupsByUserPara
 }
 
 const listRecentGroupMessages = `-- name: ListRecentGroupMessages :many
-SELECT id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at FROM ctx_group_message
+
+SELECT id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at, content_blocks FROM ctx_group_message
 WHERE group_id = $1
 ORDER BY seq DESC
 LIMIT $2
@@ -431,6 +446,9 @@ type ListRecentGroupMessagesParams struct {
 	MaxCount int32  `json:"max_count"`
 }
 
+// List queries SELECT * and therefore drag content_blocks (image payloads,
+// bounded by the channel inline ceiling) for history windows; switch to an
+// explicit column list if measured dispatch latency makes that matter.
 func (q *Queries) ListRecentGroupMessages(ctx context.Context, arg ListRecentGroupMessagesParams) ([]CtxGroupMessage, error) {
 	rows, err := q.db.Query(ctx, listRecentGroupMessages, arg.GroupID, arg.MaxCount)
 	if err != nil {
@@ -455,6 +473,7 @@ func (q *Queries) ListRecentGroupMessages(ctx context.Context, arg ListRecentGro
 			&i.Reasoning,
 			&i.AgentSessionID,
 			&i.CreatedAt,
+			&i.ContentBlocks,
 		); err != nil {
 			return nil, err
 		}
@@ -467,7 +486,7 @@ func (q *Queries) ListRecentGroupMessages(ctx context.Context, arg ListRecentGro
 }
 
 const listRecentGroupMessagesBeforeSeq = `-- name: ListRecentGroupMessagesBeforeSeq :many
-SELECT id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at FROM ctx_group_message
+SELECT id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at, content_blocks FROM ctx_group_message
 WHERE group_id = $1
   AND seq < $2
 ORDER BY seq DESC
@@ -504,6 +523,7 @@ func (q *Queries) ListRecentGroupMessagesBeforeSeq(ctx context.Context, arg List
 			&i.Reasoning,
 			&i.AgentSessionID,
 			&i.CreatedAt,
+			&i.ContentBlocks,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/db/sqlc/ctx_group.sql.go
+++ b/pkg/db/sqlc/ctx_group.sql.go
@@ -322,7 +322,10 @@ func (q *Queries) GetGroupStateByTriple(ctx context.Context, arg GetGroupStateBy
 }
 
 const listGroupMessagesPaginated = `-- name: ListGroupMessagesPaginated :many
-SELECT id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at, content_blocks FROM ctx_group_message
+SELECT id, group_id, seq, source_channel_id, actor_type, actor_id,
+       platform_message_id, reply_to, platform_timestamp, idempotency_key,
+       content, reasoning, agent_session_id, created_at
+FROM ctx_group_message
 WHERE group_id = $1
 ORDER BY seq DESC
 LIMIT $3 OFFSET $2
@@ -334,15 +337,32 @@ type ListGroupMessagesPaginatedParams struct {
 	LimitCount  int32  `json:"limit_count"`
 }
 
-func (q *Queries) ListGroupMessagesPaginated(ctx context.Context, arg ListGroupMessagesPaginatedParams) ([]CtxGroupMessage, error) {
+type ListGroupMessagesPaginatedRow struct {
+	ID                string             `json:"id"`
+	GroupID           string             `json:"group_id"`
+	Seq               int64              `json:"seq"`
+	SourceChannelID   pgtype.Text        `json:"source_channel_id"`
+	ActorType         string             `json:"actor_type"`
+	ActorID           string             `json:"actor_id"`
+	PlatformMessageID pgtype.Text        `json:"platform_message_id"`
+	ReplyTo           pgtype.Text        `json:"reply_to"`
+	PlatformTimestamp pgtype.Timestamptz `json:"platform_timestamp"`
+	IdempotencyKey    pgtype.Text        `json:"idempotency_key"`
+	Content           string             `json:"content"`
+	Reasoning         string             `json:"reasoning"`
+	AgentSessionID    string             `json:"agent_session_id"`
+	CreatedAt         time.Time          `json:"created_at"`
+}
+
+func (q *Queries) ListGroupMessagesPaginated(ctx context.Context, arg ListGroupMessagesPaginatedParams) ([]ListGroupMessagesPaginatedRow, error) {
 	rows, err := q.db.Query(ctx, listGroupMessagesPaginated, arg.GroupID, arg.OffsetCount, arg.LimitCount)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []CtxGroupMessage{}
+	items := []ListGroupMessagesPaginatedRow{}
 	for rows.Next() {
-		var i CtxGroupMessage
+		var i ListGroupMessagesPaginatedRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.GroupID,
@@ -358,7 +378,6 @@ func (q *Queries) ListGroupMessagesPaginated(ctx context.Context, arg ListGroupM
 			&i.Reasoning,
 			&i.AgentSessionID,
 			&i.CreatedAt,
-			&i.ContentBlocks,
 		); err != nil {
 			return nil, err
 		}
@@ -446,9 +465,17 @@ type ListRecentGroupMessagesParams struct {
 	MaxCount int32  `json:"max_count"`
 }
 
-// List queries SELECT * and therefore drag content_blocks (image payloads,
-// bounded by the channel inline ceiling) for history windows; switch to an
-// explicit column list if measured dispatch latency makes that matter.
+// content_blocks holds inbound image payloads, so a single row is bounded only
+// by the channel inline ceiling (telegram/qq inline up to 20MB today; 5MB once
+// #786 lands). Only the dispatch reads above (GetGroupMessage / the dedup
+// :one lookups) rehydrate images, so they keep SELECT *. The text-only list
+// consumers below — semantic-arbiter recent context, LCM cross-agent assembly,
+// and web pagination — read only the projected text columns, so they select an
+// explicit column list that EXCLUDES content_blocks and never drag image blobs
+// across a history window.
+// ListRecentGroupMessages currently has no caller; it keeps SELECT * so a future
+// replay/dispatch consumer that needs content_blocks gets the full row. Give it
+// an explicit lean list only if a text-only consumer adopts it.
 func (q *Queries) ListRecentGroupMessages(ctx context.Context, arg ListRecentGroupMessagesParams) ([]CtxGroupMessage, error) {
 	rows, err := q.db.Query(ctx, listRecentGroupMessages, arg.GroupID, arg.MaxCount)
 	if err != nil {
@@ -486,7 +513,10 @@ func (q *Queries) ListRecentGroupMessages(ctx context.Context, arg ListRecentGro
 }
 
 const listRecentGroupMessagesBeforeSeq = `-- name: ListRecentGroupMessagesBeforeSeq :many
-SELECT id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at, content_blocks FROM ctx_group_message
+SELECT id, group_id, seq, source_channel_id, actor_type, actor_id,
+       platform_message_id, reply_to, platform_timestamp, idempotency_key,
+       content, reasoning, agent_session_id, created_at
+FROM ctx_group_message
 WHERE group_id = $1
   AND seq < $2
 ORDER BY seq DESC
@@ -499,15 +529,32 @@ type ListRecentGroupMessagesBeforeSeqParams struct {
 	MaxCount  int32  `json:"max_count"`
 }
 
-func (q *Queries) ListRecentGroupMessagesBeforeSeq(ctx context.Context, arg ListRecentGroupMessagesBeforeSeqParams) ([]CtxGroupMessage, error) {
+type ListRecentGroupMessagesBeforeSeqRow struct {
+	ID                string             `json:"id"`
+	GroupID           string             `json:"group_id"`
+	Seq               int64              `json:"seq"`
+	SourceChannelID   pgtype.Text        `json:"source_channel_id"`
+	ActorType         string             `json:"actor_type"`
+	ActorID           string             `json:"actor_id"`
+	PlatformMessageID pgtype.Text        `json:"platform_message_id"`
+	ReplyTo           pgtype.Text        `json:"reply_to"`
+	PlatformTimestamp pgtype.Timestamptz `json:"platform_timestamp"`
+	IdempotencyKey    pgtype.Text        `json:"idempotency_key"`
+	Content           string             `json:"content"`
+	Reasoning         string             `json:"reasoning"`
+	AgentSessionID    string             `json:"agent_session_id"`
+	CreatedAt         time.Time          `json:"created_at"`
+}
+
+func (q *Queries) ListRecentGroupMessagesBeforeSeq(ctx context.Context, arg ListRecentGroupMessagesBeforeSeqParams) ([]ListRecentGroupMessagesBeforeSeqRow, error) {
 	rows, err := q.db.Query(ctx, listRecentGroupMessagesBeforeSeq, arg.GroupID, arg.BeforeSeq, arg.MaxCount)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []CtxGroupMessage{}
+	items := []ListRecentGroupMessagesBeforeSeqRow{}
 	for rows.Next() {
-		var i CtxGroupMessage
+		var i ListRecentGroupMessagesBeforeSeqRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.GroupID,
@@ -523,7 +570,6 @@ func (q *Queries) ListRecentGroupMessagesBeforeSeq(ctx context.Context, arg List
 			&i.Reasoning,
 			&i.AgentSessionID,
 			&i.CreatedAt,
-			&i.ContentBlocks,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/db/sqlc/ctx_group_ingest.sql.go
+++ b/pkg/db/sqlc/ctx_group_ingest.sql.go
@@ -75,7 +75,7 @@ func (q *Queries) IsIngestError(ctx context.Context, arg IsIngestErrorParams) (b
 }
 
 const listGroupMessagesAfterSeq = `-- name: ListGroupMessagesAfterSeq :many
-SELECT id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at FROM ctx_group_message
+SELECT id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at, content_blocks FROM ctx_group_message
 WHERE group_id = $1 AND seq > $2
 ORDER BY seq ASC
 LIMIT $3
@@ -111,6 +111,7 @@ func (q *Queries) ListGroupMessagesAfterSeq(ctx context.Context, arg ListGroupMe
 			&i.Reasoning,
 			&i.AgentSessionID,
 			&i.CreatedAt,
+			&i.ContentBlocks,
 		); err != nil {
 			return nil, err
 		}
@@ -123,7 +124,7 @@ func (q *Queries) ListGroupMessagesAfterSeq(ctx context.Context, arg ListGroupMe
 }
 
 const listGroupMessagesBetweenSeqs = `-- name: ListGroupMessagesBetweenSeqs :many
-SELECT id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at FROM ctx_group_message
+SELECT id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at, content_blocks FROM ctx_group_message
 WHERE group_id = $1
   AND seq > $2
   AND seq < $3
@@ -160,6 +161,7 @@ func (q *Queries) ListGroupMessagesBetweenSeqs(ctx context.Context, arg ListGrou
 			&i.Reasoning,
 			&i.AgentSessionID,
 			&i.CreatedAt,
+			&i.ContentBlocks,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/db/sqlc/ctx_group_ingest.sql.go
+++ b/pkg/db/sqlc/ctx_group_ingest.sql.go
@@ -7,6 +7,9 @@ package sqlc
 
 import (
 	"context"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 const createIngestError = `-- name: CreateIngestError :exec
@@ -75,7 +78,11 @@ func (q *Queries) IsIngestError(ctx context.Context, arg IsIngestErrorParams) (b
 }
 
 const listGroupMessagesAfterSeq = `-- name: ListGroupMessagesAfterSeq :many
-SELECT id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at, content_blocks FROM ctx_group_message
+
+SELECT id, group_id, seq, source_channel_id, actor_type, actor_id,
+       platform_message_id, reply_to, platform_timestamp, idempotency_key,
+       content, reasoning, agent_session_id, created_at
+FROM ctx_group_message
 WHERE group_id = $1 AND seq > $2
 ORDER BY seq ASC
 LIMIT $3
@@ -87,15 +94,37 @@ type ListGroupMessagesAfterSeqParams struct {
 	BatchLimit int32  `json:"batch_limit"`
 }
 
-func (q *Queries) ListGroupMessagesAfterSeq(ctx context.Context, arg ListGroupMessagesAfterSeqParams) ([]CtxGroupMessage, error) {
+type ListGroupMessagesAfterSeqRow struct {
+	ID                string             `json:"id"`
+	GroupID           string             `json:"group_id"`
+	Seq               int64              `json:"seq"`
+	SourceChannelID   pgtype.Text        `json:"source_channel_id"`
+	ActorType         string             `json:"actor_type"`
+	ActorID           string             `json:"actor_id"`
+	PlatformMessageID pgtype.Text        `json:"platform_message_id"`
+	ReplyTo           pgtype.Text        `json:"reply_to"`
+	PlatformTimestamp pgtype.Timestamptz `json:"platform_timestamp"`
+	IdempotencyKey    pgtype.Text        `json:"idempotency_key"`
+	Content           string             `json:"content"`
+	Reasoning         string             `json:"reasoning"`
+	AgentSessionID    string             `json:"agent_session_id"`
+	CreatedAt         time.Time          `json:"created_at"`
+}
+
+// Both ingest list queries feed text-only consumers (group-memory extraction and
+// LCM cross-agent assembly); neither reads content_blocks. They select an
+// explicit column list that EXCLUDES content_blocks so a lagging agent or a
+// memory batch never drags inbound image payloads across the seq range —
+// ListGroupMessagesBetweenSeqs has no LIMIT, so the interval alone bounds it.
+func (q *Queries) ListGroupMessagesAfterSeq(ctx context.Context, arg ListGroupMessagesAfterSeqParams) ([]ListGroupMessagesAfterSeqRow, error) {
 	rows, err := q.db.Query(ctx, listGroupMessagesAfterSeq, arg.GroupID, arg.MinSeq, arg.BatchLimit)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []CtxGroupMessage{}
+	items := []ListGroupMessagesAfterSeqRow{}
 	for rows.Next() {
-		var i CtxGroupMessage
+		var i ListGroupMessagesAfterSeqRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.GroupID,
@@ -111,7 +140,6 @@ func (q *Queries) ListGroupMessagesAfterSeq(ctx context.Context, arg ListGroupMe
 			&i.Reasoning,
 			&i.AgentSessionID,
 			&i.CreatedAt,
-			&i.ContentBlocks,
 		); err != nil {
 			return nil, err
 		}
@@ -124,7 +152,10 @@ func (q *Queries) ListGroupMessagesAfterSeq(ctx context.Context, arg ListGroupMe
 }
 
 const listGroupMessagesBetweenSeqs = `-- name: ListGroupMessagesBetweenSeqs :many
-SELECT id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at, content_blocks FROM ctx_group_message
+SELECT id, group_id, seq, source_channel_id, actor_type, actor_id,
+       platform_message_id, reply_to, platform_timestamp, idempotency_key,
+       content, reasoning, agent_session_id, created_at
+FROM ctx_group_message
 WHERE group_id = $1
   AND seq > $2
   AND seq < $3
@@ -137,15 +168,32 @@ type ListGroupMessagesBetweenSeqsParams struct {
 	BeforeSeq int64  `json:"before_seq"`
 }
 
-func (q *Queries) ListGroupMessagesBetweenSeqs(ctx context.Context, arg ListGroupMessagesBetweenSeqsParams) ([]CtxGroupMessage, error) {
+type ListGroupMessagesBetweenSeqsRow struct {
+	ID                string             `json:"id"`
+	GroupID           string             `json:"group_id"`
+	Seq               int64              `json:"seq"`
+	SourceChannelID   pgtype.Text        `json:"source_channel_id"`
+	ActorType         string             `json:"actor_type"`
+	ActorID           string             `json:"actor_id"`
+	PlatformMessageID pgtype.Text        `json:"platform_message_id"`
+	ReplyTo           pgtype.Text        `json:"reply_to"`
+	PlatformTimestamp pgtype.Timestamptz `json:"platform_timestamp"`
+	IdempotencyKey    pgtype.Text        `json:"idempotency_key"`
+	Content           string             `json:"content"`
+	Reasoning         string             `json:"reasoning"`
+	AgentSessionID    string             `json:"agent_session_id"`
+	CreatedAt         time.Time          `json:"created_at"`
+}
+
+func (q *Queries) ListGroupMessagesBetweenSeqs(ctx context.Context, arg ListGroupMessagesBetweenSeqsParams) ([]ListGroupMessagesBetweenSeqsRow, error) {
 	rows, err := q.db.Query(ctx, listGroupMessagesBetweenSeqs, arg.GroupID, arg.AfterSeq, arg.BeforeSeq)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []CtxGroupMessage{}
+	items := []ListGroupMessagesBetweenSeqsRow{}
 	for rows.Next() {
-		var i CtxGroupMessage
+		var i ListGroupMessagesBetweenSeqsRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.GroupID,
@@ -161,7 +209,6 @@ func (q *Queries) ListGroupMessagesBetweenSeqs(ctx context.Context, arg ListGrou
 			&i.Reasoning,
 			&i.AgentSessionID,
 			&i.CreatedAt,
-			&i.ContentBlocks,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/db/sqlc/models.go
+++ b/pkg/db/sqlc/models.go
@@ -412,6 +412,7 @@ type CtxGroupMessage struct {
 	Reasoning         string             `json:"reasoning"`
 	AgentSessionID    string             `json:"agent_session_id"`
 	CreatedAt         time.Time          `json:"created_at"`
+	ContentBlocks     json.RawMessage    `json:"content_blocks"`
 }
 
 type CtxGroupOutbox struct {


### PR DESCRIPTION
## What

Inbound images in group chats now survive the durable group dispatcher. The event log gains a structured projection of message content (`ctx_group_message.content_blocks`, JSONB), written when a message carries image blocks and rehydrated at dispatch, so the agent receives the actual image instead of an empty text message.

Closes #780

## Why

Regression from the durable group dispatcher (`965c0fb9`): ingest stored `contentBlocksToText(msg.Content)` (text only, `internal/channel/group_dispatch.go`) and replay rebuilt `[]ai.ContentBlock{TextContent{...}}` (`group_dispatcher.go`), silently discarding `ai.ImageContent`. An image-only group message degraded to an empty string with no log. DMs were unaffected. Full evidence chain in #780.

## How

- **Migration**: `content_blocks JSONB NOT NULL DEFAULT '[]'` on `ctx_group_message`. `content` stays the plain-text projection, so the semantic arbiter, history assembly, and every other text consumer are untouched. Additive and backward compatible; old rows read as `[]` and fall back to text.
- **Codec**: `ai.MarshalContentBlocks` / `ai.UnmarshalContentBlocks` in `pkg/ai` — the canonical text+image JSON serialization, wire-compatible with the LCM message store's existing `contentBlockJSON` shape (`{kind, text, data, mime_type}`). Storage-internal kinds (thinking, tool calls) are skipped.
- **Ingest**: `appendGroupMessage` serializes blocks only when `ai.HasImage` — text-only messages store `'[]'` and replay from the text projection, so the column stays negligible for the common case. `CreateGroupMessage` COALESCEs a nil param to `'[]'` so existing callers need no change. An **image-only** message has no text blocks, so `contentBlocksToText` projects it to a deterministic `"[image]"` placeholder in `content` — otherwise the semantic arbiter would treat the empty text as "nothing to route" and drop it before rehydration ran. The placeholder lives only in the text projection; rehydration prefers `content_blocks`, so it never leaks into the real image blocks. (Holds regardless of #786 merge order.)
- **Dispatch**: both the channel path (`chatDispatchUnqueued`) and the web path (`chatWeb`) rehydrate via shared helpers, degrading to the text projection for legacy or corrupt rows rather than dropping the message.

**Lean projections**: a single `content_blocks` row is bounded only by the channel inline ceiling (telegram/qq inline up to 20MB today; 5MB once #786 lands), so the text-only list consumers now select an explicit column list that EXCLUDES `content_blocks` — semantic-arbiter recent context (`ListRecentGroupMessagesBeforeSeq`), LCM cross-agent assembly (`ListGroupMessagesBetweenSeqs`, which has no LIMIT over the seq interval), group-memory ingest (`ListGroupMessagesAfterSeq`), and web pagination (`ListGroupMessagesPaginated`). The dispatch reads that actually rehydrate images (`GetGroupMessage` and the dedup `:one` lookups) keep `SELECT *`. The `ctx_group.sql` ceiling comment is updated to be honest about the 20MB/5MB inline bound.

## Verification

- New DB tests: `TestAppendPersistsContentBlocks`, `TestAppendWithoutContentBlocksStoresEmptyArray` (real Postgres via dbtest).
- New unit tests: codec round-trip / internal-kind skipping (`pkg/ai`), ingest gating (`TestMarshalGroupContentBlocks`), rehydration incl. legacy `[]` and corrupt-JSON fallback (`TestGroupMessageContentRehydration`).
- New/extended tests for this review: image-only + text+image projection cases in `TestContentBlocksToText`, and `TestImageOnlyMessageProjectionAndRehydration` (placeholder stored, real image rehydrated, no leak).
- `mise run format && mise run build && mise run test` pass locally (includes migration apply against the test database).

## Refs

- #780 (issue), #786 (inbound image persistence at the channel edge — independent PR, no file overlap)
- Out of scope, unchanged from #780: the outbound agent→channel image pipeline (`runtime.Event.Image` has no producer)
