### PR TITLE
MBP-16: unify Library routing and profile UI

### DIFF
--- a/web/src/features/agents/ProfilePage.tsx
+++ b/web/src/features/agents/ProfilePage.tsx
@@ -35,6 +35,7 @@ import { ProfileSection } from "@/features/memories/ProfileSection";
 import { KnowledgeSection } from "@/features/memories/KnowledgeSection";
 import { ConstraintsSection } from "@/features/memories/ConstraintsSection";
 import { ChangelogSection } from "@/features/memories/ChangelogSection";
+import { AgentLibraryTab } from "@/features/library/LibraryFilesPage";
 
 /**
  * Skills keep their own full-page management surface (deep-linked from the
@@ -80,6 +81,7 @@ export function ProfilePage() {
     "overview",
     "memory",
     "skills",
+    ...(!projectId ? (["library"] as const) : []),
     ...(projectId ? [] : (["tools", "channels"] as const)),
     ...(canConfigure ? (["config"] as const) : []),
   ];
@@ -116,8 +118,11 @@ export function ProfilePage() {
   const selectTab = useCallback(
     (next: ProfileTab) => {
       // Overview is the canonical bare URL, so it clears the param instead of
-      // writing "?tab=overview".
-      updateSearch({ tab: next === "overview" ? undefined : next });
+      // writing "?tab=overview". Library's search is local to that tab.
+      updateSearch({
+        tab: next === "overview" ? undefined : next,
+        q: next === "library" ? search.q : undefined,
+      });
     },
     [updateSearch],
   );
@@ -135,6 +140,7 @@ export function ProfilePage() {
     overview: t("profile.overview"),
     memory: t("profile.memory"),
     skills: t("profile.skills"),
+    library: t("library.title"),
     tools: t("profile.tools"),
     channels: t("profile.channels"),
     config: t("profile.configuration"),
@@ -174,17 +180,6 @@ export function ProfilePage() {
                   {TAB_LABEL[value]}
                 </TabsTab>
               ))}
-            {!projectId && (
-              // Library is a sibling route, not a profile panel. Keep link
-              // semantics while presenting it alongside the profile tabs.
-              <Link
-                to="/agents/$agentId/library"
-                params={{ agentId }}
-                className="relative flex h-9 shrink-0 grow items-center justify-center whitespace-nowrap rounded-md border border-transparent px-[calc(--spacing(2.5)-1px)] text-base font-medium outline-none transition-[color,background-color,box-shadow] hover:bg-accent hover:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring sm:h-8 sm:text-sm"
-              >
-                {t("library.title")}
-              </Link>
-            )}
             {canConfigure && <TabsTab value="config">{TAB_LABEL.config}</TabsTab>}
           </TabsList>
 
@@ -249,6 +244,16 @@ export function ProfilePage() {
           <TabsPanel value="skills" className="pt-4">
             <ProfileSkillsTab agentId={agentId} projectId={projectId} />
           </TabsPanel>
+
+          {!projectId && (
+            <TabsPanel value="library" className="pt-4">
+              <AgentLibraryTab
+                agentId={agentId}
+                query={search.q ?? ""}
+                onQueryChange={(q) => updateSearch({ q: q || undefined })}
+              />
+            </TabsPanel>
+          )}
 
           {!projectId && (
             <TabsPanel value="tools" className="pt-4">
@@ -385,13 +390,12 @@ function OverviewTab({
           />
         )}
         {!projectId && (
-          <Link to="/agents/$agentId/library" params={{ agentId }} className={SUMMARY_CARD_CLS}>
-            <SummaryCardBody
-              icon={<Library size={16} />}
-              title={t("library.title")}
-              detail={t("library.description.userAgent", { agent: agentName })}
-            />
-          </Link>
+          <SummaryCard
+            icon={<Library size={16} />}
+            title={t("library.title")}
+            detail={t("library.description.userAgent", { agent: agentName })}
+            onClick={() => onSelectTab("library")}
+          />
         )}
         {!projectId && (
           <Link to="/agents/$agentId/goals" params={{ agentId }} className={SUMMARY_CARD_CLS}>

--- a/web/src/features/library/LibraryFilesPage.tsx
+++ b/web/src/features/library/LibraryFilesPage.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState, type ReactNode } from "react";
 import { targetValue } from "@/lib/utils";
 import { useInfiniteQuery, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
+import { useNavigate, useSearch } from "@tanstack/react-router";
 import { FileText, Library, Search, Upload } from "lucide-react";
 import { createLibraryFile, deleteLibraryFile } from "@/lib/api-client/sdk.gen";
 import type { LibraryFile, LibraryFileScope, LibraryFileStatus } from "@/lib/api-client/types.gen";
@@ -49,6 +49,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { SettingsList, SettingsRow, SettingsSection } from "@/features/settings/SettingsCardGrid";
 import { SettingsEmptyState } from "@/features/settings/SettingsEmptyState";
 import { SettingsPageHeader } from "@/features/settings/SettingsPageHeader";
+import { ProfilePanelSection, ProfileSectionMessage } from "@/features/agents/ProfilePanelSection";
 
 type UploadState = "queued" | "uploading" | "success" | "error";
 
@@ -66,6 +67,7 @@ interface LibraryFilesViewProps {
   title: string;
   description: string;
   controls?: ReactNode;
+  embedded?: boolean;
   onQueryChange: (query: string) => void;
 }
 
@@ -82,6 +84,7 @@ function LibraryFilesView({
   title,
   description,
   controls,
+  embedded = false,
   onQueryChange,
 }: LibraryFilesViewProps) {
   const { t } = useI18n();
@@ -163,12 +166,60 @@ function LibraryFilesView({
     }
   }
 
-  const uploadButton = (
+  const uploadButton = embedded ? (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon-sm"
+      disabled={!targetReady}
+      aria-label={t("library.upload.action")}
+      title={t("library.upload.action")}
+      onClick={() => fileInput.current?.click()}
+    >
+      <Upload aria-hidden="true" />
+    </Button>
+  ) : (
     <Button type="button" disabled={!targetReady} onClick={() => fileInput.current?.click()}>
       <Upload aria-hidden="true" />
       {t("library.upload.action")}
     </Button>
   );
+  const fileRows = files.map((file) => (
+    <SettingsRow
+      key={file.id}
+      icon={<FileText aria-hidden="true" />}
+      title={file.file_name}
+      subtitle={
+        file.status === "failed" && file.error_message
+          ? file.error_message
+          : `${formatBytes(file.size_bytes)} · ${new Date(file.created_at).toLocaleString()}`
+      }
+      status={
+        <Badge size="sm" variant={statusVariant[file.status]}>
+          {t(`library.status.${file.status}`)}
+        </Badge>
+      }
+      menu={[
+        {
+          label: t("common.delete"),
+          destructive: true,
+          onClick: () => setPendingDelete(file),
+        },
+      ]}
+    />
+  ));
+  const loadMore = result.hasNextPage ? (
+    <div className="flex justify-center pt-3">
+      <Button
+        type="button"
+        variant="outline"
+        loading={result.isFetchingNextPage}
+        onClick={() => void result.fetchNextPage()}
+      >
+        {t("common.loadMore")}
+      </Button>
+    </div>
+  ) : null;
 
   return (
     <>
@@ -185,9 +236,16 @@ function LibraryFilesView({
           if (selected.length > 0) void uploadSelected(selected);
         }}
       />
-      <div className="h-full min-h-0 overflow-y-auto">
-        <div className="mx-auto max-w-5xl space-y-8 p-6">
-          <SettingsPageHeader title={title} description={description} action={uploadButton} />
+      <div className={embedded ? "flex flex-col gap-6" : "h-full min-h-0 overflow-y-auto"}>
+        <div className={embedded ? "flex flex-col gap-6" : "mx-auto max-w-5xl space-y-8 p-6"}>
+          {embedded ? (
+            <div className="flex items-start justify-between gap-2">
+              <p className="min-w-0 text-sm text-muted-foreground">{description}</p>
+              {uploadButton}
+            </div>
+          ) : (
+            <SettingsPageHeader title={title} description={description} action={uploadButton} />
+          )}
           {controls}
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <InputGroup className="w-full sm:max-w-md">
@@ -217,15 +275,28 @@ function LibraryFilesView({
           </div>
 
           {!targetReady ? (
-            <SettingsEmptyState
-              icon={<Library aria-hidden="true" />}
-              message={t("library.agent.required")}
-              description={t("library.agent.requiredDesc")}
-            />
+            embedded ? (
+              <ProfileSectionMessage>{t("library.agent.required")}</ProfileSectionMessage>
+            ) : (
+              <SettingsEmptyState
+                icon={<Library aria-hidden="true" />}
+                message={t("library.agent.required")}
+                description={t("library.agent.requiredDesc")}
+              />
+            )
           ) : result.isPending ? (
-            <div className="flex justify-center py-12">
-              <Spinner />
-            </div>
+            embedded ? (
+              <ProfileSectionMessage>
+                <span className="inline-flex items-center gap-2">
+                  <Spinner />
+                  {t("common.loading")}
+                </span>
+              </ProfileSectionMessage>
+            ) : (
+              <div className="flex justify-center py-12">
+                <Spinner />
+              </div>
+            )
           ) : result.isError ? (
             <SettingsEmptyState
               icon={<Library aria-hidden="true" />}
@@ -238,52 +309,27 @@ function LibraryFilesView({
               }
             />
           ) : files.length === 0 ? (
-            <SettingsEmptyState
-              icon={<Library aria-hidden="true" />}
-              message={query ? t("library.empty.search") : t("library.empty.title")}
-              description={query ? t("library.empty.searchDesc") : t("library.empty.description")}
-              action={query ? undefined : uploadButton}
-            />
+            embedded ? (
+              <ProfileSectionMessage>
+                {query ? t("library.empty.search") : t("library.empty.title")}
+              </ProfileSectionMessage>
+            ) : (
+              <SettingsEmptyState
+                icon={<Library aria-hidden="true" />}
+                message={query ? t("library.empty.search") : t("library.empty.title")}
+                description={query ? t("library.empty.searchDesc") : t("library.empty.description")}
+                action={query ? undefined : uploadButton}
+              />
+            )
+          ) : embedded ? (
+            <ProfilePanelSection title={t("library.files")} count={files.length}>
+              <SettingsList>{fileRows}</SettingsList>
+              {loadMore}
+            </ProfilePanelSection>
           ) : (
             <SettingsSection title={t("library.files")} count={files.length}>
-              <SettingsList>
-                {files.map((file) => (
-                  <SettingsRow
-                    key={file.id}
-                    icon={<FileText aria-hidden="true" />}
-                    title={file.file_name}
-                    subtitle={
-                      file.status === "failed" && file.error_message
-                        ? file.error_message
-                        : `${formatBytes(file.size_bytes)} · ${new Date(file.created_at).toLocaleString()}`
-                    }
-                    status={
-                      <Badge size="sm" variant={statusVariant[file.status]}>
-                        {t(`library.status.${file.status}`)}
-                      </Badge>
-                    }
-                    menu={[
-                      {
-                        label: t("common.delete"),
-                        destructive: true,
-                        onClick: () => setPendingDelete(file),
-                      },
-                    ]}
-                  />
-                ))}
-              </SettingsList>
-              {result.hasNextPage ? (
-                <div className="flex justify-center pt-3">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    loading={result.isFetchingNextPage}
-                    onClick={() => void result.fetchNextPage()}
-                  >
-                    {t("common.loadMore")}
-                  </Button>
-                </div>
-              ) : null}
+              <SettingsList>{fileRows}</SettingsList>
+              {loadMore}
             </SettingsSection>
           )}
         </div>
@@ -507,34 +553,28 @@ export function GlobalLibraryPage() {
   return <ScopedSettingsLibraryPage scopeBand="system" />;
 }
 
-interface AgentLibrarySearch {
-  q?: string;
-}
-
-export function AgentLibraryPage() {
+export function AgentLibraryTab({
+  agentId,
+  query,
+  onQueryChange,
+}: {
+  agentId: string;
+  query: string;
+  onQueryChange: (query: string) => void;
+}) {
   const { t } = useI18n();
-  const navigate = useNavigate();
-  const { agentId } = useParams({ from: "/_app/agents/$agentId" });
-  // SAFETY: this route's search is the validated agent-library schema.
-  const search = useSearch({ strict: false }) as AgentLibrarySearch;
   const { data: agents = [] } = useQuery(agentsQueryOptions);
   const agentName = agents.find((agent) => agent.id === agentId)?.name ?? agentId;
-  const query = search.q ?? "";
+
   return (
     <LibraryFilesView
+      embedded
       scope="user_agent"
       agentID={agentId}
       query={query}
       title={t("library.title")}
       description={t("library.description.userAgent", { agent: agentName })}
-      onQueryChange={(next) =>
-        void navigate({
-          to: "/agents/$agentId/library",
-          params: { agentId },
-          search: next ? { q: next } : {},
-          replace: true,
-        })
-      }
+      onQueryChange={onQueryChange}
     />
   );
 }

--- a/web/src/lib/route-search.ts
+++ b/web/src/lib/route-search.ts
@@ -1,4 +1,6 @@
 export interface MemorySearch {
+  /** Search term used by the agent profile's Library tab. */
+  q?: string;
   knowledge?: "removed";
   /**
    * Selected tab of the agent/project profile page. Absent means "overview" —
@@ -8,7 +10,14 @@ export interface MemorySearch {
   tab?: ProfileTab;
 }
 
-export type ProfileTab = "overview" | "memory" | "skills" | "tools" | "channels" | "config";
+export type ProfileTab =
+  | "overview"
+  | "memory"
+  | "skills"
+  | "library"
+  | "tools"
+  | "channels"
+  | "config";
 
 import type { JsonObject, JsonValue } from "./types";
 
@@ -27,6 +36,7 @@ const PROFILE_TABS = new Set<string>([
   "overview",
   "memory",
   "skills",
+  "library",
   "tools",
   "channels",
   "config",
@@ -52,6 +62,7 @@ export function validateThreadsSearch(search: RouteSearchInput): ThreadsSearch {
 
 export function validateMemorySearch(search: RouteSearchInput): MemorySearch {
   const out: MemorySearch = {};
+  if (isString(search.q) && search.q) out.q = search.q.slice(0, 200);
   if (search.knowledge === "removed") out.knowledge = "removed";
   // SAFETY: tab is validated by PROFILE_TABS before this cast.
   if (PROFILE_TABS.has(search.tab as string)) {

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -499,11 +499,7 @@ const AppAgentsAgentIdLibraryIndexRoute =
     id: '/library/',
     path: '/library/',
     getParentRoute: () => AppAgentsAgentIdRoute,
-  } as any).lazy(() =>
-    import('./routes/_app/agents.$agentId/library/index.lazy').then(
-      (d) => d.Route,
-    ),
-  )
+  } as any)
 const AppAgentsAgentIdGoalsIndexRoute =
   AppAgentsAgentIdGoalsIndexRouteImport.update({
     id: '/goals/',

--- a/web/src/routes/_app/agents.$agentId/library/index.lazy.tsx
+++ b/web/src/routes/_app/agents.$agentId/library/index.lazy.tsx
@@ -1,6 +1,0 @@
-import { createLazyFileRoute } from "@tanstack/react-router";
-import { AgentLibraryPage } from "@/features/library/LibraryFilesPage";
-
-export const Route = createLazyFileRoute("/_app/agents/$agentId/library/")({
-  component: AgentLibraryPage,
-});

--- a/web/src/routes/_app/agents.$agentId/library/index.tsx
+++ b/web/src/routes/_app/agents.$agentId/library/index.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 import { isString, type RouteSearchInput } from "@/lib/route-search";
 
 export interface AgentLibrarySearch {
@@ -9,4 +9,15 @@ export const Route = createFileRoute("/_app/agents/$agentId/library/")({
   validateSearch: (search: RouteSearchInput): AgentLibrarySearch => ({
     q: isString(search.q) && search.q ? search.q.slice(0, 200) : undefined,
   }),
+  beforeLoad: ({ params: { agentId }, search }) => {
+    throw redirect({
+      to: "/agents/$agentId/profile",
+      params: { agentId },
+      search: {
+        tab: "library",
+        ...(search.q ? { q: search.q } : undefined),
+      },
+      replace: true,
+    });
+  },
 });


### PR DESCRIPTION
## What

Move the agent Library surface into the agent profile as a real profile tab and keep the existing legacy Library URL working through a redirect.

## Why

Library was rendered as a standalone settings-style page even though its entry point sat beside the agent profile tabs. That made the route lose the profile context and gave Library a different navigation and visual structure from the other agent facets.

## How

- Add `library` to the validated profile tab search state.
- Render agent Library files inside the profile tab using the profile section layout, while retaining the full settings layout for personal and admin Library surfaces.
- Redirect `/agents/:agentId/library` bookmarks, including their search query, to `/agents/:agentId/profile?tab=library`.
- Remove the now-unused lazy route component and regenerate the route tree.

## Test

- `mise run format`
- `mise run build`
- `mise run test`
- `mise run test:web` via the full test task
- `pnpm exec vp lint src/features/agents/ProfilePage.tsx src/features/library/LibraryFilesPage.tsx src/lib/route-search.ts src/routes/_app/agents.$agentId/library/index.tsx`

## Refs

Closes MBP-16

## Checklist

- [x] The PR links a GitHub issue, or states why the fix is small enough not to need one.
- [x] I added or updated focused tests for changed non-trivial behavior, or explained why none are needed. Existing web route and surface checks passed; the redirect is covered by the typed route build.
- [x] I updated relevant English and Chinese documentation, or no documentation change is needed. This is an internal navigation and presentation change.
- [x] I ran `mise run format && mise run build && mise run test`.
- [x] If this changes agent behavior (tools, prompts, the runner loop): I included eval evidence with both jobs, commits, tier, k, host, and model, or stated why it is not applicable. This only changes web routing and UI.
- [x] If the change touches a surface no eval task exercises (pixel understanding, document extraction, CRLF fidelity, non-UTF-8, binary handling): I said so, and named the tests that cover it instead. It does not touch those surfaces.
- [x] Any earlier measurement this PR invalidates is marked superseded with its reason, not deleted. No earlier measurements are affected.
