### PR TITLE
🔀 chore(release): sync v0.63.1 back to main

### DIFF
--- a/deploy/helm/stella/Chart.yaml
+++ b/deploy/helm/stella/Chart.yaml
@@ -8,7 +8,7 @@ version: 0.1.1
 # against. It is NOT the default image tag: the chart defaults image.tag to
 # "latest" (see stella.image / values.yaml) so a fresh install tracks the newest
 # published release. Pin image.tag or image.digest for reproducible deploys.
-appVersion: "v0.63.0"
+appVersion: "v0.63.1"
 home: https://stella.cherryin.com
 sources:
   - https://github.com/CherryHQ/stella

--- a/mise.toml
+++ b/mise.toml
@@ -177,6 +177,9 @@ PY
 
 [tasks."pg:runtime:download"]
 description = "Download the embedded PostgreSQL runtime used by tests and local server runs"
+# This command compiles stellad, which imports generated API packages. Resolve
+# generation before sibling dependencies can race it on a clean checkout.
+depends = ["generate"]
 run = "go run ./cmd/stellad postgres download"
 
 [tasks."build:web"]

--- a/web/content/docs/changelog.mdx
+++ b/web/content/docs/changelog.mdx
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.63.1] - 2026-08-08
+
+### 🔧 CI
+
+- Releases now use maintained `release/vX.Y` branches, so each minor line has a stable base for patch releases while `main` remains the default development branch. Tag validation rejects commits outside the matching branch and runs quality/build, Go and Web tests, the System Test, and release packaging in parallel. Feature branches also avoid duplicate push and pull-request checks. ([#948](https://github.com/CherryHQ/stella/pull/948), [#947](https://github.com/CherryHQ/stella/issues/947))
+
+**Full Changelog**: [v0.63.0...v0.63.1](https://github.com/CherryHQ/stella/compare/v0.63.0...v0.63.1)
+
 ## [0.63.0] - 2026-08-08
 
 ### ✨ Features

--- a/web/content/docs/changelog.zh.mdx
+++ b/web/content/docs/changelog.zh.mdx
@@ -11,6 +11,14 @@ icon: History
 
 ## [Unreleased]
 
+## [0.63.1] - 2026-08-08
+
+### 🔧 CI
+
+- 发布现在使用长期维护的 `release/vX.Y` 分支，让每条 minor 版本线都有稳定的 patch 基线，同时保留 `main` 作为默认开发分支。Tag 验证会拒绝不属于匹配分支的提交，并行运行质量与构建、Go 与 Web 测试、System Test 和发布打包。Feature 分支也不再重复运行 push 与 pull request 检查。([#948](https://github.com/CherryHQ/stella/pull/948), [#947](https://github.com/CherryHQ/stella/issues/947))
+
+**完整变更记录**：[v0.63.0...v0.63.1](https://github.com/CherryHQ/stella/compare/v0.63.0...v0.63.1)
+
 ## [0.63.0] - 2026-08-08
 
 ### ✨ 功能

--- a/web/content/docs/development/rules/release.md
+++ b/web/content/docs/development/rules/release.md
@@ -77,7 +77,9 @@ commit that is not reachable from that branch.
    gh issue list --repo CherryHQ/stella --milestone vX.Y.Z --state all
    ```
 10. Push the preparation branch and open a PR against `release/vX.Y`. Wait for
-    required checks and merge it.
+    required checks and merge it. GitHub auto-closes linked issues only when a PR
+    merges into the default branch, so close the release issue explicitly and
+    recheck that the version milestone has no open scope.
 11. Fetch the merged release branch, then tag its remote tip:
     ```bash
     git fetch origin --prune

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.63.0",
+  "version": "0.63.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## What

Sync the v0.63.1 release metadata and clean-checkout generation fix from `release/v0.63` back to `main`.

## Why

The maintained release line must not leave package versions, changelogs, or release-process fixes behind.

## How

- Apply the v0.63.1 package, Helm, and bilingual changelog commit.
- Apply the `pg:runtime:download` generation dependency and release-issue closure note found during the first tag attempt.

## Test

- Fresh generated outputs removed, then `mise run system-test` passed.
- `mise run format`
- `mise run build`
- `mise run test`
- `mise run release:check`
- `mise run release:snapshot`
- v0.63.1 release run succeeded: https://github.com/CherryHQ/stella/actions/runs/31252984889

## Refs

Refs #949
Refs #947