### PR TITLE
📝 docs: Update CHANGELOG for v0.63.1

### DIFF
--- a/.github/scripts/verify-release-source.sh
+++ b/.github/scripts/verify-release-source.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+tag=${1:?usage: verify-release-source.sh <tag> [commit] [remote]}
+commit=${2:-HEAD}
+remote=${3:-origin}
+
+if [[ ! "$tag" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)(-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$ ]]; then
+  echo "invalid release tag: $tag" >&2
+  exit 1
+fi
+
+release_branch="release/v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+commit_sha=$(git rev-parse "${commit}^{commit}")
+remote_ref="refs/remotes/${remote}/${release_branch}"
+
+git fetch --quiet --no-tags "$remote" \
+  "refs/heads/${release_branch}:${remote_ref}"
+
+if ! git merge-base --is-ancestor "$commit_sha" "$remote_ref"; then
+  echo "release commit $commit_sha is not on $release_branch" >&2
+  exit 1
+fi
+
+printf '%s\n' "$release_branch"

--- a/.github/scripts/verify-release-source_test.sh
+++ b/.github/scripts/verify-release-source_test.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script=$(cd "$(dirname "$0")" && pwd)/verify-release-source.sh
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+git init --quiet --bare "$tmp/origin.git"
+git init --quiet "$tmp/repo"
+git -C "$tmp/repo" config user.email release-test@stella.invalid
+git -C "$tmp/repo" config user.name 'Stella Release Test'
+git -C "$tmp/repo" remote add origin "$tmp/origin.git"
+
+printf 'release\n' >"$tmp/repo/source"
+git -C "$tmp/repo" add source
+git -C "$tmp/repo" commit --quiet -m release
+release_commit=$(git -C "$tmp/repo" rev-parse HEAD)
+git -C "$tmp/repo" branch release/v0.63
+git -C "$tmp/repo" push --quiet origin release/v0.63
+
+test "$(cd "$tmp/repo" && "$script" v0.63.0 "$release_commit")" = release/v0.63
+test "$(cd "$tmp/repo" && "$script" v0.63.1-rc.2 "$release_commit")" = release/v0.63
+
+printf 'not released\n' >>"$tmp/repo/source"
+git -C "$tmp/repo" commit --quiet -am unrelated
+unreleased_commit=$(git -C "$tmp/repo" rev-parse HEAD)
+
+if (cd "$tmp/repo" && "$script" v0.63.1 "$unreleased_commit") >/dev/null 2>&1; then
+  echo 'accepted a commit outside release/v0.63' >&2
+  exit 1
+fi
+
+if (cd "$tmp/repo" && "$script" v0.63 "$release_commit") >/dev/null 2>&1; then
+  echo 'accepted an invalid release tag' >&2
+  exit 1
+fi

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -2,13 +2,17 @@ name: Format and Test
 
 on:
   push:
-    branches: ["**"]
+    branches: [main, "release/v*"]
     tags-ignore: ["v*.*.*"]
   pull_request:
-    branches: [main]
+    branches: [main, "release/v*"]
   merge_group:
-    branches: [main]
+    branches: [main, "release/v*"]
     types: [checks_requested]
+
+concurrency:
+  group: format-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -36,6 +40,9 @@ jobs:
 
       - name: Generate code and check drift
         run: mise run generate:check
+
+      - name: Test release source policy
+        run: bash .github/scripts/verify-release-source_test.sh
 
       - name: Run pre-commit hooks
         run: prek run --all-files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,8 @@ env:
   IMAGE_NAME: cherryhq/stella
 
 jobs:
-  validate:
-    name: Validate Tagged Commit
+  source:
+    name: Verify Release Source
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -25,7 +25,7 @@ jobs:
           ref: ${{ github.sha }}
           fetch-depth: 0
 
-      - name: Verify tagged commit identity
+      - name: Verify tag identity and release branch
         env:
           EVENT_REF: ${{ github.ref }}
           EVENT_SHA: ${{ github.sha }}
@@ -36,11 +36,26 @@ jobs:
           tag_commit="$(git rev-parse "${EVENT_REF}^{commit}")"
           test "$head_commit" = "$event_commit"
           test "$head_commit" = "$tag_commit"
+
+          release_branch="$(.github/scripts/verify-release-source.sh "$GITHUB_REF_NAME" "$head_commit")"
           {
             echo "### Validated release source"
             echo "- Tag: \`${GITHUB_REF_NAME}\`"
+            echo "- Branch: \`${release_branch}\`"
             echo "- Commit: \`${head_commit}\`"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  quality:
+    name: Quality and Build
+    needs: source
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout tagged commit
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
 
       - name: Setup mise
         uses: jdx/mise-action@v4
@@ -50,20 +65,21 @@ jobs:
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install bubblewrap
-        run: |
-          set -euo pipefail
-          sudo apt-get install -y bubblewrap
-          # Ubuntu 24.04 blocks unprivileged user namespaces through AppArmor, so
-          # an installed bwrap still cannot create a sandbox. The local sandbox
-          # backend probes exactly this, and the System Test runs real agent
-          # turns through it — without the sysctl every turn fails at runtime.
-          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-          # Fail here, with the reason visible, rather than inside a test run.
-          bwrap --unshare-pid --unshare-ipc --unshare-uts --dev-bind / / -- true
+      - name: Cache Go build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       - name: Generate code and check drift
         run: mise run generate:check
+
+      - name: Test release source policy
+        run: bash .github/scripts/verify-release-source_test.sh
 
       - name: Check formatting and lint
         run: |
@@ -74,10 +90,50 @@ jobs:
       - name: Build
         run: mise run build
 
-      # go:embed snapshots web/static/dist at compile time, so the SPA has to
-      # exist before the test binaries are built. GoReleaser builds it later in
-      # this job anyway — building it here is what lets the PWA build contract
-      # be checked instead of skipped.
+  tests:
+    name: Go and Web Tests
+    needs: source
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout tagged commit
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Setup mise
+        uses: jdx/mise-action@v4
+        with:
+          experimental: true
+          install: true
+          cache: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Go build and PostgreSQL runtime
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+            ~/.stella/pg-runtime
+          key: ${{ runner.os }}-tests-${{ hashFiles('**/go.sum', 'internal/pgruntime/**') }}
+          restore-keys: |
+            ${{ runner.os }}-tests-
+            ${{ runner.os }}-go-
+
+      - name: Install bubblewrap
+        run: |
+          set -euo pipefail
+          sudo apt-get install -y bubblewrap
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          bwrap --unshare-pid --unshare-ipc --unshare-uts --dev-bind / / -- true
+
+      - name: Generate code and check drift
+        run: mise run generate:check
+
+      # go:embed snapshots web/static/dist at compile time. Build the SPA before
+      # test binaries so the PWA contract cannot silently skip.
       - name: Build web assets
         run: mise run build:web
 
@@ -86,6 +142,45 @@ jobs:
         env:
           STELLA_TEST_REQUIRE_BWRAP: "1"
           STELLA_TEST_REQUIRE_SPA: "1"
+
+  system:
+    name: System Test
+    needs: source
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout tagged commit
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Setup mise
+        uses: jdx/mise-action@v4
+        with:
+          experimental: true
+          install: true
+          cache: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Go build and PostgreSQL runtime
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+            ~/.stella/pg-runtime
+          key: ${{ runner.os }}-system-${{ hashFiles('**/go.sum', 'internal/pgruntime/**') }}
+          restore-keys: |
+            ${{ runner.os }}-system-
+            ${{ runner.os }}-go-
+
+      - name: Install bubblewrap
+        run: |
+          set -euo pipefail
+          sudo apt-get install -y bubblewrap
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          bwrap --unshare-pid --unshare-ipc --unshare-uts --dev-bind / / -- true
 
       - name: Run System Test
         run: mise run system-test
@@ -99,6 +194,38 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  snapshot:
+    name: Release Snapshot
+    needs: source
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout tagged commit
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Setup mise
+        uses: jdx/mise-action@v4
+        with:
+          experimental: true
+          install: true
+          cache: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Go build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-snapshot-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-snapshot-
+            ${{ runner.os }}-go-
+
       - name: Check GoReleaser configuration
         run: mise run release:check
 
@@ -107,7 +234,7 @@ jobs:
 
   goreleaser:
     name: GoReleaser
-    needs: validate
+    needs: [quality, tests, system, snapshot]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -126,11 +253,8 @@ jobs:
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      # No pnpm/Node setup here on purpose. mise-action installed both from
-      # mise.toml above; adding actions/setup-node prepended a different Node to
-      # PATH and silently won, so the release built the embedded SPA on Node 22
-      # while every PR built it on Node 24. The validate job above already runs
-      # the same SPA build on mise alone.
+      # No setup-node action: mise owns the Node and pnpm versions used by every
+      # build, including the SPA embedded by GoReleaser.
       - name: Cache Go build
         uses: actions/cache@v4
         with:
@@ -153,7 +277,7 @@ jobs:
 
   docker:
     name: Docker Release
-    needs: validate
+    needs: [quality, tests, system, snapshot]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/deploy/helm/stella/Chart.yaml
+++ b/deploy/helm/stella/Chart.yaml
@@ -8,7 +8,7 @@ version: 0.1.1
 # against. It is NOT the default image tag: the chart defaults image.tag to
 # "latest" (see stella.image / values.yaml) so a fresh install tracks the newest
 # published release. Pin image.tag or image.digest for reproducible deploys.
-appVersion: "v0.63.0"
+appVersion: "v0.63.1"
 home: https://stella.cherryin.com
 sources:
   - https://github.com/CherryHQ/stella

--- a/web/content/docs/changelog.mdx
+++ b/web/content/docs/changelog.mdx
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.63.1] - 2026-08-08
+
+### 🔧 CI
+
+- Releases now use maintained `release/vX.Y` branches, so each minor line has a stable base for patch releases while `main` remains the default development branch. Tag validation rejects commits outside the matching branch and runs quality/build, Go and Web tests, the System Test, and release packaging in parallel. Feature branches also avoid duplicate push and pull-request checks. ([#948](https://github.com/CherryHQ/stella/pull/948), [#947](https://github.com/CherryHQ/stella/issues/947))
+
+**Full Changelog**: [v0.63.0...v0.63.1](https://github.com/CherryHQ/stella/compare/v0.63.0...v0.63.1)
+
 ## [0.63.0] - 2026-08-08
 
 ### ✨ Features

--- a/web/content/docs/changelog.zh.mdx
+++ b/web/content/docs/changelog.zh.mdx
@@ -11,6 +11,14 @@ icon: History
 
 ## [Unreleased]
 
+## [0.63.1] - 2026-08-08
+
+### 🔧 CI
+
+- 发布现在使用长期维护的 `release/vX.Y` 分支，让每条 minor 版本线都有稳定的 patch 基线，同时保留 `main` 作为默认开发分支。Tag 验证会拒绝不属于匹配分支的提交，并行运行质量与构建、Go 与 Web 测试、System Test 和发布打包。Feature 分支也不再重复运行 push 与 pull request 检查。([#948](https://github.com/CherryHQ/stella/pull/948), [#947](https://github.com/CherryHQ/stella/issues/947))
+
+**完整变更记录**：[v0.63.0...v0.63.1](https://github.com/CherryHQ/stella/compare/v0.63.0...v0.63.1)
+
 ## [0.63.0] - 2026-08-08
 
 ### ✨ 功能

--- a/web/content/docs/development/rules/release.md
+++ b/web/content/docs/development/rules/release.md
@@ -8,48 +8,91 @@ description: Release tagging and packaging workflow for Stella.
 Use semantic versioning with `v` prefix: `v0.1.0`, `v1.0.0`, `v1.2.3-rc.1`.
 GoReleaser auto-detects pre-release suffixes (`-rc.1`, `-beta.1`).
 
+## Branch Model
+
+`main` remains the default development branch. Releases use maintained minor
+branches named `release/vX.Y`, for example `release/v0.63`:
+
+- Cut a new minor release branch from the intended commit on `main`.
+- Publish `vX.Y.0` and every `vX.Y.Z` patch from that same branch.
+- Land fixes on `main` first when practical, then backport the exact commit to a
+  short-lived branch and open a PR against `release/vX.Y`.
+- Sync release metadata and any release-only fix back to `main` through a PR.
+  Never leave the two lines silently divergent.
+
+Protect `release/v*` with the same required Format and Test checks as `main`.
+Disallow force-pushes and branch deletion, and require PRs for updates. The tag
+workflow also derives `release/vX.Y` from the version and rejects a tagged
+commit that is not reachable from that branch.
+
 ## Release Flow
 
 1. Choose release tag `vX.Y.Z`; the web package version is `X.Y.Z` (without `v`).
-2. Update `web/package.json` so `.version` matches the API/server release version:
+2. Create or update the maintained release branch:
+
+   ```bash
+   RELEASE_BRANCH=release/vX.Y
+   git fetch origin --prune
+
+   # New minor line only:
+   git switch main
+   git pull --ff-only origin main
+   git switch -c "$RELEASE_BRANCH"
+   git push -u origin "$RELEASE_BRANCH"
+
+   # Existing patch line:
+   git switch "$RELEASE_BRANCH"
+   git pull --ff-only origin "$RELEASE_BRANCH"
+   ```
+
+3. Create a short-lived preparation branch from `release/vX.Y`. Do not commit
+   release metadata directly to the maintained branch.
+4. Update `web/package.json` so `.version` matches the API/server release version:
    ```bash
    VERSION=X.Y.Z
    tmp=$(mktemp)
    jq --arg version "$VERSION" '.version = $version' web/package.json > "$tmp" && mv "$tmp" web/package.json
    test "$(jq -r '.version' web/package.json)" = "$VERSION"
    ```
-3. Update the Helm chart metadata in `deploy/helm/stella/Chart.yaml`:
+5. Update the Helm chart metadata in `deploy/helm/stella/Chart.yaml`:
    - Set `appVersion: "vX.Y.Z"` so the chart records the release it ships alongside.
      The default `image.tag` is `latest` (CI publishes it for every stable release,
      see Artifacts), so a fresh install already tracks this version; `appVersion`
      just keeps the metadata honest.
    - Bump the chart's own `version` (its SemVer, independent of `appVersion`)
      whenever the chart changed since the last release.
-4. Update `web/content/docs/changelog.mdx` and `web/content/docs/changelog.zh.mdx` (see below).
-5. Commit: `📝 docs: Update CHANGELOG for vX.Y.Z` including both changelogs, `web/package.json`, and `deploy/helm/stella/Chart.yaml`.
-6. Verify the commit succeeded and the working tree is clean:
+6. Update `web/content/docs/changelog.mdx` and `web/content/docs/changelog.zh.mdx` (see below).
+7. Commit: `📝 docs: Update CHANGELOG for vX.Y.Z` including both changelogs,
+   `web/package.json`, and `deploy/helm/stella/Chart.yaml`.
+8. Run the full pre-cut gate below. Verify that the release commit is `HEAD` and
+   the working tree is clean:
    ```bash
    git status --short
    git log --oneline -1
    ```
-   Stop if the release commit is not `HEAD`; never tag before the commit exists.
-7. Verify that the version milestone contains the exact release scope and has
+9. Verify that the version milestone contains the exact release scope and has
    no open issues. Stop and resolve any open issue before tagging:
    ```bash
    gh issue list --repo CherryHQ/stella --milestone vX.Y.Z --state open
    gh issue list --repo CherryHQ/stella --milestone vX.Y.Z --state all
    ```
-8. Tag the release commit and verify the tag points at `HEAD`:
-   ```bash
-   git tag vX.Y.Z
-   test "$(git rev-parse vX.Y.Z)" = "$(git rev-parse HEAD)"
-   ```
-9. Push the branch and new release tag explicitly: `git push origin main vX.Y.Z`.
-10. CI triggers `.github/workflows/release.yml`. Its validation job checks the
-    exact tagged commit before the GoReleaser or Docker publication jobs can
-    start.
-11. After CI succeeds and the GitHub Release is visible, close the version
-    milestone:
+10. Push the preparation branch and open a PR against `release/vX.Y`. Wait for
+    required checks and merge it.
+11. Fetch the merged release branch, then tag its remote tip:
+    ```bash
+    git fetch origin --prune
+    git switch "$RELEASE_BRANCH"
+    git reset --hard "origin/$RELEASE_BRANCH"
+    git tag vX.Y.Z
+    test "$(git rev-parse vX.Y.Z)" = "$(git rev-parse origin/$RELEASE_BRANCH)"
+    git push origin vX.Y.Z
+    ```
+12. CI triggers `.github/workflows/release.yml`. It verifies the exact tagged
+    commit and the matching maintained branch before publication starts.
+13. After CI succeeds and the GitHub Release is visible, open a sync-back PR
+    from `release/vX.Y` to `main` when the release branch contains commits not
+    already present on `main`.
+14. Close the version milestone:
     ```bash
     MILESTONE_NUMBER=$(gh api 'repos/CherryHQ/stella/milestones?state=open' \
       --jq '.[] | select(.title == "vX.Y.Z") | .number')
@@ -70,7 +113,7 @@ Gather changes since last tag:
 
 ```bash
 git log $(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD)..HEAD --oneline
-gh pr list --state merged --base main --search "merged:>=$(git log -1 --format=%aI $(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD))"
+gh pr list --state merged --base "$RELEASE_BRANCH" --search "merged:>=$(git log -1 --format=%aI $(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD))"
 ```
 
 Apply to both changelog files:
@@ -92,12 +135,15 @@ test "$(jq -r '.version' web/package.json)" = "$VERSION"
 mise run release:validate
 ```
 
-The system suite (`system-test`) runs both in the local gate and in the
-tag-triggered validation job. Release CI pins a supported Ubuntu runner and
-uploads the suite's server logs before any snapshot build can clean `dist/`.
-GoReleaser and Docker publication jobs depend directly on the validation result,
-so a failed or unsupported System Test cannot publish partial release artifacts.
-See `system-test.md`.
+The local gate remains sequential so the first failure stops later work. The
+tag workflow verifies the release source once, then runs quality/build, Go and
+Web tests, the System Test, and the release snapshot in parallel. GoReleaser and
+Docker publication depend on all four jobs. A failure in any lane blocks every
+publication job.
+
+Release CI pins supported Ubuntu runners. The System Test lane uploads its server
+logs with `if: always()` before any other job can affect its isolated workspace,
+so failed subprocess journeys remain diagnosable. See `system-test.md`.
 
 ## Artifacts
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.63.0",
+  "version": "0.63.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## What

Publish the first v0.63 patch from the maintained `release/v0.63` line. This backports the release-branch and parallel-validation workflow from #948, bumps package and Helm metadata to v0.63.1, and adds synchronized changelogs.

## Why

A real patch release is the acceptance test for the new branch ancestry gate and parallel release workflow.

## How

- Backport the squash commit from #948 onto `release/v0.63`.
- Keep Helm chart version 0.1.1 because the chart itself did not change.
- Record the CI-only patch in both changelogs.

## Test

- `mise run generate`
- `VERSION=0.63.1 mise run release:validate`

## Refs

Closes #949
Refs #947