### PR TITLE
🐛 fix(ci): order generation before PostgreSQL download

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -177,6 +177,9 @@ PY
 
 [tasks."pg:runtime:download"]
 description = "Download the embedded PostgreSQL runtime used by tests and local server runs"
+# This command compiles stellad, which imports generated API packages. Resolve
+# generation before sibling dependencies can race it on a clean checkout.
+depends = ["generate"]
 run = "go run ./cmd/stellad postgres download"
 
 [tasks."build:web"]

--- a/web/content/docs/development/rules/release.md
+++ b/web/content/docs/development/rules/release.md
@@ -77,7 +77,9 @@ commit that is not reachable from that branch.
    gh issue list --repo CherryHQ/stella --milestone vX.Y.Z --state all
    ```
 10. Push the preparation branch and open a PR against `release/vX.Y`. Wait for
-    required checks and merge it.
+    required checks and merge it. GitHub auto-closes linked issues only when a PR
+    merges into the default branch, so close the release issue explicitly and
+    recheck that the version milestone has no open scope.
 11. Fetch the merged release branch, then tag its remote tip:
     ```bash
     git fetch origin --prune


### PR DESCRIPTION
## What

Make `pg:runtime:download` depend on code generation and document explicit issue closure for release-branch PRs.

## Why

The first v0.63.1 tag attempt correctly failed in the isolated System Test lane. On a clean checkout, `system-test` started its sibling `build` and `pg:runtime:download` dependencies concurrently. The latter compiles `stellad` before `build` finishes generating `api/server`, `api/types`, and `internal/server/docs_spec.yaml`. Local COW clones hid the race because those ignored generated files already existed.

GitHub also does not apply `Closes` keywords when a PR merges into a non-default release branch, so the documented release flow must require explicit issue closure before the milestone check.

## How

Put `generate` below `pg:runtime:download` in the mise dependency graph. Shared dependency resolution completes generation once before `build` and the PostgreSQL download can run concurrently.

## Test

- Removed `api/server`, `api/types`, `web/src/lib/api-client`, and `internal/server/docs_spec.yaml`, then ran `mise run system-test` successfully.
- `mise run format`
- `mise run build`
- `mise run test`

## Refs

Refs #949
Refs #947