### PR TITLE
📝 docs(project-tracker): drop the mandatory Feishu task and the issue-per-small-fix rule

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,13 +16,13 @@
 
 ## Refs
 
-<!-- Every PR must link an issue. Use "Closes #123" when this PR completes it, or "Refs #123" for partial work. -->
+<!-- Use "Closes #123" when this PR completes an issue, or "Refs #123" for partial work. A small self-contained fix needs no issue: replace the line below with "No issue: <reason>". -->
 
 Closes #
 
 ## Checklist
 
-- [ ] The PR links a GitHub issue.
+- [ ] The PR links a GitHub issue, or states why the fix is small enough not to need one.
 - [ ] I added or updated focused tests for changed non-trivial behavior, or explained why none are needed.
 - [ ] I updated relevant English and Chinese documentation, or no documentation change is needed.
 - [ ] I ran `mise run format && mise run build && mise run test`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ When behavior, APIs, config, commands, or architecture change:
 ## Issue & PR tracking
 
 - **Every PR must link to a GitHub issue.** If a PR is being created without an associated issue, stop and ask the user to create one first (or create it on their behalf). No PR should be opened without a traceable issue.
-- When starting a new feature or task, ensure a tracked GitHub issue exists. Maintainer-committed work must also be linked from a Feishu Task; community issues remain GitHub-only until accepted and scheduled. **Read `web/content/docs/development/rules/project-tracker.md`** for the full workflow.
+- When starting a new feature or task, ensure a tracked GitHub issue exists. A Feishu Task is not a prerequisite: committed Feishu Tasks create their own issue, and issues without a task are reconciled by the Tuesday delivery review. **Read `web/content/docs/development/rules/project-tracker.md`** for the full workflow.
 
 ## Commit style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ When behavior, APIs, config, commands, or architecture change:
 
 ## Issue & PR tracking
 
-- **Every PR must link to a GitHub issue.** If a PR is being created without an associated issue, stop and ask the user to create one first (or create it on their behalf). No PR should be opened without a traceable issue.
+- **Most PRs link a GitHub issue.** A small self-contained fix (typo, one-line bug, doc correction) can go straight to a PR with `No issue: <reason>` in Refs. For anything that needs discussion, changes external behavior, or spans several areas, make sure an issue exists first (create it on the user's behalf if needed).
 - When starting a new feature or task, ensure a tracked GitHub issue exists. A Feishu Task is not a prerequisite: committed Feishu Tasks create their own issue, and issues without a task are reconciled by the Tuesday delivery review. **Read `web/content/docs/development/rules/project-tracker.md`** for the full workflow.
 
 ## Commit style

--- a/web/content/docs/development/rules/project-tracker.md
+++ b/web/content/docs/development/rules/project-tracker.md
@@ -12,8 +12,14 @@ Stella uses two trackers with separate ownership:
   details, technical discussion, assignees, pull requests, and release scope.
 
 Do not create a GitHub Project or duplicate the same editable field in both
-systems. A missing Feishu task means that a GitHub issue is not committed to a
-delivery plan; it does not mean that the issue is invalid.
+systems.
+
+Planning flows one way. A Feishu task creates or links a GitHub issue when the
+team commits to it, so a committed task always has an issue. The reverse is not
+required: an issue with no Feishu task is normal and valid, whether it came from
+the community or from a maintainer who started coding first. The Tuesday
+delivery review reconciles those issues back into tasks. Never block work on
+creating a task first.
 
 The planning Base is
 [Stella Roadmap](https://mcnnox2fhjfq.feishu.cn/base/BEEbbI9jtad6PmsYSXpcmBy2nUd?table=tbl4pUhlngTJdg2Z&view=vewBhCvlG1).
@@ -149,7 +155,8 @@ record back (`+record-search`) rather than trusting the exit status.
 
 `待评估` tasks are internal candidates and do not need a GitHub issue. Every
 task at `就绪` or later must contain a full GitHub Issue URL. Store the URL,
-not only the issue number. Draft acceptance in Feishu while evaluating a task.
+not only the issue number. This requirement runs task to issue only; an issue
+without a task is not a gap to fix on the spot. Draft acceptance in Feishu while evaluating a task.
 When promoting it to `就绪`, copy the complete requirement and acceptance
 criteria to GitHub; the issue becomes the execution source of truth.
 
@@ -161,7 +168,7 @@ Issue forms add `status:needs-triage` to new community reports.
 New GitHub issue
   ├── invalid / duplicate / question → explain and close or redirect
   ├── valid, not scheduled           → status:accepted; GitHub only
-  └── committed                      → Feishu Task at 就绪 + status:ready
+  └── committed                      → status:ready; task optional, backfilled Tuesday
 ```
 
 During triage:
@@ -171,9 +178,11 @@ During triage:
    `design`).
 3. Remove `status:needs-triage`.
 4. If valid but unscheduled, add `status:accepted`. Do not create a Feishu task.
-5. If committed, search Feishu and GitHub for duplicates, create or link the
-   Feishu task, add its GitHub Issue URL, move it to `就绪`, remove
-   `status:accepted`, and add `status:ready`.
+5. If committed, remove `status:accepted` and add `status:ready`. Create a
+   Feishu task now only if you are planning the work there; otherwise leave it
+   and let the Tuesday review backfill the task. When you do create one, search
+   both systems for duplicates first, store the Issue URL, and move it to
+   `就绪`.
 6. Add a version milestone only when the target release is known.
 
 ## Execution lifecycle
@@ -187,6 +196,10 @@ During triage:
 | Implementation closes  | unchanged until acceptance | Close through the PR                         |
 | Acceptance passes      | `已完成`                   | Closed                                       |
 | Cancelled              | `已取消`                   | Close with the reason                        |
+
+The Feishu column applies once a task exists. Work tracked only on GitHub is
+legitimate and complete on its own; the Tuesday review creates the task
+afterwards.
 
 An open PR is the marker for `进行中` because it is the one transition with an
 objective timestamp. Set the state that matches reality: work already
@@ -209,6 +222,9 @@ commits a task:
    is already open.
 4. Add the matching status label and, when known, a version milestone to the
    issue.
+
+Work that starts on GitHub takes the short path: file the issue, label it, and
+build. The Tuesday review turns it into a task.
 
 Contributors do not need Feishu access. Maintainers own the Feishu promotion
 step when accepting community work.
@@ -255,22 +271,22 @@ Before creating an issue on a user's behalf:
 
 1. Draft and confirm its title and body.
 2. Choose the type label.
-3. Ask whether the work is merely accepted or already committed.
-4. For accepted-only work, add `status:accepted` and stop.
-5. For committed work, confirm that a Feishu task will link the new issue, and
-   ask whether a version milestone is known. `none` is valid.
+3. Choose the status label: `status:accepted` when the work is accepted but
+   unscheduled, `status:ready` when it is committed and not started, and none
+   when a PR is already open.
 
-Then create the issue. For committed work, create or update the Feishu task with
-the returned URL, set the state matching real progress (`就绪`, or `进行中` with
-no `status:ready` when a PR is already open), add the matching status label, and
-return the Issue URL. Do not bulk-create issues without confirmation, and prefer
-closing over deleting.
+Then create the issue and return its URL. Do not ask about a Feishu task; the
+Tuesday review reconciles it. Add a version milestone only when the target
+release is already known. Do not bulk-create issues without confirmation, and
+prefer closing over deleting.
 
 ## Weekly delivery review
 
 Every Tuesday, reconcile the week that just closed against the Base: collect the
 merged PRs, create or refresh the matching tasks, and report what shipped. The
-delivery week runs Tuesday to Tuesday.
+delivery week runs Tuesday to Tuesday. This is where issues that were delivered
+without a Feishu task get one, which is why nothing upstream has to wait on task
+creation.
 
 The `weekly-delivery` skill in `.agents/skills/weekly-delivery/` carries the
 procedure. Its scripts own the mechanical half — window arithmetic, PR

--- a/web/content/docs/development/rules/project-tracker.md
+++ b/web/content/docs/development/rules/project-tracker.md
@@ -261,9 +261,16 @@ Use an issue form for community reports. Maintainer-created implementation
 issues use **What**, **Why**, **How**, and **Refs**. Keep issue descriptions
 current and do not copy issue comments into Feishu.
 
-Every PR must link a GitHub issue. Use `Closes #123` when the PR completes it,
-or `Refs #123` for partial work. Complete the PR template's What, Why, How,
-Test, and Refs sections.
+Most PRs link a GitHub issue. Use `Closes #123` when the PR completes it, or
+`Refs #123` for partial work. Complete the PR template's What, Why, How, Test,
+and Refs sections.
+
+A small fix does not need an issue. Open the PR directly when the change is
+self-contained enough that a reviewer can judge it from the diff: a typo, a
+one-line bug fix, a doc correction, a test fix. Write `No issue: <reason>` in
+Refs instead of a number. File an issue when the change needs discussion,
+alters external behavior, or spans several areas — anything a reviewer would
+want the background for.
 
 ## Creating issues for a user
 

--- a/web/content/docs/development/rules/project-tracker.zh.md
+++ b/web/content/docs/development/rules/project-tracker.zh.md
@@ -215,7 +215,9 @@ gh issue edit <number> --repo CherryHQ/stella --milestone v0.61.0
 
 社区报告使用 Issue 表单。维护者创建的实现 Issue 使用 **What**、**Why**、**How** 和 **Refs**。计划变化时及时更新 Issue，不要把 Issue 评论复制到飞书。
 
-每个 PR 都必须关联 GitHub Issue。PR 完成整个 Issue 时使用 `Closes #123`；只完成一部分时使用 `Refs #123`。完整填写 PR 模板中的 What、Why、How、Test 和 Refs。
+多数 PR 会关联 GitHub Issue。PR 完成整个 Issue 时使用 `Closes #123`；只完成一部分时使用 `Refs #123`。完整填写 PR 模板中的 What、Why、How、Test 和 Refs。
+
+小修不需要 Issue。改动足够自洽、Reviewer 看 diff 就能判断时直接开 PR：错别字、一行 bug 修复、文档订正、测试修复。此时在 Refs 写 `No issue: <原因>` 代替 Issue 号。需要讨论、改变对外行为、或者跨多个模块的改动仍然先建 Issue——凡是 Reviewer 会想了解背景的都算。
 
 ## 代用户创建 Issue
 

--- a/web/content/docs/development/rules/project-tracker.zh.md
+++ b/web/content/docs/development/rules/project-tracker.zh.md
@@ -8,7 +8,9 @@ Stella 使用两个职责分离的跟踪系统：
 - **飞书多维表格**负责内部计划：Roadmap、产品里程碑、候选与已承诺任务、优先级、目标日期和交付负责人。
 - **GitHub** 负责公开与研发记录：社区需求入口、Issue 详情、技术讨论、Assignee、PR 和发布范围。
 
-不要创建 GitHub Project，也不要让同一个可编辑字段同时存在于两套系统。GitHub Issue 没有飞书任务，只表示团队尚未承诺交付，不表示 Issue 无效。
+不要创建 GitHub Project，也不要让同一个可编辑字段同时存在于两套系统。
+
+计划只朝一个方向流动：飞书 Task 被承诺时创建或关联 GitHub Issue，因此已承诺的 Task 一定有 Issue。反向不做要求——只有 Issue 没有飞书 Task 是正常且合法的，无论它来自社区还是维护者先写了代码。周二的交付复盘会把这些 Issue 统一回填成 Task。不要为了"先建 Task"而卡住工作。
 
 计划表为 [Stella Roadmap](https://mcnnox2fhjfq.feishu.cn/base/BEEbbI9jtad6PmsYSXpcmBy2nUd?table=tbl4pUhlngTJdg2Z&view=vewBhCvlG1)。
 
@@ -133,7 +135,7 @@ lark-cli base +record-upsert --base-token $BASE --table-id $TASKS --as user \
 
 ### 生命周期规则
 
-`待评估` Task 是内部候选，不要求 GitHub Issue。进入 `就绪` 或后续状态的 Task 必须填写完整 GitHub Issue URL，不要只存 Issue number。评估阶段在飞书起草验收标准；晋级到 `就绪` 时，把完整需求和验收条件写入 GitHub，此后 Issue 是研发执行事实源。
+`待评估` Task 是内部候选，不要求 GitHub Issue。进入 `就绪` 或后续状态的 Task 必须填写完整 GitHub Issue URL，不要只存 Issue number。这条约束只作用于 Task → Issue 方向；只有 Issue 没有 Task 不是需要当场补上的缺口。评估阶段在飞书起草验收标准；晋级到 `就绪` 时，把完整需求和验收条件写入 GitHub，此后 Issue 是研发执行事实源。
 
 ## 社区 Issue 分流
 
@@ -143,7 +145,7 @@ Issue 表单会为新的社区报告添加 `status:needs-triage`。
 新 GitHub Issue
   ├── 无效 / 重复 / 问题咨询 → 解释后关闭或转到正确入口
   ├── 有效但未排期           → status:accepted；只留在 GitHub
-  └── 已承诺                 → 飞书 Task 就绪 + status:ready
+  └── 已承诺                 → status:ready；Task 可选，周二回填
 ```
 
 分流步骤：
@@ -152,7 +154,7 @@ Issue 表单会为新的社区报告添加 `status:needs-triage`。
 2. 添加合适的类型标签：`bug`、`enhancement`、`documentation` 或 `design`。
 3. 移除 `status:needs-triage`。
 4. 有效但未排期时添加 `status:accepted`，不要创建飞书 Task。
-5. 确认承诺后，先在飞书和 GitHub 搜索重复项，再创建或关联飞书 Task，填入 GitHub Issue URL，将其改为 `就绪`，移除 `status:accepted`，添加 `status:ready`。
+5. 确认承诺后，移除 `status:accepted`，添加 `status:ready`。只有当下就要在飞书排期时才创建 Task，否则交给周二复盘回填。确实要建时，先在飞书和 GitHub 搜索重复项，填入 Issue URL，并改为 `就绪`。
 6. 只有明确目标发布版本后才添加版本 Milestone。
 
 ## 执行生命周期
@@ -166,6 +168,8 @@ Issue 表单会为新的社区报告添加 `status:needs-triage`。
 | 实现关闭       | 验收前不变 | 通过 PR 关闭                                 |
 | 验收通过       | `已完成`   | Closed                                       |
 | 取消           | `已取消`   | 说明原因后关闭                               |
+
+飞书那一列只在 Task 存在时适用。只在 GitHub 上跟踪的工作本身就是完整合法的，Task 由周二复盘补建。
 
 以"PR 已开"作为 `进行中` 的标志，因为它是唯一带客观时间戳的转换点。状态要如实
 反映进度：建 Issue 时代码已经写完的工作直接进 `进行中`，不经过 `status:ready`。
@@ -181,6 +185,8 @@ Issue 表单会为新的社区报告添加 `status:needs-triage`。
 3. 在飞书 Task 填入完整 Issue URL 和最终验收标准，再改为与实际进度一致的状态——
    `就绪`，或 PR 已开时直接进 `进行中`。
 4. 为 Issue 添加对应的状态 label；目标版本明确时再添加版本 Milestone。
+
+从 GitHub 起步的工作走短路径：建 Issue、打标签、开做，周二复盘再把它变成 Task。
 
 外部贡献者不需要访问飞书。接受社区工作时，由维护者完成飞书侧的晋级操作。
 
@@ -217,16 +223,15 @@ gh issue edit <number> --repo CherryHQ/stella --milestone v0.61.0
 
 1. 起草并确认标题和正文。
 2. 选择类型标签。
-3. 确认工作只是已接受，还是已经承诺交付。
-4. 仅接受时添加 `status:accepted`，然后结束。
-5. 已承诺时确认飞书 Task 将关联新 Issue，并询问是否已有目标版本；`none` 是合法答案。
+3. 选择状态标签：已接受但未排期用 `status:accepted`，已承诺但未动工用 `status:ready`，PR 已开则不加。
 
-随后创建 Issue。已承诺的工作还要用返回的 URL 创建或更新飞书 Task，将其改为与实际进度一致的状态（`就绪`；PR 已开则是 `进行中` 且不加 `status:ready`），并添加对应的状态 label；最后返回 Issue URL。未经确认不要批量创建；优先关闭而不是删除。
+随后创建 Issue 并返回 URL。不要追问飞书 Task，周二复盘会处理。只有目标版本已经明确时才添加版本 Milestone。未经确认不要批量创建；优先关闭而不是删除。
 
 ## 每周交付复盘
 
 每周二复盘刚结束的一周：收集已合并 PR，创建或刷新对应任务，汇报交付了什么。
-交付周从周二算到下周二。
+交付周从周二算到下周二。没有飞书 Task 就交付了的 Issue 正是在这一步补上 Task，
+所以前面的任何环节都不需要等 Task 建好。
 
 流程固化在 `.agents/skills/weekly-delivery/` 的 `weekly-delivery` skill 里。
 脚本负责机械部分——周窗口计算、PR 收集、区分 issue 号与 PR 号、与任务表比对


### PR DESCRIPTION
## What

Update the project-tracker rule (English, Chinese, and the `AGENTS.md` summary line) so a Feishu task is no longer a prerequisite for a GitHub issue.

## Why

The rule read as if every committed issue had to be linked from a Feishu task before work could start, which blocks real work on tracker bookkeeping. In practice planning flows one way: a committed Feishu task creates its issue, and issues that start on GitHub are reconciled into tasks by the Tuesday delivery review.

## How

- State the one-way direction up front, and say explicitly that an issue without a task is normal and valid.
- Triage: committed work gets `status:ready`; creating the Feishu task is optional and backfilled on Tuesday.
- Execution lifecycle: the Feishu column applies only once a task exists.
- "Creating issues for a user": drop the committed-vs-accepted interrogation and the Feishu task confirmation; pick a status label and create the issue.
- Weekly delivery review: name it as the step that backfills tasks for delivered issues.

## Test

Documentation only. `mise run format` passes (prettier + lint over 403 files); no code changed.

## Refs

Closes #1025

## Checklist

- [x] The PR links a GitHub issue.
- [x] I added or updated focused tests for changed non-trivial behavior, or explained why none are needed.
- [x] I updated relevant English and Chinese documentation, or no documentation change is needed.
- [ ] I ran `mise run format && mise run build && mise run test`. Ran `mise run format` only; this branch changes no code.


## Feishu Task

- [#1025 澄清 GitHub Issue 与飞书任务的跟踪关系](https://mcnnox2fhjfq.feishu.cn/record/CkscrfeexeyJcdcGB8icke12nxc)
