### PR TITLE
🐛 fix(tools): bump xberg to v1.0.4 so its CLI install verifies

### DIFF
--- a/internal/manifestplugins/loader_test.go
+++ b/internal/manifestplugins/loader_test.go
@@ -31,8 +31,8 @@ func TestLoadBuiltinXberg(t *testing.T) {
 			t.Fatalf("len(Binaries) = %d, want 1", len(p.Binaries))
 		}
 		b := p.Binaries[0]
-		if b.Name != "xberg" || b.Tool != "github:xberg-io/xberg" || b.Version != "1.0.0-rc.29" {
-			t.Fatalf("binary = %+v, want Xberg v1.0.0-rc.29", b)
+		if b.Name != "xberg" || b.Tool != "github:xberg-io/xberg" || b.Version != "1.0.4" {
+			t.Fatalf("binary = %+v, want Xberg v1.0.4", b)
 		}
 		platforms, ok := b.Options["platforms"].(map[string]any)
 		if !ok {

--- a/resources/tools.yaml
+++ b/resources/tools.yaml
@@ -104,7 +104,7 @@ plugins:
     binaries:
       - name: xberg
         tool: github:xberg-io/xberg
-        version: "1.0.0-rc.29"
+        version: "1.0.4"
         platforms:
           linux-arm64:
             asset_pattern: "xberg-cli-aarch64-unknown-linux-gnu.tar.gz"


### PR DESCRIPTION
Closes #819.

## What

Bumps the `tool/kreuzberg` manifest pin for `github:xberg-io/xberg` from `1.0.0-rc.29` to `1.0.4` (plus the loader test assertion). Two files, two lines.

## Why

rc.29's early asset uploads contained a binary named `kreuzberg` (pre-rename), so `mise which xberg` verification failed on every startup (`manifest binary install failed … xberg is not a mise bin`) and mise never repaired it — the version directory existed, so install was skipped forever. v1.0.4 is the newest release shipping standalone `xberg-cli-*` assets (v1.0.5 has only Homebrew bottles); its archives contain a properly named `xberg`. The version bump doubles as the repair path for already-broken deployments: a new version directory forces a fresh install.

## Verification

- `go test ./internal/manifestplugins/` green; full `format && build && test` green.
- Manual: installed v1.0.4 via the bundled mise (2026.4.25) with the same `asset_pattern` config in an isolated `MISE_DATA_DIR` — extracts a binary named `xberg`, `mise which xberg` resolves.

## Known upstream limitation (not addressed here)

Both rc.29 and v1.0.4 darwin CLI binaries dynamically link `/opt/homebrew/opt/libheif/lib/libheif.1.dylib` — on a macOS host without Homebrew's libheif the binary fails to launch (`dyld: Library not loaded`). Upstream packaging defect; workaround `brew install libheif`. Detailed in #819.