### PR TITLE
🧭 agent: nudge from the remaining step budget

### DIFF
--- a/internal/agent/runner_impl.go
+++ b/internal/agent/runner_impl.go
@@ -442,24 +442,13 @@ func (r *runner) Chat(ctx context.Context, history []ai.Message, message Message
 			}(),
 		})
 
-		// Inject progress nudges at milestone turns so the model can summarize
-		// its state before the timeout fires.
-		chatStart := time.Now()
-		loopRunner.SetTurnNotify(func(turn int, _ time.Duration) *string {
-			elapsed := time.Since(chatStart).Round(time.Second)
-			var msg string
-			switch turn {
-			case 50:
-				msg = fmt.Sprintf("You have been running for %s and completed 50 turns. Please report your current progress. If the user's request is not yet resolved, suggest alternative approaches.", elapsed)
-			case 80:
-				msg = fmt.Sprintf("You have been running for %s and completed 80 turns. Please report your progress again and consider whether a simpler approach could resolve the problem.", elapsed)
-			case 100:
-				msg = fmt.Sprintf("You have been running for %s and completed 100 turns. Please summarize the current state clearly and stop further attempts. Wait for the user's instructions before continuing.", elapsed)
-			default:
-				return nil
-			}
-			return &msg
-		})
+		// Nudge the model toward a summary as the wall-clock budget runs out.
+		// The trigger is elapsed time, not a turn count. Turn milestones fire in
+		// the middle of healthy work on fast turns, and the old turn-50 message
+		// ("please report your current progress") was answered with a summary
+		// and no tool call, which ends the loop: every unattended task was
+		// capped at 50 turns regardless of how much of its budget was left.
+		loopRunner.SetTurnNotify(progressNudge(timeout))
 
 		// Reload the OAuth-derived session env before each turn so a long-lived
 		// cached runner (kept warm by frequent scheduler fires) never hands tools
@@ -741,4 +730,38 @@ func summarizeToolInput(toolName string, args map[string]any) string {
 		}
 	}
 	return ""
+}
+
+// Progress-nudge thresholds, as a fraction of the chat budget. The first is a
+// checkpoint the model must survive without stopping; the second is close
+// enough to the deadline that wrapping up is the useful thing to do.
+const (
+	nudgeCheckpointFraction = 3.0 / 4.0
+	nudgeWrapUpFraction     = 9.0 / 10.0
+)
+
+// progressNudge returns a turn-notify callback that fires at most twice per
+// chat, on elapsed time rather than turn count. The wording matters as much as
+// the trigger: a nudge the model reads as "stop and report" ends the loop,
+// because a turn without a tool call is a finished turn.
+func progressNudge(budget time.Duration) func(int, time.Duration) *string {
+	checkpoint := time.Duration(float64(budget) * nudgeCheckpointFraction)
+	wrapUp := time.Duration(float64(budget) * nudgeWrapUpFraction)
+	var sentCheckpoint, sentWrapUp bool
+	return func(_ int, elapsed time.Duration) *string {
+		var msg string
+		switch {
+		case !sentWrapUp && elapsed >= wrapUp:
+			sentWrapUp, sentCheckpoint = true, true
+			msg = fmt.Sprintf("You have about %s left of a %s budget for this request. Finish or safely stop what you are doing now, then summarize what you completed and what remains.",
+				(budget - elapsed).Round(time.Second), budget.Round(time.Second))
+		case !sentCheckpoint && elapsed >= checkpoint:
+			sentCheckpoint = true
+			msg = fmt.Sprintf("Checkpoint: you have been working for %s of a %s budget. Briefly state your progress and then keep working. This is not a request to stop; if the approach is not converging, try a different one.",
+				elapsed.Round(time.Second), budget.Round(time.Second))
+		default:
+			return nil
+		}
+		return &msg
+	}
 }

--- a/internal/agent/runner_impl_test.go
+++ b/internal/agent/runner_impl_test.go
@@ -377,3 +377,54 @@ func TestConvertLoopEventStripsRenderableReferences(t *testing.T) {
 		t.Fatalf("stored references = %#v", stored.References)
 	}
 }
+
+// A long unattended task used to be capped at 50 turns: the turn-50 nudge asked
+// the model to report progress, it answered without a tool call, and a turn with
+// no tool call ends the loop. Turn count must not trigger a nudge at all.
+func TestProgressNudgeIgnoresTurnCount(t *testing.T) {
+	nudge := progressNudge(30 * time.Minute)
+	for turn := 1; turn <= 200; turn++ {
+		if msg := nudge(turn, time.Minute); msg != nil {
+			t.Fatalf("turn %d nudged with a fresh budget: %q", turn, *msg)
+		}
+	}
+}
+
+func TestProgressNudgeFiresOncePerThresholdAsTheBudgetRunsOut(t *testing.T) {
+	budget := 40 * time.Minute
+	nudge := progressNudge(budget)
+
+	checkpoint := nudge(3, 30*time.Minute) // 75%
+	if checkpoint == nil {
+		t.Fatal("no checkpoint at three quarters of the budget")
+	}
+	if !strings.Contains(*checkpoint, "not a request to stop") {
+		t.Errorf("checkpoint reads as an instruction to stop: %q", *checkpoint)
+	}
+	if again := nudge(4, 31*time.Minute); again != nil {
+		t.Errorf("checkpoint repeated: %q", *again)
+	}
+
+	wrapUp := nudge(5, 36*time.Minute) // 90%
+	if wrapUp == nil {
+		t.Fatal("no wrap-up near the deadline")
+	}
+	if !strings.Contains(*wrapUp, "summarize") {
+		t.Errorf("wrap-up does not ask for a summary: %q", *wrapUp)
+	}
+	if again := nudge(6, 39*time.Minute); again != nil {
+		t.Errorf("wrap-up repeated: %q", *again)
+	}
+}
+
+// A chat that blows straight past both thresholds (a single very slow turn)
+// must not emit two nudges back to back.
+func TestProgressNudgeSkipsTheCheckpointWhenItIsAlreadyTooLate(t *testing.T) {
+	nudge := progressNudge(10 * time.Minute)
+	if msg := nudge(1, 9*time.Minute+30*time.Second); msg == nil || !strings.Contains(*msg, "summarize") {
+		t.Fatalf("expected the wrap-up, got %v", msg)
+	}
+	if msg := nudge(2, 9*time.Minute+40*time.Second); msg != nil {
+		t.Fatalf("checkpoint fired after the wrap-up: %q", *msg)
+	}
+}


### PR DESCRIPTION
## What

Move long-running agent progress nudges from fixed turn counts to 75% and 90% of the wall-clock request budget.

## Why

The turn-50 prompt asked the model to report progress. A response without another tool call ends the loop, so fast unattended tasks stopped at turn 50 even when most of their time budget remained.

## How

Create one per-chat callback that emits at most two time-based messages. The 75% checkpoint explicitly tells the model to continue; the 90% message asks it to finish or stop safely. Focused tests cover thresholds, one-shot delivery, short budgets, and late first observation.

## Test

- `mise run format`
- `mise run build`
- `mise run test`

## Refs

No issue: self-contained correctness fix discovered while running #1054.