### PR TITLE
🧪 test(agent): 修复 macOS 上因 /var 符号链接失败的 5 个测试

### DIFF
--- a/internal/agent/runner_builder_principal_test.go
+++ b/internal/agent/runner_builder_principal_test.go
@@ -29,24 +29,28 @@ func (w failingWorkspaceViewer) WorkspaceView(context.Context, home.WorkspaceReq
 func (w testWorkspaceViewer) WorkspaceView(_ context.Context, req home.WorkspaceRequest) (home.WorkspaceView, error) {
 	shared := home.WorkspaceView{}
 	if req.GroupID != "" {
-		principal := GroupHomeDir(w.root, req.GroupID)
-		agent := AgentDirInHome(principal, req.AgentID)
-		if err := os.MkdirAll(agent, 0o755); err != nil {
-			return home.WorkspaceView{}, err
-		}
-		shared.PrincipalRoot, shared.DataRoot, shared.AgentRoot = principal, filepath.Join(principal, "data"), agent
-		return shared, nil
+		return principalView(GroupHomeDir(w.root, req.GroupID), req.AgentID)
 	}
 	if req.UserID != "" {
-		principal := UserHomeDir(w.root, req.UserID)
-		agent := AgentDirInHome(principal, req.AgentID)
-		if err := os.MkdirAll(agent, 0o755); err != nil {
-			return home.WorkspaceView{}, err
-		}
-		shared.PrincipalRoot, shared.DataRoot, shared.AgentRoot = principal, filepath.Join(principal, "data"), agent
-		return shared, nil
+		return principalView(UserHomeDir(w.root, req.UserID), req.AgentID)
 	}
 	return shared, nil
+}
+
+// principalView mirrors what the real Home viewer materializes: both the agent
+// dir and the shared data root exist before a runner is built. Creating the data
+// root is not cosmetic — ResolvePaths compares resolved paths, and an absent dir
+// cannot be resolved, so on macOS the caller's /var/... would never match the
+// authorized /private/var/... root.
+func principalView(principal, agentID string) (home.WorkspaceView, error) {
+	agent := AgentDirInHome(principal, agentID)
+	data := filepath.Join(principal, "data")
+	for _, dir := range []string{agent, data} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return home.WorkspaceView{}, err
+		}
+	}
+	return home.WorkspaceView{PrincipalRoot: principal, DataRoot: data, AgentRoot: agent}, nil
 }
 
 func (w testWorkspaceViewer) ResolveCoordinate(c home.Coordinate) (home.RootScope, string, error) {
@@ -139,6 +143,9 @@ func (r runnerTestRoot) Rename(context.Context, string, string, home.RenameOptio
 
 func TestNewRunnerFuncUsesPrincipalWorkspace(t *testing.T) {
 	stellaHome := t.TempDir()
+	// Sandbox mounts carry resolved host paths, and macOS hands out temp dirs
+	// under the /var -> /private/var symlink; compare against the same form.
+	stellaHome, _ = filepath.EvalSymlinks(stellaHome)
 	t.Setenv("STELLA_HOME", stellaHome)
 	config.ResetStellaHome()
 	t.Cleanup(config.ResetStellaHome)

--- a/internal/agent/sandbox/paths_test.go
+++ b/internal/agent/sandbox/paths_test.go
@@ -79,6 +79,9 @@ func TestResolvePaths_projectRootSymlink(t *testing.T) {
 
 func TestResolvePathsAcceptsOnlyExactAuthorizedRoots(t *testing.T) {
 	userRoot := t.TempDir()
+	// ResolvePaths compares fully resolved paths, and macOS hands out temp dirs
+	// under the /var -> /private/var symlink. Resolve here like the tests above.
+	userRoot, _ = filepath.EvalSymlinks(userRoot)
 	workspace := filepath.Join(userRoot, "agents", "agent")
 	data := filepath.Join(userRoot, "data")
 	for _, dir := range []string{workspace, data} {


### PR DESCRIPTION
Closes #1010

## 问题

macOS 上 `mise run test` 稳定失败 5 个（Linux CI 不受影响）：`internal/agent` 4 个 runner 测试 + `internal/agent/sandbox` 的 `TestResolvePathsAcceptsOnlyExactAuthorizedRoots`。

`t.TempDir()` 在 macOS 上返回 `/var/folders/...`，而 `/var` 是指向 `/private/var` 的符号链接。`ResolvePaths` 按解析后的路径做授权比较，测试却用未解析的路径构造输入和断言，两边永远不等。

runner 那 4 个还有第二层原因：stub `testWorkspaceViewer` 只建了 agent 目录、没建共享 data 目录。`EvalSymlinks` 解析不了不存在的路径、会原样返回，于是比较的两边一边解析、一边没解析。真实的 Home viewer 两个都会建，所以是 stub 偏离了生产行为，不是生产 bug。

## 改动

只动测试：

- `paths_test.go` 与 `runner_builder_principal_test.go` 里解析临时目录，和该文件里既有的 `userRoot, _ = filepath.EvalSymlinks(userRoot)` 写法保持一致。
- stub viewer 抽出 `principalView`，像真实 viewer 一样把 agent 目录和 data 根目录都建出来。

生产代码零改动。

## 验证

macOS 上 `mise run format && mise run build && mise run test` 全绿（改动前这 5 个必挂）。

## Feishu Task

- [#1010 修复 macOS 沙箱测试路径兼容性](https://mcnnox2fhjfq.feishu.cn/record/DMuCrjcwJeDQ0uc2eXhcG7ASn2f)
