### PR TITLE
⚡ perf(groups): quantize claim age so live claims stop busting the prompt cache

### DIFF
--- a/internal/channel/group_claim_tool.go
+++ b/internal/channel/group_claim_tool.go
@@ -97,10 +97,24 @@ func groupClaimOwnerName(ctx context.Context, q *sqlc.Queries, agentID string) s
 	return eventlog.NewParticipantNamer(q).Name(ctx, "", string(eventlog.ActorAgent), agentID)
 }
 
-// groupClaimAge rounds to the minute: a claim's exact second never changes a
-// decision, and an exact timestamp invites the model to do arithmetic.
+// groupClaimAge quantizes to four buckets. This string renders inside the
+// system prompt, the first bytes of every request: a per-minute value there
+// invalidates the provider prompt cache for the whole prompt on every turn.
+// A claim's exact age never changes a decision; whether it is fresh or stale
+// does, and that survives quantization. TTLs clamp to 24h, so "over 1d" only
+// marks a claim outliving its lease.
 func groupClaimAge(createdAt time.Time) string {
-	return max(time.Now().UTC().Sub(createdAt), 0).Round(time.Minute).String()
+	age := max(time.Now().UTC().Sub(createdAt), 0)
+	switch {
+	case age < 10*time.Minute:
+		return "under 10m"
+	case age < time.Hour:
+		return "under 1h"
+	case age < 24*time.Hour:
+		return "under 1d"
+	default:
+		return "over 1d"
+	}
 }
 
 func (t *GroupClaimTools) Tools() []tools.Tool {

--- a/internal/channel/group_claim_tool_test.go
+++ b/internal/channel/group_claim_tool_test.go
@@ -265,3 +265,24 @@ func TestGroupClaimsToolProjectsRows(t *testing.T) {
 		t.Fatalf("raw row plumbing leaked to the model: %s", out)
 	}
 }
+
+func TestGroupClaimAgeIsQuantizedForPromptStability(t *testing.T) {
+	now := time.Now().UTC()
+	for _, tc := range []struct {
+		age  time.Duration
+		want string
+	}{
+		{0, "under 10m"},
+		{9 * time.Minute, "under 10m"},
+		{10 * time.Minute, "under 1h"},
+		{59 * time.Minute, "under 1h"},
+		{time.Hour, "under 1d"},
+		{23 * time.Hour, "under 1d"},
+		{25 * time.Hour, "over 1d"},
+		{-time.Minute, "under 10m"}, // clock skew must not print a negative age
+	} {
+		if got := groupClaimAge(now.Add(-tc.age)); got != tc.want {
+			t.Fatalf("groupClaimAge(%v ago) = %q, want %q", tc.age, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

The system prompt renders each live group claim as `- {agent} owns {subject} (claimed {age} ago)`. The age was exact wall-clock (`5m`, `6m`, `7m`…), so it changed every minute — inside the first bytes of every request. Whenever any claim is live, the whole provider prompt cache is invalidated on every turn, exactly in the multi-agent group scenario where cache reuse matters most.

## Fix

`groupClaimAge` now quantizes to four byte-stable buckets: `under 10m` / `under 1h` / `under 1d` / `over 1d`. A claim's exact age never changes a decision; whether it is fresh or stale does, and that survives quantization. TTLs clamp to 24h, so `over 1d` only marks a claim outliving its lease. Negative skew clamps to zero.

The same helper feeds the `group_claims` tool result, which gets the same buckets — consistent wording, and tool results also land in cached context.

The prompt template is deliberately untouched (it already renders `claimed {age} ago`), avoiding conflict with the in-flight docs-sync PR that edits `system_prompt.tmpl`.

## Verification

- `mise run format && mise run build && mise run test` — green.
- New `TestGroupClaimAgeIsQuantizedForPromptStability`: 8 boundary cases including negative clock skew.

Refs: #1096. No issue: single-function perf fix, no behavior decision.
