### PR TITLE
🐛 fix(sandbox): make read cap errors actionable

### DIFF
--- a/internal/agent/sandbox/read.go
+++ b/internal/agent/sandbox/read.go
@@ -77,10 +77,7 @@ func (t *hostReadTool) ExecuteContent(ctx context.Context, args map[string]any) 
 	if err != nil {
 		var tooLarge *pkgsandbox.FileTooLargeError
 		if errors.As(err, &tooLarge) {
-			outputByteLimit := pkgtools.OutputByteLimit()
-			sliceLines := max(outputByteLimit/conservativeReadSliceBytesPerLine, 1)
-			outputLimitKB := max((outputByteLimit+bytesPerKiB-1)/bytesPerKiB, 1)
-			command := fmt.Sprintf("sed -n '1,%dp' -- %s", sliceLines, shellQuote(path))
+			command, sliceLines, outputLimitKB := oversizedReadSliceCommand(path)
 			return nil, fmt.Errorf("read %q: file is %d bytes, over the %d-byte read cap. Tool output is capped at ~%d KB per call, so start with a %d-line slice from the beginning, not the whole file. Next call: bash(command=%q)", path, tooLarge.Size, tooLarge.Limit, outputLimitKB, sliceLines, command)
 		}
 		return nil, fmt.Errorf("read %s: %w", path, err)
@@ -146,6 +143,31 @@ func (t *hostReadTool) imageBlocks(ctx context.Context, displayPath string, cont
 		ai.TextContent{Text: fmt.Sprintf("Read image file [%s]", outMime)},
 		ai.ImageContent{Data: base64.StdEncoding.EncodeToString(data), MimeType: outMime},
 	}
+}
+
+func oversizedReadSliceCommand(path string) (command string, sliceLines, outputLimitKB int) {
+	outputByteLimit := pkgtools.OutputByteLimit()
+	sliceLines = max(outputByteLimit/conservativeReadSliceBytesPerLine, 1)
+	outputLimitKB = max((outputByteLimit+bytesPerKiB-1)/bytesPerKiB, 1)
+	command = fmt.Sprintf("sed -n '1,%dp' < %s", sliceLines, shellQuoteToolPath(path))
+	return command, sliceLines, outputLimitKB
+}
+
+// shellQuoteToolPath preserves an allowed leading filesystem variable for the
+// shell to expand. Session Exec environments and read path expansion both come
+// from the same Policy.Env; the suffix remains literal shell data.
+func shellQuoteToolPath(value string) string {
+	_, suffix, hasVariable, err := pkgsandbox.SplitLeadingPathVariable(value)
+	if err != nil || !hasVariable {
+		return shellQuote(value)
+	}
+
+	variable := value[:len(value)-len(suffix)]
+	quoted := `"` + variable + `"`
+	if suffix == "" {
+		return quoted
+	}
+	return quoted + suffix[:1] + shellQuote(suffix[1:])
 }
 
 func shellQuote(value string) string {

--- a/internal/agent/sandbox/read.go
+++ b/internal/agent/sandbox/read.go
@@ -163,11 +163,15 @@ func shellQuoteToolPath(value string) string {
 	}
 
 	variable := value[:len(value)-len(suffix)]
+	return shellQuoteLeadingVariablePath(variable, suffix)
+}
+
+func shellQuoteLeadingVariablePath(variable, suffix string) string {
 	quoted := `"` + variable + `"`
 	if suffix == "" {
 		return quoted
 	}
-	return quoted + suffix[:1] + shellQuote(suffix[1:])
+	return quoted + shellQuote(suffix)
 }
 
 func shellQuote(value string) string {

--- a/internal/agent/sandbox/read.go
+++ b/internal/agent/sandbox/read.go
@@ -3,6 +3,7 @@ package sandbox
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -66,6 +67,11 @@ func (t *hostReadTool) ExecuteContent(ctx context.Context, args map[string]any) 
 
 	content, err := view.Files.ReadFile(resolvedPath)
 	if err != nil {
+		var tooLarge *pkgsandbox.FileTooLargeError
+		if errors.As(err, &tooLarge) {
+			command := fmt.Sprintf("sed -n '1,1000p' -- %s", shellQuote(path))
+			return nil, fmt.Errorf("read %q: file is %d bytes, over the %d-byte read cap. Next call: bash(command=%q)", path, tooLarge.Size, tooLarge.Limit, command)
+		}
 		return nil, fmt.Errorf("read %s: %w", path, err)
 	}
 
@@ -129,6 +135,10 @@ func (t *hostReadTool) imageBlocks(ctx context.Context, displayPath string, cont
 		ai.TextContent{Text: fmt.Sprintf("Read image file [%s]", outMime)},
 		ai.ImageContent{Data: base64.StdEncoding.EncodeToString(data), MimeType: outMime},
 	}
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
 }
 
 func paginateReadContent(content string, offset, limit int) (string, int) {

--- a/internal/agent/sandbox/read.go
+++ b/internal/agent/sandbox/read.go
@@ -37,6 +37,14 @@ type hostReadTool struct {
 	host pkgsandbox.Session
 }
 
+const (
+	// Wide CSV rows can easily reach a few hundred bytes. This conservative
+	// default aims below the per-call output budget; #1118's truncation marker
+	// remains the fallback when actual rows are wider.
+	conservativeReadSliceBytesPerLine = 250
+	bytesPerKiB                       = 1024
+)
+
 func (t *hostReadTool) Definition() pkgtools.Definition { return readDefinition() }
 
 func (t *hostReadTool) Execute(ctx context.Context, args map[string]any) (string, error) {
@@ -69,8 +77,11 @@ func (t *hostReadTool) ExecuteContent(ctx context.Context, args map[string]any) 
 	if err != nil {
 		var tooLarge *pkgsandbox.FileTooLargeError
 		if errors.As(err, &tooLarge) {
-			command := fmt.Sprintf("sed -n '1,1000p' -- %s", shellQuote(path))
-			return nil, fmt.Errorf("read %q: file is %d bytes, over the %d-byte read cap. Next call: bash(command=%q)", path, tooLarge.Size, tooLarge.Limit, command)
+			outputByteLimit := pkgtools.OutputByteLimit()
+			sliceLines := max(outputByteLimit/conservativeReadSliceBytesPerLine, 1)
+			outputLimitKB := max((outputByteLimit+bytesPerKiB-1)/bytesPerKiB, 1)
+			command := fmt.Sprintf("sed -n '1,%dp' -- %s", sliceLines, shellQuote(path))
+			return nil, fmt.Errorf("read %q: file is %d bytes, over the %d-byte read cap. Tool output is capped at ~%d KB per call, so start with a %d-line slice from the beginning, not the whole file. Next call: bash(command=%q)", path, tooLarge.Size, tooLarge.Limit, outputLimitKB, sliceLines, command)
 		}
 		return nil, fmt.Errorf("read %s: %w", path, err)
 	}

--- a/internal/agent/sandbox/read_test.go
+++ b/internal/agent/sandbox/read_test.go
@@ -137,6 +137,7 @@ func TestReadImageCanonicalResultKeepsOriginalForTransform(t *testing.T) {
 }
 
 func TestReadTooLargeErrorSuggestsExecutableBashRange(t *testing.T) {
+	t.Setenv("STELLA_TOOL_MAX_BYTES", "")
 	const (
 		publicPath = "/app/input file's.csv"
 		hostPath   = "/private/host/eval/input.csv"
@@ -156,11 +157,16 @@ func TestReadTooLargeErrorSuggestsExecutableBashRange(t *testing.T) {
 		t.Fatal("expected oversized read to fail")
 	}
 	message := err.Error()
+	outputByteLimit := pkgtools.OutputByteLimit()
+	sliceLines := max(outputByteLimit/conservativeReadSliceBytesPerLine, 1)
+	outputLimitKB := max((outputByteLimit+bytesPerKiB-1)/bytesPerKiB, 1)
 	for _, want := range []string{
 		publicPath,
 		"51066691 bytes",
 		"33554432-byte read cap",
-		fmt.Sprintf("bash(command=%q)", "sed -n '1,1000p' -- "+shellQuote(publicPath)),
+		fmt.Sprintf("capped at ~%d KB per call", outputLimitKB),
+		fmt.Sprintf("a %d-line slice from the beginning, not the whole file", sliceLines),
+		fmt.Sprintf("bash(command=%q)", fmt.Sprintf("sed -n '1,%dp' -- %s", sliceLines, shellQuote(publicPath))),
 	} {
 		if !strings.Contains(message, want) {
 			t.Errorf("error %q does not contain %q", message, want)

--- a/internal/agent/sandbox/read_test.go
+++ b/internal/agent/sandbox/read_test.go
@@ -178,6 +178,14 @@ func TestReadTooLargeErrorSuggestsExecutableBashRange(t *testing.T) {
 	}
 }
 
+func TestShellQuoteLeadingVariablePathQuotesBackslashSuffix(t *testing.T) {
+	got := shellQuoteLeadingVariablePath("$HOME", `\foo`)
+	want := `"$HOME"'\foo'`
+	if got != want {
+		t.Fatalf("quoted path = %q, want %q", got, want)
+	}
+}
+
 func TestOversizedReadSliceCommandExecutesForAgentPaths(t *testing.T) {
 	t.Setenv("STELLA_TOOL_MAX_BYTES", "500")
 	root := t.TempDir()

--- a/internal/agent/sandbox/read_test.go
+++ b/internal/agent/sandbox/read_test.go
@@ -9,6 +9,7 @@ import (
 	"image/color"
 	"image/png"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -166,7 +167,7 @@ func TestReadTooLargeErrorSuggestsExecutableBashRange(t *testing.T) {
 		"33554432-byte read cap",
 		fmt.Sprintf("capped at ~%d KB per call", outputLimitKB),
 		fmt.Sprintf("a %d-line slice from the beginning, not the whole file", sliceLines),
-		fmt.Sprintf("bash(command=%q)", fmt.Sprintf("sed -n '1,%dp' -- %s", sliceLines, shellQuote(publicPath))),
+		fmt.Sprintf("bash(command=%q)", fmt.Sprintf("sed -n '1,%dp' < %s", sliceLines, shellQuoteToolPath(publicPath))),
 	} {
 		if !strings.Contains(message, want) {
 			t.Errorf("error %q does not contain %q", message, want)
@@ -174,6 +175,46 @@ func TestReadTooLargeErrorSuggestsExecutableBashRange(t *testing.T) {
 	}
 	if strings.Contains(message, hostPath) {
 		t.Fatalf("error leaked resolved host path: %q", message)
+	}
+}
+
+func TestOversizedReadSliceCommandExecutesForAgentPaths(t *testing.T) {
+	t.Setenv("STELLA_TOOL_MAX_BYTES", "500")
+	root := t.TempDir()
+	home := filepath.Join(root, "home dir")
+	if err := os.Mkdir(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name     string
+		toolPath string
+		filePath string
+	}{
+		{name: "ordinary", toolPath: filepath.Join(root, "plain.csv"), filePath: filepath.Join(root, "plain.csv")},
+		{name: "space", toolPath: filepath.Join(root, "input file.csv"), filePath: filepath.Join(root, "input file.csv")},
+		{name: "single quote", toolPath: filepath.Join(root, "input'file.csv"), filePath: filepath.Join(root, "input'file.csv")},
+		{name: "leading HOME", toolPath: "$HOME/home file's.csv", filePath: filepath.Join(home, "home file's.csv")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := os.WriteFile(tt.filePath, []byte("line1\nline2\nline3\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			command, sliceLines, _ := oversizedReadSliceCommand(tt.toolPath)
+			if sliceLines != 2 {
+				t.Fatalf("slice lines = %d, want 2", sliceLines)
+			}
+			cmd := exec.Command("sh", "-c", command)
+			cmd.Env = []string{"HOME=" + home, "PATH=" + os.Getenv("PATH")}
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("command %q failed: %v\n%s", command, err, output)
+			}
+			if got, want := string(output), "line1\nline2\n"; got != want {
+				t.Fatalf("command %q output = %q, want %q", command, got, want)
+			}
+		})
 	}
 }
 

--- a/internal/agent/sandbox/read_test.go
+++ b/internal/agent/sandbox/read_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"fmt"
 	"image"
 	"image/color"
 	"image/png"
@@ -34,6 +35,13 @@ func writePNG(t *testing.T, path string, w, h int) {
 		t.Fatalf("write png: %v", err)
 	}
 }
+
+type readErrorFiles struct {
+	pkgsandbox.FileAccess
+	err error
+}
+
+func (f readErrorFiles) ReadFile(string) ([]byte, error) { return nil, f.err }
 
 func newTestReadTool(t *testing.T, projectRoot string) pkgtools.Tool {
 	t.Helper()
@@ -125,6 +133,41 @@ func TestReadImageCanonicalResultKeepsOriginalForTransform(t *testing.T) {
 				t.Fatal("canonical read changed original bytes")
 			}
 		}
+	}
+}
+
+func TestReadTooLargeErrorSuggestsExecutableBashRange(t *testing.T) {
+	const (
+		publicPath = "/app/input file's.csv"
+		hostPath   = "/private/host/eval/input.csv"
+		size       = int64(51_066_691)
+		limit      = int64(33_554_432)
+	)
+	host := &stubHost{
+		workingDir: "/app",
+		resolvePath: func(string) (string, error) {
+			return hostPath, nil
+		},
+		files: readErrorFiles{err: &pkgsandbox.FileTooLargeError{Size: size, Limit: limit}},
+	}
+
+	_, err := newReadTool(host).Execute(context.Background(), map[string]any{"path": publicPath})
+	if err == nil {
+		t.Fatal("expected oversized read to fail")
+	}
+	message := err.Error()
+	for _, want := range []string{
+		publicPath,
+		"51066691 bytes",
+		"33554432-byte read cap",
+		fmt.Sprintf("bash(command=%q)", "sed -n '1,1000p' -- "+shellQuote(publicPath)),
+	} {
+		if !strings.Contains(message, want) {
+			t.Errorf("error %q does not contain %q", message, want)
+		}
+	}
+	if strings.Contains(message, hostPath) {
+		t.Fatalf("error leaked resolved host path: %q", message)
 	}
 }
 

--- a/pkg/sandbox/session.go
+++ b/pkg/sandbox/session.go
@@ -3,6 +3,7 @@ package sandbox
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"time"
@@ -125,6 +126,18 @@ type ProjectedFile struct {
 // ErrProjectionConflict reports that an exact projection path already exists
 // with a different tree, mode, or content.
 var ErrProjectionConflict = errors.New("sandbox: projection conflicts with exact files")
+
+// FileTooLargeError reports that a backend refused to transfer a complete file.
+// It deliberately carries no path so provider-internal filesystem coordinates
+// cannot cross the sandbox boundary; the caller already has the public path.
+type FileTooLargeError struct {
+	Size  int64
+	Limit int64
+}
+
+func (e *FileTooLargeError) Error() string {
+	return fmt.Sprintf("sandbox: file is %d bytes, over the %d-byte transfer limit", e.Size, e.Limit)
+}
 
 // FileAccess is the narrow data-filesystem capability used by prompt
 // construction, core tools, and exact per-Session projections. Paths use the

--- a/pkg/tools/truncate.go
+++ b/pkg/tools/truncate.go
@@ -63,6 +63,12 @@ func maxBytes() int {
 	return defaultMaxBytes
 }
 
+// OutputByteLimit returns the current per-call byte budget for textual tool
+// output, including an operator override when configured.
+func OutputByteLimit() int {
+	return maxBytes()
+}
+
 func maxTurnBytes() int {
 	if v := os.Getenv("STELLA_TOOL_MAX_TURN_BYTES"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {

--- a/pkg/tools/truncate_test.go
+++ b/pkg/tools/truncate_test.go
@@ -196,6 +196,13 @@ func TestMaxBytesDefault(t *testing.T) {
 	}
 }
 
+func TestOutputByteLimitUsesCurrentPerCallBudget(t *testing.T) {
+	t.Setenv("STELLA_TOOL_MAX_BYTES", "12345")
+	if got := OutputByteLimit(); got != 12345 {
+		t.Errorf("OutputByteLimit = %d, want 12345", got)
+	}
+}
+
 func TestMaxLinesInvalidEnvVar(t *testing.T) {
 	t.Setenv("STELLA_TOOL_MAX_LINES", "notanumber")
 	got := maxLines()

--- a/plugins/sandbox/bridge/client.go
+++ b/plugins/sandbox/bridge/client.go
@@ -53,6 +53,7 @@ type response struct {
 	Entries    []dirEntry `json:"entries,omitempty"`
 	IsDir      bool       `json:"is_dir,omitempty"`
 	Size       int64      `json:"size,omitempty"`
+	Limit      int64      `json:"limit,omitempty"`
 }
 
 // Error codes the bridge server may return; mapped to fs-style errors so core
@@ -62,6 +63,7 @@ const (
 	codeIsDir    = "is_dir"
 	codeNonce    = "bad_nonce"
 	codeConflict = "conflict"
+	codeTooLarge = "too_large"
 )
 
 var errBadNonce = errors.New("bridge: nonce rejected by bridge (binding mismatch)")

--- a/plugins/sandbox/bridge/contract_test.go
+++ b/plugins/sandbox/bridge/contract_test.go
@@ -175,6 +175,20 @@ func TestBridgeContract(t *testing.T) {
 		t.Fatalf("missing stat: want ErrNotExist, got %v", err)
 	}
 
+	// Oversized reads preserve structured size metadata without exposing a path.
+	res, err = session.Exec(ctx, `truncate -s 33554433 "/app/large.bin"`, execOptions)
+	if err != nil || res.ExitCode != 0 {
+		t.Fatalf("create oversized file: %v %+v", err, res)
+	}
+	_, err = files.ReadFile("/app/large.bin")
+	var tooLarge *sandboxpkg.FileTooLargeError
+	if !errors.As(err, &tooLarge) || tooLarge.Size != 33_554_433 || tooLarge.Limit != 33_554_432 {
+		t.Fatalf("oversized read: want structured size error, got %v", err)
+	}
+	if strings.Contains(err.Error(), "/app/large.bin") {
+		t.Fatalf("oversized read leaked bridge path: %v", err)
+	}
+
 	// Projection: publish, idempotent republish, conflict on different content.
 	tree := []sandboxpkg.ProjectedFile{
 		{Path: "SKILL.md", Content: []byte("# skill\n"), Mode: 0o644},

--- a/plugins/sandbox/bridge/session.go
+++ b/plugins/sandbox/bridge/session.go
@@ -212,17 +212,25 @@ func (f *fileAccess) call(op string, req request) (response, error) {
 	defer cancel()
 	resp, err := f.s.client.call(ctx, req)
 	if err != nil {
-		switch resp.Code {
-		case codeNotFound:
-			return resp, &fs.PathError{Op: op, Path: req.Path, Err: fs.ErrNotExist}
-		case codeIsDir:
-			return resp, &fs.PathError{Op: op, Path: req.Path, Err: errors.New("is a directory")}
-		case codeConflict:
-			return resp, fmt.Errorf("%w: %s", sandboxpkg.ErrProjectionConflict, resp.Error)
-		}
-		return resp, err
+		return resp, mapFileCallError(resp, req, err)
 	}
 	return resp, nil
+}
+
+func mapFileCallError(resp response, req request, err error) error {
+	switch resp.Code {
+	case codeNotFound:
+		return &fs.PathError{Op: req.Op, Path: req.Path, Err: fs.ErrNotExist}
+	case codeIsDir:
+		return &fs.PathError{Op: req.Op, Path: req.Path, Err: errors.New("is a directory")}
+	case codeConflict:
+		return fmt.Errorf("%w: %s", sandboxpkg.ErrProjectionConflict, resp.Error)
+	case codeTooLarge:
+		if resp.Size > 0 && resp.Limit > 0 {
+			return &sandboxpkg.FileTooLargeError{Size: resp.Size, Limit: resp.Limit}
+		}
+	}
+	return err
 }
 
 func (f *fileAccess) ReadFile(name string) ([]byte, error) {

--- a/plugins/sandbox/bridge/session_test.go
+++ b/plugins/sandbox/bridge/session_test.go
@@ -1,0 +1,37 @@
+package bridge
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	sandboxpkg "github.com/CherryHQ/stella/pkg/sandbox"
+)
+
+func TestMapFileCallErrorMapsStructuredTooLargeResponse(t *testing.T) {
+	original := errors.New("bridge: read_file failed")
+	err := mapFileCallError(response{
+		Code:  codeTooLarge,
+		Size:  51_066_691,
+		Limit: 33_554_432,
+	}, request{Op: "read_file", Path: "/app/input.csv"}, original)
+
+	var tooLarge *sandboxpkg.FileTooLargeError
+	if !errors.As(err, &tooLarge) {
+		t.Fatalf("error = %v, want FileTooLargeError", err)
+	}
+	if tooLarge.Size != 51_066_691 || tooLarge.Limit != 33_554_432 {
+		t.Fatalf("FileTooLargeError = %+v", tooLarge)
+	}
+	if got := err.Error(); got == "" || strings.Contains(got, "/app/input.csv") {
+		t.Fatalf("generic error leaked bridge path: %q", got)
+	}
+}
+
+func TestMapFileCallErrorLeavesUnstructuredTooLargeResponseGeneric(t *testing.T) {
+	original := errors.New("bridge: project: request exceeds cap")
+	err := mapFileCallError(response{Code: codeTooLarge}, request{Op: "project"}, original)
+	if !errors.Is(err, original) {
+		t.Fatalf("error = %v, want original generic transport error", err)
+	}
+}

--- a/test/evals/harbor/stella_harbor/bridge.py
+++ b/test/evals/harbor/stella_harbor/bridge.py
@@ -32,9 +32,10 @@ MAX_PAYLOAD = 32 << 20
 
 
 class BridgeError(Exception):
-    def __init__(self, code: str, message: str):
+    def __init__(self, code: str, message: str, **details: int):
         super().__init__(message)
         self.code = code
+        self.details = details
 
 
 def _is_timeout(exc: BaseException, timeout_sec: int) -> bool:
@@ -220,7 +221,7 @@ class BridgeServer:
             else:
                 resp = await self._dispatch(req)
         except BridgeError as e:
-            resp = {"ok": False, "code": e.code, "error": str(e)}
+            resp = {"ok": False, "code": e.code, "error": str(e), **e.details}
         except Exception as e:  # noqa: BLE001 - surface any failure to the caller
             resp = {"ok": False, "code": "internal", "error": f"{type(e).__name__}: {e}"}
         try:
@@ -363,7 +364,12 @@ class BridgeServer:
         if st["is_dir"]:
             raise BridgeError("is_dir", f"{req['path']}: is a directory")
         if st["size"] > MAX_PAYLOAD:
-            raise BridgeError("too_large", f"{req['path']}: {st['size']} bytes exceeds cap {MAX_PAYLOAD}")
+            raise BridgeError(
+                "too_large",
+                f"{req['path']}: {st['size']} bytes exceeds cap {MAX_PAYLOAD}",
+                size=st["size"],
+                limit=MAX_PAYLOAD,
+            )
         source = await self._resolve_symlink(req["path"])
         with tempfile.TemporaryDirectory(prefix="stella-bridge-") as td:
             local = Path(td) / "f"

--- a/test/evals/harbor/tests/test_bridge.py
+++ b/test/evals/harbor/tests/test_bridge.py
@@ -55,6 +55,48 @@ def test_read_file_downloads_the_symlink_target_not_the_link(tmp_path):
     assert base64.b64decode(out["data"]) == b"hello"
 
 
+def test_read_file_too_large_response_includes_structured_size_and_limit(tmp_path):
+    from stella_harbor.bridge import MAX_PAYLOAD
+
+    env = _FakeEnv()
+
+    async def exec_with_large_stat(command: str, **kwargs) -> _Result:
+        if "-d " in command:
+            return _Result(stdout=f"f {MAX_PAYLOAD + 7}\n")
+        return _Result()
+
+    env.exec = exec_with_large_stat  # type: ignore[method-assign]
+    server = _ready_server(env, tmp_path)
+
+    class _Writer:
+        def __init__(self) -> None:
+            self.data = b""
+
+        def write(self, data: bytes) -> None:
+            self.data += data
+
+        async def drain(self) -> None:
+            pass
+
+        def close(self) -> None:
+            pass
+
+    async def call_server() -> dict:
+        reader = asyncio.StreamReader()
+        reader.feed_data(json.dumps({"nonce": server.nonce, "op": "read_file", "path": "/app/input.csv"}).encode())
+        reader.feed_eof()
+        writer = _Writer()
+        await server._handle(reader, writer)  # type: ignore[arg-type]
+        return json.loads(writer.data)
+
+    response = asyncio.run(call_server())
+
+    assert response["code"] == "too_large"
+    assert response["size"] == MAX_PAYLOAD + 7
+    assert response["limit"] == MAX_PAYLOAD
+    assert "/app/input.csv" in response["error"]
+
+
 def test_read_file_falls_back_to_the_original_path_when_readlink_is_absent(tmp_path):
     env = _FakeEnv()
 


### PR DESCRIPTION
## What

Make oversized `read` failures report the file's actual size, the read cap, and a directly executable `bash(command=...)` call that reads a conservative line slice with `sed`.

## Why

The Harbor bridge refuses files larger than 32 MiB, but its generic error gave the agent no recovery step, causing identical retries. Although the `read` schema exposes `offset` and `limit`, the implementation currently reads the whole file before paginating, so recommending those parameters would still fail.

## How

- Carry bridge `read_file` size and limit metadata as a provider-neutral `sandbox.FileTooLargeError` with no path.
- Add the agent-facing recovery text only in the `read` tool layer, not the generic bridge transport.
- Derive the suggested line count from the current per-call tool output budget, using a documented conservative estimate of 250 bytes per line. The default 50 KiB budget produces a 204-line starting slice and follows `STELLA_TOOL_MAX_BYTES` overrides.
- Tell the agent explicitly that the command reads only an initial slice and remains subject to the per-call output cap; #1118's actionable truncation marker handles wider-than-estimated rows.
- Build the portable `sed -n '1,<derived>p' < <operand>` form. Ordinary paths are shell-quoted; an allowed leading filesystem variable remains expandable with a separately quoted literal suffix, such as `"$HOME"/'x.csv'`.
- Leave unstructured `too_large` responses and every non-read payload path on their existing generic error behavior.
- Do not clamp, partially return, or otherwise change read behavior.

## Test

- `mise run format && mise run build && mise run test` passed after the latest change.
- `go test -tags evalbridge ./plugins/sandbox/bridge/ -run TestBridgeContract -v` passed against a real container, including a 33,554,433-byte file over the 33,554,432-byte cap.
- `cd test/evals/harbor && uv run pytest tests/test_bridge.py` passed, 13 tests.
- Focused tests execute the generated command with the host shell and assert exit 0 plus the exact two-line output for ordinary paths, spaces, single quotes, and a leading `$HOME` whose value contains a space. Other tests prove the error does not expose the resolved host path or reinterpret unstructured payload-limit failures.
- Quick eval was skipped because neither this COW checkout nor its source checkout has the required gitignored `./.env`; no credentials were requested or logged.

## Refs

Refs #1122

## Checklist

- [x] The PR links a GitHub issue, or states why the fix is small enough not to need one.
- [x] I added or updated focused tests for changed non-trivial behavior, or explained why none are needed.
- [x] No documentation change is needed; read behavior is unchanged.
- [x] I ran `mise run format && mise run build && mise run test`.

## Feishu Task

- [读取超限时告知 agent 如何分页](https://mcnnox2fhjfq.feishu.cn/record/EYSrrbvHjeGX5tcalKNc4vrNnfg) (#1122)