### PR TITLE
🐛 fix(db): explain a PostgreSQL runtime that cannot run on this host

### DIFF
--- a/internal/db/embedded.go
+++ b/internal/db/embedded.go
@@ -112,6 +112,9 @@ func startEmbeddedOnce(dataDir string, port uint32) (*Embedded, error) {
 		// embedded-postgres may return after a partial start. Keep the marked root
 		// for a future janitor rather than guessing that it is safe to remove.
 		ephemeral.release()
+		if hint := rt.startupDiagnostic(err); hint != "" {
+			return nil, fmt.Errorf("db: start embedded postgres: %w — %s", err, hint)
+		}
 		return nil, fmt.Errorf("db: start embedded postgres: %w", err)
 	}
 

--- a/internal/db/pgruntime.go
+++ b/internal/db/pgruntime.go
@@ -3,8 +3,10 @@ package db
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/CherryHQ/stella/internal/pgruntime"
 )
@@ -224,10 +226,50 @@ func postgresLibraryRoot(root string) string {
 }
 
 func pgCtlName() string {
+	return pgBinaryName("pg_ctl")
+}
+
+func pgBinaryName(name string) string {
 	if runtime.GOOS == "windows" {
-		return "pg_ctl.exe"
+		return name + ".exe"
 	}
-	return "pg_ctl"
+	return name
+}
+
+// startupDiagnostic explains a failed start when the cause is that the
+// runtime's binaries cannot run at all, and returns "" otherwise. A runtime
+// whose bundled libraries do not resolve on this host fails as "exit status
+// 127", which says nothing about what to do; embedded-postgres passes the
+// child's stderr through only sometimes. Re-running the cheapest binary in the
+// bundle settles both questions, and cause is only appended when the failure
+// does not already carry it.
+//
+// Called only after a start has already failed, so its cost never lands on a
+// healthy path.
+func (rt postgresRuntimeInfo) startupDiagnostic(cause error) string {
+	if rt.BinariesPath == "" {
+		return ""
+	}
+	initdb := filepath.Join(rt.BinariesPath, "bin", pgBinaryName("initdb"))
+	out, err := exec.Command(initdb, "--version").CombinedOutput()
+	if err == nil {
+		return ""
+	}
+	detail := strings.TrimSpace(string(out))
+	if detail == "" {
+		detail = err.Error()
+	}
+	if cause != nil && strings.Contains(cause.Error(), detail) {
+		detail = ""
+	} else {
+		detail = ": " + detail
+	}
+	return fmt.Sprintf(
+		"the PostgreSQL runtime at %s cannot run on this host%s. "+
+			"Its bundled libraries may not resolve here — install the matching system libraries "+
+			"(on Debian/Ubuntu usually libicu) or re-download the runtime with "+
+			"`stellad postgres download-runtime --force`",
+		rt.BinariesPath, detail)
 }
 
 func postgresSharedLibraryName(name string) string {

--- a/internal/db/pgruntime.go
+++ b/internal/db/pgruntime.go
@@ -1,12 +1,14 @@
 package db
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/CherryHQ/stella/internal/pgruntime"
 )
@@ -26,6 +28,10 @@ const (
 	// settled; external DSNs remain the supported advanced-search path for now.
 	postgresRuntimeEnvName = "STELLA_POSTGRES_RUNTIME"
 )
+
+// Long enough for a cold binary on a slow disk, short enough that a hung probe
+// cannot outlive the error it is explaining. A variable so tests can shorten it.
+var startupDiagnosticTimeout = 10 * time.Second
 
 type postgresRuntimeInfo struct {
 	BinariesPath string
@@ -250,8 +256,15 @@ func (rt postgresRuntimeInfo) startupDiagnostic(cause error) string {
 	if rt.BinariesPath == "" {
 		return ""
 	}
+	// A diagnostic must never outlast the failure it explains. The probe runs a
+	// binary this host has already shown it cannot be trusted to run, so bound
+	// it and let WaitDelay cut a child that holds the output pipe open.
+	ctx, cancel := context.WithTimeout(context.Background(), startupDiagnosticTimeout)
+	defer cancel()
 	initdb := filepath.Join(rt.BinariesPath, "bin", pgBinaryName("initdb"))
-	out, err := exec.Command(initdb, "--version").CombinedOutput()
+	cmd := exec.CommandContext(ctx, initdb, "--version")
+	cmd.WaitDelay = time.Second
+	out, err := cmd.CombinedOutput()
 	if err == nil {
 		return ""
 	}
@@ -259,9 +272,8 @@ func (rt postgresRuntimeInfo) startupDiagnostic(cause error) string {
 	if detail == "" {
 		detail = err.Error()
 	}
-	if cause != nil && strings.Contains(cause.Error(), detail) {
-		detail = ""
-	} else {
+	detail = withoutLinesFrom(detail, cause)
+	if detail != "" {
 		detail = ": " + detail
 	}
 	return fmt.Sprintf(
@@ -270,6 +282,24 @@ func (rt postgresRuntimeInfo) startupDiagnostic(cause error) string {
 			"(on Debian/Ubuntu usually libicu) or re-download the runtime with "+
 			"`stellad postgres download-runtime --force`",
 		rt.BinariesPath, detail)
+}
+
+// withoutLinesFrom drops the lines of detail that cause already reports. It
+// works per line because the probe's output and the failed start's output
+// overlap partially: the loader message is the same, the command line around it
+// is not.
+func withoutLinesFrom(detail string, cause error) string {
+	if cause == nil {
+		return detail
+	}
+	reported := cause.Error()
+	var kept []string
+	for line := range strings.SplitSeq(detail, "\n") {
+		if trimmed := strings.TrimSpace(line); trimmed != "" && !strings.Contains(reported, trimmed) {
+			kept = append(kept, trimmed)
+		}
+	}
+	return strings.Join(kept, "\n")
 }
 
 func postgresSharedLibraryName(name string) string {

--- a/internal/db/pgruntime_test.go
+++ b/internal/db/pgruntime_test.go
@@ -1,9 +1,11 @@
 package db
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -166,5 +168,73 @@ func touch(t *testing.T, path string) {
 	}
 	if err := os.WriteFile(path, nil, 0o755); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// writeFakeInitdb installs a bin/initdb that behaves like the script says. It
+// stands in for the real binary so the diagnostic can be exercised without a
+// downloaded runtime.
+func writeFakeInitdb(t *testing.T, binariesPath, script string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake executables need a POSIX shell")
+	}
+	path := filepath.Join(binariesPath, "bin", pgBinaryName("initdb"))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+script+"\n"), 0o755); err != nil {
+		t.Fatalf("write initdb: %v", err)
+	}
+}
+
+// A runtime whose bundled libraries do not resolve on this host fails with a
+// bare exit status and no stderr, because embedded-postgres drops the child's
+// output. The diagnostic has to put the loader's own message back in the error.
+func TestPostgresRuntimeStartupDiagnosticSurfacesLoaderFailure(t *testing.T) {
+	rt := postgresRuntimeInfo{BinariesPath: t.TempDir()}
+	writeFakeInitdb(t, rt.BinariesPath, `echo "initdb: error while loading shared libraries: libicudata.so.76: cannot open shared object file" >&2; exit 127`)
+
+	hint := rt.startupDiagnostic(nil)
+	if !strings.Contains(hint, "libicudata.so.76") {
+		t.Errorf("diagnostic lost the loader message: %q", hint)
+	}
+	if !strings.Contains(hint, rt.BinariesPath) {
+		t.Errorf("diagnostic does not name the runtime: %q", hint)
+	}
+	if !strings.Contains(hint, "download-runtime") {
+		t.Errorf("diagnostic gives no way forward: %q", hint)
+	}
+}
+
+func TestPostgresRuntimeStartupDiagnosticSilentWhenBinariesRun(t *testing.T) {
+	rt := postgresRuntimeInfo{BinariesPath: t.TempDir()}
+	writeFakeInitdb(t, rt.BinariesPath, `echo "initdb (PostgreSQL) 18.4"`)
+
+	if hint := rt.startupDiagnostic(nil); hint != "" {
+		t.Errorf("diagnostic = %q, want empty for a runnable runtime", hint)
+	}
+}
+
+func TestPostgresRuntimeStartupDiagnosticSilentWithoutBinariesPath(t *testing.T) {
+	var rt postgresRuntimeInfo
+	if hint := rt.startupDiagnostic(nil); hint != "" {
+		t.Errorf("diagnostic = %q, want empty when no runtime is configured", hint)
+	}
+}
+
+// embedded-postgres sometimes passes the child's stderr through. Repeating it
+// makes the error twice as long and no clearer, so the advice stands alone.
+func TestPostgresRuntimeStartupDiagnosticDoesNotRepeatKnownCause(t *testing.T) {
+	rt := postgresRuntimeInfo{BinariesPath: t.TempDir()}
+	const loaderError = "initdb: error while loading shared libraries: libicudata.so.76: cannot open shared object file"
+	writeFakeInitdb(t, rt.BinariesPath, `echo "`+loaderError+`" >&2; exit 127`)
+
+	hint := rt.startupDiagnostic(errors.New("unable to init database: exit status 127\n" + loaderError))
+	if strings.Contains(hint, loaderError) {
+		t.Errorf("diagnostic repeats what the error already says: %q", hint)
+	}
+	if !strings.Contains(hint, "download-runtime") {
+		t.Errorf("diagnostic gives no way forward: %q", hint)
 	}
 }

--- a/internal/db/pgruntime_test.go
+++ b/internal/db/pgruntime_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestPostgresRuntimeFromRootWithNestedPostgresRoot(t *testing.T) {
@@ -236,5 +237,62 @@ func TestPostgresRuntimeStartupDiagnosticDoesNotRepeatKnownCause(t *testing.T) {
 	}
 	if !strings.Contains(hint, "download-runtime") {
 		t.Errorf("diagnostic gives no way forward: %q", hint)
+	}
+}
+
+// A probe must not outlive the failure it explains: the binary it runs is one
+// this host has already shown it cannot be trusted to run.
+func TestPostgresRuntimeStartupDiagnosticGivesUpOnAHungProbe(t *testing.T) {
+	rt := postgresRuntimeInfo{BinariesPath: t.TempDir()}
+	writeFakeInitdb(t, rt.BinariesPath, `sleep 60`)
+	restore := startupDiagnosticTimeout
+	startupDiagnosticTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { startupDiagnosticTimeout = restore })
+
+	done := make(chan string, 1)
+	go func() { done <- rt.startupDiagnostic(nil) }()
+	select {
+	case hint := <-done:
+		if !strings.Contains(hint, "cannot run on this host") {
+			t.Errorf("diagnostic = %q, want the runtime named", hint)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("startupDiagnostic did not return after its timeout elapsed")
+	}
+}
+
+// The probe's output and the failed start's output overlap only in part: the
+// loader message is shared, the command line around it is not.
+func TestPostgresRuntimeStartupDiagnosticKeepsLinesTheCauseOmits(t *testing.T) {
+	rt := postgresRuntimeInfo{BinariesPath: t.TempDir()}
+	const shared = "initdb: error while loading shared libraries: libicudata.so.76: cannot open shared object file"
+	writeFakeInitdb(t, rt.BinariesPath, `echo "`+shared+`" >&2; echo "initdb: hint: check your installation" >&2; exit 127`)
+
+	hint := rt.startupDiagnostic(errors.New("unable to init database: exit status 127\n" + shared))
+	if strings.Contains(hint, shared) {
+		t.Errorf("diagnostic repeats the line the error already carries: %q", hint)
+	}
+	if !strings.Contains(hint, "check your installation") {
+		t.Errorf("diagnostic dropped a line the error does not carry: %q", hint)
+	}
+}
+
+// The diagnostic is only worth anything if a real failed start reaches it.
+func TestStartEmbeddedExplainsARuntimeThatCannotRun(t *testing.T) {
+	root := t.TempDir()
+	binaries := filepath.Join(root, "postgres")
+	writeFakeInitdb(t, binaries, `echo "initdb: error while loading shared libraries: libicudata.so.76: cannot open shared object file" >&2; exit 127`)
+	touch(t, filepath.Join(binaries, "bin", pgCtlName()))
+	t.Setenv(postgresRuntimeEnvName, root)
+
+	_, err := StartEmbedded("", 0)
+	if err == nil {
+		t.Fatal("StartEmbedded succeeded with a runtime that cannot run")
+	}
+	if !strings.Contains(err.Error(), "download-runtime --force") {
+		t.Errorf("StartEmbedded error carries no remediation: %v", err)
+	}
+	if got := strings.Count(err.Error(), "libicudata.so.76"); got != 1 {
+		t.Errorf("loader message appears %d times, want exactly 1: %v", got, err)
 	}
 }


### PR DESCRIPTION
Part of #866 (item 2, this-repo half). **Stacked on #871 → #868** — review the top commit only; retargets to `main` as the stack lands.

## Problem

On linux/arm64 without a system libicu, the bundled runtime's `initdb` dies in the dynamic loader:

```
db: start embedded postgres: unable to init database using '.../bin/initdb ...': exit status 127
```

`libicuuc.so.76` resolves from the bundle's own `runtime/` via RPATH, but `libicudata.so.76` — which libicuuc itself needs — is not in the bundle at all. embedded-postgres passes the child's stderr through only sometimes, and even when it does, nothing tells you what to do.

## Change

After a failed start, re-run `initdb --version`. If the binaries genuinely cannot execute, append the loader's message and the two ways out (system libs, or `download-runtime --force`). The probe never runs on a healthy path, stays quiet when the failure is anything else (a broken cluster still reports its own error), and does not repeat the cause when the error already carries it.

Before / after, same host:

```
... exit status 127
        .../initdb: error while loading shared libraries: libicudata.so.76: cannot open shared object file
```
```
... exit status 127
        .../initdb: error while loading shared libraries: libicudata.so.76: cannot open shared object file
         — the PostgreSQL runtime at .../postgresql/18 cannot run on this host. Its bundled libraries may not
           resolve here — install the matching system libraries (on Debian/Ubuntu usually libicu) or
           re-download the runtime with `stellad postgres download-runtime --force`
```

## This does not fix the bundle

That lives in `CherryHQ/stella-pg-runtime` and needs its own PR. Two things worth flagging there, because #866's framing ("arm64 lost it in packaging, amd64 is fine") is probably wrong:

- The builder is arch-symmetric and native on both arches, so amd64 is likely equally broken — it just runs on hosts that happen to have a matching system libicu. Worth confirming rather than assuming.
- The dependency collector patches RPATH on `bin/` and `lib/` but not on the copied libs in `postgres/lib/runtime/`. glibc does **not** use the executable's `DT_RUNPATH` for transitive dependencies, so `libicudata` is resolved against libicuuc's own empty RUNPATH — meaning simply adding the file to the bundle may not be enough without `--set-rpath '$ORIGIN'` on the runtime libs too. The builder's smoke test can't catch this: it runs in the build container, which has the system libs.

## Verification

- Four unit tests in `internal/db/pgruntime_test.go` covering: loader failure surfaced, silence when the binaries run, silence with no runtime configured, no duplication when the cause already carries the detail.
- End-to-end on the real failure: `golang:1.25-trixie` arm64 **without** `libicu76`, real downloaded runtime — output above is copied from that run.
- `mise run format && mise run build && mise run test` green on macOS; `go test ./internal/db/...` green.