### PR TITLE
📝 docs: Sync v0.63.3 release metadata to main

### DIFF
--- a/deploy/helm/stella/Chart.yaml
+++ b/deploy/helm/stella/Chart.yaml
@@ -8,7 +8,7 @@ version: 0.1.1
 # against. It is NOT the default image tag: the chart defaults image.tag to
 # "latest" (see stella.image / values.yaml) so a fresh install tracks the newest
 # published release. Pin image.tag or image.digest for reproducible deploys.
-appVersion: "v0.63.2"
+appVersion: "v0.63.3"
 home: https://stella.cherryin.com
 sources:
   - https://github.com/CherryHQ/stella

--- a/test/system/webhook_test.go
+++ b/test/system/webhook_test.go
@@ -125,8 +125,23 @@ func containsMessage(messages []string, want string) bool {
 		if strings.Contains(message, want) {
 			return true
 		}
+		start := strings.IndexByte(message, '{')
+		var envelope struct {
+			Content string `json:"content"`
+		}
+		if start >= 0 && json.Unmarshal([]byte(message[start:]), &envelope) == nil && strings.Contains(envelope.Content, want) {
+			return true
+		}
 	}
 	return false
+}
+
+func TestContainsMessageAcceptsInformationOnlyActorEnvelope(t *testing.T) {
+	const payload = `{"ref":"refs/heads/main"}`
+	envelope := "ts:1786432168\n" + `{"stella_actor":{"type":"agent","authority":"information_only"},"content":"{\"ref\":\"refs/heads/main\"}"}`
+	if !containsMessage([]string{envelope}, payload) {
+		t.Fatal("actor envelope did not preserve the webhook payload")
+	}
 }
 
 func (h *harness) createWebhookFakeProvider(t *testing.T, ctx context.Context, baseURL, suffix string) string {

--- a/web/content/docs/changelog.mdx
+++ b/web/content/docs/changelog.mdx
@@ -11,10 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.63.3] - 2026-08-11
+
 ### ✨ Features
 
+- Agents now use one bounded Session interface to find, inspect, create, and send to their own execution threads. Busy targets queue synchronously, message actors are persisted by the runtime, and nested calls enforce depth, ancestry, and inherited tool exclusions. ([#962](https://github.com/CherryHQ/stella/pull/962), [#958](https://github.com/CherryHQ/stella/issues/958))
 - Agents can now ask for additional OAuth permissions for one user on demand. A provider's configured scopes are the minimum every connection requests, each user's own added scopes are remembered across authorizations, and only that user re-authorizes — other connections are untouched. Requested, granted, and missing permissions are visible per connection, and a missing grant produces an actionable reconnect state. ([#978](https://github.com/CherryHQ/stella/pull/978), [#977](https://github.com/CherryHQ/stella/issues/977))
 - Lark and Feishu return as Stella-managed OAuth providers, with the bundled Lark CLI's full permission set recommended by default so one authorization covers its documented commands. Users connect from the Web UI or chat without host-shell access, and the app secret is never exposed to the agent or its sandbox. ([#978](https://github.com/CherryHQ/stella/pull/978), [#977](https://github.com/CherryHQ/stella/issues/977))
+
+### 🐛 Bug Fixes
+
+- An Agent's Channels tab now shows only channels bound to that Agent, removing cross-Agent bind and transfer actions from the Agent-scoped inventory while preserving channel creation, editing, account linking, and confirmed unbinding. ([#982](https://github.com/CherryHQ/stella/pull/982), [#981](https://github.com/CherryHQ/stella/issues/981))
+
+**Full Changelog**: [v0.63.2...v0.63.3](https://github.com/CherryHQ/stella/compare/v0.63.2...v0.63.3)
 
 ## [0.63.2] - 2026-08-09
 

--- a/web/content/docs/changelog.zh.mdx
+++ b/web/content/docs/changelog.zh.mdx
@@ -11,10 +11,19 @@ icon: History
 
 ## [Unreleased]
 
+## [0.63.3] - 2026-08-11
+
 ### ✨ Features
 
+- Agent 现在通过一个有边界的 Session 接口查找、检查、创建自己的执行线程并向其发送消息。繁忙目标会同步排队，消息 actor 由运行时持久化，嵌套调用则强制执行深度、祖先链和继承的工具排除规则。([#962](https://github.com/CherryHQ/stella/pull/962), [#958](https://github.com/CherryHQ/stella/issues/958))
 - Agent 现在可以按需为单个用户申请额外的 OAuth 权限。provider 配置的权限是每次连接至少请求的下限，用户自己追加的权限会跨授权保留，且只有该用户需要重新授权，其他人的连接不受影响。每个连接都能看到请求、已授予和缺失的权限，缺失时会给出可操作的重新连接提示。([#978](https://github.com/CherryHQ/stella/pull/978), [#977](https://github.com/CherryHQ/stella/issues/977))
 - Lark 和飞书重新成为 Stella 托管的 OAuth provider，默认推荐内置 Lark CLI 的完整权限集，一次授权即可覆盖其文档中的命令。用户在 Web UI 或聊天中即可完成连接，无需主机 shell 访问，App Secret 也不会暴露给 Agent 或沙盒。([#978](https://github.com/CherryHQ/stella/pull/978), [#977](https://github.com/CherryHQ/stella/issues/977))
+
+### 🐛 修复
+
+- Agent 的“渠道”标签页现在只显示绑定到该 Agent 的渠道，移除 Agent 范围清单中的跨 Agent 绑定和转移操作，同时保留渠道创建、编辑、账户关联和确认解绑。([#982](https://github.com/CherryHQ/stella/pull/982), [#981](https://github.com/CherryHQ/stella/issues/981))
+
+**完整变更记录**：[v0.63.2...v0.63.3](https://github.com/CherryHQ/stella/compare/v0.63.2...v0.63.3)
 
 ## [0.63.2] - 2026-08-09
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.63.2",
+  "version": "0.63.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## What

Sync the published v0.63.3 release metadata back to `main`:

- Web package version `0.63.3`
- Helm `appVersion: v0.63.3`
- synchronized English and Chinese v0.63.3 changelog entries
- the release-only GitHub webhook system assertion correction required by #962's information-only actor envelope

## Why

The maintained release line must not silently diverge from `main` after publication. The three product commits were already present on `main`; only release metadata and the test correction need syncing.

## How

Apply only the two release-line patches, preserving `main`'s current product history and existing `[Unreleased]` content.

## Test

- `mise run format`
- `mise run build`
- `mise run test` — all Go packages and 24 Web files / 244 tests passed
- `mise run system-test` — passed

## Refs

Refs #983

Published release: https://github.com/CherryHQ/stella/releases/tag/v0.63.3