### PR TITLE
✅ test(sandbox): run local exec tests through a real session

### DIFF
--- a/plugins/sandbox/local/session_test.go
+++ b/plugins/sandbox/local/session_test.go
@@ -200,6 +200,30 @@ func newTestSession(t *testing.T) (*localSession, string) {
 	return s, root
 }
 
+// newExecTestSession returns a session built by the factory, so the sandbox root
+// carries the platform's real mapping (/workspace under bwrap). Tests that run a
+// command must not use newTestSession: its hand-built session claims the host
+// path is also the sandbox path, which on Linux collides with the session's
+// private /tmp bind and leaves the working directory unreachable.
+func newExecTestSession(t *testing.T) *localSession {
+	t.Helper()
+	root := t.TempDir()
+	policy := sandboxpkg.Policy{
+		Filesystem: sandboxpkg.FilesystemPolicy{
+			WorkspaceRoot: root,
+			WorkingDir:    root,
+		},
+		Network:    sandboxpkg.NetworkPolicy{Mode: sandboxpkg.NetworkAllowAll},
+		InheritEnv: true,
+	}
+	sess, err := NewFactory().CreateSession(context.Background(), policy)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	t.Cleanup(func() { sess.Close() }) //nolint:errcheck
+	return sess.(*localSession)
+}
+
 // TestResolvePath_rejectsOutsideRoot verifies that ResolvePath returns an error
 // when the resolved path is outside the workspace root.
 func TestResolvePath_rejectsOutsideRoot(t *testing.T) {
@@ -940,7 +964,7 @@ func TestBuildEnv_denyListFiltersVaultKey(t *testing.T) {
 // failing commands and does not surface it as a Go error.
 func TestExec_nonzeroExitCode(t *testing.T) {
 	skipIfBwrapNotFunctional(t)
-	s, _ := newTestSession(t)
+	s := newExecTestSession(t)
 	result, err := s.Exec(context.Background(), "exit 42", sandboxpkg.ExecOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -954,7 +978,7 @@ func TestExec_nonzeroExitCode(t *testing.T) {
 // captures stdout correctly.
 func TestExec_success(t *testing.T) {
 	skipIfBwrapNotFunctional(t)
-	s, _ := newTestSession(t)
+	s := newExecTestSession(t)
 	result, err := s.Exec(context.Background(), "echo hello", sandboxpkg.ExecOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
Closes #860

## What

`TestExec_success` and `TestExec_nonzeroExitCode` build their session through the factory instead of the hand-built `newTestSession` fixture.

## Why

#857 made bwrap functional on the release runner, which un-skipped these two tests — and they immediately failed the `v0.61.0` validation job ([run 30879051245](https://github.com/CherryHQ/stella/actions/runs/30879051245)) with `expected exit code 0, got 1`. The discarded stderr explains it:

```
bwrap: Can't chdir to /tmp/Test.../001: No such file or directory
```

`newTestSession` sets `sandboxRoot == realRoot == t.TempDir()`. That holds on macOS, where `resolveSandboxRoot` returns the host path, but on Linux the sandbox root is `/workspace` — and `t.TempDir()` sits under `/tmp`, which each session shadows with its own private bind. The working directory the test claims to occupy does not exist inside the sandbox.

This is a fixture defect, not a product defect. `CreateSession` maps the roots correctly, the factory-based bwrap tests pass on Linux, and production workspace roots live under `STELLA_HOME`. The gap survived because these tests have been skipped on Linux CI since `78c503bf` (2026-04-25).

## Verification

- Privileged `golang:1.25` container with bubblewrap: `go test ./plugins/sandbox/local/` — reproduced the failure first, green after the change (whole package).
- macOS: `go test ./plugins/sandbox/local/` green — the darwin path is unchanged.