### PR TITLE
🐛 build: keep the assembled components spec out of a shared /tmp path

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -75,9 +75,14 @@ run = "vp install && vp exec openapi-ts"
 [tasks."generate:api"]
 description = "Assemble api/spec/components.yaml from domain files then generate Go types and server"
 run = """
+# Assemble through a unique sibling temp file: a shared /tmp path collides when
+# two checkouts generate at once, and a fixed name leaks an untracked file into
+# the worktree if yq fails before the mv.
+components_tmp=$(mktemp api/spec/components.yaml.tmp.XXXXXX)
+trap 'rm -f "$components_tmp"' EXIT
 yq eval-all '. as $item ireduce ({}; . *+ $item) | .info.title = "stella API Components" | .info.description = "Assembled from api/spec/components/common.yaml + api/spec/domain/*/schemas.yaml — DO NOT EDIT"' \
   api/spec/components/common.yaml api/spec/domain/*/schemas.yaml \
-  > api/spec/components.yaml.tmp && mv api/spec/components.yaml.tmp api/spec/components.yaml
+  > "$components_tmp" && mv "$components_tmp" api/spec/components.yaml
 dprint fmt api/spec/components.yaml
 go tool oapi-codegen --config api/codegen/types.yaml   api/spec/components.yaml
 go tool oapi-codegen --config api/codegen/server.yaml  api/spec/openapi.yaml

--- a/mise.toml
+++ b/mise.toml
@@ -77,7 +77,7 @@ description = "Assemble api/spec/components.yaml from domain files then generate
 run = """
 yq eval-all '. as $item ireduce ({}; . *+ $item) | .info.title = "stella API Components" | .info.description = "Assembled from api/spec/components/common.yaml + api/spec/domain/*/schemas.yaml — DO NOT EDIT"' \
   api/spec/components/common.yaml api/spec/domain/*/schemas.yaml \
-  > /tmp/stella-components.yaml && mv /tmp/stella-components.yaml api/spec/components.yaml
+  > api/spec/components.yaml.tmp && mv api/spec/components.yaml.tmp api/spec/components.yaml
 dprint fmt api/spec/components.yaml
 go tool oapi-codegen --config api/codegen/types.yaml   api/spec/components.yaml
 go tool oapi-codegen --config api/codegen/server.yaml  api/spec/openapi.yaml


### PR DESCRIPTION
`generate:api` assembled the components spec into a fixed `/tmp/stella-components.yaml` and then moved it into the repo. That path is global, so two checkouts running `mise run build` at the same time raced for one file and the loser died with:

```
mv: /tmp/stella-components.yaml: No such file or directory
```

Two worktrees building concurrently is the normal case in this repo, and it bit a live eval run today: the loop's `mise run build` overlapped with a test-suite build in another worktree, and the eval job failed at testbed startup with an error that pointed nowhere near the real cause.

Staging next to the destination also makes the rename atomic. `/tmp` can sit on a different filesystem, which silently turns the `mv` into a copy.

Verified with `mise run generate:api` (clean regeneration, no diff) and the pre-commit format gate.

Refs: No issue: one-line build fix found while running the eval loop.