### PR TITLE
📝 docs: Keep runtime version at v0.62.0

### DIFF
--- a/deploy/helm/stella/Chart.yaml
+++ b/deploy/helm/stella/Chart.yaml
@@ -8,7 +8,7 @@ version: 0.1.1
 # against. It is NOT the default image tag: the chart defaults image.tag to
 # "latest" (see stella.image / values.yaml) so a fresh install tracks the newest
 # published release. Pin image.tag or image.digest for reproducible deploys.
-appVersion: "v0.63.0"
+appVersion: "v0.62.0"
 home: https://stella.cherryin.com
 sources:
   - https://github.com/CherryHQ/stella

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.63.0",
+  "version": "0.62.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## What

Restore `web/package.json` and Helm `appVersion` to v0.62.0 so #945 publishes only the bilingual changelogs. No v0.63.0 release tag or artifacts are being published.

## Verification

- `mise run format`
- `mise run test:web`

Closes #944