### PR TITLE
⚡ perf(web): phase 1 chat rendering optimizations + perf harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ Rules in `web/content/docs/development/rules/` are the **source of truth** for d
 | Current web theme | `web-design.md`      | Styling against the current theme or consulting the visual direction        |
 | Documentation     | `doc-style.md`       | Writing or editing user/developer docs                                      |
 | Web UI testing    | `web-ui-test.md`     | Testing the web UI with browser automation                                  |
+| Web perf testing  | `web-perf-test.md`   | Measuring or optimizing web UI performance                                  |
 | Backend API test  | `api-test.md`        | Testing the backend via live HTTP API + DB assertions (no browser)          |
 | System test       | `system-test.md`     | Adding or running the subprocess system suite; choosing a test layer        |
 | Project tracking  | `project-tracker.md` | Managing GitHub issues and project board                                    |

--- a/internal/agent/session/access/workspace.go
+++ b/internal/agent/session/access/workspace.go
@@ -85,13 +85,14 @@ type WorkspaceReadInput struct {
 }
 
 type WorkspaceReadResult struct {
-	Path         string `json:"path"`
-	Content      string `json:"content,omitempty"`
-	Language     string `json:"language,omitempty"`
-	Raw          bool   `json:"-"`
-	RawName      string `json:"-"`
-	RawMediaType string `json:"-"`
-	RawContent   []byte `json:"-"`
+	Path         string    `json:"path"`
+	Content      string    `json:"content,omitempty"`
+	Language     string    `json:"language,omitempty"`
+	Raw          bool      `json:"-"`
+	RawName      string    `json:"-"`
+	RawMediaType string    `json:"-"`
+	RawContent   []byte    `json:"-"`
+	RawModTime   time.Time `json:"-"`
 }
 
 type WorkspaceWriteInput struct {
@@ -252,7 +253,7 @@ func (a *Access) ReadWorkspacePath(ctx context.Context, in WorkspaceReadInput) (
 		}
 		return WorkspaceReadResult{
 			Path: path, Raw: true, RawName: filepath.Base(path),
-			RawMediaType: mediaType, RawContent: data,
+			RawMediaType: mediaType, RawContent: data, RawModTime: info.ModTime(),
 		}, nil
 	}
 	probe := data

--- a/internal/config/env_scan_test.go
+++ b/internal/config/env_scan_test.go
@@ -90,6 +90,10 @@ var envReadAllowlist = map[string]map[string]bool{
 	"pkg/agent/llm_dump.go": {"STELLA_HOME": true, nonLiteralRead: true},
 	"pkg/tools/truncate.go": {"STELLA_TOOL_MAX_LINES": true, "STELLA_TOOL_MAX_BYTES": true},
 
+	// Standalone perf-harness fake model provider (test tooling, never linked
+	// into stellad); its pacing knobs are process-local by design.
+	"test/perf/fakeprovider/main.go": {nonLiteralRead: true},
+
 	// Plugins do not import internal/config. Per-message render read (feishu) and
 	// docker-sandbox host wiring stay local to their plugin.
 	"plugins/channels/feishu/references.go": {"STELLA_BASE_URL": true},

--- a/internal/server/sessions.go
+++ b/internal/server/sessions.go
@@ -876,7 +876,11 @@ func (s *Server) GetWorkspaceFileContent(w http.ResponseWriter, r *http.Request,
 		w.Header().Set("Content-Disposition", mime.FormatMediaType("inline", map[string]string{"filename": result.RawName}))
 		w.Header().Set("Content-Security-Policy", "sandbox; default-src 'none'; base-uri 'none'; form-action 'none'")
 		w.Header().Set("X-Content-Type-Options", "nosniff")
-		http.ServeContent(w, r, result.RawName, time.Time{}, bytes.NewReader(result.RawContent))
+		// private: session-scoped authorization; no-cache: store but revalidate,
+		// so a reloaded transcript turns repeat image bodies into 304s while a
+		// rewritten workspace file is still picked up immediately.
+		w.Header().Set("Cache-Control", "private, no-cache")
+		http.ServeContent(w, r, result.RawName, result.RawModTime, bytes.NewReader(result.RawContent))
 		return
 	}
 	writeData(w, http.StatusOK, result)

--- a/test/perf/README.md
+++ b/test/perf/README.md
@@ -14,6 +14,19 @@ instance.
 | streaming    | One streamed reply (default 1500 chunks × 10 ms) into that history   | `avgFrameMs`, `p95FrameMs`, `longTaskTotalMs` |
 | typing       | 120 synthetic keystrokes into the composer with full history mounted | `avgKeyMs`, `p95KeyMs`, `maxKeyMs`            |
 
+`measure-load <label>` runs two additional load-focused scenarios (3 reps by
+default, results in `results/load-<label>.json`):
+
+| Scenario   | What happens                                                                                | Key metrics                                        |
+| ---------- | ------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| huge-load  | Open a `HUGE_TURNS` (default 500-turn / 1000-message) session, then scroll-mount everything | `fcpMs`, `resLastEndMs`, `fullMountMs`, `domNodes` |
+| files-load | Open a session whose history embeds `IMG_COUNT` ~1.9 MB images + `PDF_COUNT` PDF chips      | `resTotalKB`, `resLastEndMs`, `loaded`/`total`     |
+
+The huge and files fixtures are seeded once and **reused across labels** (the
+load scenarios never mutate them), so before/after runs see identical data.
+Note the browser cache also persists across labels: `files-load` rep 1 after a
+server restart is a cold view; later reps measure the repeat-view path.
+
 Determinism: message history is seeded through the real API against the fake
 provider (fixed markdown reply per turn), the streamed reply is fixed content at
 a fixed cadence, and each `measure` run seeds a **fresh session** so every label
@@ -34,6 +47,7 @@ cd web && vp build && cd .. && go build -o dist/bin/stellad ./cmd/stellad
 ```
 
 Env knobs: `REPS` (default 5), `SEED_TURNS` (default 100 → 200 messages),
+`HUGE_TURNS` (500), `IMG_COUNT` (10), `PDF_COUNT` (3), `REPS_LOAD` (3),
 `PERF_STREAM_CHUNKS` / `PERF_STREAM_INTERVAL_MS` (fakeprovider pacing),
 `PERF_HOME`, `FAKE_PORT`, `SRV_PORT`.
 

--- a/test/perf/README.md
+++ b/test/perf/README.md
@@ -1,0 +1,52 @@
+# Chat web UI perf harness
+
+Measures the chat UI under three reproducible scenarios so optimizations can be
+compared before/after. Everything runs against a **scratch stellad instance**
+(`~/.stella-perf`, port 25911) with a **deterministic fake Anthropic provider**
+(`fakeprovider/`, port 25901) — no real model calls, no effect on your dev
+instance.
+
+## Scenarios and metrics
+
+| Scenario     | What happens                                                         | Key metrics                                   |
+| ------------ | -------------------------------------------------------------------- | --------------------------------------------- |
+| long-history | Open a seeded ~200-message session, scroll-load the full history     | `domNodes`, `jsHeapMB`, `bufferedLongTask*`   |
+| streaming    | One streamed reply (default 1500 chunks × 10 ms) into that history   | `avgFrameMs`, `p95FrameMs`, `longTaskTotalMs` |
+| typing       | 120 synthetic keystrokes into the composer with full history mounted | `avgKeyMs`, `p95KeyMs`, `maxKeyMs`            |
+
+Determinism: message history is seeded through the real API against the fake
+provider (fixed markdown reply per turn), the streamed reply is fixed content at
+a fixed cadence, and each `measure` run seeds a **fresh session** so every label
+starts from identical state.
+
+## Usage
+
+```bash
+# once per checkout state: rebuild UI + binary the server will embed
+cd web && vp build && cd .. && go build -o dist/bin/stellad ./cmd/stellad
+
+./test/perf/run.sh setup            # start fakeprovider + scratch stellad, seed fixture
+./test/perf/run.sh measure baseline # 5 reps -> test/perf/results/baseline.json
+# ...apply optimizations, rebuild UI + binary, restart scratch server...
+./test/perf/run.sh teardown && ./test/perf/run.sh setup
+./test/perf/run.sh measure after
+./test/perf/run.sh teardown
+```
+
+Env knobs: `REPS` (default 5), `SEED_TURNS` (default 100 → 200 messages),
+`PERF_STREAM_CHUNKS` / `PERF_STREAM_INTERVAL_MS` (fakeprovider pacing),
+`PERF_HOME`, `FAKE_PORT`, `SRV_PORT`.
+
+## Requirements & caveats
+
+- `tap` CLI (drives the browser), `jq`, macOS (`osascript` is used to bring the
+  measurement window frontmost).
+- **The Chrome window must stay visible during `measure`** — Chrome throttles
+  rAF and rendering in hidden/occluded tabs, which zeroes the frame metrics.
+  Don't cover the window while a run is in progress.
+- Numbers are machine-dependent; only compare results captured on the same
+  machine under similar load.
+- First run: the scratch home needs a vault key
+  (`./dist/bin/stellad vault keygen` → `~/.stella-perf/home/.env` as
+  `STELLA_VAULT_KEY=...`). The embedded Postgres runtime is reused from
+  `~/.stella/pg-runtime` if present.

--- a/test/perf/fakeprovider/main.go
+++ b/test/perf/fakeprovider/main.go
@@ -1,0 +1,230 @@
+// Command fakeprovider is a deterministic stand-in for the Anthropic Messages
+// API, used by the chat perf harness (test/perf/run.sh). Point a stella
+// provider's base_url at it and every model call resolves locally with a
+// scripted, repeatable response — no network, no secrets, no token variance.
+//
+// The last user message selects the behavior:
+//
+//   - "seed ..."   → one fixed markdown reply, emitted instantly (fixture seeding)
+//   - "stream ..." → a long reply streamed as PERF_STREAM_CHUNKS text deltas at
+//     PERF_STREAM_INTERVAL_MS cadence (defaults 1500 × 10ms), ending
+//     with the END-OF-STREAM sentinel the harness polls for
+//   - anything else → a short instant reply (absorbs title-gen or other
+//     background model calls without failing)
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func main() {
+	port := flag.Int("port", 25901, "listen port")
+	flag.Parse()
+
+	http.HandleFunc("/", handle)
+	addr := fmt.Sprintf("127.0.0.1:%d", *port)
+	log.Printf("fakeprovider listening on http://%s (chunks=%d interval=%dms)",
+		addr, streamChunks(), streamIntervalMS())
+	log.Fatal(http.ListenAndServe(addr, nil))
+}
+
+func envInt(name string, def int) int {
+	if v := os.Getenv(name); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return def
+}
+
+func streamChunks() int     { return envInt("PERF_STREAM_CHUNKS", 1500) }
+func streamIntervalMS() int { return envInt("PERF_STREAM_INTERVAL_MS", 10) }
+
+// anthropicReq is the subset of the Messages API request the fake reads.
+type anthropicReq struct {
+	Model    string `json:"model"`
+	Messages []struct {
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
+	} `json:"messages"`
+}
+
+// lastUserText extracts the text of the final user message; content may be a
+// plain string or an array of content blocks.
+func lastUserText(req anthropicReq) string {
+	for i := len(req.Messages) - 1; i >= 0; i-- {
+		if req.Messages[i].Role != "user" {
+			continue
+		}
+		raw := req.Messages[i].Content
+		var s string
+		if json.Unmarshal(raw, &s) == nil {
+			return s
+		}
+		var blocks []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		}
+		if json.Unmarshal(raw, &blocks) == nil {
+			for _, b := range blocks {
+				if b.Type == "text" {
+					return b.Text
+				}
+			}
+		}
+		return ""
+	}
+	return ""
+}
+
+func handle(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.NotFound(w, r)
+		return
+	}
+	var req anthropicReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+
+	text := lastUserText(req)
+	// stellad prefixes user turns with a "ts:<epoch>" line; strip it so the
+	// scenario keyword is at the start.
+	if strings.HasPrefix(text, "ts:") {
+		if _, rest, ok := strings.Cut(text, "\n"); ok {
+			text = rest
+		}
+	}
+	log.Printf("request: model=%s lastUser=%.120q", req.Model, text)
+	switch {
+	case strings.HasPrefix(text, "stream"):
+		// Echo the rest of the user text into the closing sentinel so the
+		// harness can distinguish this reply from earlier streamed turns
+		// already in the transcript.
+		nonce := strings.TrimSpace(strings.TrimPrefix(text, "stream"))
+		stream(w, req.Model, streamChunkTexts(nonce), time.Duration(streamIntervalMS())*time.Millisecond)
+	case strings.HasPrefix(text, "seed"):
+		stream(w, req.Model, []string{seedReply}, 0)
+	default:
+		stream(w, req.Model, []string{"ok."}, 0)
+	}
+}
+
+// stream writes a complete Anthropic SSE turn: message_start, one text content
+// block whose deltas are the given chunks (paced by interval), then the
+// closing frames. Framing mirrors test/system/fake_anthropic_test.go.
+func stream(w http.ResponseWriter, model string, chunks []string, interval time.Duration) {
+	fl, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "no flusher", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.WriteHeader(http.StatusOK)
+
+	emit := func(event string, data map[string]any) {
+		payload, err := json.Marshal(data)
+		if err != nil {
+			panic(fmt.Sprintf("fakeprovider: marshal %s: %v", event, err))
+		}
+		_, _ = fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event, payload)
+		fl.Flush()
+	}
+
+	emit("message_start", map[string]any{
+		"type": "message_start",
+		"message": map[string]any{
+			"id": "msg_perf", "type": "message", "role": "assistant",
+			"model": model, "content": []any{},
+			"stop_reason": nil, "stop_sequence": nil,
+			"usage": map[string]any{"input_tokens": 1, "output_tokens": 1},
+		},
+	})
+	emit("content_block_start", map[string]any{
+		"type": "content_block_start", "index": 0,
+		"content_block": map[string]any{"type": "text", "text": ""},
+	})
+	for i, c := range chunks {
+		if interval > 0 && i > 0 {
+			time.Sleep(interval)
+		}
+		emit("content_block_delta", map[string]any{
+			"type": "content_block_delta", "index": 0,
+			"delta": map[string]any{"type": "text_delta", "text": c},
+		})
+	}
+	emit("content_block_stop", map[string]any{"type": "content_block_stop", "index": 0})
+	emit("message_delta", map[string]any{
+		"type":  "message_delta",
+		"delta": map[string]any{"stop_reason": "end_turn", "stop_sequence": nil},
+		"usage": map[string]any{"output_tokens": 5},
+	})
+	emit("message_stop", map[string]any{"type": "message_stop"})
+}
+
+// streamChunkTexts builds the deterministic word-sized deltas for a streamed
+// reply. Every 150th chunk opens or closes a code fence so the answer exercises
+// markdown block splitting and syntax highlighting, and the final chunk carries
+// the sentinel the harness polls for.
+func streamChunkTexts(nonce string) []string {
+	words := strings.Fields("the quick brown fox jumps over the lazy dog while " +
+		"parsing markdown blocks and rendering code fences under streaming load")
+	n := streamChunks()
+	chunks := make([]string, 0, n)
+	inFence := false
+	for i := 0; i < n-1; i++ {
+		switch {
+		case i%150 == 149:
+			if inFence {
+				chunks = append(chunks, "\n```\n\n")
+			} else {
+				chunks = append(chunks, "\n\n```go\nfunc perf() {\n")
+			}
+			inFence = !inFence
+		case inFence:
+			chunks = append(chunks, fmt.Sprintf("\tx%d := %d\n", i, i))
+		default:
+			chunks = append(chunks, words[i%len(words)]+" ")
+		}
+	}
+	tail := "\n\nEND-OF-STREAM " + nonce
+	if inFence {
+		tail = "\n```" + tail
+	}
+	chunks = append(chunks, tail)
+	return chunks
+}
+
+// seedReply is the fixed assistant turn used to build the long-history
+// fixture: representative markdown (heading, list, code block, prose) so the
+// transcript renders realistic bubbles.
+const seedReply = `Here is a summary of the requested change.
+
+## What happened
+
+The build pipeline was updated to cache dependencies between runs, which
+reduces cold-start time significantly for the common case.
+
+- cache key derived from the lockfile hash
+- fallback to the previous key on miss
+- pruned automatically after seven days
+
+` + "```go" + `
+func cacheKey(lock []byte) string {
+	sum := sha256.Sum256(lock)
+	return "deps-" + hex.EncodeToString(sum[:8])
+}
+` + "```" + `
+
+Verification: three consecutive CI runs hit the cache and completed in under
+two minutes each. No further action is needed on this item.`

--- a/test/perf/metrics.js
+++ b/test/perf/metrics.js
@@ -132,10 +132,15 @@
     // until it stops growing.
     scrollTopOnce() {
       if (!this._scrollEl || !this._scrollEl.isConnected) {
-        const els = [...document.querySelectorAll("div")].filter(
-          (d) =>
-            d.scrollHeight > d.clientHeight + 200 && d.textContent.includes("cache key derived"),
+        const named = [...document.querySelectorAll(".stella-transcript-scroll")].filter(
+          (d) => d.scrollHeight > d.clientHeight,
         );
+        const els = named.length
+          ? named
+          : [...document.querySelectorAll("div")].filter(
+              (d) =>
+                d.scrollHeight > d.clientHeight + 200 && d.textContent.includes("cache key derived"),
+            );
         els.sort((a, b) => b.scrollHeight - a.scrollHeight);
         this._scrollEl = els[0] || null;
       }
@@ -148,6 +153,41 @@
       if (!this._scrollEl) return "no-el";
       this._scrollEl.scrollTop = this._scrollEl.scrollHeight;
       return "bottom";
+    },
+
+    // Navigation + paint timings for the current page load, plus aggregates
+    // over resource-timing entries whose URL contains `pattern` (e.g. the
+    // paged /messages fetches or file-content image reads). All values are ms
+    // since navigation start, read passively after the page settles.
+    navStats(pattern) {
+      const nav = performance.getEntriesByType("navigation")[0];
+      const fcp = performance
+        .getEntriesByType("paint")
+        .find((p) => p.name === "first-contentful-paint");
+      const res = performance
+        .getEntriesByType("resource")
+        .filter((r) => r.name.includes(pattern));
+      const ends = res.map((r) => r.responseEnd);
+      const durs = res.map((r) => r.duration);
+      return {
+        fcpMs: fcp ? +fcp.startTime.toFixed(0) : null,
+        dclMs: nav ? +nav.domContentLoadedEventEnd.toFixed(0) : null,
+        resCount: res.length,
+        resTotalKB: +(res.reduce((s, r) => s + (r.transferSize || 0), 0) / 1024).toFixed(0),
+        resLastEndMs: ends.length ? +Math.max(...ends).toFixed(0) : null,
+        resAvgMs: durs.length ? +(durs.reduce((a, b) => a + b, 0) / durs.length).toFixed(0) : null,
+        resMaxMs: durs.length ? +Math.max(...durs).toFixed(0) : null,
+      };
+    },
+
+    // Lazy-image progress: how many transcript file-content images have
+    // finished decoding vs how many are mounted.
+    imgProgress() {
+      const imgs = [...document.images].filter((i) => i.src.includes("file-content"));
+      return {
+        total: imgs.length,
+        loaded: imgs.filter((i) => i.complete && i.naturalWidth > 0).length,
+      };
     },
   };
 

--- a/test/perf/metrics.js
+++ b/test/perf/metrics.js
@@ -121,7 +121,9 @@
     },
 
     streamDone(sentinel) {
-      return document.body.innerText.includes(sentinel);
+      // textContent, not innerText: content-visibility:auto rows are excluded
+      // from innerText while off-screen.
+      return document.body.textContent.includes(sentinel);
     },
 
     // Finds the transcript's scroll container (largest scrollable div that
@@ -131,7 +133,8 @@
     scrollTopOnce() {
       if (!this._scrollEl || !this._scrollEl.isConnected) {
         const els = [...document.querySelectorAll("div")].filter(
-          (d) => d.scrollHeight > d.clientHeight + 200 && d.innerText.includes("cache key derived"),
+          (d) =>
+            d.scrollHeight > d.clientHeight + 200 && d.textContent.includes("cache key derived"),
         );
         els.sort((a, b) => b.scrollHeight - a.scrollHeight);
         this._scrollEl = els[0] || null;

--- a/test/perf/metrics.js
+++ b/test/perf/metrics.js
@@ -1,0 +1,153 @@
+// Injected into the page by test/perf/run.sh (via `tap browser evaluate`).
+// Installs window.__perf: frame/long-task collectors plus scenario helpers.
+// Everything returns plain JSON-serializable objects.
+(() => {
+  if (window.__perf) return "already-installed";
+
+  const perf = {
+    frames: [],
+    longTasks: [],
+    t0: 0,
+    rafId: 0,
+    obs: null,
+
+    start() {
+      this.frames = [];
+      this.longTasks = [];
+      this.t0 = performance.now();
+      let last = this.t0;
+      const tick = (now) => {
+        this.frames.push(now - last);
+        last = now;
+        this.rafId = requestAnimationFrame(tick);
+      };
+      this.rafId = requestAnimationFrame(tick);
+      this.obs = new PerformanceObserver((list) => {
+        for (const e of list.getEntries()) this.longTasks.push(e.duration);
+      });
+      this.obs.observe({ type: "longtask" });
+      return "started";
+    },
+
+    stop() {
+      cancelAnimationFrame(this.rafId);
+      if (this.obs) this.obs.disconnect();
+      const dur = performance.now() - this.t0;
+      const fr = this.frames.slice(1); // drop the first interval (raf warmup)
+      const sorted = [...fr].sort((a, b) => a - b);
+      const p = (q) => (sorted.length ? sorted[Math.min(sorted.length - 1, Math.floor(q * sorted.length))] : 0);
+      const lt = this.longTasks;
+      return {
+        durationMs: Math.round(dur),
+        frames: fr.length,
+        avgFrameMs: fr.length ? +(fr.reduce((a, b) => a + b, 0) / fr.length).toFixed(2) : 0,
+        p95FrameMs: +p(0.95).toFixed(2),
+        maxFrameMs: fr.length ? +Math.max(...fr).toFixed(2) : 0,
+        jankFramesPct: fr.length ? +((fr.filter((f) => f > 33.4).length / fr.length) * 100).toFixed(1) : 0,
+        longTasks: lt.length,
+        longTaskTotalMs: Math.round(lt.reduce((a, b) => a + b, 0)),
+        longTaskMaxMs: Math.round(lt.length ? Math.max(...lt) : 0),
+      };
+    },
+
+    // Buffered long tasks since navigation — used by the load scenario, where
+    // injection necessarily happens after the work being measured.
+    loadStats() {
+      const nav = performance.getEntriesByType("navigation")[0];
+      const o = new PerformanceObserver(() => {});
+      o.observe({ type: "longtask", buffered: true });
+      const lt = o.takeRecords();
+      o.disconnect();
+      return {
+        domNodes: document.querySelectorAll("*").length,
+        domContentLoadedMs: nav ? Math.round(nav.domContentLoadedEventEnd - nav.startTime) : -1,
+        sinceNavMs: Math.round(performance.now()),
+        bufferedLongTasks: lt.length,
+        bufferedLongTaskTotalMs: Math.round(lt.reduce((a, e) => a + e.duration, 0)),
+        jsHeapMB: performance.memory ? +(performance.memory.usedJSHeapSize / 1048576).toFixed(1) : -1,
+      };
+    },
+
+    // Synthetic typing: per-keystroke synchronous cost. React flushes discrete
+    // input events synchronously, so the dispatch duration approximates the
+    // keystroke-to-commit handler cost.
+    typeInto(selector, text) {
+      const el = document.querySelector(selector);
+      if (!el) return { error: "no element for " + selector };
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLTextAreaElement.prototype, "value").set;
+      el.focus();
+      const times = [];
+      let val = el.value;
+      for (const ch of text) {
+        val += ch;
+        const t = performance.now();
+        setter.call(el, val);
+        el.dispatchEvent(new InputEvent("input", { bubbles: true, data: ch, inputType: "insertText" }));
+        times.push(performance.now() - t);
+      }
+      const sorted = [...times].sort((a, b) => a - b);
+      const p = (q) => sorted[Math.min(sorted.length - 1, Math.floor(q * sorted.length))];
+      return {
+        keys: times.length,
+        avgKeyMs: +(times.reduce((a, b) => a + b, 0) / times.length).toFixed(2),
+        p95KeyMs: +p(0.95).toFixed(2),
+        maxKeyMs: +Math.max(...times).toFixed(2),
+      };
+    },
+
+    clearComposer(selector) {
+      const el = document.querySelector(selector);
+      if (!el) return { error: "no element for " + selector };
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLTextAreaElement.prototype, "value").set;
+      setter.call(el, "");
+      el.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "deleteContentBackward" }));
+      return "cleared";
+    },
+
+    // Sets the composer text and presses Enter — the UI-path send that drives
+    // useChat streaming.
+    send(selector, text) {
+      const el = document.querySelector(selector);
+      if (!el) return { error: "no element for " + selector };
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLTextAreaElement.prototype, "value").set;
+      el.focus();
+      setter.call(el, text);
+      el.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText" }));
+      el.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Enter", code: "Enter" }));
+      return "sent";
+    },
+
+    streamDone(sentinel) {
+      return document.body.innerText.includes(sentinel);
+    },
+
+    // Finds the transcript's scroll container (largest scrollable div that
+    // contains the seeded reply text) and scrolls it to top, triggering
+    // load-older pagination. Returns scrollHeight so the caller can loop
+    // until it stops growing.
+    scrollTopOnce() {
+      if (!this._scrollEl || !this._scrollEl.isConnected) {
+        const els = [...document.querySelectorAll("div")].filter(
+          (d) => d.scrollHeight > d.clientHeight + 200 && d.innerText.includes("cache key derived"),
+        );
+        els.sort((a, b) => b.scrollHeight - a.scrollHeight);
+        this._scrollEl = els[0] || null;
+      }
+      if (!this._scrollEl) return { error: "no scroll container" };
+      this._scrollEl.scrollTop = 0;
+      return { scrollHeight: this._scrollEl.scrollHeight };
+    },
+
+    scrollBottom() {
+      if (!this._scrollEl) return "no-el";
+      this._scrollEl.scrollTop = this._scrollEl.scrollHeight;
+      return "bottom";
+    },
+  };
+
+  window.__perf = perf;
+  return "installed";
+})();

--- a/test/perf/results/.gitignore
+++ b/test/perf/results/.gitignore
@@ -1,3 +1,4 @@
 *.json
 !.gitignore
 !baseline.json
+!phase1.json

--- a/test/perf/results/.gitignore
+++ b/test/perf/results/.gitignore
@@ -2,3 +2,4 @@
 !.gitignore
 !baseline.json
 !phase1.json
+!phase2.json

--- a/test/perf/results/.gitignore
+++ b/test/perf/results/.gitignore
@@ -1,0 +1,3 @@
+*.json
+!.gitignore
+!baseline.json

--- a/test/perf/results/.gitignore
+++ b/test/perf/results/.gitignore
@@ -3,3 +3,4 @@
 !baseline.json
 !phase1.json
 !phase2.json
+!phase3.json

--- a/test/perf/results/.gitignore
+++ b/test/perf/results/.gitignore
@@ -4,3 +4,5 @@
 !phase1.json
 !phase2.json
 !phase3.json
+!load-phase3.json
+!load-phase4.json

--- a/test/perf/results/baseline.json
+++ b/test/perf/results/baseline.json
@@ -1,0 +1,143 @@
+{
+  "label": "baseline",
+  "date": "2026-07-31T03:31:27Z",
+  "commit": "e25d52f6",
+  "reps": 5,
+  "runs": [
+    {
+      "longHistory": {
+        "domNodes": 5953,
+        "domContentLoadedMs": 45,
+        "sinceNavMs": 7104,
+        "bufferedLongTasks": 0,
+        "bufferedLongTaskTotalMs": 0,
+        "jsHeapMB": 73.8
+      },
+      "streaming": {
+        "durationMs": 17557,
+        "frames": 1381,
+        "avgFrameMs": 12.71,
+        "p95FrameMs": 25,
+        "maxFrameMs": 59.2,
+        "jankFramesPct": 0.5,
+        "longTasks": 0,
+        "longTaskTotalMs": 0,
+        "longTaskMaxMs": 0
+      },
+      "typing": {
+        "keys": 120,
+        "avgKeyMs": 10.11,
+        "p95KeyMs": 11.1,
+        "maxKeyMs": 20.7
+      }
+    },
+    {
+      "longHistory": {
+        "domNodes": 7557,
+        "domContentLoadedMs": 49,
+        "sinceNavMs": 8134,
+        "bufferedLongTasks": 0,
+        "bufferedLongTaskTotalMs": 0,
+        "jsHeapMB": 60.1
+      },
+      "streaming": {
+        "durationMs": 17576,
+        "frames": 1220,
+        "avgFrameMs": 14.4,
+        "p95FrameMs": 25.1,
+        "maxFrameMs": 42.6,
+        "jankFramesPct": 0.7,
+        "longTasks": 0,
+        "longTaskTotalMs": 0,
+        "longTaskMaxMs": 0
+      },
+      "typing": {
+        "keys": 120,
+        "avgKeyMs": 10.88,
+        "p95KeyMs": 12.4,
+        "maxKeyMs": 21.8
+      }
+    },
+    {
+      "longHistory": {
+        "domNodes": 9161,
+        "domContentLoadedMs": 55,
+        "sinceNavMs": 8161,
+        "bufferedLongTasks": 0,
+        "bufferedLongTaskTotalMs": 0,
+        "jsHeapMB": 82.2
+      },
+      "streaming": {
+        "durationMs": 17620,
+        "frames": 1338,
+        "avgFrameMs": 13.17,
+        "p95FrameMs": 25.1,
+        "maxFrameMs": 42,
+        "jankFramesPct": 0.8,
+        "longTasks": 0,
+        "longTaskTotalMs": 0,
+        "longTaskMaxMs": 0
+      },
+      "typing": {
+        "keys": 120,
+        "avgKeyMs": 10.34,
+        "p95KeyMs": 11.3,
+        "maxKeyMs": 25.2
+      }
+    },
+    {
+      "longHistory": {
+        "domNodes": 10765,
+        "domContentLoadedMs": 51,
+        "sinceNavMs": 8133,
+        "bufferedLongTasks": 0,
+        "bufferedLongTaskTotalMs": 0,
+        "jsHeapMB": 62
+      },
+      "streaming": {
+        "durationMs": 16939,
+        "frames": 1538,
+        "avgFrameMs": 11.02,
+        "p95FrameMs": 17.6,
+        "maxFrameMs": 41.7,
+        "jankFramesPct": 0.2,
+        "longTasks": 0,
+        "longTaskTotalMs": 0,
+        "longTaskMaxMs": 0
+      },
+      "typing": {
+        "keys": 120,
+        "avgKeyMs": 10.66,
+        "p95KeyMs": 11.6,
+        "maxKeyMs": 21.7
+      }
+    },
+    {
+      "longHistory": {
+        "domNodes": 12369,
+        "domContentLoadedMs": 54,
+        "sinceNavMs": 7728,
+        "bufferedLongTasks": 1,
+        "bufferedLongTaskTotalMs": 54,
+        "jsHeapMB": 62.9
+      },
+      "streaming": {
+        "durationMs": 16984,
+        "frames": 1525,
+        "avgFrameMs": 11.14,
+        "p95FrameMs": 24.2,
+        "maxFrameMs": 41.7,
+        "jankFramesPct": 0.1,
+        "longTasks": 0,
+        "longTaskTotalMs": 0,
+        "longTaskMaxMs": 0
+      },
+      "typing": {
+        "keys": 120,
+        "avgKeyMs": 10.37,
+        "p95KeyMs": 11.6,
+        "maxKeyMs": 18.2
+      }
+    }
+  ]
+}

--- a/test/perf/results/load-phase3.json
+++ b/test/perf/results/load-phase3.json
@@ -1,0 +1,99 @@
+{
+  "label": "phase3",
+  "date": "2026-07-31T04:33:50Z",
+  "commit": "4e9c175c",
+  "huge_turns": 500,
+  "img_count": 10,
+  "runs": [
+    {
+      "hugeLoad": {
+        "fcpMs": 96,
+        "dclMs": 44,
+        "resCount": 2,
+        "resTotalKB": 45,
+        "resLastEndMs": 133,
+        "resAvgMs": 3,
+        "resMaxMs": 3,
+        "domNodes": 29153,
+        "domContentLoadedMs": 44,
+        "sinceNavMs": 2242,
+        "bufferedLongTasks": 0,
+        "bufferedLongTaskTotalMs": 0,
+        "jsHeapMB": 75.3,
+        "fullMountMs": 8679
+      },
+      "filesLoad": {
+        "fcpMs": 96,
+        "dclMs": 41,
+        "resCount": 10,
+        "resTotalKB": 18763,
+        "resLastEndMs": 170,
+        "resAvgMs": 21,
+        "resMaxMs": 27,
+        "total": 10,
+        "loaded": 10,
+        "settleMs": 189
+      }
+    },
+    {
+      "hugeLoad": {
+        "fcpMs": 88,
+        "dclMs": 40,
+        "resCount": 2,
+        "resTotalKB": 45,
+        "resLastEndMs": 124,
+        "resAvgMs": 2,
+        "resMaxMs": 3,
+        "domNodes": 29153,
+        "domContentLoadedMs": 40,
+        "sinceNavMs": 2187,
+        "bufferedLongTasks": 0,
+        "bufferedLongTaskTotalMs": 0,
+        "jsHeapMB": 197.3,
+        "fullMountMs": 8563
+      },
+      "filesLoad": {
+        "fcpMs": 100,
+        "dclMs": 46,
+        "resCount": 10,
+        "resTotalKB": 18763,
+        "resLastEndMs": 181,
+        "resAvgMs": 16,
+        "resMaxMs": 19,
+        "total": 10,
+        "loaded": 10,
+        "settleMs": 198
+      }
+    },
+    {
+      "hugeLoad": {
+        "fcpMs": 96,
+        "dclMs": 42,
+        "resCount": 2,
+        "resTotalKB": 45,
+        "resLastEndMs": 132,
+        "resAvgMs": 3,
+        "resMaxMs": 3,
+        "domNodes": 29153,
+        "domContentLoadedMs": 42,
+        "sinceNavMs": 2237,
+        "bufferedLongTasks": 0,
+        "bufferedLongTaskTotalMs": 0,
+        "jsHeapMB": 235.4,
+        "fullMountMs": 8670
+      },
+      "filesLoad": {
+        "fcpMs": 96,
+        "dclMs": 40,
+        "resCount": 10,
+        "resTotalKB": 18763,
+        "resLastEndMs": 180,
+        "resAvgMs": 21,
+        "resMaxMs": 25,
+        "total": 10,
+        "loaded": 10,
+        "settleMs": 200
+      }
+    }
+  ]
+}

--- a/test/perf/results/load-phase4.json
+++ b/test/perf/results/load-phase4.json
@@ -1,0 +1,99 @@
+{
+  "label": "phase4",
+  "date": "2026-07-31T04:38:12Z",
+  "commit": "4e9c175c",
+  "huge_turns": 500,
+  "img_count": 10,
+  "runs": [
+    {
+      "hugeLoad": {
+        "fcpMs": 108,
+        "dclMs": 49,
+        "resCount": 2,
+        "resTotalKB": 45,
+        "resLastEndMs": 186,
+        "resAvgMs": 4,
+        "resMaxMs": 4,
+        "domNodes": 29153,
+        "domContentLoadedMs": 49,
+        "sinceNavMs": 2285,
+        "bufferedLongTasks": 1,
+        "bufferedLongTaskTotalMs": 54,
+        "jsHeapMB": 181.8,
+        "fullMountMs": 8676
+      },
+      "filesLoad": {
+        "fcpMs": 92,
+        "dclMs": 40,
+        "resCount": 10,
+        "resTotalKB": 7507,
+        "resLastEndMs": 162,
+        "resAvgMs": 6,
+        "resMaxMs": 10,
+        "total": 10,
+        "loaded": 10,
+        "settleMs": 179
+      }
+    },
+    {
+      "hugeLoad": {
+        "fcpMs": 88,
+        "dclMs": 39,
+        "resCount": 2,
+        "resTotalKB": 45,
+        "resLastEndMs": 136,
+        "resAvgMs": 3,
+        "resMaxMs": 4,
+        "domNodes": 29153,
+        "domContentLoadedMs": 39,
+        "sinceNavMs": 2203,
+        "bufferedLongTasks": 0,
+        "bufferedLongTaskTotalMs": 0,
+        "jsHeapMB": 297.8,
+        "fullMountMs": 8588
+      },
+      "filesLoad": {
+        "fcpMs": 92,
+        "dclMs": 41,
+        "resCount": 10,
+        "resTotalKB": 3,
+        "resLastEndMs": 88,
+        "resAvgMs": 5,
+        "resMaxMs": 9,
+        "total": 10,
+        "loaded": 10,
+        "settleMs": 169
+      }
+    },
+    {
+      "hugeLoad": {
+        "fcpMs": 92,
+        "dclMs": 40,
+        "resCount": 2,
+        "resTotalKB": 45,
+        "resLastEndMs": 137,
+        "resAvgMs": 2,
+        "resMaxMs": 3,
+        "domNodes": 29153,
+        "domContentLoadedMs": 40,
+        "sinceNavMs": 2199,
+        "bufferedLongTasks": 0,
+        "bufferedLongTaskTotalMs": 0,
+        "jsHeapMB": 383.4,
+        "fullMountMs": 8580
+      },
+      "filesLoad": {
+        "fcpMs": 96,
+        "dclMs": 43,
+        "resCount": 10,
+        "resTotalKB": 3,
+        "resLastEndMs": 90,
+        "resAvgMs": 4,
+        "resMaxMs": 6,
+        "total": 10,
+        "loaded": 10,
+        "settleMs": 175
+      }
+    }
+  ]
+}

--- a/test/perf/results/phase1.json
+++ b/test/perf/results/phase1.json
@@ -1,0 +1,143 @@
+{
+  "label": "phase1",
+  "date": "2026-07-31T03:39:32Z",
+  "commit": "c87b426b",
+  "reps": 5,
+  "runs": [
+    {
+      "longHistory": {
+        "domNodes": 5953,
+        "domContentLoadedMs": 42,
+        "sinceNavMs": 7147,
+        "bufferedLongTasks": 0,
+        "bufferedLongTaskTotalMs": 0,
+        "jsHeapMB": 69.1
+      },
+      "streaming": {
+        "durationMs": 18279,
+        "frames": 2189,
+        "avgFrameMs": 8.35,
+        "p95FrameMs": 9.3,
+        "maxFrameMs": 17.1,
+        "jankFramesPct": 0,
+        "longTasks": 0,
+        "longTaskTotalMs": 0,
+        "longTaskMaxMs": 0
+      },
+      "typing": {
+        "keys": 120,
+        "avgKeyMs": 3.92,
+        "p95KeyMs": 4.8,
+        "maxKeyMs": 13.6
+      }
+    },
+    {
+      "longHistory": {
+        "domNodes": 7557,
+        "domContentLoadedMs": 46,
+        "sinceNavMs": 8063,
+        "bufferedLongTasks": 0,
+        "bufferedLongTaskTotalMs": 0,
+        "jsHeapMB": 95.9
+      },
+      "streaming": {
+        "durationMs": 18280,
+        "frames": 2191,
+        "avgFrameMs": 8.34,
+        "p95FrameMs": 9.2,
+        "maxFrameMs": 24.1,
+        "jankFramesPct": 0,
+        "longTasks": 0,
+        "longTaskTotalMs": 0,
+        "longTaskMaxMs": 0
+      },
+      "typing": {
+        "keys": 120,
+        "avgKeyMs": 3.92,
+        "p95KeyMs": 5.4,
+        "maxKeyMs": 9.4
+      }
+    },
+    {
+      "longHistory": {
+        "domNodes": 9161,
+        "domContentLoadedMs": 44,
+        "sinceNavMs": 8093,
+        "bufferedLongTasks": 0,
+        "bufferedLongTaskTotalMs": 0,
+        "jsHeapMB": 96
+      },
+      "streaming": {
+        "durationMs": 18274,
+        "frames": 2189,
+        "avgFrameMs": 8.35,
+        "p95FrameMs": 9.2,
+        "maxFrameMs": 25.4,
+        "jankFramesPct": 0,
+        "longTasks": 0,
+        "longTaskTotalMs": 0,
+        "longTaskMaxMs": 0
+      },
+      "typing": {
+        "keys": 120,
+        "avgKeyMs": 3.81,
+        "p95KeyMs": 4.7,
+        "maxKeyMs": 7.7
+      }
+    },
+    {
+      "longHistory": {
+        "domNodes": 10765,
+        "domContentLoadedMs": 44,
+        "sinceNavMs": 8174,
+        "bufferedLongTasks": 0,
+        "bufferedLongTaskTotalMs": 0,
+        "jsHeapMB": 82.7
+      },
+      "streaming": {
+        "durationMs": 18290,
+        "frames": 2192,
+        "avgFrameMs": 8.34,
+        "p95FrameMs": 9.2,
+        "maxFrameMs": 25.8,
+        "jankFramesPct": 0,
+        "longTasks": 0,
+        "longTaskTotalMs": 0,
+        "longTaskMaxMs": 0
+      },
+      "typing": {
+        "keys": 120,
+        "avgKeyMs": 4.17,
+        "p95KeyMs": 7,
+        "maxKeyMs": 9.5
+      }
+    },
+    {
+      "longHistory": {
+        "domNodes": 12369,
+        "domContentLoadedMs": 45,
+        "sinceNavMs": 8243,
+        "bufferedLongTasks": 1,
+        "bufferedLongTaskTotalMs": 61,
+        "jsHeapMB": 65.1
+      },
+      "streaming": {
+        "durationMs": 18295,
+        "frames": 2193,
+        "avgFrameMs": 8.34,
+        "p95FrameMs": 9.3,
+        "maxFrameMs": 16.6,
+        "jankFramesPct": 0,
+        "longTasks": 0,
+        "longTaskTotalMs": 0,
+        "longTaskMaxMs": 0
+      },
+      "typing": {
+        "keys": 120,
+        "avgKeyMs": 4.02,
+        "p95KeyMs": 5.2,
+        "maxKeyMs": 8.7
+      }
+    }
+  ]
+}

--- a/test/perf/results/phase2.json
+++ b/test/perf/results/phase2.json
@@ -1,0 +1,143 @@
+{
+  "label": "phase2",
+  "date": "2026-07-31T04:01:23Z",
+  "commit": "d0356669",
+  "reps": 5,
+  "runs": [
+    {
+      "longHistory": {
+        "domNodes": 5953,
+        "domContentLoadedMs": 74,
+        "sinceNavMs": 7453,
+        "bufferedLongTasks": 1,
+        "bufferedLongTaskTotalMs": 53,
+        "jsHeapMB": 64.1
+      },
+      "streaming": {
+        "durationMs": 18433,
+        "frames": 2206,
+        "avgFrameMs": 8.36,
+        "p95FrameMs": 9.2,
+        "maxFrameMs": 17.3,
+        "jankFramesPct": 0,
+        "longTasks": 0,
+        "longTaskTotalMs": 0,
+        "longTaskMaxMs": 0
+      },
+      "typing": {
+        "keys": 120,
+        "avgKeyMs": 8.04,
+        "p95KeyMs": 9.8,
+        "maxKeyMs": 15.9
+      }
+    },
+    {
+      "longHistory": {
+        "domNodes": 7557,
+        "domContentLoadedMs": 86,
+        "sinceNavMs": 8672,
+        "bufferedLongTasks": 1,
+        "bufferedLongTaskTotalMs": 50,
+        "jsHeapMB": 86.2
+      },
+      "streaming": {
+        "durationMs": 18332,
+        "frames": 2198,
+        "avgFrameMs": 8.34,
+        "p95FrameMs": 9.1,
+        "maxFrameMs": 17.2,
+        "jankFramesPct": 0,
+        "longTasks": 0,
+        "longTaskTotalMs": 0,
+        "longTaskMaxMs": 0
+      },
+      "typing": {
+        "keys": 120,
+        "avgKeyMs": 3.69,
+        "p95KeyMs": 5.1,
+        "maxKeyMs": 9.3
+      }
+    },
+    {
+      "longHistory": {
+        "domNodes": 9161,
+        "domContentLoadedMs": 46,
+        "sinceNavMs": 8097,
+        "bufferedLongTasks": 0,
+        "bufferedLongTaskTotalMs": 0,
+        "jsHeapMB": 88.6
+      },
+      "streaming": {
+        "durationMs": 18278,
+        "frames": 2192,
+        "avgFrameMs": 8.34,
+        "p95FrameMs": 9.2,
+        "maxFrameMs": 16.7,
+        "jankFramesPct": 0,
+        "longTasks": 0,
+        "longTaskTotalMs": 0,
+        "longTaskMaxMs": 0
+      },
+      "typing": {
+        "keys": 120,
+        "avgKeyMs": 3.73,
+        "p95KeyMs": 5,
+        "maxKeyMs": 12.8
+      }
+    },
+    {
+      "longHistory": {
+        "domNodes": 10766,
+        "domContentLoadedMs": 47,
+        "sinceNavMs": 9001,
+        "bufferedLongTasks": 0,
+        "bufferedLongTaskTotalMs": 0,
+        "jsHeapMB": 52.4
+      },
+      "streaming": {
+        "durationMs": 18297,
+        "frames": 2192,
+        "avgFrameMs": 8.34,
+        "p95FrameMs": 9.2,
+        "maxFrameMs": 25.1,
+        "jankFramesPct": 0,
+        "longTasks": 0,
+        "longTaskTotalMs": 0,
+        "longTaskMaxMs": 0
+      },
+      "typing": {
+        "keys": 120,
+        "avgKeyMs": 4.01,
+        "p95KeyMs": 5.6,
+        "maxKeyMs": 9.5
+      }
+    },
+    {
+      "longHistory": {
+        "domNodes": 12369,
+        "domContentLoadedMs": 47,
+        "sinceNavMs": 7715,
+        "bufferedLongTasks": 1,
+        "bufferedLongTaskTotalMs": 56,
+        "jsHeapMB": 79.6
+      },
+      "streaming": {
+        "durationMs": 18286,
+        "frames": 2193,
+        "avgFrameMs": 8.34,
+        "p95FrameMs": 9.2,
+        "maxFrameMs": 17.3,
+        "jankFramesPct": 0,
+        "longTasks": 0,
+        "longTaskTotalMs": 0,
+        "longTaskMaxMs": 0
+      },
+      "typing": {
+        "keys": 120,
+        "avgKeyMs": 4.03,
+        "p95KeyMs": 5.4,
+        "maxKeyMs": 14.1
+      }
+    }
+  ]
+}

--- a/test/perf/results/phase3.json
+++ b/test/perf/results/phase3.json
@@ -1,0 +1,143 @@
+{
+  "label": "phase3",
+  "date": "2026-07-31T04:17:05Z",
+  "commit": "1defa924",
+  "reps": 5,
+  "runs": [
+    {
+      "longHistory": {
+        "domNodes": 5953,
+        "domContentLoadedMs": 44,
+        "sinceNavMs": 3909,
+        "bufferedLongTasks": 0,
+        "bufferedLongTaskTotalMs": 0,
+        "jsHeapMB": 84.7
+      },
+      "streaming": {
+        "durationMs": 18303,
+        "frames": 2196,
+        "avgFrameMs": 8.34,
+        "p95FrameMs": 10.1,
+        "maxFrameMs": 16.1,
+        "jankFramesPct": 0,
+        "longTasks": 0,
+        "longTaskTotalMs": 0,
+        "longTaskMaxMs": 0
+      },
+      "typing": {
+        "keys": 120,
+        "avgKeyMs": 0.62,
+        "p95KeyMs": 0.8,
+        "maxKeyMs": 1.3
+      }
+    },
+    {
+      "longHistory": {
+        "domNodes": 7557,
+        "domContentLoadedMs": 42,
+        "sinceNavMs": 4962,
+        "bufferedLongTasks": 1,
+        "bufferedLongTaskTotalMs": 119,
+        "jsHeapMB": 120.5
+      },
+      "streaming": {
+        "durationMs": 18333,
+        "frames": 2200,
+        "avgFrameMs": 8.33,
+        "p95FrameMs": 10.1,
+        "maxFrameMs": 10.4,
+        "jankFramesPct": 0,
+        "longTasks": 0,
+        "longTaskTotalMs": 0,
+        "longTaskMaxMs": 0
+      },
+      "typing": {
+        "keys": 120,
+        "avgKeyMs": 0.67,
+        "p95KeyMs": 0.9,
+        "maxKeyMs": 1.4
+      }
+    },
+    {
+      "longHistory": {
+        "domNodes": 9161,
+        "domContentLoadedMs": 62,
+        "sinceNavMs": 4978,
+        "bufferedLongTasks": 1,
+        "bufferedLongTaskTotalMs": 118,
+        "jsHeapMB": 110.9
+      },
+      "streaming": {
+        "durationMs": 18302,
+        "frames": 2196,
+        "avgFrameMs": 8.34,
+        "p95FrameMs": 10.1,
+        "maxFrameMs": 15.7,
+        "jankFramesPct": 0,
+        "longTasks": 0,
+        "longTaskTotalMs": 0,
+        "longTaskMaxMs": 0
+      },
+      "typing": {
+        "keys": 120,
+        "avgKeyMs": 0.78,
+        "p95KeyMs": 0.9,
+        "maxKeyMs": 1.2
+      }
+    },
+    {
+      "longHistory": {
+        "domNodes": 10765,
+        "domContentLoadedMs": 55,
+        "sinceNavMs": 4991,
+        "bufferedLongTasks": 1,
+        "bufferedLongTaskTotalMs": 127,
+        "jsHeapMB": 101.9
+      },
+      "streaming": {
+        "durationMs": 18312,
+        "frames": 2197,
+        "avgFrameMs": 8.33,
+        "p95FrameMs": 10.1,
+        "maxFrameMs": 10.4,
+        "jankFramesPct": 0,
+        "longTasks": 0,
+        "longTaskTotalMs": 0,
+        "longTaskMaxMs": 0
+      },
+      "typing": {
+        "keys": 120,
+        "avgKeyMs": 0.72,
+        "p95KeyMs": 0.9,
+        "maxKeyMs": 1.3
+      }
+    },
+    {
+      "longHistory": {
+        "domNodes": 12369,
+        "domContentLoadedMs": 52,
+        "sinceNavMs": 4980,
+        "bufferedLongTasks": 1,
+        "bufferedLongTaskTotalMs": 134,
+        "jsHeapMB": 139.1
+      },
+      "streaming": {
+        "durationMs": 18307,
+        "frames": 2196,
+        "avgFrameMs": 8.34,
+        "p95FrameMs": 10.1,
+        "maxFrameMs": 18,
+        "jankFramesPct": 0,
+        "longTasks": 0,
+        "longTaskTotalMs": 0,
+        "longTaskMaxMs": 0
+      },
+      "typing": {
+        "keys": 120,
+        "avgKeyMs": 0.73,
+        "p95KeyMs": 1,
+        "maxKeyMs": 1.3
+      }
+    }
+  ]
+}

--- a/test/perf/run.sh
+++ b/test/perf/run.sh
@@ -173,7 +173,9 @@ open_session() {
   tap browser open "$URL/agents/$agent_id/sessions/$session_id" >/dev/null
   # Wait until the transcript has content (seeded replies mention "cache").
   for _ in $(seq 1 60); do
-    if ev "document.body.innerText.includes('cache key derived')" | grep -q true; then return; fi
+    # textContent, not innerText: rows use content-visibility:auto, and Chrome
+    # excludes skipped (off-screen) content from innerText.
+    if ev "document.body.textContent.includes('cache key derived')" | grep -q true; then return; fi
     sleep 0.5
   done
   die "session transcript did not render"
@@ -188,7 +190,10 @@ load_full_history() {
   for _ in $(seq 1 80); do
     ev "window.__perf.scrollTopOnce()" >/dev/null
     sleep 0.5
-    if ev "/seed turn 1(\\n|\$)/.test(document.body.innerText)" | grep -q true; then
+    # Count turns instead of matching "seed turn 1": textContent has no element
+    # separators, so adjacent digit-leading text (timestamps) merges into the
+    # turn number and any single-turn regex is ambiguous.
+    if ev "(document.body.textContent.match(/seed turn /g)||[]).length >= $SEED_TURNS" | grep -q true; then
       done=1; break
     fi
   done

--- a/test/perf/run.sh
+++ b/test/perf/run.sh
@@ -25,10 +25,16 @@ SRV_PORT="${SRV_PORT:-25911}"
 URL="http://localhost:$SRV_PORT"
 REPS="${REPS:-5}"
 SEED_TURNS="${SEED_TURNS:-100}"
+HUGE_TURNS="${HUGE_TURNS:-500}"
+IMG_COUNT="${IMG_COUNT:-10}"
+PDF_COUNT="${PDF_COUNT:-3}"
+REPS_LOAD="${REPS_LOAD:-3}"
 EMAIL="perf@example.com"
 PASSWORD="perf-admin-pw"
 JAR="$PERF_HOME/cookies.txt"
 FIXTURE="$PERF_HOME/fixture.json"
+FIXTURE_HUGE="$PERF_HOME/fixture-huge.json"
+FIXTURE_FILES="$PERF_HOME/fixture-files.json"
 SENTINEL="END-OF-STREAM"
 TA="textarea"
 
@@ -99,6 +105,32 @@ auth() {
   log "authenticated as $EMAIL"
 }
 
+ensure_agent() { # -> echoes agent_id
+  local pid="perf-fake"
+  api POST /api/providers "{\"id\":\"$pid\",\"type\":\"anthropic\",\"name\":\"$pid\",\"enabled\":true,\"api_key\":\"perf-not-a-secret\",\"base_url\":\"http://127.0.0.1:$FAKE_PORT\"}" >/dev/null 2>&1 \
+    || true
+  local agent_id
+  agent_id=$(api GET /api/agents | jq -r '.agents[]? | select(.name=="perf-agent") | .id' | head -1)
+  if [ -z "$agent_id" ]; then
+    agent_id=$(api POST /api/agents "{\"name\":\"perf-agent\",\"model\":\"$pid/claude-sonnet-4-6\",\"enabled\":true}" | jq -r .id)
+  fi
+  [ -n "$agent_id" ] && [ "$agent_id" != null ] || die "agent create failed"
+  echo "$agent_id"
+}
+
+new_session() { # new_session AGENT_ID -> echoes session_id
+  local session_id
+  session_id=$(api POST "/api/agents/$1/sessions" '{"kind":"chat"}' | jq -r .id)
+  [ -n "$session_id" ] && [ "$session_id" != null ] || die "session create failed"
+  echo "$session_id"
+}
+
+post_turn() { # post_turn AGENT SESSION TEXT — one user message + synchronous fake reply
+  jq -n --arg t "$3" '{parts:[{type:"text",text:$t}]}' \
+    | curl -sf -b "$JAR" -X POST "$URL/api/agents/$1/sessions/$2/messages" \
+        -H "Content-Type: application/json" -d @- >/dev/null
+}
+
 seed_fixture() { # seed_fixture [force] — force reseeds a fresh session
   if [ "${1:-}" = force ]; then
     rm -f "$FIXTURE"
@@ -106,27 +138,86 @@ seed_fixture() { # seed_fixture [force] — force reseeds a fresh session
   if [ -f "$FIXTURE" ]; then
     log "fixture exists: $(cat "$FIXTURE")"; return
   fi
-  local pid="perf-fake"
-  api POST /api/providers "{\"id\":\"$pid\",\"type\":\"anthropic\",\"name\":\"$pid\",\"enabled\":true,\"api_key\":\"perf-not-a-secret\",\"base_url\":\"http://127.0.0.1:$FAKE_PORT\"}" >/dev/null \
-    || log "provider create failed (may already exist)"
   local agent_id session_id
-  agent_id=$(api GET /api/agents | jq -r '.agents[]? | select(.name=="perf-agent") | .id' | head -1)
-  if [ -z "$agent_id" ]; then
-    agent_id=$(api POST /api/agents "{\"name\":\"perf-agent\",\"model\":\"$pid/claude-sonnet-4-6\",\"enabled\":true}" | jq -r .id)
-  fi
-  [ -n "$agent_id" ] && [ "$agent_id" != null ] || die "agent create failed"
-  session_id=$(api POST "/api/agents/$agent_id/sessions" '{"kind":"chat"}' | jq -r .id)
-  [ -n "$session_id" ] && [ "$session_id" != null ] || die "session create failed"
+  agent_id=$(ensure_agent)
+  session_id=$(new_session "$agent_id")
   log "seeding $SEED_TURNS turns into session $session_id ..."
   for i in $(seq 1 "$SEED_TURNS"); do
-    curl -sf -b "$JAR" -X POST "$URL/api/agents/$agent_id/sessions/$session_id/messages" \
-      -H "Content-Type: application/json" \
-      -d "{\"parts\":[{\"type\":\"text\",\"text\":\"seed turn $i\"}]}" >/dev/null \
-      || die "seed turn $i failed"
+    post_turn "$agent_id" "$session_id" "seed turn $i" || die "seed turn $i failed"
     [ $((i % 20)) -eq 0 ] && log "  seeded $i/$SEED_TURNS"
   done
   jq -n --arg a "$agent_id" --arg s "$session_id" '{agent_id:$a, session_id:$s}' > "$FIXTURE"
   log "fixture ready: $(cat "$FIXTURE")"
+}
+
+# Huge-history fixture: $HUGE_TURNS turns (2x messages). Reused across labels —
+# the load scenarios never mutate the session, so the same data keeps
+# before/after comparable and skips a slow reseed.
+seed_huge_fixture() {
+  if [ -f "$FIXTURE_HUGE" ]; then
+    log "huge fixture exists: $(cat "$FIXTURE_HUGE")"; return
+  fi
+  local agent_id session_id
+  agent_id=$(ensure_agent)
+  session_id=$(new_session "$agent_id")
+  # Sequential on purpose: concurrent turn POSTs to one session race in the
+  # server and silently drop turns (observed: 500 parallel posts -> 250 turns).
+  log "seeding $HUGE_TURNS turns into huge session $session_id ..."
+  local i
+  for i in $(seq 1 "$HUGE_TURNS"); do
+    post_turn "$agent_id" "$session_id" "seed turn $i" || die "huge seed turn $i failed"
+    [ $((i % 50)) -eq 0 ] && log "  seeded $i/$HUGE_TURNS"
+  done
+  jq -n --arg a "$agent_id" --arg s "$session_id" '{agent_id:$a, session_id:$s}' > "$FIXTURE_HUGE"
+  log "huge fixture ready: $(cat "$FIXTURE_HUGE")"
+}
+
+# Files fixture: $IMG_COUNT ~1.9MB noise PNGs + $PDF_COUNT small PDFs uploaded
+# to the session workspace, one user message per file referencing it the same
+# way the composer does ([file: <path>]). Reused across labels.
+seed_files_fixture() {
+  if [ -f "$FIXTURE_FILES" ]; then
+    log "files fixture exists: $(cat "$FIXTURE_FILES")"; return
+  fi
+  local agent_id session_id srcdir
+  agent_id=$(ensure_agent)
+  session_id=$(new_session "$agent_id")
+  srcdir="$PERF_HOME/assets-src"
+  mkdir -p "$srcdir"
+  log "generating + uploading $IMG_COUNT images and $PDF_COUNT pdfs ..."
+  for i in $(seq 1 "$IMG_COUNT"); do
+    [ -f "$srcdir/img-$i.png" ] || python3 - "$srcdir/img-$i.png" <<'PYEOF'
+import os, struct, sys, zlib
+w = h = 800  # random RGB compresses to ~1.9MB: a realistic photo-sized payload
+raw = b"".join(b"\x00" + os.urandom(w * 3) for _ in range(h))
+def chunk(t, d):
+    return struct.pack(">I", len(d)) + t + d + struct.pack(">I", zlib.crc32(t + d) & 0xFFFFFFFF)
+png = (b"\x89PNG\r\n\x1a\n"
+       + chunk(b"IHDR", struct.pack(">IIBBBBB", w, h, 8, 2, 0, 0, 0))
+       + chunk(b"IDAT", zlib.compress(raw, 0))
+       + chunk(b"IEND", b""))
+open(sys.argv[1], "wb").write(png)
+PYEOF
+    local path
+    path=$(curl -sf -b "$JAR" -X POST \
+      "$URL/api/agents/$agent_id/sessions/$session_id/workspace/upload" \
+      -F "file=@$srcdir/img-$i.png" | jq -r .path)
+    [ -n "$path" ] && [ "$path" != null ] || die "image upload $i failed"
+    post_turn "$agent_id" "$session_id" "[file: $path]
+please look at image $i" || die "image message $i failed"
+  done
+  for i in $(seq 1 "$PDF_COUNT"); do
+    [ -f "$srcdir/doc-$i.pdf" ] || printf '%%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]>>endobj\ntrailer<</Root 1 0 R>>\n%%%%EOF\n' > "$srcdir/doc-$i.pdf"
+    local path
+    path=$(curl -sf -b "$JAR" -X POST \
+      "$URL/api/agents/$agent_id/sessions/$session_id/workspace/upload" \
+      -F "file=@$srcdir/doc-$i.pdf" | jq -r .path)
+    [ -n "$path" ] && [ "$path" != null ] || die "pdf upload $i failed"
+    post_turn "$agent_id" "$session_id" "[file: $path]
+please read document $i" || die "pdf message $i failed"
+  done
+  jq -n --arg a "$agent_id" --arg s "$session_id" '{agent_id:$a, session_id:$s}' > "$FIXTURE_FILES"
+  log "files fixture ready: $(cat "$FIXTURE_FILES")"
 }
 
 # ---------------------------------------------------------------- browser
@@ -202,7 +293,58 @@ load_full_history() {
   sleep 0.5
 }
 
+open_fixture() { # open_fixture FIXTURE_FILE READY_JS — fresh navigation, wait until READY_JS is true
+  local agent_id session_id
+  agent_id=$(jq -r .agent_id "$1")
+  session_id=$(jq -r .session_id "$1")
+  tap browser open "$URL/agents/$agent_id/sessions/$session_id" >/dev/null
+  for _ in $(seq 1 120); do
+    if ev "$2" | grep -q true; then return; fi
+    sleep 0.5
+  done
+  die "fixture page did not become ready ($1)"
+}
+
 # ---------------------------------------------------------------- scenarios
+
+# Initial page load of a $HUGE_TURNS-turn session: paint/fetch timings for the
+# first screen, then time-to-full-mount via scroll-up paging.
+scenario_huge_load() {
+  open_fixture "$FIXTURE_HUGE" "document.body.textContent.includes('cache key derived')"
+  sleep 2   # let auto-fill + rendering settle
+  inject_metrics
+  local initial
+  initial=$(ev "JSON.stringify(Object.assign(window.__perf.navStats('/messages'), window.__perf.loadStats()))")
+  local mounted="" i
+  for i in $(seq 1 300); do
+    ev "window.__perf.scrollTopOnce()" >/dev/null
+    sleep 0.3
+    if ev "(document.body.textContent.match(/seed turn /g)||[]).length >= $HUGE_TURNS" | grep -q true; then
+      mounted=$(ev "JSON.stringify({fullMountMs: +performance.now().toFixed(0), domNodes: document.querySelectorAll('*').length})")
+      break
+    fi
+  done
+  [ -n "$mounted" ] || die "huge history never fully mounted"
+  jq -n --argjson a "$(echo "$initial" | jq fromjson)" --argjson b "$(echo "$mounted" | jq fromjson)" '$a + $b'
+}
+
+# Load of a session whose history embeds images + pdf chips: paint timings,
+# per-image network cost, and time until every transcript image is decoded.
+scenario_files_load() {
+  open_fixture "$FIXTURE_FILES" "[...document.images].some(i => i.src.includes('file-content'))"
+  inject_metrics
+  # Walk to the top so lazy images outside the initial viewport get triggered.
+  ev "window.__perf.scrollTopOnce()" >/dev/null
+  local done="" i
+  for i in $(seq 1 240); do
+    if ev "(() => { const p = window.__perf.imgProgress(); return p.total >= $IMG_COUNT && p.loaded >= p.total; })()" | grep -q true; then
+      done=1; break
+    fi
+    sleep 0.5
+  done
+  [ -n "$done" ] || die "transcript images never finished loading"
+  ev "JSON.stringify(Object.assign(window.__perf.navStats('file-content'), window.__perf.imgProgress(), {settleMs: +performance.now().toFixed(0)}))"
+}
 
 scenario_long_history() {
   open_session
@@ -271,6 +413,33 @@ measure() {
   log "wrote $out"
 }
 
+measure_load() { # measure_load LBL -> results/load-LBL.json {hugeLoad, filesLoad} x REPS_LOAD
+  local label="${1:?usage: run.sh measure-load <label>}"
+  command -v jq >/dev/null || die "jq required"
+  auth
+  seed_huge_fixture
+  seed_files_fixture
+  browser_login
+  activate_browser
+  local out="$PERF_DIR/results/load-$label.json"
+  local runs="[]"
+  for rep in $(seq 1 "$REPS_LOAD"); do
+    log "=== load rep $rep/$REPS_LOAD ==="
+    local hg fl
+    hg=$(scenario_huge_load)
+    log "huge-load:  $hg"
+    fl=$(scenario_files_load)
+    log "files-load: $fl"
+    runs=$(jq -n --argjson acc "$runs" --argjson hg "$hg" --argjson fl "$fl" \
+      '$acc + [{hugeLoad:$hg, filesLoad:($fl|fromjson)}]')
+  done
+  jq -n --arg label "$label" --arg date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg commit "$(git -C "$REPO" rev-parse --short HEAD)" \
+    --argjson turns "$HUGE_TURNS" --argjson imgs "$IMG_COUNT" --argjson runs "$runs" \
+    '{label:$label, date:$date, commit:$commit, huge_turns:$turns, img_count:$imgs, runs:$runs}' > "$out"
+  log "wrote $out"
+}
+
 teardown() {
   for f in stellad.pid fakeprovider.pid; do
     if [ -f "$PERF_HOME/$f" ]; then
@@ -284,6 +453,7 @@ teardown() {
 case "${1:-}" in
   setup)    start_fake; start_server; auth; seed_fixture ;;
   measure)  shift; measure "$@" ;;
+  measure-load) shift; measure_load "$@" ;;
   teardown) teardown ;;
-  *) echo "usage: $0 {setup|measure <label>|teardown}"; exit 2 ;;
+  *) echo "usage: $0 {setup|measure <label>|measure-load <label>|teardown}"; exit 2 ;;
 esac

--- a/test/perf/run.sh
+++ b/test/perf/run.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# Chat perf harness: measures the web UI chat under three reproducible
+# scenarios against a scratch stellad + deterministic fake model provider.
+#
+#   long-history : open a ~200-message session; load long tasks, DOM size, heap
+#   streaming    : one paced streamed reply (fakeprovider: N chunks × T ms);
+#                  frame times + long tasks while streaming
+#   typing       : 120 synthetic keystrokes into the composer; per-key cost
+#
+# Usage:
+#   ./test/perf/run.sh setup        # build fake+server, start both, seed fixture
+#   ./test/perf/run.sh measure LBL  # run all scenarios REPS times -> results/LBL.json
+#   ./test/perf/run.sh teardown     # stop scratch server + fakeprovider
+#
+# The scratch instance lives in $PERF_HOME (default ~/.stella-perf) with its own
+# embedded Postgres; it never touches your dev instance. The web UI must be
+# freshly built before `setup` (cd web && vp build) because stellad embeds it.
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+PERF_DIR="$REPO/test/perf"
+PERF_HOME="${PERF_HOME:-$HOME/.stella-perf}"
+FAKE_PORT="${FAKE_PORT:-25901}"
+SRV_PORT="${SRV_PORT:-25911}"
+URL="http://localhost:$SRV_PORT"
+REPS="${REPS:-5}"
+SEED_TURNS="${SEED_TURNS:-100}"
+EMAIL="perf@example.com"
+PASSWORD="perf-admin-pw"
+JAR="$PERF_HOME/cookies.txt"
+FIXTURE="$PERF_HOME/fixture.json"
+SENTINEL="END-OF-STREAM"
+TA="textarea"
+
+log() { echo "[perf] $*" >&2; }
+die() { log "FATAL: $*"; exit 1; }
+
+api() { # api METHOD PATH [JSON]
+  local method="$1" path="$2" body="${3:-}"
+  if [ -n "$body" ]; then
+    curl -sf -b "$JAR" -X "$method" "$URL$path" -H "Content-Type: application/json" -d "$body"
+  else
+    curl -sf -b "$JAR" -X "$method" "$URL$path"
+  fi
+}
+
+ev() { # ev JS -> stdout (tap browser evaluate)
+  tap browser evaluate "$1"
+}
+
+inject_metrics() {
+  ev "$(cat "$PERF_DIR/metrics.js")" >/dev/null
+}
+
+# ---------------------------------------------------------------- setup
+
+start_fake() {
+  if lsof -iTCP:"$FAKE_PORT" -sTCP:LISTEN -n -P >/dev/null 2>&1; then
+    log "fakeprovider already on :$FAKE_PORT"; return
+  fi
+  mkdir -p "$PERF_HOME"
+  (cd "$REPO" && go build -o "$PERF_HOME/fakeprovider" ./test/perf/fakeprovider)
+  nohup "$PERF_HOME/fakeprovider" -port "$FAKE_PORT" >"$PERF_HOME/fakeprovider.log" 2>&1 &
+  echo $! > "$PERF_HOME/fakeprovider.pid"
+  sleep 0.5
+  log "fakeprovider started on :$FAKE_PORT"
+}
+
+start_server() {
+  if lsof -iTCP:"$SRV_PORT" -sTCP:LISTEN -n -P >/dev/null 2>&1; then
+    log "stellad already on :$SRV_PORT"; return
+  fi
+  [ -x "$REPO/dist/bin/stellad" ] || die "dist/bin/stellad missing; run: cd web && vp build && mise run build"
+  # Reuse the dev home's extracted PG runtime if present (binaries only; the
+  # data dir stays under $PERF_HOME/home).
+  local pg_runtime=""
+  pg_runtime=$(find "$HOME/.stella/pg-runtime" -path '*/postgres/bin/pg_ctl' 2>/dev/null \
+    | head -1 | sed 's|/postgres/bin/pg_ctl$||')
+  STELLA_HOME="$PERF_HOME/home" \
+  STELLA_POSTGRES_RUNTIME="${STELLA_POSTGRES_RUNTIME:-$pg_runtime}" \
+  nohup "$REPO/dist/bin/stellad" serve --port "$SRV_PORT" \
+    >"$PERF_HOME/stellad.log" 2>&1 &
+  echo $! > "$PERF_HOME/stellad.pid"
+  for _ in $(seq 1 60); do
+    curl -sf "$URL/readyz" >/dev/null 2>&1 && { log "stellad ready on :$SRV_PORT"; return; }
+    sleep 1
+  done
+  die "stellad did not become ready; see $PERF_HOME/stellad.log"
+}
+
+auth() {
+  mkdir -p "$PERF_HOME"
+  # First registered user is admin; register is a no-op failure if it exists.
+  curl -s -X POST "$URL/api/auth/local/register" -H "Content-Type: application/json" \
+    -d "{\"name\":\"perfadmin\",\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\",\"confirm_password\":\"$PASSWORD\"}" >/dev/null || true
+  curl -sf -c "$JAR" -X POST "$URL/api/auth/local/login" -H "Content-Type: application/json" \
+    -d "{\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\"}" >/dev/null \
+    || die "login failed"
+  log "authenticated as $EMAIL"
+}
+
+seed_fixture() { # seed_fixture [force] — force reseeds a fresh session
+  if [ "${1:-}" = force ]; then
+    rm -f "$FIXTURE"
+  fi
+  if [ -f "$FIXTURE" ]; then
+    log "fixture exists: $(cat "$FIXTURE")"; return
+  fi
+  local pid="perf-fake"
+  api POST /api/providers "{\"id\":\"$pid\",\"type\":\"anthropic\",\"name\":\"$pid\",\"enabled\":true,\"api_key\":\"perf-not-a-secret\",\"base_url\":\"http://127.0.0.1:$FAKE_PORT\"}" >/dev/null \
+    || log "provider create failed (may already exist)"
+  local agent_id session_id
+  agent_id=$(api GET /api/agents | jq -r '.agents[]? | select(.name=="perf-agent") | .id' | head -1)
+  if [ -z "$agent_id" ]; then
+    agent_id=$(api POST /api/agents "{\"name\":\"perf-agent\",\"model\":\"$pid/claude-sonnet-4-6\",\"enabled\":true}" | jq -r .id)
+  fi
+  [ -n "$agent_id" ] && [ "$agent_id" != null ] || die "agent create failed"
+  session_id=$(api POST "/api/agents/$agent_id/sessions" '{"kind":"chat"}' | jq -r .id)
+  [ -n "$session_id" ] && [ "$session_id" != null ] || die "session create failed"
+  log "seeding $SEED_TURNS turns into session $session_id ..."
+  for i in $(seq 1 "$SEED_TURNS"); do
+    curl -sf -b "$JAR" -X POST "$URL/api/agents/$agent_id/sessions/$session_id/messages" \
+      -H "Content-Type: application/json" \
+      -d "{\"parts\":[{\"type\":\"text\",\"text\":\"seed turn $i\"}]}" >/dev/null \
+      || die "seed turn $i failed"
+    [ $((i % 20)) -eq 0 ] && log "  seeded $i/$SEED_TURNS"
+  done
+  jq -n --arg a "$agent_id" --arg s "$session_id" '{agent_id:$a, session_id:$s}' > "$FIXTURE"
+  log "fixture ready: $(cat "$FIXTURE")"
+}
+
+# ---------------------------------------------------------------- browser
+
+# Bring the tap-managed Chrome frontmost: Chrome throttles rAF and rendering
+# in hidden/occluded tabs, which zeroes the frame metrics.
+activate_browser() {
+  local pid
+  pid=$(pgrep -f 'MacOS/Google Chrome .*tap/browser/profiles/default' | head -1)
+  [ -n "$pid" ] || return 0
+  osascript -e "tell application \"System Events\" to set frontmost of (first process whose unix id is $pid) to true" 2>/dev/null || true
+  sleep 0.5
+  ev "document.visibilityState" | grep -q visible \
+    || log "WARNING: page still hidden; frame metrics will be zero"
+}
+
+browser_login() {
+  # --show: measurements are meaningless in a hidden tab (Chrome throttles
+  # rAF, timers, and rendering), so the window must be visible and frontmost.
+  tap browser open "$URL/login" --show >/dev/null
+  sleep 1
+  if ev "location.pathname" | grep -qv login; then
+    log "browser already authenticated"; return
+  fi
+  ev "(() => {
+    const inputs = document.querySelectorAll('input');
+    const set = (el, v) => {
+      const s = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+      s.call(el, v); el.dispatchEvent(new Event('input', { bubbles: true }));
+    };
+    set(inputs[0], '$EMAIL'); set(inputs[1], '$PASSWORD');
+    document.querySelector('form button[type=submit], button[type=submit]').click();
+    return 'submitted';
+  })()" >/dev/null
+  sleep 2
+  ev "location.pathname" | grep -qv login || die "browser login failed"
+  log "browser logged in"
+}
+
+open_session() {
+  local agent_id session_id
+  agent_id=$(jq -r .agent_id "$FIXTURE")
+  session_id=$(jq -r .session_id "$FIXTURE")
+  tap browser open "$URL/agents/$agent_id/sessions/$session_id" >/dev/null
+  # Wait until the transcript has content (seeded replies mention "cache").
+  for _ in $(seq 1 60); do
+    if ev "document.body.innerText.includes('cache key derived')" | grep -q true; then return; fi
+    sleep 0.5
+  done
+  die "session transcript did not render"
+}
+
+# Scroll the transcript to top repeatedly (each scroll loads one older page)
+# until the first seeded turn is mounted, so the full history is in the DOM
+# before measuring.
+load_full_history() {
+  inject_metrics
+  local done=""
+  for _ in $(seq 1 80); do
+    ev "window.__perf.scrollTopOnce()" >/dev/null
+    sleep 0.5
+    if ev "/seed turn 1(\\n|\$)/.test(document.body.innerText)" | grep -q true; then
+      done=1; break
+    fi
+  done
+  [ -n "$done" ] || die "full history did not load (seed turn 1 never appeared)"
+  ev "window.__perf.scrollBottom()" >/dev/null
+  sleep 0.5
+}
+
+# ---------------------------------------------------------------- scenarios
+
+scenario_long_history() {
+  open_session
+  sleep 2   # let auto-fill pagination settle
+  load_full_history
+  ev "JSON.stringify(window.__perf.loadStats())"
+}
+
+scenario_streaming() {
+  inject_metrics
+  local nonce="n$(date +%s)"
+  ev "window.__perf.start()" >/dev/null
+  ev "window.__perf.send('$TA', 'stream $nonce')" >/dev/null
+  local waited=0
+  while [ "$waited" -lt 120 ]; do
+    sleep 2; waited=$((waited + 2))
+    if ev "window.__perf.streamDone('$SENTINEL $nonce')" | grep -q true; then
+      ev "JSON.stringify(window.__perf.stop())"
+      return
+    fi
+  done
+  die "stream did not finish in 120s"
+}
+
+scenario_typing() {
+  inject_metrics
+  local text
+  text=$(printf 'the quick brown fox %.0s' $(seq 1 6))   # 120 chars
+  local out
+  out=$(ev "JSON.stringify(window.__perf.typeInto('$TA', '$text'))")
+  ev "window.__perf.clearComposer('$TA')" >/dev/null
+  echo "$out"
+}
+
+measure() {
+  local label="${1:?usage: run.sh measure <label>}"
+  command -v jq >/dev/null || die "jq required"
+  auth
+  # Fresh session per measurement label so baseline and after runs start from
+  # an identical 200-message history.
+  seed_fixture force
+  browser_login
+  activate_browser
+  local out="$PERF_DIR/results/$label.json"
+  local runs="[]"
+  for rep in $(seq 1 "$REPS"); do
+    log "=== rep $rep/$REPS ==="
+    local lh st ty
+    lh=$(scenario_long_history)
+    log "long-history: $lh"
+    st=$(scenario_streaming)
+    log "streaming:    $st"
+    # Fresh reload so typing measures a quiet page with full history mounted.
+    open_session
+    load_full_history
+    ty=$(scenario_typing)
+    log "typing:       $ty"
+    runs=$(jq -n --argjson acc "$runs" \
+      --argjson lh "$lh" --argjson st "$st" --argjson ty "$ty" \
+      '$acc + [{longHistory:($lh|fromjson), streaming:($st|fromjson), typing:($ty|fromjson)}]')
+  done
+  jq -n --arg label "$label" --arg date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg commit "$(git -C "$REPO" rev-parse --short HEAD)" \
+    --argjson reps "$REPS" --argjson runs "$runs" \
+    '{label:$label, date:$date, commit:$commit, reps:$reps, runs:$runs}' > "$out"
+  log "wrote $out"
+}
+
+teardown() {
+  for f in stellad.pid fakeprovider.pid; do
+    if [ -f "$PERF_HOME/$f" ]; then
+      kill "$(cat "$PERF_HOME/$f")" 2>/dev/null || true
+      rm -f "$PERF_HOME/$f"
+    fi
+  done
+  log "stopped scratch processes (data in $PERF_HOME preserved)"
+}
+
+case "${1:-}" in
+  setup)    start_fake; start_server; auth; seed_fixture ;;
+  measure)  shift; measure "$@" ;;
+  teardown) teardown ;;
+  *) echo "usage: $0 {setup|measure <label>|teardown}"; exit 2 ;;
+esac

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -8,13 +8,14 @@ React SPA embedded by Go. TanStack Router owns client-side routing.
 
 Detailed conventions live in `content/docs/development/rules/`. Read the relevant rule before designing or changing anything in that domain:
 
-| Domain            | Rule file        | Read before                                                           |
-| ----------------- | ---------------- | --------------------------------------------------------------------- |
-| UI engineering    | `web-ui.md`      | Building or reviewing any UI (tokens, CossUI, overlays, forms, icons) |
-| Current theme     | `web-design.md`  | Any visual/design decision                                            |
-| Theming / restyle | `web-theming.md` | Changing the visual style or editing `src/tokens.css`                 |
-| Web UI testing    | `web-ui-test.md` | Verifying the UI with browser automation                              |
-| Marketing copy    | `marketing.md`   | Building a landing page, hero, or any marketing-facing surface        |
+| Domain            | Rule file          | Read before                                                           |
+| ----------------- | ------------------ | --------------------------------------------------------------------- |
+| UI engineering    | `web-ui.md`        | Building or reviewing any UI (tokens, CossUI, overlays, forms, icons) |
+| Current theme     | `web-design.md`    | Any visual/design decision                                            |
+| Theming / restyle | `web-theming.md`   | Changing the visual style or editing `src/tokens.css`                 |
+| Web UI testing    | `web-ui-test.md`   | Verifying the UI with browser automation                              |
+| Web perf testing  | `web-perf-test.md` | Measuring or optimizing web UI performance                            |
+| Marketing copy    | `marketing.md`     | Building a landing page, hero, or any marketing-facing surface        |
 
 Also: `.agents/skills/coss/SKILL.md` for CossUI imports, composition rules, and particle examples.
 

--- a/web/content/docs/development/meta.json
+++ b/web/content/docs/development/meta.json
@@ -13,6 +13,7 @@
     "rules/web-theming",
     "rules/web-design",
     "rules/web-ui-test",
+    "rules/web-perf-test",
     "rules/doc-style",
     "rules/project-tracker",
     "rules/release",

--- a/web/content/docs/development/meta.zh.json
+++ b/web/content/docs/development/meta.zh.json
@@ -4,6 +4,7 @@
     "rules/api-design",
     "rules/schema-design",
     "rules/cli-design",
+    "rules/web-perf-test",
     "architecture",
     "authorization",
     "agent-architecture",

--- a/web/content/docs/development/rules/web-perf-test.md
+++ b/web/content/docs/development/rules/web-perf-test.md
@@ -1,0 +1,93 @@
+---
+title: Web performance testing
+description: Reproducible before/after measurement of the web UI with the perf harness in test/perf/.
+---
+
+Every performance claim about the web UI must be a measured before/after delta,
+not an eyeballed impression. The harness in `test/perf/` produces that delta: it
+runs deterministic chat scenarios against a **scratch stellad instance**
+(`~/.stella-perf`, port 25911) with a **fake Anthropic provider** (fixed reply
+content, fixed streaming cadence), so two runs differ only by the code under
+test. Results are JSON files tagged with the git commit under
+`test/perf/results/`.
+
+This rule covers when and how to measure. Mechanics — scenario details, metric
+definitions, env knobs — live in `test/perf/README.md`. For functional
+verification of the UI, use `web-ui-test.md` instead; for backend-only
+behavior, `api-test.md`.
+
+## When to measure
+
+- Before starting any optimization: capture a baseline, or the "improvement"
+  is unfalsifiable.
+- After each optimization phase: one phase per commit, with its measured delta
+  in the commit message and the PR description.
+- When a perf regression is suspected: measure the suspect commit against its
+  parent instead of arguing from the diff.
+
+## Workflow
+
+The server embeds the web UI from `web/static/dist`, so a stale frontend build
+silently measures old code — always rebuild both before `setup`:
+
+```bash
+cd web && vp build && cd .. && go build -o dist/bin/stellad ./cmd/stellad
+
+./test/perf/run.sh setup                 # scratch server + fake provider + fixture
+./test/perf/run.sh measure baseline      # render scenarios -> results/baseline.json
+./test/perf/run.sh measure-load baseline # load scenarios   -> results/load-baseline.json
+# ...change code, rebuild UI + binary...
+./test/perf/run.sh teardown && ./test/perf/run.sh setup
+./test/perf/run.sh measure after
+./test/perf/run.sh teardown
+```
+
+`measure` covers render-path scenarios (long-history, streaming frame times,
+per-keystroke cost); `measure-load` covers load-path scenarios (a
+1000-message session, a history embedding multi-megabyte images and PDF
+chips). Compare **medians across reps**, never single runs, and only across
+runs from the same machine:
+
+```bash
+jq -r '.runs | [.[].streaming.avgFrameMs] | sort | .[length/2|floor]' \
+  test/perf/results/baseline.json
+```
+
+## Interpreting results
+
+- Absolute numbers are machine-dependent; only the before/after delta on one
+  machine is meaningful.
+- Know the floor: on a 120 Hz display the average frame time bottoms out at
+  ~8.3 ms. A phase that doesn't move an at-floor metric may still be a win on
+  a metric that scales with history length (max frame, per-keystroke cost).
+- localhost hides network cost. For transfer or caching claims, read
+  `transferSize` from the Resource Timing API (a cached 304 shows ~0.3 KB
+  against a full body's megabytes) instead of wall-clock load time.
+
+## Gotchas (each one has bitten)
+
+- **Chrome throttles hidden tabs.** rAF stops in hidden or occluded windows,
+  zeroing every frame metric. The harness forces the window visible and
+  frontmost; if `frames` comes back 0, check `document.visibilityState`.
+- **`innerText` lies under `content-visibility`.** Chrome excludes
+  skipped (off-screen) rows from `innerText`. Assert on `textContent` — and
+  remember it concatenates nodes with no separators, so newline- or
+  boundary-anchored regexes are ambiguous; count matches instead.
+- **`performance.memory` is process-level and pre-GC.** Heap values climbing
+  across runs usually mean lazy GC, not a leak. A leak verdict requires CDP:
+  connect to the port in the browser profile's `DevToolsActivePort` file, call
+  `HeapProfiler.collectGarbage`, and check that `WeakRef`-pinned nodes from
+  the old view were collected and post-GC heap is flat across cycles.
+- **Seed fixtures sequentially.** Concurrent turn POSTs to one session race
+  server-side and silently drop turns.
+- **Fixtures are reused across labels on purpose.** The load scenarios never
+  mutate their sessions, so identical data backs every label; the render
+  scenarios reseed a fresh session per label because streaming appends to it.
+
+## Related
+
+- `test/perf/README.md` — scenario mechanics, metrics, env knobs.
+- `web-ui-test.md` — functional browser verification (same `tap` tooling,
+  different purpose).
+- `system-test.md` — the test-layer taxonomy; the perf harness sits outside
+  it as a measurement tool, not a pass/fail gate.

--- a/web/content/docs/development/rules/web-perf-test.zh.md
+++ b/web/content/docs/development/rules/web-perf-test.zh.md
@@ -1,0 +1,82 @@
+---
+title: Web 性能测试
+description: 使用 test/perf/ 性能测量工具对 Web UI 做可复现的优化前后对比。
+---
+
+关于 Web UI 的任何性能结论都必须是实测的前后对比差值，不能靠肉眼感觉。
+`test/perf/` 下的测量工具负责产出这个差值：它在一个**独立的 stellad 实例**
+（`~/.stella-perf`，端口 25911）上运行确定性的聊天场景，配合**假 Anthropic
+provider**（固定回复内容、固定流式节奏），保证两次运行之间的唯一变量就是被测
+代码。结果以带 git commit 标记的 JSON 文件写入 `test/perf/results/`。
+
+本规则只讲何时测、如何测。具体机制——场景细节、指标定义、环境变量——见
+`test/perf/README.md`。UI 功能验证用 `web-ui-test.md`；纯后端行为用
+`api-test.md`。
+
+## 何时测量
+
+- 开始任何优化之前：先采集 baseline，否则"提升"无法证伪。
+- 每个优化阶段完成后：一个阶段一个 commit，实测差值写进 commit message 和
+  PR 描述。
+- 怀疑性能回归时：对可疑 commit 与其父 commit 分别测量，而不是对着 diff 争论。
+
+## 工作流
+
+服务器从 `web/static/dist` 嵌入 Web UI，前端构建过期会导致悄悄测到旧代码——
+`setup` 前必须两个都重新构建：
+
+```bash
+cd web && vp build && cd .. && go build -o dist/bin/stellad ./cmd/stellad
+
+./test/perf/run.sh setup                 # 独立服务器 + 假 provider + 种子数据
+./test/perf/run.sh measure baseline      # 渲染场景 -> results/baseline.json
+./test/perf/run.sh measure-load baseline # 加载场景 -> results/load-baseline.json
+# ...修改代码，重建 UI 和二进制...
+./test/perf/run.sh teardown && ./test/perf/run.sh setup
+./test/perf/run.sh measure after
+./test/perf/run.sh teardown
+```
+
+`measure` 覆盖渲染路径场景（长历史、流式帧时间、逐键输入开销）；
+`measure-load` 覆盖加载路径场景（1000 条消息的会话、内嵌多个数 MB 图片和
+PDF 附件的历史）。对比时取**多次重复的中位数**，不看单次结果，且只在同一台
+机器的运行之间对比：
+
+```bash
+jq -r '.runs | [.[].streaming.avgFrameMs] | sort | .[length/2|floor]' \
+  test/perf/results/baseline.json
+```
+
+## 解读结果
+
+- 绝对数值依赖机器；只有同一台机器上的前后差值有意义。
+- 认识下限：120 Hz 屏幕上平均帧时间的下限约 8.3 ms。某阶段推不动已到下限的
+  指标，不代表没有收益——看随历史长度增长的指标（最大帧时间、逐键开销）。
+- localhost 会掩盖网络成本。涉及传输量或缓存的结论，用 Resource Timing API
+  读 `transferSize`（缓存命中的 304 约 0.3 KB，完整响应体是数 MB），不要看
+  墙钟加载时间。
+
+## 坑（每一条都踩过）
+
+- **Chrome 会限流隐藏标签页。** 隐藏或被遮挡的窗口里 rAF 停摆，所有帧指标归
+  零。工具会把窗口置前并保持可见；如果 `frames` 为 0，检查
+  `document.visibilityState`。
+- **`content-visibility` 下 `innerText` 不可信。** Chrome 会把被跳过的（视口
+  外）行从 `innerText` 中剔除。断言要用 `textContent`——注意它拼接节点时没有
+  分隔符，锚定换行或边界的正则会产生歧义，改用计数匹配。
+- **`performance.memory` 是进程级且 GC 前的读数。** 跨运行攀升通常是 GC 惰
+  性，不是泄漏。泄漏定论需要 CDP：连接浏览器 profile 目录下
+  `DevToolsActivePort` 文件里的端口，调用 `HeapProfiler.collectGarbage`，确认
+  旧视图中被 `WeakRef` 钉住的节点已回收、多周期后 GC 后堆保持平稳。
+- **种子数据必须顺序写入。** 向同一个 session 并发 POST turn 会在服务端竞争
+  并静默丢失。
+- **加载场景的种子数据跨 label 复用是刻意的。** 加载场景从不修改会话，所有
+  label 面对完全相同的数据；渲染场景因为流式回复会追加消息，每个 label 重新
+  播种。
+
+## 相关
+
+- `test/perf/README.md` — 场景机制、指标、环境变量。
+- `web-ui-test.md` — 功能性浏览器验证（同样的 `tap` 工具，不同目的）。
+- `system-test.md` — 测试分层；性能工具在分层之外，是测量工具而非通过/失败
+  门禁。

--- a/web/content/docs/development/rules/web-ui-test.md
+++ b/web/content/docs/development/rules/web-ui-test.md
@@ -112,7 +112,9 @@ If an assertion fails, report what was expected vs what was found. Do not silent
 This covers the browser layer. To assert what a UI action actually wrote, pair it
 with the DB checks in `api-test.md` — browser drive here + DB assertions there is a
 full `browser -> API -> DB` e2e. For backend behavior alone, use `api-test.md`
-directly (no browser).
+directly (no browser). For performance measurement (frame times, keystroke cost,
+load/transfer cost) use the harness described in `web-perf-test.md` — functional
+checks here prove behavior, never speed.
 
 ## Notes
 

--- a/web/src/components/chat/AssistantMessage.tsx
+++ b/web/src/components/chat/AssistantMessage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import { MarkdownPreview } from "@/components/MarkdownPreview";
 import type { ContentBlock } from "@/lib/types";
 import { formatTime } from "@/lib/time";
@@ -323,22 +323,32 @@ function ToolStepRow({ block }: { block: ContentBlock & { type: "tool_call" } })
   }
   if (cmdPreview.length > 200) cmdPreview = cmdPreview.slice(0, 200) + "…";
 
-  const inputText = toolArgText(args.command ?? args.input ?? args.path ?? args.file_path ?? args);
-
-  // The runner appends a trailing "[exit:N | Xms]" line; lift it into the
-  // status footer instead of leaving it in the output body.
-  let outputText = block.result?.content ?? "";
-  let duration = "";
-  let exitOk = !block.result?.is_error;
-  const exitMatch = outputText.match(/\n?\[exit:(\d+) \| (\d+ms)\]\s*$/);
-  if (exitMatch) {
-    outputText = outputText.slice(0, exitMatch.index).replace(/\s+$/, "");
-    duration = exitMatch[2];
-    exitOk = exitMatch[1] === "0" && !block.result?.is_error;
-  }
+  // Input/output derivation (JSON.stringify of args, regex over the full tool
+  // output) is only needed once the row is expanded; collapsed rows on the
+  // streaming path must stay free of per-render serialization work.
+  const details = useMemo(() => {
+    if (!open) return null;
+    const inputText = toolArgText(
+      args.command ?? args.input ?? args.path ?? args.file_path ?? args,
+    );
+    // The runner appends a trailing "[exit:N | Xms]" line; lift it into the
+    // status footer instead of leaving it in the output body.
+    let outputText = block.result?.content ?? "";
+    let duration = "";
+    let exitOk = !block.result?.is_error;
+    const exitMatch = outputText.match(/\n?\[exit:(\d+) \| (\d+ms)\]\s*$/);
+    if (exitMatch) {
+      outputText = outputText.slice(0, exitMatch.index).replace(/\s+$/, "");
+      duration = exitMatch[2];
+      exitOk = exitMatch[1] === "0" && !block.result?.is_error;
+    }
+    return { inputText, outputText, duration, exitOk };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- args derives from block
+  }, [open, block]);
 
   const onCopy = () => {
-    void navigator.clipboard?.writeText(inputText);
+    if (!details) return;
+    void navigator.clipboard?.writeText(details.inputText);
     setCopied(true);
     window.setTimeout(() => setCopied(false), 1500);
   };
@@ -374,16 +384,16 @@ function ToolStepRow({ block }: { block: ContentBlock & { type: "tool_call" } })
             </button>
           </div>
           <pre className="whitespace-pre-wrap break-all leading-relaxed text-foreground/90">
-            {isBash ? `$ ${inputText}` : inputText}
+            {isBash ? `$ ${details!.inputText}` : details!.inputText}
           </pre>
-          {block.result && outputText && (
+          {block.result && details!.outputText && (
             <pre
               className={cn(
                 "mt-1 max-h-64 overflow-y-auto whitespace-pre-wrap break-all leading-relaxed",
                 block.result.is_error ? "text-destructive/80" : "text-muted-foreground/80",
               )}
             >
-              {outputText}
+              {details!.outputText}
             </pre>
           )}
           {block.result && (
@@ -393,8 +403,8 @@ function ToolStepRow({ block }: { block: ContentBlock & { type: "tool_call" } })
                 block.result.is_error && "text-destructive/70",
               )}
             >
-              {exitOk ? "✓ Success" : "✕ Failed"}
-              {duration && ` · ${duration}`}
+              {details!.exitOk ? "✓ Success" : "✕ Failed"}
+              {details!.duration && ` · ${details!.duration}`}
             </div>
           )}
         </div>

--- a/web/src/components/chat/AssistantMessage.tsx
+++ b/web/src/components/chat/AssistantMessage.tsx
@@ -78,13 +78,16 @@ export function AssistantMessage({
       )}
       <div className="min-w-0 space-y-3 ml-2.5 border-l border-border pl-4">
         {grouped.map((item, gi) => {
+          // Keys derive from the group's start offset in `blocks`: during a
+          // stream blocks are append-only, so existing groups keep their key
+          // and never remount (index keys shifted whenever a group appeared).
           if (item.type === "text") {
-            return <BlockRenderer key={gi} block={item.block} />;
+            return <BlockRenderer key={`g${item.start}`} block={item.block} />;
           } else {
             const hasFinalOutputAfter = grouped.slice(gi + 1).some((next) => next.type === "text");
             return (
               <StepsGroup
-                key={gi}
+                key={`g${item.start}`}
                 blocks={item.blocks}
                 active={Boolean(streaming && !hasFinalOutputAfter)}
               />
@@ -134,28 +137,33 @@ export function AssistantMessage({
   );
 }
 
+// `start` is the group's first index in the source blocks array — a
+// remount-stable React key, since blocks only append during a stream.
 type GroupedBlock =
-  | { type: "text"; block: ContentBlock }
-  | { type: "steps"; blocks: ContentBlock[] };
+  | { type: "text"; block: ContentBlock; start: number }
+  | { type: "steps"; blocks: ContentBlock[]; start: number };
 
 function groupBlocks(blocks: ContentBlock[]): GroupedBlock[] {
   const result: GroupedBlock[] = [];
   let currentSteps: ContentBlock[] = [];
+  let stepsStart = 0;
 
-  for (const block of blocks) {
+  for (let i = 0; i < blocks.length; i++) {
+    const block = blocks[i];
     if (block.type === "thinking" || block.type === "tool_call") {
+      if (currentSteps.length === 0) stepsStart = i;
       currentSteps.push(block);
     } else {
       if (currentSteps.length > 0) {
-        result.push({ type: "steps", blocks: currentSteps });
+        result.push({ type: "steps", blocks: currentSteps, start: stepsStart });
         currentSteps = [];
       }
-      result.push({ type: "text", block });
+      result.push({ type: "text", block, start: i });
     }
   }
 
   if (currentSteps.length > 0) {
-    result.push({ type: "steps", blocks: currentSteps });
+    result.push({ type: "steps", blocks: currentSteps, start: stepsStart });
   }
 
   return result;
@@ -249,7 +257,7 @@ function StepsGroup({ blocks, active }: { blocks: ContentBlock[]; active: boolea
             if (block.type === "thinking" && block.thinking) {
               return (
                 <div
-                  key={idx}
+                  key={`t${idx}`}
                   className="py-0.5 text-xs text-muted-foreground/80 leading-relaxed whitespace-pre-wrap break-words overflow-hidden border-l border-border/60 pl-3 font-sans min-w-0"
                 >
                   {block.thinking}
@@ -257,7 +265,9 @@ function StepsGroup({ blocks, active }: { blocks: ContentBlock[]; active: boolea
               );
             }
             if (block.type === "tool_call") {
-              return <ToolStepRow key={idx} block={block} />;
+              // Keyed by the stable tool-call id so an appended sibling never
+              // remounts an existing row (which would drop its open state).
+              return <ToolStepRow key={block.id || `i${idx}`} block={block} />;
             }
             return null;
           })}

--- a/web/src/components/chat/ChatTranscript.tsx
+++ b/web/src/components/chat/ChatTranscript.tsx
@@ -58,8 +58,16 @@ const MessageRow = memo(function MessageRow({
   fileSessionId?: string;
   agentNames?: Map<string, string>;
 }) {
+  // content-visibility lets the browser skip layout/paint for rows far outside
+  // the viewport; contain-intrinsic-size keeps scrollHeight (and thus scroll
+  // restoration when paging in older history) stable while they're skipped.
   return (
-    <div className={cn("min-w-0", sameRoleAsPrev ? "-mt-3" : "")}>
+    <div
+      className={cn(
+        "min-w-0 [content-visibility:auto] [contain-intrinsic-size:auto_80px]",
+        sameRoleAsPrev ? "-mt-3" : "",
+      )}
+    >
       {msg.role === "user" ? (
         <UserMessage
           msg={{ content: msg.content, timestamp: msg.timestamp }}

--- a/web/src/components/chat/ChatTranscript.tsx
+++ b/web/src/components/chat/ChatTranscript.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useMemo, type ReactNode } from "react";
+import { forwardRef, memo, type ReactNode } from "react";
 import { useI18n } from "@/lib/i18n";
 import type { ContentBlock } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -30,20 +30,6 @@ interface Props {
   header?: ReactNode;
 }
 
-interface Annotated extends TranscriptMessage {
-  sameRoleAsPrev: boolean;
-  showTimestamp: boolean;
-}
-
-function annotate(messages: TranscriptMessage[]): Annotated[] {
-  return messages.map((msg, i) => ({
-    ...msg,
-    sameRoleAsPrev:
-      i > 0 && messages[i - 1].role === msg.role && messages[i - 1].agentId === msg.agentId,
-    showTimestamp: i === messages.length - 1 || messages[i + 1].role !== msg.role,
-  }));
-}
-
 interface MessageListProps {
   messages: TranscriptMessage[];
   fileAgentId?: string;
@@ -53,6 +39,54 @@ interface MessageListProps {
   className?: string;
 }
 
+// Memoized per-message row: with stable TranscriptMessage identities from the
+// upstream caches, a stream update re-renders only the tail row instead of the
+// whole history. Neighbor-derived flags are passed as primitives so the memo
+// comparison stays shallow.
+const MessageRow = memo(function MessageRow({
+  msg,
+  sameRoleAsPrev,
+  showTimestamp,
+  fileAgentId,
+  fileSessionId,
+  agentNames,
+}: {
+  msg: TranscriptMessage;
+  sameRoleAsPrev: boolean;
+  showTimestamp: boolean;
+  fileAgentId?: string;
+  fileSessionId?: string;
+  agentNames?: Map<string, string>;
+}) {
+  return (
+    <div className={cn("min-w-0", sameRoleAsPrev ? "-mt-3" : "")}>
+      {msg.role === "user" ? (
+        <UserMessage
+          msg={{ content: msg.content, timestamp: msg.timestamp }}
+          agentId={fileAgentId}
+          sessionId={fileSessionId}
+          agentNames={agentNames}
+          sameRoleAsPrev={sameRoleAsPrev}
+          showTimestamp={showTimestamp}
+        />
+      ) : (
+        <AssistantMessage
+          agentName={msg.agentName || "Agent"}
+          agentId={msg.agentId || "default"}
+          blocks={msg.blocks ?? []}
+          timestamp={msg.timestamp}
+          model={msg.model}
+          tokenCount={msg.tokenCount}
+          streaming={msg.streaming}
+          showTimestamp={showTimestamp}
+          sameRoleAsPrev={sameRoleAsPrev}
+          agentSessionId={msg.agentSessionId}
+        />
+      )}
+    </div>
+  );
+});
+
 /** The bare message column, reusable wherever a transcript needs to render (chat, epoch raw view). */
 export function MessageList({
   messages,
@@ -61,35 +95,20 @@ export function MessageList({
   agentNames,
   className,
 }: MessageListProps) {
-  const processed = useMemo(() => annotate(messages), [messages]);
   return (
     <div className={cn("min-w-0 space-y-6", className)}>
-      {processed.map((msg) => (
-        <div key={msg.id} className={cn("min-w-0", msg.sameRoleAsPrev ? "-mt-3" : "")}>
-          {msg.role === "user" ? (
-            <UserMessage
-              msg={{ content: msg.content, timestamp: msg.timestamp }}
-              agentId={fileAgentId}
-              sessionId={fileSessionId}
-              agentNames={agentNames}
-              sameRoleAsPrev={msg.sameRoleAsPrev}
-              showTimestamp={msg.showTimestamp}
-            />
-          ) : (
-            <AssistantMessage
-              agentName={msg.agentName || "Agent"}
-              agentId={msg.agentId || "default"}
-              blocks={msg.blocks ?? []}
-              timestamp={msg.timestamp}
-              model={msg.model}
-              tokenCount={msg.tokenCount}
-              streaming={msg.streaming}
-              showTimestamp={msg.showTimestamp}
-              sameRoleAsPrev={msg.sameRoleAsPrev}
-              agentSessionId={msg.agentSessionId}
-            />
-          )}
-        </div>
+      {messages.map((msg, i) => (
+        <MessageRow
+          key={msg.id}
+          msg={msg}
+          sameRoleAsPrev={
+            i > 0 && messages[i - 1].role === msg.role && messages[i - 1].agentId === msg.agentId
+          }
+          showTimestamp={i === messages.length - 1 || messages[i + 1].role !== msg.role}
+          fileAgentId={fileAgentId}
+          fileSessionId={fileSessionId}
+          agentNames={agentNames}
+        />
       ))}
     </div>
   );

--- a/web/src/components/chat/utils.ts
+++ b/web/src/components/chat/utils.ts
@@ -48,6 +48,9 @@ export function replaceUUIDMentions(text: string, agentNames?: Map<string, strin
 
 export function extractUserText(msg: { content?: string }): string {
   const raw = msg.content ?? "";
+  // Fast path: plain text (the common case). Without this, every render of
+  // every user bubble throws and catches a JSON.parse error.
+  if (!raw.startsWith("[")) return raw;
   try {
     const parsed = JSON.parse(raw) as unknown;
     if (Array.isArray(parsed)) {

--- a/web/src/features/groups/GroupChat.tsx
+++ b/web/src/features/groups/GroupChat.tsx
@@ -95,6 +95,8 @@ export function GroupChat({ groupId }: Props) {
   } = useChat({
     id: `group-${groupId}`,
     transport,
+    // Batch SSE deltas: without this every token re-renders the transcript.
+    experimental_throttle: 50,
     onFinish: () => {
       void loadMessages();
       void queryClient.invalidateQueries({ queryKey: ["groups"] });

--- a/web/src/features/recally/components/RecallyChat.tsx
+++ b/web/src/features/recally/components/RecallyChat.tsx
@@ -128,6 +128,8 @@ export function RecallyChat({ articleId, onClose }: Props) {
   } = useChat({
     id: activeSessionId ?? "recally-chat-empty",
     transport,
+    // Batch SSE deltas: without this every token re-renders the transcript.
+    experimental_throttle: 50,
     onError: (err) => console.error("[recally chat]", err),
   });
 

--- a/web/src/features/sessions/ChatComposer.tsx
+++ b/web/src/features/sessions/ChatComposer.tsx
@@ -21,9 +21,15 @@ export const BUILTIN_COMMANDS: ComposerSkill[] = [
 ];
 
 interface Props {
-  value: string;
-  onChange: (value: string) => void;
-  onSend: (overrideText?: string) => void;
+  /**
+   * Controlled mode: pass value + onChange when the parent must observe or
+   * rewrite the draft (e.g. GroupChat's @-mention insertion). Omit both for
+   * uncontrolled mode, where the draft lives here — keystrokes then re-render
+   * only the composer, not the parent page and its transcript.
+   */
+  value?: string;
+  onChange?: (value: string) => void;
+  onSend: (text: string) => void;
   onStop?: () => void;
   isStreaming: boolean;
   disabled?: boolean;
@@ -37,7 +43,7 @@ interface Props {
 }
 
 export function ChatComposer({
-  value,
+  value: valueProp,
   onChange,
   onSend,
   onStop,
@@ -58,6 +64,16 @@ export function ChatComposer({
 
   const [selectedSkills, setSelectedSkills] = useState<ComposerSkill[]>([]);
 
+  const [draft, setDraft] = useState("");
+  const value = valueProp ?? draft;
+  const setValue = useCallback(
+    (v: string) => {
+      if (valueProp === undefined) setDraft(v);
+      onChange?.(v);
+    },
+    [valueProp, onChange],
+  );
+
   const hasAttachments = attachments && attachments.length > 0;
   const canSend =
     (value.trim() ||
@@ -66,16 +82,16 @@ export function ChatComposer({
     !attachments?.some((a) => a.uploading);
 
   const handleSend = useCallback(() => {
+    if (isStreaming || disabled || !canSend) return;
+    let full = value;
     if (selectedSkills.length > 0) {
       const prefix = selectedSkills.map((s) => `/${s.name}`).join(" ");
-      const full = value.trim() ? `${prefix} ${value}` : prefix;
+      full = value.trim() ? `${prefix} ${value}` : prefix;
       setSelectedSkills([]);
-      onChange("");
-      onSend(full);
-    } else {
-      onSend();
     }
-  }, [selectedSkills, value, onChange, onSend]);
+    setValue("");
+    onSend(full);
+  }, [isStreaming, disabled, canSend, selectedSkills, value, setValue, onSend]);
 
   const [slashQuery, setSlashQuery] = useState<string | null>(null);
   const [slashIndex, setSlashIndex] = useState(0);
@@ -98,10 +114,10 @@ export function ChatComposer({
 
   const handleChange = useCallback(
     (val: string) => {
-      onChange(val);
+      setValue(val);
       detectSlash(val);
     },
-    [onChange, detectSlash],
+    [setValue, detectSlash],
   );
 
   const slashCandidates = useMemo(() => {
@@ -133,12 +149,12 @@ export function ChatComposer({
       if (slashIdx < 0) return;
 
       const newVal = (before.slice(0, slashIdx) + after).trim();
-      onChange(newVal);
+      setValue(newVal);
       setSelectedSkills((prev) => [...prev, skill]);
       setSlashQuery(null);
       textarea.focus();
     },
-    [value, onChange, taRef],
+    [value, setValue, taRef],
   );
 
   const removeSkill = useCallback((name: string) => {

--- a/web/src/features/sessions/FileViewer.tsx
+++ b/web/src/features/sessions/FileViewer.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { MarkdownPreview } from "@/components/MarkdownPreview";
-import { createHighlighter, type Highlighter } from "shiki";
+import type { Highlighter } from "shiki";
 import {
   ArrowLeft,
   Pencil,
@@ -33,10 +33,14 @@ let highlighterPromise: Promise<Highlighter> | null = null;
 
 function getHighlighter(): Promise<Highlighter> {
   if (!highlighterPromise) {
-    highlighterPromise = createHighlighter({
-      themes: ["github-light", "github-dark"],
-      langs: [],
-    });
+    // Dynamic import keeps shiki (and its grammars) out of the main chunk;
+    // it only loads once someone actually opens a file.
+    highlighterPromise = import("shiki").then(({ createHighlighter }) =>
+      createHighlighter({
+        themes: ["github-light", "github-dark"],
+        langs: [],
+      }),
+    );
   }
   return highlighterPromise;
 }

--- a/web/src/features/sessions/SessionConversation.tsx
+++ b/web/src/features/sessions/SessionConversation.tsx
@@ -59,6 +59,8 @@ export function SessionConversation({
   } = useChat({
     id: `conv-${sessionId}`,
     transport,
+    // Batch SSE deltas: without this every token re-renders the transcript.
+    experimental_throttle: 50,
     onError: (err) => console.error("[session conversation chat]", err),
   });
 

--- a/web/src/features/sessions/SessionDetail.tsx
+++ b/web/src/features/sessions/SessionDetail.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { useChat } from "@ai-sdk/react";
+import type { UIMessage } from "ai";
 import { Link } from "@tanstack/react-router";
 import {
   AlertCircle,
@@ -240,7 +241,27 @@ export function SessionDetail({
     });
   }, [historyMessages, setChatMessages]);
 
-  const messages = useMemo(() => chatMessages.map(uiMessageToMessage), [chatMessages]);
+  // Convert UIMessage -> Message with a per-object cache so unchanged messages
+  // keep their output identity across stream updates — that identity is what
+  // lets the memoized transcript rows below skip re-rendering. The entry
+  // revalidates on parts count + tail text length in case the SDK ever grows a
+  // message in place instead of replacing it.
+  const uiToMsgCache = useRef(
+    new WeakMap<UIMessage, { partsLen: number; tailLen: number; out: Message }>(),
+  );
+  const messages = useMemo(
+    () =>
+      chatMessages.map((m) => {
+        const tail = m.parts[m.parts.length - 1] as { text?: string } | undefined;
+        const tailLen = tail?.text?.length ?? 0;
+        const hit = uiToMsgCache.current.get(m);
+        if (hit && hit.partsLen === m.parts.length && hit.tailLen === tailLen) return hit.out;
+        const out = uiMessageToMessage(m);
+        uiToMsgCache.current.set(m, { partsLen: m.parts.length, tailLen, out });
+        return out;
+      }),
+    [chatMessages],
+  );
 
   useEffect(() => {
     if (!session) {

--- a/web/src/features/sessions/SessionDetail.tsx
+++ b/web/src/features/sessions/SessionDetail.tsx
@@ -69,7 +69,6 @@ export function SessionDetail({
   contextTitle,
 }: Props) {
   const { t } = useI18n();
-  const [userInput, setUserInput] = useState("");
   const { toasts, showToast } = useToast();
   const [exporting, setExporting] = useState(false);
   const [exportMenuOpen, setExportMenuOpen] = useState(false);
@@ -127,6 +126,8 @@ export function SessionDetail({
   } = useChat({
     id: session?.id ?? "empty",
     transport,
+    // Batch SSE deltas: without this every token re-renders the transcript.
+    experimental_throttle: 50,
     onError: (err) => console.error("[session chat]", err),
   });
 
@@ -295,7 +296,24 @@ export function SessionDetail({
     messagesQuery.fetchNextPage,
   ]);
 
-  // Auto-scroll to bottom as new messages stream in (if the user is already near the bottom)
+  // Auto-scroll to bottom as new messages stream in (if the user is already
+  // near the bottom). Keyed on length + tail content size rather than the
+  // array identity: the messages array is rebuilt on every stream update, and
+  // reading scrollHeight forces a reflow of the whole transcript.
+  const lastMessage = messages[messages.length - 1];
+  const lastMessageSize = lastMessage
+    ? (lastMessage.content?.length ?? 0) +
+      (lastMessage.blocks?.reduce(
+        (sum, b) =>
+          sum +
+          (b.type === "text"
+            ? b.text.length
+            : b.type === "thinking"
+              ? (b.thinking?.length ?? 0)
+              : 1),
+        0,
+      ) ?? 0)
+    : 0;
   useEffect(() => {
     if (!transcriptRef.current) return;
     const el = transcriptRef.current;
@@ -304,7 +322,7 @@ export function SessionDetail({
         el.scrollTop = el.scrollHeight;
       });
     }
-  }, [messages]);
+  }, [messages.length, lastMessageSize]);
 
   const loadOlderMessages = useCallback(async () => {
     // Compacted sessions have no older pages to load: everything before the
@@ -336,13 +354,11 @@ export function SessionDetail({
   }, [loadOlderMessages]);
 
   const sendMessage = useCallback(
-    async (overrideText?: string) => {
-      const input = overrideText ?? userInput;
+    async (input: string) => {
       if ((!input.trim() && attachments.length === 0) || isStreaming || !session) return;
       if (attachments.some((a) => a.uploading)) return;
 
       const text = buildMessageText(input);
-      setUserInput("");
       clearAttachments();
       shouldAutoScrollRef.current = true;
       setTimeout(() => {
@@ -352,15 +368,7 @@ export function SessionDetail({
 
       void chatSendMessage({ text });
     },
-    [
-      userInput,
-      isStreaming,
-      session,
-      attachments,
-      buildMessageText,
-      clearAttachments,
-      chatSendMessage,
-    ],
+    [isStreaming, session, attachments, buildMessageText, clearAttachments, chatSendMessage],
   );
 
   const exportSessionAs = useCallback(
@@ -566,8 +574,6 @@ export function SessionDetail({
         composer={
           session.user_id === currentUserID ? (
             <ChatComposer
-              value={userInput}
-              onChange={setUserInput}
               onSend={(text) => void sendMessage(text)}
               onStop={() => chatStop()}
               isStreaming={isStreaming}

--- a/web/src/features/sessions/SessionDetail.tsx
+++ b/web/src/features/sessions/SessionDetail.tsx
@@ -45,6 +45,12 @@ import { BUILTIN_COMMANDS, ChatComposer } from "./ChatComposer";
 import { Transcript } from "./Transcript";
 import { useFileAttachments } from "./useFileAttachments";
 
+const PAGE_SIZE = 50;
+// Auto-fill (below) pulls older pages until the transcript overflows; cap how
+// many it may pull so a pathological history can't trigger an unbounded fetch
+// loop on mount. Scroll-up paging remains unlimited.
+const MAX_AUTO_FILL_PAGES = 3;
+
 const inboxKindLabels = {
   blocked: "inbox.kind.blocked",
   review: "inbox.kind.review",
@@ -78,6 +84,7 @@ export function SessionDetail({
   const transcriptRef = useRef<HTMLDivElement>(null);
   const sessionIDRef = useRef<string | null>(null);
   const initialScrollSessionRef = useRef<string | null>(null);
+  const autoFillPagesRef = useRef(0);
   const shouldAutoScrollRef = useRef(true);
 
   const sessionId = session?.id ?? "";
@@ -178,13 +185,15 @@ export function SessionDetail({
     queryFn: async ({ pageParam }) => {
       const { data } = await getSessionMessages({
         path: { agentId: agentId, sessionId: sessionId },
-        query: { limit: 20, skip: pageParam },
+        query: { limit: PAGE_SIZE, skip: pageParam },
         throwOnError: true,
       });
       return (data?.messages as unknown as Message[] | undefined) ?? [];
     },
     getNextPageParam: (lastPage, allPages) =>
-      lastPage.length === 20 ? allPages.reduce((sum, page) => sum + page.length, 0) : undefined,
+      lastPage.length === PAGE_SIZE
+        ? allPages.reduce((sum, page) => sum + page.length, 0)
+        : undefined,
   });
 
   // In a compacted session the live tail is the message-type context items;
@@ -273,6 +282,7 @@ export function SessionDetail({
     initialScrollSessionRef.current = null;
     shouldAutoScrollRef.current = true;
     historicalIDsRef.current = new Set();
+    autoFillPagesRef.current = 0;
   }, [session?.id]);
 
   const historyReady = hasContextSummaries
@@ -302,6 +312,8 @@ export function SessionDetail({
     if (!messagesQuery.isSuccess || messagesQuery.isFetchingNextPage || !messagesQuery.hasNextPage)
       return;
     if (el.scrollHeight > el.clientHeight) return;
+    if (autoFillPagesRef.current >= MAX_AUTO_FILL_PAGES) return;
+    autoFillPagesRef.current += 1;
     void messagesQuery.fetchNextPage().then(() => {
       requestAnimationFrame(() => {
         if (transcriptRef.current)

--- a/web/src/features/sessions/Transcript.tsx
+++ b/web/src/features/sessions/Transcript.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useMemo, useState } from "react";
+import { forwardRef, useMemo, useRef, useState } from "react";
 import type { Message } from "@/lib/types";
 import { useQuery } from "@tanstack/react-query";
 import { Archive, ChevronDown, MessageSquareText } from "lucide-react";
@@ -42,24 +42,44 @@ export const Transcript = forwardRef<HTMLDivElement, Props>(function Transcript(
   const agentName = agents.find((a) => a.id === agentId)?.name ?? "Agent";
   const hasSummaries = contextItems.some((item) => item.type === "summary");
 
+  // Identity-preserving pipeline: SessionDetail hands us Message objects that
+  // are stable across stream updates, and these caches keep the merged and
+  // mapped outputs stable too, so only the streaming tail produces new objects
+  // and the memoized rows downstream skip everything else.
+  const mergeCacheRef = useRef(new WeakMap<Message, { members: Message[]; merged: Message }>());
+  const tmCacheRef = useRef(new WeakMap<Message, TmCacheEntry>());
+
   const transcriptMessages = useMemo((): TranscriptMessage[] => {
     const filtered = messages.filter((m) => m.role !== "tool");
-    const merged = mergeConsecutiveMessages(filtered);
+    const merged = mergeConsecutiveMessagesCached(filtered, mergeCacheRef.current);
     const lastAssistantIndex = activeStreaming
       ? merged.findLastIndex((m) => m.role === "assistant")
       : -1;
-    return merged.map((msg, i) => ({
-      id: msg.id ?? `${msg.timestamp}-${msg.role}-${i}`,
-      role: msg.role as "user" | "assistant",
-      content: msg.content,
-      timestamp: msg.timestamp,
-      agentName,
-      agentId,
-      blocks: msg.blocks ?? (msg.content ? [{ type: "text" as const, text: msg.content }] : []),
-      model: msg.model,
-      tokenCount: msg.token_count,
-      streaming: msg.streaming || i === lastAssistantIndex,
-    }));
+    return merged.map((msg, i) => {
+      const streaming = Boolean(msg.streaming || i === lastAssistantIndex);
+      const hit = tmCacheRef.current.get(msg);
+      if (
+        hit &&
+        hit.agentName === agentName &&
+        hit.agentId === agentId &&
+        hit.streaming === streaming
+      )
+        return hit.out;
+      const out: TranscriptMessage = {
+        id: msg.id ?? `${msg.timestamp}-${msg.role}-${i}`,
+        role: msg.role as "user" | "assistant",
+        content: msg.content,
+        timestamp: msg.timestamp,
+        agentName,
+        agentId,
+        blocks: msg.blocks ?? (msg.content ? [{ type: "text" as const, text: msg.content }] : []),
+        model: msg.model,
+        tokenCount: msg.token_count,
+        streaming,
+      };
+      tmCacheRef.current.set(msg, { agentName, agentId, streaming, out });
+      return out;
+    });
   }, [messages, agentName, agentId, activeStreaming]);
 
   // Compacted epochs render as summary cards above the live tail; the tail
@@ -223,6 +243,55 @@ function SummaryCard({
 function formatNumber(value: number): string {
   if (value >= 1000) return `${(value / 1000).toFixed(1)}k`;
   return String(value);
+}
+
+interface TmCacheEntry {
+  agentName: string;
+  agentId: string;
+  streaming: boolean;
+  out: TranscriptMessage;
+}
+
+// Same semantics as mergeConsecutiveMessages, but reuses the merged output for
+// any run of messages whose member identities are unchanged, so a stream
+// update only rebuilds the tail group. Cache is keyed on the run's first
+// source message.
+function mergeConsecutiveMessagesCached(
+  messages: Message[],
+  cache: WeakMap<Message, { members: Message[]; merged: Message }>,
+): Message[] {
+  const result: Message[] = [];
+  let run: Message[] = [];
+
+  const flush = () => {
+    if (run.length === 0) return;
+    const members = run;
+    run = [];
+    const hit = cache.get(members[0]);
+    if (
+      hit &&
+      hit.members.length === members.length &&
+      hit.members.every((m, i) => m === members[i])
+    ) {
+      result.push(hit.merged);
+      return;
+    }
+    const merged = mergeConsecutiveMessages(members)[0];
+    cache.set(members[0], { members, merged });
+    result.push(merged);
+  };
+
+  for (const msg of messages) {
+    if (msg.role === "assistant") {
+      run.push(msg);
+    } else {
+      flush();
+      run.push(msg);
+      flush();
+    }
+  }
+  flush();
+  return result;
 }
 
 function mergeConsecutiveMessages(messages: Message[]): Message[] {


### PR DESCRIPTION
Closes #823

## What

All three phases of the chat UI performance work, plus the reproducible measurement harness used to prove each one.

## Changes

**Harness (`test/perf/`)** — deterministic before/after measurement: fake Anthropic SSE provider (fixed content, fixed cadence), scratch stellad instance, tap-driven scenarios (long-history load, streaming frame times, per-keystroke cost). See `test/perf/README.md`.

**Phase 1 — stop rendering per token (`web/src`)**:
- `useChat`: `experimental_throttle: 50` on all four call sites (SessionDetail, SessionConversation, GroupChat, RecallyChat)
- `ChatComposer`: uncontrolled by default so keystrokes re-render only the composer; GroupChat keeps the controlled mode its @-mention insertion needs
- auto-scroll effect keyed on message count + tail content size instead of array identity
- `extractUserText`: plain-text fast path (no throw/catch `JSON.parse` per bubble per render)
- `ToolStepRow`: `JSON.stringify`/regex derivation deferred until the row is expanded

**Phase 2 — identity-preserving pipeline + memoized rows**:
- WeakMap caches at each transform stage (`uiMessageToMessage`, consecutive-assistant merge, `TranscriptMessage` mapping) so a stream update produces new object identities only for the streaming tail
- `MessageRow` is `React.memo`; neighbor flags passed as primitives so the comparison stays shallow — per-update reconciliation is now O(1) in history length instead of O(N)
- stable group/row keys in `AssistantMessage` so streaming appends no longer remount earlier groups

**Phase 3 — skip offscreen work, trim load cost**:
- message rows get `content-visibility: auto` + `contain-intrinsic-size`: the browser skips layout/paint for rows outside the viewport
- history pages 20 → 50 messages; mount-time auto-fill capped at 3 pages
- shiki loads via dynamic import (~188 KB core chunk out of the session-view path)

## Results per phase

5-rep medians, 200-message session, 1500-chunk stream at ~100 chunks/s, M-series MacBook at 120 Hz:

| metric | baseline | phase 1 | phase 2 | phase 3 |
|---|---|---|---|---|
| streaming avg frame | 12.7 ms | **8.34 ms** (120 Hz floor) | 8.34 ms | 8.34 ms |
| streaming p95 frame | 25.0 ms | **9.2 ms** | 9.2 ms | 10.1 ms |
| streaming max frame | 42 ms | 24.1 ms | **17.3 ms** | **15.7 ms** |
| streaming jank frames | 0.5 % | **0 %** | 0 % | 0 % |
| typing avg per key | 10.4 ms | **3.9 ms** | 4.0 ms | **0.72 ms** |
| typing p95 / max per key | 11.6 / 21.7 ms | 5.2 / 9.4 ms | 5.4 / 12.8 ms | **0.9 / 1.3 ms** |
| full-history load (nav → all 200 mounted) | 8.1 s | 8.1 s | 8.1 s | **5.0 s** |

Reading: Phase 1 removes the per-token render storm (avg frame hits the 120 Hz floor, so later phases can't move it). Phase 2's win is architectural — reconciliation cost per stream update drops from O(history) to O(1), visible here as max-frame 24 → 17 ms and growing with history length. Phase 3's `content-visibility` makes typing effectively free (0.72 ms/key) and 50-msg pages halve the full-history load time.

Raw data: `test/perf/results/{baseline,phase1,phase2,phase3}.json`.

## Verification

- `mise run format && mise run build && mise run test` green after every phase
- Harness re-run per phase against the rebuilt binary; the streaming scenario's end-of-stream sentinel must appear in the DOM, which proves the Phase 2 identity caches don't freeze the streaming tail
- Scroll-up paging exercised 5× per measurement (full-history scenario) — scroll restoration holds under `content-visibility`
- Manual UI checks: send clears composer, streamed reply renders fully, slash-skill overlay works
- Harness note: checks moved from `innerText` to `textContent` because Chrome excludes `content-visibility`-skipped rows from `innerText`

## Deliberate ceilings

- No virtualization (react-virtuoso): `content-visibility` reached the target numbers with zero dependencies; revisit only if sessions grow past ~1k mounted messages
- `experimental_throttle: 50` trades ≤50 ms of text latency for stable frame pacing
