### PR TITLE
⚡ perf(agent): stabilize tool definition ordering for prompt cache reuse

### DIFF
--- a/internal/agent/runner_impl_test.go
+++ b/internal/agent/runner_impl_test.go
@@ -63,33 +63,36 @@ func withTestRunnerPaths(t *testing.T, cfg runnerConfig) runnerConfig {
 
 func TestFilterRunnerTools(t *testing.T) {
 	reg := tools.NewRegistry()
-	reg.Register(&stubTool{name: "bash"})
-	reg.Register(&stubTool{name: "notify"})
-	reg.Register(&stubTool{name: "scheduler"})
+	reg.Register(&stubTool{name: "zeta"})
+	reg.Register(&stubTool{name: "middle"})
+	reg.Register(&stubTool{name: "alpha"})
 
-	set, defs, err := filterRunnerTools(reg, []string{"notify", "scheduler"})
+	set, defs, err := filterRunnerTools(reg, []string{"middle", "not-registered"})
 	if err != nil {
 		t.Fatalf("filterRunnerTools: %v", err)
 	}
-	if len(defs) != 1 || defs[0].Name != "bash" {
-		t.Fatalf("defs = %#v, want only bash", defs)
+	if len(defs) != 2 || defs[0].Name != "alpha" || defs[1].Name != "zeta" {
+		t.Fatalf("defs = %#v, want alpha then zeta", defs)
 	}
-	if _, ok := set["notify"]; ok {
-		t.Fatal("notify should be excluded")
+	if len(set) != 2 {
+		t.Fatalf("tool set length = %d, want 2", len(set))
 	}
-	if _, ok := set["scheduler"]; ok {
-		t.Fatal("scheduler should be excluded")
+	if _, ok := set["middle"]; ok {
+		t.Fatal("middle should be excluded")
 	}
-	if _, ok := set["bash"]; !ok {
-		t.Fatal("bash should remain available")
+	if _, ok := set["alpha"]; !ok {
+		t.Fatal("alpha should remain available")
+	}
+	if _, ok := set["zeta"]; !ok {
+		t.Fatal("zeta should remain available")
 	}
 
-	result, err := set["bash"](context.Background(), ai.ToolCall{Name: "bash"})
+	result, err := set["alpha"](context.Background(), ai.ToolCall{Name: "alpha"})
 	if err != nil {
-		t.Fatalf("execute filtered bash tool: %v", err)
+		t.Fatalf("execute filtered alpha tool: %v", err)
 	}
-	if ai.FlattenText(result) != "bash" {
-		t.Fatalf("filtered bash result = %q, want bash", ai.FlattenText(result))
+	if ai.FlattenText(result) != "alpha" {
+		t.Fatalf("filtered alpha result = %q, want alpha", ai.FlattenText(result))
 	}
 }
 

--- a/pkg/tools/registry.go
+++ b/pkg/tools/registry.go
@@ -1,8 +1,10 @@
 package tools
 
 import (
+	"cmp"
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/CherryHQ/stella/pkg/ai"
 )
@@ -37,12 +39,15 @@ func (r *Registry) Register(t Tool) {
 	r.tools[t.Definition().Name] = t
 }
 
-// Definitions returns all tool definitions for passing to the LLM.
+// Definitions returns all tool definitions in stable name order for passing to the LLM.
 func (r *Registry) Definitions() []Definition {
 	defs := make([]Definition, 0, len(r.tools))
 	for _, t := range r.tools {
 		defs = append(defs, t.Definition())
 	}
+	slices.SortFunc(defs, func(a, b Definition) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
 	return defs
 }
 

--- a/pkg/tools/registry_test.go
+++ b/pkg/tools/registry_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 )
@@ -53,13 +54,42 @@ func TestRegistry_RegisterAndHas(t *testing.T) {
 	}
 }
 
-func TestRegistry_Definitions(t *testing.T) {
-	r := NewRegistry()
-	r.Register(&mockTool{name: "a"})
-	r.Register(&mockTool{name: "b"})
-	defs := r.Definitions()
-	if len(defs) != 2 {
-		t.Errorf("expected 2 definitions, got %d", len(defs))
+func TestRegistry_DefinitionsStableOrder(t *testing.T) {
+	registrationOrders := [][]string{
+		{"zeta", "alpha", "middle"},
+		{"middle", "zeta", "alpha"},
+	}
+	wantNames := []string{"alpha", "middle", "zeta"}
+	var wantJSON string
+
+	for _, order := range registrationOrders {
+		r := NewRegistry()
+		for _, name := range order {
+			r.Register(&mockTool{name: name})
+		}
+
+		// Materialize repeatedly so map iteration can never leak into provider-facing order.
+		for range 16 {
+			defs := r.Definitions()
+			if len(defs) != len(wantNames) {
+				t.Fatalf("Definitions() length = %d, want %d", len(defs), len(wantNames))
+			}
+			for i, wantName := range wantNames {
+				if defs[i].Name != wantName {
+					t.Fatalf("Definitions()[%d].Name = %q, want %q; definitions = %#v", i, defs[i].Name, wantName, defs)
+				}
+			}
+
+			encoded, err := json.Marshal(defs)
+			if err != nil {
+				t.Fatalf("json.Marshal(Definitions()) error: %v", err)
+			}
+			if wantJSON == "" {
+				wantJSON = string(encoded)
+			} else if string(encoded) != wantJSON {
+				t.Fatalf("serialized Definitions() = %s, want %s", encoded, wantJSON)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## What

Stabilize the provider-visible tool definition order by returning `Registry.Definitions()` in lexicographic tool-name order.

Add regression coverage for different registration orders, repeated JSON serialization, and excluded-tool filtering without changing tool execution behavior.

## Why

`Registry` stores tools in a Go map, so directly materializing definitions from that map can reorder an otherwise identical `tools` array between requests. That changes the request prefix seen by providers and can reduce KV/prompt cache reuse.

## How

- Sort definitions once at the shared `Registry.Definitions()` boundary.
- Let initial, per-run, and filtered runner paths inherit the same deterministic order.
- Keep provider adapters, hooks, registration, lookup, permissions, and `BuiltinNames()` behavior unchanged.
- Verify that excluded tools remain unavailable while retained tools are still executable.

## Test

- `mise run format`
- `mise run build`
- `mise run test`
- `mise exec -- go test -count=1 ./pkg/tools`
- `mise exec -- go test -count=1 ./internal/agent -run '^TestFilterRunnerTools$'`

## Refs

Closes #801

## Checklist

- [x] The PR links a GitHub issue.
- [x] I added or updated focused tests for changed non-trivial behavior.
- [x] No documentation change is needed because this only makes an existing internal ordering deterministic.
- [x] I ran `mise run format && mise run build && mise run test`.
