### PR TITLE
🐛 fix(sandbox): restore managed temp mounts before execution

### DIFF
--- a/plugins/sandbox/local/session.go
+++ b/plugins/sandbox/local/session.go
@@ -334,6 +334,39 @@ func cleanupOwnedTmpMounts(mounts []tmpMount) {
 	}
 }
 
+// ensureOwnedTmpMounts restores session-owned temporary directories removed by
+// host cleanup services while a long-lived session is still active. Borrowed
+// mounts are deliberately ignored: their lifecycle belongs to the operator,
+// and a missing source must still fail closed in the platform sandbox.
+func ensureOwnedTmpMounts(mounts []tmpMount) error {
+	for _, mount := range mounts {
+		if !mount.owned {
+			continue
+		}
+		info, err := os.Lstat(mount.realPath)
+		switch {
+		case err == nil:
+			if !info.IsDir() {
+				return fmt.Errorf("temporary mount source %q is not a directory", mount.realPath)
+			}
+		case errors.Is(err, os.ErrNotExist):
+			if err := os.Mkdir(mount.realPath, 0o700); err != nil && !errors.Is(err, os.ErrExist) {
+				return fmt.Errorf("recreate temporary mount source %q: %w", mount.realPath, err)
+			}
+			info, err = os.Lstat(mount.realPath)
+			if err != nil {
+				return fmt.Errorf("verify temporary mount source %q: %w", mount.realPath, err)
+			}
+			if !info.IsDir() {
+				return fmt.Errorf("temporary mount source %q is not a directory", mount.realPath)
+			}
+		default:
+			return fmt.Errorf("inspect temporary mount source %q: %w", mount.realPath, err)
+		}
+	}
+	return nil
+}
+
 // deregisterProcess removes a process handle from the session's tracked list.
 // Called by localProcess after natural exit so stale PIDs are not killed.
 func (s *localSession) deregisterProcess(p *localProcess) {
@@ -463,6 +496,9 @@ func (s *localSession) Exec(ctx context.Context, command string, opts sandboxpkg
 	if closed {
 		return sandboxpkg.ExecResult{}, fmt.Errorf("local: session is closed")
 	}
+	if err := ensureOwnedTmpMounts(s.tmpMounts); err != nil {
+		return sandboxpkg.ExecResult{}, fmt.Errorf("local exec: prepare temporary mounts: %w", err)
+	}
 
 	sandboxCwd := opts.Cwd
 	if sandboxCwd == "" {
@@ -543,8 +579,15 @@ func (s *localSession) Exec(ctx context.Context, command string, opts sandboxpkg
 func (s *localSession) StartProcess(ctx context.Context, req sandboxpkg.ProcessRequest) (sandboxpkg.ProcessHandle, error) {
 	// Per-exec env reads take a policy snapshot under the lock.
 	s.mu.RLock()
+	closed := s.closed
 	policy := s.policy
 	s.mu.RUnlock()
+	if closed {
+		return nil, fmt.Errorf("local: session is closed")
+	}
+	if err := ensureOwnedTmpMounts(s.tmpMounts); err != nil {
+		return nil, fmt.Errorf("local start_process: prepare temporary mounts: %w", err)
+	}
 
 	sandboxCwd := req.Cwd
 	if sandboxCwd == "" {

--- a/plugins/sandbox/local/session_test.go
+++ b/plugins/sandbox/local/session_test.go
@@ -118,6 +118,58 @@ func TestCleanupOwnedTmpMountsLeavesBorrowedMounts(t *testing.T) {
 	}
 }
 
+func TestEnsureOwnedTmpMountsRestoresOnlyManagedDirectories(t *testing.T) {
+	root := t.TempDir()
+	owned := filepath.Join(root, "owned")
+	borrowed := filepath.Join(root, "borrowed")
+	mounts := []tmpMount{
+		{realPath: owned, owned: true},
+		{realPath: borrowed},
+	}
+
+	if err := ensureOwnedTmpMounts(mounts); err != nil {
+		t.Fatalf("ensureOwnedTmpMounts: %v", err)
+	}
+	info, err := os.Stat(owned)
+	if err != nil {
+		t.Fatalf("stat restored owned mount: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o700 {
+		t.Fatalf("restored owned mount mode = %o, want 700", got)
+	}
+	if _, err := os.Stat(borrowed); !os.IsNotExist(err) {
+		t.Fatalf("borrowed mount was created: %v", err)
+	}
+}
+
+func TestLocalSessionExecRestoresRemovedManagedTempDirectory(t *testing.T) {
+	skipIfBwrapNotFunctional(t)
+	root := t.TempDir()
+	policy := sandboxpkg.Policy{
+		Filesystem: sandboxpkg.FilesystemPolicy{WorkspaceRoot: root, WorkingDir: root},
+		Network:    sandboxpkg.NetworkPolicy{Mode: sandboxpkg.NetworkAllowAll},
+	}
+	session, err := NewFactory().CreateSession(context.Background(), policy)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	s := session.(*localSession)
+	defer s.Close() //nolint:errcheck
+
+	tmpDir := s.tmpMounts[0].realPath
+	if err := os.RemoveAll(tmpDir); err != nil {
+		t.Fatalf("remove managed temp directory: %v", err)
+	}
+	result, err := s.Exec(context.Background(), `printf recovered > "$TMPDIR/recovered"`, sandboxpkg.ExecOptions{})
+	if err != nil || result.ExitCode != 0 {
+		t.Fatalf("Exec after temp removal = %+v, %v", result, err)
+	}
+	data, err := os.ReadFile(filepath.Join(tmpDir, "recovered"))
+	if err != nil || string(data) != "recovered" {
+		t.Fatalf("restored temp output = %q, %v", data, err)
+	}
+}
+
 func TestLocalSession_closeAndAlive(t *testing.T) {
 	s, _ := newTestSession(t)
 	if !s.Alive() {


### PR DESCRIPTION
## What

Restore missing Stella-managed temporary bind sources before local sandbox commands start, allowing long-lived runners to recover after host cleanup removes their session temp directories.

## Why

`systemd-tmpfiles-clean` can remove a temp backing directory while its local sandbox session remains cached. Bubblewrap then fails every command before execution because the bind source no longer exists; recovery previously required restarting Stella.

## How

- Validate session-owned temp mounts before both `Exec` and `StartProcess`.
- Recreate only missing `owned` directories with mode `0700`.
- Reject a managed source that reappears as a non-directory.
- Leave borrowed and operator-managed mounts untouched so missing external sources still fail closed.
- Check `StartProcess` closed state before recreating session-owned resources.

## Test

- `mise run format` — passed.
- `mise run build` — passed.
- `mise run build:web && mise run test` — passed; all Go packages and 194 Web tests passed.
- `TARGET_GOOS=linux TARGET_GOARCH=amd64 mise run build` — passed.
- Added an integration regression that deletes a live session's temp backing and verifies the next command recreates and uses it.

The first fresh-clone `mise run test` reached and passed `plugins/sandbox/local`, then failed only because the inherited checkout lacked built PWA root files. Building the SPA before rerunning the complete suite resolved that environment prerequisite.

## Refs

Closes #941

## Checklist

- [x] The PR links a GitHub issue.
- [x] I added or updated focused tests for changed non-trivial behavior, or explained why none are needed.
- [x] I updated relevant English and Chinese documentation, or no documentation change is needed. This is internal recovery behavior with no user-facing contract change.
- [x] I ran `mise run format && mise run build && mise run test`.