### PR TITLE
🧪 test(providers): lock OpenAI tool-loop contracts

### DIFF
--- a/plugins/providers/openai-response/contract_test.go
+++ b/plugins/providers/openai-response/contract_test.go
@@ -1,0 +1,352 @@
+package openairesponse
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/CherryHQ/stella/pkg/ai"
+	"github.com/CherryHQ/stella/pkg/providers"
+)
+
+const (
+	contractAPIKey = "fake-openai-key"
+	contractModel  = "gpt-4.1-mini"
+	contractSystem = "You are a concise weather assistant."
+	contractPrompt = "What is the weather in Paris?"
+)
+
+// TestProviderStreamContractToolLoop exercises the production adapter against a
+// local Responses endpoint. It locks the request and normalized-event contracts
+// for the function-call round trip without credentials or a public endpoint.
+func TestProviderStreamContractToolLoop(t *testing.T) {
+	tool := ai.ToolDefinition{
+		Name:        "lookup_weather",
+		Description: "Look up the current weather for a city.",
+		InputSchema: map[string]any{
+			"type":                 "object",
+			"additionalProperties": false,
+			"properties": map[string]any{
+				"city": map[string]any{"type": "string"},
+			},
+			"required": []any{"city"},
+		},
+	}
+
+	scripts := &responsesScripts{scripts: []responseScript{
+		{
+			body: responseRequest([]any{
+				map[string]any{"role": "user", "content": contractPrompt},
+			}, tool),
+			events: []string{
+				`{"type":"response.output_item.added","sequence_number":1,"output_index":0,"item":{"id":"fc_item_weather_1","type":"function_call","call_id":"call_weather_1","name":"lookup_weather","arguments":"","status":"in_progress"}}`,
+				`{"type":"response.function_call_arguments.delta","sequence_number":2,"item_id":"fc_item_weather_1","output_index":0,"delta":"{\"city\":\""}`,
+				`{"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_item_weather_1","output_index":0,"delta":"Paris\"}"}`,
+				`{"type":"response.function_call_arguments.done","sequence_number":4,"item_id":"fc_item_weather_1","output_index":0,"arguments":"{\"city\":\"Paris\"}"}`,
+				completedResponseEvent("resp_weather_1", 11, 6, 17),
+			},
+		},
+		{
+			body: responseRequest([]any{
+				map[string]any{"role": "user", "content": contractPrompt},
+				map[string]any{
+					"type":      "function_call",
+					"call_id":   "call_weather_1",
+					"name":      "lookup_weather",
+					"arguments": `{"city":"Paris"}`,
+				},
+				map[string]any{
+					"type":    "function_call_output",
+					"call_id": "call_weather_1",
+					"output":  "weather=21C",
+				},
+			}, tool),
+			events: []string{
+				`{"type":"response.output_text.delta","sequence_number":1,"item_id":"msg_weather_2","output_index":0,"content_index":0,"delta":"Paris is "}`,
+				`{"type":"response.output_text.delta","sequence_number":2,"item_id":"msg_weather_2","output_index":0,"content_index":0,"delta":"21C."}`,
+				completedResponseEvent("resp_weather_2", 20, 4, 24),
+			},
+		},
+	}}
+	server := httptest.NewServer(http.HandlerFunc(scripts.serveHTTP))
+	t.Cleanup(func() {
+		server.Close()
+		if err := scripts.consumed(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	provider := New(Config{APIKey: contractAPIKey, BaseURL: server.URL + "/v1"})
+	model := ai.Model{Name: contractModel}
+	firstContext := ai.Context{
+		System:   contractSystem,
+		Messages: []ai.Message{ai.UserMessage{Content: contractPrompt}},
+		Tools:    []ai.ToolDefinition{tool},
+	}
+
+	first, err := provider.Stream(ctx, model, firstContext, ai.StreamOptions{})
+	if err != nil {
+		t.Fatalf("start first stream: %v", err)
+	}
+	firstEvents, err := collectContractEvents(ctx, first)
+	if err != nil {
+		t.Fatalf("collect first stream: %v", err)
+	}
+	call := assertFirstTurn(t, firstEvents)
+
+	secondContext := ai.Context{
+		System: contractSystem,
+		Messages: []ai.Message{
+			ai.UserMessage{Content: contractPrompt},
+			ai.AssistantMessage{Content: []ai.ContentBlock{call}},
+			ai.ToolResultMessage{
+				ToolCallID: call.ID,
+				ToolName:   call.Name,
+				Content:    []ai.ContentBlock{ai.TextContent{Text: "weather=21C"}},
+			},
+		},
+		Tools: []ai.ToolDefinition{tool},
+	}
+	second, err := provider.Stream(ctx, model, secondContext, ai.StreamOptions{})
+	if err != nil {
+		t.Fatalf("start second stream: %v", err)
+	}
+	secondEvents, err := collectContractEvents(ctx, second)
+	if err != nil {
+		t.Fatalf("collect second stream: %v", err)
+	}
+	assertSecondTurn(t, secondEvents)
+}
+
+func responseRequest(input []any, tool ai.ToolDefinition) map[string]any {
+	return map[string]any{
+		"instructions": contractSystem,
+		"input":        input,
+		"model":        contractModel,
+		"stream":       true,
+		"tools": []any{map[string]any{
+			"type":        "function",
+			"name":        tool.Name,
+			"description": tool.Description,
+			"parameters":  tool.InputSchema,
+		}},
+	}
+}
+
+func completedResponseEvent(id string, inputTokens, outputTokens, totalTokens int) string {
+	return fmt.Sprintf(`{"type":"response.completed","sequence_number":5,"response":{"id":%q,"object":"response","created_at":1700000000,"status":"completed","model":%q,"output":[],"usage":{"input_tokens":%d,"input_tokens_details":{"cached_tokens":0},"output_tokens":%d,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":%d}}}`,
+		id, contractModel, inputTokens, outputTokens, totalTokens)
+}
+
+type responseScript struct {
+	body   map[string]any
+	events []string
+}
+
+type responsesScripts struct {
+	mu      sync.Mutex
+	scripts []responseScript
+	used    int
+	diag    error
+}
+
+func (s *responsesScripts) serveHTTP(w http.ResponseWriter, r *http.Request) {
+	body, err := decodeContractRequest(r.Body)
+	if err != nil {
+		s.reject(w, fmt.Errorf("decode request body: %w", err))
+		return
+	}
+
+	s.mu.Lock()
+	if s.used >= len(s.scripts) {
+		s.rejectLocked(w, fmt.Errorf("unscripted request %s %s", r.Method, r.URL.Path))
+		s.mu.Unlock()
+		return
+	}
+
+	script := s.scripts[s.used]
+	if err := validateContractRequest(r, body, script.body); err != nil {
+		s.rejectLocked(w, fmt.Errorf("script %d: %w", s.used+1, err))
+		s.mu.Unlock()
+		return
+	}
+	s.used++
+	s.mu.Unlock()
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	for _, event := range script.events {
+		var envelope struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal([]byte(event), &envelope); err != nil || envelope.Type == "" {
+			s.reject(w, fmt.Errorf("scripted response event has no valid type: %w", err))
+			return
+		}
+		_, _ = fmt.Fprintf(w, "event: %s\ndata: %s\n\n", envelope.Type, event)
+	}
+	if flusher, ok := w.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+func decodeContractRequest(body io.Reader) (map[string]any, error) {
+	decoder := json.NewDecoder(io.LimitReader(body, 64<<10))
+	var request map[string]any
+	if err := decoder.Decode(&request); err != nil {
+		return nil, err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return nil, fmt.Errorf("multiple JSON values")
+	}
+	return request, nil
+}
+
+func validateContractRequest(r *http.Request, got, want map[string]any) error {
+	if r.Method != http.MethodPost {
+		return fmt.Errorf("method = %s, want POST", r.Method)
+	}
+	if r.URL.Path != "/v1/responses" {
+		return fmt.Errorf("path = %s, want /v1/responses", r.URL.Path)
+	}
+	if r.Header.Get("Authorization") != "Bearer "+contractAPIKey {
+		return fmt.Errorf("authorization does not carry the fixed bearer token")
+	}
+	if !strings.HasPrefix(r.Header.Get("Content-Type"), "application/json") {
+		return fmt.Errorf("content type = %q, want application/json", r.Header.Get("Content-Type"))
+	}
+	if !reflect.DeepEqual(got, want) {
+		return fmt.Errorf("request JSON does not match the scripted contract")
+	}
+	return nil
+}
+
+func (s *responsesScripts) reject(w http.ResponseWriter, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.rejectLocked(w, err)
+}
+
+func (s *responsesScripts) rejectLocked(w http.ResponseWriter, err error) {
+	if s.diag == nil {
+		message := err.Error()
+		if len(message) > 512 {
+			message = message[:512]
+		}
+		s.diag = fmt.Errorf("responses contract server: %s", message)
+	}
+	http.Error(w, "contract request rejected", http.StatusBadRequest)
+}
+
+func (s *responsesScripts) consumed() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.diag != nil {
+		return s.diag
+	}
+	if s.used != len(s.scripts) {
+		return fmt.Errorf("responses contract scripts consumed = %d, want %d", s.used, len(s.scripts))
+	}
+	return nil
+}
+
+func collectContractEvents(ctx context.Context, stream providers.AssistantEventStream) ([]ai.AssistantEvent, error) {
+	var events []ai.AssistantEvent
+	for {
+		select {
+		case event, ok := <-stream.Events():
+			if !ok {
+				return events, stream.Wait()
+			}
+			events = append(events, event)
+		case <-ctx.Done():
+			_ = stream.Close()
+			return nil, ctx.Err()
+		}
+	}
+}
+
+func assertFirstTurn(t *testing.T, events []ai.AssistantEvent) ai.ToolCall {
+	t.Helper()
+	if len(events) != 6 {
+		t.Fatalf("first turn events = %d, want 6: %#v", len(events), events)
+	}
+	if _, ok := events[0].(ai.EventStart); !ok {
+		t.Fatalf("first turn event 0 = %T, want EventStart", events[0])
+	}
+	first, ok := events[1].(ai.EventToolCallDelta)
+	if !ok {
+		t.Fatalf("first turn event 1 = %T, want EventToolCallDelta", events[1])
+	}
+	second, ok := events[2].(ai.EventToolCallDelta)
+	if !ok {
+		t.Fatalf("first turn event 2 = %T, want EventToolCallDelta", events[2])
+	}
+	third, ok := events[3].(ai.EventToolCallDelta)
+	if !ok {
+		t.Fatalf("first turn event 3 = %T, want EventToolCallDelta", events[3])
+	}
+	if first.ID != "call_weather_1" || first.Name != "lookup_weather" || first.Arguments != "" {
+		t.Fatalf("first tool delta = %+v, want call ID/name without arguments", first)
+	}
+	if second.ID != first.ID || third.ID != first.ID || second.Name != "" || third.Name != "" {
+		t.Fatalf("tool call identity drifted across deltas: %+v, %+v, %+v", first, second, third)
+	}
+	arguments := second.Arguments + third.Arguments
+	if arguments != `{"city":"Paris"}` {
+		t.Fatalf("tool arguments = %q, want %q", arguments, `{"city":"Paris"}`)
+	}
+	usage, ok := events[4].(ai.EventUsage)
+	if !ok || usage.Usage != (ai.Usage{InputTokens: 11, OutputTokens: 6, TotalTokens: 17}) {
+		t.Fatalf("first turn event 4 = %#v, want usage before stop", events[4])
+	}
+	stop, ok := events[5].(ai.EventStop)
+	if !ok || stop.Reason != ai.StopReasonStop {
+		t.Fatalf("first turn event 5 = %#v, want StopReasonStop", events[5])
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(arguments), &decoded); err != nil {
+		t.Fatalf("decode observed tool arguments: %v", err)
+	}
+	return ai.ToolCall{ID: first.ID, Name: first.Name, Arguments: decoded}
+}
+
+func assertSecondTurn(t *testing.T, events []ai.AssistantEvent) {
+	t.Helper()
+	if len(events) != 5 {
+		t.Fatalf("second turn events = %d, want 5: %#v", len(events), events)
+	}
+	if _, ok := events[0].(ai.EventStart); !ok {
+		t.Fatalf("second turn event 0 = %T, want EventStart", events[0])
+	}
+	first, ok := events[1].(ai.EventTextDelta)
+	if !ok {
+		t.Fatalf("second turn event 1 = %T, want EventTextDelta", events[1])
+	}
+	second, ok := events[2].(ai.EventTextDelta)
+	if !ok {
+		t.Fatalf("second turn event 2 = %T, want EventTextDelta", events[2])
+	}
+	if first.Text+second.Text != "Paris is 21C." {
+		t.Fatalf("second turn text = %q, want %q", first.Text+second.Text, "Paris is 21C.")
+	}
+	usage, ok := events[3].(ai.EventUsage)
+	if !ok || usage.Usage != (ai.Usage{InputTokens: 20, OutputTokens: 4, TotalTokens: 24}) {
+		t.Fatalf("second turn event 3 = %#v, want usage before stop", events[3])
+	}
+	stop, ok := events[4].(ai.EventStop)
+	if !ok || stop.Reason != ai.StopReasonStop {
+		t.Fatalf("second turn event 4 = %#v, want StopReasonStop", events[4])
+	}
+}

--- a/plugins/providers/openai/contract_test.go
+++ b/plugins/providers/openai/contract_test.go
@@ -1,0 +1,371 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/CherryHQ/stella/pkg/ai"
+)
+
+const (
+	contractToken  = "sk-contract-test-token"
+	contractModel  = "gpt-4o-mini"
+	contractSystem = "You answer weather questions using the provided tool."
+	contractPrompt = "What is the weather in Paris?"
+	contractCallID = "call_weather_paris"
+)
+
+// TestProviderStreamToolLoopContract exercises the production Chat Completions
+// adapter against a local scripted endpoint. It locks the wire format at the
+// boundary where tool call deltas become the next turn's assistant/tool messages.
+func TestProviderStreamToolLoopContract(t *testing.T) {
+	toolSchema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"city": map[string]any{
+				"type":        "string",
+				"description": "The city to look up.",
+			},
+		},
+		"required":             []any{"city"},
+		"additionalProperties": false,
+	}
+	tools := []ai.ToolDefinition{{
+		Name:        "lookup_weather",
+		Description: "Look up the current weather for a city.",
+		InputSchema: toolSchema,
+	}}
+
+	firstMessages := []any{
+		map[string]any{"role": "system", "content": contractSystem},
+		map[string]any{"role": "user", "content": contractPrompt},
+	}
+	server := newChatCompletionScriptServer([]chatCompletionScript{
+		{
+			request: chatCompletionRequest(contractModel, firstMessages, toolSchema),
+			response: strings.Join([]string{
+				`data: {"id":"chatcmpl-tool","object":"chat.completion.chunk","created":1,"model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_weather_paris","type":"function","function":{}}]},"finish_reason":null}]}`,
+				`data: {"id":"chatcmpl-tool","object":"chat.completion.chunk","created":1,"model":"gpt-4o-mini","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":"lookup_weather","arguments":"{\"city\":"}}]},"finish_reason":null}]}`,
+				`data: {"id":"chatcmpl-tool","object":"chat.completion.chunk","created":1,"model":"gpt-4o-mini","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"Paris\"}"}}]},"finish_reason":null}]}`,
+				`data: {"id":"chatcmpl-tool","object":"chat.completion.chunk","created":1,"model":"gpt-4o-mini","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+				"data: [DONE]",
+			}, "\n\n") + "\n\n",
+		},
+		{
+			request: func(body map[string]any) error {
+				assistant := map[string]any{
+					"role": "assistant",
+					"tool_calls": []any{map[string]any{
+						"id":   contractCallID,
+						"type": "function",
+						"function": map[string]any{
+							"name":      "lookup_weather",
+							"arguments": `{"city":"Paris"}`,
+						},
+					}},
+				}
+				messages := append(append([]any{}, firstMessages...), assistant, map[string]any{
+					"role":         "tool",
+					"tool_call_id": contractCallID,
+					"content":      "weather=21C",
+				})
+				return chatCompletionRequest(contractModel, messages, toolSchema)(body)
+			},
+			response: strings.Join([]string{
+				`data: {"id":"chatcmpl-final","object":"chat.completion.chunk","created":2,"model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant","content":"The weather in "},"finish_reason":null}]}`,
+				`data: {"id":"chatcmpl-final","object":"chat.completion.chunk","created":2,"model":"gpt-4o-mini","choices":[{"index":0,"delta":{"content":"Paris is 21C."},"finish_reason":null}]}`,
+				`data: {"id":"chatcmpl-final","object":"chat.completion.chunk","created":2,"model":"gpt-4o-mini","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+				"data: [DONE]",
+			}, "\n\n") + "\n\n",
+		},
+	})
+	defer server.Close()
+	t.Cleanup(func() { server.assertConsumed(t) })
+
+	provider := New(Config{APIKey: contractToken, BaseURL: server.URL + "/v1"})
+	model := ai.Model{Name: contractModel}
+	firstContext := ai.Context{
+		System:   contractSystem,
+		Messages: []ai.Message{ai.UserMessage{Content: contractPrompt}},
+		Tools:    tools,
+	}
+
+	firstEvents := streamEvents(t, provider, model, firstContext)
+	assertEventKinds(t, firstEvents, "start", "toolcall_delta", "toolcall_delta", "toolcall_delta", "stop")
+	firstDeltas := toolCallDeltas(t, firstEvents[1:4])
+	for i, delta := range firstDeltas {
+		if delta.ID != contractCallID {
+			t.Fatalf("turn 1 tool delta %d ID = %q, want %q", i, delta.ID, contractCallID)
+		}
+	}
+	if firstDeltas[0].Name != "" || firstDeltas[0].Arguments != "" {
+		t.Fatalf("turn 1 ID delta = %+v, want only ID", firstDeltas[0])
+	}
+	if firstDeltas[1].Name != "lookup_weather" || firstDeltas[1].Arguments != `{"city":` {
+		t.Fatalf("turn 1 name/argument delta = %+v", firstDeltas[1])
+	}
+	if firstDeltas[2].Name != "" || firstDeltas[2].Arguments != `"Paris"}` {
+		t.Fatalf("turn 1 final argument delta = %+v", firstDeltas[2])
+	}
+	callName := firstDeltas[1].Name
+	arguments := firstDeltas[0].Arguments + firstDeltas[1].Arguments + firstDeltas[2].Arguments
+	if callName != "lookup_weather" {
+		t.Fatalf("turn 1 tool name = %q, want lookup_weather", callName)
+	}
+	if arguments != `{"city":"Paris"}` {
+		t.Fatalf("turn 1 concatenated arguments = %q", arguments)
+	}
+	if stop := firstEvents[len(firstEvents)-1].(ai.EventStop); stop.Reason != ai.StopReasonToolUse {
+		t.Fatalf("turn 1 stop reason = %q, want %q", stop.Reason, ai.StopReasonToolUse)
+	}
+
+	var toolArguments map[string]any
+	if err := json.Unmarshal([]byte(arguments), &toolArguments); err != nil {
+		t.Fatalf("turn 1 tool arguments must be JSON: %v", err)
+	}
+	secondContext := ai.Context{
+		System: contractSystem,
+		Messages: []ai.Message{
+			ai.UserMessage{Content: contractPrompt},
+			ai.AssistantMessage{Content: []ai.ContentBlock{
+				ai.ToolCall{ID: firstDeltas[0].ID, Name: callName, Arguments: toolArguments},
+			}},
+			ai.ToolResultMessage{
+				ToolCallID: firstDeltas[0].ID,
+				ToolName:   callName,
+				Content:    []ai.ContentBlock{ai.TextContent{Text: "weather=21C"}},
+			},
+		},
+		Tools: tools,
+	}
+
+	secondEvents := streamEvents(t, provider, model, secondContext)
+	assertEventKinds(t, secondEvents, "start", "text_delta", "text_delta", "stop")
+	if text := secondEvents[1].(ai.EventTextDelta).Text + secondEvents[2].(ai.EventTextDelta).Text; text != "The weather in Paris is 21C." {
+		t.Fatalf("turn 2 text = %q", text)
+	}
+	if stop := secondEvents[3].(ai.EventStop); stop.Reason != ai.StopReasonStop {
+		t.Fatalf("turn 2 stop reason = %q, want %q", stop.Reason, ai.StopReasonStop)
+	}
+}
+
+func chatCompletionRequest(model string, messages []any, schema map[string]any) func(map[string]any) error {
+	return func(body map[string]any) error {
+		want := map[string]any{
+			"model":    model,
+			"stream":   true,
+			"messages": messages,
+			"tools": []any{map[string]any{
+				"type": "function",
+				"function": map[string]any{
+					"name":        "lookup_weather",
+					"description": "Look up the current weather for a city.",
+					"parameters":  schema,
+				},
+			}},
+		}
+		if !reflect.DeepEqual(body, want) {
+			return fmt.Errorf("JSON body mismatch\n got: %#v\nwant: %#v", body, want)
+		}
+		return nil
+	}
+}
+
+func streamEvents(t *testing.T, provider *Provider, model ai.Model, input ai.Context) []ai.AssistantEvent {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	stream, err := provider.Stream(ctx, model, input, ai.StreamOptions{})
+	if err != nil {
+		t.Fatalf("Provider.Stream() error = %v", err)
+	}
+	var events []ai.AssistantEvent
+	for {
+		select {
+		case event, ok := <-stream.Events():
+			if !ok {
+				if err := stream.Wait(); err != nil {
+					t.Fatalf("stream.Wait() error = %v", err)
+				}
+				return events
+			}
+			events = append(events, event)
+		case <-ctx.Done():
+			t.Fatalf("timed out collecting provider events: %v", ctx.Err())
+		}
+	}
+}
+
+func assertEventKinds(t *testing.T, events []ai.AssistantEvent, want ...string) {
+	t.Helper()
+	got := make([]string, 0, len(events))
+	for _, event := range events {
+		switch event.(type) {
+		case ai.EventStart:
+			got = append(got, "start")
+		case ai.EventTextDelta:
+			got = append(got, "text_delta")
+		case ai.EventToolCallDelta:
+			got = append(got, "toolcall_delta")
+		case ai.EventStop:
+			got = append(got, "stop")
+		case ai.EventUsage:
+			got = append(got, "usage")
+		case ai.EventError:
+			got = append(got, "error")
+		default:
+			got = append(got, fmt.Sprintf("%T", event))
+		}
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("event order = %v, want %v", got, want)
+	}
+}
+
+func toolCallDeltas(t *testing.T, events []ai.AssistantEvent) []ai.EventToolCallDelta {
+	t.Helper()
+	deltas := make([]ai.EventToolCallDelta, 0, len(events))
+	for _, event := range events {
+		delta, ok := event.(ai.EventToolCallDelta)
+		if !ok {
+			t.Fatalf("event %T is not a tool call delta", event)
+		}
+		deltas = append(deltas, delta)
+	}
+	return deltas
+}
+
+type chatCompletionScript struct {
+	request  func(map[string]any) error
+	response string
+}
+
+type chatCompletionScriptServer struct {
+	mu      sync.Mutex
+	scripts []chatCompletionScript
+	next    int
+	errors  []string
+}
+
+type chatCompletionContractServer struct {
+	*httptest.Server
+	handler *chatCompletionScriptServer
+}
+
+func newChatCompletionScriptServer(scripts []chatCompletionScript) *chatCompletionContractServer {
+	handler := &chatCompletionScriptServer{scripts: scripts}
+	return &chatCompletionContractServer{
+		Server:  httptest.NewServer(handler),
+		handler: handler,
+	}
+}
+
+func (s *chatCompletionContractServer) assertConsumed(t *testing.T) {
+	s.handler.assertConsumed(t)
+}
+
+func (s *chatCompletionScriptServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if err := validateChatCompletionTransport(r); err != nil {
+		s.recordError(err)
+		http.Error(w, "contract request rejected", http.StatusBadRequest)
+		return
+	}
+	body, err := decodeJSONBody(w, r)
+	if err != nil {
+		s.recordError(err)
+		http.Error(w, "contract request rejected", http.StatusBadRequest)
+		return
+	}
+
+	s.mu.Lock()
+	if s.next >= len(s.scripts) {
+		s.recordErrorLocked(fmt.Errorf("unscripted request %s %s", r.Method, r.URL.Path))
+		s.mu.Unlock()
+		http.Error(w, "unscripted request", http.StatusInternalServerError)
+		return
+	}
+	script := s.scripts[s.next]
+	s.next++
+	scriptNumber := s.next
+	s.mu.Unlock()
+
+	if err := script.request(body); err != nil {
+		s.recordError(fmt.Errorf("script %d: %w", scriptNumber, err))
+		http.Error(w, "contract request rejected", http.StatusBadRequest)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(http.StatusOK)
+	_, _ = io.WriteString(w, script.response)
+}
+
+func validateChatCompletionTransport(r *http.Request) error {
+	if r.Method != http.MethodPost {
+		return fmt.Errorf("method = %q, want POST", r.Method)
+	}
+	if r.URL.Path != "/v1/chat/completions" {
+		return fmt.Errorf("path = %q, want /v1/chat/completions", r.URL.Path)
+	}
+	if got := r.Header.Get("Authorization"); got != "Bearer "+contractToken {
+		return fmt.Errorf("Authorization = %q, want Bearer fake contract token", got)
+	}
+	if got := r.Header.Get("Content-Type"); got != "application/json" {
+		return fmt.Errorf("Content-Type = %q, want application/json", got)
+	}
+	if got := r.Header.Get("Accept"); got != "application/json" {
+		return fmt.Errorf("Accept = %q, want application/json", got)
+	}
+	return nil
+}
+
+func decodeJSONBody(w http.ResponseWriter, r *http.Request) (map[string]any, error) {
+	defer func() { _ = r.Body.Close() }()
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, 64<<10))
+	var body map[string]any
+	if err := decoder.Decode(&body); err != nil {
+		return nil, fmt.Errorf("decode request JSON: %w", err)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return nil, fmt.Errorf("request body has multiple JSON values")
+		}
+		return nil, fmt.Errorf("decode trailing request JSON: %w", err)
+	}
+	return body, nil
+}
+
+func (s *chatCompletionScriptServer) recordError(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.recordErrorLocked(err)
+}
+
+func (s *chatCompletionScriptServer) recordErrorLocked(err error) {
+	const maxErrors = 4
+	if len(s.errors) < maxErrors {
+		s.errors = append(s.errors, err.Error())
+	}
+}
+
+func (s *chatCompletionScriptServer) assertConsumed(t *testing.T) {
+	t.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.errors) > 0 {
+		t.Errorf("scripted Chat Completions server errors: %s", strings.Join(s.errors, "; "))
+	}
+	if s.next != len(s.scripts) {
+		t.Errorf("consumed %d scripted requests, want %d", s.next, len(s.scripts))
+	}
+}


### PR DESCRIPTION
## What

Add credential-free, production-adapter contract journeys for OpenAI Chat Completions and OpenAI Responses. Each runs a complete two-request tool loop against a strict local SSE endpoint: model tool call → exact split arguments → matching tool result → final text.

## Why

Existing tests covered request conversion and stream-event mapping separately. They could both stay green while an SDK upgrade or adapter change broke the composed wire exchange—the exact seam currently hidden behind optional Live credentials. Release validation needs current-candidate evidence without a real key or public endpoint.

## How

- Point each real provider adapter at its own `httptest.Server` with a fixed fake bearer token.
- Reject wrong methods, paths, headers, complete JSON bodies, malformed bodies, and unscripted extra requests.
- Script protocol-realistic SSE for split function-call identity/arguments and final text.
- Assert each protocol's distinct normalized event ordering:
  - Chat Completions: tool deltas → `toolUse`; final text → `stop`.
  - Responses: item/call-ID mapping and argument deltas; terminal usage before normalized stop.
- Build turn two from the adapter-observed tool call, then prove the production converters emit the exact assistant/function call and matching tool-result wire shapes.
- Bound every stream with a local timeout and require both scripts to be consumed.

Deliberate limit: Chat Completions does not currently request `stream_options.include_usage`, so this PR does not fabricate or claim Live streaming usage evidence. Usage accounting is a separate product decision/follow-up, not silently smuggled into a protocol-regression PR.

## Test

- `mise exec -- go test -count=1 ./plugins/providers/openai ./plugins/providers/openai-response` — passed
- Mutation check, Chat Completions: temporarily blanking the production tool-result `tool_call_id` failed the second request with an exact body mismatch.
- Mutation check, Responses: temporarily blanking production `function_call_output.call_id` failed the second request with an exact body mismatch.
- `mise run format` — passed
- `mise run build` — passed
- `mise run test` — passed, including full Go and Web suites
- Independent Opus blocker review — no blocker; realistic Chat usage and Responses SSE framing feedback was incorporated.

## Refs

Refs #835

Controlled Protocols Stack: this PR is the independent bottom layer, based on `main` at `v0.61.0`.

## Checklist

- [x] The PR links a GitHub issue.
- [x] I added focused tests for the changed non-trivial release evidence.
- [x] No documentation change is needed; product behavior and operator workflow are unchanged.
- [x] I ran `mise run format && mise run build && mise run test`.
