### PR TITLE
🐛 fix(web): build workspace file URLs from relative path and scope

### DIFF
--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -3786,11 +3786,20 @@ components:
           description: New file content to write
     WorkspaceUploadResponse:
       type: object
-      required: [path]
+      required: [path, relative_path, scope]
       properties:
         path:
           type: string
-          description: Relative path of the uploaded file within the workspace
+          description: >-
+            Sandbox-view path of the uploaded file (e.g. /user/assets/...), embedded in the message text the agent reads.
+        relative_path:
+          type: string
+          description: >-
+            Path of the uploaded file relative to its workspace root. Combine with scope to build a workspace file-content read URL.
+        scope:
+          allOf:
+            - $ref: "#/components/schemas/WorkspaceScope"
+          description: Which workspace root the file was written to.
     SessionList:
       type: object
       required: [sessions]

--- a/api/spec/domain/sessions/paths.yaml
+++ b/api/spec/domain/sessions/paths.yaml
@@ -434,7 +434,13 @@ paths:
           in: query
           required: true
           schema: { type: string }
-          description: Relative path of the file within the workspace
+          description: >-
+            Either a workspace-relative path (paired with scope) or a
+            sandbox-view/host absolute path that resolves inside one of the
+            session's workspace roots. When the path is absolute it is
+            self-describing: the server resolves which authorized root contains
+            it and ignores the scope parameter. An absolute path outside every
+            workspace root is rejected.
         - name: raw
           in: query
           required: false

--- a/api/spec/domain/sessions/paths.yaml
+++ b/api/spec/domain/sessions/paths.yaml
@@ -438,9 +438,11 @@ paths:
             Either a workspace-relative path (paired with scope) or a
             sandbox-view/host absolute path that resolves inside one of the
             session's workspace roots. When the path is absolute it is
-            self-describing: the server resolves which authorized root contains
-            it and ignores the scope parameter. An absolute path outside every
-            workspace root is rejected.
+            self-describing and the scope parameter is ignored: the server first
+            checks host-root containment (a real host path is served from the
+            root that physically contains it), then falls back to sandbox mount
+            mapping (/user and /workspace map to the user-data and agent roots).
+            An absolute path that matches neither is rejected.
         - name: raw
           in: query
           required: false

--- a/api/spec/domain/sessions/schemas.yaml
+++ b/api/spec/domain/sessions/schemas.yaml
@@ -187,11 +187,22 @@ components:
 
     WorkspaceUploadResponse:
       type: object
-      required: [path]
+      required: [path, relative_path, scope]
       properties:
         path:
           type: string
-          description: Relative path of the uploaded file within the workspace
+          description: >-
+            Sandbox-view path of the uploaded file (e.g. /user/assets/...), embedded
+            in the message text the agent reads.
+        relative_path:
+          type: string
+          description: >-
+            Path of the uploaded file relative to its workspace root. Combine with
+            scope to build a workspace file-content read URL.
+        scope:
+          allOf:
+            - $ref: "#/components/schemas/WorkspaceScope"
+          description: Which workspace root the file was written to.
 
     SessionList:
       type: object

--- a/internal/agent/session/access/workspace.go
+++ b/internal/agent/session/access/workspace.go
@@ -205,11 +205,24 @@ func (a *Access) ReadWorkspacePath(ctx context.Context, in WorkspaceReadInput) (
 	if in.Path == "" {
 		return WorkspaceReadResult{}, ErrInvalid
 	}
-	root, err := a.workspaceRoot(ctx, in.AgentID, in.SessionID, in.Scope, authz.ActionRead)
+	scope, path := in.Scope, in.Path
+	// An absolute path is self-describing (e.g. a host path embedded in a chat
+	// message by a non-isolating backend, or a sandbox-view mount path). Resolve
+	// which authorized workspace root contains it and read under that root's
+	// scope, ignoring the requested scope. This never widens authority: the file
+	// must already be reachable via one of the two roots the caller may read.
+	if filepath.IsAbs(filepath.FromSlash(path)) {
+		resolvedScope, rel, err := a.canonicalizeAbsPath(ctx, in.AgentID, in.SessionID, path)
+		if err != nil {
+			return WorkspaceReadResult{}, err
+		}
+		scope, path = resolvedScope, rel
+	}
+	root, err := a.workspaceRoot(ctx, in.AgentID, in.SessionID, scope, authz.ActionRead)
 	if err != nil {
 		return WorkspaceReadResult{}, err
 	}
-	rootFS, name, err := sharepkg.OpenSafeRoot(root, in.Path)
+	rootFS, name, err := sharepkg.OpenSafeRoot(root, path)
 	if err != nil {
 		return WorkspaceReadResult{}, ErrInvalid
 	}
@@ -232,12 +245,12 @@ func (a *Access) ReadWorkspacePath(ctx context.Context, in WorkspaceReadInput) (
 		return WorkspaceReadResult{}, err
 	}
 	if in.Raw {
-		mediaType := mime.TypeByExtension(filepath.Ext(in.Path))
+		mediaType := mime.TypeByExtension(filepath.Ext(path))
 		if mediaType == "" {
 			mediaType = "application/octet-stream"
 		}
 		return WorkspaceReadResult{
-			Path: in.Path, Raw: true, RawName: filepath.Base(in.Path),
+			Path: path, Raw: true, RawName: filepath.Base(path),
 			RawMediaType: mediaType, RawContent: data,
 		}, nil
 	}
@@ -248,7 +261,66 @@ func (a *Access) ReadWorkspacePath(ctx context.Context, in WorkspaceReadInput) (
 	if slices.Contains(probe, 0) {
 		return WorkspaceReadResult{}, ErrBinary
 	}
-	return WorkspaceReadResult{Path: in.Path, Content: string(data), Language: DetectLanguage(in.Path)}, nil
+	return WorkspaceReadResult{Path: path, Content: string(data), Language: DetectLanguage(path)}, nil
+}
+
+// canonicalizeAbsPath maps an absolute request path to the (scope, relative
+// path) pair under whichever authorized workspace root contains it. Both roots
+// are resolved through the same ActionRead authorization the endpoint applies
+// for an explicit scope, so an absolute path can only ever resolve to content
+// already reachable via (scope, relative path) — no new roots, no widening.
+// A path inside neither root is ErrNotFound, identical to a missing relative
+// file. The two roots are disjoint siblings (users/<id>/data vs
+// users/<id>/agents/<id>), so the checked order is immaterial.
+func (a *Access) canonicalizeAbsPath(ctx context.Context, agentID, sessionID, absPath string) (WorkspaceScope, string, error) {
+	for _, scope := range []WorkspaceScope{WorkspaceScopeUser, WorkspaceScopeAgent} {
+		root, err := a.workspaceRoot(ctx, agentID, sessionID, scope, authz.ActionRead)
+		if err != nil {
+			return "", "", err
+		}
+		if rel, ok := containedRel(root, absPath); ok {
+			return scope, rel, nil
+		}
+	}
+	return "", "", ErrNotFound
+}
+
+// containedRel reports whether absPath resolves to a location strictly inside
+// root and, if so, returns the cleaned root-relative path. It resolves symlinks
+// on both sides — matching macOS realities like /var → /private/var — the same
+// way agent.ValidateProjectDir does, then requires the relative result to be
+// local (filepath.IsLocal rejects any ".." escape). A path equal to or outside
+// root yields ok=false, so authority is never widened.
+func containedRel(root, absPath string) (string, bool) {
+	cleanRoot := resolveExistingSymlinks(filepath.Clean(root))
+	cleanPath := resolveExistingSymlinks(filepath.Clean(filepath.FromSlash(absPath)))
+	rel, err := filepath.Rel(cleanRoot, cleanPath)
+	if err != nil {
+		return "", false
+	}
+	if rel == "." || !filepath.IsLocal(rel) {
+		return "", false
+	}
+	return rel, true
+}
+
+// resolveExistingSymlinks returns path with symlinks resolved, falling back to
+// the longest existing ancestor so a symlinked parent cannot mask an escape
+// even when the leaf does not exist yet. Mirrors agent.ValidateProjectDir.
+func resolveExistingSymlinks(path string) string {
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return resolved
+	}
+	dir := path
+	for dir != string(filepath.Separator) && dir != "." {
+		parent := filepath.Dir(dir)
+		if resolved, err := filepath.EvalSymlinks(parent); err == nil {
+			tail, _ := filepath.Rel(parent, path)
+			return filepath.Join(resolved, tail)
+		}
+		dir = parent
+	}
+	return path
 }
 
 func (a *Access) WriteWorkspacePath(ctx context.Context, in WorkspaceWriteInput) (WorkspaceReadResult, error) {

--- a/internal/agent/session/access/workspace.go
+++ b/internal/agent/session/access/workspace.go
@@ -110,7 +110,14 @@ type WorkspaceUploadInput struct {
 }
 
 type WorkspaceUploadResult struct {
+	// Path is the sandbox-view path the agent reads (e.g. /user/assets/... on
+	// isolating backends, the absolute host path otherwise).
 	Path string `json:"path"`
+	// RelativePath is the upload location relative to its workspace root.
+	// Combine with Scope to build a workspace file-content read URL.
+	RelativePath string `json:"relative_path"`
+	// Scope is the workspace root the file was written to.
+	Scope WorkspaceScope `json:"scope"`
 }
 
 func (a *Access) ListWorkspace(ctx context.Context, in WorkspaceListInput) (WorkspaceInfo, error) {
@@ -286,8 +293,13 @@ func (a *Access) UploadWorkspacePath(ctx context.Context, in WorkspaceUploadInpu
 		return WorkspaceUploadResult{}, err
 	}
 	rel, _ := filepath.Rel(root, abs)
+	relSlash := filepath.ToSlash(rel)
 	sandboxRoot := sandbox.UserDataViewFor(a.svc.sandboxBackend(ctx), root)
-	return WorkspaceUploadResult{Path: filepath.ToSlash(filepath.Join(sandboxRoot, rel))}, nil
+	return WorkspaceUploadResult{
+		Path:         filepath.ToSlash(filepath.Join(sandboxRoot, rel)),
+		RelativePath: relSlash,
+		Scope:        WorkspaceScopeUser,
+	}, nil
 }
 
 func (a *Access) workspaceRoot(ctx context.Context, agentID, sessionID string, scope WorkspaceScope, action authz.Action) (string, error) {

--- a/internal/agent/session/access/workspace.go
+++ b/internal/agent/session/access/workspace.go
@@ -314,6 +314,11 @@ func resolveExistingSymlinks(path string) string {
 	dir := path
 	for dir != string(filepath.Separator) && dir != "." {
 		parent := filepath.Dir(dir)
+		if parent == dir {
+			// Fixed point (e.g. a Windows drive root that itself fails to
+			// resolve); the request path is attacker-controlled, so never spin.
+			break
+		}
 		if resolved, err := filepath.EvalSymlinks(parent); err == nil {
 			tail, _ := filepath.Rel(parent, path)
 			return filepath.Join(resolved, tail)

--- a/internal/agent/session/access/workspace.go
+++ b/internal/agent/session/access/workspace.go
@@ -18,6 +18,7 @@ import (
 	"github.com/CherryHQ/stella/internal/authz"
 	"github.com/CherryHQ/stella/internal/config"
 	sharepkg "github.com/CherryHQ/stella/internal/share"
+	pkgsandbox "github.com/CherryHQ/stella/pkg/sandbox"
 )
 
 var (
@@ -265,13 +266,28 @@ func (a *Access) ReadWorkspacePath(ctx context.Context, in WorkspaceReadInput) (
 }
 
 // canonicalizeAbsPath maps an absolute request path to the (scope, relative
-// path) pair under whichever authorized workspace root contains it. Both roots
-// are resolved through the same ActionRead authorization the endpoint applies
-// for an explicit scope, so an absolute path can only ever resolve to content
-// already reachable via (scope, relative path) — no new roots, no widening.
-// A path inside neither root is ErrNotFound, identical to a missing relative
-// file. The two roots are disjoint siblings (users/<id>/data vs
-// users/<id>/agents/<id>), so the checked order is immaterial.
+// path) pair under whichever authorized workspace root the endpoint may read.
+// Both roots are resolved through the same ActionRead authorization the endpoint
+// applies for an explicit scope, so an absolute path can only ever resolve to
+// content already reachable via (scope, relative path) — no new roots, no
+// widening.
+//
+// Resolution order is deliberate:
+//  1. Host-root containment. A path that physically lives inside a workspace
+//     root is served from that root. This wins so a genuine host path that
+//     happens to sit under a /workspace-like STELLA_HOME is served from the root
+//     that actually contains it, never mistaken for a sandbox mount view.
+//  2. Sandbox mount mapping. A path under neither host root may still be a
+//     sandbox-view mount path (/user, /workspace) that an isolating backend
+//     embedded in a chat message. It maps to the owning scope; the mapped
+//     relative path flows through the same ActionRead authz and OpenSafeRoot
+//     containment as any relative request, so a ".."-escaping mount path is
+//     rejected and mount mapping can only reach content (scope, rel) already
+//     could.
+//
+// A path matched by neither step is ErrNotFound, identical to a missing relative
+// file. The two host roots are disjoint siblings (users/<id>/data vs
+// users/<id>/agents/<id>), so the containment check order is immaterial.
 func (a *Access) canonicalizeAbsPath(ctx context.Context, agentID, sessionID, absPath string) (WorkspaceScope, string, error) {
 	for _, scope := range []WorkspaceScope{WorkspaceScopeUser, WorkspaceScopeAgent} {
 		root, err := a.workspaceRoot(ctx, agentID, sessionID, scope, authz.ActionRead)
@@ -282,7 +298,37 @@ func (a *Access) canonicalizeAbsPath(ctx context.Context, agentID, sessionID, ab
 			return scope, rel, nil
 		}
 	}
+	if scope, rel, ok := mountScopeRel(absPath); ok {
+		return scope, rel, nil
+	}
 	return "", "", ErrNotFound
+}
+
+// mountScopeRel maps a sandbox mount-view absolute path to the workspace scope
+// that mount belongs to and the path relative to the mount. It matches only on a
+// full path-segment boundary — exactly the mount, or the mount followed by "/" —
+// so /userdata never matches the /user mount. The remainder is returned
+// uncleaned; the caller runs it through OpenSafeRoot, which rejects any
+// non-local (".."-escaping) result. That boundary means /workspace/../user/...
+// maps to the agent scope with a "../user/..." remainder and is rejected, never
+// crossing into the user root.
+func mountScopeRel(absPath string) (WorkspaceScope, string, bool) {
+	p := filepath.ToSlash(absPath)
+	for _, m := range []struct {
+		mount string
+		scope WorkspaceScope
+	}{
+		{pkgsandbox.MountUserData, WorkspaceScopeUser},
+		{pkgsandbox.MountWorkspace, WorkspaceScopeAgent},
+	} {
+		if p == m.mount {
+			return m.scope, ".", true
+		}
+		if rel, ok := strings.CutPrefix(p, m.mount+"/"); ok {
+			return m.scope, rel, true
+		}
+	}
+	return "", "", false
 }
 
 // containedRel reports whether absPath resolves to a location strictly inside

--- a/internal/server/sessions_blob_test.go
+++ b/internal/server/sessions_blob_test.go
@@ -128,6 +128,101 @@ func TestGetWorkspaceFileContentRestoresAssetFromAuthorityOnMiss(t *testing.T) {
 	}
 }
 
+// TestGetWorkspaceFileContentAbsoluteHostPathResolvesToUserRoot is the macOS
+// non-isolating repro: an uploaded file is referenced in a chat message by its
+// absolute host path (no /user mount to strip). The client cannot know the
+// scope, so it sends no scope param; the server must recognize the path lies
+// inside the user-data root and serve it there.
+func TestGetWorkspaceFileContentAbsoluteHostPathResolvesToUserRoot(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("STELLA_HOME", home)
+	config.ResetStellaHome()
+	defer config.ResetStellaHome()
+	mem := memorytest.New()
+	if err := mem.SaveInfo(context.Background(), memory.SessionInfo{ID: "s1", UserID: "u1", AgentID: "a1"}); err != nil {
+		t.Fatal(err)
+	}
+	local := filepath.Join(agent.UserDataDir(agent.UserHomeDir(home, "u1")), "assets", "202607", "note.txt")
+	if err := os.MkdirAll(filepath.Dir(local), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(local, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s := assetServer(t, home, nil, mem)
+	req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(withAuthInfo(context.Background(), &AuthInfo{UserID: "u1"}))
+	rr := httptest.NewRecorder()
+	s.GetWorkspaceFileContent(rr, req, "a1", "s1", apiserver.GetWorkspaceFileContentParams{Path: local})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var body struct {
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil || body.Content != "hello" {
+		t.Fatalf("body=%s err=%v", rr.Body.String(), err)
+	}
+}
+
+// TestGetWorkspaceFileContentAbsolutePathOutsideRootsRejected asserts an
+// absolute path that lies inside neither workspace root is never served.
+func TestGetWorkspaceFileContentAbsolutePathOutsideRootsRejected(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("STELLA_HOME", home)
+	config.ResetStellaHome()
+	defer config.ResetStellaHome()
+	mem := memorytest.New()
+	if err := mem.SaveInfo(context.Background(), memory.SessionInfo{ID: "s1", UserID: "u1", AgentID: "a1"}); err != nil {
+		t.Fatal(err)
+	}
+	s := assetServer(t, home, nil, mem)
+	req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(withAuthInfo(context.Background(), &AuthInfo{UserID: "u1"}))
+	rr := httptest.NewRecorder()
+	s.GetWorkspaceFileContent(rr, req, "a1", "s1", apiserver.GetWorkspaceFileContentParams{Path: "/etc/passwd"})
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status=%d body=%s, want 404", rr.Code, rr.Body.String())
+	}
+	if strings.Contains(rr.Body.String(), "root:") {
+		t.Fatalf("served host file contents: %s", rr.Body.String())
+	}
+}
+
+// TestGetWorkspaceFileContentAbsoluteTraversalRejected asserts an absolute path
+// that descends into a workspace root then climbs back out (via ..) resolves,
+// after cleaning, to a location outside the root and is rejected — the sibling
+// secret is never served.
+func TestGetWorkspaceFileContentAbsoluteTraversalRejected(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("STELLA_HOME", home)
+	config.ResetStellaHome()
+	defer config.ResetStellaHome()
+	mem := memorytest.New()
+	if err := mem.SaveInfo(context.Background(), memory.SessionInfo{ID: "s1", UserID: "u1", AgentID: "a1"}); err != nil {
+		t.Fatal(err)
+	}
+	// A secret outside both workspace roots (roots live under home/users/u1/).
+	secret := filepath.Join(home, "secret.txt")
+	if err := os.WriteFile(secret, []byte("top secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	userData := agent.UserDataDir(agent.UserHomeDir(home, "u1"))
+	if err := os.MkdirAll(userData, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// userData is home/users/u1/data; three ".." climb out to home/secret.txt.
+	escape := userData + "/../../../secret.txt"
+	s := assetServer(t, home, nil, mem)
+	req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(withAuthInfo(context.Background(), &AuthInfo{UserID: "u1"}))
+	rr := httptest.NewRecorder()
+	s.GetWorkspaceFileContent(rr, req, "a1", "s1", apiserver.GetWorkspaceFileContentParams{Path: escape})
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status=%d body=%s, want 404", rr.Code, rr.Body.String())
+	}
+	if strings.Contains(rr.Body.String(), "top secret") {
+		t.Fatalf("served secret outside root: %s", rr.Body.String())
+	}
+}
+
 func TestGetWorkspaceRawContentUsesConstrainedInlineResponse(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("STELLA_HOME", home)

--- a/internal/server/sessions_blob_test.go
+++ b/internal/server/sessions_blob_test.go
@@ -223,6 +223,128 @@ func TestGetWorkspaceFileContentAbsoluteTraversalRejected(t *testing.T) {
 	}
 }
 
+// TestGetWorkspaceFileContentSandboxViewUserPathResolves is the isolating-backend
+// repro (docker, linux local): an uploaded file is referenced in a chat message
+// by its sandbox-view mount path (/user/...), which lives under no host root. The
+// client sends it verbatim with no scope; the server must map the /user mount to
+// the user-data root and serve the file. This is the Major-1 regression guard —
+// before mount mapping the path failed host containment and 404'd.
+func TestGetWorkspaceFileContentSandboxViewUserPathResolves(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("STELLA_HOME", home)
+	config.ResetStellaHome()
+	defer config.ResetStellaHome()
+	mem := memorytest.New()
+	if err := mem.SaveInfo(context.Background(), memory.SessionInfo{ID: "s1", UserID: "u1", AgentID: "a1"}); err != nil {
+		t.Fatal(err)
+	}
+	local := filepath.Join(agent.UserDataDir(agent.UserHomeDir(home, "u1")), "assets", "202607", "note.txt")
+	if err := os.MkdirAll(filepath.Dir(local), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(local, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s := assetServer(t, home, nil, mem)
+	req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(withAuthInfo(context.Background(), &AuthInfo{UserID: "u1"}))
+	rr := httptest.NewRecorder()
+	s.GetWorkspaceFileContent(rr, req, "a1", "s1", apiserver.GetWorkspaceFileContentParams{Path: "/user/assets/202607/note.txt"})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var body struct {
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil || body.Content != "hello" {
+		t.Fatalf("body=%s err=%v", rr.Body.String(), err)
+	}
+}
+
+// TestGetWorkspaceFileContentSandboxViewMountTraversalRejected asserts a mount
+// path that climbs out of its mount with ".." before descending into the other
+// mount (/workspace/../user/...) is rejected, not silently re-mapped to the user
+// root. Mount matching keys off the leading /workspace segment; the "../user/..."
+// remainder is non-local and OpenSafeRoot rejects it.
+func TestGetWorkspaceFileContentSandboxViewMountTraversalRejected(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("STELLA_HOME", home)
+	config.ResetStellaHome()
+	defer config.ResetStellaHome()
+	mem := memorytest.New()
+	if err := mem.SaveInfo(context.Background(), memory.SessionInfo{ID: "s1", UserID: "u1", AgentID: "a1"}); err != nil {
+		t.Fatal(err)
+	}
+	local := filepath.Join(agent.UserDataDir(agent.UserHomeDir(home, "u1")), "assets", "202607", "note.txt")
+	if err := os.MkdirAll(filepath.Dir(local), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(local, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s := assetServer(t, home, nil, mem)
+	req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(withAuthInfo(context.Background(), &AuthInfo{UserID: "u1"}))
+	rr := httptest.NewRecorder()
+	s.GetWorkspaceFileContent(rr, req, "a1", "s1", apiserver.GetWorkspaceFileContentParams{Path: "/workspace/../user/assets/202607/note.txt"})
+	if rr.Code == http.StatusOK {
+		t.Fatalf("status=%d body=%s, want rejection", rr.Code, rr.Body.String())
+	}
+	if strings.Contains(rr.Body.String(), "hello") {
+		t.Fatalf("served file via mount traversal: %s", rr.Body.String())
+	}
+}
+
+// TestGetWorkspaceFileContentSymlinkedRootAliasResolves pins the symlink
+// resolution in containedRel: STELLA_HOME is a symlink alias, so the workspace
+// root the server computes differs in symlink form from the canonical host path
+// a chat message may carry. The absolute request path (fully resolved) must still
+// resolve inside the root. This covers the macOS /var → /private/var reality; it
+// fails if resolveExistingSymlinks were removed (raw filepath.Rel would see the
+// two forms as disjoint and 404).
+func TestGetWorkspaceFileContentSymlinkedRootAliasResolves(t *testing.T) {
+	realHome := t.TempDir()
+	aliasHome := filepath.Join(t.TempDir(), "home-alias")
+	if err := os.Symlink(realHome, aliasHome); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	t.Setenv("STELLA_HOME", aliasHome)
+	config.ResetStellaHome()
+	defer config.ResetStellaHome()
+	mem := memorytest.New()
+	if err := mem.SaveInfo(context.Background(), memory.SessionInfo{ID: "s1", UserID: "u1", AgentID: "a1"}); err != nil {
+		t.Fatal(err)
+	}
+	// Written through the alias-form root the server computes from STELLA_HOME.
+	aliasLocal := filepath.Join(agent.UserDataDir(agent.UserHomeDir(aliasHome, "u1")), "assets", "202607", "note.txt")
+	if err := os.MkdirAll(filepath.Dir(aliasLocal), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(aliasLocal, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// The request carries the fully-resolved canonical path, which differs in
+	// symlink form from the alias-form root; only symlink resolution reconciles them.
+	canonical, err := filepath.EvalSymlinks(aliasLocal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if canonical == aliasLocal {
+		t.Skipf("temp dir not symlinked; alias and canonical paths identical")
+	}
+	s := assetServer(t, aliasHome, nil, mem)
+	req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(withAuthInfo(context.Background(), &AuthInfo{UserID: "u1"}))
+	rr := httptest.NewRecorder()
+	s.GetWorkspaceFileContent(rr, req, "a1", "s1", apiserver.GetWorkspaceFileContentParams{Path: canonical})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var body struct {
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil || body.Content != "hello" {
+		t.Fatalf("body=%s err=%v", rr.Body.String(), err)
+	}
+}
+
 func TestGetWorkspaceRawContentUsesConstrainedInlineResponse(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("STELLA_HOME", home)

--- a/internal/server/sessions_blob_test.go
+++ b/internal/server/sessions_blob_test.go
@@ -427,3 +427,60 @@ func TestUploadWorkspaceFileMirrorsToAuthority(t *testing.T) {
 		t.Fatalf("local data=%q err=%v", localData, err)
 	}
 }
+
+// TestUploadWorkspaceFileReturnsRelativePathAndScope asserts the upload response
+// exposes the workspace-relative path and scope the web chat needs to build a
+// working file-content read URL, alongside the sandbox-view path the agent reads.
+func TestUploadWorkspaceFileReturnsRelativePathAndScope(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("STELLA_HOME", home)
+	config.ResetStellaHome()
+	defer config.ResetStellaHome()
+	remote, err := blob.NewFSStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	mem := memorytest.New()
+	if err := mem.SaveInfo(context.Background(), memory.SessionInfo{ID: "s1", UserID: "u1", AgentID: "a1"}); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	part, err := mw.CreateFormFile("file", "photo.png")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := part.Write([]byte("upload")); err != nil {
+		t.Fatal(err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	s := assetServer(t, home, remote, mem)
+	req := httptest.NewRequest(http.MethodPost, "/", &buf).WithContext(withAuthInfo(context.Background(), &AuthInfo{UserID: "u1"}))
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	rr := httptest.NewRecorder()
+	s.UploadWorkspaceFile(rr, req, "a1", "s1")
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var body apitypes.WorkspaceUploadResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Scope != apitypes.WorkspaceScopeUser {
+		t.Fatalf("scope=%q, want %q", body.Scope, apitypes.WorkspaceScopeUser)
+	}
+	rel := filepath.ToSlash(body.RelativePath)
+	if rel == "" || strings.HasPrefix(rel, "/") || strings.Contains(rel, "..") {
+		t.Fatalf("relative_path=%q, want a non-empty local path", rel)
+	}
+	if !strings.HasPrefix(rel, "assets/") || !strings.HasSuffix(rel, "-photo.png") {
+		t.Fatalf("relative_path=%q, want assets/...-photo.png", rel)
+	}
+	// The sandbox-view path is the scope root joined with the relative path, so
+	// the relative path is always its suffix regardless of sandbox backend.
+	if !strings.HasSuffix(filepath.ToSlash(body.Path), rel) {
+		t.Fatalf("path=%q does not end with relative_path=%q", body.Path, rel)
+	}
+}

--- a/web/src/components/chat/utils.ts
+++ b/web/src/components/chat/utils.ts
@@ -8,10 +8,34 @@ export function basename(path: string): string {
   return path.split("/").pop() || path;
 }
 
+// Sandbox mount prefixes on isolating backends. A file reference embedded in a
+// message (e.g. an uploaded `[file: /user/assets/...]`) carries the sandbox-view
+// path the agent reads; the file-content endpoint instead wants a workspace root
+// plus a relative path. Map the mount prefix back to its scope and strip it so
+// the read URL is scoped and relative (see UserDataViewFor/WorkspaceViewFor).
+const SANDBOX_MOUNT_SCOPES: ReadonlyArray<readonly [string, "user" | "agent"]> = [
+  ["/user/", "user"],
+  ["/workspace/", "agent"],
+];
+
+// workspaceRef splits a message-embedded file path into the workspace-relative
+// path and scope the file-content endpoint expects. Paths without a known sandbox
+// mount prefix (e.g. non-isolating backends) pass through unchanged with no scope.
+export function workspaceRef(path: string): { path: string; scope?: "user" | "agent" } {
+  for (const [prefix, scope] of SANDBOX_MOUNT_SCOPES) {
+    if (path.startsWith(prefix)) {
+      return { path: path.slice(prefix.length), scope };
+    }
+  }
+  return { path };
+}
+
 export function workspaceFileURL(agentId: string, sessionId: string, path: string): string {
+  const ref = workspaceRef(path);
+  const scopeParam = ref.scope ? `&scope=${ref.scope}` : "";
   return `/api/agents/${encodeURIComponent(agentId)}/sessions/${encodeURIComponent(
     sessionId,
-  )}/workspace/file-content?path=${encodeURIComponent(path)}&raw=true`;
+  )}/workspace/file-content?path=${encodeURIComponent(ref.path)}&raw=true${scopeParam}`;
 }
 
 // parseFileRefs splits a user message into the `[file: path]` attachments the

--- a/web/src/components/chat/utils.ts
+++ b/web/src/components/chat/utils.ts
@@ -8,34 +8,16 @@ export function basename(path: string): string {
   return path.split("/").pop() || path;
 }
 
-// Sandbox mount prefixes on isolating backends. A file reference embedded in a
-// message (e.g. an uploaded `[file: /user/assets/...]`) carries the sandbox-view
-// path the agent reads; the file-content endpoint instead wants a workspace root
-// plus a relative path. Map the mount prefix back to its scope and strip it so
-// the read URL is scoped and relative (see UserDataViewFor/WorkspaceViewFor).
-const SANDBOX_MOUNT_SCOPES: ReadonlyArray<readonly [string, "user" | "agent"]> = [
-  ["/user/", "user"],
-  ["/workspace/", "agent"],
-];
-
-// workspaceRef splits a message-embedded file path into the workspace-relative
-// path and scope the file-content endpoint expects. Paths without a known sandbox
-// mount prefix (e.g. non-isolating backends) pass through unchanged with no scope.
-export function workspaceRef(path: string): { path: string; scope?: "user" | "agent" } {
-  for (const [prefix, scope] of SANDBOX_MOUNT_SCOPES) {
-    if (path.startsWith(prefix)) {
-      return { path: path.slice(prefix.length), scope };
-    }
-  }
-  return { path };
-}
-
+// workspaceFileURL builds a raw file-content read URL for a message-embedded
+// file path. The path is passed verbatim: an absolute sandbox-view (/user/...,
+// /workspace/...) or host path is self-describing, and the server resolves which
+// authorized workspace root contains it (host containment first, then sandbox
+// mount mapping). The client cannot disambiguate mount views from real host
+// paths, so it must not guess a scope — that decision belongs to the server.
 export function workspaceFileURL(agentId: string, sessionId: string, path: string): string {
-  const ref = workspaceRef(path);
-  const scopeParam = ref.scope ? `&scope=${ref.scope}` : "";
   return `/api/agents/${encodeURIComponent(agentId)}/sessions/${encodeURIComponent(
     sessionId,
-  )}/workspace/file-content?path=${encodeURIComponent(ref.path)}&raw=true${scopeParam}`;
+  )}/workspace/file-content?path=${encodeURIComponent(path)}&raw=true`;
 }
 
 // parseFileRefs splits a user message into the `[file: path]` attachments the


### PR DESCRIPTION
## What

Uploading an image in the Web UI chat rendered only a filename chip / broken image, and clicking it (or the inline `<img>` load) issued a `GET` that always returned `400 INVALID_ARGUMENT`.

This makes uploaded chat images render and their file link work.

## Why

Path-shape + scope mismatch between the upload response and the file-serving endpoint:

- `UploadWorkspacePath` returned only the **sandbox-view** path — absolute on macOS/`none`, `/user/...` on isolating backends.
- The chat renderer (`workspaceFileURL`) built the read URL from that path verbatim, with **no `scope` param**.
- The read endpoint requires `filepath.IsLocal` (absolute paths 400) and defaults to **agent** scope, while uploads write to **user** scope — so even a relative path hit the wrong root.

## How

The server is the **single authority** for absolute-path semantics; the client stops guessing.

- **Backend — absolute-path resolution (`ReadWorkspacePath` / `canonicalizeAbsPath`).** The file-content read path accepts a self-describing **absolute** path and resolves it in a defined order:
  1. **Host-root containment.** If the path physically lives inside one of the session's two authorized workspace roots (user-data, agent), it is served from that root. Containment resolves symlinks on both sides (macOS `/var → /private/var`) and requires `filepath.IsLocal`, so `..` escapes are rejected. Containment winning **first** means a genuine host path under a `/workspace`-like `STELLA_HOME` is served from the root that actually contains it, never mistaken for a mount view.
  2. **Sandbox mount mapping.** A path under neither host root may still be a sandbox-view mount path an isolating backend embedded in the message (`/user/...`, `/workspace/...`). It maps to the owning scope on a full path-segment boundary (exactly the mount or mount + `/`, so `/userdata` never matches `/user`); the mapped relative path flows through the **same** `ActionRead` authz and `OpenSafeRoot` containment as any relative request. A `..`-escaping mount path (`/workspace/../user/...`) is therefore rejected, and mount mapping can only reach content `(scope, rel)` already could — no new roots, no widened authority.

  This fixes the isolating-backend regression: the exact sandbox-view path the upload returns (`/user/assets/...`) previously failed both host-containment checks and 404'd, contradicting the spec.
- **Web (`workspaceFileURL`).** Deleted the client-side prefix guessing (`workspaceRef`). The renderer now passes the message-embedded path **verbatim** with no `scope` param. The client cannot disambiguate a sandbox mount view from a real host path that happens to start with `/workspace` — only the server can, so the decision moved entirely server-side. This removes the Major-2 mangling where a real host path under a `/workspace`-rooted `STELLA_HOME` was rewritten to the wrong scope.
- **API (spec-first).** `WorkspaceUploadResponse` still returns `relative_path` and `scope` alongside the sandbox-view `path`; the `path` param doc now states the resolution precedence (host containment → mount mapping). Regenerated Go + TS SDK from the spec.

## Verification

- `mise run format && mise run build && mise run test` — all green.
- `TestUploadWorkspaceFileReturnsRelativePathAndScope` asserts the upload response exposes `relative_path` + `scope` consistent with `path`.
- Absolute-path canonicalization tests (`internal/server/sessions_blob_test.go`):
  - `TestGetWorkspaceFileContentAbsoluteHostPathResolvesToUserRoot` — absolute host path under the user-data root, **no scope param** → 200 (macOS/non-isolating repro).
  - `TestGetWorkspaceFileContentSandboxViewUserPathResolves` — sandbox-view `/user/...` path, no scope → 200 (isolating-backend regression guard).
  - `TestGetWorkspaceFileContentSandboxViewMountTraversalRejected` — `/workspace/../user/...` → rejected, file never served.
  - `TestGetWorkspaceFileContentAbsolutePathOutsideRootsRejected` — `/etc/passwd` → 404, host file never served.
  - `TestGetWorkspaceFileContentAbsoluteTraversalRejected` — absolute path climbing out of a root via `..` → 404.
  - `TestGetWorkspaceFileContentSymlinkedRootAliasResolves` — request via a fully-resolved canonical path when the root is a symlink alias → 200; pins `resolveExistingSymlinks` (macOS `/var → /private/var`).
  - Existing `workspace read cannot follow a symlink outside its root` (access matrix) pins the `os.Root` guard for an in-workspace symlink pointing outside.
- No frontend test framework exists in `web/` (no vitest / test script); `vp check` (type + lint) covers the `utils.ts` change.

## Follow-ups

- **Out of scope (separate behavioral change):** making web chat uploads produce real `ai.ImageContent` blocks so vision models receive the pixels instead of a text reference. Today the model only gets a `[file: <path>]` text ref (see #785 for unified inbound image presentation).

Closes #790
