### PR TITLE
🔒 ci: make bwrap functional in the release validation job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,16 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install bubblewrap
-        run: sudo apt-get install -y bubblewrap
+        run: |
+          set -euo pipefail
+          sudo apt-get install -y bubblewrap
+          # Ubuntu 24.04 blocks unprivileged user namespaces through AppArmor, so
+          # an installed bwrap still cannot create a sandbox. The local sandbox
+          # backend probes exactly this, and the System Test runs real agent
+          # turns through it — without the sysctl every turn fails at runtime.
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          # Fail here, with the reason visible, rather than inside a test run.
+          bwrap --unshare-pid --unshare-ipc --unshare-uts --dev-bind / / -- true
 
       - name: Generate code and check drift
         run: mise run generate:check


### PR DESCRIPTION
Closes #856

## What

Two lines in `release.yml`'s bubblewrap step: relax `kernel.apparmor_restrict_unprivileged_userns`, then probe bwrap with the same namespace flags the local sandbox uses.

## Why

`v0.61.0`'s validation job ([run 30877628529](https://github.com/CherryHQ/stella/actions/runs/30877628529)) installed bubblewrap successfully and still failed every System Test journey that runs an agent turn: Ubuntu 24.04 blocks unprivileged user namespaces through AppArmor, so `bwrapFunctional()` (`plugins/sandbox/local/session_linux.go:146`) sees a non-functional bwrap and the local sandbox refuses to create sessions. No tag can publish until this is fixed.

## How

- `sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0` after the install.
- One `bwrap ... -- true` probe, so a future runner-image change fails at the install step with the reason on screen instead of surfacing as 90-second timeouts inside the suite.
- `set -euo pipefail` so the step cannot pass on a failed install.

## Verification

Not reproducible on a PR — the validate job only runs on tag pushes. Proof is the re-run of `v0.61.0` after merge; the install step's probe makes success or failure explicit.

## Out of scope

`lint-and-test.yml` has the same gap, but there the sandbox tests *skip* rather than fail, so Linux CI has been silently not covering the local sandbox backend. That deserves its own issue and its own risk assessment (it may surface real failures).