### PR TITLE
fix(openai): prevent SSE stream hang

### DIFF
--- a/plugins/providers/openai/client.go
+++ b/plugins/providers/openai/client.go
@@ -108,6 +108,10 @@ func (s *sseCommentStripper) Read(p []byte) (int, error) {
 			default:
 				s.done = true
 			}
+			if s.done {
+				// Stop draining as soon as the first normal SSE payload byte is found.
+				break
+			}
 		}
 		if s.done {
 			break

--- a/plugins/providers/openai/client_sse_test.go
+++ b/plugins/providers/openai/client_sse_test.go
@@ -1,0 +1,40 @@
+package openai
+
+import (
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSSECommentStripperReturnsNormalData(t *testing.T) {
+	t.Parallel()
+
+	stripper := &sseCommentStripper{
+		rc: io.NopCloser(strings.NewReader("data: {\"ok\":true}\n\n")),
+	}
+	type readResult struct {
+		n   int
+		err error
+	}
+	result := make(chan readResult, 1)
+	buffer := make([]byte, 64)
+
+	// Run Read asynchronously so the regression reports a timeout instead of hanging the test suite.
+	go func() {
+		n, err := stripper.Read(buffer)
+		result <- readResult{n: n, err: err}
+	}()
+
+	select {
+	case got := <-result:
+		if got.err != nil {
+			t.Fatalf("Read() error = %v", got.err)
+		}
+		if text := string(buffer[:got.n]); text != "data: {\"ok\":true}\n\n" {
+			t.Fatalf("Read() = %q", text)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Read() did not return for a normal SSE data event")
+	}
+}


### PR DESCRIPTION
## What

- Stop `sseCommentStripper` from spinning forever when it reaches the first normal SSE payload byte.
- Add a regression test that verifies a normal `data:` event is returned promptly and unchanged.

## Why

The stripper set `done = true` for non-comment data but remained inside the inner buffer-draining loop without consuming the buffer. OpenAI Chat Completions-compatible streams could therefore hang before returning any model output.

## How

Exit the inner draining loop immediately after the first normal payload byte is detected. The existing outer loop then returns the buffered SSE event through the normal path.

## Testing

- `mise run format`
- `mise run build`
- `mise exec -- go test ./plugins/providers/openai -count=1`
- `mise run test` — the OpenAI provider package passes; the command still reports three unrelated local sandbox failures that reproduce unchanged on `upstream/main`:
  - `TestReadToolProjectRootAbsolutePathUsesHostBoundary`
  - `TestExec_nonzeroExitCode`
  - `TestExec_success`

## Refs

Closes #812
