### PR TITLE
🐛 fix(embedding): preserve cancellation boundaries

### DIFF
--- a/internal/embedding/apiprovider_contract_test.go
+++ b/internal/embedding/apiprovider_contract_test.go
@@ -1,0 +1,262 @@
+package embedding
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+)
+
+const contractAPIKey = "embedding-contract-token"
+
+type embeddingScript func(t *testing.T, w http.ResponseWriter, r *http.Request)
+
+// scriptedEmbeddingServer rejects requests the test did not describe, making
+// accidental retries or fallback traffic visible instead of silently accepted.
+type scriptedEmbeddingServer struct {
+	t       *testing.T
+	server  *httptest.Server
+	mu      sync.Mutex
+	scripts []embeddingScript
+	next    int
+}
+
+func newScriptedEmbeddingServer(t *testing.T, scripts ...embeddingScript) *scriptedEmbeddingServer {
+	t.Helper()
+	s := &scriptedEmbeddingServer{t: t, scripts: scripts}
+	s.server = httptest.NewServer(http.HandlerFunc(s.serveHTTP))
+	t.Cleanup(s.server.Close)
+	t.Cleanup(s.assertConsumed)
+	return s
+}
+
+func (s *scriptedEmbeddingServer) serveHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	if s.next >= len(s.scripts) {
+		s.mu.Unlock()
+		s.t.Errorf("embedding API received unscripted %s %s", r.Method, r.URL.Path)
+		http.Error(w, "unscripted request", http.StatusInternalServerError)
+		return
+	}
+	script := s.scripts[s.next]
+	s.next++
+	s.mu.Unlock()
+	script(s.t, w, r)
+}
+
+func (s *scriptedEmbeddingServer) assertConsumed() {
+	s.t.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.next != len(s.scripts) {
+		s.t.Errorf("embedding API consumed %d of %d scripted requests", s.next, len(s.scripts))
+	}
+}
+
+func contractProvider(serverURL string) Provider {
+	return NewAPIProvider(APIConfig{
+		Name:    "contract-api",
+		Model:   "contract-model",
+		Dim:     3,
+		APIKey:  contractAPIKey,
+		BaseURL: serverURL + "/v1",
+	})
+}
+
+func assertEmbeddingRequest(t *testing.T, r *http.Request, wantInput []string) {
+	t.Helper()
+	if r.Method != http.MethodPost {
+		t.Errorf("embedding request method = %s, want POST", r.Method)
+	}
+	if r.URL.Path != "/v1/embeddings" {
+		t.Errorf("embedding request path = %s, want /v1/embeddings", r.URL.Path)
+	}
+	if got := r.Header.Get("Authorization"); got != "Bearer "+contractAPIKey {
+		t.Errorf("embedding request authorization = %q, want fixed Bearer token", got)
+	}
+	if got := r.Header.Get("Content-Type"); got != "application/json" {
+		t.Errorf("embedding request content type = %q, want application/json", got)
+	}
+
+	var got map[string]any
+	if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+		t.Errorf("decode embedding request JSON: %v", err)
+		return
+	}
+	want := map[string]any{
+		"input":      stringsToAny(wantInput),
+		"model":      "contract-model",
+		"dimensions": float64(3),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("embedding request JSON = %#v, want %#v", got, want)
+	}
+}
+
+func stringsToAny(values []string) []any {
+	result := make([]any, len(values))
+	for i, value := range values {
+		result[i] = value
+	}
+	return result
+}
+
+func writeEmbeddingResponse(w http.ResponseWriter, data any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"object": "list",
+		"data":   data,
+		"model":  "contract-model",
+		"usage": map[string]any{
+			"prompt_tokens": 0,
+			"total_tokens":  0,
+		},
+	})
+}
+
+func TestAPIProvider_EmbedsContractRequestAndRestoresResponseIndexOrder(t *testing.T) {
+	server := newScriptedEmbeddingServer(t, func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+		assertEmbeddingRequest(t, r, []string{"first", "second"})
+		writeEmbeddingResponse(w, []any{
+			map[string]any{"object": "embedding", "index": 1, "embedding": []float64{20, 21, 22}},
+			map[string]any{"object": "embedding", "index": 0, "embedding": []float64{10, 11, 12}},
+		})
+	})
+
+	result, err := contractProvider(server.server.URL).Embed(context.Background(), Request{Texts: []string{"first", "second"}})
+	if err != nil {
+		t.Fatalf("embedding request failed: %v", err)
+	}
+	want := [][]float32{{10, 11, 12}, {20, 21, 22}}
+	if !reflect.DeepEqual(result.Vectors, want) {
+		t.Fatalf("vectors = %#v, want input order %#v", result.Vectors, want)
+	}
+}
+
+func TestAPIProvider_MalformedResponseIsTerminalWithoutVectors(t *testing.T) {
+	tests := []struct {
+		name string
+		data []any
+	}{
+		{
+			name: "duplicate index",
+			data: []any{
+				map[string]any{"object": "embedding", "index": 0, "embedding": []float64{1, 2, 3}},
+				map[string]any{"object": "embedding", "index": 0, "embedding": []float64{4, 5, 6}},
+			},
+		},
+		{
+			name: "out of range index",
+			data: []any{
+				map[string]any{"object": "embedding", "index": 2, "embedding": []float64{1, 2, 3}},
+				map[string]any{"object": "embedding", "index": 1, "embedding": []float64{4, 5, 6}},
+			},
+		},
+		{
+			name: "missing index",
+			data: []any{
+				map[string]any{"object": "embedding", "index": 0, "embedding": []float64{1, 2, 3}},
+			},
+		},
+		{
+			name: "wrong dimension",
+			data: []any{
+				map[string]any{"object": "embedding", "index": 0, "embedding": []float64{1, 2}},
+				map[string]any{"object": "embedding", "index": 1, "embedding": []float64{4, 5, 6}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := newScriptedEmbeddingServer(t, func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+				assertEmbeddingRequest(t, r, []string{"first", "second"})
+				writeEmbeddingResponse(w, tt.data)
+			})
+
+			result, err := contractProvider(server.server.URL).Embed(context.Background(), Request{Texts: []string{"first", "second"}})
+			if !IsTerminal(err) {
+				t.Fatalf("malformed %s error = %v, want terminal", tt.name, err)
+			}
+			if result.Vectors != nil {
+				t.Fatalf("malformed %s returned vectors %#v", tt.name, result.Vectors)
+			}
+		})
+	}
+}
+
+func TestChain_CallerCancellationStopsAPIFallbackAndDoesNotTripBreaker(t *testing.T) {
+	requestStarted := make(chan struct{}, 1)
+	server := newScriptedEmbeddingServer(t,
+		func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			assertEmbeddingRequest(t, r, []string{"hi"})
+			requestStarted <- struct{}{}
+			select {
+			case <-r.Context().Done():
+			case <-time.After(time.Second):
+				t.Errorf("first embedding request was not cancelled within one second")
+			}
+		},
+		func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			assertEmbeddingRequest(t, r, []string{"hi"})
+			writeEmbeddingResponse(w, []any{
+				map[string]any{"object": "embedding", "index": 0, "embedding": []float64{1, 2, 3}},
+			})
+		},
+	)
+	primary := contractProvider(server.server.URL)
+	fallback := &fakeProvider{name: "fallback", kind: KindLocal, model: "local-space"}
+	chain := NewChain([]Provider{primary, fallback}, BreakerConfig{FailureThreshold: 1, OpenDuration: time.Hour}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	type outcome struct {
+		result Result
+		err    error
+	}
+	firstResult := make(chan outcome, 1)
+	go func() {
+		result, err := chain.Embed(ctx, req())
+		firstResult <- outcome{result: result, err: err}
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first embedding request did not reach API provider")
+	}
+	cancel()
+	select {
+	case got := <-firstResult:
+		if !errors.Is(got.err, context.Canceled) {
+			t.Fatalf("cancelled chain error = %v, want context.Canceled", got.err)
+		}
+		if got.result.Vectors != nil {
+			t.Fatalf("cancelled chain returned vectors %#v", got.result.Vectors)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cancelled chain did not return within one second")
+	}
+	if fallback.calls != 0 {
+		t.Fatalf("caller cancellation must not call fallback, calls=%d", fallback.calls)
+	}
+
+	result, err := chain.Embed(context.Background(), req())
+	if err != nil {
+		t.Fatalf("second embedding request failed: %v", err)
+	}
+	if result.ProviderName != "contract-api" {
+		t.Fatalf("second request provider = %q, want primary API", result.ProviderName)
+	}
+	if !reflect.DeepEqual(result.Vectors, [][]float32{{1, 2, 3}}) {
+		t.Fatalf("second request vectors = %#v, want primary response", result.Vectors)
+	}
+	if fallback.calls != 0 {
+		t.Fatalf("breaker must not be poisoned by caller cancellation; fallback calls=%d", fallback.calls)
+	}
+}

--- a/internal/embedding/chain.go
+++ b/internal/embedding/chain.go
@@ -71,6 +71,13 @@ func (c *Chain) Embed(ctx context.Context, req Request) (Result, error) {
 		eligible = true
 
 		res, err := p.Embed(ctx, req)
+		// The caller no longer needs a result. Do not turn its cancellation into a
+		// provider failure (or send it to a fallback): an upstream timeout remains
+		// a transient provider failure as long as this context is still live.
+		if err := ctx.Err(); err != nil {
+			c.breakers[i].releaseProbe()
+			return Result{}, err
+		}
 		if err == nil {
 			c.breakers[i].recordSuccess()
 			res.ProviderName = p.Name()
@@ -81,6 +88,7 @@ func (c *Chain) Embed(ctx context.Context, req Request) (Result, error) {
 		// Caller/data faults are not the provider's fault to fix: every provider
 		// would reject identically, so stop rather than fan the same error out.
 		if IsTerminal(err) {
+			c.breakers[i].releaseProbe()
 			return Result{}, err
 		}
 		c.breakers[i].recordFailure()
@@ -146,4 +154,12 @@ func (b *breaker) recordFailure() {
 	if b.failures >= b.threshold {
 		b.openUntil = b.now().Add(b.openFor)
 	}
+}
+
+// releaseProbe gives back a half-open slot when the caller cancels. Cancellation
+// is not a provider outcome, so it neither closes nor extends the breaker window.
+func (b *breaker) releaseProbe() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.probing = false
 }

--- a/internal/embedding/chain_test.go
+++ b/internal/embedding/chain_test.go
@@ -80,6 +80,71 @@ func TestChain_TransientFailsOverToLocal(t *testing.T) {
 	}
 }
 
+func TestChain_LiveCallerTreatsUpstreamDeadlineAsProviderFailure(t *testing.T) {
+	primary := &fakeProvider{name: "api", kind: KindAPI, model: "space-a", outcomes: []error{context.DeadlineExceeded}}
+	local := &fakeProvider{name: "local", kind: KindLocal, model: "space-b"}
+	c := NewChain([]Provider{primary, local}, BreakerConfig{}, nil)
+
+	res, err := c.Embed(context.Background(), req())
+	if err != nil {
+		t.Fatalf("upstream deadline with live caller returned error: %v", err)
+	}
+	if res.ProviderName != "local" || !res.FallbackUsed {
+		t.Fatalf("upstream deadline must fall back, got provider=%q fallback=%v", res.ProviderName, res.FallbackUsed)
+	}
+}
+
+type halfOpenCancelProvider struct {
+	cancel context.CancelFunc
+	calls  int
+}
+
+func (*halfOpenCancelProvider) Name() string  { return "api" }
+func (*halfOpenCancelProvider) Kind() Kind    { return KindAPI }
+func (*halfOpenCancelProvider) Model() string { return "space-a" }
+
+func (p *halfOpenCancelProvider) Embed(ctx context.Context, req Request) (Result, error) {
+	p.calls++
+	switch p.calls {
+	case 1:
+		return Result{}, errors.New("503")
+	case 2:
+		p.cancel()
+		return Result{}, ctx.Err()
+	default:
+		vecs := make([][]float32, len(req.Texts))
+		for i := range vecs {
+			vecs[i] = []float32{1, 0, 0}
+		}
+		return Result{Vectors: vecs}, nil
+	}
+}
+
+func TestChain_CallerCancellationReleasesHalfOpenProbe(t *testing.T) {
+	clock := &manualClock{t: time.Unix(1000, 0)}
+	primary := &halfOpenCancelProvider{}
+	local := &fakeProvider{name: "local", kind: KindLocal, model: "space-b"}
+	chain := NewChain([]Provider{primary, local}, BreakerConfig{FailureThreshold: 1, OpenDuration: time.Minute}, clock.now)
+
+	if result, err := chain.Embed(context.Background(), req()); err != nil || result.ProviderName != "local" {
+		t.Fatalf("trip breaker result = provider %q, error %v; want local fallback", result.ProviderName, err)
+	}
+	clock.advance(time.Minute + time.Second)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	primary.cancel = cancel
+	if _, err := chain.Embed(ctx, req()); !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled half-open probe error = %v, want context.Canceled", err)
+	}
+	if local.calls != 1 {
+		t.Fatalf("cancelled half-open probe called fallback; local calls = %d, want 1", local.calls)
+	}
+
+	if result, err := chain.Embed(context.Background(), req()); err != nil || result.ProviderName != "api" {
+		t.Fatalf("next half-open probe result = provider %q, error %v; want API success", result.ProviderName, err)
+	}
+}
+
 func TestChain_TerminalErrorDoesNotFallback(t *testing.T) {
 	primary := &fakeProvider{name: "api", kind: KindAPI, model: "space-a", outcomes: []error{Terminal(errors.New("401 unauthorized"))}}
 	local := &fakeProvider{name: "local", kind: KindLocal, model: "space-b"}


### PR DESCRIPTION
## What

Add a credential-free OpenAI-compatible Embeddings contract and fix caller cancellation crossing the provider-chain boundary.

The API provider now has executable evidence for exact request shape, response-index ordering, and malformed vector rejection. The Chain now returns caller cancellation/deadline immediately without fallback or breaker failure, while preserving fallback for an upstream timeout when the caller context is still live.

## Why

The prior Chain treated every non-terminal provider error as provider failure. Cancelling an HTTP request therefore called the local fallback and advanced the API circuit breaker; at threshold one, a user abort could disable a healthy provider. A cancelled half-open probe could also retain its probe slot indefinitely.

Existing tests covered the abstract fallback policy but never exercised the production SDK request/response boundary, so dimensions drift, response index corruption, and this cancellation behavior had no candidate-bound regression.

## How

- Send exact `model`, ordered `input`, and `dimensions` through the production API provider to a strict local endpoint with a fixed fake bearer token.
- Return vectors in reverse index order and prove the provider restores input order.
- Reject duplicate, out-of-range, missing, and wrong-dimension responses as terminal contract violations with no vectors.
- Check `ctx.Err()` immediately after a provider returns and before success/failure accounting.
- Release a claimed half-open probe on cancellation or terminal caller/data errors without closing or extending the breaker window.
- Prove a cancelled real HTTP request neither calls fallback nor poisons a threshold-one breaker; the next request still reaches and succeeds on the primary API.
- Prove an upstream `DeadlineExceeded` with a live caller remains transient and falls back.

Deliberate limit: SDK retry policy is unchanged. The strict fake rejects any unexpected retry; changing production retry behavior is not required for the cancellation fix.

## Test

- `mise exec -- go test -count=10 ./internal/embedding` — passed
- Mutation check: temporarily removing production `dimensions` emission failed the exact request contract with the missing field shown.
- `mise run format` — passed
- `mise run build` — passed
- `mise run test` — passed, including full Go and Web suites
- Independent Opus blocker review — no blocker; half-open cancellation/terminal probe release was included in the final state-machine design.

## Refs

Refs #835

Controlled Protocols Stack: #867 → this PR

## Checklist

- [x] The PR links a GitHub issue.
- [x] I added focused tests for request, response, cancellation, fallback, and breaker invariants.
- [x] No documentation change is needed; public configuration and operator workflow are unchanged.
- [x] I ran `mise run format && mise run build && mise run test`.
