### PR TITLE
♻️ refactor: split manifest plugin definition type

### DIFF
--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -2436,9 +2436,191 @@ components:
         config:
           type: object
           additionalProperties: true
+    ManifestBinary:
+      type: object
+      additionalProperties: false
+      required: [name, tool]
+      properties:
+        name:
+          type: string
+          description: Binary name installed into Stella's bin directory.
+        tool:
+          type: string
+          description: mise tool key, such as github:cli/cli or npm:serve.
+        version:
+          type: string
+          description: Version to install. Defaults to latest when omitted.
+        options:
+          type: object
+          additionalProperties: true
+          description: mise backend options.
+    ManifestSkill:
+      type: object
+      additionalProperties: false
+      required: [repo, name]
+      properties:
+        repo:
+          type: string
+        name:
+          type: string
+    ManifestSessionEnv:
+      type: object
+      additionalProperties: false
+      required: [env_var, source]
+      properties:
+        env_var:
+          type: string
+        source:
+          type: string
+          description: Value source, such as static or oauth.access_token.
+        value:
+          type: string
+        required:
+          type: boolean
+    ManifestPluginDefinition:
+      type: object
+      additionalProperties: false
+      required: [name, display_name, description]
+      properties:
+        name:
+          type: string
+        display_name:
+          type: string
+        description:
+          type: string
+        category:
+          type: string
+          description: Optional settings UI grouping hint.
+        prompt:
+          type: string
+        binaries:
+          type: array
+          items:
+            $ref: "#/components/schemas/ManifestBinary"
+        skills:
+          type: array
+          items:
+            $ref: "#/components/schemas/ManifestSkill"
+        session_env:
+          type: array
+          items:
+            $ref: "#/components/schemas/ManifestSessionEnv"
+        oauth_provider:
+          type: string
     ManifestPlugin:
       type: object
-      additionalProperties: true
+      additionalProperties: false
+      required: [id, kind, name, display_name, description, enabled]
+      properties:
+        id:
+          type: string
+        kind:
+          type: string
+        name:
+          type: string
+        display_name:
+          type: string
+        description:
+          type: string
+        enabled:
+          type: boolean
+        category:
+          type: string
+          description: Optional settings UI grouping hint.
+        essential:
+          type: boolean
+          description: Server policy indicating that the plugin cannot be disabled.
+        prompt:
+          type: string
+        binaries:
+          type: array
+          items:
+            $ref: "#/components/schemas/ManifestBinary"
+        skills:
+          type: array
+          items:
+            $ref: "#/components/schemas/ManifestSkill"
+        session_env:
+          type: array
+          items:
+            $ref: "#/components/schemas/ManifestSessionEnv"
+        oauth_provider:
+          type: string
+        builtin:
+          type: boolean
+          readOnly: true
+          description: Whether the plugin definition ships with the server.
+        overridden_fields:
+          type: array
+          readOnly: true
+          description: Definition fields owned by the stored override.
+          items:
+            $ref: "#/components/schemas/ManifestPluginDefinitionField"
+    ManifestPluginInput:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          description: Ignored; the URL identifies the plugin.
+        kind:
+          type: string
+          description: Must match the kind in the URL when supplied.
+        name:
+          type: string
+        display_name:
+          type: string
+        description:
+          type: string
+        enabled:
+          type: boolean
+          description: Used for admin-added plugins and ignored for builtins.
+        category:
+          type: string
+          description: Optional settings UI grouping hint.
+        essential:
+          type: boolean
+          description: Server-owned for builtins.
+        prompt:
+          type: string
+        binaries:
+          type: array
+          items:
+            $ref: "#/components/schemas/ManifestBinary"
+        skills:
+          type: array
+          items:
+            $ref: "#/components/schemas/ManifestSkill"
+        session_env:
+          type: array
+          items:
+            $ref: "#/components/schemas/ManifestSessionEnv"
+        oauth_provider:
+          type: string
+    ManifestPluginDefinitionField:
+      type: string
+      enum:
+        - name
+        - display_name
+        - description
+        - category
+        - prompt
+        - binaries
+        - skills
+        - session_env
+        - oauth_provider
+    SaveManifestPluginDefinitionRequest:
+      type: object
+      additionalProperties: false
+      required: [plugin]
+      properties:
+        plugin:
+          $ref: "#/components/schemas/ManifestPluginInput"
+        fields:
+          type: array
+          description: Definition fields this request takes ownership of. Builtins only.
+          items:
+            $ref: "#/components/schemas/ManifestPluginDefinitionField"
     ManifestOAuthProvider:
       type: object
       properties:
@@ -2454,6 +2636,7 @@ components:
           type: string
     ManifestPluginsResponse:
       type: object
+      required: [plugins, oauth_providers]
       properties:
         plugins:
           type: array

--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -2456,6 +2456,10 @@ components:
           description: mise backend options.
     ManifestSkill:
       type: object
+      deprecated: true
+      description: >
+        Reserved manifest declaration. Stella currently stores and returns skill entries but does not install or register them at runtime.
+
       additionalProperties: false
       required: [repo, name]
       properties:
@@ -2499,6 +2503,10 @@ components:
             $ref: "#/components/schemas/ManifestBinary"
         skills:
           type: array
+          deprecated: true
+          description: >
+            Reserved declarations. They are stored and returned but are not currently installed or registered at runtime.
+
           items:
             $ref: "#/components/schemas/ManifestSkill"
         session_env:
@@ -2538,6 +2546,10 @@ components:
             $ref: "#/components/schemas/ManifestBinary"
         skills:
           type: array
+          deprecated: true
+          description: >
+            Reserved declarations. They are stored and returned but are not currently installed or registered at runtime.
+
           items:
             $ref: "#/components/schemas/ManifestSkill"
         session_env:
@@ -2558,6 +2570,9 @@ components:
             $ref: "#/components/schemas/ManifestPluginDefinitionField"
     ManifestPluginInput:
       type: object
+      description: >
+        Submitted builtin plugin view. Only the definition fields named by the sibling `fields` array are stored; all other values are context for validation and remain unowned.
+
       additionalProperties: false
       properties:
         id:
@@ -2589,6 +2604,10 @@ components:
             $ref: "#/components/schemas/ManifestBinary"
         skills:
           type: array
+          deprecated: true
+          description: >
+            Reserved declarations. They are stored and returned but are not currently installed or registered at runtime.
+
           items:
             $ref: "#/components/schemas/ManifestSkill"
         session_env:
@@ -2599,6 +2618,9 @@ components:
           type: string
     ManifestPluginDefinitionField:
       type: string
+      description: >
+        Editable definition field. `skills` is reserved: its value can be stored and returned but is not currently installed or registered at runtime.
+
       enum:
         - name
         - display_name
@@ -2609,18 +2631,89 @@ components:
         - skills
         - session_env
         - oauth_provider
-    SaveManifestPluginDefinitionRequest:
+    SaveBuiltinManifestPluginDefinitionRequest:
       type: object
       additionalProperties: false
-      required: [plugin]
+      required: [plugin, fields]
       properties:
         plugin:
           $ref: "#/components/schemas/ManifestPluginInput"
         fields:
           type: array
-          description: Definition fields this request takes ownership of. Builtins only.
+          description: Definition fields this request takes ownership of.
           items:
             $ref: "#/components/schemas/ManifestPluginDefinitionField"
+    ManifestPluginReplacement:
+      type: object
+      description: >
+        Complete replacement value for an admin-added plugin. Empty strings and arrays explicitly clear optional definition fields.
+
+      additionalProperties: false
+      required:
+        - kind
+        - name
+        - display_name
+        - description
+        - enabled
+        - category
+        - essential
+        - prompt
+        - binaries
+        - skills
+        - session_env
+        - oauth_provider
+      properties:
+        id:
+          type: string
+          description: Ignored; the URL identifies the plugin.
+        kind:
+          type: string
+        name:
+          type: string
+        display_name:
+          type: string
+        description:
+          type: string
+        enabled:
+          type: boolean
+        category:
+          type: string
+        essential:
+          type: boolean
+        prompt:
+          type: string
+        binaries:
+          type: array
+          items:
+            $ref: "#/components/schemas/ManifestBinary"
+        skills:
+          type: array
+          deprecated: true
+          description: >
+            Reserved declarations. They are stored and returned but are not currently installed or registered at runtime.
+
+          items:
+            $ref: "#/components/schemas/ManifestSkill"
+        session_env:
+          type: array
+          items:
+            $ref: "#/components/schemas/ManifestSessionEnv"
+        oauth_provider:
+          type: string
+    ReplaceCustomManifestPluginDefinitionRequest:
+      type: object
+      description: >
+        Full replacement for an admin-added plugin.
+
+      additionalProperties: false
+      required: [plugin]
+      properties:
+        plugin:
+          $ref: "#/components/schemas/ManifestPluginReplacement"
+    SaveManifestPluginDefinitionRequest:
+      oneOf:
+        - $ref: "#/components/schemas/SaveBuiltinManifestPluginDefinitionRequest"
+        - $ref: "#/components/schemas/ReplaceCustomManifestPluginDefinitionRequest"
     ManifestOAuthProvider:
       type: object
       properties:

--- a/api/spec/domain/plugins/paths.yaml
+++ b/api/spec/domain/plugins/paths.yaml
@@ -168,7 +168,8 @@ paths:
         and cannot be owned. `enabled` is ignored for a builtin — the enable
         switch has its own operation. A plugin an admin added has no shipped
         definition underneath it, so the body is the whole plugin, `fields` does
-        not apply, and `enabled` travels with it.
+        not apply, `enabled` travels with it, and empty values explicitly clear
+        optional definition fields.
       operationId: saveManifestPluginDefinition
       requestBody:
         required: true

--- a/api/spec/domain/plugins/paths.yaml
+++ b/api/spec/domain/plugins/paths.yaml
@@ -175,18 +175,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required: [plugin]
-              properties:
-                plugin: {
-                  $ref: "../../components.yaml#/components/schemas/ManifestPlugin",
-                }
-                fields:
-                  type: array
-                  description: >
-                    Definition fields this request takes ownership of, e.g.
-                    ["binaries"]. Builtin plugins only.
-                  items: { type: string }
+              $ref: "../../components.yaml#/components/schemas/SaveManifestPluginDefinitionRequest"
       responses:
         "200":
           description: ok

--- a/api/spec/domain/plugins/schemas.yaml
+++ b/api/spec/domain/plugins/schemas.yaml
@@ -34,9 +34,164 @@ components:
       properties:
         config: { type: object, additionalProperties: true }
 
+    ManifestBinary:
+      type: object
+      additionalProperties: false
+      required: [name, tool]
+      properties:
+        name:
+          type: string
+          description: Binary name installed into Stella's bin directory.
+        tool:
+          type: string
+          description: mise tool key, such as github:cli/cli or npm:serve.
+        version:
+          type: string
+          description: Version to install. Defaults to latest when omitted.
+        options:
+          type: object
+          additionalProperties: true
+          description: mise backend options.
+
+    ManifestSkill:
+      type: object
+      additionalProperties: false
+      required: [repo, name]
+      properties:
+        repo: { type: string }
+        name: { type: string }
+
+    ManifestSessionEnv:
+      type: object
+      additionalProperties: false
+      required: [env_var, source]
+      properties:
+        env_var: { type: string }
+        source:
+          type: string
+          description: Value source, such as static or oauth.access_token.
+        value: { type: string }
+        required: { type: boolean }
+
+    ManifestPluginDefinition:
+      type: object
+      additionalProperties: false
+      required: [name, display_name, description]
+      properties:
+        name: { type: string }
+        display_name: { type: string }
+        description: { type: string }
+        category:
+          type: string
+          description: Optional settings UI grouping hint.
+        prompt: { type: string }
+        binaries:
+          type: array
+          items: { $ref: "#/components/schemas/ManifestBinary" }
+        skills:
+          type: array
+          items: { $ref: "#/components/schemas/ManifestSkill" }
+        session_env:
+          type: array
+          items: { $ref: "#/components/schemas/ManifestSessionEnv" }
+        oauth_provider: { type: string }
+
     ManifestPlugin:
       type: object
-      additionalProperties: true
+      additionalProperties: false
+      required: [id, kind, name, display_name, description, enabled]
+      properties:
+        id: { type: string }
+        kind: { type: string }
+        name: { type: string }
+        display_name: { type: string }
+        description: { type: string }
+        enabled: { type: boolean }
+        category:
+          type: string
+          description: Optional settings UI grouping hint.
+        essential:
+          type: boolean
+          description: Server policy indicating that the plugin cannot be disabled.
+        prompt: { type: string }
+        binaries:
+          type: array
+          items: { $ref: "#/components/schemas/ManifestBinary" }
+        skills:
+          type: array
+          items: { $ref: "#/components/schemas/ManifestSkill" }
+        session_env:
+          type: array
+          items: { $ref: "#/components/schemas/ManifestSessionEnv" }
+        oauth_provider: { type: string }
+        builtin:
+          type: boolean
+          readOnly: true
+          description: Whether the plugin definition ships with the server.
+        overridden_fields:
+          type: array
+          readOnly: true
+          description: Definition fields owned by the stored override.
+          items:
+            $ref: "#/components/schemas/ManifestPluginDefinitionField"
+
+    ManifestPluginInput:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          description: Ignored; the URL identifies the plugin.
+        kind:
+          type: string
+          description: Must match the kind in the URL when supplied.
+        name: { type: string }
+        display_name: { type: string }
+        description: { type: string }
+        enabled:
+          type: boolean
+          description: Used for admin-added plugins and ignored for builtins.
+        category:
+          type: string
+          description: Optional settings UI grouping hint.
+        essential:
+          type: boolean
+          description: Server-owned for builtins.
+        prompt: { type: string }
+        binaries:
+          type: array
+          items: { $ref: "#/components/schemas/ManifestBinary" }
+        skills:
+          type: array
+          items: { $ref: "#/components/schemas/ManifestSkill" }
+        session_env:
+          type: array
+          items: { $ref: "#/components/schemas/ManifestSessionEnv" }
+        oauth_provider: { type: string }
+
+    ManifestPluginDefinitionField:
+      type: string
+      enum:
+        - name
+        - display_name
+        - description
+        - category
+        - prompt
+        - binaries
+        - skills
+        - session_env
+        - oauth_provider
+
+    SaveManifestPluginDefinitionRequest:
+      type: object
+      additionalProperties: false
+      required: [plugin]
+      properties:
+        plugin: { $ref: "#/components/schemas/ManifestPluginInput" }
+        fields:
+          type: array
+          description: Definition fields this request takes ownership of. Builtins only.
+          items: { $ref: "#/components/schemas/ManifestPluginDefinitionField" }
 
     ManifestOAuthProvider:
       type: object
@@ -50,6 +205,7 @@ components:
 
     ManifestPluginsResponse:
       type: object
+      required: [plugins, oauth_providers]
       properties:
         plugins:
           type: array

--- a/api/spec/domain/plugins/schemas.yaml
+++ b/api/spec/domain/plugins/schemas.yaml
@@ -55,6 +55,10 @@ components:
 
     ManifestSkill:
       type: object
+      deprecated: true
+      description: >
+        Reserved manifest declaration. Stella currently stores and returns skill
+        entries but does not install or register them at runtime.
       additionalProperties: false
       required: [repo, name]
       properties:
@@ -90,6 +94,10 @@ components:
           items: { $ref: "#/components/schemas/ManifestBinary" }
         skills:
           type: array
+          deprecated: true
+          description: >
+            Reserved declarations. They are stored and returned but are not
+            currently installed or registered at runtime.
           items: { $ref: "#/components/schemas/ManifestSkill" }
         session_env:
           type: array
@@ -119,6 +127,10 @@ components:
           items: { $ref: "#/components/schemas/ManifestBinary" }
         skills:
           type: array
+          deprecated: true
+          description: >
+            Reserved declarations. They are stored and returned but are not
+            currently installed or registered at runtime.
           items: { $ref: "#/components/schemas/ManifestSkill" }
         session_env:
           type: array
@@ -137,6 +149,10 @@ components:
 
     ManifestPluginInput:
       type: object
+      description: >
+        Submitted builtin plugin view. Only the definition fields named by the
+        sibling `fields` array are stored; all other values are context for
+        validation and remain unowned.
       additionalProperties: false
       properties:
         id:
@@ -163,6 +179,10 @@ components:
           items: { $ref: "#/components/schemas/ManifestBinary" }
         skills:
           type: array
+          deprecated: true
+          description: >
+            Reserved declarations. They are stored and returned but are not
+            currently installed or registered at runtime.
           items: { $ref: "#/components/schemas/ManifestSkill" }
         session_env:
           type: array
@@ -171,6 +191,9 @@ components:
 
     ManifestPluginDefinitionField:
       type: string
+      description: >
+        Editable definition field. `skills` is reserved: its value can be stored
+        and returned but is not currently installed or registered at runtime.
       enum:
         - name
         - display_name
@@ -182,16 +205,76 @@ components:
         - session_env
         - oauth_provider
 
-    SaveManifestPluginDefinitionRequest:
+    SaveBuiltinManifestPluginDefinitionRequest:
       type: object
       additionalProperties: false
-      required: [plugin]
+      required: [plugin, fields]
       properties:
         plugin: { $ref: "#/components/schemas/ManifestPluginInput" }
         fields:
           type: array
-          description: Definition fields this request takes ownership of. Builtins only.
+          description: Definition fields this request takes ownership of.
           items: { $ref: "#/components/schemas/ManifestPluginDefinitionField" }
+
+    ManifestPluginReplacement:
+      type: object
+      description: >
+        Complete replacement value for an admin-added plugin. Empty strings and
+        arrays explicitly clear optional definition fields.
+      additionalProperties: false
+      required:
+        - kind
+        - name
+        - display_name
+        - description
+        - enabled
+        - category
+        - essential
+        - prompt
+        - binaries
+        - skills
+        - session_env
+        - oauth_provider
+      properties:
+        id:
+          type: string
+          description: Ignored; the URL identifies the plugin.
+        kind: { type: string }
+        name: { type: string }
+        display_name: { type: string }
+        description: { type: string }
+        enabled: { type: boolean }
+        category: { type: string }
+        essential: { type: boolean }
+        prompt: { type: string }
+        binaries:
+          type: array
+          items: { $ref: "#/components/schemas/ManifestBinary" }
+        skills:
+          type: array
+          deprecated: true
+          description: >
+            Reserved declarations. They are stored and returned but are not
+            currently installed or registered at runtime.
+          items: { $ref: "#/components/schemas/ManifestSkill" }
+        session_env:
+          type: array
+          items: { $ref: "#/components/schemas/ManifestSessionEnv" }
+        oauth_provider: { type: string }
+
+    ReplaceCustomManifestPluginDefinitionRequest:
+      type: object
+      description: >
+        Full replacement for an admin-added plugin.
+      additionalProperties: false
+      required: [plugin]
+      properties:
+        plugin: { $ref: "#/components/schemas/ManifestPluginReplacement" }
+
+    SaveManifestPluginDefinitionRequest:
+      oneOf:
+        - $ref: "#/components/schemas/SaveBuiltinManifestPluginDefinitionRequest"
+        - $ref: "#/components/schemas/ReplaceCustomManifestPluginDefinitionRequest"
 
     ManifestOAuthProvider:
       type: object

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -722,6 +722,18 @@ components:
     ManifestPlugin: {
       $ref: "./components.yaml#/components/schemas/ManifestPlugin",
     }
+    ManifestPluginDefinition: {
+      $ref: "./components.yaml#/components/schemas/ManifestPluginDefinition",
+    }
+    ManifestPluginInput: {
+      $ref: "./components.yaml#/components/schemas/ManifestPluginInput",
+    }
+    ManifestPluginDefinitionField: {
+      $ref: "./components.yaml#/components/schemas/ManifestPluginDefinitionField",
+    }
+    SaveManifestPluginDefinitionRequest: {
+      $ref: "./components.yaml#/components/schemas/SaveManifestPluginDefinitionRequest",
+    }
     Goal: { $ref: "./components.yaml#/components/schemas/Goal" }
     GoalList: {
       $ref: "./components.yaml#/components/schemas/GoalList",

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -731,6 +731,15 @@ components:
     ManifestPluginDefinitionField: {
       $ref: "./components.yaml#/components/schemas/ManifestPluginDefinitionField",
     }
+    SaveBuiltinManifestPluginDefinitionRequest: {
+      $ref: "./components.yaml#/components/schemas/SaveBuiltinManifestPluginDefinitionRequest",
+    }
+    ManifestPluginReplacement: {
+      $ref: "./components.yaml#/components/schemas/ManifestPluginReplacement",
+    }
+    ReplaceCustomManifestPluginDefinitionRequest: {
+      $ref: "./components.yaml#/components/schemas/ReplaceCustomManifestPluginDefinitionRequest",
+    }
     SaveManifestPluginDefinitionRequest: {
       $ref: "./components.yaml#/components/schemas/SaveManifestPluginDefinitionRequest",
     }

--- a/internal/manifestplugins/loader.go
+++ b/internal/manifestplugins/loader.go
@@ -66,18 +66,10 @@ func resolvePlugin(rp rawManifestPlugin) ManifestPlugin {
 		enabled = *rp.Enabled
 	}
 	return ManifestPlugin{
-		ID:            rp.ID,
-		Kind:          rp.Kind,
-		Name:          rp.Name,
-		DisplayName:   rp.DisplayName,
-		Description:   rp.Description,
-		Enabled:       enabled,
-		Category:      rp.Category,
-		Essential:     rp.Essential,
-		Prompt:        rp.Prompt,
-		Binaries:      rp.Binaries,
-		Skills:        rp.Skills,
-		SessionEnvs:   rp.SessionEnvs,
-		OAuthProvider: rp.OAuthProvider,
+		ID:                       rp.ID,
+		Kind:                     rp.Kind,
+		Enabled:                  enabled,
+		Essential:                rp.Essential,
+		ManifestPluginDefinition: rp.ManifestPluginDefinition,
 	}
 }

--- a/internal/manifestplugins/override.go
+++ b/internal/manifestplugins/override.go
@@ -46,28 +46,11 @@ import (
 // deliberately not a ManifestPlugin field, so it can never collide with one.
 const sparseMarker = "$sparse"
 
-// definition is the customizable half of a ManifestPlugin. ID is the key, Enabled
-// is its own column, and Builtin is computed at resolve time — none of them are
-// part of what an admin edits, so none of them belong in the stored override.
-type definition struct {
-	Kind          string               `json:"kind"`
-	Name          string               `json:"name"`
-	DisplayName   string               `json:"display_name"`
-	Description   string               `json:"description"`
-	Category      string               `json:"category,omitempty"`
-	Essential     bool                 `json:"essential,omitempty"`
-	Prompt        string               `json:"prompt,omitempty"`
-	Binaries      []ManifestBinary     `json:"binaries,omitempty"`
-	Skills        []ManifestSkill      `json:"skills,omitempty"`
-	SessionEnvs   []ManifestSessionEnv `json:"session_env,omitempty"`
-	OAuthProvider string               `json:"oauth_provider,omitempty"`
-}
-
 // definitionFieldNames is every field the definition carries, in declaration
 // order. It is derived from the struct so a new field cannot be added without
 // being serialized, resettable, and reportable in the same edit.
 var definitionFieldNames = func() []string {
-	t := reflect.TypeFor[definition]()
+	t := reflect.TypeFor[ManifestPluginDefinition]()
 	names := make([]string, 0, t.NumField())
 	for i := range t.NumField() {
 		name, _, _ := strings.Cut(t.Field(i).Tag.Get("json"), ",")
@@ -78,67 +61,32 @@ var definitionFieldNames = func() []string {
 	return names
 }()
 
-// serverOwnedFields are definition fields an override may not take from the
-// server, even though an admin-added plugin still has to carry them.
-//
-// kind participates in the plugin's identity: the ID is prefixed with it, the
-// UI groups by it, and the runtime reloads tools and hooks separately, so an
-// override that disagreed would make three answers out of one question.
-// essential is policy — it is the server's statement that disabling this plugin
-// breaks Grep or Glob, and the disable check reads the shipped value, so letting
-// an override say otherwise only produced a UI that offered a switch the API
-// then refused.
-var serverOwnedFields = []string{"kind", "essential"}
-
 // IsOwnableField reports whether name is a definition field an override may own.
 func IsOwnableField(name string) bool {
-	return slices.Contains(definitionFieldNames, name) && !slices.Contains(serverOwnedFields, name)
+	return slices.Contains(definitionFieldNames, name)
 }
 
 // OwnableFields lists every field an override may own, in definition order.
 func OwnableFields() []string {
-	out := make([]string, 0, len(definitionFieldNames))
-	for _, name := range definitionFieldNames {
-		if IsOwnableField(name) {
-			out = append(out, name)
-		}
-	}
-	return out
-}
-
-func definitionOf(p ManifestPlugin) definition {
-	// Normalize empty slices to nil so omitempty produces stable JSON whether the
-	// source said null or [].
-	binaries, skills, envs := p.Binaries, p.Skills, p.SessionEnvs
-	if len(binaries) == 0 {
-		binaries = nil
-	}
-	if len(skills) == 0 {
-		skills = nil
-	}
-	if len(envs) == 0 {
-		envs = nil
-	}
-	return definition{
-		Kind:          p.Kind,
-		Name:          p.Name,
-		DisplayName:   p.DisplayName,
-		Description:   p.Description,
-		Category:      p.Category,
-		Essential:     p.Essential,
-		Prompt:        p.Prompt,
-		Binaries:      binaries,
-		Skills:        skills,
-		SessionEnvs:   envs,
-		OAuthProvider: p.OAuthProvider,
-	}
+	return slices.Clone(definitionFieldNames)
 }
 
 // DefinitionJSON serializes a plugin's whole definition. It is what an
 // admin-added plugin stores: there is no builtin underneath it to inherit from,
 // so the row is the plugin.
 func DefinitionJSON(p ManifestPlugin) (string, error) {
-	data, err := json.Marshal(definitionOf(p))
+	// Keep kind and essential in full snapshots. They are server-owned for a
+	// builtin, but an admin-added plugin has no shipped metadata underneath it.
+	stored := struct {
+		Kind      string `json:"kind"`
+		Essential bool   `json:"essential,omitempty"`
+		ManifestPluginDefinition
+	}{
+		Kind:                     p.Kind,
+		Essential:                p.Essential,
+		ManifestPluginDefinition: p.ManifestPluginDefinition,
+	}
+	data, err := json.Marshal(stored)
 	if err != nil {
 		return "", fmt.Errorf("marshal plugin definition %q: %w", p.ID, err)
 	}
@@ -146,7 +94,7 @@ func DefinitionJSON(p ManifestPlugin) (string, error) {
 }
 
 func definitionFields(p ManifestPlugin) (map[string]json.RawMessage, error) {
-	data, err := json.Marshal(definitionOf(p))
+	data, err := json.Marshal(p.ManifestPluginDefinition)
 	if err != nil {
 		return nil, fmt.Errorf("marshal plugin definition %q: %w", p.ID, err)
 	}
@@ -174,9 +122,8 @@ func ownedMap(override string) (map[string]json.RawMessage, error) {
 	}
 	if marker, ok := stored[sparseMarker]; ok && string(marker) == "true" {
 		delete(stored, sparseMarker)
-		for _, name := range serverOwnedFields {
-			delete(stored, name)
-		}
+		delete(stored, "kind")
+		delete(stored, "essential")
 		return stored, nil
 	}
 
@@ -194,9 +141,6 @@ func ownedMap(override string) (map[string]json.RawMessage, error) {
 	// plugin's policy at whatever it was the day someone renamed it.
 	owned := make(map[string]json.RawMessage, len(definitionFieldNames))
 	for _, name := range definitionFieldNames {
-		if !IsOwnableField(name) {
-			continue
-		}
 		if value, ok := present[name]; ok {
 			owned[name] = value
 			continue
@@ -314,15 +258,11 @@ func ApplyOverride(base ManifestPlugin, override string) (ManifestPlugin, error)
 	if err != nil {
 		return ManifestPlugin{}, fmt.Errorf("marshal merged plugin %q: %w", base.ID, err)
 	}
-	out := ManifestPlugin{}
-	if err := json.Unmarshal(data, &out); err != nil {
+	out := base
+	out.ManifestPluginDefinition = ManifestPluginDefinition{}
+	if err := json.Unmarshal(data, &out.ManifestPluginDefinition); err != nil {
 		return ManifestPlugin{}, fmt.Errorf("read merged plugin %q: %w", base.ID, err)
 	}
-	// The three fields a definition deliberately omits are the caller's, not the
-	// override's.
-	out.ID = base.ID
-	out.Enabled = base.Enabled
-	out.Builtin = base.Builtin
 	return out, nil
 }
 

--- a/internal/manifestplugins/override_test.go
+++ b/internal/manifestplugins/override_test.go
@@ -9,14 +9,16 @@ import (
 
 func builtinPlugin() ManifestPlugin {
 	return ManifestPlugin{
-		ID:          "tool/gh",
-		Kind:        "tool",
-		Name:        "gh",
-		DisplayName: "GitHub CLI",
-		Description: "the description that shipped",
-		Enabled:     true,
-		Prompt:      "use gh for GitHub",
-		Binaries:    []ManifestBinary{{Name: "gh", Tool: "github:cli/cli", Version: "latest"}},
+		ID:      "tool/gh",
+		Kind:    "tool",
+		Enabled: true,
+		ManifestPluginDefinition: ManifestPluginDefinition{
+			Name:        "gh",
+			DisplayName: "GitHub CLI",
+			Description: "the description that shipped",
+			Prompt:      "use gh for GitHub",
+			Binaries:    []ManifestBinary{{Name: "gh", Tool: "github:cli/cli", Version: "latest"}},
+		},
 	}
 }
 
@@ -258,11 +260,13 @@ func TestReleasingTheLastFieldEmptiesTheOverride(t *testing.T) {
 func legacySnapshot(t *testing.T) string {
 	t.Helper()
 	snapshot, err := DefinitionJSON(ManifestPlugin{
-		Kind:        "tool",
-		Name:        "gh",
-		DisplayName: "GitHub CLI",
-		Description: "pinned by an old row",
-		Binaries:    []ManifestBinary{{Name: "gh", Tool: "npm:gh"}},
+		Kind: "tool",
+		ManifestPluginDefinition: ManifestPluginDefinition{
+			Name:        "gh",
+			DisplayName: "GitHub CLI",
+			Description: "pinned by an old row",
+			Binaries:    []ManifestBinary{{Name: "gh", Tool: "npm:gh"}},
+		},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/manifestplugins/reconcile_test.go
+++ b/internal/manifestplugins/reconcile_test.go
@@ -17,13 +17,13 @@ func makeMinimalManifest(pluginID string, enabled bool, binaryName, version stri
 			{
 				ID:      pluginID,
 				Enabled: enabled,
-				Binaries: []ManifestBinary{
+				ManifestPluginDefinition: ManifestPluginDefinition{Binaries: []ManifestBinary{
 					{
 						Name:    binaryName,
 						Tool:    "github:owner/repo",
 						Version: version,
 					},
-				},
+				}},
 			},
 		},
 	}
@@ -152,35 +152,35 @@ func TestReconcile_EnabledCount(t *testing.T) {
 			{
 				ID:      "enabled-plugin",
 				Enabled: true,
-				Binaries: []ManifestBinary{
+				ManifestPluginDefinition: ManifestPluginDefinition{Binaries: []ManifestBinary{
 					{
 						Name:    "tool-a",
 						Tool:    "github:owner/tool-a",
 						Version: "0.1.0",
 					},
-				},
+				}},
 			},
 			{
 				ID:      "disabled-plugin-1",
 				Enabled: false,
-				Binaries: []ManifestBinary{
+				ManifestPluginDefinition: ManifestPluginDefinition{Binaries: []ManifestBinary{
 					{
 						Name:    "tool-b",
 						Tool:    "github:owner/tool-b",
 						Version: "1.0.0",
 					},
-				},
+				}},
 			},
 			{
 				ID:      "disabled-plugin-2",
 				Enabled: false,
-				Binaries: []ManifestBinary{
+				ManifestPluginDefinition: ManifestPluginDefinition{Binaries: []ManifestBinary{
 					{
 						Name:    "tool-c",
 						Tool:    "github:owner/tool-c",
 						Version: "3.0.0",
 					},
-				},
+				}},
 			},
 		},
 	}

--- a/internal/manifestplugins/types.go
+++ b/internal/manifestplugins/types.go
@@ -1,26 +1,29 @@
 package manifestplugins
 
-type ManifestPlugin struct {
-	ID          string `json:"id" yaml:"id"`
-	Kind        string `json:"kind" yaml:"kind"`
-	Name        string `json:"name" yaml:"name"`
-	DisplayName string `json:"display_name" yaml:"display_name"`
-	Description string `json:"description" yaml:"description"`
-	Enabled     bool   `json:"enabled" yaml:"enabled"`
-
-	// Category is a display-only hint for grouping in the settings UI
-	// ("system", "integration", "tool"). Empty means the UI derives a bucket
-	// from the plugin's signals (oauth → integration, hook → system, else tool).
-	Category string `json:"category,omitempty" yaml:"category,omitempty"`
-	// Essential marks a plugin the runtime depends on (e.g. rg/fd back the
-	// Grep/Glob tools); the UI guards against disabling it.
-	Essential bool `json:"essential,omitempty" yaml:"essential,omitempty"`
-
+// ManifestPluginDefinition is the editable definition of a manifest plugin.
+// Resource state and server-owned metadata live on ManifestPlugin instead.
+type ManifestPluginDefinition struct {
+	Name          string               `json:"name" yaml:"name"`
+	DisplayName   string               `json:"display_name" yaml:"display_name"`
+	Description   string               `json:"description" yaml:"description"`
+	Category      string               `json:"category,omitempty" yaml:"category,omitempty"`
 	Prompt        string               `json:"prompt,omitempty" yaml:"prompt,omitempty"`
 	Binaries      []ManifestBinary     `json:"binaries,omitempty" yaml:"binaries,omitempty"`
 	Skills        []ManifestSkill      `json:"skills,omitempty" yaml:"skills,omitempty"`
 	SessionEnvs   []ManifestSessionEnv `json:"session_env,omitempty" yaml:"session_env,omitempty"`
 	OAuthProvider string               `json:"oauth_provider,omitempty" yaml:"oauth_provider,omitempty"`
+}
+
+type ManifestPlugin struct {
+	ID      string `json:"id" yaml:"id"`
+	Kind    string `json:"kind" yaml:"kind"`
+	Enabled bool   `json:"enabled" yaml:"enabled"`
+
+	// Essential marks a plugin the runtime depends on (e.g. rg/fd back the
+	// Grep/Glob tools). It is shipped server policy, not editable definition.
+	Essential bool `json:"essential,omitempty" yaml:"essential,omitempty"`
+
+	ManifestPluginDefinition `yaml:",inline"`
 
 	// Builtin marks a plugin that ships with the server. It is computed when the
 	// manifest is resolved, never read from a manifest or an override: a builtin
@@ -88,19 +91,11 @@ type Manifest struct {
 }
 
 type rawManifestPlugin struct {
-	ID            string               `yaml:"id"`
-	Kind          string               `yaml:"kind"`
-	Name          string               `yaml:"name"`
-	DisplayName   string               `yaml:"display_name"`
-	Description   string               `yaml:"description"`
-	Enabled       *bool                `yaml:"enabled"`
-	Category      string               `yaml:"category,omitempty"`
-	Essential     bool                 `yaml:"essential,omitempty"`
-	Prompt        string               `yaml:"prompt,omitempty"`
-	Binaries      []ManifestBinary     `yaml:"binaries,omitempty"`
-	Skills        []ManifestSkill      `yaml:"skills,omitempty"`
-	SessionEnvs   []ManifestSessionEnv `yaml:"session_env,omitempty"`
-	OAuthProvider string               `yaml:"oauth_provider,omitempty"`
+	ID                       string `yaml:"id"`
+	Kind                     string `yaml:"kind"`
+	Enabled                  *bool  `yaml:"enabled"`
+	Essential                bool   `yaml:"essential,omitempty"`
+	ManifestPluginDefinition `yaml:",inline"`
 }
 
 type rawManifestOAuthFlow struct {

--- a/internal/manifestplugins/validate_test.go
+++ b/internal/manifestplugins/validate_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestValidate_NoID(t *testing.T) {
 	m := &Manifest{Plugins: []ManifestPlugin{
-		{Binaries: []ManifestBinary{{Name: "x", Tool: "github:a/b"}}},
+		{ManifestPluginDefinition: ManifestPluginDefinition{Binaries: []ManifestBinary{{Name: "x", Tool: "github:a/b"}}}},
 	}}
 	if err := Validate(m); err == nil {
 		t.Error("expected error for plugin with no ID")
@@ -25,8 +25,8 @@ func TestValidate_RequiresManifestContent(t *testing.T) {
 func TestValidate_BinaryNoTool(t *testing.T) {
 	m := &Manifest{Plugins: []ManifestPlugin{
 		{
-			ID:       "tool/x",
-			Binaries: []ManifestBinary{{Name: "x"}},
+			ID:                       "tool/x",
+			ManifestPluginDefinition: ManifestPluginDefinition{Binaries: []ManifestBinary{{Name: "x"}}},
 		},
 	}}
 	if err := Validate(m); err == nil {
@@ -37,8 +37,8 @@ func TestValidate_BinaryNoTool(t *testing.T) {
 func TestValidate_BinaryMiseRegistryTool(t *testing.T) {
 	m := &Manifest{Plugins: []ManifestPlugin{
 		{
-			ID:       "tool/uv",
-			Binaries: []ManifestBinary{{Name: "uv", Tool: "uv"}},
+			ID:                       "tool/uv",
+			ManifestPluginDefinition: ManifestPluginDefinition{Binaries: []ManifestBinary{{Name: "uv", Tool: "uv"}}},
 		},
 	}}
 	if err := Validate(m); err != nil {
@@ -49,8 +49,8 @@ func TestValidate_BinaryMiseRegistryTool(t *testing.T) {
 func TestValidate_LeavesToolKeysToMise(t *testing.T) {
 	m := &Manifest{Plugins: []ManifestPlugin{
 		{
-			ID:       "tool/x",
-			Binaries: []ManifestBinary{{Name: "x", Tool: "github:repo"}},
+			ID:                       "tool/x",
+			ManifestPluginDefinition: ManifestPluginDefinition{Binaries: []ManifestBinary{{Name: "x", Tool: "github:repo"}}},
 		},
 	}}
 	if err := Validate(m); err != nil {
@@ -62,8 +62,10 @@ func TestValidate_SessionEnvInvalidSource(t *testing.T) {
 	m := &Manifest{Plugins: []ManifestPlugin{
 		{
 			ID: "tool/x",
-			SessionEnvs: []ManifestSessionEnv{
-				{EnvVar: "MY_TOKEN", Source: "invalid_source"},
+			ManifestPluginDefinition: ManifestPluginDefinition{
+				SessionEnvs: []ManifestSessionEnv{
+					{EnvVar: "MY_TOKEN", Source: "invalid_source"},
+				},
 			},
 		},
 	}}

--- a/internal/pluginhost/capability_test.go
+++ b/internal/pluginhost/capability_test.go
@@ -190,7 +190,8 @@ func TestManifestPluginsReceiveNoPlatformCapabilities(t *testing.T) {
 		WithChannelRuntimeServices(NewChannelRuntimeServices()))
 	host.RegisterManifestPlugins(&manifestplugins.Manifest{
 		Plugins: []manifestplugins.ManifestPlugin{{
-			ID: "tool/manifest", Kind: "tool", Name: "manifest", Enabled: true, Prompt: "Use this tool.",
+			ID: "tool/manifest", Kind: "tool", Enabled: true,
+			ManifestPluginDefinition: manifestplugins.ManifestPluginDefinition{Name: "manifest", Prompt: "Use this tool."},
 		}},
 	})
 	if host.platform("tool/manifest").ChannelPlatform() != nil {

--- a/internal/pluginhost/host_test.go
+++ b/internal/pluginhost/host_test.go
@@ -361,8 +361,8 @@ func TestValidateRegistrationsAcceptsToolLifecycleOnly(t *testing.T) {
 func TestSessionPluginViewRegistersDisabledManifestPlugins(t *testing.T) {
 	host := New(&stubStore{plugins: map[string]config.Plugin{}})
 	host.RegisterManifestPlugins(&manifestplugins.Manifest{Plugins: []manifestplugins.ManifestPlugin{
-		{ID: "tool/xberg", Kind: "tool", Name: "xberg", Enabled: false, Binaries: []manifestplugins.ManifestBinary{{Name: "xberg", Tool: "github:xberg-io/xberg"}}},
-		{ID: "tool/enabled", Kind: "tool", Name: "enabled", Enabled: true, Prompt: "enabled"},
+		{ID: "tool/xberg", Kind: "tool", Enabled: false, ManifestPluginDefinition: manifestplugins.ManifestPluginDefinition{Name: "xberg", Binaries: []manifestplugins.ManifestBinary{{Name: "xberg", Tool: "github:xberg-io/xberg"}}}},
+		{ID: "tool/enabled", Kind: "tool", Enabled: true, ManifestPluginDefinition: manifestplugins.ManifestPluginDefinition{Name: "enabled", Prompt: "enabled"}},
 	}})
 
 	view, err := host.SessionPluginView(context.Background())
@@ -388,12 +388,14 @@ func TestValidateRegistrationsAcceptsCLIBackedPromptOnlyTool(t *testing.T) {
 	host.RegisterManifestPlugins(&manifestplugins.Manifest{
 		Plugins: []manifestplugins.ManifestPlugin{
 			{
-				ID:          "tool/mise",
-				Kind:        "tool",
-				Name:        "mise",
-				DisplayName: "mise",
-				Enabled:     enabled,
-				Prompt:      "Use mise to manage runtimes and tools.",
+				ID:      "tool/mise",
+				Kind:    "tool",
+				Enabled: enabled,
+				ManifestPluginDefinition: manifestplugins.ManifestPluginDefinition{
+					Name:        "mise",
+					DisplayName: "mise",
+					Prompt:      "Use mise to manage runtimes and tools.",
+				},
 			},
 		},
 	})
@@ -410,13 +412,15 @@ func TestManifestSessionEnvPropagatesOAuthProvider(t *testing.T) {
 		Plugins: []manifestplugins.ManifestPlugin{{
 			ID:      "tool/acme-cli",
 			Kind:    "tool",
-			Name:    "acme-cli",
 			Enabled: true,
-			SessionEnvs: []manifestplugins.ManifestSessionEnv{{
-				EnvVar: "ACME_ACCESS_TOKEN",
-				Source: "oauth.access_token",
-			}},
-			OAuthProvider: "acme",
+			ManifestPluginDefinition: manifestplugins.ManifestPluginDefinition{
+				Name: "acme-cli",
+				SessionEnvs: []manifestplugins.ManifestSessionEnv{{
+					EnvVar: "ACME_ACCESS_TOKEN",
+					Source: "oauth.access_token",
+				}},
+				OAuthProvider: "acme",
+			},
 		}},
 	}
 	host.RegisterManifestPlugins(manifest)

--- a/internal/server/oauth_test.go
+++ b/internal/server/oauth_test.go
@@ -46,36 +46,42 @@ func TestOAuthProviderRequiredBy(t *testing.T) {
 	host.RegisterManifestPlugins(&manifestplugins.Manifest{
 		Plugins: []manifestplugins.ManifestPlugin{
 			{
-				ID:            "tool/acme-exporter",
-				Kind:          "tool",
-				Name:          "acme-exporter",
-				DisplayName:   "Acme Exporter",
-				Enabled:       true,
-				OAuthProvider: "acme",
-				SessionEnvs: []manifestplugins.ManifestSessionEnv{
-					{EnvVar: "ACME_EXPORTER_TOKEN", Source: "oauth.access_token"},
-					{EnvVar: "ACME_EXPORTER_APP_ID", Source: "oauth.client_id"},
+				ID:      "tool/acme-exporter",
+				Kind:    "tool",
+				Enabled: true,
+				ManifestPluginDefinition: manifestplugins.ManifestPluginDefinition{
+					Name:          "acme-exporter",
+					DisplayName:   "Acme Exporter",
+					OAuthProvider: "acme",
+					SessionEnvs: []manifestplugins.ManifestSessionEnv{
+						{EnvVar: "ACME_EXPORTER_TOKEN", Source: "oauth.access_token"},
+						{EnvVar: "ACME_EXPORTER_APP_ID", Source: "oauth.client_id"},
+					},
 				},
 			},
 			{
-				ID:            "tool/gh",
-				Kind:          "tool",
-				Name:          "gh",
-				DisplayName:   "GitHub CLI",
-				Enabled:       true,
-				OAuthProvider: "github",
-				SessionEnvs: []manifestplugins.ManifestSessionEnv{
-					{EnvVar: "GH_TOKEN", Source: "oauth.access_token"},
+				ID:      "tool/gh",
+				Kind:    "tool",
+				Enabled: true,
+				ManifestPluginDefinition: manifestplugins.ManifestPluginDefinition{
+					Name:          "gh",
+					DisplayName:   "GitHub CLI",
+					OAuthProvider: "github",
+					SessionEnvs: []manifestplugins.ManifestSessionEnv{
+						{EnvVar: "GH_TOKEN", Source: "oauth.access_token"},
+					},
 				},
 			},
 			{
-				ID:            "tool/disabled",
-				Kind:          "tool",
-				Name:          "disabled",
-				Enabled:       false,
-				OAuthProvider: "acme",
-				SessionEnvs: []manifestplugins.ManifestSessionEnv{
-					{EnvVar: "X", Source: "oauth.access_token"},
+				ID:      "tool/disabled",
+				Kind:    "tool",
+				Enabled: false,
+				ManifestPluginDefinition: manifestplugins.ManifestPluginDefinition{
+					Name:          "disabled",
+					OAuthProvider: "acme",
+					SessionEnvs: []manifestplugins.ManifestSessionEnv{
+						{EnvVar: "X", Source: "oauth.access_token"},
+					},
 				},
 			},
 		},

--- a/web/manifest_fields_test.go
+++ b/web/manifest_fields_test.go
@@ -3,39 +3,51 @@ package web
 import (
 	"os"
 	"path/filepath"
-	"regexp"
 	"slices"
-	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/CherryHQ/stella/internal/manifestplugins"
 )
 
-// The editor names the definition fields a save takes ownership of, and the
-// server refuses any name it does not recognise. That makes a stray name a loud
-// 400 — but a *missing* one is silent: the field is edited, never claimed, and
-// goes back to following the shipped definition on the next upgrade, which is
-// the exact bug sparse overrides exist to prevent. Go derives its list from the
-// definition struct; the editor has to spell it out, so pin the two together.
-func TestEditorKnowsEveryOwnableDefinitionField(t *testing.T) {
-	source, err := os.ReadFile(filepath.Join("src", "features", "plugins", "pluginUtils.ts"))
+// The OpenAPI definition and field enum connect Go's ownership source to the
+// generated TypeScript types that the editor checks exhaustively. Keep that
+// chain intact so a new Go definition field cannot be editable but unownable.
+func TestManifestDefinitionFieldsStayInSyncWithOpenAPI(t *testing.T) {
+	source, err := os.ReadFile(filepath.Join("..", "api", "spec", "domain", "plugins", "schemas.yaml"))
 	if err != nil {
-		t.Fatalf("read pluginUtils.ts: %v", err)
+		t.Fatalf("read plugin schemas: %v", err)
 	}
-	block := regexp.MustCompile(`manifestPluginDefinitionFields\s*=\s*\[([^\]]*)\]`).FindSubmatch(source)
-	if block == nil {
-		t.Fatal("manifestPluginDefinitionFields not found in pluginUtils.ts")
+	var spec struct {
+		Components struct {
+			Schemas struct {
+				Definition struct {
+					Properties map[string]any `yaml:"properties"`
+				} `yaml:"ManifestPluginDefinition"`
+				Field struct {
+					Enum []string `yaml:"enum"`
+				} `yaml:"ManifestPluginDefinitionField"`
+			} `yaml:"schemas"`
+		} `yaml:"components"`
 	}
-	var editor []string
-	for _, quoted := range regexp.MustCompile(`"([^"]+)"`).FindAllSubmatch(block[1], -1) {
-		editor = append(editor, string(quoted[1]))
+	if err := yaml.Unmarshal(source, &spec); err != nil {
+		t.Fatalf("parse plugin schemas: %v", err)
 	}
 
-	server := manifestplugins.OwnableFields()
-	slices.Sort(editor)
-	slices.Sort(server)
-	if !slices.Equal(editor, server) {
-		t.Errorf("the editor claims ownership of %s, the server allows %s — a field the editor omits is edited but never owned",
-			strings.Join(editor, ","), strings.Join(server, ","))
+	properties := make([]string, 0, len(spec.Components.Schemas.Definition.Properties))
+	for name := range spec.Components.Schemas.Definition.Properties {
+		properties = append(properties, name)
+	}
+	fields := spec.Components.Schemas.Field.Enum
+	ownable := manifestplugins.OwnableFields()
+	slices.Sort(properties)
+	slices.Sort(fields)
+	slices.Sort(ownable)
+	if !slices.Equal(properties, ownable) {
+		t.Errorf("OpenAPI definition properties = %v, Go ownable fields = %v", properties, ownable)
+	}
+	if !slices.Equal(fields, ownable) {
+		t.Errorf("OpenAPI definition field enum = %v, Go ownable fields = %v", fields, ownable)
 	}
 }

--- a/web/src/features/plugins/CliToolPanel.tsx
+++ b/web/src/features/plugins/CliToolPanel.tsx
@@ -5,6 +5,7 @@ import type {
   ManifestBinary,
   ManifestOAuthProvider,
   ManifestPlugin,
+  ManifestPluginDefinitionField,
   ManifestSessionEnv,
   PluginWithMeta,
 } from "@/lib/types";
@@ -236,7 +237,7 @@ export function CliToolAddForm({ existingIds, onCreate, onCancel }: AddFormProps
 interface EditorProps {
   plugin: PluginWithMeta;
   oauthProviders: ManifestOAuthProvider[];
-  onSave: (next: ManifestPlugin, fields: string[]) => Promise<void>;
+  onSave: (next: ManifestPlugin, fields: ManifestPluginDefinitionField[]) => Promise<void>;
   onResetField: (field: string) => Promise<void>;
   resettingField: string | null;
   showToast: (message: string, type?: "success" | "error") => void;

--- a/web/src/features/plugins/PluginsPage.tsx
+++ b/web/src/features/plugins/PluginsPage.tsx
@@ -19,6 +19,7 @@ import type {
   ManifestBinary,
   ManifestOAuthProvider,
   ManifestPlugin,
+  ManifestPluginDefinitionField,
   Plugin,
   PluginSchemaProperty,
   PluginWithMeta,
@@ -310,10 +311,15 @@ export function PluginsPage() {
 
   // Save one definition and explicitly declare only the fields this edit takes
   // ownership of. Existing field ownership is retained by the backend.
-  async function upsertManifestPlugin(next: ManifestPlugin, fields: string[], successMsg: string) {
+  async function upsertManifestPlugin(
+    next: ManifestPlugin,
+    fields: ManifestPluginDefinitionField[],
+    successMsg: string,
+  ) {
+    const { builtin: _builtin, overridden_fields: _overriddenFields, ...plugin } = next;
     await saveManifestPluginDefinition({
       path: manifestPluginPath(next.id),
-      body: { plugin: { ...next }, fields },
+      body: { plugin, fields },
       throwOnError: true,
     });
     await loadManifestPlugins();
@@ -482,7 +488,7 @@ export function PluginsPage() {
 
         {p._manifest &&
           (pluginHasBinaries(p) ||
-            ["binaries", "session_env", "oauth_provider"].some((field) =>
+            (["binaries", "session_env", "oauth_provider"] as const).some((field) =>
               pluginFieldIsOverridden(p, field),
             )) && (
             <div className="border-t border-border pt-4 -mx-6 px-0">

--- a/web/src/features/plugins/PluginsPage.tsx
+++ b/web/src/features/plugins/PluginsPage.tsx
@@ -316,10 +316,20 @@ export function PluginsPage() {
     fields: ManifestPluginDefinitionField[],
     successMsg: string,
   ) {
-    const { builtin: _builtin, overridden_fields: _overriddenFields, ...plugin } = next;
+    const { builtin, overridden_fields: _overriddenFields, ...plugin } = next;
+    const replacement = {
+      ...plugin,
+      category: plugin.category ?? "",
+      essential: plugin.essential ?? false,
+      prompt: plugin.prompt ?? "",
+      binaries: plugin.binaries ?? [],
+      skills: plugin.skills ?? [],
+      session_env: plugin.session_env ?? [],
+      oauth_provider: plugin.oauth_provider ?? "",
+    };
     await saveManifestPluginDefinition({
       path: manifestPluginPath(next.id),
-      body: { plugin, fields },
+      body: builtin ? { plugin, fields } : { plugin: replacement },
       throwOnError: true,
     });
     await loadManifestPlugins();

--- a/web/src/features/plugins/pluginUtils.test.ts
+++ b/web/src/features/plugins/pluginUtils.test.ts
@@ -109,7 +109,7 @@ describe("changedManifestPluginFields", () => {
     expect(
       changedManifestPluginFields(initial, {
         ...initial,
-        binaries: [{ version: "1.0.0", tool: "github:example/x", name: "x", bin_path: undefined }],
+        binaries: [{ version: "1.0.0", tool: "github:example/x", name: "x", options: undefined }],
         session_env: [{ required: true, source: "static", env_var: "TOKEN" }],
       }),
     ).toEqual([]);

--- a/web/src/features/plugins/pluginUtils.ts
+++ b/web/src/features/plugins/pluginUtils.ts
@@ -1,5 +1,7 @@
 import type {
   ManifestPlugin,
+  ManifestPluginDefinition,
+  ManifestPluginDefinitionField,
   Plugin,
   PluginSchemaField,
   PluginSchemaProperty,
@@ -306,16 +308,18 @@ export function pluginIsCustomized(plugin: PluginWithMeta): boolean {
 
 // pluginFieldIsOverridden reports whether one builtin definition field is
 // pinned by an admin instead of following the value shipped by the server.
-export function pluginFieldIsOverridden(plugin: PluginWithMeta, field: string): boolean {
+export function pluginFieldIsOverridden(
+  plugin: PluginWithMeta,
+  field: ManifestPluginDefinitionField,
+): boolean {
   const manifest = plugin._manifestPlugin;
   return !!manifest?.builtin && !!manifest.overridden_fields?.includes(field);
 }
 
 // manifestPluginDefinitionFields is every field an override may take ownership
-// of, and must stay in step with the Go OwnableFields(); web/manifest_fields_test.go
-// pins the two lists together. `kind` and `essential` are the server's and are
-// deliberately absent: kind is part of the plugin's identity, and essential is
-// the server's statement about what breaks if the plugin is disabled.
+// of. The generated definition type below pins this runtime list to the OpenAPI
+// schema. `kind` and `essential` are deliberately absent because they belong to
+// the server rather than the editable definition.
 export const manifestPluginDefinitionFields = [
   "name",
   "display_name",
@@ -326,7 +330,25 @@ export const manifestPluginDefinitionFields = [
   "skills",
   "session_env",
   "oauth_provider",
-] as const;
+] as const satisfies readonly ManifestPluginDefinitionField[];
+
+// Keep the runtime comparison list exhaustive as the generated definition
+// grows; invalid and missing names are both compile errors.
+const manifestPluginDefinitionFieldsAreExhaustive: Exclude<
+  keyof ManifestPluginDefinition,
+  (typeof manifestPluginDefinitionFields)[number]
+> extends never
+  ? true
+  : never = true;
+void manifestPluginDefinitionFieldsAreExhaustive;
+
+const manifestPluginDefinitionFieldEnumIsExhaustive: Exclude<
+  ManifestPluginDefinitionField,
+  (typeof manifestPluginDefinitionFields)[number]
+> extends never
+  ? true
+  : never = true;
+void manifestPluginDefinitionFieldEnumIsExhaustive;
 
 function valuesEqual(left: unknown, right: unknown): boolean {
   if (Object.is(left, right)) return true;
@@ -375,7 +397,7 @@ function emptyAsAbsent(value: unknown): unknown {
 export function changedManifestPluginFields(
   initial: ManifestPlugin,
   next: ManifestPlugin,
-): string[] {
+): ManifestPluginDefinitionField[] {
   const initialRecord = initial as unknown as Record<string, unknown>;
   const nextRecord = next as unknown as Record<string, unknown>;
   return manifestPluginDefinitionFields.filter(

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -7,6 +7,9 @@ import type {
   ComponentsChannel,
   ComponentsIdentity,
   ComponentsJob,
+  ComponentsManifestPlugin,
+  ComponentsManifestPluginDefinition,
+  ComponentsManifestPluginDefinitionField,
   ComponentsOAuthFlowStatus,
   ComponentsOAuthProviderConfig,
   ComponentsOAuthProviderStatus,
@@ -20,6 +23,9 @@ import type {
   ComponentsUserMemory,
   ComponentsVaultEntry,
   JobRun,
+  ManifestBinary as SdkManifestBinary,
+  ManifestOAuthProvider as SdkManifestOAuthProvider,
+  ManifestSessionEnv as SdkManifestSessionEnv,
   Project as SdkProject,
   SessionWorkspace,
 } from "@/lib/api-client/types.gen";
@@ -185,46 +191,12 @@ export interface Personalisation {
   loaded: boolean;
 }
 
-export interface ManifestBinary {
-  name: string;
-  tool: string;
-  version?: string;
-  bin_path?: string;
-  bin?: string;
-}
-
-export interface ManifestSessionEnv {
-  env_var: string;
-  source: string;
-  value?: string;
-  required?: boolean;
-}
-
-export interface ManifestPlugin {
-  id: string;
-  kind: string;
-  name: string;
-  display_name: string;
-  description: string;
-  enabled: boolean;
-  category?: string;
-  essential?: boolean;
-  prompt?: string;
-  binaries?: ManifestBinary[];
-  session_env?: ManifestSessionEnv[];
-  oauth_provider?: string;
-  /** Ships with the server: it can be customized or disabled, never removed. */
-  builtin?: boolean;
-  /** Definition fields that no longer follow the server's builtin value. */
-  overridden_fields?: string[];
-}
-
-export interface ManifestOAuthProvider {
-  id: string;
-  scopes?: string[];
-  vault_key?: string;
-  client_id?: string;
-}
+export type ManifestBinary = SdkManifestBinary;
+export type ManifestSessionEnv = SdkManifestSessionEnv;
+export type ManifestPluginDefinition = ComponentsManifestPluginDefinition;
+export type ManifestPluginDefinitionField = ComponentsManifestPluginDefinitionField;
+export type ManifestPlugin = ComponentsManifestPlugin;
+export type ManifestOAuthProvider = SdkManifestOAuthProvider;
 
 export interface PluginSchema {
   properties?: Record<string, PluginSchemaProperty>;


### PR DESCRIPTION
## What

Split the editable manifest plugin definition from resource and resolved state, and replace the permissive manifest plugin OpenAPI object with concrete read and update schemas.

This PR stacks on #964 and targets its `963-sparse-plugin-override` branch.

## Why

`ManifestPlugin` previously mixed shipped/editable definition fields, resource state, and resolve-time fields. The override implementation therefore duplicated the definition shape and filtered server-owned fields at runtime, while OpenAPI exposed no useful field names or types.

## How

- Added an exported `ManifestPluginDefinition` containing exactly the fields an override may own, embedded it in the resolved `ManifestPlugin` view, and kept `kind`/`essential` as server-owned metadata.
- Derived serialization, ownership, reset, and reporting from that one Go definition type.
- Preserved sparse override and legacy full-snapshot storage semantics, including `$sparse`, absent-as-inherit, null-as-owned-empty, and stored `kind`/`essential` for admin-added full definitions.
- Added concrete OpenAPI schemas for manifest definitions, read views, update inputs, binaries, skills, and session environment entries; made update `fields` an enum.
- Switched the web manifest types to generated SDK types and replaced the source-regex parity guard with Go↔OpenAPI parity plus generated-TypeScript exhaustiveness checks.
- Kept runtime request decoding permissive for backward compatibility; this fills in the OpenAPI contract without introducing a user-visible behavior change.

## Test

- `mise run generate:api && mise run generate:ts-sdk`
- `mise exec -- vp check --fix`
- `mise exec -- vp test run src/features/plugins/pluginUtils.test.ts` — 13 passed
- `mise exec -- go test ./internal/manifestplugins ./web`
- `mise run format && mise run build && mise run test` — passed; all Go packages passed and 212 web tests passed

## Refs

Closes #967

Stacked on #964.

## Checklist

- [x] The PR links a GitHub issue.
- [x] I added or updated focused tests for changed non-trivial behavior, or explained why none are needed.
- [x] No documentation change is needed because this is a behavior-preserving internal refactor and schema fill-in.
- [x] I ran `mise run format && mise run build && mise run test`.
