### PR TITLE
🔒 chore: ignore .env files in-repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ internal/agent/runner/.agents/
 .impeccable/*
 !.impeccable/config.json
 web/.impeccable/
+
+# Local credential files, never committed
+.env*


### PR DESCRIPTION
## What

Add `.env*` to the repository’s own `.gitignore`.

## Why

The repository is public, and the Harbor eval workflow expects a local `.env` carrying `OPENAI_API_KEY` and AWS credentials. Nothing in the repository ignored it. The only thing standing between that file and a `git add .` was a machine-local rule in one developer’s global git ignore, which no contributor inherits.

History is clean: no `.env` has ever been committed.

## How

One line, plus a comment naming the reason.

## Test

`git check-ignore -v .env` resolves to the repository rule rather than a global one.

## Refs

No issue: one-line gitignore hardening.