### PR TITLE
✅ ci: verify the PWA build contract instead of skipping it

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -67,10 +67,18 @@ jobs:
       - name: Generate code and check drift
         run: mise run generate:check
 
+      # go:embed snapshots web/static/dist at compile time, so this has to run
+      # before the test binaries are built. Without it the PWA build contract
+      # only gets checked at tag time, and a commit that breaks the Web UI's
+      # installability merges green.
+      - name: Build web assets
+        run: mise run build:web
+
       - name: Run tests with race detection and coverage
         run: mise run test:coverage:race
         env:
           STELLA_TEST_REQUIRE_BWRAP: "1"
+          STELLA_TEST_REQUIRE_SPA: "1"
 
       - name: Prepare coverage report data
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,10 +74,18 @@ jobs:
       - name: Build
         run: mise run build
 
+      # go:embed snapshots web/static/dist at compile time, so the SPA has to
+      # exist before the test binaries are built. GoReleaser builds it later in
+      # this job anyway — building it here is what lets the PWA build contract
+      # be checked instead of skipped.
+      - name: Build web assets
+        run: mise run build:web
+
       - name: Run Go and Web tests
         run: mise run test
         env:
           STELLA_TEST_REQUIRE_BWRAP: "1"
+          STELLA_TEST_REQUIRE_SPA: "1"
 
       - name: Run System Test
         run: mise run system-test

--- a/mise.toml
+++ b/mise.toml
@@ -156,9 +156,11 @@ run = "go run ./cmd/stellad postgres download-runtime"
 
 [tasks."build:web"]
 description = "Build the SPA into web/static/dist, which the Go binary embeds"
+# tsc imports web/src/lib/api-client, which is generated and gitignored, so the
+# build needs the SDK before it can typecheck anything. The Dockerfile runs
+# openapi-ts for the same reason; GoReleaser gets it from `mise run generate`.
+depends = ["generate:ts-sdk"]
 dir = "web"
-# Same command GoReleaser's before-hook and the Dockerfile run, so the three
-# build paths cannot drift.
 run = "pnpm install --frozen-lockfile && pnpm build"
 
 [tasks.test]

--- a/mise.toml
+++ b/mise.toml
@@ -154,6 +154,13 @@ PY
 description = "Download the embedded PostgreSQL runtime used by tests and local server runs"
 run = "go run ./cmd/stellad postgres download-runtime"
 
+[tasks."build:web"]
+description = "Build the SPA into web/static/dist, which the Go binary embeds"
+dir = "web"
+# Same command GoReleaser's before-hook and the Dockerfile run, so the three
+# build paths cannot drift.
+run = "pnpm install --frozen-lockfile && pnpm build"
+
 [tasks.test]
 description = "Run all tests"
 depends = ["pg:runtime:download"]
@@ -255,7 +262,12 @@ run = """
 set -e
 mise run format
 mise run build
-mise run test
+# The SPA must exist before `test` compiles the test binaries: go:embed
+# snapshots web/static/dist at compile time, and STELLA_TEST_REQUIRE_SPA makes
+# the PWA build contract a failure instead of a skip. A stale dist here is what
+# caught the missing service worker during the v0.61.0 release.
+mise run build:web
+STELLA_TEST_REQUIRE_SPA=1 mise run test
 mise run system-test
 mise run release:check
 mise run release:snapshot

--- a/web/pwa_test.go
+++ b/web/pwa_test.go
@@ -28,8 +28,17 @@ func TestPWARootFilesArePublished(t *testing.T) {
 // exists but holds the wrong bytes (a truncated copy, or an error page picked
 // up by a broken asset step) is indistinguishable from a healthy build until a
 // browser refuses to install.
+// requireSPAEnv lets an environment that builds the SPA turn the skip below into
+// a failure. A backend-only `go test ./...` with no web/static/dist must stay
+// usable, but where the SPA is genuinely built the contract has to be checked —
+// otherwise the skip means the test never runs anywhere that matters.
+const requireSPAEnv = "STELLA_TEST_REQUIRE_SPA"
+
 func TestPWARootFilesAreBuilt(t *testing.T) {
 	if _, err := staticFS.ReadFile("static/dist/index.html"); err != nil {
+		if os.Getenv(requireSPAEnv) != "" {
+			t.Fatalf("SPA must be built here but is not (%s is set): %v", requireSPAEnv, err)
+		}
 		t.Skipf("SPA not built: %v", err)
 	}
 	for _, path := range PWARootFiles {


### PR DESCRIPTION
Part of #866 (item 3 of three). **Stacked on #868** — base is `ci/lint-test-bwrap-coverage`; review the top commit only, and this retargets to `main` once #868 lands.

## Problem

`TestPWARootFilesAreBuilt` skips when `static/dist/index.html` is absent from the embedded FS. `mise run build` builds only the Go binary and nothing in `mise run test`'s chain runs the SPA build, so it skips in CI as well. In the release job the web assets *are* built — but by GoReleaser's before-hook, long after `mise run test` ran. The contract it pins (service worker and manifest surviving the build, and not being served as the HTML shell) was verified nowhere.

Not hypothetical: the first local `release:validate` of v0.61.0 failed here against a stale `dist/` predating #853, which is the only reason anyone noticed the test exists.

## Change

- New `build:web` mise task running `pnpm install --frozen-lockfile && pnpm build` — byte-identical to what `.goreleaser.yaml`'s before-hook and the Dockerfile already run, so the three build paths can't drift.
- Release job: build web assets *before* the test step. `go:embed` snapshots `web/static/dist` at compile time, so the ordering is load-bearing.
- `STELLA_TEST_REQUIRE_SPA=1` on that step and in the `release:validate` chain turns the skip into a failure.
- Local backend-only `go test ./...` with no dist still skips.

`lint-and-test.yml` deliberately does *not* build the SPA: a multi-minute pnpm+vite build on every push buys little for a release-scoped contract. Easy to revisit if we want earlier signal.

## Verification

All three paths exercised locally:

| state | result |
| --- | --- |
| no dist, no env | `--- SKIP` |
| no dist, `STELLA_TEST_REQUIRE_SPA=1` | `FAIL: SPA must be built here but is not` |
| after `mise run build:web`, env set | `--- PASS` |

Plus `mise run format && mise run build && STELLA_TEST_REQUIRE_SPA=1 mise run test` green.