### PR TITLE
📚 docs(evals): make the loop usable for measuring a change

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,3 +26,6 @@ Closes #
 - [ ] I added or updated focused tests for changed non-trivial behavior, or explained why none are needed.
 - [ ] I updated relevant English and Chinese documentation, or no documentation change is needed.
 - [ ] I ran `mise run format && mise run build && mise run test`.
+- [ ] If this changes agent behavior (tools, prompts, the runner loop): I included eval evidence with both jobs, commits, tier, k, host, and model, or stated why it is not applicable. See `test/evals/harbor/README.md`.
+- [ ] If the change touches a surface no eval task exercises (pixel understanding, document extraction, CRLF fidelity, non-UTF-8, binary handling): I said so, and named the tests that cover it instead.
+- [ ] Any earlier measurement this PR invalidates is marked superseded with its reason, not deleted.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,27 +33,28 @@ Stella is a single-tenant, multi-user, multi-agent AI assistant platform written
 
 ## Development rules
 
-Rules in `web/content/docs/development/rules/` are the **source of truth** for development conventions. Read the relevant rule before designing or changing anything in that domain.
+Rules in `web/content/docs/development/rules/` are the **source of truth** for development conventions. Read the relevant rule before designing or changing anything in that domain. Bare filenames below live in that directory; a row that names a rule kept elsewhere gives its full path.
 
-| Domain            | Rule file            | Read before                                                                 |
-| ----------------- | -------------------- | --------------------------------------------------------------------------- |
-| Schema design     | `schema-design.md`   | Designing or changing any table                                             |
-| goose migrations  | `goose.md`           | Creating or modifying database migrations                                   |
-| sqlc queries      | `sqlc.md`            | Writing or editing SQL query files                                          |
-| API design        | `api-design.md`      | Designing or changing any HTTP API                                          |
-| Go patterns       | `go-patterns.md`     | Writing or reviewing Go concurrency, secret-redaction, or file-install code |
-| CLI design        | `cli-design.md`      | Designing or changing any `stellad` operator command                        |
-| Web UI            | `web-ui.md`          | Building or reviewing any web UI                                            |
-| Web theming       | `web-theming.md`     | Changing the web visual style or tokens                                     |
-| Current web theme | `web-design.md`      | Styling against the current theme or consulting the visual direction        |
-| Documentation     | `doc-style.md`       | Writing or editing user/developer docs                                      |
-| Web UI testing    | `web-ui-test.md`     | Testing the web UI with browser automation                                  |
-| Web perf testing  | `web-perf-test.md`   | Measuring or optimizing web UI performance                                  |
-| Backend API test  | `api-test.md`        | Testing the backend via live HTTP API + DB assertions (no browser)          |
-| System test       | `system-test.md`     | Adding or running the subprocess system suite; choosing a test layer        |
-| Project tracking  | `project-tracker.md` | Managing Feishu plans, GitHub issues, and pull requests                     |
-| Release           | `release.md`         | Cutting a release, tagging, changelog                                       |
-| Marketing         | `marketing.md`       | Writing a landing page, README opener, hero copy, or any marketing content  |
+| Domain            | Rule file                     | Read before                                                                 |
+| ----------------- | ----------------------------- | --------------------------------------------------------------------------- |
+| Schema design     | `schema-design.md`            | Designing or changing any table                                             |
+| goose migrations  | `goose.md`                    | Creating or modifying database migrations                                   |
+| sqlc queries      | `sqlc.md`                     | Writing or editing SQL query files                                          |
+| API design        | `api-design.md`               | Designing or changing any HTTP API                                          |
+| Go patterns       | `go-patterns.md`              | Writing or reviewing Go concurrency, secret-redaction, or file-install code |
+| CLI design        | `cli-design.md`               | Designing or changing any `stellad` operator command                        |
+| Web UI            | `web-ui.md`                   | Building or reviewing any web UI                                            |
+| Web theming       | `web-theming.md`              | Changing the web visual style or tokens                                     |
+| Current web theme | `web-design.md`               | Styling against the current theme or consulting the visual direction        |
+| Documentation     | `doc-style.md`                | Writing or editing user/developer docs                                      |
+| Web UI testing    | `web-ui-test.md`              | Testing the web UI with browser automation                                  |
+| Web perf testing  | `web-perf-test.md`            | Measuring or optimizing web UI performance                                  |
+| Backend API test  | `api-test.md`                 | Testing the backend via live HTTP API + DB assertions (no browser)          |
+| System test       | `system-test.md`              | Adding or running the subprocess system suite; choosing a test layer        |
+| Project tracking  | `project-tracker.md`          | Managing Feishu plans, GitHub issues, and pull requests                     |
+| Release           | `release.md`                  | Cutting a release, tagging, changelog                                       |
+| Eval loop         | `test/evals/harbor/README.md` | Measuring any change to agent behavior (tools, prompts, runner loop)        |
+| Marketing         | `marketing.md`                | Writing a landing page, README opener, hero copy, or any marketing content  |
 
 For new or changed HTTP APIs, also follow `api/CLAUDE.md` for the OpenAPI-first workflow.
 
@@ -64,7 +65,7 @@ Test at the lowest sufficient layer: add a subprocess system-test journey only f
 Agent-behavior changes (tools, prompts, the runner loop) are measured against Terminal-Bench through the Harbor eval loop, not argued from first principles.
 
 - **Read `test/evals/harbor/README.md`** before running or citing an eval; its "Evaluating a change" section is the procedure and `PROTOCOL.md` is the authority on what a comparison may conclude.
-- Take the reference **before** you change anything, on the same machine and model. Iterate on `--tier quick` (~5 min), confirm at single-task `k=5` with `--confirm`, then run the full tier before opening the PR.
+- Take the quick and full references **before** you change anything, on the same machine and model, from the commit you branched off. Iterate on `--tier quick` (~5 min), then confirm at single-task `k=5` with `--confirm` — that pair runs candidate first, reference second, per `PROTOCOL.md`. Run the full tier on both sides before opening the PR.
 - A rise at loop k is a `SIGNAL`, not an improvement. Only a `--confirm` verdict backs an improvement claim in a PR.
 - Put the evidence in the PR as a table naming both jobs, commits, tier, k, host, and model. If a change touches a surface no task exercises (images, documents, CRLF, binaries, non-UTF-8), say so rather than letting the score imply coverage.
 - Never set `OTEL_STELLA_RECORD_TOOL_IO` for an eval run: Terminal-Bench ships synthetic-secret tasks.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,16 @@ For new or changed HTTP APIs, also follow `api/CLAUDE.md` for the OpenAPI-first 
 
 Test at the lowest sufficient layer: add a subprocess system-test journey only for a seam a Go test cannot reach (process startup, real HTTP auth, SSE transport, cross-request flows, async workers); everything else stays an in-process test. See `system-test.md`.
 
+## Measuring a change
+
+Agent-behavior changes (tools, prompts, the runner loop) are measured against Terminal-Bench through the Harbor eval loop, not argued from first principles.
+
+- **Read `test/evals/harbor/README.md`** before running or citing an eval; its "Evaluating a change" section is the procedure and `PROTOCOL.md` is the authority on what a comparison may conclude.
+- Take the reference **before** you change anything, on the same machine and model. Iterate on `--tier quick` (~5 min), confirm at single-task `k=5` with `--confirm`, then run the full tier before opening the PR.
+- A rise at loop k is a `SIGNAL`, not an improvement. Only a `--confirm` verdict backs an improvement claim in a PR.
+- Put the evidence in the PR as a table naming both jobs, commits, tier, k, host, and model. If a change touches a surface no task exercises (images, documents, CRLF, binaries, non-UTF-8), say so rather than letting the score imply coverage.
+- Never set `OTEL_STELLA_RECORD_TOOL_IO` for an eval run: Terminal-Bench ships synthetic-secret tasks.
+
 ## Timestamps and timezones
 
 - **Store UTC and serialize timezone-aware.** Use `time.Now().UTC()` in Go; schema defaults use `now()`. Emit RFC3339 with zone via `t.UTC().Format(time.RFC3339)`. Never return naive local time in code or API responses. pgx scans `timestamptz` into `time.Time`; call `.UTC()` before formatting.

--- a/test/evals/harbor/PROTOCOL.md
+++ b/test/evals/harbor/PROTOCOL.md
@@ -112,8 +112,9 @@ single column is a conclusion.
 ## Sequential A/B discipline
 
 Sides run as whole jobs, sequentially, on one machine. The mitigations are
-part of the protocol, not advice: task images are pulled before either side
-runs, so neither side pays the cold cache; every trial records its duration
+part of the protocol, not advice: the operator warms the task images before
+either side runs, because Harbor has no prefetch step and the first side would
+otherwise pay the cold pull; every trial records its duration
 and timeout class; and a delta whose only outcome change is a timeout-class
 flip is marked untrusted rather than judged. Trials within a task are not
 paired, so the flip test is count-based: the timeout-class distribution
@@ -148,16 +149,24 @@ they did.
 
 ## Manifest
 
-Every loop run writes a manifest next to its job directory: git commit,
-dirty-tree flag, the task list and its canonical hash (always the SHA-256
-of the sorted, newline-joined, dataset-qualified task names, so a taskset
-file and an identical explicit list hash the same and a comment edit changes
-nothing; when a taskset file was used its own SHA-256 is recorded separately
-as provenance), dataset name and hash, per-task image digests,
-k, concurrency, timeout multiplier, tool strategy, capability profile digest,
-model, gateway base URL host, and created-at. These are the fields the
-comparator's fingerprint guard checks. The comparator takes explicit job
-paths; nothing ever defaults to "the latest directory".
+Every loop run writes a manifest next to its job directory: created-at, job
+name, git commit, dirty-tree flag, the taskset path when one was used, the task
+list and its canonical hash (the SHA-256 of the sorted, newline-joined,
+dataset-qualified task names, so a taskset file and an identical explicit list
+hash the same and a comment edit changes nothing), k, concurrency, model,
+gateway base URL host, the Harbor flag **names**, the OTel setting, and the
+per-run excluded-tools list.
+
+The manifest is provenance for a human, not the comparator's input. The
+fingerprint guard reads Harbor's own artifacts and the driver results: dataset
+id and hash, attempt budget, concurrency, timeout multiplier, model, agent
+name, tool strategy, capability profile digest, and candidate commit. Two runs
+whose manifests look alike can still be refused, and a run with no manifest at
+all still compares.
+
+Only flag names are persisted, never their values: an argument can carry a
+credential or a private path. The comparator takes explicit job paths; nothing
+ever defaults to "the latest directory".
 
 ## Model policy
 

--- a/test/evals/harbor/PROTOCOL.md
+++ b/test/evals/harbor/PROTOCOL.md
@@ -160,7 +160,8 @@ per-run excluded-tools list.
 The manifest is provenance for a human, not the comparator's input. The
 fingerprint guard reads Harbor's own artifacts and the driver results: dataset
 id and hash, attempt budget, concurrency, timeout multiplier, model, agent
-name, tool strategy, capability profile digest, and candidate commit. Two runs
+name, tool strategy, capability profile digest, candidate commit, and the
+excluded-tools list. Two runs
 whose manifests look alike can still be refused, and a run with no manifest at
 all still compares.
 

--- a/test/evals/harbor/PROTOCOL.md
+++ b/test/evals/harbor/PROTOCOL.md
@@ -21,6 +21,13 @@ task list but the comparison discipline: the manifest records exactly what
 ran, and the comparator refuses a candidate that is missing any task its
 reference declares. There is no silent intersection.
 
+The quick tier ([`tasksets/quick.yaml`](tasksets/quick.yaml), 6 tasks at k=1)
+is not a verdict tier. At one attempt per task there is no pass^k and no way
+to separate a real change from a coin flip, so a quick run may report a break
+and may never conclude a fix worked. It exists to shorten the edit-run-check
+cycle, and everything it shows still has to be re-earned at k=3 or, for a
+claim, at single-task k=5.
+
 ## Definitions
 
 - A **trial is valid** when it produced usable evidence. When Stella adapter

--- a/test/evals/harbor/README.md
+++ b/test/evals/harbor/README.md
@@ -30,7 +30,10 @@ mise run eval:loop -- --tier quick                             # six tasks, k=1,
 mise run eval:loop -- --excluded-tools view_image              # tool ablation
 ```
 
-Everything after `--` reaches `harbor run` verbatim. Task names must be
+`loop.sh` consumes its own flags (`--tier`, `--otel` / `--no-otel`,
+`--excluded-tools`, `--reuse-testbed`, `--against`, `--plan`) and everything
+else after `--` reaches `harbor run`, alongside the `-a`, `-m`, `-o`, and `-n`
+it supplies itself. Task names must be
 dataset-qualified (`terminal-bench/regex-log`): a bare name matches nothing and
 silently runs all 89 tasks. Harbor refuses a task filter on top of a config
 file, so passing `-i` switches the source from `tasksets/loop.yaml` to the
@@ -127,10 +130,26 @@ a 6-task reference. Three questions, three matched A/B pairs:
 
 A reference always runs the **pre-change build**, on the same machine, model,
 and gateway. _When_ in wall-clock time you run it differs by tier: quick and
-full references are cheap to take up front and impossible to reconstruct once
-you have started editing, so take them first. The k=5 confirmation reference is
+full references are cheap to take up front and cost a base-commit checkout to
+reconstruct afterwards, so take them first. The k=5 confirmation reference is
 the exception, and [`PROTOCOL.md`](PROTOCOL.md) fixes its order: candidate
 first, then reference, so gateway drift is not free to flatter the change.
+
+**Warm the images before the first side of any pair.** [`PROTOCOL.md`](PROTOCOL.md)
+requires it and Harbor has no prefetch step, so whichever side runs first
+otherwise pays the cold pull and its trial durations are not comparable to the
+other side's. A throwaway run of the same task set is the warm-up; discard the
+job directory and never cite it.
+
+```bash
+set -a; . ./.env; set +a
+mise run eval:loop -- --tier quick                     # quick's six images
+mise run eval:loop -- --tier full                      # the full tier's twelve
+mise run eval:loop -- -i terminal-bench/<task> -k 1    # one task's image
+```
+
+Warm only the tiers the pair will use. On a machine that has run those tasks
+recently the images are already warm and this is a no-op you can skip.
 
 **1. Take the quick and full references**, from the commit your PR branches
 off.
@@ -185,14 +204,13 @@ loop k that never takes this step is a `SIGNAL`, and calling it an improvement
 in a PR is a claim the evidence does not support.
 
 **4. Run the full tier on both sides before opening the PR**, so the guards get
-their k=3.
+their k=3. If you skipped the full reference in step 1, take it now from the
+base commit; that is a checkout and a rerun, not an excuse to skip it. Then,
+with both sides in hand:
 
 ```bash
 mise run eval:loop -- --tier full --against dist/evals/jobs/<full reference>
 ```
-
-If you skipped the full reference in step 1, take it now from the base commit;
-that is a checkout and a rerun, not an excuse to skip it.
 
 **5. Read the run before reading the score.** A number from a broken run is
 worse than no number. Confirm, for both sides:
@@ -206,19 +224,25 @@ worse than no number. Confirm, for both sides:
 
 **6. Put the evidence in the PR.** A table, both sides named by job and commit:
 
-```markdown
-| Metric      | Reference (`<commit>`) | Candidate (`<commit>`) |
-| ----------- | ---------------------- | ---------------------- |
-| Resolved    | 26/30 (86.7%)          | 29/30 (96.7%)          |
-| pass^5      | 4/6                    | 5/6                    |
-| Turns       | 264                    | 179                    |
-| Tool calls  | 261                    | 167                    |
-| Tool errors | 20                     | 2                      |
-| Cost        | $0.2140                | $0.1931                |
+The confirmation from step 3 is what backs a claim, so lead with it:
 
-Jobs: `dist/evals/jobs/<ref>` and `dist/evals/jobs/<cand>`. Quick task set at
-`-k 5` (30 trials; the tier's own k is 1), same host, `gpt-5.6-luna`, both
-`dirty: false`.
+```markdown
+**Confirmation** (`terminal-bench/<task>`, k=5 both sides, `--confirm`):
+CONFIRMED_IMPROVEMENT, 1/5 → 4/5 resolved.
+
+| Metric      | Reference (`<base commit>`) | Candidate (`<head commit>`) |
+| ----------- | --------------------------- | --------------------------- |
+| Resolved    | 1/5                         | 4/5                         |
+| Turns       | 61                          | 38                          |
+| Tool calls  | 58                          | 34                          |
+| Tool errors | 9                           | 1                           |
+| Cost        | $0.0412                     | $0.0330                     |
+
+Jobs: `dist/evals/jobs/<ref>` and `dist/evals/jobs/<cand>`. Same host,
+`gpt-5.6-luna`, both `dirty: false`.
+
+**Full tier** (12 tasks, k=3): no SUSPECTED_REGRESSION, no guard dropped
+below 3/3. Jobs: `dist/evals/jobs/loop-<ref>` and `dist/evals/jobs/loop-<cand>`.
 ```
 
 Paste the comparator's own output alongside it, not just your summary of it.

--- a/test/evals/harbor/README.md
+++ b/test/evals/harbor/README.md
@@ -1,7 +1,8 @@
 # Harbor evaluation adapter
 
-Run a Stella trial from the host while its `bash`, `read`, `write`, and `edit`
-tools operate in the Harbor task container through the bridge backend.
+Run a Stella trial from the host while its sandbox tools operate in the Harbor
+task container through the bridge backend. The core set is `bash` and
+`view_image`, plus `vllm` when the deployment configured a vision model.
 
 For the fix-iteration loop (small task sets, same-machine before/after,
 verdict tiers), read [`PROTOCOL.md`](PROTOCOL.md); the default task set is
@@ -25,7 +26,8 @@ where.
 mise run eval:loop -- --plan                                   # print the steps, run nothing
 mise run eval:loop -- -i terminal-bench/build-cython-ext -k 5  # one task, k=5
 mise run eval:loop -- --against dist/evals/jobs/loop-<earlier> # compare when it finishes
-mise run eval:loop -- --excluded-tools read,write,edit         # bash-only tool ablation
+mise run eval:loop -- --tier quick                             # six tasks, k=1, fastest signal
+mise run eval:loop -- --excluded-tools view_image              # tool ablation
 ```
 
 Everything after `--` reaches `harbor run` verbatim. Task names must be
@@ -61,6 +63,132 @@ comparator.
 
 The first run of a task pays the image pull; Harbor has no separate prefetch,
 so a cold machine is slower on its first loop and comparable afterwards.
+
+## Tiers
+
+`--tier` picks the task set, and the task set owns k and concurrency.
+
+| Tier             | Tasks                                            | k         | Concurrency      | Answers                         |
+| ---------------- | ------------------------------------------------ | --------- | ---------------- | ------------------------------- |
+| `quick`          | 6 ([`tasksets/quick.yaml`](tasksets/quick.yaml)) | 1         | 6                | did I obviously break something |
+| `full` (default) | 12 ([`tasksets/loop.yaml`](tasksets/loop.yaml))  | 3         | 4                | did behavior move               |
+| targeted         | your `-i` list                                   | your `-k` | from the taskset | did this specific fix work      |
+
+Quick's six tasks were each selected to run under two minutes per trial, so the
+tier lands in roughly five minutes on a warm machine. Full is 36 trials at
+concurrency 4 and takes substantially longer; time it on your own host rather
+than trusting a number here, because the first run of any task also pays the
+image pull.
+
+Quick is the edit-run-check cycle and **cannot** tell you a fix worked: one
+attempt per task has no pass^k, so a change and a coin flip look identical.
+Its job is to catch the break you did not intend, in the time it takes to read
+the diff again. Selection is by measured wall time, not difficulty, so a task
+being in quick says nothing about how hard it is.
+
+OTel defaults on for quick and off for full, because quick is small enough that
+per-turn telemetry is worth its overhead. Override either way with `--otel` /
+`--no-otel`.
+
+`--reuse-testbed` skips the testbed build and start, which is most of quick's
+fixed cost. It requires an already-running healthy bridge testbed with OTel
+off, and `STELLA_URL`, `STELLA_TESTBED_CREDENTIALS`, and the original
+`STELLA_EVAL_BRIDGE_DIR` still exported. It cannot retrofit OTel into a testbed
+that started without it.
+
+> **Never set `OTEL_STELLA_RECORD_TOOL_IO` for an eval run.** Terminal-Bench
+> ships tasks whose goal is recovering a synthetic secret, and the agent puts
+> that secret in its own commands. Recording tool IO writes it to telemetry.
+
+## Evaluating a change
+
+The loop's mechanics are above; this is the order to use them in. Every step
+answers a question the previous one cannot.
+
+**1. Take the reference before you change anything.** Same machine, same
+model, same task set, from a stated commit. A reference measured after the
+change, or on a different machine, is not a reference. Keep the job path; the
+comparator never guesses which directory you meant.
+
+```bash
+set -a; . ./.env; set +a
+mise run eval:loop -- --tier quick
+```
+
+`eval:loop` names the job itself, `dist/evals/jobs/<tier>-<UTC timestamp>`, and
+prints the path. **Write it down.** Do not pass your own `-o`: the script
+already passes one, and nothing here ever defaults to "the latest directory".
+
+**2. Iterate on quick.** Fast enough to run on every meaningful edit. Read it
+as a break detector, not as evidence.
+
+**3. Confirm the fix at single-task k=5, candidate first.**
+
+```bash
+mise run eval:loop -- -i terminal-bench/<the task your fix targets> -k 5
+uv run --project test/evals/harbor python -m stella_harbor.compare \
+  dist/evals/jobs/<candidate> dist/evals/jobs/<reference> \
+  --names after before --confirm
+```
+
+The first path is always the candidate. `--against <ref-job>` runs the same
+comparison inline when the job finishes, but it is advisory and never fails the
+command; run `compare --confirm` yourself for a verdict.
+
+`--confirm` applies the frozen predicates in [`PROTOCOL.md`](PROTOCOL.md):
+two or more resolved apart either way, anything weaker is `DISMISSED`. A rise
+at loop k that never takes this step is a `SIGNAL`, and calling it an
+improvement in a PR is a claim the evidence does not support.
+
+**4. Run the full tier before opening the PR**, so the guards get their k=3.
+
+**5. Put the evidence in the PR.** Not a sentence, a table, with both sides
+named by job and commit:
+
+```markdown
+| Metric      | Reference (`<commit>`) | Candidate (`<commit>`) |
+| ----------- | ---------------------- | ---------------------- |
+| Resolved    | 26/30 (86.7%)          | 29/30 (96.7%)          |
+| pass^5      | 4/6                    | 5/6                    |
+| Turns       | 264                    | 179                    |
+| Tool calls  | 261                    | 167                    |
+| Tool errors | 20                     | 2                      |
+| Cost        | $0.2140                | $0.1931                |
+
+Jobs: `dist/evals/jobs/<ref>` and `dist/evals/jobs/<cand>`. Quick task set at
+`-k 5` (30 trials; the tier's own k is 1), same host, `gpt-5.6-luna`.
+```
+
+State the tier, k, host, and model. A number without them is not reproducible
+and will be read as a benchmark result, which it is not.
+
+**6. When a measurement is invalidated, mark it superseded, do not delete it.**
+A configuration change or a broken host makes earlier numbers void, not
+nonexistent. Keep them in the PR under a heading that says why they no longer
+apply. A reviewer who saw the first table needs to know what happened to it;
+silently swapping in better numbers is the same shape as fabricating them.
+
+## What the loop cannot see
+
+The loop measures the task set and nothing else. Its verdicts are only as
+broad as the tasks that ran.
+
+The quick and full sets are pure-ASCII LF text on a Linux container. They
+exercise no image, no document format, no CRLF file, no binary, and no
+non-UTF-8 encoding. A change to any of those surfaces can be measured as a
+clean improvement here while being broken in exactly the way the task set
+cannot express. During the #1132 / #1134 tool work every defect that mattered
+was found by review and local reproduction, not by the loop, while the score
+went up.
+
+So: **if your change touches a surface no task exercises, say so in the PR**
+rather than letting the score imply coverage it does not have. Adding a task
+is better than the disclaimer, and the disclaimer is much better than nothing.
+
+One concrete gap to know about: [`build_tool_bundle.sh`](build_tool_bundle.sh)
+installs only `rg` and `fd`, so `xberg` is not present in any trial. The
+`xberg extract` guidance in bash's tool description has therefore never
+executed in an eval run.
 
 ## Prerequisites
 
@@ -160,8 +288,8 @@ interval, pass^k across tasks, timeouts, every predicate violation, bridge
 adapter faults, a failure breakdown, and a per-tool cost table.
 
 `errs` and `cmd!0` are deliberately two columns. `errs` (`tool_error_total`) is
-the tool itself failing: an `edit` whose `old_string` did not match, a `read` of
-a path that does not exist. `cmd!0` (`command_nonzero_total`) is a command that
+the tool itself failing: a `view_image` on a path that does not exist, a `vllm`
+call the vision model rejected. `cmd!0` (`command_nonzero_total`) is a command that
 ran to completion and exited nonzero: probing for a binary, a test suite failing
 before the fix, a `grep` that matched nothing. That is the container answering,
 not the machinery breaking, and only `errs` feeds the `execution` failure class.
@@ -429,6 +557,32 @@ Fix it before the first trial and restart Docker:
 }
 ```
 
+**Check disk before every run, not after a bad one.** Docker running out of
+space does not report itself as a disk problem. The trials come back as
+**bridge adapter faults**, and the underlying errors are buried:
+`Error setting up pivot dir ... no space left on device` and
+`chown ... no space left on device`. It looks exactly like a harness bug, and
+it silently voided a complete k=5 baseline before anyone read the container
+logs.
+
+```bash
+docker system df                     # before the run
+df -h /var/lib/docker
+```
+
+If a run reports adapter faults, check disk first, before suspecting the
+bridge. Reclaiming space between runs:
+
+```bash
+docker container prune -f            # stopped trial containers
+docker image prune -f                # dangling layers
+docker builder prune -af             # the build cache, usually the largest
+```
+
+Those three are safe: they remove nothing a rerun cannot rebuild. Do not add
+`-a` to `image prune` or touch named volumes without looking at what they hold;
+task images are expensive to pull again.
+
 **Never run one `-k 5` job.** Harbor grows roughly 160 MB of RSS per completed
 trial and does not give it back. A 445-trial job reached 62 GB and was
 OOM-killed at trial 378, taking six hours of work with it. Run k separate `-k 1`
@@ -583,6 +737,20 @@ start a turn when it finds one and names it in the result.
 excluded: their runtime trees are not present in minimal benchmark images. The
 bundle manifest and disabled tool list produce `capability_profile_digest` in
 each driver result.
+
+`xberg` is **not** in the bundle. bash's tool description tells the model it may
+be available and to check `command -v xberg` first, so a trial takes the
+fallback path every time. That is correct behavior, not a bug, but it means the
+extraction path is unmeasured here: no eval run has ever executed it. Adding it
+would change `capability_profile_digest`, which the comparator treats as agent
+identity, so runs from before and after the change are not comparable to each
+other.
+
+The tool set a trial sees is the deployment's core set (`bash`, `view_image`,
+and `vllm` when a vision model is configured) minus anything `--excluded-tools`
+hid for that run. The exclusion list is recorded in the manifest and in the run
+fingerprint, so the comparator refuses to put two same-agent runs with
+different toolsets side by side.
 
 Run the adapter-only tests:
 

--- a/test/evals/harbor/README.md
+++ b/test/evals/harbor/README.md
@@ -55,9 +55,10 @@ The manifest sits next to the job directory as `<job>.manifest.json` and
 records what the comparator's fingerprint cannot derive from the artifacts
 alone: commit and dirty flag, the taskset path, the task names with their
 canonical SHA-256 (sorted, newline-joined, dataset-qualified), k, concurrency,
-model, the gateway host without its path or key, the verbatim Harbor arguments,
-the OTel setting, the canonical per-run `excluded_tools` list, and the UTC
-creation time. The driver result carries the same exclusion list in the run
+model, the gateway host without its path or key, the Harbor flag **names**
+without their values, the OTel setting, the canonical per-run `excluded_tools`
+list, and the UTC creation time. Values are deliberately dropped: an argument
+can carry a credential or a private path. The driver result carries the same exclusion list in the run
 fingerprint, so same-agent runs with different toolsets are rejected by the
 comparator.
 
@@ -90,11 +91,19 @@ OTel defaults on for quick and off for full, because quick is small enough that
 per-turn telemetry is worth its overhead. Override either way with `--otel` /
 `--no-otel`.
 
-`--reuse-testbed` skips the testbed build and start, which is most of quick's
-fixed cost. It requires an already-running healthy bridge testbed with OTel
-off, and `STELLA_URL`, `STELLA_TESTBED_CREDENTIALS`, and the original
+`--reuse-testbed` skips copying the binaries, downloading Postgres, and
+starting the server, which is most of quick's fixed cost. It still runs
+`eval:build` every time. It requires an already-running healthy bridge testbed
+with OTel off, and `STELLA_URL`, `STELLA_TESTBED_CREDENTIALS`, and the original
 `STELLA_EVAL_BRIDGE_DIR` still exported. It cannot retrofit OTel into a testbed
 that started without it.
+
+> **A reused testbed keeps serving the `stellad` it started with.** `eval:build`
+> refreshes `dist/bin/stellad` in the repo, but nothing copies it into a testbed
+> that is already up, and the health check only compares the HEAD commit. So an
+> uncommitted edit rebuilds, passes the check, and is **not** what ran. Reuse the
+> testbed for reference runs and reruns of unchanged code; restart it after any
+> edit to server code you intend to measure.
 
 > **Never set `OTEL_STELLA_RECORD_TOOL_IO` for an eval run.** Terminal-Bench
 > ships tasks whose goal is recovering a synthetic secret, and the agent puts
@@ -102,48 +111,100 @@ that started without it.
 
 ## Evaluating a change
 
-The loop's mechanics are above; this is the order to use them in. Every step
-answers a question the previous one cannot.
+The loop's mechanics are above; this is the order to use them in.
 
-**1. Take the reference before you change anything.** Same machine, same
-model, same task set, from a stated commit. A reference measured after the
-change, or on a different machine, is not a reference. Keep the job path; the
-comparator never guesses which directory you meant.
+**Every comparison needs its own matched reference.** The comparator judges a
+task only when both sides hold exactly k scoreable trials for it, and refuses a
+candidate missing any task its reference declares. So a quick reference cannot
+back a k=5 confirmation, and a single-task candidate cannot be compared against
+a 6-task reference. Three questions, three matched A/B pairs:
+
+| Question              | Both sides run   |
+| --------------------- | ---------------- |
+| did I break something | `--tier quick`   |
+| did behavior move     | `--tier full`    |
+| did this fix work     | `-i <task> -k 5` |
+
+A reference always runs the **pre-change build**, on the same machine, model,
+and gateway. _When_ in wall-clock time you run it differs by tier: quick and
+full references are cheap to take up front and impossible to reconstruct once
+you have started editing, so take them first. The k=5 confirmation reference is
+the exception, and [`PROTOCOL.md`](PROTOCOL.md) fixes its order: candidate
+first, then reference, so gateway drift is not free to flatter the change.
+
+**1. Take the quick and full references**, from the commit your PR branches
+off.
 
 ```bash
 set -a; . ./.env; set +a
 mise run eval:loop -- --tier quick
+mise run eval:loop -- --tier full   # skip only if you will take it in step 4
 ```
 
-`eval:loop` names the job itself, `dist/evals/jobs/<tier>-<UTC timestamp>`, and
-prints the path. **Write it down.** Do not pass your own `-o`: the script
+`eval:loop` names each job itself, `dist/evals/jobs/quick-<UTC timestamp>` or
+`loop-<UTC timestamp>` for the full tier, and prints the path. **Write them down.** Do not pass your own `-o`: the script
 already passes one, and nothing here ever defaults to "the latest directory".
 
-**2. Iterate on quick.** Fast enough to run on every meaningful edit. Read it
-as a break detector, not as evidence.
+Every run on both sides must come from a clean tree. The manifest records a
+`dirty` flag, and a dirty run is not evidence: nobody, including you next
+week, can say what code produced it. Commit before you measure.
 
-**3. Confirm the fix at single-task k=5, candidate first.**
+**2. Iterate on quick.** Fast enough to run on every meaningful edit. Compare
+quick against quick and read it as a break detector, not as evidence.
 
 ```bash
+mise run eval:loop -- --tier quick --against dist/evals/jobs/<quick reference>
+```
+
+**3. Confirm the fix at single-task k=5 — candidate first, then reference.**
+The reference here is taken _now_, by checking out the base commit and running
+the same command again. That ordering is the protocol's, not a convenience.
+
+```bash
+# Commit the change first; both runs must report dirty: false.
 mise run eval:loop -- -i terminal-bench/<the task your fix targets> -k 5
+git checkout <base commit>       # or run this half in a second checkout
+mise run eval:loop -- -i terminal-bench/<the same task> -k 5
+git checkout -
 uv run --project test/evals/harbor python -m stella_harbor.compare \
   dist/evals/jobs/<candidate> dist/evals/jobs/<reference> \
   --names after before --confirm
 ```
 
-The first path is always the candidate. `--against <ref-job>` runs the same
-comparison inline when the job finishes, but it is advisory and never fails the
-command; run `compare --confirm` yourself for a verdict.
+If you are reusing a testbed, restart it between those two runs: a running
+testbed keeps serving the binary it started with, so both runs would measure
+the same code.
 
-`--confirm` applies the frozen predicates in [`PROTOCOL.md`](PROTOCOL.md):
-two or more resolved apart either way, anything weaker is `DISMISSED`. A rise
-at loop k that never takes this step is a `SIGNAL`, and calling it an
-improvement in a PR is a claim the evidence does not support.
+The first path is always the candidate. `--against` runs the same comparison
+inline, but it is advisory and never fails the command; run `compare --confirm`
+yourself for a verdict.
 
-**4. Run the full tier before opening the PR**, so the guards get their k=3.
+`--confirm` applies the frozen predicates in [`PROTOCOL.md`](PROTOCOL.md): two
+or more resolved apart either way, anything weaker is `DISMISSED`. A rise at
+loop k that never takes this step is a `SIGNAL`, and calling it an improvement
+in a PR is a claim the evidence does not support.
 
-**5. Put the evidence in the PR.** Not a sentence, a table, with both sides
-named by job and commit:
+**4. Run the full tier on both sides before opening the PR**, so the guards get
+their k=3.
+
+```bash
+mise run eval:loop -- --tier full --against dist/evals/jobs/<full reference>
+```
+
+If you skipped the full reference in step 1, take it now from the base commit;
+that is a checkout and a rerun, not an excuse to skip it.
+
+**5. Read the run before reading the score.** A number from a broken run is
+worse than no number. Confirm, for both sides:
+
+- the comparator reported no blocking fingerprint mismatch, and you did not
+  reach for `--allow-mismatch`
+- every task holds exactly k scoreable trials, no `INSUFFICIENT_EVIDENCE`
+- no invalid trials and no bridge adapter faults
+- no task marked `UNTRUSTED` by a timeout-class flip
+- both manifests say `dirty: false`
+
+**6. Put the evidence in the PR.** A table, both sides named by job and commit:
 
 ```markdown
 | Metric      | Reference (`<commit>`) | Candidate (`<commit>`) |
@@ -156,13 +217,15 @@ named by job and commit:
 | Cost        | $0.2140                | $0.1931                |
 
 Jobs: `dist/evals/jobs/<ref>` and `dist/evals/jobs/<cand>`. Quick task set at
-`-k 5` (30 trials; the tier's own k is 1), same host, `gpt-5.6-luna`.
+`-k 5` (30 trials; the tier's own k is 1), same host, `gpt-5.6-luna`, both
+`dirty: false`.
 ```
 
-State the tier, k, host, and model. A number without them is not reproducible
+Paste the comparator's own output alongside it, not just your summary of it.
+State the tier, k, host, and model: a number without them is not reproducible
 and will be read as a benchmark result, which it is not.
 
-**6. When a measurement is invalidated, mark it superseded, do not delete it.**
+**7. When a measurement is invalidated, mark it superseded, do not delete it.**
 A configuration change or a broken host makes earlier numbers void, not
 nonexistent. Keep them in the PR under a heading that says why they no longer
 apply. A reviewer who saw the first table needs to know what happened to it;
@@ -173,13 +236,23 @@ silently swapping in better numbers is the same shape as fabricating them.
 The loop measures the task set and nothing else. Its verdicts are only as
 broad as the tasks that ran.
 
-The quick and full sets are pure-ASCII LF text on a Linux container. They
-exercise no image, no document format, no CRLF file, no binary, and no
-non-UTF-8 encoding. A change to any of those surfaces can be measured as a
-clean improvement here while being broken in exactly the way the task set
-cannot express. During the #1132 / #1134 tool work every defect that mattered
-was found by review and local reproduction, not by the loop, while the score
-went up.
+Binary and image _files_ do appear: `pytorch-model-cli` ships an `image.png`
+and a `model.pth`, `pytorch-model-recovery` three `.pt` files. What no task
+requires is the agent **understanding** them. The images are program input, so
+a trial passes without ever looking at one. Unexercised, therefore, and worth
+naming precisely:
+
+- model-facing pixel understanding (`view_image`, `vllm`)
+- document extraction (pdf, docx, xlsx, pptx, epub)
+- CRLF and trailing-newline fidelity through a read-modify-write
+- non-UTF-8 encodings
+- a binary read as if it were text, which is the failure the size budget makes
+  expensive
+
+A change to any of those can measure as a clean improvement here while being
+broken in exactly the way the task set cannot express. During the #1132 /
+#1134 tool work every defect that mattered was found by review and local
+reproduction, not by the loop, while the score went up.
 
 So: **if your change touches a surface no task exercises, say so in the PR**
 rather than letting the score imply coverage it does not have. Adding a task
@@ -574,16 +647,26 @@ If a run reports adapter faults, check disk first, before suspecting the
 bridge. Reclaiming space between runs:
 
 ```bash
-docker container prune -f            # stopped trial containers
-docker image prune -f                # dangling layers
 docker builder prune -af             # the build cache, usually the largest
+docker image prune -f                # dangling layers
+docker container prune -f            # every stopped container on this daemon
 ```
 
-Those three are safe: they remove nothing a rerun cannot rebuild. Do not add
-`-a` to `image prune` or touch named volumes without looking at what they hold;
-task images are expensive to pull again.
+The first two remove nothing a rerun cannot rebuild. **`container prune` is
+not in that class**: it deletes every stopped container the daemon has, not
+just this run's, so it belongs on a disposable eval host and nowhere else. On a
+shared machine list first and remove by name:
 
-**Never run one `-k 5` job.** Harbor grows roughly 160 MB of RSS per completed
+```bash
+docker ps -a --filter status=exited --format '{{.ID}} {{.Names}} {{.Image}}'
+```
+
+Do not add `-a` to `image prune` or touch named volumes without reading what
+they hold; task images are expensive to pull again.
+
+**Never run the whole 89-task set as one `-k 5` job.** (A single-task `-k 5`
+confirmation is 5 trials and perfectly safe; this is about the 445-trial
+baseline.) Harbor grows roughly 160 MB of RSS per completed
 trial and does not give it back. A 445-trial job reached 62 GB and was
 OOM-killed at trial 378, taking six hours of work with it. Run k separate `-k 1`
 passes into separate job directories instead. A pass is then also the recovery

--- a/test/evals/harbor/loop.sh
+++ b/test/evals/harbor/loop.sh
@@ -338,7 +338,15 @@ step "running Harbor: $source_kind"; echo "    job: $JOB"
 "${harbor_cmd[@]}"
 step "report"
 uv run --project "$HARBOR_DIR" python -m stella_harbor.report "$JOB"
-if [ -n "$AGAINST" ]; then step "comparing against $AGAINST (candidate)"; uv run --project "$HARBOR_DIR" python -m stella_harbor.compare "$JOB" "$AGAINST" || true; fi
+if [ -n "$AGAINST" ]; then
+  step "comparing against $AGAINST (candidate)"
+  # Harbor dumps the run config with exclude_defaults=True, so a k=1 job never
+  # records n_attempts and the comparator cannot verify the budget. Supplying
+  # the k we actually ran is the only way a quick-tier comparison is not
+  # refused; it is rejected outright if it disagrees with what a job recorded.
+  RUN_K=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("n_attempts", 1))' "$WORK/config.json")
+  uv run --project "$HARBOR_DIR" python -m stella_harbor.compare "$JOB" "$AGAINST" --k "$RUN_K" || true
+fi
 
 : >"$WORK/args.txt"; [ -z "${HARBOR_ARGS[*]-}" ] || printf '%s\n' "${HARBOR_ARGS[@]}" >"$WORK/args.txt"
 TASKSET_PATH=$([ "$using_taskset" = 1 ] && echo "${TASKSET#"$REPO_ROOT"/}" || echo ""); export TASKSET_PATH JOB OTEL EXCLUDED_TOOLS

--- a/test/evals/harbor/tests/test_compare.py
+++ b/test/evals/harbor/tests/test_compare.py
@@ -771,6 +771,19 @@ def test_k_still_fills_in_a_budget_no_artifact_recorded(tmp_path, capsys):
     assert "UNTRUSTWORTHY" not in out and "CANNOT VERIFY" not in out
 
 
+def test_a_k1_pair_is_refused_until_k_is_supplied(tmp_path, capsys):
+    # Harbor dumps the run config with exclude_defaults=True, and n_attempts
+    # defaults to 1, so a k=1 job on both sides records no budget at all. That
+    # is the quick tier, and it must fail closed rather than guess k=1.
+    candidate = write_side(tmp_path, "cand", {"t": resolved(1)}, n_attempts=None)
+    reference = write_side(tmp_path, "ref", {"t": resolved(0)}, n_attempts=None)
+
+    assert main([str(candidate), str(reference)]) == 2
+    assert "expected at run config.json: n_attempts" in capsys.readouterr().err
+    # loop.sh --against supplies the k it actually ran, which unblocks it.
+    assert main([str(candidate), str(reference), "--k", "1"]) == 0
+
+
 def test_a_subset_that_selects_nothing_is_refused(tmp_path, capsys):
     candidate = write_side(tmp_path, "cand", {"a": resolved(1)})
     reference = write_side(tmp_path, "ref", {"a": resolved(1)})

--- a/test/evals/harbor/tests/test_loop.py
+++ b/test/evals/harbor/tests/test_loop.py
@@ -249,6 +249,16 @@ def test_manifest_records_only_harbor_option_names_not_values():
     assert '"harbor_args": harbor_flags' in source
 
 
+def test_against_supplies_the_run_k_the_comparator_cannot_verify():
+    # Harbor omits n_attempts from config.json when it equals the default of 1,
+    # so a k=1 job records no budget and the comparator fails closed. loop.sh
+    # has to restate the k it ran, read from the run's own printed config.
+    source = LOOP.read_text()
+    assert 'RUN_K=$(python3 -c \'import json,sys; print(json.load(open(sys.argv[1])).get("n_attempts", 1))\' "$WORK/config.json")' in source
+    assert 'stella_harbor.compare "$JOB" "$AGAINST" --k "$RUN_K"' in source
+    assert source.index('--print-config') < source.index('RUN_K=')
+
+
 def test_reuse_rejects_non_loopback_urls_before_sending_credentials(tmp_path):
     credentials = tmp_path / "credentials.json"
     credentials.write_text("{}")


### PR DESCRIPTION
## What

Makes the Harbor eval loop usable for measuring a change, so a future feature can be evaluated, compared, and confirmed the same day.

**This is not docs-only.** It carries one behavior fix.

### Code

`test/evals/harbor/loop.sh` now passes `--k` to the comparator on `--against`.

Harbor dumps the run config with `exclude_defaults=True`, and `n_attempts` defaults to 1, so a k=1 job never records its attempt budget on disk. The comparator is fail-closed on an unverifiable budget, so `--tier quick --against <ref>` refused every comparison it was asked for: the edit-run-check step of the workflow this PR documents produced a `REFUSING` and nothing else. Verified on disk — every k=1 job in `dist/evals/jobs` has `n_attempts` absent, every k>=2 job records it.

`loop.sh` reads `n_attempts` from the run's own `--print-config` dump and passes it. Safe unconditionally: `compare.py` rejects a `--k` that disagrees with any budget a job did record, so restating the truth can only unblock the k=1 case.

Two new tests: `test_a_k1_pair_is_refused_until_k_is_supplied` (comparator) and `test_against_supplies_the_run_k_the_comparator_cannot_verify` (plumbing).

### Docs

`test/evals/harbor/README.md` gains a `## Tiers` table, an `## Evaluating a change` procedure, and a `## What the loop cannot see` section. `PROTOCOL.md`, `AGENTS.md`, and `.github/pull_request_template.md` are brought in line.

The procedure is built around matched A/B pairs, because the comparator judges a task only when both sides hold exactly k scoreable trials: quick against quick for breakage, full against full for movement, single-task k=5 with `--confirm` for a claim. The k=5 reference runs *after* the candidate, per PROTOCOL, so gateway drift cannot flatter the change.

### Corrections to what the docs previously claimed

Each verified in the source, not inferred:

- `--reuse-testbed` does not skip `eval:build`, and a reused testbed keeps serving the binary it started with while the health check only compares HEAD commit. An uncommitted edit rebuilds, passes the check, and is not what ran. Now documented as the trap it is.
- Binary and image *files* do appear in the task set (`pytorch-model-cli` ships `image.png` and `model.pth`); what no task requires is the agent understanding them. The old "no image, no binary" claim was false.
- The full tier's job prefix is `loop-`, not `full-`.
- `docker container prune -f` is not safe on a shared machine.
- The manifest field list was wrong in both files, and only Harbor flag *names* are persisted, deliberately, so no argument can carry a credential.
- `excluded_tools` was missing from PROTOCOL's fingerprint enumeration (11 fields, 10 listed).
- "Everything after `--` reaches `harbor run` verbatim" was false; `loop.sh` consumes its own flags first.
- "Never run one `-k 5` job" is about the 445-trial baseline and read as forbidding the 5-trial confirmation the next section asks for.
- PROTOCOL mandates warming the task images before either side runs; the README gave no way to do it.

## Verification

- `mise run format` — clean
- `mise run build && mise run test` — exit 0
- `uv run --project test/evals/harbor python -m pytest test/evals/harbor/tests` — 167 passed
- `bash -n test/evals/harbor/loop.sh` — clean

No eval run: this PR does not change agent behavior. `loop.sh` change affects only the comparator invocation.

## Deferred

`compare` emitting the PR evidence table itself is #1138. Hand-copying numbers is the most forgeable step in the loop, but it is a feature, not a doc correction.

Reference staleness has no time bound. Both reviewers ruled that inventing a number would be the same error as the fabricated wall-time this PR removed; a condition-based norm is possible follow-up.

Refs: #1136