### PR TITLE
✨ evals: implement the loop comparator

### DIFF
--- a/test/evals/harbor/PROTOCOL.md
+++ b/test/evals/harbor/PROTOCOL.md
@@ -70,6 +70,9 @@ headline rate: the loop's trial counts are far too small for one.
     as such.
 - Only CONFIRMED_REGRESSION exits nonzero.
 
+The comparator's first argument is always the candidate and its second the
+reference, and the report header names both roles; no role is ever inferred.
+
 ## Process metrics
 
 At loop scale, process metrics are the primary signal: resolution is 0/1 with
@@ -85,8 +88,12 @@ while resolution stands still (#1076's case: fewer wasted edits at the same
    runs the amd64 task images under emulation; timing there is noise).
 
 All tiers are displayed. **EFFICIENCY_SIGNAL** triggers on exactly two
-metrics: provider-reported cost, and per-tool error counts. The computation
-is frozen: per task and side, take the mean over valid trials; the delta is
+metrics: provider-reported cost, and per-tool error counts, judged per tool
+name — any single tool crossing the threshold triggers; there is no
+aggregate-errors metric. Error counts recorded before #1077 fold command
+exits in, so they are displayed with a marker and never judged. The
+computation is frozen: per task and side, take the mean over valid trials; the
+delta is
 `(candidate - reference) / reference`; a reference mean of zero or a missing
 value leaves that metric unjudged for that task. A task whose resolved count
 is unchanged but whose judged delta exceeds 25% in either direction is an
@@ -101,7 +108,11 @@ Sides run as whole jobs, sequentially, on one machine. The mitigations are
 part of the protocol, not advice: task images are pulled before either side
 runs, so neither side pays the cold cache; every trial records its duration
 and timeout class; and a delta whose only outcome change is a timeout-class
-flip is marked untrusted rather than judged.
+flip is marked untrusted rather than judged. Trials within a task are not
+paired, so the flip test is count-based: the timeout-class distribution
+changed between the sides, and the change in timed-out trials is at least the
+size of the resolved delta. A flip so detected marks the task untrusted; it
+is listed, never folded into a verdict.
 
 The timeout classes are frozen, one per trial, by the first matching rule:
 

--- a/test/evals/harbor/PROTOCOL.md
+++ b/test/evals/harbor/PROTOCOL.md
@@ -110,9 +110,9 @@ runs, so neither side pays the cold cache; every trial records its duration
 and timeout class; and a delta whose only outcome change is a timeout-class
 flip is marked untrusted rather than judged. Trials within a task are not
 paired, so the flip test is count-based: the timeout-class distribution
-changed between the sides, and the change in timed-out trials is at least the
-size of the resolved delta. A flip so detected marks the task untrusted; it
-is listed, never folded into a verdict.
+changed between the sides, the timed-out count moved opposite to the resolved
+delta, and its change is at least the delta's size. A flip so detected marks
+the task untrusted; it is listed, never folded into a verdict.
 
 The timeout classes are frozen, one per trial, by the first matching rule:
 
@@ -134,6 +134,10 @@ comparison to fix the concurrency setting.
 
 - Efficiency threshold: 25% paired per-task delta, either direction.
 - Loop k: 3. Concurrency: 4, pending the pilot.
+
+The comparator reads k from the jobs' recorded attempt budget; a command-line
+k may only fill in a budget the artifacts never recorded, never override one
+they did.
 
 ## Manifest
 

--- a/test/evals/harbor/README.md
+++ b/test/evals/harbor/README.md
@@ -229,15 +229,19 @@ uv run --project test/evals/harbor python -m stella_harbor.compare   dist/evals/
   task-set dimension is relaxed — model and dataset stay hard.
 - **k comes from the run budget** (`n_attempts`); `--k` only fills in a budget
   the artifacts never recorded and is refused when it conflicts with one they
-  did. A task is judged only when both sides hold exactly k scoreable trials;
+  did. An unrecorded budget is otherwise a blocking fingerprint issue, so `--k`
+  is what makes an archived run comparable; it answers that one question and
+  no other, and any further mismatch still refuses. A task is judged only when both sides hold exactly k scoreable trials;
   anything else prints `INSUFFICIENT_EVIDENCE` and is excluded from every
   verdict.
 - **A side may span several jobs.** Repeat `--candidate-job` / `--reference-job`
   when a side's k trials were topped up in a second run. Every path is still
   named explicitly; nothing defaults to the latest directory. A top-up passes
   the same identity validation as a positional job, the attempt budget being
-  the one permitted difference, and the same run or trial offered twice is
-  refused rather than counted twice.
+  the one permitted difference: every other field, agent identity included,
+  must be present and identical, because a top-up whose build cannot be
+  verified is trials of unknown provenance joining a denominator. The same run
+  or trial offered twice is refused rather than counted twice.
 - **Verdicts.** Any per-task movement is a `SIGNAL`. A guard (a task the
   reference resolved k of k) falling below k/k, or any task down two or more
   resolved, is a `SUSPECTED_REGRESSION`. Neither gates: the default mode always

--- a/test/evals/harbor/README.md
+++ b/test/evals/harbor/README.md
@@ -254,8 +254,9 @@ uv run --project test/evals/harbor python -m stella_harbor.compare   dist/evals/
   two or more resolved apart is `CONFIRMED_REGRESSION` or
   `CONFIRMED_IMPROVEMENT`, anything weaker is `DISMISSED` with both counts. Only
   `CONFIRMED_REGRESSION` exits nonzero. An `UNTRUSTED` task confirms nothing,
-  and `--allow-mismatch` is refused outright: an exploratory comparison can
-  never gate.
+  `--allow-mismatch` is refused outright, and a top-up carrying an `unrecorded`
+  identity field is refused too: an identity nobody records is tolerable in a
+  report and not underneath the one verdict that gates.
 - **Process metrics** print in the protocol's three trust tiers: behavioral
   (tool calls, per-tool error counts, turns), gateway-reported (tokens, cost),
   and wall time, which is displayed and never judged. Error counts from before

--- a/test/evals/harbor/README.md
+++ b/test/evals/harbor/README.md
@@ -238,10 +238,14 @@ uv run --project test/evals/harbor python -m stella_harbor.compare   dist/evals/
   when a side's k trials were topped up in a second run. Every path is still
   named explicitly; nothing defaults to the latest directory. A top-up passes
   the same identity validation as a positional job, the attempt budget being
-  the one permitted difference: every other field, agent identity included,
-  must be present and identical, because a top-up whose build cannot be
-  verified is trials of unknown provenance joining a denominator. The same run
-  or trial offered twice is refused rather than counted twice.
+  the one permitted difference. Every other field is judged in three states:
+  both jobs recorded it and the values differ, or one recorded it and the other
+  carries no evidence at all, are both refused; a field neither job ever
+  recorded is reported as `unrecorded` and does not block, because refusing
+  mutual silence would condemn the re-run path a top-up exists to serve. Inside
+  one job, partial coverage whose values agree is that job's value with its
+  coverage reported; two different values inside one job are refused. The same
+  run or trial offered twice is refused rather than counted twice.
 - **Verdicts.** Any per-task movement is a `SIGNAL`. A guard (a task the
   reference resolved k of k) falling below k/k, or any task down two or more
   resolved, is a `SUSPECTED_REGRESSION`. Neither gates: the default mode always

--- a/test/evals/harbor/README.md
+++ b/test/evals/harbor/README.md
@@ -214,6 +214,45 @@ agent's own reported usage), so it works against a downloaded community job too.
 A missing Stella adapter result is reported as "no evidence contract", never as
 a failed one.
 
+### The loop comparator
+
+`PROTOCOL.md` is the authority for what the comparator concludes; this is how to
+drive it. The first path is the candidate, the second the reference:
+
+```bash
+uv run --project test/evals/harbor python -m stella_harbor.compare   dist/evals/jobs/after dist/evals/jobs/before --names after before
+```
+
+- **Coverage is required.** A candidate missing any task its reference declares
+  is refused by name. There is no silent intersection. To compare a subset on
+  purpose, pass `--tasks a,b`; the flag is echoed in the output, and only the
+  task-set dimension is relaxed — model and dataset stay hard.
+- **k comes from the run budget** (`n_attempts`), or from `--k` when a side
+  predates the manifest. A task is judged only when both sides hold exactly k
+  scoreable trials; anything else prints `INSUFFICIENT_EVIDENCE` and is excluded
+  from every verdict.
+- **A side may span several jobs.** Repeat `--candidate-job` / `--reference-job`
+  when a side's k trials were topped up in a second run. Every path is still
+  named explicitly; nothing defaults to the latest directory.
+- **Verdicts.** Any per-task movement is a `SIGNAL`. A guard (a task the
+  reference resolved k of k) falling below k/k, or any task down two or more
+  resolved, is a `SUSPECTED_REGRESSION`. Neither gates: the default mode always
+  exits 0.
+- **Confirmation.** `--confirm` applies the frozen single-task k=5 predicates:
+  two or more resolved apart is `CONFIRMED_REGRESSION` or
+  `CONFIRMED_IMPROVEMENT`, anything weaker is `DISMISSED` with both counts. Only
+  `CONFIRMED_REGRESSION` exits nonzero.
+- **Process metrics** print in the protocol's three trust tiers: behavioral
+  (tool calls, per-tool error counts, turns), gateway-reported (tokens, cost),
+  and wall time, which is displayed and never judged. Error counts from before
+  #1077 are marked `*` and never judged, because they fold nonzero command exits
+  in. `EFFICIENCY_SIGNAL` triggers on exactly two metrics, provider cost and
+  per-tool error counts, past a 25% paired delta with the resolved count
+  unchanged; a reference mean of zero or missing leaves that metric unjudged.
+- **Timeout classes** are recorded per trial (`harness_timeout`,
+  `agent_deadline`, `command_timeout`, `none`), and a task whose only outcome
+  change is a timeout-class flip is marked `UNTRUSTED` and not judged.
+
 ## Pi UTF-8 recovery and the archived k=5 rerun
 
 Harbor 0.21.0's installed `Pi.populate_context_post_run()` calls

--- a/test/evals/harbor/README.md
+++ b/test/evals/harbor/README.md
@@ -227,13 +227,17 @@ uv run --project test/evals/harbor python -m stella_harbor.compare   dist/evals/
   is refused by name. There is no silent intersection. To compare a subset on
   purpose, pass `--tasks a,b`; the flag is echoed in the output, and only the
   task-set dimension is relaxed — model and dataset stay hard.
-- **k comes from the run budget** (`n_attempts`), or from `--k` when a side
-  predates the manifest. A task is judged only when both sides hold exactly k
-  scoreable trials; anything else prints `INSUFFICIENT_EVIDENCE` and is excluded
-  from every verdict.
+- **k comes from the run budget** (`n_attempts`); `--k` only fills in a budget
+  the artifacts never recorded and is refused when it conflicts with one they
+  did. A task is judged only when both sides hold exactly k scoreable trials;
+  anything else prints `INSUFFICIENT_EVIDENCE` and is excluded from every
+  verdict.
 - **A side may span several jobs.** Repeat `--candidate-job` / `--reference-job`
   when a side's k trials were topped up in a second run. Every path is still
-  named explicitly; nothing defaults to the latest directory.
+  named explicitly; nothing defaults to the latest directory. A top-up passes
+  the same identity validation as a positional job, the attempt budget being
+  the one permitted difference, and the same run or trial offered twice is
+  refused rather than counted twice.
 - **Verdicts.** Any per-task movement is a `SIGNAL`. A guard (a task the
   reference resolved k of k) falling below k/k, or any task down two or more
   resolved, is a `SUSPECTED_REGRESSION`. Neither gates: the default mode always
@@ -241,7 +245,9 @@ uv run --project test/evals/harbor python -m stella_harbor.compare   dist/evals/
 - **Confirmation.** `--confirm` applies the frozen single-task k=5 predicates:
   two or more resolved apart is `CONFIRMED_REGRESSION` or
   `CONFIRMED_IMPROVEMENT`, anything weaker is `DISMISSED` with both counts. Only
-  `CONFIRMED_REGRESSION` exits nonzero.
+  `CONFIRMED_REGRESSION` exits nonzero. An `UNTRUSTED` task confirms nothing,
+  and `--allow-mismatch` is refused outright: an exploratory comparison can
+  never gate.
 - **Process metrics** print in the protocol's three trust tiers: behavioral
   (tool calls, per-tool error counts, turns), gateway-reported (tokens, cost),
   and wall time, which is displayed and never judged. Error counts from before
@@ -251,7 +257,10 @@ uv run --project test/evals/harbor python -m stella_harbor.compare   dist/evals/
   unchanged; a reference mean of zero or missing leaves that metric unjudged.
 - **Timeout classes** are recorded per trial (`harness_timeout`,
   `agent_deadline`, `command_timeout`, `none`), and a task whose only outcome
-  change is a timeout-class flip is marked `UNTRUSTED` and not judged.
+  change is a timeout-class flip is marked `UNTRUSTED` and not judged. The flip
+  has to point the right way: the timed-out count must move opposite to the
+  resolved delta, so an improvement is not thrown away and a regression that
+  came with fewer timeouts is not hidden.
 
 ## Pi UTF-8 recovery and the archived k=5 rerun
 

--- a/test/evals/harbor/stella_harbor/compare.py
+++ b/test/evals/harbor/stella_harbor/compare.py
@@ -24,6 +24,9 @@ from pathlib import Path
 from typing import Any
 
 from .fingerprint import (
+    CONDITION_FIELDS,
+    FINGERPRINT_FIELDS,
+    FINGERPRINT_SOURCES,
     FingerprintMismatchError,
     collect_fingerprint_details,
     comparison_mode,
@@ -120,10 +123,25 @@ def _row(trial: Path, data: dict[str, Any], agent: dict[str, Any], adapter: dict
     # final, even against a verifier reward. The reward fallback is only for
     # trials that carry no adapter evidence at all, such as pi.
     valid = bool(adapter.get("valid")) if adapter else reward is not None
-    tools = metrics.get("tools") or {}
+    # Per-tool error evidence has three states and truthiness collapses two of
+    # them. A post-#1077 trial with `tools: {}` measured zero errors for every
+    # tool; a trial with no tools field never measured them at all; a trial
+    # predating #1077 measured them into a counter that folds nonzero command
+    # exits in, so its numbers exist but must never be judged.
+    tools = metrics.get("tools")
+    measured = isinstance(tools, dict)
+    if not measured:
+        errors_state = "missing"
+    elif metrics.get("command_nonzero_total") is None:
+        errors_state = "pre_split"
+    else:
+        errors_state = "measured"
     return {
         "task": trial.name.rsplit("__", 1)[0],
         "trial": trial.name,
+        # Canonical provenance: the same trial reached through two job paths is
+        # one piece of evidence, not two.
+        "source": str(trial.resolve()),
         "reward": reward,
         "valid": valid,
         # A valid trial with no reward means the verifier's infrastructure
@@ -136,11 +154,9 @@ def _row(trial: Path, data: dict[str, Any], agent: dict[str, Any], adapter: dict
         "turns": metrics.get("turns"),
         "tool_calls": metrics.get("tool_call_total"),
         "tool_errors": metrics.get("tool_error_total"),
-        "errors_by_tool": {name: stat.get("errors", 0) for name, stat in tools.items()} if tools else None,
+        "errors_by_tool": {n: (stat or {}).get("errors", 0) for n, stat in tools.items()} if measured else None,
         # PROTOCOL.md tier 1: "Error counts are trustworthy only after #1077."
-        # A trial that never split the counters folded nonzero command exits
-        # into its error count, so the number exists but must not be judged.
-        "errors_trusted": metrics.get("command_nonzero_total") is not None,
+        "errors_state": errors_state,
         "wall_ms": _wall_ms(data, adapter),
         "timeout_class": _timeout_class(data, adapter),
         # Absent adapter means an agent that carries no evidence contract;
@@ -173,8 +189,24 @@ def by_task(rows: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
 
 
 def _mean(values: list[Any]) -> float | None:
-    present = [float(v) for v in values if v is not None]
-    return sum(present) / len(present) if present else None
+    """The mean over a side's trials, or None if any of them lacks the value.
+
+    A mean over the subset that happens to carry a field is a different number
+    from the mean the metric names, so a missing value makes the whole metric
+    unjudged for that task rather than quietly shrinking the denominator.
+    """
+    if not values or any(v is None for v in values):
+        return None
+    return sum(float(v) for v in values) / len(values)
+
+
+def _errors_trusted(trials: list[dict[str, Any]]) -> bool:
+    """Error counts are judgeable only when no contributing trial predates #1077.
+
+    A pre-split trial taints the pair even when its tools dict is empty: the
+    counter it kept folded command exits in either way.
+    """
+    return all(t["errors_state"] != "pre_split" for t in trials)
 
 
 def _tool_names(trials: list[dict[str, Any]]) -> set[str]:
@@ -197,16 +229,20 @@ def efficiency(candidate: list[dict[str, Any]], reference: list[dict[str, Any]])
         "reference": _mean([t["cost_usd"] for t in ref_valid]),
         "trusted": True,
     }]
+    trusted = _errors_trusted(cand_valid + ref_valid)
     for name in sorted(_tool_names(cand_valid) | _tool_names(ref_valid)):
         def errors(trials: list[dict[str, Any]]) -> list[Any]:
-            return [t["errors_by_tool"].get(name, 0) if t["errors_by_tool"] else None for t in trials]
+            # A measured trial that never called this tool contributes 0; a
+            # trial that measured nothing contributes an unknown.
+            return [t["errors_by_tool"].get(name, 0) if t["errors_by_tool"] is not None else None
+                    for t in trials]
 
         metrics.append({
             "metric": f"errors:{name}",
             "candidate": _mean(errors(cand_valid)),
             "reference": _mean(errors(ref_valid)),
             # Pre-#1077 counts exist but fold command exits in; display, never judge.
-            "trusted": all(t["errors_trusted"] for t in cand_valid + ref_valid if t["errors_by_tool"]),
+            "trusted": trusted,
         })
     for metric in metrics:
         ref, cand = metric["reference"], metric["candidate"]
@@ -227,16 +263,18 @@ def _timeout_flip(candidate: list[dict[str, Any]], reference: list[dict[str, Any
 
     PROTOCOL.md "Sequential A/B discipline" marks such a delta untrusted rather
     than judging it. Trials are not paired one to one inside a task, so this
-    reads the counts: the classes moved, and the movement in timed-out trials
-    is large enough to account for the whole outcome change.
+    reads the counts, and the count change has to point the right way: timing
+    out more often explains resolving less, not resolving more. Without the
+    sign an improvement is thrown away and a regression that came with fewer
+    timeouts is hidden behind an untrusted marker.
     """
     if delta == 0:
         return False
     cand, ref = _timeout_counts(candidate), _timeout_counts(reference)
     if cand == ref:
         return False
-    timed_out = abs((sum(cand.values()) - cand["none"]) - (sum(ref.values()) - ref["none"]))
-    return timed_out >= abs(delta)
+    timed_out = (sum(cand.values()) - cand["none"]) - (sum(ref.values()) - ref["none"])
+    return timed_out * delta < 0 and abs(timed_out) >= abs(delta)
 
 
 def task_verdicts(
@@ -295,7 +333,7 @@ def _process_metrics(candidate: list[dict[str, Any]], reference: list[dict[str, 
         },
         # Wall time is reported and never judged: an emulating host makes it noise.
         "wall": {"wall_ms": pair("wall_ms")},
-        "errors_trusted": all(t["errors_trusted"] for t in cand_valid + ref_valid if t["errors_by_tool"]),
+        "errors_trusted": _errors_trusted(cand_valid + ref_valid),
     }
 
 
@@ -320,11 +358,18 @@ def verdicts(rows: list[dict[str, Any]], k: int | None) -> dict[str, Any]:
 
 
 def confirm(rows: list[dict[str, Any]]) -> dict[str, Any]:
-    """The frozen single-task k=5 confirmation predicates."""
+    """The frozen single-task k=5 confirmation predicates.
+
+    Untrusted rows are excluded exactly as verdicts() excludes them: a
+    timeout-class flip already accounts for the movement, so it can neither
+    confirm a regression nor an improvement.
+    """
     judged = [r for r in rows if r["judged"]]
     if len(judged) != 1:
-        return {"verdict": "INSUFFICIENT_EVIDENCE", "row": judged[0] if len(judged) == 1 else None}
+        return {"verdict": "INSUFFICIENT_EVIDENCE", "row": None}
     row = judged[0]
+    if row["untrusted"]:
+        return {"verdict": "UNTRUSTED", "row": row}
     if row["delta"] <= -2:
         verdict = "CONFIRMED_REGRESSION"
     elif row["delta"] >= 2:
@@ -506,6 +551,75 @@ def _budget(details: dict[str, Any]) -> int | None:
     return value if isinstance(value, int) else None
 
 
+def _duplicate_runs(jobs: list[tuple[str, Path]]) -> list[str]:
+    """Names of runs offered more than once across the four job inputs.
+
+    Canonical on the run directory rather than the argument, so a job root and
+    the run directory inside it are recognised as one piece of evidence. The
+    same run counted twice doubles its trials and moves every rate it touches.
+    """
+    seen: dict[Path, str] = {}
+    duplicates: list[str] = []
+    for label, job in jobs:
+        run = latest_run(job).resolve()
+        if run in seen:
+            duplicates.append(f"{label} and {seen[run]} name the same run ({run})")
+        else:
+            seen[run] = label
+    return duplicates
+
+
+def _duplicate_trials(rows: list[dict[str, Any]]) -> list[str]:
+    """Trial paths that reached the comparison twice through different jobs."""
+    seen: set[str] = set()
+    duplicates: set[str] = set()
+    for row in rows:
+        if row["source"] in seen:
+            duplicates.add(row["source"])
+        seen.add(row["source"])
+    return sorted(duplicates)
+
+
+def _topup_issues(primary: dict[str, Any], extra: dict[str, Any], label: str) -> list[dict[str, Any]]:
+    """Validate a top-up job against the positional job of its own side.
+
+    A top-up is the same run condition sampled again, so it faces the same
+    identity validation as a positional job. The single permitted difference is
+    the attempt budget: adding trials the first job did not run is the whole
+    reason a top-up exists.
+    """
+    issues: list[dict[str, Any]] = []
+    for field in FINGERPRINT_FIELDS:
+        if field == "budget":
+            continue
+        left, right = primary["fingerprint"].get(field), extra["fingerprint"].get(field)
+        complete = extra["evidence"].get(field, {}).get("status") == "complete"
+        if field in CONDITION_FIELDS:
+            if not complete:
+                kind = "unverifiable"
+            elif left != right:
+                kind = "different"
+            else:
+                continue
+        else:
+            # Agent identity, the commit included: judged only where both jobs
+            # recorded a value. Incompleteness is already reported cross-side.
+            if left is None or right is None or left == right:
+                continue
+            kind = "different"
+        issues.append({
+            "kind": kind,
+            "field": f"{label}:{field}",
+            "left": left,
+            "right": right,
+            "left_evidence": primary["evidence"].get(field, {}),
+            "right_evidence": extra["evidence"].get(field, {}),
+            "reject": True,
+            "source": FINGERPRINT_SOURCES[field],
+        })
+    return issues
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Compare a candidate Harbor job against a reference.")
     parser.add_argument("candidate", type=Path)
@@ -529,6 +643,21 @@ def main(argv: list[str] | None = None) -> int:
     candidate_jobs = [args.candidate, *args.candidate_job]
     reference_jobs = [args.reference, *args.reference_job]
 
+    # An explicitly untrusted comparison is exploratory by construction, and a
+    # confirmation is the one thing here that gates. They cannot be the same run.
+    if args.confirm and args.allow_mismatch:
+        print("REFUSING CONFIRMATION: --allow-mismatch renders an untrusted comparison, "
+              "which can never back a confirmation. Fix the fingerprint mismatch and re-run.",
+              file=sys.stderr)
+        return 2
+
+    duplicates = _duplicate_runs(
+        [(str(job), job) for job in candidate_jobs] + [(str(job), job) for job in reference_jobs])
+    if duplicates:
+        print("REFUSING COMPARISON: the same run was given more than once, which would "
+              "replicate its trials:\n  - " + "\n  - ".join(duplicates), file=sys.stderr)
+        return 2
+
     candidate_details = collect_fingerprint_details(args.candidate)
     reference_details = collect_fingerprint_details(args.reference)
     candidate_fingerprint = candidate_details["fingerprint"]
@@ -539,6 +668,11 @@ def main(argv: list[str] | None = None) -> int:
         candidate_details["evidence"],
         reference_details["evidence"],
     )
+    for side, primary, extras in (("candidate", candidate_details, args.candidate_job),
+                                  ("reference", reference_details, args.reference_job)):
+        for job in extras:
+            mismatches.extend(_topup_issues(primary, collect_fingerprint_details(job),
+                                            f"{side} top-up {job.name}"))
     blocking = [issue for issue in mismatches if issue.get("reject")]
     mode = comparison_mode(
         candidate_fingerprint,
@@ -550,7 +684,17 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     candidate_rows, reference_rows = load(candidate_jobs), load(reference_jobs)
+    repeated = _duplicate_trials(candidate_rows + reference_rows)
+    if repeated:
+        print("REFUSING COMPARISON: the same trial reached the comparison twice:\n  - "
+              + "\n  - ".join(repeated), file=sys.stderr)
+        return 2
+
     subset = [t.strip() for t in args.tasks.split(",") if t.strip()] if args.tasks else None
+    if args.tasks is not None and not subset:
+        print("REFUSING COMPARISON: --tasks selected no task at all; name at least one.",
+              file=sys.stderr)
+        return 2
     if subset is not None:
         candidate_rows, reference_rows = _select(candidate_rows, subset), _select(reference_rows, subset)
         unknown = sorted(set(subset) - {r["task"] for r in reference_rows})
@@ -558,6 +702,11 @@ def main(argv: list[str] | None = None) -> int:
             print("REFUSING COMPARISON: --tasks names task(s) the reference never ran: "
                   + ", ".join(unknown), file=sys.stderr)
             return 2
+
+    if not reference_rows:
+        print("REFUSING COMPARISON: the reference declares no tasks; there is nothing to compare.",
+              file=sys.stderr)
+        return 2
 
     # No silent intersection: a candidate missing any task its reference
     # declares is refused by name, subset flag or not.
@@ -568,16 +717,28 @@ def main(argv: list[str] | None = None) -> int:
               + "\nRe-run those tasks, or select an explicit subset with --tasks.", file=sys.stderr)
         return 2
 
-    budgets = {_budget(candidate_details), _budget(reference_details)}
-    k = args.k if args.k is not None else (budgets.pop() if len(budgets) == 1 else None)
+    # --k supplements artifacts, never overrides them: k is a property of the
+    # run that happened, and a command line cannot change what was run.
+    recorded = {b for b in (_budget(candidate_details), _budget(reference_details)) if b is not None}
+    if args.k is not None and recorded and recorded != {args.k}:
+        print(f"REFUSING COMPARISON: --k {args.k} conflicts with the attempt budget the jobs "
+              f"recorded ({', '.join(str(b) for b in sorted(recorded))}). --k may only fill in a "
+              "budget the artifacts never recorded.", file=sys.stderr)
+        return 2
+    if recorded:
+        k = recorded.pop() if len(recorded) == 1 else None
+    else:
+        k = args.k
 
     if args.confirm and k != 5:
         print(f"REFUSING CONFIRMATION: confirmation is a single-task k=5 run on both sides; k={k}.",
               file=sys.stderr)
         return 2
-    if args.confirm and len({r["task"] for r in reference_rows}) != 1:
-        print("REFUSING CONFIRMATION: confirmation is a single-task run; select one task with --tasks.",
-              file=sys.stderr)
+    candidate_tasks = {r["task"] for r in candidate_rows}
+    reference_tasks = {r["task"] for r in reference_rows}
+    if args.confirm and (len(reference_tasks) != 1 or candidate_tasks != reference_tasks):
+        print("REFUSING CONFIRMATION: confirmation is a single-task run on both sides; "
+              "select one task with --tasks.", file=sys.stderr)
         return 2
 
     print(render(
@@ -599,6 +760,10 @@ def main(argv: list[str] | None = None) -> int:
                   "re-run the short side.")
             return 0
         counts = f"candidate {row['candidate_resolved']}/5 vs reference {row['reference_resolved']}/5"
+        if outcome["verdict"] == "UNTRUSTED":
+            print(f"\nUNTRUSTED: {counts}; the only outcome change is a timeout-class flip, "
+                  "so nothing is confirmed. Re-run both sides.")
+            return 0
         print(f"\n{outcome['verdict']}: {counts}")
         return 1 if outcome["verdict"] == "CONFIRMED_REGRESSION" else 0
     return 0

--- a/test/evals/harbor/stella_harbor/compare.py
+++ b/test/evals/harbor/stella_harbor/compare.py
@@ -1,12 +1,16 @@
-"""Put two Harbor jobs side by side.
+"""Compare a candidate loop run against a reference run.
 
-The Stella adapter writes its own evidence, but a baseline run (upstream pi,
-Terminus, a published community job) writes only Harbor's per-trial result.json.
-Comparing has to work off that common denominator, so this reads reward and the
-provider-reported usage Harbor records for every agent, and reports validity
-only when the Stella adapter happens to be present.
+This is the loop comparator described in ../PROTOCOL.md. The protocol is the
+authority for every rule below; where a docstring paraphrases it, the protocol
+wins. Two things it insists on and this module enforces literally: the
+candidate must cover every task its reference declares (no silent
+intersection), and a task is judged only when both sides hold exactly k
+scoreable trials.
 
-    python -m stella_harbor.compare dist/evals/jobs/sample dist/evals/jobs/pi-sample
+    python -m stella_harbor.compare dist/evals/jobs/candidate dist/evals/jobs/reference
+    python -m stella_harbor.compare CAND REF --confirm      # single-task k=5
+
+Only CONFIRMED_REGRESSION exits nonzero. Everything else reports.
 """
 
 from __future__ import annotations
@@ -15,6 +19,7 @@ import argparse
 import json
 import sys
 from collections import defaultdict
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -25,7 +30,15 @@ from .fingerprint import (
     fingerprint_mismatches,
     format_mismatches,
 )
-from .report import RESOLVED, wilson_interval
+from .report import RESOLVED, _command_outcomes, wilson_interval
+
+# PROTOCOL.md "Thresholds and calibration": 25% paired per-task delta, either
+# direction. A starting value the pilot recalibrates, recorded there.
+EFFICIENCY_THRESHOLD = 0.25
+
+# PROTOCOL.md "Sequential A/B discipline": one class per trial, first match
+# wins, in this order.
+TIMEOUT_CLASSES = ("harness_timeout", "agent_deadline", "command_timeout", "none")
 
 
 def latest_run(job_dir: Path) -> Path:
@@ -38,38 +51,112 @@ def latest_run(job_dir: Path) -> Path:
     return runs[-1]
 
 
-def load(job_dir: Path) -> list[dict[str, Any]]:
-    run = latest_run(job_dir)
+def _timeout_class(harbor: dict[str, Any], adapter: dict[str, Any]) -> str:
+    """Classify one trial, first matching rule wins (PROTOCOL.md).
+
+    `harness_timeout` reads Harbor's own exception: its timeout types are
+    AgentTimeoutError, AgentSetupTimeoutError and VerifierTimeoutError, which
+    is what "names an agent or verifier timeout" denotes. An environment-start
+    timeout is neither, and a trial that died there carries no agent evidence
+    to compare anyway. `command_timeout` reads the killed-command sentinel,
+    exit code -1, which survives structurally in the bridge ledger rather than
+    in the message text.
+    """
+    exception = harbor.get("exception_info") or {}
+    if isinstance(exception, dict):
+        kind = f"{exception.get('exception_type') or ''} {exception.get('exception_message') or ''}".lower()
+        if "timeout" in kind and ("agent" in kind or "verifier" in kind):
+            return "harness_timeout"
+    if adapter.get("timed_out"):
+        return "agent_deadline"
+    _, killed = _command_outcomes(adapter.get("metrics") or {}, adapter.get("bridge_ledger") or [])
+    if killed:
+        return "command_timeout"
+    return "none"
+
+
+def _wall_ms(harbor: dict[str, Any], adapter: dict[str, Any]) -> float | None:
+    timing = ((adapter.get("metrics") or {}).get("timing_ms") or {}).get("total")
+    if timing is not None:
+        return float(timing)
+    started, finished = harbor.get("started_at"), harbor.get("finished_at")
+    if isinstance(started, str) and isinstance(finished, str):
+        try:
+            return (datetime.fromisoformat(finished) - datetime.fromisoformat(started)).total_seconds() * 1000
+        except ValueError:
+            return None
+    return None
+
+
+def load(job_dirs: Path | list[Path]) -> list[dict[str, Any]]:
+    """Read one row per trial from one or more job directories.
+
+    Several job directories per side is not a default-to-latest shortcut: a
+    side's k trials can be split across top-up jobs, and the caller still names
+    every path explicitly, which is what the protocol requires.
+    """
+    if isinstance(job_dirs, Path):
+        job_dirs = [job_dirs]
     rows: list[dict[str, Any]] = []
-    for trial in sorted(p for p in run.iterdir() if p.is_dir()):
-        result = trial / "result.json"
-        if not result.exists():
-            continue
-        data = json.loads(result.read_text())
-        agent = data.get("agent_result") or {}
-        adapter_path = trial / "agent" / "stella" / "result.json"
-        adapter = json.loads(adapter_path.read_text()) if adapter_path.exists() else {}
-        rows.append({
-            "task": trial.name.rsplit("__", 1)[0],
-            "reward": ((data.get("verifier_result") or {}).get("rewards") or {}).get("reward"),
-            "cost_usd": agent.get("cost_usd"),
-            "input_tokens": agent.get("n_input_tokens"),
-            "output_tokens": agent.get("n_output_tokens"),
-            # Absent adapter means an agent that carries no evidence contract;
-            # that is not the same as a trial that failed one.
-            "valid": adapter.get("valid") if adapter else None,
-        })
+    for job_dir in job_dirs:
+        run = latest_run(job_dir)
+        for trial in sorted(p for p in run.iterdir() if p.is_dir()):
+            result = trial / "result.json"
+            if not result.exists():
+                continue
+            data = json.loads(result.read_text())
+            agent = data.get("agent_result") or {}
+            adapter_path = trial / "agent" / "stella" / "result.json"
+            adapter = json.loads(adapter_path.read_text()) if adapter_path.exists() else {}
+            rows.append(_row(trial, data, agent, adapter))
     return rows
 
 
+def _row(trial: Path, data: dict[str, Any], agent: dict[str, Any], adapter: dict[str, Any]) -> dict[str, Any]:
+    metrics = adapter.get("metrics") or {}
+    usage = metrics.get("usage") or {}
+    reward = ((data.get("verifier_result") or {}).get("rewards") or {}).get("reward")
+    # PROTOCOL.md "Definitions": when adapter evidence is present its verdict is
+    # final, even against a verifier reward. The reward fallback is only for
+    # trials that carry no adapter evidence at all, such as pi.
+    valid = bool(adapter.get("valid")) if adapter else reward is not None
+    tools = metrics.get("tools") or {}
+    return {
+        "task": trial.name.rsplit("__", 1)[0],
+        "trial": trial.name,
+        "reward": reward,
+        "valid": valid,
+        # A valid trial with no reward means the verifier's infrastructure
+        # failed. That is not an agent failure, so it never counts as unresolved.
+        "scoreable": valid and reward is not None,
+        "resolved": valid and reward is not None and reward >= RESOLVED,
+        "cost_usd": agent.get("cost_usd") if agent.get("cost_usd") is not None else usage.get("cost_usd"),
+        "input_tokens": agent.get("n_input_tokens") if agent.get("n_input_tokens") is not None else usage.get("input_tokens"),
+        "output_tokens": agent.get("n_output_tokens") if agent.get("n_output_tokens") is not None else usage.get("output_tokens"),
+        "turns": metrics.get("turns"),
+        "tool_calls": metrics.get("tool_call_total"),
+        "tool_errors": metrics.get("tool_error_total"),
+        "errors_by_tool": {name: stat.get("errors", 0) for name, stat in tools.items()} if tools else None,
+        # PROTOCOL.md tier 1: "Error counts are trustworthy only after #1077."
+        # A trial that never split the counters folded nonzero command exits
+        # into its error count, so the number exists but must not be judged.
+        "errors_trusted": metrics.get("command_nonzero_total") is not None,
+        "wall_ms": _wall_ms(data, adapter),
+        "timeout_class": _timeout_class(data, adapter),
+        # Absent adapter means an agent that carries no evidence contract;
+        # that is not the same as a trial that failed one.
+        "adapter": bool(adapter),
+    }
+
+
 def summarize(rows: list[dict[str, Any]]) -> dict[str, Any]:
-    scoreable = [r for r in rows if r["valid"] is not False]
-    resolved = [r for r in scoreable if (r["reward"] or 0) >= RESOLVED]
+    scoreable = [r for r in rows if r["scoreable"]]
+    resolved = [r for r in scoreable if r["resolved"]]
     costs = [r["cost_usd"] for r in rows if r["cost_usd"] is not None]
     low, high = wilson_interval(len(resolved), len(scoreable))
     return {
         "trials": len(rows),
-        "invalid": len(rows) - len(scoreable),
+        "invalid": sum(1 for r in rows if not r["valid"]),
         "scoreable": len(scoreable),
         "resolved": len(resolved),
         "rate": len(resolved) / len(scoreable) if scoreable else 0.0,
@@ -78,32 +165,200 @@ def summarize(rows: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
-def _by_task(rows: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+def by_task(rows: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
     grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for row in rows:
         grouped[row["task"]].append(row)
-    return {task: summarize(trials) for task, trials in grouped.items()}
+    return dict(grouped)
+
+
+def _mean(values: list[Any]) -> float | None:
+    present = [float(v) for v in values if v is not None]
+    return sum(present) / len(present) if present else None
+
+
+def _tool_names(trials: list[dict[str, Any]]) -> set[str]:
+    return {name for t in trials if t["errors_by_tool"] for name in t["errors_by_tool"]}
+
+
+def efficiency(candidate: list[dict[str, Any]], reference: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """The two frozen EFFICIENCY_SIGNAL metrics for one task.
+
+    PROTOCOL.md "Process metrics": provider-reported cost and per-tool error
+    counts, nothing else. Per task and side, the mean over *valid* trials; the
+    delta is (candidate - reference) / reference; a reference mean of zero or a
+    missing value leaves that metric unjudged.
+    """
+    cand_valid = [t for t in candidate if t["valid"]]
+    ref_valid = [t for t in reference if t["valid"]]
+    metrics: list[dict[str, Any]] = [{
+        "metric": "cost",
+        "candidate": _mean([t["cost_usd"] for t in cand_valid]),
+        "reference": _mean([t["cost_usd"] for t in ref_valid]),
+        "trusted": True,
+    }]
+    for name in sorted(_tool_names(cand_valid) | _tool_names(ref_valid)):
+        def errors(trials: list[dict[str, Any]]) -> list[Any]:
+            return [t["errors_by_tool"].get(name, 0) if t["errors_by_tool"] else None for t in trials]
+
+        metrics.append({
+            "metric": f"errors:{name}",
+            "candidate": _mean(errors(cand_valid)),
+            "reference": _mean(errors(ref_valid)),
+            # Pre-#1077 counts exist but fold command exits in; display, never judge.
+            "trusted": all(t["errors_trusted"] for t in cand_valid + ref_valid if t["errors_by_tool"]),
+        })
+    for metric in metrics:
+        ref, cand = metric["reference"], metric["candidate"]
+        unjudged = ref in (None, 0) or cand is None or not metric["trusted"]
+        metric["delta"] = None if unjudged else (cand - ref) / ref
+    return metrics
+
+
+def _timeout_counts(trials: list[dict[str, Any]]) -> dict[str, int]:
+    counts = dict.fromkeys(TIMEOUT_CLASSES, 0)
+    for trial in trials:
+        counts[trial["timeout_class"]] += 1
+    return counts
+
+
+def _timeout_flip(candidate: list[dict[str, Any]], reference: list[dict[str, Any]], delta: int) -> bool:
+    """Whether a task's only outcome change is a timeout-class flip.
+
+    PROTOCOL.md "Sequential A/B discipline" marks such a delta untrusted rather
+    than judging it. Trials are not paired one to one inside a task, so this
+    reads the counts: the classes moved, and the movement in timed-out trials
+    is large enough to account for the whole outcome change.
+    """
+    if delta == 0:
+        return False
+    cand, ref = _timeout_counts(candidate), _timeout_counts(reference)
+    if cand == ref:
+        return False
+    timed_out = abs((sum(cand.values()) - cand["none"]) - (sum(ref.values()) - ref["none"]))
+    return timed_out >= abs(delta)
+
+
+def task_verdicts(
+    candidate: list[dict[str, Any]],
+    reference: list[dict[str, Any]],
+    k: int | None,
+) -> list[dict[str, Any]]:
+    """Pair every task, judging only where both sides hold exactly k scoreable."""
+    cand_tasks, ref_tasks = by_task(candidate), by_task(reference)
+    rows: list[dict[str, Any]] = []
+    for task in sorted(set(cand_tasks) | set(ref_tasks)):
+        cand, ref = cand_tasks.get(task, []), ref_tasks.get(task, [])
+        cand_scoreable = sum(1 for t in cand if t["scoreable"])
+        ref_scoreable = sum(1 for t in ref if t["scoreable"])
+        cand_resolved = sum(1 for t in cand if t["resolved"])
+        ref_resolved = sum(1 for t in ref if t["resolved"])
+        judged = k is not None and cand_scoreable == k and ref_scoreable == k
+        delta = cand_resolved - ref_resolved
+        untrusted = judged and _timeout_flip(cand, ref, delta)
+        rows.append({
+            "task": task,
+            "candidate_scoreable": cand_scoreable,
+            "reference_scoreable": ref_scoreable,
+            "candidate_resolved": cand_resolved,
+            "reference_resolved": ref_resolved,
+            "delta": delta,
+            "judged": judged,
+            # PROTOCOL.md: a guard is any task the reference resolved k of k.
+            "guard": judged and ref_resolved == k,
+            "untrusted": untrusted,
+            "timeout_classes": (_timeout_counts(cand), _timeout_counts(ref)),
+            "efficiency": efficiency(cand, ref),
+            "process": _process_metrics(cand, ref),
+        })
+    return rows
+
+
+def _process_metrics(candidate: list[dict[str, Any]], reference: list[dict[str, Any]]) -> dict[str, Any]:
+    """Paired means for the three trust tiers. All are displayed."""
+    cand_valid = [t for t in candidate if t["valid"]]
+    ref_valid = [t for t in reference if t["valid"]]
+
+    def pair(field: str) -> tuple[float | None, float | None]:
+        return _mean([t[field] for t in cand_valid]), _mean([t[field] for t in ref_valid])
+
+    return {
+        "behavioral": {
+            "tool_calls": pair("tool_calls"),
+            "tool_errors": pair("tool_errors"),
+            "turns": pair("turns"),
+        },
+        "gateway": {
+            "input_tokens": pair("input_tokens"),
+            "output_tokens": pair("output_tokens"),
+            "cost_usd": pair("cost_usd"),
+        },
+        # Wall time is reported and never judged: an emulating host makes it noise.
+        "wall": {"wall_ms": pair("wall_ms")},
+        "errors_trusted": all(t["errors_trusted"] for t in cand_valid + ref_valid if t["errors_by_tool"]),
+    }
+
+
+def efficiency_signals(row: dict[str, Any]) -> list[dict[str, Any]]:
+    """Judged efficiency metrics past the threshold, on an unchanged resolved count."""
+    if not row["judged"] or row["delta"] != 0:
+        return []
+    return [m for m in row["efficiency"] if m["delta"] is not None and abs(m["delta"]) > EFFICIENCY_THRESHOLD]
+
+
+def verdicts(rows: list[dict[str, Any]], k: int | None) -> dict[str, Any]:
+    judged = [r for r in rows if r["judged"] and not r["untrusted"]]
+    suspected = [r for r in judged if (r["guard"] and r["candidate_resolved"] < k) or r["delta"] <= -2]
+    signal = [r for r in judged if r["delta"] != 0]
+    return {
+        "signal": signal,
+        "suspected_regression": suspected,
+        "insufficient": [r for r in rows if not r["judged"]],
+        "untrusted": [r for r in rows if r["untrusted"]],
+        "efficiency": [(r, efficiency_signals(r)) for r in rows if efficiency_signals(r)],
+    }
+
+
+def confirm(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """The frozen single-task k=5 confirmation predicates."""
+    judged = [r for r in rows if r["judged"]]
+    if len(judged) != 1:
+        return {"verdict": "INSUFFICIENT_EVIDENCE", "row": judged[0] if len(judged) == 1 else None}
+    row = judged[0]
+    if row["delta"] <= -2:
+        verdict = "CONFIRMED_REGRESSION"
+    elif row["delta"] >= 2:
+        verdict = "CONFIRMED_IMPROVEMENT"
+    else:
+        verdict = "DISMISSED"
+    return {"verdict": verdict, "row": row}
+
+
+def _pct(value: float | None) -> str:
+    return "-" if value is None else f"{value * 100:+.1f}%"
+
+
+def _num(value: float | None, digits: int = 1) -> str:
+    return "-" if value is None else f"{value:.{digits}f}"
+
+
+def _pair(values: tuple[float | None, float | None], digits: int = 1) -> str:
+    return f"{_num(values[0], digits)} / {_num(values[1], digits)}"
 
 
 def render(
-    left: list[dict[str, Any]],
-    right: list[dict[str, Any]],
+    candidate: list[dict[str, Any]],
+    reference: list[dict[str, Any]],
     names: tuple[str, str],
     *,
+    k: int | None = None,
     mismatches: list[dict[str, Any]] | None = None,
     mode: str | None = None,
     agent_names: tuple[Any, Any] | None = None,
+    subset: list[str] | None = None,
 ) -> str:
-    left_tasks, right_tasks = _by_task(left), _by_task(right)
-    tasks = sorted(set(left_tasks) | set(right_tasks))
-    width = max([24, *(len(t) for t in tasks)])
-
-    def cell(stats: dict[str, Any] | None) -> str:
-        if not stats:
-            return f"{'-':>16}"
-        cost = "-" if stats["cost"] is None else f"${stats['cost']:.3f}"
-        return f"{stats['resolved']}/{stats['scoreable']} {cost:>9}"
-
+    rows = task_verdicts(candidate, reference, k)
+    result = verdicts(rows, k)
     issues = mismatches or []
     untrusted = any(issue.get("reject") for issue in issues)
     marker = "[UNTRUSTWORTHY COMPARISON] "
@@ -111,11 +366,11 @@ def render(
     def mark(line: str) -> str:
         return marker + line if untrusted else line
 
-    out = [mark(f"{names[0]}  vs  {names[1]}"), ""]
+    out = [mark(f"candidate {names[0]}  vs  reference {names[1]}"), ""]
     if mode:
         if mode == "cross-agent":
-            left_agent, right_agent = agent_names or (None, None)
-            identity = f"CROSS-AGENT COMPARISON: left agent={left_agent!r}; right agent={right_agent!r}"
+            cand_agent, ref_agent = agent_names or (None, None)
+            identity = f"CROSS-AGENT COMPARISON: candidate agent={cand_agent!r}; reference agent={ref_agent!r}"
         else:
             identity = f"{mode.upper()}: agent identity is part of the report, not the run-condition gate"
         out.append(mark(identity))
@@ -126,14 +381,71 @@ def render(
             *format_mismatches(issues),
         ])
         out.append("")
-    out.append(mark(f"{'task':<{width}}  {names[0][:16]:>16}  {names[1][:16]:>16}"))
-    out.append(mark("-" * (width + 38)))
-    for task in tasks:
-        out.append(mark(f"{task:<{width}}  {cell(left_tasks.get(task)):>16}  {cell(right_tasks.get(task)):>16}"))
+
+    if subset is not None:
+        out.append(mark(
+            f"EXPLICIT SUBSET (--tasks): {len(subset)} task(s) compared — {', '.join(subset)}. "
+            "The task-set dimension of the fingerprint is relaxed for this run; "
+            "model and dataset are not."))
+    else:
+        out.append(mark(f"task set: all {len({r['task'] for r in reference})} task(s) the reference declares"))
+    out.append(mark(
+        f"k = {k} (both sides must hold exactly k scoreable trials for a task to be judged)"
+        if k is not None else
+        "k is unknown: no run recorded a budget, so no task can be judged. "
+        "Pass --k to state it."))
+    out.append("")
+
+    width = max([24, *(len(r["task"]) for r in rows)]) if rows else 24
+    out.append(mark(f"{'task':<{width}}  {'cand':>7}  {'ref':>7}  {'Δres':>5}  {'Δcost':>8}  {'Δerrs':>8}  notes"))
+    out.append(mark("-" * (width + 48)))
+    for row in rows:
+        cost = next((m for m in row["efficiency"] if m["metric"] == "cost"), None)
+        errs = [m for m in row["efficiency"] if m["metric"].startswith("errors:") and m["delta"] is not None]
+        worst = max(errs, key=lambda m: abs(m["delta"])) if errs else None
+        notes = []
+        if not row["judged"]:
+            notes.append("INSUFFICIENT_EVIDENCE")
+        if row["untrusted"]:
+            notes.append("UNTRUSTED (timeout-class flip)")
+        if row in result["suspected_regression"]:
+            notes.append("SUSPECTED_REGRESSION")
+        elif row in result["signal"]:
+            notes.append("SIGNAL")
+        if row["guard"]:
+            notes.append("guard")
+        if efficiency_signals(row):
+            notes.append("EFFICIENCY_SIGNAL")
+        out.append(mark(
+            f"{row['task']:<{width}}  "
+            f"{f'{row["candidate_resolved"]}/{row["candidate_scoreable"]}':>7}  "
+            f"{f'{row["reference_resolved"]}/{row["reference_scoreable"]}':>7}  "
+            f"{row['delta']:+5d}  {_pct(cost['delta'] if cost else None):>8}  "
+            f"{_pct(worst['delta'] if worst else None):>8}  {', '.join(notes)}"))
 
     out.append("")
-    for name, rows in ((names[0], left), (names[1], right)):
-        s = summarize(rows)
+    out.append(mark("Process metrics — paired means over valid trials, three trust tiers."))
+    out.append(mark(f"{'task':<{width}}  {'calls c/r':>13}  {'errs c/r':>13}  {'turns c/r':>13}  "
+                    f"{'in.tok c/r':>17}  {'cost c/r':>17}  {'wall s c/r':>15}"))
+    out.append(mark("-" * (width + 96)))
+    for row in rows:
+        p = row["process"]
+        errors = _pair(p["behavioral"]["tool_errors"])
+        if not p["errors_trusted"]:
+            errors += "*"
+        wall = tuple(None if v is None else v / 1000 for v in p["wall"]["wall_ms"])
+        out.append(mark(
+            f"{row['task']:<{width}}  {_pair(p['behavioral']['tool_calls']):>13}  {errors:>13}  "
+            f"{_pair(p['behavioral']['turns']):>13}  {_pair(p['gateway']['input_tokens'], 0):>17}  "
+            f"{_pair(p['gateway']['cost_usd'], 4):>17}  {_pair(wall):>15}"))
+    if any(not r["process"]["errors_trusted"] for r in rows):
+        out.append(mark("* error counts predate #1077: they fold nonzero command exits in, so they are "
+                        "displayed and never judged."))
+    out.append(mark("Wall time is displayed and never judged: an emulating host makes it noise."))
+
+    out.append("")
+    for name, trials in ((names[0], candidate), (names[1], reference)):
+        s = summarize(trials)
         cost = "-" if s["cost"] is None else f"${s['cost']:.2f}"
         invalid = f", {s['invalid']} invalid" if s["invalid"] else ""
         out.append(mark(
@@ -141,53 +453,154 @@ def render(
             f"({s['rate'] * 100:.1f}%, 95% CI {s['ci'][0] * 100:.1f}-{s['ci'][1] * 100:.1f}%), "
             f"total {cost}{invalid}"
         ))
+
     out.append("")
+    out.extend(mark(line) for line in _verdict_lines(result))
+    out.append("")
+    out.append(mark("Rates are per task and paired; loop trial counts are far too small for a headline rate."))
     out.append(mark("Costs come from each agent's own usage reporting, so they are comparable"))
     out.append(mark("only when both runs used the same model and price table."))
     return "\n".join(out)
 
 
+def _verdict_lines(result: dict[str, Any]) -> list[str]:
+    lines: list[str] = []
+    for row in result["insufficient"]:
+        lines.append(
+            f"INSUFFICIENT_EVIDENCE {row['task']}: candidate {row['candidate_scoreable']} scoreable, "
+            f"reference {row['reference_scoreable']}; excluded from every verdict")
+    for row in result["untrusted"]:
+        cand, ref = row["timeout_classes"]
+        lines.append(
+            f"UNTRUSTED {row['task']}: the only outcome change is a timeout-class flip "
+            f"(candidate {cand}, reference {ref}); not judged")
+    for row in result["suspected_regression"]:
+        why = "a guard dropped below k/k" if row["guard"] else f"down {abs(row['delta'])} resolved"
+        lines.append(
+            f"SUSPECTED_REGRESSION {row['task']}: {row['candidate_resolved']} vs "
+            f"{row['reference_resolved']} resolved ({why}); reported loudly, does not gate")
+    for row in result["signal"]:
+        lines.append(
+            f"SIGNAL {row['task']}: {row['candidate_resolved']} vs {row['reference_resolved']} resolved "
+            f"({row['delta']:+d}); reported, never gates")
+    for row, metrics in result["efficiency"]:
+        detail = "; ".join(f"{m['metric']} {_pct(m['delta'])}" for m in metrics)
+        lines.append(
+            f"EFFICIENCY_SIGNAL {row['task']}: resolved unchanged at {row['candidate_resolved']}, {detail}; "
+            "shown, not a gate — direction alone proves nothing")
+    if not lines:
+        lines.append("No movement: every judged task holds its resolved count.")
+    return lines
+
+
+def _missing_tasks(candidate: list[dict[str, Any]], reference: list[dict[str, Any]]) -> list[str]:
+    return sorted({r["task"] for r in reference} - {r["task"] for r in candidate})
+
+
+def _select(rows: list[dict[str, Any]], tasks: list[str] | None) -> list[dict[str, Any]]:
+    return rows if tasks is None else [r for r in rows if r["task"] in tasks]
+
+
+def _budget(details: dict[str, Any]) -> int | None:
+    value = details["fingerprint"].get("budget")
+    return value if isinstance(value, int) else None
+
+
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Compare two Harbor job directories.")
-    parser.add_argument("left", type=Path)
-    parser.add_argument("right", type=Path)
-    parser.add_argument("--names", nargs=2, metavar=("LEFT", "RIGHT"))
+    parser = argparse.ArgumentParser(description="Compare a candidate Harbor job against a reference.")
+    parser.add_argument("candidate", type=Path)
+    parser.add_argument("reference", type=Path)
+    parser.add_argument("--candidate-job", type=Path, action="append", default=[],
+                        help="additional job directory belonging to the candidate side")
+    parser.add_argument("--reference-job", type=Path, action="append", default=[],
+                        help="additional job directory belonging to the reference side")
+    parser.add_argument("--names", nargs=2, metavar=("CANDIDATE", "REFERENCE"))
+    parser.add_argument("--tasks", help="comma-separated explicit subset; echoed in the output")
+    parser.add_argument("--k", type=int, help="scoreable trials per side required to judge a task")
+    parser.add_argument("--confirm", action="store_true",
+                        help="apply the frozen single-task k=5 confirmation predicates")
     parser.add_argument(
         "--allow-mismatch",
         action="store_true",
         help="render an explicitly untrusted comparison despite fingerprint mismatches",
     )
     args = parser.parse_args(argv)
-    names = tuple(args.names) if args.names else (args.left.name, args.right.name)
+    names = tuple(args.names) if args.names else (args.candidate.name, args.reference.name)
+    candidate_jobs = [args.candidate, *args.candidate_job]
+    reference_jobs = [args.reference, *args.reference_job]
 
-    left_details = collect_fingerprint_details(args.left)
-    right_details = collect_fingerprint_details(args.right)
-    left_fingerprint = left_details["fingerprint"]
-    right_fingerprint = right_details["fingerprint"]
+    candidate_details = collect_fingerprint_details(args.candidate)
+    reference_details = collect_fingerprint_details(args.reference)
+    candidate_fingerprint = candidate_details["fingerprint"]
+    reference_fingerprint = reference_details["fingerprint"]
     mismatches = fingerprint_mismatches(
-        left_fingerprint,
-        right_fingerprint,
-        left_details["evidence"],
-        right_details["evidence"],
+        candidate_fingerprint,
+        reference_fingerprint,
+        candidate_details["evidence"],
+        reference_details["evidence"],
     )
     blocking = [issue for issue in mismatches if issue.get("reject")]
     mode = comparison_mode(
-        left_fingerprint,
-        right_fingerprint,
-        (left_details["evidence"], right_details["evidence"]),
+        candidate_fingerprint,
+        reference_fingerprint,
+        (candidate_details["evidence"], reference_details["evidence"]),
     )
     if blocking and not args.allow_mismatch:
         print(str(FingerprintMismatchError(mismatches)), file=sys.stderr)
         return 2
 
+    candidate_rows, reference_rows = load(candidate_jobs), load(reference_jobs)
+    subset = [t.strip() for t in args.tasks.split(",") if t.strip()] if args.tasks else None
+    if subset is not None:
+        candidate_rows, reference_rows = _select(candidate_rows, subset), _select(reference_rows, subset)
+        unknown = sorted(set(subset) - {r["task"] for r in reference_rows})
+        if unknown:
+            print("REFUSING COMPARISON: --tasks names task(s) the reference never ran: "
+                  + ", ".join(unknown), file=sys.stderr)
+            return 2
+
+    # No silent intersection: a candidate missing any task its reference
+    # declares is refused by name, subset flag or not.
+    missing = _missing_tasks(candidate_rows, reference_rows)
+    if missing:
+        print("REFUSING COMPARISON: the candidate is missing task(s) the reference declares: "
+              + ", ".join(missing)
+              + "\nRe-run those tasks, or select an explicit subset with --tasks.", file=sys.stderr)
+        return 2
+
+    budgets = {_budget(candidate_details), _budget(reference_details)}
+    k = args.k if args.k is not None else (budgets.pop() if len(budgets) == 1 else None)
+
+    if args.confirm and k != 5:
+        print(f"REFUSING CONFIRMATION: confirmation is a single-task k=5 run on both sides; k={k}.",
+              file=sys.stderr)
+        return 2
+    if args.confirm and len({r["task"] for r in reference_rows}) != 1:
+        print("REFUSING CONFIRMATION: confirmation is a single-task run; select one task with --tasks.",
+              file=sys.stderr)
+        return 2
+
     print(render(
-        load(args.left),
-        load(args.right),
+        candidate_rows,
+        reference_rows,
         names,
+        k=k,
         mismatches=mismatches or None,
         mode=mode,
-        agent_names=(left_fingerprint.get("agent_name"), right_fingerprint.get("agent_name")),
+        agent_names=(candidate_fingerprint.get("agent_name"), reference_fingerprint.get("agent_name")),
+        subset=subset,
     ))
+
+    if args.confirm:
+        outcome = confirm(task_verdicts(candidate_rows, reference_rows, k))
+        row = outcome["row"]
+        if row is None:
+            print("\nINSUFFICIENT_EVIDENCE: the task is not judged at k=5 on both sides; "
+                  "re-run the short side.")
+            return 0
+        counts = f"candidate {row['candidate_resolved']}/5 vs reference {row['reference_resolved']}/5"
+        print(f"\n{outcome['verdict']}: {counts}")
+        return 1 if outcome["verdict"] == "CONFIRMED_REGRESSION" else 0
     return 0
 
 

--- a/test/evals/harbor/stella_harbor/compare.py
+++ b/test/evals/harbor/stella_harbor/compare.py
@@ -24,7 +24,6 @@ from pathlib import Path
 from typing import Any
 
 from .fingerprint import (
-    CONDITION_FIELDS,
     FINGERPRINT_FIELDS,
     FINGERPRINT_SOURCES,
     FingerprintMismatchError,
@@ -401,6 +400,7 @@ def render(
     mode: str | None = None,
     agent_names: tuple[Any, Any] | None = None,
     subset: list[str] | None = None,
+    k_from_flag: bool = False,
 ) -> str:
     rows = task_verdicts(candidate, reference, k)
     result = verdicts(rows, k)
@@ -434,8 +434,10 @@ def render(
             "model and dataset are not."))
     else:
         out.append(mark(f"task set: all {len({r['task'] for r in reference})} task(s) the reference declares"))
+    source = " — supplied by --k; no run recorded an attempt budget" if k_from_flag else ""
     out.append(mark(
-        f"k = {k} (both sides must hold exactly k scoreable trials for a task to be judged)"
+        f"k = {k}{source} "
+        "(both sides must hold exactly k scoreable trials for a task to be judged)"
         if k is not None else
         "k is unknown: no run recorded a budget, so no task can be judged. "
         "Pass --k to state it."))
@@ -587,26 +589,26 @@ def _topup_issues(primary: dict[str, Any], extra: dict[str, Any], label: str) ->
     identity validation as a positional job. The single permitted difference is
     the attempt budget: adding trials the first job did not run is the whole
     reason a top-up exists.
+
+    Every other field is fail-closed, agent identity included. Cross-side, an
+    incomplete capability digest or commit is a diagnostic because the two
+    sides are allowed to be different builds; within a side it is not, because
+    a top-up whose build cannot be verified is trials of unknown provenance
+    merged into one denominator.
     """
     issues: list[dict[str, Any]] = []
     for field in FINGERPRINT_FIELDS:
         if field == "budget":
             continue
         left, right = primary["fingerprint"].get(field), extra["fingerprint"].get(field)
-        complete = extra["evidence"].get(field, {}).get("status") == "complete"
-        if field in CONDITION_FIELDS:
-            if not complete:
-                kind = "unverifiable"
-            elif left != right:
-                kind = "different"
-            else:
-                continue
-        else:
-            # Agent identity, the commit included: judged only where both jobs
-            # recorded a value. Incompleteness is already reported cross-side.
-            if left is None or right is None or left == right:
-                continue
+        verified = all(
+            side["evidence"].get(field, {}).get("status") == "complete" for side in (primary, extra))
+        if not verified:
+            kind = "unverifiable"
+        elif left != right:
             kind = "different"
+        else:
+            continue
         issues.append({
             "kind": kind,
             "field": f"{label}:{field}",
@@ -673,7 +675,28 @@ def main(argv: list[str] | None = None) -> int:
         for job in extras:
             mismatches.extend(_topup_issues(primary, collect_fingerprint_details(job),
                                             f"{side} top-up {job.name}"))
+    # k is resolved before the gate because a missing attempt budget is one of
+    # the things the gate rejects, and --k is the documented way to supply it.
+    recorded = {b for b in (_budget(candidate_details), _budget(reference_details)) if b is not None}
+    if args.k is not None and recorded and recorded != {args.k}:
+        print(f"REFUSING COMPARISON: --k {args.k} conflicts with the attempt budget the jobs "
+              f"recorded ({', '.join(str(b) for b in sorted(recorded))}). --k may only fill in a "
+              "budget the artifacts never recorded.", file=sys.stderr)
+        return 2
+    k = (recorded.pop() if len(recorded) == 1 else None) if recorded else args.k
+
     blocking = [issue for issue in mismatches if issue.get("reject")]
+    # An archive that never wrote n_attempts leaves budget unverifiable, and a
+    # confirmation may not use --allow-mismatch, so without this an archived
+    # run cannot be compared at all. --k answers that one question and no
+    # other: any further blocking issue still refuses.
+    unrecorded_budget = [i for i in blocking if i["field"] == "budget" and i["kind"] == "unverifiable"]
+    if k is not None and not recorded and unrecorded_budget and len(unrecorded_budget) == len(blocking):
+        mismatches = [i for i in mismatches if i not in unrecorded_budget]
+        blocking = []
+        k_from_flag = True
+    else:
+        k_from_flag = False
     mode = comparison_mode(
         candidate_fingerprint,
         reference_fingerprint,
@@ -717,19 +740,6 @@ def main(argv: list[str] | None = None) -> int:
               + "\nRe-run those tasks, or select an explicit subset with --tasks.", file=sys.stderr)
         return 2
 
-    # --k supplements artifacts, never overrides them: k is a property of the
-    # run that happened, and a command line cannot change what was run.
-    recorded = {b for b in (_budget(candidate_details), _budget(reference_details)) if b is not None}
-    if args.k is not None and recorded and recorded != {args.k}:
-        print(f"REFUSING COMPARISON: --k {args.k} conflicts with the attempt budget the jobs "
-              f"recorded ({', '.join(str(b) for b in sorted(recorded))}). --k may only fill in a "
-              "budget the artifacts never recorded.", file=sys.stderr)
-        return 2
-    if recorded:
-        k = recorded.pop() if len(recorded) == 1 else None
-    else:
-        k = args.k
-
     if args.confirm and k != 5:
         print(f"REFUSING CONFIRMATION: confirmation is a single-task k=5 run on both sides; k={k}.",
               file=sys.stderr)
@@ -750,6 +760,7 @@ def main(argv: list[str] | None = None) -> int:
         mode=mode,
         agent_names=(candidate_fingerprint.get("agent_name"), reference_fingerprint.get("agent_name")),
         subset=subset,
+        k_from_flag=k_from_flag,
     ))
 
     if args.confirm:

--- a/test/evals/harbor/stella_harbor/compare.py
+++ b/test/evals/harbor/stella_harbor/compare.py
@@ -708,15 +708,18 @@ def main(argv: list[str] | None = None) -> int:
               f"recorded ({', '.join(str(b) for b in sorted(recorded))}). --k may only fill in a "
               "budget the artifacts never recorded.", file=sys.stderr)
         return 2
-    k = (recorded.pop() if len(recorded) == 1 else None) if recorded else args.k
+    # Read, never consume: emptying the set here would make a budget recorded
+    # by one side alone look like a budget nobody recorded.
+    k = next(iter(recorded)) if len(recorded) == 1 else (args.k if not recorded else None)
 
     blocking = [issue for issue in mismatches if issue.get("reject")]
     # An archive that never wrote n_attempts leaves budget unverifiable, and a
     # confirmation may not use --allow-mismatch, so without this an archived
-    # run cannot be compared at all. --k answers that one question and no
-    # other: any further blocking issue still refuses.
+    # run cannot be compared at all. Only an explicit --k answers it, and it
+    # answers nothing else: one side recording a budget the other cannot
+    # confirm is still a mismatch, and any further blocking issue still refuses.
     unrecorded_budget = [i for i in blocking if i["field"] == "budget" and i["kind"] == "unverifiable"]
-    if k is not None and not recorded and unrecorded_budget and len(unrecorded_budget) == len(blocking):
+    if args.k is not None and not recorded and unrecorded_budget and len(unrecorded_budget) == len(blocking):
         mismatches = [i for i in mismatches if i not in unrecorded_budget]
         blocking = []
         k_from_flag = True
@@ -729,6 +732,16 @@ def main(argv: list[str] | None = None) -> int:
     )
     if blocking and not args.allow_mismatch:
         print(str(FingerprintMismatchError(mismatches)), file=sys.stderr)
+        return 2
+
+    # A narrow closure over the three-state top-up rule: an identity no
+    # artifact records is tolerable in a report and not underneath a verdict
+    # that gates. Confirmation is the only mode that gates.
+    unrecorded = [i["field"] for i in mismatches if i["kind"] == "unrecorded"]
+    if args.confirm and unrecorded:
+        print("REFUSING CONFIRMATION: a top-up carries identity no artifact records "
+              f"({', '.join(unrecorded)}), and a confirmation gates. Wait for the PR-D "
+              "manifest to record it, or confirm without a top-up.", file=sys.stderr)
         return 2
 
     candidate_rows, reference_rows = load(candidate_jobs), load(reference_jobs)

--- a/test/evals/harbor/stella_harbor/compare.py
+++ b/test/evals/harbor/stella_harbor/compare.py
@@ -590,35 +590,60 @@ def _topup_issues(primary: dict[str, Any], extra: dict[str, Any], label: str) ->
     the attempt budget: adding trials the first job did not run is the whole
     reason a top-up exists.
 
-    Every other field is fail-closed, agent identity included. Cross-side, an
-    incomplete capability digest or commit is a diagnostic because the two
-    sides are allowed to be different builds; within a side it is not, because
-    a top-up whose build cannot be verified is trials of unknown provenance
-    merged into one denominator.
+    Every other field is judged in three states, because "recorded and
+    different" and "nobody ever recorded it" are not the same risk:
+
+    1. Both jobs recorded a value and the values differ: blocking. This is a
+       top-up from another run condition or another build.
+    2. One job recorded it and the other carries no evidence at all: blocking.
+       The top-up cannot show it belongs to this side.
+    3. Neither job ever recorded it: reported as `unrecorded`, not blocking.
+       Refusing a field that no artifact writes would condemn the protocol's
+       own re-run path, since an INSUFFICIENT_EVIDENCE top-up is exactly this
+       case, and mutual silence is not evidence of a difference. When PR-D's
+       manifest starts recording candidate_commit and tool_strategy, those
+       fields move into state 1 or 2 by themselves: the rule tightens with no
+       code change here.
+
+    Inside one job, partial coverage whose recorded values all agree is that
+    job's value, reported with its coverage; two different values inside one
+    job are never safe to compare and are blocking.
     """
     issues: list[dict[str, Any]] = []
+
+    def issue(kind: str, field: str, reject: bool, line: str | None = None) -> None:
+        entry = {
+            "kind": kind,
+            "field": f"{label}:{field}",
+            "left": primary["fingerprint"].get(field),
+            "right": extra["fingerprint"].get(field),
+            "left_evidence": primary["evidence"].get(field, {}),
+            "right_evidence": extra["evidence"].get(field, {}),
+            "reject": reject,
+            "source": FINGERPRINT_SOURCES[field],
+        }
+        if line is not None:
+            entry["line"] = line
+        issues.append(entry)
+
     for field in FINGERPRINT_FIELDS:
         if field == "budget":
             continue
-        left, right = primary["fingerprint"].get(field), extra["fingerprint"].get(field)
-        verified = all(
-            side["evidence"].get(field, {}).get("status") == "complete" for side in (primary, extra))
-        if not verified:
-            kind = "unverifiable"
-        elif left != right:
-            kind = "different"
-        else:
+        statuses = tuple(
+            side["evidence"].get(field, {}).get("status") for side in (primary, extra))
+        if "inconsistent" in statuses:
+            issue("internal", field, True)
             continue
-        issues.append({
-            "kind": kind,
-            "field": f"{label}:{field}",
-            "left": left,
-            "right": right,
-            "left_evidence": primary["evidence"].get(field, {}),
-            "right_evidence": extra["evidence"].get(field, {}),
-            "reject": True,
-            "source": FINGERPRINT_SOURCES[field],
-        })
+        recorded = tuple(status in ("complete", "partial") for status in statuses)
+        if not any(recorded):
+            issue("unrecorded", field, False,
+                  line=f"unrecorded: {label}:{field} (identity not verifiable on either side)")
+        elif not all(recorded):
+            issue("asymmetric", field, True)
+        elif primary["fingerprint"].get(field) != extra["fingerprint"].get(field):
+            issue("different", field, True)
+        elif "partial" in statuses:
+            issue("coverage", field, False)
     return issues
 
 

--- a/test/evals/harbor/stella_harbor/fingerprint.py
+++ b/test/evals/harbor/stella_harbor/fingerprint.py
@@ -334,7 +334,10 @@ def format_mismatches(mismatches: list[dict[str, Any]]) -> list[str]:
         ("different", "CONFIGURATION DIFFERENT:"),
         ("unverifiable", "CANNOT VERIFY CONFIGURATION:"),
         ("internal", "INTERNALLY INCONSISTENT RUN:"),
+        ("asymmetric", "TOP-UP EVIDENCE RECORDED ON ONE SIDE ONLY:"),
         ("agent_incomplete", "AGENT IDENTITY INCOMPLETE (reported, not blocking):"),
+        ("unrecorded", "IDENTITY NEVER RECORDED (reported, not blocking):"),
+        ("coverage", "IDENTITY PARTIALLY COVERED (reported, not blocking):"),
     )
     for kind, title in groups:
         items = [item for item in mismatches if item["kind"] == kind]
@@ -342,6 +345,11 @@ def format_mismatches(mismatches: list[dict[str, Any]]) -> list[str]:
             continue
         lines.append(title)
         for item in items:
+            # An issue may carry its own wording when a value pair would say
+            # less than the sentence does.
+            if item.get("line"):
+                lines.append(f"  - {item['line']}")
+                continue
             left = _side(item["left"], item["left_evidence"])
             right = _side(item["right"], item["right_evidence"])
             source = f"; expected at {item['source']}" if item.get("source") else ""

--- a/test/evals/harbor/tests/test_compare.py
+++ b/test/evals/harbor/tests/test_compare.py
@@ -616,3 +616,210 @@ def test_an_unknown_k_judges_nothing(tmp_path, capsys):
     out = capsys.readouterr().out
     assert "k is unknown" in out
     assert "INSUFFICIENT_EVIDENCE t" in out
+
+
+# --- review fixes (#1111) ---------------------------------------------------
+
+
+def test_a_top_up_job_with_a_different_condition_is_refused(tmp_path, capsys):
+    # A top-up faces the same identity validation as a positional job; only its
+    # attempt budget may differ.
+    candidate = write_side(tmp_path, "cand", {"t": [{"reward": 1.0}, {"reward": 0.0}]})
+    topup = write_side(tmp_path, "cand-b", {"t": [{"reward": 1.0}]},
+                       agents=[{"name": "stella_harbor.agent:StellaAgent", "model_name": "other/model"}])
+    reference = write_side(tmp_path, "ref", {"t": resolved(0)})
+
+    assert main([str(candidate), str(reference), "--candidate-job", str(topup)]) == 2
+    err = capsys.readouterr().err
+    assert "candidate top-up cand-b:model" in err
+
+
+def test_a_top_up_may_carry_a_different_attempt_budget(tmp_path, capsys):
+    # The one permitted difference: a top-up exists to add trials the first job
+    # did not run.
+    candidate = write_side(tmp_path, "cand", {"t": [{"reward": 1.0}, {"reward": 0.0}]})
+    topup = write_side(tmp_path, "cand-b", {"t": [{"reward": 1.0}]}, n_attempts=1)
+    reference = write_side(tmp_path, "ref", {"t": resolved(0)})
+
+    assert main([str(candidate), str(reference), "--candidate-job", str(topup)]) == 0
+    assert "SIGNAL t: 2 vs 0 resolved (+2)" in capsys.readouterr().out
+
+
+def test_the_same_job_twice_is_refused_before_it_replicates_evidence(tmp_path, capsys):
+    candidate = write_side(tmp_path, "cand", {"t": resolved(1)})
+    reference = write_side(tmp_path, "ref", {"t": resolved(1)})
+
+    assert main([str(candidate), str(reference), "--candidate-job", str(candidate)]) == 2
+    err = capsys.readouterr().err
+    assert "the same run was given more than once" in err
+
+    # A job root and the run directory inside it are the same evidence.
+    assert main([str(candidate), str(reference), "--candidate-job", str(candidate / RUN)]) == 2
+    assert "the same run was given more than once" in capsys.readouterr().err
+
+
+def test_the_same_trial_reached_through_two_jobs_is_refused(tmp_path, capsys):
+    candidate = write_side(tmp_path, "cand", {"t": resolved(1)})
+    reference = write_side(tmp_path, "ref", {"t": resolved(1)})
+    mirror = tmp_path / "cand-mirror"
+    (mirror / RUN).mkdir(parents=True)
+    for name in ("config.json", "result.json"):
+        (mirror / RUN / name).write_text((candidate / RUN / name).read_text())
+    (mirror / RUN / "t__0").symlink_to(candidate / RUN / "t__0")
+
+    assert main([str(candidate), str(reference), "--candidate-job", str(mirror)]) == 2
+    assert "the same trial reached the comparison twice" in capsys.readouterr().err
+
+
+def test_an_untrusted_row_confirms_nothing(tmp_path, capsys):
+    # The candidate lost two, and it also timed out twice more. The flip already
+    # explains the movement, so a confirmation cannot be drawn from it.
+    candidate = write_side(tmp_path, "cand", {"t": [
+        {"reward": 1.0}, {"reward": 1.0}, {"reward": 1.0},
+        {"reward": 0.0, "timed_out": True}, {"reward": 0.0, "timed_out": True},
+    ]}, n_attempts=5)
+    reference = write_side(tmp_path, "ref", {"t": resolved(5, k=5)}, n_attempts=5)
+
+    assert main([str(candidate), str(reference), "--confirm"]) == 0
+    out = capsys.readouterr().out
+    assert "UNTRUSTED: candidate 3/5 vs reference 5/5" in out
+    assert "Re-run both sides." in out
+    assert "CONFIRMED_REGRESSION" not in out
+
+
+def test_allow_mismatch_can_never_back_a_confirmation(tmp_path, capsys):
+    candidate = write_side(tmp_path, "cand", {"t": resolved(1, k=5)}, n_attempts=5)
+    reference = write_side(tmp_path, "ref", {"t": resolved(4, k=5)}, n_attempts=5)
+
+    assert main([str(candidate), str(reference), "--confirm", "--allow-mismatch"]) == 2
+    assert "can never back a confirmation" in capsys.readouterr().err
+
+
+def test_k_may_not_override_a_recorded_attempt_budget(tmp_path, capsys):
+    candidate = write_side(tmp_path, "cand", {"t": resolved(3)})
+    reference = write_side(tmp_path, "ref", {"t": resolved(0)})
+
+    assert main([str(candidate), str(reference), "--k", "5"]) == 2
+    err = capsys.readouterr().err
+    assert "conflicts with the attempt budget the jobs recorded (3)" in err
+    # Restating the recorded budget is not a conflict.
+    assert main([str(candidate), str(reference), "--k", "3"]) == 0
+
+
+def test_k_still_fills_in_a_budget_no_artifact_recorded(tmp_path, capsys):
+    candidate = write_side(tmp_path, "cand", {"t": resolved(3)}, n_attempts=None)
+    reference = write_side(tmp_path, "ref", {"t": resolved(0)}, n_attempts=None)
+
+    assert main([str(candidate), str(reference), "--k", "3", "--allow-mismatch"]) == 0
+    assert "SIGNAL t: 3 vs 0 resolved (+3)" in capsys.readouterr().out
+
+
+def test_a_subset_that_selects_nothing_is_refused(tmp_path, capsys):
+    candidate = write_side(tmp_path, "cand", {"a": resolved(1)})
+    reference = write_side(tmp_path, "ref", {"a": resolved(1)})
+
+    assert main([str(candidate), str(reference), "--tasks", ","]) == 2
+    assert "selected no task at all" in capsys.readouterr().err
+
+
+def test_a_reference_with_no_tasks_is_refused(tmp_path, capsys):
+    candidate = write_side(tmp_path, "cand", {"a": resolved(1)})
+    reference = write_side(tmp_path, "ref", {})
+
+    assert main([str(candidate), str(reference)]) == 2
+    assert "the reference declares no tasks" in capsys.readouterr().err
+
+
+def test_confirmation_refuses_a_candidate_carrying_an_extra_task(tmp_path, capsys):
+    # Coverage only requires the candidate to hold every reference task, so a
+    # one-task reference does not by itself make a single-task confirmation.
+    candidate = write_side(tmp_path, "cand", {"t": resolved(1, k=5), "extra": resolved(1, k=5)}, n_attempts=5)
+    reference = write_side(tmp_path, "ref", {"t": resolved(4, k=5)}, n_attempts=5)
+
+    assert main([str(candidate), str(reference), "--confirm"]) == 2
+    assert "single-task run on both sides" in capsys.readouterr().err
+
+
+def test_an_improvement_that_came_with_more_timeouts_is_still_judged(tmp_path, capsys):
+    # Timing out more often does not explain resolving more, so the flip test
+    # must not swallow the improvement.
+    candidate = write_side(tmp_path, "cand", {"t": [
+        {"reward": 1.0}, {"reward": 1.0}, {"reward": 0.0, "timed_out": True},
+    ]})
+    reference = write_side(tmp_path, "ref", {"t": resolved(1)})
+
+    assert main([str(candidate), str(reference)]) == 0
+    out = capsys.readouterr().out
+    assert "SIGNAL t: 2 vs 1 resolved (+1)" in out
+    assert "UNTRUSTED" not in out
+
+
+def test_a_regression_that_came_with_fewer_timeouts_is_still_judged(tmp_path, capsys):
+    # Timing out less often does not explain resolving less; absolute counts
+    # would have hidden this regression behind an untrusted marker.
+    candidate = write_side(tmp_path, "cand", {"t": resolved(0)})
+    reference = write_side(tmp_path, "ref", {"t": [
+        {"reward": 1.0}, {"reward": 1.0}, {"reward": 0.0, "timed_out": True},
+    ]})
+
+    assert main([str(candidate), str(reference)]) == 0
+    out = capsys.readouterr().out
+    assert "SUSPECTED_REGRESSION t" in out and "down 2 resolved" in out
+    assert "UNTRUSTED" not in out
+
+
+def test_one_trial_without_a_metric_leaves_the_whole_metric_unjudged(tmp_path, capsys):
+    # A mean over the trials that happen to carry the field is not the mean the
+    # metric names: two of three at 0.02 must not read as a cost signal.
+    candidate = write_side(tmp_path, "cand", {"t": [
+        {"reward": 1.0, "cost": 0.02}, {"reward": 1.0, "cost": 0.02},
+        {"reward": 0.0, "cost": None},
+    ]})
+    reference = write_side(tmp_path, "ref", {"t": resolved(2, cost=0.01)})
+
+    assert main([str(candidate), str(reference)]) == 0
+    out = capsys.readouterr().out
+    assert "EFFICIENCY_SIGNAL" not in out
+
+
+def test_an_empty_tools_dict_measured_zero_errors(tmp_path, capsys):
+    # Post-#1077 with tools: {} means the tool never erred, which is a real
+    # zero: a reference mean of zero leaves the metric unjudged, it does not
+    # make the trial's evidence missing.
+    candidate = write_side(tmp_path, "cand", {"t": resolved(2, tools={"edit": 4})})
+    reference = write_side(tmp_path, "ref", {"t": [
+        {"reward": 1.0, "tools": {}}, {"reward": 1.0, "tools": {}}, {"reward": 0.0, "tools": {}},
+    ]})
+
+    assert main([str(candidate), str(reference)]) == 0
+    out = capsys.readouterr().out
+    assert "error counts predate #1077" not in out
+    assert "4.0 / 0.0" in out
+    assert "EFFICIENCY_SIGNAL" not in out
+
+
+def test_a_trial_without_tool_evidence_leaves_error_counts_unjudged(tmp_path, capsys):
+    candidate = write_side(tmp_path, "cand", {"t": [
+        {"reward": 1.0, "tools": {"edit": 4}}, {"reward": 1.0, "tools": {"edit": 4}},
+        {"reward": 0.0, "no_adapter": True},
+    ]})
+    reference = write_side(tmp_path, "ref", {"t": resolved(2, tools={"edit": 1})})
+
+    assert main([str(candidate), str(reference)]) == 0
+    out = capsys.readouterr().out
+    assert "EFFICIENCY_SIGNAL" not in out
+    assert "error counts predate #1077" not in out
+
+
+def test_a_pre_split_trial_with_no_tools_still_taints_the_pair(tmp_path, capsys):
+    # An empty tools dict does not exempt a pre-#1077 trial: the counter it kept
+    # folded command exits in either way.
+    candidate = write_side(tmp_path, "cand", {"t": [
+        *resolved(2, k=2, tools={"edit": 4}), {"reward": 0.0, "tools": {}, "errors_split": False},
+    ]})
+    reference = write_side(tmp_path, "ref", {"t": resolved(2, tools={"edit": 1})})
+
+    assert main([str(candidate), str(reference)]) == 0
+    out = capsys.readouterr().out
+    assert "error counts predate #1077" in out
+    assert "EFFICIENCY_SIGNAL" not in out

--- a/test/evals/harbor/tests/test_compare.py
+++ b/test/evals/harbor/tests/test_compare.py
@@ -61,8 +61,12 @@ def test_compare_reads_a_job_without_the_stella_adapter(tmp_path):
 
     rows = load(job)
 
-    assert rows == [{"task": "regex-log", "reward": 1.0, "cost_usd": 0.02,
-                     "input_tokens": 10, "output_tokens": 5, "valid": None}]
+    assert len(rows) == 1
+    row = rows[0]
+    assert (row["task"], row["reward"], row["cost_usd"]) == ("regex-log", 1.0, 0.02)
+    assert (row["input_tokens"], row["output_tokens"]) == (10, 5)
+    # No adapter evidence at all, so the verifier reward is the validity fallback.
+    assert row["valid"] is True and row["adapter"] is False
     assert summarize(rows)["resolved"] == 1
 
 
@@ -103,7 +107,7 @@ def test_matching_fingerprints_are_comparable(tmp_path, capsys):
     assert not any(issue["reject"] for issue in issues)
     assert main([str(left), str(right), "--names", "left", "right"]) == 0
     output = capsys.readouterr().out
-    assert "left  vs  right" in output
+    assert "candidate left  vs  reference right" in output
     assert "SAME-AGENT" in output
 
 
@@ -237,7 +241,9 @@ def test_partial_capability_coverage_is_reported(tmp_path, capsys):
     (job / run / "result.json").write_text(json.dumps({"n_total_trials": 5}))
     for index in range(5):
         adapter = {"capability_profile_digest": "capability-a"} if index < 2 else None
-        write(job, run, f"task-{index}", 1.0, 0.01, adapter=adapter)
+        # One task, five trials: the coverage rule compares task sets, and this
+        # fixture is about fingerprint evidence, not task selection.
+        write(job, run, "t", 1.0, 0.01, suffix=f"trial-{index}", adapter=adapter)
 
     details = collect_fingerprint_details(job)
     evidence = details["evidence"]["capability_profile_digest"]
@@ -288,3 +294,325 @@ def test_render_names_both_runs_and_every_task(tmp_path):
 
     assert "shared" in out and "only-right" in out
     assert "stella" in out and "pi" in out
+
+
+# --- loop comparator (PROTOCOL.md) -----------------------------------------
+
+RUN = "2026-08-19__10-00-00"
+
+
+def write_side(tmp_path, name, tasks, *, n_attempts=3, **overrides):
+    """Build one side of a comparison.
+
+    `tasks` maps a task name to a list of trial specs; a spec is a dict with
+    any of reward, cost, valid, timed_out, exception, tools, errors_split,
+    calls, turns, ledger.
+    """
+    job = tmp_path / name
+    write_run_config(job, RUN, n_attempts=n_attempts, **overrides)
+    (job / RUN / "result.json").write_text("{}")
+    for task, trials in tasks.items():
+        for index, spec in enumerate(trials):
+            trial = job / RUN / f"{task}__{index}"
+            trial.mkdir(parents=True)
+            harbor = {
+                "agent_result": {
+                    "cost_usd": spec.get("cost", 0.01),
+                    "n_input_tokens": spec.get("input_tokens", 1000),
+                    "n_output_tokens": 100,
+                },
+            }
+            reward = spec.get("reward")
+            if reward is not None:
+                harbor["verifier_result"] = {"rewards": {"reward": reward}}
+            if spec.get("exception"):
+                harbor["exception_info"] = spec["exception"]
+            (trial / "result.json").write_text(json.dumps(harbor))
+            if spec.get("no_adapter"):
+                continue
+            tools = spec.get("tools", {"bash": 0})
+            metrics = {
+                "turns": spec.get("turns", 5),
+                "tool_call_total": spec.get("calls", 10),
+                "tool_error_total": sum(tools.values()),
+                "tools": {n: {"calls": 5, "errors": e} for n, e in tools.items()},
+                "timing_ms": {"total": spec.get("wall_ms", 1000)},
+            }
+            if spec.get("errors_split", True):
+                metrics["command_nonzero_total"] = spec.get("command_nonzero_total", 0)
+            adapter = {
+                "valid": spec.get("valid", True),
+                "timed_out": spec.get("timed_out", False),
+                "capability_profile_digest": "capability-a",
+                "metrics": metrics,
+            }
+            if spec.get("ledger"):
+                adapter["bridge_ledger"] = spec["ledger"]
+            (trial / "agent" / "stella").mkdir(parents=True)
+            (trial / "agent" / "stella" / "result.json").write_text(json.dumps(adapter))
+    return job
+
+
+def resolved(n, k=3, **spec):
+    """k trials for one task, n of them resolved."""
+    return [{"reward": 1.0 if i < n else 0.0, **spec} for i in range(k)]
+
+
+def test_a_task_moves_and_is_reported_as_a_signal(tmp_path, capsys):
+    candidate = write_side(tmp_path, "cand", {"target": resolved(1)})
+    reference = write_side(tmp_path, "ref", {"target": resolved(0)})
+
+    assert main([str(candidate), str(reference)]) == 0
+    out = capsys.readouterr().out
+    assert "SIGNAL target: 1 vs 0 resolved (+1)" in out
+    assert "SUSPECTED_REGRESSION" not in out
+
+
+def test_a_guard_falling_below_k_is_a_suspected_regression(tmp_path, capsys):
+    candidate = write_side(tmp_path, "cand", {"guarded": resolved(2)})
+    reference = write_side(tmp_path, "ref", {"guarded": resolved(3)})
+
+    assert main([str(candidate), str(reference)]) == 0
+    out = capsys.readouterr().out
+    assert "SUSPECTED_REGRESSION guarded" in out and "a guard dropped below k/k" in out
+    # Loud, but it still does not gate.
+    assert "does not gate" in out
+
+
+def test_a_two_point_drop_is_a_suspected_regression_without_a_guard(tmp_path, capsys):
+    # The reference never resolved k of k, so this is not a guard; the drop alone
+    # is what triggers.
+    candidate = write_side(tmp_path, "cand", {"flaky": resolved(0)}, n_attempts=3)
+    reference = write_side(tmp_path, "ref", {"flaky": resolved(2)}, n_attempts=3)
+
+    assert main([str(candidate), str(reference)]) == 0
+    out = capsys.readouterr().out
+    assert "SUSPECTED_REGRESSION flaky" in out and "down 2 resolved" in out
+
+
+def test_no_movement_says_so(tmp_path, capsys):
+    candidate = write_side(tmp_path, "cand", {"steady": resolved(2)})
+    reference = write_side(tmp_path, "ref", {"steady": resolved(2)})
+
+    assert main([str(candidate), str(reference)]) == 0
+    assert "No movement" in capsys.readouterr().out
+
+
+def test_a_short_side_is_insufficient_evidence_and_never_judged(tmp_path, capsys):
+    candidate = write_side(tmp_path, "cand", {"t": resolved(0, k=2)})
+    reference = write_side(tmp_path, "ref", {"t": resolved(3)})
+
+    assert main([str(candidate), str(reference)]) == 0
+    out = capsys.readouterr().out
+    assert "INSUFFICIENT_EVIDENCE t: candidate 2 scoreable, reference 3" in out
+    # A guard that dropped 3 -> 0 would be the loudest verdict there is; it must
+    # not appear, because the task was never judged.
+    assert "SUSPECTED_REGRESSION" not in out and "SIGNAL t" not in out
+
+
+def test_a_valid_trial_without_a_reward_is_not_scoreable(tmp_path, capsys):
+    # The verifier's infrastructure failed. That is not an agent failure, so the
+    # trial leaves the denominator instead of counting as unresolved.
+    candidate = write_side(tmp_path, "cand", {"t": [*resolved(2), {"reward": None}]})
+    reference = write_side(tmp_path, "ref", {"t": resolved(2)})
+
+    assert main([str(candidate), str(reference)]) == 0
+    out = capsys.readouterr().out
+    assert "INSUFFICIENT_EVIDENCE" not in out
+    assert "No movement" in out
+
+
+def test_a_missing_required_task_is_refused_by_name(tmp_path, capsys):
+    candidate = write_side(tmp_path, "cand", {"a": resolved(1)})
+    reference = write_side(tmp_path, "ref", {"a": resolved(1), "b": resolved(1), "c": resolved(1)})
+
+    assert main([str(candidate), str(reference)]) == 2
+    err = capsys.readouterr().err
+    assert "REFUSING COMPARISON" in err and "missing task(s)" in err
+    assert "b" in err and "c" in err
+
+
+def test_an_explicit_subset_is_allowed_and_echoed(tmp_path, capsys):
+    candidate = write_side(tmp_path, "cand", {"a": resolved(1)})
+    reference = write_side(tmp_path, "ref", {"a": resolved(1), "b": resolved(1)})
+
+    assert main([str(candidate), str(reference), "--tasks", "a"]) == 0
+    out = capsys.readouterr().out
+    assert "EXPLICIT SUBSET (--tasks): 1 task(s) compared — a" in out
+    assert "model and dataset are not" in out
+
+
+def test_a_subset_naming_an_unknown_task_is_refused(tmp_path, capsys):
+    candidate = write_side(tmp_path, "cand", {"a": resolved(1)})
+    reference = write_side(tmp_path, "ref", {"a": resolved(1)})
+
+    assert main([str(candidate), str(reference), "--tasks", "nope"]) == 2
+    assert "the reference never ran" in capsys.readouterr().err
+
+
+def test_confirmation_confirms_a_regression_and_exits_nonzero(tmp_path, capsys):
+    candidate = write_side(tmp_path, "cand", {"t": resolved(1, k=5)}, n_attempts=5)
+    reference = write_side(tmp_path, "ref", {"t": resolved(4, k=5)}, n_attempts=5)
+
+    assert main([str(candidate), str(reference), "--confirm"]) == 1
+    assert "CONFIRMED_REGRESSION: candidate 1/5 vs reference 4/5" in capsys.readouterr().out
+
+
+def test_confirmation_confirms_an_improvement_without_gating(tmp_path, capsys):
+    candidate = write_side(tmp_path, "cand", {"t": resolved(4, k=5)}, n_attempts=5)
+    reference = write_side(tmp_path, "ref", {"t": resolved(1, k=5)}, n_attempts=5)
+
+    assert main([str(candidate), str(reference), "--confirm"]) == 0
+    assert "CONFIRMED_IMPROVEMENT: candidate 4/5 vs reference 1/5" in capsys.readouterr().out
+
+
+def test_a_one_trial_difference_is_dismissed_with_both_counts(tmp_path, capsys):
+    candidate = write_side(tmp_path, "cand", {"t": resolved(3, k=5)}, n_attempts=5)
+    reference = write_side(tmp_path, "ref", {"t": resolved(2, k=5)}, n_attempts=5)
+
+    assert main([str(candidate), str(reference), "--confirm"]) == 0
+    assert "DISMISSED: candidate 3/5 vs reference 2/5" in capsys.readouterr().out
+
+
+def test_confirmation_refuses_anything_that_is_not_a_single_task_at_k5(tmp_path, capsys):
+    candidate = write_side(tmp_path, "cand", {"t": resolved(1)})
+    reference = write_side(tmp_path, "ref", {"t": resolved(1)})
+    assert main([str(candidate), str(reference), "--confirm"]) == 2
+    assert "single-task k=5 run" in capsys.readouterr().err
+
+    two = {"a": resolved(1, k=5), "b": resolved(1, k=5)}
+    candidate = write_side(tmp_path, "cand5", two, n_attempts=5)
+    reference = write_side(tmp_path, "ref5", two, n_attempts=5)
+    assert main([str(candidate), str(reference), "--confirm"]) == 2
+    assert "single-task run" in capsys.readouterr().err
+
+
+def test_efficiency_signal_triggers_on_cost_with_resolution_unchanged(tmp_path, capsys):
+    candidate = write_side(tmp_path, "cand", {"t": resolved(2, cost=0.02)})
+    reference = write_side(tmp_path, "ref", {"t": resolved(2, cost=0.01)})
+
+    assert main([str(candidate), str(reference)]) == 0
+    out = capsys.readouterr().out
+    assert "EFFICIENCY_SIGNAL t" in out and "cost +100.0%" in out
+    assert "resolved unchanged at 2" in out
+
+
+def test_efficiency_signal_triggers_on_per_tool_error_counts(tmp_path, capsys):
+    candidate = write_side(tmp_path, "cand", {"t": resolved(2, tools={"edit": 1})})
+    reference = write_side(tmp_path, "ref", {"t": resolved(2, tools={"edit": 4})})
+
+    assert main([str(candidate), str(reference)]) == 0
+    out = capsys.readouterr().out
+    assert "EFFICIENCY_SIGNAL t" in out and "errors:edit -75.0%" in out
+
+
+def test_a_zero_reference_mean_leaves_the_metric_unjudged(tmp_path, capsys):
+    # Dividing by a reference mean of zero has no defined delta, so the metric
+    # is unjudged rather than infinite.
+    candidate = write_side(tmp_path, "cand", {"t": resolved(2, tools={"edit": 3})})
+    reference = write_side(tmp_path, "ref", {"t": resolved(2, tools={"edit": 0})})
+
+    assert main([str(candidate), str(reference)]) == 0
+    out = capsys.readouterr().out
+    assert "EFFICIENCY_SIGNAL" not in out
+    assert "No movement" in out
+
+
+def test_a_missing_metric_leaves_it_unjudged(tmp_path, capsys):
+    # The reference agent reports no cost and no adapter metrics at all.
+    candidate = write_side(tmp_path, "cand", {"t": resolved(2, cost=0.05)})
+    reference = write_side(tmp_path, "ref", {"t": resolved(2, cost=None, no_adapter=True)})
+
+    assert main([str(candidate), str(reference)]) == 0
+    out = capsys.readouterr().out
+    assert "EFFICIENCY_SIGNAL" not in out
+
+
+def test_a_change_that_is_only_a_timeout_class_flip_is_untrusted(tmp_path, capsys):
+    candidate = write_side(tmp_path, "cand", {"t": [
+        {"reward": 0.0, "timed_out": True}, {"reward": 1.0}, {"reward": 1.0},
+    ]})
+    reference = write_side(tmp_path, "ref", {"t": resolved(3)})
+
+    assert main([str(candidate), str(reference)]) == 0
+    out = capsys.readouterr().out
+    assert "UNTRUSTED t" in out and "timeout-class flip" in out
+    # Untrusted means not judged: the guard drop must not be reported as a verdict.
+    assert "SUSPECTED_REGRESSION" not in out and "SIGNAL t" not in out
+
+
+def test_timeout_classes_are_assigned_by_first_match(tmp_path):
+    from stella_harbor.compare import load
+
+    job = write_side(tmp_path, "job", {"t": [
+        {"reward": 0.0, "exception": {"exception_type": "AgentTimeoutError",
+                                      "exception_message": "agent timed out"},
+         "timed_out": True},
+        {"reward": 0.0, "timed_out": True, "ledger": [{"op": "exec", "ok": True, "return_code": -1}]},
+        {"reward": 0.0, "ledger": [{"op": "exec", "ok": True, "return_code": -1}]},
+        {"reward": 1.0},
+    ]})
+
+    classes = [row["timeout_class"] for row in load(job)]
+
+    assert classes == ["harness_timeout", "agent_deadline", "command_timeout", "none"]
+
+
+def test_pre_1077_error_counts_are_displayed_but_never_judged(tmp_path, capsys):
+    # Both sides predate the split, so their error counts fold nonzero command
+    # exits in. A 4x difference must still not raise an EFFICIENCY_SIGNAL.
+    candidate = write_side(tmp_path, "cand", {"t": resolved(2, tools={"bash": 8}, errors_split=False)})
+    reference = write_side(tmp_path, "ref", {"t": resolved(2, tools={"bash": 2}, errors_split=False)})
+
+    assert main([str(candidate), str(reference)]) == 0
+    out = capsys.readouterr().out
+    assert "EFFICIENCY_SIGNAL" not in out
+    assert "error counts predate #1077" in out
+    # Displayed all the same: 8.0 and 2.0 means, marked untrusted.
+    assert "8.0 / 2.0*" in out
+
+
+def test_mixed_old_and_new_sides_do_not_judge_error_counts(tmp_path, capsys):
+    # The candidate split its counters, the reference did not. The pair is only
+    # as trustworthy as its weaker side.
+    candidate = write_side(tmp_path, "cand", {"t": resolved(2, tools={"bash": 1})})
+    reference = write_side(tmp_path, "ref", {"t": resolved(2, tools={"bash": 6}, errors_split=False)})
+
+    assert main([str(candidate), str(reference)]) == 0
+    out = capsys.readouterr().out
+    assert "EFFICIENCY_SIGNAL" not in out
+    assert "error counts predate #1077" in out
+
+
+def test_process_metrics_show_all_three_tiers(tmp_path, capsys):
+    candidate = write_side(tmp_path, "cand", {"t": resolved(2, calls=20, turns=9, wall_ms=4000)})
+    reference = write_side(tmp_path, "ref", {"t": resolved(2, calls=10, turns=4, wall_ms=2000)})
+
+    assert main([str(candidate), str(reference)]) == 0
+    out = capsys.readouterr().out
+    assert "Process metrics" in out
+    assert "20.0 / 10.0" in out and "9.0 / 4.0" in out       # behavioral
+    assert "1000 / 1000" in out and "0.0100 / 0.0100" in out  # gateway
+    assert "4.0 / 2.0" in out                                 # wall, displayed
+    assert "Wall time is displayed and never judged" in out
+
+
+def test_several_job_directories_make_up_one_side(tmp_path, capsys):
+    # A side's k trials can be split across top-up jobs; every path is still named.
+    first = write_side(tmp_path, "cand-a", {"t": [{"reward": 1.0}, {"reward": 0.0}]})
+    second = write_side(tmp_path, "cand-b", {"t": [{"reward": 1.0}]})
+    reference = write_side(tmp_path, "ref", {"t": resolved(0)})
+
+    assert main([str(first), str(reference), "--candidate-job", str(second)]) == 0
+    out = capsys.readouterr().out
+    assert "SIGNAL t: 2 vs 0 resolved (+2)" in out
+
+
+def test_an_unknown_k_judges_nothing(tmp_path, capsys):
+    candidate = write_side(tmp_path, "cand", {"t": resolved(3)}, n_attempts=None)
+    reference = write_side(tmp_path, "ref", {"t": resolved(0)}, n_attempts=None)
+
+    assert main([str(candidate), str(reference), "--allow-mismatch"]) == 0
+    out = capsys.readouterr().out
+    assert "k is unknown" in out
+    assert "INSUFFICIENT_EVIDENCE t" in out

--- a/test/evals/harbor/tests/test_compare.py
+++ b/test/evals/harbor/tests/test_compare.py
@@ -923,3 +923,36 @@ def test_two_build_identities_inside_one_top_up_are_refused(tmp_path, capsys):
     err = capsys.readouterr().err
     assert "INTERNALLY INCONSISTENT RUN:" in err
     assert "candidate top-up cand-b:capability_profile_digest" in err
+
+
+def test_a_budget_recorded_by_one_side_alone_is_still_a_mismatch(tmp_path, capsys):
+    # Reading the recorded budget must not consume it: without --k there is
+    # nothing to fill the reference's silence with.
+    candidate = write_side(tmp_path, "cand", {"t": resolved(5, k=5)}, n_attempts=5)
+    reference = write_side(tmp_path, "ref", {"t": resolved(5, k=5)}, n_attempts=None)
+
+    assert main([str(candidate), str(reference)]) == 2
+    err = capsys.readouterr().err
+    assert "CANNOT VERIFY CONFIGURATION:" in err and "budget" in err
+    assert "supplied by --k" not in capsys.readouterr().out
+
+
+def test_confirmation_refuses_a_top_up_whose_identity_nothing_records(tmp_path, capsys):
+    candidate = write_side(tmp_path, "cand", {"t": resolved(1, k=3)}, n_attempts=5)
+    topup = write_side(tmp_path, "cand-b", {"t": resolved(0, k=2)}, n_attempts=5)
+    reference = write_side(tmp_path, "ref", {"t": resolved(4, k=5)}, n_attempts=5)
+
+    assert main([str(candidate), str(reference), "--confirm", "--candidate-job", str(topup)]) == 2
+    err = capsys.readouterr().err
+    assert "a top-up carries identity no artifact records" in err
+    assert "candidate top-up cand-b:candidate_commit" in err
+
+
+def test_confirmation_without_a_top_up_runs_with_the_same_silent_fields(tmp_path, capsys):
+    # Nothing records candidate_commit or tool_strategy here either; the
+    # closure is about top-ups, not about the fields themselves.
+    candidate = write_side(tmp_path, "cand", {"t": resolved(1, k=5)}, n_attempts=5)
+    reference = write_side(tmp_path, "ref", {"t": resolved(4, k=5)}, n_attempts=5)
+
+    assert main([str(candidate), str(reference), "--confirm"]) == 1
+    assert "CONFIRMED_REGRESSION: candidate 1/5 vs reference 4/5" in capsys.readouterr().out

--- a/test/evals/harbor/tests/test_compare.py
+++ b/test/evals/harbor/tests/test_compare.py
@@ -309,10 +309,6 @@ def write_side(tmp_path, name, tasks, *, n_attempts=3, **overrides):
     calls, turns, ledger.
     """
     job = tmp_path / name
-    # A loop side records its build identity; without it a top-up cannot be
-    # verified to belong to the same side, which is now refused.
-    overrides.setdefault("tool_strategy", "default")
-    overrides.setdefault("candidate_commit", "commit-a")
     write_run_config(job, RUN, n_attempts=n_attempts, **overrides)
     (job / RUN / "result.json").write_text("{}")
     for task, trials in tasks.items():
@@ -347,7 +343,7 @@ def write_side(tmp_path, name, tasks, *, n_attempts=3, **overrides):
             adapter = {
                 "valid": spec.get("valid", True),
                 "timed_out": spec.get("timed_out", False),
-                "capability_profile_digest": "capability-a",
+                "capability_profile_digest": spec.get("capability", "capability-a"),
                 "metrics": metrics,
             }
             if spec.get("ledger"):
@@ -836,8 +832,8 @@ def test_a_pre_split_trial_with_no_tools_still_taints_the_pair(tmp_path, capsys)
 
 
 def test_a_top_up_that_cannot_prove_its_build_is_refused(tmp_path, capsys):
-    # Cross-side an incomplete capability digest is a diagnostic; within a side
-    # it is trials of unknown provenance joining one denominator.
+    # State 2, asymmetric evidence: the side recorded a build, the top-up
+    # recorded nothing, so it cannot show it belongs here.
     candidate = write_side(tmp_path, "cand", {"t": [{"reward": 1.0}, {"reward": 0.0}]})
     topup = write_side(tmp_path, "cand-b", {"t": [{"reward": 1.0, "no_adapter": True}]})
     reference = write_side(tmp_path, "ref", {"t": resolved(0)})
@@ -850,7 +846,9 @@ def test_a_top_up_that_cannot_prove_its_build_is_refused(tmp_path, capsys):
 
 
 def test_a_top_up_from_a_different_commit_is_refused(tmp_path, capsys):
-    candidate = write_side(tmp_path, "cand", {"t": [{"reward": 1.0}, {"reward": 0.0}]})
+    # State 1, both recorded and they differ.
+    candidate = write_side(tmp_path, "cand", {"t": [{"reward": 1.0}, {"reward": 0.0}]},
+                           candidate_commit="commit-a")
     topup = write_side(tmp_path, "cand-b", {"t": [{"reward": 1.0}]}, candidate_commit="commit-b")
     reference = write_side(tmp_path, "ref", {"t": resolved(0)})
 
@@ -875,3 +873,53 @@ def test_k_rescues_only_the_budget_and_nothing_else(tmp_path, capsys):
     assert main([str(candidate), str(reference), "--k", "3"]) == 2
     err = capsys.readouterr().err
     assert "CANNOT VERIFY CONFIGURATION:" in err and "model" in err
+
+
+def test_a_field_neither_job_ever_recorded_is_reported_not_refused(tmp_path, capsys):
+    # State 3. No Harbor artifact writes candidate_commit or tool_strategy
+    # today, and refusing mutual silence would condemn the protocol's own
+    # re-run path: an INSUFFICIENT_EVIDENCE top-up is exactly this case.
+    candidate = write_side(tmp_path, "cand", {"t": [{"reward": 1.0}, {"reward": 0.0}]})
+    topup = write_side(tmp_path, "cand-b", {"t": [{"reward": 1.0}]})
+    reference = write_side(tmp_path, "ref", {"t": resolved(0)})
+
+    assert main([str(candidate), str(reference), "--candidate-job", str(topup)]) == 0
+    out = capsys.readouterr().out
+    assert "IDENTITY NEVER RECORDED (reported, not blocking):" in out
+    assert "unrecorded: candidate top-up cand-b:candidate_commit " \
+           "(identity not verifiable on either side)" in out
+    assert "unrecorded: candidate top-up cand-b:tool_strategy " \
+           "(identity not verifiable on either side)" in out
+    assert "UNTRUSTWORTHY" not in out
+    # The top-up's trials are merged, which is the whole point of the path.
+    assert "SIGNAL t: 2 vs 0 resolved (+2)" in out
+
+
+def test_partial_coverage_inside_a_job_is_that_jobs_value(tmp_path, capsys):
+    # Real archives carry the digest on most trials, not all. One value, some
+    # trials silent: the job's value, with its coverage reported.
+    candidate = write_side(tmp_path, "cand", {"t": [
+        {"reward": 1.0}, {"reward": 0.0}, {"reward": 0.0, "no_adapter": True},
+    ]})
+    topup = write_side(tmp_path, "cand-b", {"t": [{"reward": 1.0}]})
+    reference = write_side(tmp_path, "ref", {"t": resolved(0)})
+
+    assert main([str(candidate), str(reference), "--candidate-job", str(topup)]) == 0
+    out = capsys.readouterr().out
+    assert "IDENTITY PARTIALLY COVERED (reported, not blocking):" in out
+    assert "candidate top-up cand-b:capability_profile_digest" in out and "[2/3]" in out
+    assert "UNTRUSTWORTHY" not in out
+
+
+def test_two_build_identities_inside_one_top_up_are_refused(tmp_path, capsys):
+    candidate = write_side(tmp_path, "cand", {"t": [{"reward": 1.0}, {"reward": 0.0}]})
+    topup = write_side(tmp_path, "cand-b", {"t": [
+        {"reward": 1.0, "capability": "capability-a"},
+        {"reward": 1.0, "capability": "capability-b"},
+    ]})
+    reference = write_side(tmp_path, "ref", {"t": resolved(0)})
+
+    assert main([str(candidate), str(reference), "--candidate-job", str(topup)]) == 2
+    err = capsys.readouterr().err
+    assert "INTERNALLY INCONSISTENT RUN:" in err
+    assert "candidate top-up cand-b:capability_profile_digest" in err

--- a/test/evals/harbor/tests/test_compare.py
+++ b/test/evals/harbor/tests/test_compare.py
@@ -309,6 +309,10 @@ def write_side(tmp_path, name, tasks, *, n_attempts=3, **overrides):
     calls, turns, ledger.
     """
     job = tmp_path / name
+    # A loop side records its build identity; without it a top-up cannot be
+    # verified to belong to the same side, which is now refused.
+    overrides.setdefault("tool_strategy", "default")
+    overrides.setdefault("candidate_commit", "commit-a")
     write_run_config(job, RUN, n_attempts=n_attempts, **overrides)
     (job / RUN / "result.json").write_text("{}")
     for task, trials in tasks.items():
@@ -707,11 +711,17 @@ def test_k_may_not_override_a_recorded_attempt_budget(tmp_path, capsys):
 
 
 def test_k_still_fills_in_a_budget_no_artifact_recorded(tmp_path, capsys):
+    # An unrecorded budget is a blocking fingerprint issue, and a confirmation
+    # may not use --allow-mismatch, so --k has to satisfy it or archived runs
+    # cannot be compared at all.
     candidate = write_side(tmp_path, "cand", {"t": resolved(3)}, n_attempts=None)
     reference = write_side(tmp_path, "ref", {"t": resolved(0)}, n_attempts=None)
 
-    assert main([str(candidate), str(reference), "--k", "3", "--allow-mismatch"]) == 0
-    assert "SIGNAL t: 3 vs 0 resolved (+3)" in capsys.readouterr().out
+    assert main([str(candidate), str(reference), "--k", "3"]) == 0
+    out = capsys.readouterr().out
+    assert "SIGNAL t: 3 vs 0 resolved (+3)" in out
+    assert "k = 3 — supplied by --k; no run recorded an attempt budget" in out
+    assert "UNTRUSTWORTHY" not in out and "CANNOT VERIFY" not in out
 
 
 def test_a_subset_that_selects_nothing_is_refused(tmp_path, capsys):
@@ -823,3 +833,45 @@ def test_a_pre_split_trial_with_no_tools_still_taints_the_pair(tmp_path, capsys)
     out = capsys.readouterr().out
     assert "error counts predate #1077" in out
     assert "EFFICIENCY_SIGNAL" not in out
+
+
+def test_a_top_up_that_cannot_prove_its_build_is_refused(tmp_path, capsys):
+    # Cross-side an incomplete capability digest is a diagnostic; within a side
+    # it is trials of unknown provenance joining one denominator.
+    candidate = write_side(tmp_path, "cand", {"t": [{"reward": 1.0}, {"reward": 0.0}]})
+    topup = write_side(tmp_path, "cand-b", {"t": [{"reward": 1.0, "no_adapter": True}]})
+    reference = write_side(tmp_path, "ref", {"t": resolved(0)})
+
+    assert main([str(candidate), str(reference), "--candidate-job", str(topup)]) == 2
+    captured = capsys.readouterr()
+    assert "candidate top-up cand-b:capability_profile_digest" in captured.err
+    # The unverified trials must not have been merged into the side.
+    assert "SIGNAL" not in captured.out
+
+
+def test_a_top_up_from_a_different_commit_is_refused(tmp_path, capsys):
+    candidate = write_side(tmp_path, "cand", {"t": [{"reward": 1.0}, {"reward": 0.0}]})
+    topup = write_side(tmp_path, "cand-b", {"t": [{"reward": 1.0}]}, candidate_commit="commit-b")
+    reference = write_side(tmp_path, "ref", {"t": resolved(0)})
+
+    assert main([str(candidate), str(reference), "--candidate-job", str(topup)]) == 2
+    assert "candidate top-up cand-b:candidate_commit" in capsys.readouterr().err
+
+
+def test_an_unrecorded_budget_without_k_is_still_refused(tmp_path, capsys):
+    candidate = write_side(tmp_path, "cand", {"t": resolved(3)}, n_attempts=None)
+    reference = write_side(tmp_path, "ref", {"t": resolved(0)}, n_attempts=None)
+
+    assert main([str(candidate), str(reference)]) == 2
+    err = capsys.readouterr().err
+    assert "CANNOT VERIFY CONFIGURATION:" in err and "budget" in err
+
+
+def test_k_rescues_only_the_budget_and_nothing_else(tmp_path, capsys):
+    agents = [{"name": "stella_harbor.agent:StellaAgent", "model_name": None}]
+    candidate = write_side(tmp_path, "cand", {"t": resolved(3)}, n_attempts=None, agents=agents)
+    reference = write_side(tmp_path, "ref", {"t": resolved(0)}, n_attempts=None, agents=agents)
+
+    assert main([str(candidate), str(reference), "--k", "3"]) == 2
+    err = capsys.readouterr().err
+    assert "CANNOT VERIFY CONFIGURATION:" in err and "model" in err


### PR DESCRIPTION
Implements `test/evals/harbor/PROTOCOL.md` in `stella_harbor/compare.py`. Python only, no Go.

## What it does now

**Coverage.** The first path is the candidate, the second the reference. A candidate missing any task its reference declares is refused by name, exit 2. No silent intersection. `--tasks a,b` is the only way to compare a subset, and the flag is echoed in the report.

**Denominators.** Adapter evidence decides validity when it is present, even against a verifier reward; the reward fallback applies only to trials with no adapter at all (pi). Scoreable = valid AND has a reward, so a valid trial whose verifier broke leaves the denominator instead of counting as unresolved. A task is judged only when both sides hold exactly k scoreable trials; otherwise it prints `INSUFFICIENT_EVIDENCE` and is excluded from every verdict. k comes from the run budget, or `--k` for jobs that predate the manifest.

**Verdicts.** Any per-task movement is a `SIGNAL`. A guard — dynamically, any task the reference resolved k of k — falling below k/k, or any task down two or more resolved, is a `SUSPECTED_REGRESSION`. Neither gates; the default mode always exits 0. `--confirm` applies the frozen single-task k=5 predicates: `CONFIRMED_REGRESSION` / `CONFIRMED_IMPROVEMENT` at a difference of two or more, else `DISMISSED` with both counts. Only `CONFIRMED_REGRESSION` exits nonzero.

**Process metrics.** Paired per-task means in the three trust tiers: behavioral (tool calls, per-tool error counts, turns), gateway-reported (tokens, cost), and wall time, displayed and never judged. `EFFICIENCY_SIGNAL` uses exactly the two frozen metrics with the frozen computation: mean over valid trials, delta `(candidate - reference) / reference`, a reference mean of zero or missing leaves the metric unjudged, trigger over 25% with the resolved count unchanged. Efficiency deltas sit beside the resolution column.

**Timeout classes.** One per trial by first match: `harness_timeout` from Harbor's exception, `agent_deadline` from the taxonomy's timeout evidence, `command_timeout` from the killed-command sentinel (exit -1) in the bridge ledger, else `none`. A task whose only outcome change is a timeout-class flip is marked `UNTRUSTED` and not judged.

**Fingerprint.** Untouched and still hard on model and dataset. Only the task-set dimension relaxes, and the output says so when comparing a subset. A side may span several jobs via repeated `--candidate-job` / `--reference-job`; every path is still named explicitly.

## Verification

- `mise run format && mise run build && mise run test` — pass.
- `uv run --project test/evals/harbor pytest` — 106 passed (41 in `test_compare.py`), covering every verdict branch, `INSUFFICIENT_EVIDENCE`, the missing-required-task refusal, `EFFICIENCY_SIGNAL` triggers plus both unjudged cases, timeout-class first-match and untrusted marking, and mixed pre/post-#1077 field data.
- Sanity across the two archived bundles in `results/terminal-bench-2.1/`: the known numbers appear, `build-cython-ext 2/5 vs 5/5` (flagged as a guard drop and a `SUSPECTED_REGRESSION`), `caffe-cifar-10 0/5 vs 5/5`. Trials that only exist as a 6th top-up correctly report `INSUFFICIENT_EVIDENCE`.

## Judgment calls, flagged rather than buried

The protocol was frozen to avoid interpretation, and it mostly delivered. Four places still needed a reading; each is commented at the code and none changes a frozen number:

1. **Which side is the candidate.** The protocol says confirmation runs "candidate first, then reference"; the CLI positionals follow that order and the report labels both roles.
2. **"per-tool error counts" as an EFFICIENCY_SIGNAL metric** is computed per tool name, matching the words used in both the tier list and the signal definition, rather than as one aggregate.
3. **Pre-#1077 error counts** are displayed with a `*` and never judged, from tier 1's "trustworthy only after #1077". The protocol does not restate this inside the EFFICIENCY_SIGNAL rule.
4. **"a delta whose only outcome change is a timeout-class flip"** — trials are not paired one to one inside a task, so this reads counts: the classes moved, and the movement in timed-out trials is large enough to account for the whole resolved delta.

Also worth naming: `--k` exists because the archived bundles predate the manifest, and `EnvironmentStartTimeoutError` is not classified as `harness_timeout` because the protocol names an agent or verifier timeout.

Refs #1107

## Feishu Task

- [本地 run→fix→rerun 评测循环](https://mcnnox2fhjfq.feishu.cn/record/ElRNrZ40TegQdQcjPKfcELannje) (#1107)