### PR TITLE
⚡ perf(ci): cache the Go build cache and the PostgreSQL runtime

### DIFF
--- a/.github/actions/toolchain-caches/action.yml
+++ b/.github/actions/toolchain-caches/action.yml
@@ -1,0 +1,82 @@
+name: Toolchain caches
+description: >-
+  Restore the caches every Stella job rebuilds from cold. mise-action's own
+  `cache: true` covers only the tools mise installs, so without this a job
+  recompiles the whole Go module, re-downloads 576 npm packages, re-fetches
+  dprint's WASM plugins, and re-analyses every package with golangci-lint.
+
+inputs:
+  scope:
+    description: >-
+      Cache namespace. Jobs that produce different build artifacts from the same
+      sources must use different scopes — race-instrumented Go objects are a
+      separate build graph from plain ones, and sharing a key would make the
+      jobs evict each other on every run.
+    required: true
+  go:
+    description: Cache GOCACHE and GOMODCACHE.
+    required: false
+    default: "true"
+  node:
+    description: Cache the pnpm store and dprint's plugin cache.
+    required: false
+    default: "true"
+  lint:
+    description: Cache golangci-lint's analysis cache.
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    # Resolved rather than hardcoded: mise owns the toolchain, and Windows puts
+    # both caches somewhere else entirely.
+    - name: Resolve Go cache paths
+      if: inputs.go == 'true'
+      id: go-paths
+      shell: bash
+      run: |
+        echo "build=$(mise exec -- go env GOCACHE)" >> "$GITHUB_OUTPUT"
+        echo "mod=$(mise exec -- go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+
+    # restore-keys fall back progressively: the Go build cache is
+    # content-addressed, so a partial hit after a go.sum change still carries
+    # most of the saving.
+    - name: Cache Go build and module cache
+      if: inputs.go == 'true'
+      uses: actions/cache@v4
+      with:
+        path: |
+          ${{ steps.go-paths.outputs.build }}
+          ${{ steps.go-paths.outputs.mod }}
+        key: go-${{ inputs.scope }}-${{ runner.os }}-${{ hashFiles('mise.toml') }}-${{ hashFiles('go.sum') }}
+        restore-keys: |
+          go-${{ inputs.scope }}-${{ runner.os }}-${{ hashFiles('mise.toml') }}-
+          go-${{ inputs.scope }}-${{ runner.os }}-
+
+    # Both default locations are listed because the store path depends on the
+    # pnpm version vp delegates to. A path that does not exist is skipped, so
+    # listing both costs nothing and a wrong guess degrades to today's behaviour.
+    - name: Cache pnpm store and dprint plugins
+      if: inputs.node == 'true'
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.local/share/pnpm/store
+          ~/.cache/pnpm
+          ~/.cache/dprint
+        key: node-${{ inputs.scope }}-${{ runner.os }}-${{ hashFiles('web/pnpm-lock.yaml', 'web/pnpm-workspace.yaml', 'dprint.json') }}
+        restore-keys: |
+          node-${{ inputs.scope }}-${{ runner.os }}-
+
+    # golangci-lint keeps its own analysis cache separate from GOCACHE, and
+    # `mise run format` runs it over the whole module through the prek hook.
+    - name: Cache golangci-lint analysis
+      if: inputs.lint == 'true'
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/golangci-lint
+        key: golangci-${{ inputs.scope }}-${{ runner.os }}-${{ hashFiles('mise.toml') }}-${{ hashFiles('go.sum') }}
+        restore-keys: |
+          golangci-${{ inputs.scope }}-${{ runner.os }}-

--- a/.github/actions/toolchain-caches/action.yml
+++ b/.github/actions/toolchain-caches/action.yml
@@ -1,17 +1,21 @@
 name: Toolchain caches
 description: >-
-  Restore the caches every Stella job rebuilds from cold. mise-action's own
-  `cache: true` covers only the tools mise installs, so without this a job
+  Restore the caches every Stella job otherwise rebuilds from cold. mise-action's
+  own `cache: true` covers only the tools mise installs, so without this a job
   recompiles the whole Go module, re-downloads 576 npm packages, re-fetches
-  dprint's WASM plugins, and re-analyses every package with golangci-lint.
+  dprint's WASM plugins, and re-downloads the PostgreSQL runtime.
+
+  Only the Go *build* cache is scoped per job. Everything else is byte-identical
+  across jobs, and the repository shares a 10 GB cache budget that these entries
+  can exhaust on their own — a duplicate copy is not free, it evicts something
+  another job needed.
 
 inputs:
   scope:
     description: >-
-      Cache namespace. Jobs that produce different build artifacts from the same
-      sources must use different scopes — race-instrumented Go objects are a
-      separate build graph from plain ones, and sharing a key would make the
-      jobs evict each other on every run.
+      Namespace for the Go build cache only. Jobs whose compiled objects differ
+      need different scopes: race-instrumented objects are a separate build
+      graph, so sharing a key would make those jobs evict each other every run.
     required: true
   go:
     description: Cache GOCACHE and GOMODCACHE.
@@ -21,8 +25,8 @@ inputs:
     description: Cache the pnpm store and dprint's plugin cache.
     required: false
     default: "true"
-  lint:
-    description: Cache golangci-lint's analysis cache.
+  pg:
+    description: Cache the embedded PostgreSQL runtime.
     required: false
     default: "false"
 
@@ -39,24 +43,34 @@ runs:
         echo "build=$(mise exec -- go env GOCACHE)" >> "$GITHUB_OUTPUT"
         echo "mod=$(mise exec -- go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
 
-    # restore-keys fall back progressively: the Go build cache is
-    # content-addressed, so a partial hit after a go.sum change still carries
-    # most of the saving.
-    - name: Cache Go build and module cache
+    # Downloaded module source, identical for every job on a given go.sum.
+    # Unscoped on purpose: this is the larger half of a Go cache, and scoping it
+    # stored the same ~500 MB once per job.
+    - name: Cache Go module cache
       if: inputs.go == 'true'
       uses: actions/cache@v4
       with:
-        path: |
-          ${{ steps.go-paths.outputs.build }}
-          ${{ steps.go-paths.outputs.mod }}
-        key: go-${{ inputs.scope }}-${{ runner.os }}-${{ hashFiles('mise.toml') }}-${{ hashFiles('go.sum') }}
+        path: ${{ steps.go-paths.outputs.mod }}
+        key: gomod-${{ runner.os }}-${{ hashFiles('go.sum') }}
         restore-keys: |
-          go-${{ inputs.scope }}-${{ runner.os }}-${{ hashFiles('mise.toml') }}-
-          go-${{ inputs.scope }}-${{ runner.os }}-
+          gomod-${{ runner.os }}-
 
-    # Both default locations are listed because the store path depends on the
-    # pnpm version vp delegates to. A path that does not exist is skipped, so
-    # listing both costs nothing and a wrong guess degrades to today's behaviour.
+    # Compiled objects, which genuinely differ per job. restore-keys fall back
+    # progressively because this cache is content-addressed: a partial hit after
+    # a go.sum change still carries most of the saving.
+    - name: Cache Go build cache
+      if: inputs.go == 'true'
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.go-paths.outputs.build }}
+        key: gobuild-${{ inputs.scope }}-${{ runner.os }}-${{ hashFiles('mise.toml') }}-${{ hashFiles('go.sum') }}
+        restore-keys: |
+          gobuild-${{ inputs.scope }}-${{ runner.os }}-${{ hashFiles('mise.toml') }}-
+          gobuild-${{ inputs.scope }}-${{ runner.os }}-
+
+    # Both pnpm store locations are listed because the path depends on the pnpm
+    # version vp delegates to. A path that does not exist is skipped, so a wrong
+    # guess degrades to today's behaviour rather than failing.
     - name: Cache pnpm store and dprint plugins
       if: inputs.node == 'true'
       uses: actions/cache@v4
@@ -65,18 +79,16 @@ runs:
           ~/.local/share/pnpm/store
           ~/.cache/pnpm
           ~/.cache/dprint
-        key: node-${{ inputs.scope }}-${{ runner.os }}-${{ hashFiles('web/pnpm-lock.yaml', 'web/pnpm-workspace.yaml', 'dprint.json') }}
+        key: node-${{ runner.os }}-${{ hashFiles('web/pnpm-lock.yaml', 'web/pnpm-workspace.yaml', 'dprint.json') }}
         restore-keys: |
-          node-${{ inputs.scope }}-${{ runner.os }}-
+          node-${{ runner.os }}-
 
-    # golangci-lint keeps its own analysis cache separate from GOCACHE, and
-    # `mise run format` runs it over the whole module through the prek hook.
-    - name: Cache golangci-lint analysis
-      if: inputs.lint == 'true'
+    # The runtime tarball is immutable per pgruntime.RuntimeVersion, so hashing
+    # that file is the whole key. Over-invalidating on an unrelated edit to it
+    # costs exactly one re-download.
+    - name: Cache embedded PostgreSQL runtime
+      if: inputs.pg == 'true'
       uses: actions/cache@v4
       with:
-        path: |
-          ~/.cache/golangci-lint
-        key: golangci-${{ inputs.scope }}-${{ runner.os }}-${{ hashFiles('mise.toml') }}-${{ hashFiles('go.sum') }}
-        restore-keys: |
-          golangci-${{ inputs.scope }}-${{ runner.os }}-
+        path: ~/.stella/pg-runtime
+        key: pg-runtime-${{ runner.os }}-${{ hashFiles('internal/pgruntime/runtime.go') }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -79,7 +79,7 @@ jobs:
           # missed every time too. The GitHub Actions cache needs no registry
           # push, which is what makes it usable on a pull_request run.
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=min
           build-args: |
             VERSION=${{ github.sha }}
           secrets: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,6 +35,11 @@ jobs:
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Restore toolchain caches
+        uses: ./.github/actions/toolchain-caches
+        with:
+          scope: docker
+
       - name: Generate code
         run: mise run generate
 
@@ -67,8 +72,14 @@ jobs:
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
-          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/{1}:buildcache,mode=max', env.REGISTRY, env.IMAGE_NAME) || '' }}
+          # This workflow only triggers on pull_request, so the old
+          # `event_name != 'pull_request'` guard on cache-to meant the layer
+          # cache was never written — and the registry tag it read from is not
+          # the one release.yml writes (`buildcache-<suffix>`), so cache-from
+          # missed every time too. The GitHub Actions cache needs no registry
+          # push, which is what makes it usable on a pull_request run.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           build-args: |
             VERSION=${{ github.sha }}
           secrets: |

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -38,6 +38,27 @@ jobs:
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+      # mise-action caches the tools it installs, not Go's own caches, so
+      # without this every run recompiles the whole module from cold.
+      - name: Resolve Go cache paths
+        id: go-cache-paths
+        run: |
+          echo "build=$(mise exec -- go env GOCACHE)" >> "$GITHUB_OUTPUT"
+          echo "mod=$(mise exec -- go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+
+      # Keyed per job because race-instrumented objects are a separate build
+      # graph: sharing one key would make the two jobs evict each other.
+      - name: Cache Go build and module cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ steps.go-cache-paths.outputs.build }}
+            ${{ steps.go-cache-paths.outputs.mod }}
+          key: go-format-${{ runner.os }}-${{ hashFiles('mise.toml') }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-format-${{ runner.os }}-${{ hashFiles('mise.toml') }}-
+            go-format-${{ runner.os }}-
+
       - name: Generate code and check drift
         run: mise run generate:check
 
@@ -61,6 +82,31 @@ jobs:
           install: true
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve Go cache paths
+        id: go-cache-paths
+        run: |
+          echo "build=$(mise exec -- go env GOCACHE)" >> "$GITHUB_OUTPUT"
+          echo "mod=$(mise exec -- go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Go build and module cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ steps.go-cache-paths.outputs.build }}
+            ${{ steps.go-cache-paths.outputs.mod }}
+          key: go-race-${{ runner.os }}-${{ hashFiles('mise.toml') }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-race-${{ runner.os }}-${{ hashFiles('mise.toml') }}-
+            go-race-${{ runner.os }}-
+
+      # The runtime tarball is immutable per RuntimeVersion, so the version
+      # constant is the whole cache key. A miss just re-downloads it.
+      - name: Cache embedded PostgreSQL runtime
+        uses: actions/cache@v4
+        with:
+          path: ~/.stella/pg-runtime
+          key: pg-runtime-${{ runner.os }}-${{ hashFiles('internal/pgruntime/runtime.go') }}
 
       - name: Install bubblewrap
         run: |
@@ -152,6 +198,24 @@ jobs:
           install_args: go
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve Go cache paths
+        id: go-cache-paths
+        shell: bash
+        run: |
+          echo "build=$(mise exec -- go env GOCACHE)" >> "$GITHUB_OUTPUT"
+          echo "mod=$(mise exec -- go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Go build and module cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ steps.go-cache-paths.outputs.build }}
+            ${{ steps.go-cache-paths.outputs.mod }}
+          key: go-windows-${{ runner.os }}-${{ hashFiles('mise.toml') }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-windows-${{ runner.os }}-${{ hashFiles('mise.toml') }}-
+            go-windows-${{ runner.os }}-
 
       - name: Test Windows resource bundle portability
         run: mise exec -- go test ./resources -run '^TestBuiltinBundleWindowsFilesystemModes$' -count=1

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -38,13 +38,10 @@ jobs:
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      # This job runs golangci-lint over the whole module via the prek hook, so
-      # it wants the lint cache the other jobs have no use for.
       - name: Restore toolchain caches
         uses: ./.github/actions/toolchain-caches
         with:
           scope: format
-          lint: "true"
 
       - name: Generate code and check drift
         run: mise run generate:check
@@ -71,19 +68,12 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       # Scoped "race": these objects are built with -race and must not share a
-      # key with the Format job's plain ones.
+      # build cache key with the Format job's plain ones.
       - name: Restore toolchain caches
         uses: ./.github/actions/toolchain-caches
         with:
           scope: race
-
-      # The runtime tarball is immutable per RuntimeVersion, so the version
-      # constant is the whole cache key. A miss just re-downloads it.
-      - name: Cache embedded PostgreSQL runtime
-        uses: actions/cache@v4
-        with:
-          path: ~/.stella/pg-runtime
-          key: pg-runtime-${{ runner.os }}-${{ hashFiles('internal/pgruntime/runtime.go') }}
+          pg: "true"
 
       - name: Install bubblewrap
         run: |

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -38,26 +38,13 @@ jobs:
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      # mise-action caches the tools it installs, not Go's own caches, so
-      # without this every run recompiles the whole module from cold.
-      - name: Resolve Go cache paths
-        id: go-cache-paths
-        run: |
-          echo "build=$(mise exec -- go env GOCACHE)" >> "$GITHUB_OUTPUT"
-          echo "mod=$(mise exec -- go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
-
-      # Keyed per job because race-instrumented objects are a separate build
-      # graph: sharing one key would make the two jobs evict each other.
-      - name: Cache Go build and module cache
-        uses: actions/cache@v4
+      # This job runs golangci-lint over the whole module via the prek hook, so
+      # it wants the lint cache the other jobs have no use for.
+      - name: Restore toolchain caches
+        uses: ./.github/actions/toolchain-caches
         with:
-          path: |
-            ${{ steps.go-cache-paths.outputs.build }}
-            ${{ steps.go-cache-paths.outputs.mod }}
-          key: go-format-${{ runner.os }}-${{ hashFiles('mise.toml') }}-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            go-format-${{ runner.os }}-${{ hashFiles('mise.toml') }}-
-            go-format-${{ runner.os }}-
+          scope: format
+          lint: "true"
 
       - name: Generate code and check drift
         run: mise run generate:check
@@ -83,22 +70,12 @@ jobs:
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Resolve Go cache paths
-        id: go-cache-paths
-        run: |
-          echo "build=$(mise exec -- go env GOCACHE)" >> "$GITHUB_OUTPUT"
-          echo "mod=$(mise exec -- go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Go build and module cache
-        uses: actions/cache@v4
+      # Scoped "race": these objects are built with -race and must not share a
+      # key with the Format job's plain ones.
+      - name: Restore toolchain caches
+        uses: ./.github/actions/toolchain-caches
         with:
-          path: |
-            ${{ steps.go-cache-paths.outputs.build }}
-            ${{ steps.go-cache-paths.outputs.mod }}
-          key: go-race-${{ runner.os }}-${{ hashFiles('mise.toml') }}-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            go-race-${{ runner.os }}-${{ hashFiles('mise.toml') }}-
-            go-race-${{ runner.os }}-
+          scope: race
 
       # The runtime tarball is immutable per RuntimeVersion, so the version
       # constant is the whole cache key. A miss just re-downloads it.
@@ -199,23 +176,12 @@ jobs:
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Resolve Go cache paths
-        id: go-cache-paths
-        shell: bash
-        run: |
-          echo "build=$(mise exec -- go env GOCACHE)" >> "$GITHUB_OUTPUT"
-          echo "mod=$(mise exec -- go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Go build and module cache
-        uses: actions/cache@v4
+      # No Node or lint work here: this job only compiles Go.
+      - name: Restore toolchain caches
+        uses: ./.github/actions/toolchain-caches
         with:
-          path: |
-            ${{ steps.go-cache-paths.outputs.build }}
-            ${{ steps.go-cache-paths.outputs.mod }}
-          key: go-windows-${{ runner.os }}-${{ hashFiles('mise.toml') }}-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            go-windows-${{ runner.os }}-${{ hashFiles('mise.toml') }}-
-            go-windows-${{ runner.os }}-
+          scope: windows
+          node: "false"
 
       - name: Test Windows resource bundle portability
         run: mise exec -- go test ./resources -run '^TestBuiltinBundleWindowsFilesystemModes$' -count=1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,15 +65,10 @@ jobs:
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Cache Go build
-        uses: actions/cache@v4
+      - name: Restore toolchain caches
+        uses: ./.github/actions/toolchain-caches
         with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          scope: release-verify
 
       - name: Generate code and check drift
         run: mise run generate:check
@@ -110,17 +105,11 @@ jobs:
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Cache Go build and PostgreSQL runtime
-        uses: actions/cache@v4
+      - name: Restore toolchain caches
+        uses: ./.github/actions/toolchain-caches
         with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-            ~/.stella/pg-runtime
-          key: ${{ runner.os }}-tests-${{ hashFiles('**/go.sum', 'internal/pgruntime/**') }}
-          restore-keys: |
-            ${{ runner.os }}-tests-
-            ${{ runner.os }}-go-
+          scope: release-tests
+          pg: "true"
 
       - name: Install bubblewrap
         run: |
@@ -163,17 +152,11 @@ jobs:
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Cache Go build and PostgreSQL runtime
-        uses: actions/cache@v4
+      - name: Restore toolchain caches
+        uses: ./.github/actions/toolchain-caches
         with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-            ~/.stella/pg-runtime
-          key: ${{ runner.os }}-system-${{ hashFiles('**/go.sum', 'internal/pgruntime/**') }}
-          restore-keys: |
-            ${{ runner.os }}-system-
-            ${{ runner.os }}-go-
+          scope: release-system
+          pg: "true"
 
       - name: Install bubblewrap
         run: |
@@ -215,16 +198,10 @@ jobs:
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Cache Go build
-        uses: actions/cache@v4
+      - name: Restore toolchain caches
+        uses: ./.github/actions/toolchain-caches
         with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-snapshot-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-snapshot-
-            ${{ runner.os }}-go-
+          scope: release-snapshot
 
       - name: Check GoReleaser configuration
         run: mise run release:check
@@ -255,15 +232,10 @@ jobs:
 
       # No setup-vp or setup-node action: mise owns global Vite+ and Node for
       # every build. Vite+ resolves pnpm from web/package.json.
-      - name: Cache Go build
-        uses: actions/cache@v4
+      - name: Restore toolchain caches
+        uses: ./.github/actions/toolchain-caches
         with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          scope: release-goreleaser
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6


### PR DESCRIPTION
## What

Adds `.github/actions/toolchain-caches` and uses it across `lint-and-test.yml`,
`docker.yml`, and `release.yml`. Fixes a Docker layer cache that was configured
but never written.

## Measured

Same commit, cold run then warm rerun:

| Job | Before | After | Δ |
|---|---|---|---|
| Test | 684s | **243s** | −64% |
| Format | 206s | **71s** | −66% |
| Windows | 139s | **73s** | −47% |

The step that mattered:

| Step | Before | After |
|---|---|---|
| `go test -race -coverprofile` | 525s | **140s** |
| `generate:check` | 89–99s | **18–27s** |
| `prek run --all-files` | 107s | 69s |

## Why it was slow

The workflow already had three `cache: true` entries, which is why this was easy
to miss: they are all `jdx/mise-action`'s, and that caches the tools mise
installs, **not** `~/.cache/go-build` or `~/go/pkg/mod`. There was no
`actions/setup-go` and no `actions/cache`.

So every run recompiled the whole module from cold — with race instrumentation
in the Test job. `vp install` reported `resolved 576, reused 0` every time, and
`generate:api` recompiled six dprint WASM plugins from scratch.

## The cache budget, which is the interesting part

The first pass scoped every cache per job. That pushed the repository to
**10.09 GB against a 10 GB budget**. Past the limit GitHub evicts LRU, so the
duplicates were not merely wasteful — they would have evicted the entries the
next run needed and clawed the speedup back.

Only compiled Go objects genuinely differ per job, and only because `-race` is a
separate build graph. So `GOCACHE` stays scoped and everything else is shared:

- **`GOMODCACHE`** is downloaded module source, identical for a given `go.sum`.
  It was being stored four times at ~500 MB each.
- **pnpm store + dprint plugins** were stored three times at 230 MB each.
- **golangci-lint cache** came to 1 MB, because golangci-lint keeps its real
  analysis output in `GOCACHE`. Dropped — it bought nothing.

`release.yml` had five hand-rolled cache blocks, each storing its own copy of
the module cache under a different key. Those are the `Linux-snapshot`,
`Linux-tests`, `Linux-system` and `Linux-go` entries that alone held **4.37 GB**.
All five now use the shared action.

## The dead Docker cache

`docker.yml` triggers **only** on `pull_request`, but `cache-to` was gated on
`github.event_name != 'pull_request'` — so it never wrote anything. And
`cache-from` read `:buildcache`, which is not the tag `release.yml` writes
(`buildcache-<suffix>`), so it never hit either. That 5m14s job had no cache at
all in practice.

Switched to `type=gha`, which needs no registry push and therefore works on a PR
run. `mode=min` rather than `mode=max`: the first `mode=max` run took 1.67 GB of
the shared budget for intermediate layers.

`sandbox-docker.yml` looks like it has the same bug but does not — it also
triggers on push to `main`, so its registry cache is written there and read on
PRs. Left alone.

## Two things I checked and did not do

- **Deduplicating `generate:check` across Format and Test would make CI
  slower.** The jobs run in parallel, so wall time is `max(206, 684) = 684s`.
  Sharing generation output requires `needs:` plus an artifact, which
  serializes: `206 + (684 − 99) = 791s`, **107s worse**. Caching `generate`'s
  inputs speeds it up in both jobs at once instead, which is what the numbers
  above show.
- **The embedded-PostgreSQL theory was wrong.** `internal/db/dbtest/dbtest.go`
  already starts one server per test process behind a `sync.Once`, migrates a
  template database once, and clones it per test with
  `CREATE DATABASE ... TEMPLATE`. There is no easy win there.

## Test

- `actionlint` on all four workflows — pass
- `mise run format` — pass
- Cold/warm timings above, from runs on this branch

**Note for the reviewer:** this last commit changes every cache key, so the
first run after it is cold again by construction. Judge it on the second run.

## Risk

Cache entries are large and the budget is shared. This change reduces the
footprint substantially, but if eviction still shows up, the `windows` scope is
the first to drop — that job is only 73s warm.

## Refs

Closes #1031

## Checklist

- [x] The PR links a GitHub issue, or states why the fix is small enough not to need one.
- [x] I added or updated focused tests for changed non-trivial behavior, or explained why none are needed.
- [x] I updated relevant English and Chinese documentation, or no documentation change is needed.
- [ ] I ran `mise run format && mise run build && mise run test`. — ran `format` and `actionlint`; `build`/`test` are unaffected by a CI-config change and CI runs them here.

## Feishu Task

- [#1031 缓存 CI 的 Go 与 PostgreSQL 构建产物](https://mcnnox2fhjfq.feishu.cn/record/J85krKQTUeTmRIccgYlc9ZamnMb)
