### PR TITLE
🧹 chore(docker): use ParadeDB in Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,13 +29,16 @@ services:
     command: ["sh", "-c", "chown -R stella:stella /home/stella/.stella"]
 
   postgres:
-    # Match the embedded PostgreSQL version (embedded-postgres DefaultConfig -> V18 / 18.3.0)
-    image: postgres:18
+    # PostgreSQL 18 with Stella's required pg_search and pgvector extensions.
+    image: paradedb/paradedb:0.24.0-pg18
+    command: ["postgres", "-c", "shared_preload_libraries=pg_search,pg_cron"]
     restart: unless-stopped
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=stella
+      # Preserve the existing Compose volume layout across the image switch.
+      - PGDATA=/var/lib/postgresql/data
     volumes:
       - stella-pg-data:/var/lib/postgresql/data
     healthcheck:


### PR DESCRIPTION
## What

Switch the default PostgreSQL service in `docker-compose.yml` to the pinned ParadeDB PostgreSQL 18 image.

## Why

Stella requires `pg_search` and `pgvector`; the previous stock PostgreSQL image did not provide those extensions.

## How

- Use `paradedb/paradedb:0.24.0-pg18` rather than a floating image tag.
- Preload `pg_search` and `pg_cron`, which ParadeDB's bootstrap requires.
- Preserve the existing `stella-pg-data` volume location by overriding `PGDATA` to `/var/lib/postgresql/data`.

## Test

- `docker compose config -q`
- Isolated ParadeDB container smoke test with the Compose `PGDATA` and preload settings.
- `mise run format && mise run build && mise run test`

No focused automated test was added: this is declarative Compose configuration, covered by the validated rendered configuration and container startup. Documentation is unchanged because the shipped Compose file is the user-facing default and existing deployment docs already state the required PostgreSQL extensions. Agent-behavior evals and unevaluated media/document/binary surfaces are not applicable. No earlier measurement is superseded.

## Refs

Refs #591

## Checklist

- [x] The PR links a GitHub issue, or states why the fix is small enough not to need one.
- [x] I added or updated focused tests for changed non-trivial behavior, or explained why none are needed.
- [x] I updated relevant English and Chinese documentation, or no documentation change is needed.
- [x] I ran `mise run format && mise run build && mise run test`.
- [x] If this changes agent behavior (tools, prompts, the runner loop): I included eval evidence with both jobs, commits, tier, k, host, and model, or stated why it is not applicable. See `test/evals/harbor/README.md`.
- [x] If the change touches a surface no eval task exercises (pixel understanding, document extraction, CRLF fidelity, non-UTF-8, binary handling): I said so, and named the tests that cover it instead.
- [x] Any earlier measurement this PR invalidates is marked superseded with its reason, not deleted.

## Feishu Task

- [提供 Stella 官方 PostgreSQL 镜像与 Docker 部署文档](https://mcnnox2fhjfq.feishu.cn/record/BPVurRToOeMQqjc8kcjcDeiKnyb) (#591)
