### PR TITLE
🧪 eval: make the Terminal-Bench control run survivable and attributable

### DIFF
--- a/test/evals/harbor/README.md
+++ b/test/evals/harbor/README.md
@@ -158,6 +158,64 @@ agent's own reported usage), so it works against a downloaded community job too.
 A missing Stella adapter result is reported as "no evidence contract", never as
 a failed one.
 
+## Pi UTF-8 recovery and the archived k=5 rerun
+
+Harbor 0.21.0's installed `Pi.populate_context_post_run()` calls
+`Path.read_text()` on `pi.txt`. A truncated final UTF-8 sequence therefore raises
+`UnicodeDecodeError` while Harbor is syncing the agent result, after the agent
+has already run. The `PiGateway` subclass now decodes the file strictly first,
+then uses replacement decoding only for usage parsing. A damaged file keeps its
+original bytes in the Harbor logs and records `agent_result.metadata.pi_output_decode`
+with the UTF-8 error count, whether the error was an EOF truncation, and the file
+size. The warning is visible in the trial log, so recovery cannot silently turn a
+damaged trial into clean evidence.
+
+A local adapter override is deliberate here instead of patching Harbor in place.
+It is the smallest change that protects this controlled Pi baseline immediately,
+without forking or replacing Harbor for every installed agent. An upstream Harbor
+patch remains the right long-term fix, but it must first be accepted and released;
+when that happens, remove this override after verifying the released behavior.
+
+To reproduce the archived Stella baseline's Pi configuration after this fix,
+human operators must provide the exact same gateway endpoint used by the archived
+run and a credential for it. Do not substitute the default OpenAI endpoint:
+
+```bash
+export OPENAI_BASE_URL='<the exact endpoint used by the archived baseline>'
+export OPENAI_API_KEY='<credential for that endpoint>'
+
+cat >/tmp/stella-pi-luna-k5.json <<'JSON'
+{
+  "job_name": "pi-luna-k5-rerun",
+  "jobs_dir": "dist/evals/jobs/pi-luna-k5-rerun",
+  "n_attempts": 5,
+  "agent_timeout_multiplier": 1.0,
+  "n_concurrent_trials": 16,
+  "quiet": true,
+  "agents": [
+    {
+      "name": "stella_harbor.pi_gateway:PiGateway",
+      "model_name": "gateway/gpt-5.6-luna"
+    }
+  ],
+  "datasets": [
+    {
+      "name": "terminal-bench/terminal-bench-2-1",
+      "ref": "sha256:7d7bdc1cbedad549fc1140404bd4dc45e5fd0ea7c4186773687d177ad3a0699a"
+    }
+  ]
+}
+JSON
+
+uv run --project test/evals/harbor harbor run \
+  --config /tmp/stella-pi-luna-k5.json
+```
+
+Run it on the same `c7i.8xlarge` class as the archived baseline. The command
+above preserves the required 89-task dataset, `k=5`, concurrency `16`, agent
+timeout multiplier `1.0`, model `gateway/gpt-5.6-luna`, and dataset SHA-256.
+The endpoint and API credential are intentionally not stored in this repository.
+
 ## Publishing a run
 
 `harbor upload <job>/<timestamp>` sends the whole trial directory to the Harbor

--- a/test/evals/harbor/README.md
+++ b/test/evals/harbor/README.md
@@ -226,23 +226,44 @@ uv run --project test/evals/harbor python -m stella_harbor.archive \
   test/evals/harbor/results/terminal-bench-2.1/2026-08-21-pi-luna-k5
 ```
 
-The output contains every `result.json` and `config.json`. It adds a redacted
-`trajectory.json` only for non-pass or invalid trials; pass trajectories are
-omitted. The source trajectory remains full, unredacted, and untouched under
-`dist/`. Known credential shapes use the existing `[redacted_secret]` marker:
+By default this produces the public-safe payload: every `result.json` and
+`config.json`, `manifest.json`, and `SHA256SUMS`, with no trajectory files. Use
+`--include-trajectories` only for a private diagnostic bundle:
+
+```bash
+uv run --project test/evals/harbor python -m stella_harbor.archive \
+  dist/evals/jobs/pi-luna-k5-rerun --include-trajectories --output \
+  /private/path/pi-luna-k5-diagnostic
+```
+
+With that explicit switch, the command adds a redacted `trajectory.json` only
+for non-pass or invalid trials; pass trajectories remain omitted. The source
+job, including its full unredacted trajectories, stays under `dist/` and must
+be retained securely outside the repository. It is the artifact for later
+failure attribution. A public archive is for score and evidence verification,
+not for publishing the model's solution path.
+
+Known trajectory credential shapes use the existing `[redacted_secret]` marker:
 private-key headers, `ghp_`/`github_pat_`/`sk-` tokens, secret assignments,
 credential-bearing URL userinfo, valid Bearer/Basic Authorization headers,
 JWTs, high-entropy mixed-case tokens, and the trial's bridge nonce. An
 unclassified credential-looking value excludes the entire trajectory, never a
 partially scrubbed copy.
 
-`manifest.json` records the redaction rules version, per-trial classification,
-trajectory status (`included`, `omitted`, `missing`, or `excluded`), exclusion
-reason and locations, redaction count, and source/output hashes. `SHA256SUMS`
-checks every archived payload file plus the manifest. The command refuses a
-non-empty output directory and refuses an output path inside the source job.
-Do not run it against the append-only `results/` directory as the source, and do
-not try to repair historical archives whose trajectories were never preserved.
+Every `result.json` and `config.json` is also scanned read-only before copying.
+The scan uses the stricter credential-shape checks, not the broad long-token
+path detector, so benchmark fixtures, agent-written regexes, and file paths do
+not abort an archive. A real credential-shaped hit aborts the archive and
+reports its file and JSON location; these payload files are never rewritten.
+
+`manifest.json` records whether trajectories were requested, the redaction rules
+version, per-trial classification, trajectory status (`disabled`, `included`,
+`omitted`, `missing`, or `excluded`), exclusion reason and locations,
+redaction count, and source/output hashes. `SHA256SUMS` checks every archived
+payload file plus the manifest. The command refuses a non-empty output directory
+and refuses an output path inside the source job. Do not run it against the
+append-only `results/` directory as the source, and do not try to repair
+historical archives whose trajectories were never preserved.
 
 ## Publishing a run
 

--- a/test/evals/harbor/README.md
+++ b/test/evals/harbor/README.md
@@ -216,6 +216,34 @@ above preserves the required 89-task dataset, `k=5`, concurrency `16`, agent
 timeout multiplier `1.0`, model `gateway/gpt-5.6-luna`, and dataset SHA-256.
 The endpoint and API credential are intentionally not stored in this repository.
 
+## Creating an evidence archive
+
+Archive a completed Harbor job without changing its gitignored source files:
+
+```bash
+uv run --project test/evals/harbor python -m stella_harbor.archive \
+  dist/evals/jobs/pi-luna-k5-rerun --output \
+  test/evals/harbor/results/terminal-bench-2.1/2026-08-21-pi-luna-k5
+```
+
+The output contains every `result.json` and `config.json`. It adds a redacted
+`trajectory.json` only for non-pass or invalid trials; pass trajectories are
+omitted. The source trajectory remains full, unredacted, and untouched under
+`dist/`. Known credential shapes use the existing `[redacted_secret]` marker:
+private-key headers, `ghp_`/`github_pat_`/`sk-` tokens, secret assignments,
+credential-bearing URL userinfo, valid Bearer/Basic Authorization headers,
+JWTs, high-entropy mixed-case tokens, and the trial's bridge nonce. An
+unclassified credential-looking value excludes the entire trajectory, never a
+partially scrubbed copy.
+
+`manifest.json` records the redaction rules version, per-trial classification,
+trajectory status (`included`, `omitted`, `missing`, or `excluded`), exclusion
+reason and locations, redaction count, and source/output hashes. `SHA256SUMS`
+checks every archived payload file plus the manifest. The command refuses a
+non-empty output directory and refuses an output path inside the source job.
+Do not run it against the append-only `results/` directory as the source, and do
+not try to repair historical archives whose trajectories were never preserved.
+
 ## Publishing a run
 
 `harbor upload <job>/<timestamp>` sends the whole trial directory to the Harbor

--- a/test/evals/harbor/stella_harbor/archive.py
+++ b/test/evals/harbor/stella_harbor/archive.py
@@ -1,0 +1,381 @@
+"""Create a reviewable, fail-closed Harbor evidence archive.
+
+Usage:
+    python -m stella_harbor.archive <job> --output <directory>
+
+The source job is never changed. Only result/config files and redacted
+trajectories for non-passing or invalid trials are copied.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import hashlib
+import json
+import re
+import shutil
+from pathlib import Path
+from typing import Any
+
+REDACTION_RULES_VERSION = "stella-reflect-secret-v1"
+REDACTION_PLACEHOLDER = "[redacted_secret]"
+
+_PRIVATE_KEY = re.compile(r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----", re.IGNORECASE)
+_TOKEN_PREFIX = re.compile(
+    r"\b(?:ghp_[a-z0-9_]{16,}|github_pat_[a-z0-9_]{16,}|sk-[a-z0-9_-]{16,})\b",
+    re.IGNORECASE,
+)
+_ASSIGNMENT = re.compile(
+    r"\b(?:password|passwd|secret|api[_-]?key|access[_-]?token|refresh[_-]?token)"
+    r"\b\s*[:=]\s*[\"']?[^\s\"']{8,}",
+    re.IGNORECASE,
+)
+_URL_USERINFO = re.compile(r"(\b[a-z][a-z0-9+.-]*://)[^\s/@]+@", re.IGNORECASE)
+_AUTHORIZATION = re.compile(
+    r"(\bauthorization\s*:\s*)(bearer|basic)(\s+)([^\s\"'<>]+)",
+    re.IGNORECASE,
+)
+_JWT = re.compile(
+    r"\beyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\b"
+)
+_LONG_TOKEN = re.compile(r"[A-Za-z0-9+/=_-]{48,}")
+_UNKNOWN_ASSIGNMENT = re.compile(
+    r"\b(password|passwd|secret|api[_-]?key|access[_-]?token|refresh[_-]?token|token)"
+    r"\b\s*[:=]\s*[\"']?([^\s\"']*)",
+    re.IGNORECASE,
+)
+
+_PLACEHOLDER_VALUES = {"", "none", "null", "unset", "<none>", "[redacted_secret]"}
+
+
+def _looks_high_entropy(token: str) -> bool:
+    if len(token) < 48:
+        return False
+    if not (
+        any(char.islower() for char in token)
+        and any(char.isupper() for char in token)
+        and any(char.isdigit() for char in token)
+    ):
+        return False
+    return len(set(token)) / len(token) > 0.35 and "..." not in token
+
+
+def _looks_like_basic_credential(token: str) -> bool:
+    for padding in ("", "=" * ((4 - len(token) % 4) % 4)):
+        try:
+            decoded = base64.b64decode(token + padding, validate=True)
+        except (ValueError, binascii.Error):
+            continue
+        if b":" in decoded:
+            return True
+    return False
+
+
+def _replace_known(text: str, nonce: str) -> tuple[str, int]:
+    sanitized = text
+    replacements = 0
+
+    if nonce:
+        sanitized, count = re.subn(re.escape(nonce), REDACTION_PLACEHOLDER, sanitized)
+        replacements += count
+
+    def replace(pattern: re.Pattern[str], replacement: str | None = None) -> None:
+        nonlocal sanitized, replacements
+        new, count = pattern.subn(replacement or REDACTION_PLACEHOLDER, sanitized)
+        sanitized = new
+        replacements += count
+
+    replace(_URL_USERINFO, r"\1" + REDACTION_PLACEHOLDER + "@")
+
+    def replace_authorization(match: re.Match[str]) -> str:
+        token = match.group(4)
+        if not re.fullmatch(r"[A-Za-z0-9\-._~+/]+={0,}", token):
+            return match.group(0)
+        if match.group(2).lower() == "basic" and not _looks_like_basic_credential(token):
+            return match.group(0)
+        return match.group(1) + match.group(2) + match.group(3) + REDACTION_PLACEHOLDER
+
+    def replace_authorization_counted(match: re.Match[str]) -> str:
+        nonlocal replacements
+        replacement = replace_authorization(match)
+        if replacement != match.group(0):
+            replacements += 1
+        return replacement
+
+    sanitized = _AUTHORIZATION.sub(replace_authorization_counted, sanitized)
+    replace(_JWT)
+    replace(_PRIVATE_KEY)
+    replace(_TOKEN_PREFIX)
+    replace(_ASSIGNMENT)
+
+    def replace_long_token(match: re.Match[str]) -> str:
+        nonlocal replacements
+        if not _looks_high_entropy(match.group(0)):
+            return match.group(0)
+        replacements += 1
+        return REDACTION_PLACEHOLDER
+
+    sanitized = _LONG_TOKEN.sub(replace_long_token, sanitized)
+    return sanitized, replacements
+
+
+def _unknown_credential_shapes(text: str) -> list[str]:
+    """Return locations of suspicious values not covered by known rules.
+
+    The existing Go policy intentionally has a minimum length for secret
+    assignments. Values shorter than that, malformed Authorization headers, and
+    generic ``token=...`` fields are kept out rather than partially sanitized.
+    """
+    unknown: list[str] = []
+    for match in _UNKNOWN_ASSIGNMENT.finditer(text):
+        key = match.group(1).lower()
+        value = match.group(2).strip()
+        if not value or value.lower() in _PLACEHOLDER_VALUES or value.isdigit():
+            continue
+        if key == "token":
+            _, known_replacements = _replace_known(value, "")
+            if known_replacements == 0:
+                unknown.append("credential-assignment")
+        elif len(value) < 8:
+            unknown.append("credential-assignment")
+
+    for match in _AUTHORIZATION.finditer(text):
+        token = match.group(4)
+        valid_token68 = re.fullmatch(r"[A-Za-z0-9\-._~+/]+={0,}", token)
+        if valid_token68 and (
+            match.group(2).lower() != "basic" or _looks_like_basic_credential(token)
+        ):
+            continue
+        if token.lower() not in _PLACEHOLDER_VALUES:
+            unknown.append("authorization-header")
+
+    return unknown
+
+
+def _redact_value(value: str, nonce: str, field: str = "") -> tuple[str, int, list[str]]:
+    unknown = _unknown_credential_shapes(value)
+    sanitized, replacements = _replace_known(value, nonce)
+    field_name = field.lower().replace("-", "_")
+    secret_field = re.fullmatch(
+        r"(?:password|passwd|secret|api_key|access_token|refresh_token)", field_name
+    )
+    if secret_field and value and value.lower() not in _PLACEHOLDER_VALUES:
+        if replacements == 0 and len(value) >= 8:
+            sanitized, replacements = REDACTION_PLACEHOLDER, 1
+        elif len(value) < 8 and not value.isdigit():
+            unknown.append("credential-field")
+    elif field_name == "token" and value and value.lower() not in _PLACEHOLDER_VALUES:
+        if replacements == 0 and not value.isdigit():
+            unknown.append("credential-field")
+    return sanitized, replacements, unknown
+
+
+def _redact_json(
+    value: Any, nonce: str, path: str = "$", field: str = ""
+) -> tuple[Any, int, list[str]]:
+    if isinstance(value, str):
+        sanitized, replacements, unknown = _redact_value(value, nonce, field)
+        return sanitized, replacements, [f"{path}:{reason}" for reason in unknown]
+    if isinstance(value, list):
+        output = []
+        replacements = 0
+        unknown: list[str] = []
+        for index, item in enumerate(value):
+            sanitized, count, reasons = _redact_json(item, nonce, f"{path}[{index}]")
+            output.append(sanitized)
+            replacements += count
+            unknown.extend(reasons)
+        return output, replacements, unknown
+    if isinstance(value, dict):
+        output: dict[str, Any] = {}
+        replacements = 0
+        unknown = []
+        for key, item in value.items():
+            sanitized, count, reasons = _redact_json(
+                item, nonce, f"{path}.{key}", str(key)
+            )
+            output[key] = sanitized
+            replacements += count
+            unknown.extend(reasons)
+        return output, replacements, unknown
+    return value, 0, []
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _read_json(path: Path) -> Any | None:
+    try:
+        return json.loads(path.read_text())
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return None
+
+
+def _trial_classification(trial_dir: Path, result: Any, adapter: Any | None) -> str:
+    if adapter is not None and (
+        adapter.get("valid") is False or adapter.get("predicate_violations")
+    ):
+        return "invalid"
+    if not isinstance(result, dict):
+        return "invalid"
+    rewards = (result.get("verifier_result") or {}).get("rewards") or {}
+    reward = rewards.get("reward")
+    try:
+        if float(reward) >= 1.0:
+            return "pass"
+    except (TypeError, ValueError):
+        pass
+    return "non-pass"
+
+
+def _copy_payload(source: Path, output: Path, relative: Path) -> Path:
+    target = output / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source, target)
+    return target
+
+
+def _trajectory_source(trial_dir: Path) -> Path | None:
+    for candidate in (trial_dir / "trajectory.json", trial_dir / "agent" / "stella" / "trajectory.json"):
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def build_archive(job: Path, output: Path) -> dict[str, Any]:
+    job = job.expanduser().resolve()
+    output = output.expanduser().resolve()
+    if not job.is_dir():
+        raise ValueError(f"job directory does not exist: {job}")
+    if output == job or output.is_relative_to(job):
+        raise ValueError("output directory must not be inside the source job")
+    if output.exists() and any(output.iterdir()):
+        raise ValueError(f"output directory is not empty: {output}")
+    output.mkdir(parents=True, exist_ok=True)
+
+    payload_paths: list[Path] = []
+    for source in sorted(job.rglob("*")):
+        if source.is_symlink():
+            continue
+        if source.is_file() and source.name in {"result.json", "config.json"}:
+            payload_paths.append(_copy_payload(source, output, source.relative_to(job)))
+
+    trials: list[dict[str, Any]] = []
+    for config_path in sorted(job.rglob("config.json")):
+        config = _read_json(config_path)
+        if not isinstance(config, dict) or not config.get("trial_name"):
+            continue
+        trial_dir = config_path.parent
+        result_path = trial_dir / "result.json"
+        result = _read_json(result_path)
+        adapter_path = trial_dir / "agent" / "stella" / "result.json"
+        adapter = _read_json(adapter_path) if adapter_path.is_file() else None
+        classification = _trial_classification(trial_dir, result, adapter)
+        trajectory = _trajectory_source(trial_dir)
+        record: dict[str, Any] = {
+            "trial": str(trial_dir.relative_to(job)),
+            "classification": classification,
+            "trajectory": {"status": "omitted", "reason": "pass"}
+            if classification == "pass"
+            else {"status": "missing", "reason": "trajectory file not found"},
+        }
+
+        if classification == "pass" and trajectory is not None:
+            record["trajectory"]["source_path"] = trajectory.relative_to(job).as_posix()
+
+        if classification != "pass" and trajectory is not None:
+            nonce = ""
+            if isinstance(adapter, dict):
+                nonce = str(adapter.get("bridge_nonce") or "")
+            try:
+                raw = json.loads(trajectory.read_text())
+            except (OSError, UnicodeError, json.JSONDecodeError):
+                record["trajectory"] = {
+                    "status": "excluded",
+                    "source_path": trajectory.relative_to(job).as_posix(),
+                    "source_sha256": _sha256(trajectory),
+                    "reason": "trajectory is not valid UTF-8 JSON",
+                }
+            else:
+                redacted, replacements, unknown = _redact_json(raw, nonce)
+                if unknown:
+                    record["trajectory"] = {
+                        "status": "excluded",
+                        "source_path": trajectory.relative_to(job).as_posix(),
+                        "source_sha256": _sha256(trajectory),
+                        "reason": "unclassified credential shape",
+                        "locations": sorted(set(unknown)),
+                    }
+                else:
+                    relative = trajectory.relative_to(job)
+                    target = output / relative
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    target.write_text(
+                        json.dumps(redacted, ensure_ascii=False, indent=2) + "\n"
+                    )
+                    payload_paths.append(target)
+                    record["trajectory"] = {
+                        "status": "included",
+                        "path": relative.as_posix(),
+                        "redactions": replacements,
+                        "source_sha256": _sha256(trajectory),
+                    }
+        trials.append(record)
+
+    files = [
+        {
+            "path": path.relative_to(output).as_posix(),
+            "sha256": _sha256(path),
+        }
+        for path in sorted(set(payload_paths))
+    ]
+    manifest: dict[str, Any] = {
+        "manifest_version": 1,
+        "source_job": job.name,
+        "redaction_rules_version": REDACTION_RULES_VERSION,
+        "redaction_placeholder": REDACTION_PLACEHOLDER,
+        "policy": {
+            "include": ["result.json", "config.json"],
+            "trajectory": "non-pass and invalid trials only",
+            "fail_closed": "exclude the whole trajectory on an unclassified credential shape",
+        },
+        "trials": trials,
+        "files": files,
+    }
+    manifest_path = output / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n")
+
+    checksums = [f"{entry['sha256']}  {entry['path']}" for entry in files]
+    checksums.append(f"{_sha256(manifest_path)}  manifest.json")
+    (output / "SHA256SUMS").write_text("\n".join(checksums) + "\n")
+    return manifest
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("job", type=Path, help="Harbor job directory to archive")
+    parser.add_argument("--output", required=True, type=Path, help="new archive directory")
+    args = parser.parse_args(argv)
+    manifest = build_archive(args.job, args.output)
+    included = sum(
+        trial["trajectory"]["status"] == "included" for trial in manifest["trials"]
+    )
+    excluded = sum(
+        trial["trajectory"]["status"] == "excluded" for trial in manifest["trials"]
+    )
+    print(
+        f"archived {len(manifest['files'])} payload file(s), "
+        f"{included} trajectory/trajectories included, {excluded} excluded"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/evals/harbor/stella_harbor/archive.py
+++ b/test/evals/harbor/stella_harbor/archive.py
@@ -48,6 +48,9 @@ _UNKNOWN_ASSIGNMENT = re.compile(
 )
 
 _PLACEHOLDER_VALUES = {"", "none", "null", "unset", "<none>", "[redacted_secret]"}
+_SECRET_FIELDS = re.compile(
+    r"(?:password|passwd|secret|api_key|access_token|refresh_token)", re.IGNORECASE
+)
 
 
 def _looks_high_entropy(token: str) -> bool:
@@ -73,6 +76,23 @@ def _looks_like_basic_credential(token: str) -> bool:
     return False
 
 
+def _is_obvious_fixture(value: str) -> bool:
+    """Ignore regex templates and the ordered synthetic token used by the benchmark."""
+    lowered = value.lower()
+    return (
+        any(marker in value for marker in ("[", "]", "{", "}", "\\"))
+        or "abcdefghijklmnopqrstuvwxyz" in lowered
+        or "0123456789" in lowered
+    )
+
+
+def _is_valid_authorization(match: re.Match[str]) -> bool:
+    token = match.group(4)
+    if not re.fullmatch(r"[A-Za-z0-9\-._~+/]+={0,}", token):
+        return False
+    return match.group(2).lower() != "basic" or _looks_like_basic_credential(token)
+
+
 def _replace_known(text: str, nonce: str) -> tuple[str, int]:
     sanitized = text
     replacements = 0
@@ -90,10 +110,7 @@ def _replace_known(text: str, nonce: str) -> tuple[str, int]:
     replace(_URL_USERINFO, r"\1" + REDACTION_PLACEHOLDER + "@")
 
     def replace_authorization(match: re.Match[str]) -> str:
-        token = match.group(4)
-        if not re.fullmatch(r"[A-Za-z0-9\-._~+/]+={0,}", token):
-            return match.group(0)
-        if match.group(2).lower() == "basic" and not _looks_like_basic_credential(token):
+        if not _is_valid_authorization(match):
             return match.group(0)
         return match.group(1) + match.group(2) + match.group(3) + REDACTION_PLACEHOLDER
 
@@ -143,15 +160,60 @@ def _unknown_credential_shapes(text: str) -> list[str]:
 
     for match in _AUTHORIZATION.finditer(text):
         token = match.group(4)
-        valid_token68 = re.fullmatch(r"[A-Za-z0-9\-._~+/]+={0,}", token)
-        if valid_token68 and (
-            match.group(2).lower() != "basic" or _looks_like_basic_credential(token)
-        ):
+        if _is_valid_authorization(match):
             continue
         if token.lower() not in _PLACEHOLDER_VALUES:
             unknown.append("authorization-header")
 
     return unknown
+
+
+def _scan_credential_shapes(text: str, field: str = "") -> list[str]:
+    """Find actionable credential shapes without using the broad long-token rule."""
+    findings = list(_unknown_credential_shapes(text))
+    field_name = field.lower().replace("-", "_")
+    if field_name == "bridge_nonce":
+        return findings
+
+    if _SECRET_FIELDS.fullmatch(field_name) and text and text.lower() not in _PLACEHOLDER_VALUES:
+        if not _is_obvious_fixture(text):
+            findings.append("credential-field")
+
+    for pattern, label in (
+        (_ASSIGNMENT, "credential-assignment"),
+        (_URL_USERINFO, "url-userinfo"),
+        (_JWT, "jwt"),
+        (_PRIVATE_KEY, "private-key"),
+    ):
+        for match in pattern.finditer(text):
+            if not _is_obvious_fixture(match.group(0)):
+                findings.append(label)
+
+    for match in _AUTHORIZATION.finditer(text):
+        if _is_valid_authorization(match) and not _is_obvious_fixture(match.group(0)):
+            findings.append("authorization-header")
+
+    for match in _TOKEN_PREFIX.finditer(text):
+        if not _is_obvious_fixture(match.group(0)):
+            findings.append("token-prefix")
+
+    return findings
+
+
+def _scan_json(value: Any, path: str = "$", field: str = "") -> list[str]:
+    if isinstance(value, str):
+        return [f"{path}:{reason}" for reason in _scan_credential_shapes(value, field)]
+    if isinstance(value, list):
+        findings: list[str] = []
+        for index, item in enumerate(value):
+            findings.extend(_scan_json(item, f"{path}[{index}]"))
+        return findings
+    if isinstance(value, dict):
+        findings = []
+        for key, item in value.items():
+            findings.extend(_scan_json(item, f"{path}.{key}", str(key)))
+        return findings
+    return []
 
 
 def _redact_value(value: str, nonce: str, field: str = "") -> tuple[str, int, list[str]]:
@@ -242,6 +304,29 @@ def _copy_payload(source: Path, output: Path, relative: Path) -> Path:
     return target
 
 
+def _payload_files(job: Path) -> list[Path]:
+    return [
+        source
+        for source in sorted(job.rglob("*"))
+        if not source.is_symlink() and source.is_file() and source.name in {"result.json", "config.json"}
+    ]
+
+
+def _inspect_payloads(payloads: list[Path]) -> None:
+    findings: list[str] = []
+    for source in payloads:
+        try:
+            value = json.loads(source.read_text())
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise ValueError(f"cannot inspect {source}: invalid JSON ({exc})") from exc
+        findings.extend(
+            f"{source}: {finding}" for finding in _scan_json(value)
+        )
+    if findings:
+        details = "; ".join(sorted(set(findings)))
+        raise ValueError(f"refusing archive; credential-shaped payload content: {details}")
+
+
 def _trajectory_source(trial_dir: Path) -> Path | None:
     for candidate in (trial_dir / "trajectory.json", trial_dir / "agent" / "stella" / "trajectory.json"):
         if candidate.is_file():
@@ -249,7 +334,9 @@ def _trajectory_source(trial_dir: Path) -> Path | None:
     return None
 
 
-def build_archive(job: Path, output: Path) -> dict[str, Any]:
+def build_archive(
+    job: Path, output: Path, *, include_trajectories: bool = False
+) -> dict[str, Any]:
     job = job.expanduser().resolve()
     output = output.expanduser().resolve()
     if not job.is_dir():
@@ -258,14 +345,15 @@ def build_archive(job: Path, output: Path) -> dict[str, Any]:
         raise ValueError("output directory must not be inside the source job")
     if output.exists() and any(output.iterdir()):
         raise ValueError(f"output directory is not empty: {output}")
+
+    payload_sources = _payload_files(job)
+    _inspect_payloads(payload_sources)
     output.mkdir(parents=True, exist_ok=True)
 
-    payload_paths: list[Path] = []
-    for source in sorted(job.rglob("*")):
-        if source.is_symlink():
-            continue
-        if source.is_file() and source.name in {"result.json", "config.json"}:
-            payload_paths.append(_copy_payload(source, output, source.relative_to(job)))
+    payload_paths = [
+        _copy_payload(source, output, source.relative_to(job))
+        for source in payload_sources
+    ]
 
     trials: list[dict[str, Any]] = []
     for config_path in sorted(job.rglob("config.json")):
@@ -278,19 +366,26 @@ def build_archive(job: Path, output: Path) -> dict[str, Any]:
         adapter_path = trial_dir / "agent" / "stella" / "result.json"
         adapter = _read_json(adapter_path) if adapter_path.is_file() else None
         classification = _trial_classification(trial_dir, result, adapter)
-        trajectory = _trajectory_source(trial_dir)
+        trajectory = _trajectory_source(trial_dir) if include_trajectories else None
+        if not include_trajectories:
+            trajectory_status = {
+                "status": "disabled",
+                "reason": "trajectory inclusion not requested",
+            }
+        elif classification == "pass":
+            trajectory_status = {"status": "omitted", "reason": "pass"}
+        else:
+            trajectory_status = {"status": "missing", "reason": "trajectory file not found"}
         record: dict[str, Any] = {
             "trial": str(trial_dir.relative_to(job)),
             "classification": classification,
-            "trajectory": {"status": "omitted", "reason": "pass"}
-            if classification == "pass"
-            else {"status": "missing", "reason": "trajectory file not found"},
+            "trajectory": trajectory_status,
         }
 
-        if classification == "pass" and trajectory is not None:
+        if include_trajectories and classification == "pass" and trajectory is not None:
             record["trajectory"]["source_path"] = trajectory.relative_to(job).as_posix()
 
-        if classification != "pass" and trajectory is not None:
+        if include_trajectories and classification != "pass" and trajectory is not None:
             nonce = ""
             if isinstance(adapter, dict):
                 nonce = str(adapter.get("bridge_nonce") or "")
@@ -341,10 +436,16 @@ def build_archive(job: Path, output: Path) -> dict[str, Any]:
         "source_job": job.name,
         "redaction_rules_version": REDACTION_RULES_VERSION,
         "redaction_placeholder": REDACTION_PLACEHOLDER,
+        "include_trajectories": include_trajectories,
         "policy": {
             "include": ["result.json", "config.json"],
-            "trajectory": "non-pass and invalid trials only",
+            "trajectory": (
+                "redacted non-pass and invalid trials only"
+                if include_trajectories
+                else "disabled unless --include-trajectories is requested"
+            ),
             "fail_closed": "exclude the whole trajectory on an unclassified credential shape",
+            "payload_scan": "read-only credential-shape check; abort on a finding",
         },
         "trials": trials,
         "files": files,
@@ -362,8 +463,18 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("job", type=Path, help="Harbor job directory to archive")
     parser.add_argument("--output", required=True, type=Path, help="new archive directory")
+    parser.add_argument(
+        "--include-trajectories",
+        action="store_true",
+        help="include redacted trajectories for non-pass and invalid trials",
+    )
     args = parser.parse_args(argv)
-    manifest = build_archive(args.job, args.output)
+    try:
+        manifest = build_archive(
+            args.job, args.output, include_trajectories=args.include_trajectories
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
     included = sum(
         trial["trajectory"]["status"] == "included" for trial in manifest["trials"]
     )

--- a/test/evals/harbor/stella_harbor/pi_gateway.py
+++ b/test/evals/harbor/stella_harbor/pi_gateway.py
@@ -17,6 +17,7 @@ from typing import override
 
 from harbor.agents.installed.pi import Pi
 from harbor.environments.base import BaseEnvironment
+from harbor.models.agent.context import AgentContext
 
 PROVIDER = "gateway"
 
@@ -28,6 +29,36 @@ _MODEL_DEFAULTS = {
     "maxTokens": 128000,
     "cost": {"input": 1.25, "output": 10.0, "cacheRead": 0.125, "cacheWrite": 0.0},
 }
+
+
+def _decode_output(data: bytes) -> tuple[str, int, bool]:
+    """Decode Pi's JSONL output without hiding malformed UTF-8.
+
+    A strict pass identifies whether the file is damaged. The recovery pass is
+    deliberately limited to the text used for usage parsing; the original file
+    remains in Harbor's logs, and the diagnostics are copied into agent_result.
+    """
+    try:
+        return data.decode("utf-8"), 0, False
+    except UnicodeDecodeError:
+        text = data.decode("utf-8", errors="replace")
+
+    errors = 0
+    truncated = False
+    offset = 0
+    while offset < len(data):
+        try:
+            data[offset:].decode("utf-8")
+            break
+        except UnicodeDecodeError as exc:
+            errors += 1
+            truncated = truncated or (
+                exc.reason == "unexpected end of data"
+                and offset + exc.end == len(data)
+            )
+            offset += max(exc.end, exc.start + 1)
+
+    return text, errors, truncated
 
 
 class PiGateway(Pi):
@@ -78,3 +109,59 @@ class PiGateway(Pi):
                 "chmod 600 $HOME/.pi/agent/models.json"
             ),
         )
+
+    @override
+    def populate_context_post_run(self, context: AgentContext) -> None:
+        """Parse Pi usage while keeping truncated output visible.
+
+        Harbor 0.21's Pi implementation uses ``Path.read_text()`` here, so a
+        partial UTF-8 sequence raises before the trial result is written. This
+        adapter owns the workaround until Harbor ships the equivalent fix.
+        """
+        output_file = self.logs_dir / self._OUTPUT_FILENAME
+        if not output_file.exists():
+            return
+
+        raw_output = output_file.read_bytes()
+        output, decode_errors, truncated = _decode_output(raw_output)
+        if decode_errors:
+            self.logger.warning(
+                "Pi output %s had %d UTF-8 decode error(s)%s; usage parsing recovered",
+                output_file,
+                decode_errors,
+                " at EOF (likely truncated)" if truncated else "",
+            )
+            context.metadata = context.metadata or {}
+            context.metadata["pi_output_decode"] = {
+                "utf8_decode_errors": decode_errors,
+                "truncated_utf8": truncated,
+                "output_bytes": len(raw_output),
+            }
+
+        total_input_tokens = 0
+        total_output_tokens = 0
+        total_cache_read_tokens = 0
+        total_cost = 0.0
+
+        for line in output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+                if event.get("type") == "message_end":
+                    message = event.get("message") or {}
+                    if message.get("role") == "assistant":
+                        usage = message.get("usage") or {}
+                        total_input_tokens += usage.get("input", 0)
+                        total_output_tokens += usage.get("output", 0)
+                        total_cache_read_tokens += usage.get("cacheRead", 0)
+                        cost = usage.get("cost") or {}
+                        total_cost += cost.get("total", 0.0)
+            except (json.JSONDecodeError, AttributeError, TypeError):
+                continue
+
+        context.n_input_tokens = total_input_tokens + total_cache_read_tokens
+        context.n_output_tokens = total_output_tokens
+        context.n_cache_tokens = total_cache_read_tokens
+        context.cost_usd = total_cost if total_cost > 0 else None

--- a/test/evals/harbor/tests/test_archive.py
+++ b/test/evals/harbor/tests/test_archive.py
@@ -1,0 +1,155 @@
+import hashlib
+import json
+from pathlib import Path
+
+from stella_harbor.archive import build_archive
+
+
+NONCE = "0123456789abcdef0123456789abcdef"
+
+
+def _write_trial(job: Path, name: str, *, reward, valid=True, trajectory=None):
+    trial = job / "2026-08-20__00-00-00" / f"{name}__abc"
+    (trial / "agent" / "stella").mkdir(parents=True)
+    (trial / "config.json").write_text(
+        json.dumps({"trial_name": f"{name}__abc", "agent": {"name": "stella"}})
+    )
+    (trial / "result.json").write_text(
+        json.dumps({"verifier_result": {"rewards": {"reward": reward}}})
+    )
+    (trial / "agent" / "stella" / "result.json").write_text(
+        json.dumps({"valid": valid, "bridge_nonce": NONCE})
+    )
+    if trajectory is not None:
+        (trial / "trajectory.json").write_text(json.dumps(trajectory, ensure_ascii=False))
+    return trial
+
+
+def _manifest(output):
+    return json.loads((output / "manifest.json").read_text())
+
+
+def _trial(manifest, name):
+    return next(item for item in manifest["trials"] if name in item["trial"])
+
+
+def test_archive_keeps_results_and_configs_and_omits_pass_trajectory(tmp_path):
+    job = tmp_path / "job"
+    pass_trajectory = {"messages": [{"role": "assistant", "text": "passed"}]}
+    fail_trajectory = {"messages": [{"role": "assistant", "text": "ordinary output"}]}
+    _write_trial(job, "pass", reward=1.0, trajectory=pass_trajectory)
+    _write_trial(job, "fail", reward=0.0, trajectory=fail_trajectory)
+    _write_trial(
+        job,
+        "invalid",
+        reward=1.0,
+        valid=False,
+        trajectory={"messages": [{"text": "invalid evidence"}]},
+    )
+    output = tmp_path / "archive"
+
+    manifest = build_archive(job, output)
+
+    assert _trial(manifest, "pass")["trajectory"]["status"] == "omitted"
+    assert _trial(manifest, "pass")["trajectory"]["reason"] == "pass"
+    assert _trial(manifest, "pass")["trajectory"]["source_path"].endswith(
+        "pass__abc/trajectory.json"
+    )
+    included = _trial(manifest, "fail")["trajectory"]
+    assert included["status"] == "included"
+    assert (output / included["path"]).exists()
+    assert not list(output.glob("**/pass__*/trajectory.json"))
+    assert (output / "2026-08-20__00-00-00/pass__abc/result.json").exists()
+    assert (output / "2026-08-20__00-00-00/pass__abc/config.json").exists()
+    assert (output / "2026-08-20__00-00-00/pass__abc/agent/stella/result.json").exists()
+    assert _trial(manifest, "invalid")["classification"] == "invalid"
+    assert _trial(manifest, "invalid")["trajectory"]["status"] == "included"
+
+    for entry in manifest["files"]:
+        path = output / entry["path"]
+        assert hashlib.sha256(path.read_bytes()).hexdigest() == entry["sha256"]
+    assert "manifest.json" in (output / "SHA256SUMS").read_text()
+
+
+def test_archive_redacts_known_credential_shapes_and_bridge_nonce(tmp_path):
+    job = tmp_path / "job"
+    high_entropy = "Aa1Bb2Cc3Dd4Ee5Ff6Gg7Hh8Ii9Jj0Kk1Ll2Mm3Nn4Oo5Pp6"
+    trajectory = {
+        "messages": [
+            {
+                "text": (
+                    "password=supersecretvalue "
+                    "ghp_abcdefghijklmnopqrstuvwxyz123456 "
+                    "github_pat_abcdefghijklmnopqrstuvwxyz123456 "
+                    "sk-abcdefghijklmnopqrstuvwxyz123456 "
+                    "postgres://user:correct-horse-battery-staple@db.example/app "
+                    "Authorization: Bearer bearer-token-123456 "
+                    "Authorization: Basic dXNlcjpwYXNz "
+                    "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.signature123 "
+                    "-----BEGIN RSA PRIVATE KEY----- "
+                    f"{high_entropy} {NONCE}"
+                )
+            }
+        ]
+    }
+    trial = _write_trial(job, "known-secrets", reward=0.0, trajectory=trajectory)
+    original = (trial / "trajectory.json").read_bytes()
+    output = tmp_path / "archive"
+
+    manifest = build_archive(job, output)
+
+    record = _trial(manifest, "known-secrets")["trajectory"]
+    assert record["status"] == "included"
+    assert (trial / "trajectory.json").read_bytes() == original
+    redacted = json.loads((output / record["path"]).read_text())
+    text = redacted["messages"][0]["text"]
+    for secret in [
+        "supersecretvalue",
+        "ghp_abcdefghijklmnopqrstuvwxyz123456",
+        "github_pat_abcdefghijklmnopqrstuvwxyz123456",
+        "sk-abcdefghijklmnopqrstuvwxyz123456",
+        "correct-horse-battery-staple",
+        "bearer-token-123456",
+        "dXNlcjpwYXNz",
+        "eyJhbGciOiJIUzI1NiJ9",
+        "-----BEGIN RSA PRIVATE KEY-----",
+        high_entropy,
+        NONCE,
+    ]:
+        assert secret not in text
+    assert text.count("[redacted_secret]") >= 11
+
+
+def test_archive_does_not_mistake_normal_content_for_a_credential(tmp_path):
+    job = tmp_path / "job"
+    trajectory = {
+        "messages": [
+            {
+                "text": "The API key is rotated monthly; token_count: 12; no secret is shown."
+            }
+        ]
+    }
+    _write_trial(job, "normal", reward=0.0, trajectory=trajectory)
+    output = tmp_path / "archive"
+
+    manifest = build_archive(job, output)
+
+    record = _trial(manifest, "normal")["trajectory"]
+    assert record["status"] == "included"
+    assert json.loads((output / record["path"]).read_text()) == trajectory
+    assert record["redactions"] == 0
+
+
+def test_archive_excludes_unknown_credential_shape_fail_closed(tmp_path):
+    job = tmp_path / "job"
+    trajectory = {"messages": [{"tool_result": {"token": "mystery-token"}}]}
+    _write_trial(job, "unknown", reward=0.0, trajectory=trajectory)
+    output = tmp_path / "archive"
+
+    manifest = build_archive(job, output)
+
+    record = _trial(manifest, "unknown")["trajectory"]
+    assert record["status"] == "excluded"
+    assert record["reason"] == "unclassified credential shape"
+    assert record["locations"] == ["$.messages[0].tool_result.token:credential-field"]
+    assert not list(output.glob("**/unknown__*/trajectory.json"))

--- a/test/evals/harbor/tests/test_archive.py
+++ b/test/evals/harbor/tests/test_archive.py
@@ -2,6 +2,8 @@ import hashlib
 import json
 from pathlib import Path
 
+import pytest
+
 from stella_harbor.archive import build_archive
 
 
@@ -33,6 +35,27 @@ def _trial(manifest, name):
     return next(item for item in manifest["trials"] if name in item["trial"])
 
 
+def test_archive_defaults_to_public_payload_without_trajectories(tmp_path):
+    job = tmp_path / "job"
+    _write_trial(
+        job,
+        "fail",
+        reward=0.0,
+        trajectory={"messages": [{"text": "private failure context"}]},
+    )
+    output = tmp_path / "archive"
+
+    manifest = build_archive(job, output)
+
+    assert manifest["include_trajectories"] is False
+    assert _trial(manifest, "fail")["trajectory"] == {
+        "status": "disabled",
+        "reason": "trajectory inclusion not requested",
+    }
+    assert not list(output.glob("**/trajectory.json"))
+    assert all(Path(entry["path"]).name != "trajectory.json" for entry in manifest["files"])
+
+
 def test_archive_keeps_results_and_configs_and_omits_pass_trajectory(tmp_path):
     job = tmp_path / "job"
     pass_trajectory = {"messages": [{"role": "assistant", "text": "passed"}]}
@@ -48,7 +71,7 @@ def test_archive_keeps_results_and_configs_and_omits_pass_trajectory(tmp_path):
     )
     output = tmp_path / "archive"
 
-    manifest = build_archive(job, output)
+    manifest = build_archive(job, output, include_trajectories=True)
 
     assert _trial(manifest, "pass")["trajectory"]["status"] == "omitted"
     assert _trial(manifest, "pass")["trajectory"]["reason"] == "pass"
@@ -96,7 +119,7 @@ def test_archive_redacts_known_credential_shapes_and_bridge_nonce(tmp_path):
     original = (trial / "trajectory.json").read_bytes()
     output = tmp_path / "archive"
 
-    manifest = build_archive(job, output)
+    manifest = build_archive(job, output, include_trajectories=True)
 
     record = _trial(manifest, "known-secrets")["trajectory"]
     assert record["status"] == "included"
@@ -132,7 +155,7 @@ def test_archive_does_not_mistake_normal_content_for_a_credential(tmp_path):
     _write_trial(job, "normal", reward=0.0, trajectory=trajectory)
     output = tmp_path / "archive"
 
-    manifest = build_archive(job, output)
+    manifest = build_archive(job, output, include_trajectories=True)
 
     record = _trial(manifest, "normal")["trajectory"]
     assert record["status"] == "included"
@@ -146,10 +169,46 @@ def test_archive_excludes_unknown_credential_shape_fail_closed(tmp_path):
     _write_trial(job, "unknown", reward=0.0, trajectory=trajectory)
     output = tmp_path / "archive"
 
-    manifest = build_archive(job, output)
+    manifest = build_archive(job, output, include_trajectories=True)
 
     record = _trial(manifest, "unknown")["trajectory"]
     assert record["status"] == "excluded"
     assert record["reason"] == "unclassified credential shape"
     assert record["locations"] == ["$.messages[0].tool_result.token:credential-field"]
     assert not list(output.glob("**/unknown__*/trajectory.json"))
+
+
+def test_payload_scan_ignores_benchmark_fixtures_and_paths(tmp_path):
+    job = tmp_path / "job"
+    trial = _write_trial(job, "fixtures", reward=0.0)
+    (trial / "result.json").write_text(
+        json.dumps(
+            {
+                "bridge_ledger": [
+                    {"command": "PASSWORD=[A-Z0-9]{23}"},
+                    {"command": "https://[^[:space:]]+@"},
+                    {"path": "/tmp/Aa1Bb2Cc3Dd4Ee5Ff6Gg7Hh8Ii9Jj0Kk1Ll2Mm3Nn4Oo5Pp6"},
+                    {"token": "ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"},
+                ]
+            }
+        )
+    )
+    output = tmp_path / "archive"
+
+    manifest = build_archive(job, output)
+
+    assert manifest["include_trajectories"] is False
+
+
+def test_payload_scan_aborts_without_writing_output_on_real_credential(tmp_path):
+    job = tmp_path / "job"
+    trial = _write_trial(job, "leak", reward=0.0)
+    (trial / "result.json").write_text(
+        json.dumps({"agent_result": {"metadata": {"api_key": "real-secret-value"}}})
+    )
+    output = tmp_path / "archive"
+
+    with pytest.raises(ValueError, match="credential-shaped payload content"):
+        build_archive(job, output)
+
+    assert not output.exists()

--- a/test/evals/harbor/tests/test_pi_gateway.py
+++ b/test/evals/harbor/tests/test_pi_gateway.py
@@ -1,0 +1,71 @@
+import json
+
+from harbor.models.agent.context import AgentContext
+
+from stella_harbor.pi_gateway import PiGateway
+
+
+def _agent(tmp_path):
+    return PiGateway(logs_dir=tmp_path, model_name="gateway/gpt-5.6-luna")
+
+
+def _event(*, input_tokens=11, output_tokens=7, cache_read=3, cost=0.25):
+    return {
+        "type": "message_end",
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "你好"}],
+            "usage": {
+                "input": input_tokens,
+                "output": output_tokens,
+                "cacheRead": cache_read,
+                "cacheWrite": 2,
+                "cost": {"total": cost},
+            },
+        },
+    }
+
+
+def test_pi_output_usage_parses_normal_utf8(tmp_path):
+    (tmp_path / "pi.txt").write_text(json.dumps(_event(), ensure_ascii=False) + "\n")
+    context = AgentContext()
+
+    _agent(tmp_path).populate_context_post_run(context)
+
+    assert context.n_input_tokens == 14
+    assert context.n_output_tokens == 7
+    assert context.n_cache_tokens == 3
+    assert context.cost_usd == 0.25
+    assert context.metadata is None
+
+
+def test_pi_output_recovers_truncated_utf8_and_records_it(tmp_path):
+    complete = json.dumps(_event(input_tokens=5), ensure_ascii=False).encode("utf-8")
+    truncated = b'{"type":"message_end","message":{"role":"assistant","content":"' + "中".encode("utf-8")[:-1]
+    (tmp_path / "pi.txt").write_bytes(complete + b"\n" + truncated)
+    context = AgentContext()
+
+    _agent(tmp_path).populate_context_post_run(context)
+
+    assert context.n_input_tokens == 8
+    assert context.n_output_tokens == 7
+    assert context.metadata == {
+        "pi_output_decode": {
+            "utf8_decode_errors": 1,
+            "truncated_utf8": True,
+            "output_bytes": len(complete) + 1 + len(truncated),
+        }
+    }
+
+
+def test_pi_output_usage_handles_empty_output(tmp_path):
+    (tmp_path / "pi.txt").write_bytes(b"")
+    context = AgentContext()
+
+    _agent(tmp_path).populate_context_post_run(context)
+
+    assert context.n_input_tokens == 0
+    assert context.n_output_tokens == 0
+    assert context.n_cache_tokens == 0
+    assert context.cost_usd is None
+    assert context.metadata is None


### PR DESCRIPTION
## What

Make the Terminal-Bench control run both survivable and attributable:

- Harden the Harbor Pi gateway adapter against truncated UTF-8 in `pi.txt`.
- Add a deterministic, public-safe evidence archive with an explicit private trajectory mode.

## Why

Harbor 0.21.0's installed Pi adapter used strict `Path.read_text()` while syncing usage. A partial final UTF-8 sequence aborted the 2026-08-20 Pi control job after 320 completed, 28 errored, and 125 pending trials, leaving no complete `pass^5` baseline.

The driver has always written complete, mode-0600 trajectories. The archived Luna bundle omitted them because the bundle was assembled by hand, so 48 suspicious tasks could not be distinguished between Stella context loss and model decisions three weeks later. That is the evidence gap encountered by #1057. The original exclusion rationale, synthetic secrets in Terminal-Bench, was valid; the retention policy was not executable.

Publishing full solution trajectories is also irreversible. A bundle can be withheld and later published, but a public trajectory cannot be recalled, and it can contaminate future Terminal-Bench runs by giving agents solution paths. Public verification needs `result.json` verifier rewards, evidence verdicts, bridge ledgers, nonce matching, and predicate violations, not the model's private reasoning path.

## How

- `PiGateway.populate_context_post_run` does a strict UTF-8 pass, recovers only the usage parser with replacement decoding, and records decode count, EOF truncation, and byte count in `agent_result.metadata.pi_output_decode`. The original log bytes remain available in the source job.
- `python -m stella_harbor.archive <job> --output <dir>` now defaults to `result.json`, `config.json`, `manifest.json`, and `SHA256SUMS`, with no trajectories. `--include-trajectories` explicitly opts into a private diagnostic bundle containing redacted trajectories only for non-pass and invalid trials; pass trajectories remain omitted.
- The source job, including full unredacted trajectories, is never changed and must be retained securely outside the repository for later failure attribution.
- Trajectory redaction follows the existing `internal/reflect` credential policy: private-key headers, `ghp_`/`github_pat_`/`sk-` tokens, secret assignments, credential-bearing URL userinfo, valid Bearer/Basic Authorization headers, JWTs, high-entropy mixed-case tokens, plus the trial bridge nonce. Replacements use the visible `[redacted_secret]` marker.
- Redaction is fail-closed. Any credential-looking shape not covered by those rules excludes the whole trajectory and records the source path, hash, reason, and locations in `manifest.json`.
- Every result/config file is scanned read-only before copying. The scan uses the stricter credential-shape checks and ignores broad long-token matches, so file paths, agent-written regexes, and the benchmark's ordered fake token do not abort a run. A real credential-shaped hit aborts the archive with its file and JSON location; result/config files are never rewritten.
- The manifest records whether trajectories were requested, per-trial status, redaction counts, and source/output SHA-256 values; `SHA256SUMS` covers the payload and manifest. No dependencies were added.

## Test

- `mise run format`
- `mise run build`
- `mise run test`
- `uv run --project test/evals/harbor pytest test/evals/harbor/tests -q` — 55 passed, including default trajectory exclusion, explicit private inclusion, credential redaction, source preservation, checksum records, payload scan false-positive fixtures, and fail-closed payload/trajectory credentials
- Smoke-archived the preserved partial 2026-08-20 bundle in a temporary directory with the default public mode: payload scan passed, 642 payload files and 320 trial records were indexed, and zero trajectory files were produced.

Not run: the full 89-task × k=5 control run. It still requires the archived endpoint/key and a `c7i.8xlarge`-class host.

## Refs

Closes #1097

Related: #1057, evidence retention and failure-attribution gap

## Feishu Task

- [Pi × Terminal-Bench 完整对照基线](https://mcnnox2fhjfq.feishu.cn/record/HoY0rCWNKeTLT9cv8Hzckjgcneh) (#1097)