### PR TITLE
🐛 fix(session): keep chat turns alive across navigation

### DIFF
--- a/api/spec/domain/sessions/paths.yaml
+++ b/api/spec/domain/sessions/paths.yaml
@@ -240,8 +240,7 @@ paths:
       operationId: stopSession
       responses:
         "204": {
-          description: The active turn was stopped,
-          or no turn was active,
+          description: "The active turn was stopped, or no turn was active",
         }
         "401": {
           $ref: "../../components.yaml#/components/responses/Unauthorized",

--- a/api/spec/domain/sessions/paths.yaml
+++ b/api/spec/domain/sessions/paths.yaml
@@ -227,6 +227,28 @@ paths:
         }
         "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
 
+  /api/agents/{agentId}/sessions/{sessionId}/stop:
+    parameters:
+      - { name: agentId, in: path, required: true, schema: { type: string } }
+      - { name: sessionId, in: path, required: true, schema: { type: string } }
+    post:
+      tags: [sessions]
+      summary: Stop the active turn on a session
+      description: >
+        Explicitly cancel the session's in-flight turn. Disconnecting from a
+        message or events stream does not stop the turn.
+      operationId: stopSession
+      responses:
+        "204": {
+          description: The active turn was stopped,
+          or no turn was active,
+        }
+        "401": {
+          $ref: "../../components.yaml#/components/responses/Unauthorized",
+        }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+
   /api/agents/{agentId}/sessions/{sessionId}/events:
     parameters:
       - { name: agentId, in: path, required: true, schema: { type: string } }
@@ -236,10 +258,10 @@ paths:
       summary: Stream a session's live turn events (read-only SSE)
       description: >
         Subscribe to the events of an in-flight turn on this session without
-        initiating one. Used by the web UI to watch server-driven turns
-        (scheduler, task, delegate) or a turn started in another tab in real
-        time. The stream emits the same Vercel AI-SDK UI message frames as the
-        message-send endpoint and ends when the turn finishes.
+        initiating one. Used by the web UI to resume a turn after navigation,
+        refresh, connection loss, or a turn started elsewhere. The stream emits
+        the same Vercel AI-SDK UI message frames as the message-send endpoint
+        and ends when the turn finishes.
       operationId: streamSessionEvents
       responses:
         "200":

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -225,6 +225,8 @@ paths:
     $ref: "./domain/sessions/paths.yaml#/paths/~1api~1agents~1{agentId}~1sessions~1{sessionId}~1messages"
   /api/agents/{agentId}/sessions/{sessionId}/media/{mediaId}:
     $ref: "./domain/sessions/paths.yaml#/paths/~1api~1agents~1{agentId}~1sessions~1{sessionId}~1media~1{mediaId}"
+  /api/agents/{agentId}/sessions/{sessionId}/stop:
+    $ref: "./domain/sessions/paths.yaml#/paths/~1api~1agents~1{agentId}~1sessions~1{sessionId}~1stop"
   /api/agents/{agentId}/sessions/{sessionId}/events:
     $ref: "./domain/sessions/paths.yaml#/paths/~1api~1agents~1{agentId}~1sessions~1{sessionId}~1events"
   /api/agents/{agentId}/sessions/{sessionId}/context-items:

--- a/cmd/stellad/gateway.go
+++ b/cmd/stellad/gateway.go
@@ -421,7 +421,10 @@ func runServer(ctx context.Context, s *setupResult, loginConfig oidc.LoginConfig
 	// send path degrades to 503 while CRUD stays available).
 	groupSvc := channel.NewGroupService(s.db, agentAccess, channel.NewRuntimeResolver(s.store), elStore, groupDispatcher)
 
-	adminSrv, err := server.New(gctx, server.Deps{
+	// Accepted Web turns outlive their initiating HTTP connections and must also
+	// survive the errgroup cancellation caused by HTTP Shutdown. workCtx is
+	// canceled only after the graceful-drain accepted-work wait completes.
+	adminSrv, err := server.New(workCtx, server.Deps{
 		Pinger:              s.db,
 		Account:             accountSvc,
 		Profile:             profileSvc,

--- a/internal/agent/runtime/busy_guard_test.go
+++ b/internal/agent/runtime/busy_guard_test.go
@@ -103,6 +103,65 @@ func TestChat_BusyGuard_RejectsConcurrentSameSession(t *testing.T) {
 	}
 }
 
+type contextRunner struct{}
+
+func (r *contextRunner) Chat(ctx context.Context, _ []ai.Message, _ MessageContent) <-chan Event {
+	out := make(chan Event, 1)
+	go func() {
+		defer close(out)
+		out <- Event{Text: "partial"}
+		<-ctx.Done()
+	}()
+	return out
+}
+func (r *contextRunner) Alive() bool             { return true }
+func (r *contextRunner) Busy() bool              { return false }
+func (r *contextRunner) LastActivity() time.Time { return time.Now() }
+func (r *contextRunner) SystemPrompt() string    { return "" }
+func (r *contextRunner) Close() error            { return nil }
+
+func TestStopSessionCancelsOnlyExplicitly(t *testing.T) {
+	mem := &recordingMemory{}
+	rt, err := New(Config{
+		NewRunner: func(_ context.Context, _ RunnerParams) (Runner, error) {
+			return &contextRunner{}, nil
+		},
+		Memory: mem,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	info := session.Info{ID: "sess-stop", UserID: "u1", AgentID: "a1"}
+	stream := rt.Chat(context.Background(), info, "hello")
+
+	deadline := time.Now().Add(time.Second)
+	for !rt.SessionLive(info.ID) && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if !rt.StopSession(t.Context(), info.ID) {
+		t.Fatal("StopSession reported no active turn")
+	}
+	for range stream {
+	}
+	waitSessionFree(t, rt, info.ID)
+	if rt.StopSession(t.Context(), info.ID) {
+		t.Fatal("stopping an idle session should report false")
+	}
+	mem.mu.Lock()
+	defer mem.mu.Unlock()
+	if len(mem.messages) != 2 {
+		t.Fatalf("persisted messages = %d, want user plus partial assistant", len(mem.messages))
+	}
+	assistant, ok := mem.messages[1].(ai.AssistantMessage)
+	if !ok || len(assistant.Content) != 1 {
+		t.Fatalf("persisted partial assistant = %#v", mem.messages[1])
+	}
+	text, ok := assistant.Content[0].(ai.TextContent)
+	if !ok || text.Text != "partial" {
+		t.Fatalf("persisted partial text = %#v", assistant.Content[0])
+	}
+}
+
 func TestChat_BusyGuard_AllowsDifferentSessions(t *testing.T) {
 	gate := make(chan struct{})
 	rt := newTestRuntime(gate)

--- a/internal/agent/runtime/chat.go
+++ b/internal/agent/runtime/chat.go
@@ -383,6 +383,8 @@ func (rt *Runtime) streamEvents(
 	isGroup := memSess.GroupID != ""
 	var chatErr error
 	var pendingStores []ai.Message
+	var textBuf strings.Builder
+	var reasoningBuf strings.Builder
 	appendWithPrefix := func(msgs ...ai.Message) error {
 		storeMessages := make([]ai.Message, 0, len(storePrefix)+len(msgs))
 		storeMessages = append(storeMessages, storePrefix...)
@@ -400,6 +402,16 @@ func (rt *Runtime) streamEvents(
 		}
 		return appendWithPrefix(msgs...)
 	}
+	flushInterruptedAssistant := func() {
+		if isGroup || (textBuf.Len() == 0 && reasoningBuf.Len() == 0) {
+			return
+		}
+		if err := appendWithPrefix(bufferedAssistantMessage(textBuf.String(), reasoningBuf.String())); err != nil {
+			rt.log.Warn("memory append interrupted assistant failed", "session_id", sessionID, "error", err)
+		}
+		textBuf.Reset()
+		reasoningBuf.Reset()
+	}
 	defer func() {
 		hs.RunPostAgentCall(ctx, &hooks.PostAgentCallContext{
 			HookMeta: hookMeta,
@@ -409,19 +421,14 @@ func (rt *Runtime) streamEvents(
 		close(out)
 	}()
 
-	var textBuf strings.Builder
-	var reasoningBuf strings.Builder
-
 	for evt := range stream {
 		if evt.Err != nil {
 			chatErr = evt.Err
-			if !isGroup && (textBuf.Len() > 0 || reasoningBuf.Len() > 0) {
-				flush := bufferedAssistantMessage(textBuf.String(), reasoningBuf.String())
-				if err := rt.mem.Append(persistCtx, memSess, flush); err != nil {
-					rt.log.Warn("memory append error-flush failed", "session_id", sessionID, "error", err)
-				}
-				textBuf.Reset()
-				reasoningBuf.Reset()
+			flushInterruptedAssistant()
+			// Explicit stop and lifecycle shutdown are normal cancellation paths,
+			// not failed turns to surface as an in-band chat error.
+			if ctx.Err() != nil && errors.Is(evt.Err, context.Canceled) {
+				return ctx.Err()
 			}
 			if errors.Is(evt.Err, ErrChatTimeout) {
 				notice := "I've been working on this for a while and have reached the time limit. Here's where things stand — feel free to send a message to continue or change direction."
@@ -460,6 +467,7 @@ func (rt *Runtime) streamEvents(
 		if evt.ToolUse != nil {
 			if !sendEvent(ctx, out, evt) {
 				chatErr = ctx.Err()
+				flushInterruptedAssistant()
 				return chatErr
 			}
 			continue
@@ -473,11 +481,13 @@ func (rt *Runtime) streamEvents(
 		}
 		if !sendEvent(ctx, out, evt) {
 			chatErr = ctx.Err()
+			flushInterruptedAssistant()
 			return chatErr
 		}
 	}
 
 	if ctx.Err() != nil {
+		flushInterruptedAssistant()
 		return ctx.Err()
 	}
 	if textBuf.Len() > 0 || reasoningBuf.Len() > 0 {

--- a/internal/agent/runtime/hub.go
+++ b/internal/agent/runtime/hub.go
@@ -47,6 +47,10 @@ const (
 	// from turning one active session into unbounded server memory.
 	replayMaxEvents = 4096
 	replayMaxBytes  = 8 << 20
+	// Bound string concatenation so retaining streamed deltas stays linear in
+	// output size; 2 KiB chunks can still fill the 8 MiB byte ceiling without
+	// hitting the event ceiling first.
+	replayDeltaMaxBytes = 2 << 10
 )
 
 // NewSessionHub returns an empty hub.
@@ -151,9 +155,13 @@ func (h *SessionHub) publish(sessionID string, event Event) {
 
 	h.mu.Lock()
 	if state := h.replay[sessionID]; replayable && state != nil && !state.disabled {
-		coalescesWithTail := deltaKind != 0 && len(state.events) > 0 &&
-			replayDeltaKind(state.events[len(state.events)-1]) == deltaKind
 		deltaSize := len(event.Text) + len(event.Reasoning)
+		coalescesWithTail := false
+		if deltaKind != 0 && len(state.events) > 0 {
+			last := state.events[len(state.events)-1]
+			coalescesWithTail = replayDeltaKind(last) == deltaKind &&
+				len(last.Text)+len(last.Reasoning)+deltaSize <= replayDeltaMaxBytes
+		}
 		switch {
 		case coalescesWithTail && state.bytes+deltaSize > replayMaxBytes:
 			disableReplay(state)

--- a/internal/agent/runtime/hub.go
+++ b/internal/agent/runtime/hub.go
@@ -1,15 +1,19 @@
 package runtime
 
-import "sync"
+import (
+	"encoding/json"
+	"sync"
+)
 
 // SessionHub fans out a session's live turn events to any number of read-only
 // subscribers. The runtime publishes every event of an in-flight turn; HTTP SSE
-// handlers subscribe to watch a turn they did not initiate — a scheduler/task
-// turn driven server-side, or a turn started from another browser tab.
+// handlers subscribe to watch a turn after navigation or connection loss, one
+// driven server-side, or one started from another browser tab.
 //
 // Publishing never blocks the turn: a slow subscriber drops events rather than
-// stalling the agent. Subscribers reconcile final state by reloading persisted
-// history, so dropped deltas are cosmetic.
+// stalling the agent. While a turn is active, the hub retains a bounded replay
+// so a newly attached subscriber can reconstruct output emitted before it
+// connected. Subscribers still reconcile final state from persisted history.
 //
 // Placement invariant: the hub lives on the Runtime that executes a session's
 // turns, and the SSE handler subscribes via the Service of `session.AgentID`.
@@ -20,29 +24,54 @@ import "sync"
 // stream would silently fall back to 204. Such a change must hoist the hub to a
 // single per-pool instance keyed by session ID.
 type SessionHub struct {
-	mu   sync.Mutex
-	subs map[string]map[chan Event]struct{}
-	live map[string]int // session ID → in-flight turn count
+	mu     sync.Mutex
+	subs   map[string]map[chan Event]struct{}
+	live   map[string]int // session ID → in-flight turn count
+	replay map[string]*replayState
 }
 
-// subBuffer bounds per-subscriber buffering before events are dropped.
-const subBuffer = 256
+type replayState struct {
+	events   []Event
+	bytes    int
+	disabled bool
+}
+
+const (
+	// subBuffer bounds live per-subscriber buffering before events are dropped.
+	subBuffer = 256
+	// Replay is deliberately process-local: it covers browser navigation and
+	// transient disconnects. A durable event log is the upgrade when turns must
+	// survive process replacement. The byte ceiling prevents tool/image output
+	// from turning one active session into unbounded server memory.
+	replayMaxEvents = 4096
+	replayMaxBytes  = 8 << 20
+)
 
 // NewSessionHub returns an empty hub.
 func NewSessionHub() *SessionHub {
 	return &SessionHub{
-		subs: make(map[string]map[chan Event]struct{}),
-		live: make(map[string]int),
+		subs:   make(map[string]map[chan Event]struct{}),
+		live:   make(map[string]int),
+		replay: make(map[string]*replayState),
 	}
 }
 
-// Subscribe registers a listener for a session's live events. The returned
-// channel delivers events until the turn ends (then it is closed) or the caller
-// invokes cancel. Callers must always invoke cancel to avoid leaking the
-// subscription.
+// Subscribe registers a listener for a session's live events. Events already
+// emitted by the active turn are queued before live delivery. The returned
+// channel closes when the turn ends or the caller invokes cancel.
 func (h *SessionHub) Subscribe(sessionID string) (<-chan Event, func()) {
-	ch := make(chan Event, subBuffer)
 	h.mu.Lock()
+	replayed := h.replay[sessionID]
+	capacity := subBuffer
+	if replayed != nil && !replayed.disabled && len(replayed.events)+subBuffer > capacity {
+		capacity = len(replayed.events) + subBuffer
+	}
+	ch := make(chan Event, capacity)
+	if replayed != nil && !replayed.disabled {
+		for _, event := range replayed.events {
+			ch <- event
+		}
+	}
 	set := h.subs[sessionID]
 	if set == nil {
 		set = make(map[chan Event]struct{})
@@ -80,6 +109,9 @@ func (h *SessionHub) IsLive(sessionID string) bool {
 // begin marks a turn as in flight.
 func (h *SessionHub) begin(sessionID string) {
 	h.mu.Lock()
+	if h.live[sessionID] == 0 {
+		h.replay[sessionID] = &replayState{}
+	}
 	h.live[sessionID]++
 	h.mu.Unlock()
 }
@@ -93,6 +125,7 @@ func (h *SessionHub) end(sessionID string) {
 	}
 	if h.live[sessionID] == 0 {
 		delete(h.live, sessionID)
+		delete(h.replay, sessionID)
 		for ch := range h.subs[sessionID] {
 			close(ch)
 		}
@@ -101,15 +134,35 @@ func (h *SessionHub) end(sessionID string) {
 	h.mu.Unlock()
 }
 
-// publish delivers an event to every current subscriber, dropping it for any
-// subscriber whose buffer is full.
-func (h *SessionHub) publish(sessionID string, ev Event) {
+// publish records and delivers an event without blocking the producer.
+func (h *SessionHub) publish(sessionID string, event Event) {
 	h.mu.Lock()
+	if state := h.replay[sessionID]; state != nil && !state.disabled {
+		size := replayEventSize(event)
+		if len(state.events) >= replayMaxEvents || state.bytes+size > replayMaxBytes {
+			state.events = nil
+			state.bytes = 0
+			state.disabled = true
+		} else {
+			state.events = append(state.events, event)
+			state.bytes += size
+		}
+	}
 	for ch := range h.subs[sessionID] {
 		select {
-		case ch <- ev:
+		case ch <- event:
 		default:
 		}
 	}
 	h.mu.Unlock()
+}
+
+func replayEventSize(event Event) int {
+	// JSON is only used to account for nested tool/reference payloads. If an
+	// event cannot be represented, disable replay rather than undercount it.
+	encoded, err := json.Marshal(event)
+	if err != nil {
+		return replayMaxBytes + 1
+	}
+	return len(encoded)
 }

--- a/internal/agent/runtime/hub.go
+++ b/internal/agent/runtime/hub.go
@@ -153,14 +153,15 @@ func (h *SessionHub) publish(sessionID string, event Event) {
 	if state := h.replay[sessionID]; replayable && state != nil && !state.disabled {
 		coalescesWithTail := deltaKind != 0 && len(state.events) > 0 &&
 			replayDeltaKind(state.events[len(state.events)-1]) == deltaKind
+		deltaSize := len(event.Text) + len(event.Reasoning)
 		switch {
-		case coalescesWithTail && state.bytes+size > replayMaxBytes:
+		case coalescesWithTail && state.bytes+deltaSize > replayMaxBytes:
 			disableReplay(state)
 		case coalescesWithTail:
 			last := &state.events[len(state.events)-1]
 			last.Text += event.Text
 			last.Reasoning += event.Reasoning
-			state.bytes += size
+			state.bytes += deltaSize
 		case len(state.events) >= replayMaxEvents || state.bytes+size > replayMaxBytes:
 			disableReplay(state)
 		default:

--- a/internal/agent/runtime/hub.go
+++ b/internal/agent/runtime/hub.go
@@ -3,6 +3,8 @@ package runtime
 import (
 	"encoding/json"
 	"sync"
+
+	"github.com/CherryHQ/stella/pkg/renderrefs"
 )
 
 // SessionHub fans out a session's live turn events to any number of read-only
@@ -136,14 +138,32 @@ func (h *SessionHub) end(sessionID string) {
 
 // publish records and delivers an event without blocking the producer.
 func (h *SessionHub) publish(sessionID string, event Event) {
+	// Store events are never encoded by the SSE boundary, so retaining them only
+	// burns replay memory. Size everything else before taking the runtime-wide
+	// hub lock; structured tool arguments are rare but may require JSON encoding.
+	replayable := event.Store == nil
+	size := 0
+	deltaKind := 0
+	if replayable {
+		size = replayEventSize(event)
+		deltaKind = replayDeltaKind(event)
+	}
+
 	h.mu.Lock()
-	if state := h.replay[sessionID]; state != nil && !state.disabled {
-		size := replayEventSize(event)
-		if len(state.events) >= replayMaxEvents || state.bytes+size > replayMaxBytes {
-			state.events = nil
-			state.bytes = 0
-			state.disabled = true
-		} else {
+	if state := h.replay[sessionID]; replayable && state != nil && !state.disabled {
+		coalescesWithTail := deltaKind != 0 && len(state.events) > 0 &&
+			replayDeltaKind(state.events[len(state.events)-1]) == deltaKind
+		switch {
+		case coalescesWithTail && state.bytes+size > replayMaxBytes:
+			disableReplay(state)
+		case coalescesWithTail:
+			last := &state.events[len(state.events)-1]
+			last.Text += event.Text
+			last.Reasoning += event.Reasoning
+			state.bytes += size
+		case len(state.events) >= replayMaxEvents || state.bytes+size > replayMaxBytes:
+			disableReplay(state)
+		default:
 			state.events = append(state.events, event)
 			state.bytes += size
 		}
@@ -157,12 +177,56 @@ func (h *SessionHub) publish(sessionID string, event Event) {
 	h.mu.Unlock()
 }
 
-func replayEventSize(event Event) int {
-	// JSON is only used to account for nested tool/reference payloads. If an
-	// event cannot be represented, disable replay rather than undercount it.
-	encoded, err := json.Marshal(event)
-	if err != nil {
-		return replayMaxBytes + 1
+func disableReplay(state *replayState) {
+	state.events = nil
+	state.bytes = 0
+	state.disabled = true
+}
+
+func replayDeltaKind(event Event) int {
+	if event.Image != nil || event.File != nil || event.ToolUse != nil || len(event.References) > 0 || event.Step != nil || event.Store != nil || event.Err != nil {
+		return 0
 	}
-	return len(encoded)
+	if event.Text != "" && event.Reasoning == "" {
+		return 1
+	}
+	if event.Reasoning != "" && event.Text == "" {
+		return 2
+	}
+	return 0
+}
+
+func replayEventSize(event Event) int {
+	size := 64 + len(event.Text) + len(event.Reasoning)
+	if event.Image != nil {
+		size += len(event.Image.Data) + len(event.Image.MimeType)
+	}
+	if event.File != nil {
+		size += len(event.File.Path) + len(event.File.Name)
+	}
+	if event.ToolUse != nil {
+		size += len(event.ToolUse.ID) + len(event.ToolUse.Tool) + len(event.ToolUse.Status) + len(event.ToolUse.Input) + len(event.ToolUse.Detail) + len(event.ToolUse.Content)
+		if arguments, err := json.Marshal(event.ToolUse.Arguments); err == nil {
+			size += len(arguments)
+		} else {
+			return replayMaxBytes + 1
+		}
+		size += replayReferencesSize(event.ToolUse.References)
+	}
+	size += replayReferencesSize(event.References)
+	if event.Err != nil {
+		size += len(event.Err.Error())
+	}
+	return size
+}
+
+func replayReferencesSize(references []renderrefs.Reference) int {
+	size := 0
+	for _, reference := range references {
+		size += 64 + len(reference.Type) + len(reference.ID) + len(reference.Intent) + len(reference.AgentID)
+		if reference.Preview != nil {
+			size += len(reference.Preview.Title) + len(reference.Preview.Status)
+		}
+	}
+	return size
 }

--- a/internal/agent/runtime/hub.go
+++ b/internal/agent/runtime/hub.go
@@ -47,9 +47,9 @@ const (
 	// from turning one active session into unbounded server memory.
 	replayMaxEvents = 4096
 	replayMaxBytes  = 8 << 20
-	// Bound string concatenation so retaining streamed deltas stays linear in
-	// output size; 2 KiB chunks can still fill the 8 MiB byte ceiling without
-	// hitting the event ceiling first.
+	// Bound string concatenation so retaining token-sized streamed deltas stays
+	// linear in output size and can approach the 8 MiB byte ceiling before the
+	// event ceiling. Provider-batched deltas may hit the event ceiling earlier.
 	replayDeltaMaxBytes = 2 << 10
 )
 

--- a/internal/agent/runtime/hub_perf_test.go
+++ b/internal/agent/runtime/hub_perf_test.go
@@ -1,0 +1,53 @@
+package runtime
+
+import "testing"
+
+func BenchmarkSessionHubReplayTextTurn(b *testing.B) {
+	for _, chunks := range []int{1500, 10000} {
+		b.Run(testName(chunks), func(b *testing.B) {
+			event := Event{Text: "0123456789"}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				hub := NewSessionHub()
+				hub.begin("session")
+				for range chunks {
+					hub.publish("session", event)
+				}
+				hub.end("session")
+			}
+			b.ReportMetric(float64(chunks), "events/turn")
+		})
+	}
+}
+
+func BenchmarkSessionHubReplayAndSubscriberTextTurn(b *testing.B) {
+	event := Event{Text: "0123456789"}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		hub := NewSessionHub()
+		hub.begin("session")
+		stream, cancel := hub.Subscribe("session")
+		done := make(chan struct{})
+		go func() {
+			for range stream {
+			}
+			close(done)
+		}()
+		for range 1500 {
+			hub.publish("session", event)
+		}
+		hub.end("session")
+		cancel()
+		<-done
+	}
+	b.ReportMetric(1500, "events/turn")
+}
+
+func testName(n int) string {
+	if n == 1500 {
+		return "1500Chunks"
+	}
+	return "10000Chunks"
+}

--- a/internal/agent/runtime/hub_perf_test.go
+++ b/internal/agent/runtime/hub_perf_test.go
@@ -1,10 +1,13 @@
 package runtime
 
-import "testing"
+import (
+	"strconv"
+	"testing"
+)
 
 func BenchmarkSessionHubReplayTextTurn(b *testing.B) {
 	for _, chunks := range []int{1500, 10000} {
-		b.Run(testName(chunks), func(b *testing.B) {
+		b.Run(strconv.Itoa(chunks)+"Chunks", func(b *testing.B) {
 			event := Event{Text: "0123456789"}
 			b.ReportAllocs()
 			b.ResetTimer()
@@ -43,11 +46,4 @@ func BenchmarkSessionHubReplayAndSubscriberTextTurn(b *testing.B) {
 		<-done
 	}
 	b.ReportMetric(1500, "events/turn")
-}
-
-func testName(n int) string {
-	if n == 1500 {
-		return "1500Chunks"
-	}
-	return "10000Chunks"
 }

--- a/internal/agent/runtime/hub_test.go
+++ b/internal/agent/runtime/hub_test.go
@@ -70,10 +70,18 @@ func TestSessionHubCoalescesTextBeforeEventCeiling(t *testing.T) {
 		h.publish("s1", Event{Text: "x"})
 	}
 
-	ch, cancel := h.Subscribe("s1")
-	defer cancel()
-	if event := <-ch; len(event.Text) != replayMaxEvents+1 {
-		t.Fatalf("coalesced replay length = %d, want %d", len(event.Text), replayMaxEvents+1)
+	h.mu.Lock()
+	events := append([]Event(nil), h.replay["s1"].events...)
+	h.mu.Unlock()
+	if len(events) != 3 {
+		t.Fatalf("coalesced replay events = %d, want 3 bounded chunks", len(events))
+	}
+	length := 0
+	for _, event := range events {
+		length += len(event.Text)
+	}
+	if length != replayMaxEvents+1 {
+		t.Fatalf("coalesced replay length = %d, want %d", length, replayMaxEvents+1)
 	}
 	h.end("s1")
 }

--- a/internal/agent/runtime/hub_test.go
+++ b/internal/agent/runtime/hub_test.go
@@ -63,6 +63,38 @@ func TestSessionHubReplayCeilingFailsClosed(t *testing.T) {
 	h.end("s1")
 }
 
+func TestSessionHubCoalescesTextBeforeEventCeiling(t *testing.T) {
+	h := NewSessionHub()
+	h.begin("s1")
+	for range replayMaxEvents + 1 {
+		h.publish("s1", Event{Text: "x"})
+	}
+
+	ch, cancel := h.Subscribe("s1")
+	defer cancel()
+	if event := <-ch; len(event.Text) != replayMaxEvents+1 {
+		t.Fatalf("coalesced replay length = %d, want %d", len(event.Text), replayMaxEvents+1)
+	}
+	h.end("s1")
+}
+
+func TestSessionHubEventCeilingFailsClosed(t *testing.T) {
+	h := NewSessionHub()
+	h.begin("s1")
+	for range replayMaxEvents + 1 {
+		h.publish("s1", Event{Step: &StepEvent{Kind: "start"}})
+	}
+
+	ch, cancel := h.Subscribe("s1")
+	defer cancel()
+	select {
+	case event := <-ch:
+		t.Fatalf("event-count overflow unexpectedly replayed: %#v", event)
+	default:
+	}
+	h.end("s1")
+}
+
 func TestSessionHubCancelUnsubscribes(t *testing.T) {
 	h := NewSessionHub()
 	ch, cancel := h.Subscribe("s1")

--- a/internal/agent/runtime/hub_test.go
+++ b/internal/agent/runtime/hub_test.go
@@ -78,6 +78,23 @@ func TestSessionHubCoalescesTextBeforeEventCeiling(t *testing.T) {
 	h.end("s1")
 }
 
+func TestSessionHubCoalescedByteAccountingChargesOneEntry(t *testing.T) {
+	h := NewSessionHub()
+	h.begin("s1")
+	for range 100 {
+		h.publish("s1", Event{Text: "x"})
+	}
+
+	h.mu.Lock()
+	state := h.replay["s1"]
+	got := state.bytes
+	h.mu.Unlock()
+	if want := 64 + 100; got != want {
+		t.Fatalf("coalesced replay bytes = %d, want %d", got, want)
+	}
+	h.end("s1")
+}
+
 func TestSessionHubEventCeilingFailsClosed(t *testing.T) {
 	h := NewSessionHub()
 	h.begin("s1")

--- a/internal/agent/runtime/hub_test.go
+++ b/internal/agent/runtime/hub_test.go
@@ -30,6 +30,39 @@ func TestSessionHubFanOutAndClose(t *testing.T) {
 	}
 }
 
+func TestSessionHubReplaysActiveTurnBeforeLiveEvents(t *testing.T) {
+	h := NewSessionHub()
+	h.begin("s1")
+	h.publish("s1", Event{Text: "before"})
+
+	ch, cancel := h.Subscribe("s1")
+	defer cancel()
+	h.publish("s1", Event{Text: "after"})
+
+	if event := <-ch; event.Text != "before" {
+		t.Fatalf("first event = %q, want replayed event", event.Text)
+	}
+	if event := <-ch; event.Text != "after" {
+		t.Fatalf("second event = %q, want live event", event.Text)
+	}
+	h.end("s1")
+}
+
+func TestSessionHubReplayCeilingFailsClosed(t *testing.T) {
+	h := NewSessionHub()
+	h.begin("s1")
+	h.publish("s1", Event{Text: string(make([]byte, replayMaxBytes+1))})
+
+	ch, cancel := h.Subscribe("s1")
+	defer cancel()
+	select {
+	case event := <-ch:
+		t.Fatalf("oversized replay unexpectedly delivered: %d bytes", len(event.Text))
+	default:
+	}
+	h.end("s1")
+}
+
 func TestSessionHubCancelUnsubscribes(t *testing.T) {
 	h := NewSessionHub()
 	ch, cancel := h.Subscribe("s1")

--- a/internal/agent/runtime/runtime.go
+++ b/internal/agent/runtime/runtime.go
@@ -286,8 +286,16 @@ func safeClose(ch chan Event) {
 // busy guard. A nil error means the turn is admitted; every later runtime failure
 // is delivered on the returned stream. ErrSessionBusy means no turn was started,
 // so the caller can decide before any run/session/tool side effect is visible.
+type activeTurn struct {
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
 func (rt *Runtime) ChatAdmitted(ctx context.Context, info session.Info, msg MessageContent, opts ...Option) (<-chan Event, error) {
-	if _, loaded := rt.active.LoadOrStore(info.ID, struct{}{}); loaded {
+	turnCtx, cancel := context.WithCancel(ctx)
+	turn := &activeTurn{cancel: cancel, done: make(chan struct{})}
+	if _, loaded := rt.active.LoadOrStore(info.ID, turn); loaded {
+		cancel()
 		return nil, fmt.Errorf("%w: session %s", ErrSessionBusy, info.ID)
 	}
 	out := make(chan Event, 100)
@@ -296,7 +304,7 @@ func (rt *Runtime) ChatAdmitted(ctx context.Context, info session.Info, msg Mess
 	for _, o := range opts {
 		o(&co)
 	}
-	ctx = memory.WithSessionID(ctx, info.ID)
+	ctx = memory.WithSessionID(turnCtx, info.ID)
 	// One identifier per turn. Tools that must know whether a second, real user
 	// message arrived since something happened compare turn ids; the runtime
 	// admits one turn per session at a time, so "different id" means "different
@@ -317,7 +325,6 @@ func (rt *Runtime) ChatAdmitted(ctx context.Context, info session.Info, msg Mess
 	rt.turns.begin()
 	go func() {
 		defer rt.turns.end()
-		defer rt.active.Delete(info.ID)
 		defer func() {
 			if p := recover(); p != nil {
 				// rt.chat panicked. Close inner so the forwarder drains and
@@ -333,6 +340,9 @@ func (rt *Runtime) ChatAdmitted(ctx context.Context, info session.Info, msg Mess
 	}()
 	go func() {
 		defer close(out)
+		defer close(turn.done)
+		defer cancel()
+		defer rt.active.CompareAndDelete(info.ID, turn)
 		defer rt.hub.end(info.ID)
 		for ev := range inner {
 			rt.hub.publish(info.ID, ev)
@@ -349,6 +359,34 @@ func (rt *Runtime) ChatAdmitted(ctx context.Context, info session.Info, msg Mess
 		}
 	}()
 	return out, nil
+}
+
+// StopSession cancels the active turn for sessionID. It returns false when the
+// session has no in-flight turn. Disconnecting an observer never calls this;
+// cancellation is an explicit, authorized action at the Session boundary.
+// stopWaitCeiling keeps a broken provider from pinning the stop HTTP request.
+// Cooperative providers finish immediately; increase only if a real backend
+// needs a longer cancellation unwind.
+const stopWaitCeiling = 5 * time.Second
+
+func (rt *Runtime) StopSession(ctx context.Context, sessionID string) bool {
+	value, ok := rt.active.Load(sessionID)
+	if !ok {
+		return false
+	}
+	turn, ok := value.(*activeTurn)
+	if !ok {
+		return false
+	}
+	turn.cancel()
+	timer := time.NewTimer(stopWaitCeiling)
+	defer timer.Stop()
+	select {
+	case <-turn.done:
+	case <-ctx.Done():
+	case <-timer.C:
+	}
+	return true
 }
 
 // Chat preserves the historic stream-only API. A rejected admission surfaces as

--- a/internal/agent/runtime/runtime.go
+++ b/internal/agent/runtime/runtime.go
@@ -361,14 +361,14 @@ func (rt *Runtime) ChatAdmitted(ctx context.Context, info session.Info, msg Mess
 	return out, nil
 }
 
-// StopSession cancels the active turn for sessionID. It returns false when the
-// session has no in-flight turn. Disconnecting an observer never calls this;
-// cancellation is an explicit, authorized action at the Session boundary.
 // stopWaitCeiling keeps a broken provider from pinning the stop HTTP request.
 // Cooperative providers finish immediately; increase only if a real backend
 // needs a longer cancellation unwind.
 const stopWaitCeiling = 5 * time.Second
 
+// StopSession cancels the active turn for sessionID. It returns false when the
+// session has no in-flight turn. Disconnecting an observer never calls this;
+// cancellation is an explicit, authorized action at the Session boundary.
 func (rt *Runtime) StopSession(ctx context.Context, sessionID string) bool {
 	value, ok := rt.active.Load(sessionID)
 	if !ok {

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -172,6 +172,12 @@ func (s *Service) Chat(ctx context.Context, req ChatRequest) <-chan Event {
 	return stream
 }
 
+// StopSession cancels the active turn for sessionID. Authorization belongs to
+// the Session access boundary; this method only exposes the runtime operation.
+func (s *Service) StopSession(ctx context.Context, sessionID string) bool {
+	return s.Runtime.StopSession(ctx, sessionID)
+}
+
 // SubscribeSession registers a read-only listener for a session's live turn
 // events, regardless of who initiated the turn. Used by the SSE endpoint to let
 // the web UI watch scheduler/task/delegate turns in real time.

--- a/internal/agent/session/access/runtime.go
+++ b/internal/agent/session/access/runtime.go
@@ -62,6 +62,7 @@ func (m agentRuntimeManager) Default() RuntimeService {
 // agent runtime. It deliberately excludes session lookup and policy concerns.
 type RuntimeService interface {
 	Chat(context.Context, agent.ChatRequest) <-chan agent.Event
+	StopSession(context.Context, string) bool
 	SubscribeSession(sessionID string) (<-chan agent.Event, func())
 	SessionLive(sessionID string) bool
 	CompactAuthorizedSession(context.Context, agentsession.Info) (string, error)
@@ -96,7 +97,7 @@ type SendResult struct {
 // Send authorizes and starts exactly one foreground turn. The returned event
 // chunks are not re-authorized by Session access; the single Access evaluation
 // covers the turn initiation, matching the send semantics expected by the UI.
-func (s *Service) Send(ctx context.Context, in SendInput) (SendResult, error) {
+func (s *Service) Send(ctx, runCtx context.Context, in SendInput) (SendResult, error) {
 	access, err := s.Begin(ctx, in.Authority)
 	if err != nil {
 		return SendResult{}, err
@@ -121,7 +122,10 @@ func (s *Service) Send(ctx context.Context, in SendInput) (SendResult, error) {
 	if info.Archived {
 		return SendResult{}, fmt.Errorf("%w: %s", agentsession.ErrArchived, in.SessionID)
 	}
-	ch := runtime.Chat(ctx, agent.ChatRequest{
+	// Authorization and input resolution use the request context above. The
+	// admitted turn uses the server lifecycle context so losing the initiating
+	// HTTP/SSE connection only detaches that observer; it does not kill work.
+	ch := runtime.Chat(runCtx, agent.ChatRequest{
 		SessionID: in.SessionID,
 		UserID:    info.UserID,
 		AgentID:   info.AgentID,
@@ -130,7 +134,55 @@ func (s *Service) Send(ctx context.Context, in SendInput) (SendResult, error) {
 		Message:   in.Message,
 		Authority: in.Authority,
 	})
-	return SendResult{Events: ch}, nil
+	return SendResult{Events: relayEventsUntilDone(ctx, ch)}, nil
+}
+
+// relayEventsUntilDone keeps draining the runtime's initiating stream after the
+// HTTP observer disconnects. The runtime publishes to attach subscribers before
+// writing this stream, but leaving it unread would eventually fill its bounded
+// buffer and stall the producer.
+func relayEventsUntilDone(observerCtx context.Context, source <-chan agent.Event) <-chan agent.Event {
+	out := make(chan agent.Event, 100)
+	go func() {
+		defer close(out)
+		forward := true
+		for event := range source {
+			if !forward {
+				continue
+			}
+			select {
+			case out <- event:
+			case <-observerCtx.Done():
+				forward = false
+			}
+		}
+	}()
+	return out
+}
+
+type StopInput struct {
+	Authority authz.Authority
+	AgentID   string
+	SessionID string
+}
+
+// Stop authorizes use of a session and explicitly cancels its active turn. It
+// is idempotent: stopping an idle session succeeds without inventing state.
+func (s *Service) Stop(ctx context.Context, in StopInput) error {
+	access, err := s.Begin(ctx, in.Authority)
+	if err != nil {
+		return err
+	}
+	info, err := access.Use(ctx, in.AgentID, in.SessionID)
+	if err != nil {
+		return err
+	}
+	runtime, err := s.runtimeFor(info.AgentID)
+	if err != nil {
+		return err
+	}
+	runtime.StopSession(ctx, in.SessionID)
+	return nil
 }
 
 type AttachInput struct {

--- a/internal/agent/session/access/runtime.go
+++ b/internal/agent/session/access/runtime.go
@@ -154,6 +154,11 @@ func relayEventsUntilDone(observerCtx context.Context, source <-chan agent.Event
 			case out <- event:
 			case <-observerCtx.Done():
 				forward = false
+			default:
+				// A connection can remain open while its peer stops reading. Detach
+				// this observer rather than letting two full buffers stall the turn;
+				// reconnect and persisted history are the recovery paths.
+				forward = false
 			}
 		}
 	}()

--- a/internal/agent/session/access/runtime.go
+++ b/internal/agent/session/access/runtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/CherryHQ/stella/internal/agent"
 	agentsession "github.com/CherryHQ/stella/internal/agent/session"
@@ -137,6 +138,10 @@ func (s *Service) Send(ctx, runCtx context.Context, in SendInput) (SendResult, e
 	return SendResult{Events: relayEventsUntilDone(ctx, ch)}, nil
 }
 
+// observerStallCeiling separates transient HTTP backpressure from a peer that
+// has stopped reading without closing its connection.
+const observerStallCeiling = 30 * time.Second
+
 // relayEventsUntilDone keeps draining the runtime's initiating stream after the
 // HTTP observer disconnects. The runtime publishes to attach subscribers before
 // writing this stream, but leaving it unread would eventually fill its bounded
@@ -145,19 +150,28 @@ func relayEventsUntilDone(observerCtx context.Context, source <-chan agent.Event
 	out := make(chan agent.Event, 100)
 	go func() {
 		defer close(out)
+		stall := time.NewTimer(observerStallCeiling)
+		defer stall.Stop()
 		forward := true
 		for event := range source {
 			if !forward {
 				continue
 			}
+			if !stall.Stop() {
+				select {
+				case <-stall.C:
+				default:
+				}
+			}
+			stall.Reset(observerStallCeiling)
 			select {
 			case out <- event:
 			case <-observerCtx.Done():
 				forward = false
-			default:
+			case <-stall.C:
 				// A connection can remain open while its peer stops reading. Detach
-				// this observer rather than letting two full buffers stall the turn;
-				// reconnect and persisted history are the recovery paths.
+				// only after sustained backpressure; reconnect and persisted history
+				// are the recovery paths.
 				forward = false
 			}
 		}

--- a/internal/agent/session/access/runtime_perf_test.go
+++ b/internal/agent/session/access/runtime_perf_test.go
@@ -1,0 +1,42 @@
+package access
+
+import (
+	"context"
+	"testing"
+
+	"github.com/CherryHQ/stella/internal/agent"
+)
+
+func BenchmarkEventDelivery1500Chunks(b *testing.B) {
+	b.Run("Direct", func(b *testing.B) {
+		benchmarkEventDelivery(b, func(_ context.Context, source <-chan agent.Event) <-chan agent.Event {
+			return source
+		})
+	})
+	b.Run("RelayWithStallTimer", func(b *testing.B) {
+		benchmarkEventDelivery(b, relayEventsUntilDone)
+	})
+}
+
+func benchmarkEventDelivery(b *testing.B, wrap func(context.Context, <-chan agent.Event) <-chan agent.Event) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		source := make(chan agent.Event, 100)
+		output := wrap(context.Background(), source)
+		go func() {
+			for range 1500 {
+				source <- agent.Event{Text: "0123456789"}
+			}
+			close(source)
+		}()
+		count := 0
+		for range output {
+			count++
+		}
+		if count != 1500 {
+			b.Fatalf("events = %d, want 1500", count)
+		}
+	}
+	b.ReportMetric(1500, "events/turn")
+}

--- a/internal/agent/session/access/runtime_test.go
+++ b/internal/agent/session/access/runtime_test.go
@@ -128,14 +128,21 @@ func TestRelayDrainsRuntimeAfterObserverDisconnect(t *testing.T) {
 func TestRelayPreservesTransientBackpressure(t *testing.T) {
 	source := make(chan agent.Event)
 	output := relayEventsUntilDone(t.Context(), source)
+	bufferFilled := make(chan struct{})
 
 	go func() {
 		for i := range 150 {
 			source <- agent.Event{Text: fmt.Sprintf("%d", i)}
+			if i == cap(output) {
+				// The relay has received the first event beyond its output capacity
+				// and must now be applying backpressure until the reader starts.
+				close(bufferFilled)
+			}
 		}
 		close(source)
 	}()
 
+	<-bufferFilled
 	var got []string
 	for event := range output {
 		got = append(got, event.Text)

--- a/internal/agent/session/access/runtime_test.go
+++ b/internal/agent/session/access/runtime_test.go
@@ -3,6 +3,7 @@ package access
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -121,6 +122,26 @@ func TestRelayDrainsRuntimeAfterObserverDisconnect(t *testing.T) {
 		t.Fatal("runtime source stalled after observer disconnect")
 	}
 	for range output {
+	}
+}
+
+func TestRelayPreservesTransientBackpressure(t *testing.T) {
+	source := make(chan agent.Event)
+	output := relayEventsUntilDone(t.Context(), source)
+
+	go func() {
+		for i := range 150 {
+			source <- agent.Event{Text: fmt.Sprintf("%d", i)}
+		}
+		close(source)
+	}()
+
+	var got []string
+	for event := range output {
+		got = append(got, event.Text)
+	}
+	if len(got) != 150 || got[149] != "149" {
+		t.Fatalf("relayed events = %d (tail %q), want all 150", len(got), got[len(got)-1])
 	}
 }
 

--- a/internal/agent/session/access/runtime_test.go
+++ b/internal/agent/session/access/runtime_test.go
@@ -32,18 +32,26 @@ func (m fakeRuntimeManager) Default() RuntimeService          { return m.svc }
 
 type fakeRuntimeService struct {
 	chatCalls      int
+	stopCalls      int
 	subscribeCalls int
 	live           bool
 	events         chan agent.Event
+	chatCtx        context.Context
 }
 
-func (s *fakeRuntimeService) Chat(context.Context, agent.ChatRequest) <-chan agent.Event {
+func (s *fakeRuntimeService) Chat(ctx context.Context, _ agent.ChatRequest) <-chan agent.Event {
 	s.chatCalls++
+	s.chatCtx = ctx
 	ch := make(chan agent.Event, 2)
 	ch <- agent.Event{Text: "hello"}
 	ch <- agent.Event{Text: " world"}
 	close(ch)
 	return ch
+}
+
+func (s *fakeRuntimeService) StopSession(context.Context, string) bool {
+	s.stopCalls++
+	return s.live
 }
 
 func (s *fakeRuntimeService) SubscribeSession(string) (<-chan agent.Event, func()) {
@@ -62,7 +70,7 @@ func TestMain(m *testing.M) { dbtest.Main(m) }
 
 func TestSendStartsOneTurnAndChunksDoNotReevaluate(t *testing.T) {
 	svc, rt, _, authority := newRuntimeTestService(t)
-	result, err := svc.Send(context.Background(), SendInput{Authority: authority, AgentID: "a1", SessionID: "s1", Message: "hello"})
+	result, err := svc.Send(context.Background(), context.Background(), SendInput{Authority: authority, AgentID: "a1", SessionID: "s1", Message: "hello"})
 	if err != nil {
 		t.Fatalf("Send: %v", err)
 	}
@@ -70,6 +78,62 @@ func TestSendStartsOneTurnAndChunksDoNotReevaluate(t *testing.T) {
 	}
 	if rt.chatCalls != 1 || rt.subscribeCalls != 0 {
 		t.Fatalf("chat=%d subscribe=%d, want one chat and no subscribe", rt.chatCalls, rt.subscribeCalls)
+	}
+}
+
+func TestSendUsesLifecycleContextNotObserverContext(t *testing.T) {
+	svc, rt, _, authority := newRuntimeTestService(t)
+	observerCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	runCtx := t.Context()
+	result, err := svc.Send(observerCtx, runCtx, SendInput{
+		Authority: authority, AgentID: "a1", SessionID: "s1", Message: "hello",
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	cancel()
+	for range result.Events {
+	}
+	if rt.chatCtx != runCtx {
+		t.Fatal("runtime did not receive the independent lifecycle context")
+	}
+}
+
+func TestRelayDrainsRuntimeAfterObserverDisconnect(t *testing.T) {
+	observerCtx, cancel := context.WithCancel(context.Background())
+	source := make(chan agent.Event)
+	output := relayEventsUntilDone(observerCtx, source)
+	cancel()
+
+	drained := make(chan struct{})
+	go func() {
+		defer close(drained)
+		for range 200 {
+			source <- agent.Event{Text: "chunk"}
+		}
+		close(source)
+	}()
+
+	select {
+	case <-drained:
+	case <-time.After(time.Second):
+		t.Fatal("runtime source stalled after observer disconnect")
+	}
+	for range output {
+	}
+}
+
+func TestStopAuthorizesAndCancelsActiveTurn(t *testing.T) {
+	svc, rt, _, authority := newRuntimeTestService(t)
+	rt.live = true
+	if err := svc.Stop(context.Background(), StopInput{
+		Authority: authority, AgentID: "a1", SessionID: "s1",
+	}); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if rt.stopCalls != 1 {
+		t.Fatalf("stop calls = %d, want 1", rt.stopCalls)
 	}
 }
 
@@ -142,7 +206,7 @@ func TestSendRejectsArchivedSessionDistinguishably(t *testing.T) {
 		t.Fatalf("SaveInfo: %v", err)
 	}
 
-	_, err = svc.Send(ctx, SendInput{Authority: authority, AgentID: "a1", SessionID: "s1", Message: "hello"})
+	_, err = svc.Send(ctx, ctx, SendInput{Authority: authority, AgentID: "a1", SessionID: "s1", Message: "hello"})
 	if !errors.Is(err, agentsession.ErrArchived) {
 		t.Fatalf("Send = %v, want ErrArchived", err)
 	}

--- a/internal/server/sessions.go
+++ b/internal/server/sessions.go
@@ -164,10 +164,12 @@ func (s *Server) SendSessionMessage(w http.ResponseWriter, r *http.Request, agen
 		streamPlainReply(w, flusher, result.PlainReply)
 		return
 	}
-	// The response follows the request context, but the admitted turn follows the
-	// server lifecycle context. Navigation or connection loss ends this observer
-	// only; graceful shutdown still owns cancellation of the underlying work.
-	streamAgentEvents(r.Context(), w, flusher, agentID, sessionID, result.Events, nil)
+	// The response follows the request and drain contexts, but the admitted turn
+	// follows the server work lifecycle. Navigation, connection loss, or graceful
+	// HTTP drain ends this observer only; accepted-work drain owns the turn.
+	sctx, cancel := s.readiness.streamContext(r.Context())
+	defer cancel()
+	streamAgentEvents(sctx, w, flusher, agentID, sessionID, result.Events, nil)
 }
 
 // StopSession explicitly cancels an in-flight turn. Transport disconnects never

--- a/internal/server/sessions.go
+++ b/internal/server/sessions.go
@@ -83,6 +83,32 @@ const (
 	maxSessionMessageParts = 32
 )
 
+// lifecycleValueContext takes cancellation and deadlines from the server
+// lifecycle while preserving request-scoped values for tracing and downstream
+// hooks. A browser disconnect therefore detaches transport without orphaning
+// the turn from process shutdown.
+type lifecycleValueContext struct {
+	context.Context
+	values context.Context
+}
+
+func (c lifecycleValueContext) Value(key any) any {
+	if value := c.values.Value(key); value != nil {
+		return value
+	}
+	return c.Context.Value(key)
+}
+
+func (s *Server) turnContext(requestCtx context.Context) context.Context {
+	lifecycle := s.runtimeCtx
+	if lifecycle == nil {
+		// Production always injects runtimeCtx. The fallback keeps directly-built
+		// handler tests safe without coupling a turn to their request recorder.
+		lifecycle = context.Background()
+	}
+	return lifecycleValueContext{Context: lifecycle, values: context.WithoutCancel(requestCtx)}
+}
+
 func (s *Server) SendSessionMessage(w http.ResponseWriter, r *http.Request, agentID string, sessionID string) {
 	if sessionID == "" {
 		writeError(w, http.StatusBadRequest, "missing session ID")
@@ -122,7 +148,7 @@ func (s *Server) SendSessionMessage(w http.ResponseWriter, r *http.Request, agen
 		return
 	}
 
-	result, err := s.sessionAccess.Send(r.Context(), sessionaccess.SendInput{Authority: authority, AgentID: agentID, SessionID: sessionID, Message: message})
+	result, err := s.sessionAccess.Send(r.Context(), s.turnContext(r.Context()), sessionaccess.SendInput{Authority: authority, AgentID: agentID, SessionID: sessionID, Message: message})
 	if err != nil {
 		// An archived session is a state conflict, not a missing one: the client
 		// holds a session that was rotated away and needs to move to the new one
@@ -138,11 +164,32 @@ func (s *Server) SendSessionMessage(w http.ResponseWriter, r *http.Request, agen
 		streamPlainReply(w, flusher, result.PlainReply)
 		return
 	}
-	// Deliberately NOT drain-cancelled: the turn above runs on the request
-	// context, so ending this stream at drain start would kill the in-flight
-	// turn — the exact work the graceful HTTP shutdown budget exists to finish.
-	// The stream ends when the turn completes; force-close is the backstop.
+	// The response follows the request context, but the admitted turn follows the
+	// server lifecycle context. Navigation or connection loss ends this observer
+	// only; graceful shutdown still owns cancellation of the underlying work.
 	streamAgentEvents(r.Context(), w, flusher, agentID, sessionID, result.Events, nil)
+}
+
+// StopSession explicitly cancels an in-flight turn. Transport disconnects never
+// call this endpoint; they only detach an SSE observer.
+func (s *Server) StopSession(w http.ResponseWriter, r *http.Request, agentID string, sessionID string) {
+	if sessionID == "" {
+		writeError(w, http.StatusBadRequest, "missing session ID")
+		return
+	}
+	authority, ok := s.sessionAuthority(w, r)
+	if !ok {
+		return
+	}
+	if err := s.sessionAccess.Stop(r.Context(), sessionaccess.StopInput{
+		Authority: authority,
+		AgentID:   agentID,
+		SessionID: sessionID,
+	}); err != nil {
+		s.writeSessionAccessError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // streamAgentEvents encodes a live turn's events to w as a Vercel AI-SDK UI

--- a/internal/server/sessions_archived_send_test.go
+++ b/internal/server/sessions_archived_send_test.go
@@ -26,6 +26,8 @@ func (r *recordingRuntime) Chat(context.Context, agent.ChatRequest) <-chan agent
 	return ch
 }
 
+func (r *recordingRuntime) StopSession(context.Context, string) bool { return false }
+
 func (r *recordingRuntime) SubscribeSession(string) (<-chan agent.Event, func()) {
 	ch := make(chan agent.Event)
 	close(ch)

--- a/internal/server/sessions_archived_send_test.go
+++ b/internal/server/sessions_archived_send_test.go
@@ -128,4 +128,14 @@ func TestSendToArchivedSessionConflicts(t *testing.T) {
 	if n := rt.stops.Load(); n != 1 {
 		t.Fatalf("runtime stops = %d, want 1", n)
 	}
+
+	_, otherToken := createTestUserWithToken(t, env.authStore, env.oidcStore, "stop-other-user", "user")
+	rr = doRequestWithSession(t, env.srv, otherToken, http.MethodPost,
+		"/api/agents/"+agentID+"/sessions/live-send/stop", nil)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("cross-user POST stop = %d, want opaque %d (body: %s)", rr.Code, http.StatusNotFound, rr.Body.String())
+	}
+	if n := rt.stops.Load(); n != 1 {
+		t.Fatalf("denied stop reached runtime: stops = %d, want 1", n)
+	}
 }

--- a/internal/server/sessions_archived_send_test.go
+++ b/internal/server/sessions_archived_send_test.go
@@ -17,7 +17,10 @@ import (
 // recordingRuntime stands in for the agent pool and reports whether a turn was
 // ever started. Nothing else in this test can tell the difference between "the
 // send was rejected" and "the send ran and then failed".
-type recordingRuntime struct{ chats atomic.Int64 }
+type recordingRuntime struct {
+	chats atomic.Int64
+	stops atomic.Int64
+}
 
 func (r *recordingRuntime) Chat(context.Context, agent.ChatRequest) <-chan agent.Event {
 	r.chats.Add(1)
@@ -26,7 +29,10 @@ func (r *recordingRuntime) Chat(context.Context, agent.ChatRequest) <-chan agent
 	return ch
 }
 
-func (r *recordingRuntime) StopSession(context.Context, string) bool { return false }
+func (r *recordingRuntime) StopSession(context.Context, string) bool {
+	r.stops.Add(1)
+	return true
+}
 
 func (r *recordingRuntime) SubscribeSession(string) (<-chan agent.Event, func()) {
 	ch := make(chan agent.Event)
@@ -112,5 +118,14 @@ func TestSendToArchivedSessionConflicts(t *testing.T) {
 	}
 	if n := rt.chats.Load(); n != 1 {
 		t.Fatalf("runtime turns after a live send = %d, want 1", n)
+	}
+
+	rr = doRequest(t, env, http.MethodPost,
+		"/api/agents/"+agentID+"/sessions/live-send/stop", nil)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("POST stop live session = %d, want %d (body: %s)", rr.Code, http.StatusNoContent, rr.Body.String())
+	}
+	if n := rt.stops.Load(); n != 1 {
+		t.Fatalf("runtime stops = %d, want 1", n)
 	}
 }

--- a/internal/server/stream_guard_test.go
+++ b/internal/server/stream_guard_test.go
@@ -72,6 +72,7 @@ func (m stubRuntimeManager) Default() sessionaccess.RuntimeService          { re
 type stubRuntimeService struct{ events chan agent.Event }
 
 func (s *stubRuntimeService) Chat(context.Context, agent.ChatRequest) <-chan agent.Event { return nil }
+func (s *stubRuntimeService) StopSession(context.Context, string) bool                   { return false }
 func (s *stubRuntimeService) SubscribeSession(string) (<-chan agent.Event, func()) {
 	return s.events, func() {}
 }

--- a/test/system/chat_resume_test.go
+++ b/test/system/chat_resume_test.go
@@ -1,0 +1,140 @@
+//go:build system
+
+package system
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// testChatDisconnectResume proves the cross-request seam the Web UI relies on:
+// closing the initiating SSE connection does not cancel the turn, and a fresh
+// events subscription replays the first half before streaming the remainder.
+func (h *harness) testChatDisconnectResume(t *testing.T) {
+	fake := newFakeAnthropic(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	first := "before disconnect " + h.runID
+	second := " after reconnect " + h.runID
+	gate := fake.enqueueGatedText(first, second)
+	providerID := h.createFakeProviderNamed(t, ctx, fake.baseURL(), "anthropic-resume-"+h.runID)
+	agentID := h.createAgentNamed(t, ctx, providerID+"/claude-sonnet-4-6", "sys-test-resume-agent-"+h.runID)
+	sessionID := h.createSession(t, ctx, agentID)
+	userText := "resume me " + h.runID
+
+	sendCtx, disconnect := context.WithCancel(ctx)
+	resp := h.openChatStream(t, sendCtx, agentID, sessionID, userText)
+	scanner := newSSEScanner(resp)
+	for {
+		event, done := scanTurnEvent(t, scanner)
+		if done {
+			t.Fatal("initiating stream finished before the gated first delta")
+		}
+		if event.Type == "text-delta" && event.Delta != "" {
+			if event.Delta != first {
+				t.Fatalf("first delta = %q, want %q", event.Delta, first)
+			}
+			break
+		}
+	}
+	disconnect()
+	_ = resp.Body.Close()
+
+	eventsPath := fmt.Sprintf("/api/agents/%s/sessions/%s/events", agentID, sessionID)
+	eventsReq, err := http.NewRequestWithContext(ctx, http.MethodGet, h.baseURL+eventsPath, nil)
+	if err != nil {
+		t.Fatalf("build resume request: %v", err)
+	}
+	eventsReq.Header.Set("Accept", "text/event-stream")
+	resumed, err := h.client.Do(eventsReq)
+	if err != nil {
+		t.Fatalf("GET resume stream: %v\n%s", err, h.proc.logTail(40))
+	}
+	defer func() { _ = resumed.Body.Close() }()
+	if resumed.StatusCode != http.StatusOK {
+		t.Fatalf("GET resume stream = %d, want 200\n%s", resumed.StatusCode, h.proc.logTail(40))
+	}
+
+	close(gate.release)
+	var replayed strings.Builder
+	resumedScanner := newSSEScanner(resumed)
+	for {
+		event, done := scanTurnEvent(t, resumedScanner)
+		if event.Type == "error" {
+			t.Fatalf("resumed stream error: %s\n%s", event.ErrorText, h.proc.logTail(40))
+		}
+		if event.Type == "text-delta" {
+			replayed.WriteString(event.Delta)
+		}
+		if done {
+			break
+		}
+	}
+	if got, want := replayed.String(), first+second; got != want {
+		t.Fatalf("resumed assistant text = %q, want %q", got, want)
+	}
+
+	h.assertChatRowsPersisted(t, ctx, sessionID, agentID, userText, first+second)
+}
+
+func (h *harness) openChatStream(t *testing.T, ctx context.Context, agentID, sessionID, text string) *http.Response {
+	t.Helper()
+	payload, err := json.Marshal(map[string]any{
+		"parts": []map[string]any{{"type": "text", "text": text}},
+	})
+	if err != nil {
+		t.Fatalf("marshal send body: %v", err)
+	}
+	path := fmt.Sprintf("/api/agents/%s/sessions/%s/messages", agentID, sessionID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, h.baseURL+path, strings.NewReader(string(payload)))
+	if err != nil {
+		t.Fatalf("build send request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream")
+	resp, err := h.client.Do(req)
+	if err != nil {
+		t.Fatalf("POST send message: %v\n%s", err, h.proc.logTail(40))
+	}
+	if resp.StatusCode != http.StatusOK {
+		_ = resp.Body.Close()
+		t.Fatalf("send message = %d, want 200\n%s", resp.StatusCode, h.proc.logTail(40))
+	}
+	return resp
+}
+
+func newSSEScanner(resp *http.Response) *bufio.Scanner {
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	return scanner
+}
+
+func scanTurnEvent(t *testing.T, scanner *bufio.Scanner) (turnEvent, bool) {
+	t.Helper()
+	for scanner.Scan() {
+		data, ok := strings.CutPrefix(scanner.Text(), "data: ")
+		if !ok {
+			continue
+		}
+		if data == "[DONE]" {
+			return turnEvent{}, true
+		}
+		var event turnEvent
+		if err := json.Unmarshal([]byte(data), &event); err != nil {
+			t.Fatalf("invalid SSE frame %q: %v", data, err)
+		}
+		return event, false
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan SSE stream: %v", err)
+	}
+	t.Fatal("SSE stream ended without [DONE]")
+	return turnEvent{}, true
+}

--- a/test/system/chat_test.go
+++ b/test/system/chat_test.go
@@ -111,8 +111,13 @@ func (h *harness) createFakeProviderNamedWithKey(t *testing.T, ctx context.Conte
 // rather than assumed).
 func (h *harness) createAgent(t *testing.T, ctx context.Context, model string) string {
 	t.Helper()
+	return h.createAgentNamed(t, ctx, model, "sys-test-agent-"+h.runID)
+}
+
+func (h *harness) createAgentNamed(t *testing.T, ctx context.Context, model, name string) string {
+	t.Helper()
 	body := map[string]any{
-		"name":    "sys-test-agent-" + h.runID,
+		"name":    name,
 		"model":   model,
 		"enabled": true,
 	}

--- a/test/system/drain_test.go
+++ b/test/system/drain_test.go
@@ -31,12 +31,11 @@ const drainFlipBudget = 15 * time.Second
 //   - an attach subscription is drain-cancelled: its read-only event stream ends
 //     promptly rather than blocking the shutdown budget;
 //
-//   - the pinned send turn completes across the drain: the send stream is
-//     deliberately not drain-cancelled (sessions.go), so once the gate releases
-//     the client must still receive the full text, finish, and [DONE] — the
-//     drain budget exists to finish exactly this work (#742);
+//   - the initiating send observer is drain-cancelled promptly while its
+//     server-owned turn remains accepted work;
 //
-//   - the process then exits 0.
+//   - once the gate releases, the detached turn completes and persists its full
+//     reply before the process exits 0.
 //
 // The gated turn both pins real work across SIGTERM and gives the attach
 // subscription something live to attach to (204 otherwise).
@@ -119,28 +118,23 @@ func (h *harness) testGracefulDrain(t *testing.T) {
 	}
 	t.Logf("graceful_drain: attach stream ended %s after SIGTERM", attachAt.Sub(sigAt))
 
-	// 6. Release the pinned turn so the fake's handler unblocks and the turn can
-	//    run to completion inside the drain budget.
-	gate.Release()
-
-	// 7. The send turn must complete cleanly across the drain: full scripted
-	//    text, a finish frame, and the [DONE] sentinel. A truncation here means
-	//    process teardown raced the drain's active-connection wait again (#742).
+	// 6. The initiating send observer is drain-cancelled too. It receives a clean
+	//    SSE epilogue for the first half, but not the still-gated second half.
 	var completion turnCompletion
 	select {
 	case completion = <-sendResult:
 	case <-time.After(drainFlipBudget):
-		t.Fatalf("send turn did not report within %s of release; the drained turn never finished\n%s", drainFlipBudget, h.proc.logTail(40))
+		t.Fatalf("send observer did not end within %s of SIGTERM\n%s", drainFlipBudget, h.proc.logTail(40))
 	}
-	if completion.err != nil {
-		t.Fatalf("send stream truncated during drain (#742 regression): %v\n%s", completion.err, h.proc.logTail(40))
+	if completion.err != nil || completion.text != part1 || !completion.sawFinish || !completion.sawDone {
+		t.Fatalf("send observer did not detach cleanly: err=%v text=%q want=%q finish=%t done=%t frames=%v\n%s",
+			completion.err, completion.text, part1, completion.sawFinish, completion.sawDone, completion.types, h.proc.logTail(40))
 	}
+
+	// 7. Release the pinned turn. HTTP has already drained, so accepted-work drain
+	//    must now wait for the detached producer to persist the complete reply.
+	gate.Release()
 	want := part1 + part2
-	if completion.text != want || !completion.sawFinish || !completion.sawDone {
-		t.Fatalf("send turn ended without a clean epilogue across drain (#742 regression): text=%q want=%q finish=%t done=%t frames=%v\n%s",
-			completion.text, want, completion.sawFinish, completion.sawDone, completion.types, h.proc.logTail(40))
-	}
-	t.Logf("graceful_drain: send turn completed cleanly across drain (%d frames, full text, finish, [DONE])", len(completion.types))
 
 	// 8. The process must exit 0 once the drain completes. This is the reliable
 	//    proof the graceful shutdown finished. The cleanup stop() then takes its
@@ -154,6 +148,7 @@ func (h *harness) testGracefulDrain(t *testing.T) {
 		t.Fatalf("server did not exit within %s of the drained turn completing\n%s", gracefulTimeout, h.proc.logTail(40))
 	}
 	t.Logf("graceful_drain: server exited 0 %s after SIGTERM", time.Since(sigAt))
+	h.assertChatRowsPersisted(t, ctx, sessionID, agentID, "ping "+h.runID, want)
 }
 
 // createDrainProvider registers the run-scoped Anthropic provider for the drain

--- a/test/system/system_test.go
+++ b/test/system/system_test.go
@@ -20,6 +20,7 @@ func TestSystem(t *testing.T) {
 	t.Run("pwa_assets_anonymous", h.testPWAAssetsAnonymous)
 	t.Run("startup_and_auth", h.testStartupAndAuth)
 	t.Run("chat_sse", h.testChatSSE)
+	t.Run("chat_disconnect_resume", h.testChatDisconnectResume)
 	t.Run("agent_provider_credentials", h.testAgentProviderCredentials)
 	t.Run("image_history", h.testImageHistory)
 	t.Run("read_tool_image_history", h.testReadToolImageHistory)

--- a/web/content/docs/development/agent-architecture.md
+++ b/web/content/docs/development/agent-architecture.md
@@ -214,7 +214,7 @@ Runtime allows at most one active turn per session. It rejects a second same-ses
 Every admitted turn is owned by the server lifecycle, not by an HTTP connection. Runtime tees its events through a per-runtime `SessionHub` so a browser can navigate, refresh, or temporarily disconnect without stopping the agent:
 
 - `Runtime.Chat` publishes each event to the hub in addition to the caller's channel. Losing the initiating message stream detaches that observer while the turn continues.
-- Publishing never blocks the turn. The hub keeps up to 4,096 events or 8 MiB of process-local replay for a newly attached observer; after that ceiling, reconnects receive future events and reconcile from persisted history when the turn ends.
+- Publishing never blocks the turn. The hub coalesces adjacent text/reasoning deltas and keeps up to 4,096 replay entries or 8 MiB of process-local replay for a newly attached observer; after that ceiling, reconnects receive future events and reconcile from persisted history when the turn ends.
 - When the turn ends, the hub closes its subscriber channels. `POST /api/agents/{agentId}/sessions/{sessionId}/stop` is the separate, explicit cancellation path.
 
 `GET /api/agents/{agentId}/sessions/{sessionId}/events` subscribes a read-only SSE stream that reuses the same AI-SDK UI message encoding as the message-send endpoint, and returns `204` when no turn is in flight. The Web UI calls the AI-SDK `resumeStream()` for every session kind and reloads persisted history after the stream settles. Replay is intentionally process-local; surviving process replacement requires a durable turn event log.

--- a/web/content/docs/development/agent-architecture.md
+++ b/web/content/docs/development/agent-architecture.md
@@ -211,13 +211,13 @@ Runtime allows at most one active turn per session. It rejects a second same-ses
 
 ### Live event fan-out
 
-Server-driven turns (`scheduler`, `task`, `delegate`) carry no HTTP request of their own, so their events would otherwise be invisible to the web UI. Runtime tees every turn's events through a per-runtime `SessionHub`:
+Every admitted turn is owned by the server lifecycle, not by an HTTP connection. Runtime tees its events through a per-runtime `SessionHub` so a browser can navigate, refresh, or temporarily disconnect without stopping the agent:
 
-- `Runtime.Chat` publishes each event to the hub in addition to the caller's channel. The hub is fed even if the initiating caller disconnects, so a turn started by the scheduler still streams to a watching browser.
-- Publishing never blocks the turn: a slow subscriber drops events rather than stalling the agent. Subscribers reconcile final state by reloading persisted history, so dropped deltas are cosmetic.
-- When the turn ends, the hub closes its subscriber channels.
+- `Runtime.Chat` publishes each event to the hub in addition to the caller's channel. Losing the initiating message stream detaches that observer while the turn continues.
+- Publishing never blocks the turn. The hub keeps up to 4,096 events or 8 MiB of process-local replay for a newly attached observer; after that ceiling, reconnects receive future events and reconcile from persisted history when the turn ends.
+- When the turn ends, the hub closes its subscriber channels. `POST /api/agents/{agentId}/sessions/{sessionId}/stop` is the separate, explicit cancellation path.
 
-`GET /api/agents/{agentId}/sessions/{sessionId}/events` subscribes a read-only SSE stream that reuses the same AI-SDK UI message encoding as the message-send endpoint, and returns `204` when no turn is in flight. The web UI calls the AI-SDK `resumeStream()` against this endpoint for internal-kind sessions so the transcript renders live.
+`GET /api/agents/{agentId}/sessions/{sessionId}/events` subscribes a read-only SSE stream that reuses the same AI-SDK UI message encoding as the message-send endpoint, and returns `204` when no turn is in flight. The Web UI calls the AI-SDK `resumeStream()` for every session kind and reloads persisted history after the stream settles. Replay is intentionally process-local; surviving process replacement requires a durable turn event log.
 
 ## Caller flows
 

--- a/web/content/docs/development/agent-architecture.zh.md
+++ b/web/content/docs/development/agent-architecture.zh.md
@@ -214,7 +214,7 @@ Runtime 对每个 session 最多允许一个 active turn。第二个 same-sessio
 每个已受理的 turn 都归服务端生命周期所有，而不是归某条 HTTP 连接所有。Runtime 把事件经由每个 runtime 一份的 `SessionHub` tee 出去，因此浏览器切换页面、刷新或短暂断线都不会停止 agent：
 
 - `Runtime.Chat` 除了写给调用方的 channel，还把每个事件发布到 hub。发消息的初始 stream 断开时只移除该观察者，turn 继续运行。
-- 发布永不阻塞 turn。Hub 为新观察者保留最多 4,096 个事件或 8 MiB 的进程内 replay；超过上限后，重连只接收后续事件，并在 turn 结束后从持久化历史对齐最终状态。
+- 发布永不阻塞 turn。Hub 会合并相邻的 text/reasoning delta，并为新观察者保留最多 4,096 条 replay entry 或 8 MiB 的进程内 replay；超过上限后，重连只接收后续事件，并在 turn 结束后从持久化历史对齐最终状态。
 - turn 结束时，hub 关闭其订阅 channel。`POST /api/agents/{agentId}/sessions/{sessionId}/stop` 是独立、显式的取消路径。
 
 `GET /api/agents/{agentId}/sessions/{sessionId}/events` 订阅一个只读 SSE 流，复用与发消息端点相同的 AI-SDK UI message 编码；没有进行中的 turn 时返回 `204`。Web UI 对所有 session kind 调用 AI-SDK 的 `resumeStream()`，并在 stream 结束后重新加载持久化历史。Replay 刻意只保存在进程内；若要跨进程替换恢复，需要持久化 turn event log。

--- a/web/content/docs/development/agent-architecture.zh.md
+++ b/web/content/docs/development/agent-architecture.zh.md
@@ -211,13 +211,13 @@ Runtime 对每个 session 最多允许一个 active turn。第二个 same-sessio
 
 ### 实时事件扇出
 
-服务端驱动的 turn(`scheduler`、`task`、`delegate`)没有自己的 HTTP 请求,因此其事件对 Web UI 本来是不可见的。Runtime 把每个 turn 的事件经由每个 runtime 一份的 `SessionHub` tee 出去:
+每个已受理的 turn 都归服务端生命周期所有，而不是归某条 HTTP 连接所有。Runtime 把事件经由每个 runtime 一份的 `SessionHub` tee 出去，因此浏览器切换页面、刷新或短暂断线都不会停止 agent：
 
-- `Runtime.Chat` 除了写给调用方的 channel,还把每个事件发布到 hub。即使发起的调用方断开,hub 仍被持续喂入,所以由 scheduler 发起的 turn 照样能流式推给正在观看的浏览器。
-- 发布永不阻塞 turn:慢订阅者丢弃事件而非拖住 agent。订阅者通过重新加载已持久化的历史来对齐最终状态,因此丢掉的增量只是视觉上的。
-- turn 结束时,hub 关闭其订阅 channel。
+- `Runtime.Chat` 除了写给调用方的 channel，还把每个事件发布到 hub。发消息的初始 stream 断开时只移除该观察者，turn 继续运行。
+- 发布永不阻塞 turn。Hub 为新观察者保留最多 4,096 个事件或 8 MiB 的进程内 replay；超过上限后，重连只接收后续事件，并在 turn 结束后从持久化历史对齐最终状态。
+- turn 结束时，hub 关闭其订阅 channel。`POST /api/agents/{agentId}/sessions/{sessionId}/stop` 是独立、显式的取消路径。
 
-`GET /api/agents/{agentId}/sessions/{sessionId}/events` 订阅一个只读 SSE 流,复用与发消息端点相同的 AI-SDK UI message 编码;没有进行中的 turn 时返回 `204`。Web UI 对内部 kind 的 session 用 AI-SDK 的 `resumeStream()` 连到该端点,使 transcript 实时渲染。
+`GET /api/agents/{agentId}/sessions/{sessionId}/events` 订阅一个只读 SSE 流，复用与发消息端点相同的 AI-SDK UI message 编码；没有进行中的 turn 时返回 `204`。Web UI 对所有 session kind 调用 AI-SDK 的 `resumeStream()`，并在 stream 结束后重新加载持久化历史。Replay 刻意只保存在进程内；若要跨进程替换恢复，需要持久化 turn event log。
 
 ## Caller flows
 

--- a/web/content/docs/development/rules/system-test.md
+++ b/web/content/docs/development/rules/system-test.md
@@ -71,6 +71,9 @@ and one shared database serve them all in sequence:
   listener, and reports ready.
 - `startup_and_auth` — bootstrap registration and session-authenticated access.
 - `chat_sse` — one chat turn end to end, consumed as a live SSE stream.
+- `chat_disconnect_resume` — disconnect the initiating message stream mid-turn,
+  reconnect through the read-only events stream, replay the first half, and
+  finish without a second model request.
 - `agent_provider_credentials` — three Agents share one global fake Provider;
   two send distinct encrypted overrides, one sends the global key, and live
   rotation/delete changes the next request without changing Agent model state.

--- a/web/content/docs/development/rules/system-test.md
+++ b/web/content/docs/development/rules/system-test.md
@@ -92,9 +92,8 @@ and one shared database serve them all in sequence:
   is persisted, the server is force-killed before it is due, and a replacement
   process on the same database executes and retires that exact job once.
 - `graceful_drain` — SIGTERM with a turn pinned in flight: `/readyz` flips away
-  from ready, an attach subscription is drain-cancelled, the pinned turn still
-  completes on its stream (full text, finish, [DONE]), and the process exits 0.
-  Runs last, since it consumes the shared server.
+  from ready, attach and send observers detach promptly, the server-owned turn
+  persists its complete reply under accepted-work drain, and the process exits 0. Runs last, since it consumes the shared server.
 
 `startup_and_auth` also covers the personal-access-token bearer lifecycle: a
 session mints a PAT, the token alone authenticates an ordinary API route with

--- a/web/content/docs/development/rules/system-test.zh.md
+++ b/web/content/docs/development/rules/system-test.zh.md
@@ -61,6 +61,8 @@ Ubuntu runner，并调用 `mise run system-test`；若该 runner 将来变得不
 - `readiness` —— 子进程迁移了交给它的数据库、绑定了 TCP 监听、并报告 ready。
 - `startup_and_auth` —— bootstrap 注册与 session 认证后的访问。
 - `chat_sse` —— 一次端到端 chat 轮次，以实时 SSE 流的方式消费。
+- `chat_disconnect_resume` —— 在 turn 中途断开发消息的初始 stream，通过只读 events
+  stream 重连，回放前半段并继续完成，且不发起第二次模型请求。
 - `image_history` —— 上传图片通过 fake provider 完成 baseline 渲染和当前回答，随后持久化为
   canonical media 与该精确 baseline；下一次回答请求不含像素、只投影 baseline，并可通过鉴权
   历史接口逐字节加载原图。

--- a/web/content/docs/development/rules/system-test.zh.md
+++ b/web/content/docs/development/rules/system-test.zh.md
@@ -78,9 +78,9 @@ Ubuntu runner，并调用 `mise run system-test`；若该 runner 将来变得不
   发送，收到异步 `202`，并且其原始 payload 恰好一次、完整地抵达 fake model。
 - `scheduler_one_time_job_survives_forced_restart` —— 持久化一个未来触发的一次性 chat job，在到期前
   强杀服务器，再由连接同一数据库的替代进程恰好执行并退役该 job 一次。
-- `graceful_drain` —— 在一个轮次仍在途中时发送 SIGTERM：`/readyz` 从 ready 翻转，一个 attach
-  订阅被 drain 取消，被钉住的轮次仍在其流上完整收尾（全文、finish、[DONE]），进程以 0 退出。
-  它最后运行，因为会消费掉共享服务器。
+- `graceful_drain` —— 在一个轮次仍在途中时发送 SIGTERM：`/readyz` 从 ready 翻转，attach 与
+  send 观察者迅速断开，服务端持有的 turn 在 accepted-work drain 内持久化完整回复，进程以 0
+  退出。它最后运行，因为会消费掉共享服务器。
 
 `startup_and_auth` 还覆盖个人访问令牌（PAT）的 bearer 生命周期：一个 session 铸造出一个
 PAT，仅凭该令牌即可用其所有者当前的权限认证普通 API 路由，撤销后同一个 bearer 会 fail closed。

--- a/web/content/docs/start-here/deployment.md
+++ b/web/content/docs/start-here/deployment.md
@@ -291,7 +291,7 @@ Stella exposes two unauthenticated infrastructure endpoints for orchestrators:
 
 On the first `SIGTERM`/`SIGINT` the daemon runs a **two-phase graceful drain** rather than stopping immediately:
 
-1. `/readyz` flips to `503` and idle watch streams (SSE subscriptions) end, so load balancers stop routing new traffic. Streams carrying an in-flight turn keep running so the turn can finish.
+1. `/readyz` flips to `503` and SSE observers detach, so load balancers stop routing new traffic. In-flight turns continue as server-owned accepted work and persist before shutdown completes.
 2. In-flight HTTP requests drain within `STELLA_HTTP_SHUTDOWN_TIMEOUT`; anything still open when the budget is spent is force-closed.
 3. Background jobs (goal and scheduler agent runs) keep executing and drain within `STELLA_RIVER_SOFT_STOP_TIMEOUT`; jobs still running when that budget is spent are cancelled.
 

--- a/web/content/docs/start-here/deployment.zh.md
+++ b/web/content/docs/start-here/deployment.zh.md
@@ -280,7 +280,7 @@ Stella 暴露两个供编排器使用的免鉴权基础设施端点：
 
 收到第一个 `SIGTERM`/`SIGINT` 时，网关不会立即退出，而是执行**两阶段优雅排空**：
 
-1. `/readyz` 翻转为 `503`，空闲的订阅流（SSE watch）结束，使负载均衡器停止转发新流量；承载进行中 turn 的流会继续运行至 turn 完成。
+1. `/readyz` 翻转为 `503`，SSE 观察者断开，使负载均衡器停止转发新流量；进行中的 turn 作为服务端 accepted work 继续运行，并在关停完成前持久化。
 2. 在 `STELLA_HTTP_SHUTDOWN_TIMEOUT` 预算内排空进行中的 HTTP 请求；预算耗尽后仍未结束的连接被强制关闭。
 3. 后台任务（goal 与 scheduler 的 agent 运行）继续执行，并在 `STELLA_RIVER_SOFT_STOP_TIMEOUT` 预算内排空；预算耗尽时仍在运行的任务被取消。
 

--- a/web/src/features/sessions/SessionConversation.tsx
+++ b/web/src/features/sessions/SessionConversation.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useInfiniteQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import { useChat } from "@ai-sdk/react";
 import { getSessionMessages, stopSession } from "@/lib/api-client/sdk.gen";
 import {
@@ -45,6 +45,7 @@ export function SessionConversation({
   inline,
 }: Props) {
   const { t } = useI18n();
+  const queryClient = useQueryClient();
   const [userInput, setUserInput] = useState("");
   const [mobileOpen, setMobileOpen] = useState(false);
   const [resumeEnabled, setResumeEnabled] = useState(true);
@@ -52,6 +53,17 @@ export function SessionConversation({
   const transcriptRef = useRef<HTMLDivElement>(null);
   const initialScrollSessionRef = useRef<string | null>(null);
   const transport = useMemo(() => createSessionTransport(agentId, sessionId), [agentId, sessionId]);
+  const historyAuthoritativeRef = useRef(false);
+  const reconcilePersistedHistory = useCallback(() => {
+    historyAuthoritativeRef.current = true;
+    void queryClient.invalidateQueries({
+      queryKey: ["session-messages", agentId, sessionId],
+    });
+  }, [queryClient, agentId, sessionId]);
+  const completeReconnectCheck = useCallback(() => {
+    setRecoveringDisconnect(false);
+    reconcilePersistedHistory();
+  }, [reconcilePersistedHistory]);
 
   const {
     messages: chatMessages,
@@ -68,7 +80,10 @@ export function SessionConversation({
     // Batch SSE deltas: without this every token re-renders the transcript.
     experimental_throttle: 50,
     onError: (err) => console.error("[session conversation chat]", err),
-    onFinish: ({ isDisconnect }) => setRecoveringDisconnect(isDisconnect),
+    onFinish: ({ isAbort, isDisconnect, isError }) => {
+      setRecoveringDisconnect(isDisconnect);
+      if (!isAbort && !isDisconnect && !isError) reconcilePersistedHistory();
+    },
   });
 
   const isStreaming = chatStatus === "streaming" || chatStatus === "submitted";
@@ -93,9 +108,6 @@ export function SessionConversation({
       lastPage.length === 20 ? allPages.reduce((sum, page) => sum + page.length, 0) : undefined,
   });
 
-  const reconcilePersistedHistory = useCallback(() => {
-    void messagesQuery.refetch();
-  }, [messagesQuery.refetch]);
   useSessionStreamResume(
     sessionId,
     resumeEnabled,
@@ -103,19 +115,8 @@ export function SessionConversation({
     chatResume,
     recoveringDisconnect,
     chatClearError,
-    reconcilePersistedHistory,
+    completeReconnectCheck,
   );
-
-  const wasStreamingRef = useRef(false);
-  useEffect(() => {
-    if (isStreaming) {
-      wasStreamingRef.current = true;
-      return;
-    }
-    if (!wasStreamingRef.current) return;
-    wasStreamingRef.current = false;
-    reconcilePersistedHistory();
-  }, [isStreaming, reconcilePersistedHistory]);
 
   const historicalIDsRef = useRef(new Set<string>());
 
@@ -126,10 +127,13 @@ export function SessionConversation({
     const uiMessages = merged.map(messageToUIMessage);
     const newIDs = new Set(uiMessages.map((m) => m.id));
     historicalIDsRef.current = newIDs;
+    const authoritative = historyAuthoritativeRef.current;
+    historyAuthoritativeRef.current = false;
     setChatMessages((prev) =>
       reconcileHistoryUIMessages(
         uiMessages,
         prev.filter((message) => !newIDs.has(message.id)),
+        { authoritative },
       ),
     );
   }, [messagesQuery.data, setChatMessages]);

--- a/web/src/features/sessions/SessionConversation.tsx
+++ b/web/src/features/sessions/SessionConversation.tsx
@@ -87,6 +87,8 @@ export function SessionConversation({
   });
 
   const isStreaming = chatStatus === "streaming" || chatStatus === "submitted";
+  const isStreamingRef = useRef(isStreaming);
+  isStreamingRef.current = isStreaming;
 
   const messagesQuery = useInfiniteQuery({
     queryKey: ["session-messages", agentId, sessionId, after, before],
@@ -127,8 +129,8 @@ export function SessionConversation({
     const uiMessages = merged.map(messageToUIMessage);
     const newIDs = new Set(uiMessages.map((m) => m.id));
     historicalIDsRef.current = newIDs;
-    const authoritative = historyAuthoritativeRef.current;
-    historyAuthoritativeRef.current = false;
+    const authoritative = historyAuthoritativeRef.current && !isStreamingRef.current;
+    if (authoritative) historyAuthoritativeRef.current = false;
     setChatMessages((prev) =>
       reconcileHistoryUIMessages(
         uiMessages,

--- a/web/src/features/sessions/SessionConversation.tsx
+++ b/web/src/features/sessions/SessionConversation.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { useChat } from "@ai-sdk/react";
-import { getSessionMessages } from "@/lib/api-client/sdk.gen";
+import { getSessionMessages, stopSession } from "@/lib/api-client/sdk.gen";
 import {
   createSessionTransport,
   mergeToolResults,
@@ -21,6 +21,7 @@ import {
 import { Transcript } from "./Transcript";
 import { ChatErrorNotice } from "@/components/chat/ChatErrorNotice";
 import { useI18n } from "@/lib/i18n";
+import { useSessionStreamResume } from "./useSessionStreamResume";
 
 interface Props {
   agentId: string;
@@ -46,6 +47,8 @@ export function SessionConversation({
   const { t } = useI18n();
   const [userInput, setUserInput] = useState("");
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [resumeEnabled, setResumeEnabled] = useState(true);
+  const [recoveringDisconnect, setRecoveringDisconnect] = useState(false);
   const transcriptRef = useRef<HTMLDivElement>(null);
   const initialScrollSessionRef = useRef<string | null>(null);
   const transport = useMemo(() => createSessionTransport(agentId, sessionId), [agentId, sessionId]);
@@ -56,6 +59,8 @@ export function SessionConversation({
     setMessages: setChatMessages,
     status: chatStatus,
     stop: chatStop,
+    resumeStream: chatResume,
+    clearError: chatClearError,
     error: chatError,
   } = useChat({
     id: `conv-${sessionId}`,
@@ -63,6 +68,7 @@ export function SessionConversation({
     // Batch SSE deltas: without this every token re-renders the transcript.
     experimental_throttle: 50,
     onError: (err) => console.error("[session conversation chat]", err),
+    onFinish: ({ isDisconnect }) => setRecoveringDisconnect(isDisconnect),
   });
 
   const isStreaming = chatStatus === "streaming" || chatStatus === "submitted";
@@ -87,6 +93,30 @@ export function SessionConversation({
       lastPage.length === 20 ? allPages.reduce((sum, page) => sum + page.length, 0) : undefined,
   });
 
+  const reconcilePersistedHistory = useCallback(() => {
+    void messagesQuery.refetch();
+  }, [messagesQuery.refetch]);
+  useSessionStreamResume(
+    sessionId,
+    resumeEnabled,
+    chatStatus,
+    chatResume,
+    recoveringDisconnect,
+    chatClearError,
+    reconcilePersistedHistory,
+  );
+
+  const wasStreamingRef = useRef(false);
+  useEffect(() => {
+    if (isStreaming) {
+      wasStreamingRef.current = true;
+      return;
+    }
+    if (!wasStreamingRef.current) return;
+    wasStreamingRef.current = false;
+    reconcilePersistedHistory();
+  }, [isStreaming, reconcilePersistedHistory]);
+
   const historicalIDsRef = useRef(new Set<string>());
 
   useEffect(() => {
@@ -107,6 +137,8 @@ export function SessionConversation({
   const messages = useMemo(() => chatMessages.map(uiMessageToMessage), [chatMessages]);
 
   useEffect(() => {
+    setResumeEnabled(true);
+    setRecoveringDisconnect(false);
     initialScrollSessionRef.current = null;
     historicalIDsRef.current = new Set();
     setChatMessages([]);
@@ -137,6 +169,8 @@ export function SessionConversation({
     const content = userInput.trim();
     if (!content || isStreaming) return;
 
+    setResumeEnabled(true);
+    setRecoveringDisconnect(false);
     setUserInput("");
     setTimeout(() => {
       if (transcriptRef.current) {
@@ -146,6 +180,19 @@ export function SessionConversation({
 
     void chatSendMessage({ text: content });
   }, [userInput, isStreaming, chatSendMessage]);
+
+  const stopActiveTurn = useCallback(() => {
+    setResumeEnabled(false);
+    setRecoveringDisconnect(false);
+    void chatStop();
+    void stopSession({
+      path: { agentId, sessionId },
+      throwOnError: true,
+    }).catch((err) => {
+      console.error("[session conversation stop]", err);
+      setResumeEnabled(true);
+    });
+  }, [agentId, sessionId, chatStop]);
 
   const renderBody = () => (
     <div className="flex h-full min-h-0 flex-col">
@@ -173,12 +220,7 @@ export function SessionConversation({
           className="min-w-0 flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm outline-hidden focus:ring-2 focus:ring-ring"
         />
         {isStreaming ? (
-          <Button
-            size="sm"
-            variant="outline"
-            className="w-full sm:w-auto"
-            onClick={() => chatStop()}
-          >
+          <Button size="sm" variant="outline" className="w-full sm:w-auto" onClick={stopActiveTurn}>
             Stop
           </Button>
         ) : (

--- a/web/src/features/sessions/SessionDetail.tsx
+++ b/web/src/features/sessions/SessionDetail.tsx
@@ -5,7 +5,12 @@ import type { UIMessage } from "ai";
 import { Link } from "@tanstack/react-router";
 import { AlertCircle, Download, MessageSquarePlus, PanelRight } from "lucide-react";
 import { useI18n } from "@/lib/i18n";
-import { getSession, getSessionMessages, uploadWorkspaceFile } from "@/lib/api-client/sdk.gen";
+import {
+  getSession,
+  getSessionMessages,
+  stopSession,
+  uploadWorkspaceFile,
+} from "@/lib/api-client/sdk.gen";
 import { agentSkillsOptions, agentsQueryOptions } from "@/lib/queries/agents";
 import { inboxQueryOptions } from "@/lib/queries/inbox";
 import { sessionContextItemsOptions } from "@/lib/queries/session-context";
@@ -44,6 +49,7 @@ import { ChatWidthToggle } from "@/components/chat/ChatWidthToggle";
 import { SessionInfoPopover } from "./SessionInfoPopover";
 import { Transcript } from "./Transcript";
 import { useFileAttachments } from "./useFileAttachments";
+import { useSessionStreamResume } from "./useSessionStreamResume";
 
 const PAGE_SIZE = 50;
 // Auto-fill (below) pulls older pages until the transcript overflows; cap how
@@ -79,6 +85,8 @@ export function SessionDetail({
   const { showToast } = useToast();
   const [exporting, setExporting] = useState(false);
   const [exportMenuOpen, setExportMenuOpen] = useState(false);
+  const [resumeEnabled, setResumeEnabled] = useState(true);
+  const [recoveringDisconnect, setRecoveringDisconnect] = useState(false);
   const { data: agentsList = [] } = useQuery(agentsQueryOptions);
 
   const transcriptRef = useRef<HTMLDivElement>(null);
@@ -130,6 +138,7 @@ export function SessionDetail({
     status: chatStatus,
     stop: chatStop,
     resumeStream: chatResume,
+    clearError: chatClearError,
     error: chatError,
   } = useChat({
     id: session?.id ?? "empty",
@@ -137,9 +146,14 @@ export function SessionDetail({
     // Batch SSE deltas: without this every token re-renders the transcript.
     experimental_throttle: 50,
     onError: (err) => console.error("[session chat]", err),
+    onFinish: ({ isDisconnect }) => setRecoveringDisconnect(isDisconnect),
   });
 
   const isStreaming = chatStatus === "streaming" || chatStatus === "submitted";
+  const reconcilePersistedHistory = useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey: ["session-messages", sessionId] });
+    void queryClient.invalidateQueries({ queryKey: ["session-tail-messages", sessionId] });
+  }, [queryClient, sessionId]);
 
   // The server titles an untitled session from its first user message *during*
   // the turn (internal/agent/runtime/chat.go), so nothing on the client knows
@@ -168,43 +182,27 @@ export function SessionDetail({
         console.error("[session refresh]", err);
       }
       void queryClient.invalidateQueries({ queryKey: ["sessions", agentId] });
+      // Replay is bounded, so persisted history is the final authority after a
+      // sent or resumed stream settles.
+      reconcilePersistedHistory();
     })();
     return () => {
       cancelled = true;
     };
-  }, [isStreaming, agentId, sessionId, onSessionUpdate, queryClient]);
+  }, [isStreaming, agentId, sessionId, onSessionUpdate, queryClient, reconcilePersistedHistory]);
 
-  // Server-driven sessions (scheduler/task/delegate) run turns that carry no
-  // HTTP request of their own, so the normal send-stream never sees them. Poll
-  // the read-only events stream to watch such a turn live: resumeStream()
-  // attaches when one is in flight and no-ops (204) otherwise. Fire it only
-  // while idle so we never double-connect, and read status via a ref to keep
-  // the interval stable.
-  const isInternalKind =
-    session?.kind === "scheduler" || session?.kind === "task" || session?.kind === "delegate";
-  const chatStatusRef = useRef(chatStatus);
-  chatStatusRef.current = chatStatus;
-  // resumeStream() is async and status only flips to "streaming" once the SSE
-  // connection parses its first frame; guard with an in-flight ref so a tick
-  // firing inside that window can't open a second concurrent stream.
-  const resumingRef = useRef(false);
-  useEffect(() => {
-    if (!session || !isInternalKind) return;
-    let cancelled = false;
-    const tick = () => {
-      if (cancelled || resumingRef.current || chatStatusRef.current !== "ready") return;
-      resumingRef.current = true;
-      void chatResume().finally(() => {
-        resumingRef.current = false;
-      });
-    };
-    tick();
-    const timer = setInterval(tick, 3000);
-    return () => {
-      cancelled = true;
-      clearInterval(timer);
-    };
-  }, [session?.id, isInternalKind, chatResume]);
+  // Every turn is server-owned once admitted. An idle view polls the read-only
+  // events stream so navigation, refresh, connection loss, and turns started
+  // elsewhere all converge on the same reconnect path.
+  useSessionStreamResume(
+    sessionId,
+    resumeEnabled,
+    chatStatus,
+    chatResume,
+    recoveringDisconnect,
+    chatClearError,
+    reconcilePersistedHistory,
+  );
 
   const messagesQuery = useInfiniteQuery({
     queryKey: ["session-messages", session?.id],
@@ -308,6 +306,8 @@ export function SessionDetail({
   );
 
   useEffect(() => {
+    setResumeEnabled(true);
+    setRecoveringDisconnect(false);
     if (!session) {
       setChatMessages([]);
       clearAttachments();
@@ -427,6 +427,8 @@ export function SessionDetail({
       if (attachments.some((a) => a.uploading)) return;
 
       const parts = buildMessageParts(input);
+      setResumeEnabled(true);
+      setRecoveringDisconnect(false);
       clearAttachments();
       shouldAutoScrollRef.current = true;
       setTimeout(() => {
@@ -438,6 +440,22 @@ export function SessionDetail({
     },
     [isStreaming, session, attachments, buildMessageParts, clearAttachments, chatSendMessage],
   );
+
+  const stopActiveTurn = useCallback(() => {
+    if (!session) return;
+    // Block automatic reconnect until another message is sent. The explicit
+    // action cancels server work; chatStop only detaches this local reader.
+    setResumeEnabled(false);
+    setRecoveringDisconnect(false);
+    void chatStop();
+    void stopSession({
+      path: { agentId: session.agent_id, sessionId: session.id },
+      throwOnError: true,
+    }).catch((err) => {
+      console.error("[session stop]", err);
+      setResumeEnabled(true);
+    });
+  }, [session, chatStop]);
 
   // A thread started from the home composer arrives with its first message
   // parked in memory. Claim it once the session is loaded; `takePendingMessage`
@@ -634,7 +652,7 @@ export function SessionDetail({
     session.user_id === currentUserID ? (
       <ChatComposer
         onSend={(text) => void sendMessage(text)}
-        onStop={() => chatStop()}
+        onStop={stopActiveTurn}
         isStreaming={isStreaming}
         placeholder={t("sessions.composer.placeholder")}
         attachments={attachments}

--- a/web/src/features/sessions/SessionDetail.tsx
+++ b/web/src/features/sessions/SessionDetail.tsx
@@ -130,6 +130,16 @@ export function SessionDetail({
     () => (session ? createSessionTransport(session.agent_id, session.id) : undefined),
     [session?.agent_id, session?.id],
   );
+  const historyAuthoritativeRef = useRef(false);
+  const reconcilePersistedHistory = useCallback(() => {
+    historyAuthoritativeRef.current = true;
+    void queryClient.invalidateQueries({ queryKey: ["session-messages", sessionId] });
+    void queryClient.invalidateQueries({ queryKey: ["session-tail-messages", sessionId] });
+  }, [queryClient, sessionId]);
+  const completeReconnectCheck = useCallback(() => {
+    setRecoveringDisconnect(false);
+    reconcilePersistedHistory();
+  }, [reconcilePersistedHistory]);
 
   const {
     messages: chatMessages,
@@ -146,14 +156,13 @@ export function SessionDetail({
     // Batch SSE deltas: without this every token re-renders the transcript.
     experimental_throttle: 50,
     onError: (err) => console.error("[session chat]", err),
-    onFinish: ({ isDisconnect }) => setRecoveringDisconnect(isDisconnect),
+    onFinish: ({ isAbort, isDisconnect, isError }) => {
+      setRecoveringDisconnect(isDisconnect);
+      if (!isAbort && !isDisconnect && !isError) reconcilePersistedHistory();
+    },
   });
 
   const isStreaming = chatStatus === "streaming" || chatStatus === "submitted";
-  const reconcilePersistedHistory = useCallback(() => {
-    void queryClient.invalidateQueries({ queryKey: ["session-messages", sessionId] });
-    void queryClient.invalidateQueries({ queryKey: ["session-tail-messages", sessionId] });
-  }, [queryClient, sessionId]);
 
   // The server titles an untitled session from its first user message *during*
   // the turn (internal/agent/runtime/chat.go), so nothing on the client knows
@@ -182,14 +191,11 @@ export function SessionDetail({
         console.error("[session refresh]", err);
       }
       void queryClient.invalidateQueries({ queryKey: ["sessions", agentId] });
-      // Replay is bounded, so persisted history is the final authority after a
-      // sent or resumed stream settles.
-      reconcilePersistedHistory();
     })();
     return () => {
       cancelled = true;
     };
-  }, [isStreaming, agentId, sessionId, onSessionUpdate, queryClient, reconcilePersistedHistory]);
+  }, [isStreaming, agentId, sessionId, onSessionUpdate, queryClient]);
 
   // Every turn is server-owned once admitted. An idle view polls the read-only
   // events stream so navigation, refresh, connection loss, and turns started
@@ -201,7 +207,7 @@ export function SessionDetail({
     chatResume,
     recoveringDisconnect,
     chatClearError,
-    reconcilePersistedHistory,
+    completeReconnectCheck,
   );
 
   const messagesQuery = useInfiniteQuery({
@@ -275,10 +281,13 @@ export function SessionDetail({
     // text copy forever (duplicated, un-collapsed tool output). Excluding
     // everything history has ever owned drops it.
     for (const m of uiMessages) historicalIDsRef.current.add(m.id);
+    const authoritative = historyAuthoritativeRef.current;
+    historyAuthoritativeRef.current = false;
     setChatMessages((prev) =>
       reconcileHistoryUIMessages(
         uiMessages,
         prev.filter((message) => !historicalIDsRef.current.has(message.id)),
+        { authoritative },
       ),
     );
   }, [historyMessages, setChatMessages]);

--- a/web/src/features/sessions/SessionDetail.tsx
+++ b/web/src/features/sessions/SessionDetail.tsx
@@ -163,6 +163,8 @@ export function SessionDetail({
   });
 
   const isStreaming = chatStatus === "streaming" || chatStatus === "submitted";
+  const isStreamingRef = useRef(isStreaming);
+  isStreamingRef.current = isStreaming;
 
   // The server titles an untitled session from its first user message *during*
   // the turn (internal/agent/runtime/chat.go), so nothing on the client knows
@@ -281,8 +283,8 @@ export function SessionDetail({
     // text copy forever (duplicated, un-collapsed tool output). Excluding
     // everything history has ever owned drops it.
     for (const m of uiMessages) historicalIDsRef.current.add(m.id);
-    const authoritative = historyAuthoritativeRef.current;
-    historyAuthoritativeRef.current = false;
+    const authoritative = historyAuthoritativeRef.current && !isStreamingRef.current;
+    if (authoritative) historyAuthoritativeRef.current = false;
     setChatMessages((prev) =>
       reconcileHistoryUIMessages(
         uiMessages,

--- a/web/src/features/sessions/useSessionStreamResume.ts
+++ b/web/src/features/sessions/useSessionStreamResume.ts
@@ -35,10 +35,18 @@ export function useSessionStreamResume(
       resumingRef.current = true;
       void resumeStream().finally(() => {
         resumingRef.current = false;
-        if (checkedSessionRef.current !== sessionId || recoveringDisconnect) {
-          checkedSessionRef.current = sessionId;
-          onInitialCheck();
-        }
+        // AI SDK resolves resumeStream() for 204 and transport errors alike;
+        // status is committed on the next render. Reconcile only from ready,
+        // which means either a clean stream finish or no active stream.
+        window.setTimeout(() => {
+          if (
+            statusRef.current === "ready" &&
+            (checkedSessionRef.current !== sessionId || recoveringDisconnect)
+          ) {
+            checkedSessionRef.current = sessionId;
+            onInitialCheck();
+          }
+        }, 0);
       });
     };
 

--- a/web/src/features/sessions/useSessionStreamResume.ts
+++ b/web/src/features/sessions/useSessionStreamResume.ts
@@ -24,6 +24,7 @@ export function useSessionStreamResume(
   useEffect(() => {
     if (!sessionId || !enabled) return;
     let cancelled = false;
+    let deferredTimer: number | undefined;
 
     const tick = () => {
       if (cancelled || resumingRef.current) return;
@@ -35,11 +36,13 @@ export function useSessionStreamResume(
       resumingRef.current = true;
       void resumeStream().finally(() => {
         resumingRef.current = false;
+        if (cancelled) return;
         // AI SDK resolves resumeStream() for 204 and transport errors alike;
         // status is committed on the next render. Reconcile only from ready,
         // which means either a clean stream finish or no active stream.
-        window.setTimeout(() => {
+        deferredTimer = window.setTimeout(() => {
           if (
+            !cancelled &&
             statusRef.current === "ready" &&
             (checkedSessionRef.current !== sessionId || recoveringDisconnect)
           ) {
@@ -55,6 +58,7 @@ export function useSessionStreamResume(
     return () => {
       cancelled = true;
       window.clearInterval(timer);
+      if (deferredTimer !== undefined) window.clearTimeout(deferredTimer);
     };
   }, [sessionId, enabled, resumeStream, recoveringDisconnect, clearError, onInitialCheck]);
 }

--- a/web/src/features/sessions/useSessionStreamResume.ts
+++ b/web/src/features/sessions/useSessionStreamResume.ts
@@ -1,0 +1,52 @@
+import { useEffect, useRef } from "react";
+
+type ChatStatus = "submitted" | "streaming" | "ready" | "error";
+
+/**
+ * Attach an idle chat view to any active server-side turn. Sending and watching
+ * use separate SSE connections, so navigation, refresh, and transient network
+ * loss can reconnect without owning the turn's lifetime.
+ */
+export function useSessionStreamResume(
+  sessionId: string,
+  enabled: boolean,
+  status: ChatStatus,
+  resumeStream: () => Promise<void>,
+  recoveringDisconnect: boolean,
+  clearError: () => void,
+  onInitialCheck: () => void,
+) {
+  const statusRef = useRef(status);
+  const resumingRef = useRef(false);
+  const checkedSessionRef = useRef<string | null>(null);
+  statusRef.current = status;
+
+  useEffect(() => {
+    if (!sessionId || !enabled) return;
+    let cancelled = false;
+
+    const tick = () => {
+      if (cancelled || resumingRef.current) return;
+      if (statusRef.current === "error" && recoveringDisconnect) {
+        clearError();
+        return;
+      }
+      if (statusRef.current !== "ready") return;
+      resumingRef.current = true;
+      void resumeStream().finally(() => {
+        resumingRef.current = false;
+        if (checkedSessionRef.current !== sessionId || recoveringDisconnect) {
+          checkedSessionRef.current = sessionId;
+          onInitialCheck();
+        }
+      });
+    };
+
+    tick();
+    const timer = window.setInterval(tick, 3000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [sessionId, enabled, resumeStream, recoveringDisconnect, clearError, onInitialCheck]);
+}

--- a/web/src/lib/chat-transport.test.ts
+++ b/web/src/lib/chat-transport.test.ts
@@ -321,4 +321,17 @@ describe("session history conversion", () => {
 
     expect(reconcileHistoryUIMessages([canonical], [optimistic])).toEqual([canonical, optimistic]);
   });
+
+  it("replaces live turn IDs when persisted history is authoritative", () => {
+    const canonical: UIMessage[] = [
+      { id: "db-user", role: "user", parts: [{ type: "text", text: "hi" }] },
+      { id: "db-assistant", role: "assistant", parts: [{ type: "text", text: "hello" }] },
+    ];
+    const live: UIMessage[] = [
+      { id: "client-user", role: "user", parts: [{ type: "text", text: "hi" }] },
+      { id: "sse-assistant", role: "assistant", parts: [{ type: "text", text: "hello" }] },
+    ];
+
+    expect(reconcileHistoryUIMessages(canonical, live, { authoritative: true })).toEqual(canonical);
+  });
 });

--- a/web/src/lib/chat-transport.ts
+++ b/web/src/lib/chat-transport.ts
@@ -195,13 +195,17 @@ export function mergeToolResults(messages: Message[]): Message[] {
 // breaks — every already-loaded message would be added a second time.
 const CANONICAL_RECONCILIATION_WINDOW_MS = 2 * 60 * 1000;
 
-// reconcileHistoryUIMessages lets canonical history replace only the optimistic
-// workspace image that produced it. Matching is one-to-one and timestamp-bound:
-// an old, identical caption is not evidence that a new upload was persisted.
+// reconcileHistoryUIMessages normally lets canonical history replace only the
+// optimistic workspace image that produced it. Matching is one-to-one and
+// timestamp-bound: an old, identical caption is not evidence that a new upload
+// was persisted. After a stream closes, authoritative mode replaces all live
+// IDs because the server has persisted the complete turn under canonical IDs.
 export function reconcileHistoryUIMessages(
   history: UIMessage[],
   current: UIMessage[],
+  options: { authoritative?: boolean } = {},
 ): UIMessage[] {
+  if (options.authoritative) return history;
   const historyIDs = new Set(history.map((message) => message.id));
   const consumedOptimisticIDs = new Set<string>();
 


### PR DESCRIPTION
## What

Keep Web-initiated Agent turns running when the browser navigates away, refreshes, or temporarily loses its SSE connection, then automatically reconnect and reconcile the transcript.

## Why

The message handler passed the HTTP request context into the Agent runtime. Unmounting the chat view aborted the SSE request and canceled the turn itself. The existing events endpoint only auto-resumed internal session kinds and could not replay output emitted before a new observer attached.

## How

- Own admitted Web turns under the server work lifecycle while draining the initiating stream after its observer disconnects.
- Add bounded process-local active-turn replay (4,096 events / 8 MiB) to `SessionHub`.
- Resume the events stream for every session kind, recover transient network disconnects, and reconcile persisted history after reconnect/finish.
- Add `POST /api/agents/{agentId}/sessions/{sessionId}/stop` so explicit cancellation remains separate from transport disconnect.
- Preserve interrupted partial assistant output and keep graceful drain semantics intact.
- Add unit coverage plus a real subprocess journey that disconnects mid-turn and resumes through a second SSE request without a second model call.

## Verification

- `mise run format`
- `mise run build`
- `mise run test`
- `mise run system-test`

Closes #937