### PR TITLE
🛑 agent: reject empty truncated completions

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -321,6 +321,19 @@ func streamAssistant(ctx context.Context, messages []ai.Message, cfg loopConfig,
 		emit(AssistantFinished{Message: msg})
 	}
 
+	// A turn truncated at the output limit that carries nothing back is not a
+	// finished turn. It looks identical to a model that chose to say nothing:
+	// zero turns, no message, no error, and the caller cannot tell the two
+	// apart. Seen with a reasoning model that spent its whole output budget
+	// thinking; on the Terminal-Bench baseline it silently killed 13 trials
+	// across 4 tasks, each of which scored 0 without touching the container.
+	// Scoped deliberately: a truncated reply that did carry text or a tool call
+	// is still usable and stays a clean finish.
+	if msg.StopReason == ai.StopReasonLength && len(msg.Content) == 0 {
+		msg.ErrorMessage = "the model reached its output token limit before it produced a reply"
+		return streamResult{Message: msg, TimeToFirstToken: ttft}, errors.New("provider: " + msg.ErrorMessage)
+	}
+
 	return streamResult{Message: msg, TimeToFirstToken: ttft}, nil
 }
 

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -469,3 +469,53 @@ func TestContinueRequiresValidTail(t *testing.T) {
 		t.Fatalf("expected tail validation error")
 	}
 }
+
+func TestRunEmptyTruncatedTurnFailsInsteadOfFinishingSilently(t *testing.T) {
+	// A reasoning model can spend its whole output budget thinking and return
+	// nothing: finish_reason=length, no text, no tool call. Reported as a clean
+	// finish it is indistinguishable from a model that chose to do nothing, and
+	// on the Terminal-Bench baseline that silently lost 13 trials.
+	stream := func(_ context.Context, _ ai.Model, _ ai.Context, _ ai.StreamOptions) (providers.AssistantEventStream, error) {
+		out := providers.NewChannelEventStream(8)
+		go func() {
+			out.Emit(ai.EventStop{Reason: ai.StopReasonLength})
+			out.Finish(nil)
+		}()
+		return out, nil
+	}
+
+	runner := newTestRunner(stream)
+	_, events, err := collectEvents(runner, []ai.Message{ai.UserMessage{Content: "go"}})
+	if err == nil {
+		t.Fatal("an empty truncated turn finished cleanly")
+	}
+	if !strings.Contains(err.Error(), "output token limit") {
+		t.Fatalf("error does not name the cause: %v", err)
+	}
+	if countEvents[AgentErrored](events) != 1 {
+		t.Fatalf("expected 1 AgentErrored, got %d", countEvents[AgentErrored](events))
+	}
+}
+
+func TestRunTruncatedTurnWithContentStaysAFinish(t *testing.T) {
+	// Scoped: a truncated reply that carried text is still usable, and failing
+	// it would throw away a partial answer the caller can read.
+	stream := func(_ context.Context, _ ai.Model, _ ai.Context, _ ai.StreamOptions) (providers.AssistantEventStream, error) {
+		out := providers.NewChannelEventStream(8)
+		go func() {
+			out.Emit(ai.EventTextDelta{Text: "half an ans"})
+			out.Emit(ai.EventStop{Reason: ai.StopReasonLength})
+			out.Finish(nil)
+		}()
+		return out, nil
+	}
+
+	runner := newTestRunner(stream)
+	history, _, err := collectEvents(runner, []ai.Message{ai.UserMessage{Content: "go"}})
+	if err != nil {
+		t.Fatalf("a truncated reply with content must still finish: %v", err)
+	}
+	if len(history) != 2 {
+		t.Fatalf("expected the partial answer in history, got %d messages", len(history))
+	}
+}


### PR DESCRIPTION
## What

Return a provider error when a length-limited response contains neither text nor tool calls.

## Why

A reasoning model can spend its entire output budget before producing a visible reply. Stella previously reported that empty truncated response as a successful finished turn, silently ending benchmark and unattended work with no evidence.

## How

After streaming completes, reject only `StopReasonLength` responses whose content is empty. Truncated responses that contain text or tool calls remain usable. Focused tests cover the empty and non-empty cases.

## Test

- `mise run format`
- `mise run build`
- `mise run test`

## Refs

No issue: self-contained correctness fix discovered while running #1054.