### PR TITLE
📝 docs: Publish v0.63.0 changelog

### DIFF
--- a/deploy/helm/stella/Chart.yaml
+++ b/deploy/helm/stella/Chart.yaml
@@ -8,7 +8,7 @@ version: 0.1.1
 # against. It is NOT the default image tag: the chart defaults image.tag to
 # "latest" (see stella.image / values.yaml) so a fresh install tracks the newest
 # published release. Pin image.tag or image.digest for reproducible deploys.
-appVersion: "v0.62.0"
+appVersion: "v0.63.0"
 home: https://stella.cherryin.com
 sources:
   - https://github.com/CherryHQ/stella

--- a/web/content/docs/changelog.mdx
+++ b/web/content/docs/changelog.mdx
@@ -11,10 +11,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.63.0] - 2026-08-08
+
 ### ✨ Features
 
-- Enterprise integrations can now create passwordless, API-only provisioned users through a restricted, expiring provisioning token. Administrators create, copy, revoke, and manage planned credential rotation in Settings; user creation and rotation return bearer secrets once, preserve unrelated personal tokens, and deactivation revokes sessions and every token through the normal account lockdown lifecycle. ([#891](https://github.com/CherryHQ/stella/issues/891))
-- Personal access tokens now inherit their owner's current account permissions, including admin authority. Creating a token no longer requires API scopes, existing tokens adopt the new behavior automatically, and the account UI is reduced to naming and creating the token. To prevent credential multiplication or account takeover, PATs cannot manage authentication credentials, browser sessions, identities, roles, or account activation. OAuth access tokens remain scoped. ([#889](https://github.com/CherryHQ/stella/issues/889))
+- Knowledge now has an immutable snapshot storage core and a deterministic derivation lifecycle for PDF, DOCX, Markdown, and text files. Publication, deletion, cleanup, and recovery remain atomic or retry-safe across PostgreSQL and raw object storage. This is backend groundwork for the upcoming Knowledge management and retrieval surfaces. ([#779](https://github.com/CherryHQ/stella/pull/779), [#855](https://github.com/CherryHQ/stella/pull/855), [#841](https://github.com/CherryHQ/stella/issues/841))
+- Enterprise integrations can create passwordless, API-only managed users through restricted, expiring provisioning tokens. Administrators can create, copy, rotate, and revoke those credentials in Settings. User creation and rotation return bearer secrets once, preserve unrelated personal tokens, and deactivation revokes sessions and every token through the normal account lockdown lifecycle. ([#892](https://github.com/CherryHQ/stella/pull/892), [#893](https://github.com/CherryHQ/stella/pull/893), [#899](https://github.com/CherryHQ/stella/pull/899), [#891](https://github.com/CherryHQ/stella/issues/891))
+- Personal access tokens now inherit their owner's current account permissions, including admin authority. Creating a token no longer requires API scopes, existing tokens adopt the new behavior automatically, and the account UI now asks only for a name. PATs still cannot manage authentication credentials, browser sessions, identities, roles, or account activation. OAuth access tokens remain scoped. ([#890](https://github.com/CherryHQ/stella/pull/890), [#889](https://github.com/CherryHQ/stella/issues/889))
+- Feishu can automatically provision verified tenant members as Stella users while preserving the existing account-linking and administrator controls. ([#753](https://github.com/CherryHQ/stella/pull/753), [#751](https://github.com/CherryHQ/stella/issues/751))
+- Discord is now a built-in channel with direct-message and guild controls, mention gates, allowlists, and opt-in persistent guest sessions. Guest sessions use restricted principals, rate limits, retention, compaction, and per-channel caps instead of shadow Stella users. ([#903](https://github.com/CherryHQ/stella/pull/903), [#921](https://github.com/CherryHQ/stella/pull/921), [#900](https://github.com/CherryHQ/stella/issues/900), [#920](https://github.com/CherryHQ/stella/issues/920))
+- Chat turns now survive navigation and expose durable queued, running, waiting, failed, and completed activity. Agents can also list and inspect their own sessions and goal execution state for ongoing work. ([#902](https://github.com/CherryHQ/stella/pull/902), [#938](https://github.com/CherryHQ/stella/pull/938), [#940](https://github.com/CherryHQ/stella/pull/940), [#901](https://github.com/CherryHQ/stella/issues/901), [#937](https://github.com/CherryHQ/stella/issues/937), [#939](https://github.com/CherryHQ/stella/issues/939))
+- The Web UI and agent guidance now organize work around Conversations and Work, with sessions and goals as the two places where work lives. The Work page uses one vocabulary for active, scheduled, repeatable, and historical work. ([#922](https://github.com/CherryHQ/stella/pull/922), [#923](https://github.com/CherryHQ/stella/pull/923), [#908](https://github.com/CherryHQ/stella/issues/908))
+
+### 🔐 Security
+
+- Telegram and Feishu now enforce fail-closed controls for private messages, group allowlists, mention requirements, and opt-in restricted guest access before downloading media or dispatching work. ([#935](https://github.com/CherryHQ/stella/pull/935), [#932](https://github.com/CherryHQ/stella/issues/932))
+
+### 🐛 Bug Fixes
+
+- The Web UI now renders structured API errors, long identifiers, machine-authored conversations, markdown, and session activity without silent failures or unreadable layouts. ([#896](https://github.com/CherryHQ/stella/pull/896), [#934](https://github.com/CherryHQ/stella/pull/934), [#895](https://github.com/CherryHQ/stella/issues/895), [#898](https://github.com/CherryHQ/stella/issues/898), [#933](https://github.com/CherryHQ/stella/issues/933))
+- Provider tool calls keep their emitted order through streaming, execution, events, and persisted history. Provider prompt-cache usage is also reported in usage logs and OpenTelemetry spans. ([#931](https://github.com/CherryHQ/stella/pull/931), [#930](https://github.com/CherryHQ/stella/issues/930))
+- The sandbox restores missing managed temporary mount sources before execution, so cleanup or a host restart no longer leaves otherwise valid sandboxes unable to start. ([#942](https://github.com/CherryHQ/stella/pull/942), [#941](https://github.com/CherryHQ/stella/issues/941))
+
+### 🔧 CI
+
+- Contributors and agents can create disposable Stella testbeds with isolated ports, state, logs, and browser-ready credentials for repeatable UI and API verification. ([#907](https://github.com/CherryHQ/stella/pull/907), [#905](https://github.com/CherryHQ/stella/issues/905))
+
+### 📝 Documentation
+
+- The Web UI testing rules now cover testbed port overrides, login fallback, state seeding, and the difference between DOM presence and visible, styled output. ([#926](https://github.com/CherryHQ/stella/pull/926), [#925](https://github.com/CherryHQ/stella/issues/925))
+
+### 📦 Dependencies
+
+- Updated Mermaid from 11.15.0 to 11.16.1. ([#927](https://github.com/CherryHQ/stella/pull/927))
+
+**Full Changelog**: [v0.62.0...v0.63.0](https://github.com/CherryHQ/stella/compare/v0.62.0...v0.63.0)
 
 ## [0.62.0] - 2026-08-05
 

--- a/web/content/docs/changelog.zh.mdx
+++ b/web/content/docs/changelog.zh.mdx
@@ -11,10 +11,41 @@ icon: History
 
 ## [Unreleased]
 
+## [0.63.0] - 2026-08-08
+
 ### ✨ 功能
 
-- 企业集成现在可通过受限且会过期的开通令牌创建无密码、仅 API 可用的受管用户。管理员可在设置中创建、复制、撤销开通凭据并完成计划轮换；用户创建和轮换只返回一次 bearer secret，会保留无关的个人令牌；停用则通过正常账户锁定流程撤销 session 和全部令牌。([#891](https://github.com/CherryHQ/stella/issues/891))
-- 个人访问令牌现在继承所属账户的当前权限，包括管理员权限。创建令牌不再需要选择 API scope，现有令牌会自动采用新行为，账户页面也简化为命名并创建令牌。为避免凭证扩散或账户接管，PAT 不能管理认证凭证、浏览器 session、身份、角色或账户启用状态；OAuth access token 仍按 scope 授权。([#889](https://github.com/CherryHQ/stella/issues/889))
+- Knowledge 新增不可变快照存储核心，以及适用于 PDF、DOCX、Markdown 和文本文件的确定性派生生命周期。发布、删除、清理和恢复跨 PostgreSQL 与原始对象存储时保持原子性或可安全重试。这是后续 Knowledge 管理与检索界面的后端基础。([#779](https://github.com/CherryHQ/stella/pull/779), [#855](https://github.com/CherryHQ/stella/pull/855), [#841](https://github.com/CherryHQ/stella/issues/841))
+- 企业集成现在可通过受限且会过期的开通令牌创建无密码、仅 API 可用的受管用户。管理员可在设置中创建、复制、轮换和撤销这些凭据。用户创建和轮换只返回一次 bearer secret，会保留无关的个人令牌；停用则通过正常账户锁定流程撤销 session 和全部令牌。([#892](https://github.com/CherryHQ/stella/pull/892), [#893](https://github.com/CherryHQ/stella/pull/893), [#899](https://github.com/CherryHQ/stella/pull/899), [#891](https://github.com/CherryHQ/stella/issues/891))
+- 个人访问令牌现在继承所属账户的当前权限，包括管理员权限。创建令牌不再需要选择 API scope，现有令牌会自动采用新行为，账户页面现在只要求填写名称。PAT 仍不能管理认证凭证、浏览器 session、身份、角色或账户启用状态；OAuth access token 继续按 scope 授权。([#890](https://github.com/CherryHQ/stella/pull/890), [#889](https://github.com/CherryHQ/stella/issues/889))
+- 飞书现在可将通过验证的租户成员自动开通为 Stella 用户，同时保留现有的账户绑定与管理员控制。([#753](https://github.com/CherryHQ/stella/pull/753), [#751](https://github.com/CherryHQ/stella/issues/751))
+- Discord 成为内置渠道，支持私信与服务器控制、提及门槛、允许列表和选择性启用的持久访客 session。访客 session 使用受限主体、速率限制、保留期、压缩和单渠道数量上限，不会创建影子 Stella 用户。([#903](https://github.com/CherryHQ/stella/pull/903), [#921](https://github.com/CherryHQ/stella/pull/921), [#900](https://github.com/CherryHQ/stella/issues/900), [#920](https://github.com/CherryHQ/stella/issues/920))
+- 对话轮次现在可在页面切换后继续运行，并持久显示排队、运行、等待、失败和完成状态。Agent 还可列出并检查自己的 session 与目标执行状态，用于跟进持续工作。([#902](https://github.com/CherryHQ/stella/pull/902), [#938](https://github.com/CherryHQ/stella/pull/938), [#940](https://github.com/CherryHQ/stella/pull/940), [#901](https://github.com/CherryHQ/stella/issues/901), [#937](https://github.com/CherryHQ/stella/issues/937), [#939](https://github.com/CherryHQ/stella/issues/939))
+- Web UI 与 Agent 指引现在以“对话”和“工作”组织任务，session 与目标是工作实际承载的两个位置。“工作”页面统一使用活跃、计划、重复和历史等词汇。([#922](https://github.com/CherryHQ/stella/pull/922), [#923](https://github.com/CherryHQ/stella/pull/923), [#908](https://github.com/CherryHQ/stella/issues/908))
+
+### 🔐 安全
+
+- Telegram 和飞书现在会在下载媒体或分派工作前，以 fail-closed 方式检查私信开关、群组允许列表、提及要求和选择性启用的受限访客访问。([#935](https://github.com/CherryHQ/stella/pull/935), [#932](https://github.com/CherryHQ/stella/issues/932))
+
+### 🐛 修复
+
+- Web UI 现在可正确呈现结构化 API 错误、长标识符、机器创建的对话、Markdown 和 session 活动，不再静默失败或产生难以阅读的布局。([#896](https://github.com/CherryHQ/stella/pull/896), [#934](https://github.com/CherryHQ/stella/pull/934), [#895](https://github.com/CherryHQ/stella/issues/895), [#898](https://github.com/CherryHQ/stella/issues/898), [#933](https://github.com/CherryHQ/stella/issues/933))
+- Provider 工具调用从流式组装、执行、事件到持久历史都会保持模型给出的顺序。Provider 的 prompt cache 用量也会写入用量日志和 OpenTelemetry span。([#931](https://github.com/CherryHQ/stella/pull/931), [#930](https://github.com/CherryHQ/stella/issues/930))
+- 沙箱会在执行前恢复缺失的受管临时挂载源，清理操作或主机重启不再导致原本有效的沙箱无法启动。([#942](https://github.com/CherryHQ/stella/pull/942), [#941](https://github.com/CherryHQ/stella/issues/941))
+
+### 🔧 CI
+
+- 贡献者与 Agent 现在可创建一次性 Stella testbed，使用隔离的端口、状态、日志和浏览器凭据，重复验证 Web UI 与 API。([#907](https://github.com/CherryHQ/stella/pull/907), [#905](https://github.com/CherryHQ/stella/issues/905))
+
+### 📝 文档
+
+- Web UI 测试规则现在覆盖 testbed 端口覆盖、登录回退、状态注入，以及 DOM 中存在元素与真正可见且样式正确之间的区别。([#926](https://github.com/CherryHQ/stella/pull/926), [#925](https://github.com/CherryHQ/stella/issues/925))
+
+### 📦 依赖
+
+- Mermaid 从 11.15.0 更新至 11.16.1。([#927](https://github.com/CherryHQ/stella/pull/927))
+
+**完整变更记录**：[v0.62.0...v0.63.0](https://github.com/CherryHQ/stella/compare/v0.62.0...v0.63.0)
 
 ## [0.62.0] - 2026-08-05
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.62.0",
+  "version": "0.63.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## What

Publish the synchronized English and Chinese v0.63.0 changelogs. This does not create a release tag or publish binaries, packages, or container images. Runtime and Helm versions remain at v0.62.0.

## Verification

- `mise run generate`
- `VERSION=0.63.0 mise run release:validate`

Closes #944