### PR TITLE
🐛 fix(memory): preserve parallel tool-call turns

### DIFF
--- a/internal/memory/lcm/assembler.go
+++ b/internal/memory/lcm/assembler.go
@@ -263,10 +263,10 @@ func advancePastOldestTurn(items []sqlc.CtxItem, splitIdx int) (int, bool) {
 func resolveOlderWithinBudget(older []sqlc.CtxItem, messages map[string]sqlc.CtxMessage, summaries map[string]sqlc.CtxSummary, children map[string][]sqlc.CtxSummary, partsByMessage map[string][]loadedMessagePart, remaining int) ([]ai.Message, error) {
 	var olderMsgs []ai.Message
 	for i := len(older) - 1; i >= 0; i-- {
-		item := older[i]
-		msgs, err := resolveItemsFromCaches(older[i:i+1], messages, summaries, children, partsByMessage)
+		start := contextItemGroupStart(older, i)
+		msgs, err := resolveItemsFromCaches(older[start:i+1], messages, summaries, children, partsByMessage)
 		if err != nil {
-			return nil, fmt.Errorf("resolve item %d: %w", item.Ordinal, err)
+			return nil, fmt.Errorf("resolve item %d: %w", older[start].Ordinal, err)
 		}
 		tokens := 0
 		for _, m := range msgs {
@@ -278,8 +278,28 @@ func resolveOlderWithinBudget(older []sqlc.CtxItem, messages map[string]sqlc.Ctx
 		}
 		remaining -= tokens
 		olderMsgs = append(olderMsgs, msgs...)
+		i = start
 	}
 	return olderMsgs, nil
+}
+
+// contextItemGroupStart returns the first item in the logical message ending at
+// end. Assistant blocks from one model turn are stored as adjacent rows, so the
+// older-history budget must admit or reject the whole run instead of splitting
+// parallel tool calls into separate assistant messages.
+func contextItemGroupStart(items []sqlc.CtxItem, end int) int {
+	if end < 0 || end >= len(items) || !isAssistantMessageItem(items[end]) {
+		return end
+	}
+	start := end
+	for start > 0 && isAssistantMessageItem(items[start-1]) {
+		start--
+	}
+	return start
+}
+
+func isAssistantMessageItem(item sqlc.CtxItem) bool {
+	return item.ItemType == itemTypeMessage && item.Role == roleAssistant
 }
 
 // stripTrailingOrphanResults removes ToolResultMessages from the end of msgs
@@ -329,17 +349,36 @@ func resolveTailFromCaches(items []sqlc.CtxItem, messages map[string]sqlc.CtxMes
 // resolveItemsFromCaches resolves a slice of context items to ai.Messages.
 func resolveItemsFromCaches(items []sqlc.CtxItem, messages map[string]sqlc.CtxMessage, summaries map[string]sqlc.CtxSummary, children map[string][]sqlc.CtxSummary, partsByMessage map[string][]loadedMessagePart) ([]ai.Message, error) {
 	var result []ai.Message
-	for _, item := range items {
+	for i := 0; i < len(items); i++ {
+		item := items[i]
 		switch item.ItemType {
 		case itemTypeMessage:
 			if !item.MessageID.Valid {
+				continue
+			}
+			if item.Role == roleAssistant {
+				// Reconstruct all adjacent rows from one assistant turn together so
+				// rowsToMessages can merge parallel tool calls into one message.
+				rows := make([]sqlc.CtxMessage, 0, 1)
+				for ; i < len(items) && isAssistantMessageItem(items[i]); i++ {
+					assistantItem := items[i]
+					if !assistantItem.MessageID.Valid {
+						continue
+					}
+					msg, ok := messages[assistantItem.MessageID.String]
+					if !ok {
+						return nil, fmt.Errorf("get message %s: %w", assistantItem.MessageID.String, pgx.ErrNoRows)
+					}
+					rows = append(rows, msg)
+				}
+				i--
+				result = append(result, rowsToMessages(rows, partsByMessage)...)
 				continue
 			}
 			msg, ok := messages[item.MessageID.String]
 			if !ok {
 				return nil, fmt.Errorf("get message %s: %w", item.MessageID.String, pgx.ErrNoRows)
 			}
-			// Preserve the pre-existing one-context-item-to-one-message reconstruction.
 			result = append(result, rowsToMessages([]sqlc.CtxMessage{msg}, partsByMessage)...)
 		case itemTypeSummary:
 			if !item.SummaryID.Valid {
@@ -449,67 +488,102 @@ func (a *assembler) loadContextWindow(ctx context.Context, convID string) ([]sql
 	return items, messages, summaries, children, partsByMessage, nil
 }
 
-// sanitizeToolPairs is a defense-in-depth pass that enforces the tool pairing
-// contract: every ToolResultMessage must have a *preceding* AssistantMessage
-// containing a ToolCall with the same ID. Orphan tool_results are dropped
-// (not promoted to UserMessage — tool output is untrusted and must not gain
-// user-role privilege). Orphan tool_calls are stripped from assembled history;
-// memory assembly always runs before the next live user message is appended.
+// sanitizeToolPairs is a defense-in-depth pass that enforces the provider tool
+// protocol: one assistant turn contains every parallel call, followed immediately
+// by the consecutive results for that turn. Orphan results are dropped rather
+// than promoted to user input, and calls without an adjacent result are stripped.
+// Memory assembly always runs before the next live user message is appended.
 func sanitizeToolPairs(msgs []ai.Message) []ai.Message {
-	// Forward scan: track call IDs as they appear, validate results against
-	// only previously-seen calls.
-	seenCalls := make(map[string]struct{})
+	msgs = mergeAdjacentAssistantMessages(msgs)
 	result := make([]ai.Message, 0, len(msgs))
-	for _, m := range msgs {
-		switch msg := m.(type) {
-		case ai.AssistantMessage:
-			for _, b := range msg.Content {
-				if tc, ok := b.(ai.ToolCall); ok {
-					seenCalls[tc.ID] = struct{}{}
-				}
-			}
-			result = append(result, m)
-		case ai.ToolResultMessage:
-			if _, found := seenCalls[msg.ToolCallID]; found {
-				result = append(result, m)
-			}
-			// Orphan tool_result: drop silently.
-		default:
-			result = append(result, m)
-		}
-	}
-
-	// Strip orphan tool_calls from assistant messages. Although a final assistant
-	// tool_call can be valid while a model turn is in progress, assembled memory
-	// history is always followed by the next live user message before provider IO.
-	resultIDs := make(map[string]struct{})
-	for _, m := range result {
-		if tr, ok := m.(ai.ToolResultMessage); ok {
-			resultIDs[tr.ToolCallID] = struct{}{}
-		}
-	}
-	for i, m := range result {
-		am, ok := m.(ai.AssistantMessage)
+	for i := 0; i < len(msgs); i++ {
+		assistant, ok := msgs[i].(ai.AssistantMessage)
 		if !ok {
+			// A result outside the consecutive run owned by the immediately
+			// preceding assistant turn is an orphan and remains untrusted.
+			if _, orphan := msgs[i].(ai.ToolResultMessage); !orphan {
+				result = append(result, msgs[i])
+			}
 			continue
 		}
-		var filtered []ai.ContentBlock
-		for _, b := range am.Content {
-			if tc, isTC := b.(ai.ToolCall); isTC {
-				if _, found := resultIDs[tc.ID]; !found {
-					continue
-				}
-			}
-			filtered = append(filtered, b)
-		}
-		if len(filtered) == 0 {
-			filtered = []ai.ContentBlock{ai.TextContent{Text: "[tool calls compacted]"}}
-		}
-		am.Content = filtered
-		result[i] = am
-	}
 
+		calls := toolCallsByID(assistant)
+		if len(calls) == 0 {
+			result = append(result, assistant)
+			continue
+		}
+
+		matched := make(map[string]struct{}, len(calls))
+		var toolResults []ai.Message
+		j := i + 1
+		for ; j < len(msgs); j++ {
+			toolResult, isResult := msgs[j].(ai.ToolResultMessage)
+			if !isResult {
+				break
+			}
+			if _, belongs := calls[toolResult.ToolCallID]; !belongs {
+				continue
+			}
+			if _, duplicate := matched[toolResult.ToolCallID]; duplicate {
+				continue
+			}
+			matched[toolResult.ToolCallID] = struct{}{}
+			toolResults = append(toolResults, toolResult)
+		}
+
+		assistant.Content = filterAssistantToolCalls(assistant.Content, matched)
+		result = append(result, assistant)
+		result = append(result, toolResults...)
+		i = j - 1
+	}
 	return result
+}
+
+// mergeAdjacentAssistantMessages restores the message boundary lost when one
+// assistant response is persisted as separate text, thinking, and tool-call rows.
+func mergeAdjacentAssistantMessages(msgs []ai.Message) []ai.Message {
+	result := make([]ai.Message, 0, len(msgs))
+	for _, msg := range msgs {
+		assistant, ok := msg.(ai.AssistantMessage)
+		if !ok || len(result) == 0 {
+			result = append(result, msg)
+			continue
+		}
+		previous, adjacent := result[len(result)-1].(ai.AssistantMessage)
+		if !adjacent {
+			result = append(result, msg)
+			continue
+		}
+		previous.Content = append(previous.Content, assistant.Content...)
+		result[len(result)-1] = previous
+	}
+	return result
+}
+
+func toolCallsByID(message ai.AssistantMessage) map[string]struct{} {
+	calls := make(map[string]struct{})
+	for _, block := range message.Content {
+		if call, ok := block.(ai.ToolCall); ok && call.ID != "" {
+			calls[call.ID] = struct{}{}
+		}
+	}
+	return calls
+}
+
+func filterAssistantToolCalls(content []ai.ContentBlock, matched map[string]struct{}) []ai.ContentBlock {
+	filtered := make([]ai.ContentBlock, 0, len(content))
+	for _, block := range content {
+		if call, ok := block.(ai.ToolCall); ok {
+			if _, found := matched[call.ID]; !found {
+				continue
+			}
+		}
+		filtered = append(filtered, block)
+	}
+	if len(filtered) == 0 {
+		return []ai.ContentBlock{ai.TextContent{Text: "[tool calls compacted]"}}
+	}
+	return filtered
 }
 
 // FormatSummaryXML formats a summary as XML for model consumption.

--- a/internal/memory/lcm/assembler.go
+++ b/internal/memory/lcm/assembler.go
@@ -2,7 +2,6 @@ package lcm
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -264,11 +263,15 @@ func advancePastOldestTurn(items []sqlc.CtxItem, splitIdx int) (int, bool) {
 func resolveOlderWithinBudget(older []sqlc.CtxItem, messages map[string]sqlc.CtxMessage, summaries map[string]sqlc.CtxSummary, children map[string][]sqlc.CtxSummary, partsByMessage map[string][]loadedMessagePart, remaining int) ([]ai.Message, error) {
 	var olderMsgs []ai.Message
 	for i := len(older) - 1; i >= 0; i-- {
-		start, end := contextItemGroupBounds(older, i, messages)
+		start, end := contextItemGroupBounds(older, i)
 		msgs, err := resolveItemsFromCaches(older[start:end], messages, summaries, children, partsByMessage)
 		if err != nil {
 			return nil, fmt.Errorf("resolve item %d: %w", older[start].Ordinal, err)
 		}
+		// Admission must cost the exact provider-visible projection. Incomplete
+		// or ambiguous persisted calls can be much larger than the completed
+		// subset that survives replay sanitization.
+		msgs = sanitizeToolPairs(msgs)
 		tokens := 0
 		for _, m := range msgs {
 			tokens += estimateMessageTokens(m)
@@ -288,98 +291,54 @@ func resolveOlderWithinBudget(older []sqlc.CtxItem, messages map[string]sqlc.Ctx
 	return olderMsgs, nil
 }
 
-// contextItemGroupBounds returns an atomic parallel tool turn containing index.
-// Ordinary assistant rows remain singletons because adjacency is not a stable
-// response boundary.
-func contextItemGroupBounds(items []sqlc.CtxItem, index int, messages map[string]sqlc.CtxMessage) (int, int) {
+// contextItemGroupBounds returns the structurally contiguous tool-call/result
+// group containing index. Only the tool-call suffix immediately before results
+// is grouped; preceding ordinary assistant rows remain independent messages.
+func contextItemGroupBounds(items []sqlc.CtxItem, index int) (int, int) {
 	if index < 0 || index >= len(items) {
 		return index, index + 1
 	}
-	assistantIndex := index
-	if items[index].ItemType == itemTypeMessage && items[index].EventType == eventTypeToolResult {
-		for assistantIndex >= 0 && items[assistantIndex].ItemType == itemTypeMessage && items[assistantIndex].EventType == eventTypeToolResult {
-			assistantIndex--
+
+	resultStart := index
+	switch {
+	case isAssistantToolCallItem(items[index]):
+		for resultStart < len(items) && isAssistantToolCallItem(items[resultStart]) {
+			resultStart++
 		}
-	}
-	start, assistantEnd, ok := assistantItemRunBounds(items, assistantIndex)
-	if !ok {
+		if resultStart >= len(items) || !isToolResultItem(items[resultStart]) {
+			return index, index + 1
+		}
+	case isToolResultItem(items[index]):
+		for resultStart > 0 && isToolResultItem(items[resultStart-1]) {
+			resultStart--
+		}
+	default:
 		return index, index + 1
 	}
-	resultEnd := assistantEnd
-	for resultEnd < len(items) && items[resultEnd].ItemType == itemTypeMessage && items[resultEnd].EventType == eventTypeToolResult {
+
+	callStart := resultStart
+	for callStart > 0 && isAssistantToolCallItem(items[callStart-1]) {
+		callStart--
+	}
+	if callStart == resultStart {
+		return index, index + 1
+	}
+	resultEnd := resultStart
+	for resultEnd < len(items) && isToolResultItem(items[resultEnd]) {
 		resultEnd++
 	}
-	if index >= start && index < resultEnd && assistantItemRunOwnsImmediateResults(items, start, assistantEnd, messages) {
-		return start, resultEnd
+	if index >= callStart && index < resultEnd {
+		return callStart, resultEnd
 	}
 	return index, index + 1
 }
 
-func isAssistantMessageItem(item sqlc.CtxItem) bool {
-	return item.ItemType == itemTypeMessage && item.Role == roleAssistant
+func isToolResultItem(item sqlc.CtxItem) bool {
+	return item.ItemType == itemTypeMessage && item.EventType == eventTypeToolResult
 }
 
 func isAssistantToolCallItem(item sqlc.CtxItem) bool {
-	return isAssistantMessageItem(item) && item.EventType == eventTypeToolCall
-}
-
-func assistantItemRunBounds(items []sqlc.CtxItem, index int) (int, int, bool) {
-	if index < 0 || index >= len(items) || !isAssistantMessageItem(items[index]) {
-		return index, index, false
-	}
-	start := index
-	for start > 0 && isAssistantMessageItem(items[start-1]) {
-		start--
-	}
-	end := index + 1
-	for end < len(items) && isAssistantMessageItem(items[end]) {
-		end++
-	}
-	return start, end, true
-}
-
-func assistantItemRunOwnsImmediateResults(items []sqlc.CtxItem, start, end int, messages map[string]sqlc.CtxMessage) bool {
-	callCounts := make(map[string]int)
-	for _, item := range items[start:end] {
-		if !isAssistantToolCallItem(item) || !item.MessageID.Valid {
-			continue
-		}
-		row, ok := messages[item.MessageID.String]
-		if !ok {
-			return false
-		}
-		call, ok := decodeToolCall(row.Content)
-		if !ok {
-			return false
-		}
-		callCounts[call.ID]++
-	}
-	if len(callCounts) == 0 {
-		return false
-	}
-
-	resultCounts := make(map[string]int)
-	for end < len(items) && items[end].ItemType == itemTypeMessage && items[end].EventType == eventTypeToolResult {
-		item := items[end]
-		if !item.MessageID.Valid {
-			return false
-		}
-		row, ok := messages[item.MessageID.String]
-		if !ok {
-			return false
-		}
-		var envelope toolResultEnvelope
-		if err := json.Unmarshal([]byte(row.Content), &envelope); err != nil {
-			return false
-		}
-		resultCounts[envelope.ID]++
-		end++
-	}
-	// A crash or cancellation may persist only a subset of parallel results.
-	// One unambiguous completed pair is enough to prove that these adjacent
-	// assistant rows belong to the result run; sanitizeToolPairs later removes
-	// incomplete and conflicting ID groups from the reconstructed turn.
-	return hasUniqueCompletedToolPair(callCounts, resultCounts)
+	return item.ItemType == itemTypeMessage && item.Role == roleAssistant && item.EventType == eventTypeToolCall
 }
 
 // stripTrailingOrphanResults removes ToolResultMessages from the end of msgs
@@ -419,6 +378,8 @@ func resolveTailFromCaches(items []sqlc.CtxItem, messages map[string]sqlc.CtxMes
 		return nil, 0, 0, err
 	}
 	msgs, compacted := compactOversizedTailResults(msgs)
+	// Tail cost and older admission use the same provider-visible projection.
+	msgs = sanitizeToolPairs(msgs)
 	tokens := 0
 	for _, msg := range msgs {
 		tokens += estimateMessageTokens(msg)
@@ -436,19 +397,19 @@ func resolveItemsFromCaches(items []sqlc.CtxItem, messages map[string]sqlc.CtxMe
 			if !item.MessageID.Valid {
 				continue
 			}
-			if start, end, ok := assistantItemRunBounds(items, i); ok && start == i && assistantItemRunOwnsImmediateResults(items, start, end, messages) {
-				// Reconstruct an assistant run only after its immediately following
-				// results prove a unique one-to-one tool turn. Adjacency alone is not
-				// a stable boundary for separately appended ordinary messages.
-				rows := make([]sqlc.CtxMessage, 0, 1)
+			if start, end := contextItemGroupBounds(items, i); start == i && end > i+1 {
+				// Reconstruct only the persisted tool-call suffix and its immediate
+				// results. Earlier assistant text/thinking may be a separate Append
+				// and cannot be joined safely without a durable response ID.
+				rows := make([]sqlc.CtxMessage, 0, end-start)
 				for ; i < end; i++ {
-					assistantItem := items[i]
-					if !assistantItem.MessageID.Valid {
+					groupItem := items[i]
+					if !groupItem.MessageID.Valid {
 						continue
 					}
-					msg, ok := messages[assistantItem.MessageID.String]
+					msg, ok := messages[groupItem.MessageID.String]
 					if !ok {
-						return nil, fmt.Errorf("get message %s: %w", assistantItem.MessageID.String, pgx.ErrNoRows)
+						return nil, fmt.Errorf("get message %s: %w", groupItem.MessageID.String, pgx.ErrNoRows)
 					}
 					rows = append(rows, msg)
 				}
@@ -575,7 +536,7 @@ func (a *assembler) loadContextWindow(ctx context.Context, convID string) ([]sql
 // than promoted to user input, and calls without an adjacent result are stripped.
 // Memory assembly always runs before the next live user message is appended.
 func sanitizeToolPairs(msgs []ai.Message) []ai.Message {
-	msgs = mergeAssistantRunsWithImmediateResults(msgs)
+	msgs = mergeToolCallRunsWithImmediateResults(msgs)
 	result := make([]ai.Message, 0, len(msgs))
 	for i := 0; i < len(msgs); i++ {
 		assistant, ok := msgs[i].(ai.AssistantMessage)
@@ -623,13 +584,13 @@ func sanitizeToolPairs(msgs []ai.Message) []ai.Message {
 	return result
 }
 
-// mergeAssistantRunsWithImmediateResults restores assistant blocks persisted as
-// separate rows when the following results prove at least one completed tool
-// pair. The sanitizer then keeps only completed, unambiguous ID groups.
-func mergeAssistantRunsWithImmediateResults(msgs []ai.Message) []ai.Message {
+// mergeToolCallRunsWithImmediateResults restores only consecutive tool-call-only
+// assistant messages immediately followed by results. Ordinary assistant content
+// before that suffix remains separate because adjacency is not a response ID.
+func mergeToolCallRunsWithImmediateResults(msgs []ai.Message) []ai.Message {
 	result := make([]ai.Message, 0, len(msgs))
 	for i := 0; i < len(msgs); {
-		first, ok := msgs[i].(ai.AssistantMessage)
+		first, ok := toolCallOnlyAssistant(msgs[i])
 		if !ok {
 			result = append(result, msgs[i])
 			i++
@@ -639,7 +600,7 @@ func mergeAssistantRunsWithImmediateResults(msgs []ai.Message) []ai.Message {
 		end := i + 1
 		combined := first
 		for end < len(msgs) {
-			next, adjacent := msgs[end].(ai.AssistantMessage)
+			next, adjacent := toolCallOnlyAssistant(msgs[end])
 			if !adjacent {
 				break
 			}
@@ -653,8 +614,7 @@ func mergeAssistantRunsWithImmediateResults(msgs []ai.Message) []ai.Message {
 			}
 			resultEnd++
 		}
-		callCounts, hasCalls := toolCallIDCounts(combined)
-		if end == i+1 || !hasCalls || !hasUniqueCompletedToolPair(callCounts, toolResultIDCounts(msgs[end:resultEnd])) {
+		if end == i+1 || resultEnd == end {
 			result = append(result, msgs[i:end]...)
 			i = end
 			continue
@@ -663,6 +623,19 @@ func mergeAssistantRunsWithImmediateResults(msgs []ai.Message) []ai.Message {
 		i = end
 	}
 	return result
+}
+
+func toolCallOnlyAssistant(message ai.Message) (ai.AssistantMessage, bool) {
+	assistant, ok := message.(ai.AssistantMessage)
+	if !ok || len(assistant.Content) == 0 {
+		return ai.AssistantMessage{}, false
+	}
+	for _, block := range assistant.Content {
+		if _, isCall := block.(ai.ToolCall); !isCall {
+			return ai.AssistantMessage{}, false
+		}
+	}
+	return assistant, true
 }
 
 func toolCallIDCounts(message ai.AssistantMessage) (map[string]int, bool) {
@@ -685,15 +658,6 @@ func toolResultIDCounts(messages []ai.Message) map[string]int {
 		}
 	}
 	return counts
-}
-
-func hasUniqueCompletedToolPair(callCounts, resultCounts map[string]int) bool {
-	for id, count := range callCounts {
-		if id != "" && count == 1 && resultCounts[id] == 1 {
-			return true
-		}
-	}
-	return false
 }
 
 func filterAssistantToolCalls(content []ai.ContentBlock, matched map[string]struct{}) []ai.ContentBlock {

--- a/internal/memory/lcm/assembler.go
+++ b/internal/memory/lcm/assembler.go
@@ -2,6 +2,7 @@ package lcm
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -263,8 +264,8 @@ func advancePastOldestTurn(items []sqlc.CtxItem, splitIdx int) (int, bool) {
 func resolveOlderWithinBudget(older []sqlc.CtxItem, messages map[string]sqlc.CtxMessage, summaries map[string]sqlc.CtxSummary, children map[string][]sqlc.CtxSummary, partsByMessage map[string][]loadedMessagePart, remaining int) ([]ai.Message, error) {
 	var olderMsgs []ai.Message
 	for i := len(older) - 1; i >= 0; i-- {
-		start := contextItemGroupStart(older, i)
-		msgs, err := resolveItemsFromCaches(older[start:i+1], messages, summaries, children, partsByMessage)
+		start, end := contextItemGroupBounds(older, i, messages)
+		msgs, err := resolveItemsFromCaches(older[start:end], messages, summaries, children, partsByMessage)
 		if err != nil {
 			return nil, fmt.Errorf("resolve item %d: %w", older[start].Ordinal, err)
 		}
@@ -277,29 +278,104 @@ func resolveOlderWithinBudget(older []sqlc.CtxItem, messages map[string]sqlc.Ctx
 			return olderMsgs, nil
 		}
 		remaining -= tokens
-		olderMsgs = append(olderMsgs, msgs...)
+		// olderMsgs is accumulated newest-first. Reverse every atomic group now
+		// so the final whole-slice reversal restores its internal chronology.
+		for j := len(msgs) - 1; j >= 0; j-- {
+			olderMsgs = append(olderMsgs, msgs[j])
+		}
 		i = start
 	}
 	return olderMsgs, nil
 }
 
-// contextItemGroupStart returns the first item in the logical message ending at
-// end. Assistant blocks from one model turn are stored as adjacent rows, so the
-// older-history budget must admit or reject the whole run instead of splitting
-// parallel tool calls into separate assistant messages.
-func contextItemGroupStart(items []sqlc.CtxItem, end int) int {
-	if end < 0 || end >= len(items) || !isAssistantMessageItem(items[end]) {
-		return end
+// contextItemGroupBounds returns an atomic parallel tool turn containing index.
+// Ordinary assistant rows remain singletons because adjacency is not a stable
+// response boundary.
+func contextItemGroupBounds(items []sqlc.CtxItem, index int, messages map[string]sqlc.CtxMessage) (int, int) {
+	if index < 0 || index >= len(items) {
+		return index, index + 1
 	}
-	start := end
-	for start > 0 && isAssistantMessageItem(items[start-1]) {
-		start--
+	assistantIndex := index
+	if items[index].ItemType == itemTypeMessage && items[index].EventType == eventTypeToolResult {
+		for assistantIndex >= 0 && items[assistantIndex].ItemType == itemTypeMessage && items[assistantIndex].EventType == eventTypeToolResult {
+			assistantIndex--
+		}
 	}
-	return start
+	start, assistantEnd, ok := assistantItemRunBounds(items, assistantIndex)
+	if !ok {
+		return index, index + 1
+	}
+	resultEnd := assistantEnd
+	for resultEnd < len(items) && items[resultEnd].ItemType == itemTypeMessage && items[resultEnd].EventType == eventTypeToolResult {
+		resultEnd++
+	}
+	if index >= start && index < resultEnd && assistantItemRunOwnsImmediateResults(items, start, assistantEnd, messages) {
+		return start, resultEnd
+	}
+	return index, index + 1
 }
 
 func isAssistantMessageItem(item sqlc.CtxItem) bool {
 	return item.ItemType == itemTypeMessage && item.Role == roleAssistant
+}
+
+func isAssistantToolCallItem(item sqlc.CtxItem) bool {
+	return isAssistantMessageItem(item) && item.EventType == eventTypeToolCall
+}
+
+func assistantItemRunBounds(items []sqlc.CtxItem, index int) (int, int, bool) {
+	if index < 0 || index >= len(items) || !isAssistantMessageItem(items[index]) {
+		return index, index, false
+	}
+	start := index
+	for start > 0 && isAssistantMessageItem(items[start-1]) {
+		start--
+	}
+	end := index + 1
+	for end < len(items) && isAssistantMessageItem(items[end]) {
+		end++
+	}
+	return start, end, true
+}
+
+func assistantItemRunOwnsImmediateResults(items []sqlc.CtxItem, start, end int, messages map[string]sqlc.CtxMessage) bool {
+	callCounts := make(map[string]int)
+	for _, item := range items[start:end] {
+		if !isAssistantToolCallItem(item) || !item.MessageID.Valid {
+			continue
+		}
+		row, ok := messages[item.MessageID.String]
+		if !ok {
+			return false
+		}
+		call, ok := decodeToolCall(row.Content)
+		if !ok {
+			return false
+		}
+		callCounts[call.ID]++
+	}
+	if len(callCounts) == 0 {
+		return false
+	}
+
+	resultCounts := make(map[string]int)
+	for end < len(items) && items[end].ItemType == itemTypeMessage && items[end].EventType == eventTypeToolResult {
+		item := items[end]
+		if !item.MessageID.Valid {
+			return false
+		}
+		row, ok := messages[item.MessageID.String]
+		if !ok {
+			return false
+		}
+		var envelope toolResultEnvelope
+		if err := json.Unmarshal([]byte(row.Content), &envelope); err != nil {
+			return false
+		}
+		resultCounts[envelope.ID]++
+		end++
+	}
+	return validUniqueToolPairs(callCounts, resultCounts)
 }
 
 // stripTrailingOrphanResults removes ToolResultMessages from the end of msgs
@@ -356,11 +432,12 @@ func resolveItemsFromCaches(items []sqlc.CtxItem, messages map[string]sqlc.CtxMe
 			if !item.MessageID.Valid {
 				continue
 			}
-			if item.Role == roleAssistant {
-				// Reconstruct all adjacent rows from one assistant turn together so
-				// rowsToMessages can merge parallel tool calls into one message.
+			if start, end, ok := assistantItemRunBounds(items, i); ok && start == i && assistantItemRunOwnsImmediateResults(items, start, end, messages) {
+				// Reconstruct an assistant run only after its immediately following
+				// results prove a unique one-to-one tool turn. Adjacency alone is not
+				// a stable boundary for separately appended ordinary messages.
 				rows := make([]sqlc.CtxMessage, 0, 1)
-				for ; i < len(items) && isAssistantMessageItem(items[i]); i++ {
+				for ; i < end; i++ {
 					assistantItem := items[i]
 					if !assistantItem.MessageID.Valid {
 						continue
@@ -494,7 +571,7 @@ func (a *assembler) loadContextWindow(ctx context.Context, convID string) ([]sql
 // than promoted to user input, and calls without an adjacent result are stripped.
 // Memory assembly always runs before the next live user message is appended.
 func sanitizeToolPairs(msgs []ai.Message) []ai.Message {
-	msgs = mergeAdjacentAssistantMessages(msgs)
+	msgs = mergeAssistantRunsWithImmediateResults(msgs)
 	result := make([]ai.Message, 0, len(msgs))
 	for i := 0; i < len(msgs); i++ {
 		assistant, ok := msgs[i].(ai.AssistantMessage)
@@ -507,67 +584,114 @@ func sanitizeToolPairs(msgs []ai.Message) []ai.Message {
 			continue
 		}
 
-		calls := toolCallsByID(assistant)
-		if len(calls) == 0 {
+		callCounts, hasCalls := toolCallIDCounts(assistant)
+		if !hasCalls {
 			result = append(result, assistant)
 			continue
 		}
 
-		matched := make(map[string]struct{}, len(calls))
-		var toolResults []ai.Message
 		j := i + 1
 		for ; j < len(msgs); j++ {
-			toolResult, isResult := msgs[j].(ai.ToolResultMessage)
-			if !isResult {
+			if _, isResult := msgs[j].(ai.ToolResultMessage); !isResult {
 				break
 			}
-			if _, belongs := calls[toolResult.ToolCallID]; !belongs {
-				continue
+		}
+		resultCounts := toolResultIDCounts(msgs[i+1 : j])
+		matched := make(map[string]struct{}, len(callCounts))
+		for id, count := range callCounts {
+			// Empty or duplicate IDs are ambiguous and cannot be repaired by
+			// choosing one payload. Drop that complete ID group deterministically.
+			if id != "" && count == 1 && resultCounts[id] == 1 {
+				matched[id] = struct{}{}
 			}
-			if _, duplicate := matched[toolResult.ToolCallID]; duplicate {
-				continue
-			}
-			matched[toolResult.ToolCallID] = struct{}{}
-			toolResults = append(toolResults, toolResult)
 		}
 
 		assistant.Content = filterAssistantToolCalls(assistant.Content, matched)
 		result = append(result, assistant)
-		result = append(result, toolResults...)
+		for _, message := range msgs[i+1 : j] {
+			toolResult := message.(ai.ToolResultMessage)
+			if _, keep := matched[toolResult.ToolCallID]; keep {
+				result = append(result, toolResult)
+			}
+		}
 		i = j - 1
 	}
 	return result
 }
 
-// mergeAdjacentAssistantMessages restores the message boundary lost when one
-// assistant response is persisted as separate text, thinking, and tool-call rows.
-func mergeAdjacentAssistantMessages(msgs []ai.Message) []ai.Message {
+// mergeAssistantRunsWithImmediateResults restores assistant blocks persisted as
+// separate rows only when the following result set proves a unique tool turn.
+func mergeAssistantRunsWithImmediateResults(msgs []ai.Message) []ai.Message {
 	result := make([]ai.Message, 0, len(msgs))
-	for _, msg := range msgs {
-		assistant, ok := msg.(ai.AssistantMessage)
-		if !ok || len(result) == 0 {
-			result = append(result, msg)
+	for i := 0; i < len(msgs); {
+		first, ok := msgs[i].(ai.AssistantMessage)
+		if !ok {
+			result = append(result, msgs[i])
+			i++
 			continue
 		}
-		previous, adjacent := result[len(result)-1].(ai.AssistantMessage)
-		if !adjacent {
-			result = append(result, msg)
+
+		end := i + 1
+		combined := first
+		for end < len(msgs) {
+			next, adjacent := msgs[end].(ai.AssistantMessage)
+			if !adjacent {
+				break
+			}
+			combined.Content = append(combined.Content, next.Content...)
+			end++
+		}
+		resultEnd := end
+		for resultEnd < len(msgs) {
+			if _, isResult := msgs[resultEnd].(ai.ToolResultMessage); !isResult {
+				break
+			}
+			resultEnd++
+		}
+		callCounts, hasCalls := toolCallIDCounts(combined)
+		if end == i+1 || !hasCalls || !validUniqueToolPairs(callCounts, toolResultIDCounts(msgs[end:resultEnd])) {
+			result = append(result, msgs[i:end]...)
+			i = end
 			continue
 		}
-		previous.Content = append(previous.Content, assistant.Content...)
-		result[len(result)-1] = previous
+		result = append(result, combined)
+		i = end
 	}
 	return result
 }
 
-func toolCallsByID(message ai.AssistantMessage) map[string]struct{} {
-	calls := make(map[string]struct{})
+func toolCallIDCounts(message ai.AssistantMessage) (map[string]int, bool) {
+	counts := make(map[string]int)
+	hasCalls := false
 	for _, block := range message.Content {
-		if call, ok := block.(ai.ToolCall); ok && call.ID != "" {
-			calls[call.ID] = struct{}{}
+		if call, ok := block.(ai.ToolCall); ok {
+			hasCalls = true
+			counts[call.ID]++
 		}
 	}
-	return calls
+	return counts, hasCalls
+}
+
+func toolResultIDCounts(messages []ai.Message) map[string]int {
+	counts := make(map[string]int)
+	for _, message := range messages {
+		if result, ok := message.(ai.ToolResultMessage); ok {
+			counts[result.ToolCallID]++
+		}
+	}
+	return counts
+}
+
+func validUniqueToolPairs(callCounts, resultCounts map[string]int) bool {
+	if len(callCounts) == 0 || len(callCounts) != len(resultCounts) {
+		return false
+	}
+	for id, count := range callCounts {
+		if id == "" || count != 1 || resultCounts[id] != 1 {
+			return false
+		}
+	}
+	return true
 }
 
 func filterAssistantToolCalls(content []ai.ContentBlock, matched map[string]struct{}) []ai.ContentBlock {

--- a/internal/memory/lcm/assembler.go
+++ b/internal/memory/lcm/assembler.go
@@ -375,7 +375,11 @@ func assistantItemRunOwnsImmediateResults(items []sqlc.CtxItem, start, end int, 
 		resultCounts[envelope.ID]++
 		end++
 	}
-	return validUniqueToolPairs(callCounts, resultCounts)
+	// A crash or cancellation may persist only a subset of parallel results.
+	// One unambiguous completed pair is enough to prove that these adjacent
+	// assistant rows belong to the result run; sanitizeToolPairs later removes
+	// incomplete and conflicting ID groups from the reconstructed turn.
+	return hasUniqueCompletedToolPair(callCounts, resultCounts)
 }
 
 // stripTrailingOrphanResults removes ToolResultMessages from the end of msgs
@@ -620,7 +624,8 @@ func sanitizeToolPairs(msgs []ai.Message) []ai.Message {
 }
 
 // mergeAssistantRunsWithImmediateResults restores assistant blocks persisted as
-// separate rows only when the following result set proves a unique tool turn.
+// separate rows when the following results prove at least one completed tool
+// pair. The sanitizer then keeps only completed, unambiguous ID groups.
 func mergeAssistantRunsWithImmediateResults(msgs []ai.Message) []ai.Message {
 	result := make([]ai.Message, 0, len(msgs))
 	for i := 0; i < len(msgs); {
@@ -649,7 +654,7 @@ func mergeAssistantRunsWithImmediateResults(msgs []ai.Message) []ai.Message {
 			resultEnd++
 		}
 		callCounts, hasCalls := toolCallIDCounts(combined)
-		if end == i+1 || !hasCalls || !validUniqueToolPairs(callCounts, toolResultIDCounts(msgs[end:resultEnd])) {
+		if end == i+1 || !hasCalls || !hasUniqueCompletedToolPair(callCounts, toolResultIDCounts(msgs[end:resultEnd])) {
 			result = append(result, msgs[i:end]...)
 			i = end
 			continue
@@ -682,16 +687,13 @@ func toolResultIDCounts(messages []ai.Message) map[string]int {
 	return counts
 }
 
-func validUniqueToolPairs(callCounts, resultCounts map[string]int) bool {
-	if len(callCounts) == 0 || len(callCounts) != len(resultCounts) {
-		return false
-	}
+func hasUniqueCompletedToolPair(callCounts, resultCounts map[string]int) bool {
 	for id, count := range callCounts {
-		if id == "" || count != 1 || resultCounts[id] != 1 {
-			return false
+		if id != "" && count == 1 && resultCounts[id] == 1 {
+			return true
 		}
 	}
-	return true
+	return false
 }
 
 func filterAssistantToolCalls(content []ai.ContentBlock, matched map[string]struct{}) []ai.ContentBlock {

--- a/internal/memory/lcm/assembler_context_window_test.go
+++ b/internal/memory/lcm/assembler_context_window_test.go
@@ -194,6 +194,8 @@ func TestAssembleParallelToolCallsRemainOneAssistantTurn(t *testing.T) {
 			}
 
 			appendMessage(roleUser, eventTypeText, "look up both values")
+			appendMessage(roleAssistant, eventTypeThinking, "checking both sources")
+			appendMessage(roleAssistant, eventTypeText, "running searches")
 			for _, call := range []toolCallEnvelope{
 				{ID: "call-a", Tool: "search", Args: json.RawMessage(`{"query":"a"}`)},
 				{ID: "call-b", Tool: "search", Args: json.RawMessage(`{"query":"b"}`)},
@@ -232,19 +234,128 @@ func TestAssembleParallelToolCallsRemainOneAssistantTurn(t *testing.T) {
 			if !ok {
 				t.Fatalf("parallel tool turn = %T, want ai.AssistantMessage", got[1])
 			}
-			if len(assistant.Content) != 2 {
-				t.Fatalf("parallel tool blocks = %d, want 2: %#v", len(assistant.Content), assistant.Content)
+			if len(assistant.Content) != 4 {
+				t.Fatalf("parallel tool blocks = %d, want thinking, text, and 2 calls: %#v", len(assistant.Content), assistant.Content)
 			}
 			for i, wantID := range []string{"call-a", "call-b"} {
-				call, ok := assistant.Content[i].(ai.ToolCall)
+				call, ok := assistant.Content[i+2].(ai.ToolCall)
 				if !ok || call.ID != wantID {
-					t.Fatalf("tool call %d = %#v, want %s", i, assistant.Content[i], wantID)
+					t.Fatalf("tool call %d = %#v, want %s", i, assistant.Content[i+2], wantID)
 				}
 			}
 			for i, wantID := range []string{"call-a", "call-b"} {
 				result, ok := got[i+2].(ai.ToolResultMessage)
 				if !ok || result.ToolCallID != wantID {
 					t.Fatalf("tool result %d = %#v, want %s", i, got[i+2], wantID)
+				}
+			}
+		})
+	}
+}
+
+func TestAssembleKeepsAdjacentOrdinaryAssistantMessagesSeparate(t *testing.T) {
+	db := newAssemblerTestDB(t)
+	defer db.Close()
+
+	ctx := context.Background()
+	q := sqlc.New(db)
+	convID := uuid.NewString()
+	if _, err := db.Exec(ctx, `INSERT INTO ctx_conversation (id, session_id, channel, kind) VALUES ($1, $2, 'test', 'chat')`, convID, uuid.NewString()); err != nil {
+		t.Fatalf("insert conversation: %v", err)
+	}
+	for i, content := range []string{"partial response", "timeout notice"} {
+		id := uuid.NewString()
+		seq := int64(i + 1)
+		if _, err := q.CreateMessage(ctx, sqlc.CreateMessageParams{
+			ID: id, ConversationID: convID, Seq: seq, Role: roleAssistant,
+			EventType: eventTypeText, Content: content, ActorType: string(eventlog.ActorAgent),
+			TokenCount: int64(memoryEstimate(content)),
+		}); err != nil {
+			t.Fatalf("create assistant message: %v", err)
+		}
+		if err := q.AppendContextItem(ctx, sqlc.AppendContextItemParams{
+			ConversationID: convID, Ordinal: seq, ItemType: itemTypeMessage,
+			MessageID: pgtype.Text{String: id, Valid: true}, EventType: eventTypeText, Role: roleAssistant,
+		}); err != nil {
+			t.Fatalf("append assistant item: %v", err)
+		}
+	}
+
+	got, err := newAssembler(q, nil).assemble(ctx, convID, 100_000, 1)
+	if err != nil {
+		t.Fatalf("assemble: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("assembled ordinary assistant messages = %d, want 2", len(got))
+	}
+	for i, want := range []string{"partial response", "timeout notice"} {
+		assistant, ok := got[i].(ai.AssistantMessage)
+		if !ok || ai.FlattenText(assistant.Content) != want {
+			t.Fatalf("assistant %d = %#v, want %q", i, got[i], want)
+		}
+	}
+}
+
+func TestAssembleDropsEmptyToolCallIDBeforeProviderReplay(t *testing.T) {
+	for _, appendNext := range []bool{false, true} {
+		name := "fresh tail"
+		if appendNext {
+			name = "older budget history"
+		}
+		t.Run(name, func(t *testing.T) {
+			db := newAssemblerTestDB(t)
+			defer db.Close()
+
+			ctx := context.Background()
+			q := sqlc.New(db)
+			convID := uuid.NewString()
+			if _, err := db.Exec(ctx, `INSERT INTO ctx_conversation (id, session_id, channel, kind) VALUES ($1, $2, 'test', 'chat')`, convID, uuid.NewString()); err != nil {
+				t.Fatalf("insert conversation: %v", err)
+			}
+			ordinal := int64(0)
+			appendMessage := func(role, eventType, content string) {
+				t.Helper()
+				ordinal++
+				id := uuid.NewString()
+				if _, err := q.CreateMessage(ctx, sqlc.CreateMessageParams{
+					ID: id, ConversationID: convID, Seq: ordinal, Role: role,
+					EventType: eventType, Content: content, ActorType: string(eventlog.ActorAgent),
+					TokenCount: int64(memoryEstimate(content)),
+				}); err != nil {
+					t.Fatalf("create message: %v", err)
+				}
+				if err := q.AppendContextItem(ctx, sqlc.AppendContextItemParams{
+					ConversationID: convID, Ordinal: ordinal, ItemType: itemTypeMessage,
+					MessageID: pgtype.Text{String: id, Valid: true}, EventType: eventType, Role: role,
+				}); err != nil {
+					t.Fatalf("append context item: %v", err)
+				}
+			}
+
+			appendMessage(roleUser, eventTypeText, "run malformed tool")
+			call, _ := json.Marshal(toolCallEnvelope{ID: "", Tool: "search", Args: json.RawMessage(`{"query":"unsafe"}`)})
+			appendMessage(roleAssistant, eventTypeToolCall, string(call))
+			result, _ := json.Marshal(toolResultEnvelope{ID: "", Tool: "search", Result: json.RawMessage(`"unsafe result"`)})
+			appendMessage(roleTool, eventTypeToolResult, string(result))
+			appendMessage(roleAssistant, eventTypeText, "safe final answer")
+			if appendNext {
+				appendMessage(roleUser, eventTypeText, "next turn")
+			}
+
+			got, err := newAssembler(q, nil).assemble(ctx, convID, 100_000, 1)
+			if err != nil {
+				t.Fatalf("assemble: %v", err)
+			}
+			for _, message := range ai.TransformMessages(got) {
+				switch value := message.(type) {
+				case ai.AssistantMessage:
+					for _, block := range value.Content {
+						if call, isCall := block.(ai.ToolCall); isCall {
+							t.Fatalf("provider replay retained malformed call: %#v", call)
+						}
+					}
+				case ai.ToolResultMessage:
+					t.Fatalf("provider replay retained malformed result: %#v", value)
 				}
 			}
 		})

--- a/internal/memory/lcm/assembler_context_window_test.go
+++ b/internal/memory/lcm/assembler_context_window_test.go
@@ -140,7 +140,7 @@ func TestAssembleContextWindowLoaderMixedLargeWindow(t *testing.T) {
 	}
 }
 
-func TestAssembleParallelToolCallsRemainOneAssistantTurn(t *testing.T) {
+func TestAssembleParallelToolCallSuffixRemainsOneAssistantTurn(t *testing.T) {
 	tests := []struct {
 		name       string
 		freshTail  int
@@ -227,26 +227,40 @@ func TestAssembleParallelToolCallsRemainOneAssistantTurn(t *testing.T) {
 			if err != nil {
 				t.Fatalf("assemble: %v", err)
 			}
-			if len(got) < 5 {
-				t.Fatalf("assembled %d messages, want at least 5", len(got))
+			if len(got) < 7 {
+				t.Fatalf("assembled %d messages, want user, thinking, text, tool turn, results, and answer", len(got))
 			}
-			assistant, ok := got[1].(ai.AssistantMessage)
+			thinking, ok := got[1].(ai.AssistantMessage)
 			if !ok {
-				t.Fatalf("parallel tool turn = %T, want ai.AssistantMessage", got[1])
+				t.Fatalf("thinking row = %T, want ai.AssistantMessage", got[1])
 			}
-			if len(assistant.Content) != 4 {
-				t.Fatalf("parallel tool blocks = %d, want thinking, text, and 2 calls: %#v", len(assistant.Content), assistant.Content)
+			if len(thinking.Content) != 1 {
+				t.Fatalf("thinking row merged into tool suffix: %#v", thinking.Content)
+			}
+			if _, ok := thinking.Content[0].(ai.ThinkingContent); !ok {
+				t.Fatalf("thinking content = %#v", thinking.Content[0])
+			}
+			text, ok := got[2].(ai.AssistantMessage)
+			if !ok || ai.FlattenText(text.Content) != "running searches" || len(text.Content) != 1 {
+				t.Fatalf("text row merged into tool suffix: %#v", got[2])
+			}
+			assistant, ok := got[3].(ai.AssistantMessage)
+			if !ok {
+				t.Fatalf("parallel tool turn = %T, want ai.AssistantMessage", got[3])
+			}
+			if len(assistant.Content) != 2 {
+				t.Fatalf("parallel tool blocks = %d, want 2 calls: %#v", len(assistant.Content), assistant.Content)
 			}
 			for i, wantID := range []string{"call-a", "call-b"} {
-				call, ok := assistant.Content[i+2].(ai.ToolCall)
+				call, ok := assistant.Content[i].(ai.ToolCall)
 				if !ok || call.ID != wantID {
-					t.Fatalf("tool call %d = %#v, want %s", i, assistant.Content[i+2], wantID)
+					t.Fatalf("tool call %d = %#v, want %s", i, assistant.Content[i], wantID)
 				}
 			}
 			for i, wantID := range []string{"call-a", "call-b"} {
-				result, ok := got[i+2].(ai.ToolResultMessage)
+				result, ok := got[i+4].(ai.ToolResultMessage)
 				if !ok || result.ToolCallID != wantID {
-					t.Fatalf("tool result %d = %#v, want %s", i, got[i+2], wantID)
+					t.Fatalf("tool result %d = %#v, want %s", i, got[i+4], wantID)
 				}
 			}
 		})

--- a/internal/memory/lcm/assembler_context_window_test.go
+++ b/internal/memory/lcm/assembler_context_window_test.go
@@ -140,6 +140,117 @@ func TestAssembleContextWindowLoaderMixedLargeWindow(t *testing.T) {
 	}
 }
 
+func TestAssembleParallelToolCallsRemainOneAssistantTurn(t *testing.T) {
+	tests := []struct {
+		name       string
+		freshTail  int
+		appendNext bool
+	}{
+		{name: "fresh tail", freshTail: 1},
+		{name: "older budget history", freshTail: 1, appendNext: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := newAssemblerTestDB(t)
+			defer db.Close()
+
+			ctx := context.Background()
+			q := sqlc.New(db)
+			convID := uuid.NewString()
+			if _, err := db.Exec(ctx, `INSERT INTO ctx_conversation (id, session_id, channel, kind) VALUES ($1, $2, 'test', 'chat')`, convID, uuid.NewString()); err != nil {
+				t.Fatalf("insert conversation: %v", err)
+			}
+
+			ordinal := int64(0)
+			seq := int64(0)
+			appendMessage := func(role, eventType, content string) {
+				t.Helper()
+				ordinal++
+				seq++
+				id := uuid.NewString()
+				if _, err := q.CreateMessage(ctx, sqlc.CreateMessageParams{
+					ID:             id,
+					ConversationID: convID,
+					Seq:            seq,
+					Role:           role,
+					EventType:      eventType,
+					Content:        content,
+					ActorType:      string(eventlog.ActorAgent),
+					TokenCount:     int64(memoryEstimate(content)),
+				}); err != nil {
+					t.Fatalf("create message: %v", err)
+				}
+				if err := q.AppendContextItem(ctx, sqlc.AppendContextItemParams{
+					ConversationID: convID,
+					Ordinal:        ordinal,
+					ItemType:       itemTypeMessage,
+					MessageID:      pgtype.Text{String: id, Valid: true},
+					EventType:      eventType,
+					Role:           role,
+				}); err != nil {
+					t.Fatalf("append context item: %v", err)
+				}
+			}
+
+			appendMessage(roleUser, eventTypeText, "look up both values")
+			for _, call := range []toolCallEnvelope{
+				{ID: "call-a", Tool: "search", Args: json.RawMessage(`{"query":"a"}`)},
+				{ID: "call-b", Tool: "search", Args: json.RawMessage(`{"query":"b"}`)},
+			} {
+				data, err := json.Marshal(call)
+				if err != nil {
+					t.Fatalf("marshal tool call: %v", err)
+				}
+				appendMessage(roleAssistant, eventTypeToolCall, string(data))
+			}
+			for _, result := range []toolResultEnvelope{
+				{ID: "call-a", Tool: "search", Result: json.RawMessage(`"result-a"`)},
+				{ID: "call-b", Tool: "search", Result: json.RawMessage(`"result-b"`)},
+			} {
+				data, err := json.Marshal(result)
+				if err != nil {
+					t.Fatalf("marshal tool result: %v", err)
+				}
+				appendMessage(roleTool, eventTypeToolResult, string(data))
+			}
+			appendMessage(roleAssistant, eventTypeText, "combined answer")
+			if tt.appendNext {
+				// This user turn makes the parallel-tool turn compete in the older
+				// budget path instead of remaining in the protected fresh tail.
+				appendMessage(roleUser, eventTypeText, "next turn")
+			}
+
+			got, err := newAssembler(q, nil).assemble(ctx, convID, 100_000, tt.freshTail)
+			if err != nil {
+				t.Fatalf("assemble: %v", err)
+			}
+			if len(got) < 5 {
+				t.Fatalf("assembled %d messages, want at least 5", len(got))
+			}
+			assistant, ok := got[1].(ai.AssistantMessage)
+			if !ok {
+				t.Fatalf("parallel tool turn = %T, want ai.AssistantMessage", got[1])
+			}
+			if len(assistant.Content) != 2 {
+				t.Fatalf("parallel tool blocks = %d, want 2: %#v", len(assistant.Content), assistant.Content)
+			}
+			for i, wantID := range []string{"call-a", "call-b"} {
+				call, ok := assistant.Content[i].(ai.ToolCall)
+				if !ok || call.ID != wantID {
+					t.Fatalf("tool call %d = %#v, want %s", i, assistant.Content[i], wantID)
+				}
+			}
+			for i, wantID := range []string{"call-a", "call-b"} {
+				result, ok := got[i+2].(ai.ToolResultMessage)
+				if !ok || result.ToolCallID != wantID {
+					t.Fatalf("tool result %d = %#v, want %s", i, got[i+2], wantID)
+				}
+			}
+		})
+	}
+}
+
 type queryCountingDB struct {
 	*pgxpool.Pool
 	queries int

--- a/internal/memory/lcm/canonical_append_test.go
+++ b/internal/memory/lcm/canonical_append_test.go
@@ -97,6 +97,76 @@ func TestAppendThenAssemblePreservesAgentInputEnvelope(t *testing.T) {
 	}
 }
 
+func TestAppendThenAssemblePreservesCompletedPartialParallelToolSubset(t *testing.T) {
+	for _, appendNextTurn := range []bool{false, true} {
+		name := "fresh tail"
+		if appendNextTurn {
+			name = "older budget history"
+		}
+		t.Run(name, func(t *testing.T) {
+			db := newLCMTestDB(t)
+			defer db.Close()
+
+			p, err := lcm.New(db, nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = p.Close() }()
+
+			sess := newLCMTestSession("partial-parallel-" + name)
+			ctx := authz.WithAgentID(authz.WithUserID(context.Background(), sess.UserID), sess.AgentID)
+			if err := p.Append(ctx, sess, ai.UserMessage{Content: "look up both values"}); err != nil {
+				t.Fatalf("append user: %v", err)
+			}
+			// The runtime persists the full assistant call set before executing
+			// tools, then persists each completed result independently.
+			if err := p.Append(ctx, sess, ai.AssistantMessage{Content: []ai.ContentBlock{
+				ai.ThinkingContent{Thinking: "checking both sources"},
+				ai.TextContent{Text: "running searches"},
+				ai.ToolCall{ID: "call-a", Name: "search", Arguments: map[string]any{"query": "a"}},
+				ai.ToolCall{ID: "call-b", Name: "search", Arguments: map[string]any{"query": "b"}},
+			}}); err != nil {
+				t.Fatalf("append assistant calls: %v", err)
+			}
+			if err := p.Append(ctx, sess, ai.ToolResultMessage{
+				ToolCallID: "call-a",
+				ToolName:   "search",
+				Content:    []ai.ContentBlock{ai.TextContent{Text: "result-a"}},
+			}); err != nil {
+				t.Fatalf("append completed result: %v", err)
+			}
+			if appendNextTurn {
+				if err := p.Append(ctx, sess, ai.UserMessage{Content: "next turn"}); err != nil {
+					t.Fatalf("append next user turn: %v", err)
+				}
+			}
+
+			got, err := p.Assemble(ctx, sess, 100_000, 1)
+			if err != nil {
+				t.Fatalf("assemble: %v", err)
+			}
+			if len(got) < 3 {
+				t.Fatalf("assembled history = %#v, want user, assistant, and completed result", got)
+			}
+			assistant, ok := got[1].(ai.AssistantMessage)
+			if !ok {
+				t.Fatalf("completed tool turn = %T, want ai.AssistantMessage", got[1])
+			}
+			if len(assistant.Content) != 3 {
+				t.Fatalf("assistant blocks = %#v, want thinking, text, and completed call A", assistant.Content)
+			}
+			call, ok := assistant.Content[2].(ai.ToolCall)
+			if !ok || call.ID != "call-a" {
+				t.Fatalf("completed call = %#v, want call-a", assistant.Content[2])
+			}
+			result, ok := got[2].(ai.ToolResultMessage)
+			if !ok || result.ToolCallID != "call-a" || ai.FlattenText(result.Content) != "result-a" {
+				t.Fatalf("completed result = %#v, want result-a", got[2])
+			}
+		})
+	}
+}
+
 func TestAgentInputCompactionKeepsNonPrincipalAttribution(t *testing.T) {
 	db := newLCMTestDB(t)
 	defer db.Close()

--- a/internal/memory/lcm/canonical_append_test.go
+++ b/internal/memory/lcm/canonical_append_test.go
@@ -145,23 +145,214 @@ func TestAppendThenAssemblePreservesCompletedPartialParallelToolSubset(t *testin
 			if err != nil {
 				t.Fatalf("assemble: %v", err)
 			}
-			if len(got) < 3 {
-				t.Fatalf("assembled history = %#v, want user, assistant, and completed result", got)
+			if len(got) < 5 {
+				t.Fatalf("assembled history = %#v, want user, thinking, text, completed call, and result", got)
 			}
-			assistant, ok := got[1].(ai.AssistantMessage)
+			thinking, ok := got[1].(ai.AssistantMessage)
 			if !ok {
-				t.Fatalf("completed tool turn = %T, want ai.AssistantMessage", got[1])
+				t.Fatalf("thinking row = %T, want ai.AssistantMessage", got[1])
 			}
-			if len(assistant.Content) != 3 {
-				t.Fatalf("assistant blocks = %#v, want thinking, text, and completed call A", assistant.Content)
+			if len(thinking.Content) != 1 {
+				t.Fatalf("thinking row merged into tool suffix: %#v", thinking.Content)
 			}
-			call, ok := assistant.Content[2].(ai.ToolCall)
+			if _, ok := thinking.Content[0].(ai.ThinkingContent); !ok {
+				t.Fatalf("thinking content = %#v", thinking.Content[0])
+			}
+			text, ok := got[2].(ai.AssistantMessage)
+			if !ok || ai.FlattenText(text.Content) != "running searches" || len(text.Content) != 1 {
+				t.Fatalf("text row merged into tool suffix: %#v", got[2])
+			}
+			assistant, ok := got[3].(ai.AssistantMessage)
+			if !ok || len(assistant.Content) != 1 {
+				t.Fatalf("completed tool suffix = %#v, want one call", got[3])
+			}
+			call, ok := assistant.Content[0].(ai.ToolCall)
 			if !ok || call.ID != "call-a" {
-				t.Fatalf("completed call = %#v, want call-a", assistant.Content[2])
+				t.Fatalf("completed call = %#v, want call-a", assistant.Content[0])
+			}
+			result, ok := got[4].(ai.ToolResultMessage)
+			if !ok || result.ToolCallID != "call-a" || ai.FlattenText(result.Content) != "result-a" {
+				t.Fatalf("completed result = %#v, want result-a", got[4])
+			}
+		})
+	}
+}
+
+func TestAppendThenAssembleDropsSplitDuplicateToolCallIDGroup(t *testing.T) {
+	for _, appendNextTurn := range []bool{false, true} {
+		name := "fresh tail"
+		if appendNextTurn {
+			name = "older budget history"
+		}
+		t.Run(name, func(t *testing.T) {
+			db := newLCMTestDB(t)
+			defer db.Close()
+
+			p, err := lcm.New(db, nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = p.Close() }()
+
+			sess := newLCMTestSession("duplicate-parallel-" + name)
+			ctx := authz.WithAgentID(authz.WithUserID(context.Background(), sess.UserID), sess.AgentID)
+			if err := p.Append(ctx, sess,
+				ai.UserMessage{Content: "run both calls"},
+				ai.AssistantMessage{Content: []ai.ContentBlock{
+					ai.ToolCall{ID: "duplicate", Name: "search", Arguments: map[string]any{"query": "first"}},
+					ai.ToolCall{ID: "duplicate", Name: "search", Arguments: map[string]any{"query": "second"}},
+				}},
+				ai.ToolResultMessage{
+					ToolCallID: "duplicate",
+					ToolName:   "search",
+					Content:    []ai.ContentBlock{ai.TextContent{Text: "ambiguous result"}},
+				},
+			); err != nil {
+				t.Fatalf("append duplicate tool turn: %v", err)
+			}
+			if appendNextTurn {
+				if err := p.Append(ctx, sess, ai.UserMessage{Content: "next turn"}); err != nil {
+					t.Fatalf("append next user turn: %v", err)
+				}
+			}
+
+			got, err := p.Assemble(ctx, sess, 100_000, 1)
+			if err != nil {
+				t.Fatalf("assemble: %v", err)
+			}
+			for _, message := range got {
+				switch value := message.(type) {
+				case ai.AssistantMessage:
+					for _, block := range value.Content {
+						if _, isCall := block.(ai.ToolCall); isCall {
+							t.Fatalf("assembled history retained ambiguous call: %#v", got)
+						}
+					}
+				case ai.ToolResultMessage:
+					t.Fatalf("assembled history retained ambiguous result: %#v", got)
+				}
+			}
+		})
+	}
+}
+
+func TestAppendThenAssembleBudgetsSanitizedPartialToolSubset(t *testing.T) {
+	db := newLCMTestDB(t)
+	defer db.Close()
+
+	p, err := lcm.New(db, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = p.Close() }()
+
+	sess := newLCMTestSession("partial-parallel-budget")
+	ctx := authz.WithAgentID(authz.WithUserID(context.Background(), sess.UserID), sess.AgentID)
+	if err := p.Append(ctx, sess,
+		ai.UserMessage{Content: "look up both values"},
+		ai.AssistantMessage{Content: []ai.ContentBlock{
+			ai.ToolCall{ID: "call-a", Name: "search", Arguments: map[string]any{"query": "a"}},
+			ai.ToolCall{ID: "call-b", Name: "search", Arguments: map[string]any{"query": strings.Repeat("b", 40_000)}},
+		}},
+		ai.ToolResultMessage{
+			ToolCallID: "call-a",
+			ToolName:   "search",
+			Content:    []ai.ContentBlock{ai.TextContent{Text: "result-a"}},
+		},
+		ai.UserMessage{Content: "next turn"},
+	); err != nil {
+		t.Fatalf("append budgeted partial turn: %v", err)
+	}
+
+	// The completed A/resultA projection fits this budget; the persisted but
+	// incomplete B arguments do not. Admission must cost what the provider sees.
+	got, err := p.Assemble(ctx, sess, 200, 1)
+	if err != nil {
+		t.Fatalf("assemble: %v", err)
+	}
+	var sawCallA, sawResultA bool
+	for _, message := range got {
+		switch value := message.(type) {
+		case ai.AssistantMessage:
+			for _, block := range value.Content {
+				if call, ok := block.(ai.ToolCall); ok {
+					if call.ID == "call-b" {
+						t.Fatalf("provider-visible history retained incomplete call B: %#v", got)
+					}
+					sawCallA = sawCallA || call.ID == "call-a"
+				}
+			}
+		case ai.ToolResultMessage:
+			sawResultA = sawResultA || value.ToolCallID == "call-a"
+		}
+	}
+	if !sawCallA || !sawResultA {
+		t.Fatalf("budgeted history lost completed A/resultA subset: %#v", got)
+	}
+}
+
+func TestAppendThenAssembleMergesOnlyToolCallSuffixBeforeResults(t *testing.T) {
+	for _, appendNextTurn := range []bool{false, true} {
+		name := "fresh tail"
+		if appendNextTurn {
+			name = "older budget history"
+		}
+		t.Run(name, func(t *testing.T) {
+			db := newLCMTestDB(t)
+			defer db.Close()
+
+			p, err := lcm.New(db, nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = p.Close() }()
+
+			sess := newLCMTestSession("tool-suffix-" + name)
+			ctx := authz.WithAgentID(authz.WithUserID(context.Background(), sess.UserID), sess.AgentID)
+			if err := p.Append(ctx, sess, ai.AssistantMessage{Content: []ai.ContentBlock{ai.TextContent{Text: "old text"}}}); err != nil {
+				t.Fatalf("append earlier assistant text: %v", err)
+			}
+			if err := p.Append(ctx, sess,
+				ai.AssistantMessage{Content: []ai.ContentBlock{
+					ai.ToolCall{ID: "call-a", Name: "search", Arguments: map[string]any{"query": "a"}},
+					ai.ToolCall{ID: "call-b", Name: "search", Arguments: map[string]any{"query": "b"}},
+				}},
+				ai.ToolResultMessage{
+					ToolCallID: "call-a",
+					ToolName:   "search",
+					Content:    []ai.ContentBlock{ai.TextContent{Text: "result-a"}},
+				},
+			); err != nil {
+				t.Fatalf("append partial tool suffix: %v", err)
+			}
+			if appendNextTurn {
+				if err := p.Append(ctx, sess, ai.UserMessage{Content: "next turn"}); err != nil {
+					t.Fatalf("append next user turn: %v", err)
+				}
+			}
+
+			got, err := p.Assemble(ctx, sess, 100_000, 1)
+			if err != nil {
+				t.Fatalf("assemble: %v", err)
+			}
+			if len(got) < 3 {
+				t.Fatalf("assembled history = %#v, want old text plus completed tool subset", got)
+			}
+			oldText, ok := got[0].(ai.AssistantMessage)
+			if !ok || ai.FlattenText(oldText.Content) != "old text" || len(oldText.Content) != 1 {
+				t.Fatalf("earlier assistant row was merged into tool suffix: %#v", got[0])
+			}
+			toolTurn, ok := got[1].(ai.AssistantMessage)
+			if !ok || len(toolTurn.Content) != 1 {
+				t.Fatalf("tool suffix = %#v, want one completed call", got[1])
+			}
+			call, ok := toolTurn.Content[0].(ai.ToolCall)
+			if !ok || call.ID != "call-a" {
+				t.Fatalf("completed suffix call = %#v, want call-a", toolTurn.Content[0])
 			}
 			result, ok := got[2].(ai.ToolResultMessage)
-			if !ok || result.ToolCallID != "call-a" || ai.FlattenText(result.Content) != "result-a" {
-				t.Fatalf("completed result = %#v, want result-a", got[2])
+			if !ok || result.ToolCallID != "call-a" {
+				t.Fatalf("completed suffix result = %#v, want call-a", got[2])
 			}
 		})
 	}

--- a/internal/memory/lcm/group_assembler.go
+++ b/internal/memory/lcm/group_assembler.go
@@ -76,18 +76,32 @@ func (p *Provider) assembleGroup(ctx context.Context, session memory.Session, bu
 		agentHistory = append(agentHistory, injected...)
 	}
 
-	// 4. Apply token budget: trim oldest messages first.
-	total := 0
-	for _, m := range agentHistory {
-		total += estimateMessageTokens(m)
-	}
-	cutIdx := 0
-	for total > budget && cutIdx < len(agentHistory) {
-		total -= estimateMessageTokens(agentHistory[cutIdx])
-		cutIdx++
-	}
+	// 4. Apply the post-injection budget by whole user turns. The ordinary
+	// assembler has already made tool turns provider-safe; a second message-level
+	// trim must not detach tool results or a final answer from their user turn.
+	agentHistory = trimOldestCompleteTurns(agentHistory, budget)
+	return sanitizeToolPairs(agentHistory), nil
+}
 
-	return sanitizeToolPairs(agentHistory[cutIdx:]), nil
+func trimOldestCompleteTurns(messages []ai.Message, budget int) []ai.Message {
+	total := 0
+	for _, message := range messages {
+		total += estimateMessageTokens(message)
+	}
+	for len(messages) > 0 && total > budget {
+		end := len(messages)
+		for i := 1; i < len(messages); i++ {
+			if _, startsNextTurn := messages[i].(ai.UserMessage); startsNextTurn {
+				end = i
+				break
+			}
+		}
+		for _, message := range messages[:end] {
+			total -= estimateMessageTokens(message)
+		}
+		messages = messages[end:]
+	}
+	return messages
 }
 
 func (p *Provider) CommitGroupCursor(ctx context.Context, session memory.Session, triggerSeq int64) error {

--- a/internal/memory/lcm/group_assembler_test.go
+++ b/internal/memory/lcm/group_assembler_test.go
@@ -3,6 +3,7 @@ package lcm
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -354,6 +355,60 @@ func TestGroupAssemble_TokenBudget(t *testing.T) {
 	}
 	if len(msgs) >= 5 {
 		t.Fatalf("expected fewer than 5 messages with tight budget, got %d", len(msgs))
+	}
+}
+
+func TestGroupAssemble_BudgetDropsParallelToolTurnAtomically(t *testing.T) {
+	db := openTestDB(t)
+	el := eventlog.NewStore(db)
+	ctx := context.Background()
+
+	res, err := el.AppendGroupMessage(ctx, eventlog.Message{
+		Platform: "test", PlatformGroupID: "group-parallel-budget", ActorType: eventlog.ActorHuman,
+		ActorID: "user1", Content: "new injected context", PlatformMessageID: "injected-1",
+	})
+	if err != nil {
+		t.Fatalf("seed injected context: %v", err)
+	}
+	trigger, err := el.AppendGroupMessage(ctx, eventlog.Message{
+		Platform: "test", PlatformGroupID: "group-parallel-budget", ActorType: eventlog.ActorHuman,
+		ActorID: "user1", Content: "trigger", PlatformMessageID: "trigger-2",
+	})
+	if err != nil {
+		t.Fatalf("seed trigger: %v", err)
+	}
+
+	p, err := New(db, nil, nil)
+	if err != nil {
+		t.Fatalf("new provider: %v", err)
+	}
+	sess := groupSess("agent-a", res.GroupID)
+	if err := p.Append(groupCtx(0), sess,
+		ai.UserMessage{Content: "old tool turn"},
+		ai.AssistantMessage{Content: []ai.ContentBlock{
+			ai.ToolCall{ID: "call-a", Name: "search"},
+			ai.ToolCall{ID: "call-b", Name: "search"},
+		}},
+		ai.ToolResultMessage{ToolCallID: "call-a", ToolName: "search", Content: []ai.ContentBlock{ai.TextContent{Text: "result-a"}}},
+		ai.ToolResultMessage{ToolCallID: "call-b", ToolName: "search", Content: []ai.ContentBlock{ai.TextContent{Text: "result-b"}}},
+		ai.AssistantMessage{Content: []ai.ContentBlock{ai.TextContent{Text: "old final answer"}}},
+	); err != nil {
+		t.Fatalf("append parallel tool turn: %v", err)
+	}
+
+	// The injected group message pushes the assembled history over this budget.
+	// The older user/tool turn must disappear as a whole, never as surviving
+	// results or a detached final assistant response.
+	msgs, err := p.Assemble(groupCtx(trigger.Seq), sess, 19, 20)
+	if err != nil {
+		t.Fatalf("assemble: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("budgeted group history = %#v, want only injected context", msgs)
+	}
+	user, ok := msgs[0].(ai.UserMessage)
+	if !ok || !strings.Contains(flattenUserMessage(user), "new injected context") {
+		t.Fatalf("remaining group message = %#v, want injected context", msgs[0])
 	}
 }
 

--- a/internal/memory/lcm/lcm_helpers_test.go
+++ b/internal/memory/lcm/lcm_helpers_test.go
@@ -902,7 +902,11 @@ func TestSanitizeToolPairs_MergesParallelAssistantCalls(t *testing.T) {
 	resultB := ai.ToolResultMessage{ToolCallID: "call-b", ToolName: "search", Content: []ai.ContentBlock{ai.TextContent{Text: "b"}}}
 
 	got := sanitizeToolPairs([]ai.Message{
-		ai.AssistantMessage{Content: []ai.ContentBlock{callA}},
+		ai.AssistantMessage{Content: []ai.ContentBlock{
+			ai.ThinkingContent{Thinking: "checking both sources"},
+			ai.TextContent{Text: "running searches"},
+			callA,
+		}},
 		ai.AssistantMessage{Content: []ai.ContentBlock{callB}},
 		resultA,
 		resultB,
@@ -914,14 +918,122 @@ func TestSanitizeToolPairs_MergesParallelAssistantCalls(t *testing.T) {
 	if !ok {
 		t.Fatalf("message 0 = %T, want ai.AssistantMessage", got[0])
 	}
-	if len(assistant.Content) != 2 {
-		t.Fatalf("assistant blocks = %d, want 2", len(assistant.Content))
+	if len(assistant.Content) != 4 {
+		t.Fatalf("assistant blocks = %d, want thinking, text, and 2 calls", len(assistant.Content))
 	}
 	for i, wantID := range []string{"call-a", "call-b"} {
-		call, ok := assistant.Content[i].(ai.ToolCall)
+		call, ok := assistant.Content[i+2].(ai.ToolCall)
 		if !ok || call.ID != wantID {
-			t.Fatalf("tool call %d = %#v, want %s", i, assistant.Content[i], wantID)
+			t.Fatalf("tool call %d = %#v, want %s", i, assistant.Content[i+2], wantID)
 		}
+	}
+}
+
+func TestSanitizeToolPairs_PreservesSeparateOrdinaryAssistantMessages(t *testing.T) {
+	// Separate runtime appends can be adjacent in storage, for example an
+	// interrupted partial response followed by the timeout notice. Adjacency
+	// alone must not collapse those two user-visible messages into one turn.
+	got := sanitizeToolPairs([]ai.Message{
+		ai.AssistantMessage{Content: []ai.ContentBlock{ai.TextContent{Text: "partial response"}}},
+		ai.AssistantMessage{Content: []ai.ContentBlock{ai.TextContent{Text: "timeout notice"}}},
+	})
+	if len(got) != 2 {
+		t.Fatalf("ordinary assistant messages = %d, want 2", len(got))
+	}
+	for i, want := range []string{"partial response", "timeout notice"} {
+		assistant, ok := got[i].(ai.AssistantMessage)
+		if !ok || ai.FlattenText(assistant.Content) != want {
+			t.Fatalf("assistant %d = %#v, want %q", i, got[i], want)
+		}
+	}
+}
+
+func TestSanitizeToolPairs_DropsInvalidCallIDGroups(t *testing.T) {
+	tests := []struct {
+		name     string
+		messages []ai.Message
+	}{
+		{
+			name: "empty ID",
+			messages: []ai.Message{
+				ai.AssistantMessage{Content: []ai.ContentBlock{
+					ai.ThinkingContent{Thinking: "safe thinking"},
+					ai.TextContent{Text: "safe text"},
+					ai.ToolCall{ID: "", Name: "search"},
+				}},
+				ai.ToolResultMessage{ToolCallID: "", ToolName: "search", Content: []ai.ContentBlock{ai.TextContent{Text: "unsafe"}}},
+			},
+		},
+		{
+			name: "duplicate call ID",
+			messages: []ai.Message{
+				ai.AssistantMessage{Content: []ai.ContentBlock{
+					ai.ThinkingContent{Thinking: "safe thinking"},
+					ai.TextContent{Text: "safe text"},
+					ai.ToolCall{ID: "duplicate", Name: "search", Arguments: map[string]any{"query": "first"}},
+					ai.ToolCall{ID: "duplicate", Name: "search", Arguments: map[string]any{"query": "second"}},
+				}},
+				ai.ToolResultMessage{ToolCallID: "duplicate", ToolName: "search", Content: []ai.ContentBlock{ai.TextContent{Text: "first result"}}},
+				ai.ToolResultMessage{ToolCallID: "duplicate", ToolName: "search", Content: []ai.ContentBlock{ai.TextContent{Text: "second result"}}, IsError: true},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeToolPairs(tt.messages)
+			if len(got) != 1 {
+				t.Fatalf("sanitized messages = %d, want safe assistant only", len(got))
+			}
+			assistant, ok := got[0].(ai.AssistantMessage)
+			if !ok || ai.FlattenText(assistant.Content) != "safe text" || len(assistant.Content) != 2 {
+				t.Fatalf("safe assistant content = %#v", got[0])
+			}
+			if thinking, ok := assistant.Content[0].(ai.ThinkingContent); !ok || thinking.Thinking != "safe thinking" {
+				t.Fatalf("safe thinking content = %#v", assistant.Content)
+			}
+			for _, message := range ai.TransformMessages(got) {
+				switch value := message.(type) {
+				case ai.AssistantMessage:
+					for _, block := range value.Content {
+						if _, isCall := block.(ai.ToolCall); isCall {
+							t.Fatalf("provider input retained invalid call: %#v", block)
+						}
+					}
+				case ai.ToolResultMessage:
+					t.Fatalf("provider input retained invalid result: %#v", value)
+				}
+			}
+		})
+	}
+}
+
+func TestSanitizeToolPairs_DropsOnlyDuplicateIDGroup(t *testing.T) {
+	got := sanitizeToolPairs([]ai.Message{
+		ai.AssistantMessage{Content: []ai.ContentBlock{
+			ai.TextContent{Text: "safe text"},
+			ai.ToolCall{ID: "duplicate", Name: "search", Arguments: map[string]any{"query": "first"}},
+			ai.ToolCall{ID: "duplicate", Name: "search", Arguments: map[string]any{"query": "second"}},
+			ai.ToolCall{ID: "valid", Name: "search", Arguments: map[string]any{"query": "valid"}},
+		}},
+		ai.ToolResultMessage{ToolCallID: "duplicate", ToolName: "search", Content: []ai.ContentBlock{ai.TextContent{Text: "first result"}}},
+		ai.ToolResultMessage{ToolCallID: "duplicate", ToolName: "search", Content: []ai.ContentBlock{ai.TextContent{Text: "second result"}}, IsError: true},
+		ai.ToolResultMessage{ToolCallID: "valid", ToolName: "search", Content: []ai.ContentBlock{ai.TextContent{Text: "valid result"}}},
+	})
+	if len(got) != 2 {
+		t.Fatalf("sanitized messages = %#v, want assistant and valid result", got)
+	}
+	assistant, ok := got[0].(ai.AssistantMessage)
+	if !ok || len(assistant.Content) != 2 {
+		t.Fatalf("sanitized assistant = %#v", got[0])
+	}
+	call, ok := assistant.Content[1].(ai.ToolCall)
+	if !ok || call.ID != "valid" {
+		t.Fatalf("remaining tool call = %#v, want valid", assistant.Content[1])
+	}
+	result, ok := got[1].(ai.ToolResultMessage)
+	if !ok || result.ToolCallID != "valid" || result.IsError {
+		t.Fatalf("remaining tool result = %#v, want valid success", got[1])
 	}
 }
 

--- a/internal/memory/lcm/lcm_helpers_test.go
+++ b/internal/memory/lcm/lcm_helpers_test.go
@@ -892,6 +892,63 @@ func TestSanitizeToolPairs_NoOrphans(t *testing.T) {
 	}
 }
 
+func TestSanitizeToolPairs_MergesParallelAssistantCalls(t *testing.T) {
+	// Durable storage keeps each assistant content block in a separate row. A
+	// defensive cleanup must restore those rows to one assistant turn before
+	// validating the immediately following tool results.
+	callA := ai.ToolCall{ID: "call-a", Name: "search"}
+	callB := ai.ToolCall{ID: "call-b", Name: "search"}
+	resultA := ai.ToolResultMessage{ToolCallID: "call-a", ToolName: "search", Content: []ai.ContentBlock{ai.TextContent{Text: "a"}}}
+	resultB := ai.ToolResultMessage{ToolCallID: "call-b", ToolName: "search", Content: []ai.ContentBlock{ai.TextContent{Text: "b"}}}
+
+	got := sanitizeToolPairs([]ai.Message{
+		ai.AssistantMessage{Content: []ai.ContentBlock{callA}},
+		ai.AssistantMessage{Content: []ai.ContentBlock{callB}},
+		resultA,
+		resultB,
+	})
+	if len(got) != 3 {
+		t.Fatalf("expected one assistant plus two results, got %d messages", len(got))
+	}
+	assistant, ok := got[0].(ai.AssistantMessage)
+	if !ok {
+		t.Fatalf("message 0 = %T, want ai.AssistantMessage", got[0])
+	}
+	if len(assistant.Content) != 2 {
+		t.Fatalf("assistant blocks = %d, want 2", len(assistant.Content))
+	}
+	for i, wantID := range []string{"call-a", "call-b"} {
+		call, ok := assistant.Content[i].(ai.ToolCall)
+		if !ok || call.ID != wantID {
+			t.Fatalf("tool call %d = %#v, want %s", i, assistant.Content[i], wantID)
+		}
+	}
+}
+
+func TestSanitizeToolPairs_RequiresImmediatelyFollowingResult(t *testing.T) {
+	call := ai.ToolCall{ID: "call-a", Name: "search"}
+	lateResult := ai.ToolResultMessage{ToolCallID: "call-a", ToolName: "search", Content: []ai.ContentBlock{ai.TextContent{Text: "late"}}}
+
+	got := sanitizeToolPairs([]ai.Message{
+		ai.AssistantMessage{Content: []ai.ContentBlock{call}},
+		ai.UserMessage{Content: "intervening turn"},
+		lateResult,
+	})
+	if len(got) != 2 {
+		t.Fatalf("expected assistant placeholder and user message, got %d messages", len(got))
+	}
+	assistant, ok := got[0].(ai.AssistantMessage)
+	if !ok || len(assistant.Content) != 1 {
+		t.Fatalf("message 0 = %#v, want one-block assistant placeholder", got[0])
+	}
+	if text, ok := assistant.Content[0].(ai.TextContent); !ok || !strings.Contains(text.Text, "compacted") {
+		t.Fatalf("assistant content = %#v, want compacted placeholder", assistant.Content)
+	}
+	if _, ok := got[1].(ai.UserMessage); !ok {
+		t.Fatalf("message 1 = %T, want ai.UserMessage", got[1])
+	}
+}
+
 func TestSanitizeToolPairs_EmptyOrphanResultDropped(t *testing.T) {
 	msgs := []ai.Message{
 		ai.ToolResultMessage{

--- a/internal/memory/lcm/lcm_helpers_test.go
+++ b/internal/memory/lcm/lcm_helpers_test.go
@@ -893,20 +893,16 @@ func TestSanitizeToolPairs_NoOrphans(t *testing.T) {
 }
 
 func TestSanitizeToolPairs_MergesParallelAssistantCalls(t *testing.T) {
-	// Durable storage keeps each assistant content block in a separate row. A
-	// defensive cleanup must restore those rows to one assistant turn before
-	// validating the immediately following tool results.
+	// Durable storage keeps each tool call in a separate row. A defensive cleanup
+	// restores only that tool-call suffix; preceding ordinary assistant content
+	// cannot be joined safely without a durable response ID.
 	callA := ai.ToolCall{ID: "call-a", Name: "search"}
 	callB := ai.ToolCall{ID: "call-b", Name: "search"}
 	resultA := ai.ToolResultMessage{ToolCallID: "call-a", ToolName: "search", Content: []ai.ContentBlock{ai.TextContent{Text: "a"}}}
 	resultB := ai.ToolResultMessage{ToolCallID: "call-b", ToolName: "search", Content: []ai.ContentBlock{ai.TextContent{Text: "b"}}}
 
 	got := sanitizeToolPairs([]ai.Message{
-		ai.AssistantMessage{Content: []ai.ContentBlock{
-			ai.ThinkingContent{Thinking: "checking both sources"},
-			ai.TextContent{Text: "running searches"},
-			callA,
-		}},
+		ai.AssistantMessage{Content: []ai.ContentBlock{callA}},
 		ai.AssistantMessage{Content: []ai.ContentBlock{callB}},
 		resultA,
 		resultB,
@@ -918,13 +914,13 @@ func TestSanitizeToolPairs_MergesParallelAssistantCalls(t *testing.T) {
 	if !ok {
 		t.Fatalf("message 0 = %T, want ai.AssistantMessage", got[0])
 	}
-	if len(assistant.Content) != 4 {
-		t.Fatalf("assistant blocks = %d, want thinking, text, and 2 calls", len(assistant.Content))
+	if len(assistant.Content) != 2 {
+		t.Fatalf("assistant blocks = %d, want 2 calls", len(assistant.Content))
 	}
 	for i, wantID := range []string{"call-a", "call-b"} {
-		call, ok := assistant.Content[i+2].(ai.ToolCall)
+		call, ok := assistant.Content[i].(ai.ToolCall)
 		if !ok || call.ID != wantID {
-			t.Fatalf("tool call %d = %#v, want %s", i, assistant.Content[i+2], wantID)
+			t.Fatalf("tool call %d = %#v, want %s", i, assistant.Content[i], wantID)
 		}
 	}
 }


### PR DESCRIPTION
## What

Preserve parallel tool calls as one assistant turn when LCM reconstructs durable conversation history.

## Why

LCM stores assistant content blocks in separate rows. Resolving those rows one at a time split one parallel tool-use turn into multiple assistant messages, which strict providers reject when the history is replayed.

## How

- Reconstruct adjacent assistant rows together in both the fresh tail and older budget-selected history.
- Admit adjacent assistant rows atomically when applying the older-history token budget.
- Sanitize assembled history so a tool-call turn is followed immediately by its matching consecutive results; drop orphan or late results and strip unmatched calls.
- Keep the existing persistence schema and provider adapters unchanged.

## Test

- PASS: `mise exec -- go test ./internal/memory/lcm -run "TestAssembleParallelToolCallsRemainOneAssistantTurn|TestSanitizeToolPairs" -count=1`
- PASS: `mise exec -- go test ./internal/memory/lcm -count=1`
- PASS: `mise run format`
- PASS: `mise run build`
- PASS: `mise run test`

## Refs

Closes #995

## Checklist

- [x] The PR links a GitHub issue.
- [x] I added or updated focused tests for changed non-trivial behavior, or explained why none are needed.
- [x] No documentation change is needed; this corrects internal history reconstruction without changing the public contract.
- [x] I ran `mise run format`, `mise run build`, and `mise run test`.


## Feishu Task

- [#995 保留并行工具调用的会话历史](https://mcnnox2fhjfq.feishu.cn/record/W6uAriothejPyiccF7Qc3o4Sn2e)
