### PR TITLE
📝 docs(project-tracker): add Feishu coordinates and define when work starts

### DIFF
--- a/web/content/docs/development/rules/project-tracker.md
+++ b/web/content/docs/development/rules/project-tracker.md
@@ -56,15 +56,96 @@ Roadmap
 Use the canonical fields and lifecycle values below. Do not add synonyms or
 one-off states.
 
-- Roadmap: `战线`, `一句话方向`, `状态` (`候选`, `进行中`, `暂停`, `已完成`),
-  `DRI`, `里程碑`.
-- Milestones: `里程碑`, `状态` (`候选`, `已计划`, `进行中`, `暂停`,
-  `已完成`, `已取消`), `目标与验收`, `DRI`, `目标日期`, `预计人周`,
-  `所属战线`, `任务`.
-- Tasks: `任务`, `状态` (`待评估`, `就绪`, `进行中`, `阻塞`, `已完成`,
-  `已取消`), `优先级`, `DRI`, `里程碑`, `GitHub Issue`, `验收标准`,
-  dates, estimate, `父任务`, `依赖任务`, `依赖说明`, `触发条件`, product
-  line, and references.
+### Coordinates
+
+Use these directly — do not re-resolve or guess them from the Base URL.
+
+| Resource              | Id                            |
+| --------------------- | ----------------------------- |
+| Base token            | `BEEbbI9jtad6PmsYSXpcmBy2nUd` |
+| Tasks (`任务`)        | `tbl4pUhlngTJdg2Z`            |
+| Milestones (`里程碑`) | `tblCRcuKDjmnKCJr`            |
+| Roadmap               | `tblp9iIcKyO9NN00`            |
+
+### Fields
+
+`select` values are the complete allowed set. `user` fields take
+`[{"id":"ou_..."}]`; resolve the id with `lark-cli contact +get-user` (omit the
+user id for yourself). `link` fields take `[{"id":"recXXXXXXXXXX"}]` referencing a
+record in the table named in the Links column — read that table first to get the
+id; never invent one.
+
+**Tasks**
+
+| Field                  | Type     | Values / links to                                         |
+| ---------------------- | -------- | --------------------------------------------------------- |
+| `任务`                 | text     | The task title                                            |
+| `状态`                 | select   | `待评估`, `就绪`, `进行中`, `阻塞`, `已完成`, `已取消`    |
+| `优先级`               | select   | `P0`, `P1`, `P2`                                          |
+| `产品线`               | select   | `数字员工`, `数字分身`, `平台核心`, `渠道`, `Web`, `运维` |
+| `DRI`                  | user     | —                                                         |
+| `里程碑`               | link     | Milestones                                                |
+| `父任务`               | link     | Tasks                                                     |
+| `依赖任务`             | link     | Tasks                                                     |
+| `GitHub Issue`         | text     | Full URL, not a number                                    |
+| `验收标准`             | text     | Acceptance criteria                                       |
+| `触发条件`             | text     | What unblocks a `待评估` task                             |
+| `依赖说明`             | text     | —                                                         |
+| `Refs`                 | text     | —                                                         |
+| `开始日期`, `截止日期` | datetime | `YYYY-MM-DD HH:MM:SS`                                     |
+| `估算(人/天)`          | number   | —                                                         |
+
+**Milestones**
+
+| Field        | Type     | Values / links to                                      |
+| ------------ | -------- | ------------------------------------------------------ |
+| `里程碑`     | text     | The milestone name                                     |
+| `状态`       | select   | `候选`, `已计划`, `进行中`, `暂停`, `已完成`, `已取消` |
+| `目标与验收` | text     | —                                                      |
+| `DRI`        | user     | —                                                      |
+| `所属战线`   | link     | Roadmap                                                |
+| `任务`       | link     | Tasks                                                  |
+| `目标日期`   | datetime | —                                                      |
+| `预计人周`   | number   | —                                                      |
+
+**Roadmap**
+
+| Field        | Type   | Values / links to                  |
+| ------------ | ------ | ---------------------------------- |
+| `战线`       | text   | The workstream name                |
+| `一句话方向` | text   | —                                  |
+| `状态`       | select | `候选`, `进行中`, `暂停`, `已完成` |
+| `DRI`        | user   | —                                  |
+| `里程碑`     | link   | Milestones                         |
+
+### Writing to the Base
+
+Use `lark-cli base` with `--as user`. Confirm fields before writing, and preview
+any write with `--dry-run` first.
+
+```bash
+BASE=BEEbbI9jtad6PmsYSXpcmBy2nUd
+TASKS=tbl4pUhlngTJdg2Z
+
+# confirm the live field set before constructing a payload
+lark-cli base +field-list --base-token $BASE --table-id $TASKS --as user
+
+# create a task (drop --dry-run to execute)
+lark-cli base +record-upsert --base-token $BASE --table-id $TASKS --as user --dry-run \
+  --json '{"任务":"...","状态":"就绪","优先级":"P2","产品线":"平台核心",
+           "GitHub Issue":"https://github.com/CherryHQ/stella/issues/123",
+           "DRI":[{"id":"ou_..."}],"验收标准":"..."}'
+
+# write back an Issue URL on an existing task
+lark-cli base +record-upsert --base-token $BASE --table-id $TASKS --as user \
+  --record-id recXXXXXXXXXX --json '{"GitHub Issue":"https://github.com/CherryHQ/stella/issues/123"}'
+```
+
+`+record-upsert` creates without `--record-id` and updates with it; it does not
+match on a business key. Its response does not echo the stored row, so read the
+record back (`+record-search`) rather than trusting the exit status.
+
+### Lifecycle rules
 
 `待评估` tasks are internal candidates and do not need a GitHub issue. Every
 task at `就绪` or later must contain a full GitHub Issue URL. Store the URL,
@@ -97,15 +178,20 @@ During triage:
 
 ## Execution lifecycle
 
-| Event                 | Feishu Task                | GitHub                                       |
-| --------------------- | -------------------------- | -------------------------------------------- |
-| Candidate             | `待评估`                   | No issue required                            |
-| Committed and ready   | `就绪`                     | Open + `status:ready`                        |
-| Work starts           | `进行中`                   | Remove `status:ready`; assign or link a PR   |
-| Blocked               | `阻塞`                     | Add `status:blocked` and explain the blocker |
-| Implementation closes | unchanged until acceptance | Close through the PR                         |
-| Acceptance passes     | `已完成`                   | Closed                                       |
-| Cancelled             | `已取消`                   | Close with the reason                        |
+| Event                  | Feishu Task                | GitHub                                       |
+| ---------------------- | -------------------------- | -------------------------------------------- |
+| Candidate              | `待评估`                   | No issue required                            |
+| Committed, not started | `就绪`                     | Open + `status:ready`                        |
+| A PR is open           | `进行中`                   | Remove `status:ready`; assign or link the PR |
+| Blocked                | `阻塞`                     | Add `status:blocked` and explain the blocker |
+| Implementation closes  | unchanged until acceptance | Close through the PR                         |
+| Acceptance passes      | `已完成`                   | Closed                                       |
+| Cancelled              | `已取消`                   | Close with the reason                        |
+
+An open PR is the marker for `进行中` because it is the one transition with an
+objective timestamp. Set the state that matches reality: work already
+implemented when its issue is filed goes straight to `进行中` and never wears
+`status:ready`.
 
 Closing an issue does not automatically complete the Feishu task; the DRI
 marks it `已完成` after acceptance.
@@ -119,8 +205,10 @@ commits a task:
 1. Search GitHub for an existing community issue.
 2. Link it when one exists; otherwise create a new issue.
 3. Put the full Issue URL and final acceptance criteria in the Feishu task, then
-   move it to `就绪`.
-4. Add `status:ready` and, when known, a version milestone to the issue.
+   move it to the state matching real progress — `就绪`, or `进行中` when a PR
+   is already open.
+4. Add the matching status label and, when known, a version milestone to the
+   issue.
 
 Contributors do not need Feishu access. Maintainers own the Feishu promotion
 step when accepting community work.
@@ -172,9 +260,10 @@ Before creating an issue on a user's behalf:
 5. For committed work, confirm that a Feishu task will link the new issue, and
    ask whether a version milestone is known. `none` is valid.
 
-Then create the issue. For committed work, create or update the Feishu task
-with the returned URL, move it to `就绪`, and add `status:ready`; finally return
-the Issue URL. Do not bulk-create issues without confirmation, and prefer
+Then create the issue. For committed work, create or update the Feishu task with
+the returned URL, set the state matching real progress (`就绪`, or `进行中` with
+no `status:ready` when a PR is already open), add the matching status label, and
+return the Issue URL. Do not bulk-create issues without confirmation, and prefer
 closing over deleting.
 
 ## Automation boundary

--- a/web/content/docs/development/rules/project-tracker.zh.md
+++ b/web/content/docs/development/rules/project-tracker.zh.md
@@ -45,9 +45,93 @@ Roadmap
 
 严格使用下面的标准字段和生命周期，不添加同义或一次性状态：
 
-- Roadmap：`战线`、`一句话方向`、`状态`（`候选`、`进行中`、`暂停`、`已完成`）、`DRI`、`里程碑`。
-- Milestones：`里程碑`、`状态`（`候选`、`已计划`、`进行中`、`暂停`、`已完成`、`已取消`）、`目标与验收`、`DRI`、`目标日期`、`预计人周`、`所属战线`、`任务`。
-- Tasks：`任务`、`状态`（`待评估`、`就绪`、`进行中`、`阻塞`、`已完成`、`已取消`）、`优先级`、`DRI`、`里程碑`、`GitHub Issue`、`验收标准`、日期、估算、`父任务`、`依赖任务`、`依赖说明`、`触发条件`、产品线和引用。
+### 坐标
+
+直接使用下列 id，不要再从 Base URL 里解析或猜测。
+
+| 资源       | Id                            |
+| ---------- | ----------------------------- |
+| Base token | `BEEbbI9jtad6PmsYSXpcmBy2nUd` |
+| 任务       | `tbl4pUhlngTJdg2Z`            |
+| 里程碑     | `tblCRcuKDjmnKCJr`            |
+| Roadmap    | `tblp9iIcKyO9NN00`            |
+
+### 字段
+
+`select` 列出的是全部合法取值。`user` 字段填 `[{"id":"ou_..."}]`，用
+`lark-cli contact +get-user` 解析（省略 user id 即查自己）。`link` 字段填
+`[{"id":"recXXXXXXXXXX"}]`，指向"关联"列所示表中的记录——先读那张表拿到 record id，
+不要凭空构造。
+
+**任务**
+
+| 字段                   | 类型     | 取值 / 关联                                               |
+| ---------------------- | -------- | --------------------------------------------------------- |
+| `任务`                 | text     | 任务标题                                                  |
+| `状态`                 | select   | `待评估`、`就绪`、`进行中`、`阻塞`、`已完成`、`已取消`    |
+| `优先级`               | select   | `P0`、`P1`、`P2`                                          |
+| `产品线`               | select   | `数字员工`、`数字分身`、`平台核心`、`渠道`、`Web`、`运维` |
+| `DRI`                  | user     | —                                                         |
+| `里程碑`               | link     | 里程碑表                                                  |
+| `父任务`               | link     | 任务表                                                    |
+| `依赖任务`             | link     | 任务表                                                    |
+| `GitHub Issue`         | text     | 完整 URL，不是 number                                     |
+| `验收标准`             | text     | 验收条件                                                  |
+| `触发条件`             | text     | `待评估` 任务的解锁条件                                   |
+| `依赖说明`             | text     | —                                                         |
+| `Refs`                 | text     | —                                                         |
+| `开始日期`、`截止日期` | datetime | `YYYY-MM-DD HH:MM:SS`                                     |
+| `估算(人/天)`          | number   | —                                                         |
+
+**里程碑**
+
+| 字段         | 类型     | 取值 / 关联                                            |
+| ------------ | -------- | ------------------------------------------------------ |
+| `里程碑`     | text     | 里程碑名称                                             |
+| `状态`       | select   | `候选`、`已计划`、`进行中`、`暂停`、`已完成`、`已取消` |
+| `目标与验收` | text     | —                                                      |
+| `DRI`        | user     | —                                                      |
+| `所属战线`   | link     | Roadmap 表                                             |
+| `任务`       | link     | 任务表                                                 |
+| `目标日期`   | datetime | —                                                      |
+| `预计人周`   | number   | —                                                      |
+
+**Roadmap**
+
+| 字段         | 类型   | 取值 / 关联                        |
+| ------------ | ------ | ---------------------------------- |
+| `战线`       | text   | 战线名称                           |
+| `一句话方向` | text   | —                                  |
+| `状态`       | select | `候选`、`进行中`、`暂停`、`已完成` |
+| `DRI`        | user   | —                                  |
+| `里程碑`     | link   | 里程碑表                           |
+
+### 写入 Base
+
+用 `lark-cli base`，带 `--as user`。写之前先确认字段，并用 `--dry-run` 预览。
+
+```bash
+BASE=BEEbbI9jtad6PmsYSXpcmBy2nUd
+TASKS=tbl4pUhlngTJdg2Z
+
+# 构造 payload 前先确认线上字段
+lark-cli base +field-list --base-token $BASE --table-id $TASKS --as user
+
+# 创建任务（去掉 --dry-run 才真正执行）
+lark-cli base +record-upsert --base-token $BASE --table-id $TASKS --as user --dry-run \
+  --json '{"任务":"...","状态":"就绪","优先级":"P2","产品线":"平台核心",
+           "GitHub Issue":"https://github.com/CherryHQ/stella/issues/123",
+           "DRI":[{"id":"ou_..."}],"验收标准":"..."}'
+
+# 给已有任务回写 Issue URL
+lark-cli base +record-upsert --base-token $BASE --table-id $TASKS --as user \
+  --record-id recXXXXXXXXXX --json '{"GitHub Issue":"https://github.com/CherryHQ/stella/issues/123"}'
+```
+
+`+record-upsert` 不带 `--record-id` 是创建，带上是更新；它不会按业务键匹配。
+它的响应不回显写入后的行，所以要用 `+record-search` 回读校验，不要只看退出状态。
+
+### 生命周期规则
 
 `待评估` Task 是内部候选，不要求 GitHub Issue。进入 `就绪` 或后续状态的 Task 必须填写完整 GitHub Issue URL，不要只存 Issue number。评估阶段在飞书起草验收标准；晋级到 `就绪` 时，把完整需求和验收条件写入 GitHub，此后 Issue 是研发执行事实源。
 
@@ -76,12 +160,15 @@ Issue 表单会为新的社区报告添加 `status:needs-triage`。
 | 事件           | 飞书 Task  | GitHub                                       |
 | -------------- | ---------- | -------------------------------------------- |
 | 候选           | `待评估`   | 不要求 Issue                                 |
-| 已承诺并可开发 | `就绪`     | Open + `status:ready`                        |
-| 开始开发       | `进行中`   | 移除 `status:ready`；分配 Assignee 或关联 PR |
+| 已承诺、未动工 | `就绪`     | Open + `status:ready`                        |
+| PR 已开        | `进行中`   | 移除 `status:ready`；分配 Assignee 或关联 PR |
 | 阻塞           | `阻塞`     | 添加 `status:blocked` 并解释阻塞原因         |
 | 实现关闭       | 验收前不变 | 通过 PR 关闭                                 |
 | 验收通过       | `已完成`   | Closed                                       |
 | 取消           | `已取消`   | 说明原因后关闭                               |
+
+以"PR 已开"作为 `进行中` 的标志，因为它是唯一带客观时间戳的转换点。状态要如实
+反映进度：建 Issue 时代码已经写完的工作直接进 `进行中`，不经过 `status:ready`。
 
 关闭 GitHub Issue 不会自动完成飞书 Task；DRI 验收后再将 Task 改为 `已完成`。
 
@@ -91,8 +178,9 @@ Issue 表单会为新的社区报告添加 `status:needs-triage`。
 
 1. 搜索是否已有对应的社区 Issue。
 2. 有则直接关联，没有再创建。
-3. 在飞书 Task 填入完整 Issue URL 和最终验收标准，再改为 `就绪`。
-4. 为 Issue 添加 `status:ready`；目标版本明确时再添加版本 Milestone。
+3. 在飞书 Task 填入完整 Issue URL 和最终验收标准，再改为与实际进度一致的状态——
+   `就绪`，或 PR 已开时直接进 `进行中`。
+4. 为 Issue 添加对应的状态 label；目标版本明确时再添加版本 Milestone。
 
 外部贡献者不需要访问飞书。接受社区工作时，由维护者完成飞书侧的晋级操作。
 
@@ -133,7 +221,7 @@ gh issue edit <number> --repo CherryHQ/stella --milestone v0.61.0
 4. 仅接受时添加 `status:accepted`，然后结束。
 5. 已承诺时确认飞书 Task 将关联新 Issue，并询问是否已有目标版本；`none` 是合法答案。
 
-随后创建 Issue。已承诺的工作还要用返回的 URL 创建或更新飞书 Task，将其改为 `就绪`，并添加 `status:ready`；最后返回 Issue URL。未经确认不要批量创建；优先关闭而不是删除。
+随后创建 Issue。已承诺的工作还要用返回的 URL 创建或更新飞书 Task，将其改为与实际进度一致的状态（`就绪`；PR 已开则是 `进行中` 且不加 `status:ready`），并添加对应的状态 label；最后返回 Issue URL。未经确认不要批量创建；优先关闭而不是删除。
 
 ## 自动化边界
 


### PR DESCRIPTION
Closes #852

## What

Make the Feishu side of `project-tracker.md` actionable, and resolve a
contradiction about when a task becomes `进行中`. Both EN and ZH.

## Why

Running the workflow end to end for #850 hit four walls:

1. **The Base had no machine-readable coordinates.** Only a browser URL, so
   writing meant scraping a base token and table id out of a query string. Worse,
   only the Tasks table was reachable at all — Milestones and Roadmap appear in
   the hierarchy diagram with no ids anywhere, which makes the `里程碑` link
   field unfillable.

2. **Field names without types.** The lists said a task has a `DRI` and a
   `里程碑`, not that `DRI` is a user field needing `[{"id":"ou_..."}]` or that
   `里程碑` is a link field needing a record id. `产品线` option values were
   missing entirely.

3. **No write path.** The GitHub side documents every `gh` command; the Feishu
   side mandated "store the full Issue URL" without naming a tool.

4. **A contradiction.** The lifecycle table maps "work starts" to `进行中` +
   removing `status:ready`; the issue-creation steps unconditionally set `就绪` +
   `status:ready`. Work already implemented when its issue is filed satisfies
   both and neither — "work starts" was never defined.

Worth noting: the pre-#848 revision documented the GitHub Project's ids in a
table and explicitly said *"use these coordinates directly — do not re-resolve
or guess"*. That habit got dropped along with the Project. This restores it.

## How

- **Coordinates table** — base token plus all three table ids.
- **Per-table field tables** — type for every field, the complete option set for
  every `select`, and the target table for every `link`, plus how to resolve the
  ids that `user` and `link` fields need.
- **A `lark-cli` section** covering the three operations the workflow requires:
  inspect fields, create a task, write back an Issue URL. Includes the
  `+record-upsert` gotcha that its response does not echo the stored row, so the
  record must be read back rather than trusting the exit status.
- **"Work starts" is now "a PR is open"** — the one transition with an objective
  timestamp. The two places that hardcoded `就绪` + `status:ready` now say to set
  the state matching real progress.

## Test

Docs-only; `format`, `build`, and `test` pass.

Every id in the coordinates table and every command in the new section was
executed against the live Base rather than transcribed — including the
`--record-id` update path, verified via `--dry-run` to confirm it issues
`PATCH .../records/{id}`.

## Refs

- #850 / #851 — the run that surfaced this
- #848 — moved planning to Feishu

## Note for the reviewer

The coordinates table puts the base token in a public repo. It is already there
in the Base URL two sections above, so this adds no exposure — but if the intent
is that these ids stay out of the public docs, the whole Feishu section (URL
included) needs to move somewhere private, and I'd rather you make that call.