### PR TITLE
test(memory): add PersonaMem benchmark baseline

### DIFF
--- a/cmd/stellad/memory_benchmark_helpers_test.go
+++ b/cmd/stellad/memory_benchmark_helpers_test.go
@@ -1,0 +1,468 @@
+//go:build personamemeval
+
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/CherryHQ/stella/internal/agent/runtime"
+	"github.com/CherryHQ/stella/internal/auth"
+	"github.com/CherryHQ/stella/internal/config"
+	"github.com/CherryHQ/stella/internal/memory"
+	"github.com/CherryHQ/stella/pkg/tools"
+)
+
+const (
+	memoryBenchmarkToolName               = "memory"
+	memoryBenchmarkBudgetExhaustedMessage = "Memory lookup budget exhausted. Answer now using evidence already retrieved."
+)
+
+type memoryBenchmarkKnowledgeUsageRow struct {
+	FactID     string    `json:"fact_id"`
+	LastUsedAt time.Time `json:"last_used_at"`
+	CreatedAt  time.Time `json:"created_at"`
+}
+
+type memoryBenchmarkPendingQuestion struct {
+	QAIndex   int                                `json:"qa_index"`
+	SessionID string                             `json:"session_id"`
+	Usage     []memoryBenchmarkKnowledgeUsageRow `json:"usage"`
+}
+
+type memoryBenchmarkRemoteModelMetadata struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	Created int64  `json:"created"`
+	OwnedBy string `json:"owned_by"`
+}
+
+// frozenMemoryBenchmarkTool prevents a benchmark question from retrieving
+// messages written by its own temporary QA session while preserving production
+// memory behavior for the frozen conversation history.
+type frozenMemoryBenchmarkTool struct {
+	inner            tools.Tool
+	blockedSessionID string
+	maxCalls         int32
+	calls            atomic.Int32
+}
+
+func newFrozenMemoryBenchmarkTool(provider memory.Provider, blockedSessionID string, maxCalls int) tools.Tool {
+	return &frozenMemoryBenchmarkTool{
+		inner:            memory.BuildTool(provider, memory.WithSessionReadOnlyWrites()),
+		blockedSessionID: blockedSessionID,
+		maxCalls:         int32(maxCalls),
+	}
+}
+
+func (tool *frozenMemoryBenchmarkTool) Definition() tools.Definition {
+	return tool.inner.Definition()
+}
+
+func (tool *frozenMemoryBenchmarkTool) Execute(ctx context.Context, args map[string]any) (string, error) {
+	if tool.calls.Add(1) > tool.maxCalls {
+		return memoryBenchmarkBudgetExhaustedMessage, nil
+	}
+	if action, _ := args["action"].(string); action != "search" {
+		return tool.inner.Execute(ctx, args)
+	}
+
+	requestedLimit := memoryBenchmarkIntArg(args, "limit", 20)
+	searchArgs := make(map[string]any, len(args))
+	for key, value := range args {
+		searchArgs[key] = value
+	}
+	// Overfetch before removing current-session rows so historical hits can
+	// still fill the model-requested result count.
+	searchArgs["limit"] = min(requestedLimit+64, 100)
+	result, err := tool.inner.Execute(ctx, searchArgs)
+	if err != nil || result == "No matches found." {
+		return result, err
+	}
+
+	var hits []memory.SearchResult
+	if err := json.Unmarshal([]byte(result), &hits); err != nil {
+		return "", fmt.Errorf("decode benchmark memory search: %w", err)
+	}
+	filtered := make([]memory.SearchResult, 0, min(len(hits), requestedLimit))
+	for _, hit := range hits {
+		if hit.SessionID == tool.blockedSessionID {
+			continue
+		}
+		filtered = append(filtered, hit)
+		if len(filtered) == requestedLimit {
+			break
+		}
+	}
+	if len(filtered) == 0 {
+		return "No matches found.", nil
+	}
+	payload, err := json.MarshalIndent(filtered, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("encode benchmark memory search: %w", err)
+	}
+	return string(payload), nil
+}
+
+func memoryBenchmarkIntArg(args map[string]any, key string, defaultValue int) int {
+	value, ok := args[key]
+	if !ok {
+		return defaultValue
+	}
+	var result int
+	switch number := value.(type) {
+	case int:
+		result = number
+	case float64:
+		result = int(number)
+	case json.Number:
+		parsed, err := strconv.Atoi(number.String())
+		if err != nil {
+			return defaultValue
+		}
+		result = parsed
+	default:
+		return defaultValue
+	}
+	if result <= 0 {
+		return defaultValue
+	}
+	return result
+}
+
+func configureMemoryBenchmarkAgent(
+	ctx context.Context,
+	setupState *setupResult,
+	agentID string,
+	agentName string,
+	providerID string,
+	modelID string,
+) (config.Agent, error) {
+	agentCfg, err := setupState.store.GetAgent(ctx, agentID)
+	if err != nil {
+		return config.Agent{}, fmt.Errorf("load benchmark agent %q: %w", agentID, err)
+	}
+	modelRef := providerID + "/" + modelID
+	agentCfg.Name = agentName
+	agentCfg.Enabled = true
+	agentCfg.SystemPrompt = ""
+	agentCfg.Soul = ""
+	agentCfg.Workspace = ""
+	agentCfg.Sandbox = config.SandboxConfig{}
+	agentCfg.Scope = config.AgentScopeSystem
+	agentCfg.Model = modelRef
+	agentCfg.ModelStrong = modelRef
+	agentCfg.ModelFast = modelRef
+	agentCfg.ModelThinking = ""
+	agentCfg.ModelStrongThinking = ""
+	agentCfg.ModelFastThinking = ""
+	if err := setupState.store.UpdateAgent(ctx, agentCfg); err != nil {
+		return config.Agent{}, fmt.Errorf("configure benchmark agent: %w", err)
+	}
+	if err := setupState.poolManager.SyncAgent(ctx, agentCfg.ID); err != nil {
+		return config.Agent{}, fmt.Errorf("reload benchmark agent: %w", err)
+	}
+	return agentCfg, nil
+}
+
+func collectMemoryBenchmarkAnswer(stream <-chan runtime.Event) (string, []string, error) {
+	var current strings.Builder
+	var fallback strings.Builder
+	final := ""
+	toolSet := make(map[string]struct{})
+	for event := range stream {
+		if event.Err != nil {
+			return "", nil, event.Err
+		}
+		if event.Step != nil && event.Step.Kind == "start" {
+			current.Reset()
+		}
+		if event.Text != "" {
+			current.WriteString(event.Text)
+			fallback.WriteString(event.Text)
+		}
+		if event.ToolUse != nil && event.ToolUse.Tool != "" {
+			toolSet[event.ToolUse.Tool] = struct{}{}
+		}
+		if event.Step != nil && event.Step.Kind == "finish" {
+			if text := strings.TrimSpace(current.String()); text != "" {
+				final = text
+			}
+		}
+	}
+	if final == "" {
+		final = strings.TrimSpace(fallback.String())
+	}
+	toolsUsed := make([]string, 0, len(toolSet))
+	for name := range toolSet {
+		toolsUsed = append(toolsUsed, name)
+	}
+	sort.Strings(toolsUsed)
+	return final, toolsUsed, nil
+}
+
+func snapshotMemoryBenchmarkKnowledgeUsage(
+	ctx context.Context,
+	setupState *setupResult,
+	userID string,
+	agentID string,
+) ([]memoryBenchmarkKnowledgeUsageRow, error) {
+	rows, err := setupState.db.Query(ctx, `
+		SELECT fact_id::text, last_used_at, created_at
+		FROM knowledge_usage
+		WHERE user_id = $1 AND agent_id = $2
+		ORDER BY fact_id`, userID, agentID)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot knowledge usage: %w", err)
+	}
+	defer rows.Close()
+	var result []memoryBenchmarkKnowledgeUsageRow
+	for rows.Next() {
+		var item memoryBenchmarkKnowledgeUsageRow
+		if err := rows.Scan(&item.FactID, &item.LastUsedAt, &item.CreatedAt); err != nil {
+			return nil, err
+		}
+		result = append(result, item)
+	}
+	return result, rows.Err()
+}
+
+func restoreMemoryBenchmarkKnowledgeUsage(
+	ctx context.Context,
+	setupState *setupResult,
+	userID string,
+	agentID string,
+	usage []memoryBenchmarkKnowledgeUsageRow,
+) error {
+	tx, err := setupState.db.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := tx.Exec(ctx, `DELETE FROM knowledge_usage WHERE user_id = $1 AND agent_id = $2`, userID, agentID); err != nil {
+		return fmt.Errorf("clear knowledge usage: %w", err)
+	}
+	for _, item := range usage {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO knowledge_usage (fact_id, user_id, agent_id, last_used_at, created_at)
+			VALUES ($1, $2, $3, $4, $5)`, item.FactID, userID, agentID, item.LastUsedAt, item.CreatedAt); err != nil {
+			return fmt.Errorf("restore knowledge usage %s: %w", item.FactID, err)
+		}
+	}
+	return tx.Commit(ctx)
+}
+
+func recoverMemoryBenchmarkPendingQuestion(
+	ctx context.Context,
+	setupState *setupResult,
+	userID string,
+	agentID string,
+	pending *memoryBenchmarkPendingQuestion,
+) error {
+	if pending == nil {
+		return nil
+	}
+	if service := setupState.poolManager.GetService(agentID); service != nil {
+		_ = service.Runtime.CloseSession(ctx, pending.SessionID)
+	}
+	tx, err := setupState.db.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := tx.Exec(ctx, `DELETE FROM ctx_agent_memory_snapshot WHERE session_id = $1`, pending.SessionID); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM plugin_state WHERE scope_kind = 'session' AND scope_id = $1`, pending.SessionID); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM ctx_conversation WHERE session_id = $1 AND user_id = $2 AND agent_id = $3`, pending.SessionID, userID, agentID); err != nil {
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return err
+	}
+	return restoreMemoryBenchmarkKnowledgeUsage(ctx, setupState, userID, agentID, pending.Usage)
+}
+
+func memoryBenchmarkPairDigest(
+	ctx context.Context,
+	setupState *setupResult,
+	userID string,
+	agentID string,
+) (string, error) {
+	queries := []string{
+		`SELECT COALESCE(jsonb_agg(to_jsonb(t) ORDER BY t.id)::text, '[]') FROM (SELECT * FROM facts WHERE user_id=$1 AND agent_id=$2) t`,
+		`SELECT COALESCE(jsonb_agg(to_jsonb(t))::text, '[]') FROM (SELECT * FROM ctx_agent_memory WHERE user_id=$1 AND agent_id=$2) t`,
+		`SELECT COALESCE(jsonb_agg(to_jsonb(t) ORDER BY t.id)::text, '[]') FROM (SELECT * FROM ctx_agent_memory_changelog WHERE user_id=$1 AND agent_id=$2) t`,
+		`SELECT COALESCE(jsonb_agg(to_jsonb(t) ORDER BY t.fact_id)::text, '[]') FROM (SELECT * FROM knowledge_usage WHERE user_id=$1 AND agent_id=$2) t`,
+		`SELECT COALESCE(jsonb_agg(to_jsonb(t) ORDER BY t.session_id)::text, '[]') FROM (SELECT * FROM ctx_agent_memory_snapshot WHERE user_id=$1 AND agent_id=$2) t`,
+		`SELECT COALESCE(jsonb_agg(to_jsonb(t) ORDER BY t.id)::text, '[]') FROM (SELECT * FROM skill WHERE user_id=$1 AND agent_id=$2) t`,
+		`SELECT COALESCE(jsonb_agg(to_jsonb(t) ORDER BY t.skill_id)::text, '[]') FROM (SELECT * FROM skill_usage WHERE user_id=$1 AND agent_id=$2) t`,
+	}
+	hash := sha256.New()
+	for _, query := range queries {
+		var payload string
+		if err := setupState.db.QueryRow(ctx, query, userID, agentID).Scan(&payload); err != nil {
+			return "", fmt.Errorf("digest pair state: %w", err)
+		}
+		_, _ = hash.Write([]byte(payload))
+		_, _ = hash.Write([]byte{0})
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func resetMemoryBenchmarkPair(
+	ctx context.Context,
+	setupState *setupResult,
+	userID string,
+	agentID string,
+	name string,
+) error {
+	if service := setupState.poolManager.GetService(agentID); service != nil {
+		_ = service.Runtime.ResetRunnersForUser(userID)
+	}
+	tx, err := setupState.db.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := tx.Exec(ctx, `
+		DELETE FROM plugin_state
+		WHERE scope_kind = 'session'
+		  AND scope_id IN (SELECT session_id FROM ctx_conversation WHERE user_id=$1 AND agent_id=$2)`, userID, agentID); err != nil {
+		return fmt.Errorf("delete pair plugin state: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM ctx_agent_memory_snapshot WHERE user_id=$1 AND agent_id=$2`, userID, agentID); err != nil {
+		return fmt.Errorf("delete pair snapshots: %w", err)
+	}
+	// Conversation rows intentionally have no auth_user cascade.
+	if _, err := tx.Exec(ctx, `DELETE FROM ctx_conversation WHERE user_id=$1 AND agent_id=$2`, userID, agentID); err != nil {
+		return fmt.Errorf("delete pair conversations: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM auth_user WHERE id=$1`, userID); err != nil {
+		return fmt.Errorf("delete benchmark user: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return err
+	}
+	return createMemoryBenchmarkUser(ctx, setupState, userID, agentID, name)
+}
+
+func ensureMemoryBenchmarkUser(
+	ctx context.Context,
+	setupState *setupResult,
+	userID string,
+	agentID string,
+	name string,
+) error {
+	var exists bool
+	if err := setupState.db.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM auth_user WHERE id=$1)`, userID).Scan(&exists); err != nil {
+		return err
+	}
+	if !exists {
+		return createMemoryBenchmarkUser(ctx, setupState, userID, agentID, name)
+	}
+	return setupState.authStore.AssignAgent(ctx, userID, agentID)
+}
+
+func createMemoryBenchmarkUser(
+	ctx context.Context,
+	setupState *setupResult,
+	userID string,
+	agentID string,
+	name string,
+) error {
+	_, err := setupState.authStore.CreateUser(ctx, auth.User{
+		ID: userID, Email: fmt.Sprintf("benchmark-%s@benchmark.invalid", userID), Name: name, Role: auth.RoleUser,
+	})
+	if err != nil {
+		return fmt.Errorf("create benchmark user: %w", err)
+	}
+	if err := setupState.authStore.AssignAgent(ctx, userID, agentID); err != nil {
+		return fmt.Errorf("assign benchmark agent: %w", err)
+	}
+	return nil
+}
+
+func inspectMemoryBenchmarkRemoteModelMetadata(
+	ctx context.Context,
+	providerCfg config.Provider,
+	modelID string,
+) ([]memoryBenchmarkRemoteModelMetadata, error) {
+	endpoint := strings.TrimRight(providerCfg.BaseURL, "/") + "/models"
+	requestCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+providerCfg.APIKey)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("model metadata request returned %s", resp.Status)
+	}
+	var payload struct {
+		Data []memoryBenchmarkRemoteModelMetadata `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, err
+	}
+	metadata := make([]memoryBenchmarkRemoteModelMetadata, 0, 1)
+	for _, model := range payload.Data {
+		if model.ID == modelID {
+			metadata = append(metadata, model)
+		}
+	}
+	return metadata, nil
+}
+
+func writeMemoryBenchmarkJSONAtomic(path string, value any) error {
+	payload, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	payload = append(payload, '\n')
+	temporary := path + ".tmp"
+	if err := os.WriteFile(temporary, payload, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(temporary, path)
+}
+
+func isMemoryBenchmarkTransient(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return !errors.Is(err, context.Canceled)
+	}
+	message := strings.ToLower(err.Error())
+	for _, marker := range []string{
+		"unexpected eof", "connection reset", "temporarily unavailable", "timeout", "timed out",
+		"context deadline exceeded",
+		"status code 429", "status code 500", "status code 502", "status code 503", "status code 504",
+	} {
+		if strings.Contains(message, marker) {
+			return true
+		}
+	}
+	return errors.Is(err, pgx.ErrTxClosed)
+}

--- a/cmd/stellad/personamem_benchmark_test.go
+++ b/cmd/stellad/personamem_benchmark_test.go
@@ -1,0 +1,960 @@
+//go:build personamemeval
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"encoding/csv"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/CherryHQ/stella/internal/config"
+	"github.com/CherryHQ/stella/internal/memory"
+	"github.com/CherryHQ/stella/internal/vault"
+	"github.com/CherryHQ/stella/pkg/tools"
+)
+
+type personaMemStubTool struct {
+	execute func(context.Context, map[string]any) (string, error)
+}
+
+func (tool personaMemStubTool) Definition() tools.Definition {
+	return tools.Definition{Name: memoryBenchmarkToolName}
+}
+
+func (tool personaMemStubTool) Execute(ctx context.Context, args map[string]any) (string, error) {
+	return tool.execute(ctx, args)
+}
+
+func TestPersonaMemQuestionTypeAliases(t *testing.T) {
+	tests := map[string]personaMemCategory{
+		"recall_user_shared_facts":                      personaMemRecall,
+		"recalling_facts_mentioned_by_the_user":         personaMemRecall,
+		"acknowledge_latest_user_preferences":           personaMemLatest,
+		"acknowledge_latest_preferences":                personaMemLatest,
+		"track_full_preference_evolution":               personaMemEvolution,
+		"track_full_preference_updates":                 personaMemEvolution,
+		"recalling_the_reasons_behind_previous_updates": personaMemRevisit,
+		"revisit_reasons_behind_preference_updates":     personaMemRevisit,
+		"generalize_to_new_scenarios":                   personaMemGeneralization,
+		"generalizing_to_new_scenarios":                 personaMemGeneralization,
+		"provide_preference_aligned_recommendations":    personaMemRecommendation,
+		"suggest_new_ideas":                             personaMemSuggestIdeas,
+	}
+	for value, want := range tests {
+		got, ok := normalizePersonaMemQuestionType(value)
+		if !ok || got != want {
+			t.Errorf("normalize %q = %q/%t, want %q/true", value, got, ok, want)
+		}
+	}
+	if _, ok := normalizePersonaMemQuestionType("unknown_personamem_task"); ok {
+		t.Fatal("unknown question type was accepted")
+	}
+}
+
+func TestPersonaMemSnapshotStatusRequiresExplicitOperatorInput(t *testing.T) {
+	t.Setenv("PERSONAMEM_MODEL_SNAPSHOT_STATUS", "")
+	status, verified, err := personaMemSnapshotStatusFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != personaMemDefaultSnapshotStatus || verified {
+		t.Fatalf("default snapshot status = %q/%t", status, verified)
+	}
+
+	t.Setenv("PERSONAMEM_MODEL_SNAPSHOT_STATUS", "operator-confirmed-latest")
+	status, verified, err = personaMemSnapshotStatusFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != "operator-confirmed-latest" || !verified {
+		t.Fatalf("explicit snapshot status = %q/%t", status, verified)
+	}
+
+	t.Setenv("PERSONAMEM_MODEL_SNAPSHOT_STATUS", "invalid\nstatus")
+	if _, _, err := personaMemSnapshotStatusFromEnv(); err == nil {
+		t.Fatal("multi-line snapshot status was accepted")
+	}
+}
+
+func TestPersonaMemExtractAnswerMatchesOfficialPolicy(t *testing.T) {
+	tests := []struct {
+		name       string
+		prediction string
+		gold       string
+		correct    bool
+		extracted  string
+	}{
+		{name: "tagged", prediction: "Reasoning. <final_answer> (c)</final_answer>", gold: "(c)", correct: true, extracted: "(c)"},
+		{name: "last tag wins", prediction: "<final_answer>(a) <final_answer>(d)", gold: "(d)", correct: true, extracted: "(d)"},
+		{name: "word option", prediction: "<final_answer> b", gold: "(b)", correct: true, extracted: "b"},
+		{name: "multiple choices fail", prediction: "<final_answer>(a) or (b)", gold: "(a)", correct: false, extracted: "(a) or (b)"},
+		{name: "fallback full response", prediction: "The answer is (c). <final_answer>unknown", gold: "(c)", correct: true, extracted: "unknown"},
+		{name: "wrong", prediction: "<final_answer>(a)", gold: "(d)", correct: false, extracted: "(a)"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			correct, extracted := extractPersonaMemAnswer(test.prediction, test.gold)
+			if correct != test.correct || extracted != test.extracted {
+				t.Fatalf("extract = %t/%q, want %t/%q", correct, extracted, test.correct, test.extracted)
+			}
+		})
+	}
+}
+
+func TestPersonaMemFrozenMemoryToolFiltersCurrentSession(t *testing.T) {
+	var delegatedLimit int
+	inner := personaMemStubTool{execute: func(_ context.Context, args map[string]any) (string, error) {
+		delegatedLimit = memoryBenchmarkIntArg(args, "limit", 0)
+		payload, err := json.Marshal([]memory.SearchResult{
+			{SourceID: "self", SessionID: "qa-current", Score: 3},
+			{SourceID: "history-1", SessionID: "history-1", Score: 2},
+			{SourceID: "history-2", SessionID: "history-2", Score: 1},
+		})
+		return string(payload), err
+	}}
+	tool := &frozenMemoryBenchmarkTool{inner: inner, blockedSessionID: "qa-current", maxCalls: 8}
+
+	result, err := tool.Execute(context.Background(), map[string]any{
+		"action": "search",
+		"limit":  2,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var hits []memory.SearchResult
+	if err := json.Unmarshal([]byte(result), &hits); err != nil {
+		t.Fatal(err)
+	}
+	if delegatedLimit != 66 {
+		t.Fatalf("delegated search limit = %d, want 66", delegatedLimit)
+	}
+	if len(hits) != 2 || hits[0].SourceID != "history-1" || hits[1].SourceID != "history-2" {
+		t.Fatalf("filtered hits = %#v", hits)
+	}
+}
+
+func TestPersonaMemFrozenMemoryToolStopsAfterBudget(t *testing.T) {
+	var delegatedCalls int
+	inner := personaMemStubTool{execute: func(_ context.Context, _ map[string]any) (string, error) {
+		delegatedCalls++
+		return "delegated", nil
+	}}
+	tool := &frozenMemoryBenchmarkTool{inner: inner, maxCalls: 1}
+
+	if result, err := tool.Execute(context.Background(), map[string]any{"action": "status"}); err != nil || result != "delegated" {
+		t.Fatalf("first call = %q, %v", result, err)
+	}
+	result, err := tool.Execute(context.Background(), map[string]any{"action": "status"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if delegatedCalls != 1 || result != memoryBenchmarkBudgetExhaustedMessage {
+		t.Fatalf("budget response = %q, delegated calls = %d", result, delegatedCalls)
+	}
+}
+
+func TestPersonaMemSelectedDatasetContract(t *testing.T) {
+	if _, err := auditPersonaMemQuestionSplits(); err != nil {
+		t.Fatal(err)
+	}
+	samples, hashes, err := loadPersonaMemDataset(personaMemSelectedSpecs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(samples) != 6 || len(hashes) != 4 {
+		t.Fatalf("selected samples/hashes = %d/%d, want 6/4", len(samples), len(hashes))
+	}
+	if !sameStringMap(hashes, personaMemExpectedDatasetSHA256) {
+		t.Fatalf("dataset SHA-256 = %#v, want fixed PersonaMem v1 hashes", hashes)
+	}
+	wantQuestionCounts := []int{17, 28, 21, 64, 52, 46}
+	personas := make(map[string]struct{})
+	questionIDs := make(map[string]struct{})
+	rawEndpointCount := 0
+	effectiveEndpointCount := 0
+	coreQuestionCount := 0
+	extendedQuestionCount := 0
+	for index, sample := range samples {
+		if len(sample.Questions) != wantQuestionCounts[index] {
+			t.Fatalf("selected sample %d questions = %d, want %d", index, len(sample.Questions), wantQuestionCounts[index])
+		}
+		personas[sample.Spec.PersonaID] = struct{}{}
+		rawEndpointCount += sample.Spec.RawEndpointCount
+		effectiveEndpointCount += len(personaMemEndpoints(sample))
+		coreRawEndpoints := make(map[int]struct{})
+		extendedRawEndpoints := make(map[int]struct{})
+		for _, question := range sample.Questions {
+			if _, duplicate := questionIDs[question.QuestionID]; duplicate {
+				t.Fatalf("duplicate question ID %s", question.QuestionID)
+			}
+			questionIDs[question.QuestionID] = struct{}{}
+			if personaMemIsCoreCategory(question.Category) {
+				coreQuestionCount++
+				coreRawEndpoints[question.RawEndpoint] = struct{}{}
+			} else if personaMemIsExtendedCategory(question.Category) {
+				extendedQuestionCount++
+				extendedRawEndpoints[question.RawEndpoint] = struct{}{}
+			}
+		}
+		for endpoint := range extendedRawEndpoints {
+			if _, ok := coreRawEndpoints[endpoint]; !ok {
+				t.Fatalf("%s extension endpoint %d has no core question", sample.Spec.ContextID, endpoint)
+			}
+		}
+	}
+	if len(personas) != 6 || rawEndpointCount != 48 || effectiveEndpointCount != 47 {
+		t.Fatalf("personas/raw/effective endpoints = %d/%d/%d, want 6/48/47", len(personas), rawEndpointCount, effectiveEndpointCount)
+	}
+	if coreQuestionCount != 148 || extendedQuestionCount != 80 || len(questionIDs) != 228 {
+		t.Fatalf("core/extended/total questions = %d/%d/%d, want 148/80/228", coreQuestionCount, extendedQuestionCount, len(questionIDs))
+	}
+	for _, sample := range samples {
+		for _, endpoint := range personaMemEndpoints(sample) {
+			// Official inference uses context[:endpoint], so endpoint itself must
+			// remain future content until the next checkpoint.
+			if endpoint < len(sample.Messages) && sample.Messages[endpoint-1] == sample.Messages[endpoint] {
+				t.Fatalf("%s endpoint %d does not separate distinct messages", sample.Spec.Split, endpoint)
+			}
+		}
+	}
+}
+
+func TestPersonaMemRepositoryLocalPaths(t *testing.T) {
+	wantRoot := filepath.Clean(personaMemRepositoryRoot)
+	gotRoot, err := findPersonaMemRepositoryRoot(filepath.Join(wantRoot, "cmd", "stellad"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotRoot != wantRoot {
+		t.Fatalf("repository root = %q, want %q", gotRoot, wantRoot)
+	}
+
+	wantBenchmarkRoot := filepath.Join(wantRoot, "dist", "benchmarks", "personamem")
+	if personaMemBenchmarkRoot != wantBenchmarkRoot {
+		t.Fatalf("benchmark root = %q, want %q", personaMemBenchmarkRoot, wantBenchmarkRoot)
+	}
+	for _, path := range []string{personaMemRunsRoot, personaMemHomesRoot} {
+		relative, err := filepath.Rel(wantRoot, path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+			t.Fatalf("PersonaMem path escaped worktree: %s", path)
+		}
+	}
+	configuredDataRoot := strings.TrimSpace(os.Getenv("PERSONAMEM_DATA_ROOT"))
+	if configuredDataRoot == "" {
+		if personaMemDataRoot != filepath.Join(wantBenchmarkRoot, "data") {
+			t.Fatalf("default data root = %q", personaMemDataRoot)
+		}
+	} else if personaMemDataRoot != filepath.Clean(configuredDataRoot) {
+		t.Fatalf("configured data root = %q, want %q", personaMemDataRoot, filepath.Clean(configuredDataRoot))
+	}
+
+	runName, err := personaMemRunName("representative")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runName != "representative-v2" {
+		t.Fatalf("representative run name = %q, want representative-v2", runName)
+	}
+	home, err := personaMemHomeForMode("representative")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if home != filepath.Join(personaMemBenchmarkRoot, "h", "r-v2") {
+		t.Fatalf("representative home = %q", home)
+	}
+	if _, err := personaMemRunName("selected"); err == nil {
+		t.Fatal("legacy selected mode was accepted")
+	}
+}
+
+func TestPersonaMemRepresentativeSelectorContract(t *testing.T) {
+	stats32, err := loadPersonaMemSelectionStats("32k")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stats128, err := loadPersonaMemSelectionStats("128k")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pools32, err := buildPersonaMemSelectionPools("32k", stats32)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pools128, err := buildPersonaMemSelectionPools("128k", stats128)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := []int{len(pools32[0]), len(pools32[1]), len(pools32[2])}; !samePersonaMemInts(got, []int{12, 10, 15}) {
+		t.Fatalf("32k low/middle/high pools = %v, want [12 10 15]", got)
+	}
+	if got := []int{len(pools128[0]), len(pools128[1]), len(pools128[2])}; !samePersonaMemInts(got, []int{24, 20, 16}) {
+		t.Fatalf("128k low/middle/high pools = %v, want [24 20 16]", got)
+	}
+
+	triples32 := buildPersonaMemSelectionTriples(pools32)
+	triples128 := buildPersonaMemSelectionTriples(pools128)
+	if len(triples32) != 1641 || len(triples128) != 6996 {
+		t.Fatalf("32k/128k triples = %d/%d, want 1641/6996", len(triples32), len(triples128))
+	}
+
+	valid, bestHash, bestIDs := choosePersonaMemRepresentativeCombination(triples32, triples128)
+	if valid != 1935 {
+		t.Fatalf("valid selector combinations = %d, want 1935", valid)
+	}
+	if bestHash != personaMemSelectorHash {
+		t.Fatalf("selector hash = %s, want %s", bestHash, personaMemSelectorHash)
+	}
+	wantIDs := make([]string, 0, len(personaMemSelectedSpecs))
+	for _, spec := range personaMemSelectedSpecs {
+		wantIDs = append(wantIDs, spec.ContextID)
+	}
+	sort.Strings(wantIDs)
+	if strings.Join(bestIDs, "|") != strings.Join(wantIDs, "|") {
+		t.Fatalf("selected context IDs = %v, want %v", bestIDs, wantIDs)
+	}
+}
+
+func TestPersonaMemSelectionDigestIsCanonical(t *testing.T) {
+	first := personaMemSample{Spec: personaMemSampleSpec{Split: "32k", ContextID: "context-a"}, Questions: []personaMemQuestion{
+		{QuestionID: "q2", Category: personaMemLatest, RawEndpoint: 4, Endpoint: 4},
+		{QuestionID: "q1", Category: personaMemRecall, RawEndpoint: 2, Endpoint: 2},
+	}}
+	second := personaMemSample{Spec: personaMemSampleSpec{Split: "128k", ContextID: "context-b"}, Questions: []personaMemQuestion{
+		{QuestionID: "q3", Category: personaMemEvolution, RawEndpoint: 8, Endpoint: 7},
+	}}
+	want := personaMemSelectionSHA256([]personaMemSample{first, second})
+	first.Questions[0], first.Questions[1] = first.Questions[1], first.Questions[0]
+	if got := personaMemSelectionSHA256([]personaMemSample{second, first}); got != want {
+		t.Fatalf("reordered selection digest = %s, want %s", got, want)
+	}
+	second.Questions[0].QuestionID = "q3-changed"
+	if got := personaMemSelectionSHA256([]personaMemSample{first, second}); got == want {
+		t.Fatal("selection digest did not change after question identity changed")
+	}
+}
+
+func TestPersonaMemCheckpointRejectsContractMismatch(t *testing.T) {
+	temporary := t.TempDir()
+	path := filepath.Join(temporary, "checkpoint.json")
+	runDir := filepath.Join(temporary, "representative-v2")
+	datasetSHA := map[string]string{"questions_32k.csv": "dataset-a"}
+	model := personaMemModelIdentity{
+		ProviderHost: "router.example", ProviderEndpointSHA256: "endpoint-a",
+		RequestedModel: personaMemAnswerModelID, SnapshotStatus: personaMemDefaultSnapshotStatus,
+		SnapshotVerified: true, Note: "test model identity",
+	}
+	checkpoint, err := loadOrCreatePersonaMemCheckpoint(path, runDir, "representative", model, datasetSHA, "selection-a", 148, 80)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if checkpoint.Version != 3 || checkpoint.SelectionSHA256 != "selection-a" ||
+		checkpoint.ReflectReviewerTimeoutSeconds != int64(personaMemReflectTimeout/time.Second) ||
+		checkpoint.ReflectPreWriteMaxAttempts != personaMemReflectMaxAttempts {
+		t.Fatalf("new checkpoint = %#v", checkpoint)
+	}
+	if _, err := loadOrCreatePersonaMemCheckpoint(path, runDir, "representative", model, datasetSHA, "selection-a", 148, 80); err != nil {
+		t.Fatalf("reload matching checkpoint: %v", err)
+	}
+	if _, err := loadOrCreatePersonaMemCheckpoint(path, runDir, "representative", model, datasetSHA, "selection-b", 148, 80); err == nil {
+		t.Fatal("checkpoint with mismatched selection digest was accepted")
+	}
+
+	tests := map[string]func(*personaMemCheckpoint){
+		"legacy version": func(value *personaMemCheckpoint) { value.Version = 2 },
+		"dataset hash":   func(value *personaMemCheckpoint) { value.DatasetSHA256["questions_32k.csv"] = "dataset-b" },
+		"answer model":   func(value *personaMemCheckpoint) { value.AnswerModel = "different-model" },
+		"provider endpoint": func(value *personaMemCheckpoint) {
+			value.Model.ProviderEndpointSHA256 = "endpoint-b"
+		},
+		"reflect timeout": func(value *personaMemCheckpoint) { value.ReflectReviewerTimeoutSeconds = 1 },
+		"reflect retries": func(value *personaMemCheckpoint) { value.ReflectPreWriteMaxAttempts = 1 },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			payload, err := json.Marshal(checkpoint)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var changed personaMemCheckpoint
+			if err := json.Unmarshal(payload, &changed); err != nil {
+				t.Fatal(err)
+			}
+			mutate(&changed)
+			changedPath := filepath.Join(temporary, strings.ReplaceAll(name, " ", "-")+".json")
+			if err := writeMemoryBenchmarkJSONAtomic(changedPath, &changed); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := loadOrCreatePersonaMemCheckpoint(changedPath, runDir, "representative", model, datasetSHA, "selection-a", 148, 80); err == nil {
+				t.Fatalf("checkpoint with mismatched %s was accepted", name)
+			}
+		})
+	}
+
+}
+
+func TestPersonaMemSmokeReusesOneEndpoint(t *testing.T) {
+	samples, _, err := loadPersonaMemDataset(personaMemSelectedSpecs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	smoke := personaMemSmokeSamples(samples)
+	if len(smoke) != 1 || len(smoke[0].Questions) != 2 {
+		t.Fatalf("smoke samples/questions = %d/%d, want 1/2", len(smoke), len(smoke[0].Questions))
+	}
+	if smoke[0].Questions[0].Endpoint != smoke[0].Questions[1].Endpoint {
+		t.Fatalf("smoke questions use endpoints %d and %d", smoke[0].Questions[0].Endpoint, smoke[0].Questions[1].Endpoint)
+	}
+	if !personaMemQuestionsContainCoreAndExtended(smoke[0].Questions) {
+		t.Fatal("smoke endpoint does not include one core and one extended question")
+	}
+}
+
+func TestPersonaMemPythonSliceEnd(t *testing.T) {
+	tests := map[int]int{-100: 0, -1: 9, 0: 0, 5: 5, 10: 10, 11: 10}
+	for endpoint, want := range tests {
+		if got := personaMemPythonSliceEnd(endpoint, 10); got != want {
+			t.Errorf("slice end %d = %d, want %d", endpoint, got, want)
+		}
+	}
+}
+
+func TestPersonaMemScoreExcludesIncompleteFromAccuracy(t *testing.T) {
+	samples := []personaMemSample{{Questions: []personaMemQuestion{
+		{QuestionID: "q1", Category: personaMemRecall},
+		{QuestionID: "q2", Category: personaMemRecall},
+		{QuestionID: "q3", Category: personaMemLatest},
+		{QuestionID: "q4", Category: personaMemEvolution},
+		{QuestionID: "q5", Category: personaMemRevisit},
+		{QuestionID: "q6", Category: personaMemGeneralization},
+		{QuestionID: "q7", Category: personaMemRecommendation},
+		{QuestionID: "q8", Category: personaMemSuggestIdeas},
+	}}}
+	answers := []*personaMemAnswerRecord{
+		{QuestionID: "q1", Category: personaMemRecall, Completed: true, Correct: true},
+		{QuestionID: "q2", Category: personaMemRecall, Completed: false},
+		{QuestionID: "q3", Category: personaMemLatest, Completed: true, Correct: false},
+		{QuestionID: "q4", Category: personaMemEvolution, Completed: true, Correct: true},
+		{QuestionID: "q5", Category: personaMemRevisit, Completed: true, Correct: false},
+		{QuestionID: "q6", Category: personaMemGeneralization, Completed: true, Correct: true},
+		{QuestionID: "q7", Category: personaMemRecommendation, Completed: true, Correct: false},
+		{QuestionID: "q8", Category: personaMemSuggestIdeas, Completed: true, Correct: true},
+	}
+	report := buildPersonaMemScoreReport(samples, answers)
+	if report.Overall.Correct != 4 || report.Overall.Completed != 7 || report.Overall.Expected != 8 {
+		t.Fatalf("overall score = %#v", report.Overall)
+	}
+	if report.Overall.Accuracy == nil || *report.Overall.Accuracy != float64(4)/7 {
+		t.Fatalf("overall accuracy = %v, want 4/7", report.Overall.Accuracy)
+	}
+	recall := report.CoreCategories[personaMemRecall]
+	if recall.Correct != 1 || recall.Completed != 1 || recall.Expected != 2 || recall.Accuracy == nil || *recall.Accuracy != 1 {
+		t.Fatalf("recall score = %#v", recall)
+	}
+	if report.CoreMacroAccuracy == nil || *report.CoreMacroAccuracy != 0.5 {
+		t.Fatalf("core macro accuracy = %v, want 0.5", report.CoreMacroAccuracy)
+	}
+	if got := report.ExtendedCategories[personaMemGeneralization]; got.Correct != 1 || got.Expected != 1 {
+		t.Fatalf("generalization score = %#v", got)
+	}
+}
+
+func TestPersonaMemCoreMacroRequiresAllCategories(t *testing.T) {
+	samples := []personaMemSample{{Questions: []personaMemQuestion{{QuestionID: "q1", Category: personaMemRecall}}}}
+	report := buildPersonaMemScoreReport(samples, []*personaMemAnswerRecord{{
+		QuestionID: "q1", Category: personaMemRecall, Completed: true, Correct: true,
+	}})
+	if report.CoreMacroAccuracy != nil {
+		t.Fatalf("core macro accuracy = %v, want nil", *report.CoreMacroAccuracy)
+	}
+}
+
+func TestPersonaMemNormalizeLegacyMemoryCallOutcomes(t *testing.T) {
+	calls := make([]personaMemMemoryCall, 10)
+	for index := range calls {
+		calls[index].ResultBytes = 100 + index
+	}
+	calls[8].ResultBytes = len(memoryBenchmarkBudgetExhaustedMessage)
+	calls[9].ResultBytes = len(memoryBenchmarkBudgetExhaustedMessage)
+
+	if err := normalizePersonaMemMemoryCallOutcomes(calls); err != nil {
+		t.Fatal(err)
+	}
+	for index, call := range calls {
+		want := "executed"
+		if index >= personaMemQAToolBudget {
+			want = "budget_denied"
+		}
+		if call.Outcome != want {
+			t.Errorf("call %d outcome = %q, want %q", index, call.Outcome, want)
+		}
+	}
+}
+
+func TestPersonaMemEmptyAnswerIsRetryable(t *testing.T) {
+	if !isPersonaMemQATransient(errPersonaMemEmptyAnswer) {
+		t.Fatal("empty PersonaMem answer was not retryable")
+	}
+	if !isPersonaMemQATransient(errors.New("provider: context deadline exceeded")) {
+		t.Fatal("provider deadline string was not retryable")
+	}
+	if isPersonaMemQATransient(errors.New("permanent benchmark contract error")) {
+		t.Fatal("permanent PersonaMem error was retryable")
+	}
+}
+
+type personaMemSelectionStats struct {
+	Split                  string
+	ContextID              string
+	PersonaID              string
+	EffectiveEndpointCount int
+	CategoryCounts         [4]int
+	DistanceCounts         [4][3]int
+}
+
+type personaMemSelectionTriple struct {
+	Contexts       [3]*personaMemSelectionStats
+	CategoryCounts [4]int
+	DistanceCounts [4][3]int
+}
+
+func loadPersonaMemSelectionStats(split string) ([]*personaMemSelectionStats, error) {
+	contextLengths, err := loadPersonaMemContextLengths(split)
+	if err != nil {
+		return nil, err
+	}
+	path := filepath.Join(personaMemDataRoot, "questions_"+split+".csv")
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open PersonaMem selector questions: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	reader := csv.NewReader(file)
+	header, err := reader.Read()
+	if err != nil {
+		return nil, fmt.Errorf("read PersonaMem selector header: %w", err)
+	}
+	columns := make(map[string]int, len(header))
+	for index, name := range header {
+		columns[name] = index
+	}
+	required := []string{
+		"persona_id", "question_type", "shared_context_id", "end_index_in_shared_context",
+		"distance_to_ref_proportion_in_context",
+	}
+	for _, name := range required {
+		if _, ok := columns[name]; !ok {
+			return nil, fmt.Errorf("PersonaMem selector data lacks column %q", name)
+		}
+	}
+
+	type aggregate struct {
+		stats              *personaMemSelectionStats
+		effectiveEndpoints map[int]struct{}
+	}
+	aggregates := make(map[string]*aggregate)
+	for rowNumber := 2; ; rowNumber++ {
+		row, readErr := reader.Read()
+		if errors.Is(readErr, io.EOF) {
+			break
+		}
+		if readErr != nil {
+			return nil, fmt.Errorf("read PersonaMem selector row %d: %w", rowNumber, readErr)
+		}
+		category, ok := normalizePersonaMemQuestionType(row[columns["question_type"]])
+		if !ok || !personaMemIsCoreCategory(category) {
+			continue
+		}
+		categoryIndex, ok := personaMemCoreCategoryIndex(category)
+		if !ok {
+			return nil, fmt.Errorf("index PersonaMem core category %q", category)
+		}
+		contextID := row[columns["shared_context_id"]]
+		messageCount, ok := contextLengths[contextID]
+		if !ok {
+			return nil, fmt.Errorf("PersonaMem selector context %s is missing", contextID)
+		}
+		rawEndpoint, err := strconv.Atoi(row[columns["end_index_in_shared_context"]])
+		if err != nil {
+			return nil, fmt.Errorf("PersonaMem selector row %d endpoint: %w", rowNumber, err)
+		}
+		distanceBucket, err := personaMemDistanceBucket(row[columns["distance_to_ref_proportion_in_context"]])
+		if err != nil {
+			return nil, fmt.Errorf("PersonaMem selector row %d distance: %w", rowNumber, err)
+		}
+
+		entry := aggregates[contextID]
+		if entry == nil {
+			entry = &aggregate{
+				stats: &personaMemSelectionStats{
+					Split: split, ContextID: contextID, PersonaID: row[columns["persona_id"]],
+				},
+				effectiveEndpoints: make(map[int]struct{}),
+			}
+			aggregates[contextID] = entry
+		}
+		if entry.stats.PersonaID != row[columns["persona_id"]] {
+			return nil, fmt.Errorf("PersonaMem context %s has multiple personas", contextID)
+		}
+		entry.stats.CategoryCounts[categoryIndex]++
+		entry.stats.DistanceCounts[categoryIndex][distanceBucket]++
+		entry.effectiveEndpoints[personaMemPythonSliceEnd(rawEndpoint, messageCount)] = struct{}{}
+	}
+
+	result := make([]*personaMemSelectionStats, 0, len(aggregates))
+	for _, entry := range aggregates {
+		entry.stats.EffectiveEndpointCount = len(entry.effectiveEndpoints)
+		result = append(result, entry.stats)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].ContextID < result[j].ContextID })
+	return result, nil
+}
+
+func loadPersonaMemContextLengths(split string) (map[string]int, error) {
+	path := filepath.Join(personaMemDataRoot, "shared_contexts_"+split+".jsonl")
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open PersonaMem selector contexts: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	result := make(map[string]int)
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 64*1024), 32*1024*1024)
+	for scanner.Scan() {
+		var row map[string]json.RawMessage
+		if err := json.Unmarshal(scanner.Bytes(), &row); err != nil {
+			return nil, fmt.Errorf("decode PersonaMem selector context row: %w", err)
+		}
+		for contextID, raw := range row {
+			var messages []personaMemMessage
+			if err := json.Unmarshal(raw, &messages); err != nil {
+				return nil, fmt.Errorf("decode PersonaMem selector context %s: %w", contextID, err)
+			}
+			if _, duplicate := result[contextID]; duplicate {
+				return nil, fmt.Errorf("PersonaMem selector context %s appears more than once", contextID)
+			}
+			result[contextID] = len(messages)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan PersonaMem selector contexts: %w", err)
+	}
+	return result, nil
+}
+
+func personaMemCoreCategoryIndex(category personaMemCategory) (int, bool) {
+	for index, current := range personaMemCoreCategories {
+		if current == category {
+			return index, true
+		}
+	}
+	return 0, false
+}
+
+func personaMemDistanceBucket(value string) (int, error) {
+	percent, err := strconv.ParseFloat(strings.TrimSuffix(strings.TrimSpace(value), "%"), 64)
+	if err != nil {
+		return 0, err
+	}
+	switch {
+	case percent < 100.0/3.0:
+		return 0, nil
+	case percent < 200.0/3.0:
+		return 1, nil
+	default:
+		return 2, nil
+	}
+}
+
+func buildPersonaMemSelectionPools(split string, stats []*personaMemSelectionStats) ([3][]*personaMemSelectionStats, error) {
+	var pools [3][]*personaMemSelectionStats
+	for _, item := range stats {
+		band := -1
+		switch split {
+		case "32k":
+			switch {
+			case item.EffectiveEndpointCount <= 2:
+				band = 0
+			case item.EffectiveEndpointCount <= 8:
+				band = 1
+			default:
+				band = 2
+			}
+		case "128k":
+			switch {
+			case item.EffectiveEndpointCount >= 6 && item.EffectiveEndpointCount <= 7:
+				band = 0
+			case item.EffectiveEndpointCount >= 8 && item.EffectiveEndpointCount <= 9:
+				band = 1
+			case item.EffectiveEndpointCount >= 10:
+				band = 2
+			}
+		default:
+			return pools, fmt.Errorf("unsupported PersonaMem selector split %q", split)
+		}
+		if band >= 0 {
+			pools[band] = append(pools[band], item)
+		}
+	}
+	for index := range pools {
+		sort.Slice(pools[index], func(i, j int) bool {
+			return pools[index][i].ContextID < pools[index][j].ContextID
+		})
+	}
+	return pools, nil
+}
+
+func buildPersonaMemSelectionTriples(pools [3][]*personaMemSelectionStats) []personaMemSelectionTriple {
+	var result []personaMemSelectionTriple
+	for _, low := range pools[0] {
+		for _, middle := range pools[1] {
+			if low.PersonaID == middle.PersonaID {
+				continue
+			}
+			for _, high := range pools[2] {
+				if high.PersonaID == low.PersonaID || high.PersonaID == middle.PersonaID {
+					continue
+				}
+				triple := personaMemSelectionTriple{Contexts: [3]*personaMemSelectionStats{low, middle, high}}
+				for _, item := range triple.Contexts {
+					for category := range triple.CategoryCounts {
+						triple.CategoryCounts[category] += item.CategoryCounts[category]
+						for bucket := range triple.DistanceCounts[category] {
+							triple.DistanceCounts[category][bucket] += item.DistanceCounts[category][bucket]
+						}
+					}
+				}
+				result = append(result, triple)
+			}
+		}
+	}
+	return result
+}
+
+func choosePersonaMemRepresentativeCombination(
+	triples32, triples128 []personaMemSelectionTriple,
+) (int, string, []string) {
+	valid := 0
+	bestHash := ""
+	var bestIDs []string
+	for _, triple32 := range triples32 {
+		for _, triple128 := range triples128 {
+			if personaMemTriplesSharePersona(triple32, triple128) || !personaMemCombinationMeetsCoverage(triple32, triple128) {
+				continue
+			}
+			valid++
+			ids := make([]string, 0, 6)
+			for _, item := range triple32.Contexts {
+				ids = append(ids, item.ContextID)
+			}
+			for _, item := range triple128.Contexts {
+				ids = append(ids, item.ContextID)
+			}
+			sort.Strings(ids)
+			sum := sha256.Sum256([]byte(personaMemSelectorSeed + "|" + strings.Join(ids, "|")))
+			hash := hex.EncodeToString(sum[:])
+			if bestHash == "" || hash < bestHash {
+				bestHash = hash
+				bestIDs = append([]string(nil), ids...)
+			}
+		}
+	}
+	return valid, bestHash, bestIDs
+}
+
+func personaMemTriplesSharePersona(first, second personaMemSelectionTriple) bool {
+	for _, left := range first.Contexts {
+		for _, right := range second.Contexts {
+			if left.PersonaID == right.PersonaID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func personaMemCombinationMeetsCoverage(first, second personaMemSelectionTriple) bool {
+	for category := range first.CategoryCounts {
+		if first.CategoryCounts[category]+second.CategoryCounts[category] < 30 {
+			return false
+		}
+		for bucket := range first.DistanceCounts[category] {
+			if first.DistanceCounts[category][bucket]+second.DistanceCounts[category][bucket] < 3 {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func samePersonaMemInts(first, second []int) bool {
+	if len(first) != len(second) {
+		return false
+	}
+	for index := range first {
+		if first[index] != second[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func ensurePersonaMemBenchmarkConfig(ctx context.Context, setupState *setupResult) error {
+	providers, err := setupState.store.ListProviders(ctx)
+	if err != nil {
+		return fmt.Errorf("list PersonaMem benchmark providers: %w", err)
+	}
+	agents, err := setupState.store.ListAgents(ctx)
+	if err != nil {
+		return fmt.Errorf("list PersonaMem benchmark agents: %w", err)
+	}
+	provider, hasProvider := personaMemProviderByID(providers, personaMemProviderID)
+	if hasProvider && (!provider.Enabled || strings.TrimSpace(provider.APIKey) == "" || strings.TrimSpace(provider.BaseURL) == "") {
+		return fmt.Errorf("PersonaMem provider %q exists but is not enabled with API key and base URL", personaMemProviderID)
+	}
+	hasBenchmarkAgent := false
+	for _, agent := range agents {
+		if agent.ID == personaMemAgentID {
+			hasBenchmarkAgent = true
+			break
+		}
+	}
+	if hasProvider && hasBenchmarkAgent {
+		return nil
+	}
+
+	if !hasProvider {
+		apiKey := strings.TrimSpace(os.Getenv("PERSONAMEM_PROVIDER_API_KEY"))
+		baseURL := strings.TrimSpace(os.Getenv("PERSONAMEM_PROVIDER_BASE_URL"))
+		if apiKey == "" || baseURL == "" {
+			return fmt.Errorf("PERSONAMEM_PROVIDER_API_KEY and PERSONAMEM_PROVIDER_BASE_URL are required for a fresh benchmark home")
+		}
+		provider := config.Provider{
+			ID: personaMemProviderID, Type: "openai", Name: "PersonaMem OpenAI-compatible provider",
+			Enabled: true, APIKey: apiKey, BaseURL: baseURL,
+		}
+		if err := setupState.store.CreateProvider(ctx, provider); err != nil {
+			return fmt.Errorf("bootstrap PersonaMem provider config: %w", err)
+		}
+	}
+
+	if !hasBenchmarkAgent {
+		modelRef := personaMemProviderID + "/" + personaMemAnswerModelID
+		agent := config.Agent{
+			ID:          personaMemAgentID,
+			Name:        "PersonaMem Benchmark",
+			Model:       modelRef,
+			ModelStrong: modelRef,
+			ModelFast:   modelRef,
+			Scope:       config.AgentScopeSystem,
+			Enabled:     true,
+		}
+		// The v2 agent intentionally starts without copied soul, custom system
+		// prompt, workspace, or skills so old benchmark state cannot leak in.
+		if err := setupState.store.CreateAgent(ctx, agent); err != nil {
+			return fmt.Errorf("bootstrap PersonaMem benchmark agent: %w", err)
+		}
+	}
+	return nil
+}
+
+func personaMemProviderByID(providers []config.Provider, id string) (config.Provider, bool) {
+	for _, provider := range providers {
+		if provider.ID == id {
+			return provider, true
+		}
+	}
+	return config.Provider{}, false
+}
+
+func TestPersonaMemBenchmark(t *testing.T) {
+	mode := strings.TrimSpace(os.Getenv("PERSONAMEM_MODE"))
+	if mode == "" {
+		t.Skip("set PERSONAMEM_MODE=inspect, smoke, or representative")
+	}
+	expectedHome, err := personaMemHomeForMode(mode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := config.StellaHome(); got != expectedHome {
+		t.Fatalf("STELLA_HOME = %q, want isolated benchmark home %q", got, expectedHome)
+	}
+	if mode == "inspect" {
+		if err := inspectPersonaMemData(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfg, err := config.LoadServerConfig(os.LookupEnv)
+	if err != nil {
+		t.Fatalf("load server config: %v", err)
+	}
+	// Production runner construction evaluates service-tool availability even
+	// when the benchmark excludes those tools. Supply an ephemeral vault key so
+	// the isolated setup follows the normal production dependency graph.
+	vaultKey, err := vault.GenerateMasterIdentity()
+	if err != nil {
+		t.Fatalf("generate isolated benchmark vault key: %v", err)
+	}
+	cfg.Vault.Key = vaultKey
+	ctx, cancel := context.WithCancel(context.Background())
+	// representative-v2 always uses a fresh home. Production setup installs the
+	// required search extensions before migrations; the legacy out-of-order
+	// repair helper is only valid for cloned development databases.
+	setupState, err := setup(ctx, cfg, "http://127.0.0.1:18081")
+	if err != nil {
+		cancel()
+		t.Fatalf("setup isolated Stella: %v", err)
+	}
+	// PersonaMem drives only the production Fact Reflect line synchronously.
+	setupState.schedulerSvc.Quiesce()
+	t.Cleanup(func() {
+		cancel()
+		setupState.waitBackgroundTasks()
+		_ = setupState.poolManager.Close()
+		if setupState.embedded != nil {
+			setupState.db.Close()
+			_ = setupState.embedded.Stop()
+		}
+	})
+	if err := ensurePersonaMemBenchmarkConfig(ctx, setupState); err != nil {
+		t.Fatalf("bootstrap isolated PersonaMem config: %v", err)
+	}
+
+	switch mode {
+	case "inspect":
+		providerCfg, err := setupState.store.GetProvider(ctx, personaMemProviderID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		identity, err := personaMemModelIdentityFromProvider(ctx, providerCfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		fmt.Printf("PersonaMem model identity: %+v\n", identity)
+	case "smoke", "representative":
+		if err := runPersonaMem(ctx, setupState, mode); err != nil {
+			t.Fatalf("run PersonaMem %s: %v", mode, err)
+		}
+	default:
+		t.Fatalf("unsupported PERSONAMEM_MODE %q", mode)
+	}
+}

--- a/cmd/stellad/personamem_run_test.go
+++ b/cmd/stellad/personamem_run_test.go
@@ -1,0 +1,2008 @@
+//go:build personamemeval
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"encoding/csv"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/CherryHQ/stella/internal/agent/runtime"
+	"github.com/CherryHQ/stella/internal/agent/session"
+	"github.com/CherryHQ/stella/internal/authz"
+	"github.com/CherryHQ/stella/internal/config"
+	"github.com/CherryHQ/stella/internal/memory"
+	"github.com/CherryHQ/stella/internal/pluginhost"
+	"github.com/CherryHQ/stella/internal/reflect"
+	"github.com/CherryHQ/stella/pkg/ai"
+	"github.com/CherryHQ/stella/pkg/providers"
+	"github.com/CherryHQ/stella/pkg/tools"
+	openaiprovider "github.com/CherryHQ/stella/plugins/providers/openai"
+)
+
+const (
+	personaMemAnswerModelID         = "deepseek/deepseek-v4-flash"
+	personaMemProviderID            = "openai"
+	personaMemQAPolicy              = "frozen-session-v1"
+	personaMemRunRevision           = "v2"
+	personaMemSelectorSeed          = "stella-personamem-representative-v2"
+	personaMemSelectorHash          = "000f922f3ed2b743856b5536d52ba713eed6dce771f55cb735c6ab2726145e15"
+	personaMemMaxAttempts           = 3
+	personaMemQAToolBudget          = 8
+	personaMemQATimeout             = 90 * time.Second
+	personaMemReflectTimeout        = 4 * time.Minute
+	personaMemReflectMaxAttempts    = 6
+	personaMemSystemPrefix          = "Current user persona:"
+	personaMemAnswerPrompt          = "Find the most appropriate model response and give your final answer (a), (b), (c), or (d) after the special token <final_answer>."
+	personaMemDefaultSnapshotStatus = "unverified-alias"
+)
+
+var (
+	personaMemRepositoryRoot = mustPersonaMemRepositoryRoot()
+	personaMemBenchmarkRoot  = filepath.Join(personaMemRepositoryRoot, "dist", "benchmarks", "personamem")
+	personaMemDataRoot       = personaMemPathFromEnv("PERSONAMEM_DATA_ROOT", filepath.Join(personaMemBenchmarkRoot, "data"))
+	personaMemRunsRoot       = filepath.Join(personaMemBenchmarkRoot, "runs")
+	// Keep the physical home path short enough for PostgreSQL's 107-byte Unix
+	// socket limit while retaining all benchmark state inside this worktree.
+	personaMemHomesRoot      = filepath.Join(personaMemBenchmarkRoot, "h")
+	personaMemAgentID        = uuid.NewSHA1(uuid.NameSpaceURL, []byte("stella/personamem/benchmark-agent/v2")).String()
+	errPersonaMemEmptyAnswer = errors.New("PersonaMem QA runner returned an empty answer")
+)
+
+func personaMemPathFromEnv(name string, fallback string) string {
+	if path := strings.TrimSpace(os.Getenv(name)); path != "" {
+		return filepath.Clean(path)
+	}
+	return fallback
+}
+
+func mustPersonaMemRepositoryRoot() string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		panic(fmt.Sprintf("resolve PersonaMem working directory: %v", err))
+	}
+	root, err := findPersonaMemRepositoryRoot(cwd)
+	if err != nil {
+		panic(err)
+	}
+	return root
+}
+
+func findPersonaMemRepositoryRoot(start string) (string, error) {
+	directory, err := filepath.Abs(start)
+	if err != nil {
+		return "", fmt.Errorf("resolve PersonaMem start path: %w", err)
+	}
+	for {
+		if info, statErr := os.Stat(filepath.Join(directory, "go.mod")); statErr == nil && !info.IsDir() {
+			return directory, nil
+		}
+		parent := filepath.Dir(directory)
+		if parent == directory {
+			return "", fmt.Errorf("find Stella repository root from %s", start)
+		}
+		directory = parent
+	}
+}
+
+func personaMemRunName(mode string) (string, error) {
+	switch mode {
+	case "inspect", "smoke", "representative":
+		return mode + "-" + personaMemRunRevision, nil
+	default:
+		return "", fmt.Errorf("unsupported PERSONAMEM_MODE %q", mode)
+	}
+}
+
+func personaMemHomeForMode(mode string) (string, error) {
+	var prefix string
+	switch mode {
+	case "inspect":
+		prefix = "i"
+	case "smoke":
+		prefix = "s"
+	case "representative":
+		prefix = "r"
+	default:
+		return "", fmt.Errorf("unsupported PERSONAMEM_MODE %q", mode)
+	}
+	return filepath.Join(personaMemHomesRoot, prefix+"-"+personaMemRunRevision), nil
+}
+
+type personaMemCategory string
+
+const (
+	personaMemRecall         personaMemCategory = "recall"
+	personaMemLatest         personaMemCategory = "latest"
+	personaMemEvolution      personaMemCategory = "evolution"
+	personaMemRevisit        personaMemCategory = "revisit"
+	personaMemGeneralization personaMemCategory = "generalization"
+	personaMemRecommendation personaMemCategory = "recommendation"
+	personaMemSuggestIdeas   personaMemCategory = "suggest_new_ideas"
+)
+
+var personaMemCoreCategories = []personaMemCategory{
+	personaMemRecall,
+	personaMemLatest,
+	personaMemEvolution,
+	personaMemRevisit,
+}
+
+var personaMemExtendedCategories = []personaMemCategory{
+	personaMemGeneralization,
+	personaMemRecommendation,
+	personaMemSuggestIdeas,
+}
+
+var personaMemCategories = []personaMemCategory{
+	personaMemRecall,
+	personaMemLatest,
+	personaMemEvolution,
+	personaMemRevisit,
+	personaMemGeneralization,
+	personaMemRecommendation,
+	personaMemSuggestIdeas,
+}
+
+var personaMemExpectedDatasetSHA256 = map[string]string{
+	"questions_128k.csv":         "f0e137c3167fadbffbce5be2786105283c3299972c4ac1f158939155fd1578a7",
+	"questions_32k.csv":          "cccd34cf53e0bc4d9536c04cff5ca045156d9a4e227e83327112482840bbc93c",
+	"shared_contexts_128k.jsonl": "733cc009e84a138b386c9e40adea741565db01074f73af4058fd039b42951726",
+	"shared_contexts_32k.jsonl":  "217247ebfec9e8442fc53570c795ab69f21aad08745f7de78d9beab51b122d4a",
+}
+
+type personaMemSampleSpec struct {
+	Split                  string                     `json:"split"`
+	ContextID              string                     `json:"shared_context_id"`
+	PersonaID              string                     `json:"persona_id"`
+	RawEndpointCount       int                        `json:"raw_endpoint_count"`
+	EffectiveEndpointCount int                        `json:"effective_endpoint_count"`
+	CategoryCounts         map[personaMemCategory]int `json:"category_counts"`
+}
+
+var personaMemSelectedSpecs = []personaMemSampleSpec{
+	{
+		Split:            "32k",
+		ContextID:        "f56dc82b80270d4a2d45ddff57844726783aa968c7ede0114de9894b782c8ac9",
+		PersonaID:        "13",
+		RawEndpointCount: 1, EffectiveEndpointCount: 1,
+		CategoryCounts: map[personaMemCategory]int{
+			personaMemRecall: 7, personaMemRevisit: 2,
+			personaMemGeneralization: 3, personaMemRecommendation: 1, personaMemSuggestIdeas: 4,
+		},
+	},
+	{
+		Split:            "32k",
+		ContextID:        "1621543a17bd464feaf4ba73d83d579d0160987536bde8725ac29131ecf235c3",
+		PersonaID:        "2",
+		RawEndpointCount: 8, EffectiveEndpointCount: 8,
+		CategoryCounts: map[personaMemCategory]int{
+			personaMemRecall: 6, personaMemEvolution: 10, personaMemRevisit: 6,
+			personaMemGeneralization: 4, personaMemSuggestIdeas: 2,
+		},
+	},
+	{
+		Split:            "32k",
+		ContextID:        "7797915581c01170c2a46616041687c09d59240b417898659034cd31cdc8cebf",
+		PersonaID:        "10",
+		RawEndpointCount: 10, EffectiveEndpointCount: 10,
+		CategoryCounts: map[personaMemCategory]int{
+			personaMemRecall: 6, personaMemEvolution: 5, personaMemRevisit: 4,
+			personaMemGeneralization: 2, personaMemRecommendation: 1, personaMemSuggestIdeas: 3,
+		},
+	},
+	{
+		Split:            "128k",
+		ContextID:        "bb7f46b01bc93add9dc337aa563a8a9bbc4a8245adcffc5a527e6a389dd81743",
+		PersonaID:        "5",
+		RawEndpointCount: 8, EffectiveEndpointCount: 7,
+		CategoryCounts: map[personaMemCategory]int{
+			personaMemRecall: 3, personaMemLatest: 23, personaMemEvolution: 10, personaMemRevisit: 6,
+			personaMemGeneralization: 3, personaMemRecommendation: 6, personaMemSuggestIdeas: 13,
+		},
+	},
+	{
+		Split:            "128k",
+		ContextID:        "5fa9c2b9e3d3f5e476d2a59210ae5d74f94da5f9aa062b7ccdfc650e936944ad",
+		PersonaID:        "4",
+		RawEndpointCount: 8, EffectiveEndpointCount: 8,
+		CategoryCounts: map[personaMemCategory]int{
+			personaMemRecall: 3, personaMemLatest: 14, personaMemEvolution: 4, personaMemRevisit: 7,
+			personaMemGeneralization: 5, personaMemRecommendation: 9, personaMemSuggestIdeas: 10,
+		},
+	},
+	{
+		Split:            "128k",
+		ContextID:        "8d42d864b2b012e2711741b70e107e978aa678ae002d3743070412174e566b51",
+		PersonaID:        "15",
+		RawEndpointCount: 13, EffectiveEndpointCount: 13,
+		CategoryCounts: map[personaMemCategory]int{
+			personaMemRecall: 5, personaMemLatest: 13, personaMemEvolution: 8, personaMemRevisit: 6,
+			personaMemGeneralization: 3, personaMemRecommendation: 1, personaMemSuggestIdeas: 10,
+		},
+	},
+}
+
+var personaMemExpectedSplitCounts = map[string]map[personaMemCategory]int{
+	"32k": {
+		personaMemRecall: 146, personaMemLatest: 0, personaMemEvolution: 139, personaMemRevisit: 99,
+		personaMemGeneralization: 57, personaMemRecommendation: 55, personaMemSuggestIdeas: 93,
+	},
+	"128k": {
+		personaMemRecall: 171, personaMemLatest: 866, personaMemEvolution: 341, personaMemRevisit: 269,
+		personaMemGeneralization: 213, personaMemRecommendation: 349, personaMemSuggestIdeas: 518,
+	},
+	"1M": {
+		personaMemRecall: 144, personaMemLatest: 768, personaMemEvolution: 225, personaMemRevisit: 235,
+		personaMemGeneralization: 295, personaMemRecommendation: 280, personaMemSuggestIdeas: 727,
+	},
+}
+
+var personaMemExpectedHashes = map[string]string{
+	"questions_32k.csv":          "cccd34cf53e0bc4d9536c04cff5ca045156d9a4e227e83327112482840bbc93c",
+	"shared_contexts_32k.jsonl":  "217247ebfec9e8442fc53570c795ab69f21aad08745f7de78d9beab51b122d4a",
+	"questions_128k.csv":         "f0e137c3167fadbffbce5be2786105283c3299972c4ac1f158939155fd1578a7",
+	"shared_contexts_128k.jsonl": "733cc009e84a138b386c9e40adea741565db01074f73af4058fd039b42951726",
+	"questions_1M.csv":           "f24db37c1ef49e8f3cc6585da3d7e1638bb9bfb32c95df4de065e4666e448e1f",
+}
+
+type personaMemMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type personaMemQuestion struct {
+	PersonaID   string             `json:"persona_id"`
+	QuestionID  string             `json:"question_id"`
+	Type        string             `json:"question_type"`
+	Category    personaMemCategory `json:"category"`
+	Topic       string             `json:"topic"`
+	Question    string             `json:"question"`
+	Gold        string             `json:"gold"`
+	Options     string             `json:"options"`
+	ContextID   string             `json:"shared_context_id"`
+	RawEndpoint int                `json:"raw_endpoint"`
+	Endpoint    int                `json:"effective_endpoint"`
+}
+
+type personaMemSample struct {
+	Spec          personaMemSampleSpec
+	Messages      []personaMemMessage
+	MessageBlocks []int
+	PersonaSeed   string
+	SystemCount   int
+	Questions     []personaMemQuestion
+}
+
+type personaMemDataAudit struct {
+	SHA256        string
+	CategoryCount map[personaMemCategory]int
+}
+
+type personaMemMemoryCall struct {
+	Action      string `json:"action"`
+	Query       string `json:"query,omitempty"`
+	Limit       int    `json:"limit,omitempty"`
+	Outcome     string `json:"outcome"`
+	ResultBytes int    `json:"result_bytes"`
+	Error       string `json:"error,omitempty"`
+}
+
+type personaMemAnswerRecord struct {
+	Split           string                 `json:"split"`
+	ContextID       string                 `json:"shared_context_id"`
+	PersonaID       string                 `json:"persona_id"`
+	Endpoint        int                    `json:"endpoint"`
+	QuestionID      string                 `json:"question_id"`
+	QuestionType    string                 `json:"question_type"`
+	Category        personaMemCategory     `json:"category"`
+	Question        string                 `json:"question"`
+	Gold            string                 `json:"gold"`
+	Prediction      string                 `json:"prediction,omitempty"`
+	ExtractedAnswer string                 `json:"extracted_answer,omitempty"`
+	Completed       bool                   `json:"completed"`
+	Correct         bool                   `json:"correct"`
+	Attempts        int                    `json:"attempts"`
+	ToolsUsed       []string               `json:"tools_used,omitempty"`
+	MemoryCalls     []personaMemMemoryCall `json:"memory_calls,omitempty"`
+	Error           string                 `json:"error,omitempty"`
+	AnsweredAt      time.Time              `json:"answered_at"`
+}
+
+type personaMemEndpointState struct {
+	Endpoint       int              `json:"endpoint"`
+	MemoryVersion  int64            `json:"memory_version"`
+	Profile        string           `json:"profile"`
+	Knowledge      []memory.Fact    `json:"knowledge"`
+	FactWatermarks map[string]int64 `json:"fact_watermarks"`
+	PairDigest     string           `json:"pair_digest"`
+	CapturedAt     time.Time        `json:"captured_at"`
+}
+
+type personaMemContextCheckpoint struct {
+	Split                 string                              `json:"split"`
+	ContextID             string                              `json:"shared_context_id"`
+	PersonaID             string                              `json:"persona_id"`
+	UserID                string                              `json:"user_id"`
+	ProfileSeeded         bool                                `json:"profile_seeded"`
+	LastIngestedExclusive int                                 `json:"last_ingested_exclusive"`
+	LastCompletedEndpoint int                                 `json:"last_completed_endpoint"`
+	FactWatermarks        map[string]int64                    `json:"fact_watermarks"`
+	EndpointStates        map[string]*personaMemEndpointState `json:"endpoint_states"`
+	PendingQuestion       *memoryBenchmarkPendingQuestion     `json:"pending_question,omitempty"`
+	Answers               map[string]*personaMemAnswerRecord  `json:"answers"`
+	PairDigest            string                              `json:"pair_digest,omitempty"`
+	ResetRequired         bool                                `json:"reset_required"`
+}
+
+type personaMemCheckpoint struct {
+	Version                       int                                     `json:"version"`
+	Mode                          string                                  `json:"mode"`
+	QAPolicy                      string                                  `json:"qa_policy"`
+	DatasetSHA256                 map[string]string                       `json:"dataset_sha256"`
+	SelectorSeed                  string                                  `json:"selector_seed"`
+	SelectorHash                  string                                  `json:"selector_hash"`
+	SelectionSHA256               string                                  `json:"selection_sha256"`
+	CoreQuestionCount             int                                     `json:"core_question_count"`
+	ExtendedQuestionCount         int                                     `json:"extended_question_count"`
+	AnswerModel                   string                                  `json:"answer_model"`
+	Model                         personaMemModelIdentity                 `json:"model"`
+	ReflectReviewerTimeoutSeconds int64                                   `json:"reflect_reviewer_timeout_seconds"`
+	ReflectPreWriteMaxAttempts    int                                     `json:"reflect_pre_write_max_attempts"`
+	StartedAt                     time.Time                               `json:"started_at"`
+	UpdatedAt                     time.Time                               `json:"updated_at"`
+	Contexts                      map[string]*personaMemContextCheckpoint `json:"contexts"`
+	RunDirectory                  string                                  `json:"run_directory"`
+}
+
+type personaMemModelIdentity struct {
+	ProviderHost           string                               `json:"provider_host"`
+	ProviderEndpointSHA256 string                               `json:"provider_endpoint_sha256"`
+	RequestedModel         string                               `json:"requested_model"`
+	RouterMetadata         []memoryBenchmarkRemoteModelMetadata `json:"router_metadata"`
+	SnapshotStatus         string                               `json:"snapshot_status"`
+	SnapshotVerified       bool                                 `json:"snapshot_verified"`
+	Note                   string                               `json:"note"`
+}
+
+type personaMemRunManifest struct {
+	Version                       int                     `json:"version"`
+	Mode                          string                  `json:"mode"`
+	QAPolicy                      string                  `json:"qa_policy"`
+	RepositoryCommit              string                  `json:"repository_commit"`
+	AgentID                       string                  `json:"agent_id"`
+	DatasetSHA256                 map[string]string       `json:"dataset_sha256"`
+	SelectorSeed                  string                  `json:"selector_seed"`
+	SelectorHash                  string                  `json:"selector_hash"`
+	SelectionSHA256               string                  `json:"selection_sha256"`
+	CoreQuestionCount             int                     `json:"core_question_count"`
+	ExtendedQuestionCount         int                     `json:"extended_question_count"`
+	SelectedContexts              []personaMemSampleSpec  `json:"selected_contexts"`
+	Model                         personaMemModelIdentity `json:"model"`
+	Thinking                      string                  `json:"thinking"`
+	Temperature                   float64                 `json:"temperature"`
+	MemoryToolBudget              int                     `json:"memory_tool_budget"`
+	MemoryCallAudit               string                  `json:"memory_call_audit"`
+	ReflectReviewerTimeoutSeconds int64                   `json:"reflect_reviewer_timeout_seconds"`
+	ReflectPreWriteMaxAttempts    int                     `json:"reflect_pre_write_max_attempts"`
+	FactLine                      bool                    `json:"fact_line"`
+	SkillLine                     bool                    `json:"skill_line"`
+	Curator                       bool                    `json:"curator"`
+	ProfileSeedPolicy             string                  `json:"profile_seed_policy"`
+	EndpointSlicePolicy           string                  `json:"endpoint_slice_policy"`
+	CreatedAt                     time.Time               `json:"created_at"`
+}
+
+type personaMemScore struct {
+	Correct   int      `json:"correct"`
+	Completed int      `json:"completed"`
+	Expected  int      `json:"expected"`
+	Accuracy  *float64 `json:"accuracy,omitempty"`
+}
+
+type personaMemScoreReport struct {
+	Overall            personaMemScore                        `json:"overall"`
+	CoreCategories     map[personaMemCategory]personaMemScore `json:"core_categories"`
+	CoreMacroAccuracy  *float64                               `json:"core_macro_accuracy,omitempty"`
+	ExtendedCategories map[personaMemCategory]personaMemScore `json:"extended_categories"`
+	GeneratedAt        time.Time                              `json:"generated_at"`
+}
+
+type personaMemAuditMemoryTool struct {
+	inner tools.Tool
+	mu    sync.Mutex
+	calls []personaMemMemoryCall
+}
+
+func (tool *personaMemAuditMemoryTool) Definition() tools.Definition {
+	return tool.inner.Definition()
+}
+
+func (tool *personaMemAuditMemoryTool) Execute(ctx context.Context, args map[string]any) (string, error) {
+	result, err := tool.inner.Execute(ctx, args)
+	outcome := "executed"
+	// The frozen wrapper returns a successful sentinel for attempts denied
+	// before backend execution, so preserve that distinction in artifacts.
+	if err == nil && result == memoryBenchmarkBudgetExhaustedMessage {
+		outcome = "budget_denied"
+	}
+	call := personaMemMemoryCall{
+		Action:      personaMemStringArg(args, "action"),
+		Query:       personaMemStringArg(args, "query"),
+		Limit:       memoryBenchmarkIntArg(args, "limit", 0),
+		Outcome:     outcome,
+		ResultBytes: len(result),
+	}
+	if err != nil {
+		call.Error = err.Error()
+	}
+	tool.mu.Lock()
+	tool.calls = append(tool.calls, call)
+	tool.mu.Unlock()
+	return result, err
+}
+
+func personaMemStringArg(args map[string]any, key string) string {
+	value, ok := args[key].(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(value)
+}
+
+func (tool *personaMemAuditMemoryTool) Calls() []personaMemMemoryCall {
+	tool.mu.Lock()
+	defer tool.mu.Unlock()
+	return append([]personaMemMemoryCall(nil), tool.calls...)
+}
+
+func normalizePersonaMemQuestionType(value string) (personaMemCategory, bool) {
+	switch strings.TrimSpace(value) {
+	case "recall_user_shared_facts", "recalling_facts_mentioned_by_the_user":
+		return personaMemRecall, true
+	case "acknowledge_latest_user_preferences", "acknowledge_latest_preferences":
+		return personaMemLatest, true
+	case "track_full_preference_evolution", "track_full_preference_updates":
+		return personaMemEvolution, true
+	case "recalling_the_reasons_behind_previous_updates", "revisit_reasons_behind_preference_updates":
+		return personaMemRevisit, true
+	case "generalize_to_new_scenarios", "generalizing_to_new_scenarios":
+		return personaMemGeneralization, true
+	case "provide_preference_aligned_recommendations":
+		return personaMemRecommendation, true
+	case "suggest_new_ideas":
+		return personaMemSuggestIdeas, true
+	default:
+		return "", false
+	}
+}
+
+func loadPersonaMemDataset(specs []personaMemSampleSpec) ([]personaMemSample, map[string]string, error) {
+	samples := make([]personaMemSample, 0, len(specs))
+	hashes := make(map[string]string, len(specs)*2)
+	for _, spec := range specs {
+		questionName := "questions_" + spec.Split + ".csv"
+		contextName := "shared_contexts_" + spec.Split + ".jsonl"
+		questions, audit, err := loadPersonaMemQuestions(filepath.Join(personaMemDataRoot, questionName), spec.ContextID)
+		if err != nil {
+			return nil, nil, err
+		}
+		messages, contextSHA, err := loadPersonaMemContext(filepath.Join(personaMemDataRoot, contextName), spec.ContextID)
+		if err != nil {
+			return nil, nil, err
+		}
+		hashes[questionName] = audit.SHA256
+		hashes[contextName] = contextSHA
+		sample, err := buildPersonaMemSample(spec, questions, messages)
+		if err != nil {
+			return nil, nil, fmt.Errorf("validate PersonaMem %s/%s: %w", spec.Split, spec.ContextID, err)
+		}
+		samples = append(samples, sample)
+	}
+	if err := validatePersonaMemHashes(hashes); err != nil {
+		return nil, nil, err
+	}
+	return samples, hashes, nil
+}
+
+func loadPersonaMemQuestions(path, contextID string) ([]personaMemQuestion, personaMemDataAudit, error) {
+	payload, err := os.Open(path)
+	if err != nil {
+		return nil, personaMemDataAudit{}, fmt.Errorf("open PersonaMem questions: %w", err)
+	}
+	defer func() { _ = payload.Close() }()
+	hash := sha256.New()
+	reader := csv.NewReader(io.TeeReader(payload, hash))
+	reader.ReuseRecord = true
+	header, err := reader.Read()
+	if err != nil {
+		return nil, personaMemDataAudit{}, fmt.Errorf("read PersonaMem question header: %w", err)
+	}
+	columns := make(map[string]int, len(header))
+	for index, name := range header {
+		columns[name] = index
+	}
+	required := []string{"persona_id", "question_id", "question_type", "topic", "user_question_or_message", "correct_answer", "all_options", "shared_context_id", "end_index_in_shared_context"}
+	for _, name := range required {
+		if _, ok := columns[name]; !ok {
+			return nil, personaMemDataAudit{}, fmt.Errorf("PersonaMem questions lack column %q", name)
+		}
+	}
+	audit := personaMemDataAudit{CategoryCount: make(map[personaMemCategory]int)}
+	var selected []personaMemQuestion
+	for rowNumber := 2; ; rowNumber++ {
+		row, err := reader.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, personaMemDataAudit{}, fmt.Errorf("read PersonaMem question row %d: %w", rowNumber, err)
+		}
+		category, target := normalizePersonaMemQuestionType(row[columns["question_type"]])
+		if !target {
+			continue
+		}
+		audit.CategoryCount[category]++
+		if row[columns["shared_context_id"]] != contextID {
+			continue
+		}
+		endpoint, err := strconv.Atoi(row[columns["end_index_in_shared_context"]])
+		if err != nil {
+			return nil, personaMemDataAudit{}, fmt.Errorf("row %d endpoint: %w", rowNumber, err)
+		}
+		selected = append(selected, personaMemQuestion{
+			PersonaID: row[columns["persona_id"]], QuestionID: row[columns["question_id"]],
+			Type: row[columns["question_type"]], Category: category, Topic: row[columns["topic"]],
+			Question: row[columns["user_question_or_message"]], Gold: row[columns["correct_answer"]],
+			Options: row[columns["all_options"]], ContextID: contextID,
+			RawEndpoint: endpoint, Endpoint: endpoint,
+		})
+	}
+	audit.SHA256 = hex.EncodeToString(hash.Sum(nil))
+	sort.Slice(selected, func(i, j int) bool {
+		if selected[i].Endpoint == selected[j].Endpoint {
+			return selected[i].QuestionID < selected[j].QuestionID
+		}
+		return selected[i].Endpoint < selected[j].Endpoint
+	})
+	return selected, audit, nil
+}
+
+func loadPersonaMemContext(path, contextID string) ([]personaMemMessage, string, error) {
+	sha, err := personaMemSHA256File(path)
+	if err != nil {
+		return nil, "", err
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, "", fmt.Errorf("open PersonaMem contexts: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 64*1024), 32*1024*1024)
+	var found []personaMemMessage
+	for scanner.Scan() {
+		var row map[string]json.RawMessage
+		if err := json.Unmarshal(scanner.Bytes(), &row); err != nil {
+			return nil, "", fmt.Errorf("decode PersonaMem context row: %w", err)
+		}
+		raw, ok := row[contextID]
+		if !ok {
+			continue
+		}
+		if found != nil {
+			return nil, "", fmt.Errorf("PersonaMem context %s appears more than once", contextID)
+		}
+		if err := json.Unmarshal(raw, &found); err != nil {
+			return nil, "", fmt.Errorf("decode PersonaMem context %s: %w", contextID, err)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, "", fmt.Errorf("scan PersonaMem contexts: %w", err)
+	}
+	if found == nil {
+		return nil, "", fmt.Errorf("PersonaMem context %s is missing", contextID)
+	}
+	return found, sha, nil
+}
+
+func personaMemSHA256File(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = file.Close() }()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func buildPersonaMemSample(spec personaMemSampleSpec, questions []personaMemQuestion, messages []personaMemMessage) (personaMemSample, error) {
+	if len(questions) == 0 || len(messages) == 0 {
+		return personaMemSample{}, fmt.Errorf("questions and messages are required")
+	}
+	categoryCounts := make(map[personaMemCategory]int)
+	endpoints := make(map[int]struct{})
+	rawEndpoints := make(map[int]struct{})
+	for index := range questions {
+		questions[index].Endpoint = personaMemPythonSliceEnd(questions[index].RawEndpoint, len(messages))
+	}
+	sort.Slice(questions, func(i, j int) bool {
+		if questions[i].Endpoint == questions[j].Endpoint {
+			return questions[i].QuestionID < questions[j].QuestionID
+		}
+		return questions[i].Endpoint < questions[j].Endpoint
+	})
+	for _, question := range questions {
+		if question.PersonaID != spec.PersonaID {
+			return personaMemSample{}, fmt.Errorf("question %s persona=%s, want %s", question.QuestionID, question.PersonaID, spec.PersonaID)
+		}
+		if question.Endpoint <= 0 || question.Endpoint > len(messages) {
+			return personaMemSample{}, fmt.Errorf("question %s endpoint=%d outside context length %d", question.QuestionID, question.Endpoint, len(messages))
+		}
+		if messages[question.Endpoint-1].Role == "system" {
+			return personaMemSample{}, fmt.Errorf("question %s endpoint ends on a system boundary", question.QuestionID)
+		}
+		if normalizePersonaMemGold(question.Gold) == "" {
+			return personaMemSample{}, fmt.Errorf("question %s has invalid gold %q", question.QuestionID, question.Gold)
+		}
+		if strings.TrimSpace(question.Options) == "" {
+			return personaMemSample{}, fmt.Errorf("question %s has empty options", question.QuestionID)
+		}
+		categoryCounts[question.Category]++
+		endpoints[question.Endpoint] = struct{}{}
+		rawEndpoints[question.RawEndpoint] = struct{}{}
+	}
+	for _, category := range personaMemCategories {
+		if categoryCounts[category] != spec.CategoryCounts[category] {
+			return personaMemSample{}, fmt.Errorf("%s count=%d, want %d", category, categoryCounts[category], spec.CategoryCounts[category])
+		}
+	}
+	if len(rawEndpoints) != spec.RawEndpointCount || len(endpoints) != spec.EffectiveEndpointCount {
+		return personaMemSample{}, fmt.Errorf("raw/effective endpoint counts=%d/%d, want %d/%d",
+			len(rawEndpoints), len(endpoints), spec.RawEndpointCount, spec.EffectiveEndpointCount)
+	}
+
+	blocks := make([]int, len(messages))
+	block := 0
+	persona := ""
+	for index, message := range messages {
+		switch message.Role {
+		case "system":
+			block++
+			if !strings.HasPrefix(strings.TrimSpace(message.Content), personaMemSystemPrefix) {
+				return personaMemSample{}, fmt.Errorf("system message %d lacks persona prefix", index)
+			}
+			if persona == "" {
+				persona = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(message.Content), personaMemSystemPrefix))
+			} else if message.Content != messages[0].Content {
+				return personaMemSample{}, fmt.Errorf("system persona at message %d differs from the first copy", index)
+			}
+		case "user", "assistant":
+			if block == 0 {
+				return personaMemSample{}, fmt.Errorf("message %d appears before the first system boundary", index)
+			}
+		default:
+			return personaMemSample{}, fmt.Errorf("message %d has unsupported role %q", index, message.Role)
+		}
+		blocks[index] = block
+	}
+	if block == 0 || persona == "" {
+		return personaMemSample{}, fmt.Errorf("context has no usable system persona")
+	}
+	return personaMemSample{
+		Spec: spec, Messages: messages, MessageBlocks: blocks,
+		PersonaSeed: persona, SystemCount: block, Questions: questions,
+	}, nil
+}
+
+func personaMemPythonSliceEnd(endpoint, length int) int {
+	if endpoint < 0 {
+		endpoint = length + endpoint
+	}
+	if endpoint < 0 {
+		return 0
+	}
+	if endpoint > length {
+		return length
+	}
+	return endpoint
+}
+
+func validatePersonaMemHashes(hashes map[string]string) error {
+	for name, actual := range hashes {
+		if expected := personaMemExpectedHashes[name]; expected != "" && actual != expected {
+			return fmt.Errorf("PersonaMem %s SHA256=%s, want %s", name, actual, expected)
+		}
+	}
+	return nil
+}
+
+var (
+	personaMemParenOption = regexp.MustCompile(`\(([a-d])\)`)
+	personaMemWordOption  = regexp.MustCompile(`\b([a-d])\b`)
+)
+
+func extractPersonaMemAnswer(prediction, gold string) (bool, string) {
+	correct := normalizePersonaMemGold(gold)
+	full := prediction
+	cleaned := strings.TrimSpace(prediction)
+	if index := strings.LastIndex(cleaned, "<final_answer>"); index >= 0 {
+		cleaned = strings.TrimSpace(cleaned[index+len("<final_answer>"):])
+	}
+	if strings.HasSuffix(cleaned, "</final_answer>") {
+		cleaned = strings.TrimSpace(strings.TrimSuffix(cleaned, "</final_answer>"))
+	}
+	cleanedOptions := personaMemOptionSet(cleaned)
+	if cleanedOptions[correct] && len(cleanedOptions) == 1 {
+		return true, cleaned
+	}
+	options := personaMemOptionSet(full)
+	return options[correct] && len(options) == 1, cleaned
+}
+
+func normalizePersonaMemGold(value string) string {
+	value = strings.ToLower(strings.Trim(value, "() \t\r\n"))
+	if len(value) == 1 && value[0] >= 'a' && value[0] <= 'd' {
+		return value
+	}
+	return ""
+}
+
+func personaMemOptionSet(value string) map[string]bool {
+	value = strings.ToLower(value)
+	matches := personaMemParenOption.FindAllStringSubmatch(value, -1)
+	if len(matches) == 0 {
+		matches = personaMemWordOption.FindAllStringSubmatch(value, -1)
+	}
+	result := make(map[string]bool, len(matches))
+	for _, match := range matches {
+		result[match[1]] = true
+	}
+	return result
+}
+
+func buildPersonaMemQuestionPrompt(question personaMemQuestion) string {
+	return question.Question + "\n\n" + personaMemAnswerPrompt + "\n\n" + question.Options
+}
+
+func personaMemEndpoints(sample personaMemSample) []int {
+	set := make(map[int]struct{})
+	for _, question := range sample.Questions {
+		set[question.Endpoint] = struct{}{}
+	}
+	result := make([]int, 0, len(set))
+	for endpoint := range set {
+		result = append(result, endpoint)
+	}
+	sort.Ints(result)
+	return result
+}
+
+func personaMemQuestionsAt(sample personaMemSample, endpoint int) []personaMemQuestion {
+	var result []personaMemQuestion
+	for _, question := range sample.Questions {
+		if question.Endpoint == endpoint {
+			result = append(result, question)
+		}
+	}
+	return result
+}
+
+func personaMemSelectionSHA256(samples []personaMemSample) string {
+	records := make([]string, 0)
+	for _, sample := range samples {
+		for _, question := range sample.Questions {
+			records = append(records, strings.Join([]string{
+				sample.Spec.Split,
+				sample.Spec.ContextID,
+				question.QuestionID,
+				string(question.Category),
+				strconv.Itoa(question.RawEndpoint),
+				strconv.Itoa(question.Endpoint),
+			}, "|"))
+		}
+	}
+	sort.Strings(records)
+	sum := sha256.Sum256([]byte(strings.Join(records, "\n")))
+	return hex.EncodeToString(sum[:])
+}
+
+func personaMemQuestionGroupCounts(samples []personaMemSample) (int, int, error) {
+	core := 0
+	extended := 0
+	for _, sample := range samples {
+		for _, question := range sample.Questions {
+			switch {
+			case personaMemIsCoreCategory(question.Category):
+				core++
+			case personaMemIsExtendedCategory(question.Category):
+				extended++
+			default:
+				return 0, 0, fmt.Errorf("unsupported PersonaMem category %q", question.Category)
+			}
+		}
+	}
+	return core, extended, nil
+}
+
+func runPersonaMem(ctx context.Context, setupState *setupResult, mode string) error {
+	samples, datasetSHA, err := loadPersonaMemDataset(personaMemSelectedSpecs)
+	if err != nil {
+		return err
+	}
+	if !sameStringMap(datasetSHA, personaMemExpectedDatasetSHA256) {
+		return fmt.Errorf("PersonaMem dataset SHA-256 does not match the fixed v1 evaluation corpus")
+	}
+	if mode == "smoke" {
+		samples = personaMemSmokeSamples(samples)
+	}
+	selectionSHA := personaMemSelectionSHA256(samples)
+	coreQuestionCount, extendedQuestionCount, err := personaMemQuestionGroupCounts(samples)
+	if err != nil {
+		return err
+	}
+	agentCfg, err := configureMemoryBenchmarkAgent(
+		ctx,
+		setupState,
+		personaMemAgentID,
+		"PersonaMem Benchmark",
+		personaMemProviderID,
+		personaMemAnswerModelID,
+	)
+	if err != nil {
+		return err
+	}
+	providerCfg, err := setupState.store.GetProvider(ctx, personaMemProviderID)
+	if err != nil {
+		return fmt.Errorf("get provider %q: %w", personaMemProviderID, err)
+	}
+	if !providerCfg.Enabled || strings.TrimSpace(providerCfg.APIKey) == "" || strings.TrimSpace(providerCfg.BaseURL) == "" {
+		return fmt.Errorf("provider %q is not enabled with API key and base URL", personaMemProviderID)
+	}
+	benchmarkSnapshot, err := setupState.snapshotLoader.Snapshot(ctx, agentCfg.ID)
+	if err != nil {
+		return fmt.Errorf("load PersonaMem credential-aware snapshot: %w", err)
+	}
+	resolvedCreds := benchmarkSnapshot.ResolveProviderCreds(personaMemProviderID)
+	if resolvedCreds.Type != providerCfg.Type || resolvedCreds.APIKey != providerCfg.APIKey ||
+		strings.TrimRight(resolvedCreds.BaseURL, "/") != strings.TrimRight(providerCfg.BaseURL, "/") {
+		return fmt.Errorf("PersonaMem benchmark agent has a provider credential override; use an isolated home without agent-specific credentials")
+	}
+	personaMemStream := openaiprovider.NewDeepSeekThinkingDisabledBenchmarkStream(openaiprovider.Config{
+		APIKey: providerCfg.APIKey, BaseURL: providerCfg.BaseURL,
+	})
+	if err := probePersonaMemModel(ctx, providerCfg, personaMemStream); err != nil {
+		return fmt.Errorf("probe PersonaMem model %q: %w", personaMemAnswerModelID, err)
+	}
+	modelIdentity, err := personaMemModelIdentityFromProvider(ctx, providerCfg)
+	if err != nil {
+		return err
+	}
+
+	runName, err := personaMemRunName(mode)
+	if err != nil {
+		return err
+	}
+	runDir := filepath.Join(personaMemRunsRoot, runName)
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		return fmt.Errorf("create PersonaMem run directory: %w", err)
+	}
+	checkpointPath := filepath.Join(runDir, "checkpoint.json")
+	checkpoint, err := loadOrCreatePersonaMemCheckpoint(
+		checkpointPath,
+		runDir,
+		mode,
+		modelIdentity,
+		datasetSHA,
+		selectionSHA,
+		coreQuestionCount,
+		extendedQuestionCount,
+	)
+	if err != nil {
+		return err
+	}
+	if err := writePersonaMemManifest(
+		runDir,
+		mode,
+		datasetSHA,
+		samples,
+		selectionSHA,
+		coreQuestionCount,
+		extendedQuestionCount,
+		agentCfg.ID,
+		modelIdentity,
+	); err != nil {
+		return err
+	}
+
+	reflectSvc := reflect.New(reflect.Config{
+		StateStore: pluginhost.NewScopedStateStore(setupState.pluginHost.StateStore(), "reflect"),
+		Memory:     setupState.mem,
+		Store:      setupState.store,
+		Snapshots:  setupState.snapshotLoader,
+		Providers: func(api, apiKey, baseURL string) (providers.StreamFunc, error) {
+			if api != personaMemProviderID {
+				return nil, fmt.Errorf("PersonaMem expected provider %q, got %q", personaMemProviderID, api)
+			}
+			base := openaiprovider.NewDeepSeekThinkingDisabledBenchmarkStream(openaiprovider.Config{
+				APIKey: apiKey, BaseURL: baseURL,
+			})
+			return personaMemReflectStream(base), nil
+		},
+	})
+
+	for _, sample := range samples {
+		key := sample.Spec.Split + ":" + sample.Spec.ContextID
+		state := checkpoint.Contexts[key]
+		newState := state == nil
+		if state == nil {
+			state = newPersonaMemContextCheckpoint(mode, sample)
+			checkpoint.Contexts[key] = state
+		}
+		if err := normalizePersonaMemContextCheckpoint(state); err != nil {
+			return fmt.Errorf("checkpoint %s: %w", key, err)
+		}
+		if mode == "smoke" || newState || state.ResetRequired {
+			if err := resetPersonaMemContext(ctx, setupState, checkpointPath, checkpoint, state, sample, agentCfg.ID); err != nil {
+				return err
+			}
+		} else {
+			if err := ensureMemoryBenchmarkUser(ctx, setupState, state.UserID, agentCfg.ID, "PersonaMem persona "+sample.Spec.PersonaID); err != nil {
+				return err
+			}
+			if state.PendingQuestion != nil {
+				if err := recoverMemoryBenchmarkPendingQuestion(ctx, setupState, state.UserID, agentCfg.ID, state.PendingQuestion); err != nil {
+					return err
+				}
+				state.PendingQuestion = nil
+				if err := savePersonaMemCheckpoint(checkpointPath, checkpoint); err != nil {
+					return err
+				}
+			}
+			if state.PairDigest != "" {
+				current, err := personaMemPairDigest(ctx, setupState, state.UserID, agentCfg.ID)
+				if err != nil {
+					return err
+				}
+				if current != state.PairDigest {
+					state.ResetRequired = true
+					_ = savePersonaMemCheckpoint(checkpointPath, checkpoint)
+					return fmt.Errorf("PersonaMem %s persisted pair state differs from checkpoint; rerun to rebuild it", key)
+				}
+			}
+		}
+
+		for _, endpoint := range personaMemEndpoints(sample) {
+			if endpoint > state.LastCompletedEndpoint {
+				if err := ingestPersonaMemEndpoint(ctx, setupState, reflectSvc, checkpointPath, checkpoint, state, sample, agentCfg.ID, endpoint); err != nil {
+					return err
+				}
+			}
+			for _, question := range personaMemQuestionsAt(sample, endpoint) {
+				if state.Answers[question.QuestionID] != nil {
+					continue
+				}
+				record, err := answerPersonaMemQuestionWithRetry(ctx, setupState, checkpointPath, checkpoint, state, sample, question, agentCfg.ID, personaMemStream)
+				if err != nil {
+					return err
+				}
+				state.Answers[question.QuestionID] = record
+				if err := savePersonaMemCheckpoint(checkpointPath, checkpoint); err != nil {
+					return err
+				}
+				if err := writePersonaMemArtifacts(runDir, checkpoint, samples); err != nil {
+					return err
+				}
+			}
+			current, err := personaMemPairDigest(ctx, setupState, state.UserID, agentCfg.ID)
+			if err != nil {
+				return err
+			}
+			if current != state.PairDigest {
+				state.ResetRequired = true
+				_ = savePersonaMemCheckpoint(checkpointPath, checkpoint)
+				return fmt.Errorf("PersonaMem %s endpoint %d changed frozen pair state during QA", key, endpoint)
+			}
+			fmt.Printf("personamem endpoint complete: split=%s context=%s endpoint=%d questions=%d\n",
+				sample.Spec.Split, sample.Spec.ContextID[:12], endpoint, len(personaMemQuestionsAt(sample, endpoint)))
+		}
+	}
+	if err := savePersonaMemCheckpoint(checkpointPath, checkpoint); err != nil {
+		return err
+	}
+	if err := writePersonaMemArtifacts(runDir, checkpoint, samples); err != nil {
+		return err
+	}
+	if err := verifyNoPersonaMemQASessions(ctx, setupState, mode); err != nil {
+		return err
+	}
+	fmt.Printf("PersonaMem %s artifacts: %s\n", mode, runDir)
+	return nil
+}
+
+func personaMemReflectStream(base providers.StreamFunc) providers.StreamFunc {
+	return func(ctx context.Context, model ai.Model, aiCtx ai.Context, opts ai.StreamOptions) (providers.AssistantEventStream, error) {
+		// PersonaMem's dense 128k sessions can exceed the production reviewer's
+		// two-minute provider budget. Only this local benchmark stream receives
+		// the larger timeout; production Reflect and benchmark QA are unchanged.
+		if opts.Timeout < personaMemReflectTimeout {
+			opts.Timeout = personaMemReflectTimeout
+		}
+		return base(ctx, model, aiCtx, opts)
+	}
+}
+
+func personaMemSmokeSamples(samples []personaMemSample) []personaMemSample {
+	bestSample := -1
+	bestEndpoint := 0
+	for sampleIndex, sample := range samples {
+		for _, endpoint := range personaMemEndpoints(sample) {
+			questions := personaMemQuestionsAt(sample, endpoint)
+			if !personaMemQuestionsContainCoreAndExtended(questions) {
+				continue
+			}
+			if bestSample == -1 || endpoint < bestEndpoint {
+				bestSample = sampleIndex
+				bestEndpoint = endpoint
+			}
+		}
+	}
+	if bestSample == -1 {
+		return samples
+	}
+	sample := samples[bestSample]
+	questions := personaMemQuestionsAt(sample, bestEndpoint)
+	var coreQuestion, extendedQuestion *personaMemQuestion
+	for index := range questions {
+		if coreQuestion == nil && personaMemIsCoreCategory(questions[index].Category) {
+			coreQuestion = &questions[index]
+		}
+		if extendedQuestion == nil && personaMemIsExtendedCategory(questions[index].Category) {
+			extendedQuestion = &questions[index]
+		}
+	}
+	if coreQuestion == nil || extendedQuestion == nil {
+		return samples
+	}
+	sample.Questions = []personaMemQuestion{*coreQuestion, *extendedQuestion}
+	return []personaMemSample{sample}
+}
+
+func personaMemQuestionsContainCoreAndExtended(questions []personaMemQuestion) bool {
+	hasCore := false
+	hasExtended := false
+	for _, question := range questions {
+		hasCore = hasCore || personaMemIsCoreCategory(question.Category)
+		hasExtended = hasExtended || personaMemIsExtendedCategory(question.Category)
+	}
+	return hasCore && hasExtended
+}
+
+func personaMemIsCoreCategory(category personaMemCategory) bool {
+	switch category {
+	case personaMemRecall, personaMemLatest, personaMemEvolution, personaMemRevisit:
+		return true
+	default:
+		return false
+	}
+}
+
+func personaMemIsExtendedCategory(category personaMemCategory) bool {
+	switch category {
+	case personaMemGeneralization, personaMemRecommendation, personaMemSuggestIdeas:
+		return true
+	default:
+		return false
+	}
+}
+
+func newPersonaMemContextCheckpoint(mode string, sample personaMemSample) *personaMemContextCheckpoint {
+	return &personaMemContextCheckpoint{
+		Split: sample.Spec.Split, ContextID: sample.Spec.ContextID, PersonaID: sample.Spec.PersonaID,
+		UserID:         deterministicPersonaMemUserID(mode, sample.Spec.Split, sample.Spec.ContextID),
+		FactWatermarks: make(map[string]int64), EndpointStates: make(map[string]*personaMemEndpointState),
+		Answers: make(map[string]*personaMemAnswerRecord), ResetRequired: true,
+	}
+}
+
+func normalizePersonaMemContextCheckpoint(state *personaMemContextCheckpoint) error {
+	if state == nil || state.UserID == "" || state.ContextID == "" || state.Split == "" {
+		return fmt.Errorf("incomplete context identity")
+	}
+	if state.FactWatermarks == nil {
+		state.FactWatermarks = make(map[string]int64)
+	}
+	if state.EndpointStates == nil {
+		state.EndpointStates = make(map[string]*personaMemEndpointState)
+	}
+	if state.Answers == nil {
+		state.Answers = make(map[string]*personaMemAnswerRecord)
+	}
+	for questionID, answer := range state.Answers {
+		if answer == nil {
+			return fmt.Errorf("answer %s is nil", questionID)
+		}
+		if err := normalizePersonaMemMemoryCallOutcomes(answer.MemoryCalls); err != nil {
+			return fmt.Errorf("answer %s memory audit: %w", questionID, err)
+		}
+	}
+	return nil
+}
+
+// normalizePersonaMemMemoryCallOutcomes upgrades records produced before the
+// audit distinguished real backend execution from host-side budget denial.
+func normalizePersonaMemMemoryCallOutcomes(calls []personaMemMemoryCall) error {
+	legacy := make([]bool, len(calls))
+	missing := 0
+	existingDenied := 0
+	for index := range calls {
+		switch calls[index].Outcome {
+		case "":
+			legacy[index] = true
+			calls[index].Outcome = "executed"
+			missing++
+		case "executed":
+		case "budget_denied":
+			existingDenied++
+		default:
+			return fmt.Errorf("unknown outcome %q", calls[index].Outcome)
+		}
+	}
+	if missing == 0 || len(calls) <= personaMemQAToolBudget {
+		return nil
+	}
+
+	denied := len(calls) - personaMemQAToolBudget - existingDenied
+	if denied < 0 {
+		return fmt.Errorf("budget-denied calls exceed attempted calls")
+	}
+	for index := len(calls) - 1; index >= 0 && denied > 0; index-- {
+		call := &calls[index]
+		if legacy[index] && call.Error == "" && call.ResultBytes == len(memoryBenchmarkBudgetExhaustedMessage) {
+			call.Outcome = "budget_denied"
+			denied--
+		}
+	}
+	if denied != 0 {
+		return fmt.Errorf("cannot identify %d legacy budget-denied calls", denied)
+	}
+	return nil
+}
+
+func resetPersonaMemContext(
+	ctx context.Context,
+	setupState *setupResult,
+	checkpointPath string,
+	checkpoint *personaMemCheckpoint,
+	state *personaMemContextCheckpoint,
+	sample personaMemSample,
+	agentID string,
+) error {
+	state.ResetRequired = true
+	if err := savePersonaMemCheckpoint(checkpointPath, checkpoint); err != nil {
+		return err
+	}
+	if err := resetMemoryBenchmarkPair(ctx, setupState, state.UserID, agentID, "PersonaMem persona "+sample.Spec.PersonaID); err != nil {
+		return err
+	}
+	state.ProfileSeeded = false
+	state.LastIngestedExclusive = 0
+	state.LastCompletedEndpoint = 0
+	state.FactWatermarks = make(map[string]int64)
+	state.EndpointStates = make(map[string]*personaMemEndpointState)
+	state.PendingQuestion = nil
+	state.Answers = make(map[string]*personaMemAnswerRecord)
+	state.PairDigest = ""
+	writeCtx := authz.WithUserID(ctx, state.UserID)
+	writeCtx = authz.WithAgentID(writeCtx, agentID)
+	profiles, ok := setupState.mem.(memory.ProfileStore)
+	if !ok {
+		return fmt.Errorf("memory provider does not support PersonaMem profile seed")
+	}
+	if err := profiles.SetProfile(writeCtx, state.UserID, agentID, sample.PersonaSeed); err != nil {
+		return fmt.Errorf("seed PersonaMem profile: %w", err)
+	}
+	if err := verifyPersonaMemManualProfileSeed(writeCtx, setupState.mem, state.UserID, agentID, sample.PersonaSeed); err != nil {
+		return err
+	}
+	state.ProfileSeeded = true
+	state.ResetRequired = false
+	return savePersonaMemCheckpoint(checkpointPath, checkpoint)
+}
+
+func verifyPersonaMemManualProfileSeed(ctx context.Context, provider memory.Provider, userID, agentID, want string) error {
+	facts, ok := provider.(memory.FactStore)
+	if !ok {
+		return fmt.Errorf("memory provider does not support fact reads")
+	}
+	profiles, err := facts.ListActiveFacts(ctx, userID, agentID, memory.FactSubjectUser)
+	if err != nil {
+		return fmt.Errorf("read PersonaMem profile seed: %w", err)
+	}
+	if len(profiles) != 1 || profiles[0].Content != want || profiles[0].Source != memory.SourceManual {
+		return fmt.Errorf("PersonaMem profile seed did not persist as one manual user fact")
+	}
+	return nil
+}
+
+func ingestPersonaMemEndpoint(
+	ctx context.Context,
+	setupState *setupResult,
+	reflectSvc *reflect.Service,
+	checkpointPath string,
+	checkpoint *personaMemCheckpoint,
+	state *personaMemContextCheckpoint,
+	sample personaMemSample,
+	agentID string,
+	endpoint int,
+) error {
+	if endpoint <= state.LastIngestedExclusive || endpoint > len(sample.Messages) {
+		return fmt.Errorf("PersonaMem endpoint %d cannot follow exclusive index %d", endpoint, state.LastIngestedExclusive)
+	}
+	state.ResetRequired = true
+	if err := savePersonaMemCheckpoint(checkpointPath, checkpoint); err != nil {
+		return err
+	}
+	touched, err := appendPersonaMemRange(ctx, setupState, checkpoint.Mode, state, sample, agentID, state.LastIngestedExclusive, endpoint)
+	if err != nil {
+		return err
+	}
+	snapshot, err := setupState.snapshotLoader.Snapshot(ctx, agentID)
+	if err != nil {
+		return fmt.Errorf("load PersonaMem agent snapshot: %w", err)
+	}
+	for _, scope := range touched {
+		for round := 1; ; round++ {
+			result, err := reviewPersonaMemFactLineWithRetry(ctx, reflectSvc, snapshot, scope)
+			if err != nil {
+				return fmt.Errorf("PersonaMem fact reflect %s round %d: %w", scope.ID, round, err)
+			}
+			state.FactWatermarks[scope.ID] = result.WatermarkAfter
+			fmt.Printf("personamem reflect: split=%s context=%s endpoint=%d session=%s round=%d fresh=%d generated=%d accepted=%d writes=%d noops=%d calls=%d truncated=%t watermark=%d\n",
+				sample.Spec.Split, sample.Spec.ContextID[:12], endpoint, scope.ID, round, result.FreshCount,
+				result.Generated, result.Accepted, result.Writes, result.Noops, result.LLMCalls, result.Truncated, result.WatermarkAfter)
+			if !result.Truncated {
+				break
+			}
+			if result.WatermarkAfter <= result.WatermarkBefore {
+				return fmt.Errorf("PersonaMem fact reflect %s made no watermark progress", scope.ID)
+			}
+		}
+	}
+	state.LastIngestedExclusive = endpoint
+	state.LastCompletedEndpoint = endpoint
+	endpointState, err := capturePersonaMemEndpointState(ctx, setupState, state, agentID, endpoint)
+	if err != nil {
+		return err
+	}
+	state.PairDigest = endpointState.PairDigest
+	state.EndpointStates[strconv.Itoa(endpoint)] = endpointState
+	state.ResetRequired = false
+	return savePersonaMemCheckpoint(checkpointPath, checkpoint)
+}
+
+func reviewPersonaMemFactLineWithRetry(
+	ctx context.Context,
+	reflectSvc *reflect.Service,
+	snapshot *config.Snapshot,
+	scope memory.Session,
+) (reflect.BenchmarkFactReviewResult, error) {
+	var lastErr error
+	for attempt := 1; attempt <= personaMemReflectMaxAttempts; attempt++ {
+		result, err := reflectSvc.BenchmarkReviewFactLine(ctx, snapshot, scope)
+		if err == nil {
+			return result, nil
+		}
+		lastErr = err
+		// Only provider/protocol failures explicitly marked as pre-write-safe may
+		// retry. Ambiguous write-stage failures still rebuild the whole pair.
+		if !reflect.BenchmarkFactReviewRetrySafe(err) || !isMemoryBenchmarkTransient(err) || attempt == personaMemReflectMaxAttempts {
+			break
+		}
+		fmt.Printf("personamem reflect pre-write retry: session=%s attempt=%d error=%v\n", scope.ID, attempt, err)
+		time.Sleep(time.Duration(attempt*2) * time.Second)
+	}
+	return reflect.BenchmarkFactReviewResult{}, lastErr
+}
+
+func appendPersonaMemRange(
+	ctx context.Context,
+	setupState *setupResult,
+	mode string,
+	state *personaMemContextCheckpoint,
+	sample personaMemSample,
+	agentID string,
+	start, end int,
+) ([]memory.Session, error) {
+	sessionManager, ok := setupState.mem.(memory.SessionManager)
+	if !ok {
+		return nil, fmt.Errorf("memory provider does not support sessions")
+	}
+	type appendBatch struct {
+		scope    memory.Session
+		block    int
+		messages []ai.Message
+	}
+	var batches []appendBatch
+	for index := start; index < end; index++ {
+		message := sample.Messages[index]
+		if message.Role == "system" {
+			continue
+		}
+		block := sample.MessageBlocks[index]
+		sessionID := personaMemHistorySessionID(mode, sample, block)
+		scope := memory.Session{ID: sessionID, UserID: state.UserID, AgentID: agentID, Channel: string(session.ChannelCLI)}
+		if len(batches) == 0 || batches[len(batches)-1].block != block {
+			batches = append(batches, appendBatch{scope: scope, block: block})
+		}
+		var converted ai.Message
+		if message.Role == "user" {
+			converted = ai.UserMessage{Content: message.Content}
+		} else {
+			converted = ai.AssistantMessage{Content: []ai.ContentBlock{ai.TextContent{Text: message.Content}}}
+		}
+		batches[len(batches)-1].messages = append(batches[len(batches)-1].messages, converted)
+	}
+	touched := make([]memory.Session, 0, len(batches))
+	for _, batch := range batches {
+		writeCtx := authz.WithUserID(ctx, state.UserID)
+		writeCtx = authz.WithAgentID(writeCtx, agentID)
+		if err := sessionManager.SaveInfo(writeCtx, memory.SessionInfo{
+			ID: batch.scope.ID, UserID: state.UserID, AgentID: agentID,
+			Channel: string(session.ChannelCLI), Kind: string(session.KindChat),
+			Title: fmt.Sprintf("PersonaMem %s block %d", sample.Spec.ContextID[:12], batch.block),
+		}); err != nil {
+			return nil, fmt.Errorf("create PersonaMem history session %s: %w", batch.scope.ID, err)
+		}
+		if err := setupState.mem.Append(writeCtx, batch.scope, batch.messages...); err != nil {
+			return nil, fmt.Errorf("append PersonaMem history %s: %w", batch.scope.ID, err)
+		}
+		touched = append(touched, batch.scope)
+	}
+	if len(touched) == 0 {
+		return nil, fmt.Errorf("PersonaMem range [%d,%d) contains no user or assistant messages", start, end)
+	}
+	return touched, nil
+}
+
+func personaMemHistorySessionID(mode string, sample personaMemSample, block int) string {
+	return fmt.Sprintf("personamem-%s-%s-%s-b%02d", mode, sample.Spec.Split, sample.Spec.ContextID[:12], block)
+}
+
+func deterministicPersonaMemUserID(mode, split, contextID string) string {
+	return uuid.NewSHA1(uuid.NameSpaceOID, []byte("stella-personamem-v1:"+mode+":"+split+":"+contextID)).String()
+}
+
+func answerPersonaMemQuestionWithRetry(
+	ctx context.Context,
+	setupState *setupResult,
+	checkpointPath string,
+	checkpoint *personaMemCheckpoint,
+	state *personaMemContextCheckpoint,
+	sample personaMemSample,
+	question personaMemQuestion,
+	agentID string,
+	stream providers.StreamFunc,
+) (*personaMemAnswerRecord, error) {
+	var lastErr error
+	for attempt := 1; attempt <= personaMemMaxAttempts; attempt++ {
+		record, err := answerPersonaMemQuestion(ctx, setupState, checkpointPath, checkpoint, state, sample, question, agentID, stream, attempt)
+		if err == nil {
+			return record, nil
+		}
+		lastErr = err
+		if !isPersonaMemQATransient(err) {
+			return nil, fmt.Errorf("answer PersonaMem question %s: %w", question.QuestionID, err)
+		}
+		if attempt < personaMemMaxAttempts {
+			time.Sleep(time.Duration(attempt*2) * time.Second)
+		}
+	}
+	return &personaMemAnswerRecord{
+		Split: sample.Spec.Split, ContextID: sample.Spec.ContextID, PersonaID: sample.Spec.PersonaID,
+		Endpoint: question.Endpoint, QuestionID: question.QuestionID, QuestionType: question.Type,
+		Category: question.Category, Question: question.Question, Gold: question.Gold,
+		Completed: false, Correct: false, Attempts: personaMemMaxAttempts,
+		Error: lastErr.Error(), AnsweredAt: time.Now().UTC(),
+	}, nil
+}
+
+func isPersonaMemQATransient(err error) bool {
+	// An empty collected answer has no durable effects after the temporary QA
+	// session cleanup, so a fresh attempt is safe just like a provider timeout.
+	return errors.Is(err, errPersonaMemEmptyAnswer) || isMemoryBenchmarkTransient(err)
+}
+
+func answerPersonaMemQuestion(
+	ctx context.Context,
+	setupState *setupResult,
+	checkpointPath string,
+	checkpoint *personaMemCheckpoint,
+	state *personaMemContextCheckpoint,
+	sample personaMemSample,
+	question personaMemQuestion,
+	agentID string,
+	providerStream providers.StreamFunc,
+	attempt int,
+) (_ *personaMemAnswerRecord, returnErr error) {
+	usage, err := snapshotMemoryBenchmarkKnowledgeUsage(ctx, setupState, state.UserID, agentID)
+	if err != nil {
+		return nil, err
+	}
+	qaSessionID := fmt.Sprintf("personamem-%s-qa-%s-%s-a%d", checkpoint.Mode, sample.Spec.ContextID[:12], question.QuestionID, attempt)
+	state.PendingQuestion = &memoryBenchmarkPendingQuestion{QAIndex: question.Endpoint, SessionID: qaSessionID, Usage: usage}
+	if err := savePersonaMemCheckpoint(checkpointPath, checkpoint); err != nil {
+		return nil, err
+	}
+	defer func() {
+		cleanupErr := recoverMemoryBenchmarkPendingQuestion(ctx, setupState, state.UserID, agentID, state.PendingQuestion)
+		if cleanupErr == nil {
+			state.PendingQuestion = nil
+			cleanupErr = savePersonaMemCheckpoint(checkpointPath, checkpoint)
+		}
+		if cleanupErr != nil {
+			returnErr = errors.Join(returnErr, cleanupErr)
+		}
+	}()
+
+	info := session.NewInfo(qaSessionID, agentID, state.UserID, string(session.ChannelCLI), session.KindChat, "", time.Now().UTC())
+	record, err := info.Record()
+	if err != nil {
+		return nil, err
+	}
+	writeCtx := authz.WithUserID(ctx, state.UserID)
+	writeCtx = authz.WithAgentID(writeCtx, agentID)
+	sessionManager, ok := setupState.mem.(memory.SessionManager)
+	if !ok {
+		return nil, fmt.Errorf("memory provider does not support QA sessions")
+	}
+	if err := sessionManager.SaveInfo(writeCtx, record); err != nil {
+		return nil, fmt.Errorf("create PersonaMem QA session: %w", err)
+	}
+	service := setupState.poolManager.GetService(agentID)
+	if service == nil {
+		return nil, fmt.Errorf("agent service %s is unavailable", agentID)
+	}
+	modelRef := personaMemProviderID + "/" + personaMemAnswerModelID
+	frozenMemory := newFrozenMemoryBenchmarkTool(setupState.mem, qaSessionID, personaMemQAToolBudget)
+	auditedMemory := &personaMemAuditMemoryTool{inner: frozenMemory}
+	toolNames, err := service.Runtime.BenchmarkPrepareRunner(writeCtx, info, modelRef, 0, personaMemQATimeout, auditedMemory)
+	if err != nil {
+		return nil, fmt.Errorf("prepare PersonaMem QA runner: %w", err)
+	}
+	if err := service.Runtime.BenchmarkOverrideRunnerStream(writeCtx, info, modelRef, providerStream); err != nil {
+		return nil, fmt.Errorf("install PersonaMem non-thinking stream: %w", err)
+	}
+	var excluded []string
+	memoryFound := false
+	for _, name := range toolNames {
+		if name == memoryBenchmarkToolName {
+			memoryFound = true
+			continue
+		}
+		excluded = append(excluded, name)
+	}
+	if !memoryFound {
+		return nil, fmt.Errorf("production memory tool is not registered")
+	}
+	stream := service.Runtime.Chat(writeCtx, info, buildPersonaMemQuestionPrompt(question),
+		runtime.WithModel(modelRef), runtime.WithExcludedTools(excluded...))
+	prediction, toolsUsed, err := collectMemoryBenchmarkAnswer(stream)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(prediction) == "" {
+		return nil, errPersonaMemEmptyAnswer
+	}
+	correct, extracted := extractPersonaMemAnswer(prediction, question.Gold)
+	return &personaMemAnswerRecord{
+		Split: sample.Spec.Split, ContextID: sample.Spec.ContextID, PersonaID: sample.Spec.PersonaID,
+		Endpoint: question.Endpoint, QuestionID: question.QuestionID, QuestionType: question.Type,
+		Category: question.Category, Question: question.Question, Gold: question.Gold,
+		Prediction: strings.TrimSpace(prediction), ExtractedAnswer: extracted,
+		Completed: true, Correct: correct, Attempts: attempt, ToolsUsed: toolsUsed,
+		MemoryCalls: auditedMemory.Calls(), AnsweredAt: time.Now().UTC(),
+	}, nil
+}
+
+func capturePersonaMemEndpointState(
+	ctx context.Context,
+	setupState *setupResult,
+	state *personaMemContextCheckpoint,
+	agentID string,
+	endpoint int,
+) (*personaMemEndpointState, error) {
+	readCtx := authz.WithUserID(ctx, state.UserID)
+	readCtx = authz.WithAgentID(readCtx, agentID)
+	profiles, ok := setupState.mem.(memory.ProfileStore)
+	if !ok {
+		return nil, fmt.Errorf("memory provider does not support profile reads")
+	}
+	profile, err := profiles.GetProfile(readCtx, state.UserID, agentID)
+	if err != nil {
+		return nil, fmt.Errorf("read PersonaMem endpoint profile: %w", err)
+	}
+	facts, ok := setupState.mem.(memory.FactStore)
+	if !ok {
+		return nil, fmt.Errorf("memory provider does not support fact reads")
+	}
+	knowledge, err := facts.ListActiveFacts(readCtx, state.UserID, agentID, memory.FactSubjectWorld)
+	if err != nil {
+		return nil, fmt.Errorf("read PersonaMem endpoint knowledge: %w", err)
+	}
+	sort.Slice(knowledge, func(i, j int) bool { return knowledge[i].ID < knowledge[j].ID })
+	var version int64
+	if err := setupState.db.QueryRow(ctx, `SELECT version FROM ctx_agent_memory WHERE user_id=$1 AND agent_id=$2`, state.UserID, agentID).Scan(&version); err != nil {
+		return nil, fmt.Errorf("read PersonaMem memory version: %w", err)
+	}
+	digest, err := personaMemPairDigest(ctx, setupState, state.UserID, agentID)
+	if err != nil {
+		return nil, err
+	}
+	watermarks := make(map[string]int64, len(state.FactWatermarks))
+	for sessionID, mark := range state.FactWatermarks {
+		watermarks[sessionID] = mark
+	}
+	return &personaMemEndpointState{
+		Endpoint: endpoint, MemoryVersion: version, Profile: profile, Knowledge: knowledge,
+		FactWatermarks: watermarks, PairDigest: digest, CapturedAt: time.Now().UTC(),
+	}, nil
+}
+
+func personaMemPairDigest(ctx context.Context, setupState *setupResult, userID, agentID string) (string, error) {
+	base, err := memoryBenchmarkPairDigest(ctx, setupState, userID, agentID)
+	if err != nil {
+		return "", err
+	}
+	queries := []string{
+		`SELECT COALESCE(jsonb_agg(jsonb_build_object('session_id', c.session_id, 'channel', c.channel, 'kind', c.kind) ORDER BY c.session_id)::text, '[]') FROM ctx_conversation c WHERE c.user_id=$1 AND c.agent_id=$2`,
+		`SELECT COALESCE(jsonb_agg(jsonb_build_object('session_id', c.session_id, 'seq', m.seq, 'role', m.role, 'event_type', m.event_type, 'content', m.content) ORDER BY c.session_id, m.seq)::text, '[]') FROM ctx_message m JOIN ctx_conversation c ON c.id=m.conversation_id WHERE c.user_id=$1 AND c.agent_id=$2`,
+		`SELECT COALESCE(jsonb_agg(jsonb_build_object('plugin_id', p.plugin_id, 'scope_id', p.scope_id, 'state_key', p.state_key, 'value', p.value) ORDER BY p.plugin_id, p.scope_id, p.state_key)::text, '[]') FROM plugin_state p WHERE p.scope_kind='session' AND p.scope_id IN (SELECT c.session_id FROM ctx_conversation c WHERE c.user_id=$1 AND c.agent_id=$2)`,
+	}
+	hash := sha256.New()
+	_, _ = hash.Write([]byte(base))
+	for _, query := range queries {
+		var payload string
+		if err := setupState.db.QueryRow(ctx, query, userID, agentID).Scan(&payload); err != nil {
+			return "", fmt.Errorf("digest PersonaMem pair state: %w", err)
+		}
+		_, _ = hash.Write([]byte{0})
+		_, _ = hash.Write([]byte(payload))
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func verifyNoPersonaMemQASessions(ctx context.Context, setupState *setupResult, mode string) error {
+	pattern := "personamem-" + mode + "-qa-%"
+	checks := []struct {
+		name  string
+		query string
+	}{
+		{name: "conversation", query: `SELECT COUNT(*) FROM ctx_conversation WHERE session_id LIKE $1`},
+		{name: "snapshot", query: `SELECT COUNT(*) FROM ctx_agent_memory_snapshot WHERE session_id LIKE $1`},
+		{name: "session plugin state", query: `SELECT COUNT(*) FROM plugin_state WHERE scope_kind='session' AND scope_id LIKE $1`},
+	}
+	for _, check := range checks {
+		var count int
+		if err := setupState.db.QueryRow(ctx, check.query, pattern).Scan(&count); err != nil {
+			return fmt.Errorf("count residual PersonaMem QA %s rows: %w", check.name, err)
+		}
+		if count != 0 {
+			return fmt.Errorf("residual PersonaMem QA %s rows: %d", check.name, count)
+		}
+	}
+	return nil
+}
+
+func personaMemModelIdentityFromProvider(ctx context.Context, providerCfg config.Provider) (personaMemModelIdentity, error) {
+	parsed, err := url.Parse(providerCfg.BaseURL)
+	if err != nil {
+		return personaMemModelIdentity{}, fmt.Errorf("parse PersonaMem provider endpoint: %w", err)
+	}
+	metadata, err := inspectMemoryBenchmarkRemoteModelMetadata(ctx, providerCfg, personaMemAnswerModelID)
+	if err != nil {
+		return personaMemModelIdentity{}, fmt.Errorf("inspect PersonaMem model metadata: %w", err)
+	}
+	snapshotStatus, snapshotVerified, err := personaMemSnapshotStatusFromEnv()
+	if err != nil {
+		return personaMemModelIdentity{}, err
+	}
+	endpoint := strings.TrimRight(providerCfg.BaseURL, "/")
+	endpointSHA := sha256.Sum256([]byte(endpoint))
+	note := "The provider alias is not immutable; router metadata does not expose an independent revision ID."
+	if snapshotVerified {
+		note = "The run operator supplied an explicit snapshot status; router metadata still does not expose an independent revision ID."
+	}
+	return personaMemModelIdentity{
+		ProviderHost: parsed.Hostname(), ProviderEndpointSHA256: hex.EncodeToString(endpointSHA[:]),
+		RequestedModel: personaMemAnswerModelID, RouterMetadata: metadata,
+		SnapshotStatus: snapshotStatus, SnapshotVerified: snapshotVerified, Note: note,
+	}, nil
+}
+
+func personaMemSnapshotStatusFromEnv() (string, bool, error) {
+	status := strings.TrimSpace(os.Getenv("PERSONAMEM_MODEL_SNAPSHOT_STATUS"))
+	if status == "" {
+		return personaMemDefaultSnapshotStatus, false, nil
+	}
+	if len(status) > 128 || strings.ContainsAny(status, "\r\n") {
+		return "", false, fmt.Errorf("PERSONAMEM_MODEL_SNAPSHOT_STATUS must be a single line no longer than 128 bytes")
+	}
+	return status, true, nil
+}
+
+func probePersonaMemModel(ctx context.Context, providerCfg config.Provider, stream providers.StreamFunc) error {
+	var lastErr error
+	for attempt := 1; attempt <= personaMemMaxAttempts; attempt++ {
+		if err := probePersonaMemModelOnce(ctx, providerCfg, stream); err == nil {
+			return nil
+		} else {
+			lastErr = err
+			if !isMemoryBenchmarkTransient(err) {
+				return err
+			}
+		}
+		if attempt < personaMemMaxAttempts {
+			time.Sleep(time.Duration(attempt*2) * time.Second)
+		}
+	}
+	return fmt.Errorf("model probe failed after %d attempts: %w", personaMemMaxAttempts, lastErr)
+}
+
+func probePersonaMemModelOnce(ctx context.Context, providerCfg config.Provider, stream providers.StreamFunc) error {
+	temperature := 0.0
+	probeCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	message, err := providers.Complete(probeCtx, ai.Model{
+		ID: personaMemAnswerModelID, Name: personaMemAnswerModelID, API: providerCfg.Type,
+		Provider: providerCfg.ID, BaseURL: providerCfg.BaseURL,
+	}, ai.Context{Messages: []ai.Message{ai.UserMessage{Content: "Reply with exactly OK."}}}, ai.CompleteOptions{
+		StreamOptions: ai.StreamOptions{Temperature: &temperature, Timeout: 2 * time.Minute},
+	}, stream)
+	if err != nil {
+		return err
+	}
+	if message.StopReason == ai.StopReasonError {
+		return fmt.Errorf("provider: %s", message.ErrorMessage)
+	}
+	return nil
+}
+
+func loadOrCreatePersonaMemCheckpoint(
+	path, runDir, mode string,
+	model personaMemModelIdentity,
+	datasetSHA map[string]string,
+	selectionSHA string,
+	coreQuestionCount, extendedQuestionCount int,
+) (*personaMemCheckpoint, error) {
+	payload, err := os.ReadFile(path)
+	if err == nil {
+		var checkpoint personaMemCheckpoint
+		if err := json.Unmarshal(payload, &checkpoint); err != nil {
+			return nil, fmt.Errorf("decode PersonaMem checkpoint: %w", err)
+		}
+		if checkpoint.Version != 3 || checkpoint.Mode != mode || checkpoint.QAPolicy != personaMemQAPolicy ||
+			checkpoint.AnswerModel != personaMemAnswerModelID || !sameStringMap(checkpoint.DatasetSHA256, datasetSHA) ||
+			!samePersonaMemModelIdentity(checkpoint.Model, model) ||
+			checkpoint.SelectorSeed != personaMemSelectorSeed || checkpoint.SelectorHash != personaMemSelectorHash ||
+			checkpoint.SelectionSHA256 != selectionSHA || checkpoint.CoreQuestionCount != coreQuestionCount ||
+			checkpoint.ExtendedQuestionCount != extendedQuestionCount ||
+			checkpoint.ReflectReviewerTimeoutSeconds != int64(personaMemReflectTimeout/time.Second) ||
+			checkpoint.ReflectPreWriteMaxAttempts != personaMemReflectMaxAttempts ||
+			filepath.Clean(checkpoint.RunDirectory) != filepath.Clean(runDir) {
+			return nil, fmt.Errorf("PersonaMem checkpoint configuration does not match this run")
+		}
+		if checkpoint.Contexts == nil {
+			checkpoint.Contexts = make(map[string]*personaMemContextCheckpoint)
+		}
+		return &checkpoint, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+	now := time.Now().UTC()
+	checkpoint := &personaMemCheckpoint{
+		Version: 3, Mode: mode, QAPolicy: personaMemQAPolicy,
+		DatasetSHA256: cloneStringMap(datasetSHA),
+		SelectorSeed:  personaMemSelectorSeed, SelectorHash: personaMemSelectorHash,
+		SelectionSHA256: selectionSHA, CoreQuestionCount: coreQuestionCount,
+		ExtendedQuestionCount: extendedQuestionCount, AnswerModel: personaMemAnswerModelID, Model: model,
+		ReflectReviewerTimeoutSeconds: int64(personaMemReflectTimeout / time.Second),
+		ReflectPreWriteMaxAttempts:    personaMemReflectMaxAttempts,
+		StartedAt:                     now, UpdatedAt: now, Contexts: make(map[string]*personaMemContextCheckpoint),
+		RunDirectory: runDir,
+	}
+	if err := savePersonaMemCheckpoint(path, checkpoint); err != nil {
+		return nil, err
+	}
+	return checkpoint, nil
+}
+
+func samePersonaMemModelIdentity(first, second personaMemModelIdentity) bool {
+	if first.ProviderHost != second.ProviderHost ||
+		first.ProviderEndpointSHA256 != second.ProviderEndpointSHA256 ||
+		first.RequestedModel != second.RequestedModel ||
+		first.SnapshotStatus != second.SnapshotStatus ||
+		first.SnapshotVerified != second.SnapshotVerified ||
+		first.Note != second.Note ||
+		len(first.RouterMetadata) != len(second.RouterMetadata) {
+		return false
+	}
+	for index := range first.RouterMetadata {
+		if first.RouterMetadata[index] != second.RouterMetadata[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func savePersonaMemCheckpoint(path string, checkpoint *personaMemCheckpoint) error {
+	checkpoint.UpdatedAt = time.Now().UTC()
+	return writeMemoryBenchmarkJSONAtomic(path, checkpoint)
+}
+
+func writePersonaMemManifest(
+	runDir, mode string,
+	datasetSHA map[string]string,
+	samples []personaMemSample,
+	selectionSHA string,
+	coreQuestionCount, extendedQuestionCount int,
+	agentID string,
+	model personaMemModelIdentity,
+) error {
+	commit := "unknown"
+	if output, err := exec.Command("git", "rev-parse", "HEAD").Output(); err == nil {
+		commit = strings.TrimSpace(string(output))
+	}
+	selected := make([]personaMemSampleSpec, 0, len(samples))
+	for _, sample := range samples {
+		spec := sample.Spec
+		spec.CategoryCounts = make(map[personaMemCategory]int)
+		for _, question := range sample.Questions {
+			spec.CategoryCounts[question.Category]++
+		}
+		spec.RawEndpointCount = 0
+		spec.EffectiveEndpointCount = len(personaMemEndpoints(sample))
+		rawEndpoints := make(map[int]struct{})
+		for _, question := range sample.Questions {
+			rawEndpoints[question.RawEndpoint] = struct{}{}
+		}
+		spec.RawEndpointCount = len(rawEndpoints)
+		selected = append(selected, spec)
+	}
+	manifest := personaMemRunManifest{
+		Version: 2, Mode: mode, QAPolicy: personaMemQAPolicy, RepositoryCommit: commit, AgentID: agentID,
+		DatasetSHA256: cloneStringMap(datasetSHA),
+		SelectorSeed:  personaMemSelectorSeed, SelectorHash: personaMemSelectorHash,
+		SelectionSHA256: selectionSHA, CoreQuestionCount: coreQuestionCount,
+		ExtendedQuestionCount: extendedQuestionCount, SelectedContexts: selected, Model: model,
+		Thinking: "disabled", Temperature: 0,
+		MemoryToolBudget:              personaMemQAToolBudget,
+		MemoryCallAudit:               "memory_calls records model attempts; outcome distinguishes executed from host-side budget denial",
+		ReflectReviewerTimeoutSeconds: int64(personaMemReflectTimeout / time.Second),
+		ReflectPreWriteMaxAttempts:    personaMemReflectMaxAttempts,
+		FactLine:                      true, SkillLine: false, Curator: false,
+		ProfileSeedPolicy:   "first identical system persona -> one manual subject=user singleton; repeated copies are session boundaries only",
+		EndpointSlicePolicy: "exclusive context[:end_index_in_shared_context]",
+		CreatedAt:           time.Now().UTC(),
+	}
+	return writeMemoryBenchmarkJSONAtomic(filepath.Join(runDir, "manifest.json"), manifest)
+}
+
+func writePersonaMemArtifacts(runDir string, checkpoint *personaMemCheckpoint, samples []personaMemSample) error {
+	answers := make([]*personaMemAnswerRecord, 0)
+	endpointStates := make(map[string]map[string]*personaMemEndpointState)
+	for key, state := range checkpoint.Contexts {
+		for _, answer := range state.Answers {
+			answers = append(answers, answer)
+		}
+		endpointStates[key] = state.EndpointStates
+	}
+	sort.Slice(answers, func(i, j int) bool {
+		if answers[i].Split != answers[j].Split {
+			return answers[i].Split < answers[j].Split
+		}
+		if answers[i].ContextID != answers[j].ContextID {
+			return answers[i].ContextID < answers[j].ContextID
+		}
+		if answers[i].Endpoint != answers[j].Endpoint {
+			return answers[i].Endpoint < answers[j].Endpoint
+		}
+		return answers[i].QuestionID < answers[j].QuestionID
+	})
+	if err := writeMemoryBenchmarkJSONAtomic(filepath.Join(runDir, "answers.json"), answers); err != nil {
+		return err
+	}
+	if err := writeMemoryBenchmarkJSONAtomic(filepath.Join(runDir, "endpoint_states.json"), endpointStates); err != nil {
+		return err
+	}
+	report := buildPersonaMemScoreReport(samples, answers)
+	return writeMemoryBenchmarkJSONAtomic(filepath.Join(runDir, "scores.json"), report)
+}
+
+func buildPersonaMemScoreReport(samples []personaMemSample, answers []*personaMemAnswerRecord) personaMemScoreReport {
+	report := personaMemScoreReport{
+		CoreCategories:     make(map[personaMemCategory]personaMemScore),
+		ExtendedCategories: make(map[personaMemCategory]personaMemScore),
+		GeneratedAt:        time.Now().UTC(),
+	}
+	for _, category := range personaMemCoreCategories {
+		report.CoreCategories[category] = personaMemScore{}
+	}
+	for _, category := range personaMemExtendedCategories {
+		report.ExtendedCategories[category] = personaMemScore{}
+	}
+	expectedCategories := make(map[string]personaMemCategory)
+	for _, sample := range samples {
+		for _, question := range sample.Questions {
+			scores := personaMemCategoryScores(&report, question.Category)
+			if scores == nil {
+				continue
+			}
+			score := scores[question.Category]
+			score.Expected++
+			scores[question.Category] = score
+			report.Overall.Expected++
+			expectedCategories[question.QuestionID] = question.Category
+		}
+	}
+	for _, answer := range answers {
+		expectedCategory, ok := expectedCategories[answer.QuestionID]
+		if !ok || expectedCategory != answer.Category {
+			continue
+		}
+		scores := personaMemCategoryScores(&report, answer.Category)
+		if scores == nil {
+			continue
+		}
+		score := scores[answer.Category]
+		if answer.Completed {
+			score.Completed++
+			report.Overall.Completed++
+			if answer.Correct {
+				score.Correct++
+				report.Overall.Correct++
+			}
+		}
+		scores[answer.Category] = score
+	}
+	macroTotal := 0.0
+	macroAvailable := true
+	for _, category := range personaMemCoreCategories {
+		score := report.CoreCategories[category]
+		score.Accuracy = personaMemAccuracy(score.Correct, score.Completed)
+		report.CoreCategories[category] = score
+		if score.Accuracy == nil {
+			macroAvailable = false
+		} else {
+			macroTotal += *score.Accuracy
+		}
+	}
+	if macroAvailable {
+		value := macroTotal / float64(len(personaMemCoreCategories))
+		report.CoreMacroAccuracy = &value
+	}
+	for _, category := range personaMemExtendedCategories {
+		score := report.ExtendedCategories[category]
+		score.Accuracy = personaMemAccuracy(score.Correct, score.Completed)
+		report.ExtendedCategories[category] = score
+	}
+	report.Overall.Accuracy = personaMemAccuracy(report.Overall.Correct, report.Overall.Completed)
+	return report
+}
+
+func personaMemCategoryScores(
+	report *personaMemScoreReport,
+	category personaMemCategory,
+) map[personaMemCategory]personaMemScore {
+	if personaMemIsCoreCategory(category) {
+		return report.CoreCategories
+	}
+	if personaMemIsExtendedCategory(category) {
+		return report.ExtendedCategories
+	}
+	return nil
+}
+
+func personaMemAccuracy(correct, completed int) *float64 {
+	if completed == 0 {
+		return nil
+	}
+	value := float64(correct) / float64(completed)
+	return &value
+}
+
+func auditPersonaMemQuestionSplits() (map[string]personaMemDataAudit, error) {
+	result := make(map[string]personaMemDataAudit, len(personaMemExpectedSplitCounts))
+	for _, split := range []string{"32k", "128k", "1M"} {
+		path := filepath.Join(personaMemDataRoot, "questions_"+split+".csv")
+		_, audit, err := loadPersonaMemQuestions(path, "__no_selected_context__")
+		if err != nil {
+			return nil, err
+		}
+		if expected := personaMemExpectedHashes[filepath.Base(path)]; audit.SHA256 != expected {
+			return nil, fmt.Errorf("PersonaMem %s question SHA256=%s, want %s", split, audit.SHA256, expected)
+		}
+		for _, category := range personaMemCategories {
+			if got, want := audit.CategoryCount[category], personaMemExpectedSplitCounts[split][category]; got != want {
+				return nil, fmt.Errorf("PersonaMem %s %s count=%d, want %d", split, category, got, want)
+			}
+		}
+		result[split] = audit
+	}
+	return result, nil
+}
+
+func inspectPersonaMemData() error {
+	audits, err := auditPersonaMemQuestionSplits()
+	if err != nil {
+		return err
+	}
+	samples, hashes, err := loadPersonaMemDataset(personaMemSelectedSpecs)
+	if err != nil {
+		return err
+	}
+	fmt.Println("PersonaMem target split audit:")
+	for _, split := range []string{"32k", "128k", "1M"} {
+		fmt.Printf("  %s: recall=%d latest=%d evolution=%d revisit=%d generalization=%d recommendation=%d suggest_new_ideas=%d sha256=%s\n", split,
+			audits[split].CategoryCount[personaMemRecall], audits[split].CategoryCount[personaMemLatest],
+			audits[split].CategoryCount[personaMemEvolution], audits[split].CategoryCount[personaMemRevisit],
+			audits[split].CategoryCount[personaMemGeneralization], audits[split].CategoryCount[personaMemRecommendation],
+			audits[split].CategoryCount[personaMemSuggestIdeas], audits[split].SHA256)
+	}
+	for _, sample := range samples {
+		fmt.Printf("PersonaMem selected: split=%s context=%s persona=%s messages=%d systems=%d endpoints=%v questions=%d\n",
+			sample.Spec.Split, sample.Spec.ContextID, sample.Spec.PersonaID, len(sample.Messages), sample.SystemCount,
+			personaMemEndpoints(sample), len(sample.Questions))
+	}
+	payload, _ := json.MarshalIndent(hashes, "", "  ")
+	fmt.Printf("PersonaMem selected hashes: %s\n", payload)
+	core, extended, err := personaMemQuestionGroupCounts(samples)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("PersonaMem selected contract: core=%d extended=%d total=%d selection_sha256=%s\n",
+		core, extended, core+extended, personaMemSelectionSHA256(samples))
+	return nil
+}
+
+func sameStringMap(left, right map[string]string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for key, value := range left {
+		if right[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func cloneStringMap(source map[string]string) map[string]string {
+	result := make(map[string]string, len(source))
+	for key, value := range source {
+		result[key] = value
+	}
+	return result
+}

--- a/docs/test-reports/memory/issue-904/2026-08-05-personamem-representative-v2.zh.md
+++ b/docs/test-reports/memory/issue-904/2026-08-05-personamem-representative-v2.zh.md
@@ -1,0 +1,242 @@
+# PersonaMem Representative V2 测评报告
+
+## 评测范围
+
+- 被测系统：Full Stella，提交 `d070430e9b0d04a870faa92ab8cc6cfc4b9a754f`
+- 数据集：[PersonaMem v1](https://github.com/bowen-upenn/PersonaMem)，使用 32k 与 128k split
+- 模型：`deepseek/deepseek-v4-flash`
+- 样本：6 个 context，6 个 persona，47 个有效 endpoint
+- 题目：核心 148 题，扩展 80 题，共 228 题
+- 记忆路径：生产 agent prompt、profile 注入、knowledge search、LCM search、Fact Reflect
+- 关闭项：Skill Reflect、Curator
+- QA：每个 endpoint 完成历史摄入和 Fact Reflect 后冻结记忆；每题使用独立、非持久化临时 session
+- 评分：官方四选一答案解析；不使用 LLM judge
+
+本次运行使用确定性 selector。`selector_hash` 为
+`000f922f3ed2b743856b5536d52ba713eed6dce771f55cb735c6ab2726145e15`，
+`selection_sha256` 为
+`64a689644cbe06abc4154fab65bdf373bfd8d598767522ceedb500aff4e943f8`。
+
+## 为什么以四项核心指标为主
+
+本次评测的主要目标是验证 Stella 记忆系统重构，而不是单独评估回答模型的通用推理或创意能力。因此，主指标只采用 Recall、Latest、Evolution 和 Revisit：
+
+- Recall 直接检查用户信息能否被保存、检索并用于回答。
+- Latest 直接检查新信息能否修正旧信息，以及回答时能否采用最新状态。
+- Evolution 检查系统能否保留并重建用户状态随时间变化的过程。
+- Revisit 检查跨 session 的历史话题能否被重新找到并连续使用。
+
+这四项并非完全不受回答模型影响，但与记忆的写入、时序维护、检索和跨会话连续性联系更直接，因此以四类 accuracy 的等权 macro average 作为核心结果。
+
+Generalization、Preference-aligned Recommendation 和 Suggest New Ideas 仍然需要记忆，但还显著依赖回答模型本身：
+
+- Generalization 需要把已知偏好类比到未见过的新场景。
+- Recommendation 需要在多个都合理的方案中进行个性化排序，并可能依赖模型的常识和推荐倾向。
+- Suggest New Ideas 还要求组合多个用户特征、判断新颖性，并与数据集对“好想法”的标注口径一致。
+
+即使向两个模型提供完全相同的记忆状态，这三项也可能因为模型的类比能力、决策偏好、创意能力、prompt 遵循和选项判断差异而出现较大分差。因此，本报告将后三项作为 Full Stella 的端到端扩展诊断，单独披露，但不把它们纳入记忆系统的核心 Macro。它们不是与记忆无关，而是不适合被单独解释为记忆质量。
+
+## 评测方法
+
+本节定义本次 PersonaMem 评测的可复现协议。后续修改 Stella 记忆实现后做对比测试时，除明确列为实验变量的改动外，应保持这里的数据、样本、模型、摄入顺序、QA 和评分方法不变。
+
+### 1. 数据与代表性样本
+
+评测读取 PersonaMem 的 `questions_32k.csv`、`questions_128k.csv`、`shared_contexts_32k.jsonl` 和 `shared_contexts_128k.jsonl`。文件来自官方 [PersonaMem v1 数据集](https://huggingface.co/datasets/bowen-upenn/PersonaMem-v1)，通过 `PERSONAMEM_DATA_ROOT` 指向本地下载目录。数据文件的 SHA-256 固定在 `manifest.json`；文件内容变化时不得从旧 checkpoint 继续运行。由于本机没有完整的 1M context 文件，本次不包含 1M split。
+
+| 文件                         | SHA-256                                                            |
+| ---------------------------- | ------------------------------------------------------------------ |
+| `questions_32k.csv`          | `cccd34cf53e0bc4d9536c04cff5ca045156d9a4e227e83327112482840bbc93c` |
+| `questions_128k.csv`         | `f0e137c3167fadbffbce5be2786105283c3299972c4ac1f158939155fd1578a7` |
+| `shared_contexts_32k.jsonl`  | `217247ebfec9e8442fc53570c795ab69f21aad08745f7de78d9beab51b122d4a` |
+| `shared_contexts_128k.jsonl` | `733cc009e84a138b386c9e40adea741565db01074f73af4058fd039b42951726` |
+
+抽样单位是完整 `shared_context_id`，不是随机抽散题。确定性 selector 选择 6 个 context：
+
+- 32k 和 128k 各 3 个，分别覆盖低、中、高 effective endpoint 复杂度。
+- 6 个 context 使用 6 个不同 persona。
+- Recall、Latest、Evolution、Revisit 各不少于 30 题。
+- 每个核心类别均覆盖 near、middle、far 三个历史距离桶。
+- selector 只读取数据集 metadata，不读取 Stella 输出。
+- 满足约束的 1,935 个组合使用固定 seed 和排序后 context ID 计算 SHA-256，选择哈希最小者，避免人工按已有结果挑样本。
+
+选定 context 中的四类核心题全部进入评测，共 148 题。同一批核心 endpoint 上存在的三类扩展题也全部加入，共 80 题。扩展题不新增 context、历史摄入、Reflect 或 endpoint snapshot，因此总计为 6 个 context、47 个有效 endpoint、228 题。
+
+### 2. Context、session 与 endpoint
+
+PersonaMem 的每个 `shared_context_id` 是一条扁平消息数组。评测按以下规则映射到 Stella：
+
+1. 每个 context 创建一个独立 user-agent pair，不与其他 context 共享 profile、knowledge、LCM、session 或 usage。
+2. 数组中的每条 `system` 消息表示一个原始会话边界。该 system 后面的 user/assistant 消息直到下一条 system 为一个 Stella 历史 session。
+3. system 消息本身不写入 session。第一份 `Current user persona:` 内容作为一次性 `source=manual`、`subject=user` profile singleton 写入；同一 context 的后续 system persona 必须与第一份完全一致，只作为边界使用。
+4. 不按 token 数、固定消息数或时间间隔重新切 session。本次 6 个 context 共形成 71 个历史 session。
+5. 每道题的 `end_index_in_shared_context` 按 Python exclusive slice 解释，即该题只能看到 `context[:endpoint]`。负索引先按 Python 语义换算；映射到相同位置的 endpoint 共用同一冻结状态。
+6. endpoint 按升序执行。第一个 endpoint 摄入 `context[0:e1]`，下一个只追加 `context[e1:e2]`，不得重复摄入旧消息或提前摄入未来消息。若增量仍位于同一 system block，则继续写入原 session；跨过 system 边界时才进入新 session。
+
+32k/128k 是 PersonaMem 提供的数据规模分组，不是本评测设置的 session 或 review window 大小。
+
+### 3. 历史摄入与 Fact Reflect
+
+每个 endpoint 的增量历史按原始 role 和 content 写入生产 memory provider，然后只运行 Fact Reflect：
+
+- Fact candidate generation、evaluation、related discovery、reconciliation 和 fact batch write 均使用 Stella 当前实现。
+- Skill Reflect 和 Curator 关闭，避免测试范围混入 skill 生成或生命周期淘汰。
+- Reflect 对该 endpoint 涉及的每个历史 session 分别运行。
+- 如 bounded ReviewUnit 被截断，则在同一 session 上继续运行，直到 fact watermark 到达最后完整消息；多轮 review 不会创建新 session。
+- 只有明确标记为 pre-write-safe 的 provider/protocol 失败可以重试；写入阶段或写后状态不确定时 fail closed。
+- 为覆盖 128k 高密度 session，本地 PersonaMem adapter 将单次 Fact Reflect reviewer timeout 设为 4 分钟，并将 pre-write-safe 最大尝试次数设为 6。该调整不修改生产默认值，也不改变候选 schema、评分门槛、候选上限或写入逻辑。
+
+完成 Reflect 后记录 memory version、profile、active knowledge、fact watermark 和 pair digest，形成该 endpoint 的冻结状态。该 endpoint 的所有题回答完之前，不摄入下一个 endpoint。
+
+### 4. 冻结记忆后的逐题 QA
+
+每道题都从所属 endpoint 的同一冻结记忆状态开始，但使用独立临时 QA session：
+
+- 使用 Full Stella 的生产 agent prompt、profile 注入、knowledge search、LCM search 和 memory tool。
+- 使用官方 `user_question_or_message`、`all_options` 和答题指令，不改写问题和选项。
+- 模型固定为 `deepseek/deepseek-v4-flash`，temperature 为 0，thinking 关闭。
+- 每题最多执行 8 次 memory tool 后端读取；超出预算的调用由 host 拒绝，不访问后端。
+- 单次 QA timeout 为 90 秒，运行错误最多尝试 3 次。错误选项不重试；只有 timeout、连接错误、空答案等在临时状态完整清理后可安全重试。
+- 问题、回答、QA snapshot 以及 QA 导致的 usage 变化均在题后清理。QA session 不进入 Reflect，也不得改变冻结 pair digest。
+
+因此，同一 endpoint 的题目相互独立，并且不会因为前一道题已经询问过某项记忆而获得额外上下文。
+
+### 5. 答案解析与评分
+
+所有题均为 `(a)` 至 `(d)` 四选一，不使用 LLM judge。解析逻辑镜像 PersonaMem 官方 `extract_answer`：
+
+1. 优先读取最后一个 `<final_answer>` 后的内容。
+2. 优先提取括号形式 `(a)` 至 `(d)`，否则提取独立字母。
+3. 只有唯一提取选项与 gold option 相同才得 1 分。
+4. 三次运行尝试均失败的题记为 incomplete，而不是错误答案；所有报告同时披露 `completed/expected`。
+
+主报告分别计算 Recall、Latest、Evolution、Revisit accuracy，并取四项等权 macro average。扩展三项分别报告，不进入核心 Macro。228 题 overall 是固定代表性样本的诊断性 micro accuracy，不称为 PersonaMem 官方全量分数。
+
+### 6. Checkpoint、恢复与产物
+
+`manifest.json` 固定仓库提交、数据 SHA-256、selector、selection SHA、模型、开关和运行参数。`checkpoint.json` 记录每个 context 的 user ID、摄入位置、watermark、endpoint state、已完成题和临时恢复状态；当前适配器还将不含凭据的 provider endpoint SHA-256 与模型 metadata 纳入恢复身份，避免切换路由后继续混用旧答案。
+
+恢复时必须校验上述身份；不一致时 fail closed。成功题逐题原子落盘，安全恢复不得重复已完成题，也不得跳过未完成题。最终产物为：
+
+- `manifest.json`：实验身份和配置。
+- `checkpoint.json`：可恢复运行状态。
+- `endpoint_states.json`：47 个冻结记忆状态。
+- `answers.json`：228 题的预测、gold、评分、尝试次数和 memory tool audit。
+- `scores.json`：核心、扩展和综合指标。
+- `representative-run.log`：Reflect、QA、恢复和数据库日志。
+
+### 7. 后续对比测试协议
+
+后续评估记忆系统改动时，应使用新的空 Stella home、run directory 和 checkpoint，从零重建 6 个 context，不能复用本次 `representative-v2` 的数据库、facts 或答案。对比至少固定：
+
+- PersonaMem 数据文件及其 SHA-256。
+- 6 个 context、228 个 question ID、endpoint 映射和 `selection_sha256`。
+- 回答模型、temperature、thinking、QA prompt、tool budget 和评分器。
+- system persona seed、session 边界、增量摄入和冻结 QA 语义。
+- 除待测改动外的 Reflect 配置和运行开关。
+
+每轮同时比较核心四项、扩展三项、completed/expected、Reflect generated/accepted/write/no-op、最终 active facts、memory tool 调用和运行错误。若修改了模型、prompt、样本、tool budget 或评测 adapter，必须视为新的实验条件单独披露，不能直接把分差归因于记忆系统。
+
+当前可复现命令为：
+
+```bash
+# 纯结构、selector、checkpoint 和评分测试，不调用真实模型
+PERSONAMEM_DATA_ROOT=/absolute/path/to/personamem-v1 \
+mise exec -- go test -tags=personamemeval ./cmd/stellad \
+  -run '^TestPersonaMem' -count=1
+
+# 正式运行；相同 run identity 会从安全 checkpoint 恢复
+STELLA_HOME="$(pwd)/dist/benchmarks/personamem/h/r-v2" \
+PERSONAMEM_DATA_ROOT=/absolute/path/to/personamem-v1 \
+PERSONAMEM_PROVIDER_API_KEY=... \
+PERSONAMEM_PROVIDER_BASE_URL=... \
+PERSONAMEM_MODEL_SNAPSHOT_STATUS=operator-confirmed-latest \
+PERSONAMEM_MODE=representative \
+mise exec -- go test -tags=personamemeval ./cmd/stellad \
+  -run '^TestPersonaMemBenchmark$' -count=1 -v -timeout 0
+```
+
+未来做独立对比运行时，需要先分配新的 run revision 和空 home；不得仅删除答案而保留旧记忆状态。
+
+下载的数据、benchmark home、checkpoint、逐题答案、endpoint snapshot 和日志均保留在被忽略的 `dist/benchmarks/personamem/` 下，不进入 Git。仓库只跟踪评测适配器、运行协议和本报告。
+
+## 核心结果
+
+| 类别      | 正确 | 完成 / 预期 | Accuracy |
+| --------- | ---: | ----------: | -------: |
+| Recall    |   25 |     30 / 30 |   83.33% |
+| Latest    |   37 |     50 / 50 |   74.00% |
+| Evolution |   26 |     37 / 37 |   70.27% |
+| Revisit   |   22 |     31 / 31 |   70.97% |
+
+四类核心指标的等权 macro accuracy 为 **74.64%**。
+
+## 扩展结果
+
+| 类别                              | 正确 | 完成 / 预期 | Accuracy |
+| --------------------------------- | ---: | ----------: | -------: |
+| Generalization                    |   10 |     20 / 20 |   50.00% |
+| Preference-aligned Recommendation |   10 |     18 / 18 |   55.56% |
+| Suggest New Ideas                 |    7 |     42 / 42 |   16.67% |
+
+全部 228 题的诊断性 micro accuracy 为 **60.09%**（137 / 228）。该数值混合了核心和扩展题，不能替代核心 PersonaMem macro 指标。
+
+## Context 结果
+
+| Split | Context        | 正确 / 题数 | Accuracy |
+| ----- | -------------- | ----------: | -------: |
+| 32k   | `f56dc82b8027` |     10 / 17 |   58.82% |
+| 32k   | `1621543a17bd` |     18 / 28 |   64.29% |
+| 32k   | `7797915581c0` |     15 / 21 |   71.43% |
+| 128k  | `bb7f46b01bc9` |     38 / 64 |   59.38% |
+| 128k  | `5fa9c2b9e3d3` |     30 / 52 |   57.69% |
+| 128k  | `8d42d864b2b0` |     26 / 46 |   56.52% |
+
+## 执行完整性
+
+- 228 个 answer record 对应 228 个唯一 question ID，全部 completed，无 incomplete。
+- 47 个有效 endpoint 均有冻结状态。
+- 运行结束时 `pending_question` 全部为空，`reset_required` 全部为 false。
+- 测试结束前执行残留 QA session 检查，并正常关闭 benchmark PostgreSQL。
+- 227 题一次完成；1 题在 provider deadline 后完成清理并于第 2 次尝试成功。
+- 最后一次 checkpoint 续跑耗时 803.13 秒。完整评测经历过中断和续跑，因此不把各次运行的墙钟时间相加为稳定性能指标。
+
+## Memory Tool 诊断
+
+- 116 / 228 题至少调用过一次 memory tool。
+- 共记录 254 次 memory tool 请求，其中 249 次执行，5 次在达到每题 8 次上限后由 host 拒绝。
+- 已执行/请求动作：`search` 144 次、`profile_get` 54 次、`get_message` 49 次、`search_knowledge` 3 次、`profile_history` 2 次、`expand` 1 次、`constraint_list` 1 次。
+
+达到 tool budget 后的拒绝不会访问后端，也不会自动把该题判错；模型仍可用已经获得的证据完成回答。
+
+## Fact Reflect 诊断
+
+按 `session + round + watermark` 去重成功的 review unit 后：
+
+- 成功处理 112 个 review unit、2,498 条 fresh message。
+- generator 产生 261 个 fact candidate。
+- evaluator 接受 256 个 candidate。
+- reconciliation 提交 99 次实际写入，另有 29 次语义 no-op。
+- 6 个 context 的初始官方 persona 分别以一条 manual profile seed 写入；99 次 Reflect 写入加上 6 次 seed，对应最终 memory version 总和 105。
+- 最终 active records 为 6 个 subject=user profile singleton 和 2 条 subject=world knowledge。
+- 最终 profile 长度为 2,891 至 8,714 字符，平均 5,822.5 字符。
+
+这里的“候选数”“写入次数”和“最终 active record 数”不是同一口径。profile 是持续聚合更新的 singleton，不能用最终 6 条 profile row 代表其中包含的语义事实数量。
+
+## 观察与限制
+
+1. 核心四类中 Recall 最好；Latest、Evolution、Revisit 接近但明显更低。后续分析应优先区分错误来自 profile 更新、历史检索还是最终选择。
+2. Suggest New Ideas 只有 16.67%，显著低于其他类别。它更多衡量基于 persona 的开放式候选选择能力，不应与事实回忆能力混为一谈。
+3. 两条 active knowledge 中，一条合同术语符合 subject=world；另一条“用户正在开发旅行预算应用”从内容看更像 subject=user profile，说明本轮出现至少一次 subject 误分类。
+4. 官方 system persona 作为 manual profile seed 注入，因此本结果衡量的是“保留官方 persona 先验后，Stella 如何维护和使用后续历史”，不是从空记忆完全学习 persona。
+5. 为覆盖 128k 高密度历史和 provider 抖动，本地适配器仅对 PersonaMem Fact Reflect 使用 4 分钟 reviewer timeout 和最多 6 次 pre-write-safe retry；生产默认值未修改。
+6. `deepseek/deepseek-v4-flash` 是 provider alias，路由没有提供可独立验证的不可变 revision ID。因此本报告固定了执行协议和当时可见的模型 metadata，但未来同名 alias 仍可能发生模型漂移，不能把小幅分差全部归因于 Stella。
+
+## 产物
+
+- `manifest.json`：输入、模型、开关和样本身份
+- `checkpoint.json`：可恢复执行状态
+- `endpoint_states.json`：47 个冻结 endpoint 状态
+- `answers.json`：228 题逐题输出、评分与 tool audit
+- `scores.json`：核心、扩展和综合分数
+- `representative-run.log`：运行日志

--- a/docs/test-reports/memory/issue-904/README.md
+++ b/docs/test-reports/memory/issue-904/README.md
@@ -1,0 +1,59 @@
+# Memory #904 PersonaMem Test Report
+
+This directory stores the committed, human-readable baseline report for the
+Full Stella PersonaMem v1 representative evaluation introduced by #904.
+
+## Data
+
+Download the official PersonaMem v1 files from the
+[PersonaMem repository](https://github.com/bowen-upenn/PersonaMem) or its
+[Hugging Face dataset](https://huggingface.co/datasets/bowen-upenn/PersonaMem-v1):
+
+- `questions_32k.csv`
+- `questions_128k.csv`
+- `shared_contexts_32k.jsonl`
+- `shared_contexts_128k.jsonl`
+
+Place them under `dist/benchmarks/personamem/data/`, or set
+`PERSONAMEM_DATA_ROOT` to another directory containing those files. The
+benchmark validates the dataset hashes recorded by its checkpoint.
+
+## Run
+
+The evaluator is excluded from normal builds by the `personamemeval` build tag.
+Its deterministic contract tests do not call a real model:
+
+```bash
+PERSONAMEM_DATA_ROOT=/absolute/path/to/personamem-v1 \
+mise exec -- go test -tags=personamemeval ./cmd/stellad \
+  -run '^TestPersonaMem' -count=1
+```
+
+A real representative run additionally requires an OpenAI-compatible endpoint
+that serves `deepseek/deepseek-v4-flash`:
+
+```bash
+STELLA_HOME="$(pwd)/dist/benchmarks/personamem/h/r-v2" \
+PERSONAMEM_DATA_ROOT=/absolute/path/to/personamem-v1 \
+PERSONAMEM_PROVIDER_API_KEY=... \
+PERSONAMEM_PROVIDER_BASE_URL=... \
+PERSONAMEM_MODEL_SNAPSHOT_STATUS=operator-confirmed-latest \
+PERSONAMEM_MODE=representative \
+mise exec -- go test -tags=personamemeval ./cmd/stellad \
+  -run '^TestPersonaMemBenchmark$' -count=1 -v -timeout 0
+```
+
+Use an empty Stella home and run directory for an independent comparison. A
+matching interrupted run resumes from its validated checkpoint.
+
+`PERSONAMEM_MODEL_SNAPSHOT_STATUS` is optional. Without it, the manifest records
+the mutable model alias as `unverified-alias`; setting it is an operator claim,
+not an independently verified immutable model revision.
+
+## Artifact Boundary
+
+Of the generated run artifacts, only the human-readable report is committed.
+Downloaded data, benchmark homes, checkpoints, endpoint snapshots, per-question
+answers, score JSON, and logs stay under ignored
+`dist/benchmarks/personamem/` paths. No credentials belong in the report or
+repository.

--- a/internal/agent/memory_benchmark_export.go
+++ b/internal/agent/memory_benchmark_export.go
@@ -1,0 +1,50 @@
+//go:build personamemeval
+
+package agent
+
+import (
+	"sort"
+	"time"
+
+	"github.com/CherryHQ/stella/pkg/providers"
+	"github.com/CherryHQ/stella/pkg/tools"
+)
+
+// BenchmarkToolNames returns a stable list so an end-to-end benchmark can hide
+// every unrelated tool while retaining the production memory query tool.
+func (r *runner) BenchmarkToolNames() []string {
+	if r.tools == nil {
+		return nil
+	}
+	names := r.tools.BuiltinNames()
+	sort.Strings(names)
+	return names
+}
+
+// BenchmarkSetTemperature changes only the build-tagged benchmark runner.
+func (r *runner) BenchmarkSetTemperature(value float64) {
+	r.streamOptions.Temperature = &value
+}
+
+// BenchmarkSetChatTimeout bounds one benchmark question without changing the
+// production runner defaults.
+func (r *runner) BenchmarkSetChatTimeout(value time.Duration) {
+	r.chatTimeout = value
+}
+
+// BenchmarkRegisterTool replaces a tool by name in the cached runner registry.
+func (r *runner) BenchmarkRegisterTool(tool tools.Tool) {
+	r.tools.Register(tool)
+}
+
+// BenchmarkSetStream swaps the benchmark runner's provider stream while
+// preserving its production prompt and tool registry.
+func (r *runner) BenchmarkSetStream(stream providers.StreamFunc) error {
+	coreRunner, err := newAgentRunner(stream, r.tools, r.model, r.streamOptions, r.system, r.hookSet, r.toolLifecycle, r.canonicalImages)
+	if err != nil {
+		return err
+	}
+	r.stream = stream
+	r.runner = coreRunner
+	return nil
+}

--- a/internal/agent/runtime/memory_benchmark_export.go
+++ b/internal/agent/runtime/memory_benchmark_export.go
@@ -1,0 +1,67 @@
+//go:build personamemeval
+
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/CherryHQ/stella/internal/agent/session"
+	"github.com/CherryHQ/stella/pkg/providers"
+	"github.com/CherryHQ/stella/pkg/tools"
+)
+
+type benchmarkRunnerControl interface {
+	BenchmarkToolNames() []string
+	BenchmarkRegisterTool(tools.Tool)
+	BenchmarkSetChatTimeout(time.Duration)
+	BenchmarkSetTemperature(float64)
+	BenchmarkSetStream(providers.StreamFunc) error
+}
+
+// BenchmarkOverrideRunnerStream replaces the cached benchmark runner stream
+// after it has been prepared with the production prompt and memory tool.
+func (rt *Runtime) BenchmarkOverrideRunnerStream(
+	ctx context.Context,
+	info session.Info,
+	model string,
+	stream providers.StreamFunc,
+) error {
+	_, runner, err := rt.getOrCreateRunner(ctx, info, model, nil)
+	if err != nil {
+		return err
+	}
+	controlled, ok := runner.(benchmarkRunnerControl)
+	if !ok {
+		return fmt.Errorf("benchmark runner control is unavailable")
+	}
+	return controlled.BenchmarkSetStream(stream)
+}
+
+// BenchmarkPrepareRunner creates the production runner, fixes its sampling
+// settings, installs benchmark-safe replacement tools, and returns all tool
+// names so the caller can exclude anything outside the measured memory path.
+func (rt *Runtime) BenchmarkPrepareRunner(
+	ctx context.Context,
+	info session.Info,
+	model string,
+	temperature float64,
+	chatTimeout time.Duration,
+	replacementTools ...tools.Tool,
+) ([]string, error) {
+	_, runner, err := rt.getOrCreateRunner(ctx, info, model, nil)
+	if err != nil {
+		return nil, err
+	}
+	controlled, ok := runner.(benchmarkRunnerControl)
+	if !ok {
+		return nil, fmt.Errorf("benchmark runner control is unavailable")
+	}
+	controlled.BenchmarkSetTemperature(temperature)
+	controlled.BenchmarkSetChatTimeout(chatTimeout)
+	for _, tool := range replacementTools {
+		controlled.BenchmarkRegisterTool(tool)
+	}
+	return controlled.BenchmarkToolNames(), nil
+}

--- a/internal/reflect/memory_benchmark_export.go
+++ b/internal/reflect/memory_benchmark_export.go
@@ -1,0 +1,129 @@
+//go:build personamemeval
+
+package reflect
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/CherryHQ/stella/internal/authz"
+	"github.com/CherryHQ/stella/internal/config"
+	"github.com/CherryHQ/stella/internal/memory"
+)
+
+var errBenchmarkFactReviewRetrySafe = errors.New("benchmark fact review failed before writes")
+
+// BenchmarkFactReviewResult exposes only the aggregate diagnostics required by
+// an end-to-end memory benchmark. Production candidate payloads remain private.
+type BenchmarkFactReviewResult struct {
+	FreshCount      int
+	Generated       int
+	Accepted        int
+	Writes          int
+	Noops           int
+	LLMCalls        int
+	Skipped         int
+	Truncated       bool
+	LastIncludedSeq int64
+	WatermarkBefore int64
+	WatermarkAfter  int64
+	Duration        time.Duration
+}
+
+// BenchmarkReviewFactLine runs the production fact generation, evaluation,
+// discovery, reconciliation, write, and watermark path without starting the
+// skill line. The method exists only in PersonaMem benchmark builds.
+func (s *Service) BenchmarkReviewFactLine(
+	ctx context.Context,
+	snapshot *config.Snapshot,
+	session memory.Session,
+) (BenchmarkFactReviewResult, error) {
+	var output BenchmarkFactReviewResult
+	if snapshot == nil {
+		return output, fmt.Errorf("benchmark fact review: config snapshot is required")
+	}
+	if session.ID == "" || session.UserID == "" || session.AgentID == "" {
+		return output, fmt.Errorf("benchmark fact review: complete session scope is required")
+	}
+
+	ctx = authz.WithUserID(ctx, session.UserID)
+	ctx = authz.WithAgentID(ctx, session.AgentID)
+	ctx = memory.WithChangeSource(ctx, memory.SourceReflect)
+	target := reviewTarget{session: session, privateOneToOne: true}
+
+	model := snapshot.ResolveModelTier(config.ModelTierFast)
+	creds := snapshot.ResolveProviderCreds(model.API)
+	stream, err := s.buildStreamFunc(model.API, creds.APIKey, creds.BaseURL)
+	if err != nil {
+		return output, markBenchmarkFactReviewRetrySafe(fmt.Errorf("benchmark fact review: build provider: %w", err))
+	}
+	reviewer, instrumentation := instrumentCandidateReviewer(stream, model, s.candidateGates)
+
+	mark, err := s.wm.getLine(ctx, session.ID, reflectLineFact)
+	if err != nil {
+		return output, markBenchmarkFactReviewRetrySafe(fmt.Errorf("benchmark fact review: get watermark: %w", err))
+	}
+	output.WatermarkBefore = mark.Seq
+	unit, err := s.buildReviewUnit(ctx, target, mark, maxFallbackReviewTokens)
+	if err != nil {
+		return output, markBenchmarkFactReviewRetrySafe(fmt.Errorf("benchmark fact review: build review unit: %w", err))
+	}
+	output.FreshCount = unit.FreshCount
+	output.Skipped = len(unit.Skipped)
+	output.Truncated = unit.Truncated
+	output.LastIncludedSeq = unit.LastIncludedSeq
+
+	var result candidatePipelineResult
+	started := time.Now()
+	err = s.runFactReconciliationLine(ctx, target, unit, reconciliationPipelineOptions{
+		FactLine: func(ctx context.Context, unit ReviewUnit) ([]factCandidateDecision, error) {
+			decisions, err := reviewer.runFactDecisionLine(ctx, unit)
+			if err != nil {
+				return nil, markBenchmarkFactReviewRetrySafe(err)
+			}
+			return decisions, nil
+		},
+		FactReconciler: func(
+			ctx context.Context,
+			target reviewTarget,
+			unit ReviewUnit,
+			decisions []factCandidateDecision,
+		) (reconciliationWriteStats, error) {
+			stats, err := s.reconcileFactCandidates(ctx, target, unit, decisions, reviewer)
+			if isFactReconciliationPreWrite(err) {
+				return stats, markBenchmarkFactReviewRetrySafe(err)
+			}
+			return stats, err
+		},
+	}, &result)
+	output.Duration = time.Since(started)
+	output.Generated = int(instrumentation.candidates.Load())
+	output.LLMCalls = int(instrumentation.llmCalls.Load())
+	output.Accepted = len(result.FactAccepted)
+	output.Writes = result.FactStats.Writes
+	output.Noops = result.FactStats.Noops
+	if err != nil {
+		return output, fmt.Errorf("benchmark fact review: %w", err)
+	}
+
+	mark, err = s.wm.getLine(ctx, session.ID, reflectLineFact)
+	if err != nil {
+		// The reconciliation may already have committed, so this failure is not
+		// safe for the benchmark harness to retry.
+		return output, fmt.Errorf("benchmark fact review: read advanced watermark: %w", err)
+	}
+	output.WatermarkAfter = mark.Seq
+	return output, nil
+}
+
+// BenchmarkFactReviewRetrySafe reports whether a review failed before entering
+// the fact batch executor. Callers must additionally require a transient error.
+func BenchmarkFactReviewRetrySafe(err error) bool {
+	return errors.Is(err, errBenchmarkFactReviewRetrySafe)
+}
+
+func markBenchmarkFactReviewRetrySafe(err error) error {
+	return fmt.Errorf("%w: %w", errBenchmarkFactReviewRetrySafe, err)
+}

--- a/internal/reflect/memory_benchmark_export_test.go
+++ b/internal/reflect/memory_benchmark_export_test.go
@@ -1,0 +1,23 @@
+//go:build personamemeval
+
+package reflect
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestBenchmarkFactReviewRetrySafeMarkerPreservesCause(t *testing.T) {
+	cause := errors.New("transient provider failure")
+	marked := markBenchmarkFactReviewRetrySafe(cause)
+
+	if !BenchmarkFactReviewRetrySafe(marked) {
+		t.Fatal("benchmark pre-write error was not classified as retry-safe")
+	}
+	if !errors.Is(marked, cause) {
+		t.Fatal("benchmark retry marker does not preserve its cause")
+	}
+	if BenchmarkFactReviewRetrySafe(cause) {
+		t.Fatal("unmarked error was classified as retry-safe")
+	}
+}

--- a/internal/reflect/reconciliation_pipeline_test.go
+++ b/internal/reflect/reconciliation_pipeline_test.go
@@ -7,6 +7,24 @@ import (
 	"time"
 )
 
+func TestFactReconciliationPreWriteMarkerPreservesCause(t *testing.T) {
+	cause := errors.New("discovery failed")
+	marked := markFactReconciliationPreWrite(cause)
+
+	if marked.Error() != cause.Error() {
+		t.Fatalf("marked error = %q, want %q", marked, cause)
+	}
+	if !errors.Is(marked, cause) {
+		t.Fatal("marked error does not preserve its cause")
+	}
+	if !isFactReconciliationPreWrite(marked) {
+		t.Fatal("pre-write marker was not detected")
+	}
+	if isFactReconciliationPreWrite(cause) {
+		t.Fatal("unmarked error was classified as pre-write")
+	}
+}
+
 func TestReconciliationPipelineRunsFactAndSkillConcurrently(t *testing.T) {
 	svc, target, _, _ := newCandidatePipelineTestService(t)
 	started := make(chan reflectLine, 2)

--- a/internal/reflect/reconciliation_service.go
+++ b/internal/reflect/reconciliation_service.go
@@ -2,21 +2,49 @@ package reflect
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/CherryHQ/stella/internal/memory"
 )
 
+// factReconciliationPreWriteError marks failures that occurred before the fact
+// batch executor was entered. Its Error method preserves the original message
+// so callers can classify retry safety without losing the underlying cause.
+type factReconciliationPreWriteError struct {
+	err error
+}
+
+func (err *factReconciliationPreWriteError) Error() string {
+	return err.err.Error()
+}
+
+func (err *factReconciliationPreWriteError) Unwrap() error {
+	return err.err
+}
+
+func markFactReconciliationPreWrite(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &factReconciliationPreWriteError{err: err}
+}
+
+func isFactReconciliationPreWrite(err error) bool {
+	var marked *factReconciliationPreWriteError
+	return errors.As(err, &marked)
+}
+
 func (s *Service) reconcileFactCandidates(ctx context.Context, target reviewTarget, unit ReviewUnit, decisions []factCandidateDecision, runner candidateLineReviewer) (reconciliationWriteStats, error) {
 	facts, ok := s.memory.(memory.FactStore)
 	if !ok {
-		return reconciliationWriteStats{}, fmt.Errorf("fact reconciliation: memory provider does not support fact reads")
+		return reconciliationWriteStats{}, markFactReconciliationPreWrite(fmt.Errorf("fact reconciliation: memory provider does not support fact reads"))
 	}
 	// Tracing wrappers expose read interfaces but batch writes live on the
 	// underlying memory provider.
 	writer, ok := memory.Unwrap(s.memory).(factBatchWriter)
 	if !ok {
-		return reconciliationWriteStats{}, fmt.Errorf("fact reconciliation: memory provider does not support fact batch writes")
+		return reconciliationWriteStats{}, markFactReconciliationPreWrite(fmt.Errorf("fact reconciliation: memory provider does not support fact batch writes"))
 	}
 	var constraints memory.ConstraintStore
 	if store, ok := s.memory.(memory.ConstraintStore); ok {
@@ -28,27 +56,27 @@ func (s *Service) reconcileFactCandidates(ctx context.Context, target reviewTarg
 	candidates := factCandidatesFromDecisions(decisions)
 	bundle, err := buildFactRelatedBundle(ctx, facts, constraints, userID, agentID, candidates)
 	if err != nil {
-		return reconciliationWriteStats{}, err
+		return reconciliationWriteStats{}, markFactReconciliationPreWrite(err)
 	}
 	selections, err := runner.discoverKnowledgeRelations(ctx, bundle.Knowledge)
 	if err != nil {
-		return reconciliationWriteStats{}, err
+		return reconciliationWriteStats{}, markFactReconciliationPreWrite(err)
 	}
 	knowledge, err := attachKnowledgeRelatedRecords(bundle.Knowledge, selections)
 	if err != nil {
-		return reconciliationWriteStats{}, err
+		return reconciliationWriteStats{}, markFactReconciliationPreWrite(err)
 	}
 	bundle.Knowledge = knowledge
 	plan, err := runner.reconcileFacts(ctx, bundle)
 	if err != nil {
-		return reconciliationWriteStats{}, err
+		return reconciliationWriteStats{}, markFactReconciliationPreWrite(err)
 	}
 	writes := factReconciliationWriteCount(plan)
 	provenance := factProvenanceInput{Decisions: decisions}
 	if writes > 0 {
 		provenance.Context, err = newReflectProvenanceContext(target.session.ID, runner.Model.ID, unit)
 		if err != nil {
-			return reconciliationWriteStats{}, err
+			return reconciliationWriteStats{}, markFactReconciliationPreWrite(err)
 		}
 	}
 	_, err = executeFactReconciliationPlan(ctx, writer, userID, agentID, bundle, plan, provenance)

--- a/plugins/providers/openai/memory_benchmark_export.go
+++ b/plugins/providers/openai/memory_benchmark_export.go
@@ -1,0 +1,44 @@
+//go:build personamemeval
+
+package openai
+
+import (
+	"context"
+
+	"github.com/openai/openai-go/option"
+
+	"github.com/CherryHQ/stella/pkg/ai"
+	"github.com/CherryHQ/stella/pkg/providers"
+)
+
+// NewDeepSeekThinkingDisabledBenchmarkStream uses the production OpenAI
+// adapter while explicitly sending both gateway and DeepSeek non-thinking
+// controls. The helper is absent from normal builds.
+func NewDeepSeekThinkingDisabledBenchmarkStream(cfg Config) providers.StreamFunc {
+	provider := New(cfg)
+	return func(goCtx context.Context, model ai.Model, ctx ai.Context, opts ai.StreamOptions) (providers.AssistantEventStream, error) {
+		requestCtx := goCtx
+		cancel := func() {}
+		if opts.Timeout > 0 {
+			requestCtx, cancel = context.WithTimeout(goCtx, opts.Timeout)
+		}
+		params := buildParams(model, ctx, opts)
+		reqOpts := buildRequestOptions(opts)
+		reqOpts = append(reqOpts, option.WithJSONSet("reasoning_effort", "none"))
+		reqOpts = append(reqOpts, option.WithJSONSet("thinking", map[string]string{"type": "disabled"}))
+		sdkStream := provider.client.Chat.Completions.NewStreaming(requestCtx, params, reqOpts...)
+
+		out := providers.NewChannelEventStream(32)
+		go func() {
+			defer cancel()
+			defer func() { _ = sdkStream.Close() }()
+			defer out.Finish(nil)
+			out.Emit(ai.EventStart{})
+			completed := consumeStream(sdkStream, out)
+			if err := sdkStream.Err(); err != nil && !completed {
+				out.Emit(ai.EventError{Err: err})
+			}
+		}()
+		return out, nil
+	}
+}


### PR DESCRIPTION
## What

Add a reproducible, build-tagged Full Stella PersonaMem v1 representative benchmark and commit the human-readable baseline report from the completed 228-question run.

## Why

Stella had component-level Reflect evaluations but no repeatable end-to-end personalization benchmark covering production profile injection, knowledge/LCM retrieval, memory tools, and Fact Reflect. This provides a fixed protocol and baseline for comparing future memory changes.

## How

- Select six complete PersonaMem contexts deterministically: three 32k and three 128k contexts, with 148 memory-core and 80 diagnostic questions.
- Incrementally ingest official history into isolated user-agent pairs, run only the production Fact Reflect line to each complete watermark, and freeze every endpoint before QA.
- Answer each question in an independent temporary session while retaining only the production memory tool, then restore usage and remove all QA state.
- Validate dataset hashes, selection identity, model/endpoint identity, checkpoint compatibility, answer parsing, and score aggregation.
- Keep the evaluator behind `personamemeval`; normal builds do not require PersonaMem data or a model endpoint.
- Commit only the adapter, protocol, and readable report. Raw data, benchmark databases, checkpoints, answers, endpoint snapshots, and logs remain ignored under `dist/`.

The committed report records the historical baseline produced from Stella commit `d070430e9b0d04a870faa92ab8cc6cfc4b9a754f`: 74.64% core macro accuracy and 60.09% diagnostic micro accuracy across all 228 completed questions.

## Test

- `mise run format`
- `mise run build`
- `mise run test`
- `mise exec -- go test ./internal/reflect -count=1`
- `PERSONAMEM_DATA_ROOT=/home/yb/src/stella/memory-benchmarks-local/dist/benchmarks/personamem/data mise exec -- go test -tags=personamemeval ./internal/reflect ./cmd/stellad -count=1`
- `git diff --cached --check`
- staged-path and secret/local-path audits; no datasets, run artifacts, credentials, `solution.md`, or `implementation.md` are included

## Refs

Closes #904

## Checklist

- [x] The PR links a GitHub issue.
- [x] I added or updated focused tests for changed non-trivial behavior, or explained why none are needed.
- [x] I updated relevant English and Chinese documentation, or no documentation change is needed.
- [x] I ran `mise run format && mise run build && mise run test`.
