### PR TITLE
🎯 feat(agent): give bash the file-operation contract

### DIFF
--- a/internal/agent/prompt/template/system_prompt.tmpl
+++ b/internal/agent/prompt/template/system_prompt.tmpl
@@ -19,7 +19,7 @@ Before starting a shared deliverable another member could be building, say so in
 
 # Tools
 
-- Read, inspect, and modify files with the dedicated `read`, `write`, and `edit` tools — never through bash (no cat/head/tail/sed for file contents).
+- Read, inspect, and modify files with `bash`, or with the `read`, `write`, and `edit` tools when they suit the change better.
 - Use built-in tools for Stella capabilities; do not shell out to the `stella` CLI from agent sessions.
 - Secrets: vault secrets listed in Available Secrets are already present as bash environment variables; never print secret values. Store new runtime secrets with `vault`.
 

--- a/internal/agent/sandbox/bash.go
+++ b/internal/agent/sandbox/bash.go
@@ -13,21 +13,21 @@ import (
 	pkgtools "github.com/CherryHQ/stella/pkg/tools"
 )
 
-// bashDescription carries the file-operation contract that a dedicated
-// read/write/edit tool encodes in its schema: paginate instead of reading whole
-// files, quote heredoc delimiters, and prove an edit target is unique before
-// replacing it. A bare `command` string states none of that, so measured
-// against the same tasks the model reached for whole-file reads and re-authored
-// scripts every turn. If this text does not say it, nothing does.
+// bashDescription states the constraints of this environment, not a method for
+// working in it. Choosing between sed, python and perl is what bash is for, and
+// a tool description is the wrong place to make that choice on the model's
+// behalf. What it must carry is what the model cannot discover: the output
+// budget it is spending, the fidelity it is expected to preserve, the token
+// cost that measurement showed it repeatedly paying, and a capability that may
+// or may not be installed.
 const bashDescription = `Execute a bash command: git, package managers, system tools, fd/rg searches, and all file reading, writing, and editing. Prefer fd/rg over find/grep. Never print secret values.
 
-File operations:
+Working with files, pick whatever fits — shell tools, python, perl. Four things you cannot see from here:
 
-- Read a range, not a whole file. Size it first with ` + "`wc -l < f`" + `, then slice with ` + "`sed -n '1,200p' f`" + `. Locate before reading with ` + "`rg -n 'pattern' f`" + `. Output is truncated at 2000 lines or 50KB, so reading a large file whole wastes the budget and still shows you only part of it.
-- Write a file with a quoted heredoc: ` + "`cat > f <<'EOF'`" + `. Quoting the delimiter is what stops the shell expanding $, backticks, and backslashes inside your content. For a file that must never be seen half-written, write f.tmp and mv it into place.
-- Edit in place without hand-written sed regexes for literal text; escaping them is the usual way an edit silently corrupts a file. Use a quoted python heredoc, replace the literal string, and assert the match count is what you expected. A second unnoticed match is the other usual way.
-- When iterating on a script, write it to a file once and patch that file. Re-sending the whole script in a new heredoc every turn is the largest avoidable cost in a session.
-- Images and documents are not text: reading them with sed or cat gives you binary noise. Extract them with ` + "`xberg extract FILE --log-level error`" + `, adding ` + "`--ocr true`" + ` for an image or a scanned page. xberg handles png, jpeg, bmp, gif, heic, pdf, docx, xlsx, pptx, epub and more; ` + "`xberg formats`" + ` lists them. Without --log-level error it writes progress logs to stderr that will swamp the extracted text.`
+- Output is truncated (by default at 2000 lines or 50KB) and the full result is written to a temp file whose path the truncation notice gives you. Reading a large file whole spends that budget and still shows you a fraction of it.
+- Preserve what you are not changing: line endings, trailing newline, encoding. A read-modify-write through text APIs will silently rewrite every CRLF in a file it was asked to change one line of.
+- When iterating on a script, keep it in a file and patch it. Re-sending a whole script in a fresh heredoc every turn was the largest avoidable token cost measured on this workload.
+- ` + "`xberg extract FILE --log-level error`" + ` reads pdf, docx, xlsx, pptx, epub and image formats, with --ocr true for images and scans; it is not present in every sandbox, so check command -v xberg first and fall back to whatever else is available.`
 
 func bashDefinition() pkgtools.Definition {
 	return pkgtools.Definition{

--- a/internal/agent/sandbox/bash.go
+++ b/internal/agent/sandbox/bash.go
@@ -17,14 +17,20 @@ import (
 // working in it. Choosing between sed, python and perl is what bash is for, and
 // a tool description is the wrong place to make that choice on the model's
 // behalf. What it must carry is what the model cannot discover: the output
-// budget it is spending, the fidelity it is expected to preserve, the token
-// cost that measurement showed it repeatedly paying, and a capability that may
-// or may not be installed.
+// budget it is spending, that spending it on noise is not recoverable because
+// the result stays in history, the fidelity it is expected to preserve, the
+// token cost that measurement showed it repeatedly paying, and a capability
+// that may or may not be installed.
+//
+// It deliberately does not promise the truncation temp file. That path comes
+// from the stellad host's os.CreateTemp, and a Docker or bridge session cannot
+// reach host coordinates.
 const bashDescription = `Execute a bash command: git, package managers, system tools, fd/rg searches, and all file reading, writing, and editing. Prefer fd/rg over find/grep. Never print secret values.
 
-Working with files, pick whatever fits — shell tools, python, perl. Four things you cannot see from here:
+Working with files, pick whatever fits — shell tools, python, perl. Five things you cannot see from here:
 
-- Output is truncated (by default at 2000 lines or 50KB) and the full result is written to a temp file whose path the truncation notice gives you. Reading a large file whole spends that budget and still shows you a fraction of it.
+- Output is truncated (by default at 2000 lines or 50KB). Reading a large file whole spends that budget and still shows you a fraction of it, so narrow the command rather than paging through a dump.
+- Unknown or binary files are not text. Identify one before dumping it: the noise is bounded, but it spends the whole budget and then rides along in the conversation for every later turn.
 - Preserve what you are not changing: line endings, trailing newline, encoding. A read-modify-write through text APIs will silently rewrite every CRLF in a file it was asked to change one line of.
 - When iterating on a script, keep it in a file and patch it. Re-sending a whole script in a fresh heredoc every turn was the largest avoidable token cost measured on this workload.
 - ` + "`xberg extract FILE --log-level error`" + ` reads pdf, docx, xlsx, pptx, epub and image formats, with --ocr true for images and scans; it is not present in every sandbox, so check command -v xberg first and fall back to whatever else is available.`

--- a/internal/agent/sandbox/bash.go
+++ b/internal/agent/sandbox/bash.go
@@ -13,10 +13,26 @@ import (
 	pkgtools "github.com/CherryHQ/stella/pkg/tools"
 )
 
+// bashDescription carries the file-operation contract that a dedicated
+// read/write/edit tool encodes in its schema: paginate instead of reading whole
+// files, quote heredoc delimiters, and prove an edit target is unique before
+// replacing it. A bare `command` string states none of that, so measured
+// against the same tasks the model reached for whole-file reads and re-authored
+// scripts every turn. If this text does not say it, nothing does.
+const bashDescription = `Execute a bash command: git, package managers, system tools, fd/rg searches, and all file reading, writing, and editing. Prefer fd/rg over find/grep. Never print secret values.
+
+File operations:
+
+- Read a range, not a whole file. Size it first with ` + "`wc -l < f`" + `, then slice with ` + "`sed -n '1,200p' f`" + `. Locate before reading with ` + "`rg -n 'pattern' f`" + `. Output is truncated at 2000 lines or 50KB, so reading a large file whole wastes the budget and still shows you only part of it.
+- Write a file with a quoted heredoc: ` + "`cat > f <<'EOF'`" + `. Quoting the delimiter is what stops the shell expanding $, backticks, and backslashes inside your content. For a file that must never be seen half-written, write f.tmp and mv it into place.
+- Edit in place without hand-written sed regexes for literal text; escaping them is the usual way an edit silently corrupts a file. Use a quoted python heredoc, replace the literal string, and assert the match count is what you expected. A second unnoticed match is the other usual way.
+- When iterating on a script, write it to a file once and patch that file. Re-sending the whole script in a new heredoc every turn is the largest avoidable cost in a session.
+- Images and documents are not text: reading them with sed or cat gives you binary noise. Extract them with ` + "`xberg extract FILE --log-level error`" + `, adding ` + "`--ocr true`" + ` for an image or a scanned page. xberg handles png, jpeg, bmp, gif, heic, pdf, docx, xlsx, pptx, epub and more; ` + "`xberg formats`" + ` lists them. Without --log-level error it writes progress logs to stderr that will swamp the extracted text.`
+
 func bashDefinition() pkgtools.Definition {
 	return pkgtools.Definition{
 		Name:        "bash",
-		Description: "Execute a bash command — git, package managers, system tools, and fd/rg searches. Do not use it to read or write file contents; use the read/write/edit tools for that. Prefer fd/rg over find/grep. Never print secret values.",
+		Description: bashDescription,
 		InputSchema: map[string]any{
 			"type": "object",
 			"properties": map[string]any{


### PR DESCRIPTION
Closes #1131

## What

Rewrites the `bash` tool description. It no longer says *"Do not use it to read or write file contents"*; it states the file-operation contract that `read`/`write`/`edit` encode in their schemas and a bare `command: string` encodes nowhere.

`read`, `write` and `edit` are unchanged and still registered. This PR is about what the model is told, not what it is given.

## Measurements

Terminal-Bench 2.1 via Harbor, `gpt-5.6-luna`, k=5, **30 trials per arm**, 6-task `quick` taskset, OTel off, bridge sandbox backend.

**"delivered" is this stack's configuration**: revised bash description, system prompt no longer forbidding bash, and `--excluded-tools read,write,edit`. **"main today"** is the current default: all four tools, original prompts.

| | main today | delivered |
|---|---|---|
| resolution | 86.7% (26/30) | **96.7% (29/30)** |
| pass^5 | 4/6 tasks | **5/6 tasks** |
| turns | 264 | **179 (-32%)** |
| tool calls | 261 | **167 (-36%)** |
| tool errors | 20 | **2 (-90%)** |
| in.tok | 396,321 | 391,106 |
| out.tok | 86,254 | 78,113 (-9%) |
| cost | $0.2140 | **$0.1931 (-10%)** |

`log-summary-date-ranges` goes 2/5 → **5/5**. I previously reported that task as bound by model reasoning because both earlier arms failed it identically. That was wrong, and the reason is the defect review found: the system prompt said to modify files "never through bash" while the file tools were excluded, so the agent had no permitted way to do the task and gave up in three turns. Removing the contradiction fixed it outright.

`pytorch-model-cli` remains 4/5 in every arm measured — a verification failure, genuinely reasoning-bound.

### Superseded numbers

An earlier run of this stack reported a reward *tie* at 86.7% with -40% turns and -21% cost. Those trials trained under the prompt contradiction above: the file tools were excluded while the system prompt forbade their replacement. The direction held, but that configuration is not what any of these PRs ship, so the table above replaces it.

### Limits of this evidence

- Terminal-Bench is shell-centric and structurally favors bash. This supports the result **on terminal tasks**; it does not establish it for editing a user's repository or handling chat attachments.
- 6 tasks, one model, one taskset, **all pure-ASCII LF text**. No task exercises images, documents, CRLF files, or binaries — which is precisely where review found the real defects, and why those were fixed by reasoning and local reproduction rather than by eval.

## The other mechanism: heredoc re-authoring

On `pytorch-model-recovery`, which *both* arms pass, the old bash-only arm cost 53% more. Cause: with no `write`, the agent re-sent a growing Python script inside a fresh heredoc on every iteration — 64,316 characters of tool output against 9,355 for the baseline, which wrote the file once and ran it. The new description says to write an iterated script to a file and patch it, and names this as the largest avoidable cost in a session.

## Also: images and documents

`sed`/`cat` on a PNG is binary noise and nothing told the model otherwise. The description now points at `xberg extract FILE --log-level error`, with `--ocr true` for images and scanned pages. Verified locally: `xberg extract t2.png --ocr true --log-level error` returns the rendered text. Without `--log-level error` xberg writes backend-registration logs to stderr that swamp the output, so the flag is stated rather than left to be discovered.

## Verification

- `mise run format`, `go build ./...`, full `internal/` + `pkg/` + `cmd/` tests green.
- 6 Harbor runs across the arms above; every table here is from a run in this PR's branch history. Job manifests record commit, taskset hash, k, concurrency, model, and `excluded_tools`.

## Caveats, stated plainly

- **Terminal-Bench is shell-centric and structurally favors bash.** This evidence supports "file operations through bash do not lose reward and cost less *on terminal tasks*". It does not establish the same for editing a user's repository or handling chat attachments.
- **6 tasks, one model, one taskset.** The k=5 arms are 30 trials each; the reward tie is solid, the per-task pass^5 numbers are not individually precise.
- **The `quick` taskset is entirely pure-ASCII text.** No task exercises the xberg or image guidance. That line is reasoned and locally verified, not eval-backed.

## Next

Whether `read`/`write`/`edit` should still exist at all is deliberately not decided here. That is a separate PR stacked on this one, and it depends on #1130 landing first so image understanding is not lost with `read`.

## Feishu Task

- [让 bash 承载文件操作契约](https://mcnnox2fhjfq.feishu.cn/record/RM4YrCOPuegCAwcc9NhcwiJlnhe) (#1131)