### PR TITLE
🔒 feat(sandbox): support configured Docker OCI runtimes

### DIFF
--- a/.agents/skills/weekly-delivery/SKILL.md
+++ b/.agents/skills/weekly-delivery/SKILL.md
@@ -16,12 +16,12 @@ The delivery week runs **Tuesday 00:00 to the next Tuesday 00:00**, matching the
 Scripts do the mechanical work; you make the judgement calls; V approves before
 anything is written.
 
-| Step                                                         | Owner        | Why                                                |
-| ------------------------------------------------------------ | ------------ | -------------------------------------------------- |
-| Window, PR collection, issue extraction, diff against Feishu | `collect.py` | Deterministic, easy to get subtly wrong by hand    |
-| Task title, 状态, 优先级, 产品线, 里程碑, 验收标准           | you          | Requires reading the issue and knowing the roadmap |
-| Approving the draft                                          | V            | Feishu writes are not reversible in bulk           |
-| Batch write and read-back verification                       | `write.py`   | Deterministic                                      |
+| Step                                                                  | Owner        | Why                                                             |
+| --------------------------------------------------------------------- | ------------ | --------------------------------------------------------------- |
+| Window, PR collection, issue extraction, diff against Feishu          | `collect.py` | Deterministic, easy to get subtly wrong by hand                 |
+| Task title, 状态, 优先级, 产品线, 里程碑, 验收标准, release milestone | you          | Requires reading the issue, release scope, and roadmap          |
+| Approving the draft                                                   | V            | Feishu and GitHub metadata writes need an explicit confirmation |
+| Batch write and read-back verification                                | `write.py`   | Deterministic                                                   |
 
 ## Procedure
 
@@ -74,7 +74,8 @@ only add noise here. Dependabot PRs carry no issue and drop out on their own.
 
 ### 3. Show V the draft and wait
 
-Present a compact table: issue, proposed 任务, 状态, 产品线, 里程碑, PR count.
+Present a compact table: issue, proposed 任务, 状态, 产品线, 里程碑, release
+version, PR count.
 Call out anything you were unsure about. Do not write before V answers.
 
 ### 4. Write
@@ -87,7 +88,24 @@ python3 .agents/skills/weekly-delivery/scripts/write.py
 It batch-creates, batch-updates, then reads the table back and fails loudly if
 any touched row lacks its PR links.
 
-### 5. Report
+### 5. Link delivery PRs and release milestones
+
+After the Feishu write succeeds, generate a share link for every touched task
+and append a `## Feishu Task` section to every delivery PR that references it.
+A PR that delivers two issues carries two task links. Do not manufacture a task
+for a small `No issue:` PR or a release-bookkeeping PR.
+
+Set the linked GitHub Issue's **GitHub release milestone** only when its complete
+work shipped in that release. The release tag and release PR are the evidence,
+not merge time alone: release branches can cherry-pick a PR, and an open Issue
+with partial PRs must remain unmilestoned. A closed release milestone can be
+assigned through the GitHub Issues API even though `gh issue edit` only lists
+open milestones.
+
+This is a GitHub-side delivery record, not a synchronization of the Feishu
+product milestone. Never copy names or links between those two milestone types.
+
+### 6. Report
 
 Pull the numbers from the Base rather than recomputing them locally:
 

--- a/.agents/skills/weekly-delivery/SKILL.md
+++ b/.agents/skills/weekly-delivery/SKILL.md
@@ -76,6 +76,8 @@ only add noise here. Dependabot PRs carry no issue and drop out on their own.
 
 Present a compact table: issue, proposed 任务, 状态, 产品线, 里程碑, release
 version, PR count.
+List `stats.skipped_release_issues` separately so the release-only
+classification is visible during approval.
 Call out anything you were unsure about. Do not write before V answers.
 
 ### 4. Write

--- a/.agents/skills/weekly-delivery/scripts/collect.py
+++ b/.agents/skills/weekly-delivery/scripts/collect.py
@@ -126,7 +126,7 @@ def main():
         if m:
             by_issue[m.group(1)] = t
 
-    new, update = [], []
+    new, update, skipped_release = [], [], []
     for n, plist in sorted(issues.items(), key=lambda kv: int(kv[0])):
         plist = sorted(plist, key=lambda p: p["createdAt"])
         meta = issue_meta(n)
@@ -145,6 +145,12 @@ def main():
         }
         task = by_issue.get(n)
         if is_release_action(meta):
+            skipped_release.append({
+                "issue": n,
+                "issue_title": meta["title"],
+                "issue_url": entry["issue_url"],
+                "prs": entry["prs"],
+            })
             continue
         if task is None:
             # Judgement fields the agent must fill before write.py will accept it.
@@ -167,6 +173,7 @@ def main():
             "real_issues": len(issues),
             "pr_numbers_mistaken_for_issues": sorted(set(refs) - set(issues), key=int),
             "unlinked_prs": unlinked,
+            "skipped_release_issues": skipped_release,
         },
         "new": new,
         "update": update,
@@ -179,6 +186,8 @@ def main():
     print(f"issues   {len(issues)} real ({len(refs) - len(issues)} refs were PR numbers)")
     print(f"new      {len(new)} tasks to create")
     print(f"update   {len(update)} existing tasks to refresh")
+    if skipped_release:
+        print(f"release  {[item['issue'] for item in skipped_release]}  <- skipped release bookkeeping")
     if unlinked:
         print(f"unlinked {unlinked}  <- PRs with no issue reference")
     print(f"draft    {args.out}")

--- a/.agents/skills/weekly-delivery/scripts/collect.py
+++ b/.agents/skills/weekly-delivery/scripts/collect.py
@@ -76,17 +76,31 @@ def issue_meta(number):
     return json.loads(raw)
 
 
+def is_release_action(meta):
+    """Release bookkeeping belongs to the GitHub release milestone, not Feishu tasks."""
+    return meta["title"].lower().startswith("release:")
+
+
 def feishu_tasks():
-    raw = sh([
-        "lark-cli", "base", "+record-list", "--base-token", BASE,
-        "--table-id", TASKS, "--as", "user", "--limit", "200", "--json",
-    ])
-    data = json.loads(raw)["data"]
-    fields = data["fields"]
-    return [
-        dict(zip(fields, row), _id=rid)
-        for rid, row in zip(data["record_id_list"], data["data"])
-    ]
+    tasks, offset = [], 0
+    while True:
+        raw = sh([
+            "lark-cli", "base", "+record-list", "--base-token", BASE,
+            "--table-id", TASKS, "--as", "user", "--limit", "200",
+            "--offset", str(offset), "--json",
+        ])
+        data = json.loads(raw)["data"]
+        fields = data["fields"]
+        batch = [
+            dict(zip(fields, row), _id=rid)
+            for rid, row in zip(data["record_id_list"], data["data"])
+        ]
+        tasks.extend(batch)
+        if not data.get("has_more"):
+            return tasks
+        if not batch:
+            sys.exit("record-list returned has_more with an empty page")
+        offset += len(batch)
 
 
 def main():
@@ -130,6 +144,8 @@ def main():
             "last_merged": plist[-1]["mergedAt"][:10],
         }
         task = by_issue.get(n)
+        if is_release_action(meta):
+            continue
         if task is None:
             # Judgement fields the agent must fill before write.py will accept it.
             entry.update({"任务": None, "状态": None, "优先级": None,

--- a/.agents/skills/weekly-delivery/scripts/test_collect.py
+++ b/.agents/skills/weekly-delivery/scripts/test_collect.py
@@ -1,0 +1,40 @@
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import collect
+
+
+class CollectTest(unittest.TestCase):
+    def test_release_skip_remains_visible_in_draft(self):
+        pr = {
+            "number": 12,
+            "title": "release work",
+            "url": "https://example.test/pr/12",
+            "createdAt": "2026-08-12T00:00:00Z",
+            "mergedAt": "2026-08-13T00:00:00Z",
+            "body": "Closes #34",
+        }
+        with tempfile.TemporaryDirectory() as tmp, \
+             mock.patch.object(collect, "merged_prs", return_value=[pr]), \
+             mock.patch.object(collect, "is_issue", return_value=True), \
+             mock.patch.object(collect, "issue_meta", return_value={
+                 "title": "release: validate candidate artifacts",
+                 "state": "CLOSED",
+                 "labels": [],
+             }), \
+             mock.patch.object(collect, "feishu_tasks", return_value=[]), \
+             mock.patch.object(sys, "argv", ["collect.py", "--week-start", "2026-08-11", "--out", str(Path(tmp) / "draft.json")]):
+            collect.main()
+            draft = json.loads((Path(tmp) / "draft.json").read_text())
+
+        self.assertEqual(draft["new"], [])
+        self.assertEqual(draft["update"], [])
+        self.assertEqual(draft["stats"]["skipped_release_issues"][0]["issue"], "34")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/weekly-delivery/scripts/write.py
+++ b/.agents/skills/weekly-delivery/scripts/write.py
@@ -53,6 +53,23 @@ def milestone_cell(name):
     return [{"id": MILESTONES[name]}]
 
 
+def all_rows():
+    rows, offset = {}, 0
+    while True:
+        argv = ["lark-cli", "base", "+record-list", "--base-token", BASE, "--table-id", TASKS,
+                "--as", "user", "--limit", "200", "--offset", str(offset), "--json"]
+        table = json.loads(subprocess.run(argv, capture_output=True, text=True).stdout)["data"]
+        rows.update(
+            (rid, dict(zip(table["fields"], row)))
+            for rid, row in zip(table["record_id_list"], table["data"])
+        )
+        if not table.get("has_more"):
+            return rows
+        if not table["record_id_list"]:
+            sys.exit("record-list returned has_more with an empty page")
+        offset += len(table["record_id_list"])
+
+
 def common(entry):
     """Fields every touched task carries, whether new or refreshed."""
     fields = {
@@ -105,6 +122,11 @@ def main():
     updates = {}
     for e in draft["update"]:
         row = dict(common(e))
+        # Updates normally refresh only delivery references. These explicit
+        # fields let the reviewed draft repair a task whose lifecycle drifted.
+        for field in ("状态", "完成日期"):
+            if field in e:
+                row[field] = e[field]
         ms = milestone_cell(e.get("里程碑"))
         if ms:
             row["里程碑"] = ms
@@ -122,11 +144,7 @@ def main():
         lark("+record-batch-update", {"update_records": updates})
 
     # The write APIs do not echo stored rows, so confirm against the table.
-    argv = ["lark-cli", "base", "+record-list", "--base-token", BASE, "--table-id", TASKS,
-            "--as", "user", "--limit", "200", "--json"]
-    table = json.loads(subprocess.run(argv, capture_output=True, text=True).stdout)["data"]
-    rows = {rid: dict(zip(table["fields"], row))
-            for rid, row in zip(table["record_id_list"], table["data"])}
+    rows = all_rows()
     touched = set(created) | set(updates)
     missing_pr = [rid for rid in touched if not rows.get(rid, {}).get("PR")]
     print(f"verified {len(touched - set(missing_pr))}/{len(touched)} rows carry PR links")

--- a/cmd/stellad/service_darwin.go
+++ b/cmd/stellad/service_darwin.go
@@ -27,6 +27,8 @@ const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
     <dict>
         <key>STELLA_HOME</key>
         <string>HOME_DIR/.stella</string>
+        <key>STELLA_DOCKER_SANDBOX_MODE</key>
+        <string>host</string>
     </dict>
 
     <key>RunAtLoad</key>

--- a/cmd/stellad/service_darwin_test.go
+++ b/cmd/stellad/service_darwin_test.go
@@ -1,0 +1,14 @@
+//go:build darwin
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLaunchAgentOwnsDockerSandboxMode(t *testing.T) {
+	if !strings.Contains(plistTemplate, "<key>STELLA_DOCKER_SANDBOX_MODE</key>\n        <string>host</string>") {
+		t.Fatal("LaunchAgent must pin native Docker sandbox mode to host")
+	}
+}

--- a/cmd/stellad/service_linux.go
+++ b/cmd/stellad/service_linux.go
@@ -23,6 +23,7 @@ User=stella
 Group=stella
 WorkingDirectory=/var/lib/stella
 Environment=STELLA_HOME=/var/lib/stella
+Environment=STELLA_DOCKER_SANDBOX_MODE=host
 Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 ExecStart=STELLAD_EXEC

--- a/cmd/stellad/service_linux_test.go
+++ b/cmd/stellad/service_linux_test.go
@@ -28,3 +28,9 @@ func TestCheckBinaryPathSecurityRejectsUserOwnedBinary(t *testing.T) {
 		t.Fatalf("error = %q, want root-owned hint", err.Error())
 	}
 }
+
+func TestSystemServiceOwnsDockerSandboxMode(t *testing.T) {
+	if !strings.Contains(systemUnitTemplate, "Environment=STELLA_DOCKER_SANDBOX_MODE=host") {
+		t.Fatal("system service must pin native Docker sandbox mode to host")
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,8 @@ services:
       - STELLA_SANDBOX_BACKEND=docker
       # Explicit Docker sandbox mode: host | bind | volume
       - STELLA_DOCKER_SANDBOX_MODE=volume
+      # Optional registered OCI runtime for sandbox containers (for example, runsc for gVisor)
+      - STELLA_DOCKER_RUNTIME=${STELLA_DOCKER_RUNTIME:-}
       # Tell volume mode which named volume backs STELLA_HOME
       - STELLA_HOME_VOLUME=stella-data
       # OTEL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       - STELLA_DATABASE_URL=postgres://postgres:postgres@postgres:5432/stella?sslmode=disable
       # Lock sandbox backend via env (docker | local | none); UI becomes read-only
       - STELLA_SANDBOX_BACKEND=docker
-      # Explicit Docker sandbox mode: host | bind | volume
+      # Deployment-owned mode: this Compose topology always uses the named volume below
       - STELLA_DOCKER_SANDBOX_MODE=volume
       # Optional registered OCI runtime for sandbox containers (for example, runsc for gVisor)
       - STELLA_DOCKER_RUNTIME=${STELLA_DOCKER_RUNTIME:-}

--- a/internal/agent/sandbox/session.go
+++ b/internal/agent/sandbox/session.go
@@ -2,6 +2,7 @@ package sandbox
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -58,15 +59,18 @@ func createDockerSession(ctx context.Context, cfg Config) (pkgsandbox.Session, e
 
 	session, err := factory.CreateSession(ctx, policy)
 	if err != nil {
-		if dockerImageIsDev() {
-			err = fmt.Errorf("%w (run `mise run sandbox:docker:build` to build the local %q image)", err, dockerImage())
-		} else {
-			err = fmt.Errorf("docker not available; install and start Docker Desktop or the docker daemon: %w", err)
-		}
-		return nil, err
+		return nil, dockerSessionError(err)
 	}
 
 	return session, nil
+}
+
+func dockerSessionError(err error) error {
+	var imageErr *dockerplugin.ImageUnavailableError
+	if dockerImageIsDev() && errors.As(err, &imageErr) {
+		return fmt.Errorf("%w (run `mise run sandbox:docker:build` to build the local %q image)", err, dockerImage())
+	}
+	return fmt.Errorf("create docker session: %w", err)
 }
 
 // createLocalSession creates a local (no container isolation) session.

--- a/internal/agent/sandbox/session_error_test.go
+++ b/internal/agent/sandbox/session_error_test.go
@@ -1,0 +1,26 @@
+package sandbox
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/CherryHQ/stella/internal/version"
+	dockerplugin "github.com/CherryHQ/stella/plugins/sandbox/docker"
+)
+
+func TestDockerSessionErrorAddsBuildHintOnlyForDevImageFailure(t *testing.T) {
+	original := version.Version
+	t.Cleanup(func() { version.Version = original })
+	version.Version = "dev"
+
+	runtimeErr := errors.New(`docker preflight: runtime "runsc" is not registered`)
+	if got := dockerSessionError(runtimeErr).Error(); strings.Contains(got, "sandbox:docker:build") {
+		t.Fatalf("runtime error received image build hint: %s", got)
+	}
+
+	imageErr := &dockerplugin.ImageUnavailableError{Err: errors.New("image pull failed")}
+	if got := dockerSessionError(imageErr).Error(); !strings.Contains(got, "sandbox:docker:build") {
+		t.Fatalf("dev image error missing build hint: %s", got)
+	}
+}

--- a/internal/config/env_scan_test.go
+++ b/internal/config/env_scan_test.go
@@ -99,11 +99,12 @@ var envReadAllowlist = map[string]map[string]bool{
 	// docker-sandbox host wiring stay local to their plugin.
 	"plugins/channels/feishu/references.go": {"STELLA_BASE_URL": true},
 	"plugins/sandbox/docker/dood.go": {
-		"STELLA_HOME_HOST":          true,
-		"STELLA_HOME_VOLUME":        true,
-		"STELLA_SANDBOX_NETWORK":    true,
-		"STELLA_SANDBOX_SERVER_URL": true,
-		nonLiteralRead:              true,
+		"STELLA_DOCKER_RUNTIME":      true,
+		"STELLA_DOCKER_SANDBOX_MODE": true,
+		"STELLA_HOME_HOST":           true,
+		"STELLA_HOME_VOLUME":         true,
+		"STELLA_SANDBOX_NETWORK":     true,
+		"STELLA_SANDBOX_SERVER_URL":  true,
 	},
 }
 

--- a/plugins/sandbox/docker/Dockerfile
+++ b/plugins/sandbox/docker/Dockerfile
@@ -58,7 +58,7 @@ ARG USER_GID=1000
 
 RUN groupadd --non-unique -g ${USER_GID} stella && \
     useradd --non-unique -u ${USER_UID} -g ${USER_GID} -m -s /bin/bash stella && \
-    mkdir -p /workspace /user /opt/stella/bin /opt/stella/.mise-tools/configs && \
+    mkdir -p /workspace /user /opt/stella/bin /opt/stella/.mise-tools/configs /opt/stella/user-tools && \
     ln -s /opt/stella/bin/.stella-shell-env /etc/profile.d/99-stella-mise.sh && \
     chown -R stella:stella /home/stella /workspace /user /opt/stella
 

--- a/plugins/sandbox/docker/config.go
+++ b/plugins/sandbox/docker/config.go
@@ -22,6 +22,11 @@ type Config struct {
 	// Image is the container image to use. Required.
 	Image string
 
+	// Runtime selects the Docker daemon's registered OCI runtime for every
+	// sandbox and tool-cache helper container. Empty uses the daemon default.
+	// Normally auto-derived from STELLA_DOCKER_RUNTIME by NewFactory.
+	Runtime string
+
 	// ExpectedBundleRevision is the revision embedded by the running stellad.
 	// Docker readiness rejects an image that labels a different revision.
 	ExpectedBundleRevision string

--- a/plugins/sandbox/docker/dockerclient/client.go
+++ b/plugins/sandbox/docker/dockerclient/client.go
@@ -70,6 +70,7 @@ type DaemonSecurity struct {
 	UserNamespace bool
 	CgroupDriver  string
 	MemoryLimit   bool
+	SwapLimit     bool
 	CPUCfsPeriod  bool
 	CPUCfsQuota   bool
 	PidsLimit     bool
@@ -164,6 +165,7 @@ func (c *Client) Security(ctx context.Context) (DaemonSecurity, error) {
 	security := DaemonSecurity{
 		CgroupDriver: res.Info.CgroupDriver,
 		MemoryLimit:  res.Info.MemoryLimit,
+		SwapLimit:    res.Info.SwapLimit,
 		CPUCfsPeriod: res.Info.CPUCfsPeriod,
 		CPUCfsQuota:  res.Info.CPUCfsQuota,
 		PidsLimit:    res.Info.PidsLimit,

--- a/plugins/sandbox/docker/dockerclient/client.go
+++ b/plugins/sandbox/docker/dockerclient/client.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 
 	"github.com/containerd/errdefs"
@@ -65,9 +66,29 @@ type VersionInfo struct {
 // DaemonSecurity describes daemon properties that change how sandbox identity
 // and resource enforcement must be rendered.
 type DaemonSecurity struct {
-	Rootless     bool
-	CgroupDriver string
+	Rootless      bool
+	UserNamespace bool
+	CgroupDriver  string
+	MemoryLimit   bool
+	CPUCfsPeriod  bool
+	CPUCfsQuota   bool
+	PidsLimit     bool
 }
+
+// RuntimeInfo contains the registered runtime settings that affect Stella's
+// sandbox guarantees.
+type RuntimeInfo struct {
+	Name string
+	Args []string
+}
+
+// ImageUnavailableError identifies failures while preparing a container image.
+type ImageUnavailableError struct {
+	Err error
+}
+
+func (e *ImageUnavailableError) Error() string { return e.Err.Error() }
+func (e *ImageUnavailableError) Unwrap() error { return e.Err }
 
 // New returns a Client configured from the process environment. API-version
 // negotiation is enabled by default in the moby SDK.
@@ -115,18 +136,22 @@ func (c *Client) Version(ctx context.Context) (*VersionInfo, error) {
 	return info, nil
 }
 
-// RuntimeAvailable reports whether the daemon has registered the named OCI
-// runtime. An empty name means the daemon default and needs no lookup.
-func (c *Client) RuntimeAvailable(ctx context.Context, name string) (bool, error) {
-	if name == "" {
-		return true, nil
-	}
+// Runtime reports the daemon configuration for one registered OCI runtime.
+// An empty name resolves to the daemon default so its safety settings are not
+// exempt from preflight.
+func (c *Client) Runtime(ctx context.Context, name string) (RuntimeInfo, bool, error) {
 	res, err := c.api.Info(ctx, mobyclient.InfoOptions{})
 	if err != nil {
-		return false, fmt.Errorf("dockerclient: system info: %w", err)
+		return RuntimeInfo{}, false, fmt.Errorf("dockerclient: system info: %w", err)
 	}
-	_, ok := res.Info.Runtimes[name]
-	return ok, nil
+	if name == "" {
+		name = res.Info.DefaultRuntime
+	}
+	if name == "" {
+		return RuntimeInfo{}, false, nil
+	}
+	runtime, ok := res.Info.Runtimes[name]
+	return RuntimeInfo{Name: name, Args: append([]string(nil), runtime.Args...)}, ok, nil
 }
 
 // Security reports whether Docker itself is rootless and which cgroup driver
@@ -136,14 +161,26 @@ func (c *Client) Security(ctx context.Context) (DaemonSecurity, error) {
 	if err != nil {
 		return DaemonSecurity{}, fmt.Errorf("dockerclient: system info: %w", err)
 	}
-	security := DaemonSecurity{CgroupDriver: res.Info.CgroupDriver}
+	security := DaemonSecurity{
+		CgroupDriver: res.Info.CgroupDriver,
+		MemoryLimit:  res.Info.MemoryLimit,
+		CPUCfsPeriod: res.Info.CPUCfsPeriod,
+		CPUCfsQuota:  res.Info.CPUCfsQuota,
+		PidsLimit:    res.Info.PidsLimit,
+	}
 	for _, option := range res.Info.SecurityOptions {
-		if option == "rootless" || option == "name=rootless" {
+		if securityOptionEnabled(option, "rootless") {
 			security.Rootless = true
-			break
+		}
+		if securityOptionEnabled(option, "userns") {
+			security.UserNamespace = true
 		}
 	}
 	return security, nil
+}
+
+func securityOptionEnabled(option, name string) bool {
+	return option == name || option == "name="+name || strings.HasPrefix(option, "name="+name+",")
 }
 
 // ImageExists reports whether the image exists locally.

--- a/plugins/sandbox/docker/dockerclient/client.go
+++ b/plugins/sandbox/docker/dockerclient/client.go
@@ -68,7 +68,6 @@ type VersionInfo struct {
 type DaemonSecurity struct {
 	Rootless      bool
 	UserNamespace bool
-	CgroupDriver  string
 	MemoryLimit   bool
 	SwapLimit     bool
 	CPUCfsPeriod  bool
@@ -163,7 +162,6 @@ func (c *Client) Security(ctx context.Context) (DaemonSecurity, error) {
 		return DaemonSecurity{}, fmt.Errorf("dockerclient: system info: %w", err)
 	}
 	security := DaemonSecurity{
-		CgroupDriver: res.Info.CgroupDriver,
 		MemoryLimit:  res.Info.MemoryLimit,
 		SwapLimit:    res.Info.SwapLimit,
 		CPUCfsPeriod: res.Info.CPUCfsPeriod,

--- a/plugins/sandbox/docker/dockerclient/client.go
+++ b/plugins/sandbox/docker/dockerclient/client.go
@@ -18,6 +18,7 @@ import (
 // surface.
 type API interface {
 	ServerVersion(ctx context.Context, opts mobyclient.ServerVersionOptions) (mobyclient.ServerVersionResult, error)
+	Info(ctx context.Context, opts mobyclient.InfoOptions) (mobyclient.SystemInfoResult, error)
 	ImageInspect(ctx context.Context, image string, opts ...mobyclient.ImageInspectOption) (mobyclient.ImageInspectResult, error)
 	ImagePull(ctx context.Context, ref string, opts mobyclient.ImagePullOptions) (mobyclient.ImagePullResponse, error)
 
@@ -105,6 +106,20 @@ func (c *Client) Version(ctx context.Context) (*VersionInfo, error) {
 	info.Server.APIVersion = res.APIVersion
 	info.Client.Version = mobyclient.MaxAPIVersion
 	return info, nil
+}
+
+// RuntimeAvailable reports whether the daemon has registered the named OCI
+// runtime. An empty name means the daemon default and needs no lookup.
+func (c *Client) RuntimeAvailable(ctx context.Context, name string) (bool, error) {
+	if name == "" {
+		return true, nil
+	}
+	res, err := c.api.Info(ctx, mobyclient.InfoOptions{})
+	if err != nil {
+		return false, fmt.Errorf("dockerclient: system info: %w", err)
+	}
+	_, ok := res.Info.Runtimes[name]
+	return ok, nil
 }
 
 // ImageExists reports whether the image exists locally.

--- a/plugins/sandbox/docker/dockerclient/client.go
+++ b/plugins/sandbox/docker/dockerclient/client.go
@@ -62,6 +62,13 @@ type VersionInfo struct {
 	}
 }
 
+// DaemonSecurity describes daemon properties that change how sandbox identity
+// and resource enforcement must be rendered.
+type DaemonSecurity struct {
+	Rootless     bool
+	CgroupDriver string
+}
+
 // New returns a Client configured from the process environment. API-version
 // negotiation is enabled by default in the moby SDK.
 func New() (*Client, error) {
@@ -120,6 +127,23 @@ func (c *Client) RuntimeAvailable(ctx context.Context, name string) (bool, error
 	}
 	_, ok := res.Info.Runtimes[name]
 	return ok, nil
+}
+
+// Security reports whether Docker itself is rootless and which cgroup driver
+// backs container resource limits.
+func (c *Client) Security(ctx context.Context) (DaemonSecurity, error) {
+	res, err := c.api.Info(ctx, mobyclient.InfoOptions{})
+	if err != nil {
+		return DaemonSecurity{}, fmt.Errorf("dockerclient: system info: %w", err)
+	}
+	security := DaemonSecurity{CgroupDriver: res.Info.CgroupDriver}
+	for _, option := range res.Info.SecurityOptions {
+		if option == "rootless" || option == "name=rootless" {
+			security.Rootless = true
+			break
+		}
+	}
+	return security, nil
 }
 
 // ImageExists reports whether the image exists locally.

--- a/plugins/sandbox/docker/dockerclient/container.go
+++ b/plugins/sandbox/docker/dockerclient/container.go
@@ -94,27 +94,27 @@ func (c *Client) CreateAndStart(ctx context.Context, opts CreateOptions) (string
 		for _, warning := range created.Warnings {
 			slog.Warn("dockerclient: refusing sandbox container created with daemon warning", "container_id", created.ID, "container_name", opts.Name, "warning", warning)
 		}
-		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		if _, removeErr := c.api.ContainerRemove(cleanupCtx, created.ID, mobyclient.ContainerRemoveOptions{Force: true}); removeErr != nil && !errdefs.IsNotFound(removeErr) {
-			slog.Warn("dockerclient: cleanup failed after container create warning", "container_id", created.ID, "container_name", opts.Name, "error", removeErr)
-		}
+		c.cleanupCreatedContainer(created.ID, opts.Name)
 		return "", fmt.Errorf("dockerclient: container create returned warnings: %s", strings.Join(created.Warnings, "; "))
 	}
 
 	slog.Info("dockerclient: starting sandbox container", "container_id", created.ID, "container_name", opts.Name)
 	if _, err := c.api.ContainerStart(ctx, created.ID, mobyclient.ContainerStartOptions{}); err != nil {
 		slog.Warn("dockerclient: container start failed", "container_id", created.ID, "container_name", opts.Name, "error", err)
-		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		if _, removeErr := c.api.ContainerRemove(cleanupCtx, created.ID, mobyclient.ContainerRemoveOptions{Force: true}); removeErr != nil && !errdefs.IsNotFound(removeErr) {
-			slog.Warn("dockerclient: cleanup failed after container start failure", "container_id", created.ID, "container_name", opts.Name, "error", removeErr)
-		}
+		c.cleanupCreatedContainer(created.ID, opts.Name)
 		return "", fmt.Errorf("dockerclient: container start %s: %w", created.ID, err)
 	}
 
 	slog.Info("dockerclient: sandbox container started", "container_id", created.ID, "container_name", opts.Name)
 	return created.ID, nil
+}
+
+func (c *Client) cleanupCreatedContainer(containerID, containerName string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if _, err := c.api.ContainerRemove(ctx, containerID, mobyclient.ContainerRemoveOptions{Force: true}); err != nil && !errdefs.IsNotFound(err) {
+		slog.Warn("dockerclient: cleanup failed after container setup", "container_id", containerID, "container_name", containerName, "error", err)
+	}
 }
 
 // Stop sends SIGTERM with a 2-second grace period, then removes the container.

--- a/plugins/sandbox/docker/dockerclient/container.go
+++ b/plugins/sandbox/docker/dockerclient/container.go
@@ -55,6 +55,7 @@ type Mount struct {
 // CreateOptions configures a new sandbox container.
 type CreateOptions struct {
 	Image          string
+	Runtime        string      // optional registered OCI runtime; empty uses the daemon default
 	WorkspaceHost  string      // absolute host path (daemon-side)
 	WorkspaceMount string      // absolute in-container path (e.g. "/workspace")
 	ExtraMounts    []Mount     // additional host -> container mounts; ReadOnly is honored per mount
@@ -76,7 +77,7 @@ func (c *Client) CreateAndStart(ctx context.Context, opts CreateOptions) (string
 
 	createOpts := buildContainerCreateOptions(opts)
 
-	slog.Info("dockerclient: creating sandbox container", "image", opts.Image, "container_name", opts.Name, "network_mode", opts.NetworkMode, "mounts", len(createOpts.HostConfig.Mounts))
+	slog.Info("dockerclient: creating sandbox container", "image", opts.Image, "container_name", opts.Name, "runtime", opts.Runtime, "network_mode", opts.NetworkMode, "mounts", len(createOpts.HostConfig.Mounts))
 	created, err := c.api.ContainerCreate(ctx, createOpts)
 	if err != nil && errdefs.IsNotFound(err) {
 		c.invalidateImageReady(opts.Image)
@@ -246,6 +247,7 @@ func buildContainerConfig(opts CreateOptions) *container.Config {
 func buildHostConfig(opts CreateOptions) *container.HostConfig {
 	pidsLimit := sandboxPidsLimit
 	hc := &container.HostConfig{
+		Runtime:     opts.Runtime,
 		NetworkMode: mapNetworkMode(opts),
 		Resources: container.Resources{
 			Memory:    sandboxMemoryLimitBytes,

--- a/plugins/sandbox/docker/dockerclient/container.go
+++ b/plugins/sandbox/docker/dockerclient/container.go
@@ -261,9 +261,10 @@ func buildHostConfig(opts CreateOptions) *container.HostConfig {
 		Runtime:     opts.Runtime,
 		NetworkMode: mapNetworkMode(opts),
 		Resources: container.Resources{
-			Memory:    sandboxMemoryLimitBytes,
-			NanoCPUs:  sandboxNanoCPUs,
-			PidsLimit: &pidsLimit,
+			Memory:     sandboxMemoryLimitBytes,
+			MemorySwap: sandboxMemoryLimitBytes,
+			NanoCPUs:   sandboxNanoCPUs,
+			PidsLimit:  &pidsLimit,
 		},
 		// Drop all capabilities by default; relax narrowly if a toolchain genuinely needs one.
 		CapDrop:        []string{"ALL"},

--- a/plugins/sandbox/docker/dockerclient/container.go
+++ b/plugins/sandbox/docker/dockerclient/container.go
@@ -72,7 +72,7 @@ type CreateOptions struct {
 // If the image is not present locally it is pulled automatically.
 func (c *Client) CreateAndStart(ctx context.Context, opts CreateOptions) (string, error) {
 	if err := c.EnsureImageReady(ctx, opts.Image, opts.Name); err != nil {
-		return "", err
+		return "", &ImageUnavailableError{Err: err}
 	}
 
 	createOpts := buildContainerCreateOptions(opts)
@@ -82,13 +82,24 @@ func (c *Client) CreateAndStart(ctx context.Context, opts CreateOptions) (string
 	if err != nil && errdefs.IsNotFound(err) {
 		c.invalidateImageReady(opts.Image)
 		if readyErr := c.EnsureImageReady(ctx, opts.Image, opts.Name); readyErr != nil {
-			return "", readyErr
+			return "", &ImageUnavailableError{Err: readyErr}
 		}
 		created, err = c.api.ContainerCreate(ctx, createOpts)
 	}
 	if err != nil {
 		slog.Warn("dockerclient: container create failed", "image", opts.Image, "container_name", opts.Name, "error", err)
 		return "", fmt.Errorf("dockerclient: container create: %w", err)
+	}
+	if len(created.Warnings) > 0 {
+		for _, warning := range created.Warnings {
+			slog.Warn("dockerclient: refusing sandbox container created with daemon warning", "container_id", created.ID, "container_name", opts.Name, "warning", warning)
+		}
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if _, removeErr := c.api.ContainerRemove(cleanupCtx, created.ID, mobyclient.ContainerRemoveOptions{Force: true}); removeErr != nil && !errdefs.IsNotFound(removeErr) {
+			slog.Warn("dockerclient: cleanup failed after container create warning", "container_id", created.ID, "container_name", opts.Name, "error", removeErr)
+		}
+		return "", fmt.Errorf("dockerclient: container create returned warnings: %s", strings.Join(created.Warnings, "; "))
 	}
 
 	slog.Info("dockerclient: starting sandbox container", "container_id", created.ID, "container_name", opts.Name)

--- a/plugins/sandbox/docker/dockerclient/container_test.go
+++ b/plugins/sandbox/docker/dockerclient/container_test.go
@@ -66,6 +66,9 @@ func TestBuildHostConfigHardening(t *testing.T) {
 	if hc.Memory != sandboxMemoryLimitBytes {
 		t.Fatalf("Memory = %d, want %d", hc.Memory, sandboxMemoryLimitBytes)
 	}
+	if hc.MemorySwap != sandboxMemoryLimitBytes {
+		t.Fatalf("MemorySwap = %d, want %d", hc.MemorySwap, sandboxMemoryLimitBytes)
+	}
 	if hc.NanoCPUs != sandboxNanoCPUs {
 		t.Fatalf("NanoCPUs = %d, want %d", hc.NanoCPUs, sandboxNanoCPUs)
 	}

--- a/plugins/sandbox/docker/dockerclient/container_test.go
+++ b/plugins/sandbox/docker/dockerclient/container_test.go
@@ -56,7 +56,10 @@ func TestMapNetworkMode(t *testing.T) {
 }
 
 func TestBuildHostConfigHardening(t *testing.T) {
-	hc := buildHostConfig(CreateOptions{NetworkMode: NetworkDisabled})
+	hc := buildHostConfig(CreateOptions{Runtime: "runsc", NetworkMode: NetworkDisabled})
+	if hc.Runtime != "runsc" {
+		t.Fatalf("Runtime = %q, want runsc", hc.Runtime)
+	}
 	if hc.NetworkMode != container.NetworkMode("none") {
 		t.Fatalf("NetworkMode = %q, want none", hc.NetworkMode)
 	}

--- a/plugins/sandbox/docker/dockerclient/lifecycle_test.go
+++ b/plugins/sandbox/docker/dockerclient/lifecycle_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"iter"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -98,6 +99,36 @@ func TestCreateAndStartRemovesContainerWhenStartFails(t *testing.T) {
 	}
 }
 
+func TestCreateAndStartRejectsDaemonWarningsAndRemovesContainer(t *testing.T) {
+	var started bool
+	var removedID string
+	api := &lifecycleAPI{
+		createFn: func(context.Context, mobyclient.ContainerCreateOptions) (mobyclient.ContainerCreateResult, error) {
+			return mobyclient.ContainerCreateResult{ID: "warning-container", Warnings: []string{"CPU limitation discarded"}}, nil
+		},
+		startFn: func(context.Context, string) (mobyclient.ContainerStartResult, error) {
+			started = true
+			return mobyclient.ContainerStartResult{}, nil
+		},
+		removeFn: func(_ context.Context, id string, _ mobyclient.ContainerRemoveOptions) (mobyclient.ContainerRemoveResult, error) {
+			removedID = id
+			return mobyclient.ContainerRemoveResult{}, nil
+		},
+	}
+	client := NewWithAPI(api)
+
+	_, err := client.CreateAndStart(context.Background(), CreateOptions{Image: "warning:latest", Name: "test"})
+	if err == nil || !strings.Contains(err.Error(), "CPU limitation discarded") {
+		t.Fatalf("CreateAndStart warning error = %v", err)
+	}
+	if started {
+		t.Fatal("container with daemon warnings was started")
+	}
+	if removedID != "warning-container" {
+		t.Fatalf("removed container = %q, want warning-container", removedID)
+	}
+}
+
 func TestCreateAndStartRemovesContainerWithFreshContextWhenStartCancelsCaller(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -178,6 +209,29 @@ func TestCreateAndStartInvalidatesImageMemoAndRetriesCreateOnNotFound(t *testing
 	}
 	if !client.isImageReady(image) {
 		t.Fatal("image should be memoized ready after retry pull")
+	}
+}
+
+func TestCreateAndStartTypesImageFailureAfterConcurrentPrune(t *testing.T) {
+	const image = "pruned:latest"
+	api := &lifecycleAPI{
+		inspectFn: func(context.Context, string) (mobyclient.ImageInspectResult, error) {
+			return mobyclient.ImageInspectResult{}, errdefs.ErrNotFound
+		},
+		pullFn: func(context.Context, string) (mobyclient.ImagePullResponse, error) {
+			return nil, errors.New("pull unavailable")
+		},
+		createFn: func(context.Context, mobyclient.ContainerCreateOptions) (mobyclient.ContainerCreateResult, error) {
+			return mobyclient.ContainerCreateResult{}, errdefs.ErrNotFound
+		},
+	}
+	client := NewWithAPI(api)
+	client.imageReady[image] = struct{}{}
+
+	_, err := client.CreateAndStart(context.Background(), CreateOptions{Image: image, Name: "test"})
+	var imageErr *ImageUnavailableError
+	if !errors.As(err, &imageErr) {
+		t.Fatalf("CreateAndStart error = %v, want ImageUnavailableError", err)
 	}
 }
 

--- a/plugins/sandbox/docker/dockerclient/runtime_test.go
+++ b/plugins/sandbox/docker/dockerclient/runtime_test.go
@@ -60,6 +60,7 @@ func TestSecurity(t *testing.T) {
 			SecurityOptions: []string{"name=seccomp,profile=builtin", "name=rootless,param=value"},
 			CgroupDriver:    "systemd",
 			MemoryLimit:     true,
+			SwapLimit:       true,
 			CPUCfsPeriod:    true,
 			CPUCfsQuota:     true,
 			PidsLimit:       true,
@@ -70,7 +71,7 @@ func TestSecurity(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !got.Rootless || got.CgroupDriver != "systemd" || !got.MemoryLimit || !got.CPUCfsPeriod || !got.CPUCfsQuota || !got.PidsLimit {
+	if !got.Rootless || got.CgroupDriver != "systemd" || !got.MemoryLimit || !got.SwapLimit || !got.CPUCfsPeriod || !got.CPUCfsQuota || !got.PidsLimit {
 		t.Fatalf("Security = %+v, want rootless systemd", got)
 	}
 }

--- a/plugins/sandbox/docker/dockerclient/runtime_test.go
+++ b/plugins/sandbox/docker/dockerclient/runtime_test.go
@@ -1,0 +1,46 @@
+package dockerclient
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/moby/moby/api/types/system"
+	mobyclient "github.com/moby/moby/client"
+)
+
+type runtimeAPI struct {
+	API
+	result mobyclient.SystemInfoResult
+	err    error
+}
+
+func (f runtimeAPI) Info(context.Context, mobyclient.InfoOptions) (mobyclient.SystemInfoResult, error) {
+	return f.result, f.err
+}
+
+func TestRuntimeAvailable(t *testing.T) {
+	client := NewWithAPI(runtimeAPI{result: mobyclient.SystemInfoResult{
+		Info: system.Info{Runtimes: map[string]system.RuntimeWithStatus{"runc": {}, "runsc": {}}},
+	}})
+
+	for _, tc := range []struct {
+		name string
+		want bool
+	}{{"", true}, {"runsc", true}, {"kata", false}} {
+		got, err := client.RuntimeAvailable(context.Background(), tc.name)
+		if err != nil {
+			t.Fatalf("RuntimeAvailable(%q): %v", tc.name, err)
+		}
+		if got != tc.want {
+			t.Errorf("RuntimeAvailable(%q) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestRuntimeAvailableInfoError(t *testing.T) {
+	client := NewWithAPI(runtimeAPI{err: errors.New("daemon failed")})
+	if _, err := client.RuntimeAvailable(context.Background(), "runsc"); err == nil {
+		t.Fatal("RuntimeAvailable succeeded despite daemon info error")
+	}
+}

--- a/plugins/sandbox/docker/dockerclient/runtime_test.go
+++ b/plugins/sandbox/docker/dockerclient/runtime_test.go
@@ -58,7 +58,6 @@ func TestSecurity(t *testing.T) {
 	client := NewWithAPI(runtimeAPI{result: mobyclient.SystemInfoResult{
 		Info: system.Info{
 			SecurityOptions: []string{"name=seccomp,profile=builtin", "name=rootless,param=value"},
-			CgroupDriver:    "systemd",
 			MemoryLimit:     true,
 			SwapLimit:       true,
 			CPUCfsPeriod:    true,
@@ -71,21 +70,21 @@ func TestSecurity(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !got.Rootless || got.CgroupDriver != "systemd" || !got.MemoryLimit || !got.SwapLimit || !got.CPUCfsPeriod || !got.CPUCfsQuota || !got.PidsLimit {
-		t.Fatalf("Security = %+v, want rootless systemd", got)
+	if !got.Rootless || !got.MemoryLimit || !got.SwapLimit || !got.CPUCfsPeriod || !got.CPUCfsQuota || !got.PidsLimit {
+		t.Fatalf("Security = %+v, want rootless with resource limits", got)
 	}
 }
 
 func TestSecurityRootful(t *testing.T) {
 	client := NewWithAPI(runtimeAPI{result: mobyclient.SystemInfoResult{
-		Info: system.Info{SecurityOptions: []string{"name=seccomp,profile=builtin", "name=userns,mode=remap"}, CgroupDriver: "cgroupfs"},
+		Info: system.Info{SecurityOptions: []string{"name=seccomp,profile=builtin", "name=userns,mode=remap"}},
 	}})
 
 	got, err := client.Security(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Rootless || !got.UserNamespace || got.CgroupDriver != "cgroupfs" {
-		t.Fatalf("Security = %+v, want rootful userns-remap cgroupfs", got)
+	if got.Rootless || !got.UserNamespace {
+		t.Fatalf("Security = %+v, want rootful userns-remap", got)
 	}
 }

--- a/plugins/sandbox/docker/dockerclient/runtime_test.go
+++ b/plugins/sandbox/docker/dockerclient/runtime_test.go
@@ -44,3 +44,34 @@ func TestRuntimeAvailableInfoError(t *testing.T) {
 		t.Fatal("RuntimeAvailable succeeded despite daemon info error")
 	}
 }
+
+func TestSecurity(t *testing.T) {
+	client := NewWithAPI(runtimeAPI{result: mobyclient.SystemInfoResult{
+		Info: system.Info{
+			SecurityOptions: []string{"name=seccomp,profile=builtin", "name=rootless"},
+			CgroupDriver:    "systemd",
+		},
+	}})
+
+	got, err := client.Security(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.Rootless || got.CgroupDriver != "systemd" {
+		t.Fatalf("Security = %+v, want rootless systemd", got)
+	}
+}
+
+func TestSecurityRootful(t *testing.T) {
+	client := NewWithAPI(runtimeAPI{result: mobyclient.SystemInfoResult{
+		Info: system.Info{SecurityOptions: []string{"name=seccomp,profile=builtin"}, CgroupDriver: "cgroupfs"},
+	}})
+
+	got, err := client.Security(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Rootless || got.CgroupDriver != "cgroupfs" {
+		t.Fatalf("Security = %+v, want rootful cgroupfs", got)
+	}
+}

--- a/plugins/sandbox/docker/dockerclient/runtime_test.go
+++ b/plugins/sandbox/docker/dockerclient/runtime_test.go
@@ -19,37 +19,50 @@ func (f runtimeAPI) Info(context.Context, mobyclient.InfoOptions) (mobyclient.Sy
 	return f.result, f.err
 }
 
-func TestRuntimeAvailable(t *testing.T) {
+func TestRuntime(t *testing.T) {
 	client := NewWithAPI(runtimeAPI{result: mobyclient.SystemInfoResult{
-		Info: system.Info{Runtimes: map[string]system.RuntimeWithStatus{"runc": {}, "runsc": {}}},
+		Info: system.Info{DefaultRuntime: "runc", Runtimes: map[string]system.RuntimeWithStatus{
+			"runc":  {},
+			"runsc": {Runtime: system.Runtime{Args: []string{"--platform=systrap"}}},
+		}},
 	}})
 
 	for _, tc := range []struct {
 		name string
 		want bool
 	}{{"", true}, {"runsc", true}, {"kata", false}} {
-		got, err := client.RuntimeAvailable(context.Background(), tc.name)
+		info, got, err := client.Runtime(context.Background(), tc.name)
 		if err != nil {
-			t.Fatalf("RuntimeAvailable(%q): %v", tc.name, err)
+			t.Fatalf("Runtime(%q): %v", tc.name, err)
 		}
 		if got != tc.want {
-			t.Errorf("RuntimeAvailable(%q) = %v, want %v", tc.name, got, tc.want)
+			t.Errorf("Runtime(%q) registered = %v, want %v", tc.name, got, tc.want)
+		}
+		if tc.name == "runsc" && len(info.Args) != 1 {
+			t.Errorf("Runtime(runsc) args = %v", info.Args)
+		}
+		if tc.name == "" && info.Name != "runc" {
+			t.Errorf("Runtime(default) name = %q, want runc", info.Name)
 		}
 	}
 }
 
-func TestRuntimeAvailableInfoError(t *testing.T) {
+func TestRuntimeInfoError(t *testing.T) {
 	client := NewWithAPI(runtimeAPI{err: errors.New("daemon failed")})
-	if _, err := client.RuntimeAvailable(context.Background(), "runsc"); err == nil {
-		t.Fatal("RuntimeAvailable succeeded despite daemon info error")
+	if _, _, err := client.Runtime(context.Background(), "runsc"); err == nil {
+		t.Fatal("Runtime succeeded despite daemon info error")
 	}
 }
 
 func TestSecurity(t *testing.T) {
 	client := NewWithAPI(runtimeAPI{result: mobyclient.SystemInfoResult{
 		Info: system.Info{
-			SecurityOptions: []string{"name=seccomp,profile=builtin", "name=rootless"},
+			SecurityOptions: []string{"name=seccomp,profile=builtin", "name=rootless,param=value"},
 			CgroupDriver:    "systemd",
+			MemoryLimit:     true,
+			CPUCfsPeriod:    true,
+			CPUCfsQuota:     true,
+			PidsLimit:       true,
 		},
 	}})
 
@@ -57,21 +70,21 @@ func TestSecurity(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !got.Rootless || got.CgroupDriver != "systemd" {
+	if !got.Rootless || got.CgroupDriver != "systemd" || !got.MemoryLimit || !got.CPUCfsPeriod || !got.CPUCfsQuota || !got.PidsLimit {
 		t.Fatalf("Security = %+v, want rootless systemd", got)
 	}
 }
 
 func TestSecurityRootful(t *testing.T) {
 	client := NewWithAPI(runtimeAPI{result: mobyclient.SystemInfoResult{
-		Info: system.Info{SecurityOptions: []string{"name=seccomp,profile=builtin"}, CgroupDriver: "cgroupfs"},
+		Info: system.Info{SecurityOptions: []string{"name=seccomp,profile=builtin", "name=userns,mode=remap"}, CgroupDriver: "cgroupfs"},
 	}})
 
 	got, err := client.Security(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Rootless || got.CgroupDriver != "cgroupfs" {
-		t.Fatalf("Security = %+v, want rootful cgroupfs", got)
+	if got.Rootless || !got.UserNamespace || got.CgroupDriver != "cgroupfs" {
+		t.Fatalf("Security = %+v, want rootful userns-remap cgroupfs", got)
 	}
 }

--- a/plugins/sandbox/docker/dood.go
+++ b/plugins/sandbox/docker/dood.go
@@ -10,7 +10,10 @@ import (
 	"github.com/CherryHQ/stella/plugins/sandbox/docker/dockerclient"
 )
 
-const dockerSandboxModeEnv = "STELLA_DOCKER_SANDBOX_MODE"
+const (
+	dockerSandboxModeEnv = "STELLA_DOCKER_SANDBOX_MODE"
+	dockerRuntimeEnv     = "STELLA_DOCKER_RUNTIME"
+)
 
 // defaultSandboxServerPort is stellad's default admin/API port (see cmd/stellad
 // gateway). Auto-detected sandbox URLs target it; override the whole URL with
@@ -24,6 +27,11 @@ var lookupHostname = os.Hostname
 // lookupDockerSandboxMode reads STELLA_DOCKER_SANDBOX_MODE. Overridden in tests.
 var lookupDockerSandboxMode = func() string {
 	return strings.TrimSpace(os.Getenv(dockerSandboxModeEnv))
+}
+
+// lookupDockerRuntime reads STELLA_DOCKER_RUNTIME. Overridden in tests.
+var lookupDockerRuntime = func() string {
+	return strings.TrimSpace(os.Getenv(dockerRuntimeEnv))
 }
 
 // lookupStellaHomeHost reads the STELLA_HOME_HOST env. Overridden in tests.
@@ -164,6 +172,9 @@ func findNetwork(nets []dockerclient.SelfNetwork, name string) *dockerclient.Sel
 // The caller describes the deployment; the backend validates that the mode has
 // exactly the env needed for that mode and no conflicting mode env.
 func applyDockerMode(cfg Config, stellaHome string) (Config, error) {
+	if cfg.Runtime == "" {
+		cfg.Runtime = lookupDockerRuntime()
+	}
 	if cfg.RuntimeMode == "" {
 		cfg.RuntimeMode = DockerSandboxMode(lookupDockerSandboxMode())
 	}

--- a/plugins/sandbox/docker/dood.go
+++ b/plugins/sandbox/docker/dood.go
@@ -10,10 +10,7 @@ import (
 	"github.com/CherryHQ/stella/plugins/sandbox/docker/dockerclient"
 )
 
-const (
-	dockerSandboxModeEnv = "STELLA_DOCKER_SANDBOX_MODE"
-	dockerRuntimeEnv     = "STELLA_DOCKER_RUNTIME"
-)
+const dockerSandboxModeEnv = "STELLA_DOCKER_SANDBOX_MODE"
 
 // defaultSandboxServerPort is stellad's default admin/API port (see cmd/stellad
 // gateway). Auto-detected sandbox URLs target it; override the whole URL with
@@ -23,36 +20,6 @@ const defaultSandboxServerPort = 25678
 // lookupHostname reports the current hostname, which Docker defaults to the
 // short container ID. Overridden in tests.
 var lookupHostname = os.Hostname
-
-// lookupDockerSandboxMode reads STELLA_DOCKER_SANDBOX_MODE. Overridden in tests.
-var lookupDockerSandboxMode = func() string {
-	return strings.TrimSpace(os.Getenv(dockerSandboxModeEnv))
-}
-
-// lookupDockerRuntime reads STELLA_DOCKER_RUNTIME. Overridden in tests.
-var lookupDockerRuntime = func() string {
-	return strings.TrimSpace(os.Getenv(dockerRuntimeEnv))
-}
-
-// lookupStellaHomeHost reads the STELLA_HOME_HOST env. Overridden in tests.
-var lookupStellaHomeHost = func() string {
-	return strings.TrimSpace(os.Getenv("STELLA_HOME_HOST"))
-}
-
-// lookupStellaHomeVolume reads the STELLA_HOME_VOLUME env. Overridden in tests.
-var lookupStellaHomeVolume = func() string {
-	return strings.TrimSpace(os.Getenv("STELLA_HOME_VOLUME"))
-}
-
-// lookupSandboxNetwork reads the STELLA_SANDBOX_NETWORK env. Overridden in tests.
-var lookupSandboxNetwork = func() string {
-	return strings.TrimSpace(os.Getenv("STELLA_SANDBOX_NETWORK"))
-}
-
-// lookupSandboxServerURL reads the STELLA_SANDBOX_SERVER_URL env. Overridden in tests.
-var lookupSandboxServerURL = func() string {
-	return strings.TrimSpace(os.Getenv("STELLA_SANDBOX_SERVER_URL"))
-}
 
 // autodetectServerReachability fills SandboxNetwork/ServerURL by inspecting the
 // container stellad runs in, so DooD sandboxes reach stellad with zero extra
@@ -161,7 +128,8 @@ func findNetwork(nets []dockerclient.SelfNetwork, name string) *dockerclient.Sel
 	return nil
 }
 
-// applyDockerMode fills and validates the explicit docker sandbox runtime mode.
+// resolveDockerConfig fills deployment-owned settings from the environment and
+// validates the Docker home topology.
 //
 // STELLA_DOCKER_SANDBOX_MODE is required when NewFactory receives StellaHome:
 //   - host: stellad runs on the host; stella-process paths are daemon-visible.
@@ -171,24 +139,24 @@ func findNetwork(nets []dockerclient.SelfNetwork, name string) *dockerclient.Sel
 // This intentionally does not inspect /.dockerenv or other runtime markers.
 // The caller describes the deployment; the backend validates that the mode has
 // exactly the env needed for that mode and no conflicting mode env.
-func applyDockerMode(cfg Config, stellaHome string) (Config, error) {
+func resolveDockerConfig(cfg Config, stellaHome string) (Config, error) {
 	if cfg.Runtime == "" {
-		cfg.Runtime = lookupDockerRuntime()
+		cfg.Runtime = strings.TrimSpace(os.Getenv("STELLA_DOCKER_RUNTIME"))
 	}
 	if cfg.RuntimeMode == "" {
-		cfg.RuntimeMode = DockerSandboxMode(lookupDockerSandboxMode())
+		cfg.RuntimeMode = DockerSandboxMode(strings.TrimSpace(os.Getenv("STELLA_DOCKER_SANDBOX_MODE")))
 	}
 	if cfg.StellaHomeVolume == "" {
-		cfg.StellaHomeVolume = lookupStellaHomeVolume()
+		cfg.StellaHomeVolume = strings.TrimSpace(os.Getenv("STELLA_HOME_VOLUME"))
 	}
 	if cfg.SandboxNetwork == "" {
-		cfg.SandboxNetwork = lookupSandboxNetwork()
+		cfg.SandboxNetwork = strings.TrimSpace(os.Getenv("STELLA_SANDBOX_NETWORK"))
 	}
 	if cfg.ServerURL == "" {
-		cfg.ServerURL = lookupSandboxServerURL()
+		cfg.ServerURL = strings.TrimSpace(os.Getenv("STELLA_SANDBOX_SERVER_URL"))
 	}
 	if cfg.ContainerPathPrefix == "" && cfg.HostPathPrefix == "" {
-		if hostPath := lookupStellaHomeHost(); hostPath != "" {
+		if hostPath := strings.TrimSpace(os.Getenv("STELLA_HOME_HOST")); hostPath != "" {
 			cfg.ContainerPathPrefix = stellaHome
 			cfg.HostPathPrefix = hostPath
 		}

--- a/plugins/sandbox/docker/dood_test.go
+++ b/plugins/sandbox/docker/dood_test.go
@@ -7,27 +7,17 @@ import (
 
 func withDockerModeEnv(t *testing.T, mode, stellaHomeHost, stellaHomeVolume string) {
 	t.Helper()
-	prevMode := lookupDockerSandboxMode
-	prevRuntime := lookupDockerRuntime
-	prevHost := lookupStellaHomeHost
-	prevVolume := lookupStellaHomeVolume
-	lookupDockerSandboxMode = func() string { return mode }
-	lookupDockerRuntime = func() string { return "" }
-	lookupStellaHomeHost = func() string { return stellaHomeHost }
-	lookupStellaHomeVolume = func() string { return stellaHomeVolume }
-	t.Cleanup(func() {
-		lookupDockerSandboxMode = prevMode
-		lookupDockerRuntime = prevRuntime
-		lookupStellaHomeHost = prevHost
-		lookupStellaHomeVolume = prevVolume
-	})
+	t.Setenv(dockerSandboxModeEnv, mode)
+	t.Setenv("STELLA_DOCKER_RUNTIME", "")
+	t.Setenv("STELLA_HOME_HOST", stellaHomeHost)
+	t.Setenv("STELLA_HOME_VOLUME", stellaHomeVolume)
 }
 
-func TestApplyDockerMode_Runtime(t *testing.T) {
+func TestResolveDockerConfig_Runtime(t *testing.T) {
 	withDockerModeEnv(t, "host", "", "")
-	lookupDockerRuntime = func() string { return "runsc" }
+	t.Setenv("STELLA_DOCKER_RUNTIME", "runsc")
 
-	out, err := applyDockerMode(Config{}, "/Users/v/.stella")
+	out, err := resolveDockerConfig(Config{}, "/Users/v/.stella")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -35,7 +25,7 @@ func TestApplyDockerMode_Runtime(t *testing.T) {
 		t.Fatalf("Runtime = %q, want runsc", out.Runtime)
 	}
 
-	out, err = applyDockerMode(Config{Runtime: "kata"}, "/Users/v/.stella")
+	out, err = resolveDockerConfig(Config{Runtime: "kata"}, "/Users/v/.stella")
 	if err != nil {
 		t.Fatalf("unexpected explicit runtime error: %v", err)
 	}
@@ -44,9 +34,9 @@ func TestApplyDockerMode_Runtime(t *testing.T) {
 	}
 }
 
-func TestApplyDockerMode_Host(t *testing.T) {
+func TestResolveDockerConfig_Host(t *testing.T) {
 	withDockerModeEnv(t, "host", "", "")
-	out, err := applyDockerMode(Config{}, "/Users/v/.stella")
+	out, err := resolveDockerConfig(Config{}, "/Users/v/.stella")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -58,9 +48,9 @@ func TestApplyDockerMode_Host(t *testing.T) {
 	}
 }
 
-func TestApplyDockerMode_HostRejectsModeSpecificEnv(t *testing.T) {
+func TestResolveDockerConfig_HostRejectsModeSpecificEnv(t *testing.T) {
 	withDockerModeEnv(t, "host", "/host/stella", "")
-	_, err := applyDockerMode(Config{}, "/home/nonroot/.stella")
+	_, err := resolveDockerConfig(Config{}, "/home/nonroot/.stella")
 	if err == nil {
 		t.Fatal("expected error when host mode sets STELLA_HOME_HOST")
 	}
@@ -69,9 +59,9 @@ func TestApplyDockerMode_HostRejectsModeSpecificEnv(t *testing.T) {
 	}
 }
 
-func TestApplyDockerMode_ExplicitModeWins(t *testing.T) {
+func TestResolveDockerConfig_ExplicitModeWins(t *testing.T) {
 	withDockerModeEnv(t, "volume", "", "")
-	out, err := applyDockerMode(Config{RuntimeMode: DockerSandboxModeHost}, "/Users/v/.stella")
+	out, err := resolveDockerConfig(Config{RuntimeMode: DockerSandboxModeHost}, "/Users/v/.stella")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -80,9 +70,9 @@ func TestApplyDockerMode_ExplicitModeWins(t *testing.T) {
 	}
 }
 
-func TestApplyDockerMode_BindUsesStellaHomeHost(t *testing.T) {
+func TestResolveDockerConfig_BindUsesStellaHomeHost(t *testing.T) {
 	withDockerModeEnv(t, "bind", "/Users/v/.stella-dev", "")
-	out, err := applyDockerMode(Config{}, "/home/nonroot/.stella")
+	out, err := resolveDockerConfig(Config{}, "/home/nonroot/.stella")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -97,13 +87,13 @@ func TestApplyDockerMode_BindUsesStellaHomeHost(t *testing.T) {
 	}
 }
 
-func TestApplyDockerMode_BindPreservesExplicitPrefixes(t *testing.T) {
+func TestResolveDockerConfig_BindPreservesExplicitPrefixes(t *testing.T) {
 	withDockerModeEnv(t, "bind", "/env/host", "")
 	in := Config{
 		ContainerPathPrefix: "/explicit/container",
 		HostPathPrefix:      "/explicit/host",
 	}
-	out, err := applyDockerMode(in, "/home/nonroot/.stella")
+	out, err := resolveDockerConfig(in, "/home/nonroot/.stella")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -112,9 +102,9 @@ func TestApplyDockerMode_BindPreservesExplicitPrefixes(t *testing.T) {
 	}
 }
 
-func TestApplyDockerMode_BindRequiresHostPath(t *testing.T) {
+func TestResolveDockerConfig_BindRequiresHostPath(t *testing.T) {
 	withDockerModeEnv(t, "bind", "", "")
-	_, err := applyDockerMode(Config{}, "/home/nonroot/.stella")
+	_, err := resolveDockerConfig(Config{}, "/home/nonroot/.stella")
 	if err == nil {
 		t.Fatal("expected error when bind mode has no STELLA_HOME_HOST")
 	}
@@ -123,9 +113,9 @@ func TestApplyDockerMode_BindRequiresHostPath(t *testing.T) {
 	}
 }
 
-func TestApplyDockerMode_BindRejectsVolume(t *testing.T) {
+func TestResolveDockerConfig_BindRejectsVolume(t *testing.T) {
 	withDockerModeEnv(t, "bind", "/host/stella", "stella-data")
-	_, err := applyDockerMode(Config{}, "/home/nonroot/.stella")
+	_, err := resolveDockerConfig(Config{}, "/home/nonroot/.stella")
 	if err == nil {
 		t.Fatal("expected error when bind mode also sets STELLA_HOME_VOLUME")
 	}
@@ -134,9 +124,9 @@ func TestApplyDockerMode_BindRejectsVolume(t *testing.T) {
 	}
 }
 
-func TestApplyDockerMode_VolumeUsesStellaHomeVolume(t *testing.T) {
+func TestResolveDockerConfig_VolumeUsesStellaHomeVolume(t *testing.T) {
 	withDockerModeEnv(t, "volume", "", "stella-data")
-	out, err := applyDockerMode(Config{}, "/home/nonroot/.stella")
+	out, err := resolveDockerConfig(Config{}, "/home/nonroot/.stella")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -148,9 +138,9 @@ func TestApplyDockerMode_VolumeUsesStellaHomeVolume(t *testing.T) {
 	}
 }
 
-func TestApplyDockerMode_VolumePreservesExplicitVolume(t *testing.T) {
+func TestResolveDockerConfig_VolumePreservesExplicitVolume(t *testing.T) {
 	withDockerModeEnv(t, "volume", "", "env-volume")
-	out, err := applyDockerMode(Config{StellaHomeVolume: "explicit-volume"}, "/home/nonroot/.stella")
+	out, err := resolveDockerConfig(Config{StellaHomeVolume: "explicit-volume"}, "/home/nonroot/.stella")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -159,9 +149,9 @@ func TestApplyDockerMode_VolumePreservesExplicitVolume(t *testing.T) {
 	}
 }
 
-func TestApplyDockerMode_VolumeRequiresVolume(t *testing.T) {
+func TestResolveDockerConfig_VolumeRequiresVolume(t *testing.T) {
 	withDockerModeEnv(t, "volume", "", "")
-	_, err := applyDockerMode(Config{}, "/home/nonroot/.stella")
+	_, err := resolveDockerConfig(Config{}, "/home/nonroot/.stella")
 	if err == nil {
 		t.Fatal("expected error when volume mode has no STELLA_HOME_VOLUME")
 	}
@@ -170,9 +160,9 @@ func TestApplyDockerMode_VolumeRequiresVolume(t *testing.T) {
 	}
 }
 
-func TestApplyDockerMode_VolumeRejectsHostPath(t *testing.T) {
+func TestResolveDockerConfig_VolumeRejectsHostPath(t *testing.T) {
 	withDockerModeEnv(t, "volume", "/host/stella", "stella-data")
-	_, err := applyDockerMode(Config{}, "/home/nonroot/.stella")
+	_, err := resolveDockerConfig(Config{}, "/home/nonroot/.stella")
 	if err == nil {
 		t.Fatal("expected error when volume mode also sets STELLA_HOME_HOST")
 	}
@@ -181,9 +171,9 @@ func TestApplyDockerMode_VolumeRejectsHostPath(t *testing.T) {
 	}
 }
 
-func TestApplyDockerMode_MissingModeErrors(t *testing.T) {
+func TestResolveDockerConfig_MissingModeErrors(t *testing.T) {
 	withDockerModeEnv(t, "", "", "")
-	_, err := applyDockerMode(Config{}, "/home/nonroot/.stella")
+	_, err := resolveDockerConfig(Config{}, "/home/nonroot/.stella")
 	if err == nil {
 		t.Fatal("expected error when STELLA_DOCKER_SANDBOX_MODE is unset")
 	}
@@ -192,9 +182,9 @@ func TestApplyDockerMode_MissingModeErrors(t *testing.T) {
 	}
 }
 
-func TestApplyDockerMode_InvalidModeErrors(t *testing.T) {
+func TestResolveDockerConfig_InvalidModeErrors(t *testing.T) {
 	withDockerModeEnv(t, "container", "", "")
-	_, err := applyDockerMode(Config{}, "/home/nonroot/.stella")
+	_, err := resolveDockerConfig(Config{}, "/home/nonroot/.stella")
 	if err == nil {
 		t.Fatal("expected error for invalid mode")
 	}

--- a/plugins/sandbox/docker/dood_test.go
+++ b/plugins/sandbox/docker/dood_test.go
@@ -8,16 +8,40 @@ import (
 func withDockerModeEnv(t *testing.T, mode, stellaHomeHost, stellaHomeVolume string) {
 	t.Helper()
 	prevMode := lookupDockerSandboxMode
+	prevRuntime := lookupDockerRuntime
 	prevHost := lookupStellaHomeHost
 	prevVolume := lookupStellaHomeVolume
 	lookupDockerSandboxMode = func() string { return mode }
+	lookupDockerRuntime = func() string { return "" }
 	lookupStellaHomeHost = func() string { return stellaHomeHost }
 	lookupStellaHomeVolume = func() string { return stellaHomeVolume }
 	t.Cleanup(func() {
 		lookupDockerSandboxMode = prevMode
+		lookupDockerRuntime = prevRuntime
 		lookupStellaHomeHost = prevHost
 		lookupStellaHomeVolume = prevVolume
 	})
+}
+
+func TestApplyDockerMode_Runtime(t *testing.T) {
+	withDockerModeEnv(t, "host", "", "")
+	lookupDockerRuntime = func() string { return "runsc" }
+
+	out, err := applyDockerMode(Config{}, "/Users/v/.stella")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Runtime != "runsc" {
+		t.Fatalf("Runtime = %q, want runsc", out.Runtime)
+	}
+
+	out, err = applyDockerMode(Config{Runtime: "kata"}, "/Users/v/.stella")
+	if err != nil {
+		t.Fatalf("unexpected explicit runtime error: %v", err)
+	}
+	if out.Runtime != "kata" {
+		t.Fatalf("explicit Runtime = %q, want kata", out.Runtime)
+	}
 }
 
 func TestApplyDockerMode_Host(t *testing.T) {

--- a/plugins/sandbox/docker/preflight.go
+++ b/plugins/sandbox/docker/preflight.go
@@ -10,6 +10,15 @@ import (
 
 const builtinBundleRevisionLabel = "org.cherryhq.stella.builtin-bundle-revision"
 
+// ImageUnavailableError identifies image preparation failures so callers can
+// attach image-specific recovery without mislabeling runtime or daemon errors.
+type ImageUnavailableError struct {
+	Err error
+}
+
+func (e *ImageUnavailableError) Error() string { return e.Err.Error() }
+func (e *ImageUnavailableError) Unwrap() error { return e.Err }
+
 // PreflightConfig configures a Preflight check.
 type PreflightConfig struct {
 	StellaHome string
@@ -57,6 +66,13 @@ func preflightWithClient(ctx context.Context, cfg PreflightConfig, client *docke
 	if _, err := client.Version(ctx); err != nil {
 		return fmt.Errorf("docker preflight: daemon not reachable: %w", err)
 	}
+	security, err := client.Security(ctx)
+	if err != nil {
+		return fmt.Errorf("docker preflight: inspect daemon security: %w", err)
+	}
+	if security.Rootless && security.CgroupDriver == "none" {
+		return fmt.Errorf("docker preflight: rootless daemon has no cgroup driver; Stella cannot enforce sandbox CPU, memory, or PID limits")
+	}
 	if runtime := cfg.Docker.Runtime; runtime != "" {
 		available, err := client.RuntimeAvailable(ctx, runtime)
 		if err != nil {
@@ -68,7 +84,7 @@ func preflightWithClient(ctx context.Context, cfg PreflightConfig, client *docke
 	}
 
 	if err := client.EnsureImageReady(ctx, cfg.Docker.Image, "preflight"); err != nil {
-		return fmt.Errorf("docker preflight: %w", err)
+		return fmt.Errorf("docker preflight: %w", &ImageUnavailableError{Err: err})
 	}
 	if expected := cfg.Docker.ExpectedBundleRevision; expected != "" {
 		actual, err := client.ImageLabel(ctx, cfg.Docker.Image, builtinBundleRevisionLabel)

--- a/plugins/sandbox/docker/preflight.go
+++ b/plugins/sandbox/docker/preflight.go
@@ -109,6 +109,9 @@ func unsupportedResourceLimits(security dockerclient.DaemonSecurity) []string {
 	if !security.MemoryLimit {
 		unsupported = append(unsupported, "memory")
 	}
+	if !security.SwapLimit {
+		unsupported = append(unsupported, "swap")
+	}
 	if !security.CPUCfsPeriod || !security.CPUCfsQuota {
 		unsupported = append(unsupported, "CPU quota")
 	}
@@ -121,10 +124,14 @@ func unsupportedResourceLimits(security dockerclient.DaemonSecurity) []string {
 func unsafeRuntimeResourceArg(args []string) (string, bool) {
 	for _, arg := range args {
 		trimmed := strings.TrimSpace(arg)
-		if trimmed == "--ignore-cgroups" {
+		if !strings.HasPrefix(trimmed, "-") {
+			continue
+		}
+		flag := strings.TrimLeft(trimmed, "-")
+		if flag == "ignore-cgroups" {
 			return arg, true
 		}
-		value, found := strings.CutPrefix(trimmed, "--ignore-cgroups=")
+		value, found := strings.CutPrefix(flag, "ignore-cgroups=")
 		if !found {
 			continue
 		}

--- a/plugins/sandbox/docker/preflight.go
+++ b/plugins/sandbox/docker/preflight.go
@@ -57,6 +57,15 @@ func preflightWithClient(ctx context.Context, cfg PreflightConfig, client *docke
 	if _, err := client.Version(ctx); err != nil {
 		return fmt.Errorf("docker preflight: daemon not reachable: %w", err)
 	}
+	if runtime := cfg.Docker.Runtime; runtime != "" {
+		available, err := client.RuntimeAvailable(ctx, runtime)
+		if err != nil {
+			return fmt.Errorf("docker preflight: inspect runtime %q: %w", runtime, err)
+		}
+		if !available {
+			return fmt.Errorf("docker preflight: runtime %q from %s is not registered with the Docker daemon", runtime, dockerRuntimeEnv)
+		}
+	}
 
 	if err := client.EnsureImageReady(ctx, cfg.Docker.Image, "preflight"); err != nil {
 		return fmt.Errorf("docker preflight: %w", err)

--- a/plugins/sandbox/docker/preflight.go
+++ b/plugins/sandbox/docker/preflight.go
@@ -3,6 +3,8 @@ package docker
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/CherryHQ/stella/plugins/sandbox/docker/dockerclient"
@@ -10,14 +12,9 @@ import (
 
 const builtinBundleRevisionLabel = "org.cherryhq.stella.builtin-bundle-revision"
 
-// ImageUnavailableError identifies image preparation failures so callers can
-// attach image-specific recovery without mislabeling runtime or daemon errors.
-type ImageUnavailableError struct {
-	Err error
-}
-
-func (e *ImageUnavailableError) Error() string { return e.Err.Error() }
-func (e *ImageUnavailableError) Unwrap() error { return e.Err }
+// ImageUnavailableError is exposed at the plugin boundary so callers do not
+// need to depend on the Docker client implementation package.
+type ImageUnavailableError = dockerclient.ImageUnavailableError
 
 // PreflightConfig configures a Preflight check.
 type PreflightConfig struct {
@@ -70,17 +67,25 @@ func preflightWithClient(ctx context.Context, cfg PreflightConfig, client *docke
 	if err != nil {
 		return fmt.Errorf("docker preflight: inspect daemon security: %w", err)
 	}
-	if security.Rootless && security.CgroupDriver == "none" {
-		return fmt.Errorf("docker preflight: rootless daemon has no cgroup driver; Stella cannot enforce sandbox CPU, memory, or PID limits")
+	if security.UserNamespace {
+		return fmt.Errorf("docker preflight: Docker userns-remap is unsupported because Stella cannot map writable sandbox mounts safely")
 	}
-	if runtime := cfg.Docker.Runtime; runtime != "" {
-		available, err := client.RuntimeAvailable(ctx, runtime)
-		if err != nil {
-			return fmt.Errorf("docker preflight: inspect runtime %q: %w", runtime, err)
+	unsupported := unsupportedResourceLimits(security)
+	if len(unsupported) > 0 {
+		return fmt.Errorf("docker preflight: Docker daemon cannot enforce required sandbox resource limits: %s", strings.Join(unsupported, ", "))
+	}
+	runtimeInfo, available, err := client.Runtime(ctx, cfg.Docker.Runtime)
+	if err != nil {
+		return fmt.Errorf("docker preflight: inspect runtime %q: %w", cfg.Docker.Runtime, err)
+	}
+	if !available {
+		if runtime := cfg.Docker.Runtime; runtime != "" {
+			return fmt.Errorf("docker preflight: runtime %q is not registered with the Docker daemon", runtime)
 		}
-		if !available {
-			return fmt.Errorf("docker preflight: runtime %q from %s is not registered with the Docker daemon", runtime, dockerRuntimeEnv)
-		}
+		return fmt.Errorf("docker preflight: Docker daemon did not report its default OCI runtime")
+	}
+	if arg, unsafe := unsafeRuntimeResourceArg(runtimeInfo.Args); unsafe {
+		return fmt.Errorf("docker preflight: runtime %q uses %q, which disables Stella sandbox resource limits", runtimeInfo.Name, arg)
 	}
 
 	if err := client.EnsureImageReady(ctx, cfg.Docker.Image, "preflight"); err != nil {
@@ -97,4 +102,36 @@ func preflightWithClient(ctx context.Context, cfg PreflightConfig, client *docke
 	}
 
 	return nil
+}
+
+func unsupportedResourceLimits(security dockerclient.DaemonSecurity) []string {
+	var unsupported []string
+	if !security.MemoryLimit {
+		unsupported = append(unsupported, "memory")
+	}
+	if !security.CPUCfsPeriod || !security.CPUCfsQuota {
+		unsupported = append(unsupported, "CPU quota")
+	}
+	if !security.PidsLimit {
+		unsupported = append(unsupported, "PID")
+	}
+	return unsupported
+}
+
+func unsafeRuntimeResourceArg(args []string) (string, bool) {
+	for _, arg := range args {
+		trimmed := strings.TrimSpace(arg)
+		if trimmed == "--ignore-cgroups" {
+			return arg, true
+		}
+		value, found := strings.CutPrefix(trimmed, "--ignore-cgroups=")
+		if !found {
+			continue
+		}
+		enabled, err := strconv.ParseBool(value)
+		if err != nil || enabled {
+			return arg, true
+		}
+	}
+	return "", false
 }

--- a/plugins/sandbox/docker/preflight_test.go
+++ b/plugins/sandbox/docker/preflight_test.go
@@ -158,6 +158,22 @@ func TestPreflightRuntime(t *testing.T) {
 	})
 }
 
+func TestPreflightRejectsRootlessDaemonWithoutCgroups(t *testing.T) {
+	api := &fakePreflightAPI{
+		infoFn: func() (mobyclient.SystemInfoResult, error) {
+			return mobyclient.SystemInfoResult{Info: system.Info{
+				SecurityOptions: []string{"name=rootless"},
+				CgroupDriver:    "none",
+			}}, nil
+		},
+	}
+	client := dockerclient.NewWithAPI(api)
+	err := preflightWithClient(context.Background(), PreflightConfig{Docker: Config{Image: "sandbox:test"}}, client)
+	if err == nil || !strings.Contains(err.Error(), "cannot enforce sandbox CPU, memory, or PID limits") {
+		t.Fatalf("rootless daemon without cgroups error = %v", err)
+	}
+}
+
 func TestPreflightRejectsBuiltinBundleRevisionMismatch(t *testing.T) {
 	api := &fakePreflightAPI{inspectFn: func(string) (mobyclient.ImageInspectResult, error) { return mobyclient.ImageInspectResult{}, nil }}
 	client := dockerclient.NewWithAPI(api)

--- a/plugins/sandbox/docker/preflight_test.go
+++ b/plugins/sandbox/docker/preflight_test.go
@@ -207,7 +207,6 @@ func TestPreflightResourceLimits(t *testing.T) {
 			infoFn: func() (mobyclient.SystemInfoResult, error) {
 				info := supportedSystemInfo()
 				info.Info.SecurityOptions = []string{"name=rootless,param=value"}
-				info.Info.CgroupDriver = "systemd"
 				return info, nil
 			},
 			inspectFn: func(string) (mobyclient.ImageInspectResult, error) {
@@ -225,7 +224,6 @@ func TestPreflightResourceLimits(t *testing.T) {
 			infoFn: func() (mobyclient.SystemInfoResult, error) {
 				return mobyclient.SystemInfoResult{Info: system.Info{
 					SecurityOptions: []string{"name=rootless"},
-					CgroupDriver:    "none",
 					MemoryLimit:     true,
 				}}, nil
 			},

--- a/plugins/sandbox/docker/preflight_test.go
+++ b/plugins/sandbox/docker/preflight_test.go
@@ -38,6 +38,7 @@ func (f *fakePreflightAPI) Info(context.Context, mobyclient.InfoOptions) (mobycl
 func supportedSystemInfo() mobyclient.SystemInfoResult {
 	return mobyclient.SystemInfoResult{Info: system.Info{
 		MemoryLimit:    true,
+		SwapLimit:      true,
 		CPUCfsPeriod:   true,
 		CPUCfsQuota:    true,
 		PidsLimit:      true,
@@ -231,7 +232,7 @@ func TestPreflightResourceLimits(t *testing.T) {
 		}
 		client := dockerclient.NewWithAPI(api)
 		err := preflightWithClient(context.Background(), PreflightConfig{Docker: Config{Image: "sandbox:test"}}, client)
-		if err == nil || !strings.Contains(err.Error(), "CPU quota, PID") {
+		if err == nil || !strings.Contains(err.Error(), "swap, CPU quota, PID") {
 			t.Fatalf("rootless daemon without cgroups error = %v", err)
 		}
 	})
@@ -259,8 +260,11 @@ func TestUnsafeRuntimeResourceArg(t *testing.T) {
 		{args: []string{"--ignore-cgroups=TRUE"}, unsafe: true},
 		{args: []string{"--ignore-cgroups=1"}, unsafe: true},
 		{args: []string{"--ignore-cgroups=t"}, unsafe: true},
+		{args: []string{"-ignore-cgroups"}, unsafe: true},
+		{args: []string{"-ignore-cgroups=true"}, unsafe: true},
 		{args: []string{"--ignore-cgroups=maybe"}, unsafe: true},
 		{args: []string{"--ignore-cgroups=false"}, unsafe: false},
+		{args: []string{"-ignore-cgroups=0"}, unsafe: false},
 		{args: []string{"--platform=systrap"}, unsafe: false},
 	} {
 		_, got := unsafeRuntimeResourceArg(tc.args)

--- a/plugins/sandbox/docker/preflight_test.go
+++ b/plugins/sandbox/docker/preflight_test.go
@@ -30,9 +30,20 @@ type fakePreflightAPI struct {
 
 func (f *fakePreflightAPI) Info(context.Context, mobyclient.InfoOptions) (mobyclient.SystemInfoResult, error) {
 	if f.infoFn == nil {
-		return mobyclient.SystemInfoResult{}, nil
+		return supportedSystemInfo(), nil
 	}
 	return f.infoFn()
+}
+
+func supportedSystemInfo() mobyclient.SystemInfoResult {
+	return mobyclient.SystemInfoResult{Info: system.Info{
+		MemoryLimit:    true,
+		CPUCfsPeriod:   true,
+		CPUCfsQuota:    true,
+		PidsLimit:      true,
+		DefaultRuntime: "runc",
+		Runtimes:       map[string]system.RuntimeWithStatus{"runc": {}},
+	}}
 }
 
 func (f *fakePreflightAPI) ServerVersion(context.Context, mobyclient.ServerVersionOptions) (mobyclient.ServerVersionResult, error) {
@@ -134,7 +145,9 @@ func TestPreflightRuntime(t *testing.T) {
 	t.Run("registered", func(t *testing.T) {
 		api := &fakePreflightAPI{
 			infoFn: func() (mobyclient.SystemInfoResult, error) {
-				return mobyclient.SystemInfoResult{Info: system.Info{Runtimes: map[string]system.RuntimeWithStatus{"runsc": {}}}}, nil
+				info := supportedSystemInfo()
+				info.Info.Runtimes = map[string]system.RuntimeWithStatus{"runsc": {}}
+				return info, nil
 			},
 			inspectFn: func(string) (mobyclient.ImageInspectResult, error) {
 				return mobyclient.ImageInspectResult{}, nil
@@ -152,25 +165,108 @@ func TestPreflightRuntime(t *testing.T) {
 		client := dockerclient.NewWithAPI(api)
 		cfg := PreflightConfig{Docker: Config{Image: "sandbox:test", Runtime: "runsc"}}
 		err := preflightWithClient(context.Background(), cfg, client)
-		if err == nil || !strings.Contains(err.Error(), `runtime "runsc"`) || !strings.Contains(err.Error(), dockerRuntimeEnv) {
+		if err == nil || !strings.Contains(err.Error(), `runtime "runsc"`) {
 			t.Fatalf("missing runtime error = %v", err)
+		}
+	})
+
+	t.Run("runtime disabling cgroups fails closed", func(t *testing.T) {
+		api := &fakePreflightAPI{infoFn: func() (mobyclient.SystemInfoResult, error) {
+			info := supportedSystemInfo()
+			info.Info.Runtimes = map[string]system.RuntimeWithStatus{
+				"runsc": {Runtime: system.Runtime{Args: []string{"--ignore-cgroups"}}},
+			}
+			return info, nil
+		}}
+		client := dockerclient.NewWithAPI(api)
+		err := preflightWithClient(context.Background(), PreflightConfig{Docker: Config{Image: "sandbox:test", Runtime: "runsc"}}, client)
+		if err == nil || !strings.Contains(err.Error(), "disables Stella sandbox resource limits") {
+			t.Fatalf("unsafe runtime error = %v", err)
+		}
+	})
+
+	t.Run("default runtime disabling cgroups fails closed", func(t *testing.T) {
+		api := &fakePreflightAPI{infoFn: func() (mobyclient.SystemInfoResult, error) {
+			info := supportedSystemInfo()
+			info.Info.DefaultRuntime = "runsc"
+			info.Info.Runtimes["runsc"] = system.RuntimeWithStatus{Runtime: system.Runtime{Args: []string{"--ignore-cgroups=1"}}}
+			return info, nil
+		}}
+		client := dockerclient.NewWithAPI(api)
+		err := preflightWithClient(context.Background(), PreflightConfig{Docker: Config{Image: "sandbox:test"}}, client)
+		if err == nil || !strings.Contains(err.Error(), `runtime "runsc"`) || !strings.Contains(err.Error(), "disables Stella sandbox resource limits") {
+			t.Fatalf("unsafe default runtime error = %v", err)
 		}
 	})
 }
 
-func TestPreflightRejectsRootlessDaemonWithoutCgroups(t *testing.T) {
-	api := &fakePreflightAPI{
-		infoFn: func() (mobyclient.SystemInfoResult, error) {
-			return mobyclient.SystemInfoResult{Info: system.Info{
-				SecurityOptions: []string{"name=rootless"},
-				CgroupDriver:    "none",
-			}}, nil
-		},
-	}
-	client := dockerclient.NewWithAPI(api)
-	err := preflightWithClient(context.Background(), PreflightConfig{Docker: Config{Image: "sandbox:test"}}, client)
-	if err == nil || !strings.Contains(err.Error(), "cannot enforce sandbox CPU, memory, or PID limits") {
-		t.Fatalf("rootless daemon without cgroups error = %v", err)
+func TestPreflightResourceLimits(t *testing.T) {
+	t.Run("rootless with all limits passes", func(t *testing.T) {
+		api := &fakePreflightAPI{
+			infoFn: func() (mobyclient.SystemInfoResult, error) {
+				info := supportedSystemInfo()
+				info.Info.SecurityOptions = []string{"name=rootless,param=value"}
+				info.Info.CgroupDriver = "systemd"
+				return info, nil
+			},
+			inspectFn: func(string) (mobyclient.ImageInspectResult, error) {
+				return mobyclient.ImageInspectResult{}, nil
+			},
+		}
+		client := dockerclient.NewWithAPI(api)
+		if err := preflightWithClient(context.Background(), PreflightConfig{Docker: Config{Image: "sandbox:test"}}, client); err != nil {
+			t.Fatalf("supported rootless daemon rejected: %v", err)
+		}
+	})
+
+	t.Run("missing limits fail closed", func(t *testing.T) {
+		api := &fakePreflightAPI{
+			infoFn: func() (mobyclient.SystemInfoResult, error) {
+				return mobyclient.SystemInfoResult{Info: system.Info{
+					SecurityOptions: []string{"name=rootless"},
+					CgroupDriver:    "none",
+					MemoryLimit:     true,
+				}}, nil
+			},
+		}
+		client := dockerclient.NewWithAPI(api)
+		err := preflightWithClient(context.Background(), PreflightConfig{Docker: Config{Image: "sandbox:test"}}, client)
+		if err == nil || !strings.Contains(err.Error(), "CPU quota, PID") {
+			t.Fatalf("rootless daemon without cgroups error = %v", err)
+		}
+	})
+
+	t.Run("userns remap fails closed", func(t *testing.T) {
+		api := &fakePreflightAPI{infoFn: func() (mobyclient.SystemInfoResult, error) {
+			info := supportedSystemInfo()
+			info.Info.SecurityOptions = []string{"name=userns"}
+			return info, nil
+		}}
+		client := dockerclient.NewWithAPI(api)
+		err := preflightWithClient(context.Background(), PreflightConfig{Docker: Config{Image: "sandbox:test"}}, client)
+		if err == nil || !strings.Contains(err.Error(), "userns-remap is unsupported") {
+			t.Fatalf("userns-remap error = %v", err)
+		}
+	})
+}
+
+func TestUnsafeRuntimeResourceArg(t *testing.T) {
+	for _, tc := range []struct {
+		args   []string
+		unsafe bool
+	}{
+		{args: []string{"--ignore-cgroups"}, unsafe: true},
+		{args: []string{"--ignore-cgroups=TRUE"}, unsafe: true},
+		{args: []string{"--ignore-cgroups=1"}, unsafe: true},
+		{args: []string{"--ignore-cgroups=t"}, unsafe: true},
+		{args: []string{"--ignore-cgroups=maybe"}, unsafe: true},
+		{args: []string{"--ignore-cgroups=false"}, unsafe: false},
+		{args: []string{"--platform=systrap"}, unsafe: false},
+	} {
+		_, got := unsafeRuntimeResourceArg(tc.args)
+		if got != tc.unsafe {
+			t.Errorf("unsafeRuntimeResourceArg(%v) = %v, want %v", tc.args, got, tc.unsafe)
+		}
 	}
 }
 

--- a/plugins/sandbox/docker/preflight_test.go
+++ b/plugins/sandbox/docker/preflight_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/containerd/errdefs"
 	jsonstream "github.com/moby/moby/api/types/jsonstream"
+	"github.com/moby/moby/api/types/system"
 	mobyclient "github.com/moby/moby/client"
 
 	"github.com/CherryHQ/stella/plugins/sandbox/docker/dockerclient"
@@ -22,8 +23,16 @@ type fakePreflightAPI struct {
 	noopAPI
 
 	versionFn func() (mobyclient.ServerVersionResult, error)
+	infoFn    func() (mobyclient.SystemInfoResult, error)
 	inspectFn func(image string) (mobyclient.ImageInspectResult, error)
 	pullFn    func(image string) (mobyclient.ImagePullResponse, error)
+}
+
+func (f *fakePreflightAPI) Info(context.Context, mobyclient.InfoOptions) (mobyclient.SystemInfoResult, error) {
+	if f.infoFn == nil {
+		return mobyclient.SystemInfoResult{}, nil
+	}
+	return f.infoFn()
 }
 
 func (f *fakePreflightAPI) ServerVersion(context.Context, mobyclient.ServerVersionOptions) (mobyclient.ServerVersionResult, error) {
@@ -119,6 +128,34 @@ func TestPreflightDaemonUnreachable(t *testing.T) {
 	if !strings.Contains(err.Error(), "daemon not reachable") {
 		t.Errorf("expected 'daemon not reachable' in error, got: %v", err)
 	}
+}
+
+func TestPreflightRuntime(t *testing.T) {
+	t.Run("registered", func(t *testing.T) {
+		api := &fakePreflightAPI{
+			infoFn: func() (mobyclient.SystemInfoResult, error) {
+				return mobyclient.SystemInfoResult{Info: system.Info{Runtimes: map[string]system.RuntimeWithStatus{"runsc": {}}}}, nil
+			},
+			inspectFn: func(string) (mobyclient.ImageInspectResult, error) {
+				return mobyclient.ImageInspectResult{}, nil
+			},
+		}
+		client := dockerclient.NewWithAPI(api)
+		cfg := PreflightConfig{Docker: Config{Image: "sandbox:test", Runtime: "runsc"}}
+		if err := preflightWithClient(context.Background(), cfg, client); err != nil {
+			t.Fatalf("registered runtime rejected: %v", err)
+		}
+	})
+
+	t.Run("missing fails closed", func(t *testing.T) {
+		api := &fakePreflightAPI{}
+		client := dockerclient.NewWithAPI(api)
+		cfg := PreflightConfig{Docker: Config{Image: "sandbox:test", Runtime: "runsc"}}
+		err := preflightWithClient(context.Background(), cfg, client)
+		if err == nil || !strings.Contains(err.Error(), `runtime "runsc"`) || !strings.Contains(err.Error(), dockerRuntimeEnv) {
+			t.Fatalf("missing runtime error = %v", err)
+		}
+	})
 }
 
 func TestPreflightRejectsBuiltinBundleRevisionMismatch(t *testing.T) {

--- a/plugins/sandbox/docker/process_user_test.go
+++ b/plugins/sandbox/docker/process_user_test.go
@@ -1,12 +1,18 @@
+//go:build !windows
+
 package docker
 
-import "testing"
+import (
+	"fmt"
+	"os"
+	"testing"
+)
 
 func TestDockerProcessUser(t *testing.T) {
 	if got := dockerProcessUser(true); got != "0:0" {
 		t.Fatalf("rootless process user = %q, want 0:0", got)
 	}
-	if got, want := dockerProcessUser(false), rootfulDockerProcessUser(); got != want {
+	if got, want := dockerProcessUser(false), fmt.Sprintf("%d:%d", os.Geteuid(), os.Getegid()); got != want {
 		t.Fatalf("rootful process user = %q, want %q", got, want)
 	}
 }

--- a/plugins/sandbox/docker/process_user_test.go
+++ b/plugins/sandbox/docker/process_user_test.go
@@ -1,0 +1,12 @@
+package docker
+
+import "testing"
+
+func TestDockerProcessUser(t *testing.T) {
+	if got := dockerProcessUser(true); got != "0:0" {
+		t.Fatalf("rootless process user = %q, want 0:0", got)
+	}
+	if got, want := dockerProcessUser(false), rootfulDockerProcessUser(); got != want {
+		t.Fatalf("rootful process user = %q, want %q", got, want)
+	}
+}

--- a/plugins/sandbox/docker/process_user_unix.go
+++ b/plugins/sandbox/docker/process_user_unix.go
@@ -7,8 +7,9 @@ import (
 	"os"
 )
 
-// dockerProcessUser aligns bind/volume file ownership with the stellad process.
-// The container still drops every capability and runs with no-new-privileges.
-func dockerProcessUser() string {
+// rootfulDockerProcessUser aligns bind/volume ownership with stellad. Rootless
+// Docker instead maps the daemon user to container UID 0; selecting the host
+// numeric UID there makes daemon-user-owned bind mounts unwritable.
+func rootfulDockerProcessUser() string {
 	return fmt.Sprintf("%d:%d", os.Geteuid(), os.Getegid())
 }

--- a/plugins/sandbox/docker/process_user_unix.go
+++ b/plugins/sandbox/docker/process_user_unix.go
@@ -7,9 +7,12 @@ import (
 	"os"
 )
 
-// rootfulDockerProcessUser aligns bind/volume ownership with stellad. Rootless
-// Docker instead maps the daemon user to container UID 0; selecting the host
-// numeric UID there makes daemon-user-owned bind mounts unwritable.
-func rootfulDockerProcessUser() string {
+// dockerProcessUser renders the ownership model exposed by the daemon. UID 0
+// on a rootless daemon maps to the unprivileged daemon user on the host and is
+// the owner rootless bind mounts expose inside the container.
+func dockerProcessUser(rootless bool) string {
+	if rootless {
+		return "0:0"
+	}
 	return fmt.Sprintf("%d:%d", os.Geteuid(), os.Getegid())
 }

--- a/plugins/sandbox/docker/process_user_windows.go
+++ b/plugins/sandbox/docker/process_user_windows.go
@@ -1,4 +1,4 @@
 package docker
 
 // Docker Desktop mediates Windows filesystem ownership; keep the image user.
-func dockerProcessUser() string { return "" }
+func rootfulDockerProcessUser() string { return "" }

--- a/plugins/sandbox/docker/process_user_windows.go
+++ b/plugins/sandbox/docker/process_user_windows.go
@@ -1,4 +1,4 @@
 package docker
 
 // Docker Desktop mediates Windows filesystem ownership; keep the image user.
-func rootfulDockerProcessUser() string { return "" }
+func dockerProcessUser(bool) string { return "" }

--- a/plugins/sandbox/docker/session.go
+++ b/plugins/sandbox/docker/session.go
@@ -248,6 +248,7 @@ func (f *dockerFactory) CreateSession(ctx context.Context, policy sandboxpkg.Pol
 	cleanupScope := f.cfg.cleanupScope(f.cfg.StellaHome)
 	opts := dockerclient.CreateOptions{
 		Image:          f.cfg.Image,
+		Runtime:        f.cfg.Runtime,
 		User:           dockerProcessUser(),
 		WorkspaceHost:  workspaceHost,
 		WorkspaceMount: workspaceMount,
@@ -370,6 +371,7 @@ func (f *dockerFactory) CreateSession(ctx context.Context, policy sandboxpkg.Pol
 		"session_id", sessionID,
 		"image", opts.Image,
 		"container_name", opts.Name,
+		"runtime", opts.Runtime,
 		"workspace", workspaceHost,
 		"network_mode", opts.NetworkMode,
 		"extra_mounts", len(opts.ExtraMounts),

--- a/plugins/sandbox/docker/session.go
+++ b/plugins/sandbox/docker/session.go
@@ -244,12 +244,18 @@ func (f *dockerFactory) CreateSession(ctx context.Context, policy sandboxpkg.Pol
 		span.End()
 		return nil, fmt.Errorf("docker session: client: %w", err)
 	}
+	security, err := client.Security(ctx)
+	if err != nil {
+		recordError(span, err)
+		span.End()
+		return nil, fmt.Errorf("docker session: inspect daemon security: %w", err)
+	}
 
 	cleanupScope := f.cfg.cleanupScope(f.cfg.StellaHome)
 	opts := dockerclient.CreateOptions{
 		Image:          f.cfg.Image,
 		Runtime:        f.cfg.Runtime,
-		User:           dockerProcessUser(),
+		User:           dockerProcessUser(security.Rootless),
 		WorkspaceHost:  workspaceHost,
 		WorkspaceMount: workspaceMount,
 		NetworkMode:    networkMode,
@@ -425,6 +431,16 @@ func (f *dockerFactory) CreateSession(ctx context.Context, policy sandboxpkg.Pol
 	go session.watchContainer()
 
 	return session, nil
+}
+
+// dockerProcessUser renders the ownership model exposed by the daemon. UID 0
+// on a rootless daemon is the unprivileged daemon user on the host, not host
+// root, and is the owner rootless bind mounts expose inside the container.
+func dockerProcessUser(rootless bool) string {
+	if rootless {
+		return "0:0"
+	}
+	return rootfulDockerProcessUser()
 }
 
 // mapNetworkMode translates sandbox policy network mode to the dockerclient type.

--- a/plugins/sandbox/docker/session.go
+++ b/plugins/sandbox/docker/session.go
@@ -79,7 +79,7 @@ func (f *dockerFactory) client() (*dockerclient.Client, error) {
 func NewFactoryWithMountSources(cfg Config, mountSources map[string]string) (sandboxpkg.Factory, error) {
 	if cfg.StellaHome != "" {
 		var err error
-		cfg, err = applyDockerMode(cfg, cfg.StellaHome)
+		cfg, err = resolveDockerConfig(cfg, cfg.StellaHome)
 		if err != nil {
 			return nil, err
 		}

--- a/plugins/sandbox/docker/session.go
+++ b/plugins/sandbox/docker/session.go
@@ -433,16 +433,6 @@ func (f *dockerFactory) CreateSession(ctx context.Context, policy sandboxpkg.Pol
 	return session, nil
 }
 
-// dockerProcessUser renders the ownership model exposed by the daemon. UID 0
-// on a rootless daemon is the unprivileged daemon user on the host, not host
-// root, and is the owner rootless bind mounts expose inside the container.
-func dockerProcessUser(rootless bool) string {
-	if rootless {
-		return "0:0"
-	}
-	return rootfulDockerProcessUser()
-}
-
 // mapNetworkMode translates sandbox policy network mode to the dockerclient type.
 func mapNetworkMode(policy sandboxpkg.Policy) dockerclient.NetworkMode {
 	switch policy.NetworkModeOrDefault() {

--- a/plugins/sandbox/docker/session_lifecycle_test.go
+++ b/plugins/sandbox/docker/session_lifecycle_test.go
@@ -57,9 +57,13 @@ type startFailAPI struct {
 	noopAPI
 	createOpts mobyclient.ContainerCreateOptions
 	rootless   bool
+	infoErr    error
 }
 
 func (f *startFailAPI) Info(context.Context, mobyclient.InfoOptions) (mobyclient.SystemInfoResult, error) {
+	if f.infoErr != nil {
+		return mobyclient.SystemInfoResult{}, f.infoErr
+	}
 	info := system.Info{CgroupDriver: "systemd"}
 	if f.rootless {
 		info.SecurityOptions = []string{"name=rootless"}
@@ -337,6 +341,40 @@ func TestCreateSessionStartFailureRemovesOwnedTemp(t *testing.T) {
 	}
 	if _, err := os.Stat(tempSource); !os.IsNotExist(err) {
 		t.Fatalf("owned fallback temp survives start failure: %v", err)
+	}
+}
+
+func TestCreateSessionUsesRootfulProcessIdentity(t *testing.T) {
+	api := &startFailAPI{}
+	factory := &dockerFactory{
+		cfg:          Config{Image: "test:latest", RuntimeMode: DockerSandboxModeHost},
+		mountSources: map[string]string{workspaceMount: t.TempDir()},
+		clientFn:     func() (*dockerclient.Client, error) { return dockerclient.NewWithAPI(api), nil },
+	}
+	_, err := factory.CreateSession(context.Background(), sandboxpkg.Policy{
+		Filesystem: sandboxpkg.FilesystemPolicy{
+			WorkingDir: workspaceMount,
+			Mounts:     []sandboxpkg.Mount{{SandboxPath: workspaceMount, Access: sandboxpkg.MountReadWrite}},
+		},
+	})
+	if err == nil {
+		t.Fatal("CreateSession succeeded despite container start failure")
+	}
+	if got, want := api.createOpts.Config.User, dockerProcessUser(false); got != want {
+		t.Errorf("rootful container user = %q, want %q", got, want)
+	}
+}
+
+func TestCreateSessionFailsWhenDaemonSecurityCannotBeInspected(t *testing.T) {
+	api := &startFailAPI{infoErr: errors.New("info unavailable")}
+	factory := &dockerFactory{
+		cfg:          Config{Image: "test:latest", RuntimeMode: DockerSandboxModeHost},
+		mountSources: map[string]string{workspaceMount: t.TempDir()},
+		clientFn:     func() (*dockerclient.Client, error) { return dockerclient.NewWithAPI(api), nil },
+	}
+	_, err := factory.CreateSession(context.Background(), sandboxpkg.Policy{})
+	if err == nil || !strings.Contains(err.Error(), "inspect daemon security") {
+		t.Fatalf("daemon security error = %v", err)
 	}
 }
 

--- a/plugins/sandbox/docker/session_lifecycle_test.go
+++ b/plugins/sandbox/docker/session_lifecycle_test.go
@@ -296,7 +296,7 @@ func TestCreateSessionStartFailureRemovesOwnedTemp(t *testing.T) {
 	api := &startFailAPI{}
 	workspace := t.TempDir()
 	factory := &dockerFactory{
-		cfg:          Config{Image: "test:latest", RuntimeMode: DockerSandboxModeHost},
+		cfg:          Config{Image: "test:latest", Runtime: "runsc", RuntimeMode: DockerSandboxModeHost},
 		mountSources: map[string]string{workspaceMount: workspace},
 		clientFn:     func() (*dockerclient.Client, error) { return dockerclient.NewWithAPI(api), nil },
 	}
@@ -321,6 +321,9 @@ func TestCreateSessionStartFailureRemovesOwnedTemp(t *testing.T) {
 	}
 	if got, want := api.createOpts.Config.User, dockerProcessUser(); got != want {
 		t.Errorf("container user = %q, want stellad process user %q", got, want)
+	}
+	if got := api.createOpts.HostConfig.Runtime; got != "runsc" {
+		t.Errorf("container runtime = %q, want runsc", got)
 	}
 	if _, err := os.Stat(tempSource); !os.IsNotExist(err) {
 		t.Fatalf("owned fallback temp survives start failure: %v", err)

--- a/plugins/sandbox/docker/session_lifecycle_test.go
+++ b/plugins/sandbox/docker/session_lifecycle_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/system"
 	mobyclient "github.com/moby/moby/client"
 
 	sandboxpkg "github.com/CherryHQ/stella/pkg/sandbox"
@@ -55,6 +56,15 @@ func (f *sessionListAPI) ContainerList(context.Context, mobyclient.ContainerList
 type startFailAPI struct {
 	noopAPI
 	createOpts mobyclient.ContainerCreateOptions
+	rootless   bool
+}
+
+func (f *startFailAPI) Info(context.Context, mobyclient.InfoOptions) (mobyclient.SystemInfoResult, error) {
+	info := system.Info{CgroupDriver: "systemd"}
+	if f.rootless {
+		info.SecurityOptions = []string{"name=rootless"}
+	}
+	return mobyclient.SystemInfoResult{Info: info}, nil
 }
 
 func (f *startFailAPI) ContainerCreate(_ context.Context, opts mobyclient.ContainerCreateOptions) (mobyclient.ContainerCreateResult, error) {
@@ -293,7 +303,7 @@ func TestCreateSessionRejectsOverlappingPhysicalMountsBeforeContainerCreate(t *t
 }
 
 func TestCreateSessionStartFailureRemovesOwnedTemp(t *testing.T) {
-	api := &startFailAPI{}
+	api := &startFailAPI{rootless: true}
 	workspace := t.TempDir()
 	factory := &dockerFactory{
 		cfg:          Config{Image: "test:latest", Runtime: "runsc", RuntimeMode: DockerSandboxModeHost},
@@ -319,8 +329,8 @@ func TestCreateSessionStartFailureRemovesOwnedTemp(t *testing.T) {
 	if tempSource == "" {
 		t.Fatal("CreateSession did not configure a /tmp mount")
 	}
-	if got, want := api.createOpts.Config.User, dockerProcessUser(); got != want {
-		t.Errorf("container user = %q, want stellad process user %q", got, want)
+	if got, want := api.createOpts.Config.User, "0:0"; got != want {
+		t.Errorf("rootless container user = %q, want %q", got, want)
 	}
 	if got := api.createOpts.HostConfig.Runtime; got != "runsc" {
 		t.Errorf("container runtime = %q, want runsc", got)

--- a/plugins/sandbox/docker/session_pure_test.go
+++ b/plugins/sandbox/docker/session_pure_test.go
@@ -170,7 +170,7 @@ func TestMapNetworkMode(t *testing.T) {
 
 func TestInjectToolPaths_PrependedWhenSet(t *testing.T) {
 	env := map[string]string{"PATH": "/usr/bin:/bin"}
-	paths := []string{"/opt/stella/users/u1/.mise-tools/shims", "/home/stella/.stella-tools/bin"}
+	paths := []string{"/opt/stella/users/u1/.mise-tools/shims", "/opt/stella/user-tools/bin"}
 	got := injectToolPaths(env, paths)
 	want := strings.Join(append(append([]string(nil), paths...), "/usr/bin", "/bin"), ":")
 	if got["PATH"] != want {
@@ -182,14 +182,14 @@ func TestInjectToolPaths_PrependedWhenSet(t *testing.T) {
 }
 
 func TestInjectToolPaths_UsesDefaultPathWhenPATHAbsent(t *testing.T) {
-	got := injectToolPaths(map[string]string{}, []string{"/home/stella/.stella-tools/bin"})
+	got := injectToolPaths(map[string]string{}, []string{"/opt/stella/user-tools/bin"})
 	if got["PATH"] == "" {
 		t.Fatal("PATH should not be empty when tool paths are set")
 	}
-	if got["PATH"][:len("/home/stella/.stella-tools/bin:")] != "/home/stella/.stella-tools/bin:" {
+	if got["PATH"][:len("/opt/stella/user-tools/bin:")] != "/opt/stella/user-tools/bin:" {
 		t.Errorf("PATH does not start with user tool bin: %q", got["PATH"])
 	}
-	if len(got["PATH"]) <= len("/home/stella/.stella-tools/bin:") {
+	if len(got["PATH"]) <= len("/opt/stella/user-tools/bin:") {
 		t.Error("PATH should include containerDefaultPATH after user tool bin")
 	}
 }

--- a/plugins/sandbox/docker/testhelpers_test.go
+++ b/plugins/sandbox/docker/testhelpers_test.go
@@ -16,6 +16,10 @@ func (noopAPI) ServerVersion(context.Context, mobyclient.ServerVersionOptions) (
 	return mobyclient.ServerVersionResult{}, nil
 }
 
+func (noopAPI) Info(context.Context, mobyclient.InfoOptions) (mobyclient.SystemInfoResult, error) {
+	return mobyclient.SystemInfoResult{}, nil
+}
+
 func (noopAPI) ImageInspect(context.Context, string, ...mobyclient.ImageInspectOption) (mobyclient.ImageInspectResult, error) {
 	return mobyclient.ImageInspectResult{}, nil
 }

--- a/plugins/sandbox/docker/toolcache.go
+++ b/plugins/sandbox/docker/toolcache.go
@@ -116,6 +116,7 @@ func installUserToolCache(ctx context.Context, client *dockerclient.Client, cfg 
 
 	containerID, err := client.CreateAndStart(ctx, dockerclient.CreateOptions{
 		Image:       cfg.Image,
+		Runtime:     cfg.Runtime,
 		NetworkMode: dockerclient.NetworkAllowAll,
 		User:        "root",
 		Env: map[string]string{
@@ -233,6 +234,7 @@ func resetToolCacheMemoForTest() {
 func verifyUserToolCache(ctx context.Context, client *dockerclient.Client, cfg Config, hash string, cache *userToolCache) error {
 	containerID, err := client.CreateAndStart(ctx, dockerclient.CreateOptions{
 		Image:       cfg.Image,
+		Runtime:     cfg.Runtime,
 		NetworkMode: dockerclient.NetworkDisabled,
 		User:        "root",
 		ExtraMounts: []dockerclient.Mount{

--- a/plugins/sandbox/docker/toolcache.go
+++ b/plugins/sandbox/docker/toolcache.go
@@ -32,7 +32,9 @@ const (
 )
 
 const (
-	containerUserToolsRoot        = "/home/stella/.stella-tools"
+	// /opt/stella is world-traversable. /home/stella is 0700, so rootless
+	// container UID 0 with all capabilities dropped cannot reach mounts there.
+	containerUserToolsRoot        = "/opt/stella/user-tools"
 	containerUserToolsBin         = containerUserToolsRoot + "/bin"
 	containerUserToolsReadyMarker = containerUserToolsRoot + "/.stella-tools-ready"
 )

--- a/web/content/docs/development/rules/project-tracker.md
+++ b/web/content/docs/development/rules/project-tracker.md
@@ -306,6 +306,12 @@ delivered them. `截止日期` stays a deadline. The `交付周` and `周次` fo
 derive from `完成日期`, so the `上周交付` view and the `交付总览` dashboard roll
 over on their own.
 
+After a reviewed delivery write, link each delivery PR back to its Feishu Task.
+Set the linked Issue's GitHub release milestone only when the complete issue
+shipped in that release. Release tags and release-branch cherry-picks establish
+that fact; merge time alone does not. This remains GitHub release metadata, not
+a copy of the Feishu product milestone.
+
 ## Automation boundary
 
 The workflow is manual until repeated evidence justifies automation. The only

--- a/web/content/docs/development/rules/project-tracker.zh.md
+++ b/web/content/docs/development/rules/project-tracker.zh.md
@@ -243,6 +243,11 @@ gh issue edit <number> --repo CherryHQ/stella --milestone v0.61.0
 仍然是 deadline。`交付周` 与 `周次` 是基于 `完成日期` 的公式，因此 `上周交付`
 视图和 `交付总览` 仪表盘会自动滚动。
 
+交付写入经复核后，需要从每个交付 PR 回链对应的飞书 Task。只有完整 Issue 已随该
+版本发布时，才设置其 GitHub 发布 Milestone。发布 tag 与 release 分支的 cherry-pick
+才是依据，不能只按合入时间判断。这仍是 GitHub 的发布元数据，不是复制飞书产品
+里程碑。
+
 ## 自动化边界
 
 在反复出现明确痛点之前保持手工流程。初期仅考虑两项自动化：

--- a/web/content/docs/guides/sandbox.md
+++ b/web/content/docs/guides/sandbox.md
@@ -65,7 +65,7 @@ STELLA_DOCKER_RUNTIME=runsc
 
 An alternative OCI runtime reduces host-kernel exposure, but it does not restrict network egress or protect writable mounts. Keep the sandbox network policy and mount permissions independently constrained.
 
-Stella also detects whether the Docker daemon is rootless. A rootful daemon runs sandbox processes with the `stellad` UID and GID. A rootless daemon runs them as container UID/GID `0:0`, which maps to the unprivileged daemon user on the host and keeps that user's bind mounts writable. Capabilities remain dropped and `no-new-privileges` remains enabled in both modes. Preflight requires the daemon to report support for memory, CPU quota, and PID limits, and rejects a selected runtime configured with `--ignore-cgroups`. Docker `userns-remap` is not supported because its bind-mount ownership model differs from both rootful and rootless Docker.
+Stella also detects whether the Docker daemon is rootless. A rootful daemon runs sandbox processes with the `stellad` UID and GID. A rootless daemon runs them as container UID/GID `0:0`, which maps to the unprivileged daemon user on the host and keeps that user's bind mounts writable. Capabilities remain dropped and `no-new-privileges` remains enabled in both modes. Preflight requires the daemon to report support for memory, swap, CPU quota, and PID limits; memory plus swap is capped at the same 2 GiB ceiling. Stella also rejects a selected runtime configured with `--ignore-cgroups`. Docker `userns-remap` is not supported because its bind-mount ownership model differs from both rootful and rootless Docker.
 
 ### Docker Compose Examples
 

--- a/web/content/docs/guides/sandbox.md
+++ b/web/content/docs/guides/sandbox.md
@@ -39,20 +39,6 @@ Docker provides full container-level process, filesystem, and network isolation.
 - **Bind-mount performance**: On Docker Desktop for macOS, bind-mount filesystem operations are 5–20× slower than native disk. Avoid it for heavy read/write workflows.
 - **No copy-on-write isolation**: Unlike the local backend (which uses overlayfs on Linux), the Docker backend does not provide overlay-based COW. A runaway script can modify or damage the mounted workspace.
 
-### Advanced: Custom Deployment Mode
-
-The deployment entry point normally owns how Docker sees `STELLA_HOME`; this is not a routine sandbox choice. `stellad service install` injects `host`, and the official Docker Compose file injects `volume` with the `stella-data` volume. You only set `STELLA_DOCKER_SANDBOX_MODE` yourself when starting `stellad server` directly or building a custom container deployment.
-
-| Mode     | When to use                                             | Required env                                        |
-| -------- | ------------------------------------------------------- | --------------------------------------------------- |
-| `host`   | stellad runs on the host (not in a container)           | Neither `STELLA_HOME_HOST` nor `STELLA_HOME_VOLUME` |
-| `bind`   | stellad runs in Docker; `STELLA_HOME` is a bind mount   | `STELLA_HOME_HOST` = the host-side path             |
-| `volume` | stellad runs in Docker; `STELLA_HOME` is a named volume | `STELLA_HOME_VOLUME` = the volume name              |
-
-Each mode rejects env vars that belong to other modes. For example, `bind` mode with `STELLA_HOME_VOLUME` set is an error. A custom container deployment must choose `bind` or `volume` explicitly; Stella does not guess whether container paths are visible to the host daemon.
-
-Volume mode requires Docker Engine 25+ for volume subpath mounts.
-
 ### OCI Runtime
 
 By default, sandbox containers use the Docker daemon's default Open Container Initiative (OCI) runtime, normally `runc`. Set `STELLA_DOCKER_RUNTIME` to a runtime registered with that daemon to select a stronger or specialized execution boundary:
@@ -67,7 +53,21 @@ An alternative OCI runtime reduces host-kernel exposure, but it does not restric
 
 Stella also detects whether the Docker daemon is rootless. A rootful daemon runs sandbox processes with the `stellad` UID and GID. A rootless daemon runs them as container UID/GID `0:0`, which maps to the unprivileged daemon user on the host and keeps that user's bind mounts writable. Capabilities remain dropped and `no-new-privileges` remains enabled in both modes. Preflight requires the daemon to report support for memory, swap, CPU quota, and PID limits; memory plus swap is capped at the same 2 GiB ceiling. Stella also rejects a selected runtime configured with `--ignore-cgroups`. Docker `userns-remap` is not supported because its bind-mount ownership model differs from both rootful and rootless Docker.
 
-### Docker Compose Examples
+### Custom Deployments
+
+Standard service and Compose deployments require only the backend and optional runtime settings above. Continue here only when starting `stellad server` directly or building your own container deployment.
+
+Custom deployments must tell Stella how the Docker daemon sees `STELLA_HOME`:
+
+| Mode     | When to use                                             | Required env                                        |
+| -------- | ------------------------------------------------------- | --------------------------------------------------- |
+| `host`   | stellad runs on the host (not in a container)           | Neither `STELLA_HOME_HOST` nor `STELLA_HOME_VOLUME` |
+| `bind`   | stellad runs in Docker; `STELLA_HOME` is a bind mount   | `STELLA_HOME_HOST` = the host-side path             |
+| `volume` | stellad runs in Docker; `STELLA_HOME` is a named volume | `STELLA_HOME_VOLUME` = the volume name              |
+
+Set `STELLA_DOCKER_SANDBOX_MODE` to the matching mode. Each mode rejects variables that belong to another mode. A custom container deployment must choose `bind` or `volume` explicitly; Stella does not guess whether container paths are visible to the host daemon. Volume mode requires Docker Engine 25+ for volume subpath mounts.
+
+### Custom Docker Compose
 
 **Container with `local` or `none` sandbox** — the simplest deployment:
 
@@ -95,6 +95,7 @@ services:
       - ./stella-data:/home/stella/.stella
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
+      - STELLA_SANDBOX_BACKEND=docker
       - STELLA_DOCKER_SANDBOX_MODE=bind
       - STELLA_DOCKER_RUNTIME=runsc # optional; must be registered with Docker
       - STELLA_HOME_HOST=${PWD}/stella-data
@@ -111,6 +112,7 @@ services:
       - stella-data:/home/stella/.stella
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
+      - STELLA_SANDBOX_BACKEND=docker
       - STELLA_DOCKER_SANDBOX_MODE=volume
       - STELLA_DOCKER_RUNTIME=runsc # optional; must be registered with Docker
       - STELLA_HOME_VOLUME=stella-data
@@ -118,18 +120,6 @@ services:
 volumes:
   stella-data:
 ```
-
-### Environment Variables
-
-| Variable                     | Description                                                                                         |
-| ---------------------------- | --------------------------------------------------------------------------------------------------- |
-| `STELLA_SANDBOX_BACKEND`     | Sandbox backend for the deployment: `docker`, `local` (default), or `none`                          |
-| `STELLA_DOCKER_SANDBOX_MODE` | Deployment-owned mode: `host`, `bind`, or `volume`; set manually only for direct/custom deployments |
-| `STELLA_DOCKER_RUNTIME`      | Optional registered OCI runtime for Docker sandbox containers, such as `runsc`                      |
-| `STELLA_HOME_HOST`           | Host-side path backing `STELLA_HOME`; required only in `bind` mode                                  |
-| `STELLA_HOME_VOLUME`         | Docker named volume backing `STELLA_HOME`; required only in `volume` mode                           |
-
-If agents use `local` or `none`, none of these variables are needed.
 
 ## Local Backend
 

--- a/web/content/docs/guides/sandbox.md
+++ b/web/content/docs/guides/sandbox.md
@@ -53,6 +53,18 @@ Each mode rejects env vars that belong to other modes. For example, `bind` mode 
 
 Volume mode requires Docker Engine 25+ for volume subpath mounts.
 
+### OCI Runtime
+
+By default, sandbox containers use the Docker daemon's default Open Container Initiative (OCI) runtime, normally `runc`. Set `STELLA_DOCKER_RUNTIME` to a runtime registered with that daemon to select a stronger or specialized execution boundary:
+
+```bash
+STELLA_DOCKER_RUNTIME=runsc
+```
+
+`runsc` is the gVisor runtime. Install and register it with Docker before enabling this setting, then confirm it appears in `docker info`. Stella preflight rejects an unavailable configured runtime and does not fall back to the daemon default. The selected runtime applies to agent sessions and Docker tool-cache helper containers.
+
+An alternative OCI runtime reduces host-kernel exposure, but it does not restrict network egress or protect writable mounts. Keep the sandbox network policy and mount permissions independently constrained.
+
 ### Docker Compose Examples
 
 **Container with `local` or `none` sandbox** — the simplest deployment:
@@ -82,6 +94,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - STELLA_DOCKER_SANDBOX_MODE=bind
+      - STELLA_DOCKER_RUNTIME=runsc # optional; must be registered with Docker
       - STELLA_HOME_HOST=${PWD}/stella-data
 ```
 
@@ -97,6 +110,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - STELLA_DOCKER_SANDBOX_MODE=volume
+      - STELLA_DOCKER_RUNTIME=runsc # optional; must be registered with Docker
       - STELLA_HOME_VOLUME=stella-data
 
 volumes:
@@ -105,12 +119,13 @@ volumes:
 
 ### Environment Variables
 
-| Variable                     | Description                                                                |
-| ---------------------------- | -------------------------------------------------------------------------- |
-| `STELLA_SANDBOX_BACKEND`     | Sandbox backend for the deployment: `docker`, `local` (default), or `none` |
-| `STELLA_DOCKER_SANDBOX_MODE` | Required for the `docker` sandbox backend: `host`, `bind`, or `volume`     |
-| `STELLA_HOME_HOST`           | Host-side path backing `STELLA_HOME`; required only in `bind` mode         |
-| `STELLA_HOME_VOLUME`         | Docker named volume backing `STELLA_HOME`; required only in `volume` mode  |
+| Variable                     | Description                                                                    |
+| ---------------------------- | ------------------------------------------------------------------------------ |
+| `STELLA_SANDBOX_BACKEND`     | Sandbox backend for the deployment: `docker`, `local` (default), or `none`     |
+| `STELLA_DOCKER_SANDBOX_MODE` | Required for the `docker` sandbox backend: `host`, `bind`, or `volume`         |
+| `STELLA_DOCKER_RUNTIME`      | Optional registered OCI runtime for Docker sandbox containers, such as `runsc` |
+| `STELLA_HOME_HOST`           | Host-side path backing `STELLA_HOME`; required only in `bind` mode             |
+| `STELLA_HOME_VOLUME`         | Docker named volume backing `STELLA_HOME`; required only in `volume` mode      |
 
 If agents use `local` or `none`, none of these variables are needed.
 

--- a/web/content/docs/guides/sandbox.md
+++ b/web/content/docs/guides/sandbox.md
@@ -65,6 +65,8 @@ STELLA_DOCKER_RUNTIME=runsc
 
 An alternative OCI runtime reduces host-kernel exposure, but it does not restrict network egress or protect writable mounts. Keep the sandbox network policy and mount permissions independently constrained.
 
+Stella also detects whether the Docker daemon is rootless. A rootful daemon runs sandbox processes with the `stellad` UID and GID. A rootless daemon runs them as container UID/GID `0:0`, which maps to the unprivileged daemon user on the host and keeps that user's bind mounts writable. Capabilities remain dropped and `no-new-privileges` remains enabled in both modes. Rootless preflight fails when the daemon has no cgroup driver because Stella could not enforce its CPU, memory, and PID limits; do not configure gVisor with `--ignore-cgroups` in production.
+
 ### Docker Compose Examples
 
 **Container with `local` or `none` sandbox** — the simplest deployment:

--- a/web/content/docs/guides/sandbox.md
+++ b/web/content/docs/guides/sandbox.md
@@ -61,11 +61,11 @@ By default, sandbox containers use the Docker daemon's default Open Container In
 STELLA_DOCKER_RUNTIME=runsc
 ```
 
-`runsc` is the gVisor runtime. Install and register it with Docker before enabling this setting, then confirm it appears in `docker info`. Stella preflight rejects an unavailable configured runtime and does not fall back to the daemon default. The selected runtime applies to agent sessions and Docker tool-cache helper containers.
+`runsc` is the gVisor runtime. Install and register it with Docker before enabling this setting, then confirm it appears in `docker info`. Stella preflight rejects an unregistered configured runtime and does not fall back to the daemon default. Registration is an operator trust decision; Stella cannot prove that an arbitrary runtime implementation honors the OCI resource contract. The selected runtime applies to agent sessions and Docker tool-cache helper containers.
 
 An alternative OCI runtime reduces host-kernel exposure, but it does not restrict network egress or protect writable mounts. Keep the sandbox network policy and mount permissions independently constrained.
 
-Stella also detects whether the Docker daemon is rootless. A rootful daemon runs sandbox processes with the `stellad` UID and GID. A rootless daemon runs them as container UID/GID `0:0`, which maps to the unprivileged daemon user on the host and keeps that user's bind mounts writable. Capabilities remain dropped and `no-new-privileges` remains enabled in both modes. Rootless preflight fails when the daemon has no cgroup driver because Stella could not enforce its CPU, memory, and PID limits; do not configure gVisor with `--ignore-cgroups` in production.
+Stella also detects whether the Docker daemon is rootless. A rootful daemon runs sandbox processes with the `stellad` UID and GID. A rootless daemon runs them as container UID/GID `0:0`, which maps to the unprivileged daemon user on the host and keeps that user's bind mounts writable. Capabilities remain dropped and `no-new-privileges` remains enabled in both modes. Preflight requires the daemon to report support for memory, CPU quota, and PID limits, and rejects a selected runtime configured with `--ignore-cgroups`. Docker `userns-remap` is not supported because its bind-mount ownership model differs from both rootful and rootless Docker.
 
 ### Docker Compose Examples
 

--- a/web/content/docs/guides/sandbox.md
+++ b/web/content/docs/guides/sandbox.md
@@ -39,9 +39,9 @@ Docker provides full container-level process, filesystem, and network isolation.
 - **Bind-mount performance**: On Docker Desktop for macOS, bind-mount filesystem operations are 5–20× slower than native disk. Avoid it for heavy read/write workflows.
 - **No copy-on-write isolation**: Unlike the local backend (which uses overlayfs on Linux), the Docker backend does not provide overlay-based COW. A runaway script can modify or damage the mounted workspace.
 
-### Runtime Modes
+### Advanced: Custom Deployment Mode
 
-When stellad itself runs inside a Docker container and agents use the `docker` sandbox backend, you must tell Stella how the Docker daemon can see `STELLA_HOME`. Set `STELLA_DOCKER_SANDBOX_MODE` to one of:
+The deployment entry point normally owns how Docker sees `STELLA_HOME`; this is not a routine sandbox choice. `stellad service install` injects `host`, and the official Docker Compose file injects `volume` with the `stella-data` volume. You only set `STELLA_DOCKER_SANDBOX_MODE` yourself when starting `stellad server` directly or building a custom container deployment.
 
 | Mode     | When to use                                             | Required env                                        |
 | -------- | ------------------------------------------------------- | --------------------------------------------------- |
@@ -49,7 +49,7 @@ When stellad itself runs inside a Docker container and agents use the `docker` s
 | `bind`   | stellad runs in Docker; `STELLA_HOME` is a bind mount   | `STELLA_HOME_HOST` = the host-side path             |
 | `volume` | stellad runs in Docker; `STELLA_HOME` is a named volume | `STELLA_HOME_VOLUME` = the volume name              |
 
-Each mode rejects env vars that belong to other modes. For example, `bind` mode with `STELLA_HOME_VOLUME` set is an error.
+Each mode rejects env vars that belong to other modes. For example, `bind` mode with `STELLA_HOME_VOLUME` set is an error. A custom container deployment must choose `bind` or `volume` explicitly; Stella does not guess whether container paths are visible to the host daemon.
 
 Volume mode requires Docker Engine 25+ for volume subpath mounts.
 
@@ -121,13 +121,13 @@ volumes:
 
 ### Environment Variables
 
-| Variable                     | Description                                                                    |
-| ---------------------------- | ------------------------------------------------------------------------------ |
-| `STELLA_SANDBOX_BACKEND`     | Sandbox backend for the deployment: `docker`, `local` (default), or `none`     |
-| `STELLA_DOCKER_SANDBOX_MODE` | Required for the `docker` sandbox backend: `host`, `bind`, or `volume`         |
-| `STELLA_DOCKER_RUNTIME`      | Optional registered OCI runtime for Docker sandbox containers, such as `runsc` |
-| `STELLA_HOME_HOST`           | Host-side path backing `STELLA_HOME`; required only in `bind` mode             |
-| `STELLA_HOME_VOLUME`         | Docker named volume backing `STELLA_HOME`; required only in `volume` mode      |
+| Variable                     | Description                                                                                         |
+| ---------------------------- | --------------------------------------------------------------------------------------------------- |
+| `STELLA_SANDBOX_BACKEND`     | Sandbox backend for the deployment: `docker`, `local` (default), or `none`                          |
+| `STELLA_DOCKER_SANDBOX_MODE` | Deployment-owned mode: `host`, `bind`, or `volume`; set manually only for direct/custom deployments |
+| `STELLA_DOCKER_RUNTIME`      | Optional registered OCI runtime for Docker sandbox containers, such as `runsc`                      |
+| `STELLA_HOME_HOST`           | Host-side path backing `STELLA_HOME`; required only in `bind` mode                                  |
+| `STELLA_HOME_VOLUME`         | Docker named volume backing `STELLA_HOME`; required only in `volume` mode                           |
 
 If agents use `local` or `none`, none of these variables are needed.
 

--- a/web/content/docs/guides/sandbox.zh.md
+++ b/web/content/docs/guides/sandbox.zh.md
@@ -53,6 +53,18 @@ Docker 提供完整的容器级进程、文件系统和网络隔离。在受支�
 
 Volume 模式需要 Docker Engine 25+ 以支持 volume subpath 挂载。
 
+### OCI Runtime
+
+默认情况下，沙箱容器使用 Docker daemon 的默认开放容器倡议（OCI）runtime，通常是 `runc`。将 `STELLA_DOCKER_RUNTIME` 设为该 daemon 已注册的 runtime，可以选择更强或专用的执行边界：
+
+```bash
+STELLA_DOCKER_RUNTIME=runsc
+```
+
+`runsc` 是 gVisor runtime。启用前先安装并注册到 Docker，再确认它出现在 `docker info` 中。Stella 预检会拒绝不可用的已配置 runtime，不会回退到 daemon 默认值。所选 runtime 同时用于 agent 会话和 Docker 工具缓存辅助容器。
+
+替代 OCI runtime 可以减少宿主内核暴露面，但不会限制网络出口，也不会保护可写挂载。沙箱网络策略和挂载权限仍需独立收紧。
+
 ### Docker Compose 示例
 
 **容器内使用 `local` 或 `none` 沙箱** — 最简单的部署：
@@ -82,6 +94,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - STELLA_DOCKER_SANDBOX_MODE=bind
+      - STELLA_DOCKER_RUNTIME=runsc # 可选；必须已注册到 Docker
       - STELLA_HOME_HOST=${PWD}/stella-data
 ```
 
@@ -97,6 +110,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - STELLA_DOCKER_SANDBOX_MODE=volume
+      - STELLA_DOCKER_RUNTIME=runsc # 可选；必须已注册到 Docker
       - STELLA_HOME_VOLUME=stella-data
 
 volumes:
@@ -109,6 +123,7 @@ volumes:
 | ---------------------------- | ------------------------------------------------------------------- |
 | `STELLA_SANDBOX_BACKEND`     | 部署使用的沙箱后端：`docker`、`local`（默认）或 `none`              |
 | `STELLA_DOCKER_SANDBOX_MODE` | `docker` 沙箱后端必须设置：`host`、`bind` 或 `volume`               |
+| `STELLA_DOCKER_RUNTIME`      | Docker 沙箱容器使用的可选已注册 OCI runtime，例如 `runsc`           |
 | `STELLA_HOME_HOST`           | `STELLA_HOME` 的宿主机侧路径；仅 `bind` 模式需要                    |
 | `STELLA_HOME_VOLUME`         | `STELLA_HOME` 对应的 Docker named volume 名称；仅 `volume` 模式需要 |
 

--- a/web/content/docs/guides/sandbox.zh.md
+++ b/web/content/docs/guides/sandbox.zh.md
@@ -61,11 +61,11 @@ Volume 模式需要 Docker Engine 25+ 以支持 volume subpath 挂载。
 STELLA_DOCKER_RUNTIME=runsc
 ```
 
-`runsc` 是 gVisor runtime。启用前先安装并注册到 Docker，再确认它出现在 `docker info` 中。Stella 预检会拒绝不可用的已配置 runtime，不会回退到 daemon 默认值。所选 runtime 同时用于 agent 会话和 Docker 工具缓存辅助容器。
+`runsc` 是 gVisor runtime。启用前先安装并注册到 Docker，再确认它出现在 `docker info` 中。Stella 预检会拒绝未注册的已配置 runtime，不会回退到 daemon 默认值。注册 runtime 属于运维信任决策；Stella 无法证明任意 runtime 实现都会遵守 OCI 资源限制约定。所选 runtime 同时用于 agent 会话和 Docker 工具缓存辅助容器。
 
 替代 OCI runtime 可以减少宿主内核暴露面，但不会限制网络出口，也不会保护可写挂载。沙箱网络策略和挂载权限仍需独立收紧。
 
-Stella 还会检测 Docker daemon 是否为 rootless。rootful daemon 使用 `stellad` 的 UID/GID 运行沙箱进程；rootless daemon 使用容器 UID/GID `0:0`，它在宿主机上映射为非特权 daemon 用户，并保持该用户的 bind mount 可写。两种模式都会继续丢弃 capabilities 并启用 `no-new-privileges`。如果 rootless daemon 没有 cgroup driver，Stella 会在预检时拒绝启动，因为此时无法执行 CPU、内存和 PID 限制；生产环境不要为 gVisor 配置 `--ignore-cgroups`。
+Stella 还会检测 Docker daemon 是否为 rootless。rootful daemon 使用 `stellad` 的 UID/GID 运行沙箱进程；rootless daemon 使用容器 UID/GID `0:0`，它在宿主机上映射为非特权 daemon 用户，并保持该用户的 bind mount 可写。两种模式都会继续丢弃 capabilities 并启用 `no-new-privileges`。预检要求 daemon 明确报告支持内存、CPU quota 和 PID 限制，并拒绝使用 `--ignore-cgroups` 配置的 runtime。Docker `userns-remap` 不受支持，因为它的 bind mount 所有权模型与 rootful、rootless Docker 都不同。
 
 ### Docker Compose 示例
 

--- a/web/content/docs/guides/sandbox.zh.md
+++ b/web/content/docs/guides/sandbox.zh.md
@@ -65,7 +65,7 @@ STELLA_DOCKER_RUNTIME=runsc
 
 替代 OCI runtime 可以减少宿主内核暴露面，但不会限制网络出口，也不会保护可写挂载。沙箱网络策略和挂载权限仍需独立收紧。
 
-Stella 还会检测 Docker daemon 是否为 rootless。rootful daemon 使用 `stellad` 的 UID/GID 运行沙箱进程；rootless daemon 使用容器 UID/GID `0:0`，它在宿主机上映射为非特权 daemon 用户，并保持该用户的 bind mount 可写。两种模式都会继续丢弃 capabilities 并启用 `no-new-privileges`。预检要求 daemon 明确报告支持内存、CPU quota 和 PID 限制，并拒绝使用 `--ignore-cgroups` 配置的 runtime。Docker `userns-remap` 不受支持，因为它的 bind mount 所有权模型与 rootful、rootless Docker 都不同。
+Stella 还会检测 Docker daemon 是否为 rootless。rootful daemon 使用 `stellad` 的 UID/GID 运行沙箱进程；rootless daemon 使用容器 UID/GID `0:0`，它在宿主机上映射为非特权 daemon 用户，并保持该用户的 bind mount 可写。两种模式都会继续丢弃 capabilities 并启用 `no-new-privileges`。预检要求 daemon 明确报告支持内存、swap、CPU quota 和 PID 限制；内存加 swap 的总上限与内存上限相同，均为 2 GiB。Stella 还会拒绝使用 `--ignore-cgroups` 配置的 runtime。Docker `userns-remap` 不受支持，因为它的 bind mount 所有权模型与 rootful、rootless Docker 都不同。
 
 ### Docker Compose 示例
 

--- a/web/content/docs/guides/sandbox.zh.md
+++ b/web/content/docs/guides/sandbox.zh.md
@@ -39,9 +39,9 @@ Docker 提供完整的容器级进程、文件系统和网络隔离。在受支�
 - **绑定挂载性能**：在 macOS 的 Docker Desktop 上，绑定挂载文件系统操作比原生磁盘慢 5–20 倍。大量读写操作的工作流应避免使用。
 - **无写时复制隔离**：与本地后端（在 Linux 上使用 overlayfs）不同，Docker 后端不提供基于 overlay 的 COW。失控脚本可能修改或损坏已挂载的工作区。
 
-### 运行模式
+### 高级：自定义部署模式
 
-当 stellad 本身运行在 Docker 容器内且 agent 使用 `docker` 沙箱后端时，你需要告诉 Stella Docker daemon 如何访问 `STELLA_HOME`。将 `STELLA_DOCKER_SANDBOX_MODE` 设置为以下之一：
+Docker 如何看到 `STELLA_HOME` 通常由部署入口负责，不是日常需要选择的沙箱选项。`stellad service install` 会注入 `host`，官方 Docker Compose 文件会注入 `volume` 并使用 `stella-data` volume。只有直接启动 `stellad server` 或构建自定义容器部署时，才需要自行设置 `STELLA_DOCKER_SANDBOX_MODE`。
 
 | 模式     | 何时使用                                                | 需要的环境变量                                    |
 | -------- | ------------------------------------------------------- | ------------------------------------------------- |
@@ -49,7 +49,7 @@ Docker 提供完整的容器级进程、文件系统和网络隔离。在受支�
 | `bind`   | stellad 运行在 Docker 内；`STELLA_HOME` 是 bind mount   | `STELLA_HOME_HOST` = 宿主机侧路径                 |
 | `volume` | stellad 运行在 Docker 内；`STELLA_HOME` 是 named volume | `STELLA_HOME_VOLUME` = volume 名称                |
 
-每种模式都会拒绝属于其他模式的环境变量。例如，`bind` 模式下设置 `STELLA_HOME_VOLUME` 会报错。
+每种模式都会拒绝属于其他模式的环境变量。例如，`bind` 模式下设置 `STELLA_HOME_VOLUME` 会报错。自定义容器部署必须明确选择 `bind` 或 `volume`；Stella 不会猜测容器路径是否对宿主 Docker daemon 可见。
 
 Volume 模式需要 Docker Engine 25+ 以支持 volume subpath 挂载。
 
@@ -121,13 +121,13 @@ volumes:
 
 ### 环境变量
 
-| 变量                         | 描述                                                                |
-| ---------------------------- | ------------------------------------------------------------------- |
-| `STELLA_SANDBOX_BACKEND`     | 部署使用的沙箱后端：`docker`、`local`（默认）或 `none`              |
-| `STELLA_DOCKER_SANDBOX_MODE` | `docker` 沙箱后端必须设置：`host`、`bind` 或 `volume`               |
-| `STELLA_DOCKER_RUNTIME`      | Docker 沙箱容器使用的可选已注册 OCI runtime，例如 `runsc`           |
-| `STELLA_HOME_HOST`           | `STELLA_HOME` 的宿主机侧路径；仅 `bind` 模式需要                    |
-| `STELLA_HOME_VOLUME`         | `STELLA_HOME` 对应的 Docker named volume 名称；仅 `volume` 模式需要 |
+| 变量                         | 描述                                                                         |
+| ---------------------------- | ---------------------------------------------------------------------------- |
+| `STELLA_SANDBOX_BACKEND`     | 部署使用的沙箱后端：`docker`、`local`（默认）或 `none`                       |
+| `STELLA_DOCKER_SANDBOX_MODE` | 部署入口负责的模式：`host`、`bind` 或 `volume`；仅直接或自定义部署需手动设置 |
+| `STELLA_DOCKER_RUNTIME`      | Docker 沙箱容器使用的可选已注册 OCI runtime，例如 `runsc`                    |
+| `STELLA_HOME_HOST`           | `STELLA_HOME` 的宿主机侧路径；仅 `bind` 模式需要                             |
+| `STELLA_HOME_VOLUME`         | `STELLA_HOME` 对应的 Docker named volume 名称；仅 `volume` 模式需要          |
 
 agent 使用 `local` 或 `none` 时，这些变量都不需要。
 

--- a/web/content/docs/guides/sandbox.zh.md
+++ b/web/content/docs/guides/sandbox.zh.md
@@ -39,20 +39,6 @@ Docker 提供完整的容器级进程、文件系统和网络隔离。在受支�
 - **绑定挂载性能**：在 macOS 的 Docker Desktop 上，绑定挂载文件系统操作比原生磁盘慢 5–20 倍。大量读写操作的工作流应避免使用。
 - **无写时复制隔离**：与本地后端（在 Linux 上使用 overlayfs）不同，Docker 后端不提供基于 overlay 的 COW。失控脚本可能修改或损坏已挂载的工作区。
 
-### 高级：自定义部署模式
-
-Docker 如何看到 `STELLA_HOME` 通常由部署入口负责，不是日常需要选择的沙箱选项。`stellad service install` 会注入 `host`，官方 Docker Compose 文件会注入 `volume` 并使用 `stella-data` volume。只有直接启动 `stellad server` 或构建自定义容器部署时，才需要自行设置 `STELLA_DOCKER_SANDBOX_MODE`。
-
-| 模式     | 何时使用                                                | 需要的环境变量                                    |
-| -------- | ------------------------------------------------------- | ------------------------------------------------- |
-| `host`   | stellad 运行在宿主机上（不在容器内）                    | 不需要 `STELLA_HOME_HOST` 和 `STELLA_HOME_VOLUME` |
-| `bind`   | stellad 运行在 Docker 内；`STELLA_HOME` 是 bind mount   | `STELLA_HOME_HOST` = 宿主机侧路径                 |
-| `volume` | stellad 运行在 Docker 内；`STELLA_HOME` 是 named volume | `STELLA_HOME_VOLUME` = volume 名称                |
-
-每种模式都会拒绝属于其他模式的环境变量。例如，`bind` 模式下设置 `STELLA_HOME_VOLUME` 会报错。自定义容器部署必须明确选择 `bind` 或 `volume`；Stella 不会猜测容器路径是否对宿主 Docker daemon 可见。
-
-Volume 模式需要 Docker Engine 25+ 以支持 volume subpath 挂载。
-
 ### OCI Runtime
 
 默认情况下，沙箱容器使用 Docker daemon 的默认开放容器倡议（OCI）runtime，通常是 `runc`。将 `STELLA_DOCKER_RUNTIME` 设为该 daemon 已注册的 runtime，可以选择更强或专用的执行边界：
@@ -67,7 +53,21 @@ STELLA_DOCKER_RUNTIME=runsc
 
 Stella 还会检测 Docker daemon 是否为 rootless。rootful daemon 使用 `stellad` 的 UID/GID 运行沙箱进程；rootless daemon 使用容器 UID/GID `0:0`，它在宿主机上映射为非特权 daemon 用户，并保持该用户的 bind mount 可写。两种模式都会继续丢弃 capabilities 并启用 `no-new-privileges`。预检要求 daemon 明确报告支持内存、swap、CPU quota 和 PID 限制；内存加 swap 的总上限与内存上限相同，均为 2 GiB。Stella 还会拒绝使用 `--ignore-cgroups` 配置的 runtime。Docker `userns-remap` 不受支持，因为它的 bind mount 所有权模型与 rootful、rootless Docker 都不同。
 
-### Docker Compose 示例
+### 自定义部署
+
+标准 service 和 Compose 部署只需要上面的后端和可选 runtime 配置。仅当直接启动 `stellad server` 或构建自定义容器部署时，才需要继续配置本节。
+
+自定义部署必须告诉 Stella Docker daemon 如何看到 `STELLA_HOME`：
+
+| 模式     | 何时使用                                                | 需要的环境变量                                    |
+| -------- | ------------------------------------------------------- | ------------------------------------------------- |
+| `host`   | stellad 运行在宿主机上（不在容器内）                    | 不需要 `STELLA_HOME_HOST` 和 `STELLA_HOME_VOLUME` |
+| `bind`   | stellad 运行在 Docker 内；`STELLA_HOME` 是 bind mount   | `STELLA_HOME_HOST` = 宿主机侧路径                 |
+| `volume` | stellad 运行在 Docker 内；`STELLA_HOME` 是 named volume | `STELLA_HOME_VOLUME` = volume 名称                |
+
+将 `STELLA_DOCKER_SANDBOX_MODE` 设为对应模式。每种模式都会拒绝属于其他模式的变量。自定义容器部署必须明确选择 `bind` 或 `volume`；Stella 不会猜测容器路径是否对宿主 Docker daemon 可见。Volume 模式需要 Docker Engine 25+ 以支持 volume subpath 挂载。
+
+### 自定义 Docker Compose
 
 **容器内使用 `local` 或 `none` 沙箱** — 最简单的部署：
 
@@ -95,6 +95,7 @@ services:
       - ./stella-data:/home/stella/.stella
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
+      - STELLA_SANDBOX_BACKEND=docker
       - STELLA_DOCKER_SANDBOX_MODE=bind
       - STELLA_DOCKER_RUNTIME=runsc # 可选；必须已注册到 Docker
       - STELLA_HOME_HOST=${PWD}/stella-data
@@ -111,6 +112,7 @@ services:
       - stella-data:/home/stella/.stella
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
+      - STELLA_SANDBOX_BACKEND=docker
       - STELLA_DOCKER_SANDBOX_MODE=volume
       - STELLA_DOCKER_RUNTIME=runsc # 可选；必须已注册到 Docker
       - STELLA_HOME_VOLUME=stella-data
@@ -118,18 +120,6 @@ services:
 volumes:
   stella-data:
 ```
-
-### 环境变量
-
-| 变量                         | 描述                                                                         |
-| ---------------------------- | ---------------------------------------------------------------------------- |
-| `STELLA_SANDBOX_BACKEND`     | 部署使用的沙箱后端：`docker`、`local`（默认）或 `none`                       |
-| `STELLA_DOCKER_SANDBOX_MODE` | 部署入口负责的模式：`host`、`bind` 或 `volume`；仅直接或自定义部署需手动设置 |
-| `STELLA_DOCKER_RUNTIME`      | Docker 沙箱容器使用的可选已注册 OCI runtime，例如 `runsc`                    |
-| `STELLA_HOME_HOST`           | `STELLA_HOME` 的宿主机侧路径；仅 `bind` 模式需要                             |
-| `STELLA_HOME_VOLUME`         | `STELLA_HOME` 对应的 Docker named volume 名称；仅 `volume` 模式需要          |
-
-agent 使用 `local` 或 `none` 时，这些变量都不需要。
 
 ## 本地后端
 

--- a/web/content/docs/guides/sandbox.zh.md
+++ b/web/content/docs/guides/sandbox.zh.md
@@ -65,6 +65,8 @@ STELLA_DOCKER_RUNTIME=runsc
 
 替代 OCI runtime 可以减少宿主内核暴露面，但不会限制网络出口，也不会保护可写挂载。沙箱网络策略和挂载权限仍需独立收紧。
 
+Stella 还会检测 Docker daemon 是否为 rootless。rootful daemon 使用 `stellad` 的 UID/GID 运行沙箱进程；rootless daemon 使用容器 UID/GID `0:0`，它在宿主机上映射为非特权 daemon 用户，并保持该用户的 bind mount 可写。两种模式都会继续丢弃 capabilities 并启用 `no-new-privileges`。如果 rootless daemon 没有 cgroup driver，Stella 会在预检时拒绝启动，因为此时无法执行 CPU、内存和 PID 限制；生产环境不要为 gVisor 配置 `--ignore-cgroups`。
+
 ### Docker Compose 示例
 
 **容器内使用 `local` 或 `none` 沙箱** — 最简单的部署：

--- a/web/content/docs/start-here/configuration.md
+++ b/web/content/docs/start-here/configuration.md
@@ -106,25 +106,23 @@ All data lives under `~/.stella` (configurable via `STELLA_HOME`):
 
 Only a small set of environment variables is recognized:
 
-| Variable                      | Description                                                                                                           |
-| ----------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `STELLA_HOME`                 | Override the home directory (default `~/.stella`)                                                                     |
-| `STELLA_DATABASE_URL`         | Use an external PostgreSQL database instead of the embedded cluster                                                   |
-| `STELLA_BLOB_S3_ENDPOINT`     | Optional S3-compatible endpoint for immutable BlobStore data                                                          |
-| `STELLA_BLOB_S3_BUCKET`       | Bucket for immutable BlobStore data; set with endpoint/access/secret or leave all unset                               |
-| `STELLA_BLOB_S3_ACCESS_KEY`   | Access key for immutable BlobStore data                                                                               |
-| `STELLA_BLOB_S3_SECRET_KEY`   | Secret key for immutable BlobStore data                                                                               |
-| `STELLA_BLOB_S3_REGION`       | Optional S3 region                                                                                                    |
-| `STELLA_BLOB_S3_USE_SSL`      | Use HTTPS for S3-compatible storage; defaults to `true`                                                               |
-| `STELLA_VAULT_KEY`            | Master key for the [secret vault](/docs/guides/secrets-and-keys) — required for secrets, OAuth, and bearer tokens     |
-| `STELLA_DOCKER_SANDBOX_MODE`  | Deployment-owned Docker home mode; service install and official Compose set it, direct/custom deployments must set it |
-| `STELLA_DOCKER_RUNTIME`       | Optional registered OCI runtime for Docker sandboxes, such as gVisor's `runsc`; unavailable values fail preflight     |
-| `STELLA_HOME_HOST`            | Host-side path for `STELLA_HOME`; required only when `STELLA_DOCKER_SANDBOX_MODE=bind`                                |
-| `STELLA_HOME_VOLUME`          | Docker named volume for `STELLA_HOME`; required only when `STELLA_DOCKER_SANDBOX_MODE=volume`                         |
-| `STELLA_REFLECT_CURATOR_MODE` | Lifecycle curator: `armed` (default) or non-mutating emergency-stop mode `shadow`                                     |
+| Variable                      | Description                                                                                                       |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `STELLA_HOME`                 | Override the home directory (default `~/.stella`)                                                                 |
+| `STELLA_DATABASE_URL`         | Use an external PostgreSQL database instead of the embedded cluster                                               |
+| `STELLA_BLOB_S3_ENDPOINT`     | Optional S3-compatible endpoint for immutable BlobStore data                                                      |
+| `STELLA_BLOB_S3_BUCKET`       | Bucket for immutable BlobStore data; set with endpoint/access/secret or leave all unset                           |
+| `STELLA_BLOB_S3_ACCESS_KEY`   | Access key for immutable BlobStore data                                                                           |
+| `STELLA_BLOB_S3_SECRET_KEY`   | Secret key for immutable BlobStore data                                                                           |
+| `STELLA_BLOB_S3_REGION`       | Optional S3 region                                                                                                |
+| `STELLA_BLOB_S3_USE_SSL`      | Use HTTPS for S3-compatible storage; defaults to `true`                                                           |
+| `STELLA_VAULT_KEY`            | Master key for the [secret vault](/docs/guides/secrets-and-keys) — required for secrets, OAuth, and bearer tokens |
+| `STELLA_SANDBOX_BACKEND`      | Sandbox backend: `docker`, `local` (default), or `none`                                                           |
+| `STELLA_DOCKER_RUNTIME`       | Optional registered OCI runtime for Docker sandboxes, such as gVisor's `runsc`; unavailable values fail preflight |
+| `STELLA_REFLECT_CURATOR_MODE` | Lifecycle curator: `armed` (default) or non-mutating emergency-stop mode `shadow`                                 |
 
 Structured Reflect is the only writer. Curator mode is read at server startup, so restart Stella after changing it. Invalid curator modes stop startup. See [Deployment](/docs/start-here/deployment#structured-reflect-and-curator) for operational checks and [Memory internals](/docs/development/memory-internals#structured-reflect-and-curator) for the detailed mechanism.
 
-See the [Sandbox guide](/docs/guides/sandbox) to choose a sandbox backend. Standard service and Compose deployments already own their Docker home mode; the guide documents manual and custom deployments separately.
+See the [Sandbox guide](/docs/guides/sandbox) to choose a backend and optional OCI runtime. Custom deployment details are documented separately in that guide.
 
 All other configuration is managed through the Web UI.

--- a/web/content/docs/start-here/configuration.md
+++ b/web/content/docs/start-here/configuration.md
@@ -118,6 +118,7 @@ Only a small set of environment variables is recognized:
 | `STELLA_BLOB_S3_USE_SSL`      | Use HTTPS for S3-compatible storage; defaults to `true`                                                           |
 | `STELLA_VAULT_KEY`            | Master key for the [secret vault](/docs/guides/secrets-and-keys) — required for secrets, OAuth, and bearer tokens |
 | `STELLA_DOCKER_SANDBOX_MODE`  | Required only for the `docker` sandbox backend: `host`, `bind`, or `volume`                                       |
+| `STELLA_DOCKER_RUNTIME`       | Optional registered OCI runtime for Docker sandboxes, such as gVisor's `runsc`; unavailable values fail preflight |
 | `STELLA_HOME_HOST`            | Host-side path for `STELLA_HOME`; required only when `STELLA_DOCKER_SANDBOX_MODE=bind`                            |
 | `STELLA_HOME_VOLUME`          | Docker named volume for `STELLA_HOME`; required only when `STELLA_DOCKER_SANDBOX_MODE=volume`                     |
 | `STELLA_REFLECT_CURATOR_MODE` | Lifecycle curator: `armed` (default) or non-mutating emergency-stop mode `shadow`                                 |

--- a/web/content/docs/start-here/configuration.md
+++ b/web/content/docs/start-here/configuration.md
@@ -106,25 +106,25 @@ All data lives under `~/.stella` (configurable via `STELLA_HOME`):
 
 Only a small set of environment variables is recognized:
 
-| Variable                      | Description                                                                                                       |
-| ----------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `STELLA_HOME`                 | Override the home directory (default `~/.stella`)                                                                 |
-| `STELLA_DATABASE_URL`         | Use an external PostgreSQL database instead of the embedded cluster                                               |
-| `STELLA_BLOB_S3_ENDPOINT`     | Optional S3-compatible endpoint for immutable BlobStore data                                                      |
-| `STELLA_BLOB_S3_BUCKET`       | Bucket for immutable BlobStore data; set with endpoint/access/secret or leave all unset                           |
-| `STELLA_BLOB_S3_ACCESS_KEY`   | Access key for immutable BlobStore data                                                                           |
-| `STELLA_BLOB_S3_SECRET_KEY`   | Secret key for immutable BlobStore data                                                                           |
-| `STELLA_BLOB_S3_REGION`       | Optional S3 region                                                                                                |
-| `STELLA_BLOB_S3_USE_SSL`      | Use HTTPS for S3-compatible storage; defaults to `true`                                                           |
-| `STELLA_VAULT_KEY`            | Master key for the [secret vault](/docs/guides/secrets-and-keys) — required for secrets, OAuth, and bearer tokens |
-| `STELLA_DOCKER_SANDBOX_MODE`  | Required only for the `docker` sandbox backend: `host`, `bind`, or `volume`                                       |
-| `STELLA_DOCKER_RUNTIME`       | Optional registered OCI runtime for Docker sandboxes, such as gVisor's `runsc`; unavailable values fail preflight |
-| `STELLA_HOME_HOST`            | Host-side path for `STELLA_HOME`; required only when `STELLA_DOCKER_SANDBOX_MODE=bind`                            |
-| `STELLA_HOME_VOLUME`          | Docker named volume for `STELLA_HOME`; required only when `STELLA_DOCKER_SANDBOX_MODE=volume`                     |
-| `STELLA_REFLECT_CURATOR_MODE` | Lifecycle curator: `armed` (default) or non-mutating emergency-stop mode `shadow`                                 |
+| Variable                      | Description                                                                                                           |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `STELLA_HOME`                 | Override the home directory (default `~/.stella`)                                                                     |
+| `STELLA_DATABASE_URL`         | Use an external PostgreSQL database instead of the embedded cluster                                                   |
+| `STELLA_BLOB_S3_ENDPOINT`     | Optional S3-compatible endpoint for immutable BlobStore data                                                          |
+| `STELLA_BLOB_S3_BUCKET`       | Bucket for immutable BlobStore data; set with endpoint/access/secret or leave all unset                               |
+| `STELLA_BLOB_S3_ACCESS_KEY`   | Access key for immutable BlobStore data                                                                               |
+| `STELLA_BLOB_S3_SECRET_KEY`   | Secret key for immutable BlobStore data                                                                               |
+| `STELLA_BLOB_S3_REGION`       | Optional S3 region                                                                                                    |
+| `STELLA_BLOB_S3_USE_SSL`      | Use HTTPS for S3-compatible storage; defaults to `true`                                                               |
+| `STELLA_VAULT_KEY`            | Master key for the [secret vault](/docs/guides/secrets-and-keys) — required for secrets, OAuth, and bearer tokens     |
+| `STELLA_DOCKER_SANDBOX_MODE`  | Deployment-owned Docker home mode; service install and official Compose set it, direct/custom deployments must set it |
+| `STELLA_DOCKER_RUNTIME`       | Optional registered OCI runtime for Docker sandboxes, such as gVisor's `runsc`; unavailable values fail preflight     |
+| `STELLA_HOME_HOST`            | Host-side path for `STELLA_HOME`; required only when `STELLA_DOCKER_SANDBOX_MODE=bind`                                |
+| `STELLA_HOME_VOLUME`          | Docker named volume for `STELLA_HOME`; required only when `STELLA_DOCKER_SANDBOX_MODE=volume`                         |
+| `STELLA_REFLECT_CURATOR_MODE` | Lifecycle curator: `armed` (default) or non-mutating emergency-stop mode `shadow`                                     |
 
 Structured Reflect is the only writer. Curator mode is read at server startup, so restart Stella after changing it. Invalid curator modes stop startup. See [Deployment](/docs/start-here/deployment#structured-reflect-and-curator) for operational checks and [Memory internals](/docs/development/memory-internals#structured-reflect-and-curator) for the detailed mechanism.
 
-See the [Sandbox guide](/docs/guides/sandbox) for how to choose a sandbox backend and configure Docker sandbox modes.
+See the [Sandbox guide](/docs/guides/sandbox) to choose a sandbox backend. Standard service and Compose deployments already own their Docker home mode; the guide documents manual and custom deployments separately.
 
 All other configuration is managed through the Web UI.

--- a/web/content/docs/start-here/configuration.zh.md
+++ b/web/content/docs/start-here/configuration.zh.md
@@ -97,25 +97,25 @@ Runner 控制代理如何处理消息。你可以在Web UI的 **设置** 页面�
 
 仅识别少量环境变量：
 
-| 变量                          | 描述                                                                                     |
-| ----------------------------- | ---------------------------------------------------------------------------------------- |
-| `STELLA_HOME`                 | 覆盖主目录（默认 `~/.stella`）                                                           |
-| `STELLA_DATABASE_URL`         | 使用外部 PostgreSQL 数据库，而不是内嵌集群                                               |
-| `STELLA_BLOB_S3_ENDPOINT`     | 可选的 S3 兼容 endpoint，用于 immutable BlobStore 数据                                   |
-| `STELLA_BLOB_S3_BUCKET`       | immutable BlobStore 数据的 bucket；需与 endpoint/access/secret 同时设置，或全部不设置    |
-| `STELLA_BLOB_S3_ACCESS_KEY`   | immutable BlobStore 数据使用的 access key                                                |
-| `STELLA_BLOB_S3_SECRET_KEY`   | immutable BlobStore 数据使用的 secret key                                                |
-| `STELLA_BLOB_S3_REGION`       | 可选 S3 region                                                                           |
-| `STELLA_BLOB_S3_USE_SSL`      | S3 兼容存储是否使用 HTTPS；默认 `true`                                                   |
-| `STELLA_VAULT_KEY`            | [密钥库](/docs/guides/secrets-and-keys)的主密钥 — 密钥管理、OAuth 和 Bearer Token 所必需 |
-| `STELLA_DOCKER_SANDBOX_MODE`  | 仅 `docker` 沙箱后端需要：`host`、`bind` 或 `volume`                                     |
-| `STELLA_DOCKER_RUNTIME`       | Docker 沙箱使用的可选已注册 OCI runtime，例如 gVisor 的 `runsc`；不可用时预检失败        |
-| `STELLA_HOME_HOST`            | `STELLA_HOME` 的宿主机侧路径；仅 `STELLA_DOCKER_SANDBOX_MODE=bind` 时需要                |
-| `STELLA_HOME_VOLUME`          | `STELLA_HOME` 的 Docker named volume 名称；仅 `STELLA_DOCKER_SANDBOX_MODE=volume` 时需要 |
-| `STELLA_REFLECT_CURATOR_MODE` | 生命周期 curator：`armed`（默认值）或不产生写入的紧急停止模式 `shadow`                   |
+| 变量                          | 描述                                                                                                 |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `STELLA_HOME`                 | 覆盖主目录（默认 `~/.stella`）                                                                       |
+| `STELLA_DATABASE_URL`         | 使用外部 PostgreSQL 数据库，而不是内嵌集群                                                           |
+| `STELLA_BLOB_S3_ENDPOINT`     | 可选的 S3 兼容 endpoint，用于 immutable BlobStore 数据                                               |
+| `STELLA_BLOB_S3_BUCKET`       | immutable BlobStore 数据的 bucket；需与 endpoint/access/secret 同时设置，或全部不设置                |
+| `STELLA_BLOB_S3_ACCESS_KEY`   | immutable BlobStore 数据使用的 access key                                                            |
+| `STELLA_BLOB_S3_SECRET_KEY`   | immutable BlobStore 数据使用的 secret key                                                            |
+| `STELLA_BLOB_S3_REGION`       | 可选 S3 region                                                                                       |
+| `STELLA_BLOB_S3_USE_SSL`      | S3 兼容存储是否使用 HTTPS；默认 `true`                                                               |
+| `STELLA_VAULT_KEY`            | [密钥库](/docs/guides/secrets-and-keys)的主密钥 — 密钥管理、OAuth 和 Bearer Token 所必需             |
+| `STELLA_DOCKER_SANDBOX_MODE`  | 部署入口负责的 Docker home 模式；service install 和官方 Compose 会设置，直接或自定义部署必须自行设置 |
+| `STELLA_DOCKER_RUNTIME`       | Docker 沙箱使用的可选已注册 OCI runtime，例如 gVisor 的 `runsc`；不可用时预检失败                    |
+| `STELLA_HOME_HOST`            | `STELLA_HOME` 的宿主机侧路径；仅 `STELLA_DOCKER_SANDBOX_MODE=bind` 时需要                            |
+| `STELLA_HOME_VOLUME`          | `STELLA_HOME` 的 Docker named volume 名称；仅 `STELLA_DOCKER_SANDBOX_MODE=volume` 时需要             |
+| `STELLA_REFLECT_CURATOR_MODE` | 生命周期 curator：`armed`（默认值）或不产生写入的紧急停止模式 `shadow`                               |
 
 Structured Reflect 是唯一写入器。Curator 模式在服务启动时读取，修改后需要重启 Stella；非法值会阻止启动。运行检查见[部署](/docs/start-here/deployment#structured-reflect-与-curator)，详细机制见[记忆系统内部原理](/docs/development/memory-internals#structured-reflect-与-curator)。
 
-有关如何选择沙箱后端和配置 Docker 沙箱模式，请参阅[沙箱指南](/docs/guides/sandbox)。
+请参阅[沙箱指南](/docs/guides/sandbox)选择沙箱后端。标准 service 和 Compose 部署已负责 Docker home 模式；指南会单独说明直接和自定义部署。
 
 所有其他配置通过Web UI进行管理。

--- a/web/content/docs/start-here/configuration.zh.md
+++ b/web/content/docs/start-here/configuration.zh.md
@@ -97,25 +97,23 @@ Runner 控制代理如何处理消息。你可以在Web UI的 **设置** 页面�
 
 仅识别少量环境变量：
 
-| 变量                          | 描述                                                                                                 |
-| ----------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `STELLA_HOME`                 | 覆盖主目录（默认 `~/.stella`）                                                                       |
-| `STELLA_DATABASE_URL`         | 使用外部 PostgreSQL 数据库，而不是内嵌集群                                                           |
-| `STELLA_BLOB_S3_ENDPOINT`     | 可选的 S3 兼容 endpoint，用于 immutable BlobStore 数据                                               |
-| `STELLA_BLOB_S3_BUCKET`       | immutable BlobStore 数据的 bucket；需与 endpoint/access/secret 同时设置，或全部不设置                |
-| `STELLA_BLOB_S3_ACCESS_KEY`   | immutable BlobStore 数据使用的 access key                                                            |
-| `STELLA_BLOB_S3_SECRET_KEY`   | immutable BlobStore 数据使用的 secret key                                                            |
-| `STELLA_BLOB_S3_REGION`       | 可选 S3 region                                                                                       |
-| `STELLA_BLOB_S3_USE_SSL`      | S3 兼容存储是否使用 HTTPS；默认 `true`                                                               |
-| `STELLA_VAULT_KEY`            | [密钥库](/docs/guides/secrets-and-keys)的主密钥 — 密钥管理、OAuth 和 Bearer Token 所必需             |
-| `STELLA_DOCKER_SANDBOX_MODE`  | 部署入口负责的 Docker home 模式；service install 和官方 Compose 会设置，直接或自定义部署必须自行设置 |
-| `STELLA_DOCKER_RUNTIME`       | Docker 沙箱使用的可选已注册 OCI runtime，例如 gVisor 的 `runsc`；不可用时预检失败                    |
-| `STELLA_HOME_HOST`            | `STELLA_HOME` 的宿主机侧路径；仅 `STELLA_DOCKER_SANDBOX_MODE=bind` 时需要                            |
-| `STELLA_HOME_VOLUME`          | `STELLA_HOME` 的 Docker named volume 名称；仅 `STELLA_DOCKER_SANDBOX_MODE=volume` 时需要             |
-| `STELLA_REFLECT_CURATOR_MODE` | 生命周期 curator：`armed`（默认值）或不产生写入的紧急停止模式 `shadow`                               |
+| 变量                          | 描述                                                                                     |
+| ----------------------------- | ---------------------------------------------------------------------------------------- |
+| `STELLA_HOME`                 | 覆盖主目录（默认 `~/.stella`）                                                           |
+| `STELLA_DATABASE_URL`         | 使用外部 PostgreSQL 数据库，而不是内嵌集群                                               |
+| `STELLA_BLOB_S3_ENDPOINT`     | 可选的 S3 兼容 endpoint，用于 immutable BlobStore 数据                                   |
+| `STELLA_BLOB_S3_BUCKET`       | immutable BlobStore 数据的 bucket；需与 endpoint/access/secret 同时设置，或全部不设置    |
+| `STELLA_BLOB_S3_ACCESS_KEY`   | immutable BlobStore 数据使用的 access key                                                |
+| `STELLA_BLOB_S3_SECRET_KEY`   | immutable BlobStore 数据使用的 secret key                                                |
+| `STELLA_BLOB_S3_REGION`       | 可选 S3 region                                                                           |
+| `STELLA_BLOB_S3_USE_SSL`      | S3 兼容存储是否使用 HTTPS；默认 `true`                                                   |
+| `STELLA_VAULT_KEY`            | [密钥库](/docs/guides/secrets-and-keys)的主密钥 — 密钥管理、OAuth 和 Bearer Token 所必需 |
+| `STELLA_SANDBOX_BACKEND`      | 沙箱后端：`docker`、`local`（默认）或 `none`                                             |
+| `STELLA_DOCKER_RUNTIME`       | Docker 沙箱使用的可选已注册 OCI runtime，例如 gVisor 的 `runsc`；不可用时预检失败        |
+| `STELLA_REFLECT_CURATOR_MODE` | 生命周期 curator：`armed`（默认值）或不产生写入的紧急停止模式 `shadow`                   |
 
 Structured Reflect 是唯一写入器。Curator 模式在服务启动时读取，修改后需要重启 Stella；非法值会阻止启动。运行检查见[部署](/docs/start-here/deployment#structured-reflect-与-curator)，详细机制见[记忆系统内部原理](/docs/development/memory-internals#structured-reflect-与-curator)。
 
-请参阅[沙箱指南](/docs/guides/sandbox)选择沙箱后端。标准 service 和 Compose 部署已负责 Docker home 模式；指南会单独说明直接和自定义部署。
+请参阅[沙箱指南](/docs/guides/sandbox)选择沙箱后端和可选 OCI runtime。自定义部署细节在该指南中单独说明。
 
 所有其他配置通过Web UI进行管理。

--- a/web/content/docs/start-here/configuration.zh.md
+++ b/web/content/docs/start-here/configuration.zh.md
@@ -109,6 +109,7 @@ Runner 控制代理如何处理消息。你可以在Web UI的 **设置** 页面�
 | `STELLA_BLOB_S3_USE_SSL`      | S3 兼容存储是否使用 HTTPS；默认 `true`                                                   |
 | `STELLA_VAULT_KEY`            | [密钥库](/docs/guides/secrets-and-keys)的主密钥 — 密钥管理、OAuth 和 Bearer Token 所必需 |
 | `STELLA_DOCKER_SANDBOX_MODE`  | 仅 `docker` 沙箱后端需要：`host`、`bind` 或 `volume`                                     |
+| `STELLA_DOCKER_RUNTIME`       | Docker 沙箱使用的可选已注册 OCI runtime，例如 gVisor 的 `runsc`；不可用时预检失败        |
 | `STELLA_HOME_HOST`            | `STELLA_HOME` 的宿主机侧路径；仅 `STELLA_DOCKER_SANDBOX_MODE=bind` 时需要                |
 | `STELLA_HOME_VOLUME`          | `STELLA_HOME` 的 Docker named volume 名称；仅 `STELLA_DOCKER_SANDBOX_MODE=volume` 时需要 |
 | `STELLA_REFLECT_CURATOR_MODE` | 生命周期 curator：`armed`（默认值）或不产生写入的紧急停止模式 `shadow`                   |

--- a/web/content/docs/start-here/deployment.md
+++ b/web/content/docs/start-here/deployment.md
@@ -139,7 +139,7 @@ stellad service restart
 stellad service uninstall
 ```
 
-Logs are written to `~/Library/Logs/stella/stella.log`. The agent starts automatically on login and restarts on crash. The generated LaunchAgent pins Docker sandbox mode to `host`; if you enable the Docker backend, you only choose the optional OCI runtime.
+Logs are written to `~/Library/Logs/stella/stella.log`. The agent starts automatically on login and restarts on crash.
 
 ### Linux — systemd user mode (no root required)
 
@@ -168,7 +168,7 @@ stellad service logs --follow
 sudo stellad service uninstall --system
 ```
 
-The unit file is installed to `/etc/systemd/system/stella.service`. The generated service pins Docker sandbox mode to `host`.
+The unit file is installed to `/etc/systemd/system/stella.service`.
 
 ## Docker
 
@@ -229,7 +229,7 @@ services:
       - STELLA_DATABASE_URL=postgres://user:pass@postgres.example.com:5432/stella?sslmode=require
 ```
 
-The `seccomp=unconfined` flag is needed for the `local` sandbox backend (bubblewrap). The official Compose file already configures the Docker socket and volume mode for the `docker` sandbox backend; see the [Sandbox guide](/docs/guides/sandbox#docker-compose-examples) for custom Compose deployments.
+The `seccomp=unconfined` flag is needed for the `local` sandbox backend (bubblewrap). The official Compose file already configures the Docker socket for the `docker` sandbox backend; see the [Sandbox guide](/docs/guides/sandbox#custom-docker-compose) for custom Compose deployments.
 
 ```bash
 docker compose up -d
@@ -341,7 +341,7 @@ terminationGracePeriodSeconds: 200
 
 ## Sandbox Backends
 
-Running Stella inside a Docker container (described above) is separate from using Docker as a sandbox backend for agent tool execution. Stella supports three sandbox backends: `docker`, `local`, and `none`. Standard service and Compose deployments already select the correct Docker home mode. See the [Sandbox guide](/docs/guides/sandbox) to choose a backend, select an optional OCI runtime, or configure a direct/custom deployment.
+Running Stella inside a Docker container (described above) is separate from using Docker as a sandbox backend for agent tool execution. Stella supports three sandbox backends: `docker`, `local`, and `none`. See the [Sandbox guide](/docs/guides/sandbox) to choose a backend and optional OCI runtime.
 
 ## Volumes & Data
 
@@ -379,14 +379,12 @@ Configuration is managed through the Web UI (default `http://localhost:25678`; u
 | `STELLA_BLOB_S3_REGION`          | No                        | Optional S3 region                                                                                                                                                            |
 | `STELLA_BLOB_S3_USE_SSL`         | No                        | Use HTTPS for S3-compatible storage; defaults to `true`                                                                                                                       |
 | `STELLA_VAULT_KEY`               | Yes†                      | age secret key for the vault — required for secrets, OAuth, and bearer tokens                                                                                                 |
-| `STELLA_DOCKER_SANDBOX_MODE`     | No‡                       | Deployment-owned Docker home mode; service install and official Compose set it, direct/custom deployments must set it                                                         |
+| `STELLA_SANDBOX_BACKEND`         | No                        | Sandbox backend: `docker`, `local` (default), or `none`                                                                                                                       |
 | `STELLA_DOCKER_RUNTIME`          | No‡                       | Registered OCI runtime for Docker sandbox and tool-cache containers; unset uses the daemon default, unavailable configured values fail preflight                              |
-| `STELLA_HOME_HOST`               | No‡                       | Host-side path backing `STELLA_HOME` — required only when `STELLA_DOCKER_SANDBOX_MODE=bind`                                                                                   |
-| `STELLA_HOME_VOLUME`             | No‡                       | Docker named volume backing `STELLA_HOME` — required only when `STELLA_DOCKER_SANDBOX_MODE=volume`                                                                            |
 
 † Without `STELLA_VAULT_KEY`, vault endpoints return `503`, OAuth tokens cannot be issued, and plugin secrets are not injected. Generate a key with `age-keygen`.
 
-‡ Relevant only when agents use the `docker` sandbox backend. Standard service and Compose deployments set the mode. For direct/custom deployments, use `host` when stellad runs on the host, `bind` for a containerized host bind mount, and `volume` for a Docker named volume.
+‡ Relevant only when agents use the `docker` sandbox backend.
 
 § Set all four required S3 variables together, or leave all unset. Partial blob-store configuration fails startup. Mutable assets never require these variables.
 

--- a/web/content/docs/start-here/deployment.md
+++ b/web/content/docs/start-here/deployment.md
@@ -139,7 +139,7 @@ stellad service restart
 stellad service uninstall
 ```
 
-Logs are written to `~/Library/Logs/stella/stella.log`. The agent starts automatically on login and restarts on crash.
+Logs are written to `~/Library/Logs/stella/stella.log`. The agent starts automatically on login and restarts on crash. The generated LaunchAgent pins Docker sandbox mode to `host`; if you enable the Docker backend, you only choose the optional OCI runtime.
 
 ### Linux — systemd user mode (no root required)
 
@@ -168,7 +168,7 @@ stellad service logs --follow
 sudo stellad service uninstall --system
 ```
 
-The unit file is installed to `/etc/systemd/system/stella.service`.
+The unit file is installed to `/etc/systemd/system/stella.service`. The generated service pins Docker sandbox mode to `host`.
 
 ## Docker
 
@@ -229,7 +229,7 @@ services:
       - STELLA_DATABASE_URL=postgres://user:pass@postgres.example.com:5432/stella?sslmode=require
 ```
 
-The `seccomp=unconfined` flag is needed for the `local` sandbox backend (bubblewrap). If agents use the `docker` sandbox backend, you need additional Docker socket mounts and mode-specific environment variables — see the [Sandbox guide](/docs/guides/sandbox#docker-compose-examples) for all compose variants.
+The `seccomp=unconfined` flag is needed for the `local` sandbox backend (bubblewrap). The official Compose file already configures the Docker socket and volume mode for the `docker` sandbox backend; see the [Sandbox guide](/docs/guides/sandbox#docker-compose-examples) for custom Compose deployments.
 
 ```bash
 docker compose up -d
@@ -341,7 +341,7 @@ terminationGracePeriodSeconds: 200
 
 ## Sandbox Backends
 
-Running Stella inside a Docker container (described above) is separate from using Docker as a sandbox backend for agent tool execution. Stella supports three sandbox backends: `docker`, `local`, and `none`. See the [Sandbox guide](/docs/guides/sandbox) for how to choose a backend, configure Docker sandbox modes, and troubleshoot common issues.
+Running Stella inside a Docker container (described above) is separate from using Docker as a sandbox backend for agent tool execution. Stella supports three sandbox backends: `docker`, `local`, and `none`. Standard service and Compose deployments already select the correct Docker home mode. See the [Sandbox guide](/docs/guides/sandbox) to choose a backend, select an optional OCI runtime, or configure a direct/custom deployment.
 
 ## Volumes & Data
 
@@ -379,14 +379,14 @@ Configuration is managed through the Web UI (default `http://localhost:25678`; u
 | `STELLA_BLOB_S3_REGION`          | No                        | Optional S3 region                                                                                                                                                            |
 | `STELLA_BLOB_S3_USE_SSL`         | No                        | Use HTTPS for S3-compatible storage; defaults to `true`                                                                                                                       |
 | `STELLA_VAULT_KEY`               | Yes†                      | age secret key for the vault — required for secrets, OAuth, and bearer tokens                                                                                                 |
-| `STELLA_DOCKER_SANDBOX_MODE`     | No‡                       | Required only for the `docker` sandbox backend: `host`, `bind`, or `volume`                                                                                                   |
+| `STELLA_DOCKER_SANDBOX_MODE`     | No‡                       | Deployment-owned Docker home mode; service install and official Compose set it, direct/custom deployments must set it                                                         |
 | `STELLA_DOCKER_RUNTIME`          | No‡                       | Registered OCI runtime for Docker sandbox and tool-cache containers; unset uses the daemon default, unavailable configured values fail preflight                              |
 | `STELLA_HOME_HOST`               | No‡                       | Host-side path backing `STELLA_HOME` — required only when `STELLA_DOCKER_SANDBOX_MODE=bind`                                                                                   |
 | `STELLA_HOME_VOLUME`             | No‡                       | Docker named volume backing `STELLA_HOME` — required only when `STELLA_DOCKER_SANDBOX_MODE=volume`                                                                            |
 
 † Without `STELLA_VAULT_KEY`, vault endpoints return `503`, OAuth tokens cannot be issued, and plugin secrets are not injected. Generate a key with `age-keygen`.
 
-‡ Required only when agents use the `docker` sandbox backend. Use `host` when stellad runs on the host, `bind` when stellad runs in Docker with a host bind mount, and `volume` when stellad runs in Docker with a named volume.
+‡ Relevant only when agents use the `docker` sandbox backend. Standard service and Compose deployments set the mode. For direct/custom deployments, use `host` when stellad runs on the host, `bind` for a containerized host bind mount, and `volume` for a Docker named volume.
 
 § Set all four required S3 variables together, or leave all unset. Partial blob-store configuration fails startup. Mutable assets never require these variables.
 

--- a/web/content/docs/start-here/deployment.md
+++ b/web/content/docs/start-here/deployment.md
@@ -380,6 +380,7 @@ Configuration is managed through the Web UI (default `http://localhost:25678`; u
 | `STELLA_BLOB_S3_USE_SSL`         | No                        | Use HTTPS for S3-compatible storage; defaults to `true`                                                                                                                       |
 | `STELLA_VAULT_KEY`               | Yes†                      | age secret key for the vault — required for secrets, OAuth, and bearer tokens                                                                                                 |
 | `STELLA_DOCKER_SANDBOX_MODE`     | No‡                       | Required only for the `docker` sandbox backend: `host`, `bind`, or `volume`                                                                                                   |
+| `STELLA_DOCKER_RUNTIME`          | No‡                       | Registered OCI runtime for Docker sandbox and tool-cache containers; unset uses the daemon default, unavailable configured values fail preflight                              |
 | `STELLA_HOME_HOST`               | No‡                       | Host-side path backing `STELLA_HOME` — required only when `STELLA_DOCKER_SANDBOX_MODE=bind`                                                                                   |
 | `STELLA_HOME_VOLUME`             | No‡                       | Docker named volume backing `STELLA_HOME` — required only when `STELLA_DOCKER_SANDBOX_MODE=volume`                                                                            |
 

--- a/web/content/docs/start-here/deployment.zh.md
+++ b/web/content/docs/start-here/deployment.zh.md
@@ -128,7 +128,7 @@ stellad service restart
 stellad service uninstall
 ```
 
-日志写入 `~/Library/Logs/stella/stella.log`。agent 在登录时自动启动，崩溃后自动重启。生成的 LaunchAgent 会将 Docker 沙箱模式固定为 `host`；启用 Docker 后端时，你只需选择可选的 OCI runtime。
+日志写入 `~/Library/Logs/stella/stella.log`。agent 在登录时自动启动，崩溃后自动重启。
 
 ### Linux — systemd 用户模式（无需 root）
 
@@ -157,7 +157,7 @@ stellad service logs --follow
 sudo stellad service uninstall --system
 ```
 
-Unit 文件安装至 `/etc/systemd/system/stella.service`。生成的 service 会将 Docker 沙箱模式固定为 `host`。
+Unit 文件安装至 `/etc/systemd/system/stella.service`。
 
 ## Docker
 
@@ -218,7 +218,7 @@ services:
       - STELLA_DATABASE_URL=postgres://user:pass@postgres.example.com:5432/stella?sslmode=require
 ```
 
-`seccomp=unconfined` 标志是 `local` 沙箱后端（bubblewrap）所必需的。官方 Compose 已为 `docker` 沙箱后端配置 Docker socket 和 volume 模式；自定义 Compose 请参阅[沙箱指南](/docs/guides/sandbox#docker-compose-示例)。
+`seccomp=unconfined` 标志是 `local` 沙箱后端（bubblewrap）所必需的。官方 Compose 已为 `docker` 沙箱后端配置 Docker socket；自定义 Compose 请参阅[沙箱指南](/docs/guides/sandbox#自定义-docker-compose)。
 
 ```bash
 docker compose up -d
@@ -330,7 +330,7 @@ terminationGracePeriodSeconds: 200
 
 ## 沙箱后端
 
-将 Stella 运行在 Docker 容器中（见上文）与使用 Docker 作为 agent 工具执行的沙箱后端是两件独立的事。Stella 支持三种沙箱后端：`docker`、`local` 和 `none`。标准 service 和 Compose 部署已选择正确的 Docker home 模式。请参阅[沙箱指南](/docs/guides/sandbox)选择后端和可选 OCI runtime，或配置直接、自定义部署。
+将 Stella 运行在 Docker 容器中（见上文）与使用 Docker 作为 agent 工具执行的沙箱后端是两件独立的事。Stella 支持三种沙箱后端：`docker`、`local` 和 `none`。请参阅[沙箱指南](/docs/guides/sandbox)选择后端和可选 OCI runtime。
 
 ## 卷和数据
 
@@ -368,14 +368,12 @@ terminationGracePeriodSeconds: 200
 | `STELLA_BLOB_S3_REGION`          | 否                        | 可选 S3 region                                                                                                         |
 | `STELLA_BLOB_S3_USE_SSL`         | 否                        | S3 兼容存储是否使用 HTTPS；默认 `true`                                                                                 |
 | `STELLA_VAULT_KEY`               | 是†                       | 密钥库使用的 age 私钥 —— 密钥管理、OAuth 和 Bearer Token 所必需                                                        |
-| `STELLA_DOCKER_SANDBOX_MODE`     | 否‡                       | 部署入口负责的 Docker home 模式；service install 和官方 Compose 会设置，直接或自定义部署必须自行设置                   |
+| `STELLA_SANDBOX_BACKEND`         | 否                        | 沙箱后端：`docker`、`local`（默认）或 `none`                                                                           |
 | `STELLA_DOCKER_RUNTIME`          | 否‡                       | Docker 沙箱和工具缓存容器使用的已注册 OCI runtime；未设置时使用 daemon 默认值，配置值不可用时预检失败                  |
-| `STELLA_HOME_HOST`               | 否‡                       | `STELLA_HOME` 的宿主机侧路径；仅 `STELLA_DOCKER_SANDBOX_MODE=bind` 时需要                                              |
-| `STELLA_HOME_VOLUME`             | 否‡                       | `STELLA_HOME` 的 Docker named volume 名称；仅 `STELLA_DOCKER_SANDBOX_MODE=volume` 时需要                               |
 
 † 未设置 `STELLA_VAULT_KEY` 时，密钥库接口返回 `503`，无法签发 OAuth Token，插件密钥也不会被注入。使用 `age-keygen` 生成密钥。
 
-‡ 仅当 agent 使用 `docker` 沙箱后端时相关。标准 service 和 Compose 部署会设置模式。直接或自定义部署中，stellad 在宿主机上运行用 `host`；容器化 host bind mount 用 `bind`；Docker named volume 用 `volume`。
+‡ 仅当 agent 使用 `docker` 沙箱后端时相关。
 
 § 四个必需的 S3 变量必须同时设置，或全部不设置。部分设置会导致启动失败；可变资产不需要这些变量。
 

--- a/web/content/docs/start-here/deployment.zh.md
+++ b/web/content/docs/start-here/deployment.zh.md
@@ -369,6 +369,7 @@ terminationGracePeriodSeconds: 200
 | `STELLA_BLOB_S3_USE_SSL`         | 否                        | S3 兼容存储是否使用 HTTPS；默认 `true`                                                                                 |
 | `STELLA_VAULT_KEY`               | 是†                       | 密钥库使用的 age 私钥 —— 密钥管理、OAuth 和 Bearer Token 所必需                                                        |
 | `STELLA_DOCKER_SANDBOX_MODE`     | 否‡                       | 仅 `docker` 沙箱后端需要：`host`、`bind` 或 `volume`                                                                   |
+| `STELLA_DOCKER_RUNTIME`          | 否‡                       | Docker 沙箱和工具缓存容器使用的已注册 OCI runtime；未设置时使用 daemon 默认值，配置值不可用时预检失败                  |
 | `STELLA_HOME_HOST`               | 否‡                       | `STELLA_HOME` 的宿主机侧路径；仅 `STELLA_DOCKER_SANDBOX_MODE=bind` 时需要                                              |
 | `STELLA_HOME_VOLUME`             | 否‡                       | `STELLA_HOME` 的 Docker named volume 名称；仅 `STELLA_DOCKER_SANDBOX_MODE=volume` 时需要                               |
 

--- a/web/content/docs/start-here/deployment.zh.md
+++ b/web/content/docs/start-here/deployment.zh.md
@@ -128,7 +128,7 @@ stellad service restart
 stellad service uninstall
 ```
 
-日志写入 `~/Library/Logs/stella/stella.log`。agent 在登录时自动启动，崩溃后自动重启。
+日志写入 `~/Library/Logs/stella/stella.log`。agent 在登录时自动启动，崩溃后自动重启。生成的 LaunchAgent 会将 Docker 沙箱模式固定为 `host`；启用 Docker 后端时，你只需选择可选的 OCI runtime。
 
 ### Linux — systemd 用户模式（无需 root）
 
@@ -157,7 +157,7 @@ stellad service logs --follow
 sudo stellad service uninstall --system
 ```
 
-Unit 文件安装至 `/etc/systemd/system/stella.service`。
+Unit 文件安装至 `/etc/systemd/system/stella.service`。生成的 service 会将 Docker 沙箱模式固定为 `host`。
 
 ## Docker
 
@@ -218,7 +218,7 @@ services:
       - STELLA_DATABASE_URL=postgres://user:pass@postgres.example.com:5432/stella?sslmode=require
 ```
 
-`seccomp=unconfined` 标志是 `local` 沙箱后端（bubblewrap）所必需的。如果 agent 使用 `docker` 沙箱后端，需要额外挂载 Docker socket 和设置模式相关的环境变量——请参阅[沙箱指南](/docs/guides/sandbox#docker-compose-示例)了解所有 compose 变体。
+`seccomp=unconfined` 标志是 `local` 沙箱后端（bubblewrap）所必需的。官方 Compose 已为 `docker` 沙箱后端配置 Docker socket 和 volume 模式；自定义 Compose 请参阅[沙箱指南](/docs/guides/sandbox#docker-compose-示例)。
 
 ```bash
 docker compose up -d
@@ -330,7 +330,7 @@ terminationGracePeriodSeconds: 200
 
 ## 沙箱后端
 
-将 Stella 运行在 Docker 容器中（见上文）与使用 Docker 作为 agent 工具执行的沙箱后端是两件独立的事。Stella 支持三种沙箱后端：`docker`、`local` 和 `none`。请参阅[沙箱指南](/docs/guides/sandbox)了解如何选择后端、配置 Docker 沙箱模式和排查常见问题。
+将 Stella 运行在 Docker 容器中（见上文）与使用 Docker 作为 agent 工具执行的沙箱后端是两件独立的事。Stella 支持三种沙箱后端：`docker`、`local` 和 `none`。标准 service 和 Compose 部署已选择正确的 Docker home 模式。请参阅[沙箱指南](/docs/guides/sandbox)选择后端和可选 OCI runtime，或配置直接、自定义部署。
 
 ## 卷和数据
 
@@ -368,14 +368,14 @@ terminationGracePeriodSeconds: 200
 | `STELLA_BLOB_S3_REGION`          | 否                        | 可选 S3 region                                                                                                         |
 | `STELLA_BLOB_S3_USE_SSL`         | 否                        | S3 兼容存储是否使用 HTTPS；默认 `true`                                                                                 |
 | `STELLA_VAULT_KEY`               | 是†                       | 密钥库使用的 age 私钥 —— 密钥管理、OAuth 和 Bearer Token 所必需                                                        |
-| `STELLA_DOCKER_SANDBOX_MODE`     | 否‡                       | 仅 `docker` 沙箱后端需要：`host`、`bind` 或 `volume`                                                                   |
+| `STELLA_DOCKER_SANDBOX_MODE`     | 否‡                       | 部署入口负责的 Docker home 模式；service install 和官方 Compose 会设置，直接或自定义部署必须自行设置                   |
 | `STELLA_DOCKER_RUNTIME`          | 否‡                       | Docker 沙箱和工具缓存容器使用的已注册 OCI runtime；未设置时使用 daemon 默认值，配置值不可用时预检失败                  |
 | `STELLA_HOME_HOST`               | 否‡                       | `STELLA_HOME` 的宿主机侧路径；仅 `STELLA_DOCKER_SANDBOX_MODE=bind` 时需要                                              |
 | `STELLA_HOME_VOLUME`             | 否‡                       | `STELLA_HOME` 的 Docker named volume 名称；仅 `STELLA_DOCKER_SANDBOX_MODE=volume` 时需要                               |
 
 † 未设置 `STELLA_VAULT_KEY` 时，密钥库接口返回 `503`，无法签发 OAuth Token，插件密钥也不会被注入。使用 `age-keygen` 生成密钥。
 
-‡ 仅当 agent 使用 `docker` 沙箱后端时需要。stellad 在宿主机上运行用 `host`；stellad 在 Docker 内且使用 host bind mount 用 `bind`；stellad 在 Docker 内且使用 named volume 用 `volume`。
+‡ 仅当 agent 使用 `docker` 沙箱后端时相关。标准 service 和 Compose 部署会设置模式。直接或自定义部署中，stellad 在宿主机上运行用 `host`；容器化 host bind mount 用 `bind`；Docker named volume 用 `volume`。
 
 § 四个必需的 S3 变量必须同时设置，或全部不设置。部分设置会导致启动失败；可变资产不需要这些变量。
 


### PR DESCRIPTION
## What

Add `STELLA_DOCKER_RUNTIME` so Docker sandboxes can use a registered OCI runtime such as gVisor's `runsc`. Support rootful and rootless Docker identity models without making bind mounts unwritable, and fail closed when the daemon or runtime cannot enforce Stella's resource ceilings.

This branch also carries the two requested pre-existing local commits that harden weekly-delivery reconciliation and document delivery PR/release links.

## Why

Operators need to select a stronger sandbox runtime without changing Docker's global default. Runtime selection must never silently fall back, and sandbox CPU, memory, swap, and PID limits must not silently disappear.

Rootless Docker maps its unprivileged daemon user to container UID 0. Reusing the host numeric UID inside that user namespace makes daemon-user-owned bind mounts unwritable, so rootful and rootless daemons require different container identities.

## How

- Read the optional runtime from `STELLA_DOCKER_RUNTIME` while preserving explicit programmatic configuration.
- Pass it to agent session, tool-cache installer, and tool-cache verifier containers.
- Validate both explicitly selected and daemon-default runtimes; reject missing configured runtimes and gVisor `ignore-cgroups` in all valid Go bool flag forms.
- Require daemon support for memory, swap, CPU period/quota, and PID limits before creating a sandbox.
- Cap memory plus swap at 2 GiB and reject any Docker container-create warning, cleaning up the unstarted container.
- Detect daemon identity from Docker security metadata:
  - rootful uses the `stellad` process UID/GID;
  - rootless uses container `0:0`, which maps to the unprivileged daemon user;
  - `userns-remap` is rejected because its bind-mount ownership model is unsupported.
- Move the user tool cache mount to world-traversable `/opt/stella/user-tools`; `/home/stella` is `0700` and inaccessible to rootless UID 0 after capabilities are dropped.
- Keep capability dropping, read-only rootfs, and `no-new-privileges` in both identity modes.
- Type image preparation failures so only actual dev-image failures receive the `sandbox:docker:build` recovery hint.
- Keep release-only weekly-delivery issues excluded per policy, but expose every skipped issue in the approval draft and terminal summary.
- Make deployment entry points own Docker home topology: native `stellad service install` templates pin `host`, while official Compose pins `volume`; direct/custom deployments remain explicit and fail closed.
- Treat rootless identity as daemon-reported implementation detail, not an operator setting.
- Pass the runtime variable through Docker Compose and document behavior in English and Chinese.

Deliberate limit: selecting `runsc` reduces host-kernel exposure but does not constrain egress or writable mounts. Registering an arbitrary OCI runtime remains an operator trust decision; Stella can reject known unsafe configuration but cannot prove an implementation honors the OCI contract.

## Test

- `mise run format && mise run build && mise run test` passed: complete Go suite and 273 Web tests.
- `go test ./plugins/sandbox/docker/... ./internal/agent/sandbox` passed.
- Weekly-delivery Python unit test passed.
- `TARGET_GOOS=windows TARGET_GOARCH=amd64 mise run build` passed.
- Linux amd64 `cmd/stellad` test binary cross-compiled; macOS LaunchAgent and Linux systemd templates have focused mode-ownership tests.
- `mise run sandbox:docker:build` passed; one first-attempt transient `mise: text file busy` build race cleared on retry.
- macOS/OrbStack daemon-default preflight passed with all required resource capabilities.
- Linux ARM64 rootful Docker + `runsc release-20260810.0`: hello-world and gVisor kernel marker passed.
- Linux ARM64 rootless Docker + runsc smoke: real Stella factory created a network-disabled sandbox, reported `Starting gVisor...`, selected container UID/GID `0:0`, wrote `/workspace`, and closed without residue.
- Rootful and rootless Docker both wrote the relocated tool-cache volume under `/opt/stella/user-tools` with all capabilities dropped and a read-only rootfs.
- The Orb rootless smoke daemon intentionally uses `--ignore-cgroups`; production preflight now rejects it with `memory, swap, CPU quota, PID` unsupported.
- Independent reviews: Terra found and verified the runtime/resource gaps; Opus performed two follow-up reviews and returned final `MERGE` after commit `01a0dac31`.

System tests were not run because runtime, identity, and resource selection are contained within Docker provider preflight and container-create requests, covered at provider, contract, real image, and real Linux daemon layers.

## Refs

Closes #1062

No issue: the included weekly-delivery reconciliation changes were pre-existing, self-contained local commits.

## Checklist

- [x] The PR links a GitHub issue, or states why the fix is small enough not to need one.
- [x] I added or updated focused tests for changed non-trivial behavior, or explained why none are needed.
- [x] I updated relevant English and Chinese documentation, or no documentation change is needed.
- [x] I ran `mise run format && mise run build && mise run test`.

## Feishu Task

- [Docker 沙箱支持指定 OCI 运行时](https://mcnnox2fhjfq.feishu.cn/record/AF80r06gReAIkdcK1iMc46XHnAf) (#1062)