### PR TITLE
✨ feat(ci): mirror release images to a configurable registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,11 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: cherryhq/stella
+  # Optional mirror registry (e.g. Aliyun ACR). Configure the ACR_REGISTRY /
+  # ACR_IMAGE_NAME repository variables and ACR_USERNAME / ACR_PASSWORD
+  # secrets to enable; the copy steps are skipped when unset.
+  ACR_REGISTRY: ${{ vars.ACR_REGISTRY }}
+  ACR_IMAGE_NAME: ${{ vars.ACR_IMAGE_NAME }}
 
 jobs:
   source:
@@ -364,3 +369,19 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+
+      - name: Log into mirror registry
+        if: env.ACR_REGISTRY != ''
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.ACR_REGISTRY }}
+          username: ${{ secrets.ACR_USERNAME }}
+          password: ${{ secrets.ACR_PASSWORD }}
+
+      - name: Copy manifest list to mirror registry
+        if: env.ACR_REGISTRY != ''
+        run: |
+          for source in $(jq -cr '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON"); do
+            target="${ACR_REGISTRY}/${ACR_IMAGE_NAME}:${source##*:}"
+            docker buildx imagetools create -t "$target" "$source"
+          done


### PR DESCRIPTION
## What

Add an optional, configuration-gated step to the release workflow that copies the published multi-arch image (all tags) to a mirror registry such as Aliyun ACR.

## Why

Cherry Studio Enterprise ships Stella as an on-prem component and pins `ghcr.io/cherryhq/stella:<tag>` in its deployment manifest. Deployments in mainland China cannot reach ghcr.io reliably (and the ghcr package is currently private), so releases need to land on a registry those environments can pull from.

## How

- Two new workflow env entries read the `ACR_REGISTRY` / `ACR_IMAGE_NAME` repository variables; both new steps are skipped when `ACR_REGISTRY` is unset, so forks and the current release flow are unaffected.
- After `Merge Docker Manifests` creates the manifest list on ghcr, the new step logs into the mirror registry with the `ACR_USERNAME` / `ACR_PASSWORD` secrets and copies every tag produced by the metadata action with `docker buildx imagetools create` (cross-registry copy, no rebuild).
- Repository admins enable it by configuring the two variables and two secrets; no workflow change is needed afterwards.

## Test

- `release.yml` still parses as valid YAML (checked with the `yaml` parser).
- Not executed end-to-end: the job only runs on `v*.*.*` tags with registry credentials configured. When the variables are unset the new steps are skipped, so existing releases behave exactly as before.

## Refs

No issue: small self-contained CI addition.

## Checklist

- [x] The PR links a GitHub issue, or states why the fix is small enough not to need one.
- [x] I added or updated focused tests for changed non-trivial behavior, or explained why none are needed. (CI workflow only; gated steps are skipped unless explicitly configured.)
- [x] I updated relevant English and Chinese documentation, or no documentation change is needed.
- [x] I ran `mise run format && mise run build && mise run test`. (Not run: no source, build, or test surface is touched — the change is a workflow file only.)
- [x] If this changes agent behavior (tools, prompts, the runner loop): I included eval evidence with both jobs, commits, tier, k, host, and model, or stated why it is not applicable. (Not applicable: CI workflow only.)
- [x] If the change touches a surface no eval task exercises (pixel understanding, document extraction, CRLF fidelity, non-UTF-8, binary handling): I said so, and named the tests that cover it instead. (Not applicable.)
- [x] Any earlier measurement this PR invalidates is marked superseded with its reason, not deleted. (None invalidated.)
