### PR TITLE
🐛 fix(web): don't send chat message when Enter confirms IME composition

### DIFF
--- a/web/src/features/recally/components/RecallyChat.tsx
+++ b/web/src/features/recally/components/RecallyChat.tsx
@@ -297,6 +297,7 @@ export function RecallyChat({ articleId, onClose }: Props) {
             value={userInput}
             onChange={(e) => setUserInput(e.target.value)}
             onKeyDown={(e) => {
+              if (e.nativeEvent.isComposing || e.keyCode === 229) return;
               if (e.key === "Enter" && !e.shiftKey) {
                 e.preventDefault();
                 void sendMessage();

--- a/web/src/features/sessions/ChatComposer.tsx
+++ b/web/src/features/sessions/ChatComposer.tsx
@@ -287,6 +287,9 @@ export function ChatComposer({
             value={value}
             onChange={(e) => handleChange(e.target.value)}
             onKeyDown={(e) => {
+              // IME (e.g. pinyin) Enter confirms composition; React's synthetic
+              // event hides isComposing, so check the native event first.
+              if (e.nativeEvent.isComposing || e.keyCode === 229) return;
               if (slashOpen) {
                 if (e.key === "ArrowDown") {
                   e.preventDefault();

--- a/web/src/features/sessions/SessionConversation.tsx
+++ b/web/src/features/sessions/SessionConversation.tsx
@@ -217,6 +217,7 @@ export function SessionConversation({
           value={userInput}
           onChange={(e) => setUserInput(e.target.value)}
           onKeyDown={(e) => {
+            if (e.nativeEvent.isComposing || e.keyCode === 229) return;
             if (e.key === "Enter" && !e.shiftKey) {
               e.preventDefault();
               sendMessage();


### PR DESCRIPTION
## What

Pinyin/ZWJ input confirms composition on Enter, which fired keydown with nativeEvent.isComposing=true before the send handler ran — so pressing Enter to pick a pinyin candidate sent the message instead of confirming the candidate.

## Why

React synthetic keydown events don't expose isComposing, so the existing Enter-to-send handlers (which only checked e.key === 'Enter') could not tell composition-confirmation apart from a real send.

## How

Guard the Enter-to-send paths with if (e.nativeEvent.isComposing || e.keyCode === 229) return; (keyCode 229 as a fallback for older browsers) in:

- web/src/features/sessions/ChatComposer.tsx (main composer, covers both the slash-menu and send branches)
- web/src/features/sessions/SessionConversation.tsx
- web/src/features/recally/components/RecallyChat.tsx

## Verification

- mise run format && mise run build — pass (lint/typecheck clean)
- pre-commit hooks (format + web tests) — pass
- Manual: start dev instance, type with a pinyin IME, press Enter to confirm a candidate (message not sent), then press Enter again to send.

## Refs

No issue: small self-contained input-handling bug fix (5 lines across 3 files), no behavior change beyond correcting Enter-during-composition.