### PR TITLE
🐛 fix: allow unlinked Discord group members

### DIFF
--- a/internal/channel/guest_resolution_test.go
+++ b/internal/channel/guest_resolution_test.go
@@ -26,6 +26,13 @@ func (s *guestResolutionConfigStore) ListEnabledAgents(context.Context) ([]confi
 	return nil, nil
 }
 
+func (s *guestResolutionConfigStore) GetAgent(_ context.Context, id string) (config.Agent, error) {
+	if id != s.channel.AgentID {
+		return config.Agent{}, pgx.ErrNoRows
+	}
+	return config.Agent{ID: id, Enabled: true}, nil
+}
+
 type guestResolutionAuthStore struct{ channelAuthStore }
 
 func (guestResolutionAuthStore) GetChannelIdentityByPlatform(context.Context, string, string) (auth.ChannelIdentity, error) {
@@ -55,6 +62,12 @@ func (s *guestResolutionStore) ResolveOrCreateGuest(_ context.Context, channelID
 	s.calls++
 	s.guest.ChannelID, s.guest.Platform, s.guest.ExternalID = channelID, platform, externalID
 	return s.guest, nil
+}
+
+type guestResolutionGroupResolver struct{}
+
+func (guestResolutionGroupResolver) ResolveGroupID(context.Context, string, string, string) (string, error) {
+	return "11111111-1111-4111-8111-111111111111", nil
 }
 
 func TestCoordinatorGuestResolutionIsSupportedPrivateOptInOnly(t *testing.T) {
@@ -131,4 +144,19 @@ func TestCoordinatorGuestResolutionIsSupportedPrivateOptInOnly(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("unlinked Discord group uses channel binding", func(t *testing.T) {
+		store.channel = channel
+		guestStore := &guestResolutionStore{guest: sqlc.ChannelGuest{ID: "unexpected"}}
+		resolved, err := ResolveWithChannel(ctx, manager, store, authStore, nil, guestResolutionGroupResolver{}, guestStore, "discord", channel.ID, "unlinked-member", nil, "Guest", "guild-channel", "", true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resolved.AgentID != channel.AgentID || resolved.GroupID == "" || resolved.User.ID != "" {
+			t.Fatalf("resolved group = %#v", resolved)
+		}
+		if guestStore.calls != 0 {
+			t.Fatalf("guest store calls = %d, want 0", guestStore.calls)
+		}
+	})
 }

--- a/internal/channel/resolved_chat.go
+++ b/internal/channel/resolved_chat.go
@@ -229,7 +229,17 @@ func ResolveWithChannel(ctx context.Context, sm agent.ServiceManager, store conf
 
 	var guestID, agentID string
 	guestMessageLimitPerMinute := 0
-	if resolved.User.ID == "" && !isGroup {
+	switch {
+	case isGroup && groupID != "":
+		// A platform group speaks through its persisted channel binding. Sender
+		// identity must not gate the group agent: most group members are not
+		// expected to have Stella accounts.
+		channel, channelErr := validatePlatformChannel(ctx, store, platform, channelID)
+		if channelErr != nil {
+			return nil, fmt.Errorf("resolve group agent: %w", channelErr)
+		}
+		agentID = channel.AgentID
+	case resolved.User.ID == "" && !isGroup:
 		channel, channelErr := store.GetChannel(ctx, channelID)
 		if senderID == "" || channelErr != nil || channel.Type != platform || channel.AgentID == "" || !pkgchannel.AllowsUnlinkedGuestDM(channel.Type, channel.Enabled, channel.Config) || guests == nil {
 			return nil, ErrAgentAccessDenied
@@ -247,7 +257,7 @@ func ResolveWithChannel(ctx context.Context, sm agent.ServiceManager, store conf
 		}
 		guestID, agentID = guest.ID, channel.AgentID
 		guestMessageLimitPerMinute = guestConfig.GuestMessageLimitPerMinute
-	} else {
+	default:
 		agentID, err = ResolveAgent(ctx, store, accessService, resolved, chatCtx)
 		if err != nil {
 			return nil, fmt.Errorf("resolve agent: %w", err)
@@ -256,7 +266,7 @@ func ResolveWithChannel(ctx context.Context, sm agent.ServiceManager, store conf
 
 	var authority authz.Authority
 	var subject auth.Subject
-	if guestID == "" {
+	if guestID == "" && groupID == "" {
 		role := resolved.User.Role
 		if role == "" {
 			role = auth.RoleUser


### PR DESCRIPTION
## What

Allow unlinked Discord server members to invoke the agent bound to the configured Discord channel.

## Why

Group resolution previously entered ordinary user-based agent selection before constructing the persisted group authority. An unlinked server member was therefore denied before the group channel binding could authorize the turn.

## How

- Select group agents from the validated, enabled platform channel binding.
- Skip user-authority construction when the turn has a durable group identity.
- Keep private guest DM and ordinary linked-user authorization unchanged.
- Add a regression test for an unlinked Discord group member.

## Test

- `mise run format` — passed.
- `mise run build` — passed.
- `mise exec -- go test ./internal/channel -run TestCoordinatorGuestResolutionIsSupportedPrivateOptInOnly -count=1` — passed.
- `mise run test` — attempted; database-backed packages fail because the Orb embedded PostgreSQL runtime times out during `pg_ctl start`.
- `git diff --check` — passed.

## Refs

Closes #953

## Checklist

- [x] The PR links a GitHub issue.
- [x] I added or updated focused tests for changed non-trivial behavior, or explained why none are needed.
- [x] I updated relevant English and Chinese documentation, or no documentation change is needed. No documentation change is needed for this regression fix.
- [x] I ran `mise run format && mise run build && mise run test`.
