### PR TITLE
🧪 test: prove worker state reconstruction

### DIFF
--- a/internal/memory/lcm/provider_reconstruction_test.go
+++ b/internal/memory/lcm/provider_reconstruction_test.go
@@ -1,0 +1,104 @@
+package lcm_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/CherryHQ/stella/internal/memory"
+	"github.com/CherryHQ/stella/internal/memory/lcm"
+	"github.com/CherryHQ/stella/pkg/ai"
+)
+
+func TestReconstructedProviderReusesCommittedCompaction(t *testing.T) {
+	ctx := context.Background()
+	db := newLCMTestDB(t)
+	defer db.Close()
+	session := newLCMTestSession("reconstructed-compaction")
+	var calls atomic.Int64
+	summarizer := func(context.Context, string) (string, error) {
+		calls.Add(1)
+		return "committed compaction summary", nil
+	}
+	config := map[string]any{"fresh_tail": 1}
+
+	first, err := lcm.New(db, summarizer, config)
+	if err != nil {
+		t.Fatalf("new first provider: %v", err)
+	}
+	if err := first.Bootstrap(ctx, session); err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	for i := 1; i <= 11; i++ {
+		if err := first.Append(ctx, session, ai.UserMessage{Content: fmt.Sprintf("private message %02d", i)}); err != nil {
+			t.Fatalf("append message %d: %v", i, err)
+		}
+	}
+	firstResult, err := memory.Compactor(first).Compact(ctx, session, memory.CompactionIncremental)
+	if err != nil {
+		t.Fatalf("first compact: %v", err)
+	}
+	if firstResult.LeafSummariesCreated == 0 || firstResult.MessagesCompacted == 0 {
+		t.Fatalf("first compact result = %+v, want committed leaf compaction", firstResult)
+	}
+	if calls.Load() == 0 {
+		t.Fatal("first compact did not call the summarizer")
+	}
+	callsAfterFirst := calls.Load()
+
+	convID := conversationID(t, db, session.ID)
+	var summaryCount, itemCount int
+	if err := db.QueryRow(ctx, `SELECT COUNT(*) FROM ctx_summary WHERE conversation_id = $1`, convID).Scan(&summaryCount); err != nil {
+		t.Fatalf("count summaries: %v", err)
+	}
+	if err := db.QueryRow(ctx, `SELECT COUNT(*) FROM ctx_item WHERE conversation_id = $1`, convID).Scan(&itemCount); err != nil {
+		t.Fatalf("count context items: %v", err)
+	}
+	if summaryCount == 0 || itemCount == 0 {
+		t.Fatalf("committed rows: ctx_summary=%d ctx_item=%d, want persisted compaction", summaryCount, itemCount)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("close first provider: %v", err)
+	}
+
+	second, err := lcm.New(db, summarizer, config)
+	if err != nil {
+		t.Fatalf("new reconstructed provider: %v", err)
+	}
+	defer func() { _ = second.Close() }()
+	assembled, err := second.Assemble(ctx, session, 100_000, 1)
+	if err != nil {
+		t.Fatalf("assemble committed compaction: %v", err)
+	}
+	assembledText := make([]string, 0, len(assembled))
+	for _, message := range assembled {
+		assembledText = append(assembledText, memory.MessageText(message))
+	}
+	assembledContext := strings.Join(assembledText, "\n")
+	if !strings.Contains(assembledContext, "committed compaction summary") || !strings.Contains(assembledContext, "private message 11") {
+		t.Fatalf("assembled committed compaction = %#v", assembled)
+	}
+
+	secondResult, err := memory.Compactor(second).Compact(ctx, session, memory.CompactionIncremental)
+	if err != nil {
+		t.Fatalf("second compact: %v", err)
+	}
+	if secondResult.LeafSummariesCreated != 0 || secondResult.CondensedSummariesCreated != 0 || secondResult.MessagesCompacted != 0 {
+		t.Fatalf("second compact result = %+v, want no new work", secondResult)
+	}
+	if calls.Load() != callsAfterFirst {
+		t.Fatalf("second compact summarizer calls = %d, want unchanged %d", calls.Load(), callsAfterFirst)
+	}
+	var finalSummaryCount, finalItemCount int
+	if err := db.QueryRow(ctx, `SELECT COUNT(*) FROM ctx_summary WHERE conversation_id = $1`, convID).Scan(&finalSummaryCount); err != nil {
+		t.Fatalf("count summaries after reconstruction: %v", err)
+	}
+	if err := db.QueryRow(ctx, `SELECT COUNT(*) FROM ctx_item WHERE conversation_id = $1`, convID).Scan(&finalItemCount); err != nil {
+		t.Fatalf("count context items after reconstruction: %v", err)
+	}
+	if finalSummaryCount != summaryCount || finalItemCount != itemCount {
+		t.Fatalf("reconstructed compact wrote rows: ctx_summary=%d ctx_item=%d, want unchanged %d/%d", finalSummaryCount, finalItemCount, summaryCount, itemCount)
+	}
+}

--- a/internal/reflect/candidate_pipeline_reconstruction_test.go
+++ b/internal/reflect/candidate_pipeline_reconstruction_test.go
@@ -1,0 +1,106 @@
+package reflect
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/CherryHQ/stella/internal/db/dbtest"
+	"github.com/CherryHQ/stella/internal/memory"
+	"github.com/CherryHQ/stella/internal/memory/memorytest"
+	"github.com/CherryHQ/stella/internal/pluginstate"
+	"github.com/CherryHQ/stella/pkg/ai"
+)
+
+func TestServiceReconstructionPostgresWatermarksRetryOnlyFailedFactWithoutDuplicatingSkill(t *testing.T) {
+	ctx := context.Background()
+	db := dbtest.New(t)
+	memoryFixture := memorytest.New()
+	session := memory.Session{ID: "reconstruct-watermarks", AgentID: "agent-1", UserID: "user-1"}
+	freshAt := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	if err := memoryFixture.Bootstrap(ctx, session); err != nil {
+		t.Fatalf("bootstrap memory: %v", err)
+	}
+	if err := memoryFixture.Append(ctx, session, ai.UserMessage{Content: "durable review candidate", Timestamp: freshAt}); err != nil {
+		t.Fatalf("append memory: %v", err)
+	}
+
+	newService := func() *Service {
+		return New(Config{
+			StateStore: testStateStore{store: pluginstate.New(db)},
+			Memory:     &nonReviewerProvider{inner: memoryFixture},
+		})
+	}
+	target := reviewTarget{session: session, privateOneToOne: true}
+	factFailure := errors.New("fact line failed")
+	factCalls, skillCalls := 0, 0
+
+	first := newService()
+	result, err := first.runCandidatePipeline(ctx, target, candidatePipelineOptions{
+		FactLine: func(context.Context, ReviewUnit) ([]factCandidate, error) {
+			factCalls++
+			return nil, factFailure
+		},
+		SkillLine: func(context.Context, ReviewUnit) ([]skillCandidate, error) {
+			skillCalls++
+			return nil, nil
+		},
+	})
+	if err == nil {
+		t.Fatal("first review succeeded after fact line failure")
+	}
+	if len(result.Errors) != 1 || result.Errors[0].Line != reflectLineFact || !errors.Is(result.Errors[0].Err, factFailure) {
+		t.Fatalf("first review errors = %#v, want only fact failure", result.Errors)
+	}
+	if factCalls != 1 || skillCalls != 1 {
+		t.Fatalf("first review calls: fact=%d skill=%d, want 1/1", factCalls, skillCalls)
+	}
+	if mark, markErr := first.wm.getLine(ctx, session.ID, reflectLineFact); markErr != nil || mark != (reviewWatermark{}) {
+		t.Fatalf("fact watermark after failed line = %#v, %v; want zero", mark, markErr)
+	}
+	if mark, markErr := first.wm.getLine(ctx, session.ID, reflectLineSkill); markErr != nil || !mark.At.Equal(freshAt) {
+		t.Fatalf("skill watermark after committed line = %#v, %v; want %v", mark, markErr, freshAt)
+	}
+
+	second := newService()
+	result, err = second.runCandidatePipeline(ctx, target, candidatePipelineOptions{
+		FactLine: func(context.Context, ReviewUnit) ([]factCandidate, error) {
+			factCalls++
+			return nil, nil
+		},
+		SkillLine: func(context.Context, ReviewUnit) ([]skillCandidate, error) {
+			skillCalls++
+			return nil, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("reconstructed review: %v", err)
+	}
+	if factCalls != 2 || skillCalls != 1 {
+		t.Fatalf("reconstructed review calls: fact=%d skill=%d, want 2/1", factCalls, skillCalls)
+	}
+	if mark, markErr := second.wm.getLine(ctx, session.ID, reflectLineFact); markErr != nil || !mark.At.Equal(freshAt) {
+		t.Fatalf("fact watermark after retry = %#v, %v; want %v", mark, markErr, freshAt)
+	}
+	if mark, markErr := second.wm.getLine(ctx, session.ID, reflectLineSkill); markErr != nil || !mark.At.Equal(freshAt) {
+		t.Fatalf("skill watermark after retry = %#v, %v; want %v", mark, markErr, freshAt)
+	}
+
+	third := newService()
+	if _, err := third.runCandidatePipeline(ctx, target, candidatePipelineOptions{
+		FactLine: func(context.Context, ReviewUnit) ([]factCandidate, error) {
+			factCalls++
+			return nil, nil
+		},
+		SkillLine: func(context.Context, ReviewUnit) ([]skillCandidate, error) {
+			skillCalls++
+			return nil, nil
+		},
+	}); err != nil {
+		t.Fatalf("fully caught-up reconstructed review: %v", err)
+	}
+	if factCalls != 2 || skillCalls != 1 {
+		t.Fatalf("caught-up review ran candidate lines: fact=%d skill=%d, want 2/1", factCalls, skillCalls)
+	}
+}


### PR DESCRIPTION
## What

Add the two missing in-process reconstruction regressions found by the #835 worker-recovery evidence pass:

- Reflect resumes from PostgreSQL-backed per-line watermarks without rerunning a committed line.
- LCM reconstructs from persisted summary/message state and reuses committed compaction without duplicate writes.

## Why

Existing Reflect tests separately proved line failure isolation and watermark storage, while LCM tests proved compaction and reuse within one provider instance. Neither composed those contracts across reconstruction—the actual restart boundary. A release regression could therefore pass both unit sets while forgetting persisted progress when services are rebuilt.

Goal does not need another journey: its existing owning-package tests already drive a real River `InsertTx` in the claim transaction, prove rollback/commit atomicity, keep cancelled running attempts replayable through lease reap, and verify queued/running recovery budgets. The subprocess Goal lifecycle also proves production worker wiring. A forced-restart Goal duplicate would add a multi-minute lease wait without a new invariant.

## How

- Run Reflect once with a failed fact line and successful skill line over the real plugin-state PostgreSQL adapter.
- Reconstruct the Service and adapter on the same DB; prove only the failed fact line retries.
- Reconstruct again; prove both committed watermarks suppress duplicate review.
- Compact a persisted LCM conversation, close the provider, and reconstruct a new provider on the same DB.
- Prove the new provider assembles the committed summary plus fresh tail, then performs zero summarizer calls and zero summary/context writes on another incremental compaction.

No System journey or production behavior was added: these are storage-module invariants and the owning-package layer is sufficient.

## Test

- `mise exec -- go test -count=1 ./internal/goal ./internal/reflect ./internal/memory/lcm` — passed
- `mise run format` — passed
- `mise run build` — passed
- `mise run test` — passed, including Go and Web suites
- System Test not rerun: no System file or process behavior changed.

## Refs

Refs #835

Stack: #845 → #858 → this PR

## Checklist

- [x] The PR links a GitHub issue.
- [x] I added focused tests for the missing persistence boundaries.
- [x] No documentation change is needed; product behavior and operator workflow are unchanged.
- [x] I ran `mise run format && mise run build && mise run test`.
