### PR TITLE
⬆️ chore(ci): move GitHub Actions onto the Node 24 runtime

### DIFF
--- a/.github/actions/toolchain-caches/action.yml
+++ b/.github/actions/toolchain-caches/action.yml
@@ -48,7 +48,7 @@ runs:
     # stored the same ~500 MB once per job.
     - name: Cache Go module cache
       if: inputs.go == 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ${{ steps.go-paths.outputs.mod }}
         key: gomod-${{ runner.os }}-${{ hashFiles('go.sum') }}
@@ -60,7 +60,7 @@ runs:
     # a go.sum change still carries most of the saving.
     - name: Cache Go build cache
       if: inputs.go == 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ${{ steps.go-paths.outputs.build }}
         key: gobuild-${{ inputs.scope }}-${{ runner.os }}-${{ hashFiles('mise.toml') }}-${{ hashFiles('go.sum') }}
@@ -73,7 +73,7 @@ runs:
     # guess degrades to today's behaviour rather than failing.
     - name: Cache pnpm store and dprint plugins
       if: inputs.node == 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: |
           ~/.local/share/pnpm/store
@@ -88,7 +88,7 @@ runs:
     # costs exactly one re-download.
     - name: Cache embedded PostgreSQL runtime
       if: inputs.pg == 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/.stella/pg-runtime
         key: pg-runtime-${{ runner.os }}-${{ hashFiles('internal/pgruntime/runtime.go') }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,6 @@ permissions:
   packages: write
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: ghcr.io
   IMAGE_NAME: cherryhq/stella
 
@@ -25,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup mise
         uses: jdx/mise-action@v4
@@ -44,11 +43,11 @@ jobs:
         run: mise run generate
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log into GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -56,7 +55,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -64,7 +63,7 @@ jobs:
             type=sha,format=long
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -19,16 +19,13 @@ permissions:
   issues: write
   pull-requests: write
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   format:
     name: Format
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup mise
         uses: jdx/mise-action@v4
@@ -57,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup mise
         uses: jdx/mise-action@v4
@@ -137,13 +134,13 @@ jobs:
 
       - name: Post coverage comment on PR
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: coverage-report
           path: coverage-report.md
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: coverage-report
@@ -155,7 +152,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup mise
         uses: jdx/mise-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,6 @@ permissions:
   contents: read
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: ghcr.io
   IMAGE_NAME: cherryhq/stella
 
@@ -20,7 +19,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout tagged commit
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
@@ -53,7 +52,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout tagged commit
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.sha }}
 
@@ -93,7 +92,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout tagged commit
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.sha }}
 
@@ -140,7 +139,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout tagged commit
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.sha }}
 
@@ -170,7 +169,7 @@ jobs:
 
       - name: Upload System Test diagnostics
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: system-test-logs-${{ github.run_id }}-${{ github.run_attempt }}
           path: dist/logs/system-test/
@@ -185,7 +184,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout tagged commit
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
@@ -217,7 +216,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
@@ -238,7 +237,7 @@ jobs:
           scope: release-goreleaser
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -269,18 +268,18 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.sha }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log into GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -288,7 +287,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -312,7 +311,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: digests-${{ matrix.suffix }}
           path: /tmp/digests/*
@@ -330,17 +329,17 @@ jobs:
 
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           path: /tmp/digests
           pattern: digests-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log into GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -348,7 +347,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |

--- a/.github/workflows/sandbox-docker.yml
+++ b/.github/workflows/sandbox-docker.yml
@@ -20,7 +20,6 @@ permissions:
   packages: write
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: ghcr.io
   IMAGE_NAME: cherryhq/stella-sandbox
 
@@ -36,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup mise
         uses: jdx/mise-action@v4
@@ -54,14 +53,14 @@ jobs:
         run: echo "revision=$(go run ./cmd/stellad system-bundle revision)" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log into GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -69,7 +68,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -81,7 +80,7 @@ jobs:
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: plugins/sandbox/docker/Dockerfile


### PR DESCRIPTION
## What

Bumps the eleven actions whose pinned major predates their Node 24 release, then removes `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` from all four workflows.

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | v5 | v7 |
| `actions/cache` | v4 | v6 |
| `actions/upload-artifact` | v5 | v7 |
| `actions/download-artifact` | v5 | v8 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/login-action` | v3 | v4 |
| `docker/metadata-action` | v5 | v6 |
| `docker/build-push-action` | v6 | v7 |
| `docker/setup-qemu-action` | v3 | v4 |
| `goreleaser/goreleaser-action` | v6 | v7 |
| `marocchino/sticky-pull-request-comment` | v2 | v3 |

`jdx/mise-action@v4` is already Node 24 and is unchanged.

## Why now

Every run ended with a Node 20 deprecation annotation. The flag we used to silence it only forces a Node 20 action bundle to execute on Node 24 — it does not make the action Node 24 native, and it stops helping the day GitHub removes the Node 20 runtime, at which point these pins fail instead of warning.

## Compatibility

All target majors require Actions Runner >= 2.327.1. Every job runs on GitHub-hosted `ubuntu-24.04` / `ubuntu-latest` / `windows-latest`, so that is satisfied; there are no self-hosted runners.

Behavior changes that are more than repackaging, and why each is safe here:

- **`checkout@v7`** blocks fork-PR checkout for `pull_request_target` and `workflow_run`. Neither trigger exists in this repo (verified: only `push`, `pull_request`, and `merge_group`).
- **`download-artifact@v8`** turns hash mismatches into a hard error. `release.yml` only downloads artifacts produced in the same run.
- **`setup-buildx-action@v4`** removes deprecated inputs/outputs; we pass none.
- **`build-push-action@v7`** removes `DOCKER_BUILD_NO_SUMMARY` and `DOCKER_BUILD_EXPORT_RETENTION_DAYS`; we set neither.
- **`metadata-action@v6`** changes `#` handling inside list inputs; no tag pattern here contains one.
- **`goreleaser-action@v7`** is Node 24 + ESM only. The GoReleaser v2 breaking change was v6, which we already use.
- `cache@v6`, `upload-artifact@v7`, and `sticky-pull-request-comment@v3` are Node 24 + ESM packaging with no input changes.

## Verification

`actionlint` clean, `mise run format` clean. The real check is this PR's own run: Format, Test, Windows, and Build Docker Image all exercise the bumped actions, and the annotation should be gone.

`release.yml` is the one workflow this PR cannot exercise from a PR — it only triggers on a `v*.*.*` tag. Its changed steps (`checkout`, `cache` via the composite action, `upload-artifact`, `download-artifact`, `goreleaser-action`, the docker set) are all covered by the other four workflows except `goreleaser-action` and `download-artifact`, which stay behind the next tag. v0.64.0 has just shipped, so there is a full patch cycle of runway before that matters.

## Refs

Closes #1042

## Feishu Task

- [#1042 升级 CI Actions 至 Node 24](https://mcnnox2fhjfq.feishu.cn/record/FcZer9O1TebEh9cxBFYcfWM5nwb)
