### PR TITLE
✨ feat(evals): expose per-run tool exclusions

### DIFF
--- a/api/spec/components.yaml
+++ b/api/spec/components.yaml
@@ -4469,6 +4469,11 @@ components:
           items:
             $ref: "#/components/schemas/MessagePart"
           description: Message content parts (text, image, file)
+        excluded_tools:
+          type: array
+          items:
+            type: string
+          description: Tool names to hide for this run only. Omit or pass an empty array for no exclusions.
     SystemPromptResponse:
       type: object
       required: [system_prompt]

--- a/api/spec/domain/sessions/schemas.yaml
+++ b/api/spec/domain/sessions/schemas.yaml
@@ -94,6 +94,10 @@ components:
           items:
             $ref: "#/components/schemas/MessagePart"
           description: Message content parts (text, image, file)
+        excluded_tools:
+          type: array
+          items: { type: string }
+          description: Tool names to hide for this run only. Omit or pass an empty array for no exclusions.
 
     SystemPromptResponse:
       type: object

--- a/cmd/stella-eval-agent/main.go
+++ b/cmd/stella-eval-agent/main.go
@@ -55,6 +55,7 @@ type result struct {
 	ElapsedSec              float64        `json:"elapsed_sec"`
 	BridgeNonce             string         `json:"bridge_nonce"`
 	DisabledToolsCount      int            `json:"disabled_tools_count"`
+	ExcludedTools           []string       `json:"excluded_tools"`
 	MCPTools                []string       `json:"mcp_tools,omitempty"`
 	CapabilityProfileDigest string         `json:"capability_profile_digest"`
 	SandboxBackend          string         `json:"sandbox_backend,omitempty"`
@@ -126,8 +127,12 @@ func (c apiClient) call(ctx context.Context, method, path string, in, out any) e
 // streamTurn posts the instruction and consumes the SSE turn stream until the
 // server closes it. It returns the error events the turn emitted; the caller
 // decides whether those are product failures. Any transport error is returned.
-func (c apiClient) streamTurn(ctx context.Context, agentID, sessionID, instruction string) (events int, streamErrors []string, err error) {
-	body, err := json.Marshal(map[string]any{"parts": []map[string]string{{"type": "text", "text": instruction}}})
+func (c apiClient) streamTurn(ctx context.Context, agentID, sessionID, instruction string, excludedTools []string) (events int, streamErrors []string, err error) {
+	payload := map[string]any{"parts": []map[string]string{{"type": "text", "text": instruction}}}
+	if len(excludedTools) > 0 {
+		payload["excluded_tools"] = excludedTools
+	}
+	body, err := json.Marshal(payload)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -228,6 +233,24 @@ func sortStrings(v []string) {
 			}
 		}
 	}
+}
+
+func parseExcludedTools(value string) []string {
+	seen := make(map[string]struct{})
+	tools := make([]string, 0)
+	for name := range strings.SplitSeq(value, ",") {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		tools = append(tools, name)
+	}
+	sortStrings(tools)
+	return tools
 }
 
 func waitForTerminal(ctx context.Context, c apiClient, agentID, sessionID string) (string, error) {
@@ -389,7 +412,7 @@ func gitRevParseHead() string {
 }
 
 func run() int {
-	var baseURL, instructionFile, bindingFile, bindingDir, model, output, externalID, bundleDigest, trajectory string
+	var baseURL, instructionFile, bindingFile, bindingDir, model, output, externalID, bundleDigest, trajectory, excludedToolsCSV string
 	var deadlineSec int
 	var stopConfirmSec int
 	flag.StringVar(&baseURL, "stella-url", "", "Stella base URL")
@@ -401,6 +424,7 @@ func run() int {
 	flag.StringVar(&externalID, "user-id", "", "unique Harbor trial identifier")
 	flag.StringVar(&bundleDigest, "bundle-digest", "", "helper bundle SHA-256")
 	flag.StringVar(&trajectory, "trajectory", "", "write the verbatim message history here")
+	flag.StringVar(&excludedToolsCSV, "excluded-tools", "", "comma-separated tool names to hide for this run")
 	flag.IntVar(&deadlineSec, "deadline-seconds", 0, "working time in seconds, excluding the stop confirmation that follows it")
 	flag.IntVar(&stopConfirmSec, "stop-confirm-seconds", 0, "seconds allowed to confirm the session stopped after the deadline; must fit inside the caller's trial limit")
 	flag.Parse()
@@ -408,6 +432,7 @@ func run() int {
 		ToolCalls:       map[string]int{},
 		Model:           model,
 		CandidateCommit: gitRevParseHead(),
+		ExcludedTools:   parseExcludedTools(excludedToolsCSV),
 	}
 	start := time.Now()
 	// Phase boundaries are measured here rather than inferred from the message
@@ -583,7 +608,7 @@ func run() int {
 	phase(&r.Metrics.Timing.SetupMs)
 	turnCtx, cancel := context.WithDeadline(ctx, deadline)
 	defer cancel()
-	r.StreamEvents, r.StreamErrors, err = streamUser.streamTurn(turnCtx, r.AgentID, r.SessionID, string(instruction))
+	r.StreamEvents, r.StreamErrors, err = streamUser.streamTurn(turnCtx, r.AgentID, r.SessionID, string(instruction), r.ExcludedTools)
 	phase(&r.Metrics.Timing.TurnMs)
 	if errors.Is(err, context.DeadlineExceeded) {
 		return finishTimedOut(user, &r, trajectory, phase, confirmBudget)

--- a/cmd/stella-eval-agent/main_test.go
+++ b/cmd/stella-eval-agent/main_test.go
@@ -13,6 +13,47 @@ import (
 	"time"
 )
 
+func TestParseExcludedToolsCanonicalizesTheList(t *testing.T) {
+	got := parseExcludedTools(" write,read,write, ,edit ")
+	want := []string{"edit", "read", "write"}
+	if len(got) != len(want) {
+		t.Fatalf("parseExcludedTools = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("parseExcludedTools = %v, want %v", got, want)
+		}
+	}
+	if got := parseExcludedTools(""); len(got) != 0 || got == nil {
+		t.Fatalf("empty excluded tools = %#v, want non-nil empty list", got)
+	}
+}
+
+func TestStreamTurnPassesExcludedToolsInTheRunRequest(t *testing.T) {
+	var body struct {
+		ExcludedTools []string `json:"excluded_tools"`
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: [DONE]\\n\\n"))
+	}))
+	defer server.Close()
+
+	client := apiClient{baseURL: server.URL, token: "token", http: server.Client()}
+	if _, _, err := client.streamTurn(t.Context(), "agent", "session", "work", []string{"edit", "read", "write"}); err != nil {
+		t.Fatalf("streamTurn: %v", err)
+	}
+	want := []string{"edit", "read", "write"}
+	for i := range want {
+		if i >= len(body.ExcludedTools) || body.ExcludedTools[i] != want[i] {
+			t.Fatalf("request excluded_tools = %v, want %v", body.ExcludedTools, want)
+		}
+	}
+}
+
 func TestStopAndConfirmStopsBeforeObservingTerminalState(t *testing.T) {
 	stopped := false
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/agent/runner_impl_test.go
+++ b/internal/agent/runner_impl_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -74,6 +75,48 @@ func withTestRunnerPaths(t *testing.T, cfg runnerConfig) runnerConfig {
 	cfg.Sandbox.Paths.AgentRoot = workspace
 	cfg.Sandbox.Paths.UserRoot = userRoot
 	return cfg
+}
+
+func TestRunnerChatOmitsExcludedToolsFromProviderRequest(t *testing.T) {
+	reg := tools.NewRegistry()
+	for _, name := range []string{"bash", "read", "write", "edit"} {
+		reg.Register(&stubTool{name: name})
+	}
+
+	var got []string
+	stream := func(_ context.Context, _ ai.Model, aiCtx ai.Context, _ ai.StreamOptions) (providers.AssistantEventStream, error) {
+		for _, definition := range aiCtx.Tools {
+			got = append(got, definition.Name)
+		}
+		events := providers.NewChannelEventStream(1)
+		events.Emit(ai.EventStop{Reason: ai.StopReasonStop})
+		events.Finish(nil)
+		return events, nil
+	}
+	model := ai.Model{ID: "test", API: "test", Name: "test"}
+	coreRunner, err := newAgentRunner(stream, reg, model, ai.StreamOptions{}, "system", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("newAgentRunner: %v", err)
+	}
+	r := &runner{
+		runner:       coreRunner,
+		stream:       stream,
+		tools:        reg,
+		model:        model,
+		system:       "system",
+		chatTimeout:  time.Second,
+		lastActivity: time.Now(),
+	}
+
+	ctx := WithExcludedTools(context.Background(), "read", "write", "edit")
+	for event := range r.Chat(ctx, nil, "work") {
+		if event.Err != nil {
+			t.Fatalf("Chat: %v", event.Err)
+		}
+	}
+	if want := []string{"bash"}; !slices.Equal(got, want) {
+		t.Fatalf("provider tools = %v, want %v", got, want)
+	}
 }
 
 func TestFilterRunnerTools(t *testing.T) {

--- a/internal/agent/session/access/runtime.go
+++ b/internal/agent/session/access/runtime.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/CherryHQ/stella/internal/agent"
 	delegatetool "github.com/CherryHQ/stella/internal/agent/delegate"
+	agentruntime "github.com/CherryHQ/stella/internal/agent/runtime"
 	agentsession "github.com/CherryHQ/stella/internal/agent/session"
 	"github.com/CherryHQ/stella/internal/authz"
 	"github.com/CherryHQ/stella/internal/memory"
@@ -96,10 +97,11 @@ func (s *Service) BindRuntimeManager(runtime RuntimeManager) error {
 }
 
 type SendInput struct {
-	Authority authz.Authority
-	AgentID   string
-	SessionID string
-	Message   agent.MessageContent
+	Authority     authz.Authority
+	AgentID       string
+	SessionID     string
+	Message       agent.MessageContent
+	ExcludedTools []string
 }
 
 type SendResult struct {
@@ -138,14 +140,19 @@ func (s *Service) Send(ctx, runCtx context.Context, in SendInput) (SendResult, e
 	// Authorization and input resolution use the request context above. The
 	// admitted turn uses the server lifecycle context so losing the initiating
 	// HTTP/SSE connection only detaches that observer; it does not kill work.
+	var runtimeOpts []agentruntime.Option
+	if len(in.ExcludedTools) > 0 {
+		runtimeOpts = append(runtimeOpts, agentruntime.WithExcludedTools(in.ExcludedTools...))
+	}
 	ch := runtime.Chat(runCtx, agent.ChatRequest{
-		SessionID: in.SessionID,
-		UserID:    info.UserID,
-		AgentID:   info.AgentID,
-		Kind:      agentsession.Kind(info.Kind),
-		Channel:   agentsession.Channel(info.Channel),
-		Message:   in.Message,
-		Authority: in.Authority,
+		SessionID:   in.SessionID,
+		UserID:      info.UserID,
+		AgentID:     info.AgentID,
+		Kind:        agentsession.Kind(info.Kind),
+		Channel:     agentsession.Channel(info.Channel),
+		Message:     in.Message,
+		RuntimeOpts: runtimeOpts,
+		Authority:   in.Authority,
 	})
 	return SendResult{Events: relayEventsUntilDone(ctx, ch)}, nil
 }

--- a/internal/server/sessions.go
+++ b/internal/server/sessions.go
@@ -153,7 +153,17 @@ func (s *Server) SendSessionMessage(w http.ResponseWriter, r *http.Request, agen
 		return
 	}
 
-	result, err := s.sessionAccess.Send(r.Context(), s.turnContext(r.Context()), sessionaccess.SendInput{Authority: authority, AgentID: agentID, SessionID: sessionID, Message: message})
+	excludedTools := []string(nil)
+	if body.ExcludedTools != nil {
+		excludedTools = *body.ExcludedTools
+	}
+	result, err := s.sessionAccess.Send(r.Context(), s.turnContext(r.Context()), sessionaccess.SendInput{
+		Authority:     authority,
+		AgentID:       agentID,
+		SessionID:     sessionID,
+		Message:       message,
+		ExcludedTools: excludedTools,
+	})
 	if err != nil {
 		// An archived session is a state conflict, not a missing one: the client
 		// holds a session that was rotated away and needs to move to the new one

--- a/internal/server/sessions_archived_send_test.go
+++ b/internal/server/sessions_archived_send_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -14,10 +15,13 @@ import (
 
 	"github.com/CherryHQ/stella/internal/agent"
 	delegatetool "github.com/CherryHQ/stella/internal/agent/delegate"
+	agentruntime "github.com/CherryHQ/stella/internal/agent/runtime"
 	agentsession "github.com/CherryHQ/stella/internal/agent/session"
 	sessionaccess "github.com/CherryHQ/stella/internal/agent/session/access"
 	"github.com/CherryHQ/stella/internal/config"
 	"github.com/CherryHQ/stella/internal/memory"
+	"github.com/CherryHQ/stella/internal/memory/memorytest"
+	"github.com/CherryHQ/stella/pkg/ai"
 )
 
 // recordingRuntime stands in for the agent pool and reports whether a turn was
@@ -26,10 +30,17 @@ import (
 type recordingRuntime struct {
 	chats atomic.Int64
 	stops atomic.Int64
+	run   *agentruntime.Runtime
 }
 
-func (r *recordingRuntime) Chat(context.Context, agent.ChatRequest) <-chan agent.Event {
+func (r *recordingRuntime) Chat(ctx context.Context, req agent.ChatRequest) <-chan agent.Event {
 	r.chats.Add(1)
+	if r.run != nil {
+		return r.run.Chat(ctx, agentsession.Info{
+			ID: req.SessionID, UserID: req.UserID, AgentID: req.AgentID,
+			Kind: string(req.Kind), Channel: string(req.Channel),
+		}, req.Message, req.RuntimeOpts...)
+	}
 	ch := make(chan agent.Event)
 	close(ch)
 	return ch
@@ -63,6 +74,23 @@ func (r *recordingRuntime) CompactAuthorizedSession(context.Context, agentsessio
 	return "", nil
 }
 
+type excludedToolsRecordingRunner struct {
+	excluded chan []string
+}
+
+func (r *excludedToolsRecordingRunner) Chat(ctx context.Context, _ []ai.Message, _ agent.MessageContent) <-chan agent.Event {
+	r.excluded <- agent.ExcludedToolsFromContext(ctx)
+	ch := make(chan agent.Event)
+	close(ch)
+	return ch
+}
+
+func (*excludedToolsRecordingRunner) Alive() bool             { return true }
+func (*excludedToolsRecordingRunner) Busy() bool              { return false }
+func (*excludedToolsRecordingRunner) LastActivity() time.Time { return time.Now() }
+func (*excludedToolsRecordingRunner) SystemPrompt() string    { return "test" }
+func (*excludedToolsRecordingRunner) Close() error            { return nil }
+
 type recordingRuntimeManager struct {
 	rt      *recordingRuntime
 	lookups *atomic.Int64
@@ -80,6 +108,53 @@ func (m recordingRuntimeManager) Default() sessionaccess.RuntimeService {
 		m.lookups.Add(1)
 	}
 	return m.rt
+}
+
+func TestSendSessionMessageAppliesExcludedToolsToOnlyThatRun(t *testing.T) {
+	env := setupAdmin(t)
+	recorded := make(chan []string, 2)
+	runner := &excludedToolsRecordingRunner{excluded: recorded}
+	run, err := agentruntime.New(agentruntime.Config{
+		Memory: memorytest.New(),
+		NewRunner: func(context.Context, agentruntime.RunnerParams) (agentruntime.Runner, error) {
+			return runner, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("runtime.New: %v", err)
+	}
+	if err := env.deps.SessionAccess.BindRuntimeManager(recordingRuntimeManager{rt: &recordingRuntime{run: run}}); err != nil {
+		t.Fatalf("BindRuntimeManager: %v", err)
+	}
+	agentID := createAgentAsUser(t, env, env.bearerToken, "Excluded Tools Agent")
+	if _, err := env.db.Exec(context.Background(), `
+		INSERT INTO ctx_conversation (id, session_id, channel, kind, agent_id, user_id, last_active)
+		VALUES ($1, 'excluded-tools-run', 'web', 'chat', $2, $3, now())
+	`, uuid.NewString(), agentID, env.adminUser.ID); err != nil {
+		t.Fatalf("seed conversation: %v", err)
+	}
+
+	path := "/api/agents/" + agentID + "/sessions/excluded-tools-run/messages"
+	rr := doRequest(t, env, http.MethodPost, path, map[string]any{
+		"parts":          []map[string]string{{"type": "text", "text": "work"}},
+		"excluded_tools": []string{"read", "write", "edit"},
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("excluded send = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	if got, want := <-recorded, []string{"read", "write", "edit"}; !slices.Equal(got, want) {
+		t.Fatalf("runtime excluded tools = %v, want %v", got, want)
+	}
+
+	rr = doRequest(t, env, http.MethodPost, path, map[string]any{
+		"parts": []map[string]string{{"type": "text", "text": "work again"}},
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("ordinary send = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	if got := <-recorded; len(got) != 0 {
+		t.Fatalf("excluded tools leaked into the next run: %v", got)
+	}
 }
 
 // TestSendToArchivedSessionConflicts covers the archived-send answer at the

--- a/test/evals/harbor/README.md
+++ b/test/evals/harbor/README.md
@@ -25,6 +25,7 @@ where.
 mise run eval:loop -- --plan                                   # print the steps, run nothing
 mise run eval:loop -- -i terminal-bench/build-cython-ext -k 5  # one task, k=5
 mise run eval:loop -- --against dist/evals/jobs/loop-<earlier> # compare when it finishes
+mise run eval:loop -- --excluded-tools read,write,edit         # bash-only tool ablation
 ```
 
 Everything after `--` reaches `harbor run` verbatim. Task names must be
@@ -53,7 +54,10 @@ records what the comparator's fingerprint cannot derive from the artifacts
 alone: commit and dirty flag, the taskset path, the task names with their
 canonical SHA-256 (sorted, newline-joined, dataset-qualified), k, concurrency,
 model, the gateway host without its path or key, the verbatim Harbor arguments,
-and the UTC creation time.
+the OTel setting, the canonical per-run `excluded_tools` list, and the UTC
+creation time. The driver result carries the same exclusion list in the run
+fingerprint, so same-agent runs with different toolsets are rejected by the
+comparator.
 
 The first run of a task pays the image pull; Harbor has no separate prefetch,
 so a cold machine is slower on its first loop and comparable afterwards.

--- a/test/evals/harbor/loop.sh
+++ b/test/evals/harbor/loop.sh
@@ -24,7 +24,7 @@ MODEL=$PROVIDER_ID/$MODEL_ID
 READY_TIMEOUT=${STELLA_EVAL_READY_TIMEOUT:-120}
 # Any fixed port collides on someone's machine. The testbed port uses a kernel
 # allocation; Docker does the same for OTel's published ports below.
-TIER=full OTEL="" REUSE_TESTBED=0 PLAN=0 AGAINST=""
+TIER=full OTEL="" REUSE_TESTBED=0 PLAN=0 AGAINST="" EXCLUDED_TOOLS=""
 
 die() { echo "eval:loop: $*" >&2; exit 1; }
 step() { echo "==> $*"; }
@@ -32,12 +32,13 @@ free_port() { python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0)
 usage() {
   cat <<'EOF'
 usage: mise run eval:loop [-- [--tier quick|full] [--otel|--no-otel]
-                           [--reuse-testbed] [--plan] [--against REF_JOB]
-                           [harbor args...]]
+                           [--excluded-tools TOOL,...] [--reuse-testbed]
+                           [--plan] [--against REF_JOB] [harbor args...]]
 
   --tier TIER       quick (k=1, six tasks) or full (12-task baseline); default full
   --otel            force OTel on (quick defaults on, full defaults off)
   --no-otel         force OTel off
+  --excluded-tools  comma-separated tool names to hide for each session run
   --reuse-testbed   reuse a healthy, already-running bridge testbed with OTel off
   --plan            print the safe execution plan, run nothing
   --against REF     compare the completed job against REF_JOB
@@ -52,6 +53,8 @@ while [ $# -gt 0 ]; do
     --tier=*) TIER=${1#*=} ;;
     --otel) OTEL=1 ;;
     --no-otel) OTEL=0 ;;
+    --excluded-tools) [ $# -ge 2 ] || die "--excluded-tools needs a comma-separated list"; EXCLUDED_TOOLS=$2; shift ;;
+    --excluded-tools=*) EXCLUDED_TOOLS=${1#*=} ;;
     --reuse-testbed) REUSE_TESTBED=1 ;;
     --plan) PLAN=1 ;;
     --against) [ $# -ge 2 ] || die "--against needs a reference job directory"; AGAINST=$2; shift ;;
@@ -63,6 +66,11 @@ while [ $# -gt 0 ]; do
   shift
 done
 HARBOR_ARGS=("$@")
+EXCLUDED_TOOLS=$(python3 - "$EXCLUDED_TOOLS" <<'PY'
+import sys
+print(",".join(sorted({name.strip() for name in sys.argv[1].split(",") if name.strip()})))
+PY
+)
 case $TIER in
   quick) TASKSET=$HARBOR_DIR/tasksets/quick.yaml ;;
   full) TASKSET=$HARBOR_DIR/tasksets/loop.yaml ;;
@@ -141,6 +149,7 @@ if [ "$PLAN" = 1 ]; then
 plan only, nothing is executed.
 
 1. preflight   tier $TIER; taskset $TASKSET$( [ "$caller_concurrency" = 0 ] && echo "; explicit concurrency -n $TASKSET_CONCURRENCY" || echo "; caller-supplied concurrency" )
+               excluded tools: $( [ -n "$EXCLUDED_TOOLS" ] && echo "$EXCLUDED_TOOLS" || echo "none" )
                OPENAI_BASE_URL $gateway_state and OPENAI_API_KEY $key_state exported
 2. build       mise run eval:build, only when each binary is older than its sources
 3. otel        $( [ "$OTEL" = 1 ] && echo "docker run -d grafana/otel-lgtm; discover kernel-assigned OTLP HTTP and Grafana ports; install an OTel wrapper only around the private stellad copy under $TESTBED_ROOT. Before testbed start the wrapper exports the local OTLP settings, disables logs/metrics, raises OTEL_BSP_MAX_QUEUE_SIZE for the six-trial wave, and flushes once per second; shared dist/bin/stellad is never modified." || echo "disabled (full baseline default)" )
@@ -321,6 +330,7 @@ PY
 api POST /api/admin/provisioning-tokens cookie "$WORK/provisioning.json" >"$WORK/token.json"
 STELLA_EVAL_ADMIN_TOKEN=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["token"])' "$WORK/token.json")
 export STELLA_EVAL_ADMIN_TOKEN STELLA_EVAL_MODEL=$MODEL STELLA_EVAL_AGENT_BIN=$AGENT_BIN
+export STELLA_EVAL_EXCLUDED_TOOLS=$EXCLUDED_TOOLS
 
 step "running Harbor: $source_kind"; echo "    job: $JOB"
 # The first run of a task pays the image pull; Harbor has no separate prefetch.
@@ -331,7 +341,7 @@ uv run --project "$HARBOR_DIR" python -m stella_harbor.report "$JOB"
 if [ -n "$AGAINST" ]; then step "comparing against $AGAINST (candidate)"; uv run --project "$HARBOR_DIR" python -m stella_harbor.compare "$JOB" "$AGAINST" || true; fi
 
 : >"$WORK/args.txt"; [ -z "${HARBOR_ARGS[*]-}" ] || printf '%s\n' "${HARBOR_ARGS[@]}" >"$WORK/args.txt"
-TASKSET_PATH=$([ "$using_taskset" = 1 ] && echo "${TASKSET#"$REPO_ROOT"/}" || echo ""); export TASKSET_PATH JOB OTEL
+TASKSET_PATH=$([ "$using_taskset" = 1 ] && echo "${TASKSET#"$REPO_ROOT"/}" || echo ""); export TASKSET_PATH JOB OTEL EXCLUDED_TOOLS
 python3 - "$MANIFEST" "$WORK/config.json" "$WORK/args.txt" <<'PY'
 import datetime, hashlib, json, os, subprocess, sys
 from urllib.parse import urlsplit
@@ -343,7 +353,8 @@ git = lambda *a: subprocess.run(["git", *a], capture_output=True, text=True).std
 harbor_flags = [arg.split("=", 1)[0] for arg in open(sys.argv[3]).read().split() if arg.startswith("-")]
 json.dump({"created_at": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"), "job": os.path.basename(os.environ["JOB"]), "commit": os.environ["SNAPSHOT_COMMIT"], "dirty": bool(git("status", "--porcelain")), "taskset": os.environ["TASKSET_PATH"] or None, "task_names": tasks, # Canonical over sorted dataset-qualified names.
 "task_hash": "sha256:" + hashlib.sha256("\n".join(tasks).encode()).hexdigest(), "k": config.get("n_attempts", 1), "concurrency": config.get("n_concurrent_trials"), "model": os.environ["MODEL"], # Host only: the path can carry a deployment id.
-"gateway_host": urlsplit(os.environ["OPENAI_BASE_URL"]).hostname, "harbor_args": harbor_flags, "otel": os.environ["OTEL"] == "1"}, open(sys.argv[1], "w"), indent=2)
+"gateway_host": urlsplit(os.environ["OPENAI_BASE_URL"]).hostname, "harbor_args": harbor_flags, "otel": os.environ["OTEL"] == "1",
+"excluded_tools": os.environ["EXCLUDED_TOOLS"].split(",") if os.environ["EXCLUDED_TOOLS"] else []}, open(sys.argv[1], "w"), indent=2)
 PY
 step "manifest: $MANIFEST"
 if [ "$OTEL" = 1 ]; then

--- a/test/evals/harbor/stella_harbor/agent.py
+++ b/test/evals/harbor/stella_harbor/agent.py
@@ -174,7 +174,8 @@ class StellaAgent(BaseInstalledAgent):
     def __init__(self, logs_dir: Path, *args: Any, stella_url: str | None = None,
                  admin_token_env: str = "STELLA_EVAL_ADMIN_TOKEN", model: str | None = None,
                  deadline_margin_sec: int = 15, eval_agent_bin: str | None = None,
-                 binding_dir: str | None = None, **kwargs: Any) -> None:
+                 binding_dir: str | None = None, excluded_tools: str | None = None,
+                 **kwargs: Any) -> None:
         super().__init__(logs_dir, *args, **kwargs)
         self.stella_url = stella_url or os.environ.get("STELLA_URL", "")
         self.admin_token_env = admin_token_env
@@ -183,6 +184,7 @@ class StellaAgent(BaseInstalledAgent):
         self.stop_confirm_sec = self.STOP_CONFIRM_SEC
         self.eval_agent_bin = eval_agent_bin or os.environ.get("STELLA_EVAL_AGENT_BIN", "stella-eval-agent")
         self.binding_dir = binding_dir or os.environ.get("STELLA_EVAL_BRIDGE_DIR", "")
+        self.excluded_tools = excluded_tools if excluded_tools is not None else os.environ.get("STELLA_EVAL_EXCLUDED_TOOLS", "")
         self.bundle_digest = ""
 
     # Cancellation budgets. Both are deliberately small: they run after the
@@ -240,6 +242,8 @@ class StellaAgent(BaseInstalledAgent):
                    "--binding-dir", self.binding_dir, "--model", self.stella_model, "--user-id", trial,
                    "--deadline-seconds", str(deadline), "--stop-confirm-seconds", str(confirm), "--bundle-digest", self.bundle_digest, "--output", str(result_path),
                    "--trajectory", str(trial_dir / "trajectory.json")]
+        if self.excluded_tools:
+            command.extend(["--excluded-tools", self.excluded_tools])
         child_env = os.environ.copy()
         if token := os.environ.get(self.admin_token_env):
             # The Go process has one fixed secret name, so its env-read surface

--- a/test/evals/harbor/stella_harbor/fingerprint.py
+++ b/test/evals/harbor/stella_harbor/fingerprint.py
@@ -135,7 +135,10 @@ def _trial_values(
     if field == "tool_strategy":
         return _distinct(_walk_values(config, {"tool_strategy", "tool_policy"}))
     if field == "excluded_tools":
-        return _distinct(_walk_values(adapter, {field}))
+        # The field predates its artifact recording. Missing or explicit null
+        # means the run requested no exclusions, the same semantics as [].
+        value = adapter.get(field)
+        return _distinct([[] if value is None else value])
     return []
 
 

--- a/test/evals/harbor/stella_harbor/fingerprint.py
+++ b/test/evals/harbor/stella_harbor/fingerprint.py
@@ -19,6 +19,7 @@ AGENT_FIELDS = (
     "capability_profile_digest",
     "candidate_commit",
     "tool_strategy",
+    "excluded_tools",
 )
 FINGERPRINT_FIELDS = CONDITION_FIELDS + AGENT_FIELDS
 # Candidate commits are the variable being measured in a same-agent comparison.
@@ -34,6 +35,7 @@ FINGERPRINT_SOURCES = {
     "capability_profile_digest": "driver result.json: capability_profile_digest",
     "candidate_commit": "driver result.json: candidate_commit",
     "tool_strategy": "run/trial config: tool_strategy or tool_policy",
+    "excluded_tools": "driver result.json: excluded_tools",
 }
 
 
@@ -132,6 +134,8 @@ def _trial_values(
         return _distinct(_walk_values({"config": config, "result": result, "adapter": adapter}, {field, "candidate_commit_sha"}))
     if field == "tool_strategy":
         return _distinct(_walk_values(config, {"tool_strategy", "tool_policy"}))
+    if field == "excluded_tools":
+        return _distinct(_walk_values(adapter, {field}))
     return []
 
 

--- a/test/evals/harbor/tests/test_agent.py
+++ b/test/evals/harbor/tests/test_agent.py
@@ -1,4 +1,10 @@
-from stella_harbor.agent import split_trial_budget, verify_evidence
+from stella_harbor.agent import StellaAgent, split_trial_budget, verify_evidence
+
+
+def test_agent_reads_the_loop_exclusion_list(monkeypatch, tmp_path):
+    monkeypatch.setenv("STELLA_EVAL_EXCLUDED_TOOLS", "edit,read,write")
+    agent = StellaAgent(tmp_path, model="gateway/test", binding_dir=str(tmp_path / "bindings"))
+    assert agent.excluded_tools == "edit,read,write"
 
 
 def result(**changes):

--- a/test/evals/harbor/tests/test_compare.py
+++ b/test/evals/harbor/tests/test_compare.py
@@ -192,6 +192,41 @@ def test_driver_result_fields_are_read_into_the_fingerprint(tmp_path):
     assert fingerprint["candidate_commit"] == "driver-commit"
 
 
+def test_absent_excluded_tools_matches_explicit_empty_list(tmp_path, capsys):
+    left = write_fingerprinted_job(tmp_path, "left", candidate_commit="left")
+    right = write_fingerprinted_job(tmp_path, "right", candidate_commit="right")
+    adapter_path = tmp_path / "left" / "2026-08-19__10-00-00" / "t__a" / "agent" / "stella" / "result.json"
+    adapter = json.loads(adapter_path.read_text())
+    adapter.pop("excluded_tools")
+    adapter_path.write_text(json.dumps(adapter))
+
+    details = collect_fingerprint_details(left)
+    assert details["fingerprint"]["excluded_tools"] == []
+    assert details["evidence"]["excluded_tools"]["status"] == "complete"
+    assert main([str(left), str(right)]) == 0
+    assert "excluded_tools" not in capsys.readouterr().out
+
+
+def test_absent_excluded_tools_differs_from_nonempty_list(tmp_path, capsys):
+    left = write_fingerprinted_job(tmp_path, "left", candidate_commit="left")
+    right = write_fingerprinted_job(tmp_path, "right", candidate_commit="right")
+    left_adapter_path = tmp_path / "left" / "2026-08-19__10-00-00" / "t__a" / "agent" / "stella" / "result.json"
+    left_adapter = json.loads(left_adapter_path.read_text())
+    left_adapter.pop("excluded_tools")
+    left_adapter_path.write_text(json.dumps(left_adapter))
+    right_adapter_path = tmp_path / "right" / "2026-08-19__10-00-00" / "t__a" / "agent" / "stella" / "result.json"
+    right_adapter = json.loads(right_adapter_path.read_text())
+    right_adapter["excluded_tools"] = ["edit", "read", "write"]
+    right_adapter_path.write_text(json.dumps(right_adapter))
+
+    assert main([str(left), str(right)]) == 2
+    message = capsys.readouterr().err
+    assert "CONFIGURATION DIFFERENT:" in message
+    assert "excluded_tools" in message
+    assert "left=[]" in message
+    assert '["edit", "read", "write"]' in message
+
+
 def test_same_agent_excluded_tools_difference_is_rejected(tmp_path, capsys):
     left = write_fingerprinted_job(tmp_path, "left", candidate_commit="left")
     right = write_fingerprinted_job(tmp_path, "right", candidate_commit="right")

--- a/test/evals/harbor/tests/test_compare.py
+++ b/test/evals/harbor/tests/test_compare.py
@@ -45,7 +45,7 @@ def write_fingerprinted_job(tmp_path, name, **overrides):
         "t",
         1.0,
         0.01,
-        adapter={"capability_profile_digest": "capability-a"},
+        adapter={"capability_profile_digest": "capability-a", "excluded_tools": []},
     )
     (job / run / "t__a" / "result.json").write_text(json.dumps({
         "verifier_result": {"rewards": {"reward": 1.0}},
@@ -100,6 +100,7 @@ def test_matching_fingerprints_are_comparable(tmp_path, capsys):
         "timeout_multiplier": 1.0,
         "agent_name": "stella_harbor.agent:StellaAgent",
         "tool_strategy": None,
+        "excluded_tools": [],
         "capability_profile_digest": "capability-a",
         "candidate_commit": "commit-left",
     }
@@ -189,6 +190,21 @@ def test_driver_result_fields_are_read_into_the_fingerprint(tmp_path):
 
     assert fingerprint["model"] == "gateway/actual"
     assert fingerprint["candidate_commit"] == "driver-commit"
+
+
+def test_same_agent_excluded_tools_difference_is_rejected(tmp_path, capsys):
+    left = write_fingerprinted_job(tmp_path, "left", candidate_commit="left")
+    right = write_fingerprinted_job(tmp_path, "right", candidate_commit="right")
+    adapter_path = tmp_path / "right" / "2026-08-19__10-00-00" / "t__a" / "agent" / "stella" / "result.json"
+    adapter = json.loads(adapter_path.read_text())
+    adapter["excluded_tools"] = ["edit", "read", "write"]
+    adapter_path.write_text(json.dumps(adapter))
+
+    assert main([str(left), str(right)]) == 2
+    message = capsys.readouterr().err
+    assert "CONFIGURATION DIFFERENT:" in message
+    assert "excluded_tools" in message
+    assert '["edit", "read", "write"]' in message
 
 
 def test_same_agent_capability_difference_is_rejected(tmp_path, capsys):

--- a/test/evals/harbor/tests/test_loop.py
+++ b/test/evals/harbor/tests/test_loop.py
@@ -25,6 +25,11 @@ def test_quick_plan_enables_otel_and_keeps_the_key_out_of_output():
     assert "do-not-print-this-secret" not in output
 
 
+def test_plan_canonicalizes_and_reports_excluded_tools():
+    output = plan("--excluded-tools", " write,read,write,edit ")
+    assert "excluded tools: edit,read,write" in output
+
+
 def test_full_plan_keeps_baseline_telemetry_off_unless_overridden():
     assert "disabled (full baseline default)" in plan()
     assert "docker run -d grafana/otel-lgtm" in plan("--otel")
@@ -230,6 +235,12 @@ def test_filtered_runs_do_not_claim_the_full_taskset_in_the_manifest():
     source = LOOP.read_text()
     assert 'using_taskset=0' in source
     assert 'TASKSET_PATH=$([ "$using_taskset" = 1 ]' in source
+
+
+def test_excluded_tools_reach_the_driver_and_manifest():
+    source = LOOP.read_text()
+    assert "export STELLA_EVAL_EXCLUDED_TOOLS=$EXCLUDED_TOOLS" in source
+    assert '"excluded_tools": os.environ["EXCLUDED_TOOLS"].split(",")' in source
 
 
 def test_manifest_records_only_harbor_option_names_not_values():


### PR DESCRIPTION
## Summary

- expose optional per-run `excluded_tools` on session message requests
- pass exclusions through Session access into the existing runtime tool filter
- add Harbor `--excluded-tools` support and persist the canonical list in manifests and fingerprints
- cover HTTP-to-runtime plumbing, provider-visible tool removal, driver forwarding, and comparison refusal

## Verification

- `mise run format && mise run build && mise run test`
- `PYTHONPATH="$PWD/test/evals/harbor" mise exec -- uv run --project test/evals/harbor pytest -q test/evals/harbor/tests` (163 passed)

Live Harbor eval skipped because this isolated workspace has no gitignored `.env`.

Closes #1127

## Feishu Task

- [通过 HTTP 暴露会话级 excluded_tools](https://mcnnox2fhjfq.feishu.cn/record/J8warhrKQe3PflcPHeccOdaLn2e) (#1127)