### PR TITLE
📊 evals: freeze the loop protocol and default task set

### DIFF
--- a/test/evals/harbor/PROTOCOL.md
+++ b/test/evals/harbor/PROTOCOL.md
@@ -1,0 +1,101 @@
+# Loop protocol
+
+The loop is the iteration tool between full baselines: run a small task set
+against the current checkout, compare it to a same-machine reference, and get
+a verdict the same day a fix is written. It is deliberately not a benchmark.
+Only a complete k=5 run on the reference host may touch
+`results/README.md`, and only that run may back a public improvement claim.
+Everything below exists to keep the cheap loop honest about what it can and
+cannot conclude. Designed in #1107; amendments live in that issue's comments.
+
+## Task selection
+
+`tasksets/loop.yaml` is the default set: 12 tasks in three tiers (improvement
+targets, high-sensitivity flaky, regression guards), selected from the k=5
+baselines and annotated in place. Arbitrary task selection is equally valid:
+a targeted fix runs its own task list, typically single-task at k=5. What is
+frozen is not the task list but the comparison discipline: the manifest
+records exactly what ran, and the comparator refuses a candidate that is
+missing any task its reference declares. There is no silent intersection.
+
+## Definitions
+
+- A **trial is valid** when it produced usable evidence: the adapter evidence
+  validates, or a verifier reward exists. Infrastructure failures (bridge
+  faults, harness exceptions before the agent ran) make a trial invalid; they
+  leave the denominator and are never counted as agent failures.
+- **Resolved** is verifier reward 1.0. All rates are `resolved / valid`.
+- A **reference** is a completed loop run of the same task set, at the same k,
+  with the same model and gateway, on the same machine, from a stated git
+  commit. The pinned EC2 baseline is an absolute sanity check, never the
+  verdict: its host architecture and timing differ from a local machine, so
+  fix verdicts always come from same-machine before/after pairs.
+
+## Verdict tiers
+
+Outcome movement is judged per task, paired against the reference, never as a
+headline rate: the loop's trial counts are far too small for one.
+
+- **SIGNAL**: any per-task movement at loop k, including a target rising 0 to
+  1. Reported, never gates.
+- **SUSPECTED_REGRESSION**: a guard task drops below k/k, or any task drops
+  by two or more resolved. Reported loudly, still does not gate.
+- **CONFIRMED_REGRESSION / CONFIRMED_IMPROVEMENT**: the suspected task re-run
+  at k=5 on both sides, candidate first then reference, so gateway drift
+  works against the confirmation rather than for it. Only a confirmed
+  regression exits nonzero.
+
+## Process metrics
+
+At loop scale, process metrics are the primary signal: resolution is 0/1 with
+a resolution of one attempt, while cost, tokens, and tool behavior are
+continuous, paired per task, and detect stable movement at k=3. A fix can be
+a clear win while resolution stands still (#1076's case: fewer wasted edits
+at the same 2/5). The comparator reports per-task paired deltas in three
+trust tiers:
+
+1. **Behavioral** (tool calls, per-tool error counts, turns): host
+   independent, judged. Error counts are trustworthy only after #1077.
+2. **Gateway-reported** (tokens, cost): host independent, judged.
+3. **Wall time**: reported, never judged on an emulating host (Apple Silicon
+   runs the amd64 task images under emulation; timing there is noise).
+
+Same resolution with a paired tier-1 or tier-2 delta beyond the threshold is
+an **EFFICIENCY_SIGNAL**: shown in the PR table, not a gate. Direction alone
+proves nothing; fewer tool calls can mean smarter or can mean giving up
+earlier, so efficiency deltas are always displayed beside the resolution
+column and no single column is a conclusion.
+
+## Thresholds and calibration
+
+Starting values, to be recalibrated by the pilot (an A/A run: the same commit
+twice on the same machine) and recorded here with the pilot's job ids:
+
+- Efficiency threshold: +/-25% paired per-task delta.
+- Loop k: 3. Concurrency: 4, pending the pilot's 1/2/4 comparison.
+
+## Manifest
+
+Every loop run writes a manifest next to its job directory: git commit,
+dirty-tree flag, task set and its file hash, k, concurrency, model, gateway
+base URL host, capability profile digest, and created-at. The comparator
+takes explicit job paths; nothing ever defaults to "the latest directory".
+
+## Model policy
+
+Verdicts run `gpt-5.6-luna` through the eval gateway, always. A cheaper model
+may drive a smoke run for tool-protocol crashes, but its output is never a
+verdict: changing the model changes tool-calling strategy, which is exactly
+what tool-behavior fixes touch.
+
+## Upgrade triggers
+
+Deliberate ceilings, and what would raise them:
+
+- Whole-job sequential A/B (no per-task interleaving). Revisit if a
+  timeout-class flip appears between same-config rounds, or the A/A pilot
+  shows directional pass/fail flips beyond what k=3 predicts.
+- Scripted cookie login for testbed provisioning (no server-side bootstrap
+  endpoint). Revisit if an auth-flow change breaks the script more than once.
+- EFFICIENCY_SIGNAL never gates. Revisit once A/A data bounds its false-alarm
+  rate.

--- a/test/evals/harbor/PROTOCOL.md
+++ b/test/evals/harbor/PROTOCOL.md
@@ -30,21 +30,22 @@ reference declares. There is no silent intersection.
   agents such as pi). Infrastructure failures (bridge faults, harness
   exceptions before the agent ran) make a trial invalid; they leave the
   denominator and are never counted as agent failures.
-- **Resolved** is verifier reward 1.0. All rates are `resolved / valid`.
-- A valid trial with no verifier reward is not scoreable: the verifier's
-  infrastructure failed, which is not an agent failure. The trial does not
-  count as unresolved; its task needs a re-run, and until then it is
-  INSUFFICIENT_EVIDENCE.
-- A task is **judged** only when both sides hold exactly k valid trials for
-  it. A side that comes up short is re-run until it has k valid trials or the
-  task is reported as INSUFFICIENT_EVIDENCE; an insufficient task is never
-  folded into a verdict.
+- A trial is **scoreable** when it is valid and carries a verifier reward.
+  Valid only says the agent evidence is trustworthy; a valid trial with no
+  reward means the verifier's infrastructure failed, which is not an agent
+  failure, so it never counts as unresolved.
+- **Resolved** is verifier reward 1.0. All rates are `resolved / scoreable`.
+- A task is **judged** only when both sides hold exactly k scoreable trials
+  for it. A side that comes up short is re-run until it does, or the task is
+  reported as INSUFFICIENT_EVIDENCE; an insufficient task is never folded
+  into a verdict.
 - A **reference** is a completed loop run of the same task set, at the same k,
   with the same model and gateway, on the same machine, from a stated git
   commit. The pinned EC2 baseline is an absolute sanity check, never the
   verdict: its host architecture and timing differ from a local machine, so
   fix verdicts always come from same-machine before/after pairs.
-- A **guard** is any task the reference side resolved k/k, whatever task list
+- A **guard** is any task the reference side resolved k of k scoreable,
+  whatever task list
   is in play. The rule is dynamic so explicit task lists need no role
   metadata.
 

--- a/test/evals/harbor/PROTOCOL.md
+++ b/test/evals/harbor/PROTOCOL.md
@@ -3,33 +3,46 @@
 The loop is the iteration tool between full baselines: run a small task set
 against the current checkout, compare it to a same-machine reference, and get
 a verdict the same day a fix is written. It is deliberately not a benchmark.
-Only a complete k=5 run on the reference host may touch
-`results/README.md`, and only that run may back a public improvement claim.
-Everything below exists to keep the cheap loop honest about what it can and
-cannot conclude. Designed in #1107; amendments live in that issue's comments.
+Only a complete 89-task k=5 run on the reference host may touch
+`results/README.md`, and only that run may back a public improvement claim; a
+single-task k=5 confirmation is never a "complete run". Everything below
+exists to keep the cheap loop honest about what it can and cannot conclude.
+Designed in #1107; amendments live in that issue's comments.
 
 ## Task selection
 
 `tasksets/loop.yaml` is the default set: 12 tasks in three tiers (improvement
 targets, high-sensitivity flaky, regression guards), selected from the k=5
-baselines and annotated in place. Arbitrary task selection is equally valid:
-a targeted fix runs its own task list, typically single-task at k=5. What is
-frozen is not the task list but the comparison discipline: the manifest
-records exactly what ran, and the comparator refuses a candidate that is
-missing any task its reference declares. There is no silent intersection.
+baselines and annotated in place. The tier comments are selection rationale
+only; task roles are derived at compare time (see verdicts), never parsed
+from comments. Arbitrary task selection is equally valid: a targeted fix runs
+its own task list, typically single-task at k=5. What is frozen is not the
+task list but the comparison discipline: the manifest records exactly what
+ran, and the comparator refuses a candidate that is missing any task its
+reference declares. There is no silent intersection.
 
 ## Definitions
 
-- A **trial is valid** when it produced usable evidence: the adapter evidence
-  validates, or a verifier reward exists. Infrastructure failures (bridge
-  faults, harness exceptions before the agent ran) make a trial invalid; they
-  leave the denominator and are never counted as agent failures.
+- A **trial is valid** when it produced usable evidence. When Stella adapter
+  evidence is present, its verdict is final: an adapter-invalid trial stays
+  invalid even if a verifier reward exists. The verifier-reward fallback
+  applies only to trials that carry no adapter evidence at all (external
+  agents such as pi). Infrastructure failures (bridge faults, harness
+  exceptions before the agent ran) make a trial invalid; they leave the
+  denominator and are never counted as agent failures.
 - **Resolved** is verifier reward 1.0. All rates are `resolved / valid`.
+- A task is **judged** only when both sides hold exactly k valid trials for
+  it. A side that comes up short is re-run until it has k valid trials or the
+  task is reported as INSUFFICIENT_EVIDENCE; an insufficient task is never
+  folded into a verdict.
 - A **reference** is a completed loop run of the same task set, at the same k,
   with the same model and gateway, on the same machine, from a stated git
   commit. The pinned EC2 baseline is an absolute sanity check, never the
   verdict: its host architecture and timing differ from a local machine, so
   fix verdicts always come from same-machine before/after pairs.
+- A **guard** is any task the reference side resolved k/k, whatever task list
+  is in play. The rule is dynamic so explicit task lists need no role
+  metadata.
 
 ## Verdict tiers
 
@@ -38,48 +51,73 @@ headline rate: the loop's trial counts are far too small for one.
 
 - **SIGNAL**: any per-task movement at loop k, including a target rising 0 to
   1. Reported, never gates.
-- **SUSPECTED_REGRESSION**: a guard task drops below k/k, or any task drops
-  by two or more resolved. Reported loudly, still does not gate.
-- **CONFIRMED_REGRESSION / CONFIRMED_IMPROVEMENT**: the suspected task re-run
-  at k=5 on both sides, candidate first then reference, so gateway drift
-  works against the confirmation rather than for it. Only a confirmed
-  regression exits nonzero.
+- **SUSPECTED_REGRESSION**: a guard drops below k/k, or any task drops by two
+  or more resolved. Reported loudly, still does not gate.
+- **Confirmation** is a single-task k=5 run on both sides, candidate first,
+  then reference, so gateway drift works against the confirmation rather
+  than for it. The predicates are frozen:
+  - **CONFIRMED_REGRESSION**: at k=5, candidate resolved is at least two
+    below reference resolved. Anything weaker is recorded as DISMISSED with
+    both counts.
+  - **CONFIRMED_IMPROVEMENT**: entered only when a PR wants to claim a gain;
+    at k=5, candidate resolved is at least two above reference resolved. A
+    loop-k rise that never takes this step remains a SIGNAL and is reported
+    as such.
+- Only CONFIRMED_REGRESSION exits nonzero.
 
 ## Process metrics
 
 At loop scale, process metrics are the primary signal: resolution is 0/1 with
-a resolution of one attempt, while cost, tokens, and tool behavior are
-continuous, paired per task, and detect stable movement at k=3. A fix can be
-a clear win while resolution stands still (#1076's case: fewer wasted edits
-at the same 2/5). The comparator reports per-task paired deltas in three
-trust tiers:
+a resolution of one attempt, while cost and tool behavior are continuous,
+paired per task, and detect stable movement at k=3. A fix can be a clear win
+while resolution stands still (#1076's case: fewer wasted edits at the same
+2/5). The comparator reports per-task paired deltas in three trust tiers:
 
 1. **Behavioral** (tool calls, per-tool error counts, turns): host
-   independent, judged. Error counts are trustworthy only after #1077.
-2. **Gateway-reported** (tokens, cost): host independent, judged.
+   independent. Error counts are trustworthy only after #1077.
+2. **Gateway-reported** (tokens, cost): host independent.
 3. **Wall time**: reported, never judged on an emulating host (Apple Silicon
    runs the amd64 task images under emulation; timing there is noise).
 
-Same resolution with a paired tier-1 or tier-2 delta beyond the threshold is
-an **EFFICIENCY_SIGNAL**: shown in the PR table, not a gate. Direction alone
-proves nothing; fewer tool calls can mean smarter or can mean giving up
-earlier, so efficiency deltas are always displayed beside the resolution
-column and no single column is a conclusion.
+All tiers are displayed. **EFFICIENCY_SIGNAL** triggers on exactly two
+metrics: provider-reported cost, and per-tool error counts. The computation
+is frozen: per task and side, take the mean over valid trials; the delta is
+`(candidate - reference) / reference`; a reference mean of zero or a missing
+value leaves that metric unjudged for that task. A task whose resolved count
+is unchanged but whose judged delta exceeds 25% in either direction is an
+EFFICIENCY_SIGNAL: shown in the PR table, not a gate. Direction alone proves
+nothing; fewer tool calls can mean smarter or can mean giving up earlier, so
+efficiency deltas are always displayed beside the resolution column and no
+single column is a conclusion.
+
+## Sequential A/B discipline
+
+Sides run as whole jobs, sequentially, on one machine. The mitigations are
+part of the protocol, not advice: task images are pulled before either side
+runs, so neither side pays the cold cache; every trial records its duration
+and timeout class; and a delta whose only outcome change is a timeout-class
+flip is marked untrusted rather than judged.
 
 ## Thresholds and calibration
 
-Starting values, to be recalibrated by the pilot (an A/A run: the same commit
-twice on the same machine) and recorded here with the pilot's job ids:
+Starting values, to be recalibrated by the pilot and recorded here with the
+pilot's job ids. The pilot uses 2-3 tasks: an A/A run (the same commit twice
+on the same machine) to bound the false-alarm rate, and a concurrency 1/2/4
+comparison to fix the concurrency setting.
 
-- Efficiency threshold: +/-25% paired per-task delta.
-- Loop k: 3. Concurrency: 4, pending the pilot's 1/2/4 comparison.
+- Efficiency threshold: 25% paired per-task delta, either direction.
+- Loop k: 3. Concurrency: 4, pending the pilot.
 
 ## Manifest
 
 Every loop run writes a manifest next to its job directory: git commit,
-dirty-tree flag, task set and its file hash, k, concurrency, model, gateway
-base URL host, capability profile digest, and created-at. The comparator
-takes explicit job paths; nothing ever defaults to "the latest directory".
+dirty-tree flag, the task list and its canonical hash (the taskset file's
+SHA-256 when one was used, otherwise the SHA-256 of the sorted
+dataset-qualified task names), dataset name and hash, per-task image digests,
+k, concurrency, timeout multiplier, tool strategy, capability profile digest,
+model, gateway base URL host, and created-at. These are the fields the
+comparator's fingerprint guard checks. The comparator takes explicit job
+paths; nothing ever defaults to "the latest directory".
 
 ## Model policy
 
@@ -94,8 +132,12 @@ Deliberate ceilings, and what would raise them:
 
 - Whole-job sequential A/B (no per-task interleaving). Revisit if a
   timeout-class flip appears between same-config rounds, or the A/A pilot
-  shows directional pass/fail flips beyond what k=3 predicts.
+  shows directional pass/fail flips beyond what k=3 predicts. The per-trial
+  duration and timeout-class records above are the evidence this trigger
+  reads.
 - Scripted cookie login for testbed provisioning (no server-side bootstrap
-  endpoint). Revisit if an auth-flow change breaks the script more than once.
+  endpoint). The script keeps the cookie in a jar file, never prints a
+  credential, and deletes the jar on exit. Revisit if an auth-flow change
+  breaks the script more than once.
 - EFFICIENCY_SIGNAL never gates. Revisit once A/A data bounds its false-alarm
   rate.

--- a/test/evals/harbor/PROTOCOL.md
+++ b/test/evals/harbor/PROTOCOL.md
@@ -31,6 +31,10 @@ reference declares. There is no silent intersection.
   exceptions before the agent ran) make a trial invalid; they leave the
   denominator and are never counted as agent failures.
 - **Resolved** is verifier reward 1.0. All rates are `resolved / valid`.
+- A valid trial with no verifier reward is not scoreable: the verifier's
+  infrastructure failed, which is not an agent failure. The trial does not
+  count as unresolved; its task needs a re-run, and until then it is
+  INSUFFICIENT_EVIDENCE.
 - A task is **judged** only when both sides hold exactly k valid trials for
   it. A side that comes up short is re-run until it has k valid trials or the
   task is reported as INSUFFICIENT_EVIDENCE; an insufficient task is never
@@ -98,6 +102,17 @@ runs, so neither side pays the cold cache; every trial records its duration
 and timeout class; and a delta whose only outcome change is a timeout-class
 flip is marked untrusted rather than judged.
 
+The timeout classes are frozen, one per trial, by the first matching rule:
+
+- `harness_timeout`: Harbor recorded a timeout exception for the trial
+  (`exception_info` names an agent or verifier timeout).
+- `agent_deadline`: the trial deadline stopped the agent mid-task (the
+  failure taxonomy's `timeout` evidence: the turn ended `stopped` by the
+  deadline).
+- `command_timeout`: no trial-level timeout, but at least one tool result
+  carries the command-timeout sentinel (a killed command, exit code -1).
+- `none`: everything else.
+
 ## Thresholds and calibration
 
 Starting values, to be recalibrated by the pilot and recorded here with the
@@ -111,9 +126,11 @@ comparison to fix the concurrency setting.
 ## Manifest
 
 Every loop run writes a manifest next to its job directory: git commit,
-dirty-tree flag, the task list and its canonical hash (the taskset file's
-SHA-256 when one was used, otherwise the SHA-256 of the sorted
-dataset-qualified task names), dataset name and hash, per-task image digests,
+dirty-tree flag, the task list and its canonical hash (always the SHA-256
+of the sorted, newline-joined, dataset-qualified task names, so a taskset
+file and an identical explicit list hash the same and a comment edit changes
+nothing; when a taskset file was used its own SHA-256 is recorded separately
+as provenance), dataset name and hash, per-task image digests,
 k, concurrency, timeout multiplier, tool strategy, capability profile digest,
 model, gateway base URL host, and created-at. These are the fields the
 comparator's fingerprint guard checks. The comparator takes explicit job

--- a/test/evals/harbor/README.md
+++ b/test/evals/harbor/README.md
@@ -3,6 +3,10 @@
 Run a Stella trial from the host while its `bash`, `read`, `write`, and `edit`
 tools operate in the Harbor task container through the bridge backend.
 
+For the fix-iteration loop (small task sets, same-machine before/after,
+verdict tiers), read [`PROTOCOL.md`](PROTOCOL.md); the default task set is
+[`tasksets/loop.yaml`](tasksets/loop.yaml).
+
 ## Prerequisites
 
 - Docker and `uv`

--- a/test/evals/harbor/tasksets/loop.yaml
+++ b/test/evals/harbor/tasksets/loop.yaml
@@ -1,0 +1,35 @@
+# The default loop task set: 12 Terminal-Bench 2.1 tasks selected from the
+# 2026-08-20/21 k=5 baselines (results/README.md). Selection rules and verdict
+# semantics live in ../PROTOCOL.md; change the list only through a PR that
+# updates both files, because every comparison manifest records this file's
+# hash and a silent edit would make old verdicts unreproducible.
+#
+# Task names must be dataset-qualified (`terminal-bench/<task>`): Harbor
+# matches them with fnmatch against the qualified name, and a bare name
+# matches nothing, which silently runs all 89 tasks.
+#
+# The agent, model, and prices are injected at run time (see eval:loop):
+# prices as agent kwargs so they land in each trial's config.json.
+
+job_name: loop
+n_attempts: 3
+n_concurrent_trials: 4
+
+datasets:
+  - name: terminal-bench/terminal-bench-2-1
+    task_names:
+      # Improvement targets: Stella <=1/5, pi >=4/5. The measured gap lives here.
+      - terminal-bench/caffe-cifar-10 # 0/5 vs 5/5
+      - terminal-bench/llm-inference-batching-scheduler # 0/5 vs 5/5
+      - terminal-bench/compile-compcert # 0/5 vs 4/5
+      - terminal-bench/qemu-startup # 1/5 vs 5/5
+      # High-sensitivity flaky: Stella 2-3/5, pi 5/5. Small behavior changes move these.
+      - terminal-bench/build-cython-ext # 2/5 vs 5/5; the #1076 task
+      - terminal-bench/large-scale-text-editing # 3/5 vs 5/5
+      - terminal-bench/reshard-c4-data # 3/5 vs 5/5
+      - terminal-bench/pytorch-model-cli # 3/5 vs 5/5
+      # Regression guards: Stella 5/5. A fix that breaks these is a net loss.
+      - terminal-bench/regex-log # 5/5 vs 5/5
+      - terminal-bench/log-summary-date-ranges # 5/5 vs 5/5
+      - terminal-bench/openssl-selfsigned-cert # 5/5 vs 5/5
+      - terminal-bench/pytorch-model-recovery # 5/5 vs 0/5; the one task Stella wins outright


### PR DESCRIPTION
## What

Freezes the fix-iteration loop's experimental protocol before its tooling lands: `test/evals/harbor/PROTOCOL.md` (valid-trial definition, same-machine reference rule, SIGNAL / SUSPECTED / CONFIRMED verdict tiers, process-metric trust tiers, EFFICIENCY_SIGNAL, manifest requirements, model policy, upgrade triggers) and `tasksets/loop.yaml`, the default 12-task set with every selection annotated from the archived k=5 baselines. One pointer paragraph in the harbor README.

## Why

The loop's comparator and orchestration (next PRs) must implement rules that were decided before looking at their results, or the cheap loop quietly becomes a benchmark. The protocol is the review outcome of #1107 including both amendment rounds.

## Verification

- `loop.yaml` validates against Harbor's `JobConfig` (`model_validate`, 12 unique dataset-qualified names).
- All 12 task names checked against the archived baseline reports in `results/terminal-bench-2.1/`.
- `mise run format` passes (docs-only change; requires a full `mise run generate` in a fresh worktree first, which is pre-existing behavior).

Refs #1107

## Feishu Task

- [本地 run→fix→rerun 评测循环](https://mcnnox2fhjfq.feishu.cn/record/ElRNrZ40TegQdQcjPKfcELannje) (#1107)