### PR TITLE
🐛 fix(groups): fence PASS retirement with CAS and fail closed on cursor read errors

### DIFF
--- a/internal/channel/group_dispatcher_test.go
+++ b/internal/channel/group_dispatcher_test.go
@@ -2642,3 +2642,31 @@ func TestKnownPublisherErrorCannotErasePriorAmbiguousSend(t *testing.T) {
 		t.Fatalf("ambiguous accepted publish limit = %d, want recovery limit %d", got, acceptedPublishRecoveryMaxAttempts)
 	}
 }
+
+func TestRetireModelPassRejectsLostDispatchOwnership(t *testing.T) {
+	fx := newDispatcherFixture(t, "web", "{}")
+	ctx := context.Background()
+	committed := false
+	fx.d.SetGroupTurnCommitter(groupTurnCommitterFunc(func(context.Context, *sqlc.Queries, memory.DeferredGroupTurn) error {
+		committed = true
+		return nil
+	}))
+	createDispatchForGroupMessage(t, fx.db, fx.message, "d15a0000-0000-0000-0000-000000000110", "agent-1", fx.groupID, "running", pgtype.Timestamptz{})
+	row, err := fx.q.GetGroupDispatch(ctx, "d15a0000-0000-0000-0000-000000000110")
+	if err != nil {
+		t.Fatal(err)
+	}
+	row.AttemptCount++ // a previous owner retired this attempt after our read
+
+	err = fx.d.retireModelPass(ctx, row, memory.DeferredGroupTurn{Complete: true})
+	if err == nil || !strings.Contains(err.Error(), "lost dispatch ownership") {
+		t.Fatalf("pass error = %v, want lost dispatch ownership", err)
+	}
+	if committed {
+		t.Fatal("lost ownership committed deferred turn")
+	}
+	stored, err := fx.q.GetGroupDispatch(ctx, row.ID)
+	if err != nil || stored.Status != "running" {
+		t.Fatalf("dispatch after stale pass = %q/%v, want running", stored.Status, err)
+	}
+}

--- a/internal/channel/group_pass.go
+++ b/internal/channel/group_pass.go
@@ -110,11 +110,17 @@ func (d *GroupDispatcher) retireModelPass(ctx context.Context, row sqlc.CtxGroup
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 	q := d.q.WithTx(tx)
+	// CAS before committing memory: a worker that outlived its lease must not
+	// advance the cursor for a dispatch a newer attempt now owns.
+	updated, err := q.MarkGroupDispatchSilent(ctx, sqlc.MarkGroupDispatchSilentParams{ID: row.ID, AttemptCount: row.AttemptCount, Reason: groupSilentModelPass})
+	if err != nil {
+		return fmt.Errorf("model pass: mark silent: %w", err)
+	}
+	if updated == 0 {
+		return fmt.Errorf("model pass: mark silent: lost dispatch ownership")
+	}
 	if err := d.committer.CommitGroupTurn(ctx, q, turn); err != nil {
 		return fmt.Errorf("model pass: commit read context: %w", err)
-	}
-	if _, err := q.MarkGroupDispatchSilent(ctx, sqlc.MarkGroupDispatchSilentParams{ID: row.ID, AttemptCount: row.AttemptCount, Reason: groupSilentModelPass}); err != nil {
-		return fmt.Errorf("model pass: mark silent: %w", err)
 	}
 	if err := tx.Commit(ctx); err != nil {
 		return fmt.Errorf("model pass: commit: %w", err)

--- a/internal/memory/lcm/group_assembler.go
+++ b/internal/memory/lcm/group_assembler.go
@@ -45,8 +45,12 @@ func (p *Provider) assembleGroup(ctx context.Context, session memory.Session, bu
 		return nil, fmt.Errorf("assemble agent history: %w", err)
 	}
 
-	// 2. Read watermark: last event log seq this agent incorporated.
-	watermark := p.getGroupCursor(ctx, groupID, pipeline)
+	// 2. Read watermark: last event log seq this agent incorporated. Fail the
+	// turn before model execution rather than assemble from seq 0.
+	watermark, err := p.getGroupCursor(ctx, groupID, pipeline)
+	if err != nil {
+		return nil, err
+	}
 
 	// 3. Read between-turn messages from event log.
 	var injected []ai.Message
@@ -122,7 +126,10 @@ func (p *Provider) commitGroupCursorWithQueries(ctx context.Context, q *sqlc.Que
 	}
 	groupID := session.GroupID
 	pipeline := groupCursorPipeline(session.AgentID)
-	watermark := p.getGroupCursorWithQueries(ctx, q, groupID, pipeline)
+	watermark, err := p.getGroupCursorWithQueries(ctx, q, groupID, pipeline)
+	if err != nil {
+		return err
+	}
 	if triggerSeq <= watermark {
 		return nil
 	}
@@ -191,24 +198,26 @@ func flattenUserContent(msg ai.UserMessage) string {
 	}
 }
 
-// getGroupCursor returns the last-seen event log seq for this agent, or 0.
-func (p *Provider) getGroupCursor(ctx context.Context, groupID, pipeline string) int64 {
+// getGroupCursor returns the last-seen event log seq for this agent, or 0 when
+// the agent has none yet. A read error is returned, never masked as 0: a
+// transient failure treated as "no cursor" would replay the entire group
+// history and re-persist it.
+func (p *Provider) getGroupCursor(ctx context.Context, groupID, pipeline string) (int64, error) {
 	return p.getGroupCursorWithQueries(ctx, p.q, groupID, pipeline)
 }
 
-func (p *Provider) getGroupCursorWithQueries(ctx context.Context, q *sqlc.Queries, groupID, pipeline string) int64 {
+func (p *Provider) getGroupCursorWithQueries(ctx context.Context, q *sqlc.Queries, groupID, pipeline string) (int64, error) {
 	cursor, err := q.GetIngestCursor(ctx, sqlc.GetIngestCursorParams{
 		GroupID:  groupID,
 		Pipeline: pipeline,
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
-		return 0
+		return 0, nil
 	}
 	if err != nil {
-		p.log.Warn("failed to read group cursor", "group_id", groupID, "error", err)
-		return 0
+		return 0, fmt.Errorf("read group cursor: %w", err)
 	}
-	return cursor.LastSeq
+	return cursor.LastSeq, nil
 }
 
 // groupRowsToMessages converts event log rows to ai.Messages.

--- a/internal/memory/lcm/group_assembler_test.go
+++ b/internal/memory/lcm/group_assembler_test.go
@@ -614,7 +614,7 @@ func TestGroupAssemble_WatermarkAdvances(t *testing.T) {
 		t.Fatalf("turn 1: expected 2 injected, got %d", len(msgs))
 	}
 
-	if got := p.getGroupCursor(context.Background(), gid, groupCursorPipeline("agent-a")); got != 0 {
+	if got := mustGroupCursor(t, context.Background(), p, gid, groupCursorPipeline("agent-a")); got != 0 {
 		t.Fatalf("assemble advanced cursor before commit: got %d", got)
 	}
 
@@ -629,7 +629,7 @@ func TestGroupAssemble_WatermarkAdvances(t *testing.T) {
 	if err := p.CommitGroupCursor(context.Background(), sess, res3.Seq); err != nil {
 		t.Fatalf("commit cursor turn 1: %v", err)
 	}
-	if got := p.getGroupCursor(context.Background(), gid, groupCursorPipeline("agent-a")); got != res3.Seq {
+	if got := mustGroupCursor(t, context.Background(), p, gid, groupCursorPipeline("agent-a")); got != res3.Seq {
 		t.Fatalf("cursor after commit = %d, want %d", got, res3.Seq)
 	}
 
@@ -687,7 +687,7 @@ func TestGroupAssemblePersistsInjectedButCommitAdvancesCursor(t *testing.T) {
 	if len(msgs) != 1 {
 		t.Fatalf("assemble messages = %d, want 1", len(msgs))
 	}
-	if got := p.getGroupCursor(context.Background(), res1.GroupID, groupCursorPipeline("agent-a")); got != 0 {
+	if got := mustGroupCursor(t, context.Background(), p, res1.GroupID, groupCursorPipeline("agent-a")); got != 0 {
 		t.Fatalf("cursor before commit = %d, want 0", got)
 	}
 	historyBeforeCommit, err := p.assembler.assemble(context.Background(), mustConversationID(t, p, sess), 100_000, 20)
@@ -716,7 +716,7 @@ func TestGroupAssemblePersistsInjectedButCommitAdvancesCursor(t *testing.T) {
 	if err := p.CommitGroupCursor(context.Background(), sess, res2.Seq); err != nil {
 		t.Fatalf("commit cursor: %v", err)
 	}
-	if got := p.getGroupCursor(context.Background(), res1.GroupID, groupCursorPipeline("agent-a")); got != res2.Seq {
+	if got := mustGroupCursor(t, context.Background(), p, res1.GroupID, groupCursorPipeline("agent-a")); got != res2.Seq {
 		t.Fatalf("cursor after commit = %d, want %d", got, res2.Seq)
 	}
 	historyAfterCommit, err := p.assembler.assemble(context.Background(), mustConversationID(t, p, sess), 100_000, 20)
@@ -813,7 +813,7 @@ func TestTxGroupCommitterUsesOuterTxAndSessionLock(t *testing.T) {
 	if stats, err := p.Stats(ctx, sess); err != nil || stats.MessageCount != 3 {
 		t.Fatalf("committed turn stats = %+v, %v", stats, err)
 	}
-	if got := p.getGroupCursor(ctx, groupID, groupCursorPipeline("agent-a")); got != 5 {
+	if got := mustGroupCursor(t, ctx, p, groupID, groupCursorPipeline("agent-a")); got != 5 {
 		t.Fatalf("cursor = %d, want 5", got)
 	}
 }
@@ -895,7 +895,7 @@ func TestGroupAssemble_RotationResetsContextButKeepsWatermark(t *testing.T) {
 	if err := p.CommitGroupCursor(context.Background(), before, res2.Seq); err != nil {
 		t.Fatalf("commit cursor: %v", err)
 	}
-	watermark := p.getGroupCursor(context.Background(), gid, groupCursorPipeline("agent-a"))
+	watermark := mustGroupCursor(t, context.Background(), p, gid, groupCursorPipeline("agent-a"))
 	if watermark != res2.Seq {
 		t.Fatalf("watermark before rotation = %d, want %d", watermark, res2.Seq)
 	}
@@ -911,7 +911,7 @@ func TestGroupAssemble_RotationResetsContextButKeepsWatermark(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("rotate group session: %v", err)
 	}
-	if got := p.getGroupCursor(context.Background(), gid, groupCursorPipeline("agent-a")); got != watermark {
+	if got := mustGroupCursor(t, context.Background(), p, gid, groupCursorPipeline("agent-a")); got != watermark {
 		t.Fatalf("rotation moved the watermark: got %d, want %d", got, watermark)
 	}
 
@@ -977,4 +977,14 @@ func flattenUserMessage(um ai.UserMessage) string {
 	default:
 		return ""
 	}
+}
+
+// mustGroupCursor reads the cursor and fails the test on a read error.
+func mustGroupCursor(t *testing.T, ctx context.Context, p *Provider, groupID, pipeline string) int64 {
+	t.Helper()
+	got, err := p.getGroupCursor(ctx, groupID, pipeline)
+	if err != nil {
+		t.Fatalf("getGroupCursor: %v", err)
+	}
+	return got
 }


### PR DESCRIPTION
## Summary

Two correctness fixes in the merged group-collaboration runtime, found during the #1059 architecture review (PR 0 of that plan):

1. **PASS loses the ownership fence.** `retireModelPass` committed the deferred turn (memory rows + ingest cursor) before `MarkGroupDispatchSilent` and ignored the CAS row count, unlike the accepted/HOLD/silent paths which verify `updated == 1` before committing. A worker that outlived its lease (e.g. a provider ignoring cancellation) could advance the cursor for a dispatch a newer attempt owned. The CAS now runs first in the same transaction and requires one updated row, mirroring `stopGroupTurn`.

2. **Cursor read failed open.** `getGroupCursor` returned 0 on any read error, so a transient database failure became a full group-history replay into one prompt plus re-persistence of every peer row. Read errors now fail the turn before model execution; only `ErrNoRows` means a legitimate empty cursor.

## Tests

- New `TestRetireModelPassRejectsLostDispatchOwnership` (stale attempt → error, no commit, dispatch untouched), modeled on the existing stop-path ownership test.
- Cursor call sites now propagate errors; test helper asserts clean reads.

## Verification

`mise run format && mise run build && mise run test` and `mise run system-test` all green locally.

Refs #1059

## Feishu Task

- [群聊上下文改为每 Agent 独立 LCM + 按需公共历史召回](https://mcnnox2fhjfq.feishu.cn/record/F266rokpce2NuMcp2oHcs0senJg) (#1059)