### PR TITLE
MBP-12: settings: expose deployment and MCP mutations

### DIFF
--- a/cmd/stellad/commands.go
+++ b/cmd/stellad/commands.go
@@ -121,6 +121,7 @@ type setupResult struct {
 	goalSvc                  *goal.Service
 	vaultSvc                 *vault.Service
 	mcpSvc                   *mcp.Service
+	mcpAccess                *mcp.Access
 	controlPlane             *controlplane.Service
 	webhooks                 *webhook.Service
 	credSvc                  *connections.Service
@@ -291,6 +292,7 @@ func setup(parent context.Context, cfg config.ServerConfig, baseURL string) (*se
 	}
 
 	var poolMgr *agent.PoolManager
+	var controlPlaneSvc *controlplane.Service
 	memProvider = wrapMemoryWithTracing(memProvider, &poolMgr)
 	if _, ok := memory.Unwrap(memProvider).(memory.InboxAppender); !ok {
 		return nil, errors.New("memory provider does not support durable Session inbox")
@@ -506,6 +508,7 @@ func setup(parent context.Context, cfg config.ServerConfig, baseURL string) (*se
 		mcpVault = vaultSvc
 	}
 	mcpSvc := mcp.NewServiceForPool(db, mcpVault)
+	mcpAccess := mcp.NewAccess(mcpSvc, agentAccess)
 
 	// Settings is registered before the pool starts, but its Agent management and
 	// runner invalidation dependencies are completed later in this composition
@@ -555,6 +558,8 @@ func setup(parent context.Context, cfg config.ServerConfig, baseURL string) (*se
 			settings.WithLibraryMutations(librarySvc),
 			settings.WithSkillMutations(settings.NewSkillMutator(skillAccess, skillStore)),
 			settings.WithToolOverrideMutations(settings.NewToolOverrideMutator(agentAccess, toolOverrides, settingsInvalidator, isManagedSettingsTool)),
+			settings.WithDeploymentMutations(settings.NewDeploymentMutatorRef(&controlPlaneSvc)),
+			settings.WithMCPMutations(mcpAccess),
 		),
 		Available: settings.Available,
 	})
@@ -583,6 +588,10 @@ func setup(parent context.Context, cfg config.ServerConfig, baseURL string) (*se
 		agent.WithProjectResolver(projectStore.Resolve),
 		agent.WithHomeWorkspace(homeRegistry),
 	)
+
+	// The control-plane service shares the final pool manager for provider/plugin
+	// reloads. The Settings tool reaches it through the reference-bound adapter.
+	controlPlaneSvc = controlplane.NewService(store, phost, poolMgr, credSvc, slog.With("component", "controlplane"))
 
 	// Bind the static Vault/MCP/OAuth capabilities into the pool BEFORE StartAll,
 	// as one-shot pre-start binds. Binding them up front means agents are built
@@ -626,6 +635,7 @@ func setup(parent context.Context, cfg config.ServerConfig, baseURL string) (*se
 	// after StartAll; the shared credSvc is then fully configured before it is
 	// handed to the admin server via Deps.
 	credSvc.SetInvalidator(poolMgr)
+	mcpSvc.SetInvalidator(poolMgr)
 
 	// Webhook resource domain. It owns the user→Agent binding, opaque capability
 	// verifier, and lifecycle independently from deployment channel management.
@@ -642,7 +652,7 @@ func setup(parent context.Context, cfg config.ServerConfig, baseURL string) (*se
 	// (providers/settings/plugins/channels). Authorization is the admin gate in
 	// Begin, so the HTTP transport keeps only decode/shape. Built here, after the
 	// pool and shared connections service are fully wired.
-	controlPlaneSvc := controlplane.NewService(store, phost, poolMgr, credSvc, slog.With("component", "controlplane"))
+	// controlPlaneSvc was created before StartAll so Settings and HTTP share one instance.
 
 	// Composition root for River: both the scheduler and goal subsystems are now
 	// built, so assemble the single shared working client from their queues and
@@ -713,6 +723,7 @@ func setup(parent context.Context, cfg config.ServerConfig, baseURL string) (*se
 		goalSvc:                  goalSvc,
 		vaultSvc:                 vaultSvc,
 		mcpSvc:                   mcpSvc,
+		mcpAccess:                mcpAccess,
 		controlPlane:             controlPlaneSvc,
 		webhooks:                 webhookSvc,
 		credSvc:                  credSvc,

--- a/cmd/stellad/gateway.go
+++ b/cmd/stellad/gateway.go
@@ -495,6 +495,7 @@ func runServer(ctx context.Context, s *setupResult, loginConfig oidc.LoginConfig
 		Vault:               s.vaultSvc,
 		VaultRecipient:      vaultRecipient,
 		MCP:                 s.mcpSvc,
+		MCPAccess:           s.mcpAccess,
 		Scheduler:           s.schedulerSvc,
 		Goal:                s.goalSvc,
 		Workflow:            s.workflowSvc,

--- a/internal/mcp/access.go
+++ b/internal/mcp/access.go
@@ -1,0 +1,113 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+
+	agentaccess "github.com/CherryHQ/stella/internal/agent/access"
+	"github.com/CherryHQ/stella/internal/authz"
+)
+
+// Access binds MCP scope ownership to a verified Authority. HTTP and the
+// model-facing Settings tool use this same seam; raw Service methods are kept
+// for trusted runtime reads and are not an authorization boundary.
+type Access struct {
+	svc       *Service
+	agents    *agentaccess.Service
+	authority authz.Authority
+}
+
+func NewAccess(svc *Service, agents *agentaccess.Service) *Access {
+	return &Access{svc: svc, agents: agents}
+}
+
+func (s *Access) Begin(authority authz.Authority) (*Access, error) {
+	if s == nil || s.svc == nil || !authority.Valid() || authority.Kind() != authz.ActorUser {
+		return nil, authz.ErrForbidden
+	}
+	return &Access{svc: s.svc, agents: s.agents, authority: authority}, nil
+}
+
+func (a *Access) owner(ctx context.Context, scope, agentID string) (string, string, error) {
+	if a == nil || a.authority.Kind() != authz.ActorUser {
+		return "", "", authz.ErrForbidden
+	}
+	userID := string(a.authority.UserID())
+	switch scope {
+	case ScopeUser:
+		if agentID != "" {
+			return "", "", errors.New("mcp: user scope cannot include agent_id")
+		}
+		return userID, "", nil
+	case ScopeUserAgent:
+		if agentID == "" {
+			return "", "", errors.New("mcp: user_agent scope requires agent_id")
+		}
+		if a.agents == nil {
+			return "", "", authz.ErrForbidden
+		}
+		if err := a.agents.Authorize(ctx, a.authority, agentID, authz.ActionRead); err != nil {
+			return "", "", err
+		}
+		return userID, agentID, nil
+	case ScopeSystem:
+		if !a.authority.IsAdmin() || agentID != "" {
+			return "", "", authz.ErrForbidden
+		}
+		return "", "", nil
+	case ScopeSystemAgent:
+		if !a.authority.IsAdmin() || agentID == "" {
+			return "", "", authz.ErrForbidden
+		}
+		if a.agents == nil {
+			return "", "", authz.ErrForbidden
+		}
+		if err := a.agents.Authorize(ctx, a.authority, agentID, authz.ActionRead); err != nil {
+			return "", "", err
+		}
+		return "", agentID, nil
+	default:
+		return "", "", errors.New("mcp: invalid scope")
+	}
+}
+
+func (a *Access) List(ctx context.Context, scope, agentID string) ([]Registration, error) {
+	uid, aid, err := a.owner(ctx, scope, agentID)
+	if err != nil {
+		return nil, err
+	}
+	return a.svc.ListByScope(ctx, scope, uid, aid)
+}
+
+func (a *Access) Create(ctx context.Context, in CreateInput) (Registration, error) {
+	uid, aid, err := a.owner(ctx, in.Scope, in.AgentID)
+	if err != nil {
+		return Registration{}, err
+	}
+	in.UserID, in.AgentID = uid, aid
+	return a.svc.Create(ctx, in)
+}
+
+func (a *Access) Update(ctx context.Context, in UpdateInput) (Registration, error) {
+	uid, aid, err := a.owner(ctx, in.Scope, in.AgentID)
+	if err != nil {
+		return Registration{}, err
+	}
+	in.UserID, in.AgentID = uid, aid
+	if in.NewScope != nil {
+		newUID, newAID, err := a.owner(ctx, *in.NewScope, in.NewAgentID)
+		if err != nil {
+			return Registration{}, err
+		}
+		in.NewUserID, in.NewAgentID = newUID, newAID
+	}
+	return a.svc.Update(ctx, in)
+}
+
+func (a *Access) Delete(ctx context.Context, id, scope, agentID string) error {
+	uid, aid, err := a.owner(ctx, scope, agentID)
+	if err != nil {
+		return err
+	}
+	return a.svc.Delete(ctx, id, scope, uid, aid)
+}

--- a/internal/mcp/access_test.go
+++ b/internal/mcp/access_test.go
@@ -1,0 +1,56 @@
+package mcp
+
+import "testing"
+
+func TestDeleteForeignOwnerDoesNotPurgeCredential(t *testing.T) {
+	db := newFakeDB()
+	vault := newFakeVault()
+	svc := NewService(db, vault)
+	reg, err := svc.Create(t.Context(), CreateInput{
+		Scope: ScopeUser, UserID: "owner", Name: "remote", URL: "https://example.test/mcp",
+		Transport: TransportStreamableHTTP, AuthType: AuthTypeBearer, Token: "secret-token",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.Delete(t.Context(), reg.ID, ScopeUser, "attacker", ""); err != nil {
+		t.Fatal(err)
+	}
+	if got, ok := vault.stored[vaultKey(ScopeUser, "owner", "", reg.CredentialRef)]; !ok || got != "secret-token" {
+		t.Fatalf("foreign delete purged owner credential: present=%t value=%q", ok, got)
+	}
+}
+
+type recordingInvalidator struct{ users, userAgents, agents, all int }
+
+func (r *recordingInvalidator) InvalidateUser(string) error              { r.users++; return nil }
+func (r *recordingInvalidator) InvalidateUserAgent(string, string) error { r.userAgents++; return nil }
+func (r *recordingInvalidator) InvalidateAgent(string) error             { r.agents++; return nil }
+func (r *recordingInvalidator) InvalidateAll() error                     { r.all++; return nil }
+
+func TestRegistrationMutationsInvalidateThroughService(t *testing.T) {
+	db := newFakeDB()
+	inv := &recordingInvalidator{}
+	svc := NewService(db, nil)
+	svc.SetInvalidator(inv)
+	reg, err := svc.Create(t.Context(), CreateInput{Scope: ScopeUser, UserID: "u1", Name: "remote", URL: "https://example.test/mcp", Transport: TransportStreamableHTTP, AuthType: AuthTypeNone})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inv.users != 1 {
+		t.Fatalf("create invalidations = %d, want 1", inv.users)
+	}
+	name := "renamed"
+	if _, err := svc.Update(t.Context(), UpdateInput{ID: reg.ID, Scope: ScopeUser, UserID: "u1", Name: &name}); err != nil {
+		t.Fatal(err)
+	}
+	if inv.users != 2 {
+		t.Fatalf("update invalidations = %d, want 2", inv.users)
+	}
+	if err := svc.Delete(t.Context(), reg.ID, ScopeUser, "u1", ""); err != nil {
+		t.Fatal(err)
+	}
+	if inv.users != 3 {
+		t.Fatalf("delete invalidations = %d, want 3", inv.users)
+	}
+}

--- a/internal/mcp/service.go
+++ b/internal/mcp/service.go
@@ -38,8 +38,19 @@ type Vault interface {
 // The registration table holds no secret material — the bearer token lives in
 // the vault and is referenced by CredentialRef.
 type Service struct {
-	db    DB
-	vault Vault
+	db          DB
+	vault       Vault
+	invalidator RunnerInvalidator
+}
+
+// RunnerInvalidator is the cache invalidation port used after a registration
+// mutation. Keeping it here makes MCP invalidation a service invariant rather
+// than a transport chore.
+type RunnerInvalidator interface {
+	InvalidateUser(string) error
+	InvalidateUserAgent(string, string) error
+	InvalidateAgent(string) error
+	InvalidateAll() error
 }
 
 // NewService builds a Service. vault may be nil, in which case bearer auth is
@@ -53,6 +64,32 @@ func NewService(db DB, vault Vault) *Service {
 // bearer auth is rejected (there is nowhere to store the secret).
 func NewServiceForPool(pool *pgxpool.Pool, vault Vault) *Service {
 	return NewService(sqlc.New(pool), vault)
+}
+
+// SetInvalidator wires the runner cache used by both HTTP and Settings callers.
+// It is optional for tests and deployments that do not run agent pools.
+func (s *Service) SetInvalidator(invalidator RunnerInvalidator) {
+	if s != nil {
+		s.invalidator = invalidator
+	}
+}
+
+func (s *Service) invalidate(scope, userID, agentID string) error {
+	if s == nil || s.invalidator == nil {
+		return nil
+	}
+	switch scope {
+	case ScopeUser:
+		return s.invalidator.InvalidateUser(userID)
+	case ScopeUserAgent:
+		return s.invalidator.InvalidateUserAgent(userID, agentID)
+	case ScopeSystemAgent:
+		return s.invalidator.InvalidateAgent(agentID)
+	case ScopeSystem:
+		return s.invalidator.InvalidateAll()
+	default:
+		return nil
+	}
 }
 
 // CreateInput describes a new registration. Token is the raw bearer token,
@@ -141,7 +178,11 @@ func (s *Service) Create(ctx context.Context, in CreateInput) (Registration, err
 		}
 		return Registration{}, fmt.Errorf("mcp: create registration: %w", err)
 	}
-	return registrationFromRow(row), nil
+	reg := registrationFromRow(row)
+	// Invalidation is best-effort after commit. Returning its error would make a
+	// durable success look like a failed mutation and invite a duplicate retry.
+	_ = s.invalidate(reg.Scope, reg.UserID, reg.AgentID)
+	return reg, nil
 }
 
 // ListByScope returns every registration in exactly one scope/owner bucket.
@@ -286,7 +327,12 @@ func (s *Service) Update(ctx context.Context, in UpdateInput) (Registration, err
 	if deleteOldToken {
 		_ = s.deleteToken(ctx, oldTokenScope, oldTokenUserID, oldTokenAgentID, old.CredentialRef)
 	}
-	return registrationFromRow(row), nil
+	reg := registrationFromRow(row)
+	_ = s.invalidate(old.Scope, old.UserID, old.AgentID)
+	if old.Scope != reg.Scope || old.UserID != reg.UserID || old.AgentID != reg.AgentID {
+		_ = s.invalidate(reg.Scope, reg.UserID, reg.AgentID)
+	}
+	return reg, nil
 }
 
 // Delete removes a registration in the given scope and its vault credential.
@@ -294,10 +340,13 @@ func (s *Service) Delete(ctx context.Context, id, scope, userID, agentID string)
 	if err := validateScopeOwner(scope, userID, agentID); err != nil {
 		return err
 	}
-	// Load the row first so we know the credential to purge. A missing row is a
-	// no-op delete, not an error.
-	if row, err := s.db.GetMCPServerByID(ctx, id); err == nil && row.CredentialRef != "" {
-		_ = s.deleteToken(ctx, scope, userID, agentID, row.CredentialRef)
+	// Load the row first so we know the credential to purge. Only purge when the
+	// row belongs to the caller's exact bucket. A foreign ID must be a no-op and
+	// must never let a caller delete another owner's vault entry.
+	row, getErr := s.db.GetMCPServerByID(ctx, id)
+	matches := getErr == nil && rowMatchesScopeOwner(row, scope, userID, agentID)
+	if matches && row.CredentialRef != "" {
+		_ = s.deleteToken(ctx, row.Scope, textOrEmpty(row.UserID), textOrEmpty(row.AgentID), row.CredentialRef)
 	}
 	if err := s.db.DeleteMCPServerByScope(ctx, sqlc.DeleteMCPServerByScopeParams{
 		ID:      id,
@@ -307,6 +356,7 @@ func (s *Service) Delete(ctx context.Context, id, scope, userID, agentID string)
 	}); err != nil {
 		return fmt.Errorf("mcp: delete registration: %w", err)
 	}
+	_ = s.invalidate(scope, userID, agentID)
 	return nil
 }
 

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -35,7 +35,7 @@ func mcpServerResponse(reg mcp.Registration) apitypes.MCPServer {
 
 // ListScopedMCPServers handles GET /api/mcp/servers.
 func (s *Server) ListScopedMCPServers(w http.ResponseWriter, r *http.Request, params apiserver.ListScopedMCPServersParams) {
-	if s.mcpSvc == nil {
+	if s.mcpSvc == nil || s.mcpAccess == nil {
 		writeCapabilityUnavailable(w, capMCP)
 		return
 	}
@@ -53,12 +53,18 @@ func (s *Server) ListScopedMCPServers(w http.ResponseWriter, r *http.Request, pa
 	if params.AgentId != nil {
 		agentID = *params.AgentId
 	}
-	userID, agentID, ok := s.resolveScope(w, r, info, scope, agentID)
-	if !ok {
+	authority, err := info.authority()
+	if err != nil {
+		writeError(w, http.StatusUnauthorized, "not authenticated")
+		return
+	}
+	access, err := s.mcpAccess.Begin(authority)
+	if err != nil {
+		writeError(w, http.StatusForbidden, "forbidden")
 		return
 	}
 
-	regs, err := s.mcpSvc.ListByScope(r.Context(), scope, userID, agentID)
+	regs, err := access.List(r.Context(), scope, agentID)
 	if err != nil {
 		s.log.Error("list scoped mcp servers", "user_id", info.UserID, "scope", scope, "agent_id", agentID, "error", err)
 		writeError(w, http.StatusBadRequest, "invalid request")
@@ -73,7 +79,7 @@ func (s *Server) ListScopedMCPServers(w http.ResponseWriter, r *http.Request, pa
 
 // CreateScopedMCPServer handles POST /api/mcp/servers.
 func (s *Server) CreateScopedMCPServer(w http.ResponseWriter, r *http.Request) {
-	if s.mcpSvc == nil {
+	if s.mcpSvc == nil || s.mcpAccess == nil {
 		writeCapabilityUnavailable(w, capMCP)
 		return
 	}
@@ -96,8 +102,14 @@ func (s *Server) CreateScopedMCPServer(w http.ResponseWriter, r *http.Request) {
 	if body.AgentId != nil {
 		agentID = *body.AgentId
 	}
-	userID, agentID, ok := s.resolveScope(w, r, info, scope, agentID)
-	if !ok {
+	authority, err := info.authority()
+	if err != nil {
+		writeError(w, http.StatusUnauthorized, "not authenticated")
+		return
+	}
+	access, err := s.mcpAccess.Begin(authority)
+	if err != nil {
+		writeError(w, http.StatusForbidden, "forbidden")
 		return
 	}
 
@@ -114,9 +126,8 @@ func (s *Server) CreateScopedMCPServer(w http.ResponseWriter, r *http.Request) {
 		token = *body.Token
 	}
 
-	reg, err := s.mcpSvc.Create(r.Context(), mcp.CreateInput{
+	reg, err := access.Create(r.Context(), mcp.CreateInput{
 		Scope:     scope,
-		UserID:    userID,
 		AgentID:   agentID,
 		Name:      body.Name,
 		URL:       body.Url,
@@ -131,13 +142,12 @@ func (s *Server) CreateScopedMCPServer(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	s.invalidateMCPRunners(reg.Scope, reg.UserID, reg.AgentID)
 	writeData(w, http.StatusCreated, mcpServerResponse(reg))
 }
 
 // UpdateScopedMCPServer handles PATCH /api/mcp/servers/{id}.
 func (s *Server) UpdateScopedMCPServer(w http.ResponseWriter, r *http.Request, id string, params apiserver.UpdateScopedMCPServerParams) {
-	if s.mcpSvc == nil {
+	if s.mcpSvc == nil || s.mcpAccess == nil {
 		writeCapabilityUnavailable(w, capMCP)
 		return
 	}
@@ -165,8 +175,14 @@ func (s *Server) UpdateScopedMCPServer(w http.ResponseWriter, r *http.Request, i
 	if params.AgentId != nil {
 		agentID = *params.AgentId
 	}
-	userID, agentID, ok := s.resolveScope(w, r, info, scope, agentID)
-	if !ok {
+	authority, err := info.authority()
+	if err != nil {
+		writeError(w, http.StatusUnauthorized, "not authenticated")
+		return
+	}
+	access, err := s.mcpAccess.Begin(authority)
+	if err != nil {
+		writeError(w, http.StatusForbidden, "forbidden")
 		return
 	}
 
@@ -178,10 +194,8 @@ func (s *Server) UpdateScopedMCPServer(w http.ResponseWriter, r *http.Request, i
 	if body.AgentId != nil {
 		newAgentID = *body.AgentId
 	}
-	newUserID, newAgentID, ok := s.resolveScope(w, r, info, newScope, newAgentID)
-	if !ok {
-		return
-	}
+	// Access resolves both the current and destination owner from Authority.
+	newUserID := ""
 
 	var transport *string
 	if body.Transport != nil {
@@ -194,10 +208,9 @@ func (s *Server) UpdateScopedMCPServer(w http.ResponseWriter, r *http.Request, i
 		authType = &v
 	}
 
-	reg, err := s.mcpSvc.Update(r.Context(), mcp.UpdateInput{
+	reg, err := access.Update(r.Context(), mcp.UpdateInput{
 		ID:         id,
 		Scope:      scope,
-		UserID:     userID,
 		AgentID:    agentID,
 		NewScope:   &newScope,
 		NewUserID:  newUserID,
@@ -214,16 +227,12 @@ func (s *Server) UpdateScopedMCPServer(w http.ResponseWriter, r *http.Request, i
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	s.invalidateMCPRunners(scope, userID, agentID)
-	if newScope != scope || newUserID != userID || newAgentID != agentID {
-		s.invalidateMCPRunners(newScope, newUserID, newAgentID)
-	}
 	writeData(w, http.StatusOK, mcpServerResponse(reg))
 }
 
 // DeleteScopedMCPServer handles DELETE /api/mcp/servers/{id}.
 func (s *Server) DeleteScopedMCPServer(w http.ResponseWriter, r *http.Request, id string, params apiserver.DeleteScopedMCPServerParams) {
-	if s.mcpSvc == nil {
+	if s.mcpSvc == nil || s.mcpAccess == nil {
 		writeCapabilityUnavailable(w, capMCP)
 		return
 	}
@@ -245,36 +254,21 @@ func (s *Server) DeleteScopedMCPServer(w http.ResponseWriter, r *http.Request, i
 	if params.AgentId != nil {
 		agentID = *params.AgentId
 	}
-	userID, agentID, ok := s.resolveScope(w, r, info, scope, agentID)
-	if !ok {
+	authority, err := info.authority()
+	if err != nil {
+		writeError(w, http.StatusUnauthorized, "not authenticated")
+		return
+	}
+	access, err := s.mcpAccess.Begin(authority)
+	if err != nil {
+		writeError(w, http.StatusForbidden, "forbidden")
 		return
 	}
 
-	if err := s.mcpSvc.Delete(r.Context(), id, scope, userID, agentID); err != nil {
+	if err := access.Delete(r.Context(), id, scope, agentID); err != nil {
 		s.log.Error("delete scoped mcp server", "user_id", info.UserID, "scope", scope, "agent_id", agentID, "id", id, "error", err)
 		writeError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
-	s.invalidateMCPRunners(scope, userID, agentID)
 	w.WriteHeader(http.StatusNoContent)
-}
-
-func (s *Server) invalidateMCPRunners(scope, userID, agentID string) {
-	if s.poolManager == nil {
-		return
-	}
-	var err error
-	switch scope {
-	case mcp.ScopeUser:
-		err = s.poolManager.InvalidateUser(userID)
-	case mcp.ScopeUserAgent:
-		err = s.poolManager.InvalidateUserAgent(userID, agentID)
-	case mcp.ScopeSystemAgent:
-		err = s.poolManager.InvalidateAgent(agentID)
-	case mcp.ScopeSystem:
-		err = s.poolManager.InvalidateAll()
-	}
-	if err != nil {
-		s.log.Warn("invalidate runners after mcp registration change", "scope", scope, "user_id", userID, "agent_id", agentID, "error", err)
-	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -67,6 +67,7 @@ type Server struct {
 	vaultRecipient   *age.X25519Recipient  // optional; if set, age keys are generated for new users
 	vaultSvc         *vault.Service        // optional; if nil, vault endpoints return 503
 	mcpSvc           *mcp.Service          // optional; if nil, MCP endpoints return 503
+	mcpAccess        *mcp.Access           // authority-bound MCP use cases shared by HTTP
 	credResolver     *credential.Service   // unified bearer credential front door
 	oauthAS          *oidc.Service         // OAuth2 authorization server
 	controlPlane     *controlplane.Service // control-plane PEP (providers/settings/plugins/channels)
@@ -213,6 +214,7 @@ type Deps struct {
 	Vault          *vault.Service
 	VaultRecipient *age.X25519Recipient
 	MCP            *mcp.Service
+	MCPAccess      *mcp.Access
 	Scheduler      *scheduler.Service
 	Goal           *goal.Service
 	Workflow       *workflowpkg.Service
@@ -316,6 +318,7 @@ func New(ctx context.Context, deps Deps) (*Server, error) {
 		vaultRecipient:   deps.VaultRecipient,
 		vaultSvc:         deps.Vault,
 		mcpSvc:           deps.MCP,
+		mcpAccess:        deps.MCPAccess,
 		credResolver:     deps.CredentialFrontDoor,
 		oauthAS:          deps.OAuthAuthServer,
 		controlPlane:     deps.ControlPlane,

--- a/internal/settings/deployment.go
+++ b/internal/settings/deployment.go
@@ -1,0 +1,227 @@
+package settings
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/CherryHQ/stella/internal/authz"
+	"github.com/CherryHQ/stella/internal/config"
+	"github.com/CherryHQ/stella/internal/controlplane"
+	"github.com/CherryHQ/stella/internal/mcp"
+	pkgplugins "github.com/CherryHQ/stella/pkg/plugins"
+)
+
+// DeploymentMutation is the narrow, admin-only control-plane port exposed to
+// Settings. The adapter below re-enters controlplane.Begin for every operation.
+// Secrets are deliberately absent from this interface.
+type DeploymentMutation interface {
+	ListProviders(context.Context, authz.Authority) ([]config.Provider, error)
+	GetProvider(context.Context, authz.Authority, string) (config.Provider, error)
+	CreateProvider(context.Context, authz.Authority, config.Provider) error
+	UpdateProvider(context.Context, authz.Authority, string, config.Provider) (config.Provider, error)
+	DeleteProvider(context.Context, authz.Authority, string) error
+	GetEmbedding(context.Context, authz.Authority) (config.EmbeddingSettings, error)
+	SetEmbedding(context.Context, authz.Authority, controlplane.EmbeddingUpdate) (config.EmbeddingSettings, error)
+	GetVision(context.Context, authz.Authority) (config.VisionSettings, error)
+	SetVision(context.Context, authz.Authority, config.VisionSettings) (config.VisionSettings, error)
+	ListPlugins(context.Context, authz.Authority) ([]pkgplugins.RegisteredPlugin, error)
+	TogglePlugin(context.Context, authz.Authority, string, string, bool) (config.Plugin, error)
+}
+
+// NewDeploymentMutator binds Settings to the existing control-plane PEP. It is
+// intentionally boring: no model-facing caller can receive a controlplane.Access
+// and every method is admin-gated by the domain's Begin method.
+func NewDeploymentMutator(svc *controlplane.Service) DeploymentMutation {
+	return &deploymentMutator{svc: svc}
+}
+
+// NewDeploymentMutatorRef supports composition roots where the pool manager
+// and control-plane service are created after the tool is registered.
+func NewDeploymentMutatorRef(ref **controlplane.Service) DeploymentMutation {
+	return &deploymentMutator{ref: ref}
+}
+
+type deploymentMutator struct {
+	svc *controlplane.Service
+	ref **controlplane.Service
+}
+
+func (m *deploymentMutator) begin(ctx context.Context, authority authz.Authority) (*controlplane.Access, error) {
+	if m == nil {
+		return nil, ErrUnavailable
+	}
+	svc := m.svc
+	if m.ref != nil {
+		svc = *m.ref
+	}
+	if svc == nil {
+		return nil, ErrUnavailable
+	}
+	return svc.Begin(ctx, authority)
+}
+
+func (m *deploymentMutator) ListProviders(ctx context.Context, a authz.Authority) ([]config.Provider, error) {
+	acc, err := m.begin(ctx, a)
+	if err != nil {
+		return nil, err
+	}
+	return acc.ListProviders(ctx)
+}
+
+func (m *deploymentMutator) GetProvider(ctx context.Context, a authz.Authority, id string) (config.Provider, error) {
+	acc, err := m.begin(ctx, a)
+	if err != nil {
+		return config.Provider{}, err
+	}
+	return acc.GetProvider(ctx, id)
+}
+
+func (m *deploymentMutator) CreateProvider(ctx context.Context, a authz.Authority, p config.Provider) error {
+	acc, err := m.begin(ctx, a)
+	if err != nil {
+		return err
+	}
+	return acc.CreateProvider(ctx, p)
+}
+
+func (m *deploymentMutator) UpdateProvider(ctx context.Context, a authz.Authority, id string, p config.Provider) (config.Provider, error) {
+	acc, err := m.begin(ctx, a)
+	if err != nil {
+		return config.Provider{}, err
+	}
+	return acc.UpdateProvider(ctx, id, p)
+}
+
+func (m *deploymentMutator) DeleteProvider(ctx context.Context, a authz.Authority, id string) error {
+	acc, err := m.begin(ctx, a)
+	if err != nil {
+		return err
+	}
+	return acc.DeleteProvider(ctx, id)
+}
+
+func (m *deploymentMutator) GetEmbedding(ctx context.Context, a authz.Authority) (config.EmbeddingSettings, error) {
+	acc, err := m.begin(ctx, a)
+	if err != nil {
+		return config.EmbeddingSettings{}, err
+	}
+	return acc.GetEmbeddingSettings(ctx)
+}
+
+func (m *deploymentMutator) SetEmbedding(ctx context.Context, a authz.Authority, u controlplane.EmbeddingUpdate) (config.EmbeddingSettings, error) {
+	acc, err := m.begin(ctx, a)
+	if err != nil {
+		return config.EmbeddingSettings{}, err
+	}
+	return acc.SetEmbeddingSettings(ctx, u)
+}
+
+func (m *deploymentMutator) GetVision(ctx context.Context, a authz.Authority) (config.VisionSettings, error) {
+	acc, err := m.begin(ctx, a)
+	if err != nil {
+		return config.VisionSettings{}, err
+	}
+	return acc.GetVisionSettings(ctx)
+}
+
+func (m *deploymentMutator) SetVision(ctx context.Context, a authz.Authority, s config.VisionSettings) (config.VisionSettings, error) {
+	acc, err := m.begin(ctx, a)
+	if err != nil {
+		return config.VisionSettings{}, err
+	}
+	return acc.SetVisionSettings(ctx, s)
+}
+
+func (m *deploymentMutator) ListPlugins(ctx context.Context, a authz.Authority) ([]pkgplugins.RegisteredPlugin, error) {
+	acc, err := m.begin(ctx, a)
+	if err != nil {
+		return nil, err
+	}
+	return acc.ListPlugins(ctx)
+}
+
+func (m *deploymentMutator) TogglePlugin(ctx context.Context, a authz.Authority, kind, name string, enabled bool) (config.Plugin, error) {
+	acc, err := m.begin(ctx, a)
+	if err != nil {
+		return config.Plugin{}, err
+	}
+	return acc.TogglePlugin(ctx, kind, name, enabled)
+}
+
+// MCPMutation is implemented by mcp.Access. Keeping this port at the Settings
+// boundary prevents raw Service calls from bypassing owner resolution.
+type MCPMutation interface {
+	List(context.Context, string, string) ([]mcp.Registration, error)
+	Create(context.Context, mcp.CreateInput) (mcp.Registration, error)
+	Update(context.Context, mcp.UpdateInput) (mcp.Registration, error)
+	Delete(context.Context, string, string, string) error
+}
+
+func safeURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return ""
+	}
+	u.User = nil
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String()
+}
+
+// validateSettingsURL is narrower than the MCP runtime policy on purpose. The
+// model-facing boundary rejects URL-carried secrets without changing HTTP or
+// control-plane behavior used by existing clients.
+func validateSettingsURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return fmt.Errorf("URL must be an absolute URL")
+	}
+	if u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+		return fmt.Errorf("URL must not contain userinfo, query, or fragment")
+	}
+	return nil
+}
+
+func providerView(p config.Provider) map[string]any {
+	return map[string]any{
+		"id": p.ID, "type": p.Type, "name": p.Name, "enabled": p.Enabled,
+		"has_api_key": p.APIKey != "", "base_url": safeURL(p.BaseURL), "model_count": len(p.Models),
+	}
+}
+
+func embeddingView(s config.EmbeddingSettings) map[string]any {
+	return map[string]any{"enabled": s.Enabled, "model": s.Model, "dimension": s.Dim, "base_url": safeURL(s.BaseURL), "normalize": s.Normalize, "has_api_key": s.APIKey != ""}
+}
+
+func visionView(s config.VisionSettings) map[string]any { return map[string]any{"model": s.Model} }
+
+func pluginView(p pkgplugins.RegisteredPlugin) map[string]any {
+	return map[string]any{"id": p.Info.ID, "kind": p.Kind, "name": p.Name, "enabled": p.State.Enabled, "has_config": p.HasConfig, "has_status": p.HasStatus, "capabilities": p.Capabilities}
+}
+
+func mcpView(r mcp.Registration) map[string]any {
+	return map[string]any{"id": r.ID, "scope": r.Scope, "agent_id": r.AgentID, "name": r.Name, "url": safeURL(r.URL), "transport": r.Transport, "auth_type": r.AuthType, "has_secret": r.CredentialRef != "", "enabled": r.Enabled}
+}
+
+func registrationDigest(r mcp.Registration) string {
+	return digestValue(map[string]any{"id": r.ID, "scope": r.Scope, "user_id": r.UserID, "agent_id": r.AgentID, "name": r.Name, "url": safeURL(r.URL), "transport": r.Transport, "auth_type": r.AuthType, "enabled": r.Enabled})
+}
+
+func findRegistration(rows []mcp.Registration, id string) (mcp.Registration, bool) {
+	for _, row := range rows {
+		if row.ID == id {
+			return row, true
+		}
+	}
+	return mcp.Registration{}, false
+}
+
+func findPlugin(rows []pkgplugins.RegisteredPlugin, kind, name string) (pkgplugins.RegisteredPlugin, bool) {
+	for _, row := range rows {
+		if row.Kind == kind && row.Name == name || row.Info.Kind == kind && row.Info.Name == name {
+			return row, true
+		}
+	}
+	return pkgplugins.RegisteredPlugin{}, false
+}

--- a/internal/settings/deployment_protocol.go
+++ b/internal/settings/deployment_protocol.go
@@ -1,0 +1,501 @@
+package settings
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/CherryHQ/stella/internal/authz"
+	"github.com/CherryHQ/stella/internal/config"
+	"github.com/CherryHQ/stella/internal/controlplane"
+	"github.com/CherryHQ/stella/internal/mcp"
+)
+
+func (t *Tool) readResource(ctx context.Context, args map[string]any, action string) (string, error) {
+	resource, _ := args["resource"].(string)
+	if resource == "agents" {
+		return t.readAgents(ctx, args, action)
+	}
+	authority, _ := authz.AuthorityFromContext(ctx)
+	switch resource {
+	case "providers", "embedding", "vision", "plugins":
+		return t.readDeployment(ctx, authority, args, action)
+	case "mcp":
+		return t.readMCP(ctx, authority, args, action)
+	default:
+		return "", fmt.Errorf("unsupported settings resource %q", resource)
+	}
+}
+
+func (t *Tool) readDeployment(ctx context.Context, authority authz.Authority, args map[string]any, action string) (string, error) {
+	if t.deploymentMutations == nil {
+		return "", ErrUnavailable
+	}
+	resource, _ := args["resource"].(string)
+	allowed := []string{"action", "resource"}
+	if action == "get" {
+		allowed = append(allowed, "id")
+	}
+	if err := rejectUnexpected(args, allowed...); err != nil {
+		return "", err
+	}
+	switch resource {
+	case "providers":
+		if action == "list" {
+			rows, err := t.deploymentMutations.ListProviders(ctx, authority)
+			if err != nil {
+				return "", err
+			}
+			out := make([]map[string]any, 0, len(rows))
+			for _, row := range rows {
+				out = append(out, providerView(row))
+			}
+			return marshalAgentResult(action, map[string]any{"providers": out})
+		}
+		id, err := stringArg(args, "id", true)
+		if err != nil {
+			return "", err
+		}
+		row, err := t.deploymentMutations.GetProvider(ctx, authority, id)
+		if err != nil {
+			return "", err
+		}
+		return marshalAgentResult(action, providerView(row))
+	case "embedding":
+		if action != "get" {
+			return "", fmt.Errorf("embedding supports only get")
+		}
+		row, err := t.deploymentMutations.GetEmbedding(ctx, authority)
+		if err != nil {
+			return "", err
+		}
+		return marshalAgentResult(action, embeddingView(row))
+	case "vision":
+		if action != "get" {
+			return "", fmt.Errorf("vision supports only get")
+		}
+		row, err := t.deploymentMutations.GetVision(ctx, authority)
+		if err != nil {
+			return "", err
+		}
+		return marshalAgentResult(action, visionView(row))
+	case "plugins":
+		if action != "list" {
+			return "", fmt.Errorf("plugins supports only list")
+		}
+		rows, err := t.deploymentMutations.ListPlugins(ctx, authority)
+		if err != nil {
+			return "", err
+		}
+		out := make([]map[string]any, 0, len(rows))
+		for _, row := range rows {
+			out = append(out, pluginView(row))
+		}
+		return marshalAgentResult(action, map[string]any{"plugins": out})
+	default:
+		return "", fmt.Errorf("unsupported settings resource %q", resource)
+	}
+}
+
+func (t *Tool) readMCP(ctx context.Context, authority authz.Authority, args map[string]any, action string) (string, error) {
+	if t.mcpAccess == nil {
+		return "", ErrUnavailable
+	}
+	allowed := []string{"action", "resource", "scope", "agent_id"}
+	if action == "get" {
+		allowed = append(allowed, "id")
+	}
+	if err := rejectUnexpected(args, allowed...); err != nil {
+		return "", err
+	}
+	scope, err := stringArg(args, "scope", true)
+	if err != nil {
+		return "", err
+	}
+	agentID, err := stringArg(args, "agent_id", false)
+	if err != nil {
+		return "", err
+	}
+	access, err := t.mcpAccess.Begin(authority)
+	if err != nil {
+		return "", err
+	}
+	rows, err := access.List(ctx, scope, agentID)
+	if err != nil {
+		return "", err
+	}
+	if action == "get" {
+		id, err := stringArg(args, "id", true)
+		if err != nil {
+			return "", err
+		}
+		row, ok := findRegistration(rows, id)
+		if !ok {
+			return "", authz.ErrNotFound
+		}
+		return marshalAgentResult(action, mcpView(row))
+	}
+	out := make([]map[string]any, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, mcpView(row))
+	}
+	return marshalAgentResult(action, map[string]any{"servers": out})
+}
+
+type providerMutationInput struct {
+	ID      string  `json:"id"`
+	Type    string  `json:"type"`
+	Name    *string `json:"name"`
+	Enabled *bool   `json:"enabled"`
+	BaseURL *string `json:"base_url"`
+}
+
+func (in providerMutationInput) candidate(existing *config.Provider) config.Provider {
+	var p config.Provider
+	if existing != nil {
+		p = *existing
+		if existing.Models != nil {
+			p.Models = existing.Models
+		}
+	}
+	if in.ID != "" {
+		p.ID = in.ID
+	}
+	if in.Type != "" {
+		p.Type = in.Type
+	}
+	if in.Name != nil {
+		p.Name = *in.Name
+	}
+	if in.Enabled != nil {
+		p.Enabled = *in.Enabled
+	}
+	if in.BaseURL != nil {
+		p.BaseURL = *in.BaseURL
+	}
+	return p
+}
+
+func (t *Tool) previewDeployment(ctx context.Context, resource, operation string, input map[string]any) (string, error) {
+	if t.deploymentMutations == nil {
+		return "", ErrUnavailable
+	}
+	authority, ok := authz.AuthorityFromContext(ctx)
+	if !ok {
+		return "", ErrUnavailable
+	}
+	switch resource {
+	case "providers":
+		var in providerMutationInput
+		if err := decodeObject(input, &in); err != nil {
+			return "", err
+		}
+		switch operation {
+		case "create":
+			if in.ID == "" || in.Type == "" {
+				return "", errors.New("providers.create requires id and type")
+			}
+			if in.BaseURL != nil && *in.BaseURL != "" {
+				if err := validateSettingsURL(*in.BaseURL); err != nil {
+					return "", err
+				}
+			}
+			return "", nil
+		case "update", "delete":
+			if in.ID == "" {
+				return "", errors.New("provider id is required")
+			}
+			current, err := t.deploymentMutations.GetProvider(ctx, authority, in.ID)
+			if err != nil {
+				return "", err
+			}
+			if operation == "update" && in.BaseURL != nil && *in.BaseURL != "" {
+				if err := validateSettingsURL(*in.BaseURL); err != nil {
+					return "", err
+				}
+			}
+			return digestValue(providerView(current)), nil
+		default:
+			return "", fmt.Errorf("unsupported providers operation %q", operation)
+		}
+	case "embedding":
+		if operation != "update" {
+			return "", fmt.Errorf("unsupported embedding operation %q", operation)
+		}
+		var in embeddingMutationInput
+		if err := decodeObject(input, &in); err != nil {
+			return "", err
+		}
+		if in.BaseURL != nil && *in.BaseURL != "" {
+			if err := validateSettingsURL(*in.BaseURL); err != nil {
+				return "", err
+			}
+		}
+		current, err := t.deploymentMutations.GetEmbedding(ctx, authority)
+		if err != nil {
+			return "", err
+		}
+		return digestValue(embeddingView(current)), nil
+	case "vision":
+		if operation != "update" {
+			return "", fmt.Errorf("unsupported vision operation %q", operation)
+		}
+		var in visionMutationInput
+		if err := decodeObject(input, &in); err != nil {
+			return "", err
+		}
+		current, err := t.deploymentMutations.GetVision(ctx, authority)
+		if err != nil {
+			return "", err
+		}
+		return digestValue(visionView(current)), nil
+	case "plugins":
+		if operation != "enable" && operation != "disable" {
+			return "", fmt.Errorf("unsupported plugins operation %q", operation)
+		}
+		var in pluginMutationInput
+		if err := decodeObject(input, &in); err != nil {
+			return "", err
+		}
+		if in.Kind == "" || in.Name == "" {
+			return "", errors.New("plugins mutation requires kind and name")
+		}
+		rows, err := t.deploymentMutations.ListPlugins(ctx, authority)
+		if err != nil {
+			return "", err
+		}
+		if _, found := findPlugin(rows, in.Kind, in.Name); !found {
+			return "", authz.ErrNotFound
+		}
+		return "", nil
+	default:
+		return "", fmt.Errorf("unsupported settings resource %q", resource)
+	}
+}
+
+type embeddingMutationInput struct {
+	Enabled   *bool   `json:"enabled"`
+	Model     *string `json:"model"`
+	Dim       *int    `json:"dim"`
+	BaseURL   *string `json:"base_url"`
+	Normalize *bool   `json:"normalize"`
+}
+type visionMutationInput struct {
+	Model *string `json:"model"`
+}
+type pluginMutationInput struct {
+	Kind string `json:"kind"`
+	Name string `json:"name"`
+}
+
+func (t *Tool) confirmDeployment(ctx context.Context, resource, operation string, input map[string]any, expected string) error {
+	if t.deploymentMutations == nil {
+		return ErrUnavailable
+	}
+	authority, ok := authz.AuthorityFromContext(ctx)
+	if !ok {
+		return ErrUnavailable
+	}
+	switch resource {
+	case "providers":
+		var in providerMutationInput
+		if err := decodeObject(input, &in); err != nil {
+			return err
+		}
+		switch operation {
+		case "create":
+			return t.deploymentMutations.CreateProvider(ctx, authority, in.candidate(nil))
+		case "update":
+			current, err := t.deploymentMutations.GetProvider(ctx, authority, in.ID)
+			if err != nil {
+				return err
+			}
+			if digestValue(providerView(current)) != expected {
+				return errors.New("provider changed since preview")
+			}
+			_, err = t.deploymentMutations.UpdateProvider(ctx, authority, in.ID, in.candidate(&current))
+			return err
+		case "delete":
+			return t.deploymentMutations.DeleteProvider(ctx, authority, in.ID)
+		}
+	case "embedding":
+		var in embeddingMutationInput
+		if err := decodeObject(input, &in); err != nil {
+			return err
+		}
+		current, err := t.deploymentMutations.GetEmbedding(ctx, authority)
+		if err != nil {
+			return err
+		}
+		if digestValue(embeddingView(current)) != expected {
+			return errors.New("embedding settings changed since preview")
+		}
+		upd := controlplane.EmbeddingUpdate{Enabled: current.Enabled, Model: current.Model, Dim: current.Dim, BaseURL: current.BaseURL, Normalize: current.Normalize}
+		if in.Enabled != nil {
+			upd.Enabled = *in.Enabled
+		}
+		if in.Model != nil {
+			upd.Model = *in.Model
+		}
+		if in.Dim != nil {
+			upd.Dim = *in.Dim
+		}
+		if in.BaseURL != nil {
+			upd.BaseURL = *in.BaseURL
+		}
+		if in.Normalize != nil {
+			upd.Normalize = *in.Normalize
+		}
+		_, err = t.deploymentMutations.SetEmbedding(ctx, authority, upd)
+		return err
+	case "vision":
+		var in visionMutationInput
+		if err := decodeObject(input, &in); err != nil {
+			return err
+		}
+		current, err := t.deploymentMutations.GetVision(ctx, authority)
+		if err != nil {
+			return err
+		}
+		if digestValue(visionView(current)) != expected {
+			return errors.New("vision settings changed since preview")
+		}
+		model := current.Model
+		if in.Model != nil {
+			model = *in.Model
+		}
+		_, err = t.deploymentMutations.SetVision(ctx, authority, config.VisionSettings{Model: model})
+		return err
+	case "plugins":
+		var in pluginMutationInput
+		if err := decodeObject(input, &in); err != nil {
+			return err
+		}
+		_, err := t.deploymentMutations.TogglePlugin(ctx, authority, in.Kind, in.Name, operation == "enable")
+		return err
+	}
+	return fmt.Errorf("unsupported %s operation %q", resource, operation)
+}
+
+func (t *Tool) previewMCP(ctx context.Context, operation string, input map[string]any) (string, error) {
+	if t.mcpAccess == nil {
+		return "", ErrUnavailable
+	}
+	authority, ok := authz.AuthorityFromContext(ctx)
+	if !ok {
+		return "", ErrUnavailable
+	}
+	var in mcpMutationInput
+	if err := decodeObject(input, &in); err != nil {
+		return "", err
+	}
+	access, err := t.mcpAccess.Begin(authority)
+	if err != nil {
+		return "", err
+	}
+	switch operation {
+	case "create":
+		if in.AuthType != "" && in.AuthType != mcp.AuthTypeNone {
+			return "", errors.New("only no-auth MCP registrations are supported by the model tool")
+		}
+		if stringValue(in.URL) == "" || stringValue(in.Name) == "" || in.Scope == "" {
+			return "", errors.New("mcp.create requires scope, name, and url")
+		}
+		if err := validateSettingsURL(stringValue(in.URL)); err != nil {
+			return "", err
+		}
+		return "", nil
+	case "update", "delete":
+		if in.ID == "" || in.Scope == "" {
+			return "", errors.New("mcp mutation requires id and scope")
+		}
+		rows, err := access.List(ctx, in.Scope, in.AgentID)
+		if err != nil {
+			return "", err
+		}
+		row, found := findRegistration(rows, in.ID)
+		if !found {
+			return "", authz.ErrNotFound
+		}
+		if in.URL != nil && *in.URL != "" {
+			if err := validateSettingsURL(*in.URL); err != nil {
+				return "", err
+			}
+		}
+		return registrationDigest(row), nil
+	default:
+		return "", fmt.Errorf("unsupported mcp operation %q", operation)
+	}
+}
+
+type mcpMutationInput struct {
+	ID             string  `json:"id"`
+	Scope          string  `json:"scope"`
+	AgentID        string  `json:"agent_id"`
+	Name           *string `json:"name"`
+	URL            *string `json:"url"`
+	Transport      *string `json:"transport"`
+	Enabled        *bool   `json:"enabled"`
+	AuthType       string  `json:"auth_type"`
+	ExpectedDigest string  `json:"expected_digest"`
+}
+
+func (t *Tool) confirmMCP(ctx context.Context, operation string, input map[string]any, expected string) error {
+	if t.mcpAccess == nil {
+		return ErrUnavailable
+	}
+	authority, ok := authz.AuthorityFromContext(ctx)
+	if !ok {
+		return ErrUnavailable
+	}
+	var in mcpMutationInput
+	if err := decodeObject(input, &in); err != nil {
+		return err
+	}
+	access, err := t.mcpAccess.Begin(authority)
+	if err != nil {
+		return err
+	}
+	switch operation {
+	case "create":
+		if in.AuthType != "" && in.AuthType != mcp.AuthTypeNone {
+			return errors.New("only no-auth MCP registrations are supported by the model tool")
+		}
+		r := mcp.CreateInput{Scope: in.Scope, AgentID: in.AgentID, Name: stringValue(in.Name), URL: stringValue(in.URL), Transport: stringValue(in.Transport), AuthType: mcp.AuthTypeNone}
+		_, err := access.Create(ctx, r)
+		return err
+	case "update":
+		rows, err := access.List(ctx, in.Scope, in.AgentID)
+		if err != nil {
+			return err
+		}
+		row, found := findRegistration(rows, in.ID)
+		if !found {
+			return authz.ErrNotFound
+		}
+		if registrationDigest(row) != expected {
+			return errors.New("MCP registration changed since preview")
+		}
+		upd := mcp.UpdateInput{ID: in.ID, Scope: in.Scope, AgentID: in.AgentID, NewScope: &in.Scope, NewUserID: string(authority.UserID()), NewAgentID: in.AgentID, Name: in.Name, URL: in.URL, Transport: in.Transport, Enabled: in.Enabled}
+		if in.AuthType != "" && in.AuthType != mcp.AuthTypeNone {
+			return errors.New("only no-auth MCP registrations are supported by the model tool")
+		}
+		_, err = access.Update(ctx, upd)
+		return err
+	case "delete":
+		rows, err := access.List(ctx, in.Scope, in.AgentID)
+		if err != nil {
+			return err
+		}
+		row, found := findRegistration(rows, in.ID)
+		if !found {
+			return authz.ErrNotFound
+		}
+		if registrationDigest(row) != expected {
+			return errors.New("MCP registration changed since preview")
+		}
+		return access.Delete(ctx, in.ID, in.Scope, in.AgentID)
+	default:
+		return fmt.Errorf("unsupported mcp operation %q", operation)
+	}
+}

--- a/internal/settings/deployment_protocol_test.go
+++ b/internal/settings/deployment_protocol_test.go
@@ -1,0 +1,80 @@
+package settings
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/CherryHQ/stella/internal/authz"
+	"github.com/CherryHQ/stella/internal/config"
+	"github.com/CherryHQ/stella/internal/controlplane"
+	"github.com/CherryHQ/stella/internal/mcp"
+)
+
+func TestDeploymentMutatorRejectsOrdinaryAuthorityAtControlPlaneBoundary(t *testing.T) {
+	mutator := NewDeploymentMutator(controlplane.NewService(nil, nil, nil, nil, nil))
+	ordinary, err := authz.NewUserAuthority("user-1", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	if _, err := mutator.ListProviders(ctx, ordinary); !errors.Is(err, authz.ErrForbidden) {
+		t.Fatalf("ListProviders = %v, want forbidden", err)
+	}
+	if _, err := mutator.GetEmbedding(ctx, ordinary); !errors.Is(err, authz.ErrForbidden) {
+		t.Fatalf("GetEmbedding = %v, want forbidden", err)
+	}
+	if err := mutator.CreateProvider(ctx, ordinary, config.Provider{ID: "x", Type: "x"}); !errors.Is(err, authz.ErrForbidden) {
+		t.Fatalf("CreateProvider = %v, want forbidden", err)
+	}
+}
+
+func TestSettingsViewsNeverSerializeDeploymentSecrets(t *testing.T) {
+	provider, err := json.Marshal(providerView(config.Provider{
+		ID: "openai", Type: "openai", APIKey: "api-key-secret", BaseURL: "https://api.example.test/v1?token=query-secret#fragment-secret",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	providerText := string(provider)
+	for _, secret := range []string{"api-key-secret", "query-secret", "fragment-secret"} {
+		if strings.Contains(providerText, secret) {
+			t.Fatalf("provider view leaks %q: %s", secret, providerText)
+		}
+	}
+	if !strings.Contains(providerText, `"has_api_key":true`) {
+		t.Fatalf("provider view does not expose presence bit: %s", providerText)
+	}
+
+	mcpText, err := json.Marshal(mcpView(mcp.Registration{
+		URL: "https://mcp.example.test/tools?token=query-secret#fragment-secret", CredentialRef: "MCP_TOKEN_SECRET", AuthType: mcp.AuthTypeBearer,
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, secret := range []string{"query-secret", "fragment-secret", "MCP_TOKEN_SECRET"} {
+		if strings.Contains(string(mcpText), secret) {
+			t.Fatalf("MCP view leaks %q: %s", secret, mcpText)
+		}
+	}
+	if !strings.Contains(string(mcpText), `"has_secret":true`) {
+		t.Fatalf("MCP view does not expose presence bit: %s", mcpText)
+	}
+}
+
+func TestSettingsRejectsURLCarriedSecretsAtModelBoundary(t *testing.T) {
+	for _, raw := range []string{
+		"https://user:password@example.test/mcp",
+		"https://example.test/mcp?api_key=secret",
+		"https://example.test/mcp#bearer-secret",
+	} {
+		if err := validateSettingsURL(raw); err == nil {
+			t.Fatalf("validateSettingsURL(%q) succeeded", raw)
+		}
+	}
+	if err := validateSettingsURL("https://example.test/mcp"); err != nil {
+		t.Fatalf("safe URL rejected: %v", err)
+	}
+}

--- a/internal/settings/protocol.go
+++ b/internal/settings/protocol.go
@@ -55,6 +55,33 @@ var operationContracts = map[string]map[string]operationContract{
 		"set":   {Required: []string{"tool_name", "scope", "enabled"}, Optional: []string{"agent_id"}, Constraints: []string{"scope is user, user_agent, system, or system_agent; agent_id is required only for agent-bound scopes; core and unmanaged tools are rejected"}},
 		"clear": {Required: []string{"tool_name", "scope"}, Optional: []string{"agent_id"}, Constraints: []string{"scope is user, user_agent, system, or system_agent; agent_id is required only for agent-bound scopes; core and unmanaged tools are rejected"}},
 	},
+	"providers": {
+		"list":   {Required: []string{}, Optional: []string{}, Constraints: []string{"API keys are never returned"}},
+		"get":    {Required: []string{"id"}, Optional: []string{}, Constraints: []string{"API keys are never returned"}},
+		"create": {Required: []string{"id", "type"}, Optional: []string{"name", "enabled", "base_url"}, Constraints: []string{"credentials are configured outside this model-facing tool"}},
+		"update": {Required: []string{"id"}, Optional: []string{"name", "type", "enabled", "base_url"}, Constraints: []string{"credentials are immutable here; URL must not contain userinfo, query, or fragment"}},
+		"delete": {Required: []string{"id"}, Optional: []string{}, Constraints: []string{"deletes the deployment provider"}},
+	},
+	"embedding": {
+		"get":    {Required: []string{}, Optional: []string{}, Constraints: []string{"API keys are never returned"}},
+		"update": {Required: []string{}, Optional: []string{"enabled", "model", "dim", "base_url", "normalize"}, Constraints: []string{"API keys cannot be written here; URL must not contain userinfo, query, or fragment"}},
+	},
+	"vision": {
+		"get":    {Required: []string{}, Optional: []string{}, Constraints: []string{}},
+		"update": {Required: []string{}, Optional: []string{"model"}, Constraints: []string{"model uses provider/model"}},
+	},
+	"plugins": {
+		"list":    {Required: []string{}, Optional: []string{}, Constraints: []string{"channel/plugin credentials and arbitrary config are never returned"}},
+		"enable":  {Required: []string{"kind", "name"}, Optional: []string{}, Constraints: []string{"changes one registered plugin"}},
+		"disable": {Required: []string{"kind", "name"}, Optional: []string{}, Constraints: []string{"changes one registered plugin"}},
+	},
+	"mcp": {
+		"list":   {Required: []string{"scope"}, Optional: []string{"agent_id"}, Constraints: []string{"bearer credentials and credential refs are never returned"}},
+		"get":    {Required: []string{"id", "scope"}, Optional: []string{"agent_id"}, Constraints: []string{"bearer credentials and credential refs are never returned"}},
+		"create": {Required: []string{"scope", "name", "url"}, Optional: []string{"agent_id", "transport"}, Constraints: []string{"only no-auth HTTP registrations; URL must not contain userinfo, query, or fragment"}},
+		"update": {Required: []string{"id", "scope"}, Optional: []string{"agent_id", "name", "url", "transport", "enabled", "expected_digest"}, Constraints: []string{"only metadata and no-auth changes; URL must not contain userinfo, query, or fragment"}},
+		"delete": {Required: []string{"id", "scope"}, Optional: []string{"agent_id", "expected_digest"}, Constraints: []string{"foreign-owner IDs never purge credentials"}},
+	},
 }
 
 type pendingMutation struct {
@@ -175,6 +202,10 @@ func (t *Tool) previewMutation(ctx context.Context, args map[string]any) (string
 		digest, err = t.previewSkill(ctx, operation, input)
 	case "tool_overrides":
 		digest, err = t.previewOverride(ctx, operation, input)
+	case "providers", "embedding", "vision", "plugins":
+		digest, err = t.previewDeployment(ctx, resource, operation, input)
+	case "mcp":
+		digest, err = t.previewMCP(ctx, operation, input)
 	default:
 		err = fmt.Errorf("unsupported settings resource %q", resource)
 	}
@@ -263,6 +294,10 @@ func (t *Tool) confirmMutation(ctx context.Context, args map[string]any) (string
 		applyErr = t.confirmSkill(ctx, pending.operation, input, pending.digest)
 	case "tool_overrides":
 		applyErr = t.confirmOverride(ctx, pending.operation, input, pending.digest)
+	case "providers", "embedding", "vision", "plugins":
+		applyErr = t.confirmDeployment(ctx, pending.resource, pending.operation, input, pending.digest)
+	case "mcp":
+		applyErr = t.confirmMCP(ctx, pending.operation, input, pending.digest)
 	default:
 		applyErr = fmt.Errorf("unsupported settings resource %q", pending.resource)
 	}

--- a/internal/settings/tool.go
+++ b/internal/settings/tool.go
@@ -12,6 +12,7 @@ import (
 	"github.com/CherryHQ/stella/internal/agent"
 	"github.com/CherryHQ/stella/internal/authz"
 	"github.com/CherryHQ/stella/internal/config"
+	"github.com/CherryHQ/stella/internal/mcp"
 	"github.com/CherryHQ/stella/internal/memory"
 	"github.com/CherryHQ/stella/pkg/tools"
 )
@@ -57,6 +58,14 @@ func WithToolOverrideMutations(m ToolOverrideMutation) ToolOption {
 	return func(t *Tool) { t.toolOverrideMutations = m }
 }
 
+func WithDeploymentMutations(m DeploymentMutation) ToolOption {
+	return func(t *Tool) { t.deploymentMutations = m }
+}
+
+func WithMCPMutations(m *mcp.Access) ToolOption {
+	return func(t *Tool) { t.mcpAccess = m }
+}
+
 // Tool is a deliberately small protocol facade. Mutation payloads are retained
 // only in-memory for one short-lived model-side preview/confirm handshake.
 type Tool struct {
@@ -65,6 +74,8 @@ type Tool struct {
 	libraryMutations      LibraryMutation
 	skillMutations        SkillMutation
 	toolOverrideMutations ToolOverrideMutation
+	deploymentMutations   DeploymentMutation
+	mcpAccess             *mcp.Access
 	tokensMu              sync.Mutex
 	tokens                map[string]pendingMutation
 }
@@ -94,7 +105,7 @@ func (t *Tool) Definition() tools.Definition {
   "additionalProperties":false,
   "properties":{
     "action":{"type":"string","enum":["catalog","describe","list","get","preview","confirm"]},
-    "resource":{"type":"string","enum":["agents","library","skills","tool_overrides"]},
+    "resource":{"type":"string","enum":["agents","library","skills","tool_overrides","providers","embedding","vision","plugins","mcp"]},
     "operation":{"type":"string","enum":["create","update","delete","set","clear"]},
     "input":{"type":"object","description":"Mutation fields. Identity and owner fields are resolved from the current turn."},
     "token":{"type":"string","description":"Single-use token returned by preview."},
@@ -130,6 +141,11 @@ func (t *Tool) Execute(ctx context.Context, args map[string]any) (string, error)
 				{"name": "library", "operations": []string{"create", "delete"}},
 				{"name": "skills", "operations": []string{"create", "update", "delete"}},
 				{"name": "tool_overrides", "operations": []string{"set", "clear"}},
+				{"name": "providers", "operations": []string{"list", "get", "create", "update", "delete"}},
+				{"name": "embedding", "operations": []string{"get", "update"}},
+				{"name": "vision", "operations": []string{"get", "update"}},
+				{"name": "plugins", "operations": []string{"list", "enable", "disable"}},
+				{"name": "mcp", "operations": []string{"list", "get", "create", "update", "delete"}},
 			},
 			"protocol": "Mutations require preview then confirm with a single-use token; this is a model-side protocol, not human approval.",
 		})
@@ -139,7 +155,7 @@ func (t *Tool) Execute(ctx context.Context, args map[string]any) (string, error)
 		}
 		return t.describeResource(ctx, args)
 	case "list", "get":
-		return t.readAgents(ctx, args, action)
+		return t.readResource(ctx, args, action)
 	default:
 		return "", fmt.Errorf("unknown settings action %q", action)
 	}


### PR DESCRIPTION
## What

Add Phase 3 deployment/admin mutation support to `stella_settings` for providers, embedding, vision, and plugin enablement, plus authority-bound MCP create/update/delete.

## Why

Keep deployment writes behind the existing admin control-plane PEP, keep user-owned MCP writes behind the shared scope authority, and make runner invalidation a service invariant instead of duplicated transport behavior.

## How

- Extend the existing preview/confirm protocol without exposing API keys, OAuth/channel/Vault/MCP bearer secrets, credential refs, or arbitrary plugin config.
- Redact URL userinfo, query, and fragment at the Settings model boundary only.
- Share one `mcp.Access` between HTTP and Settings; move MCP invalidation into `mcp.Service` and retain exact-owner credential purge checks.
- Keep provider credentials write-only and support only no-auth MCP mutations from the model-facing tool.

## Test

- `go test ./internal/settings ./internal/controlplane ./internal/mcp ./internal/server`
- `go test ./cmd/stellad`
- `mise run generate`
- `git diff --check`

## Refs

Refs MBP-12

Harbor evaluation was not run; this is an authorization/protocol change outside the existing behavior-eval task set.