### PR TITLE
🧪 test(system): prove scheduler recovery after crash

### DIFF
--- a/test/system/harness_test.go
+++ b/test/system/harness_test.go
@@ -43,6 +43,9 @@ const (
 	// startupAttempts bounds retries when the free-port pick races another
 	// process binding the same port between selection and server bind.
 	startupAttempts = 3
+	// forcedCrashTimeout bounds reaping an intentionally killed server and
+	// proving its owned process group is gone before a replacement starts.
+	forcedCrashTimeout = 10 * time.Second
 )
 
 // harness owns every resource of one system-test run: the embedded PostgreSQL
@@ -51,11 +54,20 @@ const (
 // registered on t as each resource is acquired, so a failure at any point
 // still tears down everything acquired so far.
 type harness struct {
+	owner   *testing.T
 	runID   string
 	baseURL string
 	client  *http.Client
 	db      *pgxpool.Pool
 	proc    *serverProcess
+
+	// These are deliberately retained for restart journeys. A replacement
+	// process must receive the original home, database, and vault identity so
+	// it proves durable recovery rather than a fresh deployment.
+	home       string
+	dsn        string
+	vaultKey   string
+	generation int
 }
 
 // newHarness starts the full system under test or skips on hosts without an
@@ -84,7 +96,7 @@ func newHarness(t *testing.T) *harness {
 	}
 	home := t.TempDir()
 
-	proc, baseURL := startServer(t, runID, home, embedded.DSN(), vaultKey)
+	proc, baseURL := startServer(t, t, runID, 1, home, embedded.DSN(), vaultKey)
 
 	db, err := pgxpool.New(context.Background(), embedded.DSN())
 	if err != nil {
@@ -100,12 +112,15 @@ func newHarness(t *testing.T) *harness {
 	// stream. Every request must carry its own context deadline instead.
 	client := &http.Client{Jar: jar}
 
-	return &harness{runID: runID, baseURL: baseURL, client: client, db: db, proc: proc}
+	return &harness{
+		owner: t, runID: runID, baseURL: baseURL, client: client, db: db, proc: proc,
+		home: home, dsn: embedded.DSN(), vaultKey: vaultKey, generation: 1,
+	}
 }
 
 // startServer boots the stellad subprocess and waits for readiness, retrying
 // with a fresh port when the free-port pick loses its bind race.
-func startServer(t *testing.T, runID, home, dsn, vaultKey string) (*serverProcess, string) {
+func startServer(t, cleanupT *testing.T, runID string, generation int, home, dsn, vaultKey string) (*serverProcess, string) {
 	t.Helper()
 	for attempt := 1; ; attempt++ {
 		port := freePort(t)
@@ -118,7 +133,7 @@ func startServer(t *testing.T, runID, home, dsn, vaultKey string) (*serverProces
 			fmt.Sprintf("PORT=%d", port),
 			"LOG_LEVEL=debug",
 		)
-		proc := startServerProcess(t, fmt.Sprintf("server-%s-a%d", runID, attempt), env)
+		proc := startServerProcess(t, cleanupT, fmt.Sprintf("server-%s-g%d-a%d", runID, generation, attempt), env)
 		err := proc.waitReady(baseURL, readyTimeout)
 		if err == nil {
 			return proc, baseURL
@@ -130,6 +145,26 @@ func startServer(t *testing.T, runID, home, dsn, vaultKey string) (*serverProces
 		}
 		t.Fatalf("system: server never became ready: %v", err)
 	}
+}
+
+// restartAfterForcedCrash replaces the running server with a new process while
+// retaining the same durable identities. It is intentionally not a graceful
+// shutdown: a restart recovery journey needs the old process to leave no
+// in-process cleanup behind. The expected signal exit is reaped but never
+// reported as a graceful-shutdown failure.
+func (h *harness) restartAfterForcedCrash(t *testing.T) *serverProcess {
+	t.Helper()
+	old := h.proc
+	old.forceCrash(t)
+
+	h.generation++
+	// startServer registers process cleanup on the harness owner, not the
+	// restart journey's subtest. The replacement must remain alive for later
+	// ordered journeys, especially graceful_drain.
+	proc, baseURL := startServer(t, h.owner, h.runID, h.generation, h.home, h.dsn, h.vaultKey)
+	h.proc = proc
+	h.baseURL = baseURL
+	return old
 }
 
 // skipUnsupportedHost skips before any resource is acquired on platforms where
@@ -169,7 +204,7 @@ type serverProcess struct {
 // startServerProcess launches `stellad serve` in its own process group with
 // stdout/stderr captured to a per-run log under dist/logs/system-test/. The
 // log outlives the run so failures can always point at it.
-func startServerProcess(t *testing.T, logName string, env []string) *serverProcess {
+func startServerProcess(t, cleanupT *testing.T, logName string, env []string) *serverProcess {
 	t.Helper()
 	logPath := filepath.Join(logDir(t), logName+".log")
 	logFile, err := os.Create(logPath)
@@ -193,7 +228,7 @@ func startServerProcess(t *testing.T, logName string, env []string) *serverProce
 		p.waitErr = cmd.Wait()
 		close(p.done)
 	}()
-	t.Cleanup(func() { p.stop(t) })
+	cleanupT.Cleanup(func() { p.stop(cleanupT) })
 	return p
 }
 
@@ -261,6 +296,39 @@ func (p *serverProcess) stop(t *testing.T) {
 	if processGroupAlive(p.cmd) {
 		killProcessGroup(p.cmd)
 		t.Errorf("system: processes left in the server's process group after shutdown (server log: %s)", p.logPath)
+	}
+}
+
+// forceCrash kills this owned process group and waits until it has been reaped
+// and the group no longer exists. Unlike stop, a signal-caused exit is the
+// expected outcome and must not be mistaken for graceful-shutdown failure.
+func (p *serverProcess) forceCrash(t *testing.T) {
+	t.Helper()
+	if p.exited() {
+		t.Fatalf("system: server exited before forced crash: %v\nserver log: %s\n%s", p.waitErr, p.logPath, p.logTail(40))
+	}
+
+	killProcessGroup(p.cmd)
+	deadline := time.NewTimer(forcedCrashTimeout)
+	defer deadline.Stop()
+	select {
+	case <-p.done:
+	case <-deadline.C:
+		t.Fatalf("system: server did not exit within %s of forced process-group kill (pid %d, server log: %s)\n%s",
+			forcedCrashTimeout, p.cmd.Process.Pid, p.logPath, p.logTail(40))
+	}
+
+	// Reaping the group leader does not prove a descendant has gone away. Poll
+	// signal-0 under the same deadline until the owned group is empty.
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+	for processGroupAlive(p.cmd) {
+		select {
+		case <-ticker.C:
+		case <-deadline.C:
+			t.Fatalf("system: processes left in forced-crash process group (pid %d, server log: %s)\n%s",
+				p.cmd.Process.Pid, p.logPath, p.logTail(40))
+		}
 	}
 }
 

--- a/test/system/scheduler_restart_test.go
+++ b/test/system/scheduler_restart_test.go
@@ -1,0 +1,364 @@
+//go:build system
+
+package system
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+const (
+	// restartFireDelay leaves enough room to prove the original process died
+	// before the fire and for its replacement to become ready before the due
+	// time. It is not a success wait: the durable rows drive every assertion.
+	restartFireDelay   = 45 * time.Second
+	restartPollBudget  = 75 * time.Second
+	restartQuietWindow = 8 * time.Second
+)
+
+// testSchedulerOneTimeJobSurvivesForcedRestart proves the process seam for a
+// durable one-shot chat job. It is killed before its future fire time, then a
+// replacement using the same PostgreSQL, home, and vault identity must execute
+// the existing River fire exactly once. This deliberately does not crash an
+// in-flight model call: external side effects cannot honestly be made exactly
+// once after an abrupt crash, while the pending durable-fire contract can.
+func (h *harness) testSchedulerOneTimeJobSurvivesForcedRestart(t *testing.T) {
+	fake := newFakeAnthropic(t)
+	ctx, cancel := context.WithTimeout(context.Background(), restartPollBudget+30*time.Second)
+	defer cancel()
+
+	const modelID = "claude-sonnet-4-6"
+	wantReply := "scheduler restart reply " + h.runID
+	wantMessage := "run once after forced restart " + h.runID
+	fake.enqueueText(wantReply)
+	providerID := h.createFakeProviderNamed(t, ctx, fake.baseURL(), "anthropic-scheduler-restart-"+h.runID)
+	agentID := h.createAgent(t, ctx, providerID+"/"+modelID)
+
+	fireAt := time.Now().UTC().Add(restartFireDelay).Truncate(time.Second)
+	jobID := h.createSchedulerRestartJob(t, ctx, agentID, fireAt, wantMessage)
+	old := h.proc
+
+	before := h.schedulerRestartSnapshot(t, ctx, jobID)
+	if err := before.pendingInvariant(jobID, fireAt.Format(time.RFC3339)); err != nil {
+		h.failSchedulerRestart(t, ctx, fake, old, jobID, "durable one-time job was not ready before forced crash: %v", err)
+	}
+	if len(fake.requests()) != 0 {
+		h.failSchedulerRestart(t, ctx, fake, old, jobID, "fake received a model request before the forced crash")
+	}
+	if !time.Now().Before(fireAt) {
+		h.failSchedulerRestart(t, ctx, fake, old, jobID, "job due time %s passed before forced crash", fireAt.Format(time.RFC3339))
+	}
+
+	old = h.restartAfterForcedCrash(t)
+	// Reloading persisted jobs must deduplicate against the original pending
+	// River row. This is the inexpensive non-vacuous recovery guard: removing
+	// schedUniqueOpts makes this assertion observe two pending fires.
+	afterRestart := h.schedulerRestartSnapshot(t, ctx, jobID)
+	if err := afterRestart.pendingInvariant(jobID, fireAt.Format(time.RFC3339)); err != nil {
+		h.failSchedulerRestart(t, ctx, fake, old, jobID, "restart changed the pending durable fire: %v", err)
+	}
+
+	final := h.awaitSchedulerRestartSuccess(t, ctx, fake, old, jobID, fireAt.Format(time.RFC3339), modelID, wantMessage, wantReply)
+	if err := final.successInvariant(jobID, fireAt.Format(time.RFC3339), modelID, wantMessage, wantReply, fake.requests()); err != nil {
+		h.failSchedulerRestart(t, ctx, fake, old, jobID, "one-time job did not finish exactly once: %v", err)
+	}
+
+	// Keep observing durable state rather than sleeping and checking once: a
+	// duplicate fire from restart re-registration must fail at any point in this
+	// bounded window.
+	quietUntil := time.NewTimer(restartQuietWindow)
+	defer quietUntil.Stop()
+	ticker := time.NewTicker(150 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-quietUntil.C:
+			return
+		case <-ctx.Done():
+			h.failSchedulerRestart(t, ctx, fake, old, jobID, "context expired during duplicate-execution observation: %v", ctx.Err())
+		case <-ticker.C:
+			snapshot := h.schedulerRestartSnapshot(t, ctx, jobID)
+			if err := snapshot.successInvariant(jobID, fireAt.Format(time.RFC3339), modelID, wantMessage, wantReply, fake.requests()); err != nil {
+				h.failSchedulerRestart(t, ctx, fake, old, jobID, "duplicate-execution observation failed: %v", err)
+			}
+		}
+	}
+}
+
+func (h *harness) createSchedulerRestartJob(t *testing.T, ctx context.Context, agentID string, fireAt time.Time, message string) string {
+	t.Helper()
+	resp := h.postJSON(t, ctx, "/api/agents/"+agentID+"/scheduler/jobs", map[string]any{
+		"name":         "restart-once-" + h.runID,
+		"message":      message,
+		"at":           fireAt.Format(time.RFC3339),
+		"session_mode": "reuse",
+	})
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("POST scheduler one-time job = %d, want %d\n%s", resp.StatusCode, http.StatusCreated, h.proc.logTail(40))
+	}
+	var created struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode scheduler one-time job: %v", err)
+	}
+	if created.ID == "" {
+		t.Fatal("created scheduler one-time job has empty id")
+	}
+	return created.ID
+}
+
+type schedulerRestartSnapshot struct {
+	jobExists   bool
+	jobEnabled  bool
+	scheduleAt  string
+	lastRunAt   *time.Time
+	lastError   string
+	jobRowCount int
+	runs        []schedulerRestartRun
+	river       []schedulerRestartRiverJob
+}
+
+type schedulerRestartRun struct {
+	id, status, sessionID, errText, output string
+	startedAt                              time.Time
+	finishedAt                             *time.Time
+}
+
+type schedulerRestartRiverJob struct {
+	id                 int64
+	state, args, queue string
+	attempt            int16
+	scheduledAt        time.Time
+	finalizedAt        *time.Time
+}
+
+func (h *harness) schedulerRestartSnapshot(t *testing.T, ctx context.Context, jobID string) schedulerRestartSnapshot {
+	t.Helper()
+	var s schedulerRestartSnapshot
+	err := h.db.QueryRow(ctx, `
+		SELECT enabled, schedule_at, last_run_at, last_error,
+		       count(*) OVER ()
+		FROM sched_job
+		WHERE id = $1`, jobID).Scan(&s.jobEnabled, &s.scheduleAt, &s.lastRunAt, &s.lastError, &s.jobRowCount)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return s
+		}
+		t.Fatalf("query scheduler job %s: %v", jobID, err)
+	}
+	s.jobExists = true
+
+	runRows, err := h.db.Query(ctx, `
+		SELECT id, status, session_id, started_at, finished_at, error, output
+		FROM sched_job_run
+		WHERE job_id = $1
+		ORDER BY started_at, id`, jobID)
+	if err != nil {
+		t.Fatalf("query scheduler runs for %s: %v", jobID, err)
+	}
+	defer runRows.Close()
+	for runRows.Next() {
+		var r schedulerRestartRun
+		if err := runRows.Scan(&r.id, &r.status, &r.sessionID, &r.startedAt, &r.finishedAt, &r.errText, &r.output); err != nil {
+			t.Fatalf("scan scheduler run for %s: %v", jobID, err)
+		}
+		s.runs = append(s.runs, r)
+	}
+	if err := runRows.Err(); err != nil {
+		t.Fatalf("iterate scheduler runs for %s: %v", jobID, err)
+	}
+
+	riverRows, err := h.db.Query(ctx, `
+		SELECT id, state::text, attempt, scheduled_at, finalized_at, args::text, queue
+		FROM river_job
+		WHERE kind = 'stella_scheduler_job'
+		  AND args->>'job_id' = $1
+		ORDER BY id`, jobID)
+	if err != nil {
+		t.Fatalf("query River jobs for %s: %v", jobID, err)
+	}
+	defer riverRows.Close()
+	for riverRows.Next() {
+		var r schedulerRestartRiverJob
+		if err := riverRows.Scan(&r.id, &r.state, &r.attempt, &r.scheduledAt, &r.finalizedAt, &r.args, &r.queue); err != nil {
+			t.Fatalf("scan River job for %s: %v", jobID, err)
+		}
+		s.river = append(s.river, r)
+	}
+	if err := riverRows.Err(); err != nil {
+		t.Fatalf("iterate River jobs for %s: %v", jobID, err)
+	}
+	return s
+}
+
+func (s schedulerRestartSnapshot) pendingInvariant(jobID, wantAt string) error {
+	if !s.jobExists || s.jobRowCount != 1 {
+		return fmt.Errorf("scheduler job identity %q exists=%t count=%d, want exactly one row", jobID, s.jobExists, s.jobRowCount)
+	}
+	if !s.jobEnabled || s.scheduleAt != wantAt || s.lastRunAt != nil || s.lastError != "" {
+		return fmt.Errorf("scheduler job enabled=%t schedule_at=%q last_run_at=%v last_error=%q, want enabled/%q/nil/empty", s.jobEnabled, s.scheduleAt, s.lastRunAt, s.lastError, wantAt)
+	}
+	if len(s.runs) != 0 {
+		return fmt.Errorf("scheduler run count=%d, want 0 before due time", len(s.runs))
+	}
+	if len(s.river) != 1 {
+		return fmt.Errorf("River job count=%d, want exactly one pending fire", len(s.river))
+	}
+	r := s.river[0]
+	var args struct {
+		At    string `json:"at"`
+		JobID string `json:"job_id"`
+	}
+	if err := json.Unmarshal([]byte(r.args), &args); err != nil {
+		return fmt.Errorf("decode River job args %q: %w", r.args, err)
+	}
+	if r.state != "scheduled" || r.queue != "stella_scheduler" || args.At != wantAt || args.JobID != jobID {
+		return fmt.Errorf("River job state=%q queue=%q args=%s, want scheduled/stella_scheduler/job_id=%q/at=%q", r.state, r.queue, r.args, jobID, wantAt)
+	}
+	return nil
+}
+
+func (s schedulerRestartSnapshot) successInvariant(jobID, wantAt, modelID, wantMessage, wantReply string, reqs []fakeRequest) error {
+	if !s.jobExists || s.jobRowCount != 1 {
+		return fmt.Errorf("scheduler job identity %q exists=%t count=%d, want exactly one row", jobID, s.jobExists, s.jobRowCount)
+	}
+	if s.jobEnabled || s.scheduleAt != wantAt || s.lastRunAt == nil || s.lastError != "" {
+		return fmt.Errorf("scheduler job enabled=%t schedule_at=%q last_run_at=%v last_error=%q, want disabled/%q/set/empty", s.jobEnabled, s.scheduleAt, s.lastRunAt, s.lastError, wantAt)
+	}
+	if len(s.runs) != 1 {
+		return fmt.Errorf("scheduler run count=%d, want exactly one", len(s.runs))
+	}
+	run := s.runs[0]
+	if run.status != "success" || run.finishedAt == nil || run.errText != "" {
+		return fmt.Errorf("scheduler run id=%s status=%q finished_at=%v error=%q, want success/finished/empty", run.id, run.status, run.finishedAt, run.errText)
+	}
+	if run.output != wantReply {
+		return fmt.Errorf("scheduler run output=%q, want %q", run.output, wantReply)
+	}
+	if len(s.river) != 1 || s.river[0].state != "completed" || s.river[0].finalizedAt == nil {
+		return fmt.Errorf("River terminal rows=%+v, want one completed finalized fire", s.river)
+	}
+	if len(reqs) != 1 {
+		return fmt.Errorf("fake model request count=%d, want exactly one", len(reqs))
+	}
+	if reqs[0].Model != modelID {
+		return fmt.Errorf("fake model request model=%q, want %q", reqs[0].Model, modelID)
+	}
+	if !strings.Contains(strings.Join(reqs[0].Messages, "\n"), wantMessage) {
+		return fmt.Errorf("fake model request did not contain scheduled message %q", wantMessage)
+	}
+	return nil
+}
+
+func (h *harness) awaitSchedulerRestartSuccess(t *testing.T, ctx context.Context, fake *fakeAnthropic, old *serverProcess, jobID, wantAt, modelID, wantMessage, wantReply string) schedulerRestartSnapshot {
+	t.Helper()
+	timer := time.NewTimer(restartPollBudget)
+	defer timer.Stop()
+	ticker := time.NewTicker(150 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		snapshot := h.schedulerRestartSnapshot(t, ctx, jobID)
+		if err := snapshot.successInvariant(jobID, wantAt, modelID, wantMessage, wantReply, fake.requests()); err == nil {
+			return snapshot
+		}
+		select {
+		case <-ctx.Done():
+			h.failSchedulerRestart(t, ctx, fake, old, jobID, "context expired waiting for one-time job: %v", ctx.Err())
+		case <-timer.C:
+			h.failSchedulerRestart(t, ctx, fake, old, jobID, "one-time job did not succeed within %s", restartPollBudget)
+		case <-ticker.C:
+		}
+	}
+}
+
+func (h *harness) failSchedulerRestart(t *testing.T, ctx context.Context, fake *fakeAnthropic, old *serverProcess, jobID, format string, args ...any) {
+	t.Helper()
+	t.Fatalf(format+"\n%s", append(args, h.dumpSchedulerRestart(ctx, fake, old, jobID))...)
+}
+
+func (h *harness) dumpSchedulerRestart(ctx context.Context, fake *fakeAnthropic, old *serverProcess, jobID string) string {
+	diagCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	ctx = diagCtx
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "scheduler restart diagnostics for job %s\n", jobID)
+	if old != nil {
+		fmt.Fprintf(&b, "old server log: %s\n%s\n", old.logPath, old.logTail(60))
+	}
+	if h.proc != nil {
+		fmt.Fprintf(&b, "new server log: %s\n%s\n", h.proc.logPath, h.proc.logTail(60))
+	}
+
+	rows, err := h.db.Query(ctx, `
+		SELECT id, enabled, schedule_at, last_run_at, last_error
+		FROM sched_job WHERE id = $1`, jobID)
+	if err != nil {
+		fmt.Fprintf(&b, "query sched_job: %v\n", err)
+	} else {
+		defer rows.Close()
+		for rows.Next() {
+			var id, at, lastErr string
+			var enabled bool
+			var lastRun *time.Time
+			if err := rows.Scan(&id, &enabled, &at, &lastRun, &lastErr); err != nil {
+				fmt.Fprintf(&b, "scan sched_job: %v\n", err)
+				break
+			}
+			fmt.Fprintf(&b, "sched_job id=%s enabled=%t schedule_at=%q last_run_at=%v last_error=%q\n", id, enabled, at, lastRun, lastErr)
+		}
+	}
+
+	runs, err := h.db.Query(ctx, `SELECT id, status, started_at, finished_at, error, output FROM sched_job_run WHERE job_id = $1 ORDER BY started_at, id`, jobID)
+	if err != nil {
+		fmt.Fprintf(&b, "query sched_job_run: %v\n", err)
+	} else {
+		defer runs.Close()
+		for runs.Next() {
+			var id, status, runErr, output string
+			var started time.Time
+			var finished *time.Time
+			if err := runs.Scan(&id, &status, &started, &finished, &runErr, &output); err != nil {
+				fmt.Fprintf(&b, "scan sched_job_run: %v\n", err)
+				break
+			}
+			fmt.Fprintf(&b, "sched_job_run id=%s status=%s started=%s finished=%v error=%q output=%q\n", id, status, started.UTC().Format(time.RFC3339), finished, runErr, output)
+		}
+	}
+
+	river, err := h.db.Query(ctx, `SELECT id, state::text, attempt, scheduled_at, finalized_at, args::text FROM river_job WHERE kind = 'stella_scheduler_job' AND args->>'job_id' = $1 ORDER BY id`, jobID)
+	if err != nil {
+		fmt.Fprintf(&b, "query river_job: %v\n", err)
+	} else {
+		defer river.Close()
+		for river.Next() {
+			var id int64
+			var state, riverArgs string
+			var attempt int16
+			var scheduled time.Time
+			var finalized *time.Time
+			if err := river.Scan(&id, &state, &attempt, &scheduled, &finalized, &riverArgs); err != nil {
+				fmt.Fprintf(&b, "scan river_job: %v\n", err)
+				break
+			}
+			fmt.Fprintf(&b, "river_job id=%d state=%s attempt=%d scheduled=%s finalized=%v args=%s\n", id, state, attempt, scheduled.UTC().Format(time.RFC3339), finalized, riverArgs)
+		}
+	}
+
+	reqs := fake.requests()
+	fmt.Fprintf(&b, "fake model requests=%d", len(reqs))
+	for i, req := range reqs {
+		fmt.Fprintf(&b, " [%d model=%q tools=%v]", i+1, req.Model, req.ToolNames)
+	}
+	return b.String()
+}

--- a/test/system/system_test.go
+++ b/test/system/system_test.go
@@ -27,6 +27,7 @@ func TestSystem(t *testing.T) {
 	t.Run("webhook_sync_persistent", h.testWebhookSyncPersistent)
 	t.Run("goal_lifecycle", h.testGoalLifecycle)
 	t.Run("github_webhook_compatibility", h.testGitHubWebhookCompatibility)
+	t.Run("scheduler_one_time_job_survives_forced_restart", h.testSchedulerOneTimeJobSurvivesForcedRestart)
 	// graceful_drain MUST run last: it sends SIGTERM to the shared server and
 	// asserts the process exits, consuming the server no later journey can use.
 	t.Run("graceful_drain", h.testGracefulDrain)
@@ -79,7 +80,7 @@ func TestHarnessEarlyExit(t *testing.T) {
 		"HOST=127.0.0.1",
 		fmt.Sprintf("PORT=%d", port),
 	)
-	proc := startServerProcess(t, "early-exit-"+runID, env)
+	proc := startServerProcess(t, t, "early-exit-"+runID, env)
 
 	start := time.Now()
 	err := proc.waitReady(fmt.Sprintf("http://127.0.0.1:%d", port), readyTimeout)

--- a/web/content/docs/development/rules/system-test.md
+++ b/web/content/docs/development/rules/system-test.md
@@ -85,6 +85,9 @@ and one shared database serve them all in sequence:
 - `github_webhook_compatibility` — a GitHub-shaped JSON push delivery, sent
   without a cookie jar to an ordinary personal Webhook, receives async `202` and
   reaches the fake model exactly once with its payload intact.
+- `scheduler_one_time_job_survives_forced_restart` — a future one-time chat job
+  is persisted, the server is force-killed before it is due, and a replacement
+  process on the same database executes and retires that exact job once.
 - `graceful_drain` — SIGTERM with a turn pinned in flight: `/readyz` flips away
   from ready, an attach subscription is drain-cancelled, the pinned turn still
   completes on its stream (full text, finish, [DONE]), and the process exits 0.
@@ -139,11 +142,13 @@ and no unscripted request," never an exact call count.
 
 ## Diagnostics
 
-Server logs are written to `dist/logs/system-test/server-<runid>-a<attempt>.log`
-in the repo (they survive the run), so a failure message can always point at a
-live file. Failures attach a tail of that log; the goal journey additionally dumps
-the goal tree, its attempts, and the fake's request log, so a stuck async run is
-diagnosable without a rerun.
+Server logs are written to
+`dist/logs/system-test/server-<runid>-g<generation>-a<attempt>.log` in the repo
+(they survive the run), so restart journeys retain every process generation and
+a failure message can always point at a live file. Failures attach a tail of the
+relevant log; the goal and scheduler-restart journeys additionally dump their
+durable rows and fake request logs, so stuck async work is diagnosable without a
+rerun.
 
 ## When to add a system-test journey
 

--- a/web/content/docs/development/rules/system-test.zh.md
+++ b/web/content/docs/development/rules/system-test.zh.md
@@ -74,6 +74,8 @@ Ubuntu runner，并调用 `mise run system-test`；若该 runner 将来变得不
 - `goal_lifecycle` —— 一个 Goal 从创建被派发器的异步 worker 驱动到自主验收。
 - `github_webhook_compatibility` —— 一个 GitHub 风格的 JSON push 投递通过无 cookie jar 的普通个人 Webhook
   发送，收到异步 `202`，并且其原始 payload 恰好一次、完整地抵达 fake model。
+- `scheduler_one_time_job_survives_forced_restart` —— 持久化一个未来触发的一次性 chat job，在到期前
+  强杀服务器，再由连接同一数据库的替代进程恰好执行并退役该 job 一次。
 - `graceful_drain` —— 在一个轮次仍在途中时发送 SIGTERM：`/readyz` 从 ready 翻转，一个 attach
   订阅被 drain 取消，被钉住的轮次仍在其流上完整收尾（全文、finish、[DONE]），进程以 0 退出。
   它最后运行，因为会消费掉共享服务器。
@@ -119,9 +121,11 @@ action 枚举）才选择响应，所以普通的 prompt 改动永远不会变�
 
 ## 诊断
 
-服务器日志写到仓库内的 `dist/logs/system-test/server-<runid>-a<attempt>.log`（运行结束后仍
-保留），因此失败信息始终能指向一个真实文件。失败会附带该日志的尾部；goal journey 还会额外
-dump goal 树、它的 attempts 以及 fake 的请求日志，使卡住的异步运行无需重跑即可诊断。
+服务器日志写到仓库内的
+`dist/logs/system-test/server-<runid>-g<generation>-a<attempt>.log`（运行结束后仍保留），
+因此 restart journey 会保留每一代进程，失败信息也始终能指向一个真实文件。失败会附带相关日志
+的尾部；goal 与 scheduler restart journey 还会额外 dump 持久化行和 fake 请求日志，使卡住的
+异步任务无需重跑即可诊断。
 
 ## 何时新增一个系统测试 journey
 


### PR DESCRIPTION
## What

Add a subprocess System journey proving a future one-time Scheduler chat job survives an abrupt `stellad` crash and executes exactly once after restart against the same PostgreSQL database, home, and vault identity.

## Why

In-process Scheduler tests prove persistence and River mechanics, but they cannot prove production startup ordering: callbacks must be wired before the shared River client starts, persisted rows must be reloaded, and re-registration must deduplicate the original durable fire. A release candidate could otherwise strand or duplicate scheduled work after a host restart.

## How

- Retain the harness's database, home, and vault identity across process generations while giving every generation a distinct durable log.
- Force-kill only the owned process group before the job is due, reap it, and prove the group is gone before starting the replacement.
- Create the job through the authenticated production HTTP API and execute it through the existing scripted Anthropic fake.
- Assert one stable Scheduler job, one successful run with the expected output, one completed River row, one exact model request containing the scheduled message, and a disabled one-time job.
- Observe a bounded quiet window to reject delayed duplicate execution and dump both process logs plus Scheduler/River rows on failure.
- Document the new journey and generation-aware diagnostics in English and Chinese.

Deliberate limit: this proves recovery of a pending durable fire. It does not claim crash-safe exactly-once semantics for an external side effect already in flight.

## Test

- `mise run system-test` — passed (`test/system`, 63.304s)
- `mise exec -- go test -count=1 ./internal/scheduler` — passed
- `mise run format` — passed
- `mise run build` — passed
- `mise run test` — passed after rebuilding the ignored local `web/static/dist/` artifact from current sources
- Mutation check: temporarily removing Scheduler's one-time River uniqueness made the journey observe two pending River rows; restoration passed.
- Independent Opus blocker review — no blocker found.

## Refs

Refs #835

Stack: #845 → this PR

## Checklist

- [x] The PR links a GitHub issue.
- [x] I added or updated focused tests for changed non-trivial behavior.
- [x] I updated relevant English and Chinese documentation.
- [x] I ran `mise run format && mise run build && mise run test`.
