### PR TITLE
⬆️ chore(db): move to the PostgreSQL runtime rebuilt with working rpaths

### DIFF
--- a/cmd/stellad/version.go
+++ b/cmd/stellad/version.go
@@ -13,6 +13,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -21,6 +22,7 @@ import (
 	ucli "github.com/urfave/cli/v2"
 	"golang.org/x/term"
 
+	"github.com/CherryHQ/stella/internal/config"
 	"github.com/CherryHQ/stella/internal/version"
 	"github.com/CherryHQ/stella/pkg/httpclient"
 )
@@ -111,6 +113,7 @@ func upgradeCommand() *ucli.Command {
 
 			fmt.Printf("\n%s Upgraded stella %s -> %s\n", okMark(os.Stdout), result.CurrentVersion, result.LatestVersion)
 			fmt.Printf("  Installed to %s\n", installDir)
+			syncPostgresRuntime(c.Context, os.Stdout, installDir, config.StellaHome(), runtime.GOOS)
 			return nil
 		},
 	}
@@ -134,6 +137,45 @@ func resolveUpgradeDir(installDir string) (string, error) {
 		return "", fmt.Errorf("resolve executable symlink: %w", err)
 	}
 	return filepath.Dir(resolved), nil
+}
+
+// syncPostgresRuntime fetches the runtime the new binary needs, for a host that
+// was already running the embedded database. The binary and its runtime are
+// versioned together, so swapping the binary alone leaves a deployment that
+// starts up into "no PostgreSQL runtime" — the failure only shows at the next
+// restart, which is the worst moment to discover it.
+//
+// A host with no runtime installed is on the external-database path and is left
+// alone; a failure here is reported and not fatal, because the upgrade itself
+// has already committed and a missing runtime is recoverable by hand.
+func syncPostgresRuntime(ctx context.Context, out io.Writer, installDir, stellaHome, goos string) {
+	if !postgresRuntimeInstalled(stellaHome) {
+		return
+	}
+	fprintln(out, "\nUpdating the embedded PostgreSQL runtime for the new version...")
+	cmd := exec.CommandContext(ctx, filepath.Join(installDir, binariesToUpgrade(goos)[0]), "postgres", "download-runtime")
+	cmd.Stdout = out
+	cmd.Stderr = out
+	if err := cmd.Run(); err != nil {
+		fprintf(out, "\n  Could not update the PostgreSQL runtime: %v\n", err)
+		fprintln(out, "  Run `stellad postgres download-runtime` before starting the server.")
+	}
+}
+
+// postgresRuntimeInstalled reports whether this host runs the embedded database.
+// Any extracted runtime under the cache root counts, including one for a version
+// this binary no longer uses — that is precisely the host that needs the new one.
+func postgresRuntimeInstalled(stellaHome string) bool {
+	entries, err := os.ReadDir(filepath.Join(stellaHome, "pg-runtime"))
+	if err != nil {
+		return false
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			return true
+		}
+	}
+	return false
 }
 
 // binariesToUpgrade returns the binary names that must be present in a release

--- a/cmd/stellad/version_test.go
+++ b/cmd/stellad/version_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
 	"context"
 	"crypto/sha256"
@@ -13,6 +14,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -583,4 +585,104 @@ func TestWarnStaleUpgradeArtifacts(t *testing.T) {
 
 	// Nonexistent dir — should not panic.
 	warnStaleUpgradeArtifacts(filepath.Join(dir, "nope"))
+}
+
+func TestPostgresRuntimeInstalledDetectsAnExtractedRuntime(t *testing.T) {
+	home := t.TempDir()
+	if got := postgresRuntimeInstalled(home); got {
+		t.Error("a home with no pg-runtime dir must read as external-database")
+	}
+
+	root := filepath.Join(home, "pg-runtime")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := postgresRuntimeInstalled(home); got {
+		t.Error("an empty pg-runtime dir must read as external-database")
+	}
+
+	// A runtime for a version this binary no longer uses still means embedded.
+	if err := os.MkdirAll(filepath.Join(root, "pg18.4-pgvector0.8.2-pgsearch0.24.1-darwin-arm64"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := postgresRuntimeInstalled(home); !got {
+		t.Error("a stale extracted runtime must read as embedded")
+	}
+}
+
+// The binary and its runtime are versioned together, so an upgrade that swaps
+// only the binary leaves the next restart failing on a missing runtime.
+func TestSyncPostgresRuntimeFetchesForAnEmbeddedHost(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake executables need a POSIX shell")
+	}
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "pg-runtime", "old-version"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	installDir := t.TempDir()
+	marker := filepath.Join(installDir, "args")
+	writeFakeStellad(t, installDir, `echo "$@" > `+marker+`; echo fetched`)
+
+	var out bytes.Buffer
+	syncPostgresRuntime(context.Background(), &out, installDir, home, runtime.GOOS)
+
+	args, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("the new binary was never invoked: %v", err)
+	}
+	if got := strings.TrimSpace(string(args)); got != "postgres download-runtime" {
+		t.Errorf("invoked with %q, want \"postgres download-runtime\"", got)
+	}
+	if !strings.Contains(out.String(), "fetched") {
+		t.Errorf("child output was not surfaced: %q", out.String())
+	}
+}
+
+func TestSyncPostgresRuntimeSkipsAnExternalDatabaseHost(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake executables need a POSIX shell")
+	}
+	installDir := t.TempDir()
+	marker := filepath.Join(installDir, "args")
+	writeFakeStellad(t, installDir, `echo "$@" > `+marker)
+
+	var out bytes.Buffer
+	syncPostgresRuntime(context.Background(), &out, installDir, t.TempDir(), runtime.GOOS)
+
+	if _, err := os.Stat(marker); err == nil {
+		t.Error("a host with no runtime installed must not download one")
+	}
+	if out.Len() != 0 {
+		t.Errorf("unexpected output for an external-database host: %q", out.String())
+	}
+}
+
+// The upgrade has already committed by this point, so a runtime that cannot be
+// fetched must be reported, not fatal.
+func TestSyncPostgresRuntimeReportsAFailedFetch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake executables need a POSIX shell")
+	}
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "pg-runtime", "old-version"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	installDir := t.TempDir()
+	writeFakeStellad(t, installDir, `echo "network is unreachable" >&2; exit 1`)
+
+	var out bytes.Buffer
+	syncPostgresRuntime(context.Background(), &out, installDir, home, runtime.GOOS)
+
+	if !strings.Contains(out.String(), "download-runtime") {
+		t.Errorf("a failed fetch must tell the operator what to run: %q", out.String())
+	}
+}
+
+func writeFakeStellad(t *testing.T, installDir, script string) {
+	t.Helper()
+	path := filepath.Join(installDir, binariesToUpgrade(runtime.GOOS)[0])
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+script+"\n"), 0o755); err != nil {
+		t.Fatalf("write fake stellad: %v", err)
+	}
 }

--- a/internal/pgruntime/runtime.go
+++ b/internal/pgruntime/runtime.go
@@ -16,8 +16,10 @@ import (
 const (
 	// The -r2 suffix is a rebuild of the same upstream versions: the bundled
 	// libraries had no rpath of their own, so a host without a matching system
-	// libicu could not start the runtime. It also renames the local cache
-	// directory, which is what makes an existing install pick the fix up.
+	// libicu could not start the runtime. The suffix also renames the local
+	// cache directory, so an existing install stops using the broken extraction
+	// rather than silently keeping it — `stellad upgrade` fetches the
+	// replacement, and any other install path needs `postgres download-runtime`.
 	RuntimeVersion     = "pg18.4-pgvector0.8.2-pgsearch0.24.1-r2"
 	DefaultRuntimeRepo = "CherryHQ/stella-pg-runtime"
 

--- a/internal/pgruntime/runtime.go
+++ b/internal/pgruntime/runtime.go
@@ -14,7 +14,11 @@ import (
 )
 
 const (
-	RuntimeVersion     = "pg18.4-pgvector0.8.2-pgsearch0.24.1"
+	// The -r2 suffix is a rebuild of the same upstream versions: the bundled
+	// libraries had no rpath of their own, so a host without a matching system
+	// libicu could not start the runtime. It also renames the local cache
+	// directory, which is what makes an existing install pick the fix up.
+	RuntimeVersion     = "pg18.4-pgvector0.8.2-pgsearch0.24.1-r2"
 	DefaultRuntimeRepo = "CherryHQ/stella-pg-runtime"
 
 	supportedLinuxRuntimeSources = "bookworm, noble, trixie"

--- a/web/content/docs/changelog.mdx
+++ b/web/content/docs/changelog.mdx
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🐛 Bug Fixes
+
+- Embedded PostgreSQL: the runtime bundle shipped every library it needed but gave those libraries no rpath of their own, so on a host without a matching system libicu the database failed to start with a bare `exit status 127`. Stella now uses the rebuilt `-r2` runtime and explains the failure when it happens. `stellad upgrade` fetches the replacement automatically for embedded installs; other install paths need `stellad postgres download-runtime` once before the next start. ([#877](https://github.com/CherryHQ/stella/pull/877), [#866](https://github.com/CherryHQ/stella/issues/866))
+
 ## [0.61.0] - 2026-08-04
 
 ### ⚠️ Breaking Changes

--- a/web/content/docs/changelog.zh.mdx
+++ b/web/content/docs/changelog.zh.mdx
@@ -11,6 +11,10 @@ icon: History
 
 ## [Unreleased]
 
+### 🐛 Bug Fixes
+
+- 内嵌 PostgreSQL：runtime 包携带了所需的全部动态库，却没有给这些库设置各自的 rpath，因此在没有匹配系统 libicu 的主机上数据库会以 `exit status 127` 直接启动失败。Stella 现在使用重新构建的 `-r2` runtime，并在失败时给出可读的原因。内嵌安装执行 `stellad upgrade` 会自动获取新 runtime；其他安装方式需要在下次启动前运行一次 `stellad postgres download-runtime`。([#877](https://github.com/CherryHQ/stella/pull/877), [#866](https://github.com/CherryHQ/stella/issues/866))
+
 ## [0.61.0] - 2026-08-04
 
 ### ⚠️ 重大变更


### PR DESCRIPTION
Part of #866 (item 2, the actual fix). **Stacked on #874 → #871 → #868** — review the top commit only.

## What

One-line `RuntimeVersion` bump to `pg18.4-pgvector0.8.2-pgsearch0.24.1-r2`.

The published bundles shipped every library they needed but gave the collected libraries no rpath of their own, so `libicuuc.so.76` looked for its own `libicudata.so.76` on the host and a machine without a matching system libicu could not start the runtime at all. CherryHQ/stella-pg-runtime#4 fixes the builder and adds a self-containment check; `-r2` is that rebuild of the same upstream versions — already published, all 7 platform jobs green, 14 assets up.

New tag rather than moving the old one: the suffix also renames the local cache directory, which is what makes an existing install pick the fix up instead of keeping its broken extraction. Moving the tag would have left stale caches and checksums with no way to tell the two apart.

## Verification

Clean `debian:trixie` arm64 with **no libicu installed** — the exact host where the old runtime fails with `exit status 127`:

```
libicu present?
Installing runtime to /home/dev/.stella/pg-runtime/pg18.4-...-0.24.1-r2-linux-arm64/downloaded/trixie...
ok  	github.com/CherryHQ/stella/internal/db	4.967s
```

macOS: `mise run pg:runtime:download` fetched the r2 darwin bundle, `go test ./internal/db/... ./internal/pgruntime/...` green. `mise run format && mise run build` green.

No other reference to the runtime tag exists in the tree (checked across Go, docs, YAML, TOML).