### PR TITLE
✨ feat(eval): enforce run fingerprint matching before comparison

### DIFF
--- a/cmd/stella-eval-agent/main.go
+++ b/cmd/stella-eval-agent/main.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -44,6 +45,8 @@ type binding struct {
 type result struct {
 	SessionID               string         `json:"session_id,omitempty"`
 	AgentID                 string         `json:"agent_id,omitempty"`
+	Model                   string         `json:"model,omitempty"`
+	CandidateCommit         string         `json:"candidate_commit,omitempty"`
 	UserID                  string         `json:"user_id,omitempty"`
 	TurnTerminalState       string         `json:"turn_terminal_state,omitempty"`
 	ToolCalls               map[string]int `json:"tool_calls"`
@@ -377,6 +380,14 @@ func collectUsage(ctx context.Context, c apiClient, agentID, sessionID string) (
 	}
 }
 
+func gitRevParseHead() string {
+	out, err := exec.Command("git", "rev-parse", "HEAD").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
 func run() int {
 	var baseURL, instructionFile, bindingFile, bindingDir, model, output, externalID, bundleDigest, trajectory string
 	var deadlineSec int
@@ -393,7 +404,11 @@ func run() int {
 	flag.IntVar(&deadlineSec, "deadline-seconds", 0, "working time in seconds, excluding the stop confirmation that follows it")
 	flag.IntVar(&stopConfirmSec, "stop-confirm-seconds", 0, "seconds allowed to confirm the session stopped after the deadline; must fit inside the caller's trial limit")
 	flag.Parse()
-	r := result{ToolCalls: map[string]int{}}
+	r := result{
+		ToolCalls:       map[string]int{},
+		Model:           model,
+		CandidateCommit: gitRevParseHead(),
+	}
 	start := time.Now()
 	// Phase boundaries are measured here rather than inferred from the message
 	// timeline: a reviewer needs to see whether a slow trial was the model, a

--- a/cmd/stella-eval-agent/main_test.go
+++ b/cmd/stella-eval-agent/main_test.go
@@ -104,6 +104,9 @@ func TestRunRefusesAnInstanceThatExposesMCPTools(t *testing.T) {
 	if len(got.MCPTools) != 1 || got.MCPTools[0] != "remote_search" || got.SessionID != "" {
 		t.Fatalf("result must name the MCP tool and start no session: %+v", got)
 	}
+	if got.Model != "p/m" || got.CandidateCommit == "" {
+		t.Fatalf("result must persist model and candidate commit: %+v", got)
+	}
 }
 
 // The trajectory is what a failure taxonomy and a public run log are built

--- a/test/evals/harbor/README.md
+++ b/test/evals/harbor/README.md
@@ -153,6 +153,20 @@ uv run --project test/evals/harbor python -m stella_harbor.compare \
   dist/evals/jobs/sample dist/evals/jobs/pi-sample --names stella pi
 ```
 
+Before reading any score, the comparison derives and checks a run fingerprint
+from the Harbor artifacts. It includes dataset id and hash, attempt budget,
+concurrency, timeout multiplier, model, tool strategy, capability profile
+digest, and candidate commit. Candidate commit is intentionally ignored when
+checking compatibility, because a candidate is normally what the comparison is
+measuring. All other fields must match. The tool strategy falls back to the
+persisted Harbor agent name when the job does not contain a tool policy.
+
+A mismatch is a hard refusal and prints every differing field with both values.
+For an intentional exploratory comparison only, pass `--allow-mismatch`; every
+non-empty line of the resulting report is then marked `[UNTRUSTWORTHY COMPARISON]` so the
+exception cannot disappear in copied output. A missing value remains unknown,
+not a value inferred from the current checkout.
+
 The comparison reads only what every Harbor agent writes (reward and the
 agent's own reported usage), so it works against a downloaded community job too.
 A missing Stella adapter result is reported as "no evidence contract", never as

--- a/test/evals/harbor/README.md
+++ b/test/evals/harbor/README.md
@@ -156,16 +156,19 @@ uv run --project test/evals/harbor python -m stella_harbor.compare \
 Before reading any score, the comparison derives and checks a run fingerprint
 from the Harbor artifacts. It includes dataset id and hash, attempt budget,
 concurrency, timeout multiplier, model, tool strategy, capability profile
-digest, and candidate commit. Candidate commit is intentionally ignored when
-checking compatibility, because a candidate is normally what the comparison is
-measuring. All other fields must match. The tool strategy falls back to the
-persisted Harbor agent name when the job does not contain a tool policy.
+digest, and candidate commit. Candidate commit may differ, because a candidate
+is normally what the comparison is measuring, but it must be present on both
+sides. All other fields must be present and equal. The tool strategy falls back
+to the persisted Harbor agent name when the job does not contain a tool policy.
 
-A mismatch is a hard refusal and prints every differing field with both values.
-For an intentional exploratory comparison only, pass `--allow-mismatch`; every
-non-empty line of the resulting report is then marked `[UNTRUSTWORTHY COMPARISON]` so the
-exception cannot disappear in copied output. A missing value remains unknown,
-not a value inferred from the current checkout.
+A value difference is a hard refusal under `CONFIGURATION DIFFERENT`; a missing
+value is a separate hard refusal under `CANNOT VERIFY CONFIGURATION`, with the
+field and expected artifact location named explicitly. For an intentional
+exploratory comparison only, pass `--allow-mismatch`; every non-empty line of
+the resulting report is then marked `[UNTRUSTWORTHY COMPARISON]` so the
+exception cannot disappear in copied output. The Stella driver now writes the actual model reference as `model` and
+`git rev-parse HEAD` as `candidate_commit` into each driver result. Missing
+values are never inferred from the current checkout.
 
 The comparison reads only what every Harbor agent writes (reward and the
 agent's own reported usage), so it works against a downloaded community job too.

--- a/test/evals/harbor/README.md
+++ b/test/evals/harbor/README.md
@@ -155,18 +155,23 @@ uv run --project test/evals/harbor python -m stella_harbor.compare \
 
 Before reading any score, the comparison derives and checks a run fingerprint
 from the Harbor artifacts. It includes dataset id and hash, attempt budget,
-concurrency, timeout multiplier, model, tool strategy, capability profile
-digest, and candidate commit. Candidate commit may differ, because a candidate
-is normally what the comparison is measuring, but it must be present on both
-sides. All other fields must be present and equal. The tool strategy falls back
-to the persisted Harbor agent name when the job does not contain a tool policy.
+concurrency, timeout multiplier, model, agent name, tool strategy, capability
+profile digest, and candidate commit. Dataset, model, budget, concurrency, and
+timeout are run conditions and must be present and equal. Agent name,
+capability profile, tool strategy, and candidate commit are agent identity: a
+same-agent comparison checks the capability and tool fields, while allowing the
+candidate commit to differ; a cross-agent comparison reports both identities
+without using them as a gate.
 
 A value difference is a hard refusal under `CONFIGURATION DIFFERENT`; a missing
-value is a separate hard refusal under `CANNOT VERIFY CONFIGURATION`, with the
-field and expected artifact location named explicitly. For an intentional
-exploratory comparison only, pass `--allow-mismatch`; every non-empty line of
-the resulting report is then marked `[UNTRUSTWORTHY COMPARISON]` so the
-exception cannot disappear in copied output. The Stella driver now writes the actual model reference as `model` and
+run-condition value is a separate hard refusal under `CANNOT VERIFY
+CONFIGURATION`, with the field and expected artifact location named explicitly.
+Missing agent-identity fields are reported with coverage but do not block a
+cross-agent comparison. Internal inconsistency inside any run is reported and
+blocks the comparison. For an intentional exploratory comparison only, pass
+`--allow-mismatch`; every non-empty line of the resulting report is then marked
+`[UNTRUSTWORTHY COMPARISON]` so the exception cannot disappear in copied output.
+The Stella driver writes the actual model reference as `model` and
 `git rev-parse HEAD` as `candidate_commit` into each driver result. Missing
 values are never inferred from the current checkout.
 

--- a/test/evals/harbor/stella_harbor/compare.py
+++ b/test/evals/harbor/stella_harbor/compare.py
@@ -110,7 +110,7 @@ def render(
     out = [mark(f"{names[0]}  vs  {names[1]}"), ""]
     if untrusted:
         out.extend(mark(line) for line in [
-            "Configuration fingerprints differ; this output must not be used to attribute score changes.",
+            "Fingerprint validation failed; this output must not be used to attribute score changes.",
             *format_mismatches(mismatches or []),
         ])
         out.append("")

--- a/test/evals/harbor/stella_harbor/compare.py
+++ b/test/evals/harbor/stella_harbor/compare.py
@@ -13,10 +13,17 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
+from .fingerprint import (
+    FingerprintMismatchError,
+    collect_fingerprint,
+    fingerprint_mismatches,
+    format_mismatches,
+)
 from .report import RESOLVED, wilson_interval
 
 
@@ -77,7 +84,13 @@ def _by_task(rows: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
     return {task: summarize(trials) for task, trials in grouped.items()}
 
 
-def render(left: list[dict[str, Any]], right: list[dict[str, Any]], names: tuple[str, str]) -> str:
+def render(
+    left: list[dict[str, Any]],
+    right: list[dict[str, Any]],
+    names: tuple[str, str],
+    *,
+    mismatches: list[dict[str, Any]] | None = None,
+) -> str:
     left_tasks, right_tasks = _by_task(left), _by_task(right)
     tasks = sorted(set(left_tasks) | set(right_tasks))
     width = max([24, *(len(t) for t in tasks)])
@@ -88,25 +101,37 @@ def render(left: list[dict[str, Any]], right: list[dict[str, Any]], names: tuple
         cost = "-" if stats["cost"] is None else f"${stats['cost']:.3f}"
         return f"{stats['resolved']}/{stats['scoreable']} {cost:>9}"
 
-    out = [f"{names[0]}  vs  {names[1]}", ""]
-    out.append(f"{'task':<{width}}  {names[0][:16]:>16}  {names[1][:16]:>16}")
-    out.append("-" * (width + 38))
+    untrusted = bool(mismatches)
+    marker = "[UNTRUSTWORTHY COMPARISON] "
+
+    def mark(line: str) -> str:
+        return marker + line if untrusted else line
+
+    out = [mark(f"{names[0]}  vs  {names[1]}"), ""]
+    if untrusted:
+        out.extend(mark(line) for line in [
+            "Configuration fingerprints differ; this output must not be used to attribute score changes.",
+            *format_mismatches(mismatches or []),
+        ])
+        out.append("")
+    out.append(mark(f"{'task':<{width}}  {names[0][:16]:>16}  {names[1][:16]:>16}"))
+    out.append(mark("-" * (width + 38)))
     for task in tasks:
-        out.append(f"{task:<{width}}  {cell(left_tasks.get(task)):>16}  {cell(right_tasks.get(task)):>16}")
+        out.append(mark(f"{task:<{width}}  {cell(left_tasks.get(task)):>16}  {cell(right_tasks.get(task)):>16}"))
 
     out.append("")
     for name, rows in ((names[0], left), (names[1], right)):
         s = summarize(rows)
         cost = "-" if s["cost"] is None else f"${s['cost']:.2f}"
         invalid = f", {s['invalid']} invalid" if s["invalid"] else ""
-        out.append(
+        out.append(mark(
             f"{name}: {s['resolved']}/{s['scoreable']} resolved "
             f"({s['rate'] * 100:.1f}%, 95% CI {s['ci'][0] * 100:.1f}-{s['ci'][1] * 100:.1f}%), "
             f"total {cost}{invalid}"
-        )
+        ))
     out.append("")
-    out.append("Costs come from each agent's own usage reporting, so they are comparable")
-    out.append("only when both runs used the same model and price table.")
+    out.append(mark("Costs come from each agent's own usage reporting, so they are comparable"))
+    out.append(mark("only when both runs used the same model and price table."))
     return "\n".join(out)
 
 
@@ -115,9 +140,22 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("left", type=Path)
     parser.add_argument("right", type=Path)
     parser.add_argument("--names", nargs=2, metavar=("LEFT", "RIGHT"))
+    parser.add_argument(
+        "--allow-mismatch",
+        action="store_true",
+        help="render an explicitly untrusted comparison despite fingerprint mismatches",
+    )
     args = parser.parse_args(argv)
     names = tuple(args.names) if args.names else (args.left.name, args.right.name)
-    print(render(load(args.left), load(args.right), names))
+
+    left_fingerprint = collect_fingerprint(args.left)
+    right_fingerprint = collect_fingerprint(args.right)
+    mismatches = fingerprint_mismatches(left_fingerprint, right_fingerprint)
+    if mismatches and not args.allow_mismatch:
+        print(str(FingerprintMismatchError(mismatches)), file=sys.stderr)
+        return 2
+
+    print(render(load(args.left), load(args.right), names, mismatches=mismatches or None))
     return 0
 
 

--- a/test/evals/harbor/stella_harbor/compare.py
+++ b/test/evals/harbor/stella_harbor/compare.py
@@ -20,7 +20,8 @@ from typing import Any
 
 from .fingerprint import (
     FingerprintMismatchError,
-    collect_fingerprint,
+    collect_fingerprint_details,
+    comparison_mode,
     fingerprint_mismatches,
     format_mismatches,
 )
@@ -90,6 +91,8 @@ def render(
     names: tuple[str, str],
     *,
     mismatches: list[dict[str, Any]] | None = None,
+    mode: str | None = None,
+    agent_names: tuple[Any, Any] | None = None,
 ) -> str:
     left_tasks, right_tasks = _by_task(left), _by_task(right)
     tasks = sorted(set(left_tasks) | set(right_tasks))
@@ -101,17 +104,26 @@ def render(
         cost = "-" if stats["cost"] is None else f"${stats['cost']:.3f}"
         return f"{stats['resolved']}/{stats['scoreable']} {cost:>9}"
 
-    untrusted = bool(mismatches)
+    issues = mismatches or []
+    untrusted = any(issue.get("reject") for issue in issues)
     marker = "[UNTRUSTWORTHY COMPARISON] "
 
     def mark(line: str) -> str:
         return marker + line if untrusted else line
 
     out = [mark(f"{names[0]}  vs  {names[1]}"), ""]
-    if untrusted:
+    if mode:
+        if mode == "cross-agent":
+            left_agent, right_agent = agent_names or (None, None)
+            identity = f"CROSS-AGENT COMPARISON: left agent={left_agent!r}; right agent={right_agent!r}"
+        else:
+            identity = f"{mode.upper()}: agent identity is part of the report, not the run-condition gate"
+        out.append(mark(identity))
+    if issues:
         out.extend(mark(line) for line in [
-            "Fingerprint validation failed; this output must not be used to attribute score changes.",
-            *format_mismatches(mismatches or []),
+            "Fingerprint validation failed; this output must not be used to attribute score changes."
+            if untrusted else "Agent identity diagnostics; run-condition validation passed.",
+            *format_mismatches(issues),
         ])
         out.append("")
     out.append(mark(f"{'task':<{width}}  {names[0][:16]:>16}  {names[1][:16]:>16}"))
@@ -148,14 +160,34 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     names = tuple(args.names) if args.names else (args.left.name, args.right.name)
 
-    left_fingerprint = collect_fingerprint(args.left)
-    right_fingerprint = collect_fingerprint(args.right)
-    mismatches = fingerprint_mismatches(left_fingerprint, right_fingerprint)
-    if mismatches and not args.allow_mismatch:
+    left_details = collect_fingerprint_details(args.left)
+    right_details = collect_fingerprint_details(args.right)
+    left_fingerprint = left_details["fingerprint"]
+    right_fingerprint = right_details["fingerprint"]
+    mismatches = fingerprint_mismatches(
+        left_fingerprint,
+        right_fingerprint,
+        left_details["evidence"],
+        right_details["evidence"],
+    )
+    blocking = [issue for issue in mismatches if issue.get("reject")]
+    mode = comparison_mode(
+        left_fingerprint,
+        right_fingerprint,
+        (left_details["evidence"], right_details["evidence"]),
+    )
+    if blocking and not args.allow_mismatch:
         print(str(FingerprintMismatchError(mismatches)), file=sys.stderr)
         return 2
 
-    print(render(load(args.left), load(args.right), names, mismatches=mismatches or None))
+    print(render(
+        load(args.left),
+        load(args.right),
+        names,
+        mismatches=mismatches or None,
+        mode=mode,
+        agent_names=(left_fingerprint.get("agent_name"), right_fingerprint.get("agent_name")),
+    ))
     return 0
 
 

--- a/test/evals/harbor/stella_harbor/fingerprint.py
+++ b/test/evals/harbor/stella_harbor/fingerprint.py
@@ -1,4 +1,4 @@
-"""Extract and compare the configuration identity of a Harbor run."""
+"""Extract and validate the configuration identity of a Harbor run."""
 
 from __future__ import annotations
 
@@ -6,22 +6,22 @@ import json
 from pathlib import Path
 from typing import Any
 
-FINGERPRINT_FIELDS = (
+CONDITION_FIELDS = (
     "dataset_id",
     "dataset_hash",
     "model",
     "budget",
     "concurrency",
     "timeout_multiplier",
-    "tool_strategy",
+)
+AGENT_FIELDS = (
+    "agent_name",
     "capability_profile_digest",
     "candidate_commit",
+    "tool_strategy",
 )
-
-# A candidate commit is deliberately excluded from compatibility checks: the
-# whole point of this comparison is often to measure a new candidate against a
-# control run. Every other field must describe the same evaluation conditions.
-COMPARISON_FIELDS = tuple(field for field in FINGERPRINT_FIELDS if field != "candidate_commit")
+FINGERPRINT_FIELDS = CONDITION_FIELDS + AGENT_FIELDS
+# Candidate commits are the variable being measured in a same-agent comparison.
 
 FINGERPRINT_SOURCES = {
     "dataset_id": "run config.json: datasets[].name",
@@ -30,9 +30,10 @@ FINGERPRINT_SOURCES = {
     "budget": "run config.json: n_attempts",
     "concurrency": "run config.json: n_concurrent_trials",
     "timeout_multiplier": "effective trial config: agent_timeout_multiplier or timeout_multiplier",
-    "tool_strategy": "run/trial config: tool_strategy or tool_policy",
+    "agent_name": "run config.json: agents[].name",
     "capability_profile_digest": "driver result.json: capability_profile_digest",
     "candidate_commit": "driver result.json: candidate_commit",
+    "tool_strategy": "run/trial config: tool_strategy or tool_policy",
 }
 
 
@@ -43,13 +44,15 @@ def _read_json(path: Path) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
 
 
-def _unique(values: list[Any]) -> Any:
-    """Return one observed value, or all values when a run is internally mixed."""
+def _distinct(values: list[Any]) -> list[Any]:
     distinct: list[Any] = []
     for value in values:
-        if value is None or value in distinct:
-            continue
-        distinct.append(value)
+        if value is not None and value not in distinct:
+            distinct.append(value)
+    return distinct
+
+
+def _value(distinct: list[Any]) -> Any:
     if not distinct:
         return None
     return distinct[0] if len(distinct) == 1 else sorted(distinct, key=repr)
@@ -87,13 +90,11 @@ def _walk_values(value: Any, keys: set[str]) -> list[Any]:
 
 
 def _trial_files(run: Path) -> list[tuple[Path, dict[str, Any], dict[str, Any]]]:
+    """Read every trial directory, including trials without a result yet."""
     trials: list[tuple[Path, dict[str, Any], dict[str, Any]]] = []
     for trial in sorted(p for p in run.iterdir() if p.is_dir()):
-        result = trial / "result.json"
-        if not result.exists():
-            continue
+        result_data = _read_json(trial / "result.json")
         config = _read_json(trial / "config.json")
-        result_data = _read_json(result)
         # Older Harbor exports put the complete effective trial config in the
         # trial result while config.json contains only the task identity.
         effective_config = result_data.get("config")
@@ -103,152 +104,253 @@ def _trial_files(run: Path) -> list[tuple[Path, dict[str, Any], dict[str, Any]]]
     return trials
 
 
-def collect_fingerprint(job_dir: Path) -> dict[str, Any]:
-    """Derive a run fingerprint from the job's persisted Harbor artifacts.
+def _run_total(run_result: dict[str, Any], trials: list[Any]) -> int:
+    total = run_result.get("n_total_trials")
+    return total if isinstance(total, int) and total > 0 else len(trials)
 
-    Missing values remain ``None``. They are not guessed from the current
-    checkout or from a human-maintained note, because doing so would turn an
-    historical run into a false claim about its configuration.
-    """
-    # Import locally to keep fingerprint extraction usable without creating a
-    # second implementation of Harbor's timestamp-directory selection.
+
+def _trial_values(
+    field: str,
+    config: dict[str, Any],
+    result: dict[str, Any],
+    adapter: dict[str, Any],
+) -> list[Any]:
+    if field == "model":
+        agent = config.get("agent") or {}
+        values = [agent.get("model_name"), result.get("model")]
+        if isinstance(result.get("agent_info"), dict):
+            values.append(_model_from_info(result["agent_info"].get("model_info")))
+        return _distinct(values)
+    if field == "agent_name":
+        agent = config.get("agent") or {}
+        return _distinct([agent.get("name"), (result.get("agent_info") or {}).get("name")])
+    if field == "timeout_multiplier":
+        return _distinct([config.get("agent_timeout_multiplier"), config.get("timeout_multiplier")])
+    if field == "capability_profile_digest":
+        return _distinct(_walk_values({"result": result, "adapter": adapter}, {field}))
+    if field == "candidate_commit":
+        return _distinct(_walk_values({"config": config, "result": result, "adapter": adapter}, {field, "candidate_commit_sha"}))
+    if field == "tool_strategy":
+        return _distinct(_walk_values(config, {"tool_strategy", "tool_policy"}))
+    return []
+
+
+def _summarize_units(units: list[list[Any]], total: int, source: str) -> tuple[Any, dict[str, Any]]:
+    present = sum(bool(unit) for unit in units)
+    distinct = _distinct([value for unit in units for value in unit])
+    if len(distinct) > 1:
+        status = "inconsistent"
+    elif present == 0:
+        status = "missing"
+    elif present < total:
+        status = "partial"
+    else:
+        status = "complete"
+    return _value(distinct), {
+        "status": status,
+        "present": present,
+        "total": total,
+        "coverage": f"{present}/{total}",
+        "values": distinct,
+        "source": source,
+    }
+
+
+def _root_value(config: dict[str, Any], field: str) -> Any:
+    if field == "dataset_id" or field == "dataset_hash":
+        datasets = config.get("datasets") or []
+        dataset = datasets[0] if datasets and isinstance(datasets[0], dict) else {}
+        return dataset.get("name" if field == "dataset_id" else "ref")
+    if field == "budget":
+        return config.get("n_attempts")
+    if field == "concurrency":
+        return config.get("n_concurrent_trials")
+    if field == "agent_name":
+        return _agent_name(config)
+    if field == "model":
+        agents = config.get("agents") or []
+        agent = agents[0] if agents and isinstance(agents[0], dict) else {}
+        return agent.get("model_name")
+    if field == "timeout_multiplier":
+        return next(
+            (config.get(key) for key in ("agent_timeout_multiplier", "timeout_multiplier") if config.get(key) is not None),
+            None,
+        )
+    if field == "tool_strategy":
+        return _value(_distinct(_walk_values(config, {"tool_strategy", "tool_policy"})))
+    if field == "candidate_commit":
+        return _value(_distinct(_walk_values(config, {"candidate_commit", "candidate_commit_sha"})))
+    return None
+
+
+def collect_fingerprint_details(job_dir: Path) -> dict[str, Any]:
+    """Derive values plus evidence coverage and consistency from Harbor artifacts."""
+    # Import locally to reuse Harbor's timestamp-directory selection without a
+    # second implementation or an import cycle during module initialization.
     from .compare import latest_run
 
     run = latest_run(job_dir)
     config = _read_json(run / "config.json")
+    run_result = _read_json(run / "result.json")
     trials = _trial_files(run)
+    total_trials = _run_total(run_result, trials)
     trial_configs = [trial_config for _, trial_config, _ in trials]
     results = [result for _, _, result in trials]
-    adapter_results = [
-        _read_json(trial / "agent" / "stella" / "result.json")
-        for trial, _, _ in trials
-    ]
+    adapters = [_read_json(trial / "agent" / "stella" / "result.json") for trial, _, _ in trials]
 
-    datasets = config.get("datasets") or []
-    dataset = datasets[0] if datasets and isinstance(datasets[0], dict) else {}
-    dataset_id = dataset.get("name")
-    dataset_hash = dataset.get("ref")
-    if dataset_id is None:
-        dataset_id = _unique([cfg.get("task", {}).get("source") for cfg in trial_configs if isinstance(cfg.get("task"), dict)])
-    if dataset_hash is None:
-        dataset_hash = _unique([cfg.get("task", {}).get("dataset_hash") for cfg in trial_configs if isinstance(cfg.get("task"), dict)])
+    values: dict[str, Any] = {}
+    evidence: dict[str, dict[str, Any]] = {}
+    for field in FINGERPRINT_FIELDS:
+        root = _root_value(config, field)
+        if root is not None:
+            value, info = _summarize_units([[root]], 1, FINGERPRINT_SOURCES[field])
+        elif field in {"dataset_id", "dataset_hash"}:
+            key = "source" if field == "dataset_id" else "dataset_hash"
+            units = [
+                _distinct([cfg.get("task", {}).get(key)])
+                if isinstance(cfg.get("task"), dict) else []
+                for cfg in trial_configs
+            ]
+            value, info = _summarize_units(units, total_trials, FINGERPRINT_SOURCES[field])
+        else:
+            units = [
+                _trial_values(field, cfg, result, adapter)
+                for cfg, result, adapter in zip(trial_configs, results, adapters)
+            ]
+            value, info = _summarize_units(units, total_trials, FINGERPRINT_SOURCES[field])
+        values[field] = value
+        evidence[field] = info
 
-    agent_configs = [
-        config.get("agents", [{}])[0] if config.get("agents") else {},
-        *[cfg.get("agent") or {} for cfg in trial_configs],
-    ]
-    model = _unique([
-        agent.get("model_name") for agent in agent_configs if isinstance(agent, dict)
-    ])
-    if model is None:
-        model = _unique([
-            result.get("model") for result in results if isinstance(result.get("model"), str)
-        ])
-    if model is None:
-        model = _unique([
-            _model_from_info(result.get("agent_info", {}).get("model_info"))
-            for result in results
-            if isinstance(result.get("agent_info"), dict)
-        ])
+    return {"fingerprint": values, "evidence": evidence}
 
-    timeout_values: list[Any] = [
-        config.get("agent_timeout_multiplier"),
-        config.get("timeout_multiplier"),
-    ]
-    for trial_config in trial_configs:
-        timeout_values.extend([
-            trial_config.get("agent_timeout_multiplier"),
-            trial_config.get("timeout_multiplier"),
-        ])
 
-    explicit_tool_strategy = _walk_values(
-        {"config": config, "trials": trial_configs},
-        {"tool_strategy", "tool_policy"},
-    )
-    tool_strategy = _unique(explicit_tool_strategy)
-    if tool_strategy is None:
-        # Harbor persists the adapter name but not a generic tool allow/deny
-        # policy. Keep that observable proxy so Stella and Pi cannot silently
-        # compare as if they used the same tool strategy.
-        tool_strategy = _agent_name(config)
+def collect_fingerprint(job_dir: Path) -> dict[str, Any]:
+    """Return only fingerprint values, for callers that do not need diagnostics."""
+    return collect_fingerprint_details(job_dir)["fingerprint"]
 
-    capability_digests = _walk_values(
-        {"results": results, "adapter_results": adapter_results},
-        {"capability_profile_digest"},
-    )
-    candidate_commits = _walk_values(
-        {"config": config, "trials": trial_configs, "results": results, "adapter_results": adapter_results},
-        {"candidate_commit", "candidate_commit_sha"},
-    )
 
+def _fallback_evidence(fingerprint: dict[str, Any]) -> dict[str, dict[str, Any]]:
     return {
-        "dataset_id": dataset_id,
-        "dataset_hash": dataset_hash,
-        "model": model,
-        "budget": config.get("n_attempts"),
-        "concurrency": config.get("n_concurrent_trials"),
-        "timeout_multiplier": _unique(timeout_values),
-        "tool_strategy": tool_strategy,
-        "capability_profile_digest": _unique(capability_digests),
-        "candidate_commit": _unique(candidate_commits),
+        field: {
+            "status": "complete" if fingerprint.get(field) is not None else "missing",
+            "present": 1 if fingerprint.get(field) is not None else 0,
+            "total": 1,
+            "coverage": "1/1" if fingerprint.get(field) is not None else "0/1",
+            "values": [fingerprint[field]] if fingerprint.get(field) is not None else [],
+            "source": FINGERPRINT_SOURCES[field],
+        }
+        for field in FINGERPRINT_FIELDS
     }
 
 
-def fingerprint_mismatches(
-    left: dict[str, Any], right: dict[str, Any]
-) -> list[dict[str, Any]]:
-    """Return configuration differences and fields whose identity is unknown.
+def _is_complete(info: dict[str, Any]) -> bool:
+    return info.get("status") == "complete"
 
-    Missing values are not equal values. Candidate commits may differ, but a
-    missing candidate commit still makes the comparison unverifiable.
+
+def _issue(kind: str, field: str, left: dict[str, Any], right: dict[str, Any], reject: bool, *, source: str | None = None) -> dict[str, Any]:
+    result = {
+        "kind": kind,
+        "field": field,
+        "left": left.get("fingerprint", {}).get(field),
+        "right": right.get("fingerprint", {}).get(field),
+        "left_evidence": left.get("evidence", {}).get(field) or {},
+        "right_evidence": right.get("evidence", {}).get(field) or {},
+        "reject": reject,
+    }
+    if source is not None:
+        result["source"] = source
+    return result
+
+
+def fingerprint_mismatches(
+    left: dict[str, Any],
+    right: dict[str, Any],
+    left_evidence: dict[str, dict[str, Any]] | None = None,
+    right_evidence: dict[str, dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    """Return hard mismatches and non-blocking identity diagnostics.
+
+    Condition fields are fail-closed. Agent identity fields are diagnostics for
+    cross-agent comparisons, except an internally inconsistent run, which is
+    never safe to compare.
     """
+    left_bundle = {"fingerprint": left, "evidence": left_evidence or _fallback_evidence(left)}
+    right_bundle = {"fingerprint": right, "evidence": right_evidence or _fallback_evidence(right)}
+    left_values, right_values = left_bundle["fingerprint"], right_bundle["fingerprint"]
+    left_info, right_info = left_bundle["evidence"], right_bundle["evidence"]
     issues: list[dict[str, Any]] = []
+
+    internal_fields: set[str] = set()
     for field in FINGERPRINT_FIELDS:
-        left_value, right_value = left.get(field), right.get(field)
-        if left_value is None or right_value is None:
-            issues.append({
-                "kind": "unverifiable",
-                "field": field,
-                "left": left_value,
-                "right": right_value,
-                "source": FINGERPRINT_SOURCES[field],
-            })
-        elif field in COMPARISON_FIELDS and left_value != right_value:
-            issues.append({
-                "kind": "different",
-                "field": field,
-                "left": left_value,
-                "right": right_value,
-            })
+        if left_info[field].get("status") == "inconsistent" or right_info[field].get("status") == "inconsistent":
+            internal_fields.add(field)
+            issues.append(_issue("internal", field, left_bundle, right_bundle, True, source=FINGERPRINT_SOURCES[field]))
+
+    same_agent = (
+        _is_complete(left_info["agent_name"])
+        and _is_complete(right_info["agent_name"])
+        and left_values.get("agent_name") == right_values.get("agent_name")
+    )
+    for field in CONDITION_FIELDS:
+        if field in internal_fields:
+            continue
+        if not _is_complete(left_info[field]) or not _is_complete(right_info[field]):
+            issues.append(_issue("unverifiable", field, left_bundle, right_bundle, True, source=FINGERPRINT_SOURCES[field]))
+        elif left_values.get(field) != right_values.get(field):
+            issues.append(_issue("different", field, left_bundle, right_bundle, True))
+
+    for field in AGENT_FIELDS:
+        if field == "agent_name":
+            if field not in internal_fields and (not _is_complete(left_info[field]) or not _is_complete(right_info[field])):
+                issues.append(_issue("agent_incomplete", field, left_bundle, right_bundle, False, source=FINGERPRINT_SOURCES[field]))
+            continue
+        if field in internal_fields:
+            continue
+        if not _is_complete(left_info[field]) or not _is_complete(right_info[field]):
+            issues.append(_issue("agent_incomplete", field, left_bundle, right_bundle, False, source=FINGERPRINT_SOURCES[field]))
+        elif same_agent and field != "candidate_commit" and left_values.get(field) != right_values.get(field):
+            issues.append(_issue("different", field, left_bundle, right_bundle, True))
     return issues
+
+
+def comparison_mode(left: dict[str, Any], right: dict[str, Any], evidence: tuple[dict[str, Any], dict[str, Any]]) -> str:
+    left_info, right_info = evidence
+    if not _is_complete(left_info.get("agent_name", {})) or not _is_complete(right_info.get("agent_name", {})):
+        return "agent identity unavailable"
+    return "same-agent" if left.get("agent_name") == right.get("agent_name") else "cross-agent"
 
 
 def format_value(value: Any) -> str:
     return json.dumps(value, sort_keys=True, ensure_ascii=False)
 
 
+def _side(value: Any, evidence: dict[str, Any]) -> str:
+    return f"{format_value(value)} [{evidence.get('coverage', '?/?')}]"
+
+
 def format_mismatches(mismatches: list[dict[str, Any]]) -> list[str]:
     lines: list[str] = []
-    different = [item for item in mismatches if item["kind"] == "different"]
-    unverifiable = [item for item in mismatches if item["kind"] == "unverifiable"]
-    if different:
-        lines.append("CONFIGURATION DIFFERENT:")
-        lines.extend(
-            f"  - {item['field']}: left={format_value(item['left'])}; right={format_value(item['right'])}"
-            for item in different
-        )
-    if unverifiable:
-        lines.append("CANNOT VERIFY CONFIGURATION:")
-        lines.extend(
-            f"  - {item['field']}: left={format_value(item['left'])}; "
-            f"right={format_value(item['right'])}; expected at {item['source']}"
-            for item in unverifiable
-        )
+    groups = (
+        ("different", "CONFIGURATION DIFFERENT:"),
+        ("unverifiable", "CANNOT VERIFY CONFIGURATION:"),
+        ("internal", "INTERNALLY INCONSISTENT RUN:"),
+        ("agent_incomplete", "AGENT IDENTITY INCOMPLETE (reported, not blocking):"),
+    )
+    for kind, title in groups:
+        items = [item for item in mismatches if item["kind"] == kind]
+        if not items:
+            continue
+        lines.append(title)
+        for item in items:
+            left = _side(item["left"], item["left_evidence"])
+            right = _side(item["right"], item["right_evidence"])
+            source = f"; expected at {item['source']}" if item.get("source") else ""
+            lines.append(f"  - {item['field']}: left={left}; right={right}{source}")
     return lines
 
 
 class FingerprintMismatchError(ValueError):
-    """Raised when comparison would mix incompatible run configurations."""
+    """Raised when comparison contains any blocking fingerprint issue."""
 
     def __init__(self, mismatches: list[dict[str, Any]]) -> None:
         self.mismatches = mismatches

--- a/test/evals/harbor/stella_harbor/fingerprint.py
+++ b/test/evals/harbor/stella_harbor/fingerprint.py
@@ -1,0 +1,209 @@
+"""Extract and compare the configuration identity of a Harbor run."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+FINGERPRINT_FIELDS = (
+    "dataset_id",
+    "dataset_hash",
+    "model",
+    "budget",
+    "concurrency",
+    "timeout_multiplier",
+    "tool_strategy",
+    "capability_profile_digest",
+    "candidate_commit",
+)
+
+# A candidate commit is deliberately excluded from compatibility checks: the
+# whole point of this comparison is often to measure a new candidate against a
+# control run. Every other field must describe the same evaluation conditions.
+COMPARISON_FIELDS = tuple(field for field in FINGERPRINT_FIELDS if field != "candidate_commit")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    value = json.loads(path.read_text())
+    return value if isinstance(value, dict) else {}
+
+
+def _unique(values: list[Any]) -> Any:
+    """Return one observed value, or all values when a run is internally mixed."""
+    distinct: list[Any] = []
+    for value in values:
+        if value is None or value in distinct:
+            continue
+        distinct.append(value)
+    if not distinct:
+        return None
+    return distinct[0] if len(distinct) == 1 else sorted(distinct, key=repr)
+
+
+def _agent_name(config: dict[str, Any]) -> str | None:
+    agents = config.get("agents") or []
+    if not agents or not isinstance(agents[0], dict):
+        return None
+    name = agents[0].get("name")
+    return name if isinstance(name, str) else None
+
+
+def _model_from_info(info: Any) -> str | None:
+    if not isinstance(info, dict):
+        return None
+    name = info.get("name")
+    provider = info.get("provider")
+    if isinstance(name, str) and isinstance(provider, str) and provider:
+        return f"{provider}/{name}"
+    return name if isinstance(name, str) else None
+
+
+def _walk_values(value: Any, keys: set[str]) -> list[Any]:
+    found: list[Any] = []
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if key in keys and child is not None:
+                found.append(child)
+            found.extend(_walk_values(child, keys))
+    elif isinstance(value, list):
+        for child in value:
+            found.extend(_walk_values(child, keys))
+    return found
+
+
+def _trial_files(run: Path) -> list[tuple[Path, dict[str, Any], dict[str, Any]]]:
+    trials: list[tuple[Path, dict[str, Any], dict[str, Any]]] = []
+    for trial in sorted(p for p in run.iterdir() if p.is_dir()):
+        result = trial / "result.json"
+        if not result.exists():
+            continue
+        config = _read_json(trial / "config.json")
+        result_data = _read_json(result)
+        # Older Harbor exports put the complete effective trial config in the
+        # trial result while config.json contains only the task identity.
+        effective_config = result_data.get("config")
+        if isinstance(effective_config, dict):
+            config = {**effective_config, **config}
+        trials.append((trial, config, result_data))
+    return trials
+
+
+def collect_fingerprint(job_dir: Path) -> dict[str, Any]:
+    """Derive a run fingerprint from the job's persisted Harbor artifacts.
+
+    Missing values remain ``None``. They are not guessed from the current
+    checkout or from a human-maintained note, because doing so would turn an
+    historical run into a false claim about its configuration.
+    """
+    # Import locally to keep fingerprint extraction usable without creating a
+    # second implementation of Harbor's timestamp-directory selection.
+    from .compare import latest_run
+
+    run = latest_run(job_dir)
+    config = _read_json(run / "config.json")
+    trials = _trial_files(run)
+    trial_configs = [trial_config for _, trial_config, _ in trials]
+    results = [result for _, _, result in trials]
+    adapter_results = [
+        _read_json(trial / "agent" / "stella" / "result.json")
+        for trial, _, _ in trials
+    ]
+
+    datasets = config.get("datasets") or []
+    dataset = datasets[0] if datasets and isinstance(datasets[0], dict) else {}
+    dataset_id = dataset.get("name")
+    dataset_hash = dataset.get("ref")
+    if dataset_id is None:
+        dataset_id = _unique([cfg.get("task", {}).get("source") for cfg in trial_configs if isinstance(cfg.get("task"), dict)])
+    if dataset_hash is None:
+        dataset_hash = _unique([cfg.get("task", {}).get("dataset_hash") for cfg in trial_configs if isinstance(cfg.get("task"), dict)])
+
+    agent_configs = [
+        config.get("agents", [{}])[0] if config.get("agents") else {},
+        *[cfg.get("agent") or {} for cfg in trial_configs],
+    ]
+    model = _unique([
+        agent.get("model_name") for agent in agent_configs if isinstance(agent, dict)
+    ])
+    if model is None:
+        model = _unique([
+            _model_from_info(result.get("agent_info", {}).get("model_info"))
+            for result in results
+            if isinstance(result.get("agent_info"), dict)
+        ])
+
+    timeout_values: list[Any] = [
+        config.get("agent_timeout_multiplier"),
+        config.get("timeout_multiplier"),
+    ]
+    for trial_config in trial_configs:
+        timeout_values.extend([
+            trial_config.get("agent_timeout_multiplier"),
+            trial_config.get("timeout_multiplier"),
+        ])
+
+    explicit_tool_strategy = _walk_values(
+        {"config": config, "trials": trial_configs},
+        {"tool_strategy", "tool_policy"},
+    )
+    tool_strategy = _unique(explicit_tool_strategy)
+    if tool_strategy is None:
+        # Harbor persists the adapter name but not a generic tool allow/deny
+        # policy. Keep that observable proxy so Stella and Pi cannot silently
+        # compare as if they used the same tool strategy.
+        tool_strategy = _agent_name(config)
+
+    capability_digests = _walk_values(
+        {"results": results, "adapter_results": adapter_results},
+        {"capability_profile_digest"},
+    )
+    candidate_commits = _walk_values(
+        {"config": config, "trials": trial_configs, "results": results, "adapter_results": adapter_results},
+        {"candidate_commit", "candidate_commit_sha"},
+    )
+
+    return {
+        "dataset_id": dataset_id,
+        "dataset_hash": dataset_hash,
+        "model": model,
+        "budget": config.get("n_attempts"),
+        "concurrency": config.get("n_concurrent_trials"),
+        "timeout_multiplier": _unique(timeout_values),
+        "tool_strategy": tool_strategy,
+        "capability_profile_digest": _unique(capability_digests),
+        "candidate_commit": _unique(candidate_commits),
+    }
+
+
+def fingerprint_mismatches(
+    left: dict[str, Any], right: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Return every incompatible field, including both observed values."""
+    return [
+        {"field": field, "left": left.get(field), "right": right.get(field)}
+        for field in COMPARISON_FIELDS
+        if left.get(field) != right.get(field)
+    ]
+
+
+def format_value(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, ensure_ascii=False)
+
+
+def format_mismatches(mismatches: list[dict[str, Any]]) -> list[str]:
+    return [
+        f"  - {item['field']}: left={format_value(item['left'])}; right={format_value(item['right'])}"
+        for item in mismatches
+    ]
+
+
+class FingerprintMismatchError(ValueError):
+    """Raised when comparison would mix incompatible run configurations."""
+
+    def __init__(self, mismatches: list[dict[str, Any]]) -> None:
+        self.mismatches = mismatches
+        detail = "\n".join(format_mismatches(mismatches))
+        super().__init__("REFUSING COMPARISON: run fingerprints differ\n" + detail)

--- a/test/evals/harbor/stella_harbor/fingerprint.py
+++ b/test/evals/harbor/stella_harbor/fingerprint.py
@@ -23,6 +23,18 @@ FINGERPRINT_FIELDS = (
 # control run. Every other field must describe the same evaluation conditions.
 COMPARISON_FIELDS = tuple(field for field in FINGERPRINT_FIELDS if field != "candidate_commit")
 
+FINGERPRINT_SOURCES = {
+    "dataset_id": "run config.json: datasets[].name",
+    "dataset_hash": "run config.json: datasets[].ref",
+    "model": "driver result.json: model",
+    "budget": "run config.json: n_attempts",
+    "concurrency": "run config.json: n_concurrent_trials",
+    "timeout_multiplier": "effective trial config: agent_timeout_multiplier or timeout_multiplier",
+    "tool_strategy": "run/trial config: tool_strategy or tool_policy",
+    "capability_profile_digest": "driver result.json: capability_profile_digest",
+    "candidate_commit": "driver result.json: candidate_commit",
+}
+
 
 def _read_json(path: Path) -> dict[str, Any]:
     if not path.exists():
@@ -130,6 +142,10 @@ def collect_fingerprint(job_dir: Path) -> dict[str, Any]:
     ])
     if model is None:
         model = _unique([
+            result.get("model") for result in results if isinstance(result.get("model"), str)
+        ])
+    if model is None:
+        model = _unique([
             _model_from_info(result.get("agent_info", {}).get("model_info"))
             for result in results
             if isinstance(result.get("agent_info"), dict)
@@ -181,12 +197,30 @@ def collect_fingerprint(job_dir: Path) -> dict[str, Any]:
 def fingerprint_mismatches(
     left: dict[str, Any], right: dict[str, Any]
 ) -> list[dict[str, Any]]:
-    """Return every incompatible field, including both observed values."""
-    return [
-        {"field": field, "left": left.get(field), "right": right.get(field)}
-        for field in COMPARISON_FIELDS
-        if left.get(field) != right.get(field)
-    ]
+    """Return configuration differences and fields whose identity is unknown.
+
+    Missing values are not equal values. Candidate commits may differ, but a
+    missing candidate commit still makes the comparison unverifiable.
+    """
+    issues: list[dict[str, Any]] = []
+    for field in FINGERPRINT_FIELDS:
+        left_value, right_value = left.get(field), right.get(field)
+        if left_value is None or right_value is None:
+            issues.append({
+                "kind": "unverifiable",
+                "field": field,
+                "left": left_value,
+                "right": right_value,
+                "source": FINGERPRINT_SOURCES[field],
+            })
+        elif field in COMPARISON_FIELDS and left_value != right_value:
+            issues.append({
+                "kind": "different",
+                "field": field,
+                "left": left_value,
+                "right": right_value,
+            })
+    return issues
 
 
 def format_value(value: Any) -> str:
@@ -194,10 +228,23 @@ def format_value(value: Any) -> str:
 
 
 def format_mismatches(mismatches: list[dict[str, Any]]) -> list[str]:
-    return [
-        f"  - {item['field']}: left={format_value(item['left'])}; right={format_value(item['right'])}"
-        for item in mismatches
-    ]
+    lines: list[str] = []
+    different = [item for item in mismatches if item["kind"] == "different"]
+    unverifiable = [item for item in mismatches if item["kind"] == "unverifiable"]
+    if different:
+        lines.append("CONFIGURATION DIFFERENT:")
+        lines.extend(
+            f"  - {item['field']}: left={format_value(item['left'])}; right={format_value(item['right'])}"
+            for item in different
+        )
+    if unverifiable:
+        lines.append("CANNOT VERIFY CONFIGURATION:")
+        lines.extend(
+            f"  - {item['field']}: left={format_value(item['left'])}; "
+            f"right={format_value(item['right'])}; expected at {item['source']}"
+            for item in unverifiable
+        )
+    return lines
 
 
 class FingerprintMismatchError(ValueError):
@@ -206,4 +253,4 @@ class FingerprintMismatchError(ValueError):
     def __init__(self, mismatches: list[dict[str, Any]]) -> None:
         self.mismatches = mismatches
         detail = "\n".join(format_mismatches(mismatches))
-        super().__init__("REFUSING COMPARISON: run fingerprints differ\n" + detail)
+        super().__init__("REFUSING COMPARISON: fingerprint validation failed\n" + detail)

--- a/test/evals/harbor/tests/test_compare.py
+++ b/test/evals/harbor/tests/test_compare.py
@@ -100,8 +100,8 @@ def test_matching_fingerprints_are_comparable(tmp_path, capsys):
 
 
 def test_a_single_fingerprint_mismatch_is_rejected_with_both_values(tmp_path, capsys):
-    left = write_fingerprinted_job(tmp_path, "left", n_concurrent_trials=16)
-    right = write_fingerprinted_job(tmp_path, "right", n_concurrent_trials=8)
+    left = write_fingerprinted_job(tmp_path, "left", n_concurrent_trials=16, candidate_commit="left")
+    right = write_fingerprinted_job(tmp_path, "right", n_concurrent_trials=8, candidate_commit="right")
 
     assert main([str(left), str(right)]) == 2
     message = capsys.readouterr().err
@@ -113,11 +113,11 @@ def test_a_single_fingerprint_mismatch_is_rejected_with_both_values(tmp_path, ca
 def test_all_fingerprint_mismatches_are_reported(tmp_path, capsys):
     left = write_fingerprinted_job(
         tmp_path, "left", n_attempts=5, n_concurrent_trials=16,
-        agent_timeout_multiplier=1.0,
+        agent_timeout_multiplier=1.0, candidate_commit="left",
     )
     right = write_fingerprinted_job(
         tmp_path, "right", n_attempts=3, n_concurrent_trials=8,
-        agent_timeout_multiplier=2.0,
+        agent_timeout_multiplier=2.0, candidate_commit="right",
     )
 
     assert main([str(left), str(right)]) == 2
@@ -127,9 +127,60 @@ def test_all_fingerprint_mismatches_are_reported(tmp_path, capsys):
     assert "1.0" in message and "2.0" in message
 
 
+def test_both_missing_fields_are_rejected_as_unverifiable(tmp_path, capsys):
+    agents = [{"name": "stella_harbor.agent:StellaAgent", "model_name": None}]
+    left = write_fingerprinted_job(tmp_path, "left", agents=agents)
+    right = write_fingerprinted_job(tmp_path, "right", agents=agents)
+
+    assert main([str(left), str(right)]) == 2
+    message = capsys.readouterr().err
+    assert "CANNOT VERIFY CONFIGURATION:" in message
+    assert "model" in message and "candidate_commit" in message
+    assert "driver result.json: model" in message
+    assert "driver result.json: candidate_commit" in message
+    assert "CONFIGURATION DIFFERENT:" not in message
+
+
+def test_missing_and_different_fields_are_reported_separately(tmp_path, capsys):
+    agents = [{"name": "stella_harbor.agent:StellaAgent", "model_name": None}]
+    left = write_fingerprinted_job(tmp_path, "left", agents=agents, candidate_commit="left")
+    right = write_fingerprinted_job(tmp_path, "right", n_concurrent_trials=8, candidate_commit="right")
+
+    assert main([str(left), str(right)]) == 2
+    message = capsys.readouterr().err
+    assert "CONFIGURATION DIFFERENT:" in message
+    assert "CANNOT VERIFY CONFIGURATION:" in message
+    assert "concurrency" in message and "model" in message
+    assert "expected at driver result.json: model" in message
+
+
+def test_missing_candidate_commit_is_unverifiable_even_when_both_are_missing(tmp_path, capsys):
+    left = write_fingerprinted_job(tmp_path, "left")
+    right = write_fingerprinted_job(tmp_path, "right")
+
+    assert main([str(left), str(right)]) == 2
+    message = capsys.readouterr().err
+    assert "CANNOT VERIFY CONFIGURATION:" in message
+    assert "candidate_commit" in message
+
+
+def test_driver_result_fields_are_read_into_the_fingerprint(tmp_path):
+    agents = [{"name": "stella_harbor.agent:StellaAgent", "model_name": None}]
+    job = write_fingerprinted_job(tmp_path, "job", agents=agents)
+    result_path = job / "2026-08-19__10-00-00" / "t__a" / "result.json"
+    result = json.loads(result_path.read_text())
+    result.update({"model": "gateway/actual", "candidate_commit": "driver-commit"})
+    result_path.write_text(json.dumps(result))
+
+    fingerprint = collect_fingerprint(job)
+
+    assert fingerprint["model"] == "gateway/actual"
+    assert fingerprint["candidate_commit"] == "driver-commit"
+
+
 def test_allow_mismatch_renders_a_persistent_untrusted_marker(tmp_path, capsys):
-    left = write_fingerprinted_job(tmp_path, "left", n_concurrent_trials=16)
-    right = write_fingerprinted_job(tmp_path, "right", n_concurrent_trials=8)
+    left = write_fingerprinted_job(tmp_path, "left", n_concurrent_trials=16, candidate_commit="left")
+    right = write_fingerprinted_job(tmp_path, "right", n_concurrent_trials=8, candidate_commit="right")
 
     assert main([str(left), str(right), "--allow-mismatch"]) == 0
     output = capsys.readouterr().out

--- a/test/evals/harbor/tests/test_compare.py
+++ b/test/evals/harbor/tests/test_compare.py
@@ -1,7 +1,11 @@
 import json
 
 from stella_harbor.compare import load, main, render, summarize
-from stella_harbor.fingerprint import collect_fingerprint, fingerprint_mismatches
+from stella_harbor.fingerprint import (
+    collect_fingerprint,
+    collect_fingerprint_details,
+    fingerprint_mismatches,
+)
 
 
 def write(job, run, task, reward, cost, suffix="a", adapter=None):
@@ -90,13 +94,17 @@ def test_matching_fingerprints_are_comparable(tmp_path, capsys):
         "budget": 5,
         "concurrency": 16,
         "timeout_multiplier": 1.0,
-        "tool_strategy": "stella_harbor.agent:StellaAgent",
+        "agent_name": "stella_harbor.agent:StellaAgent",
+        "tool_strategy": None,
         "capability_profile_digest": "capability-a",
         "candidate_commit": "commit-left",
     }
-    assert fingerprint_mismatches(fingerprint, collect_fingerprint(right)) == []
+    issues = fingerprint_mismatches(fingerprint, collect_fingerprint(right))
+    assert not any(issue["reject"] for issue in issues)
     assert main([str(left), str(right), "--names", "left", "right"]) == 0
-    assert "left  vs  right" in capsys.readouterr().out
+    output = capsys.readouterr().out
+    assert "left  vs  right" in output
+    assert "SAME-AGENT" in output
 
 
 def test_a_single_fingerprint_mismatch_is_rejected_with_both_values(tmp_path, capsys):
@@ -154,14 +162,15 @@ def test_missing_and_different_fields_are_reported_separately(tmp_path, capsys):
     assert "expected at driver result.json: model" in message
 
 
-def test_missing_candidate_commit_is_unverifiable_even_when_both_are_missing(tmp_path, capsys):
+def test_missing_agent_fields_are_reported_but_do_not_block(tmp_path, capsys):
     left = write_fingerprinted_job(tmp_path, "left")
     right = write_fingerprinted_job(tmp_path, "right")
 
-    assert main([str(left), str(right)]) == 2
-    message = capsys.readouterr().err
-    assert "CANNOT VERIFY CONFIGURATION:" in message
-    assert "candidate_commit" in message
+    assert main([str(left), str(right)]) == 0
+    message = capsys.readouterr().out
+    assert "AGENT IDENTITY INCOMPLETE (reported, not blocking):" in message
+    assert "candidate_commit" in message and "tool_strategy" in message
+    assert "CANNOT VERIFY CONFIGURATION:" not in message
 
 
 def test_driver_result_fields_are_read_into_the_fingerprint(tmp_path):
@@ -176,6 +185,85 @@ def test_driver_result_fields_are_read_into_the_fingerprint(tmp_path):
 
     assert fingerprint["model"] == "gateway/actual"
     assert fingerprint["candidate_commit"] == "driver-commit"
+
+
+def test_same_agent_capability_difference_is_rejected(tmp_path, capsys):
+    left = write_fingerprinted_job(tmp_path, "left", candidate_commit="left")
+    right = write_fingerprinted_job(tmp_path, "right", candidate_commit="right")
+    adapter_path = tmp_path / "right" / "2026-08-19__10-00-00" / "t__a" / "agent" / "stella" / "result.json"
+    adapter_path.write_text(json.dumps({"capability_profile_digest": "capability-b"}))
+
+    assert main([str(left), str(right)]) == 2
+    message = capsys.readouterr().err
+    assert "CONFIGURATION DIFFERENT:" in message
+    assert "capability_profile_digest" in message
+
+
+def test_cross_agent_comparison_passes_and_reports_both_identities(tmp_path, capsys):
+    left = write_fingerprinted_job(tmp_path, "left", candidate_commit="left")
+    right = write_fingerprinted_job(
+        tmp_path,
+        "right",
+        agents=[{"name": "stella_harbor.pi_gateway:PiGateway", "model_name": "gateway/test"}],
+        candidate_commit="right",
+    )
+
+    assert main([str(left), str(right)]) == 0
+    message = capsys.readouterr().out
+    assert "CROSS-AGENT COMPARISON" in message
+    assert "stella_harbor.agent:StellaAgent" in message
+    assert "stella_harbor.pi_gateway:PiGateway" in message
+
+
+def test_cross_agent_condition_mismatch_is_rejected(tmp_path, capsys):
+    left = write_fingerprinted_job(tmp_path, "left", candidate_commit="left")
+    right = write_fingerprinted_job(
+        tmp_path,
+        "right",
+        agents=[{"name": "stella_harbor.pi_gateway:PiGateway", "model_name": "other"}],
+        candidate_commit="right",
+    )
+
+    assert main([str(left), str(right)]) == 2
+    message = capsys.readouterr().err
+    assert "CONFIGURATION DIFFERENT:" in message
+    assert "model" in message
+
+
+def test_partial_capability_coverage_is_reported(tmp_path, capsys):
+    job = tmp_path / "partial"
+    run = "2026-08-19__10-00-00"
+    write_run_config(job, run, n_attempts=5, n_concurrent_trials=16, candidate_commit="commit")
+    (job / run / "result.json").write_text(json.dumps({"n_total_trials": 5}))
+    for index in range(5):
+        adapter = {"capability_profile_digest": "capability-a"} if index < 2 else None
+        write(job, run, f"task-{index}", 1.0, 0.01, adapter=adapter)
+
+    details = collect_fingerprint_details(job)
+    evidence = details["evidence"]["capability_profile_digest"]
+    assert evidence["status"] == "partial"
+    assert evidence["present"] == 2 and evidence["total"] == 5
+
+    other = write_fingerprinted_job(tmp_path, "other", candidate_commit="commit")
+    assert main([str(job), str(other)]) == 0
+    message = capsys.readouterr().out
+    assert "capability_profile_digest" in message and "[2/5]" in message
+
+
+def test_internal_capability_inconsistency_blocks_and_is_reported(tmp_path, capsys):
+    job = tmp_path / "inconsistent"
+    run = "2026-08-19__10-00-00"
+    write_run_config(job, run, n_total_trials=2, candidate_commit="commit")
+    (job / run / "result.json").write_text(json.dumps({"n_total_trials": 2}))
+    write(job, run, "task-a", 1.0, 0.01, adapter={"capability_profile_digest": "capability-a"})
+    write(job, run, "task-b", 1.0, 0.01, adapter={"capability_profile_digest": "capability-b"})
+    other = write_fingerprinted_job(tmp_path, "other", candidate_commit="commit")
+
+    assert main([str(job), str(other)]) == 2
+    message = capsys.readouterr().err
+    assert "INTERNALLY INCONSISTENT RUN:" in message
+    assert "capability_profile_digest" in message
+    assert "[2/2]" in message
 
 
 def test_allow_mismatch_renders_a_persistent_untrusted_marker(tmp_path, capsys):

--- a/test/evals/harbor/tests/test_compare.py
+++ b/test/evals/harbor/tests/test_compare.py
@@ -1,6 +1,7 @@
 import json
 
-from stella_harbor.compare import load, render, summarize
+from stella_harbor.compare import load, main, render, summarize
+from stella_harbor.fingerprint import collect_fingerprint, fingerprint_mismatches
 
 
 def write(job, run, task, reward, cost, suffix="a", adapter=None):
@@ -13,6 +14,40 @@ def write(job, run, task, reward, cost, suffix="a", adapter=None):
     if adapter is not None:
         (trial / "agent" / "stella").mkdir(parents=True)
         (trial / "agent" / "stella" / "result.json").write_text(json.dumps(adapter))
+
+
+def write_run_config(job, run, **overrides):
+    config = {
+        "n_attempts": 5,
+        "n_concurrent_trials": 16,
+        "agent_timeout_multiplier": 1.0,
+        "agents": [{"name": "stella_harbor.agent:StellaAgent", "model_name": "gateway/test"}],
+        "datasets": [{"name": "terminal-bench/test", "ref": "sha256:dataset"}],
+        **overrides,
+    }
+    path = job / run
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "config.json").write_text(json.dumps(config))
+
+
+def write_fingerprinted_job(tmp_path, name, **overrides):
+    job = tmp_path / name
+    run = "2026-08-19__10-00-00"
+    write_run_config(job, run, **overrides)
+    (job / run / "result.json").write_text("{}")
+    write(
+        job,
+        run,
+        "t",
+        1.0,
+        0.01,
+        adapter={"capability_profile_digest": "capability-a"},
+    )
+    (job / run / "t__a" / "result.json").write_text(json.dumps({
+        "verifier_result": {"rewards": {"reward": 1.0}},
+        "agent_result": {"cost_usd": 0.01, "n_input_tokens": 10, "n_output_tokens": 5},
+    }))
+    return job
 
 
 def test_compare_reads_a_job_without_the_stella_adapter(tmp_path):
@@ -41,6 +76,66 @@ def test_an_invalid_stella_trial_still_leaves_the_denominator(tmp_path):
     (job / "2026-08-19__10-00-00" / "result.json").write_text("{}")
     stats = summarize(load(job))
     assert stats["invalid"] == 1 and stats["scoreable"] == 0
+
+
+def test_matching_fingerprints_are_comparable(tmp_path, capsys):
+    left = write_fingerprinted_job(tmp_path, "left", candidate_commit="commit-left")
+    right = write_fingerprinted_job(tmp_path, "right", candidate_commit="commit-right")
+
+    fingerprint = collect_fingerprint(left)
+    assert fingerprint == {
+        "dataset_id": "terminal-bench/test",
+        "dataset_hash": "sha256:dataset",
+        "model": "gateway/test",
+        "budget": 5,
+        "concurrency": 16,
+        "timeout_multiplier": 1.0,
+        "tool_strategy": "stella_harbor.agent:StellaAgent",
+        "capability_profile_digest": "capability-a",
+        "candidate_commit": "commit-left",
+    }
+    assert fingerprint_mismatches(fingerprint, collect_fingerprint(right)) == []
+    assert main([str(left), str(right), "--names", "left", "right"]) == 0
+    assert "left  vs  right" in capsys.readouterr().out
+
+
+def test_a_single_fingerprint_mismatch_is_rejected_with_both_values(tmp_path, capsys):
+    left = write_fingerprinted_job(tmp_path, "left", n_concurrent_trials=16)
+    right = write_fingerprinted_job(tmp_path, "right", n_concurrent_trials=8)
+
+    assert main([str(left), str(right)]) == 2
+    message = capsys.readouterr().err
+    assert "REFUSING COMPARISON" in message
+    assert "concurrency" in message
+    assert "16" in message and "8" in message
+
+
+def test_all_fingerprint_mismatches_are_reported(tmp_path, capsys):
+    left = write_fingerprinted_job(
+        tmp_path, "left", n_attempts=5, n_concurrent_trials=16,
+        agent_timeout_multiplier=1.0,
+    )
+    right = write_fingerprinted_job(
+        tmp_path, "right", n_attempts=3, n_concurrent_trials=8,
+        agent_timeout_multiplier=2.0,
+    )
+
+    assert main([str(left), str(right)]) == 2
+    message = capsys.readouterr().err
+    assert "budget" in message and "concurrency" in message and "timeout_multiplier" in message
+    assert "5" in message and "3" in message and "16" in message and "8" in message
+    assert "1.0" in message and "2.0" in message
+
+
+def test_allow_mismatch_renders_a_persistent_untrusted_marker(tmp_path, capsys):
+    left = write_fingerprinted_job(tmp_path, "left", n_concurrent_trials=16)
+    right = write_fingerprinted_job(tmp_path, "right", n_concurrent_trials=8)
+
+    assert main([str(left), str(right), "--allow-mismatch"]) == 0
+    output = capsys.readouterr().out
+    assert "[UNTRUSTWORTHY COMPARISON]" in output
+    assert output.count("[UNTRUSTWORTHY COMPARISON]") >= 6
+    assert "concurrency" in output and "16" in output and "8" in output
 
 
 def test_render_names_both_runs_and_every_task(tmp_path):


### PR DESCRIPTION
## What

Add a run fingerprint for Harbor evaluation jobs and enforce the run-condition portion in `stella_harbor.compare`. A comparison is safe only when both runs are provably scored under the same dataset, model, budget, concurrency, and timeout conditions.

This is the first block of #1056. The run registry, the one-command subset entry point, and holdout grouping are deliberately not in this PR.

## Why

The evaluate → compare → optimize loop is triggered by a human, so its failure mode is not missing automation. It is two runs that are quietly not the same scoring configuration, which makes a score change impossible to attribute.

The guard must compare scoring conditions, not pretend that two agents have to be the same. A Stella-versus-Pi comparison is a supported use case; agent identity is reported separately from the condition gate.

## How

- `fingerprint.py` derives:
  - **Run conditions (A, required and equal):** dataset id/hash, model, budget (`n_attempts`), concurrency, and timeout multiplier.
  - **Agent identity (B, reported separately):** `agent_name`, `capability_profile_digest`, `candidate_commit`, and explicit `tool_strategy`/`tool_policy` when present. `tool_strategy` no longer falls back to an agent name.
- Same-agent comparisons require all A fields to be present and equal. B capability/tool fields must match when present; candidate commits may differ because that is the variable under test. Missing B fields are reported but do not block.
- Cross-agent comparisons still require all A fields to be present and equal, but report both agent identities and do not gate on B fields. The output explicitly says `CROSS-AGENT COMPARISON`.
- A missing A field is a hard `CANNOT VERIFY CONFIGURATION` refusal. Known unequal values are a hard `CONFIGURATION DIFFERENT` refusal. Internal inconsistency within either run is reported as `INTERNALLY INCONSISTENT RUN` and blocks comparison.
- Trial evidence records complete, partial, and inconsistent states with coverage such as `442/445`; `_unique` no longer turns partial evidence into a complete value.
- `--allow-mismatch` releases blocking A/configuration or internal-consistency issues, and every non-empty report line is tagged `[UNTRUSTWORTHY COMPARISON]`.
- `cmd/stella-eval-agent` persists `model` from the actual model reference and `candidate_commit` from `git rev-parse HEAD`. A failed git read leaves the field absent rather than fabricating a value.

## Test

- `uv run --project test/evals/harbor pytest test/evals/harbor/tests -q` — 58 passed
- `go test ./cmd/stella-eval-agent`
- `mise run format`
- `mise run build`
- `mise run test`
- Real archive regression: extracted `luna-k5-results.tgz` into `dist/`, built a temporary Pi-side job with a different agent name and without Stella adapter metadata, and compared it with a temporary normalized copy of the archived Stella baseline. Exit status was 0; output explicitly reported `CROSS-AGENT COMPARISON` and the missing B evidence, including Stella capability coverage `393/445` versus Pi `0/445`, without treating it as a verification failure. The original `test/evals/harbor/results/` archive was not modified.

## Refs

Refs #1056

Follow-on in this issue: run registry, subset entry point, holdout grouping.

## Feishu Task

- [评测-对比-优化循环机制（人工触发）](https://mcnnox2fhjfq.feishu.cn/record/OOXbrkAi3egLKYcHD9icXJ3dn0b) (#1056)