### PR TITLE
🧹 chore(groups): remove assembly-rewrite leftovers

### DIFF
--- a/internal/db/queries/ctx_message.sql
+++ b/internal/db/queries/ctx_message.sql
@@ -33,17 +33,6 @@ WHERE m.id = sqlc.arg('id')
 -- name: GetMessagesByConversation :many
 SELECT * FROM ctx_message WHERE conversation_id = $1 ORDER BY seq ASC;
 
--- name: ListMessagesByConversationBeforeSeq :many
--- Reverse page for bounded assembly: newest first, restored to chronological
--- order by the caller once it has collected as much as its budget allows.
--- before_seq is NULL on the first page. A sentinel would have to be larger than
--- every legal seq, and bigint has no such value, so NULL carries "no bound".
-SELECT * FROM ctx_message
-WHERE conversation_id = sqlc.arg('conversation_id')
-  AND (sqlc.narg('before_seq')::bigint IS NULL OR seq < sqlc.narg('before_seq')::bigint)
-ORDER BY seq DESC
-LIMIT sqlc.arg('limit');
-
 -- name: GetConversationTimeBounds :one
 SELECT MIN(created_at) AS earliest_at, MAX(created_at) AS latest_at
 FROM ctx_message

--- a/internal/memory/lcm/group_assembler.go
+++ b/internal/memory/lcm/group_assembler.go
@@ -27,19 +27,16 @@ const (
 	groupWindowEvictionBlockTokens = 10_000
 )
 
-const groupHistoryOmittedMarker = "[system]: earlier group history omitted; use memory.search"
+// groupHistoryOmittedMarker is the emitted line and the token-reservation
+// input; building it through the renderer keeps the two from drifting apart.
+var groupHistoryOmittedMarker = grouptranscript.RenderGroupSystemLine("earlier group history omitted; use memory.search")
 
 type groupWindowEvent struct {
-	id               string
-	seq              int64
-	actorType        string
-	actorID          string
-	actorDisplayName string
-	content          string
-	deliveryState    string
-	line             string
-	tokens           int
-	bytes            int
+	seq     int64
+	content string
+	line    string
+	tokens  int
+	bytes   int
 }
 
 // assembleGroup reconstructs the group prompt from the canonical public event
@@ -72,7 +69,7 @@ func (p *Provider) assembleGroup(ctx context.Context, session memory.Session, bu
 
 	messages := make([]ai.Message, 0, len(window)+2)
 	if omitted {
-		messages = append(messages, ai.UserMessage{Content: grouptranscript.RenderGroupSystemLine("earlier group history omitted; use memory.search")})
+		messages = append(messages, ai.UserMessage{Content: groupHistoryOmittedMarker})
 	}
 	for _, event := range window {
 		messages = append(messages, ai.UserMessage{Content: event.line})
@@ -141,7 +138,7 @@ func (p *Provider) loadGroupWindow(ctx context.Context, groupID, agentID string,
 			break
 		}
 		for _, row := range page {
-			event := groupWindowEventFromRow(ctx, namer, groupID, agentID, row.ID, row.Seq, row.ActorType, row.ActorID, row.ActorDisplayName.String, row.Content, row.DeliveryState)
+			event := groupWindowEventFromRow(ctx, namer, groupID, agentID, row.Seq, row.ActorType, row.ActorID, row.ActorDisplayName.String, row.Content, row.DeliveryState)
 			if event.content == "" {
 				continue
 			}
@@ -169,7 +166,7 @@ collected:
 		case err != nil:
 			return nil, false, fmt.Errorf("get waking mention: %w", err)
 		default:
-			event := groupWindowEventFromRow(ctx, namer, groupID, agentID, mention.ID, mention.Seq, mention.ActorType, mention.ActorID, mention.ActorDisplayName.String, mention.Content, "delivered")
+			event := groupWindowEventFromRow(ctx, namer, groupID, agentID, mention.Seq, mention.ActorType, mention.ActorID, mention.ActorDisplayName.String, mention.Content, "delivered")
 			if event.content != "" {
 				window = append([]groupWindowEvent{event}, window...)
 			}
@@ -184,7 +181,7 @@ collected:
 		case err != nil:
 			return nil, false, fmt.Errorf("restore waking mention: %w", err)
 		default:
-			event := groupWindowEventFromRow(ctx, namer, groupID, agentID, mention.ID, mention.Seq, mention.ActorType, mention.ActorID, mention.ActorDisplayName.String, mention.Content, "delivered")
+			event := groupWindowEventFromRow(ctx, namer, groupID, agentID, mention.Seq, mention.ActorType, mention.ActorID, mention.ActorDisplayName.String, mention.Content, "delivered")
 			if event.content != "" {
 				var fit bool
 				window, fit = makeRoomForForcedGroupEvent(window, event, maxTokens)
@@ -205,7 +202,7 @@ collected:
 	return window, omitted, nil
 }
 
-func groupWindowEventFromRow(ctx context.Context, namer *eventlog.ParticipantNamer, groupID, selfAgentID, id string, seq int64, actorType, actorID, displayName, content, deliveryState string) groupWindowEvent {
+func groupWindowEventFromRow(ctx context.Context, namer *eventlog.ParticipantNamer, groupID, selfAgentID string, seq int64, actorType, actorID, displayName, content, deliveryState string) groupWindowEvent {
 	name := displayName
 	if name == "" {
 		name = namer.Name(ctx, groupID, actorType, actorID)
@@ -215,10 +212,7 @@ func groupWindowEventFromRow(ctx context.Context, namer *eventlog.ParticipantNam
 		You: actorType == string(eventlog.ActorAgent) && actorID == selfAgentID, DeliveryState: deliveryState,
 	})
 	message := ai.UserMessage{Content: line}
-	return groupWindowEvent{
-		id: id, seq: seq, actorType: actorType, actorID: actorID, actorDisplayName: displayName,
-		content: content, deliveryState: deliveryState, line: line, tokens: estimateMessageTokens(message), bytes: len(line),
-	}
+	return groupWindowEvent{seq: seq, content: content, line: line, tokens: estimateMessageTokens(message), bytes: len(line)}
 }
 
 // makeRoomForForcedGroupEvent preserves the three public-window ceilings when

--- a/pkg/db/sqlc/ctx_message.sql.go
+++ b/pkg/db/sqlc/ctx_message.sql.go
@@ -615,58 +615,6 @@ func (q *Queries) ListMessagePartsWithMediaByMessages(ctx context.Context, messa
 	return items, nil
 }
 
-const listMessagesByConversationBeforeSeq = `-- name: ListMessagesByConversationBeforeSeq :many
-SELECT id, conversation_id, seq, role, event_type, content, token_count, created_at, actor_type, actor_id, source_session_id, inbox_id, origin_group_message_id FROM ctx_message
-WHERE conversation_id = $1
-  AND ($2::bigint IS NULL OR seq < $2::bigint)
-ORDER BY seq DESC
-LIMIT $3
-`
-
-type ListMessagesByConversationBeforeSeqParams struct {
-	ConversationID string      `json:"conversation_id"`
-	BeforeSeq      pgtype.Int8 `json:"before_seq"`
-	Limit          int32       `json:"limit"`
-}
-
-// Reverse page for bounded assembly: newest first, restored to chronological
-// order by the caller once it has collected as much as its budget allows.
-// before_seq is NULL on the first page. A sentinel would have to be larger than
-// every legal seq, and bigint has no such value, so NULL carries "no bound".
-func (q *Queries) ListMessagesByConversationBeforeSeq(ctx context.Context, arg ListMessagesByConversationBeforeSeqParams) ([]CtxMessage, error) {
-	rows, err := q.db.Query(ctx, listMessagesByConversationBeforeSeq, arg.ConversationID, arg.BeforeSeq, arg.Limit)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []CtxMessage{}
-	for rows.Next() {
-		var i CtxMessage
-		if err := rows.Scan(
-			&i.ID,
-			&i.ConversationID,
-			&i.Seq,
-			&i.Role,
-			&i.EventType,
-			&i.Content,
-			&i.TokenCount,
-			&i.CreatedAt,
-			&i.ActorType,
-			&i.ActorID,
-			&i.SourceSessionID,
-			&i.InboxID,
-			&i.OriginGroupMessageID,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const listMessagesByIDs = `-- name: ListMessagesByIDs :many
 SELECT id, conversation_id, seq, role, event_type, content, token_count, created_at, actor_type, actor_id, source_session_id, inbox_id, origin_group_message_id FROM ctx_message WHERE conversation_id = $1 AND id = ANY($2::uuid[]) ORDER BY seq ASC
 `


### PR DESCRIPTION
## What

Entropy cleanup after #1096's assembly rewrite - three evidence-backed cuts, net -69 lines, zero behavior change:

1. **Delete `ListMessagesByConversationBeforeSeq`** (SQL + generated code). Added for the bounded private read; its only caller was removed by the rewrite in the same PR. Zero production consumers repo-wide.
2. **Collapse the omitted-history marker to one truth.** The marker text existed twice: a const used for token reservation and a renderer call at the emit site. Drift between them would silently mis-reserve budget. The const is now built through the renderer and both sites read it.
3. **Shrink `groupWindowEvent` to fields with readers.** `id`, `actorType`, `actorID`, `actorDisplayName`, `deliveryState` fed only the deleted stitch (inWindow/byOrigin maps, self-skip) and were write-only; the dead `id` parameter of `groupWindowEventFromRow` goes with them.

Audited and deliberately kept: `sanitizeToolPairs` (DM assembly), `ParticipantNamer.Line` (group nudge), `GetMessagesByConversation` / `GetMessagePartsByMessages` (review/sessions/transcript), `HandleDisplayName` (used by `Handle`; merging it with the renderer's copy would create an eventlog↔grouptranscript import cycle).

## Verification

`mise run format && mise run build && mise run test` green; targeted `internal/memory/lcm` + `internal/grouptranscript` suites green.

Refs: #1096. No issue: small self-contained cleanup with no behavior change.