### PR TITLE
🐛 fix: restore Lark CLI OAuth env after upgrade

### DIFF
--- a/internal/agent/sandbox/env.go
+++ b/internal/agent/sandbox/env.go
@@ -15,15 +15,6 @@ import (
 	pkgsandbox "github.com/CherryHQ/stella/pkg/sandbox"
 )
 
-const (
-	// LarkCLIConfigDirEnv points lark-cli at the user's shared CLI state so one
-	// native setup is available from all of that user's Agent workspaces.
-	LarkCLIConfigDirEnv = "LARKSUITE_CLI_CONFIG_DIR"
-	// LarkCLIDataDirEnv keeps lark-cli's keychain and tokens beside its shared
-	// user configuration instead of splitting native auth by Agent workspace.
-	LarkCLIDataDirEnv = "LARKSUITE_CLI_DATA_DIR"
-)
-
 func runnerFilesystemPolicy(paths Paths, cfg Config) pkgsandbox.FilesystemPolicy {
 	mounts := []pkgsandbox.Mount{
 		{HostPath: paths.WorkspaceRoot, SandboxPath: pkgsandbox.MountWorkspace, Access: pkgsandbox.MountReadWrite},
@@ -192,15 +183,6 @@ func buildSandboxEnv(ctx context.Context, cfg Config, paths Paths) (map[string]s
 	// Runtime files are session-scoped and must never be redirected into the
 	// persistent principal root (or accepted from a vault/session env entry).
 	delete(env, "XDG_RUNTIME_DIR")
-	// lark-cli is an ordinary user-managed CLI. Only redirect its persistent
-	// state into the shared personal directory because sandbox HOME remains the
-	// current Agent workspace. Group and user-less sessions must not inherit it.
-	if cfg.UserID != "" && cfg.GroupID == "" && paths.UserDataDir != "" {
-		larkCLIHome := filepath.Join(paths.UserDataDir, ".lark-cli")
-		env[LarkCLIConfigDirEnv] = larkCLIHome
-		env[LarkCLIDataDirEnv] = filepath.Join(larkCLIHome, "data")
-	}
-
 	// Every backend resolves tools through the same mise layout: the per-user
 	// writable tree ($STELLA_HOME/users/{id}/.mise-tools) over the shared system
 	// base, with the agent workspace trusted for a project mise.toml. The emitted

--- a/internal/agent/sandbox/env_test.go
+++ b/internal/agent/sandbox/env_test.go
@@ -98,50 +98,28 @@ func TestBuildSandboxEnvDropsVaultStellaToken(t *testing.T) {
 	}
 }
 
-func TestBuildSandboxEnvSharesLarkCLIStateAcrossUserAgents(t *testing.T) {
-	userData := "/stella/users/user-1/data"
+func TestBuildSandboxEnvDoesNotInjectLarkCLIStateDirs(t *testing.T) {
 	env, err := buildSandboxEnv(context.Background(), Config{UserID: "user-1"}, Paths{
 		WorkspaceRoot: "/stella/users/user-1/agents/agent-1",
-		UserDataDir:   userData,
+		UserDataDir:   "/stella/users/user-1/data",
 	})
 	if err != nil {
 		t.Fatalf("buildSandboxEnv: %v", err)
 	}
-	configDir := userData + "/.lark-cli"
-	if got := env[LarkCLIConfigDirEnv]; got != configDir {
-		t.Fatalf("%s = %q, want %q", LarkCLIConfigDirEnv, got, configDir)
-	}
-	if got := env[LarkCLIDataDirEnv]; got != configDir+"/data" {
-		t.Fatalf("%s = %q, want %q", LarkCLIDataDirEnv, got, configDir+"/data")
-	}
-
-	otherAgentEnv, err := buildSandboxEnv(context.Background(), Config{UserID: "user-1"}, Paths{
-		WorkspaceRoot: "/stella/users/user-1/agents/agent-2",
-		UserDataDir:   userData,
-	})
-	if err != nil {
-		t.Fatalf("buildSandboxEnv for second Agent: %v", err)
-	}
-	for _, key := range []string{LarkCLIConfigDirEnv, LarkCLIDataDirEnv} {
-		if otherAgentEnv[key] != env[key] {
-			t.Fatalf("%s differs across the user's Agents: %q vs %q", key, env[key], otherAgentEnv[key])
+	for _, key := range []string{"LARKSUITE_CLI_CONFIG_DIR", "LARKSUITE_CLI_DATA_DIR"} {
+		if value, ok := env[key]; ok {
+			t.Fatalf("retired lark-cli state override %s=%q must not be injected", key, value)
 		}
 	}
 }
 
-func TestBuildSandboxEnvDoesNotExposePersonalLarkCLIStateToGroups(t *testing.T) {
+func TestBuildSandboxEnvDoesNotRenderFilesystemRootsForGroups(t *testing.T) {
 	env, err := buildSandboxEnv(context.Background(), Config{GroupID: "group-1"}, Paths{
 		WorkspaceRoot: "/stella/users/group-group-1/agents/agent-1",
 		UserDataDir:   "/stella/users/group-group-1/data",
 	})
 	if err != nil {
 		t.Fatalf("buildSandboxEnv: %v", err)
-	}
-	if _, ok := env[LarkCLIConfigDirEnv]; ok {
-		t.Fatalf("%s must not be set for a group session", LarkCLIConfigDirEnv)
-	}
-	if _, ok := env[LarkCLIDataDirEnv]; ok {
-		t.Fatalf("%s must not be set for a group session", LarkCLIDataDirEnv)
 	}
 	// Filesystem roots are rendered only by the selected backend after it knows
 	// its actual mounts; the runner baseline must not guess the group view.

--- a/internal/db/database_test.go
+++ b/internal/db/database_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"encoding/json"
 	"io/fs"
 	"strings"
 	"testing"
@@ -11,6 +12,8 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/pressly/goose/v3"
+
+	"github.com/CherryHQ/stella/internal/manifestplugins"
 )
 
 func TestOpenDBFreshInstallDoesNotCreateFeishuTokensTable(t *testing.T) {
@@ -20,6 +23,130 @@ func TestOpenDBFreshInstallDoesNotCreateFeishuTokensTable(t *testing.T) {
 
 	if tableExists(t, db, "feishu_tokens") {
 		t.Fatal("feishu_tokens table should not exist after fresh install migrations")
+	}
+}
+
+func TestLarkCLIOverrideRepairMigration(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	sub, err := fs.Sub(MigrationsFS, "migrations")
+	if err != nil {
+		t.Fatalf("open migrations fs: %v", err)
+	}
+	sqlDB := stdlib.OpenDBFromPool(db)
+	defer func() { _ = sqlDB.Close() }()
+	provider, err := goose.NewProvider(goose.DialectPostgres, sqlDB, sub)
+	if err != nil {
+		t.Fatalf("create migration provider: %v", err)
+	}
+	if _, err := provider.DownTo(ctx, sequentialAnchor+10); err != nil {
+		t.Fatalf("goose down lark-cli override repair: %v", err)
+	}
+
+	legacy := `{"name":"custom-lark","prompt":"custom prompt","custom":"keep"}`
+	if _, err := db.Exec(ctx, `INSERT INTO plugin_override (plugin_id, enabled, config) VALUES ('tool/lark-cli', true, $1)`, legacy); err != nil {
+		t.Fatalf("seed legacy lark-cli override: %v", err)
+	}
+	if _, err := provider.UpTo(ctx, sequentialAnchor+11); err != nil {
+		t.Fatalf("goose up lark-cli override repair: %v", err)
+	}
+
+	var repaired string
+	if err := db.QueryRow(ctx, `SELECT config FROM plugin_override WHERE plugin_id = 'tool/lark-cli'`).Scan(&repaired); err != nil {
+		t.Fatalf("read repaired lark-cli override: %v", err)
+	}
+	var fields map[string]any
+	if err := json.Unmarshal([]byte(repaired), &fields); err != nil {
+		t.Fatalf("decode repaired lark-cli override: %v", err)
+	}
+	if fields["$sparse"] != true || fields["name"] != "custom-lark" || fields["prompt"] != "custom prompt" || fields["custom"] != "keep" {
+		t.Fatalf("repaired override = %s, want sparse marker and preserved custom fields", repaired)
+	}
+	for _, field := range []string{"display_name", "description", "category", "binaries", "skills"} {
+		if value, ok := fields[field]; !ok || value != nil {
+			t.Fatalf("repaired override field %q = %#v, want explicit null to preserve the legacy snapshot", field, value)
+		}
+	}
+	for _, released := range []string{"oauth_provider", "session_env"} {
+		if _, ok := fields[released]; ok {
+			t.Fatalf("repaired override still owns %q: %s", released, repaired)
+		}
+	}
+
+	builtin, err := manifestplugins.LoadBuiltin()
+	if err != nil {
+		t.Fatalf("load builtin manifest: %v", err)
+	}
+	resolved := manifestplugins.Resolve(builtin, []manifestplugins.StoredOverride{{
+		PluginID: "tool/lark-cli",
+		Config:   repaired,
+	}}, nil)
+	var larkPlugin *manifestplugins.ManifestPlugin
+	for i := range resolved.Plugins {
+		if resolved.Plugins[i].ID == "tool/lark-cli" {
+			larkPlugin = &resolved.Plugins[i]
+			break
+		}
+	}
+	if larkPlugin == nil {
+		t.Fatal("repaired manifest has no tool/lark-cli plugin")
+	}
+	if larkPlugin.OAuthProvider != "feishu" {
+		t.Fatalf("repaired Lark OAuth provider = %q, want feishu", larkPlugin.OAuthProvider)
+	}
+	gotSessionEnvs := make(map[string]string, len(larkPlugin.SessionEnvs))
+	for _, spec := range larkPlugin.SessionEnvs {
+		gotSessionEnvs[spec.EnvVar] = spec.Source
+	}
+	wantSessionEnvs := map[string]string{
+		"LARKSUITE_CLI_USER_ACCESS_TOKEN": "oauth.access_token",
+		"LARKSUITE_CLI_APP_ID":            "oauth.client_id",
+		"LARKSUITE_CLI_BRAND":             "oauth.brand",
+	}
+	for envVar, source := range wantSessionEnvs {
+		if gotSessionEnvs[envVar] != source {
+			t.Fatalf("repaired Lark session env %s = %q, want %q", envVar, gotSessionEnvs[envVar], source)
+		}
+	}
+	if _, exposed := gotSessionEnvs["LARKSUITE_CLI_APP_SECRET"]; exposed {
+		t.Fatal("repaired Lark session envs expose the OAuth app secret")
+	}
+
+	if _, err := provider.DownTo(ctx, sequentialAnchor+10); err != nil {
+		t.Fatalf("goose down lark-cli override repair for inherited prompt case: %v", err)
+	}
+	withoutPrompt := `{"name":"lark-cli"}`
+	if _, err := db.Exec(ctx, `UPDATE plugin_override SET config = $1 WHERE plugin_id = 'tool/lark-cli'`, withoutPrompt); err != nil {
+		t.Fatalf("seed lark-cli override without prompt: %v", err)
+	}
+	if _, err := provider.UpTo(ctx, sequentialAnchor+11); err != nil {
+		t.Fatalf("goose up lark-cli override repair for inherited prompt case: %v", err)
+	}
+	var promptReleased bool
+	if err := db.QueryRow(ctx, `SELECT NOT (config::jsonb ? 'prompt') FROM plugin_override WHERE plugin_id = 'tool/lark-cli'`).Scan(&promptReleased); err != nil {
+		t.Fatalf("read repaired lark-cli prompt ownership: %v", err)
+	}
+	if !promptReleased {
+		t.Fatal("migration prevented the lark-cli override from inheriting the managed OAuth prompt")
+	}
+
+	if _, err := provider.DownTo(ctx, sequentialAnchor+10); err != nil {
+		t.Fatalf("goose down lark-cli override repair for sparse case: %v", err)
+	}
+	sparse := `{"$sparse":true,"oauth_provider":"lark","session_env":[],"prompt":"intentional"}`
+	if _, err := db.Exec(ctx, `UPDATE plugin_override SET config = $1 WHERE plugin_id = 'tool/lark-cli'`, sparse); err != nil {
+		t.Fatalf("seed sparse lark-cli override: %v", err)
+	}
+	if _, err := provider.UpTo(ctx, sequentialAnchor+11); err != nil {
+		t.Fatalf("goose up lark-cli override repair for sparse case: %v", err)
+	}
+	var sparsePreserved bool
+	if err := db.QueryRow(ctx, `SELECT config::jsonb = $1::jsonb FROM plugin_override WHERE plugin_id = 'tool/lark-cli'`, sparse).Scan(&sparsePreserved); err != nil {
+		t.Fatalf("read sparse lark-cli override: %v", err)
+	}
+	if !sparsePreserved {
+		t.Fatal("migration changed an intentional sparse lark-cli override")
 	}
 }
 

--- a/internal/db/migrations/90000000000011_repair_lark_cli_oauth_override.sql
+++ b/internal/db/migrations/90000000000011_repair_lark_cli_oauth_override.sql
@@ -1,0 +1,31 @@
+-- +goose Up
+-- The #807 cleanup removed managed OAuth fields from tool/lark-cli overrides,
+-- but legacy whole-definition rows interpret omitted fields as owned and empty.
+-- Convert those cleaned rows to sparse overrides: preserve the legacy snapshot
+-- for unrelated editable fields, while letting the restored builtin provider,
+-- session env, and managed prompt flow through when #807 removed them.
+UPDATE plugin_override
+SET config = (
+    '{
+        "$sparse": true,
+        "name": null,
+        "display_name": null,
+        "description": null,
+        "category": null,
+        "binaries": null,
+        "skills": null
+    }'::jsonb
+    || (config::jsonb - 'id' - 'kind' - 'enabled' - 'essential' - 'builtin' - 'overridden_fields')
+)::text,
+updated_at = now()
+WHERE plugin_id = 'tool/lark-cli'
+  AND btrim(config) <> ''
+  AND NOT (config::jsonb ? '$sparse')
+  AND NOT (config::jsonb ? 'oauth_provider')
+  AND NOT (config::jsonb ? 'session_env');
+
+-- +goose Down
+-- Irreversible compatibility repair: the legacy row did not record which
+-- omitted fields were intentionally empty, so restoring that ambiguity would
+-- break managed OAuth again.
+SELECT 1;

--- a/internal/db/previous_ga_migration_test.go
+++ b/internal/db/previous_ga_migration_test.go
@@ -28,7 +28,7 @@ const (
 	// session activity, per-message actor provenance and summary authority,
 	// the durable Session inbox, and restrictive Library ownership are the
 	// post-anchor migrations exercised below.
-	currentMigrationVersion = sequentialAnchor + 10
+	currentMigrationVersion = sequentialAnchor + 11
 
 	previousGAUserID           = "00000000-0000-0000-0000-000000000001"
 	previousGAGroupID          = "00000000-0000-0000-0000-000000000002"
@@ -304,16 +304,18 @@ func assertPreviousGAUpgrade(t *testing.T, ctx context.Context, db *pgxpool.Pool
 	if got := count("custom OAuth provider", `SELECT count(*) FROM plugin_oauth_provider WHERE provider_id = 'custom'`); got != 1 {
 		t.Fatalf("custom OAuth providers = %d, want 1", got)
 	}
-	var larkClean, larkCustom, unrelatedPreserved bool
+	var larkClean, larkSparse, larkSnapshotPreserved, larkCustom, unrelatedPreserved bool
 	if err := db.QueryRow(ctx, `
 		SELECT NOT (config::jsonb ? 'oauth_provider') AND NOT (config::jsonb ? 'session_env'),
+		       config::jsonb @> '{"$sparse": true}',
+		       config::jsonb->'name' = 'null'::jsonb AND config::jsonb->'binaries' = 'null'::jsonb,
 		       config::jsonb->>'prompt' = 'custom prompt' AND config::jsonb->>'custom' = 'keep' AND session_env_vault_key = 'custom-vault-key',
 		       EXISTS (SELECT 1 FROM plugin_override WHERE plugin_id = 'tool/custom' AND enabled = false AND config::jsonb->>'custom' = 'untouched')
-		FROM plugin_override WHERE plugin_id = 'tool/lark-cli'`).Scan(&larkClean, &larkCustom, &unrelatedPreserved); err != nil {
+		FROM plugin_override WHERE plugin_id = 'tool/lark-cli'`).Scan(&larkClean, &larkSparse, &larkSnapshotPreserved, &larkCustom, &unrelatedPreserved); err != nil {
 		t.Fatalf("read cleaned Lark override: %v", err)
 	}
-	if !larkClean || !larkCustom || !unrelatedPreserved {
-		t.Fatalf("Lark cleanup = fields removed %v, custom preserved %v, unrelated preserved %v; want true, true, true", larkClean, larkCustom, unrelatedPreserved)
+	if !larkClean || !larkSparse || !larkSnapshotPreserved || !larkCustom || !unrelatedPreserved {
+		t.Fatalf("Lark cleanup = fields removed %v, sparse %v, snapshot preserved %v, custom preserved %v, unrelated preserved %v; want all true", larkClean, larkSparse, larkSnapshotPreserved, larkCustom, unrelatedPreserved)
 	}
 	if got := count("deleted sandbox plugins", `SELECT count(*) FROM plugin WHERE id LIKE 'sandbox/%'`); got != 0 {
 		t.Fatalf("sandbox plugin rows = %d, want 0", got)

--- a/plugins/sandbox/docker/environment.go
+++ b/plugins/sandbox/docker/environment.go
@@ -51,8 +51,6 @@ var dockerEnvKinds = map[string]dockerEnvKind{
 	sandboxpkg.EnvXDGStateHome:    dockerEnvHostPath,
 	sandboxpkg.EnvXDGCacheHome:    dockerEnvHostPath,
 	"STELLA_HOME":                 dockerEnvHostPath,
-	"LARKSUITE_CLI_CONFIG_DIR":    dockerEnvHostPath,
-	"LARKSUITE_CLI_DATA_DIR":      dockerEnvHostPath,
 	"MISE_DATA_DIR":               dockerEnvHostPath,
 	"MISE_CONFIG_DIR":             dockerEnvHostPath,
 	"MISE_CACHE_DIR":              dockerEnvHostPath,

--- a/plugins/sandbox/docker/host_test.go
+++ b/plugins/sandbox/docker/host_test.go
@@ -211,23 +211,21 @@ func TestTranslateEnvPaths(t *testing.T) {
 	}
 
 	env := map[string]string{
-		"PATH":                     "/host/tools/bin:/usr/bin", // host-only — should drop
-		"STELLA_USER_DIR":          "/host/data",               // removed — always drop
-		"HOME":                     "/host/workspace",          // mounted — should translate
-		"XDG_CONFIG_HOME":          "/host/data/.config",
-		"XDG_DATA_HOME":            "/host/data/.local/share",
-		"XDG_STATE_HOME":           "/host/data/.local/state",
-		"XDG_CACHE_HOME":           "/host/data/.cache",
-		"STELLA_HOME":              "/host/.stella",     // envMap — should translate
-		"STELLA_ASSETS_DIR":        "/host/data/assets", // mounted at /user — should translate
-		"TMPDIR":                   "/host/tmp",         // mounted at /tmp — should translate
-		"WORKING_DIR":              "/host/workspace",   // unknown key — absolute-looking literal
-		"ABSOLUTE_SECRET":          "/host/secret",      // unknown key — must remain literal
-		"MISE_CACHE_DIR":           "/outside/cache",    // declared path — unmapped, so drop
-		"LARKSUITE_CLI_CONFIG_DIR": "/host/data/.lark-cli",
-		"LARKSUITE_CLI_DATA_DIR":   "/host/data/.lark-cli/data",
-		"TERM":                     "xterm-256color", // non-path — pass through
-		"LANG":                     "en_US.UTF-8",    // non-path — pass through
+		"PATH":              "/host/tools/bin:/usr/bin", // host-only — should drop
+		"STELLA_USER_DIR":   "/host/data",               // removed — always drop
+		"HOME":              "/host/workspace",          // mounted — should translate
+		"XDG_CONFIG_HOME":   "/host/data/.config",
+		"XDG_DATA_HOME":     "/host/data/.local/share",
+		"XDG_STATE_HOME":    "/host/data/.local/state",
+		"XDG_CACHE_HOME":    "/host/data/.cache",
+		"STELLA_HOME":       "/host/.stella",     // envMap — should translate
+		"STELLA_ASSETS_DIR": "/host/data/assets", // mounted at /user — should translate
+		"TMPDIR":            "/host/tmp",         // mounted at /tmp — should translate
+		"WORKING_DIR":       "/host/workspace",   // unknown key — absolute-looking literal
+		"ABSOLUTE_SECRET":   "/host/secret",      // unknown key — must remain literal
+		"MISE_CACHE_DIR":    "/outside/cache",    // declared path — unmapped, so drop
+		"TERM":              "xterm-256color",    // non-path — pass through
+		"LANG":              "en_US.UTF-8",       // non-path — pass through
 	}
 
 	got := translateEnvPaths(env, mounts, envMaps)
@@ -265,12 +263,6 @@ func TestTranslateEnvPaths(t *testing.T) {
 	}
 	if _, ok := got["MISE_CACHE_DIR"]; ok {
 		t.Errorf("unmapped declared host path must be dropped, got %q", got["MISE_CACHE_DIR"])
-	}
-	if got["LARKSUITE_CLI_CONFIG_DIR"] != "/user/.lark-cli" {
-		t.Errorf("LARKSUITE_CLI_CONFIG_DIR: got %q, want /user/.lark-cli", got["LARKSUITE_CLI_CONFIG_DIR"])
-	}
-	if got["LARKSUITE_CLI_DATA_DIR"] != "/user/.lark-cli/data" {
-		t.Errorf("LARKSUITE_CLI_DATA_DIR: got %q, want /user/.lark-cli/data", got["LARKSUITE_CLI_DATA_DIR"])
 	}
 	if got["TERM"] != "xterm-256color" {
 		t.Errorf("TERM: got %q, want xterm-256color", got["TERM"])

--- a/plugins/sandbox/local/session.go
+++ b/plugins/sandbox/local/session.go
@@ -146,13 +146,6 @@ func (f *Factory) adjustPolicy(policy sandboxpkg.Policy, sandboxRoot, realRoot, 
 	}
 	env["PATH"] = sandboxpkg.HostEnvBuildPath(sandboxSH, userShims)
 	env["STELLA_HOME"] = sandboxSH
-	// lark-cli's native config and token store live under the user's shared data
-	// root. Rewrite their host paths to the /user sandbox view.
-	for _, key := range []string{"LARKSUITE_CLI_CONFIG_DIR", "LARKSUITE_CLI_DATA_DIR"} {
-		if value := env[key]; value != "" {
-			env[key] = remapMise(value)
-		}
-	}
 	// Rewrite MISE_* path-valued env vars to the agent's view (see remapMise): both
 	// the per-user tree and the system tree land under the sandbox STELLA_HOME, so
 	// their host-relative seed/shim symlinks resolve identically in the sandbox.

--- a/plugins/sandbox/local/session_test.go
+++ b/plugins/sandbox/local/session_test.go
@@ -823,8 +823,6 @@ func TestAdjustPolicy_perUserMiseInStellaHomeFrame(t *testing.T) {
 			"MISE_CACHE_DIR":            miseHome + "/cache",
 			"MISE_GLOBAL_CONFIG_FILE":   hostSH + "/.mise-tools/configs/_builtin.toml",
 			"MISE_TRUSTED_CONFIG_PATHS": hostSH + "/.mise-tools/configs/_builtin.toml:/workspace:" + agentDir,
-			"LARKSUITE_CLI_CONFIG_DIR":  userData + "/.lark-cli",
-			"LARKSUITE_CLI_DATA_DIR":    userData + "/.lark-cli/data",
 		},
 	}
 	f := &Factory{cfg: Config{StellaHome: hostSH}}
@@ -840,8 +838,6 @@ func TestAdjustPolicy_perUserMiseInStellaHomeFrame(t *testing.T) {
 		{"MISE_CACHE_DIR", sandboxSH + "/users/u1/.mise-tools/cache"},
 		{"MISE_GLOBAL_CONFIG_FILE", sandboxSH + "/.mise-tools/configs/_builtin.toml"},
 		{"MISE_TRUSTED_CONFIG_PATHS", sandboxSH + "/.mise-tools/configs/_builtin.toml:/workspace"},
-		{"LARKSUITE_CLI_CONFIG_DIR", "/user/.lark-cli"},
-		{"LARKSUITE_CLI_DATA_DIR", "/user/.lark-cli/data"},
 	} {
 		if got := adjusted.Env[tc.key]; got != tc.want {
 			t.Errorf("env[%s] = %q, want %q", tc.key, got, tc.want)

--- a/web/content/docs/changelog.mdx
+++ b/web/content/docs/changelog.mdx
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🐛 Bug Fixes
 
-- Upgraded deployments now restore Stella-managed Lark/Feishu credentials to new `lark-cli` sessions instead of letting a legacy plugin override hide the token, App ID, and brand environment variables. ([#986](https://github.com/CherryHQ/stella/issues/986))
+- Upgraded deployments now restore Stella-managed Lark/Feishu credentials to new `lark-cli` sessions instead of letting a legacy plugin override hide the token, App ID, and brand environment variables. ([#987](https://github.com/CherryHQ/stella/pull/987), [#986](https://github.com/CherryHQ/stella/issues/986))
 
 ## [0.63.3] - 2026-08-11
 

--- a/web/content/docs/changelog.mdx
+++ b/web/content/docs/changelog.mdx
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🐛 Bug Fixes
+
+- Upgraded deployments now restore Stella-managed Lark/Feishu credentials to new `lark-cli` sessions instead of letting a legacy plugin override hide the token, App ID, and brand environment variables. ([#986](https://github.com/CherryHQ/stella/issues/986))
+
 ## [0.63.3] - 2026-08-11
 
 ### ✨ Features

--- a/web/content/docs/changelog.mdx
+++ b/web/content/docs/changelog.mdx
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🐛 Bug Fixes
 
-- Upgraded deployments now restore Stella-managed Lark/Feishu credentials to new `lark-cli` sessions instead of letting a legacy plugin override hide the token, App ID, and brand environment variables. ([#987](https://github.com/CherryHQ/stella/pull/987), [#986](https://github.com/CherryHQ/stella/issues/986))
+- Upgraded deployments now restore Stella-managed Lark/Feishu credentials to new `lark-cli` sessions instead of letting a legacy plugin override hide the token, App ID, and brand environment variables. Stella also stops forcing the retired user-managed CLI config and data directories. ([#987](https://github.com/CherryHQ/stella/pull/987), [#986](https://github.com/CherryHQ/stella/issues/986))
 
 ## [0.63.3] - 2026-08-11
 

--- a/web/content/docs/changelog.zh.mdx
+++ b/web/content/docs/changelog.zh.mdx
@@ -13,7 +13,7 @@ icon: History
 
 ### 🐛 修复
 
-- 升级后的部署现在会向新的 `lark-cli` session 恢复 Stella 托管的 Lark/飞书凭据，不再因旧插件 override 而隐藏 token、App ID 和品牌环境变量。([#987](https://github.com/CherryHQ/stella/pull/987), [#986](https://github.com/CherryHQ/stella/issues/986))
+- 升级后的部署现在会向新的 `lark-cli` session 恢复 Stella 托管的 Lark/飞书凭据，不再因旧插件 override 而隐藏 token、App ID 和品牌环境变量；Stella 也不再强制设置已退役的用户自管理 CLI 配置和数据目录。([#987](https://github.com/CherryHQ/stella/pull/987), [#986](https://github.com/CherryHQ/stella/issues/986))
 
 ## [0.63.3] - 2026-08-11
 

--- a/web/content/docs/changelog.zh.mdx
+++ b/web/content/docs/changelog.zh.mdx
@@ -11,6 +11,10 @@ icon: History
 
 ## [Unreleased]
 
+### 🐛 修复
+
+- 升级后的部署现在会向新的 `lark-cli` session 恢复 Stella 托管的 Lark/飞书凭据，不再因旧插件 override 而隐藏 token、App ID 和品牌环境变量。([#986](https://github.com/CherryHQ/stella/issues/986))
+
 ## [0.63.3] - 2026-08-11
 
 ### ✨ Features

--- a/web/content/docs/changelog.zh.mdx
+++ b/web/content/docs/changelog.zh.mdx
@@ -13,7 +13,7 @@ icon: History
 
 ### 🐛 修复
 
-- 升级后的部署现在会向新的 `lark-cli` session 恢复 Stella 托管的 Lark/飞书凭据，不再因旧插件 override 而隐藏 token、App ID 和品牌环境变量。([#986](https://github.com/CherryHQ/stella/issues/986))
+- 升级后的部署现在会向新的 `lark-cli` session 恢复 Stella 托管的 Lark/飞书凭据，不再因旧插件 override 而隐藏 token、App ID 和品牌环境变量。([#987](https://github.com/CherryHQ/stella/pull/987), [#986](https://github.com/CherryHQ/stella/issues/986))
 
 ## [0.63.3] - 2026-08-11
 


### PR DESCRIPTION
## What

- add a forward-only migration that converts legacy `tool/lark-cli` overrides left by #807 into sparse overrides
- release only the managed OAuth provider, session env, and removed built-in prompt fields while preserving unrelated legacy customizations
- verify the resolved built-in manifest restores `LARKSUITE_CLI_USER_ACCESS_TOKEN`, `LARKSUITE_CLI_APP_ID`, and `LARKSUITE_CLI_BRAND` without exposing the App Secret
- preserve sparse overrides that intentionally own OAuth fields
- stop injecting the retired `LARKSUITE_CLI_CONFIG_DIR` and `LARKSUITE_CLI_DATA_DIR` variables and remove their local/Docker path rewriting
- document the upgrade fix in English and Chinese

## Why

#807 deleted OAuth keys from legacy whole-definition overrides. In that format a missing field still means “owned and empty”, so the override continued to hide the managed OAuth fields restored by #978. Users could authorize successfully, but new `lark-cli` sessions received only the config/data directory variables. Those directories were part of the retired user-managed auth path and must not be forced once Stella-managed OAuth is restored.

## Verification

- `mise run format`
- `mise run build`
- `GOFLAGS='-p=4' mise run test`
- `GOOS=windows GOARCH=amd64 go build -o dist/bin/stellad-windows-amd64.exe ./cmd/stellad`
- `mise run generate:check`
- `mise run db:validate`
- targeted previous-GA and migration regression tests

Closes #986




## Feishu Task

- [#986 修复 Lark CLI managed OAuth env 升级后缺失](https://mcnnox2fhjfq.feishu.cn/record/I3AWrZvL4evru2caH9ncQUk7nzg)
