### PR TITLE
🔐 feat(auth): add restricted provisioning credentials

### DIFF
--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -2982,6 +2982,55 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ProviderType"
+    ProvisioningToken:
+      type: object
+      required: [id, name, last4, created_at]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        last4:
+          type: string
+        expires_at:
+          type: string
+          format: date-time
+        last_used_at:
+          type: string
+          format: date-time
+        revoked_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+    ProvisioningTokenList:
+      type: object
+      required: [provisioning_tokens]
+      properties:
+        provisioning_tokens:
+          type: array
+          items:
+            $ref: "#/components/schemas/ProvisioningToken"
+    CreateProvisioningTokenRequest:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+        # Omit for the server's 90-day default. Provisioning tokens always expire.
+        expires_at:
+          type: string
+          format: date-time
+    CreateProvisioningTokenResponse:
+      type: object
+      required: [token, provisioning_token]
+      properties:
+        # Plaintext token, returned exactly once at creation and never again.
+        token:
+          type: string
+        provisioning_token:
+          $ref: "#/components/schemas/ProvisioningToken"
     # ── Recally ────────────────────────────────────────────────────────────────
     ArticleStatus:
       type: string

--- a/api/spec/domain/provisioning/paths.yaml
+++ b/api/spec/domain/provisioning/paths.yaml
@@ -1,0 +1,56 @@
+paths:
+  /api/admin/provisioning-tokens:
+    get:
+      tags: [provisioning]
+      summary: List the current admin's provisioning tokens
+      operationId: listProvisioningTokens
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "../../components.yaml#/components/schemas/ProvisioningTokenList"
+        "401": {
+          $ref: "../../components.yaml#/components/responses/Unauthorized",
+        }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+    post:
+      tags: [provisioning]
+      summary: Create a provisioning token
+      operationId: createProvisioningToken
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "../../components.yaml#/components/schemas/CreateProvisioningTokenRequest"
+      responses:
+        "201":
+          description: created; plaintext token returned once
+          content:
+            application/json:
+              schema:
+                $ref: "../../components.yaml#/components/schemas/CreateProvisioningTokenResponse"
+        "400": {
+          $ref: "../../components.yaml#/components/responses/BadRequest",
+        }
+        "401": {
+          $ref: "../../components.yaml#/components/responses/Unauthorized",
+        }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+
+  /api/admin/provisioning-tokens/{id}:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: string } }
+    delete:
+      tags: [provisioning]
+      summary: Revoke a provisioning token
+      operationId: revokeProvisioningToken
+      responses:
+        "204": { description: revoked }
+        "401": {
+          $ref: "../../components.yaml#/components/responses/Unauthorized",
+        }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }

--- a/api/spec/domain/provisioning/schemas.yaml
+++ b/api/spec/domain/provisioning/schemas.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.3
+info:
+  title: Provisioning Token Components
+  version: "1"
+paths: {}
+components:
+  schemas:
+    ProvisioningToken:
+      type: object
+      required: [id, name, last4, created_at]
+      properties:
+        id: { type: string }
+        name: { type: string }
+        last4: { type: string }
+        expires_at: { type: string, format: date-time }
+        last_used_at: { type: string, format: date-time }
+        revoked_at: { type: string, format: date-time }
+        created_at: { type: string, format: date-time }
+
+    ProvisioningTokenList:
+      type: object
+      required: [provisioning_tokens]
+      properties:
+        provisioning_tokens:
+          type: array
+          items: { $ref: "#/components/schemas/ProvisioningToken" }
+
+    CreateProvisioningTokenRequest:
+      type: object
+      required: [name]
+      properties:
+        name: { type: string }
+        # Omit for the server's 90-day default. Provisioning tokens always expire.
+        expires_at: { type: string, format: date-time }
+
+    CreateProvisioningTokenResponse:
+      type: object
+      required: [token, provisioning_token]
+      properties:
+        # Plaintext token, returned exactly once at creation and never again.
+        token: { type: string }
+        provisioning_token:
+          $ref: "#/components/schemas/ProvisioningToken"

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -54,6 +54,7 @@ tags:
   - name: auth-users
   - name: profile
   - name: pat
+  - name: provisioning
   - name: oauth-clients
   - name: auth
   - name: plugins
@@ -278,6 +279,12 @@ paths:
     $ref: "./domain/pat/paths.yaml#/paths/~1api~1users~1me~1tokens"
   /api/users/me/tokens/{id}:
     $ref: "./domain/pat/paths.yaml#/paths/~1api~1users~1me~1tokens~1{id}"
+
+  # ── Admin: Provisioning tokens ────────────────────────────────────────────
+  /api/admin/provisioning-tokens:
+    $ref: "./domain/provisioning/paths.yaml#/paths/~1api~1admin~1provisioning-tokens"
+  /api/admin/provisioning-tokens/{id}:
+    $ref: "./domain/provisioning/paths.yaml#/paths/~1api~1admin~1provisioning-tokens~1{id}"
 
   # ── OAuth2 clients & authorized apps ─────────────────────────────────────────
   /api/users/me/oauth-clients:

--- a/internal/credential/enforce.go
+++ b/internal/credential/enforce.go
@@ -65,6 +65,11 @@ func Enforce(p *Principal, method, path string) error {
 			return fmt.Errorf("%w: PAT may not manage authentication credentials", ErrForbidden)
 		}
 		return nil
+	case KindProvisioning:
+		if !provisionedUserRouteAllowed(path) {
+			return fmt.Errorf("%w: provisioning credentials may only access provisioned users", ErrForbidden)
+		}
+		return nil
 	case KindOAuth:
 		// OAuth access tokens are delegated capabilities, not account credentials.
 		// Preserve the existing route-to-scope and OAuth-exposability policy.
@@ -100,6 +105,7 @@ func patCredentialRouteDenied(path string) bool {
 	rest := apiSegments(path)
 	switch {
 	case hasSegmentPrefix(rest, "users", "me", "tokens"),
+		hasSegmentPrefix(rest, "admin", "provisioning-tokens"),
 		hasSegmentPrefix(rest, "users", "me", "oauth-clients"),
 		hasSegmentPrefix(rest, "users", "me", "authorized-apps"),
 		hasSegmentPrefix(rest, "auth", "sessions"),
@@ -114,6 +120,13 @@ func patCredentialRouteDenied(path string) bool {
 	default:
 		return false
 	}
+}
+
+// provisionedUserRouteAllowed is deliberately an allowlist: a provisioning
+// credential has no implicit owner authority, and future routes stay denied
+// until they are placed under this resource family on purpose.
+func provisionedUserRouteAllowed(path string) bool {
+	return hasSegmentPrefix(apiSegments(path), "provisioned-users")
 }
 
 func hasSegmentPrefix(got []string, want ...string) bool {

--- a/internal/credential/enforce_test.go
+++ b/internal/credential/enforce_test.go
@@ -40,6 +40,8 @@ func TestEnforcePATCredentialRouteFence(t *testing.T) {
 	for _, path := range []string{
 		"/api/users/me/tokens",
 		"/api/users/me/tokens/token-1",
+		"/api/admin/provisioning-tokens",
+		"/api/admin/provisioning-tokens/token-1",
 		"/api/users/me/oauth-clients",
 		"/api/users/me/oauth-clients/client-1/rotate-secret",
 		"/api/users/me/authorized-apps",
@@ -71,6 +73,29 @@ func TestEnforcePATCredentialRouteFence(t *testing.T) {
 	} {
 		if err := Enforce(p, "GET", path); err != nil {
 			t.Errorf("admin PAT GET %s must remain outside the fence: %v", path, err)
+		}
+	}
+}
+
+func TestEnforceProvisioningTokenStrictAllowlist(t *testing.T) {
+	p := &Principal{Kind: KindProvisioning, UserID: "admin", CredentialID: "token-1"}
+	for _, path := range []string{
+		"/api/provisioned-users",
+		"/api/provisioned-users/user-1",
+		"/api/provisioned-users/user-1/rotate",
+	} {
+		if err := Enforce(p, "POST", path); err != nil {
+			t.Errorf("provisioning token POST %s: %v", path, err)
+		}
+	}
+	for _, path := range []string{
+		"/api/provisioned-users-extra",
+		"/api/admin/provisioning-tokens",
+		"/api/agents",
+		"/agents",
+	} {
+		if err := Enforce(p, "GET", path); err == nil {
+			t.Errorf("provisioning token GET %s must be denied", path)
 		}
 	}
 }

--- a/internal/credential/mint.go
+++ b/internal/credential/mint.go
@@ -16,6 +16,9 @@ import (
 const (
 	// PATPrefix identifies a personal access token presented to the API.
 	PATPrefix = "stella_pat_"
+	// ProvisioningPrefix identifies a restricted provisioning token presented to
+	// the API. Its distinct wire namespace must match the stored token use.
+	ProvisioningPrefix = "stella_prv_"
 	// OAuthAccessPrefix identifies an OAuth2 access token. Reserved for #613.
 	OAuthAccessPrefix = "stella_oat_"
 	// OAuthRefreshPrefix identifies an OAuth2 refresh token. Valid only at the
@@ -89,6 +92,8 @@ func opaquePrefix(kind Kind) (string, error) {
 	switch kind {
 	case KindPAT:
 		return PATPrefix, nil
+	case KindProvisioning:
+		return ProvisioningPrefix, nil
 	case KindOAuth:
 		return OAuthAccessPrefix, nil
 	default:

--- a/internal/credential/mint_test.go
+++ b/internal/credential/mint_test.go
@@ -6,37 +6,45 @@ import (
 )
 
 func TestMintOpaqueFormatAndChecksum(t *testing.T) {
-	m, err := MintOpaque(KindPAT)
-	if err != nil {
-		t.Fatalf("mint: %v", err)
-	}
-	if !strings.HasPrefix(m.Plaintext, PATPrefix) {
-		t.Fatalf("plaintext missing family prefix: %q", m.Plaintext)
-	}
-	if m.Last4 != m.Plaintext[len(m.Plaintext)-4:] {
-		t.Fatal("last4 must be the plaintext suffix")
-	}
+	for _, tc := range []struct {
+		kind   Kind
+		prefix string
+	}{
+		{KindPAT, PATPrefix},
+		{KindProvisioning, ProvisioningPrefix},
+	} {
+		m, err := MintOpaque(tc.kind)
+		if err != nil {
+			t.Fatalf("mint %s: %v", tc.kind, err)
+		}
+		if !strings.HasPrefix(m.Plaintext, tc.prefix) {
+			t.Fatalf("%s plaintext missing family prefix: %q", tc.kind, m.Plaintext)
+		}
+		if m.Last4 != m.Plaintext[len(m.Plaintext)-4:] {
+			t.Fatal("last4 must be the plaintext suffix")
+		}
 
-	publicID, secret, err := parseOpaqueToken(PATPrefix, m.Plaintext)
-	if err != nil {
-		t.Fatalf("parse minted token: %v", err)
-	}
-	if publicID != m.PublicID {
-		t.Fatalf("public id mismatch: %q vs %q", publicID, m.PublicID)
-	}
-	if hashSecret(secret) != m.TokenHash {
-		t.Fatal("hash of parsed secret must equal stored token hash")
-	}
+		publicID, secret, err := parseOpaqueToken(tc.prefix, m.Plaintext)
+		if err != nil {
+			t.Fatalf("parse minted %s token: %v", tc.kind, err)
+		}
+		if publicID != m.PublicID {
+			t.Fatalf("public id mismatch: %q vs %q", publicID, m.PublicID)
+		}
+		if hashSecret(secret) != m.TokenHash {
+			t.Fatal("hash of parsed secret must equal stored token hash")
+		}
 
-	// Flip the last checksum char: parsing must fail (leak detection integrity).
-	bad := m.Plaintext[:len(m.Plaintext)-1]
-	if last := m.Plaintext[len(m.Plaintext)-1]; last == 'a' {
-		bad += "b"
-	} else {
-		bad += "a"
-	}
-	if _, _, err := parseOpaqueToken(PATPrefix, bad); err == nil {
-		t.Fatal("checksum tampering must be rejected")
+		// Flip the last checksum char: parsing must fail (leak detection integrity).
+		bad := m.Plaintext[:len(m.Plaintext)-1]
+		if last := m.Plaintext[len(m.Plaintext)-1]; last == 'a' {
+			bad += "b"
+		} else {
+			bad += "a"
+		}
+		if _, _, err := parseOpaqueToken(tc.prefix, bad); err == nil {
+			t.Fatal("checksum tampering must be rejected")
+		}
 	}
 }
 

--- a/internal/credential/pat.go
+++ b/internal/credential/pat.go
@@ -6,54 +6,77 @@ import (
 	"fmt"
 )
 
-// resolvePAT is the personal-access-token sub-resolver. It owns the full PAT
-// path: parse + checksum, indexed public_id lookup, constant-time hash compare,
-// expiry/revocation, active-user check, and a throttled last_used touch.
+// resolvePAT resolves a personal token. Its prefix and stored token use must
+// agree so a token can never cross into another authority model.
 func (s *Service) resolvePAT(ctx context.Context, raw string) (*Principal, error) {
+	return s.resolveToken(ctx, raw, PATPrefix, KindPAT, TokenUsePersonal, false)
+}
+
+// resolveProvisioning resolves a restricted provisioning token. Its admin-owner
+// check is intentionally here, on every bearer request, not cached at issuance.
+func (s *Service) resolveProvisioning(ctx context.Context, raw string) (*Principal, error) {
+	return s.resolveToken(ctx, raw, ProvisioningPrefix, KindProvisioning, TokenUseProvisioning, true)
+}
+
+// resolveToken owns the shared parse, lookup, verification, lifecycle, and
+// current-owner checks for personal_access_token-backed credential kinds.
+func (s *Service) resolveToken(ctx context.Context, raw, prefix string, kind Kind, expectedUse TokenUse, requireAdmin bool) (*Principal, error) {
 	if s.pats == nil || s.users == nil {
-		return nil, fmt.Errorf("credential: PAT auth not configured")
+		return nil, fmt.Errorf("credential: token auth not configured")
 	}
-	publicID, secret, err := parseOpaqueToken(PATPrefix, raw)
+	publicID, secret, err := parseOpaqueToken(prefix, raw)
 	if err != nil {
 		return nil, err
 	}
 	rec, err := s.pats.GetPATByPublicID(ctx, publicID)
 	if err != nil {
-		return nil, fmt.Errorf("credential: PAT lookup: %w", err)
+		return nil, fmt.Errorf("credential: token lookup: %w", err)
+	}
+	if rec.TokenUse != expectedUse || !rec.TokenUse.Valid() {
+		return nil, fmt.Errorf("credential: token prefix and use mismatch")
 	}
 	// Constant-time compare of the SHA-256 hex; the row is already narrowed to
 	// one public_id, so this guards against timing oracles on the secret.
 	if subtle.ConstantTimeCompare([]byte(hashSecret(secret)), []byte(rec.TokenHash)) != 1 {
-		return nil, fmt.Errorf("credential: PAT secret mismatch")
+		return nil, fmt.Errorf("credential: token secret mismatch")
 	}
 	now := s.now()
 	if rec.RevokedAt != nil {
-		return nil, fmt.Errorf("credential: PAT revoked")
+		return nil, fmt.Errorf("credential: token revoked")
 	}
 	if rec.ExpiresAt != nil && !now.Before(*rec.ExpiresAt) {
-		return nil, fmt.Errorf("credential: PAT expired")
+		return nil, fmt.Errorf("credential: token expired")
 	}
 	ident, err := s.users.LookupUser(ctx, rec.UserID)
 	if err != nil {
-		return nil, fmt.Errorf("credential: PAT user lookup: %w", err)
+		return nil, fmt.Errorf("credential: token user lookup: %w", err)
 	}
 	if !ident.IsActive {
-		return nil, fmt.Errorf("credential: PAT user deactivated")
+		return nil, fmt.Errorf("credential: token user deactivated")
+	}
+	if requireAdmin && !ident.IsAdmin {
+		return nil, fmt.Errorf("credential: provisioning token owner is not an active admin")
 	}
 	if _, err := s.pats.TouchPATLastUsed(ctx, rec.ID); err != nil {
 		// Best effort: a failed last_used update must not fail the request.
-		s.log.Warn("credential: PAT last_used update failed", "error", err, "pat_id", rec.ID)
+		s.log.Warn("credential: token last_used update failed", "error", err, "token_id", rec.ID)
+	}
+	credentialID := ""
+	if kind == KindProvisioning {
+		credentialID = rec.ID
 	}
 	return &Principal{
-		Kind:      KindPAT,
-		UserID:    ident.UserID,
-		Username:  ident.Username,
-		Email:     ident.Email,
-		Name:      ident.Name,
-		AvatarURL: ident.AvatarURL,
-		Role:      ident.Role,
-		// PATs are a revocable API-only credential for their owner, so current
-		// account authority (including role changes) applies on every request.
+		Kind:         kind,
+		UserID:       ident.UserID,
+		CredentialID: credentialID,
+		Username:     ident.Username,
+		Email:        ident.Email,
+		Name:         ident.Name,
+		AvatarURL:    ident.AvatarURL,
+		Role:         ident.Role,
+		// Personal tokens inherit current account authority. Provisioning tokens
+		// need this snapshot only for request attribution; Enforce supplies their
+		// strict route allowlist.
 		IsAdmin: ident.IsAdmin,
 	}, nil
 }

--- a/internal/credential/principal.go
+++ b/internal/credential/principal.go
@@ -16,17 +16,41 @@ type Kind string
 const (
 	// KindPAT is a user-owned personal access token (stella_pat_).
 	KindPAT Kind = "pat"
+	// KindProvisioning is an admin-owned, API-only credential restricted to the
+	// provisioned-user resource family (stella_prv_).
+	KindProvisioning Kind = "provisioning"
 	// KindOAuth is an OAuth2 access token (stella_oat_). Reserved for #613.
 	KindOAuth Kind = "oauth"
 )
+
+// TokenUse identifies the intended authority model for a row in
+// personal_access_token. Keep this extensible enum validated here, at the one
+// persistence boundary, rather than freezing it in a database CHECK constraint.
+type TokenUse string
+
+const (
+	TokenUsePersonal     TokenUse = "personal"
+	TokenUseProvisioning TokenUse = "provisioning"
+)
+
+// Valid reports whether token use is recognized by this credential version.
+func (u TokenUse) Valid() bool {
+	switch u {
+	case TokenUsePersonal, TokenUseProvisioning:
+		return true
+	default:
+		return false
+	}
+}
 
 // Principal is the single output type of Resolve: the authenticated identity
 // plus the authorization inputs Enforce needs. Identity fields are a snapshot
 // taken at resolve time so callers can build their request context without a
 // second user lookup.
 type Principal struct {
-	Kind   Kind
-	UserID string
+	Kind         Kind
+	UserID       string
+	CredentialID string // provisioning row ID for future request attribution
 	// Scopes is populated only for delegated OAuth access tokens. PAT authority
 	// comes from the owner's current account and ignores legacy stored scopes.
 	Scopes []string
@@ -61,6 +85,7 @@ type PATRecord struct {
 	TokenHash  string
 	Last4      string
 	Scopes     []string
+	TokenUse   TokenUse
 	ExpiresAt  *time.Time
 	LastUsedAt *time.Time
 	RevokedAt  *time.Time

--- a/internal/credential/resolver.go
+++ b/internal/credential/resolver.go
@@ -2,11 +2,16 @@ package credential
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
 	"time"
 )
+
+// ErrProvisioningTokenLimit prevents an admin session from accumulating more
+// than the two credentials needed for a safe rotation overlap.
+var ErrProvisioningTokenLimit = errors.New("credential: provisioning token limit reached")
 
 // PATStore is the storage backend for the personal_access_token table. It is the
 // only storage the credential package touches directly; OAuth access tokens use
@@ -15,7 +20,9 @@ type PATStore interface {
 	CreatePAT(ctx context.Context, rec PATRecord) (PATRecord, error)
 	GetPATByPublicID(ctx context.Context, publicID string) (PATRecord, error)
 	ListPATByUser(ctx context.Context, userID string) ([]PATRecord, error)
+	ListProvisioningTokenByUser(ctx context.Context, userID string) ([]PATRecord, error)
 	RevokePAT(ctx context.Context, id, userID string) (int64, error)
+	RevokeProvisioningToken(ctx context.Context, id, userID string) (int64, error)
 	RevokePATByUser(ctx context.Context, userID string) (int64, error)
 	TouchPATLastUsed(ctx context.Context, id string) (int64, error)
 }
@@ -79,6 +86,8 @@ func (s *Service) Resolve(ctx context.Context, header string) (*Principal, error
 	switch {
 	case strings.HasPrefix(raw, PATPrefix):
 		return s.resolvePAT(ctx, raw)
+	case strings.HasPrefix(raw, ProvisioningPrefix):
+		return s.resolveProvisioning(ctx, raw)
 	case strings.HasPrefix(raw, OAuthAccessPrefix):
 		// Opaque OAuth2 access token. Resolved from oauth_access_token storage --
 		// NEVER JWKS-validated as a JWT. This is the non-negotiable guardrail: the
@@ -95,28 +104,40 @@ func (s *Service) Resolve(ctx context.Context, header string) (*Principal, error
 // CreatePAT mints an opaque token for its owner's current authority and persists
 // it. The plaintext is returned exactly once and is never recoverable afterwards.
 func (s *Service) CreatePAT(ctx context.Context, userID, name string, expiresAt *time.Time) (plaintext string, rec PATRecord, err error) {
-	if s.pats == nil {
-		return "", PATRecord{}, fmt.Errorf("credential: PAT store not configured")
+	return s.createToken(ctx, KindPAT, TokenUsePersonal, userID, name, expiresAt)
+}
+
+// CreateProvisioningToken mints an admin-owned bearer that can reach only the
+// provisioned-user API family. The caller gets its plaintext exactly once.
+func (s *Service) CreateProvisioningToken(ctx context.Context, userID, name string, expiresAt time.Time) (plaintext string, rec PATRecord, err error) {
+	if s.pats == nil || s.users == nil {
+		return "", PATRecord{}, fmt.Errorf("credential: provisioning token auth not configured")
 	}
-	minted, err := MintOpaque(KindPAT)
+	owner, err := s.users.LookupUser(ctx, userID)
 	if err != nil {
-		return "", PATRecord{}, err
+		return "", PATRecord{}, fmt.Errorf("credential: provisioning token owner lookup: %w", err)
 	}
-	rec, err = s.pats.CreatePAT(ctx, PATRecord{
-		PublicID:  minted.PublicID,
-		UserID:    userID,
-		Name:      name,
-		TokenHash: minted.TokenHash,
-		Last4:     minted.Last4,
-		// Retain the legacy NOT NULL column without granting a second authority
-		// model. Existing non-empty scope sets are ignored when resolving a PAT.
-		Scopes:    []string{},
-		ExpiresAt: expiresAt,
-	})
+	if !owner.IsActive || !owner.IsAdmin {
+		return "", PATRecord{}, fmt.Errorf("%w: provisioning tokens require an active admin owner", ErrForbidden)
+	}
+	recs, err := s.pats.ListProvisioningTokenByUser(ctx, userID)
 	if err != nil {
-		return "", PATRecord{}, fmt.Errorf("credential: create PAT: %w", err)
+		return "", PATRecord{}, fmt.Errorf("credential: list provisioning tokens: %w", err)
 	}
-	return minted.Plaintext, rec, nil
+	active := 0
+	now := s.now()
+	for _, rec := range recs {
+		if rec.RevokedAt == nil && (rec.ExpiresAt == nil || now.Before(*rec.ExpiresAt)) {
+			active++
+		}
+	}
+	// Interactive issuance makes a concurrent third create unlikely. Move this
+	// ceiling into a database constraint if provisioning issuance becomes a
+	// multi-replica or non-interactive path.
+	if active >= 2 {
+		return "", PATRecord{}, ErrProvisioningTokenLimit
+	}
+	return s.createToken(ctx, KindProvisioning, TokenUseProvisioning, userID, name, &expiresAt)
 }
 
 // ListPAT returns a user's PATs (never the secret; hashes stay in storage).
@@ -125,6 +146,14 @@ func (s *Service) ListPAT(ctx context.Context, userID string) ([]PATRecord, erro
 		return nil, fmt.Errorf("credential: PAT store not configured")
 	}
 	return s.pats.ListPATByUser(ctx, userID)
+}
+
+// ListProvisioningTokens returns only provisioning tokens owned by an admin.
+func (s *Service) ListProvisioningTokens(ctx context.Context, userID string) ([]PATRecord, error) {
+	if s.pats == nil {
+		return nil, fmt.Errorf("credential: PAT store not configured")
+	}
+	return s.pats.ListProvisioningTokenByUser(ctx, userID)
 }
 
 // GetPAT returns one of the user's own PATs by id. The scan is over the caller's
@@ -158,12 +187,52 @@ func (s *Service) RevokePAT(ctx context.Context, id, userID string) (bool, error
 	return n > 0, err
 }
 
-// RevokeUserPATs cascade-revokes every active PAT a user holds. Call it when the
-// account is deactivated so tokens do not silently reactivate with the account.
-// It returns the number of tokens revoked.
+// RevokeProvisioningToken revokes a provisioning token owned by its issuing
+// admin. A personal token with the same id is deliberately indistinguishable
+// from a missing provisioning token.
+func (s *Service) RevokeProvisioningToken(ctx context.Context, id, userID string) (bool, error) {
+	if s.pats == nil {
+		return false, fmt.Errorf("credential: PAT store not configured")
+	}
+	n, err := s.pats.RevokeProvisioningToken(ctx, id, userID)
+	return n > 0, err
+}
+
+// RevokeUserPATs cascade-revokes every active personal_access_token use a user
+// holds. Call it when the account is deactivated so neither personal nor
+// provisioning tokens silently reactivate with the account.
 func (s *Service) RevokeUserPATs(ctx context.Context, userID string) (int64, error) {
 	if s.pats == nil {
 		return 0, fmt.Errorf("credential: PAT store not configured")
 	}
 	return s.pats.RevokePATByUser(ctx, userID)
+}
+
+func (s *Service) createToken(ctx context.Context, kind Kind, tokenUse TokenUse, userID, name string, expiresAt *time.Time) (plaintext string, rec PATRecord, err error) {
+	if s.pats == nil {
+		return "", PATRecord{}, fmt.Errorf("credential: PAT store not configured")
+	}
+	if !tokenUse.Valid() {
+		return "", PATRecord{}, fmt.Errorf("credential: invalid token use %q", tokenUse)
+	}
+	minted, err := MintOpaque(kind)
+	if err != nil {
+		return "", PATRecord{}, err
+	}
+	rec, err = s.pats.CreatePAT(ctx, PATRecord{
+		PublicID:  minted.PublicID,
+		UserID:    userID,
+		Name:      name,
+		TokenHash: minted.TokenHash,
+		Last4:     minted.Last4,
+		// Retain the legacy NOT NULL column without granting a second authority
+		// model. Existing non-empty scope sets are ignored when resolving a PAT.
+		Scopes:    []string{},
+		TokenUse:  tokenUse,
+		ExpiresAt: expiresAt,
+	})
+	if err != nil {
+		return "", PATRecord{}, fmt.Errorf("credential: create %s token: %w", tokenUse, err)
+	}
+	return minted.Plaintext, rec, nil
 }

--- a/internal/credential/resolver_test.go
+++ b/internal/credential/resolver_test.go
@@ -34,7 +34,17 @@ func (f *fakeStore) GetPATByPublicID(_ context.Context, publicID string) (PATRec
 func (f *fakeStore) ListPATByUser(_ context.Context, userID string) ([]PATRecord, error) {
 	var out []PATRecord
 	for _, r := range f.byPublicID {
-		if r.UserID == userID {
+		if r.UserID == userID && r.TokenUse == TokenUsePersonal {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeStore) ListProvisioningTokenByUser(_ context.Context, userID string) ([]PATRecord, error) {
+	var out []PATRecord
+	for _, r := range f.byPublicID {
+		if r.UserID == userID && r.TokenUse == TokenUseProvisioning {
 			out = append(out, r)
 		}
 	}
@@ -43,7 +53,19 @@ func (f *fakeStore) ListPATByUser(_ context.Context, userID string) ([]PATRecord
 
 func (f *fakeStore) RevokePAT(_ context.Context, id, userID string) (int64, error) {
 	for k, r := range f.byPublicID {
-		if r.ID == id && r.UserID == userID && r.RevokedAt == nil {
+		if r.ID == id && r.UserID == userID && r.TokenUse == TokenUsePersonal && r.RevokedAt == nil {
+			now := time.Now()
+			r.RevokedAt = &now
+			f.byPublicID[k] = r
+			return 1, nil
+		}
+	}
+	return 0, nil
+}
+
+func (f *fakeStore) RevokeProvisioningToken(_ context.Context, id, userID string) (int64, error) {
+	for k, r := range f.byPublicID {
+		if r.ID == id && r.UserID == userID && r.TokenUse == TokenUseProvisioning && r.RevokedAt == nil {
 			now := time.Now()
 			r.RevokedAt = &now
 			f.byPublicID[k] = r
@@ -235,5 +257,112 @@ func TestResolveRefreshTokenHardRejected(t *testing.T) {
 	p, err := svc.Resolve(context.Background(), "Bearer stella_ort_refreshtoken")
 	if p != nil || err == nil {
 		t.Fatalf("refresh token must be hard-rejected at the API boundary; got p=%v err=%v", p, err)
+	}
+}
+
+func TestProvisioningTokenRequiresActiveAdminAndCarriesCredentialID(t *testing.T) {
+	svc, store := newTestService(t)
+	ctx := context.Background()
+	store.users["u1"] = Identity{UserID: "u1", Email: "u1@x", IsActive: true, Role: "admin", IsAdmin: true}
+
+	plaintext, rec, err := svc.CreateProvisioningToken(ctx, "u1", "scim", time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("create provisioning token: %v", err)
+	}
+	p, err := svc.Resolve(ctx, "Bearer "+plaintext)
+	if err != nil {
+		t.Fatalf("resolve provisioning token: %v", err)
+	}
+	if p.Kind != KindProvisioning || p.CredentialID != rec.ID || len(p.Scopes) != 0 {
+		t.Fatalf("provisioning principal = %+v, want kind, credential ID, and no scopes", p)
+	}
+
+	store.users["u1"] = Identity{UserID: "u1", Email: "u1@x", IsActive: true, Role: "user"}
+	if _, err := svc.Resolve(ctx, "Bearer "+plaintext); err == nil {
+		t.Fatal("demoted provisioning owner must be denied")
+	}
+	if _, _, err := svc.CreateProvisioningToken(ctx, "u1", "after-demotion", time.Now().Add(time.Hour)); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("demoted owner create error = %v, want ErrForbidden", err)
+	}
+	store.users["u1"] = Identity{UserID: "u1", Email: "u1@x", IsActive: false, Role: "admin", IsAdmin: true}
+	if _, err := svc.Resolve(ctx, "Bearer "+plaintext); err == nil {
+		t.Fatal("deactivated provisioning owner must be denied")
+	}
+}
+
+func TestProvisioningTokenActiveLimit(t *testing.T) {
+	svc, store := newTestService(t)
+	ctx := context.Background()
+	store.users["u1"] = Identity{UserID: "u1", Email: "u1@x", IsActive: true, Role: "admin", IsAdmin: true}
+
+	for _, name := range []string{"current", "rotation-overlap"} {
+		if _, _, err := svc.CreateProvisioningToken(ctx, "u1", name, time.Now().Add(time.Hour)); err != nil {
+			t.Fatalf("create %s provisioning token: %v", name, err)
+		}
+	}
+	if _, _, err := svc.CreateProvisioningToken(ctx, "u1", "third", time.Now().Add(time.Hour)); !errors.Is(err, ErrProvisioningTokenLimit) {
+		t.Fatalf("third active provisioning token error = %v, want ErrProvisioningTokenLimit", err)
+	}
+}
+
+func TestProvisioningTokenRejectsPurposeMismatchExpiryAndRevocation(t *testing.T) {
+	svc, store := newTestService(t)
+	ctx := context.Background()
+	store.users["u1"] = Identity{UserID: "u1", Email: "u1@x", IsActive: true, Role: "admin", IsAdmin: true}
+
+	plaintext, rec, err := svc.CreateProvisioningToken(ctx, "u1", "scim", time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("create provisioning token: %v", err)
+	}
+	mismatch := store.byPublicID[rec.PublicID]
+	mismatch.TokenUse = TokenUsePersonal
+	store.byPublicID[rec.PublicID] = mismatch
+	if _, err := svc.Resolve(ctx, "Bearer "+plaintext); err == nil {
+		t.Fatal("provisioning prefix with personal stored use must be denied")
+	}
+
+	expired, expiredRec, err := svc.CreateProvisioningToken(ctx, "u1", "expired", time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("create expired fixture: %v", err)
+	}
+	r := store.byPublicID[expiredRec.PublicID]
+	past := time.Now().Add(-time.Hour)
+	r.ExpiresAt = &past
+	store.byPublicID[expiredRec.PublicID] = r
+	if _, err := svc.Resolve(ctx, "Bearer "+expired); err == nil {
+		t.Fatal("expired provisioning token must be denied")
+	}
+
+	revoked, revokedRec, err := svc.CreateProvisioningToken(ctx, "u1", "revoked", time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("create revoked fixture: %v", err)
+	}
+	if ok, err := svc.RevokeProvisioningToken(ctx, revokedRec.ID, "u1"); err != nil || !ok {
+		t.Fatalf("revoke provisioning token = %v, %v", ok, err)
+	}
+	if _, err := svc.Resolve(ctx, "Bearer "+revoked); err == nil {
+		t.Fatal("revoked provisioning token must be denied")
+	}
+}
+
+func TestTokenUseValidationHasOneAuthority(t *testing.T) {
+	for _, tc := range []struct {
+		use  TokenUse
+		want bool
+	}{
+		{TokenUsePersonal, true},
+		{TokenUseProvisioning, true},
+		{TokenUse("unknown"), false},
+	} {
+		if got := tc.use.Valid(); got != tc.want {
+			t.Errorf("TokenUse(%q).Valid() = %v, want %v", tc.use, got, tc.want)
+		}
+	}
+	svc, store := newTestService(t)
+	if _, _, err := svc.createToken(context.Background(), KindPAT, TokenUse("unknown"), "u1", "bad", nil); err == nil {
+		t.Fatal("invalid token use must not reach persistence")
+	}
+	if len(store.byPublicID) != 0 {
+		t.Fatal("invalid token use persisted a record")
 	}
 }

--- a/internal/credential/store_pg.go
+++ b/internal/credential/store_pg.go
@@ -39,6 +39,7 @@ func (p *PostgresStore) CreatePAT(ctx context.Context, rec PATRecord) (PATRecord
 		Last4:     rec.Last4,
 		Scopes:    rec.Scopes,
 		ExpiresAt: timestamptzFromPtr(rec.ExpiresAt),
+		TokenUse:  string(rec.TokenUse),
 	})
 	if err != nil {
 		return PATRecord{}, err
@@ -66,8 +67,24 @@ func (p *PostgresStore) ListPATByUser(ctx context.Context, userID string) ([]PAT
 	return out, nil
 }
 
+func (p *PostgresStore) ListProvisioningTokenByUser(ctx context.Context, userID string) ([]PATRecord, error) {
+	rows, err := p.q.ListProvisioningTokenByUser(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]PATRecord, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, patRecordFromRow(r))
+	}
+	return out, nil
+}
+
 func (p *PostgresStore) RevokePAT(ctx context.Context, id, userID string) (int64, error) {
 	return p.q.RevokePersonalAccessToken(ctx, sqlc.RevokePersonalAccessTokenParams{ID: id, UserID: userID})
+}
+
+func (p *PostgresStore) RevokeProvisioningToken(ctx context.Context, id, userID string) (int64, error) {
+	return p.q.RevokeProvisioningToken(ctx, sqlc.RevokeProvisioningTokenParams{ID: id, UserID: userID})
 }
 
 func (p *PostgresStore) RevokePATByUser(ctx context.Context, userID string) (int64, error) {
@@ -104,6 +121,7 @@ func patRecordFromRow(r sqlc.PersonalAccessToken) PATRecord {
 		TokenHash:  r.TokenHash,
 		Last4:      r.Last4,
 		Scopes:     r.Scopes,
+		TokenUse:   TokenUse(r.TokenUse),
 		ExpiresAt:  ptrFromTimestamptz(r.ExpiresAt),
 		LastUsedAt: ptrFromTimestamptz(r.LastUsedAt),
 		RevokedAt:  ptrFromTimestamptz(r.RevokedAt),

--- a/internal/db/migrations/90000000000002_add_provisioning_token_use.sql
+++ b/internal/db/migrations/90000000000002_add_provisioning_token_use.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+-- A constant default is metadata-only on supported PostgreSQL versions, so
+-- existing rows remain personal without a table rewrite. Bound the brief
+-- ALTER TABLE lock wait rather than queueing behind production traffic.
+SET LOCAL lock_timeout = '5s';
+ALTER TABLE personal_access_token
+    ADD COLUMN token_use TEXT NOT NULL DEFAULT 'personal';
+
+-- +goose Down
+SET LOCAL lock_timeout = '5s';
+ALTER TABLE personal_access_token
+    DROP COLUMN token_use;

--- a/internal/db/previous_ga_migration_test.go
+++ b/internal/db/previous_ga_migration_test.go
@@ -21,7 +21,7 @@ const (
 	previousGAVersion = int64(20260725161331)
 	// Knowledge V1 is the first post-anchor migration. The assertions below
 	// exercise its file, ChunkSet, chunk, and active-publication schema.
-	currentMigrationVersion = sequentialAnchor + 1
+	currentMigrationVersion = sequentialAnchor + 2
 
 	previousGAUserID         = "00000000-0000-0000-0000-000000000001"
 	previousGAGroupID        = "00000000-0000-0000-0000-000000000002"
@@ -131,6 +131,8 @@ func seedPreviousGAData(t *testing.T, ctx context.Context, db *pgxpool.Pool) {
 	}
 
 	exec("user", `INSERT INTO auth_user (id, email, created_at, updated_at) VALUES ($1, 'previous-ga@test.invalid', $2, $2)`, previousGAUserID, previousGATime)
+	exec("personal access token", `INSERT INTO personal_access_token (id, public_id, user_id, name, token_hash, last4, scopes, created_at, updated_at)
+		VALUES ('00000000-0000-0000-0000-000000000014', 'previous-ga-pat', $1, 'previous GA PAT', 'previous-ga-hash', '1234', ARRAY['goals:read'], $2, $2)`, previousGAUserID, previousGATime)
 	exec("agents", `INSERT INTO agent (id, name, workspace, created_at, updated_at) VALUES
 		($1, 'Previous GA Agent', '/tmp', $3, $3),
 		($2, 'Previous GA Cascade Agent', '/tmp', $3, $3)`, previousGAAgentID, previousGACascadeAgentID, previousGATime)
@@ -184,6 +186,13 @@ func assertPreviousGAUpgrade(t *testing.T, ctx context.Context, db *pgxpool.Pool
 			t.Fatalf("count %s: %v", name, err)
 		}
 		return got
+	}
+	var tokenUse string
+	if err := db.QueryRow(ctx, `SELECT token_use FROM personal_access_token WHERE public_id = 'previous-ga-pat'`).Scan(&tokenUse); err != nil {
+		t.Fatalf("read migrated personal access token use: %v", err)
+	}
+	if tokenUse != "personal" {
+		t.Fatalf("migrated personal access token use = %q, want personal", tokenUse)
 	}
 	if got := count("retired vault entries", `SELECT count(*) FROM vault_entry WHERE name IN ('LARK_CLI_OAUTH', 'FEISHU_CLI_OAUTH')`); got != 0 {
 		t.Fatalf("retired vault entries = %d, want 0", got)

--- a/internal/db/queries/personal_access_token.sql
+++ b/internal/db/queries/personal_access_token.sql
@@ -6,8 +6,9 @@ INSERT INTO personal_access_token (
     token_hash,
     last4,
     scopes,
-    expires_at
-) VALUES ($1, $2, $3, $4, $5, $6, $7)
+    expires_at,
+    token_use
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 RETURNING *;
 
 -- name: GetPersonalAccessTokenByPublicID :one
@@ -20,6 +21,13 @@ WHERE public_id = $1;
 -- name: ListPersonalAccessTokenByUser :many
 SELECT * FROM personal_access_token
 WHERE user_id = $1
+  AND token_use = 'personal'
+ORDER BY created_at DESC, id DESC;
+
+-- name: ListProvisioningTokenByUser :many
+SELECT * FROM personal_access_token
+WHERE user_id = $1
+  AND token_use = 'provisioning'
 ORDER BY created_at DESC, id DESC;
 
 -- name: RevokePersonalAccessToken :execrows
@@ -28,6 +36,16 @@ SET revoked_at = now(),
     updated_at = now()
 WHERE id = $1
   AND user_id = $2
+  AND token_use = 'personal'
+  AND revoked_at IS NULL;
+
+-- name: RevokeProvisioningToken :execrows
+UPDATE personal_access_token
+SET revoked_at = now(),
+    updated_at = now()
+WHERE id = $1
+  AND user_id = $2
+  AND token_use = 'provisioning'
   AND revoked_at IS NULL;
 
 -- name: RevokePersonalAccessTokenByUser :execrows

--- a/internal/server/architecture_boundary_test.go
+++ b/internal/server/architecture_boundary_test.go
@@ -1146,6 +1146,7 @@ var resourceAuthHelperAllowlist = map[string]bool{
 	"authorizeDBSkillRead":      true, // skills_scoped.go — routes a single DB-skill read through the skillaccess PEP
 	"requireAuth":               true, // middleware.go — authentication (not resource authz)
 	"requireAdmin":              true, // middleware.go — admin gate
+	"requireInteractiveAdmin":   true, // middleware.go — sole session-only credential-lifecycle gate
 	"requireAgentAccess":        true, // skills_scoped.go — agent access gate
 	"requireAgentUse":           true, // skills_scoped.go — agent execute gate
 	"requireAgentManage":        true, // skills_scoped.go — agent manage gate

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -175,6 +175,25 @@ func requireAdmin(w http.ResponseWriter, r *http.Request) *AuthInfo {
 	return info
 }
 
+// requireInteractiveAdmin is the sole gate for lifecycle actions that mint or
+// manage bearer credentials. A bearer may resolve to an admin account, but it
+// is not an interactive session and must never create its own replacement.
+func requireInteractiveAdmin(w http.ResponseWriter, r *http.Request) *AuthInfo {
+	info := requireAuth(w, r)
+	if info == nil {
+		return nil
+	}
+	if info.principal != nil {
+		writeError(w, http.StatusForbidden, "interactive admin session required")
+		return nil
+	}
+	if !info.IsAdmin {
+		writeError(w, http.StatusForbidden, "admin access required")
+		return nil
+	}
+	return info
+}
+
 // Public auth API paths that don't require a session.
 var publicAuthAPIPaths = []string{
 	"/api/auth/logout",

--- a/internal/server/provisioning_tokens.go
+++ b/internal/server/provisioning_tokens.go
@@ -1,0 +1,122 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	apitypes "github.com/CherryHQ/stella/api/types"
+	"github.com/CherryHQ/stella/internal/credential"
+)
+
+// ListProvisioningTokens handles GET /api/admin/provisioning-tokens. Only an
+// interactive admin session can inspect the provisioning credentials it owns.
+func (s *Server) ListProvisioningTokens(w http.ResponseWriter, r *http.Request) {
+	info := requireInteractiveAdmin(w, r)
+	if info == nil {
+		return
+	}
+	if s.credResolver == nil {
+		writeCapabilityUnavailable(w, capPAT)
+		return
+	}
+	recs, err := s.credResolver.ListProvisioningTokens(r.Context(), info.UserID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "list provisioning tokens failed")
+		return
+	}
+	out := make([]apitypes.ProvisioningToken, 0, len(recs))
+	for _, rec := range recs {
+		out = append(out, provisioningTokenToAPI(rec))
+	}
+	writeData(w, http.StatusOK, apitypes.ProvisioningTokenList{ProvisioningTokens: out})
+}
+
+// CreateProvisioningToken handles POST /api/admin/provisioning-tokens. The
+// plaintext token is intentionally returned exactly once and always expires.
+func (s *Server) CreateProvisioningToken(w http.ResponseWriter, r *http.Request) {
+	info := requireInteractiveAdmin(w, r)
+	if info == nil {
+		return
+	}
+	if s.credResolver == nil {
+		writeCapabilityUnavailable(w, capPAT)
+		return
+	}
+
+	var body apitypes.CreateProvisioningTokenRequest
+	if err := decodeJSON(r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	name := strings.TrimSpace(body.Name)
+	if name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	expiresAt, err := resolveProvisioningTokenExpiry(body.ExpiresAt, time.Now().UTC())
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	plaintext, rec, err := s.credResolver.CreateProvisioningToken(r.Context(), info.UserID, name, *expiresAt)
+	if err != nil {
+		if errors.Is(err, credential.ErrForbidden) {
+			writeError(w, http.StatusForbidden, "active admin account required")
+			return
+		}
+		if errors.Is(err, credential.ErrProvisioningTokenLimit) {
+			writeError(w, http.StatusConflict, "at most two active provisioning tokens are allowed")
+			return
+		}
+		s.log.Error("create provisioning token", "error", err, "user_id", info.UserID)
+		writeError(w, http.StatusInternalServerError, "create provisioning token failed")
+		return
+	}
+	writeData(w, http.StatusCreated, apitypes.CreateProvisioningTokenResponse{
+		Token:             plaintext,
+		ProvisioningToken: provisioningTokenToAPI(rec),
+	})
+}
+
+// RevokeProvisioningToken handles DELETE /api/admin/provisioning-tokens/{id}.
+func (s *Server) RevokeProvisioningToken(w http.ResponseWriter, r *http.Request, id string) {
+	info := requireInteractiveAdmin(w, r)
+	if info == nil {
+		return
+	}
+	if s.credResolver == nil {
+		writeCapabilityUnavailable(w, capPAT)
+		return
+	}
+	revoked, err := s.credResolver.RevokeProvisioningToken(r.Context(), id, info.UserID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "revoke provisioning token failed")
+		return
+	}
+	if !revoked {
+		writeError(w, http.StatusNotFound, "provisioning token not found")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func provisioningTokenToAPI(rec credential.PATRecord) apitypes.ProvisioningToken {
+	return apitypes.ProvisioningToken{
+		Id:         rec.ID,
+		Name:       rec.Name,
+		Last4:      rec.Last4,
+		ExpiresAt:  rec.ExpiresAt,
+		LastUsedAt: rec.LastUsedAt,
+		RevokedAt:  rec.RevokedAt,
+		CreatedAt:  rec.CreatedAt,
+	}
+}
+
+// resolveProvisioningTokenExpiry applies the normal 90-day default and one-year
+// ceiling but deliberately provides no never-expiring escape hatch.
+func resolveProvisioningTokenExpiry(expiresAt *time.Time, now time.Time) (*time.Time, error) {
+	return resolvePATExpiry(expiresAt, false, now)
+}

--- a/internal/server/provisioning_tokens_integration_test.go
+++ b/internal/server/provisioning_tokens_integration_test.go
@@ -1,0 +1,186 @@
+package server_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/CherryHQ/stella/internal/auth"
+)
+
+type provisioningTokenResponse struct {
+	Token             string `json:"token"`
+	ProvisioningToken struct {
+		ID        string     `json:"id"`
+		ExpiresAt *time.Time `json:"expires_at"`
+	} `json:"provisioning_token"`
+}
+
+func createProvisioningToken(t *testing.T, srvToken string, env *testEnv, name string, body map[string]any) provisioningTokenResponse {
+	t.Helper()
+	if body == nil {
+		body = map[string]any{"name": name}
+	}
+	rr := doRequestWithSession(t, env.srv, srvToken, http.MethodPost, "/api/admin/provisioning-tokens", body)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create provisioning token: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var out provisioningTokenResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode provisioning token: %v", err)
+	}
+	if out.Token == "" || !strings.HasPrefix(out.Token, "stella_prv_") || out.ProvisioningToken.ID == "" {
+		t.Fatalf("create response must contain one-time provisioning token and metadata: %s", rr.Body.String())
+	}
+	return out
+}
+
+// TestProvisioningTokenLifecycle proves the complete interactive-admin lifecycle
+// while retaining strict metadata and personal/provisioning isolation.
+func TestProvisioningTokenLifecycle(t *testing.T) {
+	env := setupAdmin(t)
+	ctx := context.Background()
+	created := createProvisioningToken(t, env.bearerToken, env, "directory-sync", nil)
+
+	if created.ProvisioningToken.ExpiresAt == nil {
+		t.Fatal("provisioning tokens must default to an expiry")
+	}
+	if d := time.Until(*created.ProvisioningToken.ExpiresAt); d < 89*24*time.Hour || d > 91*24*time.Hour {
+		t.Fatalf("default expiry want ~90d, got %v", d)
+	}
+	var tokenUse, tokenHash string
+	var expiresAt *time.Time
+	if err := env.db.QueryRow(ctx, "select token_use, token_hash, expires_at from personal_access_token where id=$1", created.ProvisioningToken.ID).Scan(&tokenUse, &tokenHash, &expiresAt); err != nil {
+		t.Fatalf("query provisioning token: %v", err)
+	}
+	if tokenUse != "provisioning" || tokenHash == created.Token || expiresAt == nil {
+		t.Fatalf("stored provisioning token use=%q hash plaintext=%v expiry=%v", tokenUse, tokenHash == created.Token, expiresAt)
+	}
+
+	// The resource list exposes metadata only, never plaintext, hashes, or the
+	// legacy scope column. A normal personal token stays out of this list.
+	personal, personalID := mintPAT(t, env, env.bearerToken, "personal-isolation")
+	if personal == "" || personalID == "" {
+		t.Fatal("personal token fixture missing")
+	}
+	list := doRequest(t, env, http.MethodGet, "/api/admin/provisioning-tokens", nil)
+	if list.Code != http.StatusOK {
+		t.Fatalf("list provisioning tokens: %d %s", list.Code, list.Body.String())
+	}
+	if strings.Contains(list.Body.String(), created.Token) || strings.Contains(list.Body.String(), "token_hash") || strings.Contains(list.Body.String(), "scopes") || strings.Contains(list.Body.String(), personalID) {
+		t.Fatalf("provisioning list leaked secret/internal data or personal token: %s", list.Body.String())
+	}
+	personalList := doRequest(t, env, http.MethodGet, "/api/users/me/tokens", nil)
+	if personalList.Code != http.StatusOK || !strings.Contains(personalList.Body.String(), personalID) || strings.Contains(personalList.Body.String(), created.ProvisioningToken.ID) {
+		t.Fatalf("personal list must isolate provisioning token: %d %s", personalList.Code, personalList.Body.String())
+	}
+	if rr := doRequest(t, env, http.MethodGet, "/api/users/me/tokens/"+created.ProvisioningToken.ID, nil); rr.Code != http.StatusNotFound {
+		t.Fatalf("personal get must not see provisioning token: want 404 got %d (%s)", rr.Code, rr.Body.String())
+	}
+	if rr := doRequest(t, env, http.MethodDelete, "/api/users/me/tokens/"+created.ProvisioningToken.ID, nil); rr.Code != http.StatusNotFound {
+		t.Fatalf("personal revoke must not manage provisioning token: want 404 got %d (%s)", rr.Code, rr.Body.String())
+	}
+
+	// The public contract intentionally has no never_expires field; an obsolete
+	// JSON member cannot manufacture an unbounded provisioning credential.
+	legacy := createProvisioningToken(t, env.bearerToken, env, "legacy", map[string]any{"name": "legacy", "never_expires": true})
+	if legacy.ProvisioningToken.ExpiresAt == nil {
+		t.Fatal("unknown never_expires field must not remove provisioning expiry")
+	}
+	if rr := doRequest(t, env, http.MethodPost, "/api/admin/provisioning-tokens", map[string]any{"name": "third"}); rr.Code != http.StatusConflict {
+		t.Fatalf("third active provisioning token: want 409 got %d (%s)", rr.Code, rr.Body.String())
+	}
+	if rr := doRequest(t, env, http.MethodDelete, "/api/admin/provisioning-tokens/"+legacy.ProvisioningToken.ID, nil); rr.Code != http.StatusNoContent {
+		t.Fatalf("revoke rotation-overlap token: want 204 got %d (%s)", rr.Code, rr.Body.String())
+	}
+	for _, body := range []map[string]any{
+		{"name": "", "expires_at": time.Now().Add(time.Hour).Format(time.RFC3339)},
+		{"name": "past", "expires_at": time.Now().Add(-time.Hour).Format(time.RFC3339)},
+		{"name": "long", "expires_at": time.Now().Add(366 * 24 * time.Hour).Format(time.RFC3339)},
+	} {
+		if rr := doRequest(t, env, http.MethodPost, "/api/admin/provisioning-tokens", body); rr.Code != http.StatusBadRequest {
+			t.Fatalf("invalid provisioning create %#v: want 400 got %d (%s)", body, rr.Code, rr.Body.String())
+		}
+	}
+	expired := createProvisioningToken(t, env.bearerToken, env, "expired", nil)
+	if _, err := env.db.Exec(ctx, "update personal_access_token set expires_at = now() - interval '1 hour' where id=$1", expired.ProvisioningToken.ID); err != nil {
+		t.Fatalf("force-expire provisioning token: %v", err)
+	}
+	if rr := doBearerRequest(t, env.srv, expired.Token, http.MethodGet, "/api/provisioned-users", nil); rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expired provisioning bearer: want 401 got %d (%s)", rr.Code, rr.Body.String())
+	}
+
+	if rr := doRequest(t, env, http.MethodDelete, "/api/admin/provisioning-tokens/"+created.ProvisioningToken.ID, nil); rr.Code != http.StatusNoContent {
+		t.Fatalf("revoke provisioning token: want 204 got %d (%s)", rr.Code, rr.Body.String())
+	}
+	if rr := doBearerRequest(t, env.srv, created.Token, http.MethodGet, "/api/provisioned-users", nil); rr.Code != http.StatusUnauthorized {
+		t.Fatalf("revoked provisioning bearer: want 401 got %d (%s)", rr.Code, rr.Body.String())
+	}
+}
+
+// TestProvisioningTokenSessionAndOwnerGuards proves no bearer can mint, list,
+// or revoke this credential family, and owner role/active state applies at use.
+func TestProvisioningTokenSessionAndOwnerGuards(t *testing.T) {
+	env := setupAdmin(t)
+	created := createProvisioningToken(t, env.bearerToken, env, "guard", nil)
+	adminPAT, _ := mintPAT(t, env, env.bearerToken, "admin-bearer")
+	clientID, secret := registerOAuthClientAPI(t, env, "https://provision.example/cb", []string{"agent:read"})
+	code := authorizeOAuthClient(t, env.srv, env.bearerToken, clientID, "https://provision.example/cb", "agent:read")
+	oauthToken := exchangeOAuthToken(t, env.srv, url.Values{
+		"grant_type":    {"authorization_code"},
+		"client_id":     {clientID},
+		"client_secret": {secret},
+		"code":          {code},
+		"redirect_uri":  {"https://provision.example/cb"},
+	}).AccessToken
+	for _, bearer := range []string{adminPAT, oauthToken, created.Token} {
+		for _, tc := range []struct{ method, path string }{
+			{http.MethodGet, "/api/admin/provisioning-tokens"},
+			{http.MethodPost, "/api/admin/provisioning-tokens"},
+			{http.MethodDelete, "/api/admin/provisioning-tokens/" + created.ProvisioningToken.ID},
+		} {
+			if rr := doBearerRequest(t, env.srv, bearer, tc.method, tc.path, map[string]any{"name": "self-mint"}); rr.Code != http.StatusForbidden {
+				t.Fatalf("bearer %s %s: want 403 got %d (%s)", tc.method, tc.path, rr.Code, rr.Body.String())
+			}
+		}
+	}
+	_, userSession := createTestUserWithToken(t, env.authStore, env.oidcStore, "provision-non-admin", auth.RoleUser)
+	for _, tc := range []struct{ method, path string }{
+		{http.MethodGet, "/api/admin/provisioning-tokens"},
+		{http.MethodPost, "/api/admin/provisioning-tokens"},
+		{http.MethodDelete, "/api/admin/provisioning-tokens/" + created.ProvisioningToken.ID},
+	} {
+		if rr := doRequestWithSession(t, env.srv, userSession, tc.method, tc.path, map[string]any{"name": "nope"}); rr.Code != http.StatusForbidden {
+			t.Fatalf("non-admin session %s %s: want 403 got %d (%s)", tc.method, tc.path, rr.Code, rr.Body.String())
+		}
+	}
+
+	owner, ownerSession := createTestUserWithToken(t, env.authStore, env.oidcStore, "provision-owner", auth.RoleAdmin)
+	owned := createProvisioningToken(t, ownerSession, env, "owned", nil)
+	if rr := doRequestWithSession(t, env.srv, ownerSession, http.MethodGet, "/api/admin/provisioning-tokens", nil); rr.Code != http.StatusOK || strings.Contains(rr.Body.String(), created.ProvisioningToken.ID) || !strings.Contains(rr.Body.String(), owned.ProvisioningToken.ID) {
+		t.Fatalf("owner provisioning list must be isolated: %d %s", rr.Code, rr.Body.String())
+	}
+	if rr := doRequest(t, env, http.MethodPatch, "/api/users/"+owner.ID+"/role", map[string]any{"role": auth.RoleUser}); rr.Code != http.StatusOK {
+		t.Fatalf("demote provisioning owner: %d %s", rr.Code, rr.Body.String())
+	}
+	if rr := doBearerRequest(t, env.srv, owned.Token, http.MethodGet, "/api/provisioned-users", nil); rr.Code != http.StatusUnauthorized {
+		t.Fatalf("demoted owner token: want 401 got %d (%s)", rr.Code, rr.Body.String())
+	}
+
+	owner2, owner2Session := createTestUserWithToken(t, env.authStore, env.oidcStore, "provision-deactivate", auth.RoleAdmin)
+	deactivated := createProvisioningToken(t, owner2Session, env, "deactivated", nil)
+	if rr := doRequest(t, env, http.MethodPatch, "/api/users/"+owner2.ID+"/active", map[string]any{"is_active": false}); rr.Code != http.StatusOK {
+		t.Fatalf("deactivate provisioning owner: %d %s", rr.Code, rr.Body.String())
+	}
+	var revokedAt *time.Time
+	if err := env.db.QueryRow(context.Background(), "select revoked_at from personal_access_token where id=$1", deactivated.ProvisioningToken.ID).Scan(&revokedAt); err != nil || revokedAt == nil {
+		t.Fatalf("deactivation must revoke provisioning token: revoked_at=%v err=%v", revokedAt, err)
+	}
+	if rr := doBearerRequest(t, env.srv, deactivated.Token, http.MethodGet, "/api/provisioned-users", nil); rr.Code != http.StatusUnauthorized {
+		t.Fatalf("deactivated owner token: want 401 got %d (%s)", rr.Code, rr.Body.String())
+	}
+}

--- a/pkg/db/sqlc/models.go
+++ b/pkg/db/sqlc/models.go
@@ -723,6 +723,7 @@ type PersonalAccessToken struct {
 	RevokedAt  pgtype.Timestamptz `json:"revoked_at"`
 	CreatedAt  time.Time          `json:"created_at"`
 	UpdatedAt  time.Time          `json:"updated_at"`
+	TokenUse   string             `json:"token_use"`
 }
 
 type Plugin struct {

--- a/pkg/db/sqlc/personal_access_token.sql.go
+++ b/pkg/db/sqlc/personal_access_token.sql.go
@@ -19,9 +19,10 @@ INSERT INTO personal_access_token (
     token_hash,
     last4,
     scopes,
-    expires_at
-) VALUES ($1, $2, $3, $4, $5, $6, $7)
-RETURNING id, public_id, user_id, name, token_hash, last4, scopes, expires_at, last_used_at, revoked_at, created_at, updated_at
+    expires_at,
+    token_use
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+RETURNING id, public_id, user_id, name, token_hash, last4, scopes, expires_at, last_used_at, revoked_at, created_at, updated_at, token_use
 `
 
 type CreatePersonalAccessTokenParams struct {
@@ -32,6 +33,7 @@ type CreatePersonalAccessTokenParams struct {
 	Last4     string             `json:"last4"`
 	Scopes    []string           `json:"scopes"`
 	ExpiresAt pgtype.Timestamptz `json:"expires_at"`
+	TokenUse  string             `json:"token_use"`
 }
 
 func (q *Queries) CreatePersonalAccessToken(ctx context.Context, arg CreatePersonalAccessTokenParams) (PersonalAccessToken, error) {
@@ -43,6 +45,7 @@ func (q *Queries) CreatePersonalAccessToken(ctx context.Context, arg CreatePerso
 		arg.Last4,
 		arg.Scopes,
 		arg.ExpiresAt,
+		arg.TokenUse,
 	)
 	var i PersonalAccessToken
 	err := row.Scan(
@@ -58,12 +61,13 @@ func (q *Queries) CreatePersonalAccessToken(ctx context.Context, arg CreatePerso
 		&i.RevokedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TokenUse,
 	)
 	return i, err
 }
 
 const getPersonalAccessTokenByPublicID = `-- name: GetPersonalAccessTokenByPublicID :one
-SELECT id, public_id, user_id, name, token_hash, last4, scopes, expires_at, last_used_at, revoked_at, created_at, updated_at FROM personal_access_token
+SELECT id, public_id, user_id, name, token_hash, last4, scopes, expires_at, last_used_at, revoked_at, created_at, updated_at, token_use FROM personal_access_token
 WHERE public_id = $1
 `
 
@@ -86,13 +90,15 @@ func (q *Queries) GetPersonalAccessTokenByPublicID(ctx context.Context, publicID
 		&i.RevokedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.TokenUse,
 	)
 	return i, err
 }
 
 const listPersonalAccessTokenByUser = `-- name: ListPersonalAccessTokenByUser :many
-SELECT id, public_id, user_id, name, token_hash, last4, scopes, expires_at, last_used_at, revoked_at, created_at, updated_at FROM personal_access_token
+SELECT id, public_id, user_id, name, token_hash, last4, scopes, expires_at, last_used_at, revoked_at, created_at, updated_at, token_use FROM personal_access_token
 WHERE user_id = $1
+  AND token_use = 'personal'
 ORDER BY created_at DESC, id DESC
 `
 
@@ -118,6 +124,48 @@ func (q *Queries) ListPersonalAccessTokenByUser(ctx context.Context, userID stri
 			&i.RevokedAt,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.TokenUse,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listProvisioningTokenByUser = `-- name: ListProvisioningTokenByUser :many
+SELECT id, public_id, user_id, name, token_hash, last4, scopes, expires_at, last_used_at, revoked_at, created_at, updated_at, token_use FROM personal_access_token
+WHERE user_id = $1
+  AND token_use = 'provisioning'
+ORDER BY created_at DESC, id DESC
+`
+
+func (q *Queries) ListProvisioningTokenByUser(ctx context.Context, userID string) ([]PersonalAccessToken, error) {
+	rows, err := q.db.Query(ctx, listProvisioningTokenByUser, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []PersonalAccessToken{}
+	for rows.Next() {
+		var i PersonalAccessToken
+		if err := rows.Scan(
+			&i.ID,
+			&i.PublicID,
+			&i.UserID,
+			&i.Name,
+			&i.TokenHash,
+			&i.Last4,
+			&i.Scopes,
+			&i.ExpiresAt,
+			&i.LastUsedAt,
+			&i.RevokedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.TokenUse,
 		); err != nil {
 			return nil, err
 		}
@@ -135,6 +183,7 @@ SET revoked_at = now(),
     updated_at = now()
 WHERE id = $1
   AND user_id = $2
+  AND token_use = 'personal'
   AND revoked_at IS NULL
 `
 
@@ -162,6 +211,29 @@ WHERE user_id = $1
 // Cascade-revoke all of a user's PATs (e.g. on account deactivation).
 func (q *Queries) RevokePersonalAccessTokenByUser(ctx context.Context, userID string) (int64, error) {
 	result, err := q.db.Exec(ctx, revokePersonalAccessTokenByUser, userID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const revokeProvisioningToken = `-- name: RevokeProvisioningToken :execrows
+UPDATE personal_access_token
+SET revoked_at = now(),
+    updated_at = now()
+WHERE id = $1
+  AND user_id = $2
+  AND token_use = 'provisioning'
+  AND revoked_at IS NULL
+`
+
+type RevokeProvisioningTokenParams struct {
+	ID     string `json:"id"`
+	UserID string `json:"user_id"`
+}
+
+func (q *Queries) RevokeProvisioningToken(ctx context.Context, arg RevokeProvisioningTokenParams) (int64, error) {
+	result, err := q.db.Exec(ctx, revokeProvisioningToken, arg.ID, arg.UserID)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
## What

Add a dedicated, expiring `stella_prv_` provisioning credential and its interactive-admin lifecycle API.

This is stack layer 2/3, based on #890. The managed-user resource API is in #893.

## Why

An admin PAT is account-equivalent and deliberately cannot mint credentials. Enterprise automation needs a narrower bearer whose only authority is the provisioning workflow, without reopening credential proliferation.

## How

- Add code-owned `KindProvisioning` / `token_use=provisioning` with prefix-purpose mismatch rejection.
- Resolve the owner on every request and require an active admin.
- Allow only the segment-aware `/api/provisioned-users` family; deny every other API/page route.
- Add `/api/admin/provisioning-tokens` create/list/revoke endpoints gated to interactive admin sessions.
- Store hashes only, return plaintext once, require expiry (90-day default, 365-day ceiling), isolate personal/provisioning token lists, and cap overlap at two active provisioning tokens.

## Test

- Migration validation and API/sqlc generation — passed
- `mise run format && mise run build && mise run test` — passed
- Focused resolver, enforcement, and live-PostgreSQL server integration tests — passed

## Refs

Refs #891

## Checklist

- [x] The PR links a GitHub issue.
- [x] I added focused tests for changed non-trivial behavior.
- [x] No user documentation is added in this foundation layer; #893 documents the complete workflow in English and Chinese.
- [x] I ran `mise run format && mise run build && mise run test`.
