### PR TITLE
🔒 fix(web): override nanoid to a non-vulnerable 3.x

### DIFF
--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -18,6 +18,7 @@ overrides:
   postcss: '>=8.5.10'
   dompurify: '>=3.4.9'
   js-yaml: '>=4.2.0'
+  nanoid: '>=3.3.18 <4'
 
 importers:
 
@@ -2754,8 +2755,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -6009,7 +6010,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.18: {}
 
   next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
@@ -6176,7 +6177,7 @@ snapshots:
 
   postcss@8.5.15:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -16,6 +16,12 @@ overrides:
   postcss: ">=8.5.10"
   dompurify: ">=3.4.9"
   js-yaml: ">=4.2.0"
+  # Transitive through postcss, whose range is ^3.3.12. Dependabot cannot fix a
+  # pnpm dependency that nothing depends on directly — it reports
+  # security_update_not_possible — so the override is the only lever. The <4
+  # bound is load-bearing: an open-ended override resolves to nanoid 6, which is
+  # ESM-only and breaks postcss's require().
+  nanoid: ">=3.3.18 <4"
 peerDependencyRules:
   allowAny:
     - vite


### PR DESCRIPTION
## What

Pins `nanoid` to `>=3.3.18 <4` in `web/pnpm-workspace.yaml` overrides, resolving the lockfile from 3.3.12 to 3.3.18.

## Why Dependabot could not do this itself

The Dependabot security update run failed with:

```
| security_update_not_possible | { "dependency-name": "nanoid",
|                                 "latest-resolvable-version": "3.3.12",
|                                 "lowest-non-vulnerable-version": "3.3.18",
|                                 "conflicting-dependencies": [] }
```

That verdict is wrong on the merits. `nanoid` enters the tree only through `postcss@8.5.15`, whose range is `nanoid: "^3.3.12"` — 3.3.18 is squarely in range and published. The npm_and_yarn updater simply cannot fix a pnpm dependency that no package depends on directly: it will only try to raise a direct dependency, and it never writes an override itself. So the override is the only lever, which is the same mechanism already used for `next`, `mermaid`, `postcss`, `dompurify`, and `js-yaml`.

## The upper bound is load-bearing

An open-ended `">=3.3.18"` resolves to **nanoid 6.0.1**, which is ESM-only and breaks postcss's `require()`. I hit this on the first install; `<4` is what keeps the override inside postcss's actual range. The comment in the file says so, to stop a future "simplify this" from reintroducing it.

## Verification

`mise run format`, `mise run build`, `mise run test:web` (26 files / 247 tests) all pass locally; full `mise run test` running alongside.

## Refs

No issue: single-line dependency security pin.