### PR TITLE
🐛 fix(agent): cap aggregate tool output per turn

### DIFF
--- a/internal/config/env_scan_test.go
+++ b/internal/config/env_scan_test.go
@@ -96,7 +96,11 @@ var envReadAllowlist = map[string]map[string]bool{
 	// pkg/ must not import internal/config. These are per-call diagnostic/tuning
 	// reads local to reusable packages.
 	"pkg/agent/llm_dump.go": {"STELLA_HOME": true, nonLiteralRead: true},
-	"pkg/tools/truncate.go": {"STELLA_TOOL_MAX_LINES": true, "STELLA_TOOL_MAX_BYTES": true},
+	"pkg/tools/truncate.go": {
+		"STELLA_TOOL_MAX_LINES":      true,
+		"STELLA_TOOL_MAX_BYTES":      true,
+		"STELLA_TOOL_MAX_TURN_BYTES": true,
+	},
 
 	// Standalone test tooling, never linked into stellad. The testbed supervisor
 	// copies a closed host-environment allowlist into its isolated server child;

--- a/pkg/agent/image_projection.go
+++ b/pkg/agent/image_projection.go
@@ -2,8 +2,10 @@ package agent
 
 import (
 	"context"
+	"strings"
 
 	"github.com/CherryHQ/stella/pkg/ai"
+	pkgtools "github.com/CherryHQ/stella/pkg/tools"
 )
 
 // MediaLoader opens one immutable session image for the current user. The
@@ -40,6 +42,10 @@ func projectImages(ctx context.Context, cfg loopConfig, messages []ai.Message, a
 		}
 		out[i] = projected
 	}
+	// Budget only after projection: these are the exact blocks providers flatten,
+	// including baseline text and inter-block separators. Canonical history stays
+	// lossless while every replay gets the same bounded provider-visible copy.
+	applyProjectedToolOutputBudgets(out)
 	return out, nil
 }
 
@@ -74,6 +80,109 @@ func projectMessage(ctx context.Context, cfg loopConfig, msg ai.Message, active 
 	default:
 		return msg, nil
 	}
+}
+
+func applyProjectedToolOutputBudgets(messages []ai.Message) {
+	for start := 0; start < len(messages); {
+		if _, ok := messages[start].(ai.ToolResultMessage); !ok {
+			start++
+			continue
+		}
+
+		end := start
+		var outputs []string
+		for end < len(messages) {
+			result, ok := messages[end].(ai.ToolResultMessage)
+			if !ok {
+				break
+			}
+			outputs = append(outputs, ai.FlattenText(result.Content))
+			end++
+		}
+		for i, budgeted := range pkgtools.ApplyTurnOutputBudget(outputs) {
+			if !budgeted.Truncated {
+				continue
+			}
+			result := messages[start+i].(ai.ToolResultMessage)
+			result.Content = applyProjectedTextBudget(result.Content, budgeted)
+			messages[start+i] = result
+		}
+		start = end
+	}
+}
+
+func applyProjectedTextBudget(blocks []ai.ContentBlock, budget pkgtools.TurnOutputBudgetResult) []ai.ContentBlock {
+	out := make([]ai.ContentBlock, len(blocks))
+	copy(out, blocks)
+
+	textIndexes := make([]int, 0, len(blocks))
+	for i, block := range blocks {
+		if text, ok := block.(ai.TextContent); ok && text.Text != "" {
+			textIndexes = append(textIndexes, i)
+		}
+	}
+	if len(textIndexes) == 0 {
+		return out
+	}
+
+	headParts := make(map[int]string, len(textIndexes))
+	headRemaining := budget.Head
+	for _, i := range textIndexes {
+		if headRemaining == "" {
+			break
+		}
+		text := blocks[i].(ai.TextContent).Text
+		if len(headRemaining) < len(text) {
+			headParts[i] = headRemaining
+			headRemaining = ""
+			break
+		}
+		headParts[i] = text
+		headRemaining = strings.TrimPrefix(headRemaining[len(text):], " ")
+	}
+
+	tailParts := make(map[int]string, len(textIndexes))
+	tailRemaining := budget.Tail
+	for pos := len(textIndexes) - 1; pos >= 0 && tailRemaining != ""; pos-- {
+		i := textIndexes[pos]
+		text := blocks[i].(ai.TextContent).Text
+		if len(tailRemaining) < len(text) {
+			tailParts[i] = tailRemaining
+			tailRemaining = ""
+			break
+		}
+		tailParts[i] = text
+		tailRemaining = strings.TrimSuffix(tailRemaining[:len(tailRemaining)-len(text)], " ")
+	}
+
+	for _, i := range textIndexes {
+		out[i] = ai.TextContent{Text: headParts[i] + tailParts[i]}
+	}
+	if len(headParts) > 0 {
+		lastHead := textIndexes[0]
+		for _, i := range textIndexes {
+			if headParts[i] != "" {
+				lastHead = i
+			}
+		}
+		text := out[lastHead].(ai.TextContent)
+		text.Text = headParts[lastHead] + budget.Marker + tailParts[lastHead]
+		out[lastHead] = text
+		return out
+	}
+	if len(tailParts) > 0 {
+		for _, i := range textIndexes {
+			if tailParts[i] == "" {
+				continue
+			}
+			text := out[i].(ai.TextContent)
+			text.Text = budget.Marker + tailParts[i]
+			out[i] = text
+			return out
+		}
+	}
+	out[textIndexes[0]] = ai.TextContent{Text: budget.Marker}
+	return out
 }
 
 func projectBlocks(ctx context.Context, cfg loopConfig, blocks []ai.ContentBlock, active bool, memo map[string]ai.ImageContent) ([]ai.ContentBlock, error) {

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -197,12 +197,11 @@ func runLoop(ctx context.Context, cfg loopConfig, history []ai.Message, activeSt
 				}
 			},
 		}, cfg.Hooks, cfg.HookMeta, cfg.ToolLifecycle, canonicalizer)
-		if err != nil {
-			return history, err
-		}
-
 		for _, result := range results {
 			history = append(history, result)
+		}
+		if err != nil {
+			return history, err
 		}
 
 		if emit != nil {

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -198,6 +198,50 @@ func TestRunPreservesToolCallOrder(t *testing.T) {
 	}
 }
 
+func TestRunKeepsCompletedToolResultWhenLaterCallFails(t *testing.T) {
+	stream := func(_ context.Context, _ ai.Model, _ ai.Context, _ ai.StreamOptions) (providers.AssistantEventStream, error) {
+		out := providers.NewChannelEventStream(8)
+		go func() {
+			out.Emit(ai.EventToolCallDelta{ID: "1", Name: "ok"})
+			out.Emit(ai.EventToolCallDelta{ID: "2", Name: "ok"})
+			out.Emit(ai.EventStop{Reason: ai.StopReasonToolUse})
+			out.Finish(nil)
+		}()
+		return out, nil
+	}
+	runner := newTestRunner(stream)
+	runner.tools = ToolSet{"ok": func(context.Context, ai.ToolCall) ([]ai.ContentBlock, error) {
+		return []ai.ContentBlock{ai.TextContent{Text: "done"}}, nil
+	}}
+	runner.toolLifecycle = &ToolLifecycle{BeforeCall: func(_ context.Context, call ToolCallContext) (ToolCallMutation, error) {
+		if call.ToolCallID == "2" {
+			return ToolCallMutation{}, fmt.Errorf("second call failed")
+		}
+		return ToolCallMutation{}, nil
+	}}
+
+	history, events, err := collectEvents(runner, []ai.Message{ai.UserMessage{Content: "go"}})
+	if err == nil || err.Error() != "second call failed" {
+		t.Fatalf("error = %v, want second call failed", err)
+	}
+	if len(history) != 3 {
+		t.Fatalf("history length = %d, want user + assistant tool calls + completed result", len(history))
+	}
+	result, ok := history[2].(ai.ToolResultMessage)
+	if !ok || result.ToolCallID != "1" || ai.FlattenText(result.Content) != "done" {
+		t.Fatalf("persistable completed result = %#v, want call 1", history[2])
+	}
+	var finished []string
+	for _, event := range events {
+		if event, ok := event.(ToolFinished); ok {
+			finished = append(finished, event.Result.ToolCallID)
+		}
+	}
+	if !slices.Equal(finished, []string{"1"}) {
+		t.Fatalf("ToolFinished calls = %v, want [1]", finished)
+	}
+}
+
 func TestBuildPartialUsesFirstSeenToolCallOrder(t *testing.T) {
 	calls := map[string]ai.ToolCall{
 		"a": {ID: "a", Name: "first"},

--- a/pkg/agent/projection_test.go
+++ b/pkg/agent/projection_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -89,6 +90,90 @@ func TestProjectImagesMatrix(t *testing.T) {
 				t.Fatalf("loads = %d, want no unsupported/unknown hydration", loads)
 			}
 		})
+	}
+}
+
+func TestProjectedToolBudgetCountsFlattenTextSeparators(t *testing.T) {
+	t.Setenv("STELLA_TOOL_MAX_TURN_BYTES", "301")
+	block := strings.Repeat("x", 100)
+	messages := []ai.Message{ai.ToolResultMessage{Content: []ai.ContentBlock{
+		ai.TextContent{Text: block},
+		ai.TextContent{Text: block},
+		ai.TextContent{Text: block},
+	}}}
+
+	projected, err := projectImages(context.Background(), loopConfig{Model: unsupportedModel()}, messages, 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := projected[0].(ai.ToolResultMessage)
+	visible := ai.FlattenText(result.Content)
+	if len(visible) > 301 {
+		t.Fatalf("provider-visible result is %d bytes, exceeds budget 301", len(visible))
+	}
+	if !strings.Contains(visible, "turn's output budget was exhausted") {
+		t.Fatalf("separator bytes did not trigger truncation: %q", visible)
+	}
+}
+
+func TestProjectedToolBudgetCountsImageBaselines(t *testing.T) {
+	t.Setenv("STELLA_TOOL_MAX_TURN_BYTES", "600")
+	baseline := ai.ImageBaseline{Text: "## Text\n" + strings.Repeat("ocr", 180) + "\n\n## Scene\n" + strings.Repeat("scene", 20)}
+	messages := []ai.Message{
+		ai.ToolResultMessage{ToolCallID: "1", Content: []ai.ContentBlock{ai.ImageRefContent{MediaID: "1", Baseline: baseline}}},
+		ai.ToolResultMessage{ToolCallID: "2", Content: []ai.ContentBlock{ai.ImageRefContent{MediaID: "2", Baseline: baseline}}},
+	}
+
+	projected, err := projectImages(context.Background(), loopConfig{Model: unsupportedModel()}, messages, 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	total := 0
+	for i, message := range projected {
+		visible := ai.FlattenText(message.(ai.ToolResultMessage).Content)
+		total += len(visible)
+		if !strings.Contains(visible, "turn's output budget was exhausted") {
+			t.Fatalf("result %d baseline was not budgeted: %q", i, visible)
+		}
+	}
+	if total > 600 {
+		t.Fatalf("provider-visible baselines total %d bytes, exceeds budget 600", total)
+	}
+}
+
+func TestProjectedToolBudgetPreservesMixedBlockOrder(t *testing.T) {
+	t.Setenv("STELLA_TOOL_MAX_TURN_BYTES", "600")
+	messages := []ai.Message{ai.ToolResultMessage{Content: []ai.ContentBlock{
+		ai.TextContent{Text: "A" + strings.Repeat("a", 499)},
+		ai.ImageRefContent{MediaID: "image", Baseline: ai.ImageBaseline{Text: "## Text\nimage\n\n## Scene\nchart"}},
+		ai.TextContent{Text: "B" + strings.Repeat("b", 499)},
+	}}}
+	cfg := loopConfig{Model: supportedModel(), CanonicalImages: testCanonicalConfig(func(context.Context, string) (ai.ImageContent, error) {
+		return ai.ImageContent{Data: "pixels", MimeType: "image/png"}, nil
+	})}
+
+	projected, err := projectImages(context.Background(), cfg, messages, 0, map[string]ai.ImageContent{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	blocks := projected[0].(ai.ToolResultMessage).Content
+	if len(blocks) != 3 {
+		t.Fatalf("blocks = %#v, want three blocks", blocks)
+	}
+	first, firstOK := blocks[0].(ai.TextContent)
+	_, imageOK := blocks[1].(ai.ImageContent)
+	last, lastOK := blocks[2].(ai.TextContent)
+	if !firstOK || !imageOK || !lastOK {
+		t.Fatalf("block order changed: %#v", blocks)
+	}
+	if !strings.HasPrefix(first.Text, "A") || !strings.Contains(first.Text, "turn's output budget was exhausted") {
+		t.Fatalf("head text or marker missing before image: %q", first.Text)
+	}
+	if last.Text == "" || strings.Trim(last.Text, "b") != "" {
+		t.Fatalf("tail text moved before image: %q", last.Text)
+	}
+	if len(ai.FlattenText(blocks)) > 600 {
+		t.Fatalf("provider-visible mixed result exceeds budget: %d", len(ai.FlattenText(blocks)))
 	}
 }
 

--- a/pkg/agent/tool_execution.go
+++ b/pkg/agent/tool_execution.go
@@ -3,11 +3,13 @@ package agent
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/CherryHQ/stella/pkg/ai"
 	pkgchannel "github.com/CherryHQ/stella/pkg/channel"
 	"github.com/CherryHQ/stella/pkg/hooks"
+	pkgtools "github.com/CherryHQ/stella/pkg/tools"
 )
 
 // toolCallbacks emits progress events around tool execution.
@@ -28,9 +30,6 @@ func executeToolCalls(ctx context.Context, calls []ai.ToolCall, tools ToolSet, c
 			}
 		}
 		results = append(results, result)
-		if cb.onFinish != nil {
-			cb.onFinish(result)
-		}
 		return nil
 	}
 
@@ -210,7 +209,57 @@ func executeToolCalls(ctx context.Context, calls []ai.ToolCall, tools ToolSet, c
 		return nil, errors.New("tool execution produced no results")
 	}
 
+	results = applyToolOutputTurnBudget(results)
+	if cb.onFinish != nil {
+		for _, result := range results {
+			cb.onFinish(result)
+		}
+	}
 	return results, nil
+}
+
+func applyToolOutputTurnBudget(results []ai.ToolResultMessage) []ai.ToolResultMessage {
+	outputs := make([]string, len(results))
+	for i, result := range results {
+		outputs[i] = toolResultText(result.Content)
+	}
+	budgeted := pkgtools.ApplyTurnOutputBudget(outputs)
+
+	for i, output := range budgeted {
+		if output.Truncated {
+			results[i].Content = replaceAllTextContent(results[i].Content, output.Content)
+		}
+	}
+	return results
+}
+
+func toolResultText(blocks []ai.ContentBlock) string {
+	var text strings.Builder
+	for _, block := range blocks {
+		if content, ok := block.(ai.TextContent); ok {
+			text.WriteString(content.Text)
+		}
+	}
+	return text.String()
+}
+
+func replaceAllTextContent(blocks []ai.ContentBlock, text string) []ai.ContentBlock {
+	out := make([]ai.ContentBlock, 0, len(blocks))
+	replaced := false
+	for _, block := range blocks {
+		if _, ok := block.(ai.TextContent); ok {
+			if !replaced {
+				out = append(out, ai.TextContent{Text: text})
+				replaced = true
+			}
+			continue
+		}
+		out = append(out, block)
+	}
+	if !replaced {
+		return append([]ai.ContentBlock{ai.TextContent{Text: text}}, out...)
+	}
+	return out
 }
 
 // classifyToolError names the failure so downstream consumers never have to

--- a/pkg/agent/tool_execution.go
+++ b/pkg/agent/tool_execution.go
@@ -3,13 +3,11 @@ package agent
 import (
 	"context"
 	"errors"
-	"strings"
 	"time"
 
 	"github.com/CherryHQ/stella/pkg/ai"
 	pkgchannel "github.com/CherryHQ/stella/pkg/channel"
 	"github.com/CherryHQ/stella/pkg/hooks"
-	pkgtools "github.com/CherryHQ/stella/pkg/tools"
 )
 
 // toolCallbacks emits progress events around tool execution.
@@ -30,6 +28,9 @@ func executeToolCalls(ctx context.Context, calls []ai.ToolCall, tools ToolSet, c
 			}
 		}
 		results = append(results, result)
+		if cb.onFinish != nil {
+			cb.onFinish(result)
+		}
 		return nil
 	}
 
@@ -48,7 +49,7 @@ func executeToolCalls(ctx context.Context, calls []ai.ToolCall, tools ToolSet, c
 				Content:    []ai.ContentBlock{ai.TextContent{Text: "tool not found"}},
 			}
 			if err := appendFinal(result); err != nil {
-				return nil, err
+				return results, err
 			}
 			continue
 		}
@@ -65,7 +66,7 @@ func executeToolCalls(ctx context.Context, calls []ai.ToolCall, tools ToolSet, c
 				Arguments:  cloneArgs(args),
 			})
 			if err != nil {
-				return nil, err
+				return results, err
 			}
 			if mutation.Block {
 				blockMsg := mutation.BlockMessage
@@ -78,7 +79,7 @@ func executeToolCalls(ctx context.Context, calls []ai.ToolCall, tools ToolSet, c
 					Content:    []ai.ContentBlock{ai.TextContent{Text: blockMsg}},
 				}
 				if err := appendFinal(result); err != nil {
-					return nil, err
+					return results, err
 				}
 				continue
 			}
@@ -134,7 +135,7 @@ func executeToolCalls(ctx context.Context, calls []ai.ToolCall, tools ToolSet, c
 					Content:    []ai.ContentBlock{ai.TextContent{Text: blockMsg}},
 				}
 				if err := appendFinal(result); err != nil {
-					return nil, err
+					return results, err
 				}
 				continue
 			}
@@ -179,7 +180,7 @@ func executeToolCalls(ctx context.Context, calls []ai.ToolCall, tools ToolSet, c
 			})
 			if err != nil {
 				runPostToolCall(execCtx, args, err.Error(), true, ai.ToolErrorKindTool, nil, duration)
-				return nil, err
+				return results, err
 			}
 			if mutation.Result != nil {
 				resultText = *mutation.Result
@@ -201,7 +202,7 @@ func executeToolCalls(ctx context.Context, calls []ai.ToolCall, tools ToolSet, c
 		runPostToolCall(execCtx, args, resultText, result.IsError, result.ErrorKind, exitCode, duration)
 
 		if err := appendFinal(result); err != nil {
-			return nil, err
+			return results, err
 		}
 	}
 
@@ -209,57 +210,7 @@ func executeToolCalls(ctx context.Context, calls []ai.ToolCall, tools ToolSet, c
 		return nil, errors.New("tool execution produced no results")
 	}
 
-	results = applyToolOutputTurnBudget(results)
-	if cb.onFinish != nil {
-		for _, result := range results {
-			cb.onFinish(result)
-		}
-	}
 	return results, nil
-}
-
-func applyToolOutputTurnBudget(results []ai.ToolResultMessage) []ai.ToolResultMessage {
-	outputs := make([]string, len(results))
-	for i, result := range results {
-		outputs[i] = toolResultText(result.Content)
-	}
-	budgeted := pkgtools.ApplyTurnOutputBudget(outputs)
-
-	for i, output := range budgeted {
-		if output.Truncated {
-			results[i].Content = replaceAllTextContent(results[i].Content, output.Content)
-		}
-	}
-	return results
-}
-
-func toolResultText(blocks []ai.ContentBlock) string {
-	var text strings.Builder
-	for _, block := range blocks {
-		if content, ok := block.(ai.TextContent); ok {
-			text.WriteString(content.Text)
-		}
-	}
-	return text.String()
-}
-
-func replaceAllTextContent(blocks []ai.ContentBlock, text string) []ai.ContentBlock {
-	out := make([]ai.ContentBlock, 0, len(blocks))
-	replaced := false
-	for _, block := range blocks {
-		if _, ok := block.(ai.TextContent); ok {
-			if !replaced {
-				out = append(out, ai.TextContent{Text: text})
-				replaced = true
-			}
-			continue
-		}
-		out = append(out, block)
-	}
-	if !replaced {
-		return append([]ai.ContentBlock{ai.TextContent{Text: text}}, out...)
-	}
-	return out
 }
 
 // classifyToolError names the failure so downstream consumers never have to

--- a/pkg/agent/tool_execution_test.go
+++ b/pkg/agent/tool_execution_test.go
@@ -414,3 +414,32 @@ func TestToolExecutionReportsErrorKindToHooks(t *testing.T) {
 		t.Errorf("success reported kind %q exit %v, want neither", got.ErrorKind, got.ExitCode)
 	}
 }
+
+func TestToolExecutionBudgetsResultsBeforeReturningAndEmitting(t *testing.T) {
+	t.Setenv("STELLA_TOOL_MAX_TURN_BYTES", "600")
+	calls := []ai.ToolCall{{ID: "1", Name: "large"}, {ID: "2", Name: "large"}}
+	tools := ToolSet{"large": func(context.Context, ai.ToolCall) ([]ai.ContentBlock, error) {
+		return []ai.ContentBlock{ai.TextContent{Text: strings.Repeat("x", 500)}}, nil
+	}}
+	var finished []ai.ToolResultMessage
+
+	results, err := executeToolCalls(context.Background(), calls, tools, toolCallbacks{
+		onFinish: func(result ai.ToolResultMessage) { finished = append(finished, result) },
+	}, nil, hooks.HookMeta{}, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 2 || len(finished) != 2 {
+		t.Fatalf("results=%d callbacks=%d, want 2 each", len(results), len(finished))
+	}
+	for i := range results {
+		resultText := ai.FlattenText(results[i].Content)
+		finishedText := ai.FlattenText(finished[i].Content)
+		if len(resultText) != 300 || resultText != finishedText {
+			t.Fatalf("result %d returned %d bytes and callback %d bytes", i, len(resultText), len(finishedText))
+		}
+		if !strings.Contains(resultText, "turn's output budget was exhausted") {
+			t.Fatalf("result %d lacks turn-budget marker: %q", i, resultText)
+		}
+	}
+}

--- a/pkg/agent/tool_execution_test.go
+++ b/pkg/agent/tool_execution_test.go
@@ -415,31 +415,68 @@ func TestToolExecutionReportsErrorKindToHooks(t *testing.T) {
 	}
 }
 
-func TestToolExecutionBudgetsResultsBeforeReturningAndEmitting(t *testing.T) {
-	t.Setenv("STELLA_TOOL_MAX_TURN_BYTES", "600")
-	calls := []ai.ToolCall{{ID: "1", Name: "large"}, {ID: "2", Name: "large"}}
-	tools := ToolSet{"large": func(context.Context, ai.ToolCall) ([]ai.ContentBlock, error) {
-		return []ai.ContentBlock{ai.TextContent{Text: strings.Repeat("x", 500)}}, nil
+func TestToolExecutionEmitsCompletedResultBeforeLaterFailure(t *testing.T) {
+	calls := []ai.ToolCall{{ID: "1", Name: "ok"}, {ID: "2", Name: "ok"}}
+	tools := ToolSet{"ok": func(context.Context, ai.ToolCall) ([]ai.ContentBlock, error) {
+		return []ai.ContentBlock{ai.TextContent{Text: "done"}}, nil
 	}}
-	var finished []ai.ToolResultMessage
+	lifecycle := &ToolLifecycle{BeforeCall: func(_ context.Context, call ToolCallContext) (ToolCallMutation, error) {
+		if call.ToolCallID == "2" {
+			return ToolCallMutation{}, errors.New("second call failed")
+		}
+		return ToolCallMutation{}, nil
+	}}
+	var events []string
 
 	results, err := executeToolCalls(context.Background(), calls, tools, toolCallbacks{
-		onFinish: func(result ai.ToolResultMessage) { finished = append(finished, result) },
-	}, nil, hooks.HookMeta{}, nil, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		onStart:  func(call ai.ToolCall) { events = append(events, "start "+call.ID) },
+		onFinish: func(result ai.ToolResultMessage) { events = append(events, "finish "+result.ToolCallID) },
+	}, nil, hooks.HookMeta{}, lifecycle, nil)
+	if err == nil || err.Error() != "second call failed" {
+		t.Fatalf("error = %v, want second call failed", err)
 	}
-	if len(results) != 2 || len(finished) != 2 {
-		t.Fatalf("results=%d callbacks=%d, want 2 each", len(results), len(finished))
+	if len(results) != 1 || results[0].ToolCallID != "1" {
+		t.Fatalf("completed results = %#v, want call 1", results)
 	}
-	for i := range results {
-		resultText := ai.FlattenText(results[i].Content)
-		finishedText := ai.FlattenText(finished[i].Content)
-		if len(resultText) != 300 || resultText != finishedText {
-			t.Fatalf("result %d returned %d bytes and callback %d bytes", i, len(resultText), len(finishedText))
+	if got, want := strings.Join(events, ","), "start 1,finish 1,start 2"; got != want {
+		t.Fatalf("events = %q, want %q", got, want)
+	}
+}
+
+func TestToolExecutionEndsHookSpanBeforeFinishAndOnLaterFailure(t *testing.T) {
+	calls := []ai.ToolCall{{ID: "1", Name: "ok"}, {ID: "2", Name: "ok"}}
+	tools := ToolSet{"ok": func(context.Context, ai.ToolCall) ([]ai.ContentBlock, error) {
+		return []ai.ContentBlock{ai.TextContent{Text: "done"}}, nil
+	}}
+	var events []string
+	hs := hooks.NewHookSet([]hooks.HookPlugin{toolExecutionHook{
+		pre: func(_ context.Context, hctx *hooks.PreToolCallContext) (hooks.PreToolCallResult, error) {
+			events = append(events, "span start "+hctx.ToolCallID)
+			return hooks.PreToolCallResult{}, nil
+		},
+		post: func(_ context.Context, hctx *hooks.PostToolCallContext) {
+			events = append(events, "span end "+hctx.ToolCallID)
+		},
+	}})
+	lifecycle := &ToolLifecycle{AfterCall: func(_ context.Context, result ToolResultContext) (ToolResultMutation, error) {
+		if result.ToolCallID == "2" {
+			return ToolResultMutation{}, errors.New("second after failed")
 		}
-		if !strings.Contains(resultText, "turn's output budget was exhausted") {
-			t.Fatalf("result %d lacks turn-budget marker: %q", i, resultText)
-		}
+		return ToolResultMutation{}, nil
+	}}
+
+	results, err := executeToolCalls(context.Background(), calls, tools, toolCallbacks{
+		onStart:  func(call ai.ToolCall) { events = append(events, "start "+call.ID) },
+		onFinish: func(result ai.ToolResultMessage) { events = append(events, "finish "+result.ToolCallID) },
+	}, hs, hooks.HookMeta{}, lifecycle, nil)
+	if err == nil || err.Error() != "second after failed" {
+		t.Fatalf("error = %v, want second after failed", err)
+	}
+	if len(results) != 1 || results[0].ToolCallID != "1" {
+		t.Fatalf("completed results = %#v, want call 1", results)
+	}
+	want := "start 1,span start 1,span end 1,finish 1,start 2,span start 2,span end 2"
+	if got := strings.Join(events, ","); got != want {
+		t.Fatalf("events = %q, want %q", got, want)
 	}
 }

--- a/pkg/tools/truncate.go
+++ b/pkg/tools/truncate.go
@@ -12,10 +12,12 @@ const (
 	defaultMaxLines = 2000
 	defaultMaxBytes = 50 * 1024 // 50KB
 
-	// Deliberate ceiling: one agent turn may add at most 64KiB of textual tool
-	// results. This leaves room above the 50KiB per-call payload cap for its
-	// diagnostics, while bounding parallel-call amplification. Raise it only
-	// when measured task completion gains outweigh the repeated context cost.
+	// Deliberate base ceiling: one agent turn gets 64KiB for provider-visible
+	// textual tool results. This leaves room above the 50KiB per-call payload cap
+	// for its diagnostics, while bounding parallel-call amplification. It is
+	// clamped upward only when a truncated share cannot hold its complete marker.
+	// Raise it otherwise only when measured task completion gains outweigh the
+	// repeated context cost.
 	defaultMaxTurnBytes = 64 * 1024
 )
 
@@ -75,20 +77,47 @@ func maxTurnBytes() int {
 // truncation was necessary.
 type TurnOutputBudgetResult struct {
 	Content      string
+	Head         string
+	Tail         string
+	Marker       string
 	Truncated    bool
 	OmittedBytes int
 }
 
 // ApplyTurnOutputBudget distributes the current turn budget across outputs by
 // max-min fairness. Small outputs surrender unused capacity to larger outputs;
-// ties and remainder bytes are resolved by call order for reproducibility.
+// ties and remainder bytes are resolved by call order for reproducibility. A
+// too-small budget is clamped only enough to keep every required marker whole.
 func ApplyTurnOutputBudget(outputs []string) []TurnOutputBudgetResult {
-	limits := fairShareBytes(outputs, maxTurnBytes())
+	limits := fairShareBytesWithMarkerFloor(outputs, maxTurnBytes())
 	results := make([]TurnOutputBudgetResult, len(outputs))
 	for i, output := range outputs {
 		results[i] = truncateForTurnBudget(output, limits[i])
 	}
 	return results
+}
+
+func fairShareBytesWithMarkerFloor(outputs []string, budget int) []int {
+	for {
+		limits := fairShareBytes(outputs, budget)
+		deficit := 0
+		for i, output := range outputs {
+			if len(output) <= limits[i] {
+				continue
+			}
+			markerBytes := len(formatTurnBudgetMarker(len(output)))
+			if limits[i] < markerBytes {
+				deficit += markerBytes - limits[i]
+			}
+		}
+		if deficit == 0 {
+			return limits
+		}
+		// A mistuned budget is clamped only by the bytes actually missing from
+		// truncated results' complete markers. The budget grows monotonically and
+		// must stop no later than the point where every output fits untruncated.
+		budget += deficit
+	}
 }
 
 func fairShareBytes(outputs []string, budget int) []int {
@@ -129,27 +158,24 @@ func truncateForTurnBudget(output string, limit int) TurnOutputBudgetResult {
 		return TurnOutputBudgetResult{Content: output}
 	}
 
-	omitted := len(output)
-	var marker, head, tail string
-	for {
-		marker = formatTurnBudgetMarker(omitted)
-		available := max(limit-len(marker), 0)
-		head = truncateStringToBytes(output, (available+1)/2)
-		tail = truncateStringToBytesFromEnd(output[len(head):], available-len(head))
-		newOmitted := len(output) - len(head) - len(tail)
-		if newOmitted == omitted {
-			break
-		}
-		omitted = newOmitted
-	}
+	// Reserve marker width from the largest possible omitted count. The actual
+	// count cannot have more decimal digits, so its marker is never larger. This
+	// avoids a fixed-point loop where UTF-8 boundary rounding and a 9→10 digit
+	// transition can oscillate forever.
+	reservedMarkerBytes := len(formatTurnBudgetMarker(len(output)))
+	// A block-preserving caller may need one implicit FlattenText separator
+	// between the marker-bearing head block and a retained tail block.
+	available := max(limit-reservedMarkerBytes-1, 0)
+	head := truncateStringToBytes(output, (available+1)/2)
+	tail := truncateStringToBytesFromEnd(output[len(head):], available-len(head))
+	omitted := len(output) - len(head) - len(tail)
+	marker := formatTurnBudgetMarker(omitted)
 
-	if len(marker) > limit {
-		marker = truncateStringToBytes(marker, limit)
-		head = ""
-		tail = ""
-	}
 	return TurnOutputBudgetResult{
 		Content:      head + marker + tail,
+		Head:         head,
+		Tail:         tail,
+		Marker:       marker,
 		Truncated:    true,
 		OmittedBytes: omitted,
 	}

--- a/pkg/tools/truncate.go
+++ b/pkg/tools/truncate.go
@@ -11,6 +11,12 @@ import (
 const (
 	defaultMaxLines = 2000
 	defaultMaxBytes = 50 * 1024 // 50KB
+
+	// Deliberate ceiling: one agent turn may add at most 64KiB of textual tool
+	// results. This leaves room above the 50KiB per-call payload cap for its
+	// diagnostics, while bounding parallel-call amplification. Raise it only
+	// when measured task completion gains outweigh the repeated context cost.
+	defaultMaxTurnBytes = 64 * 1024
 )
 
 type TruncatedBy string
@@ -53,6 +59,104 @@ func maxBytes() int {
 		}
 	}
 	return defaultMaxBytes
+}
+
+func maxTurnBytes() int {
+	if v := os.Getenv("STELLA_TOOL_MAX_TURN_BYTES"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultMaxTurnBytes
+}
+
+// TurnOutputBudgetResult is one textual tool result after the turn-wide budget
+// has been applied. Content includes the actionable turn-budget marker when
+// truncation was necessary.
+type TurnOutputBudgetResult struct {
+	Content      string
+	Truncated    bool
+	OmittedBytes int
+}
+
+// ApplyTurnOutputBudget distributes the current turn budget across outputs by
+// max-min fairness. Small outputs surrender unused capacity to larger outputs;
+// ties and remainder bytes are resolved by call order for reproducibility.
+func ApplyTurnOutputBudget(outputs []string) []TurnOutputBudgetResult {
+	limits := fairShareBytes(outputs, maxTurnBytes())
+	results := make([]TurnOutputBudgetResult, len(outputs))
+	for i, output := range outputs {
+		results[i] = truncateForTurnBudget(output, limits[i])
+	}
+	return results
+}
+
+func fairShareBytes(outputs []string, budget int) []int {
+	limits := make([]int, len(outputs))
+	active := make([]int, len(outputs))
+	for i := range outputs {
+		active[i] = i
+	}
+
+	remaining := budget
+	for len(active) > 0 {
+		share := remaining / len(active)
+		unsatisfied := active[:0]
+		for _, i := range active {
+			if len(outputs[i]) <= share {
+				limits[i] = len(outputs[i])
+				remaining -= limits[i]
+				continue
+			}
+			unsatisfied = append(unsatisfied, i)
+		}
+		if len(unsatisfied) == len(active) {
+			for _, i := range unsatisfied {
+				limits[i] = share
+			}
+			for _, i := range unsatisfied[:remaining-share*len(unsatisfied)] {
+				limits[i]++
+			}
+			break
+		}
+		active = unsatisfied
+	}
+	return limits
+}
+
+func truncateForTurnBudget(output string, limit int) TurnOutputBudgetResult {
+	if len(output) <= limit {
+		return TurnOutputBudgetResult{Content: output}
+	}
+
+	omitted := len(output)
+	var marker, head, tail string
+	for {
+		marker = formatTurnBudgetMarker(omitted)
+		available := max(limit-len(marker), 0)
+		head = truncateStringToBytes(output, (available+1)/2)
+		tail = truncateStringToBytesFromEnd(output[len(head):], available-len(head))
+		newOmitted := len(output) - len(head) - len(tail)
+		if newOmitted == omitted {
+			break
+		}
+		omitted = newOmitted
+	}
+
+	if len(marker) > limit {
+		marker = truncateStringToBytes(marker, limit)
+		head = ""
+		tail = ""
+	}
+	return TurnOutputBudgetResult{
+		Content:      head + marker + tail,
+		Truncated:    true,
+		OmittedBytes: omitted,
+	}
+}
+
+func formatTurnBudgetMarker(omittedBytes int) string {
+	return fmt.Sprintf("\n[Tool output truncated: this turn's output budget was exhausted; omitted %d bytes. Use smaller reads or split the work across turns.]\n", omittedBytes)
 }
 
 // SplitLines splits text into lines preserving newline suffixes.
@@ -262,6 +366,19 @@ func reverseStrings(values []string) {
 	for i, j := 0, len(values)-1; i < j; i, j = i+1, j-1 {
 		values[i], values[j] = values[j], values[i]
 	}
+}
+
+// truncateStringToBytes returns the head of str that fits within maxBytes,
+// adjusting to a valid UTF-8 rune boundary.
+func truncateStringToBytes(str string, maxBytes int) string {
+	if len(str) <= maxBytes {
+		return str
+	}
+	end := max(maxBytes, 0)
+	for end > 0 && !utf8.RuneStart(str[end]) {
+		end--
+	}
+	return str[:end]
 }
 
 // truncateStringToBytesFromEnd returns the tail of str that fits within maxBytes,

--- a/pkg/tools/truncate_test.go
+++ b/pkg/tools/truncate_test.go
@@ -228,8 +228,8 @@ func TestTurnOutputBudgetEqualCallsShareEvenly(t *testing.T) {
 
 	results := ApplyTurnOutputBudget(outputs)
 	for i, result := range results {
-		if !result.Truncated || len(result.Content) != 256 {
-			t.Fatalf("result %d = (truncated=%t, bytes=%d), want (true, 256)", i, result.Truncated, len(result.Content))
+		if !result.Truncated || len(result.Content) != 255 {
+			t.Fatalf("result %d = (truncated=%t, bytes=%d), want (true, 255)", i, result.Truncated, len(result.Content))
 		}
 	}
 }
@@ -249,8 +249,8 @@ func TestTurnOutputBudgetWaterFillsThreeSmallOneLarge(t *testing.T) {
 			t.Fatalf("small result %d should surrender only its unused share", i)
 		}
 	}
-	if !results[3].Truncated || len(results[3].Content) != 724 {
-		t.Fatalf("large result = (truncated=%t, bytes=%d), want (true, 724)", results[3].Truncated, len(results[3].Content))
+	if !results[3].Truncated || len(results[3].Content) > 724 || len(results[3].Content) < 720 {
+		t.Fatalf("large result = (truncated=%t, bytes=%d), want a conservative result near its 724-byte share", results[3].Truncated, len(results[3].Content))
 	}
 }
 
@@ -274,16 +274,60 @@ func TestTurnOutputBudgetExhaustionHasActionableMarker(t *testing.T) {
 			t.Fatalf("result %d omitted %d bytes, want %d", i, result.OmittedBytes, len(outputs[i])-kept)
 		}
 	}
-	if total != 512 {
-		t.Fatalf("turn added %d bytes, want hard ceiling 512", total)
+	if total > 512 {
+		t.Fatalf("turn added %d bytes, exceeds hard ceiling 512", total)
 	}
 }
 
 func TestTurnOutputBudgetEnvironmentOverride(t *testing.T) {
 	t.Setenv("STELLA_TOOL_MAX_TURN_BYTES", "600")
 	results := ApplyTurnOutputBudget([]string{strings.Repeat("a", 500), strings.Repeat("b", 500)})
-	if got := len(results[0].Content) + len(results[1].Content); got != 600 {
-		t.Fatalf("environment budget produced %d bytes, want 600", got)
+	if got := len(results[0].Content) + len(results[1].Content); got > 600 || got < 590 {
+		t.Fatalf("environment budget produced %d bytes, want near ceiling 600", got)
+	}
+}
+
+func TestTurnOutputBudgetUTF8OmittedDigitBoundaryTerminates(t *testing.T) {
+	t.Setenv("STELLA_TOOL_MAX_TURN_BYTES", "")
+	output := strings.Repeat("🙂a", 5249)
+	results := ApplyTurnOutputBudget([]string{output, output, output, output})
+
+	total := 0
+	for i, result := range results {
+		total += len(result.Content)
+		if !result.Truncated {
+			t.Fatalf("result %d should be truncated", i)
+		}
+		if result.OmittedBytes < 9999 || result.OmittedBytes > 10000 {
+			t.Fatalf("result %d omitted %d bytes, want decimal-boundary case", i, result.OmittedBytes)
+		}
+		if !utf8.ValidString(result.Content) {
+			t.Fatalf("result %d is not valid UTF-8", i)
+		}
+	}
+	if total > defaultMaxTurnBytes {
+		t.Fatalf("turn added %d bytes, exceeds hard ceiling %d", total, defaultMaxTurnBytes)
+	}
+}
+
+func TestTurnOutputBudgetClampsTinyEnvironmentValue(t *testing.T) {
+	t.Setenv("STELLA_TOOL_MAX_TURN_BYTES", "1")
+	result := ApplyTurnOutputBudget([]string{"ok"})[0]
+	if result.Truncated || result.Content != "ok" {
+		t.Fatalf("tiny configured budget should clamp, got %#v", result)
+	}
+}
+
+func TestTurnOutputBudgetClampsEachShareToActionableMarker(t *testing.T) {
+	t.Setenv("STELLA_TOOL_MAX_TURN_BYTES", "128")
+	results := ApplyTurnOutputBudget([]string{strings.Repeat("a", 1000), strings.Repeat("b", 1000)})
+	for i, result := range results {
+		if !result.Truncated {
+			t.Fatalf("result %d should be truncated", i)
+		}
+		if !strings.Contains(result.Content, "omitted ") || !strings.Contains(result.Content, "Use smaller reads or split the work across turns") {
+			t.Fatalf("result %d marker is incomplete: %q", i, result.Content)
+		}
 	}
 }
 

--- a/pkg/tools/truncate_test.go
+++ b/pkg/tools/truncate_test.go
@@ -204,6 +204,89 @@ func TestMaxLinesInvalidEnvVar(t *testing.T) {
 	}
 }
 
+func TestTurnOutputBudgetSingleCallKeepsPerCallBehavior(t *testing.T) {
+	t.Setenv("STELLA_TOOL_MAX_TURN_BYTES", "")
+	perCall := TruncateTail(strings.Repeat("x", defaultMaxBytes+1024)).Content
+	if len(perCall) <= defaultMaxBytes {
+		t.Fatalf("test needs per-call diagnostics above the payload cap, got %d bytes", len(perCall))
+	}
+
+	result := ApplyTurnOutputBudget([]string{perCall})[0]
+	if result.Truncated || result.Content != perCall {
+		t.Fatal("one call must retain the existing per-call truncation result unchanged")
+	}
+}
+
+func TestTurnOutputBudgetEqualCallsShareEvenly(t *testing.T) {
+	t.Setenv("STELLA_TOOL_MAX_TURN_BYTES", "1024")
+	outputs := []string{
+		strings.Repeat("a", 400),
+		strings.Repeat("b", 400),
+		strings.Repeat("c", 400),
+		strings.Repeat("d", 400),
+	}
+
+	results := ApplyTurnOutputBudget(outputs)
+	for i, result := range results {
+		if !result.Truncated || len(result.Content) != 256 {
+			t.Fatalf("result %d = (truncated=%t, bytes=%d), want (true, 256)", i, result.Truncated, len(result.Content))
+		}
+	}
+}
+
+func TestTurnOutputBudgetWaterFillsThreeSmallOneLarge(t *testing.T) {
+	t.Setenv("STELLA_TOOL_MAX_TURN_BYTES", "1024")
+	outputs := []string{
+		strings.Repeat("a", 100),
+		strings.Repeat("b", 100),
+		strings.Repeat("c", 100),
+		strings.Repeat("d", 1000),
+	}
+
+	results := ApplyTurnOutputBudget(outputs)
+	for i := range 3 {
+		if results[i].Truncated || results[i].Content != outputs[i] {
+			t.Fatalf("small result %d should surrender only its unused share", i)
+		}
+	}
+	if !results[3].Truncated || len(results[3].Content) != 724 {
+		t.Fatalf("large result = (truncated=%t, bytes=%d), want (true, 724)", results[3].Truncated, len(results[3].Content))
+	}
+}
+
+func TestTurnOutputBudgetExhaustionHasActionableMarker(t *testing.T) {
+	t.Setenv("STELLA_TOOL_MAX_TURN_BYTES", "512")
+	outputs := []string{strings.Repeat("a", 1000), strings.Repeat("b", 1000)}
+	results := ApplyTurnOutputBudget(outputs)
+
+	total := 0
+	for i, result := range results {
+		total += len(result.Content)
+		if !result.Truncated || result.OmittedBytes <= 0 {
+			t.Fatalf("result %d did not report omitted bytes: %#v", i, result)
+		}
+		marker := formatTurnBudgetMarker(result.OmittedBytes)
+		if !strings.Contains(result.Content, marker) {
+			t.Fatalf("result %d marker is not actionable: %q", i, result.Content)
+		}
+		kept := len(result.Content) - len(marker)
+		if result.OmittedBytes != len(outputs[i])-kept {
+			t.Fatalf("result %d omitted %d bytes, want %d", i, result.OmittedBytes, len(outputs[i])-kept)
+		}
+	}
+	if total != 512 {
+		t.Fatalf("turn added %d bytes, want hard ceiling 512", total)
+	}
+}
+
+func TestTurnOutputBudgetEnvironmentOverride(t *testing.T) {
+	t.Setenv("STELLA_TOOL_MAX_TURN_BYTES", "600")
+	results := ApplyTurnOutputBudget([]string{strings.Repeat("a", 500), strings.Repeat("b", 500)})
+	if got := len(results[0].Content) + len(results[1].Content); got != 600 {
+		t.Fatalf("environment budget produced %d bytes, want 600", got)
+	}
+}
+
 func TestIsBinary(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/web/content/docs/start-here/deployment.md
+++ b/web/content/docs/start-here/deployment.md
@@ -382,7 +382,7 @@ Configuration is managed through the Web UI (default `http://localhost:25678`; u
 | `STELLA_SANDBOX_BACKEND`         | No                        | Sandbox backend: `docker`, `local` (default), or `none`                                                                                                                       |
 | `STELLA_TOOL_MAX_LINES`          | No                        | Maximum retained lines per textual tool result (default `2000`)                                                                                                               |
 | `STELLA_TOOL_MAX_BYTES`          | No                        | Maximum retained payload bytes per textual tool result (default `51200`)                                                                                                      |
-| `STELLA_TOOL_MAX_TURN_BYTES`     | No                        | Maximum aggregate textual tool-result bytes added by one agent turn (default `65536`); parallel calls share it fairly                                                         |
+| `STELLA_TOOL_MAX_TURN_BYTES`     | No                        | Provider-visible text budget per agent turn (default `65536`); fair-shared, with a minimum for complete truncation markers                                                    |
 | `STELLA_DOCKER_RUNTIME`          | No‡                       | Registered OCI runtime for Docker sandbox and tool-cache containers; unset uses the daemon default, unavailable configured values fail preflight                              |
 
 † Without `STELLA_VAULT_KEY`, vault endpoints return `503`, OAuth tokens cannot be issued, and plugin secrets are not injected. Generate a key with `age-keygen`.

--- a/web/content/docs/start-here/deployment.md
+++ b/web/content/docs/start-here/deployment.md
@@ -380,6 +380,9 @@ Configuration is managed through the Web UI (default `http://localhost:25678`; u
 | `STELLA_BLOB_S3_USE_SSL`         | No                        | Use HTTPS for S3-compatible storage; defaults to `true`                                                                                                                       |
 | `STELLA_VAULT_KEY`               | Yes†                      | age secret key for the vault — required for secrets, OAuth, and bearer tokens                                                                                                 |
 | `STELLA_SANDBOX_BACKEND`         | No                        | Sandbox backend: `docker`, `local` (default), or `none`                                                                                                                       |
+| `STELLA_TOOL_MAX_LINES`          | No                        | Maximum retained lines per textual tool result (default `2000`)                                                                                                               |
+| `STELLA_TOOL_MAX_BYTES`          | No                        | Maximum retained payload bytes per textual tool result (default `51200`)                                                                                                      |
+| `STELLA_TOOL_MAX_TURN_BYTES`     | No                        | Maximum aggregate textual tool-result bytes added by one agent turn (default `65536`); parallel calls share it fairly                                                         |
 | `STELLA_DOCKER_RUNTIME`          | No‡                       | Registered OCI runtime for Docker sandbox and tool-cache containers; unset uses the daemon default, unavailable configured values fail preflight                              |
 
 † Without `STELLA_VAULT_KEY`, vault endpoints return `503`, OAuth tokens cannot be issued, and plugin secrets are not injected. Generate a key with `age-keygen`.

--- a/web/content/docs/start-here/deployment.zh.md
+++ b/web/content/docs/start-here/deployment.zh.md
@@ -371,7 +371,7 @@ terminationGracePeriodSeconds: 200
 | `STELLA_SANDBOX_BACKEND`         | 否                        | 沙箱后端：`docker`、`local`（默认）或 `none`                                                                           |
 | `STELLA_TOOL_MAX_LINES`          | 否                        | 每个文本工具结果最多保留的行数（默认 `2000`）                                                                          |
 | `STELLA_TOOL_MAX_BYTES`          | 否                        | 每个文本工具结果最多保留的正文载荷字节数（默认 `51200`）                                                               |
-| `STELLA_TOOL_MAX_TURN_BYTES`     | 否                        | 单个 agent 回合加入上下文的文本工具结果总字节上限（默认 `65536`）；并行调用公平共享该预算                              |
+| `STELLA_TOOL_MAX_TURN_BYTES`     | 否                        | 单个 agent 回合的 provider 可见文本基础总预算（默认 `65536`）；并行调用公平共享，过小配置仅上调至足以完整显示截断标记  |
 | `STELLA_DOCKER_RUNTIME`          | 否‡                       | Docker 沙箱和工具缓存容器使用的已注册 OCI runtime；未设置时使用 daemon 默认值，配置值不可用时预检失败                  |
 
 † 未设置 `STELLA_VAULT_KEY` 时，密钥库接口返回 `503`，无法签发 OAuth Token，插件密钥也不会被注入。使用 `age-keygen` 生成密钥。

--- a/web/content/docs/start-here/deployment.zh.md
+++ b/web/content/docs/start-here/deployment.zh.md
@@ -369,6 +369,9 @@ terminationGracePeriodSeconds: 200
 | `STELLA_BLOB_S3_USE_SSL`         | 否                        | S3 兼容存储是否使用 HTTPS；默认 `true`                                                                                 |
 | `STELLA_VAULT_KEY`               | 是†                       | 密钥库使用的 age 私钥 —— 密钥管理、OAuth 和 Bearer Token 所必需                                                        |
 | `STELLA_SANDBOX_BACKEND`         | 否                        | 沙箱后端：`docker`、`local`（默认）或 `none`                                                                           |
+| `STELLA_TOOL_MAX_LINES`          | 否                        | 每个文本工具结果最多保留的行数（默认 `2000`）                                                                          |
+| `STELLA_TOOL_MAX_BYTES`          | 否                        | 每个文本工具结果最多保留的正文载荷字节数（默认 `51200`）                                                               |
+| `STELLA_TOOL_MAX_TURN_BYTES`     | 否                        | 单个 agent 回合加入上下文的文本工具结果总字节上限（默认 `65536`）；并行调用公平共享该预算                              |
 | `STELLA_DOCKER_RUNTIME`          | 否‡                       | Docker 沙箱和工具缓存容器使用的已注册 OCI runtime；未设置时使用 daemon 默认值，配置值不可用时预检失败                  |
 
 † 未设置 `STELLA_VAULT_KEY` 时，密钥库接口返回 `503`，无法签发 OAuth Token，插件密钥也不会被注入。使用 `age-keygen` 生成密钥。


### PR DESCRIPTION
## What

Add a deterministic per-turn aggregate budget for provider-visible textual tool results, shared across all tool calls in the turn with max-min fairness.

## Why

The existing 50 KiB / 2,000-line limits apply per call. Several large calls in one turn could therefore add roughly 150 KiB to context at once, and every later model request carried that output again. The eval loop measured up to 4x trial cost from this amplification.

## How

- Set the default turn budget `B` to **64 KiB**, configurable with `STELLA_TOOL_MAX_TURN_BYTES`.
- Apply the budget after canonical image projection and measure each result with the same `ai.FlattenText` used by providers. This includes block separators and text-model image baselines without duplicating provider logic.
- Budget only the provider-ready copy. Canonical history remains lossless, completed tools emit `ToolFinished` immediately in `start/finish` order, and completed results survive a later call failure.
- Use max-min fair allocation in provider call order: small results surrender unused shares, while equally demanding results receive equal shares with deterministic remainder assignment.
- Keep the existing 50 KiB per-call payload cap unchanged. The 64 KiB base ceiling is deliberately above it so a single call, including its existing truncation diagnostics, behaves exactly as before.
- Count the turn-budget marker and `FlattenText` separator allowance inside each share. Preserve text/image block order while retaining result head and tail.
- Clamp too-small configured budgets only by the bytes required to keep every necessary truncation marker complete and actionable.
- Reserve marker width from the maximum possible omitted count (`len(output)`) and compute truncation once. The actual count can never need more digits, so UTF-8 rounding cannot create a fixed-point oscillation.
- Document all three tool-output tuning variables in English and Chinese deployment docs.

The 64 KiB base ceiling should otherwise be raised only if measured completion gains from larger same-turn outputs outweigh the cost of repeatedly carrying them in later requests.

## Test

- `mise run format`
- `mise run build`
- `mise run test`
- `go test -timeout=2s ./pkg/tools -run TestTurnOutputBudgetUTF8OmittedDigitBoundaryTerminates -count=1`
- Focused Go tests cover single-call degeneration, equal calls, three-small/one-large water filling, exhausted-budget markers, environment override, tiny-budget clamping, UTF-8 decimal-boundary termination, provider-visible block separators, image baselines, mixed block order, and completed-result persistence when a later tool fails.
- Each review regression test was temporarily run with its corresponding fix rolled back and failed as expected; details are in the PR follow-up comment.

## Refs

Fixes #1116

## Checklist

- [x] The PR links a GitHub issue, or states why the fix is small enough not to need one.
- [x] I added or updated focused tests for changed non-trivial behavior, or explained why none are needed.
- [x] I updated relevant English and Chinese documentation, or no documentation change is needed.
- [x] I ran `mise run format && mise run build && mise run test`.

## Feishu Task

- [并行工具调用按聚合上限截断输出](https://mcnnox2fhjfq.feishu.cn/record/PnKMrWqgfemqdzctXlAcY5b1nEf) (#1116)