### PR TITLE
🐛 fix(agent): preserve ToolCall order and report cache usage

### DIFF
--- a/internal/observability/tracehook/tracehook_enabled_test.go
+++ b/internal/observability/tracehook/tracehook_enabled_test.go
@@ -69,7 +69,7 @@ func driveSession(h *Hook, sessionID string, llmErr error) {
 	})
 	h.OnPostLLMCall(context.Background(), &hooks.PostLLMCallContext{
 		HookMeta: meta, Model: "claude-3", API: "anthropic",
-		Usage: ai.Usage{InputTokens: 10, OutputTokens: 5}, Duration: time.Second,
+		Usage: ai.Usage{InputTokens: 10, OutputTokens: 5, CacheRead: 7, CacheWrite: 3}, Duration: time.Second,
 		Error: llmErr,
 	})
 	h.OnPostAgentCall(context.Background(), &hooks.PostAgentCallContext{
@@ -133,6 +133,12 @@ func TestHook_EnabledSpanHierarchy(t *testing.T) {
 	assertChildOf(t, "gen_ai.chat", chat, turn)
 	assertChildOf(t, "gen_ai.execute_tool", tool, turn)
 	assertChildOf(t, "memory.search", mem, turn)
+	if got, ok := attrValue(chat, "gen_ai.usage.cache_read.input_tokens"); !ok || got.AsInt64() != 7 {
+		t.Errorf("cache read tokens = %d (ok=%v), want 7", got.AsInt64(), ok)
+	}
+	if got, ok := attrValue(chat, "gen_ai.usage.cache_creation.input_tokens"); !ok || got.AsInt64() != 3 {
+		t.Errorf("cache creation tokens = %d (ok=%v), want 3", got.AsInt64(), ok)
+	}
 }
 
 func TestHook_ToolIORecording(t *testing.T) {

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -230,6 +230,8 @@ func streamAssistant(ctx context.Context, messages []ai.Message, cfg loopConfig,
 	var text string
 	var thinking string
 	toolCalls := map[string]ai.ToolCall{}
+	// The map merges deltas by ID; this slice preserves provider emission order.
+	toolCallOrder := make([]string, 0, 4)
 	toolArgs := map[string]string{} // accumulated raw JSON per tool call ID
 	started := false
 	var ttft time.Duration
@@ -241,6 +243,9 @@ func streamAssistant(ctx context.Context, messages []ai.Message, cfg loopConfig,
 		case ai.EventThinkingDelta:
 			thinking += e.Thinking
 		case ai.EventToolCallDelta:
+			if _, ok := toolCalls[e.ID]; !ok {
+				toolCallOrder = append(toolCallOrder, e.ID)
+			}
 			call := toolCalls[e.ID]
 			call.ID = e.ID
 			if e.Name != "" {
@@ -273,7 +278,7 @@ func streamAssistant(ctx context.Context, messages []ai.Message, cfg loopConfig,
 		// Emit every provider event as a delta.
 		if emit != nil {
 			// Build current partial for the delta snapshot.
-			partial := buildPartial(msg, text, thinking, toolCalls)
+			partial := buildPartial(msg, text, thinking, toolCalls, toolCallOrder)
 			emit(AssistantDelta{Event: event, Message: partial})
 		}
 	}
@@ -301,7 +306,8 @@ func streamAssistant(ctx context.Context, messages []ai.Message, cfg loopConfig,
 	if thinking != "" {
 		msg.Content = append(msg.Content, ai.ThinkingContent{Thinking: thinking})
 	}
-	for id, call := range toolCalls {
+	for _, id := range toolCallOrder {
+		call := toolCalls[id]
 		if raw, ok := toolArgs[id]; ok && raw != "" {
 			var parsed map[string]any
 			if json.Unmarshal([]byte(raw), &parsed) == nil {
@@ -319,7 +325,7 @@ func streamAssistant(ctx context.Context, messages []ai.Message, cfg loopConfig,
 }
 
 // buildPartial constructs a snapshot of the in-progress assistant message.
-func buildPartial(base ai.AssistantMessage, text, thinking string, toolCalls map[string]ai.ToolCall) ai.AssistantMessage {
+func buildPartial(base ai.AssistantMessage, text, thinking string, toolCalls map[string]ai.ToolCall, toolCallOrder []string) ai.AssistantMessage {
 	partial := base
 	partial.Content = make([]ai.ContentBlock, 0, 4)
 	if text != "" {
@@ -328,8 +334,8 @@ func buildPartial(base ai.AssistantMessage, text, thinking string, toolCalls map
 	if thinking != "" {
 		partial.Content = append(partial.Content, ai.ThinkingContent{Thinking: thinking})
 	}
-	for _, call := range toolCalls {
-		partial.Content = append(partial.Content, call)
+	for _, id := range toolCallOrder {
+		partial.Content = append(partial.Content, toolCalls[id])
 	}
 	return partial
 }

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -51,6 +52,16 @@ func countEvents[T LoopEvent](events []LoopEvent) int {
 	return n
 }
 
+func toolCallIDs(blocks []ai.ContentBlock) []string {
+	ids := make([]string, 0, len(blocks))
+	for _, block := range blocks {
+		if call, ok := block.(ai.ToolCall); ok {
+			ids = append(ids, call.ID)
+		}
+	}
+	return ids
+}
+
 func TestRunEmitsStreamingEvents(t *testing.T) {
 	runner := newTestRunner(defaultFakeStream())
 	history, events, err := collectEvents(runner, []ai.Message{ai.UserMessage{Content: "hello"}})
@@ -97,6 +108,105 @@ func TestRunEmitsStreamingEvents(t *testing.T) {
 	tc, ok := finished.Message.Content[0].(ai.TextContent)
 	if !ok || tc.Text != "response" {
 		t.Fatalf("expected text 'response', got %v", finished.Message.Content[0])
+	}
+}
+
+func TestRunPreservesToolCallOrder(t *testing.T) {
+	wantIDs := []string{"call-e", "call-d", "call-c", "call-b", "call-a"}
+	providerCalls := 0
+	stream := func(_ context.Context, _ ai.Model, _ ai.Context, _ ai.StreamOptions) (providers.AssistantEventStream, error) {
+		providerCalls++
+		providerCall := providerCalls
+		out := providers.NewChannelEventStream(32)
+		go func() {
+			if providerCall == 1 {
+				for _, id := range wantIDs {
+					out.Emit(ai.EventToolCallDelta{ID: id, Name: "ordered"})
+				}
+				// Argument chunks may interleave without changing first-seen order.
+				for i := len(wantIDs) - 1; i >= 0; i-- {
+					out.Emit(ai.EventToolCallDelta{ID: wantIDs[i], Arguments: `{"index":`})
+				}
+				for i := len(wantIDs) - 1; i >= 0; i-- {
+					out.Emit(ai.EventToolCallDelta{ID: wantIDs[i], Arguments: fmt.Sprintf("%d}", i)})
+				}
+				out.Emit(ai.EventStop{Reason: ai.StopReasonToolUse})
+			} else {
+				out.Emit(ai.EventTextDelta{Text: "done"})
+				out.Emit(ai.EventStop{Reason: ai.StopReasonStop})
+			}
+			out.Finish(nil)
+		}()
+		return out, nil
+	}
+
+	runner := newTestRunner(stream)
+	var executed []string
+	runner.tools = ToolSet{"ordered": func(_ context.Context, call ai.ToolCall) ([]ai.ContentBlock, error) {
+		executed = append(executed, call.ID)
+		return []ai.ContentBlock{ai.TextContent{Text: call.ID}}, nil
+	}}
+
+	history, events, err := collectEvents(runner, []ai.Message{ai.UserMessage{Content: "go"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(executed, wantIDs) {
+		t.Fatalf("execution order = %v, want %v", executed, wantIDs)
+	}
+
+	var partialIDs, finalIDs, startedIDs, finishedIDs []string
+	for _, event := range events {
+		switch e := event.(type) {
+		case AssistantDelta:
+			if _, ok := e.Event.(ai.EventStop); ok && len(partialIDs) == 0 {
+				partialIDs = toolCallIDs(e.Message.Content)
+			}
+		case AssistantFinished:
+			if ids := toolCallIDs(e.Message.Content); len(ids) > 0 {
+				finalIDs = ids
+			}
+		case ToolStarted:
+			startedIDs = append(startedIDs, e.ToolCall.ID)
+		case ToolFinished:
+			finishedIDs = append(finishedIDs, e.Result.ToolCallID)
+		}
+	}
+	for label, got := range map[string][]string{
+		"partial":  partialIDs,
+		"final":    finalIDs,
+		"started":  startedIDs,
+		"finished": finishedIDs,
+	} {
+		if !slices.Equal(got, wantIDs) {
+			t.Errorf("%s order = %v, want %v", label, got, wantIDs)
+		}
+	}
+
+	if len(history) != len(wantIDs)+3 {
+		t.Fatalf("history length = %d, want %d", len(history), len(wantIDs)+3)
+	}
+	assistant, ok := history[1].(ai.AssistantMessage)
+	if !ok || !slices.Equal(toolCallIDs(assistant.Content), wantIDs) {
+		t.Fatalf("persisted assistant order = %v, want %v", toolCallIDs(assistant.Content), wantIDs)
+	}
+	for i, wantID := range wantIDs {
+		result, ok := history[i+2].(ai.ToolResultMessage)
+		if !ok || result.ToolCallID != wantID {
+			t.Fatalf("persisted result %d = %#v, want %q", i, history[i+2], wantID)
+		}
+	}
+}
+
+func TestBuildPartialUsesFirstSeenToolCallOrder(t *testing.T) {
+	calls := map[string]ai.ToolCall{
+		"a": {ID: "a", Name: "first"},
+		"b": {ID: "b", Name: "second"},
+		"c": {ID: "c", Name: "third"},
+	}
+	partial := buildPartial(ai.AssistantMessage{}, "", "", calls, []string{"c", "a", "b"})
+	if got, want := toolCallIDs(partial.Content), []string{"c", "a", "b"}; !slices.Equal(got, want) {
+		t.Fatalf("partial order = %v, want %v", got, want)
 	}
 }
 

--- a/pkg/ai/model.go
+++ b/pkg/ai/model.go
@@ -135,6 +135,10 @@ type UsageCost struct {
 }
 
 // Usage tracks token accounting returned by providers.
+// InputTokens preserves provider semantics: some providers include cached input
+// in this value while others report cache categories separately. TotalTokens is
+// the complete normalized total with cache categories counted exactly once;
+// consumers must not derive it by blindly summing the other fields.
 type Usage struct {
 	InputTokens  int
 	OutputTokens int

--- a/plugins/providers/anthropic/stream.go
+++ b/plugins/providers/anthropic/stream.go
@@ -68,11 +68,14 @@ func mapEvent(event sdk.MessageStreamEventUnion, blockToID map[int]string) []ai.
 		if event.Delta.StopReason != "" {
 			events = append(events, ai.EventStop{Reason: mapStopReason(string(event.Delta.StopReason))})
 		}
-		if event.Usage.InputTokens > 0 || event.Usage.OutputTokens > 0 {
+		if event.Usage.InputTokens > 0 || event.Usage.OutputTokens > 0 || event.Usage.CacheReadInputTokens > 0 || event.Usage.CacheCreationInputTokens > 0 {
 			events = append(events, ai.EventUsage{Usage: ai.Usage{
 				InputTokens:  int(event.Usage.InputTokens),
 				OutputTokens: int(event.Usage.OutputTokens),
-				TotalTokens:  int(event.Usage.InputTokens + event.Usage.OutputTokens),
+				CacheRead:    int(event.Usage.CacheReadInputTokens),
+				CacheWrite:   int(event.Usage.CacheCreationInputTokens),
+				TotalTokens: int(event.Usage.InputTokens + event.Usage.OutputTokens +
+					event.Usage.CacheReadInputTokens + event.Usage.CacheCreationInputTokens),
 			}})
 		}
 		return events

--- a/plugins/providers/anthropic/stream_test.go
+++ b/plugins/providers/anthropic/stream_test.go
@@ -34,8 +34,10 @@ func TestMapEventMessageDeltaUsage(t *testing.T) {
 			StopReason: "end_turn",
 		},
 		Usage: sdk.MessageDeltaUsage{
-			InputTokens:  8,
-			OutputTokens: 2,
+			InputTokens:              8,
+			OutputTokens:             2,
+			CacheReadInputTokens:     5,
+			CacheCreationInputTokens: 3,
 		},
 	}
 	events := mapEvent(event, blockToID)
@@ -45,8 +47,13 @@ func TestMapEventMessageDeltaUsage(t *testing.T) {
 	if _, ok := events[0].(ai.EventStop); !ok {
 		t.Fatalf("expected stop event")
 	}
-	if _, ok := events[1].(ai.EventUsage); !ok {
+	usage, ok := events[1].(ai.EventUsage)
+	if !ok {
 		t.Fatalf("expected usage event")
+	}
+	want := ai.Usage{InputTokens: 8, OutputTokens: 2, CacheRead: 5, CacheWrite: 3, TotalTokens: 18}
+	if usage.Usage != want {
+		t.Fatalf("usage = %+v, want %+v", usage.Usage, want)
 	}
 }
 

--- a/plugins/providers/openai-response/stream.go
+++ b/plugins/providers/openai-response/stream.go
@@ -63,10 +63,11 @@ func mapEvent(event responses.ResponseStreamEventUnion, itemToCall map[string]st
 
 	case "response.completed":
 		usage := event.Response.Usage
-		if usage.TotalTokens > 0 || usage.InputTokens > 0 || usage.OutputTokens > 0 {
+		if usage.TotalTokens > 0 || usage.InputTokens > 0 || usage.OutputTokens > 0 || usage.InputTokensDetails.CachedTokens > 0 {
 			events = append(events, ai.EventUsage{Usage: ai.Usage{
 				InputTokens:  int(usage.InputTokens),
 				OutputTokens: int(usage.OutputTokens),
+				CacheRead:    int(usage.InputTokensDetails.CachedTokens),
 				TotalTokens:  int(usage.TotalTokens),
 			}})
 		}

--- a/plugins/providers/openai-response/stream_test.go
+++ b/plugins/providers/openai-response/stream_test.go
@@ -93,6 +93,9 @@ func TestMapEventCompleted(t *testing.T) {
 				InputTokens:  10,
 				OutputTokens: 5,
 				TotalTokens:  15,
+				InputTokensDetails: responses.ResponseUsageInputTokensDetails{
+					CachedTokens: 7,
+				},
 			},
 		},
 	}
@@ -104,8 +107,9 @@ func TestMapEventCompleted(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected EventUsage, got %T", events[0])
 	}
-	if usage.Usage.InputTokens != 10 || usage.Usage.OutputTokens != 5 || usage.Usage.TotalTokens != 15 {
-		t.Fatalf("unexpected usage: %+v", usage.Usage)
+	wantUsage := ai.Usage{InputTokens: 10, OutputTokens: 5, CacheRead: 7, TotalTokens: 15}
+	if usage.Usage != wantUsage {
+		t.Fatalf("usage = %+v, want %+v", usage.Usage, wantUsage)
 	}
 	stop, ok := events[1].(ai.EventStop)
 	if !ok {

--- a/plugins/providers/openai/contract_test.go
+++ b/plugins/providers/openai/contract_test.go
@@ -161,9 +161,10 @@ func TestProviderStreamToolLoopContract(t *testing.T) {
 func chatCompletionRequest(model string, messages []any, schema map[string]any) func(map[string]any) error {
 	return func(body map[string]any) error {
 		want := map[string]any{
-			"model":    model,
-			"stream":   true,
-			"messages": messages,
+			"model":          model,
+			"stream":         true,
+			"stream_options": map[string]any{"include_usage": true},
+			"messages":       messages,
 			"tools": []any{map[string]any{
 				"type": "function",
 				"function": map[string]any{

--- a/plugins/providers/openai/options.go
+++ b/plugins/providers/openai/options.go
@@ -14,6 +14,9 @@ func buildParams(model ai.Model, ctx ai.Context, opts ai.StreamOptions) sdk.Chat
 	params := sdk.ChatCompletionNewParams{
 		Model:    model.Name,
 		Messages: messages,
+		StreamOptions: sdk.ChatCompletionStreamOptionsParam{
+			IncludeUsage: sdk.Bool(true),
+		},
 	}
 
 	if opts.Temperature != nil {

--- a/plugins/providers/openai/options_test.go
+++ b/plugins/providers/openai/options_test.go
@@ -20,6 +20,9 @@ func TestBuildParamsBasic(t *testing.T) {
 	if len(params.Messages) != 1 {
 		t.Errorf("expected 1 message, got %d", len(params.Messages))
 	}
+	if !params.StreamOptions.IncludeUsage.Value {
+		t.Error("stream_options.include_usage = false, want true")
+	}
 }
 
 func TestBuildParamsWithTemperature(t *testing.T) {

--- a/plugins/providers/openai/stream.go
+++ b/plugins/providers/openai/stream.go
@@ -55,10 +55,11 @@ func mapChunk(chunk sdk.ChatCompletionChunk, indexToID map[int]string) []ai.Assi
 		}
 	}
 
-	if chunk.Usage.TotalTokens > 0 || chunk.Usage.PromptTokens > 0 || chunk.Usage.CompletionTokens > 0 {
+	if chunk.Usage.TotalTokens > 0 || chunk.Usage.PromptTokens > 0 || chunk.Usage.CompletionTokens > 0 || chunk.Usage.PromptTokensDetails.CachedTokens > 0 {
 		events = append(events, ai.EventUsage{Usage: ai.Usage{
 			InputTokens:  int(chunk.Usage.PromptTokens),
 			OutputTokens: int(chunk.Usage.CompletionTokens),
+			CacheRead:    int(chunk.Usage.PromptTokensDetails.CachedTokens),
 			TotalTokens:  int(chunk.Usage.TotalTokens),
 		}})
 	}

--- a/plugins/providers/openai/stream_test.go
+++ b/plugins/providers/openai/stream_test.go
@@ -21,6 +21,9 @@ func TestMapChunkTextAndStop(t *testing.T) {
 			PromptTokens:     5,
 			CompletionTokens: 1,
 			TotalTokens:      6,
+			PromptTokensDetails: sdk.CompletionUsagePromptTokensDetails{
+				CachedTokens: 4,
+			},
 		},
 	}
 	events := mapChunk(chunk, indexToID)
@@ -33,8 +36,13 @@ func TestMapChunkTextAndStop(t *testing.T) {
 	if _, ok := events[1].(ai.EventStop); !ok {
 		t.Fatalf("expected second event stop")
 	}
-	if _, ok := events[2].(ai.EventUsage); !ok {
+	usage, ok := events[2].(ai.EventUsage)
+	if !ok {
 		t.Fatalf("expected third event usage")
+	}
+	want := ai.Usage{InputTokens: 5, OutputTokens: 1, CacheRead: 4, TotalTokens: 6}
+	if usage.Usage != want {
+		t.Fatalf("usage = %+v, want %+v", usage.Usage, want)
 	}
 }
 


### PR DESCRIPTION
## What

Preserve provider-emitted ToolCall order throughout partial/final assembly, sequential execution, events, and persisted history. Also map provider-reported prompt-cache usage into Stella's existing usage logs and OpenTelemetry spans.

## Why

`streamAssistant` aggregated ToolCall deltas in maps and later iterated those maps, so Go could reorder calls before execution and persistence. Stella already exposed cache read/write telemetry fields, but the Anthropic, OpenAI Chat, and OpenAI Responses adapters left them empty, making cache behavior invisible.

## How

- Keep maps for ToolCall delta aggregation and add a first-seen ID slice as the ordering source.
- Build partial and final assistant messages from that slice; leave the existing sequential executor unchanged.
- Request the final OpenAI Chat stream usage chunk, then map Anthropic cache-read/cache-creation tokens and OpenAI cached-input tokens without fabricating unsupported cache-write values.
- Verify the existing OTel cache token attributes.
- Deliberate limit: this does not enable or configure provider prompt caching; cache controls remain in #830. Conservative parallel execution remains outside this Phase 1 patch.

## Test

- `mise run format`
- `mise run build`
- `mise run build:web && mise run test`
- `mise exec -- go test ./plugins/providers/openai ./pkg/ai`
- Mutated the production fixes back to `origin/main`; the new ToolCall-order and provider cache-usage regression tests failed as expected.

## Refs

Refs #930
Refs #830

## Checklist

- [x] The PR links a GitHub issue.
- [x] I added or updated focused tests for changed non-trivial behavior, or explained why none are needed.
- [x] No documentation change is needed; this fixes internal ordering and exposes provider usage through existing telemetry fields.
- [x] I ran `mise run format && mise run build && mise run test`.

