### PR TITLE
🐛 fix(evals): count nonzero command exits separately from tool errors

### DIFF
--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -4759,6 +4759,11 @@ components:
           type: string
         is_error:
           type: boolean
+        # Why is_error is set. Absent on messages written before the split and
+        # on non-error results; absent is "unclassified", never "command_nonzero".
+        error_kind:
+          type: string
+          enum: [tool_error, command_nonzero]
         references:
           type: array
           items:

--- a/api/spec/domain/sessions/schemas.yaml
+++ b/api/spec/domain/sessions/schemas.yaml
@@ -355,6 +355,11 @@ components:
         tool_call_id: { type: string }
         tool_name: { type: string }
         is_error: { type: boolean }
+        # Why is_error is set. Absent on messages written before the split and
+        # on non-error results; absent is "unclassified", never "command_nonzero".
+        error_kind:
+          type: string
+          enum: [tool_error, command_nonzero]
         references:
           type: array
           items: { $ref: "#/components/schemas/SessionMessageReference" }

--- a/cmd/stella-eval-agent/metrics.go
+++ b/cmd/stella-eval-agent/metrics.go
@@ -26,21 +26,29 @@ type usage struct {
 }
 
 type metrics struct {
-	Turns           int                 `json:"turns"`
-	ToolCallTotal   int                 `json:"tool_call_total"`
-	ToolErrorTotal  int                 `json:"tool_error_total"`
-	Tools           map[string]toolStat `json:"tools"`
-	SlowestToolCall *toolCallTiming     `json:"slowest_tool_call,omitempty"`
-	Tokens          tokenBreakdown      `json:"tokens_estimated"`
-	Usage           *usage              `json:"usage,omitempty"`
-	Timing          timing              `json:"timing_ms"`
+	Turns         int `json:"turns"`
+	ToolCallTotal int `json:"tool_call_total"`
+	// ToolErrorTotal counts calls where the tool itself failed. A command that
+	// ran and exited nonzero is not one of those: it is the container
+	// answering, and it is counted in CommandNonzeroTotal instead. Keeping
+	// them in one number made a clean run report dozens of "errors" and fed a
+	// failure taxonomy that a reader would trust.
+	ToolErrorTotal      int                 `json:"tool_error_total"`
+	CommandNonzeroTotal int                 `json:"command_nonzero_total"`
+	Tools               map[string]toolStat `json:"tools"`
+	SlowestToolCall     *toolCallTiming     `json:"slowest_tool_call,omitempty"`
+	Tokens              tokenBreakdown      `json:"tokens_estimated"`
+	Usage               *usage              `json:"usage,omitempty"`
+	Timing              timing              `json:"timing_ms"`
 }
 
 type toolStat struct {
-	Calls   int   `json:"calls"`
-	Errors  int   `json:"errors"`
-	TotalMs int64 `json:"total_ms"`
-	MaxMs   int64 `json:"max_ms"`
+	Calls int `json:"calls"`
+	// Errors and CommandNonzero split the same way the totals do.
+	Errors         int   `json:"errors"`
+	CommandNonzero int   `json:"command_nonzero"`
+	TotalMs        int64 `json:"total_ms"`
+	MaxMs          int64 `json:"max_ms"`
 }
 
 type toolCallTiming struct {
@@ -83,13 +91,21 @@ type sessionMessage struct {
 	Timestamp  time.Time `json:"timestamp"`
 	ToolCallID string    `json:"tool_call_id"`
 	IsError    bool      `json:"is_error"`
-	Blocks     []struct {
+	// ErrorKind is the server's own classification of IsError. A server that
+	// predates it sends nothing, and an absent kind stays an unclassified tool
+	// error: the driver never re-derives it from the message text.
+	ErrorKind string `json:"error_kind"`
+	Blocks    []struct {
 		Type      string         `json:"type"`
 		ID        string         `json:"id"`
 		Name      string         `json:"name"`
 		Arguments map[string]any `json:"arguments"`
 	} `json:"blocks"`
 }
+
+// errorKindCommandNonzero is the sessions API's name for "the command ran and
+// exited nonzero". Any other value, including an absent one, is a tool error.
+const errorKindCommandNonzero = "command_nonzero"
 
 // deriveMetrics walks the message timeline once. It is pure so the attribution
 // rules stay testable without a server.
@@ -143,8 +159,13 @@ func deriveMetrics(messages []sessionMessage) (metrics, []toolCall) {
 		}
 
 		if msg.Role == "tool" {
+			commandNonzero := msg.IsError && msg.ErrorKind == errorKindCommandNonzero
 			if msg.IsError {
-				m.ToolErrorTotal++
+				if commandNonzero {
+					m.CommandNonzeroTotal++
+				} else {
+					m.ToolErrorTotal++
+				}
 			}
 			if call, ok := pending[msg.ToolCallID]; ok {
 				delete(pending, msg.ToolCallID)
@@ -152,7 +173,13 @@ func deriveMetrics(messages []sessionMessage) (metrics, []toolCall) {
 				m.Timing.ToolMs += elapsed
 				stat := m.Tools[call.name]
 				if msg.IsError {
-					stat.Errors++
+					if commandNonzero {
+						stat.CommandNonzero++
+					} else {
+						stat.Errors++
+					}
+					// The call did not succeed either way; the evidence
+					// predicate cares about that, not about whose fault it was.
 					calls[call.index].IsError = true
 				}
 				stat.TotalMs += elapsed

--- a/cmd/stella-eval-agent/metrics_test.go
+++ b/cmd/stella-eval-agent/metrics_test.go
@@ -118,3 +118,55 @@ func TestDeriveMetricsMarksTheCallThatFailed(t *testing.T) {
 		t.Fatalf("error flag not attributed to the right call: %+v", calls)
 	}
 }
+
+// The counters split at the source: a bash call that exited nonzero is the
+// container answering and must never land in tool_error_total, which a failure
+// taxonomy reads as machinery breaking under the agent.
+func TestDeriveMetricsSplitsCommandExitsFromToolErrors(t *testing.T) {
+	var messages []sessionMessage
+	if err := json.Unmarshal([]byte(`[
+	  {"role":"assistant","timestamp":"2026-08-19T10:00:00Z","blocks":[{"type":"tool_call","id":"c1","name":"bash"}]},
+	  {"role":"tool","timestamp":"2026-08-19T10:00:01Z","tool_call_id":"c1","is_error":true,"error_kind":"command_nonzero"},
+	  {"role":"assistant","timestamp":"2026-08-19T10:00:02Z","blocks":[{"type":"tool_call","id":"c2","name":"edit"}]},
+	  {"role":"tool","timestamp":"2026-08-19T10:00:03Z","tool_call_id":"c2","is_error":true,"error_kind":"tool_error"},
+	  {"role":"assistant","timestamp":"2026-08-19T10:00:04Z","blocks":[{"type":"tool_call","id":"c3","name":"bash"}]},
+	  {"role":"tool","timestamp":"2026-08-19T10:00:05Z","tool_call_id":"c3"}
+	]`), &messages); err != nil {
+		t.Fatal(err)
+	}
+
+	m, calls := deriveMetrics(messages)
+
+	if m.ToolErrorTotal != 1 || m.CommandNonzeroTotal != 1 {
+		t.Errorf("totals = %d tool errors / %d command exits, want 1 / 1", m.ToolErrorTotal, m.CommandNonzeroTotal)
+	}
+	if got := m.Tools["bash"]; got.Errors != 0 || got.CommandNonzero != 1 {
+		t.Errorf("bash stat = %+v, want 0 errors and 1 command exit", got)
+	}
+	if got := m.Tools["edit"]; got.Errors != 1 || got.CommandNonzero != 0 {
+		t.Errorf("edit stat = %+v, want 1 error and 0 command exits", got)
+	}
+	// Neither call succeeded, and the evidence predicate reads that flag.
+	if !calls[0].IsError || !calls[1].IsError || calls[2].IsError {
+		t.Errorf("failure flags = %+v", calls)
+	}
+}
+
+// A server that predates error_kind sends none. Silence is not evidence that a
+// command exited nonzero, so those results stay tool errors and old trials keep
+// reading exactly as they did.
+func TestDeriveMetricsTreatsAMissingErrorKindAsAToolError(t *testing.T) {
+	var messages []sessionMessage
+	if err := json.Unmarshal([]byte(`[
+	  {"role":"assistant","timestamp":"2026-08-19T10:00:00Z","blocks":[{"type":"tool_call","id":"c1","name":"bash"}]},
+	  {"role":"tool","timestamp":"2026-08-19T10:00:01Z","tool_call_id":"c1","is_error":true}
+	]`), &messages); err != nil {
+		t.Fatal(err)
+	}
+
+	m, _ := deriveMetrics(messages)
+
+	if m.ToolErrorTotal != 1 || m.CommandNonzeroTotal != 0 || m.Tools["bash"].Errors != 1 {
+		t.Errorf("unclassified error was reinterpreted: %+v", m)
+	}
+}

--- a/internal/agent/sandbox/bash.go
+++ b/internal/agent/sandbox/bash.go
@@ -65,6 +65,13 @@ func (t *hostBashTool) Execute(ctx context.Context, args map[string]any) (string
 
 	norm := t.normalizer.NormalizeExec(result, time.Since(start))
 	if norm.IsError {
+		// A negative code is the kill sentinel, not a status the command chose:
+		// a signal, or a sandbox-policy deadline the caller never asked for and
+		// so never reaches the explicit-timeout branch above. Only a status the
+		// command actually returned is a command exit.
+		if result.ExitCode < 0 {
+			return redactSecretValues(norm.Content, secretValues), fmt.Errorf("bash: command was killed before it exited (code %d)", result.ExitCode)
+		}
 		// Typed, not formatted: the command ran and answered. Consumers that
 		// must tell that apart from a tool failure read the type, never the text.
 		return redactSecretValues(norm.Content, secretValues), &ai.CommandExitError{Tool: "bash", ExitCode: result.ExitCode}

--- a/internal/agent/sandbox/bash.go
+++ b/internal/agent/sandbox/bash.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/CherryHQ/stella/pkg/ai"
 	pkgsandbox "github.com/CherryHQ/stella/pkg/sandbox"
 	pkgtools "github.com/CherryHQ/stella/pkg/tools"
 )
@@ -64,7 +65,9 @@ func (t *hostBashTool) Execute(ctx context.Context, args map[string]any) (string
 
 	norm := t.normalizer.NormalizeExec(result, time.Since(start))
 	if norm.IsError {
-		return redactSecretValues(norm.Content, secretValues), fmt.Errorf("bash: exit code %d", result.ExitCode)
+		// Typed, not formatted: the command ran and answered. Consumers that
+		// must tell that apart from a tool failure read the type, never the text.
+		return redactSecretValues(norm.Content, secretValues), &ai.CommandExitError{Tool: "bash", ExitCode: result.ExitCode}
 	}
 	return redactSecretValues(norm.Content, secretValues), nil
 }

--- a/internal/agent/sandbox/bash_exit_test.go
+++ b/internal/agent/sandbox/bash_exit_test.go
@@ -40,3 +40,19 @@ func TestBashTimeoutIsNotACommandExit(t *testing.T) {
 		t.Fatalf("err = %v, want a plain timeout error", err)
 	}
 }
+
+// The sandbox enforces its own deadline whether or not the call asked for one,
+// and it reports that kill the same way: err nil, exit -1. Keying the
+// distinction on the caller's timeout argument would file every policy kill as
+// a command that ran and answered -1.
+func TestBashKillWithoutAnExplicitTimeoutIsNotACommandExit(t *testing.T) {
+	session := &bashSecretSession{Session: pkgsandbox.NopSession(), result: pkgsandbox.ExecResult{Stderr: "killed\n", ExitCode: -1}}
+	tool := newBashTool(session, "", NewSessionSecretValues())
+
+	_, err := tool.Execute(context.Background(), map[string]any{"command": "sleep 99"})
+
+	var exitErr *ai.CommandExitError
+	if err == nil || errors.As(err, &exitErr) {
+		t.Fatalf("err = %v (%T), want a plain kill error", err, err)
+	}
+}

--- a/internal/agent/sandbox/bash_exit_test.go
+++ b/internal/agent/sandbox/bash_exit_test.go
@@ -1,0 +1,42 @@
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/CherryHQ/stella/pkg/ai"
+	pkgsandbox "github.com/CherryHQ/stella/pkg/sandbox"
+)
+
+// The exit code has to leave the tool as a type. Every consumer that needed
+// "did the command fail or did the tool fail" was reading it back out of the
+// result text, and text is not a contract.
+func TestBashReportsANonzeroExitAsATypedError(t *testing.T) {
+	session := &bashSecretSession{Session: pkgsandbox.NopSession(), result: pkgsandbox.ExecResult{Stderr: "no such file\n", ExitCode: 2}}
+	tool := newBashTool(session, "", NewSessionSecretValues())
+
+	_, err := tool.Execute(context.Background(), map[string]any{"command": "cat missing"})
+
+	var exitErr *ai.CommandExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("err = %v (%T), want *ai.CommandExitError", err, err)
+	}
+	if exitErr.ExitCode != 2 || exitErr.Tool != "bash" {
+		t.Errorf("exit error = %+v, want bash exit 2", exitErr)
+	}
+}
+
+// A timeout is the harness killing the command, not the command answering, so
+// it must not arrive as a command exit.
+func TestBashTimeoutIsNotACommandExit(t *testing.T) {
+	session := &bashSecretSession{Session: pkgsandbox.NopSession(), result: pkgsandbox.ExecResult{ExitCode: -1}}
+	tool := newBashTool(session, "", NewSessionSecretValues())
+
+	_, err := tool.Execute(context.Background(), map[string]any{"command": "sleep 99", "timeout": 1})
+
+	var exitErr *ai.CommandExitError
+	if err == nil || errors.As(err, &exitErr) {
+		t.Fatalf("err = %v, want a plain timeout error", err)
+	}
+}

--- a/internal/memory/lcm/engine.go
+++ b/internal/memory/lcm/engine.go
@@ -139,11 +139,14 @@ type toolCallEnvelope struct {
 // and the provider's prompt cache stays valid. Result remains the flattened text
 // for backward compatibility and token estimation.
 type toolResultEnvelope struct {
-	ID         string                 `json:"id"`
-	Tool       string                 `json:"tool"`
-	Result     json.RawMessage        `json:"result"`
-	Error      string                 `json:"error,omitempty"`
-	IsError    bool                   `json:"is_error,omitempty"`
+	ID      string          `json:"id"`
+	Tool    string          `json:"tool"`
+	Result  json.RawMessage `json:"result"`
+	Error   string          `json:"error,omitempty"`
+	IsError bool            `json:"is_error,omitempty"`
+	// ErrorKind is absent on every row written before the split; a reader must
+	// treat absent as "unclassified", not as a command exit.
+	ErrorKind  ai.ToolErrorKind       `json:"error_kind,omitempty"`
 	Blocks     []contentBlockJSON     `json:"blocks,omitempty"`
 	References []renderrefs.Reference `json:"references,omitempty"`
 }
@@ -260,6 +263,7 @@ func canonicalMessageToRows(msg ai.Message) ([]storageRow, error) {
 			Tool:       m.ToolName,
 			Result:     resultJSON,
 			IsError:    m.IsError,
+			ErrorKind:  m.ErrorKind,
 			References: mergeReferences(m.References, fallbackRefs),
 		}
 		if m.IsError {
@@ -350,6 +354,7 @@ func toolResultToRows(m ai.ToolResultMessage) []storageRow {
 		Result:     resultJSON,
 		Error:      errStr,
 		IsError:    m.IsError,
+		ErrorKind:  m.ErrorKind,
 		References: refs,
 	}
 	if ai.HasImage(content) {
@@ -709,6 +714,7 @@ func rowToToolResult(msg sqlc.CtxMessage, partSets ...[]loadedMessagePart) ai.To
 		ToolName:   env.Tool,
 		Content:    content,
 		IsError:    env.IsError || env.Error != "",
+		ErrorKind:  env.ErrorKind,
 		References: env.References,
 	}
 }

--- a/internal/memory/lcm/lcm_helpers_test.go
+++ b/internal/memory/lcm/lcm_helpers_test.go
@@ -1112,3 +1112,27 @@ func TestSanitizeToolPairs_InProgressCallNotFinal(t *testing.T) {
 		t.Errorf("expected placeholder, got %v", cleaned.Content[0])
 	}
 }
+
+// The kind is what the sessions API forwards to the eval driver, so it has to
+// survive storage. An old row carries none, and a reader must leave it empty
+// rather than assume a default.
+func TestToolResultRoundTripsErrorKind(t *testing.T) {
+	rows := toolResultToRows(ai.ToolResultMessage{
+		ToolCallID: "c1", ToolName: "bash", IsError: true,
+		ErrorKind: ai.ToolErrorKindCommandNonzero,
+		Content:   []ai.ContentBlock{ai.TextContent{Text: "no such file"}},
+	})
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+	got := rowToToolResult(sqlc.CtxMessage{Role: "tool", EventType: eventTypeToolResult, Content: rows[0].content})
+	if got.ErrorKind != ai.ToolErrorKindCommandNonzero {
+		t.Errorf("error kind = %q, want %q", got.ErrorKind, ai.ToolErrorKindCommandNonzero)
+	}
+
+	legacy, _ := json.Marshal(toolResultEnvelope{ID: "c1", Tool: "bash", Error: "boom"})
+	got = rowToToolResult(sqlc.CtxMessage{Role: "tool", EventType: eventTypeToolResult, Content: string(legacy)})
+	if !got.IsError || got.ErrorKind != "" {
+		t.Errorf("pre-split row = (%v, %q), want an unclassified error", got.IsError, got.ErrorKind)
+	}
+}

--- a/internal/server/sessions.go
+++ b/internal/server/sessions.go
@@ -1385,6 +1385,7 @@ func serializeToolRow(agentID, sessionID string, row sessionaccess.Message) apit
 		Result     json.RawMessage        `json:"result"`
 		Error      string                 `json:"error,omitempty"`
 		IsError    bool                   `json:"is_error"`
+		ErrorKind  string                 `json:"error_kind,omitempty"`
 		References []renderrefs.Reference `json:"references,omitempty"`
 	}
 	if err := json.Unmarshal([]byte(row.Content), &env); err != nil {
@@ -1401,6 +1402,12 @@ func serializeToolRow(agentID, sessionID string, row sessionaccess.Message) apit
 	}
 	isError := env.IsError || env.Error != ""
 	message.ToolCallId, message.ToolName, message.IsError = &env.ID, &env.Tool, &isError
+	// Only forwarded when the row recorded it. Rows written before the split
+	// carry no kind, and inventing one here would turn "unknown" into a claim.
+	if isError && env.ErrorKind != "" {
+		kind := apitypes.SessionMessageErrorKind(env.ErrorKind)
+		message.ErrorKind = &kind
+	}
 	setSessionMessagePresentation(&message, agentID, sessionID, text, row.Parts)
 	if len(env.References) > 0 {
 		references := make([]apitypes.SessionMessageReference, 0, len(env.References))

--- a/internal/server/sessions_test.go
+++ b/internal/server/sessions_test.go
@@ -334,3 +334,23 @@ func TestSerializeAssistantRows_mergedFirstRowID(t *testing.T) {
 		t.Errorf("id = %v, want msg-a1 (first row of merged turn)", m.Id)
 	}
 }
+
+// The eval driver reads the split from this field, so the API has to forward
+// what the row recorded, and only that: a row written before the split says
+// nothing about why it failed, and the serializer must not fill in a guess.
+func TestSerializeToolRowForwardsErrorKind(t *testing.T) {
+	withKind, _ := json.Marshal(map[string]any{
+		"id": "c1", "tool": "bash", "result": "no such file",
+		"is_error": true, "error_kind": "command_nonzero",
+	})
+	m := serializeToolRow("agent", "session", sessionaccess.Message{Role: "tool", Content: string(withKind)})
+	if m.ErrorKind == nil || *m.ErrorKind != apitypes.CommandNonzero {
+		t.Errorf("error_kind = %v, want command_nonzero", m.ErrorKind)
+	}
+
+	legacy, _ := json.Marshal(map[string]any{"id": "c1", "tool": "bash", "result": "boom", "is_error": true})
+	m = serializeToolRow("agent", "session", sessionaccess.Message{Role: "tool", Content: string(legacy)})
+	if m.ErrorKind != nil {
+		t.Errorf("error_kind = %v on a pre-split row, want absent", *m.ErrorKind)
+	}
+}

--- a/pkg/agent/tool_execution.go
+++ b/pkg/agent/tool_execution.go
@@ -45,6 +45,7 @@ func executeToolCalls(ctx context.Context, calls []ai.ToolCall, tools ToolSet, c
 				ToolCallID: call.ID,
 				ToolName:   call.Name,
 				IsError:    true,
+				ErrorKind:  ai.ToolErrorKindTool,
 				Content:    []ai.ContentBlock{ai.TextContent{Text: "tool not found"}},
 			}
 			if err := appendFinal(result); err != nil {
@@ -148,6 +149,7 @@ func executeToolCalls(ctx context.Context, calls []ai.ToolCall, tools ToolSet, c
 		result := ai.ToolResultMessage{ToolCallID: call.ID, ToolName: call.Name, Content: content}
 		if err != nil {
 			result.IsError = true
+			result.ErrorKind = classifyToolError(err)
 			errText := err.Error()
 			if t := ai.FlattenText(content); t != "" {
 				errText = t + "\n" + errText
@@ -183,6 +185,13 @@ func executeToolCalls(ctx context.Context, calls []ai.ToolCall, tools ToolSet, c
 			}
 			if mutation.IsError != nil {
 				result.IsError = *mutation.IsError
+				// The lifecycle overrode the verdict, so the original reason no
+				// longer describes this result. An error it declared is a tool
+				// error; a success carries no kind.
+				result.ErrorKind = ""
+				if result.IsError {
+					result.ErrorKind = ai.ToolErrorKindTool
+				}
 			}
 		}
 
@@ -198,6 +207,17 @@ func executeToolCalls(ctx context.Context, calls []ai.ToolCall, tools ToolSet, c
 	}
 
 	return results, nil
+}
+
+// classifyToolError names the failure so downstream consumers never have to
+// read it out of the message text. A command that ran and exited nonzero is
+// the sandbox answering; everything else is the tool failing.
+func classifyToolError(err error) ai.ToolErrorKind {
+	var exitErr *ai.CommandExitError
+	if errors.As(err, &exitErr) {
+		return ai.ToolErrorKindCommandNonzero
+	}
+	return ai.ToolErrorKindTool
 }
 
 func replaceTextContent(blocks []ai.ContentBlock, text string) []ai.ContentBlock {

--- a/pkg/agent/tool_execution_test.go
+++ b/pkg/agent/tool_execution_test.go
@@ -327,3 +327,49 @@ func (h toolExecutionHook) OnPreToolCall(ctx context.Context, hctx *hooks.PreToo
 func (h toolExecutionHook) OnPostToolCall(ctx context.Context, hctx *hooks.PostToolCallContext) {
 	h.post(ctx, hctx)
 }
+
+// A command that ran and exited nonzero is the sandbox answering, not the tool
+// breaking. The distinction has to survive as a field: every consumer that
+// tried to recover it from the message text got it wrong.
+func TestToolExecutionClassifiesCommandExitSeparately(t *testing.T) {
+	calls := []ai.ToolCall{{ID: "1", Name: "bash"}, {ID: "2", Name: "edit"}}
+	tools := ToolSet{
+		"bash": func(context.Context, ai.ToolCall) ([]ai.ContentBlock, error) {
+			return []ai.ContentBlock{ai.TextContent{Text: "no such file"}}, &ai.CommandExitError{Tool: "bash", ExitCode: 2}
+		},
+		"edit": func(context.Context, ai.ToolCall) ([]ai.ContentBlock, error) {
+			return nil, errors.New("old_string not found")
+		},
+	}
+
+	results, err := executeToolCalls(context.Background(), calls, tools, toolCallbacks{}, nil, hooks.HookMeta{}, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if !results[0].IsError || results[0].ErrorKind != ai.ToolErrorKindCommandNonzero {
+		t.Errorf("nonzero exit = (%v, %q), want (true, %q)", results[0].IsError, results[0].ErrorKind, ai.ToolErrorKindCommandNonzero)
+	}
+	if !results[1].IsError || results[1].ErrorKind != ai.ToolErrorKindTool {
+		t.Errorf("tool failure = (%v, %q), want (true, %q)", results[1].IsError, results[1].ErrorKind, ai.ToolErrorKindTool)
+	}
+}
+
+// A tool that never failed carries no kind: an empty kind on a successful
+// result is the only value that cannot be misread as a claim.
+func TestToolExecutionLeavesSuccessUnclassified(t *testing.T) {
+	calls := []ai.ToolCall{{ID: "1", Name: "echo"}}
+	tools := ToolSet{"echo": func(context.Context, ai.ToolCall) ([]ai.ContentBlock, error) {
+		return []ai.ContentBlock{ai.TextContent{Text: "ok"}}, nil
+	}}
+
+	results, err := executeToolCalls(context.Background(), calls, tools, toolCallbacks{}, nil, hooks.HookMeta{}, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if results[0].ErrorKind != "" {
+		t.Errorf("successful result carries kind %q", results[0].ErrorKind)
+	}
+}

--- a/pkg/ai/message.go
+++ b/pkg/ai/message.go
@@ -185,6 +185,33 @@ type AssistantMessage struct {
 
 func (AssistantMessage) messageRole() string { return "assistant" }
 
+// ToolErrorKind says *why* a tool result is an error. "the tool failed" and
+// "the command ran and told us it failed" are different facts, and a consumer
+// that flattens them (an eval metric, a failure taxonomy) reports healthy
+// exploration as breakage. Empty on a successful result.
+type ToolErrorKind string
+
+const (
+	// ToolErrorKindTool is the default failure: the tool itself did not
+	// produce a usable result.
+	ToolErrorKindTool ToolErrorKind = "tool_error"
+	// ToolErrorKindCommandNonzero is a command that ran to completion inside
+	// the sandbox and exited nonzero. The tool worked; the command said no.
+	ToolErrorKindCommandNonzero ToolErrorKind = "command_nonzero"
+)
+
+// CommandExitError is returned by a tool whose command completed with a
+// nonzero exit status. It carries the distinction structurally so no consumer
+// has to parse it back out of the message text.
+type CommandExitError struct {
+	Tool     string
+	ExitCode int
+}
+
+func (e *CommandExitError) Error() string {
+	return fmt.Sprintf("%s: exit code %d", e.Tool, e.ExitCode)
+}
+
 // ToolResultMessage links a tool response to a tool call.
 type ToolResultMessage struct {
 	ToolCallID string
@@ -192,6 +219,10 @@ type ToolResultMessage struct {
 	Content    []ContentBlock // TextContent | ImageContent | ImageRefContent
 	Details    any
 	IsError    bool
+	// ErrorKind classifies IsError. It is empty on older records and on
+	// results written by code that predates the split; a reader must treat
+	// empty as "unclassified", never as ToolErrorKindCommandNonzero.
+	ErrorKind  ToolErrorKind
 	Timestamp  time.Time
 	References []renderrefs.Reference
 }

--- a/test/evals/harbor/README.md
+++ b/test/evals/harbor/README.md
@@ -102,7 +102,9 @@ not the machinery breaking, and only `errs` feeds the `execution` failure class.
 The driver classifies each result at the source, from the sessions API's
 `error_kind`, never by reading the message text. `cmd!0` shows `-`, never 0, for
 a trial archived before the split: those runs never measured it, and the report
-recounts their exits from the bridge ledger instead.
+recounts their exits from the bridge ledger instead. The per-tool table follows
+the same rule per column — one contributing trial without the count makes the
+whole total unknowable, so it prints `-` rather than a partial sum.
 
 The failure breakdown answers what a pass rate cannot: a run is not just "60%
 resolved", it is some mix of the agent running out of time, the machinery

--- a/test/evals/harbor/README.md
+++ b/test/evals/harbor/README.md
@@ -88,10 +88,21 @@ plus per-trial detail the terminal has no room for: the timing bar, phase
 breakdown, bridge operations, and the full bridge ledger.
 
 It prints one row per trial (reward, validity, terminal state, wall/model/tool/
-bridge time, turns, tool calls, tool errors, provider-reported tokens and cost),
-then the reliability summary: resolution rate with a 95% Wilson confidence
+bridge time, turns, tool calls, tool errors, nonzero command exits,
+provider-reported tokens and cost), then the reliability summary: resolution rate with a 95% Wilson confidence
 interval, pass^k across tasks, timeouts, every predicate violation, bridge
 adapter faults, a failure breakdown, and a per-tool cost table.
+
+`errs` and `cmd!0` are deliberately two columns. `errs` (`tool_error_total`) is
+the tool itself failing: an `edit` whose `old_string` did not match, a `read` of
+a path that does not exist. `cmd!0` (`command_nonzero_total`) is a command that
+ran to completion and exited nonzero: probing for a binary, a test suite failing
+before the fix, a `grep` that matched nothing. That is the container answering,
+not the machinery breaking, and only `errs` feeds the `execution` failure class.
+The driver classifies each result at the source, from the sessions API's
+`error_kind`, never by reading the message text. `cmd!0` shows `-`, never 0, for
+a trial archived before the split: those runs never measured it, and the report
+recounts their exits from the bridge ledger instead.
 
 The failure breakdown answers what a pass rate cannot: a run is not just "60%
 resolved", it is some mix of the agent running out of time, the machinery

--- a/test/evals/harbor/README.md
+++ b/test/evals/harbor/README.md
@@ -100,11 +100,14 @@ ran to completion and exited nonzero: probing for a binary, a test suite failing
 before the fix, a `grep` that matched nothing. That is the container answering,
 not the machinery breaking, and only `errs` feeds the `execution` failure class.
 The driver classifies each result at the source, from the sessions API's
-`error_kind`, never by reading the message text. `cmd!0` shows `-`, never 0, for
-a trial archived before the split: those runs never measured it, and the report
-recounts their exits from the bridge ledger instead. The per-tool table follows
-the same rule per column — one contributing trial without the count makes the
-whole total unknowable, so it prints `-` rather than a partial sum.
+`error_kind`, never by reading the message text. `cmd!0` shows `-`, never 0, whenever the
+trial did not measure the field: a Stella run archived before the split, or an
+agent that writes no adapter metrics at all (pi and anything else driven through
+Harbor alone). For a pre-split Stella trial the report recounts the exits from
+the bridge ledger instead; a non-Stella trial has nothing to recount and reports
+no tool counts either. The per-tool table follows the same rule per column — one
+contributing trial without the count makes the whole total unknowable, so it
+prints `-` rather than a partial sum.
 
 The failure breakdown answers what a pass rate cannot: a run is not just "60%
 resolved", it is some mix of the agent running out of time, the machinery

--- a/test/evals/harbor/stella_harbor/htmlreport.py
+++ b/test/evals/harbor/stella_harbor/htmlreport.py
@@ -37,7 +37,8 @@ HEADER_HELP = {
     "calls": "how many tool calls it made",
     "errs": "how many of those tool calls failed",
     "cmd!0": "commands that ran and exited nonzero — the container answering, not a tool failing; "
-             "– means the trial predates the split and never measured it",
+             "a dash means this trial never measured the field: a Stella run archived before the "
+             "split, or an agent that writes no adapter metrics. It never means zero",
     "in.tok": "prompt tokens, as reported by the provider",
     "out.tok": "completion tokens, as reported by the provider",
     "cost": "USD, priced at the model's configured rate. A dash means the provider "

--- a/test/evals/harbor/stella_harbor/htmlreport.py
+++ b/test/evals/harbor/stella_harbor/htmlreport.py
@@ -36,6 +36,8 @@ HEADER_HELP = {
     "turns": "how many times the model replied",
     "calls": "how many tool calls it made",
     "errs": "how many of those tool calls failed",
+    "cmd!0": "commands that ran and exited nonzero — the container answering, not a tool failing; "
+             "– means the trial predates the split and never measured it",
     "in.tok": "prompt tokens, as reported by the provider",
     "out.tok": "completion tokens, as reported by the provider",
     "cost": "USD, priced at the model's configured rate. A dash means the provider "
@@ -207,6 +209,7 @@ def render_html(rows: list[dict[str, Any]], job_dir: str = "") -> str:
         _secs(r["bridge_ms"]), str(r["turns"] if r["turns"] is not None else "-"),
         str(r["calls"] if r["calls"] is not None else "-"),
         f'<span class="{"bad-text" if r["tool_errors"] else ""}">{r["tool_errors"] if r["tool_errors"] is not None else "-"}</span>',
+        str(r["command_nonzero_total"]) if r.get("command_nonzero_total") is not None else "-",
         _int((r.get("usage") or {}).get("input_tokens")),
         _int((r.get("usage") or {}).get("output_tokens")),
         _usd((r.get("usage") or {}).get("cost_usd")),
@@ -293,7 +296,7 @@ a task succeeded, which is what separates a capability from a lucky run.</p>
 
 {failure_block}
 <h2>Trials</h2>
-{_table(["task", "reward", "valid", "state", "wall", "model", "tool", "bridge", "turns", "calls", "errs", "est.tok"], trial_rows)}
+{_table(["task", "reward", "valid", "state", "wall", "model", "tool", "bridge", "turns", "calls", "errs", "cmd!0", "est.tok"], trial_rows)}
 <h2>Per task</h2>
 {_table(["task", "trials", "scoreable", "resolved", "pass^k"], task_rows)}
 <h2>Tool cost</h2>

--- a/test/evals/harbor/stella_harbor/report.py
+++ b/test/evals/harbor/stella_harbor/report.py
@@ -106,11 +106,13 @@ def collect(job_dir: Path) -> list[dict[str, Any]]:
             "calls": metrics.get("tool_call_total"),
             "tool_errors": metrics.get("tool_error_total"),
             # command_nonzero_total is the driver's own split: commands that ran
-            # and exited nonzero, already kept out of tool_error_total. It is
-            # None on trials archived before the split, and None is not 0 —
-            # those trials never measured it, so nothing here may claim they
-            # saw none. command_nonzero stays the ledger's recount, which is the
-            # only number those older trials have.
+            # and exited nonzero, already kept out of tool_error_total. None
+            # means the trial never measured it — a Stella run archived before
+            # the split, or an agent that writes no adapter metrics at all —
+            # and None is not 0, so nothing here may claim they saw none.
+            # command_nonzero stays the ledger's recount, which is the only
+            # number a pre-split Stella trial has; a non-Stella trial has no
+            # ledger and no tool counts to correct.
             "command_nonzero_total": metrics.get("command_nonzero_total"),
             "command_nonzero": nonzero,
             "command_timeout": timeouts,
@@ -226,7 +228,8 @@ def render(rows: list[dict[str, Any]]) -> str:
             _seconds(row["bridge_ms"]), str(row["turns"] if row["turns"] is not None else "-"),
             str(row["calls"] if row["calls"] is not None else "-"),
             str(row["tool_errors"] if row["tool_errors"] is not None else "-"),
-            # "-", never 0: a trial archived before the split did not measure this.
+            # "-", never 0: this trial did not measure the field (pre-split
+            # Stella archive, or an agent with no adapter metrics).
             _int(row.get("command_nonzero_total")),
             _int((row.get("usage") or {}).get("input_tokens")),
             _int((row.get("usage") or {}).get("output_tokens")),
@@ -279,9 +282,10 @@ def render(rows: list[dict[str, Any]]) -> str:
                                           "command_nonzero_known": True, "total_ms": 0, "max_ms": 0})
             agg["calls"] += stat.get("calls", 0)
             agg["errors"] += stat.get("errors", 0)
-            # A pre-split trial carries no per-tool count. One of those in the
-            # job makes the whole column unknowable: adding the rest and
-            # printing the sum would pass a partial number off as the total.
+            # A trial that never measured the split carries no per-tool count.
+            # One of those in the job makes the whole column unknowable: adding
+            # the rest and printing the sum would pass a partial number off as
+            # the total.
             if "command_nonzero" in stat:
                 agg["command_nonzero"] += stat.get("command_nonzero") or 0
             else:

--- a/test/evals/harbor/stella_harbor/report.py
+++ b/test/evals/harbor/stella_harbor/report.py
@@ -23,7 +23,7 @@ from .taxonomy import breakdown
 TRIAL_COLUMNS = [
     ("task", 24), ("reward", 6), ("valid", 5), ("state", 9), ("wall", 7),
     ("model", 7), ("tool", 7), ("bridge", 7), ("turns", 5), ("calls", 5),
-    ("errs", 4), ("in.tok", 8), ("out.tok", 8), ("cost", 8),
+    ("errs", 4), ("cmd!0", 5), ("in.tok", 8), ("out.tok", 8), ("cost", 8),
 ]
 
 # Terminal-Bench scores a trial as resolved only on a full reward.
@@ -105,11 +105,13 @@ def collect(job_dir: Path) -> list[dict[str, Any]]:
             "turns": metrics.get("turns"),
             "calls": metrics.get("tool_call_total"),
             "tool_errors": metrics.get("tool_error_total"),
-            # tool_error_total flags every tool message the runtime marked as an
-            # error, and a nonzero command exit is one of those. Subtracting what
-            # the ledger proves was the container answering leaves the calls that
-            # actually failed, which is the only number a failure taxonomy may
-            # read. Both are reported: exploration is signal, not noise.
+            # command_nonzero_total is the driver's own split: commands that ran
+            # and exited nonzero, already kept out of tool_error_total. It is
+            # None on trials archived before the split, and None is not 0 —
+            # those trials never measured it, so nothing here may claim they
+            # saw none. command_nonzero stays the ledger's recount, which is the
+            # only number those older trials have.
+            "command_nonzero_total": metrics.get("command_nonzero_total"),
             "command_nonzero": nonzero,
             "command_timeout": timeouts,
             "tool_faults": _tool_faults(metrics, nonzero + timeouts),
@@ -150,10 +152,19 @@ def _command_outcomes(metrics: dict[str, Any], ledger: list[dict[str, Any]]) -> 
 
 
 def _tool_faults(metrics: dict[str, Any], explained: int) -> int | None:
-    """Tool calls that failed, with nonzero command exits taken back out."""
+    """Tool calls that actually failed — the only number the taxonomy may read.
+
+    A trial from a driver that splits the counters needs no correction: its
+    tool_error_total already excludes commands that merely exited nonzero.
+    Older trials get the historical treatment, the ledger's count subtracted
+    back out, because that is the best evidence they carry and re-reading them
+    under the new rule would rewrite what those runs measured.
+    """
     errors = metrics.get("tool_error_total")
     if errors is None:
         return None
+    if metrics.get("command_nonzero_total") is not None:
+        return errors
     return max(0, errors - explained)
 
 
@@ -215,6 +226,8 @@ def render(rows: list[dict[str, Any]]) -> str:
             _seconds(row["bridge_ms"]), str(row["turns"] if row["turns"] is not None else "-"),
             str(row["calls"] if row["calls"] is not None else "-"),
             str(row["tool_errors"] if row["tool_errors"] is not None else "-"),
+            # "-", never 0: a trial archived before the split did not measure this.
+            _int(row.get("command_nonzero_total")),
             _int((row.get("usage") or {}).get("input_tokens")),
             _int((row.get("usage") or {}).get("output_tokens")),
             _usd((row.get("usage") or {}).get("cost_usd")),
@@ -259,29 +272,43 @@ def render(rows: list[dict[str, Any]]) -> str:
         if row["violations"]:
             lines.append(f"  {row['task']}: invalid — {'; '.join(row['violations'])}")
 
-    tools: dict[str, dict[str, int]] = {}
+    tools: dict[str, dict[str, Any]] = {}
     for row in rows:
         for name, stat in row["tools"].items():
-            agg = tools.setdefault(name, {"calls": 0, "errors": 0, "total_ms": 0, "max_ms": 0})
+            agg = tools.setdefault(name, {"calls": 0, "errors": 0, "command_nonzero": None,
+                                          "total_ms": 0, "max_ms": 0})
             agg["calls"] += stat.get("calls", 0)
             agg["errors"] += stat.get("errors", 0)
+            # Absent on a pre-split trial. Summing it as 0 would let one old
+            # trial in a mixed job quietly deflate the column.
+            if "command_nonzero" in stat:
+                agg["command_nonzero"] = (agg["command_nonzero"] or 0) + (stat.get("command_nonzero") or 0)
             agg["total_ms"] += stat.get("total_ms", 0)
             agg["max_ms"] = max(agg["max_ms"], stat.get("max_ms", 0))
     if tools:
         lines.append("")
-        lines.append("tool                 calls  errs  total    slowest")
+        lines.append("tool                 calls  errs  cmd!0  total    slowest")
         for name in sorted(tools, key=lambda n: -tools[n]["total_ms"]):
             stat = tools[name]
             lines.append(
                 f"{name[:20]:20} {stat['calls']:5}  {stat['errors']:4}  "
+                f"{_int(stat['command_nonzero']):5}  "
                 f"{_seconds(stat['total_ms']):7}  {_seconds(stat['max_ms'])}")
-        nonzero = sum(r.get("command_nonzero") or 0 for r in rows)
-        timeouts = sum(r.get("command_timeout") or 0 for r in rows)
-        if nonzero or timeouts:
+        split = [r for r in rows if r.get("command_nonzero_total") is not None]
+        legacy = [r for r in rows if r.get("command_nonzero_total") is None]
+        if split:
             lines.append(
-                f"of those errs, {nonzero} are commands that exited nonzero and {timeouts} timed out."
-                " Those are the container answering, not tools failing, and the failure"
-                " classes below already exclude them.")
+                f"errs counts tools that failed. cmd!0 is the {sum(r['command_nonzero_total'] for r in split)}"
+                " command(s) that ran and exited nonzero across those trials — the container"
+                " answering, not a tool failing — and the failure classes below exclude them.")
+        if legacy:
+            nonzero = sum(r.get("command_nonzero") or 0 for r in legacy)
+            timeouts = sum(r.get("command_timeout") or 0 for r in legacy)
+            if nonzero or timeouts:
+                lines.append(
+                    f"{len(legacy)} trial(s) predate the split, so their errs still include"
+                    f" {nonzero} nonzero exit(s) and {timeouts} timeout(s) recounted from the"
+                    " bridge ledger; the failure classes below subtract those instead.")
 
     failures = [b for b in breakdown(rows) if b["label"] not in {"resolved", "invalid"}]
     if failures:

--- a/test/evals/harbor/stella_harbor/report.py
+++ b/test/evals/harbor/stella_harbor/report.py
@@ -275,14 +275,17 @@ def render(rows: list[dict[str, Any]]) -> str:
     tools: dict[str, dict[str, Any]] = {}
     for row in rows:
         for name, stat in row["tools"].items():
-            agg = tools.setdefault(name, {"calls": 0, "errors": 0, "command_nonzero": None,
-                                          "total_ms": 0, "max_ms": 0})
+            agg = tools.setdefault(name, {"calls": 0, "errors": 0, "command_nonzero": 0,
+                                          "command_nonzero_known": True, "total_ms": 0, "max_ms": 0})
             agg["calls"] += stat.get("calls", 0)
             agg["errors"] += stat.get("errors", 0)
-            # Absent on a pre-split trial. Summing it as 0 would let one old
-            # trial in a mixed job quietly deflate the column.
+            # A pre-split trial carries no per-tool count. One of those in the
+            # job makes the whole column unknowable: adding the rest and
+            # printing the sum would pass a partial number off as the total.
             if "command_nonzero" in stat:
-                agg["command_nonzero"] = (agg["command_nonzero"] or 0) + (stat.get("command_nonzero") or 0)
+                agg["command_nonzero"] += stat.get("command_nonzero") or 0
+            else:
+                agg["command_nonzero_known"] = False
             agg["total_ms"] += stat.get("total_ms", 0)
             agg["max_ms"] = max(agg["max_ms"], stat.get("max_ms", 0))
     if tools:
@@ -292,7 +295,7 @@ def render(rows: list[dict[str, Any]]) -> str:
             stat = tools[name]
             lines.append(
                 f"{name[:20]:20} {stat['calls']:5}  {stat['errors']:4}  "
-                f"{_int(stat['command_nonzero']):5}  "
+                f"{_int(stat['command_nonzero'] if stat['command_nonzero_known'] else None):5}  "
                 f"{_seconds(stat['total_ms']):7}  {_seconds(stat['max_ms'])}")
         split = [r for r in rows if r.get("command_nonzero_total") is not None]
         legacy = [r for r in rows if r.get("command_nonzero_total") is None]

--- a/test/evals/harbor/stella_harbor/report.py
+++ b/test/evals/harbor/stella_harbor/report.py
@@ -298,7 +298,11 @@ def render(rows: list[dict[str, Any]]) -> str:
                 f"{_int(stat['command_nonzero'] if stat['command_nonzero_known'] else None):5}  "
                 f"{_seconds(stat['total_ms']):7}  {_seconds(stat['max_ms'])}")
         split = [r for r in rows if r.get("command_nonzero_total") is not None]
-        legacy = [r for r in rows if r.get("command_nonzero_total") is None]
+        # A trial with no tool-error count at all is not an old Stella trial,
+        # it is another agent (pi has no Stella adapter file). It has nothing
+        # to correct and must not be described as predating the split.
+        legacy = [r for r in rows
+                  if r.get("command_nonzero_total") is None and r.get("tool_errors") is not None]
         if split:
             lines.append(
                 f"errs counts tools that failed. cmd!0 is the {sum(r['command_nonzero_total'] for r in split)}"

--- a/test/evals/harbor/stella_harbor/taxonomy.py
+++ b/test/evals/harbor/stella_harbor/taxonomy.py
@@ -50,10 +50,12 @@ def classify(row: dict[str, Any]) -> tuple[str, str]:
         return "execution", str(detail)[:200]
 
     calls = row.get("calls") or 0
-    # Not tool_errors: that number counts a nonzero command exit as a tool
-    # failure, so a healthy run that probed the image would be labelled an
-    # execution failure. tool_faults is the same count with the container's own
-    # answers removed.
+    # tool_faults only: tool calls that actually failed. On a current trial the
+    # driver already split them out of tool_error_total (command_nonzero_total
+    # holds the rest); on an archived one the report subtracts the bridge
+    # ledger's count back out. Reading tool_errors here would label a healthy
+    # run that probed the image an execution failure. The fallback is for a row
+    # that carries neither, which no report produces.
     errors = row.get("tool_faults")
     if errors is None:
         errors = row.get("tool_errors") or 0

--- a/test/evals/harbor/tests/test_report.py
+++ b/test/evals/harbor/tests/test_report.py
@@ -376,3 +376,27 @@ def test_report_will_not_total_a_tool_column_one_trial_never_measured(tmp_path):
     # Both notes appear: the job genuinely holds trials of both kinds.
     assert "1 command(s) that ran and exited nonzero" in out
     assert "1 trial(s) predate the split" in out
+
+
+def test_report_does_not_call_a_non_stella_trial_pre_split(tmp_path):
+    """A pi trial has no Stella counters at all; it has nothing to correct."""
+    pi = tmp_path / "2026-08-21__08-00-00" / "regex-log__xyz"
+    pi.mkdir(parents=True)
+    (pi / "result.json").write_text(json.dumps({
+        "verifier_result": {"rewards": {"reward": 1.0}},
+        "agent_result": {"n_input_tokens": 100, "n_output_tokens": 10, "cost_usd": 0.001},
+    }))
+    write_trial(tmp_path, "old", {"verifier_result": {"rewards": {"reward": 0.0}}}, {
+        "valid": True, "turn_terminal_state": "completed",
+        "metrics": {
+            "tool_call_total": 3, "tool_error_total": 2,
+            "tools": {"bash": {"calls": 3, "errors": 2, "total_ms": 20, "max_ms": 9}},
+            "bridge": {"total_ms": 20, "operations": {}, "adapter_faults": []},
+        },
+        "bridge_ledger": [{"op": "exec", "ok": True, "return_code": 1}],
+    }, run="2026-08-21__09-00-00", suffix="def")
+
+    out = render(collect(tmp_path))
+
+    # One trial predates the split; the pi trial is not counted among them.
+    assert "1 trial(s) predate the split" in out

--- a/test/evals/harbor/tests/test_report.py
+++ b/test/evals/harbor/tests/test_report.py
@@ -268,3 +268,75 @@ def test_report_falls_back_to_harbor_usage_for_non_stella_agents(tmp_path):
     # Harbor's reward is the only validity evidence such a trial has; dropping it
     # as "invalid" would report a complete run as unscoreable.
     assert "1/1 trials" in out and "invalid" not in out
+
+
+def test_report_keeps_the_drivers_split_without_subtracting_twice(tmp_path):
+    """A trial from the split driver is already correct; do not correct it again."""
+    write_trial(tmp_path, "probe", {"verifier_result": {"rewards": {"reward": 0.0}}}, {
+        "valid": True,
+        "turn_terminal_state": "completed",
+        "metrics": {
+            "tool_call_total": 10,
+            # already excludes the nonzero exits
+            "tool_error_total": 2,
+            "command_nonzero_total": 7,
+            "tools": {"bash": {"calls": 8, "errors": 0, "command_nonzero": 7, "total_ms": 10, "max_ms": 5},
+                      "edit": {"calls": 2, "errors": 2, "command_nonzero": 0, "total_ms": 4, "max_ms": 3}},
+            "bridge": {"total_ms": 10, "operations": {}, "adapter_faults": [],
+                       "command_nonzero": 7, "command_timeout": 0},
+        },
+    })
+
+    row = collect(tmp_path)[0]
+
+    assert row["command_nonzero_total"] == 7
+    assert row["tool_errors"] == 2
+    # Not 2 - 7 clamped to 0: the driver already took the exits out.
+    assert row["tool_faults"] == 2
+
+    out = render([row])
+    assert "cmd!0" in out
+    assert "7 command(s) that ran and exited nonzero" in out
+
+
+def test_report_shows_a_dash_when_the_trial_predates_the_split(tmp_path):
+    """None is not zero: an old trial never measured the new field."""
+    write_trial(tmp_path, "legacy", {"verifier_result": {"rewards": {"reward": 0.0}}}, {
+        "valid": True,
+        "turn_terminal_state": "completed",
+        "metrics": {
+            "tool_call_total": 4,
+            "tool_error_total": 3,
+            "tools": {"bash": {"calls": 4, "errors": 3, "total_ms": 10, "max_ms": 5}},
+            "bridge": {"total_ms": 10, "operations": {}, "adapter_faults": []},
+        },
+        "bridge_ledger": [{"op": "exec", "ok": True, "return_code": 1}],
+    })
+
+    rows = collect(tmp_path)
+
+    assert rows[0]["command_nonzero_total"] is None
+    # Unchanged behavior for archived data: the ledger recount is still applied.
+    assert rows[0]["tool_faults"] == 2
+
+    out = render(rows)
+    trial_line = next(line for line in out.splitlines() if line.startswith("legacy"))
+    # errs then cmd!0: three real errors, and no claim at all about the split.
+    assert " 3     -  " in trial_line
+    assert "predate the split" in out
+
+
+def test_taxonomy_reads_the_drivers_split_count_directly():
+    from stella_harbor.taxonomy import classify
+
+    # Every call failed, all of them tool faults: still an execution failure.
+    label, why = classify({"valid": True, "reward": 0.0, "state": "completed", "calls": 3,
+                           "tool_errors": 3, "tool_faults": 3, "command_nonzero_total": 0})
+    assert label == "execution"
+    assert "3 tool calls failed" in why
+
+    # Same trial shape, but the failures were commands exiting nonzero, which
+    # the driver already kept out of tool_error_total.
+    label, _ = classify({"valid": True, "reward": 0.0, "state": "completed", "calls": 3,
+                         "tool_errors": 0, "tool_faults": 0, "command_nonzero_total": 3})
+    assert label == "verification"

--- a/test/evals/harbor/tests/test_report.py
+++ b/test/evals/harbor/tests/test_report.py
@@ -340,3 +340,39 @@ def test_taxonomy_reads_the_drivers_split_count_directly():
     label, _ = classify({"valid": True, "reward": 0.0, "state": "completed", "calls": 3,
                          "tool_errors": 0, "tool_faults": 0, "command_nonzero_total": 3})
     assert label == "verification"
+
+
+def test_report_will_not_total_a_tool_column_one_trial_never_measured(tmp_path):
+    """Mixed old and new trials: a partial sum is not the total."""
+    write_trial(tmp_path, "new", {"verifier_result": {"rewards": {"reward": 0.0}}}, {
+        "valid": True, "turn_terminal_state": "completed",
+        "metrics": {
+            "tool_call_total": 2, "tool_error_total": 0, "command_nonzero_total": 1,
+            "tools": {"bash": {"calls": 2, "errors": 0, "command_nonzero": 1, "total_ms": 10, "max_ms": 5},
+                      "edit": {"calls": 1, "errors": 1, "command_nonzero": 0, "total_ms": 2, "max_ms": 2}},
+            "bridge": {"total_ms": 10, "operations": {}, "adapter_faults": []},
+        },
+    })
+    write_trial(tmp_path, "old", {"verifier_result": {"rewards": {"reward": 0.0}}}, {
+        "valid": True, "turn_terminal_state": "completed",
+        "metrics": {
+            "tool_call_total": 3, "tool_error_total": 2,
+            # pre-split: bash carries no per-tool command_nonzero at all
+            "tools": {"bash": {"calls": 3, "errors": 2, "total_ms": 20, "max_ms": 9}},
+            "bridge": {"total_ms": 20, "operations": {}, "adapter_faults": []},
+        },
+        "bridge_ledger": [{"op": "exec", "ok": True, "return_code": 1}],
+    }, suffix="def")
+
+    out = render(collect(tmp_path))
+
+    bash_line = next(line for line in out.splitlines() if line.startswith("bash "))
+    # 5 calls, 2 errors, and no cmd!0 total: one trial never measured it, so
+    # the new trial's 1 is not the column's answer.
+    assert bash_line.split()[:4] == ["bash", "5", "2", "-"]
+    # edit was only ever seen by the split trial, so its count is knowable.
+    edit_line = next(line for line in out.splitlines() if line.startswith("edit "))
+    assert edit_line.split()[:4] == ["edit", "1", "1", "0"]
+    # Both notes appear: the job genuinely holds trials of both kinds.
+    assert "1 command(s) that ran and exited nonzero" in out
+    assert "1 trial(s) predate the split" in out


### PR DESCRIPTION
## What

`tool_error_total` (and the per-tool `errors` count) counted a bash call that ran and exited nonzero as a tool failure. `taxonomy.py`'s `execution` class reads that number, so a 25/25 baseline with zero exceptions reported 81 tool errors and a failure label a reader would trust.

## How

Split the two facts at the source, never from message text:

- `internal/agent/sandbox/bash.go` returns a typed `ai.CommandExitError{Tool, ExitCode}` for a nonzero exit. A timeout stays an ordinary tool error: that is the harness killing the command, not the command answering.
- `pkg/agent/tool_execution.go` classifies the failure into the new `ai.ToolResultMessage.ErrorKind` (`tool_error` | `command_nonzero`). A lifecycle hook that overrides the verdict resets it to `tool_error`.
- `internal/memory/lcm` persists `error_kind` in the tool-result envelope and reads it back.
- The sessions API exposes `error_kind` on a tool message (`api/spec/domain/sessions/schemas.yaml`), forwarded only when the row recorded one.
- `cmd/stella-eval-agent` emits `tool_error_total` and `command_nonzero_total` as separate metrics, with the same split per tool (`tools[].errors` / `tools[].command_nonzero`). `stella_tool_calls[].is_error` is unchanged: the evidence predicate cares that a call did not succeed, not whose fault it was.

## Field semantics

- `tool_error_total` — the tool itself failed: `edit`'s `old_string` did not match, `read` on a missing path, an exec that never reached the sandbox.
- `command_nonzero_total` — the command ran to completion and exited nonzero: probing for a binary, a test suite failing before the fix, a `grep` that matched nothing. The container answering, not machinery breaking.
- Only `tool_error_total` (via `tool_faults`) feeds the `execution` failure class. `report.py` shows both as `errs` and `cmd!0`, in the terminal table, the per-tool table, and the HTML report.

## Compatibility

Archived trials predate both fields, and absence is not zero:

- A tool message with `is_error` and no `error_kind` stays an unclassified **tool** error. The driver never re-derives the kind.
- `cmd!0` renders `-`, never `0`, when `command_nonzero_total` is missing.
- For those records the report keeps its current behavior: the bridge ledger's recount is subtracted back out of `tool_error_total` to get `tool_faults`, so the taxonomy labels them exactly as before. New records are used as-is, with no second subtraction.

## Verification

- `mise run format && mise run build && mise run test` — pass.
- `uv run --project test/evals/harbor pytest` — 71 passed.
- New Go tests: the driver's split and its missing-field path, the bash typed exit error (and that a timeout is not one), the runner's classification, the storage round-trip, and the API serializer's forward-only rule.
- New Python tests: the driver-split path (no double subtraction), the archived path (`-`, ledger recount preserved), and the taxonomy on both.
- Sanity: unpacked `results/terminal-bench-2.1/2026-08-20-luna-vs-pi/luna-k5-results.tgz` and rendered `python -m stella_harbor.report` over it — 377 trials, no crash, `-` in every `cmd!0` cell, failure breakdown unchanged.

Fixes #1077
Refs #1054

## Feishu Task

- [评测指标不再把命令非零退出计为工具错误](https://mcnnox2fhjfq.feishu.cn/record/DVPhr3yZLeNhJCcvvhXcTJH3nTf) (#1077)
- [Terminal-Bench Harbor 基线接入](https://mcnnox2fhjfq.feishu.cn/record/LsGDrpS8XexX5RcCzrPcEy8MnUS) (#1054)