### PR TITLE
✅ test(sandbox): root the read-tool boundary test outside /tmp

### DIFF
--- a/internal/agent/sandbox/read_test.go
+++ b/internal/agent/sandbox/read_test.go
@@ -133,17 +133,36 @@ func TestReadTextFileReturnsTextBlock(t *testing.T) {
 	}
 }
 
-func TestReadToolProjectRootAbsolutePathUsesHostBoundary(t *testing.T) {
-	rawWorkspace := t.TempDir()
-	workspace, err := filepath.EvalSymlinks(rawWorkspace)
+// unshadowedTempDir returns a temporary directory outside the system temp tree.
+// A local sandbox session binds session-private directories over /tmp and
+// /var/tmp, so a host path under them is ambiguous with sandbox-space temp paths
+// and resolves into the private backing instead of the host file. Tests that
+// hand host paths to a real session must stay clear of that overlap.
+func unshadowedTempDir(t *testing.T) string {
+	t.Helper()
+	home, err := os.UserHomeDir()
 	if err != nil {
-		t.Fatalf("EvalSymlinks workspace: %v", err)
+		t.Fatalf("UserHomeDir: %v", err)
 	}
+	dir, err := os.MkdirTemp(home, "stella-sandbox-test-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp(%q): %v", home, err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) }) //nolint:errcheck
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q): %v", dir, err)
+	}
+	return resolved
+}
+
+func TestReadToolProjectRootAbsolutePathUsesHostBoundary(t *testing.T) {
+	workspace := unshadowedTempDir(t)
 	inside := filepath.Join(workspace, "inside.txt")
 	if err := os.WriteFile(inside, []byte("inside workspace\n"), 0o644); err != nil {
 		t.Fatalf("write inside: %v", err)
 	}
-	outside := filepath.Join(t.TempDir(), "secret.txt")
+	outside := filepath.Join(unshadowedTempDir(t), "secret.txt")
 	if err := os.WriteFile(outside, []byte("outside workspace\n"), 0o644); err != nil {
 		t.Fatalf("write outside: %v", err)
 	}


### PR DESCRIPTION
Closes #864

## What

`TestReadToolProjectRootAbsolutePathUsesHostBoundary` now builds its workspace outside `/tmp`, through a small `unshadowedTempDir` helper that documents why.

## Why

The test failed the `v0.61.0` validation job ([run 30880247763](https://github.com/CherryHQ/stella/actions/runs/30880247763)) once #857 made bwrap functional:

```
open /tmp/stella-session-tmp-6762435/TestRead.../001/inside.txt: no such file or directory
```

Each local sandbox session binds a session-private directory over `/tmp` and `/var/tmp`. With the workspace rooted at `t.TempDir()` — `/tmp/...` on Linux — the host path the test hands to the read tool is ambiguous with a sandbox-space `/tmp` path, and the resolver takes the sandbox reading, landing in the private temp backing.

Not reachable from a default deployment (production workspace roots live under `STELLA_HOME`), so this is a test-environment fix, not a behavior change.

## Verification

Reproduced and verified in a privileged `golang:1.25-trixie` container with bubblewrap, running as a non-root user with `--init`:

- `go test ./internal/agent/sandbox/ ./plugins/sandbox/local/` — failed before, green after.
- `go test -tags system ./test/system/...` — **12/12 journeys pass**, the first fully green system run on Linux with a functional bwrap.
- Full `go test ./...` on Linux — running as the final check before the release tag moves.
- macOS: both packages green; the darwin path is unchanged.