### PR TITLE
📝 docs(rules): capture testbed UI-verification gotchas in web-ui-test

### DIFF
--- a/web/content/docs/development/rules/web-ui-test.md
+++ b/web/content/docs/development/rules/web-ui-test.md
@@ -24,6 +24,15 @@ run it in a dedicated terminal or background task.
 mise run testbed:start
 ```
 
+If the default port 25678 is occupied (a dev server usually owns it), build and
+start the testbed binary directly on a free port — the URL and credentials print
+accordingly, and `mise run testbed:stop` still cleans it up:
+
+```bash
+go build -o dist/bin/testbed ./test/testbed
+./dist/bin/testbed start -port 25811
+```
+
 Start prints the server URL and a temporary credentials path. The credentials
 artifact is mode `0600`; it contains both identities and roles, the admin
 email/password/PAT, and the passwordless user's PAT. Treat it as a secret: do
@@ -99,6 +108,15 @@ sleep 1
 tap browser text | head -20
 ```
 
+If the page is still on `/login` after fill+submit, the controlled React inputs
+ignored the CDP-filled values. Log in through the API from inside the page (the
+session cookie is set the same way), then navigate:
+
+```bash
+tap browser evaluate "fetch('/api/auth/local/login',{method:'POST',headers:{'Content-Type':'application/json'},credentials:'include',body:JSON.stringify({email:'$ADMIN_EMAIL',password:'$ADMIN_PASSWORD'})}).then(r=>r.status)"
+tap browser open "$URL/agents"
+```
+
 ### Register (only when registration UI is under test)
 
 ```bash
@@ -135,6 +153,37 @@ After each action, verify the result before moving on:
 
 If an assertion fails, report what was expected vs what was found. Do not silently continue.
 
+## Seeding UI states
+
+The testbed has no model provider, so goals never advance on their own: they
+stay in `draft`, and `activate` returns 409 ("plan gate not satisfied"). Create
+plain fixtures through the API; fabricate lifecycle-dependent states directly in
+the embedded database. DB fabrication is for **visual verification only** —
+behavior tests must reach states through real paths.
+
+```bash
+# API-creatable: draft goals and scheduler jobs
+curl -X POST -H "Authorization: Bearer $ADMIN_PAT" -H 'Content-Type: application/json' \
+  "$URL/api/goals" -d '{"agent_id":"stella","title":"…","intent":"…"}'
+curl -X POST -H "Authorization: Bearer $ADMIN_PAT" -H 'Content-Type: application/json' \
+  "$URL/api/agents/stella/scheduler/jobs" \
+  -d '{"name":"…","cron":"0 8 * * *","message":"…"}'   # or "every": "4h"
+
+# DB access: DSN from the running process, psql from the managed pg runtime
+DSN=$(ps -wwE -p "$(lsof -t -iTCP:25811 -sTCP:LISTEN)" -o command= \
+  | tr ' ' '\n' | grep -m1 STELLA_DATABASE_URL | cut -d= -f2-)
+PSQL=("$HOME"/.stella/pg-runtime/*/downloaded/postgresapp/postgres/bin/psql)
+"$PSQL" "$DSN" -c "…"
+```
+
+States the Work UI and Inbox key on, all in table `agent_goal`:
+
+- **Needs you / Inbox item**: `lifecycle='blocked'` (any `block_reason`, e.g. `budget_exhausted`). `needs_attention` is derived, not a column.
+- **Active**: `lifecycle='active'`.
+- **Accepted history**: `lifecycle='done', done_reason='accepted'` — a check constraint also requires `acceptance_state='passed'` and non-null `accepted_output`.
+- **Cancelled history**: `POST /api/goals/{id}/cancel` works without any DB write.
+- **Repeatable**: insert an `agent_workflow` row with `owner_kind='agent'`, `payload_format='frozen/v0'`, `payload='{"children":[],"edges":[]}'::jsonb`, and `source_goal_id` pointing at the accepted goal.
+
 ## Related
 
 This covers the browser layer. To assert what a UI action actually wrote, pair it
@@ -151,6 +200,7 @@ through browser automation.
 ## Notes
 
 - Snapshot refs (`@e1`, `@e2`, ...) are invalidated after navigation — always re-snapshot.
+- `tap browser screenshot <path>` may ignore the path argument and write `screenshot-*.png` into the current directory — move the file afterward.
 - Password minimum length is 8 characters.
 - The login form uses `placeholder` attributes: `username`, `password`.
 - After login, the app redirects to `/agents`.

--- a/web/content/docs/development/rules/web-ui-test.zh.md
+++ b/web/content/docs/development/rules/web-ui-test.zh.md
@@ -23,6 +23,14 @@ URL=${URL:-http://localhost:25678}
 mise run testbed:start
 ```
 
+如果默认端口 25678 被占用（通常是开发服务在用），直接构建并以其他端口启动
+testbed 二进制——URL 和凭据会按新端口打印，`mise run testbed:stop` 仍能清理：
+
+```bash
+go build -o dist/bin/testbed ./test/testbed
+./dist/bin/testbed start -port 25811
+```
+
 start 会打印服务 URL 和临时凭据路径。凭据文件权限为 `0600`，其中有两个账户的身份和角色、
 管理员的邮箱/密码/PAT，以及无密码普通用户的 PAT。它是 secret：不要提交、打印或粘贴到共享日志。
 
@@ -94,6 +102,14 @@ sleep 1
 tap browser text | head -20
 ```
 
+如果 fill+submit 之后页面仍停在 `/login`，说明受控的 React 输入框忽略了 CDP
+填入的值。改为在页面内通过 API 登录（session cookie 的设置方式相同），然后导航：
+
+```bash
+tap browser evaluate "fetch('/api/auth/local/login',{method:'POST',headers:{'Content-Type':'application/json'},credentials:'include',body:JSON.stringify({email:'$ADMIN_EMAIL',password:'$ADMIN_PASSWORD'})}).then(r=>r.status)"
+tap browser open "$URL/agents"
+```
+
 ### 注册（仅在测试注册 UI 时）
 
 ```bash
@@ -129,6 +145,36 @@ tap browser open "$URL/settings"
 
 断言失败时，报告期望值和实际值；不要静默继续。
 
+## 构造 UI 状态
+
+testbed 没有配置模型 provider，goal 不会自行推进：它们停留在 `draft`，`activate`
+返回 409（"plan gate not satisfied"）。普通 fixture 走 API 创建；依赖 lifecycle 的
+状态直接写 embedded 数据库。数据库改写**只用于视觉验证**——行为测试必须通过真实
+路径到达状态。
+
+```bash
+# API 可创建：draft goal 和 scheduler job
+curl -X POST -H "Authorization: Bearer $ADMIN_PAT" -H 'Content-Type: application/json' \
+  "$URL/api/goals" -d '{"agent_id":"stella","title":"…","intent":"…"}'
+curl -X POST -H "Authorization: Bearer $ADMIN_PAT" -H 'Content-Type: application/json' \
+  "$URL/api/agents/stella/scheduler/jobs" \
+  -d '{"name":"…","cron":"0 8 * * *","message":"…"}'   # 或 "every": "4h"
+
+# 数据库访问：DSN 取自运行中的进程，psql 在托管的 pg runtime 里
+DSN=$(ps -wwE -p "$(lsof -t -iTCP:25811 -sTCP:LISTEN)" -o command= \
+  | tr ' ' '\n' | grep -m1 STELLA_DATABASE_URL | cut -d= -f2-)
+PSQL=("$HOME"/.stella/pg-runtime/*/downloaded/postgresapp/postgres/bin/psql)
+"$PSQL" "$DSN" -c "…"
+```
+
+Work UI 和 Inbox 依据的状态都在 `agent_goal` 表：
+
+- **Needs you / Inbox 条目**：`lifecycle='blocked'`（任意 `block_reason`，如 `budget_exhausted`）。`needs_attention` 是推导值，不是列。
+- **Active**：`lifecycle='active'`。
+- **已验收的历史**：`lifecycle='done', done_reason='accepted'`——check 约束还要求 `acceptance_state='passed'` 且 `accepted_output` 非空。
+- **已取消的历史**：`POST /api/goals/{id}/cancel` 即可，无需写库。
+- **Repeatable**：向 `agent_workflow` 插入一行，`owner_kind='agent'`、`payload_format='frozen/v0'`、`payload='{"children":[],"edges":[]}'::jsonb`，`source_goal_id` 指向已验收的 goal。
+
 ## 相关文档
 
 本页覆盖浏览器层。要断言 UI 操作实际写入了什么，可配合 `api-test.md` 中的数据库检查：
@@ -142,6 +188,7 @@ tap browser open "$URL/settings"
 ## 说明
 
 - 导航后 snapshot ref（`@e1`、`@e2` 等）会失效，必须重新 snapshot。
+- `tap browser screenshot <path>` 可能忽略路径参数，把 `screenshot-*.png` 写到当前目录——之后自行移动文件。
 - 密码最短长度为 8 个字符。
 - 登录表单使用 `username`、`password` placeholder。
 - 登录后应用会跳转至 `/agents`。


### PR DESCRIPTION
## What

Documents four gotchas hit during #908/#923 UI verification in `web-ui-test.md` + `.zh.md`:

1. **Port conflict** — build the testbed binary and pass `-port` when 25678 is occupied; `mise run testbed:stop` still cleans up.
2. **Login fallback** — controlled React inputs can ignore CDP-filled values; the in-page `fetch` to `/api/auth/local/login` sets the same session cookie.
3. **Screenshot path** — `tap browser screenshot <path>` may ignore the path and write into the cwd.
4. **Seeding UI states** — the testbed has no model provider so goals never leave `draft`; new section documents the API-creatable fixtures plus the embedded-DB recipe for blocked/active/accepted/workflow states (DSN discovery, psql location, check-constraint requirements), explicitly scoped to visual verification only.

Docs only; both languages updated. `mise run format && build && test` pass.

Closes #925