### PR TITLE
🔒 sandbox: add fail-closed Harbor bridge backend

### DIFF
--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -5070,7 +5070,7 @@ components:
           type: integer
     StatusResponse:
       type: object
-      required: [status, version]
+      required: [status, version, sandbox_backend]
       properties:
         status:
           type: string
@@ -5078,6 +5078,10 @@ components:
         version:
           type: string
           example: 0.1.0
+        sandbox_backend:
+          type: string
+          readOnly: true
+          description: Active deploy-time sandbox backend. local, docker, and none are built in; bridge is reserved for the eval sandbox adapter.
         commit:
           type: string
           example: abc1234

--- a/api/spec/domain/status/schemas.yaml
+++ b/api/spec/domain/status/schemas.yaml
@@ -61,7 +61,7 @@ components:
           type: integer
     StatusResponse:
       type: object
-      required: [status, version]
+      required: [status, version, sandbox_backend]
       properties:
         status:
           type: string
@@ -69,6 +69,10 @@ components:
         version:
           type: string
           example: 0.1.0
+        sandbox_backend:
+          type: string
+          readOnly: true
+          description: Active deploy-time sandbox backend. local, docker, and none are built in; bridge is reserved for the eval sandbox adapter.
         commit:
           type: string
           example: abc1234

--- a/internal/agent/sandbox/session.go
+++ b/internal/agent/sandbox/session.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/CherryHQ/stella/internal/config"
 	pkgsandbox "github.com/CherryHQ/stella/pkg/sandbox"
+	bridgeplugin "github.com/CherryHQ/stella/plugins/sandbox/bridge"
 	dockerplugin "github.com/CherryHQ/stella/plugins/sandbox/docker"
 	localplugin "github.com/CherryHQ/stella/plugins/sandbox/local"
 	noneplugin "github.com/CherryHQ/stella/plugins/sandbox/none"
@@ -119,6 +120,31 @@ func createHostSession(ctx context.Context, cfg Config) (pkgsandbox.Session, err
 	return session, nil
 }
 
+// createBridgeSession creates an evaluation session whose execution is
+// forwarded through a harness bridge into a benchmark task container. It
+// still builds the base policy so vault/OAuth env and mise prep behave as on
+// every other backend; the bridge factory then rewrites filesystem coordinates
+// to the container's. No binding or unreachable bridge is a hard error.
+func createBridgeSession(ctx context.Context, cfg Config) (pkgsandbox.Session, error) {
+	_, policy, _, err := buildBasePolicy(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	slog.Info("creating bridge session",
+		"component", "runner_sandbox",
+		"user_id", cfg.UserID,
+	)
+	session, err := bridgeplugin.NewFactory(bridgeplugin.Config{
+		BindingDir: config.EvalBridgeBindingDir(),
+		UserID:     cfg.UserID,
+		GroupID:    cfg.GroupID,
+	}).CreateSession(ctx, policy)
+	if err != nil {
+		return nil, fmt.Errorf("create bridge session: %w", err)
+	}
+	return session, nil
+}
+
 // buildBasePolicy resolves paths and builds the backend-agnostic base policy
 // (filesystem, network, env). Backend-specific adjustments are applied by
 // each factory's CreateSession.
@@ -208,6 +234,8 @@ func createSessionForBackend(ctx context.Context, cfg Config, name string) (pkgs
 		return createLocalSession(ctx, cfg)
 	case config.SandboxBackendNone:
 		return createHostSession(ctx, cfg)
+	case config.SandboxBackendBridge:
+		return createBridgeSession(ctx, cfg)
 	default:
 		return nil, fmt.Errorf("unknown sandbox backend: %q", name)
 	}

--- a/internal/config/sandbox.go
+++ b/internal/config/sandbox.go
@@ -8,6 +8,11 @@ const (
 	SandboxBackendDocker = "docker"
 	SandboxBackendLocal  = "local"
 	SandboxBackendNone   = "none"
+	// SandboxBackendBridge is evaluation-only: commands and files go through a
+	// harness-owned bridge into a benchmark task container, supplied by the
+	// Harbor eval sandbox adapter (see plugins/sandbox/bridge). The core runtime
+	// deliberately has no host fallback when it is unavailable.
+	SandboxBackendBridge = "bridge"
 
 	SandboxNetworkDisabled = "disabled"
 	SandboxNetworkAllowAll = "allow_all"

--- a/internal/config/sandbox_env.go
+++ b/internal/config/sandbox_env.go
@@ -18,9 +18,20 @@ const sandboxBackendEnv = "STELLA_SANDBOX_BACKEND"
 // ServerConfig; see the allowlist entry in env_scan_test.go.
 func ActiveSandboxBackend() string {
 	switch v := strings.TrimSpace(os.Getenv(sandboxBackendEnv)); v {
-	case SandboxBackendDocker, SandboxBackendLocal, SandboxBackendNone:
+	case SandboxBackendDocker, SandboxBackendLocal, SandboxBackendNone, SandboxBackendBridge:
 		return v
 	default:
 		return SandboxBackendLocal
 	}
+}
+
+// evalBridgeBindingDirEnv names the directory where an evaluation harness
+// publishes per-user bridge bindings for the bridge sandbox backend.
+const evalBridgeBindingDirEnv = "STELLA_EVAL_BRIDGE_DIR"
+
+// EvalBridgeBindingDir returns the bridge binding directory. Like the backend
+// name it is read per session creation: it is evaluation-only plumbing, never a
+// ServerConfig field.
+func EvalBridgeBindingDir() string {
+	return strings.TrimSpace(os.Getenv(evalBridgeBindingDirEnv))
 }

--- a/internal/config/sandbox_env_test.go
+++ b/internal/config/sandbox_env_test.go
@@ -15,6 +15,7 @@ func TestActiveSandboxBackend(t *testing.T) {
 		{name: "unset defaults to local", unset: true, want: SandboxBackendLocal},
 		{name: "empty defaults to local", env: "", want: SandboxBackendLocal},
 		{name: "docker", env: "docker", want: SandboxBackendDocker},
+		{name: "bridge", env: "bridge", want: SandboxBackendBridge},
 		{name: "none", env: "none", want: SandboxBackendNone},
 		{name: "padded value is trimmed", env: "  docker  ", want: SandboxBackendDocker},
 		{name: "unknown value falls back to local", env: "podman", want: SandboxBackendLocal},

--- a/internal/server/status.go
+++ b/internal/server/status.go
@@ -7,13 +7,15 @@ import (
 	"time"
 
 	"github.com/CherryHQ/stella/api/types"
+	"github.com/CherryHQ/stella/internal/config"
 	"github.com/CherryHQ/stella/internal/version"
 )
 
 func (s *Server) GetStatus(w http.ResponseWriter, r *http.Request) {
 	resp := types.StatusResponse{
-		Status:  "ok",
-		Version: version.Version,
+		Status:         "ok",
+		Version:        version.Version,
+		SandboxBackend: statusStringPtr(config.ActiveSandboxBackend()),
 	}
 	if version.Commit != "" {
 		resp.Commit = &version.Commit
@@ -30,6 +32,8 @@ func (s *Server) GetStatus(w http.ResponseWriter, r *http.Request) {
 	}
 	writeData(w, http.StatusOK, resp)
 }
+
+func statusStringPtr(value string) *string { return &value }
 
 func (s *Server) statusRuntime() *types.StatusRuntime {
 	var mem runtime.MemStats

--- a/internal/server/status_test.go
+++ b/internal/server/status_test.go
@@ -1,0 +1,26 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/CherryHQ/stella/api/types"
+)
+
+func TestStatusReportsActiveSandboxBackendToUnauthenticatedCallers(t *testing.T) {
+	t.Setenv("STELLA_SANDBOX_BACKEND", "bridge")
+	rr := httptest.NewRecorder()
+	(&Server{}).GetStatus(rr, httptest.NewRequest(http.MethodGet, "/api/status", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	var got types.StatusResponse
+	if err := json.NewDecoder(rr.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got.SandboxBackend == nil || *got.SandboxBackend != "bridge" {
+		t.Fatalf("sandbox_backend = %v, want bridge", got.SandboxBackend)
+	}
+}

--- a/plugins/sandbox/bridge/binding.go
+++ b/plugins/sandbox/bridge/binding.go
@@ -1,0 +1,81 @@
+// Package bridge is an evaluation-only sandbox backend. It executes every
+// command and file operation through a per-trial bridge socket owned by an
+// external harness (the Harbor adapter), which forwards them into the
+// benchmark task container. Nothing runs on the stellad host.
+//
+// The backend never falls back: a session whose principal has no binding, or
+// whose bridge socket is unreachable, fails instead of running elsewhere. That
+// is the property an evaluation depends on — a silent fallback would grade the
+// wrong environment while looking like a pass.
+package bridge
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// BindingDirEnv names the directory where the harness publishes one binding
+// file per provisioned eval user: <dir>/<user_id>.json.
+const BindingDirEnv = "STELLA_EVAL_BRIDGE_DIR"
+
+// Binding is what the harness writes for one trial. Socket and Nonce identify
+// the bridge; the rest describes the task container as the harness observed it
+// at bind time so the session env mirrors the container's own view.
+type Binding struct {
+	Socket string `json:"socket"`
+	Nonce  string `json:"nonce"`
+	// WorkDir is the task working directory inside the container (e.g. /app).
+	WorkDir string `json:"workdir"`
+	// Home is the container user's HOME. Empty falls back to WorkDir.
+	Home string `json:"home,omitempty"`
+	// TempDir is a per-trial scratch directory the harness created in the
+	// container. Empty falls back to /tmp.
+	TempDir string `json:"temp_dir,omitempty"`
+	// Path is the container PATH the harness discovered, already prefixed with
+	// the Stella helper tool bundle. Empty leaves PATH untouched.
+	Path string `json:"path,omitempty"`
+}
+
+// ErrNoBinding reports that the principal has no published bridge binding.
+var ErrNoBinding = errors.New("bridge: no binding for principal; refusing to create a session")
+
+// LoadBinding reads and validates the binding for userID from dir.
+func LoadBinding(dir, userID string) (Binding, error) {
+	if strings.TrimSpace(dir) == "" {
+		return Binding{}, fmt.Errorf("bridge: %s is not set", BindingDirEnv)
+	}
+	if userID == "" || strings.ContainsAny(userID, `/\`) || userID == "." || userID == ".." {
+		return Binding{}, fmt.Errorf("bridge: invalid principal id %q", userID)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, userID+".json"))
+	if errors.Is(err, os.ErrNotExist) {
+		return Binding{}, ErrNoBinding
+	}
+	if err != nil {
+		return Binding{}, fmt.Errorf("bridge: read binding: %w", err)
+	}
+	var b Binding
+	if err := json.Unmarshal(data, &b); err != nil {
+		return Binding{}, fmt.Errorf("bridge: parse binding: %w", err)
+	}
+	if err := b.validate(); err != nil {
+		return Binding{}, err
+	}
+	return b, nil
+}
+
+func (b Binding) validate() error {
+	switch {
+	case b.Socket == "":
+		return errors.New("bridge: binding requires socket")
+	case b.Nonce == "":
+		return errors.New("bridge: binding requires nonce")
+	case !strings.HasPrefix(b.WorkDir, "/"):
+		return fmt.Errorf("bridge: binding workdir must be absolute, got %q", b.WorkDir)
+	}
+	return nil
+}

--- a/plugins/sandbox/bridge/binding_test.go
+++ b/plugins/sandbox/bridge/binding_test.go
@@ -1,0 +1,46 @@
+package bridge
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadBinding(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	write := func(name, body string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name+".json"), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("u1", `{"socket":"/tmp/b.sock","nonce":"abc","workdir":"/app","home":"/root"}`)
+	write("bad-workdir", `{"socket":"/tmp/b.sock","nonce":"abc","workdir":"app"}`)
+	write("no-nonce", `{"socket":"/tmp/b.sock","workdir":"/app"}`)
+
+	b, err := LoadBinding(dir, "u1")
+	if err != nil {
+		t.Fatalf("valid binding: %v", err)
+	}
+	if b.Socket != "/tmp/b.sock" || b.Nonce != "abc" || b.WorkDir != "/app" || b.Home != "/root" {
+		t.Fatalf("unexpected binding %+v", b)
+	}
+
+	if _, err := LoadBinding(dir, "missing"); !errors.Is(err, ErrNoBinding) {
+		t.Fatalf("missing binding: want ErrNoBinding, got %v", err)
+	}
+	if _, err := LoadBinding(dir, "bad-workdir"); err == nil {
+		t.Fatal("relative workdir must be rejected")
+	}
+	if _, err := LoadBinding(dir, "no-nonce"); err == nil {
+		t.Fatal("binding without nonce must be rejected")
+	}
+	if _, err := LoadBinding(dir, "../u1"); err == nil {
+		t.Fatal("path traversal in principal id must be rejected")
+	}
+	if _, err := LoadBinding("", "u1"); err == nil {
+		t.Fatal("empty binding dir must be rejected")
+	}
+}

--- a/plugins/sandbox/bridge/client.go
+++ b/plugins/sandbox/bridge/client.go
@@ -1,0 +1,111 @@
+package bridge
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"time"
+)
+
+// Wire protocol: one JSON request per connection, one JSON response, close.
+// A fresh connection per call keeps the Python side trivial (no multiplexing)
+// and makes concurrent tool calls independent. Payloads are base64 inside JSON;
+// per-call size cap below. Ceiling: switch to a streaming transport if eval
+// tasks move files large enough for this to matter.
+const maxPayloadBytes = 32 << 20
+
+type request struct {
+	Nonce      string            `json:"nonce"`
+	Op         string            `json:"op"`
+	Command    string            `json:"command,omitempty"`
+	Cwd        string            `json:"cwd,omitempty"`
+	Env        map[string]string `json:"env,omitempty"`
+	TimeoutSec int               `json:"timeout_sec,omitempty"`
+	Path       string            `json:"path,omitempty"`
+	Data       []byte            `json:"data,omitempty"`
+	Mode       uint32            `json:"mode,omitempty"`
+	Files      []projFile        `json:"files,omitempty"`
+}
+
+type projFile struct {
+	Path string `json:"path"`
+	Data []byte `json:"data"`
+	Mode uint32 `json:"mode"`
+}
+
+type dirEntry struct {
+	Name  string `json:"name"`
+	IsDir bool   `json:"is_dir"`
+	Size  int64  `json:"size"`
+}
+
+type response struct {
+	OK         bool       `json:"ok"`
+	Error      string     `json:"error,omitempty"`
+	Code       string     `json:"code,omitempty"`
+	Stdout     string     `json:"stdout,omitempty"`
+	Stderr     string     `json:"stderr,omitempty"`
+	ReturnCode int        `json:"return_code,omitempty"`
+	Data       []byte     `json:"data,omitempty"`
+	Entries    []dirEntry `json:"entries,omitempty"`
+	IsDir      bool       `json:"is_dir,omitempty"`
+	Size       int64      `json:"size,omitempty"`
+}
+
+// Error codes the bridge server may return; mapped to fs-style errors so core
+// tools report "file not found" the same way they do on other backends.
+const (
+	codeNotFound = "not_found"
+	codeIsDir    = "is_dir"
+	codeNonce    = "bad_nonce"
+	codeConflict = "conflict"
+)
+
+var errBadNonce = errors.New("bridge: nonce rejected by bridge (binding mismatch)")
+
+type client struct {
+	socket string
+	nonce  string
+}
+
+func (c *client) call(ctx context.Context, req request) (response, error) {
+	req.Nonce = c.nonce
+	if len(req.Data) > maxPayloadBytes {
+		return response{}, fmt.Errorf("bridge: payload %d bytes exceeds cap %d", len(req.Data), maxPayloadBytes)
+	}
+	var d net.Dialer
+	conn, err := d.DialContext(ctx, "unix", c.socket)
+	if err != nil {
+		return response{}, fmt.Errorf("bridge: dial %s: %w", c.socket, err)
+	}
+	defer func() { _ = conn.Close() }()
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(deadline)
+	} else if req.TimeoutSec > 0 {
+		// Give the server room to enforce its own timeout first.
+		_ = conn.SetDeadline(time.Now().Add(time.Duration(req.TimeoutSec)*time.Second + 30*time.Second))
+	}
+	enc := json.NewEncoder(conn)
+	if err := enc.Encode(req); err != nil {
+		return response{}, fmt.Errorf("bridge: send %s: %w", req.Op, err)
+	}
+	if uc, ok := conn.(*net.UnixConn); ok {
+		_ = uc.CloseWrite()
+	}
+	r := bufio.NewReaderSize(conn, 64<<10)
+	var resp response
+	dec := json.NewDecoder(r)
+	if err := dec.Decode(&resp); err != nil {
+		return response{}, fmt.Errorf("bridge: read %s response: %w", req.Op, err)
+	}
+	if !resp.OK {
+		if resp.Code == codeNonce {
+			return resp, errBadNonce
+		}
+		return resp, fmt.Errorf("bridge: %s: %s", req.Op, resp.Error)
+	}
+	return resp, nil
+}

--- a/plugins/sandbox/bridge/session.go
+++ b/plugins/sandbox/bridge/session.go
@@ -1,0 +1,286 @@
+package bridge
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io/fs"
+	"maps"
+	"path"
+	"strings"
+	"sync"
+	"time"
+
+	sandboxpkg "github.com/CherryHQ/stella/pkg/sandbox"
+)
+
+// Config configures the bridge factory.
+type Config struct {
+	// BindingDir is where the harness publishes <user_id>.json bindings.
+	BindingDir string
+	// UserID is the session principal whose binding selects the bridge.
+	UserID string
+	// GroupID is set for group sessions, which the eval backend refuses.
+	GroupID string
+}
+
+// Factory creates sessions bound to one harness bridge.
+type Factory struct {
+	cfg Config
+}
+
+// NewFactory returns a bridge factory. Mount sources are ignored: the process
+// view is the task container's own filesystem, not a projection of host paths.
+func NewFactory(cfg Config) sandboxpkg.Factory { return &Factory{cfg: cfg} }
+
+func (f *Factory) Name() string    { return "bridge" }
+func (f *Factory) Available() bool { return true }
+
+// Supported accepts any policy; confinement is the task container itself.
+func (f *Factory) Supported(sandboxpkg.Policy) error { return nil }
+
+// CreateSession loads the principal's binding, verifies the bridge answers with
+// the same nonce, and rewrites the policy to the container's coordinates.
+func (f *Factory) CreateSession(ctx context.Context, policy sandboxpkg.Policy) (sandboxpkg.Session, error) {
+	if f.cfg.GroupID != "" {
+		return nil, errors.New("bridge: group sessions are not supported by the eval backend")
+	}
+	binding, err := LoadBinding(f.cfg.BindingDir, f.cfg.UserID)
+	if err != nil {
+		return nil, err
+	}
+	c := &client{socket: binding.Socket, nonce: binding.Nonce}
+	pingCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	if _, err := c.call(pingCtx, request{Op: "ping"}); err != nil {
+		return nil, fmt.Errorf("bridge: bind check failed: %w", err)
+	}
+
+	home := binding.Home
+	if home == "" {
+		home = binding.WorkDir
+	}
+	tempDir := binding.TempDir
+	if tempDir == "" {
+		tempDir = "/tmp"
+	}
+	env := maps.Clone(policy.Env)
+	if env == nil {
+		env = map[string]string{}
+	}
+	if err := sandboxpkg.ApplyFilesystemEnv(env, sandboxpkg.FilesystemView{Home: home, TempDir: tempDir}); err != nil {
+		return nil, err
+	}
+	if binding.Path != "" {
+		env["PATH"] = binding.Path
+		env[sandboxpkg.EnvRunnerPath] = binding.Path
+	}
+	policy.Env = env
+	// The container is the confinement boundary; every absolute container path
+	// is in scope. Mounts describe the data roots the runner may address.
+	policy.Filesystem = sandboxpkg.FilesystemPolicy{
+		WorkingDir: binding.WorkDir,
+		Mounts:     []sandboxpkg.Mount{{SandboxPath: "/", Access: sandboxpkg.MountReadWrite}},
+	}
+	policy.Network.Mode = sandboxpkg.NetworkAllowAll
+
+	var entropy [6]byte
+	_, _ = rand.Read(entropy[:])
+	s := &session{
+		id:      "bridge-" + hex.EncodeToString(entropy[:]),
+		client:  c,
+		policy:  policy,
+		tempDir: tempDir,
+		done:    make(chan struct{}),
+	}
+	s.files = &fileAccess{s: s}
+	sandboxpkg.LogSessionCreated(s.id, "bridge", policy)
+	return s, nil
+}
+
+type session struct {
+	id      string
+	client  *client
+	tempDir string
+	done    chan struct{}
+	files   *fileAccess
+
+	mu     sync.RWMutex
+	policy sandboxpkg.Policy
+	closed bool
+}
+
+func (s *session) Policy() sandboxpkg.Policy {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.policy
+}
+
+func (s *session) WorkingDir() string           { return s.Policy().Filesystem.WorkingDir }
+func (s *session) Files() sandboxpkg.FileAccess { return s.files }
+func (s *session) Done() <-chan struct{}        { return s.done }
+
+func (s *session) Alive() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return !s.closed
+}
+
+func (s *session) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	close(s.done)
+	sandboxpkg.LogSessionClosed(s.id, "bridge", "explicit_close")
+	return nil
+}
+
+// RefreshEnv implements sandboxpkg.EnvRefresher so OAuth-derived variables can
+// rotate mid-session exactly as on the other backends.
+func (s *session) RefreshEnv(updates map[string]string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	env := maps.Clone(s.policy.Env)
+	if env == nil {
+		env = map[string]string{}
+	}
+	maps.Copy(env, updates)
+	s.policy.Env = env
+}
+
+func (s *session) checkOpen() error {
+	if !s.Alive() {
+		return errors.New("bridge: session is closed")
+	}
+	return nil
+}
+
+func (s *session) Exec(ctx context.Context, command string, opts sandboxpkg.ExecOptions) (sandboxpkg.ExecResult, error) {
+	if err := s.checkOpen(); err != nil {
+		return sandboxpkg.ExecResult{}, err
+	}
+	policy := s.Policy()
+	env := maps.Clone(policy.Env)
+	maps.Copy(env, opts.Env)
+	timeout := opts.Timeout
+	if timeout == 0 {
+		timeout = policy.Timeout
+	}
+	cwd := opts.Cwd
+	if cwd == "" {
+		cwd = policy.Filesystem.WorkingDir
+	}
+	resp, err := s.client.call(ctx, request{
+		Op: "exec", Command: command, Cwd: cwd, Env: env,
+		TimeoutSec: int(timeout / time.Second),
+	})
+	if err != nil {
+		return sandboxpkg.ExecResult{}, err
+	}
+	return sandboxpkg.ExecResult{Stdout: resp.Stdout, Stderr: resp.Stderr, ExitCode: resp.ReturnCode}, nil
+}
+
+// StartProcess is not supported by the first bridge version: no core tool needs
+// a long-lived process, and Harbor's environment exec is request/response.
+// Ceiling: implement over a streaming transport if eval tasks require it.
+func (s *session) StartProcess(context.Context, sandboxpkg.ProcessRequest) (sandboxpkg.ProcessHandle, error) {
+	return nil, errors.New("bridge: StartProcess is not supported by the eval backend")
+}
+
+// fileAccess forwards every file operation to the bridge. Paths are container
+// paths; relative names resolve against the session working directory.
+type fileAccess struct{ s *session }
+
+func (f *fileAccess) resolve(name string) string {
+	if path.IsAbs(name) {
+		return path.Clean(name)
+	}
+	return path.Join(f.s.WorkingDir(), name)
+}
+
+func (f *fileAccess) call(op string, req request) (response, error) {
+	if err := f.s.checkOpen(); err != nil {
+		return response{}, err
+	}
+	req.Op = op
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	resp, err := f.s.client.call(ctx, req)
+	if err != nil {
+		switch resp.Code {
+		case codeNotFound:
+			return resp, &fs.PathError{Op: op, Path: req.Path, Err: fs.ErrNotExist}
+		case codeIsDir:
+			return resp, &fs.PathError{Op: op, Path: req.Path, Err: errors.New("is a directory")}
+		case codeConflict:
+			return resp, fmt.Errorf("%w: %s", sandboxpkg.ErrProjectionConflict, resp.Error)
+		}
+		return resp, err
+	}
+	return resp, nil
+}
+
+func (f *fileAccess) ReadFile(name string) ([]byte, error) {
+	resp, err := f.call("read_file", request{Path: f.resolve(name)})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
+}
+
+func (f *fileAccess) ReadDir(name string) ([]sandboxpkg.DirEntry, error) {
+	resp, err := f.call("read_dir", request{Path: f.resolve(name)})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]sandboxpkg.DirEntry, 0, len(resp.Entries))
+	for _, e := range resp.Entries {
+		out = append(out, sandboxpkg.DirEntry{Name: e.Name, IsDir: e.IsDir, Size: e.Size})
+	}
+	return out, nil
+}
+
+func (f *fileAccess) Stat(name string) (sandboxpkg.FileInfo, error) {
+	resp, err := f.call("stat", request{Path: f.resolve(name)})
+	if err != nil {
+		return sandboxpkg.FileInfo{}, err
+	}
+	return sandboxpkg.FileInfo{IsDir: resp.IsDir, Size: resp.Size}, nil
+}
+
+func (f *fileAccess) WriteFile(name string, content []byte, mode fs.FileMode) error {
+	_, err := f.call("write_file", request{Path: f.resolve(name), Data: content, Mode: uint32(mode.Perm())})
+	return err
+}
+
+func (f *fileAccess) ProjectFiles(name string, files []sandboxpkg.ProjectedFile) error {
+	return f.project(f.resolve(name), files)
+}
+
+func (f *fileAccess) ProjectTempFiles(name string, files []sandboxpkg.ProjectedFile) (string, error) {
+	if path.IsAbs(name) || !fs.ValidPath(name) || name == "." {
+		return "", fmt.Errorf("bridge: invalid temp projection name %q", name)
+	}
+	target := path.Join(f.s.tempDir, name)
+	if err := f.project(target, files); err != nil {
+		return "", err
+	}
+	return target, nil
+}
+
+func (f *fileAccess) project(target string, files []sandboxpkg.ProjectedFile) error {
+	req := request{Path: target}
+	for _, file := range files {
+		if !fs.ValidPath(file.Path) || file.Path == "." || strings.HasPrefix(file.Path, "/") {
+			return fmt.Errorf("bridge: invalid projection file %q", file.Path)
+		}
+		req.Files = append(req.Files, projFile{Path: file.Path, Data: file.Content, Mode: uint32(file.Mode.Perm())})
+	}
+	_, err := f.call("project", req)
+	return err
+}

--- a/test/testbed/supervisor.go
+++ b/test/testbed/supervisor.go
@@ -155,7 +155,10 @@ func ensurePortAvailable(port int) error {
 }
 
 func serverEnvironment(home, dsn, vaultKey string, port int) []string {
-	keep := []string{"PATH", "HOME", "TMPDIR", "LANG", "LC_ALL"}
+	// Sandbox backend selection is deploy-time and env-only, so the eval
+	// harness must be able to hand the bridge backend through here; every
+	// other STELLA_* value stays isolated.
+	keep := []string{"PATH", "HOME", "TMPDIR", "LANG", "LC_ALL", "STELLA_SANDBOX_BACKEND", "STELLA_EVAL_BRIDGE_DIR"}
 	env := make([]string, 0, len(keep)+6)
 	for _, name := range keep {
 		if value, ok := os.LookupEnv(name); ok {

--- a/test/testbed/supervisor_test.go
+++ b/test/testbed/supervisor_test.go
@@ -176,3 +176,17 @@ func TestServerEnvironmentDoesNotInheritStellaOrAuthConfig(t *testing.T) {
 		t.Fatalf("isolated environment missing explicit values: %#v", got)
 	}
 }
+
+func TestServerEnvironmentPassesSandboxBackendSelection(t *testing.T) {
+	t.Setenv("STELLA_SANDBOX_BACKEND", "bridge")
+	t.Setenv("STELLA_EVAL_BRIDGE_DIR", "/tmp/bindings")
+
+	got := map[string]string{}
+	for _, entry := range serverEnvironment("/tmp/test-home", "postgres://test", "vault-secret", 25678) {
+		name, value, _ := strings.Cut(entry, "=")
+		got[name] = value
+	}
+	if got["STELLA_SANDBOX_BACKEND"] != "bridge" || got["STELLA_EVAL_BRIDGE_DIR"] != "/tmp/bindings" {
+		t.Fatalf("sandbox backend selection must reach stellad: %#v", got)
+	}
+}

--- a/web/content/docs/guides/sandbox.md
+++ b/web/content/docs/guides/sandbox.md
@@ -21,6 +21,15 @@ Set the backend with the `STELLA_SANDBOX_BACKEND` environment variable when you 
 STELLA_SANDBOX_BACKEND=docker   # docker | local | none
 ```
 
+Verify the active selection before sending an agent work. `GET /api/status` returns `sandbox_backend` even without authentication, so an automation can fail before it provisions or executes anything:
+
+```bash
+curl -fsS http://localhost:25678/api/status
+# {"status":"ok","version":"…","sandbox_backend":"docker"}
+```
+
+This reports the deployment selection, not a successful sandbox-session creation. A backend that cannot start still fails closed when the runner is created.
+
 The default is `local`. An unset or unrecognized value also resolves to `local`, so a typo never leaves agents unisolated. There is no Web UI or per-agent override — the sandbox boundary is an operator decision, not a runtime one.
 
 ## Docker Backend

--- a/web/content/docs/guides/sandbox.zh.md
+++ b/web/content/docs/guides/sandbox.zh.md
@@ -21,6 +21,15 @@ Stella 在沙箱内运行 agent 代码。沙箱后端由运维在部署时统一
 STELLA_SANDBOX_BACKEND=docker   # docker | local | none
 ```
 
+在发送任何 Agent 工作前验证当前选择。`GET /api/status` 即使未认证也会返回 `sandbox_backend`，自动化程序可在创建资源或执行任何操作前失败退出：
+
+```bash
+curl -fsS http://localhost:25678/api/status
+# {"status":"ok","version":"…","sandbox_backend":"docker"}
+```
+
+这里报告的是部署选择，不表示沙箱会话已经成功创建。后端无法启动时，Runner 创建仍会 fail-closed。
+
 默认值是 `local`。未设置或取值无法识别时同样回落到 `local`，因此拼错变量不会让 agent 失去隔离。没有 Web UI 开关，也没有 per-agent 覆盖——沙箱边界是运维决策，不是运行时决策。
 
 ## Docker 后端


### PR DESCRIPTION
## What

Add a `bridge` sandbox backend that forwards core sandbox operations into a benchmark task container, and expose the active sandbox backend through `/api/status`.

## Why

A misconfigured Harbor run previously executed agent commands through the local backend before the harness could detect the mistake. Callers need to fail closed before provisioning or execution.

## How

- Bind each provisioned user to a Unix socket and per-trial nonce.
- Refuse missing bindings, nonce mismatches, group sessions, and background processes without falling back to the host.
- Rewrite filesystem and environment coordinates to the task container.
- Expose `sandbox_backend` and pass bridge selection through the testbed supervisor.

## Test

- `mise run format`
- `mise run build`
- `mise run test`

The cross-language Docker contract belongs to #1084, where the Python bridge server exists.

## Refs

Closes #1069
Refs #1054

Stack: 2/4, based on #1082 for review order only; the bridge diff has no usage-code dependency. Followed by #1084.

## Feishu Task

- [Terminal-Bench Harbor 基线接入](https://mcnnox2fhjfq.feishu.cn/record/LsGDrpS8XexX5RcCzrPcEy8MnUS) (#1054)
- [增加 fail-closed Harbor bridge sandbox](https://mcnnox2fhjfq.feishu.cn/record/Caqor5LXhe03hdcAlowccBrKni2) (#1069)