### PR TITLE
✨ feat(groups): assemble group context from a bounded delivered-only window

### DIFF
--- a/internal/agent/runtime/chat.go
+++ b/internal/agent/runtime/chat.go
@@ -95,14 +95,14 @@ func (rt *Runtime) chatWithRunner(ctx context.Context, out chan<- Event, info se
 	// sink on a direct session must not swallow the ordinary persist path.
 	deferredGroupTurn := hasGroupSink && memSess.GroupID != ""
 	deferred := memory.DeferredGroupTurn{
-		Session:    memSess,
-		TriggerSeq: memory.GroupSeqFromContext(ctx),
+		Session:              memSess,
+		TriggerSeq:           memory.GroupSeqFromContext(ctx),
+		OriginGroupMessageID: memory.GroupMessageIDFromContext(ctx),
 	}
 	// This is the only owner of out for a valid turn. Deliver before close gives
 	// the dispatcher a happens-before edge after it finishes draining the stream.
 	defer func() {
 		if deferredGroupTurn {
-			deferred.InjectedPeerRows = groupSink.Injected()
 			groupSink.Deliver(deferred)
 		}
 		close(out)

--- a/internal/channel/group_accept.go
+++ b/internal/channel/group_accept.go
@@ -88,12 +88,13 @@ func (d *GroupDispatcher) acceptGroupResponse(ctx context.Context, row sqlc.CtxG
 	// in the same process. One lifecycle means recovery, failure compensation
 	// and the peer wake are not three different stories per surface.
 	result, err := eventlog.AppendToGroupWithQueries(ctx, q, row.GroupID, eventlog.GroupMessage{
-		ActorType:      eventlog.ActorAgent,
-		ActorID:        row.AgentID,
-		Content:        response.text,
-		Reasoning:      response.reasoning,
-		AgentSessionID: response.sessionID,
-		DeliveryState:  "pending",
+		ActorType:        eventlog.ActorAgent,
+		ActorID:          row.AgentID,
+		ActorDisplayName: eventlog.NewParticipantNamer(q).Name(ctx, row.GroupID, string(eventlog.ActorAgent), row.AgentID),
+		Content:          response.text,
+		Reasoning:        response.reasoning,
+		AgentSessionID:   response.sessionID,
+		DeliveryState:    "pending",
 	})
 	if err != nil {
 		return groupAcceptOutcome{}, err

--- a/internal/channel/group_chat_resolver.go
+++ b/internal/channel/group_chat_resolver.go
@@ -113,7 +113,7 @@ func (r *groupChatResolver) chatDispatchUnqueued(ctx context.Context, row sqlc.C
 	case message.Seq <= cursor.LastSeq:
 		return nil, errGroupTurnSuperseded
 	}
-	ctx = memory.WithGroupSeq(ctx, message.Seq)
+	ctx = memory.WithGroupMessageID(memory.WithGroupSeq(ctx, message.Seq), message.ID)
 	content := r.triggerContent(ctx, row.GroupID, message)
 	// The only surviving web/platform split, and it is about where a turn's
 	// authority comes from, not about how the reply is delivered. A platform turn
@@ -168,7 +168,11 @@ func groupMessageContentBlocks(message sqlc.CtxGroupMessage) []ai.ContentBlock {
 func (r *groupChatResolver) triggerContent(ctx context.Context, groupID string, message sqlc.CtxGroupMessage) []ai.ContentBlock {
 	blocks := groupMessageContentBlocks(message)
 	namer := eventlog.NewParticipantNamer(r.q)
-	label := fmt.Sprintf("[seq:%d %s]:", message.Seq, namer.Handle(ctx, groupID, message.ActorType, message.ActorID))
+	name := namer.Name(ctx, groupID, message.ActorType, message.ActorID)
+	if message.ActorDisplayName.Valid {
+		name = message.ActorDisplayName.String
+	}
+	label := fmt.Sprintf("[seq:%d %s]:", message.Seq, eventlog.HandleDisplayName(name, message.ActorType))
 	for i, block := range blocks {
 		text, ok := block.(ai.TextContent)
 		if !ok {

--- a/internal/channel/group_dispatch.go
+++ b/internal/channel/group_dispatch.go
@@ -126,6 +126,7 @@ func (c *Coordinator) groupEventMessage(ctx context.Context, msg pkgchannel.Inco
 		SourceChannelID:   channelID,
 		ActorType:         eventlog.ActorHuman,
 		ActorID:           msg.SenderID,
+		ActorDisplayName:  msg.SenderName,
 		PlatformMessageID: msg.MessageID,
 		PlatformTimestamp: msg.Timestamp,
 		ReplyTo:           msg.ReplyTo,

--- a/internal/channel/group_dispatcher.go
+++ b/internal/channel/group_dispatcher.go
@@ -730,6 +730,14 @@ func (d *GroupDispatcher) groupWake(ctx context.Context, row sqlc.CtxGroupDispat
 		return wake
 	}
 	wake.HeldUpToSeq = heldUpTo
+	mentionSeq, err := d.q.GetEarliestGroupMentionSinceCursor(ctx, sqlc.GetEarliestGroupMentionSinceCursorParams{
+		GroupID: row.GroupID, AgentID: row.AgentID, Pipeline: memory.GroupIngestPipeline(row.AgentID), TriggerSeq: row.TriggerSeq,
+	})
+	if err != nil {
+		d.log.Debug("wake mention lookup failed", "dispatch_id", row.ID, "error", err)
+		return wake
+	}
+	wake.MentionSeq = mentionSeq
 	return wake
 }
 

--- a/internal/channel/group_dispatcher_test.go
+++ b/internal/channel/group_dispatcher_test.go
@@ -2089,10 +2089,9 @@ func TestModelPassCommitsReadContextWithoutOwnRows(t *testing.T) {
 	fx.d.chat = func(ctx context.Context, _ sqlc.CtxGroupDispatch, _ sqlc.CtxGroupMessage, _ sqlc.CtxGroupState) (*pkgchannel.ChatStream, error) {
 		if sink, ok := memory.GroupTurnSinkFrom(ctx); ok {
 			sink.Deliver(memory.DeferredGroupTurn{
-				Complete:         true,
-				TriggerSeq:       1,
-				InjectedPeerRows: []ai.Message{ai.UserMessage{Content: "[seq:1 user-1]: hello"}},
-				OwnRows:          []ai.Message{ai.AssistantMessage{}},
+				Complete:   true,
+				TriggerSeq: 1,
+				OwnRows:    []ai.Message{ai.AssistantMessage{}},
 			})
 		}
 		return textStream("  pass  "), nil
@@ -2105,8 +2104,8 @@ func TestModelPassCommitsReadContextWithoutOwnRows(t *testing.T) {
 	if commits != 1 {
 		t.Fatalf("commits = %d, want 1", commits)
 	}
-	if len(committed.InjectedPeerRows) != 1 || committed.TriggerSeq != 1 {
-		t.Fatalf("committed turn = %+v, want the read peer rows and cursor", committed)
+	if committed.TriggerSeq != 1 {
+		t.Fatalf("committed turn = %+v, want the completed trigger cursor", committed)
 	}
 	if len(committed.OwnRows) != 0 {
 		t.Fatalf("committed own rows = %+v, want none", committed.OwnRows)
@@ -2444,7 +2443,6 @@ func TestStoppedTurnsCommitHistoryToolTraceAndCursor(t *testing.T) {
 			tc.prepare(t, fx)
 			outcome, err := fx.d.acceptGroupResponse(ctx, row, groupResponse{text: "stale reply", complete: true}, memory.DeferredGroupTurn{
 				Complete: true, TriggerSeq: fx.message.Seq,
-				InjectedPeerRows: []ai.Message{ai.UserMessage{Content: "[seq:1 user-1]: hello"}},
 				OwnRows: []ai.Message{
 					ai.AssistantMessage{Content: []ai.ContentBlock{ai.ToolCall{ID: "call-1", Name: "group_claim"}}},
 					ai.ToolResultMessage{ToolCallID: "call-1", ToolName: "group_claim", Content: []ai.ContentBlock{ai.TextContent{Text: "claimed"}}},
@@ -2452,8 +2450,8 @@ func TestStoppedTurnsCommitHistoryToolTraceAndCursor(t *testing.T) {
 				},
 			})
 			wantGroupTurnStopped(t, outcome, err, tc.wantStatus, tc.wantReason)
-			if committed.TriggerSeq != fx.message.Seq || len(committed.InjectedPeerRows) != 1 {
-				t.Fatalf("committed read boundary = %+v, want trigger cursor and history", committed)
+			if committed.TriggerSeq != fx.message.Seq {
+				t.Fatalf("committed read boundary = %+v, want trigger cursor", committed)
 			}
 			if len(committed.OwnRows) != 2 {
 				t.Fatalf("committed own rows = %+v, want tool trace without stale assistant reply", committed.OwnRows)

--- a/internal/channel/group_nudge.go
+++ b/internal/channel/group_nudge.go
@@ -234,7 +234,7 @@ func (n *GroupNudger) append(ctx context.Context, groupID, expectedLastMessageID
 	// The nudge is read by the whole group, so it names the target the way the
 	// group addresses them; the id it dispatches on rides in the envelope.
 	targetName := eventlog.NewParticipantNamer(q).Handle(ctx, groupID, string(eventlog.ActorAgent), target)
-	result, err := eventlog.AppendToGroupWithQueries(ctx, q, groupID, eventlog.GroupMessage{ActorType: eventlog.ActorSystem, ActorID: "nudge", Content: fmt.Sprintf("%s, please continue %s.", targetName, note)})
+	result, err := eventlog.AppendToGroupWithQueries(ctx, q, groupID, eventlog.GroupMessage{ActorType: eventlog.ActorSystem, ActorID: "nudge", ActorDisplayName: eventlog.SystemParticipantName, Content: fmt.Sprintf("%s, please continue %s.", targetName, note)})
 	if err != nil {
 		return fmt.Errorf("append nudge message: %w", err)
 	}

--- a/internal/channel/group_pass.go
+++ b/internal/channel/group_pass.go
@@ -94,9 +94,8 @@ func stripTrailingTextOnlyAssistant(rows []ai.Message) []ai.Message {
 
 // retireModelPass records the silent turn and commits what the agent read.
 //
-// The peer rows it was shown and its ingest cursor still commit: the agent did
-// read them, and leaving the cursor behind would replay the same messages on
-// every later turn. The pass reply itself does not: an empty assistant message
+// Its trigger anchor, private tool trajectory, and completed-trigger cursor
+// still commit. The pass reply itself does not: an empty assistant message
 // would make the session history look like the agent ignored the group, and
 // some providers reject empty turns outright.
 func (d *GroupDispatcher) retireModelPass(ctx context.Context, row sqlc.CtxGroupDispatch, turn memory.DeferredGroupTurn) error {

--- a/internal/channel/group_service.go
+++ b/internal/channel/group_service.go
@@ -539,12 +539,14 @@ func (a *GroupAccess) PrepareSend(ctx context.Context, groupID, content, clientM
 	// Unified entry: triple resolve + dedup via AppendGroupMessage. Empty
 	// client_message_id disables tier-1 dedup (no fake UUID). The outbox is created
 	// inside the same transaction so a fresh message always has a claimable row.
+	actorID := a.actorUserID()
 	appendResult, err := a.svc.eventLog.AppendGroupMessage(ctx, eventlog.Message{
 		Platform:          webGroupPlatform,
 		PlatformGroupID:   groupID,
 		PlatformThreadID:  "",
 		ActorType:         eventlog.ActorHuman,
-		ActorID:           a.actorUserID(),
+		ActorID:           actorID,
+		ActorDisplayName:  eventlog.NewParticipantNamer(a.q()).Name(ctx, groupID, string(eventlog.ActorHuman), actorID),
 		PlatformMessageID: clientMessageID,
 		Content:           content,
 	}, eventlog.WithOnInserted(func(ctx context.Context, q *sqlc.Queries, result eventlog.AppendResult) error {

--- a/internal/db/migrations/90000000000021_add_group_context_window_origins.sql
+++ b/internal/db/migrations/90000000000021_add_group_context_window_origins.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+ALTER TABLE ctx_group_message
+    ADD COLUMN actor_display_name TEXT NULL;
+
+ALTER TABLE ctx_message
+    ADD COLUMN origin_group_message_id UUID NULL REFERENCES ctx_group_message(id);
+
+CREATE UNIQUE INDEX idx_ctx_message_conversation_origin_group_message
+    ON ctx_message (conversation_id, origin_group_message_id)
+    WHERE origin_group_message_id IS NOT NULL;
+
+-- +goose Down
+DROP INDEX idx_ctx_message_conversation_origin_group_message;
+
+ALTER TABLE ctx_message
+    DROP COLUMN origin_group_message_id;
+
+ALTER TABLE ctx_group_message
+    DROP COLUMN actor_display_name;

--- a/internal/db/previous_ga_migration_test.go
+++ b/internal/db/previous_ga_migration_test.go
@@ -29,12 +29,13 @@ const (
 	// Library V1, channel guest sessions/indexes, channel allowlist backfill,
 	// session activity, per-message actor provenance and summary authority,
 	// the durable Session inbox, restrictive Library ownership, and the Discord
-	// explicit guild-access backfill, optimistic group-dispatch plumbing, and
-	// the reply-to-wake optimistic cutover, and per-call LLM usage accounting
-	// are the post-anchor migrations exercised below. Library chunk locator
+	// explicit guild-access backfill, optimistic group-dispatch plumbing, the
+	// reply-to-wake optimistic cutover, per-call LLM usage accounting, and the
+	// group context event/trigger origin columns are the post-anchor migrations
+	// exercised below. Library chunk locator
 	// integrity, the dedicated Skill Home cutover evidence schema, and retired
 	// RTK plugin cleanup are checked explicitly.
-	currentMigrationVersion = sequentialAnchor + 20
+	currentMigrationVersion = sequentialAnchor + 21
 
 	previousGAUserID                     = "00000000-0000-0000-0000-000000000001"
 	previousGAGroupID                    = "00000000-0000-0000-0000-000000000002"

--- a/internal/db/queries/ctx_group.sql
+++ b/internal/db/queries/ctx_group.sql
@@ -248,12 +248,12 @@ LIMIT sqlc.arg(limit_count) OFFSET sqlc.arg(offset_count);
 -- name: CreateGroupMessage :one
 INSERT INTO ctx_group_message (
   id, group_id, seq, source_channel_id, actor_type, actor_id,
-  platform_message_id, reply_to, platform_timestamp, idempotency_key, content, content_blocks, reasoning, agent_session_id, delivery_state
+  platform_message_id, reply_to, platform_timestamp, idempotency_key, actor_display_name, content, content_blocks, reasoning, agent_session_id, delivery_state
 )
 VALUES (
   sqlc.arg(id), sqlc.arg(group_id), sqlc.arg(seq), sqlc.arg(source_channel_id),
   sqlc.arg(actor_type), sqlc.arg(actor_id), sqlc.arg(platform_message_id),
-  sqlc.arg(reply_to), sqlc.arg(platform_timestamp), sqlc.arg(idempotency_key),
+  sqlc.arg(reply_to), sqlc.arg(platform_timestamp), sqlc.arg(idempotency_key), sqlc.narg('actor_display_name'),
   sqlc.arg(content), COALESCE(sqlc.arg(content_blocks)::jsonb, '[]'::jsonb),
   sqlc.arg(reasoning), sqlc.arg(agent_session_id), sqlc.arg(delivery_state)
 )

--- a/internal/db/queries/ctx_group_dispatch.sql
+++ b/internal/db/queries/ctx_group_dispatch.sql
@@ -367,6 +367,22 @@ SELECT EXISTS (
     AND (outbox.envelope::jsonb -> 'mentions') @> jsonb_build_array(jsonb_build_object('AgentID', sqlc.arg(agent_id)::text))
 )::boolean;
 
+-- name: GetEarliestGroupMentionSinceCursor :one
+-- The bounded context assembler needs the actual event, not just the triage
+-- boolean, when a coalesced wake would otherwise omit the mentioning row.
+SELECT COALESCE(MIN(message.seq), 0)::bigint
+FROM ctx_group_outbox outbox
+JOIN ctx_group_message message ON message.id = outbox.group_message_id
+LEFT JOIN ctx_group_ingest_cursor cursor
+  ON cursor.group_id = message.group_id
+ AND cursor.pipeline = sqlc.arg(pipeline)
+WHERE message.group_id = sqlc.arg(group_id)
+  AND message.actor_id <> sqlc.arg(agent_id)
+  AND message.seq > COALESCE(cursor.last_seq, 0)
+  AND message.seq <= sqlc.arg(trigger_seq)
+  AND message.delivery_state = 'delivered'
+  AND (outbox.envelope::jsonb -> 'mentions') @> jsonb_build_array(jsonb_build_object('AgentID', sqlc.arg(agent_id)::text));
+
 -- name: AgentPostedSinceSeq :one
 -- Has this agent already spoken after the given seq? A nudge names one agent
 -- and never gets superseded, so a wake that was already in flight can post the

--- a/internal/db/queries/ctx_group_ingest.sql
+++ b/internal/db/queries/ctx_group_ingest.sql
@@ -18,11 +18,9 @@ ON CONFLICT(group_id, pipeline, seq) DO NOTHING;
 SELECT count(*) > 0 as is_error FROM ctx_group_ingest_error
 WHERE group_id = sqlc.arg(group_id) AND pipeline = sqlc.arg(pipeline) AND seq = sqlc.arg(seq);
 
--- Both ingest list queries feed text-only consumers (group-memory extraction and
--- LCM cross-agent assembly); neither reads content_blocks. They select an
--- explicit column list that EXCLUDES content_blocks so a lagging agent or a
--- memory batch never drags inbound image payloads across the seq range —
--- ListGroupMessagesBetweenSeqs has no LIMIT, so the interval alone bounds it.
+-- These text-only ingest/context readers deliberately exclude content_blocks:
+-- historical group context retains the content projection (including [image])
+-- without loading the original media payload.
 
 -- name: ListGroupMessagesAfterSeq :many
 SELECT id, group_id, seq, source_channel_id, actor_type, actor_id,
@@ -48,19 +46,31 @@ SELECT * FROM (
 ) recent
 ORDER BY recent.seq ASC;
 
--- name: ListGroupMessagesBetweenSeqs :many
-SELECT id, group_id, seq, source_channel_id, actor_type, actor_id,
-       platform_message_id, reply_to, platform_timestamp, idempotency_key,
-       content, reasoning, agent_session_id, created_at
+-- name: ListDeliveredGroupMessagesBeforeSeq :many
+-- Reverse pagination is mandatory: group context reads only its newest bounded
+-- window, never an interval whose size is controlled by group history.
+SELECT id, group_id, seq, actor_type, actor_id, actor_display_name, content
 FROM ctx_group_message
 WHERE group_id = sqlc.arg(group_id)
-  AND seq > sqlc.arg(after_seq)
   AND seq < sqlc.arg(before_seq)
-  -- A failed platform delivery was never visible to peers. The author keeps
-  -- its own attempted reply and tool history in memory, but no other agent may
-  -- reason from a canonical row that the conversation never received.
-  AND delivery_state <> 'failed'
-ORDER BY seq ASC;
+  AND delivery_state = 'delivered'
+ORDER BY seq DESC
+LIMIT sqlc.arg(page_size);
+
+-- name: ExistsGroupMessageBeforeSeq :one
+SELECT EXISTS (
+  SELECT 1
+  FROM ctx_group_message
+  WHERE group_id = sqlc.arg(group_id)
+    AND seq < sqlc.arg(before_seq)
+)::boolean;
+
+-- name: GetDeliveredGroupMessageBySeq :one
+SELECT id, group_id, seq, actor_type, actor_id, actor_display_name, content
+FROM ctx_group_message
+WHERE group_id = sqlc.arg(group_id)
+  AND seq = sqlc.arg(seq)
+  AND delivery_state = 'delivered';
 
 -- name: ListGroupsWithPendingIngest :many
 SELECT gs.id as group_id,

--- a/internal/db/queries/ctx_message.sql
+++ b/internal/db/queries/ctx_message.sql
@@ -1,13 +1,18 @@
 -- name: CreateMessage :one
 INSERT INTO ctx_message (
     id, conversation_id, seq, role, event_type, content, token_count,
-    actor_type, actor_id, source_session_id, inbox_id
+    actor_type, actor_id, source_session_id, inbox_id, origin_group_message_id
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, sqlc.narg('inbox_id'))
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, sqlc.narg('inbox_id'), sqlc.narg('origin_group_message_id'))
 RETURNING *;
 
 -- name: GetMessage :one
 SELECT * FROM ctx_message WHERE id = $1 AND conversation_id = $2;
+
+-- name: GetMessageByConversationOrigin :one
+SELECT * FROM ctx_message
+WHERE conversation_id = sqlc.arg(conversation_id)
+  AND origin_group_message_id = sqlc.arg(origin_group_message_id);
 
 -- name: GetMessageScoped :one
 -- Fetch one message in full by ID, scoped to (user_id, agent_id) across every
@@ -73,7 +78,7 @@ WITH ordered AS (
     LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset')
 )
 SELECT id, conversation_id, seq, role, event_type, content, token_count, created_at,
-       actor_type, actor_id, source_session_id, inbox_id
+       actor_type, actor_id, source_session_id, inbox_id, origin_group_message_id
 FROM grouped
 WHERE logical_idx IN (SELECT logical_idx FROM selected_groups)
 ORDER BY seq ASC;
@@ -119,7 +124,7 @@ WITH ordered AS (
     LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset')
 )
 SELECT id, conversation_id, seq, role, event_type, content, token_count, created_at,
-       actor_type, actor_id, source_session_id, inbox_id
+       actor_type, actor_id, source_session_id, inbox_id, origin_group_message_id
 FROM grouped
 WHERE turn_idx IN (SELECT turn_idx FROM selected_turns)
 ORDER BY seq ASC;

--- a/internal/eventlog/eventlog.go
+++ b/internal/eventlog/eventlog.go
@@ -104,8 +104,9 @@ type Message struct {
 
 	SourceChannelID string // observing bot; audit only, never a dedup/route key
 
-	ActorType ActorType
-	ActorID   string // platform sender id (human) or agent id (agent)
+	ActorType        ActorType
+	ActorID          string // platform sender id (human) or agent id (agent)
+	ActorDisplayName string // event-time snapshot; empty preserves legacy NULL
 
 	PlatformMessageID string // "" when the adapter cannot supply one
 	ReplyTo           string // platform message id this replies to; "" if none
@@ -225,6 +226,7 @@ func (s *Store) AppendGroupMessage(ctx context.Context, msg Message, opts ...App
 		SourceChannelID:   pgnull.TextTrim(msg.SourceChannelID),
 		ActorType:         string(msg.ActorType),
 		ActorID:           msg.ActorID,
+		ActorDisplayName:  pgnull.TextTrim(msg.ActorDisplayName),
 		PlatformMessageID: pgnull.TextTrim(msg.PlatformMessageID),
 		ReplyTo:           pgnull.TextTrim(msg.ReplyTo),
 		PlatformTimestamp: nullTime(msg.PlatformTimestamp),
@@ -315,16 +317,17 @@ func AppendToGroupWithQueries(ctx context.Context, q *sqlc.Queries, groupID stri
 		return AppendResult{}, fmt.Errorf("eventlog: bump seq: %w", err)
 	}
 	row, err := q.CreateGroupMessage(ctx, sqlc.CreateGroupMessageParams{
-		ID:             uuid.Must(uuid.NewV7()).String(),
-		GroupID:        groupID,
-		Seq:            seq,
-		ActorType:      string(msg.ActorType),
-		ActorID:        msg.ActorID,
-		Content:        msg.Content,
-		ContentBlocks:  contentBlocksOrEmpty(nil),
-		Reasoning:      msg.Reasoning,
-		AgentSessionID: msg.AgentSessionID,
-		DeliveryState:  deliveryStateOrDelivered(msg.DeliveryState),
+		ID:               uuid.Must(uuid.NewV7()).String(),
+		GroupID:          groupID,
+		Seq:              seq,
+		ActorType:        string(msg.ActorType),
+		ActorID:          msg.ActorID,
+		ActorDisplayName: pgnull.TextTrim(msg.ActorDisplayName),
+		Content:          msg.Content,
+		ContentBlocks:    contentBlocksOrEmpty(nil),
+		Reasoning:        msg.Reasoning,
+		AgentSessionID:   msg.AgentSessionID,
+		DeliveryState:    deliveryStateOrDelivered(msg.DeliveryState),
 	})
 	if err != nil {
 		return AppendResult{}, fmt.Errorf("eventlog: create message: %w", err)
@@ -359,11 +362,12 @@ func validateGroupAppend(groupID string, msg GroupMessage) error {
 
 // GroupMessage is a simplified message for direct group append (pre-resolved groupID).
 type GroupMessage struct {
-	ActorType      ActorType
-	ActorID        string
-	Content        string
-	Reasoning      string
-	AgentSessionID string
+	ActorType        ActorType
+	ActorID          string
+	ActorDisplayName string // event-time snapshot; empty preserves legacy NULL
+	Content          string
+	Reasoning        string
+	AgentSessionID   string
 	// DeliveryState is pending only for an accepted platform reply awaiting
 	// egress. All ingress and Web messages are immediately delivered.
 	DeliveryState string

--- a/internal/eventlog/participant.go
+++ b/internal/eventlog/participant.go
@@ -110,7 +110,12 @@ func (n *ParticipantNamer) Line(ctx context.Context, groupID string, seq int64, 
 
 // Handle is Name with the "@" agents are addressed by.
 func (n *ParticipantNamer) Handle(ctx context.Context, groupID string, actorType, actorID string) string {
-	name := n.Name(ctx, groupID, actorType, actorID)
+	return HandleDisplayName(n.Name(ctx, groupID, actorType, actorID), actorType)
+}
+
+// HandleDisplayName applies the group-addressable agent prefix to a stored
+// event-time name. Callers pass a live fallback only for legacy NULL snapshots.
+func HandleDisplayName(name, actorType string) string {
 	if actorType == string(ActorAgent) && !strings.HasPrefix(name, "@") {
 		return "@" + name
 	}

--- a/internal/memory/lcm/engine.go
+++ b/internal/memory/lcm/engine.go
@@ -152,11 +152,12 @@ type toolResultEnvelope struct {
 // name their text-only search/token projection explicitly; legacy rows leave
 // parts nil and continue to use their historical inline content codec.
 type storageRow struct {
-	role      string
-	eventType string
-	content   string
-	tokenText string
-	parts     []messagePartRow
+	role                 string
+	eventType            string
+	content              string
+	tokenText            string
+	originGroupMessageID string // set only on a group turn's trigger user anchor
+	parts                []messagePartRow
 }
 
 type messagePartRow struct {

--- a/internal/memory/lcm/group_assembler.go
+++ b/internal/memory/lcm/group_assembler.go
@@ -60,10 +60,21 @@ func (p *Provider) assembleGroup(ctx context.Context, session memory.Session, bu
 		return nil, err
 	}
 
-	messages := make([]ai.Message, 0, len(private.legacy)+len(window)+1)
-	// Origins did not exist before this migration. Keep those historical LCM
-	// rows in their old relative order rather than attempting an unsafe backfill.
-	messages = append(messages, private.legacy...)
+	inWindow := make(map[string]bool, len(window))
+	for _, event := range window {
+		inWindow[event.id] = true
+	}
+
+	messages := make([]ai.Message, 0, len(window)+1)
+	// Head: this agent's own turns that the public window no longer covers.
+	// Pre-migration turns have no origin and keep their old relative order; a
+	// turn whose trigger was evicted keeps its stored anchor plus continuation —
+	// the agent's private tool history must outlive the sliding public window.
+	for _, turn := range private.turns {
+		if turn.origin == "" || !inWindow[turn.origin] {
+			messages = append(messages, turn.full...)
+		}
+	}
 	if omitted {
 		messages = append(messages, ai.UserMessage{Content: groupHistoryOmittedMarker})
 	}
@@ -76,15 +87,16 @@ func (p *Provider) assembleGroup(ctx context.Context, session memory.Session, bu
 		messages = append(messages, ai.UserMessage{Content: event.line})
 		messages = append(messages, private.byOrigin[event.id]...)
 	}
-	// A legacy/orphaned anchor is still this agent's own turn. It has no safe
-	// public position, so preserve it at the head with other pre-migration rows.
-	messages = append(messages, private.orphaned...)
 	return sanitizeToolPairs(trimOldestCompleteTurns(messages, budget)), nil
 }
 
+type groupPrivateTurn struct {
+	origin string // "" for pre-migration rows without a trigger anchor
+	full   []ai.Message
+}
+
 type groupPrivateTurns struct {
-	legacy   []ai.Message
-	orphaned []ai.Message
+	turns    []groupPrivateTurn
 	byOrigin map[string][]ai.Message
 }
 
@@ -119,12 +131,14 @@ func (p *Provider) loadGroupPrivateTurns(ctx context.Context, convID string) (gr
 		turnMessages := rowsToMessages(turnRows, partsByMessage)
 		anchor := turnRows[0]
 		if anchor.Role != roleUser || !anchor.OriginGroupMessageID.Valid {
-			out.legacy = append(out.legacy, turnMessages...)
+			out.turns = append(out.turns, groupPrivateTurn{full: turnMessages})
 		} else {
-			// Do not repeat the stored trigger. The canonical event supplies the
-			// public anchor; only its private continuation belongs after it.
-			continuation := rowsToMessages(turnRows[1:], partsByMessage)
-			out.byOrigin[anchor.OriginGroupMessageID.String] = continuation
+			// When the trigger is inside the public window, the canonical event
+			// supplies the anchor and only the continuation follows it; when the
+			// window has evicted it, the stored anchor keeps the turn coherent.
+			origin := anchor.OriginGroupMessageID.String
+			out.turns = append(out.turns, groupPrivateTurn{origin: origin, full: turnMessages})
+			out.byOrigin[origin] = rowsToMessages(turnRows[1:], partsByMessage)
 		}
 		start = end
 	}

--- a/internal/memory/lcm/group_assembler.go
+++ b/internal/memory/lcm/group_assembler.go
@@ -201,6 +201,11 @@ collected:
 		default:
 			event := groupWindowEventFromRow(ctx, namer, groupID, mention.ID, mention.Seq, mention.ActorType, mention.ActorID, mention.ActorDisplayName.String, mention.Content)
 			if event.content != "" {
+				var fit bool
+				window, fit = makeRoomForForcedGroupEvent(window, event, maxTokens)
+				if !fit {
+					return nil, false, fmt.Errorf("waking mention exceeds group context ceiling")
+				}
 				window = append([]groupWindowEvent{event}, window...)
 			}
 		}
@@ -226,6 +231,32 @@ func groupWindowEventFromRow(ctx context.Context, namer *eventlog.ParticipantNam
 		id: id, seq: seq, actorType: actorType, actorID: actorID, actorDisplayName: displayName,
 		content: content, line: line, tokens: estimateMessageTokens(message), bytes: len(line),
 	}
+}
+
+// makeRoomForForcedGroupEvent preserves the three public-window ceilings when
+// a coalesced waking mention must be restored below the normal floor. It drops
+// whole head blocks from ordinary history; an oversized mention fails the turn
+// rather than silently violating a memory ceiling.
+func makeRoomForForcedGroupEvent(window []groupWindowEvent, forced groupWindowEvent, maxTokens int) ([]groupWindowEvent, bool) {
+	if forced.tokens > maxTokens || forced.bytes > groupWindowMaxBytes {
+		return nil, false
+	}
+	usedTokens, usedBytes := 0, 0
+	for _, event := range window {
+		usedTokens += event.tokens
+		usedBytes += event.bytes
+	}
+	for len(window) > 0 && (len(window)+1 > groupWindowMaxRows || usedTokens+forced.tokens > maxTokens || usedBytes+forced.bytes > groupWindowMaxBytes) {
+		blockTokens, end := 0, 0
+		for end < len(window) && blockTokens < groupWindowEvictionBlockTokens {
+			blockTokens += window[end].tokens
+			usedBytes -= window[end].bytes
+			end++
+		}
+		usedTokens -= blockTokens
+		window = window[end:]
+	}
+	return window, len(window)+1 <= groupWindowMaxRows && usedTokens+forced.tokens <= maxTokens && usedBytes+forced.bytes <= groupWindowMaxBytes
 }
 
 func groupWindowContainsSeq(window []groupWindowEvent, seq int64) bool {

--- a/internal/memory/lcm/group_assembler.go
+++ b/internal/memory/lcm/group_assembler.go
@@ -15,84 +15,263 @@ import (
 
 func groupCursorPipeline(agentID string) string { return memory.GroupIngestPipeline(agentID) }
 
-// assembleGroup builds a hybrid context window for group sessions.
-//
-// Per-agent reasoning (tool calls, tool results, assistant responses) lives in
-// ctx_message/ctx_item — the standard LCM path. Cross-agent conversation lives
-// in the event log. This method merges both:
-//
-//  1. Standard LCM assembly from ctx_message (agent's own conversation history)
-//  2. Event log messages from other participants between the last watermark and
-//     the current triggering message's seq
-//
-// The watermark (stored in ctx_group_ingest_cursor, pipeline="lcm:<agentID>") tracks which
-// event log seq this agent has already incorporated. The triggering message's seq
-// comes from the context (set by group_dispatch) so it can be excluded from
-// injection — it enters via the normal Append + live userMsg path in chat.go.
-func (p *Provider) assembleGroup(ctx context.Context, session memory.Session, budget, freshTail int) ([]ai.Message, error) {
-	groupID := session.GroupID
-	agentID := session.AgentID
-	triggerSeq := memory.GroupSeqFromContext(ctx)
-	pipeline := groupCursorPipeline(agentID)
+const (
+	groupWindowMaxRows   = 500
+	groupWindowMaxTokens = 80_000
+	groupWindowMaxBytes  = 4 << 20
+	groupWindowPageSize  = 100
 
-	// 1. Standard LCM assembly: agent's own conversation with tool use.
+	// This is a global ceiling. Move to per-group budgets only when group traffic
+	// or prompt-cache measurements show the shared limit is constraining them.
+	groupWindowEvictionBlockTokens = 10_000
+)
+
+const groupHistoryOmittedMarker = "[system]: earlier group history omitted; use memory.search"
+
+type groupWindowEvent struct {
+	id               string
+	seq              int64
+	actorType        string
+	actorID          string
+	actorDisplayName string
+	content          string
+	line             string
+	tokens           int
+	bytes            int
+}
+
+// assembleGroup combines the canonical delivered event window with this
+// agent's private LCM turns. Public group rows never enter ctx_message: only a
+// turn's trigger anchor and its assistant/tool continuation are durable there.
+func (p *Provider) assembleGroup(ctx context.Context, session memory.Session, budget, _ int) ([]ai.Message, error) {
 	convID, err := p.getOrCreateConversation(ctx, session)
 	if err != nil {
 		return nil, fmt.Errorf("get conversation: %w", err)
 	}
-	agentHistory, err := p.assembler.assemble(ctx, convID, budget, freshTail)
+
+	private, err := p.loadGroupPrivateTurns(ctx, convID)
 	if err != nil {
-		return nil, fmt.Errorf("assemble agent history: %w", err)
+		return nil, fmt.Errorf("load private group turns: %w", err)
 	}
 
-	// 2. Read watermark: last event log seq this agent incorporated. Fail the
-	// turn before model execution rather than assemble from seq 0.
-	watermark, err := p.getGroupCursor(ctx, groupID, pipeline)
+	wake := memory.GroupWakeFromContext(ctx)
+	window, omitted, err := p.loadGroupWindow(ctx, session.GroupID, session.AgentID, memory.GroupSeqFromContext(ctx), wake.MentionSeq, budget)
 	if err != nil {
 		return nil, err
 	}
 
-	// 3. Read between-turn messages from event log.
-	var injected []ai.Message
-	if triggerSeq > 0 && triggerSeq > watermark+1 {
-		rows, err := p.q.ListGroupMessagesBetweenSeqs(ctx, sqlc.ListGroupMessagesBetweenSeqsParams{
-			GroupID:   groupID,
-			AfterSeq:  watermark,
-			BeforeSeq: triggerSeq,
+	messages := make([]ai.Message, 0, len(private.legacy)+len(window)+1)
+	// Origins did not exist before this migration. Keep those historical LCM
+	// rows in their old relative order rather than attempting an unsafe backfill.
+	messages = append(messages, private.legacy...)
+	if omitted {
+		messages = append(messages, ai.UserMessage{Content: groupHistoryOmittedMarker})
+	}
+	for _, event := range window {
+		// This agent's published reply is already represented by the private
+		// continuation following its trigger, so never show it twice.
+		if event.actorType == string(eventlog.ActorAgent) && event.actorID == session.AgentID {
+			continue
+		}
+		messages = append(messages, ai.UserMessage{Content: event.line})
+		messages = append(messages, private.byOrigin[event.id]...)
+	}
+	// A legacy/orphaned anchor is still this agent's own turn. It has no safe
+	// public position, so preserve it at the head with other pre-migration rows.
+	messages = append(messages, private.orphaned...)
+	return sanitizeToolPairs(trimOldestCompleteTurns(messages, budget)), nil
+}
+
+type groupPrivateTurns struct {
+	legacy   []ai.Message
+	orphaned []ai.Message
+	byOrigin map[string][]ai.Message
+}
+
+func (p *Provider) loadGroupPrivateTurns(ctx context.Context, convID string) (groupPrivateTurns, error) {
+	rows, err := p.q.GetMessagesByConversation(ctx, convID)
+	if err != nil {
+		return groupPrivateTurns{}, err
+	}
+	out := groupPrivateTurns{byOrigin: make(map[string][]ai.Message)}
+	if len(rows) == 0 {
+		return out, nil
+	}
+	ids := make([]string, 0, len(rows))
+	for _, row := range rows {
+		ids = append(ids, row.ID)
+	}
+	parts, err := p.q.GetMessagePartsByMessages(ctx, ids)
+	if err != nil {
+		return groupPrivateTurns{}, err
+	}
+	partsByMessage := make(map[string][]loadedMessagePart, len(parts))
+	for _, part := range parts {
+		partsByMessage[part.MessageID] = append(partsByMessage[part.MessageID], part)
+	}
+
+	for start := 0; start < len(rows); {
+		end := start + 1
+		for end < len(rows) && rows[end].Role != roleUser {
+			end++
+		}
+		turnRows := rows[start:end]
+		turnMessages := rowsToMessages(turnRows, partsByMessage)
+		anchor := turnRows[0]
+		if anchor.Role != roleUser || !anchor.OriginGroupMessageID.Valid {
+			out.legacy = append(out.legacy, turnMessages...)
+		} else {
+			// Do not repeat the stored trigger. The canonical event supplies the
+			// public anchor; only its private continuation belongs after it.
+			continuation := rowsToMessages(turnRows[1:], partsByMessage)
+			out.byOrigin[anchor.OriginGroupMessageID.String] = continuation
+		}
+		start = end
+	}
+	return out, nil
+}
+
+// loadGroupWindow reverse-pages only delivered rows strictly before triggerSeq.
+// Each read has a LIMIT and collection stops under row, token, and byte ceilings.
+func (p *Provider) loadGroupWindow(ctx context.Context, groupID, agentID string, triggerSeq, mentionSeq int64, budget int) ([]groupWindowEvent, bool, error) {
+	if triggerSeq <= 0 {
+		return nil, false, nil
+	}
+	maxTokens := groupWindowMaxTokens
+	if budget > 0 && budget < maxTokens {
+		maxTokens = budget
+	}
+	namer := eventlog.NewParticipantNamer(p.q)
+	before := triggerSeq
+	reverse := make([]groupWindowEvent, 0, min(groupWindowMaxRows, groupWindowPageSize))
+	usedTokens, usedBytes := 0, 0
+	for len(reverse) < groupWindowMaxRows {
+		page, err := p.q.ListDeliveredGroupMessagesBeforeSeq(ctx, sqlc.ListDeliveredGroupMessagesBeforeSeqParams{
+			GroupID: groupID, BeforeSeq: before, PageSize: groupWindowPageSize,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("list between-turn messages: %w", err)
+			return nil, false, fmt.Errorf("list delivered group window: %w", err)
 		}
-		injected = groupRowsToMessages(ctx, eventlog.NewParticipantNamer(p.q), groupID, rows, agentID)
-	}
-
-	// A deferred group turn commits peer rows in the dispatcher's accept tx. The
-	// sink receives the full set before trim because rows outside this prompt
-	// window still have to be committed before its cursor can advance.
-	if sink, ok := memory.GroupTurnSinkFrom(ctx); ok {
-		sink.SetInjected(injected)
-		agentHistory = append(agentHistory, injected...)
-	} else {
-		// Legacy callers retain the original inline append path exactly. In
-		// particular, this defensive content dedup only belongs here: deferred
-		// turns must preserve legitimately repeated peer messages.
-		injected, err = p.filterAlreadyPersistedInjected(ctx, convID, injected)
-		if err != nil {
-			return nil, fmt.Errorf("filter persisted injected messages: %w", err)
+		if len(page) == 0 {
+			break
 		}
-		if len(injected) > 0 {
-			if err := p.Append(ctx, session, injected...); err != nil {
-				return nil, fmt.Errorf("persist between-turn messages: %w", err)
+		for _, row := range page {
+			event := groupWindowEventFromRow(ctx, namer, groupID, row.ID, row.Seq, row.ActorType, row.ActorID, row.ActorDisplayName.String, row.Content)
+			if event.content == "" {
+				continue
 			}
-			agentHistory = append(agentHistory, injected...)
+			if len(reverse) == groupWindowMaxRows || usedTokens+event.tokens > maxTokens || usedBytes+event.bytes > groupWindowMaxBytes {
+				goto collected
+			}
+			reverse = append(reverse, event)
+			usedTokens += event.tokens
+			usedBytes += event.bytes
+		}
+		before = page[len(page)-1].Seq
+		if len(page) < groupWindowPageSize {
+			break
 		}
 	}
 
-	// 4. Apply the post-injection budget by whole user turns. The ordinary
-	// assembler has already made tool turns provider-safe; a second message-level
-	// trim must not detach tool results or a final answer from their user turn.
-	agentHistory = trimOldestCompleteTurns(agentHistory, budget)
-	return sanitizeToolPairs(agentHistory), nil
+collected:
+	window := reverseGroupWindow(reverse)
+	if mentionSeq > 0 && (len(window) == 0 || mentionSeq < window[0].seq) {
+		mention, err := p.q.GetDeliveredGroupMessageBySeq(ctx, sqlc.GetDeliveredGroupMessageBySeqParams{GroupID: groupID, Seq: mentionSeq})
+		switch {
+		case errors.Is(err, pgx.ErrNoRows):
+			// A stale wake can point at an event that was never delivered. It is
+			// not peer-visible evidence, so the delivered-only invariant wins.
+		case err != nil:
+			return nil, false, fmt.Errorf("get waking mention: %w", err)
+		default:
+			event := groupWindowEventFromRow(ctx, namer, groupID, mention.ID, mention.Seq, mention.ActorType, mention.ActorID, mention.ActorDisplayName.String, mention.Content)
+			if event.content != "" {
+				window = append([]groupWindowEvent{event}, window...)
+			}
+		}
+	}
+	window = quantizeGroupWindow(window, maxTokens)
+	if mentionSeq > 0 && !groupWindowContainsSeq(window, mentionSeq) {
+		mention, err := p.q.GetDeliveredGroupMessageBySeq(ctx, sqlc.GetDeliveredGroupMessageBySeqParams{GroupID: groupID, Seq: mentionSeq})
+		switch {
+		case errors.Is(err, pgx.ErrNoRows):
+			// Delivery state is authoritative even for a stale mention wake.
+		case err != nil:
+			return nil, false, fmt.Errorf("restore waking mention: %w", err)
+		default:
+			event := groupWindowEventFromRow(ctx, namer, groupID, mention.ID, mention.Seq, mention.ActorType, mention.ActorID, mention.ActorDisplayName.String, mention.Content)
+			if event.content != "" {
+				window = append([]groupWindowEvent{event}, window...)
+			}
+		}
+	}
+	if len(window) == 0 {
+		return nil, false, nil
+	}
+	omitted, err := p.q.ExistsGroupMessageBeforeSeq(ctx, sqlc.ExistsGroupMessageBeforeSeqParams{GroupID: groupID, BeforeSeq: window[0].seq})
+	if err != nil {
+		return nil, false, fmt.Errorf("check omitted group history: %w", err)
+	}
+	return window, omitted, nil
+}
+
+func groupWindowEventFromRow(ctx context.Context, namer *eventlog.ParticipantNamer, groupID, id string, seq int64, actorType, actorID, displayName, content string) groupWindowEvent {
+	name := displayName
+	if name == "" {
+		name = namer.Name(ctx, groupID, actorType, actorID)
+	}
+	line := fmt.Sprintf("[seq:%d %s]: %s", seq, eventlog.HandleDisplayName(name, actorType), content)
+	message := ai.UserMessage{Content: line}
+	return groupWindowEvent{
+		id: id, seq: seq, actorType: actorType, actorID: actorID, actorDisplayName: displayName,
+		content: content, line: line, tokens: estimateMessageTokens(message), bytes: len(line),
+	}
+}
+
+func groupWindowContainsSeq(window []groupWindowEvent, seq int64) bool {
+	for _, event := range window {
+		if event.seq == seq {
+			return true
+		}
+	}
+	return false
+}
+
+func reverseGroupWindow(reverse []groupWindowEvent) []groupWindowEvent {
+	window := make([]groupWindowEvent, len(reverse))
+	for i := range reverse {
+		window[len(reverse)-1-i] = reverse[i]
+	}
+	return window
+}
+
+// quantizeGroupWindow discards complete 10k-token head blocks, instead of one
+// message at a time. That keeps the surviving prompt prefix stable between
+// evictions and improves provider prompt-cache reuse.
+func quantizeGroupWindow(window []groupWindowEvent, maxTokens int) []groupWindowEvent {
+	if maxTokens < groupWindowEvictionBlockTokens {
+		return window
+	}
+	total := 0
+	for _, event := range window {
+		total += event.tokens
+	}
+	stableBudget := maxTokens - groupWindowEvictionBlockTokens
+	for len(window) > 0 && total > stableBudget {
+		blockTokens, end := 0, 0
+		for end < len(window) && blockTokens < groupWindowEvictionBlockTokens {
+			blockTokens += window[end].tokens
+			end++
+		}
+		if end == len(window) {
+			// Keep the newest complete block. The collection caps already bounded
+			// it, and an empty public context is less useful than one large event.
+			return window
+		}
+		total -= blockTokens
+		window = window[end:]
+	}
+	return window
 }
 
 func trimOldestCompleteTurns(messages []ai.Message, budget int) []ai.Message {
@@ -124,9 +303,7 @@ func (p *Provider) commitGroupCursorWithQueries(ctx context.Context, q *sqlc.Que
 	if session.GroupID == "" || session.AgentID == "" || triggerSeq <= 0 {
 		return nil
 	}
-	groupID := session.GroupID
-	pipeline := groupCursorPipeline(session.AgentID)
-	watermark, err := p.getGroupCursorWithQueries(ctx, q, groupID, pipeline)
+	watermark, err := p.getGroupCursorWithQueries(ctx, q, session.GroupID, groupCursorPipeline(session.AgentID))
 	if err != nil {
 		return err
 	}
@@ -134,83 +311,22 @@ func (p *Provider) commitGroupCursorWithQueries(ctx context.Context, q *sqlc.Que
 		return nil
 	}
 	if err := q.UpsertIngestCursor(ctx, sqlc.UpsertIngestCursorParams{
-		GroupID:  groupID,
-		Pipeline: pipeline,
-		LastSeq:  triggerSeq,
+		GroupID: session.GroupID, Pipeline: groupCursorPipeline(session.AgentID), LastSeq: triggerSeq,
 	}); err != nil {
 		return fmt.Errorf("update group cursor: %w", err)
 	}
 	return nil
 }
 
-func (p *Provider) filterAlreadyPersistedInjected(ctx context.Context, convID string, injected []ai.Message) ([]ai.Message, error) {
-	if len(injected) == 0 {
-		return injected, nil
-	}
-	contents := make([]string, 0, len(injected))
-	for _, msg := range injected {
-		um, ok := msg.(ai.UserMessage)
-		if !ok {
-			continue
-		}
-		contents = append(contents, flattenUserContent(um))
-	}
-	if len(contents) == 0 {
-		return injected, nil
-	}
-	seen := make(map[string]struct{})
-	for start := 0; start < len(contents); start += 500 {
-		end := min(start+500, len(contents))
-		existingRows, err := p.q.ListExistingUserMessageContent(ctx, sqlc.ListExistingUserMessageContentParams{
-			ConversationID: convID,
-			Contents:       contents[start:end],
-		})
-		if err != nil {
-			return nil, err
-		}
-		for _, content := range existingRows {
-			seen[content] = struct{}{}
-		}
-	}
-	out := injected[:0]
-	for _, msg := range injected {
-		um, ok := msg.(ai.UserMessage)
-		if !ok {
-			out = append(out, msg)
-			continue
-		}
-		if _, ok := seen[flattenUserContent(um)]; ok {
-			continue
-		}
-		out = append(out, msg)
-	}
-	return out, nil
-}
-
-func flattenUserContent(msg ai.UserMessage) string {
-	switch c := msg.Content.(type) {
-	case string:
-		return c
-	case []ai.ContentBlock:
-		return ai.FlattenText(c)
-	default:
-		return fmt.Sprintf("%v", c)
-	}
-}
-
-// getGroupCursor returns the last-seen event log seq for this agent, or 0 when
-// the agent has none yet. A read error is returned, never masked as 0: a
-// transient failure treated as "no cursor" would replay the entire group
-// history and re-persist it.
+// getGroupCursor returns last_completed_trigger_seq for this agent, or zero
+// when it has never durably completed a group turn. Read failures are never
+// treated as zero because that would turn a transient error into a history replay.
 func (p *Provider) getGroupCursor(ctx context.Context, groupID, pipeline string) (int64, error) {
 	return p.getGroupCursorWithQueries(ctx, p.q, groupID, pipeline)
 }
 
 func (p *Provider) getGroupCursorWithQueries(ctx context.Context, q *sqlc.Queries, groupID, pipeline string) (int64, error) {
-	cursor, err := q.GetIngestCursor(ctx, sqlc.GetIngestCursorParams{
-		GroupID:  groupID,
-		Pipeline: pipeline,
-	})
+	cursor, err := q.GetIngestCursor(ctx, sqlc.GetIngestCursorParams{GroupID: groupID, Pipeline: pipeline})
 	if errors.Is(err, pgx.ErrNoRows) {
 		return 0, nil
 	}
@@ -218,25 +334,4 @@ func (p *Provider) getGroupCursorWithQueries(ctx context.Context, q *sqlc.Querie
 		return 0, fmt.Errorf("read group cursor: %w", err)
 	}
 	return cursor.LastSeq, nil
-}
-
-// groupRowsToMessages converts event log rows to ai.Messages.
-// The current agent's own messages are skipped (they're already in ctx_message).
-// All other messages become UserMessages with actor attribution.
-//
-// Attribution is a name, never an id: the model has to recognise the same
-// participant here, in its roster, and in the trigger of its own turn, and it
-// has to be able to address them back. The namer is the one place that decides.
-func groupRowsToMessages(ctx context.Context, namer *eventlog.ParticipantNamer, groupID string, rows []sqlc.ListGroupMessagesBetweenSeqsRow, selfAgentID string) []ai.Message {
-	msgs := make([]ai.Message, 0, len(rows))
-	for _, row := range rows {
-		if row.Content == "" {
-			continue
-		}
-		if row.ActorType == string(eventlog.ActorAgent) && row.ActorID == selfAgentID {
-			continue
-		}
-		msgs = append(msgs, ai.UserMessage{Content: namer.Line(ctx, groupID, row.Seq, row.ActorType, row.ActorID, row.Content)})
-	}
-	return msgs
 }

--- a/internal/memory/lcm/group_assembler_test.go
+++ b/internal/memory/lcm/group_assembler_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -88,6 +87,7 @@ func TestGroupAssembleExcludesFailedPeerDelivery(t *testing.T) {
 }
 
 func TestGroupAssemble_HybridFlow(t *testing.T) {
+	t.Skip("superseded by stateless group window tests")
 	db := openTestDB(t)
 	el := eventlog.NewStore(db)
 	ctx := context.Background()
@@ -183,6 +183,7 @@ func TestGroupAssemble_HybridFlow(t *testing.T) {
 }
 
 func TestGroupAssemble_OtherAgentInjected(t *testing.T) {
+	t.Skip("superseded by stateless group window tests")
 	db := openTestDB(t)
 	el := eventlog.NewStore(db)
 	ctx := context.Background()
@@ -276,6 +277,7 @@ func TestGroupAssemble_OtherAgentInjected(t *testing.T) {
 }
 
 func TestGroupAssemble_DedupsPersistedInjectedOutsideBudget(t *testing.T) {
+	t.Skip("peer-copy persistence was removed")
 	db := openTestDB(t)
 	el := eventlog.NewStore(db)
 	ctx := context.Background()
@@ -311,46 +313,6 @@ func TestGroupAssemble_DedupsPersistedInjectedOutsideBudget(t *testing.T) {
 	}
 	if count != 1 {
 		t.Fatalf("persisted injected count = %d, want 1", count)
-	}
-}
-
-func TestFilterAlreadyPersistedInjectedBatchesLargeCandidateSet(t *testing.T) {
-	db := openTestDB(t)
-	p, err := New(db, nil, map[string]any{})
-	if err != nil {
-		t.Fatalf("new provider: %v", err)
-	}
-	q := sqlc.New(db)
-	ctx := context.Background()
-	convID := uuid.NewString()
-	if _, err := q.CreateConversation(ctx, sqlc.CreateConversationParams{ID: convID, SessionID: "session-large", Channel: "test", Kind: "chat", LastActive: time.Date(2026, 6, 12, 0, 0, 0, 0, time.UTC)}); err != nil {
-		t.Fatalf("create conversation: %v", err)
-	}
-	for i, content := range []string{"candidate-0000", "candidate-0500", "candidate-1001"} {
-		if _, err := q.CreateMessage(ctx, sqlc.CreateMessageParams{ID: uuid.NewString(), ConversationID: convID, Seq: int64(i + 1), Role: "user", EventType: "text", Content: content, ActorType: string(eventlog.ActorHuman)}); err != nil {
-			t.Fatalf("create message %s: %v", content, err)
-		}
-	}
-	injected := make([]ai.Message, 0, 1005)
-	for i := range 1005 {
-		injected = append(injected, ai.UserMessage{Content: fmt.Sprintf("candidate-%04d", i)})
-	}
-
-	filtered, err := p.filterAlreadyPersistedInjected(ctx, convID, injected)
-	if err != nil {
-		t.Fatalf("filter injected: %v", err)
-	}
-	if len(filtered) != 1002 {
-		t.Fatalf("filtered len = %d, want 1002", len(filtered))
-	}
-	for _, msg := range filtered {
-		content := msg.(ai.UserMessage).Content.(string)
-		if content == "candidate-0000" || content == "candidate-0500" || content == "candidate-1001" {
-			t.Fatalf("persisted content %q was not filtered", content)
-		}
-	}
-	if got := filtered[0].(ai.UserMessage).Content.(string); got != "candidate-0001" {
-		t.Fatalf("first filtered content = %q, want order preserved", got)
 	}
 }
 
@@ -572,6 +534,7 @@ func TestGroupNeedsCompaction_AlwaysFalse(t *testing.T) {
 }
 
 func TestGroupAssemble_WatermarkAdvances(t *testing.T) {
+	t.Skip("cursor no longer measures public-history ingestion")
 	db := openTestDB(t)
 	el := eventlog.NewStore(db)
 	ctx := context.Background()
@@ -658,6 +621,7 @@ func TestGroupAssemble_WatermarkAdvances(t *testing.T) {
 }
 
 func TestGroupAssemblePersistsInjectedButCommitAdvancesCursor(t *testing.T) {
+	t.Skip("peer-copy persistence was removed")
 	db := openTestDB(t)
 	el := eventlog.NewStore(db)
 	ctx := context.Background()
@@ -735,36 +699,6 @@ func TestGroupAssemblePersistsInjectedButCommitAdvancesCursor(t *testing.T) {
 	}
 }
 
-func TestAssemblerSetsPreTrimInjectedRows(t *testing.T) {
-	db := openTestDB(t)
-	el := eventlog.NewStore(db)
-	ctx := context.Background()
-	first, err := el.AppendGroupMessage(ctx, eventlog.Message{Platform: "test", PlatformGroupID: "pre-trim", ActorType: eventlog.ActorHuman, ActorID: "user-1", Content: strings.Repeat("old peer words ", 40), PlatformMessageID: "pre-trim-1"})
-	if err != nil {
-		t.Fatalf("append peer: %v", err)
-	}
-	trigger, err := el.AppendGroupMessage(ctx, eventlog.Message{Platform: "test", PlatformGroupID: "pre-trim", ActorType: eventlog.ActorHuman, ActorID: "user-2", Content: "trigger", PlatformMessageID: "pre-trim-2"})
-	if err != nil {
-		t.Fatalf("append trigger: %v", err)
-	}
-	p, err := New(db, nil, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	sink := memory.NewGroupTurnSink()
-	msgs, err := p.Assemble(memory.WithGroupTurnSink(groupCtx(trigger.Seq), sink), groupSess("agent-a", first.GroupID), 1, 20)
-	if err != nil {
-		t.Fatalf("assemble: %v", err)
-	}
-	if len(msgs) != 0 {
-		t.Fatalf("trimmed prompt rows = %d, want 0", len(msgs))
-	}
-	injected := sink.Injected()
-	if len(injected) != 1 || !strings.Contains(flattenUserMessage(injected[0].(ai.UserMessage)), "old peer words") {
-		t.Fatalf("pre-trim injected rows = %#v", injected)
-	}
-}
-
 func TestTxGroupCommitterUsesOuterTxAndSessionLock(t *testing.T) {
 	db := openTestDB(t)
 	p, err := New(db, nil, nil)
@@ -780,11 +714,10 @@ func TestTxGroupCommitterUsesOuterTxAndSessionLock(t *testing.T) {
 	}
 	qtx := sqlc.New(tx)
 	turn := memory.DeferredGroupTurn{
-		Session:          sess,
-		InjectedPeerRows: []ai.Message{ai.UserMessage{Content: "peer"}},
-		OwnRows:          []ai.Message{ai.UserMessage{Content: "trigger"}, ai.AssistantMessage{Content: []ai.ContentBlock{ai.TextContent{Text: "answer"}}}},
-		TriggerSeq:       5,
-		Complete:         true,
+		Session:    sess,
+		OwnRows:    []ai.Message{ai.UserMessage{Content: "trigger"}, ai.AssistantMessage{Content: []ai.ContentBlock{ai.TextContent{Text: "answer"}}}},
+		TriggerSeq: 5,
+		Complete:   true,
 	}
 	if err := p.CommitGroupTurn(ctx, qtx, turn); err != nil {
 		_ = tx.Rollback(ctx)
@@ -810,7 +743,7 @@ func TestTxGroupCommitterUsesOuterTxAndSessionLock(t *testing.T) {
 	if err := tx.Commit(ctx); err != nil {
 		t.Fatalf("commit outer tx: %v", err)
 	}
-	if stats, err := p.Stats(ctx, sess); err != nil || stats.MessageCount != 3 {
+	if stats, err := p.Stats(ctx, sess); err != nil || stats.MessageCount != 2 {
 		t.Fatalf("committed turn stats = %+v, %v", stats, err)
 	}
 	if got := mustGroupCursor(t, ctx, p, groupID, groupCursorPipeline("agent-a")); got != 5 {
@@ -856,6 +789,7 @@ func TestGroupAssemble_TriggerSeqZero(t *testing.T) {
 // the rotation, so the messages the old session already consumed are not
 // re-injected into the fresh one.
 func TestGroupAssemble_RotationResetsContextButKeepsWatermark(t *testing.T) {
+	t.Skip("cursor no longer filters the stateless public window")
 	db := openTestDB(t)
 	el := eventlog.NewStore(db)
 	ctx := context.Background()

--- a/internal/memory/lcm/group_window_test.go
+++ b/internal/memory/lcm/group_window_test.go
@@ -198,3 +198,49 @@ func TestGroupWindowMentionAnchorAndQuantizedEviction(t *testing.T) {
 		t.Fatalf("quantized eviction is non-deterministic or not block-aligned: %d, %d", len(first), len(second))
 	}
 }
+
+func TestGroupWindowKeepsPrivateTurnWhoseTriggerLeftTheWindow(t *testing.T) {
+	db := openTestDB(t)
+	store := eventlog.NewStore(db)
+	anchor := appendWindowMessage(t, store, "window-evicted-origin", eventlog.ActorHuman, "u1", "Alice", "question")
+	if _, err := store.AppendToGroup(context.Background(), anchor.GroupID, eventlog.GroupMessage{ActorType: eventlog.ActorAgent, ActorID: "agent-b", ActorDisplayName: "Bee", Content: "peer update"}); err != nil {
+		t.Fatal(err)
+	}
+	trigger := appendWindowMessage(t, store, "window-evicted-origin", eventlog.ActorHuman, "u2", "Bob", "next")
+	p, err := New(db, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := groupSess("agent-a", anchor.GroupID)
+	tx, err := db.Begin(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	turn := memory.DeferredGroupTurn{
+		Session: sess, TriggerSeq: anchor.Seq, OriginGroupMessageID: anchor.Message.ID, Complete: true,
+		OwnRows: []ai.Message{ai.UserMessage{Content: "question"}, ai.AssistantMessage{Content: []ai.ContentBlock{ai.TextContent{Text: "private answer"}}}},
+	}
+	if err := p.CommitGroupTurn(context.Background(), sqlc.New(tx), turn); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	// The trigger leaves the delivered window (retraction or eviction). The
+	// agent's tool history must outlive the sliding public window via its
+	// stored anchor, not vanish with the canonical row.
+	if _, err := db.Exec(context.Background(), `UPDATE ctx_group_message SET delivery_state = 'failed' WHERE id = $1`, anchor.Message.ID); err != nil {
+		t.Fatal(err)
+	}
+	messages, err := p.Assemble(groupCtx(trigger.Seq), sess, 100_000, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(windowTexts(messages), "\n")
+	if !strings.Contains(joined, "private answer") || !strings.Contains(joined, "question") {
+		t.Fatalf("evicted-origin private turn missing: %q", joined)
+	}
+	if strings.Index(joined, "private answer") > strings.Index(joined, "peer update") {
+		t.Fatalf("private head turn should precede the public window: %q", joined)
+	}
+}

--- a/internal/memory/lcm/group_window_test.go
+++ b/internal/memory/lcm/group_window_test.go
@@ -1,0 +1,200 @@
+package lcm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/CherryHQ/stella/internal/eventlog"
+	"github.com/CherryHQ/stella/internal/memory"
+	"github.com/CherryHQ/stella/pkg/ai"
+	"github.com/CherryHQ/stella/pkg/db/sqlc"
+)
+
+func appendWindowMessage(t *testing.T, store *eventlog.Store, platformGroup string, actor eventlog.ActorType, actorID, name, content string) eventlog.AppendResult {
+	t.Helper()
+	result, err := store.AppendGroupMessage(context.Background(), eventlog.Message{
+		Platform: "test", PlatformGroupID: platformGroup, ActorType: actor, ActorID: actorID,
+		ActorDisplayName: name, Content: content,
+	})
+	if err != nil {
+		t.Fatalf("append group message: %v", err)
+	}
+	return result
+}
+
+func windowTexts(messages []ai.Message) []string {
+	out := make([]string, 0, len(messages))
+	for _, message := range messages {
+		out = append(out, memory.MessageText(message))
+	}
+	return out
+}
+
+func TestGroupWindowDeliveredOnlyAndMediaPlaceholder(t *testing.T) {
+	db := openTestDB(t)
+	store := eventlog.NewStore(db)
+	first := appendWindowMessage(t, store, "window-delivery", eventlog.ActorHuman, "u1", "Before", "visible")
+	pending, err := store.AppendToGroup(context.Background(), first.GroupID, eventlog.GroupMessage{ActorType: eventlog.ActorAgent, ActorID: "agent-b", ActorDisplayName: "Bee", Content: "pending", DeliveryState: "pending"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	failed, err := store.AppendToGroup(context.Background(), first.GroupID, eventlog.GroupMessage{ActorType: eventlog.ActorAgent, ActorID: "agent-c", ActorDisplayName: "See", Content: "failed"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	q := sqlc.New(db)
+	if _, err := q.SetGroupMessageDeliveryState(context.Background(), sqlc.SetGroupMessageDeliveryStateParams{ID: failed.Message.ID, DeliveryState: "failed"}); err != nil {
+		t.Fatal(err)
+	}
+	media := appendWindowMessage(t, store, "window-delivery", eventlog.ActorHuman, "u2", "Image user", "[image]")
+	trigger := appendWindowMessage(t, store, "window-delivery", eventlog.ActorHuman, "u3", "Trigger", "go")
+	p, err := New(db, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := groupCtx(trigger.Seq)
+	messages, err := p.Assemble(ctx, groupSess("agent-a", first.GroupID), 100_000, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(windowTexts(messages), "\n")
+	if !strings.Contains(joined, "visible") || !strings.Contains(joined, "[image]") || !strings.Contains(joined, "Image user") {
+		t.Fatalf("delivered text window = %q", joined)
+	}
+	if strings.Contains(joined, "pending") || strings.Contains(joined, "failed") {
+		t.Fatalf("non-delivered row entered peer context: %q", joined)
+	}
+	if _, err := q.SetGroupMessageDeliveryState(context.Background(), sqlc.SetGroupMessageDeliveryStateParams{ID: pending.Message.ID, DeliveryState: "delivered"}); err != nil {
+		t.Fatal(err)
+	}
+	messages, err = p.Assemble(ctx, groupSess("agent-a", first.GroupID), 100_000, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined = strings.Join(windowTexts(messages), "\n")
+	if strings.Count(joined, "pending") != 1 || strings.Index(joined, "pending") > strings.Index(joined, "[image]") {
+		t.Fatalf("delivered transition did not appear exactly once in sequence: %q", joined)
+	}
+	_ = media
+}
+
+func TestGroupWindowBoundedRowsAndOmissionMarker(t *testing.T) {
+	db := openTestDB(t)
+	store := eventlog.NewStore(db)
+	var first eventlog.AppendResult
+	for i := range groupWindowMaxRows + 1 {
+		result := appendWindowMessage(t, store, "window-cap", eventlog.ActorHuman, "u", "User", fmt.Sprintf("message %03d", i))
+		if i == 0 {
+			first = result
+		}
+	}
+	trigger := appendWindowMessage(t, store, "window-cap", eventlog.ActorHuman, "u", "User", "trigger")
+	p, err := New(db, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	messages, err := p.Assemble(groupCtx(trigger.Seq), groupSess("agent-a", first.GroupID), 100_000, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != groupWindowMaxRows+1 || memory.MessageText(messages[0]) != groupHistoryOmittedMarker {
+		t.Fatalf("bounded window = %d rows, first = %q", len(messages), memory.MessageText(messages[0]))
+	}
+	if strings.Contains(strings.Join(windowTexts(messages), "\n"), "message 000") {
+		t.Fatal("oldest row survived the row cap")
+	}
+}
+
+func TestGroupWindowInterleavesPrivateContinuationAndPersistsOnlyOwnRows(t *testing.T) {
+	db := openTestDB(t)
+	store := eventlog.NewStore(db)
+	anchor := appendWindowMessage(t, store, "window-interleave", eventlog.ActorHuman, "u1", "Alice", "question")
+	own, err := store.AppendToGroup(context.Background(), anchor.GroupID, eventlog.GroupMessage{ActorType: eventlog.ActorAgent, ActorID: "agent-a", ActorDisplayName: "Ada", Content: "answer"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	peer, err := store.AppendToGroup(context.Background(), anchor.GroupID, eventlog.GroupMessage{ActorType: eventlog.ActorAgent, ActorID: "agent-b", ActorDisplayName: "Bee", Content: "peer update"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	trigger := appendWindowMessage(t, store, "window-interleave", eventlog.ActorHuman, "u2", "Bob", "next")
+	p, err := New(db, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess := groupSess("agent-a", anchor.GroupID)
+	tx, err := db.Begin(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	turn := memory.DeferredGroupTurn{
+		Session: sess, TriggerSeq: anchor.Seq, OriginGroupMessageID: anchor.Message.ID, Complete: true,
+		OwnRows: []ai.Message{ai.UserMessage{Content: "question"}, ai.AssistantMessage{Content: []ai.ContentBlock{ai.TextContent{Text: "private answer"}}}},
+	}
+	if err := p.CommitGroupTurn(context.Background(), sqlc.New(tx), turn); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	// A retry sees the trigger origin and advances only the monotonic cursor.
+	tx, err = db.Begin(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := p.CommitGroupTurn(context.Background(), sqlc.New(tx), turn); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	messages, err := p.Assemble(groupCtx(trigger.Seq), sess, 100_000, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(windowTexts(messages), "\n")
+	if strings.Count(joined, "answer") != 1 || strings.Index(joined, "private answer") < strings.Index(joined, "question") || strings.Contains(joined, "[seq:2 @Ada]: answer") {
+		t.Fatalf("interleaved context = %q", joined)
+	}
+	if strings.Index(joined, "private answer") > strings.Index(joined, "peer update") {
+		t.Fatalf("continuation did not follow anchor: %q", joined)
+	}
+	var count int
+	if err := db.QueryRow(context.Background(), `SELECT count(*) FROM ctx_message WHERE conversation_id = (SELECT id FROM ctx_conversation WHERE session_id = $1)`, sess.ID).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Fatalf("ctx_message copied public rows: got %d, want 2", count)
+	}
+	_ = own
+	_ = peer
+}
+
+func TestGroupWindowMentionAnchorAndQuantizedEviction(t *testing.T) {
+	db := openTestDB(t)
+	store := eventlog.NewStore(db)
+	mention := appendWindowMessage(t, store, "window-mention", eventlog.ActorHuman, "u1", "Alice", strings.Repeat("mention ", 30))
+	for i := range 4 {
+		appendWindowMessage(t, store, "window-mention", eventlog.ActorHuman, "u2", "Bob", fmt.Sprintf("recent %d", i))
+	}
+	trigger := appendWindowMessage(t, store, "window-mention", eventlog.ActorHuman, "u3", "Cara", "trigger")
+	p, err := New(db, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	window, _, err := p.loadGroupWindow(memory.WithGroupWake(groupCtx(trigger.Seq), memory.GroupWake{MentionSeq: mention.Seq}), mention.GroupID, "agent-a", trigger.Seq, mention.Seq, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(window) == 0 || !strings.Contains(window[0].line, "mention") {
+		t.Fatal("waking mention was omitted from bounded context")
+	}
+	sample := []groupWindowEvent{{tokens: 6_000}, {tokens: 6_000}, {tokens: 6_000}, {tokens: 6_000}}
+	first := quantizeGroupWindow(append([]groupWindowEvent(nil), sample...), 20_000)
+	second := quantizeGroupWindow(append([]groupWindowEvent(nil), sample...), 20_000)
+	if len(first) != 2 || len(first) != len(second) {
+		t.Fatalf("quantized eviction is non-deterministic or not block-aligned: %d, %d", len(first), len(second))
+	}
+}

--- a/internal/memory/lcm/provider.go
+++ b/internal/memory/lcm/provider.go
@@ -313,12 +313,33 @@ func (p *Provider) CommitGroupTurn(ctx context.Context, qtx *sqlc.Queries, turn 
 			return err
 		}
 
-		rows := make([]storageRow, 0, len(turn.InjectedPeerRows)+len(turn.OwnRows))
-		for _, msg := range turn.InjectedPeerRows {
-			rows = append(rows, messageToRows(msg)...)
+		if turn.OriginGroupMessageID != "" {
+			if err := qtx.LockConversationForWrite(ctx, convID); err != nil {
+				return fmt.Errorf("lock group conversation: %w", err)
+			}
+			_, err := qtx.GetMessageByConversationOrigin(ctx, sqlc.GetMessageByConversationOriginParams{
+				ConversationID:       convID,
+				OriginGroupMessageID: pgtype.Text{String: turn.OriginGroupMessageID, Valid: true},
+			})
+			switch {
+			case err == nil:
+				return p.commitGroupCursorWithQueries(ctx, qtx, session, turn.TriggerSeq)
+			case !errors.Is(err, pgx.ErrNoRows):
+				return fmt.Errorf("get group turn origin: %w", err)
+			}
 		}
+
+		rows := make([]storageRow, 0, len(turn.OwnRows))
 		for _, msg := range turn.OwnRows {
 			rows = append(rows, messageToRows(msg)...)
+		}
+		if turn.OriginGroupMessageID != "" {
+			for i := range rows {
+				if rows[i].role == roleUser {
+					rows[i].originGroupMessageID = turn.OriginGroupMessageID
+					break
+				}
+			}
 		}
 		if err := p.appendRowsWithQueries(ctx, qtx, session, convID, rows, nil); err != nil {
 			return err
@@ -373,17 +394,18 @@ func (p *Provider) appendRowsWithQueries(ctx context.Context, qtx *sqlc.Queries,
 			inboxID = pgtype.Text{String: claim.id, Valid: true}
 		}
 		dbMsg, err := qtx.CreateMessage(ctx, sqlc.CreateMessageParams{
-			ID:              uuid.Must(uuid.NewV7()).String(),
-			ConversationID:  convID,
-			Seq:             seq,
-			Role:            row.role,
-			EventType:       row.eventType,
-			Content:         row.content,
-			TokenCount:      int64(memory.EstimateTokens(row.tokenText)),
-			ActorType:       string(actor.Type),
-			ActorID:         pgtype.Text{String: actor.ID, Valid: actor.ID != ""},
-			SourceSessionID: pgtype.Text{String: actor.SourceSessionID, Valid: actor.SourceSessionID != ""},
-			InboxID:         inboxID,
+			ID:                   uuid.Must(uuid.NewV7()).String(),
+			ConversationID:       convID,
+			Seq:                  seq,
+			Role:                 row.role,
+			EventType:            row.eventType,
+			Content:              row.content,
+			TokenCount:           int64(memory.EstimateTokens(row.tokenText)),
+			ActorType:            string(actor.Type),
+			ActorID:              pgtype.Text{String: actor.ID, Valid: actor.ID != ""},
+			SourceSessionID:      pgtype.Text{String: actor.SourceSessionID, Valid: actor.SourceSessionID != ""},
+			InboxID:              inboxID,
+			OriginGroupMessageID: pgtype.Text{String: row.originGroupMessageID, Valid: row.originGroupMessageID != ""},
 		})
 		if err != nil {
 			return fmt.Errorf("create message: %w", err)

--- a/internal/memory/types.go
+++ b/internal/memory/types.go
@@ -17,42 +17,23 @@ type groupTurnSinkKey struct{}
 // dispatcher. It is intentionally separate from ChatStream: stream rebuilding
 // must never lose the transaction payload.
 type DeferredGroupTurn struct {
-	Session          Session
-	InjectedPeerRows []ai.Message
-	OwnRows          []ai.Message
-	TriggerSeq       int64
-	Complete         bool
+	Session              Session
+	OwnRows              []ai.Message
+	TriggerSeq           int64
+	OriginGroupMessageID string
+	Complete             bool
 }
 
 // GroupTurnSink is a one-shot, non-blocking turn finalization record.
 type GroupTurnSink struct {
 	once      sync.Once
 	mu        sync.RWMutex
-	injected  []ai.Message
 	result    DeferredGroupTurn
 	delivered bool
 }
 
 func NewGroupTurnSink() *GroupTurnSink {
 	return &GroupTurnSink{}
-}
-
-func (s *GroupTurnSink) SetInjected(rows []ai.Message) {
-	if s == nil {
-		return
-	}
-	s.mu.Lock()
-	s.injected = append([]ai.Message(nil), rows...)
-	s.mu.Unlock()
-}
-
-func (s *GroupTurnSink) Injected() []ai.Message {
-	if s == nil {
-		return nil
-	}
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return append([]ai.Message(nil), s.injected...)
 }
 
 // Deliver records the first terminal result without blocking the producer.
@@ -117,6 +98,7 @@ const (
 	sessionIDKey      contextKey = "memory_session_id"
 	projectIDKey      contextKey = "memory_project_id"
 	groupSeqKey       contextKey = "memory_group_seq"
+	groupMessageIDKey contextKey = "memory_group_message_id"
 	currentSpeakerKey contextKey = "memory_current_speaker"
 	groupWakeKey      contextKey = "memory_group_wake"
 )
@@ -184,6 +166,9 @@ type GroupWake struct {
 	// HeldUpToSeq is set when this run follows a HOLD: a peer posted while the
 	// agent was drafting, and everything up to this seq is new since then.
 	HeldUpToSeq int64
+	// MentionSeq is the earliest unconsumed event that addressed this agent.
+	// It lets bounded context retain the reason for a coalesced wake.
+	MentionSeq int64
 }
 
 // WithGroupWake attaches this turn's wake reason to the context.
@@ -208,6 +193,18 @@ func GroupSeqFromContext(ctx context.Context) int64 {
 	return s
 }
 
+// WithGroupMessageID attaches the durable trigger event identity to a group
+// turn. It is runtime-authored alongside GroupSeq and never comes from model input.
+func WithGroupMessageID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, groupMessageIDKey, id)
+}
+
+// GroupMessageIDFromContext extracts the durable trigger event identity.
+func GroupMessageIDFromContext(ctx context.Context) string {
+	id, _ := ctx.Value(groupMessageIDKey).(string)
+	return id
+}
+
 // Session identifies the context of a single conversation.
 // It is created by the runtime and passed to all Provider methods.
 type Session struct {
@@ -219,16 +216,14 @@ type Session struct {
 	GuestID string // non-empty for a persistent channel guest; equals UserID
 }
 
-// GroupIngestPipeline names the ctx_group_ingest_cursor pipeline that tracks
-// one agent's consumption of a group's event log. The LCM assembler owns the
-// cursor's movement, but the name is shared: session rotation fast-forwards it
-// as a message boundary, and the group dispatcher reads it to drop restarted
-// dispatch rows whose trigger that boundary already consumed.
+// GroupIngestPipeline names the ctx_group_ingest_cursor pipeline that records
+// one agent's last_completed_trigger_seq. The LCM committer owns movement, but
+// the name is shared: session rotation fast-forwards the completed boundary,
+// and the dispatcher reads it to drop restarted dispatch rows already completed.
 func GroupIngestPipeline(agentID string) string { return "lcm:" + agentID }
 
-// GroupCursorCommitter advances group event-log ingestion only after a chat turn
-// has completed successfully. Assemble may prepare between-turn rows, but commit
-// owns durable cursor movement.
+// GroupCursorCommitter records a completed trigger only after its chat turn has
+// completed successfully. Assembly is stateless; commit owns durable movement.
 type GroupCursorCommitter interface {
 	CommitGroupCursor(ctx context.Context, session Session, triggerSeq int64) error
 }

--- a/pkg/db/sqlc/ctx_group.sql.go
+++ b/pkg/db/sqlc/ctx_group.sql.go
@@ -202,16 +202,16 @@ func (q *Queries) CountPeerMessagesAfterSeq(ctx context.Context, arg CountPeerMe
 const createGroupMessage = `-- name: CreateGroupMessage :one
 INSERT INTO ctx_group_message (
   id, group_id, seq, source_channel_id, actor_type, actor_id,
-  platform_message_id, reply_to, platform_timestamp, idempotency_key, content, content_blocks, reasoning, agent_session_id, delivery_state
+  platform_message_id, reply_to, platform_timestamp, idempotency_key, actor_display_name, content, content_blocks, reasoning, agent_session_id, delivery_state
 )
 VALUES (
   $1, $2, $3, $4,
   $5, $6, $7,
-  $8, $9, $10,
-  $11, COALESCE($12::jsonb, '[]'::jsonb),
-  $13, $14, $15
+  $8, $9, $10, $11,
+  $12, COALESCE($13::jsonb, '[]'::jsonb),
+  $14, $15, $16
 )
-RETURNING id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at, content_blocks, delivery_state
+RETURNING id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at, content_blocks, delivery_state, actor_display_name
 `
 
 type CreateGroupMessageParams struct {
@@ -225,6 +225,7 @@ type CreateGroupMessageParams struct {
 	ReplyTo           pgtype.Text        `json:"reply_to"`
 	PlatformTimestamp pgtype.Timestamptz `json:"platform_timestamp"`
 	IdempotencyKey    pgtype.Text        `json:"idempotency_key"`
+	ActorDisplayName  pgtype.Text        `json:"actor_display_name"`
 	Content           string             `json:"content"`
 	ContentBlocks     json.RawMessage    `json:"content_blocks"`
 	Reasoning         string             `json:"reasoning"`
@@ -244,6 +245,7 @@ func (q *Queries) CreateGroupMessage(ctx context.Context, arg CreateGroupMessage
 		arg.ReplyTo,
 		arg.PlatformTimestamp,
 		arg.IdempotencyKey,
+		arg.ActorDisplayName,
 		arg.Content,
 		arg.ContentBlocks,
 		arg.Reasoning,
@@ -268,6 +270,7 @@ func (q *Queries) CreateGroupMessage(ctx context.Context, arg CreateGroupMessage
 		&i.CreatedAt,
 		&i.ContentBlocks,
 		&i.DeliveryState,
+		&i.ActorDisplayName,
 	)
 	return i, err
 }
@@ -343,7 +346,7 @@ func (q *Queries) GetGroupLastActive(ctx context.Context, id string) (time.Time,
 }
 
 const getGroupMessage = `-- name: GetGroupMessage :one
-SELECT id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at, content_blocks, delivery_state FROM ctx_group_message WHERE id = $1
+SELECT id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at, content_blocks, delivery_state, actor_display_name FROM ctx_group_message WHERE id = $1
 `
 
 func (q *Queries) GetGroupMessage(ctx context.Context, id string) (CtxGroupMessage, error) {
@@ -366,12 +369,13 @@ func (q *Queries) GetGroupMessage(ctx context.Context, id string) (CtxGroupMessa
 		&i.CreatedAt,
 		&i.ContentBlocks,
 		&i.DeliveryState,
+		&i.ActorDisplayName,
 	)
 	return i, err
 }
 
 const getGroupMessageByIdempotencyKey = `-- name: GetGroupMessageByIdempotencyKey :one
-SELECT id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at, content_blocks, delivery_state FROM ctx_group_message
+SELECT id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at, content_blocks, delivery_state, actor_display_name FROM ctx_group_message
 WHERE idempotency_key = $1
 `
 
@@ -395,12 +399,13 @@ func (q *Queries) GetGroupMessageByIdempotencyKey(ctx context.Context, idempoten
 		&i.CreatedAt,
 		&i.ContentBlocks,
 		&i.DeliveryState,
+		&i.ActorDisplayName,
 	)
 	return i, err
 }
 
 const getGroupMessageByPlatformID = `-- name: GetGroupMessageByPlatformID :one
-SELECT id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at, content_blocks, delivery_state FROM ctx_group_message
+SELECT id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at, content_blocks, delivery_state, actor_display_name FROM ctx_group_message
 WHERE group_id = $1
   AND platform_message_id = $2
 `
@@ -430,6 +435,7 @@ func (q *Queries) GetGroupMessageByPlatformID(ctx context.Context, arg GetGroupM
 		&i.CreatedAt,
 		&i.ContentBlocks,
 		&i.DeliveryState,
+		&i.ActorDisplayName,
 	)
 	return i, err
 }
@@ -543,7 +549,7 @@ func (q *Queries) GetLatestGroupMessageID(ctx context.Context, groupID string) (
 }
 
 const getLatestPeerGroupMessageWithContent = `-- name: GetLatestPeerGroupMessageWithContent :one
-SELECT id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at, content_blocks, delivery_state
+SELECT id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at, content_blocks, delivery_state, actor_display_name
 FROM ctx_group_message
 WHERE group_id = $1
   AND NOT (actor_type = 'agent' AND actor_id = $2)
@@ -589,6 +595,7 @@ func (q *Queries) GetLatestPeerGroupMessageWithContent(ctx context.Context, arg 
 		&i.CreatedAt,
 		&i.ContentBlocks,
 		&i.DeliveryState,
+		&i.ActorDisplayName,
 	)
 	return i, err
 }
@@ -1086,7 +1093,7 @@ const setGroupMessageDeliveryState = `-- name: SetGroupMessageDeliveryState :one
 UPDATE ctx_group_message
 SET delivery_state = $1
 WHERE id = $2
-RETURNING id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at, content_blocks, delivery_state
+RETURNING id, group_id, seq, source_channel_id, actor_type, actor_id, platform_message_id, reply_to, platform_timestamp, idempotency_key, content, reasoning, agent_session_id, created_at, content_blocks, delivery_state, actor_display_name
 `
 
 type SetGroupMessageDeliveryStateParams struct {
@@ -1114,6 +1121,7 @@ func (q *Queries) SetGroupMessageDeliveryState(ctx context.Context, arg SetGroup
 		&i.CreatedAt,
 		&i.ContentBlocks,
 		&i.DeliveryState,
+		&i.ActorDisplayName,
 	)
 	return i, err
 }

--- a/pkg/db/sqlc/ctx_group_dispatch.sql.go
+++ b/pkg/db/sqlc/ctx_group_dispatch.sql.go
@@ -422,6 +422,42 @@ func (q *Queries) ExtendRunningGroupDispatchLease(ctx context.Context, arg Exten
 	return result.RowsAffected(), nil
 }
 
+const getEarliestGroupMentionSinceCursor = `-- name: GetEarliestGroupMentionSinceCursor :one
+SELECT COALESCE(MIN(message.seq), 0)::bigint
+FROM ctx_group_outbox outbox
+JOIN ctx_group_message message ON message.id = outbox.group_message_id
+LEFT JOIN ctx_group_ingest_cursor cursor
+  ON cursor.group_id = message.group_id
+ AND cursor.pipeline = $1
+WHERE message.group_id = $2
+  AND message.actor_id <> $3
+  AND message.seq > COALESCE(cursor.last_seq, 0)
+  AND message.seq <= $4
+  AND message.delivery_state = 'delivered'
+  AND (outbox.envelope::jsonb -> 'mentions') @> jsonb_build_array(jsonb_build_object('AgentID', $3::text))
+`
+
+type GetEarliestGroupMentionSinceCursorParams struct {
+	Pipeline   string `json:"pipeline"`
+	GroupID    string `json:"group_id"`
+	AgentID    string `json:"agent_id"`
+	TriggerSeq int64  `json:"trigger_seq"`
+}
+
+// The bounded context assembler needs the actual event, not just the triage
+// boolean, when a coalesced wake would otherwise omit the mentioning row.
+func (q *Queries) GetEarliestGroupMentionSinceCursor(ctx context.Context, arg GetEarliestGroupMentionSinceCursorParams) (int64, error) {
+	row := q.db.QueryRow(ctx, getEarliestGroupMentionSinceCursor,
+		arg.Pipeline,
+		arg.GroupID,
+		arg.AgentID,
+		arg.TriggerSeq,
+	)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
 const getGroupDispatch = `-- name: GetGroupDispatch :one
 SELECT id, group_message_id, group_id, agent_id, reply_channel_id, status, attempt_count, lease_until, next_attempt_at, last_error, result_message_id, created_at, updated_at, kind, trigger_seq, held_up_to_seq, publish_started_at, published_at FROM ctx_group_dispatch WHERE id = $1
 `

--- a/pkg/db/sqlc/ctx_group_ingest.sql.go
+++ b/pkg/db/sqlc/ctx_group_ingest.sql.go
@@ -37,6 +37,65 @@ func (q *Queries) CreateIngestError(ctx context.Context, arg CreateIngestErrorPa
 	return err
 }
 
+const existsGroupMessageBeforeSeq = `-- name: ExistsGroupMessageBeforeSeq :one
+SELECT EXISTS (
+  SELECT 1
+  FROM ctx_group_message
+  WHERE group_id = $1
+    AND seq < $2
+)::boolean
+`
+
+type ExistsGroupMessageBeforeSeqParams struct {
+	GroupID   string `json:"group_id"`
+	BeforeSeq int64  `json:"before_seq"`
+}
+
+func (q *Queries) ExistsGroupMessageBeforeSeq(ctx context.Context, arg ExistsGroupMessageBeforeSeqParams) (bool, error) {
+	row := q.db.QueryRow(ctx, existsGroupMessageBeforeSeq, arg.GroupID, arg.BeforeSeq)
+	var column_1 bool
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
+const getDeliveredGroupMessageBySeq = `-- name: GetDeliveredGroupMessageBySeq :one
+SELECT id, group_id, seq, actor_type, actor_id, actor_display_name, content
+FROM ctx_group_message
+WHERE group_id = $1
+  AND seq = $2
+  AND delivery_state = 'delivered'
+`
+
+type GetDeliveredGroupMessageBySeqParams struct {
+	GroupID string `json:"group_id"`
+	Seq     int64  `json:"seq"`
+}
+
+type GetDeliveredGroupMessageBySeqRow struct {
+	ID               string      `json:"id"`
+	GroupID          string      `json:"group_id"`
+	Seq              int64       `json:"seq"`
+	ActorType        string      `json:"actor_type"`
+	ActorID          string      `json:"actor_id"`
+	ActorDisplayName pgtype.Text `json:"actor_display_name"`
+	Content          string      `json:"content"`
+}
+
+func (q *Queries) GetDeliveredGroupMessageBySeq(ctx context.Context, arg GetDeliveredGroupMessageBySeqParams) (GetDeliveredGroupMessageBySeqRow, error) {
+	row := q.db.QueryRow(ctx, getDeliveredGroupMessageBySeq, arg.GroupID, arg.Seq)
+	var i GetDeliveredGroupMessageBySeqRow
+	err := row.Scan(
+		&i.ID,
+		&i.GroupID,
+		&i.Seq,
+		&i.ActorType,
+		&i.ActorID,
+		&i.ActorDisplayName,
+		&i.Content,
+	)
+	return i, err
+}
+
 const getIngestCursor = `-- name: GetIngestCursor :one
 SELECT group_id, pipeline, last_seq, updated_at FROM ctx_group_ingest_cursor
 WHERE group_id = $1 AND pipeline = $2
@@ -77,6 +136,62 @@ func (q *Queries) IsIngestError(ctx context.Context, arg IsIngestErrorParams) (b
 	return is_error, err
 }
 
+const listDeliveredGroupMessagesBeforeSeq = `-- name: ListDeliveredGroupMessagesBeforeSeq :many
+SELECT id, group_id, seq, actor_type, actor_id, actor_display_name, content
+FROM ctx_group_message
+WHERE group_id = $1
+  AND seq < $2
+  AND delivery_state = 'delivered'
+ORDER BY seq DESC
+LIMIT $3
+`
+
+type ListDeliveredGroupMessagesBeforeSeqParams struct {
+	GroupID   string `json:"group_id"`
+	BeforeSeq int64  `json:"before_seq"`
+	PageSize  int32  `json:"page_size"`
+}
+
+type ListDeliveredGroupMessagesBeforeSeqRow struct {
+	ID               string      `json:"id"`
+	GroupID          string      `json:"group_id"`
+	Seq              int64       `json:"seq"`
+	ActorType        string      `json:"actor_type"`
+	ActorID          string      `json:"actor_id"`
+	ActorDisplayName pgtype.Text `json:"actor_display_name"`
+	Content          string      `json:"content"`
+}
+
+// Reverse pagination is mandatory: group context reads only its newest bounded
+// window, never an interval whose size is controlled by group history.
+func (q *Queries) ListDeliveredGroupMessagesBeforeSeq(ctx context.Context, arg ListDeliveredGroupMessagesBeforeSeqParams) ([]ListDeliveredGroupMessagesBeforeSeqRow, error) {
+	rows, err := q.db.Query(ctx, listDeliveredGroupMessagesBeforeSeq, arg.GroupID, arg.BeforeSeq, arg.PageSize)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListDeliveredGroupMessagesBeforeSeqRow{}
+	for rows.Next() {
+		var i ListDeliveredGroupMessagesBeforeSeqRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.GroupID,
+			&i.Seq,
+			&i.ActorType,
+			&i.ActorID,
+			&i.ActorDisplayName,
+			&i.Content,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listGroupMessagesAfterSeq = `-- name: ListGroupMessagesAfterSeq :many
 
 SELECT id, group_id, seq, source_channel_id, actor_type, actor_id,
@@ -112,11 +227,9 @@ type ListGroupMessagesAfterSeqRow struct {
 	DeliveryState     string             `json:"delivery_state"`
 }
 
-// Both ingest list queries feed text-only consumers (group-memory extraction and
-// LCM cross-agent assembly); neither reads content_blocks. They select an
-// explicit column list that EXCLUDES content_blocks so a lagging agent or a
-// memory batch never drags inbound image payloads across the seq range —
-// ListGroupMessagesBetweenSeqs has no LIMIT, so the interval alone bounds it.
+// These text-only ingest/context readers deliberately exclude content_blocks:
+// historical group context retains the content projection (including [image])
+// without loading the original media payload.
 func (q *Queries) ListGroupMessagesAfterSeq(ctx context.Context, arg ListGroupMessagesAfterSeqParams) ([]ListGroupMessagesAfterSeqRow, error) {
 	rows, err := q.db.Query(ctx, listGroupMessagesAfterSeq, arg.GroupID, arg.MinSeq, arg.BatchLimit)
 	if err != nil {
@@ -142,79 +255,6 @@ func (q *Queries) ListGroupMessagesAfterSeq(ctx context.Context, arg ListGroupMe
 			&i.AgentSessionID,
 			&i.CreatedAt,
 			&i.DeliveryState,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listGroupMessagesBetweenSeqs = `-- name: ListGroupMessagesBetweenSeqs :many
-SELECT id, group_id, seq, source_channel_id, actor_type, actor_id,
-       platform_message_id, reply_to, platform_timestamp, idempotency_key,
-       content, reasoning, agent_session_id, created_at
-FROM ctx_group_message
-WHERE group_id = $1
-  AND seq > $2
-  AND seq < $3
-  -- A failed platform delivery was never visible to peers. The author keeps
-  -- its own attempted reply and tool history in memory, but no other agent may
-  -- reason from a canonical row that the conversation never received.
-  AND delivery_state <> 'failed'
-ORDER BY seq ASC
-`
-
-type ListGroupMessagesBetweenSeqsParams struct {
-	GroupID   string `json:"group_id"`
-	AfterSeq  int64  `json:"after_seq"`
-	BeforeSeq int64  `json:"before_seq"`
-}
-
-type ListGroupMessagesBetweenSeqsRow struct {
-	ID                string             `json:"id"`
-	GroupID           string             `json:"group_id"`
-	Seq               int64              `json:"seq"`
-	SourceChannelID   pgtype.Text        `json:"source_channel_id"`
-	ActorType         string             `json:"actor_type"`
-	ActorID           string             `json:"actor_id"`
-	PlatformMessageID pgtype.Text        `json:"platform_message_id"`
-	ReplyTo           pgtype.Text        `json:"reply_to"`
-	PlatformTimestamp pgtype.Timestamptz `json:"platform_timestamp"`
-	IdempotencyKey    pgtype.Text        `json:"idempotency_key"`
-	Content           string             `json:"content"`
-	Reasoning         string             `json:"reasoning"`
-	AgentSessionID    string             `json:"agent_session_id"`
-	CreatedAt         time.Time          `json:"created_at"`
-}
-
-func (q *Queries) ListGroupMessagesBetweenSeqs(ctx context.Context, arg ListGroupMessagesBetweenSeqsParams) ([]ListGroupMessagesBetweenSeqsRow, error) {
-	rows, err := q.db.Query(ctx, listGroupMessagesBetweenSeqs, arg.GroupID, arg.AfterSeq, arg.BeforeSeq)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []ListGroupMessagesBetweenSeqsRow{}
-	for rows.Next() {
-		var i ListGroupMessagesBetweenSeqsRow
-		if err := rows.Scan(
-			&i.ID,
-			&i.GroupID,
-			&i.Seq,
-			&i.SourceChannelID,
-			&i.ActorType,
-			&i.ActorID,
-			&i.PlatformMessageID,
-			&i.ReplyTo,
-			&i.PlatformTimestamp,
-			&i.IdempotencyKey,
-			&i.Content,
-			&i.Reasoning,
-			&i.AgentSessionID,
-			&i.CreatedAt,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/db/sqlc/ctx_message.sql.go
+++ b/pkg/db/sqlc/ctx_message.sql.go
@@ -16,24 +16,25 @@ import (
 const createMessage = `-- name: CreateMessage :one
 INSERT INTO ctx_message (
     id, conversation_id, seq, role, event_type, content, token_count,
-    actor_type, actor_id, source_session_id, inbox_id
+    actor_type, actor_id, source_session_id, inbox_id, origin_group_message_id
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-RETURNING id, conversation_id, seq, role, event_type, content, token_count, created_at, actor_type, actor_id, source_session_id, inbox_id
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+RETURNING id, conversation_id, seq, role, event_type, content, token_count, created_at, actor_type, actor_id, source_session_id, inbox_id, origin_group_message_id
 `
 
 type CreateMessageParams struct {
-	ID              string      `json:"id"`
-	ConversationID  string      `json:"conversation_id"`
-	Seq             int64       `json:"seq"`
-	Role            string      `json:"role"`
-	EventType       string      `json:"event_type"`
-	Content         string      `json:"content"`
-	TokenCount      int64       `json:"token_count"`
-	ActorType       string      `json:"actor_type"`
-	ActorID         pgtype.Text `json:"actor_id"`
-	SourceSessionID pgtype.Text `json:"source_session_id"`
-	InboxID         pgtype.Text `json:"inbox_id"`
+	ID                   string      `json:"id"`
+	ConversationID       string      `json:"conversation_id"`
+	Seq                  int64       `json:"seq"`
+	Role                 string      `json:"role"`
+	EventType            string      `json:"event_type"`
+	Content              string      `json:"content"`
+	TokenCount           int64       `json:"token_count"`
+	ActorType            string      `json:"actor_type"`
+	ActorID              pgtype.Text `json:"actor_id"`
+	SourceSessionID      pgtype.Text `json:"source_session_id"`
+	InboxID              pgtype.Text `json:"inbox_id"`
+	OriginGroupMessageID pgtype.Text `json:"origin_group_message_id"`
 }
 
 func (q *Queries) CreateMessage(ctx context.Context, arg CreateMessageParams) (CtxMessage, error) {
@@ -49,6 +50,7 @@ func (q *Queries) CreateMessage(ctx context.Context, arg CreateMessageParams) (C
 		arg.ActorID,
 		arg.SourceSessionID,
 		arg.InboxID,
+		arg.OriginGroupMessageID,
 	)
 	var i CtxMessage
 	err := row.Scan(
@@ -64,6 +66,7 @@ func (q *Queries) CreateMessage(ctx context.Context, arg CreateMessageParams) (C
 		&i.ActorID,
 		&i.SourceSessionID,
 		&i.InboxID,
+		&i.OriginGroupMessageID,
 	)
 	return i, err
 }
@@ -181,7 +184,7 @@ func (q *Queries) GetMaxSeq(ctx context.Context, conversationID string) (int64, 
 }
 
 const getMessage = `-- name: GetMessage :one
-SELECT id, conversation_id, seq, role, event_type, content, token_count, created_at, actor_type, actor_id, source_session_id, inbox_id FROM ctx_message WHERE id = $1 AND conversation_id = $2
+SELECT id, conversation_id, seq, role, event_type, content, token_count, created_at, actor_type, actor_id, source_session_id, inbox_id, origin_group_message_id FROM ctx_message WHERE id = $1 AND conversation_id = $2
 `
 
 type GetMessageParams struct {
@@ -205,6 +208,39 @@ func (q *Queries) GetMessage(ctx context.Context, arg GetMessageParams) (CtxMess
 		&i.ActorID,
 		&i.SourceSessionID,
 		&i.InboxID,
+		&i.OriginGroupMessageID,
+	)
+	return i, err
+}
+
+const getMessageByConversationOrigin = `-- name: GetMessageByConversationOrigin :one
+SELECT id, conversation_id, seq, role, event_type, content, token_count, created_at, actor_type, actor_id, source_session_id, inbox_id, origin_group_message_id FROM ctx_message
+WHERE conversation_id = $1
+  AND origin_group_message_id = $2
+`
+
+type GetMessageByConversationOriginParams struct {
+	ConversationID       string      `json:"conversation_id"`
+	OriginGroupMessageID pgtype.Text `json:"origin_group_message_id"`
+}
+
+func (q *Queries) GetMessageByConversationOrigin(ctx context.Context, arg GetMessageByConversationOriginParams) (CtxMessage, error) {
+	row := q.db.QueryRow(ctx, getMessageByConversationOrigin, arg.ConversationID, arg.OriginGroupMessageID)
+	var i CtxMessage
+	err := row.Scan(
+		&i.ID,
+		&i.ConversationID,
+		&i.Seq,
+		&i.Role,
+		&i.EventType,
+		&i.Content,
+		&i.TokenCount,
+		&i.CreatedAt,
+		&i.ActorType,
+		&i.ActorID,
+		&i.SourceSessionID,
+		&i.InboxID,
+		&i.OriginGroupMessageID,
 	)
 	return i, err
 }
@@ -298,7 +334,7 @@ func (q *Queries) GetMessagePartsByMessages(ctx context.Context, messageIds []st
 
 const getMessageScoped = `-- name: GetMessageScoped :one
 SELECT
-    m.id, m.conversation_id, m.seq, m.role, m.event_type, m.content, m.token_count, m.created_at, m.actor_type, m.actor_id, m.source_session_id, m.inbox_id,
+    m.id, m.conversation_id, m.seq, m.role, m.event_type, m.content, m.token_count, m.created_at, m.actor_type, m.actor_id, m.source_session_id, m.inbox_id, m.origin_group_message_id,
     c.session_id AS session_id,
     c.title AS conversation_title
 FROM ctx_message m
@@ -316,20 +352,21 @@ type GetMessageScopedParams struct {
 }
 
 type GetMessageScopedRow struct {
-	ID                string      `json:"id"`
-	ConversationID    string      `json:"conversation_id"`
-	Seq               int64       `json:"seq"`
-	Role              string      `json:"role"`
-	EventType         string      `json:"event_type"`
-	Content           string      `json:"content"`
-	TokenCount        int64       `json:"token_count"`
-	CreatedAt         time.Time   `json:"created_at"`
-	ActorType         string      `json:"actor_type"`
-	ActorID           pgtype.Text `json:"actor_id"`
-	SourceSessionID   pgtype.Text `json:"source_session_id"`
-	InboxID           pgtype.Text `json:"inbox_id"`
-	SessionID         string      `json:"session_id"`
-	ConversationTitle pgtype.Text `json:"conversation_title"`
+	ID                   string      `json:"id"`
+	ConversationID       string      `json:"conversation_id"`
+	Seq                  int64       `json:"seq"`
+	Role                 string      `json:"role"`
+	EventType            string      `json:"event_type"`
+	Content              string      `json:"content"`
+	TokenCount           int64       `json:"token_count"`
+	CreatedAt            time.Time   `json:"created_at"`
+	ActorType            string      `json:"actor_type"`
+	ActorID              pgtype.Text `json:"actor_id"`
+	SourceSessionID      pgtype.Text `json:"source_session_id"`
+	InboxID              pgtype.Text `json:"inbox_id"`
+	OriginGroupMessageID pgtype.Text `json:"origin_group_message_id"`
+	SessionID            string      `json:"session_id"`
+	ConversationTitle    pgtype.Text `json:"conversation_title"`
 }
 
 // Fetch one message in full by ID, scoped to (user_id, agent_id) across every
@@ -352,6 +389,7 @@ func (q *Queries) GetMessageScoped(ctx context.Context, arg GetMessageScopedPara
 		&i.ActorID,
 		&i.SourceSessionID,
 		&i.InboxID,
+		&i.OriginGroupMessageID,
 		&i.SessionID,
 		&i.ConversationTitle,
 	)
@@ -359,7 +397,7 @@ func (q *Queries) GetMessageScoped(ctx context.Context, arg GetMessageScopedPara
 }
 
 const getMessagesByConversation = `-- name: GetMessagesByConversation :many
-SELECT id, conversation_id, seq, role, event_type, content, token_count, created_at, actor_type, actor_id, source_session_id, inbox_id FROM ctx_message WHERE conversation_id = $1 ORDER BY seq ASC
+SELECT id, conversation_id, seq, role, event_type, content, token_count, created_at, actor_type, actor_id, source_session_id, inbox_id, origin_group_message_id FROM ctx_message WHERE conversation_id = $1 ORDER BY seq ASC
 `
 
 func (q *Queries) GetMessagesByConversation(ctx context.Context, conversationID string) ([]CtxMessage, error) {
@@ -384,6 +422,7 @@ func (q *Queries) GetMessagesByConversation(ctx context.Context, conversationID 
 			&i.ActorID,
 			&i.SourceSessionID,
 			&i.InboxID,
+			&i.OriginGroupMessageID,
 		); err != nil {
 			return nil, err
 		}
@@ -396,7 +435,7 @@ func (q *Queries) GetMessagesByConversation(ctx context.Context, conversationID 
 }
 
 const getMessagesByConversationRange = `-- name: GetMessagesByConversationRange :many
-SELECT id, conversation_id, seq, role, event_type, content, token_count, created_at, actor_type, actor_id, source_session_id, inbox_id FROM ctx_message
+SELECT id, conversation_id, seq, role, event_type, content, token_count, created_at, actor_type, actor_id, source_session_id, inbox_id, origin_group_message_id FROM ctx_message
 WHERE conversation_id = $1 AND seq >= $2 AND seq <= $3
 ORDER BY seq ASC
 `
@@ -429,6 +468,7 @@ func (q *Queries) GetMessagesByConversationRange(ctx context.Context, arg GetMes
 			&i.ActorID,
 			&i.SourceSessionID,
 			&i.InboxID,
+			&i.OriginGroupMessageID,
 		); err != nil {
 			return nil, err
 		}
@@ -441,7 +481,7 @@ func (q *Queries) GetMessagesByConversationRange(ctx context.Context, arg GetMes
 }
 
 const getMessagesSince = `-- name: GetMessagesSince :many
-SELECT id, conversation_id, seq, role, event_type, content, token_count, created_at, actor_type, actor_id, source_session_id, inbox_id FROM ctx_message
+SELECT id, conversation_id, seq, role, event_type, content, token_count, created_at, actor_type, actor_id, source_session_id, inbox_id, origin_group_message_id FROM ctx_message
 WHERE conversation_id = $1 AND created_at > $2
 ORDER BY seq ASC
 `
@@ -473,6 +513,7 @@ func (q *Queries) GetMessagesSince(ctx context.Context, arg GetMessagesSincePara
 			&i.ActorID,
 			&i.SourceSessionID,
 			&i.InboxID,
+			&i.OriginGroupMessageID,
 		); err != nil {
 			return nil, err
 		}
@@ -575,7 +616,7 @@ func (q *Queries) ListMessagePartsWithMediaByMessages(ctx context.Context, messa
 }
 
 const listMessagesByIDs = `-- name: ListMessagesByIDs :many
-SELECT id, conversation_id, seq, role, event_type, content, token_count, created_at, actor_type, actor_id, source_session_id, inbox_id FROM ctx_message WHERE conversation_id = $1 AND id = ANY($2::uuid[]) ORDER BY seq ASC
+SELECT id, conversation_id, seq, role, event_type, content, token_count, created_at, actor_type, actor_id, source_session_id, inbox_id, origin_group_message_id FROM ctx_message WHERE conversation_id = $1 AND id = ANY($2::uuid[]) ORDER BY seq ASC
 `
 
 type ListMessagesByIDsParams struct {
@@ -605,6 +646,7 @@ func (q *Queries) ListMessagesByIDs(ctx context.Context, arg ListMessagesByIDsPa
 			&i.ActorID,
 			&i.SourceSessionID,
 			&i.InboxID,
+			&i.OriginGroupMessageID,
 		); err != nil {
 			return nil, err
 		}
@@ -619,7 +661,7 @@ func (q *Queries) ListMessagesByIDs(ctx context.Context, arg ListMessagesByIDsPa
 const listMessagesByLogicalPage = `-- name: ListMessagesByLogicalPage :many
 WITH ordered AS (
     SELECT
-        id, conversation_id, seq, role, event_type, content, token_count, created_at, actor_type, actor_id, source_session_id, inbox_id,
+        id, conversation_id, seq, role, event_type, content, token_count, created_at, actor_type, actor_id, source_session_id, inbox_id, origin_group_message_id,
         lag(role) OVER (ORDER BY seq ASC) AS prev_role
     FROM ctx_message
     WHERE conversation_id = $1
@@ -627,7 +669,7 @@ WITH ordered AS (
       AND ($3::timestamptz IS NULL OR created_at <= $3)
 ), grouped AS (
     SELECT
-        id, conversation_id, seq, role, event_type, content, token_count, created_at, actor_type, actor_id, source_session_id, inbox_id, prev_role,
+        id, conversation_id, seq, role, event_type, content, token_count, created_at, actor_type, actor_id, source_session_id, inbox_id, origin_group_message_id, prev_role,
         sum(CASE WHEN role = 'assistant' AND prev_role = 'assistant' THEN 0 ELSE 1 END)
             OVER (ORDER BY seq ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS logical_idx
     FROM ordered
@@ -639,7 +681,7 @@ WITH ordered AS (
     LIMIT $5 OFFSET $4
 )
 SELECT id, conversation_id, seq, role, event_type, content, token_count, created_at,
-       actor_type, actor_id, source_session_id, inbox_id
+       actor_type, actor_id, source_session_id, inbox_id, origin_group_message_id
 FROM grouped
 WHERE logical_idx IN (SELECT logical_idx FROM selected_groups)
 ORDER BY seq ASC
@@ -654,18 +696,19 @@ type ListMessagesByLogicalPageParams struct {
 }
 
 type ListMessagesByLogicalPageRow struct {
-	ID              string      `json:"id"`
-	ConversationID  string      `json:"conversation_id"`
-	Seq             int64       `json:"seq"`
-	Role            string      `json:"role"`
-	EventType       string      `json:"event_type"`
-	Content         string      `json:"content"`
-	TokenCount      int64       `json:"token_count"`
-	CreatedAt       time.Time   `json:"created_at"`
-	ActorType       string      `json:"actor_type"`
-	ActorID         pgtype.Text `json:"actor_id"`
-	SourceSessionID pgtype.Text `json:"source_session_id"`
-	InboxID         pgtype.Text `json:"inbox_id"`
+	ID                   string      `json:"id"`
+	ConversationID       string      `json:"conversation_id"`
+	Seq                  int64       `json:"seq"`
+	Role                 string      `json:"role"`
+	EventType            string      `json:"event_type"`
+	Content              string      `json:"content"`
+	TokenCount           int64       `json:"token_count"`
+	CreatedAt            time.Time   `json:"created_at"`
+	ActorType            string      `json:"actor_type"`
+	ActorID              pgtype.Text `json:"actor_id"`
+	SourceSessionID      pgtype.Text `json:"source_session_id"`
+	InboxID              pgtype.Text `json:"inbox_id"`
+	OriginGroupMessageID pgtype.Text `json:"origin_group_message_id"`
 }
 
 // Keep this logical-message boundary in sync with serializeDBMessages in
@@ -699,6 +742,7 @@ func (q *Queries) ListMessagesByLogicalPage(ctx context.Context, arg ListMessage
 			&i.ActorID,
 			&i.SourceSessionID,
 			&i.InboxID,
+			&i.OriginGroupMessageID,
 		); err != nil {
 			return nil, err
 		}
@@ -801,7 +845,7 @@ func (q *Queries) ListRecallMessageByIDs(ctx context.Context, messageIds []strin
 const listSessionTranscriptPage = `-- name: ListSessionTranscriptPage :many
 WITH ordered AS (
     SELECT
-        id, conversation_id, seq, role, event_type, content, token_count, created_at, actor_type, actor_id, source_session_id, inbox_id,
+        id, conversation_id, seq, role, event_type, content, token_count, created_at, actor_type, actor_id, source_session_id, inbox_id, origin_group_message_id,
         lag(seq) OVER (ORDER BY seq ASC) AS prev_seq
     FROM ctx_message
     WHERE conversation_id = $1
@@ -811,7 +855,7 @@ WITH ordered AS (
       )
 ), grouped AS (
     SELECT
-        id, conversation_id, seq, role, event_type, content, token_count, created_at, actor_type, actor_id, source_session_id, inbox_id, prev_seq,
+        id, conversation_id, seq, role, event_type, content, token_count, created_at, actor_type, actor_id, source_session_id, inbox_id, origin_group_message_id, prev_seq,
         sum(CASE WHEN role = 'user' OR prev_seq IS NULL THEN 1 ELSE 0 END)
             OVER (ORDER BY seq ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS turn_idx
     FROM ordered
@@ -836,7 +880,7 @@ WITH ordered AS (
     LIMIT $5 OFFSET $4
 )
 SELECT id, conversation_id, seq, role, event_type, content, token_count, created_at,
-       actor_type, actor_id, source_session_id, inbox_id
+       actor_type, actor_id, source_session_id, inbox_id, origin_group_message_id
 FROM grouped
 WHERE turn_idx IN (SELECT turn_idx FROM selected_turns)
 ORDER BY seq ASC
@@ -851,18 +895,19 @@ type ListSessionTranscriptPageParams struct {
 }
 
 type ListSessionTranscriptPageRow struct {
-	ID              string      `json:"id"`
-	ConversationID  string      `json:"conversation_id"`
-	Seq             int64       `json:"seq"`
-	Role            string      `json:"role"`
-	EventType       string      `json:"event_type"`
-	Content         string      `json:"content"`
-	TokenCount      int64       `json:"token_count"`
-	CreatedAt       time.Time   `json:"created_at"`
-	ActorType       string      `json:"actor_type"`
-	ActorID         pgtype.Text `json:"actor_id"`
-	SourceSessionID pgtype.Text `json:"source_session_id"`
-	InboxID         pgtype.Text `json:"inbox_id"`
+	ID                   string      `json:"id"`
+	ConversationID       string      `json:"conversation_id"`
+	Seq                  int64       `json:"seq"`
+	Role                 string      `json:"role"`
+	EventType            string      `json:"event_type"`
+	Content              string      `json:"content"`
+	TokenCount           int64       `json:"token_count"`
+	CreatedAt            time.Time   `json:"created_at"`
+	ActorType            string      `json:"actor_type"`
+	ActorID              pgtype.Text `json:"actor_id"`
+	SourceSessionID      pgtype.Text `json:"source_session_id"`
+	InboxID              pgtype.Text `json:"inbox_id"`
+	OriginGroupMessageID pgtype.Text `json:"origin_group_message_id"`
 }
 
 // Agent-facing transcript pages use a whole user turn as the atomic boundary:
@@ -896,6 +941,7 @@ func (q *Queries) ListSessionTranscriptPage(ctx context.Context, arg ListSession
 			&i.ActorID,
 			&i.SourceSessionID,
 			&i.InboxID,
+			&i.OriginGroupMessageID,
 		); err != nil {
 			return nil, err
 		}
@@ -925,7 +971,7 @@ WITH candidates AS MATERIALIZED (
       AND vector_norm(e.embedding) > 0
 )
 SELECT
-    m.id, m.conversation_id, m.seq, m.role, m.event_type, m.content, m.token_count, m.created_at, m.actor_type, m.actor_id, m.source_session_id, m.inbox_id,
+    m.id, m.conversation_id, m.seq, m.role, m.event_type, m.content, m.token_count, m.created_at, m.actor_type, m.actor_id, m.source_session_id, m.inbox_id, m.origin_group_message_id,
     c.session_id AS session_id,
     c.title AS conversation_title,
     (1 - (e.embedding <=> $1::vector(1536)))::double precision AS score
@@ -945,21 +991,22 @@ type SearchMessageEmbeddingsParams struct {
 }
 
 type SearchMessageEmbeddingsRow struct {
-	ID                string      `json:"id"`
-	ConversationID    string      `json:"conversation_id"`
-	Seq               int64       `json:"seq"`
-	Role              string      `json:"role"`
-	EventType         string      `json:"event_type"`
-	Content           string      `json:"content"`
-	TokenCount        int64       `json:"token_count"`
-	CreatedAt         time.Time   `json:"created_at"`
-	ActorType         string      `json:"actor_type"`
-	ActorID           pgtype.Text `json:"actor_id"`
-	SourceSessionID   pgtype.Text `json:"source_session_id"`
-	InboxID           pgtype.Text `json:"inbox_id"`
-	SessionID         string      `json:"session_id"`
-	ConversationTitle pgtype.Text `json:"conversation_title"`
-	Score             float64     `json:"score"`
+	ID                   string      `json:"id"`
+	ConversationID       string      `json:"conversation_id"`
+	Seq                  int64       `json:"seq"`
+	Role                 string      `json:"role"`
+	EventType            string      `json:"event_type"`
+	Content              string      `json:"content"`
+	TokenCount           int64       `json:"token_count"`
+	CreatedAt            time.Time   `json:"created_at"`
+	ActorType            string      `json:"actor_type"`
+	ActorID              pgtype.Text `json:"actor_id"`
+	SourceSessionID      pgtype.Text `json:"source_session_id"`
+	InboxID              pgtype.Text `json:"inbox_id"`
+	OriginGroupMessageID pgtype.Text `json:"origin_group_message_id"`
+	SessionID            string      `json:"session_id"`
+	ConversationTitle    pgtype.Text `json:"conversation_title"`
+	Score                float64     `json:"score"`
 }
 
 // Exact KNN over the complete authorized candidate set. Materializing scope,
@@ -995,6 +1042,7 @@ func (q *Queries) SearchMessageEmbeddings(ctx context.Context, arg SearchMessage
 			&i.ActorID,
 			&i.SourceSessionID,
 			&i.InboxID,
+			&i.OriginGroupMessageID,
 			&i.SessionID,
 			&i.ConversationTitle,
 			&i.Score,
@@ -1011,7 +1059,7 @@ func (q *Queries) SearchMessageEmbeddings(ctx context.Context, arg SearchMessage
 
 const searchMessages = `-- name: SearchMessages :many
 SELECT
-    m.id, m.conversation_id, m.seq, m.role, m.event_type, m.content, m.token_count, m.created_at, m.actor_type, m.actor_id, m.source_session_id, m.inbox_id,
+    m.id, m.conversation_id, m.seq, m.role, m.event_type, m.content, m.token_count, m.created_at, m.actor_type, m.actor_id, m.source_session_id, m.inbox_id, m.origin_group_message_id,
     c.session_id AS session_id,
     c.title AS conversation_title,
     paradedb.snippet(m.content)::text AS snippet,
@@ -1034,22 +1082,23 @@ type SearchMessagesParams struct {
 }
 
 type SearchMessagesRow struct {
-	ID                string      `json:"id"`
-	ConversationID    string      `json:"conversation_id"`
-	Seq               int64       `json:"seq"`
-	Role              string      `json:"role"`
-	EventType         string      `json:"event_type"`
-	Content           string      `json:"content"`
-	TokenCount        int64       `json:"token_count"`
-	CreatedAt         time.Time   `json:"created_at"`
-	ActorType         string      `json:"actor_type"`
-	ActorID           pgtype.Text `json:"actor_id"`
-	SourceSessionID   pgtype.Text `json:"source_session_id"`
-	InboxID           pgtype.Text `json:"inbox_id"`
-	SessionID         string      `json:"session_id"`
-	ConversationTitle pgtype.Text `json:"conversation_title"`
-	Snippet           string      `json:"snippet"`
-	Score             float64     `json:"score"`
+	ID                   string      `json:"id"`
+	ConversationID       string      `json:"conversation_id"`
+	Seq                  int64       `json:"seq"`
+	Role                 string      `json:"role"`
+	EventType            string      `json:"event_type"`
+	Content              string      `json:"content"`
+	TokenCount           int64       `json:"token_count"`
+	CreatedAt            time.Time   `json:"created_at"`
+	ActorType            string      `json:"actor_type"`
+	ActorID              pgtype.Text `json:"actor_id"`
+	SourceSessionID      pgtype.Text `json:"source_session_id"`
+	InboxID              pgtype.Text `json:"inbox_id"`
+	OriginGroupMessageID pgtype.Text `json:"origin_group_message_id"`
+	SessionID            string      `json:"session_id"`
+	ConversationTitle    pgtype.Text `json:"conversation_title"`
+	Snippet              string      `json:"snippet"`
+	Score                float64     `json:"score"`
 }
 
 // Spans every active conversation of the current (user_id, agent_id). Joins
@@ -1090,6 +1139,7 @@ func (q *Queries) SearchMessages(ctx context.Context, arg SearchMessagesParams) 
 			&i.ActorID,
 			&i.SourceSessionID,
 			&i.InboxID,
+			&i.OriginGroupMessageID,
 			&i.SessionID,
 			&i.ConversationTitle,
 			&i.Snippet,

--- a/pkg/db/sqlc/ctx_summary.sql.go
+++ b/pkg/db/sqlc/ctx_summary.sql.go
@@ -252,7 +252,7 @@ func (q *Queries) GetSummaryMessageSeqRange(ctx context.Context, summaryID strin
 }
 
 const getSummaryMessages = `-- name: GetSummaryMessages :many
-SELECT m.id, m.conversation_id, m.seq, m.role, m.event_type, m.content, m.token_count, m.created_at, m.actor_type, m.actor_id, m.source_session_id, m.inbox_id FROM ctx_message m
+SELECT m.id, m.conversation_id, m.seq, m.role, m.event_type, m.content, m.token_count, m.created_at, m.actor_type, m.actor_id, m.source_session_id, m.inbox_id, m.origin_group_message_id FROM ctx_message m
 JOIN ctx_summary_message sm ON sm.message_id = m.id
 WHERE sm.summary_id = $1
 ORDER BY sm.ordinal ASC
@@ -280,6 +280,7 @@ func (q *Queries) GetSummaryMessages(ctx context.Context, summaryID string) ([]C
 			&i.ActorID,
 			&i.SourceSessionID,
 			&i.InboxID,
+			&i.OriginGroupMessageID,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/db/sqlc/models.go
+++ b/pkg/db/sqlc/models.go
@@ -494,6 +494,7 @@ type CtxGroupMessage struct {
 	CreatedAt         time.Time          `json:"created_at"`
 	ContentBlocks     json.RawMessage    `json:"content_blocks"`
 	DeliveryState     string             `json:"delivery_state"`
+	ActorDisplayName  pgtype.Text        `json:"actor_display_name"`
 }
 
 type CtxGroupOutbox struct {
@@ -551,18 +552,19 @@ type CtxMedium struct {
 }
 
 type CtxMessage struct {
-	ID              string      `json:"id"`
-	ConversationID  string      `json:"conversation_id"`
-	Seq             int64       `json:"seq"`
-	Role            string      `json:"role"`
-	EventType       string      `json:"event_type"`
-	Content         string      `json:"content"`
-	TokenCount      int64       `json:"token_count"`
-	CreatedAt       time.Time   `json:"created_at"`
-	ActorType       string      `json:"actor_type"`
-	ActorID         pgtype.Text `json:"actor_id"`
-	SourceSessionID pgtype.Text `json:"source_session_id"`
-	InboxID         pgtype.Text `json:"inbox_id"`
+	ID                   string      `json:"id"`
+	ConversationID       string      `json:"conversation_id"`
+	Seq                  int64       `json:"seq"`
+	Role                 string      `json:"role"`
+	EventType            string      `json:"event_type"`
+	Content              string      `json:"content"`
+	TokenCount           int64       `json:"token_count"`
+	CreatedAt            time.Time   `json:"created_at"`
+	ActorType            string      `json:"actor_type"`
+	ActorID              pgtype.Text `json:"actor_id"`
+	SourceSessionID      pgtype.Text `json:"source_session_id"`
+	InboxID              pgtype.Text `json:"inbox_id"`
+	OriginGroupMessageID pgtype.Text `json:"origin_group_message_id"`
 }
 
 type CtxMessageEmbedding struct {

--- a/web/content/docs/development/group-chat-multi-agent.md
+++ b/web/content/docs/development/group-chat-multi-agent.md
@@ -27,7 +27,7 @@ The replacement inverts the assumption. Assume every member might have something
 
 ## The shape of the system
 
-Four tables carry the event and work ledger. Coordination also relies on `ctx_group_state` for the locked caps/nudge state and `ctx_group_ingest_cursor` for each agent's durable read boundary. Nothing load-bearing lives only in process memory, so a restart loses no decision.
+Four tables carry the event and work ledger. Coordination also relies on `ctx_group_state` for the locked caps/nudge state and `ctx_group_ingest_cursor` for each agent's last completed trigger. Nothing load-bearing lives only in process memory, so a restart loses no decision.
 
 | Table                | Role                                                                                                                                                                                                                                                                              |
 | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -76,11 +76,11 @@ The agent has read the whole group, has its memory, and knows what it is working
 
 `isModelPass` recognises the reply through the wrapping models add — surrounding whitespace, a code fence, inline backticks, bold markers, a trailing period. Only a _bare_ pass counts: `PASS, but check the logs` is a reply that happens to start with the word, and it gets posted.
 
-The turn is retired as `silent` with reason `model_pass`. No post, no outbox, no cap or hold accounting. But **everything else the turn did still commits**: the peer rows it read, its ingest cursor, and any tool calls it made.
+The turn is retired as `silent` with reason `model_pass`. No post, no outbox, no cap or hold accounting. But **everything else the turn did still commits**: its trigger anchor, private tool trajectory, and last-completed-trigger cursor.
 
 That last part is load-bearing. An agent may claim a piece of work, write a file, and _then_ decide it has nothing worth saying. Dropping the whole turn would make it forget the claim it holds while the side effect stays real for every peer. `stripTrailingPass` removes only trailing text-only assistant messages and stops at the first message carrying a tool call, so no `tool_use` is ever separated from its `tool_result`.
 
-A `model_pass` advances the ingest cursor. So does a post-turn backstop: after a `held`, duplicate, or cap verdict, the transaction commits the history and tool trajectory the agent actually read and advances its cursor through `trigger_seq`; it discards only the trailing reply that was not accepted. Because a HOLD has therefore consumed its original mention, the successor is admitted by the covered durable held row (`held_successor`), before peer-mention or lap triage can silence it. Once that successor commits a cursor through `held_up_to_seq`, the old HOLD stops granting admission. A claim-time superseded row or a pre-turn gate decline did not run the model, so neither advances the cursor.
+A `model_pass` advances the cursor to `trigger_seq`. So does a post-turn backstop: after a `held`, duplicate, or cap verdict, the transaction commits the trigger anchor and private tool trajectory, then records that the agent durably completed that trigger; it discards only the trailing reply that was not accepted. The cursor does **not** mean that public history was copied into the agent's LCM. Because a HOLD has therefore completed its original trigger, the successor is admitted by the covered durable held row (`held_successor`), before peer-mention or lap triage can silence it. Once that successor commits a cursor through `held_up_to_seq`, the old HOLD stops granting admission. A claim-time superseded row or a pre-turn gate decline did not run the model, so neither advances the cursor.
 
 ## Gate three: the accept transaction
 
@@ -92,11 +92,15 @@ The transaction takes `FOR UPDATE` on `ctx_group_state`, then runs its gates in 
 - **Verbatim dedup.** An identical reply already in the chain retires as `silent` with reason `duplicate`. It does not consume HOLD budget.
 - **Chain and reply caps.** `agent_chain_hard_limit` and `max_replies_per_human_trigger` are re-checked under the lock, not on the snapshot, and retire the reply as `silent` if spent.
 
-If all gates pass, one transaction commits the **pending** agent message, the deferred memory turn and its cursor, and the dispatch result marker. There is deliberately no peer outbox in this transaction: this reply does not itself wake peers until the publisher returns successfully. That publisher finalization transaction marks the message `delivered` and creates its peer outbox together. The pending canonical row already exists, however, so a peer woken independently by later activity can encounter it before delivery resolves. The strict atomic guarantee is that an accepted message is never visible without its own agent memory.
+If all gates pass, one transaction commits the **pending** agent message, the deferred memory turn and its cursor, and the dispatch result marker. There is deliberately no peer outbox in this transaction: this reply does not itself wake peers until the publisher returns successfully. That publisher finalization transaction marks the message `delivered` and creates its peer outbox together. A pending row is internal publish state, never peer context. The strict atomic guarantee is that an accepted message is never visible without its own agent memory.
 
 Each gate carries its own retirement reason, reported verbatim. A gate that reports a neighbour's reason is indistinguishable from a backstop misfiring, and that is exactly the bug class this design is meant to make debuggable.
 
 ## What an agent sees
+
+Public context is a reverse-paged, chronological bounded window: at most 500 rows, 80k estimated tokens, and 4 MiB of rendered text. It contains only canonical rows with `delivery_state='delivered'` and `seq < trigger_seq`; pending and failed rows never enter a peer prompt. Eviction removes whole 10k-token head blocks for prompt-cache stability. When older group history is absent, the window says so explicitly; a coalesced waking mention is retained even when it falls below the normal floor. Historical media remains its `[image]` text projection.
+
+Each agent LCM stores only its own executed turns: the public trigger as a user anchor and its private assistant/tool continuation. Public peer rows are never copied into an LCM. During assembly, those private continuations are spliced after their canonical trigger, while the agent's published group output is skipped to avoid duplication.
 
 Every message an agent reads is labelled `[seq:N who]` with the participant's group name — including the message that woke the turn. Agents address other agents by those names only. On every surface, a human can write `@Name` in plain text, using a member's display name or ID, and it resolves the same way as a native platform mention. Participant naming tries the platform identity and account name, but resolution never fails: if that lookup or platform-ID resolution cannot produce a name, the model receives the stable raw actor ID instead.
 
@@ -132,7 +136,7 @@ The streak bound is the important one. Every nudge that remains live after the q
 
 Web `POST /api/groups/{id}/messages` only ingests and wakes workers. It returns `start`, `data-group-ingest`, and `finish`; canonical messages and turn presence arrive on the group event stream.
 
-**Web is a platform whose publisher is a noop, not a bypass.** A web reply runs the same lifecycle as a Telegram one: born `pending`, marked `delivered` in the successful publisher finalization transaction, `failed` when accepted delivery permanently cannot complete. Only that accepted-delivery failure frees peers that were held behind the reply. A normal wake that fails before acceptance has no accepted peer post to compensate. Failed canonical rows remain in the author's own memory for tool/history consistency, but are excluded from every peer's injected transcript because the conversation never received them.
+**Web is a platform whose publisher is a noop, not a bypass.** A web reply runs the same lifecycle as a Telegram one: born `pending`, marked `delivered` in the successful publisher finalization transaction, `failed` when accepted delivery permanently cannot complete. Only that accepted-delivery failure frees peers that were held behind the reply. A normal wake that fails before acceptance has no accepted peer post to compensate. Failed canonical rows remain in the author's private continuation for tool/history consistency, but never enter peer context because the conversation never received them.
 
 The real prebuffer is `bufferGroupResponse`: it drains the runtime's complete event stream, up to its 8 MiB in-memory ceiling, before acceptance or any platform side effect. Publishers receive a closed replay. `ValidateGroupReplay` is a defensive publisher-side recheck of that replay, not the mechanism that buffers a live model stream. No live model stream or model error remains at egress; platform delivery can still fail and is handled by the dispatch retry state machine. This is why platform publishers send one complete message rather than a placeholder they later edit.
 
@@ -161,7 +165,7 @@ Giving up on a row that already carries an accepted reply is not the same as giv
 - Canonical `seq` order is the client reducer key.
 - A member never wakes itself; normal fan-out skips an agent author and a nudge targets one named member.
 - At most one live dispatch, wake or nudge, runs for an agent and group.
-- Superseded rows and pre-turn gate declines do not advance the memory cursor. Model passes and post-turn backstops commit the history and tool work actually read through `trigger_seq`, without retaining a rejected trailing reply.
+- Superseded rows and pre-turn gate declines do not advance the memory cursor. Model passes and post-turn backstops atomically commit the trigger anchor, private tool work, and `last_completed_trigger_seq`, without retaining a rejected trailing reply or copying public peers into LCM.
 - Server acceptance, not model judgement, enforces freshness and caps.
 - A `running` turn frame is always followed by exactly one terminal turn frame; a gate decline and a superseded row never produce that `running` frame.
 - No model decides whether another model may speak.

--- a/web/content/docs/development/group-chat-multi-agent.zh.md
+++ b/web/content/docs/development/group-chat-multi-agent.zh.md
@@ -27,7 +27,7 @@ description: Stella 如何让多个 agent 共享同一个会话，而不需要�
 
 ## 系统的形状
 
-四张表承载事件与工作台账。协调还依赖 `ctx_group_state` 保存加锁的上限/nudge 状态，以及 `ctx_group_ingest_cursor` 保存每个 agent 的 durable 读取边界。没有承重状态只存在于进程内存里，所以重启不会丢失任何决定。
+四张表承载事件与工作台账。协调还依赖 `ctx_group_state` 保存加锁的上限/nudge 状态，以及 `ctx_group_ingest_cursor` 保存每个 agent 最后完成的 trigger。没有承重状态只存在于进程内存里，所以重启不会丢失任何决定。
 
 | 表                   | 职责                                                                                                                                                                                                          |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -76,11 +76,11 @@ agent 已经读完整个群，带着自己的记忆，也知道自己在做什�
 
 `isModelPass` 会穿过模型加的各种包装来识别它——首尾空白、代码围栏、行内反引号、粗体标记、结尾句号。**只有光秃秃的 PASS 算数**：`PASS，但记得看日志` 是一条恰好以这个词开头的正常回复，照发。
 
-这一轮以 `silent`、原因 `model_pass` 结束。不发消息、不建 outbox、不计入上限和 hold。但**这一轮做过的其他事情照常提交**：它读到的 peer 行、它的 ingest cursor，以及它调用过的任何工具。
+这一轮以 `silent`、原因 `model_pass` 结束。不发消息、不建 outbox、不计入上限和 hold。但**这一轮做过的其他事情照常提交**：它的 trigger anchor、私有工具轨迹，以及最后完成 trigger 的 cursor。
 
 最后这条是承重的。一个 agent 可能先认领一块工作、写了一个文件，**然后**才判断没什么值得说的。丢掉整轮会让它忘记自己持有的 claim，而副作用对每个 peer 都是真的。`stripTrailingPass` 只移除末尾的纯文本 assistant 消息，遇到第一条带 tool call 的消息就停，所以任何 `tool_use` 都不会和它的 `tool_result` 分家。
 
-`model_pass` 会推进 ingest cursor。post-turn backstop 也会：`held`、duplicate 或 cap 判决之后，事务会提交 agent 实际读过的 history 和 tool 轨迹，并把 cursor 推进到 `trigger_seq`；它只丢掉没有被接受的末尾回复。因为 HOLD 因而已经消费了原始 mention，它的后继会在 peer-mention 和 lap triage 有机会静默之前，由覆盖范围内的 durable held 行以 `held_successor` 准入。一旦该后继提交的 cursor 覆盖 `held_up_to_seq`，旧 HOLD 就不再提供准入。claim 阶段 superseded 的行或 turn 开始前的 gate decline 没有跑模型，所以两者都不推进 cursor。
+`model_pass` 会把 cursor 推进到 `trigger_seq`。post-turn backstop 也会：`held`、duplicate 或 cap 判决之后，事务会提交 trigger anchor 和私有工具轨迹，再记录 agent 已 durable 完成该 trigger；它只丢掉没有被接受的末尾回复。cursor **不**表示公共 history 被复制进了 agent 的 LCM。因为 HOLD 因而已经完成原始 trigger，它的后继会在 peer-mention 和 lap triage 有机会静默之前，由覆盖范围内的 durable held 行以 `held_successor` 准入。一旦该后继提交的 cursor 覆盖 `held_up_to_seq`，旧 HOLD 就不再提供准入。claim 阶段 superseded 的行或 turn 开始前的 gate decline 没有跑模型，所以两者都不推进 cursor。
 
 ## 门三：接受事务
 
@@ -92,11 +92,15 @@ agent 已经读完整个群，带着自己的记忆，也知道自己在做什�
 - **逐字去重。** 链上已存在的完全相同回复以 `silent`、原因 `duplicate` 退休；它不消耗 HOLD 预算。
 - **链和回复上限。** `agent_chain_hard_limit` 与 `max_replies_per_human_trigger` 都在锁下重新检查，而不是拿快照检查；若用尽则以 `silent` 退休。
 
-全部通过，则一个事务一起提交**`pending`** 的 agent 消息、deferred memory turn 及其 cursor、以及 dispatch result marker。这个事务刻意不建 peer outbox：这条回复本身要等 publisher 成功返回后才会唤醒 peer。publisher 的 finalize 事务会一起把消息标为 `delivered` 并创建 peer outbox。不过 pending canonical 行已经存在，所以被后续独立活动唤醒的 peer 仍可能在投递结果确定前遇到它。严格的原子保证是：被接受的消息绝不会在自己的 agent memory 尚未落地时可见。
+全部通过，则一个事务一起提交**`pending`** 的 agent 消息、deferred memory turn 及其 cursor、以及 dispatch result marker。这个事务刻意不建 peer outbox：这条回复本身要等 publisher 成功返回后才会唤醒 peer。publisher 的 finalize 事务会一起把消息标为 `delivered` 并创建 peer outbox。pending 行是内部投递状态，绝不进入 peer context。严格的原子保证是：被接受的消息绝不会在自己的 agent memory 尚未落地时可见。
 
 每道门带自己的退休原因，并且逐字上报。一道门报出邻居的原因，和这个 backstop 误触发是分不出来的——而这正是本设计想让人能调试的那一类 bug。
 
 ## agent 看到什么
+
+公共 context 是一个反向分页后按时间顺序恢复的有界窗口：最多 500 行、8 万估算 token、4 MiB 渲染文本。它只包含 `delivery_state='delivered'` 且 `seq < trigger_seq` 的 canonical 行；`pending` 和 `failed` 永不进入 peer prompt。为保持 prompt cache 稳定，淘汰以完整的 1 万 token 头部块进行。缺少更早群历史时窗口会明确说明；合并 wake 的唤醒 mention 即使落在通常窗口下界之外也会保留。历史媒体保留为 `[image]` 文本投影。
+
+每个 agent 的 LCM 只保存自己的已执行 turn：作为 user anchor 的公共 trigger，以及私有 assistant/tool continuation。公共 peer 行绝不复制进 LCM。组装时，私有 continuation 被插入 canonical trigger 之后；该 agent 已发布的群输出会跳过，避免重复。
 
 agent 读到的每条消息都带 `[seq:N 谁]` 标签，用参与者的群内名字——**包括唤醒本轮的那条**。agent 之间只用这些名字互相称呼。在任何表面上，人都可以在纯文本里写 `@Name`，使用成员的显示名或 ID，它和平台原生 @ 一样解析。参与者命名会尝试平台 identity 和账户名，但解析永不失败：如果查询或平台 ID 解析无法得到名字，模型会看到稳定的原始 actor ID。
 
@@ -132,7 +136,7 @@ streak 上限才是关键。只有通过 queue-slot moot 复检后仍然存活�
 
 Web `POST /api/groups/{id}/messages` 只负责 ingest 并唤醒 worker。它返回 `start`、`data-group-ingest`、`finish`；canonical 消息和 turn presence 通过 group event stream 到达。
 
-**Web 是一个 publisher 为 noop 的平台，而不是一条绕过。** 一条 web 回复走的生命周期和 Telegram 的完全一样：以 `pending` 出生，在 publisher 成功 finalize 的事务中标为 `delivered`，已接受的投递永久不能完成时标为 `failed`。只有这种已接受投递失败会释放被该回复 hold 住的 peer；一条接受前就失败的普通 wake 没有已接受的 peer post 可以补偿。失败的 canonical 行会留在作者自己的 memory 中，维持工具/history 一致性，但不会注入任何 peer 的 transcript，因为群对话从未收到它。
+**Web 是一个 publisher 为 noop 的平台，而不是一条绕过。** 一条 web 回复走的生命周期和 Telegram 的完全一样：以 `pending` 出生，在 publisher 成功 finalize 的事务中标为 `delivered`，已接受的投递永久不能完成时标为 `failed`。只有这种已接受投递失败会释放被该回复 hold 住的 peer；一条接受前就失败的普通 wake 没有已接受的 peer post 可以补偿。失败的 canonical 行会留在作者的私有 continuation 中，维持工具/history 一致性，但绝不进入 peer context，因为群对话从未收到它。
 
 真正的预缓冲是 `bufferGroupResponse`：它在接受和任何平台副作用之前，抽干 runtime 的完整 event stream，受 8 MiB 内存上限约束。publisher 拿到的是已经关闭的 replay。`ValidateGroupReplay` 是 publisher 侧对该 replay 的防御性复检，不是缓冲实时模型流的机制。egress 处不再有实时模型流或模型错误；平台投递本身仍可能失败，并由 dispatch 重试状态机处理。这就是平台 publisher 发一条完整消息、而不是先发占位再编辑的原因。
 
@@ -161,7 +165,7 @@ egress 补偿——重启后重新发布一条已接受的回复——会跳过 
 - canonical `seq` 顺序是客户端 reducer 的键。
 - 成员不会唤醒自己：普通扇出跳过 agent 作者，nudge 只指向一个点名成员。
 - 每个 agent/group 最多一个 live dispatch，不区分 wake 或 nudge。
-- superseded 行和 turn 前 gate decline 不推进 memory cursor。model pass 和 post-turn backstop 会提交实际读到的 history/tool 工作到 `trigger_seq`，但不保留被拒绝的末尾回复。
+- superseded 行和 turn 前 gate decline 不推进 memory cursor。model pass 和 post-turn backstop 会原子提交 trigger anchor、私有工具工作及 `last_completed_trigger_seq`，不保留被拒绝的末尾回复，也不把公共 peer 复制进 LCM。
 - 新鲜度和上限由 Server 的接受事务保证，不由模型判断保证。
 - 一个 `running` turn 帧之后，永远恰好跟着一个终态 turn 帧；gate decline 和 superseded 行都不会产生这个 `running` 帧。
 - 没有任何模型有权决定另一个模型能不能说话。


### PR DESCRIPTION
## Summary

PR 1 of the #1059 v2 redesign: public group events are no longer copied into each agent's LCM. Group context is now assembled per turn from a bounded, delivered-only window over the canonical event log, and each agent's LCM keeps only its own turns (trigger anchor + private assistant/tool continuation).

### Mechanism

- **Bounded window** (`internal/memory/lcm/group_assembler.go`): reverse-paged read of `delivery_state='delivered' AND seq < trigger_seq` rows under three caps (500 rows / 80k est. tokens / 4 MiB). Eviction drops whole 10k-token head blocks for prompt-cache prefix stability. An omission marker tells the model older history exists; a coalesced waking mention below the floor is force-included (an oversized mention fails the turn rather than silently breaching a ceiling). Historical media stays as its `[image]` text projection.
- **Private-only LCM**: `DeferredGroupTurn` loses `InjectedPeerRows`; `CommitGroupTurn` writes the trigger anchor (user row carrying `origin_group_message_id`) + own continuation + cursor in the same dispatcher-owned transaction as before. Retries are idempotent via the origin lookup; the partial unique index `(conversation_id, origin_group_message_id)` backs it. Turns whose trigger left the window (evicted or retracted by failed delivery) render whole from their stored anchor at the head — private tool history outlives the sliding public window.
- **Event-time attribution**: new `ctx_group_message.actor_display_name` snapshot written at append time on every surface (platform ingest, web PrepareSend, agent replies, nudges); read paths prefer the snapshot and fall back to live resolution only for legacy NULL rows. Renames no longer rewrite history.
- **Cursor semantics**: `ctx_group_ingest_cursor` now records `last_completed_trigger_seq` — the agent durably completed a turn at that trigger — instead of claiming every earlier event was copied. Unchanged storage, honest meaning.
- Migration `90000000000021_add_group_context_window_origins.sql`; `ListGroupMessagesBetweenSeqs` (the unbounded interval read) is deleted, replaced by paged delivered-only queries.

### Docs

`web/content/docs/development/group-chat-multi-agent.md` + `.zh.md` updated (window shape, delivered-only visibility, cursor meaning, private-only LCM).

### Verification

`mise run format && mise run build && mise run test`, `mise run system-test`, and `mise run db:validate` all green locally. New `group_window_test.go` covers delivered-only + pending→delivered transitions, row cap + omission marker, private-continuation interleaving + origin retry idempotency, mention anchor + quantized eviction, and evicted-origin private-turn survival.

Refs #1059

## Feishu Task

- [群聊上下文改为每 Agent 独立 LCM + 按需公共历史召回](https://mcnnox2fhjfq.feishu.cn/record/F266rokpce2NuMcp2oHcs0senJg) (#1059)