### PR TITLE
✨ feat(provisioning): link login identities to provisioned users

### DIFF
--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -3591,6 +3591,18 @@ components:
         token:
           type: string
           description: Plaintext replacement bearer token returned exactly once.
+    CreateProvisionedUserChannelIdentityRequest:
+      type: object
+      required: [platform, external_id]
+      properties:
+        platform:
+          type: string
+          minLength: 1
+        external_id:
+          type: string
+          minLength: 1
+        name:
+          type: string
     # ── Recally ────────────────────────────────────────────────────────────────
     ArticleStatus:
       type: string

--- a/api/spec/domain/provisioning/paths.yaml
+++ b/api/spec/domain/provisioning/paths.yaml
@@ -165,7 +165,7 @@ paths:
         "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
         "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
 
-  /api/provisioned-users/{id}/identities/login:
+  /api/provisioned-users/{id}/channel-identities:
     parameters:
       - {
           name: id,
@@ -175,27 +175,26 @@ paths:
         }
     post:
       tags: [provisioning]
-      summary: Link a login identity to a provisioned user
+      summary: Create a channel identity for a provisioned user
       description: >-
-        Lets the provisioning credential attach an external login identity
-        (e.g. a Feishu union_id) to a user it provisioned, so inbound channel
-        messages resolve to that user. Scoped to provisioned users: the target
-        must have been created through this same provisioning surface.
-      operationId: linkProvisionedUserLoginIdentity
+        Lets a provisioning credential attach a messaging-platform identity,
+        such as a Feishu union_id, to an active ordinary user created by the
+        same administrator. This does not grant an interactive login identity.
+      operationId: createProvisionedUserChannelIdentity
       requestBody:
         required: true
         content:
           application/json:
             schema: {
-              $ref: "../../components.yaml#/components/schemas/LinkLoginIdentityRequest",
+              $ref: "../../components.yaml#/components/schemas/CreateProvisionedUserChannelIdentityRequest",
             }
       responses:
-        "200":
-          description: linked
+        "201":
+          description: created
           content:
             application/json:
               schema: {
-                $ref: "../../components.yaml#/components/schemas/LoginIdentity",
+                $ref: "../../components.yaml#/components/schemas/ChannelIdentity",
               }
         "400": {
           $ref: "../../components.yaml#/components/responses/BadRequest",

--- a/api/spec/domain/provisioning/paths.yaml
+++ b/api/spec/domain/provisioning/paths.yaml
@@ -165,6 +165,48 @@ paths:
         "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
         "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
 
+  /api/provisioned-users/{id}/identities/login:
+    parameters:
+      - {
+          name: id,
+          in: path,
+          required: true,
+          schema: { type: string, format: uuid },
+        }
+    post:
+      tags: [provisioning]
+      summary: Link a login identity to a provisioned user
+      description: >-
+        Lets the provisioning credential attach an external login identity
+        (e.g. a Feishu union_id) to a user it provisioned, so inbound channel
+        messages resolve to that user. Scoped to provisioned users: the target
+        must have been created through this same provisioning surface.
+      operationId: linkProvisionedUserLoginIdentity
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {
+              $ref: "../../components.yaml#/components/schemas/LinkLoginIdentityRequest",
+            }
+      responses:
+        "200":
+          description: linked
+          content:
+            application/json:
+              schema: {
+                $ref: "../../components.yaml#/components/schemas/LoginIdentity",
+              }
+        "400": {
+          $ref: "../../components.yaml#/components/responses/BadRequest",
+        }
+        "401": {
+          $ref: "../../components.yaml#/components/responses/Unauthorized",
+        }
+        "403": { $ref: "../../components.yaml#/components/responses/Forbidden" }
+        "404": { $ref: "../../components.yaml#/components/responses/NotFound" }
+        "409": { $ref: "../../components.yaml#/components/responses/Conflict" }
+
   /api/provisioned-users/{id}/deactivate:
     parameters:
       - {

--- a/api/spec/domain/provisioning/schemas.yaml
+++ b/api/spec/domain/provisioning/schemas.yaml
@@ -127,3 +127,11 @@ components:
         token:
           type: string
           description: Plaintext replacement bearer token returned exactly once.
+
+    CreateProvisionedUserChannelIdentityRequest:
+      type: object
+      required: [platform, external_id]
+      properties:
+        platform: { type: string, minLength: 1 }
+        external_id: { type: string, minLength: 1 }
+        name: { type: string }

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -304,6 +304,8 @@ paths:
     $ref: "./domain/provisioning/paths.yaml#/paths/~1api~1provisioned-users~1{id}~1rotate-token"
   /api/provisioned-users/{id}/deactivate:
     $ref: "./domain/provisioning/paths.yaml#/paths/~1api~1provisioned-users~1{id}~1deactivate"
+  /api/provisioned-users/{id}/identities/login:
+    $ref: "./domain/provisioning/paths.yaml#/paths/~1api~1provisioned-users~1{id}~1identities~1login"
 
   # ── OAuth2 clients & authorized apps ─────────────────────────────────────────
   /api/users/me/oauth-clients:

--- a/api/spec/openapi.yaml
+++ b/api/spec/openapi.yaml
@@ -304,8 +304,8 @@ paths:
     $ref: "./domain/provisioning/paths.yaml#/paths/~1api~1provisioned-users~1{id}~1rotate-token"
   /api/provisioned-users/{id}/deactivate:
     $ref: "./domain/provisioning/paths.yaml#/paths/~1api~1provisioned-users~1{id}~1deactivate"
-  /api/provisioned-users/{id}/identities/login:
-    $ref: "./domain/provisioning/paths.yaml#/paths/~1api~1provisioned-users~1{id}~1identities~1login"
+  /api/provisioned-users/{id}/channel-identities:
+    $ref: "./domain/provisioning/paths.yaml#/paths/~1api~1provisioned-users~1{id}~1channel-identities"
 
   # ── OAuth2 clients & authorized apps ─────────────────────────────────────────
   /api/users/me/oauth-clients:

--- a/internal/db/queries/auth_provisioned_user.sql
+++ b/internal/db/queries/auth_provisioned_user.sql
@@ -112,6 +112,22 @@ JOIN auth_user u ON u.id = pu.user_id
 WHERE pu.id = sqlc.arg(id)
 FOR UPDATE OF pu, u;
 
+-- name: GetOwnedProvisionedUserForUpdate :one
+SELECT pu.id, pu.user_id, u.role, u.is_active
+FROM auth_provisioned_user pu
+JOIN auth_user u ON u.id = pu.user_id
+WHERE pu.id = sqlc.arg(id)
+  AND pu.created_by_user_id = sqlc.arg(created_by_user_id)
+FOR UPDATE OF pu, u;
+
+-- name: CreateProvisionedUserChannelIdentity :one
+INSERT INTO channel_identity (id, user_id, platform, external_id, name)
+VALUES (
+    sqlc.arg(id), sqlc.arg(user_id), sqlc.arg(platform),
+    sqlc.arg(external_id), sqlc.arg(name)
+)
+RETURNING *;
+
 -- name: RevokeProvisionedPersonalAccessTokenByUser :execrows
 UPDATE personal_access_token
 SET revoked_at = now(), updated_at = now()

--- a/internal/provisioning/service.go
+++ b/internal/provisioning/service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/CherryHQ/stella/internal/auth"
 	"github.com/CherryHQ/stella/internal/auth/account"
 	"github.com/CherryHQ/stella/internal/authz"
 	"github.com/CherryHQ/stella/internal/credential"
@@ -31,6 +32,7 @@ var (
 	ErrForbidden     = errors.New("provisioned user lifecycle forbidden")
 	ErrExternalIDDup = errors.New("provisioned user external_id already exists")
 	ErrEmailDup      = errors.New("provisioned user email already exists")
+	ErrIdentityDup   = errors.New("channel identity already exists")
 )
 
 // ExternalIDConflict carries only the already-managed resource's safe metadata;
@@ -103,6 +105,22 @@ type User struct {
 type CreateResult struct {
 	User  User
 	Token string // plaintext: caller must return it once and never persist it.
+}
+
+type ChannelIdentityInput struct {
+	Platform   string
+	ExternalID string
+	Name       string
+}
+
+type ChannelIdentity struct {
+	ID         string
+	UserID     string
+	Platform   string
+	ExternalID string
+	Name       string
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
 }
 
 func (s *Service) Create(ctx context.Context, issuer Issuer, in CreateInput) (CreateResult, error) {
@@ -251,6 +269,58 @@ func (s *Service) Rotate(ctx context.Context, issuer Issuer, id, tokenName strin
 	return result, nil
 }
 
+// CreateChannelIdentity attaches a messaging identity without granting an
+// interactive login. Ownership follows the administrator that created the
+// provisioned user, so that administrator may rotate provisioning tokens
+// without orphaning its users.
+func (s *Service) CreateChannelIdentity(ctx context.Context, issuer Issuer, id string, in ChannelIdentityInput) (ChannelIdentity, error) {
+	if issuer.UserID == "" || issuer.TokenID == "" {
+		return ChannelIdentity{}, fmt.Errorf("%w: missing provisioning issuer", ErrForbidden)
+	}
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return ChannelIdentity{}, fmt.Errorf("begin channel identity create: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	q := sqlc.New(s.db).WithTx(tx)
+	locked, err := q.GetOwnedProvisionedUserForUpdate(ctx, sqlc.GetOwnedProvisionedUserForUpdateParams{
+		ID:              id,
+		CreatedByUserID: pgtype.Text{String: issuer.UserID, Valid: true},
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ChannelIdentity{}, ErrNotFound
+	}
+	if err != nil {
+		return ChannelIdentity{}, fmt.Errorf("lock owned provisioned user: %w", err)
+	}
+	if locked.Role != auth.RoleUser || !locked.IsActive {
+		return ChannelIdentity{}, ErrForbidden
+	}
+
+	row, err := q.CreateProvisionedUserChannelIdentity(ctx, sqlc.CreateProvisionedUserChannelIdentityParams{
+		ID:         uuid.Must(uuid.NewV7()).String(),
+		UserID:     locked.UserID,
+		Platform:   in.Platform,
+		ExternalID: in.ExternalID,
+		Name:       in.Name,
+	})
+	if err != nil {
+		return ChannelIdentity{}, classifyChannelIdentityError(err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return ChannelIdentity{}, fmt.Errorf("commit channel identity create: %w", err)
+	}
+	identity := ChannelIdentity{
+		ID: row.ID, UserID: row.UserID, Platform: row.Platform, ExternalID: row.ExternalID,
+		Name: row.Name, CreatedAt: row.CreatedAt.UTC(), UpdatedAt: row.UpdatedAt.UTC(),
+	}
+	s.log.InfoContext(ctx, "provisioned user channel identity created",
+		"provisioned_user_id", id, "user_id", identity.UserID,
+		"platform", identity.Platform, "issuer_user_id", issuer.UserID, "issuer_token_id", issuer.TokenID)
+	return identity, nil
+}
+
 func (s *Service) Deactivate(ctx context.Context, issuer Issuer, authority authz.Authority, id string) (User, error) {
 	if issuer.UserID == "" || issuer.TokenID == "" {
 		return User{}, fmt.Errorf("%w: missing provisioning issuer", ErrForbidden)
@@ -337,4 +407,12 @@ func classifyCreateError(err error) error {
 		return ErrEmailDup
 	}
 	return fmt.Errorf("create provisioned user: %w", err)
+}
+
+func classifyChannelIdentityError(err error) error {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == "23505" && pgErr.ConstraintName == "channel_identity_platform_external_id_key" {
+		return ErrIdentityDup
+	}
+	return fmt.Errorf("create provisioned user channel identity: %w", err)
 }

--- a/internal/provisioning/service_test.go
+++ b/internal/provisioning/service_test.go
@@ -279,3 +279,64 @@ func TestDeactivateSerializesAfterPromotion(t *testing.T) {
 		t.Fatalf("promotion/deactivation race left role=%q active=%v, want admin/true", role, active)
 	}
 }
+
+// TestCreateChannelIdentitySerializesAfterPromotion proves the role check and
+// identity insert share one target-row lock. A promotion that wins the lock
+// must make the provisioning mutation fail without leaving an identity behind.
+func TestCreateChannelIdentitySerializesAfterPromotion(t *testing.T) {
+	ctx := context.Background()
+	db := dbtest.New(t)
+	store := appdb.NewOIDCStore(db)
+	issuer, err := store.CreateUser(ctx, auth.User{ID: uuid.NewString(), Email: "identity-issuer@example.test", Name: "Issuer", Role: auth.RoleAdmin, IsActive: true})
+	if err != nil {
+		t.Fatalf("create issuer: %v", err)
+	}
+	q := sqlc.New(db)
+	issuerToken, err := q.CreatePersonalAccessToken(ctx, sqlc.CreatePersonalAccessTokenParams{
+		PublicID: "identity-race-issuer", UserID: issuer.ID, Name: "issuer", TokenHash: "identity-race-hash", Last4: "hash", Scopes: []string{}, TokenUse: "provisioning",
+	})
+	if err != nil {
+		t.Fatalf("create issuer token: %v", err)
+	}
+	svc := New(db, accountLifecycleStub{}, nil, nil)
+	created, err := svc.Create(ctx, Issuer{UserID: issuer.ID, TokenID: issuerToken.ID}, CreateInput{
+		ExternalID: "identity-race-target", Email: "identity-race-target@example.test", Name: "Target", TokenName: "token", ExpiresAt: time.Now().UTC().Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("create target: %v", err)
+	}
+
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin promotion: %v", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := tx.Exec(ctx, `UPDATE auth_user SET role='admin', updated_at=now() WHERE id=$1`, created.User.UserID); err != nil {
+		t.Fatalf("stage promotion: %v", err)
+	}
+	result := make(chan error, 1)
+	var started sync.WaitGroup
+	started.Add(1)
+	go func() {
+		started.Done()
+		_, err := svc.CreateChannelIdentity(ctx, Issuer{UserID: issuer.ID, TokenID: issuerToken.ID}, created.User.ID, ChannelIdentityInput{
+			Platform: "feishu", ExternalID: "on_race", Name: "Target",
+		})
+		result <- err
+	}()
+	started.Wait()
+	time.Sleep(20 * time.Millisecond)
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("commit promotion: %v", err)
+	}
+	if err := <-result; !errors.Is(err, ErrForbidden) {
+		t.Fatalf("identity create after committed promotion = %v, want ErrForbidden", err)
+	}
+	var identities int
+	if err := db.QueryRow(ctx, `SELECT count(*) FROM channel_identity WHERE user_id=$1`, created.User.UserID).Scan(&identities); err != nil {
+		t.Fatalf("count channel identities: %v", err)
+	}
+	if identities != 0 {
+		t.Fatalf("channel identities after promotion race = %d, want 0", identities)
+	}
+}

--- a/internal/server/provisioned_users.go
+++ b/internal/server/provisioned_users.go
@@ -15,6 +15,8 @@ import (
 
 	apiserver "github.com/CherryHQ/stella/api/server"
 	apitypes "github.com/CherryHQ/stella/api/types"
+	"github.com/CherryHQ/stella/internal/auth"
+	"github.com/CherryHQ/stella/internal/auth/account"
 	"github.com/CherryHQ/stella/internal/provisioning"
 )
 
@@ -152,6 +154,68 @@ func (s *Server) DeactivateProvisionedUser(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	writeData(w, http.StatusOK, provisionedUserToAPI(user))
+}
+
+// LinkProvisionedUserLoginIdentity handles POST /api/provisioned-users/{id}/identities/login.
+//
+// The external directory that provisioned a user is the only party that knows
+// which IM account belongs to it, so it must be able to record that mapping;
+// otherwise inbound channel messages can never resolve to the provisioned user.
+// The blast radius stays inside the provisioning surface: the target is resolved
+// through the provisioning service first, so a provisioning credential can never
+// reach a human account's identities. PATs remain barred from every identity
+// route by the credential gate.
+func (s *Server) LinkProvisionedUserLoginIdentity(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
+	info := requireProvisioningBearer(w, r)
+	if info == nil {
+		return
+	}
+	if s.provisioningSvc == nil || s.account == nil {
+		writeError(w, http.StatusServiceUnavailable, "provisioning is unavailable")
+		return
+	}
+	// The path carries the provisioned-user record id; identities hang off the
+	// auth user it wraps. Resolving here also proves this surface owns the target.
+	provisioned, err := s.provisioningSvc.Get(r.Context(), id.String())
+	if err != nil {
+		s.writeProvisioningError(w, err)
+		return
+	}
+
+	var body struct {
+		Provider        string `json:"provider"`
+		ProviderSubject string `json:"provider_subject"`
+		Email           string `json:"email"`
+		Name            string `json:"name"`
+	}
+	if err := decodeJSON(r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	if body.Provider == "" || body.ProviderSubject == "" || body.Email == "" {
+		writeError(w, http.StatusBadRequest, "provider, provider_subject, and email are required")
+		return
+	}
+
+	// Ownership is already narrowed above, so reuse the account layer with an
+	// admin authority to inherit its conflict handling (identity owned by
+	// another user -> 409).
+	authority, err := (auth.Subject{UserID: info.UserID, Roles: []string{auth.RoleAdmin}}).Authority()
+	if err != nil {
+		writeError(w, http.StatusForbidden, "forbidden")
+		return
+	}
+	linked, err := s.account.LinkLoginIdentity(r.Context(), authority, provisioned.UserID, account.LinkLoginInput{
+		Provider:        body.Provider,
+		ProviderSubject: body.ProviderSubject,
+		Email:           body.Email,
+		Name:            body.Name,
+	})
+	if err != nil {
+		s.writeAccountError(w, err)
+		return
+	}
+	writeData(w, http.StatusOK, linked)
 }
 
 const provisionedUserPageTokenKind = "provisioned_user"

--- a/internal/server/provisioned_users.go
+++ b/internal/server/provisioned_users.go
@@ -15,8 +15,6 @@ import (
 
 	apiserver "github.com/CherryHQ/stella/api/server"
 	apitypes "github.com/CherryHQ/stella/api/types"
-	"github.com/CherryHQ/stella/internal/auth"
-	"github.com/CherryHQ/stella/internal/auth/account"
 	"github.com/CherryHQ/stella/internal/provisioning"
 )
 
@@ -156,66 +154,33 @@ func (s *Server) DeactivateProvisionedUser(w http.ResponseWriter, r *http.Reques
 	writeData(w, http.StatusOK, provisionedUserToAPI(user))
 }
 
-// LinkProvisionedUserLoginIdentity handles POST /api/provisioned-users/{id}/identities/login.
-//
-// The external directory that provisioned a user is the only party that knows
-// which IM account belongs to it, so it must be able to record that mapping;
-// otherwise inbound channel messages can never resolve to the provisioned user.
-// The blast radius stays inside the provisioning surface: the target is resolved
-// through the provisioning service first, so a provisioning credential can never
-// reach a human account's identities. PATs remain barred from every identity
-// route by the credential gate.
-func (s *Server) LinkProvisionedUserLoginIdentity(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
+// CreateProvisionedUserChannelIdentity handles
+// POST /api/provisioned-users/{id}/channel-identities.
+func (s *Server) CreateProvisionedUserChannelIdentity(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
 	info := requireProvisioningBearer(w, r)
 	if info == nil {
 		return
 	}
-	if s.provisioningSvc == nil || s.account == nil {
+	if s.provisioningSvc == nil {
 		writeError(w, http.StatusServiceUnavailable, "provisioning is unavailable")
 		return
 	}
-	// The path carries the provisioned-user record id; identities hang off the
-	// auth user it wraps. Resolving here also proves this surface owns the target.
-	provisioned, err := s.provisioningSvc.Get(r.Context(), id.String())
+	var body apitypes.CreateProvisionedUserChannelIdentityRequest
+	if err := decodeJSON(r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	in, err := provisionedChannelIdentityInput(body)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	identity, err := s.provisioningSvc.CreateChannelIdentity(r.Context(), provisioningIssuer(info), id.String(), in)
 	if err != nil {
 		s.writeProvisioningError(w, err)
 		return
 	}
-
-	var body struct {
-		Provider        string `json:"provider"`
-		ProviderSubject string `json:"provider_subject"`
-		Email           string `json:"email"`
-		Name            string `json:"name"`
-	}
-	if err := decodeJSON(r, &body); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON")
-		return
-	}
-	if body.Provider == "" || body.ProviderSubject == "" || body.Email == "" {
-		writeError(w, http.StatusBadRequest, "provider, provider_subject, and email are required")
-		return
-	}
-
-	// Ownership is already narrowed above, so reuse the account layer with an
-	// admin authority to inherit its conflict handling (identity owned by
-	// another user -> 409).
-	authority, err := (auth.Subject{UserID: info.UserID, Roles: []string{auth.RoleAdmin}}).Authority()
-	if err != nil {
-		writeError(w, http.StatusForbidden, "forbidden")
-		return
-	}
-	linked, err := s.account.LinkLoginIdentity(r.Context(), authority, provisioned.UserID, account.LinkLoginInput{
-		Provider:        body.Provider,
-		ProviderSubject: body.ProviderSubject,
-		Email:           body.Email,
-		Name:            body.Name,
-	})
-	if err != nil {
-		s.writeAccountError(w, err)
-		return
-	}
-	writeData(w, http.StatusOK, linked)
+	writeData(w, http.StatusCreated, provisionedChannelIdentityToAPI(identity))
 }
 
 const provisionedUserPageTokenKind = "provisioned_user"
@@ -286,6 +251,19 @@ func provisionedCreateInput(body apitypes.CreateProvisionedUserRequest, now time
 	return provisioning.CreateInput{ExternalID: externalID, Email: email, Name: name, TokenName: tokenName, ExpiresAt: *expiresAt}, nil
 }
 
+func provisionedChannelIdentityInput(body apitypes.CreateProvisionedUserChannelIdentityRequest) (provisioning.ChannelIdentityInput, error) {
+	platform := strings.TrimSpace(body.Platform)
+	externalID := strings.TrimSpace(body.ExternalId)
+	if platform == "" || externalID == "" {
+		return provisioning.ChannelIdentityInput{}, errors.New("platform and external_id are required")
+	}
+	name := ""
+	if body.Name != nil {
+		name = strings.TrimSpace(*body.Name)
+	}
+	return provisioning.ChannelIdentityInput{Platform: platform, ExternalID: externalID, Name: name}, nil
+}
+
 func provisionedTokenInput(tokenName *string, requestedExpiry *time.Time, now time.Time) (string, *time.Time, error) {
 	name := provisioning.DefaultTokenName
 	if tokenName != nil {
@@ -314,6 +292,14 @@ func provisionedUserToAPI(user provisioning.User) apitypes.ProvisionedUser {
 	return out
 }
 
+func provisionedChannelIdentityToAPI(identity provisioning.ChannelIdentity) apitypes.ChannelIdentity {
+	return apitypes.ChannelIdentity{
+		Id: identity.ID, UserId: identity.UserID, Platform: identity.Platform,
+		ExternalId: identity.ExternalID, Name: identity.Name,
+		CreatedAt: identity.CreatedAt.UTC(), UpdatedAt: identity.UpdatedAt.UTC(),
+	}
+}
+
 func (s *Server) writeProvisioningError(w http.ResponseWriter, err error) {
 	var external *provisioning.ExternalIDConflict
 	switch {
@@ -323,6 +309,8 @@ func (s *Server) writeProvisioningError(w http.ResponseWriter, err error) {
 		// Do not reveal whether this belongs to a self-registered, OIDC, or
 		// otherwise unmanaged account.
 		writeError(w, http.StatusConflict, "email is already in use")
+	case errors.Is(err, provisioning.ErrIdentityDup):
+		writeError(w, http.StatusConflict, "channel identity is already linked")
 	case errors.Is(err, provisioning.ErrNotFound):
 		writeError(w, http.StatusNotFound, "provisioned user not found")
 	case errors.Is(err, provisioning.ErrForbidden):

--- a/internal/server/provisioned_users_integration_test.go
+++ b/internal/server/provisioned_users_integration_test.go
@@ -229,20 +229,20 @@ func TestProvisionedUsersHTTPIntegration(t *testing.T) {
 	}
 }
 
-// TestProvisionedUserLoginIdentityHTTP covers the identity route added for
-// external directories: the provisioning credential may attach a login identity
-// to a user it provisioned, other credentials may not reach the route at all,
-// and a human account stays out of reach.
-func TestProvisionedUserLoginIdentityHTTP(t *testing.T) {
+// TestProvisionedUserChannelIdentityHTTP covers the narrow identity capability:
+// a directory may create a messaging identity for its own active ordinary user,
+// but cannot grant interactive login or cross an issuer/role boundary.
+func TestProvisionedUserChannelIdentityHTTP(t *testing.T) {
 	ctx := context.Background()
 	env := setupAdmin(t)
 	issuer := createProvisioningToken(t, env.bearerToken, env, "directory", nil)
+	sameOwner := createProvisioningToken(t, env.bearerToken, env, "directory-rotated", nil)
 	created := createProvisionedUserHTTP(t, env, issuer.Token, map[string]any{
 		"external_id": "directory-link", "email": "link@example.test", "name": "Link",
 	})
-	path := "/api/provisioned-users/" + created.ProvisionedUser.ID + "/identities/login"
+	path := "/api/provisioned-users/" + created.ProvisionedUser.ID + "/channel-identities"
 	body := map[string]any{
-		"provider": "feishu", "provider_subject": "on_union_1", "email": "link@example.test", "name": "Link",
+		"platform": "feishu", "external_id": "on_union_1", "name": "Link",
 	}
 
 	// Session and PAT bearers are barred from the provisioning family.
@@ -253,30 +253,85 @@ func TestProvisionedUserLoginIdentityHTTP(t *testing.T) {
 		}
 	}
 
-	if rr := doBearerRequest(t, env.srv, issuer.Token, http.MethodPost, path, body); rr.Code != http.StatusOK {
-		t.Fatalf("link identity: status=%d body=%s", rr.Code, rr.Body.String())
-	}
-	// Re-linking the same identity to the same user is idempotent.
-	if rr := doBearerRequest(t, env.srv, issuer.Token, http.MethodPost, path, body); rr.Code != http.StatusOK {
-		t.Fatalf("relink identity: status=%d body=%s", rr.Code, rr.Body.String())
+	for _, invalid := range []map[string]any{
+		{"platform": " ", "external_id": "on_union_1"},
+		{"platform": "feishu", "external_id": " "},
+	} {
+		if rr := doBearerRequest(t, env.srv, issuer.Token, http.MethodPost, path, invalid); rr.Code != http.StatusBadRequest {
+			t.Fatalf("invalid identity: want 400 got %d (%s)", rr.Code, rr.Body.String())
+		}
 	}
 
-	var userID string
-	if err := env.db.QueryRow(ctx, `SELECT user_id FROM auth_provisioned_user WHERE id=$1`, created.ProvisionedUser.ID).Scan(&userID); err != nil {
+	// Ownership follows the issuing administrator, not one token, so planned
+	// provisioning-token rotation does not orphan previously created users.
+	rr := doBearerRequest(t, env.srv, sameOwner.Token, http.MethodPost, path, body)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create channel identity: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var identity auth.ChannelIdentity
+	if err := json.Unmarshal(rr.Body.Bytes(), &identity); err != nil {
+		t.Fatalf("decode channel identity: %v", err)
+	}
+	if identity.UserID == "" || identity.Platform != "feishu" || identity.ExternalID != "on_union_1" {
+		t.Fatalf("channel identity response = %#v", identity)
+	}
+
+	if err := env.db.QueryRow(ctx, `SELECT user_id FROM auth_provisioned_user WHERE id=$1`, created.ProvisionedUser.ID).Scan(&created.ProvisionedUser.UserID); err != nil {
 		t.Fatalf("load provisioned user mapping: %v", err)
 	}
-	var linked int
+	var channelLinked, loginLinked int
 	if err := env.db.QueryRow(ctx,
-		`SELECT count(*) FROM auth_identity WHERE user_id=$1 AND provider='feishu' AND provider_subject='on_union_1'`,
-		userID).Scan(&linked); err != nil {
+		`SELECT count(*) FROM channel_identity WHERE user_id=$1 AND platform='feishu' AND external_id='on_union_1'`,
+		created.ProvisionedUser.UserID).Scan(&channelLinked); err != nil {
+		t.Fatalf("count channel identities: %v", err)
+	}
+	if err := env.db.QueryRow(ctx, `SELECT count(*) FROM auth_identity WHERE user_id=$1`, created.ProvisionedUser.UserID).Scan(&loginLinked); err != nil {
 		t.Fatalf("count login identities: %v", err)
 	}
-	if linked != 1 {
-		t.Fatalf("login identities linked = %d, want 1", linked)
+	if channelLinked != 1 || loginLinked != 0 {
+		t.Fatalf("identity state channel=%d login=%d, want channel=1 login=0", channelLinked, loginLinked)
+	}
+	if rr := doBearerRequest(t, env.srv, issuer.Token, http.MethodPost, path, body); rr.Code != http.StatusConflict {
+		t.Fatalf("duplicate channel identity: want 409 got %d (%s)", rr.Code, rr.Body.String())
+	}
+
+	// A provisioning token owned by another administrator cannot mutate this
+	// owner's users. Return 404 so the ownership boundary reveals nothing.
+	_, otherOwnerSession := createTestUserWithToken(t, env.authStore, env.oidcStore, "other-provision-owner", auth.RoleAdmin)
+	otherIssuer := createProvisioningToken(t, otherOwnerSession, env, "other-directory", nil)
+	foreignBody := map[string]any{"platform": "feishu", "external_id": "on_foreign", "name": "Foreign"}
+	if rr := doBearerRequest(t, env.srv, otherIssuer.Token, http.MethodPost, path, foreignBody); rr.Code != http.StatusNotFound {
+		t.Fatalf("cross-owner identity: want 404 got %d (%s)", rr.Code, rr.Body.String())
+	}
+
+	for _, target := range []struct {
+		name   string
+		mutate string
+	}{
+		{name: "promoted", mutate: `UPDATE auth_user SET role='admin' WHERE id=$1`},
+		{name: "inactive", mutate: `UPDATE auth_user SET is_active=false WHERE id=$1`},
+	} {
+		managed := createProvisionedUserHTTP(t, env, issuer.Token, map[string]any{
+			"external_id": "directory-" + target.name,
+			"email":       target.name + "@example.test",
+			"name":        target.name,
+		})
+		if err := env.db.QueryRow(ctx, `SELECT user_id FROM auth_provisioned_user WHERE id=$1`, managed.ProvisionedUser.ID).Scan(&managed.ProvisionedUser.UserID); err != nil {
+			t.Fatalf("load %s user mapping: %v", target.name, err)
+		}
+		if _, err := env.db.Exec(ctx, target.mutate, managed.ProvisionedUser.UserID); err != nil {
+			t.Fatalf("mutate %s user: %v", target.name, err)
+		}
+		targetPath := "/api/provisioned-users/" + managed.ProvisionedUser.ID + "/channel-identities"
+		if rr := doBearerRequest(t, env.srv, issuer.Token, http.MethodPost, targetPath, map[string]any{
+			"platform": "feishu", "external_id": "on_" + target.name,
+		}); rr.Code != http.StatusForbidden {
+			t.Fatalf("%s target: want 403 got %d (%s)", target.name, rr.Code, rr.Body.String())
+		}
 	}
 
 	// A user that this surface did not provision (the admin) is not reachable.
-	adminPath := "/api/provisioned-users/" + env.adminUser.ID + "/identities/login"
+	adminPath := "/api/provisioned-users/" + env.adminUser.ID + "/channel-identities"
 	if rr := doBearerRequest(t, env.srv, issuer.Token, http.MethodPost, adminPath, body); rr.Code != http.StatusNotFound {
 		t.Fatalf("foreign user: want 404 got %d (%s)", rr.Code, rr.Body.String())
 	}

--- a/internal/server/provisioned_users_integration_test.go
+++ b/internal/server/provisioned_users_integration_test.go
@@ -228,3 +228,56 @@ func TestProvisionedUsersHTTPIntegration(t *testing.T) {
 		}
 	}
 }
+
+// TestProvisionedUserLoginIdentityHTTP covers the identity route added for
+// external directories: the provisioning credential may attach a login identity
+// to a user it provisioned, other credentials may not reach the route at all,
+// and a human account stays out of reach.
+func TestProvisionedUserLoginIdentityHTTP(t *testing.T) {
+	ctx := context.Background()
+	env := setupAdmin(t)
+	issuer := createProvisioningToken(t, env.bearerToken, env, "directory", nil)
+	created := createProvisionedUserHTTP(t, env, issuer.Token, map[string]any{
+		"external_id": "directory-link", "email": "link@example.test", "name": "Link",
+	})
+	path := "/api/provisioned-users/" + created.ProvisionedUser.ID + "/identities/login"
+	body := map[string]any{
+		"provider": "feishu", "provider_subject": "on_union_1", "email": "link@example.test", "name": "Link",
+	}
+
+	// Session and PAT bearers are barred from the provisioning family.
+	adminPAT, _ := mintPAT(t, env, env.bearerToken, "admin-pat")
+	for _, denied := range []string{env.bearerToken, adminPAT} {
+		if rr := doBearerRequest(t, env.srv, denied, http.MethodPost, path, body); rr.Code != http.StatusForbidden {
+			t.Fatalf("non-provisioning credential: want 403 got %d (%s)", rr.Code, rr.Body.String())
+		}
+	}
+
+	if rr := doBearerRequest(t, env.srv, issuer.Token, http.MethodPost, path, body); rr.Code != http.StatusOK {
+		t.Fatalf("link identity: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	// Re-linking the same identity to the same user is idempotent.
+	if rr := doBearerRequest(t, env.srv, issuer.Token, http.MethodPost, path, body); rr.Code != http.StatusOK {
+		t.Fatalf("relink identity: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+
+	var userID string
+	if err := env.db.QueryRow(ctx, `SELECT user_id FROM auth_provisioned_user WHERE id=$1`, created.ProvisionedUser.ID).Scan(&userID); err != nil {
+		t.Fatalf("load provisioned user mapping: %v", err)
+	}
+	var linked int
+	if err := env.db.QueryRow(ctx,
+		`SELECT count(*) FROM auth_identity WHERE user_id=$1 AND provider='feishu' AND provider_subject='on_union_1'`,
+		userID).Scan(&linked); err != nil {
+		t.Fatalf("count login identities: %v", err)
+	}
+	if linked != 1 {
+		t.Fatalf("login identities linked = %d, want 1", linked)
+	}
+
+	// A user that this surface did not provision (the admin) is not reachable.
+	adminPath := "/api/provisioned-users/" + env.adminUser.ID + "/identities/login"
+	if rr := doBearerRequest(t, env.srv, issuer.Token, http.MethodPost, adminPath, body); rr.Code != http.StatusNotFound {
+		t.Fatalf("foreign user: want 404 got %d (%s)", rr.Code, rr.Body.String())
+	}
+}

--- a/pkg/db/sqlc/auth_provisioned_user.sql.go
+++ b/pkg/db/sqlc/auth_provisioned_user.sql.go
@@ -150,6 +150,77 @@ func (q *Queries) CreateProvisionedUser(ctx context.Context, arg CreateProvision
 	return i, err
 }
 
+const createProvisionedUserChannelIdentity = `-- name: CreateProvisionedUserChannelIdentity :one
+INSERT INTO channel_identity (id, user_id, platform, external_id, name)
+VALUES (
+    $1, $2, $3,
+    $4, $5
+)
+RETURNING id, user_id, platform, external_id, name, created_at, updated_at
+`
+
+type CreateProvisionedUserChannelIdentityParams struct {
+	ID         string `json:"id"`
+	UserID     string `json:"user_id"`
+	Platform   string `json:"platform"`
+	ExternalID string `json:"external_id"`
+	Name       string `json:"name"`
+}
+
+func (q *Queries) CreateProvisionedUserChannelIdentity(ctx context.Context, arg CreateProvisionedUserChannelIdentityParams) (ChannelIdentity, error) {
+	row := q.db.QueryRow(ctx, createProvisionedUserChannelIdentity,
+		arg.ID,
+		arg.UserID,
+		arg.Platform,
+		arg.ExternalID,
+		arg.Name,
+	)
+	var i ChannelIdentity
+	err := row.Scan(
+		&i.ID,
+		&i.UserID,
+		&i.Platform,
+		&i.ExternalID,
+		&i.Name,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getOwnedProvisionedUserForUpdate = `-- name: GetOwnedProvisionedUserForUpdate :one
+SELECT pu.id, pu.user_id, u.role, u.is_active
+FROM auth_provisioned_user pu
+JOIN auth_user u ON u.id = pu.user_id
+WHERE pu.id = $1
+  AND pu.created_by_user_id = $2
+FOR UPDATE OF pu, u
+`
+
+type GetOwnedProvisionedUserForUpdateParams struct {
+	ID              string      `json:"id"`
+	CreatedByUserID pgtype.Text `json:"created_by_user_id"`
+}
+
+type GetOwnedProvisionedUserForUpdateRow struct {
+	ID       string `json:"id"`
+	UserID   string `json:"user_id"`
+	Role     string `json:"role"`
+	IsActive bool   `json:"is_active"`
+}
+
+func (q *Queries) GetOwnedProvisionedUserForUpdate(ctx context.Context, arg GetOwnedProvisionedUserForUpdateParams) (GetOwnedProvisionedUserForUpdateRow, error) {
+	row := q.db.QueryRow(ctx, getOwnedProvisionedUserForUpdate, arg.ID, arg.CreatedByUserID)
+	var i GetOwnedProvisionedUserForUpdateRow
+	err := row.Scan(
+		&i.ID,
+		&i.UserID,
+		&i.Role,
+		&i.IsActive,
+	)
+	return i, err
+}
+
 const getProvisionedUser = `-- name: GetProvisionedUser :one
 SELECT
     pu.id, pu.external_id, pu.user_id, pu.created_by_user_id,

--- a/web/content/docs/admin/provisioned-users-reference.md
+++ b/web/content/docs/admin/provisioned-users-reference.md
@@ -5,16 +5,19 @@ description: Endpoints, request fields, responses, and lifecycle limits for ente
 
 All endpoints below require `Authorization: Bearer stella_prv_…`. Only an interactive administrator session can create, list, or revoke those provisioning tokens at `/api/admin/provisioning-tokens`.
 
-| Method | Endpoint                                   | Response                                                 |
-| ------ | ------------------------------------------ | -------------------------------------------------------- |
-| `POST` | `/api/provisioned-users`                   | `201` user metadata plus one-time `token`                |
-| `GET`  | `/api/provisioned-users`                   | `200` `provisioned_users` and `next_page_token`          |
-| `GET`  | `/api/provisioned-users/{id}`              | `200` safe user and active-token metadata                |
-| `POST` | `/api/provisioned-users/{id}/rotate-token` | `200` updated metadata plus one-time replacement `token` |
-| `POST` | `/api/provisioned-users/{id}/deactivate`   | `200` deactivated user metadata                          |
+| Method | Endpoint                                         | Response                                                 |
+| ------ | ------------------------------------------------ | -------------------------------------------------------- |
+| `POST` | `/api/provisioned-users`                         | `201` user metadata plus one-time `token`                |
+| `GET`  | `/api/provisioned-users`                         | `200` `provisioned_users` and `next_page_token`          |
+| `GET`  | `/api/provisioned-users/{id}`                    | `200` safe user and active-token metadata                |
+| `POST` | `/api/provisioned-users/{id}/channel-identities` | `201` created messaging-platform identity                |
+| `POST` | `/api/provisioned-users/{id}/rotate-token`       | `200` updated metadata plus one-time replacement `token` |
+| `POST` | `/api/provisioned-users/{id}/deactivate`         | `200` deactivated user metadata                          |
 
 `id` is Stella's canonical UUID. `external_id` is a unique immutable field, not a path identifier. List requests use `page_size` (default 20, maximum 500) and opaque `page_token` values.
 
 Create requires `external_id`, `email`, and `name`; `token_name` defaults to `enterprise-integration`. Create and rotation default `expires_at` to 90 days and reject an expiry more than 365 days away. `never_expires` is not supported.
 
 Responses expose only token ID, name, last four characters, expiry, last-used time, and creation time. They never expose a token hash, plaintext after its one response, scopes, or issuer secrets. A managed `external_id` conflict returns `409` with safe managed metadata; an email collision with an unmanaged account returns a generic `409`.
+
+Creating a channel identity requires `platform` and `external_id`; `name` is optional. It links inbound messages directly and does not grant Web UI or OpenID Connect login. The target must be an active ordinary user created by the same administrator, including through an earlier provisioning token owned by that administrator. A duplicate `(platform, external_id)` returns `409`; a user owned by another administrator returns `404`.

--- a/web/content/docs/admin/provisioned-users-reference.zh.md
+++ b/web/content/docs/admin/provisioned-users-reference.zh.md
@@ -5,16 +5,19 @@ description: 企业开通的端点、请求字段、响应和生命周期限制�
 
 以下所有端点都需要 `Authorization: Bearer stella_prv_…`。只有交互式管理员 session 可以在 `/api/admin/provisioning-tokens` 创建、列出或撤销这些开通令牌。
 
-| 方法   | 端点                                       | 响应                                           |
-| ------ | ------------------------------------------ | ---------------------------------------------- |
-| `POST` | `/api/provisioned-users`                   | `201` 用户元数据和一次性 `token`               |
-| `GET`  | `/api/provisioned-users`                   | `200` `provisioned_users` 和 `next_page_token` |
-| `GET`  | `/api/provisioned-users/{id}`              | `200` 安全的用户与活跃令牌元数据               |
-| `POST` | `/api/provisioned-users/{id}/rotate-token` | `200` 更新后的元数据和一次性替换 `token`       |
-| `POST` | `/api/provisioned-users/{id}/deactivate`   | `200` 已停用的用户元数据                       |
+| 方法   | 端点                                             | 响应                                           |
+| ------ | ------------------------------------------------ | ---------------------------------------------- |
+| `POST` | `/api/provisioned-users`                         | `201` 用户元数据和一次性 `token`               |
+| `GET`  | `/api/provisioned-users`                         | `200` `provisioned_users` 和 `next_page_token` |
+| `GET`  | `/api/provisioned-users/{id}`                    | `200` 安全的用户与活跃令牌元数据               |
+| `POST` | `/api/provisioned-users/{id}/channel-identities` | `201` 已创建的消息平台身份                     |
+| `POST` | `/api/provisioned-users/{id}/rotate-token`       | `200` 更新后的元数据和一次性替换 `token`       |
+| `POST` | `/api/provisioned-users/{id}/deactivate`         | `200` 已停用的用户元数据                       |
 
 `id` 是 Stella 的规范 UUID。`external_id` 是唯一、不可变的字段，不是路径标识。列表请求使用 `page_size`（默认 20，最大 500）和不透明的 `page_token`。
 
 创建需要 `external_id`、`email` 和 `name`；`token_name` 默认是 `enterprise-integration`。创建和轮换的 `expires_at` 默认 90 天，超过 365 天会被拒绝。不支持 `never_expires`。
 
 响应只公开令牌 ID、名称、后四位、过期时间、最后使用时间和创建时间；绝不公开令牌 hash、一次响应之后的明文、scope 或签发者 secret。受管的 `external_id` 冲突返回带安全元数据的 `409`；与未受管账户的邮箱冲突则返回通用 `409`。
+
+创建频道身份需要 `platform` 和 `external_id`，`name` 可选。该操作直接关联入站消息，不会授予 Web UI 或 OpenID Connect 登录能力。目标必须是由同一管理员创建的活跃普通用户；该管理员此前持有的开通令牌所创建的用户也可以管理。重复的 `(platform, external_id)` 返回 `409`，其他管理员拥有的用户返回 `404`。

--- a/web/content/docs/admin/provisioned-users.md
+++ b/web/content/docs/admin/provisioned-users.md
@@ -37,6 +37,19 @@ Use `GET /api/provisioned-users` and `GET /api/provisioned-users/{id}` for safe 
 
 All user tokens expire by default after 90 days; `expires_at` may shorten or extend that interval up to 365 days. There is no never-expiring option.
 
+## Link a messaging identity
+
+To route channel messages from an existing directory account to the provisioned user, create a channel identity with the platform's stable user identifier:
+
+```sh
+curl -X POST https://stella.example/api/provisioned-users/PROVISIONED_USER_ID/channel-identities \
+  -H 'Authorization: Bearer stella_prv_…' \
+  -H 'Content-Type: application/json' \
+  -d '{"platform":"feishu","external_id":"on_union_1","name":"Ada"}'
+```
+
+This creates only a messaging identity; it does not let that account sign in to the Web UI. A replacement provisioning token owned by the same administrator can manage users created by the prior token. Tokens owned by another administrator receive `404`, and promoted or inactive users receive `403`.
+
 ## Recover and respond to incidents
 
 If `external_id` already belongs to a managed user, creation returns `409` with safe existing user and token metadata, never the old token. Treat this as a retry/reconciliation result: fetch that resource and rotate its token if the earlier response was lost. An email collision with an unmanaged account also returns `409`, but deliberately reveals nothing about that account.

--- a/web/content/docs/admin/provisioned-users.zh.md
+++ b/web/content/docs/admin/provisioned-users.zh.md
@@ -37,6 +37,19 @@ curl -X POST https://stella.example/api/provisioned-users \
 
 所有用户令牌默认 90 天过期；`expires_at` 可以缩短或延长，但最长 365 天。没有永不过期选项。
 
+## 关联消息平台身份
+
+要把目录中已有账户的频道消息路由到受管用户，请使用平台的稳定用户标识创建频道身份：
+
+```sh
+curl -X POST https://stella.example/api/provisioned-users/PROVISIONED_USER_ID/channel-identities \
+  -H 'Authorization: Bearer stella_prv_…' \
+  -H 'Content-Type: application/json' \
+  -d '{"platform":"feishu","external_id":"on_union_1","name":"Ada"}'
+```
+
+该操作只创建消息平台身份，不会允许此账户登录 Web UI。同一管理员持有的替换开通令牌可以继续管理旧令牌创建的用户；其他管理员的令牌会收到 `404`，已提升或已停用的用户会收到 `403`。
+
 ## 恢复与事件响应
 
 若 `external_id` 已存在于受管用户，创建会返回 `409`，其中只有安全的既有用户和令牌元数据，绝不包含旧令牌。将其视为重试/对账结果：读取资源，若之前响应丢失则轮换令牌。若邮箱与未受管账户冲突，也会返回 `409`，但不会透露该账户的任何信息。


### PR DESCRIPTION
## Summary

- add `POST /api/provisioned-users/{id}/identities/login` so an external directory can record which IM account belongs to a user it provisioned
- resolve ownership through the provisioning service before touching any identity, so a provisioning credential can only modify users it provisioned itself
- keep PATs barred from every identity route — the credential gate is unchanged

## Design

The general identity routes (`/api/users/{id}/identities/*`) are barred to every
bearer credential by the credential gate, and that stays true. Instead of
widening the gate, the new endpoint lives in the provisioned-users family,
which the provisioning allowlist already covers. The handler resolves the
target user through the provisioning service first, so the ownership check
happens before any identity work — a credential holding the provisioning
scope still cannot reach users it did not provision.

## Validation

- `mise run format`
- `mise run build`
- `mise run test:web` (pre-commit hook)
- integration test covering the new endpoint (`internal/server/provisioned_users_integration_test.go`)

Full `mise run test` has not been run yet for this branch — to be run before
marking the PR ready for review.

Closes #990


## Feishu Task

- [#990 为预配用户绑定登录身份](https://mcnnox2fhjfq.feishu.cn/record/VYVtrxw4qe8a5PctenGcZrDdnZc)
