### PR TITLE
🔧 chore(build): move script-bodied mise tasks into .mise/tasks and gate shell with shellcheck

### DIFF
--- a/.mise/lib/github-token.sh
+++ b/.mise/lib/github-token.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Resolve GITHUB_TOKEN for image builds that fetch release assets.
+#
+# Sourced, not executed: it exports into the caller's shell. Lives outside
+# .mise/tasks/ so mise cannot mistake it for a task.
+#
+# Order: an explicit GITHUB_TOKEN, then GH_TOKEN, then whatever `gh` is logged
+# in as. A missing token is not an error; the image builds without the secret
+# and the caller decides what that means.
+export GITHUB_TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
+if [ -z "$GITHUB_TOKEN" ] && command -v gh >/dev/null 2>&1; then
+  GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)"
+  export GITHUB_TOKEN
+fi

--- a/.mise/tasks/build
+++ b/.mise/tasks/build
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#MISE description="Build stellad binary"
+#MISE depends=["generate"]
+set -euo pipefail
+
+# go:embed snapshots web/static/dist at compile time, and nothing else in this
+# task guarantees it exists: without the guard a fresh clone builds a binary
+# that serves an empty Web UI and reports no error. Presence, not freshness;
+# editing web sources still needs an explicit `mise run build:web`.
+[ -d web/static/dist ] || mise run build:web
+
+rm -rf ./dist/bin
+mkdir -p ./dist/bin
+
+VERSION=${VERSION:-$(git describe --tags --always --dirty 2>/dev/null || echo dev)}
+COMMIT=${COMMIT:-$(git rev-parse --short HEAD 2>/dev/null || echo '')}
+BUILD_DATE=${BUILD_DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}
+LDFLAGS="-X github.com/CherryHQ/stella/internal/version.Version=$VERSION -X github.com/CherryHQ/stella/internal/version.Commit=$COMMIT -X github.com/CherryHQ/stella/internal/version.BuildDate=$BUILD_DATE"
+
+# STRIP=1 drops the symbol and DWARF tables, ~35 MB, for image builds. Opt-in
+# because local builds want symbols for delve. Panic tracebacks are generated
+# from gopclntab, which -s -w does not touch, so function names and line
+# numbers survive; only source-level debugging is lost.
+if [ "${STRIP:-0}" = "1" ]; then
+  LDFLAGS="-s -w $LDFLAGS"
+fi
+
+# Generators are host tools; cross-compile only the final binary.
+if [ -n "${TARGET_GOOS+x}" ] || [ -n "${TARGET_GOARCH+x}" ]; then
+  if [ -z "${TARGET_GOOS:-}" ] || [ -z "${TARGET_GOARCH:-}" ]; then
+    echo "ERROR: TARGET_GOOS and TARGET_GOARCH must be set together" >&2
+    exit 1
+  fi
+  env GOOS="$TARGET_GOOS" GOARCH="$TARGET_GOARCH" \
+    go build -ldflags="$LDFLAGS" -o "$BINARY_D" ./cmd/stellad
+else
+  go build -ldflags="$LDFLAGS" -o "$BINARY_D" ./cmd/stellad
+fi

--- a/.mise/tasks/dev/docker
+++ b/.mise/tasks/dev/docker
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#MISE description="Start the Docker dev stack: stellad + docker sandbox + otel-lgtm"
+#MISE depends=["docker:build", "sandbox:docker:build"]
+set -euo pipefail
+
+docker volume create stella-data >/dev/null
+docker volume create stella-otel-data >/dev/null
+docker volume create stella-pg-data >/dev/null
+
+# The stack decrypts what a previous run encrypted, so the key has to outlive
+# the containers: keep it in the dev home's .env and generate it once.
+ENV_FILE="${STELLA_HOME:-$HOME/.stella-dev}/.env"
+mkdir -p "$(dirname "$ENV_FILE")"
+if ! grep -q '^STELLA_VAULT_KEY=' "$ENV_FILE" 2>/dev/null; then
+  docker run --rm stella:latest stellad vault keygen | sed 's/^/STELLA_VAULT_KEY=/' >> "$ENV_FILE"
+fi
+
+# shellcheck source=../../lib/github-token.sh
+source .mise/lib/github-token.sh
+
+# The container joins the group that owns the host socket so it can talk to the
+# Docker daemon. Docker Desktop proxies the socket and reports gid 0 regardless,
+# so only Linux needs the lookup.
+if [ "$(uname -s)" = "Darwin" ]; then
+  DOCKER_SOCKET_GID=0
+else
+  DOCKER_SOCKET_GID="$(stat -c %g /var/run/docker.sock 2>/dev/null || echo 0)"
+fi
+export DOCKER_SOCKET_GID
+
+export STELLA_IMAGE=stella:latest
+docker compose up -d otel
+docker compose up -d --force-recreate stella-volume-init stella
+
+echo "stella up — UI http://localhost:25688 · Grafana http://localhost:13413"
+echo "logs: docker compose logs -f stella   ·   stop: docker compose down"

--- a/.mise/tasks/docker/build
+++ b/.mise/tasks/docker/build
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#MISE description="Build Docker image"
+set -euo pipefail
+
+# shellcheck source=../../lib/github-token.sh
+source .mise/lib/github-token.sh
+
+VERSION=${VERSION:-$(git describe --tags --always --dirty 2>/dev/null || echo dev)}
+
+args=(--build-arg "VERSION=$VERSION" -t stella:latest)
+if [ -n "$GITHUB_TOKEN" ]; then
+  args=("--secret" "id=github_token,env=GITHUB_TOKEN" "${args[@]}")
+fi
+
+DOCKER_BUILDKIT=1 docker build "${args[@]}" .

--- a/.mise/tasks/generate/api
+++ b/.mise/tasks/generate/api
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#MISE description="Assemble api/spec/components.yaml from domain files then generate Go types and server"
+set -euo pipefail
+
+# Assemble through a unique sibling temp file: a shared /tmp path collides when
+# two checkouts generate at once, and a fixed name leaks an untracked file into
+# the worktree if yq fails before the mv.
+components_tmp=$(mktemp api/spec/components.yaml.tmp.XXXXXX)
+trap 'rm -f "$components_tmp"' EXIT
+
+# shellcheck disable=SC2016  # single quotes are deliberate: $item is a yq variable
+yq eval-all '. as $item ireduce ({}; . *+ $item) | .info.title = "stella API Components" | .info.description = "Assembled from api/spec/components/common.yaml + api/spec/domain/*/schemas.yaml — DO NOT EDIT"' \
+  api/spec/components/common.yaml api/spec/domain/*/schemas.yaml \
+  > "$components_tmp"
+mv "$components_tmp" api/spec/components.yaml
+
+dprint fmt api/spec/components.yaml
+go tool oapi-codegen --config api/codegen/types.yaml api/spec/components.yaml
+go tool oapi-codegen --config api/codegen/server.yaml api/spec/openapi.yaml
+go run ./internal/goal/cmd/gengoalcontrolschema
+
+# Pin: redocly 2.40.0 tightened YAML parsing and rejects openapi.yaml's flow
+# mappings (issue #769). Bump deliberately after verifying the spec still bundles.
+vp dlx @redocly/cli@2.39.0 bundle api/spec/openapi.yaml -o internal/server/docs_spec.yaml
+
+go run ./internal/cmd/toolgen

--- a/.mise/tasks/lint/shell
+++ b/.mise/tasks/lint/shell
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#MISE description="Run shellcheck over the repository's shell scripts and .mise file tasks"
+set -euo pipefail
+
+# File tasks carry no extension, so they are found by the executable bit rather
+# than by glob. -x follows `source`d libraries, which is how the shared
+# github-token helper gets checked at each call site.
+#
+# No mapfile: macOS ships bash 3.2, and every file task has to run there.
+targets=()
+while IFS= read -r target; do
+  targets+=("$target")
+done < <(
+  git ls-files '*.sh'
+  find .mise -type f -perm -u+x | sort
+)
+
+# --source-path=SCRIPTDIR: `source` directives in the existing scripts are
+# written relative to the script, not to the repository root this runs from.
+shellcheck -x --source-path=SCRIPTDIR "${targets[@]}"
+echo "shellcheck: ${#targets[@]} files clean"

--- a/.mise/tasks/release/snapshot
+++ b/.mise/tasks/release/snapshot
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#MISE description="Create host-only snapshot build and verify single-binary archive"
+set -euo pipefail
+
+goreleaser release --snapshot --clean --skip=publish
+
+echo "Verifying archive contains stellad..."
+goos=$(go env GOOS)
+goarch=$(go env GOARCH)
+
+# The archive extension follows the platform, and neither `ls` finding nothing
+# is an error here: the explicit check below reports it.
+archive=$(ls "dist/stella_"*"_${goos}_${goarch}.tar.gz" 2>/dev/null \
+  || ls "dist/stella_"*"_${goos}_${goarch}.zip" 2>/dev/null \
+  || true)
+if [ -z "$archive" ]; then
+  echo "ERROR: no archive found for host platform" >&2
+  exit 1
+fi
+
+bin="stellad"
+if [ "$goos" = "windows" ]; then
+  bin="stellad.exe"
+fi
+
+if ! tar tzf "$archive" 2>/dev/null | grep -Eq "(^|/)${bin}$" \
+  && ! unzip -l "$archive" 2>/dev/null | grep -Eq " ${bin}$"; then
+  echo "ERROR: $bin missing from $archive" >&2
+  exit 1
+fi
+
+echo "OK: archive $archive contains stellad"

--- a/.mise/tasks/sandbox/docker/build
+++ b/.mise/tasks/sandbox/docker/build
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#MISE description="Build local stella-sandbox:dev image (used by the docker sandbox backend in dev builds)"
+set -euo pipefail
+
+# shellcheck source=../../../lib/github-token.sh
+source .mise/lib/github-token.sh
+
+VERSION_ARG=${VERSION:-$(git describe --tags --always --dirty 2>/dev/null || echo dev)}
+BUNDLE_REVISION="$(go run ./cmd/stellad system-bundle revision)"
+
+args=(
+  --build-arg "VERSION=$VERSION_ARG"
+  --build-arg "BUILTIN_BUNDLE_REVISION=$BUNDLE_REVISION"
+  -f plugins/sandbox/docker/Dockerfile
+  -t stella-sandbox:dev
+)
+if [ -n "$GITHUB_TOKEN" ]; then
+  args=("--secret" "id=github_token,env=GITHUB_TOKEN" "${args[@]}")
+fi
+
+DOCKER_BUILDKIT=1 docker build "${args[@]}" .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ Stella is a single-tenant, multi-user, multi-agent AI assistant platform written
 - This project requires `mise` for development workflows.
 - On a fresh clone, run `mise run setup` once. Use `mise tasks` to discover workflows.
 - Run project workflows through `mise run <task>` instead of invoking underlying tools directly.
+- A task whose body is a script lives in `.mise/tasks/` (path = task name); one-liners stay in `mise.toml`. File tasks run under `set -euo pipefail`, must work on bash 3.2 (what macOS ships), and are linted by `mise run lint:shell`, which `mise run format` includes.
 - Before committing, **ALWAYS** run: `mise run format && mise run build && mise run test`.
 - `mise run system-test` runs the subprocess system suite (real `stellad` over TCP against embedded PostgreSQL); it is a local and tag-release gate and requires a supported runtime host. `mise run release:validate` runs the full local pre-release gate sequentially (format → build → test → system-test → release checks).
 - When touching platform-specific behavior, run a targeted cross-platform build before committing (e.g., `GOOS=windows GOARCH=amd64 go build -o dist/bin/stellad-windows-amd64.exe ./cmd/stellad`).

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,10 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV MISE_INSTALL_PATH="/usr/local/bin/mise"
 RUN curl -fsSL https://mise.run | sh
 WORKDIR /src
+# The whole mise config, not just mise.toml: task bodies live in .mise/tasks/,
+# and a stage that copies only the TOML fails on the first file task it runs.
 COPY mise.toml ./
+COPY .mise/ ./.mise/
 RUN mise trust && mise install node vp
 COPY api/spec/ ./api/spec/
 COPY web/ ./web/
@@ -35,6 +38,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV MISE_INSTALL_PATH="/usr/local/bin/mise"
 RUN curl -fsSL https://mise.run | sh
 COPY mise.toml mise.toml
+COPY .mise/ ./.mise/
 RUN mise trust
 
 # Build app

--- a/mise.toml
+++ b/mise.toml
@@ -5,6 +5,7 @@ dprint = "0.54.0"
 jq = "1.8.1"
 yq = "4.49.2"
 act = "0.2.88"
+shellcheck = "0.11.0"
 helm = "3.16.4"
 # Go
 "github:pressly/goose" = "3.27.1"
@@ -24,48 +25,11 @@ LOG_LEVEL = "debug"
 # ============================================================================
 # Build
 # ============================================================================
-
-[tasks.build]
-description = "Build stellad binary"
-depends = ["generate"]
-# One script, not a list: mise runs each list entry in its own shell, so the
-# variables exported by one entry are gone by the next and the build shipped
-# empty -ldflags.
-run = """
-# go:embed snapshots web/static/dist at compile time, and nothing else in this
-# task guarantees it exists: without the guard a fresh clone builds a binary
-# that serves an empty Web UI and reports no error. Presence, not freshness;
-# editing web sources still needs an explicit `mise run build:web`.
-[ -d web/static/dist ] || mise run build:web
-
-rm -rf ./dist/bin
-mkdir -p ./dist/bin
-
-VERSION=${VERSION:-$(git describe --tags --always --dirty 2>/dev/null || echo dev)}
-COMMIT=${COMMIT:-$(git rev-parse --short HEAD 2>/dev/null || echo '')}
-BUILD_DATE=${BUILD_DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}
-LDFLAGS="-X github.com/CherryHQ/stella/internal/version.Version=$VERSION -X github.com/CherryHQ/stella/internal/version.Commit=$COMMIT -X github.com/CherryHQ/stella/internal/version.BuildDate=$BUILD_DATE"
-
-# STRIP=1 drops the symbol and DWARF tables, ~35 MB, for image builds. Opt-in
-# because local builds want symbols for delve. Panic tracebacks are generated
-# from gopclntab, which -s -w does not touch, so function names and line
-# numbers survive; only source-level debugging is lost.
-if [ "${STRIP:-0}" = "1" ]; then
-  LDFLAGS="-s -w $LDFLAGS"
-fi
-
-# Generators are host tools; cross-compile only the final binary.
-if [ -n "${TARGET_GOOS+x}" ] || [ -n "${TARGET_GOARCH+x}" ]; then
-  if [ -z "${TARGET_GOOS:-}" ] || [ -z "${TARGET_GOARCH:-}" ]; then
-    echo "ERROR: TARGET_GOOS and TARGET_GOARCH must be set together" >&2
-    exit 1
-  fi
-  env GOOS="$TARGET_GOOS" GOARCH="$TARGET_GOARCH" \
-    go build -ldflags="$LDFLAGS" -o "$BINARY_D" ./cmd/stellad
-else
-  go build -ldflags="$LDFLAGS" -o "$BINARY_D" ./cmd/stellad
-fi
-"""
+#
+# Tasks whose body is a script rather than a command live in .mise/tasks/ (path
+# = task name, so .mise/tasks/sandbox/docker/build is `sandbox:docker:build`).
+# They run under `set -euo pipefail` and are covered by shellcheck; a TOML `run`
+# string is neither. Keep one-liners here.
 
 [tasks.clean]
 description = "Remove build artifacts"
@@ -90,27 +54,6 @@ sqlc generate
 description = "Generate TypeScript client (types + fetch client + Tanstack Query hooks) from OpenAPI spec"
 dir = "web"
 run = "vp install && vp exec openapi-ts"
-
-[tasks."generate:api"]
-description = "Assemble api/spec/components.yaml from domain files then generate Go types and server"
-run = """
-# Assemble through a unique sibling temp file: a shared /tmp path collides when
-# two checkouts generate at once, and a fixed name leaks an untracked file into
-# the worktree if yq fails before the mv.
-components_tmp=$(mktemp api/spec/components.yaml.tmp.XXXXXX)
-trap 'rm -f "$components_tmp"' EXIT
-yq eval-all '. as $item ireduce ({}; . *+ $item) | .info.title = "stella API Components" | .info.description = "Assembled from api/spec/components/common.yaml + api/spec/domain/*/schemas.yaml — DO NOT EDIT"' \
-  api/spec/components/common.yaml api/spec/domain/*/schemas.yaml \
-  > "$components_tmp" && mv "$components_tmp" api/spec/components.yaml
-dprint fmt api/spec/components.yaml
-go tool oapi-codegen --config api/codegen/types.yaml   api/spec/components.yaml
-go tool oapi-codegen --config api/codegen/server.yaml  api/spec/openapi.yaml
-go run ./internal/goal/cmd/gengoalcontrolschema
-# Pin: redocly 2.40.0 tightened YAML parsing and rejects openapi.yaml's flow
-# mappings (issue #769). Bump deliberately after verifying the spec still bundles.
-vp dlx @redocly/cli@2.39.0 bundle api/spec/openapi.yaml -o internal/server/docs_spec.yaml
-go run ./internal/cmd/toolgen
-"""
 
 [tasks."generate:check"]
 description = "Generate code and fail if generated files drift"
@@ -151,45 +94,6 @@ exec ./dist/bin/testbed start
 [tasks."testbed:stop"]
 description = "Stop and clean up this checkout's Stella testbed"
 run = 'go run ./test/testbed stop'
-
-[tasks."dev:docker"]
-description = "Start the Docker dev stack: stellad + docker sandbox + otel-lgtm"
-depends = ["docker:build", "sandbox:docker:build"]
-run = """
-  docker volume create stella-data >/dev/null
-  docker volume create stella-otel-data >/dev/null
-  docker volume create stella-pg-data >/dev/null
-
-  ENV_FILE="${STELLA_HOME:-$HOME/.stella-dev}/.env"
-  mkdir -p "$(dirname "$ENV_FILE")"
-  if ! grep -q '^STELLA_VAULT_KEY=' "$ENV_FILE" 2>/dev/null; then
-    docker run --rm stella:latest stellad vault keygen | sed 's/^/STELLA_VAULT_KEY=/' >> "$ENV_FILE"
-  fi
-
-  export GITHUB_TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
-  if [ -z "$GITHUB_TOKEN" ] && command -v gh >/dev/null 2>&1; then
-    export GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)"
-  fi
-
-  if [ "$(uname -s)" = "Darwin" ]; then
-    DOCKER_SOCKET_GID=0
-  else
-    DOCKER_SOCKET_GID="$(python3 - <<'PY'
-import os
-try:
-    print(os.stat('/var/run/docker.sock').st_gid)
-except OSError:
-    print(0)
-PY
-    )"
-  fi
-  export DOCKER_SOCKET_GID
-
-  STELLA_IMAGE=stella:latest docker compose up -d otel
-  STELLA_IMAGE=stella:latest docker compose up -d --force-recreate stella-volume-init stella
-  echo "stella up — UI http://localhost:25688 · Grafana http://localhost:13413"
-  echo "logs: docker compose logs -f stella   ·   stop: docker compose down"
-"""
 
 # ============================================================================
 # Code Quality
@@ -267,6 +171,7 @@ run = [
   "dprint fmt",
   "go mod tidy",
   "golangci-lint run --fix ./...",
+  "mise run lint:shell",
   "cd web && vp install && vp check --fix",
 ]
 
@@ -343,21 +248,6 @@ mise run release:check
 mise run release:snapshot
 """
 
-[tasks."release:snapshot"]
-description = "Create host-only snapshot build and verify single-binary archive"
-run = """
-goreleaser release --snapshot --clean --skip=publish
-echo "Verifying archive contains stellad..."
-archive=$(ls dist/stella_*_$(go env GOOS)_$(go env GOARCH).tar.gz 2>/dev/null || ls dist/stella_*_$(go env GOOS)_$(go env GOARCH).zip 2>/dev/null)
-if [ -z "$archive" ]; then echo "ERROR: no archive found for host platform" >&2; exit 1; fi
-suffix=""; [ "$(go env GOOS)" = "windows" ] && suffix=".exe"
-bin="stellad${suffix}"
-if ! tar tzf "$archive" 2>/dev/null | grep -Eq "(^|/)${bin}$" && ! unzip -l "$archive" 2>/dev/null | grep -Eq " ${bin}$"; then
-  echo "ERROR: $bin missing from $archive" >&2; exit 1
-fi
-echo "OK: archive $archive contains stellad"
-"""
-
 # ============================================================================
 # Deploy
 # ============================================================================
@@ -365,37 +255,3 @@ echo "OK: archive $archive contains stellad"
 [tasks."deploy:helm:check"]
 description = "Lint and render-assert the Kubernetes Helm chart"
 run = "bash deploy/helm/check.sh"
-
-# ============================================================================
-# Docker
-# ============================================================================
-
-[tasks."docker:build"]
-description = "Build Docker image"
-run = "VERSION=${VERSION:-$(git describe --tags --always --dirty 2>/dev/null || echo dev)}; export GITHUB_TOKEN=\"${GITHUB_TOKEN:-${GH_TOKEN:-}}\"; if [ -z \"$GITHUB_TOKEN\" ] && command -v gh >/dev/null 2>&1; then export GITHUB_TOKEN=\"$(gh auth token 2>/dev/null || true)\"; fi; if [ -n \"$GITHUB_TOKEN\" ]; then DOCKER_BUILDKIT=1 docker build --secret id=github_token,env=GITHUB_TOKEN --build-arg VERSION=$VERSION -t stella:latest .; else DOCKER_BUILDKIT=1 docker build --build-arg VERSION=$VERSION -t stella:latest .; fi"
-
-[tasks."sandbox:docker:build"]
-description = "Build local stella-sandbox:dev image (used by the docker sandbox backend in dev builds)"
-run = """
-  DIR=plugins/sandbox/docker
-  VERSION_ARG=${VERSION:-$(git describe --tags --always --dirty 2>/dev/null || echo dev)}
-	BUNDLE_REVISION="$(go run ./cmd/stellad system-bundle revision)"
-  export GITHUB_TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
-  if [ -z "$GITHUB_TOKEN" ] && command -v gh >/dev/null 2>&1; then
-    export GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)"
-  fi
-  if [ -n "${GITHUB_TOKEN:-}" ]; then
-    DOCKER_BUILDKIT=1 docker build \
-      --secret id=github_token,env=GITHUB_TOKEN \
-      --build-arg VERSION=$VERSION_ARG \
-		--build-arg BUILTIN_BUNDLE_REVISION=$BUNDLE_REVISION \
-      -f "$DIR/Dockerfile" \
-      -t stella-sandbox:dev .
-  else
-    DOCKER_BUILDKIT=1 docker build \
-      --build-arg VERSION=$VERSION_ARG \
-		--build-arg BUILTIN_BUNDLE_REVISION=$BUNDLE_REVISION \
-      -f "$DIR/Dockerfile" \
-      -t stella-sandbox:dev .
-  fi
-"""

--- a/resources/binaries/shell_env.sh
+++ b/resources/binaries/shell_env.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Stella-managed shell environment. Sourced by non-interactive Bash through
 # BASH_ENV and by Docker login shells through /etc/profile.d.
 #

--- a/test/evals/harbor/run_state.sh
+++ b/test/evals/harbor/run_state.sh
@@ -23,7 +23,9 @@ claim_run_state() {
         rmdir "$candidate_state" 2>/dev/null || true
         return 1
       fi
+      # shellcheck disable=SC2034  # read by loop.sh after this returns
       CLAIMED_JOB=$candidate_job
+      # shellcheck disable=SC2034  # read by loop.sh after this returns
       CLAIMED_RUN_STATE=$candidate_state
       return 0
     fi

--- a/test/perf/run.sh
+++ b/test/perf/run.sh
@@ -355,7 +355,8 @@ scenario_long_history() {
 
 scenario_streaming() {
   inject_metrics
-  local nonce="n$(date +%s)"
+  local nonce
+  nonce="n$(date +%s)"
   ev "window.__perf.start()" >/dev/null
   ev "window.__perf.send('$TA', 'stream $nonce')" >/dev/null
   local waited=0

--- a/web/toolchain_test.go
+++ b/web/toolchain_test.go
@@ -102,19 +102,16 @@ func TestDockerCrossBuildScopesGoTargetToFinalBuild(t *testing.T) {
 		t.Error("Dockerfile must clear GOOS/GOARCH and pass TARGET_GOOS/TARGET_GOARCH to mise")
 	}
 
-	mise, err := os.ReadFile(filepath.Join("..", "mise.toml"))
-	if err != nil {
-		t.Fatalf("read mise.toml: %v", err)
+	build := readBuildTask(t)
+	if !regexp.MustCompile(`(?s)TARGET_GOOS\+x.*TARGET_GOARCH\+x.*TARGET_GOOS:-.*TARGET_GOARCH:-.*must be set together.*exit 1`).Match(build) {
+		t.Error("the build task must reject a missing TARGET_GOOS or TARGET_GOARCH")
 	}
-	if !regexp.MustCompile(`(?s)TARGET_GOOS\+x.*TARGET_GOARCH\+x.*TARGET_GOOS:-.*TARGET_GOARCH:-.*must be set together.*exit 1`).Match(mise) {
-		t.Error("mise build must reject a missing TARGET_GOOS or TARGET_GOARCH")
-	}
-	if strings.Count(string(mise), `GOOS="$TARGET_GOOS"`) != 1 || strings.Count(string(mise), `GOARCH="$TARGET_GOARCH"`) != 1 {
+	if strings.Count(string(build), `GOOS="$TARGET_GOOS"`) != 1 || strings.Count(string(build), `GOARCH="$TARGET_GOARCH"`) != 1 {
 		t.Error("TARGET_GOOS/TARGET_GOARCH must map to GOOS/GOARCH exactly once")
 	}
 	finalBuild := regexp.MustCompile(`(?s)env\s+GOOS="\$TARGET_GOOS"\s+GOARCH="\$TARGET_GOARCH"\s+\\?\s*go\s+build\b`)
-	if !finalBuild.Match(mise) {
-		t.Error("mise must apply GOOS/GOARCH only to the final go build")
+	if !finalBuild.Match(build) {
+		t.Error("the build task must apply GOOS/GOARCH only to the final go build")
 	}
 }
 
@@ -123,15 +120,12 @@ func TestDockerCrossBuildScopesGoTargetToFinalBuild(t *testing.T) {
 // their symbols, so the strip is opt-in through STRIP=1 rather than a change to
 // the default of `mise run build`.
 func TestImagesStripSymbolTables(t *testing.T) {
-	mise, err := os.ReadFile(filepath.Join("..", "mise.toml"))
-	if err != nil {
-		t.Fatalf("read mise.toml: %v", err)
+	build := readBuildTask(t)
+	if !regexp.MustCompile(`(?s)STRIP:-0.*LDFLAGS="-s -w \$LDFLAGS"`).Match(build) {
+		t.Error("the build task must add -s -w to LDFLAGS when STRIP=1")
 	}
-	if !regexp.MustCompile(`(?s)STRIP:-0.*LDFLAGS="-s -w \$LDFLAGS"`).Match(mise) {
-		t.Error("mise build must add -s -w to LDFLAGS when STRIP=1")
-	}
-	if regexp.MustCompile(`(?m)^\s*LDFLAGS="-s -w -X`).Match(mise) {
-		t.Error("mise build must not strip by default; local builds need symbols for delve")
+	if regexp.MustCompile(`(?m)^\s*LDFLAGS="-s -w -X`).Match(build) {
+		t.Error("the build task must not strip by default; local builds need symbols for delve")
 	}
 
 	dockerfile, err := os.ReadFile(filepath.Join("..", "Dockerfile"))
@@ -157,20 +151,40 @@ func TestImagesStripSymbolTables(t *testing.T) {
 // presence, not freshness: a rebuild after editing web sources still needs an
 // explicit `mise run build:web`.
 func TestBuildEnsuresEmbeddedWebUI(t *testing.T) {
-	mise, err := os.ReadFile(filepath.Join("..", "mise.toml"))
-	if err != nil {
-		t.Fatalf("read mise.toml: %v", err)
+	build := readBuildTask(t)
+	if !regexp.MustCompile(`\[ -d web/static/dist \] \|\| mise run build:web`).Match(build) {
+		t.Error("the build task must build the SPA when web/static/dist is missing")
 	}
-	if !regexp.MustCompile(`\[ -d web/static/dist \] \|\| mise run build:web`).Match(mise) {
-		t.Error("mise build must build the SPA when web/static/dist is missing")
-	}
-	// Scoped to [tasks.build]: build:embedded depends on build:web by design.
-	task := regexp.MustCompile(`(?s)\n\[tasks\.build\]\n.*?\n\[tasks\.`).Find(mise)
-	if task == nil {
-		t.Fatal("could not find the [tasks.build] section in mise.toml")
-	}
-	if regexp.MustCompile(`(?m)^depends = \[[^\]]*build:web`).Match(task) {
+	if regexp.MustCompile(`(?m)^#MISE depends=\[[^\]]*build:web`).Match(build) {
 		t.Error("build must not depend on build:web; it is uncached and would tax every Go rebuild")
+	}
+}
+
+// The build task is a file task: .mise/tasks/build, named by its path.
+func readBuildTask(t *testing.T) []byte {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join("..", ".mise", "tasks", "build"))
+	if err != nil {
+		t.Fatalf("read .mise/tasks/build: %v", err)
+	}
+	return body
+}
+
+// Every builder stage that runs a mise task needs the whole mise config, not
+// just mise.toml: task bodies live in .mise/tasks/ and a stage missing them
+// fails on the first file task it reaches.
+func TestDockerfileCopiesWholeMiseConfig(t *testing.T) {
+	dockerfile, err := os.ReadFile(filepath.Join("..", "Dockerfile"))
+	if err != nil {
+		t.Fatalf("read Dockerfile: %v", err)
+	}
+	toml := regexp.MustCompile(`(?m)^COPY mise\.toml\b`).FindAll(dockerfile, -1)
+	tasks := regexp.MustCompile(`(?m)^COPY \.mise/`).FindAll(dockerfile, -1)
+	if len(toml) == 0 {
+		t.Fatal("no stage copies mise.toml; this test is watching the wrong thing")
+	}
+	if len(tasks) != len(toml) {
+		t.Errorf("%d stages copy mise.toml but %d copy .mise/; every stage that runs a mise task needs both", len(toml), len(tasks))
 	}
 }
 


### PR DESCRIPTION
## What

Moves the six mise tasks whose body is a script into `.mise/tasks/`, makes both Dockerfile builder stages copy the whole mise config, and adds a shellcheck gate over every shell file in the repository.

Stacked on #1153 — review that first; this PR's base is its branch.

## Why

A TOML `run` string gets no shellcheck, no `set -e`, and no syntax highlighting. #1153 is what that costs: `mise run build` compiled with an empty `-ldflags` for as long as the task existed, because each entry of a `run` array executes in its own shell and every `export` was discarded. No tool in the repo could have flagged it.

The remaining TOML-embedded scripts hold real logic: `dev:docker` (42 lines, embedded Python heredoc), `docker:build` (one line of escaped quotes, duplicated `docker build` differing only by `--secret`), `release:snapshot` (archive verification with two `exit 1` paths).

Separately, `Dockerfile:14` and `:37` copied only `mise.toml` before running a mise task. That is fine while every body is inline and breaks the moment one is not — the failure mode this PR would otherwise have introduced.

## How

**Migrated** (path = task name): `build`, `generate:api`, `release:snapshot`, `docker:build`, `sandbox:docker:build`, `dev:docker`. Each runs `set -euo pipefail` and keeps its metadata in `#MISE description=` / `#MISE depends=` headers. `mise tasks` lists the same names, and `mise.toml`'s `[env]` still reaches them (verified: `BINARY_D` resolves).

**Not migrated:** `release:validate` (a chain of `mise run` calls that reads better as a list) and `db:migrate:new` (uses the `{{arg(...)}}` template, which file tasks do not have). One-liners stay in TOML.

**Deduplicated:** the two docker tasks shared a copy-pasted `GITHUB_TOKEN` fallback and a `docker build` invocation duplicated across an if/else that differed only by `--secret`. Both now source `.mise/lib/github-token.sh` and assemble an argument array. The library lives outside `.mise/tasks/` because mise treats every executable under `tasks/` as a task.

**Two latent bugs `set -e` exposed in `release:snapshot`:**

- `archive=$(ls … || ls …)` swallowed its own failure; now explicitly `|| true` with the existing empty-check reporting it.
- `[ "$(go env GOOS)" = "windows" ] && suffix=".exe"` returns non-zero on every non-Windows host. Harmless as written, fatal under `set -e`; rewritten as an `if`.

**Dockerfile:** both stages now `COPY .mise/ ./.mise/` next to `COPY mise.toml`. `TestDockerfileCopiesWholeMiseConfig` asserts the two COPY counts stay equal, so a stage added later cannot copy one without the other.

**`dev:docker`** drops the embedded Python heredoc for `stat -c %g /var/run/docker.sock 2>/dev/null || echo 0`. Same value, same fallback, one less interpreter. The Darwin branch is unchanged.

**shellcheck:** new `lint:shell` task, included in `mise run format`, covering every tracked `*.sh` plus every executable under `.mise/` (found by the executable bit — file tasks have no extension). It runs `-x --source-path=SCRIPTDIR` so `source`d libraries are followed at each call site. Six pre-existing findings in the repo's own scripts are fixed or annotated: a missing shell directive in `resources/binaries/shell_env.sh`, two `SC2034`s in `run_state.sh` (both read by `loop.sh` after the call), and one `SC2155` in `test/perf/run.sh`.

**Constraint worth knowing:** file tasks must run on bash 3.2, what macOS ships. `mapfile` in the first draft of `lint:shell` failed there; no `mapfile`, no associative arrays, no `${var,,}`. Recorded in `AGENTS.md`.

## Test

- `mise run format && mise run build && mise run test` — all pass.
- `mise run lint:shell` — clean across 19 files.
- `mise tasks` — same task names and descriptions as before the move.
- `mise run build` on a tree with `web/static/dist` deleted: rebuilt the SPA, produced a binary stamped `0.63.0-119-ge7803120d-dirty`. With `STRIP=1`: 178,977,970 B, identical to the pre-move build in #1153.
- `bash -n` on the four tasks that cannot be exercised here (docker/compose/goreleaser).
- Both new assertions verified by deliberate breakage: removing one `COPY .mise/` fails `TestDockerfileCopiesWholeMiseConfig`; removing the SPA guard fails `TestBuildEnsuresEmbeddedWebUI`.
- **Not run:** `docker:build`, `sandbox:docker:build`, `dev:docker`, `release:snapshot`. They need a Docker daemon or a full goreleaser run. They are shellcheck-clean and syntax-checked; the Dockerfile COPY contract they depend on is asserted by test.

## Refs

Closes #1154
Stacked on #1153

## Checklist

- [x] The PR links a GitHub issue, or states why the fix is small enough not to need one.
- [x] I added or updated focused tests for changed non-trivial behavior, or explained why none are needed. `TestDockerfileCopiesWholeMiseConfig` is new; the three tests from #1153 now read `.mise/tasks/build`.
- [x] I updated relevant English and Chinese documentation, or no documentation change is needed. The convention is recorded in `AGENTS.md`, which is single-language; no user-facing doc changes.
- [x] I ran `mise run format && mise run build && mise run test`.
- [x] Not applicable: build tooling only, no agent behavior (tools, prompts, runner loop) changes.
- [x] Not applicable: no runtime data surface is touched. `resources/binaries/shell_env.sh` gains a `# shellcheck shell=bash` comment; its behavior when sourced is unchanged and the embedded-binaries tests pass.
- [x] Not applicable: no earlier measurement is invalidated. The stripped-binary size is unchanged from #1153, byte for byte.

## Feishu Task

- [脚本型 mise 任务迁移到 .mise/tasks 并加 shellcheck 门禁](https://mcnnox2fhjfq.feishu.cn/record/UfhMr4gvKeyGjkcz01TcCYl3nrg) (#1154)
