### PR TITLE
🔒 ci: gate tag releases on deterministic validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,7 @@ on:
     tags: ["v*.*.*"]
 
 permissions:
-  contents: write
-  packages: write
+  contents: read
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -14,13 +13,90 @@ env:
   IMAGE_NAME: cherryhq/stella
 
 jobs:
+  validate:
+    name: Validate Tagged Commit
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout tagged commit
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Verify tagged commit identity
+        env:
+          EVENT_REF: ${{ github.ref }}
+          EVENT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          head_commit="$(git rev-parse 'HEAD^{commit}')"
+          event_commit="$(git rev-parse "${EVENT_SHA}^{commit}")"
+          tag_commit="$(git rev-parse "${EVENT_REF}^{commit}")"
+          test "$head_commit" = "$event_commit"
+          test "$head_commit" = "$tag_commit"
+          {
+            echo "### Validated release source"
+            echo "- Tag: \`${GITHUB_REF_NAME}\`"
+            echo "- Commit: \`${head_commit}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Setup mise
+        uses: jdx/mise-action@v4
+        with:
+          experimental: true
+          install: true
+          cache: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install bubblewrap
+        run: sudo apt-get install -y bubblewrap
+
+      - name: Generate code and check drift
+        run: mise run generate:check
+
+      - name: Check formatting and lint
+        run: |
+          prek run --all-files
+          git status --short
+          test -z "$(git status --porcelain)"
+
+      - name: Build
+        run: mise run build
+
+      - name: Run Go and Web tests
+        run: mise run test
+
+      - name: Run System Test
+        run: mise run system-test
+
+      - name: Upload System Test diagnostics
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: system-test-logs-${{ github.run_id }}-${{ github.run_attempt }}
+          path: dist/logs/system-test/
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Check GoReleaser configuration
+        run: mise run release:check
+
+      - name: Build release snapshot
+        run: mise run release:snapshot
+
   goreleaser:
     name: GoReleaser
+    needs: validate
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
       - name: Setup mise
@@ -66,6 +142,7 @@ jobs:
 
   docker:
     name: Docker Release
+    needs: validate
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -82,11 +159,12 @@ jobs:
     permissions:
       contents: read
       packages: write
-      id-token: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -142,7 +220,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      id-token: write
 
     steps:
       - name: Download digests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Stella is a single-tenant, multi-user, multi-agent AI assistant platform written
 - On a fresh clone, run `mise run setup` once. Use `mise tasks` to discover workflows.
 - Run project workflows through `mise run <task>` instead of invoking underlying tools directly.
 - Before committing, **ALWAYS** run: `mise run format && mise run build && mise run test`.
-- `mise run system-test` runs the subprocess system suite (real `stellad` over TCP against embedded PostgreSQL); it is a local gate, skipped on unsupported hosts. `mise run release:validate` runs the full pre-release gate sequentially (format → build → test → system-test → release checks).
+- `mise run system-test` runs the subprocess system suite (real `stellad` over TCP against embedded PostgreSQL); it is a local and tag-release gate and requires a supported runtime host. `mise run release:validate` runs the full local pre-release gate sequentially (format → build → test → system-test → release checks).
 - When touching platform-specific behavior, run a targeted cross-platform build before committing (e.g., `GOOS=windows GOARCH=amd64 go build -o dist/bin/stellad-windows-amd64.exe ./cmd/stellad`).
 - Do not run Go tests with `-race` locally by default.
 - Build with `mise run build` (outputs to `dist/bin/`) or specify `-o dist/bin/stellad` explicitly; never build the `stellad` binary into the repo root.

--- a/web/content/docs/development/rules/release.md
+++ b/web/content/docs/development/rules/release.md
@@ -53,7 +53,9 @@ GoReleaser auto-detects pre-release suffixes (`-rc.1`, `-beta.1`).
    Filter the project board by the `release:vX.Y.Z` label to confirm the release scope.
 
 9. Push the branch and new release tag explicitly: `git push origin main vX.Y.Z`.
-10. CI triggers `.github/workflows/release.yml` → GoReleaser binaries + Docker images.
+10. CI triggers `.github/workflows/release.yml`. Its validation job checks the
+    exact tagged commit before the GoReleaser or Docker publication jobs can
+    start.
 
 ## Update Changelog
 
@@ -86,10 +88,12 @@ test "$(jq -r '.version' web/package.json)" = "$VERSION"
 mise run release:validate
 ```
 
-The system suite (`system-test`) is a **local** release gate: it is skipped on
-hosts without a published embedded PostgreSQL runtime and is not run in CI, so it
-runs here as part of `release:validate` rather than in the release workflow. See
-`system-test.md`.
+The system suite (`system-test`) runs both in the local gate and in the
+tag-triggered validation job. Release CI pins a supported Ubuntu runner and
+uploads the suite's server logs before any snapshot build can clean `dist/`.
+GoReleaser and Docker publication jobs depend directly on the validation result,
+so a failed or unsupported System Test cannot publish partial release artifacts.
+See `system-test.md`.
 
 ## Artifacts
 

--- a/web/content/docs/development/rules/system-test.md
+++ b/web/content/docs/development/rules/system-test.md
@@ -54,10 +54,12 @@ resource — it does not fail. Published platforms:
   `bookworm`, `noble`, and `trixie`;
 - **macOS arm64**.
 
-On an unsupported host, point `STELLA_DATABASE_URL` at an external PostgreSQL with
-`pg_search` and `pgvector` to run the server manually, or file an issue for the
-platform. Because the suite is skipped rather than failed off-platform, it stays a
-local gate and is not run in CI.
+On an unsupported development host, point `STELLA_DATABASE_URL` at an external
+PostgreSQL with `pg_search` and `pgvector` to run the server manually, or file an
+issue for the platform. The tag-triggered release workflow pins a supported
+Ubuntu runner and invokes `mise run system-test`; its runtime-download dependency
+fails before the suite if that runner ever becomes unsupported, so publication
+cannot treat an unsupported-platform skip as a pass.
 
 ## Suite architecture
 

--- a/web/content/docs/development/rules/system-test.zh.md
+++ b/web/content/docs/development/rules/system-test.zh.md
@@ -48,9 +48,10 @@ mise run system-test
   `trixie`；
 - **macOS arm64**。
 
-在不支持的主机上，可将 `STELLA_DATABASE_URL` 指向一个带 `pg_search` 与 `pgvector` 的外部
-PostgreSQL 来手动运行服务器，或为该平台提 issue。由于套件在非受支持平台上是跳过而非失败，
-它始终是一个本地 gate，不进 CI。
+在不支持的开发主机上，可将 `STELLA_DATABASE_URL` 指向一个带 `pg_search` 与 `pgvector` 的
+外部 PostgreSQL 来手动运行服务器，或为该平台提 issue。Tag Release workflow 固定使用受支持的
+Ubuntu runner，并调用 `mise run system-test`；若该 runner 将来变得不受支持，它的 runtime 下载
+依赖会在套件执行前失败，因此发布流程不会把“不支持平台”的 skip 误算成 pass。
 
 ## 套件架构
 


### PR DESCRIPTION
## What

Add a blocking `Validate Tagged Commit` job to the tag-triggered release workflow and require it before either GoReleaser or Docker publication can start.

## Why

A `v*` tag currently enters publication without re-running Stella's deterministic release gates. A green branch build is not sufficient evidence for the exact tag event, and a validation failure must happen before any archive, package, image layer, or registry cache is published.

## How

- Check out `${{ github.sha }}` with tag history and fail unless `HEAD`, the event SHA, and the event tag ref resolve to the same commit.
- Run generation drift, formatting/lint, build, Go/Web tests, the real subprocess System Test, GoReleaser config validation, and a release snapshot on pinned `ubuntu-24.04`.
- Upload System Test server logs before the snapshot build cleans `dist/`.
- Make both `goreleaser` and the Docker matrix directly `needs: validate`; keep Docker manifest merge dependent on both publication jobs.
- Default the workflow token to `contents: read`, then grant only `contents: write` to GoReleaser and `packages: write` to Docker publication jobs. Remove unused OIDC permissions.
- Check out the immutable event SHA again in both publication jobs.

This intentionally does not promote the validation snapshot itself: build-once candidate identity and promotion remain #837.

## Verification

- `mise run format`
- `mise run build`
- `mise run test`
- Clean-checkout simulation of the full validation sequence:
  - `mise run generate:check`
  - `prek run --all-files`
  - `mise run build`
  - `mise run test`
  - `mise run system-test`
  - `mise run release:check`
  - `mise run release:snapshot`
- `actionlint 1.7.12 .github/workflows/release.yml`
- `act -l -W .github/workflows/release.yml`
- YAML parse, dependency/permission assertions, identity-script check, and `git diff --check`

## Refs

Closes #834

Refs #772
