### PR TITLE
✅ ci: run the local sandbox tests for real on Linux CI

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -53,13 +53,24 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install bubblewrap
-        run: sudo apt-get install -y bubblewrap
+        run: |
+          set -euo pipefail
+          sudo apt-get install -y bubblewrap
+          # Ubuntu 24.04 blocks unprivileged user namespaces through AppArmor, so
+          # an installed bwrap still cannot create a sandbox. The local sandbox
+          # backend probes exactly this, and the System Test runs real agent
+          # turns through it — without the sysctl every turn fails at runtime.
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          # Fail here, with the reason visible, rather than inside a test run.
+          bwrap --unshare-pid --unshare-ipc --unshare-uts --dev-bind / / -- true
 
       - name: Generate code and check drift
         run: mise run generate:check
 
       - name: Run tests with race detection and coverage
         run: mise run test:coverage:race
+        env:
+          STELLA_TEST_REQUIRE_BWRAP: "1"
 
       - name: Prepare coverage report data
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,8 @@ jobs:
 
       - name: Run Go and Web tests
         run: mise run test
+        env:
+          STELLA_TEST_REQUIRE_BWRAP: "1"
 
       - name: Run System Test
         run: mise run system-test

--- a/plugins/sandbox/local/session_linux_test.go
+++ b/plugins/sandbox/local/session_linux_test.go
@@ -3,7 +3,6 @@ package local
 import (
 	"context"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -86,9 +85,6 @@ func TestWrapCommand_linux_allowAllNoWrap(t *testing.T) {
 // available, the args include --dir /workspace, --bind <realRoot> /workspace,
 // and --chdir <sandboxCwd>.
 func TestLocalExec_linux_workspaceWritableOutsideHidden(t *testing.T) {
-	if _, err := exec.LookPath("bwrap"); err != nil {
-		t.Skip("bwrap not installed")
-	}
 	skipIfBwrapNotFunctional(t)
 
 	rawRoot := t.TempDir()
@@ -153,9 +149,6 @@ func TestAppendResolvedFileMount_mountsSymlinkTarget(t *testing.T) {
 }
 
 func TestWrapCommand_linux_bwrapWorkspaceRemap(t *testing.T) {
-	if _, err := exec.LookPath("bwrap"); err != nil {
-		t.Skip("bwrap not installed")
-	}
 	skipIfBwrapNotFunctional(t)
 
 	root := "/tmp/test-workspace"
@@ -244,9 +237,6 @@ func TestWrapCommand_linux_bwrapWorkspaceRemap(t *testing.T) {
 // on Linux — it lives under /user — but the mechanism still backs macOS and any
 // future out-of-root writable.)
 func TestWrapCommand_linux_outOfRootWritableBind(t *testing.T) {
-	if _, err := exec.LookPath("bwrap"); err != nil {
-		t.Skip("bwrap not installed")
-	}
 	skipIfBwrapNotFunctional(t)
 
 	stellaHome := t.TempDir()
@@ -291,9 +281,6 @@ func TestWrapCommand_linux_outOfRootWritableBind(t *testing.T) {
 // writable via the realRoot -> /workspace bind, and a second bind would only
 // re-expose the host path.
 func TestWrapCommand_linux_inWorkspaceWritableMountSkipped(t *testing.T) {
-	if _, err := exec.LookPath("bwrap"); err != nil {
-		t.Skip("bwrap not installed")
-	}
 	skipIfBwrapNotFunctional(t)
 
 	stellaHome := t.TempDir()
@@ -332,9 +319,6 @@ func TestWrapCommand_linux_inWorkspaceWritableMountSkipped(t *testing.T) {
 // under the STELLA_HOME tree: the /user bind already makes it writable, and a
 // second bind would re-expose the host path to the agent.
 func TestWrapCommand_linux_inUserDataWritableMountSkipped(t *testing.T) {
-	if _, err := exec.LookPath("bwrap"); err != nil {
-		t.Skip("bwrap not installed")
-	}
 	skipIfBwrapNotFunctional(t)
 
 	stellaHome := t.TempDir()
@@ -374,9 +358,6 @@ func TestWrapCommand_linux_inUserDataWritableMountSkipped(t *testing.T) {
 // /user, with NO sibling-hiding tmpfs — isolation is by non-mounting, since the
 // workspace IS the per-agent dir and siblings are never exposed.
 func TestWrapCommand_linux_twoRoots(t *testing.T) {
-	if _, err := exec.LookPath("bwrap"); err != nil {
-		t.Skip("bwrap not installed")
-	}
 	skipIfBwrapNotFunctional(t)
 
 	agentDir := "/tmp/test-workspace/users/u1/agents/a1"

--- a/plugins/sandbox/local/session_linux_test.go
+++ b/plugins/sandbox/local/session_linux_test.go
@@ -58,9 +58,7 @@ func TestWrapCommand_linux_networkDisabled(t *testing.T) {
 // TestWrapCommand_linux_allowAllNoWrap verifies that when network is allow_all,
 // bwrap is used without --unshare-net.
 func TestWrapCommand_linux_allowAllNoWrap(t *testing.T) {
-	if !bwrapFunctional() {
-		t.Skip("bwrap not functional")
-	}
+	skipIfBwrapNotFunctional(t)
 
 	root := "/tmp/test-workspace"
 	sandboxCwd := "/workspace"
@@ -91,9 +89,7 @@ func TestLocalExec_linux_workspaceWritableOutsideHidden(t *testing.T) {
 	if _, err := exec.LookPath("bwrap"); err != nil {
 		t.Skip("bwrap not installed")
 	}
-	if !bwrapFunctional() {
-		t.Skip("bwrap not functional (namespace creation blocked)")
-	}
+	skipIfBwrapNotFunctional(t)
 
 	rawRoot := t.TempDir()
 	root, err := filepath.EvalSymlinks(rawRoot)
@@ -160,9 +156,7 @@ func TestWrapCommand_linux_bwrapWorkspaceRemap(t *testing.T) {
 	if _, err := exec.LookPath("bwrap"); err != nil {
 		t.Skip("bwrap not installed")
 	}
-	if !bwrapFunctional() {
-		t.Skip("bwrap not functional (namespace creation blocked)")
-	}
+	skipIfBwrapNotFunctional(t)
 
 	root := "/tmp/test-workspace"
 	sandboxCwd := "/workspace/sub"
@@ -253,9 +247,7 @@ func TestWrapCommand_linux_outOfRootWritableBind(t *testing.T) {
 	if _, err := exec.LookPath("bwrap"); err != nil {
 		t.Skip("bwrap not installed")
 	}
-	if !bwrapFunctional() {
-		t.Skip("bwrap not functional (namespace creation blocked)")
-	}
+	skipIfBwrapNotFunctional(t)
 
 	stellaHome := t.TempDir()
 	userDir := filepath.Join(stellaHome, "users", "u1", ".mise-tools")
@@ -302,9 +294,7 @@ func TestWrapCommand_linux_inWorkspaceWritableMountSkipped(t *testing.T) {
 	if _, err := exec.LookPath("bwrap"); err != nil {
 		t.Skip("bwrap not installed")
 	}
-	if !bwrapFunctional() {
-		t.Skip("bwrap not functional (namespace creation blocked)")
-	}
+	skipIfBwrapNotFunctional(t)
 
 	stellaHome := t.TempDir()
 	userHome := filepath.Join(stellaHome, "users", "u1")
@@ -345,9 +335,7 @@ func TestWrapCommand_linux_inUserDataWritableMountSkipped(t *testing.T) {
 	if _, err := exec.LookPath("bwrap"); err != nil {
 		t.Skip("bwrap not installed")
 	}
-	if !bwrapFunctional() {
-		t.Skip("bwrap not functional (namespace creation blocked)")
-	}
+	skipIfBwrapNotFunctional(t)
 
 	stellaHome := t.TempDir()
 	agentDir := filepath.Join(stellaHome, "users", "u1", "agents", "a1")
@@ -389,9 +377,7 @@ func TestWrapCommand_linux_twoRoots(t *testing.T) {
 	if _, err := exec.LookPath("bwrap"); err != nil {
 		t.Skip("bwrap not installed")
 	}
-	if !bwrapFunctional() {
-		t.Skip("bwrap not functional (namespace creation blocked)")
-	}
+	skipIfBwrapNotFunctional(t)
 
 	agentDir := "/tmp/test-workspace/users/u1/agents/a1"
 	userData := "/tmp/test-workspace/users/u1/data"

--- a/plugins/sandbox/local/testhelpers_linux_test.go
+++ b/plugins/sandbox/local/testhelpers_linux_test.go
@@ -2,13 +2,29 @@
 
 package local
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
+
+// requireBwrapEnv lets an environment that promises a working bwrap turn the
+// skip below into a failure. Skipping is right for hosts that legitimately
+// cannot create user namespaces (unprivileged containers, AppArmor-restricted
+// distros), but on CI a silent skip is indistinguishable from coverage
+// quietly disappearing — which is exactly what happened for three months.
+const requireBwrapEnv = "STELLA_TEST_REQUIRE_BWRAP"
 
 // skipIfBwrapNotFunctional skips the test when bwrap is not installed or cannot
-// create user namespaces (e.g. AppArmor restriction on Ubuntu 24.04+).
+// create user namespaces (e.g. AppArmor restriction on Ubuntu 24.04+), unless
+// STELLA_TEST_REQUIRE_BWRAP is set, in which case it fails.
 func skipIfBwrapNotFunctional(t *testing.T) {
 	t.Helper()
-	if !bwrapFunctional() {
-		t.Skip("bwrap not functional on this Linux host (install bubblewrap or enable unprivileged user namespaces)")
+	if bwrapFunctional() {
+		return
 	}
+	const reason = "bwrap not functional on this Linux host (install bubblewrap or enable unprivileged user namespaces)"
+	if os.Getenv(requireBwrapEnv) != "" {
+		t.Fatalf("%s, but %s is set", reason, requireBwrapEnv)
+	}
+	t.Skip(reason)
 }


### PR DESCRIPTION
Part of #866 (item 1 of three; the other two land separately).

## Problem

`lint-and-test.yml` installs bubblewrap but never relaxes `kernel.apparmor_restrict_unprivileged_userns`, so on ubuntu-24.04 `bwrap` is installed and non-functional. `skipIfBwrapNotFunctional` then skips every bwrap-dependent test.

That has been true since 2026-04-25: `224c86f3` installed bubblewrap "so local sandbox tests pass on Linux", found they still did not, and `78c503bf` — 33 minutes later — added the skips. Three months of a green workflow that has never exercised the local sandbox backend on Linux. #861 and #864 are what surfaced when the release job finally did.

## Change

- `lint-and-test.yml`: the same sysctl + fail-fast probe the release job got in #857, copied verbatim so the two stay greppably identical.
- `STELLA_TEST_REQUIRE_BWRAP=1` on the test step in both workflows. When set, `skipIfBwrapNotFunctional` fails instead of skipping. Skip-by-default stays for hosts that legitimately cannot create user namespaces (unprivileged containers, AppArmor-restricted distros); an environment that *promises* bwrap can no longer lose the coverage quietly.
- The inline `t.Skip("bwrap not functional")` branches in `session_linux_test.go` were the helper written by hand and bypassed the guard, so they route through it now. The branch at line 37 asserts the degraded path and is left alone.

An explicit env var rather than sniffing `CI`/`GITHUB_ACTIONS`: only these two workflows run `go test`, and it can't break forks running act or container CI where userns is genuinely unavailable.

## Verification

Linux repro (`docker run --rm --privileged --init golang:1.25-trixie` + bubblewrap + libicu76, non-root user), which is where the tests actually run for real:

- `STELLA_TEST_REQUIRE_BWRAP=1 go test -race -v ./plugins/sandbox/local/...` — all PASS, **zero SKIP**, zero race findings.
- `STELLA_TEST_REQUIRE_BWRAP=1 go test ./...` with the pg runtime installed — fully green.

macOS: `mise run format && mise run build && mise run test` green (the guard is a no-op off Linux).