### PR TITLE
✨ feat: add Stella settings mutations

### DIFF
--- a/cmd/stellad/commands.go
+++ b/cmd/stellad/commands.go
@@ -507,6 +507,28 @@ func setup(parent context.Context, cfg config.ServerConfig, baseURL string) (*se
 	}
 	mcpSvc := mcp.NewServiceForPool(db, mcpVault)
 
+	// Settings is registered before the pool starts, but its Agent management and
+	// runner invalidation dependencies are completed later in this composition
+	// root. Deferred adapters keep that dependency order explicit.
+	settingsAgentMutation := settings.NewDeferredAgentMutation()
+	settingsInvalidator := settings.NewDeferredRunnerInvalidator()
+	toolOverrides := agent.NewToolOverrideStore(db)
+	isManagedSettingsTool := func(ctx context.Context, name string) bool {
+		for _, entry := range builtinTools {
+			if entry.Tool != nil && entry.Tool.Definition().Name == name {
+				return true
+			}
+		}
+		if phost != nil {
+			for _, spec := range phost.EnabledToolSpecs(ctx) {
+				if spec.Name == name {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
 	serviceTools := []agent.BuiltinTool{
 		{Tool: goal.NewTool(goalSvc), Available: agent.BuiltinToolAvailable},
 		{Tool: sessionaccess.NewTool(sessionAccess), Available: func(ctx context.Context, params agent.RunnerParams) bool {
@@ -528,7 +550,12 @@ func setup(parent context.Context, cfg config.ServerConfig, baseURL string) (*se
 	}
 	builtinTools = append(builtinTools, serviceTools...)
 	builtinTools = append(builtinTools, agent.BuiltinTool{
-		Tool:      settings.NewTool(agentAccess),
+		Tool: settings.NewTool(agentAccess,
+			settings.WithAgentMutations(settingsAgentMutation),
+			settings.WithLibraryMutations(librarySvc),
+			settings.WithSkillMutations(settings.NewSkillMutator(skillAccess, skillStore)),
+			settings.WithToolOverrideMutations(settings.NewToolOverrideMutator(agentAccess, toolOverrides, settingsInvalidator, isManagedSettingsTool)),
+		),
 		Available: settings.Available,
 	})
 
@@ -624,6 +651,20 @@ func setup(parent context.Context, cfg config.ServerConfig, baseURL string) (*se
 	if err != nil {
 		return nil, fmt.Errorf("build Home deletion lifecycle: %w", err)
 	}
+	settingsAgentMutation.Bind(agentaccess.NewManagement(
+		agentAccess,
+		store,
+		authStore,
+		poolMgr,
+		nil,
+		agent.NewAgentActivityStore(db),
+		credentialSvc,
+		store,
+		slog.With("component", "settings-agent-management"),
+		agentaccess.WithOwnerDeletion(homeDeletion),
+		agentaccess.WithAgentIDOccupancy(homeRegistry),
+	))
+	settingsInvalidator.Bind(poolMgr)
 	groupNudgeWorker := channel.NewGroupNudgeWorker()
 	riverClient, err := buildSharedRiverClient(db, schedulerSvc, goalSvc, embeddingSvc, librarySvc, groupNudgeWorker, cfg.Lifecycle.RiverSoftStopTimeout, cfg.Observability.RiverLogLevel)
 	if err != nil {

--- a/internal/agent/access/management.go
+++ b/internal/agent/access/management.go
@@ -45,6 +45,13 @@ type OwnerDeletion interface {
 	DeleteAgent(context.Context, string, string) error
 }
 
+// ConditionalOwnerDeletion keeps compare-and-delete inside the fenced Home
+// lifecycle transaction. Deleting the row before acquiring that fence would
+// strand the workspace and make the lifecycle owner observe a missing Agent.
+type ConditionalOwnerDeletion interface {
+	DeleteAgentIfUnchanged(context.Context, string, string, config.Agent) error
+}
+
 // ManagementOption configures optional Management dependencies.
 type ManagementOption func(*Management)
 
@@ -76,7 +83,6 @@ type AgentWriter interface {
 // lock or conditional SQL statement, never as two independent calls.
 type ConditionalAgentWriter interface {
 	UpdateAgentIfUnchanged(context.Context, config.Agent, config.Agent) error
-	DeleteAgentIfUnchanged(context.Context, config.Agent) error
 }
 
 // AssignmentWriter mutates and lists the user<->agent assignment relation.
@@ -377,13 +383,9 @@ func (m *Management) UpdateIfUnchanged(ctx context.Context, authority authz.Auth
 }
 
 // DeleteIfUnchanged authorizes and deletes only the Agent version confirmed by
-// the settings token. Storage performs the final comparison while holding the
-// row lock, before the destructive delete.
+// the settings token. The Home lifecycle owns the final comparison, row delete,
+// and execution fence as one transaction.
 func (m *Management) DeleteIfUnchanged(ctx context.Context, authority authz.Authority, expected config.Agent) error {
-	writer, ok := m.agents.(ConditionalAgentWriter)
-	if !ok {
-		return fmt.Errorf("%w: conditional Agent writer is not wired", ErrUnavailable)
-	}
 	acc, err := m.pep.Begin(ctx, authority)
 	if err != nil {
 		return err
@@ -391,15 +393,16 @@ func (m *Management) DeleteIfUnchanged(ctx context.Context, authority authz.Auth
 	if _, err := acc.Delete(ctx, expected.ID); err != nil {
 		return err
 	}
-	if err := writer.DeleteAgentIfUnchanged(ctx, expected); err != nil {
-		return err
+	conditional, ok := m.deletion.(ConditionalOwnerDeletion)
+	if !ok {
+		return fmt.Errorf("%w: conditional owner deletion is not wired", ErrUnavailable)
 	}
-	if m.deletion == nil {
-		return fmt.Errorf("%w: delete agent lifecycle is not wired", ErrUnavailable)
-	}
-	if err := m.deletion.DeleteAgent(ctx, expected.ID, string(authority.UserID())); err != nil {
+	if err := conditional.DeleteAgentIfUnchanged(ctx, expected.ID, string(authority.UserID()), expected); err != nil {
 		if errors.Is(err, config.ErrAgentInUse) || isAgentInUse(err) {
 			return ErrInUse
+		}
+		if errors.Is(err, config.ErrAgentChanged) {
+			return err
 		}
 		return fmt.Errorf("%w: delete agent: %w", ErrUnavailable, err)
 	}
@@ -429,7 +432,10 @@ func (m *Management) Delete(ctx context.Context, authority authz.Authority, agen
 
 func isAgentInUse(err error) bool {
 	var pgErr *pgconn.PgError
-	return errors.As(err, &pgErr) && (pgErr.Code == "23001" || pgErr.Code == "23503") && pgErr.ConstraintName == "webhook_agent_id_fkey"
+	if !errors.As(err, &pgErr) || (pgErr.Code != "23001" && pgErr.Code != "23503") {
+		return false
+	}
+	return pgErr.ConstraintName == "webhook_agent_id_fkey" || pgErr.ConstraintName == "library_file_agent_id_fkey"
 }
 
 // ListProviderCredentials returns secret-free credential metadata for an Agent.

--- a/internal/agent/access/management.go
+++ b/internal/agent/access/management.go
@@ -71,6 +71,14 @@ type AgentWriter interface {
 	DeleteAgent(ctx context.Context, id string) error
 }
 
+// ConditionalAgentWriter is the atomic compare-and-swap port used by model-side
+// settings confirmation. Implementations must compare and write under one row
+// lock or conditional SQL statement, never as two independent calls.
+type ConditionalAgentWriter interface {
+	UpdateAgentIfUnchanged(context.Context, config.Agent, config.Agent) error
+	DeleteAgentIfUnchanged(context.Context, config.Agent) error
+}
+
 // AssignmentWriter mutates and lists the user<->agent assignment relation.
 // auth.AuthStore satisfies it.
 type AssignmentWriter interface {
@@ -328,6 +336,74 @@ func (m *Management) Update(ctx context.Context, authority authz.Authority, cand
 	}
 	m.reload(ctx, candidate.ID)
 	return candidate, nil
+}
+
+// UpdateIfUnchanged applies the same Agent policy and server-owned field rules
+// as Update, then delegates the final compare-and-swap to the storage boundary.
+func (m *Management) UpdateIfUnchanged(ctx context.Context, authority authz.Authority, expected, candidate config.Agent) (config.Agent, error) {
+	writer, ok := m.agents.(ConditionalAgentWriter)
+	if !ok {
+		return config.Agent{}, fmt.Errorf("%w: conditional Agent writer is not wired", ErrUnavailable)
+	}
+	if expected.ID == "" || expected.ID != candidate.ID {
+		return config.Agent{}, config.ErrAgentChanged
+	}
+	acc, err := m.pep.Begin(ctx, authority)
+	if err != nil {
+		return config.Agent{}, err
+	}
+	existing, err := acc.Manage(ctx, candidate.ID)
+	if err != nil {
+		return config.Agent{}, err
+	}
+	if candidate.Scope == "" {
+		candidate.Scope = existing.Scope
+	}
+	if candidate.Scope != config.AgentScopeSystem && candidate.Scope != config.AgentScopeRestricted {
+		return config.Agent{}, ErrInvalidScope
+	}
+	candidate.Workspace = ""
+	candidate.CreatorID = existing.CreatorID
+	if candidate.Scope == config.AgentScopeRestricted && candidate.CreatorID != "" {
+		if err := m.assign.AssignAgent(ctx, candidate.CreatorID, candidate.ID); err != nil {
+			return config.Agent{}, fmt.Errorf("%w: assign creator: %w", ErrUnavailable, err)
+		}
+	}
+	if err := writer.UpdateAgentIfUnchanged(ctx, expected, candidate); err != nil {
+		return config.Agent{}, err
+	}
+	m.reload(ctx, candidate.ID)
+	return candidate, nil
+}
+
+// DeleteIfUnchanged authorizes and deletes only the Agent version confirmed by
+// the settings token. Storage performs the final comparison while holding the
+// row lock, before the destructive delete.
+func (m *Management) DeleteIfUnchanged(ctx context.Context, authority authz.Authority, expected config.Agent) error {
+	writer, ok := m.agents.(ConditionalAgentWriter)
+	if !ok {
+		return fmt.Errorf("%w: conditional Agent writer is not wired", ErrUnavailable)
+	}
+	acc, err := m.pep.Begin(ctx, authority)
+	if err != nil {
+		return err
+	}
+	if _, err := acc.Delete(ctx, expected.ID); err != nil {
+		return err
+	}
+	if err := writer.DeleteAgentIfUnchanged(ctx, expected); err != nil {
+		return err
+	}
+	if m.deletion == nil {
+		return fmt.Errorf("%w: delete agent lifecycle is not wired", ErrUnavailable)
+	}
+	if err := m.deletion.DeleteAgent(ctx, expected.ID, string(authority.UserID())); err != nil {
+		if errors.Is(err, config.ErrAgentInUse) || isAgentInUse(err) {
+			return ErrInUse
+		}
+		return fmt.Errorf("%w: delete agent: %w", ErrUnavailable, err)
+	}
+	return nil
 }
 
 // Delete authorizes (Delete) and removes an agent. Reload is best-effort.

--- a/internal/agent/access/management_test.go
+++ b/internal/agent/access/management_test.go
@@ -124,6 +124,10 @@ func (f fakeOwnerDeletion) DeleteAgent(ctx context.Context, id, actor string) er
 	return f.deleteAgent(ctx, id, actor)
 }
 
+func (f fakeOwnerDeletion) DeleteAgentIfUnchanged(ctx context.Context, id, actor string, _ config.Agent) error {
+	return f.deleteAgent(ctx, id, actor)
+}
+
 func (f *fakeReloader) SyncAgent(_ context.Context, id string) error {
 	f.synced = append(f.synced, id)
 	return f.err

--- a/internal/agent/prompt/template/system_prompt.tmpl
+++ b/internal/agent/prompt/template/system_prompt.tmpl
@@ -26,7 +26,7 @@ Before starting a shared deliverable another member could be building, say so in
 - A specialized tool listed by name: call it directly. Use built-in tools for Stella capabilities.
 {{ end }}- If listed, use `view_image` for pixels; use bash OCR or `xberg extract` for text.
 - Never shell out to the `stella` CLI. Never print secrets; available vault secrets are already bash environment variables. Store new runtime secrets with `vault`.
-- Use the read-only `stella_settings` tool to inspect supported settings in Stella's direct one-to-one sessions.
+- Use `stella_settings` to inspect supported settings in direct one-to-one sessions. Settings mutations require its model-side preview then single-use confirm protocol, which is not human approval.
 
 # Working model
 

--- a/internal/agent/tool_override_store.go
+++ b/internal/agent/tool_override_store.go
@@ -2,8 +2,10 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/CherryHQ/stella/pkg/db/pgnull"
@@ -35,6 +37,24 @@ func (s *ToolOverrideStore) Fetch(ctx context.Context, userID, agentID string) (
 		out = append(out, ToolOverride{ToolName: row.ToolName, Scope: row.Scope, Enabled: row.Enabled})
 	}
 	return out, nil
+}
+
+// Get returns one exact owner-bound override. Missing is not an error, because
+// clearing an absent override is an idempotent mutation.
+func (s *ToolOverrideStore) Get(ctx context.Context, k ToolOverrideKey) (ToolOverride, bool, error) {
+	if !isOverrideScope(k.Scope) {
+		return ToolOverride{}, false, fmt.Errorf("tool override: invalid scope %q", k.Scope)
+	}
+	row, err := s.q.GetToolOverride(ctx, sqlc.GetToolOverrideParams{
+		ToolName: k.ToolName, Scope: k.Scope, UserID: pgnull.Text(k.UserID), AgentID: pgnull.Text(k.AgentID),
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ToolOverride{}, false, nil
+	}
+	if err != nil {
+		return ToolOverride{}, false, err
+	}
+	return ToolOverride{ToolName: row.ToolName, Scope: row.Scope, Enabled: row.Enabled}, true, nil
 }
 
 // ToolOverrideWrite is the durable owner+scope key plus the desired enabled state

--- a/internal/agent/tool_override_store.go
+++ b/internal/agent/tool_override_store.go
@@ -2,6 +2,9 @@ package agent
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -15,12 +18,22 @@ import (
 // ToolOverrideStore reads persisted tool-visibility overrides for an
 // agent+user context. Its Fetch method satisfies ToolOverrideFetcher.
 type ToolOverrideStore struct {
-	q *sqlc.Queries
+	q    *sqlc.Queries
+	pool *pgxpool.Pool
 }
 
 // NewToolOverrideStore builds a ToolOverrideStore over the given pool.
 func NewToolOverrideStore(db *pgxpool.Pool) *ToolOverrideStore {
-	return &ToolOverrideStore{q: sqlc.New(db)}
+	return &ToolOverrideStore{q: sqlc.New(db), pool: db}
+}
+
+// ToolOverrideDigest is the stable digest used by the settings preview/confirm
+// protocol. It intentionally covers only the owner-bound row state that the
+// mutation changes, not database timestamps or surrogate IDs.
+func ToolOverrideDigest(found, enabled bool) string {
+	data, _ := json.Marshal(map[string]any{"found": found, "enabled": enabled})
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
 }
 
 // Fetch returns the tool overrides that apply to the given user+agent pair.
@@ -82,14 +95,80 @@ func (s *ToolOverrideStore) Set(ctx context.Context, w ToolOverrideWrite) error 
 	if !isOverrideScope(w.Scope) {
 		return fmt.Errorf("tool override: invalid scope %q", w.Scope)
 	}
-	_, err := s.q.UpsertToolOverride(ctx, sqlc.UpsertToolOverrideParams{
-		ToolName: w.ToolName,
-		Scope:    w.Scope,
-		UserID:   pgnull.Text(w.UserID),
-		AgentID:  pgnull.Text(w.AgentID),
-		Enabled:  w.Enabled,
+	return s.withKeyLock(ctx, ToolOverrideKey{ToolName: w.ToolName, Scope: w.Scope, UserID: w.UserID, AgentID: w.AgentID}, func(q *sqlc.Queries) error {
+		_, err := q.UpsertToolOverride(ctx, sqlc.UpsertToolOverrideParams{
+			ToolName: w.ToolName, Scope: w.Scope, UserID: pgnull.Text(w.UserID), AgentID: pgnull.Text(w.AgentID), Enabled: w.Enabled,
+		})
+		return err
 	})
-	return err
+}
+
+// SetIfDigest compares the current owner-bound row and upserts it in one
+// transaction. The row lock prevents a concurrent writer from changing the
+// value after the comparison and before the write.
+func (s *ToolOverrideStore) SetIfDigest(ctx context.Context, w ToolOverrideWrite, expected string) error {
+	if !isOverrideScope(w.Scope) {
+		return fmt.Errorf("tool override: invalid scope %q", w.Scope)
+	}
+	return s.mutateIfDigest(ctx, ToolOverrideKey{ToolName: w.ToolName, Scope: w.Scope, UserID: w.UserID, AgentID: w.AgentID}, expected, func(q *sqlc.Queries) error {
+		_, err := q.UpsertToolOverride(ctx, sqlc.UpsertToolOverrideParams{
+			ToolName: w.ToolName, Scope: w.Scope, UserID: pgnull.Text(w.UserID), AgentID: pgnull.Text(w.AgentID), Enabled: w.Enabled,
+		})
+		return err
+	})
+}
+
+// ClearIfDigest compares and deletes the current owner-bound row under one row
+// lock. An absent row is a valid compare target, so clear remains idempotent.
+func (s *ToolOverrideStore) ClearIfDigest(ctx context.Context, k ToolOverrideKey, expected string) error {
+	if !isOverrideScope(k.Scope) {
+		return fmt.Errorf("tool override: invalid scope %q", k.Scope)
+	}
+	return s.mutateIfDigest(ctx, k, expected, func(q *sqlc.Queries) error {
+		return q.DeleteToolOverride(ctx, sqlc.DeleteToolOverrideParams{
+			ToolName: k.ToolName, Scope: k.Scope, UserID: pgnull.Text(k.UserID), AgentID: pgnull.Text(k.AgentID),
+		})
+	})
+}
+
+func (s *ToolOverrideStore) mutateIfDigest(ctx context.Context, k ToolOverrideKey, expected string, mutate func(*sqlc.Queries) error) error {
+	return s.withKeyLock(ctx, k, func(q *sqlc.Queries) error {
+		row, err := q.GetToolOverrideForUpdate(ctx, sqlc.GetToolOverrideParams{
+			ToolName: k.ToolName, Scope: k.Scope, UserID: pgnull.Text(k.UserID), AgentID: pgnull.Text(k.AgentID),
+		})
+		found := err == nil
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return err
+		}
+		if expected != ToolOverrideDigest(found, found && row.Enabled) {
+			return errors.New("tool override changed since preview")
+		}
+		return mutate(q)
+	})
+}
+
+func (s *ToolOverrideStore) withKeyLock(ctx context.Context, k ToolOverrideKey, mutate func(*sqlc.Queries) error) error {
+	if s == nil || s.pool == nil {
+		return errors.New("tool override: conditional writer unavailable")
+	}
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin tool override mutation: %w", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck // successful commit makes rollback inert
+	q := s.q.WithTx(tx)
+	if err := q.LockToolOverrideKey(ctx, sqlc.LockToolOverrideKeyParams{LockKey: toolOverrideLockKey(k)}); err != nil {
+		return fmt.Errorf("lock tool override key: %w", err)
+	}
+	if err := mutate(q); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+func toolOverrideLockKey(k ToolOverrideKey) string {
+	data, _ := json.Marshal(k)
+	return string(data)
 }
 
 // Clear deletes a tool visibility override if present. The scope is validated for
@@ -98,11 +177,10 @@ func (s *ToolOverrideStore) Clear(ctx context.Context, k ToolOverrideKey) error 
 	if !isOverrideScope(k.Scope) {
 		return fmt.Errorf("tool override: invalid scope %q", k.Scope)
 	}
-	return s.q.DeleteToolOverride(ctx, sqlc.DeleteToolOverrideParams{
-		ToolName: k.ToolName,
-		Scope:    k.Scope,
-		UserID:   pgnull.Text(k.UserID),
-		AgentID:  pgnull.Text(k.AgentID),
+	return s.withKeyLock(ctx, k, func(q *sqlc.Queries) error {
+		return q.DeleteToolOverride(ctx, sqlc.DeleteToolOverrideParams{
+			ToolName: k.ToolName, Scope: k.Scope, UserID: pgnull.Text(k.UserID), AgentID: pgnull.Text(k.AgentID),
+		})
 	})
 }
 

--- a/internal/agent/tool_override_store.go
+++ b/internal/agent/tool_override_store.go
@@ -133,7 +133,7 @@ func (s *ToolOverrideStore) ClearIfDigest(ctx context.Context, k ToolOverrideKey
 
 func (s *ToolOverrideStore) mutateIfDigest(ctx context.Context, k ToolOverrideKey, expected string, mutate func(*sqlc.Queries) error) error {
 	return s.withKeyLock(ctx, k, func(q *sqlc.Queries) error {
-		row, err := q.GetToolOverrideForUpdate(ctx, sqlc.GetToolOverrideParams{
+		row, err := q.GetToolOverrideForUpdate(ctx, sqlc.GetToolOverrideForUpdateParams{
 			ToolName: k.ToolName, Scope: k.Scope, UserID: pgnull.Text(k.UserID), AgentID: pgnull.Text(k.AgentID),
 		})
 		found := err == nil
@@ -157,7 +157,7 @@ func (s *ToolOverrideStore) withKeyLock(ctx context.Context, k ToolOverrideKey, 
 	}
 	defer tx.Rollback(ctx) //nolint:errcheck // successful commit makes rollback inert
 	q := s.q.WithTx(tx)
-	if err := q.LockToolOverrideKey(ctx, sqlc.LockToolOverrideKeyParams{LockKey: toolOverrideLockKey(k)}); err != nil {
+	if err := q.LockToolOverrideKey(ctx, toolOverrideLockKey(k)); err != nil {
 		return fmt.Errorf("lock tool override key: %w", err)
 	}
 	if err := mutate(q); err != nil {

--- a/internal/agent/tool_override_store_test.go
+++ b/internal/agent/tool_override_store_test.go
@@ -67,6 +67,21 @@ func TestToolOverrideStoreRoundTrip(t *testing.T) {
 		t.Fatalf("fetched = %+v, want one disabled memory user_agent override", fetched)
 	}
 
+	store := NewToolOverrideStore(db)
+	key := ToolOverrideKey{ToolName: "memory", Scope: ToolOverrideScopeUserAgent, UserID: user.ID, AgentID: agentID}
+	if err := store.SetIfDigest(ctx, ToolOverrideWrite{ToolName: key.ToolName, Scope: key.Scope, UserID: key.UserID, AgentID: key.AgentID, Enabled: true}, ToolOverrideDigest(true, false)); err != nil {
+		t.Fatalf("SetIfDigest: %v", err)
+	}
+	if err := store.SetIfDigest(ctx, ToolOverrideWrite{ToolName: key.ToolName, Scope: key.Scope, UserID: key.UserID, AgentID: key.AgentID, Enabled: false}, ToolOverrideDigest(true, false)); err == nil {
+		t.Fatal("stale SetIfDigest succeeded")
+	}
+	if err := store.ClearIfDigest(ctx, key, ToolOverrideDigest(true, true)); err != nil {
+		t.Fatalf("ClearIfDigest: %v", err)
+	}
+	if err := store.ClearIfDigest(ctx, key, ToolOverrideDigest(false, false)); err != nil {
+		t.Fatalf("ClearIfDigest absent: %v", err)
+	}
+
 	if err := q.DeleteToolOverride(ctx, sqlc.DeleteToolOverrideParams{
 		ToolName: "memory", Scope: ToolOverrideScopeUserAgent,
 		UserID: pgnull.Text(user.ID), AgentID: pgnull.Text(agentID),

--- a/internal/config/agent.go
+++ b/internal/config/agent.go
@@ -7,7 +7,12 @@ import (
 
 // ErrAgentInUse prevents deleting an Agent while a durable resource still
 // depends on it. Callers surface this normal lifecycle conflict as HTTP 409.
-var ErrAgentInUse = errors.New("agent is still in use")
+var (
+	ErrAgentInUse = errors.New("agent is still in use")
+	// ErrAgentChanged is returned when a conditional settings mutation loses its
+	// compare-and-swap race against another Agent writer.
+	ErrAgentChanged = errors.New("agent changed since preview")
+)
 
 // AgentScope constants define the access scope for an agent.
 const (

--- a/internal/db/queries/tool_override.sql
+++ b/internal/db/queries/tool_override.sql
@@ -1,3 +1,6 @@
+-- name: LockToolOverrideKey :exec
+SELECT pg_advisory_xact_lock(hashtextextended(sqlc.arg(lock_key), 0));
+
 -- name: GetToolOverride :one
 SELECT * FROM tool_override
 WHERE tool_name = sqlc.arg(tool_name)
@@ -5,6 +8,15 @@ WHERE tool_name = sqlc.arg(tool_name)
   AND coalesce(user_id::text, '') = coalesce(sqlc.narg(user_id)::text, '')
   AND coalesce(agent_id, '') = coalesce(sqlc.narg(agent_id), '')
 LIMIT 1;
+
+-- name: GetToolOverrideForUpdate :one
+SELECT * FROM tool_override
+WHERE tool_name = sqlc.arg(tool_name)
+  AND scope = sqlc.arg(scope)
+  AND coalesce(user_id::text, '') = coalesce(sqlc.narg(user_id)::text, '')
+  AND coalesce(agent_id, '') = coalesce(sqlc.narg(agent_id), '')
+LIMIT 1
+FOR UPDATE;
 
 -- ListToolOverridesForAgentContext returns rows visible to one user and agent.
 -- name: ListToolOverridesForAgentContext :many

--- a/internal/db/queries/tool_override.sql
+++ b/internal/db/queries/tool_override.sql
@@ -1,3 +1,11 @@
+-- name: GetToolOverride :one
+SELECT * FROM tool_override
+WHERE tool_name = sqlc.arg(tool_name)
+  AND scope = sqlc.arg(scope)
+  AND coalesce(user_id::text, '') = coalesce(sqlc.narg(user_id)::text, '')
+  AND coalesce(agent_id, '') = coalesce(sqlc.narg(agent_id), '')
+LIMIT 1;
+
 -- ListToolOverridesForAgentContext returns rows visible to one user and agent.
 -- name: ListToolOverridesForAgentContext :many
 SELECT * FROM tool_override

--- a/internal/home/deletion.go
+++ b/internal/home/deletion.go
@@ -2,8 +2,10 @@ package home
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 
@@ -11,6 +13,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/CherryHQ/stella/internal/config"
 	"github.com/CherryHQ/stella/pkg/db/sqlc"
 )
 
@@ -45,20 +48,44 @@ func NewOwnerDeletion(db *pgxpool.Pool, manager *WorkspaceManager, fencer OwnerF
 }
 
 func (d *OwnerDeletion) DeleteGroup(ctx context.Context, id, actor string) error {
-	return d.delete(ctx, OwnerGroup, id, actor, func(ctx context.Context, q *sqlc.Queries, id string) error { return q.DeleteGroupState(ctx, id) })
+	return d.delete(ctx, OwnerGroup, id, actor, nil, func(ctx context.Context, q *sqlc.Queries, id string) error { return q.DeleteGroupState(ctx, id) })
 }
 
 func (d *OwnerDeletion) DeleteAgent(ctx context.Context, id, actor string) error {
-	return d.delete(ctx, OwnerAgent, id, actor, func(ctx context.Context, q *sqlc.Queries, id string) error { return q.DeleteAgent(ctx, id) })
+	return d.delete(ctx, OwnerAgent, id, actor, nil, func(ctx context.Context, q *sqlc.Queries, id string) error { return q.DeleteAgent(ctx, id) })
+}
+
+// DeleteAgentIfUnchanged compares the locked Agent row and deletes it inside the
+// same lifecycle fence and transaction. The fence must be acquired before the
+// row disappears so no new workspace or runner work can race the deletion.
+func (d *OwnerDeletion) DeleteAgentIfUnchanged(ctx context.Context, id, actor string, expected config.Agent) error {
+	check := func(ctx context.Context, q *sqlc.Queries, id string) error {
+		row, err := q.GetAgentForUpdate(ctx, id)
+		if err != nil {
+			return err
+		}
+		current, err := deletionAgentFromDB(row)
+		if err != nil {
+			return err
+		}
+		if !reflect.DeepEqual(current, expected) {
+			return config.ErrAgentChanged
+		}
+		return nil
+	}
+	return d.delete(ctx, OwnerAgent, id, actor, check, func(ctx context.Context, q *sqlc.Queries, id string) error { return q.DeleteAgent(ctx, id) })
 }
 
 func (d *OwnerDeletion) DeleteUser(ctx context.Context, id, actor string) error {
-	return d.delete(ctx, OwnerUser, id, actor, func(ctx context.Context, q *sqlc.Queries, id string) error { return q.DeleteAuthUser(ctx, id) })
+	return d.delete(ctx, OwnerUser, id, actor, nil, func(ctx context.Context, q *sqlc.Queries, id string) error { return q.DeleteAuthUser(ctx, id) })
 }
 
-type deleteFunc func(context.Context, *sqlc.Queries, string) error
+type (
+	deleteCheck func(context.Context, *sqlc.Queries, string) error
+	deleteFunc  func(context.Context, *sqlc.Queries, string) error
+)
 
-func (d *OwnerDeletion) delete(ctx context.Context, kind OwnerKind, id, actor string, del deleteFunc) error {
+func (d *OwnerDeletion) delete(ctx context.Context, kind OwnerKind, id, actor string, check deleteCheck, del deleteFunc) error {
 	if strings.TrimSpace(id) == "" || strings.TrimSpace(actor) == "" {
 		return errors.New("home: owner deletion ID and actor required")
 	}
@@ -84,6 +111,11 @@ func (d *OwnerDeletion) delete(ctx context.Context, kind OwnerKind, id, actor st
 	q := sqlc.New(tx)
 	if err = d.exists(ctx, q, kind, id, true); err != nil {
 		return err
+	}
+	if check != nil {
+		if err = check(ctx, q, id); err != nil {
+			return err
+		}
 	}
 	if err = del(ctx, q, id); err != nil {
 		return err
@@ -121,6 +153,26 @@ func (d *OwnerDeletion) delete(ctx context.Context, kind OwnerKind, id, actor st
 	}
 	lease.Commit()
 	return nil
+}
+
+func deletionAgentFromDB(row sqlc.Agent) (config.Agent, error) {
+	var sandbox config.SandboxConfig
+	if len(row.Sandbox) > 0 {
+		if err := json.Unmarshal(row.Sandbox, &sandbox); err != nil {
+			return config.Agent{}, fmt.Errorf("home: parse Agent %q sandbox: %w", row.ID, err)
+		}
+	}
+	scope := row.Scope
+	if scope == "" {
+		scope = config.AgentScopeSystem
+	}
+	return config.Agent{
+		ID: row.ID, Name: row.Name, Model: row.Model, ModelThinking: row.ModelThinking,
+		ModelStrong: row.ModelStrong, ModelStrongThinking: row.ModelStrongThinking,
+		ModelFast: row.ModelFast, ModelFastThinking: row.ModelFastThinking,
+		SystemPrompt: row.SystemPrompt, Soul: row.Soul, Workspace: row.Workspace,
+		Sandbox: sandbox, Scope: scope, CreatorID: row.CreatorID, Enabled: row.Enabled,
+	}, nil
 }
 
 func (d *OwnerDeletion) exists(ctx context.Context, q *sqlc.Queries, kind OwnerKind, id string, lock bool) error {

--- a/internal/home/deletion_test.go
+++ b/internal/home/deletion_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 
+	"github.com/CherryHQ/stella/internal/config"
 	"github.com/CherryHQ/stella/internal/db/dbtest"
 	"github.com/CherryHQ/stella/pkg/db/sqlc"
 )
@@ -150,6 +151,58 @@ func TestOwnerDeletionReconcilesUnknownCommitOutcomes(t *testing.T) {
 				t.Fatalf("owner error = %v, wantOwner=%t", ownerErr, tc.wantOwner)
 			}
 		})
+	}
+}
+
+func TestConditionalAgentDeletionComparesInsideFence(t *testing.T) {
+	ctx, db := t.Context(), dbtest.New(t)
+	const id = "conditional-agent"
+	if _, err := db.Exec(ctx, `INSERT INTO agent (id,name,workspace,scope,enabled) VALUES ($1,'Before','','restricted',true)`, id); err != nil {
+		t.Fatal(err)
+	}
+	manager, err := NewWorkspaceManager(db, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = manager.Close() })
+	fence := &testFence{}
+	deletion, err := NewOwnerDeletion(db, manager, fence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	row, err := sqlc.New(db).GetAgent(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected, err := deletionAgentFromDB(row)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(ctx, `UPDATE agent SET name = 'After' WHERE id = $1`, id); err != nil {
+		t.Fatal(err)
+	}
+	if err := deletion.DeleteAgentIfUnchanged(ctx, id, "actor", expected); !errors.Is(err, config.ErrAgentChanged) {
+		t.Fatalf("stale conditional delete = %v, want ErrAgentChanged", err)
+	}
+	if fence.lease == nil || fence.lease.committed || !fence.lease.released {
+		t.Fatalf("stale deletion fence = %#v, want released without commit", fence.lease)
+	}
+	row, err = sqlc.New(db).GetAgent(ctx, id)
+	if err != nil {
+		t.Fatalf("stale delete removed Agent: %v", err)
+	}
+	expected, err = deletionAgentFromDB(row)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := deletion.DeleteAgentIfUnchanged(ctx, id, "actor", expected); err != nil {
+		t.Fatalf("conditional delete: %v", err)
+	}
+	if fence.lease == nil || !fence.lease.committed || !fence.lease.released {
+		t.Fatalf("successful deletion fence = %#v", fence.lease)
+	}
+	if _, err := sqlc.New(db).GetAgent(ctx, id); !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("deleted Agent lookup = %v, want no rows", err)
 	}
 }
 

--- a/internal/library/lifecycle.go
+++ b/internal/library/lifecycle.go
@@ -1,7 +1,9 @@
 package library
 
 import (
+	"bytes"
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"time"
@@ -23,8 +25,27 @@ func (s *Service) DeleteManaged(
 	authority authz.Authority,
 	id string,
 ) error {
-	if _, err := s.GetManaged(ctx, authority, id); err != nil {
+	return s.DeleteManagedWithDigest(ctx, authority, id, "")
+}
+
+// DeleteManagedWithDigest performs the same owner check as DeleteManaged and
+// additionally binds the destructive write to the previewed immutable snapshot.
+// The digest is the SHA-256 of the raw source, not a caller-selected owner key.
+func (s *Service) DeleteManagedWithDigest(
+	ctx context.Context,
+	authority authz.Authority,
+	id string,
+	expectedDigest string,
+) error {
+	file, err := s.GetManaged(ctx, authority, id)
+	if err != nil {
 		return err
+	}
+	if expectedDigest != "" {
+		want, decodeErr := hex.DecodeString(expectedDigest)
+		if decodeErr != nil || !bytes.Equal(file.RawSHA256, want) {
+			return ErrGenerationChanged
+		}
 	}
 	return s.tombstoneManagedFile(ctx, id)
 }

--- a/internal/settings/deferred.go
+++ b/internal/settings/deferred.go
@@ -34,3 +34,17 @@ func (d *DeferredAgentMutation) Delete(ctx context.Context, a authz.Authority, i
 	}
 	return d.target.Delete(ctx, a, id)
 }
+
+func (d *DeferredAgentMutation) UpdateIfUnchanged(ctx context.Context, a authz.Authority, expected, candidate config.Agent) (config.Agent, error) {
+	if d.target == nil {
+		return config.Agent{}, ErrUnavailable
+	}
+	return d.target.UpdateIfUnchanged(ctx, a, expected, candidate)
+}
+
+func (d *DeferredAgentMutation) DeleteIfUnchanged(ctx context.Context, a authz.Authority, expected config.Agent) error {
+	if d.target == nil {
+		return ErrUnavailable
+	}
+	return d.target.DeleteIfUnchanged(ctx, a, expected)
+}

--- a/internal/settings/deferred.go
+++ b/internal/settings/deferred.go
@@ -1,0 +1,36 @@
+package settings
+
+import (
+	"context"
+
+	"github.com/CherryHQ/stella/internal/agent/access"
+	"github.com/CherryHQ/stella/internal/authz"
+	"github.com/CherryHQ/stella/internal/config"
+)
+
+// DeferredAgentMutation lets setup wire a tool before the runtime pool and Home
+// deletion lifecycle exist. The target is populated before setup returns.
+type DeferredAgentMutation struct{ target *access.Management }
+
+func NewDeferredAgentMutation() *DeferredAgentMutation          { return &DeferredAgentMutation{} }
+func (d *DeferredAgentMutation) Bind(target *access.Management) { d.target = target }
+func (d *DeferredAgentMutation) Create(ctx context.Context, a authz.Authority, c config.Agent) (config.Agent, error) {
+	if d.target == nil {
+		return config.Agent{}, ErrUnavailable
+	}
+	return d.target.Create(ctx, a, c)
+}
+
+func (d *DeferredAgentMutation) Update(ctx context.Context, a authz.Authority, c config.Agent) (config.Agent, error) {
+	if d.target == nil {
+		return config.Agent{}, ErrUnavailable
+	}
+	return d.target.Update(ctx, a, c)
+}
+
+func (d *DeferredAgentMutation) Delete(ctx context.Context, a authz.Authority, id string) error {
+	if d.target == nil {
+		return ErrUnavailable
+	}
+	return d.target.Delete(ctx, a, id)
+}

--- a/internal/settings/invalidation.go
+++ b/internal/settings/invalidation.go
@@ -1,0 +1,37 @@
+package settings
+
+// DeferredRunnerInvalidator delays the pool-manager dependency until the
+// composition root has finished building the runtime graph. Calls happen only
+// after setup, so a missing target is still a hard failure rather than a silent
+// no-op.
+type DeferredRunnerInvalidator struct{ target RunnerInvalidator }
+
+func NewDeferredRunnerInvalidator() *DeferredRunnerInvalidator     { return &DeferredRunnerInvalidator{} }
+func (d *DeferredRunnerInvalidator) Bind(target RunnerInvalidator) { d.target = target }
+func (d *DeferredRunnerInvalidator) InvalidateUser(id string) error {
+	if d.target == nil {
+		return ErrUnavailable
+	}
+	return d.target.InvalidateUser(id)
+}
+
+func (d *DeferredRunnerInvalidator) InvalidateUserAgent(user, agent string) error {
+	if d.target == nil {
+		return ErrUnavailable
+	}
+	return d.target.InvalidateUserAgent(user, agent)
+}
+
+func (d *DeferredRunnerInvalidator) InvalidateAgent(id string) error {
+	if d.target == nil {
+		return ErrUnavailable
+	}
+	return d.target.InvalidateAgent(id)
+}
+
+func (d *DeferredRunnerInvalidator) InvalidateAll() error {
+	if d.target == nil {
+		return ErrUnavailable
+	}
+	return d.target.InvalidateAll()
+}

--- a/internal/settings/mutations.go
+++ b/internal/settings/mutations.go
@@ -145,6 +145,11 @@ type ToolOverrideWriter interface {
 	Clear(context.Context, agent.ToolOverrideKey) error
 }
 
+type ConditionalToolOverrideWriter interface {
+	SetIfDigest(context.Context, agent.ToolOverrideWrite, string) error
+	ClearIfDigest(context.Context, agent.ToolOverrideKey, string) error
+}
+
 type RunnerInvalidator interface {
 	InvalidateUser(string) error
 	InvalidateUserAgent(string, string) error
@@ -202,40 +207,28 @@ func (m *toolOverrideMutator) Preview(ctx context.Context, authority authz.Autho
 	if err != nil {
 		return "", err
 	}
-	if !found {
-		return digestValue(map[string]any{"found": false}), nil
-	}
-	return digestValue(map[string]any{"found": true, "enabled": current.Enabled}), nil
-}
-
-func (m *toolOverrideMutator) checkCurrent(ctx context.Context, authority authz.Authority, in toolOverrideRequest, expected string) error {
-	current, err := m.Preview(ctx, authority, in)
-	if err != nil {
-		return err
-	}
-	if expected == "" || current != expected {
-		return errors.New("tool override changed since preview")
-	}
-	return nil
+	return agent.ToolOverrideDigest(found, found && current.Enabled), nil
 }
 
 func (m *toolOverrideMutator) Set(ctx context.Context, authority authz.Authority, in toolOverrideRequest, expected string) error {
-	if err := m.checkCurrent(ctx, authority, in, expected); err != nil {
-		return err
+	writer, ok := m.store.(ConditionalToolOverrideWriter)
+	if !ok {
+		return ErrUnavailable
 	}
 	userID, agentID := overrideOwner(authority, in)
-	if err := m.store.Set(ctx, agent.ToolOverrideWrite{ToolName: in.ToolName, Scope: in.Scope, UserID: userID, AgentID: agentID, Enabled: in.Enabled}); err != nil {
+	if err := writer.SetIfDigest(ctx, agent.ToolOverrideWrite{ToolName: in.ToolName, Scope: in.Scope, UserID: userID, AgentID: agentID, Enabled: in.Enabled}, expected); err != nil {
 		return err
 	}
 	return m.invalidate(in.Scope, userID, agentID)
 }
 
 func (m *toolOverrideMutator) Clear(ctx context.Context, authority authz.Authority, in toolOverrideRequest, expected string) error {
-	if err := m.checkCurrent(ctx, authority, in, expected); err != nil {
-		return err
+	writer, ok := m.store.(ConditionalToolOverrideWriter)
+	if !ok {
+		return ErrUnavailable
 	}
 	userID, agentID := overrideOwner(authority, in)
-	if err := m.store.Clear(ctx, agent.ToolOverrideKey{ToolName: in.ToolName, Scope: in.Scope, UserID: userID, AgentID: agentID}); err != nil {
+	if err := writer.ClearIfDigest(ctx, agent.ToolOverrideKey{ToolName: in.ToolName, Scope: in.Scope, UserID: userID, AgentID: agentID}, expected); err != nil {
 		return err
 	}
 	return m.invalidate(in.Scope, userID, agentID)

--- a/internal/settings/mutations.go
+++ b/internal/settings/mutations.go
@@ -211,6 +211,11 @@ func (m *toolOverrideMutator) Preview(ctx context.Context, authority authz.Autho
 }
 
 func (m *toolOverrideMutator) Set(ctx context.Context, authority authz.Authority, in toolOverrideRequest, expected string) error {
+	// Confirm re-enters the owner/Agent/tool-name PEP. The subsequent conditional
+	// write closes the race between this fresh authorization read and persistence.
+	if _, err := m.Preview(ctx, authority, in); err != nil {
+		return err
+	}
 	writer, ok := m.store.(ConditionalToolOverrideWriter)
 	if !ok {
 		return ErrUnavailable
@@ -223,6 +228,9 @@ func (m *toolOverrideMutator) Set(ctx context.Context, authority authz.Authority
 }
 
 func (m *toolOverrideMutator) Clear(ctx context.Context, authority authz.Authority, in toolOverrideRequest, expected string) error {
+	if _, err := m.Preview(ctx, authority, in); err != nil {
+		return err
+	}
 	writer, ok := m.store.(ConditionalToolOverrideWriter)
 	if !ok {
 		return ErrUnavailable

--- a/internal/settings/mutations.go
+++ b/internal/settings/mutations.go
@@ -1,0 +1,339 @@
+package settings
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/CherryHQ/stella/internal/agent"
+	agentaccess "github.com/CherryHQ/stella/internal/agent/access"
+	"github.com/CherryHQ/stella/internal/authz"
+	"github.com/CherryHQ/stella/internal/config"
+	"github.com/CherryHQ/stella/internal/library"
+	"github.com/CherryHQ/stella/internal/skillaccess"
+	"github.com/CherryHQ/stella/internal/skills"
+)
+
+// AgentMutation is the narrow write port used by the settings facade. The
+// concrete Management service owns the Agent PEP and durable invariants.
+type AgentMutation interface {
+	Create(context.Context, authz.Authority, config.Agent) (config.Agent, error)
+	Update(context.Context, authz.Authority, config.Agent) (config.Agent, error)
+	Delete(context.Context, authz.Authority, string) error
+}
+
+type LibraryMutation interface {
+	ResolveManageOwner(context.Context, authz.Authority, library.Scope, string) (library.Owner, error)
+	GetManaged(context.Context, authz.Authority, string) (library.LibraryFile, error)
+	CreateManagedUpload(context.Context, authz.Authority, library.Scope, string, string, io.Reader) (library.LibraryFile, error)
+	DeleteManagedWithDigest(context.Context, authz.Authority, string, string) error
+}
+
+type SkillMutation interface {
+	PreviewCreate(context.Context, authz.Authority, string, string) error
+	PreviewExisting(context.Context, authz.Authority, string, authz.Action) (skills.Skill, error)
+	Create(context.Context, authz.Authority, skillCreateRequest) (skills.SkillSnapshot, error)
+	Update(context.Context, authz.Authority, skillUpdateRequest) (skills.SkillSnapshot, error)
+	Delete(context.Context, authz.Authority, skillDeleteRequest) error
+}
+
+type ToolOverrideMutation interface {
+	Preview(context.Context, authz.Authority, toolOverrideRequest) (string, error)
+	Set(context.Context, authz.Authority, toolOverrideRequest, string) error
+	Clear(context.Context, authz.Authority, toolOverrideRequest, string) error
+}
+
+type SkillStore interface {
+	CreateManagedSkill(context.Context, skills.Skill, map[string]string) (skills.SkillSnapshot, error)
+	UpdateManagedSkill(context.Context, skills.ManagedSkillUpdate) (skills.SkillSnapshot, error)
+	DeleteManagedSkill(context.Context, skills.ManagedSkillDelete) error
+}
+
+type skillMutator struct {
+	access *skillaccess.Service
+	store  SkillStore
+}
+
+func NewSkillMutator(access *skillaccess.Service, store SkillStore) SkillMutation {
+	return &skillMutator{access: access, store: store}
+}
+
+func (m *skillMutator) PreviewCreate(ctx context.Context, authority authz.Authority, scope, agentID string) error {
+	if m == nil || m.access == nil || m.store == nil {
+		return skills.ErrManagedSkillsUnavailable
+	}
+	acc, err := m.access.Begin(ctx, authority)
+	if err != nil {
+		return err
+	}
+	_, _, err = acc.AuthorizeManageScope(ctx, scope, agentID)
+	return err
+}
+
+func (m *skillMutator) PreviewExisting(ctx context.Context, authority authz.Authority, id string, action authz.Action) (skills.Skill, error) {
+	if m == nil || m.access == nil || m.store == nil {
+		return skills.Skill{}, skills.ErrManagedSkillsUnavailable
+	}
+	acc, err := m.access.Begin(ctx, authority)
+	if err != nil {
+		return skills.Skill{}, err
+	}
+	return acc.AuthorizeManageByID(ctx, id, action)
+}
+
+func (m *skillMutator) Create(ctx context.Context, authority authz.Authority, in skillCreateRequest) (skills.SkillSnapshot, error) {
+	if err := m.PreviewCreate(ctx, authority, in.Scope, in.AgentID); err != nil {
+		return skills.SkillSnapshot{}, err
+	}
+	acc, err := m.access.Begin(ctx, authority)
+	if err != nil {
+		return skills.SkillSnapshot{}, err
+	}
+	userID, agentID, err := acc.AuthorizeManageScope(ctx, in.Scope, in.AgentID)
+	if err != nil {
+		return skills.SkillSnapshot{}, err
+	}
+	if in.Files == nil {
+		in.Files = map[string]string{skills.MainFile: skillFileContent(in.Name, in.Description, in.Body)}
+	}
+	if _, ok := in.Files[skills.MainFile]; !ok {
+		return skills.SkillSnapshot{}, fmt.Errorf("files must include %s", skills.MainFile)
+	}
+	return m.store.CreateManagedSkill(ctx, skills.Skill{
+		Scope: in.Scope, UserID: userID, AgentID: agentID,
+		Name: in.Name, Description: in.Description,
+		DisableModelInvocation: in.DisableModelInvocation,
+	}, in.Files)
+}
+
+func (m *skillMutator) Update(ctx context.Context, authority authz.Authority, in skillUpdateRequest) (skills.SkillSnapshot, error) {
+	sk, err := m.PreviewExisting(ctx, authority, in.ID, authz.ActionWrite)
+	if err != nil {
+		return skills.SkillSnapshot{}, err
+	}
+	if in.ExpectedDigest == "" || sk.ContentDigest != in.ExpectedDigest {
+		return skills.SkillSnapshot{}, skills.ErrSkillDigestConflict
+	}
+	patch := skills.UpdatePatch{Description: in.Description, DisableModelInvocation: in.DisableModelInvocation}
+	return m.store.UpdateManagedSkill(ctx, skills.ManagedSkillUpdate{
+		ID: sk.ID, UserID: sk.UserID, AgentID: sk.AgentID, Scope: sk.Scope,
+		Patch: patch, Files: in.Files, DeleteFiles: in.DeleteFiles,
+		ExpectedDigest: in.ExpectedDigest,
+	})
+}
+
+func (m *skillMutator) Delete(ctx context.Context, authority authz.Authority, in skillDeleteRequest) error {
+	sk, err := m.PreviewExisting(ctx, authority, in.ID, authz.ActionDelete)
+	if err != nil {
+		return err
+	}
+	if in.ExpectedDigest == "" || sk.ContentDigest != in.ExpectedDigest {
+		return skills.ErrSkillDigestConflict
+	}
+	return m.store.DeleteManagedSkill(ctx, skills.ManagedSkillDelete{
+		ID: sk.ID, UserID: sk.UserID, AgentID: sk.AgentID, Scope: sk.Scope,
+		ExpectedDigest: in.ExpectedDigest,
+	})
+}
+
+type ToolOverrideWriter interface {
+	Get(context.Context, agent.ToolOverrideKey) (agent.ToolOverride, bool, error)
+	Set(context.Context, agent.ToolOverrideWrite) error
+	Clear(context.Context, agent.ToolOverrideKey) error
+}
+
+type RunnerInvalidator interface {
+	InvalidateUser(string) error
+	InvalidateUserAgent(string, string) error
+	InvalidateAgent(string) error
+	InvalidateAll() error
+}
+
+type ToolNameManager func(context.Context, string) bool
+
+type toolOverrideMutator struct {
+	access      *agentaccess.Service
+	store       ToolOverrideWriter
+	invalidator RunnerInvalidator
+	isManaged   ToolNameManager
+}
+
+func NewToolOverrideMutator(access *agentaccess.Service, store ToolOverrideWriter, invalidator RunnerInvalidator, isManaged ToolNameManager) ToolOverrideMutation {
+	return &toolOverrideMutator{access: access, store: store, invalidator: invalidator, isManaged: isManaged}
+}
+
+func (m *toolOverrideMutator) Preview(ctx context.Context, authority authz.Authority, in toolOverrideRequest) (string, error) {
+	if m == nil || m.access == nil || m.store == nil || m.invalidator == nil {
+		return "", ErrUnavailable
+	}
+	if strings.TrimSpace(in.ToolName) == "" || agent.IsCoreToolName(in.ToolName) || m.isManaged == nil || !m.isManaged(ctx, in.ToolName) {
+		return "", fmt.Errorf("tool override is not managed")
+	}
+	if !authority.Valid() {
+		return "", agentaccess.ErrForbidden
+	}
+	switch in.Scope {
+	case agent.ToolOverrideScopeSystem, agent.ToolOverrideScopeSystemAgent:
+		if !authority.IsAdmin() {
+			return "", agentaccess.ErrForbidden
+		}
+	case agent.ToolOverrideScopeUser, agent.ToolOverrideScopeUserAgent:
+		if authority.Kind() != authz.ActorUser {
+			return "", agentaccess.ErrForbidden
+		}
+	default:
+		return "", fmt.Errorf("invalid tool override scope %q", in.Scope)
+	}
+	if in.Scope == agent.ToolOverrideScopeUserAgent || in.Scope == agent.ToolOverrideScopeSystemAgent {
+		if in.AgentID == "" {
+			return "", fmt.Errorf("agent_id is required for %s scope", in.Scope)
+		}
+		if _, err := m.access.Read(ctx, authority, in.AgentID); err != nil {
+			return "", err
+		}
+	} else if in.AgentID != "" {
+		return "", fmt.Errorf("agent_id is not allowed for %s scope", in.Scope)
+	}
+	userID, agentID := overrideOwner(authority, in)
+	current, found, err := m.store.Get(ctx, agent.ToolOverrideKey{ToolName: in.ToolName, Scope: in.Scope, UserID: userID, AgentID: agentID})
+	if err != nil {
+		return "", err
+	}
+	if !found {
+		return digestValue(map[string]any{"found": false}), nil
+	}
+	return digestValue(map[string]any{"found": true, "enabled": current.Enabled}), nil
+}
+
+func (m *toolOverrideMutator) checkCurrent(ctx context.Context, authority authz.Authority, in toolOverrideRequest, expected string) error {
+	current, err := m.Preview(ctx, authority, in)
+	if err != nil {
+		return err
+	}
+	if expected == "" || current != expected {
+		return errors.New("tool override changed since preview")
+	}
+	return nil
+}
+
+func (m *toolOverrideMutator) Set(ctx context.Context, authority authz.Authority, in toolOverrideRequest, expected string) error {
+	if err := m.checkCurrent(ctx, authority, in, expected); err != nil {
+		return err
+	}
+	userID, agentID := overrideOwner(authority, in)
+	if err := m.store.Set(ctx, agent.ToolOverrideWrite{ToolName: in.ToolName, Scope: in.Scope, UserID: userID, AgentID: agentID, Enabled: in.Enabled}); err != nil {
+		return err
+	}
+	return m.invalidate(in.Scope, userID, agentID)
+}
+
+func (m *toolOverrideMutator) Clear(ctx context.Context, authority authz.Authority, in toolOverrideRequest, expected string) error {
+	if err := m.checkCurrent(ctx, authority, in, expected); err != nil {
+		return err
+	}
+	userID, agentID := overrideOwner(authority, in)
+	if err := m.store.Clear(ctx, agent.ToolOverrideKey{ToolName: in.ToolName, Scope: in.Scope, UserID: userID, AgentID: agentID}); err != nil {
+		return err
+	}
+	return m.invalidate(in.Scope, userID, agentID)
+}
+
+func (m *toolOverrideMutator) invalidate(scope, userID, agentID string) error {
+	switch scope {
+	case agent.ToolOverrideScopeUser:
+		return m.invalidator.InvalidateUser(userID)
+	case agent.ToolOverrideScopeUserAgent:
+		return m.invalidator.InvalidateUserAgent(userID, agentID)
+	case agent.ToolOverrideScopeSystemAgent:
+		return m.invalidator.InvalidateAgent(agentID)
+	case agent.ToolOverrideScopeSystem:
+		return m.invalidator.InvalidateAll()
+	default:
+		return agentaccess.ErrForbidden
+	}
+}
+
+func overrideOwner(authority authz.Authority, in toolOverrideRequest) (string, string) {
+	if in.Scope == agent.ToolOverrideScopeUser || in.Scope == agent.ToolOverrideScopeUserAgent {
+		return string(authority.UserID()), in.AgentID
+	}
+	return "", in.AgentID
+}
+
+type skillCreateRequest struct {
+	Scope                  string
+	AgentID                string
+	Name                   string
+	Description            string
+	Body                   string
+	Files                  map[string]string
+	DisableModelInvocation bool
+}
+
+type skillUpdateRequest struct {
+	ID                     string
+	ExpectedDigest         string
+	Description            *string
+	DisableModelInvocation *bool
+	Files                  map[string]string
+	DeleteFiles            []string
+}
+
+type skillDeleteRequest struct{ ID, ExpectedDigest string }
+
+type toolOverrideRequest struct {
+	ToolName string
+	Scope    string
+	AgentID  string
+	Enabled  bool
+}
+
+func decodeObject(value any, out any) error {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(encoded)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(out); err != nil {
+		return fmt.Errorf("invalid mutation input: %w", err)
+	}
+	return nil
+}
+
+func skillFileContent(name, description, body string) string {
+	var b strings.Builder
+	b.WriteString("---\nname: ")
+	b.WriteString(name)
+	b.WriteString("\ndescription: ")
+	b.WriteString(description)
+	b.WriteString("\n---\n")
+	b.WriteString(body)
+	if body != "" && !strings.HasSuffix(body, "\n") {
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func ensureSkillInput(in skillCreateRequest) error {
+	if strings.TrimSpace(in.Scope) == "" || strings.TrimSpace(in.Name) == "" {
+		return errors.New("skill scope and name are required")
+	}
+	if in.Scope != skillaccess.ScopeUser && in.Scope != skillaccess.ScopeUserAgent && in.Scope != skillaccess.ScopeSystem && in.Scope != skillaccess.ScopeSystemAgent {
+		return fmt.Errorf("invalid skill scope %q", in.Scope)
+	}
+	if in.Scope == skillaccess.ScopeUserAgent || in.Scope == skillaccess.ScopeSystemAgent {
+		if strings.TrimSpace(in.AgentID) == "" {
+			return errors.New("agent_id is required for agent-bound skills")
+		}
+	} else if in.AgentID != "" {
+		return errors.New("agent_id is not allowed for this skill scope")
+	}
+	if len(in.Files) == 0 && strings.TrimSpace(in.Body) == "" {
+		return errors.New("skill body or files are required")
+	}
+	return nil
+}

--- a/internal/settings/mutations_test.go
+++ b/internal/settings/mutations_test.go
@@ -1,0 +1,83 @@
+package settings
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/CherryHQ/stella/internal/agent"
+	agentaccess "github.com/CherryHQ/stella/internal/agent/access"
+	"github.com/CherryHQ/stella/internal/config"
+)
+
+type mutationAgentStore struct{ agent config.Agent }
+
+func (s mutationAgentStore) GetAgent(context.Context, string) (config.Agent, error) {
+	return s.agent, nil
+}
+
+func (s mutationAgentStore) ListAgents(context.Context) ([]config.Agent, error) {
+	return []config.Agent{s.agent}, nil
+}
+
+type mutableAssignments struct{ assigned bool }
+
+func (s *mutableAssignments) ListUserAgentIDs(context.Context, string) ([]string, error) {
+	if s.assigned {
+		return []string{"target"}, nil
+	}
+	return nil, nil
+}
+
+type conditionalOverrideStore struct {
+	setCalls   int
+	clearCalls int
+}
+
+func (*conditionalOverrideStore) Get(context.Context, agent.ToolOverrideKey) (agent.ToolOverride, bool, error) {
+	return agent.ToolOverride{}, false, nil
+}
+
+func (*conditionalOverrideStore) Set(context.Context, agent.ToolOverrideWrite) error { return nil }
+func (*conditionalOverrideStore) Clear(context.Context, agent.ToolOverrideKey) error { return nil }
+
+func (s *conditionalOverrideStore) SetIfDigest(context.Context, agent.ToolOverrideWrite, string) error {
+	s.setCalls++
+	return nil
+}
+
+func (s *conditionalOverrideStore) ClearIfDigest(context.Context, agent.ToolOverrideKey, string) error {
+	s.clearCalls++
+	return nil
+}
+
+type recordingInvalidator struct{ calls int }
+
+func (i *recordingInvalidator) InvalidateUser(string) error              { i.calls++; return nil }
+func (i *recordingInvalidator) InvalidateUserAgent(string, string) error { i.calls++; return nil }
+func (i *recordingInvalidator) InvalidateAgent(string) error             { i.calls++; return nil }
+func (i *recordingInvalidator) InvalidateAll() error                     { i.calls++; return nil }
+
+func TestToolOverrideConfirmReauthorizesAgentScope(t *testing.T) {
+	assignments := &mutableAssignments{assigned: true}
+	access := agentaccess.NewService(mutationAgentStore{agent: config.Agent{
+		ID: "target", Scope: config.AgentScopeRestricted, Enabled: true,
+	}}, assignments)
+	store := &conditionalOverrideStore{}
+	invalidator := &recordingInvalidator{}
+	mutator := NewToolOverrideMutator(access, store, invalidator, func(context.Context, string) bool { return true })
+	authority := userAuthority(t, "u1")
+	request := toolOverrideRequest{ToolName: "custom-tool", Scope: agent.ToolOverrideScopeUserAgent, AgentID: "target", Enabled: true}
+
+	digest, err := mutator.Preview(t.Context(), authority, request)
+	if err != nil {
+		t.Fatalf("preview: %v", err)
+	}
+	assignments.assigned = false
+	if err := mutator.Set(t.Context(), authority, request, digest); !errors.Is(err, agentaccess.ErrForbidden) {
+		t.Fatalf("confirm after assignment removal = %v, want forbidden", err)
+	}
+	if store.setCalls != 0 || invalidator.calls != 0 {
+		t.Fatalf("unauthorized confirm reached write/invalidation: set=%d invalidate=%d", store.setCalls, invalidator.calls)
+	}
+}

--- a/internal/settings/protocol.go
+++ b/internal/settings/protocol.go
@@ -1,0 +1,621 @@
+package settings
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/CherryHQ/stella/internal/authz"
+	"github.com/CherryHQ/stella/internal/config"
+	"github.com/CherryHQ/stella/internal/library"
+	"github.com/CherryHQ/stella/internal/memory"
+	"github.com/CherryHQ/stella/internal/skills"
+	"github.com/CherryHQ/stella/pkg/tools"
+)
+
+const mutationTokenTTL = 2 * time.Minute
+
+type pendingMutation struct {
+	userID    string
+	sessionID string
+	agentID   string
+	resource  string
+	operation string
+	input     json.RawMessage
+	digest    string
+	expiresAt time.Time
+}
+
+func (t *Tool) describeResource(ctx context.Context, args map[string]any) (string, error) {
+	if err := rejectUnexpected(args, "action", "resource"); err != nil {
+		return "", err
+	}
+	resource, err := stringArg(args, "resource", true)
+	if err != nil {
+		return "", err
+	}
+	var operations []string
+	switch resource {
+	case "agents":
+		operations = []string{"list", "get", "create", "update", "delete"}
+	case "library":
+		operations = []string{"create", "delete"}
+	case "skills":
+		operations = []string{"create", "update", "delete"}
+	case "tool_overrides":
+		operations = []string{"set", "clear"}
+	default:
+		return "", fmt.Errorf("unsupported settings resource %q", resource)
+	}
+	return tools.MarshalResult(map[string]any{
+		"resource":   resource,
+		"operations": operations,
+		"protocol":   "preview then confirm; confirmation is model-side and is not human approval",
+	})
+}
+
+func (t *Tool) previewMutation(ctx context.Context, args map[string]any) (string, error) {
+	if err := rejectUnexpected(args, "action", "resource", "operation", "input"); err != nil {
+		return "", err
+	}
+	resource, err := stringArg(args, "resource", true)
+	if err != nil {
+		return "", err
+	}
+	operation, err := stringArg(args, "operation", true)
+	if err != nil {
+		return "", err
+	}
+	input, ok := args["input"].(map[string]any)
+	if !ok {
+		return "", errors.New("input must be an object")
+	}
+	encoded, err := json.Marshal(input)
+	if err != nil {
+		return "", err
+	}
+	var digest string
+	switch resource {
+	case "agents":
+		digest, err = t.previewAgent(ctx, operation, input)
+	case "library":
+		digest, err = t.previewLibrary(ctx, operation, input)
+	case "skills":
+		digest, err = t.previewSkill(ctx, operation, input)
+	case "tool_overrides":
+		digest, err = t.previewOverride(ctx, operation, input)
+	default:
+		err = fmt.Errorf("unsupported settings resource %q", resource)
+	}
+	if err != nil {
+		return "", err
+	}
+	token, err := newMutationToken()
+	if err != nil {
+		return "", err
+	}
+	t.tokensMu.Lock()
+	if t.tokens == nil {
+		t.tokens = make(map[string]pendingMutation)
+	}
+	now := time.Now().UTC()
+	for key, pending := range t.tokens {
+		if !pending.expiresAt.After(now) {
+			delete(t.tokens, key)
+		}
+	}
+	if len(t.tokens) >= 256 {
+		t.tokensMu.Unlock()
+		return "", errors.New("too many pending settings confirmations")
+	}
+	t.tokens[token] = pendingMutation{
+		userID: authz.UserIDFromContext(ctx), sessionID: currentSessionID(ctx), agentID: authz.AgentIDFromContext(ctx),
+		resource: resource, operation: operation, input: encoded, digest: digest, expiresAt: now.Add(mutationTokenTTL),
+	}
+	t.tokensMu.Unlock()
+	result := map[string]any{"confirmation_token": token, "resource": resource, "operation": operation, "expires_in_seconds": int(mutationTokenTTL / time.Second)}
+	if digest != "" {
+		result["expected_digest"] = digest
+	}
+	return tools.MarshalResult(result)
+}
+
+func (t *Tool) confirmMutation(ctx context.Context, args map[string]any) (string, error) {
+	if err := rejectUnexpected(args, "action", "token"); err != nil {
+		return "", err
+	}
+	token, err := stringArg(args, "token", true)
+	if err != nil {
+		return "", err
+	}
+	t.tokensMu.Lock()
+	pending, ok := t.tokens[token]
+	if ok {
+		delete(t.tokens, token)
+	}
+	t.tokensMu.Unlock()
+	if !ok || !pending.expiresAt.After(time.Now().UTC()) {
+		return "", errors.New("confirmation token is invalid or expired")
+	}
+	if pending.userID != authz.UserIDFromContext(ctx) || pending.sessionID != currentSessionID(ctx) || pending.agentID != authz.AgentIDFromContext(ctx) {
+		return "", errors.New("confirmation token belongs to another turn")
+	}
+	var input map[string]any
+	if err := json.Unmarshal(pending.input, &input); err != nil {
+		return "", errors.New("confirmation token payload is invalid")
+	}
+	var applyErr error
+	switch pending.resource {
+	case "agents":
+		applyErr = t.confirmAgent(ctx, pending.operation, input, pending.digest)
+	case "library":
+		applyErr = t.confirmLibrary(ctx, pending.operation, input, pending.digest)
+	case "skills":
+		applyErr = t.confirmSkill(ctx, pending.operation, input, pending.digest)
+	case "tool_overrides":
+		applyErr = t.confirmOverride(ctx, pending.operation, input, pending.digest)
+	default:
+		applyErr = fmt.Errorf("unsupported settings resource %q", pending.resource)
+	}
+	if applyErr != nil {
+		return "", applyErr
+	}
+	return tools.MarshalResult(map[string]any{"confirmed": true, "resource": pending.resource, "operation": pending.operation})
+}
+
+func currentSessionID(ctx context.Context) string { return memory.SessionIDFromContext(ctx) }
+
+func newMutationToken() (string, error) {
+	var raw [32]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", fmt.Errorf("create confirmation token: %w", err)
+	}
+	return hex.EncodeToString(raw[:]), nil
+}
+
+func digestValue(value any) string {
+	encoded, _ := json.Marshal(value)
+	sum := sha256.Sum256(encoded)
+	return hex.EncodeToString(sum[:])
+}
+
+func agentDigest(a config.Agent) string { return digestValue(a) }
+
+func validateAgentCandidate(a config.Agent) error {
+	if strings.TrimSpace(a.Name) == "" {
+		return errors.New("agent name is required")
+	}
+	if a.Scope != "" && a.Scope != config.AgentScopeSystem && a.Scope != config.AgentScopeRestricted {
+		return fmt.Errorf("invalid agent scope %q", a.Scope)
+	}
+	for field, value := range map[string]string{"model": a.Model, "model_strong": a.ModelStrong, "model_fast": a.ModelFast} {
+		if strings.TrimSpace(value) == "" {
+			continue
+		}
+		provider, model := config.ParseModelRef(value)
+		if strings.TrimSpace(provider) == "" || strings.TrimSpace(model) == "" {
+			return fmt.Errorf("invalid %s %q: expected provider/model", field, value)
+		}
+	}
+	for field, value := range map[string]string{"model_thinking": a.ModelThinking, "model_strong_thinking": a.ModelStrongThinking, "model_fast_thinking": a.ModelFastThinking} {
+		switch value {
+		case "", "minimal", "low", "medium", "high", "xhigh":
+		default:
+			return fmt.Errorf("invalid %s %q", field, value)
+		}
+	}
+	return nil
+}
+
+func (t *Tool) previewAgent(ctx context.Context, operation string, input map[string]any) (string, error) {
+	if t.agentMutations == nil {
+		return "", ErrUnavailable
+	}
+	var in agentWireInput
+	if err := decodeObject(input, &in); err != nil {
+		return "", err
+	}
+	authority, ok := authz.AuthorityFromContext(ctx)
+	if !ok {
+		return "", ErrUnavailable
+	}
+	switch operation {
+	case "create":
+		candidate := in.createCandidate()
+		if err := validateAgentCandidate(candidate); err != nil {
+			return "", err
+		}
+		if canCreate, ok := t.agents.(interface {
+			CanCreate(context.Context, authz.Authority) error
+		}); ok {
+			if err := canCreate.CanCreate(ctx, authority); err != nil {
+				return "", err
+			}
+		}
+		return "", nil
+	case "update", "delete":
+		if in.ID == "" {
+			return "", errors.New("agent id is required")
+		}
+		if t.agents == nil {
+			return "", ErrUnavailable
+		}
+		current, err := t.agents.Read(ctx, authority, in.ID)
+		if err != nil {
+			return "", err
+		}
+		digest := agentDigest(current)
+		if in.ExpectedDigest != "" && in.ExpectedDigest != digest {
+			return "", errors.New("agent changed since it was inspected")
+		}
+		if operation == "update" {
+			if !in.hasPatch() {
+				return "", errors.New("agent update has no fields")
+			}
+			in.apply(&current)
+			if err := validateAgentCandidate(current); err != nil {
+				return "", err
+			}
+		}
+		return digest, nil
+	default:
+		return "", fmt.Errorf("unsupported agents operation %q", operation)
+	}
+}
+
+func (t *Tool) confirmAgent(ctx context.Context, operation string, input map[string]any, expected string) error {
+	if t.agentMutations == nil {
+		return ErrUnavailable
+	}
+	var in agentWireInput
+	if err := decodeObject(input, &in); err != nil {
+		return err
+	}
+	authority, ok := authz.AuthorityFromContext(ctx)
+	if !ok {
+		return ErrUnavailable
+	}
+	switch operation {
+	case "create":
+		_, err := t.agentMutations.Create(ctx, authority, in.createCandidate())
+		return err
+	case "update":
+		current, err := t.agents.Read(ctx, authority, in.ID)
+		if err != nil {
+			return err
+		}
+		if agentDigest(current) != expected {
+			return errors.New("agent changed since preview")
+		}
+		in.apply(&current)
+		_, err = t.agentMutations.Update(ctx, authority, current)
+		return err
+	case "delete":
+		current, err := t.agents.Read(ctx, authority, in.ID)
+		if err != nil {
+			return err
+		}
+		if agentDigest(current) != expected {
+			return errors.New("agent changed since preview")
+		}
+		return t.agentMutations.Delete(ctx, authority, in.ID)
+	default:
+		return fmt.Errorf("unsupported agents operation %q", operation)
+	}
+}
+
+type agentWireInput struct {
+	ID                  string  `json:"id"`
+	ExpectedDigest      string  `json:"expected_digest"`
+	Name                *string `json:"name"`
+	Model               *string `json:"model"`
+	SystemPrompt        *string `json:"system_prompt"`
+	Soul                *string `json:"soul"`
+	Scope               *string `json:"scope"`
+	Enabled             *bool   `json:"enabled"`
+	ModelThinking       *string `json:"model_thinking"`
+	ModelStrong         *string `json:"model_strong"`
+	ModelStrongThinking *string `json:"model_strong_thinking"`
+	ModelFast           *string `json:"model_fast"`
+	ModelFastThinking   *string `json:"model_fast_thinking"`
+}
+
+func (in agentWireInput) hasPatch() bool {
+	return in.Name != nil || in.Model != nil || in.SystemPrompt != nil || in.Soul != nil || in.Scope != nil || in.Enabled != nil || in.ModelThinking != nil || in.ModelStrong != nil || in.ModelStrongThinking != nil || in.ModelFast != nil || in.ModelFastThinking != nil
+}
+
+func (in agentWireInput) createCandidate() config.Agent {
+	a := config.Agent{}
+	in.apply(&a)
+	if a.ID == "" {
+		a.ID = slug(in.Name)
+	}
+	return a
+}
+
+func (in agentWireInput) apply(a *config.Agent) {
+	if in.Name != nil {
+		a.Name = *in.Name
+	}
+	if in.Model != nil {
+		a.Model = *in.Model
+	}
+	if in.SystemPrompt != nil {
+		a.SystemPrompt = *in.SystemPrompt
+	}
+	if in.Soul != nil {
+		a.Soul = *in.Soul
+	}
+	if in.Scope != nil {
+		a.Scope = *in.Scope
+	}
+	if in.Enabled != nil {
+		a.Enabled = *in.Enabled
+	}
+	if in.ModelThinking != nil {
+		a.ModelThinking = *in.ModelThinking
+	}
+	if in.ModelStrong != nil {
+		a.ModelStrong = *in.ModelStrong
+	}
+	if in.ModelStrongThinking != nil {
+		a.ModelStrongThinking = *in.ModelStrongThinking
+	}
+	if in.ModelFast != nil {
+		a.ModelFast = *in.ModelFast
+	}
+	if in.ModelFastThinking != nil {
+		a.ModelFastThinking = *in.ModelFastThinking
+	}
+}
+
+func slug(value *string) string {
+	if value == nil {
+		return "agent"
+	}
+	s := strings.ToLower(strings.TrimSpace(*value))
+	var b strings.Builder
+	for _, r := range s {
+		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' {
+			b.WriteRune(r)
+		} else if b.Len() > 0 {
+			b.WriteByte('-')
+		}
+	}
+	if b.Len() == 0 {
+		return "agent"
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+func (t *Tool) previewLibrary(ctx context.Context, operation string, input map[string]any) (string, error) {
+	if t.libraryMutations == nil {
+		return "", ErrUnavailable
+	}
+	var in libraryWireInput
+	if err := decodeObject(input, &in); err != nil {
+		return "", err
+	}
+	authority, ok := authz.AuthorityFromContext(ctx)
+	if !ok {
+		return "", ErrUnavailable
+	}
+	switch operation {
+	case "create":
+		if in.FileName == "" || in.Content == "" {
+			return "", errors.New("library file_name and content are required")
+		}
+		if len(in.Content) > library.MaxFileBytes {
+			return "", library.ErrFileTooLarge
+		}
+		_, err := t.libraryMutations.ResolveManageOwner(ctx, authority, library.Scope(in.Scope), in.AgentID)
+		return "", err
+	case "delete":
+		if in.ID == "" {
+			return "", errors.New("library id is required")
+		}
+		file, err := t.libraryMutations.GetManaged(ctx, authority, in.ID)
+		if err != nil {
+			return "", err
+		}
+		d := hex.EncodeToString(file.RawSHA256)
+		if in.ExpectedDigest != "" && in.ExpectedDigest != d {
+			return "", library.ErrGenerationChanged
+		}
+		return d, nil
+	default:
+		return "", fmt.Errorf("unsupported library operation %q", operation)
+	}
+}
+
+type libraryWireInput struct {
+	ID             string `json:"id"`
+	Scope          string `json:"scope"`
+	AgentID        string `json:"agent_id"`
+	FileName       string `json:"file_name"`
+	Content        string `json:"content"`
+	ExpectedDigest string `json:"expected_digest"`
+}
+
+func (t *Tool) confirmLibrary(ctx context.Context, operation string, input map[string]any, expected string) error {
+	var in libraryWireInput
+	if err := decodeObject(input, &in); err != nil {
+		return err
+	}
+	a, ok := authz.AuthorityFromContext(ctx)
+	if !ok {
+		return ErrUnavailable
+	}
+	switch operation {
+	case "create":
+		_, err := t.libraryMutations.CreateManagedUpload(ctx, a, library.Scope(in.Scope), in.AgentID, in.FileName, strings.NewReader(in.Content))
+		return err
+	case "delete":
+		return t.libraryMutations.DeleteManagedWithDigest(ctx, a, in.ID, expected)
+	default:
+		return fmt.Errorf("unsupported library operation %q", operation)
+	}
+}
+
+func (t *Tool) previewSkill(ctx context.Context, operation string, input map[string]any) (string, error) {
+	if t.skillMutations == nil {
+		return "", ErrUnavailable
+	}
+	var in skillWireInput
+	if err := decodeObject(input, &in); err != nil {
+		return "", err
+	}
+	a, ok := authz.AuthorityFromContext(ctx)
+	if !ok {
+		return "", ErrUnavailable
+	}
+	switch operation {
+	case "create":
+		if err := ensureSkillInput(in.create()); err != nil {
+			return "", err
+		}
+		return "", t.skillMutations.PreviewCreate(ctx, a, in.Scope, in.AgentID)
+	case "update":
+		if in.ID == "" {
+			return "", errors.New("skill id is required")
+		}
+		sk, err := t.skillMutations.PreviewExisting(ctx, a, in.ID, authz.ActionWrite)
+		if err != nil {
+			return "", err
+		}
+		if in.ExpectedDigest == "" || in.ExpectedDigest != sk.ContentDigest {
+			return "", skills.ErrSkillDigestConflict
+		}
+		return sk.ContentDigest, nil
+	case "delete":
+		if in.ID == "" {
+			return "", errors.New("skill id is required")
+		}
+		sk, err := t.skillMutations.PreviewExisting(ctx, a, in.ID, authz.ActionDelete)
+		if err != nil {
+			return "", err
+		}
+		if in.ExpectedDigest != "" && in.ExpectedDigest != sk.ContentDigest {
+			return "", skills.ErrSkillDigestConflict
+		}
+		return sk.ContentDigest, nil
+	default:
+		return "", fmt.Errorf("unsupported skills operation %q", operation)
+	}
+}
+
+type skillWireInput struct {
+	ID                     string            `json:"id"`
+	Scope                  string            `json:"scope"`
+	AgentID                string            `json:"agent_id"`
+	Name                   string            `json:"name"`
+	Description            *string           `json:"description"`
+	Body                   string            `json:"body"`
+	Files                  map[string]string `json:"files"`
+	DeleteFiles            []string          `json:"delete_files"`
+	DisableModelInvocation *bool             `json:"disable_model_invocation"`
+	ExpectedDigest         string            `json:"expected_digest"`
+}
+
+func (in skillWireInput) create() skillCreateRequest {
+	var description string
+	if in.Description != nil {
+		description = *in.Description
+	}
+	var disable bool
+	if in.DisableModelInvocation != nil {
+		disable = *in.DisableModelInvocation
+	}
+	return skillCreateRequest{Scope: in.Scope, AgentID: in.AgentID, Name: in.Name, Description: description, Body: in.Body, Files: in.Files, DisableModelInvocation: disable}
+}
+
+func (in skillWireInput) update() skillUpdateRequest {
+	return skillUpdateRequest{ID: in.ID, ExpectedDigest: in.ExpectedDigest, Description: in.Description, DisableModelInvocation: in.DisableModelInvocation, Files: in.Files, DeleteFiles: in.DeleteFiles}
+}
+
+func (t *Tool) confirmSkill(ctx context.Context, operation string, input map[string]any, expected string) error {
+	var in skillWireInput
+	if err := decodeObject(input, &in); err != nil {
+		return err
+	}
+	a, ok := authz.AuthorityFromContext(ctx)
+	if !ok {
+		return ErrUnavailable
+	}
+	switch operation {
+	case "create":
+		return func() error {
+			req := in.create()
+			returnErr := ensureSkillInput(req)
+			if returnErr != nil {
+				return returnErr
+			}
+			_, err := t.skillMutations.Create(ctx, a, req)
+			return err
+		}()
+	case "update":
+		req := in.update()
+		req.ExpectedDigest = expected
+		_, err := t.skillMutations.Update(ctx, a, req)
+		return err
+	case "delete":
+		return t.skillMutations.Delete(ctx, a, skillDeleteRequest{ID: in.ID, ExpectedDigest: expected})
+	default:
+		return fmt.Errorf("unsupported skills operation %q", operation)
+	}
+}
+
+func (t *Tool) previewOverride(ctx context.Context, operation string, input map[string]any) (string, error) {
+	if t.toolOverrideMutations == nil {
+		return "", ErrUnavailable
+	}
+	var in toolOverrideWireInput
+	if err := decodeObject(input, &in); err != nil {
+		return "", err
+	}
+	if operation != "set" && operation != "clear" {
+		return "", fmt.Errorf("unsupported tool_overrides operation %q", operation)
+	}
+	return t.toolOverrideMutations.Preview(ctx, mustAuthority(ctx), in.request())
+}
+
+type toolOverrideWireInput struct {
+	ToolName string `json:"tool_name"`
+	Scope    string `json:"scope"`
+	AgentID  string `json:"agent_id"`
+	Enabled  bool   `json:"enabled"`
+}
+
+func (in toolOverrideWireInput) request() toolOverrideRequest {
+	return toolOverrideRequest(in)
+}
+
+func (t *Tool) confirmOverride(ctx context.Context, operation string, input map[string]any, expected string) error {
+	var in toolOverrideWireInput
+	if err := decodeObject(input, &in); err != nil {
+		return err
+	}
+	a, ok := authz.AuthorityFromContext(ctx)
+	if !ok {
+		return ErrUnavailable
+	}
+	switch operation {
+	case "set":
+		return t.toolOverrideMutations.Set(ctx, a, in.request(), expected)
+	case "clear":
+		return t.toolOverrideMutations.Clear(ctx, a, in.request(), expected)
+	default:
+		return fmt.Errorf("unsupported tool_overrides operation %q", operation)
+	}
+}
+
+func mustAuthority(ctx context.Context) authz.Authority {
+	a, _ := authz.AuthorityFromContext(ctx)
+	return a
+}

--- a/internal/settings/protocol.go
+++ b/internal/settings/protocol.go
@@ -22,26 +22,33 @@ import (
 
 const mutationTokenTTL = 2 * time.Minute
 
-var operationContracts = map[string]map[string]map[string]any{
+type operationContract struct {
+	Required      []string   `json:"required"`
+	Optional      []string   `json:"optional"`
+	RequiredAnyOf [][]string `json:"required_any_of,omitempty"`
+	Constraints   []string   `json:"constraints"`
+}
+
+var operationContracts = map[string]map[string]operationContract{
 	"agents": {
-		"list":   {"required": []string{}, "optional": []string{"page_size", "page_token"}, "constraints": []string{"page_size is 1..100; page_token is the opaque token returned by the previous page"}},
-		"get":    {"required": []string{"id"}, "optional": []string{}, "constraints": []string{"id must identify an Agent readable by the current Authority"}},
-		"create": {"required": []string{"name"}, "optional": []string{"id", "model", "model_thinking", "model_strong", "model_strong_thinking", "model_fast", "model_fast_thinking", "system_prompt", "soul", "scope", "enabled"}, "constraints": []string{"scope is restricted for ordinary users and may be system only for admin Authority; model fields use provider/model; thinking fields are minimal, low, medium, high, or xhigh"}},
-		"update": {"required": []string{"id"}, "optional": []string{"name", "model", "model_thinking", "model_strong", "model_strong_thinking", "model_fast", "model_fast_thinking", "system_prompt", "soul", "scope", "enabled", "expected_digest"}, "constraints": []string{"ordinary users may update only their own restricted Agent; expected_digest is checked against the current row at confirm"}},
-		"delete": {"required": []string{"id"}, "optional": []string{"expected_digest"}, "constraints": []string{"ordinary users may delete only their own restricted Agent; expected_digest is checked against the current row at confirm"}},
+		"list":   {Required: []string{}, Optional: []string{"page_size", "page_token"}, Constraints: []string{"page_size is 1..100; page_token is the opaque token returned by the previous page"}},
+		"get":    {Required: []string{"id"}, Optional: []string{}, Constraints: []string{"id must identify an Agent readable by the current Authority"}},
+		"create": {Required: []string{"name"}, Optional: []string{"model", "model_thinking", "model_strong", "model_strong_thinking", "model_fast", "model_fast_thinking", "system_prompt", "soul", "scope", "enabled"}, Constraints: []string{"scope defaults to restricted for ordinary users and may be system only for admin Authority; model fields use provider/model; thinking fields are minimal, low, medium, high, or xhigh"}},
+		"update": {Required: []string{"id"}, Optional: []string{"name", "model", "model_thinking", "model_strong", "model_strong_thinking", "model_fast", "model_fast_thinking", "system_prompt", "soul", "scope", "enabled", "expected_digest"}, Constraints: []string{"ordinary users may update only their own restricted Agent; expected_digest is checked against the current row at confirm"}},
+		"delete": {Required: []string{"id"}, Optional: []string{"expected_digest"}, Constraints: []string{"ordinary users may delete only their own restricted Agent; expected_digest is checked against the current row at confirm"}},
 	},
 	"library": {
-		"create": {"required": []string{"scope", "file_name", "content"}, "optional": []string{"agent_id"}, "constraints": []string{"scope is user, user_agent, system, or system_agent; agent_id is required only for agent-bound scopes; content is bounded text"}},
-		"delete": {"required": []string{"id"}, "optional": []string{"expected_digest"}, "constraints": []string{"the current Authority must own the file; expected_digest is the raw snapshot SHA-256"}},
+		"create": {Required: []string{"scope", "file_name", "content"}, Optional: []string{"agent_id"}, Constraints: []string{"scope is user, user_agent, system, or system_agent; agent_id is required only for agent-bound scopes; content is bounded text"}},
+		"delete": {Required: []string{"id"}, Optional: []string{"expected_digest"}, Constraints: []string{"the current Authority must own the file; expected_digest is the raw snapshot SHA-256"}},
 	},
 	"skills": {
-		"create": {"required": []string{"scope", "name", "body or files"}, "optional": []string{"agent_id", "description", "disable_model_invocation", "files"}, "constraints": []string{"scope is user, user_agent, system, or system_agent; agent_id is required only for agent-bound scopes; files must include SKILL.md when supplied"}},
-		"update": {"required": []string{"id", "expected_digest"}, "optional": []string{"description", "disable_model_invocation", "files", "delete_files"}, "constraints": []string{"expected_digest must equal the current Skill content digest; the current Authority must own the Skill"}},
-		"delete": {"required": []string{"id", "expected_digest"}, "optional": []string{}, "constraints": []string{"expected_digest must equal the current Skill content digest; the current Authority must own the Skill"}},
+		"create": {Required: []string{"scope", "name"}, Optional: []string{"agent_id", "description", "body", "files", "disable_model_invocation"}, RequiredAnyOf: [][]string{{"body", "files"}}, Constraints: []string{"at least one of body or files is required; scope is user, user_agent, system, or system_agent; agent_id is required only for agent-bound scopes; files must include SKILL.md when supplied"}},
+		"update": {Required: []string{"id", "expected_digest"}, Optional: []string{"description", "disable_model_invocation", "files", "delete_files"}, Constraints: []string{"expected_digest must equal the current Skill content digest; the current Authority must own the Skill"}},
+		"delete": {Required: []string{"id", "expected_digest"}, Optional: []string{}, Constraints: []string{"expected_digest must equal the current Skill content digest; the current Authority must own the Skill"}},
 	},
 	"tool_overrides": {
-		"set":   {"required": []string{"tool_name", "scope", "enabled"}, "optional": []string{"agent_id"}, "constraints": []string{"scope is user, user_agent, system, or system_agent; agent_id is required only for agent-bound scopes; core and unmanaged tools are rejected"}},
-		"clear": {"required": []string{"tool_name", "scope"}, "optional": []string{"agent_id"}, "constraints": []string{"scope is user, user_agent, system, or system_agent; agent_id is required only for agent-bound scopes; core and unmanaged tools are rejected"}},
+		"set":   {Required: []string{"tool_name", "scope", "enabled"}, Optional: []string{"agent_id"}, Constraints: []string{"scope is user, user_agent, system, or system_agent; agent_id is required only for agent-bound scopes; core and unmanaged tools are rejected"}},
+		"clear": {Required: []string{"tool_name", "scope"}, Optional: []string{"agent_id"}, Constraints: []string{"scope is user, user_agent, system, or system_agent; agent_id is required only for agent-bound scopes; core and unmanaged tools are rejected"}},
 	},
 }
 
@@ -81,6 +88,45 @@ func (t *Tool) describeResource(ctx context.Context, args map[string]any) (strin
 	})
 }
 
+func validateMutationContract(resource, operation string, input map[string]any) error {
+	operations, ok := operationContracts[resource]
+	if !ok {
+		return fmt.Errorf("unsupported settings resource %q", resource)
+	}
+	contract, ok := operations[operation]
+	if !ok {
+		return fmt.Errorf("unsupported %s operation %q", resource, operation)
+	}
+	allowed := make(map[string]bool, len(contract.Required)+len(contract.Optional))
+	for _, field := range contract.Required {
+		allowed[field] = true
+		if value, present := input[field]; !present || value == nil {
+			return fmt.Errorf("%s.%s input requires %q", resource, operation, field)
+		}
+	}
+	for _, field := range contract.Optional {
+		allowed[field] = true
+	}
+	for _, group := range contract.RequiredAnyOf {
+		found := false
+		for _, field := range group {
+			allowed[field] = true
+			if value, present := input[field]; present && value != nil {
+				found = true
+			}
+		}
+		if !found {
+			return fmt.Errorf("%s.%s input requires at least one of %s", resource, operation, strings.Join(group, ", "))
+		}
+	}
+	for field := range input {
+		if !allowed[field] {
+			return fmt.Errorf("%s.%s input does not support %q", resource, operation, field)
+		}
+	}
+	return nil
+}
+
 func (t *Tool) previewMutation(ctx context.Context, args map[string]any) (string, error) {
 	if err := rejectUnexpected(args, "action", "resource", "operation", "input"); err != nil {
 		return "", err
@@ -96,6 +142,9 @@ func (t *Tool) previewMutation(ctx context.Context, args map[string]any) (string
 	input, ok := args["input"].(map[string]any)
 	if !ok {
 		return "", errors.New("input must be an object")
+	}
+	if err := validateMutationContract(resource, operation, input); err != nil {
+		return "", err
 	}
 	authority, ok := authz.AuthorityFromContext(ctx)
 	if !ok {

--- a/internal/settings/protocol.go
+++ b/internal/settings/protocol.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -20,6 +21,29 @@ import (
 )
 
 const mutationTokenTTL = 2 * time.Minute
+
+var operationContracts = map[string]map[string]map[string]any{
+	"agents": {
+		"list":   {"required": []string{}, "optional": []string{"page_size", "page_token"}, "constraints": []string{"page_size is 1..100; page_token is the opaque token returned by the previous page"}},
+		"get":    {"required": []string{"id"}, "optional": []string{}, "constraints": []string{"id must identify an Agent readable by the current Authority"}},
+		"create": {"required": []string{"name"}, "optional": []string{"id", "model", "model_thinking", "model_strong", "model_strong_thinking", "model_fast", "model_fast_thinking", "system_prompt", "soul", "scope", "enabled"}, "constraints": []string{"scope is restricted for ordinary users and may be system only for admin Authority; model fields use provider/model; thinking fields are minimal, low, medium, high, or xhigh"}},
+		"update": {"required": []string{"id"}, "optional": []string{"name", "model", "model_thinking", "model_strong", "model_strong_thinking", "model_fast", "model_fast_thinking", "system_prompt", "soul", "scope", "enabled", "expected_digest"}, "constraints": []string{"ordinary users may update only their own restricted Agent; expected_digest is checked against the current row at confirm"}},
+		"delete": {"required": []string{"id"}, "optional": []string{"expected_digest"}, "constraints": []string{"ordinary users may delete only their own restricted Agent; expected_digest is checked against the current row at confirm"}},
+	},
+	"library": {
+		"create": {"required": []string{"scope", "file_name", "content"}, "optional": []string{"agent_id"}, "constraints": []string{"scope is user, user_agent, system, or system_agent; agent_id is required only for agent-bound scopes; content is bounded text"}},
+		"delete": {"required": []string{"id"}, "optional": []string{"expected_digest"}, "constraints": []string{"the current Authority must own the file; expected_digest is the raw snapshot SHA-256"}},
+	},
+	"skills": {
+		"create": {"required": []string{"scope", "name", "body or files"}, "optional": []string{"agent_id", "description", "disable_model_invocation", "files"}, "constraints": []string{"scope is user, user_agent, system, or system_agent; agent_id is required only for agent-bound scopes; files must include SKILL.md when supplied"}},
+		"update": {"required": []string{"id", "expected_digest"}, "optional": []string{"description", "disable_model_invocation", "files", "delete_files"}, "constraints": []string{"expected_digest must equal the current Skill content digest; the current Authority must own the Skill"}},
+		"delete": {"required": []string{"id", "expected_digest"}, "optional": []string{}, "constraints": []string{"expected_digest must equal the current Skill content digest; the current Authority must own the Skill"}},
+	},
+	"tool_overrides": {
+		"set":   {"required": []string{"tool_name", "scope", "enabled"}, "optional": []string{"agent_id"}, "constraints": []string{"scope is user, user_agent, system, or system_agent; agent_id is required only for agent-bound scopes; core and unmanaged tools are rejected"}},
+		"clear": {"required": []string{"tool_name", "scope"}, "optional": []string{"agent_id"}, "constraints": []string{"scope is user, user_agent, system, or system_agent; agent_id is required only for agent-bound scopes; core and unmanaged tools are rejected"}},
+	},
+}
 
 type pendingMutation struct {
 	userID    string
@@ -40,23 +64,20 @@ func (t *Tool) describeResource(ctx context.Context, args map[string]any) (strin
 	if err != nil {
 		return "", err
 	}
-	var operations []string
-	switch resource {
-	case "agents":
-		operations = []string{"list", "get", "create", "update", "delete"}
-	case "library":
-		operations = []string{"create", "delete"}
-	case "skills":
-		operations = []string{"create", "update", "delete"}
-	case "tool_overrides":
-		operations = []string{"set", "clear"}
-	default:
+	contracts, ok := operationContracts[resource]
+	if !ok {
 		return "", fmt.Errorf("unsupported settings resource %q", resource)
 	}
+	operations := make([]string, 0, len(contracts))
+	for operation := range contracts {
+		operations = append(operations, operation)
+	}
+	sort.Strings(operations)
 	return tools.MarshalResult(map[string]any{
-		"resource":   resource,
-		"operations": operations,
-		"protocol":   "preview then confirm; confirmation is model-side and is not human approval",
+		"resource":            resource,
+		"operations":          operations,
+		"operation_contracts": contracts,
+		"protocol":            "preview then confirm; confirmation is model-side and is not human approval",
 	})
 }
 
@@ -75,6 +96,13 @@ func (t *Tool) previewMutation(ctx context.Context, args map[string]any) (string
 	input, ok := args["input"].(map[string]any)
 	if !ok {
 		return "", errors.New("input must be an object")
+	}
+	authority, ok := authz.AuthorityFromContext(ctx)
+	if !ok {
+		return "", ErrUnavailable
+	}
+	if err := authorizeMutationScope(authority, input); err != nil {
+		return "", err
 	}
 	encoded, err := json.Marshal(input)
 	if err != nil {
@@ -150,6 +178,13 @@ func (t *Tool) confirmMutation(ctx context.Context, args map[string]any) (string
 	if err := json.Unmarshal(pending.input, &input); err != nil {
 		return "", errors.New("confirmation token payload is invalid")
 	}
+	authority, ok := authz.AuthorityFromContext(ctx)
+	if !ok {
+		return "", ErrUnavailable
+	}
+	if err := authorizeMutationScope(authority, input); err != nil {
+		return "", err
+	}
 	var applyErr error
 	switch pending.resource {
 	case "agents":
@@ -186,6 +221,37 @@ func digestValue(value any) string {
 }
 
 func agentDigest(a config.Agent) string { return digestValue(a) }
+
+func authorizeMutationScope(authority authz.Authority, input map[string]any) error {
+	scope, _ := input["scope"].(string)
+	if !authority.IsAdmin() && (scope == config.AgentScopeSystem || scope == "system_agent") {
+		return authz.ErrForbidden
+	}
+	return nil
+}
+
+func authorizeAgentScope(authority authz.Authority, requested string, current *config.Agent) error {
+	if authority.IsAdmin() {
+		return nil
+	}
+	if current != nil && current.Scope == config.AgentScopeSystem {
+		return authz.ErrForbidden
+	}
+	if requested == config.AgentScopeSystem {
+		return authz.ErrForbidden
+	}
+	if requested != "" && requested != config.AgentScopeRestricted {
+		return fmt.Errorf("invalid agent scope %q", requested)
+	}
+	return nil
+}
+
+func stringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
 
 func validateAgentCandidate(a config.Agent) error {
 	if strings.TrimSpace(a.Name) == "" {
@@ -228,6 +294,9 @@ func (t *Tool) previewAgent(ctx context.Context, operation string, input map[str
 	switch operation {
 	case "create":
 		candidate := in.createCandidate()
+		if err := authorizeAgentScope(authority, candidate.Scope, nil); err != nil {
+			return "", err
+		}
 		if err := validateAgentCandidate(candidate); err != nil {
 			return "", err
 		}
@@ -248,6 +317,9 @@ func (t *Tool) previewAgent(ctx context.Context, operation string, input map[str
 		}
 		current, err := t.agents.Read(ctx, authority, in.ID)
 		if err != nil {
+			return "", err
+		}
+		if err := authorizeAgentScope(authority, stringValue(in.Scope), &current); err != nil {
 			return "", err
 		}
 		digest := agentDigest(current)
@@ -283,28 +355,51 @@ func (t *Tool) confirmAgent(ctx context.Context, operation string, input map[str
 	}
 	switch operation {
 	case "create":
-		_, err := t.agentMutations.Create(ctx, authority, in.createCandidate())
+		candidate := in.createCandidate()
+		if err := authorizeAgentScope(authority, candidate.Scope, nil); err != nil {
+			return err
+		}
+		_, err := t.agentMutations.Create(ctx, authority, candidate)
 		return err
 	case "update":
-		current, err := t.agents.Read(ctx, authority, in.ID)
+		expectedAgent, err := t.agents.Read(ctx, authority, in.ID)
 		if err != nil {
 			return err
 		}
-		if agentDigest(current) != expected {
+		if err := authorizeAgentScope(authority, stringValue(in.Scope), &expectedAgent); err != nil {
+			return err
+		}
+		if agentDigest(expectedAgent) != expected {
 			return errors.New("agent changed since preview")
 		}
+		current := expectedAgent
 		in.apply(&current)
-		_, err = t.agentMutations.Update(ctx, authority, current)
+		atomic, ok := t.agentMutations.(interface {
+			UpdateIfUnchanged(context.Context, authz.Authority, config.Agent, config.Agent) (config.Agent, error)
+		})
+		if !ok {
+			return ErrUnavailable
+		}
+		_, err = atomic.UpdateIfUnchanged(ctx, authority, expectedAgent, current)
 		return err
 	case "delete":
 		current, err := t.agents.Read(ctx, authority, in.ID)
 		if err != nil {
 			return err
 		}
+		if err := authorizeAgentScope(authority, "", &current); err != nil {
+			return err
+		}
 		if agentDigest(current) != expected {
 			return errors.New("agent changed since preview")
 		}
-		return t.agentMutations.Delete(ctx, authority, in.ID)
+		atomic, ok := t.agentMutations.(interface {
+			DeleteIfUnchanged(context.Context, authz.Authority, config.Agent) error
+		})
+		if !ok {
+			return ErrUnavailable
+		}
+		return atomic.DeleteIfUnchanged(ctx, authority, current)
 	default:
 		return fmt.Errorf("unsupported agents operation %q", operation)
 	}
@@ -582,6 +677,9 @@ func (t *Tool) previewOverride(ctx context.Context, operation string, input map[
 	if operation != "set" && operation != "clear" {
 		return "", fmt.Errorf("unsupported tool_overrides operation %q", operation)
 	}
+	if operation == "set" && in.Enabled == nil {
+		return "", errors.New("tool_overrides.set requires enabled")
+	}
 	return t.toolOverrideMutations.Preview(ctx, mustAuthority(ctx), in.request())
 }
 
@@ -589,11 +687,11 @@ type toolOverrideWireInput struct {
 	ToolName string `json:"tool_name"`
 	Scope    string `json:"scope"`
 	AgentID  string `json:"agent_id"`
-	Enabled  bool   `json:"enabled"`
+	Enabled  *bool  `json:"enabled"`
 }
 
 func (in toolOverrideWireInput) request() toolOverrideRequest {
-	return toolOverrideRequest(in)
+	return toolOverrideRequest{ToolName: in.ToolName, Scope: in.Scope, AgentID: in.AgentID, Enabled: in.Enabled != nil && *in.Enabled}
 }
 
 func (t *Tool) confirmOverride(ctx context.Context, operation string, input map[string]any, expected string) error {

--- a/internal/settings/protocol.go
+++ b/internal/settings/protocol.go
@@ -20,7 +20,12 @@ import (
 	"github.com/CherryHQ/stella/pkg/tools"
 )
 
-const mutationTokenTTL = 2 * time.Minute
+const (
+	mutationTokenTTL         = 2 * time.Minute
+	maxPendingMutationBytes  = 256 * 1024
+	maxPendingMutations      = 256
+	maxPendingPerUserSession = 16
+)
 
 type operationContract struct {
 	Required      []string   `json:"required"`
@@ -38,7 +43,7 @@ var operationContracts = map[string]map[string]operationContract{
 		"delete": {Required: []string{"id"}, Optional: []string{"expected_digest"}, Constraints: []string{"ordinary users may delete only their own restricted Agent; expected_digest is checked against the current row at confirm"}},
 	},
 	"library": {
-		"create": {Required: []string{"scope", "file_name", "content"}, Optional: []string{"agent_id"}, Constraints: []string{"scope is user, user_agent, system, or system_agent; agent_id is required only for agent-bound scopes; content is bounded text"}},
+		"create": {Required: []string{"scope", "file_name", "content"}, Optional: []string{"agent_id"}, Constraints: []string{"scope is user, user_agent, system, or system_agent; agent_id is required only for agent-bound scopes; the entire preview payload is limited to 256 KiB"}},
 		"delete": {Required: []string{"id"}, Optional: []string{"expected_digest"}, Constraints: []string{"the current Authority must own the file; expected_digest is the raw snapshot SHA-256"}},
 	},
 	"skills": {
@@ -157,6 +162,9 @@ func (t *Tool) previewMutation(ctx context.Context, args map[string]any) (string
 	if err != nil {
 		return "", err
 	}
+	if len(encoded) > maxPendingMutationBytes {
+		return "", errors.New("settings mutation payload exceeds the 256 KiB limit")
+	}
 	var digest string
 	switch resource {
 	case "agents":
@@ -187,12 +195,23 @@ func (t *Tool) previewMutation(ctx context.Context, args map[string]any) (string
 			delete(t.tokens, key)
 		}
 	}
-	if len(t.tokens) >= 256 {
+	if len(t.tokens) >= maxPendingMutations {
 		t.tokensMu.Unlock()
 		return "", errors.New("too many pending settings confirmations")
 	}
+	userID, sessionID := authz.UserIDFromContext(ctx), currentSessionID(ctx)
+	pendingForSession := 0
+	for _, pending := range t.tokens {
+		if pending.userID == userID && pending.sessionID == sessionID {
+			pendingForSession++
+		}
+	}
+	if pendingForSession >= maxPendingPerUserSession {
+		t.tokensMu.Unlock()
+		return "", errors.New("too many pending settings confirmations for this session")
+	}
 	t.tokens[token] = pendingMutation{
-		userID: authz.UserIDFromContext(ctx), sessionID: currentSessionID(ctx), agentID: authz.AgentIDFromContext(ctx),
+		userID: userID, sessionID: sessionID, agentID: authz.AgentIDFromContext(ctx),
 		resource: resource, operation: operation, input: encoded, digest: digest, expiresAt: now.Add(mutationTokenTTL),
 	}
 	t.tokensMu.Unlock()

--- a/internal/settings/protocol_test.go
+++ b/internal/settings/protocol_test.go
@@ -1,0 +1,121 @@
+package settings
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/CherryHQ/stella/internal/authz"
+	"github.com/CherryHQ/stella/internal/config"
+)
+
+type recordingAgentMutation struct {
+	created []config.Agent
+	updated []config.Agent
+	deleted []string
+}
+
+func (m *recordingAgentMutation) Create(_ context.Context, _ authz.Authority, a config.Agent) (config.Agent, error) {
+	m.created = append(m.created, a)
+	return a, nil
+}
+
+func (m *recordingAgentMutation) Update(_ context.Context, _ authz.Authority, a config.Agent) (config.Agent, error) {
+	m.updated = append(m.updated, a)
+	return a, nil
+}
+
+func (m *recordingAgentMutation) Delete(_ context.Context, _ authz.Authority, id string) error {
+	m.deleted = append(m.deleted, id)
+	return nil
+}
+
+func tokenFromResult(t *testing.T, raw string) string {
+	t.Helper()
+	var result struct {
+		Token string `json:"confirmation_token"`
+	}
+	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Token == "" {
+		t.Fatal("preview returned no confirmation token")
+	}
+	return result.Token
+}
+
+func TestMutationPreviewConfirmReauthorizesAndConsumesToken(t *testing.T) {
+	current := config.Agent{ID: "writer", Name: "Writer", Model: "openai/gpt", Enabled: true}
+	reader := &mutableAgentReader{agent: current}
+	mutation := &recordingAgentMutation{}
+	tool := NewTool(reader, WithAgentMutations(mutation))
+	ctx := settingsContext(userAuthority(t, "u1"))
+
+	preview, err := tool.Execute(ctx, map[string]any{"action": "preview", "resource": "agents", "operation": "update", "input": map[string]any{
+		"id": "writer", "name": "Updated",
+	}})
+	if err != nil {
+		t.Fatalf("preview: %v", err)
+	}
+	token := tokenFromResult(t, preview)
+	if _, err := tool.Execute(ctx, map[string]any{"action": "confirm", "token": token}); err != nil {
+		t.Fatalf("confirm: %v", err)
+	}
+	if len(mutation.updated) != 1 || mutation.updated[0].Name != "Updated" {
+		t.Fatalf("updates = %#v", mutation.updated)
+	}
+	if _, err := tool.Execute(ctx, map[string]any{"action": "confirm", "token": token}); err == nil {
+		t.Fatal("single-use token was accepted twice")
+	}
+}
+
+type mutableAgentReader struct{ agent config.Agent }
+
+func (r *mutableAgentReader) ListReadable(context.Context, authz.Authority, bool) ([]config.Agent, error) {
+	return []config.Agent{r.agent}, nil
+}
+
+func (r *mutableAgentReader) Read(_ context.Context, _ authz.Authority, id string) (config.Agent, error) {
+	if id != r.agent.ID {
+		return config.Agent{}, errors.New("not found")
+	}
+	return r.agent, nil
+}
+
+func TestMutationConfirmRejectsStaleAgentWithoutWriting(t *testing.T) {
+	reader := &mutableAgentReader{agent: config.Agent{ID: "writer", Name: "Writer"}}
+	mutation := &recordingAgentMutation{}
+	tool := NewTool(reader, WithAgentMutations(mutation))
+	ctx := settingsContext(userAuthority(t, "u1"))
+	preview, err := tool.Execute(ctx, map[string]any{"action": "preview", "resource": "agents", "operation": "delete", "input": map[string]any{"id": "writer"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := tokenFromResult(t, preview)
+	reader.agent.Name = "Changed"
+	if _, err := tool.Execute(ctx, map[string]any{"action": "confirm", "token": token}); err == nil {
+		t.Fatal("stale confirmation succeeded")
+	}
+	if len(mutation.deleted) != 0 {
+		t.Fatalf("deleted = %#v", mutation.deleted)
+	}
+}
+
+func TestMutationTokenIsBoundToSessionAndUser(t *testing.T) {
+	reader := &mutableAgentReader{agent: config.Agent{ID: "writer", Name: "Writer"}}
+	tool := NewTool(reader, WithAgentMutations(&recordingAgentMutation{}))
+	ctx := settingsContext(userAuthority(t, "u1"))
+	preview, err := tool.Execute(ctx, map[string]any{"action": "preview", "resource": "agents", "operation": "delete", "input": map[string]any{"id": "writer"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := tokenFromResult(t, preview)
+	other := settingsContext(userAuthority(t, "u2"))
+	if _, err := tool.Execute(other, map[string]any{"action": "confirm", "token": token}); err == nil {
+		t.Fatal("foreign user consumed token")
+	}
+	if _, err := tool.Execute(ctx, map[string]any{"action": "confirm", "token": token}); err == nil {
+		t.Fatal("token should be consumed on a mismatched attempt")
+	}
+}

--- a/internal/settings/protocol_test.go
+++ b/internal/settings/protocol_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -116,6 +118,30 @@ func TestMutationContractsRejectMissingAndUnsupportedFields(t *testing.T) {
 				t.Fatalf("validateMutationContract() = %v, wantErr=%t", err, tc.wantErr)
 			}
 		})
+	}
+}
+
+func TestMutationPreviewBoundsPendingPayloadsAndPerSessionCapacity(t *testing.T) {
+	tool := NewTool(&mutableAgentReader{agent: config.Agent{ID: "writer", Scope: config.AgentScopeRestricted}}, WithAgentMutations(&recordingAgentMutation{}))
+	ctx := settingsContext(userAuthority(t, "u1"))
+	if _, err := tool.Execute(ctx, map[string]any{
+		"action": "preview", "resource": "library", "operation": "create", "input": map[string]any{
+			"scope": "user", "file_name": "large.md", "content": strings.Repeat("x", maxPendingMutationBytes),
+		},
+	}); err == nil {
+		t.Fatal("oversized pending mutation was accepted")
+	}
+	for i := range maxPendingPerUserSession {
+		if _, err := tool.Execute(ctx, map[string]any{
+			"action": "preview", "resource": "agents", "operation": "create", "input": map[string]any{"name": fmt.Sprintf("Agent %d", i)},
+		}); err != nil {
+			t.Fatalf("preview %d: %v", i, err)
+		}
+	}
+	if _, err := tool.Execute(ctx, map[string]any{
+		"action": "preview", "resource": "agents", "operation": "create", "input": map[string]any{"name": "overflow"},
+	}); err == nil {
+		t.Fatal("per-session pending mutation cap was not enforced")
 	}
 }
 

--- a/internal/settings/protocol_test.go
+++ b/internal/settings/protocol_test.go
@@ -65,8 +65,10 @@ func TestDescribeExposesEveryMutationContract(t *testing.T) {
 			}
 			var decoded struct {
 				Contracts map[string]struct {
-					Required    []string `json:"required"`
-					Constraints []string `json:"constraints"`
+					Required      []string   `json:"required"`
+					Optional      []string   `json:"optional"`
+					RequiredAnyOf [][]string `json:"required_any_of"`
+					Constraints   []string   `json:"constraints"`
 				} `json:"operation_contracts"`
 			}
 			if err := json.Unmarshal([]byte(result), &decoded); err != nil {
@@ -76,11 +78,65 @@ func TestDescribeExposesEveryMutationContract(t *testing.T) {
 				t.Fatal("describe returned no operation contracts")
 			}
 			for operation, contract := range decoded.Contracts {
-				if contract.Required == nil || contract.Constraints == nil || len(contract.Constraints) == 0 {
+				if contract.Required == nil || contract.Optional == nil || contract.Constraints == nil || len(contract.Constraints) == 0 {
 					t.Fatalf("%s contract is incomplete: %#v", operation, contract)
 				}
 			}
+			if resource == "skills" {
+				create := decoded.Contracts["create"]
+				if len(create.RequiredAnyOf) != 1 || len(create.RequiredAnyOf[0]) != 2 {
+					t.Fatalf("skills.create any-of contract = %#v", create.RequiredAnyOf)
+				}
+			}
 		})
+	}
+}
+
+func TestMutationContractsRejectMissingAndUnsupportedFields(t *testing.T) {
+	cases := []struct {
+		name      string
+		resource  string
+		operation string
+		input     map[string]any
+		wantErr   bool
+	}{
+		{name: "agent create", resource: "agents", operation: "create", input: map[string]any{"name": "Writer"}},
+		{name: "agent create rejects id", resource: "agents", operation: "create", input: map[string]any{"name": "Writer", "id": "caller-owned"}, wantErr: true},
+		{name: "override set requires enabled", resource: "tool_overrides", operation: "set", input: map[string]any{"tool_name": "memory", "scope": "user"}, wantErr: true},
+		{name: "override false is present", resource: "tool_overrides", operation: "set", input: map[string]any{"tool_name": "memory", "scope": "user", "enabled": false}},
+		{name: "skill requires body or files", resource: "skills", operation: "create", input: map[string]any{"scope": "user", "name": "x"}, wantErr: true},
+		{name: "skill body satisfies any-of", resource: "skills", operation: "create", input: map[string]any{"scope": "user", "name": "x", "body": "body"}},
+		{name: "operation-specific unknown field", resource: "library", operation: "delete", input: map[string]any{"id": "f", "content": "ignored"}, wantErr: true},
+		{name: "unknown operation", resource: "library", operation: "update", input: map[string]any{"id": "f"}, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateMutationContract(tc.resource, tc.operation, tc.input)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("validateMutationContract() = %v, wantErr=%t", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestMutationScopeMatrix(t *testing.T) {
+	ordinary := userAuthority(t, "u1")
+	admin, err := authz.NewUserAuthority("admin", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, scope := range []string{"system", "system_agent"} {
+		if err := authorizeMutationScope(ordinary, map[string]any{"scope": scope}); !errors.Is(err, authz.ErrForbidden) {
+			t.Fatalf("ordinary %s scope = %v, want forbidden", scope, err)
+		}
+		if err := authorizeMutationScope(admin, map[string]any{"scope": scope}); err != nil {
+			t.Fatalf("admin %s scope = %v", scope, err)
+		}
+	}
+	for _, scope := range []string{"", "restricted", "user", "user_agent"} {
+		if err := authorizeMutationScope(ordinary, map[string]any{"scope": scope}); err != nil {
+			t.Fatalf("ordinary %s scope = %v", scope, err)
+		}
 	}
 }
 

--- a/internal/settings/protocol_test.go
+++ b/internal/settings/protocol_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/CherryHQ/stella/internal/authz"
 	"github.com/CherryHQ/stella/internal/config"
@@ -31,6 +32,14 @@ func (m *recordingAgentMutation) Delete(_ context.Context, _ authz.Authority, id
 	return nil
 }
 
+func (m *recordingAgentMutation) UpdateIfUnchanged(ctx context.Context, authority authz.Authority, _ config.Agent, candidate config.Agent) (config.Agent, error) {
+	return m.Update(ctx, authority, candidate)
+}
+
+func (m *recordingAgentMutation) DeleteIfUnchanged(ctx context.Context, authority authz.Authority, expected config.Agent) error {
+	return m.Delete(ctx, authority, expected.ID)
+}
+
 func tokenFromResult(t *testing.T, raw string) string {
 	t.Helper()
 	var result struct {
@@ -43,6 +52,49 @@ func tokenFromResult(t *testing.T, raw string) string {
 		t.Fatal("preview returned no confirmation token")
 	}
 	return result.Token
+}
+
+func TestDescribeExposesEveryMutationContract(t *testing.T) {
+	tool := NewTool(&mutableAgentReader{agent: config.Agent{ID: "writer", Scope: config.AgentScopeRestricted}})
+	ctx := settingsContext(userAuthority(t, "u1"))
+	for _, resource := range []string{"agents", "library", "skills", "tool_overrides"} {
+		t.Run(resource, func(t *testing.T) {
+			result, err := tool.Execute(ctx, map[string]any{"action": "describe", "resource": resource})
+			if err != nil {
+				t.Fatalf("describe: %v", err)
+			}
+			var decoded struct {
+				Contracts map[string]struct {
+					Required    []string `json:"required"`
+					Constraints []string `json:"constraints"`
+				} `json:"operation_contracts"`
+			}
+			if err := json.Unmarshal([]byte(result), &decoded); err != nil {
+				t.Fatalf("decode describe: %v", err)
+			}
+			if len(decoded.Contracts) == 0 {
+				t.Fatal("describe returned no operation contracts")
+			}
+			for operation, contract := range decoded.Contracts {
+				if contract.Required == nil || contract.Constraints == nil || len(contract.Constraints) == 0 {
+					t.Fatalf("%s contract is incomplete: %#v", operation, contract)
+				}
+			}
+		})
+	}
+}
+
+func TestConfirmRechecksDeploymentScopeMatrix(t *testing.T) {
+	tool := NewTool(&mutableAgentReader{agent: config.Agent{ID: "writer", Scope: config.AgentScopeRestricted}})
+	ctx := settingsContext(userAuthority(t, "u1"))
+	tool.tokens["scope-token"] = pendingMutation{
+		userID: "u1", sessionID: currentSessionID(ctx), agentID: "stella",
+		resource: "skills", operation: "create", input: json.RawMessage(`{"scope":"system","name":"x","body":"x"}`),
+		expiresAt: time.Now().Add(time.Minute),
+	}
+	if _, err := tool.Execute(ctx, map[string]any{"action": "confirm", "token": "scope-token"}); !errors.Is(err, authz.ErrForbidden) {
+		t.Fatalf("confirm error = %v, want forbidden", err)
+	}
 }
 
 func TestMutationPreviewConfirmReauthorizesAndConsumesToken(t *testing.T) {
@@ -81,6 +133,52 @@ func (r *mutableAgentReader) Read(_ context.Context, _ authz.Authority, id strin
 		return config.Agent{}, errors.New("not found")
 	}
 	return r.agent, nil
+}
+
+func TestOrdinaryUserCannotWriteDeploymentScopesAcrossMutationResources(t *testing.T) {
+	tool := NewTool(&mutableAgentReader{agent: config.Agent{ID: "writer", Scope: config.AgentScopeRestricted}})
+	ctx := settingsContext(userAuthority(t, "u1"))
+	cases := []struct {
+		resource  string
+		operation string
+		input     map[string]any
+	}{
+		{"agents", "create", map[string]any{"name": "system", "scope": config.AgentScopeSystem}},
+		{"library", "create", map[string]any{"scope": "system", "file_name": "x.md", "content": "x"}},
+		{"skills", "create", map[string]any{"scope": "system", "name": "system", "body": "x"}},
+		{"tool_overrides", "set", map[string]any{"scope": "system", "tool_name": "memory", "enabled": false}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.resource, func(t *testing.T) {
+			_, err := tool.Execute(ctx, map[string]any{"action": "preview", "resource": tc.resource, "operation": tc.operation, "input": tc.input})
+			if !errors.Is(err, authz.ErrForbidden) {
+				t.Fatalf("preview error = %v, want forbidden", err)
+			}
+		})
+	}
+}
+
+func TestOrdinaryUserCannotWriteSystemAgentScope(t *testing.T) {
+	reader := &mutableAgentReader{agent: config.Agent{ID: "system-agent", Name: "System", Scope: config.AgentScopeSystem}}
+	mutation := &recordingAgentMutation{}
+	tool := NewTool(reader, WithAgentMutations(mutation))
+	ctx := settingsContext(userAuthority(t, "u1"))
+
+	if _, err := tool.Execute(ctx, map[string]any{"action": "preview", "resource": "agents", "operation": "create", "input": map[string]any{
+		"name": "Should fail", "scope": config.AgentScopeSystem,
+	}}); !errors.Is(err, authz.ErrForbidden) {
+		t.Fatalf("system create error = %v, want forbidden", err)
+	}
+	if _, err := tool.Execute(ctx, map[string]any{"action": "preview", "resource": "agents", "operation": "update", "input": map[string]any{
+		"id": "system-agent", "name": "Should fail",
+	}}); !errors.Is(err, authz.ErrForbidden) {
+		t.Fatalf("system update error = %v, want forbidden", err)
+	}
+	if _, err := tool.Execute(ctx, map[string]any{"action": "preview", "resource": "agents", "operation": "delete", "input": map[string]any{
+		"id": "system-agent",
+	}}); !errors.Is(err, authz.ErrForbidden) {
+		t.Fatalf("system delete error = %v, want forbidden", err)
+	}
 }
 
 func TestMutationConfirmRejectsStaleAgentWithoutWriting(t *testing.T) {

--- a/internal/settings/tool.go
+++ b/internal/settings/tool.go
@@ -137,13 +137,6 @@ func (t *Tool) Execute(ctx context.Context, args map[string]any) (string, error)
 		if err := rejectUnexpected(args, "action", "resource"); err != nil {
 			return "", err
 		}
-		resource, err := stringArg(args, "resource", true)
-		if err != nil {
-			return "", err
-		}
-		if resource != "agents" {
-			return "", fmt.Errorf("unsupported settings resource %q", resource)
-		}
 		return t.describeResource(ctx, args)
 	case "list", "get":
 		return t.readAgents(ctx, args, action)

--- a/internal/settings/tool.go
+++ b/internal/settings/tool.go
@@ -1,5 +1,5 @@
-// Package settings exposes the small, read-only settings surface owned by Stella.
-// Mutation protocols and deployment-wide settings stay out of this first slice.
+// Package settings exposes the Stella-owned settings protocol. It keeps model
+// mutations behind a short-lived preview/confirm token and domain PEPs.
 package settings
 
 import (
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/CherryHQ/stella/internal/agent"
 	"github.com/CherryHQ/stella/internal/authz"
@@ -45,12 +46,35 @@ type boundedAgentReader interface {
 	ReadProjection(context.Context, authz.Authority, string) (config.Agent, error)
 }
 
-type Tool struct {
-	agents agentReader
+type ToolOption func(*Tool)
+
+func WithAgentMutations(m AgentMutation) ToolOption { return func(t *Tool) { t.agentMutations = m } }
+func WithLibraryMutations(m LibraryMutation) ToolOption {
+	return func(t *Tool) { t.libraryMutations = m }
+}
+func WithSkillMutations(m SkillMutation) ToolOption { return func(t *Tool) { t.skillMutations = m } }
+func WithToolOverrideMutations(m ToolOverrideMutation) ToolOption {
+	return func(t *Tool) { t.toolOverrideMutations = m }
 }
 
-func NewTool(agents agentReader) *Tool {
-	return &Tool{agents: agents}
+// Tool is a deliberately small protocol facade. Mutation payloads are retained
+// only in-memory for one short-lived model-side preview/confirm handshake.
+type Tool struct {
+	agents                agentReader
+	agentMutations        AgentMutation
+	libraryMutations      LibraryMutation
+	skillMutations        SkillMutation
+	toolOverrideMutations ToolOverrideMutation
+	tokensMu              sync.Mutex
+	tokens                map[string]pendingMutation
+}
+
+func NewTool(agents agentReader, options ...ToolOption) *Tool {
+	t := &Tool{agents: agents, tokens: make(map[string]pendingMutation)}
+	for _, option := range options {
+		option(t)
+	}
+	return t
 }
 
 // Available is the registry gate. Execute repeats the same checks because
@@ -64,13 +88,16 @@ func Available(_ context.Context, params agent.RunnerParams) bool {
 func (t *Tool) Definition() tools.Definition {
 	return tools.Definition{
 		Name:        toolName,
-		Description: "Read-only settings catalog for Stella's direct one-to-one session. Use catalog first, then list or get supported resources. Configuration mutations are not available in this first slice.",
+		Description: "Settings catalog for Stella's direct one-to-one session. Read resources directly; mutations use the model-side preview then single-use confirm protocol. This is not human approval.",
 		InputSchema: tools.MustInputSchema(`{
   "type":"object",
   "additionalProperties":false,
   "properties":{
-    "action":{"type":"string","enum":["catalog","describe","list","get"]},
-    "resource":{"type":"string","enum":["agents"]},
+    "action":{"type":"string","enum":["catalog","describe","list","get","preview","confirm"]},
+    "resource":{"type":"string","enum":["agents","library","skills","tool_overrides"]},
+    "operation":{"type":"string","enum":["create","update","delete","set","clear"]},
+    "input":{"type":"object","description":"Mutation fields. Identity and owner fields are resolved from the current turn."},
+    "token":{"type":"string","description":"Single-use token returned by preview."},
     "id":{"type":"string"},
     "page_size":{"type":"integer","minimum":1,"maximum":100,"description":"Number of agents returned by list."},
     "page_token":{"type":"string","description":"Opaque list cursor; pass it back unchanged."}
@@ -89,13 +116,22 @@ func (t *Tool) Execute(ctx context.Context, args map[string]any) (string, error)
 		return "", err
 	}
 	switch action {
+	case "preview":
+		return t.previewMutation(ctx, args)
+	case "confirm":
+		return t.confirmMutation(ctx, args)
 	case "catalog":
 		if err := rejectUnexpected(args, "action"); err != nil {
 			return "", err
 		}
 		return tools.MarshalResult(map[string]any{
-			"resources": []map[string]any{{"name": "agents", "operations": []string{"list", "get"}}},
-			"mutations": "unsupported",
+			"resources": []map[string]any{
+				{"name": "agents", "operations": []string{"list", "get", "create", "update", "delete"}},
+				{"name": "library", "operations": []string{"create", "delete"}},
+				{"name": "skills", "operations": []string{"create", "update", "delete"}},
+				{"name": "tool_overrides", "operations": []string{"set", "clear"}},
+			},
+			"protocol": "Mutations require preview then confirm with a single-use token; this is a model-side protocol, not human approval.",
 		})
 	case "describe":
 		if err := rejectUnexpected(args, "action", "resource"); err != nil {
@@ -108,12 +144,7 @@ func (t *Tool) Execute(ctx context.Context, args map[string]any) (string, error)
 		if resource != "agents" {
 			return "", fmt.Errorf("unsupported settings resource %q", resource)
 		}
-		return tools.MarshalResult(map[string]any{
-			"resource":    "agents",
-			"operations":  []string{"list", "get"},
-			"read_fields": []string{"id", "name", "model", "system_prompt", "soul", "scope", "enabled"},
-			"write":       false,
-		})
+		return t.describeResource(ctx, args)
 	case "list", "get":
 		return t.readAgents(ctx, args, action)
 	default:

--- a/internal/store/dbstore.go
+++ b/internal/store/dbstore.go
@@ -406,35 +406,6 @@ func updateAgentParams(a config.Agent) (sqlc.UpdateAgentParams, error) {
 	}, nil
 }
 
-// DeleteAgentIfUnchanged performs the delete after locking and comparing the
-// exact Agent row used during preview. A changed row is never deleted.
-func (s *DBStore) DeleteAgentIfUnchanged(ctx context.Context, expected config.Agent) error {
-	tx, err := s.pool.Begin(ctx)
-	if err != nil {
-		return fmt.Errorf("begin conditional Agent delete: %w", err)
-	}
-	defer tx.Rollback(ctx) //nolint:errcheck // successful commit makes rollback inert
-	qtx := s.q.WithTx(tx)
-	row, err := qtx.GetAgentForUpdate(ctx, expected.ID)
-	if err != nil {
-		return fmt.Errorf("lock Agent %q for conditional delete: %w", expected.ID, err)
-	}
-	current, err := agentFromDB(row)
-	if err != nil {
-		return err
-	}
-	if !reflect.DeepEqual(current, expected) {
-		return config.ErrAgentChanged
-	}
-	if err := qtx.DeleteAgent(ctx, expected.ID); err != nil {
-		return fmt.Errorf("conditional delete agent %q: %w", expected.ID, err)
-	}
-	if err := tx.Commit(ctx); err != nil {
-		return fmt.Errorf("commit conditional Agent delete %q: %w", expected.ID, err)
-	}
-	return nil
-}
-
 func (s *DBStore) DeleteAgent(ctx context.Context, id string) error {
 	err := s.q.DeleteAgent(ctx, id)
 	var pgErr *pgconn.PgError

--- a/internal/store/dbstore.go
+++ b/internal/store/dbstore.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"reflect"
 	"time"
 
 	"github.com/google/uuid"
@@ -340,35 +341,96 @@ func createAgentParams(a config.Agent) (sqlc.CreateAgentParams, error) {
 }
 
 func (s *DBStore) UpdateAgent(ctx context.Context, a config.Agent) error {
+	params, err := updateAgentParams(a)
+	if err != nil {
+		return err
+	}
+	if err := s.q.UpdateAgent(ctx, params); err != nil {
+		return fmt.Errorf("update agent %q: %w", a.ID, err)
+	}
+	return nil
+}
+
+// UpdateAgentIfUnchanged performs the settings facade's compare-and-swap under
+// one row lock. The caller's read is only a proposal; the locked row is compared
+// again immediately before the write, closing the preview/confirm TOCTOU window.
+func (s *DBStore) UpdateAgentIfUnchanged(ctx context.Context, expected, next config.Agent) error {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin conditional Agent update: %w", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck // successful commit makes rollback inert
+	qtx := s.q.WithTx(tx)
+	row, err := qtx.GetAgentForUpdate(ctx, expected.ID)
+	if err != nil {
+		return fmt.Errorf("lock Agent %q for conditional update: %w", expected.ID, err)
+	}
+	current, err := agentFromDB(row)
+	if err != nil {
+		return err
+	}
+	if !reflect.DeepEqual(current, expected) {
+		return config.ErrAgentChanged
+	}
+	params, err := updateAgentParams(next)
+	if err != nil {
+		return err
+	}
+	if err := qtx.UpdateAgent(ctx, params); err != nil {
+		return fmt.Errorf("conditional update agent %q: %w", next.ID, err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit conditional Agent update %q: %w", next.ID, err)
+	}
+	return nil
+}
+
+func updateAgentParams(a config.Agent) (sqlc.UpdateAgentParams, error) {
 	scope := a.Scope
 	if scope == "" {
 		scope = config.AgentScopeSystem
 	}
 	if err := a.Sandbox.Validate(); err != nil {
-		return fmt.Errorf("update agent %q: %w", a.ID, err)
+		return sqlc.UpdateAgentParams{}, fmt.Errorf("update agent %q: %w", a.ID, err)
 	}
 	sandboxJSON, err := marshalSandboxConfig(a.Sandbox)
 	if err != nil {
-		return fmt.Errorf("update agent %q: %w", a.ID, err)
+		return sqlc.UpdateAgentParams{}, fmt.Errorf("update agent %q: %w", a.ID, err)
 	}
-	err = s.q.UpdateAgent(ctx, sqlc.UpdateAgentParams{
-		ID:                  a.ID,
-		Name:                a.Name,
-		Model:               a.Model,
-		ModelThinking:       a.ModelThinking,
-		ModelStrong:         a.ModelStrong,
-		ModelStrongThinking: a.ModelStrongThinking,
-		ModelFast:           a.ModelFast,
-		ModelFastThinking:   a.ModelFastThinking,
-		SystemPrompt:        a.SystemPrompt,
-		Soul:                a.Soul,
-		Workspace:           a.Workspace,
-		Sandbox:             sandboxJSON,
-		Scope:               scope,
-		Enabled:             a.Enabled,
-	})
+	return sqlc.UpdateAgentParams{
+		ID: a.ID, Name: a.Name, Model: a.Model, ModelThinking: a.ModelThinking,
+		ModelStrong: a.ModelStrong, ModelStrongThinking: a.ModelStrongThinking,
+		ModelFast: a.ModelFast, ModelFastThinking: a.ModelFastThinking,
+		SystemPrompt: a.SystemPrompt, Soul: a.Soul, Workspace: a.Workspace,
+		Sandbox: sandboxJSON, Scope: scope, Enabled: a.Enabled,
+	}, nil
+}
+
+// DeleteAgentIfUnchanged performs the delete after locking and comparing the
+// exact Agent row used during preview. A changed row is never deleted.
+func (s *DBStore) DeleteAgentIfUnchanged(ctx context.Context, expected config.Agent) error {
+	tx, err := s.pool.Begin(ctx)
 	if err != nil {
-		return fmt.Errorf("update agent %q: %w", a.ID, err)
+		return fmt.Errorf("begin conditional Agent delete: %w", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck // successful commit makes rollback inert
+	qtx := s.q.WithTx(tx)
+	row, err := qtx.GetAgentForUpdate(ctx, expected.ID)
+	if err != nil {
+		return fmt.Errorf("lock Agent %q for conditional delete: %w", expected.ID, err)
+	}
+	current, err := agentFromDB(row)
+	if err != nil {
+		return err
+	}
+	if !reflect.DeepEqual(current, expected) {
+		return config.ErrAgentChanged
+	}
+	if err := qtx.DeleteAgent(ctx, expected.ID); err != nil {
+		return fmt.Errorf("conditional delete agent %q: %w", expected.ID, err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit conditional Agent delete %q: %w", expected.ID, err)
 	}
 	return nil
 }

--- a/internal/store/dbstore_test.go
+++ b/internal/store/dbstore_test.go
@@ -453,16 +453,6 @@ func TestAgentConditionalMutationRejectsStaleSnapshot(t *testing.T) {
 	if err := s.UpdateAgentIfUnchanged(ctx, expected, next); !errors.Is(err, config.ErrAgentChanged) {
 		t.Fatalf("stale UpdateAgentIfUnchanged = %v, want ErrAgentChanged", err)
 	}
-	current, err := s.GetAgent(ctx, "conditional")
-	if err != nil {
-		t.Fatalf("GetAgent after update: %v", err)
-	}
-	if err := s.DeleteAgentIfUnchanged(ctx, expected); !errors.Is(err, config.ErrAgentChanged) {
-		t.Fatalf("stale DeleteAgentIfUnchanged = %v, want ErrAgentChanged", err)
-	}
-	if err := s.DeleteAgentIfUnchanged(ctx, current); err != nil {
-		t.Fatalf("DeleteAgentIfUnchanged: %v", err)
-	}
 }
 
 func TestAgentCRUD(t *testing.T) {

--- a/internal/store/dbstore_test.go
+++ b/internal/store/dbstore_test.go
@@ -435,6 +435,36 @@ func TestProviderCredentialsIgnoreEnvironment(t *testing.T) {
 	}
 }
 
+func TestAgentConditionalMutationRejectsStaleSnapshot(t *testing.T) {
+	s := setupDBStore(t)
+	ctx := testCtx()
+	if err := s.CreateAgent(ctx, config.Agent{ID: "conditional", Name: "Conditional", Scope: config.AgentScopeRestricted, Enabled: true}); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	expected, err := s.GetAgent(ctx, "conditional")
+	if err != nil {
+		t.Fatalf("GetAgent: %v", err)
+	}
+	next := expected
+	next.Name = "Updated"
+	if err := s.UpdateAgentIfUnchanged(ctx, expected, next); err != nil {
+		t.Fatalf("UpdateAgentIfUnchanged: %v", err)
+	}
+	if err := s.UpdateAgentIfUnchanged(ctx, expected, next); !errors.Is(err, config.ErrAgentChanged) {
+		t.Fatalf("stale UpdateAgentIfUnchanged = %v, want ErrAgentChanged", err)
+	}
+	current, err := s.GetAgent(ctx, "conditional")
+	if err != nil {
+		t.Fatalf("GetAgent after update: %v", err)
+	}
+	if err := s.DeleteAgentIfUnchanged(ctx, expected); !errors.Is(err, config.ErrAgentChanged) {
+		t.Fatalf("stale DeleteAgentIfUnchanged = %v, want ErrAgentChanged", err)
+	}
+	if err := s.DeleteAgentIfUnchanged(ctx, current); err != nil {
+		t.Fatalf("DeleteAgentIfUnchanged: %v", err)
+	}
+}
+
 func TestAgentCRUD(t *testing.T) {
 	s := setupDBStore(t)
 	ctx := testCtx()

--- a/pkg/db/sqlc/tool_override.sql.go
+++ b/pkg/db/sqlc/tool_override.sql.go
@@ -11,19 +11,6 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-const lockToolOverrideKey = `-- name: LockToolOverrideKey :exec
-SELECT pg_advisory_xact_lock(hashtextextended($1, 0))
-`
-
-type LockToolOverrideKeyParams struct {
-	LockKey string `json:"lock_key"`
-}
-
-func (q *Queries) LockToolOverrideKey(ctx context.Context, arg LockToolOverrideKeyParams) error {
-	_, err := q.db.Exec(ctx, lockToolOverrideKey, arg.LockKey)
-	return err
-}
-
 const deleteToolOverride = `-- name: DeleteToolOverride :exec
 DELETE FROM tool_override
 WHERE tool_name = $1
@@ -96,7 +83,14 @@ LIMIT 1
 FOR UPDATE
 `
 
-func (q *Queries) GetToolOverrideForUpdate(ctx context.Context, arg GetToolOverrideParams) (ToolOverride, error) {
+type GetToolOverrideForUpdateParams struct {
+	ToolName string      `json:"tool_name"`
+	Scope    string      `json:"scope"`
+	UserID   pgtype.Text `json:"user_id"`
+	AgentID  pgtype.Text `json:"agent_id"`
+}
+
+func (q *Queries) GetToolOverrideForUpdate(ctx context.Context, arg GetToolOverrideForUpdateParams) (ToolOverride, error) {
 	row := q.db.QueryRow(ctx, getToolOverrideForUpdate,
 		arg.ToolName,
 		arg.Scope,
@@ -164,6 +158,15 @@ func (q *Queries) ListToolOverridesForAgentContext(ctx context.Context, arg List
 		return nil, err
 	}
 	return items, nil
+}
+
+const lockToolOverrideKey = `-- name: LockToolOverrideKey :exec
+SELECT pg_advisory_xact_lock(hashtextextended($1, 0))
+`
+
+func (q *Queries) LockToolOverrideKey(ctx context.Context, lockKey string) error {
+	_, err := q.db.Exec(ctx, lockToolOverrideKey, lockKey)
+	return err
 }
 
 const upsertToolOverride = `-- name: UpsertToolOverride :one

--- a/pkg/db/sqlc/tool_override.sql.go
+++ b/pkg/db/sqlc/tool_override.sql.go
@@ -11,6 +11,19 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const lockToolOverrideKey = `-- name: LockToolOverrideKey :exec
+SELECT pg_advisory_xact_lock(hashtextextended($1, 0))
+`
+
+type LockToolOverrideKeyParams struct {
+	LockKey string `json:"lock_key"`
+}
+
+func (q *Queries) LockToolOverrideKey(ctx context.Context, arg LockToolOverrideKeyParams) error {
+	_, err := q.db.Exec(ctx, lockToolOverrideKey, arg.LockKey)
+	return err
+}
+
 const deleteToolOverride = `-- name: DeleteToolOverride :exec
 DELETE FROM tool_override
 WHERE tool_name = $1
@@ -54,6 +67,37 @@ type GetToolOverrideParams struct {
 
 func (q *Queries) GetToolOverride(ctx context.Context, arg GetToolOverrideParams) (ToolOverride, error) {
 	row := q.db.QueryRow(ctx, getToolOverride,
+		arg.ToolName,
+		arg.Scope,
+		arg.UserID,
+		arg.AgentID,
+	)
+	var i ToolOverride
+	err := row.Scan(
+		&i.ID,
+		&i.ToolName,
+		&i.Scope,
+		&i.UserID,
+		&i.AgentID,
+		&i.Enabled,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getToolOverrideForUpdate = `-- name: GetToolOverrideForUpdate :one
+SELECT id, tool_name, scope, user_id, agent_id, enabled, created_at, updated_at FROM tool_override
+WHERE tool_name = $1
+  AND scope = $2
+  AND coalesce(user_id::text, '') = coalesce($3::text, '')
+  AND coalesce(agent_id, '') = coalesce($4, '')
+LIMIT 1
+FOR UPDATE
+`
+
+func (q *Queries) GetToolOverrideForUpdate(ctx context.Context, arg GetToolOverrideParams) (ToolOverride, error) {
+	row := q.db.QueryRow(ctx, getToolOverrideForUpdate,
 		arg.ToolName,
 		arg.Scope,
 		arg.UserID,

--- a/pkg/db/sqlc/tool_override.sql.go
+++ b/pkg/db/sqlc/tool_override.sql.go
@@ -36,6 +36,43 @@ func (q *Queries) DeleteToolOverride(ctx context.Context, arg DeleteToolOverride
 	return err
 }
 
+const getToolOverride = `-- name: GetToolOverride :one
+SELECT id, tool_name, scope, user_id, agent_id, enabled, created_at, updated_at FROM tool_override
+WHERE tool_name = $1
+  AND scope = $2
+  AND coalesce(user_id::text, '') = coalesce($3::text, '')
+  AND coalesce(agent_id, '') = coalesce($4, '')
+LIMIT 1
+`
+
+type GetToolOverrideParams struct {
+	ToolName string      `json:"tool_name"`
+	Scope    string      `json:"scope"`
+	UserID   pgtype.Text `json:"user_id"`
+	AgentID  pgtype.Text `json:"agent_id"`
+}
+
+func (q *Queries) GetToolOverride(ctx context.Context, arg GetToolOverrideParams) (ToolOverride, error) {
+	row := q.db.QueryRow(ctx, getToolOverride,
+		arg.ToolName,
+		arg.Scope,
+		arg.UserID,
+		arg.AgentID,
+	)
+	var i ToolOverride
+	err := row.Scan(
+		&i.ID,
+		&i.ToolName,
+		&i.Scope,
+		&i.UserID,
+		&i.AgentID,
+		&i.Enabled,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const listToolOverridesForAgentContext = `-- name: ListToolOverridesForAgentContext :many
 SELECT id, tool_name, scope, user_id, agent_id, enabled, created_at, updated_at FROM tool_override
 WHERE scope = 'system'

--- a/web/content/docs/start-here/configuration.md
+++ b/web/content/docs/start-here/configuration.md
@@ -104,9 +104,9 @@ All data lives under `~/.stella` (configurable via `STELLA_HOME`):
 
 ## Stella settings tool
 
-Stella exposes a read-only `stella_settings` tool only in its direct one-to-one sessions. It provides a catalog and authorized list/get operations for Agent metadata. Ordinary Agents and group/guest sessions do not receive this tool. Large Agent text fields are bounded in model results, and `list` returns `next_page_token` when another page is available.
+Stella exposes `stella_settings` only in direct one-to-one sessions. It provides authorized Agent inspection plus user-owned mutations for Agents, Library files, Skills, and managed tool overrides. Ordinary Agents and group/guest sessions do not receive this tool.
 
-Settings mutations remain a Web UI operation in this phase. The tool deliberately does not expose secrets, opaque sandbox configuration, provider credentials, or deployment-wide settings.
+Mutations use a model-side `preview` then single-use `confirm` token. This is a protocol for the model, not human approval. Confirm rechecks the current domain authorization and rejects stale resource digests. Core and unmanaged tools, foreign owners, and deployment-wide settings outside the supported resource matrix remain unavailable. The tool deliberately does not expose secrets, opaque sandbox configuration, provider credentials, or raw Library bytes in results.
 
 ## Environment Variables
 

--- a/web/content/docs/start-here/configuration.zh.md
+++ b/web/content/docs/start-here/configuration.zh.md
@@ -95,9 +95,9 @@ Runner 控制代理如何处理消息。你可以在Web UI的 **设置** 页面�
 
 ## Stella 设置工具
 
-Stella 只在自己的直接一对一会话中暴露只读的 `stella_settings` 工具。它提供设置目录，以及经过授权的 Agent 元数据 list/get。普通 Agent 以及群组/访客会话都不会收到这个工具。模型结果中的大型 Agent 文本字段会被限制长度，`list` 在还有下一页时返回 `next_page_token`。
+Stella 只在直接一对一会话中暴露 `stella_settings`。除 Agent 元数据查看外，它支持 Agents、Library 文件、Skills 和受管理工具覆盖的用户拥有资源修改。普通 Agent 以及群组/访客会话都不会收到这个工具。
 
-本阶段的设置修改仍通过 Web UI 完成。该工具刻意不暴露 secret、不返回不透明的 sandbox 配置、提供商凭据或部署级设置。
+修改使用模型侧 `preview` 再 `confirm` 的一次性 token 协议，这不是人工审批。confirm 会重新检查当前领域授权，并拒绝过期的资源 digest。核心工具、未受管理工具、他人资源，以及支持矩阵之外的部署级设置仍不可用。工具刻意不暴露 secret、不在结果中返回不透明的 sandbox 配置、提供商凭据或 Library 原始字节。
 
 ## 环境变量
 


### PR DESCRIPTION
## What

Add the Phase 2 `stella_settings` mutation surface for Agents, Library files, managed Skills, and tool overrides on top of PR #1147.

## Why

Stella's direct settings tool could inspect Agent metadata but had no safe model-facing write path. Mutations now have a bounded preview/confirm protocol while preserving each domain's existing owner and policy enforcement point.

## How

- Add a short-lived, session/user/Agent-bound, single-use in-memory confirmation token. `confirm` consumes the token before applying and never trusts preview authorization.
- Reauthorize Agents through `agent/access.Management`, Library operations through `library.Service`, Skills through `skillaccess` plus the managed POSIX store, and tool overrides through owner-aware scope checks.
- Bind update/delete operations to resource digests. Library delete gains a raw-snapshot digest check; tool overrides get exact-row reads for stale-state detection.
- Reject foreign owners, invalid scopes, core tools, and unmanaged tools. Successful override writes invalidate the affected user, user+Agent, Agent, or all runners.
- Wire the facade after the existing composition dependencies are ready, without introducing a new identity model or deployment-wide settings policy.

Preview/confirm is explicitly a model-side two-step protocol. It is not human approval.

## Test

- `mise run format` ✅
- `mise run build` ✅
- `mise run test` ✅, all Go and web tests passed
- Focused: `go test ./internal/settings ./internal/agent/access ./internal/agent ./internal/library ./internal/skills` ✅
- `go vet ./internal/settings ./internal/library ./internal/agent ./cmd/stellad` ✅
- `git diff --check` ✅

Harbor agent-behavior eval: not run. This phase changes a settings tool and authorization paths not covered by the existing Terminal-Bench task set; focused domain and protocol tests are included instead.

## Refs

Refs #1147

## Checklist

- [x] The PR links a GitHub issue, or states why the fix is small enough not to need one.
- [x] I added or updated focused tests for changed non-trivial behavior.
- [x] I updated relevant English and Chinese documentation.
- [x] I ran `mise run format && mise run build && mise run test`.
- [x] Agent-behavior eval applicability is documented above.
- [x] Binary/document surfaces are not changed; existing full test coverage passed.
- [x] No earlier measurement is invalidated.
