### PR TITLE
📝 docs(marketing): reposition marketing rules and docs index around digital employees

### DIFF
--- a/web/content/docs/development/rules/marketing.md
+++ b/web/content/docs/development/rules/marketing.md
@@ -11,7 +11,7 @@ The source for these principles is field-tested app marketing practice, adapted 
 
 Write for these in order. When a single piece of copy can only serve one, serve the first.
 
-1. **Enterprises and teams (primary).** An organization that needs a _repeatable expert_: a Finance agent for reimbursement, an HR agent for referrals and screening, an Engineering agent for reviews and releases. The buyer is usually an IT lead, an ops manager, or a department head who is tired of the same questions reaching the same expensive people. They care about: not making everyone learn another internal system, keeping data self-hosted, per-user memory and permissions, and a knowledge base the agent actually uses.
+1. **Enterprises and teams (primary).** An organization that wants to _hire digital employees_: a finance employee that runs reimbursement end to end, an HR employee that keeps hiring moving, an engineering employee that reviews and chases PRs. The buyer is usually an IT lead who invested in private AI and now has to show what it delivered, or a department head whose processes stall on people — unapproved requests, missing invoices, unanswered status questions. They care about: work they can count and audit (verified completions, receipts, a weekly report), agents that act within each person's existing permissions, keeping data self-hosted, and per-user memory so the employee actually knows the team.
 2. **Small teams (secondary).** A 5–30 person company that can't staff a full-time admin, HR, or finance person and wants AI coworkers living in the Feishu/WeChat group they already use.
 3. **Individual developers (tertiary).** One person doing everything who wants AI agents as a back-office team. Real, but never the headline.
 
@@ -25,7 +25,7 @@ Before writing a headline, fill this in and keep it visible while you write:
 
 Enterprise default:
 
-> Stella helps **teams whose experts keep answering the same questions**, when **a teammate needs finance / HR / engineering help**, to solve it **without that teammate learning another internal system or interrupting the expert**.
+> Stella helps **teams that invested in AI but can't name what it delivered**, when **work stalls on people — an unapproved request, a missing invoice, an unanswered status question**, to get it **finished by a digital employee whose work is counted, verified, and auditable**.
 
 If a headline doesn't trace back to a filled-in formula, it's decoration. Cut it.
 
@@ -33,27 +33,32 @@ If a headline doesn't trace back to a filled-in formula, it's decoration. Cut it
 
 Engineering describes Stella in feature language. Users don't buy features; they buy "what this does for me." Every feature claim must be translated to its value before it ships in marketing copy.
 
-| Feature layer (how we build it)                | Value layer (what the reader gets)                                                         |
-| ---------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| One deployment, many users and agents          | Anyone on the team just asks — no new system to learn, no seat-by-seat setup               |
-| Per-user-per-agent memory                      | The agent remembers each teammate's context, so nobody re-explains themselves              |
-| Telegram / QQ / Feishu / WeChat / Web channels | It shows up in the group chat you already live in — no new app to install                  |
-| Skills, tools, sandbox policy                  | It does the work, not just chats — and only within boundaries you set                      |
-| Self-hosted, bring-your-own model keys         | Your data and your keys stay on infrastructure you control                                 |
-| Knowledge base + permissions                   | The agent answers from _your_ docs, and only shows each person what they're allowed to see |
-| Scheduler / durable jobs                       | Reminders, digests, and recurring work keep running and notify the right people            |
+| Feature layer (how we build it)                   | Value layer (what the reader gets)                                                                     |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Verified work items + weekly report               | Your digital employee files a weekly report; click any line to see what it did and the proof it's done |
+| Action receipts on every external write           | Every piece of work leaves a paper trail you can audit — including attempts that were refused          |
+| Acceptance checks against external systems        | Work only counts when your systems confirm it's done — the AI never grades its own homework            |
+| Per-person authority (avatars act as their owner) | It acts with each person's own permissions, so your existing access controls contain it                |
+| Follow-ups with escalation                        | It chases the right person until the thing is actually done — approvals, invoices, reviews             |
+| One deployment, many users and agents             | Anyone on the team just asks — no new system to learn, no seat-by-seat setup                           |
+| Per-user-per-agent memory                         | The agent remembers each teammate's context, so nobody re-explains themselves                          |
+| Telegram / QQ / Feishu / WeChat / Web channels    | It shows up in the group chat you already live in — no new app to install                              |
+| Skills, tools, sandbox policy                     | It does the work, not just chats — and only within boundaries you set                                  |
+| Self-hosted, bring-your-own model keys            | Your data and your keys stay on infrastructure you control                                             |
+| Knowledge base + permissions                      | The agent answers from _your_ docs, and only shows each person what they're allowed to see             |
+| Scheduler / durable jobs                          | Reminders, digests, and recurring work keep running and notify the right people                        |
 
 The test for any marketing sentence: a reader should feel **"this is about me,"** not "this is impressive engineering." If a sentence only makes sense to someone who already knows the architecture, it belongs in `development/`, not on a landing page.
 
-Banned on marketing surfaces unless immediately translated: `single-tenant`, `multi-agent`, `sandbox policy`, `durable jobs`, `pgxpool`, `River`, model/library names, and any other internal mechanism. Naming the mechanism is fine _after_ the value lands ("…because each agent runs in its own sandbox").
+Banned on marketing surfaces unless immediately translated: `single-tenant`, `multi-agent`, `sandbox policy`, `durable jobs`, `Action Gateway`, `Action Receipt`, `acceptance contract`, `SoR`, `Goal engine`, `pgxpool`, `River`, model/library names, and any other internal mechanism. Naming the mechanism is fine _after_ the value lands ("…because each agent runs in its own sandbox").
 
 ## Write for a specific person, not a persona
 
 "Efficiency tool users" is not a person. "A new hire on day one asking the Feishu group how to file a reimbursement" is. Anchor copy to people you could actually point at:
 
-- **Scenario** — when do they reach for Stella? Put the feature inside a moment in their day. ("Monday morning, before standup, the Research agent has already summarized the weekend's RSS updates.")
-- **Emotion** — what feeling are they buying away? ("Stop being the person who answers the same onboarding question for the ninth time.")
-- **Identity** — who do they become by using it? ("A team that doesn't waste its smartest people on lookups.")
+- **Scenario** — when do they reach for Stella? Put the feature inside a moment in their day. ("Monday morning, the finance digital employee has already filed its weekly report: 47 items verified, 12 missing invoices chased down.")
+- **Emotion** — what feeling are they buying away? ("Stop being the person who chases the same approval three times a week.")
+- **Identity** — who do they become by using it? ("A team whose experts supervise the work instead of doing the chasing.")
 
 Three concrete scenario stories beat five abstract benefit bullets. Lead with the moment, then name the capability that serves it.
 
@@ -61,12 +66,14 @@ Three concrete scenario stories beat five abstract benefit bullets. Lead with th
 
 A visitor decides whether to keep reading in roughly one second. The hero (headline + subhead + one visual) carries that decision — most bounce is a first-screen failure, not a feature gap.
 
-- The headline states a **value-layer outcome** for the primary audience, not a category label. "Your team's repeat questions don't need you" beats "Multi-agent AI platform."
+- The headline states a **value-layer outcome** for the primary audience, not a category label. "Hire an AI employee whose work you can audit" beats "Multi-agent AI platform."
 - The subhead names the **specific person and moment**.
-- The visual shows the **product doing the job in a real channel** (an agent answering in a Feishu/Telegram thread), not an abstract robot, a gradient, or a dashboard nobody can read.
+- The visual shows the **product doing the job in a real channel** (an agent chasing an approval in a Feishu thread, or a weekly report whose lines open into receipts), not an abstract robot, a gradient, or a dashboard nobody can read.
 - One primary CTA. Verb-led. ("Start Stella", "Read the quickstart") — never "Learn more."
 
 If you can't tell within one second who it's for and what they get, the hero has failed regardless of how correct the copy below it is.
+
+Numbers discipline: weekly-report and metric claims on marketing surfaces must be numbers the product actually produced in dogfood or a customer deployment — never invented figures. Until real numbers exist for a capability, market the capability, not sample numbers.
 
 ## Match content type to product tonality
 
@@ -78,10 +85,10 @@ When something works, don't use it once. Recombine it: same scenario × differen
 
 People search before they decide. Weave the terms a buyer would actually search — naturally, in headlines, body, and captions, not as a hashtag dump:
 
-- **Audience terms** — IT lead, ops team, small company, indie developer
-- **Scenario terms** — onboarding, reimbursement, candidate screening, code review, RSS digest
+- **Audience terms** — IT lead, department head, ops team, small company, indie developer
+- **Scenario terms** — onboarding, reimbursement, approval follow-up, candidate screening, code review, RSS digest
 - **Product terms** — Stella, and the names people give it ("Feishu AI bot", "self-hosted AI assistant")
-- **Category terms** — self-hosted AI agent, open-source AI assistant, team AI coworker
+- **Category terms** — AI digital employee, self-hosted AI agent, open-source AI assistant, team AI coworker
 - **Competitor terms** — only where Stella genuinely wins; otherwise you're sending traffic to them
 
 Not every page carries every term. More pages, wider coverage, higher odds of being found.
@@ -101,6 +108,7 @@ Not every page carries every term. More pages, wider coverage, higher odds of be
 - [ ] No untranslated internal mechanism names
 - [ ] Anchored to a specific person, moment, and feeling — not a persona
 - [ ] Hero states a value outcome and shows the product in a real channel
+- [ ] Any numbers shown are real dogfood/customer numbers, not invented
 - [ ] Voice matches `web-design.md` (friendly, direct, not enterprise-formal)
 - [ ] Searchable terms are woven in naturally
 - [ ] English and Chinese versions both updated (per `doc-style.md`)

--- a/web/content/docs/index.mdx
+++ b/web/content/docs/index.mdx
@@ -1,14 +1,14 @@
 ---
 title: Stella
-description: Shared AI coworkers for every team.
+description: Self-hosted digital employees for your team.
 icon: Bot
 ---
 
 import { Cards, Card } from "@/components/docs/mdx-components";
 
-Stella turns the expertise your team repeats into shared AI coworkers. A domain owner gives an agent instructions, skills, tools, knowledge, and memory rules; everyone else chats with that agent, gives it goals, and tracks larger work as goal trees with acceptance checks.
+Stella turns the work your team repeats into digital employees. A domain owner gives an agent instructions, skills, tools, knowledge, and memory rules; everyone else chats with it in the channels they already use, gives it goals, and tracks larger work as goal trees with acceptance checks — so what it finishes is verified, not just claimed.
 
-Use Stella when a team needs a repeatable expert: a Finance agent for reimbursement work, an HR agent for referrals and hiring, an Engineering agent for reviews and releases, or a Research agent that keeps reading and summarizing the web for you.
+Use Stella when a team needs an extra pair of hands it can trust: a finance employee that handles reimbursement paperwork, an HR employee that keeps hiring moving, an engineering employee that reviews code and chases releases, or a research employee that keeps reading and summarizing the web for you.
 
 ## Start Here
 

--- a/web/content/docs/index.zh.mdx
+++ b/web/content/docs/index.zh.mdx
@@ -1,14 +1,14 @@
 ---
 title: Stella
-description: 为每个团队创建共享的 AI 同事
+description: 为团队自部署数字员工
 icon: Bot
 ---
 
 import { Cards, Card } from "@/components/docs/mdx-components";
 
-Stella 把团队里重复的专业能力变成共享的 AI 同事。业务负责人为 Agent 配置 instructions、skills、tools、knowledge 和记忆策略；其他人像找同事一样聊天，把 goal 交给它；更大的工作会被追踪为带验收检查的 goal 树。
+Stella 把团队里重复的工作交给数字员工。业务负责人为 Agent 配置 instructions、skills、tools、knowledge 和记忆策略；其他人在已有的渠道里和它协作，把 goal 交给它；更大的工作会被追踪为带验收检查的 goal 树——它做完的事是被验证过的，不是自己说的。
 
-当团队需要一个可复用的专家时，就应该使用 Stella：财务 Agent 处理报销，HR Agent 处理内推和招聘，工程 Agent 处理代码审查和发布，研究 Agent 持续阅读并总结网页和 PDF。
+当团队需要一双信得过的额外的手时，就该使用 Stella：财务数字员工处理报销事务，HR 数字员工推进招聘，工程数字员工审查代码、跟进发布，研究数字员工持续阅读并总结网页和 PDF。
 
 ## 从这里开始
 


### PR DESCRIPTION
## What

Repositions the two marketing-facing surfaces in-repo around the digital-employee narrative:

- `web/content/docs/development/rules/marketing.md` — audience #1 becomes organizations hiring digital employees; the value-translation table gains rows for verified work items, weekly reports, action receipts, acceptance checks, per-person authority, and follow-ups; banned-terms list extended (Action Gateway, Action Receipt, acceptance contract, SoR, Goal engine); scenario/emotion/identity examples updated to weekly-report imagery.
- `web/content/docs/index.mdx` / `index.zh.mdx` — hero copy shifts from "shared AI coworkers" to "self-hosted digital employees", emphasizing verified (not just claimed) work. Both locales updated.

## Why

Product direction settled on the digital-employee employment model (数字员工雇佣制, roadmap v4, maintained in Feishu). Marketing rules and the docs landing page should speak the new language before any new marketing content is written against the old positioning.

## How

Docs-only change extracted from the retired planning branch `docs/digital-employee-positioning` (never opened as a PR). No behavior changes. `mise run generate && mise run format && mise run build && mise run test` all pass locally.

## Refs

Closes #795. Related: #766 (Extension Pack), #767 (Action Gateway).