### PR TITLE
✨ evals: add quick tier and OTel analysis

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -232,8 +232,12 @@ depends = ["pg:runtime:download", "build"]
 run = "go test -tags system -count=1 -timeout 15m ./test/system/..."
 
 [tasks."eval:loop"]
-description = "Run the fix-iteration eval loop end to end (build, testbed, Harbor, report, manifest)"
+description = "Run the quick/full fix-iteration eval loop (default full; quick enables OTel)"
 run = "./test/evals/harbor/loop.sh"
+
+[tasks."eval:build"]
+description = "Build eval binaries only when the checked-in sources are newer"
+run = "./test/evals/harbor/eval_build.sh"
 
 [tasks.format]
 description = "Fix and format files"

--- a/test/evals/harbor/eval_build.sh
+++ b/test/evals/harbor/eval_build.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Build eval-only binaries without making a fresh stellad rebuild regenerate.
+set -euo pipefail
+
+HARBOR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=stellad_wrapper.sh
+source "$HARBOR_DIR/stellad_wrapper.sh"
+
+tracked_sources_newer() {
+  local binary=$1 source
+  shift
+  [ -x "$binary" ] || return 0
+  while IFS= read -r source; do
+    [ "$source" -nt "$binary" ] && return 0
+  done < <(git ls-files -- "$@")
+  return 1
+}
+
+untracked_go_sources_newer() {
+  local binary=$1 source
+  shift
+  [ -x "$binary" ] || return 0
+  while IFS= read -r source; do
+    git ls-files --error-unmatch "$source" >/dev/null 2>&1 && continue
+    [ "$source" -nt "$binary" ] && return 0
+  done < <(find "$@" -type f -name '*.go' -print 2>/dev/null)
+  return 1
+}
+
+stellad_source_identity() {
+  {
+    git rev-parse HEAD
+    git status --porcelain -- cmd/stellad internal pkg plugins api resources web go.mod go.sum
+  } | shasum -a 256 | awk '{print $1}'
+}
+
+main() {
+  local identity stamp=./dist/bin/stellad.eval-source
+  recover_stale_stellad_binary ./dist/bin/stellad
+  identity=$(stellad_source_identity)
+
+  if [ ! -f "$stamp" ] || [ "$(cat "$stamp")" != "$identity" ] ||
+    tracked_sources_newer ./dist/bin/stellad cmd/stellad internal pkg plugins api resources web go.mod go.sum ||
+    untracked_go_sources_newer ./dist/bin/stellad cmd/stellad internal pkg plugins; then
+    local version commit build_date ldflags
+    version=$(git describe --tags --always --dirty 2>/dev/null || echo dev)
+    commit=$(git rev-parse --short HEAD)
+    build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    ldflags="-X github.com/CherryHQ/stella/internal/version.Version=$version -X github.com/CherryHQ/stella/internal/version.Commit=$commit -X github.com/CherryHQ/stella/internal/version.BuildDate=$build_date"
+    mise run generate
+    rm -rf ./dist/bin
+    mkdir -p ./dist/bin
+    go build -ldflags="$ldflags" -o ./dist/bin/stellad ./cmd/stellad
+    identity=$(stellad_source_identity)
+    printf '%s\n' "$identity" >"$stamp"
+  else
+    echo "eval:build: reusing dist/bin/stellad (newer than sources, source identity unchanged)"
+  fi
+
+  mkdir -p ./dist/bin ./dist/bin-eval
+  if tracked_sources_newer ./dist/bin/testbed test/testbed internal/db internal/pgruntime internal/vault go.mod go.sum ||
+    untracked_go_sources_newer ./dist/bin/testbed test/testbed internal/db internal/pgruntime internal/vault; then
+    go build -o ./dist/bin/testbed ./test/testbed
+  fi
+  if tracked_sources_newer ./dist/bin-eval/stella-eval-agent cmd/stella-eval-agent internal pkg plugins test/evals/harbor go.mod go.sum ||
+    untracked_go_sources_newer ./dist/bin-eval/stella-eval-agent cmd/stella-eval-agent internal pkg plugins test/evals/harbor; then
+    go build -o ./dist/bin-eval/stella-eval-agent ./cmd/stella-eval-agent
+  fi
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  main "$@"
+fi

--- a/test/evals/harbor/eval_build.sh
+++ b/test/evals/harbor/eval_build.sh
@@ -2,10 +2,6 @@
 # Build eval-only binaries without making a fresh stellad rebuild regenerate.
 set -euo pipefail
 
-HARBOR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-# shellcheck source=stellad_wrapper.sh
-source "$HARBOR_DIR/stellad_wrapper.sh"
-
 tracked_sources_newer() {
   local binary=$1 source
   shift
@@ -34,9 +30,33 @@ stellad_source_identity() {
   } | shasum -a 256 | awk '{print $1}'
 }
 
+acquire_build_lock() {
+  local lock=./dist/.eval-build.lock owner deadline=$((SECONDS + 300))
+  mkdir -p ./dist
+  while ! mkdir "$lock" 2>/dev/null; do
+    owner=$(cat "$lock/pid" 2>/dev/null || true)
+    if [ -n "$owner" ] && ! kill -0 "$owner" 2>/dev/null; then
+      rm -rf "$lock"
+      continue
+    fi
+    [ "$SECONDS" -lt "$deadline" ] || {
+      echo "eval:build: timed out waiting for $lock" >&2
+      return 1
+    }
+    sleep 1
+  done
+  printf '%s\n' "$$" >"$lock/pid"
+}
+
+release_build_lock() { rm -rf ./dist/.eval-build.lock; }
+
 main() {
   local identity stamp=./dist/bin/stellad.eval-source
-  recover_stale_stellad_binary ./dist/bin/stellad
+  acquire_build_lock
+  trap release_build_lock EXIT
+  trap 'exit 129' HUP
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
   identity=$(stellad_source_identity)
 
   if [ ! -f "$stamp" ] || [ "$(cat "$stamp")" != "$identity" ] ||

--- a/test/evals/harbor/eval_build.sh
+++ b/test/evals/harbor/eval_build.sh
@@ -31,16 +31,14 @@ stellad_source_identity() {
 }
 
 acquire_build_lock() {
-  local lock=./dist/.eval-build.lock owner deadline=$((SECONDS + 300))
+  local lock=./dist/.eval-build.lock owner timeout=${STELLA_EVAL_BUILD_LOCK_TIMEOUT:-300}
+  local deadline=$((SECONDS + timeout))
   mkdir -p ./dist
   while ! mkdir "$lock" 2>/dev/null; do
     owner=$(cat "$lock/pid" 2>/dev/null || true)
-    if [ -n "$owner" ] && ! kill -0 "$owner" 2>/dev/null; then
-      rm -rf "$lock"
-      continue
-    fi
     [ "$SECONDS" -lt "$deadline" ] || {
-      echo "eval:build: timed out waiting for $lock" >&2
+      [ -n "$owner" ] || owner=unknown
+      echo "eval:build: timed out waiting for $lock (owner PID: $owner); confirm that process is dead, then rm -rf $lock" >&2
       return 1
     }
     sleep 1

--- a/test/evals/harbor/loop.sh
+++ b/test/evals/harbor/loop.sh
@@ -117,20 +117,22 @@ STELLA_TESTBED_PORT=${STELLA_TESTBED_PORT:-$(free_port)}
 STELLA_URL=${STELLA_URL:-http://127.0.0.1:$STELLA_TESTBED_PORT}
 JOB_PREFIX=$TIER
 [ "$TIER" != full ] || JOB_PREFIX=loop # Preserve the established full baseline job layout.
-JOB=$REPO_ROOT/dist/evals/jobs/$JOB_PREFIX-$(date -u +%Y%m%dT%H%M%SZ)
+JOB_BASE=$REPO_ROOT/dist/evals/jobs/$JOB_PREFIX-$(date -u +%Y%m%dT%H%M%SZ)
+JOB=$JOB_BASE
 RUN_STATE=$REPO_ROOT/dist/evals/runs/$(basename "$JOB")
-if [ -e "$JOB" ] || [ -e "$JOB.manifest.json" ] || [ -e "$RUN_STATE" ]; then
-  JOB=$JOB-$$
-  RUN_STATE=$REPO_ROOT/dist/evals/runs/$(basename "$JOB")
-fi
-MANIFEST=$JOB.manifest.json
-TESTBED_ROOT=$RUN_STATE/testbed-root
-TESTBED_LOG=$RUN_STATE/testbed.log
+set_run_paths() {
+  MANIFEST=$JOB.manifest.json
+  TESTBED_ROOT=$RUN_STATE/testbed-root
+  TESTBED_LOG=$RUN_STATE/testbed.log
+}
+build_harbor_cmd() {
+  harbor_cmd=(uv run --project "$HARBOR_DIR" harbor run ${source_args[@]+"${source_args[@]}"} -a stella_harbor.agent:StellaAgent -m "$MODEL" -o "$JOB" ${HARBOR_ARGS[@]+"${HARBOR_ARGS[@]}"})
+  if [ "$caller_concurrency" = 0 ]; then
+    harbor_cmd=(uv run --project "$HARBOR_DIR" harbor run ${source_args[@]+"${source_args[@]}"} -n "$TASKSET_CONCURRENCY" -a stella_harbor.agent:StellaAgent -m "$MODEL" -o "$JOB" ${HARBOR_ARGS[@]+"${HARBOR_ARGS[@]}"})
+  fi
+}
+set_run_paths
 AGENT_BIN=$REPO_ROOT/dist/bin-eval/stella-eval-agent
-harbor_cmd=(uv run --project "$HARBOR_DIR" harbor run ${source_args[@]+"${source_args[@]}"} -a stella_harbor.agent:StellaAgent -m "$MODEL" -o "$JOB" ${HARBOR_ARGS[@]+"${HARBOR_ARGS[@]}"})
-if [ "$caller_concurrency" = 0 ]; then
-  harbor_cmd=(uv run --project "$HARBOR_DIR" harbor run ${source_args[@]+"${source_args[@]}"} -n "$TASKSET_CONCURRENCY" -a stella_harbor.agent:StellaAgent -m "$MODEL" -o "$JOB" ${HARBOR_ARGS[@]+"${HARBOR_ARGS[@]}"})
-fi
 
 if [ "$PLAN" = 1 ]; then
   gateway_state="(MISSING)"; [ -z "${OPENAI_BASE_URL:-}" ] || gateway_state="(set, host $(python3 -c 'import os,urllib.parse; print(urllib.parse.urlsplit(os.environ["OPENAI_BASE_URL"]).hostname or "?")'))"
@@ -176,12 +178,16 @@ raise SystemExit(0 if ok else 1)
 PY
 fi
 
-mkdir -p "$REPO_ROOT/dist/evals/runs"
+RUNS_ROOT=$REPO_ROOT/dist/evals/runs
+mkdir -p "$RUNS_ROOT"
 # Crash residue is deliberately discoverable under dist/evals/runs. Only dead
 # owners older than one day are pruned; live owners are never removed.
-prune_stale_run_states "$REPO_ROOT/dist/evals/runs" 86400
-mkdir -p "$RUN_STATE"
-printf '%s\n' "$$" >"$RUN_STATE/owner.pid"
+prune_stale_run_states "$RUNS_ROOT" 86400
+claim_run_state "$JOB_BASE" "$RUNS_ROOT" 100 "$$" || die "cannot claim eval run state"
+JOB=$CLAIMED_JOB
+RUN_STATE=$CLAIMED_RUN_STATE
+set_run_paths
+build_harbor_cmd
 WORK=$(mktemp -d)
 COOKIE_JAR=$WORK/cookies.txt
 TESTBED_STARTED=0 OTEL_CONTAINER=""

--- a/test/evals/harbor/loop.sh
+++ b/test/evals/harbor/loop.sh
@@ -22,7 +22,6 @@ MODEL=$PROVIDER_ID/$MODEL_ID
 READY_TIMEOUT=${STELLA_EVAL_READY_TIMEOUT:-120}
 # Any fixed port collides on someone's machine. The testbed port uses a kernel
 # allocation; Docker does the same for OTel's published ports below.
-TESTBED_LOG=$REPO_ROOT/dist/logs/eval-loop-testbed.log
 TIER=full OTEL="" REUSE_TESTBED=0 PLAN=0 AGAINST=""
 
 die() { echo "eval:loop: $*" >&2; exit 1; }
@@ -117,7 +116,14 @@ STELLA_URL=${STELLA_URL:-http://127.0.0.1:$STELLA_TESTBED_PORT}
 JOB_PREFIX=$TIER
 [ "$TIER" != full ] || JOB_PREFIX=loop # Preserve the established full baseline job layout.
 JOB=$REPO_ROOT/dist/evals/jobs/$JOB_PREFIX-$(date -u +%Y%m%dT%H%M%SZ)
+RUN_STATE=$REPO_ROOT/dist/evals/runs/$(basename "$JOB")
+if [ -e "$JOB" ] || [ -e "$JOB.manifest.json" ] || [ -e "$RUN_STATE" ]; then
+  JOB=$JOB-$$
+  RUN_STATE=$REPO_ROOT/dist/evals/runs/$(basename "$JOB")
+fi
 MANIFEST=$JOB.manifest.json
+TESTBED_ROOT=$RUN_STATE/testbed-root
+TESTBED_LOG=$RUN_STATE/testbed.log
 AGENT_BIN=$REPO_ROOT/dist/bin-eval/stella-eval-agent
 harbor_cmd=(uv run --project "$HARBOR_DIR" harbor run ${source_args[@]+"${source_args[@]}"} -a stella_harbor.agent:StellaAgent -m "$MODEL" -o "$JOB" ${HARBOR_ARGS[@]+"${HARBOR_ARGS[@]}"})
 if [ "$caller_concurrency" = 0 ]; then
@@ -133,8 +139,8 @@ plan only, nothing is executed.
 1. preflight   tier $TIER; taskset $TASKSET$( [ "$caller_concurrency" = 0 ] && echo "; explicit concurrency -n $TASKSET_CONCURRENCY" || echo "; caller-supplied concurrency" )
                OPENAI_BASE_URL $gateway_state and OPENAI_API_KEY $key_state exported
 2. build       mise run eval:build, only when each binary is older than its sources
-3. otel        $( [ "$OTEL" = 1 ] && echo "docker run -d grafana/otel-lgtm; discover kernel-assigned OTLP HTTP and Grafana ports; atomically move dist/bin/stellad to a private real-binary path, then atomically install a temporary stellad wrapper at dist/bin/stellad. Before testbed start the wrapper exports the local OTLP settings, disables logs/metrics, raises OTEL_BSP_MAX_QUEUE_SIZE for the six-trial wave, and flushes once per second; cleanup atomically restores the real binary." || echo "disabled (full baseline default)" )
-4. testbed     $( [ "$REUSE_TESTBED" = 1 ] && echo "reuse STELLA_URL after bridge health check, OTel must be off; credentials path from STELLA_TESTBED_CREDENTIALS" || echo "fresh bridge testbed on $STELLA_URL" )
+3. otel        $( [ "$OTEL" = 1 ] && echo "docker run -d grafana/otel-lgtm; discover kernel-assigned OTLP HTTP and Grafana ports; install an OTel wrapper only around the private stellad copy under $TESTBED_ROOT. Before testbed start the wrapper exports the local OTLP settings, disables logs/metrics, raises OTEL_BSP_MAX_QUEUE_SIZE for the six-trial wave, and flushes once per second; shared dist/bin/stellad is never modified." || echo "disabled (full baseline default)" )
+4. testbed     $( [ "$REUSE_TESTBED" = 1 ] && echo "reuse STELLA_URL after bridge and build-commit health checks, OTel must be off; credentials path and bridge dir are caller-supplied" || echo "copy eval binaries to $TESTBED_ROOT; start a fresh bridge testbed on $STELLA_URL (log $TESTBED_LOG)" )
 5. provision   credentials-file path only; private cookie jar; provider and provisioning token
 6. run         source: $source_kind; Harbor command $( [ "$caller_concurrency" = 0 ] && echo "uses explicit -n $TASKSET_CONCURRENCY" || echo "preserves caller-supplied concurrency" )
 7. after       report$( [ "$OTEL" = 1 ] && echo ", Tempo span analysis and per-trial nonzero-span assertion" ); manifest -> $MANIFEST
@@ -168,18 +174,27 @@ raise SystemExit(0 if ok else 1)
 PY
 fi
 
+mkdir -p "$REPO_ROOT/dist/evals/runs"
+# Crash residue is deliberately discoverable under dist/evals/runs. Remove only
+# old inactive leftovers; a normal cleanup removes its own directory below.
+find "$REPO_ROOT/dist/evals/runs" -mindepth 1 -maxdepth 1 -type d -mtime +1 -exec rm -rf {} +
+mkdir -p "$RUN_STATE"
 WORK=$(mktemp -d)
 COOKIE_JAR=$WORK/cookies.txt
-TESTBED_STARTED=0 OTEL_CONTAINER="" REAL_STELLAD=""
+TESTBED_STARTED=0 OTEL_CONTAINER=""
 cleanup() {
   status=$?
   set +e
-  rm -f "$COOKIE_JAR"; rm -rf "$WORK"
   if [ "$TESTBED_STARTED" = 1 ]; then
     step "stopping the testbed"
-    (cd "$REPO_ROOT" && mise run testbed:stop) >/dev/null 2>&1
+    (cd "$TESTBED_ROOT" && ./dist/bin/testbed stop) >/dev/null 2>&1
   fi
-  restore_stellad_binary "$REPO_ROOT/dist/bin/stellad" "$REAL_STELLAD"
+  rm -f "$COOKIE_JAR"; rm -rf "$WORK"
+  if [ "$status" -eq 0 ]; then
+    rm -rf "$RUN_STATE"
+  else
+    echo "eval:loop: run state kept at $RUN_STATE" >&2
+  fi
   [ -z "$OTEL_CONTAINER" ] || echo "eval:loop: OTel is still running; stop it with: docker stop $OTEL_CONTAINER" >&2
   [ "$status" -eq 0 ] || [ ! -d "$JOB" ] || echo "eval:loop: failed; Harbor job kept at $JOB" >&2
 }
@@ -202,6 +217,11 @@ api() {
 step "capturing build/start snapshot and preparing binaries"
 SNAPSHOT_COMMIT=$(git -C "$REPO_ROOT" rev-parse HEAD); export SNAPSHOT_COMMIT
 (cd "$REPO_ROOT" && mise run eval:build)
+if [ "$REUSE_TESTBED" = 0 ]; then
+  mkdir -p "$TESTBED_ROOT/dist/bin"
+  cp "$REPO_ROOT/dist/bin/stellad" "$TESTBED_ROOT/dist/bin/stellad"
+  cp "$REPO_ROOT/dist/bin/testbed" "$TESTBED_ROOT/dist/bin/testbed"
+fi
 
 if [ "$OTEL" = 1 ]; then
   step "starting OTel LGTM on kernel-assigned ports"
@@ -215,10 +235,9 @@ if [ "$OTEL" = 1 ]; then
     sleep 1
   done
   echo "    Grafana/Tempo: http://127.0.0.1:$OTEL_GRAFANA_PORT"
-  # testbed filters OTEL_* from child env. After ports are known, stage the
-  # wrapper before starting it so the server gets only this local allowlist.
-  REAL_STELLAD=$REPO_ROOT/dist/bin/.stellad-eval-real-$$-$RANDOM
-  stage_otel_stellad_wrapper "$REPO_ROOT/dist/bin/stellad" "$REAL_STELLAD" "http://127.0.0.1:$OTEL_OTLP_PORT"
+  # testbed filters OTEL_* from child env. Wrap only this run's private binary;
+  # concurrent evals and later no-otel runs never observe the wrapper.
+  stage_otel_stellad_wrapper "$TESTBED_ROOT/dist/bin/stellad" "$TESTBED_ROOT/dist/bin/stellad.real" "http://127.0.0.1:$OTEL_OTLP_PORT"
 fi
 
 export PROVIDER_ID PROVIDER_TYPE MODEL_ID MODEL STELLA_URL STELLA_TESTBED_PORT
@@ -235,7 +254,7 @@ else
   # `postgres download` is idempotent: the existing stellad checks for its
   # runtime and downloads only when absent. It does not invoke mise build or
   # generate, so a fresh dist/bin/stellad stays genuinely reusable.
-  (cd "$REPO_ROOT" && ./dist/bin/stellad postgres download && exec ./dist/bin/testbed start) >"$TESTBED_LOG" 2>&1 &
+  (cd "$TESTBED_ROOT" && ./dist/bin/stellad postgres download && exec ./dist/bin/testbed start) >"$TESTBED_LOG" 2>&1 &
   TESTBED_PID=$!; TESTBED_STARTED=1
 fi
 deadline=$((SECONDS + READY_TIMEOUT))

--- a/test/evals/harbor/loop.sh
+++ b/test/evals/harbor/loop.sh
@@ -7,321 +7,318 @@
 # script never reads .env, never prints a secret, and never puts one in a
 # process argument: request bodies go in from private files, bearer tokens go
 # in through a curl config on stdin.
-#
-#   mise run eval:loop                              # the default 12-task set
-#   mise run eval:loop -- -i terminal-bench/build-cython-ext -k 5
-#   mise run eval:loop -- --against dist/evals/jobs/loop-<earlier>
-#   mise run eval:loop -- --plan                    # print the steps, run none
-
 set -euo pipefail
-umask 077 # every file this script creates is private from birth
+umask 077
 
 REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
 HARBOR_DIR=$REPO_ROOT/test/evals/harbor
-TASKSET=$HARBOR_DIR/tasksets/loop.yaml
+# shellcheck source=stellad_wrapper.sh
+source "$HARBOR_DIR/stellad_wrapper.sh"
 DATASET=terminal-bench/terminal-bench-2-1
 PROVIDER_ID=${STELLA_EVAL_PROVIDER_ID:-gateway}
 PROVIDER_TYPE=${STELLA_EVAL_PROVIDER_TYPE:-openai-response}
 MODEL_ID=${STELLA_EVAL_MODEL_ID:-gpt-5.6-luna}
 MODEL=$PROVIDER_ID/$MODEL_ID
-# Any fixed port collides on someone's machine: 25678 is a dev server, 25679 a
-# production stellad. Ask the kernel for a free one instead. There is a race
-# between this bind and the server's, and it is deliberately not defended
-# against: losing it fails loudly at startup with the port in the message.
-# testbed:stop is keyed by repository root, not by port, so it cleans up
-# whatever port the run picked.
-STELLA_TESTBED_PORT=${STELLA_TESTBED_PORT:-$(python3 -c 'import socket
-s = socket.socket()
-s.bind(("127.0.0.1", 0))
-print(s.getsockname()[1])
-s.close()')}
-STELLA_URL=${STELLA_URL:-http://127.0.0.1:$STELLA_TESTBED_PORT}
 READY_TIMEOUT=${STELLA_EVAL_READY_TIMEOUT:-120}
+# Any fixed port collides on someone's machine. The testbed port uses a kernel
+# allocation; Docker does the same for OTel's published ports below.
 TESTBED_LOG=$REPO_ROOT/dist/logs/eval-loop-testbed.log
-export PROVIDER_ID PROVIDER_TYPE MODEL_ID MODEL STELLA_URL STELLA_TESTBED_PORT
+TIER=full OTEL="" REUSE_TESTBED=0 PLAN=0 AGAINST=""
 
+die() { echo "eval:loop: $*" >&2; exit 1; }
+step() { echo "==> $*"; }
+free_port() { python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()'; }
 usage() {
-	cat <<'EOF'
-usage: mise run eval:loop [-- [--plan] [--against REF_JOB] [harbor args...]]
+  cat <<'EOF'
+usage: mise run eval:loop [-- [--tier quick|full] [--otel|--no-otel]
+                           [--reuse-testbed] [--plan] [--against REF_JOB]
+                           [harbor args...]]
 
-  --plan            print every step and the exact commands, execute nothing
-  --against REF     after the run, compare it against a reference job
-                    directory (the new run is the candidate)
-  -h, --help        this text
+  --tier TIER       quick (k=1, six tasks) or full (12-task baseline); default full
+  --otel            force OTel on (quick defaults on, full defaults off)
+  --no-otel         force OTel off
+  --reuse-testbed   reuse a healthy, already-running bridge testbed with OTel off
+  --plan            print the safe execution plan, run nothing
+  --against REF     compare the completed job against REF_JOB
 
-Anything else is passed to `harbor run` verbatim. The default source is
-tasksets/loop.yaml; passing -i/--include-task-name switches the source to the
-Terminal-Bench 2.1 dataset, because Harbor refuses task filters on top of a
-config file. Task names must be dataset-qualified (terminal-bench/<task>): a
-bare name matches nothing and silently runs all 89 tasks.
-
-Required in the environment: OPENAI_BASE_URL and OPENAI_API_KEY for the eval
-gateway. Export them yourself; this script never reads .env.
-
-The testbed listens on STELLA_TESTBED_PORT, a free port taken from the kernel
-unless you set it, so a dev or production server on this machine is untouched.
+The selected taskset owns concurrency; eval:loop always passes its explicit -n.
 EOF
 }
 
-die() {
-	echo "eval:loop: $*" >&2
-	exit 1
-}
-step() { echo "==> $*"; }
-
-PLAN=0
-AGAINST=""
 while [ $# -gt 0 ]; do
-	case $1 in
-	--plan) PLAN=1 ;;
-	--against)
-		[ $# -ge 2 ] || die "--against needs a reference job directory"
-		AGAINST=$2
-		shift
-		;;
-	--against=*) AGAINST=${1#*=} ;;
-	-h | --help)
-		usage
-		exit 0
-		;;
-	--)
-		shift
-		break
-		;;
-	*) break ;;
-	esac
-	shift
+  case $1 in
+    --tier) [ $# -ge 2 ] || die "--tier needs quick or full"; TIER=$2; shift ;;
+    --tier=*) TIER=${1#*=} ;;
+    --otel) OTEL=1 ;;
+    --no-otel) OTEL=0 ;;
+    --reuse-testbed) REUSE_TESTBED=1 ;;
+    --plan) PLAN=1 ;;
+    --against) [ $# -ge 2 ] || die "--against needs a reference job directory"; AGAINST=$2; shift ;;
+    --against=*) AGAINST=${1#*=} ;;
+    -h|--help) usage; exit 0 ;;
+    --) shift; break ;;
+    *) break ;;
+  esac
+  shift
 done
 HARBOR_ARGS=("$@")
+case $TIER in
+  quick) TASKSET=$HARBOR_DIR/tasksets/quick.yaml ;;
+  full) TASKSET=$HARBOR_DIR/tasksets/loop.yaml ;;
+  *) die "unknown tier $TIER (want quick or full)" ;;
+esac
+[ -f "$TASKSET" ] || die "missing taskset: $TASKSET"
+[ -n "$OTEL" ] || { [ "$TIER" = quick ] && OTEL=1 || OTEL=0; }
+[ "$REUSE_TESTBED" = 0 ] || [ "$OTEL" = 0 ] || die "--reuse-testbed cannot retrofit OTel into an already-started testbed; use --no-otel"
 
-# Harbor refuses --include-task-name on top of --config, so a targeted run
-# swaps the task set for the dataset it was drawn from rather than failing.
+# Harbor refuses a task filter on top of --config. Keep its prior caller-source
+# behavior, but always make the selected taskset's concurrency explicit.
 source_args=(-c "$TASKSET")
-source_kind="taskset $TASKSET"
-for arg in ${HARBOR_ARGS[@]+"${HARBOR_ARGS[@]}"}; do
-	case $arg in
-	-c | --config | -d | --dataset | --task | --path)
-		source_args=()
-		source_kind="caller-supplied"
-		break
-		;;
-	-i | --include-task-name | --exclude-task-name)
-		source_args=(-d "$DATASET")
-		source_kind="dataset $DATASET (task filter given)"
-		;;
-	esac
+source_kind="tier $TIER ($TASKSET)"
+using_taskset=1
+caller_config=""
+caller_concurrency=0
+arg_index=0
+arg_count=$#
+while [ "$arg_index" -lt "$arg_count" ]; do
+  arg=${HARBOR_ARGS[$arg_index]}
+  case $arg in
+    -c|--config)
+      arg_index=$((arg_index + 1)); [ "$arg_index" -lt "$arg_count" ] || die "$arg needs a config path"
+      caller_config=${HARBOR_ARGS[$arg_index]}; source_args=(); source_kind="caller-supplied"; using_taskset=0 ;;
+    --config=*) caller_config=${arg#*=}; source_args=(); source_kind="caller-supplied"; using_taskset=0 ;;
+    -c?*) caller_config=${arg#-c}; source_args=(); source_kind="caller-supplied"; using_taskset=0 ;;
+    -d|--dataset|--dataset=*|--task|--task=*|--path|--path=*|-d?*) source_args=(); source_kind="caller-supplied"; using_taskset=0 ;;
+    -i|--include-task-name|--exclude-task-name|-i=*|--include-task-name=*|--exclude-task-name=*|-i?*) source_args=(-d "$DATASET"); source_kind="tier $TIER dataset $DATASET (task filter given)"; using_taskset=0 ;;
+    -n|--n-concurrent|--n-concurrent=*|-n?*) caller_concurrency=1 ;;
+  esac
+  arg_index=$((arg_index + 1))
 done
 
-JOB=$REPO_ROOT/dist/evals/jobs/loop-$(date -u +%Y%m%dT%H%M%SZ)
+# Harbor does not preserve YAML concurrency in job config. Parse it from the
+# selected taskset, or from a local caller-supplied config when there is one.
+concurrency_taskset=$TASKSET
+[ -z "$caller_config" ] || [ ! -f "$caller_config" ] || concurrency_taskset=$caller_config
+TASKSET_CONCURRENCY=$(python3 - "$concurrency_taskset" <<'PY'
+import re, sys
+for line in open(sys.argv[1]):
+    m = re.fullmatch(r"n_concurrent_trials:\s*([1-9][0-9]*)\s*", line)
+    if m:
+        print(m.group(1))
+        break
+else:
+    raise SystemExit("taskset has no positive n_concurrent_trials")
+PY
+)
+
+STELLA_URL_WAS_SET=${STELLA_URL+x}
+STELLA_TESTBED_PORT=${STELLA_TESTBED_PORT:-$(free_port)}
+STELLA_URL=${STELLA_URL:-http://127.0.0.1:$STELLA_TESTBED_PORT}
+JOB_PREFIX=$TIER
+[ "$TIER" != full ] || JOB_PREFIX=loop # Preserve the established full baseline job layout.
+JOB=$REPO_ROOT/dist/evals/jobs/$JOB_PREFIX-$(date -u +%Y%m%dT%H%M%SZ)
 MANIFEST=$JOB.manifest.json
 AGENT_BIN=$REPO_ROOT/dist/bin-eval/stella-eval-agent
-harbor_cmd=(uv run --project "$HARBOR_DIR" harbor run
-	${source_args[@]+"${source_args[@]}"}
-	-a stella_harbor.agent:StellaAgent -m "$MODEL" -o "$JOB"
-	${HARBOR_ARGS[@]+"${HARBOR_ARGS[@]}"})
+harbor_cmd=(uv run --project "$HARBOR_DIR" harbor run ${source_args[@]+"${source_args[@]}"} -a stella_harbor.agent:StellaAgent -m "$MODEL" -o "$JOB" ${HARBOR_ARGS[@]+"${HARBOR_ARGS[@]}"})
+if [ "$caller_concurrency" = 0 ]; then
+  harbor_cmd=(uv run --project "$HARBOR_DIR" harbor run ${source_args[@]+"${source_args[@]}"} -n "$TASKSET_CONCURRENCY" -a stella_harbor.agent:StellaAgent -m "$MODEL" -o "$JOB" ${HARBOR_ARGS[@]+"${HARBOR_ARGS[@]}"})
+fi
 
 if [ "$PLAN" = 1 ]; then
-	# Status words only, computed here rather than substituted in the heredoc:
-	# `${VAR:-default}` expands to the *value* when the variable is set, which
-	# is how a plan meant to say "(set)" printed the key instead.
-	gateway_state="(MISSING)"
-	[ -z "${OPENAI_BASE_URL:-}" ] ||
-		gateway_state="(set, host $(python3 -c 'import os,urllib.parse; print(urllib.parse.urlsplit(os.environ["OPENAI_BASE_URL"]).hostname or "?")'))"
-	key_state="(MISSING)"
-	# Never any part of the key, not even a prefix or a length.
-	[ -z "${OPENAI_API_KEY:-}" ] || key_state="(set)"
-	cat <<EOF
+  gateway_state="(MISSING)"; [ -z "${OPENAI_BASE_URL:-}" ] || gateway_state="(set, host $(python3 -c 'import os,urllib.parse; print(urllib.parse.urlsplit(os.environ["OPENAI_BASE_URL"]).hostname or "?")'))"
+  key_state="(MISSING)"; [ -z "${OPENAI_API_KEY:-}" ] || key_state="(set)"
+  cat <<EOF
 plan only, nothing is executed.
 
-1. preflight   repo root $REPO_ROOT; docker, uv, curl, python3 present;
+1. preflight   tier $TIER; taskset $TASKSET$( [ "$caller_concurrency" = 0 ] && echo "; explicit concurrency -n $TASKSET_CONCURRENCY" || echo "; caller-supplied concurrency" )
                OPENAI_BASE_URL $gateway_state and OPENAI_API_KEY $key_state exported
-2. build       mise run build
-               go build -o $AGENT_BIN ./cmd/stella-eval-agent
-3. testbed     STELLA_SANDBOX_BACKEND=bridge, fresh STELLA_EVAL_BRIDGE_DIR,
-               STELLA_TESTBED_PORT=$STELLA_TESTBED_PORT (free port from the kernel; no fixed default to collide)
-               mise run testbed:start (background, log $TESTBED_LOG)
-               poll $STELLA_URL/api/status for sandbox_backend=bridge, ${READY_TIMEOUT}s
-4. provision   read the credentials-file path the testbed prints (never its body)
-               POST /api/auth/local/login    -> private cookie jar, deleted on exit
-               POST /api/providers           -> $PROVIDER_ID ($PROVIDER_TYPE), model $MODEL_ID enabled
-               POST /api/admin/provisioning-tokens (session cookie; a PAT gets 403)
-               export STELLA_URL STELLA_EVAL_MODEL=$MODEL STELLA_EVAL_ADMIN_TOKEN STELLA_EVAL_AGENT_BIN
-5. run         source: $source_kind
-               ${harbor_cmd[*]}
-6. after       python -m stella_harbor.report $JOB${AGAINST:+
-               python -m stella_harbor.compare $JOB $AGAINST}
-               manifest -> $MANIFEST
-   cleanup     mise run testbed:stop, cookie jar deleted, job kept on failure
+2. build       mise run eval:build, only when each binary is older than its sources
+3. otel        $( [ "$OTEL" = 1 ] && echo "docker run -d grafana/otel-lgtm; discover kernel-assigned OTLP HTTP and Grafana ports; atomically move dist/bin/stellad to a private real-binary path, then atomically install a temporary stellad wrapper at dist/bin/stellad. Before testbed start the wrapper exports the local OTLP settings, disables logs/metrics, raises OTEL_BSP_MAX_QUEUE_SIZE for the six-trial wave, and flushes once per second; cleanup atomically restores the real binary." || echo "disabled (full baseline default)" )
+4. testbed     $( [ "$REUSE_TESTBED" = 1 ] && echo "reuse STELLA_URL after bridge health check, OTel must be off; credentials path from STELLA_TESTBED_CREDENTIALS" || echo "fresh bridge testbed on $STELLA_URL" )
+5. provision   credentials-file path only; private cookie jar; provider and provisioning token
+6. run         source: $source_kind; Harbor command $( [ "$caller_concurrency" = 0 ] && echo "uses explicit -n $TASKSET_CONCURRENCY" || echo "preserves caller-supplied concurrency" )
+7. after       report$( [ "$OTEL" = 1 ] && echo ", Tempo span analysis and per-trial nonzero-span assertion" ); manifest -> $MANIFEST
+   cleanup     $( [ "$REUSE_TESTBED" = 1 ] && echo "reused testbed preserved" || echo "testbed stopped" ); OTel container preserved
 EOF
-	exit 0
+  exit 0
 fi
 
 step "preflight"
-[ "$(git -C "$REPO_ROOT" rev-parse --show-toplevel 2>/dev/null)" = "$REPO_ROOT" ] ||
-	die "not at the repository root: $REPO_ROOT"
-for tool in mise uv curl python3 go docker; do
-	command -v "$tool" >/dev/null || die "$tool is required and not on PATH"
-done
+[ "$(git -C "$REPO_ROOT" rev-parse --show-toplevel 2>/dev/null)" = "$REPO_ROOT" ] || die "not at repository root"
+for tool in mise uv curl python3 go docker; do command -v "$tool" >/dev/null || die "$tool is required"; done
 docker info >/dev/null 2>&1 || die "docker is not running"
-[ -n "${OPENAI_BASE_URL:-}" ] && [ -n "${OPENAI_API_KEY:-}" ] ||
-	die "export OPENAI_BASE_URL and OPENAI_API_KEY first (set -a; . ./.env; set +a)"
+[ -n "${OPENAI_BASE_URL:-}" ] && [ -n "${OPENAI_API_KEY:-}" ] || die "export OPENAI_BASE_URL and OPENAI_API_KEY first"
 [ -z "$AGAINST" ] || [ -d "$AGAINST" ] || die "--against: no such job directory: $AGAINST"
+[ "$REUSE_TESTBED" = 0 ] || [ -n "$STELLA_URL_WAS_SET" ] || die "--reuse-testbed requires STELLA_URL"
+[ "$REUSE_TESTBED" = 0 ] || [ -n "${STELLA_TESTBED_CREDENTIALS:-}" ] || die "--reuse-testbed requires STELLA_TESTBED_CREDENTIALS"
+[ "$REUSE_TESTBED" = 0 ] || [ -n "${STELLA_EVAL_BRIDGE_DIR:-}" ] || die "--reuse-testbed requires the original STELLA_EVAL_BRIDGE_DIR"
+if [ "$REUSE_TESTBED" = 1 ]; then
+  python3 - "$STELLA_URL" <<'PY' || die "--reuse-testbed requires a loopback http:// STELLA_URL without credentials, query, or fragment"
+import ipaddress, sys
+from urllib.parse import urlsplit
+url = urlsplit(sys.argv[1])
+try:
+    loopback = ipaddress.ip_address(url.hostname or "").is_loopback
+except ValueError:
+    loopback = (url.hostname == "localhost")
+ok = (url.scheme == "http" and loopback and url.port is not None and
+      url.username is None and url.password is None and
+      url.path in ("", "/") and not url.query and not url.fragment)
+raise SystemExit(0 if ok else 1)
+PY
+fi
 
 WORK=$(mktemp -d)
 COOKIE_JAR=$WORK/cookies.txt
-TESTBED_STARTED=0
+TESTBED_STARTED=0 OTEL_CONTAINER="" REAL_STELLAD=""
 cleanup() {
-	status=$?
-	set +e
-	rm -f "$COOKIE_JAR"
-	rm -rf "$WORK"
-	if [ "$TESTBED_STARTED" = 1 ]; then
-		step "stopping the testbed"
-		(cd "$REPO_ROOT" && mise run testbed:stop) >/dev/null 2>&1
-	fi
-	if [ "$status" -ne 0 ] && [ -d "$JOB" ]; then
-		echo "eval:loop: failed; the Harbor job is kept at $JOB" >&2
-	fi
+  status=$?
+  set +e
+  rm -f "$COOKIE_JAR"; rm -rf "$WORK"
+  if [ "$TESTBED_STARTED" = 1 ]; then
+    step "stopping the testbed"
+    (cd "$REPO_ROOT" && mise run testbed:stop) >/dev/null 2>&1
+  fi
+  restore_stellad_binary "$REPO_ROOT/dist/bin/stellad" "$REAL_STELLAD"
+  [ -z "$OTEL_CONTAINER" ] || echo "eval:loop: OTel is still running; stop it with: docker stop $OTEL_CONTAINER" >&2
+  [ "$status" -eq 0 ] || [ ! -d "$JOB" ] || echo "eval:loop: failed; Harbor job kept at $JOB" >&2
 }
 trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
-# curl wrapper. Secrets never reach argv: bodies arrive from a private file and
-# the bearer token from a curl config on stdin. Failures report the status code
-# and never the response body, which can quote what was sent.
 api() {
-	local method=$1 path=$2 auth=$3 body=${4:-} status
-	local args=(-sS -X "$method" -H 'Content-Type: application/json'
-		-o "$WORK/response.json" -w '%{http_code}')
-	[ -z "$body" ] || args+=(--data-binary "@$body")
-	[ "$auth" != cookie ] || args+=(-b "$COOKIE_JAR" -c "$COOKIE_JAR")
-	if [ "$auth" = bearer ]; then
-		status=$(printf 'header = "Authorization: Bearer %s"\n' "$ADMIN_PAT" |
-			curl "${args[@]}" -K - "$STELLA_URL$path")
-	else
-		status=$(curl "${args[@]}" "$STELLA_URL$path")
-	fi
-	case $status in
-	2*) cat "$WORK/response.json" ;;
-	*) die "$method $path failed with HTTP $status" ;;
-	esac
+  # Secrets never reach argv: bodies arrive from a private file and bearer
+  # tokens from a curl config on stdin. Failures never print response bodies.
+  local method=$1 path=$2 auth=$3 body=${4:-} status
+  local args=(-sS -X "$method" -H 'Content-Type: application/json' -o "$WORK/response.json" -w '%{http_code}')
+  [ -z "$body" ] || args+=(--data-binary "@$body")
+  [ "$auth" != cookie ] || args+=(-b "$COOKIE_JAR" -c "$COOKIE_JAR")
+  if [ "$auth" = bearer ]; then status=$(printf 'header = "Authorization: Bearer %s"\n' "$ADMIN_PAT" | curl "${args[@]}" -K - "$STELLA_URL$path"); else status=$(curl "${args[@]}" "$STELLA_URL$path"); fi
+  case $status in 2*) cat "$WORK/response.json" ;; *) die "$method $path failed with HTTP $status" ;; esac
 }
 
-step "building stellad and the eval driver"
-(cd "$REPO_ROOT" && mise run build)
-# Outside dist/bin on purpose: mise run build clears that directory, and the
-# driver must survive the rebuild the next loop iteration performs.
-(cd "$REPO_ROOT" && go build -o "$AGENT_BIN" ./cmd/stella-eval-agent)
+step "capturing build/start snapshot and preparing binaries"
+SNAPSHOT_COMMIT=$(git -C "$REPO_ROOT" rev-parse HEAD); export SNAPSHOT_COMMIT
+(cd "$REPO_ROOT" && mise run eval:build)
 
-step "starting a disposable testbed on the bridge backend"
+if [ "$OTEL" = 1 ]; then
+  step "starting OTel LGTM on kernel-assigned ports"
+  OTEL_CONTAINER=$(docker run -d -p 127.0.0.1::4318 -p 127.0.0.1::3000 grafana/otel-lgtm)
+  OTEL_OTLP_PORT=$(docker port "$OTEL_CONTAINER" 4318/tcp | sed -n 's/.*:\([0-9][0-9]*\)$/\1/p' | head -1)
+  OTEL_GRAFANA_PORT=$(docker port "$OTEL_CONTAINER" 3000/tcp | sed -n 's/.*:\([0-9][0-9]*\)$/\1/p' | head -1)
+  [ -n "$OTEL_OTLP_PORT" ] && [ -n "$OTEL_GRAFANA_PORT" ] || die "could not determine OTel host ports"
+  deadline=$((SECONDS + READY_TIMEOUT))
+  until curl -fsS "http://127.0.0.1:$OTEL_GRAFANA_PORT/api/datasources/proxy/uid/tempo/ready" >/dev/null 2>&1; do
+    [ "$SECONDS" -lt "$deadline" ] || die "Tempo did not become ready within ${READY_TIMEOUT}s"
+    sleep 1
+  done
+  echo "    Grafana/Tempo: http://127.0.0.1:$OTEL_GRAFANA_PORT"
+  # testbed filters OTEL_* from child env. After ports are known, stage the
+  # wrapper before starting it so the server gets only this local allowlist.
+  REAL_STELLAD=$REPO_ROOT/dist/bin/.stellad-eval-real-$$-$RANDOM
+  stage_otel_stellad_wrapper "$REPO_ROOT/dist/bin/stellad" "$REAL_STELLAD" "http://127.0.0.1:$OTEL_OTLP_PORT"
+fi
+
+export PROVIDER_ID PROVIDER_TYPE MODEL_ID MODEL STELLA_URL STELLA_TESTBED_PORT
 export STELLA_SANDBOX_BACKEND=bridge
-STELLA_EVAL_BRIDGE_DIR=${STELLA_EVAL_BRIDGE_DIR:-$(mktemp -d)}
-export STELLA_EVAL_BRIDGE_DIR
 # Both variables must be exported before testbed:start; the server reads them
 # once, and exporting them afterwards silently leaves the backend on local.
+STELLA_EVAL_BRIDGE_DIR=${STELLA_EVAL_BRIDGE_DIR:-$(mktemp -d)}; export STELLA_EVAL_BRIDGE_DIR
 mkdir -p "$(dirname "$TESTBED_LOG")"
-(cd "$REPO_ROOT" && mise run testbed:start) >"$TESTBED_LOG" 2>&1 &
-TESTBED_PID=$!
-TESTBED_STARTED=1
-
+if [ "$REUSE_TESTBED" = 1 ]; then
+  step "checking the reused bridge testbed"
+  CREDS=$STELLA_TESTBED_CREDENTIALS; [ -f "$CREDS" ] || die "STELLA_TESTBED_CREDENTIALS is not a file"
+else
+  step "starting a disposable testbed on the bridge backend"
+  # `postgres download` is idempotent: the existing stellad checks for its
+  # runtime and downloads only when absent. It does not invoke mise build or
+  # generate, so a fresh dist/bin/stellad stays genuinely reusable.
+  (cd "$REPO_ROOT" && ./dist/bin/stellad postgres download && exec ./dist/bin/testbed start) >"$TESTBED_LOG" 2>&1 &
+  TESTBED_PID=$!; TESTBED_STARTED=1
+fi
 deadline=$((SECONDS + READY_TIMEOUT))
-until curl -fsS "$STELLA_URL/api/status" 2>/dev/null |
-	python3 -c 'import json,sys; sys.exit(0 if json.load(sys.stdin).get("sandbox_backend")=="bridge" else 1)' 2>/dev/null; do
-	kill -0 "$TESTBED_PID" 2>/dev/null || die "the testbed exited early; see $TESTBED_LOG"
-	[ "$SECONDS" -lt "$deadline" ] || die "the testbed did not report sandbox_backend=bridge within ${READY_TIMEOUT}s; see $TESTBED_LOG"
-	sleep 2
+until curl -fsS "$STELLA_URL/api/status" -o "$WORK/status.json" 2>/dev/null &&
+  python3 - "$WORK/status.json" "$SNAPSHOT_COMMIT" <<'PY' 2>/dev/null
+import json, sys
+status = json.load(open(sys.argv[1]))
+commit = status.get("commit") or ""
+ok = status.get("sandbox_backend") == "bridge" and commit and sys.argv[2].startswith(commit)
+raise SystemExit(0 if ok else 1)
+PY
+do
+  if [ "$REUSE_TESTBED" = 0 ]; then kill -0 "$TESTBED_PID" 2>/dev/null || die "testbed exited early; see $TESTBED_LOG"; fi
+  [ "$SECONDS" -lt "$deadline" ] || die "testbed did not report bridge mode at build commit $SNAPSHOT_COMMIT within ${READY_TIMEOUT}s"
+  sleep 2
 done
 
 step "provisioning the provider, model, and a provisioning token"
-# mise prefixes every line with the task name, so the anchor is anywhere on
-# the line, not at its start.
-CREDS=$(sed -n 's/^.*Credentials: //p' "$TESTBED_LOG" | head -1)
-[ -n "$CREDS" ] && [ -f "$CREDS" ] || die "the testbed printed no credentials-file path; see $TESTBED_LOG"
+if [ "$REUSE_TESTBED" = 0 ]; then
+	# mise prefixes every line with the task name, so the anchor is anywhere on
+	# the line, not at its start.
+	# The status endpoint can answer before the credentials line reaches the log,
+	# so poll for it rather than reading once and giving up on a lost race.
+	creds_deadline=$((SECONDS + 60))
+	while :; do
+		CREDS=$(sed -n 's/^.*Credentials: //p' "$TESTBED_LOG" | head -1)
+		[ -n "$CREDS" ] && [ -f "$CREDS" ] && break
+		[ "$SECONDS" -lt "$creds_deadline" ] || die "the testbed printed no credentials-file path within 60s; see $TESTBED_LOG"
+		sleep 1
+	done
+fi
 # Only the path is read from stdout and only fields are read from the file;
 # neither is ever echoed.
 ADMIN_PAT=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["admin"]["token"])' "$CREDS")
-
 python3 - "$WORK/login.json" "$CREDS" <<'PY'
 import json, sys
 admin = json.load(open(sys.argv[2]))["admin"]
 json.dump({"email": admin["email"], "password": admin["password"]}, open(sys.argv[1], "w"))
 PY
 api POST /api/auth/local/login cookie "$WORK/login.json" >/dev/null
-
 python3 - "$WORK/provider.json" <<'PY'
 import json, os, sys
 # Per-million-token prices, the same numbers the pi baseline is scored with, so
 # the two cost columns mean the same thing.
-cost = {
-    "input": float(os.environ.get("EVAL_COST_INPUT", "0.20")),
-    "output": float(os.environ.get("EVAL_COST_OUTPUT", "1.20")),
-    "cacheRead": float(os.environ.get("EVAL_COST_CACHE_READ", "0.02")),
-    "cacheWrite": float(os.environ.get("EVAL_COST_CACHE_WRITE", "0.25")),
-}
-json.dump({
-    "id": os.environ["PROVIDER_ID"],
-    "type": os.environ["PROVIDER_TYPE"],
-    "name": "Eval gateway",
-    "enabled": True,
-    "api_key": os.environ["OPENAI_API_KEY"],
-    "base_url": os.environ["OPENAI_BASE_URL"],
-    "models": {os.environ["MODEL_ID"]: {"enabled": True, "cost": cost}},
-}, open(sys.argv[1], "w"))
+cost = {"input": float(os.environ.get("EVAL_COST_INPUT", "0.20")), "output": float(os.environ.get("EVAL_COST_OUTPUT", "1.20")), "cacheRead": float(os.environ.get("EVAL_COST_CACHE_READ", "0.02")), "cacheWrite": float(os.environ.get("EVAL_COST_CACHE_WRITE", "0.25"))}
+json.dump({"id": os.environ["PROVIDER_ID"], "type": os.environ["PROVIDER_TYPE"], "name": "Eval gateway", "enabled": True, "api_key": os.environ["OPENAI_API_KEY"], "base_url": os.environ["OPENAI_BASE_URL"], "models": {os.environ["MODEL_ID"]: {"enabled": True, "cost": cost}}}, open(sys.argv[1], "w"))
 PY
 api POST /api/providers bearer "$WORK/provider.json" >/dev/null
-
 python3 - "$WORK/provisioning.json" <<'PY'
 import datetime, json, sys
 expires = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=6)
-json.dump({"name": "eval-loop", "expires_at": expires.strftime("%Y-%m-%dT%H:%M:%SZ")},
-          open(sys.argv[1], "w"))
+json.dump({"name": "eval-loop", "expires_at": expires.strftime("%Y-%m-%dT%H:%M:%SZ")}, open(sys.argv[1], "w"))
 PY
 # A PAT gets 403 here; this one needs the interactive session cookie.
 api POST /api/admin/provisioning-tokens cookie "$WORK/provisioning.json" >"$WORK/token.json"
 STELLA_EVAL_ADMIN_TOKEN=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["token"])' "$WORK/token.json")
-export STELLA_EVAL_ADMIN_TOKEN
-export STELLA_EVAL_MODEL=$MODEL
-export STELLA_EVAL_AGENT_BIN=$AGENT_BIN
+export STELLA_EVAL_ADMIN_TOKEN STELLA_EVAL_MODEL=$MODEL STELLA_EVAL_AGENT_BIN=$AGENT_BIN
 
-step "running Harbor: $source_kind"
-echo "    job: $JOB"
+step "running Harbor: $source_kind"; echo "    job: $JOB"
 # The first run of a task pays the image pull; Harbor has no separate prefetch.
 "${harbor_cmd[@]}" --print-config >"$WORK/config.json"
 "${harbor_cmd[@]}"
-
 step "report"
 uv run --project "$HARBOR_DIR" python -m stella_harbor.report "$JOB"
-if [ -n "$AGAINST" ]; then
-	step "comparing against $AGAINST (this run is the candidate)"
-	uv run --project "$HARBOR_DIR" python -m stella_harbor.compare "$JOB" "$AGAINST" || true
-fi
+if [ -n "$AGAINST" ]; then step "comparing against $AGAINST (candidate)"; uv run --project "$HARBOR_DIR" python -m stella_harbor.compare "$JOB" "$AGAINST" || true; fi
 
-: >"$WORK/args.txt"
-[ ${#HARBOR_ARGS[@]} -eq 0 ] || printf '%s\n' "${HARBOR_ARGS[@]}" >"$WORK/args.txt"
-TASKSET_PATH=$([ "$source_kind" = "taskset $TASKSET" ] && echo "${TASKSET#"$REPO_ROOT"/}" || echo "")
-export TASKSET_PATH JOB
+: >"$WORK/args.txt"; [ -z "${HARBOR_ARGS[*]-}" ] || printf '%s\n' "${HARBOR_ARGS[@]}" >"$WORK/args.txt"
+TASKSET_PATH=$([ "$using_taskset" = 1 ] && echo "${TASKSET#"$REPO_ROOT"/}" || echo ""); export TASKSET_PATH JOB OTEL
 python3 - "$MANIFEST" "$WORK/config.json" "$WORK/args.txt" <<'PY'
 import datetime, hashlib, json, os, subprocess, sys
 from urllib.parse import urlsplit
-
 config = json.load(open(sys.argv[2]))
 tasks = sorted({t for d in config.get("datasets", []) for t in (d.get("task_names") or [])})
 git = lambda *a: subprocess.run(["git", *a], capture_output=True, text=True).stdout.strip()
-json.dump({
-    "created_at": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-    "job": os.path.basename(os.environ["JOB"]),
-    "commit": git("rev-parse", "HEAD"),
-    "dirty": bool(git("status", "--porcelain")),
-    "taskset": os.environ["TASKSET_PATH"] or None,
-    "task_names": tasks,
-    # Canonical over the sorted, newline-joined, dataset-qualified names, so a
-    # taskset file and an identical explicit list hash the same.
-    "task_hash": "sha256:" + hashlib.sha256("\n".join(tasks).encode()).hexdigest(),
-    "k": config.get("n_attempts", 1),
-    "concurrency": config.get("n_concurrent_trials", 4),
-    "model": os.environ["MODEL"],
-    # Host only: the path can carry a deployment id and the key never leaves.
-    "gateway_host": urlsplit(os.environ["OPENAI_BASE_URL"]).hostname,
-    "harbor_args": open(sys.argv[3]).read().split(),
-}, open(sys.argv[1], "w"), indent=2)
+# Values are already represented by normalized config fields above. Persist only
+# option names, never arbitrary values that may be credentials or private paths.
+harbor_flags = [arg.split("=", 1)[0] for arg in open(sys.argv[3]).read().split() if arg.startswith("-")]
+json.dump({"created_at": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"), "job": os.path.basename(os.environ["JOB"]), "commit": os.environ["SNAPSHOT_COMMIT"], "dirty": bool(git("status", "--porcelain")), "taskset": os.environ["TASKSET_PATH"] or None, "task_names": tasks, # Canonical over sorted dataset-qualified names.
+"task_hash": "sha256:" + hashlib.sha256("\n".join(tasks).encode()).hexdigest(), "k": config.get("n_attempts", 1), "concurrency": config.get("n_concurrent_trials"), "model": os.environ["MODEL"], # Host only: the path can carry a deployment id.
+"gateway_host": urlsplit(os.environ["OPENAI_BASE_URL"]).hostname, "harbor_args": harbor_flags, "otel": os.environ["OTEL"] == "1"}, open(sys.argv[1], "w"), indent=2)
 PY
 step "manifest: $MANIFEST"
+if [ "$OTEL" = 1 ]; then
+  step "analyzing OTel spans (Grafana Tempo proxy)"
+  uv run --project "$HARBOR_DIR" python -m stella_harbor.otel "$JOB" --grafana-url "http://127.0.0.1:$OTEL_GRAFANA_PORT"
+fi

--- a/test/evals/harbor/loop.sh
+++ b/test/evals/harbor/loop.sh
@@ -14,6 +14,8 @@ REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
 HARBOR_DIR=$REPO_ROOT/test/evals/harbor
 # shellcheck source=stellad_wrapper.sh
 source "$HARBOR_DIR/stellad_wrapper.sh"
+# shellcheck source=run_state.sh
+source "$HARBOR_DIR/run_state.sh"
 DATASET=terminal-bench/terminal-bench-2-1
 PROVIDER_ID=${STELLA_EVAL_PROVIDER_ID:-gateway}
 PROVIDER_TYPE=${STELLA_EVAL_PROVIDER_TYPE:-openai-response}
@@ -175,10 +177,11 @@ PY
 fi
 
 mkdir -p "$REPO_ROOT/dist/evals/runs"
-# Crash residue is deliberately discoverable under dist/evals/runs. Remove only
-# old inactive leftovers; a normal cleanup removes its own directory below.
-find "$REPO_ROOT/dist/evals/runs" -mindepth 1 -maxdepth 1 -type d -mtime +1 -exec rm -rf {} +
+# Crash residue is deliberately discoverable under dist/evals/runs. Only dead
+# owners older than one day are pruned; live owners are never removed.
+prune_stale_run_states "$REPO_ROOT/dist/evals/runs" 86400
 mkdir -p "$RUN_STATE"
+printf '%s\n' "$$" >"$RUN_STATE/owner.pid"
 WORK=$(mktemp -d)
 COOKIE_JAR=$WORK/cookies.txt
 TESTBED_STARTED=0 OTEL_CONTAINER=""

--- a/test/evals/harbor/run_state.sh
+++ b/test/evals/harbor/run_state.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Lifecycle helpers for discoverable per-run eval state.
+
+prune_stale_run_states() {
+  local root=$1 max_age=${2:-86400} dir owner_file owner
+  [ -d "$root" ] || return 0
+  for dir in "$root"/*; do
+    [ -d "$dir" ] || continue
+    owner_file=$dir/owner.pid
+    # Missing/partial ownership metadata may be a creator between mkdir and
+    # writing its PID. Preserve it rather than racing that creator.
+    [ -f "$owner_file" ] || continue
+    owner=$(cat "$owner_file" 2>/dev/null || true)
+    case $owner in *[!0-9]*|'') continue ;; esac
+    # Process liveness is the safety gate. Age only decides when dead residue
+    # becomes eligible; a live run is never removed, however old it is.
+    kill -0 "$owner" 2>/dev/null && continue
+    python3 - "$owner_file" "$max_age" <<'PY' || continue
+import os, sys, time
+age = time.time() - os.stat(sys.argv[1]).st_mtime
+raise SystemExit(0 if age > int(sys.argv[2]) else 1)
+PY
+    rm -rf -- "$dir"
+  done
+}

--- a/test/evals/harbor/run_state.sh
+++ b/test/evals/harbor/run_state.sh
@@ -1,6 +1,37 @@
 #!/usr/bin/env bash
 # Lifecycle helpers for discoverable per-run eval state.
 
+claim_run_state() {
+  local base_job=$1 runs_root=$2 max_attempts=${3:-100} owner=${4:-$$}
+  local attempt suffix candidate_job candidate_state
+  for ((attempt = 0; attempt < max_attempts; attempt++)); do
+    suffix=""
+    [ "$attempt" -eq 0 ] || suffix="-$owner-$attempt"
+    candidate_job=$base_job$suffix
+    candidate_state=$runs_root/$(basename "$candidate_job")
+    # Completed jobs reserve their output name even after normal run-state
+    # cleanup. The active owner is claimed only by atomic mkdir without -p.
+    [ ! -e "$candidate_job" ] && [ ! -e "$candidate_job.manifest.json" ] || continue
+    if mkdir "$candidate_state" 2>/dev/null; then
+      # Recheck after the claim. Every current loop must own this state before
+      # creating the job, so the claim serializes same-name creators.
+      if [ -e "$candidate_job" ] || [ -e "$candidate_job.manifest.json" ]; then
+        rmdir "$candidate_state" 2>/dev/null || true
+        continue
+      fi
+      if ! printf '%s\n' "$owner" >"$candidate_state/owner.pid"; then
+        rmdir "$candidate_state" 2>/dev/null || true
+        return 1
+      fi
+      CLAIMED_JOB=$candidate_job
+      CLAIMED_RUN_STATE=$candidate_state
+      return 0
+    fi
+  done
+  echo "eval:loop: could not claim a unique run state after $max_attempts attempts for $base_job" >&2
+  return 1
+}
+
 prune_stale_run_states() {
   local root=$1 max_age=${2:-86400} dir owner_file owner
   [ -d "$root" ] || return 0

--- a/test/evals/harbor/stella_harbor/otel.py
+++ b/test/evals/harbor/stella_harbor/otel.py
@@ -15,8 +15,12 @@ from urllib.request import urlopen
 
 
 def _value(value: dict[str, Any]) -> Any:
-    """Unwrap one OTLP JSON AnyValue without assuming its concrete scalar type."""
-    for key in ("stringValue", "intValue", "doubleValue", "boolValue"):
+    """Unwrap one OTLP JSON AnyValue, including Tempo's string-encoded ints."""
+    if "intValue" in value:
+        return int(value["intValue"])
+    if "doubleValue" in value:
+        return float(value["doubleValue"])
+    for key in ("stringValue", "boolValue"):
         if key in value:
             return value[key]
     return None
@@ -124,28 +128,30 @@ def _group_name(span: dict[str, Any]) -> str:
     return name
 
 
-def summarize(sessions: dict[str, str], spans: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], int, Counter[str]]:
+def summarize(
+    sessions: dict[str, str], spans: list[dict[str, Any]]
+) -> tuple[list[dict[str, Any]], dict[str, int], Counter[str]]:
     per_trial: Counter[str] = Counter()
     grouped: dict[str, list[float]] = defaultdict(list)
-    retries = 0
+    model = {"request_spans": 0, "attempts": 0, "retries": 0}
     for span in spans:
         attrs = span["attributes"]
         session = span.get("trial_session_id") or attrs.get("gen_ai.conversation.id")
         if session in sessions:
             per_trial[str(session)] += 1
         grouped[_group_name(span)].append(float(span["duration_ms"]))
-        # Stella has no retry attribute today. Keeping the recognized names
-        # here makes retries visible when a provider adds one, without guessing
-        # from repeated model calls (which are normal agent turns).
-        for key in ("stella.retry_count", "gen_ai.retry_count", "retry_count", "retries"):
-            value = attrs.get(key)
-            if isinstance(value, (int, float)):
-                retries += int(value)
-                break
+        if span["name"] == "gen_ai.chat.request":
+            model["request_spans"] += 1
+        attempts = attrs.get("gen_ai.request.attempts")
+        retries = attrs.get("gen_ai.request.retry_count")
+        if isinstance(attempts, (int, float)):
+            model["attempts"] += int(attempts)
+        if isinstance(retries, (int, float)):
+            model["retries"] += int(retries)
     stats = [{"name": name, "count": len(values), "total_ms": sum(values),
               "mean_ms": sum(values) / len(values), "p95_ms": _p95(values), "max_ms": max(values)}
              for name, values in grouped.items()]
-    return sorted(stats, key=lambda row: (-row["total_ms"], row["name"])), retries, per_trial
+    return sorted(stats, key=lambda row: (-row["total_ms"], row["name"])), model, per_trial
 
 
 def harbor_retries(job: Path) -> int | None:
@@ -160,7 +166,7 @@ def harbor_retries(job: Path) -> int | None:
 
 
 def render(job: Path, sessions: dict[str, str], spans: list[dict[str, Any]]) -> str:
-    stats, retries, per_trial = summarize(sessions, spans)
+    stats, model, per_trial = summarize(sessions, spans)
     matched = [(session, sessions[session], per_trial[session]) for session in sessions if per_trial[session]]
     if not matched:
         raise RuntimeError("Tempo returned zero spans for every trial session in this job")
@@ -177,9 +183,14 @@ def render(job: Path, sessions: dict[str, str], spans: list[dict[str, Any]]) -> 
     absent = len(sessions) - len(matched)
     if absent:
         lines.append(f"trial sessions with no retained Tempo trace: {absent}")
+    attempts = model["attempts"] or model["request_spans"]
+    lines.append(
+        f"model requests: spans={model['request_spans']}, attempts={attempts}, "
+        f"retries={model['retries']}"
+    )
     harbor = harbor_retries(job)
     harbor_text = "unknown" if harbor is None else str(harbor)
-    lines.append(f"retries: harbor={harbor_text}, span_attributes={retries}")
+    lines.append(f"Harbor trial retries: {harbor_text}")
     return "\n".join(lines)
 
 

--- a/test/evals/harbor/stella_harbor/otel.py
+++ b/test/evals/harbor/stella_harbor/otel.py
@@ -1,0 +1,197 @@
+"""Fetch and summarize the spans belonging to a Harbor job from Tempo."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import time
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlencode
+from urllib.request import urlopen
+
+
+def _value(value: dict[str, Any]) -> Any:
+    """Unwrap one OTLP JSON AnyValue without assuming its concrete scalar type."""
+    for key in ("stringValue", "intValue", "doubleValue", "boolValue"):
+        if key in value:
+            return value[key]
+    return None
+
+
+def _attrs(items: list[dict[str, Any]]) -> dict[str, Any]:
+    return {item.get("key", ""): _value(item.get("value", {})) for item in items}
+
+
+def _span_rows(trace: dict[str, Any]) -> list[dict[str, Any]]:
+    """Normalize Tempo's OTLP JSON trace response to the fields this report needs."""
+    rows: list[dict[str, Any]] = []
+    for resource_span in trace.get("resourceSpans", trace.get("batches", [])):
+        scopes = resource_span.get("scopeSpans", resource_span.get("instrumentationLibrarySpans", []))
+        for scope in scopes:
+            for span in scope.get("spans", []):
+                attrs = _attrs(span.get("attributes", []))
+                start = int(span.get("startTimeUnixNano", 0))
+                end = int(span.get("endTimeUnixNano", 0))
+                if end < start:
+                    continue
+                rows.append({"name": span.get("name", "unknown"), "duration_ms": (end - start) / 1_000_000,
+                             "attributes": attrs})
+    return rows
+
+
+def trial_sessions(job: Path) -> dict[str, str]:
+    """Return session id -> trial label from the adapter evidence saved per trial."""
+    sessions: dict[str, str] = {}
+    for result in job.glob("*/**/agent/stella/result.json"):
+        try:
+            session = json.loads(result.read_text()).get("session_id")
+        except (OSError, json.JSONDecodeError):
+            continue
+        if session:
+            sessions[str(session)] = result.parents[2].name
+    return sessions
+
+
+def _get_json(url: str) -> dict[str, Any]:
+    with urlopen(url, timeout=20) as response:  # nosec B310: localhost Tempo chosen by this script
+        return json.load(response)
+
+
+def _trace_ids(grafana_url: str, session: str, start: int, end: int) -> list[str]:
+    # Tempo's search API accepts TraceQL in q. The conversation id is set on
+    # agent.loop and gen_ai.chat by Stella's trace hook; fetching whole traces
+    # afterward includes child spans which legitimately do not repeat it.
+    query = '{ span.gen_ai.conversation.id = "' + session.replace('"', '\\"') + '" }'
+    params = urlencode({"q": query, "start": start, "end": end, "limit": 100})
+    data = _get_json(f"{grafana_url}/api/datasources/proxy/uid/tempo/api/search?{params}")
+    return [str(item["traceID"]) for item in data.get("traces", []) if item.get("traceID")]
+
+
+def _trace_window(job: Path) -> tuple[int, int]:
+    mtimes = [path.stat().st_mtime for path in job.rglob("*") if path.is_file()]
+    if not mtimes:
+        now = int(time.time())
+        return now - 3600, now + 300
+    return int(min(mtimes)) - 300, int(max(mtimes)) + 300
+
+
+def fetch(job: Path, grafana_url: str) -> tuple[dict[str, str], list[dict[str, Any]]]:
+    sessions = trial_sessions(job)
+    rows: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    pending = set(sessions)
+    start, end = _trace_window(job)
+    deadline = time.monotonic() + 15
+    while pending:
+        for session in list(pending):
+            trace_ids = _trace_ids(grafana_url, session, start, end)
+            if not trace_ids:
+                continue
+            pending.remove(session)
+            for trace_id in trace_ids:
+                key = (session, trace_id)
+                if key in seen:
+                    continue
+                seen.add(key)
+                trace_rows = _span_rows(_get_json(
+                    f"{grafana_url}/api/datasources/proxy/uid/tempo/api/traces/{trace_id}"
+                ))
+                for row in trace_rows:
+                    row["trial_session_id"] = session
+                rows.extend(trace_rows)
+        if not pending or time.monotonic() >= deadline:
+            break
+        time.sleep(1)
+    return sessions, rows
+
+
+def _p95(values: list[float]) -> float:
+    if not values:
+        return 0
+    return sorted(values)[min(len(values) - 1, math.ceil(len(values) * 0.95) - 1)]
+
+
+def _group_name(span: dict[str, Any]) -> str:
+    name = str(span["name"])
+    if span["attributes"].get("db.system"):
+        return "db.query"
+    if re.fullmatch(r"turn [0-9]+", name):
+        return "turn"
+    return name
+
+
+def summarize(sessions: dict[str, str], spans: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], int, Counter[str]]:
+    per_trial: Counter[str] = Counter()
+    grouped: dict[str, list[float]] = defaultdict(list)
+    retries = 0
+    for span in spans:
+        attrs = span["attributes"]
+        session = span.get("trial_session_id") or attrs.get("gen_ai.conversation.id")
+        if session in sessions:
+            per_trial[str(session)] += 1
+        grouped[_group_name(span)].append(float(span["duration_ms"]))
+        # Stella has no retry attribute today. Keeping the recognized names
+        # here makes retries visible when a provider adds one, without guessing
+        # from repeated model calls (which are normal agent turns).
+        for key in ("stella.retry_count", "gen_ai.retry_count", "retry_count", "retries"):
+            value = attrs.get(key)
+            if isinstance(value, (int, float)):
+                retries += int(value)
+                break
+    stats = [{"name": name, "count": len(values), "total_ms": sum(values),
+              "mean_ms": sum(values) / len(values), "p95_ms": _p95(values), "max_ms": max(values)}
+             for name, values in grouped.items()]
+    return sorted(stats, key=lambda row: (-row["total_ms"], row["name"])), retries, per_trial
+
+
+def harbor_retries(job: Path) -> int | None:
+    for result in sorted(job.glob("*/result.json")):
+        try:
+            value = (json.loads(result.read_text()).get("stats") or {}).get("n_retries")
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(value, int):
+            return value
+    return None
+
+
+def render(job: Path, sessions: dict[str, str], spans: list[dict[str, Any]]) -> str:
+    stats, retries, per_trial = summarize(sessions, spans)
+    matched = [(session, sessions[session], per_trial[session]) for session in sessions if per_trial[session]]
+    if not matched:
+        raise RuntimeError("Tempo returned zero spans for every trial session in this job")
+    lines = [f"OTel span analysis: {len(spans)} spans from {len(matched)}/{len(sessions)} trial session(s)",
+             "span name                         count    total     mean      p95  slowest"]
+    for stat in stats:
+        lines.append(f"{stat['name'][:32]:32} {stat['count']:5} {stat['total_ms']:7.0f}ms"
+                     f" {stat['mean_ms']:7.0f}ms {stat['p95_ms']:7.0f}ms {stat['max_ms']:7.0f}ms")
+    assertion_session, assertion_trial, assertion_count = matched[0]
+    lines.append(
+        f"trial span assertion: PASS session={assertion_session} "
+        f"trial={assertion_trial} spans={assertion_count}"
+    )
+    absent = len(sessions) - len(matched)
+    if absent:
+        lines.append(f"trial sessions with no retained Tempo trace: {absent}")
+    harbor = harbor_retries(job)
+    harbor_text = "unknown" if harbor is None else str(harbor)
+    lines.append(f"retries: harbor={harbor_text}, span_attributes={retries}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("job", type=Path)
+    parser.add_argument("--grafana-url", required=True)
+    args = parser.parse_args(argv)
+    sessions, spans = fetch(args.job, args.grafana_url.rstrip("/"))
+    print(render(args.job, sessions, spans))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/evals/harbor/stellad_wrapper.sh
+++ b/test/evals/harbor/stellad_wrapper.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
-# Eval-only staging for testbed's intentionally sterile child environment.
+# Eval-only OTel wrapper for a per-run private stellad copy.
 
-# stage_otel_stellad_wrapper replaces $1 only after the real binary has moved
-# to $2. Both paths live in dist/bin, so each rename is atomic. The caller
-# records $2 before calling this function; restore is then safe even if an
-# interrupt lands between the two renames.
 stage_otel_stellad_wrapper() {
   local stellad_path=$1 real_path=$2 otlp_endpoint=$3 wrapper_path
   local stellad_dir quoted_real quoted_endpoint
@@ -28,8 +24,8 @@ stage_otel_stellad_wrapper() {
     printf 'export OTEL_EXPORTER_OTLP_ENDPOINT=%s\n' "$quoted_endpoint"
     printf 'export OTEL_EXPORTER_OTLP_PROTOCOL=%s\n' http/protobuf
     printf 'export OTEL_EXPORTER_OTLP_INSECURE=%s\n' true
-    # Six concurrent trials plus pgx spans overflow the SDK's 2048-span default.
-    # Flush every second and retain the complete wave without recording tool IO.
+    # Six concurrent trials plus pgx spans can overflow the SDK's 2048-span
+    # default. Flush every second and retain the wave without recording tool IO.
     printf 'export OTEL_BSP_MAX_QUEUE_SIZE=%s\n' 16384
     printf 'export OTEL_BSP_MAX_EXPORT_BATCH_SIZE=%s\n' 2048
     printf 'export OTEL_BSP_SCHEDULE_DELAY=%s\n' 1000
@@ -47,32 +43,4 @@ stage_otel_stellad_wrapper() {
     mv "$real_path" "$stellad_path" || true
     return 1
   fi
-}
-
-# restore_stellad_binary replaces the wrapper in one rename. A failed or
-# interrupted stage leaves no private binary, making this a safe no-op.
-restore_stellad_binary() {
-  local stellad_path=$1 real_path=$2
-  [ -n "$real_path" ] && [ -e "$real_path" ] || return 0
-  mv -f "$real_path" "$stellad_path"
-}
-
-# Recover after SIGKILL, host crash, or power loss, where EXIT traps cannot run.
-# Refuse ambiguity rather than choosing among multiple private binaries.
-recover_stale_stellad_binary() {
-  local stellad_path=$1 candidate
-  local -a candidates=()
-  [ -f "$stellad_path" ] || return 0
-  grep -q '^# stella-eval-otel-wrapper$' "$stellad_path" || return 0
-  while IFS= read -r candidate; do candidates+=("$candidate"); done < <(
-    find "$(dirname "$stellad_path")" -maxdepth 1 -type f -name '.stellad-eval-real-*' -print
-  )
-  case ${#candidates[@]} in
-    0) rm -f "$stellad_path" ;;
-    1) mv -f "${candidates[0]}" "$stellad_path" ;;
-    *)
-      echo "eval:build: multiple stale eval stellad binaries; refusing recovery" >&2
-      return 1
-      ;;
-  esac
 }

--- a/test/evals/harbor/stellad_wrapper.sh
+++ b/test/evals/harbor/stellad_wrapper.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Eval-only staging for testbed's intentionally sterile child environment.
+
+# stage_otel_stellad_wrapper replaces $1 only after the real binary has moved
+# to $2. Both paths live in dist/bin, so each rename is atomic. The caller
+# records $2 before calling this function; restore is then safe even if an
+# interrupt lands between the two renames.
+stage_otel_stellad_wrapper() {
+  local stellad_path=$1 real_path=$2 otlp_endpoint=$3 wrapper_path
+  local stellad_dir quoted_real quoted_endpoint
+  stellad_dir=$(dirname "$stellad_path")
+
+  [ -x "$stellad_path" ] || {
+    echo "eval:loop: missing executable $stellad_path" >&2
+    return 1
+  }
+  [ ! -e "$real_path" ] || {
+    echo "eval:loop: private stellad path already exists: $real_path" >&2
+    return 1
+  }
+
+  printf -v quoted_real '%q' "$real_path"
+  printf -v quoted_endpoint '%q' "$otlp_endpoint"
+  wrapper_path=$(mktemp "$stellad_dir/.stellad-eval-wrapper.XXXXXX") || return 1
+  {
+    printf '%s\n' '#!/usr/bin/env bash' '# stella-eval-otel-wrapper'
+    printf 'export OTEL_SERVICE_NAME=%s\n' stella-eval
+    printf 'export OTEL_EXPORTER_OTLP_ENDPOINT=%s\n' "$quoted_endpoint"
+    printf 'export OTEL_EXPORTER_OTLP_PROTOCOL=%s\n' http/protobuf
+    printf 'export OTEL_EXPORTER_OTLP_INSECURE=%s\n' true
+    # Six concurrent trials plus pgx spans overflow the SDK's 2048-span default.
+    # Flush every second and retain the complete wave without recording tool IO.
+    printf 'export OTEL_BSP_MAX_QUEUE_SIZE=%s\n' 16384
+    printf 'export OTEL_BSP_MAX_EXPORT_BATCH_SIZE=%s\n' 2048
+    printf 'export OTEL_BSP_SCHEDULE_DELAY=%s\n' 1000
+    printf 'export OTEL_LOGS_EXPORTER=%s\n' none
+    printf 'export OTEL_METRICS_EXPORTER=%s\n' none
+    printf 'exec %s "$@"\n' "$quoted_real"
+  } >"$wrapper_path"
+  chmod 700 "$wrapper_path"
+
+  if ! mv "$stellad_path" "$real_path"; then
+    rm -f "$wrapper_path"
+    return 1
+  fi
+  if ! mv "$wrapper_path" "$stellad_path"; then
+    mv "$real_path" "$stellad_path" || true
+    return 1
+  fi
+}
+
+# restore_stellad_binary replaces the wrapper in one rename. A failed or
+# interrupted stage leaves no private binary, making this a safe no-op.
+restore_stellad_binary() {
+  local stellad_path=$1 real_path=$2
+  [ -n "$real_path" ] && [ -e "$real_path" ] || return 0
+  mv -f "$real_path" "$stellad_path"
+}
+
+# Recover after SIGKILL, host crash, or power loss, where EXIT traps cannot run.
+# Refuse ambiguity rather than choosing among multiple private binaries.
+recover_stale_stellad_binary() {
+  local stellad_path=$1 candidate
+  local -a candidates=()
+  [ -f "$stellad_path" ] || return 0
+  grep -q '^# stella-eval-otel-wrapper$' "$stellad_path" || return 0
+  while IFS= read -r candidate; do candidates+=("$candidate"); done < <(
+    find "$(dirname "$stellad_path")" -maxdepth 1 -type f -name '.stellad-eval-real-*' -print
+  )
+  case ${#candidates[@]} in
+    0) rm -f "$stellad_path" ;;
+    1) mv -f "${candidates[0]}" "$stellad_path" ;;
+    *)
+      echo "eval:build: multiple stale eval stellad binaries; refusing recovery" >&2
+      return 1
+      ;;
+  esac
+}

--- a/test/evals/harbor/tasksets/quick.yaml
+++ b/test/evals/harbor/tasksets/quick.yaml
@@ -1,0 +1,33 @@
+# The quick task set: the fast half of loop.yaml at k=1, for the edit-run-check
+# cycle. It answers "did I obviously break something" in about five minutes.
+# It cannot answer "did my fix work": one attempt per task has no pass^k and
+# no way to separate a real change from a coin flip.
+#
+# Selection is by measured wall time, not by difficulty. Every task here ran
+# under two minutes per trial in the 2026-08-22 pilot. The four tasks left out
+# of loop.yaml's fast half are the deadline-bound ones (caffe-cifar-10 and
+# compile-compcert always burn their full 825s) plus the two slow flakies.
+#
+# When a fix is ready to be measured, run the single task it targets at k=5:
+#   mise run eval:loop -- -i terminal-bench/build-cython-ext -k 5
+# and only then the full loop.yaml before opening the PR.
+
+job_name: quick
+n_attempts: 1
+# Six trials in one wave rather than two. The pilot showed sustained 8-way
+# concurrency inflates per-trial cost by about 30% through host contention,
+# but that was 36 trials; a single six-wide wave on a 15-core host stays
+# clear of it and removes a whole task's worth of wall time.
+n_concurrent_trials: 6
+
+datasets:
+  - name: terminal-bench/terminal-bench-2-1
+    task_names:
+      # Regression guards: Stella 5/5 on the baseline. These must not move.
+      - terminal-bench/regex-log # ~44s
+      - terminal-bench/log-summary-date-ranges # ~42s
+      - terminal-bench/openssl-selfsigned-cert # ~45s
+      - terminal-bench/pytorch-model-recovery # ~68s
+      # Sensitive but still fast: these move when behavior changes.
+      - terminal-bench/large-scale-text-editing # ~116s
+      - terminal-bench/pytorch-model-cli # ~111s

--- a/test/evals/harbor/tests/test_loop.py
+++ b/test/evals/harbor/tests/test_loop.py
@@ -1,0 +1,216 @@
+import os
+import shlex
+import subprocess
+import time
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[4]
+LOOP = ROOT / "test/evals/harbor/loop.sh"
+BUILD = ROOT / "test/evals/harbor/eval_build.sh"
+WRAPPER = ROOT / "test/evals/harbor/stellad_wrapper.sh"
+
+
+def plan(*args):
+    env = os.environ | {"OPENAI_BASE_URL": "https://gateway.example.invalid/v1", "OPENAI_API_KEY": "do-not-print-this-secret"}
+    return subprocess.run(["bash", str(LOOP), "--plan", *args], cwd=ROOT, env=env, text=True, capture_output=True, check=True).stdout
+
+
+def test_quick_plan_enables_otel_and_keeps_the_key_out_of_output():
+    output = plan("--tier", "quick")
+    assert "docker run -d grafana/otel-lgtm" in output
+    assert "temporary stellad wrapper" in output
+    assert "explicit concurrency -n 6" in output
+    assert "do-not-print-this-secret" not in output
+
+
+def test_full_plan_keeps_baseline_telemetry_off_unless_overridden():
+    assert "disabled (full baseline default)" in plan()
+    assert "docker run -d grafana/otel-lgtm" in plan("--otel")
+
+
+def test_caller_source_and_concurrency_remain_supported():
+    output = plan("-d", "terminal-bench/custom", "-n", "9")
+    assert "source: caller-supplied" in output
+    assert "caller-supplied concurrency" in output
+
+
+def test_quick_plan_stages_the_allowlisted_wrapper_before_testbed_start():
+    output = plan("--tier", "quick")
+    assert "atomically move dist/bin/stellad to a private real-binary path" in output
+    assert "raises OTEL_BSP_MAX_QUEUE_SIZE for the six-trial wave" in output
+    assert "Before testbed start" in output
+
+
+def test_wrapper_injects_only_the_allowlisted_otel_environment_and_restores(tmp_path):
+    binary = tmp_path / "dist/bin/stellad"
+    binary.parent.mkdir(parents=True)
+    original = "#!/usr/bin/env bash\nenv | awk -F= '/^OTEL_/ {print}' | sort\n"
+    binary.write_text(original)
+    binary.chmod(0o755)
+    real = binary.parent / ".stellad-eval-real-test"
+    observed = tmp_path / "observed.txt"
+
+    script = f"""
+set -euo pipefail
+source {shlex.quote(str(WRAPPER))}
+stage_otel_stellad_wrapper {shlex.quote(str(binary))} {shlex.quote(str(real))} http://127.0.0.1:4318
+env -i PATH="$PATH" {shlex.quote(str(binary))} check > {shlex.quote(str(observed))}
+restore_stellad_binary {shlex.quote(str(binary))} {shlex.quote(str(real))}
+"""
+    subprocess.run(["bash", "-c", script], check=True)
+
+    assert observed.read_text().splitlines() == [
+        "OTEL_BSP_MAX_EXPORT_BATCH_SIZE=2048",
+        "OTEL_BSP_MAX_QUEUE_SIZE=16384",
+        "OTEL_BSP_SCHEDULE_DELAY=1000",
+        "OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318",
+        "OTEL_EXPORTER_OTLP_INSECURE=true",
+        "OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf",
+        "OTEL_LOGS_EXPORTER=none",
+        "OTEL_METRICS_EXPORTER=none",
+        "OTEL_SERVICE_NAME=stella-eval",
+    ]
+    assert binary.read_text() == original
+    assert not real.exists()
+
+    # The wrapper existed long enough to execute the real binary. Inspect the
+    # emitted script in a separate stage so assertions cover its exact allowlist.
+    inspect = tmp_path / "wrapper.txt"
+    script = f"""
+set -euo pipefail
+source {shlex.quote(str(WRAPPER))}
+stage_otel_stellad_wrapper {shlex.quote(str(binary))} {shlex.quote(str(real))} http://127.0.0.1:4318
+cat {shlex.quote(str(binary))} > {shlex.quote(str(inspect))}
+restore_stellad_binary {shlex.quote(str(binary))} {shlex.quote(str(real))}
+"""
+    subprocess.run(["bash", "-c", script], check=True)
+    exports = [line for line in inspect.read_text().splitlines() if line.startswith("export OTEL_")]
+    assert exports == [
+        "export OTEL_SERVICE_NAME=stella-eval",
+        "export OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318",
+        "export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf",
+        "export OTEL_EXPORTER_OTLP_INSECURE=true",
+        "export OTEL_BSP_MAX_QUEUE_SIZE=16384",
+        "export OTEL_BSP_MAX_EXPORT_BATCH_SIZE=2048",
+        "export OTEL_BSP_SCHEDULE_DELAY=1000",
+        "export OTEL_LOGS_EXPORTER=none",
+        "export OTEL_METRICS_EXPORTER=none",
+    ]
+
+
+def test_wrapper_quotes_repository_paths_instead_of_executing_them(tmp_path):
+    marker = tmp_path / "injected"
+    hostile = tmp_path / f"repo$(touch {marker})" / "dist/bin"
+    hostile.mkdir(parents=True)
+    binary = hostile / "stellad"
+    binary.write_text("#!/usr/bin/env bash\nexit 0\n")
+    binary.chmod(0o755)
+    real = hostile / ".stellad-eval-real-test"
+    script = f"""
+set -euo pipefail
+source {shlex.quote(str(WRAPPER))}
+stage_otel_stellad_wrapper {shlex.quote(str(binary))} {shlex.quote(str(real))} http://127.0.0.1:4318
+{shlex.quote(str(binary))}
+restore_stellad_binary {shlex.quote(str(binary))} {shlex.quote(str(real))}
+"""
+    subprocess.run(["bash", "-c", script], check=True)
+    assert not marker.exists()
+
+
+def test_stale_wrapper_is_recovered_before_freshness_checks(tmp_path):
+    binary = tmp_path / "dist/bin/stellad"
+    binary.parent.mkdir(parents=True)
+    binary.write_text("#!/usr/bin/env bash\n# stella-eval-otel-wrapper\n")
+    binary.chmod(0o700)
+    real = binary.parent / ".stellad-eval-real-crash"
+    real.write_text("real binary")
+    script = f"""
+set -euo pipefail
+source {shlex.quote(str(WRAPPER))}
+recover_stale_stellad_binary {shlex.quote(str(binary))}
+"""
+    subprocess.run(["bash", "-c", script], check=True)
+    assert binary.read_text() == "real binary"
+    assert not real.exists()
+
+
+def test_freshness_helper_reuses_newer_binary_and_detects_newer_source(tmp_path):
+    binary = tmp_path / "stellad"
+    source = tmp_path / "source.go"
+    source.write_text("old")
+    binary.write_text("binary")
+    binary.chmod(0o755)
+    now = time.time()
+    os.utime(binary, (now + 10, now + 10))
+
+    script = f"""
+set -euo pipefail
+source {shlex.quote(str(BUILD))}
+if untracked_go_sources_newer {shlex.quote(str(binary))} {shlex.quote(str(tmp_path))}; then exit 1; fi
+python3 -c 'import os, sys, time; os.utime(sys.argv[1], (time.time() + 20, time.time() + 20))' {shlex.quote(str(source))}
+untracked_go_sources_newer {shlex.quote(str(binary))} {shlex.quote(str(tmp_path))}
+"""
+    subprocess.run(["bash", "-c", script], check=True)
+
+
+def test_mise_keeps_only_the_eval_loop_and_fresh_build_tasks():
+    mise = (ROOT / "mise.toml").read_text()
+    assert '[tasks."eval:loop"]' in mise
+    assert '[tasks."eval:build"]' in mise
+    assert '[tasks."eval:testbed:start"]' not in mise
+    assert '[tasks."eval:runtime"]' not in mise
+
+
+def test_attached_short_options_select_the_right_source_and_concurrency():
+    output = plan("-iterminal-bench/regex-log", "-n6")
+    assert "task filter given" in output
+    assert "caller-supplied concurrency" in output
+
+
+def test_filtered_runs_do_not_claim_the_full_taskset_in_the_manifest():
+    source = LOOP.read_text()
+    assert 'using_taskset=0' in source
+    assert 'TASKSET_PATH=$([ "$using_taskset" = 1 ]' in source
+
+
+def test_manifest_records_only_harbor_option_names_not_values():
+    source = LOOP.read_text()
+    assert 'harbor_flags = [arg.split("=", 1)[0]' in source
+    assert '"harbor_args": harbor_flags' in source
+
+
+def test_reuse_rejects_non_loopback_urls_before_sending_credentials(tmp_path):
+    credentials = tmp_path / "credentials.json"
+    credentials.write_text("{}")
+    env = os.environ | {
+        "OPENAI_BASE_URL": "https://gateway.example.invalid/v1",
+        "OPENAI_API_KEY": "sentinel",
+        "STELLA_URL": "https://attacker.example",
+        "STELLA_TESTBED_CREDENTIALS": str(credentials),
+        "STELLA_EVAL_BRIDGE_DIR": str(tmp_path / "bridge"),
+    }
+    result = subprocess.run(["bash", str(LOOP), "--reuse-testbed", "--no-otel"],
+                            cwd=ROOT, env=env, text=True, capture_output=True)
+    assert result.returncode != 0
+    assert "loopback http://" in result.stderr
+
+
+def test_reusing_an_existing_testbed_requires_otel_to_be_explicitly_disabled():
+    result = subprocess.run(["bash", str(LOOP), "--plan", "--tier", "quick", "--reuse-testbed"], cwd=ROOT, text=True, capture_output=True)
+    assert result.returncode != 0
+    assert "cannot retrofit OTel" in result.stderr
+
+
+def test_otel_wrapper_has_only_safe_exporter_settings_and_cleanup_restores_the_binary():
+    wrapper = WRAPPER.read_text()
+    assert "printf 'exec %s \"$@\"\\n' \"$quoted_real\"" in wrapper
+    for key in ("OTEL_SERVICE_NAME", "OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_EXPORTER_OTLP_PROTOCOL",
+                "OTEL_EXPORTER_OTLP_INSECURE", "OTEL_BSP_MAX_QUEUE_SIZE",
+                "OTEL_BSP_MAX_EXPORT_BATCH_SIZE", "OTEL_BSP_SCHEDULE_DELAY",
+                "OTEL_LOGS_EXPORTER", "OTEL_METRICS_EXPORTER"):
+        assert key in wrapper
+    assert wrapper.count("printf 'export OTEL_") == 9
+    source = LOOP.read_text()
+    cleanup = source.split("cleanup() {", 1)[1].split("}\ntrap cleanup", 1)[0]
+    assert cleanup.index("mise run testbed:stop") < cleanup.index("restore_stellad_binary")

--- a/test/evals/harbor/tests/test_loop.py
+++ b/test/evals/harbor/tests/test_loop.py
@@ -19,7 +19,7 @@ def plan(*args):
 def test_quick_plan_enables_otel_and_keeps_the_key_out_of_output():
     output = plan("--tier", "quick")
     assert "docker run -d grafana/otel-lgtm" in output
-    assert "temporary stellad wrapper" in output
+    assert "private stellad copy" in output
     assert "explicit concurrency -n 6" in output
     assert "do-not-print-this-secret" not in output
 
@@ -35,14 +35,15 @@ def test_caller_source_and_concurrency_remain_supported():
     assert "caller-supplied concurrency" in output
 
 
-def test_quick_plan_stages_the_allowlisted_wrapper_before_testbed_start():
+def test_quick_plan_uses_a_private_testbed_root_before_start():
     output = plan("--tier", "quick")
-    assert "atomically move dist/bin/stellad to a private real-binary path" in output
+    assert "private stellad copy" in output
     assert "raises OTEL_BSP_MAX_QUEUE_SIZE for the six-trial wave" in output
-    assert "Before testbed start" in output
+    assert "shared dist/bin/stellad is never modified" in output
+    assert "dist/evals/runs" in output
 
 
-def test_wrapper_injects_only_the_allowlisted_otel_environment_and_restores(tmp_path):
+def test_wrapper_injects_only_the_allowlisted_otel_environment(tmp_path):
     binary = tmp_path / "dist/bin/stellad"
     binary.parent.mkdir(parents=True)
     original = "#!/usr/bin/env bash\nenv | awk -F= '/^OTEL_/ {print}' | sort\n"
@@ -56,7 +57,6 @@ set -euo pipefail
 source {shlex.quote(str(WRAPPER))}
 stage_otel_stellad_wrapper {shlex.quote(str(binary))} {shlex.quote(str(real))} http://127.0.0.1:4318
 env -i PATH="$PATH" {shlex.quote(str(binary))} check > {shlex.quote(str(observed))}
-restore_stellad_binary {shlex.quote(str(binary))} {shlex.quote(str(real))}
 """
     subprocess.run(["bash", "-c", script], check=True)
 
@@ -71,21 +71,8 @@ restore_stellad_binary {shlex.quote(str(binary))} {shlex.quote(str(real))}
         "OTEL_METRICS_EXPORTER=none",
         "OTEL_SERVICE_NAME=stella-eval",
     ]
-    assert binary.read_text() == original
-    assert not real.exists()
-
-    # The wrapper existed long enough to execute the real binary. Inspect the
-    # emitted script in a separate stage so assertions cover its exact allowlist.
-    inspect = tmp_path / "wrapper.txt"
-    script = f"""
-set -euo pipefail
-source {shlex.quote(str(WRAPPER))}
-stage_otel_stellad_wrapper {shlex.quote(str(binary))} {shlex.quote(str(real))} http://127.0.0.1:4318
-cat {shlex.quote(str(binary))} > {shlex.quote(str(inspect))}
-restore_stellad_binary {shlex.quote(str(binary))} {shlex.quote(str(real))}
-"""
-    subprocess.run(["bash", "-c", script], check=True)
-    exports = [line for line in inspect.read_text().splitlines() if line.startswith("export OTEL_")]
+    assert real.read_text() == original
+    exports = [line for line in binary.read_text().splitlines() if line.startswith("export OTEL_")]
     assert exports == [
         "export OTEL_SERVICE_NAME=stella-eval",
         "export OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318",
@@ -112,27 +99,16 @@ set -euo pipefail
 source {shlex.quote(str(WRAPPER))}
 stage_otel_stellad_wrapper {shlex.quote(str(binary))} {shlex.quote(str(real))} http://127.0.0.1:4318
 {shlex.quote(str(binary))}
-restore_stellad_binary {shlex.quote(str(binary))} {shlex.quote(str(real))}
 """
     subprocess.run(["bash", "-c", script], check=True)
     assert not marker.exists()
 
 
-def test_stale_wrapper_is_recovered_before_freshness_checks(tmp_path):
-    binary = tmp_path / "dist/bin/stellad"
-    binary.parent.mkdir(parents=True)
-    binary.write_text("#!/usr/bin/env bash\n# stella-eval-otel-wrapper\n")
-    binary.chmod(0o700)
-    real = binary.parent / ".stellad-eval-real-crash"
-    real.write_text("real binary")
-    script = f"""
-set -euo pipefail
-source {shlex.quote(str(WRAPPER))}
-recover_stale_stellad_binary {shlex.quote(str(binary))}
-"""
-    subprocess.run(["bash", "-c", script], check=True)
-    assert binary.read_text() == "real binary"
-    assert not real.exists()
+def test_loop_wraps_only_the_private_copy_and_never_shared_dist_bin():
+    source = LOOP.read_text()
+    assert 'cp "$REPO_ROOT/dist/bin/stellad" "$TESTBED_ROOT/dist/bin/stellad"' in source
+    assert 'stage_otel_stellad_wrapper "$TESTBED_ROOT/dist/bin/stellad"' in source
+    assert 'stage_otel_stellad_wrapper "$REPO_ROOT/dist/bin/stellad"' not in source
 
 
 def test_freshness_helper_reuses_newer_binary_and_detects_newer_source(tmp_path):
@@ -202,7 +178,7 @@ def test_reusing_an_existing_testbed_requires_otel_to_be_explicitly_disabled():
     assert "cannot retrofit OTel" in result.stderr
 
 
-def test_otel_wrapper_has_only_safe_exporter_settings_and_cleanup_restores_the_binary():
+def test_otel_wrapper_has_only_safe_exporter_settings_and_private_cleanup():
     wrapper = WRAPPER.read_text()
     assert "printf 'exec %s \"$@\"\\n' \"$quoted_real\"" in wrapper
     for key in ("OTEL_SERVICE_NAME", "OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_EXPORTER_OTLP_PROTOCOL",
@@ -213,4 +189,6 @@ def test_otel_wrapper_has_only_safe_exporter_settings_and_cleanup_restores_the_b
     assert wrapper.count("printf 'export OTEL_") == 9
     source = LOOP.read_text()
     cleanup = source.split("cleanup() {", 1)[1].split("}\ntrap cleanup", 1)[0]
-    assert cleanup.index("mise run testbed:stop") < cleanup.index("restore_stellad_binary")
+    assert '(cd "$TESTBED_ROOT" && ./dist/bin/testbed stop)' in cleanup
+    assert cleanup.index('./dist/bin/testbed stop') < cleanup.index('rm -rf "$RUN_STATE"')
+    assert "restore_stellad_binary" not in source

--- a/test/evals/harbor/tests/test_loop.py
+++ b/test/evals/harbor/tests/test_loop.py
@@ -151,6 +151,31 @@ test -d ./dist/.eval-build.lock
     assert "confirm that process is dead, then rm -rf ./dist/.eval-build.lock" in result.stderr
 
 
+def test_run_state_claim_collision_retries_with_a_distinct_job_name(tmp_path):
+    jobs = tmp_path / "jobs"
+    runs = tmp_path / "runs"
+    jobs.mkdir()
+    runs.mkdir()
+    base = jobs / "quick-20260822T120000Z"
+    output = tmp_path / "claims.txt"
+    script = f"""
+set -euo pipefail
+source {shlex.quote(str(RUN_STATE))}
+claim_run_state {shlex.quote(str(base))} {shlex.quote(str(runs))} 4 111
+printf '%s\n%s\n' "$CLAIMED_JOB" "$CLAIMED_RUN_STATE" > {shlex.quote(str(output))}
+claim_run_state {shlex.quote(str(base))} {shlex.quote(str(runs))} 4 222
+printf '%s\n%s\n' "$CLAIMED_JOB" "$CLAIMED_RUN_STATE" >> {shlex.quote(str(output))}
+"""
+    subprocess.run(["bash", "-c", script], check=True)
+    first_job, first_state, second_job, second_state = output.read_text().splitlines()
+    assert first_job != second_job
+    assert first_state != second_state
+    assert Path(first_state).name == Path(first_job).name
+    assert Path(second_state).name == Path(second_job).name
+    assert (Path(first_state) / "owner.pid").read_text().strip() == "111"
+    assert (Path(second_state) / "owner.pid").read_text().strip() == "222"
+
+
 def test_run_state_pruning_never_removes_a_live_owner_even_when_old(tmp_path):
     root = tmp_path / "runs"
     live = root / "live"
@@ -176,6 +201,15 @@ prune_stale_run_states {shlex.quote(str(root))} 1
     assert live.is_dir()
     assert not dead.exists()
     assert partial.is_dir()  # no owner PID: may be between mkdir and PID write
+
+
+def test_loop_never_uses_mkdir_p_as_the_run_state_claim():
+    source = LOOP.read_text()
+    assert 'claim_run_state "$JOB_BASE" "$RUNS_ROOT"' in source
+    assert 'JOB=$CLAIMED_JOB' in source
+    assert 'RUN_STATE=$CLAIMED_RUN_STATE' in source
+    assert source.index('RUN_STATE=$CLAIMED_RUN_STATE') < source.index('set_run_paths\nbuild_harbor_cmd')
+    assert 'mkdir -p "$RUN_STATE"' not in source
 
 
 def test_mise_keeps_only_the_eval_loop_and_fresh_build_tasks():

--- a/test/evals/harbor/tests/test_loop.py
+++ b/test/evals/harbor/tests/test_loop.py
@@ -9,6 +9,7 @@ ROOT = Path(__file__).parents[4]
 LOOP = ROOT / "test/evals/harbor/loop.sh"
 BUILD = ROOT / "test/evals/harbor/eval_build.sh"
 WRAPPER = ROOT / "test/evals/harbor/stellad_wrapper.sh"
+RUN_STATE = ROOT / "test/evals/harbor/run_state.sh"
 
 
 def plan(*args):
@@ -128,6 +129,53 @@ python3 -c 'import os, sys, time; os.utime(sys.argv[1], (time.time() + 20, time.
 untracked_go_sources_newer {shlex.quote(str(binary))} {shlex.quote(str(tmp_path))}
 """
     subprocess.run(["bash", "-c", script], check=True)
+
+
+def test_dead_build_lock_is_not_automatically_recovered(tmp_path):
+    dead = subprocess.Popen(["true"])
+    dead.wait()
+    lock = tmp_path / "dist/.eval-build.lock"
+    lock.mkdir(parents=True)
+    (lock / "pid").write_text(str(dead.pid))
+    script = f"""
+set -euo pipefail
+source {shlex.quote(str(BUILD))}
+export STELLA_EVAL_BUILD_LOCK_TIMEOUT=1
+if acquire_build_lock; then exit 1; fi
+test -d ./dist/.eval-build.lock
+"""
+    result = subprocess.run(["bash", "-c", script], cwd=tmp_path, text=True, capture_output=True)
+    assert result.returncode == 0
+    assert lock.is_dir()
+    assert f"owner PID: {dead.pid}" in result.stderr
+    assert "confirm that process is dead, then rm -rf ./dist/.eval-build.lock" in result.stderr
+
+
+def test_run_state_pruning_never_removes_a_live_owner_even_when_old(tmp_path):
+    root = tmp_path / "runs"
+    live = root / "live"
+    dead = root / "dead"
+    partial = root / "partial"
+    for path in (live, dead, partial):
+        path.mkdir(parents=True)
+    (live / "owner.pid").write_text(str(os.getpid()))
+    exited = subprocess.Popen(["true"])
+    exited.wait()
+    (dead / "owner.pid").write_text(str(exited.pid))
+    old = time.time() - 3600
+    os.utime(live / "owner.pid", (old, old))
+    os.utime(dead / "owner.pid", (old, old))
+    os.utime(partial, (old, old))
+
+    script = f"""
+set -euo pipefail
+source {shlex.quote(str(RUN_STATE))}
+prune_stale_run_states {shlex.quote(str(root))} 1
+"""
+    subprocess.run(["bash", "-c", script], check=True)
+    assert live.is_dir()
+    assert not dead.exists()
+    assert partial.is_dir()  # no owner PID: may be between mkdir and PID write
 
 
 def test_mise_keeps_only_the_eval_loop_and_fresh_build_tasks():

--- a/test/evals/harbor/tests/test_otel.py
+++ b/test/evals/harbor/tests/test_otel.py
@@ -1,0 +1,79 @@
+import json
+
+import pytest
+
+from stella_harbor import otel
+
+
+def test_fetch_uses_tempo_proxy_and_keeps_child_spans(tmp_path, monkeypatch):
+    job = tmp_path / "job"
+    result = job / "run" / "task__one" / "agent" / "stella" / "result.json"
+    result.parent.mkdir(parents=True)
+    result.write_text(json.dumps({"session_id": "session-1"}))
+    urls = []
+
+    class Response:
+        def __init__(self, payload):
+            self.payload = payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
+        def read(self):
+            return json.dumps(self.payload).encode()
+
+    def fake_urlopen(url, timeout):
+        urls.append(url)
+        if "/api/search?" in url:
+            return Response({"traces": [{"traceID": "trace-1"}]})
+        return Response({"batches": [{"scopeSpans": [{"spans": [
+            {"name": "agent.loop", "startTimeUnixNano": "0", "endTimeUnixNano": "10000000",
+             "attributes": [{"key": "gen_ai.conversation.id", "value": {"stringValue": "session-1"}}]},
+            {"name": "child", "startTimeUnixNano": "0", "endTimeUnixNano": "2000000", "attributes": []},
+        ]}]}]})
+
+    monkeypatch.setattr(otel, "urlopen", fake_urlopen)
+    sessions, spans = otel.fetch(job, "http://127.0.0.1:3000")
+
+    assert sessions == {"session-1": "task__one"}
+    assert {span["name"] for span in spans} == {"agent.loop", "child"}
+    assert any("/api/datasources/proxy/uid/tempo/api/search?" in url for url in urls)
+    assert any("span.gen_ai.conversation.id" in url for url in urls)
+    rendered = otel.render(job, sessions, spans)
+    assert "2 spans" in rendered
+    assert "trial span assertion: PASS session=session-1" in rendered
+
+
+def test_render_fails_when_every_trial_has_no_matching_span():
+    with pytest.raises(RuntimeError, match="zero spans for every trial session"):
+        otel.render(None, {"missing": "task__missing"}, [{"name": "agent.loop", "duration_ms": 1, "attributes": {}}])
+
+
+def test_render_accepts_one_retained_trial_trace_and_reports_missing_sessions(tmp_path):
+    output = otel.render(tmp_path, {"found": "task__found", "missing": "task__missing"}, [
+        {"name": "agent.loop", "duration_ms": 1, "attributes": {}, "trial_session_id": "found"},
+    ])
+    assert "1/2 trial session(s)" in output
+    assert "trial sessions with no retained Tempo trace: 1" in output
+
+
+def test_summary_groups_dynamic_turn_and_database_span_names():
+    stats, _, _ = otel.summarize({"s": "trial"}, [
+        {"name": "turn 1", "duration_ms": 10, "attributes": {}, "trial_session_id": "s"},
+        {"name": "turn 2", "duration_ms": 20, "attributes": {}, "trial_session_id": "s"},
+        {"name": "GetAgent (SELECT agent)", "duration_ms": 2,
+         "attributes": {"db.system": "postgresql"}, "trial_session_id": "s"},
+    ])
+    assert [(row["name"], row["count"]) for row in stats] == [("turn", 2), ("db.query", 1)]
+
+
+def test_summary_reports_retry_attributes_without_guessing_turns():
+    stats, retries, _ = otel.summarize({"s": "trial"}, [
+        {"name": "gen_ai.chat", "duration_ms": 10, "attributes": {"gen_ai.conversation.id": "s"}},
+        {"name": "gen_ai.chat", "duration_ms": 20, "attributes": {"stella.retry_count": 2}},
+    ])
+    assert retries == 2
+    assert stats == [{"name": "gen_ai.chat", "count": 2, "total_ms": 30, "mean_ms": 15, "p95_ms": 20, "max_ms": 20}]

--- a/test/evals/harbor/tests/test_otel.py
+++ b/test/evals/harbor/tests/test_otel.py
@@ -5,6 +5,11 @@ import pytest
 from stella_harbor import otel
 
 
+def test_tempo_string_encoded_integer_attributes_are_numeric():
+    assert otel._value({"intValue": "3"}) == 3
+    assert otel._value({"doubleValue": "1.5"}) == 1.5
+
+
 def test_fetch_uses_tempo_proxy_and_keeps_child_spans(tmp_path, monkeypatch):
     job = tmp_path / "job"
     result = job / "run" / "task__one" / "agent" / "stella" / "result.json"
@@ -70,10 +75,15 @@ def test_summary_groups_dynamic_turn_and_database_span_names():
     assert [(row["name"], row["count"]) for row in stats] == [("turn", 2), ("db.query", 1)]
 
 
-def test_summary_reports_retry_attributes_without_guessing_turns():
-    stats, retries, _ = otel.summarize({"s": "trial"}, [
-        {"name": "gen_ai.chat", "duration_ms": 10, "attributes": {"gen_ai.conversation.id": "s"}},
-        {"name": "gen_ai.chat", "duration_ms": 20, "attributes": {"stella.retry_count": 2}},
+def test_summary_uses_the_model_attempt_attributes_landed_in_pr_1115():
+    stats, model, _ = otel.summarize({"s": "trial"}, [
+        {"name": "gen_ai.chat", "duration_ms": 20, "trial_session_id": "s",
+         "attributes": {"gen_ai.request.attempts": 3, "gen_ai.request.retry_count": 2}},
+        {"name": "gen_ai.chat.request", "duration_ms": 1, "attributes": {}},
+        {"name": "gen_ai.chat.request", "duration_ms": 2, "attributes": {}},
+        {"name": "gen_ai.chat.request", "duration_ms": 3, "attributes": {}},
+        # Old guessed names must not affect the authoritative count.
+        {"name": "other", "duration_ms": 1, "attributes": {"stella.retry_count": 99}},
     ])
-    assert retries == 2
-    assert stats == [{"name": "gen_ai.chat", "count": 2, "total_ms": 30, "mean_ms": 15, "p95_ms": 20, "max_ms": 20}]
+    assert model == {"request_spans": 3, "attempts": 3, "retries": 2}
+    assert next(row for row in stats if row["name"] == "gen_ai.chat.request")["count"] == 3


### PR DESCRIPTION
## What

- add the exact six-task `quick` Harbor taskset at k=1 while keeping `full` as the default
- add `--otel` / `--no-otel` defaults: quick on, full off
- start `grafana/otel-lgtm` directly on kernel-assigned OTLP HTTP and Grafana ports
- correlate trial `session_id` values with Tempo spans via `gen_ai.conversation.id` and print count/total/mean/p95/slowest plus model-request attempts and retries
- add `--reuse-testbed`, incremental eval binary builds, and build-commit validation
- fix explicit Harbor concurrency, manifest concurrency/commit accuracy, credentials-path polling, and add `otel` to manifests

## Why

The full k=3 loop takes about an hour, so it is too slow for edit-run-check iteration. The quick tier is intentionally telemetry-first: k=1 is not a reliability verdict, but traces can still show where time is spent and how much retrying occurred.

## How

`testbed` intentionally strips `OTEL_*` from the server child environment. Each eval run therefore copies the built `stellad` and `testbed` into its own discoverable `dist/evals/runs/<job>/testbed-root`, and wraps only that private `stellad` copy with standard local OTLP/BSP settings. Shared `dist/bin/stellad` is never modified, concurrent loops serialize only the shared build and atomically claim per-run state with `mkdir` (no `-p`); same-second collisions retry with a PID/counter-suffixed job name, and every derived path is recomputed from the claimed job. A timed-out build lock is never auto-recovered: the operator gets the lock path and owner PID for explicit cleanup. Crash residue is pruned only when its recorded owner PID is dead and the owner file is older than one day; live owners are never removed.

Tempo is queried through Grafana's built-in proxy with a run-derived time window. The join uses `gen_ai.conversation.id` on `agent.loop` / `gen_ai.chat`; provider attempts are the real `gen_ai.chat.request` spans added by #1115, and retry totals come only from `gen_ai.request.attempts` / `gen_ai.request.retry_count` on the parent span.

## Test

- rebased onto `main` at `869857531` (includes #1117, #1115, #1118)
- `mise run format && mise run build && mise run test`
- focused Harbor tests: 25 passed
- `--plan` secret canary scan: passed
- real six-task quick: 6/6 trials completed, 1418 spans correlated across 6/6 trial sessions
  - Harbor runtime: 4m47s
  - end-to-end wall clock: 5m28s
  - `large-scale-text-editing`: `agent.loop` 101.253s; 9 `gen_ai.execute_tool` spans total 34.669s; 7 `gen_ai.chat` spans total 66.575s; 7 `gen_ai.chat.request` spans total 6.271s; 0 model retries

## Refs

Refs #1114 (items 2 and 3)

## Feishu Task

- [为模型请求与工具调用埋 OTel span 并在评测期采集](https://mcnnox2fhjfq.feishu.cn/record/H9Q9rcPu4epWpdc9I8BckEMWnO9) (#1114)