### PR TITLE
🔧 chore: add postgres prune, and pin the web toolchain in one place

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,19 +126,11 @@ jobs:
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 11.0.8
-          run_install: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: pnpm
-          cache-dependency-path: web/pnpm-lock.yaml
-
+      # No pnpm/Node setup here on purpose. mise-action installed both from
+      # mise.toml above; adding actions/setup-node prepended a different Node to
+      # PATH and silently won, so the release built the embedded SPA on Node 22
+      # while every PR built it on Node 24. The validate job above already runs
+      # the same SPA build on mise alone.
       - name: Cache Go build
         uses: actions/cache@v4
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,8 +3,11 @@ version: 2
 before:
   hooks:
     - go mod download
-    - mise run generate
-    - sh -c "cd web && pnpm install --frozen-lockfile && pnpm build"
+    # Not a raw pnpm invocation: that ran against whatever pnpm and Node the job
+    # happened to put on PATH, which is how release binaries ended up embedding
+    # an SPA built on a Node version no pull request ever tests. mise.toml pins
+    # the toolchain in one place; go through it.
+    - mise run build:embedded
 
 builds:
   - id: stellad

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,26 @@
 # syntax=docker/dockerfile:1.7
 
-FROM --platform=$BUILDPLATFORM ghcr.io/pnpm/pnpm:latest AS web-builder
-RUN pnpm runtime set node 24 -g
-WORKDIR /web
-COPY web/package.json web/pnpm-lock.yaml web/pnpm-workspace.yaml ./
-RUN pnpm install --frozen-lockfile
-COPY api/spec/ /api/spec/
-COPY web/ ./
-RUN pnpm openapi-ts && CI=true pnpm build
+# Built through mise rather than a pnpm base image so the Node and pnpm versions
+# come from mise.toml, the same place the local and CI builds read them from. An
+# image tag pinned here would be a fourth toolchain to keep in step.
+FROM --platform=$BUILDPLATFORM debian:13-slim AS web-builder
+RUN apt-get update \
+    && apt-get -y --no-install-recommends install ca-certificates curl git libatomic1 \
+    && rm -rf /var/lib/apt/lists/*
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ENV MISE_INSTALL_PATH="/usr/local/bin/mise"
+RUN curl -fsSL https://mise.run | sh
+WORKDIR /src
+COPY mise.toml ./
+RUN mise trust && mise install node pnpm
+COPY api/spec/ ./api/spec/
+COPY web/ ./web/
+ENV CI=true
+# The SPA build needs Node and pnpm and nothing else; without this mise would
+# also fetch Go, sqlc, and GoReleaser here just to satisfy mise.toml.
+ENV MISE_TASK_RUN_AUTO_INSTALL=0
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
+    mise run build:web
 
 # Xberg's GNU release links libheif dynamically. Debian 13's packaged version
 # is too old, so build the upstream-supported 1.23.0 locally for each target.
@@ -48,7 +61,7 @@ RUN mise trust
 
 # Build app
 COPY . .
-COPY --from=web-builder /web/static/dist/ ./web/static/dist/
+COPY --from=web-builder /src/web/static/dist/ ./web/static/dist/
 
 ENV CGO_ENABLED=0
 ARG TARGETOS

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,9 @@ RUN --mount=type=secret,id=github_token \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     if [ -f /run/secrets/github_token ]; then export GITHUB_TOKEN="$(cat /run/secrets/github_token)"; fi; \
-    GOOS=${TARGETOS} GOARCH=${TARGETARCH} mise run build
+    env -u GOOS -u GOARCH \
+      TARGET_GOOS=${TARGETOS} TARGET_GOARCH=${TARGETARCH} \
+      mise run build
 
 FROM debian:13-slim AS app
 

--- a/cmd/stellad/postgres.go
+++ b/cmd/stellad/postgres.go
@@ -22,15 +22,15 @@ func postgresCommand() *ucli.Command {
 		Usage:    "Manage the embedded PostgreSQL runtime",
 		Category: "System",
 		Subcommands: []*ucli.Command{
-			postgresDownloadRuntimeCommand(),
-			postgresPruneRuntimesCommand(),
+			postgresDownloadCommand(),
+			postgresPruneCommand(),
 		},
 	}
 }
 
-func postgresPruneRuntimesCommand() *ucli.Command {
+func postgresPruneCommand() *ucli.Command {
 	return &ucli.Command{
-		Name:  "prune-runtimes",
+		Name:  "prune",
 		Usage: "Remove downloaded PostgreSQL runtimes this binary does not use",
 		Description: "Every runtime version installs into its own directory and nothing removes the " +
 			"siblings, so each upgrade leaves a few hundred megabytes behind. This lists what it " +
@@ -65,7 +65,7 @@ type pruneReport struct {
 func pruneRuntimes(out io.Writer, stellaHome string, force, asJSON bool) error {
 	installed, err := pgruntime.InstalledRuntimes(stellaHome)
 	if err != nil {
-		return fmt.Errorf("postgres prune-runtimes: %w", err)
+		return fmt.Errorf("postgres prune: %w", err)
 	}
 
 	report := pruneReport{Current: pgruntime.CurrentRuntimeDir(), Pruned: force}
@@ -83,7 +83,7 @@ func pruneRuntimes(out io.Writer, stellaHome string, force, asJSON bool) error {
 	if force {
 		for _, rt := range report.Runtimes {
 			if err := os.RemoveAll(rt.Path); err != nil {
-				return fmt.Errorf("postgres prune-runtimes: remove %s: %w", rt.Path, err)
+				return fmt.Errorf("postgres prune: remove %s: %w", rt.Path, err)
 			}
 		}
 	}
@@ -119,10 +119,15 @@ func writePruneReport(out io.Writer, report pruneReport) {
 	fprintf(out, "\n%s would be reclaimed. Re-run with --force to remove them.\n", humanBytes(report.Bytes))
 }
 
-func postgresDownloadRuntimeCommand() *ucli.Command {
+func postgresDownloadCommand() *ucli.Command {
 	return &ucli.Command{
-		Name:  "download-runtime",
-		Usage: "Download the embedded PostgreSQL runtime for this platform",
+		Name: "download",
+		// The command shipped as download-runtime; the suffix was redundant under
+		// a domain whose whole job is the runtime. Keep the old name working —
+		// it is in released docs, in error hints users have already seen, and in
+		// whatever scripts they wrote around it.
+		Aliases: []string{"download-runtime"},
+		Usage:   "Download the embedded PostgreSQL runtime for this platform",
 		Description: "Download and install the PostgreSQL runtime used when STELLA_DATABASE_URL is unset. " +
 			"Set STELLA_DATABASE_URL instead if you run PostgreSQL yourself.",
 		Flags: []ucli.Flag{
@@ -136,7 +141,7 @@ func postgresDownloadRuntimeCommand() *ucli.Command {
 				var ok bool
 				source, ok = pgruntime.DefaultRuntimeSource()
 				if !ok {
-					return fmt.Errorf("postgres download-runtime: no default runtime source for %s/%s. %s", runtime.GOOS, runtime.GOARCH, pgruntime.MissingRuntimeHint())
+					return fmt.Errorf("postgres download: no default runtime source for %s/%s. %s", runtime.GOOS, runtime.GOARCH, pgruntime.MissingRuntimeHint())
 				}
 			}
 			root, err := downloadPostgresRuntime(c.Context, os.Stderr, config.StellaHome(), c.String("repo"), source, c.Bool("force"))

--- a/cmd/stellad/postgres.go
+++ b/cmd/stellad/postgres.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -22,8 +23,100 @@ func postgresCommand() *ucli.Command {
 		Category: "System",
 		Subcommands: []*ucli.Command{
 			postgresDownloadRuntimeCommand(),
+			postgresPruneRuntimesCommand(),
 		},
 	}
+}
+
+func postgresPruneRuntimesCommand() *ucli.Command {
+	return &ucli.Command{
+		Name:  "prune-runtimes",
+		Usage: "Remove downloaded PostgreSQL runtimes this binary does not use",
+		Description: "Every runtime version installs into its own directory and nothing removes the " +
+			"siblings, so each upgrade leaves a few hundred megabytes behind. This lists what it " +
+			"would remove and stops; pass --force to delete. Stop any stellad still serving from an " +
+			"older runtime first — removing a directory a live server has open turns a disk-space " +
+			"cleanup into an outage.",
+		Flags: []ucli.Flag{
+			&ucli.BoolFlag{Name: "force", Usage: "Remove the runtimes instead of listing them"},
+			&ucli.BoolFlag{Name: "json", Usage: "Emit the result as JSON"},
+		},
+		Action: func(c *ucli.Context) error {
+			return pruneRuntimes(os.Stdout, config.StellaHome(), c.Bool("force"), c.Bool("json"))
+		},
+	}
+}
+
+// prunedRuntime mirrors pgruntime.InstalledRuntime for --json consumers, which
+// need a stable snake_case shape that does not move when the Go struct does.
+type prunedRuntime struct {
+	Name  string `json:"name"`
+	Path  string `json:"path"`
+	Bytes int64  `json:"bytes"`
+}
+
+type pruneReport struct {
+	Current  string          `json:"current"`
+	Pruned   bool            `json:"pruned"`
+	Runtimes []prunedRuntime `json:"runtimes"`
+	Bytes    int64           `json:"bytes"`
+}
+
+func pruneRuntimes(out io.Writer, stellaHome string, force, asJSON bool) error {
+	installed, err := pgruntime.InstalledRuntimes(stellaHome)
+	if err != nil {
+		return fmt.Errorf("postgres prune-runtimes: %w", err)
+	}
+
+	report := pruneReport{Current: pgruntime.CurrentRuntimeDir(), Pruned: force}
+	for _, rt := range installed {
+		if rt.Current {
+			continue
+		}
+		report.Runtimes = append(report.Runtimes, prunedRuntime{Name: rt.Name, Path: rt.Path, Bytes: rt.Bytes})
+		report.Bytes += rt.Bytes
+	}
+
+	// Remove before reporting, so a partial failure never claims space it did
+	// not reclaim. The first failure stops the run rather than continuing to
+	// delete under whatever condition caused it.
+	if force {
+		for _, rt := range report.Runtimes {
+			if err := os.RemoveAll(rt.Path); err != nil {
+				return fmt.Errorf("postgres prune-runtimes: remove %s: %w", rt.Path, err)
+			}
+		}
+	}
+
+	if asJSON {
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		if report.Runtimes == nil {
+			report.Runtimes = []prunedRuntime{}
+		}
+		return enc.Encode(report)
+	}
+	writePruneReport(out, report)
+	return nil
+}
+
+func writePruneReport(out io.Writer, report pruneReport) {
+	if len(report.Runtimes) == 0 {
+		fprintf(out, "No unused PostgreSQL runtimes. In use: %s\n", report.Current)
+		return
+	}
+	if report.Pruned {
+		for _, rt := range report.Runtimes {
+			fprintf(out, "Removed %s (%s)\n", rt.Name, humanBytes(rt.Bytes))
+		}
+		fprintf(out, "Reclaimed %s.\n", humanBytes(report.Bytes))
+		return
+	}
+	fprintf(out, "In use: %s\n\nUnused, safe to remove once no server is running from them:\n", report.Current)
+	for _, rt := range report.Runtimes {
+		fprintf(out, "  %s  %s\n", rt.Name, humanBytes(rt.Bytes))
+	}
+	fprintf(out, "\n%s would be reclaimed. Re-run with --force to remove them.\n", humanBytes(report.Bytes))
 }
 
 func postgresDownloadRuntimeCommand() *ucli.Command {

--- a/cmd/stellad/postgres_test.go
+++ b/cmd/stellad/postgres_test.go
@@ -13,7 +13,16 @@ import (
 	"github.com/CherryHQ/stella/internal/pgruntime"
 )
 
-func TestPostgresDownloadRuntimeHelp(t *testing.T) {
+func TestPostgresDownloadHelp(t *testing.T) {
+	app := newApp()
+	if err := app.Run([]string{"stellad", "postgres", "download", "--help"}); err != nil {
+		t.Fatalf("run postgres download --help: %v", err)
+	}
+}
+
+// The command shipped as download-runtime and appears in released docs and in
+// error hints users have already read, so the old name has to keep resolving.
+func TestPostgresDownloadRuntimeAliasStillResolves(t *testing.T) {
 	app := newApp()
 	if err := app.Run([]string{"stellad", "postgres", "download-runtime", "--help"}); err != nil {
 		t.Fatalf("run postgres download-runtime --help: %v", err)
@@ -154,9 +163,9 @@ func TestPruneRuntimesJSONWithNothingToRemove(t *testing.T) {
 	}
 }
 
-func TestPostgresPruneRuntimesHelp(t *testing.T) {
+func TestPostgresPruneHelp(t *testing.T) {
 	app := newApp()
-	if err := app.Run([]string{"stellad", "postgres", "prune-runtimes", "--help"}); err != nil {
-		t.Fatalf("run postgres prune-runtimes --help: %v", err)
+	if err := app.Run([]string{"stellad", "postgres", "prune", "--help"}); err != nil {
+		t.Fatalf("run postgres prune --help: %v", err)
 	}
 }

--- a/cmd/stellad/postgres_test.go
+++ b/cmd/stellad/postgres_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -43,5 +45,118 @@ func TestDownloadPostgresRuntimeUsesExistingInstall(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "already installed") {
 		t.Fatalf("output = %q, want already installed", out.String())
+	}
+}
+
+func installRuntimeDir(t *testing.T, stellaHome, name string, size int) string {
+	t.Helper()
+	dir := filepath.Join(stellaHome, "pg-runtime", name, "downloaded", "trixie", "bin")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("create %s: %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "postgres"), make([]byte, size), 0o755); err != nil {
+		t.Fatalf("write runtime file: %v", err)
+	}
+	return filepath.Join(stellaHome, "pg-runtime", name)
+}
+
+// Without --force the command is a report. A maintenance command that deleted
+// hundreds of megabytes on a bare invocation would be exactly the surprise the
+// CLI rules forbid.
+func TestPruneRuntimesWithoutForceRemovesNothing(t *testing.T) {
+	home := t.TempDir()
+	old := installRuntimeDir(t, home, "pg17.0-old-linux-amd64", 128)
+	installRuntimeDir(t, home, pgruntime.CurrentRuntimeDir(), 64)
+
+	var out bytes.Buffer
+	if err := pruneRuntimes(&out, home, false, false); err != nil {
+		t.Fatalf("pruneRuntimes: %v", err)
+	}
+	if _, err := os.Stat(old); err != nil {
+		t.Fatalf("the old runtime should still exist: %v", err)
+	}
+	if !strings.Contains(out.String(), "--force") {
+		t.Errorf("the report should say how to actually remove them, got:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "pg17.0-old-linux-amd64") {
+		t.Errorf("the report should name the unused runtime, got:\n%s", out.String())
+	}
+}
+
+// The runtime this binary uses must survive --force; removing it would leave a
+// server that cannot start and call it a cleanup.
+func TestPruneRuntimesKeepsTheCurrentRuntime(t *testing.T) {
+	home := t.TempDir()
+	old := installRuntimeDir(t, home, "pg17.0-old-linux-amd64", 128)
+	current := installRuntimeDir(t, home, pgruntime.CurrentRuntimeDir(), 64)
+
+	var out bytes.Buffer
+	if err := pruneRuntimes(&out, home, true, false); err != nil {
+		t.Fatalf("pruneRuntimes: %v", err)
+	}
+	if _, err := os.Stat(old); !os.IsNotExist(err) {
+		t.Errorf("the old runtime should be gone, stat err = %v", err)
+	}
+	if _, err := os.Stat(current); err != nil {
+		t.Fatalf("the current runtime must survive: %v", err)
+	}
+	if !strings.Contains(out.String(), "Reclaimed") {
+		t.Errorf("output should report what it reclaimed, got:\n%s", out.String())
+	}
+}
+
+func TestPruneRuntimesJSONReportsWhatItRemoved(t *testing.T) {
+	home := t.TempDir()
+	installRuntimeDir(t, home, "pg17.0-old-linux-amd64", 128)
+	installRuntimeDir(t, home, pgruntime.CurrentRuntimeDir(), 64)
+
+	var out bytes.Buffer
+	if err := pruneRuntimes(&out, home, true, true); err != nil {
+		t.Fatalf("pruneRuntimes: %v", err)
+	}
+	var report pruneReport
+	if err := json.Unmarshal(out.Bytes(), &report); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out.String())
+	}
+	if report.Current != pgruntime.CurrentRuntimeDir() {
+		t.Errorf("current = %q, want %q", report.Current, pgruntime.CurrentRuntimeDir())
+	}
+	if !report.Pruned {
+		t.Error("pruned should be true after --force")
+	}
+	if len(report.Runtimes) != 1 || report.Runtimes[0].Name != "pg17.0-old-linux-amd64" {
+		t.Fatalf("runtimes = %+v, want only the old one", report.Runtimes)
+	}
+	if report.Bytes != 128 {
+		t.Errorf("bytes = %d, want 128", report.Bytes)
+	}
+}
+
+// --json is for scripts, so an empty result still has to parse rather than
+// emitting `null` or a prose line.
+func TestPruneRuntimesJSONWithNothingToRemove(t *testing.T) {
+	home := t.TempDir()
+	installRuntimeDir(t, home, pgruntime.CurrentRuntimeDir(), 64)
+
+	var out bytes.Buffer
+	if err := pruneRuntimes(&out, home, false, true); err != nil {
+		t.Fatalf("pruneRuntimes: %v", err)
+	}
+	var report pruneReport
+	if err := json.Unmarshal(out.Bytes(), &report); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out.String())
+	}
+	if report.Runtimes == nil {
+		t.Error("runtimes should be an empty array, not null")
+	}
+	if len(report.Runtimes) != 0 || report.Bytes != 0 {
+		t.Errorf("report = %+v, want nothing to remove", report)
+	}
+}
+
+func TestPostgresPruneRuntimesHelp(t *testing.T) {
+	app := newApp()
+	if err := app.Run([]string{"stellad", "postgres", "prune-runtimes", "--help"}); err != nil {
+		t.Fatalf("run postgres prune-runtimes --help: %v", err)
 	}
 }

--- a/cmd/stellad/version.go
+++ b/cmd/stellad/version.go
@@ -153,12 +153,12 @@ func syncPostgresRuntime(ctx context.Context, out io.Writer, installDir, stellaH
 		return
 	}
 	fprintln(out, "\nUpdating the embedded PostgreSQL runtime for the new version...")
-	cmd := exec.CommandContext(ctx, filepath.Join(installDir, binariesToUpgrade(goos)[0]), "postgres", "download-runtime")
+	cmd := exec.CommandContext(ctx, filepath.Join(installDir, binariesToUpgrade(goos)[0]), "postgres", "download")
 	cmd.Stdout = out
 	cmd.Stderr = out
 	if err := cmd.Run(); err != nil {
 		fprintf(out, "\n  Could not update the PostgreSQL runtime: %v\n", err)
-		fprintln(out, "  Run `stellad postgres download-runtime` before starting the server.")
+		fprintln(out, "  Run `stellad postgres download` before starting the server.")
 	}
 }
 

--- a/cmd/stellad/version_test.go
+++ b/cmd/stellad/version_test.go
@@ -631,8 +631,8 @@ func TestSyncPostgresRuntimeFetchesForAnEmbeddedHost(t *testing.T) {
 	if err != nil {
 		t.Fatalf("the new binary was never invoked: %v", err)
 	}
-	if got := strings.TrimSpace(string(args)); got != "postgres download-runtime" {
-		t.Errorf("invoked with %q, want \"postgres download-runtime\"", got)
+	if got := strings.TrimSpace(string(args)); got != "postgres download" {
+		t.Errorf("invoked with %q, want \"postgres download\"", got)
 	}
 	if !strings.Contains(out.String(), "fetched") {
 		t.Errorf("child output was not surfaced: %q", out.String())
@@ -674,7 +674,7 @@ func TestSyncPostgresRuntimeReportsAFailedFetch(t *testing.T) {
 	var out bytes.Buffer
 	syncPostgresRuntime(context.Background(), &out, installDir, home, runtime.GOOS)
 
-	if !strings.Contains(out.String(), "download-runtime") {
+	if !strings.Contains(out.String(), "postgres download") {
 		t.Errorf("a failed fetch must tell the operator what to run: %q", out.String())
 	}
 }

--- a/internal/db/pgruntime.go
+++ b/internal/db/pgruntime.go
@@ -67,7 +67,7 @@ func newPostgresRuntimeInfo(dataDir, tmpDir string) (postgresRuntimeInfo, error)
 			// runtime is installed. Refuse instead of booting vanilla PostgreSQL and
 			// failing later with missing extension errors.
 			return postgresRuntimeInfo{}, fmt.Errorf(
-				"db: no PostgreSQL runtime for %s/%s (expected %s). Download it with `stellad postgres download-runtime`, set STELLA_DATABASE_URL to an external PostgreSQL with pg_search and pgvector, or set %s to an extracted runtime. %s",
+				"db: no PostgreSQL runtime for %s/%s (expected %s). Download it with `stellad postgres download`, set STELLA_DATABASE_URL to an external PostgreSQL with pg_search and pgvector, or set %s to an extracted runtime. %s",
 				runtime.GOOS, runtime.GOARCH, postgresRuntimeID, postgresRuntimeEnvName, pgruntime.MissingRuntimeHint())
 		}
 	}
@@ -280,7 +280,7 @@ func (rt postgresRuntimeInfo) startupDiagnostic(cause error) string {
 		"the PostgreSQL runtime at %s cannot run on this host%s. "+
 			"Its bundled libraries may not resolve here — install the matching system libraries "+
 			"(on Debian/Ubuntu usually libicu) or re-download the runtime with "+
-			"`stellad postgres download-runtime --force`",
+			"`stellad postgres download --force`",
 		rt.BinariesPath, detail)
 }
 

--- a/internal/db/pgruntime_test.go
+++ b/internal/db/pgruntime_test.go
@@ -203,7 +203,7 @@ func TestPostgresRuntimeStartupDiagnosticSurfacesLoaderFailure(t *testing.T) {
 	if !strings.Contains(hint, rt.BinariesPath) {
 		t.Errorf("diagnostic does not name the runtime: %q", hint)
 	}
-	if !strings.Contains(hint, "download-runtime") {
+	if !strings.Contains(hint, "postgres download") {
 		t.Errorf("diagnostic gives no way forward: %q", hint)
 	}
 }
@@ -235,7 +235,7 @@ func TestPostgresRuntimeStartupDiagnosticDoesNotRepeatKnownCause(t *testing.T) {
 	if strings.Contains(hint, loaderError) {
 		t.Errorf("diagnostic repeats what the error already says: %q", hint)
 	}
-	if !strings.Contains(hint, "download-runtime") {
+	if !strings.Contains(hint, "postgres download") {
 		t.Errorf("diagnostic gives no way forward: %q", hint)
 	}
 }
@@ -289,7 +289,7 @@ func TestStartEmbeddedExplainsARuntimeThatCannotRun(t *testing.T) {
 	if err == nil {
 		t.Fatal("StartEmbedded succeeded with a runtime that cannot run")
 	}
-	if !strings.Contains(err.Error(), "download-runtime --force") {
+	if !strings.Contains(err.Error(), "postgres download --force") {
 		t.Errorf("StartEmbedded error carries no remediation: %v", err)
 	}
 	if got := strings.Count(err.Error(), "libicudata.so.76"); got != 1 {

--- a/internal/pgruntime/installed_test.go
+++ b/internal/pgruntime/installed_test.go
@@ -1,0 +1,99 @@
+package pgruntime
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeRuntimeDir(t *testing.T, stellaHome, name string, fileSizes ...int) string {
+	t.Helper()
+	dir := filepath.Join(stellaHome, "pg-runtime", name, "downloaded", "trixie", "bin")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("create %s: %v", dir, err)
+	}
+	for i, size := range fileSizes {
+		path := filepath.Join(dir, "file"+string(rune('a'+i)))
+		if err := os.WriteFile(path, make([]byte, size), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	return filepath.Join(stellaHome, "pg-runtime", name)
+}
+
+// Nothing downloaded yet is the normal state on a host using an external
+// database, and asking to prune there is not an error.
+func TestInstalledRuntimesWithoutTheDirectory(t *testing.T) {
+	installed, err := InstalledRuntimes(t.TempDir())
+	if err != nil {
+		t.Fatalf("InstalledRuntimes: %v", err)
+	}
+	if len(installed) != 0 {
+		t.Fatalf("installed = %v, want none", installed)
+	}
+}
+
+// The whole point of the listing is telling the runtime in use apart from the
+// siblings an upgrade left behind, so that flag has to be right.
+func TestInstalledRuntimesMarksTheCurrentOne(t *testing.T) {
+	home := t.TempDir()
+	writeRuntimeDir(t, home, "pg17.0-old-linux-amd64", 100, 200)
+	writeRuntimeDir(t, home, CurrentRuntimeDir(), 50)
+
+	installed, err := InstalledRuntimes(home)
+	if err != nil {
+		t.Fatalf("InstalledRuntimes: %v", err)
+	}
+	if len(installed) != 2 {
+		t.Fatalf("installed = %v, want 2 entries", installed)
+	}
+
+	byName := map[string]InstalledRuntime{}
+	for _, rt := range installed {
+		byName[rt.Name] = rt
+	}
+	current, ok := byName[CurrentRuntimeDir()]
+	if !ok || !current.Current {
+		t.Errorf("%s should be marked current, got %+v", CurrentRuntimeDir(), current)
+	}
+	if current.Bytes != 50 {
+		t.Errorf("current bytes = %d, want 50", current.Bytes)
+	}
+	old := byName["pg17.0-old-linux-amd64"]
+	if old.Current {
+		t.Error("an older version should not be marked current")
+	}
+	if old.Bytes != 300 {
+		t.Errorf("old bytes = %d, want 300", old.Bytes)
+	}
+}
+
+// RuntimeRoot and the listing must agree on the layout, or prune would offer to
+// delete the directory the server is about to start from.
+func TestRuntimeRootLivesUnderTheCurrentRuntimeDir(t *testing.T) {
+	home := t.TempDir()
+	root := RuntimeRoot(home, "trixie")
+	want := filepath.Join(home, "pg-runtime", CurrentRuntimeDir(), "downloaded", "trixie")
+	if root != want {
+		t.Fatalf("RuntimeRoot = %s, want %s", root, want)
+	}
+}
+
+// A stray file next to the version directories is not a runtime and must not
+// show up as something to remove.
+func TestInstalledRuntimesIgnoresLooseFiles(t *testing.T) {
+	home := t.TempDir()
+	writeRuntimeDir(t, home, "pg17.0-old-linux-amd64", 10)
+	stray := filepath.Join(home, "pg-runtime", "README")
+	if err := os.WriteFile(stray, []byte("not a runtime"), 0o644); err != nil {
+		t.Fatalf("write stray: %v", err)
+	}
+
+	installed, err := InstalledRuntimes(home)
+	if err != nil {
+		t.Fatalf("InstalledRuntimes: %v", err)
+	}
+	if len(installed) != 1 || installed[0].Name != "pg17.0-old-linux-amd64" {
+		t.Fatalf("installed = %v, want only the version directory", installed)
+	}
+}

--- a/internal/pgruntime/runtime.go
+++ b/internal/pgruntime/runtime.go
@@ -21,7 +21,7 @@ const (
 	// libicu could not start the runtime. The suffix also renames the local
 	// cache directory, so an existing install stops using the broken extraction
 	// rather than silently keeping it — `stellad upgrade` fetches the
-	// replacement, and any other install path needs `postgres download-runtime`.
+	// replacement, and any other install path needs `postgres download`.
 	RuntimeVersion     = "pg18.4-pgvector0.8.2-pgsearch0.24.1-r2"
 	DefaultRuntimeRepo = "CherryHQ/stella-pg-runtime"
 
@@ -35,19 +35,19 @@ func MissingRuntimeHint() string {
 	case "linux":
 		data, err := os.ReadFile("/etc/os-release")
 		if err != nil {
-			return fmt.Sprintf("Could not read /etc/os-release to select a Linux runtime. Supported Linux runtime sources: %s. Run `stellad postgres download-runtime`, set STELLA_DATABASE_URL to an external PostgreSQL with pg_search and pgvector, or file an issue with your OS details: %s", supportedLinuxRuntimeSources, stellaIssueURL)
+			return fmt.Sprintf("Could not read /etc/os-release to select a Linux runtime. Supported Linux runtime sources: %s. Run `stellad postgres download`, set STELLA_DATABASE_URL to an external PostgreSQL with pg_search and pgvector, or file an issue with your OS details: %s", supportedLinuxRuntimeSources, stellaIssueURL)
 		}
 		codename := linuxRuntimeCodenameFromOSRelease(string(data))
 		if codename == "" {
-			return fmt.Sprintf("Could not detect VERSION_CODENAME or UBUNTU_CODENAME from /etc/os-release. Supported Linux runtime sources: %s. Run `stellad postgres download-runtime`, set STELLA_DATABASE_URL to an external PostgreSQL with pg_search and pgvector, or file an issue with your /etc/os-release: %s", supportedLinuxRuntimeSources, stellaIssueURL)
+			return fmt.Sprintf("Could not detect VERSION_CODENAME or UBUNTU_CODENAME from /etc/os-release. Supported Linux runtime sources: %s. Run `stellad postgres download`, set STELLA_DATABASE_URL to an external PostgreSQL with pg_search and pgvector, or file an issue with your /etc/os-release: %s", supportedLinuxRuntimeSources, stellaIssueURL)
 		}
 		if _, ok := supportedLinuxRuntimeSource(codename); !ok {
 			return fmt.Sprintf("Detected Linux runtime source %q, but Stella only publishes PostgreSQL runtimes for: %s. Set STELLA_DATABASE_URL to an external PostgreSQL with pg_search and pgvector, or file an issue requesting this distro: %s", codename, supportedLinuxRuntimeSources, stellaIssueURL)
 		}
-		return fmt.Sprintf("Detected supported Linux runtime source %q, but no PostgreSQL runtime is installed. Run `stellad postgres download-runtime`, set STELLA_DATABASE_URL to an external PostgreSQL with pg_search and pgvector, or file an issue if download-runtime fails: %s", codename, stellaIssueURL)
+		return fmt.Sprintf("Detected supported Linux runtime source %q, but no PostgreSQL runtime is installed. Run `stellad postgres download`, set STELLA_DATABASE_URL to an external PostgreSQL with pg_search and pgvector, or file an issue if download fails: %s", codename, stellaIssueURL)
 	case "darwin":
 		if runtime.GOARCH == "arm64" {
-			return fmt.Sprintf("No PostgreSQL runtime is installed for darwin/arm64. Run `stellad postgres download-runtime`, set STELLA_DATABASE_URL to an external PostgreSQL with pg_search and pgvector, or file an issue if download-runtime fails: %s", stellaIssueURL)
+			return fmt.Sprintf("No PostgreSQL runtime is installed for darwin/arm64. Run `stellad postgres download`, set STELLA_DATABASE_URL to an external PostgreSQL with pg_search and pgvector, or file an issue if download fails: %s", stellaIssueURL)
 		}
 		return fmt.Sprintf("PostgreSQL runtime downloads are not published for darwin/%s. Set STELLA_DATABASE_URL to an external PostgreSQL with pg_search and pgvector, or file an issue for this platform: %s", runtime.GOARCH, stellaIssueURL)
 	default:

--- a/internal/pgruntime/runtime.go
+++ b/internal/pgruntime/runtime.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/klauspost/compress/zstd"
@@ -66,7 +68,78 @@ func DefaultRuntimeSource() (string, bool) {
 }
 
 func RuntimeRoot(stellaHome, source string) string {
-	return filepath.Join(stellaHome, "pg-runtime", RuntimeVersion+"-"+runtime.GOOS+"-"+runtime.GOARCH, "downloaded", source)
+	return filepath.Join(runtimesDir(stellaHome), CurrentRuntimeDir(), "downloaded", source)
+}
+
+// CurrentRuntimeDir names the directory holding the runtime this binary uses.
+// Every installed version gets its own sibling, so the name doubles as the
+// identity an operator sees when deciding what is safe to remove.
+func CurrentRuntimeDir() string {
+	return RuntimeVersion + "-" + runtime.GOOS + "-" + runtime.GOARCH
+}
+
+func runtimesDir(stellaHome string) string {
+	return filepath.Join(stellaHome, "pg-runtime")
+}
+
+// InstalledRuntime is one extracted runtime version found on disk.
+type InstalledRuntime struct {
+	// Name is the directory name, which encodes version, OS, and architecture.
+	Name string
+	Path string
+	// Bytes is the extracted size, best effort: entries that cannot be read are
+	// skipped rather than failing a report whose only purpose is disk space.
+	Bytes int64
+	// Current marks the runtime this binary would use. Removing it is not
+	// pruning, it is uninstalling, so callers keep the two apart.
+	Current bool
+}
+
+// InstalledRuntimes lists the runtime versions extracted under $STELLA_HOME,
+// sorted by name. A missing pg-runtime directory is not an error: it just means
+// nothing has been downloaded yet.
+func InstalledRuntimes(stellaHome string) ([]InstalledRuntime, error) {
+	dir := runtimesDir(stellaHome)
+	entries, err := os.ReadDir(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read PostgreSQL runtime dir %s: %w", dir, err)
+	}
+	current := CurrentRuntimeDir()
+	installed := make([]InstalledRuntime, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		installed = append(installed, InstalledRuntime{
+			Name:    entry.Name(),
+			Path:    path,
+			Bytes:   dirSize(path),
+			Current: entry.Name() == current,
+		})
+	}
+	slices.SortFunc(installed, func(a, b InstalledRuntime) int { return strings.Compare(a.Name, b.Name) })
+	return installed, nil
+}
+
+func dirSize(root string) int64 {
+	var total int64
+	_ = filepath.WalkDir(root, func(_ string, d fs.DirEntry, err error) error {
+		// Only regular files consume space here; a symlink's target is either
+		// inside the tree already or outside it and not ours to count.
+		if err == nil && d.Type().IsRegular() {
+			if info, statErr := d.Info(); statErr == nil {
+				total += info.Size()
+			}
+		}
+		// Unreadable entries are skipped rather than aborting: this number only
+		// tells an operator roughly how much a prune would free.
+		return nil
+	})
+	return total
 }
 
 func RuntimeAssetName(version, goos, goarch, source string) string {

--- a/mise.toml
+++ b/mise.toml
@@ -156,7 +156,7 @@ PY
 
 [tasks."pg:runtime:download"]
 description = "Download the embedded PostgreSQL runtime used by tests and local server runs"
-run = "go run ./cmd/stellad postgres download-runtime"
+run = "go run ./cmd/stellad postgres download"
 
 [tasks."build:web"]
 description = "Build the SPA into web/static/dist, which the Go binary embeds"

--- a/mise.toml
+++ b/mise.toml
@@ -44,7 +44,19 @@ run = [
   "export COMMIT=${COMMIT:-$(git rev-parse --short HEAD 2>/dev/null || echo '')}",
   "export BUILD_DATE=${BUILD_DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}",
   "export LDFLAGS=\"-X github.com/CherryHQ/stella/internal/version.Version=$VERSION -X github.com/CherryHQ/stella/internal/version.Commit=$COMMIT -X github.com/CherryHQ/stella/internal/version.BuildDate=$BUILD_DATE\"",
-  "go build -ldflags=\"$LDFLAGS\" -o $BINARY_D ./cmd/stellad",
+  # Generators are host tools; cross-compile only the final binary.
+  """
+if [ -n "${TARGET_GOOS+x}" ] || [ -n "${TARGET_GOARCH+x}" ]; then
+  if [ -z "${TARGET_GOOS:-}" ] || [ -z "${TARGET_GOARCH:-}" ]; then
+    echo "ERROR: TARGET_GOOS and TARGET_GOARCH must be set together" >&2
+    exit 1
+  fi
+  env GOOS="$TARGET_GOOS" GOARCH="$TARGET_GOARCH" \
+    go build -ldflags="$LDFLAGS" -o "$BINARY_D" ./cmd/stellad
+else
+  go build -ldflags="$LDFLAGS" -o "$BINARY_D" ./cmd/stellad
+fi
+""",
 ]
 
 [tasks.clean]

--- a/mise.toml
+++ b/mise.toml
@@ -14,7 +14,11 @@ go = "1.25.9"
 "github:sqlc-dev/sqlc" = "1.29.0"
 # Web
 vp = "0.1.20"
-pnpm = "10.33.0"
+# This pin bootstraps pnpm for the root-level `pnpm --package=...` calls below,
+# which run outside web/ and so cannot be governed by its packageManager field.
+# Inside web/, pnpm self-switches to packageManager, which means a mismatch here
+# is invisible rather than loud — web/toolchain_test.go fails if they drift.
+pnpm = "11.0.8"
 node = "24.14.1"
 
 [env]
@@ -157,11 +161,17 @@ run = "go run ./cmd/stellad postgres download-runtime"
 [tasks."build:web"]
 description = "Build the SPA into web/static/dist, which the Go binary embeds"
 # tsc imports web/src/lib/api-client, which is generated and gitignored, so the
-# build needs the SDK before it can typecheck anything. The Dockerfile runs
-# openapi-ts for the same reason; GoReleaser gets it from `mise run generate`.
+# build needs the SDK before it can typecheck anything.
 depends = ["generate:ts-sdk"]
 dir = "web"
 run = "pnpm install --frozen-lockfile && pnpm build"
+
+[tasks."build:embedded"]
+description = "Generate code and build the SPA, i.e. everything the Go binary embeds"
+# One entry point for GoReleaser and the Dockerfile, so neither reimplements the
+# SPA build with its own toolchain. Both tasks want generate:ts-sdk; naming them
+# together lets mise resolve that dependency once instead of twice.
+depends = ["generate", "build:web"]
 
 [tasks.test]
 description = "Run all tests"

--- a/resources/skills/system/stella/SKILL.md
+++ b/resources/skills/system/stella/SKILL.md
@@ -28,7 +28,7 @@ Run mode:
 
 - **Server**: `stellad server` (Telegram, QQ, Feishu, WeChat bots + scheduler + Web UI)
 
-Setup: run `stellad server` and open `http://localhost:25678` to configure everything via the Web UI. All configuration and runtime state live in PostgreSQL: an embedded cluster managed under the operator's `$STELLA_HOME` (install its runtime with `stellad postgres download-runtime` if missing), or an external server when `STELLA_DATABASE_URL` is set. `$STELLA_HOME` is an operator configuration location, not an Agent sandbox path.
+Setup: run `stellad server` and open `http://localhost:25678` to configure everything via the Web UI. All configuration and runtime state live in PostgreSQL: an embedded cluster managed under the operator's `$STELLA_HOME` (install its runtime with `stellad postgres download` if missing), or an external server when `STELLA_DATABASE_URL` is set. `$STELLA_HOME` is an operator configuration location, not an Agent sandbox path.
 
 ## Filesystem locations
 

--- a/resources/skills/system/stella/references/configuration.md
+++ b/resources/skills/system/stella/references/configuration.md
@@ -1,6 +1,6 @@
 # Configuration reference
 
-All configuration is stored in PostgreSQL. Stella can run an embedded PostgreSQL cluster whose data directory lives under `$STELLA_HOME`; run `stellad postgres download-runtime` first if the runtime is not installed. Set `STELLA_DATABASE_URL` to point at an external PostgreSQL server instead.
+All configuration is stored in PostgreSQL. Stella can run an embedded PostgreSQL cluster whose data directory lives under `$STELLA_HOME`; run `stellad postgres download` first if the runtime is not installed. Set `STELLA_DATABASE_URL` to point at an external PostgreSQL server instead.
 
 The easiest way to configure stella is to run `stellad server` and open `http://localhost:25678`. Use `--port` to change the port.
 
@@ -104,7 +104,7 @@ All paths are relative to `$STELLA_HOME` (`~/.stella` by default).
 | Operator path                               | Purpose                                                                                                         |
 | ------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
 | `postgres/`                                 | Embedded PostgreSQL data directory (all config; absent when `STELLA_DATABASE_URL` points at an external server) |
-| `pg-runtime/`                               | Downloaded embedded PostgreSQL runtime; recreate with `stellad postgres download-runtime`                       |
+| `pg-runtime/`                               | Downloaded embedded PostgreSQL runtime; recreate with `stellad postgres download`                               |
 | `cache/models.json`                         | Cached model list (safe to delete)                                                                              |
 | `agents/{agent_id}/`                        | User-independent agent definition and administrator-managed area                                                |
 | `agents/{agent_id}/.agents/skills/`         | Administrator-managed, agent-bound skills                                                                       |

--- a/web/content/docs/changelog.mdx
+++ b/web/content/docs/changelog.mdx
@@ -13,11 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ✨ Features
 
-- `stellad postgres prune-runtimes` reports the embedded-PostgreSQL runtimes this binary no longer uses and, with `--force`, removes them. Every runtime revision installed alongside the old one and nothing cleaned up, so an upgraded host was carrying a few hundred megabytes per version. Pruning stays manual on purpose: a rolled-back binary or a second server still running from the old runtime would both break. ([#881](https://github.com/CherryHQ/stella/pull/881), [#878](https://github.com/CherryHQ/stella/issues/878))
+- `stellad postgres prune` reports the embedded-PostgreSQL runtimes this binary no longer uses and, with `--force`, removes them. Every runtime revision installed alongside the old one and nothing cleaned up, so an upgraded host was carrying a few hundred megabytes per version. Pruning stays manual on purpose: a rolled-back binary or a second server still running from the old runtime would both break. ([#881](https://github.com/CherryHQ/stella/pull/881), [#878](https://github.com/CherryHQ/stella/issues/878))
 
 ### 🐛 Bug Fixes
 
-- Embedded PostgreSQL: the runtime bundle shipped every library it needed but gave those libraries no rpath of their own, so on a host without a matching system libicu the database failed to start with a bare `exit status 127`. Stella now uses the rebuilt `-r2` runtime and explains the failure when it happens. `stellad upgrade` fetches the replacement automatically for embedded installs; other install paths need `stellad postgres download-runtime` once before the next start. ([#877](https://github.com/CherryHQ/stella/pull/877), [#866](https://github.com/CherryHQ/stella/issues/866))
+- Embedded PostgreSQL: the runtime bundle shipped every library it needed but gave those libraries no rpath of their own, so on a host without a matching system libicu the database failed to start with a bare `exit status 127`. Stella now uses the rebuilt `-r2` runtime and explains the failure when it happens. `stellad upgrade` fetches the replacement automatically for embedded installs; other install paths need `stellad postgres download` once before the next start. ([#877](https://github.com/CherryHQ/stella/pull/877), [#866](https://github.com/CherryHQ/stella/issues/866))
 
 ## [0.61.0] - 2026-08-04
 

--- a/web/content/docs/changelog.mdx
+++ b/web/content/docs/changelog.mdx
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ✨ Features
+
+- `stellad postgres prune-runtimes` reports the embedded-PostgreSQL runtimes this binary no longer uses and, with `--force`, removes them. Every runtime revision installed alongside the old one and nothing cleaned up, so an upgraded host was carrying a few hundred megabytes per version. Pruning stays manual on purpose: a rolled-back binary or a second server still running from the old runtime would both break. ([#881](https://github.com/CherryHQ/stella/pull/881), [#878](https://github.com/CherryHQ/stella/issues/878))
+
 ### 🐛 Bug Fixes
 
 - Embedded PostgreSQL: the runtime bundle shipped every library it needed but gave those libraries no rpath of their own, so on a host without a matching system libicu the database failed to start with a bare `exit status 127`. Stella now uses the rebuilt `-r2` runtime and explains the failure when it happens. `stellad upgrade` fetches the replacement automatically for embedded installs; other install paths need `stellad postgres download-runtime` once before the next start. ([#877](https://github.com/CherryHQ/stella/pull/877), [#866](https://github.com/CherryHQ/stella/issues/866))

--- a/web/content/docs/changelog.zh.mdx
+++ b/web/content/docs/changelog.zh.mdx
@@ -11,7 +11,11 @@ icon: History
 
 ## [Unreleased]
 
-### 🐛 Bug Fixes
+### ✨ 功能
+
+- `stellad postgres prune-runtimes` 会列出当前二进制不再使用的内嵌 PostgreSQL runtime，加 `--force` 才真正删除。此前每次 runtime 版本更新都会在旧版本旁新装一份且从不清理，升级过的主机因此每个版本多占数百 MB。清理刻意保持手动：回滚后的二进制、或仍在使用旧 runtime 运行的另一个服务进程，都会因自动删除而中断。([#881](https://github.com/CherryHQ/stella/pull/881), [#878](https://github.com/CherryHQ/stella/issues/878))
+
+### 🐛 修复
 
 - 内嵌 PostgreSQL：runtime 包携带了所需的全部动态库，却没有给这些库设置各自的 rpath，因此在没有匹配系统 libicu 的主机上数据库会以 `exit status 127` 直接启动失败。Stella 现在使用重新构建的 `-r2` runtime，并在失败时给出可读的原因。内嵌安装执行 `stellad upgrade` 会自动获取新 runtime；其他安装方式需要在下次启动前运行一次 `stellad postgres download-runtime`。([#877](https://github.com/CherryHQ/stella/pull/877), [#866](https://github.com/CherryHQ/stella/issues/866))
 

--- a/web/content/docs/changelog.zh.mdx
+++ b/web/content/docs/changelog.zh.mdx
@@ -13,11 +13,11 @@ icon: History
 
 ### ✨ 功能
 
-- `stellad postgres prune-runtimes` 会列出当前二进制不再使用的内嵌 PostgreSQL runtime，加 `--force` 才真正删除。此前每次 runtime 版本更新都会在旧版本旁新装一份且从不清理，升级过的主机因此每个版本多占数百 MB。清理刻意保持手动：回滚后的二进制、或仍在使用旧 runtime 运行的另一个服务进程，都会因自动删除而中断。([#881](https://github.com/CherryHQ/stella/pull/881), [#878](https://github.com/CherryHQ/stella/issues/878))
+- `stellad postgres prune` 会列出当前二进制不再使用的内嵌 PostgreSQL runtime，加 `--force` 才真正删除。此前每次 runtime 版本更新都会在旧版本旁新装一份且从不清理，升级过的主机因此每个版本多占数百 MB。清理刻意保持手动：回滚后的二进制、或仍在使用旧 runtime 运行的另一个服务进程，都会因自动删除而中断。([#881](https://github.com/CherryHQ/stella/pull/881), [#878](https://github.com/CherryHQ/stella/issues/878))
 
 ### 🐛 修复
 
-- 内嵌 PostgreSQL：runtime 包携带了所需的全部动态库，却没有给这些库设置各自的 rpath，因此在没有匹配系统 libicu 的主机上数据库会以 `exit status 127` 直接启动失败。Stella 现在使用重新构建的 `-r2` runtime，并在失败时给出可读的原因。内嵌安装执行 `stellad upgrade` 会自动获取新 runtime；其他安装方式需要在下次启动前运行一次 `stellad postgres download-runtime`。([#877](https://github.com/CherryHQ/stella/pull/877), [#866](https://github.com/CherryHQ/stella/issues/866))
+- 内嵌 PostgreSQL：runtime 包携带了所需的全部动态库，却没有给这些库设置各自的 rpath，因此在没有匹配系统 libicu 的主机上数据库会以 `exit status 127` 直接启动失败。Stella 现在使用重新构建的 `-r2` runtime，并在失败时给出可读的原因。内嵌安装执行 `stellad upgrade` 会自动获取新 runtime；其他安装方式需要在下次启动前运行一次 `stellad postgres download`。([#877](https://github.com/CherryHQ/stella/pull/877), [#866](https://github.com/CherryHQ/stella/issues/866))
 
 ## [0.61.0] - 2026-08-04
 

--- a/web/content/docs/start-here/configuration.md
+++ b/web/content/docs/start-here/configuration.md
@@ -2,7 +2,7 @@
 title: Configuration
 ---
 
-Most configuration is managed through the Web UI. Start the server with `stellad server` and open [http://localhost:25678](http://localhost:25678) in your browser. Everything is stored in PostgreSQL — either an embedded cluster managed under `~/.stella`, or an external server when you set `STELLA_DATABASE_URL`. If the embedded PostgreSQL runtime is not installed, run `stellad postgres download-runtime` once before starting the server. There are no config files to edit.
+Most configuration is managed through the Web UI. Start the server with `stellad server` and open [http://localhost:25678](http://localhost:25678) in your browser. Everything is stored in PostgreSQL — either an embedded cluster managed under `~/.stella`, or an external server when you set `STELLA_DATABASE_URL`. If the embedded PostgreSQL runtime is not installed, run `stellad postgres download` once before starting the server. There are no config files to edit.
 
 The home directory defaults to `~/.stella` and can be changed by setting the `STELLA_HOME` environment variable.
 
@@ -94,7 +94,7 @@ All data lives under `~/.stella` (configurable via `STELLA_HOME`):
 | Path                                    | Purpose                                                                                                                             |
 | --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
 | `~/.stella/postgres/`                   | Embedded PostgreSQL data (config, memory, scheduler) — back this up. Absent when `STELLA_DATABASE_URL` points at an external server |
-| `~/.stella/pg-runtime/`                 | Downloaded embedded PostgreSQL runtime; recreate with `stellad postgres download-runtime` if deleted                                |
+| `~/.stella/pg-runtime/`                 | Downloaded embedded PostgreSQL runtime; recreate with `stellad postgres download` if deleted                                        |
 | `~/.stella/agents/{agent-id}/`          | Per-agent workspace, skills, and overrides                                                                                          |
 | `~/.stella/agents/{agent-id}/SOUL.md`   | Optional agent personality override                                                                                                 |
 | `~/.stella/agents/{agent-id}/SYSTEM.md` | Optional system prompt override                                                                                                     |

--- a/web/content/docs/start-here/configuration.zh.md
+++ b/web/content/docs/start-here/configuration.zh.md
@@ -2,7 +2,7 @@
 title: 配置
 ---
 
-大多数配置都通过 Web UI 管理。使用 `stellad server` 启动服务器，然后在浏览器中打开 [http://localhost:25678](http://localhost:25678)。所有配置存储在 PostgreSQL 中——可以使用托管在 `~/.stella` 下的内嵌集群，也可以在设置 `STELLA_DATABASE_URL` 时使用外部服务器。如果内嵌 PostgreSQL runtime 尚未安装，先运行一次 `stellad postgres download-runtime`。无需编辑任何配置文件。
+大多数配置都通过 Web UI 管理。使用 `stellad server` 启动服务器，然后在浏览器中打开 [http://localhost:25678](http://localhost:25678)。所有配置存储在 PostgreSQL 中——可以使用托管在 `~/.stella` 下的内嵌集群，也可以在设置 `STELLA_DATABASE_URL` 时使用外部服务器。如果内嵌 PostgreSQL runtime 尚未安装，先运行一次 `stellad postgres download`。无需编辑任何配置文件。
 
 主目录默认为 `~/.stella`，可以通过设置 `STELLA_HOME` 环境变量来更改。
 
@@ -85,7 +85,7 @@ Runner 控制代理如何处理消息。你可以在Web UI的 **设置** 页面�
 | 路径                                    | 用途                                                                                                        |
 | --------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
 | `~/.stella/postgres/`                   | 内嵌 PostgreSQL 数据（配置、记忆、调度器）— 请备份此目录。设置 `STELLA_DATABASE_URL` 指向外部服务器时不存在 |
-| `~/.stella/pg-runtime/`                 | 下载的内嵌 PostgreSQL runtime；删除后可用 `stellad postgres download-runtime` 重建                          |
+| `~/.stella/pg-runtime/`                 | 下载的内嵌 PostgreSQL runtime；删除后可用 `stellad postgres download` 重建                                  |
 | `~/.stella/agents/{agent-id}/`          | 每个代理的工作空间、技能和覆盖文件                                                                          |
 | `~/.stella/agents/{agent-id}/SOUL.md`   | 可选的代理人格覆盖                                                                                          |
 | `~/.stella/agents/{agent-id}/SYSTEM.md` | 可选的系统提示覆盖                                                                                          |

--- a/web/content/docs/start-here/deployment.md
+++ b/web/content/docs/start-here/deployment.md
@@ -10,7 +10,7 @@ title: Deployment
 brew install CherryHQ/tap/stella
 ```
 
-If you do not set `STELLA_DATABASE_URL`, run `stellad postgres download-runtime` once before starting the service.
+If you do not set `STELLA_DATABASE_URL`, run `stellad postgres download` once before starting the service.
 
 ### Linux packages (.deb / .rpm)
 
@@ -24,7 +24,7 @@ sudo apt install ./stella_*_linux_amd64.deb
 sudo dnf install ./stella_*_linux_amd64.rpm
 ```
 
-If you do not set `STELLA_DATABASE_URL`, run `stellad postgres download-runtime` once before starting the service.
+If you do not set `STELLA_DATABASE_URL`, run `stellad postgres download` once before starting the service.
 
 ### Binary
 
@@ -55,7 +55,7 @@ Start the server — the Web UI is available at `http://localhost:25678`:
 stellad server
 ```
 
-This starts the server and the Web UI where you configure API keys, channels, and agent profiles. All configuration is stored in PostgreSQL — either an embedded cluster under `~/.stella`, or an external server when you set `STELLA_DATABASE_URL`. If the embedded runtime is missing, run `stellad postgres download-runtime` once before `stellad server`. No config files needed.
+This starts the server and the Web UI where you configure API keys, channels, and agent profiles. All configuration is stored in PostgreSQL — either an embedded cluster under `~/.stella`, or an external server when you set `STELLA_DATABASE_URL`. If the embedded runtime is missing, run `stellad postgres download` once before `stellad server`. No config files needed.
 
 ```bash
 stellad server --port 8080             # custom port
@@ -346,7 +346,7 @@ All data lives under the stella home directory (`~/.stella` by default, configur
 | Path                                  | Purpose                                                                                       |
 | ------------------------------------- | --------------------------------------------------------------------------------------------- |
 | `~/.stella/postgres/`                 | Embedded PostgreSQL data (config, memory, scheduler); absent when using `STELLA_DATABASE_URL` |
-| `~/.stella/pg-runtime/`               | Downloaded embedded PostgreSQL runtime; recreate with `stellad postgres download-runtime`     |
+| `~/.stella/pg-runtime/`               | Downloaded embedded PostgreSQL runtime; recreate with `stellad postgres download`             |
 | `~/.stella/agents/{agent-id}/skills/` | Per-agent installed skills                                                                    |
 | `~/.stella/agents/{agent-id}/SOUL.md` | Optional per-agent soul/identity override                                                     |
 | `~/.stella/cache/`                    | Model cache (regenerable, safe to delete)                                                     |

--- a/web/content/docs/start-here/deployment.zh.md
+++ b/web/content/docs/start-here/deployment.zh.md
@@ -10,7 +10,7 @@ title: 部署
 brew install CherryHQ/tap/stella
 ```
 
-如果不设置 `STELLA_DATABASE_URL`，启动服务前先运行一次 `stellad postgres download-runtime`。
+如果不设置 `STELLA_DATABASE_URL`，启动服务前先运行一次 `stellad postgres download`。
 
 ### Linux 软件包（.deb / .rpm）
 
@@ -24,7 +24,7 @@ sudo apt install ./stella_*_linux_amd64.deb
 sudo dnf install ./stella_*_linux_amd64.rpm
 ```
 
-如果不设置 `STELLA_DATABASE_URL`，启动服务前先运行一次 `stellad postgres download-runtime`。
+如果不设置 `STELLA_DATABASE_URL`，启动服务前先运行一次 `stellad postgres download`。
 
 ### 二进制文件
 
@@ -55,7 +55,7 @@ cd stella && go build -o dist/bin/stellad ./cmd/stellad/
 stellad server
 ```
 
-这会启动服务器并提供Web UI，你可以在其中设置 API 密钥、渠道和代理配置。所有配置都存储在 PostgreSQL 中——可以使用 `~/.stella` 下的内嵌集群，也可以在设置 `STELLA_DATABASE_URL` 时使用外部服务器。如果缺少内嵌 runtime，先运行一次 `stellad postgres download-runtime` 再启动 `stellad server`。无需手动配置文件。
+这会启动服务器并提供Web UI，你可以在其中设置 API 密钥、渠道和代理配置。所有配置都存储在 PostgreSQL 中——可以使用 `~/.stella` 下的内嵌集群，也可以在设置 `STELLA_DATABASE_URL` 时使用外部服务器。如果缺少内嵌 runtime，先运行一次 `stellad postgres download` 再启动 `stellad server`。无需手动配置文件。
 
 ```bash
 stellad server --port 8080                  # 自定义端口
@@ -335,7 +335,7 @@ terminationGracePeriodSeconds: 200
 | 路径                                  | 用途                                                                            |
 | ------------------------------------- | ------------------------------------------------------------------------------- |
 | `~/.stella/postgres/`                 | 内嵌 PostgreSQL 数据（配置、记忆、调度器）；使用 `STELLA_DATABASE_URL` 时不存在 |
-| `~/.stella/pg-runtime/`               | 下载的内嵌 PostgreSQL runtime；可用 `stellad postgres download-runtime` 重建    |
+| `~/.stella/pg-runtime/`               | 下载的内嵌 PostgreSQL runtime；可用 `stellad postgres download` 重建            |
 | `~/.stella/agents/{agent-id}/skills/` | 每个 agent 安装的技能                                                           |
 | `~/.stella/agents/{agent-id}/SOUL.md` | 可选的每个 agent 的灵魂/身份覆盖                                                |
 | `~/.stella/cache/`                    | 模型缓存（可重新生成，安全删除）                                                |

--- a/web/content/docs/start-here/storage.md
+++ b/web/content/docs/start-here/storage.md
@@ -18,7 +18,7 @@ This page classifies every directory and tells you the volume and backup treatme
 | `.agents/skills/`, `.agents/db-skills/`, `users/{id}/.../.agents/skills/` | Skill files on disk for sandbox execution             | Derived cache  | Ephemeral disk is fine. Rebuilt from PostgreSQL.                                  |
 | `bin/`                                                                    | Embedded tools and the `stella` CLI                   | Derived cache  | Ephemeral disk is fine. Re-extracted at startup.                                  |
 | `.mise-tools/`, `users/{id}/.mise-tools/`                                 | Toolchains for the sandbox                            | Derived cache  | Ephemeral disk is fine. Re-installed on demand.                                   |
-| `pg-runtime/`                                                             | Downloaded and extracted embedded-PostgreSQL runtime  | Derived cache  | Ephemeral disk is fine. Re-download with `stellad postgres download-runtime`.     |
+| `pg-runtime/`                                                             | Downloaded and extracted embedded-PostgreSQL runtime  | Derived cache  | Ephemeral disk is fine. Re-download with `stellad postgres download`.             |
 | `users/{id}/data/.cache/`                                                 | Per-user tool cache                                   | Derived cache  | Ephemeral disk is fine.                                                           |
 | `dumps/`                                                                  | Diagnostic dumps written on signal                    | Scratch        | Ephemeral disk is fine. Diagnostic only.                                          |
 
@@ -55,7 +55,7 @@ These directories are rebuilt automatically and can live on ephemeral disk:
 - **Skill mirrors** (`.agents/skills/`, `.agents/db-skills/`, and the per-user and per-agent `.agents/skills/` trees): PostgreSQL is the source of truth. The disk copies are rebuilt at startup and refreshed on every skill load, so a stale or missing mirror self-heals.
 - **`bin/`**: embedded tools and the `stella` CLI, re-extracted at startup.
 - **Toolchains** (`.mise-tools/`, per-user `.mise-tools/`): re-installed on demand.
-- **`pg-runtime/`**: the downloaded embedded-PostgreSQL runtime; re-download with `stellad postgres download-runtime`. Each runtime version installs into its own directory and older ones are never removed automatically — a few hundred megabytes each. Run `stellad postgres prune-runtimes` to see what is unused, and again with `--force` to remove it.
+- **`pg-runtime/`**: the downloaded embedded-PostgreSQL runtime; re-download with `stellad postgres download`. Each runtime version installs into its own directory and older ones are never removed automatically — a few hundred megabytes each. Run `stellad postgres prune` to see what is unused, and again with `--force` to remove it.
 - **`users/{id}/data/.cache/`**: per-user tool cache.
 
 ## Scratch

--- a/web/content/docs/start-here/storage.md
+++ b/web/content/docs/start-here/storage.md
@@ -55,7 +55,7 @@ These directories are rebuilt automatically and can live on ephemeral disk:
 - **Skill mirrors** (`.agents/skills/`, `.agents/db-skills/`, and the per-user and per-agent `.agents/skills/` trees): PostgreSQL is the source of truth. The disk copies are rebuilt at startup and refreshed on every skill load, so a stale or missing mirror self-heals.
 - **`bin/`**: embedded tools and the `stella` CLI, re-extracted at startup.
 - **Toolchains** (`.mise-tools/`, per-user `.mise-tools/`): re-installed on demand.
-- **`pg-runtime/`**: the downloaded embedded-PostgreSQL runtime; re-download with `stellad postgres download-runtime`.
+- **`pg-runtime/`**: the downloaded embedded-PostgreSQL runtime; re-download with `stellad postgres download-runtime`. Each runtime version installs into its own directory and older ones are never removed automatically — a few hundred megabytes each. Run `stellad postgres prune-runtimes` to see what is unused, and again with `--force` to remove it.
 - **`users/{id}/data/.cache/`**: per-user tool cache.
 
 ## Scratch

--- a/web/content/docs/start-here/storage.zh.md
+++ b/web/content/docs/start-here/storage.zh.md
@@ -55,7 +55,7 @@ PostgreSQL 保存了几乎全部状态：配置、密钥元数据、消息历史
 - **技能镜像**（`.agents/skills/`、`.agents/db-skills/` 以及每用户、每 agent 的 `.agents/skills/` 树）：PostgreSQL 是事实来源。磁盘副本在启动时重建，并在每次加载技能时刷新，因此陈旧或缺失的镜像会自我修复。
 - **`bin/`**：内嵌工具与 `stella` CLI，启动时重新解压。
 - **工具链**（`.mise-tools/`、每用户 `.mise-tools/`）：按需重新安装。
-- **`pg-runtime/`**：下载的内嵌 PostgreSQL runtime；用 `stellad postgres download-runtime` 重新下载。
+- **`pg-runtime/`**：下载的内嵌 PostgreSQL runtime；用 `stellad postgres download-runtime` 重新下载。每个 runtime 版本安装在各自的目录中，旧版本不会被自动清理，每个约数百 MB。执行 `stellad postgres prune-runtimes` 查看哪些已不再使用，加 `--force` 才会真正删除。
 - **`users/{id}/data/.cache/`**：每用户工具缓存。
 
 ## 临时数据

--- a/web/content/docs/start-here/storage.zh.md
+++ b/web/content/docs/start-here/storage.zh.md
@@ -8,19 +8,19 @@ Stella 写入磁盘的所有内容都位于 `$STELLA_HOME` 下（默认为 `~/.s
 
 ## 分类速览
 
-| `$STELLA_HOME` 下的路径                                                   | 存放内容                              | 分类       | Kubernetes / 临时磁盘处理方式                                   |
-| ------------------------------------------------------------------------- | ------------------------------------- | ---------- | --------------------------------------------------------------- |
-| `postgres/`                                                               | 内嵌 PostgreSQL 集群——事实来源        | 持久数据   | 持久卷**并**备份。设置 `STELLA_DATABASE_URL` 时不存在。         |
-| `users/{id}/data/assets/`                                                 | 用户上传的文件（按用户）              | 持久数据\* | 持久卷——**除非**配置了 S3 镜像（见下文）。                      |
-| `users/group-{id}/data/assets/`                                           | 用户上传的文件（按群组）              | 持久数据\* | 同按用户资产。                                                  |
-| `users/{id}/agents/{id}/`                                                 | Agent 工作树与项目文件                | 持久数据   | 持久卷**并**固定到单一副本。不在任何地方镜像。                  |
-| `library/`                                                                | 旧版文章镜像（正被迁移进 PostgreSQL） | 遗留       | 保留在卷上，直到回填报告缺失为零，之后可归档或删除。            |
-| `.agents/skills/`、`.agents/db-skills/`、`users/{id}/.../.agents/skills/` | 供沙箱执行的磁盘技能文件              | 派生缓存   | 临时磁盘即可。从 PostgreSQL 重建。                              |
-| `bin/`                                                                    | 内嵌工具与 `stella` CLI               | 派生缓存   | 临时磁盘即可。启动时重新解压。                                  |
-| `.mise-tools/`、`users/{id}/.mise-tools/`                                 | 沙箱工具链                            | 派生缓存   | 临时磁盘即可。按需重新安装。                                    |
-| `pg-runtime/`                                                             | 下载并解压的内嵌 PostgreSQL runtime   | 派生缓存   | 临时磁盘即可。用 `stellad postgres download-runtime` 重新下载。 |
-| `users/{id}/data/.cache/`                                                 | 每用户工具缓存                        | 派生缓存   | 临时磁盘即可。                                                  |
-| `dumps/`                                                                  | 收到信号时写出的诊断转储              | 临时数据   | 临时磁盘即可。仅用于诊断。                                      |
+| `$STELLA_HOME` 下的路径                                                   | 存放内容                              | 分类       | Kubernetes / 临时磁盘处理方式                           |
+| ------------------------------------------------------------------------- | ------------------------------------- | ---------- | ------------------------------------------------------- |
+| `postgres/`                                                               | 内嵌 PostgreSQL 集群——事实来源        | 持久数据   | 持久卷**并**备份。设置 `STELLA_DATABASE_URL` 时不存在。 |
+| `users/{id}/data/assets/`                                                 | 用户上传的文件（按用户）              | 持久数据\* | 持久卷——**除非**配置了 S3 镜像（见下文）。              |
+| `users/group-{id}/data/assets/`                                           | 用户上传的文件（按群组）              | 持久数据\* | 同按用户资产。                                          |
+| `users/{id}/agents/{id}/`                                                 | Agent 工作树与项目文件                | 持久数据   | 持久卷**并**固定到单一副本。不在任何地方镜像。          |
+| `library/`                                                                | 旧版文章镜像（正被迁移进 PostgreSQL） | 遗留       | 保留在卷上，直到回填报告缺失为零，之后可归档或删除。    |
+| `.agents/skills/`、`.agents/db-skills/`、`users/{id}/.../.agents/skills/` | 供沙箱执行的磁盘技能文件              | 派生缓存   | 临时磁盘即可。从 PostgreSQL 重建。                      |
+| `bin/`                                                                    | 内嵌工具与 `stella` CLI               | 派生缓存   | 临时磁盘即可。启动时重新解压。                          |
+| `.mise-tools/`、`users/{id}/.mise-tools/`                                 | 沙箱工具链                            | 派生缓存   | 临时磁盘即可。按需重新安装。                            |
+| `pg-runtime/`                                                             | 下载并解压的内嵌 PostgreSQL runtime   | 派生缓存   | 临时磁盘即可。用 `stellad postgres download` 重新下载。 |
+| `users/{id}/data/.cache/`                                                 | 每用户工具缓存                        | 派生缓存   | 临时磁盘即可。                                          |
+| `dumps/`                                                                  | 收到信号时写出的诊断转储              | 临时数据   | 临时磁盘即可。仅用于诊断。                              |
 
 \* 默认在本地磁盘上属于持久数据；一旦配置了 S3 镜像即变为可恢复的缓存——参见[用户资产](#用户资产持久或镜像)。
 
@@ -55,7 +55,7 @@ PostgreSQL 保存了几乎全部状态：配置、密钥元数据、消息历史
 - **技能镜像**（`.agents/skills/`、`.agents/db-skills/` 以及每用户、每 agent 的 `.agents/skills/` 树）：PostgreSQL 是事实来源。磁盘副本在启动时重建，并在每次加载技能时刷新，因此陈旧或缺失的镜像会自我修复。
 - **`bin/`**：内嵌工具与 `stella` CLI，启动时重新解压。
 - **工具链**（`.mise-tools/`、每用户 `.mise-tools/`）：按需重新安装。
-- **`pg-runtime/`**：下载的内嵌 PostgreSQL runtime；用 `stellad postgres download-runtime` 重新下载。每个 runtime 版本安装在各自的目录中，旧版本不会被自动清理，每个约数百 MB。执行 `stellad postgres prune-runtimes` 查看哪些已不再使用，加 `--force` 才会真正删除。
+- **`pg-runtime/`**：下载的内嵌 PostgreSQL runtime；用 `stellad postgres download` 重新下载。每个 runtime 版本安装在各自的目录中，旧版本不会被自动清理，每个约数百 MB。执行 `stellad postgres prune` 查看哪些已不再使用，加 `--force` 才会真正删除。
 - **`users/{id}/data/.cache/`**：每用户工具缓存。
 
 ## 临时数据

--- a/web/toolchain_test.go
+++ b/web/toolchain_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 )
 
@@ -64,6 +65,35 @@ func TestNodeIsPinnedOnlyInMise(t *testing.T) {
 			t.Errorf("%s sets up its own Node; it would shadow the mise pin on PATH. "+
 				"Use jdx/mise-action and run the build through a mise task instead", path)
 		}
+	}
+}
+
+func TestDockerCrossBuildScopesGoTargetToFinalBuild(t *testing.T) {
+	dockerfile, err := os.ReadFile(filepath.Join("..", "Dockerfile"))
+	if err != nil {
+		t.Fatalf("read Dockerfile: %v", err)
+	}
+	if regexp.MustCompile(`(?s)\b(?:GOOS|GOARCH)=\$\{TARGET(?:OS|ARCH)\}.*?\bmise\s+run\s+build\b`).Match(dockerfile) {
+		t.Error("Dockerfile passes GOOS/GOARCH to the entire mise build task graph")
+	}
+	crossBuild := regexp.MustCompile(`(?m)env\s+-u\s+GOOS\s+-u\s+GOARCH\s+\\?\s*TARGET_GOOS=\$\{TARGETOS\}\s+TARGET_GOARCH=\$\{TARGETARCH\}\s+\\?\s*mise\s+run\s+build\b`)
+	if !crossBuild.Match(dockerfile) {
+		t.Error("Dockerfile must clear GOOS/GOARCH and pass TARGET_GOOS/TARGET_GOARCH to mise")
+	}
+
+	mise, err := os.ReadFile(filepath.Join("..", "mise.toml"))
+	if err != nil {
+		t.Fatalf("read mise.toml: %v", err)
+	}
+	if !regexp.MustCompile(`(?s)TARGET_GOOS\+x.*TARGET_GOARCH\+x.*TARGET_GOOS:-.*TARGET_GOARCH:-.*must be set together.*exit 1`).Match(mise) {
+		t.Error("mise build must reject a missing TARGET_GOOS or TARGET_GOARCH")
+	}
+	if strings.Count(string(mise), `GOOS="$TARGET_GOOS"`) != 1 || strings.Count(string(mise), `GOARCH="$TARGET_GOARCH"`) != 1 {
+		t.Error("TARGET_GOOS/TARGET_GOARCH must map to GOOS/GOARCH exactly once")
+	}
+	finalBuild := regexp.MustCompile(`(?s)env\s+GOOS="\$TARGET_GOOS"\s+GOARCH="\$TARGET_GOARCH"\s+\\?\s*go\s+build\b`)
+	if !finalBuild.Match(mise) {
+		t.Error("mise must apply GOOS/GOARCH only to the final go build")
 	}
 }
 

--- a/web/toolchain_test.go
+++ b/web/toolchain_test.go
@@ -1,0 +1,77 @@
+package web
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+)
+
+// mise.toml is the one place the Node and pnpm versions are pinned. pnpm is the
+// exception that cannot be: the repository runs pnpm from the root, where there
+// is no package.json, so mise has to install a version to bootstrap with — and
+// inside web/ pnpm then self-switches to packageManager. A mismatch therefore
+// never fails anything, it just means the pinned version is not the one that
+// runs, which is how the pin drifted three minor versions out of date unnoticed.
+func TestMisePnpmPinMatchesPackageManager(t *testing.T) {
+	mise, err := os.ReadFile(filepath.Join("..", "mise.toml"))
+	if err != nil {
+		t.Fatalf("read mise.toml: %v", err)
+	}
+	pinned := firstSubmatch(t, regexp.MustCompile(`(?m)^pnpm\s*=\s*"([^"]+)"`), mise, "pnpm pin in mise.toml")
+
+	body, err := os.ReadFile("package.json")
+	if err != nil {
+		t.Fatalf("read package.json: %v", err)
+	}
+	var pkg struct {
+		PackageManager string `json:"packageManager"`
+	}
+	if err := json.Unmarshal(body, &pkg); err != nil {
+		t.Fatalf("package.json is not valid JSON: %v", err)
+	}
+	if want := "pnpm@" + pinned; pkg.PackageManager != want {
+		t.Errorf("package.json packageManager = %q, but mise.toml pins %q. "+
+			"pnpm self-switches to packageManager, so the mise pin would silently stop being the version that runs",
+			pkg.PackageManager, want)
+	}
+}
+
+// Nothing else may pin Node. The release job used to install its own, which is
+// how tagged binaries shipped an SPA built on a Node version no pull request
+// exercised.
+func TestNodeIsPinnedOnlyInMise(t *testing.T) {
+	mise, err := os.ReadFile(filepath.Join("..", "mise.toml"))
+	if err != nil {
+		t.Fatalf("read mise.toml: %v", err)
+	}
+	firstSubmatch(t, regexp.MustCompile(`(?m)^node\s*=\s*"([^"]+)"`), mise, "node pin in mise.toml")
+
+	// Match the step, not prose: the comment explaining why the step is gone
+	// lives in the workflow it was removed from.
+	setupNode := regexp.MustCompile(`(?m)^\s*(uses:\s*actions/setup-node|node-version:)`)
+	workflows, err := filepath.Glob(filepath.Join("..", ".github", "workflows", "*.yml"))
+	if err != nil {
+		t.Fatalf("glob workflows: %v", err)
+	}
+	for _, path := range workflows {
+		body, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if setupNode.Match(body) {
+			t.Errorf("%s sets up its own Node; it would shadow the mise pin on PATH. "+
+				"Use jdx/mise-action and run the build through a mise task instead", path)
+		}
+	}
+}
+
+func firstSubmatch(t *testing.T, re *regexp.Regexp, body []byte, what string) string {
+	t.Helper()
+	m := re.FindSubmatch(body)
+	if m == nil {
+		t.Fatalf("could not find the %s", what)
+	}
+	return string(m[1])
+}


### PR DESCRIPTION
Two loose ends from the #866 cleanup. Separate commits — they are independent judgment calls.

Closes #878
Closes #880

## `stellad postgres prune`

Every runtime version installs into its own directory under `$STELLA_HOME/pg-runtime` and nothing removed the siblings, so each revision left a few hundred megabytes behind. On my machine, right after the `-r2` upgrade:

```
$ stellad postgres prune
In use: pg18.4-pgvector0.8.2-pgsearch0.24.1-r2-darwin-arm64

Unused, safe to remove once no server is running from them:
  pg18.4-pgvector0.8.2-pgsearch0.24.1-darwin-arm64  518.7 MiB

518.7 MiB would be reclaimed. Re-run with --force to remove them.
```

A bare invocation reports; only `--force` deletes. `--json` for scripts. Pruning is deliberately not automatic after a successful install — a rolled-back binary, or a second `stellad` still serving from the old root, would both break, and removing a directory a live process has open turns a disk-space annoyance into an outage.

`pgruntime` gains `CurrentRuntimeDir` and `InstalledRuntimes`, so the `<version>-<goos>-<goarch>` layout stays in the one package that already built it — `RuntimeRoot` now composes from the same function, and a test pins them together. Getting that wrong would mean offering to delete the directory the server is about to start from.

## One place for the web toolchain

Four paths build the SPA the binary embeds, and they disagreed about Node:

| Path | Node before | Node after |
| --- | --- | --- |
| local + `lint-and-test.yml` | 24.14.1 | 24.14.1 |
| `release.yml` goreleaser job | **22** | 24.14.1 |
| `Dockerfile` | floating 24.x | 24.14.1 |

Tagged binaries shipped a frontend built on a runtime no pull request ever exercised. That is the same shape of gap #866 was about, one layer down.

The release job only set up its own pnpm and Node to feed a raw `sh -c "cd web && pnpm install --frozen-lockfile && pnpm build"` GoReleaser hook. That hook now calls `mise run build:embedded`, so the setup steps have no reason to exist and are gone. The Dockerfile's web stage moves off `ghcr.io/pnpm/pnpm:latest` onto mise — the Go stage already installed mise, so the file was half doing this already, and it means no image tag to keep in step either.

Two details:

- **The mise pnpm pin was inert.** `web/package.json` declares `packageManager`, pnpm self-switches to it, and `pnpm -v` printed `11.0.8` from inside the `10.33.0` install directory. It cannot simply be deleted — root-level `pnpm --package=@redocly/cli` runs where there is no `package.json` and needs something to bootstrap — so it is corrected, and `web/toolchain_test.go` fails if the two drift again. The same test rejects any workflow that sets up its own Node.
- **`build:embedded`** exists so GoReleaser names one task. Both `generate` and `build:web` want `generate:ts-sdk`; asking for them together lets mise resolve it once instead of regenerating the SDK twice per release.

## Docker cross-build correctness

Review caught a pre-existing bug in the Go builder. Docker runs the builder stage on `$BUILDPLATFORM`, but it passed the target `GOOS` and `GOARCH` to the whole `mise run build` task graph. Since `build` runs generators first, `go run gen.go` compiled the generator for the target and then tried to execute it on the build host. Cross-platform builds failed with `exec format error`.

Docker now passes `TARGET_GOOS` and `TARGET_GOARCH` through generation with `GOOS` and `GOARCH` unset. The build task maps them only for the final `go build`. Generators stay native while the downloaded mise asset and final Stella binary still match the target. A test pins this boundary and rejects half-specified target pairs.

## Verification

- `mise run format && mise run build && mise run test` — green.
- `mise run release:snapshot` — GoReleaser runs the new hook and produces all six archives plus deb/rpm; `generate:ts-sdk` runs exactly once.
- `docker build --target web-builder` — green; the image resolves Node **24.14.1** and pnpm **11.0.8**, matching the mise pins, and emits `web/static/dist/index.html` and `sw.js`.
- Cross-build checks from macOS arm64 to Linux arm64 and Linux amd64 both produce a target-architecture `stellad` and embedded mise binary; the old path reproduced `exec format error`.
- `stellad postgres prune` and `--json` run against a real `$STELLA_HOME` carrying the pre-`-r2` runtime (output above).
- New tests cover prune safety, empty JSON output, toolchain pin drift, and the Docker cross-build environment boundary.
