### PR TITLE
✨ feat(session): transactional main-session rotation and real /new for DMs (1/4)

### DIFF
--- a/api/spec/domain/sessions/paths.yaml
+++ b/api/spec/domain/sessions/paths.yaml
@@ -198,6 +198,7 @@ paths:
           $ref: "../../components.yaml#/components/responses/Unauthorized",
         }
         "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "409": { $ref: "../../components.yaml#/components/responses/Conflict" }
 
   /api/agents/{agentId}/sessions/{sessionId}/events:
     parameters:

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -37,6 +37,7 @@ type SessionAccessService interface {
 type SessionAccess interface {
 	Create(context.Context, string, string, string, session.Kind, session.Channel) (session.Info, error)
 	ResolveMain(context.Context, string, string) (session.Info, error)
+	RotateMain(context.Context, string, string, string) (session.Info, error)
 	Use(context.Context, string, string) (session.Info, error)
 	EnsureRead(context.Context, session.Request) (session.Info, error)
 	EnsureUse(context.Context, session.Request) (session.Info, error)
@@ -524,6 +525,25 @@ func (s *Service) resolveMainSession(ctx context.Context, authority authz.Author
 		return info, err
 	}
 	return access.Use(ctx, info.AgentID, info.ID)
+}
+
+// RotateMainSession archives the user's current main session and returns the
+// successor, which starts empty. It is the `/new` counterpart to
+// ResolveMainSessionForUse: rotation is one authorized compare-and-rotate use
+// case rather than a resolve followed by a separate archive, so a turn that
+// raced another rotation cannot archive the successor.
+//
+// expectedSessionID is the main session the caller observed; an empty value
+// rotates whatever is current. A mismatch reports session.ErrStaleRotation.
+func (s *Service) RotateMainSession(ctx context.Context, authority authz.Authority, userID, agentID, expectedSessionID string) (session.Info, error) {
+	if agentID == "" {
+		agentID = s.AgentID
+	}
+	access, err := s.beginSessionAccess(ctx, authority)
+	if err != nil {
+		return session.Info{}, err
+	}
+	return access.RotateMain(ctx, userID, agentID, expectedSessionID)
 }
 
 // CompactSession runs full compaction on the session identified by sessionID.

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -36,6 +36,10 @@ func (a fakeSessionAccess) ResolveMain(ctx context.Context, userID, agentID stri
 	return a.reg.ResolveMain(ctx, session.MainRequest{UserID: userID, AgentID: agentID})
 }
 
+func (a fakeSessionAccess) RotateMain(ctx context.Context, userID, agentID, expectedSessionID string) (session.Info, error) {
+	return a.reg.RotateMain(ctx, session.MainRequest{UserID: userID, AgentID: agentID, ExpectedSessionID: expectedSessionID})
+}
+
 func (a fakeSessionAccess) Use(ctx context.Context, agentID, sessionID string) (session.Info, error) {
 	return a.reg.Get(ctx, session.Scope{AgentID: agentID, System: true}, sessionID)
 }

--- a/internal/agent/session/access/runtime.go
+++ b/internal/agent/session/access/runtime.go
@@ -114,6 +114,13 @@ func (s *Service) Send(ctx context.Context, in SendInput) (SendResult, error) {
 			return SendResult{PlainReply: reply}, nil
 		}
 	}
+	// Rotation can archive the session a client is holding (a `/new` from another
+	// surface). The turn would fail deep inside the runtime and reach the client as
+	// free text in the event stream, so reject it here while the caller can still be
+	// told what happened.
+	if info.Archived {
+		return SendResult{}, fmt.Errorf("%w: %s", agentsession.ErrArchived, in.SessionID)
+	}
 	ch := runtime.Chat(ctx, agent.ChatRequest{
 		SessionID: in.SessionID,
 		UserID:    info.UserID,

--- a/internal/agent/session/access/runtime_test.go
+++ b/internal/agent/session/access/runtime_test.go
@@ -127,6 +127,30 @@ func TestAttachGuardDeniesAfterDurableAgentRevocation(t *testing.T) {
 	}
 }
 
+// TestSendRejectsArchivedSessionDistinguishably covers a client that kept sending
+// to a session `/new` rotated away: the refusal must carry ErrArchived so the
+// transport can tell "rotated away" apart from "gone", and no turn may start.
+func TestSendRejectsArchivedSessionDistinguishably(t *testing.T) {
+	ctx := context.Background()
+	svc, rt, _, authority := newRuntimeTestService(t)
+	info, err := svc.memory.LoadInfo(ctx, "s1")
+	if err != nil {
+		t.Fatalf("LoadInfo: %v", err)
+	}
+	info.Archived = true
+	if err := svc.memory.SaveInfo(ctx, info); err != nil {
+		t.Fatalf("SaveInfo: %v", err)
+	}
+
+	_, err = svc.Send(ctx, SendInput{Authority: authority, AgentID: "a1", SessionID: "s1", Message: "hello"})
+	if !errors.Is(err, agentsession.ErrArchived) {
+		t.Fatalf("Send = %v, want ErrArchived", err)
+	}
+	if rt.chatCalls != 0 {
+		t.Fatalf("chat=%d, want no turn started on an archived session", rt.chatCalls)
+	}
+}
+
 func newRuntimeTestService(t *testing.T) (*Service, *fakeRuntimeService, config.Store, authz.Authority) {
 	t.Helper()
 	ctx := context.Background()

--- a/internal/agent/session/access/service.go
+++ b/internal/agent/session/access/service.go
@@ -246,6 +246,30 @@ func (a *Access) ResolveMain(ctx context.Context, userID, agentID string) (agent
 	return a.svc.registry.ResolveMain(ctx, agentsession.MainRequest{UserID: userID, AgentID: agentID})
 }
 
+// RotateMain archives the caller's current main session and returns its
+// successor. Both halves are decided here under one evaluation — Delete on the
+// session being retired and Create on the one replacing it — because the
+// successor does not exist yet and the predecessor is chosen by the registry:
+// no caller can pre-authorize an Info and hand it to the lifecycle layer.
+// expectedSessionID, when set, makes this a compare-and-rotate.
+func (a *Access) RotateMain(ctx context.Context, userID, agentID, expectedSessionID string) (agentsession.Info, error) {
+	if userID == "" || agentID == "" || string(a.authority.UserID()) != userID {
+		return agentsession.Info{}, ErrForbidden
+	}
+	if err := a.authorizeAgent(ctx, agentID, authz.ActionRead); err != nil {
+		return agentsession.Info{}, err
+	}
+	actor := a.authority
+	facts := sessionFacts{
+		isOwner:    true,
+		isExecutor: string(actor.AgentID()) != "" && string(actor.AgentID()) == agentID,
+	}
+	if !a.allowSession(authz.ActionDelete, facts) || !a.allowSession(authz.ActionCreate, facts) {
+		return agentsession.Info{}, ErrNotFound
+	}
+	return a.svc.registry.RotateMain(ctx, agentsession.MainRequest{UserID: userID, AgentID: agentID, ExpectedSessionID: expectedSessionID})
+}
+
 // List lists the actor's sessions and filters every row through the same
 // evaluation. Collection visibility and individual visibility therefore cannot
 // drift apart.

--- a/internal/agent/session/memory_adapter.go
+++ b/internal/agent/session/memory_adapter.go
@@ -27,6 +27,16 @@ func (a *memoryAdapter) save(ctx context.Context, info Info) error {
 	return a.sm.SaveInfo(ctx, rec)
 }
 
+func (a *memoryAdapter) rotate(ctx context.Context, expectedSessionID string, successor Info) error {
+	rec, err := successor.Record()
+	if err != nil {
+		return err
+	}
+	ctx = authz.WithUserID(ctx, successor.UserID)
+	ctx = authz.WithAgentID(ctx, successor.AgentID)
+	return a.sm.RotateInfo(ctx, expectedSessionID, rec)
+}
+
 func (a *memoryAdapter) load(ctx context.Context, sessionID, userID, agentID string) (Info, error) {
 	ctx = authz.WithUserID(ctx, userID)
 	ctx = authz.WithAgentID(ctx, agentID)

--- a/internal/agent/session/memory_adapter_test.go
+++ b/internal/agent/session/memory_adapter_test.go
@@ -16,6 +16,10 @@ type fakeSessionManager struct {
 }
 
 func (f *fakeSessionManager) SaveInfo(context.Context, memory.SessionInfo) error { return nil }
+func (f *fakeSessionManager) RotateInfo(context.Context, string, memory.SessionInfo) error {
+	return nil
+}
+
 func (f *fakeSessionManager) LoadInfo(context.Context, string) (memory.SessionInfo, error) {
 	return f.rec, nil
 }

--- a/internal/agent/session/registry.go
+++ b/internal/agent/session/registry.go
@@ -25,6 +25,11 @@ var ErrWrongKind = errors.New("session kind mismatch")
 // ErrArchived is returned when an attempt is made to write to an archived session.
 var ErrArchived = errors.New("session is archived")
 
+// ErrStaleRotation is returned when a rotation's expected session is no longer
+// the active one. It is the store-level sentinel so callers can match a stale
+// rotation with one errors.Is check regardless of which layer detected it.
+var ErrStaleRotation = memory.ErrStaleRotation
+
 // Registry is the sole owner of agent-session lifecycle.
 // It creates, resumes, lists, and archives sessions; it also converts validated
 // session records into memory operation scopes.
@@ -161,22 +166,81 @@ func (r *Registry) ResolveMain(ctx context.Context, req MainRequest) (Info, erro
 	unlock := r.mainMu.lock(agentID + "\x00" + req.UserID)
 	defer unlock()
 
-	// Look for an existing main-kind session.
-	mains, err := r.store.list(ctx, req.UserID, agentID, memory.ListOptions{
+	current, found, err := r.currentMainLocked(ctx, req.UserID, agentID)
+	if err != nil {
+		return Info{}, err
+	}
+	if found {
+		return current, nil
+	}
+
+	info := newMainInfo(agentID, req.UserID)
+	if err := r.store.save(ctx, info); err != nil {
+		return Info{}, fmt.Errorf("create main session: %w", err)
+	}
+	return info, nil
+}
+
+// RotateMain archives the user's current main session and returns its
+// successor, so the next turn starts with an empty context while the old
+// session stays searchable. The archive and the create are one store-level
+// transaction: the binding is never left without an active main.
+//
+// When req.ExpectedSessionID is set it must still be the current main;
+// otherwise the rotation is stale (another /new already ran) and reports
+// ErrStaleRotation without changing anything. Rotating when no main exists is
+// just a create.
+func (r *Registry) RotateMain(ctx context.Context, req MainRequest) (Info, error) {
+	if req.UserID == "" || req.AgentID == "" {
+		return Info{}, fmt.Errorf("RotateMain requires UserID and AgentID")
+	}
+	agentID := r.resolveAgentID(req.AgentID)
+	unlock := r.mainMu.lock(agentID + "\x00" + req.UserID)
+	defer unlock()
+
+	current, found, err := r.currentMainLocked(ctx, req.UserID, agentID)
+	if err != nil {
+		return Info{}, err
+	}
+	successor := newMainInfo(agentID, req.UserID)
+
+	if !found {
+		if req.ExpectedSessionID != "" {
+			return Info{}, fmt.Errorf("%w: %s is no longer the main session", ErrStaleRotation, req.ExpectedSessionID)
+		}
+		if err := r.store.save(ctx, successor); err != nil {
+			return Info{}, fmt.Errorf("create main session: %w", err)
+		}
+		return successor, nil
+	}
+	if req.ExpectedSessionID != "" && req.ExpectedSessionID != current.ID {
+		return Info{}, fmt.Errorf("%w: %s is no longer the main session", ErrStaleRotation, req.ExpectedSessionID)
+	}
+	if err := r.store.rotate(ctx, current.ID, successor); err != nil {
+		return Info{}, fmt.Errorf("rotate main session: %w", err)
+	}
+	return successor, nil
+}
+
+// currentMainLocked resolves the session ResolveMain would hand back when one
+// already exists: an active main-kind session, or the most recent promotable
+// chat candidate. Callers must hold the per-(agent,user) main lock.
+func (r *Registry) currentMainLocked(ctx context.Context, userID, agentID string) (Info, bool, error) {
+	mains, err := r.store.list(ctx, userID, agentID, memory.ListOptions{
 		Kind:            string(KindMain),
-		UserID:          req.UserID,
+		UserID:          userID,
 		AgentID:         agentID,
 		ProjectIDIsNull: true,
 	})
 	if err == nil {
 		for _, info := range mains {
-			return info, nil
+			return info, true, nil
 		}
 	}
 
 	// No main session: look for the most recent chat candidate.
-	candidates, err := r.store.list(ctx, req.UserID, agentID, memory.ListOptions{
-		UserID:  req.UserID,
+	candidates, err := r.store.list(ctx, userID, agentID, memory.ListOptions{
+		UserID:  userID,
 		AgentID: agentID,
 	})
 	if err != nil {
@@ -186,32 +250,31 @@ func (r *Registry) ResolveMain(ctx context.Context, req MainRequest) (Info, erro
 	var best *Info
 	for i := range candidates {
 		c := &candidates[i]
-		if !isMainCandidate(*c, req.UserID) {
+		if !isMainCandidate(*c, userID) {
 			continue
 		}
 		if best == nil || c.LastActive.After(best.LastActive) {
 			best = c
 		}
 	}
-
-	if best != nil {
-		best.Kind = string(KindMain)
-		if err := r.store.save(ctx, *best); err != nil {
-			return Info{}, fmt.Errorf("promote session to main: %w", err)
-		}
-		return *best, nil
+	if best == nil {
+		return Info{}, false, nil
 	}
 
-	// Create a fresh main session.
+	best.Kind = string(KindMain)
+	if err := r.store.save(ctx, *best); err != nil {
+		return Info{}, false, fmt.Errorf("promote session to main: %w", err)
+	}
+	return *best, true, nil
+}
+
+// newMainInfo builds a fresh main session. Main sessions use a private user
+// channel by convention; isMainCandidate keys promotion off that shape.
+func newMainInfo(agentID, userID string) Info {
 	now := time.Now().UTC()
 	id := uuid.Must(uuid.NewV7()).String()
-	// Main sessions use a private user channel by convention.
-	channel := agentID + ":user:" + req.UserID + ":private"
-	info := NewInfo(id, agentID, req.UserID, channel, KindMain, "", now)
-	if err := r.store.save(ctx, info); err != nil {
-		return Info{}, fmt.Errorf("create main session: %w", err)
-	}
-	return info, nil
+	channel := agentID + ":user:" + userID + ":private"
+	return NewInfo(id, agentID, userID, channel, KindMain, "", now)
 }
 
 // ListForReview returns sessions that are candidates for reflect review.
@@ -226,8 +289,12 @@ func (r *Registry) ListForReview(ctx context.Context, req ReviewRequest) ([]Info
 		policy = DefaultReviewPolicy()
 	}
 
+	// Archived sessions stay candidates: rotation (/new) archives a session the
+	// instant the user starts a fresh one, and its final messages still have to
+	// reach reflect. The caller drops them once their watermarks catch up.
 	all, err := r.store.listForReview(ctx, agentID, memory.ListOptions{
-		AgentID: agentID,
+		AgentID:         agentID,
+		IncludeArchived: true,
 	})
 	if err != nil {
 		return nil, err
@@ -235,9 +302,6 @@ func (r *Registry) ListForReview(ctx context.Context, req ReviewRequest) ([]Info
 
 	out := all[:0]
 	for _, info := range all {
-		if info.Archived {
-			continue
-		}
 		if !policy.Includes(Kind(info.Kind)) {
 			continue
 		}

--- a/internal/agent/session/registry_test.go
+++ b/internal/agent/session/registry_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -13,6 +14,12 @@ import (
 // fakeStore is an in-memory store for tests.
 type fakeStore struct {
 	sessions map[string]Info
+	// rotateErr, when set, fails rotate so callers can prove a failed rotation
+	// leaves the predecessor active (the store's transaction rolled back).
+	rotateErr error
+	// beforeRotate runs inside rotate, standing in for a concurrent writer that
+	// commits between the caller's resolve and the compare-and-rotate.
+	beforeRotate func()
 }
 
 func newFakeStore() *fakeStore {
@@ -21,6 +28,23 @@ func newFakeStore() *fakeStore {
 
 func (f *fakeStore) save(_ context.Context, info Info) error {
 	f.sessions[info.ID] = info
+	return nil
+}
+
+func (f *fakeStore) rotate(_ context.Context, expectedSessionID string, successor Info) error {
+	if f.beforeRotate != nil {
+		f.beforeRotate()
+	}
+	if f.rotateErr != nil {
+		return f.rotateErr
+	}
+	expected, ok := f.sessions[expectedSessionID]
+	if !ok || expected.Archived {
+		return fmt.Errorf("%w: %s", ErrStaleRotation, expectedSessionID)
+	}
+	expected.Archived = true
+	f.sessions[expectedSessionID] = expected
+	f.sessions[successor.ID] = successor
 	return nil
 }
 
@@ -267,7 +291,9 @@ func TestReviewPolicy_ExcludesDelegate(t *testing.T) {
 	}
 }
 
-// TestListForReview excludes delegate and archived sessions.
+// TestListForReview excludes delegate sessions but keeps archived ones: a
+// rotated-away session is archived immediately and its final messages still have
+// to be distilled. Watermark comparison, not archival, ends review candidacy.
 func TestListForReview(t *testing.T) {
 	r, s := newTestRegistry(t)
 	now := time.Now().UTC()
@@ -281,16 +307,15 @@ func TestListForReview(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListForReview: %v", err)
 	}
+	got := make(map[string]bool, len(infos))
 	for _, i := range infos {
 		if Kind(i.Kind) == KindDelegate {
 			t.Errorf("delegate session %q should be excluded", i.ID)
 		}
-		if i.Archived {
-			t.Errorf("archived session %q should be excluded", i.ID)
-		}
+		got[i.ID] = true
 	}
-	if len(infos) != 1 || infos[0].ID != "chat-1" {
-		t.Errorf("expected [chat-1], got %v", infos)
+	if !got["chat-1"] || !got["arch-1"] || len(infos) != 2 {
+		t.Errorf("expected [chat-1 arch-1], got %v", infos)
 	}
 }
 
@@ -451,4 +476,141 @@ func TestEnsure_ResumeGroupReconciliation(t *testing.T) {
 			t.Fatalf("err = %v, want ErrForbidden", err)
 		}
 	})
+}
+
+// --- RotateMain -------------------------------------------------------------
+
+// TestRotateMain_ArchivesOldMain proves /new hands back a fresh, empty main and
+// leaves the previous one archived but intact.
+func TestRotateMain_ArchivesOldMain(t *testing.T) {
+	r, s := newTestRegistry(t)
+	now := time.Now().UTC()
+	s.sessions["main-1"] = NewInfo("main-1", "agent1", "u1", "agent1:user:u1:private", KindMain, "", now)
+
+	successor, err := r.RotateMain(context.Background(), MainRequest{UserID: "u1", AgentID: "agent1"})
+	if err != nil {
+		t.Fatalf("RotateMain: %v", err)
+	}
+	if successor.ID == "main-1" {
+		t.Fatal("RotateMain must return a new session, not the rotated one")
+	}
+	if successor.Kind != string(KindMain) || successor.Archived {
+		t.Fatalf("successor = %+v, want an active main", successor)
+	}
+	if !strings.Contains(successor.Channel, ":user:u1:") {
+		t.Errorf("successor channel = %q, want a private user channel", successor.Channel)
+	}
+	if !s.sessions["main-1"].Archived {
+		t.Error("the rotated main must be archived, not deleted")
+	}
+
+	resolved, err := r.ResolveMain(context.Background(), MainRequest{UserID: "u1", AgentID: "agent1"})
+	if err != nil {
+		t.Fatalf("ResolveMain after rotation: %v", err)
+	}
+	if resolved.ID != successor.ID {
+		t.Errorf("ResolveMain = %q, want the successor %q", resolved.ID, successor.ID)
+	}
+}
+
+// TestRotateMain_CreatesWhenNoMainExists treats rotation from nothing as a
+// plain create rather than an error.
+func TestRotateMain_CreatesWhenNoMainExists(t *testing.T) {
+	r, _ := newTestRegistry(t)
+
+	info, err := r.RotateMain(context.Background(), MainRequest{UserID: "u1", AgentID: "agent1"})
+	if err != nil {
+		t.Fatalf("RotateMain: %v", err)
+	}
+	if info.Kind != string(KindMain) {
+		t.Errorf("kind = %q, want %q", info.Kind, KindMain)
+	}
+}
+
+// TestRotateMain_StaleExpectedSession is the duplicate-/new case: the second
+// rotation names a session that is no longer the main, so it must not rotate
+// the successor the first one just created.
+func TestRotateMain_StaleExpectedSession(t *testing.T) {
+	r, s := newTestRegistry(t)
+	now := time.Now().UTC()
+	s.sessions["main-1"] = NewInfo("main-1", "agent1", "u1", "agent1:user:u1:private", KindMain, "", now)
+
+	successor, err := r.RotateMain(context.Background(), MainRequest{UserID: "u1", AgentID: "agent1", ExpectedSessionID: "main-1"})
+	if err != nil {
+		t.Fatalf("RotateMain: %v", err)
+	}
+
+	_, err = r.RotateMain(context.Background(), MainRequest{UserID: "u1", AgentID: "agent1", ExpectedSessionID: "main-1"})
+	if !errors.Is(err, ErrStaleRotation) {
+		t.Fatalf("second RotateMain = %v, want ErrStaleRotation", err)
+	}
+	if s.sessions[successor.ID].Archived {
+		t.Error("a stale rotation must leave the current main active")
+	}
+}
+
+// TestRotateMain_StoreFailureKeepsOldMain proves a failed rotation is a no-op:
+// the store transaction rolls back, so the old main is still resolvable.
+func TestRotateMain_StoreFailureKeepsOldMain(t *testing.T) {
+	r, s := newTestRegistry(t)
+	now := time.Now().UTC()
+	s.sessions["main-1"] = NewInfo("main-1", "agent1", "u1", "agent1:user:u1:private", KindMain, "", now)
+	s.rotateErr = errors.New("create successor failed")
+
+	if _, err := r.RotateMain(context.Background(), MainRequest{UserID: "u1", AgentID: "agent1"}); err == nil {
+		t.Fatal("RotateMain must report the store failure")
+	}
+	if s.sessions["main-1"].Archived {
+		t.Fatal("a failed rotation must not archive the old main")
+	}
+	resolved, err := r.ResolveMain(context.Background(), MainRequest{UserID: "u1", AgentID: "agent1"})
+	if err != nil {
+		t.Fatalf("ResolveMain after failed rotation: %v", err)
+	}
+	if resolved.ID != "main-1" {
+		t.Errorf("ResolveMain = %q, want main-1", resolved.ID)
+	}
+}
+
+// TestRotateMain_ConcurrentResolveNeverPromotesStale proves the keyed main lock
+// covers the whole rotation: a ResolveMain racing it sees either the old main or
+// the successor, never a promoted third session.
+func TestRotateMain_ConcurrentResolveNeverPromotesStale(t *testing.T) {
+	r, s := newTestRegistry(t)
+	now := time.Now().UTC()
+	s.sessions["main-1"] = NewInfo("main-1", "agent1", "u1", "agent1:user:u1:private", KindMain, "", now)
+	// A promotable chat candidate on the same private channel. If ResolveMain ran
+	// while the rotation had archived main-1 but not yet created its successor,
+	// this is the session it would wrongly promote.
+	s.sessions["chat-1"] = NewInfo("chat-1", "agent1", "u1", "agent1:user:u1:private", KindChat, "", now.Add(-time.Hour))
+
+	resolved := make(chan Info, 1)
+	s.beforeRotate = func() {
+		go func() {
+			info, err := r.ResolveMain(context.Background(), MainRequest{UserID: "u1", AgentID: "agent1"})
+			if err != nil {
+				t.Errorf("concurrent ResolveMain: %v", err)
+			}
+			resolved <- info
+		}()
+		// Give the racing resolve a chance to reach the lock before the rotation
+		// finishes; it must block there rather than observe the gap.
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	successor, err := r.RotateMain(context.Background(), MainRequest{UserID: "u1", AgentID: "agent1"})
+	if err != nil {
+		t.Fatalf("RotateMain: %v", err)
+	}
+	select {
+	case info := <-resolved:
+		if info.ID != successor.ID && info.ID != "main-1" {
+			t.Fatalf("concurrent ResolveMain promoted %q; want the old main or the successor", info.ID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("concurrent ResolveMain did not complete")
+	}
+	if s.sessions["chat-1"].Kind == string(KindMain) {
+		t.Error("a stale chat session must never be promoted during rotation")
+	}
 }

--- a/internal/agent/session/request.go
+++ b/internal/agent/session/request.go
@@ -53,10 +53,15 @@ type ListOptions struct {
 	Offset    int
 }
 
-// MainRequest describes a main-session resolution request.
+// MainRequest describes a main-session resolution or rotation request.
 type MainRequest struct {
 	UserID  string
 	AgentID string
+	// ExpectedSessionID makes a rotation a compare-and-rotate: the current main
+	// must still be this session, otherwise RotateMain reports ErrStaleRotation
+	// and changes nothing. Empty means "rotate whatever is current"; it is
+	// ignored by ResolveMain.
+	ExpectedSessionID string
 }
 
 // ReviewRequest describes which sessions are candidates for reflect review.

--- a/internal/agent/session/store.go
+++ b/internal/agent/session/store.go
@@ -11,6 +11,9 @@ import (
 // memory.SessionManager. Tests may substitute a fake.
 type store interface {
 	save(ctx context.Context, info Info) error
+	// rotate archives expectedSessionID and creates successor atomically,
+	// reporting ErrStaleRotation when expectedSessionID is no longer active.
+	rotate(ctx context.Context, expectedSessionID string, successor Info) error
 	load(ctx context.Context, sessionID, userID, agentID string) (Info, error)
 	list(ctx context.Context, userID, agentID string, opts memory.ListOptions) ([]Info, error)
 	listForReview(ctx context.Context, agentID string, opts memory.ListOptions) ([]Info, error)

--- a/internal/channel/commands.go
+++ b/internal/channel/commands.go
@@ -7,11 +7,21 @@ import (
 	"strings"
 
 	"github.com/CherryHQ/stella/internal/agent"
+	"github.com/CherryHQ/stella/internal/agent/session"
 	pkgchannel "github.com/CherryHQ/stella/pkg/channel"
 )
 
+// ErrRotationUnsupported reports a chat whose session cannot be rotated yet:
+// group chats and unlinked private channels are still pinned to a session whose
+// ID is their session key, so there is no successor to switch to.
+var ErrRotationUnsupported = errors.New("starting a fresh session is not supported for this chat")
+
 // HandleCommand processes common bot commands shared across all channels.
 // /model and /agent are left to each channel because they need platform-specific UI.
+//
+// /new is deliberately absent: rotating a session must run in the same
+// per-session FIFO queue as chat turns, so the coordinator owns it (see
+// Coordinator.handleNewSessionCommand) and calls NewSessionReply from there.
 func HandleCommand(ctx context.Context, rc *ResolvedChat, text, senderID string) (string, bool) {
 	fields := strings.Fields(text)
 	if len(fields) == 0 {
@@ -22,7 +32,7 @@ func HandleCommand(ctx context.Context, rc *ResolvedChat, text, senderID string)
 	switch cmd {
 	case "/start", "/help":
 		return pkgchannel.WelcomeMessage, true
-	case "/new", "/compact":
+	case "/compact":
 		if _, err := rc.CompactSession(ctx); err != nil {
 			if errors.Is(err, agent.ErrGroupCompactionUnsupported) {
 				return pkgchannel.GroupCompactUnsupportedMessage, true
@@ -35,4 +45,21 @@ func HandleCommand(ctx context.Context, rc *ResolvedChat, text, senderID string)
 	}
 
 	return "", false
+}
+
+// NewSessionReply rotates the chat onto a fresh session and returns the user
+// reply. expectedSessionID is the session observed when the command arrived; a
+// rotation that no longer matches it is reported as an already-done reset rather
+// than resetting the successor a concurrent /new just created.
+func NewSessionReply(ctx context.Context, rc *ResolvedChat, expectedSessionID string) string {
+	switch _, err := rc.RotateSession(ctx, expectedSessionID); {
+	case err == nil:
+		return pkgchannel.NewSessionStartedMessage
+	case errors.Is(err, session.ErrStaleRotation):
+		return pkgchannel.SessionAlreadyResetMessage
+	case errors.Is(err, ErrRotationUnsupported):
+		return pkgchannel.NewSessionUnsupportedMessage
+	default:
+		return fmt.Sprintf("Starting a new session failed: %v", err)
+	}
 }

--- a/internal/channel/commands_test.go
+++ b/internal/channel/commands_test.go
@@ -116,6 +116,13 @@ func (a compactSessionAccess) ResolveMain(ctx context.Context, userID, agentID s
 	return a.reg.ResolveMain(ctx, session.MainRequest{UserID: userID, AgentID: agentID})
 }
 
+func (a compactSessionAccess) RotateMain(ctx context.Context, userID, agentID, expectedSessionID string) (session.Info, error) {
+	if a.useErr != nil {
+		return session.Info{}, a.useErr
+	}
+	return a.reg.RotateMain(ctx, session.MainRequest{UserID: userID, AgentID: agentID, ExpectedSessionID: expectedSessionID})
+}
+
 func (a compactSessionAccess) Use(ctx context.Context, agentID, sessionID string) (session.Info, error) {
 	if a.useErr != nil {
 		return session.Info{}, a.useErr

--- a/internal/channel/coordinator.go
+++ b/internal/channel/coordinator.go
@@ -326,6 +326,11 @@ func (c *Coordinator) handleResolvedIncoming(ctx context.Context, rc *ResolvedCh
 		if command == "/config" {
 			return c.handleConfigCommand(ctx, rc, args)
 		}
+		// /new runs through the session queue, so it cannot go through the
+		// stateless shared command handler.
+		if command == "/new" {
+			return c.handleNewSessionCommand(ctx, rc), true, nil, nil
+		}
 		if resp, ok := HandleCommand(ctx, rc, command+" "+args, msg.SenderID); ok {
 			return resp, true, nil, nil
 		}
@@ -336,7 +341,9 @@ func (c *Coordinator) handleResolvedIncoming(ctx context.Context, rc *ResolvedCh
 		switch intent {
 		case IntentAbort:
 			return c.handleAbort(rc), true, nil, nil
-		case IntentHelp, IntentNew, IntentCompact:
+		case IntentNew:
+			return c.handleNewSessionCommand(ctx, rc), true, nil, nil
+		case IntentHelp, IntentCompact:
 			if resp, ok := HandleCommand(ctx, rc, IntentToCommand(intent), msg.SenderID); ok {
 				return resp, true, nil, nil
 			}
@@ -378,6 +385,31 @@ func (c *Coordinator) handleConfigCommand(ctx context.Context, rc *ResolvedChat,
 		return "", false, nil, err
 	}
 	return "", false, stream, nil
+}
+
+// handleNewSessionCommand starts a fresh session for this chat. The rotation is
+// queued behind any in-flight turn on the same session: aborting the user's
+// running work on a reset request would be surprising, and rotating underneath it
+// would land its reply in a session the user already left.
+func (c *Coordinator) handleNewSessionCommand(ctx context.Context, rc *ResolvedChat) string {
+	// Resolve before queueing so the queued rotation names the session the user
+	// was actually looking at; a second /new behind it is then stale, not a
+	// second reset.
+	current, err := rc.CurrentSessionForRotation(ctx)
+	if err != nil {
+		if errors.Is(err, ErrRotationUnsupported) {
+			return pkgchannel.NewSessionUnsupportedMessage
+		}
+		return fmt.Sprintf("Starting a new session failed: %v", err)
+	}
+	var reply string
+	if err := c.queue.EnqueueControl(ctx, rc.SessionKey, func(qctx context.Context) error {
+		reply = NewSessionReply(qctx, rc, current.ID)
+		return nil
+	}); err != nil {
+		return fmt.Sprintf("Starting a new session failed: %v", err)
+	}
+	return reply
 }
 
 // handleAbort cancels the currently-running request for the resolved session.

--- a/internal/channel/new_session_test.go
+++ b/internal/channel/new_session_test.go
@@ -1,0 +1,160 @@
+package channel
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/CherryHQ/stella/internal/agent"
+	"github.com/CherryHQ/stella/internal/agent/session"
+	"github.com/CherryHQ/stella/internal/auth"
+	pkgchannel "github.com/CherryHQ/stella/pkg/channel"
+)
+
+// newRotateTestChat builds a DM chat pinned to the user's main session — the
+// only shape `/new` rotates in this phase.
+func newRotateTestChat(t *testing.T, user auth.User) *ResolvedChat {
+	t.Helper()
+	rc := newCompactTestChat(t, "", user)
+	rc.Channel = session.Channel(rc.AgentID + ":user:" + user.ID + ":private")
+	rc.SessionKey = agent.BuildUserSessionKey(rc.AgentID, user.ID, "private")
+	return rc
+}
+
+func TestNewSessionReplyRotatesMainSession(t *testing.T) {
+	ctx := context.Background()
+	rc := newRotateTestChat(t, auth.User{ID: "user-1", Role: auth.RoleUser})
+
+	before, err := rc.CurrentSessionForRotation(ctx)
+	if err != nil {
+		t.Fatalf("CurrentSessionForRotation: %v", err)
+	}
+	if reply := NewSessionReply(ctx, rc, before.ID); reply != pkgchannel.NewSessionStartedMessage {
+		t.Fatalf("reply = %q, want %q", reply, pkgchannel.NewSessionStartedMessage)
+	}
+
+	after, err := rc.ResolveSession(ctx)
+	if err != nil {
+		t.Fatalf("ResolveSession: %v", err)
+	}
+	if after.ID == before.ID {
+		t.Fatal("/new must move the chat onto a new session")
+	}
+	if after.Archived {
+		t.Fatal("the successor must be active")
+	}
+}
+
+// TestNewSessionReplyDuplicateIsNoOp covers two `/new` commands racing on one
+// chat: the second names a session the first already rotated away, so it must
+// report the reset as already done instead of resetting again.
+func TestNewSessionReplyDuplicateIsNoOp(t *testing.T) {
+	ctx := context.Background()
+	rc := newRotateTestChat(t, auth.User{ID: "user-1", Role: auth.RoleUser})
+
+	before, err := rc.CurrentSessionForRotation(ctx)
+	if err != nil {
+		t.Fatalf("CurrentSessionForRotation: %v", err)
+	}
+	if reply := NewSessionReply(ctx, rc, before.ID); reply != pkgchannel.NewSessionStartedMessage {
+		t.Fatalf("first reply = %q", reply)
+	}
+	first, err := rc.ResolveSession(ctx)
+	if err != nil {
+		t.Fatalf("ResolveSession: %v", err)
+	}
+
+	if reply := NewSessionReply(ctx, rc, before.ID); reply != pkgchannel.SessionAlreadyResetMessage {
+		t.Fatalf("duplicate reply = %q, want %q", reply, pkgchannel.SessionAlreadyResetMessage)
+	}
+	second, err := rc.ResolveSession(ctx)
+	if err != nil {
+		t.Fatalf("ResolveSession after duplicate: %v", err)
+	}
+	if second.ID != first.ID {
+		t.Fatal("a duplicate /new must not rotate the session a second time")
+	}
+}
+
+// TestNewSessionReplyUnsupportedForGroup keeps group chats on the existing
+// not-yet-supported reply: their session is still pinned to its session key.
+func TestNewSessionReplyUnsupportedForGroup(t *testing.T) {
+	const groupID = "11111111-1111-4111-8111-111111111111"
+	rc := newCompactTestChat(t, groupID, auth.User{})
+
+	if reply := NewSessionReply(context.Background(), rc, ""); reply != pkgchannel.NewSessionUnsupportedMessage {
+		t.Fatalf("group reply = %q, want %q", reply, pkgchannel.NewSessionUnsupportedMessage)
+	}
+}
+
+// TestHandleNewSessionCommandWaitsForActiveTurn proves `/new` is queued rather
+// than immediate: rotating underneath an in-flight turn would land its reply in
+// a session the user has already left.
+func TestHandleNewSessionCommandWaitsForActiveTurn(t *testing.T) {
+	ctx := context.Background()
+	c := &Coordinator{queue: newSessionQueue()}
+	rc := newRotateTestChat(t, auth.User{ID: "user-1", Role: auth.RoleUser})
+
+	before, err := rc.CurrentSessionForRotation(ctx)
+	if err != nil {
+		t.Fatalf("CurrentSessionForRotation: %v", err)
+	}
+
+	turnRunning := make(chan struct{})
+	turnUnblock := make(chan struct{})
+	turnDone := make(chan struct{})
+	go func() {
+		defer close(turnDone)
+		stream, doneC, err := c.queue.Enqueue(ctx, rc.SessionKey, func(context.Context) (*pkgchannel.ChatStream, error) {
+			close(turnRunning)
+			<-turnUnblock
+			return makeStream(pkgchannel.Event{Text: "answer"}), nil
+		})
+		if err != nil {
+			t.Errorf("enqueue turn: %v", err)
+			return
+		}
+		for range stream.Events {
+		}
+		close(doneC)
+	}()
+	<-turnRunning
+
+	replyC := make(chan string, 1)
+	go func() { replyC <- c.handleNewSessionCommand(ctx, rc) }()
+
+	select {
+	case reply := <-replyC:
+		t.Fatalf("/new ran ahead of the in-flight turn (reply %q)", reply)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// The session must still be the one the running turn is writing to.
+	current, err := rc.ResolveSession(ctx)
+	if err != nil {
+		t.Fatalf("ResolveSession: %v", err)
+	}
+	if current.ID != before.ID {
+		t.Fatal("/new rotated the session while a turn was still running")
+	}
+
+	close(turnUnblock)
+	<-turnDone
+
+	select {
+	case reply := <-replyC:
+		if reply != pkgchannel.NewSessionStartedMessage {
+			t.Fatalf("reply = %q, want %q", reply, pkgchannel.NewSessionStartedMessage)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("/new did not run after the turn finished")
+	}
+
+	rotated, err := rc.ResolveSession(ctx)
+	if err != nil {
+		t.Fatalf("ResolveSession after rotation: %v", err)
+	}
+	if rotated.ID == before.ID {
+		t.Fatal("/new must rotate once the turn completes")
+	}
+}

--- a/internal/channel/resolved_chat.go
+++ b/internal/channel/resolved_chat.go
@@ -47,8 +47,15 @@ func (rc *ResolvedChat) sessionUserID() string {
 	return rc.User.ID
 }
 
+// usesMainSession reports whether this chat is pinned to the user's singleton
+// main session — a linked user talking on their private channel. Every other
+// chat (group, unlinked private channel) is pinned to a key-derived session ID.
+func (rc *ResolvedChat) usesMainSession() bool {
+	return rc.User.ID != "" && strings.Contains(string(rc.Channel), ":user:")
+}
+
 func (rc *ResolvedChat) ResolveSession(ctx context.Context) (session.Info, error) {
-	if rc.User.ID != "" && strings.Contains(string(rc.Channel), ":user:") {
+	if rc.usesMainSession() {
 		return rc.Service.ResolveMainSession(ctx, rc.Authority, rc.User.ID, rc.AgentID)
 	}
 	if rc.GroupID != "" {
@@ -63,7 +70,7 @@ func (rc *ResolvedChat) CompactSession(ctx context.Context) (string, error) {
 		err  error
 	)
 	switch {
-	case rc.User.ID != "" && strings.Contains(string(rc.Channel), ":user:"):
+	case rc.usesMainSession():
 		info, err = rc.Service.ResolveMainSessionForUse(ctx, rc.Authority, rc.User.ID, rc.AgentID)
 	case rc.GroupID != "":
 		info, err = rc.Service.ResolveGroupChannelSessionForUse(ctx, rc.Authority, rc.SessionKey, rc.GroupID, rc.AgentID, rc.Channel)
@@ -74,6 +81,27 @@ func (rc *ResolvedChat) CompactSession(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("resolve session for compaction: %w", err)
 	}
 	return rc.Service.CompactAuthorizedSession(ctx, info)
+}
+
+// CurrentSessionForRotation resolves and authorizes the session a `/new` would
+// replace. It runs before the rotation is queued so the queued operation carries
+// the session the user actually saw; a duplicate `/new` behind it then resolves
+// as stale instead of resetting a second time.
+func (rc *ResolvedChat) CurrentSessionForRotation(ctx context.Context) (session.Info, error) {
+	if !rc.usesMainSession() {
+		return session.Info{}, ErrRotationUnsupported
+	}
+	return rc.Service.ResolveMainSessionForUse(ctx, rc.Authority, rc.User.ID, rc.AgentID)
+}
+
+// RotateSession archives the chat's current session and returns its empty
+// successor. Only the DM main session rotates today; group and unlinked
+// private-channel chats are still pinned to a key-derived session ID.
+func (rc *ResolvedChat) RotateSession(ctx context.Context, expectedSessionID string) (session.Info, error) {
+	if !rc.usesMainSession() {
+		return session.Info{}, ErrRotationUnsupported
+	}
+	return rc.Service.RotateMainSession(ctx, rc.Authority, rc.User.ID, rc.AgentID, expectedSessionID)
 }
 
 // AuthorizeUse performs the fresh execution decision at dequeue time. The

--- a/internal/channel/session_queue.go
+++ b/internal/channel/session_queue.go
@@ -144,6 +144,8 @@ func (q *sessionQueue) Enqueue(
 	case <-ctx.Done():
 		// Wait for the queue worker in the background to send the result.
 		// If it produced a stream, we must clean it up to prevent a slot leak.
+		// doneC is closed whether or not a stream came back: the worker blocks on
+		// it, so a stream-less operation would otherwise wedge the session.
 		go func() {
 			res := <-resultC
 			if res.stream != nil {
@@ -151,13 +153,30 @@ func (q *sessionQueue) Enqueue(
 					for range res.stream.Events {
 					}
 				}()
-				if res.doneC != nil {
-					close(res.doneC)
-				}
+			}
+			if res.doneC != nil {
+				close(res.doneC)
 			}
 		}()
 		return nil, nil, ctx.Err()
 	}
+}
+
+// EnqueueControl runs a non-streaming session operation (e.g. /new) in the same
+// per-session FIFO order as chat turns and waits for it to finish. Rotating a
+// session ahead of an in-flight turn would strand that turn's reply in a session
+// the user has already left, so control operations wait their turn instead.
+func (q *sessionQueue) EnqueueControl(ctx context.Context, sessionKey string, fn func(context.Context) error) error {
+	var opErr error
+	_, doneC, err := q.Enqueue(ctx, sessionKey, func(qctx context.Context) (*pkgchannel.ChatStream, error) {
+		opErr = fn(qctx)
+		return nil, nil
+	})
+	if err != nil {
+		return err
+	}
+	close(doneC)
+	return opErr
 }
 
 // Abort cancels the currently-running request for sessionKey.

--- a/internal/channel/session_queue_test.go
+++ b/internal/channel/session_queue_test.go
@@ -335,3 +335,45 @@ func TestSessionQueue_RecreatesSlotAfterIdleCleanup(t *testing.T) {
 		t.Fatalf("second enqueue: %v", err)
 	}
 }
+
+// TestSessionQueue_ControlOpReleasesSlotWhenCallerGivesUp covers the abandoned
+// control operation: it produces no stream, so the queue must still close its
+// done channel or the session slot stays blocked forever.
+func TestSessionQueue_ControlOpReleasesSlotWhenCallerGivesUp(t *testing.T) {
+	q := newSessionQueue()
+	ctx, cancel := context.WithCancel(context.Background())
+	started := make(chan struct{})
+	go func() {
+		<-started
+		cancel()
+	}()
+
+	err := q.EnqueueControl(ctx, "sess-ctl", func(opCtx context.Context) error {
+		close(started)
+		<-opCtx.Done()
+		return nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("EnqueueControl error = %v, want context.Canceled", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		stream, doneC, err := q.Enqueue(context.Background(), "sess-ctl", func(context.Context) (*pkgchannel.ChatStream, error) {
+			return makeStream(pkgchannel.Event{Text: "next"}), nil
+		})
+		if err != nil {
+			t.Errorf("follow-up enqueue: %v", err)
+			return
+		}
+		for range stream.Events {
+		}
+		close(doneC)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("session slot stayed blocked after an abandoned control operation")
+	}
+}

--- a/internal/db/queries/ctx_conversation.sql
+++ b/internal/db/queries/ctx_conversation.sql
@@ -38,6 +38,20 @@ WHERE id = sqlc.arg(id) AND user_id = sqlc.arg(user_id) AND agent_id IS NOT DIST
 UPDATE ctx_conversation SET archived = sqlc.arg(archived), updated_at = now()
 WHERE session_id = sqlc.arg(session_id) AND user_id = sqlc.arg(user_id) AND agent_id IS NOT DISTINCT FROM sqlc.narg(agent_id);
 
+-- name: ArchiveActiveConversationBySessionID :execrows
+-- Compare-and-rotate half of a session rotation: the row is archived only while
+-- it is still active and still matches the caller's expected binding, so a
+-- rotation that lost a race reports zero rows instead of archiving the successor
+-- another rotation just created. The UPDATE also holds the row lock for the rest
+-- of the enclosing transaction, serializing concurrent rotations of one session.
+UPDATE ctx_conversation SET archived = true, updated_at = now()
+WHERE session_id = sqlc.arg(session_id)
+  AND user_id = sqlc.arg(user_id)
+  AND agent_id IS NOT DISTINCT FROM sqlc.narg(agent_id)
+  AND kind = sqlc.arg(kind)
+  AND project_id IS NOT DISTINCT FROM sqlc.narg(project_id)
+  AND archived = false;
+
 -- name: UpdateConversationLastActive :exec
 UPDATE ctx_conversation SET last_active = now(), updated_at = now()
 WHERE session_id = sqlc.arg(session_id) AND user_id = sqlc.arg(user_id) AND agent_id IS NOT DISTINCT FROM sqlc.narg(agent_id);
@@ -116,6 +130,10 @@ ORDER BY last_active DESC, session_id DESC;
 -- name: ListConversationsForReviewFiltered :many
 -- Ownerless legacy rows (NULL/empty user_id) are excluded: review is user-scoped
 -- and such rows were never review candidates.
+-- An archived session is still a candidate when include_archived is set: rotation
+-- (/new) archives a session the moment the user starts a fresh one, and its last
+-- messages would otherwise never be distilled. The caller drops archived rows
+-- once their review watermarks reach latest_seq.
 SELECT
   sqlc.embed(c),
   COALESCE((
@@ -125,7 +143,7 @@ SELECT
   ), 0)::bigint AS latest_seq
 FROM ctx_conversation c
 WHERE c.agent_id = sqlc.arg(agent_id)
-  AND c.archived = false
+  AND (sqlc.arg(include_archived) != 0 OR c.archived = false)
   AND c.user_id IS NOT NULL AND c.user_id <> ''
   AND (sqlc.narg(kind)::text IS NULL OR c.kind = sqlc.narg(kind))
   AND (sqlc.arg(project_id_is_null) = 0 OR c.project_id IS NULL)

--- a/internal/memory/lcm/rotation_test.go
+++ b/internal/memory/lcm/rotation_test.go
@@ -1,0 +1,238 @@
+package lcm_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/CherryHQ/stella/internal/authz"
+	"github.com/CherryHQ/stella/internal/memory"
+	"github.com/CherryHQ/stella/internal/memory/lcm"
+)
+
+// rotationScope returns the context the SessionManager methods expect plus a
+// main-session record for testUserID.
+func rotationScope(t *testing.T) (context.Context, memory.SessionInfo) {
+	t.Helper()
+	ctx := authz.WithAgentID(authz.WithUserID(context.Background(), testUserID), "test")
+	return ctx, memory.SessionInfo{
+		ID:      "main-" + uuid.NewString(),
+		AgentID: "test",
+		UserID:  testUserID,
+		Channel: "test:user:" + testUserID + ":private",
+		Kind:    "main",
+	}
+}
+
+func newRotationProvider(t *testing.T) *lcm.Provider {
+	t.Helper()
+	db := newLCMTestDB(t)
+	t.Cleanup(db.Close)
+	p, err := lcm.New(db, nil, nil)
+	if err != nil {
+		t.Fatalf("new provider: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Close() })
+	return p
+}
+
+// TestRotateInfoReplacesMainAtomically proves the successor is created and the
+// predecessor archived in one step, which the idx_one_agent_main partial unique
+// index (one active main per agent+user) would reject in any other order.
+func TestRotateInfoReplacesMainAtomically(t *testing.T) {
+	p := newRotationProvider(t)
+	ctx, main := rotationScope(t)
+	if err := p.SaveInfo(ctx, main); err != nil {
+		t.Fatalf("SaveInfo: %v", err)
+	}
+
+	successor := main
+	successor.ID = "main-" + uuid.NewString()
+	if err := p.RotateInfo(ctx, main.ID, successor); err != nil {
+		t.Fatalf("RotateInfo: %v", err)
+	}
+
+	predecessor, err := p.LoadInfo(ctx, main.ID)
+	if err != nil {
+		t.Fatalf("LoadInfo predecessor: %v", err)
+	}
+	if !predecessor.Archived {
+		t.Error("predecessor must be archived")
+	}
+	created, err := p.LoadInfo(ctx, successor.ID)
+	if err != nil {
+		t.Fatalf("LoadInfo successor: %v", err)
+	}
+	if created.Archived || created.Kind != "main" {
+		t.Fatalf("successor = %+v, want an active main", created)
+	}
+
+	active, err := p.ListInfo(ctx, memory.ListOptions{UserID: testUserID, AgentID: "test", Kind: "main"})
+	if err != nil {
+		t.Fatalf("ListInfo: %v", err)
+	}
+	if len(active) != 1 || active[0].ID != successor.ID {
+		t.Fatalf("active mains = %v, want only the successor", sessionIDs(active))
+	}
+}
+
+// TestRotateInfoRollsBackFailedSuccessor injects a successor insert failure (a
+// session_id that already exists) and proves the whole rotation rolls back: the
+// old session is still active and resolvable.
+func TestRotateInfoRollsBackFailedSuccessor(t *testing.T) {
+	p := newRotationProvider(t)
+	ctx, main := rotationScope(t)
+	if err := p.SaveInfo(ctx, main); err != nil {
+		t.Fatalf("SaveInfo: %v", err)
+	}
+	occupied := main
+	occupied.ID = "chat-" + uuid.NewString()
+	occupied.Kind = "chat"
+	if err := p.SaveInfo(ctx, occupied); err != nil {
+		t.Fatalf("SaveInfo occupied: %v", err)
+	}
+
+	successor := main
+	successor.ID = occupied.ID // session_id is UNIQUE: the INSERT must fail
+	if err := p.RotateInfo(ctx, main.ID, successor); err == nil {
+		t.Fatal("RotateInfo must fail when the successor cannot be created")
+	}
+
+	predecessor, err := p.LoadInfo(ctx, main.ID)
+	if err != nil {
+		t.Fatalf("LoadInfo predecessor: %v", err)
+	}
+	if predecessor.Archived {
+		t.Fatal("a failed rotation must leave the predecessor active")
+	}
+	active, err := p.ListInfo(ctx, memory.ListOptions{UserID: testUserID, AgentID: "test", Kind: "main"})
+	if err != nil {
+		t.Fatalf("ListInfo: %v", err)
+	}
+	if len(active) != 1 || active[0].ID != main.ID {
+		t.Fatalf("active mains = %v, want only the original main", sessionIDs(active))
+	}
+}
+
+// TestRotateInfoStaleExpectedSession covers the duplicate-/new race: the second
+// rotation names a session another rotation already archived, so it must report
+// ErrStaleRotation and write nothing.
+func TestRotateInfoStaleExpectedSession(t *testing.T) {
+	p := newRotationProvider(t)
+	ctx, main := rotationScope(t)
+	if err := p.SaveInfo(ctx, main); err != nil {
+		t.Fatalf("SaveInfo: %v", err)
+	}
+	first := main
+	first.ID = "main-" + uuid.NewString()
+	if err := p.RotateInfo(ctx, main.ID, first); err != nil {
+		t.Fatalf("first RotateInfo: %v", err)
+	}
+
+	second := main
+	second.ID = "main-" + uuid.NewString()
+	if err := p.RotateInfo(ctx, main.ID, second); !errors.Is(err, memory.ErrStaleRotation) {
+		t.Fatalf("stale RotateInfo = %v, want ErrStaleRotation", err)
+	}
+	if _, err := p.LoadInfo(ctx, second.ID); err == nil {
+		t.Error("a stale rotation must not create a successor")
+	}
+	current, err := p.LoadInfo(ctx, first.ID)
+	if err != nil {
+		t.Fatalf("LoadInfo current main: %v", err)
+	}
+	if current.Archived {
+		t.Error("a stale rotation must not archive the current main")
+	}
+}
+
+// TestRotateInfoRejectsBindingMismatch keeps rotation bound to one durable
+// binding: an expected session of a different kind is not this binding's
+// predecessor, so nothing may be archived or created.
+func TestRotateInfoRejectsBindingMismatch(t *testing.T) {
+	p := newRotationProvider(t)
+	ctx, main := rotationScope(t)
+	chat := main
+	chat.ID = "chat-" + uuid.NewString()
+	chat.Kind = "chat"
+	if err := p.SaveInfo(ctx, chat); err != nil {
+		t.Fatalf("SaveInfo: %v", err)
+	}
+
+	successor := main
+	successor.ID = "main-" + uuid.NewString()
+	if err := p.RotateInfo(ctx, chat.ID, successor); !errors.Is(err, memory.ErrStaleRotation) {
+		t.Fatalf("RotateInfo across kinds = %v, want ErrStaleRotation", err)
+	}
+	kept, err := p.LoadInfo(ctx, chat.ID)
+	if err != nil {
+		t.Fatalf("LoadInfo: %v", err)
+	}
+	if kept.Archived {
+		t.Error("a mismatched rotation must not archive the session it named")
+	}
+}
+
+// TestRotatedSuccessorFreezesCurrentMemoryVersion pins the snapshot contract
+// rotation depends on: the successor's first snapshot freezes the memory version
+// as of now, and the archived session keeps the version it froze earlier.
+func TestRotatedSuccessorFreezesCurrentMemoryVersion(t *testing.T) {
+	db := newLCMTestDB(t)
+	defer db.Close()
+	p, err := lcm.New(db, nil, nil)
+	if err != nil {
+		t.Fatalf("new provider: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	ctx := authz.WithAgentID(authz.WithUserID(context.Background(), testUserID), "test")
+	main := memory.SessionInfo{
+		ID:      "main-" + uuid.NewString(),
+		AgentID: "test",
+		UserID:  testUserID,
+		Channel: "test:user:" + testUserID + ":private",
+		Kind:    "main",
+	}
+	if err := p.SaveInfo(ctx, main); err != nil {
+		t.Fatalf("SaveInfo: %v", err)
+	}
+	before, err := p.GetOrCreateSessionSnapshot(ctx, main.ID, testUserID, "test")
+	if err != nil {
+		t.Fatalf("GetOrCreateSessionSnapshot: %v", err)
+	}
+
+	// Advance the memory clock between the two sessions.
+	if err := p.SetProfile(ctx, testUserID, "test", "likes deterministic tests"); err != nil {
+		t.Fatalf("SetProfile: %v", err)
+	}
+	var current int64
+	if err := db.QueryRow(ctx, `SELECT version FROM ctx_agent_memory WHERE user_id = $1 AND agent_id = $2`, testUserID, "test").Scan(&current); err != nil {
+		t.Fatalf("read memory version: %v", err)
+	}
+	if current <= before.Version {
+		t.Fatalf("memory version %d did not advance past %d", current, before.Version)
+	}
+
+	successor := main
+	successor.ID = "main-" + uuid.NewString()
+	if err := p.RotateInfo(ctx, main.ID, successor); err != nil {
+		t.Fatalf("RotateInfo: %v", err)
+	}
+
+	fresh, err := p.GetOrCreateSessionSnapshot(ctx, successor.ID, testUserID, "test")
+	if err != nil {
+		t.Fatalf("GetOrCreateSessionSnapshot successor: %v", err)
+	}
+	if fresh.Version != current {
+		t.Errorf("successor snapshot version = %d, want the current memory version %d", fresh.Version, current)
+	}
+	after, err := p.GetOrCreateSessionSnapshot(ctx, main.ID, testUserID, "test")
+	if err != nil {
+		t.Fatalf("GetOrCreateSessionSnapshot predecessor: %v", err)
+	}
+	if after.Version != before.Version {
+		t.Errorf("archived session snapshot version = %d, want it untouched at %d", after.Version, before.Version)
+	}
+}

--- a/internal/memory/lcm/sessions.go
+++ b/internal/memory/lcm/sessions.go
@@ -108,6 +108,69 @@ func (p *Provider) SaveInfo(ctx context.Context, info memory.SessionInfo) error 
 	return nil
 }
 
+// RotateInfo implements memory.SessionManager.
+//
+// Order inside the transaction matters: idx_one_agent_main admits a single
+// active main per (agent, user), so the predecessor must be archived before the
+// successor row is inserted. Both statements commit together, so a failed insert
+// leaves the predecessor active and resolvable.
+func (p *Provider) RotateInfo(ctx context.Context, expectedSessionID string, successor memory.SessionInfo) error {
+	if expectedSessionID == "" {
+		return fmt.Errorf("rotate session: expected session id is required")
+	}
+	userID, agentID, err := requireSessionScope(ctx, successor.UserID, successor.AgentID)
+	if err != nil {
+		return err
+	}
+	successor.UserID = userID
+	successor.AgentID = agentID
+	if successor.Kind == "" {
+		successor.Kind = "chat"
+	}
+	if successor.LastActive.IsZero() {
+		successor.LastActive = time.Now().UTC()
+	}
+
+	tx, err := p.db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	qtx := p.q.WithTx(tx)
+
+	archived, err := qtx.ArchiveActiveConversationBySessionID(ctx, sqlc.ArchiveActiveConversationBySessionIDParams{
+		SessionID: expectedSessionID,
+		UserID:    pgtype.Text{String: userID, Valid: true},
+		AgentID:   pgnull.Text(agentID),
+		Kind:      successor.Kind,
+		ProjectID: pgnull.Text(successor.ProjectID),
+	})
+	if err != nil {
+		return fmt.Errorf("archive rotated conversation: %w", err)
+	}
+	if archived == 0 {
+		return fmt.Errorf("%w: %s", memory.ErrStaleRotation, expectedSessionID)
+	}
+
+	if _, err := qtx.CreateConversation(ctx, sqlc.CreateConversationParams{
+		ID:         uuid.Must(uuid.NewV7()).String(),
+		SessionID:  successor.ID,
+		Title:      pgtype.Text{String: successor.Title, Valid: successor.Title != ""},
+		Channel:    successor.Channel,
+		Kind:       successor.Kind,
+		ProjectID:  pgnull.Text(successor.ProjectID),
+		Archived:   successor.Archived,
+		LastActive: successor.LastActive.UTC(),
+		AgentID:    pgnull.Text(successor.AgentID),
+		UserID:     pgtype.Text{String: successor.UserID, Valid: true},
+		GroupID:    pgnull.Text(successor.GroupID),
+	}); err != nil {
+		return fmt.Errorf("create successor conversation: %w", err)
+	}
+
+	return tx.Commit(ctx)
+}
+
 // LoadInfo implements memory.SessionManager.
 func (p *Provider) LoadInfo(ctx context.Context, sessionID string) (memory.SessionInfo, error) {
 	userID, agentID, err := requireSessionScope(ctx, "", "")
@@ -155,6 +218,7 @@ func (p *Provider) ListInfoForReview(ctx context.Context, opts memory.ListOption
 	}
 	convs, err := p.q.ListConversationsForReviewFiltered(ctx, sqlc.ListConversationsForReviewFilteredParams{
 		AgentID:         pgnull.Text(opts.AgentID),
+		IncludeArchived: boolToInt(opts.IncludeArchived),
 		Kind:            pgnull.Text(opts.Kind),
 		ProjectIDIsNull: boolToInt(opts.ProjectIDIsNull),
 		ProjectID:       pgnull.Text(opts.ProjectID),

--- a/internal/memory/memorytest/conformance.go
+++ b/internal/memory/memorytest/conformance.go
@@ -2,6 +2,7 @@ package memorytest
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -314,6 +315,45 @@ func RunConformance(t *testing.T, provider memory.Provider) {
 			}
 			if len(history) < 5 {
 				t.Errorf("expected at least 5 messages in history, got %d", len(history))
+			}
+
+			// Rotation runs on its own session so the shared conformance session
+			// stays active for the capability blocks that follow.
+			rotated := info
+			rotated.ID = session.ID + "-rotating"
+			rotated.Kind = "chat"
+			rotated.Title = "Rotating Session"
+			if err := sm.SaveInfo(ctx, rotated); err != nil {
+				t.Fatalf("SaveInfo rotating session: %v", err)
+			}
+			successor := rotated
+			successor.ID = session.ID + "-successor"
+			successor.Title = "Successor Session"
+			if err := sm.RotateInfo(ctx, rotated.ID, successor); err != nil {
+				t.Fatalf("RotateInfo: %v", err)
+			}
+			predecessor, err := sm.LoadInfo(ctx, rotated.ID)
+			if err != nil {
+				t.Fatalf("LoadInfo predecessor: %v", err)
+			}
+			if !predecessor.Archived {
+				t.Error("RotateInfo must archive the predecessor")
+			}
+			created, err := sm.LoadInfo(ctx, successor.ID)
+			if err != nil {
+				t.Fatalf("LoadInfo successor: %v", err)
+			}
+			if created.Archived {
+				t.Error("RotateInfo must leave the successor active")
+			}
+
+			stale := successor
+			stale.ID = session.ID + "-stale"
+			if err := sm.RotateInfo(ctx, rotated.ID, stale); !errors.Is(err, memory.ErrStaleRotation) {
+				t.Fatalf("RotateInfo on an archived predecessor = %v, want ErrStaleRotation", err)
+			}
+			if _, err := sm.LoadInfo(ctx, stale.ID); err == nil {
+				t.Error("a stale rotation must not create a successor")
 			}
 		})
 	}

--- a/internal/memory/memorytest/fake.go
+++ b/internal/memory/memorytest/fake.go
@@ -64,6 +64,8 @@ type Fake struct {
 	changelog []memory.ChangeEntry
 	// snapshots maps "sessionID:userID:agentID" -> SessionSnapshot.
 	snapshots map[string]memory.SessionSnapshot
+	// rotateErr, when set, fails every RotateInfo (see FailRotation).
+	rotateErr error
 	// mu protects all maps.
 	mu sync.Mutex
 }
@@ -446,6 +448,34 @@ func (f *Fake) SaveInfo(_ context.Context, info memory.SessionInfo) error {
 	defer f.mu.Unlock()
 	f.sessionInfos[info.ID] = fakeSessionInfo{info: info}
 	return nil
+}
+
+// RotateInfo implements memory.SessionManager. The mutex stands in for the real
+// provider's transaction: the archive and the successor become visible together.
+func (f *Fake) RotateInfo(_ context.Context, expectedSessionID string, successor memory.SessionInfo) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.rotateErr != nil {
+		return f.rotateErr
+	}
+	expected, ok := f.sessionInfos[expectedSessionID]
+	if !ok || expected.info.Archived || expected.info.Kind != successor.Kind ||
+		expected.info.UserID != successor.UserID || expected.info.AgentID != successor.AgentID ||
+		expected.info.ProjectID != successor.ProjectID {
+		return fmt.Errorf("%w: %s", memory.ErrStaleRotation, expectedSessionID)
+	}
+	expected.info.Archived = true
+	f.sessionInfos[expectedSessionID] = expected
+	f.sessionInfos[successor.ID] = fakeSessionInfo{info: successor}
+	return nil
+}
+
+// FailRotation makes the next RotateInfo calls fail with err, so callers can
+// prove a rotation failure leaves the predecessor untouched.
+func (f *Fake) FailRotation(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.rotateErr = err
 }
 
 // LoadInfo implements memory.SessionManager.

--- a/internal/memory/provider.go
+++ b/internal/memory/provider.go
@@ -7,6 +7,7 @@ package memory
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/CherryHQ/stella/pkg/ai"
@@ -328,10 +329,22 @@ type ConstraintStore interface {
 // Capability: SessionManager
 // ---------------------------------------------------------------------------
 
+// ErrStaleRotation reports that the session a rotation expected to replace is no
+// longer the active one — a concurrent rotation already won. Rotation is a
+// compare-and-rotate, so a stale caller changed nothing and must not retry.
+var ErrStaleRotation = errors.New("session rotation is stale")
+
 // SessionManager is implemented by providers that support session lifecycle management.
 type SessionManager interface {
 	// SaveInfo persists or updates session metadata.
 	SaveInfo(ctx context.Context, info SessionInfo) error
+
+	// RotateInfo archives expectedSessionID and creates successor as one atomic
+	// unit, so a durable binding is never left without an active session and a
+	// one-active-session-per-binding index is never violated mid-rotation.
+	// It returns ErrStaleRotation, with nothing persisted, when expectedSessionID
+	// is no longer active or no longer matches successor's binding.
+	RotateInfo(ctx context.Context, expectedSessionID string, successor SessionInfo) error
 
 	// LoadInfo retrieves metadata for a single session.
 	LoadInfo(ctx context.Context, sessionID string) (SessionInfo, error)

--- a/internal/memory/traced.go
+++ b/internal/memory/traced.go
@@ -439,6 +439,20 @@ func (t *tracedProvider) SaveInfo(ctx context.Context, info SessionInfo) error {
 	return err
 }
 
+func (t *tracedProvider) RotateInfo(ctx context.Context, expectedSessionID string, successor SessionInfo) error {
+	sm, ok := t.inner.(SessionManager)
+	if !ok {
+		return errCapabilityNotSupported("SessionManager")
+	}
+	hctx := &hooks.PostMemoryCallContext{HookMeta: hooks.HookMeta{SessionID: successor.ID, UserID: successor.UserID, AgentID: successor.AgentID}, Op: hooks.MemoryOpRotateInfo, SessionID: successor.ID}
+	ctx, start := t.begin(ctx, hctx)
+	err := sm.RotateInfo(ctx, expectedSessionID, successor)
+	hctx.Error = err
+	hctx.Detail = fmt.Sprintf("expected=%s successor=%s kind=%s", expectedSessionID, successor.ID, successor.Kind)
+	t.finish(ctx, start, hctx)
+	return err
+}
+
 func (t *tracedProvider) LoadInfo(ctx context.Context, sessionID string) (SessionInfo, error) {
 	sm, ok := t.inner.(SessionManager)
 	if !ok {

--- a/internal/reflect/review_targets.go
+++ b/internal/reflect/review_targets.go
@@ -73,8 +73,11 @@ func (s *Service) reviewTargetLimit() int {
 	return defaultMaxReviewTargetsPerAgent
 }
 
+// listSessionInfoForReview includes archived sessions: a rotated-away session is
+// archived immediately, and its pre-rotation messages must still be distilled.
+// The watermark check in unreviewedTarget drops it once review catches up.
 func listSessionInfoForReview(ctx context.Context, sm memory.SessionManager, agentID string) ([]memory.SessionInfo, error) {
-	opts := memory.ListOptions{AgentID: agentID, IncludeArchived: false}
+	opts := memory.ListOptions{AgentID: agentID, IncludeArchived: true}
 	if lister, ok := sm.(interface {
 		ListInfoForReview(ctx context.Context, opts memory.ListOptions) ([]memory.SessionInfo, error)
 	}); ok {

--- a/internal/reflect/review_unit_test.go
+++ b/internal/reflect/review_unit_test.go
@@ -859,6 +859,10 @@ func (p *nonReviewerProvider) ListInfo(ctx context.Context, opts memory.ListOpti
 	return p.inner.ListInfo(ctx, opts)
 }
 
+func (p *nonReviewerProvider) RotateInfo(ctx context.Context, expectedSessionID string, successor memory.SessionInfo) error {
+	return p.inner.RotateInfo(ctx, expectedSessionID, successor)
+}
+
 func (p *nonReviewerProvider) LoadHistory(ctx context.Context, sessionID string) ([]ai.Message, error) {
 	return p.inner.LoadHistory(ctx, sessionID)
 }

--- a/internal/reflect/rotation_continuity_test.go
+++ b/internal/reflect/rotation_continuity_test.go
@@ -1,0 +1,71 @@
+package reflect
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/CherryHQ/stella/internal/agent/session"
+	"github.com/CherryHQ/stella/internal/memory/memorytest"
+	"github.com/CherryHQ/stella/pkg/ai"
+)
+
+// TestReviewKeepsRotatedSessionUntilWatermarkCatchesUp is the reflect-continuity
+// contract behind `/new`: rotation archives the previous session immediately, so
+// archival must not end review candidacy — only a watermark that has reached the
+// session's last message does.
+func TestReviewKeepsRotatedSessionUntilWatermarkCatchesUp(t *testing.T) {
+	ctx := context.Background()
+	fake := memorytest.New()
+	wm := newFakeWatermarks()
+	svc := &Service{memory: fake, wm: wm, log: testLogger()}
+	reg, err := session.NewRegistry(fake, "a")
+	if err != nil {
+		t.Fatalf("new registry: %v", err)
+	}
+
+	main, err := reg.ResolveMain(ctx, session.MainRequest{UserID: "u1", AgentID: "a"})
+	if err != nil {
+		t.Fatalf("ResolveMain: %v", err)
+	}
+	scope, err := reg.MemoryScope(main)
+	if err != nil {
+		t.Fatalf("MemoryScope: %v", err)
+	}
+	if err := fake.Append(ctx, scope, ai.UserMessage{Content: "remember this", Timestamp: main.LastActive}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	if _, err := reg.RotateMain(ctx, session.MainRequest{UserID: "u1", AgentID: "a"}); err != nil {
+		t.Fatalf("RotateMain: %v", err)
+	}
+
+	targets, err := svc.listUnreviewedFromRegistry(ctx, reg, "a")
+	if err != nil {
+		t.Fatalf("listUnreviewedFromRegistry: %v", err)
+	}
+	if !containsTargetSession(targets, main.ID) {
+		t.Fatal("the rotated-away session must stay a review target until it is reviewed")
+	}
+
+	reviewedAt := main.LastActive.Add(time.Second)
+	wm.setLineMark(main.ID, reflectLineFact, reviewedAt)
+	wm.setLineMark(main.ID, reflectLineSkill, reviewedAt)
+
+	targets, err = svc.listUnreviewedFromRegistry(ctx, reg, "a")
+	if err != nil {
+		t.Fatalf("listUnreviewedFromRegistry after review: %v", err)
+	}
+	if containsTargetSession(targets, main.ID) {
+		t.Fatal("a reviewed archived session must drop out of the review queue")
+	}
+}
+
+func containsTargetSession(targets []reviewTarget, sessionID string) bool {
+	for _, target := range targets {
+		if target.session.ID == sessionID {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/server/sessions.go
+++ b/internal/server/sessions.go
@@ -98,6 +98,13 @@ func (s *Server) SendSessionMessage(w http.ResponseWriter, r *http.Request, agen
 
 	result, err := s.sessionAccess.Send(r.Context(), sessionaccess.SendInput{Authority: authority, AgentID: agentID, SessionID: sessionID, Message: partsToMessageContent(body.Parts)})
 	if err != nil {
+		// An archived session is a state conflict, not a missing one: the client
+		// holds a session that was rotated away and needs to move to the new one
+		// rather than treat its own link as broken.
+		if errors.Is(err, session.ErrArchived) {
+			writeError(w, http.StatusConflict, "session is archived; start a new session")
+			return
+		}
 		s.writeSessionAccessError(w, err)
 		return
 	}

--- a/pkg/channel/util.go
+++ b/pkg/channel/util.go
@@ -22,7 +22,7 @@ Some agents/channels also support a few short natural-language controls.
 For those shortcuts, keep them short and command-like.
 
 Session control
-  /new       Compact conversation context (same as /compact)
+  /new       Start a fresh session (previous history stays searchable)
              When enabled, short phrases like: "new session", "start over", "新会话", "重新开始"
   /compact   Compact conversation context
              When enabled, short phrases like: "compact", "summarize history", "压缩会话", "总结历史"
@@ -44,6 +44,20 @@ Just send a message to get started.`
 // per-agent LCM conversation, so manual compaction does not apply. Both the web
 // group endpoint and the shared channel command handler use this text.
 const GroupCompactUnsupportedMessage = "⚠️ Group memory is managed automatically from the shared event log, so manual compaction is not available in group chats."
+
+// NewSessionStartedMessage is the shared reply after `/new` rotated the chat
+// onto a fresh session. The previous session is archived, not deleted, so it
+// stays reachable through cross-session memory search.
+const NewSessionStartedMessage = "Started a fresh session. Previous history stays searchable via memory."
+
+// SessionAlreadyResetMessage is the shared reply when a `/new` arrives after
+// another one already rotated the same chat, so it has nothing left to do.
+const SessionAlreadyResetMessage = "Session was already reset."
+
+// NewSessionUnsupportedMessage is the shared reply for chats whose session is
+// still pinned to a fixed key (group chats and unlinked private channels), where
+// `/new` cannot rotate anything yet.
+const NewSessionUnsupportedMessage = "⚠️ Starting a fresh session here is not supported yet."
 
 // SplitMessage splits text into chunks that fit within maxLen.
 // It tries to split at newline boundaries and avoids cutting multi-byte

--- a/pkg/db/sqlc/ctx_conversation.sql.go
+++ b/pkg/db/sqlc/ctx_conversation.sql.go
@@ -12,6 +12,43 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const archiveActiveConversationBySessionID = `-- name: ArchiveActiveConversationBySessionID :execrows
+UPDATE ctx_conversation SET archived = true, updated_at = now()
+WHERE session_id = $1
+  AND user_id = $2
+  AND agent_id IS NOT DISTINCT FROM $3
+  AND kind = $4
+  AND project_id IS NOT DISTINCT FROM $5
+  AND archived = false
+`
+
+type ArchiveActiveConversationBySessionIDParams struct {
+	SessionID string      `json:"session_id"`
+	UserID    pgtype.Text `json:"user_id"`
+	AgentID   pgtype.Text `json:"agent_id"`
+	Kind      string      `json:"kind"`
+	ProjectID pgtype.Text `json:"project_id"`
+}
+
+// Compare-and-rotate half of a session rotation: the row is archived only while
+// it is still active and still matches the caller's expected binding, so a
+// rotation that lost a race reports zero rows instead of archiving the successor
+// another rotation just created. The UPDATE also holds the row lock for the rest
+// of the enclosing transaction, serializing concurrent rotations of one session.
+func (q *Queries) ArchiveActiveConversationBySessionID(ctx context.Context, arg ArchiveActiveConversationBySessionIDParams) (int64, error) {
+	result, err := q.db.Exec(ctx, archiveActiveConversationBySessionID,
+		arg.SessionID,
+		arg.UserID,
+		arg.AgentID,
+		arg.Kind,
+		arg.ProjectID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const createConversation = `-- name: CreateConversation :one
 INSERT INTO ctx_conversation (id, session_id, title, channel, kind, project_id, archived, last_active, agent_id, user_id, group_id)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
@@ -518,17 +555,18 @@ SELECT
   ), 0)::bigint AS latest_seq
 FROM ctx_conversation c
 WHERE c.agent_id = $1
-  AND c.archived = false
+  AND ($2 != 0 OR c.archived = false)
   AND c.user_id IS NOT NULL AND c.user_id <> ''
-  AND ($2::text IS NULL OR c.kind = $2)
-  AND ($3 = 0 OR c.project_id IS NULL)
-  AND ($4::text IS NULL OR c.project_id = $4)
+  AND ($3::text IS NULL OR c.kind = $3)
+  AND ($4 = 0 OR c.project_id IS NULL)
+  AND ($5::text IS NULL OR c.project_id = $5)
 ORDER BY c.last_active DESC, c.session_id DESC
-LIMIT NULLIF($6, -1) OFFSET $5
+LIMIT NULLIF($7, -1) OFFSET $6
 `
 
 type ListConversationsForReviewFilteredParams struct {
 	AgentID         pgtype.Text `json:"agent_id"`
+	IncludeArchived interface{} `json:"include_archived"`
 	Kind            pgtype.Text `json:"kind"`
 	ProjectIDIsNull interface{} `json:"project_id_is_null"`
 	ProjectID       pgtype.Text `json:"project_id"`
@@ -543,9 +581,14 @@ type ListConversationsForReviewFilteredRow struct {
 
 // Ownerless legacy rows (NULL/empty user_id) are excluded: review is user-scoped
 // and such rows were never review candidates.
+// An archived session is still a candidate when include_archived is set: rotation
+// (/new) archives a session the moment the user starts a fresh one, and its last
+// messages would otherwise never be distilled. The caller drops archived rows
+// once their review watermarks reach latest_seq.
 func (q *Queries) ListConversationsForReviewFiltered(ctx context.Context, arg ListConversationsForReviewFilteredParams) ([]ListConversationsForReviewFilteredRow, error) {
 	rows, err := q.db.Query(ctx, listConversationsForReviewFiltered,
 		arg.AgentID,
+		arg.IncludeArchived,
 		arg.Kind,
 		arg.ProjectIDIsNull,
 		arg.ProjectID,

--- a/pkg/hooks/hook.go
+++ b/pkg/hooks/hook.go
@@ -152,6 +152,7 @@ const (
 	MemoryOpGetAgentSoulAt             MemoryOp = "get_agent_soul_at"
 	MemoryOpSetAgentSoul               MemoryOp = "set_agent_soul"
 	MemoryOpSaveInfo                   MemoryOp = "save_info"
+	MemoryOpRotateInfo                 MemoryOp = "rotate_info"
 	MemoryOpLoadInfo                   MemoryOp = "load_info"
 	MemoryOpListInfo                   MemoryOp = "list_info"
 	MemoryOpListInfoForReview          MemoryOp = "list_info_for_review"


### PR DESCRIPTION
Part 1 of a 4-PR stack for #794 (split from #797). Stack: **this** ← #794-s2 ← #794-s3 ← #797 (docs + review hardening).

Introduces the rotation primitive and applies it to DMs:

- `SessionManager.RotateInfo`: single-transaction compare-and-rotate (CAS archive of the predecessor + insert of the successor; `ErrStaleRotation` on mismatch), so a failed create can never strand a chat with its session archived.
- `Registry.RotateMain` / `Access.RotateMain` / `Service.RotateMainSession` — `ExpectedSessionID` is captured at command arrival, making duplicate `/new` a no-op instead of a double rotation.
- `/new` split from `/compact` (previously aliases) and run as a control op on the per-session FIFO queue, after any in-flight turn.
- Reflect keeps archived sessions as review candidates until watermarks catch `latest_seq`, so rotation can't drop unprocessed messages out of distillation.
- HTTP send to an archived session → 409 (spec-first).
- Fixes a latent queue wedge: a stream-less control op with an abandoned caller could wedge the per-key slot goroutine forever.

Note: two review-hardening commits (from three sol review rounds on the combined branch) live at the top of the stack in #797; findings touching this layer (atomic turn-metadata save, HTTP-level 409 test) are fixed there.

Closes nothing on its own; tracked by #794.