### PR TITLE
📚 docs: codify Feishu and GitHub tracking workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,65 @@
+name: Bug report
+description: Report reproducible incorrect behavior in Stella.
+title: "bug: "
+labels:
+  - bug
+  - status:needs-triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve Stella. Search existing issues first and remove secrets or private data from everything you submit.
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened?
+      description: Describe the incorrect behavior clearly and concisely.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: How can we reproduce it?
+      description: Give the smallest reliable sequence of steps, commands, or input.
+      placeholder: |
+        1. Configure ...
+        2. Run ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Stella version or commit, operating system, deployment method, and relevant provider or channel.
+      placeholder: |
+        Stella: v0.61.0
+        OS: macOS 15.5 arm64
+        Deployment: Homebrew
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Include only relevant evidence. Redact tokens, credentials, personal data, and private content.
+  - type: textarea
+    id: refs
+    attributes:
+      label: References
+      description: Link related issues, pull requests, discussions, or documentation.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission checks
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: I removed secrets, credentials, and private data from this report.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/CherryHQ/stella/security/advisories/new
+    about: Report vulnerabilities privately. Do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,49 @@
+name: Feature request
+description: Propose a user-visible capability or improvement.
+title: "feat: "
+labels:
+  - enhancement
+  - status:needs-triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the problem before prescribing a solution. Accepted requests remain on GitHub until maintainers commit them to the delivery plan.
+  - type: textarea
+    id: what
+    attributes:
+      label: What should Stella enable?
+      description: Describe the desired outcome in one or two sentences.
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why is this needed?
+      description: Explain the concrete user problem, who has it, and its impact.
+    validations:
+      required: true
+  - type: textarea
+    id: how
+    attributes:
+      label: Suggested approach
+      description: Optional. Include constraints and acceptance criteria if known.
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe current workarounds or simpler alternatives.
+  - type: textarea
+    id: refs
+    attributes:
+      label: References
+      description: Link examples, related issues, designs, discussions, or documentation.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission checks
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: This request describes a problem or outcome, not only a preferred implementation.
+          required: true

--- a/.github/ISSUE_TEMPLATE/other.yml
+++ b/.github/ISSUE_TEMPLATE/other.yml
@@ -1,0 +1,39 @@
+name: Documentation or other issue
+description: Report documentation problems or work that does not fit the other forms.
+title: ""
+labels:
+  - status:needs-triage
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What needs to change?
+      description: Describe the problem or requested outcome clearly.
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why is this needed?
+      description: Explain the impact of leaving the current behavior or documentation unchanged.
+    validations:
+      required: true
+  - type: textarea
+    id: how
+    attributes:
+      label: Suggested approach
+      description: Optional. Include acceptance criteria if known.
+  - type: textarea
+    id: refs
+    attributes:
+      label: References
+      description: Link affected pages, related issues, pull requests, discussions, or other evidence.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission checks
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: I removed secrets, credentials, and private data from this report.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## What
+
+<!-- Summarize the delivered change in one or two sentences. -->
+
+## Why
+
+<!-- Explain the problem and why this change is necessary. -->
+
+## How
+
+<!-- Describe the approach, important decisions, and deliberate limits. -->
+
+## Test
+
+<!-- List the exact checks run and their results. Say why if a relevant check was skipped. -->
+
+## Refs
+
+<!-- Every PR must link an issue. Use "Closes #123" when this PR completes it, or "Refs #123" for partial work. -->
+
+Closes #
+
+## Checklist
+
+- [ ] The PR links a GitHub issue.
+- [ ] I added or updated focused tests for changed non-trivial behavior, or explained why none are needed.
+- [ ] I updated relevant English and Chinese documentation, or no documentation change is needed.
+- [ ] I ran `mise run format && mise run build && mise run test`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ Rules in `web/content/docs/development/rules/` are the **source of truth** for d
 | Web perf testing  | `web-perf-test.md`   | Measuring or optimizing web UI performance                                  |
 | Backend API test  | `api-test.md`        | Testing the backend via live HTTP API + DB assertions (no browser)          |
 | System test       | `system-test.md`     | Adding or running the subprocess system suite; choosing a test layer        |
-| Project tracking  | `project-tracker.md` | Managing GitHub issues and project board                                    |
+| Project tracking  | `project-tracker.md` | Managing Feishu plans, GitHub issues, and pull requests                     |
 | Release           | `release.md`         | Cutting a release, tagging, changelog                                       |
 | Marketing         | `marketing.md`       | Writing a landing page, README opener, hero copy, or any marketing content  |
 
@@ -70,7 +70,7 @@ When behavior, APIs, config, commands, or architecture change:
 ## Issue & PR tracking
 
 - **Every PR must link to a GitHub issue.** If a PR is being created without an associated issue, stop and ask the user to create one first (or create it on their behalf). No PR should be opened without a traceable issue.
-- When starting a new feature or task, ensure a tracked GitHub issue exists; if not, create one and add it to the project board. **Read `web/content/docs/development/rules/project-tracker.md`** for the full workflow.
+- When starting a new feature or task, ensure a tracked GitHub issue exists. Maintainer-committed work must also be linked from a Feishu Task; community issues remain GitHub-only until accepted and scheduled. **Read `web/content/docs/development/rules/project-tracker.md`** for the full workflow.
 
 ## Commit style
 

--- a/resources/skills/system/stella/references/report-issue.md
+++ b/resources/skills/system/stella/references/report-issue.md
@@ -10,9 +10,9 @@ Never create an issue without explicit confirmation, and never run the flow with
 2. **Draft the issue.** Summarize the problem from the conversation and recent errors. Ask clarifying questions only when required context is missing. Use the standard structure below.
 3. **Get explicit confirmation.** Show the user the drafted title and body. Do not create the issue until they approve.
 4. **Check GitHub link status:** use the `oauth` tool with `action=list`. If GitHub is not connected, run the OAuth flow (next section) before continuing. Do not ask the user to authenticate `gh` manually.
-5. **Create the issue** once approved and authenticated. Use a heredoc for the body — a literal `\n` inside a double-quoted `--body` is written verbatim, not as a newline. Add a `bug` label (or `docs`/`enhancement` if it fits better):
+5. **Create the issue** once approved and authenticated. Use a heredoc for the body — a literal `\n` inside a double-quoted `--body` is written verbatim, not as a newline. Add a `bug` label (or `documentation`/`enhancement` if it fits better):
    ```bash
-   gh issue create --repo CherryHQ/stella --label bug \
+   gh issue create --repo CherryHQ/stella --label bug --label status:needs-triage \
      --title "<title>" \
      --body "$(cat <<'EOF'
    ## What
@@ -25,7 +25,7 @@ Never create an issue without explicit confirmation, and never run the flow with
 
 ## Issue structure
 
-Follow the project's standard four-section format (the What/Why/How/Refs convention from the repo's issue template). A user-reported bug only needs the issue itself with a label — skip the milestone and project-board steps the full tracker workflow uses.
+Follow the project's standard four-section format (the What/Why/How/Refs convention from the repo's issue template). A user-reported bug remains GitHub-only with `status:needs-triage` until a maintainer accepts and schedules it. Do not create a Feishu task or assign a release milestone during this reporting flow.
 
 ```markdown
 ## What

--- a/web/content/docs/development/rules/project-tracker.md
+++ b/web/content/docs/development/rules/project-tracker.md
@@ -1,214 +1,189 @@
 ---
 title: Project tracker
-description: GitHub Projects and Issues workflow for Stella requirements and status.
+description: Feishu planning and GitHub execution workflow for Stella.
 ---
 
-Manage requirements and development status entirely in GitHub. **GitHub Projects**
-owns the product layer (status, priority, roadmap views). **GitHub Issues** are
-the execution artifacts (description, labels, assignee, milestone, linked PRs).
+Stella uses two trackers with separate ownership:
 
-Only tool needed: `gh` CLI.
+- **Feishu Base** owns internal planning: Roadmap, product milestones,
+  candidate and committed tasks, priority, target dates, and delivery
+  ownership.
+- **GitHub** owns the public and engineering record: community intake, issue
+  details, technical discussion, assignees, pull requests, and release scope.
 
-## Known projects
+Do not create a GitHub Project or duplicate the same editable field in both
+systems. A missing Feishu task means that a GitHub issue is not committed to a
+delivery plan; it does not mean that the issue is invalid.
 
-Use these coordinates directly — do not re-resolve or guess:
+The planning Base is
+[Stella Roadmap](https://mcnnox2fhjfq.feishu.cn/base/BEEbbI9jtad6PmsYSXpcmBy2nUd?table=tbl4pUhlngTJdg2Z&view=vewBhCvlG1).
 
-| Project                                                        | Repo              | Number | Node ID                |
-| -------------------------------------------------------------- | ----------------- | ------ | ---------------------- |
-| [Stella](https://github.com/orgs/CherryHQ/projects/14/views/1) | `CherryHQ/stella` | 14     | `PVT_kwDOCzFCf84BXEej` |
+## Ownership
 
-### Project fields (Stella #14)
+| Concern                                                        | Source of truth          | Notes                                          |
+| -------------------------------------------------------------- | ------------------------ | ---------------------------------------------- |
+| Roadmap and product direction                                  | Feishu Roadmap           | Internal planning, not copied to GitHub        |
+| Product milestone and acceptance                               | Feishu Milestones        | Outcome-oriented; may span releases            |
+| Candidate work, commitment, priority, dates, DRI, dependencies | Feishu Tasks             | A task becomes committed when it enters `就绪` |
+| Public request and technical discussion                        | GitHub Issue             | Community issues remain here before commitment |
+| Implementation and current engineer                            | GitHub Issue and PR      | Use assignees, links, and comments             |
+| Release scope                                                  | GitHub release milestone | Version names only, such as `v0.61.0`          |
+| Code delivery                                                  | GitHub PR                | A PR must link its issue                       |
 
-| Field      | ID                               | Type          | Options                                                                                    |
-| ---------- | -------------------------------- | ------------- | ------------------------------------------------------------------------------------------ |
-| Title      | `PVTF_lADOCzFCf84BXEejzhST8rM`   | text          | —                                                                                          |
-| Assignees  | `PVTF_lADOCzFCf84BXEejzhST8rQ`   | text          | —                                                                                          |
-| **Status** | `PVTSSF_lADOCzFCf84BXEejzhST8rU` | single-select | Backlog (`d98918fd`), Todo (`f75ad846`), In Progress (`47fc9ee4`), Done (`98236657`)       |
-| **Week**   | `PVTIF_lADOCzFCf84BXEejzhUocBE`  | iteration     | 7-day cycles starting Monday. Query current iteration IDs before setting `--iteration-id`. |
-| Labels     | `PVTF_lADOCzFCf84BXEejzhST8rY`   | text          | —                                                                                          |
-| Linked PRs | `PVTF_lADOCzFCf84BXEejzhST8rc`   | text          | —                                                                                          |
-| Milestone  | `PVTF_lADOCzFCf84BXEejzhST8rg`   | text          | —                                                                                          |
-| Repository | `PVTF_lADOCzFCf84BXEejzhST8rk`   | text          | —                                                                                          |
+The Feishu task's DRI owns delivery; the GitHub assignee is the current
+implementer. They may be different people.
 
-## Status workflow
+## Milestone semantics
 
+Product milestones and release milestones are deliberately different:
+
+- A **Feishu product milestone** describes an outcome, such as “Multimodal
+  model support”.
+- A **GitHub release milestone** describes a version, such as `v0.61.0`.
+
+Never synchronize or reuse names between them. The linked GitHub issue carries
+the target release when one is known. Do not create thematic GitHub milestones
+or `release:*` labels.
+
+## Feishu structure
+
+```text
+Roadmap
+  └── Milestones
+        └── Tasks ── GitHub Issue URL
 ```
-Backlog → Todo → In Progress → Done
+
+Use the canonical fields and lifecycle values below. Do not add synonyms or
+one-off states.
+
+- Roadmap: `战线`, `一句话方向`, `状态` (`候选`, `进行中`, `暂停`, `已完成`),
+  `DRI`, `里程碑`.
+- Milestones: `里程碑`, `状态` (`候选`, `已计划`, `进行中`, `暂停`,
+  `已完成`, `已取消`), `目标与验收`, `DRI`, `目标日期`, `预计人周`,
+  `所属战线`, `任务`.
+- Tasks: `任务`, `状态` (`待评估`, `就绪`, `进行中`, `阻塞`, `已完成`,
+  `已取消`), `优先级`, `DRI`, `里程碑`, `GitHub Issue`, `验收标准`,
+  dates, estimate, `父任务`, `依赖任务`, `依赖说明`, `触发条件`, product
+  line, and references.
+
+`待评估` tasks are internal candidates and do not need a GitHub issue. Every
+task at `就绪` or later must contain a full GitHub Issue URL. Store the URL,
+not only the issue number. Draft acceptance in Feishu while evaluating a task.
+When promoting it to `就绪`, copy the complete requirement and acceptance
+criteria to GitHub; the issue becomes the execution source of truth.
+
+## Community issue triage
+
+Issue forms add `status:needs-triage` to new community reports.
+
+```text
+New GitHub issue
+  ├── invalid / duplicate / question → explain and close or redirect
+  ├── valid, not scheduled           → status:accepted; GitHub only
+  └── committed                      → Feishu Task at 就绪 + status:ready
 ```
 
-- **Backlog** — acknowledged but not yet committed to.
-- **Todo** — accepted and scheduled; ready to pick up.
-- **In Progress** — actively being worked on.
-- **Done** — issue closed (automatically moves here if project auto-close is enabled).
+During triage:
 
-## Common operations
+1. Reproduce or clarify the request.
+2. Apply the appropriate type label (`bug`, `enhancement`, `documentation`, or
+   `design`).
+3. Remove `status:needs-triage`.
+4. If valid but unscheduled, add `status:accepted`. Do not create a Feishu task.
+5. If committed, search Feishu and GitHub for duplicates, create or link the
+   Feishu task, add its GitHub Issue URL, move it to `就绪`, remove
+   `status:accepted`, and add `status:ready`.
+6. Add a version milestone only when the target release is known.
 
-All operations use the `gh` CLI. Owner is `CherryHQ`, project number is `14`.
+## Execution lifecycle
 
-### View the board
+| Event                 | Feishu Task                | GitHub                                       |
+| --------------------- | -------------------------- | -------------------------------------------- |
+| Candidate             | `待评估`                   | No issue required                            |
+| Committed and ready   | `就绪`                     | Open + `status:ready`                        |
+| Work starts           | `进行中`                   | Remove `status:ready`; assign or link a PR   |
+| Blocked               | `阻塞`                     | Add `status:blocked` and explain the blocker |
+| Implementation closes | unchanged until acceptance | Close through the PR                         |
+| Acceptance passes     | `已完成`                   | Closed                                       |
+| Cancelled             | `已取消`                   | Close with the reason                        |
+
+Closing an issue does not automatically complete the Feishu task; the DRI
+marks it `已完成` after acceptance.
+
+## Maintainer-planned work
+
+Create internal ideas as `待评估` Tasks only when they are concrete enough to
+estimate or compare. Do not create speculative GitHub issues. When the team
+commits a task:
+
+1. Search GitHub for an existing community issue.
+2. Link it when one exists; otherwise create a new issue.
+3. Put the full Issue URL and final acceptance criteria in the Feishu task, then
+   move it to `就绪`.
+4. Add `status:ready` and, when known, a version milestone to the issue.
+
+Contributors do not need Feishu access. Maintainers own the Feishu promotion
+step when accepting community work.
+
+## GitHub labels
+
+Project-tracking labels are intentionally small:
+
+- Type and resolution: `bug`, `enhancement`, `documentation`, `design`,
+  `duplicate`, `invalid`, `question`, `wontfix`.
+- Intake and execution: `status:needs-triage`, `status:accepted`,
+  `status:ready`, `status:blocked`.
+- Contributor help: `good first issue`, `help wanted`.
+
+Automation-owned labels such as `dependencies`, `go`, and `javascript` may
+remain on generated pull requests. Do not add priority labels; priority belongs
+to Feishu. Do not add release labels; the version milestone is the release
+record.
+
+Common operations:
 
 ```bash
-# all items
-gh project item-list 14 --owner CherryHQ --format json
-
-# filter by status (use jq)
-gh project item-list 14 --owner CherryHQ --format json \
-  | jq '[.items[] | select(.status == "In Progress")]'
-
-# quick summary
-gh project item-list 14 --owner CherryHQ
+gh issue list --repo CherryHQ/stella --label status:needs-triage
+gh issue edit <number> --repo CherryHQ/stella \
+  --remove-label status:needs-triage --add-label status:accepted
+gh issue edit <number> --repo CherryHQ/stella \
+  --remove-label status:accepted --add-label status:ready
+gh issue edit <number> --repo CherryHQ/stella --milestone v0.61.0
 ```
 
-### Create an issue and add to project
+## Issue and pull request conventions
 
-```bash
-# 1. create the issue. Use a heredoc for the body — a "\n" inside a
-#    double-quoted --body is written literally, not as a newline.
-gh issue create --repo CherryHQ/stella \
-  --title "feat: ..." \
-  --milestone "v0.42.0" \
-  --body "$(cat <<'EOF'
-## What
-...
-## Why
-...
-## How
-...
-## Refs
-...
-EOF
-)"
+Use an issue form for community reports. Maintainer-created implementation
+issues use **What**, **Why**, **How**, and **Refs**. Keep issue descriptions
+current and do not copy issue comments into Feishu.
 
-# 2. add it to the project. The "Auto-add to project" workflow already adds new
-#    issues automatically, so this is usually redundant (it's idempotent — adding
-#    an already-present issue just returns the existing item). Run it to capture
-#    the item ID for the next step:
-ITEM_ID=$(gh project item-add 14 --owner CherryHQ --url <issue-url> --format json --jq '.id')
+Every PR must link a GitHub issue. Use `Closes #123` when the PR completes it,
+or `Refs #123` for partial work. Complete the PR template's What, Why, How,
+Test, and Refs sections.
 
-# 3. set initial status
-gh project item-edit \
-  --project-id PVT_kwDOCzFCf84BXEej \
-  --id "$ITEM_ID" \
-  --field-id PVTSSF_lADOCzFCf84BXEejzhST8rU \
-  --single-select-option-id f75ad846   # Todo
-```
+## Creating issues for a user
 
-### Move an item to a different status
+Before creating an issue on a user's behalf:
 
-```bash
-gh project item-edit \
-  --project-id PVT_kwDOCzFCf84BXEej \
-  --id <item-id> \
-  --field-id PVTSSF_lADOCzFCf84BXEejzhST8rU \
-  --single-select-option-id <option-id>
-```
+1. Draft and confirm its title and body.
+2. Choose the type label.
+3. Ask whether the work is merely accepted or already committed.
+4. For accepted-only work, add `status:accepted` and stop.
+5. For committed work, confirm that a Feishu task will link the new issue, and
+   ask whether a version milestone is known. `none` is valid.
 
-Status option IDs:
+Then create the issue. For committed work, create or update the Feishu task
+with the returned URL, move it to `就绪`, and add `status:ready`; finally return
+the Issue URL. Do not bulk-create issues without confirmation, and prefer
+closing over deleting.
 
-- Backlog: `d98918fd`
-- Todo: `f75ad846`
-- In Progress: `47fc9ee4`
-- Done: `98236657`
+## Automation boundary
 
-### Set week on an item
+The workflow is manual until repeated evidence justifies automation. The only
+safe initial automation candidates are:
 
-```bash
-# query current iteration IDs
-gh api graphql -f query='{
-  node(id: "PVT_kwDOCzFCf84BXEej") {
-    ... on ProjectV2 {
-      field(name: "Week") {
-        ... on ProjectV2IterationField {
-          configuration {
-            iterations { id title startDate }
-          }
-        }
-      }
-    }
-  }
-}'
+1. create or link an issue when a task enters `就绪` and write back its URL;
+2. notify the Feishu task when the linked issue is closed or reopened.
 
-# set an item to a specific week
-gh project item-edit \
-  --project-id PVT_kwDOCzFCf84BXEej \
-  --id <item-id> \
-  --field-id PVTIF_lADOCzFCf84BXEejzhUocBE \
-  --iteration-id <iteration-id>
-```
-
-### View a specific issue
-
-```bash
-gh issue view <number> --repo CherryHQ/stella
-gh issue view <number> --repo CherryHQ/stella --json state,labels,assignees,milestone,projectItems
-```
-
-### List open issues
-
-```bash
-gh issue list --repo CherryHQ/stella
-gh issue list --repo CherryHQ/stella --label "bug" --assignee "@me"
-```
-
-### Update an issue
-
-```bash
-gh issue edit <number> --repo CherryHQ/stella --add-label "priority:p0"
-gh issue edit <number> --repo CherryHQ/stella --add-assignee vaayne
-gh issue close <number> --repo CherryHQ/stella
-```
-
-## Issue conventions
-
-Follow the repo's issue/PR template:
-
-- **What** — the change in one or two sentences.
-- **Why** — the motivation or problem it solves.
-- **How** — the approach, plan, and design details.
-- **Refs** — related issues, PRs, docs, or discussions.
-
-Keep issue and PR descriptions current as the plan evolves.
-
-### Labels
-
-Use labels for categorization. Common patterns:
-
-- `bug`, `feature`, `enhancement`, `docs`
-- `priority:p0` through `priority:p3`
-- `status:in-review` — PR is open and awaiting review
-
-### Milestones & releases
-
-Every release maps to a GitHub Milestone (e.g., `v0.42.0`). Use milestones to
-scope what ships in a release:
-
-```
-Plan:    gh issue edit #123 --milestone v0.42.0
-Track:   gh issue list --repo CherryHQ/stella --milestone v0.42.0
-Release: /release → tag + changelog → close milestone
-```
-
-Release mechanics live in [`release.md`](./release.md).
-
-## Creating issues — interaction flow
-
-When creating an issue, **always ask the user** for:
-
-1. **Title and description** — draft from context if available, confirm before creating.
-2. **Milestone** — list open milestones (`gh api repos/CherryHQ/stella/milestones --jq '.[].title'`)
-   and ask which one to assign. If the list is empty or none fit, ask whether to
-   create one (`gh api repos/CherryHQ/stella/milestones -f title=vX.Y.Z`) or skip
-   (allow "none" for un-scoped work).
-3. **Status** — default Backlog; ask if it should be Todo or In Progress.
-4. **Week** — ask if it should be tagged to the current week.
-
-Then execute: create issue → add to project → set Status / Week / Milestone.
-
-## Guardrails
-
-- Prefer **closing** over deleting issues — `gh issue delete` usually lacks permission.
-- Don't bulk-create issues without confirmation — ask the user first.
-- When creating issues from a list of requirements, create them one at a time and
-  confirm each title/body before proceeding.
-- Always add new issues to the project board after creation.
-- Always ask for milestone assignment when creating issues.
+Do not bidirectionally synchronize descriptions, comments, assignees,
+priorities, dates, milestones, or deletion. Each field already has one owner.

--- a/web/content/docs/development/rules/project-tracker.zh.md
+++ b/web/content/docs/development/rules/project-tracker.zh.md
@@ -1,0 +1,145 @@
+---
+title: 项目跟踪
+description: Stella 的飞书计划与 GitHub 执行流程。
+---
+
+Stella 使用两个职责分离的跟踪系统：
+
+- **飞书多维表格**负责内部计划：Roadmap、产品里程碑、候选与已承诺任务、优先级、目标日期和交付负责人。
+- **GitHub** 负责公开与研发记录：社区需求入口、Issue 详情、技术讨论、Assignee、PR 和发布范围。
+
+不要创建 GitHub Project，也不要让同一个可编辑字段同时存在于两套系统。GitHub Issue 没有飞书任务，只表示团队尚未承诺交付，不表示 Issue 无效。
+
+计划表为 [Stella Roadmap](https://mcnnox2fhjfq.feishu.cn/base/BEEbbI9jtad6PmsYSXpcmBy2nUd?table=tbl4pUhlngTJdg2Z&view=vewBhCvlG1)。
+
+## 职责归属
+
+| 内容                                    | 事实源                   | 说明                             |
+| --------------------------------------- | ------------------------ | -------------------------------- |
+| Roadmap 与产品方向                      | 飞书 Roadmap             | 内部计划，不复制到 GitHub        |
+| 产品里程碑与验收                        | 飞书 Milestones          | 面向成果，可以跨多个版本         |
+| 候选工作、承诺、优先级、日期、DRI、依赖 | 飞书 Tasks               | Task 进入 `就绪` 时代表团队承诺  |
+| 公开需求与技术讨论                      | GitHub Issue             | 社区 Issue 在承诺前只留在 GitHub |
+| 实现过程与当前开发者                    | GitHub Issue 与 PR       | 使用 Assignee、链接和评论        |
+| 发布范围                                | GitHub Release Milestone | 只使用 `v0.61.0` 这类版本名      |
+| 代码交付                                | GitHub PR                | PR 必须关联 Issue                |
+
+飞书 Task 的 DRI 对交付结果负责；GitHub Assignee 是当前实现者，两者可以不是同一个人。
+
+## Milestone 语义
+
+产品里程碑与发布里程碑刻意分开：
+
+- **飞书产品里程碑**描述成果，例如“支持多模态模型”。
+- **GitHub 发布里程碑**描述版本，例如 `v0.61.0`。
+
+不要同步两者，也不要复用名称。目标版本明确后，记录在关联 GitHub Issue 的发布 Milestone 上。不要创建主题型 GitHub Milestone 或 `release:*` label。
+
+## 飞书结构
+
+```text
+Roadmap
+  └── Milestones
+        └── Tasks ── GitHub Issue URL
+```
+
+严格使用下面的标准字段和生命周期，不添加同义或一次性状态：
+
+- Roadmap：`战线`、`一句话方向`、`状态`（`候选`、`进行中`、`暂停`、`已完成`）、`DRI`、`里程碑`。
+- Milestones：`里程碑`、`状态`（`候选`、`已计划`、`进行中`、`暂停`、`已完成`、`已取消`）、`目标与验收`、`DRI`、`目标日期`、`预计人周`、`所属战线`、`任务`。
+- Tasks：`任务`、`状态`（`待评估`、`就绪`、`进行中`、`阻塞`、`已完成`、`已取消`）、`优先级`、`DRI`、`里程碑`、`GitHub Issue`、`验收标准`、日期、估算、`父任务`、`依赖任务`、`依赖说明`、`触发条件`、产品线和引用。
+
+`待评估` Task 是内部候选，不要求 GitHub Issue。进入 `就绪` 或后续状态的 Task 必须填写完整 GitHub Issue URL，不要只存 Issue number。评估阶段在飞书起草验收标准；晋级到 `就绪` 时，把完整需求和验收条件写入 GitHub，此后 Issue 是研发执行事实源。
+
+## 社区 Issue 分流
+
+Issue 表单会为新的社区报告添加 `status:needs-triage`。
+
+```text
+新 GitHub Issue
+  ├── 无效 / 重复 / 问题咨询 → 解释后关闭或转到正确入口
+  ├── 有效但未排期           → status:accepted；只留在 GitHub
+  └── 已承诺                 → 飞书 Task 就绪 + status:ready
+```
+
+分流步骤：
+
+1. 复现或澄清需求。
+2. 添加合适的类型标签：`bug`、`enhancement`、`documentation` 或 `design`。
+3. 移除 `status:needs-triage`。
+4. 有效但未排期时添加 `status:accepted`，不要创建飞书 Task。
+5. 确认承诺后，先在飞书和 GitHub 搜索重复项，再创建或关联飞书 Task，填入 GitHub Issue URL，将其改为 `就绪`，移除 `status:accepted`，添加 `status:ready`。
+6. 只有明确目标发布版本后才添加版本 Milestone。
+
+## 执行生命周期
+
+| 事件           | 飞书 Task  | GitHub                                       |
+| -------------- | ---------- | -------------------------------------------- |
+| 候选           | `待评估`   | 不要求 Issue                                 |
+| 已承诺并可开发 | `就绪`     | Open + `status:ready`                        |
+| 开始开发       | `进行中`   | 移除 `status:ready`；分配 Assignee 或关联 PR |
+| 阻塞           | `阻塞`     | 添加 `status:blocked` 并解释阻塞原因         |
+| 实现关闭       | 验收前不变 | 通过 PR 关闭                                 |
+| 验收通过       | `已完成`   | Closed                                       |
+| 取消           | `已取消`   | 说明原因后关闭                               |
+
+关闭 GitHub Issue 不会自动完成飞书 Task；DRI 验收后再将 Task 改为 `已完成`。
+
+## 维护者计划的工作
+
+未承诺的内部想法具体到可以估算或比较时，以 `待评估` Task 记录；不要创建猜想中的 GitHub Issue。团队承诺任务时：
+
+1. 搜索是否已有对应的社区 Issue。
+2. 有则直接关联，没有再创建。
+3. 在飞书 Task 填入完整 Issue URL 和最终验收标准，再改为 `就绪`。
+4. 为 Issue 添加 `status:ready`；目标版本明确时再添加版本 Milestone。
+
+外部贡献者不需要访问飞书。接受社区工作时，由维护者完成飞书侧的晋级操作。
+
+## GitHub Labels
+
+项目管理标签刻意保持精简：
+
+- 类型与结论：`bug`、`enhancement`、`documentation`、`design`、`duplicate`、`invalid`、`question`、`wontfix`。
+- Intake 与执行：`status:needs-triage`、`status:accepted`、`status:ready`、`status:blocked`。
+- 贡献者辅助：`good first issue`、`help wanted`。
+
+`dependencies`、`go`、`javascript` 等自动化标签可以保留在生成的 PR 上。不要添加 priority label，优先级由飞书负责；不要添加 release label，版本 Milestone 就是发布记录。
+
+常用操作：
+
+```bash
+gh issue list --repo CherryHQ/stella --label status:needs-triage
+gh issue edit <number> --repo CherryHQ/stella \
+  --remove-label status:needs-triage --add-label status:accepted
+gh issue edit <number> --repo CherryHQ/stella \
+  --remove-label status:accepted --add-label status:ready
+gh issue edit <number> --repo CherryHQ/stella --milestone v0.61.0
+```
+
+## Issue 与 PR 约定
+
+社区报告使用 Issue 表单。维护者创建的实现 Issue 使用 **What**、**Why**、**How** 和 **Refs**。计划变化时及时更新 Issue，不要把 Issue 评论复制到飞书。
+
+每个 PR 都必须关联 GitHub Issue。PR 完成整个 Issue 时使用 `Closes #123`；只完成一部分时使用 `Refs #123`。完整填写 PR 模板中的 What、Why、How、Test 和 Refs。
+
+## 代用户创建 Issue
+
+代用户创建 Issue 前：
+
+1. 起草并确认标题和正文。
+2. 选择类型标签。
+3. 确认工作只是已接受，还是已经承诺交付。
+4. 仅接受时添加 `status:accepted`，然后结束。
+5. 已承诺时确认飞书 Task 将关联新 Issue，并询问是否已有目标版本；`none` 是合法答案。
+
+随后创建 Issue。已承诺的工作还要用返回的 URL 创建或更新飞书 Task，将其改为 `就绪`，并添加 `status:ready`；最后返回 Issue URL。未经确认不要批量创建；优先关闭而不是删除。
+
+## 自动化边界
+
+在反复出现明确痛点之前保持手工流程。初期仅考虑两项自动化：
+
+1. 飞书 Task 进入 `就绪` 时创建或关联 Issue，并回写 URL；
+2. 关联 Issue 关闭或重新打开时通知飞书 Task。
+
+不要双向同步描述、评论、Assignee、优先级、日期、Milestone 或删除操作；这些字段已经各有唯一 owner。

--- a/web/content/docs/development/rules/release.md
+++ b/web/content/docs/development/rules/release.md
@@ -33,29 +33,33 @@ GoReleaser auto-detects pre-release suffixes (`-rc.1`, `-beta.1`).
    git log --oneline -1
    ```
    Stop if the release commit is not `HEAD`; never tag before the commit exists.
-7. Tag the release commit and verify the tag points at `HEAD`:
+7. Verify that the version milestone contains the exact release scope and has
+   no open issues. Stop and resolve any open issue before tagging:
+   ```bash
+   gh issue list --repo CherryHQ/stella --milestone vX.Y.Z --state open
+   gh issue list --repo CherryHQ/stella --milestone vX.Y.Z --state all
+   ```
+8. Tag the release commit and verify the tag points at `HEAD`:
    ```bash
    git tag vX.Y.Z
    test "$(git rev-parse vX.Y.Z)" = "$(git rev-parse HEAD)"
    ```
-8. Tag release issues with the release label so they are traceable on the GitHub Project board:
-
-   ```bash
-   # warn about any issue still open in the milestone before tagging
-   gh issue list --repo CherryHQ/stella --milestone vX.Y.Z --state open
-
-   # label every issue in the milestone with release:vX.Y.Z (--add-label is idempotent)
-   gh issue list --repo CherryHQ/stella --milestone vX.Y.Z --state all \
-     --json number --jq '.[].number' \
-   | xargs -I{} gh issue edit {} --repo CherryHQ/stella --add-label "release:vX.Y.Z"
-   ```
-
-   Filter the project board by the `release:vX.Y.Z` label to confirm the release scope.
-
 9. Push the branch and new release tag explicitly: `git push origin main vX.Y.Z`.
 10. CI triggers `.github/workflows/release.yml`. Its validation job checks the
     exact tagged commit before the GoReleaser or Docker publication jobs can
     start.
+11. After CI succeeds and the GitHub Release is visible, close the version
+    milestone:
+    ```bash
+    MILESTONE_NUMBER=$(gh api 'repos/CherryHQ/stella/milestones?state=open' \
+      --jq '.[] | select(.title == "vX.Y.Z") | .number')
+    test -n "$MILESTONE_NUMBER"
+    gh api --method PATCH "repos/CherryHQ/stella/milestones/$MILESTONE_NUMBER" \
+      -f state=closed
+    ```
+
+The version milestone is the durable release record. Do not create a duplicate
+`release:vX.Y.Z` label.
 
 ## Update Changelog
 

--- a/web/content/docs/development/rules/release.zh.md
+++ b/web/content/docs/development/rules/release.zh.md
@@ -1,0 +1,89 @@
+---
+title: 发布
+description: Stella 的发布打标与打包流程。
+---
+
+## Tag 格式
+
+使用带 `v` 前缀的语义化版本：`v0.1.0`、`v1.0.0`、`v1.2.3-rc.1`。GoReleaser 会自动识别 `-rc.1`、`-beta.1` 这类预发布后缀。
+
+## 发布流程
+
+1. 选择发布 tag `vX.Y.Z`；Web package 版本为不带 `v` 的 `X.Y.Z`。
+2. 更新 `web/package.json`，确保 `.version` 与 API/server 发布版本一致：
+   ```bash
+   VERSION=X.Y.Z
+   tmp=$(mktemp)
+   jq --arg version "$VERSION" '.version = $version' web/package.json > "$tmp" && mv "$tmp" web/package.json
+   test "$(jq -r '.version' web/package.json)" = "$VERSION"
+   ```
+3. 更新 `deploy/helm/stella/Chart.yaml` 中的 Helm chart 元数据：
+   - 将 `appVersion` 设为 `"vX.Y.Z"`，记录 chart 同期交付的应用版本。默认 `image.tag` 为 `latest`，CI 会在每个稳定版本发布它，因此全新安装会直接使用该版本；`appVersion` 只负责保持元数据准确。
+   - 如果 chart 自上次发布后发生变化，递增 chart 自身独立的 SemVer `version`。
+4. 更新 `web/content/docs/changelog.mdx` 和 `web/content/docs/changelog.zh.mdx`。
+5. 提交：`📝 docs: Update CHANGELOG for vX.Y.Z`，包含两份 changelog、`web/package.json` 和 `deploy/helm/stella/Chart.yaml`。
+6. 确认提交成功且工作区干净：
+   ```bash
+   git status --short
+   git log --oneline -1
+   ```
+   如果发布提交不是 `HEAD`，立即停止；提交存在前绝不打 tag。
+7. 确认版本 Milestone 包含准确的发布范围，且没有未关闭的 Issue。存在未关闭 Issue 时停止，不要打 tag：
+   ```bash
+   gh issue list --repo CherryHQ/stella --milestone vX.Y.Z --state open
+   gh issue list --repo CherryHQ/stella --milestone vX.Y.Z --state all
+   ```
+8. 为发布提交打 tag，并验证 tag 指向 `HEAD`：
+   ```bash
+   git tag vX.Y.Z
+   test "$(git rev-parse vX.Y.Z)" = "$(git rev-parse HEAD)"
+   ```
+9. 显式推送分支与新 tag：`git push origin main vX.Y.Z`。
+10. CI 触发 `.github/workflows/release.yml`。其中的 validation job 会先验证 tag 指向的确切提交，之后 GoReleaser 和 Docker 发布 job 才能开始。
+11. CI 成功且 GitHub Release 可见后，关闭版本 Milestone：
+    ```bash
+    MILESTONE_NUMBER=$(gh api 'repos/CherryHQ/stella/milestones?state=open' \
+      --jq '.[] | select(.title == "vX.Y.Z") | .number')
+    test -n "$MILESTONE_NUMBER"
+    gh api --method PATCH "repos/CherryHQ/stella/milestones/$MILESTONE_NUMBER" \
+      -f state=closed
+    ```
+
+版本 Milestone 是持久的发布记录，不要再创建重复的 `release:vX.Y.Z` label。
+
+## 更新 Changelog
+
+Changelog 位于 `web/content/docs/changelog.mdx` 和 `web/content/docs/changelog.zh.mdx`，并渲染在文档站点。文件带 YAML frontmatter；编辑时保留该区块，只修改 `---` 之后的正文，并保持中英文条目同步。
+
+收集上一个 tag 之后的变更：
+
+```bash
+git log $(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD)..HEAD --oneline
+gh pr list --state merged --base main --search "merged:>=$(git log -1 --format=%aI $(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD))"
+```
+
+同时更新两份 changelog：
+
+1. 将 `[Unreleased]` 改为 `[X.Y.Z] - YYYY-MM-DD`。
+2. 在其上方新增空的 `[Unreleased]`。
+3. 按 `✨ Features`、`🐛 Bug Fixes`、`♻️ Refactoring`、`📝 Documentation`、`📦 Dependencies` 分类。
+4. 链接 PR：`([#123](https://github.com/CherryHQ/stella/pull/123))`。
+5. 追加 `**Full Changelog**: [vPREV...vX.Y.Z](https://github.com/CherryHQ/stella/compare/vPREV...vX.Y.Z)`。
+
+## 验证与测试
+
+运行完整发布前门禁。它严格按 `format` → `build` → `test` → `system-test` → `release:check` → `release:snapshot` 执行：
+
+```bash
+VERSION=X.Y.Z
+test "$(jq -r '.version' web/package.json)" = "$VERSION"
+mise run release:validate
+```
+
+System Test 同时在本地门禁和 tag 触发的 validation job 中运行。发布 CI 固定使用支持的 Ubuntu runner，并在 snapshot build 清理 `dist/` 之前上传测试服务器日志。GoReleaser 与 Docker 发布 job 直接依赖 validation 结果，因此失败或不受支持的 System Test 无法发布部分工件。详见 `system-test.zh.md`。
+
+## 发布工件
+
+- **二进制**：linux/darwin/windows × amd64/arm64（GoReleaser）
+- **Docker**：`ghcr.io/cherryhq/stella` — linux/amd64 + linux/arm64
+- **Docker tags**：`latest`（稳定版）、`vX.Y.Z`（发布版）、SHA（每次构建）


### PR DESCRIPTION
## What

Define Stella's Feishu planning and GitHub execution workflow, add structured Issue forms and a PR template, and update release tracking to use version Milestones instead of release labels.

The accompanying operational migration has normalized the Feishu Roadmap/Milestone/Task schema and cleaned GitHub labels and Milestones.

## Why

Planning data was split across inconsistent Feishu fields, legacy GitHub Project assumptions, release labels, and thematic GitHub Milestones. That made ownership ambiguous and allowed product outcomes, engineering execution, and release scope to drift.

## How

- Make Feishu the source of truth for Roadmap, product Milestones, Task lifecycle, priority, dates, DRI, and dependencies.
- Keep community intake, implementation details, PRs, and version release scope in GitHub.
- Use selective promotion: community Issues stay GitHub-only until committed; committed Tasks enter `就绪` and link a full Issue URL.
- Standardize GitHub workflow labels to `status:needs-triage`, `status:accepted`, `status:ready`, and `status:blocked`.
- Remove release-label and thematic-Milestone workflows; version Milestones are the durable release record.
- Add English and Chinese workflow/release documentation plus repository templates.
- Deliberate limit: no broad bidirectional synchronization. Five pre-existing in-progress Feishu Tasks without GitHub Issues remain as known historical exceptions by maintainer decision.

## Test

- `mise run format` — passed
- `mise run build` — passed
- `mise run test` — passed
- Parsed all Issue form YAML with `yq` — passed
- `git diff --check` — passed
- Post-migration checks: zero release labels and zero open thematic GitHub Milestones

## Refs

Closes #847

## Checklist

- [x] The PR links a GitHub issue.
- [x] No focused code tests are needed; this changes documentation, templates, and external tracker configuration.
- [x] I updated relevant English and Chinese documentation.
- [x] I ran `mise run format && mise run build && mise run test`.