### PR TITLE
⬆️ chore(tools): upgrade bundled mise and pinned builtin tools

### DIFF
--- a/internal/manifestplugins/loader_test.go
+++ b/internal/manifestplugins/loader_test.go
@@ -72,8 +72,8 @@ func TestLoadBuiltinLarkCLIIsStandaloneTool(t *testing.T) {
 		if len(p.SessionEnvs) != 0 {
 			t.Fatalf("SessionEnvs = %#v, want no Stella OAuth injection", p.SessionEnvs)
 		}
-		if len(p.Binaries) != 1 || p.Binaries[0].Version != "1.0.79" {
-			t.Fatalf("Binaries = %#v, want pinned lark-cli 1.0.79", p.Binaries)
+		if len(p.Binaries) != 1 || p.Binaries[0].Version != "1.0.80" {
+			t.Fatalf("Binaries = %#v, want pinned lark-cli 1.0.80", p.Binaries)
 		}
 		return
 	}

--- a/plugins/sandbox/docker/Dockerfile
+++ b/plugins/sandbox/docker/Dockerfile
@@ -56,7 +56,7 @@ FROM debian:13-slim
 # reconcile-builtins` below installs them from resources/tools.yaml, exposing
 # them via mise shims exactly as the host does. Only non-mise base runtime deps
 # are installed via apt.
-COPY --from=jdxcode/mise:2026.4.25 /usr/local/bin/mise /opt/stella/bin/mise
+COPY --from=jdxcode/mise:2026.7.18 /usr/local/bin/mise /opt/stella/bin/mise
 COPY --from=libheif-builder /usr/local/lib/libheif.so.1.23.0 /usr/local/lib/
 
 RUN apt-get update && \

--- a/resources/binaries/gen.go
+++ b/resources/binaries/gen.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 )
 
-const miseVersion = "2026.4.25"
+const miseVersion = "2026.7.18"
 
 type miseAsset struct {
 	file   string // filename template with {ver} placeholder
@@ -67,8 +67,8 @@ func main() {
 		outName = "mise.exe.gz"
 	}
 	outPath := filepath.Join(outDir, outName)
-	if _, err := os.Stat(outPath); err == nil {
-		fmt.Printf("skipping %s (already exists)\n", outPath)
+	if cachedVersion(outPath) == miseVersion {
+		fmt.Printf("skipping %s (already at %s)\n", outPath, miseVersion)
 		return
 	}
 
@@ -110,7 +110,7 @@ func main() {
 	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		fatalf("create output dir: %v", err)
 	}
-	if err := gzipFile(binaryPath, outPath); err != nil {
+	if err := gzipFile(binaryPath, outPath, miseVersion); err != nil {
 		fatalf("gzip binary: %v", err)
 	}
 	fmt.Printf("wrote %s\n", outPath)
@@ -252,7 +252,26 @@ func findFile(root, name string) (string, error) {
 	return match, nil
 }
 
-func gzipFile(src, dst string) error {
+// cachedVersion reports the mise version stamped into an already-generated
+// archive, or "" when the archive is missing or unstamped. The version lives in
+// the gzip header comment so it travels with the artifact itself and cannot go
+// stale independently of it — a bumped miseVersion therefore always forces a
+// re-download instead of silently reusing the previous binary.
+func cachedVersion(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = f.Close() }()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = gz.Close() }()
+	return gz.Header.Comment
+}
+
+func gzipFile(src, dst, version string) error {
 	in, err := os.Open(src)
 	if err != nil {
 		return err
@@ -269,6 +288,7 @@ func gzipFile(src, dst string) error {
 		_ = tmp.Close()
 		return err
 	}
+	gz.Header.Comment = version
 	if _, err := io.Copy(gz, in); err != nil {
 		_ = gz.Close()
 		_ = tmp.Close()

--- a/resources/tools.yaml
+++ b/resources/tools.yaml
@@ -58,7 +58,7 @@ plugins:
     binaries:
       - name: lark-cli
         tool: github:larksuite/cli
-        version: "1.0.79"
+        version: "1.0.80"
 
   - id: tool/fd
     kind: tool


### PR DESCRIPTION
Closes #821.

## What

- **Bundled mise `2026.4.25` → `2026.7.18`** (`resources/binaries/gen.go`), plus the drifting `jdxcode/mise` base image in `plugins/sandbox/docker/Dockerfile` synced to the same version.
- **`gen.go` cache invalidation now keys on version, not file existence.** The generator previously skipped the download whenever `binaries/<platform>/mise.gz` existed, so a version bump silently kept stale local caches. The version is now stamped into the gzip header comment and compared before skipping — it travels with the artifact itself, so it cannot go stale independently; the runtime extract side (`gzip.NewReader`) ignores comments, and archives from the old generator have no comment so they regenerate automatically. No `.gitignore`/embed-pattern changes needed.
- **lark-cli `1.0.79` → `1.0.80`** (`resources/tools.yaml` + loader test assertion).
- **tap stays `0.4.10`** — already the latest release. `lightpanda` stays `nightly`; unpinned tools resolve latest already; `xberg` untouched (owned by #820).

## Verification

- Deleted local `mise.gz` caches → `go generate` downloaded 2026.7.18; extracted binary reports `2026.7.18 macos-arm64`. Re-run skips with `already at 2026.7.18`. Scratch check with the const reverted proved the skip re-downloads on version mismatch (both directions).
- lark-cli 1.0.80 and tap 0.4.10 install cleanly with the NEW bundled mise in a fully isolated env (checksum + SLSA provenance verified); `mise which` resolves and `--version` runs. No asset-layout changes.
- `mise run format && build && test` green (run by implementer and reviewer); `GOOS=windows GOARCH=amd64 go build` green.
- CI uses `mise run generate`/`generate:check` and does not depend on the old skip semantics.