### PR TITLE
✨ feat(sandbox): make edit uniqueness recovery actionable

### DIFF
--- a/internal/agent/sandbox/edit.go
+++ b/internal/agent/sandbox/edit.go
@@ -11,8 +11,10 @@ import (
 )
 
 const (
-	editMatchPreviewLimit = 5
-	editMatchPreviewWidth = 120
+	editMatchPreviewLimit       = 5
+	editMatchPreviewWidth       = 120
+	editMatchPreviewBeforeBytes = 32
+	editMatchPreviewAfterBytes  = editMatchPreviewWidth * utf8.UTFMax
 )
 
 func editDefinition() pkgtools.Definition {
@@ -129,15 +131,49 @@ func editMatchPreview(content string, offset int) (int, int, string) {
 	lineStart := strings.LastIndex(content[:offset], "\n") + 1
 	column := utf8.RuneCountInString(content[lineStart:offset]) + 1
 	lineEnd := len(content)
-	if relative := strings.IndexByte(content[lineStart:], '\n'); relative >= 0 {
-		lineEnd = lineStart + relative
+	if relative := strings.IndexByte(content[offset:], '\n'); relative >= 0 {
+		lineEnd = offset + relative
 	}
-	preview := strings.TrimSuffix(content[lineStart:lineEnd], "\r")
+
+	windowStart := max(lineStart, offset-editMatchPreviewBeforeBytes)
+	for windowStart < offset && !utf8.RuneStart(content[windowStart]) {
+		windowStart++
+	}
+	windowEnd := min(lineEnd, offset+editMatchPreviewAfterBytes)
+	for windowEnd > offset && windowEnd < len(content) && !utf8.RuneStart(content[windowEnd]) {
+		windowEnd--
+	}
+
+	preview := strings.TrimSuffix(content[windowStart:windowEnd], "\r")
 	preview = strings.ReplaceAll(preview, "\t", `\t`)
 	preview = strings.ReplaceAll(preview, "\r", `\r`)
 	runes := []rune(preview)
-	if len(runes) > editMatchPreviewWidth {
-		preview = string(runes[:editMatchPreviewWidth-1]) + "…"
+	prefixOmitted := windowStart > lineStart
+	suffixOmitted := windowEnd < lineEnd
+	available := editMatchPreviewWidth
+	if prefixOmitted {
+		available--
 	}
-	return line, column, preview
+	if suffixOmitted {
+		available--
+	}
+	if len(runes) > available && !suffixOmitted {
+		suffixOmitted = true
+		available--
+	}
+	if len(runes) > available {
+		runes = runes[:available]
+	}
+
+	var bounded strings.Builder
+	if prefixOmitted {
+		bounded.WriteRune('…')
+	}
+	for _, r := range runes {
+		bounded.WriteRune(r)
+	}
+	if suffixOmitted {
+		bounded.WriteRune('…')
+	}
+	return line, column, bounded.String()
 }

--- a/internal/agent/sandbox/edit.go
+++ b/internal/agent/sandbox/edit.go
@@ -4,9 +4,15 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	pkgsandbox "github.com/CherryHQ/stella/pkg/sandbox"
 	pkgtools "github.com/CherryHQ/stella/pkg/tools"
+)
+
+const (
+	editMatchPreviewLimit = 5
+	editMatchPreviewWidth = 120
 )
 
 func editDefinition() pkgtools.Definition {
@@ -16,9 +22,10 @@ func editDefinition() pkgtools.Definition {
 		InputSchema: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
-				"path":       map[string]any{"type": "string", "description": "Relative paths are working/project files. Supported roots: $HOME, $STELLA_ASSETS_DIR, and $TMPDIR. Default work to $HOME; save final user deliverables in $STELLA_ASSETS_DIR when available."},
-				"old_string": map[string]any{"type": "string", "description": "The exact text to find and replace. Must match the file content exactly."},
-				"new_string": map[string]any{"type": "string", "description": "The replacement text."},
+				"path":        map[string]any{"type": "string", "description": "Relative paths are working/project files. Supported roots: $HOME, $STELLA_ASSETS_DIR, and $TMPDIR. Default work to $HOME; save final user deliverables in $STELLA_ASSETS_DIR when available."},
+				"old_string":  map[string]any{"type": "string", "description": "The exact text to find and replace. Must match the file content exactly."},
+				"new_string":  map[string]any{"type": "string", "description": "The replacement text."},
+				"replace_all": map[string]any{"type": "boolean", "default": false, "description": "Replace every occurrence of old_string. Defaults to false; when false, old_string must be unique."},
 			},
 			"required": []string{"path", "old_string", "new_string"},
 		},
@@ -60,17 +67,77 @@ func (t *hostEditTool) Execute(ctx context.Context, args map[string]any) (string
 		return "", fmt.Errorf("edit: read %s: %w", path, err)
 	}
 	fileContent := string(raw)
-	count := strings.Count(fileContent, oldStr)
+	count, matchOffsets := editMatchOffsets(fileContent, oldStr)
 	if count == 0 {
 		return "", fmt.Errorf("edit: old_string not found in %s", path)
 	}
-	if count > 1 {
-		return "", fmt.Errorf("edit: old_string matches %d times in %s (must be unique)", count, path)
+
+	replaceAll, _ := args["replace_all"].(bool)
+	if count > 1 && !replaceAll {
+		return "", fmt.Errorf("%s", editUniquenessError(path, fileContent, count, matchOffsets))
 	}
 
-	updated := strings.Replace(fileContent, oldStr, newStr, 1)
+	replacements := 1
+	if replaceAll {
+		replacements = count
+	}
+	updated := strings.Replace(fileContent, oldStr, newStr, replacements)
 	if err := view.Files.WriteFile(resolvedPath, []byte(updated), 0o644); err != nil {
 		return "", fmt.Errorf("edit %s: %w", path, err)
 	}
+	if replaceAll {
+		occurrence := "occurrence"
+		if count != 1 {
+			occurrence += "s"
+		}
+		return fmt.Sprintf("Edited %s: replaced %d %s", path, count, occurrence), nil
+	}
 	return fmt.Sprintf("Edited %s", path), nil
+}
+
+func editMatchOffsets(content, old string) (int, []int) {
+	count := 0
+	offsets := make([]int, 0, editMatchPreviewLimit)
+	for searchFrom := 0; searchFrom <= len(content)-len(old); {
+		relative := strings.Index(content[searchFrom:], old)
+		if relative < 0 {
+			break
+		}
+		offset := searchFrom + relative
+		count++
+		if len(offsets) < editMatchPreviewLimit {
+			offsets = append(offsets, offset)
+		}
+		searchFrom = offset + len(old)
+	}
+	return count, offsets
+}
+
+func editUniquenessError(path, content string, count int, offsets []int) string {
+	var message strings.Builder
+	fmt.Fprintf(&message, "edit: old_string matches %d times in %s (must be unique). Showing first %d of %d matches:", count, path, len(offsets), count)
+	for i, offset := range offsets {
+		line, column, preview := editMatchPreview(content, offset)
+		fmt.Fprintf(&message, "\n%d. line %d, column %d: %s", i+1, line, column, preview)
+	}
+	fmt.Fprintf(&message, "\nUse a more specific old_string, or set replace_all: true to replace all %d matches.", count)
+	return message.String()
+}
+
+func editMatchPreview(content string, offset int) (int, int, string) {
+	line := strings.Count(content[:offset], "\n") + 1
+	lineStart := strings.LastIndex(content[:offset], "\n") + 1
+	column := utf8.RuneCountInString(content[lineStart:offset]) + 1
+	lineEnd := len(content)
+	if relative := strings.IndexByte(content[lineStart:], '\n'); relative >= 0 {
+		lineEnd = lineStart + relative
+	}
+	preview := strings.TrimSuffix(content[lineStart:lineEnd], "\r")
+	preview = strings.ReplaceAll(preview, "\t", `\t`)
+	preview = strings.ReplaceAll(preview, "\r", `\r`)
+	runes := []rune(preview)
+	if len(runes) > editMatchPreviewWidth {
+		preview = string(runes[:editMatchPreviewWidth-1]) + "…"
+	}
+	return line, column, preview
 }

--- a/internal/agent/sandbox/edit_test.go
+++ b/internal/agent/sandbox/edit_test.go
@@ -1,0 +1,254 @@
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestEditDefinitionIncludesReplaceAllDefaultFalse(t *testing.T) {
+	properties := editDefinition().InputSchema["properties"].(map[string]any)
+	replaceAll, ok := properties["replace_all"].(map[string]any)
+	if !ok {
+		t.Fatal("edit schema is missing replace_all")
+	}
+	if got := replaceAll["type"]; got != "boolean" {
+		t.Fatalf("replace_all type = %v, want boolean", got)
+	}
+	if got, ok := replaceAll["default"].(bool); !ok || got {
+		t.Fatalf("replace_all default = %v, want false", replaceAll["default"])
+	}
+}
+
+func TestEditUniquenessErrorReportsMatchesFromFile(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		oldString   string
+		wantDetails []string
+		wantAbsent  []string
+	}{
+		{
+			name:      "matches on different lines",
+			content:   "header\nneedle alpha\nmiddle\nneedle beta\nfooter\n",
+			oldString: "needle",
+			wantDetails: []string{
+				"Showing first 2 of 2 matches:",
+				"1. line 2, column 1: needle alpha",
+				"2. line 4, column 1: needle beta",
+				"replace_all: true to replace all 2 matches",
+			},
+		},
+		{
+			name:      "two matches on the same line",
+			content:   "needle left needle right\n",
+			oldString: "needle",
+			wantDetails: []string{
+				"Showing first 2 of 2 matches:",
+				"1. line 1, column 1: needle left needle right",
+				"2. line 1, column 13: needle left needle right",
+			},
+		},
+		{
+			name:      "multiline old string with trailing newline",
+			content:   "header\nstart\nmiddle\nend\nseparator\nstart\nmiddle\nend\n",
+			oldString: "start\nmiddle\n",
+			wantDetails: []string{
+				"1. line 2, column 1: start",
+				"2. line 6, column 1: start",
+			},
+		},
+		{
+			name:      "CRLF multiline matches",
+			content:   "header\r\nstart\r\nnext\r\nseparator\r\nstart\r\nnext\r\n",
+			oldString: "start\r\nnext",
+			wantDetails: []string{
+				"1. line 2, column 1: start",
+				"2. line 5, column 1: start",
+			},
+			wantAbsent: []string{"column 1: start\\r"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, tool := newEditTestFile(t, tt.content)
+			_, err := tool.Execute(context.Background(), map[string]any{
+				"path":       path,
+				"old_string": tt.oldString,
+				"new_string": "replacement",
+			})
+			if err == nil {
+				t.Fatal("edit succeeded with a non-unique old_string")
+			}
+			message := err.Error()
+			for _, want := range tt.wantDetails {
+				if !strings.Contains(message, want) {
+					t.Errorf("error missing %q:\n%s", want, message)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(message, absent) {
+					t.Errorf("error unexpectedly contains %q:\n%s", absent, message)
+				}
+			}
+			got, readErr := os.ReadFile(path)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if string(got) != tt.content {
+				t.Fatalf("failed uniqueness check changed file to %q", got)
+			}
+		})
+	}
+}
+
+func TestEditCRLFLineNumbersAlignWithReadOffsets(t *testing.T) {
+	content := "header\r\nstart\r\nnext\r\nseparator\r\nstart\r\nnext\r\n"
+	path, tool := newEditTestFile(t, content)
+	_, err := tool.Execute(context.Background(), map[string]any{
+		"path":       path,
+		"old_string": "start\r\nnext",
+		"new_string": "replacement",
+	})
+	if err == nil || !strings.Contains(err.Error(), "2. line 5, column 1: start") {
+		t.Fatalf("edit error = %v, want second match on line 5", err)
+	}
+
+	got, err := newReadTool(&stubHost{}).Execute(context.Background(), map[string]any{
+		"path":   path,
+		"offset": 5,
+		"limit":  1,
+	})
+	if err != nil {
+		t.Fatalf("read line 5: %v", err)
+	}
+	if !strings.HasPrefix(got, "start\r\n") || strings.Contains(got, "next") {
+		t.Fatalf("read offset 5 = %q, want only the CRLF start line before any pagination hint", got)
+	}
+}
+
+func TestEditUniquenessErrorBoundsMatchListAndPreview(t *testing.T) {
+	t.Run("lists only first five matches", func(t *testing.T) {
+		var content strings.Builder
+		for i := 1; i <= 7; i++ {
+			fmt.Fprintf(&content, "match %d: needle\n", i)
+		}
+		path, tool := newEditTestFile(t, content.String())
+		_, err := tool.Execute(context.Background(), map[string]any{
+			"path":       path,
+			"old_string": "needle",
+			"new_string": "replacement",
+		})
+		if err == nil {
+			t.Fatal("edit succeeded with seven matches")
+		}
+		message := err.Error()
+		for _, want := range []string{
+			"old_string matches 7 times",
+			"Showing first 5 of 7 matches:",
+			"5. line 5, column 10: match 5: needle",
+			"replace_all: true to replace all 7 matches",
+		} {
+			if !strings.Contains(message, want) {
+				t.Errorf("error missing %q:\n%s", want, message)
+			}
+		}
+		for _, absent := range []string{"match 6: needle", "match 7: needle", "6. line"} {
+			if strings.Contains(message, absent) {
+				t.Errorf("bounded error unexpectedly contains %q:\n%s", absent, message)
+			}
+		}
+	})
+
+	t.Run("truncates long previews to fixed width", func(t *testing.T) {
+		line := "needle" + strings.Repeat("界", 150)
+		path, tool := newEditTestFile(t, line+"\n"+line+"\n")
+		_, err := tool.Execute(context.Background(), map[string]any{
+			"path":       path,
+			"old_string": "needle",
+			"new_string": "replacement",
+		})
+		if err == nil {
+			t.Fatal("edit succeeded with two long-line matches")
+		}
+		previewPrefix := "1. line 1, column 1: "
+		start := strings.Index(err.Error(), previewPrefix)
+		if start < 0 {
+			t.Fatalf("error missing first preview:\n%s", err)
+		}
+		preview := err.Error()[start+len(previewPrefix):]
+		preview = strings.SplitN(preview, "\n", 2)[0]
+		if got := utf8.RuneCountInString(preview); got != editMatchPreviewWidth {
+			t.Fatalf("preview width = %d runes, want %d: %q", got, editMatchPreviewWidth, preview)
+		}
+		if !strings.HasSuffix(preview, "…") {
+			t.Fatalf("truncated preview has no ellipsis: %q", preview)
+		}
+		if strings.Contains(preview, strings.Repeat("界", 120)) {
+			t.Fatalf("preview retained content beyond the fixed width: %q", preview)
+		}
+	})
+}
+
+func TestEditReplaceAllReplacesEveryOccurrenceAndReportsCount(t *testing.T) {
+	t.Run("multiple non-overlapping occurrences", func(t *testing.T) {
+		path, tool := newEditTestFile(t, "np.int first\nnp.int second np.int\n")
+		result, err := tool.Execute(context.Background(), map[string]any{
+			"path":        path,
+			"old_string":  "np.int",
+			"new_string":  "np.int_",
+			"replace_all": true,
+		})
+		if err != nil {
+			t.Fatalf("replace all: %v", err)
+		}
+		if want := "replaced 3 occurrences"; !strings.Contains(result, want) {
+			t.Fatalf("result = %q, missing %q", result, want)
+		}
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := "np.int_ first\nnp.int_ second np.int_\n"
+		if string(got) != want {
+			t.Fatalf("file content = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("overlapping candidates count like strings replace", func(t *testing.T) {
+		path, tool := newEditTestFile(t, "aaa")
+		result, err := tool.Execute(context.Background(), map[string]any{
+			"path":        path,
+			"old_string":  "aa",
+			"new_string":  "x",
+			"replace_all": true,
+		})
+		if err != nil {
+			t.Fatalf("replace overlapping candidate: %v", err)
+		}
+		if want := "replaced 1 occurrence"; !strings.Contains(result, want) {
+			t.Fatalf("result = %q, missing %q", result, want)
+		}
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != "xa" {
+			t.Fatalf("file content = %q, want %q", got, "xa")
+		}
+	})
+}
+
+func newEditTestFile(t *testing.T, content string) (string, *hostEditTool) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "edit.txt")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path, newEditTool(&stubHost{}).(*hostEditTool)
+}

--- a/internal/agent/sandbox/edit_test.go
+++ b/internal/agent/sandbox/edit_test.go
@@ -193,6 +193,52 @@ func TestEditUniquenessErrorBoundsMatchListAndPreview(t *testing.T) {
 			t.Fatalf("preview retained content beyond the fixed width: %q", preview)
 		}
 	})
+
+	t.Run("keeps a match beyond column 120 in its preview", func(t *testing.T) {
+		line := strings.Repeat("a", 200) + "needle" + strings.Repeat("b", 200)
+		path, tool := newEditTestFile(t, line+"\nneedle\n")
+		_, err := tool.Execute(context.Background(), map[string]any{
+			"path":       path,
+			"old_string": "needle",
+			"new_string": "replacement",
+		})
+		if err == nil {
+			t.Fatal("edit succeeded with two matches")
+		}
+		previewPrefix := "1. line 1, column 201: "
+		start := strings.Index(err.Error(), previewPrefix)
+		if start < 0 {
+			t.Fatalf("error missing far-column preview:\n%s", err)
+		}
+		preview := err.Error()[start+len(previewPrefix):]
+		preview = strings.SplitN(preview, "\n", 2)[0]
+		if !strings.HasPrefix(preview, "…") {
+			t.Fatalf("far-column preview has no omitted-prefix marker: %q", preview)
+		}
+		if !strings.Contains(preview, "needle") {
+			t.Fatalf("far-column preview omitted the match itself: %q", preview)
+		}
+	})
+
+	t.Run("keeps output bounded for a multi-megabyte line", func(t *testing.T) {
+		chunk := strings.Repeat("界", 350_000)
+		content := strings.Repeat(chunk+"needle", editMatchPreviewLimit) + chunk
+		path, tool := newEditTestFile(t, content)
+		_, err := tool.Execute(context.Background(), map[string]any{
+			"path":       path,
+			"old_string": "needle",
+			"new_string": "replacement",
+		})
+		if err == nil {
+			t.Fatal("edit succeeded with five matches on a multi-megabyte line")
+		}
+		// Five 120-rune previews are at most UTFMax bytes per rune; 1 KiB
+		// comfortably bounds the path, locations, counts, and guidance text.
+		limit := editMatchPreviewLimit*editMatchPreviewWidth*utf8.UTFMax + 1024
+		if got := len(err.Error()); got > limit {
+			t.Fatalf("uniqueness error is %d bytes, want at most %d", got, limit)
+		}
+	})
 }
 
 func TestEditReplaceAllReplacesEveryOccurrenceAndReportsCount(t *testing.T) {


### PR DESCRIPTION
## Summary

- make non-unique `edit` failures actionable with 1-based line and column locations plus bounded one-line previews
- cap diagnostics at the first 5 matches and 120 runes per preview, while reporting the total match count
- add `replace_all` (default `false`) and report the number of replacements on success
- preserve the default uniqueness guard and cover LF, CRLF, multiline, trailing-newline, same-line, truncation, and replacement-count behavior through real file-backed `Execute` tests

## Testing

- `mise run format`
- `mise run build`
- `mise run test`

## Refs

Refs #1076

## Feishu Task

- [edit 唯一性失败时给出可定位的匹配信息](https://mcnnox2fhjfq.feishu.cn/record/Iv8Grh3queo4NKcV9MncQceOnHe) (#1076)